### PR TITLE
fix(project): warn loudly when canonical PCB missing (closes #2792)

### DIFF
--- a/src/kicad_tools/project.py
+++ b/src/kicad_tools/project.py
@@ -186,6 +186,23 @@ class Project:
         """
         Load a KiCad project from .kicad_pro file.
 
+        Resolution order for the PCB and schematic files:
+
+        1. Parse ``.kicad_pro`` JSON. If the top-level ``boards`` array is
+           non-empty (KiCad multi-board project), each entry's ``file`` key
+           is resolved relative to the project directory. The first existing
+           ``.kicad_pcb`` wins.
+        2. Otherwise, fall back to the basename convention
+           (``<project_name>.kicad_pcb`` / ``.kicad_sch``).
+        3. If the basename PCB does not exist, scan the project directory
+           for ``*.kicad_pcb`` siblings:
+
+           - 0 siblings: ``_pcb_path`` is left as ``None`` and a warning is
+             logged naming the project dir.
+           - 1 sibling: that file is used and a warning is logged.
+           - 2+ siblings: a :class:`FileNotFoundError` is raised listing
+             every candidate so the caller can pick one explicitly.
+
         Args:
             project_path: Path to .kicad_pro file
 
@@ -193,19 +210,77 @@ class Project:
             Project instance
 
         Raises:
-            FileNotFoundError: If project file doesn't exist
+            FileNotFoundError: If the project file itself does not exist, or
+                if the canonical PCB is missing AND multiple ``*.kicad_pcb``
+                siblings exist (ambiguous resolution).
         """
         project_path = Path(project_path)
         if not project_path.exists():
             raise FileNotFoundError(f"Project file not found: {project_path}")
 
-        # Parse project file to find related files
         project_dir = project_path.parent
         project_name = project_path.stem
 
-        # Look for schematic and PCB
+        # 1. Try to honor an explicit boards[] array in .kicad_pro (multi-board).
+        pcb_from_pro: Path | None = None
+        try:
+            pro_text = project_path.read_text()
+            pro_data: dict[str, Any] = json.loads(pro_text) if pro_text.strip() else {}
+            boards = pro_data.get("boards", [])
+            if isinstance(boards, list) and boards:
+                for entry in boards:
+                    if not isinstance(entry, dict):
+                        continue
+                    file_field = entry.get("file") or entry.get("filename")
+                    if not file_field:
+                        continue
+                    candidate = (project_dir / file_field).resolve()
+                    if candidate.exists() and candidate.suffix == ".kicad_pcb":
+                        pcb_from_pro = candidate
+                        logger.info(
+                            "Using PCB %s from boards[] entry in %s",
+                            candidate.name,
+                            project_path.name,
+                        )
+                        break
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning(
+                "Could not parse %s as JSON (%s); falling back to basename convention.",
+                project_path,
+                exc,
+            )
+
+        # 2. Basename convention for schematic; PCB falls through to scan if missing.
         schematic_path = project_dir / f"{project_name}.kicad_sch"
-        pcb_path = project_dir / f"{project_name}.kicad_pcb"
+        pcb_path = pcb_from_pro or (project_dir / f"{project_name}.kicad_pcb")
+
+        # 3. If basename PCB is missing, scan for siblings.
+        if not pcb_path.exists():
+            siblings = sorted(project_dir.glob("*.kicad_pcb"))
+            if len(siblings) == 1:
+                logger.warning(
+                    "Canonical PCB %s not found in %s; using %s instead. "
+                    "Pass --pcb explicitly to silence this warning.",
+                    pcb_path.name,
+                    project_dir,
+                    siblings[0].name,
+                )
+                pcb_path = siblings[0]
+            elif len(siblings) > 1:
+                names = ", ".join(p.name for p in siblings)
+                raise FileNotFoundError(
+                    f"Project {project_path.name} loaded, but canonical "
+                    f"{pcb_path.name} not found and multiple .kicad_pcb "
+                    f"candidates exist in {project_dir}: {names}. "
+                    f"Pass --pcb explicitly to disambiguate."
+                )
+            else:
+                logger.warning(
+                    "No .kicad_pcb files found in %s (canonical %s missing). "
+                    "Project loaded without a PCB path.",
+                    project_dir,
+                    pcb_path.name,
+                )
 
         return cls(
             schematic=schematic_path if schematic_path.exists() else None,

--- a/src/kicad_tools/sync/reconciler.py
+++ b/src/kicad_tools/sync/reconciler.py
@@ -234,6 +234,7 @@ class Reconciler:
         self._schematic_path: Path | None = None
         self._pcb_path: Path | None = None
 
+        project_path: Path | None = None
         if project:
             project_path = Path(project)
             if not project_path.exists():
@@ -247,6 +248,28 @@ class Reconciler:
             self._pcb_path = Path(pcb)
 
         if not self._schematic_path or not self._pcb_path:
+            if project_path is not None:
+                missing = []
+                if not self._schematic_path:
+                    missing.append("schematic")
+                if not self._pcb_path:
+                    missing.append("PCB")
+                project_dir = project_path.parent
+                pcb_candidates = sorted(project_dir.glob("*.kicad_pcb"))
+                sch_candidates = sorted(project_dir.glob("*.kicad_sch"))
+                pcb_str = (
+                    ", ".join(p.name for p in pcb_candidates) if pcb_candidates else "(none)"
+                )
+                sch_str = (
+                    ", ".join(p.name for p in sch_candidates) if sch_candidates else "(none)"
+                )
+                raise ValueError(
+                    f"Project {project_path.name} loaded, but "
+                    f"{' and '.join(missing)} file(s) could not be resolved. "
+                    f"Candidate PCBs in {project_dir}: {pcb_str}. "
+                    f"Candidate schematics: {sch_str}. "
+                    f"Pass --schematic/--pcb explicitly to disambiguate."
+                )
             raise ValueError(
                 "Must provide either a project file or both --schematic and --pcb paths"
             )

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -247,6 +247,167 @@ class TestProjectLoad:
         with pytest.raises(FileNotFoundError):
             Project.load(pro_path)
 
+    def test_load_basename_pcb_missing_single_sibling(self, tmp_path, caplog):
+        """When canonical PCB missing but one sibling exists, use sibling with warning."""
+        import logging
+
+        pro_path = tmp_path / "foo.kicad_pro"
+        sch_path = tmp_path / "foo.kicad_sch"
+        sibling_pcb = tmp_path / "foo_v2.kicad_pcb"
+
+        pro_path.write_text("{}")
+        sch_path.write_text("")
+        sibling_pcb.write_text("")
+
+        with caplog.at_level(logging.WARNING, logger="kicad_tools.project"):
+            project = Project.load(pro_path)
+
+        assert project._pcb_path == sibling_pcb
+        assert project._schematic_path == sch_path
+        # A warning naming the sibling should be emitted.
+        assert any("foo_v2.kicad_pcb" in rec.message for rec in caplog.records)
+
+    def test_load_basename_pcb_missing_multiple_siblings_raises(self, tmp_path):
+        """When canonical PCB missing and 2+ siblings exist, raise listing all."""
+        pro_path = tmp_path / "foo.kicad_pro"
+        sch_path = tmp_path / "foo.kicad_sch"
+        sib1 = tmp_path / "foo_v1.kicad_pcb"
+        sib2 = tmp_path / "foo_v2.kicad_pcb"
+
+        pro_path.write_text("{}")
+        sch_path.write_text("")
+        sib1.write_text("")
+        sib2.write_text("")
+
+        with pytest.raises(FileNotFoundError) as exc_info:
+            Project.load(pro_path)
+
+        msg = str(exc_info.value)
+        assert "foo_v1.kicad_pcb" in msg
+        assert "foo_v2.kicad_pcb" in msg
+        assert "foo.kicad_pro" in msg
+        assert "--pcb" in msg
+
+    def test_load_no_pcb_files_at_all(self, tmp_path, caplog):
+        """Preserve current behavior: no PCB files found -> _pcb_path is None (with warning)."""
+        import logging
+
+        pro_path = tmp_path / "foo.kicad_pro"
+        sch_path = tmp_path / "foo.kicad_sch"
+
+        pro_path.write_text("{}")
+        sch_path.write_text("")
+
+        with caplog.at_level(logging.WARNING, logger="kicad_tools.project"):
+            project = Project.load(pro_path)
+
+        assert project._pcb_path is None
+        assert project._schematic_path == sch_path
+        # Warning naming the project dir should be emitted.
+        assert any("No .kicad_pcb" in rec.message for rec in caplog.records)
+
+    def test_load_with_boards_array_in_pro(self, tmp_path):
+        """When .kicad_pro has a non-empty boards[] array, honor it over basename."""
+        import json as _json
+
+        pro_path = tmp_path / "foo.kicad_pro"
+        sch_path = tmp_path / "foo.kicad_sch"
+        # Both canonical AND explicit-boards-file exist; explicit should win.
+        canonical_pcb = tmp_path / "foo.kicad_pcb"
+        explicit_pcb = tmp_path / "explicit.kicad_pcb"
+
+        pro_path.write_text(_json.dumps({"boards": [{"file": "explicit.kicad_pcb"}]}))
+        sch_path.write_text("")
+        canonical_pcb.write_text("")
+        explicit_pcb.write_text("")
+
+        project = Project.load(pro_path)
+
+        assert project._pcb_path == explicit_pcb.resolve()
+
+    def test_load_with_boards_array_empty_uses_basename(self, tmp_path):
+        """Empty boards[] (the typical single-board case) falls through to basename."""
+        import json as _json
+
+        pro_path = tmp_path / "foo.kicad_pro"
+        sch_path = tmp_path / "foo.kicad_sch"
+        canonical_pcb = tmp_path / "foo.kicad_pcb"
+
+        pro_path.write_text(_json.dumps({"boards": []}))
+        sch_path.write_text("")
+        canonical_pcb.write_text("")
+
+        project = Project.load(pro_path)
+
+        assert project._pcb_path == canonical_pcb
+
+    def test_load_with_boards_array_missing_file_falls_through(self, tmp_path):
+        """If boards[] entry's file doesn't exist, fall through to basename heuristic."""
+        import json as _json
+
+        pro_path = tmp_path / "foo.kicad_pro"
+        sch_path = tmp_path / "foo.kicad_sch"
+        canonical_pcb = tmp_path / "foo.kicad_pcb"
+
+        pro_path.write_text(_json.dumps({"boards": [{"file": "ghost.kicad_pcb"}]}))
+        sch_path.write_text("")
+        canonical_pcb.write_text("")
+
+        project = Project.load(pro_path)
+
+        # boards[] entry didn't resolve; fall back to canonical basename.
+        assert project._pcb_path == canonical_pcb
+
+    def test_load_malformed_pro_falls_back_to_basename(self, tmp_path, caplog):
+        """Corrupt JSON in .kicad_pro should not crash; basename heuristic still works."""
+        import logging
+
+        pro_path = tmp_path / "foo.kicad_pro"
+        sch_path = tmp_path / "foo.kicad_sch"
+        pcb_path = tmp_path / "foo.kicad_pcb"
+
+        pro_path.write_text("{not valid json")
+        sch_path.write_text("")
+        pcb_path.write_text("")
+
+        with caplog.at_level(logging.WARNING, logger="kicad_tools.project"):
+            project = Project.load(pro_path)
+
+        assert project._pcb_path == pcb_path
+        assert project._schematic_path == sch_path
+        assert any("Could not parse" in rec.message for rec in caplog.records)
+
+    def test_load_empty_pro_does_not_crash(self, tmp_path):
+        """A zero-byte .kicad_pro file must not crash the loader."""
+        pro_path = tmp_path / "foo.kicad_pro"
+        sch_path = tmp_path / "foo.kicad_sch"
+        pcb_path = tmp_path / "foo.kicad_pcb"
+
+        pro_path.write_text("")  # zero-byte
+        sch_path.write_text("")
+        pcb_path.write_text("")
+
+        project = Project.load(pro_path)
+
+        assert project._pcb_path == pcb_path
+        assert project._schematic_path == sch_path
+
+    def test_load_pro_with_unrelated_keys_falls_through(self, tmp_path):
+        """Pro file with no boards key (or unrelated keys) uses basename heuristic."""
+        import json as _json
+
+        pro_path = tmp_path / "foo.kicad_pro"
+        sch_path = tmp_path / "foo.kicad_sch"
+        pcb_path = tmp_path / "foo.kicad_pcb"
+
+        pro_path.write_text(_json.dumps({"meta": {"filename": "foo.kicad_pro"}}))
+        sch_path.write_text("")
+        pcb_path.write_text("")
+
+        project = Project.load(pro_path)
+
+        assert project._pcb_path == pcb_path
+
 
 class TestProjectFromPCB:
     """Tests for Project.from_pcb() class method."""

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -255,6 +255,53 @@ class TestReconciler:
         finally:
             Path(sch_path).unlink()
 
+    def test_init_project_loaded_but_pcb_unresolved_lists_candidates(self, tmp_path):
+        """When project loads but resolves to no PCB and multi-candidate scan would
+        also fail to disambiguate at Project.load(), the project loader itself
+        raises with a candidate list. We assert the candidate names appear."""
+        pro_path = tmp_path / "foo.kicad_pro"
+        sch_path = tmp_path / "foo.kicad_sch"
+        sib1 = tmp_path / "foo_v1.kicad_pcb"
+        sib2 = tmp_path / "foo_v2.kicad_pcb"
+
+        pro_path.write_text("{}")
+        sch_path.write_text("")
+        sib1.write_text("")
+        sib2.write_text("")
+
+        # Project.load raises in the ambiguous case; the reconciler surfaces it.
+        with pytest.raises(FileNotFoundError) as exc_info:
+            Reconciler(project=str(pro_path))
+
+        msg = str(exc_info.value)
+        assert "foo_v1.kicad_pcb" in msg
+        assert "foo_v2.kicad_pcb" in msg
+        assert "--pcb" in msg
+
+    def test_init_project_loaded_but_no_pcb_names_project_file(self, tmp_path):
+        """When project loads but no PCB resolves (e.g. no .kicad_pcb files at all),
+        the reconciler error must name the project file and the candidate list."""
+        pro_path = tmp_path / "foo.kicad_pro"
+        sch_path = tmp_path / "foo.kicad_sch"
+        pro_path.write_text("{}")
+        sch_path.write_text("")
+        # No PCB files anywhere -> Project.load logs warning, returns _pcb_path=None.
+
+        with pytest.raises(ValueError) as exc_info:
+            Reconciler(project=str(pro_path))
+
+        msg = str(exc_info.value)
+        assert "foo.kicad_pro" in msg
+        assert "PCB" in msg
+        assert "(none)" in msg
+        assert "--pcb" in msg
+
+    def test_init_no_args_still_raises_generic_error(self):
+        """When neither project nor schematic+pcb provided, the generic error
+        message is still surfaced (no project context to enrich it with)."""
+        with pytest.raises(ValueError, match="Must provide either a project file"):
+            Reconciler()
+
 
 class TestReconcilerAnalyze:
     """Tests for Reconciler.analyze() using mocked schematic/PCB data."""


### PR DESCRIPTION
## Summary

- `Project.load()` no longer silently sets `_pcb_path=None` when the basename `.kicad_pcb` is missing. It now scans for siblings: 1 sibling -> use with warning, 2+ -> `FileNotFoundError` listing candidates, 0 -> warn + preserve `None`.
- Defensive support for `.kicad_pro` `boards[]` multi-board array (honored if non-empty; all real `.kicad_pro` files in this repo have it empty).
- `Reconciler.__init__` upgrades the generic "Must provide either a project file..." error: when a project *was* provided but resolution failed, the message now names the project file and lists candidate PCBs/schematics.
- Malformed / empty `.kicad_pro` JSON falls back to the basename heuristic with a warning instead of crashing.

## Why

Originating real-world failure: `chorus-test-revA.kicad_pro` had only versioned PCBs (`*_v17.kicad_pcb`, `*_v18.kicad_pcb`, ...) and no canonical `chorus-test-revA.kicad_pcb`. `kct sync --analyze` failed with `"Must provide either a project file or both --schematic and --pcb paths"` — implying argparse misconfiguration even though the user *did* pass `.kicad_pro`. The root cause was a silent `_pcb_path=None` resolution upstream in `Project.load()`.

## Test plan

- [x] `tests/test_project.py::TestProjectLoad` - 13 tests pass including new:
  - `test_load_basename_pcb_missing_single_sibling` - single non-canonical sibling found, used with warning
  - `test_load_basename_pcb_missing_multiple_siblings_raises` - 2+ siblings raises listing all
  - `test_load_no_pcb_files_at_all` - preserves current None behavior + warning
  - `test_load_with_boards_array_in_pro` - explicit boards[] wins over basename
  - `test_load_with_boards_array_empty_uses_basename` - empty boards[] falls through
  - `test_load_with_boards_array_missing_file_falls_through` - boards[] entry pointing at missing file falls through
  - `test_load_malformed_pro_falls_back_to_basename` - corrupt JSON warns + falls back
  - `test_load_empty_pro_does_not_crash` - zero-byte .kicad_pro tolerated
  - `test_load_pro_with_unrelated_keys_falls_through` - .kicad_pro without `boards` falls through cleanly
- [x] `tests/test_sync.py::TestReconciler` - 7 tests pass including new:
  - `test_init_project_loaded_but_pcb_unresolved_lists_candidates` - ambiguous case surfaces FileNotFoundError with candidate list
  - `test_init_project_loaded_but_no_pcb_names_project_file` - single-board case with no PCB surfaces ValueError naming project file
  - `test_init_no_args_still_raises_generic_error` - argparse-style failure still surfaces generic message
- [x] All 84 tests in `test_project.py` + `test_sync.py::TestReconciler` pass.
- [x] Pre-existing `test_audit.py::TestZoneConnectedNets::test_no_zones_regression` failure confirmed independent of this change (also fails on `main`).

Closes #2792

🤖 Generated with [Claude Code](https://claude.com/claude-code)