### PR TITLE
feat(fleet): kct fleet status consults DRC results for ship-ready (closes #2932)

### DIFF
--- a/src/kicad_tools/cli/commands/fleet.py
+++ b/src/kicad_tools/cli/commands/fleet.py
@@ -41,4 +41,8 @@ def run_fleet_command(args) -> int:
         if pattern:
             sub_argv.extend(["--pattern", pattern])
 
+        drc_tolerance_file = getattr(args, "fleet_drc_tolerance_file", None)
+        if drc_tolerance_file:
+            sub_argv.extend(["--drc-tolerance-file", drc_tolerance_file])
+
     return fleet_main(sub_argv)

--- a/src/kicad_tools/cli/fleet_cmd.py
+++ b/src/kicad_tools/cli/fleet_cmd.py
@@ -34,6 +34,11 @@ from kicad_tools.analysis.net_status import NetStatusAnalyzer
 
 SCHEMA_VERSION = "1.0"
 
+# Default location for the per-board DRC tolerance allowlist (mirrors
+# ``scripts/ci/check_routed_drc.py``). Boards listed here have a
+# grandfathered non-zero error count; boards NOT listed must report 0.
+_DRC_TOLERANCE_PATH = Path(".github/routed-drc-tolerance.yml")
+
 
 # ---------------------------------------------------------------------------
 # Data classes
@@ -115,6 +120,39 @@ class ManufacturingStatus:
 
 
 @dataclass
+class DRCStatus:
+    """DRC report presence + error count for a single board.
+
+    A board is DRC-clean when ``report_exists`` is True AND ``errors``
+    does not exceed ``tolerance``. When ``report_exists`` is False the
+    DRC step has not yet run for this board, so it must NOT block
+    ship-ready (issue #2932 backwards-compat rule).
+    """
+
+    report_exists: bool = False
+    errors: int = 0
+    tolerance: int = 0
+    # Per ``.github/routed-drc-tolerance.yml`` schema, this is the
+    # repo-relative path used to look up the tolerance. Surfaced so
+    # JSON consumers can correlate.
+    tolerance_key: str | None = None
+
+    @property
+    def over_tolerance(self) -> bool:
+        """True iff a real DRC report exists AND it exceeds tolerance."""
+        return self.report_exists and self.errors > self.tolerance
+
+    def to_dict(self) -> dict:
+        return {
+            "report_exists": self.report_exists,
+            "errors": self.errors,
+            "tolerance": self.tolerance,
+            "tolerance_key": self.tolerance_key,
+            "over_tolerance": self.over_tolerance,
+        }
+
+
+@dataclass
 class BoardStatus:
     """Aggregated status for a single board."""
 
@@ -123,6 +161,7 @@ class BoardStatus:
     routed_mtime: float | None
     routing: RoutingStatus
     manufacturing: ManufacturingStatus
+    drc: DRCStatus = field(default_factory=DRCStatus)
     blockers: list[str] = field(default_factory=list)
 
     @property
@@ -136,6 +175,7 @@ class BoardStatus:
             "routed_mtime": _iso_or_none(self.routed_mtime),
             "routing": self.routing.to_dict(),
             "manufacturing": self.manufacturing.to_dict(),
+            "drc": self.drc.to_dict(),
             "ship_ready": self.ship_ready,
             "blockers": list(self.blockers),
         }
@@ -220,6 +260,104 @@ def _detect_manufacturing(board_dir: Path) -> ManufacturingStatus:
     return mfg
 
 
+def _load_drc_tolerances(
+    tolerance_path: Path = _DRC_TOLERANCE_PATH,
+) -> dict[str, int]:
+    """Load per-board DRC tolerance allowlist.
+
+    Mirrors the loader in ``scripts/ci/check_routed_drc.py`` but kept
+    self-contained here to avoid importing CI utility code from the CLI
+    surface. Missing/unreadable/malformed files yield an empty mapping
+    (every board must report 0 errors), matching the safer default.
+    """
+    if not tolerance_path.exists():
+        return {}
+    try:
+        import yaml  # local import: optional dep at call site
+    except ImportError:  # pragma: no cover - pyyaml is a hard dep
+        return {}
+    try:
+        data = yaml.safe_load(tolerance_path.read_text())
+    except (OSError, yaml.YAMLError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    tolerances = data.get("tolerances", {})
+    if not isinstance(tolerances, dict):
+        return {}
+    result: dict[str, int] = {}
+    for key, value in tolerances.items():
+        if not isinstance(key, str):
+            continue
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            continue
+        result[key] = value
+    return result
+
+
+def _drc_tolerance_for(
+    routed_pcb: Path,
+    tolerances: dict[str, int],
+) -> tuple[int, str | None]:
+    """Look up the tolerance for ``routed_pcb`` in ``tolerances``.
+
+    Tolerances are keyed by repo-relative path (e.g.
+    ``boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb``).
+    We accept any suffix match so the lookup is robust to absolute paths
+    passed in by callers (the CI script writes repo-relative; the CLI
+    typically resolves ``--boards-dir`` to absolute).
+
+    Returns ``(tolerance, matched_key_or_None)``. When no entry matches
+    we return ``(0, None)`` -- absence means strict 0-error gate per the
+    allowlist's policy.
+    """
+    if not tolerances:
+        return (0, None)
+    # Normalize once for suffix comparison.
+    pcb_str = str(routed_pcb)
+    pcb_posix = routed_pcb.as_posix()
+    for key, value in tolerances.items():
+        if pcb_str.endswith(key) or pcb_posix.endswith(key):
+            return (value, key)
+    return (0, None)
+
+
+def _detect_drc(
+    routed_pcb: Path,
+    tolerances: dict[str, int],
+) -> DRCStatus:
+    """Read ``<routed_pcb>.parent/drc_report.json`` and return DRC status.
+
+    Backwards-compat rule (issue #2932): if the report does not exist,
+    return a status with ``report_exists=False`` and ``errors=0``. The
+    blocker computation must then NOT treat the board as failing DRC,
+    so boards that have not yet been DRC'd retain their pre-fix
+    classification.
+    """
+    drc = DRCStatus()
+    report_path = routed_pcb.parent / "drc_report.json"
+    tolerance, matched_key = _drc_tolerance_for(routed_pcb, tolerances)
+    drc.tolerance = tolerance
+    drc.tolerance_key = matched_key
+    if not report_path.is_file():
+        return drc
+    try:
+        with report_path.open() as fh:
+            report = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        # Treat a malformed report identically to a missing one --
+        # don't regress ship-ready when the DRC stage is broken
+        # for unrelated reasons.
+        return drc
+    summary = report.get("summary") if isinstance(report, dict) else None
+    if isinstance(summary, dict):
+        errors = summary.get("errors", 0)
+        if isinstance(errors, int) and not isinstance(errors, bool):
+            drc.errors = errors
+    drc.report_exists = True
+    return drc
+
+
 def _compute_routing(routed_pcb: Path) -> RoutingStatus:
     """Run NetStatusAnalyzer on a routed PCB and tally pads/nets."""
     status = RoutingStatus()
@@ -243,8 +381,19 @@ def _compute_blockers(
     routing: RoutingStatus,
     mfg: ManufacturingStatus,
     routed_pcb: Path | None,
+    drc: DRCStatus | None = None,
 ) -> list[str]:
-    """First-failing list of reasons a board cannot ship."""
+    """First-failing list of reasons a board cannot ship.
+
+    DRC handling (issue #2932): when a ``drc_report.json`` exists AND its
+    error count exceeds the per-board tolerance allowlist (see
+    ``.github/routed-drc-tolerance.yml``), a ``DRC errors: N`` blocker
+    is appended. Boards with no DRC report keep their pre-#2932
+    classification (no blocker added). The DRC blocker is ordered after
+    routing/manufacturing-artifact blockers so the first-failure reason
+    in the table stays consistent with prior behavior; DRC surfaces
+    when those upstream gates already pass.
+    """
     blockers: list[str] = []
     if routed_pcb is None:
         blockers.append("no routed PCB")
@@ -270,15 +419,27 @@ def _compute_blockers(
         blockers.append("no manifest")
     if mfg.stale:
         blockers.append("artifacts stale")
+    if drc is not None and drc.over_tolerance:
+        if drc.tolerance > 0:
+            blockers.append(
+                f"DRC errors: {drc.errors} (allowed {drc.tolerance})"
+            )
+        else:
+            blockers.append(f"DRC errors: {drc.errors}")
     return blockers
 
 
-def _survey_board(board_dir: Path, pattern: str) -> BoardStatus:
+def _survey_board(
+    board_dir: Path,
+    pattern: str,
+    drc_tolerances: dict[str, int] | None = None,
+) -> BoardStatus:
     """Build a BoardStatus for a single board directory."""
     routed_pcb = _discover_routed_pcb(board_dir, pattern)
     routed_mtime: float | None = None
     routing = RoutingStatus()
     mfg = ManufacturingStatus()
+    drc = DRCStatus()
 
     if routed_pcb is not None:
         try:
@@ -293,8 +454,9 @@ def _survey_board(board_dir: Path, pattern: str) -> BoardStatus:
             and routed_mtime > mfg.manifest_mtime
         ):
             mfg.stale = True
+        drc = _detect_drc(routed_pcb, drc_tolerances or {})
 
-    blockers = _compute_blockers(routing, mfg, routed_pcb)
+    blockers = _compute_blockers(routing, mfg, routed_pcb, drc)
 
     return BoardStatus(
         name=board_dir.name,
@@ -302,11 +464,16 @@ def _survey_board(board_dir: Path, pattern: str) -> BoardStatus:
         routed_mtime=routed_mtime,
         routing=routing,
         manufacturing=mfg,
+        drc=drc,
         blockers=blockers,
     )
 
 
-def _discover_boards(boards_dir: Path, pattern: str) -> list[BoardStatus]:
+def _discover_boards(
+    boards_dir: Path,
+    pattern: str,
+    drc_tolerance_path: Path | None = None,
+) -> list[BoardStatus]:
     """Survey every board sub-directory of ``boards_dir``.
 
     A board is discovered if it contains a routed PCB matching ``pattern``
@@ -315,6 +482,9 @@ def _discover_boards(boards_dir: Path, pattern: str) -> list[BoardStatus]:
     """
     if not boards_dir.is_dir():
         return []
+    tolerances = _load_drc_tolerances(
+        drc_tolerance_path if drc_tolerance_path is not None else _DRC_TOLERANCE_PATH
+    )
     boards: list[BoardStatus] = []
     for entry in sorted(boards_dir.iterdir()):
         if not entry.is_dir():
@@ -330,7 +500,7 @@ def _discover_boards(boards_dir: Path, pattern: str) -> list[BoardStatus]:
         # Skip directories with no routed PCB matching the pattern.
         if _discover_routed_pcb(entry, pattern) is None:
             continue
-        boards.append(_survey_board(entry, pattern))
+        boards.append(_survey_board(entry, pattern, tolerances))
     return boards
 
 
@@ -360,6 +530,21 @@ def _stale_label(mfg: ManufacturingStatus) -> str:
     return "STALE" if mfg.stale else "fresh"
 
 
+def _drc_label(drc: DRCStatus) -> str:
+    """Render the DRC column cell.
+
+    ``-``       : no ``drc_report.json`` yet (backwards-compat: do not
+                  block ship-ready).
+    ``N``       : N errors, within tolerance (N <= allowance).
+    ``N!``      : N errors, exceeds tolerance (drives the ship-ready
+                  ``NO`` blocker).
+    """
+    if not drc.report_exists:
+        return "-"
+    suffix = "!" if drc.over_tolerance else ""
+    return f"{drc.errors}{suffix}"
+
+
 def _format_table(
     boards: list[BoardStatus],
     boards_dir: Path,
@@ -368,7 +553,10 @@ def _format_table(
 ) -> str:
     """Format a fixed-width plain-ASCII table."""
     lines: list[str] = []
-    header = f"{'Board':<28} {'Pads':>7} {'%':>5} {'Mfr':<8} {'Stale':<6} Ship?"
+    header = (
+        f"{'Board':<28} {'Pads':>7} {'%':>5} {'Mfr':<8} {'Stale':<6} "
+        f"{'DRC':>5} Ship?"
+    )
     sep = "-" * len(header)
     lines.append(header)
     lines.append(sep)
@@ -386,12 +574,14 @@ def _format_table(
             pct = f"{b.routing.completion_pct:.0f}%"
             mfr = _mfr_letters(b.manufacturing)
             stale = _stale_label(b.manufacturing)
+            drc_cell = _drc_label(b.drc)
             if b.ship_ready:
                 ship = "YES"
             else:
                 ship = f"NO  ({b.blockers[0]})"
             lines.append(
-                f"{b.name[:28]:<28} {pads:>7} {pct:>5} {mfr:<8} {stale:<6} {ship}"
+                f"{b.name[:28]:<28} {pads:>7} {pct:>5} {mfr:<8} {stale:<6} "
+                f"{drc_cell:>5} {ship}"
             )
 
     # Footer (always uses full board list, not filtered view).
@@ -404,9 +594,11 @@ def _format_table(
             if not b.routing.routing_complete and b.routing.error is None
         )
         stale_count = sum(1 for b in boards if b.manufacturing.stale)
+        drc_failing = sum(1 for b in boards if b.drc.over_tolerance)
         lines.append(
             f"{len(boards)} boards surveyed, {ship_ready} ship-ready, "
-            f"{incomplete} incomplete, {stale_count} artifacts stale"
+            f"{incomplete} incomplete, {stale_count} artifacts stale, "
+            f"{drc_failing} DRC over tolerance"
         )
         lines.append(f"boards-dir: {boards_dir}")
 
@@ -428,6 +620,7 @@ def _format_json(boards: list[BoardStatus], boards_dir: Path) -> str:
             for b in boards
             if not b.manufacturing.has_all
         ),
+        "drc_over_tolerance": sum(1 for b in boards if b.drc.over_tolerance),
     }
     doc = {
         "schema_version": SCHEMA_VERSION,
@@ -487,13 +680,24 @@ def _build_parser() -> argparse.ArgumentParser:
         default="*_routed.kicad_pcb",
         help="Glob to identify routed PCB inside output/ (default: *_routed.kicad_pcb)",
     )
+    status_parser.add_argument(
+        "--drc-tolerance-file",
+        default=str(_DRC_TOLERANCE_PATH),
+        help=(
+            "Path to the per-board DRC tolerance allowlist (default: "
+            ".github/routed-drc-tolerance.yml). Boards exceeding the listed "
+            "tolerance -- or any board not listed with errors > 0 -- block "
+            "ship-ready."
+        ),
+    )
     return parser
 
 
 def run_status(args: argparse.Namespace) -> int:
     """Execute the ``fleet status`` sub-action."""
     boards_dir = Path(args.boards_dir)
-    boards = _discover_boards(boards_dir, args.pattern)
+    tolerance_path = Path(getattr(args, "drc_tolerance_file", _DRC_TOLERANCE_PATH))
+    boards = _discover_boards(boards_dir, args.pattern, tolerance_path)
 
     if args.format == "json":
         print(_format_json(boards, boards_dir))

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -4343,6 +4343,17 @@ def _add_fleet_parser(subparsers) -> None:
         default="*_routed.kicad_pcb",
         help="Glob to identify routed PCB inside output/ (default: *_routed.kicad_pcb)",
     )
+    fleet_status.add_argument(
+        "--drc-tolerance-file",
+        dest="fleet_drc_tolerance_file",
+        default=".github/routed-drc-tolerance.yml",
+        help=(
+            "Path to the per-board DRC tolerance allowlist (default: "
+            ".github/routed-drc-tolerance.yml). Boards exceeding the listed "
+            "tolerance -- or any board not listed with errors > 0 -- block "
+            "ship-ready. Missing file is treated as a strict 0-error gate."
+        ),
+    )
 
 
 def _add_clean_parser(subparsers) -> None:

--- a/tests/test_fleet_status_drc.py
+++ b/tests/test_fleet_status_drc.py
@@ -1,0 +1,440 @@
+"""Tests for the DRC-aware ship-ready logic in ``kct fleet status`` (#2932).
+
+These tests live in a separate module so the original
+``test_fleet_status.py`` suite stays focused on routing + manufacturing
+detection, and the DRC integration can grow its own coverage matrix.
+
+Acceptance criteria covered:
+
+* clean board (drc_report.json with 0 errors) -> ship-ready YES
+* board with DRC errors beyond tolerance -> ship-ready NO with a
+  ``DRC errors: N`` blocker
+* board WITHOUT drc_report.json -> classification unchanged
+  (backwards-compat: a previously-YES board stays YES)
+* per-board tolerance allowlist (``.github/routed-drc-tolerance.yml``)
+  is honored: errors within tolerance do NOT block ship-ready
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from kicad_tools.cli.fleet_cmd import main
+
+# Reuse the synthetic-PCB fixtures + ``make_fake_board`` builder from
+# the sibling test module to keep board-construction logic in one place.
+from tests.test_fleet_status import make_fake_board
+
+# ---------------------------------------------------------------------------
+# DRC report builder
+# ---------------------------------------------------------------------------
+
+
+def _write_drc_report(routed_pcb: Path, *, errors: int) -> Path:
+    """Write a minimal ``drc_report.json`` next to ``routed_pcb``.
+
+    Only the ``summary.errors`` key is consulted by the fleet surveyor;
+    we provide a realistic shell otherwise so future schema readers
+    don't trip on missing fields.
+    """
+    report = {
+        "file": str(routed_pcb),
+        "manufacturer": "jlcpcb-tier1",
+        "layers": 2,
+        "summary": {
+            "errors": errors,
+            "warnings": 0,
+            "infos": 0,
+            "rules_checked": 25,
+            "rules_checked_by_rule": {},
+            "passed": errors == 0,
+        },
+        "violations": [
+            {
+                "rule_id": "clearance_pad_segment",
+                "type": "clearance_pad_segment",
+                "severity": "error",
+                "message": "synthetic DRC error",
+            }
+            for _ in range(errors)
+        ],
+    }
+    report_path = routed_pcb.parent / "drc_report.json"
+    report_path.write_text(json.dumps(report))
+    return report_path
+
+
+def _write_tolerance_file(path: Path, mapping: dict[str, int]) -> Path:
+    """Write a minimal ``.github/routed-drc-tolerance.yml``-shaped file.
+
+    Avoids importing ``yaml`` here; the surveyor's loader uses pyyaml
+    but plain hand-rolled YAML is fine for these fixtures.
+    """
+    lines = ["tolerances:"]
+    for k, v in mapping.items():
+        lines.append(f"  {k}: {v}")
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Acceptance-criterion tests
+# ---------------------------------------------------------------------------
+
+
+class TestFleetStatusDRC:
+    def test_clean_board_with_zero_errors_is_ship_ready(
+        self, tmp_path: Path, capsys
+    ):
+        """Board has all artifacts + drc_report.json with 0 errors -> YES."""
+        boards = tmp_path / "boards"
+        routed_pcb = make_fake_board(
+            boards,
+            "a-clean",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        _write_drc_report(routed_pcb, errors=0)
+
+        # Empty tolerance file -> strict 0-error gate applies.
+        tol = _write_tolerance_file(tmp_path / "tol.yml", {})
+
+        rc = main(
+            [
+                "status",
+                "--boards-dir",
+                str(boards),
+                "--drc-tolerance-file",
+                str(tol),
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == 0
+
+        data = json.loads(capsys.readouterr().out)
+        b = data["boards"][0]
+        assert b["ship_ready"] is True
+        assert b["blockers"] == []
+        assert b["drc"]["report_exists"] is True
+        assert b["drc"]["errors"] == 0
+        assert b["drc"]["over_tolerance"] is False
+
+    def test_board_with_drc_errors_blocks_ship_ready(
+        self, tmp_path: Path, capsys
+    ):
+        """Board with 182 DRC errors (mirrors board-02) reports NO with reason."""
+        boards = tmp_path / "boards"
+        routed_pcb = make_fake_board(
+            boards,
+            "b-broken",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        _write_drc_report(routed_pcb, errors=182)
+
+        # No tolerance file at all -> strict 0-error gate -> blocker.
+        tol = tmp_path / "absent-tolerance.yml"
+        # Intentionally do not create tol; loader treats absent as empty.
+        assert not tol.exists()
+
+        rc = main(
+            [
+                "status",
+                "--boards-dir",
+                str(boards),
+                "--drc-tolerance-file",
+                str(tol),
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == 2
+
+        data = json.loads(capsys.readouterr().out)
+        b = data["boards"][0]
+        assert b["ship_ready"] is False
+        assert b["drc"]["report_exists"] is True
+        assert b["drc"]["errors"] == 182
+        assert b["drc"]["over_tolerance"] is True
+        # The blocker text must cite the DRC count.
+        assert any(
+            "DRC errors" in blocker and "182" in blocker
+            for blocker in b["blockers"]
+        ), f"missing DRC-cited blocker in {b['blockers']!r}"
+
+    def test_board_without_drc_report_keeps_pre_fix_classification(
+        self, tmp_path: Path, capsys
+    ):
+        """No drc_report.json -> board is treated as DRC-unknown.
+
+        Backwards-compat invariant from issue #2932: do NOT block
+        ship-ready when the DRC stage has not run. A fully-routed board
+        with all artifacts must still report YES.
+        """
+        boards = tmp_path / "boards"
+        routed_pcb = make_fake_board(
+            boards,
+            "c-no-drc",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        # No drc_report.json next to routed_pcb.
+        assert not (routed_pcb.parent / "drc_report.json").exists()
+
+        tol = _write_tolerance_file(tmp_path / "tol.yml", {})
+
+        rc = main(
+            [
+                "status",
+                "--boards-dir",
+                str(boards),
+                "--drc-tolerance-file",
+                str(tol),
+                "--format",
+                "json",
+            ]
+        )
+        # All artifacts present + no DRC blocker added -> ship-ready.
+        assert rc == 0
+
+        data = json.loads(capsys.readouterr().out)
+        b = data["boards"][0]
+        assert b["ship_ready"] is True
+        assert b["blockers"] == []
+        assert b["drc"]["report_exists"] is False
+        # over_tolerance is False because the report wasn't seen.
+        assert b["drc"]["over_tolerance"] is False
+
+
+class TestFleetStatusDRCTolerance:
+    """The per-board allowlist must let grandfathered boards ship."""
+
+    def test_errors_within_tolerance_do_not_block(self, tmp_path: Path, capsys):
+        """Tolerance of 53, actual 38 -> still ship-ready."""
+        boards = tmp_path / "boards"
+        routed_pcb = make_fake_board(
+            boards,
+            "05-bldc-motor-controller",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        _write_drc_report(routed_pcb, errors=38)
+
+        # Tolerance keyed by suffix that matches the routed PCB path.
+        # The suffix lookup in ``_drc_tolerance_for`` accepts both
+        # repo-relative and absolute matches.
+        suffix = (
+            "05-bldc-motor-controller/output/"
+            "05_bldc_motor_controller_routed.kicad_pcb"
+        )
+        tol = _write_tolerance_file(tmp_path / "tol.yml", {suffix: 53})
+
+        rc = main(
+            [
+                "status",
+                "--boards-dir",
+                str(boards),
+                "--drc-tolerance-file",
+                str(tol),
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        b = data["boards"][0]
+        assert b["ship_ready"] is True
+        assert b["drc"]["errors"] == 38
+        assert b["drc"]["tolerance"] == 53
+        assert b["drc"]["over_tolerance"] is False
+
+    def test_errors_above_tolerance_block(self, tmp_path: Path, capsys):
+        """Tolerance of 53, actual 60 -> blocker cites the count + allowance."""
+        boards = tmp_path / "boards"
+        routed_pcb = make_fake_board(
+            boards,
+            "05-bldc-motor-controller",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        _write_drc_report(routed_pcb, errors=60)
+        suffix = (
+            "05-bldc-motor-controller/output/"
+            "05_bldc_motor_controller_routed.kicad_pcb"
+        )
+        tol = _write_tolerance_file(tmp_path / "tol.yml", {suffix: 53})
+
+        rc = main(
+            [
+                "status",
+                "--boards-dir",
+                str(boards),
+                "--drc-tolerance-file",
+                str(tol),
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == 2
+        data = json.loads(capsys.readouterr().out)
+        b = data["boards"][0]
+        assert b["ship_ready"] is False
+        # Blocker message must include the actual count AND the allowance
+        # so reviewers can see how far over budget the board is.
+        msg = " ".join(b["blockers"])
+        assert "DRC errors" in msg
+        assert "60" in msg
+        assert "53" in msg
+
+
+class TestFleetStatusDRCTableRendering:
+    """The DRC column must render without breaking the existing table."""
+
+    def test_drc_column_present_in_header(self, tmp_path: Path, capsys):
+        boards = tmp_path / "boards"
+        make_fake_board(
+            boards,
+            "a-board",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        main(["status", "--boards-dir", str(boards)])
+        out = capsys.readouterr().out
+        # Column heading.
+        assert "DRC" in out
+        # Existing columns still present (no regression).
+        for col in ("Board", "Pads", "Mfr", "Stale", "Ship?"):
+            assert col in out
+
+    def test_drc_dash_for_missing_report(self, tmp_path: Path, capsys):
+        """No drc_report.json -> the DRC cell renders as ``-``."""
+        boards = tmp_path / "boards"
+        make_fake_board(
+            boards,
+            "a-board",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        main(["status", "--boards-dir", str(boards)])
+        out = capsys.readouterr().out
+        # The header row of the DRC column is "DRC"; the data row must
+        # contain "-" in the cell. We assert the literal cell appears
+        # in the row that names the board.
+        for line in out.splitlines():
+            if line.startswith("a-board"):
+                # Crude but sufficient: a "-" token must appear in the
+                # column-aligned data line.
+                assert " - " in line or line.endswith(" -")
+                return
+        raise AssertionError("a-board row not found in table output")
+
+    def test_drc_cell_shows_count_with_bang_when_over_tolerance(
+        self, tmp_path: Path, capsys
+    ):
+        boards = tmp_path / "boards"
+        routed_pcb = make_fake_board(
+            boards,
+            "a-board",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        _write_drc_report(routed_pcb, errors=17)
+        tol = _write_tolerance_file(tmp_path / "tol.yml", {})
+        main(
+            [
+                "status",
+                "--boards-dir",
+                str(boards),
+                "--drc-tolerance-file",
+                str(tol),
+            ]
+        )
+        out = capsys.readouterr().out
+        # Either "17!" (over tolerance) appears, or the row exists with
+        # a ship-NO and "DRC errors" reason text.
+        assert "17!" in out
+        assert "DRC errors" in out
+
+
+class TestFleetStatusDRCBackwardsCompat:
+    """The DRC integration must not regress the existing tests' fixtures."""
+
+    def test_mixed_with_and_without_drc(self, tmp_path: Path, capsys):
+        """Two boards: one with a DRC report exceeding tolerance, one without.
+
+        The board with the DRC report must drop to NO; the board
+        without one must keep YES.
+        """
+        boards = tmp_path / "boards"
+        clean_pcb = make_fake_board(
+            boards,
+            "a-no-drc",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        # Deliberately omit drc_report.json for a-no-drc.
+        assert not (clean_pcb.parent / "drc_report.json").exists()
+
+        bad_pcb = make_fake_board(
+            boards,
+            "b-drc-bad",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        _write_drc_report(bad_pcb, errors=12)
+        tol = _write_tolerance_file(tmp_path / "tol.yml", {})
+
+        rc = main(
+            [
+                "status",
+                "--boards-dir",
+                str(boards),
+                "--drc-tolerance-file",
+                str(tol),
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == 2  # at least one board not ship-ready
+        data = json.loads(capsys.readouterr().out)
+        by_name = {b["name"]: b for b in data["boards"]}
+
+        assert by_name["a-no-drc"]["ship_ready"] is True
+        assert by_name["a-no-drc"]["blockers"] == []
+
+        assert by_name["b-drc-bad"]["ship_ready"] is False
+        assert any(
+            "DRC errors" in blk for blk in by_name["b-drc-bad"]["blockers"]
+        )


### PR DESCRIPTION
## Summary

- Adds `DRCStatus` dataclass + DRC column to `kct fleet status`
- Reads `drc_report.json` for each board and looks up per-board tolerance in `.github/routed-drc-tolerance.yml`
- Surfaces `DRC errors: N` blocker when count exceeds tolerance; **boards with no DRC report yet keep pre-fix classification** (backwards-compat)

Closes #2932

## Root cause

`_compute_blockers` previously examined routing completion, gerber/BOM/CPL/manifest presence, and staleness only. Zero DRC references. Any board with 100% connectivity + manufacturing dir reported `YES` regardless of clearance violations.

## Behavior

| State | Pre-PR | Post-PR |
|---|---|---|
| Fully routed + artifacts + 0 DRC errors | `YES` | `YES` |
| Fully routed + artifacts + 182 DRC errors | `YES` (bug) | `NO  (DRC errors: 182)` |
| Fully routed + artifacts + 38 errors with tolerance 53 | `YES` | `YES` |
| Fully routed + artifacts + 60 errors with tolerance 53 | `YES` (bug) | `NO  (DRC errors: 60 (allowed 53))` |
| Fully routed + artifacts + no `drc_report.json` | `YES` | `YES` (no regression) |
| Incomplete routing + DRC fails | `NO (incomplete routing)` | `NO (incomplete routing)` (routing reason still wins) |

## Sample table output

```
Board                           Pads     % Mfr      Stale    DRC Ship?
----------------------------------------------------------------------
01-voltage-divider               6/8   75% -        -          - NO  (incomplete routing (1/3 nets))
02-charlieplex-led             32/34   94% -        -          - NO  (incomplete routing (1/10 nets))
...
7 boards surveyed, 0 ship-ready, 7 incomplete, 2 artifacts stale, 0 DRC over tolerance
```

When a `drc_report.json` exists with errors, the DRC cell renders as `N` (within tolerance) or `N!` (over tolerance).

## JSON schema extension

Each board entry gains a `drc` block:

```json
"drc": {
  "report_exists": true,
  "errors": 182,
  "tolerance": 0,
  "tolerance_key": null,
  "over_tolerance": true
}
```

And summary gets `drc_over_tolerance: N`.

## Test plan

- [x] `tests/test_fleet_status_drc.py` (new): 9 tests covering clean, broken, missing-report, within-tolerance, over-tolerance, table rendering, and mixed scenarios
- [x] `tests/test_fleet_status.py`: existing 13 tests stay green (no regression)
- [x] Lint: `uv run ruff check` clean on all modified files
- [x] Smoke: `uv run kct fleet status` against `boards/` renders cleanly, no crashes on absent DRC reports
- [x] Acceptance criterion #1 verified: synthetic board-02-shaped state (full routing + all artifacts + 182 DRC errors) reports `NO` with `DRC errors: 182` blocker

🤖 Generated with [Claude Code](https://claude.com/claude-code)