### PR TITLE
fix(router): forward per_net_timeout through route_with_escape

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -1636,6 +1636,7 @@ def route_with_layer_escalation(
                 router.route_with_escape(
                     use_negotiated=(args.strategy == "negotiated"),
                     timeout=args.timeout,
+                    per_net_timeout=getattr(args, "per_net_timeout", None) or None,
                 )
             elif getattr(args, "multi_resolution", False):
                 router.route_all_multi_resolution(
@@ -2310,6 +2311,7 @@ def route_with_rule_relaxation(
                 router.route_with_escape(
                     use_negotiated=(args.strategy == "negotiated"),
                     timeout=args.timeout,
+                    per_net_timeout=getattr(args, "per_net_timeout", None) or None,
                 )
             elif getattr(args, "multi_resolution", False):
                 router.route_all_multi_resolution(
@@ -2829,6 +2831,7 @@ def route_with_combined_escalation(
                     router.route_with_escape(
                         use_negotiated=(args.strategy == "negotiated"),
                         timeout=args.timeout,
+                        per_net_timeout=getattr(args, "per_net_timeout", None) or None,
                     )
                 elif getattr(args, "multi_resolution", False):
                     router.route_all_multi_resolution(
@@ -4919,6 +4922,7 @@ def main(argv: list[str] | None = None) -> int:
                 return router.route_with_escape(
                     use_negotiated=(args.strategy == "negotiated"),
                     timeout=args.timeout,
+                    per_net_timeout=getattr(args, "per_net_timeout", None) or None,
                 )
 
             # Progressive clearance relaxation mode

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -8287,6 +8287,7 @@ class Autorouter:
         use_negotiated: bool = True,
         progress_callback: ProgressCallback | None = None,
         timeout: float | None = None,
+        per_net_timeout: float | None = None,
     ) -> list[Route]:
         """Route with automatic escape routing for dense packages.
 
@@ -8300,7 +8301,11 @@ class Autorouter:
         Args:
             use_negotiated: Use negotiated congestion routing
             progress_callback: Optional callback for progress updates
-            timeout: Optional timeout in seconds
+            timeout: Optional board-level timeout in seconds
+            per_net_timeout: Optional wall-clock timeout per A* search.
+                Forwarded to ``route_all_two_phase`` so dense-package nets
+                cannot consume an unbounded share of the board-level budget
+                (Issue #2768; part of board 05 BLDC regression #2746).
 
         Returns:
             List of all routes (escapes + regular routing)
@@ -8353,6 +8358,7 @@ class Autorouter:
                 corridor_width_factor=2.0,
                 progress_callback=progress_callback,
                 timeout=timeout,
+                per_net_timeout=per_net_timeout,
             )
         else:
             main_routes = self.route_all(

--- a/tests/test_global_router.py
+++ b/tests/test_global_router.py
@@ -1482,6 +1482,82 @@ class TestEscapeRouteRipupEligibility:
             call_kwargs = mock_two_phase.call_args[1]
             assert "initial_routes" not in call_kwargs
 
+    def test_route_with_escape_forwards_per_net_timeout(self, autorouter):
+        """route_with_escape must forward per_net_timeout to route_all_two_phase.
+
+        Issue #2768 (board 05 BLDC regression #2746): the escape-routing path
+        previously dropped the CLI's ``--per-net-timeout`` value because
+        ``route_with_escape`` did not accept the parameter. With the fix, the
+        value must be forwarded through to ``route_all_two_phase`` (and from
+        there to the A* pathfinder) so dense-package nets cannot consume an
+        unbounded share of the board-level budget.
+        """
+        from unittest.mock import MagicMock, patch
+
+        autorouter.add_component(
+            ref="R1",
+            pads=[
+                {"number": "1", "x": 3.0, "y": 10.0, "net": 1, "net_name": "VCC"},
+                {"number": "2", "x": 17.0, "y": 10.0, "net": 1, "net_name": "VCC"},
+            ],
+        )
+
+        fake_escape = MagicMock(net=1, segments=[], vias=[])
+
+        with (
+            patch.object(autorouter, "_run_subgrid_prepass", return_value=[]),
+            patch.object(
+                autorouter, "generate_escape_routes", return_value=[fake_escape]
+            ),
+            patch.object(
+                autorouter, "detect_dense_packages", return_value=[MagicMock()]
+            ),
+            patch.object(
+                autorouter, "route_all_two_phase", return_value=[]
+            ) as mock_two_phase,
+        ):
+            autorouter.route_with_escape(per_net_timeout=42.0)
+            mock_two_phase.assert_called_once()
+            call_kwargs = mock_two_phase.call_args[1]
+            assert call_kwargs["per_net_timeout"] == 42.0
+
+    def test_route_with_escape_defaults_per_net_timeout_to_none(self, autorouter):
+        """When per_net_timeout is not provided, the forwarded value is None.
+
+        Ensures backwards compatibility: callers that previously used
+        ``route_with_escape(timeout=...)`` continue to work, and the
+        downstream router receives ``per_net_timeout=None`` (its existing
+        default semantics: no per-net cap).
+        """
+        from unittest.mock import MagicMock, patch
+
+        autorouter.add_component(
+            ref="R1",
+            pads=[
+                {"number": "1", "x": 3.0, "y": 10.0, "net": 1, "net_name": "VCC"},
+                {"number": "2", "x": 17.0, "y": 10.0, "net": 1, "net_name": "VCC"},
+            ],
+        )
+
+        fake_escape = MagicMock(net=1, segments=[], vias=[])
+
+        with (
+            patch.object(autorouter, "_run_subgrid_prepass", return_value=[]),
+            patch.object(
+                autorouter, "generate_escape_routes", return_value=[fake_escape]
+            ),
+            patch.object(
+                autorouter, "detect_dense_packages", return_value=[MagicMock()]
+            ),
+            patch.object(
+                autorouter, "route_all_two_phase", return_value=[]
+            ) as mock_two_phase,
+        ):
+            autorouter.route_with_escape()
+            mock_two_phase.assert_called_once()
+            call_kwargs = mock_two_phase.call_args[1]
+            assert call_kwargs["per_net_timeout"] is None
+
     def test_two_phase_initial_routes_seeded_into_net_routes(self, rules):
         """Initial routes are seeded into the negotiated router's net_routes."""
         from unittest.mock import MagicMock


### PR DESCRIPTION
## Summary

`route_with_escape()` silently dropped the CLI's `--per-net-timeout` value because the function did not accept the parameter. On dense boards (e.g. board 05 BLDC: U3 DRV8301 HTSSOP-56 + U10 STM32G431) this let single nets consume the entire board-level budget — PHASE_A burned 159s of a 240s budget on 6/35 nets before aborting. With the fix, the per-net cap reaches the A* pathfinder via the existing `route_all_two_phase` -> `route_all_negotiated` -> C++ pathfinder plumbing, bounding any single net's wall-clock to `--per-net-timeout` (default 30s).

This is the canonical fix already used for the sibling two-phase call sites at `route_cmd.py:1647-1653, 2321-2327, 2840-2847, 4940-4946`; the escape branch was simply omitted.

## Changes

- `src/kicad_tools/router/core.py:8285-8295` — `route_with_escape` signature now accepts `per_net_timeout: float | None = None`; docstring updated.
- `src/kicad_tools/router/core.py:8351-8357` — `per_net_timeout` forwarded into `route_all_two_phase(...)` on the `use_negotiated=True` branch (the only branch exercised by the CLI default `--strategy negotiated`).
- `src/kicad_tools/cli/route_cmd.py:1636-1640, 2310-2315, 2829-2835, 4919-4926` — all 4 escape call sites now pass `per_net_timeout=getattr(args, "per_net_timeout", None) or None`, matching the existing two-phase pattern.
- `tests/test_global_router.py` — 2 new unit tests in `TestEscapeRouteRipupEligibility`:
  - `test_route_with_escape_forwards_per_net_timeout`: patches `route_all_two_phase`, calls `route_with_escape(per_net_timeout=42.0)`, asserts `call_kwargs["per_net_timeout"] == 42.0`.
  - `test_route_with_escape_defaults_per_net_timeout_to_none`: backwards-compat assertion that omitting the kwarg yields `per_net_timeout=None`.

Out of scope (per curator): the `use_negotiated=False` branch (`core.py:8358-8360`) calls `route_all(...)` which doesn't yet accept `per_net_timeout`; left untouched since CLI default is `strategy=negotiated`. A follow-up can plumb `route_all` if a non-negotiated escape workflow appears.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `route_with_escape` signature accepts `per_net_timeout: float \| None = None` | Met | `core.py:8285-8290` shows new parameter |
| `route_with_escape` forwards `per_net_timeout` to `route_all_two_phase` on `use_negotiated=True` | Met | `core.py:8351-8357` adds the kwarg |
| All 4 CLI call sites (`route_cmd.py:1636, 2311, 2831, 4922`) pass `per_net_timeout=getattr(args, "per_net_timeout", None) or None` | Met | `grep -n "route_with_escape" src/kicad_tools/cli/route_cmd.py` confirms 4 sites, all updated |
| Existing escape tests still pass (`test_route_with_escape_calls_subgrid_prepass`, `test_route_with_escape_does_not_pass_initial_routes`) | Met | Both pass in `TestEscapeRouteRipupEligibility` |
| New unit test asserts `call_kwargs["per_net_timeout"] == 42.0` when invoked with `per_net_timeout=42.0` | Met | `test_route_with_escape_forwards_per_net_timeout` added |
| No regressions in router/escape suites | Met | 202/202 pass in `test_global_router.py` + `test_negotiated_timeout_propagation.py` + `test_escape*.py` |

## Test Plan

- [x] `uv run pytest tests/test_global_router.py::TestEscapeRouteRipupEligibility -xvs` -> 5/5 pass (3 existing + 2 new)
- [x] `uv run pytest tests/test_global_router.py tests/test_negotiated_timeout_propagation.py tests/test_escape.py tests/test_escape_endpoint_routing.py tests/test_escape_per_footprint_clearance.py` -> 202/202 pass
- [x] `uv run pytest tests/test_cli_route_match_groups.py` -> 10/10 pass
- [x] `grep -n "route_with_escape" src/kicad_tools/cli/route_cmd.py` confirms all 4 call sites updated

## Notes for reviewer

- The board-level regression-improvement criterion (#2746 line item "board-level budget no longer exhausted by <=6 nets") is the runtime consequence of this plumbing fix. End-to-end board 05 re-run is out of scope for a single-file unit-level PR and is tracked under #2746 / #2769.
- Linked dependency: #2769 (RSMT per-edge vs per-net bracketing) is unblocked by this change.
- 23 pre-existing ruff lint errors and pre-existing format diffs in the touched files were verified to exist on the parent commit before my changes; they are not introduced here.

Closes #2768