### PR TITLE
feat(router): declarative routing-intent opt-out via route_via field (closes #2772)

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -1352,12 +1352,23 @@ def _auto_skip_pour_nets(
     skip_nets: list[str],
     quiet: bool = False,
 ) -> tuple[list[str], list[str]]:
-    """Detect pour nets in the PCB and add them to the skip list.
+    """Detect non-pathfinder nets in the PCB and add them to the skip list.
 
     Reads net definitions from the PCB file and classifies them.  Nets
-    identified as pour nets (GND, power rails, etc.) are appended to
-    *skip_nets* so the router excludes them -- they will be connected
-    via zone fill instead of traces.
+    whose net class declares a non-pathfinder routing intent are appended
+    to *skip_nets* so the router excludes them:
+
+    - ``route_via="pour"`` (or legacy ``is_pour_net=True``) -- the net is
+      satisfied by a copper zone if one exists in the PCB; otherwise the
+      net falls through to ``no_zone_nets`` and is routed as a signal.
+    - ``route_via="manual"`` (Issue #2772) -- the designer is responsible
+      for routing the net by hand (e.g. wide motor-phase traces); the net
+      is unconditionally skipped regardless of zone presence and a
+      distinct ``Manual:`` log line is emitted.
+
+    An explicit ``route_via="pathfinder"`` always wins over the legacy
+    ``is_pour_net=True`` inference -- the new declarative field lets
+    designers override the name-pattern classifier for a specific class.
 
     Args:
         pcb_path: Path to the .kicad_pcb file.
@@ -1367,7 +1378,8 @@ def _auto_skip_pour_nets(
 
     Returns:
         Tuple of (auto_skipped, no_zone_nets):
-        - auto_skipped: Net names that were auto-skipped (have zones).
+        - auto_skipped: Net names that were auto-skipped (zone-routed
+          pour nets and ``route_via="manual"`` nets combined).
         - no_zone_nets: Pour net names that lack zones and must be
           routed as signals.  Pass these to the autorouter's
           ``_pour_nets_without_zones`` attribute so that
@@ -1404,32 +1416,66 @@ def _auto_skip_pour_nets(
                 nets_with_zones.add(zm.group(1))
             del pcb_text  # free memory
 
+            # Issue #2772: route_via takes precedence over the legacy
+            # ``is_pour_net`` flag.  An explicit ``route_via="pathfinder"``
+            # overrides ``is_pour_net=True`` (designer-declared opt-IN to
+            # pathfinder routing for an otherwise-pour-classified class);
+            # ``route_via="pour"`` or ``"manual"`` are the opt-OUT signals.
+            def _wants_pour(routing) -> bool:
+                if routing.route_via == "pathfinder":
+                    return False
+                if routing.route_via == "pour":
+                    return True
+                # Legacy fall-back: pre-#2772 classes with default
+                # ``route_via="pathfinder"`` but ``is_pour_net=True``.
+                return routing.is_pour_net
+
+            def _wants_manual(routing) -> bool:
+                return routing.route_via == "manual"
+
             # ERC-marker nets (PWR_FLAG and friends) are misclassified as
             # pour nets by the name pattern but carry no copper and have
             # no zone -- exclude them from both the auto-skip and the
             # "pour nets without zones" warning so the user does not see
             # a misleading "use zone fill" log line for a non-existent
             # zone.  See router/auto_pour.py for the filter.
-            auto_skip = [
+            pour_skip = [
                 name
                 for name, routing in net_class_map.items()
-                if routing.is_pour_net
+                if _wants_pour(routing)
                 and name not in skip_nets
                 and name in nets_with_zones
                 and not _is_erc_marker_net(name)
             ]
-            if auto_skip:
-                skip_nets.extend(auto_skip)
+            # ``route_via="manual"`` nets are always skipped (designer
+            # routes them by hand); zone presence is irrelevant.  ERC
+            # markers are still excluded for the same reason as above.
+            manual_skip = [
+                name
+                for name, routing in net_class_map.items()
+                if _wants_manual(routing) and name not in skip_nets and not _is_erc_marker_net(name)
+            ]
+            auto_skip = pour_skip + manual_skip
+            if pour_skip:
+                skip_nets.extend(pour_skip)
                 if not quiet:
                     print(
-                        f"Auto-skip: {', '.join(sorted(auto_skip))} (pour nets \u2014 use zone fill)"
+                        f"Auto-skip: {', '.join(sorted(pour_skip))} (pour nets \u2014 use zone fill)"
+                    )
+            if manual_skip:
+                skip_nets.extend(manual_skip)
+                if not quiet:
+                    print(
+                        f"Manual: {', '.join(sorted(manual_skip))} (skipped \u2014 route_via=manual)"
                     )
             # Warn about pour nets without zones (excluding ERC markers
-            # which never get zones by design).
+            # which never get zones by design).  ``route_via="manual"``
+            # nets are intentionally NOT in this list -- the designer has
+            # declared they will handle routing by hand, not via a zone.
             no_zone = [
                 name
                 for name, routing in net_class_map.items()
-                if routing.is_pour_net
+                if _wants_pour(routing)
                 and name not in skip_nets
                 and name not in nets_with_zones
                 and not _is_erc_marker_net(name)
@@ -5316,9 +5362,7 @@ def main(argv: list[str] | None = None) -> int:
                     for (_route, res) in member_dict.values()
                 ]
                 n_tuned = sum(1 for r in all_results if r.reason == "tuned")
-                n_clean = sum(
-                    1 for r in all_results if r.reason == "already_within_tolerance"
-                )
+                n_clean = sum(1 for r in all_results if r.reason == "already_within_tolerance")
                 n_rollback = sum(
                     1 for r in all_results if r.reason == "post_insertion_drc_violation"
                 )
@@ -5327,9 +5371,7 @@ def main(argv: list[str] | None = None) -> int:
                     for r in all_results
                     if r.reason in ("exceeded_max_inserts", "cascade_budget_exhausted")
                 )
-                n_skipped = sum(
-                    1 for r in all_results if r.reason == "not_length_critical"
-                )
+                n_skipped = sum(1 for r in all_results if r.reason == "not_length_critical")
                 print(
                     f"  Summary: {len(tune_results_groups)} groups, "
                     f"{n_tuned} tuned, {n_clean} clean, "

--- a/src/kicad_tools/router/net_class.py
+++ b/src/kicad_tools/router/net_class.py
@@ -570,6 +570,11 @@ def apply_net_class_rules(
             zone_priority=20,  # Highest zone priority
             zone_connection="solid",
             is_pour_net=True,
+            # Issue #2772: declarative routing-intent.  Ground nets are
+            # always satisfied by a copper zone (or fall through to the
+            # no-zone warning path) -- they should never enter the
+            # pathfinder as ordinary traces.
+            route_via="pour",
         ),
         NetClass.HIGH_CURRENT_SIGNAL: NET_CLASS_HIGH_CURRENT_SIGNAL,
         NetClass.CLOCK: NET_CLASS_CLOCK,

--- a/src/kicad_tools/router/rules.py
+++ b/src/kicad_tools/router/rules.py
@@ -8,8 +8,19 @@ This module provides:
 """
 
 from dataclasses import dataclass, field
+from typing import Literal
 
 from .layers import Layer
+
+# Allowed values for :attr:`NetClassRouting.route_via`.
+# - ``"pathfinder"`` (default) -- ordinary trace, standard pathfinder routing.
+# - ``"pour"`` -- skip from pathfinder; expect a copper zone/pour to satisfy
+#   the net (e.g. GND, VCC).  When no zone exists, callers fall through to
+#   the existing ``no_zone_nets`` warning path rather than skipping silently.
+# - ``"manual"`` -- skip from pathfinder; designer is responsible for routing
+#   the net by hand (e.g. wide motor-phase traces).  Emits a distinct log
+#   line so the user is not left wondering why the net is unconnected.
+RouteVia = Literal["pathfinder", "pour", "manual"]
 
 
 @dataclass
@@ -442,6 +453,42 @@ class NetClassRouting:
     zone_connection: str = "thermal"  # Default connection type ("thermal", "solid", "none")
     is_pour_net: bool = False  # This net is used for copper pours (e.g., GND, VCC)
 
+    # Routing-intent opt-out (Issue #2772)
+    route_via: RouteVia = "pathfinder"
+    """Declarative routing-intent selector for nets in this class.
+
+    Lets designers opt OUT of the pathfinder declaratively rather than
+    hand-rolling ``skip_nets`` in a custom ``design.py``:
+
+    - ``"pathfinder"`` (default) -- standard pathfinder routing; preserves
+      pre-#2772 behavior for every existing class.
+    - ``"pour"`` -- ``_auto_skip_pour_nets`` skips this net when a zone for
+      it exists in the PCB; otherwise falls through to the existing
+      ``no_zone_nets`` warning path so the user is not left silently
+      unconnected.  ``NET_CLASS_POWER`` flips to this value in #2772 to
+      match the long-standing ``is_pour_net=True`` semantics.
+    - ``"manual"`` -- always skip from the pathfinder; the designer is
+      responsible for laying down the trace by hand (e.g. wide motor-phase
+      traces routed in a custom script).  ``_auto_skip_pour_nets`` emits a
+      distinct log line (``Manual: <names> ...``) so the user sees that the
+      net was deliberately deferred to manual routing rather than dropped.
+
+    Orthogonal to :attr:`is_pour_net`.  The legacy flag continues to drive
+    zone-fill priority and zone-connection inference at the auto-pour layer
+    (``router/auto_pour.py``); the new field drives the pathfinder skip
+    predicate at the CLI layer (``cli/route_cmd.py``).  When both are set
+    on a class, ``route_via`` takes precedence in the skip predicate -- a
+    class with ``is_pour_net=True`` and an explicit ``route_via="pathfinder"``
+    will NOT be auto-skipped, allowing a designer to override the legacy
+    inference for a specific net class.
+
+    Backward-compat: ``NET_CLASS_HIGH_CURRENT_SIGNAL`` deliberately stays
+    at the ``"pathfinder"`` default; its phase outputs (PHASE_A/B/C) are
+    point-to-point traces, not pours, and the per-net timeout pathology
+    that motivated the original framing of this issue is fixed in sibling
+    issues #2768 / #2769, not here.
+    """
+
     # Layer preference parameters (Issue #625)
     preferred_layers: list[int] | None = None  # Layer indices to prefer (lower cost)
     avoid_layers: list[int] | None = None  # Layer indices to avoid (higher cost)
@@ -811,6 +858,7 @@ class NetClassRouting:
             "zone_priority": self.zone_priority,
             "zone_connection": self.zone_connection,
             "is_pour_net": self.is_pour_net,
+            "route_via": self.route_via,
             "preferred_layers": (
                 list(self.preferred_layers) if self.preferred_layers is not None else None
             ),
@@ -865,6 +913,7 @@ class NetClassRouting:
             zone_priority=data.get("zone_priority", 0),
             zone_connection=data.get("zone_connection", "thermal"),
             is_pour_net=data.get("is_pour_net", False),
+            route_via=data.get("route_via", "pathfinder"),
             preferred_layers=data.get("preferred_layers"),
             avoid_layers=data.get("avoid_layers"),
             layer_cost_multiplier=data.get("layer_cost_multiplier", 2.0),
@@ -897,6 +946,11 @@ NET_CLASS_POWER = NetClassRouting(
     zone_priority=10,  # Fill power zones first
     zone_connection="solid",  # Direct connection for power
     is_pour_net=True,  # Power nets often have pours
+    # Issue #2772: declarative routing-intent matches the long-standing
+    # ``is_pour_net=True`` semantics -- power nets should be satisfied by a
+    # copper zone (or fall through to the no-zone warning path) rather than
+    # consumed by the pathfinder.
+    route_via="pour",
 )
 
 # High-current signal nets such as motor phase outputs (PHASE_A/B/C),

--- a/tests/test_net_class_serialization.py
+++ b/tests/test_net_class_serialization.py
@@ -269,6 +269,7 @@ class TestDriftPrevention:
             "zone_priority": 42,
             "zone_connection": "solid",
             "is_pour_net": True,
+            "route_via": "manual",
             "preferred_layers": [3, 4, 5],
             "avoid_layers": [6, 7],
             "layer_cost_multiplier": 4.5,

--- a/tests/test_pour_net_auto_skip.py
+++ b/tests/test_pour_net_auto_skip.py
@@ -870,7 +870,7 @@ class TestFilterPourNetsWithoutZones:
 
         assert 1 not in filtered  # GND filtered
         assert 2 not in filtered  # GNDA filtered
-        assert 3 in filtered      # SPI_CLK kept
+        assert 3 in filtered  # SPI_CLK kept
 
     def test_auto_skip_returns_no_zone_list(self, pcb_mixed_zone: Path) -> None:
         """_auto_skip_pour_nets returns (skipped, no_zone) where no_zone
@@ -878,9 +878,7 @@ class TestFilterPourNetsWithoutZones:
         from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
 
         skip_nets: list[str] = []
-        auto_skipped, no_zone = _auto_skip_pour_nets(
-            pcb_mixed_zone, skip_nets, quiet=True
-        )
+        auto_skipped, no_zone = _auto_skip_pour_nets(pcb_mixed_zone, skip_nets, quiet=True)
 
         assert "GND" in auto_skipped
         assert "+5V" in no_zone
@@ -947,9 +945,7 @@ class TestPourNetsWithoutZonesSerialization:
             origin_x=config["origin_x"],
             origin_y=config["origin_y"],
         )
-        reconstructed._pour_nets_without_zones = set(
-            config.get("pour_nets_without_zones", [])
-        )
+        reconstructed._pour_nets_without_zones = set(config.get("pour_nets_without_zones", []))
         reconstructed.net_names = {int(k): v for k, v in config["net_names"].items()}
         reconstructed.net_class_map = config.get("net_class_map")
 
@@ -974,9 +970,7 @@ class TestPourNetsWithoutZonesSerialization:
         net_class_map = classify_and_apply_rules(reconstructed.net_names)
         reconstructed.net_class_map = net_class_map
         reconstructed.nets = {1: [], 2: [], 3: []}
-        reconstructed._pour_nets_without_zones = set(
-            config.get("pour_nets_without_zones", [])
-        )
+        reconstructed._pour_nets_without_zones = set(config.get("pour_nets_without_zones", []))
 
         # GNDA is in _pour_nets_without_zones -> should NOT be treated as pour
         assert reconstructed._is_pour_net(2) is False
@@ -1067,9 +1061,7 @@ class TestAutoSkipExcludesErcMarkers:
         from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
 
         skip_nets: list[str] = []
-        auto_skipped, no_zone = _auto_skip_pour_nets(
-            pcb_with_pwr_flag, skip_nets, quiet=True
-        )
+        auto_skipped, no_zone = _auto_skip_pour_nets(pcb_with_pwr_flag, skip_nets, quiet=True)
 
         # GND has a zone -> auto-skipped.  +3.3V is a pour net without
         # zone -> reported in no_zone.  PWR_FLAG must appear in NEITHER.
@@ -1078,9 +1070,7 @@ class TestAutoSkipExcludesErcMarkers:
         assert "PWR_FLAG" not in skip_nets
         assert "PWR_FLAG" not in no_zone
 
-    def test_pwr_flag_not_in_auto_skip_log(
-        self, pcb_with_pwr_flag: Path, capsys
-    ) -> None:
+    def test_pwr_flag_not_in_auto_skip_log(self, pcb_with_pwr_flag: Path, capsys) -> None:
         """The auto-skip / routing log lines must not mention PWR_FLAG."""
         from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
 
@@ -1089,3 +1079,281 @@ class TestAutoSkipExcludesErcMarkers:
 
         out = capsys.readouterr().out
         assert "PWR_FLAG" not in out
+
+
+# ===========================================================================
+# Tests for declarative routing-intent opt-out via route_via (Issue #2772)
+# ===========================================================================
+
+
+# Minimal PCB with PHASE_A/B/C (HIGH_CURRENT_SIGNAL) plus a SIG_DATA signal,
+# no zones for the phase nets.  Used to verify that a synthetic
+# ``route_via="manual"`` classification causes the phases to be auto-skipped
+# without a zone, while ``route_via="pathfinder"`` does NOT.
+ROUTE_VIA_PHASE_PCB = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup
+    (pad_to_mask_clearance 0.05)
+    (pcbplotparams (layerselection 0x0) (plot_on_all_layers_selection 0x0))
+  )
+  (net 0 "")
+  (net 1 "PHASE_A")
+  (net 2 "PHASE_B")
+  (net 3 "PHASE_C")
+  (net 4 "SIG_DATA")
+
+  (gr_line (start 0 0) (end 50 0) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 50 0) (end 50 40) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 50 40) (end 0 40) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 0 40) (end 0 0) (layer "Edge.Cuts") (stroke (width 0.1)))
+
+  (footprint "R_0603"
+    (layer "F.Cu")
+    (at 10 10)
+    (attr smd)
+    (property "Reference" "R1")
+    (property "Value" "10k")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "PHASE_A"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 4 "SIG_DATA"))
+  )
+
+  (footprint "R_0603"
+    (layer "F.Cu")
+    (at 20 10)
+    (attr smd)
+    (property "Reference" "R2")
+    (property "Value" "10k")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 2 "PHASE_B"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 4 "SIG_DATA"))
+  )
+
+  (footprint "R_0603"
+    (layer "F.Cu")
+    (at 30 10)
+    (attr smd)
+    (property "Reference" "R3")
+    (property "Value" "10k")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 3 "PHASE_C"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 4 "SIG_DATA"))
+  )
+)
+"""
+
+
+@pytest.fixture
+def pcb_phase_nets(tmp_path: Path) -> Path:
+    """Write a PCB with PHASE_A/B/C and a SIG_DATA net (no zones)."""
+    p = tmp_path / "board_phase.kicad_pcb"
+    p.write_text(ROUTE_VIA_PHASE_PCB)
+    return p
+
+
+class TestRouteViaField:
+    """Verify the new ``route_via`` field on :class:`NetClassRouting`."""
+
+    def test_route_via_defaults_to_pathfinder(self) -> None:
+        """New classes default to ``route_via="pathfinder"`` (no behaviour change)."""
+        from kicad_tools.router.rules import NetClassRouting
+
+        nc = NetClassRouting(name="Custom")
+        assert nc.route_via == "pathfinder"
+
+    def test_route_via_pour_serializes(self) -> None:
+        """``route_via="pour"`` round-trips through ``to_dict``/``from_dict``."""
+        from kicad_tools.router.rules import NetClassRouting
+
+        original = NetClassRouting(name="PowerLike", route_via="pour")
+        roundtripped = NetClassRouting.from_dict(original.to_dict())
+        assert roundtripped.route_via == "pour"
+
+    def test_route_via_manual_serializes(self) -> None:
+        """``route_via="manual"`` round-trips through ``to_dict``/``from_dict``."""
+        from kicad_tools.router.rules import NetClassRouting
+
+        original = NetClassRouting(name="ManualPhase", route_via="manual")
+        roundtripped = NetClassRouting.from_dict(original.to_dict())
+        assert roundtripped.route_via == "manual"
+
+    def test_from_dict_missing_route_via_defaults_to_pathfinder(self) -> None:
+        """Legacy dicts without ``route_via`` deserialize to the default."""
+        from kicad_tools.router.rules import NetClassRouting
+
+        legacy_dict = {"name": "Legacy"}  # No route_via key
+        nc = NetClassRouting.from_dict(legacy_dict)
+        assert nc.route_via == "pathfinder"
+
+    def test_net_class_power_routes_via_pour(self) -> None:
+        """``NET_CLASS_POWER`` declares the new ``route_via="pour"`` intent."""
+        from kicad_tools.router.rules import NET_CLASS_POWER
+
+        assert NET_CLASS_POWER.route_via == "pour"
+        # And keeps the legacy is_pour_net for backwards compatibility.
+        assert NET_CLASS_POWER.is_pour_net is True
+
+    def test_net_class_high_current_signal_stays_pathfinder(self) -> None:
+        """``NET_CLASS_HIGH_CURRENT_SIGNAL`` is the regression baseline:
+        PHASE_A/B/C must still be pathfinder-routed (NOT auto-skipped) so the
+        pathfinder produces point-to-point wide traces rather than coupling
+        switching noise via a pour.  See ``rules.py:902-921`` comment block.
+        """
+        from kicad_tools.router.rules import NET_CLASS_HIGH_CURRENT_SIGNAL
+
+        assert NET_CLASS_HIGH_CURRENT_SIGNAL.route_via == "pathfinder"
+        assert NET_CLASS_HIGH_CURRENT_SIGNAL.is_pour_net is False
+
+
+class TestAutoSkipRouteViaManual:
+    """Verify ``_auto_skip_pour_nets`` honours ``route_via="manual"``.
+
+    Issue #2772: designers can declaratively opt OUT of the pathfinder
+    by setting ``route_via="manual"`` on the relevant net class.  The
+    nets are then unconditionally added to ``skip_nets`` (regardless of
+    zone presence) and a distinct ``Manual:`` log line is emitted so the
+    user is not confused into thinking the net was dropped.
+    """
+
+    def _patch_classifier_with(self, mapping):
+        """Helper: return a patch context for classify_and_apply_rules.
+
+        ``_auto_skip_pour_nets`` calls
+        ``kicad_tools.router.net_class.classify_and_apply_rules`` but the
+        symbol is imported locally inside the function, so we must patch
+        the source module, not the route_cmd namespace.
+        """
+        return patch(
+            "kicad_tools.router.net_class.classify_and_apply_rules",
+            return_value=mapping,
+        )
+
+    def test_manual_net_is_auto_skipped_even_without_zone(self, pcb_phase_nets: Path) -> None:
+        """PHASE_A declared ``route_via="manual"`` is skipped (no zone needed)."""
+        from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
+        from kicad_tools.router.rules import NetClassRouting
+
+        manual = NetClassRouting(name="ManualPhase", route_via="manual")
+        signal = NetClassRouting(name="Signal", route_via="pathfinder")
+        mapping = {
+            "PHASE_A": manual,
+            "PHASE_B": manual,
+            "PHASE_C": manual,
+            "SIG_DATA": signal,
+        }
+
+        skip_nets: list[str] = []
+        with self._patch_classifier_with(mapping):
+            auto_skipped, no_zone = _auto_skip_pour_nets(pcb_phase_nets, skip_nets, quiet=True)
+
+        # PHASE_A/B/C are manual -> auto-skipped regardless of zone.
+        assert "PHASE_A" in auto_skipped
+        assert "PHASE_B" in auto_skipped
+        assert "PHASE_C" in auto_skipped
+        # SIG_DATA is pathfinder -> NOT skipped.
+        assert "SIG_DATA" not in auto_skipped
+        assert "SIG_DATA" not in skip_nets
+        # Manual nets do not appear in ``no_zone`` -- the designer has
+        # declared they are handled by hand, not by a missing zone.
+        assert "PHASE_A" not in no_zone
+        assert "PHASE_B" not in no_zone
+        assert "PHASE_C" not in no_zone
+
+    def test_manual_emits_distinct_log_line(self, pcb_phase_nets: Path, capsys) -> None:
+        """The ``Manual:`` log line is emitted (distinct from ``Auto-skip:``)."""
+        from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
+        from kicad_tools.router.rules import NetClassRouting
+
+        manual = NetClassRouting(name="ManualPhase", route_via="manual")
+        signal = NetClassRouting(name="Signal", route_via="pathfinder")
+        mapping = {
+            "PHASE_A": manual,
+            "PHASE_B": manual,
+            "PHASE_C": manual,
+            "SIG_DATA": signal,
+        }
+
+        skip_nets: list[str] = []
+        with self._patch_classifier_with(mapping):
+            _auto_skip_pour_nets(pcb_phase_nets, skip_nets, quiet=False)
+
+        out = capsys.readouterr().out
+        assert "Manual:" in out
+        assert "PHASE_A" in out
+        assert "route_via=manual" in out
+
+    def test_pathfinder_override_beats_is_pour_net(self, pcb_phase_nets: Path) -> None:
+        """Explicit ``route_via="pathfinder"`` wins over legacy ``is_pour_net=True``.
+
+        Acceptance criterion: a net with ``route_via="pathfinder"`` is NOT
+        skipped even when ``is_pour_net=True`` -- the explicit declarative
+        opt-IN overrides the legacy name-pattern inference.
+        """
+        from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
+        from kicad_tools.router.rules import NetClassRouting
+
+        # Net class with the legacy pour flag set, but explicit pathfinder
+        # routing intent -- the new field must take precedence.
+        override = NetClassRouting(
+            name="PourOverridePathfinder",
+            is_pour_net=True,
+            route_via="pathfinder",
+        )
+        mapping = {
+            "PHASE_A": override,
+            "PHASE_B": override,
+            "PHASE_C": override,
+            "SIG_DATA": NetClassRouting(name="Signal", route_via="pathfinder"),
+        }
+
+        skip_nets: list[str] = []
+        with self._patch_classifier_with(mapping):
+            auto_skipped, no_zone = _auto_skip_pour_nets(pcb_phase_nets, skip_nets, quiet=True)
+
+        # Despite is_pour_net=True, route_via="pathfinder" wins.
+        assert "PHASE_A" not in auto_skipped
+        assert "PHASE_B" not in auto_skipped
+        assert "PHASE_C" not in auto_skipped
+        assert "PHASE_A" not in skip_nets
+
+    def test_phase_nets_default_classifier_stay_pathfinder(self, pcb_phase_nets: Path) -> None:
+        """Regression baseline: under the default classifier, PHASE_A/B/C
+        are HIGH_CURRENT_SIGNAL with ``route_via="pathfinder"`` and must
+        NOT be auto-skipped.  Without this guard, board 05 (BLDC motor
+        controller) would regress -- the comment block at
+        ``router/rules.py:902-921`` explicitly forbids pouring phase
+        outputs because it couples switching noise into nearby traces.
+        """
+        from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
+
+        skip_nets: list[str] = []
+        # NO mock -- use the real classifier.
+        auto_skipped, no_zone = _auto_skip_pour_nets(pcb_phase_nets, skip_nets, quiet=True)
+
+        # PHASE_A/B/C are HIGH_CURRENT_SIGNAL; default route_via is
+        # "pathfinder"; must NOT be skipped.
+        assert "PHASE_A" not in auto_skipped
+        assert "PHASE_B" not in auto_skipped
+        assert "PHASE_C" not in auto_skipped
+        assert "PHASE_A" not in skip_nets
+        # They also should NOT show up in the no_zone (pour-without-zone)
+        # warning because their class does not declare is_pour_net.
+        assert "PHASE_A" not in no_zone
+
+    def test_pour_net_with_zone_still_skipped(self, pcb_with_gnd: Path) -> None:
+        """No-regression: predefined ground class (route_via="pour") still
+        auto-skips GND when a zone exists.  This verifies the
+        ``NetClass.GROUND`` migration in ``net_class.py`` is wired up.
+        """
+        from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
+
+        skip_nets: list[str] = []
+        auto_skipped, _no_zone = _auto_skip_pour_nets(pcb_with_gnd, skip_nets, quiet=True)
+
+        assert "GND" in auto_skipped
+        assert "GND" in skip_nets


### PR DESCRIPTION
## Summary

Adds a `Literal["pathfinder", "pour", "manual"]` `route_via` field to
`NetClassRouting` so designers can declaratively opt OUT of the pathfinder
without hand-rolling `skip_nets` in a custom `design.py`.

- **`"pathfinder"` (default)** — preserves pre-#2772 behaviour for every existing class.
- **`"pour"`** — skip from pathfinder; expect a copper zone (`NET_CLASS_POWER` and the predefined `NetClass.GROUND` class flip to this value).
- **`"manual"`** — always skip from pathfinder; designer routes by hand. Emits a distinct `Manual:` log line so the net is visibly deferred rather than dropped silently.

`NET_CLASS_HIGH_CURRENT_SIGNAL` deliberately keeps `route_via="pathfinder"` — PHASE_A/B/C on board 05 must remain pathfinder-routed with wide traces, not poured (see `rules.py:902-921` comment block). The 159s/net pathology that motivated the original framing is covered by sibling issues **#2768 / #2769**, not here.

Explicit `route_via="pathfinder"` wins over legacy `is_pour_net=True` — designers can override the name-pattern classifier for a specific class via the new declarative field.

## Files changed

- `src/kicad_tools/router/rules.py` — add `route_via` field + serialization; set `NET_CLASS_POWER.route_via="pour"`.
- `src/kicad_tools/router/net_class.py` — set `NetClass.GROUND` inline class to `route_via="pour"` (preserves auto-skip behaviour for GND/VSS/AGND/...).
- `src/kicad_tools/cli/route_cmd.py` — `_auto_skip_pour_nets` now honours `route_via`; manual nets emit a distinct log line; explicit pathfinder override beats legacy `is_pour_net`.
- `tests/test_pour_net_auto_skip.py` — 11 new tests covering field defaults, serialization, manual-skip, pathfinder-override, and PHASE_A/B/C non-regression.
- `tests/test_net_class_serialization.py` — extend drift-prevention dict with `route_via` key.

## Acceptance criteria

- [x] `NetClassRouting.route_via` field exists with 3 Literal values, defaults to `"pathfinder"`.
- [x] `NET_CLASS_POWER` and the predefined `NetClass.GROUND` class set `route_via="pour"`.
- [x] `_auto_skip_pour_nets` honors the new field and matches existing behavior on `NET_CLASS_POWER` and `NET_CLASS_GROUND` (no regression on the 51 pre-existing pour-net tests).
- [x] A custom NetClass with `route_via="manual"` is auto-skipped from the pathfinder, even without a zone.
- [x] PHASE_A/B/C (HIGH_CURRENT_SIGNAL) continue to be pathfinder-routed — verified by `test_phase_nets_default_classifier_stay_pathfinder`.
- [x] Regression test: synthetic class with `route_via="manual"` is skipped; `route_via="pathfinder"` is NOT skipped (even when `is_pour_net=True`).
- [x] `to_dict()` / `from_dict()` round-trip the new field; legacy dicts without the key default to `"pathfinder"`.

## Test plan

- [x] `tests/test_pour_net_auto_skip.py` — 51 tests pass (40 pre-existing + 11 new).
- [x] `tests/test_net_class_serialization.py` — 39 tests pass (drift-prevention dict extended).
- [x] `tests/test_net_class.py`, `tests/test_net_class_trace_width.py` — pass.
- [x] `tests/test_route_cmd_*` (input preservation, params, placement feedback, power nets, stale layer cleanup, zone fill) — pass.
- [x] `tests/test_route_signal_handling.py`, `tests/test_build_zones_step.py` — pass.
- [x] 340 tests pass across the related modules.
- [x] `ruff check` clean; `ruff format` applied.

## Out of scope

- Per-net timeout enforcement (covered by **#2768**).
- RSMT per-net cap (covered by **#2769**).
- Schematic-side declaration syntax for `route_via` (follow-up).
- Migrating `boards/05-bldc-motor-controller/design.py` to use `route_via="manual"` (follow-up).

## Coordination

- **#2761** (`core.py:1466-1478`) — different file/range, no overlap.
- **#2768** (`core.py:8285-8290` + `route_cmd.py:1636/2310/2829/4919`) — same file (`route_cmd.py`), different ranges. My touch is `1350-1442`; theirs is later.
- **#2773** (`build_cmd.py` SYNC step) — different file.

Closes #2772

🤖 Generated with [Claude Code](https://claude.com/claude-code)