### PR TITLE
fix(build): all-power-nets guard fixes silent empty-route on board 01 (closes #2740)

### DIFF
--- a/src/kicad_tools/cli/build_cmd.py
+++ b/src/kicad_tools/cli/build_cmd.py
@@ -859,6 +859,21 @@ def _run_step_zones(ctx: BuildContext, console: Console) -> BuildResult:
     the same fill via ``kct zones fill``.  ``kct export`` also runs a
     safety-net fill if the PCB still has unfilled zones at export time
     (see :func:`export.gerber.GerberExporter._export_gerbers`).
+
+    All-power-board guard (issue #2740)
+    -----------------------------------
+
+    When *every* net on the board classifies as POWER or GROUND (e.g.
+    board 01-voltage-divider with VIN/VOUT/GND only), zone creation is
+    **skipped** entirely so the router can route those nets as ordinary
+    signals.  If zones were created instead, ``kct route``'s
+    ``_auto_skip_pour_nets`` would auto-skip every net (each has a zone),
+    ``nets_to_route`` would drop to 0, the router would report 100%
+    completion trivially, and the build would silently ship a PCB with
+    zero copper segments.  This guard mirrors the one in
+    :func:`kicad_tools.router.auto_pour.auto_pour_if_missing` and both
+    call sites share :func:`classify_pour_candidates` so the two cannot
+    drift again.
     """
     if not ctx.pcb_file or not ctx.pcb_file.exists():
         return BuildResult(
@@ -868,7 +883,7 @@ def _run_step_zones(ctx: BuildContext, console: Console) -> BuildResult:
         )
 
     try:
-        from kicad_tools.router.net_class import NetClass, auto_classify_nets
+        from kicad_tools.router.auto_pour import classify_pour_candidates
         from kicad_tools.schema.pcb import PCB
         from kicad_tools.zones.generator import auto_create_zones_for_pour_nets
 
@@ -886,21 +901,33 @@ def _run_step_zones(ctx: BuildContext, console: Console) -> BuildResult:
                 message="No nets found in PCB, skipping zone creation",
             )
 
-        # Classify nets
-        classifications = auto_classify_nets(net_names)
-
-        # Identify pour nets (POWER and GROUND)
-        pour_nets: list[tuple[str, NetClass]] = []
-        for net_id, classification in classifications.items():
-            if classification.net_class in (NetClass.POWER, NetClass.GROUND):
-                net_name = net_names[net_id]
-                pour_nets.append((net_name, classification.net_class))
+        # Classify nets and check the all-power-board guard.  This MUST
+        # match the guard in router.auto_pour.auto_pour_if_missing -- both
+        # call sites use the same helper to prevent drift.  See the
+        # function docstring for issue-#2740 context.
+        pour_nets, _signal_net_count, is_all_power_board = classify_pour_candidates(net_names)
 
         if not pour_nets:
             return BuildResult(
                 step="zones",
                 success=True,
                 message="No power/ground nets detected, skipping zone creation",
+            )
+
+        if is_all_power_board:
+            if not ctx.quiet:
+                console.print(
+                    "  All nets are power/ground "
+                    "(skipping zone creation — routing as signals instead)"
+                )
+            return BuildResult(
+                step="zones",
+                success=True,
+                message=(
+                    "All nets are power/ground; skipping zone creation so the "
+                    "router routes them as signals (see issue #2740)"
+                ),
+                output_file=ctx.pcb_file,
             )
 
         # Check for existing zones on these nets (idempotency)
@@ -1157,6 +1184,17 @@ def _run_step_route(ctx: BuildContext, console: Console) -> BuildResult:
         )
 
         if result.returncode == 0:
+            # Defense-in-depth postcondition (issue #2740): the router can
+            # silently "succeed" with zero segments when every multi-pad net
+            # is auto-skipped for zone fill but no traces are produced.
+            # Verify that the routed PCB actually contains copper when the
+            # input had routable signal nets.
+            postcondition = _check_route_postcondition(
+                input_pcb=ctx.pcb_file,
+                routed_pcb=output_file,
+            )
+            if postcondition is not None:
+                return postcondition
             return BuildResult(
                 step="route",
                 success=True,
@@ -1196,6 +1234,121 @@ def _run_step_route(ctx: BuildContext, console: Console) -> BuildResult:
             success=False,
             message=f"Routing failed: {e}",
         )
+
+
+def _count_multi_pad_signal_nets(input_pcb: Path) -> int:
+    """Return the count of nets that need routing (>=2 pads, not pour-only).
+
+    Used by :func:`_check_route_postcondition` to decide whether a
+    "success exit, zero segments" result from ``kct route`` is plausible
+    (no signal nets to route) or pathological (silent empty output --
+    issue #2740).
+
+    A net counts as routable if:
+
+    * It is referenced by at least two pads in the PCB, AND
+    * It is *not* a pure pour net with an existing zone (those nets
+      get connected via copper fill rather than traces, so zero
+      segments on them is legitimate).
+
+    A POWER/GROUND net **without** a zone is still counted -- such nets
+    must be routed as signal traces (see :func:`route_cmd._auto_skip_pour_nets`
+    and the ``_pour_nets_without_zones`` carve-out from issue #1841).
+
+    Args:
+        input_pcb: Path to the unrouted PCB the router consumed.
+
+    Returns:
+        Number of nets the router was expected to produce segments for.
+        Returns 0 if the file cannot be parsed (postcondition then
+        cannot fire -- best-effort).
+    """
+    try:
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.load(str(input_pcb))
+
+        # Count pads per net.
+        pad_counts: dict[int, int] = {}
+        for fp in pcb.footprints:
+            for pad in fp.pads:
+                if pad.net_number > 0:
+                    pad_counts[pad.net_number] = pad_counts.get(pad.net_number, 0) + 1
+
+        # Determine which nets have zones (pour-handled, segments not required).
+        zone_net_names = {z.net_name for z in pcb.zones if z.net_name}
+
+        # Build net_number -> net_name lookup.
+        nets_with_zones: set[int] = set()
+        for net_id, net in pcb.nets.items():
+            if net.name and net.name in zone_net_names:
+                nets_with_zones.add(net_id)
+
+        # Count multi-pad nets that lack a zone (so must be routed as signals).
+        return sum(
+            1
+            for net_id, count in pad_counts.items()
+            if count >= 2 and net_id not in nets_with_zones
+        )
+    except Exception:
+        return 0
+
+
+def _check_route_postcondition(
+    input_pcb: Path | None,
+    routed_pcb: Path | None,
+) -> BuildResult | None:
+    """Validate that ``kct route``'s successful exit produced real copper.
+
+    Defense-in-depth check for issue #2740.  The router can exit 0 with
+    ``completion = 1.0`` when every multi-pad net is auto-skipped as a
+    pour net (``nets_to_route`` becomes 0 -> the
+    ``nets_routed / nets_to_route if nets_to_route > 0 else 1.0`` ternary
+    in :mod:`kicad_tools.cli.route_cmd` returns 1.0).  Without this
+    postcondition the build pipeline would proceed to verify/export with
+    an electrically empty PCB and the only symptom would be
+    ``zone_unfilled`` warnings (severity = warning, not error).
+
+    Returns a *failure* :class:`BuildResult` when:
+
+    * The input PCB had at least one multi-pad signal net (so routing
+      should produce >=1 segment), AND
+    * The routed PCB exists and contains zero segments AND zero vias.
+
+    Returns ``None`` (i.e., "postcondition OK, continue") otherwise --
+    including when the input PCB has no routable signal nets (small
+    designs where every net is poured), when files are missing (handled
+    by upstream callers), or when the PCB cannot be parsed.
+    """
+    if not input_pcb or not routed_pcb or not routed_pcb.exists():
+        return None
+
+    expected = _count_multi_pad_signal_nets(input_pcb)
+    if expected == 0:
+        return None  # No signal nets to route -- zero segments is legitimate
+
+    try:
+        from kicad_tools.schema.pcb import PCB
+
+        routed = PCB.load(str(routed_pcb))
+        segment_count = len(routed.segments)
+        via_count = len(routed.vias)
+    except Exception:
+        return None  # Best-effort: parse failure should not break the build
+
+    if segment_count == 0 and via_count == 0:
+        return BuildResult(
+            step="route",
+            success=False,
+            message=(
+                f"Route step exited 0 but produced 0 segments and 0 vias "
+                f"for {expected} routable signal net(s).  This indicates a "
+                f"silent router failure (see issue #2740 -- the build will "
+                f"not ship an electrically empty PCB)."
+            ),
+            output_file=routed_pcb,
+        )
+    return None
 
 
 def _run_step_verify(ctx: BuildContext, console: Console) -> BuildResult:

--- a/src/kicad_tools/router/auto_pour.py
+++ b/src/kicad_tools/router/auto_pour.py
@@ -72,6 +72,64 @@ def _is_erc_marker_net(name: str) -> bool:
     return any(re.match(p, name) for p in ERC_MARKER_NET_PATTERNS)
 
 
+def classify_pour_candidates(
+    net_names: dict[int, str],
+):
+    """Classify a board's nets into pour candidates and signal nets.
+
+    Shared helper used by both :func:`auto_pour_if_missing` and the
+    ``kct build`` zones step (:func:`kicad_tools.cli.build_cmd._run_step_zones`).
+    Both call sites must agree on the all-power-board guard so a board
+    whose only nets are POWER/GROUND is *never* given zones for every
+    net -- doing so converts every net into a pour-skip target and the
+    router then has nothing to route (see issue #2740).
+
+    Args:
+        net_names: Mapping of net id -> net name from the PCB file.
+
+    Returns:
+        A 3-tuple ``(pour_nets, signal_net_count, is_all_power_board)``:
+
+        * ``pour_nets`` -- list of ``(name, NetClass)`` tuples for nets
+          classified as POWER or GROUND, excluding ERC-marker nets such
+          as ``PWR_FLAG`` (which carry no copper).
+        * ``signal_net_count`` -- count of nets that are *not* pour
+          candidates (i.e., not POWER/GROUND, not ERC markers, or
+          unclassified).  Used by the all-power-board guard.
+        * ``is_all_power_board`` -- True when ``pour_nets`` is non-empty
+          and ``signal_net_count == 0``.  Callers should skip zone
+          creation entirely when this is True so the router can route
+          every net as a signal.
+    """
+    from kicad_tools.router.net_class import NetClass, auto_classify_nets
+
+    classifications = auto_classify_nets(net_names)
+
+    pour_nets: list[tuple[str, NetClass]] = []
+    signal_net_count = 0
+    for net_id, classification in classifications.items():
+        net_name = net_names[net_id]
+        # ERC-marker nets (PWR_FLAG and friends) carry no copper; the
+        # name-based classifier reports them as POWER but they must not
+        # be poured.  Treat them as if they did not exist for the
+        # all-power guard below -- a board whose only "power" net is
+        # PWR_FLAG should not be mistaken for a power-only design.
+        if _is_erc_marker_net(net_name):
+            continue
+        if classification.net_class in (NetClass.POWER, NetClass.GROUND):
+            pour_nets.append((net_name, classification.net_class))
+        else:
+            signal_net_count += 1
+
+    # Count unclassified nets (those that didn't meet confidence threshold)
+    # as signal nets -- they are certainly not power/ground.
+    unclassified = len(net_names) - len(classifications)
+    signal_net_count += unclassified
+
+    is_all_power_board = bool(pour_nets) and signal_net_count == 0
+    return pour_nets, signal_net_count, is_all_power_board
+
+
 def _detect_uninset_zones(
     pcb_path: Path,
     edge_clearance: float,
@@ -243,7 +301,6 @@ def auto_pour_if_missing(
         Tuple of ``(zones_created, pour_net_names)`` where
         *pour_net_names* lists the nets that received new zones.
     """
-    from kicad_tools.router.net_class import NetClass, auto_classify_nets
     from kicad_tools.zones.generator import auto_create_zones_for_pour_nets
 
     pcb_path = Path(pcb_path)
@@ -262,30 +319,17 @@ def auto_pour_if_missing(
         return 0, []
 
     # ------------------------------------------------------------------
-    # 2. Classify nets
+    # 2. Classify nets + apply all-power-board guard
     # ------------------------------------------------------------------
-    classifications = auto_classify_nets(net_names)
-
-    pour_nets: list[tuple[str, NetClass]] = []
-    signal_net_count = 0
-    for net_id, classification in classifications.items():
-        net_name = net_names[net_id]
-        # ERC-marker nets (PWR_FLAG and friends) carry no copper; the
-        # name-based classifier reports them as POWER but they must not
-        # be poured.  Treat them as if they did not exist for the
-        # all-power guard below -- a board whose only "power" net is
-        # PWR_FLAG should not be mistaken for a power-only design.
-        if _is_erc_marker_net(net_name):
-            continue
-        if classification.net_class in (NetClass.POWER, NetClass.GROUND):
-            pour_nets.append((net_name, classification.net_class))
-        else:
-            signal_net_count += 1
-
-    # Count unclassified nets (those that didn't meet confidence threshold)
-    # as signal nets -- they are certainly not power/ground.
-    unclassified = len(net_names) - len(classifications)
-    signal_net_count += unclassified
+    # NOTE: the all-power guard must mirror the one in
+    # :func:`kicad_tools.cli.build_cmd._run_step_zones` (kct build's
+    # zone-creation step).  Both call sites share ``classify_pour_candidates``
+    # so the two cannot drift.  Drifting once caused issue #2740, where
+    # ``kct build`` created zones for every net on board 01 (VIN/VOUT/GND
+    # all-power), the auto-skip step then skipped every net as a pour
+    # net, ``nets_to_route`` became 0, the router reported 100%
+    # completion trivially, and the build silently shipped an empty PCB.
+    pour_nets, _signal_net_count, is_all_power_board = classify_pour_candidates(net_names)
 
     if not pour_nets:
         return 0, []
@@ -293,7 +337,7 @@ def auto_pour_if_missing(
     # ------------------------------------------------------------------
     # 3. Board-level guard: skip if ALL nets are power/ground
     # ------------------------------------------------------------------
-    if signal_net_count == 0:
+    if is_all_power_board:
         if not quiet:
             print("Auto-pour: skipped (all nets are power/ground — routing as signals instead)")
         return 0, []

--- a/tests/test_build_zones_step.py
+++ b/tests/test_build_zones_step.py
@@ -29,6 +29,40 @@ MINIMAL_PCB = """\
   (net 0 "")
   (net 1 "GND")
   (net 2 "+3.3V")
+  (net 3 "SDA")
+  (gr_rect
+    (start 0 0)
+    (end 50 50)
+    (stroke (width 0.15) (type solid))
+    (fill none)
+    (layer "Edge.Cuts")
+    (uuid "edge-uuid")
+  )
+)
+"""
+
+# Board where every net classifies as POWER or GROUND (issue #2740).
+# The build pipeline must SKIP zone creation entirely on such boards so
+# the router can route VIN/VOUT/GND as ordinary signal traces.  Without
+# this guard, _auto_skip_pour_nets in route_cmd would skip every net,
+# nets_to_route would drop to 0, and the router would silently emit a
+# PCB with zero copper.
+MINIMAL_PCB_ALL_POWER = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "kicad")
+  (general
+    (thickness 1.6)
+  )
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "VIN")
+  (net 2 "VOUT")
+  (net 3 "GND")
   (gr_rect
     (start 0 0)
     (end 50 50)
@@ -81,6 +115,7 @@ MINIMAL_PCB_AGND = """\
   (net 0 "")
   (net 1 "AGND")
   (net 2 "+3.3V")
+  (net 3 "SDA")
   (gr_rect
     (start 0 0)
     (end 50 50)
@@ -121,9 +156,17 @@ MINIMAL_PCB_GND_ONLY = """\
 
 @pytest.fixture
 def pcb_with_power(tmp_path: Path) -> Path:
-    """PCB containing GND and +3.3V nets."""
+    """PCB containing GND, +3.3V, and one signal net (SDA)."""
     p = tmp_path / "board.kicad_pcb"
     p.write_text(MINIMAL_PCB)
+    return p
+
+
+@pytest.fixture
+def pcb_all_power(tmp_path: Path) -> Path:
+    """PCB whose only nets are VIN/VOUT/GND (all-power board, issue #2740)."""
+    p = tmp_path / "board.kicad_pcb"
+    p.write_text(MINIMAL_PCB_ALL_POWER)
     return p
 
 
@@ -432,3 +475,286 @@ class TestRunStepZonesEdgeClearance:
             assert max(xs) >= 49.99
             assert min(ys) <= 0.01
             assert max(ys) >= 49.99
+
+
+# ---------------------------------------------------------------------------
+# All-power-board guard (issue #2740)
+# ---------------------------------------------------------------------------
+
+
+class TestAllPowerBoardGuard:
+    """Regression test for issue #2740 — board 01 silent empty-route.
+
+    On boards where every net classifies as POWER or GROUND (e.g.
+    01-voltage-divider with VIN/VOUT/GND), ``_run_step_zones`` MUST
+    skip zone creation so the router routes those nets as signal
+    traces.  Without this guard, ``kct route``'s ``_auto_skip_pour_nets``
+    skips every net (each has a zone), ``nets_to_route`` drops to 0,
+    the router hard-codes completion = 1.0 and exits 0, and the build
+    silently ships a PCB with zero copper segments.
+
+    The guard mirrors the one in
+    :func:`kicad_tools.router.auto_pour.auto_pour_if_missing` and both
+    call sites share :func:`classify_pour_candidates`.
+    """
+
+    def test_all_power_board_skips_zone_creation(self, pcb_all_power: Path):
+        """VIN/VOUT/GND-only board must not get zones from kct build."""
+        ctx = _make_ctx(pcb_file=pcb_all_power)
+        result = _run_step_zones(ctx, Console())
+
+        assert result.success is True
+        assert "skipping zone creation" in result.message.lower()
+        assert "#2740" in result.message or "power/ground" in result.message.lower()
+
+        # Critical postcondition: NO zones on disk.
+        pcb = PCB.load(str(pcb_all_power))
+        assert len(pcb.zones) == 0, (
+            "All-power board must have zero zones so the router can route "
+            "every net as a signal (see issue #2740)."
+        )
+
+    def test_all_power_guard_mirrors_auto_pour(self, pcb_all_power: Path):
+        """Both call sites must agree the board is all-power.
+
+        Drift between :func:`_run_step_zones` and
+        :func:`auto_pour_if_missing` was the root cause of issue #2740.
+        Both now share ``classify_pour_candidates`` so they cannot drift.
+        """
+        from kicad_tools.router.auto_pour import (
+            auto_pour_if_missing,
+            classify_pour_candidates,
+        )
+
+        # Shared helper agrees this is an all-power board.
+        net_names = {1: "VIN", 2: "VOUT", 3: "GND"}
+        _pour, _signal_count, is_all_power = classify_pour_candidates(net_names)
+        assert is_all_power is True
+
+        # auto_pour_if_missing also skips this board.
+        count, names = auto_pour_if_missing(pcb_all_power)
+        assert count == 0
+        assert names == []
+        # And the file is unchanged.
+        pcb = PCB.load(str(pcb_all_power))
+        assert len(pcb.zones) == 0
+
+    def test_mixed_board_still_creates_zones(self, pcb_with_power: Path):
+        """A board with power/ground + signal nets must still get zones.
+
+        Guards against over-correction: the all-power guard must only
+        fire when every classified net is POWER or GROUND.  MINIMAL_PCB
+        contains GND + +3.3V + SDA, so the guard must NOT fire.
+        """
+        ctx = _make_ctx(pcb_file=pcb_with_power)
+        result = _run_step_zones(ctx, Console())
+
+        assert result.success is True
+        assert "created" in result.message.lower()
+
+        pcb = PCB.load(str(pcb_with_power))
+        # 2 zones expected: GND and +3.3V.  SDA has no zone (it's signal).
+        zone_nets = {z.net_name for z in pcb.zones}
+        assert "GND" in zone_nets
+        assert "+3.3V" in zone_nets
+        assert "SDA" not in zone_nets
+
+
+# ---------------------------------------------------------------------------
+# Route-step postcondition (issue #2740 defense-in-depth)
+# ---------------------------------------------------------------------------
+
+
+class TestRouteStepPostcondition:
+    """Tests for :func:`build_cmd._check_route_postcondition`.
+
+    This postcondition catches the "silent green empty PCB" failure mode
+    where ``kct route`` exits 0 with ``completion = 1.0`` because every
+    routable net was auto-skipped (yielding ``nets_to_route == 0``).
+    See issue #2740.
+    """
+
+    @staticmethod
+    def _pcb_with_pads_no_traces(tmp_path: Path) -> tuple[Path, Path]:
+        """Build an input/output pair representing the empty-route regression.
+
+        Returns (input_pcb, routed_pcb) where:
+        - input_pcb has 3 multi-pad signal nets and zero zones
+          (so the postcondition expects segments to be produced).
+        - routed_pcb is byte-identical (zero segments, zero vias),
+          simulating the silent-success path.
+        """
+        # Minimal PCB with two footprints sharing 3 nets via pads.
+        # Each net has 2 pads => 3 multi-pad signal nets to route.
+        pcb_text = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "kicad")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "VIN")
+  (net 2 "VOUT")
+  (net 3 "GND")
+  (gr_rect
+    (start 0 0)
+    (end 50 50)
+    (stroke (width 0.15) (type solid))
+    (fill none)
+    (layer "Edge.Cuts")
+    (uuid "edge-uuid")
+  )
+  (footprint "Test:U1"
+    (layer "F.Cu")
+    (at 10 10)
+    (uuid "fp1-uuid")
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "VIN"))
+    (pad "2" smd rect (at 2 0) (size 1 1) (layers "F.Cu") (net 2 "VOUT"))
+    (pad "3" smd rect (at 4 0) (size 1 1) (layers "F.Cu") (net 3 "GND"))
+  )
+  (footprint "Test:U2"
+    (layer "F.Cu")
+    (at 30 10)
+    (uuid "fp2-uuid")
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "VIN"))
+    (pad "2" smd rect (at 2 0) (size 1 1) (layers "F.Cu") (net 2 "VOUT"))
+    (pad "3" smd rect (at 4 0) (size 1 1) (layers "F.Cu") (net 3 "GND"))
+  )
+)
+"""
+        input_pcb = tmp_path / "input.kicad_pcb"
+        input_pcb.write_text(pcb_text)
+        routed_pcb = tmp_path / "input_routed.kicad_pcb"
+        routed_pcb.write_text(pcb_text)  # Same content == zero segments produced.
+        return input_pcb, routed_pcb
+
+    def test_postcondition_fails_when_zero_segments_for_routable_nets(self, tmp_path: Path):
+        """Routed PCB with 0 segments + 0 vias for >=1 signal net must fail."""
+        from kicad_tools.cli.build_cmd import _check_route_postcondition
+
+        input_pcb, routed_pcb = self._pcb_with_pads_no_traces(tmp_path)
+        result = _check_route_postcondition(input_pcb=input_pcb, routed_pcb=routed_pcb)
+
+        assert result is not None, "Postcondition must fail on empty routed PCB"
+        assert result.success is False
+        assert "0 segments" in result.message
+        assert "#2740" in result.message
+
+    def test_postcondition_ok_when_no_routable_signal_nets(self, tmp_path: Path):
+        """No multi-pad signal nets in the input => zero segments is fine."""
+        from kicad_tools.cli.build_cmd import _check_route_postcondition
+
+        # Single-pad-per-net PCB: no multi-pad nets => nothing to route.
+        pcb_text = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "kicad")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "VCC")
+  (gr_rect
+    (start 0 0)
+    (end 10 10)
+    (stroke (width 0.15) (type solid))
+    (fill none)
+    (layer "Edge.Cuts")
+    (uuid "e")
+  )
+  (footprint "Test:U1"
+    (layer "F.Cu")
+    (at 1 1)
+    (uuid "fp1")
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "VCC"))
+  )
+)
+"""
+        input_pcb = tmp_path / "input.kicad_pcb"
+        input_pcb.write_text(pcb_text)
+        routed_pcb = tmp_path / "input_routed.kicad_pcb"
+        routed_pcb.write_text(pcb_text)
+
+        result = _check_route_postcondition(input_pcb=input_pcb, routed_pcb=routed_pcb)
+        # No multi-pad signal nets => postcondition cannot fire.
+        assert result is None
+
+    def test_postcondition_ok_when_all_nets_have_zones(self, tmp_path: Path):
+        """All multi-pad nets are pour-handled with zones => 0 segments is fine."""
+        from kicad_tools.cli.build_cmd import _check_route_postcondition
+
+        pcb_text = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "kicad")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (gr_rect
+    (start 0 0)
+    (end 50 50)
+    (stroke (width 0.15) (type solid))
+    (fill none)
+    (layer "Edge.Cuts")
+    (uuid "e")
+  )
+  (footprint "Test:U1"
+    (layer "F.Cu")
+    (at 10 10)
+    (uuid "fp1")
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "GND"))
+  )
+  (footprint "Test:U2"
+    (layer "F.Cu")
+    (at 30 10)
+    (uuid "fp2")
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "GND"))
+  )
+  (zone
+    (net 1)
+    (net_name "GND")
+    (layer "B.Cu")
+    (uuid "z1")
+    (hatch edge 0.5)
+    (connect_pads (clearance 0.25))
+    (min_thickness 0.25)
+    (fill yes)
+    (polygon
+      (pts
+        (xy 0 0) (xy 50 0) (xy 50 50) (xy 0 50)
+      )
+    )
+  )
+)
+"""
+        input_pcb = tmp_path / "input.kicad_pcb"
+        input_pcb.write_text(pcb_text)
+        routed_pcb = tmp_path / "input_routed.kicad_pcb"
+        routed_pcb.write_text(pcb_text)
+
+        result = _check_route_postcondition(input_pcb=input_pcb, routed_pcb=routed_pcb)
+        # GND has a zone => pour-handled => postcondition does not fire.
+        assert result is None
+
+    def test_postcondition_ok_with_missing_files(self, tmp_path: Path):
+        """Missing files => postcondition returns None (best-effort)."""
+        from kicad_tools.cli.build_cmd import _check_route_postcondition
+
+        result = _check_route_postcondition(input_pcb=None, routed_pcb=None)
+        assert result is None
+
+        nonexistent = tmp_path / "ghost.kicad_pcb"
+        result = _check_route_postcondition(input_pcb=nonexistent, routed_pcb=nonexistent)
+        assert result is None


### PR DESCRIPTION
## Summary

Closes #2740 — board 01-voltage-divider (the gold-standard baseline) was silently producing an electrically empty PCB while `kct build` reported success.

### Root cause (confirmed)

`_run_step_zones` in `src/kicad_tools/cli/build_cmd.py` lacked the all-power-nets guard that `auto_pour_if_missing` in `src/kicad_tools/router/auto_pour.py` already had. On VIN/VOUT/GND-only boards, this two-pipeline mismatch produced:

1. `kct build` zones step created zones for every net (no signal-net check).
2. `kct route._auto_skip_pour_nets` skipped every net (each had a zone).
3. `nets_to_route = 0` → router hard-coded `completion = 1.0` (`route_cmd.py:1694`) → exit 0.
4. Zone-fill gated on `nets_routed > 0` → zones stayed unfilled.
5. DRC saw only `zone_unfilled` *warnings* (severity = warning, not error).
6. Build proceeded to verify/export and shipped an empty manufacturing package.

### Fix

**Primary**: extracted the classification + all-power guard into `classify_pour_candidates()` in `auto_pour.py`. Both call sites (`auto_pour_if_missing` and `_run_step_zones`) now share the same helper so they cannot drift again. When every classified net is POWER/GROUND, zone creation is skipped entirely and the router routes them as signals.

**Defense-in-depth**: `_check_route_postcondition()` in `build_cmd.py` validates that a successful `kct route` exit actually produced copper. If the input PCB had `>=1` multi-pad signal net and the routed PCB has `0 segments + 0 vias`, the route step now fails with a clear message rather than letting the empty PCB slip through verify/export.

### Verification

- Board 01 (`uv run kct build boards/01-voltage-divider --mfr jlcpcb`):
  - VIN: 3 segments, VOUT: 3 segments, GND: 6 segments + 2 vias
  - 0 DRC errors, 0 `zone_unfilled` warnings (4 `pad_grid` warnings pre-existing, out of scope)
  - Build exit 0
- Standalone `kct route` on board 01: 3/3 nets, 24 segments + 3 vias.
- Mixed boards (board 02, etc.) still create zones for power+ground when signal nets are present — the guard only fires when every classified net is POWER/GROUND.

### Acceptance criteria status

- [x] Routed PCB has `>= 1` segment per VIN/VOUT/GND.
- [x] Zero `(zone ...)` blocks on disk for board 01 (fix variant (a) from the curator note).
- [x] `kct check` reports 0 errors and 0 `zone_unfilled` warnings.
- [x] `kct build` postcondition fails when 0 segments produced for routable nets.
- [x] Boards 01..05 zone step still functions correctly (board 02-05 zone creation unaffected; board 02's route_demo.py failure is a pre-existing issue unrelated to #2740).
- [x] Regression tests added in `tests/test_build_zones_step.py`:
  - `TestAllPowerBoardGuard` (3 tests)
  - `TestRouteStepPostcondition` (4 tests)
- [x] Standalone `kct route` on board 01 produces 3/3 routed nets.
- [x] Docstrings on `_run_step_zones`, `classify_pour_candidates`, `_check_route_postcondition`, and `_count_multi_pad_signal_nets` document the guard and link the two call sites.

### Out of scope (filed as follow-ups, recommended by curator)

- Promoting `zone_unfilled` from warning to error in DRC (policy decision, intersects with manufacturer-specific rules).
- Adding an explicit "100% trivially" vs "100% successfully" distinction in `route_cmd.py` when `nets_to_route == 0`.

## Test plan

- [x] `uv run python -m pytest tests/test_auto_pour.py tests/test_build_zones_step.py` → 44 passed.
- [x] `uv run python -m pytest tests/test_route_cmd_zone_fill.py tests/test_route_cmd_input_preservation.py` → 17 passed.
- [x] `uv run kct build boards/01-voltage-divider --mfr jlcpcb` → success + 12 segments + 2 vias + 0 zones.
- [x] `uv run kct check boards/01-voltage-divider/output/voltage_divider_routed.kicad_pcb --mfr jlcpcb` → 0 errors.
- [x] `uv run kct route boards/01-voltage-divider/output/voltage_divider.kicad_pcb` → 3/3 routed.
- [x] `uv run ruff format --check` + `uv run ruff check` on changed files → clean.