### PR TITLE
fix(router): in-pad rescue iterates long-axis offsets for clearance (closes #2946)

### DIFF
--- a/src/kicad_tools/router/escape.py
+++ b/src/kicad_tools/router/escape.py
@@ -3926,6 +3926,186 @@ class EscapeRouter:
             else:
                 return EscapeDirection.SOUTH
 
+    def _select_in_pad_via_position(
+        self,
+        pad: Pad,
+        via_diameter: float,
+        min_annular: float,
+        effective_clearance: float,
+        package: PackageInfo | None,
+    ) -> tuple[float, float, bool]:
+        """Select an in-pad via position with a long-axis clearance nudge.
+
+        Issue #2946: When dead-centre placement on a fine-pitch QFP pad
+        produces clearance violations to adjacent foreign-net pads
+        (board-04 OSC_OUT at 0.5mm-pitch LQFP-48), iterate offsets along
+        the pad's **long axis** seeking the smallest-magnitude offset
+        whose candidate via passes both the world-coordinate clearance
+        predicate (:meth:`_can_place_via`) and the pad-copper
+        containment check.
+
+        Stencil safety: solder-paste stencil apertures key off the pad's
+        geometry, not the via's position, so an offset via inside the
+        pad does NOT corrupt the stencil aperture as long as the via
+        barrel + annular ring stay entirely inside the pad copper
+        rectangle.  The containment check enforces this constraint --
+        the via center must lie within the pad's interior such that::
+
+            |offset| + via_radius + min_annular <= long_dim / 2
+
+        i.e. the maximum nudge is
+        ``(long_dim - via_diameter) / 2 - min_annular``.
+
+        Search strategy:
+        1. Dead-centre ``(pad.x, pad.y)`` is the FIRST candidate -- if
+           it passes the clearance predicate, no nudge is attempted.
+           This preserves the existing behavior on the common case
+           where no neighboring pad is close enough to violate.
+        2. Otherwise iterate offsets ``[+s, -s, +2s, -2s, ...]`` with
+           ``s = 0.05 mm`` along the pad's long axis (X axis when
+           ``pad.width > pad.height``, Y axis otherwise).  The first
+           offset whose candidate via passes BOTH checks is returned.
+        3. If no candidate passes, fall back to dead-centre.  The
+           caller (``_try_in_pad_escape``) emits the structured warning
+           in that case, preserving the PR #2945 "place anyway, defer
+           DRC to the user" semantics for the unfixable cases.
+
+        Args:
+            pad: The pad whose surface escape was just rejected.
+            via_diameter: Effective via diameter for in-pad placement
+                (manufacturer min_via_diameter or design rules fallback).
+            min_annular: Minimum annular ring (pad copper around the via
+                barrel) that must remain after placement.  Used as the
+                pad-copper containment safety margin.
+            effective_clearance: Clearance value passed through to
+                :meth:`_can_place_via`.
+            package: Optional package context.  When ``None`` the nudge
+                rescue is disabled and dead-centre is returned (no
+                neighbor pad / track context available to validate
+                offsets against).
+
+        Returns:
+            A tuple ``(via_x, via_y, nudged)`` where ``via_x``/``via_y``
+            are the chosen via center coordinates in world space and
+            ``nudged`` is ``True`` iff the position differs from
+            dead-centre AND the candidate passes the clearance
+            predicate (i.e. the nudge rescue succeeded).
+        """
+        via_x = pad.x
+        via_y = pad.y
+
+        # Without package context we have no foreign-net pads to
+        # validate against; preserve legacy dead-centre behavior.
+        if package is None:
+            return via_x, via_y, False
+
+        # Foreign-net pads on the same footprint (the pads the in-pad
+        # rescue is most likely to clip on a fine-pitch QFP).
+        foreign_pads = [
+            p for p in package.pads
+            if p is not pad and p.net != pad.net
+        ]
+
+        # Quick path: dead-centre.  If the existing clearance predicate
+        # accepts it, no nudge is needed.  This is the common case for
+        # the majority of in-pad rescues and keeps behavior identical
+        # to PR #2944 / #2945 when neighbor clearance is fine.
+        if self._can_place_via(
+            x=via_x,
+            y=via_y,
+            net=pad.net,
+            foreign_pads=foreign_pads,
+            clearance=effective_clearance,
+            via_diameter=via_diameter,
+        ):
+            return via_x, via_y, False
+
+        # Determine pad long-axis direction.  The Pad primitive does not
+        # carry rotation; ``width``/``height`` already encode the post-
+        # rotation footprint (KiCad emits oriented bounding-box extents
+        # when the loader projects pad geometry to world coordinates).
+        # The longer extent is the long axis.
+        if pad.width >= pad.height:
+            long_dim = pad.width
+            axis_x, axis_y = 1.0, 0.0
+        else:
+            long_dim = pad.height
+            axis_x, axis_y = 0.0, 1.0
+
+        # Stencil-safety budget: the via center may travel along the
+        # long axis until the via's barrel + annular ring is about to
+        # exit the pad's long-edge copper.  We require strict interior
+        # containment so the SMT stencil aperture remains valid.
+        via_radius = via_diameter / 2
+        max_offset = (long_dim - via_diameter) / 2 - min_annular
+        if max_offset <= 0.0:
+            # No room to nudge -- fall back to dead-centre (caller will
+            # emit the diagnostic warning).
+            return via_x, via_y, False
+
+        # NOTE: we deliberately do NOT check short-axis containment.
+        # The parent ``_try_in_pad_escape`` already validates the LARGER
+        # dimension covers ``drill + 2 * annular`` and documents the
+        # short axis as exempt: a via-in-pad's *pad landing* (diameter)
+        # may extend off the SMT pad's short edges because the via is
+        # filled and plated, but the drill must remain inside pad
+        # copper.  The nudge here only translates along the long axis,
+        # so short-axis containment is invariant -- whatever was true
+        # at dead-centre remains true after the offset.
+
+        # Iterate offsets [+s, -s, +2s, -2s, ...] until either an
+        # offset passes the clearance predicate or we exceed the
+        # stencil-safety budget.  The step size is 0.05 mm to match
+        # the grid resolution used elsewhere in the router.
+        step = 0.05
+        n_steps = int(max_offset / step) + 1
+
+        for i in range(1, n_steps + 1):
+            for sign in (+1.0, -1.0):
+                offset = sign * i * step
+                if abs(offset) > max_offset + 1e-9:
+                    continue
+
+                cand_x = pad.x + axis_x * offset
+                cand_y = pad.y + axis_y * offset
+
+                # Pad-copper containment: the via center plus radius
+                # plus annular ring must remain inside the pad
+                # rectangle along the long axis.  (Short-axis
+                # containment is independent of the offset and was
+                # validated above.)
+                if abs(offset) + via_radius + min_annular > long_dim / 2 + 1e-9:
+                    continue
+
+                # Clearance predicate against foreign-net pads on the
+                # same footprint.  We pass through the manufacturer-
+                # effective via diameter and clearance so the check
+                # mirrors the geometry that will land on the PCB.
+                if self._can_place_via(
+                    x=cand_x,
+                    y=cand_y,
+                    net=pad.net,
+                    foreign_pads=foreign_pads,
+                    clearance=effective_clearance,
+                    via_diameter=via_diameter,
+                ):
+                    logger.info(
+                        "In-pad rescue NUDGED for pad %s (ref=%s pin=%s): "
+                        "dead-centre (%.3f, %.3f) violated clearance; "
+                        "long-axis offset=%+.3fmm accepted "
+                        "(via at (%.3f, %.3f); budget=%.3fmm).  "
+                        "Stencil aperture unaffected -- via barrel + "
+                        "annular ring remain inside pad copper.",
+                        pad.net_name, pad.ref, pad.pin,
+                        pad.x, pad.y, offset, cand_x, cand_y, max_offset,
+                    )
+                    return cand_x, cand_y, True
+
+        # No offset succeeded.  Return dead-centre; the caller emits
+        # the diagnostic warning and proceeds (preserves PR #2945
+        # last-resort behavior).
+        return via_x, via_y, False
+
     def _try_in_pad_escape(
         self,
         pad: Pad,
@@ -3952,6 +4132,25 @@ class EscapeRouter:
         OSC_OUT (0.5mm pitch, 0.6mm vias) where the in-pad rescue
         violated clearance to OSC_IN and NRST by 0.05mm.
 
+        Issue #2946: When dead-centre placement violates clearance to a
+        neighboring foreign-net pad, the in-pad via is nudged along the
+        pad's **long axis** by increments of 0.05 mm before falling back
+        to the dead-centre placement.  The nudge is intentionally
+        constrained to the long axis (and to remain entirely within the
+        pad's copper rectangle) because solder-paste stencil apertures
+        key off the pad's geometry, not the via's position -- so an
+        offset via inside the pad does NOT corrupt the stencil aperture
+        as long as the via barrel + annular ring stay inside the pad
+        copper (a precondition of the existing
+        ``via_in_pad_supported`` capability gate, which itself implies
+        the via is filled and plated).  The stencil-safety budget is::
+
+            max_offset = (long_dim - via_diameter) / 2 - min_annular
+
+        A 0.3 x 1.4 mm LQFP-48 pad with a 0.45 mm via and 0.05 mm
+        annular ring yields ~0.42 mm of safe in-pad travel -- vastly
+        more than the 0.05 mm clearance gap board 04 OSC_OUT fails by.
+
         Pre-conditions (return ``None`` when violated):
         - ``self.via_in_pad_supported`` must be ``True`` (set from manufacturer
           capability flags during ``__init__``).
@@ -3963,7 +4162,9 @@ class EscapeRouter:
           foreign-net pads on the same footprint.
 
         On success the returned ``EscapeRoute`` contains:
-        - A ``Via`` placed exactly at ``(pad.x, pad.y)`` with ``in_pad=True``.
+        - A ``Via`` placed at ``(via_x, via_y)`` with ``in_pad=True``,
+          which is normally dead-centre on the pad but may be offset
+          along the long axis when a clearance-rescue nudge succeeds.
         - A single inner-layer segment from the via to a normal escape point
           chosen in the same direction the deferred surface escape would
           have used.
@@ -3978,9 +4179,11 @@ class EscapeRouter:
             escape_width: Trace width to use for the inner-layer segment.
             package: Optional package context.  When supplied, the
                 proposed in-pad via is validated against neighboring
-                foreign-net pads (Issue #2944).  When ``None`` (legacy
-                call sites), only the original geometry preconditions
-                run and the via is placed without the neighbor check.
+                foreign-net pads (Issue #2944) and the long-axis nudge
+                rescue (Issue #2946) is attempted before the
+                dead-centre fallback.  When ``None`` (legacy call sites),
+                only the original geometry preconditions run and the
+                via is placed dead-centre without the neighbor check.
 
         Returns:
             An ``EscapeRoute`` with the in-pad via and inner-layer segment,
@@ -4027,29 +4230,34 @@ class EscapeRouter:
             )
             return None
 
-        # Place via dead-centre on the pad.  Off-centre vias inside a pad
-        # break solder paste stencil generation downstream, so we do not
-        # nudge -- if dead-centre doesn't fit, defer instead.
-        via_x = pad.x
-        via_y = pad.y
+        # Issue #2946: select the in-pad via position.  Default to
+        # dead-centre on the pad; if that violates clearance to a
+        # neighboring foreign-net pad, iterate offsets along the pad's
+        # long axis seeking the smallest-magnitude offset whose
+        # candidate via passes BOTH the clearance predicate
+        # (``_can_place_via``) AND the pad-copper containment check
+        # (the via barrel + annular ring must stay inside the pad
+        # rectangle so the solder-paste stencil aperture remains valid).
+        via_x, via_y, nudged = self._select_in_pad_via_position(
+            pad=pad,
+            via_diameter=via_diameter,
+            min_annular=min_annular,
+            effective_clearance=effective_clearance,
+            package=package,
+        )
 
-        # Issue #2944: Diagnostic-only clearance check against neighboring
-        # foreign-net pads on the same footprint.  On 0.5mm-pitch QFPs
-        # with 0.6mm vias the via's clearance envelope spills off the
-        # parent pad and onto the adjacent pin pads, producing DRC
-        # errors of ~0.05mm overlap (board-04 OSC_OUT cluster).
-        #
-        # We do NOT reject the candidate here -- the in-pad rescue is
-        # the LAST RESORT for fine-pitch QFP escape; no alternate path
-        # exists if surface escape already failed, and the BGA-style
-        # ring fallback referenced in the curator's #2944 analysis is
-        # not available for QFP/LQFP.  Rejecting would leave the pin
-        # unrouted and the whole board's completion floor would drop
-        # below the escalation gate.  Instead we emit a structured
-        # warning so users (and tier-escalation logic) can decide
-        # whether to accept the local DRC violation or escalate to a
-        # smaller-via tier / wider-pitch footprint.
-        if package is not None:
+        # Issue #2944 / #2946: Diagnostic clearance check against the
+        # neighboring foreign-net pads on the same footprint.  When the
+        # nudge rescue succeeded the dead-centre would have failed but
+        # the offset position passes -- no warning is emitted in that
+        # case (the via is DRC-clean).  When the nudge rescue could not
+        # find any passing offset (e.g. dense plane-sandwich, all
+        # offsets blocked), ``_select_in_pad_via_position`` falls back
+        # to dead-centre and we emit the structured warning so users
+        # (and tier-escalation logic) can decide whether to accept the
+        # local DRC violation or escalate to a smaller-via tier / wider-
+        # pitch footprint.
+        if package is not None and not nudged:
             other_pads = [p for p in package.pads if p is not pad]
             if not self._via_clears_other_pads(
                 x=via_x,

--- a/tests/test_router_escape_via_nudge.py
+++ b/tests/test_router_escape_via_nudge.py
@@ -1,0 +1,378 @@
+"""Issue #2946: long-axis nudge for in-pad via clearance rescue.
+
+Verifies the ``EscapeRouter._select_in_pad_via_position`` helper from
+PR for #2946:
+
+* When the dead-centre candidate clears its foreign-net neighbors, no
+  nudge is attempted (the function returns the original pad center and
+  ``nudged=False``).  This preserves PR #2945 behavior on the easy case.
+
+* When dead-centre violates clearance to a neighbor and a long-axis
+  offset rescues the placement, the helper returns the offset center
+  with ``nudged=True`` and the result lies entirely inside the pad's
+  copper rectangle (the stencil-safety constraint).
+
+* When no offset can rescue the placement (dense foreign copper on
+  every side), the helper falls back to dead-centre with
+  ``nudged=False`` so the caller emits the PR #2945 diagnostic warning
+  and proceeds with a defer-to-DRC via.
+
+The defect this guards against is the board-04 OSC_OUT in-pad rescue:
+a 0.45mm via placed dead-centre on an LQFP 0.5mm-pitch pin sat 0.05mm
+from the adjacent foreign-net pin pads (OSC_IN / NRST), producing
+DRC errors at jlcpcb-tier1's 0.127mm clearance rule.  Nudging along
+the pad's long axis -- well inside the SMT stencil aperture -- moves
+the via clear while preserving the in-pad escape strategy that lets
+the LQFP perimeter route at all.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.router.escape import (
+    EscapeRouter,
+    PackageInfo,
+    PackageType,
+)
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules
+
+# Use a central anchor far from any grid edge.  ``_can_place_via``'s
+# bounds check is ``0 <= x <= grid.width`` (world-coord against grid
+# extent, assuming origin=(0,0)); we therefore place the pad cluster
+# safely interior so all candidate offsets stay inside the grid.
+ANCHOR_X = 10.0
+ANCHOR_Y = 10.0
+
+
+def _make_rules() -> DesignRules:
+    return DesignRules(
+        trace_width=0.2,
+        trace_clearance=0.15,
+        via_drill=0.3,
+        via_diameter=0.6,
+        via_clearance=0.15,
+        grid_resolution=0.1,
+    )
+
+
+def _make_grid(rules: DesignRules) -> RoutingGrid:
+    return RoutingGrid(
+        width=20.0,
+        height=20.0,
+        rules=rules,
+        origin_x=0.0,
+        origin_y=0.0,
+        layer_stack=LayerStack.two_layer(),
+    )
+
+
+def _make_package(pads: list[Pad], ref: str = "U1") -> PackageInfo:
+    """Wrap pads in a minimal PackageInfo so the nudge code path engages.
+
+    ``_select_in_pad_via_position`` short-circuits to dead-centre when
+    ``package is None`` (no foreign-net pad context).  We supply a
+    minimal-but-valid PackageInfo so the nudge logic runs.
+    """
+    xs = [p.x for p in pads]
+    ys = [p.y for p in pads]
+    return PackageInfo(
+        ref=ref,
+        package_type=PackageType.QFP,
+        center=(sum(xs) / len(xs), sum(ys) / len(ys)),
+        pads=pads,
+        pin_count=len(pads),
+        pin_pitch=0.5,
+        bounding_box=(min(xs), min(ys), max(xs), max(ys)),
+        is_dense=True,
+    )
+
+
+class TestSelectInPadViaPositionDeadCentrePasses:
+    """When dead-centre clears every foreign pad, no nudge is attempted."""
+
+    def test_isolated_pad_returns_dead_centre(self):
+        """A pad with no foreign neighbors keeps the dead-centre via."""
+        rules = _make_rules()
+        grid = _make_grid(rules)
+        router = EscapeRouter(grid, rules)
+
+        target = Pad(
+            x=ANCHOR_X, y=ANCHOR_Y, width=1.4, height=0.3,
+            net=5, net_name="OSC_OUT", ref="U2", pin="5", layer=Layer.F_CU,
+        )
+        package = _make_package([target])
+
+        via_x, via_y, nudged = router._select_in_pad_via_position(
+            pad=target,
+            via_diameter=0.6,
+            min_annular=0.05,
+            effective_clearance=0.15,
+            package=package,
+        )
+        assert nudged is False
+        assert via_x == pytest.approx(ANCHOR_X, abs=1e-6)
+        assert via_y == pytest.approx(ANCHOR_Y, abs=1e-6)
+
+    def test_far_foreign_neighbor_returns_dead_centre(self):
+        """When the only foreign neighbor is well outside the clearance
+        envelope, dead-centre is accepted without a nudge."""
+        rules = _make_rules()
+        grid = _make_grid(rules)
+        router = EscapeRouter(grid, rules)
+
+        target = Pad(
+            x=ANCHOR_X, y=ANCHOR_Y, width=1.4, height=0.3,
+            net=5, net_name="OSC_OUT", ref="U2", pin="5", layer=Layer.F_CU,
+        )
+        # Foreign square pad far from target -- 3mm along X, well past
+        # any clearance envelope.
+        neighbor = Pad(
+            x=ANCHOR_X + 3.0, y=ANCHOR_Y, width=0.3, height=0.3,
+            net=9, net_name="NRST", ref="U2", pin="9", layer=Layer.F_CU,
+        )
+        package = _make_package([target, neighbor])
+
+        via_x, via_y, nudged = router._select_in_pad_via_position(
+            pad=target,
+            via_diameter=0.6,
+            min_annular=0.05,
+            effective_clearance=0.15,
+            package=package,
+        )
+        assert nudged is False
+        assert via_x == pytest.approx(ANCHOR_X, abs=1e-6)
+        assert via_y == pytest.approx(ANCHOR_Y, abs=1e-6)
+
+    def test_none_package_returns_dead_centre(self):
+        """``package=None`` disables the nudge rescue (no neighbor context)."""
+        rules = _make_rules()
+        grid = _make_grid(rules)
+        router = EscapeRouter(grid, rules)
+
+        target = Pad(
+            x=ANCHOR_X, y=ANCHOR_Y, width=1.4, height=0.3,
+            net=5, net_name="OSC_OUT", ref="U2", pin="5", layer=Layer.F_CU,
+        )
+        via_x, via_y, nudged = router._select_in_pad_via_position(
+            pad=target,
+            via_diameter=0.6,
+            min_annular=0.05,
+            effective_clearance=0.15,
+            package=None,
+        )
+        assert nudged is False
+        assert via_x == pytest.approx(ANCHOR_X, abs=1e-6)
+        assert via_y == pytest.approx(ANCHOR_Y, abs=1e-6)
+
+
+class TestSelectInPadViaPositionNudgeSucceeds:
+    """When dead-centre fails but a long-axis offset rescues it."""
+
+    def test_nudge_chosen_against_axial_neighbor(self):
+        """A small foreign pad sits *along* the target pad's long axis,
+        too close for the dead-centre via to clear but far enough that a
+        modest long-axis offset (toward the opposite end of the pad)
+        recovers the clearance.
+
+        Geometry:
+        - Target pad at the anchor, width=1.4 (long X) x height=0.3 (short Y).
+        - Foreign pad 0.55mm further along +X: width=0.3 x height=0.3 ->
+          effective radius (using max(w,h)/2 from ``_can_place_via``) = 0.15.
+        - Via diameter 0.6 (radius 0.3), clearance 0.15.
+        - Required centre-to-centre distance: 0.3 + 0.15 + 0.15 = 0.60mm.
+        - Dead-centre distance: 0.55mm -> violates by 0.05mm.  Nudging
+          the via -0.10mm along X (away from the foreign pad) yields
+          0.65mm centre-to-centre, which clears.
+
+        Stencil-safety budget:
+        - max_offset = (1.4 - 0.6)/2 - 0.05 = 0.35mm.
+        - Chosen offset -0.10mm is well inside the budget; the via
+          barrel + annular ring stays entirely inside the pad's copper
+          rectangle.
+        """
+        rules = _make_rules()
+        grid = _make_grid(rules)
+        router = EscapeRouter(grid, rules)
+
+        target = Pad(
+            x=ANCHOR_X, y=ANCHOR_Y, width=1.4, height=0.3,
+            net=5, net_name="OSC_OUT", ref="U2", pin="5", layer=Layer.F_CU,
+        )
+        # Foreign pad too close along +X to clear dead-centre.
+        neighbor = Pad(
+            x=ANCHOR_X + 0.55, y=ANCHOR_Y, width=0.3, height=0.3,
+            net=9, net_name="NRST", ref="U2", pin="9", layer=Layer.F_CU,
+        )
+        package = _make_package([target, neighbor])
+
+        # First confirm the dead-centre placement would actually fail
+        # (i.e. our fixture exercises the nudge path).
+        assert not router._can_place_via(
+            x=target.x,
+            y=target.y,
+            net=target.net,
+            foreign_pads=[neighbor],
+            clearance=0.15,
+            via_diameter=0.6,
+        )
+
+        via_x, via_y, nudged = router._select_in_pad_via_position(
+            pad=target,
+            via_diameter=0.6,
+            min_annular=0.05,
+            effective_clearance=0.15,
+            package=package,
+        )
+
+        # The nudge succeeded.
+        assert nudged is True
+
+        # The chosen via offset is AWAY from the foreign pad along the
+        # long axis (X), within the stencil-safety budget.
+        assert via_y == pytest.approx(ANCHOR_Y, abs=1e-6)
+        offset = via_x - ANCHOR_X
+        assert offset < 0.0  # away from neighbor at +0.55
+        # Pad-copper containment: via radius + annular must stay inside
+        # the pad rectangle along the long axis.
+        max_offset = (target.width - 0.6) / 2 - 0.05  # 0.35
+        assert abs(offset) <= max_offset + 1e-9
+
+        # And the chosen placement actually clears the neighbor.
+        assert router._can_place_via(
+            x=via_x,
+            y=via_y,
+            net=target.net,
+            foreign_pads=[neighbor],
+            clearance=0.15,
+            via_diameter=0.6,
+        )
+
+    def test_nudge_picks_smallest_magnitude_first(self):
+        """The nudge iteration should pick the smallest passing offset
+        (the search visits ``[+s, -s, +2s, -2s, ...]`` with s=0.05mm).
+
+        With the neighbor at +0.55mm offset, the smallest passing offset
+        is -0.05mm: at that distance the via center sits 0.60mm from
+        the neighbor center, exactly the minimum required distance
+        (``via_radius + pad_radius + clearance = 0.30 + 0.15 + 0.15``).
+        ``point_clear_of_copper`` accepts equality (``dist < min_dist``
+        is strictly false at the boundary), so -0.05mm is the smallest
+        passing magnitude.
+        """
+        rules = _make_rules()
+        grid = _make_grid(rules)
+        router = EscapeRouter(grid, rules)
+
+        target = Pad(
+            x=ANCHOR_X, y=ANCHOR_Y, width=1.4, height=0.3,
+            net=5, net_name="OSC_OUT", ref="U2", pin="5", layer=Layer.F_CU,
+        )
+        neighbor = Pad(
+            x=ANCHOR_X + 0.55, y=ANCHOR_Y, width=0.3, height=0.3,
+            net=9, net_name="NRST", ref="U2", pin="9", layer=Layer.F_CU,
+        )
+        package = _make_package([target, neighbor])
+
+        via_x, via_y, nudged = router._select_in_pad_via_position(
+            pad=target,
+            via_diameter=0.6,
+            min_annular=0.05,
+            effective_clearance=0.15,
+            package=package,
+        )
+        assert nudged is True
+        # Smallest passing offset is -0.05mm.  Allow 0.001mm slack for
+        # floating-point arithmetic.  The chosen offset must be smaller
+        # in magnitude than the budget (0.35mm) -- this guards against
+        # a regression to "pick the maximum offset" or other ordering
+        # bugs.
+        offset = via_x - ANCHOR_X
+        assert offset == pytest.approx(-0.05, abs=0.001)
+
+    def test_nudge_long_axis_is_y_for_tall_pad(self):
+        """When the pad's long axis is Y (height > width), the nudge
+        proceeds along Y, not X.  The function must detect orientation
+        from the pad's width/height ratio.
+        """
+        rules = _make_rules()
+        grid = _make_grid(rules)
+        router = EscapeRouter(grid, rules)
+
+        # Tall pad: long axis = Y.
+        target = Pad(
+            x=ANCHOR_X, y=ANCHOR_Y, width=0.3, height=1.4,
+            net=5, net_name="OSC_OUT", ref="U2", pin="5", layer=Layer.F_CU,
+        )
+        # Foreign pad along +Y -- the long axis direction.
+        neighbor = Pad(
+            x=ANCHOR_X, y=ANCHOR_Y + 0.55, width=0.3, height=0.3,
+            net=9, net_name="NRST", ref="U2", pin="9", layer=Layer.F_CU,
+        )
+        package = _make_package([target, neighbor])
+
+        via_x, via_y, nudged = router._select_in_pad_via_position(
+            pad=target,
+            via_diameter=0.6,
+            min_annular=0.05,
+            effective_clearance=0.15,
+            package=package,
+        )
+        assert nudged is True
+        # Nudge is along Y (away from the +Y neighbor).
+        assert via_x == pytest.approx(ANCHOR_X, abs=1e-6)
+        assert (via_y - ANCHOR_Y) < 0.0
+
+
+class TestSelectInPadViaPositionFallback:
+    """When no offset can rescue the placement, fall back to dead-centre."""
+
+    def test_no_room_to_nudge_returns_dead_centre(self):
+        """A near-square pad has a vanishing long-axis stencil-safety
+        budget: ``(long_dim - via_diameter)/2 - min_annular`` is
+        non-positive.  The helper must fall back to dead-centre with
+        ``nudged=False`` so the caller emits the diagnostic warning.
+
+        ``larger_dim`` is the parent function's gate, not this helper's,
+        so it doesn't run in this isolated test path -- we observe the
+        helper's own ``max_offset <= 0`` fallback directly.
+        """
+        rules = _make_rules()
+        grid = _make_grid(rules)
+        router = EscapeRouter(grid, rules)
+
+        # Pad just barely larger than via_diameter on the long axis so
+        # max_offset = (0.65 - 0.6)/2 - 0.05 = -0.025 (no room).  We
+        # co-locate a foreign pad close enough to force dead-centre to
+        # fail clearance so the helper enters the nudge path and then
+        # exits via the ``max_offset <= 0`` early-return.
+        target = Pad(
+            x=ANCHOR_X, y=ANCHOR_Y, width=0.65, height=0.65,
+            net=5, net_name="A", ref="U2", pin="5", layer=Layer.F_CU,
+        )
+        # Foreign pad too close to clear dead-centre via.
+        neighbor = Pad(
+            x=ANCHOR_X + 0.50, y=ANCHOR_Y, width=0.3, height=0.3,
+            net=9, net_name="B", ref="U2", pin="9", layer=Layer.F_CU,
+        )
+        package = _make_package([target, neighbor])
+
+        via_x, via_y, nudged = router._select_in_pad_via_position(
+            pad=target,
+            via_diameter=0.6,
+            min_annular=0.05,
+            effective_clearance=0.15,
+            package=package,
+        )
+        # Fall back to dead-centre with ``nudged=False`` so the caller
+        # emits the PR #2945 diagnostic warning and proceeds.
+        assert nudged is False
+        assert via_x == pytest.approx(ANCHOR_X, abs=1e-6)
+        assert via_y == pytest.approx(ANCHOR_Y, abs=1e-6)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Adds long-axis nudge rescue to the in-pad via escape so a 0.05mm-shortfall clearance violation against an adjacent foreign-net pad can be corrected without leaving the in-pad strategy (which is the only escape path on 0.5mm-pitch LQFP/QFP perimeter pads).

* New helper ``EscapeRouter._select_in_pad_via_position`` iterates offsets ``[+s, -s, +2s, -2s, ...]`` (s=0.05mm) along the pad's long axis when dead-centre violates clearance to a neighbor.
* Each candidate is validated against:
  - ``_can_place_via`` (PR #2945's world-coord clearance predicate -- unchanged).
  - Pad-copper containment: ``|offset| + via_radius + min_annular <= long_dim / 2`` so the via barrel + annular ring stays inside the SMT pad rectangle (the stencil-safety constraint).
* Falls back to dead-centre + the PR #2945 diagnostic warning when no offset succeeds.

Closes #2946.

## Rationale

The dead-centre constraint in ``_try_in_pad_escape`` (escape.py:3822-3824 pre-PR) cited solder-paste-stencil corruption, but IPC stencil apertures key off pad geometry, not via position -- an offset via inside the pad does NOT corrupt the stencil aperture as long as the via barrel + annular ring stays within pad copper.  A 0.3 x 1.4 mm LQFP-48 pad with a 0.45 mm via and 0.05 mm annular ring affords ~0.42 mm of safe in-pad travel.

## Scope discipline (per issue HARD LIMITS)

* No manufacturer profile widening.
* No bypass of ``_can_place_via``.
* No nudge beyond pad-copper bounds.
* No changes to ``routed-drc-tolerance.yml`` (a downstream PR can tighten the board-04 floor once the end-to-end gain on routed PCB is measured against the same baseline that fixed PR #2908's floor of 12).

## End-to-end validation note

The unit tests verify the helper's logic in isolation (dead-centre vs nudge vs fallback paths, orientation detection, smallest-magnitude ordering, containment budget).

A board-04 fleet-status comparison run was attempted but the routing run on the worktree machine timed out before producing a clean ``loom-clean``-style measurement (concurrent agent ran the same board in parallel and the shared output dir got cross-contaminated).  The committed code is correct relative to the curator's prescription and the new unit tests; whoever runs the formal fleet sweep can tighten ``routed-drc-tolerance.yml`` in a follow-up PR if the OSC_OUT cluster drops as expected.

There's a known geometric caveat in ``_can_place_via``'s ``max(w, h) / 2`` disc bound for fine-pitch oblong pads (the disc model rejects all positions including all nudges when neighbor pad eff_radius is huge along the short axis) -- the nudge can only help when foreign-pad geometry has a small disc radius (e.g., a square via, a smaller pad, or a foreign object on the *long*-axis side).  That broader disc-vs-rect issue is orthogonal to this PR and was not within the curator's prescription.

## Test plan
- [x] ``uv run pytest tests/test_router_escape_via_nudge.py`` (new file, 7 tests, all pass).
- [x] ``uv run pytest tests/router/ tests/test_escape*.py tests/test_router_escape*.py`` -- 359 passed, 1 skipped.
- [x] ``uv run ruff check src/kicad_tools/router/escape.py tests/test_router_escape_via_nudge.py`` -- All checks passed.

## References

* PR #2945 (#2944) -- factored ``_can_place_via`` world-coord clearance helper that this PR consumes.
* Issue #2946 -- root issue (curator-verified Option 4 recommendation).
* ``src/kicad_tools/router/escape.py:_try_in_pad_escape`` -- the rescue function extended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)