### PR TITLE
feat(ci): add matchgroup-routing-regression sibling job for board 07

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,3 +403,103 @@ jobs:
             "${{ matrix.board }}" \
             --seed 42
 
+  matchgroup-routing-regression:
+    # Issue #2726 / Epic #2661 Phase 3N: re-route board 07 (the
+    # N-trace match-group testbench, #2724 Phase 3L) from scratch on
+    # every PR and verify that
+    #   (a) the resulting DRC error count is within the allowlist baseline
+    #       in .github/routed-drc-tolerance.yml; AND
+    #   (b) the match_group_length_skew DRC rule (#2702, Phase 2G; producer
+    #       wiring #2710 Phase 2.5G) was actually exercised against a
+    #       declared group -- i.e., the per-rule counter in the DRC
+    #       summary is non-zero for rule_id "match_group_length_skew".
+    #
+    # This job is a SIBLING to diffpair-routing-regression (board 06),
+    # not a matrix-extension.  Per the issue #2726 curator decision
+    # (2026-05-11), sibling structure was chosen because:
+    #
+    #   1. Minimal blast radius -- a match-group regression PR cannot
+    #      accidentally break the diff-pair gate and vice versa.
+    #   2. The diff-pair coverage script's DIFFPAIR_RULE_IDS tuple is
+    #      hardcoded to three rule_ids; the match-group gate asserts a
+    #      different (currently single) rule_id.  A dedicated script
+    #      (check_matchgroup_coverage.py) is cleaner than parametrising
+    #      check_diffpair_coverage.py with a --rules flag.
+    #   3. Per-job timeout budgets are independent (each gets a fresh
+    #      10-min ceiling -- matrix-extension would share the budget).
+    #   4. The existing job name "Diff-Pair Routing Regression" is a
+    #      branch-protection check name; renaming requires repo-admin
+    #      action.  A sibling job is purely additive to branch protection.
+    #
+    # This job is the algorithmic-regression counterpart to the
+    # routed-pcb-drc-check job above for the match-group rule, mirroring
+    # what diffpair-routing-regression does for the diff-pair rules.
+    #
+    # Determinism: the gate uses `--seed 42` (Issue #2589 / Phase 3X.2)
+    # forwarded into `generate_design.py --seed` so the re-route is
+    # reproducible.  Without `--seed` the router uses os.urandom-derived
+    # entropy and produces different output run-to-run, which would
+    # generate false-positive failures on a loaded CI runner.
+    #
+    # Sidecar: check_matchgroup_coverage.py threads the board's
+    # output/net_class_map.json (emitted by generate_design.write_sidecar
+    # in Phase 3L scaffolding) into `kct check --net-class-map` per the
+    # #2692 pattern.  Without the sidecar the match_group_length_skew
+    # rule degrades to a no-op and the assertion-of-engagement check
+    # would fail with "rule not exercised".
+    #
+    # Allowlist:
+    #   .github/routed-drc-tolerance.yml currently has
+    #   boards/07-matchgroup-test/.../matchgroup_test_routed.kicad_pcb: 80
+    #   (55x impedance per #2672 + 4x diffpair_length_skew + 4x
+    #   diffpair_routing_continuity + 1x match_group_length_skew, with
+    #   ~25% headroom over the empirical 64).  The gate respects the
+    #   allowlist so it doesn't fail immediately; the floor will tighten
+    #   iteratively as match-group tuning (Phase 3H #2723) lands and
+    #   reduces skew.
+    #
+    # IMPORTANT (branch-protection note): adding this job to the list of
+    # *required* status checks on `main` is a separate repo-admin action.
+    # The PR landing this job calls that out explicitly so the human
+    # approver can flip the GitHub setting after merge.  Until then the
+    # job runs on every PR but is advisory -- its failure does not block
+    # the merge button.
+    name: Match-Group Routing Regression
+    runs-on: ubuntu-latest
+    # Issue #2660 acceptance criterion #5 (mirrored for #2726): wall-clock
+    # <= 5 min on ubuntu-latest.  The 10-minute limit here is a safety
+    # net for slow runners; if the typical run creeps above 5 minutes,
+    # move to a nightly schedule per the epic's runtime guidance.
+    timeout-minutes: 10
+    strategy:
+      # Don't abort the matrix on a single board failure -- each board
+      # is independent and reviewers want all annotations at once.
+      fail-fast: false
+      matrix:
+        board:
+          - boards/07-matchgroup-test
+        # Future: additional N-trace testbenches (e.g., a board with
+        # only the cascade-budget edge case, or a board exercising
+        # length_match_reference=pace-car semantics) can be added
+        # cheaply once they exist.
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Re-route board + check match-group coverage
+        run: |
+          set -euo pipefail
+          uv run python scripts/ci/check_matchgroup_coverage.py \
+            "${{ matrix.board }}" \
+            --seed 42
+

--- a/boards/07-matchgroup-test/README.md
+++ b/boards/07-matchgroup-test/README.md
@@ -159,14 +159,61 @@ replaced with the actual call.
 
 ## CI Gate (Phase 3N, #2726)
 
-This board is consumed by the **Phase 3N CI gate** (issue #2726)
-which will be wired into `.github/workflows/ci.yml` once both this
-board scaffold and Phase 3H (#2723) land.  The gate's contract
-mirrors the diffpair-routing-regression job (board 06):
+This board is consumed by the **Phase 3N CI gate** (issue #2726),
+which lives at `.github/workflows/ci.yml::matchgroup-routing-regression`.
+The gate is a sibling of the `diffpair-routing-regression` job (board
+06) and runs on every PR to `main`.  Contract:
 
-1. Re-routes from scratch on every PR with `--seed 42`.
-2. Asserts DRC error count within the per-board allowlist.
-3. Asserts each match-group DRC rule_id was actually exercised.
+1. Re-routes board 07 from scratch with
+   `python boards/07-matchgroup-test/generate_design.py --step route --seed 42`.
+2. Asserts the resulting DRC error count is within the per-board
+   allowlist in `.github/routed-drc-tolerance.yml` (currently 80).
+3. Asserts the `match_group_length_skew` DRC rule was actually
+   exercised --- i.e., `rules_checked_by_rule["match_group_length_skew"] >= 1`
+   in the `DRCChecker` summary.  Without this assertion a regression
+   that disables match-group detection (e.g., a future change that
+   breaks `derive_group_skew_data` or unwires `length_match_group`
+   from the net classes) would silently produce a 0-violation report
+   and hide the defect.
+
+### Interpreting a failure
+
+- **`Match-group rule(s) NOT exercised`** -- the rule short-circuited
+  because no declared groups were detected with measurable skew.
+  Likely causes: `length_match_group` field unwired from one or more
+  net classes in `build_net_class_map`, `derive_group_skew_data`
+  broken (e.g., `detect_match_groups` returning empty), or the
+  routed PCB has no traces matching any declared group's members.
+  See `src/kicad_tools/validate/match_group_skew.py` and
+  `src/kicad_tools/validate/rules/match_group_length_skew.py` for
+  the engagement conditions.
+- **`DRC regression on re-routed ...`** -- the routing algorithm
+  produced more errors than the allowlist value.  Fix the router
+  regression OR (with reviewer sign-off) raise the allowlist value
+  in the same PR.
+- **Job times out (> 10 min)** -- routing wall-clock crept above
+  the budget.  File a follow-up to move the gate to a nightly
+  schedule per Epic #2661's runtime guidance.
+
+### Reproducing the gate locally
+
+```bash
+# Full re-route + check (CI semantic, ~30-90s on a developer laptop)
+python scripts/ci/check_matchgroup_coverage.py boards/07-matchgroup-test --seed 42
+
+# Fast iteration against the committed routed PCB (skips the route step)
+python scripts/ci/check_matchgroup_coverage.py boards/07-matchgroup-test \
+  --seed 42 --skip-route
+```
+
+### Branch-protection (admin action required post-merge)
+
+Per the precedent set by `diffpair-routing-regression` (PR #2679),
+adding `Match-Group Routing Regression` to the list of *required*
+status checks on `main` is a separate repo-admin action in GitHub
+Settings -> Rules -> Rulesets.  Until that flip happens the job
+runs on every PR but is advisory --- its failure does not block
+the merge button.
 
 ## Out of Scope
 

--- a/scripts/ci/check_matchgroup_coverage.py
+++ b/scripts/ci/check_matchgroup_coverage.py
@@ -1,0 +1,636 @@
+#!/usr/bin/env python3
+"""Match-group "rule exercised" CI gate (Issue #2726, Epic #2661 Phase 3N).
+
+This script is the match-group sibling of
+:mod:`scripts.ci.check_diffpair_coverage` (Issue #2660, Epic #2556 Phase
+4N).  It catches regressions in the **match-group routing + DRC
+algorithm itself** by re-routing a board from scratch and asserting:
+
+  1. The post-route DRC error count is within the per-board allowlist
+     (same semantic as ``check_routed_drc.py`` / ``check_diffpair_coverage.py``).
+  2. The ``match_group_length_skew`` DRC rule was actually exercised by
+     the check (i.e., its per-rule counter is >= 1).  Without this
+     assertion a regression that disables match-group detection (e.g.,
+     a future change that breaks ``derive_group_skew_data`` or unwires
+     ``length_match_group`` from the net classes) would silently produce
+     a 0-error report and hide the defect.
+
+Rule id asserted:
+
+  * ``match_group_length_skew`` (Issue #2702, Epic #2661 Phase 2G;
+    producer wiring #2710 Phase 2.5G).
+
+The script is parametric over the board directory so additional boards
+can be added cheaply, but the default Phase 3N target is
+``boards/07-matchgroup-test`` (Issue #2724 Phase 3L scaffolding).
+
+Usage::
+
+    # Re-route + check board 07 (the canonical match-group testbench):
+    python scripts/ci/check_matchgroup_coverage.py boards/07-matchgroup-test
+
+    # Check an already-routed board (skip the route step; useful for
+    # debugging the assertion logic locally):
+    python scripts/ci/check_matchgroup_coverage.py boards/07-matchgroup-test \\
+        --skip-route
+
+Exit codes (mirror ``check_routed_drc.py`` / ``check_diffpair_coverage.py``):
+
+    0 -- Gate passed (errors within tolerance AND the rule was exercised).
+    1 -- Tool failure (board dir missing, route step crashed, allowlist
+         parse error, etc.).
+    2 -- Gate failed: errors exceed allowlist OR the rule did not run.
+
+GitHub-Actions ``::error file=...::`` annotations are emitted on failure
+so the PR Files-changed view surfaces the failure inline.
+
+Why a separate script (not folded into ``check_diffpair_coverage.py``):
+
+    Per the curator recommendation on Issue #2726 (curator comment
+    2026-05-11), the match-group gate is a SIBLING to the diff-pair
+    gate, not a matrix-extension.  Concrete reasons:
+
+      1. Minimal blast radius -- a match-group regression PR cannot
+         accidentally break the diff-pair gate and vice versa.
+      2. The diff-pair gate's "rule exercised" check has three rule_ids
+         hardcoded; this script asserts a different (currently single)
+         rule_id.  Forking is cleaner than parametrising
+         ``check_diffpair_coverage.py`` with a ``--rules`` flag.
+      3. Per-job CI timeout budgets are independent (each gets a fresh
+         10-min ceiling).
+      4. The diff-pair coverage script re-computes skew_data from PCB
+         segments to satisfy the diff-pair length-skew rule's injection
+         contract.  The match-group equivalent (``derive_group_skew_data``
+         in ``src/kicad_tools/validate/match_group_skew.py``) is invoked
+         automatically by ``DRCChecker.check_match_group_length_skew``
+         when ``net_class_map`` is supplied -- so this script does NOT
+         need to replicate that producer-side logic; it just passes the
+         sidecar through to ``kct check``.
+
+Reusing logic from ``check_diffpair_coverage.py`` / ``check_routed_drc.py``:
+
+    * Allowlist loading (``load_allowlist``)
+    * Annotation helpers (``annotate_error``)
+    * Re-route + PCB-locate helpers (``re_route_board``, ``find_routed_pcb``)
+    * net_class_map import from generate_design.py (``build_net_class_map_for_board``)
+
+The helpers are duplicated rather than imported to keep each CI gate's
+blast radius minimal and to match the byte-for-byte convention
+established by ``check_diffpair_coverage.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+# --- shared with check_routed_drc.py / check_diffpair_coverage.py ------------
+
+DEFAULT_ALLOWLIST = Path(".github/routed-drc-tolerance.yml")
+
+# The match-group rule_id that MUST be exercised on a board that
+# declares match groups (board 07 declares 4 groups across 4 protocols,
+# so this rule should run with rules_checked_by_rule entry >= 1).  See
+# ``src/kicad_tools/drc/violation.py`` and
+# ``src/kicad_tools/validate/rules/match_group_length_skew.py`` for the
+# canonical rule_id string + per-rule counter increment (Issue #2702).
+MATCHGROUP_RULE_IDS: tuple[str, ...] = ("match_group_length_skew",)
+
+
+def load_allowlist(allowlist_path: Path) -> dict[str, int]:
+    """Load the per-board DRC tolerance allowlist.
+
+    Behaviour matches ``check_routed_drc.load_allowlist`` and
+    ``check_diffpair_coverage.load_allowlist`` exactly so all three
+    gates share the same YAML contract.  Duplicated here to keep this
+    script self-contained.
+    """
+    if not allowlist_path.exists():
+        return {}
+    try:
+        data = yaml.safe_load(allowlist_path.read_text())
+    except yaml.YAMLError as e:
+        raise ValueError(f"Malformed allowlist YAML at {allowlist_path}: {e}") from e
+
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"Allowlist {allowlist_path} must be a YAML mapping at the top level, "
+            f"got {type(data).__name__}"
+        )
+
+    tolerances = data.get("tolerances", {})
+    if not isinstance(tolerances, dict):
+        raise ValueError(
+            f"Allowlist {allowlist_path} 'tolerances' field must be a mapping, "
+            f"got {type(tolerances).__name__}"
+        )
+
+    result: dict[str, int] = {}
+    for key, value in tolerances.items():
+        if not isinstance(key, str):
+            raise ValueError(f"Allowlist {allowlist_path}: key {key!r} must be a string")
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise ValueError(
+                f"Allowlist {allowlist_path}: value for {key!r} must be a "
+                f"non-negative integer, got {value!r}"
+            )
+        result[key] = value
+    return result
+
+
+def annotate_error(file: str, message: str) -> None:
+    """Emit a GitHub-Actions ``::error file=...::`` annotation."""
+    print(f"::error file={file}::{message}", flush=True)
+
+
+# --- script-specific logic ----------------------------------------------------
+
+
+def re_route_board(board_dir: Path, seed: int) -> bool:
+    """Re-route the board's PCB from scratch using ``generate_design.py``.
+
+    Args:
+        board_dir: Path to the board directory (e.g.,
+            ``boards/07-matchgroup-test``).
+        seed: Seed for ``random.seed()`` (Issue #2589).  Required for
+            determinism so the gate produces the same artifact run-to-run.
+
+    Returns:
+        True on success (return code 0), False otherwise.
+
+    Notes:
+        Runs ``python generate_design.py --step route --seed N`` via
+        ``subprocess.run`` so the route logic runs in a fresh process
+        (no inherited state).  Stdout/stderr are streamed to the
+        CI log for diagnostic visibility.
+    """
+    script = board_dir / "generate_design.py"
+    if not script.is_file():
+        print(
+            f"::error::generate_design.py not found at {script} -- cannot re-route board.",
+            flush=True,
+        )
+        return False
+
+    cmd = [
+        sys.executable,
+        str(script),
+        "--step",
+        "route",
+        "--seed",
+        str(seed),
+    ]
+    print(f"\n[re-route] Running: {' '.join(cmd)}", flush=True)
+    proc = subprocess.run(cmd, capture_output=False, text=True, check=False)
+    if proc.returncode != 0:
+        print(
+            f"::error::Re-route failed for {board_dir} (exit code {proc.returncode}).",
+            flush=True,
+        )
+        return False
+    return True
+
+
+def find_routed_pcb(board_dir: Path) -> Path | None:
+    """Locate the board's freshly-routed PCB.
+
+    Walks ``board_dir/output`` looking for the canonical
+    ``*_routed.kicad_pcb`` artifact emitted by ``generate_design.py``.
+    Returns ``None`` if not found (caller emits the error).
+    """
+    out = board_dir / "output"
+    if not out.is_dir():
+        return None
+    candidates = list(out.glob("*_routed.kicad_pcb"))
+    if not candidates:
+        return None
+    if len(candidates) > 1:
+        print(
+            f"::warning::Multiple routed PCBs found in {out}; using first: {candidates[0]}",
+            flush=True,
+        )
+    return candidates[0]
+
+
+def find_net_class_map_sidecar(board_dir: Path) -> Path | None:
+    """Locate the board's ``net_class_map.json`` sidecar.
+
+    The Phase 3L scaffolding (Issue #2724) emits the sidecar from
+    ``generate_design.write_sidecar()`` during the route step, so the
+    file exists after ``re_route_board`` returns success.  This sidecar
+    is mandatory for the ``match_group_length_skew`` rule to fire under
+    standalone ``kct check`` -- without it the rule degrades to a no-op
+    (see ``MatchGroupLengthSkewRule`` docstring).
+    """
+    out = board_dir / "output"
+    sidecar = out / "net_class_map.json"
+    return sidecar if sidecar.is_file() else None
+
+
+def _import_module_from_path(module_name: str, path: Path):
+    """Import a module by file path without adding it to sys.path permanently."""
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot create import spec for {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def build_net_class_map_for_board(board_dir: Path) -> dict | None:
+    """Import ``generate_design.build_net_class_map()`` from a board dir.
+
+    Returns ``None`` if the board's ``generate_design.py`` does not
+    expose a ``build_net_class_map`` function.  In that case the
+    match-group rule will degrade to a no-op (the design doesn't declare
+    any match groups).
+    """
+    script = board_dir / "generate_design.py"
+    if not script.is_file():
+        return None
+
+    # The board's generate_design.py imports its sibling modules via a
+    # ``sys.path.insert(0, str(Path(__file__).parent))`` -- replicate that
+    # so the import resolves correctly.
+    saved_path = list(sys.path)
+    sys.path.insert(0, str(board_dir))
+    try:
+        mod = _import_module_from_path(
+            f"_matchgroup_coverage_generate_design_{board_dir.name.replace('-', '_')}",
+            script,
+        )
+    finally:
+        sys.path[:] = saved_path
+
+    return getattr(mod, "build_net_class_map", lambda: None)()
+
+
+def count_errors_via_kct_check(pcb_path: Path, sidecar: Path | None) -> int:
+    """Count errors via ``kct check --mfr jlcpcb --errors-only --format json``.
+
+    Mirrors ``check_diffpair_coverage.count_errors_via_kct_check`` so the
+    allowlist semantic matches the sibling CI gates exactly -- a value of
+    80 on the same routed PCB must mean the same thing across all three
+    gates (committed-diff, diff-pair regression, match-group regression).
+
+    The ``--net-class-map`` sidecar (when present) is passed through
+    explicitly per the Phase 3L pattern (#2724 / curator comment).
+    Without the sidecar the ``match_group_length_skew`` rule degrades
+    to a no-op and the violation count would be artificially low.
+
+    Args:
+        pcb_path: Path to the routed PCB.
+        sidecar: Optional path to ``net_class_map.json``.  Required for
+            the match-group rule to fire under standalone ``kct check``.
+
+    Returns:
+        The ``summary.errors`` integer from the kct check JSON envelope.
+    """
+    cmd = [
+        "uv",
+        "run",
+        "kct",
+        "check",
+        str(pcb_path),
+        "--mfr",
+        "jlcpcb",
+        "--errors-only",
+        "--format",
+        "json",
+    ]
+    if sidecar is not None:
+        cmd.extend(["--net-class-map", str(sidecar)])
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if proc.returncode == 1:
+        raise RuntimeError(
+            f"kct check failed on {pcb_path} (exit 1). stderr:\n{proc.stderr.strip()}"
+        )
+    if proc.returncode not in (0, 2):
+        raise RuntimeError(
+            f"kct check returned unexpected exit code {proc.returncode} on "
+            f"{pcb_path}. stderr:\n{proc.stderr.strip()}"
+        )
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"kct check produced invalid JSON on {pcb_path}: {e}") from e
+
+    summary = data.get("summary", {})
+    errors = summary.get("errors")
+    if not isinstance(errors, int):
+        raise RuntimeError(f"kct check JSON missing summary.errors field for {pcb_path}: {data!r}")
+    return errors
+
+
+def compute_rule_coverage(
+    pcb_path: Path,
+    net_class_map: dict | None,
+) -> dict[str, int]:
+    """Compute per-rule check counts for the match-group rule.
+
+    Invokes :class:`kicad_tools.validate.DRCChecker` directly so the
+    per-rule counter is accessible without re-parsing JSON.  The
+    ``net_class_map`` is threaded through to the checker so
+    :func:`~kicad_tools.validate.match_group_skew.derive_group_skew_data`
+    runs and the match-group rule engages (without it the rule
+    degrades to a no-op and ``rules_checked_by_rule`` never gets the
+    ``match_group_length_skew`` entry).
+
+    This is a SEPARATE pass from the error-count check (which uses
+    the standalone ``kct check`` for allowlist parity).  The two passes
+    serve different purposes: error-count gates regression in the
+    re-routed PCB, while coverage gates regression in the detection
+    logic (e.g., a future change that breaks ``derive_group_skew_data``
+    would silently zero the rule's per-rule counter).
+
+    Args:
+        pcb_path: Path to the routed PCB.
+        net_class_map: Optional ``{net_name: NetClassRouting}`` map from
+            the board's ``build_net_class_map()``.  Required for the
+            match-group rule to engage.
+
+    Returns:
+        ``rules_checked_by_rule`` dict mapping rule_id -> count.
+
+    Raises:
+        RuntimeError: If the PCB cannot be loaded.
+    """
+    from kicad_tools.schema.pcb import PCB
+    from kicad_tools.validate import DRCChecker
+
+    try:
+        pcb = PCB.load(pcb_path)
+    except Exception as e:
+        raise RuntimeError(f"Failed to load PCB {pcb_path}: {e}") from e
+
+    detected = len(pcb.copper_layers)
+    layers = detected if detected > 0 else 2
+
+    checker = DRCChecker(
+        pcb,
+        manufacturer="jlcpcb",
+        layers=layers,
+        copper_oz=1.0,
+        net_class_map=net_class_map,
+    )
+
+    # Run all rules via the standard checker entry point.  The
+    # match-group rule auto-derives skew data via
+    # ``derive_group_skew_data`` when ``net_class_map`` is supplied
+    # (see ``DRCChecker.check_match_group_length_skew``).  Unlike the
+    # diff-pair length-skew rule, no extra second-pass is required --
+    # the producer wiring (#2710 Phase 2.5G) handles everything.
+    results = checker.check_all()
+
+    return dict(results.rules_checked_by_rule)
+
+
+def check_rule_coverage(
+    rules_checked_by_rule: dict[str, int],
+    required_rule_ids: tuple[str, ...] = MATCHGROUP_RULE_IDS,
+) -> list[str]:
+    """Return the list of rule_ids that did NOT run (counter < 1 or missing).
+
+    A returned list is empty iff every required rule was exercised at
+    least once.  The ordering matches ``required_rule_ids`` so error
+    messages list rules in a stable order.
+    """
+    missing: list[str] = []
+    for rule_id in required_rule_ids:
+        if rules_checked_by_rule.get(rule_id, 0) < 1:
+            missing.append(rule_id)
+    return missing
+
+
+def check_board(
+    board_dir: Path,
+    allowlist: dict[str, int],
+    seed: int,
+    skip_route: bool,
+) -> int:
+    """Run the full gate for a single board.
+
+    Returns the exit code (0 = pass, 1 = tool failure, 2 = gate failure).
+    Mirrors the exit-code convention from ``check_routed_drc.py`` /
+    ``check_diffpair_coverage.py``.
+    """
+    if not board_dir.is_dir():
+        annotate_error(str(board_dir), f"Board directory not found: {board_dir}")
+        return 1
+
+    if not skip_route:
+        if not re_route_board(board_dir, seed):
+            return 1
+    else:
+        print(f"\n[skip-route] Using existing routed PCB in {board_dir}/output/")
+
+    routed_pcb = find_routed_pcb(board_dir)
+    if routed_pcb is None:
+        annotate_error(
+            str(board_dir),
+            "No *_routed.kicad_pcb found in board output dir after re-route.",
+        )
+        return 1
+
+    sidecar = find_net_class_map_sidecar(board_dir)
+    if sidecar is None:
+        annotate_error(
+            str(board_dir),
+            (
+                "No net_class_map.json sidecar found in board output dir; "
+                "the match_group_length_skew rule will degrade to a no-op "
+                "without it.  Expected at "
+                f"{board_dir}/output/net_class_map.json (emitted by "
+                "generate_design.write_sidecar)."
+            ),
+        )
+        return 1
+
+    # Build the net_class_map from the board's generate_design module
+    # so match-group detection in the DRC rule has the per-class
+    # context (length_match_group declarations, length_match_tolerance_mm
+    # overrides, etc.).
+    try:
+        net_class_map = build_net_class_map_for_board(board_dir)
+    except Exception as e:
+        annotate_error(
+            str(board_dir),
+            f"Failed to import build_net_class_map from {board_dir}: {e}",
+        )
+        return 1
+
+    if not net_class_map:
+        annotate_error(
+            str(board_dir),
+            (
+                "build_net_class_map() returned an empty/None map; the "
+                "match_group_length_skew rule cannot fire on a board with "
+                "no declared match groups.  Check that the board's "
+                "generate_design.py exposes a non-empty build_net_class_map."
+            ),
+        )
+        return 1
+
+    # Compute the allowlist key in the same way check_routed_drc.py does:
+    # repo-relative path string.
+    try:
+        rel = routed_pcb.resolve().relative_to(Path.cwd())
+        lookup_key = str(rel)
+    except ValueError:
+        lookup_key = str(routed_pcb)
+    allowed = allowlist.get(lookup_key, 0)
+
+    # Two-pass strategy (see docstrings on count_errors_via_kct_check
+    # and compute_rule_coverage for the rationale):
+    #   1. Error count via subprocess ``kct check --net-class-map`` --
+    #      matches the sibling allowlist semantic exactly AND ensures
+    #      the match-group rule contributes to the error count.
+    #   2. Rule coverage via in-process DRCChecker(..., net_class_map=...)
+    #      -- the only way to confirm the rule's per-rule counter
+    #      actually incremented (a regression in derive_group_skew_data
+    #      would zero the counter even with a correct error count).
+    try:
+        error_count = count_errors_via_kct_check(routed_pcb, sidecar)
+    except RuntimeError as e:
+        annotate_error(str(routed_pcb), f"kct check failed: {e}")
+        return 1
+    try:
+        rules_by_rule = compute_rule_coverage(routed_pcb, net_class_map)
+    except RuntimeError as e:
+        annotate_error(str(routed_pcb), f"Rule-coverage probe failed: {e}")
+        return 1
+
+    print(f"\n[matchgroup-coverage] Board: {board_dir.name}")
+    print(f"[matchgroup-coverage] Routed PCB: {routed_pcb}")
+    print(f"[matchgroup-coverage] Sidecar: {sidecar}")
+    print(f"[matchgroup-coverage] DRC error count: {error_count} (allowed: {allowed})")
+    print(f"[matchgroup-coverage] rules_checked_by_rule: {rules_by_rule}")
+
+    failed = False
+
+    # AC #4: the match_group_length_skew rule must have been exercised.
+    missing = check_rule_coverage(rules_by_rule)
+    if missing:
+        msg = (
+            f"Match-group rule(s) NOT exercised on {routed_pcb}: "
+            f"{', '.join(missing)}.  This is a silent regression -- the rule "
+            "short-circuited because no declared groups were detected with "
+            "measurable skew.  Likely causes: ``length_match_group`` field "
+            "unwired from one or more net classes in build_net_class_map, "
+            "derive_group_skew_data broken (e.g., detect_match_groups "
+            "returning empty), or the routed PCB has no traces matching any "
+            "declared group's members.  See "
+            "src/kicad_tools/validate/match_group_skew.py and "
+            "src/kicad_tools/validate/rules/match_group_length_skew.py for "
+            "the engagement conditions."
+        )
+        annotate_error(str(routed_pcb), msg)
+        failed = True
+    else:
+        print(
+            f"[matchgroup-coverage] OK: all {len(MATCHGROUP_RULE_IDS)} match-group "
+            "rule(s) exercised."
+        )
+
+    # AC #1 (allowlist semantic): error count must be <= allowed.
+    if error_count > allowed:
+        if allowed == 0:
+            msg = (
+                f"DRC errors detected on re-routed {routed_pcb}: {error_count} "
+                f"error(s).  Boards NOT in .github/routed-drc-tolerance.yml must "
+                "report 0 errors.  Fix the routing regression or add an explicit "
+                "allowlist entry with reviewer sign-off."
+            )
+        else:
+            msg = (
+                f"DRC regression on re-routed {routed_pcb}: {error_count} "
+                f"error(s) exceeds allowlist value {allowed} in "
+                ".github/routed-drc-tolerance.yml.  Either fix the new "
+                "violations or (if intentional) raise the allowlist value."
+            )
+        annotate_error(str(routed_pcb), msg)
+        failed = True
+    else:
+        if allowed == 0:
+            print("[matchgroup-coverage] OK: 0 errors (strict gate).")
+        else:
+            print(
+                f"[matchgroup-coverage] OK: {error_count} errors (within allowlist max {allowed})."
+            )
+
+    return 2 if failed else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="check_matchgroup_coverage",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "boards",
+        nargs="+",
+        help=(
+            "One or more board directories to check (e.g., boards/07-matchgroup-test).  "
+            "Each board must contain generate_design.py with --step route + --seed support."
+        ),
+    )
+    parser.add_argument(
+        "--allowlist",
+        default=str(DEFAULT_ALLOWLIST),
+        help=f"Path to the tolerance allowlist YAML (default: {DEFAULT_ALLOWLIST}).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        metavar="N",
+        help=(
+            "Seed forwarded to generate_design.py --seed for deterministic "
+            "re-routes (default: 42, matches Issue #2589 / Phase 3X.2 examples)."
+        ),
+    )
+    parser.add_argument(
+        "--skip-route",
+        action="store_true",
+        help=(
+            "Skip the re-route step and check the existing committed routed "
+            "PCB.  Useful for local debugging of the rule-coverage assertion."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        allowlist = load_allowlist(Path(args.allowlist))
+    except ValueError as e:
+        print(f"::error::{e}", flush=True)
+        return 1
+
+    overall = 0
+    for raw in args.boards:
+        board_dir = Path(raw).resolve()
+        rc = check_board(board_dir, allowlist, args.seed, args.skip_route)
+        if rc > overall:
+            overall = rc
+
+    if overall:
+        print(
+            f"\nGate failed (exit {overall}).  See ::error:: annotations "
+            "above; offending boards are also surfaced in the PR Files-changed "
+            "view.",
+            flush=True,
+        )
+    return overall
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Wires board 07 (`boards/07-matchgroup-test`, Epic #2661 Phase 3L) into a new `matchgroup-routing-regression` CI job that runs on every PR. The job is the match-group sibling of `diffpair-routing-regression` (board 06) and asserts both an allowlist-bounded DRC error count AND that `match_group_length_skew` (#2702) was actually exercised, so a silent-detection regression cannot pass with a 0-error report.

## Changes

- **New `scripts/ci/check_matchgroup_coverage.py`** — re-routes the board with `--seed 42`, runs `kct check --mfr jlcpcb --net-class-map output/net_class_map.json`, then runs `DRCChecker` in-process with `net_class_map` so the rule's per-rule counter is observable. Mirrors `check_diffpair_coverage.py` byte-for-byte where the logic overlaps; rule-list constant is the single-element `MATCHGROUP_RULE_IDS = ("match_group_length_skew",)`.
- **New `matchgroup-routing-regression` job in `.github/workflows/ci.yml`** — sibling to `diffpair-routing-regression`, not a matrix-extension. Sibling structure was chosen per the issue #2726 curator decision: minimal blast radius, independent timeout budgets, the diff-pair gate's branch-protection check name stays stable, and the rule_id list is different so a `--rules` flag on the shared script would only add complexity. `timeout-minutes: 10`, single board 07 in the matrix.
- **`boards/07-matchgroup-test/README.md`** — "CI Gate" section rewritten to reflect that the gate is now wired (was: "will be wired"). Documents failure modes (`rule not exercised` vs `DRC regression` vs timeout), local reproduction commands, and the post-merge branch-protection admin action.

### Design decision: sibling job, not matrix-extension

Per the issue body + curator recommendation:
1. Match-group regression PRs cannot accidentally break the diff-pair gate.
2. `DIFFPAIR_RULE_IDS` is a hardcoded three-tuple; parametrising would require a `--rules` flag (deferred).
3. Per-job timeout budgets are independent (each gets its own 10 min).
4. The existing job name `Diff-Pair Routing Regression` is a branch-protection contract — sibling is purely additive.

### Decision: separate script, not parametrised `check_diffpair_coverage.py`

The diff-pair script has rule-specific logic (`_measure_skew_data_from_pcb` recomputes skew from segments to satisfy the diff-pair length-skew rule's injection contract). The match-group equivalent is unnecessary because `derive_group_skew_data` (#2710 Phase 2.5G producer wiring) handles this automatically inside `DRCChecker.check_match_group_length_skew` when `net_class_map` is supplied. Forking keeps each script's responsibilities crisp.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| 1. `.github/routed-drc-tolerance.yml` has board 07 entry with composition comment | OK | Already landed in PR #2737 (Phase 3L scaffolding); entry at `boards/07-matchgroup-test/.../matchgroup_test_routed.kicad_pcb: 80` with per-rule composition documented in the YAML comment. |
| 2. New CI job runs on every PR + re-routes board 07 with `--seed 42` | OK | New `matchgroup-routing-regression` job added; same `pull_request` trigger as the rest of `ci.yml`; step invokes `check_matchgroup_coverage.py boards/07-matchgroup-test --seed 42`. |
| 3. Job re-routes from `generate_design.py` (not the committed PCB) | OK | `re_route_board()` shells out to `python boards/07-matchgroup-test/generate_design.py --step route --seed 42` before any DRC check. `--skip-route` only exists for local debugging. |
| 4. Job asserts `match_group_length_skew` rule was exercised | OK | `compute_rule_coverage()` runs `DRCChecker.check_all()` with `net_class_map` then reads `results.rules_checked_by_rule`. `check_rule_coverage()` returns the list of missing/zero-count rule_ids; non-empty -> exit 2 with `::error::Match-group rule(s) NOT exercised` annotation. Local test against committed PCB: counter = 1, OK. Negative-test path verified by unit-testing `check_rule_coverage({})` returning `["match_group_length_skew"]`. |
| 5. Job wall-clock <= 5 min on ubuntu-latest | EXPECTED OK | `timeout-minutes: 10` is the safety net. Local `--skip-route` runs in ~5s; full re-route locally is ~30-60s on a developer laptop. CI runner is comparable. If creep is observed post-merge, follow-up moves to nightly. |
| 6. README documents the CI gate + failure interpretation | OK | `boards/07-matchgroup-test/README.md` "CI Gate (Phase 3N, #2726)" section rewritten with three failure modes, local repro commands, and branch-protection note. |
| 7. PR description calls out branch-protection admin action | OK | See "Branch-protection admin action required" below. |
| 8. 10x stability — identical SHA across 10 re-routes | DEFERRED | Local SHA-stability spot-check is part of the Test Plan; full 10x is left to the post-merge monitoring window since #2589 already enforces seed determinism. |

## Test Plan

- [x] `uv run python scripts/ci/check_matchgroup_coverage.py boards/07-matchgroup-test --skip-route` against the committed routed PCB locally:
  - DRC error count: 64 (allowed: 80) — within allowlist.
  - `rules_checked_by_rule["match_group_length_skew"] = 1` — rule exercised.
  - Exit code 0, no `::error::` annotations.
- [x] Lint + format clean: `uv run ruff check scripts/ci/check_matchgroup_coverage.py` + `uv run ruff format --check ...`.
- [x] YAML validity: `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` returns the new job in `jobs`.
- [x] Negative-test unit assertions on `check_rule_coverage()`:
  - `{}` -> `["match_group_length_skew"]` (missing -> caught).
  - `{"match_group_length_skew": 0}` -> `["match_group_length_skew"]` (zero counter -> caught).
  - `{"match_group_length_skew": 1}` -> `[]` (engagement -> passes).
- [ ] Post-merge: verify the new job runs on the next PR and turns green.
- [ ] Post-merge: monitor 5 subsequent PRs for false-positive failures (cascade-tuning timing flakiness, etc.).
- [ ] Post-merge: spot-check 10x SHA stability of the re-route artifact locally (covered by #2589's existing determinism guarantees but worth confirming once after this job lands).

## Branch-protection admin action required

Per the precedent set by PR #2679 (the `diffpair-routing-regression` rollout), adding `Match-Group Routing Regression` to the list of *required* status checks on `main` is a separate repo-admin action in **GitHub Settings -> Rules -> Rulesets**. Until that flip happens the new job runs on every PR but is advisory — its failure does not block the merge button. Please action this immediately after merge so the gate becomes enforcing.

Closes #2726