### PR TITLE
feat(placement): --anchor-weight biases HPWL toward locked footprints (#2822)

### DIFF
--- a/src/kicad_tools/cli/commands/optimize_placement.py
+++ b/src/kicad_tools/cli/commands/optimize_placement.py
@@ -20,4 +20,5 @@ def run_optimize_placement_command(args) -> int:
         verbose=args.verbose,
         quiet=getattr(args, "quiet", False) or getattr(args, "global_quiet", False),
         no_slide_off=getattr(args, "no_slide_off", False),
+        anchor_weight=getattr(args, "anchor_weight", 0.0),
     )

--- a/src/kicad_tools/cli/optimize_placement_cmd.py
+++ b/src/kicad_tools/cli/optimize_placement_cmd.py
@@ -235,6 +235,8 @@ def _print_score(label: str, score: PlacementScore) -> None:
 
 def _read_board_data(
     pcb_path: str,
+    *,
+    anchor_weight: float = 0.0,
 ) -> tuple[
     list[ComponentDef],
     list[Net],
@@ -249,6 +251,13 @@ def _read_board_data(
 
     The returned board origin is needed by the writer to convert
     board-relative optimizer output back to sheet-absolute coordinates.
+
+    Args:
+        pcb_path: Path to .kicad_pcb file.
+        anchor_weight: When > 0, every net touching at least one ``(locked)``
+            footprint receives ``Net.weight = 1 + anchor_weight * f``, where
+            ``f`` is the fraction of the net's pins that land on locked
+            footprints (range 0..1). Default 0.0 preserves uniform weighting.
     """
     from kicad_tools.placement.vector import PadDef
     from kicad_tools.schema.pcb import PCB as SchemaPCB
@@ -272,11 +281,17 @@ def _read_board_data(
         board_outline = _extract_board_outline(pcb)
 
     # --- Components from footprints ---
+    # Track which footprints carry the (locked) attribute so we can later
+    # compute per-net anchor fractions for weighted wirelength.
+    locked_refs: set[str] = set()
     components: list[ComponentDef] = []
     for fp in pcb.footprints:
         ref = fp.reference
         if not ref:
             continue
+
+        if getattr(fp, "locked", False):
+            locked_refs.add(ref)
 
         # Compute footprint size from pad extents
         width, height = _footprint_size_from_pads(fp)
@@ -317,13 +332,40 @@ def _read_board_data(
 
     nets: list[Net] = []
     for net_name, pins in net_map.items():
-        if len(pins) >= 2:
-            nets.append(Net(name=net_name, pins=pins))
+        if len(pins) < 2:
+            continue
+        weight = _compute_net_anchor_weight(pins, locked_refs, anchor_weight)
+        nets.append(Net(name=net_name, pins=pins, weight=weight))
 
     # --- Design rules (use defaults; PCB setup has limited rule info) ---
     rules = DesignRuleSet()
 
     return components, nets, board_outline, rules, pcb.board_origin
+
+
+def _compute_net_anchor_weight(
+    pins: Sequence[tuple[str, str]],
+    locked_refs: set[str],
+    anchor_weight: float,
+) -> float:
+    """Compute the per-net wirelength weight from anchor pad fraction.
+
+    A pin contributes to the "anchored" count when its component reference
+    appears in ``locked_refs`` (set of footprints carrying the ``(locked)``
+    attribute). The returned weight is::
+
+        1.0 + anchor_weight * (anchored_pins / total_pins)
+
+    For ``anchor_weight <= 0`` the weight collapses to 1.0 (regression-safe
+    default). Nets with no anchored pins also collapse to 1.0.
+    """
+    if anchor_weight <= 0.0 or not pins or not locked_refs:
+        return 1.0
+    anchored = sum(1 for ref, _ in pins if ref in locked_refs)
+    if anchored == 0:
+        return 1.0
+    fraction = anchored / len(pins)
+    return 1.0 + anchor_weight * fraction
 
 
 
@@ -447,6 +489,7 @@ def run_optimize_placement(
     verbose: bool = False,
     quiet: bool = False,
     no_slide_off: bool = False,
+    anchor_weight: float = 0.0,
 ) -> int:
     """Run placement optimization.
 
@@ -463,6 +506,10 @@ def run_optimize_placement(
         verbose: Enable verbose output.
         quiet: Suppress non-essential output.
         no_slide_off: If True, skip slide-off overlap pre-processing.
+        anchor_weight: When > 0, nets touching a ``(locked)`` footprint
+            receive an inflated wirelength weight of
+            ``1 + anchor_weight * anchor_pad_fraction``. Default 0.0
+            preserves the historical uniform weighting (regression-safe).
 
     Returns:
         Exit code (0 for success, 1 for failure).
@@ -474,6 +521,12 @@ def run_optimize_placement(
         return 1
     if pcb_file.suffix != ".kicad_pcb":
         print(f"Error: expected .kicad_pcb file, got: {pcb_file.suffix}", file=sys.stderr)
+        return 1
+    if anchor_weight < 0.0:
+        print(
+            f"Error: --anchor-weight must be >= 0 (got {anchor_weight})",
+            file=sys.stderr,
+        )
         return 1
 
     if output_path is None:
@@ -498,7 +551,9 @@ def run_optimize_placement(
 
     # Read board data
     try:
-        components, nets, board_outline, rules, board_origin = _read_board_data(pcb_path)
+        components, nets, board_outline, rules, board_origin = _read_board_data(
+            pcb_path, anchor_weight=anchor_weight,
+        )
     except Exception as e:
         print(f"Error reading PCB: {e}", file=sys.stderr)
         if verbose:

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3600,6 +3600,21 @@ def _add_optimize_placement_parser(subparsers) -> None:
         default=False,
         help="Disable slide-off overlap pre-processing on the seed placement",
     )
+    op_parser.add_argument(
+        "--anchor-weight",
+        type=float,
+        default=0.0,
+        metavar="FLOAT",
+        help=(
+            "Per-net wirelength multiplier boost for nets that touch "
+            "footprints carrying the KiCad (locked) attribute. Each "
+            "qualifying net's HPWL is scaled by "
+            "1 + anchor_weight * (anchored_pins / total_pins). "
+            "Default 0.0 preserves uniform weighting; recommended "
+            "starting range is 2.0..5.0 to keep perimeter-anchored "
+            "signals (connectors, edge sense FETs) from being starved."
+        ),
+    )
     op_parser.add_argument("-v", "--verbose", action="store_true")
     op_parser.add_argument("-q", "--quiet", action="store_true", help="Suppress progress output")
 

--- a/src/kicad_tools/mcp/tools/optimize_placement.py
+++ b/src/kicad_tools/mcp/tools/optimize_placement.py
@@ -72,6 +72,8 @@ def _validate_pcb_path(pcb_path: str) -> Path:
 
 def _read_board_data(
     pcb_path: str,
+    *,
+    anchor_weight: float = 0.0,
 ) -> tuple[list[ComponentDef], list[Net], BoardOutline, DesignRuleSet, tuple[float, float]]:
     """Read component, net, and board data from a .kicad_pcb file.
 
@@ -80,6 +82,10 @@ def _read_board_data(
 
     Args:
         pcb_path: Path to .kicad_pcb file.
+        anchor_weight: When > 0, every net touching at least one ``(locked)``
+            footprint receives ``Net.weight = 1 + anchor_weight * f``, where
+            ``f`` is the fraction of the net's pins that land on locked
+            footprints (range 0..1). Default 0.0 preserves uniform weighting.
 
     Returns:
         Tuple of (components, nets, board_outline, rules, board_origin).
@@ -105,11 +111,15 @@ def _read_board_data(
         board_outline = _extract_board_outline(pcb)
 
     # Components from footprints
+    locked_refs: set[str] = set()
     components: list[ComponentDef] = []
     for fp in pcb.footprints:
         ref = fp.reference
         if not ref:
             continue
+
+        if getattr(fp, "locked", False):
+            locked_refs.add(ref)
 
         width, height = _footprint_size_from_pads(fp)
 
@@ -148,11 +158,39 @@ def _read_board_data(
 
     nets: list[Net] = []
     for net_name, pins in net_map.items():
-        if len(pins) >= 2:
-            nets.append(Net(name=net_name, pins=pins))
+        if len(pins) < 2:
+            continue
+        weight = _compute_net_anchor_weight(pins, locked_refs, anchor_weight)
+        nets.append(Net(name=net_name, pins=pins, weight=weight))
 
     rules = DesignRuleSet()
     return components, nets, board_outline, rules, pcb.board_origin
+
+
+def _compute_net_anchor_weight(
+    pins: Sequence[tuple[str, str]],
+    locked_refs: set[str],
+    anchor_weight: float,
+) -> float:
+    """Compute the per-net wirelength weight from anchor pad fraction.
+
+    Mirror of the helper in ``kicad_tools.cli.optimize_placement_cmd``.
+    A pin contributes to the "anchored" count when its component reference
+    appears in ``locked_refs`` (set of footprints carrying the ``(locked)``
+    attribute). The returned weight is::
+
+        1.0 + anchor_weight * (anchored_pins / total_pins)
+
+    For ``anchor_weight <= 0`` the weight collapses to 1.0 (regression-safe
+    default). Nets with no anchored pins also collapse to 1.0.
+    """
+    if anchor_weight <= 0.0 or not pins or not locked_refs:
+        return 1.0
+    anchored = sum(1 for ref, _ in pins if ref in locked_refs)
+    if anchored == 0:
+        return 1.0
+    fraction = anchored / len(pins)
+    return 1.0 + anchor_weight * fraction
 
 
 
@@ -293,6 +331,7 @@ def optimize_placement(
     seed_method: str = "force-directed",
     output_path: str | None = None,
     pre_slide_off: bool = True,
+    anchor_weight: float = 0.0,
 ) -> dict[str, Any]:
     """Optimize component placement on a PCB board using CMA-ES.
 
@@ -310,6 +349,12 @@ def optimize_placement(
         output_path: Path for output file. If None, does not write to disk.
         pre_slide_off: If True, run slide-off overlap resolution on the seed
             placement before passing it to the optimizer.
+        anchor_weight: When > 0, every net touching a footprint with the
+            KiCad ``(locked)`` attribute gets a wirelength multiplier of
+            ``1 + anchor_weight * anchor_pad_fraction``. Default 0.0
+            preserves uniform per-net weighting (regression-safe).
+            Recommended starting range: 2.0..5.0 for boards with
+            perimeter-anchored signals (connectors, edge sense FETs).
 
     Returns:
         Dictionary with optimization results:
@@ -330,12 +375,18 @@ def optimize_placement(
     Raises:
         FileNotFoundError: If the PCB file does not exist.
         ParseError: If the PCB file cannot be parsed.
+        ValueError: If anchor_weight is negative.
     """
     _validate_pcb_path(pcb_path)
 
+    if anchor_weight < 0.0:
+        raise ValueError(f"anchor_weight must be >= 0 (got {anchor_weight})")
+
     # Parse board data
     try:
-        components, nets, board_outline, rules, board_origin = _read_board_data(pcb_path)
+        components, nets, board_outline, rules, board_origin = _read_board_data(
+            pcb_path, anchor_weight=anchor_weight,
+        )
     except Exception as e:
         raise ParseError(f"Failed to parse PCB file: {e}") from e
 

--- a/src/kicad_tools/placement/cost.py
+++ b/src/kicad_tools/placement/cost.py
@@ -140,10 +140,17 @@ class Net:
     Attributes:
         name: Net name.
         pins: Sequence of (reference, pin_name) pairs in this net.
+        weight: Per-net multiplier for wirelength cost contributions.
+            Defaults to 1.0 (uniform weighting). Values >1.0 prioritise
+            keeping this net short (useful when one or more pins are
+            anchored to a fixed perimeter footprint and the optimizer
+            could otherwise stretch the channel). A weight of 0.0
+            removes the net from the wirelength sum entirely.
     """
 
     name: str
     pins: Sequence[tuple[str, str]]
+    weight: float = 1.0
 
 
 @dataclass(frozen=True)
@@ -196,12 +203,17 @@ def compute_wirelength(
     connected component positions. This is the standard HPWL estimator
     used in placement optimization.
 
+    Each net's HPWL contribution is multiplied by ``net.weight`` (default
+    ``1.0``). Setting ``weight > 1.0`` prioritises keeping that net short
+    (used by the anchor-aware path in ``optimize-placement``); setting
+    ``weight = 0.0`` excludes the net from the wirelength sum entirely.
+
     Args:
         placements: Current component positions.
         nets: Net connectivity information.
 
     Returns:
-        Total HPWL across all nets (mm).
+        Total weighted HPWL across all nets (mm).
     """
     if not nets:
         return 0.0
@@ -220,7 +232,7 @@ def compute_wirelength(
                 xs.append(x)
                 ys.append(y)
         if len(xs) >= 2:
-            total += (max(xs) - min(xs)) + (max(ys) - min(ys))
+            total += net.weight * ((max(xs) - min(xs)) + (max(ys) - min(ys)))
     return total
 
 

--- a/tests/test_optimize_placement_cmd.py
+++ b/tests/test_optimize_placement_cmd.py
@@ -917,3 +917,229 @@ class TestSlideOffOverlapDetails:
         _, result = slide_off_overlaps(vector, comps, board)
         assert result.overlaps_remaining == 0
         assert len(result.overlap_details) == 0
+
+
+# ---------------------------------------------------------------------------
+# Anchor-weight CLI behaviour (issue #2822)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def anchored_pcb(tmp_path: Path) -> Path:
+    """Synthetic PCB with one (locked) perimeter footprint and movable parts.
+
+    Layout (sheet-absolute coordinates, board origin 0,0):
+
+        J1 (locked, edge-mounted connector at (1, 25))
+            pad 1 -> NET_ANCHOR (also touches U1 in the centre)
+        U1 (movable, ~centre at (15, 15))
+            pad 1 -> NET_ANCHOR
+            pad 2 -> NET_INTERIOR
+        R1 (movable, near U1)
+            pad 1 -> NET_INTERIOR
+        R2 (movable, near U1)
+            pad 1 -> NET_INTERIOR
+
+    With ``--anchor-weight 0`` the optimizer is free to push U1 anywhere
+    that minimises the (R1, R2, U1) cluster wirelength, even if that
+    stretches NET_ANCHOR. With a non-zero anchor weight, NET_ANCHOR's
+    HPWL is amplified and the optimizer should keep U1 closer to J1.
+    """
+    pcb_content = """\
+(kicad_pcb (version 20230101) (generator "test")
+  (general (thickness 1.6))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (setup
+    (pad_to_mask_clearance 0.05)
+  )
+  (net 0 "")
+  (net 1 "NET_ANCHOR")
+  (net 2 "NET_INTERIOR")
+  (footprint "Conn_J1" (layer "F.Cu")
+    (at 1.0 25.0 0)
+    (attr through_hole locked)
+    (property "Reference" "J1")
+    (fp_text reference "J1" (at 0 -1.5) (layer "F.SilkS") (effects (font (size 1 1) (thickness 0.15))))
+    (pad "1" smd rect (at 0.0 0.0) (size 0.8 0.8) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "NET_ANCHOR"))
+  )
+  (footprint "U_Centre" (layer "F.Cu")
+    (at 15.0 15.0 0)
+    (property "Reference" "U1")
+    (fp_text reference "U1" (at 0 -1.5) (layer "F.SilkS") (effects (font (size 1 1) (thickness 0.15))))
+    (pad "1" smd rect (at -0.5 0.0) (size 0.8 0.8) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "NET_ANCHOR"))
+    (pad "2" smd rect (at 0.5 0.0) (size 0.8 0.8) (layers "F.Cu" "F.Paste" "F.Mask") (net 2 "NET_INTERIOR"))
+  )
+  (footprint "R_0805" (layer "F.Cu")
+    (at 18.0 15.0 0)
+    (property "Reference" "R1")
+    (fp_text reference "R1" (at 0 -1.5) (layer "F.SilkS") (effects (font (size 1 1) (thickness 0.15))))
+    (pad "1" smd rect (at 0.0 0.0) (size 0.5 0.5) (layers "F.Cu" "F.Paste" "F.Mask") (net 2 "NET_INTERIOR"))
+  )
+  (footprint "R_0805" (layer "F.Cu")
+    (at 12.0 15.0 0)
+    (property "Reference" "R2")
+    (fp_text reference "R2" (at 0 -1.5) (layer "F.SilkS") (effects (font (size 1 1) (thickness 0.15))))
+    (pad "1" smd rect (at 0.0 0.0) (size 0.5 0.5) (layers "F.Cu" "F.Paste" "F.Mask") (net 2 "NET_INTERIOR"))
+  )
+  (gr_line (start 0 0) (end 30 0) (layer "Edge.Cuts") (width 0.05))
+  (gr_line (start 30 0) (end 30 30) (layer "Edge.Cuts") (width 0.05))
+  (gr_line (start 30 30) (end 0 30) (layer "Edge.Cuts") (width 0.05))
+  (gr_line (start 0 30) (end 0 0) (layer "Edge.Cuts") (width 0.05))
+)
+"""
+    pcb_file = tmp_path / "anchored_board.kicad_pcb"
+    pcb_file.write_text(pcb_content)
+    return pcb_file
+
+
+class TestAnchorWeight:
+    """Verify --anchor-weight CLI flag plumbs through to Net.weight."""
+
+    def test_read_board_data_default_zero_weight(self, anchored_pcb: Path) -> None:
+        """With anchor_weight=0, every Net.weight stays at the 1.0 default."""
+        _comps, nets, _board, _rules, _origin = _read_board_data(str(anchored_pcb))
+        assert nets, "expected at least one net"
+        for net in nets:
+            assert net.weight == 1.0, (
+                f"net {net.name!r} weight should be 1.0 with default anchor_weight"
+            )
+
+    def test_read_board_data_anchor_weight_inflates_locked_net(
+        self, anchored_pcb: Path,
+    ) -> None:
+        """Anchor weight inflates only the net touching the (locked) J1."""
+        _comps, nets, _board, _rules, _origin = _read_board_data(
+            str(anchored_pcb), anchor_weight=4.0,
+        )
+        nets_by_name = {n.name: n for n in nets}
+        assert "NET_ANCHOR" in nets_by_name, "anchored net missing"
+        assert "NET_INTERIOR" in nets_by_name, "interior net missing"
+
+        anchor_net = nets_by_name["NET_ANCHOR"]
+        interior_net = nets_by_name["NET_INTERIOR"]
+
+        # NET_ANCHOR has 2 pins (J1 pad1 + U1 pad1), 1 anchored -> fraction 0.5
+        # weight = 1 + 4.0 * 0.5 = 3.0
+        assert anchor_net.weight == pytest.approx(3.0)
+
+        # NET_INTERIOR has 3 pins (U1 pad2, R1, R2), 0 anchored -> weight 1.0
+        assert interior_net.weight == pytest.approx(1.0)
+
+    def test_anchor_weight_zero_is_regression_safe(
+        self, anchored_pcb: Path, tmp_path: Path,
+    ) -> None:
+        """Two runs with anchor_weight=0.0 must produce byte-identical PCBs.
+
+        The optimizer is deterministic (seed=42), and anchor_weight=0 is
+        the historical code path -- so back-to-back runs should agree
+        byte-for-byte. This pins the regression-safe default.
+        """
+        out_a = tmp_path / "out_a.kicad_pcb"
+        out_b = tmp_path / "out_b.kicad_pcb"
+
+        rc_a = run_optimize_placement(
+            str(anchored_pcb),
+            max_iterations=5,
+            output_path=str(out_a),
+            anchor_weight=0.0,
+            quiet=True,
+        )
+        rc_b = run_optimize_placement(
+            str(anchored_pcb),
+            max_iterations=5,
+            output_path=str(out_b),
+            anchor_weight=0.0,
+            quiet=True,
+        )
+        assert rc_a == 0
+        assert rc_b == 0
+        assert out_a.read_bytes() == out_b.read_bytes(), (
+            "anchor_weight=0.0 must be deterministic and equal to baseline"
+        )
+
+    def test_anchor_weight_preserves_locked_net(
+        self, anchored_pcb: Path, tmp_path: Path,
+    ) -> None:
+        """A non-zero anchor weight should not stretch NET_ANCHOR more than
+        the unweighted run does.
+
+        The optimizer is deterministic with seed=42, so this is a stable
+        comparison rather than a probabilistic one. The expectation is that
+        with anchor_weight>0 the optimizer pays a heavier price for moving
+        U1 away from the (locked) J1, so the final Manhattan distance from
+        U1 to J1 should be no greater than the unweighted run.
+        """
+        from kicad_tools.schema.pcb import PCB as SchemaPCB
+
+        out_unweighted = tmp_path / "out_unweighted.kicad_pcb"
+        out_weighted = tmp_path / "out_weighted.kicad_pcb"
+
+        rc_u = run_optimize_placement(
+            str(anchored_pcb),
+            max_iterations=20,
+            output_path=str(out_unweighted),
+            anchor_weight=0.0,
+            quiet=True,
+        )
+        rc_w = run_optimize_placement(
+            str(anchored_pcb),
+            max_iterations=20,
+            output_path=str(out_weighted),
+            anchor_weight=10.0,
+            quiet=True,
+        )
+        assert rc_u == 0
+        assert rc_w == 0
+
+        def _u1_distance_to_j1(pcb_path: Path) -> float:
+            """Compute Manhattan distance from U1 to J1 in the saved PCB."""
+            pcb = SchemaPCB.load(str(pcb_path))
+            positions = {fp.reference: fp.position for fp in pcb.footprints}
+            u1 = positions["U1"]
+            j1 = positions["J1"]
+            return abs(u1[0] - j1[0]) + abs(u1[1] - j1[1])
+
+        d_unweighted = _u1_distance_to_j1(out_unweighted)
+        d_weighted = _u1_distance_to_j1(out_weighted)
+
+        # The weighted run should not stretch NET_ANCHOR farther than the
+        # unweighted one. Allow a tiny tolerance for floating-point and
+        # CMA-ES non-determinism on the rounding boundary.
+        assert d_weighted <= d_unweighted + 1e-3, (
+            f"anchor weight should keep U1 near J1: "
+            f"unweighted={d_unweighted:.3f} mm, weighted={d_weighted:.3f} mm"
+        )
+
+    def test_negative_anchor_weight_is_rejected(self, anchored_pcb: Path) -> None:
+        """Negative anchor_weight is invalid; the runner should exit non-zero."""
+        rc = run_optimize_placement(
+            str(anchored_pcb),
+            max_iterations=1,
+            anchor_weight=-1.0,
+            quiet=True,
+        )
+        assert rc == 1
+
+
+class TestAnchorWeightCLI:
+    """Verify the --anchor-weight argparse wiring."""
+
+    def test_default_is_zero(self) -> None:
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["optimize-placement", "board.kicad_pcb"])
+        assert args.anchor_weight == 0.0
+
+    def test_explicit_value_parsed(self) -> None:
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(
+            ["optimize-placement", "board.kicad_pcb", "--anchor-weight", "3.5"],
+        )
+        assert args.anchor_weight == pytest.approx(3.5)

--- a/tests/test_placement_cost.py
+++ b/tests/test_placement_cost.py
@@ -1,0 +1,133 @@
+"""Unit tests for kicad_tools.placement.cost.
+
+Focused on per-net wirelength weighting (issue #2822).  The module ships
+with broader cost coverage in test_optimize_placement_cmd.py and the
+strategy/seed test files; this module isolates the new ``Net.weight`` knob
+introduced for anchor-aware optimisation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.placement.cost import (
+    ComponentPlacement,
+    Net,
+    compute_wirelength,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _placements() -> list[ComponentPlacement]:
+    """Three components arranged in an L-shape.
+
+    Layout:
+
+        A (0, 0)   B (10, 0)
+                          |
+                          C (10, 5)
+
+    HPWL of net {A, B, C} is (10-0) + (5-0) = 15 mm.
+    HPWL of net {A, B} is 10 mm; HPWL of net {B, C} is 5 mm.
+    """
+    return [
+        ComponentPlacement(reference="A", x=0.0, y=0.0),
+        ComponentPlacement(reference="B", x=10.0, y=0.0),
+        ComponentPlacement(reference="C", x=10.0, y=5.0),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Default-weight regression coverage
+# ---------------------------------------------------------------------------
+
+
+class TestComputeWirelengthDefaultWeight:
+    """Net constructed without an explicit weight must behave as before."""
+
+    def test_compute_wirelength_default_weight_unchanged(self) -> None:
+        # Sanity: explicit weight=1.0 and no weight kwarg agree.
+        placements = _placements()
+        net_default = Net(name="N", pins=[("A", "1"), ("B", "1"), ("C", "1")])
+        net_explicit = Net(
+            name="N",
+            pins=[("A", "1"), ("B", "1"), ("C", "1")],
+            weight=1.0,
+        )
+        assert net_default.weight == 1.0
+        assert (
+            compute_wirelength(placements, [net_default])
+            == compute_wirelength(placements, [net_explicit])
+        )
+
+    def test_compute_wirelength_matches_pre_weight_formula(self) -> None:
+        """Aggregate equals the historical sum of HPWLs (pre-#2822)."""
+        placements = _placements()
+        nets = [
+            Net(name="N1", pins=[("A", "1"), ("B", "1")]),  # HPWL = 10
+            Net(name="N2", pins=[("B", "1"), ("C", "1")]),  # HPWL =  5
+        ]
+        assert compute_wirelength(placements, nets) == pytest.approx(15.0)
+
+
+# ---------------------------------------------------------------------------
+# Per-net weighting
+# ---------------------------------------------------------------------------
+
+
+class TestComputeWirelengthHonorsPerNetWeight:
+    """compute_wirelength must scale each net's HPWL by ``net.weight``."""
+
+    def test_weight_three_triples_contribution(self) -> None:
+        placements = _placements()
+        net = Net(
+            name="HEAVY",
+            pins=[("A", "1"), ("B", "1")],
+            weight=3.0,
+        )
+        # HPWL = 10, weight = 3.0 -> 30.
+        assert compute_wirelength(placements, [net]) == pytest.approx(30.0)
+
+    def test_mixed_weights_sum_correctly(self) -> None:
+        placements = _placements()
+        nets = [
+            Net(name="A_B", pins=[("A", "1"), ("B", "1")], weight=2.0),  # 10*2 = 20
+            Net(name="B_C", pins=[("B", "1"), ("C", "1")], weight=0.5),  #  5*0.5 = 2.5
+        ]
+        assert compute_wirelength(placements, nets) == pytest.approx(22.5)
+
+    def test_weight_scales_linearly(self) -> None:
+        """Doubling the weight doubles the contribution."""
+        placements = _placements()
+        net1 = Net(name="N", pins=[("A", "1"), ("C", "1")], weight=1.0)
+        net2 = Net(name="N", pins=[("A", "1"), ("C", "1")], weight=2.0)
+        single = compute_wirelength(placements, [net1])
+        doubled = compute_wirelength(placements, [net2])
+        assert doubled == pytest.approx(2.0 * single)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestComputeWirelengthZeroWeight:
+    """Weight of 0 must drop the net from the sum entirely."""
+
+    def test_zero_weight_excludes_net(self) -> None:
+        placements = _placements()
+        kept = Net(name="KEEP", pins=[("A", "1"), ("B", "1")])  # HPWL=10
+        dropped = Net(
+            name="DROP",
+            pins=[("B", "1"), ("C", "1")],  # would add 5 if weight==1
+            weight=0.0,
+        )
+        assert compute_wirelength(placements, [kept, dropped]) == pytest.approx(10.0)
+
+    def test_zero_weight_alone_yields_zero(self) -> None:
+        placements = _placements()
+        net = Net(name="ZERO", pins=[("A", "1"), ("B", "1"), ("C", "1")], weight=0.0)
+        assert compute_wirelength(placements, [net]) == 0.0


### PR DESCRIPTION
## Summary

Adds an optional per-net weight to the placement HPWL cost and a new
`--anchor-weight FLOAT` CLI / MCP knob that scales the weight for nets
that touch any `(locked)` footprint:

```
weight = 1 + anchor_weight * (anchored_pins / total_pins)
```

Default `0.0` preserves uniform weighting (regression-safe). Recommended
range `2.0..5.0` to stop CMA-ES from starving perimeter-anchored signals
(connectors, edge sense FETs) when it reshuffles the interior cluster --
the failure mode behind board 05 losing HALL_A/B/C, ISENSE_A-, ISENSE_B-,
PWM_AL, and SW_OUT in the optimisation experiment described in #2822.

## Implementation

Two-layer change as specified by the Curator:

**Layer 1 -- cost module (`src/kicad_tools/placement/cost.py`):**
- `Net.weight: float = 1.0` field added to the dataclass.
- `compute_wirelength` multiplies each net's HPWL by `net.weight`.
- Existing call sites continue to work unchanged (default = 1.0).

**Layer 2 -- CLI/MCP wiring:**
- `src/kicad_tools/cli/optimize_placement_cmd.py`: `_read_board_data` now
  collects `locked_refs = {fp.reference for fp in pcb.footprints if fp.locked}`
  and stamps `Net.weight` via a new `_compute_net_anchor_weight` helper.
- `src/kicad_tools/cli/parser.py`: new `--anchor-weight FLOAT` argument
  (default `0.0`, validated `>= 0` in the runner).
- `src/kicad_tools/cli/commands/optimize_placement.py`: forwards the new
  arg through `getattr(args, "anchor_weight", 0.0)`.
- `src/kicad_tools/mcp/tools/optimize_placement.py`: mirrors the change --
  `optimize_placement(...)` gains an `anchor_weight: float = 0.0` kwarg,
  raises `ValueError` on negative input, and threads through `_read_board_data`.

## Test plan

- [x] **Unit tests** in `tests/test_placement_cost.py` (7 new tests):
  - `test_compute_wirelength_default_weight_unchanged` -- explicit
    `weight=1.0` and no kwarg agree.
  - `test_compute_wirelength_matches_pre_weight_formula` -- baseline
    HPWL still equals the historical sum.
  - `test_weight_three_triples_contribution`,
    `test_mixed_weights_sum_correctly`, `test_weight_scales_linearly`.
  - `test_zero_weight_excludes_net`, `test_zero_weight_alone_yields_zero`.
- [x] **Integration tests** in `tests/test_optimize_placement_cmd.py`
  (7 new tests under `TestAnchorWeight` / `TestAnchorWeightCLI`):
  - `test_read_board_data_default_zero_weight` -- every Net.weight is 1.0.
  - `test_read_board_data_anchor_weight_inflates_locked_net` -- only the
    `(locked)`-touching net's weight inflates (`1 + 4*0.5 = 3.0`).
  - `test_anchor_weight_zero_is_regression_safe` -- two runs at
    `anchor_weight=0.0` produce byte-identical PCBs.
  - `test_anchor_weight_preserves_locked_net` -- with
    `anchor_weight=10.0`, U1 stays no farther from the (locked) J1 than
    the unweighted run.
  - `test_negative_anchor_weight_is_rejected` -- runner returns 1.
  - `test_default_is_zero`, `test_explicit_value_parsed` -- argparse wiring.
- [x] All 55 tests pass for the targeted files; broader sweep
  (`pytest tests/ -k 'placement or optimize_placement or cost'`) returns
  1248 passed, 39 skipped.

Closes #2822

🤖 Generated with [Claude Code](https://claude.com/claude-code)