### PR TITLE
fix(rotation): drop negated angle at 7 remaining forward local->world sites (closes #2789)

### DIFF
--- a/src/kicad_tools/cli/placement_cmd.py
+++ b/src/kicad_tools/cli/placement_cmd.py
@@ -940,7 +940,10 @@ def _estimate_routability(pcb_path: Path, quiet: bool = False) -> tuple[float, i
                 ref = fp.reference
                 cx, cy = fp.position
                 rotation = fp.rotation
-                rot_rad = math.radians(-rotation)
+                # NOTE: positive sign matches PCB.get_pad_position (the
+                # canonical local->world transform used throughout the
+                # codebase).  KiCad rotation is positive counter-clockwise.
+                rot_rad = math.radians(rotation)
                 cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
 
                 pads = []

--- a/src/kicad_tools/mcp/tools/routing.py
+++ b/src/kicad_tools/mcp/tools/routing.py
@@ -271,7 +271,11 @@ def route_net(
 
         fp_x, fp_y = fp.position
         rotation = fp.rotation
-        rot_rad = math.radians(-rotation)
+        # NOTE: positive sign matches PCB.get_pad_position (the canonical
+        # local->world transform used throughout the codebase).  KiCad
+        # stores rotation in degrees, positive = counter-clockwise, and
+        # the standard 2D rotation matrix applies directly (no negation).
+        rot_rad = math.radians(rotation)
         cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
 
         for pad in fp.pads:
@@ -590,7 +594,11 @@ def _build_pad_positions(pcb: PCB) -> dict[int, list[tuple[float, float]]]:
 
         fp_x, fp_y = fp.position
         rotation = fp.rotation
-        rot_rad = math.radians(-rotation)
+        # NOTE: positive sign matches PCB.get_pad_position (the canonical
+        # local->world transform used throughout the codebase).  KiCad
+        # stores rotation in degrees, positive = counter-clockwise, and
+        # the standard 2D rotation matrix applies directly (no negation).
+        rot_rad = math.radians(rotation)
         cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
 
         for pad in fp.pads:

--- a/src/kicad_tools/optim/place_route.py
+++ b/src/kicad_tools/optim/place_route.py
@@ -299,8 +299,10 @@ class PlaceRouteOptimizer:
             cx, cy = fp.position
             rotation = fp.rotation
 
-            # Transform pad positions
-            rot_rad = math.radians(-rotation)  # KiCad uses clockwise
+            # Transform pad positions.  KiCad rotation is positive
+            # counter-clockwise; the standard 2D rotation matrix applies
+            # directly (no negation).  Matches PCB.get_pad_position.
+            rot_rad = math.radians(rotation)
             cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
 
             pads = []

--- a/src/kicad_tools/reasoning/state.py
+++ b/src/kicad_tools/reasoning/state.py
@@ -433,7 +433,11 @@ class PCBState:
         pads: list[PadState] = []
         import math
 
-        rot_rad = math.radians(-rotation)
+        # NOTE: positive sign matches PCB.get_pad_position (the canonical
+        # local->world transform used throughout the codebase).  KiCad
+        # stores rotation in degrees, positive = counter-clockwise; the
+        # standard 2D rotation matrix applies directly (no negation).
+        rot_rad = math.radians(rotation)
         cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
 
         for pad_node in fp_node.find_all("pad"):

--- a/src/kicad_tools/router/adaptive.py
+++ b/src/kicad_tools/router/adaptive.py
@@ -177,8 +177,10 @@ class AdaptiveAutorouter:
         cx, cy = comp["x"], comp["y"]
         rotation = comp.get("rotation", 0)
 
-        # Transform pad positions
-        rot_rad = math.radians(-rotation)  # KiCad uses clockwise
+        # Transform pad positions.  KiCad rotation is positive
+        # counter-clockwise; the standard 2D rotation matrix applies
+        # directly (no negation).  Matches PCB.get_pad_position.
+        rot_rad = math.radians(rotation)
         cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
 
         pads: list[dict] = []

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -2239,9 +2239,12 @@ def route_pcb(
         cx, cy = comp["x"], comp["y"]
         rotation = comp.get("rotation", 0)
 
-        # Transform pad positions based on component placement
-        # KiCad uses CLOCKWISE rotation (negative angle in standard math)
-        rot_rad = math.radians(-rotation)
+        # Transform pad positions based on component placement.
+        # KiCad stores rotation in degrees, positive = counter-clockwise;
+        # the standard 2D rotation matrix applies directly (no negation).
+        # See PCB.get_pad_position (schema/pcb.py) and the canonical
+        # implementation later in this file (~line 2661) for reference.
+        rot_rad = math.radians(rotation)
         cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
 
         pads: list[dict] = []

--- a/tests/test_rotation_convention_audit.py
+++ b/tests/test_rotation_convention_audit.py
@@ -1,0 +1,663 @@
+"""Cross-subsystem audit tests for the local->world rotation sign convention.
+
+Regression coverage for issue #2789 (follow-up to #2778 and #2788).
+
+Seven distinct call sites across the codebase computed the forward
+local->world pad transform with a *negated* angle:
+
+    rot_rad = math.radians(-fp.rotation)
+    rx = px * cos(rot_rad) - py * sin(rot_rad)
+    ry = px * sin(rot_rad) + py * cos(rot_rad)
+
+The canonical KiCad convention (documented at ``src/kicad_tools/router/io.py``
+lines 2661-2667 and implemented at ``src/kicad_tools/schema/pcb.py:3628``)
+is that rotation is positive counter-clockwise and the standard 2D
+rotation matrix applies *directly* with no negation.  Using the negated
+angle mirrors the pad about the footprint y-axis, which under 90° and
+270° rotations sends pads to the wrong half of the board.
+
+Pure 0°/180° rotations pass under BOTH sign conventions (cos is even,
+and the sin*y_local terms cancel symmetrically), so these tests MUST
+exercise {45°, 90°, 270°} to discriminate the bug from a correct fix.
+Each test includes a negative-control assertion that the chosen fixture
+coordinates actually differ between the two conventions at those
+rotations — otherwise the test would silently pass against buggy code.
+
+Affected sites covered by this module (one test class each):
+
+    1. ``mcp.tools.routing.route_net`` (line 274)
+    2. ``mcp.tools.routing._build_pad_positions`` (line 593)
+    3. ``cli.placement_cmd._estimate_routability`` (line 943)
+    4. ``reasoning.state.ComponentState._parse_*`` (lines 436, 485-486)
+    5. ``router.io.route_pcb`` (line 2244)
+    6. ``router.adaptive.AdaptiveAutorouter._add_component_to_router`` (line 181)
+    7. ``optim.place_route.PlaceRouteOptimizer._load_components_into_router`` (line 303)
+
+The canonical oracle used by all assertions is ``PCB.get_pad_position``
+or the equivalent inline forward transform (the two are identical).
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pytest
+
+# Tolerance for floating-point pad-position comparisons (mm).
+EPS = 1e-9
+
+# Fixture geometry: chosen so that canonical (CCW-positive) and buggy
+# (negated) sign conventions produce noticeably different world positions
+# at each of {45°, 90°, 270°}.  pad_local = (3.0, 1.0) has nonzero,
+# distinct x/y components which is required to break 0°/180° symmetries
+# in cos.  See the negative-control test below.
+ROTATIONS = [45.0, 90.0, 270.0]
+PAD_LOCAL = (3.0, 1.0)
+FP_POS = (20.0, 15.0)
+
+
+def _canonical_world(
+    fp_pos: tuple[float, float],
+    rotation_deg: float,
+    pad_local: tuple[float, float],
+) -> tuple[float, float]:
+    """Canonical CCW-positive forward transform.
+
+    This is the reference oracle.  It is mathematically identical to
+    ``PCB.get_pad_position`` (``schema/pcb.py:3628``) and the inline
+    transform at ``router/io.py:2661-2667``.
+    """
+    rot_rad = math.radians(rotation_deg)
+    cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
+    px, py = pad_local
+    return (
+        fp_pos[0] + px * cos_r - py * sin_r,
+        fp_pos[1] + px * sin_r + py * cos_r,
+    )
+
+
+def _buggy_world(
+    fp_pos: tuple[float, float],
+    rotation_deg: float,
+    pad_local: tuple[float, float],
+) -> tuple[float, float]:
+    """The (incorrect) negated-angle transform that the bug used."""
+    rot_rad = math.radians(-rotation_deg)
+    cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
+    px, py = pad_local
+    return (
+        fp_pos[0] + px * cos_r - py * sin_r,
+        fp_pos[1] + px * sin_r + py * cos_r,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Negative control: the fixture geometry actually discriminates between
+# the two sign conventions at every rotation we test.
+# ---------------------------------------------------------------------------
+
+
+class TestFixtureDiscriminatesSignConventions:
+    """Verify that the chosen fixture would actually fail under buggy code.
+
+    This is a *meta-test* on the test fixture itself.  Without it, a
+    silently-passing parametrized test against buggy code would be
+    indistinguishable from a correct fix.
+    """
+
+    @pytest.mark.parametrize("rotation", ROTATIONS)
+    def test_canonical_and_buggy_differ(self, rotation: float) -> None:
+        canonical = _canonical_world(FP_POS, rotation, PAD_LOCAL)
+        buggy = _buggy_world(FP_POS, rotation, PAD_LOCAL)
+        dx = abs(canonical[0] - buggy[0])
+        dy = abs(canonical[1] - buggy[1])
+        # 0.5 mm is comfortably above any floating-point noise but
+        # small enough that almost any meaningful pad geometry produces
+        # discrimination at non-axis-aligned rotations.
+        assert max(dx, dy) > 0.5, (
+            f"rotation={rotation}°: fixture is symmetric — canonical="
+            f"{canonical}, buggy={buggy}; tests will silently pass "
+            f"against buggy code.  Choose pad_local with nonzero, "
+            f"distinct x/y components."
+        )
+
+    def test_axis_aligned_rotations_are_blind_spot(self) -> None:
+        """Document why the parametrization excludes 0° and 180°.
+
+        At 0°: sin(0) == sin(-0) == 0 and cos(0) == cos(-0) == 1, so
+        both conventions produce identical results.
+
+        At 180°: cos(180) == cos(-180) == -1 and sin(180) == -sin(-180)
+        but the y-component of pad_local interacts symmetrically; for
+        ANY pad_local, the canonical and buggy results are identical.
+
+        This test exists to make that blind spot explicit and to fail
+        loudly if someone later "simplifies" the parametrization to
+        only test 0° or 180° (which would render the entire module
+        useless as bug coverage).
+        """
+        for rot in (0.0, 180.0):
+            canonical = _canonical_world(FP_POS, rot, PAD_LOCAL)
+            buggy = _buggy_world(FP_POS, rot, PAD_LOCAL)
+            assert canonical == pytest.approx(buggy, abs=1e-12), (
+                f"rotation={rot}°: canonical and buggy unexpectedly "
+                f"differ — re-check the sign-symmetry argument."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Shared minimal PCB fixture.  A single rotated SMD footprint with one
+# pad at PAD_LOCAL, an asymmetric offset chosen to discriminate the two
+# sign conventions at {45°, 90°, 270°}.
+# ---------------------------------------------------------------------------
+
+
+def _rotated_pcb_text(rotation_deg: float) -> str:
+    """KiCad PCB s-expression text with one rotated footprint, one pad.
+
+    Net ``SIG1`` (net 1) carries pad ``U1.1`` only — but since the
+    Autorouter requires >= 2 pads on a net to attempt routing, we add
+    a second footprint ``U2`` with a single pad on SIG1 at a different
+    fixed (rotation=0) position.  Only U1's pad is asymmetrically
+    placed; U2's pad is at its footprint origin so rotation has no
+    effect on its world position.
+    """
+    return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "SIG1")
+
+  (gr_line (start 0 0) (end 80 0) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 80 0) (end 80 60) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 80 60) (end 0 60) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 0 60) (end 0 0) (layer "Edge.Cuts") (stroke (width 0.1)))
+
+  (footprint "Custom_U1"
+    (layer "F.Cu")
+    (at {FP_POS[0]} {FP_POS[1]} {rotation_deg})
+    (attr smd)
+    (property "Reference" "U1")
+    (property "Value" "ASYM")
+    (pad "1" smd rect (at {PAD_LOCAL[0]} {PAD_LOCAL[1]}) (size 0.6 0.6) (layers "F.Cu") (net 1 "SIG1"))
+  )
+
+  (footprint "Custom_U2"
+    (layer "F.Cu")
+    (at 60.0 45.0 0)
+    (attr smd)
+    (property "Reference" "U2")
+    (property "Value" "SYM")
+    (pad "1" smd rect (at 0 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "SIG1"))
+  )
+)
+"""
+
+
+# ---------------------------------------------------------------------------
+# Site 1: mcp.tools.routing.route_net (line 274)
+# ---------------------------------------------------------------------------
+
+
+class TestRouteNetRotation:
+    """``mcp.tools.routing.route_net`` collects pads per footprint and
+    forwards them to the Autorouter via ``add_component``.  Site at
+    line 274.
+
+    We patch ``Autorouter.add_component`` to capture the pad payloads.
+    The rotation regression bites during pad collection — well before
+    the actual route attempt — so the test does not need to run the A*
+    search, only verify the world positions handed to the router.
+    """
+
+    @pytest.mark.parametrize("rotation", ROTATIONS)
+    def test_pads_collected_with_canonical_rotation(
+        self, tmp_path: Path, rotation: float, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pytest.importorskip("pydantic")
+
+        pcb_file = tmp_path / "rotated.kicad_pcb"
+        pcb_file.write_text(_rotated_pcb_text(rotation))
+
+        captured: dict[str, list[dict]] = {}
+
+        def fake_add_component(self, ref: str, pads: list[dict]) -> None:  # noqa: ANN001
+            captured[ref] = list(pads)
+
+        monkeypatch.setattr(
+            "kicad_tools.router.core.Autorouter.add_component",
+            fake_add_component,
+        )
+
+        # Patch route_net (the bound method on the Autorouter instance)
+        # so the function returns immediately after pad collection.
+        def fake_route_net(self, net_number):  # noqa: ANN001
+            return []
+
+        monkeypatch.setattr(
+            "kicad_tools.router.core.Autorouter.route_net",
+            fake_route_net,
+        )
+
+        from kicad_tools.mcp.tools.routing import route_net
+
+        # The route_net result will be "no routes" (because we mocked
+        # the routing call), but pad collection still ran.  Best-effort
+        # invocation — assertions are on captured.
+        try:
+            route_net(pcb_path=str(pcb_file), net_name="SIG1")
+        except Exception:
+            pass
+
+        u1_pads = captured.get("U1")
+        assert u1_pads is not None, (
+            f"rotation={rotation}°: route_net did not load U1's pad"
+        )
+        assert len(u1_pads) == 1
+        pad = u1_pads[0]
+
+        expected = _canonical_world(FP_POS, rotation, PAD_LOCAL)
+        assert abs(pad["x"] - expected[0]) < EPS, (
+            f"rotation={rotation}°: route_net U1.1 x={pad['x']} differs "
+            f"from canonical {expected[0]}"
+        )
+        assert abs(pad["y"] - expected[1]) < EPS, (
+            f"rotation={rotation}°: route_net U1.1 y={pad['y']} differs "
+            f"from canonical {expected[1]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Site 2: mcp.tools.routing._build_pad_positions (line 593)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPadPositionsRotation:
+    """``_build_pad_positions`` returns a ``dict[net_number, [(x, y), ...]]``.
+    Site at line 593.
+
+    The U1 pad on SIG1 must land at the canonical world position.
+    """
+
+    @pytest.mark.parametrize("rotation", ROTATIONS)
+    def test_world_position_matches_get_pad_position(
+        self, tmp_path: Path, rotation: float
+    ) -> None:
+        pytest.importorskip("pydantic")
+        from kicad_tools.mcp.tools.routing import _build_pad_positions
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_file = tmp_path / "rotated.kicad_pcb"
+        pcb_file.write_text(_rotated_pcb_text(rotation))
+        pcb = PCB.load(str(pcb_file))
+
+        expected_u1 = pcb.get_pad_position("U1", "1")
+        assert expected_u1 is not None
+
+        positions = _build_pad_positions(pcb)
+        sig1_positions = positions[1]
+        # SIG1 has two pads: U1.1 (rotated) and U2.1 (at origin offset).
+        # Find U1's by closeness to expected.
+        u1_actual = min(
+            sig1_positions,
+            key=lambda p: (p[0] - expected_u1[0]) ** 2
+            + (p[1] - expected_u1[1]) ** 2,
+        )
+        assert abs(u1_actual[0] - expected_u1[0]) < EPS, (
+            f"rotation={rotation}°: x mismatch — got {u1_actual[0]}, "
+            f"expected {expected_u1[0]}"
+        )
+        assert abs(u1_actual[1] - expected_u1[1]) < EPS, (
+            f"rotation={rotation}°: y mismatch — got {u1_actual[1]}, "
+            f"expected {expected_u1[1]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Site 3: cli.placement_cmd._estimate_routability (line 943)
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateRoutabilityRotation:
+    """``_estimate_routability`` builds a private Autorouter and loads
+    every footprint's pads into it via ``router.add_component``.  Site
+    at line 943.
+
+    We patch ``Autorouter.add_component`` to capture the pad payloads
+    and assert U1's pad-1 lands at the canonical world position.
+    """
+
+    @pytest.mark.parametrize("rotation", ROTATIONS)
+    def test_pad_world_position_matches_canonical(
+        self, tmp_path: Path, rotation: float, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pcb_file = tmp_path / "rotated.kicad_pcb"
+        pcb_file.write_text(_rotated_pcb_text(rotation))
+
+        captured: dict[str, list[dict]] = {}
+
+        def fake_add_component(self, ref: str, pads: list[dict]) -> None:  # noqa: ANN001
+            captured[ref] = list(pads)
+
+        monkeypatch.setattr(
+            "kicad_tools.router.core.Autorouter.add_component",
+            fake_add_component,
+        )
+
+        # Patch the analyzer so we don't run the (expensive) full
+        # routability analysis — pad-loading completes BEFORE the
+        # analyzer is constructed, so we still get full coverage of
+        # the transform.
+        class _FakeReport:
+            estimated_success_rate = 1.0
+            total_nets = 0
+            problem_nets: list = []
+
+        class _FakeAnalyzer:
+            def __init__(self, router) -> None:  # noqa: ANN001
+                self.router = router
+
+            def analyze(self) -> _FakeReport:
+                return _FakeReport()
+
+        monkeypatch.setattr(
+            "kicad_tools.router.analysis.RoutabilityAnalyzer",
+            _FakeAnalyzer,
+        )
+
+        from kicad_tools.cli.placement_cmd import _estimate_routability
+
+        _estimate_routability(pcb_file, quiet=True)
+
+        # U1 was loaded with one pad at PAD_LOCAL.
+        u1_pads = captured.get("U1")
+        assert u1_pads is not None, "U1 was never loaded into router"
+        assert len(u1_pads) == 1
+        pad = u1_pads[0]
+
+        expected = _canonical_world(FP_POS, rotation, PAD_LOCAL)
+        assert abs(pad["x"] - expected[0]) < EPS, (
+            f"rotation={rotation}°: U1 pad x={pad['x']} differs from "
+            f"canonical {expected[0]}"
+        )
+        assert abs(pad["y"] - expected[1]) < EPS, (
+            f"rotation={rotation}°: U1 pad y={pad['y']} differs from "
+            f"canonical {expected[1]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Site 4: reasoning.state.ComponentState._parse_* (line 436)
+# ---------------------------------------------------------------------------
+
+
+class TestReasoningStatePadRotation:
+    """``PCBState.from_pcb`` parses footprints via ``_parse_footprint``
+    which precomputes ``cos_r, sin_r`` at line 436 from the footprint
+    rotation and passes them to ``_parse_pad`` (lines 485-486) which
+    applies the forward local->world transform.
+
+    Verify the resulting ``PadState.x/y`` match the canonical world
+    position.
+    """
+
+    @pytest.mark.parametrize("rotation", ROTATIONS)
+    def test_pad_state_world_position_matches_canonical(
+        self, tmp_path: Path, rotation: float
+    ) -> None:
+        from kicad_tools.reasoning.state import PCBState
+
+        pcb_file = tmp_path / "rotated.kicad_pcb"
+        pcb_file.write_text(_rotated_pcb_text(rotation))
+
+        state = PCBState.from_pcb(pcb_file)
+        u1 = state.get_component("U1")
+        assert u1 is not None, "U1 missing from parsed state"
+        assert len(u1.pads) == 1
+        pad = u1.pads[0]
+
+        expected = _canonical_world(FP_POS, rotation, PAD_LOCAL)
+        assert abs(pad.x - expected[0]) < EPS, (
+            f"rotation={rotation}°: U1.1 PadState.x={pad.x} differs "
+            f"from canonical {expected[0]}"
+        )
+        assert abs(pad.y - expected[1]) < EPS, (
+            f"rotation={rotation}°: U1.1 PadState.y={pad.y} differs "
+            f"from canonical {expected[1]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Site 5: router.io.route_pcb (line 2244)
+# ---------------------------------------------------------------------------
+
+
+class TestRoutePcbRotation:
+    """``router.io.route_pcb`` takes a ``components`` list of plain
+    dicts (not a PCB object) and applies the forward transform at line
+    2244.  Patch ``Autorouter.add_component`` to capture the result.
+    """
+
+    @pytest.mark.parametrize("rotation", ROTATIONS)
+    def test_pad_world_position_matches_canonical(
+        self, rotation: float, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict[str, list[dict]] = {}
+
+        def fake_add_component(self, ref: str, pads: list[dict]) -> None:  # noqa: ANN001
+            captured[ref] = list(pads)
+
+        monkeypatch.setattr(
+            "kicad_tools.router.core.Autorouter.add_component",
+            fake_add_component,
+        )
+
+        # Mock the heavy route_all() call too — we only care about the
+        # pad-coordinate transform that runs BEFORE routing begins.
+        def fake_route_all(self, *a, **kw):  # noqa: ANN001, ANN002, ANN003
+            return []
+
+        monkeypatch.setattr(
+            "kicad_tools.router.core.Autorouter.route_all", fake_route_all
+        )
+        monkeypatch.setattr(
+            "kicad_tools.router.core.Autorouter.cleanup_artifacts",
+            lambda self: None,
+        )
+        monkeypatch.setattr(
+            "kicad_tools.router.core.Autorouter.to_sexp",
+            lambda self, **kw: "",
+        )
+        monkeypatch.setattr(
+            "kicad_tools.router.core.Autorouter.get_statistics",
+            lambda self: {"routes": 0, "segments": 0, "vias": 0},
+        )
+
+        from kicad_tools.router.io import route_pcb
+
+        components = [
+            {
+                "ref": "U1",
+                "x": FP_POS[0],
+                "y": FP_POS[1],
+                "rotation": rotation,
+                "pads": [
+                    {
+                        "number": "1",
+                        "x": PAD_LOCAL[0],
+                        "y": PAD_LOCAL[1],
+                        "width": 0.6,
+                        "height": 0.6,
+                        "net": "SIG1",
+                    }
+                ],
+            },
+            {
+                "ref": "U2",
+                "x": 60.0,
+                "y": 45.0,
+                "rotation": 0.0,
+                "pads": [
+                    {
+                        "number": "1",
+                        "x": 0.0,
+                        "y": 0.0,
+                        "width": 0.6,
+                        "height": 0.6,
+                        "net": "SIG1",
+                    }
+                ],
+            },
+        ]
+        net_map = {"SIG1": 1}
+
+        try:
+            route_pcb(
+                board_width=80,
+                board_height=60,
+                components=components,
+                net_map=net_map,
+            )
+        except Exception:
+            # The patched route() may return an unexpected shape; we
+            # only care that pad collection ran first.
+            pass
+
+        u1_pads = captured.get("U1")
+        assert u1_pads is not None, "U1 not loaded into router"
+        assert len(u1_pads) == 1
+        pad = u1_pads[0]
+
+        expected = _canonical_world(FP_POS, rotation, PAD_LOCAL)
+        assert abs(pad["x"] - expected[0]) < EPS, (
+            f"rotation={rotation}°: route_pcb pad x={pad['x']} "
+            f"differs from canonical {expected[0]}"
+        )
+        assert abs(pad["y"] - expected[1]) < EPS, (
+            f"rotation={rotation}°: route_pcb pad y={pad['y']} "
+            f"differs from canonical {expected[1]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Site 6: router.adaptive.AdaptiveAutorouter._add_component_to_router (line 181)
+# ---------------------------------------------------------------------------
+
+
+class TestAdaptiveRouterRotation:
+    """``AdaptiveAutorouter._add_component_to_router`` applies the
+    forward transform at line 181 and forwards to ``add_component``.
+
+    Call the method directly to avoid the full adaptive routing flow.
+    """
+
+    @pytest.mark.parametrize("rotation", ROTATIONS)
+    def test_pad_world_position_matches_canonical(
+        self, rotation: float, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kicad_tools.router.adaptive import AdaptiveAutorouter
+
+        components = [
+            {
+                "ref": "U1",
+                "x": FP_POS[0],
+                "y": FP_POS[1],
+                "rotation": rotation,
+                "pads": [
+                    {
+                        "number": "1",
+                        "x": PAD_LOCAL[0],
+                        "y": PAD_LOCAL[1],
+                        "width": 0.6,
+                        "height": 0.6,
+                        "net": "SIG1",
+                    }
+                ],
+            }
+        ]
+        adaptive = AdaptiveAutorouter(
+            width=80,
+            height=60,
+            components=components,
+            net_map={"SIG1": 1},
+            verbose=False,
+        )
+
+        # Capture add_component invocations.
+        captured: dict[str, list[dict]] = {}
+
+        class _FakeRouter:
+            def add_component(self, ref: str, pads: list[dict]) -> None:
+                captured[ref] = list(pads)
+
+        adaptive._add_component_to_router(_FakeRouter(), components[0])
+
+        u1_pads = captured.get("U1")
+        assert u1_pads is not None
+        assert len(u1_pads) == 1
+        pad = u1_pads[0]
+
+        expected = _canonical_world(FP_POS, rotation, PAD_LOCAL)
+        assert abs(pad["x"] - expected[0]) < EPS, (
+            f"rotation={rotation}°: AdaptiveRouter pad x={pad['x']} "
+            f"differs from canonical {expected[0]}"
+        )
+        assert abs(pad["y"] - expected[1]) < EPS, (
+            f"rotation={rotation}°: AdaptiveRouter pad y={pad['y']} "
+            f"differs from canonical {expected[1]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Site 7: optim.place_route.PlaceRouteOptimizer._load_components_into_router
+# (line 303)
+# ---------------------------------------------------------------------------
+
+
+class TestPlaceRouteOptimizerLoadRotation:
+    """``PlaceRouteOptimizer._load_components_into_router`` is a static
+    method that walks ``pcb.footprints`` and loads each footprint's
+    pads into an Autorouter via ``add_component``.  Site at line 303.
+    """
+
+    @pytest.mark.parametrize("rotation", ROTATIONS)
+    def test_pad_world_position_matches_canonical(
+        self, tmp_path: Path, rotation: float
+    ) -> None:
+        from kicad_tools.optim.place_route import PlaceRouteOptimizer
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_file = tmp_path / "rotated.kicad_pcb"
+        pcb_file.write_text(_rotated_pcb_text(rotation))
+        pcb = PCB.load(str(pcb_file))
+
+        captured: dict[str, list[dict]] = {}
+
+        class _FakeRouter:
+            def add_component(self, ref: str, pads: list[dict]) -> None:
+                captured[ref] = list(pads)
+
+        PlaceRouteOptimizer._load_components_into_router(_FakeRouter(), pcb)
+
+        u1_pads = captured.get("U1")
+        assert u1_pads is not None, "U1 not loaded into router"
+        assert len(u1_pads) == 1
+        pad = u1_pads[0]
+
+        expected = pcb.get_pad_position("U1", "1")
+        assert expected is not None
+        assert abs(pad["x"] - expected[0]) < EPS, (
+            f"rotation={rotation}°: PlaceRouteOptimizer pad x={pad['x']} "
+            f"differs from canonical {expected[0]}"
+        )
+        assert abs(pad["y"] - expected[1]) < EPS, (
+            f"rotation={rotation}°: PlaceRouteOptimizer pad y={pad['y']} "
+            f"differs from canonical {expected[1]}"
+        )

--- a/tests/test_rotation_convention_audit.py
+++ b/tests/test_rotation_convention_audit.py
@@ -39,6 +39,7 @@ or the equivalent inline forward transform (the two are identical).
 
 from __future__ import annotations
 
+import contextlib
 import math
 from pathlib import Path
 
@@ -251,15 +252,11 @@ class TestRouteNetRotation:
         # The route_net result will be "no routes" (because we mocked
         # the routing call), but pad collection still ran.  Best-effort
         # invocation — assertions are on captured.
-        try:
+        with contextlib.suppress(Exception):
             route_net(pcb_path=str(pcb_file), net_name="SIG1")
-        except Exception:
-            pass
 
         u1_pads = captured.get("U1")
-        assert u1_pads is not None, (
-            f"rotation={rotation}°: route_net did not load U1's pad"
-        )
+        assert u1_pads is not None, f"rotation={rotation}°: route_net did not load U1's pad"
         assert len(u1_pads) == 1
         pad = u1_pads[0]
 
@@ -287,9 +284,7 @@ class TestBuildPadPositionsRotation:
     """
 
     @pytest.mark.parametrize("rotation", ROTATIONS)
-    def test_world_position_matches_get_pad_position(
-        self, tmp_path: Path, rotation: float
-    ) -> None:
+    def test_world_position_matches_get_pad_position(self, tmp_path: Path, rotation: float) -> None:
         pytest.importorskip("pydantic")
         from kicad_tools.mcp.tools.routing import _build_pad_positions
         from kicad_tools.schema.pcb import PCB
@@ -307,16 +302,13 @@ class TestBuildPadPositionsRotation:
         # Find U1's by closeness to expected.
         u1_actual = min(
             sig1_positions,
-            key=lambda p: (p[0] - expected_u1[0]) ** 2
-            + (p[1] - expected_u1[1]) ** 2,
+            key=lambda p: (p[0] - expected_u1[0]) ** 2 + (p[1] - expected_u1[1]) ** 2,
         )
         assert abs(u1_actual[0] - expected_u1[0]) < EPS, (
-            f"rotation={rotation}°: x mismatch — got {u1_actual[0]}, "
-            f"expected {expected_u1[0]}"
+            f"rotation={rotation}°: x mismatch — got {u1_actual[0]}, expected {expected_u1[0]}"
         )
         assert abs(u1_actual[1] - expected_u1[1]) < EPS, (
-            f"rotation={rotation}°: y mismatch — got {u1_actual[1]}, "
-            f"expected {expected_u1[1]}"
+            f"rotation={rotation}°: y mismatch — got {u1_actual[1]}, expected {expected_u1[1]}"
         )
 
 
@@ -384,12 +376,10 @@ class TestEstimateRoutabilityRotation:
 
         expected = _canonical_world(FP_POS, rotation, PAD_LOCAL)
         assert abs(pad["x"] - expected[0]) < EPS, (
-            f"rotation={rotation}°: U1 pad x={pad['x']} differs from "
-            f"canonical {expected[0]}"
+            f"rotation={rotation}°: U1 pad x={pad['x']} differs from canonical {expected[0]}"
         )
         assert abs(pad["y"] - expected[1]) < EPS, (
-            f"rotation={rotation}°: U1 pad y={pad['y']} differs from "
-            f"canonical {expected[1]}"
+            f"rotation={rotation}°: U1 pad y={pad['y']} differs from canonical {expected[1]}"
         )
 
 
@@ -425,12 +415,10 @@ class TestReasoningStatePadRotation:
 
         expected = _canonical_world(FP_POS, rotation, PAD_LOCAL)
         assert abs(pad.x - expected[0]) < EPS, (
-            f"rotation={rotation}°: U1.1 PadState.x={pad.x} differs "
-            f"from canonical {expected[0]}"
+            f"rotation={rotation}°: U1.1 PadState.x={pad.x} differs from canonical {expected[0]}"
         )
         assert abs(pad.y - expected[1]) < EPS, (
-            f"rotation={rotation}°: U1.1 PadState.y={pad.y} differs "
-            f"from canonical {expected[1]}"
+            f"rotation={rotation}°: U1.1 PadState.y={pad.y} differs from canonical {expected[1]}"
         )
 
 
@@ -464,9 +452,7 @@ class TestRoutePcbRotation:
         def fake_route_all(self, *a, **kw):  # noqa: ANN001, ANN002, ANN003
             return []
 
-        monkeypatch.setattr(
-            "kicad_tools.router.core.Autorouter.route_all", fake_route_all
-        )
+        monkeypatch.setattr("kicad_tools.router.core.Autorouter.route_all", fake_route_all)
         monkeypatch.setattr(
             "kicad_tools.router.core.Autorouter.cleanup_artifacts",
             lambda self: None,
@@ -518,17 +504,15 @@ class TestRoutePcbRotation:
         ]
         net_map = {"SIG1": 1}
 
-        try:
+        # The patched route_all() returns an empty list; we only care
+        # that pad collection ran first.
+        with contextlib.suppress(Exception):
             route_pcb(
                 board_width=80,
                 board_height=60,
                 components=components,
                 net_map=net_map,
             )
-        except Exception:
-            # The patched route() may return an unexpected shape; we
-            # only care that pad collection ran first.
-            pass
 
         u1_pads = captured.get("U1")
         assert u1_pads is not None, "U1 not loaded into router"
@@ -537,12 +521,10 @@ class TestRoutePcbRotation:
 
         expected = _canonical_world(FP_POS, rotation, PAD_LOCAL)
         assert abs(pad["x"] - expected[0]) < EPS, (
-            f"rotation={rotation}°: route_pcb pad x={pad['x']} "
-            f"differs from canonical {expected[0]}"
+            f"rotation={rotation}°: route_pcb pad x={pad['x']} differs from canonical {expected[0]}"
         )
         assert abs(pad["y"] - expected[1]) < EPS, (
-            f"rotation={rotation}°: route_pcb pad y={pad['y']} "
-            f"differs from canonical {expected[1]}"
+            f"rotation={rotation}°: route_pcb pad y={pad['y']} differs from canonical {expected[1]}"
         )
 
 
@@ -628,9 +610,7 @@ class TestPlaceRouteOptimizerLoadRotation:
     """
 
     @pytest.mark.parametrize("rotation", ROTATIONS)
-    def test_pad_world_position_matches_canonical(
-        self, tmp_path: Path, rotation: float
-    ) -> None:
+    def test_pad_world_position_matches_canonical(self, tmp_path: Path, rotation: float) -> None:
         from kicad_tools.optim.place_route import PlaceRouteOptimizer
         from kicad_tools.schema.pcb import PCB
 


### PR DESCRIPTION
## Summary

Cleans up the seven call sites that the Curator audit (#2789) verified
were still computing the forward `world = fp_pos + R(theta) * local`
pad transform with a *negated* angle.  This is the final follow-up to
the convention fix started in PR #738 (Jan 2026) and continued in
#2778, #2783, #2788, and #2790.

The canonical KiCad convention - positive counter-clockwise rotation,
standard 2D rotation matrix applied directly with no negation - is
documented at `src/kicad_tools/router/io.py:2661-2667` and implemented
at `src/kicad_tools/schema/pcb.py:3628` (`PCB.get_pad_position`).

## Changes

### Forward-transform sign fix (drop the `-`)

| File | Line | Function |
|------|-----:|----------|
| `src/kicad_tools/mcp/tools/routing.py` | 274 | `route_net` per-net pad collector |
| `src/kicad_tools/mcp/tools/routing.py` | 593 | `_build_pad_positions` |
| `src/kicad_tools/cli/placement_cmd.py` | 943 | `_estimate_routability` |
| `src/kicad_tools/reasoning/state.py` | 436 | `ComponentState._parse_footprint` |
| `src/kicad_tools/router/io.py` | 2244 | `route_pcb` |
| `src/kicad_tools/router/adaptive.py` | 181 | `AdaptiveAutorouter._add_component_to_router` |
| `src/kicad_tools/optim/place_route.py` | 303 | `PlaceRouteOptimizer._load_components_into_router` |

### Misleading comment cleanup (3 sites)

The pre-existing comments `"KiCad uses CLOCKWISE rotation (negative angle in standard math)"` and `"# KiCad uses clockwise"` actively contradicted the canonical convention.  Replaced with the standard "positive sign matches PCB.get_pad_position" wording established by PR #2783 in `zones/generator.py:977-980`:

- `src/kicad_tools/router/io.py:2242-2246`
- `src/kicad_tools/router/adaptive.py:180-183`
- `src/kicad_tools/optim/place_route.py:302-304`

### New regression tests

New file `tests/test_rotation_convention_audit.py` (25 tests):

- One test class per affected site, each parametrized over `{45 deg, 90 deg, 270 deg}`.  Axis-aligned rotations are deliberately excluded because cos is even and the sin*y_local terms cancel symmetrically, so 0 deg/180 deg pass under BOTH sign conventions.
- A meta-test class (`TestFixtureDiscriminatesSignConventions`) asserts that the chosen fixture coordinates actually diverge between canonical and buggy conventions at the chosen rotations - so the parametrized tests cannot silently pass against buggy code.
- A blind-spot documentation test that verifies 0 deg and 180 deg deliberately do NOT discriminate, so any future "simplification" of the parametrization to only cover axis-aligned cases will fail loudly.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Drop `-` in `math.radians(-fp_rotation)` at all 7 sites | done | `grep -rn 'math.radians(-rotation)\|math.radians(-fp' src/kicad_tools/` returns no hits in forward-transform code (only the legitimate inverse transform in `optim/components.py:88-89` remains) |
| Rewrite 3 misleading comments to canonical CCW-positive wording | done | `grep -rn 'KiCad uses clockwise\|CLOCKWISE rotation' src/kicad_tools/` returns no hits |
| Parametrized tests at {45, 90, 270} for each site | done | 7 test classes x 3 rotations = 21 site-specific tests |
| Negative-control assertion per site | done | `TestFixtureDiscriminatesSignConventions` asserts canonical vs. buggy diverge by > 0.5 mm at every chosen rotation |
| All 25 new tests pass under the fix | done | `pytest tests/test_rotation_convention_audit.py` -> 25 passed |
| All 21 site tests FAIL under the bug (negative control) | done | Reverted the fix locally and re-ran: 21 failed, 4 passed (the 4 meta-tests on the fixture itself) |
| No scope creep (no `rotate_local_to_world` helper extracted) | done | Curator deferred this to a separate refactor issue |
| No regressions in related subsystems | done | `pytest tests/test_mcp_routing.py tests/test_edge_clearance_epsilon.py tests/test_reasoning_state.py tests/test_place_route_optimizer.py tests/test_adaptive_grid.py` -> 220 passed |

## Test Plan

```bash
# 1. New audit tests (negative-control verified by reverting the fix locally)
uv run pytest tests/test_rotation_convention_audit.py --no-cov
# -> 25 passed

# 2. Affected subsystems
uv run pytest tests/test_mcp_routing.py tests/test_edge_clearance_epsilon.py \
              tests/test_reasoning_state.py tests/test_place_route_optimizer.py \
              tests/test_adaptive_grid.py tests/test_cli_placement_routing_aware.py \
              tests/test_mcp_placement_analyze.py --no-cov
# -> 262 passed

# 3. Confirm no remaining bad-sign sites
grep -rn "math\.radians(-" src/kicad_tools/
# Only optim/components.py:88-89 remains (legitimate world->local inverse)

grep -rn "KiCad uses clockwise\|CLOCKWISE rotation" src/kicad_tools/
# No hits
```

The one pre-existing failing test (`test_board_04_routing_regression.py::TestBoard04OscOutRouting::test_routes_all_nets_on_2l`) was confirmed to be failing on `main` before this change - it relates to issue #2745 (OSC_OUT stagnation pattern) and is unrelated to rotation sign convention.  Similarly, `test_adaptive_early_stop.py` has 7 pre-existing `SameFileError` failures from MagicMock paths, also unrelated.

Closes #2789