### PR TITLE
feat(router,cli): add --length-match-groups flag + Autorouter.apply_match_group_tuning

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -289,6 +289,9 @@ def run_route_command(args) -> int:
     # Issue #2648 (Epic #2556 Phase 3I): forward the length-match-diffpairs flag
     if getattr(args, "length_match_diffpairs", False):
         sub_argv.append("--length-match-diffpairs")
+    # Issue #2723 (Epic #2661 Phase 3H): forward the length-match-groups flag
+    if getattr(args, "length_match_groups", False):
+        sub_argv.append("--length-match-groups")
     return route_main(sub_argv)
 
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2481,6 +2481,19 @@ def _add_route_parser(subparsers) -> None:
             "warns and short-circuits)."
         ),
     )
+    route_parser.add_argument(
+        "--length-match-groups",
+        action="store_true",
+        help=(
+            "Enable N-trace match-group length-match tuning (Epic #2661 "
+            "Phase 3H). Detects parallel-bus groups (DDR, MIPI, HDMI TMDS) "
+            "declared via NetClassRouting.length_match_group, then inserts "
+            "serpentines on shorter group members until the per-group skew "
+            "is within tolerance. Compatible with --length-match-diffpairs; "
+            "groups whose members are diff pairs (MIPI/HDMI lane groups) "
+            "engage the Phase 2F symmetric-serpentine path."
+        ),
+    )
 
 
 def _add_route_auto_parser(subparsers) -> None:

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -3472,6 +3472,19 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--length-match-groups",
+        action="store_true",
+        help=(
+            "Enable N-trace match-group length-match tuning (Epic #2661 "
+            "Phase 3H). Detects parallel-bus groups (DDR, MIPI, HDMI TMDS) "
+            "declared via NetClassRouting.length_match_group, then inserts "
+            "serpentines on shorter group members until the per-group skew "
+            "is within tolerance. Compatible with --length-match-diffpairs; "
+            "groups whose members are diff pairs (MIPI/HDMI lane groups) "
+            "engage the Phase 2F symmetric-serpentine path."
+        ),
+    )
+    parser.add_argument(
         "-q",
         "--quiet",
         action="store_true",
@@ -5248,6 +5261,81 @@ def main(argv: list[str] | None = None) -> int:
                         f"{n_rollback} rolled back, {n_budget} budget-exhausted, "
                         f"{n_skipped} skipped (not length-critical)"
                     )
+
+    # N-trace match-group length-match (skew) tuning -- Epic #2661 Phase 3H
+    # (Issue #2723).  Engaged via --length-match-groups (opt-in).  Runs
+    # AFTER --length-match-diffpairs so the within-pair skew invariant is
+    # preserved before group tuning perturbs lane lengths.  Graceful
+    # short-circuit when no groups are declared / detected.
+    if getattr(args, "length_match_groups", False) and router.routes:
+        from kicad_tools.router.match_group_detection import detect_match_groups
+
+        if not quiet:
+            print("\n--- Length-Match Groups (Epic #2661 Phase 3H) ---")
+        # Build net_to_class so explicit declarations can be consulted
+        # (mirrors the construction in core.py:_finalize_routing).
+        net_to_class: dict[str, str] = {}
+        for net_name, net_class in router.net_class_map.items():
+            net_to_class[net_name] = net_class.name
+        try:
+            detected_groups = detect_match_groups(
+                net_names=router.net_names,
+                net_class_routing=router.net_class_map,
+                net_to_class=net_to_class,
+                length_tracker=router.length_tracker,
+                enable_suffix_inference=False,
+            )
+        except Exception as exc:
+            if not quiet:
+                print(f"  Match-group detection failed: {exc}; skipping.")
+            detected_groups = []
+
+        if not detected_groups:
+            if not quiet:
+                print("  No match groups detected; nothing to tune.")
+        else:
+            # Snapshot connectivity for the pad-to-pad invariant.
+            _ci_snapshot_groups = _connectivity_snapshot(router)
+            tune_results_groups = router.apply_match_group_tuning(
+                detected_groups=detected_groups,
+                verbose=not quiet,
+            )
+            _enforce_connectivity_invariant_or_exit(
+                router,
+                _ci_snapshot_groups,
+                phase="length_match_groups",
+                args=args,
+                quiet=quiet,
+            )
+            if not quiet:
+                # Aggregate per-member counters across all groups for a
+                # single end-of-phase summary line.
+                all_results = [
+                    res
+                    for member_dict in tune_results_groups.values()
+                    for (_route, res) in member_dict.values()
+                ]
+                n_tuned = sum(1 for r in all_results if r.reason == "tuned")
+                n_clean = sum(
+                    1 for r in all_results if r.reason == "already_within_tolerance"
+                )
+                n_rollback = sum(
+                    1 for r in all_results if r.reason == "post_insertion_drc_violation"
+                )
+                n_budget = sum(
+                    1
+                    for r in all_results
+                    if r.reason in ("exceeded_max_inserts", "cascade_budget_exhausted")
+                )
+                n_skipped = sum(
+                    1 for r in all_results if r.reason == "not_length_critical"
+                )
+                print(
+                    f"  Summary: {len(tune_results_groups)} groups, "
+                    f"{n_tuned} tuned, {n_clean} clean, "
+                    f"{n_rollback} rolled back, {n_budget} budget-exhausted, "
+                    f"{n_skipped} skipped (not length-critical)"
+                )
 
     # Finalize: cleanup -> sexp -> stats (canonical ordering)
     multi_pad_net_ids = set(multi_pad_nets)

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -7561,6 +7561,191 @@ class Autorouter:
         )
         return results
 
+    def apply_match_group_tuning(
+        self,
+        detected_groups: list[MatchGroup],
+        verbose: bool = True,
+    ) -> dict[str, dict[int, tuple[Route, Any]]]:
+        """Apply N-trace serpentine tuning to detected match groups.
+
+        Sibling to :meth:`apply_diffpair_length_tuning` (Epic #2556
+        Phase 3I).  For each group whose net class is flagged
+        ``length_critical=True`` AND whose measured skew exceeds the
+        per-group tolerance, attempt serpentine insertions until skew is
+        within tolerance OR the cascade budget is exhausted.
+
+        Per-insertion DRC self-check + byte-for-byte rollback (Phase 2E
+        contract).  Group-of-pairs members (when
+        :attr:`MatchGroup.pair_ids` is non-empty) are routed to the
+        Phase 2F-aware code path inside :func:`tune_match_group_v2`,
+        which applies symmetric serpentine geometry to both halves of
+        each pair member.  The orchestrator is dispatch-agnostic --
+        :func:`tune_match_group_v2` selects the right internal helper
+        based on ``group.pair_ids``.
+
+        Args:
+            detected_groups: List of
+                :class:`~kicad_tools.router.match_group_length.MatchGroup`
+                instances from
+                :func:`~kicad_tools.router.match_group_detection.detect_match_groups`.
+                Groups whose net class is not length-critical are routed
+                through the engagement gate inside
+                :func:`tune_match_group_v2` and returned with
+                ``reason="not_length_critical"``.
+            verbose: Whether to print progress information.
+
+        Returns:
+            ``{group_name: {net_id: (route, result)}}`` for each group
+            processed.  Mirrors the return shape of
+            :func:`tune_match_group_v2` per-group, keyed by
+            :attr:`MatchGroup.name`.  The per-member ``result`` values
+            are :class:`~kicad_tools.router.match_group_tuning.TuneResult`
+            instances.
+        """
+        from .match_group_tuning import TuneResult, tune_match_group_v2
+
+        results: dict[str, dict[int, tuple[Route, TuneResult]]] = {}
+
+        # Build routes_by_net lookup from the autorouter's current state.
+        routes_by_net: dict[int, Route] = {r.net: r for r in self.routes}
+
+        # Update the match-group skew tracker so the post-tuning results are
+        # queryable.  Use the layer-stack count when available, else default
+        # to 2.  Mirrors apply_diffpair_length_tuning's pre/post bracket.
+        if self.layer_stack is not None:
+            num_layers = len(self.layer_stack.layers)
+        else:
+            num_layers = 2
+        self._match_group_tracker.record_routes(
+            routes=self.routes,
+            groups=detected_groups,
+            num_copper_layers=num_layers,
+        )
+
+        for group in detected_groups:
+            # Default per-class info.  When a net class is not configured
+            # for this group's reference net (the common synthetic-test
+            # case) the tuner is invoked with the module-level default
+            # tolerance and the manufacturer minimum clearance.
+            tolerance_mm = 0.5
+            intra_group_clearance_mm = self.rules.trace_clearance
+            intra_pair_clearance_mm = self.rules.trace_clearance
+            length_critical = True
+
+            net_class = self._resolve_net_class_for_group(group)
+            if net_class is not None:
+                tolerance_mm = net_class.effective_length_match_tolerance(0.5)
+                intra_pair_clearance_mm = net_class.effective_intra_pair_clearance()
+                length_critical = net_class.length_critical
+
+            # Phase 2F (#2701) requires intra_pair_clearance_mm
+            # unconditionally for groups whose pair_ids is non-empty.  The
+            # single-ended path inside tune_match_group_v2 ignores it
+            # (see match_group_tuning.py docstring).  We pass it
+            # unconditionally so the dispatch is fully transparent here.
+            try:
+                group_results = tune_match_group_v2(
+                    group=group,
+                    routes_by_net=routes_by_net,
+                    tolerance_mm=tolerance_mm,
+                    intra_group_clearance_mm=intra_group_clearance_mm,
+                    intra_pair_clearance_mm=intra_pair_clearance_mm,
+                    length_critical=length_critical,
+                )
+            except ValueError as exc:
+                # Defensive: a malformed group (e.g. mixed pair/scalar
+                # membership for the same net) should not break the run.
+                # Skip this group with a warning and continue.
+                if verbose:
+                    print(f"  {group.name}: skipped ({exc})")
+                results[group.name] = {}
+                continue
+
+            # Commit any new Route references back into self.routes and the
+            # working ``routes_by_net`` map so subsequent groups' DRC
+            # self-checks see the updated geometry.  Mirrors the
+            # apply_diffpair_length_tuning per-pair commit-back loop.
+            for net_id, (new_route, _result) in group_results.items():
+                if net_id in routes_by_net and new_route is not routes_by_net[net_id]:
+                    routes_by_net[net_id] = new_route
+                    for i, r in enumerate(self.routes):
+                        if r.net == net_id:
+                            self.routes[i] = new_route
+                            break
+
+            results[group.name] = group_results
+
+            if verbose:
+                tuned = sum(1 for (_r, res) in group_results.values() if res.reason == "tuned")
+                clean = sum(
+                    1
+                    for (_r, res) in group_results.values()
+                    if res.reason == "already_within_tolerance"
+                )
+                rolled = sum(
+                    1
+                    for (_r, res) in group_results.values()
+                    if res.reason == "post_insertion_drc_violation"
+                )
+                budget = sum(
+                    1
+                    for (_r, res) in group_results.values()
+                    if res.reason
+                    in ("exceeded_max_inserts", "cascade_budget_exhausted")
+                )
+                skipped = sum(
+                    1
+                    for (_r, res) in group_results.values()
+                    if res.reason == "not_length_critical"
+                )
+                print(
+                    f"  {group.name}: {len(group_results)} members "
+                    f"({tuned} tuned, {clean} clean, {rolled} rolled back, "
+                    f"{budget} budget-exhausted, {skipped} skipped)"
+                )
+
+        # Refresh the skew tracker after tuning so downstream consumers
+        # (e.g. the Phase 2G match_group_length_skew DRC rule) see the
+        # updated lengths.
+        self._match_group_tracker.record_routes(
+            routes=self.routes,
+            groups=detected_groups,
+            num_copper_layers=num_layers,
+        )
+        return results
+
+    def _resolve_net_class_for_group(self, group: MatchGroup) -> Any | None:
+        """Best-effort lookup of the NetClassRouting for a match group.
+
+        Sibling to :meth:`_resolve_net_class_for_pair`.  Returns the
+        NetClassRouting keyed by the group's reference net (``"pace
+        car"`` / longest member).  When the reference net id is unset
+        (legacy ``None`` -> "longest in group" policy), falls back to
+        the first scalar member; when no member is in the class map
+        (e.g. synthetic-test boards that don't configure net classes),
+        returns ``None`` and the caller falls back to default
+        thresholds.
+        """
+        net_class_map = getattr(self, "net_class_map", None) or {}
+        if not net_class_map:
+            return None
+        # Priority 1: explicit reference net.
+        candidate_net_ids: list[int] = []
+        if group.reference_net_id is not None:
+            candidate_net_ids.append(group.reference_net_id)
+        # Priority 2: scalar members.
+        candidate_net_ids.extend(group.net_ids)
+        # Priority 3: paired members (positive halves first).
+        for p_id, n_id in group.pair_ids:
+            candidate_net_ids.append(p_id)
+            candidate_net_ids.append(n_id)
+        net_names = getattr(self, "net_names", None) or {}
+        for net_id in candidate_net_ids:
+            net_name = net_names.get(net_id)
+            if net_name and net_name in net_class_map:
+                return net_class_map[net_name]
+        return None
+
     def _resolve_net_class_for_pair(self, detected_pair) -> Any | None:
         """Best-effort lookup of the NetClassRouting for a detected pair.
 

--- a/tests/test_apply_match_group_tuning.py
+++ b/tests/test_apply_match_group_tuning.py
@@ -1,0 +1,478 @@
+"""Tests for ``Autorouter.apply_match_group_tuning`` (Epic #2661 Phase 3H).
+
+Issue #2723.  This module covers the orchestrator wrapper around
+:func:`kicad_tools.router.match_group_tuning.tune_match_group_v2`:
+
+1. **Triple-gate** -- the call chain Autorouter -> tune_match_group_v2 ->
+   serpentine insert actually fires for each detected group.
+2. **Pair-aware dispatch (AC6)** -- a :class:`MatchGroup` with
+   ``pair_ids`` populated is routed to the Phase 2F symmetric path
+   (no ``AssertionError`` from the historical entry guard).
+3. **Cascade-budget exhaustion** -- a synthetic short-segment group
+   exhausts the per-member budget without breaking the pipeline.
+4. **Signature drift-prevention (AC8)** -- the public method's return
+   type and parameter names are asserted byte-for-byte so a future
+   refactor cannot silently break the CLI consumer.
+5. **Net-class resolution helper** -- ``_resolve_net_class_for_group``
+   prefers the explicit reference net, then scalar members, then pair
+   members, before falling back to ``None``.
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import patch
+
+import pytest
+
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.match_group_length import MatchGroup, MatchGroupSource
+from kicad_tools.router.match_group_tuning import TuneResult
+from kicad_tools.router.primitives import Route, Segment
+from kicad_tools.router.rules import NetClassRouting
+
+
+# =============================================================================
+# Test helpers
+# =============================================================================
+
+
+def _straight_route(net_id: int, name: str, length_mm: float, y: float = 0.0) -> Route:
+    """Single horizontal segment along +x at y=``y``."""
+    return Route(
+        net=net_id,
+        net_name=name,
+        segments=[
+            Segment(
+                x1=0.0,
+                y1=y,
+                x2=length_mm,
+                y2=y,
+                width=0.2,
+                layer=Layer.F_CU,
+                net=net_id,
+                net_name=name,
+            )
+        ],
+    )
+
+
+def _make_autorouter_with_4_net_group() -> tuple[Autorouter, MatchGroup]:
+    """Build an autorouter with a 4-net DDR-style mismatched group.
+
+    Lengths: 22mm, 20mm, 18mm, 18mm.  Reference = longest = net 1 (22mm).
+    Net 2 needs +2mm, nets 3 & 4 need +4mm to reach tolerance.  Routes are
+    spaced apart in y so they have ample room for outer-normal bulges
+    without immediately tripping intra-group clearance.
+    """
+    ar = Autorouter(width=80.0, height=80.0)
+    ar.net_names = {1: "DQ0", 2: "DQ1", 3: "DQ2", 4: "DQ3"}
+    ar.routes = [
+        _straight_route(1, "DQ0", 22.0, y=0.0),
+        _straight_route(2, "DQ1", 20.0, y=10.0),
+        _straight_route(3, "DQ2", 18.0, y=20.0),
+        _straight_route(4, "DQ3", 18.0, y=30.0),
+    ]
+    group = MatchGroup(
+        name="DDR_DATA_BYTE_0",
+        net_ids=[1, 2, 3, 4],
+        tolerance=0.1,
+        reference_net_id=1,
+        source=MatchGroupSource.LEGACY_API,
+    )
+    return ar, group
+
+
+# =============================================================================
+# 1. Triple-gate: orchestrator invokes tuner for each detected group
+# =============================================================================
+
+
+class TestTripleGate:
+    """The full call chain Autorouter -> tune_match_group_v2 -> serpentine."""
+
+    def test_orchestrator_invokes_tuner_for_each_group(self):
+        from kicad_tools.router import match_group_tuning as mgt_module
+
+        ar, group = _make_autorouter_with_4_net_group()
+        # Two groups so the spy must fire exactly twice.
+        group2 = MatchGroup(
+            name="DDR_DATA_BYTE_1",
+            net_ids=[1, 2, 3, 4],
+            tolerance=0.5,
+            reference_net_id=1,
+            source=MatchGroupSource.LEGACY_API,
+        )
+        detected = [group, group2]
+
+        call_count = {"n": 0}
+        real_tune = mgt_module.tune_match_group_v2
+
+        def spy(*args, **kwargs):
+            call_count["n"] += 1
+            return real_tune(*args, **kwargs)
+
+        with patch.object(mgt_module, "tune_match_group_v2", spy):
+            results = ar.apply_match_group_tuning(
+                detected_groups=detected,
+                verbose=False,
+            )
+
+        assert call_count["n"] == 2, (
+            f"Expected exactly 2 tune_match_group_v2 calls (one per detected "
+            f"group), got {call_count['n']}"
+        )
+        # Each group must appear in the result keyed by name (AC8 shape).
+        assert "DDR_DATA_BYTE_0" in results
+        assert "DDR_DATA_BYTE_1" in results
+
+    def test_returns_per_member_tune_results_keyed_by_net_id(self):
+        ar, group = _make_autorouter_with_4_net_group()
+        results = ar.apply_match_group_tuning(
+            detected_groups=[group],
+            verbose=False,
+        )
+
+        # Outer key = group name, inner key = net_id, value = (Route, TuneResult).
+        assert "DDR_DATA_BYTE_0" in results
+        per_member = results["DDR_DATA_BYTE_0"]
+        assert set(per_member.keys()) == {1, 2, 3, 4}
+        for net_id, (route, result) in per_member.items():
+            assert isinstance(route, Route)
+            assert isinstance(result, TuneResult)
+            assert route.net == net_id
+
+    def test_reference_net_returned_unchanged(self):
+        """The pace-car (reference net) is never modified; same Route reference."""
+        ar, group = _make_autorouter_with_4_net_group()
+        original_ref_route = ar.routes[0]  # net 1 is reference
+        original_ref_segments = original_ref_route.segments
+
+        results = ar.apply_match_group_tuning(
+            detected_groups=[group],
+            verbose=False,
+        )
+
+        ref_route, ref_result = results["DDR_DATA_BYTE_0"][1]
+        assert ref_result.reason == "reference"
+        # By-reference rollback contract.
+        assert ref_route is original_ref_route
+        assert ref_route.segments is original_ref_segments
+
+    def test_match_group_tracker_updated_with_post_tuning_lengths(self):
+        """The pre/post bracket: tracker reflects final geometry."""
+        ar, group = _make_autorouter_with_4_net_group()
+        ar.apply_match_group_tuning(
+            detected_groups=[group],
+            verbose=False,
+        )
+        # The tracker must have at least one length recorded for each
+        # member (it was updated both before and after the tuning loop).
+        for net_id in group.net_ids:
+            assert net_id in ar.match_group_tracker.lengths
+
+
+# =============================================================================
+# 2. AC6: pair-aware dispatch (Phase 2F symmetric serpentine path)
+# =============================================================================
+
+
+class TestPairAwareDispatch:
+    """A MatchGroup with ``pair_ids`` populated runs through the Phase 2F path.
+
+    The original Phase 2E entry guard at ``match_group_tuning.py`` was
+    ``assert not group.pair_ids`` which would raise ``AssertionError``
+    when pair_ids was non-empty.  Phase 2F (#2701, integrated by PR #2717)
+    replaced that guard with an internal dispatcher; this test asserts
+    the orchestrator does NOT trip the legacy guard and produces results
+    keyed on each half's net id.
+    """
+
+    def test_pair_aware_dispatch(self):
+        """A group with two diff-pair members reaches the symmetric path."""
+        ar = Autorouter(width=80.0, height=80.0)
+        # MIPI lane group: two pairs (LANE0_P/N, LANE1_P/N), no scalar
+        # members.  Reference net id is unset so the longest member's
+        # lane-length wins by the legacy default.
+        ar.net_names = {
+            10: "MIPI_DAT0_P",
+            11: "MIPI_DAT0_N",
+            20: "MIPI_DAT1_P",
+            21: "MIPI_DAT1_N",
+        }
+        ar.routes = [
+            _straight_route(10, "MIPI_DAT0_P", 18.0, y=0.0),
+            _straight_route(11, "MIPI_DAT0_N", 18.0, y=2.0),
+            _straight_route(20, "MIPI_DAT1_P", 14.0, y=10.0),
+            _straight_route(21, "MIPI_DAT1_N", 14.0, y=12.0),
+        ]
+        group = MatchGroup(
+            name="MIPI_LANES",
+            net_ids=[],
+            pair_ids=[(10, 11), (20, 21)],
+            tolerance=0.1,
+            reference_net_id=None,
+            source=MatchGroupSource.LEGACY_API,
+        )
+
+        # Must NOT raise AssertionError -- the historical Phase 2E guard
+        # would fire here; the Phase 2F dispatcher must take over.
+        results = ar.apply_match_group_tuning(
+            detected_groups=[group],
+            verbose=False,
+        )
+
+        assert "MIPI_LANES" in results
+        per_member = results["MIPI_LANES"]
+        # Both halves of both pairs should appear in the result.
+        assert set(per_member.keys()) == {10, 11, 20, 21}
+        # No member's reason should be the legacy entry-guard sentinel.
+        for net_id, (_route, result) in per_member.items():
+            assert result.reason != "AssertionError", (
+                f"net {net_id} reason={result.reason!r} -- the orchestrator "
+                "should never expose the legacy Phase 2E entry-guard reason"
+            )
+
+    def test_pair_aware_dispatch_passes_intra_pair_clearance(self):
+        """The orchestrator passes ``intra_pair_clearance_mm`` unconditionally.
+
+        Phase 2F (#2701) requires this kwarg when ``pair_ids`` is non-empty;
+        omitting it raises ``ValueError`` at the dispatcher.  This test
+        asserts the orchestrator never triggers that ValueError.
+        """
+        from kicad_tools.router import match_group_tuning as mgt_module
+
+        ar = Autorouter(width=80.0, height=80.0)
+        ar.net_names = {10: "P0", 11: "N0", 20: "P1", 21: "N1"}
+        ar.routes = [
+            _straight_route(10, "P0", 12.0, y=0.0),
+            _straight_route(11, "N0", 12.0, y=2.0),
+            _straight_route(20, "P1", 10.0, y=10.0),
+            _straight_route(21, "N1", 10.0, y=12.0),
+        ]
+        group = MatchGroup(
+            name="PAIR_GROUP",
+            net_ids=[],
+            pair_ids=[(10, 11), (20, 21)],
+            tolerance=0.1,
+            source=MatchGroupSource.LEGACY_API,
+        )
+
+        observed_kwargs: dict[str, object] = {}
+        real_tune = mgt_module.tune_match_group_v2
+
+        def spy(*args, **kwargs):
+            observed_kwargs.update(kwargs)
+            return real_tune(*args, **kwargs)
+
+        with patch.object(mgt_module, "tune_match_group_v2", spy):
+            ar.apply_match_group_tuning(
+                detected_groups=[group],
+                verbose=False,
+            )
+
+        assert "intra_pair_clearance_mm" in observed_kwargs, (
+            "apply_match_group_tuning must pass intra_pair_clearance_mm to "
+            "tune_match_group_v2 unconditionally; Phase 2F requires it."
+        )
+        # Default should fall through to rules.trace_clearance.
+        assert observed_kwargs["intra_pair_clearance_mm"] == ar.rules.trace_clearance
+
+
+# =============================================================================
+# 3. Cascade-budget exhaustion (graceful, no crash)
+# =============================================================================
+
+
+class TestCascadeBudgetExhaustion:
+    """A short-segment group cannot fit serpentines and exhausts the budget.
+
+    The exact reason returned depends on the per-member geometry: it may
+    be ``"no_suitable_segment"`` (segment too short for any amplitude) or
+    ``"exceeded_max_inserts"`` (budget burned without reaching tolerance).
+    Both are valid graceful failures.  The point is that the orchestrator
+    does NOT crash and returns a TuneResult for every member.
+    """
+
+    def test_no_crash_when_budget_exhausted(self):
+        ar = Autorouter(width=80.0, height=80.0)
+        # Three nets, very short routes -- no room for any serpentine.
+        # The reference is net 1 at 5mm; nets 2 and 3 are 0.5mm each --
+        # 4.5mm short of the reference, far more than any single bulge can
+        # add at the segment's tiny length.
+        ar.net_names = {1: "S0", 2: "S1", 3: "S2"}
+        ar.routes = [
+            _straight_route(1, "S0", 5.0, y=0.0),
+            _straight_route(2, "S1", 0.5, y=10.0),
+            _straight_route(3, "S2", 0.5, y=20.0),
+        ]
+        group = MatchGroup(
+            name="SHORT_BUS",
+            net_ids=[1, 2, 3],
+            tolerance=0.05,
+            reference_net_id=1,
+            source=MatchGroupSource.LEGACY_API,
+        )
+
+        results = ar.apply_match_group_tuning(
+            detected_groups=[group],
+            verbose=False,
+        )
+
+        # Every member must appear in the result.
+        per_member = results["SHORT_BUS"]
+        assert set(per_member.keys()) == {1, 2, 3}
+        # Net 1 is the reference, never tuned.
+        assert per_member[1][1].reason == "reference"
+        # Nets 2 & 3 are too short -- one of the graceful-failure reasons.
+        graceful_failure_reasons = {
+            "no_suitable_segment",
+            "exceeded_max_inserts",
+            "cascade_budget_exhausted",
+            "post_insertion_drc_violation",
+            "tuned",  # if the tuner happens to find a way
+            "already_within_tolerance",  # tolerance might be wide enough
+        }
+        for nid in (2, 3):
+            assert per_member[nid][1].reason in graceful_failure_reasons, (
+                f"net {nid} returned unexpected reason {per_member[nid][1].reason!r}"
+            )
+
+
+# =============================================================================
+# 4. AC8: signature drift-prevention
+# =============================================================================
+
+
+class TestSignatureDriftPrevention:
+    """The public method's signature is asserted byte-for-byte.
+
+    A future refactor that drops or renames a parameter, or changes the
+    return-type annotation, must update this test in the same commit so
+    the CLI consumer (``--length-match-groups``) cannot silently break.
+    """
+
+    def test_apply_match_group_tuning_signature(self):
+        sig = inspect.signature(Autorouter.apply_match_group_tuning)
+        param_names = [name for name in sig.parameters if name != "self"]
+        # AC8: parameter names asserted exactly.
+        assert param_names == ["detected_groups", "verbose"], (
+            f"apply_match_group_tuning signature drift: {param_names}"
+        )
+        # `verbose` must default to True (mirrors the diff-pair sibling).
+        assert sig.parameters["verbose"].default is True
+        # `detected_groups` is positional-or-keyword with no default.
+        assert sig.parameters["detected_groups"].default is inspect.Parameter.empty
+
+    def test_apply_match_group_tuning_returns_dict_of_dict_of_tuple(self):
+        """The return type at runtime is dict[str, dict[int, tuple[Route, TuneResult]]]."""
+        ar, group = _make_autorouter_with_4_net_group()
+        results = ar.apply_match_group_tuning(
+            detected_groups=[group],
+            verbose=False,
+        )
+
+        assert isinstance(results, dict)
+        # Outer key: group name (string).
+        for outer_key in results:
+            assert isinstance(outer_key, str)
+        # Inner: dict[int, tuple[Route, TuneResult]].
+        for outer_key, inner in results.items():
+            assert isinstance(inner, dict)
+            for inner_key, value in inner.items():
+                assert isinstance(inner_key, int)
+                assert isinstance(value, tuple)
+                assert len(value) == 2
+                route, result = value
+                assert isinstance(route, Route)
+                assert isinstance(result, TuneResult)
+
+
+# =============================================================================
+# 5. Net-class resolution helper
+# =============================================================================
+
+
+class TestResolveNetClassForGroup:
+    """``_resolve_net_class_for_group`` priority: ref-net > scalar > pair > None."""
+
+    def test_returns_none_when_no_class_map(self):
+        ar = Autorouter(width=10.0, height=10.0)
+        ar.net_class_map = {}  # type: ignore[assignment]
+        ar.net_names = {1: "FOO", 2: "BAR"}
+        group = MatchGroup(name="G", net_ids=[1, 2])
+        assert ar._resolve_net_class_for_group(group) is None
+
+    def test_returns_class_keyed_by_reference_net(self):
+        ar = Autorouter(width=10.0, height=10.0)
+        ar.net_names = {1: "FOO", 2: "BAR"}
+        nc = NetClassRouting(name="HIGH_SPEED", length_critical=True)
+        ar.net_class_map = {"BAR": nc}
+        group = MatchGroup(name="G", net_ids=[1, 2], reference_net_id=2)
+        # Reference net is BAR -- its class wins.
+        assert ar._resolve_net_class_for_group(group) is nc
+
+    def test_falls_back_to_scalar_member_when_no_reference(self):
+        ar = Autorouter(width=10.0, height=10.0)
+        ar.net_names = {1: "FOO", 2: "BAR"}
+        nc = NetClassRouting(name="HIGH_SPEED", length_critical=True)
+        ar.net_class_map = {"FOO": nc}
+        group = MatchGroup(name="G", net_ids=[1, 2], reference_net_id=None)
+        # First scalar member (FOO) wins.
+        assert ar._resolve_net_class_for_group(group) is nc
+
+    def test_falls_back_to_pair_member_when_no_scalar(self):
+        ar = Autorouter(width=10.0, height=10.0)
+        ar.net_names = {10: "P0", 11: "N0"}
+        nc = NetClassRouting(name="HIGH_SPEED", length_critical=True)
+        ar.net_class_map = {"P0": nc}
+        group = MatchGroup(name="G", net_ids=[], pair_ids=[(10, 11)])
+        # First pair's positive half (P0) wins.
+        assert ar._resolve_net_class_for_group(group) is nc
+
+    def test_returns_none_when_no_member_in_class_map(self):
+        ar = Autorouter(width=10.0, height=10.0)
+        ar.net_names = {1: "FOO", 2: "BAR"}
+        ar.net_class_map = {"OTHER": NetClassRouting(name="X")}
+        group = MatchGroup(name="G", net_ids=[1, 2])
+        assert ar._resolve_net_class_for_group(group) is None
+
+
+# =============================================================================
+# 6. Empty / edge-case inputs
+# =============================================================================
+
+
+class TestEdgeCases:
+    """Empty / edge-case inputs do not crash."""
+
+    def test_empty_detected_groups_returns_empty_dict(self):
+        ar = Autorouter(width=10.0, height=10.0)
+        ar.routes = []
+        results = ar.apply_match_group_tuning(detected_groups=[], verbose=False)
+        assert results == {}
+
+    def test_group_with_unrouted_member_does_not_crash(self):
+        ar = Autorouter(width=80.0, height=80.0)
+        ar.net_names = {1: "A", 2: "B", 3: "C"}
+        # Only nets 1 and 2 are routed; net 3 is in the group but unrouted.
+        ar.routes = [
+            _straight_route(1, "A", 10.0, y=0.0),
+            _straight_route(2, "B", 8.0, y=10.0),
+        ]
+        group = MatchGroup(
+            name="MIXED",
+            net_ids=[1, 2, 3],
+            tolerance=0.1,
+            reference_net_id=1,
+        )
+        # Must not raise.
+        results = ar.apply_match_group_tuning(
+            detected_groups=[group],
+            verbose=False,
+        )
+        assert "MIXED" in results
+        # Net 3 is unrouted -> reason="unrouted".
+        per_member = results["MIXED"]
+        assert per_member[3][1].reason == "unrouted"

--- a/tests/test_apply_match_group_tuning.py
+++ b/tests/test_apply_match_group_tuning.py
@@ -23,15 +23,12 @@ from __future__ import annotations
 import inspect
 from unittest.mock import patch
 
-import pytest
-
 from kicad_tools.router.core import Autorouter
 from kicad_tools.router.layers import Layer
 from kicad_tools.router.match_group_length import MatchGroup, MatchGroupSource
 from kicad_tools.router.match_group_tuning import TuneResult
 from kicad_tools.router.primitives import Route, Segment
 from kicad_tools.router.rules import NetClassRouting
-
 
 # =============================================================================
 # Test helpers

--- a/tests/test_apply_match_group_tuning_connectivity.py
+++ b/tests/test_apply_match_group_tuning_connectivity.py
@@ -110,8 +110,7 @@ def test_baseline_no_regression():
         ar, snapshot, phase="length_match_groups", strict=False, quiet=True
     )
     assert not result.regressed_nets, (
-        f"Baseline tuning should not regress connectivity, but got "
-        f"{result.regressed_nets}"
+        f"Baseline tuning should not regress connectivity, but got {result.regressed_nets}"
     )
 
 
@@ -119,14 +118,6 @@ def test_corrupted_route_triggers_invariant_strict_mode():
     """A corrupting tuner that drops segments mid-pad causes the
     connectivity invariant to raise in strict mode (AC7)."""
     ar = _make_4_net_routed_autorouter()
-    group = MatchGroup(
-        name="DDR_DATA_BYTE_0",
-        net_ids=[1, 2, 3, 4],
-        tolerance=0.1,
-        reference_net_id=1,
-        source=MatchGroupSource.LEGACY_API,
-    )
-
     snapshot = snapshot_connectivity(ar)
 
     # Mutate the routes directly to simulate a faulty tuner that breaks

--- a/tests/test_apply_match_group_tuning_connectivity.py
+++ b/tests/test_apply_match_group_tuning_connectivity.py
@@ -1,0 +1,204 @@
+"""Connectivity-invariant test for ``apply_match_group_tuning`` (AC7).
+
+Issue #2723.  This module verifies the AC7 contract: a deliberately-faulty
+serpentine insertion (e.g. monkey-patched to corrupt a route by dropping a
+segment between pads) causes
+:func:`_enforce_connectivity_invariant_or_exit` to flag the regression --
+mirroring the Phase 3I diff-pair pattern at ``route_cmd.py:5223``.
+
+The test intentionally constructs a corrupting tuner and asserts that the
+post-phase invariant detects the regression and either reverts the routes
+(default mode) OR raises :class:`ConnectivityRegressionError` (strict mode).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.router.connectivity_invariant import (
+    ConnectivityRegressionError,
+    enforce_connectivity_invariant,
+    snapshot_connectivity,
+)
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.match_group_length import MatchGroup, MatchGroupSource
+from kicad_tools.router.primitives import Pad, Route, Segment
+
+
+def _pad(x: float, y: float, ref: str, net: int, net_name: str) -> Pad:
+    return Pad(
+        x=x,
+        y=y,
+        width=0.5,
+        height=0.5,
+        net=net,
+        net_name=net_name,
+        layer=Layer.F_CU,
+        ref=ref,
+        pin="1",
+    )
+
+
+def _two_pad_route(net: int, name: str, x1: float, y: float, x2: float) -> Route:
+    return Route(
+        net=net,
+        net_name=name,
+        segments=[
+            Segment(
+                x1=x1,
+                y1=y,
+                x2=x2,
+                y2=y,
+                width=0.2,
+                layer=Layer.F_CU,
+                net=net,
+                net_name=name,
+            )
+        ],
+    )
+
+
+def _make_4_net_routed_autorouter() -> Autorouter:
+    """An autorouter with 4 nets, each a 2-pad straight-segment net.
+
+    All 4 nets are multi-pad so the connectivity snapshot tracks them.
+    Lengths: net 1 = 22mm, net 2 = 20mm, net 3 = 18mm, net 4 = 18mm.
+    """
+    ar = Autorouter(width=80.0, height=80.0)
+    ar.net_names = {1: "DQ0", 2: "DQ1", 3: "DQ2", 4: "DQ3"}
+
+    # Pads: each net has two pads at the segment endpoints.
+    ar.pads = {}
+    ar.nets = {1: [], 2: [], 3: [], 4: []}
+    layout = [
+        (1, "DQ0", 0.0, 22.0, 0.0),
+        (2, "DQ1", 0.0, 20.0, 10.0),
+        (3, "DQ2", 0.0, 18.0, 20.0),
+        (4, "DQ3", 0.0, 18.0, 30.0),
+    ]
+    for nid, name, x1, x2, y in layout:
+        pad_a_key = (f"R{nid}", "1")
+        pad_b_key = (f"R{nid}", "2")
+        ar.pads[pad_a_key] = _pad(x1, y, f"R{nid}", nid, name)
+        ar.pads[pad_b_key] = _pad(x2, y, f"R{nid}", nid, name)
+        ar.nets[nid] = [pad_a_key, pad_b_key]
+
+    ar.routes = [
+        _two_pad_route(1, "DQ0", 0.0, 0.0, 22.0),
+        _two_pad_route(2, "DQ1", 0.0, 10.0, 20.0),
+        _two_pad_route(3, "DQ2", 0.0, 20.0, 18.0),
+        _two_pad_route(4, "DQ3", 0.0, 30.0, 18.0),
+    ]
+    return ar
+
+
+def test_baseline_no_regression():
+    """Sanity: tuning the well-formed group does NOT flag connectivity loss."""
+    ar = _make_4_net_routed_autorouter()
+    group = MatchGroup(
+        name="DDR_DATA_BYTE_0",
+        net_ids=[1, 2, 3, 4],
+        tolerance=0.1,
+        reference_net_id=1,
+        source=MatchGroupSource.LEGACY_API,
+    )
+
+    snapshot = snapshot_connectivity(ar)
+    ar.apply_match_group_tuning(detected_groups=[group], verbose=False)
+    result = enforce_connectivity_invariant(
+        ar, snapshot, phase="length_match_groups", strict=False, quiet=True
+    )
+    assert not result.regressed_nets, (
+        f"Baseline tuning should not regress connectivity, but got "
+        f"{result.regressed_nets}"
+    )
+
+
+def test_corrupted_route_triggers_invariant_strict_mode():
+    """A corrupting tuner that drops segments mid-pad causes the
+    connectivity invariant to raise in strict mode (AC7)."""
+    ar = _make_4_net_routed_autorouter()
+    group = MatchGroup(
+        name="DDR_DATA_BYTE_0",
+        net_ids=[1, 2, 3, 4],
+        tolerance=0.1,
+        reference_net_id=1,
+        source=MatchGroupSource.LEGACY_API,
+    )
+
+    snapshot = snapshot_connectivity(ar)
+
+    # Mutate the routes directly to simulate a faulty tuner that breaks
+    # the pad-to-pad chain.  We replace net 2's single segment with a
+    # half-segment that no longer touches the second pad.  This is the
+    # "deliberately-faulty serpentine insertion" hostile fixture
+    # described in AC7 -- equivalent to a corrupting monkey-patch on
+    # tune_match_group_v2.
+    for i, r in enumerate(ar.routes):
+        if r.net == 2:
+            ar.routes[i] = Route(
+                net=2,
+                net_name="DQ1",
+                segments=[
+                    Segment(
+                        x1=0.0,
+                        y1=10.0,
+                        x2=5.0,  # was 20.0 -- now ends mid-air
+                        y2=10.0,
+                        width=0.2,
+                        layer=Layer.F_CU,
+                        net=2,
+                        net_name="DQ1",
+                    )
+                ],
+            )
+            break
+
+    with pytest.raises(ConnectivityRegressionError):
+        enforce_connectivity_invariant(
+            ar, snapshot, phase="length_match_groups", strict=True, quiet=True
+        )
+
+
+def test_corrupted_route_reverts_in_default_mode():
+    """A corrupting tuner is detected and the regressed net is reverted
+    in default (non-strict) mode."""
+    ar = _make_4_net_routed_autorouter()
+    snapshot = snapshot_connectivity(ar)
+
+    # Same hostile mutation as the strict test.
+    for i, r in enumerate(ar.routes):
+        if r.net == 2:
+            ar.routes[i] = Route(
+                net=2,
+                net_name="DQ1",
+                segments=[
+                    Segment(
+                        x1=0.0,
+                        y1=10.0,
+                        x2=5.0,
+                        y2=10.0,
+                        width=0.2,
+                        layer=Layer.F_CU,
+                        net=2,
+                        net_name="DQ1",
+                    )
+                ],
+            )
+            break
+
+    result = enforce_connectivity_invariant(
+        ar, snapshot, phase="length_match_groups", strict=False, quiet=True
+    )
+    assert 2 in result.regressed_nets, (
+        "Net 2 was deliberately broken; it should appear in regressed_nets"
+    )
+    # After revert, net 2's route should once again span both pads.
+    net_2_routes = [r for r in ar.routes if r.net == 2]
+    assert len(net_2_routes) == 1
+    seg = net_2_routes[0].segments[0]
+    # Pad at x=20.0 must be on the segment.
+    assert seg.x2 == 20.0 or seg.x1 == 20.0, (
+        f"Net 2 was not reverted; segment endpoints {seg.x1},{seg.x2}"
+    )

--- a/tests/test_cli_route_match_groups.py
+++ b/tests/test_cli_route_match_groups.py
@@ -26,7 +26,6 @@ from io import StringIO
 from types import SimpleNamespace
 from unittest.mock import patch
 
-
 # =============================================================================
 # AC2 + AC3: CLI flag is defined in both parsers
 # =============================================================================
@@ -58,9 +57,7 @@ class TestFlagDefinedInBothParsers:
         from kicad_tools.cli.parser import create_parser
 
         parser = create_parser()
-        args = parser.parse_args(
-            ["route", "test.kicad_pcb", "--length-match-groups"]
-        )
+        args = parser.parse_args(["route", "test.kicad_pcb", "--length-match-groups"])
         assert args.length_match_groups is True
 
     def test_length_match_groups_default_false(self):
@@ -79,44 +76,44 @@ class TestFlagDefinedInBothParsers:
 
 def _base_args(**overrides) -> SimpleNamespace:
     """Build a minimal args namespace mirroring run_route_command's needs."""
-    base = dict(
-        pcb="test.kicad_pcb",
-        output=None,
-        strategy="negotiated",
-        skip_nets=None,
-        grid="auto",
-        trace_width=0.2,
-        clearance=0.15,
-        via_drill=0.3,
-        via_diameter=0.6,
-        mc_trials=10,
-        iterations=15,
-        verbose=False,
-        dry_run=True,
-        quiet=True,
-        power_nets=None,
-        layers="auto",
-        force=False,
-        no_optimize=False,
-        auto_layers=False,
-        max_layers=6,
-        min_completion=0.95,
-        adaptive_rules=False,
-        min_trace=None,
-        min_clearance_floor=None,
-        manufacturer="jlcpcb",
-        high_performance=False,
-        skip_drc=False,
-        auto_fix=False,
-        auto_fix_passes=None,
-        export_failed_nets=None,
-        differential_pairs=False,
-        diffpair_spacing=None,
-        diffpair_max_delta=None,
-        length_match_diffpairs=False,
-        length_match_groups=False,
-        strict=False,
-    )
+    base: dict[str, object] = {
+        "pcb": "test.kicad_pcb",
+        "output": None,
+        "strategy": "negotiated",
+        "skip_nets": None,
+        "grid": "auto",
+        "trace_width": 0.2,
+        "clearance": 0.15,
+        "via_drill": 0.3,
+        "via_diameter": 0.6,
+        "mc_trials": 10,
+        "iterations": 15,
+        "verbose": False,
+        "dry_run": True,
+        "quiet": True,
+        "power_nets": None,
+        "layers": "auto",
+        "force": False,
+        "no_optimize": False,
+        "auto_layers": False,
+        "max_layers": 6,
+        "min_completion": 0.95,
+        "adaptive_rules": False,
+        "min_trace": None,
+        "min_clearance_floor": None,
+        "manufacturer": "jlcpcb",
+        "high_performance": False,
+        "skip_drc": False,
+        "auto_fix": False,
+        "auto_fix_passes": None,
+        "export_failed_nets": None,
+        "differential_pairs": False,
+        "diffpair_spacing": None,
+        "diffpair_max_delta": None,
+        "length_match_diffpairs": False,
+        "length_match_groups": False,
+        "strict": False,
+    }
     base.update(overrides)
     return SimpleNamespace(**base)
 
@@ -255,9 +252,7 @@ class TestBackwardCompat:
 
         src = inspect.getsource(route_cmd)
         # The gate must be present and exact.
-        assert (
-            'getattr(args, "length_match_groups", False)' in src
-        ), (
+        assert 'getattr(args, "length_match_groups", False)' in src, (
             "route_cmd.py must gate the match-group tuning dispatch on "
             "args.length_match_groups (AC1)."
         )

--- a/tests/test_cli_route_match_groups.py
+++ b/tests/test_cli_route_match_groups.py
@@ -1,0 +1,263 @@
+"""Tests for the ``--length-match-groups`` CLI flag (Epic #2661 Phase 3H).
+
+Issue #2723.  This module covers the CLI surface around
+:meth:`Autorouter.apply_match_group_tuning`:
+
+- **AC2**: ``kct route --help`` lists ``--length-match-groups`` with a
+  docstring referencing Epic #2661 Phase 3.
+- **AC3**: The flag is defined in BOTH the standalone ``route_cmd.py``
+  parser AND the unified ``cli/parser.py`` route subcommand.
+- **AC4**: When no groups are detected the CLI does NOT crash -- the
+  graceful short-circuit is exercised inline (the actual end-to-end
+  invocation lives in unit tests for :meth:`apply_match_group_tuning`
+  to keep the CI matrix fast).
+- **AC5 ordering**: ``run_route_command`` forwards the flag AFTER
+  ``--length-match-diffpairs`` so ordering is preserved end-to-end.
+- **Forwarding**: ``run_route_command`` forwards / does NOT forward the
+  flag based on the args namespace value (mirrors the
+  ``--length-match-diffpairs`` plumbing).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+from io import StringIO
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+# =============================================================================
+# AC2 + AC3: CLI flag is defined in both parsers
+# =============================================================================
+
+
+class TestFlagDefinedInBothParsers:
+    """The flag must appear in both the standalone and unified parsers."""
+
+    def test_length_match_groups_in_route_cmd_help(self):
+        """``route_cmd.main(['--help'])`` lists ``--length-match-groups``."""
+        from kicad_tools.cli.route_cmd import main as route_main
+
+        help_output = StringIO()
+        with patch.object(sys, "stdout", help_output):
+            with contextlib.suppress(SystemExit):
+                route_main(["--help"])
+
+        help_text = help_output.getvalue()
+        assert "--length-match-groups" in help_text
+        # AC2: docstring must reference Epic #2661 Phase 3.
+        # argparse wraps long help text across lines, so collapse whitespace
+        # before searching for the documented strings.
+        collapsed = " ".join(help_text.split())
+        assert "Epic #2661" in collapsed
+        assert "Phase 3H" in collapsed
+
+    def test_length_match_groups_in_unified_parser(self):
+        """``kct route --length-match-groups`` is parseable via the unified parser."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(
+            ["route", "test.kicad_pcb", "--length-match-groups"]
+        )
+        assert args.length_match_groups is True
+
+    def test_length_match_groups_default_false(self):
+        """When omitted, ``length_match_groups`` defaults to False."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["route", "test.kicad_pcb"])
+        assert args.length_match_groups is False
+
+
+# =============================================================================
+# Forwarding: run_route_command -> route_cmd.main
+# =============================================================================
+
+
+def _base_args(**overrides) -> SimpleNamespace:
+    """Build a minimal args namespace mirroring run_route_command's needs."""
+    base = dict(
+        pcb="test.kicad_pcb",
+        output=None,
+        strategy="negotiated",
+        skip_nets=None,
+        grid="auto",
+        trace_width=0.2,
+        clearance=0.15,
+        via_drill=0.3,
+        via_diameter=0.6,
+        mc_trials=10,
+        iterations=15,
+        verbose=False,
+        dry_run=True,
+        quiet=True,
+        power_nets=None,
+        layers="auto",
+        force=False,
+        no_optimize=False,
+        auto_layers=False,
+        max_layers=6,
+        min_completion=0.95,
+        adaptive_rules=False,
+        min_trace=None,
+        min_clearance_floor=None,
+        manufacturer="jlcpcb",
+        high_performance=False,
+        skip_drc=False,
+        auto_fix=False,
+        auto_fix_passes=None,
+        export_failed_nets=None,
+        differential_pairs=False,
+        diffpair_spacing=None,
+        diffpair_max_delta=None,
+        length_match_diffpairs=False,
+        length_match_groups=False,
+        strict=False,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class TestForwarding:
+    """``run_route_command`` forwards the new flag when set, omits it otherwise."""
+
+    def test_length_match_groups_forwarded_when_true(self):
+        from kicad_tools.cli.commands.routing import run_route_command
+
+        args = _base_args(length_match_groups=True)
+        with patch("kicad_tools.cli.route_cmd.main") as mock_main:
+            mock_main.return_value = 0
+            run_route_command(args)
+            call_args = mock_main.call_args[0][0]
+            assert "--length-match-groups" in call_args
+
+    def test_length_match_groups_not_forwarded_when_false(self):
+        from kicad_tools.cli.commands.routing import run_route_command
+
+        args = _base_args(length_match_groups=False)
+        with patch("kicad_tools.cli.route_cmd.main") as mock_main:
+            mock_main.return_value = 0
+            run_route_command(args)
+            call_args = mock_main.call_args[0][0]
+            assert "--length-match-groups" not in call_args
+
+    def test_compatible_with_length_match_diffpairs(self):
+        """Both flags can be set together; both are forwarded."""
+        from kicad_tools.cli.commands.routing import run_route_command
+
+        args = _base_args(
+            differential_pairs=True,
+            length_match_diffpairs=True,
+            length_match_groups=True,
+        )
+        with patch("kicad_tools.cli.route_cmd.main") as mock_main:
+            mock_main.return_value = 0
+            run_route_command(args)
+            call_args = mock_main.call_args[0][0]
+            assert "--length-match-diffpairs" in call_args
+            assert "--length-match-groups" in call_args
+
+    def test_forwarding_preserves_ordering(self):
+        """AC5: ``--length-match-groups`` is forwarded AFTER
+        ``--length-match-diffpairs`` so the post-routing dispatch in
+        route_cmd.py runs pair tuning first, group tuning second."""
+        from kicad_tools.cli.commands.routing import run_route_command
+
+        args = _base_args(
+            differential_pairs=True,
+            length_match_diffpairs=True,
+            length_match_groups=True,
+        )
+        with patch("kicad_tools.cli.route_cmd.main") as mock_main:
+            mock_main.return_value = 0
+            run_route_command(args)
+            call_args = mock_main.call_args[0][0]
+            pair_idx = call_args.index("--length-match-diffpairs")
+            group_idx = call_args.index("--length-match-groups")
+            # The forwarder appends groups AFTER diffpairs; the route_cmd
+            # post-routing dispatch then runs them in the order they appear.
+            assert pair_idx < group_idx, (
+                "Forwarding order must place --length-match-diffpairs before "
+                "--length-match-groups so pair tuning runs first (preserves "
+                "the within-pair skew invariant before group tuning perturbs "
+                "lane lengths)."
+            )
+
+
+# =============================================================================
+# AC4: graceful no-op when no groups are detected
+# =============================================================================
+
+
+class TestGracefulNoOp:
+    """When no groups are detected the CLI must not crash."""
+
+    def test_no_groups_path_handled_in_route_cmd(self):
+        """The route_cmd post-routing block has the explicit
+        ``if not detected_groups`` short-circuit so a synthetic-test board
+        with no declared groups exits cleanly with no tuning attempted.
+
+        Read the source directly -- a unit-test against the live CLI
+        would have to spin up an Autorouter with a routed board, which
+        is out of scope for this fast CI-friendly test.
+        """
+        import inspect
+
+        from kicad_tools.cli import route_cmd
+
+        src = inspect.getsource(route_cmd)
+        # The literal short-circuit string is the contract.  Drift here
+        # means the AC4 graceful-no-op contract is broken silently.
+        assert "No match groups detected; nothing to tune." in src, (
+            "route_cmd.py must emit a graceful 'no groups detected' "
+            "message when detect_match_groups returns empty (AC4)."
+        )
+
+    def test_phase_label_matches_connectivity_invariant(self):
+        """The connectivity invariant phase label is ``length_match_groups``."""
+        import inspect
+
+        from kicad_tools.cli import route_cmd
+
+        src = inspect.getsource(route_cmd)
+        # The phase label is consumed by _enforce_connectivity_invariant_or_exit
+        # and surfaced to users on regression.  AC7 depends on it being
+        # consistent with the diff-pair sibling's ``length_match_diffpairs``.
+        assert 'phase="length_match_groups"' in src, (
+            "route_cmd.py must use phase='length_match_groups' for the "
+            "connectivity invariant call (AC7)."
+        )
+
+
+# =============================================================================
+# AC1: Without the flag, no tuning runs (preserves backward compat)
+# =============================================================================
+
+
+class TestBackwardCompat:
+    """Without ``--length-match-groups``, ``apply_match_group_tuning`` is
+    NOT invoked (AC1).
+    """
+
+    def test_apply_match_group_tuning_not_invoked_when_flag_absent(self):
+        """The route_cmd dispatch is gated on
+        ``getattr(args, 'length_match_groups', False)``.  This test asserts
+        the gate exists by reading the source -- the same pattern as the
+        diff-pair sibling at AC1.  A live test would require a routed
+        board, out of scope here.
+        """
+        import inspect
+
+        from kicad_tools.cli import route_cmd
+
+        src = inspect.getsource(route_cmd)
+        # The gate must be present and exact.
+        assert (
+            'getattr(args, "length_match_groups", False)' in src
+        ), (
+            "route_cmd.py must gate the match-group tuning dispatch on "
+            "args.length_match_groups (AC1)."
+        )


### PR DESCRIPTION
## Summary

Wires the N-trace match-group serpentine tuner (Phase 2E + Phase 2F) into the public CLI surface. Mirrors the diff-pair sibling at PR #2663 byte-for-byte: a single new `Autorouter.apply_match_group_tuning` orchestrator method, a single new `--length-match-groups` CLI flag (in both `route_cmd.py` and `cli/parser.py`), a forwarder line in `cli/commands/routing.py`, and the connectivity-invariant bracket around the post-routing dispatch.

The Phase 2F dispatch is fully transparent: the orchestrator passes `intra_pair_clearance_mm` unconditionally to `tune_match_group_v2`; the dispatcher inside `tune_match_group_v2` selects between `_tune_match_group_single_ended` and `_tune_match_group_of_pairs` based on `MatchGroup.pair_ids` (per the curator note on issue #2723).

## Changes

- **`src/kicad_tools/router/core.py`** -- new `Autorouter.apply_match_group_tuning(detected_groups, verbose) -> dict[str, dict[int, tuple[Route, TuneResult]]]` method (sibling to `apply_diffpair_length_tuning`). New `_resolve_net_class_for_group` helper that prefers the explicit reference net, then scalar members, then pair members. Pre/post `_match_group_tracker.record_routes` bracket. Per-pair commit-back loop. Defensive try/except on `ValueError` so a malformed group cannot break the run.
- **`src/kicad_tools/cli/route_cmd.py`** -- new `--length-match-groups` flag definition + post-routing dispatch block at `~5252`. Runs AFTER `--length-match-diffpairs` (AC5 ordering). `_connectivity_snapshot` + `_enforce_connectivity_invariant_or_exit` bracket. Graceful no-op when `detect_match_groups` returns empty.
- **`src/kicad_tools/cli/parser.py`** -- adds the same flag to the unified `kct route` subcommand.
- **`src/kicad_tools/cli/commands/routing.py`** -- forwards the flag from the unified parser to `route_cmd.main` (after `--length-match-diffpairs`, preserving order).
- **`tests/test_apply_match_group_tuning.py`** (new, 16 tests) -- triple-gate, pair-aware dispatch (AC6), cascade-budget exhaustion, signature drift-prevention (AC8), `_resolve_net_class_for_group` priority, edge cases.
- **`tests/test_apply_match_group_tuning_connectivity.py`** (new, 3 tests) -- AC7 hostile-fixture connectivity invariant test (baseline + strict-mode raise + default-mode revert).
- **`tests/test_cli_route_match_groups.py`** (new, 10 tests) -- AC2 / AC3 / AC4 / AC5 / forwarding / backward compat.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| AC1: without flag, no tuning runs | passed | `test_apply_match_group_tuning_not_invoked_when_flag_absent` asserts the dispatch is gated on `getattr(args, 'length_match_groups', False)` |
| AC2: `--help` lists the flag, references Epic #2661 Phase 3 | passed | `test_length_match_groups_in_route_cmd_help` collapses argparse line-wrap and asserts both `Epic #2661` and `Phase 3H` present |
| AC3: synthetic 4-net group declared via `length_match_group` runs tuning | covered | `test_orchestrator_invokes_tuner_for_each_group` (spy confirms 1 call per group); end-to-end CLI smoke deferred to Phase 3L test board (per issue scope) |
| AC4: graceful "no groups detected" message | passed | `test_no_groups_path_handled_in_route_cmd` asserts the literal short-circuit string is in source |
| AC5: combined with `--length-match-diffpairs`, pair tuning runs first | passed | `test_forwarding_preserves_ordering` asserts `pair_idx < group_idx` in forwarded argv |
| AC6: pair-aware dispatch (Phase 2F symmetric path) | passed | `test_pair_aware_dispatch` constructs `MatchGroup` with `pair_ids=[(10,11),(20,21)]`, asserts no `AssertionError` and all 4 halves appear in result |
| AC7: connectivity-invariant catches faulty insertion | passed | `test_corrupted_route_triggers_invariant_strict_mode` raises `ConnectivityRegressionError`; `test_corrupted_route_reverts_in_default_mode` reverts the regressed net |
| AC8: signature drift-prevention | passed | `test_apply_match_group_tuning_signature` asserts param names `['detected_groups', 'verbose']` exactly + return type at runtime is `dict[str, dict[int, tuple[Route, TuneResult]]]` |

## Curator note overrides honored

Per the curator comment on #2723 (verified against `origin/main` at `bf4d05c5`):

1. **Phase 2F dispatch is implicit** -- no `tune_match_pair_group_v2` symbol exists; the dispatcher inside `tune_match_group_v2` selects `_tune_match_group_single_ended` vs `_tune_match_group_of_pairs` based on `pair_ids`. The orchestrator does NOT switch on `pair_ids`; it passes the `MatchGroup` through unchanged.
2. **Return type is `dict[str, dict[int, tuple[Route, TuneResult]]]`** -- not the issue body's `TuneResultGroup` (which does not exist). Per-member type is `TuneResult` at `match_group_tuning.py:184`.
3. **`intra_pair_clearance_mm` passed unconditionally** -- required by Phase 2F when `pair_ids` is non-empty; ignored on the single-ended path. Verified by `test_pair_aware_dispatch_passes_intra_pair_clearance` (spy confirms the kwarg is in every call).

## Test Plan

```bash
# All 29 new tests pass:
uv run pytest tests/test_apply_match_group_tuning.py tests/test_apply_match_group_tuning_connectivity.py tests/test_cli_route_match_groups.py -q
# 29 passed in 99.52s

# CLI flag visible in --help:
uv run kct route --help | grep length-match
#   --length-match-diffpairs ... --length-match-groups ...

# Sibling tests still green (no regressions from this PR):
uv run pytest tests/test_match_group_tuning.py tests/test_match_group_detection.py -q
# 92 passed
uv run pytest tests/test_route_cmd_params.py tests/test_partial_routing_features.py -q
# 74 passed

# Lint clean:
uv run ruff check tests/test_apply_match_group_tuning*.py tests/test_cli_route_match_groups.py src/kicad_tools/cli/parser.py src/kicad_tools/cli/commands/routing.py
# All checks passed!
```

## Out of scope (explicitly per issue body)

- `tune_match_group_v2` itself is not modified (Phase 2E/2F semantics are stable).
- No new detection sources -- consumes the existing `detect_match_groups` API from Phase 1C.
- Legacy `tune_match_group` at `optimizer/serpentine.py:484` left untouched.
- Phase 3L test board (#TBD) is the consumer of this CLI flag, not a precondition.
- Documentation deferred to Phase 3M (#TBD).

Closes #2723