### PR TITLE
fix(fix-drc): per-nudge granular rollback preserves non-regressing fixes

### DIFF
--- a/src/kicad_tools/cli/fix_drc_cmd.py
+++ b/src/kicad_tools/cli/fix_drc_cmd.py
@@ -41,6 +41,16 @@ class PassResult:
     connectivity_before: int | None = None
     connectivity_after: int | None = None
     connectivity_rolled_back: bool = False
+    # Per-nudge granular rollback metadata (issue #2851):
+    #   * ``reverted_uuids`` holds the UUIDs of nudges/actions that were
+    #     individually reverted (subset of all applied work this pass).
+    #   * ``connectivity_partial_rollback`` is ``True`` when only a
+    #     proper subset of nudges was reverted; ``connectivity_rolled_back``
+    #     remains the flag for a *full* rollback so existing consumers
+    #     (text rendering, JSON ``rolled_back`` field, exit code 3) keep
+    #     their semantics.
+    reverted_uuids: tuple[str, ...] = ()
+    connectivity_partial_rollback: bool = False
 
     @property
     def violations_after(self) -> int:
@@ -260,14 +270,22 @@ Examples:
                     f"violation(s) (edge clearance, dimension, silkscreen, etc.)"
                 )
 
-        # Snapshot and baseline connectivity before the repair pass
+        # Snapshot and baseline connectivity before the repair pass.
+        # Issue #2851: we record the full ConnectivityResult (when
+        # available) alongside the count so the post-pass rollback can
+        # attribute regressions to specific nets and undo only the
+        # offending subset of nudges.  The simple count is what the
+        # rollback *decision* is based on (preserving the legacy
+        # _count_connected_nets mock surface used by existing tests).
         snapshot: bytes | None = None
         baseline_conn: int | None = None
+        baseline_report = None
         if do_connectivity_check:
             load_for_snapshot = output_path if pass_num > 1 else pcb_path
             if load_for_snapshot.exists():
                 snapshot = load_for_snapshot.read_bytes()
                 baseline_conn = _count_connected_nets(load_for_snapshot)
+                baseline_report = _connectivity_report(load_for_snapshot)
 
         # Run single-pass repairs
         clearance_result, drill_result = _run_single_pass(
@@ -288,6 +306,8 @@ Examples:
         # Post-pass connectivity check and rollback
         after_conn: int | None = None
         rolled_back = False
+        partial_rolled_back = False
+        reverted_uuids: tuple[str, ...] = ()
         if (
             snapshot is not None
             and baseline_conn is not None
@@ -298,16 +318,54 @@ Examples:
         ):
             after_conn = _count_connected_nets(output_path)
             if after_conn >= 0 and after_conn < baseline_conn:
-                # Connectivity decreased -- rollback
-                output_path.write_bytes(snapshot)
-                rolled_back = True
-                connectivity_rollback_occurred = True
-                repaired_this_pass = 0
-                print(
-                    f"Warning: pass {pass_num} decreased connectivity "
-                    f"({baseline_conn} -> {after_conn} nets); rolled back.",
-                    file=sys.stderr,
+                # Connectivity decreased -- try granular rollback first.
+                after_report = _connectivity_report(output_path)
+                regressed = _regressed_nets(baseline_report, after_report)
+
+                reverted_all, kept_count, reverted_uuid_list = _attempt_granular_rollback(
+                    output_path=output_path,
+                    clearance_result=clearance_result,
+                    drill_result=drill_result,
+                    regressed=regressed,
+                    snapshot=snapshot,
+                    pass_number=pass_num,
                 )
+
+                if reverted_all:
+                    # Full bulk rollback (legacy behavior).  All applied
+                    # nudges were thrown away.
+                    rolled_back = True
+                    connectivity_rollback_occurred = True
+                    repaired_this_pass = 0
+                    print(
+                        f"Warning: pass {pass_num} decreased connectivity "
+                        f"({baseline_conn} -> {after_conn} nets); rolled back.",
+                        file=sys.stderr,
+                    )
+                else:
+                    # Partial granular rollback: ``kept_count`` nudges
+                    # survived, ``len(reverted_uuid_list)`` were reverted.
+                    partial_rolled_back = True
+                    reverted_uuids = tuple(reverted_uuid_list)
+                    reverted_count = len(reverted_uuid_list)
+                    repaired_this_pass = kept_count
+                    pre_undo_after = after_conn
+                    # Re-measure connectivity so the JSON/text output
+                    # reports the post-undo state, not the (worse)
+                    # pre-undo state.  This is one extra
+                    # ConnectivityValidator call -- still O(1) in N.
+                    new_after = _count_connected_nets(output_path)
+                    if new_after >= 0:
+                        after_conn = new_after
+                    print(
+                        f"Warning: pass {pass_num} initially decreased "
+                        f"connectivity ({baseline_conn} -> {pre_undo_after} nets); "
+                        f"reverted {reverted_count} of "
+                        f"{reverted_count + kept_count} nudge(s) on regressed "
+                        f"net(s) {sorted(regressed)!r}; "
+                        f"now {after_conn} connected net(s).",
+                        file=sys.stderr,
+                    )
 
         pass_results.append(
             PassResult(
@@ -320,6 +378,8 @@ Examples:
                 connectivity_before=baseline_conn,
                 connectivity_after=after_conn,
                 connectivity_rolled_back=rolled_back,
+                reverted_uuids=reverted_uuids,
+                connectivity_partial_rollback=partial_rolled_back,
             )
         )
 
@@ -465,6 +525,150 @@ def _count_connected_nets(pcb_path: Path) -> int:
         return -1
 
 
+def _connectivity_report(pcb_path: Path):
+    """Return the full :class:`ConnectivityResult` for a PCB, or ``None``.
+
+    Used by the granular rollback path in addition to
+    :func:`_count_connected_nets`: the count alone is enough to *decide*
+    whether to roll back, but the per-net ``issues`` list is required to
+    attribute the regression to specific nets and identify the offending
+    nudges.  Returning ``None`` on failure lets callers transparently
+    fall back to the bulk-snapshot rollback.
+    """
+    try:
+        from kicad_tools.validate.connectivity import ConnectivityValidator
+
+        validator = ConnectivityValidator(pcb_path)
+        return validator.validate()
+    except Exception:
+        return None
+
+
+def _regressed_nets(baseline, after) -> set[str]:
+    """Compute the set of nets that regressed between two ConnectivityResults.
+
+    A net is "regressed" if it was fully connected (no issue) in the
+    ``baseline`` result but is broken (has an entry in ``issues``) in the
+    ``after`` result.  Returns an empty set when either argument is
+    ``None`` -- callers treat that as "no per-net attribution available"
+    and fall back to a bulk rollback.
+    """
+    if baseline is None or after is None:
+        return set()
+    baseline_broken = {issue.net_name for issue in baseline.issues if issue.net_name}
+    after_broken = {issue.net_name for issue in after.issues if issue.net_name}
+    return after_broken - baseline_broken
+
+
+def _attempt_granular_rollback(
+    *,
+    output_path: Path,
+    clearance_result: RepairResult,
+    drill_result: DrillRepairResult,
+    regressed: set[str],
+    snapshot: bytes,
+    pass_number: int,
+) -> tuple[bool, int, list[str]]:
+    """Revert only the nudges that touched a regressed net.
+
+    Returns a 3-tuple ``(reverted_all, kept_count, reverted_uuids)``:
+
+    * ``reverted_all`` is ``True`` when every nudge was reverted (a true
+      full rollback, e.g. all nudges touched a regressed net or
+      attribution returned an empty offender set so the safety-net
+      fallback fired).
+    * ``kept_count`` is the number of nudges that remained applied
+      (``repaired_this_pass`` minus the reverted subset).
+    * ``reverted_uuids`` lists the UUIDs of nudges that were reverted via
+      the per-nudge undo path so the renderer can tag them
+      ``(reverted)``.
+
+    The function never re-routes the board: it edits the live S-exp tree
+    in memory and rewrites the file in a single ``save`` call, satisfying
+    the O(1)-extra-routing performance guard documented in the issue.
+
+    Falls back to the bulk-snapshot restore (and reports
+    ``reverted_all=True``) on any failure: empty ``regressed`` set, every
+    nudge implicated, per-nudge undo returning ``False``, or an exception
+    during the in-place edit.  In every fallback case the caller sees the
+    legacy "revert all" semantics.
+    """
+    nudges = list(clearance_result.nudges)
+    actions = list(drill_result.actions)
+    total = len(nudges) + len(actions)
+
+    # No nudges were applied this pass -- nothing to do.
+    if total == 0:
+        return (False, 0, [])
+
+    # Identify offenders by net_name membership.
+    offending_nudges = [n for n in nudges if n.net_name in regressed]
+    offending_actions = [a for a in actions if a.net_name in regressed]
+    offender_count = len(offending_nudges) + len(offending_actions)
+
+    # If we cannot attribute the regression to any specific nudge (e.g.
+    # empty regressed set, or no net_name match), fall back to a bulk
+    # restore.  This preserves the legacy "revert all" semantics whenever
+    # the granular path can't make a confident decision.
+    if offender_count == 0:
+        output_path.write_bytes(snapshot)
+        return (True, 0, [])
+
+    # If *every* nudge is implicated, the granular path degenerates to
+    # the legacy bulk-rollback.  Skip the per-nudge edits and just
+    # restore the snapshot -- this is the cheapest and safest path.
+    if offender_count == total:
+        output_path.write_bytes(snapshot)
+        return (True, 0, [])
+
+    # Per-nudge undo on a freshly-loaded document so the edits are
+    # written atomically.  Apply clearance undos first, save, then load
+    # the saved tree to apply drill undos on top.  Any failure triggers
+    # the bulk fallback so we never leave the file half-reverted.
+    try:
+        from kicad_tools.drc.repair_clearance import ClearanceRepairer
+        from kicad_tools.drc.repair_drill_clearance import DrillClearanceRepairer
+
+        reverted_uuids: list[str] = []
+
+        if offending_nudges:
+            clearance_repairer = ClearanceRepairer(output_path)
+            for nudge in offending_nudges:
+                ok = clearance_repairer._undo_nudge(nudge)
+                if not ok:
+                    raise RuntimeError(
+                        f"per-nudge undo failed for {nudge.object_type} "
+                        f"uuid={nudge.uuid!r} on net {nudge.net_name!r}"
+                    )
+                reverted_uuids.append(nudge.uuid)
+            clearance_repairer.save(output_path)
+
+        if offending_actions:
+            drill_repairer = DrillClearanceRepairer(output_path)
+            for act in offending_actions:
+                ok = drill_repairer.undo_action(act)
+                if not ok:
+                    raise RuntimeError(
+                        f"per-action undo failed for {act.action} via "
+                        f"uuid={act.uuid!r} on net {act.net_name!r}"
+                    )
+                reverted_uuids.append(act.uuid)
+            drill_repairer.save(output_path)
+
+        kept = total - offender_count
+        return (False, kept, reverted_uuids)
+
+    except Exception as e:
+        # Fall back to bulk restore on any failure.
+        print(
+            f"Warning: pass {pass_number} per-nudge rollback failed "
+            f"({e}); falling back to bulk snapshot restore.",
+            file=sys.stderr,
+        )
+        output_path.write_bytes(snapshot)
+        return (True, 0, [])
+
+
 def _get_drc_report(drc_report_path: str | None, pcb_path: Path) -> DRCReport | None:
     """Load or generate a DRC report.
 
@@ -574,12 +778,33 @@ def _print_json(
     # surface ``clearance.repaired`` / ``drill_clearance.repaired`` the
     # same way for consistency.
     rolled_back = bool(last.connectivity_rolled_back) if last is not None else False
+    partial_rolled_back = (
+        bool(last.connectivity_partial_rollback) if last is not None else False
+    )
+    reverted_uuids = set(last.reverted_uuids) if last is not None else set()
+
+    # Per-category reverted counts (for partial rollback): count nudges /
+    # actions whose UUID is in the reverted set.  The repairer-side
+    # counters (``RepairResult.repaired`` etc.) still reflect the
+    # pre-rollback total; subtracting the reverted count gives the
+    # effective post-rollback count.
+    clearance_reverted = sum(
+        1 for n in clearance_result.nudges if n.uuid in reverted_uuids
+    )
+    drill_reverted = sum(
+        1 for a in drill_result.actions if a.uuid in reverted_uuids
+    )
 
     # For single-pass (or backward compat), use the single-pass totals
     if len(pass_results) == 1:
         total_violations = clearance_result.total_violations + drill_result.total_violations
         if rolled_back:
             total_repaired = 0
+        elif partial_rolled_back:
+            total_repaired = (
+                (clearance_result.repaired - clearance_reverted)
+                + (drill_result.repaired - drill_reverted)
+            )
         else:
             total_repaired = clearance_result.repaired + drill_result.repaired
     else:
@@ -591,10 +816,18 @@ def _print_json(
     # Non-targeted violations (detected but not repairable by fix-drc)
     non_targeted = last.non_targeted_count if last else 0
 
-    # Effective per-category repaired counts (zeroed on rollback so the JSON
+    # Effective per-category repaired counts (zeroed on full rollback,
+    # decremented by the reverted subset on partial rollback so the JSON
     # summary agrees with the text output and the exit code).
-    effective_clearance_repaired = 0 if rolled_back else clearance_result.repaired
-    effective_drill_repaired = 0 if rolled_back else drill_result.repaired
+    if rolled_back:
+        effective_clearance_repaired = 0
+        effective_drill_repaired = 0
+    elif partial_rolled_back:
+        effective_clearance_repaired = clearance_result.repaired - clearance_reverted
+        effective_drill_repaired = drill_result.repaired - drill_reverted
+    else:
+        effective_clearance_repaired = clearance_result.repaired
+        effective_drill_repaired = drill_result.repaired
 
     data: dict = {
         "dry_run": dry_run,
@@ -623,6 +856,9 @@ def _print_json(
                     "y": n.y,
                     "net_name": n.net_name,
                     "displacement_mm": round(n.displacement_mm, 4),
+                    "reverted": (
+                        bool(rolled_back) or (n.uuid in reverted_uuids)
+                    ),
                 }
                 for n in clearance_result.nudges
             ],
@@ -646,6 +882,9 @@ def _print_json(
                     "net_name": a.net_name,
                     "displacement_mm": round(a.displacement_mm, 4),
                     "detail": a.detail,
+                    "reverted": (
+                        bool(rolled_back) or (a.uuid in reverted_uuids)
+                    ),
                 }
                 for a in drill_result.actions
             ],
@@ -664,6 +903,8 @@ def _print_json(
                     "connected_nets_before": p.connectivity_before,
                     "connected_nets_after": p.connectivity_after,
                     "rolled_back": p.connectivity_rolled_back,
+                    "partial_rollback": p.connectivity_partial_rollback,
+                    "reverted_uuids": list(p.reverted_uuids),
                 }
                 for p in pass_results
                 if p.connectivity_before is not None or p.connectivity_after is not None
@@ -704,12 +945,44 @@ def _print_summary(
         clearance_result = last.clearance_result if last else RepairResult()
         drill_result = last.drill_result if last else DrillRepairResult()
         total_violations = clearance_result.total_violations + drill_result.total_violations
-        total_repaired = clearance_result.repaired + drill_result.repaired
+
+        # Issue #2851: when a rollback occurred (full or partial), the
+        # underlying ``RepairResult.repaired`` still counts the
+        # pre-rollback work; subtract the reverted subset so the
+        # ``Repaired N/M`` headline matches the on-disk state.
+        rolled_back = bool(last.connectivity_rolled_back) if last is not None else False
+        partial_rolled_back = (
+            bool(last.connectivity_partial_rollback) if last is not None else False
+        )
+        reverted_uuids = set(last.reverted_uuids) if last is not None else set()
+        clearance_reverted = sum(
+            1 for n in clearance_result.nudges if n.uuid in reverted_uuids
+        )
+        drill_reverted = sum(
+            1 for a in drill_result.actions if a.uuid in reverted_uuids
+        )
+
+        if rolled_back:
+            total_repaired = 0
+            clearance_repaired = 0
+            drill_repaired = 0
+        elif partial_rolled_back:
+            clearance_repaired = clearance_result.repaired - clearance_reverted
+            drill_repaired = drill_result.repaired - drill_reverted
+            total_repaired = clearance_repaired + drill_repaired
+        else:
+            clearance_repaired = clearance_result.repaired
+            drill_repaired = drill_result.repaired
+            total_repaired = clearance_repaired + drill_repaired
+
         print(f"{action} {total_repaired}/{total_violations} DRC violations")
         if clearance_result.total_violations > 0:
-            print(f"  Clearance: {clearance_result.repaired}/{clearance_result.total_violations}")
+            print(f"  Clearance: {clearance_repaired}/{clearance_result.total_violations}")
         if drill_result.total_violations > 0:
-            print(f"  Drill clearance: {drill_result.repaired}/{drill_result.total_violations}")
+            print(
+                f"  Drill clearance: "
+                f"{drill_repaired}/{drill_result.total_violations}"
+            )
     else:
         # Multi-pass: per-pass progress
         total_repaired_all = sum(p.repaired for p in pass_results)
@@ -756,7 +1029,30 @@ def _print_text(
     # way: header shows ``0/total (rolled back)`` and each listed nudge gets a
     # ``(reverted)`` suffix so the user can still see *what would have been
     # changed* without contradicting the summary.
+    #
+    # Issue #2851: when only a *subset* of nudges is rolled back (granular
+    # path), only those entries get the ``(reverted)`` tag; the others
+    # remain plain so the user can see the work that survived.
     rolled_back = bool(last.connectivity_rolled_back) if last is not None else False
+    partial_rolled_back = (
+        bool(last.connectivity_partial_rollback) if last is not None else False
+    )
+    reverted_uuids = set(last.reverted_uuids) if last is not None else set()
+
+    def _is_reverted(uuid: str) -> bool:
+        if rolled_back:
+            return True
+        if partial_rolled_back and uuid in reverted_uuids:
+            return True
+        return False
+
+    # Per-category reverted counts (for partial rollback).
+    clearance_reverted_count = sum(
+        1 for n in clearance_result.nudges if n.uuid in reverted_uuids
+    )
+    drill_reverted_count = sum(
+        1 for a in drill_result.actions if a.uuid in reverted_uuids
+    )
 
     print(f"\n{'=' * 60}")
     print("DRC VIOLATION REPAIR")
@@ -780,16 +1076,30 @@ def _print_text(
 
     total_violations = first_violations
     total_repaired = total_repaired_all
-    summary_suffix = " (rolled back — connectivity regression)" if rolled_back else ""
+    summary_suffix = ""
+    if rolled_back:
+        summary_suffix = " (rolled back -- connectivity regression)"
+    elif partial_rolled_back:
+        total_reverted = clearance_reverted_count + drill_reverted_count
+        summary_suffix = (
+            f" (partial rollback -- {total_reverted} nudge(s) reverted "
+            f"on regressed nets)"
+        )
     print(f"\n{action} {total_repaired}/{total_violations} violations{summary_suffix}")
-    if rolled_back and last is not None:
+    if (rolled_back or partial_rolled_back) and last is not None:
         before = last.connectivity_before
         after = last.connectivity_after
         if before is not None and after is not None:
-            print(
-                f"  Connectivity: {before} -> {after} connected nets; "
-                f"nudges reverted to preserve connectivity."
-            )
+            if rolled_back:
+                print(
+                    f"  Connectivity: {before} -> {after} connected nets; "
+                    f"nudges reverted to preserve connectivity."
+                )
+            else:
+                print(
+                    f"  Connectivity: {before} -> {after} connected nets "
+                    f"after granular rollback."
+                )
 
     if clearance_result.total_violations > 0:
         print(f"\n{'-' * 60}")
@@ -797,15 +1107,26 @@ def _print_text(
         # ``clearance_result.repaired`` still reflects the pre-rollback total
         # (the rollback happens after the repairer returns).  Report 0/total
         # here so the header agrees with the ``Repaired 0/N`` summary.
-        effective_repaired = 0 if rolled_back else clearance_result.repaired
-        header_suffix = " (reverted)" if rolled_back else ""
+        if rolled_back:
+            effective_repaired = 0
+            header_suffix = " (reverted)"
+        elif partial_rolled_back:
+            effective_repaired = clearance_result.repaired - clearance_reverted_count
+            header_suffix = (
+                f" ({clearance_reverted_count} reverted)"
+                if clearance_reverted_count > 0
+                else ""
+            )
+        else:
+            effective_repaired = clearance_result.repaired
+            header_suffix = ""
         print(
             f"CLEARANCE: {effective_repaired}/{clearance_result.total_violations}"
             f"{header_suffix}"
         )
         if clearance_result.nudges:
-            nudge_suffix = " (reverted)" if rolled_back else ""
             for nudge in clearance_result.nudges[:5]:
+                nudge_suffix = " (reverted)" if _is_reverted(nudge.uuid) else ""
                 print(f"  [{nudge.object_type.upper()}] {nudge.net_name}{nudge_suffix}")
                 print(f"    at ({nudge.x:.4f}, {nudge.y:.4f}) -> {nudge.displacement_mm:.4f}mm")
             if len(clearance_result.nudges) > 5:
@@ -813,8 +1134,19 @@ def _print_text(
 
     if drill_result.total_violations > 0:
         print(f"\n{'-' * 60}")
-        effective_drill_repaired = 0 if rolled_back else drill_result.repaired
-        drill_header_suffix = " (reverted)" if rolled_back else ""
+        if rolled_back:
+            effective_drill_repaired = 0
+            drill_header_suffix = " (reverted)"
+        elif partial_rolled_back:
+            effective_drill_repaired = drill_result.repaired - drill_reverted_count
+            drill_header_suffix = (
+                f" ({drill_reverted_count} reverted)"
+                if drill_reverted_count > 0
+                else ""
+            )
+        else:
+            effective_drill_repaired = drill_result.repaired
+            drill_header_suffix = ""
         print(
             f"DRILL CLEARANCE: {effective_drill_repaired}/{drill_result.total_violations}"
             f"{drill_header_suffix}"
@@ -825,8 +1157,8 @@ def _print_text(
             if drill_result.slid > 0:
                 print(f"  Slid apart: {drill_result.slid}")
         if drill_result.actions:
-            action_suffix = " (reverted)" if rolled_back else ""
             for act in drill_result.actions[:5]:
+                action_suffix = " (reverted)" if _is_reverted(act.uuid) else ""
                 print(f"  [{act.action.upper()}] {act.net_name}{action_suffix}")
                 print(f"    at ({act.via_x:.4f}, {act.via_y:.4f}) - {act.detail}")
             if len(drill_result.actions) > 5:

--- a/src/kicad_tools/drc/repair_clearance.py
+++ b/src/kicad_tools/drc/repair_clearance.py
@@ -1549,6 +1549,141 @@ class ClearanceRepairer:
                 end_node.set_value(0, round(ex + dx, 4))
                 end_node.set_value(1, round(ey + dy, 4))
 
+    def _find_node_by_uuid(
+        self,
+        uuid: str,
+        obj_type: str,
+    ) -> SExp | None:
+        """Find a top-level segment or via node by its UUID.
+
+        Args:
+            uuid: UUID string to match (compared against the first atom of
+                the ``(uuid ...)`` child).
+            obj_type: ``"segment"`` or ``"via"`` — the S-expression tag to
+                look for.
+
+        Returns:
+            The matching :class:`SExp` node, or ``None`` if not found.
+        """
+        if not uuid:
+            return None
+        for node in self.doc.find_all(obj_type):
+            uuid_node = node.find("uuid")
+            if not uuid_node:
+                continue
+            atom = uuid_node.get_first_atom()
+            if atom is None:
+                continue
+            if str(atom).strip('"') == str(uuid).strip('"'):
+                return node
+        return None
+
+    def _undo_nudge(self, nudge: NudgeResult) -> bool:
+        """Reverse a previously-applied nudge.
+
+        Locates the object by UUID and applies the inverse displacement
+        ``(-displacement_x, -displacement_y)``.  For vias, mirrors
+        ``_apply_nudge``'s behavior of also updating the endpoints of any
+        segments that currently terminate at the post-nudge via position
+        (so the via and its attached traces move back together).
+
+        For segments where one endpoint was pinned at a via during the
+        original nudge, only the moved endpoint is reverted.  The same
+        ``via_positions`` check used by ``_apply_nudge`` is applied to the
+        *current* board state to detect this asymmetric case.
+
+        Args:
+            nudge: The :class:`NudgeResult` to undo.
+
+        Returns:
+            ``True`` if the undo succeeded, ``False`` otherwise (e.g. the
+            UUID could not be located in the current document).  Callers
+            should treat ``False`` as a trigger for the bulk-snapshot
+            fallback so the file state is never left half-reverted.
+        """
+        if not nudge.uuid:
+            return False
+        node = self._find_node_by_uuid(nudge.uuid, nudge.object_type)
+        if node is None:
+            return False
+
+        # Inverse displacement.
+        dx = -nudge.displacement_x
+        dy = -nudge.displacement_y
+
+        if nudge.object_type == "via":
+            at_node = node.find("at")
+            if not at_node:
+                return False
+            at_atoms = at_node.get_atoms()
+            cur_x = float(at_atoms[0]) if at_atoms else 0.0
+            cur_y = float(at_atoms[1]) if len(at_atoms) > 1 else 0.0
+            new_x = round(cur_x + dx, 4)
+            new_y = round(cur_y + dy, 4)
+
+            # Find segments currently anchored at the via's post-nudge
+            # position before we move the via -- otherwise we'd be looking
+            # for segments at the pre-nudge position which no longer exists.
+            connected = self._find_connected_segments(cur_x, cur_y)
+
+            at_node.set_value(0, new_x)
+            at_node.set_value(1, new_y)
+
+            for seg_node, endpoint in connected:
+                ep_node = seg_node.find(endpoint)
+                if ep_node:
+                    ep_node.set_value(0, new_x)
+                    ep_node.set_value(1, new_y)
+            return True
+
+        if nudge.object_type == "segment":
+            start_node = node.find("start")
+            end_node = node.find("end")
+            if not (start_node and end_node):
+                return False
+
+            start_atoms = start_node.get_atoms()
+            end_atoms = end_node.get_atoms()
+            sx = float(start_atoms[0]) if start_atoms else 0.0
+            sy = float(start_atoms[1]) if len(start_atoms) > 1 else 0.0
+            ex = float(end_atoms[0]) if end_atoms else 0.0
+            ey = float(end_atoms[1]) if len(end_atoms) > 1 else 0.0
+
+            # Mirror _apply_nudge's via-pinning logic against the current
+            # board state.  If a segment endpoint is currently at a via,
+            # only the other (moved) endpoint gets the inverse displacement.
+            via_positions = self._find_via_positions()
+            tolerance = 0.001
+            start_at_via = any(
+                math.sqrt((sx - vx) ** 2 + (sy - vy) ** 2) <= tolerance
+                for vx, vy in via_positions
+            )
+            end_at_via = any(
+                math.sqrt((ex - vx) ** 2 + (ey - vy) ** 2) <= tolerance
+                for vx, vy in via_positions
+            )
+
+            if start_at_via and end_at_via:
+                # Both endpoints at vias -- _apply_nudge would have done
+                # nothing here, so there's nothing to undo.  Treat as
+                # success so the orchestrator continues.
+                return True
+
+            if start_at_via:
+                end_node.set_value(0, round(ex + dx, 4))
+                end_node.set_value(1, round(ey + dy, 4))
+            elif end_at_via:
+                start_node.set_value(0, round(sx + dx, 4))
+                start_node.set_value(1, round(sy + dy, 4))
+            else:
+                start_node.set_value(0, round(sx + dx, 4))
+                start_node.set_value(1, round(sy + dy, 4))
+                end_node.set_value(0, round(ex + dx, 4))
+                end_node.set_value(1, round(ey + dy, 4))
+            return True
+
+        return False
+
     def _closest_point_on_segment(
         self,
         x1: float,

--- a/src/kicad_tools/drc/repair_drill_clearance.py
+++ b/src/kicad_tools/drc/repair_drill_clearance.py
@@ -26,7 +26,15 @@ from .violation import DRCViolation, ViolationType
 
 @dataclass
 class DrillRepairAction:
-    """Record of a single drill clearance repair action."""
+    """Record of a single drill clearance repair action.
+
+    The signed ``displacement_x`` / ``displacement_y`` fields capture the
+    direction of a slide so callers can reverse it (used by the granular
+    rollback path in ``fix-drc``).  For ``deduplicate`` actions these are
+    zero -- a removed via cannot currently be restored from the in-memory
+    action record, so granular rollback falls back to a bulk snapshot
+    restore when a dedup action is implicated.
+    """
 
     action: str  # "deduplicate" or "slide"
     via_x: float
@@ -34,6 +42,9 @@ class DrillRepairAction:
     net_name: str
     detail: str  # human-readable description
     displacement_mm: float = 0.0  # 0 for dedup
+    displacement_x: float = 0.0
+    displacement_y: float = 0.0
+    uuid: str = ""
 
     def __str__(self) -> str:
         return f"{self.action}: via [{self.net_name}] at ({self.via_x:.4f}, {self.via_y:.4f}) - {self.detail}"
@@ -282,6 +293,8 @@ class DrillClearanceRepairer:
         dry_run: bool,
     ) -> None:
         """Remove a duplicate same-net via."""
+        uuid_node = via_node.find("uuid")
+        uuid_str = uuid_node.get_first_atom() if uuid_node else ""
         action = DrillRepairAction(
             action="deduplicate",
             via_x=via_x,
@@ -289,6 +302,7 @@ class DrillClearanceRepairer:
             net_name=net_name,
             detail="removed duplicate same-net via",
             displacement_mm=0.0,
+            uuid=str(uuid_str) if uuid_str else "",
         )
         result.actions.append(action)
 
@@ -375,6 +389,8 @@ class DrillClearanceRepairer:
                 via_x, via_y, other_x, other_y, required_displacement
             )
 
+        uuid_node = via_node.find("uuid")
+        uuid_str = uuid_node.get_first_atom() if uuid_node else ""
         action = DrillRepairAction(
             action="slide",
             via_x=via_x,
@@ -382,6 +398,9 @@ class DrillClearanceRepairer:
             net_name=via_net,
             detail=f"slid {dist:.4f}mm to increase clearance",
             displacement_mm=dist,
+            displacement_x=dx,
+            displacement_y=dy,
+            uuid=str(uuid_str) if uuid_str else "",
         )
         result.actions.append(action)
 
@@ -394,6 +413,96 @@ class DrillClearanceRepairer:
 
         result.repaired += 1
         result.slid += 1
+
+    def undo_action(self, action: DrillRepairAction) -> bool:
+        """Reverse a previously-applied drill-clearance repair action.
+
+        For ``slide`` actions, locates the via by UUID and applies the
+        inverse displacement to both the via and any segment endpoint
+        currently anchored at the slid (post-action) position.
+
+        For ``deduplicate`` actions the original via was removed from the
+        document, so the action record is insufficient to restore it.
+        These return ``False`` so callers can fall back to a bulk-snapshot
+        restore.
+
+        Args:
+            action: The :class:`DrillRepairAction` to undo.
+
+        Returns:
+            ``True`` on success, ``False`` when the action cannot be
+            reversed (UUID lookup miss, dedup action, etc.).
+        """
+        if action.action == "deduplicate":
+            # A removed via cannot be restored from the action record alone.
+            # Signal failure so the orchestrator falls back to the bulk
+            # snapshot restore.
+            return False
+
+        if action.action != "slide":
+            return False
+
+        uuid = action.uuid
+        if not uuid:
+            return False
+
+        # Locate the via by UUID at its current (post-slide) position.
+        target = None
+        for via_node in self.doc.find_all("via"):
+            uuid_node = via_node.find("uuid")
+            if not uuid_node:
+                continue
+            atom = uuid_node.get_first_atom()
+            if atom is None:
+                continue
+            if str(atom).strip('"') == str(uuid).strip('"'):
+                target = via_node
+                break
+        if target is None:
+            return False
+
+        at_node = target.find("at")
+        if not at_node:
+            return False
+
+        at_atoms = at_node.get_atoms()
+        cur_x = float(at_atoms[0]) if at_atoms else 0.0
+        cur_y = float(at_atoms[1]) if len(at_atoms) > 1 else 0.0
+
+        # The segment endpoint that was updated alongside the slide will
+        # currently sit at the post-slide via position.  Reset it together
+        # with the via.
+        dx = -action.displacement_x
+        dy = -action.displacement_y
+        new_x = round(cur_x + dx, 4)
+        new_y = round(cur_y + dy, 4)
+
+        tolerance = 0.01
+        segments_to_update: list[SExp] = []
+        for seg_node in self.doc.find_all("segment"):
+            start_node = seg_node.find("start")
+            end_node = seg_node.find("end")
+            if not (start_node and end_node):
+                continue
+            start_atoms = start_node.get_atoms()
+            end_atoms = end_node.get_atoms()
+            sx = float(start_atoms[0]) if start_atoms else 0.0
+            sy = float(start_atoms[1]) if len(start_atoms) > 1 else 0.0
+            ex = float(end_atoms[0]) if end_atoms else 0.0
+            ey = float(end_atoms[1]) if len(end_atoms) > 1 else 0.0
+            if (
+                math.sqrt((sx - cur_x) ** 2 + (sy - cur_y) ** 2) < tolerance
+                or math.sqrt((ex - cur_x) ** 2 + (ey - cur_y) ** 2) < tolerance
+            ):
+                segments_to_update.append(seg_node)
+
+        at_node.set_value(0, new_x)
+        at_node.set_value(1, new_y)
+
+        for seg_node in segments_to_update:
+            self._update_segment_endpoint(seg_node, cur_x, cur_y, new_x, new_y)
+
+        return True
 
     def _compute_push_away(
         self,

--- a/tests/test_board_03_regression.py
+++ b/tests/test_board_03_regression.py
@@ -521,3 +521,110 @@ def test_route_demo_achieves_minimum_completion(regenerated_board: Path) -> None
         f"USB-C-class pad-density boards or a placement change that pushed "
         f"a previously-routable net out of reach."
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #2851: granular rollback preserves non-regressing fixes
+# ---------------------------------------------------------------------------
+
+
+def test_fix_drc_preserves_safe_nudges_on_routed_board(tmp_path) -> None:
+    """Issue #2851: ``kct fix-drc`` repairs >0 violations on board 03.
+
+    Layer-3 acceptance criterion from issue #2839 / parent #2833.
+
+    Pre-#2851, board 03's routed PCB had 18 clearance nudges available
+    (max 0.1880 mm, well under the 2.0 mm cap), of which only a small
+    handful broke connectivity.  Under the bulk-snapshot rollback, all
+    18 nudges were thrown away whenever the connectivity check fired,
+    leaving the user with "Repaired 0/N" even though the majority were
+    safe.
+
+    With granular per-nudge rollback in place, ``fix-drc`` must keep at
+    least one nudge that did NOT touch a regressed net, so the post-fix
+    summary reports ``Repaired K/N`` with K > 0.
+
+    This test loads the committed routed PCB and runs ``fix-drc``
+    in-process via the CLI module; no router invocation is required.
+    The board 03 routed PCB has ~4 clearance violations clustered around
+    the USB diff-pair flip-routing corridor; some of those nudges touch
+    USB_D+ (whose connectivity is fragile due to the 2-of-3-pads stub
+    geometry) and some do not.  The granular rollback should preserve
+    the latter group.
+    """
+    if not ROUTED_PCB_FILE.exists():
+        pytest.skip(
+            f"Board 03 routed PCB not found at {ROUTED_PCB_FILE!s}; "
+            "regenerate via the board's generate/route demo scripts."
+        )
+
+    output_file = tmp_path / "usb_joystick_repaired.kicad_pcb"
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "kicad_tools.cli",
+            "fix-drc",
+            str(ROUTED_PCB_FILE),
+            "-o",
+            str(output_file),
+            "--format",
+            "json",
+            "--quiet",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+    # fix-drc exit codes: 0 = clean, 2 = partial, 3 = full rollback.
+    # We accept anything except 3 -- a full rollback would mean granular
+    # attribution failed and the legacy bulk path fired.
+    assert proc.returncode != 3, (
+        "fix-drc full-rolled-back on board 03: this is the issue #2851 "
+        "regression we are trying to prevent.  Expected granular "
+        "rollback to preserve at least 1 nudge.\n"
+        f"stdout:\n{proc.stdout[-2000:]}\nstderr:\n{proc.stderr[-2000:]}"
+    )
+
+    # Parse JSON to assert at least one nudge was applied.  ``fix-drc``
+    # may report ``total_repaired = 0`` when there are no violations at
+    # all (clean board), in which case the test is vacuously satisfied
+    # by the exit-code check above.
+    import json as _json
+
+    if not proc.stdout.strip():
+        return  # No JSON output (likely no violations).
+
+    # ``fix-drc`` prints a ``Running DRC on:`` preamble to stdout before
+    # the JSON document when ``--drc-report`` is not supplied.  Find the
+    # first ``{`` to locate the JSON body.
+    json_start = proc.stdout.find("{")
+    if json_start < 0:
+        return  # No JSON document emitted -- no violations to repair.
+    json_text = proc.stdout[json_start:]
+
+    try:
+        data = _json.loads(json_text)
+    except _json.JSONDecodeError:
+        pytest.fail(
+            f"Could not parse fix-drc JSON output:\n{proc.stdout[-2000:]}"
+        )
+
+    total_violations = data.get("total_violations", 0)
+    total_repaired = data.get("total_repaired", 0)
+
+    if total_violations == 0:
+        return  # No work to do; vacuously satisfied.
+
+    assert total_repaired > 0, (
+        "fix-drc on board 03 reported total_violations="
+        f"{total_violations} but total_repaired={total_repaired}.  "
+        "This is the issue #2851 layer-3 contract: granular rollback "
+        "must preserve at least 1 nudge that does not touch a regressed "
+        "net.  A zero count here means the granular path attributed the "
+        "regression to every nudge (legitimate full rollback) OR the "
+        "granular path fell back to bulk snapshot restore."
+    )

--- a/tests/test_fix_drc_cmd.py
+++ b/tests/test_fix_drc_cmd.py
@@ -2276,6 +2276,453 @@ class TestConnectivityCheckRollback:
         )
 
 
+PCB_GRANULAR_ROLLBACK = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "NET_X")
+  (net 2 "NET_Y")
+  (net 3 "NET_Z")
+  (segment (start 100 100) (end 110 100) (width 0.25) (layer "F.Cu") (net 1) (uuid "seg-x-1"))
+  (segment (start 100 100.15) (end 110 100.15) (width 0.25) (layer "F.Cu") (net 2) (uuid "seg-y-1"))
+  (segment (start 100 105) (end 110 105) (width 0.25) (layer "F.Cu") (net 1) (uuid "seg-x-2"))
+  (segment (start 100 105.15) (end 110 105.15) (width 0.25) (layer "F.Cu") (net 2) (uuid "seg-y-2"))
+  (segment (start 100 110) (end 110 110) (width 0.25) (layer "F.Cu") (net 3) (uuid "seg-z-1"))
+  (segment (start 100 110.15) (end 110 110.15) (width 0.25) (layer "F.Cu") (net 2) (uuid "seg-y-3"))
+)
+"""
+
+DRC_REPORT_GRANULAR_ROLLBACK = """\
+** Drc report for test.kicad_pcb **
+** Created on 2025-12-28T21:29:34-08:00 **
+
+** Found 3 DRC violations **
+[clearance]: Clearance violation (netclass 'Default' clearance 0.2000 mm; actual 0.1500 mm)
+    Rule: netclass 'Default'; error
+    @(105.0000 mm, 100.0000 mm): Track [NET_X] on F.Cu
+    @(105.0000 mm, 100.1500 mm): Track [NET_Y] on F.Cu
+
+[clearance]: Clearance violation (netclass 'Default' clearance 0.2000 mm; actual 0.1500 mm)
+    Rule: netclass 'Default'; error
+    @(105.0000 mm, 105.0000 mm): Track [NET_X] on F.Cu
+    @(105.0000 mm, 105.1500 mm): Track [NET_Y] on F.Cu
+
+[clearance]: Clearance violation (netclass 'Default' clearance 0.2000 mm; actual 0.1500 mm)
+    Rule: netclass 'Default'; error
+    @(105.0000 mm, 110.0000 mm): Track [NET_Z] on F.Cu
+    @(105.0000 mm, 110.1500 mm): Track [NET_Y] on F.Cu
+
+** Found 0 Footprint errors **
+** End of Report **
+"""
+
+
+@pytest.fixture
+def pcb_granular_rollback(tmp_path: Path) -> Path:
+    f = tmp_path / "granular.kicad_pcb"
+    f.write_text(PCB_GRANULAR_ROLLBACK)
+    return f
+
+
+@pytest.fixture
+def report_granular_rollback(tmp_path: Path) -> Path:
+    f = tmp_path / "granular-drc.rpt"
+    f.write_text(DRC_REPORT_GRANULAR_ROLLBACK)
+    return f
+
+
+class TestGranularRollback:
+    """Tests for issue #2851: per-nudge granular rollback.
+
+    When the post-pass connectivity check fires, only nudges that touch
+    a regressed net are reverted; the rest stay applied.  Falls back to
+    the legacy bulk-snapshot restore when per-nudge attribution is not
+    possible (empty offender set, every nudge implicated, or undo
+    failure).
+    """
+
+    def _patch_connectivity(
+        self,
+        monkeypatch,
+        *,
+        baseline_count: int,
+        after_count: int,
+        baseline_issues: tuple = (),
+        after_issues: tuple = (),
+    ):
+        """Install paired mocks for _count_connected_nets and _connectivity_report.
+
+        The two helpers are called in lockstep: every baseline/after pair
+        is one of each.  We dispatch on call_count so the after report
+        sees the regressed-net set.
+        """
+        from kicad_tools.validate.connectivity import (
+            ConnectivityIssue,
+            ConnectivityResult,
+        )
+
+        def _make_result(count: int, issues: tuple) -> ConnectivityResult:
+            r = ConnectivityResult()
+            r.connected_nets = count
+            r.total_nets = count + len(issues)
+            for net_name in issues:
+                r.add(
+                    ConnectivityIssue(
+                        severity="error",
+                        issue_type="partial",
+                        net_name=net_name,
+                        message=f"Net '{net_name}' broken",
+                        suggestion="reconnect",
+                    )
+                )
+            return r
+
+        count_calls = {"n": 0}
+        report_calls = {"n": 0}
+
+        def mock_count(_pcb_path):
+            count_calls["n"] += 1
+            return baseline_count if count_calls["n"] == 1 else after_count
+
+        def mock_report(_pcb_path):
+            report_calls["n"] += 1
+            if report_calls["n"] == 1:
+                return _make_result(baseline_count, baseline_issues)
+            return _make_result(after_count, after_issues)
+
+        monkeypatch.setattr(
+            "kicad_tools.cli.fix_drc_cmd._count_connected_nets", mock_count
+        )
+        monkeypatch.setattr(
+            "kicad_tools.cli.fix_drc_cmd._connectivity_report", mock_report
+        )
+        return count_calls, report_calls
+
+    def test_synthetic_positive_control_partial_rollback(
+        self,
+        pcb_granular_rollback: Path,
+        report_granular_rollback: Path,
+        tmp_path,
+        capsys,
+        monkeypatch,
+    ):
+        """Step 1: 3 clearance nudges, regression attributed to NET_X only.
+
+        Expect: nudges on NET_X reverted, nudges on NET_Y / NET_Z kept.
+        Top-level summary: ``Repaired (3-K)/3``, exit code != 3.
+        """
+        output_file = tmp_path / "output.kicad_pcb"
+
+        # Connectivity dropped: 10 -> 9.  Regression attributed to NET_X.
+        self._patch_connectivity(
+            monkeypatch,
+            baseline_count=10,
+            after_count=9,
+            baseline_issues=(),
+            after_issues=("NET_X",),
+        )
+
+        result = main(
+            [
+                str(pcb_granular_rollback),
+                "--drc-report",
+                str(report_granular_rollback),
+                "-o",
+                str(output_file),
+                "--format",
+                "json",
+            ]
+        )
+
+        # Partial rollback -- not a full rollback, so exit code != 3.
+        assert result != 3, f"Granular partial rollback should not return exit 3, got {result}"
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+
+        # connectivity_check should reflect the partial-rollback state.
+        conn = data["connectivity_check"]["passes"][0]
+        assert conn["rolled_back"] is False, "Partial rollback is not a full rollback"
+        assert conn["partial_rollback"] is True
+        assert len(conn["reverted_uuids"]) >= 1, "At least one nudge should be reverted"
+
+        # The clearance nudges list must tag the reverted entries.
+        nudges = data["clearance"]["nudges"]
+        net_x_nudges = [n for n in nudges if n["net_name"] == "NET_X"]
+        non_x_nudges = [n for n in nudges if n["net_name"] != "NET_X"]
+        # NET_X nudges should be reverted.
+        for n in net_x_nudges:
+            assert n["reverted"] is True, f"NET_X nudge should be reverted: {n}"
+        # Non-NET_X nudges should NOT be reverted.
+        for n in non_x_nudges:
+            assert n["reverted"] is False, f"Non-NET_X nudge should remain: {n}"
+
+        # Repaired total = total_attempted - reverted.
+        total_attempted = data["clearance"]["violations"]
+        reverted_count = sum(1 for n in nudges if n["reverted"])
+        expected_kept = total_attempted - reverted_count
+        assert data["total_repaired"] == expected_kept, (
+            f"Expected total_repaired={expected_kept}, "
+            f"got {data['total_repaired']}"
+        )
+
+    def test_full_rollback_when_all_nudges_touch_offending_net(
+        self,
+        pcb_same_net_vias: Path,
+        report_same_net_drill: Path,
+        tmp_path,
+        capsys,
+        monkeypatch,
+    ):
+        """Step 4: every applied nudge touches the regressed net -> full rollback.
+
+        The granular path must degenerate to ``revert all`` -- same exit
+        code 3 and same bulk-snapshot semantics as before.
+        """
+        output_file = tmp_path / "output.kicad_pcb"
+        original_content = pcb_same_net_vias.read_bytes()
+
+        # The same-net-vias fixture has a single GND drill-dedup action.
+        # Reporting GND as regressed implicates every applied nudge.
+        self._patch_connectivity(
+            monkeypatch,
+            baseline_count=10,
+            after_count=8,
+            baseline_issues=(),
+            after_issues=("GND",),
+        )
+
+        result = main(
+            [
+                str(pcb_same_net_vias),
+                "--drc-report",
+                str(report_same_net_drill),
+                "-o",
+                str(output_file),
+                "--format",
+                "json",
+            ]
+        )
+
+        # Full rollback path -- exit code 3, file restored.
+        assert result == 3
+        assert output_file.read_bytes() == original_content
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        conn = data["connectivity_check"]["passes"][0]
+        assert conn["rolled_back"] is True
+        assert conn["partial_rollback"] is False
+
+    def test_local_rerouter_not_called_during_rollback(
+        self,
+        pcb_granular_rollback: Path,
+        report_granular_rollback: Path,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Step 5: performance guard -- the rollback path must not re-route.
+
+        ``LocalRerouter.reroute_segment`` is the only routing entry point
+        reachable from the repair pipeline.  We install a sentinel that
+        fails the test if it is invoked at all (we use
+        ``--no-local-reroute`` so the legitimate nudge phase also never
+        routes).
+        """
+        output_file = tmp_path / "output.kicad_pcb"
+
+        from kicad_tools.drc.local_rerouter import LocalRerouter
+
+        original_reroute = LocalRerouter.reroute_segment
+        call_count = {"n": 0}
+
+        def sentinel_reroute(self, *args, **kwargs):
+            call_count["n"] += 1
+            return original_reroute(self, *args, **kwargs)
+
+        monkeypatch.setattr(LocalRerouter, "reroute_segment", sentinel_reroute)
+
+        self._patch_connectivity(
+            monkeypatch,
+            baseline_count=10,
+            after_count=9,
+            baseline_issues=(),
+            after_issues=("NET_X",),
+        )
+
+        # ``--no-local-reroute`` to ensure the nudge phase doesn't route
+        # legitimately (which would also count against the sentinel).
+        main(
+            [
+                str(pcb_granular_rollback),
+                "--drc-report",
+                str(report_granular_rollback),
+                "-o",
+                str(output_file),
+                "--no-local-reroute",
+            ]
+        )
+
+        # The rollback path must add zero routing calls.  With
+        # --no-local-reroute the nudge phase also adds zero, so the total
+        # must be zero.
+        assert call_count["n"] == 0, (
+            f"LocalRerouter.reroute was called {call_count['n']} time(s) "
+            f"during fix-drc; the rollback path must be routing-free."
+        )
+
+    def test_undo_failure_falls_back_to_bulk_snapshot(
+        self,
+        pcb_granular_rollback: Path,
+        report_granular_rollback: Path,
+        tmp_path,
+        capsys,
+        monkeypatch,
+    ):
+        """Step 6: per-nudge undo failure -> bulk snapshot restore.
+
+        Patch ``_undo_nudge`` to return False for one nudge.  Expect the
+        granular path to abort and the file to be restored to the
+        pre-pass snapshot, with a warning logged.
+        """
+        output_file = tmp_path / "output.kicad_pcb"
+        original_content = pcb_granular_rollback.read_bytes()
+
+        # Force undo failure for any nudge.
+        from kicad_tools.drc.repair_clearance import ClearanceRepairer
+
+        def failing_undo(self, nudge):
+            return False
+
+        monkeypatch.setattr(ClearanceRepairer, "_undo_nudge", failing_undo)
+
+        # Regression attributed to NET_X only -- partial path is selected,
+        # then fails, then falls back to bulk.
+        self._patch_connectivity(
+            monkeypatch,
+            baseline_count=10,
+            after_count=9,
+            baseline_issues=(),
+            after_issues=("NET_X",),
+        )
+
+        result = main(
+            [
+                str(pcb_granular_rollback),
+                "--drc-report",
+                str(report_granular_rollback),
+                "-o",
+                str(output_file),
+                "--no-local-reroute",
+            ]
+        )
+
+        # Bulk fallback -> exit code 3 and file restored.
+        assert result == 3
+        assert output_file.read_bytes() == original_content
+
+        # The warning should mention the fallback.
+        captured = capsys.readouterr()
+        assert "per-nudge rollback failed" in captured.err
+        assert "bulk snapshot restore" in captured.err
+
+    def test_connectivity_validator_calls_are_o1(
+        self,
+        pcb_granular_rollback: Path,
+        report_granular_rollback: Path,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Step 2: Approach 1 -- the rollback path uses O(1) connectivity calls.
+
+        Asserts the upper bound on _connectivity_report calls per pass
+        (Approach 1 = 2: baseline + after).  An extra post-undo
+        _count_connected_nets call is allowed (one O(1) re-check).
+        """
+        output_file = tmp_path / "output.kicad_pcb"
+
+        count_calls, report_calls = self._patch_connectivity(
+            monkeypatch,
+            baseline_count=10,
+            after_count=9,
+            baseline_issues=(),
+            after_issues=("NET_X",),
+        )
+
+        main(
+            [
+                str(pcb_granular_rollback),
+                "--drc-report",
+                str(report_granular_rollback),
+                "-o",
+                str(output_file),
+                "--no-local-reroute",
+            ]
+        )
+
+        # Approach 1 budget: 2 _connectivity_report calls (baseline + after)
+        # and at most 3 _count_connected_nets calls (baseline + after + post-undo).
+        # Anything materially larger indicates regression toward Approach 2/3.
+        assert report_calls["n"] <= 2, (
+            f"Too many _connectivity_report calls: {report_calls['n']} > 2; "
+            f"the rollback path should not re-validate per nudge."
+        )
+        assert count_calls["n"] <= 3, (
+            f"Too many _count_connected_nets calls: {count_calls['n']} > 3"
+        )
+
+    def test_empty_regressed_set_falls_back_to_bulk(
+        self,
+        pcb_granular_rollback: Path,
+        report_granular_rollback: Path,
+        tmp_path,
+        capsys,
+        monkeypatch,
+    ):
+        """When per-net attribution cannot identify offenders, bulk restore.
+
+        The count drops but no specific net is flagged as regressed.
+        Without an offender set, the granular path falls back to the
+        legacy bulk-snapshot restore.
+        """
+        output_file = tmp_path / "output.kicad_pcb"
+        original_content = pcb_granular_rollback.read_bytes()
+
+        # Count drops but issue lists are empty in both reports.
+        self._patch_connectivity(
+            monkeypatch,
+            baseline_count=10,
+            after_count=8,
+            baseline_issues=(),
+            after_issues=(),
+        )
+
+        result = main(
+            [
+                str(pcb_granular_rollback),
+                "--drc-report",
+                str(report_granular_rollback),
+                "-o",
+                str(output_file),
+                "--no-local-reroute",
+            ]
+        )
+
+        # Empty offender set -> bulk fallback -> exit 3.
+        assert result == 3
+        assert output_file.read_bytes() == original_content
+
+
 class TestCountConnectedNets:
     """Tests for the _count_connected_nets helper."""
 


### PR DESCRIPTION
## Summary

Closes #2851.

When the post-pass connectivity check fires in `fix-drc`, this PR reverts
only the subset of nudges that touched a **regressed net** instead of
bulk-restoring a pre-pass file-bytes snapshot.  Implements **Approach 1**
from the issue (net-aware filtering via `ConnectivityResult.issues[].net_name`):
O(1) extra `ConnectivityValidator` calls per pass and zero routing calls --
the rollback path edits the live S-exp tree in memory and rewrites the
file once.

The bulk-snapshot restore is preserved as a safety net: it fires on empty
offender sets, every-nudge-implicated cases, per-nudge undo failure
(e.g. UUID lookup miss), and any exception during the in-place edit.
Existing full-rollback behavior (exit code 3, complete file restore)
is unchanged when every applied nudge touches a regressed net.

### Concrete impact (board 03, the #2839 reproducer)

Before this PR:
```
Warning: pass 1 decreased connectivity (9 -> 8 nets); rolled back.
Repaired 0/4 DRC violations
```

After this PR:
```
Warning: pass 1 initially decreased connectivity (9 -> 8 nets); reverted
3 of 4 nudge(s) on regressed net(s) ['USB_D+']; now 9 connected net(s).
Repaired 1/4 DRC violations
  Clearance: 1/4
```

The 3 USB_D+ nudges that broke connectivity are reverted; the 1 USB_D-
nudge is preserved.  This satisfies the layer-3 acceptance contract
from #2839.

## Implementation

- `ClearanceRepairer._undo_nudge(nudge)` mirrors `_apply_nudge`: looks
  up the object by UUID, applies the inverse displacement, and for vias
  updates connected segment endpoints to match.
- `DrillClearanceRepairer.undo_action(action)` mirrors `_slide_via`;
  returns `False` for `deduplicate` actions (a removed via cannot be
  reconstructed from the in-memory record) to trigger bulk fallback.
- `DrillRepairAction` gains signed `displacement_x`/`displacement_y` +
  `uuid` fields so slides can be inverted (no schema removal --
  `displacement_mm` is preserved).
- `_attempt_granular_rollback` in `fix_drc_cmd.py` orchestrates the
  filter, undo, and fallback paths.
- Text/JSON output tags individually-reverted nudges `(reverted)` and
  surfaces a new `connectivity_check.passes[].partial_rollback` flag +
  `reverted_uuids` list so consumers can distinguish full vs partial
  rollbacks.  The `Repaired N/M` summary line now agrees with the
  on-disk state under partial rollback (one of the issue #2839 sub-bugs).

## Test plan

All 7 steps from the issue:

- [x] **Step 1** -- synthetic positive control:
  `TestGranularRollback::test_synthetic_positive_control_partial_rollback`
- [x] **Step 2** -- O(1) ConnectivityValidator budget:
  `test_connectivity_validator_calls_are_o1`
- [x] **Step 3** -- extends existing rollback test pattern (same
  `_count_connected_nets` mock + new `_connectivity_report` mock)
- [x] **Step 4** -- full-rollback regression guard:
  `test_full_rollback_when_all_nudges_touch_offending_net`
- [x] **Step 5** -- performance guard (no routing during rollback):
  `test_local_rerouter_not_called_during_rollback`
- [x] **Step 6** -- undo-failure fallback:
  `test_undo_failure_falls_back_to_bulk_snapshot`
- [x] **Step 7** -- board 03 regression guard:
  `test_fix_drc_preserves_safe_nudges_on_routed_board` in
  `tests/test_board_03_regression.py`

Plus `test_empty_regressed_set_falls_back_to_bulk` for the
attribution-failure fallback path.

### Acceptance criteria

- [x] Partial rollback reports `Repaired N-K/total` when K < N nudges
      are implicated; the K reverted entries are tagged `(reverted)` in
      the per-category listing
- [x] The `(rolled back -- connectivity regression)` annotation is only
      present on a true full rollback; partial rollback shows
      `(partial rollback -- K nudge(s) reverted on regressed nets)`
- [x] Performance guard: zero `LocalRerouter.reroute_segment` calls
      during rollback (asserted via sentinel monkeypatch)
- [x] On board 03 routed PCB, `fix-drc` repairs ≥1 violation without
      breaking connectivity (the #2839 layer-3 contract)
- [x] All 13 existing `TestConnectivityCheckRollback` tests still pass
- [x] No regression on boards 01 (no violations), 02 (full-rollback path
      preserved when 1 violation -> 1 broken net), 04 (full-rollback
      path preserved when many nudges -> many regressed nets)
- [x] Bulk file-bytes snapshot remains as fallback; a warning is logged
      when it fires after per-nudge undo failure

### Test counts

- `tests/test_fix_drc_cmd.py`: 111 tests pass (105 existing + 6 new)
- `tests/test_repair_clearance.py`: 67 tests pass (no changes)
- `tests/test_route_auto_fix.py`: 33 tests pass (no changes)
- `tests/test_board_03_regression.py::test_fix_drc_preserves_safe_nudges_on_routed_board`:
  passes (2.8 s, regenerate-free)

## References

- Issue #2851 -- this PR
- Parent #2839 -- visibility fixes landed in #2853; this is the
  structural follow-up
- Original board-03 issue #2833 -- routing 9/16 gap