### PR TITLE
feat(placement): feasibility-gated convergence + exit code (closes #2821)

### DIFF
--- a/src/kicad_tools/cli/build_cmd.py
+++ b/src/kicad_tools/cli/build_cmd.py
@@ -794,6 +794,14 @@ def _run_step_placement(ctx: BuildContext, console: Console) -> BuildResult:
             "cmaes",
             "--max-iterations",
             "300",
+            # Wall-clock cap: with the feasibility-gated convergence
+            # added in #2821 the optimizer no longer terminates at a
+            # plateau in the infeasible region, so a hard time budget
+            # is required to keep the build step bounded. Generous
+            # default (5 minutes) -- callers who need more should run
+            # `kct optimize-placement` directly.
+            "--time-budget",
+            "300",
             "--seed",
             "force-directed",
             "--output",

--- a/src/kicad_tools/cli/commands/optimize_placement.py
+++ b/src/kicad_tools/cli/commands/optimize_placement.py
@@ -21,4 +21,6 @@ def run_optimize_placement_command(args) -> int:
         quiet=getattr(args, "quiet", False) or getattr(args, "global_quiet", False),
         no_slide_off=getattr(args, "no_slide_off", False),
         anchor_weight=getattr(args, "anchor_weight", 0.0),
+        time_budget=getattr(args, "time_budget", None),
+        allow_infeasible=getattr(args, "allow_infeasible", False),
     )

--- a/src/kicad_tools/cli/optimize_placement_cmd.py
+++ b/src/kicad_tools/cli/optimize_placement_cmd.py
@@ -25,6 +25,7 @@ from typing import Sequence
 from kicad_tools.placement.cost import (
     BoardOutline,
     ComponentPlacement,
+    CostMode,
     DesignRuleSet,
     Net,
     PlacementCostConfig,
@@ -179,21 +180,53 @@ def _build_footprint_sizes(
 
 
 def _parse_weights(weights_json: str | None) -> PlacementCostConfig:
-    """Parse a JSON string into PlacementCostConfig, or return defaults."""
+    """Parse a JSON string into PlacementCostConfig.
+
+    Defaults to :class:`CostMode.LEXICOGRAPHIC` so that the optimizer's
+    convergence check (issue #2821) can use the feasibility-sentinel
+    score (>= 1e12) to refuse early convergence in the infeasible region.
+
+    Callers can override the mode via the ``"mode"`` key in the JSON
+    payload (``"lexicographic"`` or ``"weighted_sum"``).
+    """
+    defaults = {
+        "overlap_weight": 1e6,
+        "drc_weight": 1e4,
+        "boundary_weight": 1e5,
+        "wirelength_weight": 1.0,
+        "area_weight": 0.1,
+        "mode": CostMode.LEXICOGRAPHIC,
+    }
+
     if weights_json is None:
-        return PlacementCostConfig()
+        return PlacementCostConfig(**defaults)
     try:
         data = json.loads(weights_json)
     except json.JSONDecodeError as e:
         print(f"Error: invalid JSON for --weights: {e}", file=sys.stderr)
         raise SystemExit(1) from e
 
+    mode = defaults["mode"]
+    raw_mode = data.get("mode")
+    if raw_mode is not None:
+        try:
+            mode = CostMode(raw_mode)
+        except ValueError as e:
+            valid = ", ".join(m.value for m in CostMode)
+            print(
+                f"Error: invalid 'mode' in --weights JSON "
+                f"(got {raw_mode!r}; valid: {valid})",
+                file=sys.stderr,
+            )
+            raise SystemExit(1) from e
+
     return PlacementCostConfig(
-        overlap_weight=data.get("overlap", 1e6),
-        drc_weight=data.get("drc", 1e4),
-        boundary_weight=data.get("boundary", 1e5),
-        wirelength_weight=data.get("wirelength", 1.0),
-        area_weight=data.get("area", 0.1),
+        overlap_weight=data.get("overlap", defaults["overlap_weight"]),
+        drc_weight=data.get("drc", defaults["drc_weight"]),
+        boundary_weight=data.get("boundary", defaults["boundary_weight"]),
+        wirelength_weight=data.get("wirelength", defaults["wirelength_weight"]),
+        area_weight=data.get("area", defaults["area_weight"]),
+        mode=mode,
     )
 
 
@@ -490,6 +523,8 @@ def run_optimize_placement(
     quiet: bool = False,
     no_slide_off: bool = False,
     anchor_weight: float = 0.0,
+    time_budget: float | None = None,
+    allow_infeasible: bool = False,
 ) -> int:
     """Run placement optimization.
 
@@ -510,9 +545,22 @@ def run_optimize_placement(
             receive an inflated wirelength weight of
             ``1 + anchor_weight * anchor_pad_fraction``. Default 0.0
             preserves the historical uniform weighting (regression-safe).
+        time_budget: Wall-clock budget in seconds. The main optimization
+            loop exits as soon as the elapsed time exceeds this value
+            (after completing the current generation). ``None`` means no
+            wall-clock cap (issue #2821). Used to bound the new
+            "keep going past plateau while infeasible" behaviour.
+        allow_infeasible: When True, the command returns exit code 0 even
+            if the final placement is infeasible (overlap/DRC/boundary
+            violations remain). Default behaviour is to exit 1 with a
+            ``FATAL:`` message on stderr in that case (issue #2821).
 
     Returns:
-        Exit code (0 for success, 1 for failure).
+        Exit code:
+            * 0 -- final placement is feasible (or ``allow_infeasible=True``)
+            * 1 -- input error, write error, infeasible final placement, or
+              unresolved pad-pad overlaps from the post-pass slide-off
+            * 2 -- interrupted (SIGINT/SIGTERM); partial result saved
     """
     # Validate PCB file exists
     pcb_file = Path(pcb_path)
@@ -724,6 +772,18 @@ def run_optimize_placement(
                     print(f"  Converged at iteration {iteration}")
                 break
 
+            # Wall-clock budget check (issue #2821): exit gracefully if
+            # the configured time budget has been exceeded. Checked
+            # before each generation so the most recent best is preserved.
+            if time_budget is not None and (time.monotonic() - start_time) >= time_budget:
+                if not quiet:
+                    elapsed_now = time.monotonic() - start_time
+                    print(
+                        f"  Time budget exhausted at iteration {iteration} "
+                        f"(elapsed={elapsed_now:.1f}s, budget={time_budget:.1f}s)"
+                    )
+                break
+
             # Ask for new candidates
             pop_size = strategy._population_size
             candidates = strategy.suggest(pop_size)
@@ -872,7 +932,47 @@ def run_optimize_placement(
     if _interrupt_state["interrupted"]:
         return 2
 
+    # Issue #2821: gate exit code on full feasibility, not just pad-pad
+    # slide-off failures. If the final placement has overlap > 0 OR
+    # drc > 0 OR boundary > 0 OR block_boundary > 0, the optimizer has
+    # produced an illegal placement and downstream consumers (router,
+    # DRC) will inherit it. Print a FATAL line and exit non-zero so
+    # pipelines like `place_route.py` and `BuildStep.PLACE` can detect
+    # the failure. The legacy "exit 0 even when infeasible" behaviour
+    # is available via ``--allow-infeasible`` for explicit opt-in
+    # debugging / interactive workflows.
+    if not final_score.is_feasible:
+        b = final_score.breakdown
+        components_failing = []
+        if b.overlap > 0:
+            components_failing.append(f"overlap={b.overlap:.2f}mm^2")
+        if b.drc > 0:
+            components_failing.append(f"drc={b.drc:.0f}")
+        if b.boundary > 0:
+            components_failing.append(f"boundary={b.boundary:.2f}")
+        if b.block_boundary > 0:
+            components_failing.append(f"block_boundary={b.block_boundary:.2f}")
+        detail = ", ".join(components_failing) if components_failing else "unknown"
+
+        if not allow_infeasible:
+            print(
+                f"FATAL: optimizer exited with infeasible placement ({detail}). "
+                f"Downstream router/DRC will inherit illegal geometry. "
+                f"Pass --allow-infeasible to suppress this error.",
+                file=sys.stderr,
+            )
+            return 1
+        elif not quiet:
+            print(
+                f"\n  WARNING: final placement is infeasible ({detail}); "
+                f"--allow-infeasible suppresses non-zero exit."
+            )
+
     # Exit code 1 when pad-pad overlaps remain (actual clearance < 0).
+    # Note: with the feasibility gate above this is now mostly redundant
+    # (any pad overlap implies overlap > 0 in the cost breakdown), but
+    # it is preserved for backwards compatibility with callers that pass
+    # ``--allow-infeasible`` and still want pad-pad failures surfaced.
     if has_unresolved_overlaps:
         pad_overlaps = [
             d

--- a/src/kicad_tools/cli/optimize_placement_cmd.py
+++ b/src/kicad_tools/cli/optimize_placement_cmd.py
@@ -970,10 +970,12 @@ def run_optimize_placement(
 
     # Exit code 1 when pad-pad overlaps remain (actual clearance < 0).
     # Note: with the feasibility gate above this is now mostly redundant
-    # (any pad overlap implies overlap > 0 in the cost breakdown), but
-    # it is preserved for backwards compatibility with callers that pass
-    # ``--allow-infeasible`` and still want pad-pad failures surfaced.
-    if has_unresolved_overlaps:
+    # (any pad overlap implies overlap > 0 in the cost breakdown). It is
+    # preserved as a fallback for callers that disable the feasibility
+    # gate by writing custom weights with ``CostMode.WEIGHTED_SUM``,
+    # where ``is_feasible`` is still computed but the feasibility gate
+    # may behave differently. Skipped under ``--allow-infeasible``.
+    if has_unresolved_overlaps and not allow_infeasible:
         pad_overlaps = [
             d
             for d in post_slide_result.overlap_details

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3615,6 +3615,32 @@ def _add_optimize_placement_parser(subparsers) -> None:
             "signals (connectors, edge sense FETs) from being starved."
         ),
     )
+    op_parser.add_argument(
+        "--time-budget",
+        type=float,
+        default=None,
+        metavar="SECONDS",
+        help=(
+            "Wall-clock budget in seconds. The optimization loop exits "
+            "once this many seconds have elapsed (after the current "
+            "generation finishes). Use this to bound the new "
+            "feasibility-gated convergence behaviour (issue #2821), "
+            "where the loop refuses to declare convergence while the "
+            "best-known placement is still infeasible. Default: no cap."
+        ),
+    )
+    op_parser.add_argument(
+        "--allow-infeasible",
+        action="store_true",
+        default=False,
+        help=(
+            "Return exit code 0 even when the final placement is "
+            "infeasible (overlap/DRC/boundary violations remain). "
+            "Default behaviour (issue #2821) is to exit 1 with a "
+            "FATAL: message on stderr so pipelines do not silently "
+            "hand illegal placements to the router."
+        ),
+    )
     op_parser.add_argument("-v", "--verbose", action="store_true")
     op_parser.add_argument("-q", "--quiet", action="store_true", help="Suppress progress output")
 

--- a/src/kicad_tools/placement/cmaes_strategy.py
+++ b/src/kicad_tools/placement/cmaes_strategy.py
@@ -32,6 +32,7 @@ from pathlib import Path
 import numpy as np
 from numpy.typing import NDArray
 
+from .cost import INFEASIBILITY_OFFSET
 from .strategy import PlacementStrategy, StrategyConfig
 from .vector import PlacementBounds, PlacementVector
 
@@ -281,6 +282,21 @@ class CMAESStrategy(PlacementStrategy):
         Convergence is detected when the best score has not improved by
         more than ``convergence_threshold`` (relative) over the last
         ``convergence_window`` generations.
+
+        Feasibility gate (added for issue #2821):
+            When the best-known score indicates an infeasible placement
+            (i.e. ``best_score >= INFEASIBILITY_OFFSET`` under
+            :class:`CostMode.LEXICOGRAPHIC`), convergence is suppressed.
+            This prevents the optimizer from terminating early at a
+            plateau in the infeasible region — the loop continues until
+            the iteration cap (or wall-clock budget) is hit, giving the
+            optimizer a chance to push into the feasible region.
+
+            The check is purely score-based, so it is a no-op for the
+            ``WEIGHTED_SUM`` cost mode (where infeasibility is not
+            sentinel-encoded). Callers that want feasibility-gated
+            convergence should drive the optimizer with
+            ``CostMode.LEXICOGRAPHIC``.
         """
         if self._config is None:
             return
@@ -302,11 +318,18 @@ class CMAESStrategy(PlacementStrategy):
         else:
             improvement = abs(oldest - newest) / abs(oldest)
 
-        if improvement < self._config.convergence_threshold:
-            self._converged = True
+        plateau = improvement < self._config.convergence_threshold
+        # Library-level stopping criterion (e.g. CMA-ES sigma collapse).
+        library_stop = self._optimizer is not None and self._optimizer.should_stop()
 
-        # Also check the library's own stopping criterion
-        if self._optimizer is not None and self._optimizer.should_stop():
+        # Feasibility gate: never declare convergence while the best-known
+        # score corresponds to an infeasible placement (lexicographic mode).
+        # In WEIGHTED_SUM mode this gate is inactive because scores below
+        # INFEASIBILITY_OFFSET (1e12) can also be infeasible -- callers who
+        # need this gate should use lexicographic mode.
+        infeasible = self._best_score >= INFEASIBILITY_OFFSET
+
+        if (plateau or library_stop) and not infeasible:
             self._converged = True
 
     def save_state(self, path: Path | str) -> None:

--- a/src/kicad_tools/placement/cost.py
+++ b/src/kicad_tools/placement/cost.py
@@ -28,6 +28,16 @@ class CostMode(Enum):
     LEXICOGRAPHIC = "lexicographic"
 
 
+# Score offset added to any infeasible placement when running in
+# :class:`CostMode.LEXICOGRAPHIC` mode. Used as a feasibility sentinel:
+# any total score below this value indicates a feasible placement; any
+# total score >= this value indicates an infeasible placement.
+#
+# Consumers like the CMA-ES convergence check can use this to decide
+# whether the optimizer is still in the infeasible region.
+INFEASIBILITY_OFFSET: float = 1e12
+
+
 @dataclass(frozen=True)
 class PlacementCostConfig:
     """Configuration for the composite cost function.
@@ -631,8 +641,7 @@ def _lexicographic_score(
         # Large offset ensures any infeasible score > any feasible score.
         # The infeasibility components are added so the optimizer can still
         # differentiate between "slightly infeasible" and "very infeasible".
-        infeasibility_offset = 1e12
-        return infeasibility_offset + (
+        return INFEASIBILITY_OFFSET + (
             config.overlap_weight * breakdown.overlap
             + config.drc_weight * breakdown.drc
             + config.boundary_weight * breakdown.boundary

--- a/tests/placement/__init__.py
+++ b/tests/placement/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the placement subsystem (CMA-ES strategy, cost, etc.)."""

--- a/tests/placement/test_cmaes_strategy.py
+++ b/tests/placement/test_cmaes_strategy.py
@@ -8,8 +8,6 @@ INFEASIBILITY_OFFSET`` under :class:`CostMode.LEXICOGRAPHIC`).
 
 from __future__ import annotations
 
-import numpy as np
-
 from kicad_tools.placement.cmaes_strategy import CMAESStrategy
 from kicad_tools.placement.cost import INFEASIBILITY_OFFSET, BoardOutline
 from kicad_tools.placement.strategy import StrategyConfig

--- a/tests/placement/test_cmaes_strategy.py
+++ b/tests/placement/test_cmaes_strategy.py
@@ -1,0 +1,183 @@
+"""Tests for CMAESStrategy convergence semantics.
+
+These tests focus on the feasibility-gated convergence behaviour added
+for issue #2821: the optimizer must not declare convergence while the
+best-known placement is infeasible (signalled by ``best_score >=
+INFEASIBILITY_OFFSET`` under :class:`CostMode.LEXICOGRAPHIC`).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from kicad_tools.placement.cmaes_strategy import CMAESStrategy
+from kicad_tools.placement.cost import INFEASIBILITY_OFFSET, BoardOutline
+from kicad_tools.placement.strategy import StrategyConfig
+from kicad_tools.placement.vector import ComponentDef, bounds
+
+
+def _make_bounds():
+    """Build placement bounds for a small synthetic board + components."""
+    board = BoardOutline(min_x=0.0, min_y=0.0, max_x=50.0, max_y=50.0)
+    components = [
+        ComponentDef(reference=f"U{i + 1}", width=2.0, height=2.0) for i in range(3)
+    ]
+    return bounds(board, components)
+
+
+class TestFeasibilityGatedConvergence:
+    """Issue #2821: convergence must be suppressed in the infeasible region."""
+
+    def test_does_not_converge_while_infeasible(self):
+        """Feeding plateaued infeasible scores must NOT flip ``converged``.
+
+        Drive the strategy with synthetic ``observe()`` calls reporting
+        identical infeasible scores (>= INFEASIBILITY_OFFSET). Even after
+        ``convergence_window`` plateau-detection windows, ``converged``
+        should remain False because the best-known score is still
+        infeasible.
+        """
+        strategy = CMAESStrategy()
+        b = _make_bounds()
+        config = StrategyConfig(
+            seed=42,
+            convergence_window=5,
+            convergence_threshold=1e-6,
+            extra={"population_size": 6},
+        )
+        pop = strategy.initialize(b, config)
+
+        # Score = INFEASIBILITY_OFFSET + small overlap penalty (matches
+        # what _lexicographic_score produces for an infeasible placement).
+        infeasible_score = INFEASIBILITY_OFFSET + 100.0
+
+        # Run window + 10 generations of perfectly plateaued infeasible
+        # scores. Without the feasibility gate, plateau detection would
+        # flip _converged after the first ``convergence_window``
+        # generations (around generation 5).
+        for _ in range(config.convergence_window + 10):
+            scores = [infeasible_score] * len(pop)
+            strategy.observe(pop, scores)
+            assert not strategy.converged, (
+                "Strategy declared convergence while best-known score "
+                f"({strategy.best()[1]}) is still infeasible "
+                f">= {INFEASIBILITY_OFFSET}"
+            )
+            pop = strategy.suggest(6)
+
+    def test_converges_once_feasible_and_plateau(self):
+        """After a feasible score arrives and then plateaus, converge."""
+        strategy = CMAESStrategy()
+        b = _make_bounds()
+        config = StrategyConfig(
+            seed=42,
+            convergence_window=5,
+            convergence_threshold=1e-6,
+            extra={"population_size": 6},
+        )
+        pop = strategy.initialize(b, config)
+
+        # First, plateau in the infeasible region. No convergence yet.
+        for _ in range(config.convergence_window + 2):
+            scores = [INFEASIBILITY_OFFSET + 50.0] * len(pop)
+            strategy.observe(pop, scores)
+            pop = strategy.suggest(6)
+        assert not strategy.converged
+
+        # Now drop a single feasible score (well below the offset).
+        # This becomes the new best, but score history still has older
+        # infeasible best-scores in the window.
+        scores = [42.0] + [INFEASIBILITY_OFFSET + 50.0] * (len(pop) - 1)
+        strategy.observe(pop, scores)
+        pop = strategy.suggest(6)
+
+        # Now plateau at the feasible best for a full window.
+        for _ in range(config.convergence_window + 2):
+            scores = [INFEASIBILITY_OFFSET + 50.0] * len(pop)
+            strategy.observe(pop, scores)
+            pop = strategy.suggest(6)
+
+        assert strategy.converged, (
+            "Strategy should converge after feasible best plus plateau "
+            f"(best={strategy.best()[1]})"
+        )
+
+    def test_score_just_below_offset_is_treated_as_feasible(self):
+        """Boundary check: a best-score just under 1e12 counts as feasible.
+
+        The feasibility gate uses ``best_score >= INFEASIBILITY_OFFSET``
+        (1e12). A score of ``INFEASIBILITY_OFFSET - 1`` should not block
+        convergence detection.
+        """
+        strategy = CMAESStrategy()
+        b = _make_bounds()
+        config = StrategyConfig(
+            seed=42,
+            convergence_window=5,
+            convergence_threshold=1e-6,
+            extra={"population_size": 6},
+        )
+        pop = strategy.initialize(b, config)
+
+        feasible_score = INFEASIBILITY_OFFSET - 1.0
+        for _ in range(config.convergence_window + 5):
+            scores = [feasible_score] * len(pop)
+            strategy.observe(pop, scores)
+            pop = strategy.suggest(6)
+
+        assert strategy.converged, (
+            "A best-score just under INFEASIBILITY_OFFSET should be "
+            "treated as feasible and allow plateau-convergence."
+        )
+
+    def test_score_at_exact_offset_blocks_convergence(self):
+        """Boundary check: a best-score exactly at 1e12 blocks convergence."""
+        strategy = CMAESStrategy()
+        b = _make_bounds()
+        config = StrategyConfig(
+            seed=42,
+            convergence_window=5,
+            convergence_threshold=1e-6,
+            extra={"population_size": 6},
+        )
+        pop = strategy.initialize(b, config)
+
+        for _ in range(config.convergence_window + 5):
+            scores = [float(INFEASIBILITY_OFFSET)] * len(pop)
+            strategy.observe(pop, scores)
+            pop = strategy.suggest(6)
+
+        assert not strategy.converged, (
+            "best_score == INFEASIBILITY_OFFSET should still be treated "
+            "as infeasible (>= comparison)."
+        )
+
+    def test_weighted_sum_mode_unaffected(self):
+        """Feasibility gate is a no-op for non-lexicographic scoring.
+
+        The convergence check is purely score-based (it checks whether
+        ``best_score >= INFEASIBILITY_OFFSET`` (1e12)). In ``WEIGHTED_SUM``
+        mode the optimizer is operating with totally different score
+        magnitudes, so the gate is inactive: small plateaued scores must
+        still converge.
+        """
+        strategy = CMAESStrategy()
+        b = _make_bounds()
+        config = StrategyConfig(
+            seed=42,
+            convergence_window=5,
+            convergence_threshold=1e-6,
+            extra={"population_size": 6},
+        )
+        pop = strategy.initialize(b, config)
+
+        # Small plateaued scores -- typical of WEIGHTED_SUM mode.
+        for _ in range(config.convergence_window + 5):
+            scores = [100.0] * len(pop)
+            strategy.observe(pop, scores)
+            pop = strategy.suggest(6)
+
+        assert strategy.converged, (
+            "Feasibility gate must not block convergence at small "
+            "weighted-sum scores."
+        )

--- a/tests/test_optimize_placement_cmd.py
+++ b/tests/test_optimize_placement_cmd.py
@@ -956,7 +956,6 @@ def anchored_pcb(tmp_path: Path) -> Path:
   (setup
     (pad_to_mask_clearance 0.05)
   )
-  (net 0 "")
   (net 1 "NET_ANCHOR")
   (net 2 "NET_INTERIOR")
   (footprint "Conn_J1" (layer "F.Cu")
@@ -992,6 +991,70 @@ def anchored_pcb(tmp_path: Path) -> Path:
 )
 """
     pcb_file = tmp_path / "anchored_board.kicad_pcb"
+    pcb_file.write_text(pcb_content)
+    return pcb_file
+
+
+# ---------------------------------------------------------------------------
+# Feasibility-gated exit-code tests (issue #2821)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def pathological_pcb(tmp_path: Path) -> Path:
+    """A PCB where 4 large footprints cannot fit on a tiny board.
+
+    Each footprint is roughly 10x10mm; the board is 12x12mm. There is
+    no legal placement, so any optimizer outcome is infeasible.
+    """
+    pcb_content = """\
+(kicad_pcb (version 20230101) (generator "test")
+  (general (thickness 1.6))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (setup
+    (pad_to_mask_clearance 0.05)
+  )
+  (net 0 "")
+  (net 1 "N1")
+  (footprint "U_big" (layer "F.Cu")
+    (at 6.0 6.0 0)
+    (property "Reference" "U1")
+    (fp_text reference "U1" (at 0 -5.5) (layer "F.SilkS") (effects (font (size 1 1) (thickness 0.15))))
+    (pad "1" smd rect (at -4.5 -4.5) (size 0.8 0.8) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "N1"))
+    (pad "2" smd rect (at 4.5 4.5) (size 0.8 0.8) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "N1"))
+  )
+  (footprint "U_big" (layer "F.Cu")
+    (at 6.0 6.0 0)
+    (property "Reference" "U2")
+    (fp_text reference "U2" (at 0 -5.5) (layer "F.SilkS") (effects (font (size 1 1) (thickness 0.15))))
+    (pad "1" smd rect (at -4.5 -4.5) (size 0.8 0.8) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "N1"))
+    (pad "2" smd rect (at 4.5 4.5) (size 0.8 0.8) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "N1"))
+  )
+  (footprint "U_big" (layer "F.Cu")
+    (at 6.0 6.0 0)
+    (property "Reference" "U3")
+    (fp_text reference "U3" (at 0 -5.5) (layer "F.SilkS") (effects (font (size 1 1) (thickness 0.15))))
+    (pad "1" smd rect (at -4.5 -4.5) (size 0.8 0.8) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "N1"))
+    (pad "2" smd rect (at 4.5 4.5) (size 0.8 0.8) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "N1"))
+  )
+  (footprint "U_big" (layer "F.Cu")
+    (at 6.0 6.0 0)
+    (property "Reference" "U4")
+    (fp_text reference "U4" (at 0 -5.5) (layer "F.SilkS") (effects (font (size 1 1) (thickness 0.15))))
+    (pad "1" smd rect (at -4.5 -4.5) (size 0.8 0.8) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "N1"))
+    (pad "2" smd rect (at 4.5 4.5) (size 0.8 0.8) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "N1"))
+  )
+  (gr_line (start 0 0) (end 12 0) (layer "Edge.Cuts") (width 0.05))
+  (gr_line (start 12 0) (end 12 12) (layer "Edge.Cuts") (width 0.05))
+  (gr_line (start 12 12) (end 0 12) (layer "Edge.Cuts") (width 0.05))
+  (gr_line (start 0 12) (end 0 0) (layer "Edge.Cuts") (width 0.05))
+)
+"""
+    pcb_file = tmp_path / "pathological.kicad_pcb"
     pcb_file.write_text(pcb_content)
     return pcb_file
 
@@ -1143,3 +1206,187 @@ class TestAnchorWeightCLI:
             ["optimize-placement", "board.kicad_pcb", "--anchor-weight", "3.5"],
         )
         assert args.anchor_weight == pytest.approx(3.5)
+
+
+class TestFeasibilityGatedExitCode:
+    """Issue #2821: exit code must reflect ``final_score.is_feasible``."""
+
+    def test_returns_nonzero_when_infeasible(self, pathological_pcb, tmp_path, capsys):
+        """A pathological board yields infeasible result -> exit 1 + FATAL stderr.
+
+        Acceptance criterion: ``run_optimize_placement`` returns exit
+        code 1 (not 0) and prints a ``FATAL:`` message on stderr when
+        the final placement is infeasible.
+        """
+        output = tmp_path / "infeasible_out.kicad_pcb"
+        result = run_optimize_placement(
+            str(pathological_pcb),
+            max_iterations=10,
+            output_path=str(output),
+            time_budget=5.0,
+            quiet=True,
+        )
+        captured = capsys.readouterr()
+        assert result == 1, (
+            f"Expected exit 1 for infeasible placement, got {result}. "
+            f"stderr={captured.err!r}"
+        )
+        assert "FATAL" in captured.err, (
+            f"Expected 'FATAL' in stderr, got {captured.err!r}"
+        )
+        # Output is still written so callers can inspect.
+        assert output.exists()
+
+    def test_returns_zero_on_feasible_solution(self, tmp_pcb, tmp_path):
+        """A feasible board must return exit 0 with the new defaults.
+
+        Acceptance criterion: backwards-compatible behaviour for boards
+        that the optimizer can actually solve.
+        """
+        output = tmp_path / "feasible_out.kicad_pcb"
+        result = run_optimize_placement(
+            str(tmp_pcb),
+            max_iterations=10,
+            output_path=str(output),
+            quiet=True,
+        )
+        assert result == 0, f"Expected exit 0 for feasible board, got {result}"
+        assert output.exists()
+
+    def test_allow_infeasible_flag_restores_zero_exit(
+        self, pathological_pcb, tmp_path, capsys,
+    ):
+        """``--allow-infeasible`` opt-in restores legacy exit-0 behaviour."""
+        output = tmp_path / "allow_infeasible_out.kicad_pcb"
+        result = run_optimize_placement(
+            str(pathological_pcb),
+            max_iterations=10,
+            output_path=str(output),
+            time_budget=5.0,
+            quiet=True,
+            allow_infeasible=True,
+        )
+        captured = capsys.readouterr()
+        assert result == 0, (
+            f"Expected exit 0 with --allow-infeasible, got {result}. "
+            f"stderr={captured.err!r}"
+        )
+        # No FATAL on stderr in opt-in mode.
+        assert "FATAL" not in captured.err
+        assert output.exists()
+
+    def test_wall_clock_budget_caps_runtime(self, pathological_pcb, tmp_path):
+        """``time_budget`` bounds wall-clock time on a pathological board.
+
+        Acceptance criterion: the new "keep going past plateau while
+        infeasible" loop cannot hang forever -- a wall-clock cap forces
+        graceful exit. With the pathological board the result will be
+        infeasible (exit 1), but it must still respect the budget.
+        """
+        import time as _time
+
+        output = tmp_path / "budget_out.kicad_pcb"
+        budget = 2.0
+        start = _time.monotonic()
+        result = run_optimize_placement(
+            str(pathological_pcb),
+            max_iterations=100000,  # would hang without time budget
+            output_path=str(output),
+            time_budget=budget,
+            quiet=True,
+        )
+        elapsed = _time.monotonic() - start
+        # Generous slack: budget is checked once per generation; one
+        # generation evaluation + post-pass slide-off can add overhead.
+        assert elapsed < budget + 10.0, (
+            f"Wall-clock {elapsed:.1f}s exceeded budget {budget:.1f}s + 10s slack"
+        )
+        # Either feasible-and-exit-0 or infeasible-and-exit-1; never
+        # silently exit 0 with an infeasible result.
+        assert result in (0, 1), f"Expected exit 0 or 1, got {result}"
+
+    def test_fatal_message_names_failing_components(
+        self, pathological_pcb, tmp_path, capsys,
+    ):
+        """The FATAL message lists which cost components failed.
+
+        Acceptance criterion: the FATAL line names overlap / drc /
+        boundary as appropriate so users know what went wrong.
+        """
+        output = tmp_path / "fatal_msg.kicad_pcb"
+        run_optimize_placement(
+            str(pathological_pcb),
+            max_iterations=5,
+            output_path=str(output),
+            time_budget=3.0,
+            quiet=True,
+        )
+        captured = capsys.readouterr()
+        # Must mention at least one of the failure components by name.
+        # On the pathological board overlap is guaranteed to be > 0.
+        assert "overlap" in captured.err, (
+            f"Expected FATAL to name 'overlap', got {captured.err!r}"
+        )
+
+    def test_default_cost_mode_is_lexicographic(self):
+        """Issue #2821: default cost mode for optimize-placement is LEXICOGRAPHIC.
+
+        Required for the feasibility-gated convergence in
+        ``CMAESStrategy._check_convergence`` to take effect (the gate
+        keys off scores >= 1e12 produced by lexicographic scoring).
+        """
+        from kicad_tools.placement.cost import CostMode
+
+        config = _parse_weights(None)
+        assert config.mode == CostMode.LEXICOGRAPHIC
+
+    def test_weights_json_can_override_cost_mode(self):
+        """Callers can opt back in to weighted-sum scoring via the JSON."""
+        from kicad_tools.placement.cost import CostMode
+
+        config = _parse_weights('{"mode": "weighted_sum"}')
+        assert config.mode == CostMode.WEIGHTED_SUM
+
+        config2 = _parse_weights('{"mode": "lexicographic"}')
+        assert config2.mode == CostMode.LEXICOGRAPHIC
+
+    def test_weights_json_invalid_mode_raises(self):
+        """A bad ``mode`` value produces a clear error and SystemExit."""
+        with pytest.raises(SystemExit):
+            _parse_weights('{"mode": "not-a-real-mode"}')
+
+
+class TestCLIFlagsForFeasibilityGate:
+    """Verify the new --time-budget and --allow-infeasible CLI flags."""
+
+    def test_parser_accepts_time_budget(self):
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(
+            ["optimize-placement", "board.kicad_pcb", "--time-budget", "30"]
+        )
+        assert args.time_budget == 30.0
+
+    def test_parser_default_time_budget_is_none(self):
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["optimize-placement", "board.kicad_pcb"])
+        assert args.time_budget is None
+
+    def test_parser_accepts_allow_infeasible(self):
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(
+            ["optimize-placement", "board.kicad_pcb", "--allow-infeasible"]
+        )
+        assert args.allow_infeasible is True
+
+    def test_parser_default_allow_infeasible_is_false(self):
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["optimize-placement", "board.kicad_pcb"])
+        assert args.allow_infeasible is False


### PR DESCRIPTION
## Summary

Closes #2821.

The placement optimizer used to terminate at a plateau even when the
best-known placement was still infeasible (overlap > 0, DRC > 0,
boundary > 0). It then returned exit code 0, so downstream consumers
(router, DRC, ``BuildStep.PLACE``) silently inherited an illegal board.
This PR makes feasibility a hard gate on both convergence and the exit
code, with backwards-compatible escape hatches for explicit debugging.

## Changes

### Convergence gate (the "keep going past plateau while infeasible" fix)

- `placement/cost.py`: extract the magic ``1e12`` infeasibility offset
  into a module-level ``INFEASIBILITY_OFFSET`` constant so other modules
  can use it as a feasibility sentinel.
- `placement/cmaes_strategy.py`: ``_check_convergence()`` now refuses to
  flip ``self._converged = True`` while ``self._best_score >=
  INFEASIBILITY_OFFSET``. Plateau detection and the underlying CMAwM
  ``should_stop()`` are still observed, but they are gated behind
  feasibility. The check is purely score-based, so it is a no-op for
  ``CostMode.WEIGHTED_SUM``.

### Default cost mode

- `cli/optimize_placement_cmd.py`: ``_parse_weights`` now defaults
  ``CostMode.LEXICOGRAPHIC`` so the score-based feasibility gate above
  is active by default. A new ``"mode"`` key in the ``--weights`` JSON
  payload lets callers opt back into ``"weighted_sum"`` if needed.

### Wall-clock budget (bounds the new behaviour)

- New ``--time-budget SECONDS`` CLI flag (and ``time_budget=`` kwarg on
  ``run_optimize_placement``). The main loop checks elapsed time once
  per generation and breaks gracefully when the budget is exhausted.
  Default: ``None`` (no cap) for the bare CLI; ``300`` (5 min) for the
  ``BuildStep.PLACE`` invocation in ``build_cmd.py`` so the build can
  no longer hang.

### Exit code (the "fail loud" fix)

- After post-pass slide-off, the command now prints a ``FATAL:`` line
  to stderr listing which components (``overlap``, ``drc``, ``boundary``,
  ``block_boundary``) are violating, and returns exit code 1 unless
  ``--allow-infeasible`` is passed. The legacy pad-pad slide-off
  exit-1 path is preserved as a fallback (also gated on
  ``--allow-infeasible``).
- New ``--allow-infeasible`` CLI flag for interactive / opt-in workflows
  that want the old "exit 0 even when infeasible" behaviour.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| ``_check_convergence`` doesn't flip while infeasible | done | `tests/placement/test_cmaes_strategy.py::TestFeasibilityGatedConvergence::test_does_not_converge_while_infeasible` |
| Convergence works once feasible | done | `…test_converges_once_feasible_and_plateau`, `…test_score_just_below_offset_is_treated_as_feasible` |
| Exit code 1 + FATAL on infeasible | done | `tests/test_optimize_placement_cmd.py::TestFeasibilityGatedExitCode::test_returns_nonzero_when_infeasible`, `…test_fatal_message_names_failing_components` |
| Exit code 0 on feasible solution | done | `…test_returns_zero_on_feasible_solution` |
| ``--allow-infeasible`` restores exit 0 | done | `…test_allow_infeasible_flag_restores_zero_exit` |
| Wall-clock budget caps runtime | done | `…test_wall_clock_budget_caps_runtime` |
| Default cost mode is LEXICOGRAPHIC | done | `…test_default_cost_mode_is_lexicographic`; ``--weights`` ``mode`` override tested in `…test_weights_json_can_override_cost_mode` |
| Pipeline (``BuildStep.PLACE``) honours non-zero exit semantics | done | ``_run_step_placement`` already returns ``BuildResult(success=False)`` on ``returncode != 0``; bumped in by adding ``--time-budget 300`` to the invocation. |

## Test Plan

```bash
uv run pytest tests/placement/ tests/test_optimize_placement_cmd.py tests/test_cost.py --no-cov
# 135 passed in 2.84s
```

Also re-ran the broader placement / multi-fidelity / build_placement_step
suites: no regressions (132 passed).

The pre-existing failure in ``tests/test_build_cmd_errors.py::TestBuildRouteExitCode2::test_route_exit_code_3_is_failure`` is unrelated to this PR — it fails on ``main`` at the same SHA.