### PR TITLE
fix(build): catch silent routed-PCB write-path failures + reconcile board 06 spec

### DIFF
--- a/src/kicad_tools/cli/build_cmd.py
+++ b/src/kicad_tools/cli/build_cmd.py
@@ -992,6 +992,45 @@ def _run_step_zones(ctx: BuildContext, console: Console) -> BuildResult:
         )
 
 
+def _resolve_routed_pcb_path(ctx: BuildContext) -> Path:
+    """Resolve the on-disk path for the router's output PCB.
+
+    Resolution order (first match wins):
+
+    1. ``ctx.spec.project.artifacts.pcb_routed`` if declared in ``project.kct``.
+       Resolved relative to ``ctx.project_dir``.  This lets boards opt into a
+       non-default path (e.g. ``output/<name>_routed.kicad_pcb``) without
+       relying on ``--output``.
+    2. ``ctx.output_dir / "<stem>_routed.kicad_pcb"`` if ``--output`` was
+       passed on the CLI.
+    3. ``<pcb_file>.with_stem(<stem> + "_routed")`` as the historical
+       default (sibling of the unrouted PCB).
+
+    The caller is responsible for ensuring ``ctx.pcb_file`` is set before
+    invoking this; ``_run_step_route`` guards that precondition.
+
+    Returns:
+        Absolute or project-relative ``Path`` to write the routed PCB to.
+    """
+    assert ctx.pcb_file is not None, "_resolve_routed_pcb_path requires ctx.pcb_file"
+
+    if (
+        ctx.spec
+        and ctx.spec.project
+        and ctx.spec.project.artifacts
+        and ctx.spec.project.artifacts.pcb_routed
+    ):
+        declared = Path(ctx.spec.project.artifacts.pcb_routed)
+        if not declared.is_absolute():
+            declared = ctx.project_dir / declared
+        return declared
+
+    if ctx.output_dir:
+        return ctx.output_dir / (ctx.pcb_file.stem + "_routed.kicad_pcb")
+
+    return ctx.pcb_file.with_stem(ctx.pcb_file.stem + "_routed")
+
+
 def _run_step_route(ctx: BuildContext, console: Console) -> BuildResult:
     """Run autorouting step."""
     # Check if a routed PCB already exists (e.g., from generate_design.py)
@@ -1132,10 +1171,7 @@ def _run_step_route(ctx: BuildContext, console: Console) -> BuildResult:
         )
 
     # Place routed PCB in output dir if specified, otherwise alongside input
-    if ctx.output_dir:
-        output_file = ctx.output_dir / (ctx.pcb_file.stem + "_routed.kicad_pcb")
-    else:
-        output_file = ctx.pcb_file.with_stem(ctx.pcb_file.stem + "_routed")
+    output_file = _resolve_routed_pcb_path(ctx)
 
     # Get routing parameters from project spec (preferred) or manufacturer rules (fallback)
     grid, clearance, trace_width, via_drill, via_diameter = _get_routing_params(ctx.mfr, ctx.spec)
@@ -1303,9 +1339,9 @@ def _check_route_postcondition(
 ) -> BuildResult | None:
     """Validate that ``kct route``'s successful exit produced real copper.
 
-    Defense-in-depth check for issue #2740.  The router can exit 0 with
-    ``completion = 1.0`` when every multi-pad net is auto-skipped as a
-    pour net (``nets_to_route`` becomes 0 -> the
+    Defense-in-depth check for issues #2740 and #2782.  The router can
+    exit 0 with ``completion = 1.0`` when every multi-pad net is
+    auto-skipped as a pour net (``nets_to_route`` becomes 0 -> the
     ``nets_routed / nets_to_route if nets_to_route > 0 else 1.0`` ternary
     in :mod:`kicad_tools.cli.route_cmd` returns 1.0).  Without this
     postcondition the build pipeline would proceed to verify/export with
@@ -1315,8 +1351,11 @@ def _check_route_postcondition(
     Returns a *failure* :class:`BuildResult` when:
 
     * The input PCB had at least one multi-pad signal net (so routing
-      should produce >=1 segment), AND
-    * The routed PCB exists and contains zero segments AND zero vias.
+      should produce >=1 segment) AND the routed PCB has zero segments
+      and zero vias (issue #2740 -- silent empty-route), OR
+    * The routed PCB is byte-identical to the input PCB despite
+      ``kct route`` reporting success (issue #2782 -- silent write-path
+      failure where the router never touched the on-disk file).
 
     Returns ``None`` (i.e., "postcondition OK, continue") otherwise --
     including when the input PCB has no routable signal nets (small
@@ -1329,6 +1368,36 @@ def _check_route_postcondition(
     expected = _count_multi_pad_signal_nets(input_pcb)
     if expected == 0:
         return None  # No signal nets to route -- zero segments is legitimate
+
+    # Byte-identical check (issue #2782): if the router reported success
+    # for a PCB with routable signal nets but the output file's bytes
+    # exactly match the input, then either the router silently failed to
+    # write its result or the build pipeline pointed at the wrong path.
+    # Either way, the on-disk artifact is an unrouted PCB masquerading
+    # as a routed one -- fail loudly rather than ship it downstream.
+    try:
+        if input_pcb.exists() and input_pcb.resolve() != routed_pcb.resolve():
+            input_bytes = input_pcb.read_bytes()
+            routed_bytes = routed_pcb.read_bytes()
+            if input_bytes == routed_bytes:
+                return BuildResult(
+                    step="route",
+                    success=False,
+                    message=(
+                        f"Route step exited 0 but the routed PCB at "
+                        f"{routed_pcb} is byte-identical to the unrouted "
+                        f"input at {input_pcb} despite {expected} routable "
+                        f"signal net(s).  This indicates a silent write-path "
+                        f"failure (see issue #2782 -- the build will not "
+                        f"ship an unrouted PCB as a routed one)."
+                    ),
+                    output_file=routed_pcb,
+                )
+    except OSError:
+        # Best-effort: I/O failures should fall through to the segment
+        # check rather than mask a real router fault behind a file-read
+        # error.
+        pass
 
     try:
         from kicad_tools.schema.pcb import PCB

--- a/src/kicad_tools/spec/schema.py
+++ b/src/kicad_tools/spec/schema.py
@@ -79,7 +79,14 @@ class ProjectArtifacts(BaseModel):
     """Project file artifacts."""
 
     schematic: str | None = Field(default=None, description="Path to schematic file")
-    pcb: str | None = Field(default=None, description="Path to PCB file")
+    pcb: str | None = Field(default=None, description="Path to PCB file (unrouted)")
+    pcb_routed: str | None = Field(
+        default=None,
+        description=(
+            "Path to routed PCB file. If unset, defaults to '<pcb_stem>_routed.kicad_pcb' "
+            "alongside the PCB. Consumed by `kct build` (see _run_step_route)."
+        ),
+    )
     project: str | None = Field(default=None, description="Path to KiCad project file")
 
 
@@ -240,6 +247,14 @@ class ManufacturingRequirements(BaseModel):
     layers: dict[str, int] | None = Field(
         default=None, description="Layer count (preferred, min, max)"
     )
+    stackup: list[str] | None = Field(
+        default=None,
+        description=(
+            "Optional human-readable description of each PCB layer "
+            "(e.g., ['F.Cu (signal)', 'In1.Cu (GND plane)', ...]). "
+            "Captured for documentation/audit; not consumed by the router."
+        ),
+    )
     copper_weight: float | None = Field(
         default=None,
         description="Copper weight in oz/ft^2 (e.g., 1, 2, '2oz', '0.5oz')",
@@ -278,6 +293,32 @@ class ManufacturingRequirements(BaseModel):
                     layers.pop("copper_weight")
         return data
 
+    @model_validator(mode="before")
+    @classmethod
+    def extract_stackup_from_layers(cls, data: Any) -> Any:
+        """Promote ``stackup`` from layers dict to top-level field if nested.
+
+        Boards historically wrote::
+
+            layers:
+              preferred: 4
+              stackup:
+                - "F.Cu (signal)"
+                - "In1.Cu (GND plane)"
+
+        ``layers`` is typed ``dict[str, int]`` so a nested ``stackup`` list
+        produces a Pydantic validation error. Promote it to the top-level
+        ``stackup`` field for backwards compatibility.
+        """
+        if isinstance(data, dict):
+            layers = data.get("layers")
+            if isinstance(layers, dict) and "stackup" in layers:
+                if "stackup" not in data or data["stackup"] is None:
+                    data["stackup"] = layers.pop("stackup")
+                else:
+                    layers.pop("stackup")
+        return data
+
 
 class Compliance(BaseModel):
     """Compliance and certification requirements."""
@@ -309,11 +350,41 @@ class Requirements(BaseModel):
 
 
 class ComponentSuggestion(BaseModel):
-    """Component suggestion with preferences and rationale."""
+    """Component suggestion with preferences and rationale.
+
+    Accepts two equivalent YAML shapes for ergonomic authoring:
+
+    * Full form (preserves rationale/avoid)::
+
+          regulator:
+            preferred: ["LM7805", "TPS562201"]
+            rationale: "Common, well-documented regulators"
+
+    * Shorthand (bare string -> ``preferred: [<string>]``)::
+
+          regulator: "LM7805 5V LDO"
+
+    The shorthand is unwrapped by :meth:`unwrap_string_shorthand` so the
+    canonical model still has a list-of-strings ``preferred`` field.
+    """
 
     preferred: list[str] | None = Field(default=None, description="Preferred part numbers")
     rationale: str | None = Field(default=None, description="Reason for preference")
     avoid: list[str] | None = Field(default=None, description="Parts to avoid")
+
+    @model_validator(mode="before")
+    @classmethod
+    def unwrap_string_shorthand(cls, data: Any) -> Any:
+        """Allow a bare string to stand in for ``{preferred: [<string>]}``.
+
+        This is symmetric with how the loader is permissive about
+        single-element lists elsewhere -- it keeps board authors from
+        having to write the full mapping for the common case of a
+        one-line component note.
+        """
+        if isinstance(data, str):
+            return {"preferred": [data]}
+        return data
 
 
 class BOMSuggestions(BaseModel):

--- a/tests/test_build_route_write_path.py
+++ b/tests/test_build_route_write_path.py
@@ -1,0 +1,397 @@
+"""Regression tests for issue #2782 — silent write-path failure on routed PCB.
+
+Two complementary regressions are exercised here:
+
+1. **Byte-identical write-path failure (issue #2782)** — if the router
+   reports success but the on-disk routed PCB is byte-identical to the
+   unrouted input, the build pipeline must fail loudly rather than ship
+   an unrouted PCB downstream as a routed one.  Covered by
+   :class:`TestRoutePostconditionByteIdentical`.
+
+2. **Spec-driven routed-PCB path (issue #2782 + ProjectArtifacts.pcb_routed)** —
+   when ``project.kct`` declares ``project.artifacts.pcb_routed``, the
+   build pipeline writes to that exact path instead of the historical
+   ``<stem>_routed.kicad_pcb`` sibling.  Covered by
+   :class:`TestResolveRoutedPcbPath`.
+
+3. **Board 06 project.kct schema reconciliation (issue #2782)** — board
+   06's ``project.kct`` was the artefact that surfaced this issue;
+   ``load_spec`` must accept it with zero validation errors.  Covered
+   by :class:`TestBoardProjectKctLoads`.
+
+A separate :class:`TestBoardSpecRoundtrip` test runs every board's
+``project.kct`` through the loader to guard against future schema
+drift on the example boards.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.build_cmd import (
+    BuildContext,
+    _check_route_postcondition,
+    _resolve_routed_pcb_path,
+)
+from kicad_tools.spec.parser import load_spec
+from kicad_tools.spec.schema import (
+    ComponentSuggestion,
+    ProjectArtifacts,
+    Suggestions,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BOARDS_DIR = REPO_ROOT / "boards"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_PCB_TEMPLATE = """\
+(kicad_pcb
+  (version 20240108)
+  (generator {generator})
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "VIN")
+  (net 2 "VOUT")
+  (gr_rect
+    (start 0 0)
+    (end 50 50)
+    (stroke (width 0.15) (type solid))
+    (fill none)
+    (layer "Edge.Cuts")
+    (uuid "edge-uuid")
+  )
+  (footprint "Test:U1"
+    (layer "F.Cu")
+    (at 10 10)
+    (uuid "fp1-uuid")
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "VIN"))
+    (pad "2" smd rect (at 2 0) (size 1 1) (layers "F.Cu") (net 2 "VOUT"))
+  )
+  (footprint "Test:U2"
+    (layer "F.Cu")
+    (at 30 10)
+    (uuid "fp2-uuid")
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "VIN"))
+    (pad "2" smd rect (at 2 0) (size 1 1) (layers "F.Cu") (net 2 "VOUT"))
+  )
+)
+"""
+
+
+def _write_unrouted_pcb(path: Path, generator: str = '"kicad-tools-demo"') -> None:
+    path.write_text(_PCB_TEMPLATE.format(generator=generator))
+
+
+# ---------------------------------------------------------------------------
+# Postcondition: byte-identical input vs output (issue #2782)
+# ---------------------------------------------------------------------------
+
+
+class TestRoutePostconditionByteIdentical:
+    """Routed PCB == unrouted PCB must trigger a loud postcondition failure.
+
+    The route step's success exit + byte-identical output on a board
+    that has multi-pad signal nets is exactly the "silent write-path
+    failure" symptom this issue is named after.  The postcondition
+    must surface this with a non-success ``BuildResult`` so the build
+    pipeline aborts before downstream steps consume the unrouted PCB.
+    """
+
+    def test_byte_identical_files_fail_postcondition(self, tmp_path: Path) -> None:
+        """Identical bytes + multi-pad signal nets => loud failure."""
+        input_pcb = tmp_path / "board.kicad_pcb"
+        routed_pcb = tmp_path / "board_routed.kicad_pcb"
+        _write_unrouted_pcb(input_pcb)
+        # Copy bytes (exact, including any line-ending quirks)
+        routed_pcb.write_bytes(input_pcb.read_bytes())
+
+        result = _check_route_postcondition(input_pcb=input_pcb, routed_pcb=routed_pcb)
+
+        assert result is not None, (
+            "Postcondition must fail when routed PCB is byte-identical to input"
+        )
+        assert result.success is False
+        assert "byte-identical" in result.message
+        assert "#2782" in result.message
+
+    def test_non_identical_routed_with_segments_passes(self, tmp_path: Path) -> None:
+        """Routed PCB with at least one segment is accepted."""
+        input_pcb = tmp_path / "board.kicad_pcb"
+        routed_pcb = tmp_path / "board_routed.kicad_pcb"
+        _write_unrouted_pcb(input_pcb)
+
+        # Build a routed PCB that differs from the input AND contains
+        # one real copper segment.
+        routed_text = input_pcb.read_text().replace(
+            '(generator "kicad-tools-demo")',
+            '(generator "pcbnew")',
+        )
+        # Insert one segment before the final closing paren.
+        routed_text = routed_text.rstrip().rstrip(")") + (
+            "  (segment (start 10 10) (end 12 10) (width 0.25) "
+            '(layer "F.Cu") (net 1) (uuid "seg-1"))\n)\n'
+        )
+        routed_pcb.write_text(routed_text)
+
+        result = _check_route_postcondition(input_pcb=input_pcb, routed_pcb=routed_pcb)
+        # Either None (parser accepted -> segments > 0 -> postcondition
+        # silent) or success=True; the failure path must NOT fire.
+        if result is not None:
+            assert result.success is True, f"Postcondition fired unexpectedly: {result.message}"
+
+    def test_byte_identical_same_path_does_not_fire(self, tmp_path: Path) -> None:
+        """If input and routed paths resolve to the same file, do not fire.
+
+        Some pipelines route in-place (input.kicad_pcb -> input.kicad_pcb).
+        That's a separate failure mode the postcondition should not
+        spuriously flag, since 'byte-identical' is tautological when
+        ``input.resolve() == routed.resolve()``.
+        """
+        pcb = tmp_path / "board.kicad_pcb"
+        _write_unrouted_pcb(pcb)
+
+        result = _check_route_postcondition(input_pcb=pcb, routed_pcb=pcb)
+        # The byte-identical branch must early-out on same-path; the
+        # zero-segments branch may still fire (it does here), but the
+        # message must NOT reference issue #2782's wording.
+        if result is not None:
+            assert "byte-identical" not in result.message
+
+    def test_no_signal_nets_does_not_fire(self, tmp_path: Path) -> None:
+        """A PCB with no multi-pad signal nets => postcondition stays silent."""
+        # PCB with single-pad-per-net (no routable signal nets).
+        pcb_text = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "kicad-tools-demo")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "VCC")
+  (gr_rect
+    (start 0 0)
+    (end 10 10)
+    (stroke (width 0.15) (type solid))
+    (fill none)
+    (layer "Edge.Cuts")
+    (uuid "edge")
+  )
+  (footprint "Test:U1"
+    (layer "F.Cu")
+    (at 1 1)
+    (uuid "fp1")
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "VCC"))
+  )
+)
+"""
+        input_pcb = tmp_path / "board.kicad_pcb"
+        routed_pcb = tmp_path / "board_routed.kicad_pcb"
+        input_pcb.write_text(pcb_text)
+        routed_pcb.write_bytes(input_pcb.read_bytes())
+
+        result = _check_route_postcondition(input_pcb=input_pcb, routed_pcb=routed_pcb)
+        # No routable signal nets => zero segments is legitimate, and
+        # byte-identical is also legitimate (router had nothing to do).
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Spec-driven routed-PCB path (ProjectArtifacts.pcb_routed)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRoutedPcbPath:
+    """``_resolve_routed_pcb_path`` honours the spec when ``pcb_routed`` is set."""
+
+    def test_uses_spec_pcb_routed_when_declared(self, tmp_path: Path) -> None:
+        """``spec.project.artifacts.pcb_routed`` overrides the default sibling path."""
+        from kicad_tools.spec.schema import ProjectMetadata, ProjectSpec
+
+        pcb_file = tmp_path / "input" / "board.kicad_pcb"
+        pcb_file.parent.mkdir(parents=True)
+        pcb_file.touch()
+
+        spec = ProjectSpec(
+            project=ProjectMetadata(
+                name="Test",
+                artifacts=ProjectArtifacts(
+                    pcb="input/board.kicad_pcb",
+                    pcb_routed="output/custom_routed.kicad_pcb",
+                ),
+            ),
+        )
+
+        ctx = BuildContext(
+            project_dir=tmp_path,
+            spec_file=None,
+            spec=spec,
+            pcb_file=pcb_file,
+            output_dir=None,
+        )
+        resolved = _resolve_routed_pcb_path(ctx)
+        assert resolved == tmp_path / "output" / "custom_routed.kicad_pcb"
+
+    def test_falls_back_to_output_dir_when_no_spec(self, tmp_path: Path) -> None:
+        """No spec / no ``pcb_routed`` field => use ``--output`` dir if provided."""
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.touch()
+        output_dir = tmp_path / "custom-output"
+
+        ctx = BuildContext(
+            project_dir=tmp_path,
+            spec_file=None,
+            spec=None,
+            pcb_file=pcb_file,
+            output_dir=output_dir,
+        )
+        resolved = _resolve_routed_pcb_path(ctx)
+        assert resolved == output_dir / "board_routed.kicad_pcb"
+
+    def test_falls_back_to_sibling_path_by_default(self, tmp_path: Path) -> None:
+        """No spec / no output dir => use historical sibling path."""
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.touch()
+
+        ctx = BuildContext(
+            project_dir=tmp_path,
+            spec_file=None,
+            spec=None,
+            pcb_file=pcb_file,
+            output_dir=None,
+        )
+        resolved = _resolve_routed_pcb_path(ctx)
+        assert resolved == tmp_path / "board_routed.kicad_pcb"
+
+    def test_absolute_pcb_routed_is_respected(self, tmp_path: Path) -> None:
+        """Absolute ``pcb_routed`` paths are used verbatim."""
+        from kicad_tools.spec.schema import ProjectMetadata, ProjectSpec
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.touch()
+        abs_dest = (tmp_path / "abs-output" / "board_routed.kicad_pcb").resolve()
+
+        spec = ProjectSpec(
+            project=ProjectMetadata(
+                name="Test",
+                artifacts=ProjectArtifacts(
+                    pcb="board.kicad_pcb",
+                    pcb_routed=str(abs_dest),
+                ),
+            ),
+        )
+        ctx = BuildContext(
+            project_dir=tmp_path,
+            spec_file=None,
+            spec=spec,
+            pcb_file=pcb_file,
+            output_dir=tmp_path / "ignored",
+        )
+        assert _resolve_routed_pcb_path(ctx) == abs_dest
+
+
+# ---------------------------------------------------------------------------
+# Schema reconciliation
+# ---------------------------------------------------------------------------
+
+
+class TestBoardProjectKctLoads:
+    """Board 06's project.kct must load with zero Pydantic validation errors.
+
+    Prior to issue #2782's resolution, ``load_spec`` raised 9 errors:
+    1 for ``requirements.manufacturing.layers.stackup`` (list inside
+    ``dict[str, int]``) and 8 for ``suggestions.components.<name>``
+    (bare string instead of ``ComponentSuggestion``).  The schema now
+    accepts both shapes via top-level promotion and string-shorthand
+    unwrapping.
+    """
+
+    def test_board_06_project_kct_loads_clean(self) -> None:
+        """No validation errors on the curated board 06 project spec."""
+        path = BOARDS_DIR / "06-diffpair-test" / "project.kct"
+        if not path.exists():
+            pytest.skip(f"Board 06 spec not present at {path}")
+
+        # If this raises ValidationError, pytest will surface the
+        # individual field errors verbatim -- exactly what we want.
+        spec = load_spec(path)
+
+        # Sanity-check the fields that drove the original failure.
+        assert spec.requirements is not None
+        assert spec.requirements.manufacturing is not None
+        assert spec.requirements.manufacturing.layers == {"preferred": 4}
+        # Stackup was promoted from layers.stackup to top-level stackup.
+        assert spec.requirements.manufacturing.stackup is not None
+        assert len(spec.requirements.manufacturing.stackup) == 4
+        assert spec.suggestions is not None
+        assert spec.suggestions.components is not None
+        # The bare-string shorthand is normalised to preferred=[<string>].
+        first = next(iter(spec.suggestions.components.values()))
+        assert first.preferred is not None
+        assert len(first.preferred) >= 1
+
+    def test_pcb_routed_is_picked_up_from_spec(self) -> None:
+        """``ProjectArtifacts.pcb_routed`` is a real field, not silently ignored."""
+        path = BOARDS_DIR / "06-diffpair-test" / "project.kct"
+        if not path.exists():
+            pytest.skip(f"Board 06 spec not present at {path}")
+
+        spec = load_spec(path)
+        assert spec.project.artifacts is not None
+        assert spec.project.artifacts.pcb_routed == ("output/diffpair_test_routed.kicad_pcb")
+
+
+class TestComponentSuggestionShorthand:
+    """``ComponentSuggestion`` accepts bare strings via shorthand."""
+
+    def test_bare_string_unwrapped_to_preferred(self) -> None:
+        suggestions = Suggestions.model_validate({"components": {"regulator": "LM7805 5V LDO"}})
+        assert suggestions.components is not None
+        regulator = suggestions.components["regulator"]
+        assert regulator.preferred == ["LM7805 5V LDO"]
+        assert regulator.rationale is None
+        assert regulator.avoid is None
+
+    def test_full_dict_form_still_works(self) -> None:
+        suggestion = ComponentSuggestion.model_validate(
+            {
+                "preferred": ["LM7805", "TPS562201"],
+                "rationale": "Common, well-documented",
+            }
+        )
+        assert suggestion.preferred == ["LM7805", "TPS562201"]
+        assert suggestion.rationale == "Common, well-documented"
+
+
+class TestBoardSpecRoundtrip:
+    """Every board's ``project.kct`` must load with zero errors.
+
+    Guards against future schema drift on the example boards.  This is
+    parametrised over the directories under ``boards/`` so adding a
+    new board automatically extends coverage.
+    """
+
+    @pytest.mark.parametrize(
+        "board_dir",
+        sorted(p.name for p in BOARDS_DIR.glob("[0-9]*") if (p / "project.kct").exists()),
+    )
+    def test_board_spec_loads(self, board_dir: str) -> None:
+        path = BOARDS_DIR / board_dir / "project.kct"
+        spec = load_spec(path)
+        # Minimal sanity: project name is required by the schema.
+        assert spec.project.name

--- a/tests/test_build_zones_step.py
+++ b/tests/test_build_zones_step.py
@@ -581,12 +581,17 @@ class TestRouteStepPostcondition:
         Returns (input_pcb, routed_pcb) where:
         - input_pcb has 3 multi-pad signal nets and zero zones
           (so the postcondition expects segments to be produced).
-        - routed_pcb is byte-identical (zero segments, zero vias),
-          simulating the silent-success path.
+        - routed_pcb has zero segments and zero vias, but a different
+          generator string so it is **not** byte-identical to the input
+          (the byte-identical check from issue #2782 is exercised
+          separately in :class:`TestRouteStepWritePath`).
         """
         # Minimal PCB with two footprints sharing 3 nets via pads.
         # Each net has 2 pads => 3 multi-pad signal nets to route.
-        pcb_text = """\
+        # The two files share the same structure but differ in the
+        # generator string -- this models a router that processed the
+        # PCB (rewrote it) but produced zero copper segments.
+        pcb_text_input = """\
 (kicad_pcb
   (version 20240108)
   (generator "kicad")
@@ -626,10 +631,13 @@ class TestRouteStepPostcondition:
   )
 )
 """
+        pcb_text_routed = pcb_text_input.replace(
+            '(generator "kicad")', '(generator "kicad-tools-router")'
+        )
         input_pcb = tmp_path / "input.kicad_pcb"
-        input_pcb.write_text(pcb_text)
+        input_pcb.write_text(pcb_text_input)
         routed_pcb = tmp_path / "input_routed.kicad_pcb"
-        routed_pcb.write_text(pcb_text)  # Same content == zero segments produced.
+        routed_pcb.write_text(pcb_text_routed)
         return input_pcb, routed_pcb
 
     def test_postcondition_fails_when_zero_segments_for_routable_nets(self, tmp_path: Path):


### PR DESCRIPTION
Closes #2782

## Summary

The curator's investigation on #2782 found the headline "byte-identical to unrouted" symptom was non-reproducible at HEAD (`91a774fc`), but surfaced three real underlying defects this PR addresses:

1. **9 Pydantic validation errors on board 06's `project.kct`** — `requirements.manufacturing.layers.stackup` (list inside `dict[str, int]`) and 8 `suggestions.components.<name>` entries (bare strings instead of `ComponentSuggestion`). These caused `load_spec` to raise and `_find_artifacts` to fall back to directory globbing -- correct by accident, brittle by design.

2. **`artifacts.pcb_routed` declared but ignored** — `ProjectArtifacts` only had `schematic`/`pcb`/`project`, so Pydantic silently dropped the `pcb_routed` field that board 06 declared.

3. **No defense-in-depth check for byte-identical input/output** — if a future regression silently wrote the unrouted PCB to the routed path (or skipped writing entirely), the build would ship the unrouted artifact downstream without alarm.

## Changes

### `src/kicad_tools/spec/schema.py`
- Add `ProjectArtifacts.pcb_routed: str | None`.
- Add `ManufacturingRequirements.stackup: list[str] | None` and a `model_validator(mode='before')` that promotes `requirements.manufacturing.layers.stackup` to the top-level field (symmetric with the existing `copper_weight` promotion).
- Add a `model_validator(mode='before')` on `ComponentSuggestion` that unwraps a bare-string shorthand into `{preferred: [<string>]}`.

### `src/kicad_tools/cli/build_cmd.py`
- Extract `_resolve_routed_pcb_path(ctx)` helper. Resolution order: `spec.project.artifacts.pcb_routed` > `--output` > sibling path.
- Extend `_check_route_postcondition` with a byte-identical guard that fails loudly when `kct route` exits 0 but the on-disk routed PCB is byte-identical to the unrouted input (issue #2782 silent write-path failure mode). Same-path (in-place routing) is excluded.

### `tests/test_build_route_write_path.py` (new)
20 regression tests covering:
- Byte-identical postcondition (`TestRoutePostconditionByteIdentical`, 4 tests)
- `_resolve_routed_pcb_path` resolution order (`TestResolveRoutedPcbPath`, 4 tests)
- Board 06 spec loads cleanly + `pcb_routed` field is real (`TestBoardProjectKctLoads`, 2 tests)
- `ComponentSuggestion` shorthand (`TestComponentSuggestionShorthand`, 2 tests)
- Parametrised round-trip over every board's `project.kct` (`TestBoardSpecRoundtrip`, 8 tests — guards against future schema drift)

### `tests/test_build_zones_step.py`
Update the existing empty-route postcondition fixture so input/output differ by generator string (the test previously relied on byte-identical content, which now trips the new #2782 check before the #2740 check fires).

## Verification

- `kct build boards/06-diffpair-test --mfr jlcpcb --force` now loads the spec cleanly and emits a routed PCB with **118 segments + 118 vias** (md5 differs from the unrouted file, 65028 B vs 31476 B).
- `uv run pytest tests/test_build_route_write_path.py tests/test_build_zones_step.py tests/test_spec.py` -> **250 passed**.

## Test Plan

- [x] `uv run pytest tests/test_build_route_write_path.py` — 20/20 pass
- [x] `uv run pytest tests/test_build_zones_step.py` — 29/29 pass (one fixture updated)
- [x] `uv run pytest tests/test_spec.py tests/test_schema.py` — 211/211 pass
- [x] `uv run kct build boards/06-diffpair-test --mfr jlcpcb --force` — routes 118 segments
- [x] `uv run ruff check src/kicad_tools/spec/schema.py src/kicad_tools/cli/build_cmd.py tests/test_build_route_write_path.py tests/test_build_zones_step.py` — clean
- [x] `uv run ruff format --check ...` — clean

## Notes for reviewer

- Schema changes are strictly additive (`pcb_routed`, `stackup` as new optional fields; `ComponentSuggestion` accepts a superset of prior shapes), so no existing board's `project.kct` should regress. The parametrised `TestBoardSpecRoundtrip` confirms all 8 example boards load cleanly.
- The byte-identical postcondition uses `Path.resolve()` to exclude in-place routing pipelines from triggering false positives.
- One pre-existing test failure (`test_route_exit_code_3_is_failure` in `tests/test_build_cmd_errors.py`) is unrelated to this PR — it fails on `main` at `91a774fc` as well.