### PR TITLE
fix(stitch): outer-ring BGA pads search wider when corridors occupied (closes #2912)

### DIFF
--- a/src/kicad_tools/cli/stitch_cmd.py
+++ b/src/kicad_tools/cli/stitch_cmd.py
@@ -1747,7 +1747,7 @@ def calculate_extended_escape_position(
     via_size: float,
     existing_vias: list[tuple[float, float, int]],
     clearance: float,
-    escape_distance: float = 3.0,
+    escape_distance: float = 4.0,
     other_net_tracks: list[TrackSegment] | None = None,
     other_net_vias: list[tuple[float, float, float, int]] | None = None,
     other_net_pads: list[tuple[float, float, float, int]] | None = None,
@@ -1771,7 +1771,11 @@ def calculate_extended_escape_position(
         via_size: Via pad diameter in mm
         existing_vias: Same-net vias as (x, y, net_num) for via-to-via spacing
         clearance: Minimum clearance from existing copper in mm
-        escape_distance: Maximum total escape trace length in mm (default 3.0)
+        escape_distance: Maximum total escape trace length in mm (default 4.0).
+            For 7-row 1.27mm-pitch BGAs the corner-to-clear distance is ~4mm,
+            so the search radius must reach that far. ``_check_via_position``
+            still rejects collisions, so widening the search cannot create
+            new clearance violations.
         other_net_tracks: Track segments on other nets for clearance checking
         other_net_vias: Vias on other nets as (x, y, size, net_num) for clearance
         other_net_pads: Pads on other nets as (x, y, radius, net_num) for clearance
@@ -1821,18 +1825,25 @@ def calculate_extended_escape_position(
         axial_dirs = [(1, 0), (-1, 0), (0, 1), (0, -1)]
         escape_dirs = [(0, 1), (0, -1), (1, 0), (-1, 0)]
 
-    # Progressive axial distances for the first leg (along the pin row)
-    # These are larger than dogleg to escape past multiple neighboring pins
-    axial_distances = [0.5, 0.8, 1.0, 1.3, 1.6, 2.0, 2.5, 3.0, 3.5, 4.0]
+    # Progressive axial distances for the first leg (along the pin row).
+    # These are larger than dogleg to escape past multiple neighboring pins.
+    # Extended to 5.0mm to accommodate outer-ring pads on large (7+ row) BGAs
+    # whose corner-to-clear distance exceeds 4mm; entries are filtered by the
+    # caller-supplied ``escape_distance`` so callers can still tighten the
+    # search.
+    axial_distances = [0.5, 0.8, 1.0, 1.3, 1.6, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0]
     axial_distances = [d for d in axial_distances if d <= escape_distance]
 
-    # Escape offsets for the final breakout leg (perpendicular to pin row)
+    # Escape offsets for the final breakout leg (perpendicular to pin row).
+    # Extra rings (k=4) help when the inner rings collide with neighboring
+    # pads; ``_check_via_position`` rejects bad placements regardless.
     breakout_offsets = [
         pad_radius + offset,
         pad_radius + offset * 1.5,
         pad_radius + offset * 2,
         pad_radius + offset * 2.5,
         pad_radius + offset * 3,
+        pad_radius + offset * 4,
     ]
     breakout_offsets = [d for d in breakout_offsets if d <= escape_distance]
 
@@ -2007,6 +2018,100 @@ def calculate_extended_escape_position(
                             (wp2_x, wp2_y),
                         ]
                         return (via_x, via_y, waypoints)
+
+    # Strategy 4: Polar-grid via sampler with layer-aware 2-segment routing.
+    # The three L/Z strategies above search only the 4 cardinal directions,
+    # which leaves diagonal escape paths untested, AND they check trace
+    # clearance against tracks on every copper layer.  The pad-to-via trace
+    # is on the pad's layer (F.Cu or B.Cu), so an In*.Cu track cannot
+    # actually collide with it; the conservative all-layer check forced the
+    # earlier strategies to reject feasible escapes for outer-ring BGA pads
+    # whose escape corridors are full of inner-layer signal traces.
+    #
+    # This strategy samples candidate via positions on a polar grid (16
+    # angular steps x progressive radii) and, for each clearance-valid
+    # candidate, attempts a 2-segment routing path (pad -> halfway
+    # waypoint -> via).  Trace clearance is checked only against tracks
+    # on the pad's layer.  Via clearance still considers every layer
+    # (vias span F.Cu through B.Cu).
+    trace_layer = pad.layer
+    same_layer_tracks = [seg for seg in other_net_tracks if seg.layer == trace_layer]
+
+    def _check_path_layer_aware(pts: list[tuple[float, float]]) -> bool:
+        """Path clearance using only tracks on the pad's layer.
+
+        Vias and pads are not layer-filtered: vias span all copper layers
+        and SMD/through-hole pads can collide with traces from above/below
+        via copper exposure.  This is the same model used by the
+        layer-agnostic helper for those obstacle classes.
+        """
+        if trace_width <= 0:
+            return True
+        for i in range(len(pts) - 1):
+            sx, sy = pts[i]
+            ex, ey = pts[i + 1]
+            for seg in same_layer_tracks:
+                dist = segment_to_segment_distance(
+                    sx,
+                    sy,
+                    ex,
+                    ey,
+                    seg.start_x,
+                    seg.start_y,
+                    seg.end_x,
+                    seg.end_y,
+                )
+                if dist < trace_half_width + seg.width / 2 + clearance:
+                    return False
+            for ovx, ovy, ov_size, _onet in other_net_vias:
+                dist = point_to_segment_distance(ovx, ovy, sx, sy, ex, ey)
+                if dist < trace_half_width + ov_size / 2 + clearance:
+                    return False
+            for px, py, p_radius, _pnet in other_net_pads:
+                dist = point_to_segment_distance(px, py, sx, sy, ex, ey)
+                if dist < trace_half_width + p_radius + clearance:
+                    return False
+        return True
+
+    angular_steps = 16  # 22.5deg increments — covers diagonals
+    polar_radii = [
+        pad_radius + offset * 2.0,
+        pad_radius + offset * 2.5,
+        pad_radius + offset * 3.0,
+        pad_radius + offset * 4.0,
+        pad_radius + offset * 5.0,
+        pad_radius + offset * 6.0,
+        pad_radius + offset * 7.0,
+        pad_radius + offset * 8.0,
+    ]
+    polar_radii = [r for r in polar_radii if r <= escape_distance]
+    if not polar_radii:
+        polar_radii = [min(pad_radius + offset * 2.0, escape_distance)]
+
+    for radius in polar_radii:
+        for k in range(angular_steps):
+            theta = (2 * math.pi * k) / angular_steps
+            via_x = pad.x + radius * math.cos(theta)
+            via_y = pad.y + radius * math.sin(theta)
+
+            if not _check_via_position(via_x, via_y):
+                continue
+
+            # Intermediate waypoint at half-radius on the same bearing
+            wp_x = pad.x + (radius * 0.5) * math.cos(theta)
+            wp_y = pad.y + (radius * 0.5) * math.sin(theta)
+
+            path_points = [
+                (pad.x, pad.y),
+                (wp_x, wp_y),
+                (via_x, via_y),
+            ]
+
+            if not _check_path_layer_aware(path_points):
+                continue
+
+            waypoints = [(wp_x, wp_y)]
+            return (via_x, via_y, waypoints)
 
     return None
 
@@ -3294,7 +3399,7 @@ def run_stitch(
     target_layer: str | None = None,
     trace_width: float = 0.2,
     dry_run: bool = False,
-    escape_distance: float = 3.0,
+    escape_distance: float = 4.0,
     micro_via: bool = False,
     micro_via_size: float = 0.3,
     micro_via_drill: float = 0.15,
@@ -3311,7 +3416,7 @@ def run_stitch(
         target_layer: Target plane layer (auto-detect from zones if None)
         trace_width: Width of pad-to-via trace segments in mm
         dry_run: If True, don't modify the file
-        escape_distance: Maximum escape trace length in mm for dense IC pads (default 3.0)
+        escape_distance: Maximum escape trace length in mm for dense IC pads (default 4.0)
         micro_via: If True, retry failed pads with smaller micro-vias
         micro_via_size: Micro-via pad diameter in mm (default 0.3)
         micro_via_drill: Micro-via drill diameter in mm (default 0.15)
@@ -3954,10 +4059,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--escape-distance",
         type=float,
-        default=3.0,
-        help="Maximum escape trace length in mm for dense IC pads (default: 3.0). "
+        default=4.0,
+        help="Maximum escape trace length in mm for dense IC pads (default: 4.0). "
         "When both straight-line and dog-leg placement fail, extended escape traces "
-        "up to this length are tried to navigate between dense pin fields.",
+        "up to this length are tried to navigate between dense pin fields. The "
+        "default of 4.0mm covers outer-ring pads on 7-row 1.27mm-pitch BGAs whose "
+        "corner-to-clear distance is ~4mm.",
     )
     parser.add_argument(
         "--micro-via",

--- a/tests/test_stitch_bga_outer_ring.py
+++ b/tests/test_stitch_bga_outer_ring.py
@@ -1,0 +1,328 @@
+"""Regression tests for outer-ring BGA GND stitch (issue #2912).
+
+The original failure mode: on board 06's BGA-49 simulator (1.27mm pitch,
+7x7 grid), five outer-ring GND pads (U2.A1, B1, C7, F1, G5) could not
+be stitched because USB 3.0 escape tracks colonised every copper layer
+in a tight band around the perimeter and the extended-escape search
+was both too small (3.0mm) and too narrow (4 cardinal directions).
+
+The fix raises the default escape radius to 4.0mm and adds Strategy 4
+(polar-grid via sampler with layer-aware trace clearance) to
+``calculate_extended_escape_position``.
+
+These tests build a synthetic 7x7 1.27mm-pitch BGA in code, mark the
+outer ring as GND, place inner-layer obstacles at varying clearance
+deficits along three of four escape corridors, and assert that
+``calculate_extended_escape_position`` returns a placement for at least
+4 of the 5 outer-ring corner/edge pads named in the issue.
+"""
+
+from __future__ import annotations
+
+import math
+
+from kicad_tools.cli.stitch_cmd import (
+    PadInfo,
+    TrackSegment,
+    calculate_extended_escape_position,
+)
+
+# BGA layout — matches board 06 / U2 geometry
+BGA_PITCH = 1.27
+BGA_ROWS = 7
+BGA_COLS = 7
+BGA_PAD_SIZE = 0.45
+BGA_CENTER_X = 100.0
+BGA_CENTER_Y = 100.0
+BGA_NET_GND = 5
+BGA_NET_SIG_BASE = 10  # signal nets 10, 11, 12, ...
+
+ROW_LETTERS = "ABCDEFG"
+
+
+def _pad_xy(row_letter: str, col: int) -> tuple[float, float]:
+    """Return the (x, y) of a BGA pad given its row letter and column number."""
+    row_idx = ROW_LETTERS.index(row_letter)
+    px = BGA_CENTER_X + (col - 4) * BGA_PITCH
+    py = BGA_CENTER_Y + (row_idx - 3) * BGA_PITCH
+    return px, py
+
+
+def _make_bga_pads() -> dict[str, PadInfo]:
+    """Build a 7x7 BGA where the outer ring is GND and inner pads are signals."""
+    pads: dict[str, PadInfo] = {}
+    signal_id = 0
+    for row_letter in ROW_LETTERS:
+        for col in range(1, BGA_COLS + 1):
+            px, py = _pad_xy(row_letter, col)
+            row_idx = ROW_LETTERS.index(row_letter)
+            on_outer = row_idx == 0 or row_idx == BGA_ROWS - 1 or col == 1 or col == BGA_COLS
+            if on_outer:
+                net_number = BGA_NET_GND
+                net_name = "GND"
+            else:
+                net_number = BGA_NET_SIG_BASE + signal_id
+                net_name = f"SIG_{signal_id}"
+                signal_id += 1
+            pads[f"{row_letter}{col}"] = PadInfo(
+                reference="U2",
+                pad_number=f"{row_letter}{col}",
+                net_number=net_number,
+                net_name=net_name,
+                x=px,
+                y=py,
+                layer="F.Cu",
+                width=BGA_PAD_SIZE,
+                height=BGA_PAD_SIZE,
+                pad_type="smd",
+            )
+    return pads
+
+
+def _other_net_pads(
+    pads: dict[str, PadInfo], target: PadInfo
+) -> list[tuple[float, float, float, int]]:
+    """Return all pads other than ``target`` formatted for clearance checks."""
+    out: list[tuple[float, float, float, int]] = []
+    for p in pads.values():
+        if p is target:
+            continue
+        out.append((p.x, p.y, max(p.width, p.height) / 2, p.net_number))
+    return out
+
+
+def _obstacle_track(
+    pad: PadInfo,
+    direction: tuple[float, float],
+    gap_mm: float,
+    layer: str,
+    net_number: int,
+    width: float = 0.15,
+    length: float = 6.0,
+) -> TrackSegment:
+    """Build a track segment that grazes the pad in the given direction.
+
+    The track is placed so the closest distance from pad center to track
+    centerline is ``pad_radius + clearance + gap_mm`` (gap_mm negative
+    means the track sits inside the required clearance zone, simulating
+    a tight escape corridor).
+    """
+    dx, dy = direction
+    # Normalise direction
+    n = math.hypot(dx, dy) or 1.0
+    dx /= n
+    dy /= n
+
+    pad_radius = max(pad.width, pad.height) / 2
+    clearance = 0.2  # default stitch clearance
+    via_radius = 0.45 / 2
+
+    # offset from pad center to track centerline along the direction normal
+    offset = pad_radius + via_radius + clearance + gap_mm
+    # The track runs PERPENDICULAR to the direction, centered at the offset
+    perp = (-dy, dx)
+    cx = pad.x + dx * offset
+    cy = pad.y + dy * offset
+    sx = cx + perp[0] * length / 2
+    sy = cy + perp[1] * length / 2
+    ex = cx - perp[0] * length / 2
+    ey = cy - perp[1] * length / 2
+    return TrackSegment(
+        start_x=sx,
+        start_y=sy,
+        end_x=ex,
+        end_y=ey,
+        width=width,
+        layer=layer,
+        net_number=net_number,
+    )
+
+
+def _build_obstacles_for_corner(
+    pad: PadInfo, gap_mm: float, layers: list[str]
+) -> list[TrackSegment]:
+    """Place obstacle tracks on three of four cardinal escape corridors.
+
+    Mirrors the board-06 failure mode: signal escape tracks colonise
+    every copper layer in a tight band, leaving only diagonal/non-cardinal
+    escape paths free.
+    """
+    # Place obstacles north, south, east on the requested layers.  West is
+    # left clear so a layer-aware diagonal/polar search can still find an
+    # opening.
+    directions = [(0.0, -1.0), (0.0, 1.0), (1.0, 0.0)]  # N, S, E
+    tracks: list[TrackSegment] = []
+    for i, dir_v in enumerate(directions):
+        layer = layers[i % len(layers)]
+        net = 100 + i
+        tracks.append(_obstacle_track(pad, dir_v, gap_mm, layer, net))
+    return tracks
+
+
+# The 5 named pads from the issue
+NAMED_PADS = ["A1", "B1", "C7", "F1", "G5"]
+
+
+def test_synthetic_bga_outer_ring_stitches_at_least_4_of_5() -> None:
+    """The fix must place at least 4 of 5 named outer-ring pads.
+
+    Obstacles span In1.Cu, In2.Cu, and B.Cu at gap=-0.05 to -0.30mm,
+    simulating the corridor congestion observed on board 06.
+    """
+    pads = _make_bga_pads()
+    via_size = 0.45
+    clearance = 0.2
+    offset = 0.5
+    trace_width = 0.2
+
+    # Different gap deficits for different pads — match the issue diagnostic
+    pad_gaps = {
+        "A1": -0.26,  # board 06: In1.Cu gap=-0.26
+        "B1": -0.30,  # board 06: In2.Cu gap=-0.32 (clamp to test envelope)
+        "C7": -0.05,  # board 06: B.Cu gap=-0.06 (tight)
+        "F1": -0.28,  # board 06: In1.Cu gap=-0.30 (clamp)
+        "G5": -0.05,  # board 06: B.Cu gap=-0.06 (tight)
+    }
+    pad_layers = {
+        "A1": ["In1.Cu", "In2.Cu", "F.Cu"],
+        "B1": ["In2.Cu", "In1.Cu", "B.Cu"],
+        "C7": ["B.Cu", "In1.Cu", "In2.Cu"],
+        "F1": ["In1.Cu", "In2.Cu", "B.Cu"],
+        "G5": ["B.Cu", "In2.Cu", "In1.Cu"],
+    }
+
+    placements: dict[str, tuple[float, float, list[tuple[float, float]]] | None] = {}
+
+    for name in NAMED_PADS:
+        pad = pads[name]
+        obstacles = _build_obstacles_for_corner(pad, pad_gaps[name], pad_layers[name])
+        result = calculate_extended_escape_position(
+            pad,
+            offset=offset,
+            via_size=via_size,
+            existing_vias=[],
+            clearance=clearance,
+            escape_distance=4.0,  # new default
+            other_net_tracks=obstacles,
+            other_net_vias=[],
+            other_net_pads=_other_net_pads(pads, pad),
+            trace_width=trace_width,
+        )
+        placements[name] = result
+
+    placed = [k for k, v in placements.items() if v is not None]
+    assert len(placed) >= 4, (
+        f"Expected at least 4 of 5 named pads to stitch, got {len(placed)}: {placements}"
+    )
+
+
+def test_synthetic_bga_outer_ring_pads_have_clearance_valid_vias() -> None:
+    """For each placed via, confirm it's actually clear of the obstacles.
+
+    Prevents the search from returning a placement that violates the
+    clearance budget — a regression in ``_check_via_position`` would
+    return phantom placements that DRC would then flag.
+    """
+    pads = _make_bga_pads()
+    via_size = 0.45
+    via_radius = via_size / 2
+    clearance = 0.2
+    offset = 0.5
+    trace_width = 0.2
+
+    for name in NAMED_PADS:
+        pad = pads[name]
+        obstacles = _build_obstacles_for_corner(pad, -0.20, ["In1.Cu", "In2.Cu", "B.Cu"])
+        result = calculate_extended_escape_position(
+            pad,
+            offset=offset,
+            via_size=via_size,
+            existing_vias=[],
+            clearance=clearance,
+            escape_distance=4.0,
+            other_net_tracks=obstacles,
+            other_net_vias=[],
+            other_net_pads=_other_net_pads(pads, pad),
+            trace_width=trace_width,
+        )
+        if result is None:
+            continue
+        via_x, via_y, _waypoints = result
+
+        # Confirm the via does not collide with the obstacle tracks
+        for seg in obstacles:
+            # Closest distance from via center to track segment
+            dx = seg.end_x - seg.start_x
+            dy = seg.end_y - seg.start_y
+            seg_len_sq = dx * dx + dy * dy
+            if seg_len_sq < 1e-12:
+                dist = math.hypot(via_x - seg.start_x, via_y - seg.start_y)
+            else:
+                t = max(
+                    0.0,
+                    min(
+                        1.0,
+                        ((via_x - seg.start_x) * dx + (via_y - seg.start_y) * dy) / seg_len_sq,
+                    ),
+                )
+                cx = seg.start_x + t * dx
+                cy = seg.start_y + t * dy
+                dist = math.hypot(via_x - cx, via_y - cy)
+            min_required = via_radius + seg.width / 2 + clearance
+            assert dist >= min_required - 1e-6, (
+                f"Pad {name}: via at ({via_x:.3f}, {via_y:.3f}) too close to "
+                f"obstacle on {seg.layer} (dist={dist:.4f}, need={min_required:.4f})"
+            )
+
+        # Confirm the via does not collide with neighboring pads
+        for other in pads.values():
+            if other is pad:
+                continue
+            other_radius = max(other.width, other.height) / 2
+            dist = math.hypot(other.x - via_x, other.y - via_y)
+            min_required = via_radius + other_radius + clearance
+            assert dist >= min_required - 1e-6, (
+                f"Pad {name}: via at ({via_x:.3f}, {via_y:.3f}) collides with "
+                f"pad {other.reference}.{other.pad_number} (dist={dist:.4f}, "
+                f"need={min_required:.4f})"
+            )
+
+
+def test_clear_bga_pad_still_uses_short_escape() -> None:
+    """A BGA outer-ring pad with no obstacles must still stitch via the
+    first available strategy.  Guards against the new polar search
+    short-circuiting earlier strategies in the no-obstacle case.
+    """
+    pads = _make_bga_pads()
+    pad = pads["A1"]
+
+    result = calculate_extended_escape_position(
+        pad,
+        offset=0.5,
+        via_size=0.45,
+        existing_vias=[],
+        clearance=0.2,
+        escape_distance=4.0,
+        other_net_tracks=[],  # No obstacles
+        other_net_vias=[],
+        other_net_pads=_other_net_pads(pads, pad),
+        trace_width=0.2,
+    )
+    assert result is not None, "Open BGA outer-ring pad must stitch"
+    via_x, via_y, _wp = result
+    radius = math.hypot(via_x - pad.x, via_y - pad.y)
+    # Should not need the full 4mm when no obstacles — earlier strategies
+    # should find a closer location.
+    assert radius <= 3.0, f"Open pad placed via at unexpectedly long distance {radius:.3f}mm"
+
+
+def test_escape_distance_default_is_4mm() -> None:
+    """Lock the default to 4.0mm — board 06 requires this to clear the BGA
+    corner-to-clear distance (~4mm for 7-row 1.27mm-pitch).
+    """
+    import inspect
+
+    sig = inspect.signature(calculate_extended_escape_position)
+    assert sig.parameters["escape_distance"].default == 4.0, (
+        "Default escape_distance must be 4.0mm (issue #2912)"
+    )


### PR DESCRIPTION
Closes #2912.

## Root cause

For 7-row 1.27mm-pitch BGAs the corner-to-clear distance is ~4mm, so the
3mm extended-escape radius could not reach the open board area when
inner-layer signal escape tracks colonised the perimeter band on every
copper layer (the board-06 U2 BGA failure mode in issue #2912).

A secondary contributor: the existing L/Z escape strategies only search 4
cardinal directions, and their trace clearance check treats tracks on
every copper layer as obstacles even though the pad-to-via trace sits on
the pad's layer.  Five outer-ring GND pads (`U2.A1`, `B1`, `C7`, `F1`,
`G5`) hit both gaps and could not be stitched.

## Changes

1. Default `--escape-distance` raised `3.0 → 4.0`mm in both the inner
   helper (`calculate_extended_escape_position`) and the outer
   `run_stitch`/CLI flag.  Help text and docstrings updated.

2. `axial_distances` extended to 5.0mm and `breakout_offsets` gains a
   `k=4` ring so the existing L/Z strategies can use the wider envelope.
   `_check_via_position` still rejects any placement violating clearance,
   so widening the search cannot create new collisions.

3. **Strategy 4**: a polar-grid via sampler with **layer-aware**
   2-segment routing.  Samples 16 angular steps × progressive radii and
   filters trace obstacles to the pad's own layer (vias still consider
   all layers — they span F.Cu through B.Cu).

## Before / after — board 06

```
Before (main):   92 stitching vias / 5 skipped (U2.A1, B1, C7, F1, G5)
After (this PR): 96 stitching vias / 0 skipped
```

All 5 named pads from the issue now stitch.  `kct net-status` GND
unconnected-pad count drops from **26 → 22**.

## Fleet-wide deltas (boards 02-07)

| Board | Before | After | Notes |
|-------|--------|-------|-------|
| 02 charlieplex | 3 / 0 skipped | 3 / 0 | unchanged |
| 03 usb-joystick | 25 / 5 skipped | 29 / 1 | improved |
| 04 stm32 | 14 / 3 skipped | 14 / 3 | unchanged |
| 05 bldc | 28 / 12 skipped | 29 / 11 | improved |
| 06 diffpair | **92 / 5** | **96 / 0** | **target** |
| 07 matchgroup | 114 / 4 skipped | 118 / 0 | improved |

No board regresses.

## DRC

Zero new clearance violations introduced on board 06 — the 9 pre-existing
clearance errors are byte-identical before and after.  The 8 new
`drill_out_of_range` / `via_diameter` warnings are the same category as
the 116 pre-existing ones (stitch via 0.45mm > board-06 setup constraint
0.5mm; pre-existing limitation of board 06 setup, unrelated to this PR).

## Test plan

- [x] `uv run pytest tests/test_stitch_bga_outer_ring.py tests/test_stitch_cmd.py tests/test_stitch_mfr.py tests/test_thermal_stitch.py tests/test_stitch_via_halo.py tests/test_build_stitch_step.py` — 287 passed
- [x] `kct stitch boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb --net GND` — 96/0 skipped (was 92/5)
- [x] Boards 02-07 stitch outcomes verified — no regressions
- [x] `kct drc` on board 06 after stitch — no new clearance violations
- [x] `kct net-status` board 06 GND drops from 26 to 22 unconnected pads
- [x] `ruff check` and targeted-scope `ruff format` clean on changed files

## Acceptance criteria (issue #2912)

- [x] `kct stitch` connects 5/5 currently-skipped U2 BGA perimeter pads (target was >= 4)
- [x] No regression on existing stitch tests (287/287 pass)
- [x] Boards 02-05, 07 fleet-status parity (boards 03/05/07 improved; 02/04 unchanged)
- [x] New `tests/test_stitch_bga_outer_ring.py` exercising synthetic BGA-49 outer ring

🤖 Generated with [Claude Code](https://claude.com/claude-code)