### PR TITLE
feat(zones): partition shared-layer pour outlines into per-net bboxes

### DIFF
--- a/src/kicad_tools/router/auto_pour.py
+++ b/src/kicad_tools/router/auto_pour.py
@@ -37,6 +37,25 @@ automatically by the layer/priority allocator in
 a 2-layer stackup each ground gets a distinct priority on ``B.Cu`` to
 avoid the "zero copper" override that occurs when zones share both
 layer and priority.  See that function's docstring for the full rule.
+
+Geometric outline partition (#2771)
+-----------------------------------
+
+The layer/priority allocator alone is not sufficient when N≥2 zones
+share a single layer (the common case on 2-layer stackups, and the
+fallback path on 4-layer stackups with 3+ power nets).  Distinct
+priorities prevent the explicit zero-copper warning, but KiCad's fill
+resolver still awards the entire overlapping region to the highest
+priority zone, so siblings receive zero usable copper.
+
+To make every zone produce real copper, this module delegates to
+``kicad_tools.zones.generator.auto_create_zones_for_pour_nets``, which
+runs the **outline allocator** (``_compute_pour_outlines``) after layer
+assignment.  Zones that share a layer with one or more siblings get a
+per-net bounding-box outline (default 1.5 mm margin around the net's
+pads, clipped to the board outline), while zones that are the only zone
+on their layer keep the full board outline so return-path planes stay
+continuous.  See that function's docstring for the contract.
 """
 
 from __future__ import annotations

--- a/src/kicad_tools/zones/generator.py
+++ b/src/kicad_tools/zones/generator.py
@@ -3,10 +3,29 @@ Zone generator for creating copper pour zones on PCBs.
 
 This module provides a high-level API for generating copper pour zones,
 with automatic board outline detection and sensible defaults for power nets.
+
+Outline allocator (#2771)
+-------------------------
+
+In addition to the layer/priority allocator (:func:`_assign_layers_for_pour_nets`),
+this module owns the *outline* allocator (:func:`_compute_pour_outlines`).
+The outline allocator runs after layer assignment and decides whether each
+zone should use the full board outline (when it is the only zone on its
+layer) or a per-net bounding region derived from that net's pads (when it
+shares a layer with another zone).
+
+This is the fix for the "all power nets share F.Cu with identical board
+outlines, so the highest-priority zone wins everything" failure documented
+in #2771.  Earlier issues #2410 / #2041 / #2593 made the priorities
+distinct, which silenced the warning, but distinct priorities alone do not
+produce real copper for the losing zones -- the outlines have to be
+geometrically disjoint for KiCad's fill resolver to award copper to more
+than one zone on a shared layer.
 """
 
 from __future__ import annotations
 
+import math
 import sys
 import uuid as uuid_module
 from collections.abc import Sequence
@@ -915,6 +934,244 @@ def _assign_layers_for_pour_nets(
     return assignments
 
 
+# ---------------------------------------------------------------------------
+# Outline allocator (#2771)
+# ---------------------------------------------------------------------------
+
+# Default per-net margin around the pad bounding box, in mm.  1.5 mm gives
+# enough copper around each pad cluster for thermal relief and trace exits
+# without aggressively encroaching on neighbouring nets.  Empirically chosen
+# during the curator analysis of board 05.
+DEFAULT_POUR_BBOX_MARGIN_MM = 1.5
+
+# Default side length of the fallback square emitted when a net has only a
+# single pad (or all its pads coincide).  Slightly larger than the margin
+# alone so single-pad nets still receive a usable copper patch.
+SINGLE_PAD_FALLBACK_SIDE_MM = 4.0
+
+
+def _net_pad_positions_absolute(
+    pcb: PCB,
+    net_name: str,
+) -> list[tuple[float, float]]:
+    """Return sheet-absolute (x, y) positions of every pad on ``net_name``.
+
+    ``Footprint.position`` is board-relative after :meth:`PCB._detect_board_origin`,
+    so we add the board origin back to produce coordinates in the same frame
+    as :pyattr:`ZoneGenerator.board_outline` (which is the frame expected by
+    ``add_zone(boundary=)``).
+
+    Pads with ``net_number == 0`` (the implicit "no net" pad) are skipped
+    even if they happen to share a name with the requested net.  Footprints
+    whose reference designator is empty or begins with ``#`` (KiCad's
+    convention for power-symbol stand-ins like ``#PWR01``) are also skipped
+    because they have no physical pads on the board.
+    """
+    ox, oy = pcb.board_origin
+    positions: list[tuple[float, float]] = []
+
+    for fp in pcb.footprints:
+        if not fp.reference or fp.reference.startswith("#"):
+            continue
+
+        fp_x, fp_y = fp.position
+        rot_rad = math.radians(-fp.rotation)
+        cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
+
+        for pad in fp.pads:
+            # ``Pad.net_name`` is authoritative (matches the netlist exactly);
+            # ``net_number`` may be zero on freshly-imported PCBs that have
+            # not been routed yet, so name comparison is the safe predicate.
+            if pad.net_name != net_name:
+                continue
+            # Skip the implicit no-net pad (net_number 0 with empty name).
+            if not pad.net_name:
+                continue
+
+            px, py = pad.position
+            rx = px * cos_r - py * sin_r
+            ry = px * sin_r + py * cos_r
+            # Footprint position is board-relative -> add board origin to get
+            # sheet-absolute coordinates.
+            positions.append((fp_x + rx + ox, fp_y + ry + oy))
+
+    return positions
+
+
+def _bbox_polygon(
+    positions: list[tuple[float, float]],
+    margin_mm: float,
+) -> list[tuple[float, float]] | None:
+    """Build an axis-aligned bounding box polygon around ``positions``.
+
+    Returns ``None`` if ``positions`` is empty.  When all positions
+    coincide (e.g. a single-pad net), returns a small square of side
+    :data:`SINGLE_PAD_FALLBACK_SIDE_MM` centered on the point so the
+    resulting zone still has non-zero area.
+
+    The returned polygon is in the same coordinate frame as ``positions``.
+    """
+    if not positions:
+        return None
+
+    xs = [p[0] for p in positions]
+    ys = [p[1] for p in positions]
+    x_min, x_max = min(xs), max(xs)
+    y_min, y_max = min(ys), max(ys)
+
+    # Single-pad (or zero-extent) fallback: emit a small square centered on
+    # the pad cluster so the zone is non-degenerate.
+    if x_max - x_min < 1e-6 and y_max - y_min < 1e-6:
+        half = SINGLE_PAD_FALLBACK_SIDE_MM / 2.0
+        cx, cy = x_min, y_min
+        return [
+            (round(cx - half, 6), round(cy - half, 6)),
+            (round(cx + half, 6), round(cy - half, 6)),
+            (round(cx + half, 6), round(cy + half, 6)),
+            (round(cx - half, 6), round(cy + half, 6)),
+        ]
+
+    x_min -= margin_mm
+    x_max += margin_mm
+    y_min -= margin_mm
+    y_max += margin_mm
+
+    return [
+        (round(x_min, 6), round(y_min, 6)),
+        (round(x_max, 6), round(y_min, 6)),
+        (round(x_max, 6), round(y_max, 6)),
+        (round(x_min, 6), round(y_max, 6)),
+    ]
+
+
+def _clip_polygon_to_outline(
+    polygon: list[tuple[float, float]],
+    outline: list[tuple[float, float]],
+) -> list[tuple[float, float]]:
+    """Clip ``polygon`` to the interior of ``outline``.
+
+    Both polygons are in the same coordinate frame (sheet-absolute).  Uses
+    Shapely if available for an exact intersection; falls back to a pure
+    AABB clip when Shapely is missing or the intersection collapses.  When
+    everything fails, returns the original polygon unchanged -- KiCad
+    happily ignores zone copper that lands outside the board edge, so an
+    unclipped polygon still produces correct fills (just with a larger
+    bounding region on disk than necessary).
+    """
+    if not polygon or not outline:
+        return polygon
+
+    # Try Shapely first for accurate intersection with arbitrary outlines.
+    try:
+        from shapely.geometry import Polygon
+
+        clipped = Polygon(polygon).intersection(Polygon(outline))
+        if clipped.is_empty:
+            return polygon
+        if clipped.geom_type == "MultiPolygon":
+            clipped = max(clipped.geoms, key=lambda g: g.area)
+        if clipped.geom_type != "Polygon":
+            return polygon
+        coords = list(clipped.exterior.coords)
+        if len(coords) > 1 and coords[0] == coords[-1]:
+            coords = coords[:-1]
+        if len(coords) < 3:
+            return polygon
+        return [(round(x, 6), round(y, 6)) for x, y in coords]
+    except ImportError:
+        pass
+
+    # Pure-Python fallback: AABB clip (correct for rectangular outlines,
+    # conservative for everything else).
+    out_xs = [p[0] for p in outline]
+    out_ys = [p[1] for p in outline]
+    ox_min, ox_max = min(out_xs), max(out_xs)
+    oy_min, oy_max = min(out_ys), max(out_ys)
+
+    poly_xs = [p[0] for p in polygon]
+    poly_ys = [p[1] for p in polygon]
+    px_min = max(min(poly_xs), ox_min)
+    px_max = min(max(poly_xs), ox_max)
+    py_min = max(min(poly_ys), oy_min)
+    py_max = min(max(poly_ys), oy_max)
+
+    if px_min >= px_max or py_min >= py_max:
+        return polygon
+
+    return [
+        (round(px_min, 6), round(py_min, 6)),
+        (round(px_max, 6), round(py_min, 6)),
+        (round(px_max, 6), round(py_max, 6)),
+        (round(px_min, 6), round(py_max, 6)),
+    ]
+
+
+def _compute_pour_outlines(
+    pcb: PCB,
+    assignments: list[tuple[str, str, int]],
+    board_outline: list[tuple[float, float]],
+    margin_mm: float = DEFAULT_POUR_BBOX_MARGIN_MM,
+) -> dict[str, list[tuple[float, float]] | None]:
+    """Compute per-net pour outlines for the given layer assignments.
+
+    For each ``(net_name, layer, priority)`` in ``assignments``:
+
+    * If this is the only zone on its layer, return ``None`` so the caller
+      uses the default ``board_outline``.  This preserves the GND
+      return-path plane on 4-layer stackups (where GND sits alone on
+      ``In1.Cu``) and on 2-layer stackups (where GND sits alone on
+      ``B.Cu``).
+    * If two or more zones share a layer, compute a bounding-box outline
+      around the net's pads, inflated by ``margin_mm``, then clip to
+      ``board_outline`` so the zone never extends past the board edge.
+
+    The returned polygons are in the same coordinate frame as
+    ``board_outline`` -- sheet-absolute, which is the frame expected by
+    :meth:`ZoneGenerator.add_zone`'s ``boundary=`` argument (post-PR-#2753).
+
+    Args:
+        pcb: Loaded PCB object (used to look up pad positions).
+        assignments: Output of :func:`_assign_layers_for_pour_nets`.
+        board_outline: Sheet-absolute board outline polygon.  Used as the
+            clipping mask and returned as ``None`` for sole-zone layers
+            (the caller falls back to ``board_outline`` via
+            :pyattr:`ZoneGenerator.board_outline`).
+        margin_mm: Margin around the pad bounding box, in mm.  Defaults to
+            :data:`DEFAULT_POUR_BBOX_MARGIN_MM` (1.5 mm).
+
+    Returns:
+        Dict mapping ``net_name`` -> polygon (or ``None`` for default).
+    """
+    # Count zones per layer so we know which assignments share a layer.
+    layer_counts: dict[str, int] = {}
+    for _, layer, _ in assignments:
+        layer_counts[layer] = layer_counts.get(layer, 0) + 1
+
+    outlines: dict[str, list[tuple[float, float]] | None] = {}
+
+    for net_name, layer, _ in assignments:
+        if layer_counts[layer] < 2:
+            # Sole zone on its layer -- keep the full board outline so
+            # ground/return planes stay continuous.
+            outlines[net_name] = None
+            continue
+
+        positions = _net_pad_positions_absolute(pcb, net_name)
+        bbox = _bbox_polygon(positions, margin_mm)
+        if bbox is None:
+            # No pads found for this net.  Fall back to the full board
+            # outline -- it will still overlap siblings, but at least the
+            # zone is created.  This path is unusual (net classified as
+            # power/ground but has no physical pads) and only happens for
+            # ERC-marker leakage that the upstream filter missed.
+            outlines[net_name] = None
+            continue
+
+        outlines[net_name] = _clip_polygon_to_outline(bbox, board_outline)
+
+    return outlines
+
+
 def auto_create_zones_for_pour_nets(
     pcb_path: str | Path,
     pour_nets: list[tuple[str, NetClass]],
@@ -952,13 +1209,38 @@ def auto_create_zones_for_pour_nets(
 
     See ``_assign_layers_for_pour_nets`` for full assignment rules.
 
+    Geometric outline partition (#2771)
+    -----------------------------------
+
+    After the layer/priority allocator runs, the **outline allocator**
+    (:func:`_compute_pour_outlines`) decides whether each zone uses the
+    full board outline or a per-net bounding region:
+
+    * Zones that are the *only* zone on their layer (e.g. ``GND`` on
+      ``B.Cu`` for a single-ground 2-layer board, or ``GND`` on
+      ``In1.Cu`` for a 4-layer board) keep the full board outline.  This
+      preserves the return-path plane that signals need to cross without
+      gaps.
+    * Zones that *share* a layer with one or more other zones (e.g. the
+      ``+5V`` / ``+3.3V`` / ``PWR_LED`` cluster on F.Cu of a 2-layer
+      board) get a bounding box around their own pads (with a 1.5 mm
+      default margin), clipped to the board outline.
+
+    Without this geometric partition, distinct priorities (added in
+    #2410) are insufficient -- KiCad's fill resolver awards the entire
+    shared region to the highest-priority zone, so siblings receive zero
+    copper despite the file containing a zone definition for each
+    (see #2771 for the board 05 reproduction).
+
     Args:
         pcb_path: Path to .kicad_pcb file (modified in place)
         pour_nets: List of (net_name, NetClass) tuples identifying
             which nets need zones
         edge_clearance: Optional edge clearance in mm.  When set, the
             auto-derived board outline is inset by this distance so that
-            zone copper does not extend to the board edge.
+            zone copper does not extend to the board edge.  The same
+            inset is applied to the per-net bounding outlines so they
+            also stay inside the inset board.
 
     Returns:
         Number of zones created
@@ -969,9 +1251,20 @@ def auto_create_zones_for_pour_nets(
     copper_layer_count = len(gen.pcb.copper_layers)
     assignments = _assign_layers_for_pour_nets(copper_layer_count, pour_nets)
 
+    # Outline allocator (#2771): compute per-net bounding outlines for any
+    # layer that hosts more than one zone.  Sole-layer zones (typically
+    # ground) get ``None`` so :meth:`ZoneGenerator.add_zone` falls back to
+    # the full ``board_outline`` and keeps the return-path plane continuous.
+    pour_outlines = _compute_pour_outlines(gen.pcb, assignments, gen.board_outline)
+
     count = 0
     for net_name, layer, priority in assignments:
-        gen.add_zone(net=net_name, layer=layer, priority=priority)
+        gen.add_zone(
+            net=net_name,
+            layer=layer,
+            priority=priority,
+            boundary=pour_outlines.get(net_name),
+        )
         count += 1
 
     if count > 0:

--- a/tests/test_build_zones_step.py
+++ b/tests/test_build_zones_step.py
@@ -758,3 +758,393 @@ class TestRouteStepPostcondition:
         nonexistent = tmp_path / "ghost.kicad_pcb"
         result = _check_route_postcondition(input_pcb=nonexistent, routed_pcb=nonexistent)
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Geometric outline allocator (issue #2771)
+# ---------------------------------------------------------------------------
+
+
+def _aabb(points: list[tuple[float, float]]) -> tuple[float, float, float, float]:
+    """Return axis-aligned bounding box (x_min, y_min, x_max, y_max)."""
+    xs = [p[0] for p in points]
+    ys = [p[1] for p in points]
+    return min(xs), min(ys), max(xs), max(ys)
+
+
+def _aabbs_overlap(
+    a: tuple[float, float, float, float],
+    b: tuple[float, float, float, float],
+) -> bool:
+    """Return True iff the two AABBs overlap (touching edges allowed)."""
+    return not (a[2] <= b[0] or b[2] <= a[0] or a[3] <= b[1] or b[3] <= a[1])
+
+
+class TestAutoPourGeometricOutlines:
+    """Tests for the outline allocator added in issue #2771.
+
+    When two or more pour zones land on the same layer, they must use
+    *disjoint per-net bounding outlines* rather than the full board
+    outline.  Otherwise KiCad's fill resolver awards the entire shared
+    region to the highest-priority zone and the siblings receive zero
+    copper -- the exact failure mode on board 05 documented in #2771.
+
+    These tests cover the three scenarios called out in the issue's
+    acceptance criteria:
+      * 2-layer board with 4 power nets on F.Cu + GND on B.Cu
+      * 4-layer board with the same pour set (GND on In1.Cu full-outline)
+      * Edge case: power net with a single pad (fall back to a small
+        default square, not a zero-area polygon)
+    """
+
+    # ----- fixtures -----------------------------------------------------
+
+    @staticmethod
+    def _make_pcb(tmp_path: Path, layers_block: str, footprints_block: str) -> Path:
+        """Build a minimal PCB with the given layers and footprints.
+
+        The board 05 pour set has 5 nets (VMOTOR / +5V / +3.3V / GND /
+        PWR_LED).  Footprints are laid out in disjoint clusters along the
+        x axis so each net's bounding box is geometrically separated --
+        this mirrors the way real boards arrange their power
+        sub-circuits and lets the test assert that the bbox allocator
+        produces disjoint outlines.
+        """
+        pcb_text = f"""\
+(kicad_pcb
+  (version 20240108)
+  (generator "kicad")
+  (general (thickness 1.6))
+  (layers
+{layers_block}
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "VMOTOR")
+  (net 3 "+5V")
+  (net 4 "+3.3V")
+  (net 5 "PWR_LED")
+  (gr_rect
+    (start 0 0)
+    (end 100 50)
+    (stroke (width 0.15) (type solid))
+    (fill none)
+    (layer "Edge.Cuts")
+    (uuid "edge-uuid")
+  )
+{footprints_block}
+)
+"""
+        p = tmp_path / "board.kicad_pcb"
+        p.write_text(pcb_text)
+        return p
+
+    @staticmethod
+    def _footprints_for_board05_layout() -> str:
+        """Footprints arranged so each power net has a disjoint pad cluster.
+
+        Layout (x positions, all on F.Cu):
+          VMOTOR  cluster: x = 10, 12      (with U1, U2)
+          +5V     cluster: x = 30, 32      (U3, U4)
+          +3.3V   cluster: x = 50, 52      (U5, U6)
+          PWR_LED cluster: x = 70, 72      (U7, U8)
+          GND     pads at every footprint (return-path style)
+        """
+        rows = []
+
+        def fp(ref: str, x: float, pwr_net: str) -> str:
+            return f"""  (footprint "Test:{ref}"
+    (layer "F.Cu")
+    (at {x} 25)
+    (uuid "fp-{ref}-uuid")
+    (property "Reference" "{ref}"
+      (at 0 -2 0)
+      (layer "F.SilkS")
+      (uuid "prop-{ref}-ref-uuid")
+      (effects (font (size 1 1) (thickness 0.15)))
+    )
+    (property "Value" "TEST"
+      (at 0 2 0)
+      (layer "F.Fab")
+      (uuid "prop-{ref}-val-uuid")
+      (effects (font (size 1 1) (thickness 0.15)))
+    )
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "GND"))
+    (pad "2" smd rect (at 1 0) (size 1 1) (layers "F.Cu") (net {pwr_net} ))
+  )"""
+
+        # The board 05 pour set: 4 distinct power nets + GND.
+        rows.append(fp("U1", 10, '2 "VMOTOR"'))
+        rows.append(fp("U2", 12, '2 "VMOTOR"'))
+        rows.append(fp("U3", 30, '3 "+5V"'))
+        rows.append(fp("U4", 32, '3 "+5V"'))
+        rows.append(fp("U5", 50, '4 "+3.3V"'))
+        rows.append(fp("U6", 52, '4 "+3.3V"'))
+        rows.append(fp("U7", 70, '5 "PWR_LED"'))
+        rows.append(fp("U8", 72, '5 "PWR_LED"'))
+        return "\n".join(rows)
+
+    @pytest.fixture
+    def two_layer_board05_pcb(self, tmp_path: Path) -> Path:
+        layers = '    (0 "F.Cu" signal)\n    (31 "B.Cu" signal)'
+        fps = self._footprints_for_board05_layout()
+        return self._make_pcb(tmp_path, layers, fps)
+
+    @pytest.fixture
+    def four_layer_board05_pcb(self, tmp_path: Path) -> Path:
+        layers = (
+            '    (0 "F.Cu" signal)\n'
+            '    (1 "In1.Cu" signal)\n'
+            '    (2 "In2.Cu" signal)\n'
+            '    (31 "B.Cu" signal)'
+        )
+        fps = self._footprints_for_board05_layout()
+        return self._make_pcb(tmp_path, layers, fps)
+
+    @pytest.fixture
+    def single_pad_power_pcb(self, tmp_path: Path) -> Path:
+        """PCB where +3.3V has exactly one pad on the whole board.
+
+        Exercises the single-pad fallback in ``_bbox_polygon`` (a
+        zero-extent pad cluster must produce a non-degenerate square,
+        not a zero-area polygon).
+        """
+        layers = '    (0 "F.Cu" signal)\n    (31 "B.Cu" signal)'
+        fps = """  (footprint "Test:U1"
+    (layer "F.Cu")
+    (at 10 10)
+    (uuid "fp-u1-uuid")
+    (property "Reference" "U1"
+      (at 0 -2 0) (layer "F.SilkS") (uuid "prop-u1-ref-uuid")
+      (effects (font (size 1 1) (thickness 0.15)))
+    )
+    (property "Value" "TEST"
+      (at 0 2 0) (layer "F.Fab") (uuid "prop-u1-val-uuid")
+      (effects (font (size 1 1) (thickness 0.15)))
+    )
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "GND"))
+    (pad "2" smd rect (at 1 0) (size 1 1) (layers "F.Cu") (net 4 "+3.3V"))
+    (pad "3" smd rect (at 2 0) (size 1 1) (layers "F.Cu") (net 3 "+5V"))
+  )
+  (footprint "Test:U2"
+    (layer "F.Cu")
+    (at 40 10)
+    (uuid "fp-u2-uuid")
+    (property "Reference" "U2"
+      (at 0 -2 0) (layer "F.SilkS") (uuid "prop-u2-ref-uuid")
+      (effects (font (size 1 1) (thickness 0.15)))
+    )
+    (property "Value" "TEST"
+      (at 0 2 0) (layer "F.Fab") (uuid "prop-u2-val-uuid")
+      (effects (font (size 1 1) (thickness 0.15)))
+    )
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "GND"))
+    (pad "2" smd rect (at 1 0) (size 1 1) (layers "F.Cu") (net 3 "+5V"))
+  )"""
+        return self._make_pcb(tmp_path, layers, fps)
+
+    # ----- tests --------------------------------------------------------
+
+    def test_2layer_power_nets_have_disjoint_bboxes(
+        self, two_layer_board05_pcb: Path, capsys: pytest.CaptureFixture
+    ):
+        """Board 05 pour set on 2-layer: 4 power F.Cu zones must be disjoint."""
+        from kicad_tools.zones.generator import auto_create_zones_for_pour_nets
+
+        pour_nets = [
+            ("VMOTOR", NetClass.POWER),
+            ("+5V", NetClass.POWER),
+            ("+3.3V", NetClass.POWER),
+            ("GND", NetClass.GROUND),
+            ("PWR_LED", NetClass.POWER),
+        ]
+        count = auto_create_zones_for_pour_nets(two_layer_board05_pcb, pour_nets)
+        assert count == 5
+
+        # Every power-net zone must have a distinct AABB on F.Cu.
+        pcb = PCB.load(str(two_layer_board05_pcb))
+        f_cu_zones = [z for z in pcb.zones if z.layer == "F.Cu"]
+        assert len(f_cu_zones) == 4, (
+            f"Expected 4 power-net zones on F.Cu, got {[z.net_name for z in f_cu_zones]}"
+        )
+
+        boxes = {z.net_name: _aabb(z.polygon) for z in f_cu_zones}
+
+        # All 4 AABBs must be pairwise distinct (no two nets share an outline).
+        unique_boxes = {tuple(round(v, 3) for v in box) for box in boxes.values()}
+        assert len(unique_boxes) == 4, f"AABBs not unique: {boxes}"
+
+        # No two AABBs may overlap (this is the fix's core invariant).
+        names = list(boxes)
+        for i, name_a in enumerate(names):
+            for name_b in names[i + 1 :]:
+                assert not _aabbs_overlap(boxes[name_a], boxes[name_b]), (
+                    f"AABBs for {name_a} and {name_b} overlap: {boxes[name_a]} vs {boxes[name_b]}"
+                )
+
+        # No overlap warnings should have been emitted to stderr by
+        # ``_check_overlap`` -- the whole point of the geometric
+        # partition is to silence them on legitimate multi-power boards.
+        captured = capsys.readouterr()
+        assert "WARNING" not in captured.err, (
+            f"Unexpected overlap warning(s) from _check_overlap:\n{captured.err}"
+        )
+
+    def test_2layer_gnd_retains_full_outline(self, two_layer_board05_pcb: Path):
+        """GND on B.Cu is the only zone on its layer -> full board outline."""
+        from kicad_tools.zones.generator import auto_create_zones_for_pour_nets
+
+        pour_nets = [
+            ("VMOTOR", NetClass.POWER),
+            ("+5V", NetClass.POWER),
+            ("+3.3V", NetClass.POWER),
+            ("GND", NetClass.GROUND),
+            ("PWR_LED", NetClass.POWER),
+        ]
+        auto_create_zones_for_pour_nets(two_layer_board05_pcb, pour_nets)
+
+        pcb = PCB.load(str(two_layer_board05_pcb))
+        gnd_zones = [z for z in pcb.zones if z.net_name == "GND"]
+        assert len(gnd_zones) == 1
+        assert gnd_zones[0].layer == "B.Cu"
+
+        # GND must span the full 100x50 board (allow 1mm slop for rounding).
+        x_min, y_min, x_max, y_max = _aabb(gnd_zones[0].polygon)
+        assert x_min <= 1.0
+        assert y_min <= 1.0
+        assert x_max >= 99.0
+        assert y_max >= 49.0
+
+    def test_4layer_gnd_keeps_full_inner_plane(
+        self, four_layer_board05_pcb: Path, capsys: pytest.CaptureFixture
+    ):
+        """4-layer: GND on In1.Cu sole-zone -> full board outline preserved.
+
+        On 4-layer boards the GROUND return-path plane *must* span the
+        full board so signals can cross over it without gaps.  This is
+        the core of the "hybrid" strategy: only zones that share a layer
+        get per-net bounding regions; sole-layer zones (GND) keep the
+        full outline.
+        """
+        from kicad_tools.zones.generator import auto_create_zones_for_pour_nets
+
+        pour_nets = [
+            ("VMOTOR", NetClass.POWER),
+            ("+5V", NetClass.POWER),
+            ("+3.3V", NetClass.POWER),
+            ("GND", NetClass.GROUND),
+            ("PWR_LED", NetClass.POWER),
+        ]
+        count = auto_create_zones_for_pour_nets(four_layer_board05_pcb, pour_nets)
+        assert count == 5
+
+        pcb = PCB.load(str(four_layer_board05_pcb))
+
+        # GND should be on In1.Cu and span the full board.
+        gnd = next(z for z in pcb.zones if z.net_name == "GND")
+        assert gnd.layer == "In1.Cu"
+        x_min, y_min, x_max, y_max = _aabb(gnd.polygon)
+        assert x_min <= 1.0 and y_min <= 1.0
+        assert x_max >= 99.0 and y_max >= 49.0, (
+            f"GND on In1.Cu should be full-outline, got AABB ({x_min}, {y_min})-({x_max}, {y_max})"
+        )
+
+        # The first-priority power net (VMOTOR) is sole on In2.Cu --
+        # should also keep the full outline so it acts as a power plane.
+        vmotor = next(z for z in pcb.zones if z.net_name == "VMOTOR")
+        assert vmotor.layer == "In2.Cu"
+        x_min, y_min, x_max, y_max = _aabb(vmotor.polygon)
+        assert x_max - x_min > 50.0  # spans most of the board
+        assert y_max - y_min > 25.0
+
+        # The remaining three power nets share F.Cu -- they must use
+        # disjoint per-net bounding outlines.
+        f_cu_zones = [z for z in pcb.zones if z.layer == "F.Cu"]
+        assert len(f_cu_zones) == 3, (
+            f"Expected 3 F.Cu zones (+5V/+3.3V/PWR_LED), got {[z.net_name for z in f_cu_zones]}"
+        )
+        boxes = {z.net_name: _aabb(z.polygon) for z in f_cu_zones}
+        names = list(boxes)
+        for i, name_a in enumerate(names):
+            for name_b in names[i + 1 :]:
+                assert not _aabbs_overlap(boxes[name_a], boxes[name_b]), (
+                    f"F.Cu zones {name_a}/{name_b} overlap: {boxes[name_a]} vs {boxes[name_b]}"
+                )
+
+        captured = capsys.readouterr()
+        assert "WARNING" not in captured.err, f"Unexpected overlap warning(s):\n{captured.err}"
+
+    def test_single_pad_net_uses_fallback_square(self, single_pad_power_pcb: Path):
+        """Power net with one pad: outline is a small square, not zero-area.
+
+        ``+3.3V`` has exactly one pad on the board.  The bbox allocator
+        must produce a non-degenerate polygon (default 4 mm square)
+        rather than a zero-extent point that KiCad would silently drop.
+        """
+        from kicad_tools.zones.generator import (
+            SINGLE_PAD_FALLBACK_SIDE_MM,
+            auto_create_zones_for_pour_nets,
+        )
+
+        pour_nets = [
+            ("+5V", NetClass.POWER),
+            ("+3.3V", NetClass.POWER),
+            ("GND", NetClass.GROUND),
+        ]
+        count = auto_create_zones_for_pour_nets(single_pad_power_pcb, pour_nets)
+        assert count == 3
+
+        pcb = PCB.load(str(single_pad_power_pcb))
+        # Both power zones land on F.Cu (shared) so both must get per-net
+        # bounding outlines.
+        threev_zones = [z for z in pcb.zones if z.net_name == "+3.3V"]
+        assert len(threev_zones) == 1
+        polygon = threev_zones[0].polygon
+        x_min, y_min, x_max, y_max = _aabb(polygon)
+        width = x_max - x_min
+        height = y_max - y_min
+
+        # The polygon must have non-zero area (the failure mode the test
+        # guards against is a zero-area polygon that KiCad drops).
+        assert width > 0.5, f"+3.3V polygon collapsed: width={width}"
+        assert height > 0.5, f"+3.3V polygon collapsed: height={height}"
+
+        # The polygon must be smaller than the full board (the whole
+        # point is to NOT use the full outline when sharing a layer).
+        assert width < 90.0
+        assert height < 40.0
+
+        # And the fallback square is at least roughly the configured size.
+        # (Bbox allocator with one pad emits the default square, possibly
+        # clipped to the board outline.)
+        assert width <= SINGLE_PAD_FALLBACK_SIDE_MM + 0.1
+        assert height <= SINGLE_PAD_FALLBACK_SIDE_MM + 0.1
+
+    def test_compute_pour_outlines_returns_none_for_sole_layer(self, two_layer_board05_pcb: Path):
+        """Direct unit test: sole-layer zones (GND) get ``None`` outline."""
+        from kicad_tools.zones import ZoneGenerator
+        from kicad_tools.zones.generator import (
+            _assign_layers_for_pour_nets,
+            _compute_pour_outlines,
+        )
+
+        pour_nets = [
+            ("VMOTOR", NetClass.POWER),
+            ("+5V", NetClass.POWER),
+            ("+3.3V", NetClass.POWER),
+            ("GND", NetClass.GROUND),
+            ("PWR_LED", NetClass.POWER),
+        ]
+        gen = ZoneGenerator.from_pcb(two_layer_board05_pcb)
+        pcb = gen.pcb
+
+        assignments = _assign_layers_for_pour_nets(2, pour_nets)
+        outlines = _compute_pour_outlines(pcb, assignments, gen.board_outline)
+
+        # GND is the only zone on B.Cu -> None (use full board outline)
+        assert outlines["GND"] is None
+        # Every shared-layer zone (F.Cu) -> concrete polygon
+        for net in ("VMOTOR", "+5V", "+3.3V", "PWR_LED"):
+            assert outlines[net] is not None, f"{net} should have a per-net outline"
+            assert len(outlines[net]) >= 3, f"{net} polygon must have >=3 vertices"


### PR DESCRIPTION
## Summary
Adds the **outline allocator** to `auto_create_zones_for_pour_nets`. When two
or more pour zones land on the same copper layer, each zone now gets a per-net
bounding-box outline (1.5 mm margin around the net's pads, clipped to the
board outline) instead of the full board outline. This is the fix for the
"all power zones share F.Cu with identical outlines, so only the highest
priority gets copper" failure mode on board 05 documented in #2771.

Sole-layer zones (GND on B.Cu of a 2-layer board, GND on In1.Cu of a 4-layer
board) keep the full board outline so the return-path plane stays continuous.

## Changes
- **`src/kicad_tools/zones/generator.py`**
  - New helper `_compute_pour_outlines(pcb, assignments, board_outline, margin_mm)`.
  - New helpers `_net_pad_positions_absolute`, `_bbox_polygon`, `_clip_polygon_to_outline`.
  - `auto_create_zones_for_pour_nets` now calls `_compute_pour_outlines` and
    passes each result as `boundary=` to `gen.add_zone(...)`.
  - Sole-zone layers receive `None` so `add_zone` falls back to `board_outline`
    via the existing `boundary if boundary is not None else self.board_outline`
    branch.
  - Single-pad fallback: a power net with only one pad gets a 4 mm default
    square centered on the pad.
  - Boundaries are produced in sheet-absolute coordinates (matches the
    `add_zone(boundary=)` contract established by PR #2753).
- **`src/kicad_tools/router/auto_pour.py`** — docstring updated to describe
  the outline allocator (no behavioral change; this module already delegates
  to the generator).
- **`tests/test_build_zones_step.py`** — new `TestAutoPourGeometricOutlines`
  class with 5 tests:
  - `test_2layer_power_nets_have_disjoint_bboxes` — board 05 pour set on
    2-layer, F.Cu zones must have pairwise-distinct non-overlapping AABBs,
    no `_check_overlap` warnings.
  - `test_2layer_gnd_retains_full_outline` — sole-layer GND keeps the
    full 100x50 board outline.
  - `test_4layer_gnd_keeps_full_inner_plane` — GND on In1.Cu and VMOTOR on
    In2.Cu both keep the full outline (return-path / power-plane invariant);
    the remaining 3 power nets on F.Cu must have disjoint per-net bboxes.
  - `test_single_pad_net_uses_fallback_square` — single-pad net produces a
    non-degenerate ~4 mm square, smaller than the full board.
  - `test_compute_pour_outlines_returns_none_for_sole_layer` — direct unit
    test of the contract (sole-layer zone -> `None`; shared-layer zone ->
    concrete polygon).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| 4 power-net zones on F.Cu do NOT share the same outline (board 05 pour set) | done | `test_2layer_power_nets_have_disjoke_bboxes` asserts 4 pairwise-distinct AABBs, and a manual check on `boards/05-bldc-motor-controller/output/bldc_controller.kicad_pcb` produces 4 different AABBs (VMOTOR/+5V/+3.3V/PWR_LED) where previously they were all `(0,0)-(70,90)`. |
| 4-layer GROUND keeps full-outline on inner layer (return-path plane preserved) | done | `test_4layer_gnd_keeps_full_inner_plane` asserts GND on `In1.Cu` spans the full 100x50 board; VMOTOR on `In2.Cu` also keeps the full outline (sole-zone-on-layer rule). |
| Single-pad fallback produces non-zero-area polygon | done | `test_single_pad_net_uses_fallback_square` asserts width/height > 0.5 mm and the polygon is smaller than the full board. |
| No overlap warnings on the (synthetic, physically-disjoint) board 05 pour set | done | `test_2layer_power_nets_have_disjoint_bboxes` asserts `"WARNING" not in captured.err`. |
| Existing tests in `TestZoneOverlapDetection` / `TestZoneOverlapNonzeroOrigin` still pass | done | Full sweep of `test_zone_generator.py`, `test_zone_generator_edge_clearance.py`, `test_zones.py`, `test_zone_api.py`, `test_zones_cmd.py`, `test_pcb_add_zone.py`, `test_pcb_zones.py`, `test_validate_zone_fill.py`, `test_route_cmd_zone_fill.py`, `test_placement_zones.py`, `test_gerber_zone_fill.py`, `test_auto_pour.py`, `test_build_zones_step.py` -> 332 passed, 4 skipped. |
| Documentation in `auto_create_zones_for_pour_nets` and `auto_pour.py` docstrings | done | Both docstrings now have a "Geometric outline partition (#2771)" section explaining the allocator and the disjoint-outline invariant. |

## Test Plan
- [x] All 5 new tests in `TestAutoPourGeometricOutlines` pass.
- [x] Existing `TestZoneOverlapDetection` and `TestZoneOverlapNonzeroOrigin`
      tests pass (332 zone-related tests total, no regressions).
- [x] Layer assignment from `_assign_layers_for_pour_nets` is unchanged for
      the board 05 pour set (`(GND, B.Cu, 1)`, `(VMOTOR, F.Cu, 4)`, etc.).
- [x] On the actual `boards/05-bldc-motor-controller/output/bldc_controller.kicad_pcb`,
      VMOTOR/+5V/+3.3V/PWR_LED now have distinct per-net AABBs instead of all
      sharing `(0, 0)-(70, 90)`. (Physical pad clusters on this board still
      overlap, which is the realistic case where bbox is sufficient but not
      perfect -- see the issue's "secondary fallback" note. Voronoi partition
      is the future option.)

## Notes
- The board 05 acceptance criterion in #2746 ("at least 4 zones with non-zero
  filled copper in the routed PCB") additionally requires #2770 (zone
  preservation through the router write-back path). This PR makes auto-pour
  *produce* real copper outlines; #2770 makes that copper *survive* routing.
- Frame: the new outlines are sheet-absolute (`board_outline` frame), matching
  the `add_zone(boundary=)` contract clarified by PR #2753.
- Backward-compatibility: layer / priority assignments from
  `_assign_layers_for_pour_nets` are unchanged. The only behavioral
  difference is the boundary passed to `add_zone` when a layer hosts
  multiple zones.

Closes #2771