### PR TITLE
fix(cli): remove broken DSL-spec shim from footprint generate (closes #2801)

### DIFF
--- a/src/kicad_tools/cli/footprint_generate.py
+++ b/src/kicad_tools/cli/footprint_generate.py
@@ -301,72 +301,8 @@ def _output_footprint(fp, args) -> int:
         return 0
 
 
-def _try_dsl_generate(argv: list[str]) -> int | None:
-    """Try to interpret the first positional argument as a DSL spec string.
-
-    Returns exit code if handled, None if not a DSL string.
-    """
-    from kicad_tools.library.dsl import parse_footprint_dsl
-
-    # Known subcommands that should NOT be treated as DSL strings
-    known_subcommands = {"soic", "qfp", "qfn", "chip", "sot", "dip", "pin-header"}
-
-    # Find the first positional argument (skip flags)
-    dsl_spec = None
-    remaining = []
-    found_positional = False
-    for arg in argv:
-        if not found_positional and not arg.startswith("-") and arg not in known_subcommands:
-            dsl_spec = arg
-            found_positional = True
-        else:
-            remaining.append(arg)
-
-    if dsl_spec is None:
-        return None
-
-    # Parse remaining flags for output options
-    dsl_parser = argparse.ArgumentParser(prog="kct footprint generate <dsl-spec>")
-    dsl_parser.add_argument("-o", "--output", help="Output file path")
-    dsl_parser.add_argument(
-        "--json", action="store_true", help="Output as JSON"
-    )
-    dsl_parser.add_argument("--prefix", help="Component prefix (R, C, L)")
-    dsl_parser.add_argument("--name", help="Custom footprint name")
-
-    try:
-        dsl_args = dsl_parser.parse_args(remaining)
-    except SystemExit:
-        return 1
-
-    try:
-        fp = parse_footprint_dsl(dsl_spec)
-    except ValueError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        return 1
-
-    # Use a namespace compatible with _output_footprint
-    dsl_args.json = dsl_args.json
-    return _output_footprint(fp, dsl_args)
-
-
 def main(argv: list[str] | None = None) -> int:
     """Main entry point for footprint generate command."""
-    # Try DSL shorthand first (e.g., "kct footprint generate soic8")
-    if argv is not None and argv:
-        dsl_result = _try_dsl_generate(argv)
-        if dsl_result is not None:
-            return dsl_result
-    elif argv is None:
-        # When called from sys.argv, check sys.argv[1:]
-        import sys as _sys
-
-        real_argv = _sys.argv[1:]
-        if real_argv:
-            dsl_result = _try_dsl_generate(real_argv)
-            if dsl_result is not None:
-                return dsl_result
-
     parser = argparse.ArgumentParser(
         prog="kct footprint generate",
         description="Generate parametric KiCad footprints",

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1885,11 +1885,12 @@ def _add_footprint_parser(subparsers) -> None:
         dest="footprint_command", help="Footprint commands"
     )
 
-    # footprint generate - delegates to footprint_generate.py for subcommands
+    # footprint generate - dispatched in cli/__init__.py to footprint_generate.main,
+    # which owns its own subparser tree (soic/qfp/qfn/chip/sot/dip/pin-header).
     footprint_subparsers.add_parser(
         "generate",
         help="Generate parametric footprints",
-        add_help=False,  # Let footprint_generate handle help
+        add_help=False,  # Let footprint_generate handle --help itself
     )
 
 


### PR DESCRIPTION
## Summary

Deletes the broken `_try_dsl_generate` shim from `src/kicad_tools/cli/footprint_generate.py`. The shim's positional-scanning loop captured flag values (`8` from `--pins 8`, `0402` from `--size 0402`) as DSL specs while leaking `[\"<subcmd>\", \"--flag\"]` to the DSL argparser, causing \"unrecognized arguments\" for every documented subcommand invocation.

Per Curator analysis on #2801:
- 10 of 14 `TestFootprintGenerateCommand` tests were failing on `main`
- Zero production callers of the DSL-spec CLI form (docs, `--list`, board scripts only document the subcommand form)
- The shim was added speculatively in #2367 and never documented as a CLI surface

The library API `parse_footprint_dsl` is untouched and continues to be exercised by `tests/test_footprint_dsl.py` (60 tests).

## Changes

- `src/kicad_tools/cli/footprint_generate.py` — delete `_try_dsl_generate` function and its dispatch block at the top of `main()`
- `src/kicad_tools/cli/parser.py` — clarify the comment on the `add_help=False` stub so it reflects the new (subcommand-only) reality

## Test plan

- [x] `uv run pytest tests/test_cli.py::TestFootprintGenerateCommand` — 14/14 pass (was 4/14)
- [x] `uv run pytest tests/test_footprint_dsl.py` — 60/60 pass (library API survives)
- [x] `uv run pytest tests/test_cli.py` — 50/50 pass (no other CLI regressions)
- [x] Subprocess sanity: `uv run kct footprint generate soic --pins 8` produces SOIC-8 footprint on stdout
- [x] Subprocess sanity: `uv run kct footprint generate --list` works
- [x] `uv run ruff check` — clean

Closes #2801