### PR TITLE
feat(router): pad-position-aware fine grid zones with GCD spacing and origin offsets

### DIFF
--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -920,8 +920,6 @@ def _compute_zone_resolution_and_offset(
         # can't be refined below the coarse grid.
         return (max(coarse_resolution / 2.0, min_fine_resolution), 0.0, 0.0)
 
-    total = len(comp_pads)
-
     # Walk candidates coarsest -> finest, returning the first (R, O) that
     # places *all* of the component's pads on-grid.  This minimises the
     # fine zone's cell count while still being pad-position-aware.

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -1253,11 +1253,21 @@ def compute_multi_resolution_plan(
         )
 
         if should_escalate and off_grid_refs:
-            # Add these components as needing fine-grid zones (if not already)
-            # using the pad-position-aware solver introduced in #2837.  For
-            # each off-grid component we pick the coarsest fine resolution
-            # plus an origin offset that puts ALL of its pads on-grid.
+            # Add these components as needing fine-grid zones using the
+            # pad-position-aware solver introduced in #2837.  For each
+            # off-grid component we pick the coarsest fine resolution plus
+            # an origin offset that puts ALL of its pads on-grid.
+            #
+            # Skip single-pad components: a fine zone around a single point
+            # has nothing to refine -- the existing sub-grid escape routing
+            # already handles isolated off-grid pads.  This preserves
+            # parity with the pre-#2837 behaviour where ``if deltas`` was
+            # the gate that filtered out single-pad off-grid refs (e.g.
+            # mounting holes MH1-MH4 on board 05).
+            escalated = 0
             for ref, ref_pads in off_grid_refs.items():
+                if len(ref_pads) < 2:
+                    continue
                 fine_res, x_off, y_off = _compute_zone_resolution_and_offset(
                     ref_pads,
                     coarse_resolution=coarse_resolution,
@@ -1268,6 +1278,7 @@ def compute_multi_resolution_plan(
                 # actually checks pad-position alignment.
                 fine_components[ref] = fine_res
                 pad_position_offsets[ref] = (x_off, y_off)
+                escalated += 1
 
             logger.info(
                 "Off-grid escalation: %d/%d pads (%.1f%%) off-grid at "
@@ -1276,7 +1287,7 @@ def compute_multi_resolution_plan(
                 uniform_result.total_pads,
                 uniform_result.off_grid_percentage,
                 coarse_resolution,
-                len(off_grid_refs),
+                escalated,
             )
 
     if not fine_components:

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -503,6 +503,12 @@ class FineZone:
         x_max: Bounding box maximum X (mm)
         y_max: Bounding box maximum Y (mm)
         resolution: Fine grid resolution for this zone (mm)
+        x_offset: Origin offset of the fine grid along X (mm, default 0.0).
+            Grid points within this zone fall at ``x_offset + k * resolution``
+            for integer k.  Used so the fine grid aligns to the component's
+            actual pad positions even when those positions are off-grid in
+            world coordinates (issue #2837).
+        y_offset: Origin offset of the fine grid along Y (mm, default 0.0).
     """
 
     ref: str
@@ -511,6 +517,8 @@ class FineZone:
     x_max: float
     y_max: float
     resolution: float
+    x_offset: float = 0.0
+    y_offset: float = 0.0
 
     @property
     def width(self) -> float:
@@ -579,10 +587,15 @@ class MultiResolutionGridPlan:
             f"  Fine zones: {len(self.fine_zones)}",
         ]
         for zone in self.fine_zones:
+            offset_str = ""
+            if zone.x_offset != 0.0 or zone.y_offset != 0.0:
+                offset_str = (
+                    f" offset=({zone.x_offset:.4f},{zone.y_offset:.4f})"
+                )
             lines.append(
                 f"    {zone.ref}: {zone.resolution:.4f}mm "
                 f"({zone.width:.1f}x{zone.height:.1f}mm, "
-                f"~{zone.cell_count:,} cells)"
+                f"~{zone.cell_count:,} cells){offset_str}"
             )
         lines.append(f"  Total cell estimate: {self.total_cell_estimate:,}")
         if self.uniform_fallback > 0:
@@ -846,6 +859,91 @@ def _compute_gcd_grid_candidates(
     return result
 
 
+def _compute_zone_resolution_and_offset(
+    comp_pads: list,
+    coarse_resolution: float,
+    min_fine_resolution: float = 0.005,
+) -> tuple[float, float, float]:
+    """Find the coarsest fine-grid (resolution, x_offset, y_offset) for a component.
+
+    Searches a series of candidate fine-grid resolutions (coarsest first)
+    and, for each, finds an origin offset that maximizes on-grid coverage
+    of *this component's* pads.  Returns the coarsest resolution for which
+    ALL of the component's pads are on-grid with the chosen offset.  If no
+    candidate achieves full coverage, the finest candidate is returned with
+    its best-fit offset.
+
+    This is the pad-position-aware refinement for issue #2837: rather than
+    deriving a fine resolution heuristically from ``min_pad_delta / 10``,
+    we pick a (resolution, offset) pair that actually aligns the
+    component's pads.  This is essential for off-grid components like J1
+    USB-C (half-grid offsets) and Y1 crystals (sub-0.05mm spacing) that
+    the previous heuristic could not handle.
+
+    Args:
+        comp_pads: List of Pad objects belonging to the component.
+        coarse_resolution: The coarse global grid resolution in mm.  The
+            chosen fine resolution will be strictly finer than this (a
+            fine zone at the coarse resolution would be redundant).
+        min_fine_resolution: Floor for the fine grid resolution (mm).
+            Below this, the candidate is rejected as impractical.
+
+    Returns:
+        Tuple of (fine_resolution_mm, x_offset_mm, y_offset_mm).  When the
+        component has fewer than 2 pads, returns
+        ``(min_fine_resolution, 0.0, 0.0)`` as a conservative default.
+    """
+    if not comp_pads:
+        return (min_fine_resolution, 0.0, 0.0)
+
+    # Build candidate resolutions: fixed grid-fraction values plus
+    # GCD-derived candidates from this component's pad spacings.  Coarsest
+    # values come first so we prefer the cheapest fine zone that works.
+    fixed_candidates = [0.1, 0.05, 0.04, 0.025, 0.02, 0.0125, 0.01]
+    gcd_candidates = _compute_gcd_grid_candidates(comp_pads, min_grid=min_fine_resolution)
+    raw_candidates = sorted(
+        {round(c, 6) for c in (fixed_candidates + gcd_candidates)},
+        reverse=True,
+    )
+
+    # Keep only candidates strictly finer than the coarse grid and at or
+    # above the minimum floor.  A fine zone at >= coarse_resolution would
+    # not refine anything (the coarse grid would suffice).
+    candidates = [
+        c for c in raw_candidates
+        if c < coarse_resolution and c >= min_fine_resolution
+    ]
+
+    if not candidates:
+        # Fall back to half the coarse grid floored at the minimum.  This
+        # preserves the legacy behaviour when the component genuinely
+        # can't be refined below the coarse grid.
+        return (max(coarse_resolution / 2.0, min_fine_resolution), 0.0, 0.0)
+
+    total = len(comp_pads)
+
+    # Walk candidates coarsest -> finest, returning the first (R, O) that
+    # places *all* of the component's pads on-grid.  This minimises the
+    # fine zone's cell count while still being pad-position-aware.
+    best_finest: tuple[float, float, float, int] | None = None
+    for res in candidates:
+        offset = _find_optimal_origin_offset(comp_pads, res)
+        off_grid = _count_off_grid_with_offset(comp_pads, res, offset[0], offset[1])
+        if off_grid == 0:
+            return (res, offset[0], offset[1])
+        # Track best-effort fallback (lowest off-grid count, prefer coarser
+        # at equal off-grid count).
+        if best_finest is None or off_grid < best_finest[3]:
+            best_finest = (res, offset[0], offset[1], off_grid)
+
+    # No candidate achieved 0 off-grid; return the best-effort result.
+    if best_finest is not None:
+        return (best_finest[0], best_finest[1], best_finest[2])
+
+    # Defensive fallback (should be unreachable given the candidate list).
+    return (min_fine_resolution, 0.0, 0.0)
+
+
 def auto_select_grid_resolution(
     pads: list[Pad] | list[PadPosition] | dict[tuple[str, str], Pad],
     clearance: float,
@@ -1032,17 +1130,19 @@ def compute_multi_resolution_plan(
     zone_padding: float = 2.0,
     min_fine_resolution: float = 0.05,
     fine_pitch_threshold: float = 0.8,
-    off_grid_escalation_threshold: float = 50.0,
+    off_grid_escalation_threshold: float = 10.0,
+    min_off_grid_pads_to_escalate: int = 2,
+    min_escalation_fine_resolution: float = 0.005,
 ) -> MultiResolutionGridPlan | None:
     """Compute a multi-resolution grid plan for adaptive routing.
 
     Analyzes pad positions to determine if a multi-resolution approach is
     beneficial. Returns a plan with coarse global grid and per-component
     fine zones when fine-pitch components are detected OR when the uniform
-    grid leaves a high percentage of pads off-grid.
+    grid leaves any structurally-significant cluster of pads off-grid.
 
-    Returns None if all components are coarse-pitch and off-grid percentage
-    is acceptable (uniform grid is optimal).
+    Returns None if all components are coarse-pitch and the uniform grid
+    already places every pad on-grid (uniform grid is optimal).
 
     Args:
         pads: Pad objects or positions
@@ -1051,12 +1151,26 @@ def compute_multi_resolution_plan(
         board_height: Board height in mm
         max_cells: Maximum total cell budget across all zones
         zone_padding: Padding around component bbox for fine zones (mm)
-        min_fine_resolution: Minimum fine grid resolution floor (mm)
+        min_fine_resolution: Minimum fine grid resolution floor (mm) for
+            the fine-pitch path.  Default 0.05mm avoids generating absurdly
+            fine zones for on-grid fine-pitch components (e.g. TQFP-32
+            with 0.8mm pitch already at 0.1mm-aligned positions).
         fine_pitch_threshold: Pitch below this triggers fine-grid zone
-        off_grid_escalation_threshold: When off-grid percentage exceeds this
-            value after origin-offset optimization, automatically create
-            escape zones for off-grid pad clusters even if they are not
-            fine-pitch.  Default 50.0%.
+        off_grid_escalation_threshold: When off-grid percentage exceeds
+            this value after origin-offset optimization, escape zones are
+            created for off-grid pad clusters even if they are not
+            fine-pitch.  Default 10.0% (lowered from 50.0% in #2837 so
+            small-but-real off-grid clusters like USB-C half-grid pads
+            and crystals are caught instead of warned-about).
+        min_off_grid_pads_to_escalate: Absolute floor on the number of
+            off-grid pads required to trigger escalation independent of
+            the percentage threshold.  Prevents spurious bumps from a
+            single mis-snapped pad while still catching small clusters
+            (e.g. a 2-pad crystal off by 0.010mm).  Default 2.
+        min_escalation_fine_resolution: Floor for the escalation path's
+            fine resolution (mm).  Lower than ``min_fine_resolution`` so
+            the solver can find a (resolution, offset) that aligns
+            sub-0.05mm pad coordinates (issue #2837).  Default 0.005mm.
 
     Returns:
         MultiResolutionGridPlan if fine-pitch components detected or
@@ -1098,14 +1212,22 @@ def compute_multi_resolution_plan(
         fine_pitch_threshold=fine_pitch_threshold,
     )
 
-    # Escalation: when off-grid percentage is still high after origin-offset
-    # optimization, identify off-grid pad clusters and create escape zones
-    # for them even if they are not fine-pitch.  This handles mixed
-    # metric/imperial boards where no single uniform grid works.
-    if (
-        uniform_result.off_grid_percentage >= off_grid_escalation_threshold
-        and has_ref
-    ):
+    # Escalation: when the uniform grid still leaves any meaningful cluster
+    # of pads off-grid after origin-offset optimisation, create escape zones
+    # for the off-grid components -- even if they are not fine-pitch in the
+    # min-pad-pitch sense.  This handles mixed metric/imperial boards, USB-C
+    # half-grid pads, and crystals whose pad positions don't divide evenly
+    # into any common coarse grid (issue #2837).
+    #
+    # The escalation fires when EITHER:
+    #   - the off-grid percentage exceeds ``off_grid_escalation_threshold``,
+    #     OR
+    #   - the absolute off-grid pad count is at or above
+    #     ``min_off_grid_pads_to_escalate``.
+    # The threshold path catches large clusters; the absolute floor catches
+    # small but structurally-critical components (e.g. a 2-pad crystal).
+    pad_position_offsets: dict[str, tuple[float, float]] = {}
+    if has_ref and uniform_result.off_grid_pads > 0:
         # Find components with off-grid pads at the chosen resolution+offset
         off_grid_refs: dict[str, list] = {}
         offset = uniform_result.origin_offset
@@ -1120,32 +1242,42 @@ def compute_multi_resolution_plan(
                     off_grid_refs[ref] = []
                 off_grid_refs[ref].append(pad)
 
-        # Add these components as needing fine-grid zones (if not already)
-        for ref, ref_pads in off_grid_refs.items():
-            if ref not in fine_components:
-                # Use a resolution that divides into the component's pad pitch
-                xs = sorted({p.x for p in ref_pads})
-                ys = sorted({p.y for p in ref_pads})
-                deltas = []
-                for coords in (xs, ys):
-                    for i in range(1, len(coords)):
-                        d = coords[i] - coords[i - 1]
-                        if d > 0.001:
-                            deltas.append(d)
-                if deltas:
-                    # Pick a resolution that divides the smallest delta
-                    min_delta = min(deltas)
-                    # Use pitch/10 or min_fine_resolution, whichever is larger
-                    fine_res = max(min_delta / 10.0, min_fine_resolution)
-                    fine_components[ref] = fine_res
-
-        logger.info(
-            "Off-grid escalation: %.1f%% pads off-grid at %.3fmm, "
-            "creating escape zones for %d components",
-            uniform_result.off_grid_percentage,
-            coarse_resolution,
-            len(off_grid_refs),
+        # Decide whether the escalation actually fires.  We escalate if the
+        # percentage threshold is exceeded OR if the absolute off-grid pad
+        # count meets the minimum cluster size.  Both gates together prevent
+        # spurious escalation on boards whose pads are already aligned
+        # (uniform_result.off_grid_pads == 0 short-circuits above).
+        should_escalate = (
+            uniform_result.off_grid_percentage >= off_grid_escalation_threshold
+            or uniform_result.off_grid_pads >= min_off_grid_pads_to_escalate
         )
+
+        if should_escalate and off_grid_refs:
+            # Add these components as needing fine-grid zones (if not already)
+            # using the pad-position-aware solver introduced in #2837.  For
+            # each off-grid component we pick the coarsest fine resolution
+            # plus an origin offset that puts ALL of its pads on-grid.
+            for ref, ref_pads in off_grid_refs.items():
+                fine_res, x_off, y_off = _compute_zone_resolution_and_offset(
+                    ref_pads,
+                    coarse_resolution=coarse_resolution,
+                    min_fine_resolution=min_escalation_fine_resolution,
+                )
+                # The new solver supersedes any heuristic value that
+                # identify_fine_pitch_components produced earlier -- it
+                # actually checks pad-position alignment.
+                fine_components[ref] = fine_res
+                pad_position_offsets[ref] = (x_off, y_off)
+
+            logger.info(
+                "Off-grid escalation: %d/%d pads (%.1f%%) off-grid at "
+                "%.3fmm coarse; creating fine zones for %d component(s)",
+                uniform_result.off_grid_pads,
+                uniform_result.total_pads,
+                uniform_result.off_grid_percentage,
+                coarse_resolution,
+                len(off_grid_refs),
+            )
 
     if not fine_components:
         # No fine-pitch components and off-grid is acceptable
@@ -1174,9 +1306,24 @@ def compute_multi_resolution_plan(
         x_max = max(xs) + zone_padding
         y_max = max(ys) + zone_padding
 
-        # Fine resolution for this component
+        # Fine resolution for this component.  Escalation components use
+        # the lower ``min_escalation_fine_resolution`` floor so the solver
+        # can express the sub-0.05mm grids needed for half-grid USB-C and
+        # crystal pads (issue #2837).  Plain fine-pitch components keep the
+        # higher ``min_fine_resolution`` floor that avoids absurdly fine
+        # zones for on-grid SOIC/TSSOP/QFP packages.
         fine_res = fine_components[ref]
-        fine_res = max(fine_res, min_fine_resolution)
+        if ref in pad_position_offsets:
+            fine_res = max(fine_res, min_escalation_fine_resolution)
+        else:
+            fine_res = max(fine_res, min_fine_resolution)
+
+        # Per-zone origin offset.  If the escalation branch produced a
+        # pad-position-aware (resolution, offset) tuple, use it.  Otherwise
+        # default to (0, 0) which matches the legacy behaviour for plain
+        # fine-pitch components whose pad positions already align to a
+        # zero-origin fine grid (TSSOP, SOIC, etc.).
+        x_off, y_off = pad_position_offsets.get(ref, (0.0, 0.0))
 
         fine_zones.append(FineZone(
             ref=ref,
@@ -1185,6 +1332,8 @@ def compute_multi_resolution_plan(
             x_max=x_max,
             y_max=y_max,
             resolution=fine_res,
+            x_offset=x_off,
+            y_offset=y_off,
         ))
 
     if not fine_zones:

--- a/src/kicad_tools/router/subgrid.py
+++ b/src/kicad_tools/router/subgrid.py
@@ -573,11 +573,30 @@ class SubGridRouter:
         Returns:
             Fine resolution in mm, or None if the pad is outside all fine zones.
         """
-        best: float | None = None
+        zone = self._get_pad_fine_zone(pad)
+        return zone.resolution if zone is not None else None
+
+    def _get_pad_fine_zone(self, pad: Pad) -> "FineZone | None":
+        """Return the finest FineZone containing the pad, or None.
+
+        When a pad falls inside multiple zones (overlapping fine zones from
+        nearby components), the one with the smallest ``resolution`` wins
+        so the densest grid drives escape candidate generation.  Unlike
+        :meth:`_get_pad_fine_resolution`, this returns the full zone so
+        callers can also use its origin offsets (issue #2837).
+
+        Args:
+            pad: The pad to check.
+
+        Returns:
+            The finest containing FineZone, or None if the pad is outside
+            every fine zone.
+        """
+        best: "FineZone | None" = None
         for zone in self.fine_zones:
             if zone.contains(pad.x, pad.y):
-                if best is None or zone.resolution < best:
-                    best = zone.resolution
+                if best is None or zone.resolution < best.resolution:
+                    best = zone
         return best
 
     def _generate_fine_grid_candidates(
@@ -634,16 +653,41 @@ class SubGridRouter:
                 extended_mm = max(min_search_mm, pad_pitch * 2)
                 fine_radius = max(fine_radius, math.ceil(extended_mm / fine_resolution))
 
-        # The fine grid is centred on the pad's nearest coarse-grid point
-        # (sgp.snap_x, sgp.snap_y) and extends ``fine_radius`` fine cells
-        # in each direction.
+        # Determine the fine-grid origin.  Historically the fine grid was
+        # centred on the pad's nearest coarse-grid point (sgp.snap_x,
+        # sgp.snap_y).  For pad-position-aware fine zones (issue #2837),
+        # the FineZone may carry an explicit (x_offset, y_offset) that aligns
+        # the fine grid with the component's actual pad positions.  In that
+        # case we anchor candidates to the nearest fine-grid point that
+        # satisfies ``x = x_offset + k * fine_resolution`` (and similarly for
+        # y), so candidate columns include the pad's own coordinate even
+        # when the coarse grid does not.
+        zone = self._get_pad_fine_zone(pad)
+        if zone is not None and (zone.x_offset != 0.0 or zone.y_offset != 0.0):
+            # Snap the centre to the fine grid defined by (x_offset, y_offset).
+            anchor_x = (
+                zone.x_offset
+                + round((sgp.snap_x - zone.x_offset) / fine_resolution)
+                * fine_resolution
+            )
+            anchor_y = (
+                zone.y_offset
+                + round((sgp.snap_y - zone.y_offset) / fine_resolution)
+                * fine_resolution
+            )
+        else:
+            anchor_x = sgp.snap_x
+            anchor_y = sgp.snap_y
+
+        # The fine grid extends ``fine_radius`` fine cells in each direction
+        # around the anchor point.
         candidates: list[tuple[float, int, int, float, float]] = []
 
         for dy in range(-fine_radius, fine_radius + 1):
             for dx in range(-fine_radius, fine_radius + 1):
                 # Fine-grid candidate in world coordinates
-                fx = sgp.snap_x + dx * fine_resolution
-                fy = sgp.snap_y + dy * fine_resolution
+                fx = anchor_x + dx * fine_resolution
+                fy = anchor_y + dy * fine_resolution
 
                 # Distance from pad center to this fine-grid point
                 dist = math.sqrt((pad.x - fx) ** 2 + (pad.y - fy) ** 2)

--- a/tests/test_router_grid_auto_bump.py
+++ b/tests/test_router_grid_auto_bump.py
@@ -1,0 +1,477 @@
+"""Tests for pad-position-aware grid auto-bump (issue #2837).
+
+This module validates the multi-resolution grid plan's ability to handle
+off-grid pad clusters that the uniform-grid selector cannot resolve due
+to memory caps.  Board 03 (USB joystick) was the motivating case:
+
+- Board is 80x60mm, so 0.01mm uniform grid would need 48M cells (way over
+  the 500k cap in ``auto_select_grid_resolution``).
+- The memory cap forces 0.1mm uniform, which leaves 36/87 pads off-grid
+  (J1 USB-C on half-grid, U1 TQFP on half-grid, Y1 crystal at sub-0.05mm
+  offsets, several passives at 0.05mm half-grid).
+- The pre-#2837 plan only added fine zones for J1 (USB-C) and U1 (TQFP)
+  because Y1's 4.88mm pitch fell above the 0.8mm ``fine_pitch_threshold``
+  AND the off-grid escalation threshold of 50% never fired (41.4% < 50%).
+
+This test file verifies the structural fix:
+
+1. Synthetic 80x60mm board with a TQFP-32 at half-grid offsets, an HC49-U
+   crystal at 2.44mm half-pitch, and a few on-grid resistors -- the plan
+   includes fine zones with appropriate (resolution, offset) pairs.
+2. On-grid-only board -- no fine zones, no spurious bumps.
+3. Telemetry is emitted when escalation fires.
+
+Issue #2837 (subsumes #2387's half-completed work).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from kicad_tools.router.io import (
+    FineZone,
+    MultiResolutionGridPlan,
+    _compute_zone_resolution_and_offset,
+    _count_off_grid_with_offset,
+    _is_on_grid_with_offset,
+    auto_select_grid_resolution,
+    compute_multi_resolution_plan,
+)
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.primitives import Pad
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pad(
+    x: float,
+    y: float,
+    ref: str,
+    pin: str,
+    net: int = 1,
+    width: float = 0.3,
+    height: float = 0.6,
+    through_hole: bool = False,
+) -> Pad:
+    """Construct a Pad with the bare minimum for grid analysis."""
+    return Pad(
+        x=x,
+        y=y,
+        width=width,
+        height=height,
+        net=net,
+        net_name=f"N{net}",
+        ref=ref,
+        pin=pin,
+        layer=Layer.F_CU,
+        through_hole=through_hole,
+    )
+
+
+def _tqfp32_pads(
+    cx: float,
+    cy: float,
+    pitch: float = 0.8,
+    ref: str = "U1",
+) -> list[Pad]:
+    """Generate 32 pads in a QFP-32 ring (8 pads per side).
+
+    Pads are placed symmetrically around (cx, cy) so the corner pad
+    offsets from cx/cy are at +/- 3.5*pitch = +/-2.8mm (for 0.8mm pitch).
+    """
+    pads: list[Pad] = []
+    n_per_side = 8
+    half = (n_per_side - 1) * pitch / 2.0
+    # Body half-width / half-height: place pads ~3mm out from cx/cy along
+    # the perpendicular axis.
+    body_half = 3.0
+
+    for i in range(n_per_side):
+        # Left side: x = cx - body_half, y varies
+        y = cy - half + i * pitch
+        pads.append(_make_pad(cx - body_half, y, ref, f"{1 + i}"))
+    for i in range(n_per_side):
+        # Bottom side: y = cy + body_half, x varies
+        x = cx - half + i * pitch
+        pads.append(_make_pad(x, cy + body_half, ref, f"{9 + i}"))
+    for i in range(n_per_side):
+        # Right side: x = cx + body_half
+        y = cy + half - i * pitch
+        pads.append(_make_pad(cx + body_half, y, ref, f"{17 + i}"))
+    for i in range(n_per_side):
+        # Top side: y = cy - body_half
+        x = cx + half - i * pitch
+        pads.append(_make_pad(x, cy - body_half, ref, f"{25 + i}"))
+    return pads
+
+
+def _hc49_crystal_pads(
+    cx: float,
+    cy: float,
+    pitch: float = 4.88,
+    ref: str = "Y1",
+) -> list[Pad]:
+    """Generate two crystal pads at +/- pitch/2 from cx along x."""
+    return [
+        _make_pad(cx - pitch / 2.0, cy, ref, "1",
+                  width=1.4, height=1.4, through_hole=True),
+        _make_pad(cx + pitch / 2.0, cy, ref, "2",
+                  width=1.4, height=1.4, through_hole=True),
+    ]
+
+
+def _on_grid_resistor_pads(
+    cx: float,
+    cy: float,
+    pitch: float = 1.0,
+    ref: str = "R1",
+) -> list[Pad]:
+    """Generate 0805-style resistor with two pads at +/- pitch/2."""
+    return [
+        _make_pad(cx - pitch / 2.0, cy, ref, "1", width=1.0, height=1.25),
+        _make_pad(cx + pitch / 2.0, cy, ref, "2", width=1.0, height=1.25),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputeZoneResolutionAndOffset:
+    """Tests for the per-component (resolution, offset) solver."""
+
+    def test_on_grid_component_picks_coarsest_finer_than_coarse(self):
+        """A component whose pads are on a 0.05mm grid prefers 0.05mm."""
+        # 4 pads at x = 10, 11, 12, 13; y = 5 (all multiples of 0.05)
+        pads = [_make_pad(10.0 + i, 5.0, "R1", str(i + 1)) for i in range(4)]
+        res, x_off, y_off = _compute_zone_resolution_and_offset(
+            pads, coarse_resolution=0.1, min_fine_resolution=0.005,
+        )
+        # The coarsest fine grid finer than 0.1mm that aligns is 0.05mm.
+        assert res == 0.05
+        assert (x_off, y_off) == (0.0, 0.0)
+
+    def test_half_grid_pads_use_offset(self):
+        """Pads at half-grid use 0.05mm with no offset (50.025mm % 0.05 = 0.025)."""
+        # USB-C-style pads at x = 137.250 (10x exact for 0.05mm: 2745.0)
+        pads = [
+            _make_pad(137.250, 100.0, "J1", "1"),
+            _make_pad(137.750, 100.0, "J1", "2"),
+            _make_pad(138.250, 100.0, "J1", "3"),
+        ]
+        res, x_off, y_off = _compute_zone_resolution_and_offset(
+            pads, coarse_resolution=0.1, min_fine_resolution=0.005,
+        )
+        # 137.250 % 0.05 = 0 (250.5 = exact 250 in float terms within
+        # threshold). 0.05 should be chosen at offset (0, 0).
+        assert res == 0.05
+        # All pads must be on the chosen (res, offset) grid:
+        for p in pads:
+            assert _is_on_grid_with_offset(p.x, res, x_off)
+            assert _is_on_grid_with_offset(p.y, res, y_off)
+
+    def test_crystal_at_sub_005mm_offsets(self):
+        """HC49-U crystal at x=152.560, 157.440 (delta 4.88) needs finer than 0.05mm."""
+        pads = _hc49_crystal_pads(155.0, 100.0)
+        # Reset x positions to the literal trace from board 03:
+        pads[0].x = 152.560
+        pads[1].x = 157.440
+        res, x_off, y_off = _compute_zone_resolution_and_offset(
+            pads, coarse_resolution=0.1, min_fine_resolution=0.005,
+        )
+        # All pads must land on the chosen grid+offset.
+        off_count = _count_off_grid_with_offset(pads, res, x_off, y_off)
+        assert off_count == 0, (
+            f"Expected 0 off-grid, got {off_count} at res={res}, offset=({x_off},{y_off})"
+        )
+        # Resolution should be strictly finer than the coarse grid.
+        assert res < 0.1
+
+    def test_floors_at_min_fine_resolution(self):
+        """No candidate below ``min_fine_resolution`` is returned."""
+        pads = [
+            _make_pad(152.560, 100.0, "Y1", "1"),
+            _make_pad(157.440, 100.0, "Y1", "2"),
+        ]
+        # With a generous floor (0.05mm), the solver may fall back to a
+        # best-effort resolution rather than 0.005mm.  Verify the result
+        # is at or above the floor.
+        res, _, _ = _compute_zone_resolution_and_offset(
+            pads, coarse_resolution=0.1, min_fine_resolution=0.05,
+        )
+        # If 0.05mm can't cover both pads, the solver still returns >= 0.05
+        # (the lower-bound candidate filter).
+        assert res >= 0.05
+
+    def test_empty_component_returns_floor(self):
+        """An empty pad list returns the min_fine_resolution and zero offsets."""
+        res, x, y = _compute_zone_resolution_and_offset(
+            [], coarse_resolution=0.1, min_fine_resolution=0.025,
+        )
+        assert (res, x, y) == (0.025, 0.0, 0.0)
+
+
+class TestSyntheticOffGridBoard:
+    """Synthetic 80x60mm board mirroring the board 03 problem.
+
+    The fixture mixes pads with INCOMPATIBLE origin offsets so the global
+    origin-offset optimiser in ``auto_select_grid_resolution`` cannot
+    absorb both -- forcing the off-grid escalation branch to fire.
+
+    - Many on-grid resistors anchor the global offset to (0, 0).
+    - A TQFP-32 is placed at half-grid offsets (corner pad at 17.225,
+      17.225), so it is off-grid against any (0, 0)-origin 0.1mm grid.
+    - An HC49-U crystal has sub-0.05mm pad spacings (pitch 4.88mm with
+      the centre placed at 50.0, giving pads at 47.560 and 52.440), so
+      it is off-grid against ANY 0.05mm uniform grid regardless of offset.
+    """
+
+    @pytest.fixture
+    def synthetic_pads(self) -> list[Pad]:
+        pads: list[Pad] = []
+        # TQFP-32 at half-grid offset.  Corner pad at (17.225, 17.225)
+        # which is 0.05mm-aligned but NOT 0.1mm-aligned at any single
+        # offset that also aligns the resistor pads.
+        pads.extend(_tqfp32_pads(cx=20.025, cy=20.025, pitch=0.8, ref="U1"))
+        # HC49-U crystal at sub-0.05mm half-pitch
+        pads.extend(_hc49_crystal_pads(cx=50.0, cy=30.0, pitch=4.88, ref="Y1"))
+        # Plenty of on-grid resistors (anchor the global offset to 0).
+        for i in range(8):
+            pads.extend(_on_grid_resistor_pads(
+                cx=5.0 + i * 5.0, cy=50.0, pitch=1.0, ref=f"R{i + 1}",
+            ))
+            pads.extend(_on_grid_resistor_pads(
+                cx=5.0 + i * 5.0, cy=55.0, pitch=1.0, ref=f"R{i + 10}",
+            ))
+        return pads
+
+    def test_uniform_grid_leaves_offgrid_pads(self, synthetic_pads):
+        """At 0.1mm memory-capped, the synthetic board has off-grid pads."""
+        result = auto_select_grid_resolution(
+            synthetic_pads,
+            clearance=0.15,
+            board_width=80.0,
+            board_height=60.0,
+        )
+        # The selector picks the coarsest grid that minimises off-grid count.
+        # U1 + Y1 should leave a meaningful off-grid residue at any 0.1mm
+        # grid (32 + 2 = 34 pads off the 0.1mm grid).
+        assert result.off_grid_pads > 0
+        assert result.resolution >= 0.05
+
+    def test_multi_resolution_plan_covers_offgrid_components(
+        self, synthetic_pads,
+    ):
+        """The plan must include fine zones for U1 AND Y1 with valid (R, O)."""
+        plan = compute_multi_resolution_plan(
+            pads=synthetic_pads,
+            clearance=0.15,
+            board_width=80.0,
+            board_height=60.0,
+        )
+        assert plan is not None
+        assert plan.is_multi_resolution
+
+        zones_by_ref = {z.ref: z for z in plan.fine_zones}
+        # Both off-grid components must have fine zones.
+        assert "U1" in zones_by_ref, (
+            f"U1 missing from fine zones: {sorted(zones_by_ref.keys())}"
+        )
+        assert "Y1" in zones_by_ref, (
+            f"Y1 missing from fine zones: {sorted(zones_by_ref.keys())}"
+        )
+
+        # Each zone's (resolution, offset) must place ALL of that
+        # component's pads on-grid.
+        for ref in ("U1", "Y1"):
+            zone = zones_by_ref[ref]
+            comp_pads = [p for p in synthetic_pads if p.ref == ref]
+            off = _count_off_grid_with_offset(
+                comp_pads, zone.resolution, zone.x_offset, zone.y_offset,
+            )
+            assert off == 0, (
+                f"{ref} fine zone @ {zone.resolution}mm offset="
+                f"({zone.x_offset},{zone.y_offset}) leaves {off}/{len(comp_pads)} "
+                "off-grid"
+            )
+
+    def test_plan_within_cell_budget(self, synthetic_pads):
+        """Total cell estimate stays under the 2M default budget."""
+        plan = compute_multi_resolution_plan(
+            pads=synthetic_pads,
+            clearance=0.15,
+            board_width=80.0,
+            board_height=60.0,
+            max_cells=2_000_000,
+        )
+        assert plan is not None
+        assert plan.total_cell_estimate < 2_000_000
+
+
+class TestOnGridBoardNoSpuriousBump:
+    """Regression guard: an already-aligned board must not get fine zones."""
+
+    def test_on_grid_resistors_only_produces_no_plan(self):
+        """50x50mm board with on-grid 0805 resistors -> plan is None."""
+        pads: list[Pad] = []
+        for i in range(8):
+            pads.extend(_on_grid_resistor_pads(
+                cx=10.0 + i * 5.0, cy=10.0, pitch=1.0, ref=f"R{i + 1}",
+            ))
+            pads.extend(_on_grid_resistor_pads(
+                cx=10.0 + i * 5.0, cy=20.0, pitch=1.0, ref=f"R{i + 10}",
+            ))
+
+        # Sanity: the selector finds a perfect grid.
+        u = auto_select_grid_resolution(
+            pads, clearance=0.15, board_width=50.0, board_height=50.0,
+        )
+        assert u.off_grid_pads == 0
+
+        plan = compute_multi_resolution_plan(
+            pads=pads,
+            clearance=0.15,
+            board_width=50.0,
+            board_height=50.0,
+        )
+        assert plan is None, (
+            f"Expected None (uniform is optimal) but got plan with "
+            f"{len(plan.fine_zones) if plan else 0} fine zones"
+        )
+
+
+class TestEscalationTelemetry:
+    """Telemetry / logging contract."""
+
+    def test_escalation_logs_off_grid_summary(self, synthetic_pads_factory, caplog):
+        """When escalation fires, an INFO-level log entry is emitted."""
+        # synthetic board with off-grid pads
+        pads = synthetic_pads_factory()
+        with caplog.at_level(logging.INFO, logger="kicad_tools.router.io"):
+            plan = compute_multi_resolution_plan(
+                pads=pads,
+                clearance=0.15,
+                board_width=80.0,
+                board_height=60.0,
+            )
+        assert plan is not None and plan.is_multi_resolution
+
+        # Find the escalation log entry
+        matching = [
+            r for r in caplog.records
+            if "Off-grid escalation" in r.getMessage()
+        ]
+        assert matching, (
+            "Expected an 'Off-grid escalation' log entry but found none. "
+            f"Records: {[r.getMessage() for r in caplog.records]}"
+        )
+
+
+@pytest.fixture
+def synthetic_pads_factory():
+    """Reusable factory for the synthetic 80x60mm board fixture."""
+
+    def _factory() -> list[Pad]:
+        pads: list[Pad] = []
+        pads.extend(_tqfp32_pads(cx=20.025, cy=20.025, pitch=0.8, ref="U1"))
+        pads.extend(_hc49_crystal_pads(cx=50.0, cy=30.0, pitch=4.88, ref="Y1"))
+        for i in range(8):
+            pads.extend(_on_grid_resistor_pads(
+                cx=5.0 + i * 5.0, cy=50.0, pitch=1.0, ref=f"R{i + 1}",
+            ))
+            pads.extend(_on_grid_resistor_pads(
+                cx=5.0 + i * 5.0, cy=55.0, pitch=1.0, ref=f"R{i + 10}",
+            ))
+        return pads
+
+    return _factory
+
+
+class TestFineZoneOffsetFields:
+    """FineZone backwards-compatibility for the new offset fields."""
+
+    def test_offsets_default_to_zero(self):
+        """Old constructor signature (no offsets) still works."""
+        zone = FineZone(
+            ref="U1", x_min=0.0, y_min=0.0,
+            x_max=10.0, y_max=10.0, resolution=0.05,
+        )
+        assert zone.x_offset == 0.0
+        assert zone.y_offset == 0.0
+
+    def test_offsets_accepted_explicitly(self):
+        """New constructor with explicit offsets stores them."""
+        zone = FineZone(
+            ref="U1", x_min=0.0, y_min=0.0,
+            x_max=10.0, y_max=10.0, resolution=0.05,
+            x_offset=0.025, y_offset=0.025,
+        )
+        assert zone.x_offset == 0.025
+        assert zone.y_offset == 0.025
+
+
+class TestSubGridUsesZoneOffset:
+    """SubGridRouter must anchor fine-grid candidates to the zone offset."""
+
+    def test_fine_grid_candidates_align_to_offset(self):
+        """When a zone carries (x_offset, y_offset), candidate points
+        fall on ``x_offset + k * fine_resolution`` (and similarly for y).
+        """
+        from kicad_tools.router.grid import RoutingGrid
+        from kicad_tools.router.rules import DesignRules
+        from kicad_tools.router.subgrid import SubGridPad, SubGridRouter
+
+        rules = DesignRules(
+            grid_resolution=0.1, trace_width=0.15, trace_clearance=0.1,
+        )
+        grid = RoutingGrid(width=20.0, height=20.0, rules=rules)
+
+        # Place an off-grid pad at (10.025, 10.025)
+        pad = _make_pad(10.025, 10.025, "U1", "1", net=1)
+        grid.add_pad(pad)
+
+        # Fine zone covering the pad with explicit offset (0.025, 0.025)
+        zone = FineZone(
+            ref="U1", x_min=9.0, y_min=9.0,
+            x_max=11.0, y_max=11.0,
+            resolution=0.05,
+            x_offset=0.025, y_offset=0.025,
+        )
+
+        router = SubGridRouter(grid, rules, fine_zones=[zone])
+
+        # Sanity: zone lookup works
+        assert router._get_pad_fine_zone(pad) is zone
+        assert router._get_pad_fine_resolution(pad) == 0.05
+
+        # Walk an analysis: ensure the fine-grid candidate generation
+        # actually uses the zone's offset.  We don't need the full router
+        # execution -- we just need to verify the anchor logic produces
+        # at least one candidate whose snap point falls on
+        # ``x_offset + k * fine_resolution``.
+        analysis = router.analyze_pads([pad])
+        assert analysis.has_off_grid_pads
+        sgp = analysis.off_grid_pads[0]
+
+        candidates = router._generate_fine_grid_candidates(sgp, 0.05)
+        assert candidates, "expected at least one fine-grid candidate"
+
+        # Every candidate's (snap_x, snap_y) must satisfy the zone offset.
+        threshold = 0.05 / 10  # _is_on_grid default threshold
+        for _, _, _, snap_x, snap_y in candidates:
+            sx_residue = (snap_x - zone.x_offset) % 0.05
+            sx_residue = min(sx_residue, 0.05 - sx_residue)
+            sy_residue = (snap_y - zone.y_offset) % 0.05
+            sy_residue = min(sy_residue, 0.05 - sy_residue)
+            assert sx_residue <= threshold, (
+                f"snap_x={snap_x} not on offset grid (residue={sx_residue})"
+            )
+            assert sy_residue <= threshold, (
+                f"snap_y={snap_y} not on offset grid (residue={sy_residue})"
+            )

--- a/tests/test_router_grid_auto_bump.py
+++ b/tests/test_router_grid_auto_bump.py
@@ -32,7 +32,6 @@ import pytest
 
 from kicad_tools.router.io import (
     FineZone,
-    MultiResolutionGridPlan,
     _compute_zone_resolution_and_offset,
     _count_off_grid_with_offset,
     _is_on_grid_with_offset,
@@ -41,7 +40,6 @@ from kicad_tools.router.io import (
 )
 from kicad_tools.router.layers import Layer
 from kicad_tools.router.primitives import Pad
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -425,7 +423,7 @@ class TestSubGridUsesZoneOffset:
         """
         from kicad_tools.router.grid import RoutingGrid
         from kicad_tools.router.rules import DesignRules
-        from kicad_tools.router.subgrid import SubGridPad, SubGridRouter
+        from kicad_tools.router.subgrid import SubGridRouter
 
         rules = DesignRules(
             grid_resolution=0.1, trace_width=0.15, trace_clearance=0.1,


### PR DESCRIPTION
## Summary

Implements pad-position-aware multi-resolution grid planning for the
autorouter so that off-grid pads from USB-C connectors, crystals, and
half-grid passives can be resolved with fine zones instead of failing
the ``pad_grid`` preflight.  Motivated by board 03 (USB joystick): the
memory cap clamps the uniform grid selector to 0.1mm, which leaves
36/87 pads off-grid (J1 USB-C half-grid, U1 TQFP half-grid, Y1 crystal
at 2.44mm half-pitch, several passives at 0.05mm half-grid).

Three structural changes:

1. ``FineZone`` carries explicit ``(x_offset, y_offset)`` so each zone's
   fine grid can be anchored to a component's pad positions instead of
   the world origin.
2. ``compute_multi_resolution_plan``'s off-grid escalation threshold
   drops from 50% to 10%, with an absolute floor (2 pads) so small but
   structurally-critical clusters like a 2-pad crystal trigger
   escalation.  Single-pad refs (e.g. mounting holes MH1-MH4 on board
   05) are explicitly skipped to preserve pre-#2837 zone counts.
3. A new helper ``_compute_zone_resolution_and_offset`` walks a
   candidate-resolution ladder (fixed values + GCD-derived from the
   component's pad spacings) and returns the coarsest (R, O) pair that
   places ALL of the component's pads on-grid.  Replaces the prior
   ``min_delta / 10`` heuristic that could not produce origin offsets.

``SubGridRouter._generate_fine_grid_candidates`` now anchors fine-grid
candidate generation to the zone's offset when present so the escape
endpoints align with the same grid the FineZone advertises.

## Relationship to #2387 (closed)

#2387 (PR #2393) shipped two of three pieces of the original auto-bump
fix:

- **Already shipped in #2387**: the candidate-filter relaxation
  (``c <= clearance/2`` -> ``c <= clearance``) and ``board_width`` /
  ``board_height`` plumbing through ``compute_multi_resolution_plan``.
- **What this PR adds**: pad-position-aware fine zones with origin
  offsets, the lower (10%) off-grid escalation threshold + absolute
  pad-count floor, the GCD-driven per-component (R, O) solver, and the
  broader fine-pitch escalation criteria that include crystals.  The
  memory-cap clamp itself in ``auto_select_grid_resolution`` is left
  alone — fine zones now compensate for it.

## Changes

- ``src/kicad_tools/router/io.py``
  - Extends ``FineZone`` with ``x_offset`` / ``y_offset`` (default 0.0)
  - Adds ``_compute_zone_resolution_and_offset`` (per-component solver)
  - ``compute_multi_resolution_plan``:
    - ``off_grid_escalation_threshold`` default lowered to 10.0
    - New ``min_off_grid_pads_to_escalate`` (default 2) absolute floor
    - New ``min_escalation_fine_resolution`` (default 0.005mm) sub-floor
      used only in the escalation path; fine-pitch path keeps the
      0.05mm floor to avoid absurdly fine zones for on-grid TSSOP/QFP
    - Skips single-pad refs in the escalation loop (no deltas =>
      nothing to refine; preserves zone count parity on boards 05/04)
    - Routes escalated refs through the new solver, populating zone
      offsets
  - ``MultiResolutionGridPlan.summary`` shows the zone offset when non-zero
- ``src/kicad_tools/router/subgrid.py``
  - Adds ``SubGridRouter._get_pad_fine_zone`` to look up the finest
    containing FineZone (including offsets)
  - ``_generate_fine_grid_candidates`` anchors candidates to
    ``(x_offset, y_offset)`` instead of the nearest coarse-grid point
    when a non-zero offset is present
- ``tests/test_router_grid_auto_bump.py`` (new, 13 tests)
  - Per-component solver across on-grid, half-grid, sub-0.05mm crystal,
    and floor-respecting cases
  - Synthetic 80x60mm board (TQFP half-grid + HC49 crystal + on-grid
    resistors) gets fine zones for U1 and Y1 with valid (R, O); cell
    count stays under 2M
  - On-grid-only board produces no plan (regression guard)
  - Off-grid escalation emits an INFO log entry
  - SubGridRouter candidates honour the zone offset

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Board 03 auto-grid logs the bump/multi-res decision | Passes | ``compute_multi_resolution_plan`` plan summary now lists Y1 (0.04mm) plus 12 other off-grid passives with explicit offsets; INFO log line emitted by escalation branch |
| 0 ``pad_grid`` warnings on routed PCB at chosen resolution | Plumbing already in place | Plan's per-zone (R, O) places every pad on-grid in unit tests; ``check_pad_grid_alignment`` already accepts ``grid_resolution`` parameter (deferred: defaulting it to router's chosen value from a routed PCB) |
| No regression on boards 01, 02, 04+ on already-aligned pads | Passes | On-grid-only synthetic board returns ``plan = None``.  Board-by-board sweep: 01/04/05/06/07 zone counts unchanged from main; 02 gains 1 zone (correct -- 02 has 7/34 off-grid that main's 50% threshold missed) |
| Synthetic regression test in ``tests/test_router_grid_auto_bump.py`` | Passes | New file: 13 tests covering all paths |
| ``kct check --warnings-only`` on input board 03 still warns | Unaffected | This PR doesn't change ``check_pad_grid_alignment`` -- the input remains genuinely off-grid; the router is the side that handles it |
| PR description references #2387's shipped vs. new work | Passes | See "Relationship to #2387" above |

## Test Plan

- ``uv run pytest tests/test_router_grid_auto_bump.py`` (13/13 pass)
- ``uv run pytest tests/test_adaptive_grid.py tests/test_grid_auto_selection.py tests/test_subgrid.py tests/test_pad_grid_preflight.py tests/test_off_grid_priority.py tests/test_route_auto_fix.py`` (498/498 pass)
- Board-by-board sweep on the seven in-tree boards: only boards 02 and
  03 see plan-set changes (intentional), the rest are byte-identical
  in zone count and cell estimate
- Cell budget: each board's plan stays under the 2M ``max_cells``
  default

## Deferred / out-of-scope

- The optional ``kct check`` default-grid plumbing called out in the
  issue's acceptance criteria (defaulting ``grid_resolution`` to the
  router's chosen value when invoked from the route pipeline).  The
  parameter exists; rerouting the default is a separate change.
- Broadening ``identify_fine_pitch_components`` is unnecessary because
  the lower escalation threshold + 2-pad floor now catches crystals
  via the off-grid path.

Closes #2837