### PR TITLE
feat(router): emit per-component diagnostic on tier-ladder exhaustion (#2884)

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -3384,6 +3384,20 @@ def route_with_mfr_tier_escalation(
             f"Result: No tier in {' -> '.join(tiers_to_try)} achieved "
             "routing success."
         )
+
+        # Issue #2884: name the dominant unfixable constraint surfaced by
+        # the last inner attempt before printing the generic remediation
+        # list.  This points the user at the specific component / pin /
+        # constraint that blocked progress rather than leaving them to
+        # guess from a categorical 4-option menu.
+        named_line = _name_dominant_unfixable_constraint(
+            last_router=last_router,
+            manufacturer=args.manufacturer,
+        )
+        if named_line:
+            flush_print("\nDiagnosis:")
+            flush_print(f"  {named_line}")
+
         # Concrete remediation options.  Always print at least three so
         # users have actionable alternatives:
         flush_print("\nOptions:")
@@ -3404,6 +3418,87 @@ def route_with_mfr_tier_escalation(
         )
 
     return final_exit_code
+
+
+def _name_dominant_unfixable_constraint(
+    last_router,
+    manufacturer: str | None,
+) -> str | None:
+    """Compose the per-component diagnostic for tier-ladder exhaustion.
+
+    Issue #2884: When ``--auto-mfr-tier`` walks the full ladder and still
+    fails, surface a single human-readable line identifying *which*
+    component (and, where available, which pin) carried the unfixable
+    constraint -- using :func:`name_unfixable_constraint` from
+    ``failure_analysis``.
+
+    The dominant signal we have at this surface is the EscapeRouter's
+    ``missed_via_in_pad_rescues`` counter and the companion
+    ``missed_via_in_pad_components`` ref set.  A non-zero counter means
+    one or more fine-pitch pins would have been rescued by an in-pad
+    via -- the canonical PIN_ACCESS failure mode for the mfr-tier
+    trigger table.
+
+    Args:
+        last_router: The Autorouter instance from the last inner attempt
+            (may be ``None`` if no attempt completed cleanly).
+        manufacturer: Manufacturer name at the time of the final failure.
+
+    Returns:
+        A one-line diagnostic string suitable for terminal output, or
+        ``None`` when no signal is available (caller suppresses the
+        Diagnosis section in that case).
+    """
+    from kicad_tools.router.failure_analysis import (
+        FailureCause,
+        name_unfixable_constraint,
+    )
+
+    if last_router is None:
+        return None
+
+    escape_router = getattr(last_router, "_escape_router", None)
+    if escape_router is None:
+        return None
+
+    # Primary signal: missed via-in-pad rescues -> PIN_ACCESS failure mode.
+    missed = getattr(escape_router, "missed_via_in_pad_rescues", 0) or 0
+    try:
+        missed_int = int(missed)
+    except (TypeError, ValueError):
+        missed_int = 0
+
+    if missed_int <= 0:
+        return None
+
+    # Pick a representative component ref from the per-attempt set.
+    # Sorted to keep the diagnostic deterministic across runs.
+    refs = getattr(escape_router, "missed_via_in_pad_components", None) or set()
+    try:
+        ref_list = sorted(refs)
+    except TypeError:
+        ref_list = []
+    component_ref = ref_list[0] if ref_list else None
+
+    # Compose the canonical named-constraint line.  We do not yet have
+    # per-pin attribution at this surface -- the EscapeRouter tracks
+    # component refs only -- so we pass ``pin=None`` and let
+    # name_unfixable_constraint fall back to component-level phrasing.
+    base = name_unfixable_constraint(
+        FailureCause.PIN_ACCESS,
+        manufacturer=manufacturer,
+        component_ref=component_ref,
+        pin=None,
+    )
+
+    # When multiple components shared the same fault, mention the count
+    # so users know whether they're chasing one outlier or a board-wide
+    # problem.
+    extras = len(ref_list) - 1
+    if extras > 0:
+        base = f"{base} ({extras} other component(s) affected by the same constraint.)"
+
+    return base
 
 
 def route_with_combined_escalation(

--- a/tests/test_route_auto_mfr_tier.py
+++ b/tests/test_route_auto_mfr_tier.py
@@ -436,3 +436,179 @@ class TestNameUnfixableConstraint:
         msg = name_unfixable_constraint(FailureCause.UNKNOWN, manufacturer="jlcpcb")
         # Should still produce a non-empty string
         assert isinstance(msg, str) and msg
+
+
+class TestLadderExhaustionDiagnostic:
+    """Issue #2884: tier-ladder exhaustion must emit per-component diagnostic.
+
+    When ``route_with_mfr_tier_escalation`` exhausts the ladder without a
+    successful routing attempt, the printed summary must include a line
+    composed by ``name_unfixable_constraint()`` that names the specific
+    component / constraint blocking progress -- not just the generic
+    4-option remediation menu.
+    """
+
+    def _make_args(self, **overrides):
+        base = SimpleNamespace(
+            pcb="test.kicad_pcb",
+            manufacturer="jlcpcb",
+            auto_mfr_tier=True,
+            mfr_tier_ladder=None,
+            auto_layers=True,
+            adaptive_rules=False,
+            quiet=False,  # diagnostic only prints when not quiet
+            timeout=None,
+            _wall_clock_deadline=None,
+        )
+        for k, v in overrides.items():
+            setattr(base, k, v)
+        return base
+
+    def test_exhaustion_emits_named_constraint_line(self, capsys):
+        """Walking the full ladder with PIN_ACCESS-style failures prints
+        the ``name_unfixable_constraint`` diagnostic before the generic
+        4-option list."""
+        from kicad_tools.cli.route_cmd import route_with_mfr_tier_escalation
+
+        args = self._make_args()
+
+        def fake_inner(*, pcb_path, output_path, args, quiet):
+            # Simulate a fine-pitch QFP escape failure: missed via-in-pad
+            # rescues on U2 -> PIN_ACCESS-mode constraint.
+            mock_router = MagicMock()
+            mock_router._escape_router = MagicMock()
+            mock_router._escape_router.missed_via_in_pad_rescues = 4
+            mock_router._escape_router.missed_via_in_pad_components = {"U2"}
+            args._last_router = mock_router
+            return 2  # always fail so ladder exhausts
+
+        with patch(
+            "kicad_tools.cli.route_cmd.route_with_layer_escalation",
+            side_effect=fake_inner,
+        ):
+            from pathlib import Path
+
+            rc = route_with_mfr_tier_escalation(
+                pcb_path=Path("test.kicad_pcb"),
+                output_path=Path("out.kicad_pcb"),
+                args=args,
+                quiet=False,
+            )
+
+        out = capsys.readouterr().out
+        # Ladder exhausted -> non-zero exit, summary printed.
+        assert rc != 0
+        assert "MANUFACTURER-TIER ESCALATION SUMMARY" in out
+        # Issue #2884 acceptance criterion: the named-constraint diagnostic
+        # appears in the printed output, identifying the affected component
+        # and the constraint (via-in-pad / PIN_ACCESS).
+        assert "Diagnosis" in out
+        assert "U2" in out
+        assert "via-in-pad" in out.lower() or "via_in_pad" in out
+        # Named line precedes the generic Options list.
+        assert out.index("Diagnosis") < out.index("Options:")
+
+    def test_exhaustion_with_multiple_affected_components_reports_count(
+        self, capsys
+    ):
+        """When more than one component shares the unfixable constraint,
+        the diagnostic mentions the extra-affected count so the user knows
+        the scope of the problem."""
+        from kicad_tools.cli.route_cmd import route_with_mfr_tier_escalation
+
+        args = self._make_args()
+
+        def fake_inner(*, pcb_path, output_path, args, quiet):
+            mock_router = MagicMock()
+            mock_router._escape_router = MagicMock()
+            mock_router._escape_router.missed_via_in_pad_rescues = 7
+            mock_router._escape_router.missed_via_in_pad_components = {
+                "U2",
+                "U5",
+                "U11",
+            }
+            args._last_router = mock_router
+            return 2
+
+        with patch(
+            "kicad_tools.cli.route_cmd.route_with_layer_escalation",
+            side_effect=fake_inner,
+        ):
+            from pathlib import Path
+
+            route_with_mfr_tier_escalation(
+                pcb_path=Path("test.kicad_pcb"),
+                output_path=Path("out.kicad_pcb"),
+                args=args,
+                quiet=False,
+            )
+
+        out = capsys.readouterr().out
+        assert "Diagnosis" in out
+        # Deterministic representative pick: sorted refs -> U11 first.
+        assert "U11" in out
+        # 2 other components affected.
+        assert "2 other component" in out
+
+    def test_exhaustion_without_missed_rescues_suppresses_named_line(
+        self, capsys
+    ):
+        """When the EscapeRouter has no missed-rescue signal we don't have
+        a confident named constraint to surface; the Diagnosis section is
+        suppressed but the generic Options list still prints."""
+        from kicad_tools.cli.route_cmd import route_with_mfr_tier_escalation
+
+        args = self._make_args()
+
+        def fake_inner(*, pcb_path, output_path, args, quiet):
+            mock_router = MagicMock()
+            mock_router._escape_router = MagicMock()
+            mock_router._escape_router.missed_via_in_pad_rescues = 0
+            mock_router._escape_router.missed_via_in_pad_components = set()
+            args._last_router = mock_router
+            return 2
+
+        with patch(
+            "kicad_tools.cli.route_cmd.route_with_layer_escalation",
+            side_effect=fake_inner,
+        ):
+            from pathlib import Path
+
+            route_with_mfr_tier_escalation(
+                pcb_path=Path("test.kicad_pcb"),
+                output_path=Path("out.kicad_pcb"),
+                args=args,
+                quiet=False,
+            )
+
+        out = capsys.readouterr().out
+        assert "MANUFACTURER-TIER ESCALATION SUMMARY" in out
+        assert "Options:" in out
+        # No confident signal -> no false-positive Diagnosis line.
+        assert "Diagnosis" not in out
+
+    def test_named_constraint_helper_handles_missing_router(self):
+        """The diagnostic helper degrades gracefully when last_router is
+        None (e.g. ladder never produced a complete attempt)."""
+        from kicad_tools.cli.route_cmd import (
+            _name_dominant_unfixable_constraint,
+        )
+
+        assert _name_dominant_unfixable_constraint(
+            last_router=None, manufacturer="jlcpcb"
+        ) is None
+
+    def test_named_constraint_helper_handles_missing_escape_router(self):
+        """The diagnostic helper degrades gracefully when the Autorouter
+        never wired up its EscapeRouter (e.g. a crash before escape)."""
+        from kicad_tools.cli.route_cmd import (
+            _name_dominant_unfixable_constraint,
+        )
+
+        # MagicMock returns a child mock for any attribute by default.
+        # We need to explicitly stub _escape_router to None.
+        broken_router = MagicMock()
+        broken_router._escape_router = None
+        assert _name_dominant_unfixable_constraint(
+            last_router=broken_router, manufacturer="jlcpcb"
+        ) is None


### PR DESCRIPTION
## Summary

Wires `name_unfixable_constraint()` into the `--auto-mfr-tier` ladder-exhaustion code path so users see *which* component / pin / constraint blocked progress, not just the generic 4-option remediation menu.

- New helper `_name_dominant_unfixable_constraint()` in `route_cmd.py` extracts the dominant unfixable failure from the last inner attempt (via `missed_via_in_pad_rescues` + `missed_via_in_pad_components` on the EscapeRouter) and composes a one-line `name_unfixable_constraint(...)` diagnosis.
- The Diagnosis line prints *before* the existing 4-option Options list when the ladder fully exhausts.
- When no confident signal is available (zero missed-rescue counter, missing router, missing escape router), the Diagnosis section is suppressed and the generic Options list still prints.

## Diagnostic format

When the ladder exhausts on a fine-pitch QFP that needed via-in-pad rescue:

```
============================================================
MANUFACTURER-TIER ESCALATION SUMMARY
============================================================
Result: No tier in jlcpcb -> jlcpcb-tier1 achieved routing success.

Diagnosis:
  Cannot escape U2 to perimeter on jlcpcb. The `jlcpcb` profile does not support via-in-pad (via_in_pad_supported = false).

Options:
  1. Switch to a tighter manufacturer tier (try --mfr-tier-ladder with a custom ladder).
  2. Change fine-pitch package(s) to a wider-pitch alternative (e.g. LQFP-48 0.5mm -> LQFP-32 0.8mm).
  3. Move fine-pitch component(s) toward the board centre so escape traces have a wider channel (5+mm from edge).
  4. Add layers via --auto-layers --max-layers 6 (if not already on).
```

When more than one component shares the same fault, the line appends `(N other component(s) affected by the same constraint.)`.

## Source

Judge follow-up observation **B** on PR #2882, explicitly flagged as non-blocking.

## Scope

- `src/kicad_tools/cli/route_cmd.py`: 95 LOC added (helper + wiring)
- `tests/test_route_auto_mfr_tier.py`: 176 LOC added (5 new tests)
- No behavior change; user-visible diagnostic improvement only.

Closes #2884

## Test plan

- [x] New tests pass: `pytest tests/test_route_auto_mfr_tier.py::TestLadderExhaustionDiagnostic`
- [x] Existing 35 tests in `test_route_auto_mfr_tier.py` still pass
- [x] Existing `test_escape_missed_via_in_pad.py` still passes
- [x] `kct route --help` still loads cleanly
- [x] `ruff check` clean on all touched lines
- [x] No `uv.lock` / build artefacts in the commit

Generated with [Claude Code](https://claude.com/claude-code)