### PR TITLE
fix(cli): wire --checkpoint-interval through outer parser + add drift regression test (closes #2817)

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -184,6 +184,12 @@ def run_route_command(args) -> int:
     per_net_timeout_val = getattr(args, "per_net_timeout", 30.0)
     if per_net_timeout_val != 30.0:
         sub_argv.extend(["--per-net-timeout", str(per_net_timeout_val)])
+    # Issue #2817: forward --checkpoint-interval to the inner parser.  The
+    # inner default also lives at 30.0, so only forward when the user passed
+    # a non-default value (matches the per-net-timeout pattern above).
+    checkpoint_interval_val = getattr(args, "checkpoint_interval", 30.0)
+    if checkpoint_interval_val != 30.0:
+        sub_argv.extend(["--checkpoint-interval", str(checkpoint_interval_val)])
     if args.verbose:
         sub_argv.append("--verbose")
     if args.dry_run:
@@ -229,9 +235,7 @@ def run_route_command(args) -> int:
     if getattr(args, "placement_feedback", False):
         sub_argv.append("--placement-feedback")
     if getattr(args, "placement_feedback_budget", 3) != 3:
-        sub_argv.extend(
-            ["--placement-feedback-budget", str(args.placement_feedback_budget)]
-        )
+        sub_argv.extend(["--placement-feedback-budget", str(args.placement_feedback_budget)])
     if getattr(args, "placement_feedback_max_movement", 5.0) != 5.0:
         sub_argv.extend(
             [
@@ -240,9 +244,7 @@ def run_route_command(args) -> int:
             ]
         )
     if getattr(args, "placement_feedback_anchor", None):
-        sub_argv.extend(
-            ["--placement-feedback-anchor", args.placement_feedback_anchor]
-        )
+        sub_argv.extend(["--placement-feedback-anchor", args.placement_feedback_anchor])
     if getattr(args, "placement_feedback_no_anchor", None):
         sub_argv.extend(
             [

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2165,6 +2165,20 @@ def _add_route_parser(subparsers) -> None:
         help="Wall-clock timeout in seconds for each per-net A* search (default: 30). "
         "Prevents individual nets from monopolizing the router. Use 0 to disable.",
     )
+    # Issue #2817: forward --checkpoint-interval through the outer parser so
+    # users can disable (``0``) or tune the best-so-far checkpoint cadence
+    # introduced by #2812.  The inner parser at route_cmd.py also declares
+    # this flag (default 30.0); both sites must stay in sync, enforced by
+    # ``tests/test_cli_parser_drift.py``.
+    route_parser.add_argument(
+        "--checkpoint-interval",
+        type=float,
+        default=30.0,
+        help=(
+            "Interval in seconds between best-so-far checkpoint writes to "
+            "--output. Default: 30. Use 0 to disable."
+        ),
+    )
     # Issue #2610: --max-search-iterations override for the C++ A* memory
     # backstop (default 0 = use the historical ``cols * rows * 4`` heuristic).
     # Documented as an escape hatch for dense boards where the cap fires

--- a/tests/test_cli_parser_drift.py
+++ b/tests/test_cli_parser_drift.py
@@ -1,0 +1,222 @@
+"""Argparse-drift regression test (Issue #2817).
+
+This test prevents a recurring class of bug where a new flag is added to
+the *inner* ``route_cmd.py`` parser without being added to the *outer*
+``parser.py`` parser and to the forwarding shim in
+``commands/routing.py``.  Three prior instances of this exact pattern
+have shipped to ``main`` and required a follow-up bugfix:
+
+* **#2620** -- ``--placement-feedback-outer-timeout`` declared outer,
+  rejected inner (drift in the opposite direction).
+* **#2622 / #2793** -- manufacturer-registry argparse drift.
+* **#2812 / #2817** -- ``--checkpoint-interval`` declared inner only;
+  ``kct route --checkpoint-interval 30`` rejected with
+  ``error: unrecognized arguments``.
+
+The drift is invisible to the type checker and to most unit tests
+because both parsers are constructed independently with no shared
+schema.  This test introspects both parsers and asserts that every
+``--flag`` accepted by the inner parser is also accepted by the outer
+parser, except for an explicit allowlist of historically inner-only
+flags.
+
+If you legitimately need to add a new inner-only flag, add it to
+``INNER_ONLY_ALLOWLIST`` below with a comment explaining why it does
+not belong on the outer parser.  In most cases the right answer is to
+add it to BOTH parsers and to the forwarding shim -- see the
+``--per-net-timeout`` block in ``commands/routing.py`` for the model
+pattern.
+"""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import patch
+
+import pytest
+
+# Flags that legitimately exist ONLY on the inner ``route_cmd.py`` parser.
+#
+# Each entry should have a short justification.  When adding a new
+# inner-only flag, prefer to add it to BOTH parsers (and the forwarding
+# shim) instead -- the allowlist is for flags that are intentionally
+# internal-only (debug/diagnostic toggles, dev-only profiling switches,
+# experimental features that should not be advertised through ``kct``).
+#
+# Snapshot taken 2026-05-12 while fixing #2817.  Many of the entries
+# below pre-date the drift test; future flags should generally NOT be
+# added here -- expose them through the outer parser instead.
+INNER_ONLY_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        # Diagnostics / debug / profiling -- not part of the
+        # user-facing ``kct route`` surface.
+        "--analyze",
+        "--diagnostics",
+        "--profile",
+        "--profile-output",
+        "--cache-stats",
+        "--cache-only",
+        "--clear-cache",
+        "--preview",
+        "--show-congestion",
+        "--format",
+        # Internal routing-algorithm toggles exposed through the
+        # ``route_cmd.py`` parser for development experimentation.
+        # Promote to the outer parser when ready to support officially.
+        "--auto-pour",
+        "--no-auto-pour",
+        "--batch-routing",
+        "--bus-min-width",
+        "--bus-mode",
+        "--bus-routing",
+        "--bus-spacing",
+        "--edge-clearance",
+        "--escape-routing",
+        "--no-escape-routing",
+        "--grid-strategy",
+        "--hierarchical",
+        "--min-clearance",
+        "--multi-resolution",
+        "--no-early-stop",
+        "--no-perturbation",
+        "--perturbation",
+        "--progressive-clearance",
+        "--relaxation-levels",
+        "--stitch-power-planes",
+        "--two-phase",
+        "--two-phase-iterations",
+    }
+)
+
+
+def _flags_from_parser(parser: argparse.ArgumentParser) -> set[str]:
+    """Return the set of ``--long-form`` option strings declared on ``parser``.
+
+    Short flags (``-o``, ``-q``, ``-v``) are intentionally excluded
+    because the drift bug class only manifests for long flags -- short
+    flags are typically aliases and live alongside their long form.
+    """
+    flags: set[str] = set()
+    for action in parser._actions:
+        for option_string in action.option_strings:
+            if option_string.startswith("--"):
+                flags.add(option_string)
+    return flags
+
+
+def _inner_route_parser_flags() -> set[str]:
+    """Capture the inner ``route_cmd.main`` parser without parsing argv.
+
+    The parser is constructed inline inside ``main()``; we intercept
+    ``ArgumentParser.parse_args`` to grab the live parser instance and
+    then exit before any routing work happens.
+    """
+    from kicad_tools.cli.route_cmd import main as route_main
+
+    captured: dict[str, argparse.ArgumentParser] = {}
+    real_parse_args = argparse.ArgumentParser.parse_args
+
+    def fake_parse_args(self, *args, **kwargs):
+        # Only capture the inner ``kicad-tools route`` parser -- some
+        # add_argument calls below may also instantiate sub-parsers.
+        if getattr(self, "prog", "") == "kicad-tools route":
+            captured["parser"] = self
+            raise SystemExit(0)
+        return real_parse_args(self, *args, **kwargs)
+
+    with patch.object(argparse.ArgumentParser, "parse_args", fake_parse_args):
+        with pytest.raises(SystemExit):
+            route_main([])
+
+    assert "parser" in captured, "failed to capture inner route parser"
+    return _flags_from_parser(captured["parser"])
+
+
+def _outer_route_parser_flags() -> set[str]:
+    """Walk ``create_parser()`` to extract the ``route`` subparser flags."""
+    from kicad_tools.cli.parser import create_parser
+
+    main_parser = create_parser()
+    for action in main_parser._actions:
+        choices = getattr(action, "choices", None)
+        if choices and "route" in choices:
+            return _flags_from_parser(choices["route"])
+    raise AssertionError("could not find 'route' subparser on outer parser")
+
+
+def test_inner_only_flags_are_in_allowlist():
+    """Every flag on the inner parser must also be on the outer parser.
+
+    Exceptions live in ``INNER_ONLY_ALLOWLIST`` with justification.
+    This guards against the #2620 / #2622 / #2793 / #2812 / #2817 bug
+    class where a new flag is added to one site only.
+    """
+    inner = _inner_route_parser_flags()
+    outer = _outer_route_parser_flags()
+
+    inner_only = inner - outer
+    unexpected_inner_only = inner_only - INNER_ONLY_ALLOWLIST
+
+    if unexpected_inner_only:
+        flag_list = "\n  ".join(sorted(unexpected_inner_only))
+        pytest.fail(
+            "Argparse drift detected: the following flags are accepted by "
+            "the inner 'route_cmd.py' parser but rejected by the outer "
+            "'kct route' parser:\n  "
+            f"{flag_list}\n\n"
+            "Fix by adding each flag to BOTH:\n"
+            "  1. src/kicad_tools/cli/parser.py :: _add_route_parser\n"
+            "  2. src/kicad_tools/cli/commands/routing.py :: run_route_command "
+            "(forward to sub_argv)\n\n"
+            "Model after the --per-net-timeout block.  If the flag is "
+            "genuinely internal-only (debug/profiling), add it to "
+            "INNER_ONLY_ALLOWLIST in tests/test_cli_parser_drift.py with "
+            "justification."
+        )
+
+
+def test_allowlist_entries_are_actually_inner_only():
+    """Sanity: every flag in the allowlist should genuinely be inner-only.
+
+    Prevents the allowlist from growing stale -- if a flag is later
+    added to the outer parser it should be removed from the allowlist
+    so we don't accidentally mask a future drift bug for that flag.
+    """
+    inner = _inner_route_parser_flags()
+    outer = _outer_route_parser_flags()
+
+    stale: set[str] = set()
+    for flag in INNER_ONLY_ALLOWLIST:
+        if flag not in inner:
+            stale.add(f"{flag} (not on inner parser at all)")
+        elif flag in outer:
+            stale.add(f"{flag} (now on outer parser -- remove from allowlist)")
+
+    if stale:
+        entries = "\n  ".join(sorted(stale))
+        pytest.fail(
+            "Stale entries in INNER_ONLY_ALLOWLIST:\n  "
+            f"{entries}\n\n"
+            "Remove these entries from tests/test_cli_parser_drift.py."
+        )
+
+
+def test_checkpoint_interval_is_on_both_parsers():
+    """Direct regression test for #2817.
+
+    ``--checkpoint-interval`` was added to the inner parser by #2812 but
+    not to the outer parser, so ``kct route --checkpoint-interval 30``
+    failed with ``error: unrecognized arguments``.  This test pins both
+    parsers to ensure the flag never goes missing again.
+    """
+    inner = _inner_route_parser_flags()
+    outer = _outer_route_parser_flags()
+
+    assert "--checkpoint-interval" in inner, (
+        "--checkpoint-interval is missing from the inner route_cmd.py parser "
+        "(this would regress #2812)"
+    )
+    assert "--checkpoint-interval" in outer, (
+        "--checkpoint-interval is missing from the outer parser.py route "
+        "subparser (this would regress #2817)"
+    )


### PR DESCRIPTION
## Summary

Two-part fix for #2817:

1. **Plumbing fix** -- Wire `--checkpoint-interval` through the outer parser (`parser.py`) and the forwarding shim (`commands/routing.py`), modeled after the existing `--per-net-timeout` block.  PR #2812 added the flag only to the inner `route_cmd.py` parser, so `kct route --checkpoint-interval 30` failed with `error: unrecognized arguments`.

2. **Long-term fix** -- Add `tests/test_cli_parser_drift.py`, an argparse-drift regression test that introspects both parsers and asserts every flag on the inner parser is also on the outer parser (modulo an explicit allowlist of historically inner-only debug/diagnostic flags).  This is the third instance of the same drift pattern this session (#2620, #2622/#2793, #2812 -> #2817); the regression test prevents a fourth.

## Why the regression test matters

The drift is invisible to the type checker and to most unit tests because both parsers are constructed independently with no shared schema.  The test:

- Captures the inner parser by intercepting `argparse.ArgumentParser.parse_args` (no refactor needed)
- Walks subparsers on the outer parser to find the `route` subparser
- Computes `inner_flags - outer_flags` and asserts the difference is a subset of `INNER_ONLY_ALLOWLIST` (32 entries, snapshotted today)
- A second test (`test_allowlist_entries_are_actually_inner_only`) prevents the allowlist from going stale

I verified the test catches the bug by stashing the `parser.py` change and re-running -- 2 of 3 tests fail with a clear message pointing at the fix sites.

## Test plan

- [x] `uv run kct route --help | grep checkpoint` shows `--checkpoint-interval` in visible help
- [x] `--checkpoint-interval 0` accepted at outer parser and forwarded as `["--checkpoint-interval", "0.0"]` to inner parser
- [x] `--checkpoint-interval 5` accepted similarly
- [x] New `tests/test_cli_parser_drift.py` (3 tests) passes on fixed state
- [x] New drift test FAILS on unfixed state (confirmed by stashing the parser.py change)
- [x] All 17 existing PR #2812 tests in `tests/test_route_checkpoint.py` still pass
- [x] All 87 tests in `tests/test_cli.py` and `tests/test_cli_commands.py` still pass (107 total green)
- [x] `ruff check` and `ruff format --check` clean on touched files

Closes #2817

## Notes

- `uv.lock` has unrelated drift on `main` (a `pynng` IPC extra was added) -- not included in this commit.
- The allowlist captures 32 currently-inner-only flags (debug/profiling toggles like `--analyze`, `--diagnostics`, `--profile`, plus dev-experimental router knobs like `--two-phase`, `--escape-routing`, `--auto-pour`).  These are not part of this issue's scope; the test merely pins today's state and demands future inner-only additions be justified explicitly.
- A separate drift exists in the opposite direction: `--max-search-iterations` is on the outer parser only and is not forwarded by the shim (it relies on `getattr(args, ...)` defaulting to 0 inside the inner parser, similar to the saving-grace pattern from #2817).  Not fixed here -- the AC was scoped to inner-only flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)