### PR TITLE
fix(router): suppress in-pad rescue ERROR during --auto-mfr-tier escalation (#2891)

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -1921,6 +1921,10 @@ def route_with_layer_escalation(
         # to in-pad escape for fine-pitch LQFP/QFP (and SSOP/TSSOP) when the
         # manufacturer supports via-in-pad processing.
         manufacturer=getattr(args, "manufacturer", None),
+        # Issue #2891: forward escalation-in-progress flag so the escape
+        # router demotes the #2880 ERROR log when an outer wrapper will
+        # retry on a tier that supports via-in-pad.
+        auto_mfr_tier_in_progress=getattr(args, "_auto_mfr_tier_in_progress", False),
     )
 
     # Parse skip nets
@@ -2729,6 +2733,8 @@ def route_with_rule_relaxation(
             # in to in-pad escape for fine-pitch LQFP/QFP/SSOP/TSSOP when
             # the manufacturer supports via-in-pad processing.
             manufacturer=getattr(args, "manufacturer", None),
+            # Issue #2891: forward escalation-in-progress flag.
+            auto_mfr_tier_in_progress=getattr(args, "_auto_mfr_tier_in_progress", False),
         )
 
         # Load PCB
@@ -3296,6 +3302,14 @@ def route_with_mfr_tier_escalation(
     final_exit_code: int = 1
     saw_terminating_success: bool = False
 
+    # Issue #2891: suppress the per-attempt "does not support via-in-pad"
+    # ERROR log (#2880) while escalation is in flight.  The flag is read
+    # by ``EscapeRouter`` via ``rules.auto_mfr_tier_in_progress`` (set by
+    # the DesignRules construction sites elsewhere in this module).  We
+    # explicitly clear it before the FINAL tier attempt so a fully-
+    # exhausted ladder still surfaces the diagnostic on its last try.
+    last_tier_idx = len(tiers_to_try) - 1
+
     # Issue #2881: budget-fair per-tier slicing.  Reuse the existing
     # ``_per_attempt_budgeted_timeout`` helper transparently by having the
     # inner ``route_with_layer_escalation`` call divide ``args.timeout``
@@ -3404,6 +3418,19 @@ def route_with_mfr_tier_escalation(
         # mutation takes effect for the next inner call.
         original_mfr = args.manufacturer
         args.manufacturer = tier_name
+
+        # Issue #2891: declare whether escalation is in flight for THIS
+        # tier attempt.  All tiers except the final one are escalation-in-
+        # progress (the inner ERROR is a false alarm because we will retry
+        # on the next tier).  The FINAL tier is NOT escalation-in-progress:
+        # if it fails, the user must see the ERROR.  The DesignRules
+        # construction sites in this module read this attribute via
+        # ``getattr(args, "_auto_mfr_tier_in_progress", False)`` and
+        # forward it onto ``DesignRules.auto_mfr_tier_in_progress``,
+        # which gates the demotion in
+        # ``EscapeRouter._escape_qfp_alternating``.
+        is_final_tier = tier_idx == last_tier_idx
+        args._auto_mfr_tier_in_progress = not is_final_tier
         try:
             if not quiet:
                 flush_print("=" * 60)
@@ -3467,6 +3494,10 @@ def route_with_mfr_tier_escalation(
             # CLI calls aren't surprised.
             if last_exit_code != 0:
                 args.manufacturer = original_mfr
+            # Issue #2891: always clear the escalation-in-progress flag
+            # on exit so callers that re-use ``args`` aren't surprised by
+            # log demotion in unrelated code paths.
+            args._auto_mfr_tier_in_progress = False
 
     # Diagnostic: name the constraint when escalation did not succeed.
     if not saw_terminating_success and not quiet:
@@ -3766,6 +3797,8 @@ def route_with_combined_escalation(
                 # can opt in to in-pad escape for fine-pitch LQFP/QFP/SSOP/
                 # TSSOP when the manufacturer supports via-in-pad processing.
                 manufacturer=getattr(args, "manufacturer", None),
+                # Issue #2891: forward escalation-in-progress flag.
+                auto_mfr_tier_in_progress=getattr(args, "_auto_mfr_tier_in_progress", False),
             )
 
             # Load PCB
@@ -5432,6 +5465,10 @@ def main(argv: list[str] | None = None) -> int:
         # to in-pad escape for fine-pitch SSOP/TSSOP when the manufacturer
         # supports via-in-pad processing.
         manufacturer=getattr(args, "manufacturer", None),
+        # Issue #2891: forward escalation-in-progress flag so the escape
+        # router demotes the #2880 ERROR log when an outer wrapper will
+        # retry on a tier that supports via-in-pad.
+        auto_mfr_tier_in_progress=getattr(args, "_auto_mfr_tier_in_progress", False),
     )
 
     # Import progress helpers

--- a/src/kicad_tools/router/escape.py
+++ b/src/kicad_tools/router/escape.py
@@ -1927,9 +1927,17 @@ class EscapeRouter:
                 # rather than producing a route that DRC will later
                 # reject.  (The ``pin_boxed`` flag above already gates on
                 # along-edge direction.)
+                #
+                # Issue #2891: when ``--auto-mfr-tier`` is escalating, demote
+                # the ERROR to DEBUG -- the outer wrapper recovers by walking
+                # forward to a tier that supports via-in-pad, so the inner
+                # message is a false alarm from the user's perspective.  The
+                # wrapper is responsible for clearing the flag before the
+                # FINAL tier attempt so a fully-exhausted ladder still
+                # surfaces the diagnostic.
                 if pin_boxed and not self.via_in_pad_supported:
                     mfr_label = self.manufacturer or "<unknown manufacturer>"
-                    logger.error(
+                    msg = (
                         "Cannot escape %s pin %s (net %s) to perimeter "
                         "without violating clearance against same-component "
                         "plane-net pads at %.2fmm %s pitch. Manufacturer "
@@ -1938,7 +1946,9 @@ class EscapeRouter:
                         "profile that supports via-in-pad "
                         "(e.g. jlcpcb-tier1, pcbway), "
                         "(b) re-route on a 4-layer stackup with inner-layer "
-                        "escape, (c) increase pin pitch. (Issue #2880)",
+                        "escape, (c) increase pin pitch. (Issue #2880)"
+                    )
+                    msg_args = (
                         package.ref,
                         pad.pin,
                         pad.net_name,
@@ -1946,6 +1956,13 @@ class EscapeRouter:
                         package.package_type.name,
                         mfr_label,
                     )
+                    # Issue #2891: demote during in-flight tier escalation.
+                    # Keep the wording identical so log forensics still
+                    # locate the diagnostic via grep.
+                    if getattr(self.rules, "auto_mfr_tier_in_progress", False):
+                        logger.debug(msg, *msg_args)
+                    else:
+                        logger.error(msg, *msg_args)
 
                 # Issue #2756: clip the segment endpoint against
                 # neighbour-pad clearance.  When the manufacturer does

--- a/src/kicad_tools/router/rules.py
+++ b/src/kicad_tools/router/rules.py
@@ -81,6 +81,19 @@ class DesignRules:
     # preserving pre-#2605 deferred-pin behavior on fine-pitch SSOP/TSSOP.
     manufacturer: str | None = None
 
+    # Manufacturer-tier escalation in progress flag (Issue #2891)
+    # When True, the escape router demotes the "Cannot escape ... does not
+    # support via-in-pad" ERROR log (escape.py Issue #2880) to DEBUG level
+    # because the outer ``route_with_mfr_tier_escalation`` wrapper
+    # (route_cmd.py) will recover by switching to a manufacturer tier that
+    # DOES support via-in-pad.  Must be cleared by the wrapper before the
+    # FINAL tier attempt so that, on a fully-exhausted ladder, the ERROR
+    # re-surfaces and the user sees the unfixable constraint.  Threaded
+    # through DesignRules rather than the EscapeRouter constructor to keep
+    # the change surface small (one new field, one read in escape.py,
+    # writes localized to route_cmd.py's escalation wrapper).
+    auto_mfr_tier_in_progress: bool = False
+
     # Per-component clearance overrides (Issue #1016)
     # Maps component reference (e.g., "U1") to clearance in mm
     # Use for fine-pitch ICs where tighter clearance is needed between pins

--- a/tests/router/test_escape_qfp_plane_sandwich.py
+++ b/tests/router/test_escape_qfp_plane_sandwich.py
@@ -664,3 +664,111 @@ class TestNoViaInPadErrorPath:
             "When via-in-pad is supported, no #2880 ERROR records should "
             f"be emitted; got: {[r.getMessage() for r in sandwich_errors]}"
         )
+
+
+class TestAutoMfrTierLogSuppression:
+    """Issue #2891: when ``--auto-mfr-tier`` escalation is in flight on a
+    lower tier that lacks via-in-pad, the per-attempt #2880 ERROR is a
+    false alarm -- the outer wrapper will retry on a tier that supports
+    via-in-pad.  Demote the log to DEBUG while escalation is in flight,
+    but re-surface it on the FINAL ladder attempt so a fully-exhausted
+    ladder still names the unfixable constraint."""
+
+    def test_error_suppressed_during_escalation(self, caplog):
+        """When ``rules.auto_mfr_tier_in_progress`` is True, the #2880
+        message must NOT appear at ERROR level (the outer wrapper will
+        retry on a via-in-pad-capable tier).  It must still appear at
+        DEBUG so log forensics can find it via grep."""
+        rules = _make_rules(manufacturer="jlcpcb")
+        rules.auto_mfr_tier_in_progress = True
+        grid = _make_grid(rules)
+        router = EscapeRouter(grid, rules)
+        assert not router.via_in_pad_supported, (
+            "Fixture sanity: plain jlcpcb should not support via-in-pad"
+        )
+        pads = _make_lqfp48_along_edge_sandwich()
+        package = router.analyze_package(pads)
+
+        # Capture both DEBUG and ERROR so we can assert demotion.
+        with caplog.at_level(logging.DEBUG, logger="kicad_tools.router.escape"):
+            router.generate_escapes(package)
+
+        sandwich_errors = [
+            r
+            for r in caplog.records
+            if r.levelno >= logging.ERROR and "#2880" in r.getMessage()
+        ]
+        assert sandwich_errors == [], (
+            "Escalation-in-progress must suppress the #2880 ERROR; "
+            f"got: {[r.getMessage() for r in sandwich_errors]}"
+        )
+
+        sandwich_debugs = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.DEBUG and "#2880" in r.getMessage()
+        ]
+        assert len(sandwich_debugs) >= 1, (
+            "Escalation-in-progress must still log #2880 at DEBUG so log "
+            "forensics can locate the diagnostic; got records: "
+            f"{[(r.levelname, r.getMessage()) for r in caplog.records]}"
+        )
+
+    def test_error_resurfaces_on_ladder_exhaustion(self, caplog):
+        """When the outer wrapper has cleared ``auto_mfr_tier_in_progress``
+        for the FINAL tier attempt (i.e. the ladder is about to be
+        exhausted), the #2880 ERROR must re-surface so the user sees the
+        unfixable constraint.  Without this, a real failure would go
+        silent.  Modelled as: explicit ``auto_mfr_tier_in_progress=False``
+        on a non-via-in-pad rules object yields the same behavior as the
+        pre-#2891 baseline."""
+        rules = _make_rules(manufacturer="jlcpcb")
+        # Explicitly cleared (matches the FINAL-tier code path).
+        rules.auto_mfr_tier_in_progress = False
+        grid = _make_grid(rules)
+        router = EscapeRouter(grid, rules)
+        assert not router.via_in_pad_supported
+        pads = _make_lqfp48_along_edge_sandwich()
+        package = router.analyze_package(pads)
+
+        with caplog.at_level(logging.ERROR, logger="kicad_tools.router.escape"):
+            router.generate_escapes(package)
+
+        sandwich_errors = [
+            r
+            for r in caplog.records
+            if r.levelno >= logging.ERROR and "#2880" in r.getMessage()
+        ]
+        assert len(sandwich_errors) >= 1, (
+            "When escalation is NOT in progress (final-tier attempt), the "
+            "#2880 ERROR must re-surface so the user sees the unfixable "
+            f"constraint; got records: {[r.getMessage() for r in caplog.records]}"
+        )
+
+    def test_default_preserves_error_for_non_escalation_callers(self, caplog):
+        """A plain ``kct route --manufacturer jlcpcb`` invocation (no
+        ``--auto-mfr-tier``) must still surface the #2880 ERROR.  This is
+        the degenerate single-tier / no-ladder edge case: ``DesignRules``
+        defaults to ``auto_mfr_tier_in_progress=False`` so the demotion
+        never triggers."""
+        rules = _make_rules(manufacturer="jlcpcb")
+        # Sanity: the default must be False so non-escalation callers
+        # are unaffected by #2891.
+        assert rules.auto_mfr_tier_in_progress is False
+        grid = _make_grid(rules)
+        router = EscapeRouter(grid, rules)
+        pads = _make_lqfp48_along_edge_sandwich()
+        package = router.analyze_package(pads)
+
+        with caplog.at_level(logging.ERROR, logger="kicad_tools.router.escape"):
+            router.generate_escapes(package)
+
+        sandwich_errors = [
+            r
+            for r in caplog.records
+            if r.levelno >= logging.ERROR and "#2880" in r.getMessage()
+        ]
+        assert len(sandwich_errors) >= 1, (
+            "Non-escalation callers must still see the #2880 ERROR "
+            f"(pre-#2891 non-regression); got: {[r.getMessage() for r in caplog.records]}"
+        )

--- a/tests/test_auto_mfr_tier_log_suppression.py
+++ b/tests/test_auto_mfr_tier_log_suppression.py
@@ -1,0 +1,202 @@
+"""Issue #2891: end-to-end behaviour of the auto-mfr-tier ERROR-log
+suppression flag.
+
+Verifies that ``route_with_mfr_tier_escalation``:
+
+1. Sets ``args._auto_mfr_tier_in_progress = True`` for every
+   non-final tier attempt (so the inner ``EscapeRouter`` demotes
+   the #2880 ERROR to DEBUG -- false alarm; outer wrapper retries).
+2. Sets ``args._auto_mfr_tier_in_progress = False`` for the FINAL
+   tier attempt (so a fully-exhausted ladder surfaces the ERROR).
+3. Clears the flag after the wrapper returns (so reuse of ``args``
+   by unrelated callers isn't surprised).
+4. Handles the degenerate single-tier ladder edge case correctly:
+   that single tier IS the final tier, so the flag must be False
+   for it.
+
+These properties are tested at the wrapper-level (stubbing the
+inner ``route_with_layer_escalation``) -- the actual log demotion
+in ``EscapeRouter`` is covered by
+``tests/router/test_escape_qfp_plane_sandwich.py::TestAutoMfrTierLogSuppression``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _make_args(**overrides) -> SimpleNamespace:
+    """Build a minimal-but-complete args namespace for the wrapper."""
+    base = SimpleNamespace(
+        pcb="test.kicad_pcb",
+        manufacturer="jlcpcb",
+        auto_mfr_tier=True,
+        mfr_tier_ladder=None,
+        auto_layers=True,
+        adaptive_rules=False,
+        quiet=True,
+        timeout=None,
+        _wall_clock_deadline=None,
+    )
+    for k, v in overrides.items():
+        setattr(base, k, v)
+    return base
+
+
+class TestAutoMfrTierEscalationFlagPlumbing:
+    """The wrapper must set ``_auto_mfr_tier_in_progress`` so the inner
+    ``DesignRules`` construction (in ``route_with_layer_escalation`` /
+    related entry points) can forward it onto
+    ``DesignRules.auto_mfr_tier_in_progress`` -- which the
+    ``EscapeRouter`` reads to gate the #2880 ERROR demotion."""
+
+    def test_non_final_tiers_set_flag_true(self):
+        """Walk a two-tier ladder (jlcpcb -> jlcpcb-tier1).  The first
+        tier is non-final so its inner call must see the flag set;
+        the second tier is final so its inner call must see the flag
+        cleared (so a real failure would still surface the ERROR)."""
+        from kicad_tools.cli.route_cmd import route_with_mfr_tier_escalation
+
+        args = _make_args()
+        seen: list[tuple[str, bool]] = []
+
+        def fake_inner(*, pcb_path, output_path, args, quiet):
+            seen.append(
+                (args.manufacturer, getattr(args, "_auto_mfr_tier_in_progress", False))
+            )
+            # Set missed_via_in_pad_rescues so escalation actually fires.
+            mock_router = MagicMock()
+            mock_router._escape_router = MagicMock()
+            mock_router._escape_router.missed_via_in_pad_rescues = 3
+            args._last_router = mock_router
+            return 2  # always fail to walk the whole ladder
+
+        with patch(
+            "kicad_tools.cli.route_cmd.route_with_layer_escalation",
+            side_effect=fake_inner,
+        ):
+            route_with_mfr_tier_escalation(
+                pcb_path=Path("test.kicad_pcb"),
+                output_path=Path("out.kicad_pcb"),
+                args=args,
+                quiet=True,
+            )
+
+        # Expect: ("jlcpcb", True), ("jlcpcb-tier1", False)
+        assert len(seen) == 2, f"Expected both tiers to be attempted; got {seen}"
+        assert seen[0] == ("jlcpcb", True), (
+            f"First (non-final) tier must run with escalation-in-progress=True; got {seen[0]}"
+        )
+        assert seen[1] == ("jlcpcb-tier1", False), (
+            "Final tier must run with escalation-in-progress=False so the "
+            f"#2880 ERROR re-surfaces on ladder exhaustion; got {seen[1]}"
+        )
+
+    def test_flag_cleared_after_wrapper_returns(self):
+        """Reuse of ``args`` by unrelated callers must not see the
+        escalation flag leaking through."""
+        from kicad_tools.cli.route_cmd import route_with_mfr_tier_escalation
+
+        args = _make_args()
+
+        def fake_inner(*, pcb_path, output_path, args, quiet):
+            mock_router = MagicMock()
+            mock_router._escape_router = MagicMock()
+            mock_router._escape_router.missed_via_in_pad_rescues = 3
+            args._last_router = mock_router
+            return 2  # always fail
+
+        with patch(
+            "kicad_tools.cli.route_cmd.route_with_layer_escalation",
+            side_effect=fake_inner,
+        ):
+            route_with_mfr_tier_escalation(
+                pcb_path=Path("test.kicad_pcb"),
+                output_path=Path("out.kicad_pcb"),
+                args=args,
+                quiet=True,
+            )
+
+        assert getattr(args, "_auto_mfr_tier_in_progress", False) is False, (
+            "Wrapper must clear the escalation flag on exit so callers that "
+            "reuse `args` aren't surprised by log demotion in unrelated paths."
+        )
+
+    def test_single_tier_ladder_runs_with_flag_false(self):
+        """Degenerate ladder edge case: when the ladder collapses to a
+        single tier (e.g. user passes ``--mfr-tier-ladder jlcpcb``), that
+        single tier IS the final tier and must run with the flag
+        cleared so the #2880 ERROR is NOT suppressed."""
+        from kicad_tools.cli.route_cmd import route_with_mfr_tier_escalation
+
+        args = _make_args(
+            manufacturer="jlcpcb",
+            mfr_tier_ladder="jlcpcb",  # explicit single-element ladder
+        )
+        seen: list[tuple[str, bool]] = []
+
+        def fake_inner(*, pcb_path, output_path, args, quiet):
+            seen.append(
+                (args.manufacturer, getattr(args, "_auto_mfr_tier_in_progress", False))
+            )
+            mock_router = MagicMock()
+            mock_router._escape_router = MagicMock()
+            mock_router._escape_router.missed_via_in_pad_rescues = 3
+            args._last_router = mock_router
+            return 2  # failure
+
+        with patch(
+            "kicad_tools.cli.route_cmd.route_with_layer_escalation",
+            side_effect=fake_inner,
+        ):
+            route_with_mfr_tier_escalation(
+                pcb_path=Path("test.kicad_pcb"),
+                output_path=Path("out.kicad_pcb"),
+                args=args,
+                quiet=True,
+            )
+
+        assert seen == [("jlcpcb", False)], (
+            "Single-tier ladder: the lone tier IS the final tier and must "
+            f"run with escalation-in-progress=False; got {seen}"
+        )
+
+    def test_success_on_first_tier_runs_with_flag_appropriately(self):
+        """When the starting tier succeeds, no escalation happens.  In a
+        two-tier ladder, the first tier is NOT the final tier, so the
+        flag is set when its inner call runs.  This is the "best case"
+        path: success on tier 1 stops escalation and the suppressed
+        diagnostic (if any) was never relevant to the user."""
+        from kicad_tools.cli.route_cmd import route_with_mfr_tier_escalation
+
+        args = _make_args()
+        seen: list[tuple[str, bool]] = []
+
+        def fake_inner(*, pcb_path, output_path, args, quiet):
+            seen.append(
+                (args.manufacturer, getattr(args, "_auto_mfr_tier_in_progress", False))
+            )
+            return 0  # success
+
+        with patch(
+            "kicad_tools.cli.route_cmd.route_with_layer_escalation",
+            side_effect=fake_inner,
+        ):
+            rc = route_with_mfr_tier_escalation(
+                pcb_path=Path("test.kicad_pcb"),
+                output_path=Path("out.kicad_pcb"),
+                args=args,
+                quiet=True,
+            )
+
+        assert rc == 0
+        # Only one inner call; it was the first tier (non-final), so the
+        # flag was set when the call ran.  The fact that it succeeded
+        # means the demotion was harmless.
+        assert seen == [("jlcpcb", True)], (
+            f"Expected one call with flag=True on non-final tier; got {seen}"
+        )
+        # Flag must be cleared on exit even on the success path.
+        assert getattr(args, "_auto_mfr_tier_in_progress", False) is False


### PR DESCRIPTION
Closes #2891

## Problem

When ``kct route --auto-mfr-tier --manufacturer jlcpcb`` runs on a fine-pitch board with plane-sandwiched pins (e.g. board-04 LQFP-48), the lower tier emits an ERROR-level log:

```
Cannot escape U2 pin 6 (net OSC_OUT) ... Manufacturer profile jlcpcb does not support via-in-pad. ... (Issue #2880)
```

The outer ``route_with_mfr_tier_escalation`` wrapper will then recover by escalating to a tier that does support via-in-pad, so the ERROR is a false alarm. It clutters CI logs and autonomous-agent transcripts.

## Approach (Curator's Option B)

Threaded a flag through ``DesignRules`` so the ``EscapeRouter`` can demote the #2880 ERROR to DEBUG during in-flight escalation. Avoids touching the five ``EscapeRouter(...)`` call sites across ``core.py``, ``orchestrator.py``, and ``escape.py``.

### Changes

- ``src/kicad_tools/router/rules.py`` — Added ``DesignRules.auto_mfr_tier_in_progress: bool = False``.
- ``src/kicad_tools/router/escape.py`` — At the #2880 log site, choose ``logger.debug`` vs ``logger.error`` based on the flag. Message body byte-identical so grep-based log forensics still locate the diagnostic.
- ``src/kicad_tools/cli/route_cmd.py`` — ``route_with_mfr_tier_escalation`` sets ``args._auto_mfr_tier_in_progress = True`` for non-final tiers, ``False`` for the FINAL tier (so a fully-exhausted ladder surfaces the ERROR), and clears it on exit. Four ``DesignRules(...)`` construction sites forward the flag onto the rules object.

### Critical: re-surface on ladder exhaustion

The wrapper explicitly sets the flag to ``False`` for the final tier in the ladder, so when escalation gives up the inner ``EscapeRouter`` emits the ERROR naturally on its last try. New test ``test_error_resurfaces_on_ladder_exhaustion`` pins this.

## Tests

- Existing ``tests/router/test_escape_qfp_plane_sandwich.py::TestNoViaInPadErrorPath`` (pre-#2891 non-regression) — passes.
- New ``TestAutoMfrTierLogSuppression`` (3 tests): (a) ERROR suppressed during escalation, (b) ERROR re-surfaces on ladder exhaustion, (c) default preserves ERROR for non-escalation callers.
- New ``tests/test_auto_mfr_tier_log_suppression.py`` (4 tests): end-to-end flag plumbing through the escalation wrapper.

All targeted tests pass:

```
tests/router/test_escape_qfp_plane_sandwich.py ............. [100%]   13 passed
tests/test_auto_mfr_tier_log_suppression.py ....            [100%]    4 passed
tests/test_route_auto_mfr_tier.py tests/test_mfr_tier_ladder.py ... 72 passed
```

## Smoke test

Ran ``kct route --auto-mfr-tier --manufacturer jlcpcb --max-layers 2`` on board-04 (stm32_devboard.kicad_pcb). Confirmed:

- The ``Tier 1/2: jlcpcb`` banner is clear in stdout.
- The spurious #2880 ERROR no longer appears on the lower tier.
- The wrapper's "Diagnosis: Cannot escape component U2 to perimeter on jlcpcb..." line still surfaces the unfixable constraint to the user (the existing ``_name_dominant_unfixable_constraint`` diagnostic plumbing is unchanged).

## Parallel-PR note

PR for #2890 (predicate variant #3) is being built in parallel and also touches ``_escape_qfp_alternating``. This PR keeps its changes focused on the LOG SUPPRESSION (lines 1930-1948) only; it does NOT modify the predicate itself (lines 1840-1900). Conflicts, if any, should be mechanical.

## Test plan

- [x] ``uv run pytest tests/router/test_escape_qfp_plane_sandwich.py``
- [x] ``uv run pytest tests/test_auto_mfr_tier_log_suppression.py``
- [x] ``uv run pytest tests/test_route_auto_mfr_tier.py tests/test_mfr_tier_ladder.py``
- [x] ``uv run ruff check`` (changed files clean)
- [x] Smoke: ``kct route --auto-mfr-tier --manufacturer jlcpcb`` on board-04
- [ ] CI green