### PR TITLE
feat(build): add BuildStep.SYNC drift preflight before BOM/manufacturing (closes #2773)

### DIFF
--- a/src/kicad_tools/cli/build_cmd.py
+++ b/src/kicad_tools/cli/build_cmd.py
@@ -1734,8 +1734,7 @@ def _run_step_sync(ctx: BuildContext, console: Console) -> BuildResult:
             step="sync",
             success=True,
             message=(
-                f"[dry-run] Would reconcile {ctx.schematic_file.name}"
-                f" <-> {pcb_to_check.name}"
+                f"[dry-run] Would reconcile {ctx.schematic_file.name} <-> {pcb_to_check.name}"
             ),
         )
 

--- a/src/kicad_tools/cli/build_cmd.py
+++ b/src/kicad_tools/cli/build_cmd.py
@@ -41,6 +41,7 @@ class BuildStep(str, Enum):
     SCHEMATIC = "schematic"
     ERC = "erc"
     PCB = "pcb"
+    SYNC = "sync"
     OUTLINE = "outline"
     PLACEMENT = "placement"
     ZONES = "zones"
@@ -1642,6 +1643,187 @@ def _run_step_erc(ctx: BuildContext, console: Console) -> BuildResult:
         )
 
 
+def _print_sync_analysis_detail(analysis, console: Console) -> None:
+    """Print per-category sync analysis detail.
+
+    Mirrors :func:`pipeline_cmd._print_sync_analysis_detail` so the build
+    command surfaces the same actionable detail as ``kct pipeline``.
+    """
+    if analysis.value_mismatches:
+        console.print(f"    Value mismatches ({len(analysis.value_mismatches)}):")
+        for mm in analysis.value_mismatches:
+            console.print(
+                f"      {mm['reference']}: sch={mm['schematic_value']} pcb={mm['pcb_value']}"
+            )
+
+    if analysis.footprint_mismatches:
+        console.print(f"    Footprint mismatches ({len(analysis.footprint_mismatches)}):")
+        for mm in analysis.footprint_mismatches:
+            console.print(
+                f"      {mm['reference']}: sch={mm['schematic_footprint']}"
+                f" pcb={mm['pcb_footprint']}"
+            )
+
+    if analysis.add_footprint_actions:
+        console.print(f"    Add footprint ({len(analysis.add_footprint_actions)}):")
+        for action in analysis.add_footprint_actions:
+            ref = action["reference"]
+            fp = action.get("footprint", "")
+            val = action.get("value", "")
+            console.print(f"      {ref}: {fp} ({val})")
+
+    if analysis.schematic_orphans:
+        console.print(f"    Schematic-only ({len(analysis.schematic_orphans)}):")
+        for ref in analysis.schematic_orphans:
+            console.print(f"      {ref} - missing from PCB")
+
+    if analysis.pcb_orphans:
+        console.print(f"    PCB-only ({len(analysis.pcb_orphans)}):")
+        for ref in analysis.pcb_orphans:
+            console.print(f"      {ref} - not in schematic")
+
+
+def _run_step_sync(ctx: BuildContext, console: Console) -> BuildResult:
+    """Reconcile schematic <-> PCB component sets in-process.
+
+    Uses :class:`kicad_tools.sync.reconciler.Reconciler` to analyse drift
+    between the schematic and PCB right after the PCB write — before any
+    expensive downstream work (placement, zones, routing) is performed
+    and well before manufacturing artefacts are produced.
+
+    Mirrors :func:`pipeline_cmd._run_step_sync`'s blocking semantics:
+
+    - In sync: success with a one-line "sync: in sync" message.
+    - Schematic orphans (refs missing from PCB): blocking failure.
+      ``ctx.force`` converts this into a non-blocking warning so the user
+      can deliberately bypass the gate.
+    - Value/footprint mismatches or PCB-only refs without schematic
+      orphans: warning, build continues with ``success=True``.
+    - No schematic available: skipped (``success=True``).
+
+    Note: unlike :func:`pipeline_cmd._run_step_sync`, this implementation
+    does NOT expose a ``--apply-sync`` flag.  ``kct build --force`` is the
+    only escape hatch.  Auto-fixing drift belongs to ``kct pipeline`` /
+    ``kct sync --apply``.
+    """
+    # Skip if no schematic file available
+    if ctx.schematic_file is None or not ctx.schematic_file.exists():
+        return BuildResult(
+            step="sync",
+            success=True,
+            message=(
+                "sync: no schematic available — skipped"
+                " (use 'kct build --step schematic' or supply a schematic)"
+            ),
+        )
+
+    # Find the PCB to reconcile (prefer routed version when available,
+    # but typically SYNC runs right after PCB write so ctx.pcb_file is set
+    # and ctx.routed_pcb_file is still None).
+    pcb_to_check = ctx.routed_pcb_file or ctx.pcb_file
+    if not pcb_to_check or not pcb_to_check.exists():
+        return BuildResult(
+            step="sync",
+            success=False,
+            message="sync: no PCB file found to reconcile",
+        )
+
+    # Dry-run mode: preview without instantiating Reconciler
+    if ctx.dry_run:
+        return BuildResult(
+            step="sync",
+            success=True,
+            message=(
+                f"[dry-run] Would reconcile {ctx.schematic_file.name}"
+                f" <-> {pcb_to_check.name}"
+            ),
+        )
+
+    if not ctx.quiet:
+        console.print(f"  Reconciling {ctx.schematic_file.name} <-> {pcb_to_check.name}...")
+
+    # Instantiate Reconciler in-process (no subprocess overhead)
+    try:
+        from kicad_tools.sync.reconciler import Reconciler
+
+        reconciler = Reconciler(
+            schematic=ctx.schematic_file,
+            pcb=pcb_to_check,
+        )
+        analysis = reconciler.analyze()
+    except Exception as e:
+        logger.warning("sync: failed to analyze: %s", e)
+        return BuildResult(
+            step="sync",
+            success=False,
+            message=f"sync: failed to analyze — {e}",
+        )
+
+    # Clean pass
+    if analysis.is_in_sync:
+        return BuildResult(
+            step="sync",
+            success=True,
+            message="sync: in sync",
+        )
+
+    # Print the summary plus per-category detail
+    if not ctx.quiet:
+        for line in analysis.summary().splitlines():
+            console.print(f"    {line}")
+        _print_sync_analysis_detail(analysis, console)
+
+    schematic_orphans = list(analysis.schematic_orphans)
+    value_mismatch_count = len(analysis.value_mismatches)
+    footprint_mismatch_count = len(analysis.footprint_mismatches)
+    pcb_orphan_count = len(analysis.pcb_orphans)
+
+    # Schematic orphans are blocking (parallels ERC's blocking semantics).
+    # --force lets the user bypass; otherwise the build halts here so no
+    # downstream BOM/manufacturing artefacts are produced.
+    if schematic_orphans:
+        if ctx.force:
+            if not ctx.quiet:
+                console.print(
+                    f"  [yellow]sync: {len(schematic_orphans)} schematic-only ref(s)"
+                    " missing from PCB — continuing (--force)[/yellow]"
+                )
+            return BuildResult(
+                step="sync",
+                success=True,
+                message=(
+                    f"sync: {len(schematic_orphans)} schematic-only ref(s)"
+                    " missing from PCB — continuing (--force)"
+                ),
+            )
+
+        return BuildResult(
+            step="sync",
+            success=False,
+            message=(
+                f"sync: {len(schematic_orphans)} schematic-only ref(s) missing"
+                " from PCB (use --force to continue, or 'kct sync --apply' to fix)"
+            ),
+        )
+
+    # No blocking schematic orphans, but other drift exists -> warn, success=True
+    parts = []
+    if value_mismatch_count:
+        parts.append(f"{value_mismatch_count} value mismatch(es)")
+    if footprint_mismatch_count:
+        parts.append(f"{footprint_mismatch_count} footprint mismatch(es)")
+    if pcb_orphan_count:
+        parts.append(f"{pcb_orphan_count} PCB-only ref(s)")
+
+    return BuildResult(
+        step="sync",
+        success=True,
+        message=(
+            "sync: drift detected — " + (", ".join(parts) if parts else "non-blocking issues")
+        ),
+    )
+
+
 def _run_step_verify(ctx: BuildContext, console: Console) -> BuildResult:
     """Run verification step (DRC + audit)."""
     # Find the PCB to verify (prefer routed version)
@@ -1992,6 +2174,7 @@ Examples:
             "schematic",
             "erc",
             "pcb",
+            "sync",
             "outline",
             "placement",
             "zones",
@@ -2152,6 +2335,7 @@ Examples:
             BuildStep.SCHEMATIC,
             BuildStep.ERC,
             BuildStep.PCB,
+            BuildStep.SYNC,
             BuildStep.OUTLINE,
             BuildStep.PLACEMENT,
             BuildStep.ZONES,
@@ -2188,6 +2372,9 @@ Examples:
                 result = _run_step_pcb(ctx, console)
                 if result.output_file:
                     ctx.pcb_file = result.output_file
+
+            elif step == BuildStep.SYNC:
+                result = _run_step_sync(ctx, console)
 
             elif step == BuildStep.OUTLINE:
                 result = _run_step_outline(ctx, console)

--- a/tests/test_build_sync_step.py
+++ b/tests/test_build_sync_step.py
@@ -1,0 +1,372 @@
+"""Tests for the build pipeline SYNC step (issue #2773).
+
+Before this fix, ``kct build`` ran ``kct validate --sync`` inside the
+VERIFY step and discarded the result into a cosmetic message suffix.
+The build continued through EXPORT, producing a BOM/manufacturing
+package even when the schematic and PCB had drifted (board 05 BLDC).
+
+These tests pin the new behaviour: ``BuildStep.SYNC`` runs the
+in-process :class:`Reconciler` right after PCB write, *before* OUTLINE
+and all downstream work, and HALTS the build when schematic orphans are
+detected.  ``--force`` is the only escape hatch.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from rich.console import Console
+
+from kicad_tools.cli.build_cmd import (
+    BuildContext,
+    BuildStep,
+    _run_step_sync,
+    main,
+)
+from kicad_tools.sync.reconciler import SyncAnalysis
+
+# Stubs used to exercise the runner without constructing valid KiCad
+# files.  The Reconciler is monkey-patched in nearly every test, so the
+# file contents do not need to parse.
+STUB_PCB = "(kicad_pcb)\n"
+STUB_SCH = "(kicad_sch)\n"
+
+
+@pytest.fixture
+def pcb_file(tmp_path: Path) -> Path:
+    p = tmp_path / "board.kicad_pcb"
+    p.write_text(STUB_PCB)
+    return p
+
+
+@pytest.fixture
+def sch_file(tmp_path: Path) -> Path:
+    p = tmp_path / "board.kicad_sch"
+    p.write_text(STUB_SCH)
+    return p
+
+
+def _make_ctx(
+    schematic: Path | None,
+    pcb: Path | None,
+    *,
+    output_dir: Path | None = None,
+    dry_run: bool = False,
+    force: bool = False,
+    quiet: bool = True,
+) -> BuildContext:
+    return BuildContext(
+        project_dir=Path("/tmp"),
+        spec_file=None,
+        schematic_file=schematic,
+        pcb_file=pcb,
+        output_dir=output_dir,
+        dry_run=dry_run,
+        quiet=quiet,
+        force=force,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Enum + pipeline wiring
+# ---------------------------------------------------------------------------
+
+
+class TestBuildStepEnum:
+    """The SYNC enum entry and CLI choice are part of the public surface."""
+
+    def test_sync_is_in_buildstep_enum(self) -> None:
+        """A new BuildStep.SYNC value exists and round-trips through str()."""
+        assert BuildStep.SYNC.value == "sync"
+        assert BuildStep("sync") is BuildStep.SYNC
+
+    def test_sync_falls_between_pcb_and_outline_in_enum(self) -> None:
+        """SYNC sits between PCB and OUTLINE in the enum definition."""
+        members = list(BuildStep.__members__.keys())
+        assert members.index("PCB") < members.index("SYNC")
+        assert members.index("SYNC") < members.index("OUTLINE")
+
+    def test_sync_is_a_cli_step_choice(self) -> None:
+        """``--step sync`` must be accepted by the argument parser.
+
+        argparse rejects unknown choices with SystemExit(2); the rest of
+        the build pipeline returns an int exit code instead.
+        """
+        # Unknown step value must be rejected.
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--step", "this-step-does-not-exist", "/tmp"])
+        assert exc_info.value.code == 2
+
+        # Valid step value must be accepted (argparse does not raise).
+        # Failure later in the pipeline returns a non-zero int.
+        rc = main(["--step", "sync", "/nonexistent-project-path-for-test"])
+        assert isinstance(rc, int)
+        # Bogus path -> error int, but not argparse rejection.
+        assert rc != 2
+
+
+# ---------------------------------------------------------------------------
+# _run_step_sync behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestSyncStepSkipBehaviour:
+    """Skip / dry-run behaviour of _run_step_sync."""
+
+    def test_skipped_when_no_schematic(self, pcb_file: Path) -> None:
+        """No schematic available -> skip with informative message."""
+        ctx = _make_ctx(schematic=None, pcb=pcb_file)
+        result = _run_step_sync(ctx, Console(quiet=True))
+        assert result.success is True
+        assert "no schematic" in result.message.lower()
+
+    def test_skipped_when_schematic_path_missing(self, pcb_file: Path, tmp_path: Path) -> None:
+        """Schematic path set but file does not exist -> skip."""
+        missing = tmp_path / "missing.kicad_sch"
+        ctx = _make_ctx(schematic=missing, pcb=pcb_file)
+        result = _run_step_sync(ctx, Console(quiet=True))
+        assert result.success is True
+        assert "no schematic" in result.message.lower()
+
+    def test_fail_when_no_pcb(self, sch_file: Path) -> None:
+        """Schematic present but no PCB to reconcile against -> failure."""
+        ctx = _make_ctx(schematic=sch_file, pcb=None)
+        result = _run_step_sync(ctx, Console(quiet=True))
+        assert result.success is False
+        assert "pcb" in result.message.lower()
+
+    def test_dry_run_skips_reconciler(self, pcb_file: Path, sch_file: Path) -> None:
+        """--dry-run never instantiates a Reconciler."""
+        ctx = _make_ctx(schematic=sch_file, pcb=pcb_file, dry_run=True)
+
+        with patch("kicad_tools.sync.reconciler.Reconciler") as mock_recon:
+            result = _run_step_sync(ctx, Console(quiet=True))
+
+        mock_recon.assert_not_called()
+        assert result.success is True
+        assert result.message.startswith("[dry-run]")
+
+
+class TestSyncStepBehaviour:
+    """Analyze behaviour of _run_step_sync."""
+
+    def test_in_sync_passes(self, pcb_file: Path, sch_file: Path) -> None:
+        """An in-sync analysis returns success without warnings."""
+        ctx = _make_ctx(schematic=sch_file, pcb=pcb_file)
+
+        analysis = SyncAnalysis()  # empty analysis is in sync
+        assert analysis.is_in_sync
+
+        with patch("kicad_tools.sync.reconciler.Reconciler") as mock_cls:
+            mock_cls.return_value.analyze.return_value = analysis
+            result = _run_step_sync(ctx, Console(quiet=True))
+
+        assert result.success is True
+        assert "in sync" in result.message
+
+    def test_orphans_block_without_force(self, pcb_file: Path, sch_file: Path) -> None:
+        """Schematic orphans halt the build unless --force is set.
+
+        This is the gate that prevents board 05's unbuildable
+        manufacturing package from being shipped: schematic_orphans means
+        the BOM lists components that are not on the PCB.
+        """
+        ctx = _make_ctx(schematic=sch_file, pcb=pcb_file)
+
+        analysis = SyncAnalysis(schematic_orphans=["C18", "C19"])
+
+        with patch("kicad_tools.sync.reconciler.Reconciler") as mock_cls:
+            mock_cls.return_value.analyze.return_value = analysis
+            result = _run_step_sync(ctx, Console(quiet=True))
+
+        assert result.success is False
+        assert "schematic-only" in result.message
+        # Actionable error: tell the user how to bypass or fix the gate
+        assert "--force" in result.message
+
+    def test_force_continues_with_warning(self, pcb_file: Path, sch_file: Path) -> None:
+        """--force lets the build proceed past orphan drift as a warning."""
+        ctx = _make_ctx(schematic=sch_file, pcb=pcb_file, force=True)
+
+        analysis = SyncAnalysis(schematic_orphans=["C18"])
+
+        with patch("kicad_tools.sync.reconciler.Reconciler") as mock_cls:
+            mock_cls.return_value.analyze.return_value = analysis
+            result = _run_step_sync(ctx, Console(quiet=True))
+
+        assert result.success is True
+        assert "continuing" in result.message.lower()
+
+    def test_value_mismatch_only_is_warning(self, pcb_file: Path, sch_file: Path) -> None:
+        """Value mismatches alone are non-blocking warnings (success=True)."""
+        ctx = _make_ctx(schematic=sch_file, pcb=pcb_file)
+
+        analysis = SyncAnalysis(
+            value_mismatches=[
+                {
+                    "reference": "R1",
+                    "schematic_value": "10k",
+                    "pcb_value": "1k",
+                }
+            ]
+        )
+
+        with patch("kicad_tools.sync.reconciler.Reconciler") as mock_cls:
+            mock_cls.return_value.analyze.return_value = analysis
+            result = _run_step_sync(ctx, Console(quiet=True))
+
+        assert result.success is True
+        assert "value mismatch" in result.message.lower()
+
+    def test_footprint_mismatch_only_is_warning(self, pcb_file: Path, sch_file: Path) -> None:
+        """Footprint mismatches alone are non-blocking warnings."""
+        ctx = _make_ctx(schematic=sch_file, pcb=pcb_file)
+
+        analysis = SyncAnalysis(
+            footprint_mismatches=[
+                {
+                    "reference": "U1",
+                    "schematic_footprint": "SOIC-8",
+                    "pcb_footprint": "DIP-8",
+                }
+            ]
+        )
+
+        with patch("kicad_tools.sync.reconciler.Reconciler") as mock_cls:
+            mock_cls.return_value.analyze.return_value = analysis
+            result = _run_step_sync(ctx, Console(quiet=True))
+
+        assert result.success is True
+        assert "footprint mismatch" in result.message.lower()
+
+    def test_pcb_orphans_only_are_warning(self, pcb_file: Path, sch_file: Path) -> None:
+        """PCB-only refs (mounting holes, fiducials) alone are warnings."""
+        ctx = _make_ctx(schematic=sch_file, pcb=pcb_file)
+
+        analysis = SyncAnalysis(pcb_orphans=["MH1", "MH2", "MH3", "MH4"])
+
+        with patch("kicad_tools.sync.reconciler.Reconciler") as mock_cls:
+            mock_cls.return_value.analyze.return_value = analysis
+            result = _run_step_sync(ctx, Console(quiet=True))
+
+        assert result.success is True
+        assert "pcb-only" in result.message.lower()
+
+    def test_analyze_failure_returns_failure(self, pcb_file: Path, sch_file: Path) -> None:
+        """If Reconciler construction raises, the step reports failure."""
+        ctx = _make_ctx(schematic=sch_file, pcb=pcb_file)
+
+        with patch("kicad_tools.sync.reconciler.Reconciler") as mock_cls:
+            mock_cls.side_effect = RuntimeError("cannot load")
+            result = _run_step_sync(ctx, Console(quiet=True))
+
+        assert result.success is False
+        assert "failed to analyze" in result.message
+
+
+class TestSyncStepNoSubprocess:
+    """The sync step must use the in-process Reconciler API."""
+
+    def test_no_subprocess_in_runner_source(self) -> None:
+        """Static check: _run_step_sync source does not shell out via subprocess."""
+        import inspect
+
+        src = inspect.getsource(_run_step_sync)
+        # The runner must not call subprocess.run() to avoid the bug
+        # the original VERIFY-step sync subprocess exhibited.
+        assert "subprocess.run" not in src
+        assert "subprocess.Popen" not in src
+
+
+# ---------------------------------------------------------------------------
+# Integration: SYNC halts build before EXPORT
+# ---------------------------------------------------------------------------
+
+
+class TestSyncBlocksManufacturing:
+    """End-to-end-ish test: drift detection prevents BOM/CPL writes."""
+
+    def test_drift_in_isolated_sync_step_exits_nonzero(
+        self, pcb_file: Path, sch_file: Path, tmp_path: Path, monkeypatch
+    ) -> None:
+        """`kct build --step sync` exits non-zero when drift is present.
+
+        This is the smallest end-to-end assertion: the integration
+        between the dispatch ladder and `_run_step_sync` is intact, and
+        a Reconciler reporting schematic_orphans propagates into a
+        non-zero process exit -- which is what `kct build`'s caller
+        (e.g. CI, kct pipeline) relies on to short-circuit before any
+        manufacturing artefacts land on disk.
+        """
+        # Set up project dir with both files at the expected locations
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        (project_dir / "board.kicad_pcb").write_text(STUB_PCB)
+        (project_dir / "board.kicad_sch").write_text(STUB_SCH)
+
+        analysis = SyncAnalysis(schematic_orphans=["C18", "C19"])
+
+        with patch("kicad_tools.sync.reconciler.Reconciler") as mock_cls:
+            mock_cls.return_value.analyze.return_value = analysis
+            rc = main(["--step", "sync", str(project_dir)])
+
+        assert rc != 0, "SYNC step must exit non-zero when drift is detected"
+
+    def test_drift_with_force_exits_zero(
+        self, pcb_file: Path, sch_file: Path, tmp_path: Path
+    ) -> None:
+        """`kct build --step sync --force` exits zero even with drift."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        (project_dir / "board.kicad_pcb").write_text(STUB_PCB)
+        (project_dir / "board.kicad_sch").write_text(STUB_SCH)
+
+        analysis = SyncAnalysis(schematic_orphans=["C18"])
+
+        with patch("kicad_tools.sync.reconciler.Reconciler") as mock_cls:
+            mock_cls.return_value.analyze.return_value = analysis
+            rc = main(["--step", "sync", "--force", str(project_dir)])
+
+        assert rc == 0, "--force must allow the build to continue past drift"
+
+
+# ---------------------------------------------------------------------------
+# Ordering invariant: SYNC must run before any downstream/manufacturing step
+# ---------------------------------------------------------------------------
+
+
+class TestSyncOrdering:
+    """SYNC must run between PCB and OUTLINE in the default chain.
+
+    This is the load-bearing invariant: SYNC must fire before OUTLINE,
+    PLACEMENT, ZONES, SILKSCREEN, ROUTE, STITCH, VERIFY, and EXPORT so
+    that no expensive downstream work (and crucially, no
+    BOM/manufacturing artefacts) is produced when the schematic and PCB
+    have drifted.
+    """
+
+    def test_default_chain_orders_sync_after_pcb_before_outline(self) -> None:
+        """Statically check the default chain ordering.
+
+        We parse the source of `main` to find the BuildStep list rather
+        than running it (which would require a full project setup).
+        """
+        import inspect
+
+        from kicad_tools.cli import build_cmd
+
+        src = inspect.getsource(build_cmd.main)
+        # The default chain is a literal list inside main(); just check
+        # the relative order of the substrings is correct.  This is a
+        # weak but extremely cheap invariant to enforce.
+        pcb_idx = src.index("BuildStep.PCB")
+        sync_idx = src.index("BuildStep.SYNC")
+        outline_idx = src.index("BuildStep.OUTLINE")
+        export_idx = src.index("BuildStep.EXPORT")
+
+        assert pcb_idx < sync_idx < outline_idx, (
+            "SYNC must appear between PCB and OUTLINE in main()'s default chain"
+        )
+        assert sync_idx < export_idx, "SYNC must precede EXPORT in the default chain"


### PR DESCRIPTION
## Summary

Adds a dedicated `BuildStep.SYNC` between `PCB` and `OUTLINE` in the
`kct build` pipeline. The new step runs `Reconciler.analyze()` in-process
right after the PCB is written and HALTS the build when schematic
orphans are detected, preventing unbuildable BOM/manufacturing packages
from landing on disk (board 05 BLDC was the motivating case).

Before this change, `_run_step_verify` shelled out to `kct validate --sync`
at position 10 of 11 and dropped the result into a cosmetic message
suffix — drift never blocked the build. Mirrors `PipelineStep.SYNC`
in `pipeline_cmd.py` for parallel semantics and developer ergonomics.

## Changes

`src/kicad_tools/cli/build_cmd.py` (+186 / -1):

- `BuildStep.SYNC = "sync"` added between `PCB` and `OUTLINE` in the enum.
- argparse `--step` choices grow `"sync"` between `"pcb"` and `"outline"`.
- Default `all` chain becomes `... pcb -> sync -> outline ...`.
- New `_run_step_sync(ctx, console)` runs `Reconciler.analyze()` in-process
  (no subprocess overhead, no `kct validate --sync` shell-out).
- New helper `_print_sync_analysis_detail` ports the per-category detail
  printer from `pipeline_cmd.py`.
- Dispatch ladder gains `elif step == BuildStep.SYNC: ...` branch.

Intentionally **not** changed:
- `_PCB_WRITE_STEPS` — SYNC is read-only, no smoke check needed.
- Stop-on-failure exemption — SYNC must halt the build on failure.
- `_run_step_verify` — left alone, existing sync subprocess remains as an
  informational re-check (scope-trim).

## Behaviour

| Case | Result | Notes |
|------|--------|-------|
| No schematic | `success=True` skipped | gracefully handles --step pcb only flows |
| `is_in_sync` | `success=True` | "sync: in sync" |
| `schematic_orphans` | `success=False` | halts before EXPORT |
| `schematic_orphans` + `--force` | `success=True` warning | yellow warning, build continues |
| value / footprint / pcb-only drift | `success=True` warning | non-blocking |
| `--dry-run` | `success=True` | preview only, no Reconciler instantiation |

Scope-trim per the curator brief: NO `--apply-sync` flag is added to
`kct build`. `kct build --force` is the only escape hatch.
`kct sync --apply` / `kct pipeline --apply-sync` remain the auto-fix path.

## Test plan

- [x] `pytest tests/test_build_sync_step.py` — 18 tests, all pass.
- [x] `pytest tests/test_pipeline_sync_step.py` — 18 tests, all pass (no regression in pipeline).
- [x] Broader build suite — 164/165 pass; the one failure (`test_route_exit_code_3_is_failure`) reproduces on `origin/main` and is unrelated to this change.
- [x] `ruff check` / `ruff format --check` on changed files — clean.

Tests cover:

- Enum membership + ordering invariant
- `--step sync` argparse acceptance
- Skip behaviour when schematic missing
- Failure when no PCB to reconcile against
- Dry-run does not instantiate `Reconciler`
- `is_in_sync` returns success
- `schematic_orphans` blocks unless `--force`
- `--force` converts blocking drift to a warning
- value-only / footprint-only / pcb-only drift are warnings
- Reconciler construction failure produces a build failure
- Static check that `_run_step_sync` never calls `subprocess.run`
- Integration: `kct build --step sync` exits non-zero on drift, zero with `--force`
- Static ordering check that `SYNC` falls between `PCB` and `OUTLINE`
  and before `EXPORT` in `main()`'s default chain

Closes #2773

🤖 Generated with [Claude Code](https://claude.com/claude-code)