### PR TITLE
fix(router): wire foreign_pads/foreign_tracks into staggered_via_fanout (closes #2948)

### DIFF
--- a/src/kicad_tools/router/escape.py
+++ b/src/kicad_tools/router/escape.py
@@ -3658,18 +3658,37 @@ class EscapeRouter:
         self,
         pads: list[Pad],
         stagger_distance: float | None = None,
+        foreign_pads: list[Pad] | None = None,
+        foreign_tracks: list[Segment] | None = None,
     ) -> list[Via]:
         """Generate staggered via pattern under dense package.
 
         Places vias in a dog-bone pattern, offsetting via positions
         based on row/column to prevent via-to-via DRC violations.
 
+        Issue #2948: Forwards optional foreign-net pad / track context to
+        :meth:`_can_place_via` so the world-coordinate clearance check
+        from Issue #2944 can reject candidates whose envelope overlaps
+        adjacent foreign copper.  When omitted (the existing legacy
+        behavior), only the grid-cell bounds / obstacle check is run.
+
         Args:
-            pads: Pads to create fanout vias for
-            stagger_distance: Offset distance for stagger (defaults to via_spacing/2)
+            pads: Pads to create fanout vias for.  Each via inherits the
+                parent pad's ``net`` so the predicate can filter
+                ``foreign_pads`` / ``foreign_tracks`` down to the truly
+                foreign-net subset.
+            stagger_distance: Offset distance for stagger (defaults to
+                ``via_spacing / 2``).
+            foreign_pads: Optional list of nearby pads (board-wide pad
+                registry minus the package being fanned out, ideally) to
+                validate each candidate via against.  Pads whose ``net``
+                matches the parent pad are skipped automatically.
+            foreign_tracks: Optional list of pre-existing track segments
+                to validate against.  Segments whose ``net`` matches the
+                parent pad's net are skipped automatically.
 
         Returns:
-            List of Via objects in staggered pattern
+            List of Via objects in staggered pattern.
         """
         if not pads:
             return []
@@ -3689,8 +3708,17 @@ class EscapeRouter:
                 via_x = pad.x + offset_x
                 via_y = pad.y + offset_y
 
-                # Check if position is valid in grid
-                if self._can_place_via(via_x, via_y):
+                # Issue #2948: forward foreign-copper context (own net
+                # filtering happens inside ``_can_place_via``).  When
+                # ``foreign_pads`` / ``foreign_tracks`` are omitted the
+                # call collapses to the legacy grid-cell-only check.
+                if self._can_place_via(
+                    via_x,
+                    via_y,
+                    net=pad.net,
+                    foreign_pads=foreign_pads,
+                    foreign_tracks=foreign_tracks,
+                ):
                     via = Via(
                         x=via_x,
                         y=via_y,

--- a/tests/test_escape.py
+++ b/tests/test_escape.py
@@ -16,7 +16,7 @@ from kicad_tools.router.escape import (
 )
 from kicad_tools.router.grid import RoutingGrid
 from kicad_tools.router.layers import Layer
-from kicad_tools.router.primitives import Pad
+from kicad_tools.router.primitives import Pad, Segment
 from kicad_tools.router.rules import DesignRules
 
 # ==============================================================================
@@ -759,7 +759,11 @@ class TestStaggeredViaFanout:
 
         # Create a simple 2x2 grid of pads
         pads = create_bga_pads(2, 2, pitch=0.8)
-        vias = router.staggered_via_fanout(pads)
+        # Issue #2948: pass empty foreign-copper lists explicitly to
+        # preserve the legacy grid-cell-only behavior under test.
+        vias = router.staggered_via_fanout(
+            pads, foreign_pads=[], foreign_tracks=[]
+        )
 
         # Should have up to 4 vias
         assert len(vias) <= 4
@@ -770,7 +774,11 @@ class TestStaggeredViaFanout:
         router = EscapeRouter(grid, rules)
 
         pads = create_bga_pads(3, 3, pitch=1.0)  # Larger pitch for clarity
-        vias = router.staggered_via_fanout(pads, stagger_distance=0.3)
+        # Issue #2948: pass empty foreign-copper lists explicitly so the
+        # legacy fast path (grid-cell-only) is exercised here.
+        vias = router.staggered_via_fanout(
+            pads, stagger_distance=0.3, foreign_pads=[], foreign_tracks=[]
+        )
 
         # Check that vias are near but not exactly on pad positions
         for via in vias:
@@ -781,6 +789,120 @@ class TestStaggeredViaFanout:
             # Via should be offset from pad (not exactly on it)
             # but close enough to connect
             assert min_dist < 1.0  # Within 1mm
+
+    def test_foreign_pad_in_envelope_rejects_via(self, grid_and_rules):
+        """Issue #2948: when a foreign-net pad sits inside the via's
+        clearance envelope, ``staggered_via_fanout`` must drop the
+        offending candidate via ``_can_place_via``.
+
+        This pins the wire from caller -> predicate.  Without the wiring
+        (the pre-#2948 state) the same call would have emitted the via.
+        """
+        grid, rules = grid_and_rules
+        router = EscapeRouter(grid, rules)
+
+        # Single same-net pad; with stagger_distance=0 the candidate via
+        # lands exactly on the pad.  Place a foreign-net pad at a
+        # distance that violates the clearance envelope:
+        #
+        #   via_diameter = 0.7  -> via_radius = 0.35
+        #   foreign pad effective radius = max(0.4, 0.4) / 2 = 0.2
+        #   via_clearance = 0.2
+        #   required separation = 0.35 + 0.2 + 0.2 = 0.75 mm
+        #
+        # Place the foreign pad 0.5 mm away -> below the threshold ->
+        # rejection expected.
+        own_pad = Pad(
+            x=10.0, y=10.0, width=0.4, height=0.4,
+            net=5, net_name="OWN", layer=Layer.F_CU,
+        )
+        foreign = Pad(
+            x=10.5, y=10.0, width=0.4, height=0.4,
+            net=99, net_name="OTHER", layer=Layer.F_CU,
+        )
+
+        # Baseline: with no foreign context the legacy path emits the via.
+        baseline_vias = router.staggered_via_fanout(
+            [own_pad], stagger_distance=0.0
+        )
+        assert len(baseline_vias) == 1, (
+            "Sanity check: legacy path (no foreign context) should emit "
+            "the candidate via."
+        )
+
+        # Wired path: foreign pad inside the envelope rejects the via.
+        wired_vias = router.staggered_via_fanout(
+            [own_pad],
+            stagger_distance=0.0,
+            foreign_pads=[foreign],
+            foreign_tracks=[],
+        )
+        assert wired_vias == [], (
+            "Issue #2948: foreign-net pad inside clearance envelope must "
+            "cause _can_place_via to reject the candidate via."
+        )
+
+    def test_foreign_track_in_envelope_rejects_via(self, grid_and_rules):
+        """Issue #2948: foreign-net track segments must also be honored
+        when supplied via ``foreign_tracks``.
+        """
+        grid, rules = grid_and_rules
+        router = EscapeRouter(grid, rules)
+
+        own_pad = Pad(
+            x=10.0, y=10.0, width=0.4, height=0.4,
+            net=5, net_name="OWN", layer=Layer.F_CU,
+        )
+        # Horizontal foreign-net trace passing 0.4 mm above the via center.
+        # Required clearance:
+        #   via_radius (0.35) + trace_half_width (0.1) + via_clearance (0.2)
+        #   = 0.65 mm; actual 0.4 mm -> reject.
+        foreign_seg = Segment(
+            x1=9.0, y1=10.4, x2=11.0, y2=10.4,
+            width=0.2, layer=Layer.F_CU, net=99, net_name="OTHER",
+        )
+
+        wired_vias = router.staggered_via_fanout(
+            [own_pad],
+            stagger_distance=0.0,
+            foreign_pads=[],
+            foreign_tracks=[foreign_seg],
+        )
+        assert wired_vias == [], (
+            "Issue #2948: foreign-net track inside clearance envelope "
+            "must cause _can_place_via to reject the candidate via."
+        )
+
+    def test_same_net_pad_does_not_reject_via(self, grid_and_rules):
+        """Issue #2948: same-net pads in ``foreign_pads`` must NOT cause
+        rejection.  The predicate must filter by net before evaluating
+        clearance — otherwise the parent pad would always reject its own
+        in-pad via.
+        """
+        grid, rules = grid_and_rules
+        router = EscapeRouter(grid, rules)
+
+        own_pad = Pad(
+            x=10.0, y=10.0, width=0.4, height=0.4,
+            net=5, net_name="OWN", layer=Layer.F_CU,
+        )
+        # Same-net "foreign" pad close enough to violate clearance if
+        # treated as foreign.  Must be filtered out by net=5.
+        same_net = Pad(
+            x=10.3, y=10.0, width=0.4, height=0.4,
+            net=5, net_name="OWN", layer=Layer.F_CU,
+        )
+
+        vias = router.staggered_via_fanout(
+            [own_pad],
+            stagger_distance=0.0,
+            foreign_pads=[same_net],
+            foreign_tracks=[],
+        )
+        assert len(vias) == 1, (
+            "Issue #2948: same-net pads must be filtered out before the "
+            "world-coord clearance check."
+        )
 
 
 class TestApplyEscapeRoutes:


### PR DESCRIPTION
## Summary

PR #2945 (#2944) added optional `foreign_pads` / `foreign_tracks` parameters to `EscapeRouter._can_place_via`, but no caller supplied them — the parameters were dormant. This PR wires the only in-scope caller (`staggered_via_fanout`) per the curator-verified caller catalogue and pins the contract with new tests.

**This is preventive wiring**: there is currently NO production caller of `staggered_via_fanout` itself (only `tests/test_escape.py` exercises it), so this PR is a true no-op for boards 00-07. When an orchestrator path eventually emits fanout vias, the clearance check will be live, not dead.

## Caller catalogue compliance

| Site | File:line | Action |
|---|---|---|
| `EscapeRouter.staggered_via_fanout` | `src/kicad_tools/router/escape.py:3693` | Plumbed `foreign_pads` / `foreign_tracks` kwargs; forwarded with `net=pad.net` |

Out-of-scope matches (NOT touched, per hard limits):
- `_can_place_via_in_zones` (pathfinder.py) — separate predicate
- `_check_via_placement_cached` (pathfinder.py) — issue #2947
- `_can_place_via` in `acceleration/kernels/routing.py` — compiled kernel, separate territory
- `_try_in_pad_escape` / `_via_clears_other_pads` (escape.py) — parked under #2946 (QFP-no-fallback constraint)

## Changes

- Add `foreign_pads: list[Pad] | None = None` and `foreign_tracks: list[Segment] | None = None` to `staggered_via_fanout` signature.
- Forward to `_can_place_via(net=pad.net, foreign_pads=..., foreign_tracks=...)` so the own-net filtering (Issue #2944) kicks in.
- Update the existing exerciser tests (`test_staggered_pattern`, `test_via_positions_offset`) to pass empty lists explicitly, preserving the legacy grid-cell-only behavior under test.
- Add three new tests:
  - `test_foreign_pad_in_envelope_rejects_via` — proves the wire is live (baseline emits the via; wired path rejects it).
  - `test_foreign_track_in_envelope_rejects_via` — same proof for track segments.
  - `test_same_net_pad_does_not_reject_via` — guards own-net filtering so the parent pad doesn't reject its own in-pad via.

## Acceptance criteria

- [x] `staggered_via_fanout` signature carries `foreign_pads` / `foreign_tracks`.
- [x] Caller-side: existing test exerciser passes through; no production code in the catalogue requires updating.
- [x] Integration test asserts that supplying foreign-net pads/tracks in the clearance envelope causes `_can_place_via` rejection (proves the wire is live, not dead).
- [x] Boards 00-07 fleet-status parity (verified: no production caller fans out, so this is a true no-op).
- [x] PR body acknowledges preventive wiring + contract-pinning tests.

## Test plan

- [x] `pytest tests/test_escape.py::TestStaggeredViaFanout` — 5/5 pass (2 existing + 3 new).
- [x] `pytest tests/test_router_escape_via.py` — 13/13 pass (no regression in PR #2945 territory).
- [x] `pytest tests/test_escape.py tests/test_router_escape_via.py` — 116/116 pass.
- [x] `kct fleet status` — boards 00-07 identical to pre-change (no production caller for `staggered_via_fanout`).

## Hard limits honored

- `_try_in_pad_escape` (escape.py:3929) NOT touched — different predicate (`_via_clears_other_pads`), parked under #2946.
- `_check_via_placement_cached` NOT touched — pathfinder territory, issue #2947.
- `_can_place_via_in_zones` NOT touched — separate predicate.

Closes #2948

🤖 Generated with [Claude Code](https://claude.com/claude-code)