### PR TITLE
fix(zones): origin-shift existing.polygon in _check_overlap (closes #2759)

### DIFF
--- a/src/kicad_tools/zones/generator.py
+++ b/src/kicad_tools/zones/generator.py
@@ -185,17 +185,12 @@ class ZoneGenerator:
         coordinates. ``get_board_outline()`` returns board-relative coords,
         so we add the board origin back.
 
-        .. note::
-            **Coord-space mismatch with ``existing.polygon`` (deferred -- #2759):**
-            After PR #2753 normalized ``Zone.polygon`` to board-relative
-            coordinates during ``PCB.load()``, ``_check_overlap()`` at line
-            431 compares this sheet-absolute boundary against
-            ``existing.polygon`` (board-relative). For boards with a
-            non-zero ``Edge.Cuts`` origin the bounding-box overlap test
-            will silently report "no overlap" for actually-overlapping
-            zones. The zone-writeout path is correct (it needs sheet-absolute
-            for the sexp tree); the bug is confined to the overlap-warning
-            heuristic. Tracked in #2759.
+        Note: this property is the source of the sheet-absolute ``boundary``
+        argument passed to ``_check_overlap()``. Since PR #2753 normalized
+        ``Zone.polygon`` to board-relative coordinates on load, the overlap
+        comparison must reconcile the two frames; ``_check_overlap()`` does
+        so by shifting ``existing.polygon`` by the board origin before
+        computing the AABB intersection (see #2759).
         """
         if self._board_outline is None:
             outline = self._pcb.get_board_outline()
@@ -425,10 +420,24 @@ class ZoneGenerator:
         Checks both existing PCB zones and zones already queued in
         this generator.
 
+        Coordinate frames:
+            * ``boundary`` is sheet-absolute (sourced from
+              :attr:`board_outline`, which converts the board-relative
+              outline back to sheet-absolute for PCB output -- see PR #2753).
+            * ``existing.polygon`` is board-relative on PCBs loaded via
+              :class:`PCB` (see ``_detect_board_origin`` in
+              ``schema/pcb.py``).  We add the board origin so both polygons
+              live in the same frame before the AABB intersection test.
+            * Queued zones (``self._zones``) already carry sheet-absolute
+              boundaries because :meth:`add_zone` derives them from
+              :attr:`board_outline` (or accepts a caller-supplied boundary
+              in the same frame), so no conversion is required there.
+
         Returns:
             List of overlap warnings (empty if no overlaps detected).
         """
         warnings: list[ZoneOverlapWarning] = []
+        ox, oy = self._pcb.board_origin
 
         # Check against existing zones in the PCB
         for existing in self._pcb.zones:
@@ -437,12 +446,13 @@ class ZoneGenerator:
             if existing.net_name == net:
                 continue  # Same net on same layer is fine (e.g. re-run)
 
-            # TODO(#2759): mixed coord-space comparison. After PR #2753
-            # `existing.polygon` is board-relative while `boundary` (derived
-            # from `self.board_outline`) is sheet-absolute. For non-zero
-            # `Edge.Cuts` origin this silently misses real overlaps. Fix
-            # is deferred to keep PR #2753's blast radius bounded.
-            existing_boundary = existing.polygon
+            # Bring the board-relative existing polygon (post-PR-2753
+            # invariant) into the sheet-absolute frame used by ``boundary``
+            # so the AABB intersection test works for non-zero-origin boards.
+            if ox != 0.0 or oy != 0.0:
+                existing_boundary = [(x + ox, y + oy) for x, y in existing.polygon]
+            else:
+                existing_boundary = existing.polygon
             if self._boundaries_overlap(boundary, existing_boundary):
                 if priority <= existing.priority:
                     msg = (

--- a/tests/test_zone_generator.py
+++ b/tests/test_zone_generator.py
@@ -533,6 +533,197 @@ class TestZoneOverlapDetection:
         assert "zero copper" in captured.err
 
 
+class TestZoneOverlapNonzeroOrigin:
+    """Tests for overlap detection on PCBs with non-zero board origin.
+
+    Regression coverage for the mixed-coordinate-space bug introduced by
+    PR #2753: ``board_outline`` is sheet-absolute (PCB-output frame), but
+    ``Zone.polygon`` is board-relative after loading.  ``_check_overlap``
+    must reconcile the two frames before running the AABB intersection
+    test, otherwise overlap detection silently fails on every non-zero-
+    origin board (which is every demo board in this repo).
+    """
+
+    @pytest.fixture
+    def offset_pcb_with_existing_zone(self, tmp_path):
+        """Create a PCB at origin (100, 80) with one pre-existing GND zone.
+
+        The zone polygon is written in sheet-absolute coordinates (KiCad's
+        on-disk convention).  After PCB.load, ``Zone.polygon`` will be
+        board-relative, while ``board_outline`` (consumed by
+        ``ZoneGenerator``) will be re-converted to sheet-absolute for
+        PCB output.
+        """
+        pcb_content = """(kicad_pcb
+  (version 20240108)
+  (generator "kicad")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (net 3 "+5V")
+  (gr_rect
+    (start 100 80)
+    (end 150 110)
+    (stroke (width 0.15) (type solid))
+    (fill none)
+    (layer "Edge.Cuts")
+    (uuid "edge-uuid")
+  )
+  (zone
+    (net 1)
+    (net_name "GND")
+    (layer "B.Cu")
+    (uuid "existing-zone-uuid")
+    (hatch edge 0.5)
+    (priority 1)
+    (connect_pads (clearance 0.3))
+    (min_thickness 0.25)
+    (fill yes (thermal_gap 0.3) (thermal_bridge_width 0.4))
+    (polygon (pts (xy 100.3 80.3) (xy 149.7 80.3) (xy 149.7 109.7) (xy 100.3 109.7)))
+  )
+)
+"""
+        pcb_file = tmp_path / "offset_with_zone.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+        return pcb_file
+
+    @pytest.fixture
+    def offset_pcb_no_zone(self, tmp_path):
+        """Create a PCB at origin (100, 80) with no pre-existing zones."""
+        pcb_content = """(kicad_pcb
+  (version 20240108)
+  (generator "kicad")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (gr_rect
+    (start 100 80)
+    (end 150 110)
+    (stroke (width 0.15) (type solid))
+    (fill none)
+    (layer "Edge.Cuts")
+    (uuid "edge-uuid")
+  )
+)
+"""
+        pcb_file = tmp_path / "offset_no_zone.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+        return pcb_file
+
+    def test_existing_zone_polygon_is_board_relative(self, offset_pcb_with_existing_zone):
+        """Confirm the PCB.load invariant: Zone.polygon is board-relative.
+
+        This is a pre-condition for the regression we are guarding against;
+        if this assumption changes upstream the overlap fix may become
+        unnecessary (or wrong) and these tests should be revisited.
+        """
+        gen = ZoneGenerator.from_pcb(offset_pcb_with_existing_zone)
+        assert len(gen.pcb.zones) == 1
+        existing = gen.pcb.zones[0]
+
+        # Origin should be (100, 80)
+        assert gen.pcb.board_origin == (100.0, 80.0)
+
+        # Polygon should be board-relative (~ [0..50] x [0..30])
+        xs = [p[0] for p in existing.polygon]
+        ys = [p[1] for p in existing.polygon]
+        assert min(xs) == pytest.approx(0.3, abs=0.5)
+        assert max(xs) == pytest.approx(49.7, abs=0.5)
+        assert min(ys) == pytest.approx(0.3, abs=0.5)
+        assert max(ys) == pytest.approx(29.7, abs=0.5)
+
+    def test_overlap_detected_with_nonzero_origin(self, offset_pcb_with_existing_zone):
+        """Overlap warning fires when new zone overlaps existing on non-zero origin.
+
+        Regression for PR #2753: before the fix, ``_check_overlap``
+        compared sheet-absolute ``boundary`` against board-relative
+        ``existing.polygon`` and the AABBs were offset by the board
+        origin, so the overlap was silently missed.
+        """
+        gen = ZoneGenerator.from_pcb(offset_pcb_with_existing_zone)
+
+        # Add a +3.3V zone on B.Cu, which fully overlaps the existing GND
+        # zone on B.Cu.  Use default boundary (==board_outline, sheet-abs).
+        gen.add_zone(net="+3.3V", layer="B.Cu", priority=0)
+
+        assert len(gen.warnings) == 1
+        w = gen.warnings[0]
+        assert isinstance(w, ZoneOverlapWarning)
+        assert w.new_net == "+3.3V"
+        assert w.existing_net == "GND"
+        assert w.layer == "B.Cu"
+        # Lower priority new zone => "new zone will get zero copper"
+        assert "new zone will get zero copper" in w.message
+
+    def test_overlap_higher_priority_overrides_existing(self, offset_pcb_with_existing_zone):
+        """Higher-priority new zone reports the existing-zone-loses warning."""
+        gen = ZoneGenerator.from_pcb(offset_pcb_with_existing_zone)
+
+        # New zone at priority 2 > existing priority 1
+        gen.add_zone(net="+5V", layer="B.Cu", priority=2)
+
+        assert len(gen.warnings) == 1
+        w = gen.warnings[0]
+        assert "existing zone will get zero copper" in w.message
+        assert w.existing_net == "GND"
+
+    def test_no_overlap_warning_on_different_layer(self, offset_pcb_with_existing_zone):
+        """No overlap warning when new zone is on a different layer."""
+        gen = ZoneGenerator.from_pcb(offset_pcb_with_existing_zone)
+
+        # Existing zone is on B.Cu; add a different zone on F.Cu
+        gen.add_zone(net="+3.3V", layer="F.Cu", priority=0)
+
+        assert len(gen.warnings) == 0
+
+    def test_no_overlap_warning_same_net_same_layer(self, offset_pcb_with_existing_zone):
+        """No overlap warning when re-adding the same net on the same layer."""
+        gen = ZoneGenerator.from_pcb(offset_pcb_with_existing_zone)
+
+        gen.add_zone(net="GND", layer="B.Cu", priority=1)
+
+        assert len(gen.warnings) == 0
+
+    def test_no_overlap_warning_disjoint_custom_boundary(self, offset_pcb_with_existing_zone):
+        """No overlap when caller supplies a sheet-absolute boundary disjoint from the existing zone.
+
+        Existing zone covers (100,80) -> (150,110) in sheet-absolute.
+        Supply a boundary far away (e.g. 200,200 -> 250,250) and expect
+        no warning.  This guards against false positives caused by an
+        over-zealous origin shift.
+        """
+        gen = ZoneGenerator.from_pcb(offset_pcb_with_existing_zone)
+
+        far_away = [(200, 200), (250, 200), (250, 250), (200, 250)]
+        gen.add_zone(
+            net="+3.3V",
+            layer="B.Cu",
+            priority=0,
+            boundary=far_away,
+        )
+
+        assert len(gen.warnings) == 0
+
+    def test_no_existing_zones_no_warning(self, offset_pcb_no_zone):
+        """Sanity check: non-zero origin PCB with no existing zones produces no warning."""
+        gen = ZoneGenerator.from_pcb(offset_pcb_no_zone)
+        gen.add_zone(net="GND", layer="B.Cu", priority=1)
+
+        assert len(gen.warnings) == 0
+
+
 class TestBoundariesOverlap:
     """Tests for the static _boundaries_overlap method."""
 


### PR DESCRIPTION
## Summary

After PR #2753, `Zone.polygon` is board-relative on load while `ZoneGenerator.board_outline` (and therefore the `boundary` arg fed into `_check_overlap`) is sheet-absolute. The AABB intersection test mixed the two frames, silently missing zone overlaps on every non-zero-origin board.

This PR applies the curator-recommended **Option 1**: add the board origin to `existing.polygon` at comparison time, keeping `board_outline`'s public sheet-absolute contract and `zone_node`/`to_sexp_node` untouched. ~5-line change in `_check_overlap`, plus 7 new regression tests.

## Why this PR is based on `feature/issue-2742` (PR #2753)

This fix relies on the post-#2753 invariant that `_detect_board_origin` converts `zone.polygon` from sheet-absolute to board-relative on load (`schema/pcb.py:1616-1626`). Until #2753 lands on `main` this fix cannot exist on `main` either. The PR therefore targets PR #2753's branch (`feature/issue-2742`) so reviewers can rebase / merge it as part of the #2753 stack. If #2753 has already landed on `main` by review time, this can be rebased onto `main` cleanly.

Closes #2759.

## Changes

- `src/kicad_tools/zones/generator.py` — `_check_overlap` now reads `self._pcb.board_origin` once and converts `existing.polygon` to sheet-absolute before the AABB test. Replaces the `TODO(#2759)` placeholder left by PR #2753 with the actual fix + a docstring section documenting the coordinate-frame contract for every input.
- `tests/test_zone_generator.py` — new `TestZoneOverlapNonzeroOrigin` class with 7 regression tests:
  - `test_existing_zone_polygon_is_board_relative` (precondition / invariant check)
  - `test_overlap_detected_with_nonzero_origin` (the regression itself)
  - `test_overlap_higher_priority_overrides_existing`
  - `test_no_overlap_warning_on_different_layer`
  - `test_no_overlap_warning_same_net_same_layer`
  - `test_no_overlap_warning_disjoint_custom_boundary`
  - `test_no_existing_zones_no_warning`

I temporarily reverted the fix during development and confirmed that exactly the two `test_overlap_detected_*` tests fail — i.e. the new tests are tight regression coverage, not vacuously passing.

## Test plan

- [x] `pytest tests/test_zone_generator.py` — all 66 tests pass (59 pre-existing + 7 new)
- [x] `pytest tests/test_zone_generator.py tests/test_zones.py tests/test_zone_api.py tests/test_build_zones_step.py tests/test_pcb_zones.py` — all 162 tests pass
- [x] Confirmed regression: temporarily reverting the fix in `_check_overlap` causes exactly `test_overlap_detected_with_nonzero_origin` and `test_overlap_higher_priority_overrides_existing` to fail, while the other 5 (which guard against false positives) still pass
- [x] `ruff format` clean on touched files
- [x] No regression in zero-origin case (`TestZoneOverlapDetection` still passes)
- [x] `TestZoneGeneratorNonzeroOrigin::test_board_outline_is_sheet_absolute` still passes (no change to `board_outline` invariant)

## Acceptance criteria (from issue #2759)

- [x] `_check_overlap` correctly detects zone overlap for non-zero-origin boards
- [x] New `TestZoneOverlapNonzeroOrigin` tests cover the regression scenario
- [x] No regression in zero-origin case (still detects overlaps correctly)
- [x] Existing `TestZoneOverlapDetection` tests still pass

## Out of scope

- Option 2 (move `board_outline` to board-relative and add origin at sexp emission) — deferred per curator recommendation.
- Polygon-level (non-AABB) overlap detection — `_boundaries_overlap` docstring explicitly accepts AABB as a conservative approximation.
- `existing.filled_polygons` overlap checks — not consulted by `_check_overlap` today.