### PR TITLE
fix(router/escape): clip endpoint segments against pad clearance (#2756)

### DIFF
--- a/src/kicad_tools/router/escape.py
+++ b/src/kicad_tools/router/escape.py
@@ -1775,6 +1775,8 @@ class EscapeRouter:
             else self._get_trace_width_for_net(package.pads[0].net_name if package.pads else "")
         )
 
+        skipped_clearance = 0
+
         # Generate escapes for each edge
         for pads, primary_dir, alt_dir_cw, alt_dir_ccw in [
             (north_pads, EscapeDirection.NORTH, EscapeDirection.EAST, EscapeDirection.WEST),
@@ -1788,10 +1790,20 @@ class EscapeRouter:
                 else:
                     direction = alt_dir_cw if (i // 2) % 2 == 0 else alt_dir_ccw
 
-                escape = self._create_alternating_escape(
+                # Issue #2756: generate the unclipped escape first so we
+                # can detect the pre-#2756 violation condition and route
+                # it through the in-pad fallback when supported.  The
+                # in-pad fallback rescues pins that would otherwise be
+                # blocked at the launch step; without this ordering, the
+                # clipped escape would mask the violation from the
+                # ``_segment_violates_pad_clearance`` check and the
+                # in-pad rescue would never trigger (regression of
+                # Issue #2695).
+                unclipped_escape = self._create_alternating_escape(
                     pad=pad,
                     direction=direction,
                     package=package,
+                    pad_clearance_margin=None,
                 )
 
                 # Issue #2695: For fine-pitch QFP packages on capable
@@ -1801,8 +1813,8 @@ class EscapeRouter:
                 # The alternating scheme alone cannot fit traces between
                 # 0.5mm-pitch pads, so without this rescue inner pins
                 # never reach the main router successfully.
-                if try_in_pad_fallback and escape.segments:
-                    surface_seg = escape.segments[0]
+                if try_in_pad_fallback and unclipped_escape.segments:
+                    surface_seg = unclipped_escape.segments[0]
                     if self._segment_violates_pad_clearance(
                         surface_seg, i, pads, effective_clearance,
                     ):
@@ -1816,7 +1828,55 @@ class EscapeRouter:
                             escapes.append(in_pad_route)
                             continue
 
+                # Issue #2756: clip the segment endpoint against
+                # neighbour-pad clearance.  When the manufacturer does
+                # not support in-pad rescue (the common JLCPCB case) the
+                # clipped segment is the right answer -- it stops short
+                # of the violating pad and the main router picks up the
+                # net cleanly from the safe endpoint.
+                escape = self._create_alternating_escape(
+                    pad=pad,
+                    direction=direction,
+                    package=package,
+                    pad_clearance_margin=effective_clearance,
+                )
+
+                # Issue #2756: if the clipped segment is too short to be
+                # useful (heuristic: less than half the original launch
+                # distance), defer to the main router rather than
+                # emitting a stub that does not meaningfully exit the
+                # pin row.  Half the launch distance is the threshold
+                # used by the diff-pair coupling path
+                # (_escape_diff_pair_segment) and matches the failure
+                # mode the curator identified: violating odd-pin
+                # parallel-along-the-edge escapes get clipped to ~0
+                # while perpendicular even-pin escapes retain most of
+                # their original launch length.
+                original_launch = self.escape_clearance + self.rules.trace_width * 2
+                min_useful_length = original_launch * 0.5
+                if escape.segments:
+                    seg = escape.segments[0]
+                    seg_len = math.hypot(seg.x2 - seg.x1, seg.y2 - seg.y1)
+                    if seg_len < min_useful_length:
+                        skipped_clearance += 1
+                        logger.debug(
+                            "Escape for %s pin %s skipped: pad-clearance "
+                            "clip produced segment of %.3fmm "
+                            "(< %.3fmm threshold)",
+                            pad.net_name, pad.pin, seg_len, min_useful_length,
+                        )
+                        continue
+
                 escapes.append(escape)
+
+        if skipped_clearance:
+            logger.info(
+                "Escape routing for %s (%s): %d pins deferred to main "
+                "router due to pad-clearance clip (Issue #2756)",
+                package.ref,
+                package.package_type.name,
+                skipped_clearance,
+            )
 
         return escapes
 
@@ -1825,13 +1885,29 @@ class EscapeRouter:
         pad: Pad,
         direction: EscapeDirection,
         package: PackageInfo,
+        pad_clearance_margin: float | None = None,
     ) -> EscapeRoute:
         """Create an escape route with alternating direction.
+
+        Issue #2756: When ``pad_clearance_margin`` is provided, the escape
+        segment endpoint is shortened along the launch direction so that the
+        segment maintains at least ``pad_clearance_margin`` mm of edge-to-edge
+        clearance against every OTHER pad in ``package.pads`` on the same
+        layer.  If the maximum safe length is shorter than the requested
+        launch distance, the segment is clipped; if no useful length is
+        achievable (the pad is fully boxed in), the returned escape carries a
+        zero-length segment which the caller can detect and skip.  Passing
+        ``None`` (the default) preserves pre-#2756 behaviour exactly for
+        callers that have not yet been ported to the clipping API.
 
         Args:
             pad: The pad to escape
             direction: Escape direction
             package: Package info
+            pad_clearance_margin: Optional minimum edge-to-edge clearance
+                from the escape segment to every other package pad.  When
+                provided, the segment endpoint is clipped to honour this
+                margin.
 
         Returns:
             EscapeRoute for this pad
@@ -1841,6 +1917,25 @@ class EscapeRouter:
 
         # Calculate escape distance
         escape_dist = self.escape_clearance + self.rules.trace_width * 2
+        trace_w = self._get_trace_width_for_net(pad.net_name)
+
+        # Issue #2756: clip the escape distance against neighbour-pad
+        # clearance when requested.  This stops the QFP/QFN/HTSSOP
+        # alternating-direction emitter from producing segments that run
+        # through (or just clip) adjacent pads on the same edge -- the
+        # dominant failure mode behind board 05's 105 clearance_pad_segment
+        # violations on U3 (DRV8301 HTSSOP-56) and U10 (STM32G431 LQFP-32).
+        if pad_clearance_margin is not None:
+            safe_dist = self._compute_max_safe_escape_length(
+                pad=pad,
+                dx=dx,
+                dy=dy,
+                trace_width=trace_w,
+                package_pads=package.pads,
+                min_clearance=pad_clearance_margin,
+                max_length=escape_dist,
+            )
+            escape_dist = min(escape_dist, safe_dist)
 
         escape_x = pad.x + dx * escape_dist
         escape_y = pad.y + dy * escape_dist
@@ -1851,7 +1946,7 @@ class EscapeRouter:
             y1=pad.y,
             x2=escape_x,
             y2=escape_y,
-            width=self._get_trace_width_for_net(pad.net_name),
+            width=trace_w,
             layer=pad.layer,
             net=pad.net,
             net_name=pad.net_name,
@@ -1867,6 +1962,111 @@ class EscapeRouter:
             via=None,
             ring_index=0,
         )
+
+    def _compute_max_safe_escape_length(
+        self,
+        pad: Pad,
+        dx: float,
+        dy: float,
+        trace_width: float,
+        package_pads: list[Pad],
+        min_clearance: float,
+        max_length: float,
+    ) -> float:
+        """Find the maximum escape-segment length that respects pad clearance.
+
+        Issue #2756: The escape-pattern endpoint emitter (used by
+        ``_create_alternating_escape`` and ``_escape_radial``) historically
+        emitted segments of a fixed launch length without checking that the
+        segment kept ``pad_to_segment`` clearance to neighbour pads on the
+        same package.  When the launch direction is parallel-along-the-edge
+        (the ``alt_dir_cw`` / ``alt_dir_ccw`` cases for odd pins in
+        ``_escape_qfp_alternating``) the segment runs right past the next
+        pad in the row and clips it, producing a ``clearance_pad_segment``
+        DRC error.  This helper computes the maximum length ``L`` such that
+        the candidate segment from ``pad`` to ``(pad + (dx,dy) * L)`` keeps
+        at least ``min_clearance`` mm of edge-to-edge gap from every other
+        pad in ``package_pads`` on the same layer.
+
+        The search is a coarse binary search bracketed by 0 and
+        ``max_length`` -- a 1-D search is sufficient because the candidate
+        segment is a straight line from the pad in a single direction, and
+        the clearance function is monotonically non-decreasing as the
+        endpoint pulls back toward the originating pad along the launch
+        axis (for reasonable launch directions away from neighbours).
+
+        Args:
+            pad: Originating pad (segment starts here)
+            dx: X component of the unit launch direction
+            dy: Y component of the unit launch direction
+            trace_width: Width of the candidate segment in mm
+            package_pads: All pads on the same package (the originating pad
+                is identified by identity and skipped from the check)
+            min_clearance: Required minimum edge-to-edge clearance in mm
+            max_length: Upper bound on the search (typically the original
+                requested launch distance)
+
+        Returns:
+            The maximum safe length in mm, in the range
+            ``[0.0, max_length]``.  A returned value of 0.0 means even a
+            zero-length stub would conflict with a neighbour (only possible
+            when ``min_clearance`` is larger than the pad-to-pad spacing
+            and the originating pad already touches its neighbour's
+            clearance halo).  The caller should treat values below a small
+            useful threshold (e.g. ``min_clearance + trace_width``) as a
+            defer-to-router signal.
+        """
+        if max_length <= 0:
+            return 0.0
+
+        def _gap_at(length: float) -> float:
+            """Minimum edge-to-edge gap from the candidate segment to any
+            other pad on the same layer."""
+            ex = pad.x + dx * length
+            ey = pad.y + dy * length
+            candidate = Segment(
+                x1=pad.x, y1=pad.y, x2=ex, y2=ey,
+                width=trace_width, layer=pad.layer,
+                net=pad.net, net_name=pad.net_name,
+            )
+            min_gap = float("inf")
+            for other in package_pads:
+                if other is pad:
+                    continue
+                # Defensive: skip pads that share coords with the originator
+                # (would be a duplicate pad entry; rare but seen in tests).
+                if other.x == pad.x and other.y == pad.y:
+                    continue
+                # Only check pads that touch the segment's layer.  PTH pads
+                # touch every copper layer so always check those.
+                if not other.through_hole and other.layer != pad.layer:
+                    continue
+                gap = self._segment_to_pad_edge_gap(candidate, other)
+                if gap < min_gap:
+                    min_gap = gap
+            return min_gap
+
+        # If the full-length segment is already clear, no clipping needed.
+        full_gap = _gap_at(max_length)
+        if full_gap >= min_clearance - 1e-6:
+            return max_length
+
+        # Otherwise, binary-search for the longest length that still clears.
+        # If even a zero-length stub conflicts (rare), bail out at 0.
+        if _gap_at(0.0) < min_clearance - 1e-6:
+            return 0.0
+
+        lo = 0.0
+        hi = max_length
+        # 12 iterations resolves to ~max_length / 4096 -- well below the
+        # router grid resolution for any practical launch distance.
+        for _ in range(12):
+            mid = (lo + hi) / 2
+            if _gap_at(mid) >= min_clearance - 1e-6:
+                lo = mid
+            else:
+                hi = mid
+        return lo
 
     def _escape_fine_pitch_dual_row(self, package: PackageInfo) -> list[EscapeRoute]:
         """Generate escape routes with alternating layer escapes for fine-pitch SSOP/TSSOP.
@@ -2804,6 +3004,14 @@ class EscapeRouter:
 
         Each pin escapes directly outward from package center.
 
+        Issue #2756: When neighbour pads sit close enough to the launch
+        line that the escape stub would clip them (the dominant failure
+        mode on TO-220 MOSFETs Q5/Q6 on board 05), the segment endpoint
+        is clipped to honour pad-to-segment clearance.  Stubs that get
+        clipped below a useful threshold are dropped so the main router
+        can pick the pad up cleanly instead of having to fight an
+        already-violating escape segment.
+
         Args:
             package: Package info
 
@@ -2813,6 +3021,16 @@ class EscapeRouter:
         escapes: list[EscapeRoute] = []
         center_x, center_y = package.center
 
+        # Issue #2756: resolve the effective clearance once per package.
+        effective_clearance = self.rules.get_clearance_for_component(
+            package.ref, pin_pitch=package.pin_pitch,
+        )
+
+        # Useful-length threshold for the clipped stub: half the original
+        # launch distance.  Matches the heuristic in
+        # ``_escape_qfp_alternating``.
+        min_useful_length = self.escape_clearance * 0.5
+
         for pad in package.pads:
             # Issue #2513: Skip plane-net pads (net=0) -- they are stitched
             # via planes, not routed via escapes.
@@ -2821,8 +3039,30 @@ class EscapeRouter:
 
             direction = self._get_quadrant_direction(pad.x, pad.y, center_x, center_y)
             dx, dy = self._direction_to_vector(direction)
+            trace_w = self._get_trace_width_for_net(pad.net_name)
 
-            escape_dist = self.escape_clearance
+            # Issue #2756: clip the radial escape against neighbour pads.
+            requested_dist = self.escape_clearance
+            safe_dist = self._compute_max_safe_escape_length(
+                pad=pad,
+                dx=dx,
+                dy=dy,
+                trace_width=trace_w,
+                package_pads=package.pads,
+                min_clearance=effective_clearance,
+                max_length=requested_dist,
+            )
+            escape_dist = min(requested_dist, safe_dist)
+
+            # Drop stubs that are too short to exit the pad halo.
+            if escape_dist < min_useful_length:
+                logger.debug(
+                    "Radial escape for %s pin %s skipped: clipped length "
+                    "%.3fmm < %.3fmm threshold (Issue #2756)",
+                    pad.net_name, pad.pin, escape_dist, min_useful_length,
+                )
+                continue
+
             escape_x = pad.x + dx * escape_dist
             escape_y = pad.y + dy * escape_dist
 
@@ -2831,7 +3071,7 @@ class EscapeRouter:
                 y1=pad.y,
                 x2=escape_x,
                 y2=escape_y,
-                width=self._get_trace_width_for_net(pad.net_name),
+                width=trace_w,
                 layer=pad.layer,
                 net=pad.net,
                 net_name=pad.net_name,

--- a/tests/test_escape.py
+++ b/tests/test_escape.py
@@ -636,7 +636,17 @@ class TestEscapeRouter:
             assert escape.direction != EscapeDirection.VIA_DOWN or escape.via is not None
 
     def test_generate_escapes_qfp(self, grid_and_rules):
-        """Test escape generation for QFP."""
+        """Test escape generation for QFP.
+
+        Issue #2756: With the post-fix pad-clearance clipping, a 0.5mm-pitch
+        QFP-32 escape with trace_clearance=0.2mm produces fewer escapes than
+        the naive ``one-per-pad`` upper bound -- escapes whose clipped
+        segment is too short to clear the pad halo are deferred to the main
+        router rather than emitted as clearance-violating stubs.  The
+        previous assertion of ``len(escapes) == 32`` was relying on the
+        broken pre-#2756 behaviour where the alternating direction emitter
+        wrote violating segments unconditionally.
+        """
         grid, rules = grid_and_rules
         router = EscapeRouter(grid, rules)
 
@@ -644,8 +654,35 @@ class TestEscapeRouter:
         info = router.analyze_package(pads)
         escapes = router.generate_escapes(info)
 
-        # Should have escape for each edge pad
-        assert len(escapes) == 32
+        # At least the perpendicular (even-indexed) escapes on every edge
+        # should survive clipping (perpendicular launches don't run along
+        # the same-edge pads).  4 edges * 4 even pins = 16 minimum.
+        assert len(escapes) >= 16, (
+            f"Expected at least 16 perpendicular-axis escapes for QFP-32, "
+            f"got {len(escapes)}"
+        )
+        # Upper bound is one-per-edge-pad (32) -- no escape should be added
+        # spuriously by the clipping path.
+        assert len(escapes) <= 32
+
+        # Every escape must respect pad-to-segment clearance against
+        # every OTHER pad on the package (the post-#2756 invariant).
+        for escape in escapes:
+            for seg in escape.segments:
+                if seg.layer != Layer.F_CU:
+                    continue  # vias escape on other layers, skip
+                for other in pads:
+                    if other is escape.pad:
+                        continue
+                    if other.layer != seg.layer and not other.through_hole:
+                        continue
+                    gap = router._segment_to_pad_edge_gap(seg, other)
+                    # Allow a small float tolerance.
+                    assert gap >= rules.trace_clearance - 1e-6, (
+                        f"Escape from pad {escape.pad.net_name} violates "
+                        f"clearance against pad {other.net_name}: "
+                        f"gap={gap:.4f} < required={rules.trace_clearance:.4f}"
+                    )
 
     def test_escape_directions_vary(self, grid_and_rules):
         """Test that escapes use different directions."""

--- a/tests/test_escape_pad_clearance_2756.py
+++ b/tests/test_escape_pad_clearance_2756.py
@@ -1,0 +1,683 @@
+"""Tests for Issue #2756: escape-pattern endpoint pad-clearance check.
+
+PR #2753's coordinate-space fix surfaced 105 ``clearance_pad_segment``
+violations on board 05 (BLDC motor controller).  Curator analysis traced
+~80% of these to the QFP/QFN/HTSSOP alternating-direction escape emitter
+in ``_escape_qfp_alternating`` -- specifically, the odd-pin "parallel
+along the edge" escapes that the emitter generates without first checking
+whether the segment endpoint would clip a neighbouring pad on the same
+edge.  The DRV8301 HTSSOP-56 (U3) and STM32G431 LQFP-32 (U10) on board 05
+together account for 88 of the 105 violations, clustered tightly around
+U3-32 (6 violations), U10-30/32 and U3-31/45 (4 each).
+
+This test module pins down the invariant that the post-fix emitter
+honours: every escape segment produced by ``generate_escapes`` must
+maintain at least ``effective_clearance`` mm of edge-to-edge gap from
+every OTHER pad on the same package, on the same layer.  Tests cover:
+
+1. The new ``_compute_max_safe_escape_length`` helper (unit-level)
+2. ``_create_alternating_escape`` clipping when ``pad_clearance_margin``
+   is provided
+3. ``_escape_qfp_alternating`` deferral when a clipped segment is too
+   short to be useful (the in-pad fallback path on capable manufacturers
+   continues to work)
+4. ``_escape_radial`` clipping for TO-220-style packages where
+   neighbour-pad clearance is the binding constraint
+
+Backward compatibility:
+- Passing ``pad_clearance_margin=None`` to ``_create_alternating_escape``
+  preserves pre-#2756 behaviour exactly.
+- SSOP/TSSOP escapes (separate ``_escape_fine_pitch_dual_row`` path) are
+  unchanged -- they already had per-segment pad-clearance checks since
+  Issue #2319.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from kicad_tools.router.escape import (
+    EscapeDirection,
+    EscapeRouter,
+    PackageType,
+)
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules
+
+# ----------------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------------
+
+
+def _make_dense_qfp_pads(
+    pins_per_side: int = 14,
+    pitch: float = 0.5,
+    pad_short: float = 0.28,
+    pad_long: float = 1.30,
+    body_size: float | None = None,
+    ref: str = "U3",
+    start_net: int = 1,
+) -> list[Pad]:
+    """Build a synthetic dense QFP-like package.
+
+    Defaults approximate the DRV8301 HTSSOP-56 layout (14 pins per side
+    at 0.5 mm pitch on a ~7 x 14 mm body) -- the dominant violation
+    source on board 05.
+    """
+    if body_size is None:
+        body_size = (pins_per_side - 1) * pitch + 3.0 * pitch + 2.0 * pad_long
+    half_body = body_size / 2
+    pad_center_offset = half_body + pad_long / 2
+
+    pads: list[Pad] = []
+    pin_no = 1
+    span = (pins_per_side - 1) * pitch
+    half_span = span / 2
+
+    # WEST edge (vertical pads): long axis = X, short axis = Y
+    for i in range(pins_per_side):
+        y = half_span - i * pitch
+        pads.append(
+            Pad(
+                x=-pad_center_offset,
+                y=y,
+                width=pad_long,
+                height=pad_short,
+                net=start_net + pin_no - 1,
+                net_name=f"NET{start_net + pin_no - 1}",
+                ref=ref,
+                pin=str(pin_no),
+                layer=Layer.F_CU,
+            )
+        )
+        pin_no += 1
+
+    # SOUTH edge (horizontal pads): long axis = Y, short axis = X
+    for i in range(pins_per_side):
+        x = -half_span + i * pitch
+        pads.append(
+            Pad(
+                x=x,
+                y=-pad_center_offset,
+                width=pad_short,
+                height=pad_long,
+                net=start_net + pin_no - 1,
+                net_name=f"NET{start_net + pin_no - 1}",
+                ref=ref,
+                pin=str(pin_no),
+                layer=Layer.F_CU,
+            )
+        )
+        pin_no += 1
+
+    # EAST edge
+    for i in range(pins_per_side):
+        y = -half_span + i * pitch
+        pads.append(
+            Pad(
+                x=pad_center_offset,
+                y=y,
+                width=pad_long,
+                height=pad_short,
+                net=start_net + pin_no - 1,
+                net_name=f"NET{start_net + pin_no - 1}",
+                ref=ref,
+                pin=str(pin_no),
+                layer=Layer.F_CU,
+            )
+        )
+        pin_no += 1
+
+    # NORTH edge
+    for i in range(pins_per_side):
+        x = half_span - i * pitch
+        pads.append(
+            Pad(
+                x=x,
+                y=pad_center_offset,
+                width=pad_short,
+                height=pad_long,
+                net=start_net + pin_no - 1,
+                net_name=f"NET{start_net + pin_no - 1}",
+                ref=ref,
+                pin=str(pin_no),
+                layer=Layer.F_CU,
+            )
+        )
+        pin_no += 1
+
+    return pads
+
+
+def _jlcpcb_rules() -> DesignRules:
+    """Default JLCPCB-tier-0 design rules (no via-in-pad)."""
+    return DesignRules(
+        trace_width=0.2,
+        trace_clearance=0.127,
+        via_drill=0.3,
+        via_diameter=0.6,
+        via_clearance=0.127,
+        grid_resolution=0.05,
+        fine_pitch_clearance=0.127,
+        fine_pitch_threshold=0.8,
+        min_trace_width=0.127,
+    )
+
+
+def _make_router(rules: DesignRules | None = None) -> EscapeRouter:
+    if rules is None:
+        rules = _jlcpcb_rules()
+    grid = RoutingGrid(
+        width=40.0,
+        height=40.0,
+        rules=rules,
+        origin_x=-20.0,
+        origin_y=-20.0,
+    )
+    return EscapeRouter(grid, rules)
+
+
+# ----------------------------------------------------------------------------
+# Unit tests: _compute_max_safe_escape_length helper
+# ----------------------------------------------------------------------------
+
+
+class TestComputeMaxSafeEscapeLength:
+    """Unit-level coverage of the new clipping helper."""
+
+    def test_unobstructed_direction_returns_full_length(self):
+        """When no other pads sit along the launch ray, the helper must
+        return ``max_length`` unchanged."""
+        router = _make_router()
+        pad = Pad(
+            x=0.0,
+            y=0.0,
+            width=0.3,
+            height=0.3,
+            net=1,
+            net_name="A",
+            ref="U1",
+            pin="1",
+            layer=Layer.F_CU,
+        )
+        # Single pad means no neighbours to violate.
+        result = router._compute_max_safe_escape_length(
+            pad=pad,
+            dx=1.0,
+            dy=0.0,
+            trace_width=0.2,
+            package_pads=[pad],
+            min_clearance=0.127,
+            max_length=2.0,
+        )
+        assert result == pytest.approx(2.0)
+
+    def test_neighbor_on_launch_axis_clips_segment(self):
+        """A neighbour pad sitting directly along the launch direction
+        must clip the segment to stop short of the neighbour's
+        clearance halo."""
+        router = _make_router()
+        pad = Pad(
+            x=0.0,
+            y=0.0,
+            width=0.3,
+            height=0.3,
+            net=1,
+            net_name="A",
+            ref="U1",
+            pin="1",
+            layer=Layer.F_CU,
+        )
+        # Neighbour at x=1.0, half-width 0.15.  Neighbour west edge sits
+        # at x=0.85.  With trace half-width 0.1 + clearance 0.127, the
+        # candidate endpoint must satisfy x <= 0.85 - 0.1 - 0.127 = 0.623.
+        neighbour = Pad(
+            x=1.0,
+            y=0.0,
+            width=0.3,
+            height=0.3,
+            net=2,
+            net_name="B",
+            ref="U1",
+            pin="2",
+            layer=Layer.F_CU,
+        )
+        result = router._compute_max_safe_escape_length(
+            pad=pad,
+            dx=1.0,
+            dy=0.0,
+            trace_width=0.2,
+            package_pads=[pad, neighbour],
+            min_clearance=0.127,
+            max_length=2.0,
+        )
+        assert result < 0.85, f"Expected clip below neighbour west edge (0.85mm), got {result}"
+        # The clipped distance must keep the required clearance.
+        assert result == pytest.approx(0.85 - 0.1 - 0.127, abs=1e-3)
+
+    def test_neighbor_on_other_layer_does_not_clip(self):
+        """A neighbour on a different layer (and not PTH) must NOT
+        contribute to clipping -- the clearance check is per-layer."""
+        router = _make_router()
+        pad = Pad(
+            x=0.0,
+            y=0.0,
+            width=0.3,
+            height=0.3,
+            net=1,
+            net_name="A",
+            ref="U1",
+            pin="1",
+            layer=Layer.F_CU,
+        )
+        neighbour_back = Pad(
+            x=0.5,
+            y=0.0,
+            width=0.3,
+            height=0.3,
+            net=2,
+            net_name="B",
+            ref="U1",
+            pin="2",
+            layer=Layer.B_CU,
+            through_hole=False,
+        )
+        result = router._compute_max_safe_escape_length(
+            pad=pad,
+            dx=1.0,
+            dy=0.0,
+            trace_width=0.2,
+            package_pads=[pad, neighbour_back],
+            min_clearance=0.127,
+            max_length=2.0,
+        )
+        # Should return full length since neighbour is on opposite layer.
+        assert result == pytest.approx(2.0)
+
+    def test_through_hole_neighbor_always_clips(self):
+        """A PTH pad blocks every copper layer, so it must clip the
+        segment regardless of ``pad.layer``."""
+        router = _make_router()
+        pad = Pad(
+            x=0.0,
+            y=0.0,
+            width=0.3,
+            height=0.3,
+            net=1,
+            net_name="A",
+            ref="U1",
+            pin="1",
+            layer=Layer.F_CU,
+        )
+        # PTH neighbour with layer set to B.Cu still blocks F.Cu segments.
+        neighbour = Pad(
+            x=1.0,
+            y=0.0,
+            width=0.6,
+            height=0.6,
+            net=2,
+            net_name="B",
+            ref="U1",
+            pin="2",
+            layer=Layer.B_CU,
+            through_hole=True,
+            drill=0.3,
+        )
+        result = router._compute_max_safe_escape_length(
+            pad=pad,
+            dx=1.0,
+            dy=0.0,
+            trace_width=0.2,
+            package_pads=[pad, neighbour],
+            min_clearance=0.127,
+            max_length=2.0,
+        )
+        # PTH neighbour west edge at x=0.7; expected clip 0.7 - 0.1 - 0.127 = 0.473
+        assert result < 0.7
+        assert result == pytest.approx(0.7 - 0.1 - 0.127, abs=1e-3)
+
+    def test_zero_max_length_returns_zero(self):
+        """Defensive: passing max_length=0 must short-circuit to 0."""
+        router = _make_router()
+        pad = Pad(
+            x=0.0,
+            y=0.0,
+            width=0.3,
+            height=0.3,
+            net=1,
+            net_name="A",
+            ref="U1",
+            pin="1",
+            layer=Layer.F_CU,
+        )
+        result = router._compute_max_safe_escape_length(
+            pad=pad,
+            dx=1.0,
+            dy=0.0,
+            trace_width=0.2,
+            package_pads=[pad],
+            min_clearance=0.127,
+            max_length=0.0,
+        )
+        assert result == 0.0
+
+
+# ----------------------------------------------------------------------------
+# Integration tests: _create_alternating_escape clipping
+# ----------------------------------------------------------------------------
+
+
+class TestAlternatingEscapeClipping:
+    """``_create_alternating_escape`` must clip segments when
+    ``pad_clearance_margin`` is provided."""
+
+    def test_unclipped_behavior_preserved_when_margin_none(self):
+        """Backward compatibility: passing pad_clearance_margin=None
+        must produce the exact same EscapeRoute as the pre-#2756 code."""
+        router = _make_router()
+        pads = _make_dense_qfp_pads(pins_per_side=8, pitch=0.5)
+        info = router.analyze_package(pads)
+        assert info.package_type in (
+            PackageType.QFP,
+            PackageType.QFN,
+            PackageType.TQFP,
+        )
+
+        # Pick the first west-edge pad to escape east (parallel along edge).
+        pad = pads[0]
+        unclipped = router._create_alternating_escape(
+            pad=pad,
+            direction=EscapeDirection.EAST,
+            package=info,
+            pad_clearance_margin=None,
+        )
+        # The unclipped escape should reach the full launch distance.
+        expected_dist = router.escape_clearance + router.rules.trace_width * 2
+        seg = unclipped.segments[0]
+        actual_dist = math.hypot(seg.x2 - seg.x1, seg.y2 - seg.y1)
+        assert actual_dist == pytest.approx(expected_dist, abs=1e-6)
+
+    def test_clipped_escape_respects_pad_clearance(self):
+        """With pad_clearance_margin set, the returned segment must
+        keep clearance to every other pad in the package."""
+        router = _make_router()
+        pads = _make_dense_qfp_pads(pins_per_side=8, pitch=0.5)
+        info = router.analyze_package(pads)
+        clearance = router.rules.trace_clearance
+
+        for pad in pads[:4]:
+            # Direction along the edge (the failure mode)
+            direction = EscapeDirection.EAST if pad.x < 0 else EscapeDirection.WEST
+            escape = router._create_alternating_escape(
+                pad=pad,
+                direction=direction,
+                package=info,
+                pad_clearance_margin=clearance,
+            )
+            seg = escape.segments[0]
+            for other in pads:
+                if other is pad:
+                    continue
+                if other.layer != seg.layer and not other.through_hole:
+                    continue
+                gap = router._segment_to_pad_edge_gap(seg, other)
+                assert gap >= clearance - 1e-6, (
+                    f"Clipped escape from {pad.net_name} towards {direction.name} "
+                    f"violates clearance against {other.net_name}: "
+                    f"gap={gap:.4f} mm, required={clearance:.4f} mm"
+                )
+
+    def test_clipping_shortens_perpendicular_segments_minimally(self):
+        """Perpendicular launches (the EVEN-pin case in
+        ``_escape_qfp_alternating``) should require minimal clipping
+        because they launch AWAY from neighbour pads."""
+        router = _make_router()
+        pads = _make_dense_qfp_pads(pins_per_side=8, pitch=0.5)
+        info = router.analyze_package(pads)
+        clearance = router.rules.trace_clearance
+
+        # Pick a west-edge pad; perpendicular escape is WEST (away from package)
+        west_pad = next(p for p in pads if p.x < 0)
+        escape = router._create_alternating_escape(
+            pad=west_pad,
+            direction=EscapeDirection.WEST,
+            package=info,
+            pad_clearance_margin=clearance,
+        )
+        seg = escape.segments[0]
+        # Perpendicular escape should reach close to the original launch dist.
+        full_dist = router.escape_clearance + router.rules.trace_width * 2
+        actual_dist = math.hypot(seg.x2 - seg.x1, seg.y2 - seg.y1)
+        # Perpendicular escape should retain at least 50% of the launch dist.
+        assert actual_dist >= 0.5 * full_dist, (
+            f"Perpendicular escape was over-clipped: {actual_dist}mm of {full_dist}mm"
+        )
+
+
+# ----------------------------------------------------------------------------
+# Integration tests: _escape_qfp_alternating end-to-end behaviour
+# ----------------------------------------------------------------------------
+
+
+class TestQfpAlternatingClearance:
+    """End-to-end: every escape from ``generate_escapes`` must satisfy
+    pad-to-segment clearance against every OTHER pad on the same
+    package."""
+
+    def test_dense_htssop_escapes_respect_clearance(self):
+        """The flagship test: a DRV8301-style HTSSOP-56 package at
+        0.5mm pitch must produce zero clearance-violating escape
+        segments after the #2756 fix."""
+        router = _make_router()
+        pads = _make_dense_qfp_pads(
+            pins_per_side=14,
+            pitch=0.5,
+            ref="U3",
+        )
+        info = router.analyze_package(pads)
+        escapes = router.generate_escapes(info)
+
+        clearance = router.rules.trace_clearance
+        violations: list[tuple[str, str, float]] = []
+        for escape in escapes:
+            for seg in escape.segments:
+                if seg.layer != Layer.F_CU:
+                    continue
+                for other in pads:
+                    if other is escape.pad:
+                        continue
+                    if other.layer != seg.layer and not other.through_hole:
+                        continue
+                    gap = router._segment_to_pad_edge_gap(seg, other)
+                    if gap < clearance - 1e-6:
+                        violations.append((escape.pad.net_name, other.net_name, gap))
+
+        assert violations == [], (
+            f"Issue #2756 regression: {len(violations)} escape segments "
+            f"violate pad-to-segment clearance on a dense HTSSOP-56 fixture. "
+            f"First few: {violations[:5]}"
+        )
+
+    def test_lqfp32_escapes_respect_clearance(self):
+        """STM32G431 LQFP-32 (board 05 U10) at 0.8mm pitch -- the
+        ``use_perpendicular_only`` branch.  All perpendicular escapes
+        should remain emittable and clearance-compliant."""
+        router = _make_router()
+        pads = _make_dense_qfp_pads(
+            pins_per_side=8,
+            pitch=0.8,
+            ref="U10",
+        )
+        info = router.analyze_package(pads)
+        escapes = router.generate_escapes(info)
+
+        # LQFP-32 at 0.8mm pitch should escape ALL pads (perpendicular).
+        # We don't require every pad to escape but we DO require zero
+        # clearance violations.
+        clearance = router.rules.trace_clearance
+        for escape in escapes:
+            for seg in escape.segments:
+                if seg.layer != Layer.F_CU:
+                    continue
+                for other in pads:
+                    if other is escape.pad:
+                        continue
+                    if other.layer != seg.layer and not other.through_hole:
+                        continue
+                    gap = router._segment_to_pad_edge_gap(seg, other)
+                    assert gap >= clearance - 1e-6, (
+                        f"LQFP-32 escape from {escape.pad.net_name} "
+                        f"violates clearance against {other.net_name}: "
+                        f"gap={gap:.4f} < required={clearance:.4f}"
+                    )
+
+    def test_perpendicular_escapes_survive_clipping(self):
+        """Even-indexed pins escape perpendicular to the row -- these
+        should always be emittable because the launch direction is
+        away from same-edge neighbour pads.  At least one perpendicular
+        escape per edge must survive."""
+        router = _make_router()
+        pads = _make_dense_qfp_pads(pins_per_side=14, pitch=0.5)
+        info = router.analyze_package(pads)
+        escapes = router.generate_escapes(info)
+
+        # Each edge should contribute at least one perpendicular escape
+        # (the even-pin case in _escape_qfp_alternating).
+        directions = {e.direction for e in escapes}
+        # NORTH/SOUTH/EAST/WEST = perpendicular directions for each edge.
+        perp_dirs = {
+            EscapeDirection.NORTH,
+            EscapeDirection.SOUTH,
+            EscapeDirection.EAST,
+            EscapeDirection.WEST,
+        }
+        present_perp = directions & perp_dirs
+        assert len(present_perp) >= 2, (
+            f"Expected perpendicular escapes from at least 2 edges, "
+            f"got directions: {[d.name for d in directions]}"
+        )
+
+
+# ----------------------------------------------------------------------------
+# Integration tests: _escape_radial clipping (TO-220 case)
+# ----------------------------------------------------------------------------
+
+
+class TestRadialClearance:
+    """``_escape_radial`` (used for TO-220 MOSFETs Q5/Q6 on board 05)
+    must also clip segments to honour pad clearance."""
+
+    def test_to220_radial_escapes_respect_clearance(self):
+        """A 3-pin TO-220 with closely-spaced pads should not emit
+        radial escapes that clip neighbour pads."""
+        router = _make_router()
+        # Synthetic TO-220 layout: 3 pads at 2.54mm pitch, 1.5x1.5mm pads.
+        pads = [
+            Pad(
+                x=-2.54,
+                y=0.0,
+                width=1.5,
+                height=1.5,
+                net=1,
+                net_name="DRAIN",
+                ref="Q5",
+                pin="1",
+                layer=Layer.F_CU,
+                through_hole=True,
+                drill=1.0,
+            ),
+            Pad(
+                x=0.0,
+                y=0.0,
+                width=1.5,
+                height=1.5,
+                net=2,
+                net_name="GATE",
+                ref="Q5",
+                pin="2",
+                layer=Layer.F_CU,
+                through_hole=True,
+                drill=1.0,
+            ),
+            Pad(
+                x=2.54,
+                y=0.0,
+                width=1.5,
+                height=1.5,
+                net=3,
+                net_name="SOURCE",
+                ref="Q5",
+                pin="3",
+                layer=Layer.F_CU,
+                through_hole=True,
+                drill=1.0,
+            ),
+        ]
+        info = router.analyze_package(pads)
+        # Force radial path -- TO-220 should not be classified as dense.
+        # Call _escape_radial directly to avoid the package-type dispatch.
+        escapes = router._escape_radial(info)
+
+        clearance = router.rules.trace_clearance
+        for escape in escapes:
+            for seg in escape.segments:
+                for other in pads:
+                    if other is escape.pad:
+                        continue
+                    # PTH pads block every layer, so always check.
+                    gap = router._segment_to_pad_edge_gap(seg, other)
+                    assert gap >= clearance - 1e-6, (
+                        f"Radial escape from {escape.pad.net_name} "
+                        f"violates clearance against {other.net_name}: "
+                        f"gap={gap:.4f} < required={clearance:.4f}"
+                    )
+
+
+# ----------------------------------------------------------------------------
+# Test: in-pad fallback path is unaffected
+# ----------------------------------------------------------------------------
+
+
+class TestInPadFallbackPreserved:
+    """Issue #2695 in-pad fallback must continue to engage on capable
+    manufacturers when surface escapes fail clearance.  Specifically,
+    the #2756 clipping must NOT mask the violation from the in-pad
+    check (the in-pad path is the right answer for via-in-pad-capable
+    manufacturers, since clipping leaves a stub that cannot continue
+    routing past the same neighbour)."""
+
+    def test_lqfp48_jlcpcb_tier1_emits_in_pad_vias(self):
+        """LQFP-48 on jlcpcb-tier1 (via-in-pad supported) should still
+        produce in-pad vias for inner pins that would otherwise fail
+        surface clearance."""
+        rules = _jlcpcb_rules()
+        grid = RoutingGrid(
+            width=40.0,
+            height=40.0,
+            rules=rules,
+            origin_x=-20.0,
+            origin_y=-20.0,
+        )
+        router = EscapeRouter(grid, rules, manufacturer="jlcpcb-tier1")
+        assert router.via_in_pad_supported, (
+            "Test precondition: jlcpcb-tier1 must report via-in-pad supported"
+        )
+
+        pads = _make_dense_qfp_pads(pins_per_side=12, pitch=0.5, ref="U2")
+        info = router.analyze_package(pads)
+        escapes = router.generate_escapes(info)
+
+        # At least some escapes should use in-pad vias.
+        in_pad_count = sum(
+            1 for e in escapes if e.via is not None and getattr(e.via, "in_pad", False)
+        )
+        # We don't pin the exact count -- just verify the rescue path
+        # is exercised.  Pre-#2756 this returned >= 1; post-#2756 must too.
+        assert in_pad_count >= 1, (
+            f"Expected in-pad via rescue to fire on LQFP-48 / jlcpcb-tier1, "
+            f"got {in_pad_count} in-pad vias of {len(escapes)} escapes."
+        )


### PR DESCRIPTION
## Summary

Phase 1 fix for **Issue #2756** (DRC follow-up: `clearance_pad_segment` violations on board 05 surfaced by PR #2753 coord-space fix).

- Adds `pad_clearance_margin` to the QFP/QFN/HTSSOP alternating-direction escape emitter (`_create_alternating_escape`) so escape segment endpoints honour pad-to-segment clearance against neighbour pads on the same package.
- Extends the same clipping to the `_escape_radial` path (TO-220 case for board 05's Q5/Q6 MOSFETs).
- Adds a new `_compute_max_safe_escape_length` helper (binary search over launch distance).
- Preserves the Issue #2695 in-pad fallback exactly: the in-pad rescue check runs against the UNCLIPPED candidate so it still fires on `jlcpcb-tier1` / PCBWay; the clipped path is the right answer for default JLCPCB where in-pad isn't available.

## Root cause (from #2756 curator analysis)

PR #2753 fixed a coord-space bug that had been silently masking real DRC errors on board 05. Curator's verification on the routed PCB found:

- **105** `clearance_pad_segment` violations (the newly-visible class)
- ~88 of those (~80%) trace to the escape-pattern emitter
- Most-violated pads: `U3-32` (DRV8301 HTSSOP-56) with 6 violations; `U10-30/32`, `U3-31/45` with 4 each

The emitter writes a fixed-length escape stub from each pad without checking neighbour clearance. For odd pins using `alt_dir_cw`/`alt_dir_ccw` (parallel-along-the-edge), the stub runs right past the next pad in the row and clips it.

## What changed

| File | Change |
|---|---|
| `src/kicad_tools/router/escape.py` | +250 lines: new helper, clipping logic in `_create_alternating_escape` / `_escape_qfp_alternating` / `_escape_radial` |
| `tests/test_escape_pad_clearance_2756.py` | New file (13 tests): unit + integration coverage |
| `tests/test_escape.py` | Updated `test_generate_escapes_qfp` to reflect post-fix invariant (clearance compliance instead of escape count) |

## Test plan

- [x] All 181 escape tests pass (168 prior + 13 new)
- [x] Full router test suite: 1174 pass, 52 skipped, 2 pre-existing failures unrelated to this fix (`test_voltage_divider_high_completion`, `test_charlieplex_high_completion` — both fail on main without my changes)
- [x] `ruff check` clean on changed files
- [x] In-pad fallback preserved: `tests/test_escape_via_in_pad_lqfp.py` (9 tests) still passes
- [x] Diff-pair coupling unaffected: `tests/test_escape_diffpair.py` (28 tests) still passes
- [x] Backward compatibility: `pad_clearance_margin=None` produces identical EscapeRoute to pre-fix code

## Coordination notes (re: issue text)

- **Board 05 re-route + allowlist tightening is deferred to a follow-up.** PR #2753 (the coord-space fix that surfaces the 105 violations) is not yet merged, so the `105 → ≤25` empirical acceptance bound cannot be measured on this PR. When #2753 lands a follow-up should re-route board 05 (or wait for #2746-A's per-net-timeout fix to enable a clean route within budget) and update `.github/routed-drc-tolerance.yml`.
- **Phase 2 (Y1 placement nudge in `boards/05-bldc-motor-controller/design.py`) is out of scope.** Issue #2756 explicitly assigns Phases 2/3 as follow-ups when scope grows.
- **Sibling PRs**: #2755 / #2757 / #2758 also touch `router/escape.py` but in different functions (per-footprint clearance check / BGA escape geometry). Merge conflicts should be limited to import-order / surrounding-context.

## Closes

Closes #2756 (Phase 1 only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)