### PR TITLE
docs(match-groups): add per-protocol guides + drift-prevention tests

### DIFF
--- a/docs/guides/diff-pairs/README.md
+++ b/docs/guides/diff-pairs/README.md
@@ -14,6 +14,7 @@ Epic #2556 (Phases 1–3).
 | Length-match a pair within a skew tolerance | [04-length-matching.md](04-length-matching.md) |
 | Copy a working setup for USB / PCIe / MIPI | [05-protocol-recipes.md](05-protocol-recipes.md) |
 | Understand the diff-pair DRC rules (`kct check`) | [06-drc-rules.md](06-drc-rules.md) |
+| Length-match N>=3 nets together (parallel bus, not a pair) | [../match-groups/README.md](../match-groups/README.md) |
 
 ## Canonical pre-configured class
 

--- a/docs/guides/match-groups/01-declaring-groups.md
+++ b/docs/guides/match-groups/01-declaring-groups.md
@@ -1,0 +1,77 @@
+# 01 — Declaring a Match Group
+
+A match group is declared by configuring the **net class**, not by an
+imperative `router.add_match_group(...)` call (though that legacy API
+is still supported).
+
+Reference board: [`boards/07-matchgroup-test`](../../../boards/07-matchgroup-test/)
+exercises all three detection paths end-to-end.
+
+## Three detection paths (priority order)
+
+### 1. Explicit `length_match_group` (authoritative)
+
+The strongest declaration. Set `length_match_group="DDR_DATA_BYTE_0"` on
+every net class whose members belong to that group:
+
+```python
+from kicad_tools.router.rules import NetClassRouting
+
+ddr_dq = NetClassRouting(
+    name="DDR_DQ",
+    trace_width=0.15,
+    clearance=0.15,
+    length_match_group="DDR_DATA_BYTE_0",   # group name
+    length_match_tolerance_mm=0.1,           # ±0.1 mm
+    length_critical=True,                    # gate for the tuner
+)
+```
+
+Field defined at `src/kicad_tools/router/rules.py:602`. Multiple net
+classes may declare the same group name — their members merge into a
+single group (the documented MIPI/HDMI lane-composition pattern; see
+guide 03). Overrides suffix inference at detection time
+(`match_group_detection.py:172`).
+
+### 2. Legacy `Autorouter.add_match_group(...)` API
+
+Direct Python API kept for backward compatibility. Adds a group to the
+underlying `LengthTracker.match_groups` dict at runtime:
+
+```python
+router.add_match_group(
+    name="DDR_DATA",
+    net_ids=[100, 101, 102, 103, 104, 105, 106, 107],
+    tolerance=0.5,
+)
+```
+
+Defined at `src/kicad_tools/router/core.py:7211`. Lower priority than
+explicit declarations — a legacy group whose members are already
+claimed by an EXPLICIT class is dropped (see `detect_match_groups` at
+`match_group_detection.py:172`).
+
+### 3. Suffix inference (opt-in, last resort)
+
+Off by default. Enable by passing `enable_suffix_inference=True` to
+`detect_match_groups()`. The detector consults `BUS_GROUP_PATTERNS` at
+`match_group_detection.py:110`, which recognises:
+
+- `DQ\d+` → `DDR_DATA`
+- `CSI_DAT\d+_[PN]` → `MIPI_CSI_DATA`
+- `DSI_DAT\d+_[PN]` → `MIPI_DSI_DATA`
+- `TMDS_D\d+_[PN]` → `HDMI_TMDS_DATA`
+- `A\d+` → `ADDR_BUS`
+
+Groups with fewer than three members are **refused** (`_MIN_GROUP_SIZE=3`).
+This is the same false-positive lesson as USB-CC1/CC2 in
+`diffpair_detection.py`: low-confidence patterns (e.g. `A0`/`A1` could
+be GPIO not address bus) are not auto-promoted. **Prefer explicit
+declarations when in doubt.**
+
+## See also
+
+- [02-reference-selection.md](02-reference-selection.md) — pick which
+  trace is the reference (longest / explicit / `clock`).
+- [05-protocol-recipes.md](05-protocol-recipes.md) — copy-pasteable
+  per-protocol `NetClassRouting` blocks.

--- a/docs/guides/match-groups/02-reference-selection.md
+++ b/docs/guides/match-groups/02-reference-selection.md
@@ -1,0 +1,80 @@
+# 02 — Reference Selection
+
+`length_match_reference` decides **which trace's length the rest of the
+group must match**. Field declared at `src/kicad_tools/router/rules.py:632`;
+accessor `effective_length_match_reference()` at `rules.py:737`.
+
+Reference board: [`boards/07-matchgroup-test`](../../../boards/07-matchgroup-test/)
+exercises all three policies.
+
+## Three policies
+
+### 1. `None` — longest-in-group (default)
+
+The longest routed net becomes the reference; every shorter member is
+serpentined up to its length. Matches the legacy `tune_match_group`
+semantics at `router/optimizer/serpentine.py:438`. Use this when no
+member of the group has special timing-budget constraints.
+
+```python
+from kicad_tools.router.rules import NetClassRouting
+
+ddr_dq = NetClassRouting(
+    name="DDR_DQ",
+    length_match_group="DDR_DATA_BYTE_0",
+    length_match_reference=None,           # explicit, but the default
+    length_match_tolerance_mm=0.1,
+)
+```
+
+### 2. Explicit net name — "pace-car"
+
+Name a single net. Every other member of the group must match **that
+net's** length, even when it isn't the longest. Use this when one
+member is hard to perturb — e.g. a DDR strobe whose timing budget
+can't absorb the cumulative skew of inserted bulges, or a clock that
+must not gain phase delay.
+
+```python
+ddr_dq_pace_car = NetClassRouting(
+    name="DDR_DQ",
+    length_match_group="DDR_DATA_BYTE_0",
+    length_match_reference="DQS_P",        # pace-car: DQS_P holds, DQ meanders
+    length_match_tolerance_mm=0.1,
+)
+```
+
+The tuner refuses to perturb the named reference; if a shorter member
+cannot reach the pace-car's length within the cascade budget it returns
+`reason="exceeded_max_inserts"` and the violation is reported by the
+`match_group_length_skew` DRC rule (guide 06).
+
+### 3. `"clock"` sentinel — protocol-aware (forward-compat)
+
+Reserved value for MIPI/HDMI clock-relative matching. Phase 1A accepts
+the sentinel; Phase 2/3 resolves it to the lane group's clock pair.
+Set this when a future protocol-aware resolver should pick the
+reference automatically (e.g. MIPI CSI clock = `CSI_CLK_P/N`).
+
+```python
+mipi_csi_data = NetClassRouting(
+    name="MIPI_CSI_DATA",
+    length_match_group="MIPI_CSI",
+    length_match_reference="clock",        # resolver picks the clock pair
+    length_match_tolerance_mm=0.05,
+)
+```
+
+## Precedence
+
+Detection at `match_group_detection.py:418-432` records the policy
+verbatim on `MatchGroup.length_match_reference`. `MatchGroupTracker.get_reference_length`
+consumes it: explicit name first (must exist in the group's measured
+lengths), `None` falls back to the longest, `"clock"` is a no-op in
+Phase 1A and the longest wins.
+
+## See also
+
+- [01-declaring-groups.md](01-declaring-groups.md) — declare the group.
+- [04-cascade-safety.md](04-cascade-safety.md) — what happens when the
+  pace-car policy refuses to be reached.

--- a/docs/guides/match-groups/03-group-of-pairs.md
+++ b/docs/guides/match-groups/03-group-of-pairs.md
@@ -1,0 +1,84 @@
+# 03 — Groups Whose Members Are Diff Pairs (MIPI / HDMI)
+
+MIPI and HDMI lane groups are **groups whose members are themselves
+differential pairs**. The Phase 2F symmetric-serpentine path
+(`match_group_tuning.tune_match_group_v2`, `router/match_group_tuning.py:214`)
+preserves within-pair coupling while equalising lane-to-lane length.
+
+Reference board: [`boards/07-matchgroup-test`](../../../boards/07-matchgroup-test/)
+MIPI scenario.
+
+## The naive trap
+
+Treating each net in a MIPI lane group independently — measure each
+trace, meander whichever is shorter — destroys diff-pair length skew.
+A 0.5 mm bulge on `CSI_DAT0_P` while `CSI_DAT0_N` is left alone yields
+0.5 mm of intra-pair skew, an order of magnitude worse than the
+~0.05 mm target on MIPI D-PHY.
+
+## What the v2 tuner does
+
+When the tuner sees a group member that is **itself a diff pair**
+(detected via the per-net `NetClassRouting.diffpair_partner`), it
+inserts the serpentine on **both halves simultaneously** with
+identical amplitude, position, and segment count. The two halves stay
+coupled; only the lane-to-lane length changes.
+
+```python
+from kicad_tools.router.rules import NetClassRouting
+
+mipi_lane_0 = NetClassRouting(
+    name="MIPI_CSI_LANE_0",
+    intra_pair_clearance=0.075,
+    coupled_routing=True,
+    diffpair_partner="CSI_DAT0_N",         # within-pair
+    length_match_group="MIPI_CSI",         # cross-lane
+    length_match_tolerance_mm=0.05,
+)
+
+mipi_lane_1 = NetClassRouting(
+    name="MIPI_CSI_LANE_1",
+    intra_pair_clearance=0.075,
+    coupled_routing=True,
+    diffpair_partner="CSI_DAT1_N",
+    length_match_group="MIPI_CSI",         # same group name as lane 0
+    length_match_tolerance_mm=0.05,
+)
+```
+
+Two separate `NetClassRouting` instances declare `length_match_group="MIPI_CSI"`;
+detection merges their members into a single group (see
+`match_group_detection.py:318`, `_collect_explicit_match_groups`).
+
+## Worked example: 3-lane MIPI CSI
+
+| Lane | Pair | Routed length | Action |
+|---|---|---|---|
+| Clock | `CSI_CLK_P/N` | 24.0 mm | reference (longest) |
+| Data 0 | `CSI_DAT0_P/N` | 23.5 mm | symmetric +0.5 mm serpentine on both halves |
+| Data 1 | `CSI_DAT1_P/N` | 24.0 mm | no perturbation needed |
+| Data 2 | `CSI_DAT2_P/N` | 22.9 mm | symmetric +1.1 mm serpentine on both halves |
+
+The post-tune within-pair skew for each lane stays at its pre-tune
+value (typically <0.01 mm), while the lane-to-lane skew converges to
+within `length_match_tolerance_mm=0.05`.
+
+## Engagement order
+
+The CLI runs `--length-match-diffpairs` **before** `--length-match-groups`
+(see `cli/route_cmd.py:5265-5270`). This is intentional: within-pair
+serpentines establish the per-pair invariant first, then cross-lane
+group tuning operates on pairs whose intra-pair skew is already
+within tolerance. Reversing the order would let group tuning corrupt
+the pair invariant.
+
+## See also
+
+- [01-declaring-groups.md](01-declaring-groups.md) — the group
+  declaration itself (lanes share the group name).
+- [04-cascade-safety.md](04-cascade-safety.md) — symmetric serpentine
+  insertions count as **two** against the per-member budget (one per
+  half), so MIPI groups exhaust the budget faster than single-ended
+  groups of the same N.
+- [05-protocol-recipes.md](05-protocol-recipes.md) — full
+  copy-pasteable MIPI / HDMI blocks.

--- a/docs/guides/match-groups/04-cascade-safety.md
+++ b/docs/guides/match-groups/04-cascade-safety.md
@@ -1,0 +1,71 @@
+# 04 — Cascade Safety (Why the Tuner Gives Up)
+
+The match-group tuner inserts serpentines until every member is within
+`length_match_tolerance_mm` of the reference — **bounded** by three
+constants in `src/kicad_tools/router/match_group_tuning.py`:
+
+| Constant | Value | Source line |
+|---|---|---|
+| `MAX_INSERTS_PER_GROUP_MEMBER_SMALL=3` | per-member budget for groups with `N <= 4` | `match_group_tuning.py:153` |
+| `MAX_INSERTS_PER_GROUP_MEMBER_LARGE=2` | per-member budget for groups with `N > 4` | `match_group_tuning.py:161` |
+| `MAX_TOTAL_INSERTS_PER_GROUP=16` | absolute cumulative ceiling across the group | `match_group_tuning.py:169` |
+
+## Why the bounds exist
+
+Each trombone insertion adds cumulative perturbation:
+
+- A 10-net DDR byte at the LARGE budget can produce up to 20 inserts;
+  the 16 ceiling caps the worst case at roughly 1.6 inserts/member.
+- Dense boards with multiple groups produce 2D packing collisions
+  (group A's serpentine intrudes on group B's keep-out). The bounds
+  bound the radius of perturbation per group.
+- Without the ceiling, a single hard-to-converge member can starve
+  every other group on the board.
+
+The MIPI/HDMI lane case (guide 03) is doubly affected: symmetric
+inserts count as **two** against the per-member budget — a 4-lane MIPI
+group with N=4 (LARGE not yet triggered) still hits the SMALL cap
+after just 1–2 symmetric inserts per lane.
+
+## When the tuner gives up: `reason` field
+
+`TuneResult.reason` reports why a member could not reach tolerance.
+Defined at `match_group_tuning.py:608-722`:
+
+| Reason | Meaning |
+|---|---|
+| `"tuned"` | success — within tolerance |
+| `"exceeded_max_inserts"` | per-member budget exhausted before reaching tolerance |
+| `"cascade_budget_exhausted"` | group-level ceiling (`MAX_TOTAL_INSERTS_PER_GROUP`) hit |
+| `"post_insertion_drc_violation"` | candidate serpentine would violate intra-group or neighbour clearance; rolled back |
+| `"no_suitable_segment"` | member has no segment long enough to host any trombone amplitude |
+| `"not_length_critical"` | engagement gate fired: `length_critical=False`, no change |
+| `"unrouted"` | member was not in `routes_by_net` (never routed) |
+
+## Remediation when the tuner gives up
+
+1. **Loosen tolerance** — raise `length_match_tolerance_mm`. The
+   "right" number is usually the protocol skew budget minus a margin
+   for stackup tolerance; if you set it tighter than the routing
+   density supports, the tuner will refuse to converge.
+2. **Reduce N** — split a DDR data byte into upper/lower nibbles
+   (DQ0-3 and DQ4-7 as two groups). Halves the cumulative perturbation
+   budget pressure.
+3. **Loosen clearance** — `post_insertion_drc_violation` means the
+   serpentine collides with a neighbour. Raise `clearance` on the
+   class or reduce trace width.
+4. **Improve placement** — `no_suitable_segment` means the routed
+   path has no straight run long enough for a trombone. Move pins
+   or relocate the IC to add headroom.
+5. **Accept the violation** — for non-safety-critical buses, the
+   `match_group_length_skew` DRC rule (guide 06) can be filtered out
+   with `--skip=match_group_length_skew` once you've documented the
+   waiver.
+
+## See also
+
+- [02-reference-selection.md](02-reference-selection.md) — the
+  pace-car policy refuses to perturb the reference, which can push a
+  member into `exceeded_max_inserts`.
+- [06-drc-rule.md](06-drc-rule.md) — `match_group_length_skew` fires
+  on whatever residual skew remains after the tuner gives up.

--- a/docs/guides/match-groups/05-protocol-recipes.md
+++ b/docs/guides/match-groups/05-protocol-recipes.md
@@ -1,0 +1,98 @@
+# 05 — Protocol Recipes
+
+Copy-pasteable `NetClassRouting` blocks for parallel-bus protocols. Each
+recipe declares **one** net class; declare the same `length_match_group`
+on every class whose nets belong to the group (see guide 01). Reference
+board: [`boards/07-matchgroup-test`](../../../boards/07-matchgroup-test/).
+
+## DDR3/DDR4 data byte (DQ0-7 + DM + DQS pair) — ±0.1 mm
+
+```python
+from kicad_tools.router.rules import NetClassRouting
+
+ddr_dq = NetClassRouting(
+    name="DDR_DQ",
+    trace_width=0.15,
+    length_match_group="DDR_DATA_BYTE_0",
+    length_match_reference="DQS_P",
+    length_match_tolerance_mm=0.1,
+    length_critical=True,
+)
+assert ddr_dq.effective_length_match_tolerance() == 0.1
+```
+
+10-net group: `DQ0..DQ7`, `DM`, and the `DQS_P/N` strobe pair. The
+strobe is the pace-car. Declare the same group name on the DQS class
+so the strobe joins as the reference.
+
+## MIPI CSI / DSI lane group — ±0.05 mm
+
+```python
+from kicad_tools.router.rules import NetClassRouting
+
+mipi_csi_data = NetClassRouting(
+    name="MIPI_CSI_DATA",
+    trace_width=0.2,
+    intra_pair_clearance=0.075,
+    coupled_routing=True,
+    diffpair_partner="CSI_DAT0_N",
+    length_match_group="MIPI_CSI",
+    length_match_reference="clock",
+    length_match_tolerance_mm=0.05,
+    length_critical=True,
+)
+assert mipi_csi_data.effective_length_match_tolerance() == 0.05
+```
+
+Groups whose members are diff pairs engage the v2 symmetric-serpentine
+path (guide 03). Declare an identical class per lane; detection merges
+them by shared group name.
+
+## HDMI TMDS (3 data pairs + clock pair) — ±0.075 mm
+
+```python
+from kicad_tools.router.rules import NetClassRouting
+
+hdmi_tmds = NetClassRouting(
+    name="HDMI_TMDS_DATA",
+    trace_width=0.2,
+    intra_pair_clearance=0.075,
+    coupled_routing=True,
+    diffpair_partner="TMDS_D0_N",
+    length_match_group="HDMI_TMDS",
+    length_match_reference="clock",
+    length_match_tolerance_mm=0.075,
+    length_critical=True,
+)
+assert hdmi_tmds.effective_length_match_group() == "HDMI_TMDS"
+```
+
+6 nets across 3 data pairs plus the TMDS clock pair in a parallel class
+with `length_match_group="HDMI_TMDS"`.
+
+## Parallel address bus — ±0.5 mm
+
+```python
+from kicad_tools.router.rules import NetClassRouting
+
+addr_bus = NetClassRouting(
+    name="ADDR_BUS",
+    trace_width=0.15,
+    length_match_group="ADDR_BUS",
+    length_match_tolerance_mm=0.5,
+    length_critical=True,
+)
+assert addr_bus.effective_length_match_tolerance() == 0.5
+```
+
+Commodity tier; loose tolerance, longest-in-group reference.
+
+## DDR strobe / data / mask in one group
+
+DDR mixes a strobe diff pair (`DQS_P/N`, the pace-car), data (`DQ0..DQ7`),
+and mask (`DM`) under one group name. Declare three net classes — DQS
+sets `diffpair_partner` to route the strobe coupled; all three set
+`length_match_group="DDR_DATA_BYTE_0"`. DQS within-pair skew is tuned by
+the diff-pair pass; DQ-to-DQS lane skew by the match-group pass.
+
+## See also: [01](01-declaring-groups.md), [03](03-group-of-pairs.md), [07](07-cli-and-sidecar.md).

--- a/docs/guides/match-groups/06-drc-rule.md
+++ b/docs/guides/match-groups/06-drc-rule.md
@@ -1,0 +1,81 @@
+# 06 — `match_group_length_skew` DRC Rule
+
+The DRC rule `match_group_length_skew` (Issue #2702, Epic #2661
+Phase 2G) validates the routed lane-to-lane skew of every detected
+match group. Source:
+`src/kicad_tools/validate/rules/match_group_length_skew.py:153`.
+
+## What it detects
+
+For every group, computes `max_length - min_length` (or
+`|L_member - L_reference|` when an explicit reference is set) and
+compares against `length_match_tolerance_mm` on the group's net class.
+Fires one violation per out-of-tolerance member.
+
+```bash
+kct check routed.kicad_pcb --rules=match_group_length_skew
+```
+
+```bash
+# Bundled into the manufacturer profile
+kct check routed.kicad_pcb --mfr jlcpcb
+```
+
+## Producer-side requirement (Phase 2.5G)
+
+The rule is **a no-op unless skew data is available** — it cannot
+re-derive group membership from the PCB alone. Two producer-side
+paths feed the rule:
+
+1. **In-process** — `MatchGroupTracker` populated during routing
+   (`Autorouter.update_match_group_skew` at
+   `src/kicad_tools/router/core.py:7350`). Used by the `kct route`
+   pipeline.
+2. **Standalone** — the `--net-class-map` JSON sidecar. The
+   `derive_group_skew_data` helper at
+   `src/kicad_tools/validate/match_group_skew.py:77` re-derives
+   group membership and per-net lengths from the routed PCB +
+   sidecar map.
+
+Without either, `check_match_group_length_skew` returns zero
+violations (a no-op). This is the Phase 2.5G short-circuit; do not
+interpret "0 violations" as "no skew" if you haven't supplied the
+sidecar.
+
+## Rule ID
+
+The public string is `match_group_length_skew` — exactly the
+`ViolationType.MATCH_GROUP_LENGTH_SKEW` enum value at
+`src/kicad_tools/drc/violation.py:157`. The enum is aliased
+explicitly in the `from_string` map at
+`src/kicad_tools/drc/violation.py:299`:
+
+```python
+ViolationType.from_string("match_group_length_skew") is ViolationType.MATCH_GROUP_LENGTH_SKEW
+```
+
+The alias entry is required (the fuzzy fallback in `from_string`
+keys off the substring `"clearance"` and would otherwise drop a skew
+rule_id through to `UNKNOWN`). The `#2521` precedent applies here
+verbatim — the same gotcha that bit `diffpair_length_skew`. The
+drift-prevention test at
+`tests/test_validate_match_group_length_skew.py` guards the round-trip.
+
+## Remediation when fired
+
+The violation's `details` field reports the offending member, its
+length, the reference length, and the excess. Three responses:
+
+1. **Re-route with `--length-match-groups`** — the tuner inserts
+   serpentines to converge (see guide 07).
+2. **Loosen tolerance** — raise `length_match_tolerance_mm` on the
+   class if the protocol budget allows.
+3. **Loosen cascade safety** — see guide 04 for the
+   `MAX_INSERTS_PER_GROUP_MEMBER_*` constants and the trade-offs.
+
+## See also
+
+- [04-cascade-safety.md](04-cascade-safety.md) — the rule fires on
+  residual skew that the tuner could not eliminate.
+- [07-cli-and-sidecar.md](07-cli-and-sidecar.md) — the standalone
+  `--net-class-map` workflow.

--- a/docs/guides/match-groups/07-cli-and-sidecar.md
+++ b/docs/guides/match-groups/07-cli-and-sidecar.md
@@ -1,0 +1,99 @@
+# 07 — CLI and JSON Sidecar Workflow
+
+End-to-end: route a board with match-group tuning enabled, then
+validate it standalone with the `--net-class-map` sidecar.
+
+Reference board: [`boards/07-matchgroup-test`](../../../boards/07-matchgroup-test/).
+
+## Route with match-group tuning
+
+```bash
+kct route board.kicad_pcb \
+    --differential-pairs \
+    --length-match-diffpairs \
+    --length-match-groups \
+    --seed 42 \
+    -o routed.kicad_pcb
+```
+
+The `--length-match-groups` flag (Epic #2661 Phase 3H, see
+`src/kicad_tools/cli/route_cmd.py:3475`) engages
+`Autorouter.apply_match_group_tuning` after routing completes.
+
+### Why both `--length-match-diffpairs` AND `--length-match-groups`
+
+The pipeline runs `--length-match-diffpairs` **first** (within-pair
+tuning) then `--length-match-groups` (cross-lane tuning) — see
+`route_cmd.py:5265-5270`. Order matters for MIPI/HDMI lane groups
+(guide 03): within-pair invariants must be established before
+cross-lane tuning can preserve them via symmetric serpentine
+insertion.
+
+If you only have single-ended buses (DDR data byte, parallel address
+bus, no diff pairs), you may pass `--length-match-groups` alone.
+
+### `--seed` for reproducibility
+
+The serpentine insertion uses `random` for tie-breaking when several
+candidate segments are equally good. `--seed` makes two runs of `kct
+route` produce byte-identical output (modulo UUIDs). Use it for CI
+regression baselines.
+
+## Standalone validation with `--net-class-map`
+
+When you check a routed PCB outside the `kct route` pipeline, the
+`match_group_length_skew` rule (guide 06) needs the group-membership
+map. Emit a JSON sidecar from your board generator (Issue #2684):
+
+```python
+from kicad_tools.router.rules import net_class_map_to_dict
+import json
+
+# After building net_class_map: dict[str, NetClassRouting]
+sidecar = net_class_map_to_dict(net_class_map)
+with open("net_class_map.json", "w") as f:
+    json.dump(sidecar, f, indent=2)
+```
+
+`net_class_map_to_dict` is at `src/kicad_tools/router/rules.py:1021`.
+Board 03 (`boards/03-usb-joystick/generate_design.py`) is the
+canonical emitter; board 07 follows the same pattern.
+
+Then validate:
+
+```bash
+kct check routed.kicad_pcb \
+    --mfr jlcpcb \
+    --net-class-map net_class_map.json
+```
+
+Without `--net-class-map`, the rule short-circuits to zero violations
+(the Phase 2.5G no-op semantic — see guide 06).
+
+## Putting it all together
+
+```bash
+# 1. Generate the board (your script emits net_class_map.json)
+python boards/07-matchgroup-test/generate_design.py
+
+# 2. Route with both length-match passes
+kct route boards/07-matchgroup-test/output/board.kicad_pcb \
+    --differential-pairs \
+    --length-match-diffpairs \
+    --length-match-groups \
+    --mfr jlcpcb \
+    --seed 42 \
+    -o boards/07-matchgroup-test/output/routed.kicad_pcb
+
+# 3. Validate standalone (e.g. in CI on a separate runner)
+kct check boards/07-matchgroup-test/output/routed.kicad_pcb \
+    --mfr jlcpcb \
+    --net-class-map boards/07-matchgroup-test/output/net_class_map.json
+```
+
+## See also
+
+- [01-declaring-groups.md](01-declaring-groups.md) — declare groups
+  so they show up in `net_class_map.json`.
+- [06-drc-rule.md](06-drc-rule.md) — what
+  `match_group_length_skew` checks and why the sidecar matters.

--- a/docs/guides/match-groups/README.md
+++ b/docs/guides/match-groups/README.md
@@ -1,0 +1,25 @@
+# Match-Group Length-Matching Guides
+
+Length-match a parallel-bus **group** (DDR data byte, MIPI lane group, HDMI
+TMDS, address bus) by configuring its **net class** on `NetClassRouting`
+— not by imperative `Router.method(...)` calls. The full feature set
+landed across Epic #2661 (Phases 1–3).
+
+## Which guide do I need?
+
+| If you want to… | Read |
+|---|---|
+| Declare a group (`length_match_group`, suffix detection, legacy API) | [01-declaring-groups.md](01-declaring-groups.md) |
+| Pick a length reference (longest / explicit / `clock`) | [02-reference-selection.md](02-reference-selection.md) |
+| Compose a group whose members are diff pairs (MIPI/HDMI) | [03-group-of-pairs.md](03-group-of-pairs.md) |
+| Understand why the tuner gave up (cascade-safety budget) | [04-cascade-safety.md](04-cascade-safety.md) |
+| Copy a working setup for DDR / MIPI / HDMI / address bus | [05-protocol-recipes.md](05-protocol-recipes.md) |
+| Understand the `match_group_length_skew` DRC rule | [06-drc-rule.md](06-drc-rule.md) |
+| Run the end-to-end CLI workflow + JSON sidecar | [07-cli-and-sidecar.md](07-cli-and-sidecar.md) |
+
+## Pair vs group
+
+A **pair** is N=2 (two coupled traces — see [diff-pairs](../diff-pairs/README.md)).
+A **group** is N>=3 (a parallel bus). Use a group when more than two nets
+must arrive within a shared skew tolerance. When the group's members are
+themselves pairs (MIPI lanes, HDMI TMDS), see guide 03.

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -208,6 +208,25 @@ The canonical pre-configured class is `NET_CLASS_HIGH_SPEED` in
 
 ---
 
+## Match Groups (Parallel Buses)
+
+Length-matching a parallel-bus **group** (DDR data byte, MIPI lane group,
+HDMI TMDS, address bus) is configured per net class on `NetClassRouting`
+— same pattern as diff pairs, but for N>=3 nets. See the dedicated
+guides under [`docs/guides/match-groups/`](match-groups/README.md):
+
+- [Declaring a group](match-groups/01-declaring-groups.md) (`length_match_group`, suffix detection, legacy API)
+- [Reference selection](match-groups/02-reference-selection.md) (longest / explicit / `clock`)
+- [Groups whose members are diff pairs](match-groups/03-group-of-pairs.md) (MIPI / HDMI)
+- [Cascade safety](match-groups/04-cascade-safety.md) (when the tuner gives up)
+- [Protocol recipes](match-groups/05-protocol-recipes.md) (DDR / MIPI / HDMI / address bus)
+- [DRC rule](match-groups/06-drc-rule.md) (`match_group_length_skew`)
+- [CLI + sidecar](match-groups/07-cli-and-sidecar.md) (`--length-match-groups`, `--net-class-map`)
+
+Engage from the CLI with `kct route --length-match-diffpairs --length-match-groups`.
+
+---
+
 ## Zone Awareness
 
 Handle copper pour zones:

--- a/tests/test_match_group_docs.py
+++ b/tests/test_match_group_docs.py
@@ -1,0 +1,227 @@
+"""Sanity tests for the match-group user-documentation set.
+
+Guards the doc/code coupling for ``docs/guides/match-groups/``:
+
+* the protocol recipes in ``05-protocol-recipes.md`` are valid Python that
+  produces ``NetClassRouting`` instances whose ``effective_length_match_*``
+  accessors return the values the recipe claims to demonstrate;
+* every ``match_group_*``-prefixed ``rule_id`` registered in
+  ``ViolationType``'s alias table is documented in ``06-drc-rule.md``
+  (forward direction), and every match-group ``rule_id`` documented in
+  ``06-drc-rule.md`` exists in the alias table (reverse direction);
+* the cascade-safety constants documented in ``04-cascade-safety.md``
+  match the live values in ``router/match_group_tuning.py``;
+* all seven guides are present;
+* each guide stays under the size cap (50 lines for README, 100 for the
+  numbered guides) so we keep the "don't create monster doc files"
+  invariant from Epic #2556 Phase 4M.
+
+Issue: #2725.  Epic: #2661 (Phase 3M).  Mirrors ``test_diffpair_docs.py``.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MATCH_GROUP_DOCS = REPO_ROOT / "docs" / "guides" / "match-groups"
+ROUTING_GUIDE = REPO_ROOT / "docs" / "guides" / "routing.md"
+
+
+def _read_python_code_blocks(md_path: Path) -> list[str]:
+    """Extract every ```python fenced block from a markdown file.
+
+    Blocks are returned in document order.  Indented code blocks and
+    other-language blocks are ignored.
+    """
+    text = md_path.read_text(encoding="utf-8")
+    pattern = re.compile(r"^```python\s*\n(.*?)^```\s*$", re.DOTALL | re.MULTILINE)
+    return [m.group(1) for m in pattern.finditer(text)]
+
+
+def test_protocol_recipes_compile() -> None:
+    """Each fenced ``python`` block in 05-protocol-recipes.md must:
+
+    1. execute end-to-end under ``exec()`` without raising,
+    2. construct at least one ``NetClassRouting`` instance, and
+    3. that instance's ``effective_length_match_tolerance()`` must return
+       a finite positive float (the recipes are about length-matching;
+       a recipe that constructs a ``NetClassRouting`` but forgets to set
+       ``length_match_tolerance_mm`` is broken).
+
+    Mirrors ``test_diffpair_docs.test_protocol_recipes_compile``.
+    """
+    from kicad_tools.router.rules import NetClassRouting
+
+    recipes_path = MATCH_GROUP_DOCS / "05-protocol-recipes.md"
+    blocks = _read_python_code_blocks(recipes_path)
+    assert len(blocks) >= 4, (
+        f"Expected at least 4 protocol recipes (DDR / MIPI / HDMI / "
+        f"address-bus), got {len(blocks)} in {recipes_path}"
+    )
+
+    for i, src in enumerate(blocks):
+        ns: dict[str, object] = {}
+        try:
+            exec(compile(src, f"{recipes_path}:block-{i}", "exec"), ns)
+        except Exception as e:  # noqa: BLE001
+            pytest.fail(f"Recipe block {i} failed to exec: {e!r}\n---\n{src}")
+
+        # At least one NetClassRouting must be constructed in the block.
+        ncrs = [v for v in ns.values() if isinstance(v, NetClassRouting)]
+        assert ncrs, f"Recipe block {i} produced no NetClassRouting instance:\n---\n{src}"
+
+        # Each NetClassRouting's effective_length_match_tolerance() must
+        # return a finite positive float.  This catches the failure mode
+        # where a recipe builds a NetClassRouting but forgets to set
+        # length_match_tolerance_mm.
+        for ncr in ncrs:
+            tol = ncr.effective_length_match_tolerance()
+            assert isinstance(tol, float) and math.isfinite(tol) and tol > 0.0, (
+                f"effective_length_match_tolerance() on {ncr.name!r} in "
+                f"block {i} returned non-finite/non-positive: {tol!r}"
+            )
+
+
+def _match_group_rule_ids_from_violation_alias_table() -> set[str]:
+    """Return every ``match_group_``-prefixed rule_id alias registered in
+    ``ViolationType``.
+
+    The enum values are the canonical CLI surface — adding a rule_id there
+    without doc coverage is the drift this test exists to prevent.
+    """
+    from kicad_tools.drc.violation import ViolationType
+
+    public_rule_ids: set[str] = set()
+    for vt in ViolationType:
+        v = vt.value
+        if isinstance(v, str) and v.startswith("match_group_"):
+            public_rule_ids.add(v)
+    return public_rule_ids
+
+
+def _rule_ids_documented_in_drc_guide() -> set[str]:
+    """Return every ``match_group_*`` rule_id referenced in 06-drc-rule.md.
+
+    A rule_id is recognized either as inline-code like
+    ``` `match_group_length_skew` ``` or as a ``--rules=<id>`` flag value.
+    """
+    doc_path = MATCH_GROUP_DOCS / "06-drc-rule.md"
+    text = doc_path.read_text(encoding="utf-8")
+    found = set(re.findall(r"`(match_group_[a-z_]+)`", text))
+    for m in re.finditer(r"--rules=([A-Za-z0-9_,]+)", text):
+        for token in m.group(1).split(","):
+            token = token.strip()
+            if token.startswith("match_group_"):
+                found.add(token)
+    return found
+
+
+def test_rule_ids_match_code() -> None:
+    """Bidirectional doc/code coupling for match-group DRC rule_ids.
+
+    * Forward: every ``match_group_*`` rule_id in the ``ViolationType``
+      enum must appear in ``06-drc-rule.md``.  Prevents a new DRC rule
+      from being added to the enum (and exposed on the CLI) without
+      documentation.
+    * Reverse: every match-group rule_id mentioned in
+      ``06-drc-rule.md`` must exist in ``ViolationType``.  Prevents
+      docs from advertising a fictional CLI flag.
+    """
+    code_ids = _match_group_rule_ids_from_violation_alias_table()
+    doc_ids = _rule_ids_documented_in_drc_guide()
+
+    missing_from_doc = code_ids - doc_ids
+    assert not missing_from_doc, (
+        f"rule_id(s) registered in ViolationType but not documented in "
+        f"06-drc-rule.md: {sorted(missing_from_doc)}.  Doc coverage is "
+        f"required before a rule_id can ship on the CLI."
+    )
+
+    missing_from_code = doc_ids - code_ids
+    assert not missing_from_code, (
+        f"rule_id(s) documented in 06-drc-rule.md but not present in "
+        f"ViolationType: {sorted(missing_from_code)}.  Either remove "
+        f"the doc reference or add the rule to the enum."
+    )
+
+
+def test_cascade_safety_constants_match_code() -> None:
+    """Cascade-safety constants in 04-cascade-safety.md match source.
+
+    Three constants in ``router/match_group_tuning.py`` govern when the
+    tuner gives up.  The doc must quote them verbatim with their current
+    values, so a future PR that tightens the budget cannot silently
+    leave docs stale.
+    """
+    from kicad_tools.router.match_group_tuning import (
+        MAX_INSERTS_PER_GROUP_MEMBER_LARGE,
+        MAX_INSERTS_PER_GROUP_MEMBER_SMALL,
+        MAX_TOTAL_INSERTS_PER_GROUP,
+    )
+
+    text = (MATCH_GROUP_DOCS / "04-cascade-safety.md").read_text(encoding="utf-8")
+    expected = [
+        f"MAX_INSERTS_PER_GROUP_MEMBER_SMALL={MAX_INSERTS_PER_GROUP_MEMBER_SMALL}",
+        f"MAX_INSERTS_PER_GROUP_MEMBER_LARGE={MAX_INSERTS_PER_GROUP_MEMBER_LARGE}",
+        f"MAX_TOTAL_INSERTS_PER_GROUP={MAX_TOTAL_INSERTS_PER_GROUP}",
+    ]
+    for token in expected:
+        assert token in text, (
+            f"Cascade-safety doc 04-cascade-safety.md is missing the "
+            f"literal token {token!r}.  When match_group_tuning.py "
+            f"updates a constant, this doc must be updated in the same PR."
+        )
+
+
+def test_no_stale_api_references() -> None:
+    """``docs/guides/routing.md`` does not reference dead match-group APIs.
+
+    Currently we don't have a known list of stale tokens for match
+    groups (the API has only ever been documented under
+    ``docs/guides/match-groups/``).  This test is a placeholder that
+    asserts ``routing.md`` references the match-groups guide directory
+    (the cross-link must exist) so future cleanups can't accidentally
+    delete it.
+    """
+    text = ROUTING_GUIDE.read_text(encoding="utf-8")
+    assert "match-groups/" in text, (
+        f"{ROUTING_GUIDE} no longer references the match-groups guide "
+        f"directory.  Add the cross-link back; the routing guide must "
+        f"point users to docs/guides/match-groups/."
+    )
+
+
+def test_all_guides_present() -> None:
+    """All seven guides + README exist under ``docs/guides/match-groups/``."""
+    expected = [
+        "README.md",
+        "01-declaring-groups.md",
+        "02-reference-selection.md",
+        "03-group-of-pairs.md",
+        "04-cascade-safety.md",
+        "05-protocol-recipes.md",
+        "06-drc-rule.md",
+        "07-cli-and-sidecar.md",
+    ]
+    for name in expected:
+        path = MATCH_GROUP_DOCS / name
+        assert path.is_file(), f"Missing required guide: {path}"
+
+
+def test_guide_length_caps() -> None:
+    """Each guide ≤ 100 lines; README ≤ 50 lines.
+
+    Enforces the epic's "don't create monster doc files" rule and the
+    curator's tightened acceptance criterion.  Counted as
+    newline-delimited lines (not "lines excluding code blocks") because
+    the former is what a reader actually scrolls through.
+    """
+    for path in sorted(MATCH_GROUP_DOCS.glob("*.md")):
+        limit = 50 if path.name == "README.md" else 100
+        n_lines = sum(1 for _ in path.open(encoding="utf-8"))
+        assert n_lines <= limit, f"{path} has {n_lines} lines, exceeds cap of {limit}"


### PR DESCRIPTION
## Summary

Adds user-facing documentation for the match-group length-matching
feature surface delivered across Epic #2661 (Phases 1-3). Mirrors the
docs/guides/diff-pairs/ pattern from Epic #2556 Phase 4M: seven small
per-concept guides + a decision-tree README + a drift-prevention test
file. Phase 3M of Epic #2661.

## Changes

- New directory docs/guides/match-groups/ with 8 files:
  - README.md (index + decision tree)
  - 01-declaring-groups.md (three detection paths in priority order)
  - 02-reference-selection.md (None / explicit / "clock")
  - 03-group-of-pairs.md (MIPI/HDMI symmetric serpentine, v2 tuner)
  - 04-cascade-safety.md (MAX_INSERTS_* constants, reason strings)
  - 05-protocol-recipes.md (DDR/MIPI/HDMI/address-bus blocks, all exec-able)
  - 06-drc-rule.md (match_group_length_skew + Phase 2.5G producer-side requirement)
  - 07-cli-and-sidecar.md (--length-match-groups + --net-class-map)
- docs/guides/routing.md: new "Match Groups" cross-link section after the diff-pair section.
- docs/guides/diff-pairs/README.md: one new decision-tree row pointing to ../match-groups/.
- tests/test_match_group_docs.py: six tests mirroring tests/test_diffpair_docs.py.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| AC#1: Seven files under docs/guides/match-groups/ | done | `test_all_guides_present` passes; README + 01..07 present |
| AC#2: routing.md links to match-groups | done | grep for `match-groups/` in routing.md returns the new section |
| AC#3: diff-pairs/README.md decision-tree row | done | one new row pointing to `../match-groups/README.md` |
| AC#4: protocol recipes are valid Python | done | `test_protocol_recipes_compile` exec()s all 4 blocks, each constructs a `NetClassRouting` with finite positive `effective_length_match_tolerance()` |
| AC#5: bidirectional rule_id coupling | done | `test_rule_ids_match_code` checks both directions (curator's tightened AC) |
| AC#6: board 07 referenced at most once per guide as a top callout | done | each guide mentions `boards/07-matchgroup-test` once (in a top-of-file Reference board: line) |
| AC#7: cascade-safety constants tracked | done | `test_cascade_safety_constants_match_code` asserts `MAX_INSERTS_PER_GROUP_MEMBER_SMALL=3`, `..._LARGE=2`, `MAX_TOTAL_INSERTS_PER_GROUP=16` literal tokens are present in 04-cascade-safety.md |
| AC#8 (curator): line caps enforced | done | `test_guide_length_caps` enforces 100/50 line limits; all eight files within budget |
| AC#9 (curator): presence test | done | `test_all_guides_present` checks every expected filename |

## Test Plan

- `uv run pytest tests/test_match_group_docs.py --no-cov` -> 6/6 pass
- `uv run pytest tests/test_diffpair_docs.py tests/test_match_group_docs.py --no-cov` -> 11/11 pass (no regression in diff-pair docs)
- `uv run ruff check tests/test_match_group_docs.py` -> clean
- `uv run ruff format tests/test_match_group_docs.py` -> formatted

Closes #2725