### PR TITLE
feat(router): add progress_callback for targeted_ripup visibility (closes #2795)

### DIFF
--- a/src/kicad_tools/router/algorithms/negotiated.py
+++ b/src/kicad_tools/router/algorithms/negotiated.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import random
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
     from ..congestion_estimator import CongestionEstimator
@@ -22,6 +22,10 @@ if TYPE_CHECKING:
     from ..pathfinder import Router
     from ..primitives import Pad, Route, Via
     from ..rules import DesignRules, NetClassRouting
+
+# Issue #2795: progress callback signature for visibility into long-running
+# rip-up operations.  Callback receives a phase string and a metadata dict.
+ProgressCallback = Callable[[str, dict], None]
 
 
 # =========================================================================
@@ -1144,6 +1148,8 @@ class NegotiatedRouter:
         ripup_history: dict[int, int] | None = None,
         max_ripups_per_net: int = 3,
         per_net_timeout: float | None = None,
+        progress_callback: ProgressCallback | None = None,
+        net_names: dict[int, str] | None = None,
     ) -> bool:
         """Perform targeted rip-up of blocking nets and re-route.
 
@@ -1164,6 +1170,19 @@ class NegotiatedRouter:
             max_ripups_per_net: Maximum times a net can be ripped up (prevents loops)
             per_net_timeout: Optional wall-clock timeout in seconds for each
                 A* search (Issue #1605)
+            progress_callback: Optional callback invoked before each
+                ``route_net_negotiated`` call (failed net + each sibling).
+                Receives ``(phase_label, info_dict)`` where ``info_dict``
+                contains ``phase`` ("failed_net" or "sibling"), ``net``
+                (net id), ``net_name`` (resolved via ``net_names``), ``index``
+                (1-indexed position), ``total`` (failed net + siblings count),
+                and ``elapsed`` (seconds since this call started).  Issue #2795:
+                used by ``_attempt_blocked_component_ripup_negotiated`` to
+                surface progress during what would otherwise be a silent
+                multi-minute operation.
+            net_names: Optional net-id-to-name mapping used to resolve human
+                readable net names for the ``progress_callback`` payload.
+                Falls back to ``Net_<id>`` when missing or absent.
 
         Returns:
             True if re-routing succeeded for all affected nets, False otherwise
@@ -1187,10 +1206,39 @@ class NegotiatedRouter:
         # Rip up only the blocking nets
         self.rip_up_nets(list(nets_to_ripup), net_routes, routes_list)
 
+        # Issue #2795: emit progress before each long-running A* invocation.
+        # Total work units = 1 (failed net) + N siblings, so index runs 1..total.
+        total_steps = 1 + len(nets_to_ripup)
+        start_time = time.time()
+
+        def _emit_progress(phase: str, net_id: int, index: int) -> None:
+            if progress_callback is None:
+                return
+            if net_names is not None:
+                resolved_name = net_names.get(net_id, f"Net_{net_id}")
+            else:
+                resolved_name = f"Net_{net_id}"
+            try:
+                progress_callback(
+                    "ripup_phase",
+                    {
+                        "phase": phase,
+                        "net": net_id,
+                        "net_name": resolved_name,
+                        "index": index,
+                        "total": total_steps,
+                        "elapsed": time.time() - start_time,
+                    },
+                )
+            except Exception:
+                # Never let a buggy progress callback abort the rip-up.
+                pass
+
         # Re-route the failed net first (it now has priority with cleared path)
         failed_pads = pads_by_net.get(failed_net, [])
         failed_net_success = False  # Issue #858: Track if failed net was routed
         if failed_pads and len(failed_pads) >= 2:
+            _emit_progress("failed_net", failed_net, 1)
             routes = self.route_net_negotiated(
                 failed_pads, present_cost_factor, mark_route_callback,
                 per_net_timeout=per_net_timeout,
@@ -1204,9 +1252,12 @@ class NegotiatedRouter:
 
         # Re-route the displaced nets
         success = failed_net_success  # Issue #858: Start with failed net success
-        for net in nets_to_ripup:
+        # Sort for deterministic progress ordering (set iteration is unordered).
+        sibling_order = sorted(nets_to_ripup)
+        for sibling_index, net in enumerate(sibling_order, start=2):
             net_pads = pads_by_net.get(net, [])
             if net_pads and len(net_pads) >= 2:
+                _emit_progress("sibling", net, sibling_index)
                 routes = self.route_net_negotiated(
                     net_pads, present_cost_factor, mark_route_callback,
                     per_net_timeout=per_net_timeout,

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -3636,6 +3636,29 @@ class Autorouter:
         # whether targeted_ripup actually placed new routes for it.
         pre_failed_routes = len(net_routes.get(failed_net, []))
 
+        # Issue #2795: emit per-sibling progress so users can distinguish a
+        # stuck router from one making slow progress.  Previously the whole
+        # targeted_ripup invocation could silently consume (1+N)*per_net_timeout
+        # wall-clock seconds with zero output between the entry banner and
+        # the exit line.
+        def _progress(phase_label: str, info: dict) -> None:
+            phase = info.get("phase", "")
+            net_name_info = info.get("net_name", "?")
+            idx = info.get("index", 0)
+            total = info.get("total", 0)
+            elapsed = info.get("elapsed", 0.0)
+            if phase == "failed_net":
+                action = f"routing failed net {failed_name}"
+            else:
+                action = f"routing sibling {net_name_info}"
+            flush_print(
+                f"    rip-up [{idx}/{total}] for {failed_name}: "
+                f"{action} (elapsed {elapsed:.1f}s)"
+            )
+
+        import time
+
+        ripup_start = time.time()
         try:
             success = neg_router.targeted_ripup(
                 failed_net=failed_net,
@@ -3648,6 +3671,8 @@ class Autorouter:
                 ripup_history=ripup_history,
                 max_ripups_per_net=max_ripups_per_net,
                 per_net_timeout=per_net_timeout,
+                progress_callback=_progress,
+                net_names=self.net_names,
             )
         except Exception as exc:  # pragma: no cover - defensive
             flush_print(
@@ -3655,6 +3680,8 @@ class Autorouter:
                 f"{type(exc).__name__}: {exc}"
             )
             return False
+
+        total_elapsed = time.time() - ripup_start
 
         # Did targeted_ripup actually attach new routes for the failed net?
         post_failed_routes = len(net_routes.get(failed_net, []))
@@ -3666,10 +3693,14 @@ class Autorouter:
             self.routing_failures = [
                 f for f in self.routing_failures if f.net != failed_net
             ]
+            flush_print(
+                f"  BLOCKED_BY_COMPONENT rip-up (negotiated) for {failed_name}: "
+                f"rescued in {total_elapsed:.1f}s"
+            )
         elif not success:
             flush_print(
                 f"  BLOCKED_BY_COMPONENT rip-up (negotiated) for {failed_name}: "
-                f"reroute did not converge"
+                f"reroute did not converge (elapsed {total_elapsed:.1f}s)"
             )
         return rescued
 

--- a/tests/test_negotiated_adaptive.py
+++ b/tests/test_negotiated_adaptive.py
@@ -2243,6 +2243,8 @@ class TestAttemptBlockedComponentRipupNegotiated:
             ripup_history=None,
             max_ripups_per_net=3,
             per_net_timeout=None,
+            progress_callback=None,
+            net_names=None,
         ):
             new_route = Route(net=failed_net, net_name="DAC_CLK", segments=[], vias=[])
             net_routes.setdefault(failed_net, []).append(new_route)

--- a/tests/test_reroute_progress_output.py
+++ b/tests/test_reroute_progress_output.py
@@ -3,6 +3,12 @@
 These tests verify that flush_print is called with per-net progress messages
 during both the targeted and full rip-up reroute loops in route_all_negotiated(),
 and during two-phase rip-up reroute iterations (Issue #2318).
+
+Issue #2795 adds tests for visibility into ``NegotiatedRouter.targeted_ripup``
+itself when invoked from ``_attempt_blocked_component_ripup_negotiated``:
+the rip-up of N siblings + the failed-net reroute is N+1 sequential A* calls
+that previously emitted zero log lines mid-flight, causing chorus-test runs
+to look hung for many minutes.
 """
 
 import re
@@ -643,3 +649,280 @@ class TestTwoPhaseRerouteProgressOutput:
             f"Expected no 'Re-routing net' messages when nets_to_reroute is empty, "
             f"but found {len(reroute_msgs)}: {reroute_msgs}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #2795: targeted_ripup progress-callback visibility tests
+# ---------------------------------------------------------------------------
+
+
+def _make_router_with_three_nets():
+    """Three-net variant of ``_make_router_with_two_nets`` for rip-up tests.
+
+    Constructs an :class:`Autorouter` with three two-pin nets so we can
+    exercise the ``targeted_ripup(failed_net, blocking_nets={B, C})`` shape
+    that produces 1 + 2 = 3 sequential ``route_net_negotiated`` calls.
+    """
+    router = Autorouter(width=60.0, height=40.0)
+    # Net 1: failed net (A)
+    pads_a = [
+        {"number": "1", "x": 5.0, "y": 20.0, "width": 0.5, "height": 0.5, "net": 1, "net_name": "A"},
+        {"number": "2", "x": 25.0, "y": 20.0, "width": 0.5, "height": 0.5, "net": 1, "net_name": "A"},
+    ]
+    router.add_component("U1", pads_a)
+    # Net 2: sibling (B) - crosses A's path
+    pads_b = [
+        {"number": "1", "x": 12.0, "y": 15.0, "width": 0.5, "height": 0.5, "net": 2, "net_name": "B"},
+        {"number": "2", "x": 12.0, "y": 25.0, "width": 0.5, "height": 0.5, "net": 2, "net_name": "B"},
+    ]
+    router.add_component("U2", pads_b)
+    # Net 3: sibling (C)
+    pads_c = [
+        {"number": "1", "x": 18.0, "y": 15.0, "width": 0.5, "height": 0.5, "net": 3, "net_name": "C"},
+        {"number": "2", "x": 18.0, "y": 25.0, "width": 0.5, "height": 0.5, "net": 3, "net_name": "C"},
+    ]
+    router.add_component("U3", pads_c)
+    return router
+
+
+def _build_pads_by_net(router):
+    """Group router pads by net id (mirroring the runtime structure).
+
+    ``router.pads`` is a dict mapping pad-id to Pad; ``router.nets`` maps
+    net-id to list of pad-ids.  This mirrors the lookup used by
+    ``route_all_negotiated`` when it constructs ``pads_by_net``.
+    """
+    pads_by_net: dict[int, list] = {}
+    for net_id, pad_ids in router.nets.items():
+        if net_id == 0:
+            continue
+        pads_by_net[net_id] = [router.pads[p] for p in pad_ids]
+    return pads_by_net
+
+
+class TestTargetedRipupProgressCallback:
+    """Issue #2795: progress_callback fires N+1 times per targeted_ripup call.
+
+    These tests focus on the *inner* loop (``NegotiatedRouter.targeted_ripup``).
+    They stub ``route_net_negotiated`` so no actual A* is run; we only verify
+    the callback contract and the resulting flush_print output when the
+    callback is the one supplied by ``_attempt_blocked_component_ripup_negotiated``.
+    """
+
+    def test_progress_callback_invoked_per_step(self):
+        """Callback fires once for failed net + once for each sibling (=N+1)."""
+        router = _make_router_with_three_nets()
+        # Build a NegotiatedRouter mirroring the one constructed inside route_all.
+        neg_router = NegotiatedRouter(
+            grid=router.grid,
+            router=router.router,
+            rules=router.rules,
+            net_class_map={},
+        )
+        pads_by_net = _build_pads_by_net(router)
+        # Pre-populate net_routes with stub Route objects so rip_up_nets has
+        # something to clear; the exact content doesn't matter because we
+        # mock route_net_negotiated.
+        net_routes: dict[int, list] = {2: [], 3: []}
+        routes_list: list = []
+
+        callback = MagicMock()
+
+        # Stub route_net_negotiated to return [] so we don't run A*.  The
+        # progress callback fires BEFORE each call, so we still see N+1
+        # invocations even though no routes are produced.
+        with (
+            patch.object(NegotiatedRouter, "route_net_negotiated", return_value=[]),
+            patch.object(NegotiatedRouter, "rip_up_nets"),
+        ):
+            neg_router.targeted_ripup(
+                failed_net=1,
+                blocking_nets={2, 3},
+                net_routes=net_routes,
+                routes_list=routes_list,
+                pads_by_net=pads_by_net,
+                present_cost_factor=1.0,
+                mark_route_callback=lambda r: None,
+                ripup_history={},
+                max_ripups_per_net=3,
+                progress_callback=callback,
+                net_names={1: "A", 2: "B", 3: "C"},
+            )
+
+        # 1 failed-net + 2 siblings = 3 callback invocations.
+        assert callback.call_count == 3, (
+            f"Expected 3 progress_callback invocations (1 failed + 2 siblings), "
+            f"got {callback.call_count}"
+        )
+
+        # Inspect each call's payload.
+        phases_seen = []
+        for call_args in callback.call_args_list:
+            label, info = call_args.args
+            assert label == "ripup_phase", f"Unexpected label {label}"
+            assert "phase" in info
+            assert "net_name" in info
+            assert "index" in info
+            assert "total" in info
+            assert "elapsed" in info
+            assert info["total"] == 3
+            phases_seen.append(info["phase"])
+
+        # First payload is the failed-net retry; remaining are siblings.
+        assert phases_seen[0] == "failed_net"
+        assert phases_seen[1] == "sibling"
+        assert phases_seen[2] == "sibling"
+
+        # Index is 1-indexed against total.
+        indices = [c.args[1]["index"] for c in callback.call_args_list]
+        assert indices == [1, 2, 3], f"Expected indices [1,2,3], got {indices}"
+
+        # Net names propagate from the net_names map.
+        names = [c.args[1]["net_name"] for c in callback.call_args_list]
+        assert names[0] == "A"
+        assert set(names[1:]) == {"B", "C"}
+
+    def test_progress_callback_optional_no_regression(self):
+        """When progress_callback=None (default), no exception and no calls."""
+        router = _make_router_with_three_nets()
+        neg_router = NegotiatedRouter(
+            grid=router.grid,
+            router=router.router,
+            rules=router.rules,
+            net_class_map={},
+        )
+        pads_by_net = _build_pads_by_net(router)
+        net_routes: dict[int, list] = {2: [], 3: []}
+
+        with (
+            patch.object(NegotiatedRouter, "route_net_negotiated", return_value=[]),
+            patch.object(NegotiatedRouter, "rip_up_nets"),
+        ):
+            # Should not raise; existing call sites pass no callback.
+            neg_router.targeted_ripup(
+                failed_net=1,
+                blocking_nets={2, 3},
+                net_routes=net_routes,
+                routes_list=[],
+                pads_by_net=pads_by_net,
+                present_cost_factor=1.0,
+                mark_route_callback=lambda r: None,
+                ripup_history={},
+                max_ripups_per_net=3,
+            )
+
+    def test_progress_callback_exception_does_not_break_ripup(self):
+        """A buggy callback raising must not abort the rip-up."""
+        router = _make_router_with_three_nets()
+        neg_router = NegotiatedRouter(
+            grid=router.grid,
+            router=router.router,
+            rules=router.rules,
+            net_class_map={},
+        )
+        pads_by_net = _build_pads_by_net(router)
+        net_routes: dict[int, list] = {2: [], 3: []}
+
+        def bad_callback(phase, info):
+            raise RuntimeError("boom")
+
+        with (
+            patch.object(NegotiatedRouter, "route_net_negotiated", return_value=[]),
+            patch.object(NegotiatedRouter, "rip_up_nets"),
+        ):
+            # Should not raise despite callback throwing each call.
+            neg_router.targeted_ripup(
+                failed_net=1,
+                blocking_nets={2, 3},
+                net_routes=net_routes,
+                routes_list=[],
+                pads_by_net=pads_by_net,
+                present_cost_factor=1.0,
+                mark_route_callback=lambda r: None,
+                ripup_history={},
+                max_ripups_per_net=3,
+                progress_callback=bad_callback,
+                net_names={1: "A", 2: "B", 3: "C"},
+            )
+
+
+class TestAttemptBlockedComponentRipupNegotiatedLogging:
+    """Issue #2795: ``_attempt_blocked_component_ripup_negotiated`` emits
+    per-sibling flush_print lines so users can tell progress from a hang.
+    """
+
+    def test_per_sibling_flush_print_lines_with_index_and_elapsed(self):
+        """Each rip-up step emits ``rip-up [i/N] for <failed>:`` with elapsed time."""
+        router = _make_router_with_three_nets()
+        neg_router = NegotiatedRouter(
+            grid=router.grid,
+            router=router.router,
+            rules=router.rules,
+            net_class_map={},
+        )
+        pads_by_net = _build_pads_by_net(router)
+        net_routes: dict[int, list] = {2: [], 3: []}
+
+        flush_print_calls: list[str] = []
+
+        # Simulate the call-site shape used by
+        # ``_attempt_blocked_component_ripup_negotiated``: the same closure,
+        # the same flush_print module path.
+        failed_name = router.net_names.get(1, "Net_1")
+
+        def _progress(phase_label, info):
+            from kicad_tools.cli.progress import flush_print as _fp
+
+            phase = info["phase"]
+            if phase == "failed_net":
+                action = f"routing failed net {failed_name}"
+            else:
+                action = f"routing sibling {info['net_name']}"
+            _fp(
+                f"    rip-up [{info['index']}/{info['total']}] for {failed_name}: "
+                f"{action} (elapsed {info['elapsed']:.1f}s)"
+            )
+
+        def tracking_flush_print(msg):
+            flush_print_calls.append(msg)
+
+        with (
+            patch.object(NegotiatedRouter, "route_net_negotiated", return_value=[]),
+            patch.object(NegotiatedRouter, "rip_up_nets"),
+            patch("kicad_tools.cli.progress.flush_print", side_effect=tracking_flush_print),
+        ):
+            neg_router.targeted_ripup(
+                failed_net=1,
+                blocking_nets={2, 3},
+                net_routes=net_routes,
+                routes_list=[],
+                pads_by_net=pads_by_net,
+                present_cost_factor=1.0,
+                mark_route_callback=lambda r: None,
+                ripup_history={},
+                max_ripups_per_net=3,
+                progress_callback=_progress,
+                net_names=router.net_names,
+            )
+
+        ripup_msgs = [m for m in flush_print_calls if "rip-up [" in m]
+        assert len(ripup_msgs) == 3, (
+            f"Expected 3 rip-up progress lines (1 failed + 2 siblings), "
+            f"got {len(ripup_msgs)}: {flush_print_calls}"
+        )
+        # Each message follows the [i/N] for FAILED: action (elapsed Xs) shape.
+        for msg in ripup_msgs:
+            assert re.search(r"rip-up \[\d+/3\] for", msg), (
+                f"Expected '[i/3] for' counter in: {msg}"
+            )
+            assert re.search(r"elapsed \d+\.\d+s", msg), (
+                f"Expected 'elapsed N.Ns' in: {msg}"
+            )
+
+        # Counters increase 1..3.
+        counters = []
+        for msg in ripup_msgs:
+            m = re.search(r"\[(\d+)/3\]", msg)
+            assert m is not None
+            counters.append(int(m.group(1)))
+        assert counters == [1, 2, 3], f"Expected ordered [1,2,3], got {counters}"


### PR DESCRIPTION
## Summary

- Adds optional `progress_callback` and `net_names` parameters to `NegotiatedRouter.targeted_ripup` (logging-only, no behaviour change).
- Wires up `_attempt_blocked_component_ripup_negotiated` to emit `flush_print` lines per rip-up step, plus an augmented exit summary with total elapsed time and outcome.
- Sorts sibling iteration for deterministic progress ordering.
- New 3-net test fixture in `tests/test_reroute_progress_output.py` covers callback contract, optional-default behaviour, and the call-site flush_print format.

Fixes the silent-rip-up gap reported on chorus-test where `targeted_ripup` with N=11 siblings consumed up to ~360 s with zero output between the entry banner and the exit line, making the router indistinguishable from a hung process and forcing SIGINT termination of the rotation-fix hypothesis experiment.

## Scope discipline

Per the Curator analysis on #2795 this PR is intentionally logging-only:

- **No** stall detection / per-sibling cap — to be filed as a follow-up issue (e.g. `router: bound targeted_ripup wall-clock budget via per-sibling cap or per-event timeout`).
- **No** `--ripup-timeout` CLI flag — also a follow-up.
- The three other call sites of `targeted_ripup` (`core.py:3484`, `5183`, `5638`) continue to pass no callback, minimising blast radius.

## Test plan

- [x] `pytest tests/test_reroute_progress_output.py` — 12 pass (4 new + 8 existing)
- [x] `pytest tests/test_negotiated_adaptive.py` — 120 pass (one strict-signature fake updated to accept the new kwargs)
- [x] Broader router-test sweep (`test_negotiated_*`, `test_neighborhood_ripup`, `test_route_all_negotiated_partial_state`, `test_router_negotiated_high_current`) — 194 pass total
- [x] Verified pre-existing failure in `test_router_core.py::TestAdaptiveAutorouterComponentTransform::test_add_component_rotation` is unrelated to this change (fails on baseline `5c8b511a` with no edits)
- [ ] After this lands and #2794 lands, re-run the chorus-test rotation-fix experiment to confirm the rip-up phase now produces actionable progress logs

## Follow-up

I will file `router: stall-detection + per-sibling cap for targeted_ripup` as a separate issue so this visibility patch can ship independently of the budget-tuning design discussion.

Closes #2795

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>