### PR TITLE
feat(audit,export,pipeline): surface schematic/PCB sync drift and block unbuildable BOM

### DIFF
--- a/src/kicad_tools/audit/__init__.py
+++ b/src/kicad_tools/audit/__init__.py
@@ -21,6 +21,7 @@ from .auditor import (
     AuditResult,
     AuditVerdict,
     ManufacturingAudit,
+    SyncStatus,
 )
 from .net_audit import (
     AffectedPad,
@@ -33,6 +34,7 @@ __all__ = [
     "ManufacturingAudit",
     "AuditResult",
     "AuditVerdict",
+    "SyncStatus",
     "AffectedPad",
     "StaleNetGroup",
     "find_stale_nets",

--- a/src/kicad_tools/audit/auditor.py
+++ b/src/kicad_tools/audit/auditor.py
@@ -77,6 +77,53 @@ class DRCStatus:
 
 
 @dataclass
+class SyncStatus:
+    """Schematic <-> PCB synchronization check results.
+
+    Captures all four axes of drift between schematic and PCB:
+    - schematic_only_count: refs in schematic but missing from PCB
+      (unbuildable BOM - hard fail).
+    - pcb_only_count: refs on PCB but missing from schematic
+      (orphan footprints - warning).
+    - value_mismatch_count: same ref in both with different values.
+    - footprint_mismatch_count: same ref with different footprints.
+
+    See ``kicad_tools.sync.reconciler.SyncAnalysis`` for the underlying
+    source of truth.
+    """
+
+    schematic_only_count: int = 0
+    pcb_only_count: int = 0
+    value_mismatch_count: int = 0
+    footprint_mismatch_count: int = 0
+    passed: bool = True
+    skipped: bool = False
+    details: str = ""
+    # Up to ~10 example refs per axis (for surfacing in reports). Kept
+    # small so JSON manifest does not balloon for boards with hundreds
+    # of mismatches.
+    schematic_only_refs: list[str] = field(default_factory=list)
+    pcb_only_refs: list[str] = field(default_factory=list)
+    value_mismatch_refs: list[str] = field(default_factory=list)
+    footprint_mismatch_refs: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "schematic_only_count": self.schematic_only_count,
+            "pcb_only_count": self.pcb_only_count,
+            "value_mismatch_count": self.value_mismatch_count,
+            "footprint_mismatch_count": self.footprint_mismatch_count,
+            "passed": self.passed,
+            "skipped": self.skipped,
+            "details": self.details,
+            "schematic_only_refs": list(self.schematic_only_refs),
+            "pcb_only_refs": list(self.pcb_only_refs),
+            "value_mismatch_refs": list(self.value_mismatch_refs),
+            "footprint_mismatch_refs": list(self.footprint_mismatch_refs),
+        }
+
+
+@dataclass
 class ConnectivityStatus:
     """Net connectivity check results."""
 
@@ -228,6 +275,7 @@ class AuditResult:
     # Check results
     erc: ERCStatus = field(default_factory=ERCStatus)
     drc: DRCStatus = field(default_factory=DRCStatus)
+    sync: SyncStatus = field(default_factory=SyncStatus)
     connectivity: ConnectivityStatus = field(default_factory=ConnectivityStatus)
     compatibility: ManufacturerCompatibility = field(default_factory=ManufacturerCompatibility)
     layers: LayerUtilization = field(default_factory=LayerUtilization)
@@ -247,6 +295,12 @@ class AuditResult:
         if not self.compatibility.passed:
             return AuditVerdict.NOT_READY
 
+        # Schematic refs missing from PCB == unbuildable BOM == hard fail.
+        # The CPL/BOM that gets shipped to the fab will reference parts
+        # that have no pads on the board, so the assembly cannot succeed.
+        if self.sync.schematic_only_count > 0:
+            return AuditVerdict.NOT_READY
+
         # Connectivity: advisory when core checks pass and board has zones.
         # Zone fills cannot be verified without running KiCad's zone filler,
         # so incomplete nets on a board with zone definitions are treated as
@@ -258,6 +312,14 @@ class AuditResult:
 
         # Warnings
         if self.drc.warning_count > 0 or self.erc.warning_count > 0:
+            return AuditVerdict.WARNING
+        # Sync drift other than schematic-only: value/footprint mismatches
+        # and PCB-only orphans are reviewable, not blocking.
+        if (
+            self.sync.value_mismatch_count > 0
+            or self.sync.footprint_mismatch_count > 0
+            or self.sync.pcb_only_count > 0
+        ):
             return AuditVerdict.WARNING
 
         return AuditVerdict.READY
@@ -279,6 +341,10 @@ class AuditResult:
             "manufacturer_compatible": self.compatibility.passed,
             "estimated_cost": self.cost.total_cost,
             "action_items": len(self.action_items),
+            "sync_schematic_only": self.sync.schematic_only_count,
+            "sync_pcb_only": self.sync.pcb_only_count,
+            "sync_value_mismatches": self.sync.value_mismatch_count,
+            "sync_footprint_mismatches": self.sync.footprint_mismatch_count,
         }
 
     def to_dict(self) -> dict:
@@ -293,6 +359,7 @@ class AuditResult:
             "summary": self.summary(),
             "erc": self.erc.to_dict(),
             "drc": self.drc.to_dict(),
+            "sync": self.sync.to_dict(),
             "connectivity": self.connectivity.to_dict(),
             "compatibility": self.compatibility.to_dict(),
             "layers": self.layers.to_dict(),
@@ -547,14 +614,20 @@ class ManufacturingAudit:
             result.layers = self._check_layer_utilization(pcb)
             result.cost = self._estimate_cost(pcb)
 
+        # Run schematic <-> PCB sync drift check before generating action
+        # items so the action-item generator can read result.sync and emit
+        # sync-related items with correct priorities.
+        if self.pcb_path.exists() and self.schematic_path.exists():
+            result.sync = self._check_sync_drift()
+        else:
+            result.sync.skipped = True
+            if not self.schematic_path.exists():
+                result.sync.details = "Sync check skipped (no schematic available)"
+            else:
+                result.sync.details = "Sync check skipped (no PCB available)"
+
         # Generate action items from check results
         result.action_items = self._generate_action_items(result)
-
-        # Check for orphaned footprints (PCB refs not in schematic BOM)
-        if self.pcb_path.exists() and self.schematic_path.exists():
-            result.action_items.extend(self._check_orphaned_footprints())
-            # Re-sort after adding orphan items
-            result.action_items.sort(key=lambda x: x.priority)
 
         return result
 
@@ -962,16 +1035,76 @@ class ManufacturingAudit:
 
         return estimate
 
-    def _check_orphaned_footprints(self) -> list[ActionItem]:
-        """Check for PCB footprints that are not in the schematic BOM.
+    def _check_sync_drift(self) -> SyncStatus:
+        """Run schematic <-> PCB sync analysis via the Reconciler.
 
-        Compares PCB footprint references against schematic BOM references
-        to detect orphaned footprints (on PCB but not in schematic). DNP
-        items are included in the BOM reference set since they should still
-        have footprints.
+        Reuses :class:`kicad_tools.sync.reconciler.Reconciler` rather than
+        re-implementing set logic so ``kct audit`` and ``kct sync --analyze``
+        always agree on the four sync axes (schematic-only, PCB-only, value
+        mismatch, footprint mismatch).
 
         Returns:
-            List of ActionItems for any orphaned footprints found.
+            SyncStatus populated with the four counts, example refs (up to
+            10 per axis), and a human-readable details string.
+        """
+        status = SyncStatus()
+
+        try:
+            from kicad_tools.sync.reconciler import Reconciler
+
+            reconciler = Reconciler(
+                schematic=self.schematic_path,
+                pcb=self.pcb_path,
+            )
+            analysis = reconciler.analyze()
+
+            status.schematic_only_count = len(analysis.schematic_orphans)
+            status.pcb_only_count = len(analysis.pcb_orphans)
+            status.value_mismatch_count = len(analysis.value_mismatches)
+            status.footprint_mismatch_count = len(analysis.footprint_mismatches)
+
+            status.schematic_only_refs = list(analysis.schematic_orphans[:10])
+            status.pcb_only_refs = list(analysis.pcb_orphans[:10])
+            status.value_mismatch_refs = [m["reference"] for m in analysis.value_mismatches[:10]]
+            status.footprint_mismatch_refs = [
+                m["reference"] for m in analysis.footprint_mismatches[:10]
+            ]
+
+            # passed == every axis clean
+            status.passed = (
+                status.schematic_only_count == 0
+                and status.pcb_only_count == 0
+                and status.value_mismatch_count == 0
+                and status.footprint_mismatch_count == 0
+            )
+
+            parts: list[str] = []
+            if status.schematic_only_count:
+                parts.append(f"{status.schematic_only_count} schematic-only")
+            if status.pcb_only_count:
+                parts.append(f"{status.pcb_only_count} PCB-only")
+            if status.value_mismatch_count:
+                parts.append(f"{status.value_mismatch_count} value mismatch(es)")
+            if status.footprint_mismatch_count:
+                parts.append(f"{status.footprint_mismatch_count} footprint mismatch(es)")
+            if parts:
+                status.details = "; ".join(parts)
+            else:
+                status.details = "Schematic and PCB are in sync"
+
+        except Exception as e:
+            logger.debug(f"Sync drift check skipped: {e}")
+            status.skipped = True
+            status.details = f"Sync check failed: {e}"
+
+        return status
+
+    def _check_orphaned_footprints(self) -> list[ActionItem]:
+        """Legacy: orphan-footprint-only check kept for backward compatibility.
+
+        New code should consult :meth:`_check_sync_drift` which surfaces
+        all four sync axes.  This method still works against the schematic
+        BOM directly so existing tests continue to pass.
         """
         items: list[ActionItem] = []
 
@@ -1010,6 +1143,80 @@ class ManufacturingAudit:
     def _generate_action_items(self, result: AuditResult) -> list[ActionItem]:
         """Generate prioritized action items from results."""
         items: list[ActionItem] = []
+
+        # Schematic <-> PCB sync drift.  Schematic-only refs are a hard
+        # fail (priority 1) because they produce an unbuildable BOM: the
+        # CPL/BOM shipped to the fab references parts with no pads on the
+        # board.  Value/footprint mismatches and PCB-only orphans are
+        # priority 2 (important).
+        sync = result.sync
+        if sync.schematic_only_count > 0:
+            refs = ", ".join(sync.schematic_only_refs[:10])
+            suffix = (
+                f" (and {sync.schematic_only_count - 10} more)"
+                if sync.schematic_only_count > 10
+                else ""
+            )
+            items.append(
+                ActionItem(
+                    priority=1,
+                    description=(
+                        f"{sync.schematic_only_count} component(s) in schematic "
+                        f"missing from PCB -- BOM will be unbuildable: {refs}{suffix}"
+                    ),
+                    command=f"kct sync --analyze {self.pcb_path}",
+                )
+            )
+
+        if sync.pcb_only_count > 0:
+            refs = ", ".join(sync.pcb_only_refs[:10])
+            suffix = f" (and {sync.pcb_only_count - 10} more)" if sync.pcb_only_count > 10 else ""
+            items.append(
+                ActionItem(
+                    priority=2,
+                    description=(
+                        f"{sync.pcb_only_count} orphaned footprint(s) on PCB "
+                        f"but not in schematic: {refs}{suffix}"
+                    ),
+                    command=f"kct sync --analyze {self.pcb_path}",
+                )
+            )
+
+        if sync.value_mismatch_count > 0:
+            refs = ", ".join(sync.value_mismatch_refs[:10])
+            suffix = (
+                f" (and {sync.value_mismatch_count - 10} more)"
+                if sync.value_mismatch_count > 10
+                else ""
+            )
+            items.append(
+                ActionItem(
+                    priority=2,
+                    description=(
+                        f"{sync.value_mismatch_count} component(s) have different "
+                        f"values in schematic vs PCB: {refs}{suffix}"
+                    ),
+                    command=f"kct sync --analyze {self.pcb_path}",
+                )
+            )
+
+        if sync.footprint_mismatch_count > 0:
+            refs = ", ".join(sync.footprint_mismatch_refs[:10])
+            suffix = (
+                f" (and {sync.footprint_mismatch_count - 10} more)"
+                if sync.footprint_mismatch_count > 10
+                else ""
+            )
+            items.append(
+                ActionItem(
+                    priority=2,
+                    description=(
+                        f"{sync.footprint_mismatch_count} component(s) have different "
+                        f"footprints in schematic vs PCB: {refs}{suffix}"
+                    ),
+                    command=f"kct sync --analyze {self.pcb_path}",
+                )
+            )
 
         # Blocking ERC errors (electrical issues)
         if result.erc.blocking_error_count > 0:

--- a/src/kicad_tools/cli/audit_cmd.py
+++ b/src/kicad_tools/cli/audit_cmd.py
@@ -221,6 +221,43 @@ def output_table(result: AuditResult, verbose: bool = False) -> None:
         if drc.details:
             print(f"    Details: {drc.details}")
 
+    # Sync drift (schematic <-> PCB)
+    sync = result.sync
+    if sync.skipped:
+        print("\n[--] Sync (Schematic <-> PCB): SKIPPED")
+        if sync.details:
+            print(f"    Note: {sync.details}")
+    else:
+        sync_status = "PASS" if sync.passed else "FAIL"
+        sync_icon = "OK" if sync.passed else "X"
+        print(f"\n[{sync_icon}] Sync (Schematic <-> PCB): {sync_status}")
+        if sync.details:
+            print(f"    {sync.details}")
+        if sync.schematic_only_count > 0:
+            refs = ", ".join(sync.schematic_only_refs[:5])
+            print(
+                f"    Schematic-only ({sync.schematic_only_count}): {refs}"
+                + ("..." if sync.schematic_only_count > 5 else "")
+            )
+        if sync.pcb_only_count > 0:
+            refs = ", ".join(sync.pcb_only_refs[:5])
+            print(
+                f"    PCB-only ({sync.pcb_only_count}): {refs}"
+                + ("..." if sync.pcb_only_count > 5 else "")
+            )
+        if sync.value_mismatch_count > 0:
+            refs = ", ".join(sync.value_mismatch_refs[:5])
+            print(
+                f"    Value mismatches ({sync.value_mismatch_count}): {refs}"
+                + ("..." if sync.value_mismatch_count > 5 else "")
+            )
+        if sync.footprint_mismatch_count > 0:
+            refs = ", ".join(sync.footprint_mismatch_refs[:5])
+            print(
+                f"    Footprint mismatches ({sync.footprint_mismatch_count}): {refs}"
+                + ("..." if sync.footprint_mismatch_count > 5 else "")
+            )
+
     # Connectivity
     conn = result.connectivity
     conn_status = "PASS" if conn.passed else "FAIL"
@@ -333,6 +370,19 @@ def output_summary(result: AuditResult) -> None:
     print(f"  Verdict: {summary['verdict'].upper()}")
     print(f"  ERC errors: {summary['erc_errors']}")
     print(f"  DRC violations: {summary['drc_violations']} ({summary['drc_blocking']} blocking)")
+    sync_axes = (
+        summary["sync_schematic_only"]
+        + summary["sync_pcb_only"]
+        + summary["sync_value_mismatches"]
+        + summary["sync_footprint_mismatches"]
+    )
+    if sync_axes > 0:
+        print(
+            f"  Sync drift: {summary['sync_schematic_only']} schematic-only, "
+            f"{summary['sync_pcb_only']} PCB-only, "
+            f"{summary['sync_value_mismatches']} value, "
+            f"{summary['sync_footprint_mismatches']} footprint"
+        )
     print(f"  Net completion: {summary['net_completion']:.0f}%")
     print(f"  Manufacturer compatible: {'Yes' if summary['manufacturer_compatible'] else 'No'}")
     if summary["estimated_cost"] > 0:

--- a/src/kicad_tools/cli/export_cmd.py
+++ b/src/kicad_tools/cli/export_cmd.py
@@ -148,6 +148,15 @@ def main(argv: list[str] | None = None) -> int:
         help="Block export when preflight checks fail (for CI; default: export proceeds with warnings)",
     )
     parser.add_argument(
+        "--allow-unbuildable-bom",
+        action="store_true",
+        help=(
+            "Allow export to proceed when the BOM contains refs with no PCB "
+            "footprint (default: block, since the package would be unbuildable). "
+            "Use only for partial/debug exports."
+        ),
+    )
+    parser.add_argument(
         "--skip-drc",
         action="store_true",
         help="Skip DRC check in pre-flight validation",
@@ -271,6 +280,7 @@ def run_export(args: argparse.Namespace) -> int:
         bom_source=getattr(args, "bom_source", "schematic"),
         preflight=preflight_cfg,
         strict_preflight=getattr(args, "strict_preflight", False),
+        block_on_unbuildable_bom=not getattr(args, "allow_unbuildable_bom", False),
         pnp_config=pnp_config,
         gerber_config=gerber_config,
         latest_report_only=not getattr(args, "keep_versions", False),

--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -1096,6 +1096,17 @@ def _run_step_export(ctx: PipelineContext, console: Console) -> PipelineResult:
         str(mfr_dir),
     ]
 
+    # Pass --sch so the BOM/PCB match preflight check can run.  Without
+    # the schematic, ``_check_bom_footprint_match`` falls back to the
+    # PCB-derived BOM (which trivially matches itself), so schematic-only
+    # refs are not detected.  Auto-detect via the pipeline context or
+    # ``find_schematic`` when no explicit path is set.
+    sch_path: Path | None = ctx.schematic_file
+    if sch_path is None:
+        sch_path = _resolve_schematic(ctx.pcb_file, ctx.project_file)
+    if sch_path is not None and sch_path.exists():
+        cmd.extend(["--sch", str(sch_path)])
+
     success, message = _run_subprocess_step(cmd, ctx.pcb_file.parent, ctx.verbose)
 
     return PipelineResult(
@@ -1123,6 +1134,56 @@ def _is_git_repo(directory: Path) -> bool:
         return result.returncode == 0
     except FileNotFoundError:
         return False
+
+
+def _fetch_audit_results(ctx: PipelineContext) -> dict | None:
+    """Run ``kct audit --format json`` and return parsed result dict.
+
+    Used by :func:`_print_final_summary` so the pipeline can derive its
+    verdict from the audit's sync drift state (schematic-only refs make
+    the BOM unbuildable -> NOT_READY).
+
+    Args:
+        ctx: Pipeline context (project or PCB path, manufacturer).
+
+    Returns:
+        Parsed JSON dict on success, ``None`` on any failure.
+    """
+    import json as _json
+
+    # Audit needs a project file when available so it can pick up the
+    # schematic for sync drift detection.  Fall back to the PCB.
+    if ctx.is_project and ctx.project_file:
+        target = str(ctx.project_file)
+    else:
+        target = str(ctx.pcb_file)
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "kicad_tools.cli",
+        "audit",
+        target,
+        "--mfr",
+        ctx.mfr,
+        "--format",
+        "json",
+    ]
+
+    try:
+        audit_result = subprocess.run(
+            cmd,
+            cwd=str(ctx.pcb_file.parent),
+            capture_output=True,
+            text=True,
+        )
+        # audit exits 2 on NOT_READY but still emits valid JSON to stdout
+        data = _json.loads(audit_result.stdout)
+        if isinstance(data, dict):
+            return data
+    except Exception:
+        pass
+    return None
 
 
 def _fetch_check_results(ctx: PipelineContext) -> dict | None:
@@ -1172,6 +1233,7 @@ def _print_final_summary(
     results: list[PipelineResult],
     console: Console,
     check_data: dict | None = None,
+    audit_data: dict | None = None,
 ) -> None:
     """Print a DRC/ERC/verdict summary block after pipeline completion.
 
@@ -1184,6 +1246,10 @@ def _print_final_summary(
         console: Rich console for output.
         check_data: Pre-fetched ``kct check --format json`` result, or
             ``None`` to skip the subprocess (used for dry-run placeholder).
+        audit_data: Pre-fetched ``kct audit --format json`` result with
+            the new ``sync`` section.  When supplied with schematic-only
+            refs, the verdict is forced to NOT READY regardless of
+            DRC/ERC pass state (an unbuildable BOM blocks manufacturing).
     """
     # --- DRC ---
     if check_data is not None:
@@ -1237,11 +1303,44 @@ def _print_final_summary(
         None,
     )
 
+    # --- Sync drift (schematic <-> PCB) ---
+    # Read from audit JSON when available.  Schematic-only refs make the
+    # BOM unbuildable, which trumps every other check: the package cannot
+    # be manufactured regardless of DRC/ERC pass state.
+    sync_summary = audit_data.get("sync", {}) if audit_data else {}
+    sync_schematic_only = sync_summary.get("schematic_only_count", 0)
+    sync_pcb_only = sync_summary.get("pcb_only_count", 0)
+    sync_value_mm = sync_summary.get("value_mismatch_count", 0)
+    sync_fp_mm = sync_summary.get("footprint_mismatch_count", 0)
+    sync_drift_parts: list[str] = []
+    if sync_schematic_only:
+        sync_drift_parts.append(f"{sync_schematic_only} schematic-only")
+    if sync_pcb_only:
+        sync_drift_parts.append(f"{sync_pcb_only} PCB-only")
+    if sync_value_mm:
+        sync_drift_parts.append(f"{sync_value_mm} value mm")
+    if sync_fp_mm:
+        sync_drift_parts.append(f"{sync_fp_mm} fp mm")
+    if not audit_data:
+        sync_line = "skipped (audit unavailable)"
+    elif not sync_drift_parts:
+        sync_line = "in sync"
+    else:
+        sync_line = ", ".join(sync_drift_parts)
+
     # --- Verdict ---
+    # Schematic-only refs == unbuildable BOM == hard fail.  Check this
+    # before audit_result.success because the pipeline's audit subprocess
+    # may have run before the sync axis was wired in, but the JSON we
+    # just fetched is authoritative.
+    if sync_schematic_only > 0:
+        verdict = (
+            f"[red]NOT READY[/red] -- {sync_schematic_only} schematic-only refs (unbuildable BOM)"
+        )
     # When the AUDIT step ran, its success/failure reflects the full audit
     # verdict (ERC, DRC, connectivity, manufacturer compatibility).  Use it
     # as the authoritative source so the pipeline summary matches the audit.
-    if audit_result is not None and not audit_result.skipped:
+    elif audit_result is not None and not audit_result.skipped:
         if audit_result.success:
             # Audit passed -- distinguish READY from WARNING.
             # Check for DRC/ERC warnings to surface a WARNING verdict.
@@ -1256,9 +1355,17 @@ def _print_final_summary(
                     or (erc_result.warning and erc_result.success)
                 )
             )
-            if has_drc_warnings or erc_has_warnings:
+            has_sync_warnings = sync_pcb_only > 0 or sync_value_mm > 0 or sync_fp_mm > 0
+            if has_drc_warnings or erc_has_warnings or has_sync_warnings:
+                bits: list[str] = []
+                if has_drc_warnings:
+                    bits.append("DRC warnings")
+                if erc_has_warnings:
+                    bits.append("ERC warnings")
+                if has_sync_warnings:
+                    bits.append("sync drift")
                 verdict = (
-                    "[yellow]WARNING[/yellow] -- audit passed with warnings (review recommended)"
+                    f"[yellow]WARNING[/yellow] -- audit passed with warnings ({', '.join(bits)})"
                 )
             else:
                 verdict = "[green]READY[/green] -- audit passed"
@@ -1293,6 +1400,7 @@ def _print_final_summary(
     console.print(f"  DRC:        {drc_line}")
     console.print(f"  ERC:        {erc_line}")
     console.print(f"  Silkscreen: {silk_count} warnings")
+    console.print(f"  Sync:       {sync_line}")
     console.print(f"  Verdict:    {verdict}")
 
 
@@ -1595,11 +1703,19 @@ def run_pipeline(
             console.print("  DRC:        N/A (dry run)")
             console.print("  ERC:        N/A (dry run)")
             console.print("  Silkscreen: N/A (dry run)")
+            console.print("  Sync:       N/A (dry run)")
             console.print("  Verdict:    N/A (dry run)")
         else:
             check_data = _fetch_check_results(ctx)
+            audit_data = _fetch_audit_results(ctx)
             ctx._check_data = check_data  # cache for _build_commit_message
-            _print_final_summary(ctx, results, console, check_data=check_data)
+            _print_final_summary(
+                ctx,
+                results,
+                console,
+                check_data=check_data,
+                audit_data=audit_data,
+            )
 
     return results
 
@@ -1823,8 +1939,7 @@ Examples:
     #   1 = hard failure
     all_succeeded = all(r.success for r in results)
     has_route_warning = any(
-        r.step == PipelineStep.ROUTE and not r.success and r.warning
-        for r in results
+        r.step == PipelineStep.ROUTE and not r.success and r.warning for r in results
     )
 
     if not all_succeeded and not has_route_warning:

--- a/src/kicad_tools/export/manufacturing.py
+++ b/src/kicad_tools/export/manufacturing.py
@@ -48,6 +48,15 @@ class ManufacturingConfig(AssemblyConfig):
     # export proceeds to generate output files.
     strict_preflight: bool = False
 
+    # When True (default), the export refuses to proceed when the BOM
+    # contains references with no matching PCB footprint -- the package
+    # would be unbuildable because the fab cannot place components that
+    # are not on the board.  This gates only the ``bom_pcb_match``
+    # preflight check independently of ``strict_preflight``; users who
+    # explicitly want to ship a partial package can opt out via
+    # ``--allow-unbuildable-bom`` (which sets this to False).
+    block_on_unbuildable_bom: bool = True
+
     # When True (default), flatten the latest vN/ report directory into a
     # ``report/`` subdirectory and remove all vN/ directories from the output.
     # When False, versioned directories are preserved as-is.
@@ -163,9 +172,7 @@ def _create_project_zip(
     project_files.extend(
         f
         for f in project_dir.iterdir()
-        if f.is_file()
-        and f.suffix in sch_pro_extensions
-        and "_backup_" not in f.stem
+        if f.is_file() and f.suffix in sch_pro_extensions and "_backup_" not in f.stem
     )
 
     if not project_files:
@@ -269,6 +276,22 @@ class ManufacturingPackage:
             preflight_results = self._run_preflight()
             result.preflight_results = preflight_results
 
+            # The bom_pcb_match check returns FAIL when the BOM references
+            # parts with no matching PCB footprint -- an unbuildable
+            # package.  This is a targeted block that fires even when
+            # ``strict_preflight`` is False, because it's the only check
+            # whose failure mode is "the fab literally cannot make this".
+            unbuildable_bom_failure: PreflightResult | None = None
+            if self.config.block_on_unbuildable_bom:
+                for pr in preflight_results:
+                    if pr.name == "bom_pcb_match" and pr.status == "FAIL":
+                        # Only treat as unbuildable if the schematic-only
+                        # axis is involved (refs in BOM not on PCB).  PCB
+                        # orphans are only a WARN, so we won't get here for
+                        # them.
+                        unbuildable_bom_failure = pr
+                        break
+
             if PreflightChecker.has_failures(preflight_results):
                 # Collect failure messages
                 for pr in preflight_results:
@@ -276,13 +299,19 @@ class ManufacturingPackage:
                         msg = f"Preflight FAIL [{pr.name}]: {pr.message}"
                         if pr.details:
                             msg += f" ({pr.details})"
-                        if self.config.strict_preflight:
+                        # bom_pcb_match failures escalate to errors when
+                        # block_on_unbuildable_bom is set; other preflight
+                        # failures behave per strict_preflight.
+                        is_unbuildable = (
+                            unbuildable_bom_failure is not None and pr is unbuildable_bom_failure
+                        )
+                        if self.config.strict_preflight or is_unbuildable:
                             result.errors.append(msg)
                         else:
                             result.warnings.append(msg)
 
-                # In strict mode, block export on preflight failures
-                if self.config.strict_preflight:
+                # Block export on strict mode OR on unbuildable BOM
+                if self.config.strict_preflight or unbuildable_bom_failure is not None:
                     return result
 
         out_dir.mkdir(parents=True, exist_ok=True)
@@ -391,8 +420,7 @@ class ManufacturingPackage:
             from ..report.models import ReportData
         except ImportError:
             logger.warning(
-                "Report generation skipped: required dependency not installed "
-                "(e.g. jinja2)"
+                "Report generation skipped: required dependency not installed (e.g. jinja2)"
             )
             return
 
@@ -498,8 +526,7 @@ class ManufacturingPackage:
             result["schematic_sheets"] = sch_sheets
 
         logger.info(
-            f"Generated {len(entries)} figure(s): "
-            f"{len(pcb_figs)} PCB, {len(sch_sheets)} schematic"
+            f"Generated {len(entries)} figure(s): {len(pcb_figs)} PCB, {len(sch_sheets)} schematic"
         )
         return result or None
 
@@ -519,16 +546,14 @@ class ManufacturingPackage:
             from ..report.renderers import pdf_renderer_available
         except ImportError:
             logger.warning(
-                "PDF report rendering skipped: install 'kicad-tools[report]' "
-                "for PDF output"
+                "PDF report rendering skipped: install 'kicad-tools[report]' for PDF output"
             )
             return
 
         renderer = pdf_renderer_available()
         if renderer is None:
             logger.warning(
-                "PDF report rendering skipped: install weasyprint or pandoc+TeX "
-                "for PDF output"
+                "PDF report rendering skipped: install weasyprint or pandoc+TeX for PDF output"
             )
             return
 
@@ -699,10 +724,19 @@ class ManufacturingPackage:
 
         file_descriptions = {
             "bom": ("BOM (Bill of Materials)", "Component list for PCB assembly ordering"),
-            "pnp": ("CPL (Component Placement List)", "Pick-and-place coordinates for SMT assembly"),
-            "gerber": ("Gerber files", "PCB fabrication data (copper layers, silkscreen, solder mask, drill)"),
+            "pnp": (
+                "CPL (Component Placement List)",
+                "Pick-and-place coordinates for SMT assembly",
+            ),
+            "gerber": (
+                "Gerber files",
+                "PCB fabrication data (copper layers, silkscreen, solder mask, drill)",
+            ),
             "report": ("Design report", "Manufacturing readiness report with DRC/ERC results"),
-            "project_zip": ("KiCad project archive", "Source KiCad project files (.kicad_pcb, .kicad_sch, .kicad_pro)"),
+            "project_zip": (
+                "KiCad project archive",
+                "Source KiCad project files (.kicad_pcb, .kicad_sch, .kicad_pro)",
+            ),
             "manifest": ("Manifest", "SHA256 checksums for all output files"),
         }
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -2123,6 +2123,329 @@ class TestOrphanedFootprints:
 
 
 # ---------------------------------------------------------------------------
+# Test: schematic <-> PCB sync drift (issue #2729)
+# ---------------------------------------------------------------------------
+
+
+class TestSyncDriftStatus:
+    """SyncStatus dataclass and AuditResult.sync wiring."""
+
+    def test_sync_status_defaults(self):
+        from kicad_tools.audit.auditor import SyncStatus
+
+        s = SyncStatus()
+        assert s.schematic_only_count == 0
+        assert s.pcb_only_count == 0
+        assert s.value_mismatch_count == 0
+        assert s.footprint_mismatch_count == 0
+        assert s.passed is True
+        assert s.skipped is False
+
+    def test_sync_status_to_dict_keys(self):
+        from kicad_tools.audit.auditor import SyncStatus
+
+        s = SyncStatus(
+            schematic_only_count=3,
+            pcb_only_count=2,
+            value_mismatch_count=1,
+            footprint_mismatch_count=4,
+            schematic_only_refs=["R99", "C42"],
+        )
+        d = s.to_dict()
+        assert d["schematic_only_count"] == 3
+        assert d["pcb_only_count"] == 2
+        assert d["value_mismatch_count"] == 1
+        assert d["footprint_mismatch_count"] == 4
+        assert d["schematic_only_refs"] == ["R99", "C42"]
+
+    def test_audit_result_to_dict_includes_sync_key(self):
+        from kicad_tools.audit.auditor import AuditResult
+
+        r = AuditResult()
+        d = r.to_dict()
+        assert "sync" in d
+        # Summary should include the four sync counts
+        assert "sync_schematic_only" in d["summary"]
+        assert "sync_pcb_only" in d["summary"]
+        assert "sync_value_mismatches" in d["summary"]
+        assert "sync_footprint_mismatches" in d["summary"]
+
+
+class TestSyncDriftVerdict:
+    """AuditResult.verdict reacts to sync drift counts."""
+
+    def test_schematic_only_forces_not_ready(self):
+        from kicad_tools.audit.auditor import AuditResult, AuditVerdict
+
+        r = AuditResult()
+        r.sync.schematic_only_count = 1
+        assert r.verdict == AuditVerdict.NOT_READY
+
+    def test_pcb_only_is_warning(self):
+        from kicad_tools.audit.auditor import AuditResult, AuditVerdict
+
+        r = AuditResult()
+        r.sync.pcb_only_count = 2
+        assert r.verdict == AuditVerdict.WARNING
+
+    def test_value_mismatch_is_warning(self):
+        from kicad_tools.audit.auditor import AuditResult, AuditVerdict
+
+        r = AuditResult()
+        r.sync.value_mismatch_count = 5
+        assert r.verdict == AuditVerdict.WARNING
+
+    def test_footprint_mismatch_is_warning(self):
+        from kicad_tools.audit.auditor import AuditResult, AuditVerdict
+
+        r = AuditResult()
+        r.sync.footprint_mismatch_count = 3
+        assert r.verdict == AuditVerdict.WARNING
+
+    def test_clean_sync_is_ready(self):
+        from kicad_tools.audit.auditor import AuditResult, AuditVerdict
+
+        r = AuditResult()
+        # All zero
+        assert r.verdict == AuditVerdict.READY
+
+    def test_schematic_only_overrides_drc_warnings(self):
+        """An unbuildable BOM is a NOT_READY hard fail regardless of DRC."""
+        from kicad_tools.audit.auditor import AuditResult, AuditVerdict
+
+        r = AuditResult()
+        r.sync.schematic_only_count = 36
+        r.drc.warning_count = 0
+        r.erc.warning_count = 0
+        assert r.verdict == AuditVerdict.NOT_READY
+
+
+class TestSyncDriftCheck:
+    """ManufacturingAudit._check_sync_drift uses Reconciler."""
+
+    def test_check_sync_drift_reuses_reconciler(self, tmp_path: Path):
+        """Verify _check_sync_drift wraps Reconciler.analyze()."""
+        from unittest.mock import MagicMock, patch
+
+        from kicad_tools.sync.reconciler import SyncAnalysis
+
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(
+            """(kicad_pcb (version 20221018)
+  (generator pcbnew)
+  (layers (0 "F.Cu" signal))
+)"""
+        )
+        sch_path = tmp_path / "test.kicad_sch"
+        sch_path.write_text("")
+        project_file = tmp_path / "test.kicad_pro"
+        project_file.write_text("{}")
+
+        audit = ManufacturingAudit(project_file)
+
+        mock_analysis = SyncAnalysis(
+            schematic_orphans=["U99", "R42"],
+            pcb_orphans=["TP1"],
+            value_mismatches=[{"reference": "R1", "schematic_value": "10k", "pcb_value": "1k"}],
+            footprint_mismatches=[
+                {
+                    "reference": "C1",
+                    "schematic_footprint": "C_0402",
+                    "pcb_footprint": "C_0603",
+                }
+            ],
+        )
+
+        mock_reconciler = MagicMock()
+        mock_reconciler.analyze.return_value = mock_analysis
+
+        with patch(
+            "kicad_tools.sync.reconciler.Reconciler",
+            return_value=mock_reconciler,
+        ):
+            status = audit._check_sync_drift()
+
+        assert status.schematic_only_count == 2
+        assert status.pcb_only_count == 1
+        assert status.value_mismatch_count == 1
+        assert status.footprint_mismatch_count == 1
+        assert status.schematic_only_refs == ["U99", "R42"]
+        assert status.pcb_only_refs == ["TP1"]
+        assert status.value_mismatch_refs == ["R1"]
+        assert status.footprint_mismatch_refs == ["C1"]
+        assert status.passed is False
+
+    def test_check_sync_drift_graceful_on_reconciler_failure(self, tmp_path: Path):
+        """A Reconciler exception must not crash the audit."""
+        from unittest.mock import patch
+
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(
+            """(kicad_pcb (version 20221018)
+  (generator pcbnew)
+  (layers (0 "F.Cu" signal))
+)"""
+        )
+        sch_path = tmp_path / "test.kicad_sch"
+        sch_path.write_text("")
+        project_file = tmp_path / "test.kicad_pro"
+        project_file.write_text("{}")
+
+        audit = ManufacturingAudit(project_file)
+
+        with patch(
+            "kicad_tools.sync.reconciler.Reconciler",
+            side_effect=RuntimeError("boom"),
+        ):
+            status = audit._check_sync_drift()
+
+        assert status.skipped is True
+        assert "boom" in status.details
+
+    def test_check_sync_drift_truncates_to_10_refs(self, tmp_path: Path):
+        """Only the first 10 refs per axis are recorded (for manifest brevity)."""
+        from unittest.mock import MagicMock, patch
+
+        from kicad_tools.sync.reconciler import SyncAnalysis
+
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(
+            """(kicad_pcb (version 20221018)
+  (generator pcbnew)
+  (layers (0 "F.Cu" signal))
+)"""
+        )
+        sch_path = tmp_path / "test.kicad_sch"
+        sch_path.write_text("")
+        project_file = tmp_path / "test.kicad_pro"
+        project_file.write_text("{}")
+
+        audit = ManufacturingAudit(project_file)
+
+        many_refs = [f"R{i}" for i in range(20)]
+        mock_analysis = SyncAnalysis(schematic_orphans=many_refs)
+
+        mock_reconciler = MagicMock()
+        mock_reconciler.analyze.return_value = mock_analysis
+
+        with patch(
+            "kicad_tools.sync.reconciler.Reconciler",
+            return_value=mock_reconciler,
+        ):
+            status = audit._check_sync_drift()
+
+        assert status.schematic_only_count == 20
+        assert len(status.schematic_only_refs) == 10
+
+
+class TestSyncDriftActionItems:
+    """Action items emitted from _generate_action_items() based on sync drift."""
+
+    def test_schematic_only_creates_priority1_item(self, tmp_path: Path):
+        """Schematic-only refs produce a priority-1 action item mentioning unbuildable BOM."""
+        from kicad_tools.audit.auditor import AuditResult, SyncStatus
+
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(
+            """(kicad_pcb (version 20221018)
+  (generator pcbnew)
+  (layers (0 "F.Cu" signal))
+)"""
+        )
+        sch_path = tmp_path / "test.kicad_sch"
+        sch_path.write_text("")
+        project_file = tmp_path / "test.kicad_pro"
+        project_file.write_text("{}")
+
+        audit = ManufacturingAudit(project_file)
+        r = AuditResult()
+        r.sync = SyncStatus(
+            schematic_only_count=3,
+            schematic_only_refs=["U1", "U2", "U3"],
+        )
+        items = audit._generate_action_items(r)
+
+        # Find the schematic-only item
+        sch_only = [i for i in items if "schematic" in i.description and "missing" in i.description]
+        assert len(sch_only) == 1
+        assert sch_only[0].priority == 1
+        assert "unbuildable" in sch_only[0].description.lower()
+        assert "U1" in sch_only[0].description
+
+    def test_pcb_only_creates_priority2_item(self, tmp_path: Path):
+        from kicad_tools.audit.auditor import AuditResult, SyncStatus
+
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(
+            """(kicad_pcb (version 20221018)
+  (generator pcbnew)
+  (layers (0 "F.Cu" signal))
+)"""
+        )
+        sch_path = tmp_path / "test.kicad_sch"
+        sch_path.write_text("")
+        project_file = tmp_path / "test.kicad_pro"
+        project_file.write_text("{}")
+
+        audit = ManufacturingAudit(project_file)
+        r = AuditResult()
+        r.sync = SyncStatus(pcb_only_count=2, pcb_only_refs=["TP1", "TP2"])
+        items = audit._generate_action_items(r)
+
+        orphan = [i for i in items if "orphaned footprint" in i.description]
+        assert len(orphan) == 1
+        assert orphan[0].priority == 2
+
+    def test_value_mismatch_creates_priority2_item(self, tmp_path: Path):
+        from kicad_tools.audit.auditor import AuditResult, SyncStatus
+
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(
+            """(kicad_pcb (version 20221018)
+  (generator pcbnew)
+  (layers (0 "F.Cu" signal))
+)"""
+        )
+        sch_path = tmp_path / "test.kicad_sch"
+        sch_path.write_text("")
+        project_file = tmp_path / "test.kicad_pro"
+        project_file.write_text("{}")
+
+        audit = ManufacturingAudit(project_file)
+        r = AuditResult()
+        r.sync = SyncStatus(value_mismatch_count=4, value_mismatch_refs=["R1"])
+        items = audit._generate_action_items(r)
+
+        vm = [i for i in items if "different values" in i.description]
+        assert len(vm) == 1
+        assert vm[0].priority == 2
+
+    def test_footprint_mismatch_creates_priority2_item(self, tmp_path: Path):
+        from kicad_tools.audit.auditor import AuditResult, SyncStatus
+
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(
+            """(kicad_pcb (version 20221018)
+  (generator pcbnew)
+  (layers (0 "F.Cu" signal))
+)"""
+        )
+        sch_path = tmp_path / "test.kicad_sch"
+        sch_path.write_text("")
+        project_file = tmp_path / "test.kicad_pro"
+        project_file.write_text("{}")
+
+        audit = ManufacturingAudit(project_file)
+        r = AuditResult()
+        r.sync = SyncStatus(footprint_mismatch_count=1, footprint_mismatch_refs=["C2"])
+        items = audit._generate_action_items(r)
+
+        fm = [i for i in items if "different footprints" in i.description]
+        assert len(fm) == 1
+        assert fm[0].priority == 2
+
+
+# ---------------------------------------------------------------------------
 # Test: assembly mode / --no-assembly flag
 # ---------------------------------------------------------------------------
 

--- a/tests/test_manufacturing_package.py
+++ b/tests/test_manufacturing_package.py
@@ -416,9 +416,7 @@ class TestManufacturingPackageExport:
             PreflightResult(name="board_outline", status="FAIL", message="No board outline found"),
             PreflightResult(name="bom_pcb_match", status="OK", message="All BOM components placed"),
         ]
-        monkeypatch.setattr(
-            PreflightChecker, "run_all", lambda self: fail_results
-        )
+        monkeypatch.setattr(PreflightChecker, "run_all", lambda self: fail_results)
 
         config = ManufacturingConfig(
             include_report=False,
@@ -473,9 +471,7 @@ class TestManufacturingPackageExport:
                 details="Expected Edge.Cuts layer",
             ),
         ]
-        monkeypatch.setattr(
-            PreflightChecker, "run_all", lambda self: fail_results
-        )
+        monkeypatch.setattr(PreflightChecker, "run_all", lambda self: fail_results)
 
         config = ManufacturingConfig(
             include_report=False,
@@ -499,6 +495,115 @@ class TestManufacturingPackageExport:
 
         # Output directory should not exist
         assert not out_dir.exists()
+
+    def test_unbuildable_bom_blocks_export_by_default(self, tmp_path, monkeypatch):
+        """A bom_pcb_match FAIL (schematic-only refs) blocks export even
+        when strict_preflight is False.
+
+        Issue #2729: an unbuildable BOM (BOM references parts with no PCB
+        footprint) is treated as a hard failure independently of
+        strict_preflight so the pipeline cannot accidentally ship a
+        manufacturing package the fab cannot build.
+        """
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        pcb = project_dir / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+
+        from kicad_tools.export import assembly
+
+        assembly_called = {"value": False}
+
+        def fake_assembly_export(self, output_dir=None):
+            assembly_called["value"] = True
+            od = Path(output_dir) if output_dir else self.config.output_dir
+            od.mkdir(parents=True, exist_ok=True)
+            return assembly.AssemblyPackageResult(output_dir=od)
+
+        monkeypatch.setattr(assembly.AssemblyPackage, "export", fake_assembly_export)
+
+        # Mock preflight: bom_pcb_match FAIL (sch refs missing on PCB)
+        fail_results = [
+            PreflightResult(
+                name="bom_pcb_match",
+                status="FAIL",
+                message="BOM/PCB reference mismatch",
+                details="36 in BOM but not on PCB: U1, U2, U3",
+            ),
+        ]
+        monkeypatch.setattr(PreflightChecker, "run_all", lambda self: fail_results)
+
+        # strict_preflight defaults to False, but block_on_unbuildable_bom
+        # defaults to True
+        config = ManufacturingConfig(
+            include_report=False,
+            include_project_zip=False,
+        )
+        pkg = ManufacturingPackage(
+            pcb_path=pcb,
+            manufacturer="jlcpcb",
+            config=config,
+        )
+        out_dir = tmp_path / "out"
+        result = pkg.export(out_dir)
+
+        # Export should NOT have proceeded
+        assert not assembly_called["value"]
+        assert not result.success
+        assert len(result.errors) == 1
+        assert "bom_pcb_match" in result.errors[0]
+        # No bom_jlcpcb.csv written
+        assert not out_dir.exists() or not (out_dir / "bom_jlcpcb.csv").exists()
+
+    def test_unbuildable_bom_allowed_when_flag_disabled(self, tmp_path, monkeypatch):
+        """With block_on_unbuildable_bom=False (--allow-unbuildable-bom),
+        the export proceeds and the failure is recorded as a warning.
+        """
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        pcb = project_dir / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+
+        from kicad_tools.export import assembly
+
+        assembly_called = {"value": False}
+
+        def fake_assembly_export(self, output_dir=None):
+            assembly_called["value"] = True
+            od = Path(output_dir) if output_dir else self.config.output_dir
+            od.mkdir(parents=True, exist_ok=True)
+            return assembly.AssemblyPackageResult(output_dir=od)
+
+        monkeypatch.setattr(assembly.AssemblyPackage, "export", fake_assembly_export)
+
+        fail_results = [
+            PreflightResult(
+                name="bom_pcb_match",
+                status="FAIL",
+                message="BOM/PCB reference mismatch",
+                details="36 in BOM but not on PCB: U1, U2, U3",
+            ),
+        ]
+        monkeypatch.setattr(PreflightChecker, "run_all", lambda self: fail_results)
+
+        config = ManufacturingConfig(
+            include_report=False,
+            include_project_zip=False,
+            block_on_unbuildable_bom=False,
+        )
+        pkg = ManufacturingPackage(
+            pcb_path=pcb,
+            manufacturer="jlcpcb",
+            config=config,
+        )
+        out_dir = tmp_path / "out"
+        result = pkg.export(out_dir)
+
+        # Export proceeds
+        assert assembly_called["value"]
+        # Failure recorded as warning, not error
+        assert any("bom_pcb_match" in w for w in result.warnings)
+        assert result.success
 
 
 class TestLatestReportOnly:
@@ -573,6 +678,7 @@ class TestLatestReportOnly:
 
         # No vN/ directories should remain
         import re
+
         for child in out_dir.iterdir():
             if child.is_dir():
                 assert not re.fullmatch(r"v\d+", child.name), (
@@ -900,6 +1006,7 @@ class TestLatestReportOnly:
 
         # Parse manifest
         import json
+
         manifest = json.loads((out_dir / "manifest.json").read_text())
 
         # Manifest should have "report.md" key (at root), not "report/report.md"
@@ -956,6 +1063,7 @@ class TestLatestReportOnly:
 
         # Parse manifest -- both should have checksums
         import json
+
         manifest = json.loads((out_dir / "manifest.json").read_text())
         assert "report.pdf" in manifest["files"]
         assert "report.md" in manifest["files"]

--- a/tests/test_pipeline_cmd.py
+++ b/tests/test_pipeline_cmd.py
@@ -211,6 +211,7 @@ def empty_pcb(tmp_path: Path) -> Path:
     pcb_file.write_text(EMPTY_PCB)
     return pcb_file
 
+
 @pytest.fixture
 def zone_fill_only_pcb(tmp_path: Path) -> Path:
     """Create a PCB with zone fills but no routed traces."""
@@ -225,7 +226,6 @@ def zone_fill_with_traces_pcb(tmp_path: Path) -> Path:
     pcb_file = tmp_path / "zone_fill_with_traces.kicad_pcb"
     pcb_file.write_text(ZONE_FILL_WITH_TRACES_PCB)
     return pcb_file
-
 
 
 @pytest.fixture
@@ -261,7 +261,6 @@ class TestDetectRoutingStatus:
         assert trace_count == 0
         assert net_count == 0
 
-
     def test_zone_fill_only_not_routed(self, zone_fill_only_pcb: Path):
         """A PCB with only zone fills (no top-level segments) is unrouted (#1835)."""
         is_routed, trace_count, net_count = _detect_routing_status(zone_fill_only_pcb)
@@ -271,9 +270,7 @@ class TestDetectRoutingStatus:
 
     def test_zone_fill_with_traces_detected(self, zone_fill_with_traces_pcb: Path):
         """A PCB with zone fills AND top-level segments is detected as routed."""
-        is_routed, trace_count, net_count = _detect_routing_status(
-            zone_fill_with_traces_pcb
-        )
+        is_routed, trace_count, net_count = _detect_routing_status(zone_fill_with_traces_pcb)
         assert is_routed is True
         assert trace_count == 1
         assert net_count > 0
@@ -1834,9 +1831,7 @@ class TestSchematicFlag:
         sch_file = tmp_path / "other.kicad_sch"
         sch_file.write_text("(kicad_sch)")
 
-        result = main(
-            ["--step", "erc", "--dry-run", "--schematic", str(sch_file), str(pcb_file)]
-        )
+        result = main(["--step", "erc", "--dry-run", "--schematic", str(sch_file), str(pcb_file)])
         assert result == 0
 
 
@@ -2473,6 +2468,33 @@ class TestExportStep:
         cmd_args = mock_run.call_args[0][0]
         o_idx = cmd_args.index("-o")
         assert cmd_args[o_idx + 1] == str(routed_pcb.parent / "manufacturing")
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_export_step_forwards_sch_when_available(self, mock_run, routed_pcb: Path):
+        """Export step passes --sch to the export subprocess when a schematic
+        is available, so PreflightChecker._check_bom_footprint_match can run
+        and detect schematic-only refs (issue #2729).
+        """
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+
+        # Create a schematic next to the routed PCB so _resolve_schematic
+        # discovers it.
+        sch_path = routed_pcb.with_suffix(".kicad_sch")
+        if not sch_path.exists():
+            sch_path.write_text("(kicad_sch)")
+
+        ctx = PipelineContext(
+            pcb_file=routed_pcb,
+            schematic_file=sch_path,
+            quiet=True,
+            mfr="jlcpcb",
+        )
+        run_pipeline(ctx, [PipelineStep.EXPORT])
+
+        cmd_args = mock_run.call_args[0][0]
+        assert "--sch" in cmd_args
+        sch_idx = cmd_args.index("--sch")
+        assert cmd_args[sch_idx + 1] == str(sch_path)
 
     @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
     def test_step_export_accepted_by_argparse(self, mock_run, routed_pcb: Path):
@@ -3570,6 +3592,111 @@ class TestPrintFinalSummary:
         assert "unknown -- could not determine DRC status" in output
         assert "Silkscreen: 0 warnings" in output
 
+    def test_sync_schematic_only_forces_not_ready(self, routed_pcb: Path):
+        """Schematic-only refs in audit_data trump DRC pass -> NOT READY.
+
+        Issue #2729: an unbuildable BOM (refs in schematic missing from
+        the PCB) must produce NOT READY regardless of DRC/ERC state.
+        """
+        console, buf = self._make_console()
+        check_data = {
+            "summary": {"errors": 0, "warnings": 0, "rules_checked": 5, "passed": True},
+            "violations": [],
+        }
+        audit_data = {
+            "sync": {
+                "schematic_only_count": 36,
+                "pcb_only_count": 0,
+                "value_mismatch_count": 0,
+                "footprint_mismatch_count": 0,
+            },
+        }
+        results = [
+            PipelineResult(step=PipelineStep.ERC, success=True, message="erc: no violations found"),
+            PipelineResult(step=PipelineStep.AUDIT, success=False, message="audit: not ready"),
+        ]
+        ctx = PipelineContext(pcb_file=routed_pcb, mfr="jlcpcb", layers="2")
+
+        _print_final_summary(ctx, results, console, check_data=check_data, audit_data=audit_data)
+        output = buf.getvalue()
+
+        assert "NOT READY" in output
+        assert "36 schematic-only refs" in output
+        assert "unbuildable BOM" in output
+
+    def test_sync_pcb_only_drives_warning_when_audit_passes(self, routed_pcb: Path):
+        """PCB-only orphans surface as WARNING in the verdict line."""
+        console, buf = self._make_console()
+        check_data = {
+            "summary": {"errors": 0, "warnings": 0, "rules_checked": 5, "passed": True},
+            "violations": [],
+        }
+        audit_data = {
+            "sync": {
+                "schematic_only_count": 0,
+                "pcb_only_count": 3,
+                "value_mismatch_count": 0,
+                "footprint_mismatch_count": 0,
+            },
+        }
+        results = [
+            PipelineResult(step=PipelineStep.ERC, success=True, message="erc: no violations found"),
+            PipelineResult(step=PipelineStep.AUDIT, success=True, message="audit: passed"),
+        ]
+        ctx = PipelineContext(pcb_file=routed_pcb, mfr="jlcpcb", layers="2")
+
+        _print_final_summary(ctx, results, console, check_data=check_data, audit_data=audit_data)
+        output = buf.getvalue()
+
+        assert "WARNING" in output
+        assert "sync drift" in output
+
+    def test_sync_line_displays_drift_summary(self, routed_pcb: Path):
+        """The new Sync: line summarizes all four axes."""
+        console, buf = self._make_console()
+        check_data = {
+            "summary": {"errors": 0, "warnings": 0, "rules_checked": 5, "passed": True},
+            "violations": [],
+        }
+        audit_data = {
+            "sync": {
+                "schematic_only_count": 5,
+                "pcb_only_count": 2,
+                "value_mismatch_count": 1,
+                "footprint_mismatch_count": 3,
+            },
+        }
+        results = [
+            PipelineResult(step=PipelineStep.ERC, success=True, message="erc: no violations found"),
+            PipelineResult(step=PipelineStep.AUDIT, success=False, message="audit: not ready"),
+        ]
+        ctx = PipelineContext(pcb_file=routed_pcb, mfr="jlcpcb", layers="2")
+
+        _print_final_summary(ctx, results, console, check_data=check_data, audit_data=audit_data)
+        output = buf.getvalue()
+
+        assert "Sync:" in output
+        assert "5 schematic-only" in output
+        assert "2 PCB-only" in output
+
+    def test_sync_line_when_audit_data_missing(self, routed_pcb: Path):
+        """When audit_data is None, the sync line is rendered as skipped."""
+        console, buf = self._make_console()
+        check_data = {
+            "summary": {"errors": 0, "warnings": 0, "rules_checked": 5, "passed": True},
+            "violations": [],
+        }
+        results = [
+            PipelineResult(step=PipelineStep.ERC, success=True, message="erc: no violations found"),
+        ]
+        ctx = PipelineContext(pcb_file=routed_pcb, mfr="jlcpcb", layers="2")
+
+        _print_final_summary(ctx, results, console, check_data=check_data, audit_data=None)
+        output = buf.getvalue()
+
+        assert "Sync:" in output
+        assert "skipped" in output
+
 
 class TestVerdictMatchesAudit:
     """Tests that the pipeline verdict uses the audit step result when available.
@@ -4053,6 +4180,7 @@ class TestBestEffort:
     @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
     def test_best_effort_does_not_affect_non_route_failures(self, mock_run, unrouted_pcb: Path):
         """--best-effort only applies to ROUTE failures; other step failures still abort."""
+
         # FIX_DRC fails
         def side_effect(cmd, **kwargs):
             if "fix-drc" in cmd:
@@ -4192,9 +4320,7 @@ class TestStitchStep:
         """Stitch step invokes kct stitch as a subprocess on multi-layer boards."""
         mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
         console = MagicMock()
-        ctx = PipelineContext(
-            pcb_file=four_layer_pcb_with_zones, layers="4", quiet=True
-        )
+        ctx = PipelineContext(pcb_file=four_layer_pcb_with_zones, layers="4", quiet=True)
         result = _run_step_stitch(ctx, console)
         assert result.success is True
         assert result.skipped is False
@@ -4257,8 +4383,11 @@ class TestStitchStep:
         """Stitch dry-run message includes via size and drill from manufacturer."""
         console = MagicMock()
         ctx = PipelineContext(
-            pcb_file=four_layer_pcb_with_zones, layers="4", mfr="seeed",
-            dry_run=True, quiet=True,
+            pcb_file=four_layer_pcb_with_zones,
+            layers="4",
+            mfr="seeed",
+            dry_run=True,
+            quiet=True,
         )
         result = _run_step_stitch(ctx, console)
         assert result.success is True
@@ -4323,9 +4452,7 @@ class TestCacheFlagForwarding:
         """Both --no-cache and --clear-cache flags forwarded together."""
         mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
 
-        ctx = PipelineContext(
-            pcb_file=unrouted_pcb, quiet=True, no_cache=True, clear_cache=True
-        )
+        ctx = PipelineContext(pcb_file=unrouted_pcb, quiet=True, no_cache=True, clear_cache=True)
         results = run_pipeline(ctx, [PipelineStep.ROUTE])
 
         assert len(results) == 1
@@ -4337,9 +4464,7 @@ class TestCacheFlagForwarding:
 
     def test_dry_run_includes_no_cache(self, unrouted_pcb: Path):
         """--dry-run output includes --no-cache when set."""
-        ctx = PipelineContext(
-            pcb_file=unrouted_pcb, quiet=True, dry_run=True, no_cache=True
-        )
+        ctx = PipelineContext(pcb_file=unrouted_pcb, quiet=True, dry_run=True, no_cache=True)
         results = run_pipeline(ctx, [PipelineStep.ROUTE])
 
         assert len(results) == 1
@@ -4348,9 +4473,7 @@ class TestCacheFlagForwarding:
 
     def test_dry_run_includes_clear_cache(self, unrouted_pcb: Path):
         """--dry-run output includes --clear-cache when set."""
-        ctx = PipelineContext(
-            pcb_file=unrouted_pcb, quiet=True, dry_run=True, clear_cache=True
-        )
+        ctx = PipelineContext(pcb_file=unrouted_pcb, quiet=True, dry_run=True, clear_cache=True)
         results = run_pipeline(ctx, [PipelineStep.ROUTE])
 
         assert len(results) == 1
@@ -4359,9 +4482,7 @@ class TestCacheFlagForwarding:
 
     def test_cache_flags_ignored_when_route_skipped(self, routed_pcb: Path):
         """Cache flags cause no error when route step is skipped (already routed)."""
-        ctx = PipelineContext(
-            pcb_file=routed_pcb, quiet=True, no_cache=True, clear_cache=True
-        )
+        ctx = PipelineContext(pcb_file=routed_pcb, quiet=True, no_cache=True, clear_cache=True)
         results = run_pipeline(ctx, [PipelineStep.ROUTE])
 
         assert len(results) == 1
@@ -4380,7 +4501,5 @@ class TestCacheFlagForwarding:
 
     def test_both_cache_flags_cli_parsed(self, unrouted_pcb: Path):
         """Both --no-cache and --clear-cache accepted together via CLI."""
-        result = main(
-            ["--no-cache", "--clear-cache", "--dry-run", "--quiet", str(unrouted_pcb)]
-        )
+        result = main(["--no-cache", "--clear-cache", "--dry-run", "--quiet", str(unrouted_pcb)])
         assert result == 0


### PR DESCRIPTION
## Summary

Closes #2729.

Pipeline previously reported success while writing a BOM that referenced schematic-only parts with no matching PCB footprints (unbuildable package). This PR wires the four-axis sync drift produced by `Reconciler.analyze()` into the audit, the export gate, and the pipeline verdict.

### Changes

**A. Audit gains a first-class sync drift check** (`src/kicad_tools/audit/auditor.py`):
- New `SyncStatus` dataclass with schematic_only / pcb_only / value_mismatch / footprint_mismatch counts (plus up to 10 example refs per axis).
- New `ManufacturingAudit._check_sync_drift()` reuses `Reconciler` rather than reimplementing set logic, so `kct audit` and `kct sync --analyze` always agree.
- `AuditResult.verdict` returns **NOT_READY** when `sync.schematic_only_count > 0` (unbuildable BOM), **WARNING** for the other three axes.
- `AuditResult.to_dict()` surfaces a new `sync` key so `report.md` / `manifest.json` can pick it up.
- Audit CLI table and summary output gained a `Sync (Schematic <-> PCB)` block.

**B. Export blocks on unbuildable BOM** (`src/kicad_tools/export/manufacturing.py` + `src/kicad_tools/cli/export_cmd.py`):
- New `ManufacturingConfig.block_on_unbuildable_bom` flag (default **True**) treats `bom_pcb_match` FAIL as a hard fail independently of `strict_preflight`.
- New `kct export --allow-unbuildable-bom` CLI flag opts power users out for partial/debug exports.

**C. Pipeline reflects sync drift in its verdict** (`src/kicad_tools/cli/pipeline_cmd.py`):
- `_run_step_export` now passes `--sch` (auto-detected via `_resolve_schematic`) so `_check_bom_footprint_match` can actually fire.
- New `_fetch_audit_results()` helper runs `kct audit --format json` once and feeds the result into `_print_final_summary`.
- `_print_final_summary` now reads `sync.schematic_only_count`: when > 0 the verdict line reads `NOT READY -- N schematic-only refs (unbuildable BOM)` regardless of DRC/ERC pass.
- New `Sync:` row added to the printed summary block.

## Acceptance criteria checklist

- [x] Audit reports all four sync axes (counts plus example refs).
- [x] Audit verdict on a board with schematic-only refs is `NOT_READY`.
- [x] `kct export` exits non-zero and does NOT write `bom_jlcpcb.csv` when schematic-only refs > 0; `--allow-unbuildable-bom` overrides.
- [x] Pipeline final verdict line reads `NOT READY -- N schematic-only refs (unbuildable BOM)` when the schematic has refs missing from the PCB.
- [x] `AuditResult.to_dict()` includes a `sync` key with the four counts.
- [x] No regression in orphan-only test cases.

## Test plan

- [x] 16 new tests in `tests/test_audit.py` (SyncStatus dataclass, verdict transitions, Reconciler integration, action items).
- [x] 2 new tests in `tests/test_manufacturing_package.py` (unbuildable BOM gate fires by default; `--allow-unbuildable-bom` escape hatch works).
- [x] 5 new tests in `tests/test_pipeline_cmd.py` (sync-aware verdict, `Sync:` row, `--sch` propagation to export step).
- [x] All 105 existing `test_audit.py` orphan tests still pass.
- [x] All 39 existing `test_manufacturing_package.py` preflight tests still pass.
- [x] ruff check and ruff format are clean on all changed files.
- [ ] Manual repro against chorus-test-revA (private repo) -- to be done by the human reviewer.

The 7 pre-existing test failures observed in `test_audit.py`, `test_preflight.py`, and `test_pipeline_cmd.py` reproduce on main without these changes and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)