### PR TITLE
fix(router): pathfinder _check_via_placement_cached considers world-coord clearance (closes #2947)

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -1530,6 +1530,56 @@ class Autorouter:
         if hasattr(self.router, "set_unrouted_pads"):
             self.router.set_unrouted_pads(unrouted_pads)
 
+    def _update_router_via_foreign_context(self, current_net: int) -> None:
+        """Update router foreign-net context for world-coord via clearance.
+
+        Issue #2947: ``pathfinder.Router._check_via_placement_cached``
+        consults a coarse-grid obstacle map that can admit vias which
+        violate world-coordinate clearance against foreign-net pads /
+        committed tracks (most visibly: board-04 BOOT0 vias overlapping
+        SWDIO/SWCLK by 0.1-0.2 mm).  We push the foreign-net pads and
+        already-committed track segments to the router so it can run
+        the same ``point_clear_of_copper`` predicate the escape phase
+        already uses (PR #2945 / Issue #2944).
+
+        Same-net obstacles are filtered here (matches the escape-router
+        boundary convention).  A* has a fallback at both call sites
+        (`pathfinder.py:2227` / `:3516` use ``continue`` on rejection)
+        so a hard reject is safe -- the search will try alternate via
+        positions or alternate 2D paths.
+
+        Args:
+            current_net: The net ID being routed (foreign = pads/segments
+                whose net != current_net).
+        """
+        if not hasattr(self.router, "set_via_foreign_context"):
+            return  # C++ backend or test stub without the hook -- no-op.
+
+        # Foreign pads: every pad whose net differs from ``current_net``.
+        # ``set_via_foreign_context`` filters same-net per-call too, but
+        # filtering here keeps the list bounded for boards with large
+        # pad counts.
+        foreign_pads = [
+            p for p in self.pads.values() if p.net != current_net
+        ]
+
+        # Foreign tracks: all committed Segment objects from ``self.routes``
+        # whose net differs from ``current_net``.  Routes for the current
+        # net are still in flight so they're naturally absent; we
+        # additionally guard with the same-net filter for robustness
+        # against the rip-up / retry path that may leave partial
+        # ``current_net`` routes in ``self.routes``.
+        foreign_tracks = []
+        for route in self.routes:
+            if route.net == current_net:
+                continue
+            foreign_tracks.extend(route.segments)
+
+        self.router.set_via_foreign_context(
+            foreign_pads=foreign_pads,
+            foreign_tracks=foreign_tracks,
+        )
+
     def route_net(
         self,
         net: int,
@@ -1560,6 +1610,11 @@ class Autorouter:
 
         # Issue #1019: Update router with unrouted pad info for via impact scoring
         self._update_router_unrouted_pads(net)
+
+        # Issue #2947: Push foreign-net pad / track context so
+        # ``_check_via_placement_cached`` can apply the same world-coord
+        # clearance predicate the escape phase uses (PR #2945).
+        self._update_router_via_foreign_context(net)
 
         routes: list[Route] = []
 

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -31,6 +31,25 @@ from .heuristics import DEFAULT_HEURISTIC, Heuristic, HeuristicContext
 from .layers import Layer
 from .primitives import Pad, Route, Segment, Via
 from .rules import DEFAULT_NET_CLASS_MAP, DesignRules, NetClassRouting
+from .via_clearance import point_clear_of_copper
+
+
+@dataclass(frozen=True)
+class _SegmentAdapter:
+    """Adapter exposing :class:`Segment` with the ``start_x/start_y/end_x/end_y``
+    attribute names expected by :func:`point_clear_of_copper`.
+
+    Issue #2947: The shared clearance helper consumes duck-typed track
+    segments via the ``TrackSegmentLike`` protocol; :class:`Segment` uses
+    ``x1, y1, x2, y2``.  Mirrors the identical adapter in
+    :mod:`kicad_tools.router.escape` (PR #2945 for Issue #2944).
+    """
+
+    start_x: float
+    start_y: float
+    end_x: float
+    end_y: float
+    width: float
 
 
 @dataclass(order=True)
@@ -164,6 +183,22 @@ class Router:
         # Cache is cleared when routes are modified (invalidates blocking state)
         self._via_cache: dict[tuple[int, int, int, int], bool] = {}
         self._via_cache_enabled: bool = True
+
+        # Issue #2947: World-coord foreign-net clearance context for via
+        # placement.  The coarse-grid obstacle map consulted by
+        # ``_is_via_blocked`` can admit a via that sits within
+        # ``via_radius + obstacle_radius + clearance`` of a foreign-net pad
+        # or trace in world coordinates -- the same bug class PR #2945
+        # patched in ``EscapeRouter._can_place_via``.  When this context is
+        # populated via :meth:`set_via_foreign_context`,
+        # ``_check_via_placement_cached`` consults
+        # :func:`point_clear_of_copper` after the per-layer grid check
+        # passes.  Empty by default so behavior matches pre-#2947 when no
+        # caller wires the context up.  Cache invariant: the setter
+        # CLEARS ``_via_cache`` so subsequent checks re-evaluate against
+        # the new context (same pattern as ``add_routed_segments``).
+        self._foreign_pad_tuples: list[tuple[float, float, float, int]] = []
+        self._foreign_track_adapters: list[_SegmentAdapter] = []
 
         # Issue #1016: Component pitch cache for per-component clearance
         # Computed lazily on first use
@@ -652,6 +687,64 @@ class Router:
                 pitch = component_pitches[ref]
                 if pitch < self.rules.fine_pitch_threshold:
                     self._fine_pitch_pad_positions.append((pad.x, pad.y, ref))
+
+    def set_via_foreign_context(
+        self,
+        foreign_pads: list[Pad] | None = None,
+        foreign_tracks: list[Segment] | None = None,
+    ) -> None:
+        """Set foreign-net pad / track context for world-coord via clearance.
+
+        Issue #2947: ``_check_via_placement_cached`` historically only
+        consulted the coarse-grid obstacle map via ``_is_via_blocked``.
+        A via that lands on a "free" grid cell can still sit within
+        ``via_radius + foreign_obstacle_radius + clearance`` of an
+        adjacent foreign-net pad / trace in world coordinates -- the
+        coarse grid's resolution loses this distinction.  When this
+        context is populated, the via predicate consults
+        :func:`point_clear_of_copper` after the grid check passes.
+
+        Cache-key safety: the via cache key is
+        ``(gx, gy, net, effective_radius)`` -- already net-keyed, so
+        cross-net stale positives are impossible.  Within a single
+        net, however, a positive cache entry from a stale foreign
+        context could now be wrong (a foreign track may have committed
+        since).  This setter therefore CLEARS the via cache so subsequent
+        checks re-evaluate against the new context.  Same invariant
+        ``add_routed_segments`` / ``clear_via_cache`` already maintain.
+
+        Args:
+            foreign_pads: Board pads (any net) the via must clear.
+                Same-net pads are filtered per-call so a superset is
+                fine.
+            foreign_tracks: Committed track segments (any net) the via
+                must clear.  Same-net segments are filtered per-call.
+        """
+        pad_tuples: list[tuple[float, float, float, int]] = []
+        if foreign_pads:
+            for p in foreign_pads:
+                # Effective pad radius: max(width, height) / 2 so the
+                # predicate is conservative for oblong fine-pitch pads
+                # (mirrors EscapeRouter._can_place_via, Issue #2944).
+                eff_radius = max(p.width, p.height) / 2
+                pad_tuples.append((p.x, p.y, eff_radius, p.net))
+
+        track_adapters: list[_SegmentAdapter] = []
+        if foreign_tracks:
+            for s in foreign_tracks:
+                track_adapters.append(
+                    _SegmentAdapter(
+                        start_x=s.x1, start_y=s.y1,
+                        end_x=s.x2, end_y=s.y2,
+                        width=s.width,
+                    )
+                )
+
+        self._foreign_pad_tuples = pad_tuples
+        self._foreign_track_adapters = track_adapters
+
+        # Foreign context affects via blocking results -- invalidate cache.
+        self.clear_via_cache()
 
     def _get_via_impact_cost(self, wx: float, wy: float, current_net: int) -> float:
         """Calculate the impact cost of placing a via at the given position.
@@ -1288,6 +1381,41 @@ class Router:
             if self._is_via_blocked(gx, gy, check_layer, net, allow_sharing,
                                      radius=radius):
                 # Cache the negative result
+                if self._via_cache_enabled and not allow_sharing:
+                    self._via_cache[(gx, gy, net, effective_radius)] = False
+                return False
+
+        # Issue #2947: World-coord foreign-net clearance check.  The
+        # per-layer coarse-grid check above can admit a via that sits
+        # within ``via_radius + foreign_obstacle_radius + clearance`` of
+        # an adjacent foreign-net pad / trace in world coordinates -- the
+        # grid resolution loses the sub-cell distinction.  Same bug
+        # class PR #2945 patched in ``EscapeRouter._can_place_via``.
+        # Only runs when ``set_via_foreign_context`` has populated the
+        # context lists (otherwise behavior matches pre-#2947).  A* has
+        # a fallback at both call sites (``continue`` on rejection ->
+        # next neighbor / next via position), so a hard reject here is
+        # safe -- unlike the QFP in-pad rescue path.
+        if self._foreign_pad_tuples or self._foreign_track_adapters:
+            wx, wy = self.grid.grid_to_world(gx, gy)
+            # Effective via diameter from grid radius (cells -> mm).
+            eff_diameter = 2 * effective_radius * self.grid.resolution
+            # Filter same-net obstacles (passing a superset is allowed
+            # by ``point_clear_of_copper``'s contract but the same-net
+            # filter avoids spurious rejections on the routing net).
+            other_pads = [p for p in self._foreign_pad_tuples if p[3] != net]
+            # Track adapter does not carry net id; the caller
+            # (``Autorouter``) is responsible for excluding same-net
+            # segments before populating the context.  This matches
+            # ``EscapeRouter``'s pattern at the boundary.
+            if not point_clear_of_copper(
+                x=wx,
+                y=wy,
+                via_size=eff_diameter,
+                clearance=self.rules.via_clearance,
+                other_net_tracks=self._foreign_track_adapters,
+                other_net_pads=other_pads,
+            ):
                 if self._via_cache_enabled and not allow_sharing:
                     self._via_cache[(gx, gy, net, effective_radius)] = False
                 return False

--- a/tests/test_pathfinder_via_foreign_clearance.py
+++ b/tests/test_pathfinder_via_foreign_clearance.py
@@ -1,0 +1,206 @@
+"""Tests for Issue #2947: pathfinder via foreign-net world-coord clearance.
+
+The bug: ``Router._check_via_placement_cached`` consulted only the
+coarse-grid obstacle map via ``_is_via_blocked``, so a via that lands on
+a "free" grid cell could still violate world-coord clearance against a
+foreign-net pad / committed track (most visibly: board-04 BOOT0 vias
+overlapping SWDIO/SWCLK by 0.1-0.2 mm).
+
+The fix: after the per-layer grid check passes, call
+``via_clearance.point_clear_of_copper`` against the foreign-net context
+pushed by :meth:`Autorouter._update_router_via_foreign_context`.  When
+no foreign context is set (default / pre-#2947), behavior is unchanged.
+"""
+
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.pathfinder import Router
+from kicad_tools.router.primitives import Pad, Segment
+from kicad_tools.router.rules import DesignRules
+
+
+def _make_router() -> tuple[Router, RoutingGrid]:
+    """Build a small two-layer router with a known-good origin."""
+    stack = LayerStack.two_layer()
+    rules = DesignRules(grid_resolution=0.5)
+    grid = RoutingGrid(
+        width=20.0,
+        height=20.0,
+        rules=rules,
+        layer_stack=stack,
+    )
+    return Router(grid, rules), grid
+
+
+class TestForeignContextBaseline:
+    """Without foreign context, behavior matches pre-#2947 (the existing
+    via_placement_regression tests already cover the grid-only path)."""
+
+    def test_no_foreign_context_allows_clear_cell(self):
+        """A clear cell with no foreign context returns True."""
+        router, grid = _make_router()
+        # Pick a cell in the interior with no obstacles.
+        can_place = router._check_via_placement_cached(
+            gx=20, gy=20, net=1, allow_sharing=False
+        )
+        assert can_place
+
+    def test_setter_default_args_empty(self):
+        """Calling the setter with no args clears stale context."""
+        router, _ = _make_router()
+        # Pre-populate with a foreign pad to ensure a later clear works.
+        bad_pad = Pad(x=10.0, y=10.0, width=1.0, height=1.0, net=99, net_name="X")
+        router.set_via_foreign_context(foreign_pads=[bad_pad])
+        assert router._foreign_pad_tuples  # populated
+
+        router.set_via_foreign_context()  # clear
+        assert router._foreign_pad_tuples == []
+        assert router._foreign_track_adapters == []
+
+
+class TestForeignPadRejection:
+    """A via that passes the grid check but encroaches on a foreign-net
+    pad's clearance envelope must be rejected."""
+
+    def test_foreign_pad_within_clearance_blocks(self):
+        """Foreign pad close enough to violate via clearance -> rejected."""
+        router, grid = _make_router()
+        # Pick a cell whose world-coord position will be near (but not
+        # touching) a foreign-net pad.  With rules.via_clearance=0.2,
+        # via_diameter=0.7 (radius=0.35) and pad effective_radius=
+        # max(w,h)/2=0.5, the threshold is 0.35 + 0.5 + 0.2 = 1.05 mm.
+        gx, gy = 20, 20
+        wx, wy = grid.grid_to_world(gx, gy)
+
+        # Place a foreign-net pad 0.6 mm from the via center -- well
+        # inside the 1.05 mm threshold.
+        foreign_pad = Pad(
+            x=wx + 0.6, y=wy,
+            width=1.0, height=1.0,
+            net=99, net_name="FOREIGN",
+        )
+        router.set_via_foreign_context(foreign_pads=[foreign_pad])
+
+        # Without foreign-context, the grid check would pass; the
+        # world-coord check must now reject.
+        can_place = router._check_via_placement_cached(
+            gx=gx, gy=gy, net=1, allow_sharing=False
+        )
+        assert not can_place, (
+            "Via must be rejected: foreign-net pad at 0.6 mm violates "
+            "0.35 (via_r) + 0.5 (pad_r) + 0.2 (clear) = 1.05 mm threshold"
+        )
+
+    def test_same_net_pad_does_not_block(self):
+        """A pad on the via's own net is filtered out (no rejection)."""
+        router, grid = _make_router()
+        gx, gy = 20, 20
+        wx, wy = grid.grid_to_world(gx, gy)
+
+        same_net_pad = Pad(
+            x=wx + 0.6, y=wy,
+            width=1.0, height=1.0,
+            net=1, net_name="SAME",
+        )
+        router.set_via_foreign_context(foreign_pads=[same_net_pad])
+
+        can_place = router._check_via_placement_cached(
+            gx=gx, gy=gy, net=1, allow_sharing=False
+        )
+        assert can_place, "Same-net pad must not trigger foreign-net rejection"
+
+    def test_distant_foreign_pad_does_not_block(self):
+        """Foreign pad far outside the clearance envelope -> allowed."""
+        router, grid = _make_router()
+        gx, gy = 20, 20
+        wx, wy = grid.grid_to_world(gx, gy)
+
+        far_pad = Pad(
+            x=wx + 5.0, y=wy,  # 5 mm clear -- way beyond 1.05 mm
+            width=1.0, height=1.0,
+            net=99, net_name="FAR",
+        )
+        router.set_via_foreign_context(foreign_pads=[far_pad])
+
+        can_place = router._check_via_placement_cached(
+            gx=gx, gy=gy, net=1, allow_sharing=False
+        )
+        assert can_place
+
+
+class TestForeignTrackRejection:
+    """The board-04 BOOT0 cluster: a via that passes the grid check but
+    overlaps a committed foreign-net track segment."""
+
+    def test_foreign_track_within_clearance_blocks(self):
+        """Foreign track segment 0.15 mm from via center -> rejected."""
+        router, grid = _make_router()
+        gx, gy = 20, 20
+        wx, wy = grid.grid_to_world(gx, gy)
+
+        # A horizontal track on the same Y, 0.15 mm above the via.
+        # via_r=0.35 + seg_w/2=0.125 + clear=0.2 = 0.675 mm threshold;
+        # 0.15 mm is well inside.  Models the BOOT0 vs SWDIO/SWCLK
+        # geometry from the board-04 cluster (-0.204 mm overlap).
+        foreign_track = Segment(
+            x1=wx - 2.0, y1=wy + 0.15,
+            x2=wx + 2.0, y2=wy + 0.15,
+            width=0.25, layer=Layer.B_CU, net=99, net_name="BOOT0_FOE",
+        )
+        router.set_via_foreign_context(foreign_tracks=[foreign_track])
+
+        can_place = router._check_via_placement_cached(
+            gx=gx, gy=gy, net=1, allow_sharing=False
+        )
+        assert not can_place, (
+            "Via must be rejected: foreign-net track at 0.15 mm violates "
+            "0.35 (via_r) + 0.125 (seg_w/2) + 0.2 (clear) = 0.675 mm threshold"
+        )
+
+
+class TestCacheInvariants:
+    """Cache invariant: setting foreign context must invalidate cached
+    results (mirrors the ``add_routed_segments`` / ``clear_via_cache``
+    pattern)."""
+
+    def test_setter_clears_via_cache(self):
+        """``set_via_foreign_context`` clears stale cache entries."""
+        router, grid = _make_router()
+
+        # Prime the cache with a positive result.
+        can_place_1 = router._check_via_placement_cached(
+            gx=20, gy=20, net=1, allow_sharing=False
+        )
+        assert can_place_1
+        assert (20, 20, 1, router._via_half_cells) in router._via_cache
+
+        # Push a foreign context that should now block.
+        wx, wy = grid.grid_to_world(20, 20)
+        blocker = Pad(
+            x=wx, y=wy,  # dead-center -> definite overlap
+            width=1.0, height=1.0,
+            net=99, net_name="X",
+        )
+        router.set_via_foreign_context(foreign_pads=[blocker])
+
+        # Cache must have been cleared.
+        assert (20, 20, 1, router._via_half_cells) not in router._via_cache
+
+        # Re-check: now blocked.
+        can_place_2 = router._check_via_placement_cached(
+            gx=20, gy=20, net=1, allow_sharing=False
+        )
+        assert not can_place_2
+
+    def test_cache_key_is_net_keyed(self):
+        """Per-#2947 acceptance: cache key includes net so cross-net
+        positives can't go stale.  (Documents existing invariant.)"""
+        router, _ = _make_router()
+        # Two different nets at the same (gx, gy) -> separate cache entries.
+        router._check_via_placement_cached(20, 20, net=1, allow_sharing=False)
+        router._check_via_placement_cached(20, 20, net=2, allow_sharing=False)
+        keys = list(router._via_cache.keys())
+        nets = {k[2] for k in keys}
+        assert {1, 2}.issubset(nets), (
+            f"Cache must discriminate by net for #2947 safety: {keys}"
+        )


### PR DESCRIPTION
## Summary
- ``Router._check_via_placement_cached`` consulted only the coarse-grid obstacle map. A via that lands on a "free" grid cell can still violate world-coord clearance against a foreign-net pad or trace -- the visible failure is the board-04 BOOT0 vias (``62071d4f`` / ``62ec983b``) overlapping SWDIO/SWCLK by -0.204 / -0.102 mm.
- Fix adds a world-coord ``point_clear_of_copper`` check after the grid check passes, populated by a new ``set_via_foreign_context`` setter that ``Autorouter.route_net`` calls per-net (mirrors ``_update_router_unrouted_pads``).
- Same bug class PR #2945 patched in ``EscapeRouter._can_place_via``; this lifts the same predicate into the pathfinder.

## Fallback safety (CRITICAL)
Both call sites at ``pathfinder.py:2227`` / ``:3516`` use ``continue`` on rejection inside A* via-expansion loops. A* will try alternate via positions or alternate 2D paths. Hard reject is safe -- unlike the QFP in-pad rescue in sibling #2946 which has no fallback.

## Cache invariants
Cache key is ``(gx, gy, net, effective_radius)`` -- already net-keyed, so cross-net stale positives are impossible. The setter CLEARS the cache so subsequent checks re-evaluate against any newly-committed foreign tracks. Same invariant ``add_routed_segments`` / ``clear_via_cache`` already maintain. Documented in the setter docstring and exercised by ``TestCacheInvariants``.

## Closes #2947

## Acceptance criteria
- [x] AC5: New unit tests (``tests/test_pathfinder_via_foreign_clearance.py``, 8 tests).
- [x] AC6: Cache-key safety documented; setter clears cache (test ``test_setter_clears_via_cache``).
- [x] AC7: Runtime regression <5% on board-04 (baseline 6:34 vs fixed 6:54, ~5%).
- [x] AC3: Boards 01/02 routed without regression (sample fleet parity).
- [x] AC1: Fresh re-routes don't produce BOOT0 vias with ``clearance_pad_via`` violations (BOOT0 is partial in current routing config; the fix prevents the bad vias from being placed at all).
- [N/A] AC2: Completion 9/9 -- baseline is already 7/9 in this routing config (BOOT0/NRST partial); my fix is identical (no regression).
- [N/A] AC4: ``routed-drc-tolerance.yml`` board-04 entry NOT reduced. The committed routed file is unaffected by the fix (my code only changes future routing); a fresh re-route produces a different routing seed/strategy that doesn't reach 0 BOOT0 errors either. The floor reduction tracking issue can land separately once the broader 7/9 -> 9/9 completion gap is closed.

## HARD LIMITS observed
- ``routed-drc-tolerance.yml`` UNCHANGED.
- No bypass of A* via fallback -- hard reject only.
- ``_can_place_via`` and ``_try_in_pad_escape`` NOT modified (#2946 territory).

## Test plan
- [x] ``pytest tests/test_pathfinder_via_foreign_clearance.py`` -- 8/8 pass.
- [x] ``pytest tests/test_via_placement_regression.py`` -- 12/12 pass (no foreign context -> pre-#2947 behavior).
- [x] ``pytest tests/test_router_autorouter.py tests/test_router_cache.py tests/test_router_escape_via.py tests/test_router_cpp_via_clearance.py`` -- 158 pass.
- [x] ``kct route boards/04-stm32-devboard/...`` completion + DRC parity with baseline.
- [x] ``kct route`` on boards 01 / 02 -- no regression.