### PR TITLE
feat(cli): add 'kct fleet status' to survey routing + manufacturing readiness

### DIFF
--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -60,6 +60,7 @@ from .commands import (
     run_decisions_command,
     run_estimate_command,
     run_fix_footprints_command,
+    run_fleet_command,
     run_footprint_command,
     run_impedance_command,
     run_init_command,
@@ -389,6 +390,9 @@ def _dispatch_command(args) -> int:
 
     elif args.command == "sync":
         return run_sync_command(args)
+
+    elif args.command == "fleet":
+        return run_fleet_command(args)
 
     elif args.command == "net-status":
         from .net_status_cmd import main as net_status_cmd

--- a/src/kicad_tools/cli/commands/__init__.py
+++ b/src/kicad_tools/cli/commands/__init__.py
@@ -23,6 +23,7 @@ from .create_pcb import run_create_pcb_command
 from .datasheet import run_datasheet_command
 from .decisions import run_decisions_command
 from .estimate import run_estimate_command
+from .fleet import run_fleet_command
 from .footprint import run_footprint_command
 from .impedance import run_impedance_command
 from .ipc import run_ipc_command
@@ -100,6 +101,8 @@ __all__ = [
     "run_datasheet_command",
     # Decisions
     "run_decisions_command",
+    # Fleet
+    "run_fleet_command",
     # Reasoning
     "run_reason_command",
     # Placement

--- a/src/kicad_tools/cli/commands/fleet.py
+++ b/src/kicad_tools/cli/commands/fleet.py
@@ -1,0 +1,44 @@
+"""Fleet command handler (fleet-wide PCB status surveys)."""
+
+__all__ = ["run_fleet_command"]
+
+
+def run_fleet_command(args) -> int:
+    """Dispatch to ``fleet_cmd.main`` after re-serializing args back into argv.
+
+    Mirrors the pattern used by ``run_decisions_command``: the unified parser
+    captures top-level args and we re-package them as a sub-argv list for the
+    standalone command module so behavior stays in sync between
+    ``kct fleet status`` and ``python -m kicad_tools.cli.fleet_cmd status``.
+    """
+    from ..fleet_cmd import main as fleet_main
+
+    sub_argv: list[str] = []
+
+    fleet_command = getattr(args, "fleet_command", None)
+    if not fleet_command:
+        # No sub-action: let the standalone parser show its help.
+        return fleet_main([])
+
+    sub_argv.append(fleet_command)
+
+    if fleet_command == "status":
+        boards_dir = getattr(args, "fleet_boards_dir", None)
+        if boards_dir:
+            sub_argv.extend(["--boards-dir", boards_dir])
+
+        fmt = getattr(args, "fleet_format", None)
+        if fmt:
+            sub_argv.extend(["--format", fmt])
+
+        if getattr(args, "fleet_ship_only", False):
+            sub_argv.append("--ship-only")
+
+        if getattr(args, "fleet_include_stale", False):
+            sub_argv.append("--include-stale")
+
+        pattern = getattr(args, "fleet_pattern", None)
+        if pattern:
+            sub_argv.extend(["--pattern", pattern])
+
+    return fleet_main(sub_argv)

--- a/src/kicad_tools/cli/fleet_cmd.py
+++ b/src/kicad_tools/cli/fleet_cmd.py
@@ -1,0 +1,527 @@
+"""Fleet-wide PCB status CLI command.
+
+Survey every board under a fleet root and report routing completion plus
+manufacturing artifact readiness in a single shot. Designed to answer the
+question "are all our boards manufacturing-ready?" without requiring agents or
+humans to grep across multiple output directories.
+
+Usage::
+
+    kct fleet status
+    kct fleet status --boards-dir boards/
+    kct fleet status --format json
+    kct fleet status --ship-only
+    kct fleet status --include-stale
+    kct fleet status --pattern '*_routed.kicad_pcb'
+
+Exit Codes:
+    0 - All surveyed boards are ship-ready
+    1 - Argparse / IO error
+    2 - One or more boards are not ship-ready (default semantics, matches
+        ``net-status``)
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from kicad_tools.analysis.net_status import NetStatusAnalyzer
+
+SCHEMA_VERSION = "1.0"
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RoutingStatus:
+    """Routing completion details for a single board."""
+
+    total_pads: int = 0
+    connected_pads: int = 0
+    total_nets: int = 0
+    complete_nets: int = 0
+    incomplete_nets: int = 0
+    unrouted_nets: int = 0
+    error: str | None = None
+
+    @property
+    def completion_pct(self) -> float:
+        if self.total_pads == 0:
+            return 0.0
+        return (self.connected_pads / self.total_pads) * 100.0
+
+    @property
+    def routing_complete(self) -> bool:
+        if self.error is not None:
+            return False
+        # A board is routing-complete iff every multi-pad net is fully
+        # connected. Single-pad nets are not counted by NetStatusAnalyzer.
+        return (self.incomplete_nets + self.unrouted_nets) == 0 and self.total_nets > 0
+
+    def to_dict(self) -> dict:
+        data: dict = {
+            "total_pads": self.total_pads,
+            "connected_pads": self.connected_pads,
+            "completion_pct": round(self.completion_pct, 2),
+            "total_nets": self.total_nets,
+            "complete_nets": self.complete_nets,
+            "incomplete_nets": self.incomplete_nets,
+            "unrouted_nets": self.unrouted_nets,
+            "routing_complete": self.routing_complete,
+        }
+        if self.error is not None:
+            data["error"] = self.error
+        return data
+
+
+@dataclass
+class ManufacturingStatus:
+    """Manufacturing artifact presence/freshness for a single board."""
+
+    dir_exists: bool = False
+    has_gerbers: bool = False
+    has_bom: bool = False
+    has_cpl: bool = False
+    has_manifest: bool = False
+    manifest_mtime: float | None = None
+    stale: bool = False
+
+    @property
+    def has_any(self) -> bool:
+        return self.has_gerbers or self.has_bom or self.has_cpl or self.has_manifest
+
+    @property
+    def has_all(self) -> bool:
+        return self.has_gerbers and self.has_bom and self.has_cpl and self.has_manifest
+
+    def to_dict(self) -> dict:
+        return {
+            "dir_exists": self.dir_exists,
+            "has_gerbers": self.has_gerbers,
+            "has_bom": self.has_bom,
+            "has_cpl": self.has_cpl,
+            "has_manifest": self.has_manifest,
+            "manifest_mtime": _iso_or_none(self.manifest_mtime),
+            "stale": self.stale,
+        }
+
+
+@dataclass
+class BoardStatus:
+    """Aggregated status for a single board."""
+
+    name: str
+    routed_pcb: Path | None
+    routed_mtime: float | None
+    routing: RoutingStatus
+    manufacturing: ManufacturingStatus
+    blockers: list[str] = field(default_factory=list)
+
+    @property
+    def ship_ready(self) -> bool:
+        return not self.blockers
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "routed_pcb": str(self.routed_pcb) if self.routed_pcb else None,
+            "routed_mtime": _iso_or_none(self.routed_mtime),
+            "routing": self.routing.to_dict(),
+            "manufacturing": self.manufacturing.to_dict(),
+            "ship_ready": self.ship_ready,
+            "blockers": list(self.blockers),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _iso_or_none(mtime: float | None) -> str | None:
+    if mtime is None:
+        return None
+    return (
+        _dt.datetime.fromtimestamp(mtime, tz=_dt.timezone.utc)
+        .isoformat(timespec="seconds")
+    )
+
+
+def _now_iso() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds")
+
+
+def _discover_routed_pcb(board_dir: Path, pattern: str) -> Path | None:
+    """Find the first routed PCB inside a board's output/ directory."""
+    output_dir = board_dir / "output"
+    if not output_dir.is_dir():
+        return None
+    matches = sorted(output_dir.glob(pattern))
+    if not matches:
+        return None
+    return matches[0]
+
+
+def _detect_manufacturing(board_dir: Path) -> ManufacturingStatus:
+    """Detect manufacturing artifacts for a single board.
+
+    Prefer ``manifest.json``'s ``files`` keys when present; fall back to
+    directory globs (so we tolerate manufacturer-name variations such as
+    ``bom_jlcpcb.csv`` vs ``bom_pcbway.csv``).
+    """
+    mfg = ManufacturingStatus()
+    mfg_dir = board_dir / "output" / "manufacturing"
+    if not mfg_dir.is_dir():
+        return mfg
+
+    mfg.dir_exists = True
+    manifest_path = mfg_dir / "manifest.json"
+
+    if manifest_path.exists():
+        mfg.has_manifest = True
+        try:
+            mfg.manifest_mtime = manifest_path.stat().st_mtime
+        except OSError:
+            mfg.manifest_mtime = None
+        try:
+            with manifest_path.open() as fh:
+                manifest = json.load(fh)
+            files = manifest.get("files") if isinstance(manifest, dict) else None
+            if isinstance(files, dict):
+                for name in files.keys():
+                    lower = name.lower()
+                    if lower.startswith("bom_") and lower.endswith(".csv"):
+                        mfg.has_bom = True
+                    elif lower.startswith("cpl_") and lower.endswith(".csv"):
+                        mfg.has_cpl = True
+                    elif lower == "gerbers.zip":
+                        mfg.has_gerbers = True
+        except (OSError, json.JSONDecodeError):
+            # Manifest unreadable: fall back to directory scan below.
+            pass
+
+    # Directory-scan fallback (also fills gaps if manifest's files list is
+    # incomplete).
+    if not mfg.has_gerbers and (mfg_dir / "gerbers.zip").is_file():
+        mfg.has_gerbers = True
+    if not mfg.has_bom and any(mfg_dir.glob("bom_*.csv")):
+        mfg.has_bom = True
+    if not mfg.has_cpl and any(mfg_dir.glob("cpl_*.csv")):
+        mfg.has_cpl = True
+
+    return mfg
+
+
+def _compute_routing(routed_pcb: Path) -> RoutingStatus:
+    """Run NetStatusAnalyzer on a routed PCB and tally pads/nets."""
+    status = RoutingStatus()
+    try:
+        analyzer = NetStatusAnalyzer(routed_pcb)
+        result = analyzer.analyze()
+    except Exception as exc:  # pragma: no cover - defensive
+        status.error = f"{type(exc).__name__}: {exc}"
+        return status
+
+    status.total_pads = sum(n.total_pads for n in result.nets)
+    status.connected_pads = sum(n.connected_count for n in result.nets)
+    status.total_nets = result.total_nets
+    status.complete_nets = result.complete_count
+    status.incomplete_nets = result.incomplete_count
+    status.unrouted_nets = result.unrouted_count
+    return status
+
+
+def _compute_blockers(
+    routing: RoutingStatus,
+    mfg: ManufacturingStatus,
+    routed_pcb: Path | None,
+) -> list[str]:
+    """First-failing list of reasons a board cannot ship."""
+    blockers: list[str] = []
+    if routed_pcb is None:
+        blockers.append("no routed PCB")
+        return blockers
+    if routing.error is not None:
+        blockers.append(f"routing analysis failed: {routing.error}")
+        return blockers
+    if not routing.routing_complete:
+        incomplete = routing.incomplete_nets + routing.unrouted_nets
+        blockers.append(
+            f"incomplete routing ({incomplete}/{routing.total_nets} nets)"
+        )
+    if not mfg.dir_exists:
+        blockers.append("no manufacturing/ dir")
+        return blockers
+    if not mfg.has_gerbers:
+        blockers.append("missing gerbers")
+    if not mfg.has_bom:
+        blockers.append("missing BOM")
+    if not mfg.has_cpl:
+        blockers.append("missing CPL")
+    if not mfg.has_manifest:
+        blockers.append("no manifest")
+    if mfg.stale:
+        blockers.append("artifacts stale")
+    return blockers
+
+
+def _survey_board(board_dir: Path, pattern: str) -> BoardStatus:
+    """Build a BoardStatus for a single board directory."""
+    routed_pcb = _discover_routed_pcb(board_dir, pattern)
+    routed_mtime: float | None = None
+    routing = RoutingStatus()
+    mfg = ManufacturingStatus()
+
+    if routed_pcb is not None:
+        try:
+            routed_mtime = routed_pcb.stat().st_mtime
+        except OSError:
+            routed_mtime = None
+        routing = _compute_routing(routed_pcb)
+        mfg = _detect_manufacturing(board_dir)
+        if (
+            routed_mtime is not None
+            and mfg.manifest_mtime is not None
+            and routed_mtime > mfg.manifest_mtime
+        ):
+            mfg.stale = True
+
+    blockers = _compute_blockers(routing, mfg, routed_pcb)
+
+    return BoardStatus(
+        name=board_dir.name,
+        routed_pcb=routed_pcb,
+        routed_mtime=routed_mtime,
+        routing=routing,
+        manufacturing=mfg,
+        blockers=blockers,
+    )
+
+
+def _discover_boards(boards_dir: Path, pattern: str) -> list[BoardStatus]:
+    """Survey every board sub-directory of ``boards_dir``.
+
+    A board is discovered if it contains a routed PCB matching ``pattern``
+    under ``<board>/output/``. Boards without a routed PCB are silently
+    skipped (they haven't reached the routing stage yet).
+    """
+    if not boards_dir.is_dir():
+        return []
+    boards: list[BoardStatus] = []
+    for entry in sorted(boards_dir.iterdir()):
+        if not entry.is_dir():
+            continue
+        # Skip dotfiles / hidden dirs and obvious non-board names.
+        if entry.name.startswith("."):
+            continue
+        # A directory without an output/ sub-dir is not yet at routing
+        # stage -- skip it silently.
+        output_dir = entry / "output"
+        if not output_dir.is_dir():
+            continue
+        # Skip directories with no routed PCB matching the pattern.
+        if _discover_routed_pcb(entry, pattern) is None:
+            continue
+        boards.append(_survey_board(entry, pattern))
+    return boards
+
+
+# ---------------------------------------------------------------------------
+# Output formatters
+# ---------------------------------------------------------------------------
+
+
+def _mfr_letters(mfg: ManufacturingStatus) -> str:
+    if not mfg.dir_exists or not mfg.has_any:
+        return "-"
+    parts = []
+    if mfg.has_bom:
+        parts.append("B")
+    if mfg.has_cpl:
+        parts.append("C")
+    if mfg.has_gerbers:
+        parts.append("G")
+    if mfg.has_manifest:
+        parts.append("M")
+    return "/".join(parts) if parts else "-"
+
+
+def _stale_label(mfg: ManufacturingStatus) -> str:
+    if not mfg.has_manifest:
+        return "-"
+    return "STALE" if mfg.stale else "fresh"
+
+
+def _format_table(
+    boards: list[BoardStatus],
+    boards_dir: Path,
+    *,
+    ship_only: bool,
+) -> str:
+    """Format a fixed-width plain-ASCII table."""
+    lines: list[str] = []
+    header = f"{'Board':<28} {'Pads':>7} {'%':>5} {'Mfr':<8} {'Stale':<6} Ship?"
+    sep = "-" * len(header)
+    lines.append(header)
+    lines.append(sep)
+
+    visible = [b for b in boards if (not ship_only or b.ship_ready)]
+
+    if not visible:
+        if not boards:
+            lines.append("No boards found")
+        else:
+            lines.append("(no ship-ready boards)")
+    else:
+        for b in visible:
+            pads = f"{b.routing.connected_pads}/{b.routing.total_pads}"
+            pct = f"{b.routing.completion_pct:.0f}%"
+            mfr = _mfr_letters(b.manufacturing)
+            stale = _stale_label(b.manufacturing)
+            if b.ship_ready:
+                ship = "YES"
+            else:
+                ship = f"NO  ({b.blockers[0]})"
+            lines.append(
+                f"{b.name[:28]:<28} {pads:>7} {pct:>5} {mfr:<8} {stale:<6} {ship}"
+            )
+
+    # Footer (always uses full board list, not filtered view).
+    if boards:
+        lines.append("")
+        ship_ready = sum(1 for b in boards if b.ship_ready)
+        incomplete = sum(
+            1
+            for b in boards
+            if not b.routing.routing_complete and b.routing.error is None
+        )
+        stale_count = sum(1 for b in boards if b.manufacturing.stale)
+        lines.append(
+            f"{len(boards)} boards surveyed, {ship_ready} ship-ready, "
+            f"{incomplete} incomplete, {stale_count} artifacts stale"
+        )
+        lines.append(f"boards-dir: {boards_dir}")
+
+    return "\n".join(lines)
+
+
+def _format_json(boards: list[BoardStatus], boards_dir: Path) -> str:
+    summary = {
+        "total": len(boards),
+        "ship_ready": sum(1 for b in boards if b.ship_ready),
+        "incomplete_routing": sum(
+            1
+            for b in boards
+            if not b.routing.routing_complete and b.routing.error is None
+        ),
+        "stale_artifacts": sum(1 for b in boards if b.manufacturing.stale),
+        "missing_artifacts": sum(
+            1
+            for b in boards
+            if not b.manufacturing.has_all
+        ),
+    }
+    doc = {
+        "schema_version": SCHEMA_VERSION,
+        "surveyed_at": _now_iso(),
+        "boards_dir": str(boards_dir),
+        "summary": summary,
+        "boards": [b.to_dict() for b in boards],
+    }
+    return json.dumps(doc, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="kicad-fleet",
+        description="Fleet-wide PCB status and operations",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    subparsers = parser.add_subparsers(dest="fleet_command", help="Fleet commands")
+
+    status_parser = subparsers.add_parser(
+        "status",
+        help="Survey routing + manufacturing status for all boards",
+    )
+    status_parser.add_argument(
+        "--boards-dir",
+        default="boards",
+        help="Root directory containing per-board subdirs (default: boards)",
+    )
+    status_parser.add_argument(
+        "--format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    status_parser.add_argument(
+        "--ship-only",
+        action="store_true",
+        help="Show only ship-ready boards (table only; JSON always lists all)",
+    )
+    status_parser.add_argument(
+        "--include-stale",
+        action="store_true",
+        help=(
+            "Reserved for future use: in the default behavior stale artifacts "
+            "already demote ship-ready to NO. Currently a no-op flag retained "
+            "for forward compatibility with --ship-only filter semantics."
+        ),
+    )
+    status_parser.add_argument(
+        "--pattern",
+        default="*_routed.kicad_pcb",
+        help="Glob to identify routed PCB inside output/ (default: *_routed.kicad_pcb)",
+    )
+    return parser
+
+
+def run_status(args: argparse.Namespace) -> int:
+    """Execute the ``fleet status`` sub-action."""
+    boards_dir = Path(args.boards_dir)
+    boards = _discover_boards(boards_dir, args.pattern)
+
+    if args.format == "json":
+        print(_format_json(boards, boards_dir))
+    else:
+        print(_format_table(boards, boards_dir, ship_only=args.ship_only))
+
+    if not boards:
+        return 2  # No boards found counts as not-ship-ready.
+    if all(b.ship_ready for b in boards):
+        return 0
+    return 2
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Main entry point for the fleet command."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if not args.fleet_command:
+        parser.print_help()
+        return 0
+
+    if args.fleet_command == "status":
+        return run_status(args)
+
+    parser.print_help()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -173,6 +173,7 @@ def create_parser() -> argparse.ArgumentParser:
     _add_audit_parser(subparsers)
     _add_suggest_parser(subparsers)
     _add_net_status_parser(subparsers)
+    _add_fleet_parser(subparsers)
     _add_clean_parser(subparsers)
     _add_impedance_parser(subparsers)
     _add_mcp_parser(subparsers)
@@ -4194,6 +4195,59 @@ def _add_net_status_parser(subparsers) -> None:
         dest="net_status_verbose",
         action="store_true",
         help="Show all pads with coordinates",
+    )
+
+
+def _add_fleet_parser(subparsers) -> None:
+    """Add fleet parent-subaction parser (fleet status; future fleet route-all)."""
+    fleet_parser = subparsers.add_parser(
+        "fleet",
+        help="Fleet-wide PCB status and operations",
+        description=(
+            "Survey every board under a fleet root in one shot. Reports routing "
+            "completion (via NetStatusAnalyzer) and manufacturing-artifact "
+            "readiness (gerbers, BOM, CPL, manifest) with staleness detection."
+        ),
+    )
+    fleet_subparsers = fleet_parser.add_subparsers(
+        dest="fleet_command", help="Fleet commands"
+    )
+
+    # fleet status
+    fleet_status = fleet_subparsers.add_parser(
+        "status",
+        help="Survey routing + manufacturing status for all boards",
+    )
+    fleet_status.add_argument(
+        "--boards-dir",
+        dest="fleet_boards_dir",
+        default="boards",
+        help="Root directory containing per-board subdirs (default: boards)",
+    )
+    fleet_status.add_argument(
+        "--format",
+        dest="fleet_format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    fleet_status.add_argument(
+        "--ship-only",
+        dest="fleet_ship_only",
+        action="store_true",
+        help="Show only ship-ready boards in table output",
+    )
+    fleet_status.add_argument(
+        "--include-stale",
+        dest="fleet_include_stale",
+        action="store_true",
+        help="(Reserved) treat stale artifacts as not-shippable (already default)",
+    )
+    fleet_status.add_argument(
+        "--pattern",
+        dest="fleet_pattern",
+        default="*_routed.kicad_pcb",
+        help="Glob to identify routed PCB inside output/ (default: *_routed.kicad_pcb)",
     )
 
 

--- a/tests/test_fleet_status.py
+++ b/tests/test_fleet_status.py
@@ -1,0 +1,554 @@
+"""Tests for the `kct fleet status` CLI command."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.fleet_cmd import main
+
+# ---------------------------------------------------------------------------
+# Synthetic PCB fixtures
+# ---------------------------------------------------------------------------
+
+# PCB with fully connected nets (2 nets, 4 pads, all connected).
+CONNECTED_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general
+    (thickness 1.6)
+  )
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "VCC")
+  (net 2 "GND")
+
+  (gr_rect
+    (start 0 0)
+    (end 30 30)
+    (stroke (width 0.1))
+    (layer "Edge.Cuts")
+  )
+
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (at 10 10)
+    (property "Reference" "R1")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 1 "VCC"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 2 "GND"))
+  )
+
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (at 20 10)
+    (property "Reference" "R2")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 1 "VCC"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 2 "GND"))
+  )
+
+  (segment (start 9.5 10) (end 19.5 10) (width 0.25) (layer "F.Cu") (net 1))
+  (segment (start 10.5 10) (end 20.5 10) (width 0.25) (layer "F.Cu") (net 2))
+)
+"""
+
+
+# PCB with unrouted nets (no traces).
+UNROUTED_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general
+    (thickness 1.6)
+  )
+  (layers
+    (0 "F.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "SIG1")
+  (net 2 "SIG2")
+
+  (gr_rect
+    (start 0 0)
+    (end 40 40)
+    (stroke (width 0.1))
+    (layer "Edge.Cuts")
+  )
+
+  (footprint "Connector_PinHeader_2.54mm:PinHeader_1x02"
+    (layer "F.Cu")
+    (at 10 20)
+    (property "Reference" "J1")
+    (pad "1" thru_hole oval (at 0 0) (size 1.7 1.7) (drill 1) (layers "*.Cu" "*.Mask") (net 1 "SIG1"))
+    (pad "2" thru_hole oval (at 0 2.54) (size 1.7 1.7) (drill 1) (layers "*.Cu" "*.Mask") (net 2 "SIG2"))
+  )
+
+  (footprint "Connector_PinHeader_2.54mm:PinHeader_1x02"
+    (layer "F.Cu")
+    (at 30 20)
+    (property "Reference" "J2")
+    (pad "1" thru_hole oval (at 0 0) (size 1.7 1.7) (drill 1) (layers "*.Cu" "*.Mask") (net 1 "SIG1"))
+    (pad "2" thru_hole oval (at 0 2.54) (size 1.7 1.7) (drill 1) (layers "*.Cu" "*.Mask") (net 2 "SIG2"))
+  )
+)
+"""
+
+
+# ---------------------------------------------------------------------------
+# Fake-board builder
+# ---------------------------------------------------------------------------
+
+
+def make_fake_board(
+    boards_dir: Path,
+    name: str,
+    *,
+    routed_complete: bool = True,
+    has_gerbers: bool = False,
+    has_bom: bool = False,
+    has_cpl: bool = False,
+    has_manifest: bool = False,
+    bom_suffix: str = "jlcpcb",
+    cpl_suffix: str = "jlcpcb",
+    artifacts_older_than_routed: bool = False,
+) -> Path:
+    """Build ``boards_dir/<name>/output/`` with a minimal routed PCB and
+    optional manufacturing artifacts.
+
+    Returns the path to the routed PCB file.
+    """
+    board_dir = boards_dir / name
+    output_dir = board_dir / "output"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    pcb_text = CONNECTED_PCB if routed_complete else UNROUTED_PCB
+    routed_pcb = output_dir / f"{name.replace('-', '_')}_routed.kicad_pcb"
+    routed_pcb.write_text(pcb_text)
+
+    mfg_dir = output_dir / "manufacturing"
+    if any([has_gerbers, has_bom, has_cpl, has_manifest]):
+        mfg_dir.mkdir(parents=True, exist_ok=True)
+
+    if has_gerbers:
+        (mfg_dir / "gerbers.zip").write_bytes(b"PK\x03\x04fake")
+    if has_bom:
+        (mfg_dir / f"bom_{bom_suffix}.csv").write_text("ref,value\nR1,10k\n")
+    if has_cpl:
+        (mfg_dir / f"cpl_{cpl_suffix}.csv").write_text("ref,x,y\nR1,0,0\n")
+    if has_manifest:
+        manifest = {
+            "version": "1.0",
+            "manufacturer": bom_suffix,
+            "files": {
+                f"bom_{bom_suffix}.csv": {"sha256": "0" * 64, "size": 12},
+                f"cpl_{cpl_suffix}.csv": {"sha256": "0" * 64, "size": 13},
+                "gerbers.zip": {"sha256": "0" * 64, "size": 14},
+            },
+        }
+        (mfg_dir / "manifest.json").write_text(json.dumps(manifest))
+
+    if artifacts_older_than_routed and has_manifest:
+        # Make manifest older than routed PCB so the surveyor flags STALE.
+        manifest_path = mfg_dir / "manifest.json"
+        routed_mtime = routed_pcb.stat().st_mtime
+        old_time = routed_mtime - 3600.0
+        os.utime(manifest_path, (old_time, old_time))
+
+    return routed_pcb
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestFleetStatusBasics:
+    def test_fleet_status_all_ship_ready(self, tmp_path: Path, capsys):
+        """3 boards, all 100% routed + all artifacts present + fresh -> exit 0."""
+        boards = tmp_path / "boards"
+        for i, name in enumerate(["a-board", "b-board", "c-board"]):
+            make_fake_board(
+                boards,
+                name,
+                routed_complete=True,
+                has_gerbers=True,
+                has_bom=True,
+                has_cpl=True,
+                has_manifest=True,
+            )
+
+        result = main(
+            [
+                "status",
+                "--boards-dir",
+                str(boards),
+                "--format",
+                "json",
+            ]
+        )
+        assert result == 0
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["summary"]["total"] == 3
+        assert data["summary"]["ship_ready"] == 3
+        for board in data["boards"]:
+            assert board["ship_ready"] is True
+            assert board["blockers"] == []
+
+    def test_fleet_status_mixed_completion(self, tmp_path: Path, capsys):
+        """5 boards mixed: 1 shippable, 2 incomplete, 1 missing mfr, 1 stale."""
+        boards = tmp_path / "boards"
+
+        make_fake_board(
+            boards,
+            "a-ship",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        make_fake_board(
+            boards,
+            "b-incomplete-1",
+            routed_complete=False,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        make_fake_board(
+            boards,
+            "c-incomplete-2",
+            routed_complete=False,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        make_fake_board(
+            boards,
+            "d-no-mfr",
+            routed_complete=True,
+        )
+        make_fake_board(
+            boards,
+            "e-stale",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+            artifacts_older_than_routed=True,
+        )
+
+        result = main(
+            ["status", "--boards-dir", str(boards), "--format", "json"]
+        )
+        assert result == 2
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        by_name = {b["name"]: b for b in data["boards"]}
+
+        assert by_name["a-ship"]["ship_ready"] is True
+        assert by_name["a-ship"]["blockers"] == []
+
+        assert by_name["b-incomplete-1"]["ship_ready"] is False
+        assert any("incomplete routing" in b for b in by_name["b-incomplete-1"]["blockers"])
+
+        assert by_name["c-incomplete-2"]["ship_ready"] is False
+        assert any("incomplete routing" in b for b in by_name["c-incomplete-2"]["blockers"])
+
+        assert by_name["d-no-mfr"]["ship_ready"] is False
+        assert "no manufacturing/ dir" in by_name["d-no-mfr"]["blockers"]
+
+        assert by_name["e-stale"]["ship_ready"] is False
+        assert "artifacts stale" in by_name["e-stale"]["blockers"]
+
+    def test_fleet_status_json_schema(self, tmp_path: Path, capsys):
+        """Verify JSON schema: schema_version, ISO 8601 timestamps, board keys."""
+        boards = tmp_path / "boards"
+        make_fake_board(
+            boards,
+            "a-board",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+
+        main(["status", "--boards-dir", str(boards), "--format", "json"])
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+
+        # Top-level keys
+        assert data["schema_version"] == "1.0"
+        for key in ("schema_version", "surveyed_at", "boards_dir", "summary", "boards"):
+            assert key in data
+
+        # ISO 8601 surveyed_at
+        assert re.match(
+            r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}",
+            data["surveyed_at"],
+        )
+
+        # Board dict keys
+        b = data["boards"][0]
+        expected_board_keys = {
+            "name",
+            "routed_pcb",
+            "routed_mtime",
+            "routing",
+            "manufacturing",
+            "ship_ready",
+            "blockers",
+        }
+        assert expected_board_keys.issubset(b.keys())
+
+        # Routing sub-keys
+        expected_routing_keys = {
+            "total_pads",
+            "connected_pads",
+            "completion_pct",
+            "total_nets",
+            "complete_nets",
+            "incomplete_nets",
+            "unrouted_nets",
+            "routing_complete",
+        }
+        assert expected_routing_keys.issubset(b["routing"].keys())
+
+        # Manufacturing sub-keys
+        expected_mfg_keys = {
+            "dir_exists",
+            "has_gerbers",
+            "has_bom",
+            "has_cpl",
+            "has_manifest",
+            "manifest_mtime",
+            "stale",
+        }
+        assert expected_mfg_keys.issubset(b["manufacturing"].keys())
+
+    def test_fleet_status_table_format(self, tmp_path: Path, capsys):
+        """Table headers, summary footer, no Unicode glyphs."""
+        boards = tmp_path / "boards"
+        make_fake_board(
+            boards,
+            "a-board",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        make_fake_board(boards, "b-incomplete", routed_complete=False)
+
+        main(["status", "--boards-dir", str(boards)])
+        captured = capsys.readouterr()
+        out = captured.out
+
+        # Header row
+        assert "Board" in out
+        assert "Pads" in out
+        assert "Mfr" in out
+        assert "Stale" in out
+        assert "Ship?" in out
+
+        # Summary footer line
+        assert "boards surveyed" in out
+        assert "ship-ready" in out
+        assert "incomplete" in out
+        assert "artifacts stale" in out
+
+        # Plain ASCII only (no Unicode glyphs, no checkmarks/x-marks).
+        forbidden_chars = "✓✗✅❌─━│"
+        assert not any(c in out for c in forbidden_chars), (
+            "Unicode glyphs leaked into table output"
+        )
+
+        # YES / NO ship status appears.
+        assert "YES" in out
+        assert "NO" in out
+
+    def test_fleet_status_empty_boards_dir(self, tmp_path: Path, capsys):
+        """Empty boards/ -> 'No boards found' table, JSON boards=[]."""
+        empty = tmp_path / "boards"
+        empty.mkdir()
+
+        # Table format.
+        result = main(["status", "--boards-dir", str(empty)])
+        captured = capsys.readouterr()
+        assert "No boards found" in captured.out
+        # Exit code 2: no boards found counts as not-ship-ready (mirrors
+        # net-status semantics).
+        assert result == 2
+
+        # JSON format.
+        result = main(["status", "--boards-dir", str(empty), "--format", "json"])
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["boards"] == []
+        assert data["summary"]["total"] == 0
+        assert result == 2
+
+    def test_fleet_status_custom_boards_dir(self, tmp_path: Path, capsys):
+        """--boards-dir picks up an alternate location."""
+        alt = tmp_path / "alt-fleet"
+        make_fake_board(
+            alt,
+            "x-board",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        main(["status", "--boards-dir", str(alt), "--format", "json"])
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["summary"]["total"] == 1
+        assert data["boards"][0]["name"] == "x-board"
+
+    def test_fleet_status_ship_only_filter(self, tmp_path: Path, capsys):
+        """--ship-only hides non-ship-ready rows in table; JSON unaffected."""
+        boards = tmp_path / "boards"
+        make_fake_board(
+            boards,
+            "a-ship",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        make_fake_board(boards, "b-incomplete", routed_complete=False)
+
+        # Table with --ship-only.
+        main(["status", "--boards-dir", str(boards), "--ship-only"])
+        captured = capsys.readouterr()
+        assert "a-ship" in captured.out
+        assert "b-incomplete" not in captured.out
+
+        # JSON output always lists all boards.
+        main(["status", "--boards-dir", str(boards), "--ship-only", "--format", "json"])
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        names = {b["name"] for b in data["boards"]}
+        assert names == {"a-ship", "b-incomplete"}
+
+    def test_fleet_status_stale_detection(self, tmp_path: Path, capsys):
+        """os.utime to age the manifest below the routed PCB -> stale + blocker."""
+        boards = tmp_path / "boards"
+        make_fake_board(
+            boards,
+            "x-board",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+            artifacts_older_than_routed=True,
+        )
+        result = main(["status", "--boards-dir", str(boards), "--format", "json"])
+        assert result == 2
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        b = data["boards"][0]
+        assert b["manufacturing"]["stale"] is True
+        assert "artifacts stale" in b["blockers"]
+
+    def test_fleet_status_pattern_override(self, tmp_path: Path, capsys):
+        """--pattern '*.kicad_pcb' picks up unrouted PCBs too."""
+        boards = tmp_path / "boards"
+        board_dir = boards / "p-board" / "output"
+        board_dir.mkdir(parents=True)
+        # Only an unrouted PCB present (no *_routed.kicad_pcb).
+        (board_dir / "p_board.kicad_pcb").write_text(UNROUTED_PCB)
+
+        # Default pattern: should not pick it up.
+        main(["status", "--boards-dir", str(boards), "--format", "json"])
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["summary"]["total"] == 0
+
+        # Overridden pattern: should pick it up.
+        main(
+            [
+                "status",
+                "--boards-dir",
+                str(boards),
+                "--pattern",
+                "*.kicad_pcb",
+                "--format",
+                "json",
+            ]
+        )
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["summary"]["total"] == 1
+        assert data["boards"][0]["name"] == "p-board"
+
+
+class TestFleetStatusManufacturerVariation:
+    """Verify manufacturer-name variation tolerance for BOM/CPL detection."""
+
+    @pytest.mark.parametrize("mfr", ["jlcpcb", "pcbway", "seeed"])
+    def test_bom_cpl_suffix_variation(self, tmp_path: Path, capsys, mfr: str):
+        boards = tmp_path / "boards"
+        make_fake_board(
+            boards,
+            f"vendor-{mfr}",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+            bom_suffix=mfr,
+            cpl_suffix=mfr,
+        )
+        main(["status", "--boards-dir", str(boards), "--format", "json"])
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        b = data["boards"][0]
+        assert b["manufacturing"]["has_bom"] is True
+        assert b["manufacturing"]["has_cpl"] is True
+
+
+class TestFleetStatusIntegration:
+    """Integration smoke test against the actual repo boards/ dir."""
+
+    @pytest.mark.slow
+    def test_fleet_status_real_boards_dir(self, capsys):
+        # Locate repo root: tests/test_fleet_status.py -> ../boards
+        repo_boards = Path(__file__).resolve().parent.parent / "boards"
+        if not repo_boards.is_dir():
+            pytest.skip("repo boards/ directory not present in this checkout")
+
+        # Should run without exception and produce some output.
+        rc = main(
+            [
+                "status",
+                "--boards-dir",
+                str(repo_boards),
+                "--format",
+                "json",
+            ]
+        )
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert "schema_version" in data
+        assert "boards" in data
+        # Exit code: 0 if all ship, 2 otherwise; both are valid for a smoke test.
+        assert rc in (0, 2)


### PR DESCRIPTION
## Summary

Closes #2832.

Adds a new top-level `kct fleet` subcommand with first sub-action `status` that surveys every board under `boards/*` in one shot. Replaces the multi-step shell incantation previously required to answer "are all our boards manufacturing-ready?" Built as parent-subaction (mirroring `kct decisions` / `kct placement`) so future sub-actions like `fleet route-all` can be added by registering a new subparser only.

- **Routing completion**: reuses `NetStatusAnalyzer` (no parallel implementation). A board is routing-complete iff every multi-pad net is fully connected.
- **Manufacturing detection**: prefers `manifest.json`'s `files` keys when present; falls back to directory globs that tolerate manufacturer-name variation (`bom_jlcpcb.csv` vs `bom_pcbway.csv`).
- **Staleness**: compares `manifest.json` mtime against the routed PCB mtime. Absent manifest reports `-`, not "stale".
- **Output formats**: `table` (plain ASCII, B/C/G/M letter codes, YES/NO ship indicator) and `json` (schema v1.0, summary + per-board breakdown).
- **Exit codes**: `0` = all ship-ready, `2` = at least one not ship-ready (or no boards found), `1` = argparse/IO error. Mirrors `net-status` semantics.

## Files

- `src/kicad_tools/cli/fleet_cmd.py` (new, standalone module; also callable via `python -m kicad_tools.cli.fleet_cmd`)
- `src/kicad_tools/cli/commands/fleet.py` (new, thin wrapper that re-serializes args back into argv)
- `src/kicad_tools/cli/parser.py` (`_add_fleet_parser` registered alongside `_add_net_status_parser`)
- `src/kicad_tools/cli/__init__.py` (dispatch parallel to `net-status` block)
- `src/kicad_tools/cli/commands/__init__.py` (re-exports `run_fleet_command`)
- `tests/test_fleet_status.py` (new, 13 test cases)

## Output sample

Running against the actual `boards/` directory on this checkout:

```
Board                           Pads     % Mfr      Stale  Ship?
----------------------------------------------------------------
00-simple-led                    6/6  100% G/M      STALE  NO  (missing BOM)
01-voltage-divider               6/8   75% B/C/G/M  fresh  NO  (incomplete routing (1/3 nets))
02-charlieplex-led             32/34   94% B/C/G/M  fresh  NO  (incomplete routing (1/10 nets))
03-usb-joystick                36/85   42% -        -      NO  (incomplete routing (7/16 nets))
04-stm32-devboard              35/55   64% -        -      NO  (incomplete routing (4/12 nets))
05-bldc-motor-controller      76/206   37% -        -      NO  (incomplete routing (24/40 nets))
06-diffpair-test              46/198   23% B/C/G/M  fresh  NO  (incomplete routing (8/26 nets))
07-matchgroup-test            59/244   24% B/C/G/M  fresh  NO  (incomplete routing (9/34 nets))

8 boards surveyed, 0 ship-ready, 7 incomplete, 1 artifacts stale
boards-dir: /Users/rwalters/GitHub/kicad-tools/boards
```

JSON output (`--format json`) includes `schema_version`, `surveyed_at` (ISO 8601), `boards_dir`, a `summary` object, and a per-board `boards` array with nested `routing`, `manufacturing`, and `blockers` fields.

## Test plan

- [x] `pytest tests/test_fleet_status.py -v` is green (13 passed)
- [x] `pytest tests/test_net_status_cmd.py -v` still green (17 passed — no regression in reused analyzer)
- [x] `kct --help` lists `fleet`; `kct fleet --help` shows the `status` sub-action
- [x] `kct fleet status` runs cleanly against the repo's actual `boards/` (output sample above)
- [x] `kct fleet status --format json | jq .` parses without error
- [x] `python -m kicad_tools.cli.fleet_cmd status --boards-dir <path>` produces identical output to `kct fleet status`
- [x] `ruff check` passes on new + modified files

Test cases (all in `tests/test_fleet_status.py`):
1. `test_fleet_status_all_ship_ready` — 3 boards, all ship-ready, exit 0
2. `test_fleet_status_mixed_completion` — 5 boards mixed states, exit 2, per-board blockers verified
3. `test_fleet_status_json_schema` — top-level keys + ISO 8601 timestamps + board/routing/manufacturing sub-keys
4. `test_fleet_status_table_format` — header row, summary footer, no Unicode glyphs
5. `test_fleet_status_empty_boards_dir` — "No boards found" / empty list, exit 2
6. `test_fleet_status_custom_boards_dir` — `--boards-dir` override
7. `test_fleet_status_ship_only_filter` — table filters, JSON unaffected
8. `test_fleet_status_stale_detection` — `os.utime` ages manifest, stale flag + blocker
9. `test_fleet_status_pattern_override` — `--pattern '*.kicad_pcb'` picks up unrouted PCBs
10-12. Manufacturer suffix variations (`jlcpcb`, `pcbway`, `seeed`) parametrized
13. Integration smoke against the real `boards/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)