### PR TITLE
fix(design): MCUCoreStrategy places crystal on XTAL-pin edge (closes #2923)

### DIFF
--- a/src/kicad_tools/design/strategies.py
+++ b/src/kicad_tools/design/strategies.py
@@ -21,6 +21,7 @@ Example::
 from __future__ import annotations
 
 import math
+import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -29,6 +30,16 @@ from kicad_tools.design.subsystems import OptimizationGoal, SubsystemType
 
 if TYPE_CHECKING:
     from kicad_tools.schema.pcb import PCB
+
+# Regex pattern matching net names that indicate a crystal/oscillator pin
+# on an MCU footprint. Matches XTAL, XTAL1/XTAL2, XTALIN/XTALOUT, OSC_IN,
+# OSC_OUT, OSC32_IN, OSC32_OUT etc. Case-insensitive. Designed to be
+# permissive enough to catch common STM32, AVR, PIC and TI naming
+# conventions without false positives like "FAST_GPIO".
+_XTAL_NET_PATTERN = re.compile(
+    r"(?:^|[^A-Z0-9])(?:XTAL(?:IN|OUT|\d?)|OSC(?:32)?(?:_?IN|_?OUT|\d?))(?:$|[^A-Z0-9])",
+    re.IGNORECASE,
+)
 
 
 @dataclass
@@ -287,6 +298,96 @@ class MCUCoreStrategy(PlacementStrategy):
     def supported_patterns(self) -> list[str]:
         return ["mcu_bypass", "crystal", "reset"]
 
+    @staticmethod
+    def _xtal_edge_angle(pcb: PCB, mcu_ref: str) -> float | None:
+        """Determine the edge of an MCU package that carries XTAL/OSC pads.
+
+        Inspects the MCU footprint, finds all pads whose ``net_name``
+        matches a crystal-oscillator naming pattern (XTAL, XTAL1/2,
+        XTALIN/OUT, OSC_IN/OUT, OSC32_IN/OUT, etc.), computes their
+        centroid in the world frame (applying the footprint's rotation),
+        and snaps the centroid direction to the nearest cardinal edge.
+
+        Args:
+            pcb: PCB containing the footprint.
+            mcu_ref: Reference designator of the MCU (e.g. ``"U1"``).
+
+        Returns:
+            One of {0.0, 90.0, 180.0, 270.0} in the same screen-Y angle
+            convention used by :meth:`_calculate_position`
+            (0=east, 90=south, 180=west, 270=north). Returns ``None`` if
+            the footprint cannot be located, has no pads, or has no
+            pads whose net names match the XTAL/OSC pattern. Returning
+            ``None`` signals the caller to fall back to the legacy
+            default (270.0).
+        """
+        # Locate the footprint in the PCB. We tolerate missing pcb
+        # attributes / empty PCBs so test harnesses that pass a minimal
+        # stub PCB continue to work (the strategy was already permissive
+        # — see existing tests in tests/test_design.py).
+        footprints = getattr(pcb, "footprints", None)
+        if not footprints:
+            return None
+
+        mcu_fp = None
+        for fp in footprints:
+            if getattr(fp, "reference", None) == mcu_ref:
+                mcu_fp = fp
+                break
+        if mcu_fp is None:
+            return None
+
+        pads = getattr(mcu_fp, "pads", None) or []
+        if not pads:
+            return None
+
+        # Collect pad-local coordinates of XTAL/OSC pads.
+        xtal_offsets: list[tuple[float, float]] = []
+        for pad in pads:
+            net_name = getattr(pad, "net_name", "") or ""
+            if not net_name:
+                continue
+            if _XTAL_NET_PATTERN.search(net_name):
+                px, py = pad.position
+                xtal_offsets.append((float(px), float(py)))
+
+        if not xtal_offsets:
+            return None
+
+        # Rotate pad-local offsets into the world frame using the
+        # footprint's rotation. KiCad rotation is positive CCW; the
+        # standard 2D rotation matrix applies directly (no negation).
+        # This matches PCB.get_pad_position and the router's
+        # adaptive._add_component_to_router transform.
+        rotation_deg = float(getattr(mcu_fp, "rotation", 0.0) or 0.0)
+        rot_rad = math.radians(rotation_deg)
+        cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
+
+        sum_x = 0.0
+        sum_y = 0.0
+        for px, py in xtal_offsets:
+            rx = px * cos_r - py * sin_r
+            ry = px * sin_r + py * cos_r
+            sum_x += rx
+            sum_y += ry
+
+        n = len(xtal_offsets)
+        cx = sum_x / n
+        cy = sum_y / n
+
+        # Snap the centroid direction to the nearest cardinal edge.
+        # Note: screen-Y convention (Y grows downward), so
+        # 0=east(+x), 90=south(+y), 180=west(-x), 270=north(-y).
+        # If the centroid is essentially at the MCU centre (extremely
+        # unlikely but possible for a 1-pad XTAL or a fully symmetric
+        # placement), fall back to the legacy default.
+        if abs(cx) < 1e-9 and abs(cy) < 1e-9:
+            return None
+
+        if abs(cx) >= abs(cy):
+            return 0.0 if cx > 0 else 180.0
+        return 90.0 if cy > 0 else 270.0
+
     def compute_placements(
         self,
         components: list[str],
@@ -356,22 +457,44 @@ class MCUCoreStrategy(PlacementStrategy):
 
         # Place crystal (typically near OSC pins on one side)
         if crystal:
-            pos = self._calculate_position(anchor_position, 5.0, 270.0)  # Above MCU
+            # Inspect the MCU footprint's XTAL/OSC pads to choose a side.
+            # Falls back to 270 deg ("above MCU" in screen-Y convention)
+            # when the footprint has no XTAL-named pins or when the MCU
+            # can't be located in the PCB.
+            xtal_angle = self._xtal_edge_angle(pcb, anchor)
+            crystal_angle = xtal_angle if xtal_angle is not None else 270.0
+            pos = self._calculate_position(anchor_position, 5.0, crystal_angle)
+            rationale = (
+                f"Crystal placed on MCU XTAL-pin edge (angle {crystal_angle:.0f} deg)"
+                if xtal_angle is not None
+                else "Crystal close to OSC pins (fallback: no XTAL pads found)"
+            )
             placements[crystal] = Placement(
                 ref=crystal,
                 x=pos[0],
                 y=pos[1],
                 rotation=0.0,
-                rationale="Crystal close to OSC pins",
+                rationale=rationale,
             )
 
-            # Place load caps near crystal
+            # Place load caps near crystal. The two caps straddle the
+            # crystal along the axis perpendicular to the MCU-to-crystal
+            # vector (so each load cap sits adjacent to one crystal
+            # pad/MCU XTAL pin) and are nudged 1.5mm back toward the MCU
+            # so their GND pads sit closest to the MCU ground.
+            perp_rad = math.radians(crystal_angle + 90.0)
+            perp_dx = math.cos(perp_rad)
+            perp_dy = math.sin(perp_rad)
+            # Unit vector from crystal back toward MCU centre (= -outward).
+            inward_rad = math.radians(crystal_angle + 180.0)
+            inward_dx = math.cos(inward_rad)
+            inward_dy = math.sin(inward_rad)
             for i, cap in enumerate(load_caps):
                 offset = 1.5 if i == 0 else -1.5
                 placements[cap] = Placement(
                     ref=cap,
-                    x=pos[0] + offset,
-                    y=pos[1] + 1.5,
+                    x=pos[0] + offset * perp_dx + 1.5 * inward_dx,
+                    y=pos[1] + offset * perp_dy + 1.5 * inward_dy,
                     rotation=0.0,
                     rationale="Load capacitor near crystal",
                 )

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,0 +1,513 @@
+"""Tests for design strategies — focused on MCUCoreStrategy crystal placement.
+
+These tests exercise the XTAL-pin-side introspection added in #2923 so
+that ``MCUCoreStrategy.compute_placements`` places a crystal on whichever
+package edge actually carries the XTAL/OSC pads. The previous behaviour
+hardcoded 270 deg ("above MCU") regardless of package geometry, which
+broke routing whenever the MCU's XTAL pins were not on the north edge of
+the package (e.g. TQFP-32 XTAL pins on the west edge).
+
+The tests build synthetic MCU footprints (no real KiCad library files
+needed) and assert that the crystal lands on the correct cardinal edge
+under each (XTAL-edge x footprint-rotation) combination, and that the
+fallback to 270 deg still triggers when no XTAL pads are present.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+import pytest
+
+from kicad_tools.design.strategies import _XTAL_NET_PATTERN, MCUCoreStrategy
+
+# ---------------------------------------------------------------------------
+# Minimal mock objects
+#
+# We mock just enough of the Pad / Footprint / PCB surface to drive
+# MCUCoreStrategy._xtal_edge_angle. The real schema classes carry many
+# fields the strategy never touches (sexp_node, board_origin, layers, ...)
+# so a focused mock is safer and faster than constructing real instances.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MockPad:
+    number: str
+    position: tuple[float, float]
+    net_name: str = ""
+
+
+@dataclass
+class MockFootprint:
+    reference: str
+    position: tuple[float, float] = (0.0, 0.0)
+    rotation: float = 0.0
+    pads: list[MockPad] = field(default_factory=list)
+
+
+@dataclass
+class MockPCB:
+    footprints: list[MockFootprint] = field(default_factory=list)
+
+
+def _make_tqfp32_mcu(
+    xtal_edge: str,
+    rotation: float = 0.0,
+    *,
+    xtal_net_names: tuple[str, str] = ("XTAL1", "XTAL2"),
+    ref: str = "U1",
+    half_size: float = 4.5,
+) -> MockFootprint:
+    """Build a synthetic TQFP-32-ish MCU footprint.
+
+    The TQFP-32 package is a square with 8 pins per edge. We model just
+    enough pads to make a centroid: two XTAL pads on the requested edge
+    plus four "filler" pads with VCC/GND/IO nets on the other three
+    edges (to verify the centroid logic ignores non-XTAL nets).
+
+    Args:
+        xtal_edge: One of {"N", "S", "E", "W"} — the *intended* package
+            edge that carries the XTAL pads (before any footprint
+            rotation is applied). North/South use screen-Y convention
+            (north = negative Y in the local frame).
+        rotation: Footprint rotation in degrees, applied at the package
+            level. Positive CCW (KiCad convention).
+        xtal_net_names: Net names for the two XTAL pads. Vary this in
+            tests to exercise alternate naming (OSC_IN/OSC_OUT etc.).
+        ref: Reference designator.
+        half_size: Half the package side length (mm). XTAL pads sit
+            exactly on the edge at +/- half_size.
+    """
+    edge_offsets = {
+        "N": [(-1.0, -half_size), (1.0, -half_size)],
+        "S": [(-1.0, half_size), (1.0, half_size)],
+        "E": [(half_size, -1.0), (half_size, 1.0)],
+        "W": [(-half_size, -1.0), (-half_size, 1.0)],
+    }
+    if xtal_edge not in edge_offsets:
+        raise ValueError(f"Unknown xtal_edge: {xtal_edge}")
+
+    pads: list[MockPad] = []
+    for i, off in enumerate(edge_offsets[xtal_edge]):
+        pads.append(MockPad(number=str(i + 1), position=off, net_name=xtal_net_names[i]))
+
+    # Add some non-XTAL "noise" pads on the other three edges. These
+    # must not influence the centroid (we filter by net-name pattern).
+    noise_edges = {"N", "S", "E", "W"} - {xtal_edge}
+    noise_nets = ["VCC", "GND", "PA0", "PA1"]
+    for i, noise_edge in enumerate(noise_edges):
+        ox, oy = edge_offsets[noise_edge][0]
+        pads.append(
+            MockPad(
+                number=str(10 + i),
+                position=(ox, oy),
+                net_name=noise_nets[i % len(noise_nets)],
+            )
+        )
+
+    return MockFootprint(reference=ref, position=(0.0, 0.0), rotation=rotation, pads=pads)
+
+
+def _make_pcb_with_mcu(mcu: MockFootprint) -> MockPCB:
+    return MockPCB(footprints=[mcu])
+
+
+# ---------------------------------------------------------------------------
+# Direct tests of _xtal_edge_angle
+# ---------------------------------------------------------------------------
+
+
+class TestXTALEdgeAngleDetection:
+    """Per-edge / per-rotation introspection of XTAL pads."""
+
+    @pytest.mark.parametrize(
+        "xtal_edge,expected_angle",
+        [
+            ("N", 270.0),  # north => angle 270 (screen-Y: -y)
+            ("S", 90.0),  # south => angle 90 (+y)
+            ("E", 0.0),  # east  => angle 0 (+x)
+            ("W", 180.0),  # west  => angle 180 (-x)
+        ],
+    )
+    def test_xtal_edge_no_rotation(self, xtal_edge: str, expected_angle: float):
+        """Each cardinal XTAL-pad edge produces the matching angle."""
+        mcu = _make_tqfp32_mcu(xtal_edge=xtal_edge, rotation=0.0)
+        pcb = _make_pcb_with_mcu(mcu)
+        angle = MCUCoreStrategy._xtal_edge_angle(pcb, "U1")
+        assert angle == expected_angle
+
+    @pytest.mark.parametrize(
+        "xtal_edge,rotation,expected_angle",
+        [
+            # North XTAL pads (-y locally) rotated 90 deg CCW =>
+            # rotated to +x (east). Confirms rotation-awareness.
+            ("N", 90.0, 0.0),
+            # West XTAL pads (-x locally) rotated 90 deg CCW => -y (north).
+            ("W", 90.0, 270.0),
+            # West rotated 180 deg => east.
+            ("W", 180.0, 0.0),
+            # East rotated 270 deg => north (-y).
+            ("E", 270.0, 270.0),
+            # West rotated 90 deg CW (= -90 / 270 deg CCW) => south (+y).
+            ("W", 270.0, 90.0),
+        ],
+    )
+    def test_xtal_edge_with_rotation(self, xtal_edge: str, rotation: float, expected_angle: float):
+        """Footprint rotation moves XTAL pads to a different world-frame edge.
+
+        TQFP-32 packages have XTAL on the west edge. If the MCU is
+        rotated 90 deg CCW, the XTAL pads end up on the south edge in the
+        world frame. The placer must follow.
+        """
+        mcu = _make_tqfp32_mcu(xtal_edge=xtal_edge, rotation=rotation)
+        pcb = _make_pcb_with_mcu(mcu)
+        angle = MCUCoreStrategy._xtal_edge_angle(pcb, "U1")
+        assert angle == expected_angle
+
+    def test_osc_in_out_naming(self):
+        """STM32-style OSC_IN/OSC_OUT pads are detected, not just XTAL*."""
+        mcu = _make_tqfp32_mcu(
+            xtal_edge="W",
+            rotation=0.0,
+            xtal_net_names=("OSC_IN", "OSC_OUT"),
+        )
+        pcb = _make_pcb_with_mcu(mcu)
+        angle = MCUCoreStrategy._xtal_edge_angle(pcb, "U1")
+        assert angle == 180.0
+
+    def test_osc32_naming(self):
+        """STM32-style OSC32_IN/OSC32_OUT (LSE) pads are detected."""
+        mcu = _make_tqfp32_mcu(
+            xtal_edge="E",
+            rotation=0.0,
+            xtal_net_names=("OSC32_IN", "OSC32_OUT"),
+        )
+        pcb = _make_pcb_with_mcu(mcu)
+        angle = MCUCoreStrategy._xtal_edge_angle(pcb, "U1")
+        assert angle == 0.0
+
+    def test_hierarchical_net_names(self):
+        """Hierarchical net paths like ``mcu/XTAL1`` are also detected."""
+        mcu = _make_tqfp32_mcu(
+            xtal_edge="N",
+            rotation=0.0,
+            xtal_net_names=("mcu/XTAL1", "mcu/XTAL2"),
+        )
+        pcb = _make_pcb_with_mcu(mcu)
+        angle = MCUCoreStrategy._xtal_edge_angle(pcb, "U1")
+        assert angle == 270.0
+
+    def test_no_xtal_pads_returns_none(self):
+        """Footprint without any XTAL/OSC-named pads returns None (fallback)."""
+        mcu = MockFootprint(
+            reference="U1",
+            position=(0.0, 0.0),
+            rotation=0.0,
+            pads=[
+                MockPad(number="1", position=(-4.5, 0.0), net_name="VCC"),
+                MockPad(number="2", position=(4.5, 0.0), net_name="GND"),
+                MockPad(number="3", position=(0.0, -4.5), net_name="PA0"),
+            ],
+        )
+        pcb = _make_pcb_with_mcu(mcu)
+        angle = MCUCoreStrategy._xtal_edge_angle(pcb, "U1")
+        assert angle is None
+
+    def test_missing_mcu_returns_none(self):
+        """When the MCU reference can't be found in the PCB, returns None."""
+        pcb = MockPCB(footprints=[])
+        angle = MCUCoreStrategy._xtal_edge_angle(pcb, "U99")
+        assert angle is None
+
+    def test_missing_pads_returns_none(self):
+        """Footprint with no pads at all returns None."""
+        mcu = MockFootprint(reference="U1", pads=[])
+        pcb = _make_pcb_with_mcu(mcu)
+        angle = MCUCoreStrategy._xtal_edge_angle(pcb, "U1")
+        assert angle is None
+
+    def test_pcb_without_footprints_attr(self):
+        """A PCB-like object without a ``footprints`` attribute is tolerated."""
+
+        class BarePCB:
+            pass
+
+        angle = MCUCoreStrategy._xtal_edge_angle(BarePCB(), "U1")
+        assert angle is None
+
+    def test_xtal_pad_with_empty_net_name_ignored(self):
+        """Pads with empty net_name are ignored even if numbered like XTAL pins."""
+        mcu = MockFootprint(
+            reference="U1",
+            pads=[
+                MockPad(number="1", position=(-4.5, 0.0), net_name=""),
+                MockPad(number="2", position=(4.5, 0.0), net_name=""),
+            ],
+        )
+        pcb = _make_pcb_with_mcu(mcu)
+        angle = MCUCoreStrategy._xtal_edge_angle(pcb, "U1")
+        assert angle is None
+
+    def test_centroid_at_origin_returns_none(self):
+        """If XTAL pads' centroid lands on the MCU centre, fall back to default.
+
+        This catches degenerate inputs like a single XTAL pad placed at
+        (0, 0) or two pads exactly symmetric about the centre.
+        """
+        mcu = MockFootprint(
+            reference="U1",
+            pads=[
+                MockPad(number="1", position=(-2.0, 0.0), net_name="XTAL1"),
+                MockPad(number="2", position=(2.0, 0.0), net_name="XTAL2"),
+            ],
+        )
+        pcb = _make_pcb_with_mcu(mcu)
+        angle = MCUCoreStrategy._xtal_edge_angle(pcb, "U1")
+        assert angle is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: compute_placements integration
+# ---------------------------------------------------------------------------
+
+
+class TestMCUCoreStrategyCrystalPlacement:
+    """End-to-end integration via ``compute_placements``."""
+
+    @pytest.mark.parametrize(
+        "xtal_edge,expected_dx,expected_dy",
+        [
+            # Crystal sits 5mm from the MCU centre on the XTAL-pad edge.
+            ("N", 0.0, -5.0),
+            ("S", 0.0, 5.0),
+            ("E", 5.0, 0.0),
+            ("W", -5.0, 0.0),
+        ],
+    )
+    def test_crystal_placed_on_xtal_edge(
+        self, xtal_edge: str, expected_dx: float, expected_dy: float
+    ):
+        """Crystal lands on the MCU edge whose pads carry XTAL nets."""
+        mcu = _make_tqfp32_mcu(xtal_edge=xtal_edge, rotation=0.0)
+        pcb = _make_pcb_with_mcu(mcu)
+        strategy = MCUCoreStrategy()
+
+        anchor_pos = (50.0, 30.0)
+        placements = strategy.compute_placements(
+            components=["U1", "Y1", "C1", "C2"],
+            anchor="U1",
+            anchor_position=anchor_pos,
+            pcb=pcb,
+        )
+
+        assert "Y1" in placements
+        crystal = placements["Y1"]
+        assert math.isclose(crystal.x - anchor_pos[0], expected_dx, abs_tol=1e-6)
+        assert math.isclose(crystal.y - anchor_pos[1], expected_dy, abs_tol=1e-6)
+
+    def test_crystal_follows_mcu_rotation(self):
+        """Rotating the MCU 90 deg CCW moves XTAL pads from west to north.
+
+        TQFP-32 XTAL pads are natively on the west edge (local -x). The
+        standard 2D rotation matrix R(theta) with theta = +90 deg maps
+        the vector (-1, 0) to (0, -1). In screen-Y conventions that's
+        "north" (angle 270 deg in our 0=east, 90=south, 180=west,
+        270=north scheme). The crystal must follow.
+        """
+        mcu = _make_tqfp32_mcu(xtal_edge="W", rotation=90.0)
+        pcb = _make_pcb_with_mcu(mcu)
+        strategy = MCUCoreStrategy()
+
+        anchor_pos = (50.0, 30.0)
+        placements = strategy.compute_placements(
+            components=["U1", "Y1"],
+            anchor="U1",
+            anchor_position=anchor_pos,
+            pcb=pcb,
+        )
+
+        crystal = placements["Y1"]
+        dx = crystal.x - anchor_pos[0]
+        dy = crystal.y - anchor_pos[1]
+        # Distance is 5.0 mm and the crystal lies on a cardinal axis.
+        assert math.isclose(math.hypot(dx, dy), 5.0, abs_tol=1e-6)
+        # West edge rotated 90 deg CCW => north edge (angle 270 deg).
+        # Position vector = 5 * (cos(270), sin(270)) = (0, -5).
+        assert math.isclose(dx, 0.0, abs_tol=1e-6)
+        assert math.isclose(dy, -5.0, abs_tol=1e-6)
+
+    def test_crystal_fallback_when_no_xtal_pads(self):
+        """When MCU has no XTAL pads, fall back to 270 deg (legacy behaviour).
+
+        This preserves backwards compatibility for callers (existing
+        boards, FPGAs without crystals, MCUs whose pads simply aren't
+        net-named yet, etc.). No warning is emitted — silent fallback.
+        """
+        mcu_no_xtal = MockFootprint(
+            reference="U1",
+            pads=[
+                MockPad(number="1", position=(-4.5, 0.0), net_name="VCC"),
+                MockPad(number="2", position=(4.5, 0.0), net_name="GND"),
+            ],
+        )
+        pcb = _make_pcb_with_mcu(mcu_no_xtal)
+        strategy = MCUCoreStrategy()
+
+        anchor_pos = (50.0, 30.0)
+        placements = strategy.compute_placements(
+            components=["U1", "Y1"],
+            anchor="U1",
+            anchor_position=anchor_pos,
+            pcb=pcb,
+        )
+
+        crystal = placements["Y1"]
+        # Legacy 270 deg = above MCU (screen-Y: -y) at distance 5mm.
+        assert math.isclose(crystal.x - anchor_pos[0], 0.0, abs_tol=1e-6)
+        assert math.isclose(crystal.y - anchor_pos[1], -5.0, abs_tol=1e-6)
+
+    def test_crystal_fallback_when_no_pcb_context(self):
+        """When pcb has no footprints, fall back to 270 deg gracefully.
+
+        This is the path taken by the original ``MockPCB`` style stubs
+        in ``tests/test_design.py`` and the public API contract for
+        callers who don't populate footprints before computing.
+        """
+        empty_pcb = MockPCB(footprints=[])
+        strategy = MCUCoreStrategy()
+
+        anchor_pos = (50.0, 30.0)
+        placements = strategy.compute_placements(
+            components=["U1", "Y1"],
+            anchor="U1",
+            anchor_position=anchor_pos,
+            pcb=empty_pcb,
+        )
+
+        crystal = placements["Y1"]
+        assert math.isclose(crystal.x - anchor_pos[0], 0.0, abs_tol=1e-6)
+        assert math.isclose(crystal.y - anchor_pos[1], -5.0, abs_tol=1e-6)
+
+    def test_load_caps_straddle_crystal_perpendicular_to_mcu_vector(self):
+        """Load caps sit perpendicular to the MCU-to-crystal vector.
+
+        For an east-edge XTAL, the MCU-to-crystal direction is +x, so
+        the two caps should straddle the crystal along the Y axis (with
+        a small inward nudge along -x toward the MCU).
+        """
+        mcu = _make_tqfp32_mcu(xtal_edge="E", rotation=0.0)
+        pcb = _make_pcb_with_mcu(mcu)
+        strategy = MCUCoreStrategy()
+
+        anchor_pos = (50.0, 30.0)
+        # Classification: Y1 comes before any "C" -> the first two
+        # caps after the crystal become load caps. We pass C0, C1 as
+        # the load caps.
+        placements = strategy.compute_placements(
+            components=["U1", "Y1", "C0", "C1"],
+            anchor="U1",
+            anchor_position=anchor_pos,
+            pcb=pcb,
+        )
+
+        crystal = placements["Y1"]
+        c0 = placements["C0"]
+        c1 = placements["C1"]
+
+        # Both load caps share the same x: crystal.x - 1.5 (nudged back
+        # toward the MCU along -x, the inward direction relative to
+        # the east-edge crystal).
+        assert math.isclose(c0.x, crystal.x - 1.5, abs_tol=1e-6)
+        assert math.isclose(c1.x, crystal.x - 1.5, abs_tol=1e-6)
+        # They straddle the crystal along Y: one at +1.5, the other -1.5.
+        ys = sorted([c0.y, c1.y])
+        assert math.isclose(ys[0], crystal.y - 1.5, abs_tol=1e-6)
+        assert math.isclose(ys[1], crystal.y + 1.5, abs_tol=1e-6)
+
+    def test_load_caps_preserve_legacy_geometry_in_fallback(self):
+        """When the placer falls back to 270 deg, load caps match legacy code.
+
+        Regression guard: the pre-fix load-cap layout was caps at
+        ``(crystal_x ± 1.5, crystal_y + 1.5)``. Confirm the new
+        perpendicular-axis code reproduces that exact placement when
+        the crystal is in the legacy 270 deg position.
+        """
+        mcu_no_xtal = MockFootprint(reference="U1", pads=[])
+        pcb = _make_pcb_with_mcu(mcu_no_xtal)
+        strategy = MCUCoreStrategy()
+
+        anchor_pos = (50.0, 30.0)
+        placements = strategy.compute_placements(
+            components=["U1", "Y1", "C0", "C1"],
+            anchor="U1",
+            anchor_position=anchor_pos,
+            pcb=pcb,
+        )
+
+        crystal = placements["Y1"]
+        c0 = placements["C0"]
+        c1 = placements["C1"]
+
+        # Same y for both caps (legacy): crystal.y + 1.5 (south of
+        # crystal, which in screen-Y means "back toward the MCU" when
+        # the crystal is on the 270 deg north side).
+        assert math.isclose(c0.y, crystal.y + 1.5, abs_tol=1e-6)
+        assert math.isclose(c1.y, crystal.y + 1.5, abs_tol=1e-6)
+        # X coords straddle: ± 1.5.
+        xs = sorted([c0.x, c1.x])
+        assert math.isclose(xs[0], crystal.x - 1.5, abs_tol=1e-6)
+        assert math.isclose(xs[1], crystal.x + 1.5, abs_tol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Net-name pattern unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestXTALNetPattern:
+    """Sanity-check the regex used to identify XTAL/OSC pad nets."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "XTAL",
+            "XTAL1",
+            "XTAL2",
+            "XTALIN",
+            "XTALOUT",
+            "OSC_IN",
+            "OSC_OUT",
+            "OSC32_IN",
+            "OSC32_OUT",
+            "OSC1",
+            "OSC2",
+            "xtal1",  # case-insensitive
+            "/XTAL1",  # leading slash (hierarchical net)
+            "mcu/XTAL2",  # hierarchical prefix
+        ],
+    )
+    def test_matches_xtal_names(self, name: str):
+        assert _XTAL_NET_PATTERN.search(name)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "VCC",
+            "GND",
+            "SCK",
+            "MOSI",
+            "MISO",
+            "FAST_GPIO",
+            "NET_42",
+            "LED_OUT",
+            "RESET",
+            # "OSCILLOSCOPE_PROBE",  # would falsely match "OSC" prefix —
+            # but our pattern requires a word boundary or non-alphanumeric
+            # *after* the OSC token, so "OSCILLO..." should NOT match.
+            "OSCILLOSCOPE_PROBE",
+        ],
+    )
+    def test_skips_non_xtal_names(self, name: str):
+        assert not _XTAL_NET_PATTERN.search(name)


### PR DESCRIPTION
## Summary

Replace the hardcoded 270 deg (\"above MCU\") crystal angle in `MCUCoreStrategy.compute_placements` (`src/kicad_tools/design/strategies.py:357-366`) with an introspection-driven placer that inspects the MCU footprint's XTAL/OSC pads and snaps the crystal to the package edge those pads actually live on.

Closes #2923.

## Why

The original strategy assumed XTAL pins were always on the north edge of the MCU package. In practice the side depends on package geometry (TQFP-32 has XTAL on the west edge) and MCU rotation. PR #2924 worked around this for board-03 with a hardcoded literal; this PR fixes the generic placer so future MCU designs going through the strategy don't repeat the workaround.

## Changes

- `src/kicad_tools/design/strategies.py`:
  - New regex `_XTAL_NET_PATTERN` matching XTAL, XTAL1/2, XTALIN/OUT, OSC_IN/OUT, OSC32_IN/OUT, and hierarchical variants (e.g. `mcu/XTAL1`). Case-insensitive; carefully bounded so `OSCILLOSCOPE_PROBE` does not match.
  - New static helper `MCUCoreStrategy._xtal_edge_angle(pcb, mcu_ref)`: locates the MCU footprint, finds all pads with XTAL/OSC net names, rotates their local positions by the footprint rotation (positive-CCW per KiCad's convention, matching `PCB.get_pad_position` and the router's adaptive transform), computes the centroid, and snaps to the nearest cardinal angle in screen-Y convention (0=E, 90=S, 180=W, 270=N).
  - `compute_placements` now calls the helper; falls back **silently** to 270 deg when the helper returns `None` (no XTAL pads, no footprints, missing MCU, or degenerate centroid).
  - Load caps now straddle the crystal along the axis **perpendicular** to the MCU-to-crystal vector (with a 1.5mm inward nudge toward the MCU), so they stay adjacent to crystal pads regardless of which edge the crystal lands on. Legacy 270 deg geometry is reproduced exactly when the fallback path triggers.
- `tests/test_strategies.py` (new, 51 tests):
  - Per-edge introspection: N/S/E/W XTAL-pad placement yields the matching angle.
  - Per-rotation introspection: 90/180/270 deg footprint rotations correctly move the detected edge in the world frame.
  - Alternate naming: `OSC_IN`/`OSC_OUT`, `OSC32_IN`/`OSC32_OUT`, hierarchical (`mcu/XTAL1`).
  - End-to-end `compute_placements` integration: crystal lands at `anchor + 5mm` on the correct edge.
  - Fallback paths: no XTAL pads, no pads at all, missing MCU ref, PCB without `footprints` attribute, empty net names, centroid-at-origin.
  - Net-name pattern unit tests.

## Acceptance criteria (from #2923)

1. **MCU introspection finds XTAL pads** — implemented via `_XTAL_NET_PATTERN` over `pad.net_name`. Matches XTAL1/2, OSC_IN/OUT, OSC32_IN/OUT, and hierarchical variants. Covered by `TestXTALNetPattern` and `TestXTALEdgeAngleDetection`.
2. **Crystal angle relative to MCU centre matches dominant XTAL pin-side vector** — `_xtal_edge_angle` computes the centroid and snaps to cardinal. Verified by `TestXTALEdgeAngleDetection::test_xtal_edge_no_rotation` (all 4 edges) and `TestMCUCoreStrategyCrystalPlacement::test_crystal_placed_on_xtal_edge` (all 4 edges, end-to-end).
3. **TQFP-32 + crystal under rotation** — verified by `test_xtal_edge_with_rotation` (5 rotation cases) and `test_crystal_follows_mcu_rotation` (TQFP-32 W-edge XTAL with 90 deg CCW rotation lands on north edge).
4. **No regression on boards 04/05** — those boards do not use `MCUCoreStrategy` in their generators (verified by grep across `boards/`), and existing `tests/test_design.py` (44 tests) still passes. Note: `tests/test_board_03_regression.py::test_route_demo_achieves_minimum_completion` fails on this branch but **also fails identically on pristine main** (verified via `git stash` round-trip); the failure is a pre-existing router-quality issue and is not related to this change.

## Fallback behaviour (curator-verified AC #4)

When the MCU footprint has no XTAL-named pins (e.g. FPGAs without a crystal, MCUs whose pads aren't net-named yet), the placer silently falls back to the legacy 270 deg position with rationale `\"Crystal close to OSC pins (fallback: no XTAL pads found)\"`. **No warnings are emitted** in this path.

## Out of scope

- Per-MCU part-mapping table (filed as a follow-up note in the issue).
- Removing the board-03 hardcoded literal added by PR #2924 — that workaround stays in place until #2924 lands, per the issue's instruction.

## Test plan

- [x] `uv run pytest tests/test_strategies.py --no-cov` — 51 passed
- [x] `uv run pytest tests/test_design.py --no-cov` — 44 passed (no regression in existing strategy tests)
- [x] `uv run ruff check src/kicad_tools/design/strategies.py tests/test_strategies.py` — clean
- [x] `uv run ruff format --check ...` — clean
- [x] No board-03 / board-04 / board-05 generators use `MCUCoreStrategy` (`grep -rn` over `boards/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)