### PR TITLE
fix(schema): propagate Footprint.locked + 4 sibling fields on PCB.save

### DIFF
--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -12,7 +12,7 @@ from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import date
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 logger = logging.getLogger(__name__)
 
@@ -467,6 +467,41 @@ class Footprint:
         repr=False,
         compare=False,
     )
+    # Tokens inside ``(attr ...)`` that the parser does not yet model
+    # (e.g. ``board_only``, ``allow_missing_courtyard``,
+    # ``allow_soldermask_bridges``). Preserved verbatim so that the
+    # ``__setattr__`` rebuild of the ``(attr ...)`` block does not
+    # silently drop them on round-trip.
+    _attr_unknown_tokens: list[str] = field(
+        default_factory=list,
+        repr=False,
+        compare=False,
+    )
+
+    # Set of attr-block tokens the parser models explicitly. Anything
+    # else that appears as an atom child of ``(attr ...)`` is captured
+    # in ``_attr_unknown_tokens`` and re-emitted verbatim.
+    _ATTR_KNOWN_TOKENS: ClassVar[frozenset[str]] = frozenset(
+        {
+            "smd",
+            "through_hole",
+            "exclude_from_pos_files",
+            "exclude_from_bom",
+            "locked",
+            "dnp",
+        }
+    )
+
+    _ATTR_SYNCED_FIELDS: ClassVar[frozenset[str]] = frozenset(
+        {
+            "attr",
+            "exclude_from_pos_files",
+            "exclude_from_bom",
+            "locked",
+            "dnp",
+            "_attr_unknown_tokens",
+        }
+    )
 
     # ------------------------------------------------------------------
     # __setattr__ override -- syncs position/rotation/layer to _sexp_node
@@ -505,6 +540,73 @@ class Footprint:
             layer_node = sexp_node.find("layer")
             if layer_node is not None:
                 layer_node.set_value(0, value)
+
+        elif name in self._ATTR_SYNCED_FIELDS:
+            # Any change to a field that maps into the (attr ...) block
+            # rebuilds that block from the current Python state. Unknown
+            # tokens captured at parse time (board_only,
+            # allow_missing_courtyard, allow_soldermask_bridges, ...)
+            # are preserved verbatim via ``_attr_unknown_tokens`` so we
+            # don't drop tokens the parser doesn't yet model.
+            self._sync_attr_node()
+
+    def _sync_attr_node(self) -> None:
+        """Rebuild the ``(attr ...)`` child of ``_sexp_node`` from Python state.
+
+        Mirrors the position/rotation/layer sync pattern in
+        :meth:`__setattr__`. Removes the existing ``(attr ...)`` node
+        (if any), then re-emits it from the current values of
+        ``attr``, ``exclude_from_pos_files``, ``exclude_from_bom``,
+        ``locked``, ``dnp``, and any ``_attr_unknown_tokens`` captured
+        during parse. If no flags are set and no unknown tokens are
+        present, no ``(attr ...)`` node is emitted (matches KiCad's
+        canonical "no flags" form).
+        """
+        sexp_node: SExp | None = self.__dict__.get("_sexp_node")
+        if sexp_node is None:
+            return
+
+        # Remove any existing (attr ...) so we can rebuild it cleanly.
+        # find_children() searches direct children only -- we want to
+        # avoid stripping nested (attr ...) inside fp_text/property,
+        # which don't currently exist but could appear in future
+        # KiCad versions.
+        for existing in list(sexp_node.find_children("attr")):
+            sexp_node.remove(existing)
+
+        unknown = self.__dict__.get("_attr_unknown_tokens", []) or []
+
+        # Only emit (attr ...) if there is something to say.
+        if not (
+            self.attr
+            or self.locked
+            or self.dnp
+            or self.exclude_from_pos_files
+            or self.exclude_from_bom
+            or unknown
+        ):
+            return
+
+        attr_node = SExp.list("attr")
+        # Canonical KiCad order: <type> [board_only] [exclude_from_pos_files]
+        # [exclude_from_bom] [allow_missing_courtyard] [dnp], with `locked`
+        # appearing as a peer token. We emit modeled tokens in a stable
+        # order and append unknown tokens at the end -- KiCad accepts
+        # any ordering of these atoms, so this is a safe simplification.
+        if self.attr:
+            attr_node.add(self.attr)  # 'smd' or 'through_hole'
+        if self.exclude_from_pos_files:
+            attr_node.add("exclude_from_pos_files")
+        if self.exclude_from_bom:
+            attr_node.add("exclude_from_bom")
+        if self.locked:
+            attr_node.add("locked")
+        if self.dnp:
+            attr_node.add("dnp")
+        for token in unknown:
+            attr_node.add(token)
+
+        sexp_node.append(attr_node)
 
     @classmethod
     def from_sexp(cls, sexp: SExp) -> Footprint:
@@ -552,10 +654,29 @@ class Footprint:
         if tags := sexp.find("tags"):
             fp.tags = tags.get_string(0) or ""
         if attr := sexp.find("attr"):
-            fp.attr = attr.get_string(0) or ""
-            # Parse additional attribute flags (e.g., exclude_from_pos_files, dnp)
-            for i in range(len(attr.children)):
+            # The footprint *type* token (``smd`` / ``through_hole``)
+            # is optional in KiCad's emitted form. When KiCad omits the
+            # type, the first atom is a flag (e.g. ``(attr
+            # exclude_from_pos_files exclude_from_bom)``). Detect this
+            # by only accepting known type tokens at index 0.
+            first_token = attr.get_string(0) or ""
+            if first_token in ("smd", "through_hole"):
+                fp.attr = first_token
+                token_start_idx = 1
+            else:
+                fp.attr = ""
+                token_start_idx = 0
+            # Parse additional attribute flags (e.g., exclude_from_pos_files, dnp).
+            # Tokens we don't model (board_only, allow_missing_courtyard,
+            # allow_soldermask_bridges, ...) are captured verbatim into
+            # _attr_unknown_tokens so the (attr ...) rebuild in
+            # _sync_attr_node() can re-emit them on save without
+            # silent data loss.
+            unknown_tokens: list[str] = []
+            for i in range(token_start_idx, len(attr.children)):
                 token = attr.get_string(i)
+                if token is None:
+                    continue
                 if token == "exclude_from_pos_files":
                     fp.exclude_from_pos_files = True
                 elif token == "exclude_from_bom":
@@ -564,6 +685,10 @@ class Footprint:
                     fp.locked = True
                 elif token == "dnp":
                     fp.dnp = True
+                else:
+                    unknown_tokens.append(token)
+            if unknown_tokens:
+                fp._attr_unknown_tokens = unknown_tokens
 
         # Reference and value from fp_text (KiCad 7 format)
         for fp_text_sexp in sexp.find_all("fp_text"):

--- a/tests/test_pcb_attr_roundtrip.py
+++ b/tests/test_pcb_attr_roundtrip.py
@@ -1,0 +1,401 @@
+"""Round-trip tests for ``Footprint`` ``(attr ...)`` block fields.
+
+Regression coverage for issue #2827: ``PCB.save()`` previously dropped
+Python-side mutations to ``Footprint.attr``, ``locked``, ``dnp``,
+``exclude_from_pos_files``, and ``exclude_from_bom``. The fix extends
+``Footprint.__setattr__`` to rebuild the ``(attr ...)`` child of
+``_sexp_node`` whenever any of those fields change, while preserving
+unknown tokens (``board_only``, ``allow_missing_courtyard``,
+``allow_soldermask_bridges``, ...) that the parser does not yet model.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.schema import PCB
+
+# Minimal PCB fixture with a single footprint that has NO existing
+# (attr ...) block. Tests that need a pre-populated attr block use the
+# helper ``_inject_attr_tokens`` to splice tokens into the raw text
+# before reload.
+_BASE_PCB = """(kicad_pcb
+\t(version 20240108)
+\t(generator "pytest")
+\t(generator_version "8.0")
+\t(general (thickness 1.6) (legacy_teardrops no))
+\t(paper "A4")
+\t(layers
+\t\t(0 "F.Cu" signal)
+\t\t(31 "B.Cu" signal)
+\t\t(37 "F.SilkS" user "F.Silkscreen")
+\t\t(44 "Edge.Cuts" user)
+\t\t(49 "F.Fab" user)
+\t)
+\t(setup (pad_to_mask_clearance 0))
+\t(net 0 "")
+\t(net 1 "GND")
+\t(gr_rect (start 100 100) (end 150 150)
+\t\t(stroke (width 0.1) (type default))
+\t\t(fill none)
+\t\t(layer "Edge.Cuts")
+\t)
+\t(footprint "Resistor_SMD:R_0402_1005Metric"
+\t\t(layer "F.Cu")
+\t\t(uuid "00000000-0000-0000-0000-000000000010")
+\t\t(at 125 125)
+\t\t(property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS")
+\t\t\t(effects (font (size 1.0 1.0) (thickness 0.15)))
+\t\t\t(uuid "00000000-0000-0000-0000-000000000011"))
+\t\t(property "Value" "10k" (at 0 1.5 0) (layer "F.Fab")
+\t\t\t(uuid "00000000-0000-0000-0000-000000000012"))
+\t\t(pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64)
+\t\t\t(layers "F.Cu" "F.Paste" "F.Mask")
+\t\t\t(roundrect_rratio 0.25)
+\t\t\t(net 1 "GND"))
+\t\t(pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64)
+\t\t\t(layers "F.Cu" "F.Paste" "F.Mask")
+\t\t\t(roundrect_rratio 0.25)
+\t\t\t(net 1 "GND"))
+\t)
+)
+"""
+
+
+def _write_base_pcb(tmp_path: Path) -> Path:
+    path = tmp_path / "attr_roundtrip.kicad_pcb"
+    path.write_text(_BASE_PCB)
+    return path
+
+
+def _write_pcb_with_attr(tmp_path: Path, attr_inner: str) -> Path:
+    """Write a copy of _BASE_PCB with a hand-crafted ``(attr ...)`` block.
+
+    ``attr_inner`` is the literal token string between ``(attr`` and ``)``,
+    e.g. ``"smd locked"`` or ``"smd board_only allow_missing_courtyard"``.
+    The block is inserted immediately after the footprint's ``(at ...)``
+    line.
+    """
+    needle = '\t\t(at 125 125)\n'
+    replacement = needle + f'\t\t(attr {attr_inner})\n'
+    text = _BASE_PCB.replace(needle, replacement, 1)
+    path = tmp_path / "attr_roundtrip_seeded.kicad_pcb"
+    path.write_text(text)
+    return path
+
+
+def _file_text(path: Path) -> str:
+    return path.read_text()
+
+
+# ---------------------------------------------------------------------------
+# Round-trip behaviour for each modeled flag
+# ---------------------------------------------------------------------------
+
+
+def test_locked_flag_round_trips(tmp_path: Path):
+    """Setting ``fp.locked = True`` survives a save/load cycle."""
+    src = _write_base_pcb(tmp_path)
+
+    pcb = PCB.load(str(src))
+    fp = pcb.get_footprint("R1")
+    assert fp is not None
+    assert fp.locked is False
+
+    fp.locked = True
+
+    out = tmp_path / "out.kicad_pcb"
+    pcb.save(out)
+
+    text = _file_text(out)
+    assert "locked" in text, "locked token missing from saved PCB"
+
+    reloaded = PCB.load(str(out))
+    fp2 = reloaded.get_footprint("R1")
+    assert fp2 is not None
+    assert fp2.locked is True
+
+
+def test_locked_flag_can_be_cleared(tmp_path: Path):
+    """Setting ``fp.locked = False`` removes the ``(locked)`` token."""
+    src = _write_pcb_with_attr(tmp_path, "smd locked")
+
+    pcb = PCB.load(str(src))
+    fp = pcb.get_footprint("R1")
+    assert fp is not None
+    assert fp.locked is True
+    assert fp.attr == "smd"
+
+    fp.locked = False
+
+    out = tmp_path / "out.kicad_pcb"
+    pcb.save(out)
+
+    # Reload and confirm the flag is gone -- the source-of-truth check.
+    reloaded = PCB.load(str(out))
+    fp2 = reloaded.get_footprint("R1")
+    assert fp2 is not None
+    assert fp2.locked is False
+    # And that the smd type token survived.
+    assert fp2.attr == "smd"
+
+
+def test_dnp_flag_round_trips(tmp_path: Path):
+    """``dnp`` flag survives mutation + save + reload."""
+    src = _write_base_pcb(tmp_path)
+
+    pcb = PCB.load(str(src))
+    fp = pcb.get_footprint("R1")
+    assert fp is not None
+    assert fp.dnp is False
+
+    fp.dnp = True
+
+    out = tmp_path / "out.kicad_pcb"
+    pcb.save(out)
+
+    reloaded = PCB.load(str(out))
+    fp2 = reloaded.get_footprint("R1")
+    assert fp2 is not None
+    assert fp2.dnp is True
+
+
+def test_exclude_from_pos_files_round_trips(tmp_path: Path):
+    """``exclude_from_pos_files`` flag survives mutation + save + reload."""
+    src = _write_base_pcb(tmp_path)
+
+    pcb = PCB.load(str(src))
+    fp = pcb.get_footprint("R1")
+    assert fp is not None
+    assert fp.exclude_from_pos_files is False
+
+    fp.exclude_from_pos_files = True
+
+    out = tmp_path / "out.kicad_pcb"
+    pcb.save(out)
+
+    reloaded = PCB.load(str(out))
+    fp2 = reloaded.get_footprint("R1")
+    assert fp2 is not None
+    assert fp2.exclude_from_pos_files is True
+
+
+def test_exclude_from_bom_round_trips(tmp_path: Path):
+    """``exclude_from_bom`` flag survives mutation + save + reload."""
+    src = _write_base_pcb(tmp_path)
+
+    pcb = PCB.load(str(src))
+    fp = pcb.get_footprint("R1")
+    assert fp is not None
+    assert fp.exclude_from_bom is False
+
+    fp.exclude_from_bom = True
+
+    out = tmp_path / "out.kicad_pcb"
+    pcb.save(out)
+
+    reloaded = PCB.load(str(out))
+    fp2 = reloaded.get_footprint("R1")
+    assert fp2 is not None
+    assert fp2.exclude_from_bom is True
+
+
+def test_attr_type_round_trips(tmp_path: Path):
+    """Changing ``attr`` (smd <-> through_hole) survives round-trip.
+
+    Also exercises the "no prior (attr ...) block" -> "block now exists"
+    transition by starting from a footprint with no attr block.
+    """
+    src = _write_base_pcb(tmp_path)
+
+    pcb = PCB.load(str(src))
+    fp = pcb.get_footprint("R1")
+    assert fp is not None
+    assert fp.attr == ""
+
+    fp.attr = "smd"
+
+    out = tmp_path / "out_smd.kicad_pcb"
+    pcb.save(out)
+
+    reloaded = PCB.load(str(out))
+    fp2 = reloaded.get_footprint("R1")
+    assert fp2 is not None
+    assert fp2.attr == "smd"
+
+    # Now flip to through_hole.
+    fp2.attr = "through_hole"
+    out2 = tmp_path / "out_th.kicad_pcb"
+    reloaded.save(out2)
+
+    reloaded2 = PCB.load(str(out2))
+    fp3 = reloaded2.get_footprint("R1")
+    assert fp3 is not None
+    assert fp3.attr == "through_hole"
+
+
+# ---------------------------------------------------------------------------
+# Unknown-token preservation
+# ---------------------------------------------------------------------------
+
+
+def test_attr_unknown_tokens_preserved(tmp_path: Path):
+    """Unknown ``(attr ...)`` tokens (e.g. ``board_only``) survive round-trip.
+
+    The parser does not currently model ``board_only``,
+    ``allow_missing_courtyard``, or ``allow_soldermask_bridges``.
+    The fix captures these into a private ``_attr_unknown_tokens``
+    list at parse time and re-emits them whenever the ``(attr ...)``
+    block is rebuilt — otherwise mutating any other attr field would
+    silently strip them.
+    """
+    src = _write_pcb_with_attr(
+        tmp_path, "smd board_only allow_missing_courtyard"
+    )
+
+    pcb = PCB.load(str(src))
+    fp = pcb.get_footprint("R1")
+    assert fp is not None
+    assert fp.attr == "smd"
+    assert fp.locked is False
+    # Unknown tokens are captured verbatim.
+    assert fp._attr_unknown_tokens == [
+        "board_only",
+        "allow_missing_courtyard",
+    ]
+
+    # Mutate a modeled flag -- this triggers a rebuild of (attr ...).
+    fp.locked = True
+
+    out = tmp_path / "out.kicad_pcb"
+    pcb.save(out)
+
+    text = _file_text(out)
+    assert "board_only" in text, "unknown token board_only was dropped"
+    assert "allow_missing_courtyard" in text, (
+        "unknown token allow_missing_courtyard was dropped"
+    )
+    assert "locked" in text, "newly-set locked token did not appear"
+
+    # Round-trip back through the parser to confirm tokens are still
+    # captured and the modeled flag survives.
+    reloaded = PCB.load(str(out))
+    fp2 = reloaded.get_footprint("R1")
+    assert fp2 is not None
+    assert fp2.attr == "smd"
+    assert fp2.locked is True
+    assert "board_only" in fp2._attr_unknown_tokens
+    assert "allow_missing_courtyard" in fp2._attr_unknown_tokens
+
+
+# ---------------------------------------------------------------------------
+# Combinations and edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_multi_flag_combinations(tmp_path: Path):
+    """Setting several flags at once survives round-trip."""
+    src = _write_base_pcb(tmp_path)
+
+    pcb = PCB.load(str(src))
+    fp = pcb.get_footprint("R1")
+    assert fp is not None
+
+    fp.attr = "smd"
+    fp.locked = True
+    fp.dnp = True
+    fp.exclude_from_pos_files = True
+    fp.exclude_from_bom = True
+
+    out = tmp_path / "out.kicad_pcb"
+    pcb.save(out)
+
+    reloaded = PCB.load(str(out))
+    fp2 = reloaded.get_footprint("R1")
+    assert fp2 is not None
+    assert fp2.attr == "smd"
+    assert fp2.locked is True
+    assert fp2.dnp is True
+    assert fp2.exclude_from_pos_files is True
+    assert fp2.exclude_from_bom is True
+
+
+def test_no_attr_block_when_all_default(tmp_path: Path):
+    """Clearing every flag removes the ``(attr ...)`` block entirely.
+
+    Acceptance criteria documents either "no block" or "valid empty
+    block KiCad accepts" as acceptable. We pick the no-block form
+    because that is what KiCad emits when no flags are set, and it
+    minimises diff churn against pristine boards.
+    """
+    src = _write_pcb_with_attr(tmp_path, "smd locked dnp")
+
+    pcb = PCB.load(str(src))
+    fp = pcb.get_footprint("R1")
+    assert fp is not None
+    assert fp.attr == "smd"
+    assert fp.locked is True
+    assert fp.dnp is True
+
+    # Clear everything.
+    fp.attr = ""
+    fp.locked = False
+    fp.dnp = False
+    fp.exclude_from_pos_files = False
+    fp.exclude_from_bom = False
+    # Also clear any unknown tokens for the all-default form.
+    fp._attr_unknown_tokens = []
+
+    out = tmp_path / "out.kicad_pcb"
+    pcb.save(out)
+
+    text = _file_text(out)
+    # No `(attr` substring should remain anywhere in the footprint
+    # block. (We use a precise pattern to avoid matching e.g.
+    # ``(attr ...)`` text accidentally appearing in property values.)
+    # The base PCB has no other (attr substrings, so a blanket check
+    # is safe here.
+    assert "(attr" not in text, (
+        "(attr ...) block should be omitted when no flags set"
+    )
+
+    reloaded = PCB.load(str(out))
+    fp2 = reloaded.get_footprint("R1")
+    assert fp2 is not None
+    assert fp2.attr == ""
+    assert fp2.locked is False
+    assert fp2.dnp is False
+    assert fp2.exclude_from_pos_files is False
+    assert fp2.exclude_from_bom is False
+
+
+# ---------------------------------------------------------------------------
+# Sanity: existing position/rotation/layer round-trips still work
+# ---------------------------------------------------------------------------
+
+
+def test_attr_sync_does_not_break_position_roundtrip(tmp_path: Path):
+    """Regression guard: attr sync must not interfere with position sync."""
+    src = _write_base_pcb(tmp_path)
+
+    pcb = PCB.load(str(src))
+    fp = pcb.get_footprint("R1")
+    assert fp is not None
+
+    # Mutate position AND attr in the same flow.
+    new_x = fp.position[0] + 10.0
+    new_y = fp.position[1] - 5.0
+    fp.position = (new_x, new_y)
+    fp.locked = True
+
+    out = tmp_path / "out.kicad_pcb"
+    pcb.save(out)
+
+    reloaded = PCB.load(str(out))
+    fp2 = reloaded.get_footprint("R1")
+    assert fp2 is not None
+    assert fp2.position[0] == pytest.approx(new_x)
+    assert fp2.position[1] == pytest.approx(new_y)
+    assert fp2.locked is True


### PR DESCRIPTION
## Summary

Closes #2827.

`PCB.save()` previously dropped Python-side mutations to `Footprint.attr`, `exclude_from_pos_files`, `exclude_from_bom`, `locked`, and `dnp` because `__setattr__` only synced `position`/`rotation`/`layer` to the underlying S-expression node. Setting `fp.locked = True` and saving was a silent no-op -- the `(locked)` token never appeared in the output file, blocking programmatic locking workflows (#2822 anchor-weight) and forcing raw sexp injection workarounds.

### Changes

- **`Footprint.__setattr__` extended** with a new `_sync_attr_node()` helper that rebuilds the `(attr ...)` child of `_sexp_node` from current Python state whenever any of the five modeled fields change. Mirrors the existing position/rotation/layer sync pattern.
- **Unknown-token preservation**: A new private `_attr_unknown_tokens: list[str]` field captures attr-block tokens the parser does not yet model (`board_only`, `allow_missing_courtyard`, `allow_soldermask_bridges`, ...) at parse time and re-emits them verbatim on rebuild. Without this, mutating any modeled flag would silently strip unknown tokens.
- **Pre-existing parser fix**: KiCad emits `(attr exclude_from_pos_files exclude_from_bom)` without a type token in some cases. Previously `from_sexp` assigned the first flag to `fp.attr`. The parser now only accepts `smd`/`through_hole` as the type at index 0 and treats other first tokens as flags.
- **10 round-trip tests** in `tests/test_pcb_attr_roundtrip.py` covering all 5 flags + unknown-token preservation + multi-flag combinations + clearing all flags + a regression guard for the existing position sync.

### Out of scope (deferred to follow-up)

The Curator's guidance suggested a `kct pcb lock` / `kct pcb unlock` CLI helper. Kept out of this PR to keep the schema fix focused; can be filed as a separate issue once this lands.

## Test plan

- [x] `uv run pytest tests/test_pcb_attr_roundtrip.py -v` -- 10/10 pass
- [x] `uv run pytest tests/test_pcb.py` -- 164/164 pass (no regressions)
- [x] `uv run pytest tests/test_pcb.py tests/test_schema.py tests/test_pcb_create.py tests/test_pcb_modules.py tests/test_pcb_move_footprint.py tests/test_pcb_remove_footprint.py tests/test_pcb_sync_netlist.py tests/test_cli_pcb.py tests/test_schematic.py tests/test_schematic_models.py` -- 1011 pass, no regressions
- [ ] Judge review

### Acceptance criteria (from #2827)

- [x] Setting `fp.locked = True` results in a `(locked)` token in the output file
- [x] Setting `fp.locked = False` removes the token from the output file
- [x] Same round-trip behaviour for `dnp`, `exclude_from_pos_files`, `exclude_from_bom`
- [x] Same round-trip behaviour for `attr` (smd <-> through_hole, including empty -> set)
- [x] Setting any flag on a footprint without an existing `(attr ...)` block creates the block
- [x] Clearing all flags removes the `(attr ...)` block entirely
- [x] Unknown tokens (`board_only`, `allow_missing_courtyard`) survive round-trip
- [x] No regressions in existing position/rotation/layer round-trip tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)