### PR TITLE
fix(placement): replace misleading 0.0% improvement line with per-axis breakdown

### DIFF
--- a/src/kicad_tools/cli/optimize_placement_cmd.py
+++ b/src/kicad_tools/cli/optimize_placement_cmd.py
@@ -877,12 +877,32 @@ def run_optimize_placement(
         _print_score("Initial", seed_score)
         _print_score("Final", final_score)
 
-        if seed_score.total > 0:
-            improvement = (seed_score.total - final_score.total) / seed_score.total * 100
-        else:
-            improvement = 0.0
+        # Per-axis breakdown. We deliberately avoid a single "Improvement: X%"
+        # line because, under LEXICOGRAPHIC mode, the absolute total is
+        # dominated by the INFEASIBILITY_OFFSET (~1e12) and a real improvement
+        # of ~1e9 inside the infeasible region rounds to "0.0%". See #2828.
+        si, sf = seed_score.breakdown, final_score.breakdown
 
-        print(f"\n  Improvement: {improvement:.1f}%")
+        def _delta(initial: float, final: float, *, fmt: str = ".2f") -> str:
+            if initial == 0 and final == 0:
+                return f"{initial:{fmt}} → {final:{fmt}} (no change)"
+            if initial == 0:
+                return f"{initial:{fmt}} → {final:{fmt}} (new)"
+            pct = (final - initial) / initial * 100
+            return f"{initial:{fmt}} → {final:{fmt}} ({pct:+.1f}%)"
+
+        print("\n  Per-axis change:")
+        print(f"    Wirelength:    {_delta(si.wirelength, sf.wirelength)}")
+        print(f"    Overlap:       {_delta(si.overlap, sf.overlap)}")
+        print(f"    Boundary:      {_delta(si.boundary, sf.boundary)}")
+        print(f"    DRC:           {si.drc:.0f} → {sf.drc:.0f} ({sf.drc - si.drc:+.0f})")
+        print(f"    Area:          {_delta(si.area, sf.area)}")
+
+        # Feasibility transition (categorical, not percent)
+        seed_feas = "feasible" if seed_score.is_feasible else "INFEASIBLE"
+        final_feas = "feasible" if final_score.is_feasible else "INFEASIBLE"
+        print(f"  Feasibility:   {seed_feas} → {final_feas}")
+
         print(f"  Iterations: {iteration}")
         print(f"  Wall time: {elapsed:.2f}s")
         print(f"  Feasible: {final_score.is_feasible}")

--- a/tests/test_optimize_placement_cmd.py
+++ b/tests/test_optimize_placement_cmd.py
@@ -406,7 +406,13 @@ class TestRunOptimizePlacement:
         assert result2 == 0
 
     def test_summary_output(self, tmp_pcb, capsys):
-        """Verify the summary includes expected fields."""
+        """Verify the summary includes expected fields.
+
+        The single "Improvement: X%" line was removed in #2828 because under
+        LEXICOGRAPHIC mode (now the default) the percent was dominated by the
+        INFEASIBILITY_OFFSET and rounded to 0.0% even on dramatic real progress.
+        We now assert per-axis labels are present instead.
+        """
         result = run_optimize_placement(
             str(tmp_pcb),
             max_iterations=2,
@@ -414,9 +420,98 @@ class TestRunOptimizePlacement:
         assert result == 0
         captured = capsys.readouterr()
         assert "Optimization Summary" in captured.out
-        assert "Improvement" in captured.out
         assert "Iterations" in captured.out
         assert "Wall time" in captured.out
+        # Per-axis breakdown replaced the single misleading "Improvement: X%" line.
+        assert "Per-axis change:" in captured.out
+        assert "Wirelength:" in captured.out
+        assert "Overlap:" in captured.out
+        assert "Boundary:" in captured.out
+        assert "DRC:" in captured.out
+        assert "Area:" in captured.out
+        assert "Feasibility:" in captured.out
+
+    def test_summary_reports_per_axis_deltas(self, tmp_pcb, capsys):
+        """Run a short optimization and assert the summary contains all five
+        axis labels via capsys, per the acceptance criteria of #2828."""
+        result = run_optimize_placement(
+            str(tmp_pcb),
+            max_iterations=2,
+        )
+        assert result == 0
+        captured = capsys.readouterr()
+        # Each per-axis line must appear, sourced from score.breakdown.
+        for label in ("Wirelength:", "Overlap:", "Boundary:", "DRC:", "Area:"):
+            assert label in captured.out, f"missing per-axis label {label!r} in summary"
+
+
+class TestSummaryNoMisleadingZeroPercent:
+    """Regression coverage for #2828: the old single-percent improvement line
+    silently reported '0.0%' even when the optimizer crossed the feasibility
+    boundary, because the LEXICOGRAPHIC INFEASIBILITY_OFFSET (~1e12) dominates
+    the absolute total. The summary must surface feasibility as a categorical
+    transition and never print 'Improvement: 0.0%'.
+    """
+
+    def test_summary_no_misleading_zero_percent_on_feasibility_transition(
+        self, monkeypatch, tmp_pcb, capsys
+    ):
+        """Stub _evaluate to return an infeasible seed and a feasible final
+        score, then assert the summary does NOT contain 'Improvement: 0.0%'
+        and DOES contain 'INFEASIBLE → feasible'."""
+        infeasible_seed = PlacementScore(
+            total=1.000006658836e12,  # offset-dominated lexicographic total
+            breakdown=CostBreakdown(
+                wirelength=2608.0,
+                overlap=6.39,
+                boundary=0.0,
+                drc=27.0,
+                area=5003.65,
+            ),
+            is_feasible=False,
+        )
+        feasible_final = PlacementScore(
+            total=42.5,  # below INFEASIBILITY_OFFSET → feasible region
+            breakdown=CostBreakdown(
+                wirelength=6699.02,
+                overlap=0.0,
+                boundary=0.0,
+                drc=0.0,
+                area=6629.90,
+            ),
+            is_feasible=True,
+        )
+
+        # _evaluate is called once for the seed and once for the final result.
+        # Return infeasible first, then feasible.
+        scores = iter([infeasible_seed, feasible_final])
+
+        def _stub_evaluate(*args, **kwargs):
+            try:
+                return next(scores)
+            except StopIteration:
+                # Any extra evaluations during optimization fall through to
+                # the feasible final so the optimizer treats it as monotonic.
+                return feasible_final
+
+        monkeypatch.setattr(
+            "kicad_tools.cli.optimize_placement_cmd._evaluate",
+            _stub_evaluate,
+        )
+
+        result = run_optimize_placement(
+            str(tmp_pcb),
+            max_iterations=2,
+        )
+        assert result == 0
+        captured = capsys.readouterr()
+
+        # The pre-#2828 misleading single-percent line must be gone.
+        assert "Improvement: 0.0%" not in captured.out
+        assert "Improvement:" not in captured.out
+
+        # Feasibility transition must be surfaced categorically.
+        assert "INFEASIBLE → feasible" in captured.out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Closes #2828
- The `optimize-placement` summary's `Improvement: X%` line divided by `seed_score.total`, but under `LEXICOGRAPHIC` mode (default since #2826) `total` is dominated by `INFEASIBILITY_OFFSET = 1e12` (`placement/cost.py:38`). Real progress in the ~1e9 range therefore rounded to `0.0%`, and a feasibility crossing showed up as "100%" with no relation to placement quality.
- Drop the single-percent line entirely. Print a per-axis breakdown sourced directly from `PlacementScore.breakdown` (`wirelength`, `overlap`, `boundary`, `drc`, `area`) and add a categorical `Feasibility: INFEASIBLE → feasible` line. Per-axis percent helper handles `initial == 0` (`"(new)"`) and `0 → 0` (`"(no change)"`) so there is no `ZeroDivisionError` or `+inf%`.

## Example output

```
--- Optimization Summary ---
  Initial: 1000006658836.0000 (INFEASIBLE) [...]
  Final:   42.5000 (feasible) [...]

  Per-axis change:
    Wirelength:    2608.00 → 6699.02 (+156.9%)
    Overlap:       6.39 → 0.00 (-100.0%)
    Boundary:      0.00 → 0.00 (no change)
    DRC:           27 → 0 (-27)
    Area:          5003.65 → 6629.90 (+32.5%)
  Feasibility:   INFEASIBLE → feasible
```

## Files changed

- `src/kicad_tools/cli/optimize_placement_cmd.py` — replaced the lines 880-885 single-percent block with per-axis + feasibility output.
- `tests/test_optimize_placement_cmd.py` — flipped `test_summary_output` per-axis assertions; added `test_summary_reports_per_axis_deltas`; added `TestSummaryNoMisleadingZeroPercent::test_summary_no_misleading_zero_percent_on_feasibility_transition` which stubs `_evaluate` to force an INFEASIBLE → feasible transition and asserts `"Improvement: 0.0%"` is NOT printed and `"INFEASIBLE → feasible"` IS.

## Test plan

- [x] `uv run pytest tests/test_optimize_placement_cmd.py -x` — 62 passed
- [x] Focused run of the changed/new tests:
  - `TestRunOptimizePlacement::test_summary_output`
  - `TestRunOptimizePlacement::test_summary_reports_per_axis_deltas`
  - `TestSummaryNoMisleadingZeroPercent::test_summary_no_misleading_zero_percent_on_feasibility_transition`
- [x] Manual smoke test of the formatting logic with the issue's exact reproducer values (board 05 anchor-weight 3.0).
- [ ] Reviewer: re-run the issue's reproducer command end-to-end to confirm `Overlap: 6.39 → 0.00` and `DRC: 27 → 0 (-27)` appear (no harness for board 05 in CI).

## Out of scope

- `WEIGHTED_SUM` mode percent display (per issue guidance — not the default, punt).
- `_print_score` formatting at line 258 — kept as-is; this PR only touches the summary block.
- `INFEASIBILITY_OFFSET` semantics and `PlacementScore`/`CostBreakdown` schemas (no changes; the breakdown fields needed already exist).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>