### PR TITLE
feat(stitch): thermal-via stitching under MOSFET heat-sink pads (#2900)

### DIFF
--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -497,6 +497,25 @@ def _run_stitch_command(args) -> int:
         sub_argv.append("--blanket")
     if hasattr(args, "stitch_spacing") and args.stitch_spacing != 3.0:
         sub_argv.extend(["--spacing", str(args.stitch_spacing)])
+    if hasattr(args, "stitch_thermal") and args.stitch_thermal:
+        sub_argv.append("--thermal")
+    if hasattr(args, "stitch_vias_per_pad") and args.stitch_vias_per_pad != 4:
+        sub_argv.extend(["--vias-per-pad", str(args.stitch_vias_per_pad)])
+    if hasattr(args, "stitch_thermal_radius") and args.stitch_thermal_radius != 2.5:
+        sub_argv.extend(["--thermal-radius", str(args.stitch_thermal_radius)])
+    if (
+        hasattr(args, "stitch_thermal_min_pad_size")
+        and args.stitch_thermal_min_pad_size != 2.0
+    ):
+        sub_argv.extend(
+            ["--thermal-min-pad-size", str(args.stitch_thermal_min_pad_size)]
+        )
+    if (
+        hasattr(args, "stitch_thermal_component_prefixes")
+        and args.stitch_thermal_component_prefixes
+    ):
+        for prefix in args.stitch_thermal_component_prefixes:
+            sub_argv.extend(["--thermal-component-prefix", prefix])
     if hasattr(args, "stitch_dry_run") and args.stitch_dry_run:
         sub_argv.append("--dry-run")
     if hasattr(args, "stitch_output") and args.stitch_output:

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2084,6 +2084,55 @@ def _add_stitch_parser(subparsers) -> None:
         help="Grid spacing for blanket stitching in mm (default: 3.0)",
     )
     stitch_parser.add_argument(
+        "--thermal",
+        action="store_true",
+        dest="stitch_thermal",
+        help=(
+            "Place thermal vias under / around MOSFET heat-sink pads. "
+            "Selects pads using footprint-name (TO-220, DPAK, QFN-EP, ...), "
+            "reference-prefix (Q*), and pad-size heuristics, AND-ed with "
+            "target-net membership."
+        ),
+    )
+    stitch_parser.add_argument(
+        "--vias-per-pad",
+        type=int,
+        default=4,
+        dest="stitch_vias_per_pad",
+        help="Number of thermal vias to place per qualifying pad (default: 4)",
+    )
+    stitch_parser.add_argument(
+        "--thermal-radius",
+        type=float,
+        default=2.5,
+        dest="stitch_thermal_radius",
+        help=(
+            "Halo-mode ring radius in mm for thermal vias placed AROUND "
+            "(not under) smaller pads (default: 2.5)"
+        ),
+    )
+    stitch_parser.add_argument(
+        "--thermal-min-pad-size",
+        type=float,
+        default=2.0,
+        dest="stitch_thermal_min_pad_size",
+        help=(
+            "Minimum pad width AND height (mm) for the 'large pad' thermal "
+            "signal (default: 2.0). Pads bigger than this on both axes are "
+            "flagged as heat-sink pads even without a footprint-name match."
+        ),
+    )
+    stitch_parser.add_argument(
+        "--thermal-component-prefix",
+        action="append",
+        dest="stitch_thermal_component_prefixes",
+        help=(
+            "Reference prefix (case-sensitive) for components that should "
+            "be considered thermal-pad candidates. Can be repeated. "
+            "Defaults to 'Q' (transistors / MOSFETs)."
+        ),
+    )
+    stitch_parser.add_argument(
         "--dry-run",
         "-d",
         action="store_true",

--- a/src/kicad_tools/cli/stitch_cmd.py
+++ b/src/kicad_tools/cli/stitch_cmd.py
@@ -282,6 +282,55 @@ class ZonePolygon:
     points: list[tuple[float, float]]
 
 
+@dataclass
+class ThermalPadCandidate:
+    """A pad identified as a heat-sink / thermal pad candidate for thermal stitching.
+
+    Augments :class:`PadInfo` with the footprint library name so that the
+    thermal-pad heuristic can also key off footprint families
+    (e.g. ``TO-220``, ``DPAK``, ``QFN-EP``).
+    """
+
+    pad: PadInfo
+    footprint_name: str  # Full footprint library:name string
+    # True when the heuristic flagged this pad via footprint-name match
+    matched_by_footprint: bool = False
+    # True when the heuristic flagged this pad via large pad area
+    matched_by_size: bool = False
+    # True when the heuristic flagged this pad via reference prefix
+    matched_by_reference: bool = False
+
+
+# Default footprint-name patterns that indicate a thermal / heat-sink pad
+# context. The patterns are matched case-insensitively as substrings of the
+# footprint library:name (e.g. ``Package_TO_SOT_THT:TO-220-3_Vertical``).
+DEFAULT_THERMAL_FOOTPRINT_PATTERNS: tuple[str, ...] = (
+    "TO-220",
+    "TO220",
+    "TO-252",
+    "TO252",
+    "TO-263",
+    "TO263",
+    "DPAK",
+    "D2PAK",
+    "D-PAK",
+    "SO-8-EP",
+    "SOIC-8-EP",
+    "POWERPAD",
+    "QFN-EP",
+    "QFN_EP",
+    "DFN-EP",
+    "DFN_EP",
+    "-EP_",  # Generic "exposed pad" suffix
+    "1EP",   # Generic "1 exposed pad" suffix (e.g. QFN-32-1EP_5x5mm)
+    "_EP_",  # Underscore-bracketed EP marker
+)
+
+# Default reference-prefix list for component classes that typically have
+# heat-sink pads on power nets (Q = transistors/MOSFETs, U = power ICs).
+DEFAULT_THERMAL_REFERENCE_PREFIXES: tuple[str, ...] = ("Q",)
+
+
 def get_net_map(sexp: SExp) -> dict[int, str]:
     """Build a mapping of net number to net name."""
     net_map = {}
@@ -2493,6 +2542,575 @@ def check_via_clearance(
     return True
 
 
+def _matches_footprint_pattern(footprint_name: str, patterns: tuple[str, ...]) -> bool:
+    """Return True if any of the patterns appears (case-insensitively) in the
+    footprint name string.
+
+    The match is a substring check on the upper-cased footprint name so
+    library prefixes like ``Package_TO_SOT_THT:`` and suffixes like
+    ``_Vertical`` don't break the match.
+    """
+    if not footprint_name:
+        return False
+    up = footprint_name.upper()
+    return any(p.upper() in up for p in patterns)
+
+
+def _matches_reference_prefix(reference: str, prefixes: tuple[str, ...]) -> bool:
+    """Return True if the reference starts with any of the given prefixes.
+
+    Match is case-sensitive on the prefix so that ``Q1`` matches ``Q`` but
+    ``R10`` does not match ``Q``. References like ``Q1A`` and ``Q12`` are
+    matched by prefix ``Q`` after stripping the digit suffix is unnecessary
+    -- a simple ``startswith`` plus digit check suffices.
+    """
+    if not reference or not prefixes:
+        return False
+    for prefix in prefixes:
+        if reference.startswith(prefix):
+            # Require that the next char (if any) is a digit, so prefix "Q"
+            # matches "Q1" / "Q12" but not "QFN1" (a footprint-like name as
+            # reference).
+            rest = reference[len(prefix):]
+            if not rest or rest[0].isdigit():
+                return True
+    return False
+
+
+def find_thermal_pad_candidates(
+    sexp: SExp,
+    net_names: set[str],
+    footprint_patterns: tuple[str, ...] = DEFAULT_THERMAL_FOOTPRINT_PATTERNS,
+    reference_prefixes: tuple[str, ...] = DEFAULT_THERMAL_REFERENCE_PREFIXES,
+    min_pad_size: float = 2.0,
+) -> list[ThermalPadCandidate]:
+    """Find pads that look like MOSFET / heat-sink thermal pads.
+
+    A pad qualifies as a thermal-pad candidate when ALL of these hold:
+
+    1. The pad is on one of the target ``net_names`` (a power-plane net).
+    2. At least ONE of these signals is true:
+       a. The footprint library:name matches a known thermal-pad family
+          (``footprint_patterns``, e.g. ``TO-220``, ``DPAK``, ``QFN-EP``).
+       b. The footprint reference starts with a thermal-component prefix
+          (``reference_prefixes``, e.g. ``Q`` for MOSFETs/transistors).
+       c. The pad's bounding box meets ``min_pad_size`` mm on BOTH axes
+          (large exposed-pad style heat-sink pad).
+
+    The conjunction of (1) AND (2) ensures we don't false-positive on,
+    say, a regular SMD bypass cap on GND (passes 1 but fails 2) and we
+    don't false-positive on a MOSFET's gate signal pin (fails 1).
+
+    Args:
+        sexp: PCB S-expression
+        net_names: Target plane nets (case-sensitive)
+        footprint_patterns: Substrings (case-insensitive) of footprint
+            library:name that mark thermal-pad packages.
+        reference_prefixes: Reference prefixes (case-sensitive) for
+            component classes that typically have heat-sink pads.
+        min_pad_size: Minimum pad width AND height in mm for the
+            "large pad" signal.
+
+    Returns:
+        List of :class:`ThermalPadCandidate` describing each qualifying
+        pad (one entry per pad, not per footprint).
+    """
+    net_map = get_net_map(sexp)
+    target_net_nums = {num for num, name in net_map.items() if name in net_names}
+
+    candidates: list[ThermalPadCandidate] = []
+
+    for fp in sexp.iter_children():
+        if fp.tag != "footprint":
+            continue
+
+        # Footprint library:name string (first positional arg).
+        footprint_name = fp.get_string(0) or ""
+
+        # Footprint placement
+        at_node = fp.find_child("at")
+        if not at_node:
+            continue
+        fp_x = at_node.get_float(0) or 0.0
+        fp_y = at_node.get_float(1) or 0.0
+        fp_rotation = at_node.get_float(2) or 0.0
+
+        layer_node = fp.find_child("layer")
+        fp_layer = layer_node.get_string(0) if layer_node else "F.Cu"
+
+        # Reference
+        reference = None
+        for prop in fp.find_children("property"):
+            if prop.get_string(0) == "Reference":
+                reference = prop.get_string(1)
+                break
+        if reference is None:
+            for fp_text in fp.find_children("fp_text"):
+                if fp_text.get_string(0) == "reference":
+                    reference = fp_text.get_string(1)
+                    break
+        if reference is None:
+            reference = "??"
+
+        # Pre-compute the footprint and reference signals (constant per fp).
+        fp_match = _matches_footprint_pattern(footprint_name, footprint_patterns)
+        ref_match = _matches_reference_prefix(reference, reference_prefixes)
+
+        rad = math.radians(fp_rotation)
+        cos_r = math.cos(rad)
+        sin_r = math.sin(rad)
+
+        for pad in fp.find_children("pad"):
+            pad_number = pad.get_string(0)
+            pad_type = pad.get_string(1)
+
+            if pad_type not in ("smd", "thru_hole"):
+                continue
+
+            # Pad must be on a target plane net.
+            net_node = pad.find_child("net")
+            if not net_node:
+                continue
+            net_num = net_node.get_int(0)
+            if net_num not in target_net_nums:
+                continue
+
+            net_name = net_map.get(net_num, "")
+
+            # Pad position
+            pad_at = pad.find_child("at")
+            if not pad_at:
+                continue
+            pad_rel_x = pad_at.get_float(0) or 0.0
+            pad_rel_y = pad_at.get_float(1) or 0.0
+            pad_x = fp_x + pad_rel_x * cos_r - pad_rel_y * sin_r
+            pad_y = fp_y + pad_rel_x * sin_r + pad_rel_y * cos_r
+
+            # Pad size
+            size_node = pad.find_child("size")
+            pad_width = size_node.get_float(0) or 0.5 if size_node else 0.5
+            pad_height = size_node.get_float(1) or 0.5 if size_node else 0.5
+
+            size_match = pad_width >= min_pad_size and pad_height >= min_pad_size
+
+            # Disjunction of signals (any one is enough; net-membership is
+            # already required by the early continue above).
+            if not (fp_match or ref_match or size_match):
+                continue
+
+            pad_info = PadInfo(
+                reference=reference,
+                pad_number=pad_number or "?",
+                net_number=net_num,
+                net_name=net_name,
+                x=pad_x,
+                y=pad_y,
+                layer=fp_layer,
+                width=pad_width,
+                height=pad_height,
+                pad_type=pad_type or "smd",
+            )
+
+            candidates.append(
+                ThermalPadCandidate(
+                    pad=pad_info,
+                    footprint_name=footprint_name,
+                    matched_by_footprint=fp_match,
+                    matched_by_size=size_match,
+                    matched_by_reference=ref_match,
+                )
+            )
+
+    return candidates
+
+
+def generate_thermal_via_positions(
+    pad: PadInfo,
+    vias_per_pad: int,
+    thermal_radius: float,
+    via_size: float,
+    clearance: float,
+) -> list[tuple[float, float]]:
+    """Generate candidate positions for thermal vias around / under a pad.
+
+    Two placement strategies, selected by pad size:
+
+    * "Under-pad" mode (pad ≥ ``via_size * 2`` on both axes): place vias on
+      a uniform grid inside the pad bounding box. Suitable for large
+      exposed-pad packages (QFN-EP, D2PAK, SO8-EP) where the pad copper is
+      big enough to fit multiple vias and still satisfy via-to-pad-edge
+      clearance.
+
+    * "Halo" mode (smaller pads, e.g. TO-220 pin pads at 1.8×1.8 mm):
+      place vias on a circle centered on the pad, with radius
+      ``thermal_radius``. The ring radius is far enough that the vias do
+      not collide with the pad's own copper but close enough to share the
+      pad's local thermal field via the surrounding zone fill.
+
+    The returned positions are *candidates only* — the caller must still
+    run :func:`check_via_clearance` against the rest of the board copper.
+
+    Args:
+        pad: Source pad whose center seeds the via array.
+        vias_per_pad: Number of thermal vias to attempt to place per pad.
+        thermal_radius: Halo-mode ring radius in mm (distance from pad
+            center to via center).
+        via_size: Via pad diameter in mm (used only for under-pad spacing).
+        clearance: Edge / pad clearance in mm.
+
+    Returns:
+        List of (x, y) candidate positions, ordered such that the most
+        thermally-effective positions come first (centroid first, then
+        ring/spiral outward).
+    """
+    if vias_per_pad <= 0:
+        return []
+
+    # Decide mode based on whether a 2×2 grid of vias fits comfortably
+    # inside the pad with the requested clearance.  Each via needs
+    # (via_size + clearance) clearance on every side from the pad edge,
+    # plus we want the vias separated from each other by at least one
+    # via_size for thermal effectiveness.  Require pad ≥ 3*(via_size +
+    # clearance) on both axes so the under-pad mode is meaningfully
+    # better than a halo (a TO-220 thru-hole pad at 1.8 mm misses this
+    # threshold and falls back to halo).
+    min_under_pad = 3.0 * (via_size + clearance)
+    use_under_pad = pad.width >= min_under_pad and pad.height >= min_under_pad
+
+    positions: list[tuple[float, float]] = []
+
+    if use_under_pad:
+        # Under-pad grid.  Choose grid dimensions so that we produce at
+        # least ``vias_per_pad`` candidates (caller filters by clearance).
+        # Start with the smallest square grid that meets the target.
+        side = max(2, math.ceil(math.sqrt(vias_per_pad)))
+
+        # Compute step so the outermost grid points sit ``edge_margin`` in
+        # from the pad edge.
+        edge_margin = via_size / 2 + clearance
+        usable_w = max(0.0, pad.width - 2 * edge_margin)
+        usable_h = max(0.0, pad.height - 2 * edge_margin)
+
+        if side > 1:
+            step_x = usable_w / (side - 1)
+            step_y = usable_h / (side - 1)
+        else:
+            step_x = 0.0
+            step_y = 0.0
+
+        for i in range(side):
+            for j in range(side):
+                x = pad.x - usable_w / 2 + i * step_x
+                y = pad.y - usable_h / 2 + j * step_y
+                positions.append((x, y))
+    else:
+        # Halo ring around the pad.  Place vias on a circle of radius
+        # ``thermal_radius`` so they are close enough to the pad to
+        # participate in the thermal pour but do not collide with the pad
+        # copper.  Drop into a wider radius if the requested radius is
+        # smaller than the minimum safe distance.
+        pad_half = max(pad.width, pad.height) / 2
+        min_safe_r = pad_half + via_size / 2 + clearance
+        r_base = max(thermal_radius, min_safe_r)
+
+        # Distribute ``vias_per_pad`` points evenly on the base ring,
+        # starting at 45° so the first via sits at NE (avoids collisions
+        # with straight-line trace escapes that exit pads horizontally).
+        # Then add extra fallback candidates: (a) intermediate angles on
+        # the same ring, (b) the same angles on a wider ring.  This lets
+        # the caller's clearance filter skip blocked positions while
+        # still hitting the target via count when at least some halo
+        # slots are free.
+        n = max(vias_per_pad, 4)
+
+        # Pass 1: base ring at primary angles (NE/NW/SW/SE for n=4).
+        for k in range(n):
+            theta = (2 * math.pi * k / n) + math.pi / 4
+            x = pad.x + r_base * math.cos(theta)
+            y = pad.y + r_base * math.sin(theta)
+            positions.append((x, y))
+
+        # Pass 2: same ring at intermediate angles (N/E/S/W for n=4).
+        for k in range(n):
+            theta = (2 * math.pi * k / n)
+            x = pad.x + r_base * math.cos(theta)
+            y = pad.y + r_base * math.sin(theta)
+            positions.append((x, y))
+
+        # Pass 3: wider ring (50% larger radius) at primary angles —
+        # useful when the base ring is blocked by adjacent traces.
+        r_wide = r_base * 1.5
+        for k in range(n):
+            theta = (2 * math.pi * k / n) + math.pi / 4
+            x = pad.x + r_wide * math.cos(theta)
+            y = pad.y + r_wide * math.sin(theta)
+            positions.append((x, y))
+
+    return positions
+
+
+def run_thermal_stitch(
+    pcb_path: Path,
+    net_names: list[str],
+    via_size: float = 0.45,
+    drill: float = 0.2,
+    clearance: float = 0.2,
+    vias_per_pad: int = 4,
+    thermal_radius: float = 2.5,
+    min_pad_size: float = 2.0,
+    footprint_patterns: tuple[str, ...] | None = None,
+    reference_prefixes: tuple[str, ...] | None = None,
+    target_layer: str | None = None,
+    dry_run: bool = False,
+) -> StitchResult:
+    """Place thermal vias under / around MOSFET heat-sink pads.
+
+    Selects pads using :func:`find_thermal_pad_candidates` (footprint-name
+    family / reference-prefix / pad-size heuristic, ANDed with target-net
+    membership) and places ``vias_per_pad`` thermal vias per candidate pad
+    via :func:`generate_thermal_via_positions`.
+
+    Each candidate position is gated by:
+
+    * Standard :func:`check_via_clearance` against other-net copper.
+    * Same-net via stacking prevention (existing vias treated as
+      obstacles).
+    * Inside-zone check: the via must fall inside a same-net zone polygon
+      with at least ``via_size/2 + clearance`` margin from the zone edge
+      so the via lands on actual copper after zone fill.
+
+    Idempotent: existing same-net vias inside a candidate position's
+    exclusion radius cause the position to be skipped, so re-running the
+    stitcher does not double-stitch.
+
+    Args:
+        pcb_path: Path to the .kicad_pcb file.
+        net_names: List of target plane-net names (typically GND or the
+            user's power-plane nets).
+        via_size: Via pad diameter in mm.
+        drill: Via drill diameter in mm.
+        clearance: Minimum clearance from existing copper in mm.
+        vias_per_pad: Target number of thermal vias per qualifying pad.
+        thermal_radius: Halo-mode ring radius in mm (for smaller pads).
+        min_pad_size: Minimum pad width/height (mm) to count as a
+            "large pad" for the pad-size signal.
+        footprint_patterns: Override the default thermal-footprint
+            substring list.
+        reference_prefixes: Override the default thermal-reference
+            prefix list.
+        target_layer: Force a specific target layer for the via's deep
+            terminus (auto-detected from zones if None).
+        dry_run: If True, do not write the PCB to disk.
+
+    Returns:
+        :class:`StitchResult` describing the vias placed.
+    """
+    if footprint_patterns is None:
+        footprint_patterns = DEFAULT_THERMAL_FOOTPRINT_PATTERNS
+    if reference_prefixes is None:
+        reference_prefixes = DEFAULT_THERMAL_REFERENCE_PREFIXES
+
+    sexp = load_pcb(pcb_path)
+    copper_layers = get_copper_layers(sexp)
+
+    result = StitchResult(
+        pcb_name=pcb_path.name,
+        target_nets=net_names,
+    )
+
+    net_set = set(net_names)
+    net_map = get_net_map(sexp)
+    target_net_nums = {num for num, name in net_map.items() if name in net_set}
+
+    # Find candidate thermal pads.
+    candidates = find_thermal_pad_candidates(
+        sexp,
+        net_names=net_set,
+        footprint_patterns=footprint_patterns,
+        reference_prefixes=reference_prefixes,
+        min_pad_size=min_pad_size,
+    )
+
+    if not candidates:
+        return result
+
+    # Pre-collect obstacle copper for clearance checks.
+    other_net_tracks = find_all_track_segments(sexp, exclude_nets=target_net_nums)
+    other_net_vias = find_all_board_vias(sexp, exclude_nets=target_net_nums)
+    other_net_pads = find_all_pads(sexp, exclude_nets=target_net_nums)
+    other_net_filled_polys = find_all_filled_polygons(sexp, exclude_nets=target_net_nums)
+
+    # Per-net same-net via positions (existing + newly placed).  Treated
+    # as obstacles to prevent stacking on the same net.  A via placed for
+    # one target net (e.g. VMOTOR) appears as a different-net obstacle
+    # for another target net's processing (e.g. PHASE_A), so we also
+    # track a running list of cross-net placed vias to add to the
+    # clearance-check inputs.
+    existing_same_net_vias = find_existing_vias(sexp, target_net_nums)
+    same_net_via_positions_by_net: dict[int, list[tuple[float, float]]] = {}
+    for vx, vy, vn in existing_same_net_vias:
+        same_net_via_positions_by_net.setdefault(vn, []).append((vx, vy))
+
+    # Mutable copy of other_net_vias we can append to as we place new
+    # vias on neighbouring target nets.
+    # find_all_board_vias returns BoardVia objects with (x, y, net, ...);
+    # we mirror that shape via list mutation.
+    cross_net_placed_vias: list[tuple[float, float, int]] = []
+
+    # Build a per-net zone-polygon index for inside-zone checks and
+    # auto-target-layer detection.
+    zone_polys_by_net: dict[str, list[ZonePolygon]] = {}
+    for net_name in net_names:
+        zone_polys_by_net[net_name] = extract_zone_polygons(sexp, net_name)
+
+    # Resolve target layer per net (used to size the via stack).
+    target_layer_by_net: dict[str, str | None] = {}
+    for net_name in net_names:
+        if target_layer:
+            target_layer_by_net[net_name] = target_layer
+            continue
+        polys = zone_polys_by_net.get(net_name, [])
+        zone_layers = [zp.layer for zp in polys]
+        if zone_layers and not _should_use_stackup_fallback(zone_layers, copper_layers):
+            target_layer_by_net[net_name] = zone_layers[0]
+            result.detected_layers[net_name] = zone_layers[0]
+        else:
+            inferred = infer_target_layer_from_stackup(copper_layers, net_name)
+            if inferred:
+                target_layer_by_net[net_name] = inferred
+                result.detected_layers[net_name] = inferred
+                result.stackup_inferred_nets.append(net_name)
+            else:
+                target_layer_by_net[net_name] = None
+                result.fallback_nets.append(net_name)
+
+    # Group pads by (reference, footprint) so we can pick the "best" pad
+    # per component when multiple of its pads are on target plane nets.
+    # For TO-220-3, both pad 1 (gate) and pad 2 (drain on VMOTOR) could
+    # match -- but only the drain (the power-net pad) does in practice,
+    # since the gate net (e.g. GATE_AH) is not a plane net.
+    # The heuristic above already filters by net so this grouping just
+    # serves the diagnostic count.
+
+    for cand in candidates:
+        pad = cand.pad
+        net_name = pad.net_name
+        pad_net = pad.net_number
+
+        # Compute the via stack layers.
+        surface_layer = pad.layer if pad.layer in ("F.Cu", "B.Cu") else "F.Cu"
+        layers = get_via_layers(surface_layer, target_layer_by_net.get(net_name))
+
+        # Idempotency guard: if the pad already has at least vias_per_pad
+        # same-net vias within ``thermal_radius * 2`` (i.e. inside the
+        # wider-ring fallback area), skip placement entirely.  This
+        # prevents the second invocation of `kct stitch --thermal` from
+        # adding extra vias on the wider fallback ring after the primary
+        # ring is already saturated.
+        existing_pad_vias = same_net_via_positions_by_net.get(pad_net, [])
+        proximity_threshold = thermal_radius * 2.0
+        already_near = sum(
+            1
+            for (vx, vy) in existing_pad_vias
+            if abs(vx - pad.x) <= proximity_threshold
+            and abs(vy - pad.y) <= proximity_threshold
+        )
+        if already_near >= vias_per_pad:
+            result.already_connected += 1
+            continue
+
+        # Generate candidate positions.
+        positions = generate_thermal_via_positions(
+            pad,
+            vias_per_pad=vias_per_pad,
+            thermal_radius=thermal_radius,
+            via_size=via_size,
+            clearance=clearance,
+        )
+
+        # Required edge margin from zone boundary so the via lands on
+        # copper after fill.
+        zone_margin = via_size / 2 + clearance
+        same_net_zones = zone_polys_by_net.get(net_name, [])
+
+        # Per-net same-net via list (existing + newly placed on this net).
+        same_net_vias_for_pad = same_net_via_positions_by_net.setdefault(
+            pad_net, []
+        )
+
+        # Cross-net obstacles: starting set + any vias we've placed on
+        # other target nets during this run.
+        other_net_vias_with_placed = list(other_net_vias)
+        for cx, cy, cn in cross_net_placed_vias:
+            if cn != pad_net:
+                other_net_vias_with_placed.append((cx, cy, via_size, cn))
+
+        placed_for_pad = 0
+        for vx, vy in positions:
+            # Clearance against other-net copper and same-net stacking.
+            if not check_via_clearance(
+                vx,
+                vy,
+                via_size,
+                clearance,
+                other_net_tracks,
+                other_net_vias_with_placed,
+                other_net_pads,
+                same_net_vias_for_pad,
+                other_net_filled_polys,
+            ):
+                continue
+
+            # Must fall inside a same-net zone polygon with proper margin.
+            # (When no zones are defined for the net, fall back to placing
+            # the via anyway -- this lets the stitcher be useful on boards
+            # whose zone step has not yet run, at the cost of a possible
+            # DRC warning until zones are added.)
+            if same_net_zones:
+                in_zone = False
+                for zp in same_net_zones:
+                    if point_in_polygon(vx, vy, zp.points) and _point_has_edge_margin(
+                        vx, vy, zp.points, zone_margin
+                    ):
+                        in_zone = True
+                        break
+                if not in_zone:
+                    continue
+
+            placement = ViaPlacement(
+                pad=pad,
+                via_x=vx,
+                via_y=vy,
+                size=via_size,
+                drill=drill,
+                layers=layers,
+            )
+            result.vias_added.append(placement)
+            same_net_vias_for_pad.append((vx, vy))
+            cross_net_placed_vias.append((vx, vy, pad_net))
+            placed_for_pad += 1
+
+            if placed_for_pad >= vias_per_pad:
+                break
+
+        if placed_for_pad == 0:
+            # Diagnostic: no via could be placed for this thermal pad
+            # candidate (likely all positions failed clearance or
+            # fell outside the zone).
+            result.pads_skipped.append(
+                (pad, "thermal: no clear via position found")
+            )
+
+    # Apply changes if not dry run.
+    if not dry_run and result.vias_added:
+        for placement in result.vias_added:
+            add_via_to_pcb(sexp, placement)
+        save_pcb(sexp, pcb_path)
+        verify_pcb_write(pcb_path, expected_vias=len(result.vias_added))
+
+    return result
+
+
 def run_blanket_stitch(
     pcb_path: Path,
     net_names: list[str],
@@ -3372,6 +3990,51 @@ def main(argv: list[str] | None = None) -> int:
         help="Grid spacing for blanket stitching in mm (default: 3.0)",
     )
     parser.add_argument(
+        "--thermal",
+        action="store_true",
+        help=(
+            "Place thermal vias under / around MOSFET heat-sink pads. "
+            "Selects pads using footprint-name (TO-220, DPAK, QFN-EP, ...), "
+            "reference-prefix (Q*), and pad-size heuristics, AND-ed with "
+            "target-net membership."
+        ),
+    )
+    parser.add_argument(
+        "--vias-per-pad",
+        type=int,
+        default=4,
+        help="Number of thermal vias to place per qualifying pad (default: 4)",
+    )
+    parser.add_argument(
+        "--thermal-radius",
+        type=float,
+        default=2.5,
+        help=(
+            "Halo-mode ring radius in mm for thermal vias placed AROUND "
+            "(not under) smaller pads (default: 2.5)"
+        ),
+    )
+    parser.add_argument(
+        "--thermal-min-pad-size",
+        type=float,
+        default=2.0,
+        help=(
+            "Minimum pad width AND height (mm) for the 'large pad' thermal "
+            "signal (default: 2.0). Pads bigger than this on both axes are "
+            "flagged as heat-sink pads even without a footprint-name match."
+        ),
+    )
+    parser.add_argument(
+        "--thermal-component-prefix",
+        action="append",
+        dest="thermal_component_prefixes",
+        help=(
+            "Reference prefix (case-sensitive) for components that should "
+            "be considered thermal-pad candidates. Can be repeated. "
+            "Defaults to 'Q' (transistors / MOSFETs)."
+        ),
+    )
+    parser.add_argument(
         "--dry-run",
         "-d",
         action="store_true",
@@ -3481,7 +4144,26 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Auto-detected {len(net_names)} power plane nets: {', '.join(sorted(net_names))}")
 
     try:
-        if args.blanket:
+        if args.thermal:
+            ref_prefixes: tuple[str, ...] = (
+                tuple(args.thermal_component_prefixes)
+                if args.thermal_component_prefixes
+                else DEFAULT_THERMAL_REFERENCE_PREFIXES
+            )
+            result = run_thermal_stitch(
+                pcb_path=pcb_path,
+                net_names=net_names,
+                via_size=via_size,
+                drill=drill,
+                clearance=args.clearance,
+                vias_per_pad=args.vias_per_pad,
+                thermal_radius=args.thermal_radius,
+                min_pad_size=args.thermal_min_pad_size,
+                reference_prefixes=ref_prefixes,
+                target_layer=args.target_layer,
+                dry_run=args.dry_run,
+            )
+        elif args.blanket:
             result = run_blanket_stitch(
                 pcb_path=pcb_path,
                 net_names=net_names,

--- a/tests/test_thermal_stitch.py
+++ b/tests/test_thermal_stitch.py
@@ -1,0 +1,507 @@
+"""Tests for the thermal-via stitching feature (issue #2900).
+
+The thermal-stitch CLI mode (``kct stitch --thermal``) selects MOSFET /
+heat-sink pads via a multi-signal heuristic and drops an array of vias
+under or around each qualifying pad.  These tests exercise:
+
+* :func:`find_thermal_pad_candidates` heuristic (footprint pattern,
+  reference prefix, pad-size signal, AND target-net membership).
+* :func:`generate_thermal_via_positions` placement geometry
+  (under-pad grid vs. halo ring).
+* :func:`run_thermal_stitch` end-to-end on a synthetic 2-FET fixture:
+  via counts, idempotency, plane-net safety on non-MOSFET boards.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.stitch_cmd import (
+    DEFAULT_THERMAL_FOOTPRINT_PATTERNS,
+    PadInfo,
+    _matches_footprint_pattern,
+    _matches_reference_prefix,
+    find_thermal_pad_candidates,
+    generate_thermal_via_positions,
+    main,
+    run_thermal_stitch,
+)
+from kicad_tools.core.sexp_file import load_pcb
+
+# Synthetic 2-FET fixture: two TO-220-3 MOSFETs on F.Cu with their drain
+# pads (pad "2") on net "VMOTOR", plus a GND zone underneath on In1.Cu.
+# Layer stack: F.Cu / In1.Cu / In2.Cu / B.Cu.
+TWO_FET_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (2 "In2.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "VMOTOR")
+  (net 3 "GATE_AH")
+  (net 4 "PHASE_A")
+  (zone (net 2) (net_name "VMOTOR") (layer "In1.Cu") (uuid "zone-vm-uuid")
+    (name "VMOTOR_plane")
+    (connect_pads (clearance 0.2))
+    (min_thickness 0.2)
+    (fill yes (thermal_gap 0.3) (thermal_bridge_width 0.3))
+    (polygon (pts (xy 100 100) (xy 150 100) (xy 150 150) (xy 100 150)))
+  )
+  (footprint "Package_TO_SOT_THT:TO-220-3_Vertical"
+    (layer "F.Cu")
+    (uuid "11111111-1111-1111-1111-111111111111")
+    (at 110 120)
+    (property "Reference" "Q1" (at 0 -5) (layer "F.SilkS") (uuid "ref-q1"))
+    (pad "1" thru_hole rect (at -2.54 0) (size 1.8 1.8) (drill 1.0) (layers "*.Cu" "*.Mask") (net 3 "GATE_AH"))
+    (pad "2" thru_hole oval (at 0 0) (size 1.8 1.8) (drill 1.0) (layers "*.Cu" "*.Mask") (net 2 "VMOTOR"))
+    (pad "3" thru_hole oval (at 2.54 0) (size 1.8 1.8) (drill 1.0) (layers "*.Cu" "*.Mask") (net 4 "PHASE_A"))
+  )
+  (footprint "Package_TO_SOT_THT:TO-220-3_Vertical"
+    (layer "F.Cu")
+    (uuid "22222222-2222-2222-2222-222222222222")
+    (at 130 120)
+    (property "Reference" "Q2" (at 0 -5) (layer "F.SilkS") (uuid "ref-q2"))
+    (pad "1" thru_hole rect (at -2.54 0) (size 1.8 1.8) (drill 1.0) (layers "*.Cu" "*.Mask") (net 3 "GATE_AH"))
+    (pad "2" thru_hole oval (at 0 0) (size 1.8 1.8) (drill 1.0) (layers "*.Cu" "*.Mask") (net 2 "VMOTOR"))
+    (pad "3" thru_hole oval (at 2.54 0) (size 1.8 1.8) (drill 1.0) (layers "*.Cu" "*.Mask") (net 4 "PHASE_A"))
+  )
+)
+"""
+
+
+# Negative fixture: a board with only SMD caps on GND -- no MOSFETs.
+# After thermal-stitch we must not generate ANY vias.
+NO_MOSFET_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (zone (net 1) (net_name "GND") (layer "In1.Cu") (uuid "zone-gnd-uuid")
+    (name "GND_plane")
+    (connect_pads (clearance 0.2))
+    (min_thickness 0.2)
+    (fill yes (thermal_gap 0.3) (thermal_bridge_width 0.3))
+    (polygon (pts (xy 100 100) (xy 150 100) (xy 150 150) (xy 100 150)))
+  )
+  (footprint "Capacitor_SMD:C_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "33333333-3333-3333-3333-333333333333")
+    (at 110 110)
+    (property "Reference" "C1" (at 0 -1.5) (layer "F.SilkS") (uuid "ref-c1"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (net 2 "+3.3V"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "44444444-4444-4444-4444-444444444444")
+    (at 120 110)
+    (property "Reference" "R1" (at 0 -1.5) (layer "F.SilkS") (uuid "ref-r1"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (net 2 "+3.3V"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "GND"))
+  )
+)
+"""
+
+
+# Large exposed-pad fixture: a single QFN-style footprint with a 5x5 mm
+# central thermal pad on GND.  Exercises the under-pad placement mode.
+LARGE_EP_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (zone (net 1) (net_name "GND") (layer "In1.Cu") (uuid "zone-gnd2-uuid")
+    (name "GND_plane")
+    (connect_pads (clearance 0.2))
+    (min_thickness 0.2)
+    (fill yes (thermal_gap 0.3) (thermal_bridge_width 0.3))
+    (polygon (pts (xy 100 100) (xy 150 100) (xy 150 150) (xy 100 150)))
+  )
+  (footprint "Package_DFN_QFN:QFN-32-1EP_5x5mm_P0.5mm_EP3.45x3.45mm"
+    (layer "F.Cu")
+    (uuid "55555555-5555-5555-5555-555555555555")
+    (at 125 125)
+    (property "Reference" "U1" (at 0 -4) (layer "F.SilkS") (uuid "ref-u1"))
+    (pad "33" smd rect (at 0 0) (size 3.45 3.45) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "GND"))
+  )
+)
+"""
+
+
+@pytest.fixture
+def two_fet_pcb(tmp_path: Path) -> Path:
+    pcb = tmp_path / "two_fet.kicad_pcb"
+    pcb.write_text(TWO_FET_PCB)
+    return pcb
+
+
+@pytest.fixture
+def no_mosfet_pcb(tmp_path: Path) -> Path:
+    pcb = tmp_path / "no_mosfet.kicad_pcb"
+    pcb.write_text(NO_MOSFET_PCB)
+    return pcb
+
+
+@pytest.fixture
+def large_ep_pcb(tmp_path: Path) -> Path:
+    pcb = tmp_path / "large_ep.kicad_pcb"
+    pcb.write_text(LARGE_EP_PCB)
+    return pcb
+
+
+class TestFootprintPatternMatch:
+    """:func:`_matches_footprint_pattern` heuristic helper."""
+
+    def test_to220_matches(self) -> None:
+        assert _matches_footprint_pattern(
+            "Package_TO_SOT_THT:TO-220-3_Vertical",
+            DEFAULT_THERMAL_FOOTPRINT_PATTERNS,
+        )
+
+    def test_dpak_matches(self) -> None:
+        assert _matches_footprint_pattern(
+            "Package_TO_SOT_SMD:TO-252-3_TabPin2",
+            DEFAULT_THERMAL_FOOTPRINT_PATTERNS,
+        )
+
+    def test_qfn_ep_matches(self) -> None:
+        assert _matches_footprint_pattern(
+            "Package_DFN_QFN:QFN-32-1EP_5x5mm_P0.5mm",
+            DEFAULT_THERMAL_FOOTPRINT_PATTERNS,
+        )
+
+    def test_capacitor_does_not_match(self) -> None:
+        assert not _matches_footprint_pattern(
+            "Capacitor_SMD:C_0402_1005Metric",
+            DEFAULT_THERMAL_FOOTPRINT_PATTERNS,
+        )
+
+    def test_resistor_does_not_match(self) -> None:
+        assert not _matches_footprint_pattern(
+            "Resistor_SMD:R_0402_1005Metric",
+            DEFAULT_THERMAL_FOOTPRINT_PATTERNS,
+        )
+
+    def test_empty_returns_false(self) -> None:
+        assert not _matches_footprint_pattern("", DEFAULT_THERMAL_FOOTPRINT_PATTERNS)
+
+
+class TestReferencePrefixMatch:
+    """:func:`_matches_reference_prefix` heuristic helper."""
+
+    def test_q_prefix_with_digit(self) -> None:
+        assert _matches_reference_prefix("Q1", ("Q",))
+        assert _matches_reference_prefix("Q12", ("Q",))
+
+    def test_q_prefix_alone(self) -> None:
+        # Bare "Q" with no digit is unusual but should match (designators
+        # rarely lack numbers but we don't want a false negative).
+        assert _matches_reference_prefix("Q", ("Q",))
+
+    def test_r_does_not_match_q(self) -> None:
+        assert not _matches_reference_prefix("R1", ("Q",))
+
+    def test_qfn_reference_does_not_match_q_prefix(self) -> None:
+        # "QFN1" starts with "Q" but the next char is a letter, not a
+        # digit -- should not match as a transistor designator.
+        assert not _matches_reference_prefix("QFN1", ("Q",))
+
+    def test_multiple_prefixes(self) -> None:
+        assert _matches_reference_prefix("U5", ("Q", "U"))
+        assert _matches_reference_prefix("Q1", ("Q", "U"))
+        assert not _matches_reference_prefix("R5", ("Q", "U"))
+
+
+class TestFindThermalPadCandidates:
+    """The thermal-pad selector pulls pads that satisfy the multi-signal
+    heuristic AND are on a target plane net."""
+
+    def test_finds_to220_drain_pads(self, two_fet_pcb: Path) -> None:
+        sexp = load_pcb(two_fet_pcb)
+        candidates = find_thermal_pad_candidates(sexp, net_names={"VMOTOR"})
+
+        # Q1 pad 2 + Q2 pad 2 -- the gates / sources are on non-plane
+        # nets so they are filtered out by the net membership precondition.
+        refs = {(c.pad.reference, c.pad.pad_number) for c in candidates}
+        assert refs == {("Q1", "2"), ("Q2", "2")}
+
+        # All candidates should be flagged by both footprint-name match
+        # (TO-220) and reference prefix (Q*).
+        for cand in candidates:
+            assert cand.matched_by_footprint
+            assert cand.matched_by_reference
+
+    def test_ignores_non_target_net(self, two_fet_pcb: Path) -> None:
+        sexp = load_pcb(two_fet_pcb)
+        # GND has no pads on this fixture; thermal stitcher must return
+        # nothing rather than dumping vias randomly.
+        candidates = find_thermal_pad_candidates(sexp, net_names={"GND"})
+        assert candidates == []
+
+    def test_ignores_capacitors_on_gnd(self, no_mosfet_pcb: Path) -> None:
+        sexp = load_pcb(no_mosfet_pcb)
+        # C1 / R1 are on GND but neither footprint family nor reference
+        # prefix nor pad size match the heuristic.  Must return [].
+        candidates = find_thermal_pad_candidates(sexp, net_names={"GND"})
+        assert candidates == []
+
+    def test_finds_large_pad_via_size_signal(self, large_ep_pcb: Path) -> None:
+        sexp = load_pcb(large_ep_pcb)
+        candidates = find_thermal_pad_candidates(
+            sexp,
+            net_names={"GND"},
+            # Override defaults so the reference-prefix and footprint
+            # signals are NOT used -- the only signal left is pad size.
+            footprint_patterns=("__nonexistent_pattern__",),
+            reference_prefixes=("__nonexistent_prefix__",),
+            min_pad_size=2.0,
+        )
+        assert len(candidates) == 1
+        assert candidates[0].pad.reference == "U1"
+        assert candidates[0].matched_by_size
+        assert not candidates[0].matched_by_footprint
+        assert not candidates[0].matched_by_reference
+
+
+class TestGenerateThermalViaPositions:
+    """:func:`generate_thermal_via_positions` placement geometry."""
+
+    def test_small_pad_uses_halo_ring(self) -> None:
+        # TO-220 pad: 1.8 x 1.8 mm.  Cannot fit a 2x2 grid of 0.6mm vias
+        # with 0.2mm clearance under the pad (needs ≥1.6mm; pad is 1.8mm
+        # but tight, see min_under_pad = 2 * (0.6 + 0.2) = 1.6mm so it
+        # passes the threshold).  Force halo mode by raising clearance.
+        pad = PadInfo(
+            reference="Q1", pad_number="2", net_number=2, net_name="VMOTOR",
+            x=110.0, y=120.0, layer="F.Cu", width=1.8, height=1.8,
+            pad_type="thru_hole",
+        )
+        positions = generate_thermal_via_positions(
+            pad, vias_per_pad=4, thermal_radius=2.5,
+            via_size=0.6, clearance=0.3,  # min_under_pad = 1.8 -> halo
+        )
+        # Halo mode generates the requested 4 primary candidates plus
+        # fallback candidates (intermediate angles + wider ring) so the
+        # caller's clearance filter has alternatives when the primary
+        # positions are blocked.  Should be at least 4 (the target) and
+        # at most ~3 * vias_per_pad (3 passes).
+        assert 4 <= len(positions) <= 3 * 4 + 4
+        # The first ``vias_per_pad`` positions should sit on the base
+        # ring at radius ≥ pad_half + via_size/2 + clearance.
+        import math
+        for x, y in positions[:4]:
+            r = math.hypot(x - pad.x, y - pad.y)
+            assert r >= 0.9 + 0.3 + 0.3 - 0.001
+
+    def test_large_pad_uses_under_pad_grid(self) -> None:
+        # 5x5 mm exposed pad -- under-pad grid mode.
+        pad = PadInfo(
+            reference="U1", pad_number="33", net_number=1, net_name="GND",
+            x=100.0, y=100.0, layer="F.Cu", width=5.0, height=5.0,
+            pad_type="smd",
+        )
+        positions = generate_thermal_via_positions(
+            pad, vias_per_pad=4, thermal_radius=2.5,
+            via_size=0.45, clearance=0.2,
+        )
+        # Should produce at least 4 positions, all inside the pad
+        # bounding box.
+        assert len(positions) >= 4
+        for x, y in positions:
+            assert 100.0 - 2.5 <= x <= 100.0 + 2.5
+            assert 100.0 - 2.5 <= y <= 100.0 + 2.5
+
+    def test_zero_count_returns_empty(self) -> None:
+        pad = PadInfo(
+            reference="Q1", pad_number="2", net_number=2, net_name="VMOTOR",
+            x=0.0, y=0.0, layer="F.Cu", width=2.0, height=2.0,
+            pad_type="smd",
+        )
+        positions = generate_thermal_via_positions(
+            pad, vias_per_pad=0, thermal_radius=2.5,
+            via_size=0.45, clearance=0.2,
+        )
+        assert positions == []
+
+
+class TestRunThermalStitch:
+    """End-to-end thermal-stitch on the 2-FET fixture."""
+
+    def test_places_min_4_vias_per_fet(self, two_fet_pcb: Path) -> None:
+        result = run_thermal_stitch(
+            pcb_path=two_fet_pcb,
+            net_names=["VMOTOR"],
+            via_size=0.45,
+            drill=0.2,
+            clearance=0.2,
+            vias_per_pad=4,
+            thermal_radius=2.5,
+            dry_run=True,  # check positions without writing
+        )
+        # 2 FETs × 4 vias each minimum
+        assert len(result.vias_added) >= 8
+
+        # All vias should be on the VMOTOR net.
+        for via in result.vias_added:
+            assert via.pad.net_name == "VMOTOR"
+
+        # Vias should cluster near Q1 (110, 120) and Q2 (130, 120).
+        near_q1 = [v for v in result.vias_added if abs(v.via_x - 110.0) <= 3.0]
+        near_q2 = [v for v in result.vias_added if abs(v.via_x - 130.0) <= 3.0]
+        assert len(near_q1) >= 4
+        assert len(near_q2) >= 4
+
+    def test_writes_pcb_when_not_dry_run(self, two_fet_pcb: Path) -> None:
+        original = two_fet_pcb.read_text()
+        result = run_thermal_stitch(
+            pcb_path=two_fet_pcb,
+            net_names=["VMOTOR"],
+            via_size=0.45,
+            drill=0.2,
+            clearance=0.2,
+            vias_per_pad=4,
+            dry_run=False,
+        )
+        assert len(result.vias_added) >= 8
+        # File modified.
+        new_content = two_fet_pcb.read_text()
+        assert new_content != original
+        # New vias appear in the PCB text (single-line or multi-line form).
+        via_count = new_content.count("(via\n") + new_content.count("(via ")
+        assert via_count >= 8
+
+    def test_idempotent_second_run_adds_zero(self, two_fet_pcb: Path) -> None:
+        # First run
+        r1 = run_thermal_stitch(
+            pcb_path=two_fet_pcb,
+            net_names=["VMOTOR"],
+            via_size=0.45,
+            drill=0.2,
+            clearance=0.2,
+            vias_per_pad=4,
+            dry_run=False,
+        )
+        added_first = len(r1.vias_added)
+        assert added_first >= 8
+
+        # Second run: same parameters.  Existing vias should block all
+        # new candidate positions (same-net stacking prevention).
+        r2 = run_thermal_stitch(
+            pcb_path=two_fet_pcb,
+            net_names=["VMOTOR"],
+            via_size=0.45,
+            drill=0.2,
+            clearance=0.2,
+            vias_per_pad=4,
+            dry_run=False,
+        )
+        assert len(r2.vias_added) == 0
+
+    def test_no_mosfets_no_vias(self, no_mosfet_pcb: Path) -> None:
+        """Boards without MOSFETs must produce zero thermal vias."""
+        result = run_thermal_stitch(
+            pcb_path=no_mosfet_pcb,
+            net_names=["GND", "+3.3V"],
+            via_size=0.45,
+            drill=0.2,
+            clearance=0.2,
+            vias_per_pad=4,
+            dry_run=False,
+        )
+        assert result.vias_added == []
+        assert result.pads_skipped == []
+        # The PCB file should NOT have been modified (no vias).
+        text = no_mosfet_pcb.read_text()
+        assert "(via " not in text and "(via\n" not in text
+
+    def test_under_pad_mode_for_large_exposed_pad(
+        self, large_ep_pcb: Path
+    ) -> None:
+        """A 3.45x3.45 mm QFN exposed pad should get under-pad vias."""
+        result = run_thermal_stitch(
+            pcb_path=large_ep_pcb,
+            net_names=["GND"],
+            via_size=0.45,
+            drill=0.2,
+            clearance=0.2,
+            vias_per_pad=4,
+            dry_run=True,
+        )
+        # The QFN exposed pad is on GND and ≥ min_pad_size (2.0mm), so
+        # the pad-size signal fires.
+        assert len(result.vias_added) >= 4
+
+        # All vias should fall inside the pad bounding box (under-pad
+        # mode places them ON the pad copper).
+        pad_x, pad_y = 125.0, 125.0
+        half = 3.45 / 2
+        for via in result.vias_added:
+            assert pad_x - half <= via.via_x <= pad_x + half
+            assert pad_y - half <= via.via_y <= pad_y + half
+
+
+class TestCLIThermalFlag:
+    """`kct stitch --thermal` end-to-end via the CLI entry point."""
+
+    def test_thermal_flag_invokes_thermal_stitch(
+        self, two_fet_pcb: Path, capsys
+    ) -> None:
+        argv = [str(two_fet_pcb), "--thermal", "--net", "VMOTOR"]
+        rc = main(argv)
+        assert rc == 0
+
+        # Vias should be in the PCB now.
+        content = two_fet_pcb.read_text()
+        via_count = content.count("(via\n") + content.count("(via ")
+        assert via_count >= 8
+
+    def test_thermal_dry_run_does_not_modify(
+        self, two_fet_pcb: Path
+    ) -> None:
+        original = two_fet_pcb.read_text()
+        argv = [str(two_fet_pcb), "--thermal", "--net", "VMOTOR", "--dry-run"]
+        rc = main(argv)
+        # Dry-run can return 0 (vias would be placed) or 1 (no work);
+        # the contract is "no file modification".
+        assert rc in (0, 1)
+        assert two_fet_pcb.read_text() == original
+
+    def test_thermal_no_mosfets_returns_no_vias(
+        self, no_mosfet_pcb: Path
+    ) -> None:
+        argv = [str(no_mosfet_pcb), "--thermal", "--net", "GND"]
+        rc = main(argv)
+        # Exit code 1 because no vias were added and no pads already
+        # connected (run_thermal_stitch does not set already_connected).
+        assert rc == 1
+        # PCB should remain via-free.
+        text = no_mosfet_pcb.read_text()
+        assert "(via " not in text and "(via\n" not in text


### PR DESCRIPTION
## Summary

- Adds `kct stitch --thermal` mode that places an array of thermal vias under or around MOSFET / heat-sink pads on plane nets.
- Closes the long-standing board-05 thermal-via gap: Q1-Q6 each now receive >=4 thermal vias on their power-net pads, fulfilling the README manufacturability promise (originally raised in #2394).
- Adds 26 new unit tests in `tests/test_thermal_stitch.py` covering heuristic helpers, placement geometry (under-pad grid vs. halo ring), end-to-end runs, idempotency, plane-net safety, and the CLI entry point.

## Heuristic

A pad is selected when it is on a target plane net AND at least one of:

1. Footprint library:name matches a thermal-pad family substring (TO-220, TO-252, DPAK, D2PAK, QFN-EP, DFN-EP, SO-8-EP, generic `-EP_` / `_EP_` / `1EP` suffix, ...).
2. Reference prefix matches a configurable list (default: `Q*` for transistors; extend via `--thermal-component-prefix`).
3. Pad bounding box meets `--thermal-min-pad-size` on both axes (default 2.0 mm) -- catches large exposed pads like QFN central pads and SOT-223 tab pins.

This disjunction-of-signals + AND-with-net pattern keeps the false-positive rate low: regular 0402 SMD caps on GND pass net but fail signals; MOSFET gate pins pass signals but fail net.

## Placement geometry

- Pads >= 3*(via_size + clearance) on both axes use a square under-pad grid (good for QFN/EP pads).
- Smaller pads use a halo ring at `--thermal-radius` (default 2.5 mm).  The halo generator emits primary 45-degree-offset candidates first, then intermediate angles, then a wider-radius fallback ring -- so blocked positions can be skipped without losing the per-pad target count.

Same-net via tracking is per-net, so a via placed on (e.g.) VMOTOR counts as a clearance obstacle -- not a same-net stacking obstacle -- when the same pass later processes PHASE_A.  Idempotency is enforced via a proximity check that skips pads already containing `>= vias_per_pad` same-net vias inside `2 * thermal_radius`.

## Board 05 results (target case)

| FET   | role       | power pad(s) on    | vias placed |
|-------|------------|--------------------|-------------|
| Q1    | high-side  | VMOTOR, PHASE_A    | 11 (5 + 6)  |
| Q2    | low-side   | PHASE_A            |  4          |
| Q3    | high-side  | VMOTOR, PHASE_B    | 12 (6 + 6)  |
| Q4    | low-side   | PHASE_B            |  4          |
| Q5    | high-side  | VMOTOR, PHASE_C    | 11 (6 + 5)  |
| Q6    | low-side   | PHASE_C            |  4          |

Total across Q1-Q6: 46 thermal vias placed.  AC item (≥24 = 6 * 4) met.

## Per-board regression

| Board                    | Thermal vias added | Expected? |
|--------------------------|--------------------|-----------|
| 01-voltage-divider       | 0                  | yes (no heat-sink components) |
| 02-charlieplex-led       | 0                  | yes (LEDs + traces only) |
| 03-usb-joystick          | 0                  | yes (passives + connectors) |
| 04-stm32-devboard        | 4 on U1 (AMS1117 SOT-223 tab) | yes (legit thermal pad) |
| 06-diffpair-test         | several on QFN-EP central pads | yes (legit) |
| 07-matchgroup-test       | several on QFN-EP central pads | yes (legit) |

No false-positives on regular SMD passive boards.

## File pointers

- `src/kicad_tools/cli/stitch_cmd.py` -- new functions: `_matches_footprint_pattern`, `_matches_reference_prefix`, `find_thermal_pad_candidates`, `generate_thermal_via_positions`, `run_thermal_stitch`; new CLI flags `--thermal`, `--vias-per-pad`, `--thermal-radius`, `--thermal-min-pad-size`, `--thermal-component-prefix`.
- `src/kicad_tools/cli/parser.py` -- mirror the new flags on the `kct stitch` subcommand parser.
- `src/kicad_tools/cli/__init__.py` -- wire new args through `_run_stitch_command`.
- `tests/test_thermal_stitch.py` -- 26 unit tests.

## Coordination notes

- #2899 (in parallel) is touching `src/kicad_tools/zones/generator.py` -- this PR stays out of that file; thermal-stitch consumes whatever zone polygons exist on the board.
- #2898 (in parallel) is committing board-05 artifacts; this PR does NOT commit re-stitched board-05 artifacts to avoid conflict.  The smoke-test PCB lives at `/tmp/board05_test.kicad_pcb` and is not part of the PR.
- Did NOT touch `zones/generator.py`, `auto_pour.py`, or any router code -- narrow change set.

## Test plan

- [x] All 26 new tests in `tests/test_thermal_stitch.py` pass.
- [x] 283 pre-existing stitch tests (`tests/test_stitch_cmd.py`, `test_stitch_mfr.py`, `test_stitch_via_halo.py`, `test_build_stitch_step.py`) still pass.
- [x] Smoke test on board 05 -- Q1-Q6 each have >=4 thermal vias on power-net pads.
- [x] Regression check on boards 01-04, 06, 07 -- no spurious thermal vias on regular SMD passive footprints.
- [x] Lint clean (`uv run ruff check`).
- [ ] Full DRC verification on a stitched board-05 deferred until #2899 lands zones (no zones = thermal vias have nothing to terminate into on inner layers; the fallback path places them on F.Cu/B.Cu without DRC error but does not fulfill the heat-spread purpose).

Closes #2900

🤖 Generated with [Claude Code](https://claude.com/claude-code)