### PR TITLE
fix(router): narrow-channel guard prevents fine-pitch halo shrink when geometrically infeasible

### DIFF
--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -776,25 +776,68 @@ class RoutingGrid:
         a passive's clearance halo to the BGA pad whose *real* envelope
         was the smaller fine-pitch one.
 
+        Issue #2865 -- narrow-channel guard: the fine-pitch shrink
+        (``min_trace_width / 2``) is only a sound optimisation when the
+        resulting *inter-pad* channel is wide enough that a trace centred
+        in it still satisfies full manufacturer clearance against both
+        flanking pads.  On crowded packages such as LQFP-48 0.5 mm pitch
+        with jlcpcb-tier1 rules (``min_trace=min_clearance=0.127 mm``),
+        threading a signal trace between adjacent pads is geometrically
+        infeasible: the required channel is ``2*clearance + trace_width =
+        0.381 mm`` but only ~0.25 mm of edge-to-edge gap exists.  In that
+        situation shrinking the halo to ``0.0635 mm`` only fools the
+        pathfinder into producing a route that DRC then rejects -- the
+        observed pathology behind 44 ``clearance_pad_segment`` errors on
+        board 04's STM32 west edge.  When the shrunk channel is too
+        narrow we therefore decline the optimisation and fall back to
+        the standard envelope, which causes the pathfinder to look for
+        escape routes around the package instead of through-channel.
+
         Args:
             pin_pitch: The component pin pitch in mm, or None when not
                 available.  When below ``rules.fine_pitch_threshold``
                 (and ``rules.min_trace_width`` is configured) the envelope
                 shrinks to ``min_trace_width / 2`` -- the minimum needed
-                to keep a necked-down trace from overlapping pad copper.
-                Full manufacturer clearance is validated in post-routing
-                DRC.
+                to keep a necked-down trace from overlapping pad copper --
+                *provided* the resulting channel can still satisfy full
+                clearance per the narrow-channel guard.  Full manufacturer
+                clearance is validated in post-routing DRC.
 
         Returns:
             Clearance distance in mm to pad outside the pad's metal.
         """
+        standard = self.rules.trace_clearance + self.rules.trace_width / 2
         if (
             pin_pitch is not None
             and pin_pitch < self.rules.fine_pitch_threshold
             and self.rules.min_trace_width is not None
         ):
-            return self.rules.min_trace_width / 2
-        return self.rules.trace_clearance + self.rules.trace_width / 2
+            shrunk = self.rules.min_trace_width / 2
+            # Issue #2865 narrow-channel guard.  Reject the shrink when
+            # the resulting inter-pad channel cannot host a trace at full
+            # clearance.  The geometry (pitch-based, mirroring the
+            # Curator's recommended formula) is:
+            #
+            #     effective_channel = pitch - 2 * shrunk - trace_width
+            #     required_channel  = 2 * trace_clearance + trace_width
+            #
+            # ``effective_channel`` is the band available for a trace
+            # centered between two halo edges; ``required_channel`` is
+            # the minimum copper-to-copper distance the manufacturer
+            # rule demands (clearance on each side of the trace).  When
+            # the channel cannot fit the trace + 2 x clearance the
+            # shrunk halo is geometrically infeasible -- the pathfinder
+            # would place a trace that DRC must reject.  Fall back to
+            # the standard envelope so the router routes *around* the
+            # package via the escape mechanism instead.
+            effective_channel = pin_pitch - 2.0 * shrunk - self.rules.trace_width
+            required_channel = 2.0 * self.rules.trace_clearance + self.rules.trace_width
+            if effective_channel >= required_channel:
+                return shrunk
+            # Narrow channel -- shrink is geometrically infeasible.
+            # Fall through to the standard envelope so the router does
+            # not try to thread between these pads.
+        return standard
 
     def add_pad(self, pad: Pad, pin_pitch: float | None = None) -> None:
         """Add a pad as an obstacle (except for its own net).
@@ -1038,23 +1081,21 @@ class RoutingGrid:
         # Equivalently, it extends ``halo_from_center - pad_half_extent``
         # *beyond the pad edge* along each axis.
         #
-        # Scope to the fine-pitch case (board 04 U2.8/U2.23/U2.35 LQFP-48
-        # corner GND pins).  On standard-pitch pads the existing
-        # envelope is already ``trace_clearance + trace_width/2``, which
-        # is at least as wide as the via halo *for the via that the
-        # stitcher will actually pick*.  Applying an extra ring on
-        # standard-pitch passives crowds inter-component routing channels
-        # (board 04 passive arrays go from 9/9 -> 3/9 with an unrestricted
-        # halo applied to every GND cap).
-        standard_envelope = (
-            self.rules.trace_clearance + self.rules.trace_width / 2.0
-        )
-        if base_clearance >= standard_envelope:
-            # Standard-pitch pad already has the full clearance envelope.
-            # The via center sits inside the pad metal -- already
-            # exclusively the plane net's territory.
-            return
-
+        # Issue #2865 follow-up: the pre-check that used to short-circuit
+        # "standard-pitch pads already have the full clearance envelope"
+        # by comparing ``base_clearance`` to ``standard_envelope`` is no
+        # longer correct.  After #2865's narrow-channel guard, *fine-pitch*
+        # pads on crowded packages (LQFP-48 0.5 mm pitch + jlcpcb-tier1)
+        # also receive ``base_clearance == standard_envelope``, and they
+        # still need the via halo applied along the narrow axis (board 04
+        # U2.8/U2.23/U2.35 GND pins).  The per-axis check below is the
+        # correct gate: it compares the via halo extension along each
+        # axis to ``base_clearance`` and returns when *both* axes are
+        # already covered.  Standard-pitch wide pads (e.g. 0805 caps,
+        # half-extents >= ``halo_from_center``) still short-circuit there
+        # because ``ext_x`` and ``ext_y`` clamp to zero -- the board 04
+        # passive-array yield concern (9/9 -> 3/9) the original early
+        # return was guarding remains protected.
         halo_from_center = self.rules.stitch_via_halo_radius()
         # Halo extension is measured separately per axis: an
         # LQFP-48-style pad is wide (1.5 mm) on one axis but narrow
@@ -1121,9 +1162,7 @@ class RoutingGrid:
                     oew, oeh = other.width, other.height
                 # Use the same pin_pitch envelope; without ``_pad_pin_pitch``
                 # data we fall back to the standard envelope.
-                other_clearance = self._clearance_for_pin_pitch(
-                    self._pad_pin_pitch.get(id(other))
-                )
+                other_clearance = self._clearance_for_pin_pitch(self._pad_pin_pitch.get(id(other)))
                 same_component_envelopes.append(
                     (
                         other.x - oew / 2.0 - other_clearance,
@@ -2175,8 +2214,7 @@ class RoutingGrid:
         """
         if not (0 <= layer_idx < self.num_layers):
             raise ValueError(
-                f"reserve_corridor_cells: layer_idx {layer_idx} out of range "
-                f"[0, {self.num_layers})"
+                f"reserve_corridor_cells: layer_idx {layer_idx} out of range [0, {self.num_layers})"
             )
         owners = frozenset(int(n) for n in net_ids)
         if not owners:

--- a/src/kicad_tools/router/rules.py
+++ b/src/kicad_tools/router/rules.py
@@ -315,6 +315,23 @@ class DesignRules:
         fine-pitch clearance based on pin pitch, then falls back to the
         default trace_clearance.
 
+        Issue #2865 follow-up scope note: this method is the C++
+        pad-vs-segment validator's clearance source.  It is *parallel*
+        to :meth:`RoutingGrid._clearance_for_pin_pitch` (which sets the
+        *grid halo*) -- both layers independently shrink for fine-pitch
+        pads.  The Curator's recommended Option C patch (#2865)
+        intentionally scopes the narrow-channel guard to the grid-halo
+        path only, leaving this validator clearance untouched.  As a
+        result the localized #2865 fix tightens the grid blocking on
+        LQFP-48 0.5 mm pitch + jlcpcb-tier1 (preventing the pathfinder
+        from threading the inter-pad channel in the first place) but
+        the C++ pathfinder's geometric validator still accepts the
+        reduced clearance if the negotiated outer loop forces a
+        through-channel path under congestion pressure.  Promoting the
+        guard to this method is documented as a follow-up: see issue
+        #2865 acceptance note "the per-board allowlist entry can be
+        reduced to 0" for the eventual end-state.
+
         Args:
             ref: Component reference (e.g., "U1")
             pin_pitch: Optional pin pitch in mm (for automatic fine-pitch detection)

--- a/tests/test_grid_narrow_channel_guard.py
+++ b/tests/test_grid_narrow_channel_guard.py
@@ -1,0 +1,356 @@
+"""Tests for the fine-pitch narrow-channel guard (Issue #2865).
+
+Verifies that ``RoutingGrid._clearance_for_pin_pitch`` declines to apply
+the fine-pitch shrink when the resulting inter-pad channel cannot host a
+trace at full manufacturer clearance.  This is the fix for the 44
+``clearance_pad_segment`` errors on board 04 (STM32 LQFP-48 west edge)
+caused by the pathfinder threading traces through geometrically
+infeasible channels.
+
+Acceptance scenarios (from the issue):
+
+* LQFP-48 0.5 mm pitch under jlcpcb-tier1 (``trace=clearance=0.127 mm``):
+  the channel is too narrow; the guard returns the standard envelope and
+  the pathfinder is forced to escape around the package.
+* Wider SSOP/QFP pitches (0.65 mm) at relaxed clearance: shrink still
+  applies; chorus-test BGA pad-access routing does not regress.
+* Mirror in ``find_pad_ref_at`` happens for free because that method
+  already routes through ``_clearance_for_pin_pitch`` (per the #2604
+  symmetry fix); a dedicated test pins the contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules
+
+
+def _make_grid(rules: DesignRules) -> RoutingGrid:
+    """Build a small 20x20 mm grid centred on the origin."""
+    return RoutingGrid(
+        width=20.0,
+        height=20.0,
+        rules=rules,
+        origin_x=-10.0,
+        origin_y=-10.0,
+    )
+
+
+def _make_pad(
+    x: float,
+    y: float,
+    net: int,
+    *,
+    width: float = 0.3,
+    height: float = 1.475,
+    ref: str = "U2",
+    pin: str = "1",
+) -> Pad:
+    """LQFP-48-style pad (default 0.3 x 1.475 mm)."""
+    return Pad(
+        x=x,
+        y=y,
+        width=width,
+        height=height,
+        net=net,
+        net_name=f"NET{net}" if net > 0 else "GND",
+        ref=ref,
+        pin=pin,
+        layer=Layer.F_CU,
+    )
+
+
+class TestClearanceForPinPitchNarrowChannel:
+    """Direct unit tests for the ``_clearance_for_pin_pitch`` helper."""
+
+    def test_lqfp48_jlcpcb_tier1_refuses_shrink(self):
+        """LQFP-48 0.5 mm pitch under jlcpcb-tier1 (trace=clr=0.127):
+        channel cannot fit a trace at full clearance, so the guard
+        rejects the shrink and returns the standard envelope.
+        """
+        rules = DesignRules(
+            trace_width=0.127,
+            trace_clearance=0.127,
+            grid_resolution=0.05,
+            min_trace_width=0.127,
+            fine_pitch_threshold=0.8,
+        )
+        grid = _make_grid(rules)
+
+        standard = rules.trace_clearance + rules.trace_width / 2.0  # 0.1905
+        clearance = grid._clearance_for_pin_pitch(0.5)
+        assert clearance == pytest.approx(standard), (
+            "LQFP-48 at jlcpcb-tier1 is geometrically infeasible at 0.5 mm "
+            "pitch: required channel = 0.381 mm but only 0.246 mm available. "
+            "The guard must return the standard envelope, not the shrunk "
+            "min_trace_width/2 (0.0635 mm)."
+        )
+
+    def test_wider_pitch_still_shrinks(self):
+        """Wider SSOP-style 0.65 mm pitch under looser clearance: the
+        guard permits the shrink because a trace fits with full clearance.
+        This is the chorus-test BGA case that #1778/#2604 originally
+        added the shrink for; we must not regress it.
+        """
+        rules = DesignRules(
+            trace_width=0.15,
+            trace_clearance=0.1,
+            grid_resolution=0.05,
+            min_trace_width=0.1,
+            fine_pitch_threshold=0.8,
+        )
+        grid = _make_grid(rules)
+
+        # effective_channel = 0.65 - 2*0.05 - 0.15 = 0.4
+        # required_channel  = 2*0.1 + 0.15 = 0.35
+        # 0.4 >= 0.35 -> shrink applies
+        expected = rules.min_trace_width / 2.0  # 0.05
+        clearance = grid._clearance_for_pin_pitch(0.65)
+        assert clearance == pytest.approx(expected), (
+            "0.65 mm pitch at relaxed clearance must still get the "
+            "fine-pitch shrink (chorus-test BGA / SSOP escape case)."
+        )
+
+    def test_above_threshold_returns_standard(self):
+        """Pitch >= fine_pitch_threshold always uses the standard envelope
+        regardless of geometry.  Pre-#2865 behavior; smoke-test that the
+        narrow-channel guard did not move this branch.
+        """
+        rules = DesignRules(
+            trace_width=0.2,
+            trace_clearance=0.2,
+            min_trace_width=0.127,
+            fine_pitch_threshold=0.8,
+        )
+        grid = _make_grid(rules)
+
+        standard = rules.trace_clearance + rules.trace_width / 2.0
+        clearance = grid._clearance_for_pin_pitch(1.0)  # standard pitch
+        assert clearance == pytest.approx(standard)
+
+    def test_no_pitch_returns_standard(self):
+        """``pin_pitch=None`` (e.g. resistor pads added without pitch info)
+        uses the standard envelope.  Pre-#2865 behavior preserved.
+        """
+        rules = DesignRules(
+            trace_width=0.2,
+            trace_clearance=0.2,
+            min_trace_width=0.127,
+        )
+        grid = _make_grid(rules)
+
+        standard = rules.trace_clearance + rules.trace_width / 2.0
+        clearance = grid._clearance_for_pin_pitch(None)
+        assert clearance == pytest.approx(standard)
+
+    def test_min_trace_width_unconfigured_returns_standard(self):
+        """When ``rules.min_trace_width`` is ``None`` (no neck-down
+        configured), fine-pitch shrink is not available at all, so the
+        guard never fires -- standard envelope is always returned.
+        """
+        rules = DesignRules(
+            trace_width=0.2,
+            trace_clearance=0.2,
+            min_trace_width=None,
+            fine_pitch_threshold=0.8,
+        )
+        grid = _make_grid(rules)
+
+        standard = rules.trace_clearance + rules.trace_width / 2.0
+        clearance = grid._clearance_for_pin_pitch(0.5)
+        assert clearance == pytest.approx(standard)
+
+    def test_borderline_feasible_channel_shrinks(self):
+        """Exactly-borderline channel (effective == required) must permit
+        the shrink: the geometry is just sufficient.  This pins the
+        ``>=`` comparison in the guard against an accidental ``>`` slip
+        that would over-reject otherwise-feasible cases.
+        """
+        # Choose parameters so effective_channel == required_channel.
+        #   effective = pitch - 2*shrunk - tw     = P - mtw - tw
+        #   required  = 2*tc + tw
+        #   Equate:  P - mtw - tw = 2*tc + tw  ->  P = mtw + 2*tw + 2*tc
+        rules = DesignRules(
+            trace_width=0.1,
+            trace_clearance=0.05,
+            min_trace_width=0.1,
+            fine_pitch_threshold=0.8,
+        )
+        # P = 0.1 + 0.2 + 0.1 = 0.4
+        grid = _make_grid(rules)
+        expected = rules.min_trace_width / 2.0  # 0.05
+        clearance = grid._clearance_for_pin_pitch(0.4)
+        assert clearance == pytest.approx(expected), (
+            "Borderline feasible (effective == required) channel must still permit the shrink."
+        )
+
+    def test_just_below_borderline_refuses_shrink(self):
+        """One micron narrower than borderline must refuse: the guard's
+        ``>=`` is strict at the equality, so a hair below must fail.
+        """
+        rules = DesignRules(
+            trace_width=0.1,
+            trace_clearance=0.05,
+            min_trace_width=0.1,
+            fine_pitch_threshold=0.8,
+        )
+        grid = _make_grid(rules)
+        standard = rules.trace_clearance + rules.trace_width / 2.0
+        # P = 0.4 (borderline); shrink at 0.4 - 0.001 must refuse
+        clearance = grid._clearance_for_pin_pitch(0.399)
+        assert clearance == pytest.approx(standard), (
+            "Channel a hair below borderline must refuse the shrink "
+            "(narrow-channel guard threshold is geometric, not heuristic)."
+        )
+
+
+class TestNarrowChannelBlocksThroughChannel:
+    """Integration: a pair of LQFP-48 pads at jlcpcb-tier1 must produce a
+    grid with NO unblocked path between them, so the pathfinder is
+    forced to seek an escape rather than threading through the channel.
+    """
+
+    @pytest.fixture
+    def jlcpcb_lqfp48_rules(self) -> DesignRules:
+        """jlcpcb-tier1-equivalent clearance rules."""
+        return DesignRules(
+            trace_width=0.127,
+            trace_clearance=0.127,
+            grid_resolution=0.0125,  # fine enough to see the channel
+            min_trace_width=0.127,
+            fine_pitch_threshold=0.8,
+        )
+
+    def test_lqfp48_west_edge_channel_fully_blocked(self, jlcpcb_lqfp48_rules):
+        """Two adjacent LQFP-48 pads at 0.5 mm pitch under jlcpcb-tier1
+        leave NO unblocked cell band between them after the narrow-channel
+        guard kicks in.  Pre-#2865 the shrunk halo left ~0.246 mm of
+        unblocked band; post-#2865 the standard envelope (0.1905 mm
+        radius) exceeds the pad half-width (0.15) by 0.0405 mm and the
+        adjacent halo overlaps the same midpoint, so the channel is
+        fully obstructed for *foreign-component* nets (the
+        same-component clearance relaxation in #2452 would otherwise
+        unblock this corridor).
+
+        We use a foreign-net probe from a different component here so
+        the result is independent of #2452 same-component handling --
+        the failure mode reported in #2865 is foreign signal nets
+        threading the LQFP corridor, not the chip's own pin escapes.
+        """
+        grid = _make_grid(jlcpcb_lqfp48_rules)
+        # Two adjacent pads centred 0.5 mm apart along x (the LQFP-48
+        # west-edge pitch).  Use DISTINCT component refs so the
+        # same-component clearance relaxation (#2452) does not unblock
+        # the corridor -- the LQFP pin-to-pin failure in #2865 is about
+        # foreign signal nets threading between U2's pads, not about
+        # U2's own pin escapes (which the same-component path handles
+        # separately via _relax_same_component_clearance).
+        p1 = _make_pad(x=-0.25, y=0.0, net=1, ref="U2", pin="1")
+        p2 = _make_pad(x=0.25, y=0.0, net=2, ref="U99", pin="1")
+        grid.add_pad(p1, pin_pitch=0.5)
+        grid.add_pad(p2, pin_pitch=0.5)
+
+        # Probe the channel midpoint (x=0): with the guard, both pads'
+        # standard envelopes overlap here and the cell is blocked for
+        # any foreign net.
+        gx, gy = grid.world_to_grid(0.0, 0.0)
+        # Net 3 is "foreign" to both p1 (net=1) and p2 (net=2).
+        assert grid.is_blocked(gx, gy, Layer.F_CU, net=3), (
+            "LQFP-48 channel midpoint must be blocked for foreign nets "
+            "after the narrow-channel guard; pre-#2865 it was unblocked "
+            "and the pathfinder routed through it, producing DRC errors."
+        )
+
+    def test_wider_pitch_channel_remains_passable(self):
+        """SSOP-style 0.65 mm pitch at relaxed clearance: the guard
+        permits the shrink, so the inter-pad channel remains passable
+        and the pathfinder can still escape between pads.  Regression
+        guard for chorus-test BGA pad-access routing.
+        """
+        rules = DesignRules(
+            trace_width=0.15,
+            trace_clearance=0.1,
+            grid_resolution=0.025,
+            min_trace_width=0.1,
+            fine_pitch_threshold=0.8,
+        )
+        grid = _make_grid(rules)
+        # Two adjacent pads at 0.65 mm pitch, narrower pad to leave a
+        # genuine routing channel between them.
+        p1 = _make_pad(x=-0.325, y=0.0, net=1, pin="1", width=0.3, height=0.4)
+        p2 = _make_pad(x=0.325, y=0.0, net=2, pin="2", width=0.3, height=0.4)
+        grid.add_pad(p1, pin_pitch=0.65)
+        grid.add_pad(p2, pin_pitch=0.65)
+
+        # Midpoint x=0: with shrunk halo 0.05 mm, both halos end at
+        # x = +/-0.225 and the midpoint is well outside either halo.
+        gx, gy = grid.world_to_grid(0.0, 0.0)
+        assert not grid.is_blocked(gx, gy, Layer.F_CU, net=3), (
+            "Wider-pitch channel midpoint must remain passable for "
+            "foreign nets so chorus-test-style escape routing works."
+        )
+
+
+class TestFindPadRefAtMirrorsClearance:
+    """``find_pad_ref_at`` calls ``_clearance_for_pin_pitch`` directly
+    (lines 2506-2507), so the narrow-channel guard mirrors automatically.
+    This test pins the symmetry contract from PR #2604 review.
+    """
+
+    def test_lookup_uses_standard_envelope_when_guard_refuses_shrink(self):
+        """Under jlcpcb-tier1 LQFP-48 conditions, the guard refuses the
+        shrink for the pad's halo on the *write* side.  The *read* side
+        (``find_pad_ref_at``) must agree -- both must consider the cell
+        to belong to the standard envelope.
+        """
+        rules = DesignRules(
+            trace_width=0.127,
+            trace_clearance=0.127,
+            grid_resolution=0.025,
+            min_trace_width=0.127,
+            fine_pitch_threshold=0.8,
+        )
+        grid = _make_grid(rules)
+        pad = _make_pad(x=0.0, y=0.0, net=1, ref="U2", pin="7")
+        grid.add_pad(pad, pin_pitch=0.5)
+
+        # Standard envelope edge: 0.15 (pad half-width) + 0.1905
+        # (clearance + trace_width/2) = 0.3405 mm.  A point at
+        # x = 0.3 mm is INSIDE the standard envelope -- so the lookup
+        # must attribute it to U2 (the pad's owner).  Pre-#2604 / pre-#2865
+        # with shrunk halo, the lookup would miss it because the shrunk
+        # envelope ended at 0.2135 mm.
+        ref = grid.find_pad_ref_at(0.3, 0.0)
+        assert ref == "U2", (
+            "find_pad_ref_at must mirror _clearance_for_pin_pitch's "
+            "geometry-aware decision; with the guard refusing the shrink, "
+            "the lookup must attribute the cell to U2."
+        )
+
+    def test_lookup_uses_shrunk_envelope_when_guard_permits(self):
+        """At a pitch wide enough for the shrink to apply, the lookup
+        must agree on the smaller envelope -- chorus-test BGA case.
+        """
+        rules = DesignRules(
+            trace_width=0.15,
+            trace_clearance=0.1,
+            grid_resolution=0.025,
+            min_trace_width=0.1,
+            fine_pitch_threshold=0.8,
+        )
+        grid = _make_grid(rules)
+        pad = _make_pad(x=0.0, y=0.0, net=1, ref="U5", pin="1", width=0.3, height=0.4)
+        grid.add_pad(pad, pin_pitch=0.65)
+
+        # Shrunk envelope edge: 0.15 + 0.05 = 0.20 mm.  A point at
+        # x = 0.25 mm is OUTSIDE the shrunk envelope, so the lookup
+        # must return None (no pad's halo covers it).
+        ref = grid.find_pad_ref_at(0.25, 0.0)
+        assert ref is None, (
+            "When the guard permits the shrink, find_pad_ref_at must "
+            "use the shrunk envelope (mirror #2604 symmetry)."
+        )

--- a/tests/test_grid_plane_net_halo.py
+++ b/tests/test_grid_plane_net_halo.py
@@ -134,9 +134,7 @@ class TestPlaneNetHaloReservation:
             "nets after #2842 (halo extends to 0.425 mm from pad center)."
         )
 
-    def test_fine_pitch_plane_pad_halo_does_not_extend_beyond_radius(
-        self, fine_pitch_rules
-    ):
+    def test_fine_pitch_plane_pad_halo_does_not_extend_beyond_radius(self, fine_pitch_rules):
         """A cell well outside the halo must remain unblocked."""
         grid = _make_grid(fine_pitch_rules)
         plane_pad = _make_pad(x=0.0, y=0.0, net=0, net_name="GND")
@@ -144,9 +142,9 @@ class TestPlaneNetHaloReservation:
 
         # Halo extends 0.425 mm from pad center.  Cell at x=0.6 is
         # 0.175 mm outside the halo -- must remain passable.
-        assert not grid.is_blocked(
-            *grid.world_to_grid(0.6, 0.0), Layer.F_CU, net=9
-        ), "Cell well outside the halo radius must remain passable."
+        assert not grid.is_blocked(*grid.world_to_grid(0.6, 0.0), Layer.F_CU, net=9), (
+            "Cell well outside the halo radius must remain passable."
+        )
 
     def test_standard_pitch_plane_pad_envelope_unchanged(self, standard_pitch_rules):
         """Standard-pitch passives use ``trace_clearance + trace_width/2 =
@@ -167,29 +165,38 @@ class TestPlaneNetHaloReservation:
         # the standard halo, not by the via halo.  A cell at x=0.95
         # (just past the standard envelope) must NOT be blocked by the
         # via halo (because the halo would not extend that far).
-        assert not grid.is_blocked(
-            *grid.world_to_grid(0.95, 0.0), Layer.F_CU, net=9
-        ), (
+        assert not grid.is_blocked(*grid.world_to_grid(0.95, 0.0), Layer.F_CU, net=9), (
             "Standard-pitch plane pad must keep its pre-#2842 envelope; "
             "the via halo is satisfied inside the pad metal itself."
         )
 
     def test_signal_pad_unaffected_by_halo_machinery(self, fine_pitch_rules):
-        """Signal pads (``pad.net > 0``) must keep their existing fine-pitch
-        envelope; the via halo is *only* for plane-net pads.
+        """Signal pads (``pad.net > 0``) must not receive the *via* halo
+        regardless of pin pitch; the via halo is *only* for plane-net pads.
+
+        Issue #2865 narrow-channel guard: with this fixture's
+        ``trace_clearance=trace_width=0.2`` and ``pitch=0.5``, the
+        fine-pitch shrink is geometrically infeasible (channel cannot
+        fit ``2*clearance + trace_width = 0.6 mm`` -- only 0.246 mm is
+        available).  ``_clearance_for_pin_pitch`` therefore returns the
+        standard envelope (0.3 mm) so any cell within 0.45 mm of the pad
+        center *is* blocked, but that block comes from the standard
+        clearance envelope -- NOT from the via halo (which never applies
+        to signal pads).  Probe a point well beyond the standard
+        envelope to assert "no via halo" cleanly.
         """
         grid = _make_grid(fine_pitch_rules)
         sig_pad = _make_pad(x=0.0, y=0.0, net=9, net_name="NRST")
         grid.add_pad(sig_pad, pin_pitch=0.5)
 
-        # Fine-pitch envelope = 0.127 / 2 = 0.0635 mm.
-        # A cell at x=0.3 (0.15 east of pad edge, well past the fine-pitch
-        # envelope, well inside what the via halo *would* be) must remain
-        # passable for foreign nets (this is the whole point of fine-pitch
-        # clearance reduction -- #1778).
-        assert not grid.is_blocked(
-            *grid.world_to_grid(0.3, 0.0), Layer.F_CU, net=10
-        ), "Signal pad envelope must not get the via halo (only plane-net pads do)."
+        # Standard envelope edge: pad_half_width (0.15) + clearance +
+        # trace_width/2 (0.3) = 0.45 mm.  Via halo would have extended
+        # to 0.425 mm from center.  A cell at x=0.5 is past both, so
+        # the only way it could be blocked is if the via halo (a
+        # plane-net-only feature) were applied to this signal pad.
+        assert not grid.is_blocked(*grid.world_to_grid(0.5, 0.0), Layer.F_CU, net=10), (
+            "Signal pad envelope must not get the via halo (only plane-net pads do)."
+        )
 
     def test_halo_does_not_overwrite_signal_pad_metal(self, fine_pitch_rules):
         """When a plane-net pad's halo overlaps an adjacent same-component
@@ -222,9 +229,7 @@ class TestPlaneNetHaloReservation:
             "Signal pad's own net (9) must still reach the pad metal."
         )
 
-    def test_halo_blocks_foreign_net_but_pad_net_marker_unchanged(
-        self, fine_pitch_rules
-    ):
+    def test_halo_blocks_foreign_net_but_pad_net_marker_unchanged(self, fine_pitch_rules):
         """The halo cells must remain ``cell.net == 0`` (the plane-net
         sentinel) so the existing "static no-net obstacle" path in
         ``Grid.is_blocked`` and the pathfinder fires correctly for foreign
@@ -249,6 +254,13 @@ class TestPlaneNetHaloReservation:
         """Setting ``rules.stitch_via_halo = False`` must restore pre-#2842
         behaviour (no halo reservation).  This is the routing-intent
         opt-out the AC requires.
+
+        Issue #2865 narrow-channel guard: with the fixture's tight
+        clearance (0.2 mm) the fine-pitch shrink is geometrically
+        infeasible at 0.5 mm pitch, so the envelope falls back to the
+        standard one regardless of the via halo flag.  Probe a cell
+        past the standard envelope edge (0.45 mm) so the test isolates
+        the via halo's contribution.
         """
         rules_no_halo = DesignRules(
             trace_width=fine_pitch_rules.trace_width,
@@ -263,9 +275,11 @@ class TestPlaneNetHaloReservation:
         plane_pad = _make_pad(x=0.0, y=0.0, net=0, net_name="GND")
         grid.add_pad(plane_pad, pin_pitch=0.5)
 
-        # With the opt-out, the fine-pitch envelope is back to 0.0635 mm.
-        # A cell at x=0.4 (0.25 mm east of pad metal) must now be unblocked.
-        gx, gy = grid.world_to_grid(0.4, 0.0)
+        # With the opt-out, the via halo (which would extend to 0.425 mm
+        # from center) is not applied.  A cell at x=0.5 (past the standard
+        # envelope edge at 0.45 mm, past the would-be halo at 0.425 mm)
+        # must remain unblocked.
+        gx, gy = grid.world_to_grid(0.5, 0.0)
         assert not grid.is_blocked(gx, gy, Layer.F_CU, net=9), (
             "With stitch_via_halo=False the halo must NOT be applied."
         )
@@ -301,6 +315,5 @@ class TestPlaneNetHaloReservation:
         for layer in (Layer.F_CU, Layer.B_CU):
             gx, gy = grid.world_to_grid(1.0, 0.0)
             assert grid.is_blocked(gx, gy, layer, net=9), (
-                f"PTH plane-pad standard envelope must extend to {layer.value} "
-                "(not just F.Cu)."
+                f"PTH plane-pad standard envelope must extend to {layer.value} (not just F.Cu)."
             )

--- a/tests/test_stitch_via_halo.py
+++ b/tests/test_stitch_via_halo.py
@@ -302,7 +302,10 @@ class TestStitchViaHaloEndToEnd:
             1
             for p in gnd_pads
             if _gnd_pad_has_via_landing(
-                grid, p, STITCH_VIA_SIZE, STITCH_VIA_CLEARANCE,
+                grid,
+                p,
+                STITCH_VIA_SIZE,
+                STITCH_VIA_CLEARANCE,
                 other_pads=pads,
             )
         )
@@ -337,14 +340,11 @@ class TestStitchViaHaloEndToEnd:
                 f"Signal pad {sig_pad.pin} (net {sig_pad.net}) center cell "
                 f"lost its net assignment: got cell.net={cell.net}."
             )
-            assert cell.pad_blocked, (
-                f"Signal pad {sig_pad.pin} center must remain pad_blocked."
-            )
+            assert cell.pad_blocked, f"Signal pad {sig_pad.pin} center must remain pad_blocked."
             # And the owner net must still pass our blocked check at its
             # own pad center.
             assert not grid.is_blocked(gx, gy, Layer.F_CU, net=sig_pad.net), (
-                f"Signal pad {sig_pad.pin} center must remain reachable "
-                f"to its own net."
+                f"Signal pad {sig_pad.pin} center must remain reachable to its own net."
             )
 
     def test_halo_blocks_more_cells_than_disabled_mode(self):
@@ -353,22 +353,57 @@ class TestStitchViaHaloEndToEnd:
         cells around the pad are blocked for foreign nets.  Counts cells
         in a 1.5 mm box around pad 8's center that are blocked for a
         foreign net (net=99 -- arbitrary).
+
+        Issue #2865 follow-up: the original board-04 rules
+        (``trace_clearance=0.15``, ``trace_width=0.2``, ``pitch=0.5``)
+        now route through the narrow-channel guard's "standard
+        envelope" branch (effective channel 0.173 mm < required
+        0.5 mm).  When the standard envelope is wider than the via
+        halo on both axes, the halo and no-halo modes produce
+        identical blocking -- because the standard envelope already
+        covers what the halo would reserve.  This is the correct
+        outcome for jlcpcb-tier1 LQFP-48 corner GND pins: the
+        standard halo *is* the via halo, and no extra ring is needed.
+
+        To still exercise the halo's contribution to blocking,
+        construct a fixture where the *fine-pitch shrink remains
+        feasible* (looser clearance with min_trace_width), so the
+        halo annular ring lives outside the shrunk standard envelope.
         """
+
+        # Looser-clearance ruleset where the narrow-channel guard
+        # permits the shrink at 0.65 mm pitch, so the halo annular
+        # ring is visible beyond the shrunk envelope.
+        def _make_loose_rules() -> DesignRules:
+            return DesignRules(
+                trace_width=0.15,
+                trace_clearance=0.1,
+                via_drill=0.3,
+                via_diameter=0.6,
+                grid_resolution=0.05,
+                min_trace_width=0.1,
+                fine_pitch_clearance=0.1,
+                fine_pitch_threshold=0.8,
+                manufacturer="jlcpcb-tier1",
+            )
+
         # With halo (default)
-        rules_on = _make_board04_rules()
+        rules_on = _make_loose_rules()
         grid_on = _make_grid(rules_on)
         gnd_pins = {8, 23, 35}
-        pads_on = _make_lqfp48_pads(gnd_pin_numbers=gnd_pins)
+        # Use 0.65 mm pitch so the shrink remains feasible per #2865's
+        # narrow-channel guard.
+        pads_on = _make_lqfp48_pads(gnd_pin_numbers=gnd_pins, pitch=0.65)
         for pad in pads_on:
-            grid_on.add_pad(pad, pin_pitch=0.5)
+            grid_on.add_pad(pad, pin_pitch=0.65)
 
         # Without halo (opt-out)
-        rules_off = _make_board04_rules()
+        rules_off = _make_loose_rules()
         rules_off.stitch_via_halo = False
         grid_off = _make_grid(rules_off)
-        pads_off = _make_lqfp48_pads(gnd_pin_numbers=gnd_pins)
+        pads_off = _make_lqfp48_pads(gnd_pin_numbers=gnd_pins, pitch=0.65)
         for pad in pads_off:
-            grid_off.add_pad(pad, pin_pitch=0.5)
+            grid_off.add_pad(pad, pin_pitch=0.65)
 
         # Count cells blocked for a foreign net (net=99) in a 1.5 mm
         # box around pin 8's center.


### PR DESCRIPTION
## Summary

Implements the Curator-recommended Option C from issue #2865: extend `RoutingGrid._clearance_for_pin_pitch` with a pitch-vs-clearance geometric feasibility check before applying the `min_trace_width/2` shrink for fine-pitch pads.

When the inter-pad channel cannot accommodate a trace at full manufacturer clearance, the guard falls back to the standard envelope so the pathfinder routes **around** the package via the escape mechanism instead of threading a DRC-invalid path through the channel.

**Geometry (mirrors the Curator's formula):**
```
effective_channel = pitch - 2 * shrunk - trace_width
required_channel  = 2 * trace_clearance + trace_width
```

LQFP-48 0.5 mm pitch + jlcpcb-tier1 (`trace=clearance=0.127 mm`): `effective = 0.246 mm < required = 0.381 mm` → standard envelope (guard refuses shrink).

Wider SSOP/QFP pitches (0.65 mm) at relaxed clearance still permit the shrink — chorus-test BGA / SSOP escape routing is **regression-guarded** by dedicated tests.

## Implementation

- **`grid.py:_clearance_for_pin_pitch`** — primary guard site. Adds the channel-feasibility check before returning `min_trace_width/2`.
- **`grid.py:_apply_stitch_via_halo`** — dropped the pre-#2865 early-return `if base_clearance >= standard_envelope: return`. With the narrow-channel guard, fine-pitch plane-net pads now receive the standard envelope and still need the via halo applied along the narrow axis (board 04 U2.8/U2.23/U2.35 GND pins). The per-axis check below the removed early-return remains the correct gate and continues to short-circuit for standard-pitch wide pads (board 04 passive-array regression-guard).
- **`find_pad_ref_at`** symmetry — automatic. That method already routes through `_clearance_for_pin_pitch` per the #2604 symmetry fix; a dedicated test pins the contract.

## Scope note

The parallel C++ pad-vs-segment validator path (`DesignRules.get_clearance_for_component`) is **intentionally left untouched** per the Curator's localized Option C scoping. Documented in that method's docstring as a follow-up.

Because of that scoping, the integration AC ("`kct check ... --mfr jlcpcb-tier1` reports 0 `clearance_pad_segment` errors after re-route") is **not yet** satisfied on board 04: the C++ pathfinder's geometric validator still accepts the reduced `fine_pitch_clearance` (0.127 mm) when the negotiated outer loop forces a through-channel path under congestion pressure. Per the task description ("don't change the allowlist in this PR; leave that for a follow-up"), the `.github/routed-drc-tolerance.yml` entry for board 04 is intentionally **not** touched.

## Test plan

- [x] New `tests/test_grid_narrow_channel_guard.py` (11 tests): LQFP-48 refusal, wider-pitch acceptance, borderline equality, `find_pad_ref_at` symmetry, integration scenario (two adjacent LQFP pads on distinct refs leave no unblocked midpoint cell for foreign nets).
- [x] `tests/test_grid_plane_net_halo.py` — 12 tests pass. Two assertions updated to probe past the standard envelope edge (previous probe points relied on the now-disallowed shrink at infeasible LQFP-48 geometry).
- [x] `tests/test_stitch_via_halo.py` — 3 tests pass. `test_halo_blocks_more_cells_than_disabled_mode` switched to a looser-clearance fixture (`trace_clearance=0.1`, `pitch=0.65`) where the shrink remains feasible.
- [x] `tests/test_component_clearance.py` — 14 tests pass (parallel `get_clearance_for_component` path untouched).
- [x] `tests/test_router_grid.py` `tests/test_subgrid.py` `tests/test_escape.py` `tests/test_escape_via_in_pad_lqfp.py` `tests/test_escape_endpoint_routing.py` `tests/test_router_grid_auto_bump.py` — all pass.
- [x] `tests/test_router_core.py` — 172 pass, 1 pre-existing failure (`test_add_component_rotation`, unrelated; verified pre-existing on main).
- [x] Pre-route instrumentation confirmed `_clearance_for_pin_pitch(0.5)` now returns `0.2500` (standard envelope) instead of `0.0635` (shrunk) on board 04.

Closes #2865

Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)