### PR TITLE
feat(stitch): add --mfr flag with stackup-aware via dimension resolution

### DIFF
--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -503,6 +503,10 @@ def _run_stitch_command(args) -> int:
         sub_argv.extend(["-o", args.stitch_output])
     if hasattr(args, "stitch_drc") and args.stitch_drc:
         sub_argv.append("--drc")
+    if hasattr(args, "stitch_mfr") and args.stitch_mfr is not None:
+        sub_argv.extend(["--mfr", str(args.stitch_mfr)])
+    if hasattr(args, "stitch_copper") and args.stitch_copper != 1.0:
+        sub_argv.extend(["--copper", str(args.stitch_copper)])
 
     return stitch_cmd(sub_argv)
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2102,6 +2102,29 @@ def _add_stitch_parser(subparsers) -> None:
         dest="stitch_drc",
         help="Run DRC after stitching (fills zones automatically via kicad-cli)",
     )
+    stitch_parser.add_argument(
+        "--mfr",
+        "--manufacturer",
+        dest="stitch_mfr",
+        default=None,
+        help=(
+            "Manufacturer profile (e.g., 'jlcpcb', 'jlcpcb-tier1'). When set, "
+            "stitch via dimensions are resolved from the manufacturer's YAML "
+            "design rules using the board's actual copper layer count, "
+            "overriding --via-size and --drill defaults. When omitted, the "
+            "existing CLI defaults are used."
+        ),
+    )
+    stitch_parser.add_argument(
+        "--copper",
+        type=float,
+        default=1.0,
+        dest="stitch_copper",
+        help=(
+            "Outer copper weight in oz (default: 1.0). Used together with --mfr "
+            "to select the correct design-rules row from the manufacturer YAML."
+        ),
+    )
 
 
 def _add_route_parser(subparsers) -> None:

--- a/src/kicad_tools/cli/stitch_cmd.py
+++ b/src/kicad_tools/cli/stitch_cmd.py
@@ -34,6 +34,105 @@ from kicad_tools.sexp import SExp
 from kicad_tools.sexp.builders import segment_node, via_node
 
 
+def _count_copper_layers(pcb_path: Path) -> int:
+    """Count the number of copper layers in the PCB.
+
+    Inspects the ``(layers ...)`` block of the .kicad_pcb file via the
+    PCB schema parser and returns the count of layers whose type is
+    ``signal`` or ``power``.  Falls back to ``2`` if the PCB cannot be
+    parsed (e.g., missing/malformed file); the caller is expected to
+    surface any read errors separately.
+
+    Args:
+        pcb_path: Path to the .kicad_pcb file.
+
+    Returns:
+        Number of copper layers; defaults to ``2`` on parse failure.
+    """
+    try:
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.load(pcb_path)
+        detected = len(pcb.copper_layers)
+        return detected if detected > 0 else 2
+    except Exception:
+        return 2
+
+
+def _resolve_mfr_via_dimensions(
+    mfr: str, layers: int, copper: float = 1.0
+) -> tuple[float, float]:
+    """Resolve via diameter and drill from a manufacturer YAML profile.
+
+    Looks up the manufacturer's design rules for the actual stackup
+    (``{layers}layer_{copper}oz``) and returns the minimum via diameter
+    and drill required to satisfy both the published via geometry minima
+    AND the minimum annular ring constraint
+    (``effective_diameter = max(min_via_diameter, drill + 2 * min_annular_ring)``).
+
+    This mirrors the resolution logic in
+    :func:`kicad_tools.cli.fix_vias_cmd.get_design_rules` so that
+    ``kct stitch --mfr X`` and ``kct fix-vias --mfr X`` produce vias
+    that satisfy the same DRC profile.
+
+    Args:
+        mfr: Manufacturer identifier (e.g., ``"jlcpcb-tier1"``).
+        layers: Actual copper layer count of the target PCB.
+        copper: Outer copper weight in oz (default: 1.0).
+
+    Returns:
+        Tuple of ``(via_diameter_mm, drill_mm)``.
+
+    Raises:
+        FileNotFoundError: If no YAML profile exists for ``mfr``.
+    """
+    from kicad_tools.manufacturers.base import load_design_rules_from_yaml
+
+    # Try the user-supplied id first, then fall back to underscored
+    # variants for manufacturer registries whose YAML filenames use ``_``
+    # while the canonical alias uses ``-`` (e.g. ``jlcpcb-tier1`` vs
+    # ``jlcpcb_tier1.yaml``).
+    candidates = [mfr]
+    if "-" in mfr:
+        candidates.append(mfr.replace("-", "_"))
+    if "_" in mfr:
+        candidates.append(mfr.replace("_", "-"))
+
+    rules_dict = None
+    last_error: FileNotFoundError | None = None
+    for candidate in candidates:
+        try:
+            rules_dict = load_design_rules_from_yaml(candidate)
+            break
+        except FileNotFoundError as e:
+            last_error = e
+            continue
+    if rules_dict is None:
+        # Re-raise the last error so callers get a meaningful message.
+        assert last_error is not None
+        raise last_error
+
+    key = f"{layers}layer_{int(copper)}oz"
+    if key in rules_dict:
+        rules = rules_dict[key]
+    else:
+        # Fall back to the 1oz variant for this layer count.
+        fallback_key = f"{layers}layer_1oz"
+        if fallback_key in rules_dict:
+            rules = rules_dict[fallback_key]
+        else:
+            # Final fallback: first entry in the YAML so we still produce
+            # a usable answer rather than crashing.
+            rules = next(iter(rules_dict.values()))
+
+    drill = rules.min_via_drill_mm
+    min_annular_ring = rules.min_annular_ring_mm
+    mfr_min_diameter = rules.min_via_diameter_mm
+    annular_ring_min_diameter = drill + 2 * min_annular_ring
+    diameter = max(mfr_min_diameter, annular_ring_min_diameter)
+    return diameter, drill
+
+
 @dataclass
 class PadInfo:
     """Information about a pad."""
@@ -3288,6 +3387,29 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Run DRC after stitching (fills zones automatically via kicad-cli)",
     )
+    parser.add_argument(
+        "--mfr",
+        "--manufacturer",
+        dest="mfr",
+        default=None,
+        help=(
+            "Manufacturer profile (e.g., 'jlcpcb', 'jlcpcb-tier1'). When set, "
+            "stitch via dimensions are resolved from the manufacturer's YAML "
+            "design rules using the board's actual copper layer count, "
+            "overriding --via-size and --drill defaults. When omitted, the "
+            "existing CLI defaults are used."
+        ),
+    )
+    parser.add_argument(
+        "--copper",
+        type=float,
+        default=1.0,
+        help=(
+            "Outer copper weight in oz (default: 1.0). Used together with --mfr "
+            "to select the correct design-rules row from the manufacturer YAML "
+            "(e.g., '2layer_1oz')."
+        ),
+    )
 
     args = parser.parse_args(argv)
 
@@ -3318,6 +3440,32 @@ def main(argv: list[str] | None = None) -> int:
 
         pcb_path = output_path
 
+    # Resolve via dimensions from manufacturer profile when --mfr is set.
+    # This overrides the CLI --via-size / --drill defaults so the stitch
+    # output satisfies the manufacturer's per-stackup via geometry minima.
+    # When --mfr is not provided, the existing --via-size / --drill
+    # defaults are preserved (no behavior change).
+    via_size = args.via_size
+    drill = args.drill
+    if args.mfr is not None:
+        try:
+            detected_layers = _count_copper_layers(pcb_path)
+            mfr_via_size, mfr_drill = _resolve_mfr_via_dimensions(
+                args.mfr, detected_layers, args.copper
+            )
+        except FileNotFoundError:
+            print(
+                f"Error: No configuration found for manufacturer '{args.mfr}'",
+                file=sys.stderr,
+            )
+            return 1
+        via_size = mfr_via_size
+        drill = mfr_drill
+        print(
+            f"Manufacturer profile '{args.mfr}' ({detected_layers}-layer, "
+            f"{args.copper:g}oz): via_size={via_size:.3f}mm, drill={drill:.3f}mm"
+        )
+
     # Auto-detect power plane nets if none specified
     net_names = args.nets
     if not net_names:
@@ -3337,8 +3485,8 @@ def main(argv: list[str] | None = None) -> int:
             result = run_blanket_stitch(
                 pcb_path=pcb_path,
                 net_names=net_names,
-                via_size=args.via_size,
-                drill=args.drill,
+                via_size=via_size,
+                drill=drill,
                 clearance=args.clearance,
                 spacing=args.spacing,
                 target_layer=args.target_layer,
@@ -3348,8 +3496,8 @@ def main(argv: list[str] | None = None) -> int:
             result = run_stitch(
                 pcb_path=pcb_path,
                 net_names=net_names,
-                via_size=args.via_size,
-                drill=args.drill,
+                via_size=via_size,
+                drill=drill,
                 clearance=args.clearance,
                 offset=args.offset,
                 target_layer=args.target_layer,

--- a/tests/test_stitch_mfr.py
+++ b/tests/test_stitch_mfr.py
@@ -1,0 +1,316 @@
+"""Tests for ``kct stitch`` manufacturer-aware via dimension resolution.
+
+Covers issue #2848: ``kct stitch`` was completely manufacturer-unaware and
+silently injected jlcpcb-tier1 *4-layer* minima (0.45/0.20 mm) into
+*2-layer* PCBs, producing 14 DRC violations on board 04
+(`dimension_via_drill` / `dimension_via_diameter` / `dimension_annular_ring`).
+
+The fix adds a ``--mfr`` / ``--manufacturer`` flag that, when set, resolves
+via dimensions from the manufacturer YAML profile keyed on the board's
+actual copper layer count.  When ``--mfr`` is *not* set the previous
+defaults are preserved for backwards compatibility.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.stitch_cmd import (
+    _count_copper_layers,
+    _resolve_mfr_via_dimensions,
+    main,
+)
+
+# Minimal 2-layer PCB with a GND zone and one SMD pad on GND.  Chosen so a
+# single stitching via is produced on the F.Cu surface, with the via
+# dimensions driven entirely by the CLI / mfr resolution path.
+TWO_LAYER_GND_ZONE_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "Capacitor_SMD:C_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000100")
+    (at 110 110)
+    (property "Reference" "C1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "ref-1"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 0 ""))
+  )
+  (zone (net 1) (net_name "GND") (layer "B.Cu") (uuid "zone-1") (hatch edge 0.5)
+    (connect_pads (clearance 0.2))
+    (min_thickness 0.2) (filled_areas_thickness no)
+    (fill yes (thermal_gap 0.2) (thermal_bridge_width 0.3))
+    (polygon (pts (xy 100 100) (xy 140 100) (xy 140 140) (xy 100 140)))
+  )
+)
+"""
+
+
+# 4-layer PCB with a GND zone — identical pad/zone geometry, but the
+# stackup is declared with two inner layers so layer-count detection
+# returns 4.
+FOUR_LAYER_GND_ZONE_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (2 "In2.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "Capacitor_SMD:C_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000100")
+    (at 110 110)
+    (property "Reference" "C1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "ref-1"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 0 ""))
+  )
+  (zone (net 1) (net_name "GND") (layer "In1.Cu") (uuid "zone-1") (hatch edge 0.5)
+    (connect_pads (clearance 0.2))
+    (min_thickness 0.2) (filled_areas_thickness no)
+    (fill yes (thermal_gap 0.2) (thermal_bridge_width 0.3))
+    (polygon (pts (xy 100 100) (xy 140 100) (xy 140 140) (xy 100 140)))
+  )
+)
+"""
+
+
+@pytest.fixture
+def two_layer_pcb(tmp_path: Path) -> Path:
+    """Create a 2-layer test PCB with a GND zone."""
+    pcb_file = tmp_path / "two_layer.kicad_pcb"
+    pcb_file.write_text(TWO_LAYER_GND_ZONE_PCB)
+    return pcb_file
+
+
+@pytest.fixture
+def four_layer_pcb(tmp_path: Path) -> Path:
+    """Create a 4-layer test PCB with a GND zone."""
+    pcb_file = tmp_path / "four_layer.kicad_pcb"
+    pcb_file.write_text(FOUR_LAYER_GND_ZONE_PCB)
+    return pcb_file
+
+
+class TestCountCopperLayers:
+    """Sanity tests for the copper-layer detection helper."""
+
+    def test_two_layer_board(self, two_layer_pcb: Path) -> None:
+        assert _count_copper_layers(two_layer_pcb) == 2
+
+    def test_four_layer_board(self, four_layer_pcb: Path) -> None:
+        assert _count_copper_layers(four_layer_pcb) == 4
+
+    def test_missing_file_falls_back_to_two(self, tmp_path: Path) -> None:
+        # _count_copper_layers swallows exceptions and returns the
+        # 2-layer default; the caller surfaces missing-file errors via
+        # its own path existence check.
+        assert _count_copper_layers(tmp_path / "nope.kicad_pcb") == 2
+
+
+class TestResolveMfrViaDimensions:
+    """Direct unit tests of the YAML-driven via dimension resolver."""
+
+    def test_jlcpcb_tier1_two_layer(self) -> None:
+        """jlcpcb-tier1 / 2-layer should yield 0.6mm/0.3mm (2-layer minima)."""
+        diameter, drill = _resolve_mfr_via_dimensions("jlcpcb-tier1", 2)
+        assert diameter == pytest.approx(0.6)
+        assert drill == pytest.approx(0.3)
+
+    def test_jlcpcb_tier1_four_layer(self) -> None:
+        """jlcpcb-tier1 / 4-layer should yield 0.45mm/0.2mm (4-layer minima)."""
+        diameter, drill = _resolve_mfr_via_dimensions("jlcpcb-tier1", 4)
+        assert diameter == pytest.approx(0.45)
+        assert drill == pytest.approx(0.2)
+
+    def test_jlcpcb_two_layer(self) -> None:
+        """Base jlcpcb profile / 2-layer should yield 0.6mm/0.3mm."""
+        diameter, drill = _resolve_mfr_via_dimensions("jlcpcb", 2)
+        assert diameter == pytest.approx(0.6)
+        assert drill == pytest.approx(0.3)
+
+    def test_underscore_alias_resolves(self) -> None:
+        """jlcpcb_tier1 (alias spelling) must resolve via the dash-form YAML."""
+        diameter, drill = _resolve_mfr_via_dimensions("jlcpcb_tier1", 2)
+        assert diameter == pytest.approx(0.6)
+        assert drill == pytest.approx(0.3)
+
+    def test_unknown_mfr_raises(self) -> None:
+        """An unknown manufacturer surfaces FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            _resolve_mfr_via_dimensions("does-not-exist", 2)
+
+    def test_annular_ring_constraint_dominates(self) -> None:
+        """If drill + 2*annular > min_diameter, the diameter is enlarged.
+
+        For jlcpcb-tier1 / 2-layer: drill=0.3, annular=0.15 -> floor=0.6 == min_diameter.
+        This test pins the contract that the resolver always satisfies
+        BOTH the diameter minimum and the annular ring minimum
+        simultaneously (matches fix_vias_cmd's resolution semantics).
+        """
+        diameter, drill = _resolve_mfr_via_dimensions("jlcpcb-tier1", 2)
+        from kicad_tools.manufacturers.base import load_design_rules_from_yaml
+
+        rules = load_design_rules_from_yaml("jlcpcb_tier1")["2layer_1oz"]
+        assert diameter >= rules.min_via_diameter_mm
+        assert diameter >= drill + 2 * rules.min_annular_ring_mm
+
+
+class TestStitchMainMfrFlag:
+    """End-to-end tests through ``main()`` with the new ``--mfr`` flag."""
+
+    def test_mfr_jlcpcb_tier1_two_layer_emits_2layer_minima(
+        self, two_layer_pcb: Path, tmp_path: Path
+    ) -> None:
+        """Stitching a 2-layer board with --mfr jlcpcb-tier1 must emit 0.6/0.3 vias."""
+        output_file = tmp_path / "out.kicad_pcb"
+        exit_code = main(
+            [
+                str(two_layer_pcb),
+                "--net",
+                "GND",
+                "--output",
+                str(output_file),
+                "--mfr",
+                "jlcpcb-tier1",
+            ]
+        )
+        assert exit_code == 0
+
+        text = output_file.read_text()
+        # Acceptance from issue #2848:
+        #   * via diameter >= 0.6 mm (2-layer jlcpcb-tier1 minimum)
+        #   * via drill    >= 0.3 mm (2-layer jlcpcb-tier1 minimum)
+        # The 4-layer minima (0.45 / 0.2) must NOT appear on this board.
+        assert "(size 0.6)" in text or "(size 0.600)" in text, (
+            "Expected 2-layer jlcpcb-tier1 via diameter (0.6mm) in output"
+        )
+        assert "(drill 0.3)" in text or "(drill 0.300)" in text, (
+            "Expected 2-layer jlcpcb-tier1 via drill (0.3mm) in output"
+        )
+        # Guard against silent regression to the old hardcoded 4-layer
+        # defaults.
+        assert "(size 0.45)" not in text, (
+            "Stitch should not emit jlcpcb-tier1 4-layer via diameter (0.45mm) on a 2-layer board"
+        )
+        assert "(drill 0.2)" not in text, (
+            "Stitch should not emit jlcpcb-tier1 4-layer via drill (0.2mm) on a 2-layer board"
+        )
+
+    def test_mfr_jlcpcb_tier1_four_layer_emits_4layer_minima(
+        self, four_layer_pcb: Path, tmp_path: Path
+    ) -> None:
+        """Stitching a 4-layer board with --mfr jlcpcb-tier1 must emit 0.45/0.2 vias."""
+        output_file = tmp_path / "out.kicad_pcb"
+        exit_code = main(
+            [
+                str(four_layer_pcb),
+                "--net",
+                "GND",
+                "--output",
+                str(output_file),
+                "--mfr",
+                "jlcpcb-tier1",
+            ]
+        )
+        assert exit_code == 0
+
+        text = output_file.read_text()
+        # 4-layer jlcpcb-tier1 minima: 0.45 mm diameter / 0.20 mm drill.
+        assert "(size 0.45)" in text or "(size 0.450)" in text, (
+            "Expected 4-layer jlcpcb-tier1 via diameter (0.45mm) in output"
+        )
+        assert "(drill 0.2)" in text or "(drill 0.200)" in text, (
+            "Expected 4-layer jlcpcb-tier1 via drill (0.2mm) in output"
+        )
+
+    def test_no_mfr_preserves_existing_defaults(
+        self, two_layer_pcb: Path, tmp_path: Path
+    ) -> None:
+        """Without --mfr, the historical CLI defaults (0.45/0.2) are preserved.
+
+        This pins the contract from Curator guidance: "Default behavior
+        unchanged when --mfr not passed."  Raising the unqualified
+        defaults to 2-layer-safe values is intentionally deferred to a
+        separate follow-up (per Curator's narrowed scope).
+        """
+        output_file = tmp_path / "out.kicad_pcb"
+        exit_code = main(
+            [
+                str(two_layer_pcb),
+                "--net",
+                "GND",
+                "--output",
+                str(output_file),
+            ]
+        )
+        assert exit_code == 0
+
+        text = output_file.read_text()
+        # Existing defaults: 0.45 / 0.20.
+        assert "(size 0.45)" in text or "(size 0.450)" in text, (
+            "Default (no --mfr) stitch must preserve historical via diameter (0.45mm)"
+        )
+        assert "(drill 0.2)" in text or "(drill 0.200)" in text, (
+            "Default (no --mfr) stitch must preserve historical via drill (0.2mm)"
+        )
+
+    def test_unknown_mfr_returns_error(
+        self, two_layer_pcb: Path, tmp_path: Path, capsys
+    ) -> None:
+        """Unknown manufacturer surfaces a clear error and exits non-zero."""
+        output_file = tmp_path / "out.kicad_pcb"
+        exit_code = main(
+            [
+                str(two_layer_pcb),
+                "--net",
+                "GND",
+                "--output",
+                str(output_file),
+                "--mfr",
+                "does-not-exist",
+            ]
+        )
+        assert exit_code == 1
+        captured = capsys.readouterr()
+        assert "does-not-exist" in captured.err
+
+    def test_mfr_short_alias_route_cmd_compat(
+        self, two_layer_pcb: Path, tmp_path: Path
+    ) -> None:
+        """The --manufacturer alias matches route_cmd's spelling and works identically."""
+        output_file = tmp_path / "out.kicad_pcb"
+        exit_code = main(
+            [
+                str(two_layer_pcb),
+                "--net",
+                "GND",
+                "--output",
+                str(output_file),
+                "--manufacturer",
+                "jlcpcb-tier1",
+            ]
+        )
+        assert exit_code == 0
+        text = output_file.read_text()
+        assert "(size 0.6)" in text or "(size 0.600)" in text
+        assert "(drill 0.3)" in text or "(drill 0.300)" in text


### PR DESCRIPTION
## Summary

Adds `--mfr` / `--manufacturer` (plus `--copper`) to `kct stitch`, mirroring the route_cmd / fix_vias_cmd pattern. When set, stitch via dimensions are resolved from the manufacturer YAML profile using the board's actual copper layer count.

Closes #2848.

### Root cause

`kct stitch` was completely manufacturer-unaware (`src/kicad_tools/cli/stitch_cmd.py`: zero references to `mfr` / `manufacturer`). Its argparse defaults (`--via-size 0.45`, `--drill 0.2`) exactly match jlcpcb-tier1 *4-layer* minima. On the board 04 reproducer (2-layer), this silently injected 14 vias that violate every relevant 2-layer rule:

| Rule | Count | Stitch output | Required (2-layer jlcpcb-tier1) |
|---|---|---|---|
| `dimension_via_drill` | 14 | 0.200 mm | 0.300 mm |
| `dimension_via_diameter` | 14 | 0.450 mm | 0.600 mm |
| `dimension_annular_ring` | 14 | 0.125 mm | 0.150 mm |

The router-side `kct route --mfr jlcpcb-tier1` produced compliant 0.6/0.3 vias, so the entire 42-violation drop was attributable to the stitch step.

### Fix

`stitch_cmd._resolve_mfr_via_dimensions(mfr, layers, copper)` loads the YAML profile, picks the `{layers}layer_{copper}oz` row, and returns
```
diameter = max(min_via_diameter_mm, drill + 2 * min_annular_ring_mm)
drill    = min_via_drill_mm
```
matching the resolution semantics in `fix_vias_cmd.get_design_rules`. Layer count is read from the PCB via `kicad_tools.schema.pcb.PCB.copper_layers`.

`_resolve_mfr_via_dimensions` also tolerates the dash/underscore alias drift between the registry canonicals (`jlcpcb-tier1`) and the YAML filenames (`jlcpcb_tier1.yaml`), so any spelling the user might pass on the CLI resolves.

### Scope

Per Curator guidance the PR is intentionally narrow:
- Default behavior unchanged when `--mfr` is not passed (the historical 0.45/0.20mm defaults remain).
- Tightening the unqualified defaults to 2-layer-safe values is deferred to a separate follow-up.
- `Manufacturer.get_design_rules(layers=4)` default at `manufacturers/base.py:323` and the flat `MFR_JLCPCB_TIER1` dataclass at `router/mfr_limits.py:73-81` are flagged in #2848 as latent secondary defects worth their own issue.

### Reproducer (acceptance)

```
$ uv run kct stitch /tmp/board04_routed.kicad_pcb --net GND --output /tmp/out.kicad_pcb --mfr jlcpcb-tier1
Manufacturer profile 'jlcpcb-tier1' (2-layer, 1oz): via_size=0.600mm, drill=0.300mm
```

## Test plan

- [x] `pytest tests/test_stitch_mfr.py` — 14 new tests pass (unit + end-to-end through `main()`)
- [x] `pytest tests/test_stitch_cmd.py` — 228 existing tests still pass (no regression)
- [x] `pytest tests/test_build_stitch_step.py` — 12 build-pipeline tests still pass
- [x] `ruff check` — clean on all touched files
- [x] Manual smoke: `kct stitch ... --mfr jlcpcb-tier1` on board 04 emits resolved 0.6/0.3mm vias; `--manufacturer` alias works; unknown mfr returns exit code 1
- [ ] Optional follow-up: integration test routing then stitching board 04 with `--mfr jlcpcb-tier1` end-to-end (router parameters live in a separate PR scope)

Pre-existing failures in `tests/test_fix_vias.py::TestLayerAutoDetection` (2 tests, related to `min_via_diameter == 0.45` vs `0.50` for jlcpcb 4-layer) are present on `main` and unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)