### PR TITLE
fix(router): wire ViaConflictManager into Autorouter PIN_ACCESS retry (closes #2761 gap)

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -91,6 +91,7 @@ from .tuning import (
     tune_parameters,
 )
 from .congestion_estimator import CongestionEstimator
+from .via_conflict import ViaConflictManager
 from .zones import ZoneManager
 
 
@@ -451,6 +452,16 @@ class Autorouter:
         self._diffpair_router: DiffPairRouter | None = None
         self._escape_router: EscapeRouter | None = None
         self._subgrid_router: SubGridRouter | None = None
+
+        # Issue #2838 (closes #2761 gap): Lazy-initialized via conflict
+        # manager.  Wired into the single-ended PIN_ACCESS retry path in
+        # ``route_net`` so vias from already-routed nets that sit within
+        # clearance of a failing net's pad are relocated (or rip-rerouted)
+        # before the failure becomes terminal.  The instance is re-used
+        # across all nets routed by this Autorouter so stats accumulate
+        # for the whole ``route_all_with_diffpairs`` pass.  Mirrors
+        # ``RoutingOrchestrator._via_manager`` at orchestrator.py:137.
+        self._via_manager: ViaConflictManager | None = None
 
         # Issue #2330: Waypoint injection replaces the sub-grid escape pre-pass.
         # When True, the pathfinder injects off-grid pad positions directly into
@@ -1516,16 +1527,48 @@ class Autorouter:
 
         # Issue #1603: Retry with sub-grid escape on PIN_ACCESS failure
         # Issue #2330: Skip sub-grid retry when waypoint injection is active
-        if not _subgrid_retry and not new_routes and not self.use_waypoint_injection:
-            # Check if this net has a PIN_ACCESS failure
+        # Issue #2838: Fire via-conflict resolver whenever a PIN_ACCESS
+        # failure is recorded -- not just when every edge of a multi-pin
+        # net failed.  Pre-fix this block was gated on ``not new_routes``,
+        # which meant a 3-pin net like XTAL2 (U1.3 / Y1.2 / C6.1) that
+        # routed Y1.2->C6.1 but failed U1.3->C6.1 due to an XTAL1 via
+        # would bypass the resolver entirely.  We now run the resolver
+        # whenever the net has a fresh PIN_ACCESS failure on the
+        # routing_failures list, regardless of whether any edges of the
+        # same net previously succeeded.
+        if not _subgrid_retry:
             has_pin_access_failure = any(
                 f.net == net and f.failure_cause == FailureCause.PIN_ACCESS
                 for f in self.routing_failures
             )
             if has_pin_access_failure:
-                retry_routes = self._retry_net_with_subgrid(net)
-                if retry_routes:
-                    routes.extend(retry_routes)
+                subgrid_recovered = False
+                # Sub-grid retry is only useful when waypoint injection is
+                # disabled (otherwise the C++ pathfinder already handles
+                # off-grid pads).  Sub-grid retry is also pointless when
+                # we already produced some routes for this net (it can't
+                # add coverage; the failing edge is what we need to
+                # un-block, and only via-conflict resolution can do that).
+                if not self.use_waypoint_injection and not new_routes:
+                    retry_routes = self._retry_net_with_subgrid(net)
+                    if retry_routes:
+                        routes.extend(retry_routes)
+                        subgrid_recovered = True
+                if not subgrid_recovered:
+                    # Issue #2838 (closes #2761 gap): Run via-conflict
+                    # resolution.  Neither sub-grid escape nor waypoint
+                    # injection can move an existing via from another
+                    # net; when the failure analyser reports
+                    # ``pad_access_blockers`` with ``blocking_type ==
+                    # "via"`` the only viable fix is to relocate or
+                    # rip-reroute the offending via.  This is the
+                    # canonical XTAL2 (board 03) failure pattern: XTAL1
+                    # routes first, drops a via 0.317 mm from U1.3,
+                    # XTAL2 fails PIN_ACCESS on the U1.3->C6.1 edge
+                    # while Y1.2->C6.1 routes successfully.
+                    via_retry_routes = self._resolve_via_conflicts_for_net(net)
+                    if via_retry_routes:
+                        routes.extend(via_retry_routes)
 
         # Issue #2336: Store freshly routed solution in sub-problem cache
         if sub_sig is not None and new_routes and self._sub_problem_cache is not None:
@@ -7508,13 +7551,34 @@ class Autorouter:
                 if pad_list:
                     net_pads[net_id] = pad_list
 
-        return compute_routing_statistics(
+        stats = compute_routing_statistics(
             routes=self.routes,
             grid=self.grid,
             layer_stats=self.get_layer_usage_statistics(),
             nets_to_route_ids=nets_to_route_ids,
             net_pads=net_pads,
         )
+
+        # Issue #2838 (closes #2761 gap): Surface via conflict resolver
+        # stats so demos and tests can assert the resolver fired (the
+        # canonical acceptance criterion from #2761 / #2838 is
+        # ``relocations_succeeded + rip_reroutes_succeeded >= 1`` on
+        # boards that need it).  Reading ``self._via_manager`` directly
+        # (not the lazy property) avoids surprise instantiation when
+        # nothing has triggered the resolver.
+        if self._via_manager is not None:
+            vc_stats = self._via_manager.stats
+            stats["via_conflict_resolution"] = {
+                "conflicts_found": vc_stats.conflicts_found,
+                "relocations_attempted": vc_stats.relocations_attempted,
+                "relocations_succeeded": vc_stats.relocations_succeeded,
+                "rip_reroutes_attempted": vc_stats.rip_reroutes_attempted,
+                "rip_reroutes_succeeded": vc_stats.rip_reroutes_succeeded,
+                "nets_unblocked": vc_stats.nets_unblocked,
+                "total_resolved": vc_stats.total_resolved,
+            }
+
+        return stats
 
     def get_layer_usage_statistics(self) -> dict:
         """Get layer utilization statistics from routed segments (Issue #625).
@@ -8886,6 +8950,164 @@ class Autorouter:
         # Retry routing
         retry_routes = self.route_net(net, _subgrid_retry=True)
         return escape_routes + retry_routes
+
+    @property
+    def via_manager(self) -> ViaConflictManager | None:
+        """Lazy-initialized via conflict manager instance.
+
+        Issue #2838 (closes #2761 gap): The manager is instantiated on
+        first access and re-used across the whole routing pass so its
+        :attr:`stats` accumulate over every net that triggers
+        PIN_ACCESS via-conflict resolution.  Returns ``None`` only if
+        the Autorouter has no routing grid (should never happen post-
+        ``__init__`` since ``_create_grid_and_routers`` always builds
+        one, but checked defensively to mirror
+        :class:`RoutingOrchestrator.via_manager`).
+        """
+        if self._via_manager is None and self.grid is not None:
+            self._via_manager = ViaConflictManager(grid=self.grid, rules=self.rules)
+        return self._via_manager
+
+    def _resolve_via_conflicts_for_net(self, net: int) -> list[Route]:
+        """Resolve via conflicts blocking a net's pads, then retry routing.
+
+        Issue #2838 (closes the gap left by closed #2761): Called from
+        :meth:`route_net` after :meth:`_retry_net_with_subgrid` returns
+        empty on a PIN_ACCESS failure.  Examines the failing net's most
+        recent failure analysis for ``pad_access_blockers`` entries with
+        ``blocking_type == "via"``; for each such blocker, asks
+        :class:`ViaConflictManager` to find the offending vias, then tries
+        relocation first (cheaper, non-destructive) and falls back to
+        rip-and-reroute if relocation fails.  On any successful resolution
+        the net's failure entries are dropped and routing is retried.
+
+        Mirrors :meth:`RoutingOrchestrator._route_via_conflict_resolution`
+        (orchestrator.py:855-905), but operates on the
+        ``Autorouter.route_net`` flow used by ``kct route`` and
+        ``route_all_with_diffpairs`` -- the path that closed #2761 missed.
+
+        Args:
+            net: Net ID whose PIN_ACCESS failure should be re-attempted
+                after relocating blocking vias.
+
+        Returns:
+            List of new routes for ``net`` if a conflict was resolved and
+            the retry succeeded; empty list otherwise.  Routes are also
+            appended to ``self.routes`` via the standard ``_mark_route``
+            path inside the recursive ``route_net`` call.
+        """
+        if net not in self.nets:
+            return []
+
+        # Find the most recent failure for this net and confirm it's a
+        # PIN_ACCESS failure with at least one via blocker.  This gates
+        # the resolver so we never run on BLOCKED_PATH / CONGESTION
+        # failures (those have their own resolvers).
+        recent_failure: RoutingFailure | None = None
+        for failure in reversed(self.routing_failures):
+            if failure.net == net:
+                recent_failure = failure
+                break
+        if recent_failure is None:
+            return []
+        if recent_failure.failure_cause != FailureCause.PIN_ACCESS:
+            return []
+        analysis = recent_failure.analysis
+        if analysis is None:
+            return []
+        has_via_blocker = any(
+            blocker.blocking_type == "via"
+            for blocker in analysis.pad_access_blockers
+        )
+        if not has_via_blocker:
+            return []
+
+        manager = self.via_manager
+        if manager is None:
+            return []
+
+        # Find all vias blocking this net's pads (across every pad on the
+        # net, not just the pads named by the failure record -- a failing
+        # MST edge typically names two pads but the conflict may live on
+        # any pad of an N-port net).  Dedup by via position so we don't
+        # process the same offending via twice.
+        net_pad_keys = self.nets[net]
+        net_pads = [self.pads[key] for key in net_pad_keys if key in self.pads]
+        all_conflicts = []
+        for pad in net_pads:
+            conflicts = manager.find_blocking_vias(
+                pad=pad,
+                pad_net=net,
+                net_names=self.net_names,
+            )
+            all_conflicts.extend(conflicts)
+
+        seen_positions: set[tuple[float, float]] = set()
+        unique_conflicts = []
+        for conflict in all_conflicts:
+            key = (round(conflict.via.x, 4), round(conflict.via.y, 4))
+            if key in seen_positions:
+                continue
+            seen_positions.add(key)
+            unique_conflicts.append(conflict)
+
+        if not unique_conflicts:
+            return []
+
+        net_name = self.net_names.get(net, f"Net {net}")
+        flush_print(
+            f"  Via conflict resolver for {net_name}: "
+            f"{len(unique_conflicts)} candidate conflict(s) found"
+        )
+
+        # Attempt resolution: RELOCATE first (cheap, in-place), then fall
+        # back to RIP_REROUTE on relocation failure (destructive but
+        # broader).  We accept a single successful resolution as enough
+        # to justify the retry -- the resolver doesn't need to clear
+        # every conflict, just unblock the pad enough for A* to find a
+        # path.
+        any_resolved = False
+
+        # The rip-reroute fallback needs a callable that routes a single
+        # net.  Use ``_subgrid_retry=True`` to prevent the recursive
+        # ``route_net`` call from re-entering the via-conflict resolver
+        # (and from re-entering the sub-grid retry path).
+        def _route_net_fn(net_id: int) -> list[Route]:
+            return self.route_net(net_id, _subgrid_retry=True)
+
+        for conflict in unique_conflicts:
+            relocation = manager.try_relocate(conflict)
+            if relocation.success:
+                any_resolved = True
+                continue
+            # Relocation failed -- try rip-and-reroute.
+            rip_result = manager.try_rip_reroute(
+                conflict,
+                route_net_fn=_route_net_fn,
+            )
+            if rip_result.success:
+                any_resolved = True
+                # rip_reroute already routed the blocked net (our net)
+                # and the displaced net, so the new routes for `net`
+                # were appended to self.routes by the recursive call.
+                # We still need to drop the old failure entries and
+                # treat this as resolved; break out of the loop because
+                # the failing condition no longer holds.
+                break
+
+        if not any_resolved:
+            return []
+
+        # Drop the prior failure records for this net (mirror
+        # _retry_net_with_subgrid pattern at core.py:8895) and retry
+        # routing.  When the rip-and-reroute branch above already
+        # produced routes for ``net``, the recursive route_net call
+        # below will be a near-no-op (pads already marked), but it
+        # ensures the standard post-route bookkeeping runs and that we
+        # return a consistent route list.
+        self.routing_failures = [f for f in self.routing_failures if f.net != net]
+        retry_routes = self.route_net(net, _subgrid_retry=True)
+        return retry_routes
 
     def route_with_subgrid(
         self,

--- a/tests/test_board_03_regression.py
+++ b/tests/test_board_03_regression.py
@@ -231,6 +231,107 @@ def test_usb_diff_pair_routes_via_coupled_pathfinder(routed_board_03) -> None:
     )
 
 
+def test_xtal2_unblocks_via_conflict_resolution(routed_board_03) -> None:
+    """ViaConflictManager wiring is exercised on board 03's XTAL2 failure path.
+
+    Issue #2838 (closes #2761 gap): On ``main`` at the branch point,
+    ``Autorouter`` has no ``_via_manager`` attribute at all and the
+    PIN_ACCESS retry path in ``route_net`` never invokes via-conflict
+    resolution.  XTAL2 fails ``PIN_ACCESS`` on the U1.3 -> C6.1 edge
+    (the failure analyser reports U1.3 as blocked by a XTAL1 "via at
+    0.32mm") and the failure is terminal.
+
+    This regression test asserts the **structural wiring** is in place:
+    after ``route_all_with_diffpairs`` the ``Autorouter._via_manager``
+    attribute exists and has been instantiated, meaning the PIN_ACCESS
+    retry block in ``route_net`` reached the via-conflict resolution
+    branch.  This is the minimum verifiable bar for the #2838 wiring
+    fix on a real board.
+
+    *Caveat — XTAL2 doesn't fully route after this fix.*  Inspection
+    of board 03's actual routed state shows that XTAL1's nearest via
+    is 7.5 mm from U1.3, well outside any via-clearance zone.  The
+    failure analyser's classification of the U1.3 blocker as
+    ``blocking_type="via"`` is misleading: the real blocker is a
+    XTAL1 *trace* segment whose clearance envelope sits ~0.9 mm from
+    U1.3.  Because ``ViaConflictManager.find_blocking_vias`` only
+    scans actual ``Via`` objects on ``grid.routes``, it correctly
+    reports ``conflicts_found == 0`` for this board -- there is no
+    via to relocate.  Fully unblocking XTAL2 requires either:
+
+    1. Fixing the failure analyser's ``via`` vs ``trace`` classification
+       (the ``cell.original_net == 0`` fall-through at
+       ``failure_analysis.py:1546`` defaults to ``"via"`` for trace
+       clearance cells), or
+    2. Extending ``ViaConflictManager`` to also relocate / rip-reroute
+       *trace* segments (much larger scope -- out of scope per the
+       issue's "Out of scope" section).
+
+    Both are tracked separately.  For this PR, the success criterion
+    is the wiring -- which the synthetic test in
+    ``tests/test_via_conflict.py::TestViaConflictManagerIntegration``
+    pins more directly (it constructs a real via blocker and asserts
+    ``relocations_succeeded + rip_reroutes_succeeded >= 1``).
+    """
+    router, net_map = routed_board_03
+
+    xtal1_id = net_map.get("XTAL1")
+    xtal2_id = net_map.get("XTAL2")
+    assert xtal1_id is not None, (
+        "XTAL1 net missing from board 03 unrouted PCB.  Expected this "
+        "is one of the canonical example board's clock signals; if the "
+        "schematic / PCB generator no longer emits XTAL1, this test "
+        "needs to be updated."
+    )
+    assert xtal2_id is not None, (
+        "XTAL2 net missing from board 03 unrouted PCB -- see XTAL1 note."
+    )
+
+    routes_by_net: dict[int, int] = {}
+    for route in router.routes:
+        routes_by_net[route.net] = routes_by_net.get(route.net, 0) + len(route.segments)
+
+    # No regression on XTAL1: it routed first under pre-fix main and
+    # must continue to route post-fix (the via-conflict resolver does
+    # not rip-reroute XTAL1 on this board, but if it ever does, XTAL1
+    # must still end up routed).
+    xtal1_segments = routes_by_net.get(xtal1_id, 0)
+    assert xtal1_segments > 0, (
+        f"XTAL1 (net {xtal1_id}) routed with 0 segments after the "
+        "via-conflict fix.  Either rip-and-reroute removed XTAL1's "
+        "route to free U1.3 but failed to find an alternate path on "
+        "retry, or the routing order changed and XTAL1 is now being "
+        "scheduled after XTAL2 (which would make this test the wrong "
+        "test for the regression)."
+    )
+
+    # Structural wiring assertion (the #2838 minimum bar): the
+    # ``Autorouter._via_manager`` attribute must exist.  This is what
+    # makes the test fail on ``main`` at the branch point -- the
+    # attribute is entirely absent.
+    assert hasattr(router, "_via_manager"), (
+        "Autorouter is missing the _via_manager attribute.  This is "
+        "the Issue #2838 structural regression: the ViaConflictManager "
+        "wiring is entirely absent from Autorouter.  Check that "
+        "core.py imports ViaConflictManager and __init__ initializes "
+        "self._via_manager."
+    )
+
+    # Resolver-was-reached assertion: the lazy ``via_manager`` property
+    # was triggered, meaning ``_resolve_via_conflicts_for_net`` ran on
+    # at least one PIN_ACCESS failure during the routing pass.  XTAL2
+    # is the canonical trigger (its failure analyser reports a
+    # ``blocking_type == "via"`` blocker -- regardless of whether the
+    # underlying obstacle is actually a via or a misclassified trace).
+    assert router._via_manager is not None, (
+        "Autorouter._via_manager is None after route_all_with_diffpairs.  "
+        "The PIN_ACCESS retry block in route_net() did not call "
+        "_resolve_via_conflicts_for_net for any net.  Board 03's XTAL2 "
+        "should have triggered it -- check that the PIN_ACCESS gate at "
+        "core.py:1530 still fires when waypoint injection is on."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Issue #2744: Generator parts drift (subprocess, slower but bounded)
 # ---------------------------------------------------------------------------

--- a/tests/test_via_conflict.py
+++ b/tests/test_via_conflict.py
@@ -2,8 +2,10 @@
 
 import math
 
+from kicad_tools.router.core import Autorouter
 from kicad_tools.router.layers import Layer
 from kicad_tools.router.primitives import Pad, Route, Segment, Via
+from kicad_tools.router.rules import DesignRules
 from kicad_tools.router.via_conflict import (
     RipRerouteResult,
     ViaConflict,
@@ -564,3 +566,241 @@ class TestGenerateRelocationCandidates:
             key = (round(cx, 4), round(cy, 4))
             positions.add(key)
         assert len(positions) == len(candidates)
+
+
+class TestViaConflictManagerIntegration:
+    """Tests for ``Autorouter`` <-> ``ViaConflictManager`` integration.
+
+    Issue #2838 (closes #2761 gap): The closed PR for #2761 wired
+    ``ViaConflictManager`` into ``RoutingOrchestrator`` only.  The
+    ``Autorouter.route_net`` path used by ``kct route`` and
+    ``DiffPairRouter.route_all_with_diffpairs`` was missed -- so
+    single-ended nets whose pads ended up within via-clearance of an
+    already-routed net's via failed PIN_ACCESS with no fallback.  XTAL2
+    on board 03 is the canonical example.
+
+    These tests pin the integration: they fail on ``main`` at the issue's
+    branch point (where ``Autorouter._via_manager`` doesn't exist and
+    ``_resolve_via_conflicts_for_net`` is never called from
+    ``route_net``) and pass after the fix in this PR.
+    """
+
+    def _build_xtal2_like_router(self) -> tuple[Autorouter, int, int]:
+        """Construct an XTAL2-like fixture: blocking via in N1's pad-access zone.
+
+        Mirrors the failure geometry described in #2833 / #2838:
+
+        * Net N1 (target net, to be routed): two pads
+          - source pad at (5.048, 10.065) -- deliberately off-grid
+            (0.048 mm + 0.065 mm offsets) so the failure analyser tags
+            the failure with ``FailureCause.PIN_ACCESS`` and populates
+            ``pad_access_blockers``.
+          - target pad at (15.0, 10.0) on-grid; gives A* a clean
+            destination so the only failure mode is pad access at the
+            source.
+        * Net N2 (already-routed blocker): one pad at (5.5, 10.0) and a
+          pre-existing route consisting of a single Via at
+          (5.365, 10.065), placed 0.317 mm from N1's source pad --
+          exactly the U1.3 vs XTAL1 distance reported in the issue.
+
+        Returns ``(router, n1_id, n2_id)``.
+        """
+        rules = DesignRules(
+            trace_width=0.2,
+            trace_clearance=0.2,
+            via_drill=0.3,
+            via_diameter=0.6,
+            via_clearance=0.2,
+            grid_resolution=0.1,
+        )
+        router = Autorouter(width=20.0, height=20.0, rules=rules)
+
+        n1_id = 1
+        n2_id = 2
+
+        # N1 source pad (off-grid by 0.048mm in x, 0.065mm in y).  These
+        # offsets are sub-resolution, but their sum (0.113mm) exceeds the
+        # grid-tenth threshold (grid_resolution/10 = 0.01mm), so the
+        # failure analyser tags the failing edge as PIN_ACCESS.
+        router.add_component(
+            "U1",
+            [
+                {
+                    "number": "3",
+                    "x": 5.048,
+                    "y": 10.065,
+                    "width": 0.5,
+                    "height": 0.5,
+                    "net": n1_id,
+                    "net_name": "XTAL2",
+                },
+                {
+                    "number": "4",
+                    "x": 15.0,
+                    "y": 10.0,
+                    "width": 0.5,
+                    "height": 0.5,
+                    "net": n1_id,
+                    "net_name": "XTAL2",
+                },
+            ],
+        )
+        # N2 has a single pad on a different component.
+        router.add_component(
+            "Y1",
+            [
+                {
+                    "number": "1",
+                    "x": 6.5,
+                    "y": 10.0,
+                    "width": 0.5,
+                    "height": 0.5,
+                    "net": n2_id,
+                    "net_name": "XTAL1",
+                },
+            ],
+        )
+
+        # Pre-existing route for N2 with a blocking via placed 0.317 mm
+        # from N1's source pad center -- inside the via's clearance
+        # envelope (0.3 mm + 0.2 mm = 0.5 mm).  No segments are needed;
+        # the via alone provides the via_route reference that
+        # ViaConflictManager.find_blocking_vias inspects.
+        blocking_via = Via(
+            x=5.365,
+            y=10.065,
+            drill=0.3,
+            diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU),
+            net=n2_id,
+            net_name="XTAL1",
+        )
+        seg_to_pad = Segment(
+            x1=5.365,
+            y1=10.065,
+            x2=6.5,
+            y2=10.0,
+            width=0.2,
+            layer=Layer.F_CU,
+            net=n2_id,
+            net_name="XTAL1",
+        )
+        n2_route = Route(
+            net=n2_id,
+            net_name="XTAL1",
+            segments=[seg_to_pad],
+            vias=[blocking_via],
+        )
+        router.routes.append(n2_route)
+        router._mark_route(n2_route)
+
+        return router, n1_id, n2_id
+
+    def test_route_net_consults_manager_on_pin_access(self):
+        """``route_net`` instantiates ``_via_manager`` on PIN_ACCESS + via blocker.
+
+        Failure case on ``main`` at the branch point: ``Autorouter`` has
+        no ``_via_manager`` attribute at all and never reaches
+        :class:`ViaConflictManager` from ``route_net``.  This test asserts
+        the wiring exists and the manager actually fires when a PIN_ACCESS
+        failure is recorded with a via blocker.
+
+        Acceptance criterion (mirror of #2761 acceptance criterion in
+        the issue): the resolver attempts at least one conflict resolution
+        and successfully resolves at least one of them -- per the
+        mandatory ``relocations_succeeded + rip_reroutes_succeeded >= 1``
+        sum.  This is what proves the resolver actually fired and the
+        success is not accidental.
+        """
+        router, n1_id, _n2_id = self._build_xtal2_like_router()
+
+        # Attempt to route N1.  On main (pre-fix) this returns [] and
+        # leaves router._via_manager == None.  Post-fix, the PIN_ACCESS
+        # retry block invokes _resolve_via_conflicts_for_net which
+        # instantiates the manager and runs the resolver.
+        router.route_net(n1_id)
+
+        # Wiring assertion: the manager was instantiated.
+        assert router._via_manager is not None, (
+            "Autorouter._via_manager was never instantiated.  This is "
+            "the Issue #2838 regression: ViaConflictManager is only "
+            "wired into RoutingOrchestrator, not into Autorouter."
+        )
+
+        stats = router._via_manager.stats
+
+        # Resolver-fired assertion: at least one conflict was detected.
+        assert stats.conflicts_found >= 1, (
+            f"ViaConflictManager.find_blocking_vias did not detect any "
+            f"conflicts in the XTAL2-like fixture (conflicts_found="
+            f"{stats.conflicts_found}).  Either the geometry no longer "
+            f"reproduces the XTAL1/XTAL2 via-clearance overlap, or the "
+            f"manager is not being called from route_net()'s PIN_ACCESS "
+            f"retry block."
+        )
+
+        # Resolution-succeeded assertion: at least one conflict was
+        # resolved (either by relocation or rip-reroute).  This is the
+        # exact acceptance criterion from #2761 / #2838.
+        resolved = stats.relocations_succeeded + stats.rip_reroutes_succeeded
+        assert resolved >= 1, (
+            f"ViaConflictManager fired (conflicts_found="
+            f"{stats.conflicts_found}) but no conflicts were resolved "
+            f"(relocations_succeeded={stats.relocations_succeeded}, "
+            f"rip_reroutes_succeeded={stats.rip_reroutes_succeeded}).  "
+            f"The resolver wiring may be incomplete -- check that "
+            f"_resolve_via_conflicts_for_net is invoking try_relocate "
+            f"and/or try_rip_reroute on the discovered conflicts."
+        )
+
+    def test_via_manager_property_lazy_init(self):
+        """The ``via_manager`` property only instantiates on first access.
+
+        Mirrors :class:`RoutingOrchestrator.via_manager` lazy-init
+        semantics at ``orchestrator.py:1262-1273``: the resolver is an
+        opt-in cost; constructing an Autorouter for a quick route_net
+        call should not pay for a ViaConflictManager unless something
+        triggers the PIN_ACCESS retry path.
+        """
+        rules = DesignRules(grid_resolution=0.1)
+        router = Autorouter(width=10.0, height=10.0, rules=rules)
+
+        # Field starts None.
+        assert router._via_manager is None
+
+        # First property access initializes it.
+        manager = router.via_manager
+        assert manager is not None
+        assert router._via_manager is manager
+
+        # Second access returns the same instance (no rebuild).
+        manager2 = router.via_manager
+        assert manager2 is manager
+
+    def test_get_statistics_exposes_via_conflict_metrics_when_fired(self):
+        """``get_statistics`` includes a ``via_conflict_resolution`` block.
+
+        Post-fix the demo / observability layer needs a way to assert the
+        resolver fired.  ``get_statistics`` is the canonical Autorouter
+        observability surface; this test pins that the via-conflict
+        stats are exposed there when the manager has been instantiated.
+
+        Pre-fix: ``Autorouter._via_manager`` doesn't exist, so the
+        ``via_conflict_resolution`` key is absent from the stats dict.
+        """
+        router, n1_id, _n2_id = self._build_xtal2_like_router()
+        router.route_net(n1_id)
+
+        stats = router.get_statistics()
+        assert "via_conflict_resolution" in stats, (
+            "get_statistics() is missing the 'via_conflict_resolution' "
+            "key; the demo / regression tooling has no way to assert "
+            "the resolver fired without it."
+        )
+        vc_stats = stats["via_conflict_resolution"]
+        assert vc_stats["conflicts_found"] >= 1
+        assert (
+            vc_stats["relocations_succeeded"] + vc_stats["rip_reroutes_succeeded"]
+            >= 1
+        )
+        assert vc_stats["total_resolved"] >= 1


### PR DESCRIPTION
## Summary

Closes #2838 by wiring `ViaConflictManager` into `Autorouter.route_net`'s PIN_ACCESS retry path. The closed PR for #2761 only wired the manager into `RoutingOrchestrator` (used by `kct route-auto`); the `Autorouter` path used by `kct route` and `DiffPairRouter.route_all_with_diffpairs` was missed, so single-ended nets failing PIN_ACCESS with a via-clearance blocker had no resolver path.

## Changes

- `src/kicad_tools/router/core.py`:
  - Add `Autorouter._via_manager` field + lazy `via_manager` property (mirrors `orchestrator.py:137,1262-1273`).
  - Add `Autorouter._resolve_via_conflicts_for_net(net)` helper that runs `find_blocking_vias` -> `try_relocate` -> `try_rip_reroute` (mirrors `orchestrator.py:855-905`).
  - Wire the helper into `route_net`'s PIN_ACCESS retry block. The retry now fires whenever a PIN_ACCESS failure is recorded -- including the partial-success case where some MST edges of a multi-pin net succeeded but others failed (the canonical board 03 XTAL2 case: `U1.3 -> C6.1` fails while `Y1.2 -> C6.1` succeeds).
  - `get_statistics()` now exposes a `via_conflict_resolution` block so demos / tests can assert the resolver fired (the mandatory acceptance criterion from #2761 / #2838).

- `tests/test_via_conflict.py`:
  - New `TestViaConflictManagerIntegration` class with three tests:
    - `test_route_net_consults_manager_on_pin_access` -- synthetic XTAL2-like fixture; constructs a real via blocker 0.317 mm from a target pad and asserts `relocations_succeeded + rip_reroutes_succeeded >= 1`. Fails on main, passes after fix.
    - `test_via_manager_property_lazy_init` -- pins the lazy-init semantics of the new property.
    - `test_get_statistics_exposes_via_conflict_metrics_when_fired` -- pins the new observability surface.

- `tests/test_board_03_regression.py`:
  - New `test_xtal2_unblocks_via_conflict_resolution` -- pins the structural wiring on real board 03. Documents that XTAL2's failure is misclassified by `failure_analysis.py` (the underlying blocker is a XTAL1 trace clearance, not a via; the closest XTAL1 via is 7.5 mm from U1.3), so the resolver correctly reports `conflicts_found == 0` and cannot fully unblock XTAL2 on this board. The test asserts the wiring is reached (`_via_manager` attribute exists and is instantiated post-routing). Fully unblocking XTAL2 requires either fixing the via-vs-trace misclassification at `failure_analysis.py:1546` or extending the manager to relocate traces -- both out of scope per the issue's \"Out of scope\" section.

## Audit comment

Posted on the issue: confirmed zero matches for `via_conflict` / `ViaConflictManager` in `core.py` / `diffpair_routing.py` at branch base `b793fd0c`.

## Test plan

- [x] `tests/test_via_conflict.py` -- all 27 tests pass (24 existing + 3 new).
- [x] `tests/test_via_conflict.py::TestViaConflictManagerIntegration` -- FAILS on main at branch base (verified by reverting `core.py` while keeping the new tests).
- [x] `tests/test_board_03_regression.py::test_xtal2_unblocks_via_conflict_resolution` -- FAILS on main, passes after fix.
- [x] `tests/test_board_03_regression.py::test_usb_diff_pair_routes_via_coupled_pathfinder` -- still passes (no diff-pair regression).
- [x] `tests/test_board_06_diffpair_test.py` -- still passes (no diff-pair smoke regression).
- [x] `tests/test_progressive_clearance.py`, `tests/test_router_cleanup.py`, `tests/test_waypoint_injection.py`, `tests/test_diffpair_engagement.py` -- all pass.
- [x] No new lint errors introduced (pre-existing lint state in `core.py` unchanged).

## Caveats / follow-ups

The board 03 XTAL2 case turned out to be a failure-analyser misclassification rather than a true via conflict (real blocker is a XTAL1 trace at ~0.9 mm; nearest XTAL1 via is 7.5 mm away). This PR delivers the wiring fix from #2838 but does not fully unblock XTAL2 on board 03. Two follow-ups should be filed if not already tracked:

1. Fix the `cell.original_net == 0` fall-through at `failure_analysis.py:1546` so trace clearance cells are classified as `\"trace\"` not `\"via\"`.
2. Extend `ViaConflictManager` (or add a sibling resolver) to relocate / rip-reroute trace clearances on PIN_ACCESS failure -- larger scope, was explicitly out-of-scope per the #2838 issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)