### PR TITLE
fix(cli): accept every registered manufacturer name on every --mfr site (closes #2793)

### DIFF
--- a/src/kicad_tools/cli/build_cmd.py
+++ b/src/kicad_tools/cli/build_cmd.py
@@ -29,6 +29,8 @@ logger = logging.getLogger(__name__)
 from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
+from kicad_tools.manufacturers import get_all_manufacturer_names
+
 if TYPE_CHECKING:
     from kicad_tools.spec.schema import ProjectSpec
 
@@ -2259,7 +2261,7 @@ Examples:
     parser.add_argument(
         "--mfr",
         "-m",
-        choices=["jlcpcb", "pcbway", "oshpark", "seeed"],
+        choices=get_all_manufacturer_names(),
         default="jlcpcb",
         help="Target manufacturer for verification (default: jlcpcb)",
     )

--- a/src/kicad_tools/cli/export_cmd.py
+++ b/src/kicad_tools/cli/export_cmd.py
@@ -13,6 +13,8 @@ import argparse
 import sys
 from pathlib import Path
 
+from kicad_tools.manufacturers import get_all_manufacturer_names
+
 
 def _find_pcb_for_export(directory: Path) -> Path | None:
     """Find a .kicad_pcb file in the given directory for export.
@@ -57,7 +59,7 @@ def main(argv: list[str] | None = None) -> int:
         "--mfr",
         "-m",
         default="jlcpcb",
-        choices=["jlcpcb", "pcbway", "oshpark", "seeed", "generic"],
+        choices=[*get_all_manufacturer_names(), "generic"],
         help="Target manufacturer (default: jlcpcb)",
     )
     parser.add_argument(

--- a/src/kicad_tools/cli/fix_silkscreen_cmd.py
+++ b/src/kicad_tools/cli/fix_silkscreen_cmd.py
@@ -34,6 +34,7 @@ from kicad_tools.drc.repair_silkscreen import (
     SilkscreenRepairResult,
     TextHeightRepairResult,
 )
+from kicad_tools.manufacturers import get_all_manufacturer_names
 from kicad_tools.manufacturers.base import load_design_rules_from_yaml
 
 
@@ -270,7 +271,7 @@ Examples:
     parser.add_argument("pcb", help="Path to .kicad_pcb file")
     parser.add_argument(
         "--mfr",
-        choices=["jlcpcb", "pcbway", "oshpark", "seeed"],
+        choices=get_all_manufacturer_names(),
         default="jlcpcb",
         help="Manufacturer to use for design rules (default: jlcpcb)",
     )

--- a/src/kicad_tools/cli/fix_vias_cmd.py
+++ b/src/kicad_tools/cli/fix_vias_cmd.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from kicad_tools.core.sexp_file import save_pcb
+from kicad_tools.manufacturers import get_all_manufacturer_names
 from kicad_tools.manufacturers.base import load_design_rules_from_yaml
 from kicad_tools.sexp.parser import SExp, parse_file
 
@@ -744,7 +745,7 @@ Examples:
     parser.add_argument("pcb", help="Path to .kicad_pcb file")
     parser.add_argument(
         "--mfr",
-        choices=["jlcpcb", "pcbway", "oshpark", "seeed"],
+        choices=get_all_manufacturer_names(),
         default="jlcpcb",
         help="Manufacturer to use for design rules (default: jlcpcb)",
     )

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -8,6 +8,7 @@ The parser is organized into subparsers for each major command category.
 import argparse
 
 from kicad_tools import __version__
+from kicad_tools.manufacturers import get_all_manufacturer_names
 
 __all__ = ["create_parser"]
 
@@ -351,7 +352,7 @@ def _add_drc_parser(subparsers) -> None:
     drc_parser.add_argument("--net", help="Filter by net name")
     drc_parser.add_argument(
         "--mfr",
-        choices=["jlcpcb", "pcbway", "oshpark", "seeed"],
+        choices=get_all_manufacturer_names(),
         help="Check against manufacturer design rules",
     )
     drc_parser.add_argument("--layers", type=int, default=2, help="Number of copper layers")
@@ -387,7 +388,7 @@ def _add_check_parser(subparsers) -> None:
     check_parser.add_argument(
         "--mfr",
         "-m",
-        choices=["jlcpcb", "pcbway", "oshpark", "seeed"],
+        choices=get_all_manufacturer_names(),
         default="jlcpcb",
         help="Target manufacturer (default: jlcpcb)",
     )
@@ -2709,7 +2710,7 @@ def _add_fix_vias_parser(subparsers) -> None:
     fix_vias_parser.add_argument("pcb", help="Path to .kicad_pcb file")
     fix_vias_parser.add_argument(
         "--mfr",
-        choices=["jlcpcb", "pcbway", "oshpark", "seeed"],
+        choices=get_all_manufacturer_names(),
         default="jlcpcb",
         help="Manufacturer to use for design rules (default: jlcpcb)",
     )
@@ -2770,7 +2771,7 @@ def _add_fix_silkscreen_parser(subparsers) -> None:
     fix_silk_parser.add_argument("pcb", help="Path to .kicad_pcb file")
     fix_silk_parser.add_argument(
         "--mfr",
-        choices=["jlcpcb", "pcbway", "oshpark", "seeed"],
+        choices=get_all_manufacturer_names(),
         default="jlcpcb",
         help="Manufacturer to use for design rules (default: jlcpcb)",
     )
@@ -2821,7 +2822,7 @@ def _add_repair_clearance_parser(subparsers) -> None:
     )
     repair_parser.add_argument(
         "--mfr",
-        choices=["jlcpcb", "pcbway", "oshpark", "seeed"],
+        choices=get_all_manufacturer_names(),
         help="Target manufacturer (for context)",
     )
     repair_parser.add_argument(
@@ -3916,7 +3917,7 @@ def _add_estimate_parser(subparsers) -> None:
     estimate_cost.add_argument(
         "--mfr",
         "-m",
-        choices=["jlcpcb", "pcbway", "seeed", "oshpark"],
+        choices=get_all_manufacturer_names(),
         default="jlcpcb",
         help="Target manufacturer (default: jlcpcb)",
     )
@@ -3984,7 +3985,7 @@ def _add_audit_parser(subparsers) -> None:
         "--mfr",
         "-m",
         dest="audit_mfr",
-        choices=["jlcpcb", "pcbway", "oshpark", "seeed"],
+        choices=get_all_manufacturer_names(),
         default="jlcpcb",
         help="Target manufacturer (default: jlcpcb)",
     )
@@ -4745,7 +4746,7 @@ def _add_pipeline_parser(subparsers) -> None:
         "--mfr",
         "-m",
         dest="pipeline_mfr",
-        choices=["jlcpcb", "pcbway", "oshpark", "seeed"],
+        choices=get_all_manufacturer_names(),
         default="jlcpcb",
         help="Target manufacturer (default: jlcpcb)",
     )
@@ -4984,7 +4985,7 @@ def _add_build_parser(subparsers) -> None:
         "--mfr",
         "-m",
         dest="build_mfr",
-        choices=["jlcpcb", "pcbway", "oshpark", "seeed"],
+        choices=get_all_manufacturer_names(),
         default="jlcpcb",
         help="Target manufacturer for verification (default: jlcpcb)",
     )
@@ -5803,7 +5804,7 @@ def _add_export_parser(subparsers) -> None:
         "-m",
         dest="export_mfr",
         default="jlcpcb",
-        choices=["jlcpcb", "pcbway", "oshpark", "seeed", "generic"],
+        choices=[*get_all_manufacturer_names(), "generic"],
         help="Target manufacturer (default: jlcpcb)",
     )
     export_parser.add_argument(

--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -47,6 +47,8 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
+from kicad_tools.manufacturers import get_all_manufacturer_names
+
 logger = logging.getLogger(__name__)
 
 __all__ = ["main"]
@@ -2153,7 +2155,7 @@ Examples:
     parser.add_argument(
         "--mfr",
         "-m",
-        choices=["jlcpcb", "pcbway", "oshpark", "seeed"],
+        choices=get_all_manufacturer_names(),
         default="jlcpcb",
         help="Target manufacturer (default: jlcpcb)",
     )

--- a/src/kicad_tools/manufacturers/__init__.py
+++ b/src/kicad_tools/manufacturers/__init__.py
@@ -53,6 +53,7 @@ __all__ = [
     "get_profile",
     "list_manufacturers",
     "get_manufacturer_ids",
+    "get_all_manufacturer_names",
     "load_design_rules_from_yaml",
     "load_rotation_corrections",
     "match_rotation_correction",
@@ -146,6 +147,28 @@ def get_manufacturer_ids() -> list[str]:
         List of manufacturer ID strings
     """
     return sorted(_PROFILES.keys())
+
+
+def get_all_manufacturer_names() -> list[str]:
+    """
+    Get every name accepted by ``get_profile`` -- canonical IDs and aliases.
+
+    Returns the union of ``_PROFILES`` keys (canonical names) and
+    ``_ALIASES`` keys (alternate spellings such as ``jlc``, ``lcsc``,
+    ``jlcpcb_tier1``, ``jlcpcb-capabilityplus``, ...). This is the
+    correct ``choices=`` source for argparse ``--mfr`` flags: it accepts
+    every spelling the registry resolves, mirroring the router's CLI
+    behaviour.
+
+    See issue #2793 for why ``get_manufacturer_ids()`` alone is not
+    sufficient (it returns canonicals only, silently rejecting valid
+    aliases such as ``jlcpcb_tier1`` at argparse-time before
+    ``get_profile()`` is ever called).
+
+    Returns:
+        Sorted list of every manufacturer name and alias.
+    """
+    return sorted(set(_PROFILES.keys()) | set(_ALIASES.keys()))
 
 
 def compare_design_rules(

--- a/tests/test_manufacturer_registry_sync.py
+++ b/tests/test_manufacturer_registry_sync.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 import contextlib
 import io
 
+import pytest
+
 from kicad_tools.manufacturers import (
     _ALIASES as DRC_ALIASES,
 )
@@ -29,6 +31,7 @@ from kicad_tools.manufacturers import (
     _PROFILES as DRC_PROFILES,
 )
 from kicad_tools.manufacturers import (
+    get_all_manufacturer_names,
     get_profile,
 )
 from kicad_tools.router.mfr_limits import (
@@ -265,3 +268,153 @@ class TestJLCPCBTier1DRCProfile:
         assert "Capability" in profile.name or "Plus" in profile.name, (
             f"jlcpcb-tier1 profile name should reference Capability Plus, got {profile.name!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# CLI <-> registry parity (issue #2793)
+# ---------------------------------------------------------------------------
+#
+# Each entry below is one ``--mfr`` site in the top-level argparse tree:
+#
+# - ``argv``: the argv prefix needed to reach that subcommand's parser
+#   (positional args use dummy paths; argparse only needs the right shape).
+# - ``mfr_attr``: the attribute name on the parsed Namespace that carries
+#   the manufacturer value (most are ``mfr``; some have unique dest names
+#   to avoid collisions in the shared top-level Namespace).
+#
+# When adding a new ``--mfr`` site to the top-level parser, append it here
+# so the parametrised parity tests cover it.  See ``parser.py`` and the
+# Curator analysis in issue #2793 for the full inventory.
+CLI_MFR_SITES: list[tuple[str, list[str], str]] = [
+    ("drc", ["drc", "dummy.rpt"], "mfr"),
+    ("check", ["check", "dummy.kicad_pcb"], "mfr"),
+    ("fix-vias", ["fix-vias", "dummy.kicad_pcb"], "mfr"),
+    ("fix-silkscreen", ["fix-silkscreen", "dummy.kicad_pcb"], "mfr"),
+    ("repair-clearance", ["repair-clearance", "dummy.kicad_pcb"], "mfr"),
+    ("estimate cost", ["estimate", "cost", "dummy.kicad_pcb"], "mfr"),
+    ("audit", ["audit", "dummy.kicad_pro"], "audit_mfr"),
+    ("pipeline", ["pipeline", "dummy.kicad_pcb"], "pipeline_mfr"),
+    ("build", ["build", "dummy.kicad_pcb"], "build_mfr"),
+    ("export", ["export", "dummy.kicad_pcb"], "export_mfr"),
+]
+
+
+class TestCLIRegistryParity:
+    """CLI argparse <-> manufacturer registry parity (issue #2793).
+
+    Every ``--mfr`` argparse site in the top-level kicad-tools parser must
+    accept every name and alias the manufacturer registry resolves.  This
+    is the drift-prevention test that would have caught the #2793 bug
+    (e.g. ``kct check --mfr jlcpcb-tier1`` rejected at argparse time even
+    though ``get_profile('jlcpcb-tier1')`` works).
+    """
+
+    @pytest.mark.parametrize(
+        "label, argv_prefix, mfr_attr",
+        CLI_MFR_SITES,
+        ids=[label for label, _, _ in CLI_MFR_SITES],
+    )
+    @pytest.mark.parametrize(
+        "name",
+        sorted(set(DRC_PROFILES.keys()) | set(DRC_ALIASES.keys())),
+    )
+    def test_every_cli_site_accepts_every_registered_name(self, label, argv_prefix, mfr_attr, name):
+        """Every registered manufacturer name parses on every CLI ``--mfr`` site."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        argv = [*argv_prefix, "--mfr", name]
+        try:
+            ns = parser.parse_args(argv)
+        except SystemExit as exc:  # argparse calls sys.exit(2) on choice mismatch
+            pytest.fail(
+                f"CLI site {label!r} rejected registered manufacturer "
+                f"name {name!r} (argv={argv!r}, SystemExit({exc.code})). "
+                f"This is the #2793 / #2622 class of bug: top-level argparse "
+                f"choices= list drifted from the registry."
+            )
+
+        actual = getattr(ns, mfr_attr, None)
+        assert actual == name, (
+            f"CLI site {label!r} parsed --mfr {name!r} but Namespace.{mfr_attr} "
+            f"was {actual!r}.  Either the dest changed or argparse swallowed the value."
+        )
+
+    @pytest.mark.parametrize(
+        "label, argv_prefix, mfr_attr",
+        CLI_MFR_SITES,
+        ids=[label for label, _, _ in CLI_MFR_SITES],
+    )
+    def test_every_cli_site_rejects_bogus_manufacturer(self, label, argv_prefix, mfr_attr):
+        """An unknown manufacturer name still raises SystemExit on every site."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        argv = [*argv_prefix, "--mfr", "completely-bogus-mfr-name-xyz"]
+        with pytest.raises(SystemExit) as excinfo:
+            parser.parse_args(argv)
+        # argparse uses exit code 2 for argument errors.
+        assert excinfo.value.code == 2, (
+            f"CLI site {label!r} did not raise SystemExit(2) for a bogus "
+            f"--mfr value (got code={excinfo.value.code!r})."
+        )
+
+    def test_export_still_accepts_generic(self):
+        """The ``export`` subcommand keeps its ``generic`` sentinel alongside registry names."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        ns = parser.parse_args(["export", "dummy.kicad_pcb", "--mfr", "generic"])
+        assert ns.export_mfr == "generic", (
+            "kct export --mfr generic must still parse: 'generic' is a "
+            "non-registry sentinel for vendor-agnostic gerber export."
+        )
+
+    def test_get_all_manufacturer_names_covers_profiles_and_aliases(self):
+        """``get_all_manufacturer_names()`` returns canonicals UNION aliases."""
+        names = set(get_all_manufacturer_names())
+        expected = set(DRC_PROFILES.keys()) | set(DRC_ALIASES.keys())
+        assert names == expected, (
+            f"get_all_manufacturer_names() drifted from "
+            f"_PROFILES | _ALIASES.\n  missing:  {sorted(expected - names)}\n"
+            f"  extra:    {sorted(names - expected)}"
+        )
+
+    def test_flashpcb_is_selectable_from_cli(self):
+        """``flashpcb`` is callable from every CLI site that has a ``--mfr`` flag.
+
+        Curator note from issue #2793: ``flashpcb`` was silently inaccessible
+        from the CLI before this fix despite being a fully registered profile.
+        """
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        for label, argv_prefix, mfr_attr in CLI_MFR_SITES:
+            ns = parser.parse_args([*argv_prefix, "--mfr", "flashpcb"])
+            assert getattr(ns, mfr_attr) == "flashpcb", (
+                f"CLI site {label!r} did not surface --mfr flashpcb on Namespace.{mfr_attr}"
+            )
+
+    def test_tier1_aliases_parse_on_every_cli_site(self):
+        """All four jlcpcb-tier1 aliases parse on every CLI ``--mfr`` site.
+
+        This is the direct regression test for the user-visible #2793 symptom:
+        ``kct check board.kicad_pcb --mfr jlcpcb-tier1`` was rejected before
+        this fix.
+        """
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        tier1_names = [
+            "jlcpcb-tier1",
+            "jlcpcb_tier1",
+            "jlcpcb-capabilityplus",
+            "jlcpcb_capabilityplus",
+            "jlcpcb-capability-plus",
+        ]
+        for label, argv_prefix, mfr_attr in CLI_MFR_SITES:
+            for name in tier1_names:
+                ns = parser.parse_args([*argv_prefix, "--mfr", name])
+                assert getattr(ns, mfr_attr) == name, (
+                    f"CLI site {label!r} did not surface --mfr {name!r} on Namespace.{mfr_attr}"
+                )


### PR DESCRIPTION
Closes #2793.

## Summary

Replaces hardcoded `choices=["jlcpcb", "pcbway", "oshpark", "seeed"]` lists at all **15** `--mfr` argparse sites with a registry-derived helper. This fixes the user-visible symptom of #2793 (and the architectural ancestor #2622): `kct check board.kicad_pcb --mfr jlcpcb-tier1` was rejected at argparse time even though `get_profile('jlcpcb-tier1')` works correctly downstream.

## Changes

- **New registry helper**: `get_all_manufacturer_names()` in `kicad_tools.manufacturers` returning `sorted(_PROFILES | _ALIASES)` — the union of canonical IDs and every alias (`jlcpcb_tier1`, `jlcpcb-capabilityplus`, `jlc`, `lcsc`, `osh`, ...) — i.e. every spelling that `get_profile()` resolves.
- **10 parser.py sites** (`drc`, `check`, `fix-vias`, `fix-silkscreen`, `repair-clearance`, `estimate cost`, `audit`, `pipeline`, `build`, `export`) updated from the hardcoded 4-element list to `choices=get_all_manufacturer_names()`.
- **5 per-command modules** (`export_cmd.py`, `fix_silkscreen_cmd.py`, `pipeline_cmd.py`, `build_cmd.py`, `fix_vias_cmd.py`) also updated — they mirror the top-level argparse shape when invoked directly.
- **Export sites** preserve the `"generic"` non-registry sentinel via `choices=[*get_all_manufacturer_names(), "generic"]`.

## Side benefits

- **`flashpcb` is now selectable from every `--mfr` site.** It was registered in `_PROFILES` but silently inaccessible from the CLI before this fix.
- All four `jlcpcb-tier1` router aliases (`jlcpcb_tier1`, `jlcpcb-capabilityplus`, `jlcpcb_capabilityplus`, `jlcpcb-capability-plus`) are accepted everywhere — restoring router/DRC CLI parity that's been silently broken since #2622.

## Drift prevention (new tests)

Extends `tests/test_manufacturer_registry_sync.py` with a `TestCLIRegistryParity` class:
- Parametrised matrix: **every CLI `--mfr` site × every name in `_PROFILES | _ALIASES`** — 190 combinations.
- Each combination must parse without `SystemExit`, and the parsed Namespace must surface the value on the correct `dest`.
- Bogus names still raise `SystemExit(2)` on every site (negative test).
- Dedicated regression assertions for: `--mfr generic` on export, `flashpcb` on every site, all 5 tier-1 spellings on every site.

This is the drift-prevention test that would have caught **both #2622 and #2793** at PR time, and will catch the next instance of the same class of bug.

## Test plan

- [x] `uv run pytest tests/test_manufacturer_registry_sync.py` — **215 passed**.
- [x] `uv run pytest tests/test_mfr.py tests/test_mfr_limits.py tests/test_manufacturer_preset.py tests/test_manufacturer_registry_sync.py` — **335 passed**, 2 skipped.
- [x] `uv run pytest tests/test_cli_check.py tests/test_cli_commands.py` — **71 passed**.
- [x] `uv run ruff check` and `uv run ruff format --check` on the 8 changed files — clean.
- [x] Smoke-tested every site via `create_parser().parse_args([...])` for `jlcpcb-tier1`, `jlcpcb_tier1`, `flashpcb`, `generic` — all parse correctly with the right Namespace dest values.

## Notes

- **Pre-existing failures (not introduced by this PR)**: `tests/test_manufacturer_propagation_lint.py` has 2 failures pointing at `router/io.py:2715/2718` allowlist drift, and `tests/test_cli.py::TestFootprintGenerateCommand::*` has 7 failures about a stale footprint DSL CLI. Both reproduce on `main` without my changes — they're orthogonal to #2793.
- **Files NOT touched (correctly)**: `cli/bom_cmd.py:70` and `cli/parser.py:366` use the literal `"jlcpcb"` as a **BOM output format value**, not a manufacturer ID — Curator flagged these explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)