### PR TITLE
fix(cli): forward --max-search-iterations through route shim + symmetric drift test

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -190,6 +190,13 @@ def run_route_command(args) -> int:
     checkpoint_interval_val = getattr(args, "checkpoint_interval", 30.0)
     if checkpoint_interval_val != 30.0:
         sub_argv.extend(["--checkpoint-interval", str(checkpoint_interval_val)])
+    # Issue #2819: forward --max-search-iterations to the inner parser.
+    # Both defaults are 0 (= use cols*rows*4 heuristic), so only forward
+    # when the user passed a non-default value (matches the per-net-timeout
+    # and checkpoint-interval patterns above).
+    max_iter_val = getattr(args, "max_search_iterations", 0) or 0
+    if max_iter_val:
+        sub_argv.extend(["--max-search-iterations", str(max_iter_val)])
     if args.verbose:
         sub_argv.append("--verbose")
     if args.dry_run:

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -3860,6 +3860,23 @@ def main(argv: list[str] | None = None) -> int:
             "Use 0 to disable checkpointing (only the terminal save fires)."
         ),
     )
+    # Issue #2819: declare --max-search-iterations on the inner parser so the
+    # forwarding shim in ``commands/routing.py`` can hand it through.  Default
+    # 0 = use the historical ``cols * rows * 4`` heuristic (matches the outer
+    # parser declaration at parser.py and the C++ A* backstop semantics from
+    # Issue #2610).
+    parser.add_argument(
+        "--max-search-iterations",
+        type=int,
+        default=0,
+        help=(
+            "Override the C++ A* iteration backstop (default: 0 = use "
+            "cols*rows*4, which is ~1M for a 500x500 grid). Positive values "
+            "let dense boards trade memory for completeness. Iteration-cap "
+            "aborts are logged distinctly from --per-net-timeout (wall-clock) "
+            "aborts so you can tell which limit fired."
+        ),
+    )
     parser.add_argument(
         "--seed",
         type=int,
@@ -4920,7 +4937,12 @@ def main(argv: list[str] | None = None) -> int:
                 validate_drc=not args.force,
                 strict_drc=False,  # Only fail on hard constraint (grid > clearance)
                 # Issue #2610: thread --max-search-iterations through.
-                max_search_iterations=getattr(args, "max_search_iterations", 0) or 0,
+                # The inner parser declares this flag with default=0 (Issue
+                # #2819), so the attribute is guaranteed to exist; the
+                # ``or 0`` guards against an explicit ``--max-search-iterations 0``
+                # being treated as falsy (which is the intended behaviour:
+                # 0 means "use the cols*rows*4 heuristic").
+                max_search_iterations=args.max_search_iterations or 0,
             )
     except Exception as e:
         print(f"Error loading PCB: {e}", file=sys.stderr)
@@ -5286,7 +5308,10 @@ def main(argv: list[str] | None = None) -> int:
             if per_net_timeout_val:
                 flush_print(f"  Per-net timeout: {per_net_timeout_val}s")
             # Issue #2610: report the iteration backstop override if set.
-            _max_iter_val = getattr(args, "max_search_iterations", 0) or 0
+            # Issue #2819: the inner parser now declares the flag (default=0),
+            # so the attribute is guaranteed to exist; ``or 0`` preserves the
+            # historic semantics (0 = use cols*rows*4 heuristic, suppress log).
+            _max_iter_val = args.max_search_iterations or 0
             if _max_iter_val:
                 flush_print(f"  Max search iterations: {_max_iter_val}")
             if args.profile:

--- a/tests/test_cli_parser_drift.py
+++ b/tests/test_cli_parser_drift.py
@@ -1,10 +1,10 @@
-"""Argparse-drift regression test (Issue #2817).
+"""Argparse-drift regression test (Issues #2817, #2819).
 
-This test prevents a recurring class of bug where a new flag is added to
-the *inner* ``route_cmd.py`` parser without being added to the *outer*
-``parser.py`` parser and to the forwarding shim in
-``commands/routing.py``.  Three prior instances of this exact pattern
-have shipped to ``main`` and required a follow-up bugfix:
+This test prevents a recurring class of bug where a flag is added to one
+of the two ``route`` parsers without being added to the other (and to
+the forwarding shim in ``commands/routing.py``).  Five prior instances
+of this exact pattern have shipped to ``main`` and required a follow-up
+bugfix:
 
 * **#2620** -- ``--placement-feedback-outer-timeout`` declared outer,
   rejected inner (drift in the opposite direction).
@@ -12,20 +12,30 @@ have shipped to ``main`` and required a follow-up bugfix:
 * **#2812 / #2817** -- ``--checkpoint-interval`` declared inner only;
   ``kct route --checkpoint-interval 30`` rejected with
   ``error: unrecognized arguments``.
+* **#2819** -- ``--max-search-iterations`` declared outer only; the
+  shim dropped the flag and the inner parser never saw it, so
+  ``kct route --max-search-iterations 50000`` parsed cleanly but ran
+  the C++ A* with ``max_search_iterations=0`` (the historical
+  ``cols*rows*4`` heuristic) regardless of the user-supplied value.
 
 The drift is invisible to the type checker and to most unit tests
 because both parsers are constructed independently with no shared
-schema.  This test introspects both parsers and asserts that every
-``--flag`` accepted by the inner parser is also accepted by the outer
-parser, except for an explicit allowlist of historically inner-only
-flags.
+schema.  This test introspects both parsers and asserts symmetric
+containment:
 
-If you legitimately need to add a new inner-only flag, add it to
-``INNER_ONLY_ALLOWLIST`` below with a comment explaining why it does
-not belong on the outer parser.  In most cases the right answer is to
-add it to BOTH parsers and to the forwarding shim -- see the
-``--per-net-timeout`` block in ``commands/routing.py`` for the model
-pattern.
+* ``inner_flags - outer_flags ⊆ INNER_ONLY_ALLOWLIST`` (inner-only flags
+  must be explicitly allowlisted -- guards the #2812/#2817 direction).
+* ``outer_flags - inner_flags ⊆ OUTER_ONLY_ALLOWLIST`` (outer-only flags
+  must be explicitly allowlisted -- guards the #2819 direction, where
+  the shim consumes the flag entirely or the forwarding block is
+  missing).
+
+If you legitimately need to add a new inner-only or outer-only flag,
+add it to the corresponding allowlist below with a comment explaining
+why the flag does not belong on the other parser.  In most cases the
+right answer is to add it to BOTH parsers and to the forwarding shim --
+see the ``--per-net-timeout`` block in ``commands/routing.py`` for the
+model pattern.
 """
 
 from __future__ import annotations
@@ -43,9 +53,10 @@ import pytest
 # internal-only (debug/diagnostic toggles, dev-only profiling switches,
 # experimental features that should not be advertised through ``kct``).
 #
-# Snapshot taken 2026-05-12 while fixing #2817.  Many of the entries
-# below pre-date the drift test; future flags should generally NOT be
-# added here -- expose them through the outer parser instead.
+# Snapshot taken 2026-05-12 while fixing #2817 and the symmetric
+# outer-only check added by #2819.  Many of the entries below pre-date
+# the drift test; future flags should generally NOT be added here --
+# expose them through the outer parser instead.
 INNER_ONLY_ALLOWLIST: frozenset[str] = frozenset(
     {
         # Diagnostics / debug / profiling -- not part of the
@@ -87,6 +98,19 @@ INNER_ONLY_ALLOWLIST: frozenset[str] = frozenset(
         "--two-phase-iterations",
     }
 )
+
+# Flags that legitimately exist ONLY on the outer ``parser.py`` route
+# subparser.  These are flags the shim consumes entirely before invoking
+# the inner ``route_cmd.main`` (e.g. they alter how ``sub_argv`` is
+# built rather than being forwarded verbatim), or flags whose outer
+# spelling differs from any inner equivalent.
+#
+# Snapshot taken 2026-05-12 while fixing #2819.  After the #2819 fix,
+# ``--max-search-iterations`` lives on BOTH parsers, so the outer-only
+# set is empty -- every outer flag either has a matching inner flag or
+# would be a drift bug.  Future outer-only entries belong here only if
+# the flag is genuinely consumed by the shim and never forwarded.
+OUTER_ONLY_ALLOWLIST: frozenset[str] = frozenset(set())
 
 
 def _flags_from_parser(parser: argparse.ArgumentParser) -> set[str]:
@@ -219,4 +243,90 @@ def test_checkpoint_interval_is_on_both_parsers():
     assert "--checkpoint-interval" in outer, (
         "--checkpoint-interval is missing from the outer parser.py route "
         "subparser (this would regress #2817)"
+    )
+
+
+def test_outer_only_flags_are_in_allowlist():
+    """Every flag on the outer parser must also be on the inner parser.
+
+    Exceptions live in ``OUTER_ONLY_ALLOWLIST`` with justification.
+    This guards against the #2819 direction of the drift bug class: a
+    flag declared on the outer parser but never forwarded by the shim
+    (and therefore never declared on the inner parser).  In that
+    scenario ``kct route --flag VALUE`` parses cleanly but the inner
+    command never sees the override and the value is silently
+    discarded.
+    """
+    inner = _inner_route_parser_flags()
+    outer = _outer_route_parser_flags()
+
+    outer_only = outer - inner
+    unexpected_outer_only = outer_only - OUTER_ONLY_ALLOWLIST
+
+    if unexpected_outer_only:
+        flag_list = "\n  ".join(sorted(unexpected_outer_only))
+        pytest.fail(
+            "Argparse drift detected: the following flags are accepted by "
+            "the outer 'kct route' parser but rejected by the inner "
+            "'route_cmd.py' parser:\n  "
+            f"{flag_list}\n\n"
+            "These flags will be silently dropped by the forwarding shim, "
+            "so any user-supplied value is ignored.  Fix by:\n"
+            "  1. src/kicad_tools/cli/route_cmd.py :: main "
+            "(add matching add_argument)\n"
+            "  2. src/kicad_tools/cli/commands/routing.py :: run_route_command "
+            "(forward to sub_argv)\n\n"
+            "Model after the --per-net-timeout block.  If the flag is "
+            "genuinely consumed by the shim and intentionally never "
+            "forwarded, add it to OUTER_ONLY_ALLOWLIST in "
+            "tests/test_cli_parser_drift.py with justification."
+        )
+
+
+def test_allowlist_entries_are_actually_outer_only():
+    """Sanity: every flag in the allowlist should genuinely be outer-only.
+
+    Prevents the allowlist from growing stale -- if a flag is later
+    added to the inner parser it should be removed from the allowlist
+    so we don't accidentally mask a future drift bug for that flag.
+    """
+    inner = _inner_route_parser_flags()
+    outer = _outer_route_parser_flags()
+
+    stale: set[str] = set()
+    for flag in OUTER_ONLY_ALLOWLIST:
+        if flag not in outer:
+            stale.add(f"{flag} (not on outer parser at all)")
+        elif flag in inner:
+            stale.add(f"{flag} (now on inner parser -- remove from allowlist)")
+
+    if stale:
+        entries = "\n  ".join(sorted(stale))
+        pytest.fail(
+            "Stale entries in OUTER_ONLY_ALLOWLIST:\n  "
+            f"{entries}\n\n"
+            "Remove these entries from tests/test_cli_parser_drift.py."
+        )
+
+
+def test_max_search_iterations_is_on_both_parsers():
+    """Direct regression test for #2819.
+
+    ``--max-search-iterations`` was added to the outer parser by #2610
+    but the shim did not forward it and the inner parser never declared
+    it, so ``kct route --max-search-iterations N`` parsed cleanly and
+    the override was silently dropped (inner saw ``0`` via the defensive
+    ``getattr(args, "max_search_iterations", 0)``).  This test pins
+    both parsers to ensure the flag never goes missing again.
+    """
+    inner = _inner_route_parser_flags()
+    outer = _outer_route_parser_flags()
+
+    assert "--max-search-iterations" in inner, (
+        "--max-search-iterations is missing from the inner route_cmd.py "
+        "parser (this would regress #2819)"
+    )
+    assert "--max-search-iterations" in outer, (
+        "--max-search-iterations is missing from the outer parser.py route "
+        "subparser (this would regress #2610)"
     )


### PR DESCRIPTION
## Summary

Closes #2819.

### Part A — plumbing fix
- Declare `--max-search-iterations` on the inner `route_cmd.py` parser (`type=int, default=0`, matching the outer parser semantics from #2610).
- Add a forwarding block in `commands/routing.py::run_route_command` that only forwards non-default values (model: the `--per-net-timeout` and `--checkpoint-interval` blocks already there).
- Tighten the two defensive read sites in `route_cmd.py` (~lines 4923 and 5289) from `getattr(args, "max_search_iterations", 0) or 0` to direct attribute access plus a comment noting the inner parser now guarantees the attribute exists.

End-to-end effect: `kct route --max-search-iterations N board.kicad_pcb` now correctly threads `N` through to the C++ A* backstop instead of silently dropping the flag and running with 0 (the historical `cols*rows*4` heuristic).

### Part B — symmetric drift-test broadening
- Add `OUTER_ONLY_ALLOWLIST` near `INNER_ONLY_ALLOWLIST` (initially empty — after the #2819 fix every outer flag has an inner counterpart).
- Add `test_outer_only_flags_are_in_allowlist` asserting `outer_flags - inner_flags ⊆ OUTER_ONLY_ALLOWLIST`, mirroring the existing inner-direction check.
- Add `test_allowlist_entries_are_actually_outer_only` mirroring the existing stale-allowlist check for `INNER_ONLY_ALLOWLIST`.
- Add `test_max_search_iterations_is_on_both_parsers` direct pin (mirrors `test_checkpoint_interval_is_on_both_parsers` from #2818).
- Update the module docstring to describe the bidirectional guard and add #2819 to the historical-instance list.

This is the 5th instance of the argparse-drift bug class (after #2620, #2622/#2793, and #2812/#2817). The symmetric drift test now prevents the 6th instance landing in either direction.

## Test plan

- [x] **Inner-parser smoke**: `uv run python -c "from kicad_tools.cli.route_cmd import main; main(['--help'])"` shows `--max-search-iterations` in the help output (verified).
- [x] **End-to-end forwarding**: in-process test parses `kct route --max-search-iterations 12345 /tmp/dummy.kicad_pcb` through the outer parser, runs the shim, and confirms `["--max-search-iterations", "12345"]` is in the resulting `sub_argv` (verified — the inner parser then captures `args.max_search_iterations == 12345`).
- [x] **Default-only forwarding preserved**: without `--max-search-iterations` (or with explicit `0`), the shim does NOT add the flag to `sub_argv` — preserves "boards 01-05 produce identical routes" invariant.
- [x] **Drift test pin**: `pytest tests/test_cli_parser_drift.py::test_max_search_iterations_is_on_both_parsers` passes.
- [x] **Drift test broadening**: `pytest tests/test_cli_parser_drift.py` — all 6 tests pass (3 original + 3 new symmetric ones).
- [x] **Negative test**: simulated the bug (removed `--max-search-iterations` from the inner parser via mock) and confirmed the new `test_outer_only_flags_are_in_allowlist` catches it and names the flag.
- [x] **Lint/format**: `ruff check` and `ruff format --check` pass on all 3 changed files.

## Files touched

- `src/kicad_tools/cli/route_cmd.py` — inner parser add_argument + 2 read-site simplifications.
- `src/kicad_tools/cli/commands/routing.py` — forwarding block in `run_route_command`.
- `tests/test_cli_parser_drift.py` — `OUTER_ONLY_ALLOWLIST`, 3 new tests, updated docstring.