### PR TITLE
fix(export): fail-fast when sibling schematic missing (closes #2741)

### DIFF
--- a/src/kicad_tools/export/assembly.py
+++ b/src/kicad_tools/export/assembly.py
@@ -11,7 +11,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
-from kicad_tools.exceptions import ValidationError
 
 from .bom_enrich import EnrichmentReport, enrich_bom_lcsc
 from .bom_formats import BOMExportConfig, export_bom, read_existing_lcsc_assignments
@@ -144,6 +143,13 @@ class AssemblyPackage:
                            If not provided, will look for same name as PCB
             manufacturer: Manufacturer ID (jlcpcb, pcbway, etc.)
             config: Assembly configuration
+
+        Raises:
+            KiCadFileNotFoundError: when the PCB file does not exist, or when
+                the schematic cannot be auto-discovered and the configured
+                ``bom_source`` requires one (i.e. anything other than
+                ``"pcb"``).  Failing fast here avoids generating a partial
+                manufacturing package (Gerbers + CPL but no BOM) on disk.
         """
         self.pcb_path = Path(pcb_path)
         if not self.pcb_path.exists():
@@ -152,6 +158,9 @@ class AssemblyPackage:
                 context={"file": str(pcb_path)},
                 suggestions=["Check that the file path is correct"],
             )
+
+        self.manufacturer = manufacturer.lower()
+        self.config = config or AssemblyConfig()
 
         # Find schematic
         if schematic_path:
@@ -165,8 +174,37 @@ class AssemblyPackage:
             logger.warning(f"Schematic not found: {self.schematic_path}")
             self.schematic_path = None
 
-        self.manufacturer = manufacturer.lower()
-        self.config = config or AssemblyConfig()
+        # Fail-fast when the schematic is required for the configured
+        # BOM source.  Without this guard ``export`` would still produce
+        # Gerbers/CPL/Report/ProjectZip/Manifest before ``_generate_bom``
+        # raised -- leaving a partial (and easily misread) package on disk.
+        if (
+            self.config.include_bom
+            and self.schematic_path is None
+            and self.config.bom_source != "pcb"
+        ):
+            from kicad_tools.report.utils import (
+                SCHEMATIC_STRIP_SUFFIXES,
+                schematic_candidate_paths,
+            )
+
+            candidates = schematic_candidate_paths(self.pcb_path)
+            raise KiCadFileNotFoundError(
+                "Schematic file not found for BOM generation",
+                context={
+                    "pcb": str(self.pcb_path),
+                    "pcb_stem": self.pcb_path.stem,
+                    "search_dir": str(self.pcb_path.parent),
+                    "bom_source": self.config.bom_source,
+                    "strip_suffixes": list(SCHEMATIC_STRIP_SUFFIXES),
+                    "candidates_tried": [str(c) for c in candidates],
+                },
+                suggestions=[
+                    "Pass --sch <path-to-.kicad_sch> to point at the schematic explicitly",
+                    "Use --bom-source pcb to generate the BOM from PCB footprints",
+                    "Use --no-bom to skip BOM generation entirely",
+                ],
+            )
 
     @classmethod
     def create(
@@ -270,12 +308,26 @@ class AssemblyPackage:
         else:
             # Default: schematic source
             if not self.schematic_path:
-                raise ValidationError(
-                    ["Schematic path required for BOM generation"],
-                    context={"pcb": str(self.pcb_path)},
+                from kicad_tools.report.utils import (
+                    SCHEMATIC_STRIP_SUFFIXES,
+                    schematic_candidate_paths,
+                )
+
+                candidates = schematic_candidate_paths(self.pcb_path)
+                raise KiCadFileNotFoundError(
+                    "Schematic file not found for BOM generation",
+                    context={
+                        "pcb": str(self.pcb_path),
+                        "pcb_stem": self.pcb_path.stem,
+                        "search_dir": str(self.pcb_path.parent),
+                        "bom_source": bom_source,
+                        "strip_suffixes": list(SCHEMATIC_STRIP_SUFFIXES),
+                        "candidates_tried": [str(c) for c in candidates],
+                    },
                     suggestions=[
-                        "Provide a schematic file path when creating the AssemblyPackage",
-                        "Use --bom-source pcb to generate BOM from PCB footprints instead",
+                        "Pass --sch <path-to-.kicad_sch> to point at the schematic explicitly",
+                        "Use --bom-source pcb to generate the BOM from PCB footprints",
+                        "Use --no-bom to skip BOM generation entirely",
                     ],
                 )
 
@@ -308,9 +360,7 @@ class AssemblyPackage:
                             logger.info(line)
                         # Collect refs that got an LCSC from spec
                         spec_refs = {
-                            e.reference
-                            for e in overlay_report.entries
-                            if e.matched and e.lcsc
+                            e.reference for e in overlay_report.entries if e.matched and e.lcsc
                         }
             except Exception as e:
                 logger.warning(f"Spec overlay failed (continuing without): {e}")
@@ -448,9 +498,7 @@ class AssemblyPackage:
 
             sch_bom = extract_bom(self.schematic_path)
             sch_refs = {
-                item.reference
-                for item in sch_bom.items
-                if not item.is_virtual and not item.dnp
+                item.reference for item in sch_bom.items if not item.is_virtual and not item.dnp
             }
 
             # Compute mismatch

--- a/src/kicad_tools/export/manufacturing.py
+++ b/src/kicad_tools/export/manufacturing.py
@@ -18,6 +18,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import kicad_tools
+from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 
 from .assembly import AssemblyConfig, AssemblyPackage, AssemblyPackageResult
 from .preflight import PreflightChecker, PreflightConfig, PreflightResult
@@ -270,6 +271,24 @@ class ManufacturingPackage:
         if dry_run:
             return self._dry_run(out_dir, result)
 
+        # Pre-construct the assembly package so we surface fatal input
+        # errors (e.g. a schematic-sourced BOM with no discoverable
+        # .kicad_sch) *before* preflight runs or we create any output
+        # files.  This guarantees that a schematic-missing failure
+        # leaves nothing on disk -- avoiding the "5/8 files written,
+        # exit code 1, partial package" gap.
+        try:
+            AssemblyPackage(
+                pcb_path=self.pcb_path,
+                schematic_path=self.schematic_path,
+                manufacturer=self.manufacturer,
+                config=self.config,
+            )
+        except KiCadFileNotFoundError as e:
+            result.errors.append(f"Assembly generation failed: {e}")
+            logger.error(f"Assembly generation failed: {e}")
+            return result
+
         # Step 0: Pre-flight validation
         preflight_cfg = self.config.preflight
         if preflight_cfg is None or not preflight_cfg.skip_all:
@@ -316,8 +335,14 @@ class ManufacturingPackage:
 
         out_dir.mkdir(parents=True, exist_ok=True)
 
-        # Step 1: BOM + CPL + Gerbers via AssemblyPackage
-        self._generate_assembly(out_dir, result)
+        # Step 1: BOM + CPL + Gerbers via AssemblyPackage.  When this
+        # returns False the stage aborted before writing any artefacts
+        # (e.g. schematic missing for a schematic-sourced BOM), so we
+        # skip the rest of the pipeline to avoid producing a partial
+        # package on disk.
+        assembly_ok = self._generate_assembly(out_dir, result)
+        if not assembly_ok:
+            return result
 
         # Step 2: Report (optional)
         if self.config.include_report:
@@ -396,8 +421,16 @@ class ManufacturingPackage:
             result.manifest_path = out_dir / self.config.manifest_name
         return result
 
-    def _generate_assembly(self, out_dir: Path, result: ManufacturingResult) -> None:
-        """Run BOM + CPL + Gerber generation."""
+    def _generate_assembly(self, out_dir: Path, result: ManufacturingResult) -> bool:
+        """Run BOM + CPL + Gerber generation.
+
+        Returns:
+            ``True`` when the assembly stage was attempted successfully
+            (whether or not its individual artefacts succeeded), ``False``
+            when the stage aborted before producing any files -- in which
+            case the caller should skip subsequent stages (Report, Project
+            ZIP, Manifest) so we don't leave a partial package on disk.
+        """
         try:
             assembly = AssemblyPackage(
                 pcb_path=self.pcb_path,
@@ -405,12 +438,28 @@ class ManufacturingPackage:
                 manufacturer=self.manufacturer,
                 config=self.config,  # ManufacturingConfig extends AssemblyConfig
             )
+        except KiCadFileNotFoundError as e:
+            # Construction failed (e.g. schematic missing for a
+            # schematic-sourced BOM).  No artefacts have been written.
+            # Bail out hard so we don't produce a partial package.
+            result.errors.append(f"Assembly generation failed: {e}")
+            logger.error(f"Assembly generation failed: {e}")
+            return False
+        except Exception as e:
+            result.errors.append(f"Assembly generation failed: {e}")
+            logger.error(f"Assembly generation failed: {e}")
+            return False
+
+        try:
             result.assembly_result = assembly.export(out_dir)
             if result.assembly_result.errors:
                 result.errors.extend(result.assembly_result.errors)
         except Exception as e:
             result.errors.append(f"Assembly generation failed: {e}")
             logger.error(f"Assembly generation failed: {e}")
+            return True  # files may already have been written
+
+        return True
 
     def _generate_report(self, out_dir: Path, result: ManufacturingResult) -> None:
         """Generate a Markdown design report."""

--- a/src/kicad_tools/report/utils.py
+++ b/src/kicad_tools/report/utils.py
@@ -12,6 +12,11 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+#: Suffixes stripped from a PCB stem when looking for a sibling schematic.
+#: Exposed at module scope so error reporters (e.g. AssemblyPackage) can
+#: surface the exact candidates that were tried.
+SCHEMATIC_STRIP_SUFFIXES: tuple[str, ...] = ("_routed", "_fixed", "_v2", "_final")
+
 
 def find_schematic(pcb_path: Path) -> Path | None:
     """Locate the root .kicad_sch file for a given .kicad_pcb.
@@ -42,9 +47,8 @@ def find_schematic(pcb_path: Path) -> Path | None:
         return candidate
 
     # Step 1.5: strip known suffixes (_routed, _fixed, etc.) from the PCB stem
-    _STRIP_SUFFIXES = ("_routed", "_fixed", "_v2", "_final")
     stem = pcb_path.stem
-    for suffix in _STRIP_SUFFIXES:
+    for suffix in SCHEMATIC_STRIP_SUFFIXES:
         if stem.endswith(suffix):
             stripped = directory / (stem[: -len(suffix)] + ".kicad_sch")
             if stripped.exists():
@@ -76,6 +80,46 @@ def find_schematic(pcb_path: Path) -> Path | None:
 
     # Step 4: no candidates at all
     return None
+
+
+def schematic_candidate_paths(pcb_path: Path) -> list[Path]:
+    """Enumerate the schematic paths considered by :func:`find_schematic`.
+
+    Returns the list of concrete candidate paths (not just suffixes) that
+    auto-discovery checks for a given PCB.  Useful for error messages when
+    discovery fails -- the caller can show the user every path that was
+    probed, so they can diagnose why none matched.
+
+    Args:
+        pcb_path: Path to the ``.kicad_pcb`` file.
+
+    Returns:
+        Ordered list of :class:`~pathlib.Path` objects in the same order
+        :func:`find_schematic` consults them.  Includes the direct stem
+        match, each ``_routed`` / ``_fixed`` / ``_v2`` / ``_final``
+        suffix-stripped candidate, and any project-file-derived candidates.
+    """
+    directory = pcb_path.parent
+    candidates: list[Path] = [pcb_path.with_suffix(".kicad_sch")]
+
+    stem = pcb_path.stem
+    for suffix in SCHEMATIC_STRIP_SUFFIXES:
+        if stem.endswith(suffix):
+            candidates.append(directory / (stem[: -len(suffix)] + ".kicad_sch"))
+            break
+
+    for pro in sorted(directory.glob("*.kicad_pro")):
+        project_stem = _project_stem(pro)
+        candidates.append(directory / (project_stem + ".kicad_sch"))
+
+    # De-duplicate while preserving order
+    seen: set[Path] = set()
+    unique: list[Path] = []
+    for c in candidates:
+        if c not in seen:
+            seen.add(c)
+            unique.append(c)
+    return unique
 
 
 def _project_stem(pro_path: Path) -> str:

--- a/tests/test_bom_pcb_source.py
+++ b/tests/test_bom_pcb_source.py
@@ -16,7 +16,9 @@ from kicad_tools.schema.bom import BOM, BOMItem, extract_bom_from_pcb
 # ---------------------------------------------------------------------------
 
 BOARDS_DIR = Path(__file__).resolve().parent.parent / "boards"
-VOLTAGE_DIVIDER_PCB = BOARDS_DIR / "01-voltage-divider" / "output" / "voltage_divider_routed.kicad_pcb"
+VOLTAGE_DIVIDER_PCB = (
+    BOARDS_DIR / "01-voltage-divider" / "output" / "voltage_divider_routed.kicad_pcb"
+)
 VOLTAGE_DIVIDER_SCH = BOARDS_DIR / "01-voltage-divider" / "output" / "voltage_divider.kicad_sch"
 
 
@@ -73,9 +75,7 @@ class TestExtractBomFromPcb:
         from kicad_tools.schema.pcb import PCB
 
         pcb = PCB.load(str(vdiv_pcb_path))
-        excluded_refs = {
-            fp.reference for fp in pcb.footprints if fp.exclude_from_bom
-        }
+        excluded_refs = {fp.reference for fp in pcb.footprints if fp.exclude_from_bom}
 
         bom = extract_bom_from_pcb(str(vdiv_pcb_path))
         bom_refs = {item.reference for item in bom.items}
@@ -200,10 +200,7 @@ class TestAssemblyPackageBomSource:
         from kicad_tools.schema.pcb import PCB
 
         pcb = PCB.load(str(vdiv_pcb_path))
-        expected_refs = {
-            fp.reference for fp in pcb.footprints
-            if not fp.exclude_from_bom
-        }
+        expected_refs = {fp.reference for fp in pcb.footprints if not fp.exclude_from_bom}
 
         config = AssemblyConfig(
             bom_source="pcb",
@@ -223,8 +220,14 @@ class TestAssemblyPackageBomSource:
             assert ref in content, f"Expected reference {ref} in BOM CSV"
 
     def test_schematic_source_without_schematic_raises(self, vdiv_pcb_path: Path, tmp_path: Path):
-        """bom_source='schematic' without schematic should raise ValidationError."""
-        from kicad_tools.exceptions import ValidationError
+        """bom_source='schematic' without a discoverable schematic should fail fast.
+
+        ``AssemblyPackage.__init__`` raises ``KiCadFileNotFoundError`` so that
+        no partial package is written to disk (regression: see issue #2741).
+        """
+        import pytest
+
+        from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
         from kicad_tools.export.assembly import AssemblyConfig, AssemblyPackage
 
         config = AssemblyConfig(
@@ -232,14 +235,15 @@ class TestAssemblyPackageBomSource:
             auto_lcsc=False,
             no_spec=True,
         )
-        pkg = AssemblyPackage(
-            pcb_path=vdiv_pcb_path,
-            schematic_path="/nonexistent/path.kicad_sch",
-            config=config,
-        )
-        # The error is caught by export() and stored in result.errors
-        result = pkg.export(tmp_path)
-        assert any("BOM generation failed" in e for e in result.errors)
+        with pytest.raises(KiCadFileNotFoundError) as excinfo:
+            AssemblyPackage(
+                pcb_path=vdiv_pcb_path,
+                schematic_path="/nonexistent/path.kicad_sch",
+                config=config,
+            )
+        msg = str(excinfo.value)
+        assert "Schematic file not found" in msg
+        assert "--sch" in msg or "--bom-source pcb" in msg
 
     def test_auto_source_with_matching_refs(
         self, vdiv_pcb_path: Path, vdiv_sch_path: Path, tmp_path: Path
@@ -262,9 +266,7 @@ class TestAssemblyPackageBomSource:
         assert result.bom_path is not None
         assert result.bom_path.exists()
 
-    def test_auto_source_without_schematic_uses_pcb(
-        self, vdiv_pcb_path: Path, tmp_path: Path
-    ):
+    def test_auto_source_without_schematic_uses_pcb(self, vdiv_pcb_path: Path, tmp_path: Path):
         """auto mode should fall back to PCB when no schematic is available."""
         from kicad_tools.export.assembly import AssemblyConfig, AssemblyPackage
 
@@ -410,7 +412,9 @@ class TestCliBomSourceArg:
 
         parser = argparse.ArgumentParser()
         parser.add_argument("pcb")
-        parser.add_argument("--bom-source", default="schematic", choices=["schematic", "pcb", "auto"])
+        parser.add_argument(
+            "--bom-source", default="schematic", choices=["schematic", "pcb", "auto"]
+        )
 
         args = parser.parse_args(["test.kicad_pcb", "--bom-source", "pcb"])
         assert args.bom_source == "pcb"
@@ -420,7 +424,9 @@ class TestCliBomSourceArg:
 
         parser = argparse.ArgumentParser()
         parser.add_argument("pcb")
-        parser.add_argument("--bom-source", default="schematic", choices=["schematic", "pcb", "auto"])
+        parser.add_argument(
+            "--bom-source", default="schematic", choices=["schematic", "pcb", "auto"]
+        )
 
         args = parser.parse_args(["test.kicad_pcb", "--bom-source", "auto"])
         assert args.bom_source == "auto"
@@ -430,7 +436,9 @@ class TestCliBomSourceArg:
 
         parser = argparse.ArgumentParser()
         parser.add_argument("pcb")
-        parser.add_argument("--bom-source", default="schematic", choices=["schematic", "pcb", "auto"])
+        parser.add_argument(
+            "--bom-source", default="schematic", choices=["schematic", "pcb", "auto"]
+        )
 
         args = parser.parse_args(["test.kicad_pcb"])
         assert args.bom_source == "schematic"

--- a/tests/test_export_cmd.py
+++ b/tests/test_export_cmd.py
@@ -131,6 +131,9 @@ class TestExportCmdIntegration:
         project_dir.mkdir()
         pcb = project_dir / "board.kicad_pcb"
         pcb.write_text("(kicad_pcb)")
+        # Sibling schematic is required for the default schematic-sourced
+        # BOM path -- AssemblyPackage now fails fast without it.
+        (project_dir / "board.kicad_sch").write_text("(kicad_sch)")
 
         from kicad_tools.export import assembly
 
@@ -351,6 +354,9 @@ class TestExportCmdIncludeTHT:
         project_dir.mkdir()
         pcb = project_dir / "board.kicad_pcb"
         pcb.write_text("(kicad_pcb)")
+        # Sibling schematic is required for the default schematic-sourced
+        # BOM path -- AssemblyPackage now fails fast without it.
+        (project_dir / "board.kicad_sch").write_text("(kicad_sch)")
 
         from kicad_tools.export import assembly
 
@@ -391,6 +397,9 @@ class TestExportCmdIncludeTHT:
         project_dir.mkdir()
         pcb = project_dir / "board.kicad_pcb"
         pcb.write_text("(kicad_pcb)")
+        # Sibling schematic is required for the default schematic-sourced
+        # BOM path -- AssemblyPackage now fails fast without it.
+        (project_dir / "board.kicad_sch").write_text("(kicad_sch)")
 
         from kicad_tools.export import assembly
 
@@ -575,15 +584,14 @@ class TestExportCmdKeepVersions:
 
         def fake_export(self, output_dir=None, *, dry_run=False):
             from kicad_tools.export.manufacturing import ManufacturingResult
+
             od = Path(output_dir) if output_dir else self.config.output_dir
             return ManufacturingResult(output_dir=od)
 
         monkeypatch.setattr(ManufacturingPackage, "__init__", spy_init)
         monkeypatch.setattr(ManufacturingPackage, "export", fake_export)
 
-        rc = export_main(
-            [str(pcb), "--no-report", "--skip-preflight", "-o", str(tmp_path / "out")]
-        )
+        rc = export_main([str(pcb), "--no-report", "--skip-preflight", "-o", str(tmp_path / "out")])
         assert rc == 0
         assert captured_config["latest_report_only"] is True
 
@@ -596,7 +604,9 @@ class TestExportCmdKeepGerberFiles:
         pcb = tmp_path / "board.kicad_pcb"
         pcb.write_text("(kicad_pcb)")
 
-        rc = export_main([str(pcb), "--keep-gerber-files", "--dry-run", "-o", str(tmp_path / "out")])
+        rc = export_main(
+            [str(pcb), "--keep-gerber-files", "--dry-run", "-o", str(tmp_path / "out")]
+        )
         assert rc == 0
 
     def test_keep_gerber_files_sets_gerber_config(self, tmp_path, monkeypatch):
@@ -618,6 +628,7 @@ class TestExportCmdKeepGerberFiles:
 
         def fake_export(self, output_dir=None, *, dry_run=False):
             from kicad_tools.export.manufacturing import ManufacturingResult
+
             od = Path(output_dir) if output_dir else self.config.output_dir
             return ManufacturingResult(output_dir=od)
 
@@ -638,3 +649,189 @@ class TestExportCmdKeepGerberFiles:
         assert captured_config["gerber_config"] is not None
         assert captured_config["gerber_config"].clean_after_zip is False
 
+
+class TestExportCmdSchematicAutoDiscovery:
+    """Regression tests for issue #2741 -- sibling .kicad_sch discovery.
+
+    The original symptom was 'absolute --pcb path yields 6/8 files instead
+    of 8'.  The curator narrowed the real bug to two underlying gaps:
+
+    1. ``find_schematic`` was assumed to be CWD-sensitive (it is not).
+       This test confirms an absolute PCB path resolves the sibling
+       schematic identically whether the CWD is the board dir or not.
+
+    2. When the schematic genuinely cannot be auto-discovered (e.g. the
+       PCB was copied to a directory with no sibling schematic), the old
+       code silently wrote a partial package (Gerbers/CPL/Report/etc.) to
+       disk and then surfaced a BOM error in stderr.  The fix makes
+       ``AssemblyPackage.__init__`` fail fast, so nothing is written.
+    """
+
+    def test_absolute_pcb_path_outside_cwd_produces_full_package(self, tmp_path, monkeypatch):
+        """Running kct export with an absolute --pcb path from an unrelated
+        CWD must still discover the sibling .kicad_sch and produce a full
+        package (no missing BOM).
+        """
+        # Project lives in board_dir; we will run from cwd_dir (different).
+        board_dir = tmp_path / "boards" / "stm32_devboard" / "output"
+        board_dir.mkdir(parents=True)
+        # _routed suffix exercises the SCHEMATIC_STRIP_SUFFIXES path.
+        pcb = board_dir / "stm32_devboard_routed.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+        sch = board_dir / "stm32_devboard.kicad_sch"
+        sch.write_text("(kicad_sch)")
+
+        cwd_dir = tmp_path / "elsewhere"
+        cwd_dir.mkdir()
+        monkeypatch.chdir(cwd_dir)
+
+        from kicad_tools.export import assembly
+
+        captured_schematic = {}
+
+        original_init = assembly.AssemblyPackage.__init__
+
+        def spy_init(self, pcb_path, schematic_path=None, manufacturer="jlcpcb", config=None):
+            original_init(self, pcb_path, schematic_path, manufacturer, config)
+            captured_schematic["value"] = self.schematic_path
+
+        def fake_export(self, output_dir=None):
+            od = Path(output_dir) if output_dir else self.config.output_dir
+            od.mkdir(parents=True, exist_ok=True)
+            bom_path = od / "bom_jlcpcb.csv"
+            bom_path.write_text("Comment,Designator,Footprint,LCSC Part #\n")
+            cpl_path = od / "cpl_jlcpcb.csv"
+            cpl_path.write_text("Designator\n")
+            return assembly.AssemblyPackageResult(
+                output_dir=od,
+                bom_path=bom_path,
+                pnp_path=cpl_path,
+            )
+
+        monkeypatch.setattr(assembly.AssemblyPackage, "__init__", spy_init)
+        monkeypatch.setattr(assembly.AssemblyPackage, "export", fake_export)
+
+        out_dir = tmp_path / "out_abs"
+        rc = export_main(
+            [
+                str(pcb.resolve()),  # absolute, outside CWD
+                "--no-report",
+                "--skip-preflight",
+                "-o",
+                str(out_dir),
+            ]
+        )
+
+        assert rc == 0
+        # The schematic was auto-discovered via _routed stripping
+        assert captured_schematic["value"] == sch
+        # Manifest contains the BOM (the original missing artefact)
+        assert (out_dir / "bom_jlcpcb.csv").exists()
+        assert (out_dir / "manifest.json").exists()
+
+    def test_missing_sibling_schematic_fails_fast(self, tmp_path, capsys):
+        """When a .kicad_pcb has no discoverable sibling .kicad_sch and
+        the default schematic-sourced BOM is selected, kct export must:
+
+        - return a non-zero exit code,
+        - print an error naming the PCB stem and suggesting --sch /
+          --bom-source pcb, and
+        - leave no partial package on disk (no Gerbers, no CPL, no
+          manifest, no project zip, no README).
+        """
+        orphan_dir = tmp_path / "orphan"
+        orphan_dir.mkdir()
+        pcb = orphan_dir / "orphan_pcb.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+        # No sibling .kicad_sch, no .kicad_pro -- discovery cannot succeed.
+
+        out_dir = tmp_path / "out"
+        rc = export_main(
+            [
+                str(pcb),
+                "--no-report",
+                "--skip-preflight",
+                "-o",
+                str(out_dir),
+            ]
+        )
+
+        assert rc == 1
+
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        # Error names the PCB stem and the remediation hints
+        assert "Schematic file not found" in combined
+        assert "orphan_pcb" in combined
+        assert ("--sch" in combined) or ("--bom-source pcb" in combined)
+
+        # No partial package on disk: AssemblyPackage construction failed
+        # before mkdir, so nothing should have been written.
+        if out_dir.exists():
+            written = list(out_dir.iterdir())
+            assert written == [], (
+                f"Expected no partial package on disk, found: {[p.name for p in written]}"
+            )
+
+    def test_missing_schematic_with_bom_source_pcb_succeeds(self, tmp_path, monkeypatch):
+        """``--bom-source pcb`` is the documented escape hatch for the
+        missing-schematic case.  It must not fail in AssemblyPackage.__init__.
+        """
+        orphan_dir = tmp_path / "orphan"
+        orphan_dir.mkdir()
+        pcb = orphan_dir / "orphan_pcb.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+
+        from kicad_tools.export import assembly
+
+        def fake_export(self, output_dir=None):
+            od = Path(output_dir) if output_dir else self.config.output_dir
+            od.mkdir(parents=True, exist_ok=True)
+            return assembly.AssemblyPackageResult(output_dir=od)
+
+        monkeypatch.setattr(assembly.AssemblyPackage, "export", fake_export)
+
+        out_dir = tmp_path / "out"
+        rc = export_main(
+            [
+                str(pcb),
+                "--bom-source",
+                "pcb",
+                "--no-report",
+                "--no-project-zip",
+                "--skip-preflight",
+                "-o",
+                str(out_dir),
+            ]
+        )
+        assert rc == 0
+
+    def test_missing_schematic_with_no_bom_succeeds(self, tmp_path, monkeypatch):
+        """``--no-bom`` should likewise bypass the schematic requirement."""
+        orphan_dir = tmp_path / "orphan"
+        orphan_dir.mkdir()
+        pcb = orphan_dir / "orphan_pcb.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+
+        from kicad_tools.export import assembly
+
+        def fake_export(self, output_dir=None):
+            od = Path(output_dir) if output_dir else self.config.output_dir
+            od.mkdir(parents=True, exist_ok=True)
+            return assembly.AssemblyPackageResult(output_dir=od)
+
+        monkeypatch.setattr(assembly.AssemblyPackage, "export", fake_export)
+
+        out_dir = tmp_path / "out"
+        rc = export_main(
+            [
+                str(pcb),
+                "--no-bom",
+                "--no-report",
+                "--no-project-zip",
+                "--skip-preflight",
+                "-o",
+                str(out_dir),
+            ]
+        )
+        assert rc == 0

--- a/tests/test_export_extended.py
+++ b/tests/test_export_extended.py
@@ -536,6 +536,10 @@ class TestAssemblyPackage:
         return pcb_path
 
     def test_init(self, mock_pcb_path):
+        # A sibling .kicad_sch is required for the default schematic-sourced
+        # BOM path -- AssemblyPackage fails fast otherwise (see issue #2741).
+        sch_path = mock_pcb_path.with_suffix(".kicad_sch")
+        sch_path.write_text("(kicad_sch)")
         pkg = AssemblyPackage(mock_pcb_path)
         assert pkg.pcb_path == mock_pcb_path
 

--- a/tests/test_manufacturing_package.py
+++ b/tests/test_manufacturing_package.py
@@ -393,6 +393,7 @@ class TestManufacturingPackageExport:
         project_dir.mkdir()
         pcb = project_dir / "board.kicad_pcb"
         pcb.write_text("(kicad_pcb)")
+        (project_dir / "board.kicad_sch").write_text("(kicad_sch)")
 
         from kicad_tools.export import assembly
 
@@ -449,6 +450,7 @@ class TestManufacturingPackageExport:
         project_dir.mkdir()
         pcb = project_dir / "board.kicad_pcb"
         pcb.write_text("(kicad_pcb)")
+        (project_dir / "board.kicad_sch").write_text("(kicad_sch)")
 
         from kicad_tools.export import assembly
 
@@ -509,6 +511,7 @@ class TestManufacturingPackageExport:
         project_dir.mkdir()
         pcb = project_dir / "board.kicad_pcb"
         pcb.write_text("(kicad_pcb)")
+        (project_dir / "board.kicad_sch").write_text("(kicad_sch)")
 
         from kicad_tools.export import assembly
 
@@ -563,6 +566,7 @@ class TestManufacturingPackageExport:
         project_dir.mkdir()
         pcb = project_dir / "board.kicad_pcb"
         pcb.write_text("(kicad_pcb)")
+        (project_dir / "board.kicad_sch").write_text("(kicad_sch)")
 
         from kicad_tools.export import assembly
 

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -578,7 +578,16 @@ class TestPreflightManufacturingIntegration:
         assert not PreflightChecker.has_failures(result.preflight_results)
 
     def test_export_blocked_by_preflight_fail(self, tmp_path):
-        """Manufacturing export should fail when preflight has FAIL results."""
+        """Manufacturing export should fail when the PCB cannot be loaded.
+
+        Previously this test relied on the preflight ``file_exists`` check
+        catching a missing PCB.  After issue #2741 the export pipeline
+        constructs an ``AssemblyPackage`` up-front (so a missing schematic
+        cannot leak a partial package), which means a missing PCB now
+        fails in ``AssemblyPackage.__init__`` before preflight runs.  The
+        observable contract -- "export fails, nothing is written" -- is
+        unchanged.
+        """
         from kicad_tools.export.manufacturing import ManufacturingConfig, ManufacturingPackage
         from kicad_tools.export.preflight import PreflightConfig
 
@@ -586,16 +595,19 @@ class TestPreflightManufacturingIntegration:
             include_report=False,
             preflight=PreflightConfig(skip_drc=True, skip_erc=True),
         )
-        # Non-existent PCB will cause a FAIL
+        # Non-existent PCB will cause a fatal failure
         pkg = ManufacturingPackage(
             pcb_path=tmp_path / "nonexistent.kicad_pcb",
             manufacturer="jlcpcb",
             config=config,
         )
-        result = pkg.export(tmp_path / "output")
+        out_dir = tmp_path / "output"
+        result = pkg.export(out_dir)
 
         assert not result.success
-        assert any("Preflight FAIL" in e for e in result.errors)
+        assert any("PCB file not found" in e for e in result.errors)
+        # No output directory should be created on the fail-fast path
+        assert not out_dir.exists()
 
     def test_skip_preflight_bypasses_checks(self, tmp_path, monkeypatch):
         """With skip_all=True, preflight checks are not run."""
@@ -603,6 +615,10 @@ class TestPreflightManufacturingIntegration:
         project_dir.mkdir()
         pcb = _create_minimal_pcb(project_dir, include_outline=True)
         (project_dir / "board.kicad_pro").write_text("{}")
+        # A sibling .kicad_sch is needed because AssemblyPackage now fails
+        # fast when the BOM is schematic-sourced and the schematic cannot
+        # be auto-discovered (regression: see issue #2741).
+        (project_dir / "board.kicad_sch").write_text("(kicad_sch)")
 
         from kicad_tools.export import assembly
         from kicad_tools.export.manufacturing import ManufacturingConfig, ManufacturingPackage
@@ -692,6 +708,10 @@ class TestPreflightCLI:
         project_dir.mkdir()
         pcb = _create_minimal_pcb(project_dir, include_outline=True)
         (project_dir / "board.kicad_pro").write_text("{}")
+        # Sibling .kicad_sch needed: AssemblyPackage now fails fast when
+        # the BOM is schematic-sourced and no schematic is discoverable
+        # (regression: see issue #2741).
+        (project_dir / "board.kicad_sch").write_text("(kicad_sch)")
 
         from kicad_tools.export import assembly
 
@@ -758,6 +778,10 @@ class TestPreflightCLI:
         project_dir.mkdir()
         pcb = _create_minimal_pcb(project_dir, include_outline=True)
         (project_dir / "board.kicad_pro").write_text("{}")
+        # Sibling .kicad_sch needed: AssemblyPackage now fails fast when
+        # the BOM is schematic-sourced and no schematic is discoverable
+        # (regression: see issue #2741).
+        (project_dir / "board.kicad_sch").write_text("(kicad_sch)")
 
         from kicad_tools.export import assembly
 
@@ -1204,7 +1228,7 @@ def _create_pcb_with_mixed_footprints(
         )
         x += 5.0
 
-    for ref in (dnp_refs or []):
+    for ref in dnp_refs or []:
         footprints.append(
             f"""  (footprint "Resistor_SMD:R_0402_1005Metric"
     (layer "F.Cu")
@@ -1328,7 +1352,9 @@ class TestPreflightBomCplMatchTHT:
             items=[
                 BOMItem(reference="R1", value="10k", footprint="R_0402", lib_id="Device:R"),
                 BOMItem(reference="C1", value="100nF", footprint="C_0402", lib_id="Device:C"),
-                BOMItem(reference="J1", value="Conn", footprint="PinHeader", lib_id="Connector:Conn"),
+                BOMItem(
+                    reference="J1", value="Conn", footprint="PinHeader", lib_id="Connector:Conn"
+                ),
             ]
         )
         monkeypatch.setattr(checker, "_load_bom", lambda: bom)


### PR DESCRIPTION
## Summary

Closes #2741.

When `find_schematic` cannot auto-discover a sibling `.kicad_sch` for a
PCB and the BOM is schematic-sourced (the default), `kct export`
previously wrote Gerbers/CPL/Report/ProjectZip/Manifest to disk and
*then* failed in `_generate_bom` -- producing a partial 5/8 or 7/8
package and an exit-1 error interleaved with success lines on stdout.

This PR makes the failure unambiguous and clean:

- `AssemblyPackage.__init__` raises `KiCadFileNotFoundError` up front
  when the schematic is required but missing.  The error names the PCB
  stem, the suffix-stripping candidates tried (`_routed`, `_fixed`,
  `_v2`, `_final`), the search directory, and suggests `--sch`,
  `--bom-source pcb`, or `--no-bom`.
- `ManufacturingPackage.export` pre-constructs the `AssemblyPackage`
  before preflight runs and before `out_dir.mkdir`, so a fail-fast
  produces no partial package on disk.
- `_generate_bom` raises the same enriched error if reached directly
  (defence in depth for users who bypass `include_bom`).
- `find_schematic`'s suffix list is promoted to module scope as
  `SCHEMATIC_STRIP_SUFFIXES`, and a new `schematic_candidate_paths`
  helper enumerates the exact paths discovery probes -- so error
  messages can show users every candidate that was tried.

## Test plan

- [x] New regression tests in `tests/test_export_cmd.py`:
  - `test_absolute_pcb_path_outside_cwd_produces_full_package` -- runs
    `kct export` against an absolute `_routed.kicad_pcb` path from an
    unrelated CWD and asserts the sibling schematic is auto-discovered
    via `_routed` suffix stripping and the BOM is produced.
  - `test_missing_sibling_schematic_fails_fast` -- copies a PCB to a
    directory with no `.kicad_sch`, asserts exit code 1, that the error
    names the PCB stem and suggests `--sch` / `--bom-source pcb`, and
    that no partial package is on disk.
  - `test_missing_schematic_with_bom_source_pcb_succeeds` and
    `test_missing_schematic_with_no_bom_succeeds` -- verify the
    documented escape hatches still work.
- [x] Existing tests in `tests/test_bom_pcb_source.py`,
  `tests/test_export_cmd.py`, `tests/test_export_extended.py`,
  `tests/test_manufacturing_package.py`, `tests/test_preflight.py`
  updated to either add a sibling schematic or assert the new
  fail-fast behaviour.
- [x] All 254 tests in the touched modules pass.
- [x] Full test suite delta vs. main: 19 failures on this branch, 19
  failures on main -- identical pre-existing failures, no regressions.
- [x] `ruff check` introduces no new errors (2 pre-existing F541 in
  `manufacturing.py` only).
- [x] `ruff format` applied.

## Curator targets covered

- `src/kicad_tools/export/assembly.py:131-169` -- raises
  `KiCadFileNotFoundError` when discovery fails and `bom_source != "pcb"`.
- `src/kicad_tools/export/assembly.py:272-280` -- `_generate_bom` error
  enriched with `pcb.stem`, `SCHEMATIC_STRIP_SUFFIXES`, and the candidate
  paths tried.
- `src/kicad_tools/export/manufacturing.py:399-413` -- `_generate_assembly`
  fails fast (no CPL/Gerbers/Report/Manifest written) when BOM is
  required and schematic missing.  Also pre-validates in
  `ManufacturingPackage.export` so even `out_dir` is not created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)