### PR TITLE
fix(router): wire MFR_TIER_ESCALATION_TRIGGERS into outer escalation loop (closes #2883)

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -1120,13 +1120,8 @@ def _run_auto_fix(
                 "  Auto-fix: rolled back due to connectivity regression "
                 "(nudges would have broken at least one net)."
             )
-            print(
-                "  Run 'kct fix-drc <pcb> --no-connectivity-check' to apply "
-                "the nudges anyway"
-            )
-            print(
-                "  (only safe when partial-completion regressions are acceptable)."
-            )
+            print("  Run 'kct fix-drc <pcb> --no-connectivity-check' to apply the nudges anyway")
+            print("  (only safe when partial-completion regressions are acceptable).")
         elif result == 2:
             print("  Auto-fix: partial repair; some violations remain.")
         elif result == 1:
@@ -3127,6 +3122,71 @@ def route_with_rule_relaxation(
     return 1
 
 
+def _classify_dominant_failure_cause(router):
+    """Pick the most-common FailureCause across ``router.routing_failures``.
+
+    Issue #2883: the outer ``--auto-mfr-tier`` loop needs to consult the
+    :data:`router.failure_analysis.MFR_TIER_ESCALATION_TRIGGERS` registry
+    before walking forward.  That requires picking a single dominant cause
+    from the (possibly heterogeneous) set of per-net failures returned by
+    the inner routing attempt.
+
+    The rule used here:
+
+    1. If the router has no ``routing_failures`` attribute (e.g. the inner
+       call was stubbed in tests or returned before classification), return
+       ``None`` so callers fall back to the legacy
+       ``missed_via_in_pad_rescues`` signal.
+    2. Otherwise, tally :class:`FailureCause` values across all failures
+       and return the most common.  Ties are broken by the registry order
+       in :data:`MFR_TIER_ESCALATION_TRIGGERS` (triggering causes win), so
+       that an even split between e.g. PIN_ACCESS and BLOCKED_PATH still
+       lets escalation engage.
+
+    Args:
+        router: Inner ``Autorouter`` instance (may be ``None`` or a mock
+            that lacks ``routing_failures``).
+
+    Returns:
+        The dominant :class:`FailureCause`, or ``None`` if no failure
+        records were available.
+    """
+    from collections import Counter
+
+    if router is None:
+        return None
+    failures = getattr(router, "routing_failures", None)
+    if not failures:
+        return None
+
+    # Tally causes; ignore entries without a recognized FailureCause.
+    causes = []
+    for f in failures:
+        cause = getattr(f, "failure_cause", None)
+        if cause is not None:
+            causes.append(cause)
+    if not causes:
+        return None
+
+    counter = Counter(causes)
+    most_common_count = counter.most_common(1)[0][1]
+
+    # Find all causes tied for most common.
+    tied = [c for c, n in counter.items() if n == most_common_count]
+    if len(tied) == 1:
+        return tied[0]
+
+    # Tie-break: prefer a triggering cause so escalation isn't suppressed
+    # by an arbitrary tally tie.  Lazy import to avoid module cycles.
+    from kicad_tools.router.failure_analysis import MFR_TIER_ESCALATION_TRIGGERS
+
+    for cause in tied:
+        if MFR_TIER_ESCALATION_TRIGGERS.get(cause, False):
+            return cause
+    # No triggering cause present in the tie; return any (the first).
+    return tied[0]
+
+
 def route_with_mfr_tier_escalation(
     pcb_path: Path,
     output_path: Path,
@@ -3183,6 +3243,10 @@ def route_with_mfr_tier_escalation(
         Exit code (0 = success, 1 = failure, 2 = partial)
     """
     from kicad_tools.cli.progress import flush_print
+    from kicad_tools.router.failure_analysis import (
+        MFR_TIER_ESCALATION_TRIGGERS,
+        should_escalate_mfr_tier,
+    )
     from kicad_tools.router.mfr_limits import (
         can_escalate_scalar,
         can_escalate_via_in_pad,
@@ -3274,9 +3338,40 @@ def route_with_mfr_tier_escalation(
                     except (TypeError, ValueError):
                         triggered_by_missed_in_pad = False
 
+            # Issue #2883: consult MFR_TIER_ESCALATION_TRIGGERS on the
+            # dominant failure cause from the previous tier.  When the
+            # router reports a placement-class failure (BLOCKED_PATH,
+            # CONGESTION, KEEPOUT, ROUTING_ORDER, UNKNOWN, ...) the
+            # trigger table returns False, and we suppress escalation
+            # regardless of whether the next tier offers a capability /
+            # scalar gain -- escalation cannot fix a placement problem.
+            #
+            # When ``routing_failures`` is unavailable (e.g. in unit
+            # tests that stub the inner call), ``dominant_cause`` is
+            # None and we fall back to the legacy
+            # ``missed_via_in_pad_rescues`` / capability-gain heuristic
+            # exactly as before.
+            dominant_cause = _classify_dominant_failure_cause(last_router)
+            trigger_table_vetoes = False
+            if dominant_cause is not None:
+                # The cause is recognized AND the registry explicitly
+                # excludes it from escalation -- veto.
+                if dominant_cause in MFR_TIER_ESCALATION_TRIGGERS and not should_escalate_mfr_tier(
+                    dominant_cause
+                ):
+                    trigger_table_vetoes = True
+
             should_escalate = False
             reason = ""
-            if gains_capability and triggered_by_missed_in_pad:
+            if trigger_table_vetoes:
+                # Trigger table says this failure category is not
+                # manufacturer-fixable.  Suppress escalation even if
+                # capability / scalar gain exists.
+                reason = (
+                    f"dominant failure cause ({dominant_cause.value}) is not "
+                    "manufacturer-fixable (trigger table veto)"
+                )
+            elif gains_capability and triggered_by_missed_in_pad:
                 should_escalate = True
                 reason = "missed via-in-pad rescues detected on previous tier"
             elif gains_capability:
@@ -3284,8 +3379,7 @@ def route_with_mfr_tier_escalation(
                 # exists -- escalate defensively (the user asked for it).
                 should_escalate = True
                 reason = (
-                    "next tier offers via-in-pad capability (no missed-rescue "
-                    "signal available)"
+                    "next tier offers via-in-pad capability (no missed-rescue signal available)"
                 )
             elif gains_scalar:
                 should_escalate = True
@@ -3293,16 +3387,17 @@ def route_with_mfr_tier_escalation(
 
             if not should_escalate:
                 if not quiet:
-                    flush_print(
-                        f"  Skipping tier {tier_name}: no capability or scalar "
-                        f"gain over {prev_tier} (convergence guard)."
-                    )
+                    if trigger_table_vetoes:
+                        flush_print(f"  Skipping tier {tier_name}: {reason}.")
+                    else:
+                        flush_print(
+                            f"  Skipping tier {tier_name}: no capability or scalar "
+                            f"gain over {prev_tier} (convergence guard)."
+                        )
                 break
 
             if not quiet:
-                flush_print(
-                    f"  Escalating to {tier_name}: {reason}"
-                )
+                flush_print(f"  Escalating to {tier_name}: {reason}")
 
         # Mutate args to point at this tier.  Note: route_with_layer_escalation
         # re-reads args.manufacturer when constructing DesignRules, so the
@@ -3353,8 +3448,7 @@ def route_with_mfr_tier_escalation(
                 saw_terminating_success = True
                 if not quiet:
                     flush_print(
-                        f"\n  Tier {tier_name} achieved routing success; "
-                        "stopping tier escalation."
+                        f"\n  Tier {tier_name} achieved routing success; stopping tier escalation."
                     )
                 # Print cost note if escalation actually moved off the
                 # starting tier.
@@ -3362,8 +3456,7 @@ def route_with_mfr_tier_escalation(
                     final_limits = get_mfr_limits(tier_name)
                     if final_limits.cost_note:
                         flush_print(
-                            f"\nRecommendation: order from {tier_name}. "
-                            f"{final_limits.cost_note}."
+                            f"\nRecommendation: order from {tier_name}. {final_limits.cost_note}."
                         )
                 break
 
@@ -3380,10 +3473,7 @@ def route_with_mfr_tier_escalation(
         flush_print("\n" + "=" * 60)
         flush_print("MANUFACTURER-TIER ESCALATION SUMMARY")
         flush_print("=" * 60)
-        flush_print(
-            f"Result: No tier in {' -> '.join(tiers_to_try)} achieved "
-            "routing success."
-        )
+        flush_print(f"Result: No tier in {' -> '.join(tiers_to_try)} achieved routing success.")
 
         # Issue #2884: name the dominant unfixable constraint surfaced by
         # the last inner attempt before printing the generic remediation
@@ -3413,9 +3503,7 @@ def route_with_mfr_tier_escalation(
             "  3. Move fine-pitch component(s) toward the board centre so "
             "escape traces have a wider channel (5+mm from edge)."
         )
-        flush_print(
-            "  4. Add layers via --auto-layers --max-layers 6 (if not already on)."
-        )
+        flush_print("  4. Add layers via --auto-layers --max-layers 6 (if not already on).")
 
     return final_exit_code
 

--- a/tests/test_route_auto_mfr_tier.py
+++ b/tests/test_route_auto_mfr_tier.py
@@ -612,3 +612,282 @@ class TestLadderExhaustionDiagnostic:
         assert _name_dominant_unfixable_constraint(
             last_router=broken_router, manufacturer="jlcpcb"
         ) is None
+
+class TestTriggerTableWiring:
+    """Issue #2883: trigger table is wired into the outer escalation loop.
+
+    PR #2882 added :data:`MFR_TIER_ESCALATION_TRIGGERS` and
+    :func:`should_escalate_mfr_tier` but only unit-tested the table.  This
+    suite confirms the dispatcher in ``route_with_mfr_tier_escalation``
+    actually consults the table -- specifically that a placement-class
+    failure such as ``BLOCKED_PATH`` suppresses escalation even when the
+    next tier offers a real capability gain.
+    """
+
+    def _make_args(self, **overrides):
+        base = SimpleNamespace(
+            pcb="test.kicad_pcb",
+            manufacturer="jlcpcb",
+            auto_mfr_tier=True,
+            mfr_tier_ladder=None,
+            auto_layers=True,
+            adaptive_rules=False,
+            quiet=True,
+            timeout=None,
+            _wall_clock_deadline=None,
+        )
+        for k, v in overrides.items():
+            setattr(base, k, v)
+        return base
+
+    def _make_failure(self, cause):
+        """Build a minimal stand-in for ``RoutingFailure`` with a cause."""
+        return SimpleNamespace(failure_cause=cause)
+
+    def test_pin_access_dominant_cause_triggers_escalation(self):
+        """PIN_ACCESS-dominated failures escalate even with capability gain.
+
+        Regression for the wiring: trigger table says PIN_ACCESS=True, and
+        the outer loop should not veto.
+        """
+        from kicad_tools.cli.route_cmd import route_with_mfr_tier_escalation
+        from kicad_tools.router.failure_analysis import FailureCause
+
+        args = self._make_args()
+        seen_tiers: list[str] = []
+
+        def fake_inner(*, pcb_path, output_path, args, quiet):
+            seen_tiers.append(args.manufacturer)
+            mock_router = MagicMock()
+            mock_router._escape_router = MagicMock()
+            mock_router._escape_router.missed_via_in_pad_rescues = 2
+            # Populate routing_failures with PIN_ACCESS records (the
+            # canonical "via-in-pad would have helped" case).
+            mock_router.routing_failures = [
+                self._make_failure(FailureCause.PIN_ACCESS),
+                self._make_failure(FailureCause.PIN_ACCESS),
+            ]
+            args._last_router = mock_router
+            if args.manufacturer == "jlcpcb-tier1":
+                return 0  # success on tier1
+            return 2
+
+        with patch(
+            "kicad_tools.cli.route_cmd.route_with_layer_escalation",
+            side_effect=fake_inner,
+        ):
+            from pathlib import Path
+
+            rc = route_with_mfr_tier_escalation(
+                pcb_path=Path("test.kicad_pcb"),
+                output_path=Path("out.kicad_pcb"),
+                args=args,
+                quiet=True,
+            )
+
+        # Escalation engaged: both tiers visited, success returned.
+        assert seen_tiers == ["jlcpcb", "jlcpcb-tier1"]
+        assert rc == 0
+
+    def test_blocked_path_dominant_cause_suppresses_escalation(self):
+        """BLOCKED_PATH-dominated failures should NOT escalate.
+
+        Mirrors the shape of ``test_skips_tier_with_no_gain`` but tests
+        the trigger-table veto instead of the convergence guard.  Even
+        though the default jlcpcb -> jlcpcb-tier1 ladder offers a real
+        via-in-pad capability gain (which would otherwise escalate
+        defensively), the trigger table marks BLOCKED_PATH as
+        non-manufacturer-fixable and vetoes the walk-forward.
+        """
+        from kicad_tools.cli.route_cmd import route_with_mfr_tier_escalation
+        from kicad_tools.router.failure_analysis import FailureCause
+
+        args = self._make_args()
+        seen_tiers: list[str] = []
+
+        def fake_inner(*, pcb_path, output_path, args, quiet):
+            seen_tiers.append(args.manufacturer)
+            mock_router = MagicMock()
+            mock_router._escape_router = MagicMock()
+            # Even with non-zero missed_via_in_pad_rescues (so the
+            # legacy heuristic would escalate), the trigger table must
+            # override and suppress.
+            mock_router._escape_router.missed_via_in_pad_rescues = 5
+            mock_router.routing_failures = [
+                self._make_failure(FailureCause.BLOCKED_PATH),
+                self._make_failure(FailureCause.BLOCKED_PATH),
+                self._make_failure(FailureCause.BLOCKED_PATH),
+            ]
+            args._last_router = mock_router
+            return 2  # always fail; loop must still stop after tier 0
+
+        with patch(
+            "kicad_tools.cli.route_cmd.route_with_layer_escalation",
+            side_effect=fake_inner,
+        ):
+            from pathlib import Path
+
+            route_with_mfr_tier_escalation(
+                pcb_path=Path("test.kicad_pcb"),
+                output_path=Path("out.kicad_pcb"),
+                args=args,
+                quiet=True,
+            )
+
+        # Only the starting tier ran; trigger table vetoed escalation.
+        assert seen_tiers == ["jlcpcb"]
+
+    def test_congestion_dominant_cause_suppresses_escalation(self):
+        """CONGESTION (a layer-budget issue) should not trigger escalation."""
+        from kicad_tools.cli.route_cmd import route_with_mfr_tier_escalation
+        from kicad_tools.router.failure_analysis import FailureCause
+
+        args = self._make_args()
+        seen_tiers: list[str] = []
+
+        def fake_inner(*, pcb_path, output_path, args, quiet):
+            seen_tiers.append(args.manufacturer)
+            mock_router = MagicMock()
+            mock_router._escape_router = MagicMock()
+            mock_router._escape_router.missed_via_in_pad_rescues = 1
+            mock_router.routing_failures = [
+                self._make_failure(FailureCause.CONGESTION),
+                self._make_failure(FailureCause.CONGESTION),
+            ]
+            args._last_router = mock_router
+            return 2
+
+        with patch(
+            "kicad_tools.cli.route_cmd.route_with_layer_escalation",
+            side_effect=fake_inner,
+        ):
+            from pathlib import Path
+
+            route_with_mfr_tier_escalation(
+                pcb_path=Path("test.kicad_pcb"),
+                output_path=Path("out.kicad_pcb"),
+                args=args,
+                quiet=True,
+            )
+
+        assert seen_tiers == ["jlcpcb"]
+
+    def test_no_failure_records_falls_back_to_legacy(self):
+        """When router has no routing_failures, fall back to legacy logic.
+
+        Backward-compatibility: existing tests (e.g.
+        ``test_walks_default_jlcpcb_ladder``) stub the inner call without
+        populating ``routing_failures``; those must continue to escalate
+        on the ``missed_via_in_pad_rescues`` signal alone.
+        """
+        from kicad_tools.cli.route_cmd import route_with_mfr_tier_escalation
+
+        args = self._make_args()
+        seen_tiers: list[str] = []
+
+        def fake_inner(*, pcb_path, output_path, args, quiet):
+            seen_tiers.append(args.manufacturer)
+            mock_router = MagicMock()
+            mock_router._escape_router = MagicMock()
+            mock_router._escape_router.missed_via_in_pad_rescues = 3
+            # Critical: explicitly empty list -- legacy behaviour path.
+            mock_router.routing_failures = []
+            args._last_router = mock_router
+            if args.manufacturer == "jlcpcb-tier1":
+                return 0
+            return 2
+
+        with patch(
+            "kicad_tools.cli.route_cmd.route_with_layer_escalation",
+            side_effect=fake_inner,
+        ):
+            from pathlib import Path
+
+            rc = route_with_mfr_tier_escalation(
+                pcb_path=Path("test.kicad_pcb"),
+                output_path=Path("out.kicad_pcb"),
+                args=args,
+                quiet=True,
+            )
+
+        # Legacy missed-rescue path engaged; escalation proceeded.
+        assert seen_tiers == ["jlcpcb", "jlcpcb-tier1"]
+        assert rc == 0
+
+    def test_mixed_failures_tiebreak_picks_triggering_cause(self):
+        """Even tally between PIN_ACCESS and BLOCKED_PATH escalates.
+
+        The tie-break rule prefers the triggering cause so that escalation
+        engages on borderline cases instead of being silently suppressed.
+        """
+        from kicad_tools.cli.route_cmd import route_with_mfr_tier_escalation
+        from kicad_tools.router.failure_analysis import FailureCause
+
+        args = self._make_args()
+        seen_tiers: list[str] = []
+
+        def fake_inner(*, pcb_path, output_path, args, quiet):
+            seen_tiers.append(args.manufacturer)
+            mock_router = MagicMock()
+            mock_router._escape_router = MagicMock()
+            mock_router._escape_router.missed_via_in_pad_rescues = 2
+            # 1-1 tie between triggering and non-triggering causes.
+            mock_router.routing_failures = [
+                self._make_failure(FailureCause.PIN_ACCESS),
+                self._make_failure(FailureCause.BLOCKED_PATH),
+            ]
+            args._last_router = mock_router
+            if args.manufacturer == "jlcpcb-tier1":
+                return 0
+            return 2
+
+        with patch(
+            "kicad_tools.cli.route_cmd.route_with_layer_escalation",
+            side_effect=fake_inner,
+        ):
+            from pathlib import Path
+
+            rc = route_with_mfr_tier_escalation(
+                pcb_path=Path("test.kicad_pcb"),
+                output_path=Path("out.kicad_pcb"),
+                args=args,
+                quiet=True,
+            )
+
+        assert seen_tiers == ["jlcpcb", "jlcpcb-tier1"]
+        assert rc == 0
+
+    def test_classify_dominant_failure_cause_helper(self):
+        """Direct unit test of the dominant-cause classifier."""
+        from kicad_tools.cli.route_cmd import _classify_dominant_failure_cause
+        from kicad_tools.router.failure_analysis import FailureCause
+
+        # None router -> None
+        assert _classify_dominant_failure_cause(None) is None
+
+        # No routing_failures attribute -> None
+        bare = SimpleNamespace()
+        assert _classify_dominant_failure_cause(bare) is None
+
+        # Empty failures -> None
+        empty = SimpleNamespace(routing_failures=[])
+        assert _classify_dominant_failure_cause(empty) is None
+
+        # Single-cause majority
+        single = SimpleNamespace(
+            routing_failures=[
+                self._make_failure(FailureCause.BLOCKED_PATH),
+                self._make_failure(FailureCause.BLOCKED_PATH),
+                self._make_failure(FailureCause.PIN_ACCESS),
+            ]
+        )
+        assert _classify_dominant_failure_cause(single) == FailureCause.BLOCKED_PATH
+
+        # Tie: triggering cause wins (PIN_ACCESS over BLOCKED_PATH)
+        tied = SimpleNamespace(
+            routing_failures=[
+                self._make_failure(FailureCause.PIN_ACCESS),
+                self._make_failure(FailureCause.BLOCKED_PATH),
+            ]
+        )
+        assert _classify_dominant_failure_cause(tied) == FailureCause.PIN_ACCESS


### PR DESCRIPTION
## Summary

Wires the `MFR_TIER_ESCALATION_TRIGGERS` registry (added in PR #2882) into the outer `--auto-mfr-tier` escalation loop. Previously the trigger table was unit-tested but never consulted by the dispatcher, leaving a documented-but-not-enforced contract.

- New private helper `_classify_dominant_failure_cause()` tallies per-net `FailureCause` values from `router.routing_failures`, picking the most common cause and breaking ties in favour of triggering causes so escalation engages on borderline mixed-failure cases.
- The outer loop in `route_with_mfr_tier_escalation` consults the trigger table on that dominant cause. When the registry marks the cause as non-fixable (`BLOCKED_PATH`, `CONGESTION`, `KEEPOUT`, `ROUTING_ORDER`, `UNKNOWN`, etc.), escalation is vetoed even when the next tier offers via-in-pad capability or scalar relaxation — exactly the case the issue called out.
- When `routing_failures` is unavailable (e.g. mocked inner call in unit tests), the dispatcher falls back to the legacy `missed_via_in_pad_rescues` + capability-gain heuristic, preserving every pre-existing test.

## Trigger registry contents

| `FailureCause`      | Escalate? | Why                                       |
| ------------------- | --------- | ----------------------------------------- |
| `PIN_ACCESS`        | YES       | Canonical "via-in-pad would have helped"  |
| `CLEARANCE`         | YES (conditional on scalar gain) | Tighter tier offers smaller mins |
| `VIA_BLOCKED`       | YES       | Tighter via geometry may fit              |
| `BLOCKED_PATH`      | NO        | Placement issue, not manufacturer-fixable |
| `CONGESTION`        | NO        | Layer issue; `--auto-layers` handles it   |
| `LAYER_CONFLICT`    | NO        | Layer issue                               |
| `KEEPOUT`           | NO        | Design issue                              |
| `ROUTING_ORDER`     | NO        | Ordering, not manufacturer                |
| `LENGTH_CONSTRAINT` | NO        | Design constraint                         |
| `DIFFERENTIAL_PAIR` | NO        | Design constraint                         |
| `UNKNOWN`           | NO        | Algorithm issue; escalation would mask it |

## Test plan

- [x] `pytest tests/test_route_auto_mfr_tier.py -v` — 36 passed (6 new tests under `TestTriggerTableWiring`)
- [x] `pytest tests/test_mfr_tier_ladder.py -v` — 27 passed (no regression on the existing ladder/trigger-table tests)
- [x] `ruff check` and `ruff format` clean on touched files
- [x] Smoke test `kct route boards/01-voltage-divider/output/voltage_divider.kicad_pcb --auto-mfr-tier` — succeeds on the starting tier as expected (escalation path stays inert when not needed)

### New tests added (`tests/test_route_auto_mfr_tier.py::TestTriggerTableWiring`)

- `test_pin_access_dominant_cause_triggers_escalation` — PIN_ACCESS dominant cause escalates (smoke that the wiring did not break the happy path)
- `test_blocked_path_dominant_cause_suppresses_escalation` — BLOCKED_PATH veto fires even when `missed_via_in_pad_rescues > 0` and capability gain is available (the case the issue called out)
- `test_congestion_dominant_cause_suppresses_escalation` — CONGESTION veto fires
- `test_no_failure_records_falls_back_to_legacy` — legacy heuristic preserved when classifier signal is absent
- `test_mixed_failures_tiebreak_picks_triggering_cause` — tiebreak between triggering and non-triggering causes picks the triggering one
- `test_classify_dominant_failure_cause_helper` — direct unit test of the new classifier helper

## Files touched

- `src/kicad_tools/cli/route_cmd.py` (+102, -16): added `_classify_dominant_failure_cause()`, imported `MFR_TIER_ESCALATION_TRIGGERS` / `should_escalate_mfr_tier`, added the veto branch in the outer loop
- `tests/test_route_auto_mfr_tier.py` (+301, -13): new `TestTriggerTableWiring` class

Closes #2883

Generated with [Claude Code](https://claude.com/claude-code)