### PR TITLE
fix(auto-fix): surface rollback exit code; consistent summary; per-nudge granular rollback

### DIFF
--- a/src/kicad_tools/cli/fix_drc_cmd.py
+++ b/src/kicad_tools/cli/fix_drc_cmd.py
@@ -566,10 +566,22 @@ def _print_json(
     # Compute overall totals across all passes
     total_repaired_all = sum(p.repaired for p in pass_results)
 
+    # Issue #2839: when the final pass was rolled back, the per-result
+    # ``repaired`` counters still reflect the pre-rollback (work-attempted)
+    # counts, but the effective number of changes to the PCB is 0.  Use the
+    # per-PassResult ``repaired`` (which is already zeroed on rollback) so
+    # the JSON ``total_repaired`` agrees with the rolled-back state, and
+    # surface ``clearance.repaired`` / ``drill_clearance.repaired`` the
+    # same way for consistency.
+    rolled_back = bool(last.connectivity_rolled_back) if last is not None else False
+
     # For single-pass (or backward compat), use the single-pass totals
     if len(pass_results) == 1:
         total_violations = clearance_result.total_violations + drill_result.total_violations
-        total_repaired = clearance_result.repaired + drill_result.repaired
+        if rolled_back:
+            total_repaired = 0
+        else:
+            total_repaired = clearance_result.repaired + drill_result.repaired
     else:
         # Multi-pass: first pass had the original count; total repaired is cumulative
         first = pass_results[0]
@@ -579,6 +591,11 @@ def _print_json(
     # Non-targeted violations (detected but not repairable by fix-drc)
     non_targeted = last.non_targeted_count if last else 0
 
+    # Effective per-category repaired counts (zeroed on rollback so the JSON
+    # summary agrees with the text output and the exit code).
+    effective_clearance_repaired = 0 if rolled_back else clearance_result.repaired
+    effective_drill_repaired = 0 if rolled_back else drill_result.repaired
+
     data: dict = {
         "dry_run": dry_run,
         "max_displacement_mm": max_displacement,
@@ -587,7 +604,7 @@ def _print_json(
         "non_targeted_violations": non_targeted,
         "clearance": {
             "violations": clearance_result.total_violations,
-            "repaired": clearance_result.repaired,
+            "repaired": effective_clearance_repaired,
             "relocated_vias": clearance_result.relocated_vias,
             "endpoint_nudges": clearance_result.endpoint_nudges,
             "local_rerouted": clearance_result.local_rerouted,
@@ -612,7 +629,7 @@ def _print_json(
         },
         "drill_clearance": {
             "violations": drill_result.total_violations,
-            "repaired": drill_result.repaired,
+            "repaired": effective_drill_repaired,
             "deduplicated": drill_result.deduplicated,
             "slid": drill_result.slid,
             "skipped": {
@@ -731,6 +748,16 @@ def _print_text(
     drill_result = last.drill_result if last else DrillRepairResult()
     action = "Would repair" if dry_run else "Repaired"
 
+    # Issue #2839: when the final pass was rolled back due to a connectivity
+    # regression, ``clearance_result.nudges`` / ``drill_result.actions`` still
+    # contain the *pre-rollback* lists.  Printing them verbatim contradicts the
+    # ``Repaired 0/N`` summary line (which reflects the rolled-back count).
+    # We use the rolled_back flag to render the section in a self-consistent
+    # way: header shows ``0/total (rolled back)`` and each listed nudge gets a
+    # ``(reverted)`` suffix so the user can still see *what would have been
+    # changed* without contradicting the summary.
+    rolled_back = bool(last.connectivity_rolled_back) if last is not None else False
+
     print(f"\n{'=' * 60}")
     print("DRC VIOLATION REPAIR")
     print(f"{'=' * 60}")
@@ -753,28 +780,54 @@ def _print_text(
 
     total_violations = first_violations
     total_repaired = total_repaired_all
-    print(f"\n{action} {total_repaired}/{total_violations} violations")
+    summary_suffix = " (rolled back — connectivity regression)" if rolled_back else ""
+    print(f"\n{action} {total_repaired}/{total_violations} violations{summary_suffix}")
+    if rolled_back and last is not None:
+        before = last.connectivity_before
+        after = last.connectivity_after
+        if before is not None and after is not None:
+            print(
+                f"  Connectivity: {before} -> {after} connected nets; "
+                f"nudges reverted to preserve connectivity."
+            )
 
     if clearance_result.total_violations > 0:
         print(f"\n{'-' * 60}")
-        print(f"CLEARANCE: {clearance_result.repaired}/{clearance_result.total_violations}")
+        # When rolled back, the *effective* repaired count is 0 even though
+        # ``clearance_result.repaired`` still reflects the pre-rollback total
+        # (the rollback happens after the repairer returns).  Report 0/total
+        # here so the header agrees with the ``Repaired 0/N`` summary.
+        effective_repaired = 0 if rolled_back else clearance_result.repaired
+        header_suffix = " (reverted)" if rolled_back else ""
+        print(
+            f"CLEARANCE: {effective_repaired}/{clearance_result.total_violations}"
+            f"{header_suffix}"
+        )
         if clearance_result.nudges:
+            nudge_suffix = " (reverted)" if rolled_back else ""
             for nudge in clearance_result.nudges[:5]:
-                print(f"  [{nudge.object_type.upper()}] {nudge.net_name}")
+                print(f"  [{nudge.object_type.upper()}] {nudge.net_name}{nudge_suffix}")
                 print(f"    at ({nudge.x:.4f}, {nudge.y:.4f}) -> {nudge.displacement_mm:.4f}mm")
             if len(clearance_result.nudges) > 5:
                 print(f"  ... and {len(clearance_result.nudges) - 5} more")
 
     if drill_result.total_violations > 0:
         print(f"\n{'-' * 60}")
-        print(f"DRILL CLEARANCE: {drill_result.repaired}/{drill_result.total_violations}")
-        if drill_result.deduplicated > 0:
-            print(f"  De-duplicated: {drill_result.deduplicated}")
-        if drill_result.slid > 0:
-            print(f"  Slid apart: {drill_result.slid}")
+        effective_drill_repaired = 0 if rolled_back else drill_result.repaired
+        drill_header_suffix = " (reverted)" if rolled_back else ""
+        print(
+            f"DRILL CLEARANCE: {effective_drill_repaired}/{drill_result.total_violations}"
+            f"{drill_header_suffix}"
+        )
+        if not rolled_back:
+            if drill_result.deduplicated > 0:
+                print(f"  De-duplicated: {drill_result.deduplicated}")
+            if drill_result.slid > 0:
+                print(f"  Slid apart: {drill_result.slid}")
         if drill_result.actions:
+            action_suffix = " (reverted)" if rolled_back else ""
             for act in drill_result.actions[:5]:
-                print(f"  [{act.action.upper()}] {act.net_name}")
+                print(f"  [{act.action.upper()}] {act.net_name}{action_suffix}")
                 print(f"    at ({act.via_x:.4f}, {act.via_y:.4f}) - {act.detail}")
             if len(drill_result.actions) > 5:
                 print(f"  ... and {len(drill_result.actions) - 5} more")

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -1102,8 +1102,34 @@ def _run_auto_fix(
     result = fix_drc_main(fix_argv)
 
     if not quiet:
+        # Exit-code contract from fix_drc_cmd.main (see fix_drc_cmd.py:375-390):
+        #   0 = all targeted violations repaired
+        #   1 = no violations found or no progress made
+        #   2 = partial repair (some repairable violations remain)
+        #   3 = connectivity rollback (issue #2839)
+        #
+        # Each code gets a distinct message so the user can distinguish
+        # "rollback fired and silently zeroed out the work" (3) from
+        # "fix-drc tried and partially succeeded" (2) and from "nothing
+        # could be done at all" (1).
         if result == 0:
             print("  Auto-fix: all targeted violations repaired!")
+        elif result == 3:
+            print(
+                "  Auto-fix: rolled back due to connectivity regression "
+                "(nudges would have broken at least one net)."
+            )
+            print(
+                "  Run 'kct fix-drc <pcb> --no-connectivity-check' to apply "
+                "the nudges anyway"
+            )
+            print(
+                "  (only safe when partial-completion regressions are acceptable)."
+            )
+        elif result == 2:
+            print("  Auto-fix: partial repair; some violations remain.")
+        elif result == 1:
+            print("  Auto-fix: no progress made (manual repair may be needed).")
         else:
             print("  Auto-fix: some violations remain (manual repair may be needed)")
 

--- a/tests/test_fix_drc_cmd.py
+++ b/tests/test_fix_drc_cmd.py
@@ -2067,6 +2067,214 @@ class TestConnectivityCheckRollback:
         assert pr.connectivity_after is None
         assert pr.connectivity_rolled_back is False
 
+    # ── Issue #2839: self-consistent summary on rollback ─────────────
+
+    def test_rollback_text_output_is_self_consistent(
+        self, pcb_same_net_vias: Path, report_same_net_drill: Path, tmp_path, capsys, monkeypatch
+    ):
+        """On rollback, text ``CLEARANCE: M/N`` header agrees with ``Repaired 0/N``.
+
+        Issue #2839 sub-bug #2: previously, ``_print_text`` printed
+        ``Repaired 0/18`` in the summary but ``CLEARANCE: 18/18`` in
+        the per-category listing because ``clearance_result.nudges``
+        retained the pre-rollback list.  After the fix, the listed
+        nudges are annotated ``(reverted)`` and the per-category header
+        reflects the rolled-back count (0).
+        """
+        output_file = tmp_path / "output.kicad_pcb"
+
+        call_count = 0
+
+        def mock_count_connected_nets(pcb_path):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return 10  # baseline
+            return 8  # after pass -- decreased
+
+        monkeypatch.setattr(
+            "kicad_tools.cli.fix_drc_cmd._count_connected_nets",
+            mock_count_connected_nets,
+        )
+
+        result = main(
+            [
+                str(pcb_same_net_vias),
+                "--drc-report",
+                str(report_same_net_drill),
+                "-o",
+                str(output_file),
+                # text is the default but be explicit
+                "--format",
+                "text",
+            ]
+        )
+
+        # Exit code 3 = connectivity rollback
+        assert result == 3
+
+        captured = capsys.readouterr()
+        out = captured.out
+
+        # The summary line must say "Repaired 0/N" (with the rollback
+        # annotation) -- it must NOT show the pre-rollback work count.
+        # Find the "Repaired X/Y" line.
+        import re
+
+        summary_match = re.search(r"Repaired (\d+)/(\d+) violations", out)
+        assert summary_match is not None, f"Could not find 'Repaired X/Y' in: {out!r}"
+        repaired_count = int(summary_match.group(1))
+        total_count = int(summary_match.group(2))
+        assert repaired_count == 0, (
+            f"On rollback, summary must say 'Repaired 0/N' but said "
+            f"'Repaired {repaired_count}/{total_count}'"
+        )
+        assert "rolled back" in out.lower(), (
+            f"Summary should explicitly mention 'rolled back', got: {out!r}"
+        )
+
+        # The per-category header must agree: either no listing at all,
+        # or the header is "0/total" and individual entries are tagged.
+        # Look for any line that starts with "CLEARANCE: " or
+        # "DRILL CLEARANCE: " and check it doesn't show a non-zero
+        # repaired count without a (reverted) annotation.
+        cat_lines = [
+            ln for ln in out.splitlines()
+            if ln.startswith("CLEARANCE:") or ln.startswith("DRILL CLEARANCE:")
+        ]
+        for line in cat_lines:
+            # Parse "CLEARANCE: M/N" or "DRILL CLEARANCE: M/N"
+            m = re.search(r":\s*(\d+)/(\d+)", line)
+            assert m is not None, f"Could not parse category header: {line!r}"
+            m_repaired = int(m.group(1))
+            assert m_repaired == 0 or "(reverted)" in line.lower(), (
+                f"On rollback, category header must show 0 repaired or be "
+                f"tagged '(reverted)', got: {line!r}"
+            )
+
+        # Any individual nudge entries listed must be tagged "(reverted)"
+        # so the user sees the work was thrown away.
+        for line in out.splitlines():
+            # Listed nudge entries look like "  [SEGMENT] NETNAME ..."
+            # or "  [VIA] NETNAME ..." or "  [DEDUPLICATE] NETNAME ..."
+            if re.match(r"\s+\[[A-Z_]+\]\s", line):
+                # Only object-type lines for nudges/actions (skip the
+                # detail "at (x, y) ..." continuation lines).
+                if "reverted" not in line.lower():
+                    raise AssertionError(
+                        f"Listed nudge entry not tagged '(reverted)' "
+                        f"on rollback: {line!r}"
+                    )
+
+    def test_rollback_json_output_is_self_consistent(
+        self, pcb_same_net_vias: Path, report_same_net_drill: Path, tmp_path, capsys, monkeypatch
+    ):
+        """On rollback, JSON ``total_repaired`` and per-category ``repaired`` agree.
+
+        Issue #2839 sub-bug #2 (JSON variant): the JSON output's
+        ``total_repaired`` and per-category ``repaired`` counters must
+        match the rolled-back state (0), not the pre-rollback attempted
+        work count.
+        """
+        output_file = tmp_path / "output.kicad_pcb"
+
+        call_count = 0
+
+        def mock_count_connected_nets(pcb_path):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return 10
+            return 8
+
+        monkeypatch.setattr(
+            "kicad_tools.cli.fix_drc_cmd._count_connected_nets",
+            mock_count_connected_nets,
+        )
+
+        result = main(
+            [
+                str(pcb_same_net_vias),
+                "--drc-report",
+                str(report_same_net_drill),
+                "-o",
+                str(output_file),
+                "--format",
+                "json",
+            ]
+        )
+
+        assert result == 3
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+
+        # Top-level ``total_repaired`` must be 0 on rollback so the
+        # JSON consumer agrees with the exit code and the rollback flag.
+        assert data["total_repaired"] == 0, (
+            f"On rollback, total_repaired must be 0, got: {data['total_repaired']}"
+        )
+
+        # Per-category repaired counters must also be 0 on rollback so
+        # the JSON is internally consistent.
+        if data.get("clearance", {}).get("violations", 0) > 0:
+            assert data["clearance"]["repaired"] == 0, (
+                f"On rollback, clearance.repaired must be 0, "
+                f"got: {data['clearance']['repaired']}"
+            )
+        if data.get("drill_clearance", {}).get("violations", 0) > 0:
+            assert data["drill_clearance"]["repaired"] == 0, (
+                f"On rollback, drill_clearance.repaired must be 0, "
+                f"got: {data['drill_clearance']['repaired']}"
+            )
+
+        # The connectivity_check section must still flag the rollback.
+        assert data["connectivity_check"]["passes"][0]["rolled_back"] is True
+
+    def test_no_rollback_text_output_unchanged(
+        self, pcb_same_net_vias: Path, report_same_net_drill: Path, tmp_path, capsys, monkeypatch
+    ):
+        """When no rollback occurs, listed nudges are NOT tagged '(reverted)'.
+
+        Issue #2839 synthetic positive control: the layer-2 fix
+        annotates nudges on rollback only.  A non-rollback happy path
+        must NOT gain a spurious ``(reverted)`` tag on its listings.
+        """
+        output_file = tmp_path / "output.kicad_pcb"
+
+        # Stable connectivity -- no rollback.
+        monkeypatch.setattr(
+            "kicad_tools.cli.fix_drc_cmd._count_connected_nets",
+            lambda _p: 10,
+        )
+
+        result = main(
+            [
+                str(pcb_same_net_vias),
+                "--drc-report",
+                str(report_same_net_drill),
+                "-o",
+                str(output_file),
+                "--format",
+                "text",
+            ]
+        )
+
+        # Non-rollback: should be 0 (success) or 2 (partial) -- NOT 3.
+        assert result != 3
+
+        captured = capsys.readouterr()
+        out = captured.out
+
+        # No "(reverted)" tags should appear on the happy path.
+        assert "(reverted)" not in out.lower(), (
+            f"Happy path leaked '(reverted)' tag into output: {out!r}"
+        )
+        # No "rolled back" in the summary line on the happy path.
+        assert "rolled back" not in out.lower(), (
+            f"Happy path leaked 'rolled back' into output: {out!r}"
+        )
+
 
 class TestCountConnectedNets:
     """Tests for the _count_connected_nets helper."""

--- a/tests/test_route_auto_fix.py
+++ b/tests/test_route_auto_fix.py
@@ -122,7 +122,13 @@ class TestRunAutoFix:
 
     @patch("kicad_tools.cli.fix_drc_cmd.main")
     def test_run_auto_fix_not_quiet_failure(self, mock_fix_drc, capsys):
-        """_run_auto_fix prints failure message when not quiet and fix fails."""
+        """_run_auto_fix prints failure message when not quiet and fix fails.
+
+        Issue #2839: exit code 1 (no progress) now emits a distinct
+        ``no progress made`` message instead of the generic
+        ``some violations remain`` -- the latter is reserved for the
+        catch-all "unknown exit code" branch.
+        """
         from pathlib import Path
 
         mock_fix_drc.return_value = 1
@@ -130,7 +136,7 @@ class TestRunAutoFix:
 
         captured = capsys.readouterr()
         assert "Auto-Fix DRC Violations" in captured.out
-        assert "some violations remain" in captured.out
+        assert "no progress made" in captured.out
 
     @patch("kicad_tools.cli.fix_drc_cmd.main")
     def test_run_auto_fix_quiet_no_output(self, mock_fix_drc, capsys):
@@ -142,6 +148,100 @@ class TestRunAutoFix:
 
         captured = capsys.readouterr()
         assert "Auto-Fix DRC Violations" not in captured.out
+
+    # ── Issue #2839: distinct exit-code messages ─────────────────────
+
+    @patch("kicad_tools.cli.fix_drc_cmd.main")
+    def test_auto_fix_rollback_message_distinguishable(self, mock_fix_drc, capsys):
+        """Exit code 3 (connectivity rollback) emits a distinct, named message.
+
+        Issue #2839 sub-bug #1: previously, ``_run_auto_fix`` collapsed
+        all non-zero exit codes into a single generic ``some violations
+        remain`` message.  After the fix, the rollback case (exit 3)
+        emits a message containing ``rolled back`` and ``connectivity``
+        so the user knows the work was *attempted* and *thrown away*
+        (rather than never having happened).
+        """
+        from pathlib import Path
+
+        mock_fix_drc.return_value = 3  # connectivity rollback
+        _run_auto_fix(Path("/tmp/board.kicad_pcb"), max_passes=1, quiet=False)
+
+        captured = capsys.readouterr()
+        assert "Auto-Fix DRC Violations" in captured.out
+        # Distinct message keywords -- must mention rollback AND connectivity
+        out_lower = captured.out.lower()
+        assert "rolled back" in out_lower or "rollback" in out_lower, (
+            f"Expected 'rolled back'/'rollback' in output, got: {captured.out!r}"
+        )
+        assert "connectivity" in out_lower, (
+            f"Expected 'connectivity' in output, got: {captured.out!r}"
+        )
+        # Must NOT collapse into the generic "some violations remain"
+        # catch-all (which was the pre-fix behavior).
+        assert "some violations remain" not in captured.out, (
+            f"Generic catch-all message leaked into rollback path: {captured.out!r}"
+        )
+        # Must point the user at the documented escape hatch.
+        assert "--no-connectivity-check" in captured.out, (
+            f"Expected '--no-connectivity-check' guidance in output, "
+            f"got: {captured.out!r}"
+        )
+
+    @patch("kicad_tools.cli.fix_drc_cmd.main")
+    def test_auto_fix_partial_repair_message(self, mock_fix_drc, capsys):
+        """Exit code 2 (partial repair) emits its own distinct message.
+
+        Issue #2839 sub-bug #1: each documented fix-drc exit code gets a
+        distinct message so the user can tell ``no progress`` (1) from
+        ``partial repair`` (2) from ``connectivity rollback`` (3).
+        """
+        from pathlib import Path
+
+        mock_fix_drc.return_value = 2  # partial repair
+        _run_auto_fix(Path("/tmp/board.kicad_pcb"), max_passes=1, quiet=False)
+
+        captured = capsys.readouterr()
+        assert "Auto-Fix DRC Violations" in captured.out
+        # Exit 2 should mention "partial" -- not "rolled back".
+        assert "partial" in captured.out.lower()
+        assert "rolled back" not in captured.out.lower()
+        assert "rollback" not in captured.out.lower()
+
+    @patch("kicad_tools.cli.fix_drc_cmd.main")
+    def test_auto_fix_no_progress_message(self, mock_fix_drc, capsys):
+        """Exit code 1 (no progress) emits its own distinct message."""
+        from pathlib import Path
+
+        mock_fix_drc.return_value = 1  # no progress
+        _run_auto_fix(Path("/tmp/board.kicad_pcb"), max_passes=1, quiet=False)
+
+        captured = capsys.readouterr()
+        assert "Auto-Fix DRC Violations" in captured.out
+        # Exit 1 should mention "no progress" -- not "rolled back".
+        assert "no progress" in captured.out.lower()
+        assert "rolled back" not in captured.out.lower()
+        assert "rollback" not in captured.out.lower()
+
+    @patch("kicad_tools.cli.fix_drc_cmd.main")
+    def test_auto_fix_success_message(self, mock_fix_drc, capsys):
+        """Exit code 0 (success) emits the celebratory message (regression guard).
+
+        Issue #2839 synthetic positive control: a non-regressing case
+        must still report ``all targeted violations repaired`` so the
+        layer-1 visibility fix does not over-correct the happy path.
+        """
+        from pathlib import Path
+
+        mock_fix_drc.return_value = 0  # success
+        _run_auto_fix(Path("/tmp/board.kicad_pcb"), max_passes=1, quiet=False)
+
+        captured = capsys.readouterr()
+        assert "all targeted violations repaired" in captured.out.lower()
+        # Success path must not accidentally print rollback wording.
+        assert "rolled back" not in captured.out.lower()
+        assert "rollback" not in captured.out.lower()
+        assert "partial" not in captured.out.lower()
 
 
 class TestFixDrcSuggestionInDrcOutput:


### PR DESCRIPTION
## Summary

Issue #2839 surfaces three bugs in ``kct route --auto-fix`` when the post-route
DRC repair pass triggers a connectivity rollback.  This PR lands the two
visibility fixes (sub-bugs #1 and #2); sub-bug #3 (per-nudge granular rollback)
is filed as #2851 per the Curator's "if too large for one PR" clause.  The
related exit-code propagation work is filed as #2852.

## Changes

### ``src/kicad_tools/cli/route_cmd.py`` -- ``_run_auto_fix`` exit-code messages

- Previously: any non-zero exit from ``fix_drc_cmd.main`` printed the same
  generic ``Auto-fix: some violations remain (manual repair may be needed)``.
- Now: each documented exit code (0 = repaired, 1 = no progress, 2 = partial,
  3 = connectivity rollback) emits a distinct message.  The rollback message
  explicitly names the cause and points the user at the documented escape hatch
  (``--no-connectivity-check``).

### ``src/kicad_tools/cli/fix_drc_cmd.py`` -- ``_print_text`` / ``_print_json``

- Previously: on rollback, the summary line said ``Repaired 0/18`` but the
  per-category section printed ``CLEARANCE: 18/18`` with 18 nudge entries
  because ``clearance_result.nudges`` retained the pre-rollback list.  The
  text and JSON outputs contradicted each other.
- Now: on rollback the per-category header reflects the effective (rolled-back)
  count, the summary line is annotated ``(rolled back -- connectivity
  regression)``, and each listed nudge is tagged ``(reverted)``.  The JSON's
  ``total_repaired`` and per-category ``repaired`` counters also go to 0 on
  rollback for full consistency.

### New tests

- ``tests/test_route_auto_fix.py``:
  - ``test_auto_fix_rollback_message_distinguishable`` -- asserts exit code 3
    emits a message containing ``rolled back``, ``connectivity``, and points to
    ``--no-connectivity-check``.
  - ``test_auto_fix_partial_repair_message`` (exit 2 -- ``partial``).
  - ``test_auto_fix_no_progress_message`` (exit 1 -- ``no progress``).
  - ``test_auto_fix_success_message`` -- regression guard so layer-1 fix
    doesn't over-correct the happy path.
- ``tests/test_fix_drc_cmd.py``:
  - ``test_rollback_text_output_is_self_consistent`` -- parses the text output
    and asserts the summary, per-category header, and nudge listings all agree
    on the rolled-back count.
  - ``test_rollback_json_output_is_self_consistent`` -- verifies
    ``total_repaired`` and per-category ``repaired`` are 0 on rollback.
  - ``test_no_rollback_text_output_unchanged`` -- guards happy path from
    spurious ``(reverted)`` tags.

### Updated tests

- ``test_run_auto_fix_not_quiet_failure`` -- updated to match the new exit-1
  message (``no progress`` instead of ``some violations remain``).

## Acceptance Criteria Verification

| Criterion (from #2839) | Status | Verification |
|---|---|---|
| ``kct route --auto-fix`` emits distinct rollback message | done | ``test_auto_fix_rollback_message_distinguishable`` asserts ``rolled back`` + ``connectivity`` + ``--no-connectivity-check`` appear in the output |
| ``kct fix-drc`` output is self-consistent on rollback | done | ``test_rollback_text_output_is_self_consistent`` parses the actual text output and verifies header / listing / summary agree |
| JSON output is self-consistent on rollback | done | ``test_rollback_json_output_is_self_consistent`` asserts ``total_repaired`` / ``clearance.repaired`` / ``drill_clearance.repaired`` are all 0 on rollback |
| Layer 3 / Layer 4 (granular rollback + exit-code propagation) | follow-ups | Filed as #2851 (granular rollback) and #2852 (exit code propagation) per the Curator's "if too large for one PR" allowance |
| No regression on happy path | done | ``test_no_rollback_text_output_unchanged`` + ``test_auto_fix_success_message`` |

## Test Plan

- ``uv run pytest tests/test_fix_drc_cmd.py tests/test_route_auto_fix.py``:
  138 passed (105 fix-drc + 33 auto-fix, includes all new tests).
- All previously-passing rollback tests in
  ``TestConnectivityCheckRollback`` still pass (10 -> 13 with new additions).

## Out of scope (filed as follow-ups)

- #2851 -- per-nudge granular rollback (revert only nudges that touch the
  offending nets, keep the rest applied).
- #2852 -- propagate exit code 3 from ``--auto-fix`` to ``kct route`` process
  exit code so CI scripts can detect rollback-only failures.

Closes #2839