### PR TITLE
fix(router): make PlacementFeedbackLoop monotonic via best-known snapshot rollback

### DIFF
--- a/src/kicad_tools/router/placement_feedback.py
+++ b/src/kicad_tools/router/placement_feedback.py
@@ -8,6 +8,7 @@ routing failures.
 
 from __future__ import annotations
 
+import copy
 import math
 import time
 from dataclasses import dataclass, field
@@ -320,6 +321,26 @@ class PlacementFeedbackLoop:
         # backwards-compatible default on ``PlacementFeedbackResult``.
         exit_reason = "pf_max_iter"
 
+        # Issue #2840: best-known routed state across all iterations.
+        # The placement-feedback loop is non-monotonic by construction --
+        # each iteration calls ``_clear_routes()`` and routes fresh, so if
+        # iteration N+1 produces fewer routed nets than iteration N, the
+        # router's live ``self.routes`` ends up worse than a prior
+        # iteration's result.  To make the loop monotonic in routed-net
+        # count, snapshot the routes whenever a new iteration strictly
+        # improves on the best-known count, and restore the best snapshot
+        # before returning so callers always see the highest routed count
+        # observed in this run.
+        #
+        # Mirrors the deep-copy pattern from
+        # ``Autorouter.route_all_negotiated`` (core.py:4791-4838, PR #2805).
+        # Only deep-copies on strict improvement (Strategy B from #2803:
+        # minimal memory cost — at most ``max_adjustments + 1`` snapshots
+        # taken, only one retained).
+        best_routes_snapshot: list[Route] = []
+        best_routed_count = -1
+        best_iteration = -1
+
         if self.verbose:
             print("\n=== Placement-Routing Feedback Loop ===")
             print(f"  Max adjustments: {max_adjustments}")
@@ -383,9 +404,35 @@ class PlacementFeedbackLoop:
             routed_count = total_nets - len(failed_nets)
             routed_history.append(routed_count)
 
+            # Issue #2840: snapshot the routed state on strict improvement
+            # so the loop is monotonic in routed-net count.  Without this,
+            # a later iteration that regresses (fewer nets routed) leaves
+            # ``self.router.routes`` in a worse state than a prior pass
+            # produced, and the final ``PlacementFeedbackResult`` reports
+            # the regression.  Deep-copy only on strict improvement.
+            if routed_count > best_routed_count:
+                improved = True
+                best_routed_count = routed_count
+                best_routes_snapshot = copy.deepcopy(list(self.router.routes))
+                best_iteration = iteration
+            else:
+                improved = False
+
             if self.verbose:
                 print(f"  Routed: {routed_count}/{total_nets} nets")
                 print(f"  Failed: {len(failed_nets)} nets")
+                if improved:
+                    print(
+                        f"  [iter {iteration}] routed={routed_count}/{total_nets} "
+                        f"(best={best_routed_count}); improved"
+                    )
+                else:
+                    delta = routed_count - best_routed_count
+                    tag = "tied" if delta == 0 else "reverted"
+                    print(
+                        f"  [iter {iteration}] routed={routed_count}/{total_nets} "
+                        f"(best={best_routed_count}, delta={delta:+d}); {tag}"
+                    )
 
             # Success - all nets routed
             if not failed_nets:
@@ -474,7 +521,39 @@ class PlacementFeedbackLoop:
             adjustments.append(adjustment)
             total_moved += len(result.components_moved)
 
-        # Final failure analysis
+        # Issue #2840: restore the best-known routed state before
+        # reporting the result.  The placement-feedback loop is
+        # non-monotonic by construction (each iteration calls
+        # ``_clear_routes()`` and routes fresh), so ``self.router.routes``
+        # at this point reflects whichever iteration ran last -- not
+        # necessarily the best.  Restore the deep-copied snapshot whenever
+        # a strictly better state was observed earlier in the run.
+        #
+        # We restore by reassigning ``self.router.routes`` to a deep copy
+        # of the best snapshot.  Note: the grid state is NOT restored.
+        # That is intentional -- the grid is reset by ``_clear_routes()``
+        # at the top of every iteration, so no caller relies on grid
+        # state being consistent with ``self.router.routes`` after the
+        # placement-feedback loop returns.  ``get_failed_nets()`` derives
+        # solely from ``self.router.routes`` (core.py:8320), so restoring
+        # the routes is sufficient to make the reported failed-net count
+        # consistent with the restored snapshot.
+        current_routed_count = len(self.router.nets) - 1 - len(self.router.get_failed_nets())
+        if best_routed_count > current_routed_count:
+            if self.verbose:
+                print(
+                    f"  Restoring best snapshot from iter {best_iteration} "
+                    f"(routed={best_routed_count}) "
+                    f"instead of final iter (routed={current_routed_count})"
+                )
+            # Deep-copy the snapshot so the loop's internal best state
+            # cannot be mutated through ``self.router.routes`` after
+            # this call returns.
+            self.router.routes = copy.deepcopy(best_routes_snapshot)
+
+        # Final failure analysis -- computed AFTER restoration so the
+        # result reflects the restored state, not the live last-iteration
+        # state.
         failed_nets = self.router.get_failed_nets()
         if adjustments:
             adjustments[-1].failed_nets_after = failed_nets

--- a/tests/test_placement_feedback.py
+++ b/tests/test_placement_feedback.py
@@ -1226,3 +1226,357 @@ class TestPlacementFeedbackLoopBuilderHandoff:
         # the diagonals.  South / West / SE / SW must all appear.
         assert "W0" in all_quadrants and "0S" in all_quadrants
         assert "WS" in all_quadrants and "ES" in all_quadrants
+
+
+class _RoutingFakeRouter:
+    """Fake Autorouter that mutates ``self.routes`` per iteration.
+
+    Used by Issue #2840 rollback tests.  Each call to
+    ``route_all_negotiated`` consumes the next entry in ``routes_per_call``
+    and populates ``self.routes`` accordingly so:
+
+    - ``_reset_for_new_trial()`` clears ``self.routes`` (mirroring real
+      :class:`Autorouter` behavior).
+    - ``route_all_negotiated()`` appends the configured routes for the
+      current call index.
+    - ``get_failed_nets()`` derives strictly from ``self.routes`` membership
+      (mirroring real :meth:`Autorouter.get_failed_nets` at
+      ``core.py:8320``), so the loop's monotonicity logic operates against
+      a state model identical to the real router.
+
+    The ``Route`` objects are real ``router.primitives.Route`` instances so
+    ``copy.deepcopy`` in the loop's snapshot path exercises the real
+    ``Route`` deep-copy semantics.
+    """
+
+    def __init__(self, total_nets: int, routes_per_call: list[list]):
+        # ``nets`` len = total_nets + 1 so the loop's ``-1 for net 0``
+        # math yields ``total_nets``.
+        self.nets: dict[int, list] = {i: [] for i in range(total_nets + 1)}
+        self.routes: list = []
+        self._routes_per_call = routes_per_call
+        self._call_index = 0
+
+    def route_all_negotiated(self, **_kwargs):
+        idx = min(self._call_index, len(self._routes_per_call) - 1)
+        # Caller expects route_all_negotiated to populate self.routes
+        # with the iteration's results (real router does this via the
+        # per-iteration append loop).
+        for r in self._routes_per_call[idx]:
+            self.routes.append(r)
+        self._call_index += 1
+        return list(self.routes)
+
+    def route_all(self, **_kwargs):
+        return self.route_all_negotiated()
+
+    def get_failed_nets(self) -> list[int]:
+        """Derive failed_nets from self.routes -- mirrors core.py:8320."""
+        routed_nets = {r.net for r in self.routes}
+        all_nets = {n for n in self.nets if n != 0}
+        return list(all_nets - routed_nets)
+
+    def _reset_for_new_trial(self) -> None:
+        """Clear routes -- mirrors core.py:6683."""
+        self.routes = []
+
+    def analyze_routing_failure(self, _net_id):
+        return None
+
+
+def _make_test_route(net_id: int) -> "object":
+    """Construct a minimal ``Route`` carrying just enough state for tests.
+
+    The route's ``net`` field is what ``get_failed_nets`` keys on, so
+    that's all that matters for rollback verification.  Segments and vias
+    can be empty lists; deep-copy still exercises the dataclass clone path.
+    """
+    from kicad_tools.router.primitives import Route
+
+    return Route(net=net_id, net_name=f"NET_{net_id}", segments=[], vias=[])
+
+
+class TestPlacementFeedbackLoopRollback:
+    """Issue #2840: PlacementFeedbackLoop must restore best-known state.
+
+    The placement-feedback loop is non-monotonic by construction -- each
+    iteration clears all routes and re-routes from scratch.  Without an
+    explicit best-state snapshot, a later iteration that regresses
+    leaves ``self.router.routes`` worse than a prior pass produced, and
+    the final ``PlacementFeedbackResult`` reports the regression.
+
+    These tests exercise the snapshot/restore path added in #2840 by
+    driving a fake router through scripted sequences of routed-state
+    transitions and asserting the loop returns the best-observed state.
+    """
+
+    def _strategy_always_applies(self, loop):
+        """Patch the strategy pipeline so the loop iterates max_adjustments+1 times.
+
+        Mirrors ``_AlwaysApplyLoop.patch`` above: a dummy strategy that
+        always 'succeeds' (moves nothing) so the loop never short-circuits
+        on "no suitable placement strategy found".
+        """
+        dummy_strategy = ResolutionStrategy(
+            type=StrategyType.MOVE_COMPONENT,
+            difficulty=Difficulty.EASY,
+            confidence=0.99,
+            actions=[Action(type="move", target="C1", params={"x": 0.0, "y": 0.0})],
+        )
+
+        def _dummy_find(_failed, _conf):
+            return dummy_strategy
+
+        class _DummyApplicator:
+            def apply_strategy(self, _pcb, _strategy):
+                return ApplicationResult(
+                    success=True,
+                    components_moved=[],
+                    message="(dummy: no-op move)",
+                )
+
+            def is_safe_to_apply(self, _strategy, _pcb):
+                return True
+
+        loop._find_best_placement_strategy = _dummy_find  # type: ignore[method-assign]
+        loop._strategy_applicator = _DummyApplicator()
+        return loop
+
+    def test_regression_after_best_iteration_restores_best_state(self):
+        """Pass 1 fails connectivity -> post-rollback state == pre-pass-1 state.
+
+        Three iterations with routed counts [3, 1, 2] across 4 total
+        nets.  Without #2840 the loop returns iteration 2's state
+        (2 routed, 2 failed); WITH #2840 the loop must restore to
+        iteration 0's snapshot (3 routed, 1 failed).
+        """
+        from kicad_tools.router import PlacementFeedbackLoop
+
+        # iteration-0 routes nets 1,2,3 (3 routed); iteration-1 routes
+        # only net 1 (1 routed); iteration-2 routes nets 1,2 (2 routed).
+        # total_nets = 4 so failed_nets = {4} / {2,3,4} / {3,4} respectively.
+        iter0_routes = [_make_test_route(1), _make_test_route(2), _make_test_route(3)]
+        iter1_routes = [_make_test_route(1)]
+        iter2_routes = [_make_test_route(1), _make_test_route(2)]
+        router = _RoutingFakeRouter(
+            total_nets=4,
+            routes_per_call=[iter0_routes, iter1_routes, iter2_routes],
+        )
+        pcb = MockPCB()
+        loop = PlacementFeedbackLoop(
+            router=router,
+            pcb=pcb,
+            verbose=False,
+            stagnation_patience=0,  # disable stagnation so we run the full budget
+        )
+        self._strategy_always_applies(loop)
+        result = loop.run(max_adjustments=2)  # 3 iterations total
+
+        # Acceptance: the loop must NOT return the live last-iteration
+        # state (iteration 2 = 2 routed).  It must restore iteration 0's
+        # snapshot (3 routed) because that was the best observed.
+        assert len(result.routes) == 3, (
+            f"Issue #2840 rollback: expected 3 routes from iteration 0's "
+            f"snapshot, got {len(result.routes)} (loop returned the live "
+            f"final-iteration state instead of the best-known)"
+        )
+        # Failed nets must reflect the restored state too.
+        assert sorted(result.failed_nets) == [4], (
+            f"Issue #2840 rollback: failed_nets must match the restored "
+            f"snapshot (iteration 0 -> net 4 failed), got {result.failed_nets}"
+        )
+        # The router's own state must also be restored so post-loop
+        # callers reading self.router.routes see the best snapshot.
+        assert len(router.routes) == 3
+        assert sorted(r.net for r in router.routes) == [1, 2, 3]
+
+    def test_route_by_route_equivalence_after_rollback(self):
+        """Post-rollback routes are deep copies of the pre-pass-1 snapshot.
+
+        Construct distinct ``Route`` objects per iteration so equivalence
+        must hold on the routes' contents (net id + net_name), not on
+        Python identity.  After rollback, the restored routes must:
+
+        - Have the same ``(net, net_name)`` tuples as iter-0's routes.
+        - NOT be the same Python objects (``id()``) as iter-0's originals
+          -- the loop took a deep copy on iter-0 capture and a deep copy
+          again on restoration.
+        """
+        from kicad_tools.router import PlacementFeedbackLoop
+
+        # iter-0 = 3/4 (best); iter-1 regresses to 1/4; iter-2 stays low.
+        # Avoid 4/4 on iter-0 so the success short-circuit does not fire.
+        iter0_routes = [_make_test_route(i) for i in (10, 20, 30)]
+        iter1_routes = [_make_test_route(10)]
+        iter2_routes = [_make_test_route(10)]
+        iter0_ids = {id(r) for r in iter0_routes}
+        expected_signatures = sorted((r.net, r.net_name) for r in iter0_routes)
+
+        router = _RoutingFakeRouter(
+            total_nets=4,
+            routes_per_call=[iter0_routes, iter1_routes, iter2_routes],
+        )
+        # Bind nets so get_failed_nets() returns the singleton {40} after
+        # restoration (10/20/30 routed, 40 unrouted, plus net 0 ignored).
+        # Total nets = 4 (excluding net 0) so len(self.nets) - 1 = 4
+        # which matches the loop's ``total_nets`` math.
+        router.nets = {0: [], 10: [], 20: [], 30: [], 40: []}
+        assert len(router.nets) - 1 == 4
+
+        pcb = MockPCB()
+        loop = PlacementFeedbackLoop(
+            router=router,
+            pcb=pcb,
+            verbose=False,
+            stagnation_patience=0,
+        )
+        self._strategy_always_applies(loop)
+        result = loop.run(max_adjustments=2)
+
+        # Route-by-route equivalence on (net, net_name).
+        restored_signatures = sorted((r.net, r.net_name) for r in result.routes)
+        assert restored_signatures == expected_signatures, (
+            f"Issue #2840 rollback: restored routes do not match iter-0 "
+            f"snapshot.\n  expected: {expected_signatures}\n  got:      "
+            f"{restored_signatures}"
+        )
+        # Deep-copy semantics: no shared object identities with iter-0.
+        for r in result.routes:
+            assert id(r) not in iter0_ids, (
+                "Issue #2840: rollback returned routes by reference; "
+                "expected deep copies so future mutation of "
+                "self.router.routes does not corrupt the result"
+            )
+
+    def test_first_iteration_best_no_rollback_needed_success(self):
+        """First iteration converges -> success short-circuit, no rollback log.
+
+        Iteration 0 routes all nets (failed = []).  The loop returns via
+        the ``pf_converged`` short-circuit at line 391-403, which predates
+        #2840 and is unchanged.  No "Restoring best snapshot" log emitted.
+        """
+        from kicad_tools.router import PlacementFeedbackLoop
+
+        # iter-0 routes all 4 nets -> failed_nets = [] -> short-circuit.
+        iter0_routes = [_make_test_route(i) for i in (1, 2, 3, 4)]
+        router = _RoutingFakeRouter(
+            total_nets=4,
+            routes_per_call=[iter0_routes],
+        )
+        pcb = MockPCB()
+        loop = PlacementFeedbackLoop(
+            router=router,
+            pcb=pcb,
+            verbose=False,
+            stagnation_patience=0,
+        )
+        result = loop.run(max_adjustments=3)
+
+        # Success short-circuit fires; no rollback path executed.
+        assert result.exit_reason == "pf_converged"
+        assert result.success is True
+        assert result.iterations == 1
+        assert len(result.routes) == 4
+        assert result.failed_nets == []
+
+    def test_no_regression_returns_last_iteration_state(self):
+        """Monotonically improving routed_count -> no restore needed.
+
+        All iterations strictly improve (3 -> 4 -> 4).  The "best" is the
+        final iteration, so the restore branch is not taken.  Result must
+        be the live final state.
+        """
+        from kicad_tools.router import PlacementFeedbackLoop
+
+        # iter-0: 3 routed (net 4 failed); iter-1: 4 routed (success).
+        iter0_routes = [_make_test_route(i) for i in (1, 2, 3)]
+        iter1_routes = [_make_test_route(i) for i in (1, 2, 3, 4)]
+        router = _RoutingFakeRouter(
+            total_nets=4,
+            routes_per_call=[iter0_routes, iter1_routes],
+        )
+        pcb = MockPCB()
+        loop = PlacementFeedbackLoop(
+            router=router,
+            pcb=pcb,
+            verbose=False,
+            stagnation_patience=0,
+        )
+        self._strategy_always_applies(loop)
+        result = loop.run(max_adjustments=2)
+
+        # iter-1 short-circuits via pf_converged.
+        assert result.exit_reason == "pf_converged"
+        assert result.success is True
+        assert len(result.routes) == 4
+
+    def test_trajectory_log_emits_per_iteration_progress(self, capsys):
+        """Verbose mode emits ``[iter N] ... improved|reverted|tied`` per pass.
+
+        Iterates [3, 1, 2] across 3 iterations.  Captured stdout must
+        contain iter-0 marked improved, iter-1 marked reverted, iter-2
+        marked reverted (still below best), and a "Restoring best
+        snapshot" line at the end.
+        """
+        from kicad_tools.router import PlacementFeedbackLoop
+
+        iter0_routes = [_make_test_route(i) for i in (1, 2, 3)]  # 3 routed
+        iter1_routes = [_make_test_route(1)]  # 1 routed
+        iter2_routes = [_make_test_route(1), _make_test_route(2)]  # 2 routed
+        router = _RoutingFakeRouter(
+            total_nets=4,
+            routes_per_call=[iter0_routes, iter1_routes, iter2_routes],
+        )
+        pcb = MockPCB()
+        loop = PlacementFeedbackLoop(
+            router=router,
+            pcb=pcb,
+            verbose=True,
+            stagnation_patience=0,
+        )
+        self._strategy_always_applies(loop)
+        loop.run(max_adjustments=2)
+        captured = capsys.readouterr().out
+
+        # Trajectory log lines.
+        assert "[iter 0]" in captured
+        assert "improved" in captured
+        assert "[iter 1]" in captured
+        assert "reverted" in captured
+        # End-of-loop restore log line.
+        assert "Restoring best snapshot" in captured
+        # Restoration target points back at iteration 0.
+        assert "iter 0" in captured
+
+    def test_tied_iteration_does_not_replace_snapshot(self):
+        """Strict-improvement semantics: a tied iteration keeps the earlier snapshot.
+
+        iter-0 routes 3 nets, iter-1 routes the SAME 3 nets (same count,
+        same identity).  ``best_iteration`` must stay at 0; the snapshot
+        must not be replaced (so a later regression rolls back to iter 0,
+        not iter 1).
+        """
+        from kicad_tools.router import PlacementFeedbackLoop
+
+        iter0_routes = [_make_test_route(i) for i in (1, 2, 3)]
+        iter1_routes = [_make_test_route(i) for i in (1, 2, 3)]
+        iter2_routes = [_make_test_route(1)]  # regression
+        router = _RoutingFakeRouter(
+            total_nets=4,
+            routes_per_call=[iter0_routes, iter1_routes, iter2_routes],
+        )
+        pcb = MockPCB()
+        loop = PlacementFeedbackLoop(
+            router=router,
+            pcb=pcb,
+            verbose=False,
+            stagnation_patience=0,
+        )
+        self._strategy_always_applies(loop)
+        result = loop.run(max_adjustments=2)
+
+        # 3 routes restored from the best-known snapshot.
+        assert len(result.routes) == 3
+        # The exit_reason is pf_max_iter (we ran all 3 iterations without
+        # success), confirming no early break.
+        assert result.exit_reason == "pf_max_iter"


### PR DESCRIPTION
Closes #2840

## Summary

The placement-feedback loop is non-monotonic by construction: each iteration calls `_clear_routes()` and routes fresh, so if iteration N+1 produces fewer routed nets than iteration N, the router's live `self.routes` ends up worse than a prior pass produced -- and the final `PlacementFeedbackResult` reports the regression.

This PR adds a best-known snapshot pattern matching the existing deep-copy logic in `Autorouter.route_all_negotiated` (core.py:4791-4838, PR #2805):

1. **Snapshot on strict improvement.** At iteration end, if `routed_count` strictly improved, deep-copy `self.router.routes` into `best_routes_snapshot`.
2. **Restore best before returning.** Before constructing `PlacementFeedbackResult`, if the final iteration regressed below the best-known count, restore `self.router.routes` to a deep copy of the snapshot. The grid is intentionally NOT restored -- `_clear_routes()` resets it at the top of every iteration so no caller relies on grid/routes consistency after the loop returns.
3. **Recompute failed_nets after restoration** so the result reflects the restored state, not the live last-iteration state.

Per-iteration verbose log emits a trajectory line tagged `improved|tied|reverted` so the regression is visible at runtime. End-of-loop emits `Restoring best snapshot from iter N ...` when the restore path fires.

The success short-circuit (`failed_nets == []`) at the top of the loop is unchanged: a converged iteration is by definition the best state and short-circuits before any snapshot/restore logic runs.

## Test plan

Six new tests in `TestPlacementFeedbackLoopRollback` (all passing):

- [x] `test_regression_after_best_iteration_restores_best_state` -- three iterations routing [3, 1, 2]/4 nets; asserts restored state == iter-0 (3 routed, 1 failed, not iter-2's 2 routed / 2 failed).
- [x] `test_route_by_route_equivalence_after_rollback` -- deep-copy semantics: post-rollback routes have iter-0 contents (same `(net, net_name)` tuples) but no shared Python object identity with the originals.
- [x] `test_first_iteration_best_no_rollback_needed_success` -- `pf_converged` short-circuit unchanged when iter-0 routes all nets.
- [x] `test_no_regression_returns_last_iteration_state` -- monotonically improving routed count never triggers the restore branch.
- [x] `test_trajectory_log_emits_per_iteration_progress` -- verbose stdout contains `[iter N]` improved/reverted tags and `Restoring best snapshot` exit log.
- [x] `test_tied_iteration_does_not_replace_snapshot` -- strict-improvement semantics: a tied iteration keeps the earlier best snapshot so later regressions roll back to the earlier iteration.

Pre-existing tests still pass:
- [x] `tests/test_placement_feedback.py` -- 55 passed.
- [x] `tests/test_route_cmd_placement_feedback.py` -- 53 passed.
- [x] `tests/test_chorus_test_placement_feedback.py` -- 3 passed, 1 skipped.
- [x] `ruff check` and `ruff format --check` clean on modified files.

## Out of scope

Per Curator on #2840:

- **E1** (fix-drc rollback log clarity) -- fix-drc rollback is byte-for-byte correct in isolation; the log denominator mismatch is cosmetic.
- **E3** (full pipeline non-monotonicity vs committed baseline) -- deferred until this lands.
- Sibling sub-issues A/B/C/D (#2836-#2839).

## References

- Reference pattern: `Autorouter.route_all_negotiated` `_capture_iteration_end` at `src/kicad_tools/router/core.py:4791-4838` and the symmetric restore at `core.py:6126-6149` (PR #2805 / Issue #2803).