### PR TITLE
fix(loom): champion uses gh closingIssuesReferences instead of brittle body regex

### DIFF
--- a/.claude/commands/loom/champion-pr-merge.md
+++ b/.claude/commands/loom/champion-pr-merge.md
@@ -351,15 +351,29 @@ git checkout main 2>/dev/null || true
 
 After successful merge, verify that linked issues were automatically closed by GitHub.
 
+**Important**: Use GitHub's `closingIssuesReferences` field — NOT a regex over the
+PR body. GitHub computes `closingIssuesReferences` from the PR body using canonical
+semantics: only `Closes/Fixes/Resolves` keywords (case-insensitive, with proper
+word boundaries) create closing references. Words like `Updates`, `See`,
+`References`, or `Closure of` correctly do NOT produce closing references. A prior
+regex-based extraction (`grep -Eo "(Closes|Fixes|Resolves) #[0-9]+"`) was brittle
+and could misfire on PRs that explicitly used `Updates #N` to indicate partial
+progress. See issue [#2849](https://github.com/rjwalters/kicad-tools/issues/2849).
+
+If `.loom/scripts/lib/forge-helpers.sh` is available, prefer
+`forge_pr_close_targets "$PR_NUMBER"` for a single source of truth. The inline
+form below is equivalent.
+
 ```bash
 PR_NUMBER=$1
 
-# Extract linked issues from PR body
-PR_BODY=$(gh pr view "$PR_NUMBER" --json body --jq -r '.body')
-LINKED_ISSUES=$(echo "$PR_BODY" | grep -Eo "(Closes|Fixes|Resolves) #[0-9]+" | grep -Eo "[0-9]+" | sort -u)
+# Ask GitHub which issues this PR closes per official semantics
+# (Closes/Fixes/Resolves keywords; case-insensitive; proper word boundaries).
+LINKED_ISSUES=$(gh pr view "$PR_NUMBER" --json closingIssuesReferences \
+  --jq '.closingIssuesReferences[].number' 2>/dev/null)
 
 if [ -z "$LINKED_ISSUES" ]; then
-  echo "No linked issues found in PR body"
+  echo "No closing-issue references found - skipping closure verification"
   exit 0
 fi
 

--- a/.claude/commands/loom/champion-reference.md
+++ b/.claude/commands/loom/champion-reference.md
@@ -135,8 +135,12 @@ fi
 
 **Handling**:
 ```bash
-# Extract all linked issues
-LINKED_ISSUES=$(gh pr view "$PR_NUMBER" --json body --jq '.body' | grep -Eo "(Closes|Fixes|Resolves) #[0-9]+" | grep -Eo "[0-9]+")
+# Ask GitHub which issues this PR closes per official semantics
+# (Closes/Fixes/Resolves keywords; case-insensitive; proper word boundaries).
+# This does NOT match Updates/See/References or words like "Closure of".
+# See issue #2849 for why a body regex is the wrong tool.
+LINKED_ISSUES=$(gh pr view "$PR_NUMBER" --json closingIssuesReferences \
+  --jq '.closingIssuesReferences[].number')
 
 # Verify each issue closed after merge
 for issue in $LINKED_ISSUES; do
@@ -500,11 +504,15 @@ echo ""
 echo "STEP 4/5: Verifying linked issue closure..."
 echo ""
 
-PR_BODY=$(gh pr view "$PR_NUMBER" --json body --jq -r '.body')
-LINKED_ISSUES=$(echo "$PR_BODY" | grep -Eo "(Closes|Fixes|Resolves) #[0-9]+" | grep -Eo "[0-9]+" | sort -u)
+# Ask GitHub which issues this PR closes per official semantics
+# (Closes/Fixes/Resolves keywords; case-insensitive; proper word boundaries).
+# This does NOT match Updates/See/References or words like "Closure of".
+# See issue #2849 for why a body regex is the wrong tool.
+LINKED_ISSUES=$(gh pr view "$PR_NUMBER" --json closingIssuesReferences \
+  --jq '.closingIssuesReferences[].number' 2>/dev/null)
 
 if [ -z "$LINKED_ISSUES" ]; then
-  echo "No linked issues found - skipping closure verification"
+  echo "No closing-issue references found - skipping closure verification"
 else
   echo "Found linked issues: $LINKED_ISSUES"
   for issue in $LINKED_ISSUES; do
@@ -624,8 +632,9 @@ done
 # Check PR merge status
 gh pr view <number> --json state,mergeable,statusCheckRollup
 
-# View linked issues
-gh pr view <number> --json body --jq '.body' | grep -Eo "(Closes|Fixes|Resolves) #[0-9]+"
+# View linked issues (canonical: uses GitHub's computed closingIssuesReferences,
+# which correctly handles Closes/Fixes/Resolves keywords and ignores Updates/See/etc.)
+gh pr view <number> --json closingIssuesReferences --jq '.closingIssuesReferences[].number'
 
 # Check daemon state
 cat .loom/daemon-state.json | jq '.force_mode'

--- a/.loom/scripts/lib/forge-helpers.sh
+++ b/.loom/scripts/lib/forge-helpers.sh
@@ -515,6 +515,50 @@ forge_get_pr_reviews() {
   fi
 }
 
+# Get the list of issue numbers a PR closes per official forge semantics.
+# Usage: forge_pr_close_targets PR_NUMBER [GH_CMD]
+# Output: newline-separated issue numbers on stdout; empty if none.
+#
+# Single source of truth for "what issues does this PR close?".
+# This is the correct way to compute closure targets — NOT a regex over the
+# PR body. GitHub computes `closingIssuesReferences` from the body using
+# canonical keyword semantics (`Closes/Fixes/Resolves`, case-insensitive,
+# with proper word boundaries). Words like `Updates`, `See`, `References`,
+# or `Closure of` are correctly excluded.
+#
+# GitHub: gh pr view --json closingIssuesReferences
+# Gitea: parses the PR body with a strict word-boundary regex (Gitea exposes
+#        the body but not a server-computed closes list comparable to
+#        GitHub's `closingIssuesReferences`). The regex restricts matches
+#        to the canonical closing keywords with explicit boundaries so it
+#        cannot match `Updates`, `Closure`, etc.
+#
+# See: https://github.com/rjwalters/kicad-tools/issues/2849
+forge_pr_close_targets() {
+  local pr_number="$1"
+  local gh_cmd="${2:-gh}"
+
+  if [[ "$FORGE_TYPE" == "gitea" ]]; then
+    # Gitea has no equivalent of closingIssuesReferences; derive from body
+    # using a strict regex with explicit word boundaries.
+    local nwo
+    nwo=$(forge_get_repo_nwo) || return 0
+    local body matches
+    body=$(forge_get_pr_body "$nwo" "$pr_number")
+    # \b boundary on both sides; case-insensitive.
+    # Use `|| true` to keep behavior consistent under `set -e` when there
+    # are no matches (grep exits 1 on no match).
+    matches=$(echo "$body" \
+      | grep -oEi '\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\b[[:space:]]*#[0-9]+' \
+      || true)
+    [[ -z "$matches" ]] && return 0
+    echo "$matches" | grep -oE '[0-9]+' | sort -u
+  else
+    "$gh_cmd" pr view "$pr_number" --json closingIssuesReferences \
+      --jq '.closingIssuesReferences[].number' 2>/dev/null | sort -u
+  fi
+}
+
 # Get repo NWO (name with owner).
 # Usage: forge_get_repo_nwo [GH_CMD]
 # Returns "owner/repo" on stdout.

--- a/.loom/scripts/merge-pr.sh
+++ b/.loom/scripts/merge-pr.sh
@@ -236,7 +236,13 @@ fi
 
 success "PR #$PR_NUMBER merged successfully"
 
-# NOTE: Label cleanup on linked issues is intentionally skipped.
+# NOTE: This script does NOT close linked issues. GitHub auto-closes issues
+# referenced by `Closes/Fixes/Resolves` keywords; for cross-repo or missed
+# auto-closes, the Champion role's verify-issue-closure step handles it.
+# See: .claude/commands/loom/champion-pr-merge.md (Step 4)
+# See: https://github.com/rjwalters/kicad-tools/issues/2849
+#
+# NOTE: Label cleanup on linked issues is also intentionally skipped here.
 # Labels on closed/merged items are harmless — all agents filter by open state.
 # See: https://github.com/rjwalters/loom/issues/2838
 

--- a/.loom/scripts/tests/test-forge-helpers.sh
+++ b/.loom/scripts/tests/test-forge-helpers.sh
@@ -115,6 +115,123 @@ else
     echo -e "  ${RED}FAIL${NC}: forge_get_repo_nwo returned empty"
 fi
 
+# --- Test forge_pr_close_targets ---
+# Tests the canonical "what issues does this PR close?" helper, which is the
+# single source of truth used by the Champion role's verify-issue-closure
+# step. See issue #2849.
+#
+# We test by stubbing `gh` (GitHub path) and `forge_get_pr_body` (Gitea path).
+# The stub strategy mirrors how forge_pr_close_targets calls into them.
+echo ""
+echo "Testing forge_pr_close_targets..."
+
+# Helper to define a one-shot stub `gh` that emits canned JSON for the
+# `closingIssuesReferences` query and a different payload for everything else.
+_stub_gh_closing_refs() {
+    # $1 = JSON string for .closingIssuesReferences (e.g. '[{"number":100}]')
+    local refs_json="$1"
+    eval "gh() {
+        if [[ \"\$*\" == *closingIssuesReferences* ]]; then
+            if [[ \"\$*\" == *--jq* ]]; then
+                # Emulate \`gh ... --jq '.closingIssuesReferences[].number'\`
+                echo '$refs_json' | jq -r '.[].number'
+            else
+                echo '{\"closingIssuesReferences\": $refs_json}'
+            fi
+        fi
+    }"
+    export -f gh 2>/dev/null || true
+}
+
+_unstub_gh() {
+    unset -f gh 2>/dev/null || true
+}
+
+FORGE_TYPE="github"
+
+# Case 1: PR with Closes #100 -> closingIssuesReferences: [{number:100}]
+_stub_gh_closing_refs '[{"number":100}]'
+result=$(forge_pr_close_targets 1234 gh)
+assert_eq "100" "$result" "Closes #100 -> 100"
+_unstub_gh
+
+# Case 2: PR with Updates #100 only -> closingIssuesReferences: []
+_stub_gh_closing_refs '[]'
+result=$(forge_pr_close_targets 1234 gh)
+assert_eq "" "$result" "Updates #100 (no Closes) -> empty (the #2849 bug case)"
+_unstub_gh
+
+# Case 3: PR with Closes #100 + Updates #200 -> only 100 closes
+_stub_gh_closing_refs '[{"number":100}]'
+result=$(forge_pr_close_targets 1234 gh)
+assert_eq "100" "$result" "Closes #100 + Updates #200 -> 100 only"
+_unstub_gh
+
+# Case 4: PR mentioning "Closure of #100" but no actual close keyword -> empty
+_stub_gh_closing_refs '[]'
+result=$(forge_pr_close_targets 1234 gh)
+assert_eq "" "$result" "Closure of #100 (substring) -> empty"
+_unstub_gh
+
+# Case 5: Multiple closing references
+_stub_gh_closing_refs '[{"number":100},{"number":200},{"number":300}]'
+result=$(forge_pr_close_targets 1234 gh | tr '\n' ' ' | sed 's/ $//')
+assert_eq "100 200 300" "$result" "Multiple closes -> all numbers"
+_unstub_gh
+
+# Case 6: Empty body / no references
+_stub_gh_closing_refs '[]'
+result=$(forge_pr_close_targets 1234 gh)
+assert_eq "" "$result" "Empty body -> empty"
+_unstub_gh
+
+# --- Test Gitea body-regex path for forge_pr_close_targets ---
+echo ""
+echo "Testing forge_pr_close_targets (Gitea body-regex path)..."
+
+# Stub forge_get_pr_body and forge_get_repo_nwo for the Gitea path
+_stub_pr_body() {
+    local body="$1"
+    eval "forge_get_pr_body() { printf '%s' \"\$(cat <<'BODY_EOF'
+$body
+BODY_EOF
+)\"; }"
+    eval "forge_get_repo_nwo() { echo 'owner/repo'; }"
+}
+
+_unstub_pr_body() {
+    # Re-source to restore originals
+    source "$HELPERS_DIR/lib/forge-helpers.sh"
+}
+
+FORGE_TYPE="gitea"
+
+_stub_pr_body "Closes #100"
+result=$(forge_pr_close_targets 1234)
+assert_eq "100" "$result" "Gitea: Closes #100 -> 100"
+_unstub_pr_body
+
+FORGE_TYPE="gitea"
+_stub_pr_body "Updates #100 only, no closure keyword."
+result=$(forge_pr_close_targets 1234)
+assert_eq "" "$result" "Gitea: Updates #100 only -> empty"
+_unstub_pr_body
+
+FORGE_TYPE="gitea"
+_stub_pr_body "Closure of this criterion is gated on #200."
+result=$(forge_pr_close_targets 1234)
+assert_eq "" "$result" "Gitea: 'Closure of' substring -> empty (word boundary)"
+_unstub_pr_body
+
+FORGE_TYPE="gitea"
+_stub_pr_body "closes #42 and Fixes #43 and resolves #44"
+result=$(forge_pr_close_targets 1234 | tr '\n' ' ' | sed 's/ $//')
+assert_eq "42 43 44" "$result" "Gitea: mixed-case canonical keywords -> all"
+_unstub_pr_body
+
+# Restore FORGE_TYPE
+FORGE_TYPE="github"
+
 # --- Summary ---
 echo ""
 echo "────────────────────────────────"


### PR DESCRIPTION
## Summary

- Replace the brittle `grep -Eo "(Closes|Fixes|Resolves) #[0-9]+"` body regex in the Champion role's verify-issue-closure step with GitHub's canonical `closingIssuesReferences` field. GitHub computes this from the PR body with proper word boundaries and case-insensitivity, correctly excluding `Updates/See/References/Closure of`.
- Apply the fix to all three occurrences across the Champion role docs (`champion-pr-merge.md` Step 4, `champion-reference.md` Edge Case 8 + STEP 4 in the runbook, plus the debugging-commands snippet).
- Extract the new logic into `forge_pr_close_targets` in `.loom/scripts/lib/forge-helpers.sh` so future agents have a single source of truth. Gitea path uses a strict word-boundary regex (Gitea has no API analog).
- Add unit tests in `.loom/scripts/tests/test-forge-helpers.sh` covering the #2849 bug case (`Updates #N` -> empty), mixed-case canonical keywords, `Closure of` substring, and multiple-closes cases (10 new tests; 23/23 pass).
- Add clarifying comment in `merge-pr.sh:237-241` noting the script itself never closes issues and pointing at the Champion runbook (prevents future bug reports from re-targeting the wrong file).

## Repro verification

Against the original incident PR #2846 (body used `Updates #2834`):

```
$ gh pr view 2846 --json closingIssuesReferences --jq '.closingIssuesReferences'
[]
```

So under the new logic `LINKED_ISSUES` is empty and Step 4 exits at the `[ -z "$LINKED_ISSUES" ]` branch without ever calling `gh issue close 2834`. Verified locally:

```
$ FORGE_TYPE=github forge_pr_close_targets 2846 gh      # bug case
(empty)
$ FORGE_TYPE=github forge_pr_close_targets 2830 gh      # normal Closes #2827
2827
```

## Acceptance criteria (from issue)

- [x] `champion-pr-merge.md:359` no longer uses `grep -Eo`; uses `gh pr view --json closingIssuesReferences`.
- [x] `champion-reference.md:141-146` and `:504-518` updated identically.
- [x] A PR whose body says `Updates #N` does NOT trigger `gh issue close N`.
- [x] A PR whose body says `Closes #N` still triggers closure verification.
- [x] `merge-pr.sh:237-241` comment clarifies the script never closes issues.
- [x] Test harness added (10 new test cases, all pass).

## Test plan

- [x] `bash .loom/scripts/tests/test-forge-helpers.sh` -> 23/23 pass
- [x] `bash -n` syntax-check on all modified shell scripts
- [x] Live verification against PR #2846 (bug repro) -> empty
- [x] Live verification against PR #2830 (canonical `Closes #2827`) -> 2827

Closes #2849