### PR TITLE
docs(router): document Python-only corridor reservation contract (closes #2709)

### DIFF
--- a/src/kicad_tools/router/cpp/include/grid.hpp
+++ b/src/kicad_tools/router/cpp/include/grid.hpp
@@ -61,6 +61,11 @@ public:
     // Route marking with clearance buffer using Bresenham
     void mark_segment(int x1, int y1, int x2, int y2, int layer, int net,
                       int clearance_cells);
+    // Issue #2709: ``mark_via`` does NOT consult the corridor reservation
+    // map that Python's ``RoutingGrid._mark_via`` enforces (Issue #2677).
+    // Safe today because the escape phase never marks vias through the
+    // C++ backend; see ``cpp/src/grid.cpp`` for the full rationale and
+    // ``tests/test_grid_cpp_parity.py`` for the contract-locking test.
     void mark_via(int x, int y, int net, int radius_cells);
 
     // Unmark route (rip-up)

--- a/src/kicad_tools/router/cpp/src/grid.cpp
+++ b/src/kicad_tools/router/cpp/src/grid.cpp
@@ -99,6 +99,24 @@ void Grid3D::mark_segment(int x1, int y1, int x2, int y2, int layer, int net,
     }
 }
 
+// Issue #2709: Python-only reservation contract.
+//
+// The Python sibling ``RoutingGrid._mark_via`` (src/kicad_tools/router/grid.py)
+// consults a ``_reserved_for_nets`` map (introduced by Issue #2677 / PR #2686)
+// to skip cells reserved for paired-escape continuation corridors when the
+// via's net is not in the reservation owner set.  This C++ implementation
+// deliberately omits that check because the escape phase is Python-grid-only
+// today: ``EscapeRouter`` calls ``Grid.mark_route`` / ``Grid._mark_via``
+// directly and never reaches this C++ ``mark_via`` during the paired pre-pass
+// when reservations matter.
+//
+// If/when escape routing moves into C++ (likely with Epic #2661 Phase 2's
+// group-of-pairs serpentine), this method MUST grow an equivalent
+// reservation map + skip check or board 06's USB3_TX1+/- escape fix --
+// and DDR-style boards using the same primitive -- will silently regress.
+// A contract-locking regression test lives in
+// ``tests/test_grid_cpp_parity.py`` and is expected to fail (deliberately,
+// signalling the port is needed) at that point.
 void Grid3D::mark_via(int x, int y, int net, int radius_cells) {
     for (int layer = 0; layer < layers_; ++layer) {
         for (int dy = -radius_cells; dy <= radius_cells; ++dy) {

--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -1846,6 +1846,25 @@ class RoutingGrid:
         non-matching nets are blocked as normal on layers WHERE the cell
         is not reserved, and skipped on layers where it IS reserved.
 
+        Issue #2709 (Python-only reservation contract): the corridor
+        reservation map (``self._reserved_for_nets``) is consulted ONLY by
+        this Python implementation.  The C++ sibling
+        ``router::Grid3D::mark_via`` (``cpp/src/grid.cpp``) deliberately
+        ignores reservations because the escape phase is Python-grid-only
+        today -- ``EscapeRouter`` calls ``Grid.mark_route`` /
+        ``Grid._mark_via`` directly and never routes via marking through
+        the C++ backend during the paired pre-pass.  The C++ grid does
+        receive partner-net vias indirectly (via
+        ``RoutingCore._mark_route_on_cpp_grid`` after the escape pass),
+        but that path runs AFTER the corridor reservation has served its
+        purpose, so cell-block parity does not matter for board 06's
+        USB3_TX1+/- fix today.  If/when the escape pass moves into C++
+        (likely tied to Epic #2661 Phase 2's group-of-pairs serpentine),
+        the C++ ``mark_via`` MUST grow an equivalent reservation check
+        or board 06 (and DDR-style boards using the same primitive) will
+        regress.  See ``tests/test_grid_cpp_parity.py`` for a regression
+        test that pins the current contract.
+
         Args:
             via: The via to mark.
             max_trace_width: Maximum trace width across all net classes.

--- a/tests/test_grid_cpp_parity.py
+++ b/tests/test_grid_cpp_parity.py
@@ -1,0 +1,204 @@
+"""C++ <-> Python grid parity gates.
+
+Issue #2709: pin the current Python-only contract for the
+corridor-reservation feature added by Issue #2677 / PR #2686.
+
+The Python ``RoutingGrid._mark_via`` consults
+``RoutingGrid._reserved_for_nets`` (populated by
+``EscapeRouter._reserve_pair_continuation_corridor``) to skip cells that
+have been reserved for paired-escape continuation.  The C++ sibling
+``router::Grid3D::mark_via`` (cpp/src/grid.cpp) deliberately omits that
+check because the escape phase is Python-grid-only today.
+
+This test pins the CURRENT behaviour:
+
+  * Python ``Grid._mark_via`` with a partner-net via SKIPS reserved
+    cells (the existing diff-pair gate already covers this in
+    ``test_escape_diffpair.py::test_gate_b_partner_vias_do_not_consume_reserved_cells``).
+  * C++ ``Grid3D::mark_via`` with the same partner-net via DOES block
+    the reserved cell (because it ignores the Python reservation map).
+
+When the escape phase is ported to C++ (e.g. with Epic #2661 Phase 2's
+group-of-pairs serpentine), the C++ ``mark_via`` will need an equivalent
+reservation API.  At that point this test SHOULD be inverted to assert
+the cell remains UNblocked on the C++ side.  A failing test in this
+file is a deliberate signal that the parity gap has been closed (or that
+someone changed the Python contract without the matching C++ port).
+
+Test is skipped when the C++ backend is not built so it is non-fatal in
+Python-only environments.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.router.cpp_backend import is_cpp_available
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.primitives import Via
+from kicad_tools.router.rules import DesignRules
+
+# --------------------------------------------------------------------------- #
+# Fixtures                                                                    #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def rules() -> DesignRules:
+    return DesignRules(
+        trace_width=0.2,
+        trace_clearance=0.15,
+        via_drill=0.3,
+        via_diameter=0.6,
+        via_clearance=0.15,
+        grid_resolution=0.1,
+    )
+
+
+@pytest.fixture
+def grid_4layer(rules: DesignRules) -> RoutingGrid:
+    """4-layer all-signal stack so an inner SIGNAL layer exists.
+
+    Mirrors the fixture in ``test_escape_diffpair.py``.
+    """
+    stack = LayerStack.four_layer_all_signal()
+    return RoutingGrid(50, 50, rules, origin_x=0, origin_y=0, layer_stack=stack)
+
+
+# --------------------------------------------------------------------------- #
+# Issue #2709 parity gate                                                     #
+# --------------------------------------------------------------------------- #
+
+
+class TestMarkViaReservationParity:
+    """Pin the Python-only nature of corridor reservations.
+
+    These tests document the CURRENT behaviour described in the
+    docstring of ``RoutingGrid._mark_via`` and the Issue #2709 comment
+    block on ``router::Grid3D::mark_via``.  When the escape phase moves
+    into C++ and the reservation logic is ported, the assertions tagged
+    with ``# CONTRACT: invert when C++ port lands`` must flip.
+    """
+
+    def test_python_grid_skips_partner_via_at_reserved_cell(
+        self, grid_4layer: RoutingGrid, rules: DesignRules
+    ) -> None:
+        """Sanity gate: the Python contract still holds.
+
+        Reserves a single inner-layer cell for nets {1, 2}, then calls
+        ``Grid._mark_via`` for a foreign net (42).  The reserved cell
+        must remain UNBLOCKED, matching the Issue #2677 contract that
+        partner-net through-hole vias do not colonise reserved corridor
+        cells on the Python grid.
+        """
+        # Pick an inner-layer cell well away from the grid edge so the
+        # via radius does not run off the grid.
+        gx, gy = 25, 25
+        # Find a SIGNAL inner layer index for this stack.
+        inner_layer_idx = None
+        for idx in range(grid_4layer.num_layers):
+            layer_enum = grid_4layer.index_to_layer(idx)
+            if layer_enum not in (Layer.F_CU.value, Layer.B_CU.value):
+                inner_layer_idx = idx
+                break
+        assert inner_layer_idx is not None, "4-layer stack should expose an inner layer"
+
+        # Reserve a single cell on the inner layer for nets {1, 2}.
+        owner_nets = frozenset({1, 2})
+        grid_4layer.reserve_corridor_cells(inner_layer_idx, [(gx, gy)], owner_nets)
+        assert grid_4layer.is_reserved_for(inner_layer_idx, gx, gy, 1)
+        assert not grid_4layer.is_reserved_for(inner_layer_idx, gx, gy, 42)
+
+        # Confirm the cell starts unblocked.
+        assert not grid_4layer.grid[inner_layer_idx][gy][gx].blocked
+
+        # Place a foreign-net via at the reserved cell's world coordinate.
+        wx, wy = grid_4layer.grid_to_world(gx, gy)
+        partner_via = Via(
+            x=wx,
+            y=wy,
+            drill=rules.via_drill,
+            diameter=rules.via_diameter,
+            layers=(Layer.F_CU, Layer.B_CU),
+            net=42,
+            net_name="FOREIGN",
+        )
+        grid_4layer._mark_via(partner_via)
+
+        # Python contract: reserved cell must remain unblocked when the
+        # via belongs to a non-owner net.
+        assert not grid_4layer.grid[inner_layer_idx][gy][gx].blocked, (
+            "Python _mark_via must skip cells reserved for a different net set "
+            "(Issue #2677)."
+        )
+
+    def test_cpp_grid_ignores_python_reservations(
+        self, grid_4layer: RoutingGrid, rules: DesignRules
+    ) -> None:
+        """C++ ``Grid3D::mark_via`` does NOT consult Python reservations.
+
+        Lock the current behaviour: a foreign-net via marked through the
+        C++ binding DOES block a cell that the Python grid has reserved
+        for a different net set.
+
+        Issue #2709: this test should be INVERTED (assert ``not blocked``)
+        when escape routing is ported to C++ and the reservation logic
+        lands on ``Grid3D``.  A failing assertion below means the parity
+        gap was closed -- update the assertion and remove the
+        contract-locking docstring.
+        """
+        if not is_cpp_available():
+            pytest.skip("C++ router backend not built (run: kct build-native)")
+
+        from kicad_tools.router.cpp_backend import CppGrid
+
+        # Pick the same inner-layer cell as the Python sanity gate.
+        gx, gy = 25, 25
+        inner_layer_idx = None
+        for idx in range(grid_4layer.num_layers):
+            layer_enum = grid_4layer.index_to_layer(idx)
+            if layer_enum not in (Layer.F_CU.value, Layer.B_CU.value):
+                inner_layer_idx = idx
+                break
+        assert inner_layer_idx is not None, "4-layer stack should expose an inner layer"
+
+        # Reserve the cell on the Python grid BEFORE building the C++
+        # mirror.  ``CppGrid.from_routing_grid`` copies blocked cells but
+        # has no concept of corridor reservations -- which is exactly the
+        # parity gap this test pins.
+        owner_nets = frozenset({1, 2})
+        grid_4layer.reserve_corridor_cells(inner_layer_idx, [(gx, gy)], owner_nets)
+        assert grid_4layer.reserved_cell_count() == 1
+        assert not grid_4layer.grid[inner_layer_idx][gy][gx].blocked
+
+        cpp_grid = CppGrid.from_routing_grid(grid_4layer)
+
+        # Confirm the C++ mirror starts with the cell unblocked
+        # (reservations don't block, only Python ``_mark_via`` does).
+        assert not cpp_grid._impl.at(gx, gy, inner_layer_idx).blocked, (
+            "Cell should start unblocked on the C++ side; reservations alone "
+            "do not block cells."
+        )
+
+        # Place a foreign-net via through the C++ binding.  The radius
+        # of 0 cells targets exactly (gx, gy) on every layer, isolating
+        # the reservation-skip behaviour from clearance geometry.
+        cpp_grid._impl.mark_via(gx, gy, 42, 0)
+
+        # CONTRACT: invert when C++ port lands.
+        # Today: C++ ignores the Python reservation map, so the cell IS blocked.
+        # Future: when ``Grid3D`` learns about reservations, this should
+        # become ``assert not cell.blocked`` and the Python parity gate
+        # above will document the symmetric expectation.
+        cell = cpp_grid._impl.at(gx, gy, inner_layer_idx)
+        assert cell.blocked, (
+            "Issue #2709 contract: C++ Grid3D::mark_via deliberately ignores "
+            "Python's _reserved_for_nets map.  If this assertion fails, the "
+            "C++ port has likely landed -- invert the assertion and update "
+            "the rationale comments in cpp/src/grid.cpp and "
+            "src/kicad_tools/router/grid.py:_mark_via."
+        )
+        assert cell.net == 42, (
+            "Foreign-net via should claim the cell on the C++ side."
+        )


### PR DESCRIPTION
## Summary

Issue #2677 (PR #2686) introduced the `Grid._reserved_for_nets` map and `reserve_corridor_cells` API so paired escapes can carve out hard keep-out corridors that partner-net through-hole vias must not colonise. Python's `Grid._mark_via` consults the reservation map; the C++ `Grid3D::mark_via` (`cpp/src/grid.cpp:102`) does NOT.

The judge on PR #2686 flagged this as a future-port hazard. This PR makes the gap explicit (no behaviour change) so future work catches the divergence:

- **Python** `RoutingGrid._mark_via` (`grid.py:1837`): docstring grows an Issue #2709 paragraph naming the C++ sibling and explaining why today's behaviour is safe (escape pass is Python-grid-only; C++ vias arrive AFTER the corridor served its purpose).
- **C++** `Grid3D::mark_via` (`cpp/src/grid.cpp:102`): comment block stating the omission is deliberate and pointing porters at the contract-locking test. The header (`cpp/include/grid.hpp:64`) gets a one-line reference.
- **Test**: `tests/test_grid_cpp_parity.py` adds two pinning gates -- a Python sanity gate (foreign-net via SKIPS reserved cells) and a C++ contract gate (foreign-net via DOES block the reserved cell, locking current behaviour). Docstring instructs reviewers to invert the C++ assertion when the port lands.

No production-code change. Both new tests skip cleanly when the C++ backend is not built.

## Test plan

- [x] New `tests/test_grid_cpp_parity.py` (2 tests) passes locally with the C++ extension built.
- [x] Existing `tests/test_escape_diffpair.py::TestCorridorReservation` (6 tests) still passes.
- [x] `tests/test_router_cpp_via_clearance.py`, `tests/test_router_grid.py`, `tests/test_diffpair_partner_wiring.py` (180 tests) still pass.
- [x] `ruff check` clean on the new test file.
- [ ] CI green including `C++ Build Check` (verifies header/source change is benign and `BUILD_VERSION` still matches).

## Acceptance criteria (from issue #2709)

- [x] Comment in Python `grid.py` documenting the Python-only reservation contract.
- [x] Comment in C++ `grid.cpp` (and header) documenting the parity gap.
- [x] Regression test asserts current behavior (reservations are Python-only) -- locks the contract so future changes are deliberate.

Closes #2709

🤖 Generated with [Claude Code](https://claude.com/claude-code)