### PR TITLE
fix(router): plumb timeout through 3 route_all wrappers (closes #2800)

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -4082,6 +4082,8 @@ class Autorouter:
         max_iterations: int = 10,
         profile: CostProfile | str | None = None,
         progress_callback: ProgressCallback | None = None,
+        timeout: float | None = None,
+        per_net_timeout: float | None = None,
     ) -> list[Route]:
         """Route all nets with auto-tuned cost parameters.
 
@@ -4100,6 +4102,12 @@ class Autorouter:
                 - String: "sparse", "standard", "dense", "minimize_vias",
                   "minimize_length", "high_speed"
             progress_callback: Optional callback for progress updates
+            timeout: Optional outer wall-clock budget in seconds, forwarded
+                to the underlying ``route_all`` (Issue #2800).  ``None``
+                preserves legacy behaviour.
+            per_net_timeout: Optional advisory per-net wall-clock budget,
+                forwarded to ``route_all`` (Issue #2800).  Suppresses the
+                "no timeout supplied" warning when present.
 
         Returns:
             List of Route objects for all nets
@@ -4126,7 +4134,13 @@ class Autorouter:
 
             # Apply parameters
             self.rules = params.apply_to_rules(self.rules)
-            return self.route_all(progress_callback=progress_callback, suppress_no_timeout_warning=True)
+            # Issue #2800: forward timeout/per_net_timeout to inner route_all
+            return self.route_all(
+                progress_callback=progress_callback,
+                timeout=timeout,
+                per_net_timeout=per_net_timeout,
+                suppress_no_timeout_warning=True,
+            )
 
         # Analyze board characteristics
         characteristics = analyze_board(
@@ -4161,7 +4175,13 @@ class Autorouter:
             flush_print(f"    Congestion cost: {params.congestion:.1f}")
 
             self.rules = params.apply_to_rules(self.rules)
-            routes = self.route_all(progress_callback=progress_callback, suppress_no_timeout_warning=True)
+            # Issue #2800: forward timeout/per_net_timeout to inner route_all
+            routes = self.route_all(
+                progress_callback=progress_callback,
+                timeout=timeout,
+                per_net_timeout=per_net_timeout,
+                suppress_no_timeout_warning=True,
+            )
         else:
             # Full optimization
             flush_print(f"  Method: {method} optimization (max {max_iterations} iterations)")
@@ -4183,7 +4203,13 @@ class Autorouter:
                 flush_print(f"    Total vias: {result.quality.total_vias}")
 
             self.rules = result.params.apply_to_rules(self.rules)
-            routes = self.route_all(progress_callback=progress_callback, suppress_no_timeout_warning=True)
+            # Issue #2800: forward timeout/per_net_timeout to inner route_all
+            routes = self.route_all(
+                progress_callback=progress_callback,
+                timeout=timeout,
+                per_net_timeout=per_net_timeout,
+                suppress_no_timeout_warning=True,
+            )
 
         flush_print("\n=== Tuned Routing Complete ===")
         flush_print(f"  Routes: {len(routes)}")
@@ -6649,6 +6675,8 @@ class Autorouter:
         block_margin: float = 1.0,
         use_negotiated: bool = False,
         progress_callback: ProgressCallback | None = None,
+        timeout: float | None = None,
+        per_net_timeout: float | None = None,
     ) -> list[Route]:
         """Route all nets using per-block detail routing with sub-Pathfinders.
 
@@ -6670,6 +6698,20 @@ class Autorouter:
             use_negotiated: Use negotiated congestion routing for inter-block
                 nets. Default: False.
             progress_callback: Optional callback for progress updates.
+            timeout: Optional outer wall-clock budget in seconds, forwarded
+                to the no-blocks fallback ``route_all`` /
+                ``route_all_negotiated`` (Issue #2800).  ``None`` preserves
+                legacy behaviour.
+
+                Note: when blocks ARE defined, Phase A (``BlockRouter``)
+                does not yet honour this budget -- the per-block sub-grid
+                router has no timeout plumbing.  Phase B inter-block nets
+                route via ``_route_net_with_corridor`` which DOES accept
+                ``per_net_timeout`` (see below).
+            per_net_timeout: Optional advisory per-net wall-clock budget,
+                forwarded to ``_route_net_with_corridor`` for Phase B
+                inter-block nets, and to the no-blocks fallback
+                ``route_all`` /  ``route_all_negotiated`` (Issue #2800).
 
         Returns:
             List of Route objects (block-internal + inter-block).
@@ -6686,9 +6728,20 @@ class Autorouter:
 
         # Fallback to flat routing when no blocks defined
         if not block_list:
+            # Issue #2800: forward timeout/per_net_timeout so the fallback
+            # path honours the caller's wall-clock budget.
             if use_negotiated:
-                return self.route_all_negotiated(progress_callback=progress_callback)
-            return self.route_all(progress_callback=progress_callback, suppress_no_timeout_warning=True)
+                return self.route_all_negotiated(
+                    progress_callback=progress_callback,
+                    timeout=timeout,
+                    per_net_timeout=per_net_timeout,
+                )
+            return self.route_all(
+                progress_callback=progress_callback,
+                timeout=timeout,
+                per_net_timeout=per_net_timeout,
+                suppress_no_timeout_warning=True,
+            )
 
         flush_print("\n=== Block-Aware Routing ===")
         flush_print(f"  Blocks: {len(block_list)}")
@@ -6850,7 +6903,13 @@ class Autorouter:
                 # interiors.  The RegionGraph congestion from
                 # register_block_occupancy() guides corridors away
                 # from occupied block regions.
-                routes = self._route_net_with_corridor(net, present_cost_factor=1.0)
+                # Issue #2800: forward per_net_timeout so each inter-block
+                # A* search honours the per-net wall-clock budget.
+                routes = self._route_net_with_corridor(
+                    net,
+                    present_cost_factor=1.0,
+                    per_net_timeout=per_net_timeout,
+                )
             else:
                 routes = self.route_net(net)
             all_routes.extend(routes)
@@ -8873,7 +8932,14 @@ class Autorouter:
                 adaptive=True,
             )
         else:
-            self.route_all(progress_callback=progress_callback, suppress_no_timeout_warning=True)
+            # Issue #2800: forward ``timeout`` so the non-negotiated branch
+            # honours the outer wall-clock budget instead of silently dropping
+            # it (companion to the negotiated branch above).
+            self.route_all(
+                progress_callback=progress_callback,
+                timeout=timeout,
+                suppress_no_timeout_warning=True,
+            )
 
         coarse_stats = self.get_statistics()
         coarse_routed = coarse_stats["nets_routed"]

--- a/tests/test_build_cmd_stdout_streaming.py
+++ b/tests/test_build_cmd_stdout_streaming.py
@@ -265,3 +265,119 @@ class TestRouteAllSmokeBudget:
         assert isinstance(routes, list)
         # Tiny board: must finish well inside the budget.
         assert elapsed < 60.0
+
+    def test_route_all_multi_resolution_outer_timeout_returns_within_budget(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Issue #2800: ``route_all_multi_resolution(timeout=...)`` must
+        honour its outer wall-clock budget on both branches.
+
+        Exercises the non-negotiated branch where ``timeout`` was
+        previously dropped, plus the wrapper's outer wall-clock guard
+        at line 8893.
+        """
+        import time
+
+        from kicad_tools.router.core import Autorouter
+
+        router = Autorouter(width=50.0, height=40.0)
+        router.add_component(
+            "R1",
+            [
+                {"number": "1", "x": 10.0, "y": 10.0, "net": 1, "net_name": "N1"},
+                {"number": "2", "x": 15.0, "y": 10.0, "net": 1, "net_name": "N1"},
+            ],
+        )
+        router.add_component(
+            "R2",
+            [
+                {"number": "1", "x": 10.0, "y": 20.0, "net": 2, "net_name": "N2"},
+                {"number": "2", "x": 15.0, "y": 20.0, "net": 2, "net_name": "N2"},
+            ],
+        )
+
+        start = time.time()
+        routes = router.route_all_multi_resolution(
+            use_negotiated=False,
+            timeout=60.0,
+        )
+        elapsed = time.time() - start
+
+        assert isinstance(routes, list)
+        # Tiny board: must finish well inside the budget.
+        assert elapsed < 60.0
+
+    def test_route_all_tuned_outer_timeout_returns_within_budget(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Issue #2800: ``route_all_tuned(timeout=...)`` must accept and
+        forward its budget on the quick-tune branch."""
+        import time
+
+        from kicad_tools.router.core import Autorouter
+
+        router = Autorouter(width=50.0, height=40.0)
+        router.add_component(
+            "R1",
+            [
+                {"number": "1", "x": 10.0, "y": 10.0, "net": 1, "net_name": "N1"},
+                {"number": "2", "x": 15.0, "y": 10.0, "net": 1, "net_name": "N1"},
+            ],
+        )
+        router.add_component(
+            "R2",
+            [
+                {"number": "1", "x": 10.0, "y": 20.0, "net": 2, "net_name": "N2"},
+                {"number": "2", "x": 15.0, "y": 20.0, "net": 2, "net_name": "N2"},
+            ],
+        )
+
+        start = time.time()
+        routes = router.route_all_tuned(
+            method="quick",
+            timeout=60.0,
+            per_net_timeout=10.0,
+        )
+        elapsed = time.time() - start
+
+        assert isinstance(routes, list)
+        assert elapsed < 60.0
+
+    def test_route_all_block_aware_outer_timeout_returns_within_budget(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Issue #2800: ``route_all_block_aware(timeout=...)`` must
+        accept and forward its budget on the no-blocks fallback path."""
+        import time
+
+        from kicad_tools.router.core import Autorouter
+
+        router = Autorouter(width=50.0, height=40.0)
+        router.add_component(
+            "R1",
+            [
+                {"number": "1", "x": 10.0, "y": 10.0, "net": 1, "net_name": "N1"},
+                {"number": "2", "x": 15.0, "y": 10.0, "net": 1, "net_name": "N1"},
+            ],
+        )
+        router.add_component(
+            "R2",
+            [
+                {"number": "1", "x": 10.0, "y": 20.0, "net": 2, "net_name": "N2"},
+                {"number": "2", "x": 15.0, "y": 20.0, "net": 2, "net_name": "N2"},
+            ],
+        )
+
+        start = time.time()
+        routes = router.route_all_block_aware(
+            use_negotiated=False,
+            timeout=60.0,
+            per_net_timeout=10.0,
+        )
+        elapsed = time.time() - start
+
+        assert isinstance(routes, list)
+        assert elapsed < 60.0

--- a/tests/test_router_core.py
+++ b/tests/test_router_core.py
@@ -1439,6 +1439,131 @@ class TestAutorouterRouteAll:
         routes = router_with_nets.route_all(timeout=60.0)
         assert isinstance(routes, list)
 
+    # ------------------------------------------------------------------
+    # Issue #2800: wrappers must forward ``timeout`` / ``per_net_timeout``
+    # to the underlying ``route_all`` / ``route_all_negotiated`` calls so
+    # board scripts that pass a wall-clock budget actually have it honoured
+    # by the inner-most search.  Each test asserts:
+    #   1. the kwarg is accepted at the wrapper signature (no TypeError),
+    #   2. the wrapper returns within a generous slack on the tiny fixture,
+    #   3. ``timeout=None`` (default) still works (legacy back-compat).
+    # ------------------------------------------------------------------
+
+    def test_route_all_multi_resolution_accepts_timeout_kwarg(
+        self, router_with_nets
+    ):
+        """Issue #2800: ``route_all_multi_resolution`` must accept
+        ``timeout`` and forward it through both branches.
+
+        Exercises the previously-leaky non-negotiated branch where the
+        outer wall-clock budget was silently dropped at L8876.
+        """
+        import time
+
+        start = time.time()
+        routes = router_with_nets.route_all_multi_resolution(
+            use_negotiated=False,  # exercise the previously-leaky branch
+            timeout=10.0,
+        )
+        elapsed = time.time() - start
+
+        assert isinstance(routes, list)
+        assert elapsed < 30.0, (
+            f"Wrapper exceeded generous slack: {elapsed:.1f}s "
+            f"(would indicate kwarg silently dropped)"
+        )
+
+    def test_route_all_multi_resolution_default_no_timeout(
+        self, router_with_nets
+    ):
+        """Issue #2800: legacy back-compat -- ``timeout=None`` (default)
+        must continue to work."""
+        routes = router_with_nets.route_all_multi_resolution(
+            use_negotiated=False,
+        )
+        assert isinstance(routes, list)
+
+    def test_route_all_tuned_accepts_timeout_kwarg(self, router_with_nets):
+        """Issue #2800: ``route_all_tuned`` must accept ``timeout`` and
+        ``per_net_timeout`` and forward them to all 3 inner ``route_all``
+        call sites (profile branch, quick branch, full-optimization branch).
+        """
+        import time
+
+        start = time.time()
+        routes = router_with_nets.route_all_tuned(
+            method="quick",
+            timeout=10.0,
+            per_net_timeout=5.0,
+        )
+        elapsed = time.time() - start
+
+        assert isinstance(routes, list)
+        assert elapsed < 30.0, (
+            f"Wrapper exceeded generous slack: {elapsed:.1f}s "
+            f"(would indicate kwarg silently dropped)"
+        )
+
+    def test_route_all_tuned_profile_accepts_timeout_kwarg(
+        self, router_with_nets
+    ):
+        """Issue #2800: same contract on the ``profile=`` branch
+        (separate code path at L4129)."""
+        routes = router_with_nets.route_all_tuned(
+            profile="standard",
+            timeout=10.0,
+            per_net_timeout=5.0,
+        )
+        assert isinstance(routes, list)
+
+    def test_route_all_tuned_default_no_timeout(self, router_with_nets):
+        """Issue #2800: legacy back-compat -- defaults must still work."""
+        routes = router_with_nets.route_all_tuned(method="quick")
+        assert isinstance(routes, list)
+
+    def test_route_all_block_aware_accepts_timeout_kwarg(
+        self, router_with_nets
+    ):
+        """Issue #2800: ``route_all_block_aware`` must accept ``timeout``
+        and ``per_net_timeout`` and forward them through both the
+        no-blocks fallback and Phase B inter-block routing.
+
+        The fixture has no registered blocks, so this exercises the
+        fallback path (L6688-6701) which previously dropped both kwargs.
+        """
+        import time
+
+        start = time.time()
+        routes = router_with_nets.route_all_block_aware(
+            use_negotiated=False,
+            timeout=10.0,
+            per_net_timeout=5.0,
+        )
+        elapsed = time.time() - start
+
+        assert isinstance(routes, list)
+        assert elapsed < 30.0, (
+            f"Wrapper exceeded generous slack: {elapsed:.1f}s "
+            f"(would indicate kwarg silently dropped)"
+        )
+
+    def test_route_all_block_aware_negotiated_accepts_timeout_kwarg(
+        self, router_with_nets
+    ):
+        """Issue #2800: same contract on the negotiated fallback branch
+        (L6690 -- forwards to ``route_all_negotiated``)."""
+        routes = router_with_nets.route_all_block_aware(
+            use_negotiated=True,
+            timeout=10.0,
+            per_net_timeout=5.0,
+        )
+        assert isinstance(routes, list)
+
+    def test_route_all_block_aware_default_no_timeout(self, router_with_nets):
+        """Issue #2800: legacy back-compat -- defaults must still work."""
+        routes = router_with_nets.route_all_block_aware(use_negotiated=False)
+        assert isinstance(routes, list)
+
 
 class TestAutorouterZones:
     """Tests for zone (copper pour) support."""


### PR DESCRIPTION
## Summary

Three router wrappers silently dropped the wall-clock budget they were handed, causing board scripts to hang indefinitely even when the caller passed an explicit `timeout`. Each wrapper now forwards `timeout` (and `per_net_timeout` where applicable) to its inner `route_all` / `route_all_negotiated` / `_route_net_with_corridor` call.

Closes #2800.

## Changes

- **`route_all_multi_resolution`** (`core.py` L8876): one-line fix -- forward the existing `timeout` param to the non-negotiated branch's `route_all` call. The negotiated branch already forwarded it.
- **`route_all_tuned`** (`core.py` L4079-): add `timeout` + `per_net_timeout` params to the signature and forward at all 3 inner `route_all` call sites (profile branch, quick branch, full-optimization branch).
- **`route_all_block_aware`** (`core.py` L6646-): add `timeout` + `per_net_timeout` params to the signature, forward to the no-blocks fallback `route_all` / `route_all_negotiated`, and forward `per_net_timeout` to `_route_net_with_corridor` for Phase B inter-block nets (which already accepts the kwarg at L6320).

`route_with_escape` was already correct (verified by Curator) -- no change there.

### Out of scope (noted in docstring)

Phase A of `route_all_block_aware` (per-block `BlockRouter`) does not yet honour the budget; that requires plumbing through `BlockRouter.route_block` and would significantly broaden the diff. The wrapper docstring now notes the remaining gap.

## Cross-references

- **#2802** is the orchestration-level wall-clock companion. They are independent layers -- this PR is a prerequisite because board scripts calling `route_all_tuned` etc. directly bypass the CLI's outer wall-clock guard.
- **#2794** introduced the no-timeout warning that motivated this audit (silent hangs on board 05 BLDC).

## Test plan

- [x] 8 new acceptance tests in `TestAutorouterRouteAll` -- each wrapper exercises both the `timeout` kwarg and the legacy `timeout=None` default to prove backward compat.
- [x] 3 new wall-clock smoke tests in `TestRouteAllSmokeBudget` matching the existing `route_all(timeout=...)` budget assertion.
- [x] All existing `tests/test_router_core.py` tests pass (172 passed; 1 pre-existing unrelated failure in `test_add_component_rotation` was deselected and confirmed present on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)