### PR TITLE
fix(rotation): use CCW-positive forward transform in edge clearance and router pad builder

### DIFF
--- a/src/kicad_tools/mcp/tools/routing.py
+++ b/src/kicad_tools/mcp/tools/routing.py
@@ -627,7 +627,8 @@ def _build_pads_for_net(pcb: PCB, net_number: int, net_name: str) -> list:
             continue
 
         fp_x, fp_y = fp.position
-        rot_rad = math.radians(-fp.rotation)
+        # KiCad rotation is CCW-positive; standard 2D rotation matrix applies directly
+        rot_rad = math.radians(fp.rotation)
         cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
 
         for pad in fp.pads:

--- a/src/kicad_tools/validate/rules/edge.py
+++ b/src/kicad_tools/validate/rules/edge.py
@@ -192,8 +192,8 @@ class EdgeClearanceRule(DRCRule):
 
         for footprint in pcb.footprints:
             fp_x, fp_y = footprint.position
-            # KiCad uses clockwise-positive rotation, negate for standard math
-            fp_rotation = math.radians(-footprint.rotation)
+            # KiCad rotation is CCW-positive; standard 2D rotation matrix applies directly
+            fp_rotation = math.radians(footprint.rotation)
             cos_rot = math.cos(fp_rotation)
             sin_rot = math.sin(fp_rotation)
 

--- a/tests/test_edge_clearance_epsilon.py
+++ b/tests/test_edge_clearance_epsilon.py
@@ -12,8 +12,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from kicad_tools.validate.rules.edge import EdgeClearanceRule, _CLEARANCE_EPSILON_MM
-
+from kicad_tools.validate.rules.edge import _CLEARANCE_EPSILON_MM, EdgeClearanceRule
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -356,6 +355,180 @@ class TestCheckZonesEpsilon:
             results,
         )
         assert len(results.errors) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: _check_pads forward-rotation sign convention (issue #2788)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPadsRotationSignConvention:
+    """Verify that _check_pads applies the canonical CCW-positive rotation.
+
+    Regression coverage for issue #2788: prior code computed
+    ``math.radians(-footprint.rotation)`` which mirrored the pad across the
+    footprint origin for 90°/270° rotations and reflected it about the
+    diagonal for 45°.  Pure 0°/180° tests pass under BOTH sign conventions
+    because cos is even and sin*y_local terms vanish when y_local==0,
+    so the parametrization MUST include {45°, 90°, 270°} to catch the bug.
+
+    The fixture uses ``board_origin = (0, 0)`` to isolate rotation from
+    any origin-offset asymmetries, and the footprint is placed in the
+    interior of the board with a pad offset chosen so the correct and
+    buggy positions differ.
+    """
+
+    @staticmethod
+    def _footprint_with_offset_pad(
+        fp_position: tuple[float, float],
+        rotation: float,
+        pad_local: tuple[float, float],
+        pad_size: float = 0.4,
+    ) -> SimpleNamespace:
+        pad = SimpleNamespace(
+            position=pad_local,
+            size=(pad_size, pad_size),
+            type="smd",
+            number="1",
+        )
+        return SimpleNamespace(
+            position=fp_position,
+            rotation=rotation,
+            layer="F.Cu",
+            reference="U1",
+            pads=[pad],
+        )
+
+    @staticmethod
+    def _expected_pad_position(
+        fp_position: tuple[float, float],
+        rotation_deg: float,
+        pad_local: tuple[float, float],
+    ) -> tuple[float, float]:
+        """Canonical forward transform (CCW-positive, matches schema/pcb.py)."""
+        import math
+
+        rot_rad = math.radians(rotation_deg)
+        cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
+        px, py = pad_local
+        return (
+            fp_position[0] + px * cos_r - py * sin_r,
+            fp_position[1] + px * sin_r + py * cos_r,
+        )
+
+    def test_negative_control_buggy_vs_canonical_differ(self):
+        """Sanity check: the fixture coordinates DO differ between the two
+        sign conventions at each chosen rotation, so the parametrized
+        tests below can actually distinguish a correct fix from the bug.
+        """
+        import math
+
+        pad_local = (3.0, 1.0)
+        fp_pos = (10.0, 15.0)
+
+        for rot in (45.0, 90.0, 270.0):
+            rot_rad = math.radians(rot)
+            cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
+            correct = (
+                fp_pos[0] + pad_local[0] * cos_r - pad_local[1] * sin_r,
+                fp_pos[1] + pad_local[0] * sin_r + pad_local[1] * cos_r,
+            )
+            # Buggy (negated angle) → cos same, sin flipped sign
+            buggy = (
+                fp_pos[0] + pad_local[0] * cos_r + pad_local[1] * sin_r,
+                fp_pos[1] - pad_local[0] * sin_r + pad_local[1] * cos_r,
+            )
+            # At least one coordinate must differ by a meaningful amount
+            dx = abs(correct[0] - buggy[0])
+            dy = abs(correct[1] - buggy[1])
+            assert max(dx, dy) > 0.5, (
+                f"rotation={rot}°: fixture too symmetric — correct={correct}, "
+                f"buggy={buggy}; choose pad_local with nonzero, distinct "
+                f"x/y components"
+            )
+
+    # Per-rotation fixtures: footprint x-position chosen so that, under
+    # the CANONICAL CCW-positive transform, the pad lands close enough
+    # to the left board edge (x=0) to violate (or not violate) the
+    # 0.3mm copper-to-edge minimum, while under the BUGGY negated
+    # rotation the pad lands somewhere else with the OPPOSITE violation
+    # status.  This makes the violation *count* a clean discriminator
+    # between the two sign conventions.
+    #
+    # pad_local = (3.0, 1.0) — nonzero, distinct x/y so 0°/180°
+    # symmetries do not paper over the bug.
+    #
+    # Pre-computed pad positions (see negative-control test below for
+    # proof that canonical and buggy diverge at these rotations):
+    #   rot=45°,  fp_x=-1.9: canonical pad_x ~ -0.486 (violates),
+    #                        buggy     pad_x ~  0.928 (clears)
+    #   rot=90°,  fp_x= 0.6: canonical pad_x = -0.4   (violates),
+    #                        buggy     pad_x =  1.6   (clears)
+    #   rot=270°, fp_x= 0.6: canonical pad_x =  1.6   (clears),
+    #                        buggy     pad_x = -0.4   (violates)
+    @pytest.mark.parametrize(
+        "rotation, fp_x, expect_canonical_violation",
+        [
+            (45.0,  -1.9, True),
+            (90.0,   0.6, True),
+            (270.0,  0.6, False),
+        ],
+    )
+    def test_violation_count_matches_canonical_convention(
+        self, rotation, fp_x, expect_canonical_violation
+    ):
+        """Drive ``_check_pads`` with per-rotation fixtures where the
+        canonical (CCW-positive) and buggy (negated) sign conventions
+        disagree on whether the pad violates edge clearance.
+
+        Under the bug, two of these three parametrized cases fail
+        (violation count does not match canonical expectation).  Under
+        the correct fix, all three pass.
+        """
+        min_clearance = 0.3
+        pad_local = (3.0, 1.0)
+        fp_pos = (fp_x, 15.0)
+
+        fp = self._footprint_with_offset_pad(fp_pos, rotation, pad_local)
+        expected_pad = self._expected_pad_position(fp_pos, rotation, pad_local)
+
+        rule = EdgeClearanceRule()
+        from kicad_tools.validate.violations import DRCResults
+        results = DRCResults()
+        rule._check_pads(
+            _make_pcb(footprints=[fp]),
+            _outline_segments(),
+            _design_rules(copper_edge=min_clearance),
+            results,
+        )
+
+        if expect_canonical_violation:
+            assert len(results.errors) >= 1, (
+                f"rotation={rotation} fp_x={fp_x}: expected canonical "
+                f"violation at pad={expected_pad}, but rule reported "
+                f"{len(results.errors)} errors -- likely the rule still "
+                f"uses the buggy negated rotation."
+            )
+            # The reported violation location must match the canonical
+            # pad world position to 1e-9.
+            v = results.errors[0]
+            loc_x, loc_y = v.location
+            assert abs(loc_x - expected_pad[0]) < 1e-9, (
+                f"rotation={rotation}: violation x={loc_x} differs "
+                f"from canonical {expected_pad[0]}."
+            )
+            assert abs(loc_y - expected_pad[1]) < 1e-9, (
+                f"rotation={rotation}: violation y={loc_y} differs "
+                f"from canonical {expected_pad[1]}."
+            )
+        else:
+            assert len(results.errors) == 0, (
+                f"rotation={rotation} fp_x={fp_x}: canonical pad at "
+                f"{expected_pad} is well inside the board (no violation "
+                f"expected), but rule reported {len(results.errors)} "
+                f"errors -- likely the rule still uses the buggy "
+                f"negated rotation, placing the pad off-board."
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_routing.py
+++ b/tests/test_mcp_routing.py
@@ -741,3 +741,134 @@ class TestRouteAutoCommandErrorHandling:
         assert "Error:" in captured.err
         # Without verbose, no traceback should appear
         assert "Traceback" not in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Tests: _build_pads_for_net forward-rotation sign convention (issue #2788)
+# ---------------------------------------------------------------------------
+
+
+def _rotated_pcb_text(rotation_deg: float) -> str:
+    """Build a minimal 1-footprint, 1-net PCB with a known pad offset and
+    rotation.  The pad's local position has nonzero, distinct x/y so the
+    canonical and buggy (negated) rotation produce DIFFERENT world
+    coordinates at 45°/90°/270° — pure 0°/180° fixtures pass under both
+    sign conventions because cos is even and sin terms vanish, so this
+    fixture is intentionally asymmetric.
+
+    Board origin is implicitly (0, 0) (no setup block), isolating
+    rotation from origin-offset effects.
+    """
+    return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "SIG1")
+
+  (gr_line (start 0 0) (end 50 0) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 50 0) (end 50 40) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 50 40) (end 0 40) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 0 40) (end 0 0) (layer "Edge.Cuts") (stroke (width 0.1)))
+
+  (footprint "Custom"
+    (layer "F.Cu")
+    (at 20 15 {rotation_deg})
+    (attr smd)
+    (property "Reference" "U1")
+    (property "Value" "ASYM")
+    (pad "1" smd rect (at 3.0 1.0) (size 0.6 0.6) (layers "F.Cu") (net 1 "SIG1"))
+  )
+)
+"""
+
+
+class TestBuildPadsForNetRotationSignConvention:
+    """Verify that _build_pads_for_net applies the canonical CCW-positive
+    rotation when projecting pad-local offsets into world coordinates.
+
+    Regression coverage for issue #2788: prior code computed
+    ``math.radians(-fp.rotation)`` which mirrored pad world positions for
+    rotated footprints, feeding the autorouter wrong anchors and causing
+    unroutable nets / off-pad escape attempts.
+
+    Pure 0°/180° rotations pass under BOTH sign conventions (cos is even
+    and sin*y_local terms cancel when chosen symmetrically), so the
+    parametrization MUST include {45°, 90°, 270°} to catch the bug.
+    Agreement is asserted against the canonical reference implementation
+    in ``PCB.get_pad_position`` to within 1e-9 mm.
+    """
+
+    @pytest.mark.parametrize("rotation", [45.0, 90.0, 270.0])
+    def test_pad_world_position_matches_get_pad_position(
+        self, tmp_path: Path, rotation: float
+    ) -> None:
+        from kicad_tools.mcp.tools.routing import _build_pads_for_net
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_file = tmp_path / "rotated.kicad_pcb"
+        pcb_file.write_text(_rotated_pcb_text(rotation))
+
+        pcb = PCB.load(str(pcb_file))
+
+        # Canonical reference: PCB.get_pad_position uses the correct,
+        # un-negated forward rotation (schema/pcb.py:3628).
+        expected = pcb.get_pad_position("U1", "1")
+        assert expected is not None, (
+            f"Reference get_pad_position returned None for rotation={rotation}°"
+        )
+
+        pads = _build_pads_for_net(pcb, net_number=1, net_name="SIG1")
+        assert len(pads) == 1, (
+            f"rotation={rotation}°: expected exactly 1 pad on SIG1, got "
+            f"{len(pads)}"
+        )
+
+        actual = (pads[0].x, pads[0].y)
+        assert abs(actual[0] - expected[0]) < 1e-9, (
+            f"rotation={rotation}°: pad world x={actual[0]} differs from "
+            f"canonical {expected[0]} — sign convention regression."
+        )
+        assert abs(actual[1] - expected[1]) < 1e-9, (
+            f"rotation={rotation}°: pad world y={actual[1]} differs from "
+            f"canonical {expected[1]} — sign convention regression."
+        )
+
+    def test_negative_control_buggy_vs_canonical_differ(self) -> None:
+        """Sanity check: at each chosen rotation the canonical (CCW) and
+        buggy (negated) transforms produce noticeably different world
+        positions, so the parametrized test above can actually
+        distinguish a correct fix from the bug.
+
+        (If the fixture coordinates were symmetric — e.g., pad_local =
+        (0, 0) or (x, 0) at 180° — both sign conventions would yield the
+        same result and the test would silently pass against buggy code.)
+        """
+        import math
+
+        fp_pos = (20.0, 15.0)
+        pad_local = (3.0, 1.0)
+        for rot in (45.0, 90.0, 270.0):
+            rot_rad = math.radians(rot)
+            cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
+            canonical = (
+                fp_pos[0] + pad_local[0] * cos_r - pad_local[1] * sin_r,
+                fp_pos[1] + pad_local[0] * sin_r + pad_local[1] * cos_r,
+            )
+            # Buggy negated-rotation: cos same, sin flipped sign.
+            buggy = (
+                fp_pos[0] + pad_local[0] * cos_r + pad_local[1] * sin_r,
+                fp_pos[1] - pad_local[0] * sin_r + pad_local[1] * cos_r,
+            )
+            dx = abs(canonical[0] - buggy[0])
+            dy = abs(canonical[1] - buggy[1])
+            assert max(dx, dy) > 0.5, (
+                f"rotation={rot}°: fixture too symmetric — canonical="
+                f"{canonical}, buggy={buggy}; fixture pad_local must have "
+                f"nonzero, distinct x/y components."
+            )


### PR DESCRIPTION
Closes #2788

## Summary

- Fix two forward (local->world) pad-position transforms that were negating the rotation angle, mirroring pad world positions for rotated footprints. Same bug pattern as #2778.
- `src/kicad_tools/validate/rules/edge.py:196` (`EdgeClearanceRule._check_pads`): change `math.radians(-footprint.rotation)` to `math.radians(footprint.rotation)`; replace misleading "KiCad uses clockwise-positive rotation" comment with the canonical CCW-positive statement.
- `src/kicad_tools/mcp/tools/routing.py:630` (`_build_pads_for_net`): change `math.radians(-fp.rotation)` to `math.radians(fp.rotation)`; add canonical-convention comment.

## Runtime impact

Before the fix:
- Edge clearance for pads on rotated footprints was computed against mirrored locations, producing false-positive/false-negative DRC violations near board edges.
- The autorouter was fed wrong world anchors for pads on rotated footprints, causing unroutable nets, off-pad escape attempts, and DRC drift.

Canonical reference (unchanged, used as the test oracle): `src/kicad_tools/schema/pcb.py:3628` (`PCB.get_pad_position`) and the documented convention at `src/kicad_tools/router/io.py:2662-2667` ("positive = counter-clockwise").

## Tests

New parametrized rotation tests at {45 deg, 90 deg, 270 deg} -- the 0/180 deg cases were intentionally omitted because `cos` is even and `sin*y_local` terms vanish there, so both sign conventions yield identical results (per #2778 lessons).

- `tests/test_edge_clearance_epsilon.py::TestCheckPadsRotationSignConvention`:
  - Per-rotation fixtures chosen so the canonical and buggy sign conventions disagree on violation count -- a buggy implementation reports the wrong number of violations.
  - Negative-control test asserting the canonical and buggy transforms actually diverge at the chosen rotations (so the parametrized tests can distinguish a correct fix from the bug).
- `tests/test_mcp_routing.py::TestBuildPadsForNetRotationSignConvention`:
  - Loads a minimal one-footprint, one-net `.kicad_pcb` with a rotated footprint and asserts `_build_pads_for_net` agrees with `PCB.get_pad_position` to 1e-9 mm.
  - Negative-control test as above.

All fixtures use `board_origin = (0, 0)` to isolate rotation from origin-offset asymmetries.

## Verification (test plan)

- [x] All 6 new bug-detecting tests fail against the pre-fix code (verified by reverting both one-character source fixes via `git stash` and re-running) and pass against the post-fix code.
- [x] `pytest tests/test_edge_clearance_epsilon.py tests/test_mcp_routing.py tests/test_validate.py -v` -- 145 passed, 5 skipped.
- [x] `ruff check` clean on touched files.
- [x] `mypy` on touched files: no new errors (pre-existing errors in `routing.py` at lines 353/535 are unrelated to the one-character fix at line 631).

## Scope

This PR is narrowly scoped to the two sites confirmed by Curator in #2788. The broader audit of 7 more suspect sites is filed as #2789 and is intentionally NOT addressed here.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>