### PR TITLE
fix(cli): restore outer kct build parser parity (closes #2888)

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,13 +535,9 @@ Recent additions an agent reading these docs cold should know about:
 - **`kct stitch --mfr` / `--copper`** — stackup-aware via dimensions; the
   manufacturer YAML drives via geometry. See
   [CLI Reference → stitch](docs/reference/cli.md#stitch).
-- **`kct build` routing-completeness preflight** — gate that blocks
-  manufacturing artefacts when nets are unrouted (runs automatically
-  between `stitch` and `verify` in the default `kct build` sequence;
-  bypass via `--allow-incomplete` or the global `--force`). The outer
-  `kct` parser does not yet surface the dedicated `--step preflight-routing`
-  invocation or `--allow-incomplete` (issue #2888) — use
-  `python -m kicad_tools.cli.build_cmd` for those today. See
+- **`kct build --step preflight-routing`** — routing-completeness gate that
+  blocks manufacturing artefacts when nets are unrouted. Override with
+  `--allow-incomplete`. See
   [Manufacturing Export → Routing Completeness Preflight](docs/guides/manufacturing-export.md#routing-completeness-preflight).
 - **`Footprint.locked` + siblings round-trip** through `PCB.save` (locked,
   dnp, exclude_from_pos_files, exclude_from_bom, plus preserved unknown

--- a/docs/guides/manufacturing-export.md
+++ b/docs/guides/manufacturing-export.md
@@ -82,13 +82,6 @@ Two escape hatches are recognised:
 - `--force` — global build override; parity with `--step sync --force`.
   Also converts the failure into a warning.
 
-> **Heads-up:** the outer `kct build` parser is currently stale — it does
-> not yet surface `--step preflight-routing`, `--step erc`, `--step sync`,
-> or `--allow-incomplete` (tracked in issue #2888). To exercise just the
-> preflight step or the WIP escape hatch today, invoke the inner parser
-> directly via `python -m kicad_tools.cli.build_cmd`. The default
-> end-to-end `kct build` invocation runs the preflight automatically.
-
 ```bash
 # Default end-to-end build (preflight runs automatically between stitch
 # and verify; refuses to ship gerbers for a board with unrouted nets).
@@ -96,15 +89,11 @@ Two escape hatches are recognised:
 kct build boards/05-bldc-motor-controller/project.kct
 
 # Run only the preflight check (read-only, no side-effects).
-# Goes through the inner parser until issue #2888 lands.
-python -m kicad_tools.cli.build_cmd \
-    boards/05-bldc-motor-controller/project.kct \
+kct build boards/05-bldc-motor-controller/project.kct \
     --step preflight-routing
 
-# Bypass for an intentional WIP preview. Same caveat as above.
-python -m kicad_tools.cli.build_cmd \
-    boards/05-bldc-motor-controller/project.kct \
-    --allow-incomplete
+# Bypass for an intentional WIP preview.
+kct build boards/05-bldc-motor-controller/project.kct --allow-incomplete
 ```
 
 The check is read-only and uses `NetStatusAnalyzer` in-process (no subprocess

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -426,31 +426,23 @@ default `all` sequence. It re-uses `kct net-status` semantics in-process and
 [Routing Completeness Preflight](../guides/manufacturing-export.md#routing-completeness-preflight)
 for the full semantics.
 
-> **Note:** `kct build --help` from the top-level parser is currently stale
-> (the outer parser does not list `erc`, `sync`, or `preflight-routing` as
-> `--step` choices and is missing `--allow-incomplete` /
-> `--optimize-placement`). Tracked in issue #2888. The authoritative parser
-> is constructed inline in `main()` at
-> [`src/kicad_tools/cli/build_cmd.py:2452`](../../src/kicad_tools/cli/build_cmd.py).
-> Until #2888 lands, exercise the missing choices/flags via
-> `python -m kicad_tools.cli.build_cmd ...`.
+The outer `kct build` parser is kept in lockstep with the authoritative
+inner parser at
+[`src/kicad_tools/cli/build_cmd.py`](../../src/kicad_tools/cli/build_cmd.py)
+by [`tests/test_build_parser_parity.py`](../../tests/test_build_parser_parity.py),
+which fails if a new flag or `--step` choice is added to the inner parser
+without also being surfaced on the outer CLI.
 
 **Examples:**
 ```bash
 # Full pipeline driven by the project spec. `SPEC` is positional.
 kct build boards/05-bldc-motor-controller/project.kct
 
-# Skip the routing-completeness gate (WIP escape hatch). Goes through the
-# inner parser until issue #2888 surfaces --allow-incomplete on the outer
-# CLI.
-python -m kicad_tools.cli.build_cmd \
-    boards/05-bldc-motor-controller/project.kct \
-    --allow-incomplete
+# Skip the routing-completeness gate (WIP escape hatch).
+kct build boards/05-bldc-motor-controller/project.kct --allow-incomplete
 
-# Run a single stage. Same caveat: --step preflight-routing is only
-# accepted by the inner parser today.
-python -m kicad_tools.cli.build_cmd \
-    boards/05-bldc-motor-controller/project.kct \
+# Run a single stage.
+kct build boards/05-bldc-motor-controller/project.kct \
     --step preflight-routing
 ```
 

--- a/src/kicad_tools/cli/build_cmd.py
+++ b/src/kicad_tools/cli/build_cmd.py
@@ -2447,8 +2447,15 @@ def _smoke_check_pcb(
     return None
 
 
-def main(argv: list[str] | None = None) -> int:
-    """Main entry point for kct build command."""
+def _build_inner_parser() -> argparse.ArgumentParser:
+    """Build the inner (authoritative) ``kct build`` argument parser.
+
+    Extracted from ``main()`` so the parity test in
+    ``tests/test_build_parser_parity.py`` can introspect this parser without
+    invoking the full ``main()`` entry point.  The outer parser at
+    ``src/kicad_tools/cli/parser.py::_add_build_parser`` must mirror every
+    long option string and ``--step`` choice declared here.
+    """
     parser = argparse.ArgumentParser(
         prog="kct build",
         description="Build from spec to manufacturable design",
@@ -2550,6 +2557,12 @@ Examples:
         ),
     )
 
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Main entry point for kct build command."""
+    parser = _build_inner_parser()
     args = parser.parse_args(argv)
     console = Console(quiet=args.quiet)
 

--- a/src/kicad_tools/cli/commands/build.py
+++ b/src/kicad_tools/cli/commands/build.py
@@ -31,8 +31,25 @@ def run_build_command(args) -> int:
     if getattr(args, "build_force", False):
         sub_argv.append("--force")
 
-    # Use global quiet or command-level quiet
-    if getattr(args, "global_quiet", False):
+    # Quiet may come from the command-level --quiet/-q flag or the global flag
+    if getattr(args, "build_quiet", False) or getattr(args, "global_quiet", False):
         sub_argv.append("--quiet")
+
+    # Output directory
+    build_output = getattr(args, "build_output", None)
+    if build_output:
+        sub_argv.extend(["--output", build_output])
+
+    # Optimize placement (opt-in CMA-ES)
+    if getattr(args, "build_optimize_placement", False):
+        sub_argv.append("--optimize-placement")
+
+    # Smoke-check opt-out
+    if getattr(args, "build_no_smoke_check", False):
+        sub_argv.append("--no-smoke-check")
+
+    # Routing-completeness preflight escape hatch
+    if getattr(args, "build_allow_incomplete", False):
+        sub_argv.append("--allow-incomplete")
 
     return build_main(sub_argv)

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -5122,13 +5122,16 @@ def _add_build_parser(subparsers) -> None:
         dest="build_step",
         choices=[
             "schematic",
+            "erc",
             "pcb",
+            "sync",
             "outline",
             "placement",
             "zones",
             "silkscreen",
             "route",
             "stitch",
+            "preflight-routing",
             "verify",
             "export",
             "all",
@@ -5158,11 +5161,49 @@ def _add_build_parser(subparsers) -> None:
         help="Show detailed output",
     )
     build_parser.add_argument(
+        "-q",
+        "--quiet",
+        dest="build_quiet",
+        action="store_true",
+        help="Suppress progress output",
+    )
+    build_parser.add_argument(
         "-f",
         "--force",
         dest="build_force",
         action="store_true",
         help="Force rebuild, ignoring existing outputs and timestamp checks",
+    )
+    build_parser.add_argument(
+        "-o",
+        "--output",
+        dest="build_output",
+        help="Output directory for generated files (default: project directory)",
+    )
+    build_parser.add_argument(
+        "--optimize-placement",
+        dest="build_optimize_placement",
+        action="store_true",
+        help="Run CMA-ES placement optimization before routing (opt-in)",
+    )
+    build_parser.add_argument(
+        "--no-smoke-check",
+        dest="build_no_smoke_check",
+        action="store_true",
+        help=(
+            "Disable the per-step kicad-cli load smoke check that runs "
+            "after each PCB-write step.  Use to restore prior behaviour "
+            "when kicad-cli is misbehaving or pipeline speed matters."
+        ),
+    )
+    build_parser.add_argument(
+        "--allow-incomplete",
+        dest="build_allow_incomplete",
+        action="store_true",
+        help=(
+            "Skip the routing-completeness preflight "
+            "(advertised in failure messages; CI greppable)."
+        ),
     )
 
 

--- a/tests/test_build_parser_parity.py
+++ b/tests/test_build_parser_parity.py
@@ -1,0 +1,245 @@
+"""Parity test between the outer (top-level ``kct build``) and inner
+(``python -m kicad_tools.cli.build_cmd``) argument parsers.
+
+Background
+----------
+
+There are two argument parsers for the ``build`` command:
+
+* **Inner / authoritative** — built by
+  ``kicad_tools.cli.build_cmd._build_inner_parser``.  Used when the module is
+  invoked directly via ``python -m kicad_tools.cli.build_cmd`` or via the
+  dispatcher in ``kicad_tools.cli.commands.build.run_build_command``.
+
+* **Outer** — built inside ``kicad_tools.cli.parser.create_parser`` via
+  ``_add_build_parser``.  Backs ``kct build`` on the top-level CLI.
+
+These two parsers historically drift (see issue #2888).  This test fails
+loudly when the inner parser adds a long option string or a ``--step``
+choice that has not been mirrored to the outer parser.
+
+Maintenance contract
+--------------------
+
+If you add an option to the inner parser, you MUST also:
+
+1. Add the same long option string to the outer parser in
+   ``_add_build_parser`` (with a ``build_*`` ``dest``).
+2. Forward it from ``run_build_command`` into ``sub_argv`` so the inner
+   parser actually sees it.
+
+If you intentionally want an inner-only option (rare — usually the answer
+is to surface it on the outer CLI too), add it to ``INTENTIONAL_INNER_ONLY``
+below with an inline comment explaining why.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from kicad_tools.cli.build_cmd import _build_inner_parser
+from kicad_tools.cli.parser import create_parser
+
+# ---------------------------------------------------------------------------
+# Allowlists for intentional differences.
+# ---------------------------------------------------------------------------
+
+# Long option strings present on the inner parser that we INTENTIONALLY do
+# not mirror onto the outer parser.  Keep this list short and documented.
+INTENTIONAL_INNER_ONLY: frozenset[str] = frozenset(
+    {
+        # (none currently — issue #2888 wants full parity)
+    }
+)
+
+# Long option strings present on the outer parser that the inner parser does
+# not need to see (typically because the dispatcher consumes them itself or
+# the global parser already surfaces them).  Right now there are no outer-
+# only options.
+INTENTIONAL_OUTER_ONLY: frozenset[str] = frozenset(
+    {
+        # (none currently)
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers.
+# ---------------------------------------------------------------------------
+
+
+def _long_option_strings(parser: argparse.ArgumentParser) -> set[str]:
+    """Return the set of long option strings (``--foo``) declared on ``parser``."""
+    out: set[str] = set()
+    for action in parser._actions:  # noqa: SLF001 — argparse offers no public API
+        for opt in action.option_strings:
+            if opt.startswith("--"):
+                out.add(opt)
+    # ``--help`` is added automatically by argparse on every parser; it is not
+    # interesting for parity purposes.
+    out.discard("--help")
+    return out
+
+
+def _get_outer_build_parser() -> argparse.ArgumentParser:
+    """Locate the ``build`` subparser within the top-level CLI parser."""
+    top = create_parser()
+    for action in top._actions:  # noqa: SLF001 — argparse offers no public API
+        if isinstance(action, argparse._SubParsersAction):  # noqa: SLF001
+            if "build" in action.choices:
+                return action.choices["build"]
+    raise AssertionError(
+        "Top-level parser does not expose a 'build' subcommand; did "
+        "_add_build_parser get removed from create_parser()?"
+    )
+
+
+def _step_action(parser: argparse.ArgumentParser) -> argparse.Action:
+    """Return the ``--step`` action from ``parser``."""
+    for action in parser._actions:  # noqa: SLF001
+        if "--step" in action.option_strings:
+            return action
+    raise AssertionError("Parser is missing the required --step option")
+
+
+# ---------------------------------------------------------------------------
+# Tests.
+# ---------------------------------------------------------------------------
+
+
+def test_inner_parser_options_are_mirrored_on_outer_parser() -> None:
+    """Every inner long option (modulo the allowlist) must exist on outer."""
+    inner = _build_inner_parser()
+    outer = _get_outer_build_parser()
+
+    inner_opts = _long_option_strings(inner)
+    outer_opts = _long_option_strings(outer)
+
+    missing_on_outer = (inner_opts - outer_opts) - INTENTIONAL_INNER_ONLY
+    assert not missing_on_outer, (
+        "The following long options are declared on the inner build parser "
+        f"({sorted(missing_on_outer)}) but not on the outer (top-level "
+        "kct build) parser.  Update src/kicad_tools/cli/parser.py::"
+        "_add_build_parser to mirror them, then add forwarding in "
+        "src/kicad_tools/cli/commands/build.py::run_build_command."
+    )
+
+
+def test_outer_parser_does_not_advertise_unknown_options() -> None:
+    """Every outer long option (modulo the allowlist) must exist on inner."""
+    inner = _build_inner_parser()
+    outer = _get_outer_build_parser()
+
+    inner_opts = _long_option_strings(inner)
+    outer_opts = _long_option_strings(outer)
+
+    surplus_on_outer = (outer_opts - inner_opts) - INTENTIONAL_OUTER_ONLY
+    assert not surplus_on_outer, (
+        "The following long options are declared on the outer parser "
+        f"({sorted(surplus_on_outer)}) but not understood by the inner "
+        "build_cmd parser.  Either remove them from _add_build_parser or "
+        "add them to _build_inner_parser."
+    )
+
+
+def test_step_choice_parity() -> None:
+    """``--step`` choices must match exactly between inner and outer."""
+    inner = _build_inner_parser()
+    outer = _get_outer_build_parser()
+
+    inner_choices = set(_step_action(inner).choices or ())
+    outer_choices = set(_step_action(outer).choices or ())
+
+    missing = inner_choices - outer_choices
+    surplus = outer_choices - inner_choices
+
+    assert inner_choices == outer_choices, (
+        f"--step choices drift detected. Missing on outer: {sorted(missing)}; "
+        f"surplus on outer: {sorted(surplus)}. The outer parser must accept "
+        f"the same set as the inner parser."
+    )
+
+
+@pytest.mark.parametrize(
+    "step",
+    ["schematic", "erc", "pcb", "sync", "preflight-routing", "verify", "export", "all"],
+)
+def test_outer_parser_accepts_each_step_choice(step: str) -> None:
+    """Smoke test that the outer parser parses each documented step choice."""
+    top = create_parser()
+    args = top.parse_args(["build", "--step", step])
+    assert getattr(args, "build_step", None) == step
+
+
+def test_outer_parser_accepts_new_flags() -> None:
+    """Outer parser must accept the flags added in issue #2888."""
+    top = create_parser()
+    args = top.parse_args(
+        [
+            "build",
+            "--allow-incomplete",
+            "--optimize-placement",
+            "--no-smoke-check",
+            "-o",
+            "/tmp/out",
+            "--quiet",
+        ]
+    )
+    assert getattr(args, "build_allow_incomplete", False) is True
+    assert getattr(args, "build_optimize_placement", False) is True
+    assert getattr(args, "build_no_smoke_check", False) is True
+    assert getattr(args, "build_output", None) == "/tmp/out"
+    assert getattr(args, "build_quiet", False) is True
+
+
+def test_dispatcher_forwards_new_flags() -> None:
+    """``run_build_command`` must forward each new flag into ``sub_argv``."""
+    from types import SimpleNamespace
+
+    from kicad_tools.cli.commands import build as build_cmd_dispatch
+
+    captured: dict[str, list[str] | None] = {"argv": None}
+
+    def _fake_build_main(argv: list[str] | None) -> int:
+        captured["argv"] = list(argv) if argv is not None else None
+        return 0
+
+    # The dispatcher imports the inner main lazily inside the function body
+    # (``from ..build_cmd import main as build_main``).  Patch the module-
+    # level attribute so the import resolves to our fake.
+    import kicad_tools.cli.build_cmd as inner_module
+
+    orig_main = inner_module.main
+    inner_module.main = _fake_build_main  # type: ignore[assignment]
+    try:
+        args = SimpleNamespace(
+            build_spec="boards/x/project.kct",
+            build_step="preflight-routing",
+            build_mfr="jlcpcb",
+            build_dry_run=True,
+            build_verbose=False,
+            build_quiet=True,
+            global_quiet=False,
+            build_force=False,
+            build_output="/tmp/out",
+            build_optimize_placement=True,
+            build_no_smoke_check=True,
+            build_allow_incomplete=True,
+        )
+        rc = build_cmd_dispatch.run_build_command(args)
+    finally:
+        inner_module.main = orig_main  # type: ignore[assignment]
+
+    assert rc == 0
+    argv = captured["argv"]
+    assert argv is not None
+    assert "boards/x/project.kct" in argv
+    assert argv[1:3] == ["--step", "preflight-routing"]
+    assert "--dry-run" in argv
+    assert "--quiet" in argv
+    assert "--output" in argv and "/tmp/out" in argv
+    assert "--optimize-placement" in argv
+    assert "--no-smoke-check" in argv
+    assert "--allow-incomplete" in argv


### PR DESCRIPTION
## Summary

Closes #2888.

The top-level `kct build` parser had drifted out of sync with the authoritative inner parser at `kicad_tools.cli.build_cmd._build_inner_parser`. This PR restores parity (Phase 1 of the curator's plan) plus adds a parity test that fails loudly the next time the two drift.

### Outer parser additions (`src/kicad_tools/cli/parser.py::_add_build_parser`)

| Kind | Items |
|---|---|
| New `--step` choices | `erc`, `sync`, `preflight-routing` |
| New flags | `-q/--quiet`, `-o/--output`, `--optimize-placement`, `--no-smoke-check`, `--allow-incomplete` |

### Dispatcher additions (`src/kicad_tools/cli/commands/build.py::run_build_command`)

Forwards into `sub_argv`: `--output`, `--optimize-placement`, `--no-smoke-check`, `--allow-incomplete`, and the command-level `--quiet`/`-q` (in addition to the existing global `--quiet`).

### Refactor

`build_cmd.main()` now defers parser construction to a new `_build_inner_parser()` helper so the parity test can introspect it directly.

### New test (`tests/test_build_parser_parity.py`)

13 tests, all green:

* `test_inner_parser_options_are_mirrored_on_outer_parser` — every inner long option (modulo an explicit empty allowlist) is also declared on the outer parser.
* `test_outer_parser_does_not_advertise_unknown_options` — reverse direction, prevents outer-only flags from creeping in.
* `test_step_choice_parity` — `--step` choice sets match exactly.
* `test_outer_parser_accepts_each_step_choice[...]` — parametrized smoke test (8 choices).
* `test_outer_parser_accepts_new_flags` — outer parser accepts each newly added flag.
* `test_dispatcher_forwards_new_flags` — `run_build_command` actually forwards them into `build_main`'s argv.

### Docs restored

`docs/reference/cli.md`, `docs/guides/manufacturing-export.md`, and `README.md` drop the "outer parser is stale" workarounds from PR #2887 and go back to the unified `kct build ...` invocations (no more `python -m kicad_tools.cli.build_cmd ...` workaround needed).

## Test plan

- [x] `uv run pytest tests/test_build_parser_parity.py` — 13 passed
- [x] `uv run pytest tests/test_build_cmd_errors.py tests/test_build_cmd_stdout_streaming.py tests/test_build_preflight_routing_step.py tests/test_build_erc_step.py tests/test_build_sync_step.py tests/test_build_context.py` — 112 passed, 1 pre-existing failure (`test_route_exit_code_3_is_failure`; verified on `main` without these changes).
- [x] `uv run ruff check` on every modified file — clean.
- [x] `kct build --help` lists all new step choices + flags.
- [x] `kct build --step preflight-routing --dry-run boards/05-bldc-motor-controller/project.kct` exits 0 through the outer CLI.
- [x] `kct build --step preflight-routing --allow-incomplete --dry-run boards/05-bldc-motor-controller/project.kct` exits 0 (confirms `--allow-incomplete` is forwarded).

## Pre-existing failure note

`tests/test_build_cmd_errors.py::TestBuildRouteExitCode2::test_route_exit_code_3_is_failure` fails on `main` today (route exit code 3 currently returns `success=True` with message "Routing complete but DRC violations remain"). It is unrelated to this PR and out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)