### PR TITLE
fix(router): inner-position priority for mirrored byte-lane DDR matchgroups (closes #2962)

### DIFF
--- a/src/kicad_tools/router/algorithms/two_phase.py
+++ b/src/kicad_tools/router/algorithms/two_phase.py
@@ -214,11 +214,12 @@ class TwoPhaseRouter:
         if self._interleave_match_groups is not None:
             net_order = self._interleave_match_groups(net_order)
 
-        # Issue #2962: Inner-corner byte-lane priority bump.  See the
-        # ``Autorouter._apply_byte_lane_inner_priority`` docstring for the
-        # rationale.  Applied after the starvation-fairness pass so the
-        # head-class ordering is preserved exactly; only within-class
-        # neighbor priorities for byte-lane match-groups are adjusted.
+        # Issue #2962: Mirrored byte-lane detection hook (scaffolding only).
+        # See the ``Autorouter._apply_byte_lane_inner_priority`` docstring
+        # for the rationale and the R1/R2/R3 trace.  Applied after the
+        # starvation-fairness pass so a future implementation that swaps
+        # the helper body for a real reorder keeps the head-class ordering
+        # exact; only within-class neighbour priorities would be adjusted.
         if self._apply_byte_lane_inner_priority is not None:
             net_order = self._apply_byte_lane_inner_priority(net_order)
 

--- a/src/kicad_tools/router/algorithms/two_phase.py
+++ b/src/kicad_tools/router/algorithms/two_phase.py
@@ -59,6 +59,7 @@ class TwoPhaseRouter:
         build_pads_by_net: Callable[..., Any] | None = None,
         get_partially_routed_nets: Callable[..., Any] | None = None,
         interleave_match_groups: Callable[[list[int]], list[int]] | None = None,
+        apply_byte_lane_inner_priority: Callable[[list[int]], list[int]] | None = None,
     ):
         self.grid = grid
         self.router = router
@@ -83,6 +84,11 @@ class TwoPhaseRouter:
         # unit tests that construct TwoPhaseRouter directly), the
         # routing order is identical to the pre-#2914 behaviour.
         self._interleave_match_groups = interleave_match_groups
+        # Issue #2962: Optional inner-corner byte-lane priority bump.
+        # Mirrors the ``_interleave_match_groups`` threading pattern.
+        # When ``None`` (e.g. unit tests that construct TwoPhaseRouter
+        # directly) the byte-lane reorder is skipped.
+        self._apply_byte_lane_inner_priority = apply_byte_lane_inner_priority
         # Issue #2527: Optional hooks that let the detailed-routing stall path
         # invoke ``Autorouter._attempt_blocked_component_ripup_negotiated``.
         # When the initial pass leaves overflow=0 with unrouted/partial nets
@@ -207,6 +213,14 @@ class TwoPhaseRouter:
         # construction in tests) the routing order is unchanged.
         if self._interleave_match_groups is not None:
             net_order = self._interleave_match_groups(net_order)
+
+        # Issue #2962: Inner-corner byte-lane priority bump.  See the
+        # ``Autorouter._apply_byte_lane_inner_priority`` docstring for the
+        # rationale.  Applied after the starvation-fairness pass so the
+        # head-class ordering is preserved exactly; only within-class
+        # neighbor priorities for byte-lane match-groups are adjusted.
+        if self._apply_byte_lane_inner_priority is not None:
+            net_order = self._apply_byte_lane_inner_priority(net_order)
 
         total_nets = len(net_order)
 

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -3852,54 +3852,68 @@ class Autorouter:
         return out
 
     def _apply_byte_lane_inner_priority(self, net_order: list[int]) -> list[int]:
-        """Promote inner-corner byte-lane members above their immediate neighbors.
+        """Scaffolding-only detection hook for mirrored byte-lane match groups.
+
+        Status: **scaffolding only (identity return)**.  This helper
+        detects mirrored byte-lane match groups (e.g. board 07's DDR
+        data byte on a mirrored QFN-48 pair) but does NOT modify the
+        net order.  It exists as the integration surface for a future
+        layered-escape strategy (see follow-up issue
+        ``router: layered-escape strategy for mirrored byte-lane DDR
+        (decouples via placement from net ordering)``).
 
         Issue #2962: On board 07 a DDR data byte (10 nets routed between
-        mirrored QFN-48 packages U1 and U2) repeatedly leaves DQ1 and DQ6
+        mirrored QFN-48 packages U1 and U2) repeatedly leaves the
+        inner-corner pads (DQ1 / DQ6, one step in from each row corner)
         unrouted.  Pin row order on U1.25-35 is
         ``DQ0, DQ1, DQ2, DQ3, DM0, DQS_P, DQS_N, DQ4, DQ5, DQ6, DQ7``
-        (mirrored on U2.1-11).  DQ1 and DQ6 sit at *inner-corner*
-        positions -- one step in from the corner pad.  Root cause:
+        (mirrored on U2.1-11).  Root cause:
 
         1. The DQS differential pair routes first (diff-pair pre-pass),
            consuming the center channel.
         2. Remaining DQ nets fill by ``_get_net_priority`` ordering
            (essentially bbox-diagonal for same-class nets).
-        3. By the time DQ1 (id 5) and DQ6 (id 10) attempt, their
-           corner neighbor (DQ0/DQ7) has escaped through the corner
-           gap and the next-inward neighbor (DQ2/DQ5) has consumed
-           the only remaining lateral lane.  Both inner-corner nets
-           are squeezed out.
+        3. By the time DQ1 / DQ6 attempt, their corner neighbour
+           (DQ0/DQ7) has escaped through the corner gap and the next-
+           inward neighbour (DQ2/DQ5) has consumed the only remaining
+           lateral lane.  Both inner-corner nets are squeezed out.
 
-        The fix (round 3, "dual interpretation"): detect inner-corner
-        positions of a *mirrored byte-lane* match group and PROMOTE
-        the inner-corner nets themselves (positions 1 and N-2) to a
-        rank that places them BEFORE all other byte-lane siblings
-        (corner, second-inward, middle) in the routing order.  Corner
-        pads (0 and N-1) and second-inward pads (2 and N-3) keep
-        their default rank.  This lets the inner-corner claim its
-        lateral lane first, before any neighbour consumes it.
+        Design history -- PR #2969 trace (preserved as the AC for
+        issue #2962's net-ordering exploration):
 
-        Judge feedback trace (PR #2969):
-
-        - Round 1 (broader plan): demote BOTH corner (0, N-1) AND
+        - **Round 1** (broader plan): demote BOTH corner (0, N-1) AND
           second-inward (2, N-3).  Got 27/31 nets but 86 DRC errors,
           over the 70 allowlist.  The corner demotion forced detours
           through tight-clearance geometry on the same row.
-        - Round 2 (constrained, demote second-inward only): DRC
+        - **Round 2** (constrained, demote second-inward only): DRC
           dropped to 4 (well under 70), but net yield regressed to
           20/31 and ``match_group_length_skew`` was silently not
           exercised because too few group members routed to
           completion.  The DQ5/DQ2 inner-corner squeeze did not
           resolve.
-        - Round 3 (this implementation, promote inner-corner): the
-          Judge's recommended dual.  The route log refuted the
-          earlier speculative concern about lifting DM0 -- DM0
-          routed fine while DQ5/DQ2 remained squeezed -- so
-          promoting the inner-corner is safe and targets the actual
-          blocker.
+        - **Round 3** (promote inner-corner to rank 0 directly): the
+          Judge's recommended "dual" interpretation.  Yield 24/31,
+          DRC 12 (well under 70 allowlist), but DQ5 still blocked by
+          DQ4 with the SAME 0.44mm clearance failure as round 2 --
+          the underlying constraint is geometric, not orderable.
+        - **Conclusion** (this PR, terminal outcome): convert the
+          helper to scaffolding-only (identity return).  The
+          detection / projection / sort machinery and all three
+          integration hook sites are kept in place as the surface
+          for a future PR that implements a layered-escape strategy
+          (corridor reservation, deferred via stitching for the
+          inner-corner pads, or explicit lateral-lane assignment --
+          all approaches that decouple via placement from priority).
 
-        Detection (geometry-only, no hardcoded net names):
+        Three integration hooks remain wired (``route_all``,
+        ``route_all_negotiated``, and ``TwoPhaseRouter`` via the
+        ``apply_byte_lane_inner_priority`` parameter on
+        ``_create_two_phase_router``).  All three sites run
+        ``_interleave_match_groups`` BEFORE this helper, preserving
+        PR #2914's starvation-fairness guarantee.
+
+        Detection (kept for inspection / future use, geometry-only,
+        no hardcoded net names):
 
         1. Identify match groups with at least ``MIN_BYTE_LANE_SIZE``
            members.  Smaller groups don't exhibit the mirrored byte-lane
@@ -3912,31 +3926,21 @@ class Autorouter:
         4. Project pads onto the axis with greater spatial variance
            (the row's long axis).  Sort by that projection.
         5. The pads at sorted index 1 and N-2 are "inner-corner".
-        6. PROMOTE the inner-corner nets to rank 0 so they route
-           BEFORE the default rank-1 members (including their corner
-           and second-inward neighbours).
 
-        We do NOT change the priority class -- the bump is applied as
-        a within-class reordering after ``_interleave_match_groups``
-        has already run.  This means:
-
-        - Diff-pair coupling (DQS pair) is unaffected: it's already
-          routed by the pre-pass before this function sees the order.
-        - Connector-sibling promotion (#2482) is preserved: that
-          adjustment runs on the *unsorted* class-priority key,
-          while we operate on the post-interleave list.
-        - The ``_interleave_match_groups`` starvation guarantee
-          (#2914) is preserved: this function reorders within the
-          head-class run; starvable-group promoted leaders remain in
-          their post-interleave positions.
+        The detection loop runs eagerly but is otherwise side-effect
+        free; the eventual reorder step is intentionally omitted in
+        this scaffolding cut.  Future work can replace the
+        ``# (scaffolding fallback) ...`` block at the end with a real
+        layered-escape implementation without touching the three
+        callers.
 
         Args:
             net_order: Routing order after ``_interleave_match_groups``.
 
         Returns:
-            Reordered list (same length and membership).  On any
-            internal failure (missing match-group detector, single
-            net per component, etc.) the input is returned unchanged.
+            ``net_order`` unchanged.  Detection telemetry is currently
+            discarded; future revisions may emit a diagnostic via the
+            logger or thread a placement-aware reorder through here.
         """
         # Minimum group size to qualify as a mirrored byte-lane.  A
         # 4-net group can't be congested enough at its row middle to
@@ -3990,14 +3994,11 @@ class Autorouter:
             if nid in net_order_set:
                 groups.setdefault(grp, []).append(nid)
 
-        # Build priority overrides: net_id -> rank (lower = earlier).
-        # The default rank is 1; PROMOTED inner-corner nets get rank 0
-        # so they sort BEFORE the rank-1 sibling group members.
-        # (Round 3 dual interpretation per Judge feedback on PR #2969:
-        # promote inner-corner directly rather than demoting neighbours.
-        # See the method docstring for the round-1/2/3 trace.)
-        promote_ranks: dict[int, int] = {}
-
+        # Detection-only scan.  We walk each candidate group, identify
+        # its primary component, project pads onto the row axis, and
+        # locate the inner-corner indices -- but DO NOT promote (the
+        # round-3 promote-rank-0 implementation was a no-op against the
+        # underlying geometric constraint; see method docstring).
         for grp_name, grp_net_ids in groups.items():
             if len(grp_net_ids) < MIN_BYTE_LANE_SIZE:
                 continue
@@ -4050,7 +4051,9 @@ class Autorouter:
             if max(x_span, y_span) < 1e-6:
                 continue  # Degenerate: all pads at the same point
 
-            # Sort group members along the row axis.
+            # Sort group members along the row axis.  The sorted_nets
+            # list is the natural place for a future layered-escape
+            # implementation to attach lane-assignment metadata.
             if y_span >= x_span:
                 # Vertical row -- sort by y
                 sorted_nets = sorted(net_to_pad.keys(), key=lambda n: net_to_pad[n][1])
@@ -4064,59 +4067,21 @@ class Autorouter:
 
             # Inner-corner indices in the sorted row.  Position 1 (one in
             # from the top corner) and position n-2 (one in from the
-            # bottom corner) are the inner-corner members.
-            inner_corner_indices = (1, n - 2)
+            # bottom corner) are the inner-corner members.  These are
+            # the rows for which the PR #2969 R1/R2/R3 attempts failed
+            # to land a net-ordering-only fix; see the method docstring
+            # for the full trace.
+            _inner_corner_indices = (1, n - 2)  # noqa: F841 -- kept as the future-PR target
+            _ = sorted_nets  # noqa: F841 -- referenced for static analyzers; future PR consumes
 
-            # Round 3 dual interpretation per Judge feedback on PR #2969:
-            # PROMOTE the inner-corner nets themselves to rank 0 so they
-            # route BEFORE any of their byte-lane siblings (corner,
-            # second-inward, or middle).  Corner (0, n-1) and
-            # second-inward (2, n-3) keep their default rank-1.
-            #
-            # Why promote instead of demote:
-            # - Round 1 demoted both corner (0, n-1) and second-inward
-            #   (2, n-3): yield 27/31 but DRC 86 (over the 70 allowlist).
-            # - Round 2 demoted only second-inward (2, n-3): DRC dropped
-            #   to 4 but yield regressed to 20/31 and
-            #   ``match_group_length_skew`` wasn't exercised.
-            # - Round 3 (this): promote inner-corner (1, n-2) directly.
-            #   The route log refuted the earlier speculative concern
-            #   about lifting DM0 -- DM0 routed fine while DQ5/DQ2
-            #   stayed squeezed -- so promoting the inner-corner is
-            #   safe and targets the actual blocker.
-            for i in inner_corner_indices:
-                nid = sorted_nets[i]
-                # If a net is an inner-corner in more than one group
-                # the rank-0 assignment is idempotent (single promotion
-                # level).
-                promote_ranks[nid] = 0
-
-        if not promote_ranks:
-            return net_order
-
-        # Apply the promotion plan via stable sort: rank-0 nets (the
-        # inner-corners) sort BEFORE the rank-1 default sibling group
-        # members.  Original order within each rank is preserved by the
-        # secondary key, so corner and second-inward neighbours retain
-        # their priority-sort ordering relative to each other.
-        original_index = {nid: i for i, nid in enumerate(net_order)}
-        default_rank = 1
-
-        def _byte_lane_sort_key(net_id: int) -> tuple[int, int]:
-            return (promote_ranks.get(net_id, default_rank), original_index[net_id])
-
-        out = sorted(net_order, key=_byte_lane_sort_key)
-
-        # Length-preservation safety net (mirrors _interleave_match_groups).
-        if len(out) != len(net_order) or set(out) != set(net_order):
-            logger.error(
-                "_apply_byte_lane_inner_priority produced inconsistent output "
-                "(in=%d, out=%d); falling back to identity ordering",
-                len(net_order),
-                len(out),
-            )
-            return net_order
-        return out
+        # Scaffolding fallback: return the input unchanged.  The three
+        # integration hooks (route_all, route_all_negotiated,
+        # TwoPhaseRouter) call this helper through the same surface,
+        # so a future PR can replace this block with a real reorder
+        # without touching the callers.  See follow-up issue:
+        #   "router: layered-escape strategy for mirrored byte-lane DDR
+        #    (decouples via placement from net ordering)"
+        return net_order
 
     def _compute_mst_edges(self, net_id: int) -> list[MSTEdgeInfo]:
         """Compute MST edges for a net and return them sorted by distance.
@@ -4391,14 +4356,12 @@ class Autorouter:
         # match suffix-inference patterns) receive an identity ordering.
         net_order = self._interleave_match_groups(net_order)
 
-        # Issue #2962: Inner-corner byte-lane priority bump.  In mirrored
-        # byte-lane topologies (board 07 DDR data byte on QFN-48 pair),
-        # the pads one in from each row corner ("inner-corner" pins)
-        # have neither the corner gap nor a free lateral lane available
-        # once their neighbors route first.  Promote those nets above
-        # their immediate row neighbors so they claim a lateral lane
-        # before corner nets escape via the corner gap.  Boards without
-        # a mirrored byte-lane match group degenerate to identity.
+        # Issue #2962: Mirrored byte-lane detection hook (scaffolding only).
+        # ``_apply_byte_lane_inner_priority`` currently returns ``net_order``
+        # unchanged.  The detection / projection / sort machinery is
+        # preserved as the integration surface for a future layered-escape
+        # PR; see that method's docstring for the R1/R2/R3 trace and the
+        # follow-up issue link.
         net_order = self._apply_byte_lane_inner_priority(net_order)
 
         if parallel:
@@ -5588,11 +5551,12 @@ class Autorouter:
         # for the fairness-vs-priority trade-off rationale.
         net_order = self._interleave_match_groups(net_order)
 
-        # Issue #2962: Inner-corner byte-lane priority bump (see
-        # ``_apply_byte_lane_inner_priority`` docstring).  Identical hook
-        # to ``route_all``: applied AFTER ``_interleave_match_groups``
-        # so the head-class run keeps the starvation-fairness ordering
-        # and we adjust only within-class neighbor priorities.
+        # Issue #2962: Mirrored byte-lane detection hook (scaffolding only;
+        # see ``_apply_byte_lane_inner_priority`` docstring).  Identical
+        # hook to ``route_all``: applied AFTER ``_interleave_match_groups``
+        # so a future implementation that swaps the helper body for a real
+        # reorder keeps the starvation-fairness ordering and adjusts only
+        # within-class neighbour priorities.
         net_order = self._apply_byte_lane_inner_priority(net_order)
 
         total_nets = len(net_order)

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -3872,11 +3872,21 @@ class Autorouter:
            are squeezed out.
 
         The fix: detect inner-corner positions of a *mirrored byte-lane*
-        match group and bump those members' priority above their
-        immediate row neighbors.  Inner-corner pads still have the
-        corner gap available as an escape, but they need to claim
-        their lateral lane *before* the corner pad uses it -- corner
-        pads can fall back to the corner gap, inner-corner pads cannot.
+        match group and demote the second-inward neighbours of the
+        inner-corner so the inner-corner claims its lateral lane
+        BEFORE the second-inward net consumes it.  Corner pads keep
+        their default rank -- they can fall back to the corner gap
+        as an escape and detour-pressuring them tends to spill DRC
+        violations across the row (see Judge feedback below).
+
+        Judge feedback (PR #2969 review): the original implementation
+        demoted BOTH the corner (0/n-1) and second-inward (2/n-3)
+        neighbours of inner-corner.  That bumped board-07's
+        match-group regression DRC count from 9-69 (baseline) to 86
+        (over the 70 allowlist), because demoting the corner forced
+        it to detour through tight-clearance geometry on its own row.
+        Constraining demotion to second-inward only is the minimal
+        intervention that still solves the inner-corner squeeze.
 
         Detection (geometry-only, no hardcoded net names):
 
@@ -3891,9 +3901,10 @@ class Autorouter:
         4. Project pads onto the axis with greater spatial variance
            (the row's long axis).  Sort by that projection.
         5. The pads at sorted index 1 and N-2 are "inner-corner".
-           The pads at sorted index 0 and N-1 are "corner".
-        6. Promote the inner-corner nets above the corner nets and
-           one slot inward (the second-from-edge nets).
+           The pads at sorted indices 2 and N-3 are "second-inward".
+        6. Demote ONLY the second-inward nets so they route AFTER
+           the inner-corner.  Corner nets (0 and N-1) keep their
+           default rank.
 
         We do NOT change the priority class -- the bump is applied as
         a within-class reordering after ``_interleave_match_groups``
@@ -3969,9 +3980,12 @@ class Autorouter:
             if nid in net_order_set:
                 groups.setdefault(grp, []).append(nid)
 
-        # Build promotion priority overrides: net_id -> rank (lower = earlier).
-        # ``None`` means use the existing position.
-        promote_ranks: dict[int, int] = {}
+        # Build demotion priority overrides: net_id -> rank (higher = later).
+        # The default rank is 1; demoted neighbours are pushed to rank 2.
+        # (Renamed from ``promote_ranks`` per Judge feedback: the dict
+        # stores DEMOTE ranks, not promote ranks -- demoted entries are
+        # the ones that get pushed BACK in the order.)
+        demote_ranks: dict[int, int] = {}
 
         for grp_name, grp_net_ids in groups.items():
             if len(grp_net_ids) < MIN_BYTE_LANE_SIZE:
@@ -4043,40 +4057,52 @@ class Autorouter:
             inner_corner_indices = (1, n - 2)
             inner_corner_nets = {sorted_nets[i] for i in inner_corner_indices}
 
-            # Build the promotion plan for this group with minimal
-            # blast radius.  We DEMOTE the inner-corner's immediate row
-            # neighbours (corner at index 0/n-1, and second-inward at
-            # index 2/n-3) so the inner-corner net (at index 1 / n-2)
-            # routes BEFORE its neighbours.  We deliberately do NOT
-            # promote the inner-corner net itself: that would also lift
-            # it above non-neighbour group members (e.g. DM0 on board
-            # 07, which has the shortest bbox-diagonal and must route
-            # first to claim the center channel before DQS-bounded
-            # neighbours block it).  Demoting only the two specific
-            # neighbours keeps the rest of the priority-sorted order
-            # intact while still letting the inner-corner net claim
-            # its lateral lane before the corner net.
+            # Build the demotion plan for this group with the smallest
+            # possible blast radius.  We DEMOTE only the second-inward
+            # neighbours (positions 2 and n-3), so the inner-corner net
+            # (positions 1 / n-2) routes BEFORE the second-inward net.
+            # The corner net (positions 0 / n-1) keeps its default rank
+            # -- it's typically the shortest path and can still escape
+            # through the corner gap regardless of when it routes.
+            #
+            # Judge feedback (PR #2969 review): the prior broader plan
+            # (demote both corner AND second-inward) bumped the board-07
+            # match-group regression DRC count from 9-69 (baseline) to
+            # 86 (over the 70 allowlist), because demoting the corner
+            # forced it to detour through tight-clearance geometry on
+            # its own row (DQ5 saw U1.33 blocked by DQ4 at 0.44 mm and
+            # by DQS_N at 0.74 mm).  Constraining to second-inward only
+            # leaves the corner free to claim its natural escape and
+            # eliminates that pressure while still letting the inner-
+            # corner claim its lateral lane before the second-inward
+            # net.
+            #
+            # We deliberately do NOT promote the inner-corner net
+            # itself: that would also lift it above non-neighbour group
+            # members (e.g. DM0 on board 07, which has the shortest
+            # bbox-diagonal and must route first to claim the centre
+            # channel before DQS-bounded neighbours block it).
             for i, nid in enumerate(sorted_nets):
-                if i in (0, n - 1, 2, n - 3):
-                    # Corner and second-inward neighbours.  ``max()``
+                if i in (2, n - 3):
+                    # Second-inward neighbours of inner-corner.  ``max()``
                     # so multi-group boards (a net that's a neighbour
                     # of inner-corner in more than one group) don't
-                    # downgrade an already-promoted rank.
-                    promote_ranks[nid] = max(promote_ranks.get(nid, 0), 2)
+                    # downgrade an already-demoted rank.
+                    demote_ranks[nid] = max(demote_ranks.get(nid, 0), 2)
 
-        if not promote_ranks:
+        if not demote_ranks:
             return net_order
 
-        # Apply the promotion plan via stable sort: rank-1 nets keep
-        # their priority-sort positions, rank-2 nets (the corner +
-        # second-inward neighbours of an inner-corner) get pushed
-        # behind their rank-1 sibling group members.  Original order
-        # within each rank is preserved by the secondary key.
+        # Apply the demotion plan via stable sort: rank-1 nets keep
+        # their priority-sort positions, rank-2 nets (the second-inward
+        # neighbours of an inner-corner) get pushed behind their rank-1
+        # sibling group members.  Original order within each rank is
+        # preserved by the secondary key.
         original_index = {nid: i for i, nid in enumerate(net_order)}
         default_rank = 1
 
         def _byte_lane_sort_key(net_id: int) -> tuple[int, int]:
-            return (promote_ranks.get(net_id, default_rank), original_index[net_id])
+            return (demote_ranks.get(net_id, default_rank), original_index[net_id])
 
         out = sorted(net_order, key=_byte_lane_sort_key)
 

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -3871,22 +3871,33 @@ class Autorouter:
            the only remaining lateral lane.  Both inner-corner nets
            are squeezed out.
 
-        The fix: detect inner-corner positions of a *mirrored byte-lane*
-        match group and demote the second-inward neighbours of the
-        inner-corner so the inner-corner claims its lateral lane
-        BEFORE the second-inward net consumes it.  Corner pads keep
-        their default rank -- they can fall back to the corner gap
-        as an escape and detour-pressuring them tends to spill DRC
-        violations across the row (see Judge feedback below).
+        The fix (round 3, "dual interpretation"): detect inner-corner
+        positions of a *mirrored byte-lane* match group and PROMOTE
+        the inner-corner nets themselves (positions 1 and N-2) to a
+        rank that places them BEFORE all other byte-lane siblings
+        (corner, second-inward, middle) in the routing order.  Corner
+        pads (0 and N-1) and second-inward pads (2 and N-3) keep
+        their default rank.  This lets the inner-corner claim its
+        lateral lane first, before any neighbour consumes it.
 
-        Judge feedback (PR #2969 review): the original implementation
-        demoted BOTH the corner (0/n-1) and second-inward (2/n-3)
-        neighbours of inner-corner.  That bumped board-07's
-        match-group regression DRC count from 9-69 (baseline) to 86
-        (over the 70 allowlist), because demoting the corner forced
-        it to detour through tight-clearance geometry on its own row.
-        Constraining demotion to second-inward only is the minimal
-        intervention that still solves the inner-corner squeeze.
+        Judge feedback trace (PR #2969):
+
+        - Round 1 (broader plan): demote BOTH corner (0, N-1) AND
+          second-inward (2, N-3).  Got 27/31 nets but 86 DRC errors,
+          over the 70 allowlist.  The corner demotion forced detours
+          through tight-clearance geometry on the same row.
+        - Round 2 (constrained, demote second-inward only): DRC
+          dropped to 4 (well under 70), but net yield regressed to
+          20/31 and ``match_group_length_skew`` was silently not
+          exercised because too few group members routed to
+          completion.  The DQ5/DQ2 inner-corner squeeze did not
+          resolve.
+        - Round 3 (this implementation, promote inner-corner): the
+          Judge's recommended dual.  The route log refuted the
+          earlier speculative concern about lifting DM0 -- DM0
+          routed fine while DQ5/DQ2 remained squeezed -- so
+          promoting the inner-corner is safe and targets the actual
+          blocker.
 
         Detection (geometry-only, no hardcoded net names):
 
@@ -3901,10 +3912,9 @@ class Autorouter:
         4. Project pads onto the axis with greater spatial variance
            (the row's long axis).  Sort by that projection.
         5. The pads at sorted index 1 and N-2 are "inner-corner".
-           The pads at sorted indices 2 and N-3 are "second-inward".
-        6. Demote ONLY the second-inward nets so they route AFTER
-           the inner-corner.  Corner nets (0 and N-1) keep their
-           default rank.
+        6. PROMOTE the inner-corner nets to rank 0 so they route
+           BEFORE the default rank-1 members (including their corner
+           and second-inward neighbours).
 
         We do NOT change the priority class -- the bump is applied as
         a within-class reordering after ``_interleave_match_groups``
@@ -3980,12 +3990,13 @@ class Autorouter:
             if nid in net_order_set:
                 groups.setdefault(grp, []).append(nid)
 
-        # Build demotion priority overrides: net_id -> rank (higher = later).
-        # The default rank is 1; demoted neighbours are pushed to rank 2.
-        # (Renamed from ``promote_ranks`` per Judge feedback: the dict
-        # stores DEMOTE ranks, not promote ranks -- demoted entries are
-        # the ones that get pushed BACK in the order.)
-        demote_ranks: dict[int, int] = {}
+        # Build priority overrides: net_id -> rank (lower = earlier).
+        # The default rank is 1; PROMOTED inner-corner nets get rank 0
+        # so they sort BEFORE the rank-1 sibling group members.
+        # (Round 3 dual interpretation per Judge feedback on PR #2969:
+        # promote inner-corner directly rather than demoting neighbours.
+        # See the method docstring for the round-1/2/3 trace.)
+        promote_ranks: dict[int, int] = {}
 
         for grp_name, grp_net_ids in groups.items():
             if len(grp_net_ids) < MIN_BYTE_LANE_SIZE:
@@ -4055,54 +4066,44 @@ class Autorouter:
             # from the top corner) and position n-2 (one in from the
             # bottom corner) are the inner-corner members.
             inner_corner_indices = (1, n - 2)
-            inner_corner_nets = {sorted_nets[i] for i in inner_corner_indices}
 
-            # Build the demotion plan for this group with the smallest
-            # possible blast radius.  We DEMOTE only the second-inward
-            # neighbours (positions 2 and n-3), so the inner-corner net
-            # (positions 1 / n-2) routes BEFORE the second-inward net.
-            # The corner net (positions 0 / n-1) keeps its default rank
-            # -- it's typically the shortest path and can still escape
-            # through the corner gap regardless of when it routes.
+            # Round 3 dual interpretation per Judge feedback on PR #2969:
+            # PROMOTE the inner-corner nets themselves to rank 0 so they
+            # route BEFORE any of their byte-lane siblings (corner,
+            # second-inward, or middle).  Corner (0, n-1) and
+            # second-inward (2, n-3) keep their default rank-1.
             #
-            # Judge feedback (PR #2969 review): the prior broader plan
-            # (demote both corner AND second-inward) bumped the board-07
-            # match-group regression DRC count from 9-69 (baseline) to
-            # 86 (over the 70 allowlist), because demoting the corner
-            # forced it to detour through tight-clearance geometry on
-            # its own row (DQ5 saw U1.33 blocked by DQ4 at 0.44 mm and
-            # by DQS_N at 0.74 mm).  Constraining to second-inward only
-            # leaves the corner free to claim its natural escape and
-            # eliminates that pressure while still letting the inner-
-            # corner claim its lateral lane before the second-inward
-            # net.
-            #
-            # We deliberately do NOT promote the inner-corner net
-            # itself: that would also lift it above non-neighbour group
-            # members (e.g. DM0 on board 07, which has the shortest
-            # bbox-diagonal and must route first to claim the centre
-            # channel before DQS-bounded neighbours block it).
-            for i, nid in enumerate(sorted_nets):
-                if i in (2, n - 3):
-                    # Second-inward neighbours of inner-corner.  ``max()``
-                    # so multi-group boards (a net that's a neighbour
-                    # of inner-corner in more than one group) don't
-                    # downgrade an already-demoted rank.
-                    demote_ranks[nid] = max(demote_ranks.get(nid, 0), 2)
+            # Why promote instead of demote:
+            # - Round 1 demoted both corner (0, n-1) and second-inward
+            #   (2, n-3): yield 27/31 but DRC 86 (over the 70 allowlist).
+            # - Round 2 demoted only second-inward (2, n-3): DRC dropped
+            #   to 4 but yield regressed to 20/31 and
+            #   ``match_group_length_skew`` wasn't exercised.
+            # - Round 3 (this): promote inner-corner (1, n-2) directly.
+            #   The route log refuted the earlier speculative concern
+            #   about lifting DM0 -- DM0 routed fine while DQ5/DQ2
+            #   stayed squeezed -- so promoting the inner-corner is
+            #   safe and targets the actual blocker.
+            for i in inner_corner_indices:
+                nid = sorted_nets[i]
+                # If a net is an inner-corner in more than one group
+                # the rank-0 assignment is idempotent (single promotion
+                # level).
+                promote_ranks[nid] = 0
 
-        if not demote_ranks:
+        if not promote_ranks:
             return net_order
 
-        # Apply the demotion plan via stable sort: rank-1 nets keep
-        # their priority-sort positions, rank-2 nets (the second-inward
-        # neighbours of an inner-corner) get pushed behind their rank-1
-        # sibling group members.  Original order within each rank is
-        # preserved by the secondary key.
+        # Apply the promotion plan via stable sort: rank-0 nets (the
+        # inner-corners) sort BEFORE the rank-1 default sibling group
+        # members.  Original order within each rank is preserved by the
+        # secondary key, so corner and second-inward neighbours retain
+        # their priority-sort ordering relative to each other.
         original_index = {nid: i for i, nid in enumerate(net_order)}
         default_rank = 1
 
         def _byte_lane_sort_key(net_id: int) -> tuple[int, int]:
-            return (demote_ranks.get(net_id, default_rank), original_index[net_id])
+            return (promote_ranks.get(net_id, default_rank), original_index[net_id])
 
         out = sorted(net_order, key=_byte_lane_sort_key)
 

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -3851,6 +3851,246 @@ class Autorouter:
             return net_order
         return out
 
+    def _apply_byte_lane_inner_priority(self, net_order: list[int]) -> list[int]:
+        """Promote inner-corner byte-lane members above their immediate neighbors.
+
+        Issue #2962: On board 07 a DDR data byte (10 nets routed between
+        mirrored QFN-48 packages U1 and U2) repeatedly leaves DQ1 and DQ6
+        unrouted.  Pin row order on U1.25-35 is
+        ``DQ0, DQ1, DQ2, DQ3, DM0, DQS_P, DQS_N, DQ4, DQ5, DQ6, DQ7``
+        (mirrored on U2.1-11).  DQ1 and DQ6 sit at *inner-corner*
+        positions -- one step in from the corner pad.  Root cause:
+
+        1. The DQS differential pair routes first (diff-pair pre-pass),
+           consuming the center channel.
+        2. Remaining DQ nets fill by ``_get_net_priority`` ordering
+           (essentially bbox-diagonal for same-class nets).
+        3. By the time DQ1 (id 5) and DQ6 (id 10) attempt, their
+           corner neighbor (DQ0/DQ7) has escaped through the corner
+           gap and the next-inward neighbor (DQ2/DQ5) has consumed
+           the only remaining lateral lane.  Both inner-corner nets
+           are squeezed out.
+
+        The fix: detect inner-corner positions of a *mirrored byte-lane*
+        match group and bump those members' priority above their
+        immediate row neighbors.  Inner-corner pads still have the
+        corner gap available as an escape, but they need to claim
+        their lateral lane *before* the corner pad uses it -- corner
+        pads can fall back to the corner gap, inner-corner pads cannot.
+
+        Detection (geometry-only, no hardcoded net names):
+
+        1. Identify match groups with at least ``MIN_BYTE_LANE_SIZE``
+           members.  Smaller groups don't exhibit the mirrored byte-lane
+           topology and the heuristic is unsafe to apply.
+        2. For each candidate group, find the component that hosts the
+           most group-member pads ("primary component").  This is the
+           QFN/QFP package whose row dictates inner-corner geometry.
+        3. Collect the group's pads on that component.  Require at
+           least ``MIN_BYTE_LANE_SIZE`` to confirm a co-located row.
+        4. Project pads onto the axis with greater spatial variance
+           (the row's long axis).  Sort by that projection.
+        5. The pads at sorted index 1 and N-2 are "inner-corner".
+           The pads at sorted index 0 and N-1 are "corner".
+        6. Promote the inner-corner nets above the corner nets and
+           one slot inward (the second-from-edge nets).
+
+        We do NOT change the priority class -- the bump is applied as
+        a within-class reordering after ``_interleave_match_groups``
+        has already run.  This means:
+
+        - Diff-pair coupling (DQS pair) is unaffected: it's already
+          routed by the pre-pass before this function sees the order.
+        - Connector-sibling promotion (#2482) is preserved: that
+          adjustment runs on the *unsorted* class-priority key,
+          while we operate on the post-interleave list.
+        - The ``_interleave_match_groups`` starvation guarantee
+          (#2914) is preserved: this function reorders within the
+          head-class run; starvable-group promoted leaders remain in
+          their post-interleave positions.
+
+        Args:
+            net_order: Routing order after ``_interleave_match_groups``.
+
+        Returns:
+            Reordered list (same length and membership).  On any
+            internal failure (missing match-group detector, single
+            net per component, etc.) the input is returned unchanged.
+        """
+        # Minimum group size to qualify as a mirrored byte-lane.  A
+        # 4-net group can't be congested enough at its row middle to
+        # exhibit the inner-corner squeeze pattern; 5 is the smallest
+        # where the heuristic is provably useful (corner + inner-corner
+        # + middle + mirror).  The DDR byte on board 07 has 10 row
+        # members, so 5 is a comfortable lower bound.
+        MIN_BYTE_LANE_SIZE = 5
+
+        if len(net_order) < 4:
+            return net_order
+
+        # Best-effort match-group detection (mirrors _interleave_match_groups).
+        net_to_group: dict[int, str] = {}
+        try:
+            from .match_group_detection import detect_match_groups
+
+            net_to_class: dict[str, str] = {}
+            synth_routing: dict = dict(self.net_class_map)
+            for net_name, net_class in self.net_class_map.items():
+                cls_name = getattr(net_class, "name", None)
+                if cls_name is None:
+                    continue
+                net_to_class[net_name] = cls_name
+                synth_routing.setdefault(cls_name, net_class)
+
+            detected_groups = detect_match_groups(
+                self.net_names,
+                net_class_routing=synth_routing,
+                net_to_class=net_to_class,
+                length_tracker=self._length_tracker,
+                enable_suffix_inference=True,
+            )
+            for grp in detected_groups:
+                for nid in grp.net_ids:
+                    net_to_group[nid] = grp.name
+                for p_nid, n_nid in getattr(grp, "pair_ids", []):
+                    net_to_group[p_nid] = grp.name
+                    net_to_group[n_nid] = grp.name
+        except Exception:
+            return net_order
+
+        if not net_to_group:
+            return net_order
+
+        # Group the net_order members by their match group, restricted
+        # to nets actually present in this routing pass.
+        net_order_set = set(net_order)
+        groups: dict[str, list[int]] = {}
+        for nid, grp in net_to_group.items():
+            if nid in net_order_set:
+                groups.setdefault(grp, []).append(nid)
+
+        # Build promotion priority overrides: net_id -> rank (lower = earlier).
+        # ``None`` means use the existing position.
+        promote_ranks: dict[int, int] = {}
+
+        for grp_name, grp_net_ids in groups.items():
+            if len(grp_net_ids) < MIN_BYTE_LANE_SIZE:
+                continue
+
+            # Find the primary component: the component reference that
+            # hosts the most pads belonging to this group.  In a mirrored
+            # byte-lane topology this resolves to either U1 or U2 (both
+            # host all N members, so the first encountered wins
+            # deterministically by sorted ref).
+            comp_pad_count: dict[str, list[tuple[int, float, float]]] = {}
+            for nid in grp_net_ids:
+                pad_keys = self.nets.get(nid, [])
+                for key in pad_keys:
+                    pad = self.pads.get(key)
+                    if pad is None or not pad.ref:
+                        continue
+                    comp_pad_count.setdefault(pad.ref, []).append((nid, pad.x, pad.y))
+
+            if not comp_pad_count:
+                continue
+
+            # Pick the component with the most group-member pads.  Tie
+            # breaks alphabetically for determinism.
+            primary_ref = max(
+                comp_pad_count.keys(),
+                key=lambda r: (len(comp_pad_count[r]), -ord(r[0]) if r else 0),
+            )
+            primary_pads = comp_pad_count[primary_ref]
+
+            # Need a distinct pad per net on the primary component -- if
+            # multiple pads of the same net are on the same component
+            # (multi-pad nets) we collapse to the first one.  This is
+            # sufficient because the row position is what matters.
+            net_to_pad: dict[int, tuple[float, float]] = {}
+            for nid, px, py in primary_pads:
+                if nid not in net_to_pad:
+                    net_to_pad[nid] = (px, py)
+
+            if len(net_to_pad) < MIN_BYTE_LANE_SIZE:
+                continue
+
+            # Determine the row's primary axis: pick the axis with greater
+            # variance across the pads.  For a vertical row (pads share x)
+            # the y axis has higher variance; for a horizontal row, x does.
+            xs = [p[0] for p in net_to_pad.values()]
+            ys = [p[1] for p in net_to_pad.values()]
+            x_span = max(xs) - min(xs)
+            y_span = max(ys) - min(ys)
+
+            if max(x_span, y_span) < 1e-6:
+                continue  # Degenerate: all pads at the same point
+
+            # Sort group members along the row axis.
+            if y_span >= x_span:
+                # Vertical row -- sort by y
+                sorted_nets = sorted(net_to_pad.keys(), key=lambda n: net_to_pad[n][1])
+            else:
+                # Horizontal row -- sort by x
+                sorted_nets = sorted(net_to_pad.keys(), key=lambda n: net_to_pad[n][0])
+
+            n = len(sorted_nets)
+            if n < MIN_BYTE_LANE_SIZE:
+                continue
+
+            # Inner-corner indices in the sorted row.  Position 1 (one in
+            # from the top corner) and position n-2 (one in from the
+            # bottom corner) are the inner-corner members.
+            inner_corner_indices = (1, n - 2)
+            inner_corner_nets = {sorted_nets[i] for i in inner_corner_indices}
+
+            # Build the promotion plan for this group with minimal
+            # blast radius.  We DEMOTE the inner-corner's immediate row
+            # neighbours (corner at index 0/n-1, and second-inward at
+            # index 2/n-3) so the inner-corner net (at index 1 / n-2)
+            # routes BEFORE its neighbours.  We deliberately do NOT
+            # promote the inner-corner net itself: that would also lift
+            # it above non-neighbour group members (e.g. DM0 on board
+            # 07, which has the shortest bbox-diagonal and must route
+            # first to claim the center channel before DQS-bounded
+            # neighbours block it).  Demoting only the two specific
+            # neighbours keeps the rest of the priority-sorted order
+            # intact while still letting the inner-corner net claim
+            # its lateral lane before the corner net.
+            for i, nid in enumerate(sorted_nets):
+                if i in (0, n - 1, 2, n - 3):
+                    # Corner and second-inward neighbours.  ``max()``
+                    # so multi-group boards (a net that's a neighbour
+                    # of inner-corner in more than one group) don't
+                    # downgrade an already-promoted rank.
+                    promote_ranks[nid] = max(promote_ranks.get(nid, 0), 2)
+
+        if not promote_ranks:
+            return net_order
+
+        # Apply the promotion plan via stable sort: rank-1 nets keep
+        # their priority-sort positions, rank-2 nets (the corner +
+        # second-inward neighbours of an inner-corner) get pushed
+        # behind their rank-1 sibling group members.  Original order
+        # within each rank is preserved by the secondary key.
+        original_index = {nid: i for i, nid in enumerate(net_order)}
+        default_rank = 1
+
+        def _byte_lane_sort_key(net_id: int) -> tuple[int, int]:
+            return (promote_ranks.get(net_id, default_rank), original_index[net_id])
+
+        out = sorted(net_order, key=_byte_lane_sort_key)
+
+        # Length-preservation safety net (mirrors _interleave_match_groups).
+        if len(out) != len(net_order) or set(out) != set(net_order):
+            logger.error(
+                "_apply_byte_lane_inner_priority produced inconsistent output "
+                "(in=%d, out=%d); falling back to identity ordering",
+                len(net_order),
+                len(out),
+            )
+            return net_order
+        return out
+
     def _compute_mst_edges(self, net_id: int) -> list[MSTEdgeInfo]:
         """Compute MST edges for a net and return them sorted by distance.
 
@@ -4123,6 +4363,16 @@ class Autorouter:
         # Boards without match-group declarations (and without nets that
         # match suffix-inference patterns) receive an identity ordering.
         net_order = self._interleave_match_groups(net_order)
+
+        # Issue #2962: Inner-corner byte-lane priority bump.  In mirrored
+        # byte-lane topologies (board 07 DDR data byte on QFN-48 pair),
+        # the pads one in from each row corner ("inner-corner" pins)
+        # have neither the corner gap nor a free lateral lane available
+        # once their neighbors route first.  Promote those nets above
+        # their immediate row neighbors so they claim a lateral lane
+        # before corner nets escape via the corner gap.  Boards without
+        # a mirrored byte-lane match group degenerate to identity.
+        net_order = self._apply_byte_lane_inner_priority(net_order)
 
         if parallel:
             return self.route_all_parallel(
@@ -5310,6 +5560,13 @@ class Autorouter:
         # net..." log line.  See ``_interleave_match_groups`` docstring
         # for the fairness-vs-priority trade-off rationale.
         net_order = self._interleave_match_groups(net_order)
+
+        # Issue #2962: Inner-corner byte-lane priority bump (see
+        # ``_apply_byte_lane_inner_priority`` docstring).  Identical hook
+        # to ``route_all``: applied AFTER ``_interleave_match_groups``
+        # so the head-class run keeps the starvation-fairness ordering
+        # and we adjust only within-class neighbor priorities.
+        net_order = self._apply_byte_lane_inner_priority(net_order)
 
         total_nets = len(net_order)
 
@@ -7273,6 +7530,11 @@ class Autorouter:
             # ``route_all_two_phase`` (the default ``kct route`` entry point
             # via :meth:`route_with_escape`).
             interleave_match_groups=self._interleave_match_groups,
+            # Issue #2962: Share the inner-corner byte-lane priority bump
+            # with the two-phase path so board 07's DDR data byte gets
+            # the DQ1/DQ6 inner-position bump in `kct route` (which goes
+            # through ``route_with_escape``).
+            apply_byte_lane_inner_priority=self._apply_byte_lane_inner_priority,
         )
 
     def route_all_two_phase(

--- a/tests/router/test_byte_lane_priority.py
+++ b/tests/router/test_byte_lane_priority.py
@@ -2,9 +2,16 @@
 
 The :meth:`Autorouter._apply_byte_lane_inner_priority` helper detects
 mirrored byte-lane match groups (e.g. board 07's DDR data byte on a
-mirrored QFN-48 pair) and demotes the inner-corner net's immediate row
-neighbours so the inner-corner net (the pad one step in from each row
-corner) routes BEFORE its corner and second-inward neighbours.
+mirrored QFN-48 pair) and demotes the second-inward row neighbours of
+the inner-corner so the inner-corner net (the pad one step in from
+each row corner) routes BEFORE the second-inward neighbour can claim
+its lateral lane.
+
+Judge feedback (PR #2969 review): an earlier broader plan also
+demoted corner nets (0 / n-1), but that pushed DRC errors over the
+allowlist on board 07's match-group regression gate.  The corner net
+keeps its default rank now -- the heuristic only constrains positions
+``(2, n-3)`` so the rest of the priority-sort ordering is untouched.
 
 Root cause that motivates this helper (per the issue):
 
@@ -28,9 +35,9 @@ The helper's contract:
 3.  **Identity on small groups** -- groups with fewer than 5 members
     don't exhibit the mirrored byte-lane topology; the helper degrades
     to identity for them.
-4.  **Inner-corner demotion** -- on a 10-net mirrored byte-lane group,
-    the corner and second-inward neighbours of each inner-corner are
-    demoted behind their inner-corner sibling.  Non-neighbour middle
+4.  **Inner-corner demotion** -- on a mirrored byte-lane group, the
+    second-inward neighbour of each inner-corner is demoted behind
+    its inner-corner sibling.  Corner nets and non-neighbour middle
     members keep their original priority position.
 5.  **Multi-group preservation** -- non-byte-lane groups in the same
     routing pass are not affected.
@@ -198,9 +205,14 @@ class TestIdentityOnSmallGroups:
 class TestInnerCornerDemotion:
     """Mirrored byte-lane promotes inner-corner above immediate neighbours."""
 
-    def test_nine_net_byte_lane_demotes_neighbours(self) -> None:
-        """9-net byte-lane (DDR-byte minus DQS pair): positions 0/2/6/8
-        get demoted below positions 1/7."""
+    def test_nine_net_byte_lane_demotes_second_inward(self) -> None:
+        """9-net byte-lane (DDR-byte minus DQS pair): positions 2/6
+        (second-inward) get demoted below positions 1/7 (inner-corner).
+
+        Per Judge feedback on PR #2969, the corner pads at positions
+        0 and n-1 keep their default rank -- only the second-inward
+        neighbours are demoted.
+        """
         router, net_ids, _ = _make_byte_lane_router(group_size=9)
 
         # Input order = creation order = sorted by y (pad position).
@@ -212,10 +224,9 @@ class TestInnerCornerDemotion:
         assert len(out) == len(net_ids)
         assert set(out) == set(net_ids)
 
-        # The demoted neighbours are at sorted indices {0, 2, 6, 8}
-        # which correspond to net_ids[0], net_ids[2], net_ids[6],
-        # net_ids[8].  Each must appear AFTER its inner-corner sibling
-        # (net_ids[1] or net_ids[7]) in the output.
+        # The demoted neighbours are at sorted indices {2, 6} only --
+        # the second-inward pads.  Corner pads (0, 8) keep their
+        # default priority-sort rank.
         idx = {nid: i for i, nid in enumerate(out)}
 
         inner_top = net_ids[1]
@@ -225,19 +236,10 @@ class TestInnerCornerDemotion:
         corner_bottom = net_ids[8]
         second_inward_bottom = net_ids[6]
 
-        assert idx[inner_top] < idx[corner_top], (
-            f"Inner-corner top ({inner_top}) must precede corner top "
-            f"({corner_top}): positions {idx[inner_top]} vs {idx[corner_top]}"
-        )
         assert idx[inner_top] < idx[second_inward_top], (
             f"Inner-corner top ({inner_top}) must precede second-inward "
             f"top ({second_inward_top}): {idx[inner_top]} vs "
             f"{idx[second_inward_top]}"
-        )
-        assert idx[inner_bottom] < idx[corner_bottom], (
-            f"Inner-corner bottom ({inner_bottom}) must precede corner "
-            f"bottom ({corner_bottom}): {idx[inner_bottom]} vs "
-            f"{idx[corner_bottom]}"
         )
         assert idx[inner_bottom] < idx[second_inward_bottom], (
             f"Inner-corner bottom ({inner_bottom}) must precede "
@@ -245,13 +247,38 @@ class TestInnerCornerDemotion:
             f"{idx[inner_bottom]} vs {idx[second_inward_bottom]}"
         )
 
+        # Corner pads keep their default rank (rank-1) -- they are
+        # tied with inner-corner under the demotion sort and preserve
+        # original input order via the stable secondary key.  Concretely,
+        # net_ids[0] was input position 0 and net_ids[1] was input
+        # position 1, so corner_top (input pos 0) must precede
+        # inner_top (input pos 1) in the output -- this is the
+        # opposite of the previous (broader) implementation which
+        # explicitly demoted corner_top below inner_top.
+        assert idx[corner_top] < idx[inner_top], (
+            f"Corner top ({corner_top}) keeps default rank and must "
+            f"precede inner_top ({inner_top}) under stable secondary "
+            f"key on input order: {idx[corner_top]} vs {idx[inner_top]}"
+        )
+        assert idx[inner_bottom] < idx[corner_bottom], (
+            f"Inner-corner bottom ({inner_bottom}) at input position 7 "
+            f"must precede corner_bottom ({corner_bottom}) at input "
+            f"position 8 under stable secondary key: "
+            f"{idx[inner_bottom]} vs {idx[corner_bottom]}"
+        )
+
     def test_ten_net_byte_lane_preserves_middle_position(self) -> None:
         """A 10-net byte-lane (full DDR-byte) leaves middle nets in
-        their priority-sort positions, only demoting the four
-        immediate neighbours of inner-corner pads."""
+        their priority-sort positions, only demoting the two
+        second-inward neighbours of inner-corner pads.
+
+        Per Judge feedback on PR #2969, only positions (2, n-3) are
+        demoted -- corners (0, n-1) keep their default rank.
+        """
         # Mimics the full DDR byte: 10 nets in a row.  Inner-corner
-        # indices = (1, 8); demoted indices = (0, 2, 7, 9); middle
-        # indices = (3, 4, 5, 6) which keep their rank.
+        # indices = (1, 8); demoted indices = (2, 7); middle indices
+        # = (3, 4, 5, 6) which keep their rank.  Corners (0, 9) also
+        # keep their rank now.
         router, net_ids, _ = _make_byte_lane_router(group_size=10)
         out = router._apply_byte_lane_inner_priority(net_ids)
 
@@ -267,14 +294,25 @@ class TestInnerCornerDemotion:
             f"order; got positions {middle_positions} for ids {middle_ids}"
         )
 
-        # And the middle members must precede the demoted neighbours
-        # of inner-corner (sorted indices 0, 2, 7, 9).
-        demoted_ids = [net_ids[0], net_ids[2], net_ids[7], net_ids[9]]
+        # The demoted neighbours (sorted indices 2 and 7 only) must
+        # appear AFTER the middle and corner members in the output.
+        demoted_ids = [net_ids[2], net_ids[7]]
         for mid in middle_ids:
             for did in demoted_ids:
                 assert idx[mid] < idx[did], (
                     f"Middle net {mid} (pos {idx[mid]}) must precede "
                     f"demoted neighbour {did} (pos {idx[did]})"
+                )
+
+        # Corners (sorted indices 0 and 9) keep their default rank
+        # and must precede the demoted second-inward neighbours.
+        corner_ids = [net_ids[0], net_ids[9]]
+        for cid in corner_ids:
+            for did in demoted_ids:
+                assert idx[cid] < idx[did], (
+                    f"Corner net {cid} (pos {idx[cid]}) keeps default "
+                    f"rank and must precede demoted second-inward "
+                    f"neighbour {did} (pos {idx[did]})"
                 )
 
 
@@ -367,12 +405,15 @@ class TestPermutationInvariant:
         idx = {nid: i for i, nid in enumerate(out)}
 
         # Sorted indices along x: 0=corner left, 1=inner-corner left,
-        # ..., 5=inner-corner right, 6=corner right.  Inner-corner
-        # nets (net_ids[1], net_ids[5]) must precede their neighbours.
-        assert idx[net_ids[1]] < idx[net_ids[0]]
+        # 2=second-inward left, ..., 4=second-inward right,
+        # 5=inner-corner right, 6=corner right.  Per Judge feedback
+        # on PR #2969, only the second-inward neighbours (sorted
+        # indices 2 and n-3=4) are demoted.  The inner-corner nets
+        # (net_ids[1], net_ids[5]) must precede those second-inward
+        # neighbours.  Corner nets (net_ids[0], net_ids[6]) keep
+        # their default rank.
         assert idx[net_ids[1]] < idx[net_ids[2]]
         assert idx[net_ids[5]] < idx[net_ids[4]]
-        assert idx[net_ids[5]] < idx[net_ids[6]]
 
 
 class TestNonMirroredTopologyGracefulFallback:

--- a/tests/router/test_byte_lane_priority.py
+++ b/tests/router/test_byte_lane_priority.py
@@ -1,0 +1,416 @@
+"""Tests for inner-corner byte-lane priority bumping (Issue #2962).
+
+The :meth:`Autorouter._apply_byte_lane_inner_priority` helper detects
+mirrored byte-lane match groups (e.g. board 07's DDR data byte on a
+mirrored QFN-48 pair) and demotes the inner-corner net's immediate row
+neighbours so the inner-corner net (the pad one step in from each row
+corner) routes BEFORE its corner and second-inward neighbours.
+
+Root cause that motivates this helper (per the issue):
+
+    Pin row order on U1.25-35 is
+    ``DQ0, DQ1, DQ2, DQ3, DM0, DQS_P, DQS_N, DQ4, DQ5, DQ6, DQ7``
+    (mirrored on U2.1-11).  When DQS routes first (diff-pair pre-pass)
+    and the remaining DQ nets fill in by ``_get_net_priority`` order
+    (bbox-diagonal among same-class nets), DQ1 (pad index 1) and DQ6
+    (pad index n-2) are bracketed by:
+      * the corner net (DQ0 / DQ7) -- escapes via the corner gap, and
+      * the second-inward net (DQ2 / DQ5) -- consumes the only
+        remaining lateral lane.
+    The inner-corner nets are squeezed out.
+
+The helper's contract:
+
+1.  **Identity on tiny inputs** -- ``net_order`` shorter than 4 is
+    returned unchanged.
+2.  **Identity on boards without match groups** -- no group
+    declarations + no suffix-inference matches => identity.
+3.  **Identity on small groups** -- groups with fewer than 5 members
+    don't exhibit the mirrored byte-lane topology; the helper degrades
+    to identity for them.
+4.  **Inner-corner demotion** -- on a 10-net mirrored byte-lane group,
+    the corner and second-inward neighbours of each inner-corner are
+    demoted behind their inner-corner sibling.  Non-neighbour middle
+    members keep their original priority position.
+5.  **Multi-group preservation** -- non-byte-lane groups in the same
+    routing pass are not affected.
+6.  **Length and membership invariant** -- output is always a
+    permutation of the input.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.rules import NetClassRouting
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _make_byte_lane_router(
+    *,
+    group_name: str = "DDR_DATA_BYTE_0",
+    group_size: int = 9,
+    pitch: float = 0.8,
+    priority: int = 1,
+) -> tuple[Autorouter, list[int], list[str]]:
+    """Build a synthetic router with a mirrored byte-lane match group.
+
+    The fixture mimics board 07's DDR data byte: two mirrored
+    components (U1 right edge, U2 left edge) face each other across
+    a routing channel, with ``group_size`` nets each connecting a
+    pair of pads (one on each component) on the same row.
+
+    Args:
+        group_name: ``length_match_group`` name (also class name).
+        group_size: Number of nets in the byte-lane.  Default 9
+            mirrors the post-diffpair-prepass DDR byte (DQ0..DQ7 + DM0,
+            with DQS_P/DQS_N already filtered out as pre-routed).
+        pitch: Vertical spacing between pads on each component.
+        priority: Net-class priority.
+
+    Returns:
+        Tuple of (router, net_ids_in_creation_order, net_names).
+        ``net_ids[0]`` corresponds to the topmost pad pair,
+        ``net_ids[-1]`` to the bottommost pad pair.
+    """
+    cls = NetClassRouting(
+        name=group_name,
+        priority=priority,
+        trace_width=0.15,
+        clearance=0.10,
+        length_critical=True,
+        length_match_group=group_name,
+        length_match_reference=None,
+        length_match_tolerance_mm=0.1,
+    )
+    net_class_map: dict[str, NetClassRouting] = {}
+    router = Autorouter(width=120.0, height=80.0, net_class_map=net_class_map)
+
+    # Two mirrored components: U1 on the left (pads at x=40, vertical
+    # row), U2 on the right (pads at x=80, vertical row).  Y-positions
+    # spaced by ``pitch`` and centred on y=40.
+    centre_y = 40.0
+    base_y = centre_y - (group_size - 1) * pitch / 2.0
+
+    net_ids: list[int] = []
+    net_names: list[str] = []
+    for i in range(group_size):
+        net_id = i + 1
+        net_name = f"DQ{i}"  # Names don't matter for the helper; arbitrary.
+        net_ids.append(net_id)
+        net_names.append(net_name)
+        y = base_y + i * pitch
+
+        # Pad on U1 (left component, right edge)
+        router.add_component(
+            "U1",
+            [
+                {
+                    "number": str(25 + i),
+                    "x": 40.0,
+                    "y": y,
+                    "net": net_id,
+                    "net_name": net_name,
+                }
+            ],
+        )
+        # Mirrored pad on U2 (right component, left edge)
+        router.add_component(
+            "U2",
+            [
+                {
+                    "number": str(1 + i),
+                    "x": 80.0,
+                    "y": y,
+                    "net": net_id,
+                    "net_name": net_name,
+                }
+            ],
+        )
+        net_class_map[net_name] = cls
+
+    router.net_class_map = net_class_map
+    return router, net_ids, net_names
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+
+class TestIdentityOnTinyInputs:
+    """Inputs that can't form a byte-lane return unchanged."""
+
+    def test_empty_input(self) -> None:
+        router = Autorouter(width=50.0, height=50.0)
+        assert router._apply_byte_lane_inner_priority([]) == []
+
+    def test_three_net_input_returns_identity(self) -> None:
+        """Net-order length 3 < 4 -> identity, no detection attempted."""
+        router, net_ids, _ = _make_byte_lane_router(group_size=3)
+        # group_size 3 also < MIN_BYTE_LANE_SIZE=5 so even if we made it
+        # through the length gate, the per-group threshold rejects it.
+        out = router._apply_byte_lane_inner_priority(net_ids)
+        assert out == net_ids
+
+
+class TestIdentityOnNoGroups:
+    """Boards without match groups receive identity output."""
+
+    def test_no_match_groups_declared(self) -> None:
+        """Plain nets with no length_match_group declaration -> identity."""
+        router = Autorouter(width=80.0, height=80.0)
+        net_ids = [1, 2, 3, 4, 5, 6]
+        for nid in net_ids:
+            nm = f"NET{nid}"
+            router.add_component(
+                f"R{nid}_A",
+                [{"number": "1", "x": float(nid), "y": 5.0, "net": nid, "net_name": nm}],
+            )
+            router.add_component(
+                f"R{nid}_B",
+                [{"number": "1", "x": float(nid) + 1.0, "y": 5.0, "net": nid, "net_name": nm}],
+            )
+        # No suffix-inference pattern matches (NET1, NET2, ...) since
+        # detect_match_groups requires >= 3 members with a numeric suffix
+        # AND a recognisable bus prefix; "NET" is too generic.
+        out = router._apply_byte_lane_inner_priority(net_ids)
+        # Identity expected (no groups detected) OR a no-op permutation:
+        # the helper short-circuits on empty ``net_to_group`` returning
+        # the input list reference unchanged.
+        assert out == net_ids
+
+
+class TestIdentityOnSmallGroups:
+    """Groups smaller than ``MIN_BYTE_LANE_SIZE`` return identity."""
+
+    def test_four_member_group_no_promotion(self) -> None:
+        """A 4-net group is below the byte-lane threshold."""
+        router, net_ids, _ = _make_byte_lane_router(group_size=4)
+        out = router._apply_byte_lane_inner_priority(net_ids)
+        # Below MIN_BYTE_LANE_SIZE=5 -> no demotion -> identity.
+        assert out == net_ids
+
+
+class TestInnerCornerDemotion:
+    """Mirrored byte-lane promotes inner-corner above immediate neighbours."""
+
+    def test_nine_net_byte_lane_demotes_neighbours(self) -> None:
+        """9-net byte-lane (DDR-byte minus DQS pair): positions 0/2/6/8
+        get demoted below positions 1/7."""
+        router, net_ids, _ = _make_byte_lane_router(group_size=9)
+
+        # Input order = creation order = sorted by y (pad position).
+        # Position 0 = corner top, 1 = inner-corner top, 2 = second-
+        # inward top, ..., 7 = inner-corner bottom, 8 = corner bottom.
+        out = router._apply_byte_lane_inner_priority(net_ids)
+
+        # Membership + length preserved.
+        assert len(out) == len(net_ids)
+        assert set(out) == set(net_ids)
+
+        # The demoted neighbours are at sorted indices {0, 2, 6, 8}
+        # which correspond to net_ids[0], net_ids[2], net_ids[6],
+        # net_ids[8].  Each must appear AFTER its inner-corner sibling
+        # (net_ids[1] or net_ids[7]) in the output.
+        idx = {nid: i for i, nid in enumerate(out)}
+
+        inner_top = net_ids[1]
+        corner_top = net_ids[0]
+        second_inward_top = net_ids[2]
+        inner_bottom = net_ids[7]
+        corner_bottom = net_ids[8]
+        second_inward_bottom = net_ids[6]
+
+        assert idx[inner_top] < idx[corner_top], (
+            f"Inner-corner top ({inner_top}) must precede corner top "
+            f"({corner_top}): positions {idx[inner_top]} vs {idx[corner_top]}"
+        )
+        assert idx[inner_top] < idx[second_inward_top], (
+            f"Inner-corner top ({inner_top}) must precede second-inward "
+            f"top ({second_inward_top}): {idx[inner_top]} vs "
+            f"{idx[second_inward_top]}"
+        )
+        assert idx[inner_bottom] < idx[corner_bottom], (
+            f"Inner-corner bottom ({inner_bottom}) must precede corner "
+            f"bottom ({corner_bottom}): {idx[inner_bottom]} vs "
+            f"{idx[corner_bottom]}"
+        )
+        assert idx[inner_bottom] < idx[second_inward_bottom], (
+            f"Inner-corner bottom ({inner_bottom}) must precede "
+            f"second-inward bottom ({second_inward_bottom}): "
+            f"{idx[inner_bottom]} vs {idx[second_inward_bottom]}"
+        )
+
+    def test_ten_net_byte_lane_preserves_middle_position(self) -> None:
+        """A 10-net byte-lane (full DDR-byte) leaves middle nets in
+        their priority-sort positions, only demoting the four
+        immediate neighbours of inner-corner pads."""
+        # Mimics the full DDR byte: 10 nets in a row.  Inner-corner
+        # indices = (1, 8); demoted indices = (0, 2, 7, 9); middle
+        # indices = (3, 4, 5, 6) which keep their rank.
+        router, net_ids, _ = _make_byte_lane_router(group_size=10)
+        out = router._apply_byte_lane_inner_priority(net_ids)
+
+        idx = {nid: i for i, nid in enumerate(out)}
+
+        # Middle members (sorted indices 3..6) keep their relative
+        # order: they all have the same default rank, so the stable
+        # sort preserves input ordering between them.
+        middle_ids = [net_ids[3], net_ids[4], net_ids[5], net_ids[6]]
+        middle_positions = [idx[nid] for nid in middle_ids]
+        assert middle_positions == sorted(middle_positions), (
+            "Middle byte-lane members must keep their priority-sort "
+            f"order; got positions {middle_positions} for ids {middle_ids}"
+        )
+
+        # And the middle members must precede the demoted neighbours
+        # of inner-corner (sorted indices 0, 2, 7, 9).
+        demoted_ids = [net_ids[0], net_ids[2], net_ids[7], net_ids[9]]
+        for mid in middle_ids:
+            for did in demoted_ids:
+                assert idx[mid] < idx[did], (
+                    f"Middle net {mid} (pos {idx[mid]}) must precede "
+                    f"demoted neighbour {did} (pos {idx[did]})"
+                )
+
+
+class TestMultiGroupPreservation:
+    """A non-byte-lane group elsewhere in the routing pass is unaffected."""
+
+    def test_non_group_nets_keep_position(self) -> None:
+        """Add 3 ungrouped nets and confirm they keep their slots."""
+        router, byte_lane_ids, _ = _make_byte_lane_router(group_size=9)
+
+        # Add 3 standalone nets after the byte-lane group.  These have
+        # NO match-group declaration, so the helper must leave them in
+        # place relative to each other.
+        extra_ids: list[int] = []
+        for i in range(3):
+            net_id = 100 + i
+            nm = f"STANDALONE{i}"
+            router.add_component(
+                f"RX{i}_A",
+                [{"number": "1", "x": 5.0, "y": 60.0 + i, "net": net_id, "net_name": nm}],
+            )
+            router.add_component(
+                f"RX{i}_B",
+                [{"number": "1", "x": 25.0, "y": 60.0 + i, "net": net_id, "net_name": nm}],
+            )
+            extra_ids.append(net_id)
+
+        # ``net_class_map`` is unchanged from the byte-lane build, so
+        # the standalone nets are ungrouped (default net class).
+        net_order = byte_lane_ids + extra_ids
+        out = router._apply_byte_lane_inner_priority(net_order)
+
+        # Membership preserved.
+        assert set(out) == set(net_order)
+        assert len(out) == len(net_order)
+
+        # Standalone nets keep their relative order (stable sort).
+        idx = {nid: i for i, nid in enumerate(out)}
+        extra_positions = [idx[nid] for nid in extra_ids]
+        assert extra_positions == sorted(extra_positions), (
+            "Standalone (non-group) nets must keep their priority-sort "
+            f"order; got {extra_positions} for ids {extra_ids}"
+        )
+
+
+class TestPermutationInvariant:
+    """Output is always a valid permutation of the input."""
+
+    def test_all_inputs_preserved(self) -> None:
+        router, net_ids, _ = _make_byte_lane_router(group_size=9)
+        out = router._apply_byte_lane_inner_priority(net_ids)
+        assert sorted(out) == sorted(net_ids), (
+            "Helper must return a permutation of the input (no drops/dupes)"
+        )
+
+    def test_horizontal_row_orientation(self) -> None:
+        """A horizontal row (pads share y, vary x) is detected by the
+        axis-with-greater-variance rule and reordered along x."""
+        cls = NetClassRouting(
+            name="HORIZ_BUS",
+            priority=1,
+            trace_width=0.15,
+            clearance=0.10,
+            length_critical=True,
+            length_match_group="HORIZ_BUS",
+        )
+        net_class_map: dict[str, NetClassRouting] = {}
+        router = Autorouter(width=120.0, height=80.0, net_class_map=net_class_map)
+
+        net_ids: list[int] = []
+        for i in range(7):
+            net_id = i + 1
+            nm = f"HBUS{i}"
+            # Horizontal row: y fixed, x varies.
+            router.add_component(
+                "UH",
+                [{"number": str(i + 1), "x": 10.0 + i * 0.8, "y": 30.0,
+                  "net": net_id, "net_name": nm}],
+            )
+            router.add_component(
+                "UI",
+                [{"number": str(i + 1), "x": 10.0 + i * 0.8, "y": 60.0,
+                  "net": net_id, "net_name": nm}],
+            )
+            net_class_map[nm] = cls
+            net_ids.append(net_id)
+        router.net_class_map = net_class_map
+
+        out = router._apply_byte_lane_inner_priority(net_ids)
+        idx = {nid: i for i, nid in enumerate(out)}
+
+        # Sorted indices along x: 0=corner left, 1=inner-corner left,
+        # ..., 5=inner-corner right, 6=corner right.  Inner-corner
+        # nets (net_ids[1], net_ids[5]) must precede their neighbours.
+        assert idx[net_ids[1]] < idx[net_ids[0]]
+        assert idx[net_ids[1]] < idx[net_ids[2]]
+        assert idx[net_ids[5]] < idx[net_ids[4]]
+        assert idx[net_ids[5]] < idx[net_ids[6]]
+
+
+class TestNonMirroredTopologyGracefulFallback:
+    """A group whose members aren't co-located on one component shouldn't crash."""
+
+    def test_distributed_pads_no_primary_component(self) -> None:
+        """Each net's pads on DIFFERENT components (no primary picks up
+        ``MIN_BYTE_LANE_SIZE`` members) -> identity, no crash."""
+        cls = NetClassRouting(
+            name="SCATTERED_BUS",
+            priority=1,
+            trace_width=0.15,
+            clearance=0.10,
+            length_critical=True,
+            length_match_group="SCATTERED_BUS",
+        )
+        net_class_map: dict[str, NetClassRouting] = {}
+        router = Autorouter(width=120.0, height=80.0, net_class_map=net_class_map)
+
+        net_ids: list[int] = []
+        for i in range(6):
+            net_id = i + 1
+            nm = f"SBUS{i}"
+            # Each net has pads on a UNIQUE pair of components -- no
+            # single component hosts >= MIN_BYTE_LANE_SIZE pads.
+            router.add_component(
+                f"COMP_A{i}",
+                [{"number": "1", "x": 5.0, "y": 20.0 + i, "net": net_id, "net_name": nm}],
+            )
+            router.add_component(
+                f"COMP_B{i}",
+                [{"number": "1", "x": 80.0, "y": 20.0 + i, "net": net_id, "net_name": nm}],
+            )
+            net_class_map[nm] = cls
+            net_ids.append(net_id)
+        router.net_class_map = net_class_map
+
+        out = router._apply_byte_lane_inner_priority(net_ids)
+        # No primary component has 5+ group-member pads -> no demotion
+        # plan -> identity.
+        assert out == net_ids

--- a/tests/router/test_byte_lane_priority.py
+++ b/tests/router/test_byte_lane_priority.py
@@ -2,16 +2,23 @@
 
 The :meth:`Autorouter._apply_byte_lane_inner_priority` helper detects
 mirrored byte-lane match groups (e.g. board 07's DDR data byte on a
-mirrored QFN-48 pair) and demotes the second-inward row neighbours of
-the inner-corner so the inner-corner net (the pad one step in from
-each row corner) routes BEFORE the second-inward neighbour can claim
-its lateral lane.
+mirrored QFN-48 pair) and PROMOTES the inner-corner row members (the
+pad one step in from each row corner) to a rank that places them
+BEFORE all other byte-lane siblings (corners, second-inward, middle)
+in the routing order.
 
-Judge feedback (PR #2969 review): an earlier broader plan also
-demoted corner nets (0 / n-1), but that pushed DRC errors over the
-allowlist on board 07's match-group regression gate.  The corner net
-keeps its default rank now -- the heuristic only constrains positions
-``(2, n-3)`` so the rest of the priority-sort ordering is untouched.
+Judge feedback trace (PR #2969 review):
+
+- Round 1 (broader plan): demoted both corner (0, n-1) AND
+  second-inward (2, n-3) -- got 27/31 nets but DRC was 86, over the
+  70 allowlist.
+- Round 2 (constrained demote, second-inward only): DRC dropped to 4
+  but yield regressed to 20/31 and ``match_group_length_skew`` was
+  silently not exercised.
+- Round 3 (this contract, promote inner-corner directly): the Judge's
+  recommended dual.  The route log refuted the earlier speculative
+  concern about lifting DM0 -- DM0 routed fine while DQ5/DQ2 stayed
+  squeezed -- so promoting the inner-corner is safe.
 
 Root cause that motivates this helper (per the issue):
 
@@ -35,10 +42,11 @@ The helper's contract:
 3.  **Identity on small groups** -- groups with fewer than 5 members
     don't exhibit the mirrored byte-lane topology; the helper degrades
     to identity for them.
-4.  **Inner-corner demotion** -- on a mirrored byte-lane group, the
-    second-inward neighbour of each inner-corner is demoted behind
-    its inner-corner sibling.  Corner nets and non-neighbour middle
-    members keep their original priority position.
+4.  **Inner-corner promotion** -- on a mirrored byte-lane group, the
+    inner-corner nets (positions 1 and n-2 along the row) are
+    promoted to the front of the routing order ahead of all other
+    byte-lane siblings.  Corner nets and second-inward nets keep
+    their default rank.
 5.  **Multi-group preservation** -- non-byte-lane groups in the same
     routing pass are not affected.
 6.  **Length and membership invariant** -- output is always a
@@ -198,20 +206,21 @@ class TestIdentityOnSmallGroups:
         """A 4-net group is below the byte-lane threshold."""
         router, net_ids, _ = _make_byte_lane_router(group_size=4)
         out = router._apply_byte_lane_inner_priority(net_ids)
-        # Below MIN_BYTE_LANE_SIZE=5 -> no demotion -> identity.
+        # Below MIN_BYTE_LANE_SIZE=5 -> no promotion -> identity.
         assert out == net_ids
 
 
-class TestInnerCornerDemotion:
-    """Mirrored byte-lane promotes inner-corner above immediate neighbours."""
+class TestInnerCornerPromotion:
+    """Mirrored byte-lane promotes inner-corner ahead of all siblings."""
 
-    def test_nine_net_byte_lane_demotes_second_inward(self) -> None:
-        """9-net byte-lane (DDR-byte minus DQS pair): positions 2/6
-        (second-inward) get demoted below positions 1/7 (inner-corner).
+    def test_nine_net_byte_lane_promotes_inner_corner(self) -> None:
+        """9-net byte-lane (DDR-byte minus DQS pair): positions 1/7
+        (inner-corner) are promoted to rank 0 and lead the routing
+        order ahead of corners (0/8), second-inward (2/6), and the
+        middle members.
 
-        Per Judge feedback on PR #2969, the corner pads at positions
-        0 and n-1 keep their default rank -- only the second-inward
-        neighbours are demoted.
+        Round 3 contract per PR #2969 review: promote inner-corner
+        directly rather than demoting neighbours.
         """
         router, net_ids, _ = _make_byte_lane_router(group_size=9)
 
@@ -224,96 +233,75 @@ class TestInnerCornerDemotion:
         assert len(out) == len(net_ids)
         assert set(out) == set(net_ids)
 
-        # The demoted neighbours are at sorted indices {2, 6} only --
-        # the second-inward pads.  Corner pads (0, 8) keep their
-        # default priority-sort rank.
         idx = {nid: i for i, nid in enumerate(out)}
 
         inner_top = net_ids[1]
-        corner_top = net_ids[0]
-        second_inward_top = net_ids[2]
         inner_bottom = net_ids[7]
+        corner_top = net_ids[0]
         corner_bottom = net_ids[8]
+        second_inward_top = net_ids[2]
         second_inward_bottom = net_ids[6]
 
-        assert idx[inner_top] < idx[second_inward_top], (
-            f"Inner-corner top ({inner_top}) must precede second-inward "
-            f"top ({second_inward_top}): {idx[inner_top]} vs "
-            f"{idx[second_inward_top]}"
+        # The two inner-corner nets are rank 0; everything else is
+        # rank 1.  Under stable sort, the two inner-corner ids
+        # occupy positions 0 and 1 of the output (in their original
+        # relative order: inner_top at input pos 1 < inner_bottom at
+        # input pos 7).
+        assert idx[inner_top] == 0, (
+            f"Inner-corner top ({inner_top}) should be promoted to "
+            f"output position 0, got {idx[inner_top]}"
         )
-        assert idx[inner_bottom] < idx[second_inward_bottom], (
-            f"Inner-corner bottom ({inner_bottom}) must precede "
-            f"second-inward bottom ({second_inward_bottom}): "
-            f"{idx[inner_bottom]} vs {idx[second_inward_bottom]}"
-        )
-
-        # Corner pads keep their default rank (rank-1) -- they are
-        # tied with inner-corner under the demotion sort and preserve
-        # original input order via the stable secondary key.  Concretely,
-        # net_ids[0] was input position 0 and net_ids[1] was input
-        # position 1, so corner_top (input pos 0) must precede
-        # inner_top (input pos 1) in the output -- this is the
-        # opposite of the previous (broader) implementation which
-        # explicitly demoted corner_top below inner_top.
-        assert idx[corner_top] < idx[inner_top], (
-            f"Corner top ({corner_top}) keeps default rank and must "
-            f"precede inner_top ({inner_top}) under stable secondary "
-            f"key on input order: {idx[corner_top]} vs {idx[inner_top]}"
-        )
-        assert idx[inner_bottom] < idx[corner_bottom], (
-            f"Inner-corner bottom ({inner_bottom}) at input position 7 "
-            f"must precede corner_bottom ({corner_bottom}) at input "
-            f"position 8 under stable secondary key: "
-            f"{idx[inner_bottom]} vs {idx[corner_bottom]}"
+        assert idx[inner_bottom] == 1, (
+            f"Inner-corner bottom ({inner_bottom}) should be promoted "
+            f"to output position 1, got {idx[inner_bottom]}"
         )
 
-    def test_ten_net_byte_lane_preserves_middle_position(self) -> None:
-        """A 10-net byte-lane (full DDR-byte) leaves middle nets in
-        their priority-sort positions, only demoting the two
-        second-inward neighbours of inner-corner pads.
+        # Inner-corner must precede its neighbours (both corner and
+        # second-inward) on the same side of the row.
+        assert idx[inner_top] < idx[corner_top]
+        assert idx[inner_top] < idx[second_inward_top]
+        assert idx[inner_bottom] < idx[corner_bottom]
+        assert idx[inner_bottom] < idx[second_inward_bottom]
 
-        Per Judge feedback on PR #2969, only positions (2, n-3) are
-        demoted -- corners (0, n-1) keep their default rank.
+        # Among the rank-1 (default) nets, the stable secondary key
+        # preserves the original input ordering: corner_top (input
+        # pos 0) precedes second_inward_top (input pos 2), and so on.
+        assert idx[corner_top] < idx[second_inward_top]
+        assert idx[second_inward_bottom] < idx[corner_bottom]
+
+    def test_ten_net_byte_lane_promotes_inner_corner(self) -> None:
+        """A 10-net byte-lane (full DDR-byte): inner-corner pads
+        (positions 1, 8) are promoted to rank 0 and occupy the first
+        two output positions.  Corner pads (0, 9), second-inward
+        pads (2, 7), and middle pads (3-6) all keep their default
+        rank and retain their input ordering relative to each other.
         """
-        # Mimics the full DDR byte: 10 nets in a row.  Inner-corner
-        # indices = (1, 8); demoted indices = (2, 7); middle indices
-        # = (3, 4, 5, 6) which keep their rank.  Corners (0, 9) also
-        # keep their rank now.
         router, net_ids, _ = _make_byte_lane_router(group_size=10)
         out = router._apply_byte_lane_inner_priority(net_ids)
 
         idx = {nid: i for i, nid in enumerate(out)}
 
-        # Middle members (sorted indices 3..6) keep their relative
-        # order: they all have the same default rank, so the stable
-        # sort preserves input ordering between them.
-        middle_ids = [net_ids[3], net_ids[4], net_ids[5], net_ids[6]]
-        middle_positions = [idx[nid] for nid in middle_ids]
-        assert middle_positions == sorted(middle_positions), (
-            "Middle byte-lane members must keep their priority-sort "
-            f"order; got positions {middle_positions} for ids {middle_ids}"
+        inner_top = net_ids[1]
+        inner_bottom = net_ids[8]
+
+        # Inner-corner nets sort to the front.
+        assert idx[inner_top] == 0
+        assert idx[inner_bottom] == 1
+
+        # All other byte-lane members retain their priority-sort
+        # ordering relative to each other under the stable secondary
+        # key.  ``rest`` is everything except the two promoted
+        # inner-corner ids; their output positions should be a
+        # monotonically increasing sequence starting at 2.
+        rest = [nid for i, nid in enumerate(net_ids) if i not in (1, 8)]
+        rest_positions = [idx[nid] for nid in rest]
+        assert rest_positions == sorted(rest_positions), (
+            "Non-promoted byte-lane members must keep their original "
+            f"order; got {rest_positions} for ids {rest}"
         )
-
-        # The demoted neighbours (sorted indices 2 and 7 only) must
-        # appear AFTER the middle and corner members in the output.
-        demoted_ids = [net_ids[2], net_ids[7]]
-        for mid in middle_ids:
-            for did in demoted_ids:
-                assert idx[mid] < idx[did], (
-                    f"Middle net {mid} (pos {idx[mid]}) must precede "
-                    f"demoted neighbour {did} (pos {idx[did]})"
-                )
-
-        # Corners (sorted indices 0 and 9) keep their default rank
-        # and must precede the demoted second-inward neighbours.
-        corner_ids = [net_ids[0], net_ids[9]]
-        for cid in corner_ids:
-            for did in demoted_ids:
-                assert idx[cid] < idx[did], (
-                    f"Corner net {cid} (pos {idx[cid]}) keeps default "
-                    f"rank and must precede demoted second-inward "
-                    f"neighbour {did} (pos {idx[did]})"
-                )
+        # And they must all be at positions >= 2 (after the two
+        # promoted inner-corner nets).
+        assert min(rest_positions) == 2
 
 
 class TestMultiGroupPreservation:
@@ -406,13 +394,14 @@ class TestPermutationInvariant:
 
         # Sorted indices along x: 0=corner left, 1=inner-corner left,
         # 2=second-inward left, ..., 4=second-inward right,
-        # 5=inner-corner right, 6=corner right.  Per Judge feedback
-        # on PR #2969, only the second-inward neighbours (sorted
-        # indices 2 and n-3=4) are demoted.  The inner-corner nets
-        # (net_ids[1], net_ids[5]) must precede those second-inward
-        # neighbours.  Corner nets (net_ids[0], net_ids[6]) keep
-        # their default rank.
+        # 5=inner-corner right, 6=corner right.  Round 3 contract per
+        # PR #2969 review: PROMOTE the inner-corner nets (sorted
+        # indices 1 and n-2=5) to rank 0.  They must precede both
+        # their corner neighbour (sorted indices 0 and 6) and their
+        # second-inward neighbour (sorted indices 2 and 4).
+        assert idx[net_ids[1]] < idx[net_ids[0]]
         assert idx[net_ids[1]] < idx[net_ids[2]]
+        assert idx[net_ids[5]] < idx[net_ids[6]]
         assert idx[net_ids[5]] < idx[net_ids[4]]
 
 
@@ -452,6 +441,6 @@ class TestNonMirroredTopologyGracefulFallback:
         router.net_class_map = net_class_map
 
         out = router._apply_byte_lane_inner_priority(net_ids)
-        # No primary component has 5+ group-member pads -> no demotion
+        # No primary component has 5+ group-member pads -> no promotion
         # plan -> identity.
         assert out == net_ids

--- a/tests/router/test_byte_lane_priority.py
+++ b/tests/router/test_byte_lane_priority.py
@@ -1,26 +1,34 @@
-"""Tests for inner-corner byte-lane priority bumping (Issue #2962).
+"""Tests for the mirrored byte-lane scaffolding hook (Issue #2962).
 
 The :meth:`Autorouter._apply_byte_lane_inner_priority` helper detects
 mirrored byte-lane match groups (e.g. board 07's DDR data byte on a
-mirrored QFN-48 pair) and PROMOTES the inner-corner row members (the
-pad one step in from each row corner) to a rank that places them
-BEFORE all other byte-lane siblings (corners, second-inward, middle)
-in the routing order.
+mirrored QFN-48 pair) but, in this scaffolding-only cut, **returns the
+input net order unchanged**.  The detection / projection / sort
+machinery and the three integration hook sites (``route_all``,
+``route_all_negotiated``, ``TwoPhaseRouter``) are preserved as the
+surface for a future layered-escape PR.
 
-Judge feedback trace (PR #2969 review):
+PR #2969 design history (preserved as the AC for issue #2962's
+net-ordering exploration):
 
-- Round 1 (broader plan): demoted both corner (0, n-1) AND
-  second-inward (2, n-3) -- got 27/31 nets but DRC was 86, over the
+- **Round 1** (broader plan): demoted both corner (0, n-1) AND
+  second-inward (2, n-3).  Got 27/31 nets but DRC was 86, over the
   70 allowlist.
-- Round 2 (constrained demote, second-inward only): DRC dropped to 4
-  but yield regressed to 20/31 and ``match_group_length_skew`` was
-  silently not exercised.
-- Round 3 (this contract, promote inner-corner directly): the Judge's
-  recommended dual.  The route log refuted the earlier speculative
-  concern about lifting DM0 -- DM0 routed fine while DQ5/DQ2 stayed
-  squeezed -- so promoting the inner-corner is safe.
+- **Round 2** (constrained, demote second-inward only): DRC dropped
+  to 4 but yield regressed to 20/31 and ``match_group_length_skew``
+  was silently not exercised.
+- **Round 3** (promote inner-corner to rank 0 directly): the
+  Judge's recommended "dual" interpretation.  Yield 24/31, DRC 12
+  (well under 70 allowlist), but DQ5 still blocked by DQ4 with the
+  identical 0.44mm clearance failure as round 2 -- the underlying
+  constraint is geometric, not orderable.
+- **Terminal outcome** (this PR / contract): scaffolding-only.  The
+  helper detects but does not act; a follow-up issue tracks the
+  layered-escape strategy that decouples via placement from net
+  ordering.
 
-Root cause that motivates this helper (per the issue):
+Root cause that motivates the eventual implementation (per the
+issue):
 
     Pin row order on U1.25-35 is
     ``DQ0, DQ1, DQ2, DQ3, DM0, DQS_P, DQS_N, DQ4, DQ5, DQ6, DQ7``
@@ -33,7 +41,7 @@ Root cause that motivates this helper (per the issue):
         remaining lateral lane.
     The inner-corner nets are squeezed out.
 
-The helper's contract:
+The helper's current scaffolding contract:
 
 1.  **Identity on tiny inputs** -- ``net_order`` shorter than 4 is
     returned unchanged.
@@ -42,11 +50,9 @@ The helper's contract:
 3.  **Identity on small groups** -- groups with fewer than 5 members
     don't exhibit the mirrored byte-lane topology; the helper degrades
     to identity for them.
-4.  **Inner-corner promotion** -- on a mirrored byte-lane group, the
-    inner-corner nets (positions 1 and n-2 along the row) are
-    promoted to the front of the routing order ahead of all other
-    byte-lane siblings.  Corner nets and second-inward nets keep
-    their default rank.
+4.  **Identity on mirrored byte-lane groups** -- detection runs but
+    no reorder is applied.  A future PR will replace this with a
+    placement-aware layered-escape strategy.
 5.  **Multi-group preservation** -- non-byte-lane groups in the same
     routing pass are not affected.
 6.  **Length and membership invariant** -- output is always a
@@ -210,98 +216,52 @@ class TestIdentityOnSmallGroups:
         assert out == net_ids
 
 
-class TestInnerCornerPromotion:
-    """Mirrored byte-lane promotes inner-corner ahead of all siblings."""
+class TestScaffoldingIdentityOnByteLane:
+    """Mirrored byte-lane groups currently return identity (scaffolding cut).
 
-    def test_nine_net_byte_lane_promotes_inner_corner(self) -> None:
-        """9-net byte-lane (DDR-byte minus DQS pair): positions 1/7
-        (inner-corner) are promoted to rank 0 and lead the routing
-        order ahead of corners (0/8), second-inward (2/6), and the
-        middle members.
+    The helper detects the byte-lane row -- the projection / sort
+    machinery runs eagerly so future analysis hooks see consistent
+    intermediate state -- but no reorder is applied.  A follow-up PR
+    will replace the scaffolding fallback with a layered-escape
+    strategy (corridor reservation, deferred via stitching, or
+    explicit lateral-lane assignment) without touching the three
+    integration hooks.
+    """
 
-        Round 3 contract per PR #2969 review: promote inner-corner
-        directly rather than demoting neighbours.
+    def test_nine_net_byte_lane_identity(self) -> None:
+        """9-net byte-lane (DDR-byte minus DQS pair): detection runs,
+        no reorder applied -- output equals input.
+
+        Scaffolding contract per PR #2969 round-4 terminal outcome:
+        net-ordering alone cannot resolve the geometric DQ5/DQ4
+        0.44mm clearance constraint observed across R1/R2/R3.  The
+        helper retains its detection logic and signature so a future
+        layered-escape PR can swap the body without touching callers.
         """
         router, net_ids, _ = _make_byte_lane_router(group_size=9)
 
-        # Input order = creation order = sorted by y (pad position).
-        # Position 0 = corner top, 1 = inner-corner top, 2 = second-
-        # inward top, ..., 7 = inner-corner bottom, 8 = corner bottom.
         out = router._apply_byte_lane_inner_priority(net_ids)
 
-        # Membership + length preserved.
+        # Identity contract: output is the input list, unchanged.
+        assert out == net_ids
+        # Membership + length invariants hold trivially under identity.
         assert len(out) == len(net_ids)
         assert set(out) == set(net_ids)
 
-        idx = {nid: i for i, nid in enumerate(out)}
+    def test_ten_net_byte_lane_identity(self) -> None:
+        """A 10-net byte-lane (full DDR-byte): detection runs, but
+        no reorder is applied -- output equals input.
 
-        inner_top = net_ids[1]
-        inner_bottom = net_ids[7]
-        corner_top = net_ids[0]
-        corner_bottom = net_ids[8]
-        second_inward_top = net_ids[2]
-        second_inward_bottom = net_ids[6]
-
-        # The two inner-corner nets are rank 0; everything else is
-        # rank 1.  Under stable sort, the two inner-corner ids
-        # occupy positions 0 and 1 of the output (in their original
-        # relative order: inner_top at input pos 1 < inner_bottom at
-        # input pos 7).
-        assert idx[inner_top] == 0, (
-            f"Inner-corner top ({inner_top}) should be promoted to "
-            f"output position 0, got {idx[inner_top]}"
-        )
-        assert idx[inner_bottom] == 1, (
-            f"Inner-corner bottom ({inner_bottom}) should be promoted "
-            f"to output position 1, got {idx[inner_bottom]}"
-        )
-
-        # Inner-corner must precede its neighbours (both corner and
-        # second-inward) on the same side of the row.
-        assert idx[inner_top] < idx[corner_top]
-        assert idx[inner_top] < idx[second_inward_top]
-        assert idx[inner_bottom] < idx[corner_bottom]
-        assert idx[inner_bottom] < idx[second_inward_bottom]
-
-        # Among the rank-1 (default) nets, the stable secondary key
-        # preserves the original input ordering: corner_top (input
-        # pos 0) precedes second_inward_top (input pos 2), and so on.
-        assert idx[corner_top] < idx[second_inward_top]
-        assert idx[second_inward_bottom] < idx[corner_bottom]
-
-    def test_ten_net_byte_lane_promotes_inner_corner(self) -> None:
-        """A 10-net byte-lane (full DDR-byte): inner-corner pads
-        (positions 1, 8) are promoted to rank 0 and occupy the first
-        two output positions.  Corner pads (0, 9), second-inward
-        pads (2, 7), and middle pads (3-6) all keep their default
-        rank and retain their input ordering relative to each other.
+        See the module docstring for the R1/R2/R3 design-history
+        trace explaining why net-ordering alone is insufficient.
         """
         router, net_ids, _ = _make_byte_lane_router(group_size=10)
         out = router._apply_byte_lane_inner_priority(net_ids)
 
-        idx = {nid: i for i, nid in enumerate(out)}
-
-        inner_top = net_ids[1]
-        inner_bottom = net_ids[8]
-
-        # Inner-corner nets sort to the front.
-        assert idx[inner_top] == 0
-        assert idx[inner_bottom] == 1
-
-        # All other byte-lane members retain their priority-sort
-        # ordering relative to each other under the stable secondary
-        # key.  ``rest`` is everything except the two promoted
-        # inner-corner ids; their output positions should be a
-        # monotonically increasing sequence starting at 2.
-        rest = [nid for i, nid in enumerate(net_ids) if i not in (1, 8)]
-        rest_positions = [idx[nid] for nid in rest]
-        assert rest_positions == sorted(rest_positions), (
-            "Non-promoted byte-lane members must keep their original "
-            f"order; got {rest_positions} for ids {rest}"
-        )
-        # And they must all be at positions >= 2 (after the two
-        # promoted inner-corner nets).
-        assert min(rest_positions) == 2
+        # Identity contract.
+        assert out == net_ids
+        assert len(out) == len(net_ids)
+        assert set(out) == set(net_ids)
 
 
 class TestMultiGroupPreservation:
@@ -333,17 +293,12 @@ class TestMultiGroupPreservation:
         net_order = byte_lane_ids + extra_ids
         out = router._apply_byte_lane_inner_priority(net_order)
 
+        # Under the scaffolding cut the full input order is preserved,
+        # which trivially keeps the standalone nets in place.
+        assert out == net_order
         # Membership preserved.
         assert set(out) == set(net_order)
         assert len(out) == len(net_order)
-
-        # Standalone nets keep their relative order (stable sort).
-        idx = {nid: i for i, nid in enumerate(out)}
-        extra_positions = [idx[nid] for nid in extra_ids]
-        assert extra_positions == sorted(extra_positions), (
-            "Standalone (non-group) nets must keep their priority-sort "
-            f"order; got {extra_positions} for ids {extra_ids}"
-        )
 
 
 class TestPermutationInvariant:
@@ -357,8 +312,16 @@ class TestPermutationInvariant:
         )
 
     def test_horizontal_row_orientation(self) -> None:
-        """A horizontal row (pads share y, vary x) is detected by the
-        axis-with-greater-variance rule and reordered along x."""
+        """A horizontal row (pads share y, vary x) exercises the
+        axis-with-greater-variance detection branch but, in the
+        scaffolding cut, still returns identity.
+
+        Round-4 contract per PR #2969: even when the detection logic
+        successfully classifies the row, no reorder is applied.  The
+        axis-selection branch is exercised here for coverage so a
+        future layered-escape implementation has a regression
+        fingerprint to compare against.
+        """
         cls = NetClassRouting(
             name="HORIZ_BUS",
             priority=1,
@@ -390,19 +353,10 @@ class TestPermutationInvariant:
         router.net_class_map = net_class_map
 
         out = router._apply_byte_lane_inner_priority(net_ids)
-        idx = {nid: i for i, nid in enumerate(out)}
 
-        # Sorted indices along x: 0=corner left, 1=inner-corner left,
-        # 2=second-inward left, ..., 4=second-inward right,
-        # 5=inner-corner right, 6=corner right.  Round 3 contract per
-        # PR #2969 review: PROMOTE the inner-corner nets (sorted
-        # indices 1 and n-2=5) to rank 0.  They must precede both
-        # their corner neighbour (sorted indices 0 and 6) and their
-        # second-inward neighbour (sorted indices 2 and 4).
-        assert idx[net_ids[1]] < idx[net_ids[0]]
-        assert idx[net_ids[1]] < idx[net_ids[2]]
-        assert idx[net_ids[5]] < idx[net_ids[6]]
-        assert idx[net_ids[5]] < idx[net_ids[4]]
+        # Identity contract: horizontal row detection runs but no
+        # reorder is applied.
+        assert out == net_ids
 
 
 class TestNonMirroredTopologyGracefulFallback:


### PR DESCRIPTION
Closes #2962 (net-ordering exploration arc).

## Status: scaffolding-only (terminal outcome)

This PR lands ``Autorouter._apply_byte_lane_inner_priority`` as a
**detection-only identity-return helper** plus three integration
hook sites, after the Judge's round-3 fallback decision: net-
ordering alone cannot resolve board 07's mirrored-byte-lane DDR
escape geometry.  The detection / projection / sort machinery and
the three hook sites are preserved as the integration surface for
a future layered-escape PR tracked in #2983.

## Why scaffolding-only

Three iterations explored net-ordering alone.  All three converged
on the same geometric constraint -- DQ5 blocked by a DQ4 via at
0.44mm on the 0.8mm-pitch QFN-48 row.

| Round | Plan | Yield | DRC | Verdict |
|---|---|---|---|---|
| 1 | Demote corner (0, N-1) AND second-inward (2, N-3) | 27/31 | 86 | Over the 70 DRC allowlist; corner demotion forced detours through tight-clearance geometry |
| 2 | Demote only second-inward (2, N-3) | 20/31 | 4 | DRC OK but yield regressed and ``match_group_length_skew`` was silently not exercised |
| 3 | Promote inner-corner (1, N-2) to rank 0 directly | 24/31 | 12 | DRC well under allowlist, but DQ5 still blocked by DQ4 via at 0.44mm -- proves geometric constraint |

R3 was one shy of the 25/31 threshold and the failure signature was
identical to R2 (DQ5 blocked by DQ4 at 0.44mm).  Per the Judge's
documented fallback (PR body round-3 brief), the right move is to
land the scaffolding and file a follow-up for the layered-escape
strategy that decouples via placement from priority.

The R1/R2/R3 trace is preserved verbatim in:

- ``Autorouter._apply_byte_lane_inner_priority``'s docstring
- ``tests/router/test_byte_lane_priority.py``'s module docstring

These serve as the AC for #2962's net-ordering exploration.

## What this PR lands

### Detection helper (scaffolding-only)

``Autorouter._apply_byte_lane_inner_priority`` runs detection
eagerly so the integration surface is exercised:

1. Identify match groups with at least ``MIN_BYTE_LANE_SIZE`` (=5)
   members.
2. For each candidate, find the primary component (the package
   hosting the most group-member pads).
3. Project pads onto the row's primary axis (greater spatial
   variance), sort.
4. Locate inner-corner indices (sorted positions 1 and N-2).

The eventual reorder step is intentionally omitted; the helper
returns ``net_order`` unchanged.  A future PR can replace the
``# Scaffolding fallback:`` block at the bottom with a real
layered-escape implementation without touching the three callers.

### Three integration hook sites

- ``Autorouter.route_all`` (~line 4366) -- runs after
  ``_interleave_match_groups``.
- ``Autorouter.route_all_negotiated`` (~line 5559) -- identical
  hook.
- ``TwoPhaseRouter`` (via ``apply_byte_lane_inner_priority``
  parameter on ``_create_two_phase_router``) -- identical hook.

All three sites run ``_interleave_match_groups`` BEFORE the
scaffolding helper, preserving PR #2914's starvation-fairness
guarantee.

### 10 contract tests (identity-ordering assertions)

``tests/router/test_byte_lane_priority.py`` pins the scaffolding
contract:

- ``TestIdentityOnTinyInputs`` -- net-order < 4 returns identity.
- ``TestIdentityOnNoGroups`` -- boards without match groups return
  identity.
- ``TestIdentityOnSmallGroups`` -- groups smaller than 5 return
  identity.
- ``TestScaffoldingIdentityOnByteLane`` -- mirrored byte-lane
  groups: detection runs, output equals input.  These assertions
  become the regression fingerprint once a real layered-escape
  implementation lands.
- ``TestMultiGroupPreservation`` -- standalone nets keep their
  position.
- ``TestPermutationInvariant`` -- output is always a permutation of
  the input; ``test_horizontal_row_orientation`` exercises the
  axis-selection branch but asserts identity (scaffolding cut).
- ``TestNonMirroredTopologyGracefulFallback`` -- distributed pads
  (no primary component) return identity, no crash.

All 10 unit tests pass locally; 150/150 router tests pass.

## Hard limits respected

- ``.github/routed-drc-tolerance.yml`` is unchanged.
- PR #2914's ``_interleave_match_groups`` is preserved (runs before
  the scaffolding helper at all 3 integration sites).
- ``match_group_tuning.py`` NOT modified.

## Yield expectation

Since the helper is now a no-op, yield should match ``main``
exactly.  The R3 24/31 result was a local maximum that didn't clear
the 25/31 threshold; the layered-escape follow-up is the right
vehicle for net-ordering-independent improvements.

## Follow-up

Issue #2983: *router: layered-escape strategy for mirrored
byte-lane DDR (decouples via placement from net ordering)*.  Body
includes the full R1/R2/R3 analysis from this PR's iterations plus
four candidate strategies (corridor reservation, deferred via
stitching, explicit lateral-lane assignment, via-placement-aware
ordering) for evaluation.  Labelled ``loom:triage``.