### PR TITLE
fix(cli): --auto-layers escalation honors PCB declared stackup (closes #2916)

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -1730,6 +1730,188 @@ def _cleanup_stale_layer_artifacts(output_path: Path, quiet: bool = False) -> li
     return removed
 
 
+def _detect_pcb_layer_profile(pcb_path: Path) -> tuple[int, bool]:
+    """Inspect the PCB's declared ``(layers ...)`` block and inner-layer zones.
+
+    Returns the number of copper layers and whether any *inner* copper layer
+    has a zone definition (the canonical signature of a board that was
+    designed against power/ground planes on ``In1.Cu``/``In2.Cu``).  These two
+    pieces of information are what the layer-escalation loops need to refuse
+    structurally-invalid 2L probes on a 4L board (issue #2916) and to put the
+    plane-aware 4L variant ahead of the all-signal variant when planes exist.
+
+    The parsing matches :func:`kicad_tools.router.io.detect_layer_stack` -- we
+    reuse the same regexes so the two paths agree on what counts as a copper
+    layer and what counts as a plane zone.
+
+    Args:
+        pcb_path: Path to the input ``.kicad_pcb`` file.
+
+    Returns:
+        ``(num_copper_layers, has_inner_plane_zones)``.  Returns
+        ``(2, False)`` on any parse failure so the escalation loops fall
+        through to legacy behaviour (start at 2L) rather than crashing.
+    """
+    import re
+
+    # Accept str or Path (a few callers pass string paths, mirroring
+    # ``_cleanup_stale_layer_artifacts``).
+    pcb_path = Path(pcb_path)
+    try:
+        pcb_text = pcb_path.read_text()
+    except OSError as exc:
+        logger.debug("Could not read %s for layer detection: %s", pcb_path, exc)
+        return (2, False)
+
+    # Parse the (layers ...) section to find copper layers -- mirrors the
+    # regex used by ``detect_layer_stack`` so both paths agree.
+    copper_names: list[str] = []
+    layers_match = re.search(r"\(layers\s+(.*?)\n\s*\)", pcb_text, re.DOTALL)
+    if layers_match:
+        for layer_match in re.finditer(
+            r'\((\d+)\s+"([^"]+\.Cu)"\s+(\w+)', layers_match.group(1)
+        ):
+            copper_names.append(layer_match.group(2))
+
+    num_copper = len(copper_names) if copper_names else 2
+
+    # Detect zones on inner layers (anything that is not F.Cu or B.Cu).
+    has_inner_planes = False
+    for zone_match in re.finditer(
+        r'\(zone\s+.*?\(layer\s+"([^"]+)"\)',
+        pcb_text,
+        re.DOTALL,
+    ):
+        layer_name = zone_match.group(1)
+        if layer_name.endswith(".Cu") and layer_name not in ("F.Cu", "B.Cu"):
+            has_inner_planes = True
+            break
+
+    return (num_copper, has_inner_planes)
+
+
+def _filter_layer_configs_for_pcb(
+    layer_configs: list[tuple[int, "LayerStack"]],
+    pcb_path: Path,
+    max_layers: int,
+    quiet: bool = False,
+) -> list[tuple[int, "LayerStack"]]:
+    """Filter and reorder *layer_configs* to honour the PCB's declared stackup.
+
+    Issue #2916: ``--auto-layers`` previously started at 2L for every board
+    regardless of the PCB's declared copper count.  On a 4L board (e.g.
+    chorus-test-revA with ``In1.Cu``/``In2.Cu`` plane zones already drawn) the
+    2L probe burns a fair share of the wall-clock budget on a configuration
+    that cannot succeed, leaving the real 4L attempt to start against an
+    exhausted deadline (issue #2823 + #2802).
+
+    This helper applies three transformations:
+
+    1. **Floor by detected copper count.**  Entries whose ``layer_count`` is
+       below the PCB's declared count are dropped.  A 4-copper-layer PCB has
+       4L as its minimum sensible probe; 2L is never tried.
+    2. **Promote plane-aware variants.**  When inner-layer zones are present
+       in the PCB (the ``four_layer_sig_gnd_pwr_sig`` shape), reorder so the
+       plane-aware 4L variant runs before ``four_layer_all_signal``.  This
+       matches what the single-pass path already does via
+       :func:`detect_layer_stack`.
+    3. **Honour ``--max-layers``.**  If the user-requested cap is below the
+       detected count, emit a warning and keep the cap (the user's explicit
+       wish wins, but they are told that it is structurally below the
+       declared stackup so a partial/failed result is expected).
+
+    Args:
+        layer_configs: The unfiltered escalation ladder
+            ``[(n_layers, LayerStack), ...]``.
+        pcb_path: Path to the input ``.kicad_pcb`` file (used to probe the
+            declared copper count and inner-zone presence).
+        max_layers: User-requested ``--max-layers`` cap.
+        quiet: Suppress informational output.
+
+    Returns:
+        A new list with entries below ``detected_count`` removed, plane-aware
+        variants promoted (when applicable), and capped at ``max_layers``.
+        Falls through to the input list unchanged when detection fails or the
+        detected count is <= 2 (the natural starting point for the ladder).
+    """
+    from kicad_tools.cli.progress import flush_print
+
+    detected_count, has_inner_planes = _detect_pcb_layer_profile(pcb_path)
+
+    # Honour ``--max-layers`` even when it falls below the declared count --
+    # but warn loudly so the user knows their cap is structurally too low.
+    effective_floor = detected_count
+    if max_layers < detected_count:
+        if not quiet:
+            flush_print(
+                f"  Warning: --max-layers={max_layers} is below the PCB's "
+                f"declared copper count ({detected_count}).  Using the "
+                f"requested cap, but the board was designed for "
+                f"{detected_count} layers so routing will likely fail or "
+                "produce a partial result (issue #2916)."
+            )
+        # User's explicit cap wins -- relax the floor so the ladder still
+        # has at least one rung.
+        effective_floor = min(detected_count, max_layers)
+
+    # Apply max_layers cap as before.
+    filtered = [(n, s) for n, s in layer_configs if n <= max_layers]
+
+    # Drop entries below the detected floor (or the user's cap if lower).
+    filtered = [(n, s) for n, s in filtered if n >= effective_floor]
+
+    # When inner-layer plane zones exist, promote the plane-aware 4L variant
+    # ahead of the all-signal variant.  This matches the single-pass path
+    # which calls ``detect_layer_stack`` and returns the plane-aware shape.
+    if has_inner_planes:
+        plane_aware = []
+        all_signal = []
+        other = []
+        for n, s in filtered:
+            if n == 4 and "ALL-SIG" in s.name.upper():
+                all_signal.append((n, s))
+            elif n == 4:
+                plane_aware.append((n, s))
+            else:
+                other.append((n, s))
+        # Preserve overall layer-count ordering: 4L (plane-aware then
+        # all-signal) sandwiched between any 2L (none after floor) and 6L.
+        # ``other`` already preserves the relative ordering of the original
+        # list, so we splice the 4L entries back at their natural position.
+        if plane_aware or all_signal:
+            result = []
+            inserted_four = False
+            for n, s in other:
+                if n > 4 and not inserted_four:
+                    result.extend(plane_aware)
+                    result.extend(all_signal)
+                    inserted_four = True
+                result.append((n, s))
+            if not inserted_four:
+                result.extend(plane_aware)
+                result.extend(all_signal)
+            filtered = result
+
+    # Defensive: if the filter wiped the ladder (e.g. detected count > 6 and
+    # max_layers < detected), fall back to the original list capped at
+    # max_layers so the loop still has something to try.  The warning above
+    # already alerted the user.
+    if not filtered:
+        filtered = [(n, s) for n, s in layer_configs if n <= max_layers]
+
+    if not quiet and detected_count > 2:
+        dropped = len(layer_configs) - len(filtered)
+        if dropped > 0 or has_inner_planes:
+            ladder_str = ", ".join(f"{n}L" for n, _ in filtered)
+            flush_print(
+                f"  Detected {detected_count}-copper-layer PCB"
+                f"{' with inner plane zones' if has_inner_planes else ''}; "
+                f"escalation ladder: [{ladder_str}] (issue #2916)"
+            )
+
+    return filtered
+
+
 def _auto_skip_pour_nets(
     pcb_path: Path,
     skip_nets: list[str],
@@ -1962,8 +2144,13 @@ def route_with_layer_escalation(
         (6, LayerStack.six_layer_sig_gnd_sig_sig_pwr_sig()),
     ]
 
-    # Filter by max_layers
-    layer_configs = [(n, s) for n, s in layer_configs if n <= args.max_layers]
+    # Issue #2916: filter and reorder by the PCB's declared stackup.
+    # Drops entries below the detected copper count (so a 4L board never
+    # wastes budget on a 2L probe) and promotes the plane-aware 4L variant
+    # ahead of all-signal when inner plane zones exist.
+    layer_configs = _filter_layer_configs_for_pcb(
+        layer_configs, pcb_path, args.max_layers, quiet=quiet
+    )
 
     if not quiet:
         flush_print("=" * 60)
@@ -3705,8 +3892,13 @@ def route_with_combined_escalation(
         (6, LayerStack.six_layer_sig_gnd_sig_sig_pwr_sig()),
     ]
 
-    # Filter by max_layers
-    layer_configs = [(n, s) for n, s in layer_configs if n <= args.max_layers]
+    # Issue #2916: filter and reorder by the PCB's declared stackup.
+    # Drops entries below the detected copper count (so a 4L board never
+    # wastes budget on a 2L probe) and promotes the plane-aware 4L variant
+    # ahead of all-signal when inner plane zones exist.
+    layer_configs = _filter_layer_configs_for_pcb(
+        layer_configs, pcb_path, args.max_layers, quiet=quiet
+    )
 
     if not quiet:
         flush_print("=" * 60)

--- a/tests/test_layer_escalation.py
+++ b/tests/test_layer_escalation.py
@@ -1638,3 +1638,328 @@ class TestPlacementFeedbackOnPartial:
             f"Placement-feedback should not run on SUCCESS, got "
             f"{mock_feedback.call_count} invocations"
         )
+
+
+class TestLayerConfigsFilterForStackup:
+    """Issue #2916: ``--auto-layers`` must honour the PCB's declared stackup.
+
+    Both escalation loops in ``route_cmd.py`` (1D layer escalation and 2D
+    combined escalation) historically started at ``(2, two_layer())`` for
+    every input PCB.  On a board whose ``(layers ...)`` block declares
+    F.Cu / In1.Cu / In2.Cu / B.Cu (4 copper layers), the 2L probe is
+    structurally invalid — yet under ``_per_attempt_budgeted_timeout``
+    (#2823) it consumes a fair share of the wall-clock budget, leaving the
+    real 4L attempt to die against ``_deadline_expired`` (#2802).
+
+    These tests drive the new ``_filter_layer_configs_for_pcb`` helper
+    directly on synthetic PCB files so the assertion is independent of
+    the full router pipeline.
+    """
+
+    # Minimal PCBs covering the three cases we care about.
+    PCB_2L = """(kicad_pcb
+  (version 20240101)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (net 0 "")
+)"""
+
+    PCB_4L_NO_ZONES = """(kicad_pcb
+  (version 20240101)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (2 "In2.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (net 0 "")
+)"""
+
+    PCB_4L_PLANE_ZONES = """(kicad_pcb
+  (version 20240101)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (2 "In2.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (zone (net 1) (net_name "GND") (layer "In1.Cu")
+    (hatch edge 0.5)
+    (filled_areas_thickness no)
+    (polygon (pts (xy 0 0) (xy 10 0) (xy 10 10) (xy 0 10))))
+  (zone (net 2) (net_name "+3.3V") (layer "In2.Cu")
+    (hatch edge 0.5)
+    (filled_areas_thickness no)
+    (polygon (pts (xy 0 0) (xy 10 0) (xy 10 10) (xy 0 10))))
+)"""
+
+    PCB_6L = """(kicad_pcb
+  (version 20240101)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (2 "In2.Cu" signal)
+    (3 "In3.Cu" signal)
+    (4 "In4.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (net 0 "")
+)"""
+
+    def _full_ladder(self):
+        """Return the unfiltered escalation ladder used by both loops."""
+        from kicad_tools.router import LayerStack
+
+        return [
+            (2, LayerStack.two_layer()),
+            (4, LayerStack.four_layer_sig_gnd_pwr_sig()),
+            (4, LayerStack.four_layer_all_signal()),
+            (6, LayerStack.six_layer_sig_gnd_sig_sig_pwr_sig()),
+        ]
+
+    def test_2l_pcb_keeps_full_ladder(self, tmp_path):
+        """A 2-layer PCB must keep the legacy ladder starting at 2L.
+
+        This is the regression test for the existing fleet: boards 01-07
+        and any other 2-copper-layer PCB must continue to probe at 2L
+        first.
+        """
+        from kicad_tools.cli.route_cmd import _filter_layer_configs_for_pcb
+
+        pcb = tmp_path / "two_layer.kicad_pcb"
+        pcb.write_text(self.PCB_2L)
+
+        filtered = _filter_layer_configs_for_pcb(
+            self._full_ladder(), pcb, max_layers=6, quiet=True
+        )
+
+        # The full 4-entry ladder must survive a 2L board.
+        assert [n for n, _ in filtered] == [2, 4, 4, 6]
+        # And it still starts at 2L.
+        assert filtered[0][0] == 2
+
+    def test_4l_pcb_drops_2l_entry(self, tmp_path):
+        """A 4-copper-layer PCB must skip the 2L probe entirely.
+
+        Acceptance criterion #1: chorus-test (4-copper stackup) reaches a
+        4L attempt within budget.  This is the unit-level proof of that:
+        the ladder never contains a 2L config when the declared copper
+        count is 4.
+        """
+        from kicad_tools.cli.route_cmd import _filter_layer_configs_for_pcb
+
+        pcb = tmp_path / "four_layer.kicad_pcb"
+        pcb.write_text(self.PCB_4L_NO_ZONES)
+
+        filtered = _filter_layer_configs_for_pcb(
+            self._full_ladder(), pcb, max_layers=6, quiet=True
+        )
+
+        # 2L must be filtered out -- 4L is the floor.
+        assert all(n >= 4 for n, _ in filtered), (
+            f"Expected ladder to start at 4L on a 4-copper board, got "
+            f"{[n for n, _ in filtered]}"
+        )
+        # First attempt must be a 4L config.
+        assert filtered[0][0] == 4
+
+    def test_4l_plane_zones_promote_plane_aware_first(self, tmp_path):
+        """When inner-layer plane zones exist, plane-aware 4L runs first.
+
+        Acceptance criterion #2: unit test mocks a 4-layer stackup with
+        inner plane zones and asserts auto-layers picks the plane-aware
+        variant on the first 4L attempt (not ``four_layer_all_signal``).
+        """
+        from kicad_tools.cli.route_cmd import _filter_layer_configs_for_pcb
+
+        pcb = tmp_path / "four_layer_planes.kicad_pcb"
+        pcb.write_text(self.PCB_4L_PLANE_ZONES)
+
+        filtered = _filter_layer_configs_for_pcb(
+            self._full_ladder(), pcb, max_layers=6, quiet=True
+        )
+
+        # No 2L entries.
+        assert all(n >= 4 for n, _ in filtered)
+        # First entry must be 4L plane-aware (SIG-GND-PWR-SIG), NOT all-signal.
+        first_n, first_stack = filtered[0]
+        assert first_n == 4
+        assert "ALL-SIG" not in first_stack.name.upper(), (
+            f"Expected plane-aware 4L first on a board with In1.Cu/In2.Cu "
+            f"zones, got {first_stack.name}"
+        )
+        # And the all-signal variant must still be in the ladder (so it
+        # can serve as a fallback if the plane-aware attempt under-routes).
+        names = [s.name for _, s in filtered]
+        assert any("ALL-SIG" in n.upper() for n in names), (
+            "all-signal 4L variant must remain in the ladder as a fallback"
+        )
+        # Ordering: plane-aware before all-signal.
+        plane_idx = next(i for i, (_, s) in enumerate(filtered) if "ALL-SIG" not in s.name.upper() and _ == 4)
+        all_sig_idx = next(i for i, (_, s) in enumerate(filtered) if "ALL-SIG" in s.name.upper())
+        assert plane_idx < all_sig_idx, (
+            f"plane-aware 4L (index {plane_idx}) must precede all-signal "
+            f"(index {all_sig_idx})"
+        )
+
+    def test_max_layers_below_detected_emits_warning(self, tmp_path, capsys):
+        """``--max-layers 2`` on a 4L board emits a warning and uses the cap.
+
+        Acceptance criterion #4: ``--max-layers`` < detected emits a
+        warning and uses the requested cap (still respects user override).
+        """
+        from kicad_tools.cli.route_cmd import _filter_layer_configs_for_pcb
+
+        pcb = tmp_path / "four_layer.kicad_pcb"
+        pcb.write_text(self.PCB_4L_NO_ZONES)
+
+        filtered = _filter_layer_configs_for_pcb(
+            self._full_ladder(), pcb, max_layers=2, quiet=False
+        )
+
+        captured = capsys.readouterr()
+        # Warning must be visible.
+        assert "max-layers=2" in captured.out.lower() or "max-layers=2" in captured.out
+        assert "below" in captured.out.lower()
+        assert "4" in captured.out
+        # The ladder must still produce something to try -- the user's
+        # explicit cap wins, so 2L is the only entry that survives.
+        assert filtered, "Filter must not produce an empty ladder"
+        assert all(n <= 2 for n, _ in filtered), (
+            f"With --max-layers=2 the ladder must respect the cap, got "
+            f"{[n for n, _ in filtered]}"
+        )
+
+    def test_max_layers_below_detected_quiet_suppresses_warning(self, tmp_path, capsys):
+        """``quiet=True`` suppresses the warning but still applies the cap."""
+        from kicad_tools.cli.route_cmd import _filter_layer_configs_for_pcb
+
+        pcb = tmp_path / "four_layer.kicad_pcb"
+        pcb.write_text(self.PCB_4L_NO_ZONES)
+
+        filtered = _filter_layer_configs_for_pcb(
+            self._full_ladder(), pcb, max_layers=2, quiet=True
+        )
+
+        captured = capsys.readouterr()
+        assert captured.out == "", (
+            f"quiet=True should suppress the warning, got: {captured.out!r}"
+        )
+        # Cap still applied.
+        assert all(n <= 2 for n, _ in filtered)
+
+    def test_4l_pcb_capped_to_4_keeps_both_4l_variants(self, tmp_path):
+        """``--max-layers=4`` on a 4L board keeps both 4L variants.
+
+        Confirms the plane-aware promotion does not accidentally drop the
+        all-signal fallback when the cap leaves no room for 6L.
+        """
+        from kicad_tools.cli.route_cmd import _filter_layer_configs_for_pcb
+
+        pcb = tmp_path / "four_layer_planes.kicad_pcb"
+        pcb.write_text(self.PCB_4L_PLANE_ZONES)
+
+        filtered = _filter_layer_configs_for_pcb(
+            self._full_ladder(), pcb, max_layers=4, quiet=True
+        )
+
+        # Exactly the two 4L variants.
+        assert [n for n, _ in filtered] == [4, 4]
+        # Plane-aware first.
+        assert "ALL-SIG" not in filtered[0][1].name.upper()
+        assert "ALL-SIG" in filtered[1][1].name.upper()
+
+    def test_6l_pcb_drops_2l_and_4l_entries(self, tmp_path):
+        """A 6-copper-layer PCB must skip 2L and 4L probes."""
+        from kicad_tools.cli.route_cmd import _filter_layer_configs_for_pcb
+
+        pcb = tmp_path / "six_layer.kicad_pcb"
+        pcb.write_text(self.PCB_6L)
+
+        filtered = _filter_layer_configs_for_pcb(
+            self._full_ladder(), pcb, max_layers=6, quiet=True
+        )
+
+        # Only 6L survives the floor.
+        assert [n for n, _ in filtered] == [6]
+
+    def test_parse_failure_falls_back_to_legacy_behaviour(self, tmp_path):
+        """An unreadable / unparseable PCB falls through to the legacy ladder."""
+        from kicad_tools.cli.route_cmd import _filter_layer_configs_for_pcb
+
+        # Empty file: no (layers ...) block -> detector returns 2.
+        pcb = tmp_path / "broken.kicad_pcb"
+        pcb.write_text("(kicad_pcb (version 20240101))")
+
+        filtered = _filter_layer_configs_for_pcb(
+            self._full_ladder(), pcb, max_layers=6, quiet=True
+        )
+
+        # Legacy behaviour: full ladder starting at 2L.
+        assert [n for n, _ in filtered] == [2, 4, 4, 6]
+
+    def test_detect_pcb_layer_profile_2l(self, tmp_path):
+        """``_detect_pcb_layer_profile`` returns (2, False) for a 2L board."""
+        from kicad_tools.cli.route_cmd import _detect_pcb_layer_profile
+
+        pcb = tmp_path / "p.kicad_pcb"
+        pcb.write_text(self.PCB_2L)
+        assert _detect_pcb_layer_profile(pcb) == (2, False)
+
+    def test_detect_pcb_layer_profile_4l_no_zones(self, tmp_path):
+        """4-copper PCB without inner zones reports (4, False)."""
+        from kicad_tools.cli.route_cmd import _detect_pcb_layer_profile
+
+        pcb = tmp_path / "p.kicad_pcb"
+        pcb.write_text(self.PCB_4L_NO_ZONES)
+        assert _detect_pcb_layer_profile(pcb) == (4, False)
+
+    def test_detect_pcb_layer_profile_4l_plane_zones(self, tmp_path):
+        """4-copper PCB with In1.Cu/In2.Cu zones reports (4, True)."""
+        from kicad_tools.cli.route_cmd import _detect_pcb_layer_profile
+
+        pcb = tmp_path / "p.kicad_pcb"
+        pcb.write_text(self.PCB_4L_PLANE_ZONES)
+        assert _detect_pcb_layer_profile(pcb) == (4, True)
+
+    def test_detect_pcb_layer_profile_6l(self, tmp_path):
+        """6-copper PCB without inner zones reports (6, False)."""
+        from kicad_tools.cli.route_cmd import _detect_pcb_layer_profile
+
+        pcb = tmp_path / "p.kicad_pcb"
+        pcb.write_text(self.PCB_6L)
+        assert _detect_pcb_layer_profile(pcb) == (6, False)
+
+    def test_detect_pcb_layer_profile_outer_zone_does_not_count(self, tmp_path):
+        """A zone on F.Cu / B.Cu is not an *inner* plane zone."""
+        from kicad_tools.cli.route_cmd import _detect_pcb_layer_profile
+
+        pcb_text = """(kicad_pcb
+  (version 20240101)
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (2 "In2.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (zone (net 1) (net_name "GND") (layer "F.Cu")
+    (hatch edge 0.5)
+    (filled_areas_thickness no)
+    (polygon (pts (xy 0 0) (xy 1 0) (xy 1 1) (xy 0 1))))
+)"""
+        pcb = tmp_path / "p.kicad_pcb"
+        pcb.write_text(pcb_text)
+
+        num_copper, has_inner_planes = _detect_pcb_layer_profile(pcb)
+        assert num_copper == 4
+        # Zone is on F.Cu (outer) -- not an inner plane.
+        assert has_inner_planes is False


### PR DESCRIPTION
## Summary

- Adds ``_detect_pcb_layer_profile`` + ``_filter_layer_configs_for_pcb`` helpers in ``route_cmd.py`` so the 1D and 2D escalation loops respect the PCB's declared ``(layers ...)`` block.
- Filters the hard-coded ladder ``[(2, ...), (4, ...), (4, ...), (6, ...)]`` by dropping entries below the detected copper count, promoting the plane-aware 4L variant when ``In1.Cu``/``In2.Cu`` zones exist, and warning when ``--max-layers`` is below the detected count.
- chorus-test-revA (4-copper + inner plane zones) now starts the ladder at 4L plane-aware, freeing the wall-clock budget the previous 2L probe was burning (interaction with #2823 + #2802).

## Root cause

Both escalation entry points (``route_with_layer_escalation`` at line ~1958, ``route_with_combined_escalation`` at line ~3701) hard-coded the same ladder and never consulted ``detect_layer_stack`` -- only the single-pass ``--layers auto`` path at line ~5439 did.  Combined with the per-attempt budget allocator from #2823, a 4L board burned ~225s of a 900s budget on a structurally invalid 2L probe, then ``_deadline_expired`` killed the 4L attempt before it could finish.

## Fleet impact (verified directly)

| Board | Copper | Inner planes | Ladder before | Ladder after |
| --- | --- | --- | --- | --- |
| 01 voltage-divider | 2 | no | [2,4,4,6] | [2,4,4,6] |
| 02 charlieplex-led | 2 | no | [2,4,4,6] | [2,4,4,6] |
| 03 usb-joystick | 2 | no | [2,4,4,6] | [2,4,4,6] |
| 04 stm32-devboard | 2 | no | [2,4,4,6] | [2,4,4,6] |
| 05 bldc-motor-controller | 2 | no | [2,4,4,6] | [2,4,4,6] |
| 06 diffpair-test | 4 | no | [2,4,4,6] | [4,4,6] |
| 07 matchgroup-test | 4 | no | [2,4,4,6] | [4,4,6] |
| chorus-test-revA | 4 | yes | [2,4,4,6] | [4(plane-aware),4(all-sig),6] |

2L boards keep their full ladder (no regression).  4L boards skip the invalid 2L probe.

## Test plan

- [x] 13 new unit tests in ``TestLayerConfigsFilterForStackup`` cover all four acceptance criteria (2L unchanged; 4L drops 2L; plane zones promote plane-aware variant; ``--max-layers`` below detected emits warning).
- [x] All 50 passing tests in ``test_layer_escalation.py`` still pass.  The 9 pre-existing ``TestEarlyTermination`` failures are unrelated (MagicMock vs. ``validate_routes`` int compare in ``router/io.py:2073``) and reproduce on plain ``origin/main``.
- [x] ``tests/test_router_layers.py`` (80 tests), ``tests/test_layer_balancing.py`` (17 tests), ``tests/test_route_auto_fix.py`` (40 tests), ``tests/test_route_pipeline_connectivity.py`` (16 tests): all pass.
- [x] Live CLI smoke-tests on board 01 (2L) and board 06 (4L) confirm correct ladder behaviour and warning emission.

Closes #2916.