### PR TITLE
fix(router): geometry-based blocker classification — distinguish trace from via clearances

### DIFF
--- a/src/kicad_tools/router/failure_analysis.py
+++ b/src/kicad_tools/router/failure_analysis.py
@@ -1304,9 +1304,7 @@ class RootCauseAnalyzer:
                 )
 
         elif cause == FailureCause.ROUTING_ORDER and blocking_net:
-            suggestions.append(
-                f"Try routing {net_name or 'this net'} before {blocking_net}"
-            )
+            suggestions.append(f"Try routing {net_name or 'this net'} before {blocking_net}")
             actionable.append(
                 ActionableSuggestion(
                     category="routing_order",
@@ -1332,9 +1330,7 @@ class RootCauseAnalyzer:
                     center = corridor.center
                     direction = self._suggest_move_direction(blocking, center)
                     if direction:
-                        suggestions.append(
-                            f"Move {ref_list} {direction} to create routing channel"
-                        )
+                        suggestions.append(f"Move {ref_list} {direction} to create routing channel")
                         for ref in sorted(movable_refs)[:2]:
                             actionable.append(
                                 ActionableSuggestion(
@@ -1455,6 +1451,151 @@ class RootCauseAnalyzer:
         else:
             return "south" if dy > 0 else "north"
 
+    @staticmethod
+    def _classify_blocker_geometry(
+        grid: RoutingGrid,
+        cell_wx: float,
+        cell_wy: float,
+        cell_net: int,
+        layer: int,
+    ) -> str:
+        """Return ``"via"`` or ``"trace"`` by inspecting ``grid.routes`` for ``cell_net``.
+
+        Issue #2858: The ``cell.original_net == 0`` fall-through in
+        :meth:`analyze_pad_access_blockers` cannot distinguish a trace
+        clearance cell from a via clearance cell using ``Cell`` state alone --
+        both have ``pad_blocked=False``, ``usage_count=0``, ``original_net=0``,
+        and ``net=route.net``.  This helper resolves the ambiguity by checking
+        the actual route geometry for ``cell_net``:
+
+        1. If any ``Via`` in those routes is within
+           ``via.diameter/2 + via_clearance + trace_width/2 + safety_margin``
+           of ``(cell_wx, cell_wy)``, return ``"via"`` (matches the radius
+           used by :meth:`grid.Grid._mark_via`).
+        2. Else if any ``Segment`` in those routes has perpendicular distance
+           ``<= seg.width/2 + trace_clearance + safety_margin`` from
+           ``(cell_wx, cell_wy)``, return ``"trace"`` (matches the radius
+           used by :meth:`grid.Grid._mark_segment`).
+        3. Else default to ``"via"`` -- preserves the pre-fix fall-through
+           behaviour for stale/rip-reroute artifacts where the cell's
+           ``net`` no longer matches any current route geometry.
+
+        The safety_margin matches the ``+1 cell`` quantization buffer that
+        ``_mark_via`` (grid.py:2116) and ``_mark_segment`` (grid.py:2010)
+        apply when marking cells.  Constants are pulled from ``grid.rules``
+        and ``grid.resolution`` to stay in sync if the marking radii change.
+
+        Uses the per-layer R-tree (``grid._seg_rtree``) for fast segment
+        proximity queries when available; falls back to linear iteration
+        over ``grid.routes`` when the index is unavailable or has not yet
+        been populated for ``layer``.  Via lists are typically small
+        enough that linear iteration is fine.
+
+        Args:
+            grid: The routing grid (used for ``routes``, ``rules``,
+                ``resolution``, and the R-tree index).
+            cell_wx: World X coordinate of the cell center (mm).
+            cell_wy: World Y coordinate of the cell center (mm).
+            cell_net: Net ID stored on the cell (matches the marking
+                operation's net).
+            layer: Layer index to filter segments by.
+
+        Returns:
+            ``"via"`` or ``"trace"``.
+        """
+        rules = grid.rules
+        # ``_mark_segment`` and ``_mark_via`` both apply two cells of
+        # quantization buffer when computing the halo: one cell for the
+        # ``int(... / resolution) + 1`` round-up plus one cell for the
+        # explicit safety margin (Issue #1666 / #1797).  Plus, the actual
+        # marking uses Chebyshev (square) cells, so a corner cell at
+        # ``N`` cells away has world distance up to ``N * sqrt(2) *
+        # resolution``.  Use ``2 * resolution`` as the safety buffer for
+        # this Euclidean radius check so it conservatively covers the
+        # worst-case quantization corner.
+        safety_margin = 2.0 * grid.resolution
+        trace_w = rules.trace_width
+
+        # Step 1: Via proximity check.  Iterate vias of matching net linearly
+        # (typical route has O(1) vias; small enough that R-tree is overkill).
+        for route in grid.routes:
+            if route.net != cell_net:
+                continue
+            for via in route.vias:
+                via_radius = via.diameter / 2 + rules.via_clearance + trace_w / 2 + safety_margin
+                dx = via.x - cell_wx
+                dy = via.y - cell_wy
+                if dx * dx + dy * dy <= via_radius * via_radius:
+                    return "via"
+
+        # Step 2: Segment proximity check.  Use the R-tree when available
+        # (Issue #1249) to prune candidates by bounding box before exact
+        # distance evaluation.  The R-tree envelopes are already inflated by
+        # ``grid._rtree_clearance_inflation`` (= max_clearance), so any
+        # segment within trace clearance of the cell point is guaranteed to
+        # have its envelope contain the cell point's bbox.
+        #
+        # Per-candidate radius uses ``seg.width`` (not ``rules.trace_width``)
+        # to mirror ``_mark_segment``'s halo computation: wider net-class
+        # traces have larger envelopes than ``rules.trace_width`` would
+        # suggest.
+
+        use_rtree = (
+            grid._rtree_available and layer in grid._seg_rtree and grid._seg_rtree_count >= 1
+        )
+
+        if use_rtree:
+            # Query envelope sized to capture any segment whose halo could
+            # reach this cell.  The maximum segment halo radius for the
+            # default net class is ``trace_width / 2 + trace_clearance +
+            # safety_margin``; wide net-class traces can be larger but the
+            # R-tree envelopes are already inflated by
+            # ``_rtree_clearance_inflation`` (= ``rules.max_clearance``)
+            # which covers the worst-case net-class clearance.  Expand the
+            # query box by ``max_clearance + trace_width / 2 + safety_margin``
+            # so the resulting intersection covers every segment within
+            # halo distance of the cell point.
+            query_expand = rules.max_clearance + trace_w / 2 + safety_margin
+            query_envelope = (
+                cell_wx - query_expand,
+                cell_wy - query_expand,
+                cell_wx + query_expand,
+                cell_wy + query_expand,
+            )
+            candidate_ids = list(grid._seg_rtree[layer].intersection(query_envelope))
+            layer_items = grid._seg_rtree_items.get(layer, {})
+            for cand_id in candidate_ids:
+                seg = layer_items.get(cand_id)
+                if seg is None or seg.net != cell_net:
+                    continue
+                dist = grid._point_to_segment_distance(
+                    cell_wx, cell_wy, seg.x1, seg.y1, seg.x2, seg.y2
+                )
+                seg_radius = seg.width / 2 + rules.trace_clearance + safety_margin
+                if dist <= seg_radius:
+                    return "trace"
+        else:
+            # Brute-force fallback when the R-tree is unavailable or empty.
+            for route in grid.routes:
+                if route.net != cell_net:
+                    continue
+                for seg in route.segments:
+                    if grid.layer_to_index(seg.layer.value) != layer:
+                        continue
+                    dist = grid._point_to_segment_distance(
+                        cell_wx, cell_wy, seg.x1, seg.y1, seg.x2, seg.y2
+                    )
+                    seg_radius = seg.width / 2 + rules.trace_clearance + safety_margin
+                    if dist <= seg_radius:
+                        return "trace"
+
+        # Step 3: Default to "via" -- preserves the pre-fix fall-through for
+        # stale or rip-reroute artifacts where the cell's net no longer
+        # matches any current route geometry.  Avoids a sudden behavioural
+        # change for cells that the prior cascade also fell through to
+        # ``"via"``.
+        return "via"
+
     def analyze_pad_access_blockers(
         self,
         grid: RoutingGrid,
@@ -1534,8 +1675,15 @@ class RootCauseAnalyzer:
                 # pad-clearance zone): ``_mark_via`` overwrites ``cell.net`` to
                 # the via's net while ``cell.original_net`` stays at the
                 # pad's net. The discriminator fails and the cell correctly
-                # falls through to ``"via"`` -- matching operator intent that
-                # the immediate blocker is the via's clearance ring.
+                # falls through to the geometry classifier below -- matching
+                # operator intent that the immediate blocker is the via's
+                # clearance ring.
+                #
+                # Issue #2858: The ``cell.original_net == 0`` else branch
+                # cannot distinguish trace clearance from via clearance from
+                # Cell state alone, so it delegates to
+                # ``_classify_blocker_geometry`` which inspects
+                # ``grid.routes`` to decide.
                 if cell.pad_blocked:
                     blocking_type = "pad"
                 elif cell.usage_count > 0:
@@ -1543,7 +1691,22 @@ class RootCauseAnalyzer:
                 elif cell.original_net != 0 and cell.original_net == cell.net:
                     blocking_type = "pad_clearance"
                 else:
-                    blocking_type = "via"
+                    # Issue #2858: ``cell.original_net == 0`` can mean either
+                    # a via clearance cell or a trace clearance cell -- both
+                    # have identical Cell state shape (``pad_blocked=False``,
+                    # ``usage_count=0``, ``original_net=0``).  Inspect
+                    # ``grid.routes`` for ``cell.net`` to disambiguate by
+                    # actual route geometry rather than defaulting to
+                    # ``"via"`` (which misroutes the downstream resolver to
+                    # ``ViaConflictManager`` for trace blockers; see
+                    # ``core.py:9018``).
+                    blocking_type = self._classify_blocker_geometry(
+                        grid=grid,
+                        cell_wx=cell_wx,
+                        cell_wy=cell_wy,
+                        cell_net=cell.net,
+                        layer=layer,
+                    )
 
                 # Track closest element for this net
                 net_id = cell.net

--- a/tests/test_board_03_regression.py
+++ b/tests/test_board_03_regression.py
@@ -232,46 +232,38 @@ def test_usb_diff_pair_routes_via_coupled_pathfinder(routed_board_03) -> None:
 
 
 def test_xtal2_unblocks_via_conflict_resolution(routed_board_03) -> None:
-    """ViaConflictManager wiring is exercised on board 03's XTAL2 failure path.
+    """ViaConflictManager wiring exists and is not invoked spuriously on XTAL2.
 
     Issue #2838 (closes #2761 gap): On ``main`` at the branch point,
     ``Autorouter`` has no ``_via_manager`` attribute at all and the
     PIN_ACCESS retry path in ``route_net`` never invokes via-conflict
-    resolution.  XTAL2 fails ``PIN_ACCESS`` on the U1.3 -> C6.1 edge
-    (the failure analyser reports U1.3 as blocked by a XTAL1 "via at
-    0.32mm") and the failure is terminal.
+    resolution.  This regression test asserts the **structural wiring**
+    is in place: after ``route_all_with_diffpairs`` the
+    ``Autorouter._via_manager`` attribute exists (lazy property
+    initialized to ``None``).
 
-    This regression test asserts the **structural wiring** is in place:
-    after ``route_all_with_diffpairs`` the ``Autorouter._via_manager``
-    attribute exists and has been instantiated, meaning the PIN_ACCESS
-    retry block in ``route_net`` reached the via-conflict resolution
-    branch.  This is the minimum verifiable bar for the #2838 wiring
-    fix on a real board.
+    Issue #2858 (this PR): Fixed the misclassification of XTAL2's
+    XTAL1 blocker.  Pre-fix the failure analyser reported a XTAL1
+    "via at 0.32mm" blocker that triggered ``ViaConflictManager`` --
+    which then found 0 vias to relocate because the real obstacle is
+    a XTAL1 *trace* segment (the nearest XTAL1 via is 7.5 mm away).
+    Post-fix the classifier correctly reports the blocker as
+    ``blocking_type="trace"``, so ``_resolve_via_conflicts_for_net``
+    early-returns at the ``has_via_blocker`` gate (``core.py:9018-9023``)
+    WITHOUT invoking ``ViaConflictManager``.  Net result: the
+    ``via_manager`` lazy property never fires, and
+    ``router._via_manager`` remains ``None``.
 
-    *Caveat — XTAL2 doesn't fully route after this fix.*  Inspection
-    of board 03's actual routed state shows that XTAL1's nearest via
-    is 7.5 mm from U1.3, well outside any via-clearance zone.  The
-    failure analyser's classification of the U1.3 blocker as
-    ``blocking_type="via"`` is misleading: the real blocker is a
-    XTAL1 *trace* segment whose clearance envelope sits ~0.9 mm from
-    U1.3.  Because ``ViaConflictManager.find_blocking_vias`` only
-    scans actual ``Via`` objects on ``grid.routes``, it correctly
-    reports ``conflicts_found == 0`` for this board -- there is no
-    via to relocate.  Fully unblocking XTAL2 requires either:
+    Acceptance criteria (Issue #2858):
+      1. ``hasattr(router, "_via_manager")`` -- wiring still in place.
+      2. XTAL2's failure surfaces a XTAL1 ``"trace"`` blocker (pinned
+         by ``test_xtal2_failure_classified_as_trace_blocker``).
+      3. ``router._via_manager`` is ``None`` for this board -- the
+         resolver is NOT engaged spuriously when the only blockers
+         are traces.
 
-    1. Fixing the failure analyser's ``via`` vs ``trace`` classification
-       (the ``cell.original_net == 0`` fall-through at
-       ``failure_analysis.py:1546`` defaults to ``"via"`` for trace
-       clearance cells), or
-    2. Extending ``ViaConflictManager`` to also relocate / rip-reroute
-       *trace* segments (much larger scope -- out of scope per the
-       issue's "Out of scope" section).
-
-    Both are tracked separately.  For this PR, the success criterion
-    is the wiring -- which the synthetic test in
-    ``tests/test_via_conflict.py::TestViaConflictManagerIntegration``
-    pins more directly (it constructs a real via blocker and asserts
-    ``relocations_succeeded + rip_reroutes_succeeded >= 1``).
+    Fully unblocking XTAL2 requires a downstream trace-clearance
+    resolver tracked in #2859 -- out of scope for this PR.
     """
     router, net_map = routed_board_03
 
@@ -283,9 +275,7 @@ def test_xtal2_unblocks_via_conflict_resolution(routed_board_03) -> None:
         "schematic / PCB generator no longer emits XTAL1, this test "
         "needs to be updated."
     )
-    assert xtal2_id is not None, (
-        "XTAL2 net missing from board 03 unrouted PCB -- see XTAL1 note."
-    )
+    assert xtal2_id is not None, "XTAL2 net missing from board 03 unrouted PCB -- see XTAL1 note."
 
     routes_by_net: dict[int, int] = {}
     for route in router.routes:
@@ -317,18 +307,137 @@ def test_xtal2_unblocks_via_conflict_resolution(routed_board_03) -> None:
         "self._via_manager."
     )
 
-    # Resolver-was-reached assertion: the lazy ``via_manager`` property
-    # was triggered, meaning ``_resolve_via_conflicts_for_net`` ran on
-    # at least one PIN_ACCESS failure during the routing pass.  XTAL2
-    # is the canonical trigger (its failure analyser reports a
-    # ``blocking_type == "via"`` blocker -- regardless of whether the
-    # underlying obstacle is actually a via or a misclassified trace).
-    assert router._via_manager is not None, (
-        "Autorouter._via_manager is None after route_all_with_diffpairs.  "
-        "The PIN_ACCESS retry block in route_net() did not call "
-        "_resolve_via_conflicts_for_net for any net.  Board 03's XTAL2 "
-        "should have triggered it -- check that the PIN_ACCESS gate at "
-        "core.py:1530 still fires when waypoint injection is on."
+    # Issue #2858 acceptance criterion 3: ``_resolve_via_conflicts_for_net``
+    # MUST NOT be invoked spuriously for XTAL2's failure.  Pre-fix the
+    # XTAL1 blocker was misclassified as ``"via"`` and triggered the
+    # resolver (which then found 0 vias to relocate).  Post-fix the
+    # blocker is correctly classified as ``"trace"`` and the resolver
+    # early-returns at ``core.py:9023`` -- the lazy ``via_manager``
+    # property is never accessed.
+    #
+    # The XTAL2-specific guarantee comes from
+    # ``test_xtal2_failure_classified_as_trace_blocker``, which pins the
+    # ``blocking_type == "trace"`` classification on the same failure
+    # record.  Together the two tests pin the full Issue #2858 acceptance.
+    assert router._via_manager is None, (
+        "Issue #2858 acceptance criterion: ``ViaConflictManager`` should "
+        "NOT be invoked spuriously for XTAL2 on board 03 anymore.  The "
+        "lazy ``via_manager`` property is initialised on first access "
+        "from ``_resolve_via_conflicts_for_net``, so a non-None value "
+        "here means the resolver ran on at least one net.  XTAL2's "
+        "XTAL1 blocker should now classify as 'trace' (see "
+        "test_xtal2_failure_classified_as_trace_blocker) and the "
+        "``has_via_blocker`` gate at ``core.py:9018-9023`` should "
+        "early-return WITHOUT touching ``self.via_manager``.  If this "
+        "fails, either: (1) the classifier regressed and the blocker is "
+        "back to ``'via'``, or (2) another net on this board has a "
+        "genuine via blocker that the resolver legitimately needs to "
+        "handle -- in which case file a follow-up and adjust this "
+        "assertion to target XTAL2 specifically via ``manager.stats``."
+    )
+
+
+def test_xtal2_failure_classified_as_trace_blocker(routed_board_03) -> None:
+    """Issue #2858: XTAL2's pad-access blocker (if any) must surface as ``"trace"``.
+
+    Pre-fix behaviour (the bug):
+      The failure analyser at ``failure_analysis.py:1546`` defaulted to
+      ``blocking_type == "via"`` for any cell that wasn't a pad, trace
+      centerline, or pad-clearance zone.  XTAL2's U1.3 pad was blocked
+      by a XTAL1 *trace* clearance halo (~0.3-0.9 mm from the pad), not
+      a via (nearest XTAL1 via is 7.5 mm away).  Reporting ``"via"``
+      misrouted the failure to ``ViaConflictManager`` which then found
+      nothing to relocate, leaving the failure terminal.
+
+    Post-fix behaviour (two valid outcomes -- both pass this test):
+
+      A. **XTAL2 routes fully.**  The classifier fix changes the
+         ``_resolve_via_conflicts_for_net`` early-return point, which
+         in turn changes the downstream negotiated-routing strategy's
+         exploration path enough that XTAL2 finds a working route.
+         This is a positive side effect of the fix: with the spurious
+         ``ViaConflictManager`` engagement gone, the negotiated /
+         rip-up-and-reroute strategy has more iterations available
+         and can solve the routing.
+
+      B. **XTAL2 fails with a ``"trace"``-classified blocker.**  If
+         the routing strategy still cannot solve XTAL2 (e.g. on a
+         different machine or after future strategy tuning that
+         changes iteration counts), the failure record must report
+         the XTAL1 blocker as ``blocking_type == "trace"`` rather
+         than ``"via"`` -- the actual Issue #2858 acceptance criterion.
+
+    Either outcome confirms the fix: outcome A is empirical evidence
+    the misclassification was load-bearing in the resolver flow, and
+    outcome B directly pins the classifier change.  The fail case is
+    "blocker classified as 'via'" -- which would mean the classifier
+    fix regressed.
+
+    References:
+      - Issue #2858 (this fix)
+      - PR #2856 / Issue #2838 (XTAL2 wiring fix that exposed this bug)
+      - Issue #2859 (trace-clearance resolver, dependent on this fix)
+    """
+    router, net_map = routed_board_03
+
+    xtal1_id = net_map.get("XTAL1")
+    xtal2_id = net_map.get("XTAL2")
+    assert xtal1_id is not None and xtal2_id is not None, (
+        "XTAL1 / XTAL2 nets missing from board 03; see "
+        "test_xtal2_unblocks_via_conflict_resolution for the canonical "
+        "skip path."
+    )
+
+    xtal2_failures = [f for f in router.routing_failures if f.net == xtal2_id]
+
+    # Outcome A: XTAL2 routes fully (no failures recorded).  This is a
+    # legitimate post-fix outcome; the classifier acceptance is then
+    # pinned by the synthetic tests in
+    # ``tests/test_failure_analysis.py::TestBlockerGeometryClassifier``.
+    if not xtal2_failures:
+        # Verify XTAL2 actually has routes (not just absent from
+        # routing_failures due to never being attempted).
+        xtal2_segs = sum(
+            len(r.segments) for r in router.routes if r.net == xtal2_id
+        )
+        assert xtal2_segs > 0, (
+            "XTAL2 has no failures AND no routes -- it was skipped "
+            "entirely, not routed.  Check that the routing pass still "
+            "attempts XTAL2; if the skip list grew, update SKIP_NETS."
+        )
+        return
+
+    # Outcome B: XTAL2 still fails -- the classifier fix must surface
+    # the XTAL1 blocker as ``"trace"`` rather than ``"via"``.
+    xtal1_blockers = []
+    for failure in xtal2_failures:
+        if failure.analysis is None:
+            continue
+        for blocker in failure.analysis.pad_access_blockers:
+            if blocker.blocking_net == xtal1_id:
+                xtal1_blockers.append(blocker)
+
+    assert len(xtal1_blockers) >= 1, (
+        f"XTAL2 failed but no XTAL1 blocker appears in its "
+        f"pad_access_blockers records: {[f.analysis for f in xtal2_failures]!r}. "
+        "If the failure analyser is no longer emitting pad_access_blockers "
+        "for this case, this test needs to be updated; see issue #2858 "
+        "for what changed in the analyser."
+    )
+
+    # The Issue #2858 acceptance criterion: at least one XTAL1 blocker on
+    # XTAL2's failure must be classified ``"trace"``, not ``"via"``.
+    # Pre-fix ALL of these would be classified ``"via"``; post-fix the
+    # closest blocker (the segment halo) must be ``"trace"``.
+    trace_classified = [b for b in xtal1_blockers if b.blocking_type == "trace"]
+    assert len(trace_classified) >= 1, (
+        "Issue #2858 acceptance criterion: XTAL2's failure must report a "
+        "XTAL1 blocker with blocking_type='trace' (the real obstacle is a "
+        "XTAL1 trace segment clearance halo, ~0.3-0.9 mm from U1.3).  Got "
+        f"blocker types: {[b.blocking_type for b in xtal1_blockers]!r}.  "
+        "If this test fails, check that "
+        "_classify_blocker_geometry (failure_analysis.py) was invoked "
+        "from the else branch of analyze_pad_access_blockers's cascade."
     )
 
 

--- a/tests/test_failure_analysis.py
+++ b/tests/test_failure_analysis.py
@@ -18,7 +18,7 @@ from kicad_tools.router.failure_analysis import (
 )
 from kicad_tools.router.grid import RoutingGrid
 from kicad_tools.router.layers import Layer, LayerStack
-from kicad_tools.router.primitives import Pad, Via
+from kicad_tools.router.primitives import Pad, Route, Segment, Via
 from kicad_tools.router.rules import DesignRules
 
 
@@ -772,6 +772,357 @@ class TestPadAccessBlocker:
         assert "0.12" in s
 
 
+class TestBlockerGeometryClassifier:
+    """Issue #2858: geometry-based classification of trace vs via blockers.
+
+    The pre-fix cascade at ``failure_analysis.py:1539-1546`` defaulted to
+    ``"via"`` whenever the first three predicates fell through, which
+    misclassified *trace clearance* cells (which have the exact same
+    ``Cell`` state shape as via clearance cells:
+    ``pad_blocked=False``, ``usage_count=0``, ``original_net=0``).
+    The post-fix path delegates the else branch to
+    ``_classify_blocker_geometry``, which inspects ``grid.routes`` for
+    the cell's net and picks ``"trace"`` vs ``"via"`` by checking which
+    geometric envelope the cell falls inside.
+
+    These tests pin both the new behaviour and the cascade-order
+    invariants so regressions surface before they reach a real board.
+    """
+
+    def test_trace_clearance_classified_as_trace(self, routing_grid: RoutingGrid) -> None:
+        """A cell inside a segment's clearance envelope -> ``"trace"``.
+
+        Fails on main: the pre-fix cascade falls through to ``"via"``.
+        Passes after fix: ``_classify_blocker_geometry`` inspects
+        ``grid.routes`` and matches the segment's clearance halo.
+        """
+        # Target pad (the victim we'll analyse) at (25, 25).
+        victim = Pad(
+            x=25.0,
+            y=25.0,
+            width=0.5,
+            height=0.5,
+            net=1,
+            net_name="VICTIM",
+            layer=Layer.F_CU,
+        )
+        routing_grid.add_pad(victim)
+
+        # Lay down a horizontal segment from a different net (net=2) just
+        # outside the segment centerline but well inside its clearance halo.
+        # ``_mark_segment`` halo radius =
+        #     seg.width / 2 + trace_clearance + safety_margin (1 cell)
+        # With default rules (trace_width=0.2, trace_clearance=0.15), that's
+        # 0.1 + 0.15 + 0.1 = 0.35 mm.  Place the segment 0.3 mm above the
+        # victim so the cell at the pad's location is inside the halo but
+        # outside the centerline.
+        rules = routing_grid.rules
+        offset = rules.trace_width / 2 + rules.trace_clearance + 0.5 * routing_grid.resolution
+        seg = Segment(
+            x1=20.0,
+            y1=25.0 + offset,
+            x2=30.0,
+            y2=25.0 + offset,
+            width=rules.trace_width,
+            layer=Layer.F_CU,
+            net=2,
+            net_name="OTHER",
+        )
+        route = Route(net=2, net_name="OTHER", segments=[seg])
+        routing_grid.mark_route(route)
+
+        analyzer = RootCauseAnalyzer()
+        blockers = analyzer.analyze_pad_access_blockers(
+            grid=routing_grid,
+            pad_x=25.0,
+            pad_y=25.0,
+            pad_ref="U1.1",
+            pad_net=1,
+            layer=0,
+            net_names={1: "VICTIM", 2: "OTHER"},
+        )
+
+        other_blockers = [b for b in blockers if b.blocking_net == 2]
+        assert len(other_blockers) >= 1, (
+            f"Expected the OTHER segment's clearance halo to register as a "
+            f"blocker on the VICTIM pad, got: {blockers!r}"
+        )
+        assert any(b.blocking_type == "trace" for b in other_blockers), (
+            "Issue #2858: a segment clearance cell must classify as "
+            f"'trace', got: {[b.blocking_type for b in other_blockers]!r}"
+        )
+
+    def test_via_clearance_classified_as_via(self, routing_grid: RoutingGrid) -> None:
+        """A cell inside a via's clearance ring -> ``"via"``.
+
+        Regression guard: must still pass after the Issue #2858 fix.
+        Passes on main as well (the pre-fix default already returns
+        ``"via"`` here); the new path resolves the same answer by
+        geometric inspection.
+        """
+        victim = Pad(
+            x=25.0,
+            y=25.0,
+            width=0.5,
+            height=0.5,
+            net=1,
+            net_name="VICTIM",
+            layer=Layer.F_CU,
+        )
+        routing_grid.add_pad(victim)
+
+        # Place a via from net 2 just inside its own clearance ring of
+        # the victim pad's cell.  ``_mark_via`` radius =
+        #     via.diameter/2 + via_clearance + trace_width/2 + safety_margin
+        # = 0.3 + 0.2 + 0.1 + 0.1 = 0.7 mm.  Put the via at ~0.6 mm so the
+        # victim pad center is well inside the halo.
+        rules = routing_grid.rules
+        via_offset = (
+            0.6 / 2 + rules.via_clearance + rules.trace_width / 2 - 0.5 * routing_grid.resolution
+        )
+        offending_via = Via(
+            x=25.0 + via_offset,
+            y=25.0,
+            drill=0.3,
+            diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU),
+            net=2,
+            net_name="OTHER",
+        )
+        # Route the via through ``mark_route`` so it lands in ``grid.routes``
+        # (the new classifier inspects ``grid.routes`` rather than scanning
+        # all blocked cells).
+        route = Route(net=2, net_name="OTHER", vias=[offending_via])
+        routing_grid.mark_route(route)
+
+        analyzer = RootCauseAnalyzer()
+        blockers = analyzer.analyze_pad_access_blockers(
+            grid=routing_grid,
+            pad_x=25.0,
+            pad_y=25.0,
+            pad_ref="U1.1",
+            pad_net=1,
+            layer=0,
+            net_names={1: "VICTIM", 2: "OTHER"},
+        )
+
+        via_blockers = [b for b in blockers if b.blocking_net == 2]
+        assert len(via_blockers) >= 1, (
+            f"Expected the OTHER via's clearance ring to register as a "
+            f"blocker on the VICTIM pad, got: {blockers!r}"
+        )
+        assert all(b.blocking_type == "via" for b in via_blockers), (
+            "Issue #2858 regression guard: an isolated via must still "
+            f"classify as 'via', got: {[b.blocking_type for b in via_blockers]!r}"
+        )
+
+    def test_both_blockers_pick_closest(self, routing_grid: RoutingGrid) -> None:
+        """When both segment and via from the same net block a pad, the
+        closest cell wins; the classifier returns the type matching the
+        closest cell's geometric envelope.
+
+        Geometry: place the segment closer than the via.  The closest
+        blocking cell will be inside the segment's clearance halo, so the
+        net_closest map should record ``"trace"`` for net=2.
+        """
+        victim = Pad(
+            x=25.0,
+            y=25.0,
+            width=0.5,
+            height=0.5,
+            net=1,
+            net_name="VICTIM",
+            layer=Layer.F_CU,
+        )
+        routing_grid.add_pad(victim)
+
+        rules = routing_grid.rules
+        # Segment trace 0.4 mm above the pad (closest cell ~0.05 mm
+        # above the pad metal edge).
+        seg_offset = rules.trace_width / 2 + rules.trace_clearance + 0.5 * routing_grid.resolution
+        close_seg = Segment(
+            x1=20.0,
+            y1=25.0 + seg_offset,
+            x2=30.0,
+            y2=25.0 + seg_offset,
+            width=rules.trace_width,
+            layer=Layer.F_CU,
+            net=2,
+            net_name="OTHER",
+        )
+        # Via 1.5 mm to the east, just inside its own clearance ring but
+        # farther from the pad than the segment.
+        far_via = Via(
+            x=25.0 + 1.5,
+            y=25.0,
+            drill=0.3,
+            diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU),
+            net=2,
+            net_name="OTHER",
+        )
+        route = Route(net=2, net_name="OTHER", segments=[close_seg], vias=[far_via])
+        routing_grid.mark_route(route)
+
+        analyzer = RootCauseAnalyzer()
+        blockers = analyzer.analyze_pad_access_blockers(
+            grid=routing_grid,
+            pad_x=25.0,
+            pad_y=25.0,
+            pad_ref="U1.1",
+            pad_net=1,
+            layer=0,
+            net_names={1: "VICTIM", 2: "OTHER"},
+        )
+
+        other_blockers = [b for b in blockers if b.blocking_net == 2]
+        assert len(other_blockers) == 1, (
+            "Expected exactly one entry for OTHER (closest cell wins per net), "
+            f"got: {other_blockers!r}"
+        )
+        # The closest blocking cell sits inside the segment halo, so the
+        # geometry classifier should return 'trace'.
+        assert other_blockers[0].blocking_type == "trace", (
+            "Closest cell is inside the segment clearance halo; expected "
+            f"'trace' classification, got: {other_blockers[0].blocking_type!r}"
+        )
+
+    def test_pad_blocked_takes_precedence(self, routing_grid: RoutingGrid) -> None:
+        """``pad_blocked`` must win over geometry inspection (cascade order).
+
+        Even if a route from the same blocking net's geometry is also
+        present, the ``pad_blocked`` predicate fires first.
+        """
+        victim = Pad(
+            x=25.0,
+            y=25.0,
+            width=0.5,
+            height=0.5,
+            net=1,
+            net_name="VICTIM",
+            layer=Layer.F_CU,
+        )
+        # Place a foreign pad whose metal cell overlaps the search radius
+        # of the victim pad.  ``_block_pad`` sets ``pad_blocked=True`` on
+        # the metal cells, and that predicate is first in the cascade.
+        blocker_pad = Pad(
+            x=25.5,
+            y=25.0,
+            width=0.5,
+            height=0.5,
+            net=2,
+            net_name="OTHER",
+            layer=Layer.F_CU,
+        )
+        routing_grid.add_pad(victim)
+        routing_grid.add_pad(blocker_pad)
+
+        # Also add a Route from net=2 to ensure geometry inspection has
+        # something to find -- the predicate cascade must NOT delegate to
+        # geometry when pad_blocked is True.
+        far_seg = Segment(
+            x1=30.0,
+            y1=30.0,
+            x2=35.0,
+            y2=30.0,
+            width=routing_grid.rules.trace_width,
+            layer=Layer.F_CU,
+            net=2,
+            net_name="OTHER",
+        )
+        routing_grid.mark_route(Route(net=2, net_name="OTHER", segments=[far_seg]))
+
+        analyzer = RootCauseAnalyzer()
+        blockers = analyzer.analyze_pad_access_blockers(
+            grid=routing_grid,
+            pad_x=25.0,
+            pad_y=25.0,
+            pad_ref="U1.1",
+            pad_net=1,
+            layer=0,
+            net_names={1: "VICTIM", 2: "OTHER"},
+        )
+
+        other_blockers = [b for b in blockers if b.blocking_net == 2]
+        assert len(other_blockers) >= 1
+        # The metal cell of the foreign pad must dominate the closest cell
+        # search, and the cascade short-circuits at ``pad_blocked`` -> 'pad'.
+        assert other_blockers[0].blocking_type == "pad", (
+            "Issue #2858 cascade-order guard: ``pad_blocked`` must take "
+            f"precedence over geometry inspection, got: "
+            f"{other_blockers[0].blocking_type!r}"
+        )
+
+    def test_pad_clearance_takes_precedence(self, routing_grid: RoutingGrid) -> None:
+        """``original_net != 0 and == cell.net`` must win over geometry.
+
+        Reproduces the Issue #2810 pad-clearance test scenario but also
+        adds a foreign-net route so the geometry classifier *would*
+        return ``"trace"`` if invoked.  The cascade must short-circuit
+        at ``pad_clearance`` before reaching the geometry check.
+        """
+        victim = Pad(
+            x=25.0,
+            y=25.0,
+            width=0.2,
+            height=0.2,
+            net=1,
+            net_name="VICTIM",
+            layer=Layer.F_CU,
+        )
+        neighbor = Pad(
+            x=25.8,
+            y=25.0,
+            width=0.2,
+            height=0.2,
+            net=2,
+            net_name="NEIGHBOR",
+            layer=Layer.F_CU,
+        )
+        routing_grid.add_pad(victim)
+        routing_grid.add_pad(neighbor)
+
+        # Also add a segment from the same NEIGHBOR net so geometry would
+        # match if invoked.  The expected behaviour: the pad_clearance
+        # predicate fires first (because the neighbor's pad-clearance
+        # cells have ``original_net == net == 2``), so the geometry
+        # classifier is NOT consulted for those cells.
+        rules = routing_grid.rules
+        seg_offset = rules.trace_width / 2 + rules.trace_clearance + 0.5 * routing_grid.resolution
+        far_seg = Segment(
+            x1=22.0,
+            y1=25.0 - seg_offset,
+            x2=23.0,
+            y2=25.0 - seg_offset,
+            width=rules.trace_width,
+            layer=Layer.F_CU,
+            net=2,
+            net_name="NEIGHBOR",
+        )
+        routing_grid.mark_route(Route(net=2, net_name="NEIGHBOR", segments=[far_seg]))
+
+        analyzer = RootCauseAnalyzer()
+        blockers = analyzer.analyze_pad_access_blockers(
+            grid=routing_grid,
+            pad_x=25.0,
+            pad_y=25.0,
+            pad_ref="U1.1",
+            pad_net=1,
+            layer=0,
+            net_names={1: "VICTIM", 2: "NEIGHBOR"},
+        )
+
+        neighbor_blockers = [b for b in blockers if b.blocking_net == 2]
+        assert len(neighbor_blockers) >= 1
+        # The closest blocking cell must be in the neighbor's pad
+        # clearance envelope (not the more distant segment halo).
+        assert neighbor_blockers[0].blocking_type == "pad_clearance", (
+            "Issue #2858 cascade-order guard: ``pad_clearance`` predicate "
+            f"must take precedence over geometry inspection, got: "
+            f"{neighbor_blockers[0].blocking_type!r}"
+        )
+
+
 class TestAnalyzePadAccessBlockers:
     """Tests for analyze_pad_access_blockers method."""
 
@@ -823,9 +1174,7 @@ class TestAnalyzePadAccessBlockers:
         # The blocking element should be from net 2
         assert any(b.blocking_net == 2 for b in blockers)
 
-    def test_analyze_pad_access_blockers_same_net_not_blocked(
-        self, routing_grid: RoutingGrid
-    ):
+    def test_analyze_pad_access_blockers_same_net_not_blocked(self, routing_grid: RoutingGrid):
         """Test that same net elements don't count as blockers."""
         # Add a pad from same net
         same_net_pad = Pad(
@@ -920,9 +1269,7 @@ class TestAnalyzePadAccessBlockers:
             f"clearance zone, got: {[b.blocking_type for b in neighbor_blockers]!r}"
         )
 
-    def test_analyze_pad_access_blockers_via_remains_via(
-        self, routing_grid: RoutingGrid
-    ):
+    def test_analyze_pad_access_blockers_via_remains_via(self, routing_grid: RoutingGrid):
         """Issue #2810 regression guard: real vias must still classify as ``via``.
 
         Places only a via (no pads in the search radius) and confirms the new


### PR DESCRIPTION
## Summary

Closes #2858.

Fixes the failure analyser's cell-state cascade at `failure_analysis.py:1539-1546` to distinguish trace clearance cells from via clearance cells. Previously the cascade defaulted to `"via"` whenever the prior three predicates fell through, but trace and via clearance cells have identical Cell state shape (`pad_blocked=False`, `usage_count=0`, `original_net=0`), so trace blockers were misrouted to `ViaConflictManager` -- which then found nothing to relocate and the failure went unresolved.

The fix adds a new `RootCauseAnalyzer._classify_blocker_geometry` helper that inspects `grid.routes` for the cell's net and decides `"via"` vs `"trace"` by matching the actual marking radii used by `_mark_via` (`grid.py:2069-2138`) and `_mark_segment` (`grid.py:2018-2067`).  Constants are pulled from `grid.rules` so they stay in sync if the marking radii change.  Uses the per-layer R-tree (`grid._seg_rtree`) for fast segment lookup; falls back to linear iteration otherwise.

## Cascade order preserved

The first three predicates are kept verbatim:
1. `cell.pad_blocked` -> `"pad"`
2. `cell.usage_count > 0` -> `"trace"`
3. `cell.original_net != 0 and cell.original_net == cell.net` -> `"pad_clearance"`

Only the else branch delegates to the new helper.  Cascade-order guards are pinned by two of the new synthetic tests.

## Acceptance criteria (Issue #2858)

1. `find_pad_access_blockers` returns `"trace"` for cells inside a segment's clearance envelope.
2. `find_pad_access_blockers` returns `"via"` for cells inside a via's clearance ring.
3. `Autorouter._resolve_via_conflicts_for_net` is NOT invoked spuriously for XTAL2 on board 03.
4. Board 03 XTAL2 blocker surfaces as `"trace"` when it fails (or the net routes successfully).

## Positive side effect

After this fix, board 03's XTAL2 net (the canonical Issue #2858 example) actually **routes successfully** on most runs. The pre-fix spurious `ViaConflictManager` engagement was apparently consuming negotiated-routing iteration budget that the strategy could now redirect to a working solution path.  The new board 03 test handles both outcomes: a clean XTAL2 route OR a `"trace"`-classified failure.

## Test plan

- [x] 5 new synthetic unit tests in new `TestBlockerGeometryClassifier` class (`tests/test_failure_analysis.py`):
  - `test_trace_clearance_classified_as_trace` -- the core fix
  - `test_via_clearance_classified_as_via` -- regression guard
  - `test_both_blockers_pick_closest`
  - `test_pad_blocked_takes_precedence` -- cascade order guard
  - `test_pad_clearance_takes_precedence` -- cascade order guard
- [x] Updated `test_xtal2_unblocks_via_conflict_resolution` (`tests/test_board_03_regression.py`) -- now asserts `router._via_manager is None` (criterion #3).
- [x] New `test_xtal2_failure_classified_as_trace_blocker` (`tests/test_board_03_regression.py`) -- pins the `"trace"` classification when XTAL2 fails.
- [x] Full `tests/test_failure_analysis.py` (65 tests) still passes.
- [x] `tests/test_via_conflict.py` (27 tests) still passes.
- [x] Full `tests/test_board_03_regression.py` (6 tests) passes.

## Out of scope

- Extending `ViaConflictManager` (or sibling) to actually relocate trace clearances when classified `"trace"`.  Tracked in #2859 and explicitly dependent on this fix.
- Refactoring the cell schema to add `from_trace`/`from_via` flags so the classifier can be O(1) -- larger change with grid-serialization implications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)