### PR TITLE
fix(router): _can_place_via and _position_is_blocked respect cell.net (closes #2963)

### DIFF
--- a/src/kicad_tools/router/cpp/include/grid.hpp
+++ b/src/kicad_tools/router/cpp/include/grid.hpp
@@ -85,7 +85,12 @@ public:
     // Negotiated routing support
     void reset_usage();
     void increment_usage(int x, int y, int layer);
-    float get_negotiated_cost(int x, int y, int layer, float present_factor) const;
+    // Issue #2963: optional ``net`` parameter — when nonzero AND the
+    // cell's net matches, the ``is_obstacle`` hard-reject is skipped
+    // (the destination pad's own metal stays reachable for its own
+    // routing net post-PR #2928's first-touch obstacle marking).
+    float get_negotiated_cost(int x, int y, int layer, float present_factor,
+                              int net = 0) const;
     void update_history_costs(float increment);
     int get_total_overflow() const;
 

--- a/src/kicad_tools/router/cpp/src/bindings.cpp
+++ b/src/kicad_tools/router/cpp/src/bindings.cpp
@@ -157,7 +157,7 @@ NB_MODULE(router_cpp, m) {
         .def("reset_usage", &Grid3D::reset_usage)
         .def("increment_usage", &Grid3D::increment_usage, "x"_a, "y"_a, "layer"_a)
         .def("get_negotiated_cost", &Grid3D::get_negotiated_cost,
-             "x"_a, "y"_a, "layer"_a, "present_factor"_a)
+             "x"_a, "y"_a, "layer"_a, "present_factor"_a, "net"_a = 0)
         .def("update_history_costs", &Grid3D::update_history_costs, "increment"_a)
         .def("get_total_overflow", &Grid3D::get_total_overflow)
         // Properties

--- a/src/kicad_tools/router/cpp/src/grid.cpp
+++ b/src/kicad_tools/router/cpp/src/grid.cpp
@@ -251,13 +251,20 @@ void Grid3D::increment_usage(int x, int y, int layer) {
     }
 }
 
-float Grid3D::get_negotiated_cost(int x, int y, int layer, float present_factor) const {
+float Grid3D::get_negotiated_cost(int x, int y, int layer, float present_factor,
+                                  int net) const {
     if (!is_valid(x, y, layer)) {
         return std::numeric_limits<float>::infinity();
     }
 
     const auto& cell = at(x, y, layer);
-    if (cell.is_obstacle) {
+    // Issue #2963: own-net obstacle cells (e.g. destination pad metal
+    // marked is_obstacle=True on first touch by PR #2928) must remain
+    // reachable for the routing net.  When ``net`` is 0 the caller
+    // has no net context, so the legacy conservative reject stands;
+    // when ``net`` is nonzero AND matches the cell's net the obstacle
+    // gate is bypassed (foreign-net obstacles still hard-reject).
+    if (cell.is_obstacle && (net == 0 || cell.net != net)) {
         return std::numeric_limits<float>::infinity();
     }
 

--- a/src/kicad_tools/router/cpp/src/pathfinder.cpp
+++ b/src/kicad_tools/router/cpp/src/pathfinder.cpp
@@ -533,7 +533,11 @@ RouteResult Pathfinder::route(
             float congestion_cost = get_congestion_cost(nx, ny, nlayer);
             float negotiated_cost = 0.0f;
             if (negotiated_mode) {
-                negotiated_cost = grid_.get_negotiated_cost(nx, ny, nlayer, present_cost_factor);
+                // Issue #2963: pass routing net so own-net obstacle
+                // cells (destination pad metal post-PR #2928) stay
+                // reachable with finite cost.
+                negotiated_cost = grid_.get_negotiated_cost(
+                    nx, ny, nlayer, present_cost_factor, net);
             }
 
             float avoidance = grid_.at(nx, ny, nlayer).avoidance_cost;
@@ -581,8 +585,11 @@ RouteResult Pathfinder::route(
             float congestion_cost = get_congestion_cost(current.x, current.y, new_layer);
             float negotiated_cost = 0.0f;
             if (negotiated_mode) {
+                // Issue #2963: pass routing net so own-net obstacle
+                // cells stay reachable with finite cost (via-drop into
+                // destination pad).
                 negotiated_cost = grid_.get_negotiated_cost(
-                    current.x, current.y, new_layer, present_cost_factor);
+                    current.x, current.y, new_layer, present_cost_factor, net);
             }
 
             float avoidance = grid_.at(current.x, current.y, new_layer).avoidance_cost;
@@ -922,8 +929,10 @@ RouteResult Pathfinder::run_astar_loop() {
             float congestion_cost = get_congestion_cost(nx, ny, nlayer);
             float negotiated_cost = 0.0f;
             if (search_negotiated_mode_) {
-                negotiated_cost = grid_.get_negotiated_cost(nx, ny, nlayer,
-                                                           search_present_cost_factor_);
+                // Issue #2963: pass routing net so own-net obstacle
+                // cells (destination pad metal) stay reachable.
+                negotiated_cost = grid_.get_negotiated_cost(
+                    nx, ny, nlayer, search_present_cost_factor_, search_net_);
             }
 
             float avoidance = grid_.at(nx, ny, nlayer).avoidance_cost;
@@ -972,8 +981,12 @@ RouteResult Pathfinder::run_astar_loop() {
             float congestion_cost = get_congestion_cost(current.x, current.y, new_layer);
             float negotiated_cost = 0.0f;
             if (search_negotiated_mode_) {
+                // Issue #2963: pass routing net (search_net_) so own-net
+                // obstacle cells stay reachable for via drop into the
+                // destination pad metal.
                 negotiated_cost = grid_.get_negotiated_cost(
-                    current.x, current.y, new_layer, search_present_cost_factor_);
+                    current.x, current.y, new_layer, search_present_cost_factor_,
+                    search_net_);
             }
 
             float avoidance = grid_.at(current.x, current.y, new_layer).avoidance_cost;

--- a/src/kicad_tools/router/escape.py
+++ b/src/kicad_tools/router/escape.py
@@ -3795,12 +3795,23 @@ class EscapeRouter:
             return False
 
         # Check for obstacles in grid
+        #
+        # Issue #2963: Post-PR #2928, isolated pad-metal cells are
+        # marked ``is_obstacle=True`` on first touch.  Without an
+        # own-net filter here, every via candidate that lands inside
+        # the destination pad's footprint is rejected -- including
+        # when ``net`` is the pad's own net (e.g. NRST/BOOT0 endpoint
+        # pads on board 04).  Mirror PR #2965's pattern: only reject
+        # when the cell's net is a *different* net from the via's.
+        # When ``net`` is ``None`` the caller has no net context, so
+        # preserve the original (conservative) hard reject.
         gx, gy = self.grid.world_to_grid(x, y)
         if 0 <= gx < self.grid.cols and 0 <= gy < self.grid.rows:
             for layer_idx in range(self.grid.num_layers):
                 cell = self.grid.grid[layer_idx][gy][gx]
                 if cell.blocked and cell.is_obstacle:
-                    return False
+                    if net is None or cell.net != net:
+                        return False
 
         # Issue #2944: World-coordinate clearance check against foreign
         # copper.  Only runs when the caller supplies pad / track

--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -3517,15 +3517,42 @@ class RoutingGrid:
             self._present_cost_ema = alpha * new_present + (1.0 - alpha) * self._present_cost_ema
 
     def get_negotiated_cost(
-        self, gx: int, gy: int, layer: int, present_cost_factor: float = 1.0
+        self,
+        gx: int,
+        gy: int,
+        layer: int,
+        present_cost_factor: float = 1.0,
+        net: int | None = None,
     ) -> float:
-        """Get the negotiated congestion cost for a cell."""
+        """Get the negotiated congestion cost for a cell.
+
+        Args:
+            gx, gy, layer: Grid coordinates / layer index of the cell.
+            present_cost_factor: Adaptive present-cost weight.
+            net: Optional routing-net context.  When provided AND the
+                cell's net matches, an ``is_obstacle`` cell is treated
+                as reachable (returns a finite cost) rather than hard
+                ``inf``.  This is the cost-side mirror of the
+                ``cell.net != net`` filter applied in the pathfinder's
+                ``_is_trace_blocked`` / ``_is_via_blocked`` predicates
+                (PR #2965 pattern).  Without this, post-PR #2928 the
+                destination pad's own metal -- which is now marked
+                ``is_obstacle=True`` on first touch -- yields ``inf``
+                cost and A* cannot expand into it, leaving endpoint
+                pads (e.g. NRST/BOOT0 on board 04) unreachable.
+                Defaults to ``None`` (legacy behavior: any obstacle
+                cell is ``inf``).
+        """
         if not (0 <= gx < self.cols and 0 <= gy < self.rows):
             return float("inf")
 
         cell = self.grid[layer][gy][gx]
 
-        if cell.is_obstacle:
+        # Issue #2963: own-net obstacle cells (e.g. the destination
+        # pad's own metal after PR #2928's first-touch marking) must
+        # remain reachable for the routing net.  Foreign-net obstacles
+        # still hard-reject.
+        if cell.is_obstacle and (net is None or cell.net != net):
             return float("inf")
 
         # Issue #2333: Use EMA-smoothed present cost when available

--- a/src/kicad_tools/router/optimizer/collision.py
+++ b/src/kicad_tools/router/optimizer/collision.py
@@ -128,7 +128,11 @@ class GridCollisionChecker:
 
             # Check if blocked by another net
             if cell.blocked:
-                if cell.is_obstacle:
+                # Issue #2963: own-net obstacle cells (destination pad
+                # metal marked by PR #2928's first-touch) must remain
+                # passable for the route's own net.  Foreign-net
+                # obstacles still hard-reject.
+                if cell.is_obstacle and cell.net != exclude_net:
                     return False  # Hard obstacle (pad, keepout) -- always block
 
                 # Issue #2757: A pad on a skipped pour net (e.g. GND, +3V3)

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -1288,8 +1288,12 @@ class Router:
                 is_obstacle = is_obstacle_arr[i]
                 usage = usage_arr[i]
 
-                if is_obstacle:
-                    return True  # Obstacles always block
+                # Issue #2963: own-net obstacle cells (destination pad
+                # metal post-PR #2928 first-touch marking) must remain
+                # passable for the routing net's own via.  Foreign-net
+                # obstacles still hard-reject.
+                if is_obstacle and cell_net != net:
+                    return True  # Obstacles always block (foreign net)
 
                 # No-net pads must always block
                 if cell_net == 0:
@@ -1310,10 +1314,20 @@ class Router:
         return False
 
     def _get_negotiated_cell_cost(
-        self, gx: int, gy: int, layer: int, present_factor: float = 1.0
+        self,
+        gx: int,
+        gy: int,
+        layer: int,
+        present_factor: float = 1.0,
+        net: int | None = None,
     ) -> float:
-        """Get negotiated congestion cost for a cell."""
-        return self.grid.get_negotiated_cost(gx, gy, layer, present_factor)
+        """Get negotiated congestion cost for a cell.
+
+        Issue #2963: ``net`` plumbs the routing-net context to the
+        cost function so own-net ``is_obstacle`` cells (destination
+        pad metal marked by PR #2928's first-touch) are reachable.
+        """
+        return self.grid.get_negotiated_cost(gx, gy, layer, present_factor, net=net)
 
     def _get_layer_priority(self) -> list[int]:
         """Get layer indices sorted by congestion (most congested first).
@@ -2284,7 +2298,7 @@ class Router:
                 negotiated_cost = 0.0
                 if negotiated_mode and not (is_start_adjacent or is_end_adjacent):
                     negotiated_cost = self._get_negotiated_cell_cost(
-                        nx, ny, nlayer, present_cost_factor
+                        nx, ny, nlayer, present_cost_factor, net=start.net
                     )
 
                 # Issue #2430: Use pre-computed zone cost array
@@ -2388,7 +2402,7 @@ class Router:
                 negotiated_cost = 0.0
                 if negotiated_mode:
                     negotiated_cost = self._get_negotiated_cell_cost(
-                        current.x, current.y, new_layer, present_cost_factor
+                        current.x, current.y, new_layer, present_cost_factor, net=start.net
                     )
 
                 # Add layer preference cost for new layer (Issue #625)
@@ -3583,7 +3597,9 @@ class Router:
             congestion_cost = self._get_congestion_cost(nx, ny, nlayer)
             negotiated_cost = 0.0
             if allow_sharing and not (is_source_adjacent or is_target_adjacent):
-                negotiated_cost = self._get_negotiated_cell_cost(nx, ny, nlayer, 1.0)
+                negotiated_cost = self._get_negotiated_cell_cost(
+                    nx, ny, nlayer, 1.0, net=source_pad.net
+                )
 
             zone_cost = self._get_zone_cost(nx, ny, nlayer, source_pad.net)
             net_class = self._get_net_class(source_pad.net_name)
@@ -3668,7 +3684,7 @@ class Router:
             negotiated_cost = 0.0
             if allow_sharing:
                 negotiated_cost = self._get_negotiated_cell_cost(
-                    current.x, current.y, new_layer, 1.0
+                    current.x, current.y, new_layer, 1.0, net=source_pad.net
                 )
 
             net_class = self._get_net_class(source_pad.net_name)

--- a/src/kicad_tools/router/via_conflict.py
+++ b/src/kicad_tools/router/via_conflict.py
@@ -996,7 +996,14 @@ class ViaConflictManager:
                     cell = self.grid.grid[layer_idx][ny][nx]
                     if cell.blocked and cell.net != exclude_net and cell.net != 0:
                         return True
-                    if cell.is_obstacle:
+                    # Issue #2963: Post-PR #2928, pad-metal cells are
+                    # marked ``is_obstacle=True`` on first touch.  Without
+                    # an own-net filter, this rejects via-repair candidates
+                    # that sit inside the via's own destination pad
+                    # (e.g. NRST/BOOT0 endpoints on board 04).  Only treat
+                    # an obstacle cell as blocking when it belongs to a
+                    # different net.
+                    if cell.is_obstacle and cell.net != exclude_net:
                         return True
 
         return False

--- a/tests/test_escape.py
+++ b/tests/test_escape.py
@@ -905,6 +905,99 @@ class TestStaggeredViaFanout:
         )
 
 
+class TestCanPlaceViaOwnNetObstacle:
+    """Issue #2963 regression: `_can_place_via` must admit a candidate
+    that lands on an own-net `is_obstacle=True` cell.
+
+    Post-PR #2928, isolated pad-metal cells are marked
+    ``is_obstacle=True`` on first touch.  Before this fix, the grid-cell
+    check inside ``_can_place_via`` rejected EVERY candidate that landed
+    inside the destination pad's footprint -- even when ``net`` matched
+    the pad's own net.  On board 04 this manifested as NRST/BOOT0 (and
+    similar endpoint pads) being unreachable, dropping the route from
+    9/9 to 7/9.
+    """
+
+    @pytest.fixture
+    def grid_and_rules(self):
+        """Create grid and rules for testing."""
+        rules = DesignRules(
+            trace_width=0.2,
+            trace_clearance=0.2,
+            via_drill=0.35,
+            via_diameter=0.7,
+            via_clearance=0.2,
+            grid_resolution=0.1,
+        )
+        grid = RoutingGrid(50, 50, rules, origin_x=0, origin_y=0)
+        return grid, rules
+
+    def _paint_obstacle_cell(self, grid, x, y, net):
+        """Mark the cell at world (x, y) as a same-net obstacle on every
+        layer, mirroring the post-PR #2928 isolated-pad first-touch
+        bookkeeping.
+        """
+        gx, gy = grid.world_to_grid(x, y)
+        for layer_idx in range(grid.num_layers):
+            cell = grid.grid[layer_idx][gy][gx]
+            cell.blocked = True
+            cell.is_obstacle = True
+            cell.net = net
+
+    def test_own_net_obstacle_admits_via(self, grid_and_rules):
+        """Issue #2963 primary regression:
+        ``_can_place_via(x, y, net=pad.net)`` must return True at a cell
+        whose ``is_obstacle=True`` belongs to ``pad.net`` (own net).
+        """
+        grid, rules = grid_and_rules
+        router = EscapeRouter(grid, rules)
+
+        pad_net = 7
+        pad_x, pad_y = 10.0, 10.0
+        self._paint_obstacle_cell(grid, pad_x, pad_y, pad_net)
+
+        # Same-net via: must be admitted even though the cell is an
+        # obstacle.  Without the fix this returns False -- the bug that
+        # blocked board 04 NRST/BOOT0.
+        assert router._can_place_via(pad_x, pad_y, net=pad_net) is True, (
+            "Issue #2963: same-net via must be admitted on an own-net "
+            "is_obstacle cell (NRST/BOOT0 endpoint reachability)."
+        )
+
+    def test_foreign_net_obstacle_rejects_via(self, grid_and_rules):
+        """Issue #2963 corollary: foreign-net obstacle cells must still
+        reject the candidate via.  The fix must not loosen the original
+        PR #2928 invariant.
+        """
+        grid, rules = grid_and_rules
+        router = EscapeRouter(grid, rules)
+
+        obstacle_net = 7
+        probe_net = 99
+        x, y = 10.0, 10.0
+        self._paint_obstacle_cell(grid, x, y, obstacle_net)
+
+        assert router._can_place_via(x, y, net=probe_net) is False, (
+            "Issue #2963: foreign-net obstacle cells must still reject "
+            "the via (preserves PR #2928's invariant)."
+        )
+
+    def test_none_net_obstacle_rejects_via(self, grid_and_rules):
+        """When the caller supplies ``net=None`` (no net context), the
+        predicate must remain conservative and reject obstacle cells --
+        callers who lack net context cannot prove the cell is own-net.
+        """
+        grid, rules = grid_and_rules
+        router = EscapeRouter(grid, rules)
+
+        self._paint_obstacle_cell(grid, 10.0, 10.0, net=7)
+
+        assert router._can_place_via(10.0, 10.0, net=None) is False, (
+            "Issue #2963: with no net context, conservative reject must "
+            "be preserved (no spurious allowance)."
+        )
+
+
 class TestApplyEscapeRoutes:
     """Tests for applying escape routes to grid."""
 


### PR DESCRIPTION
## Summary

- Post-PR #2928 marked isolated pad-metal cells as `is_obstacle=True` on first touch. Several consumers read `cell.is_obstacle` without an own-net filter and rejected ANY via candidate landing inside the destination pad's footprint -- including for the pad's own net. On board 04 this blocked NRST and BOOT0 endpoints, dropping the route from 9/9 to 5/9.
- Mirrors PR #2965's pattern: only reject when `cell.net != routing_net`.

## Sites fixed

**Python:**
- `router/escape.py::EscapeRouter._can_place_via` -- primary blocker for NRST/BOOT0 endpoint via probes.
- `router/via_conflict.py::ViaConflictManager._position_is_blocked` -- secondary, used during negotiated via repair.
- `router/grid.py::RoutingGrid.get_negotiated_cost` -- cost function returned `inf` for own-net obstacle cells, making the destination pad unreachable. Adds optional `net` parameter (`None` default preserves legacy behavior).
- `router/pathfinder.py::Pathfinder._is_via_blocked` SoA branch -- via placement on destination pad's own metal was always blocked.
- `router/pathfinder.py::Pathfinder._get_negotiated_cell_cost` -- 4 call sites plumb `net=start.net` / `net=source_pad.net`.
- `router/optimizer/collision.py::CollisionChecker.is_path_clear` -- hard `is_obstacle` reject had no `exclude_net` early-out.

**C++ mirror:**
- `cpp/src/grid.cpp::Grid3D::get_negotiated_cost` -- adds optional `net` parameter (default 0 preserves legacy behavior).
- `cpp/src/pathfinder.cpp` -- 4 call sites pass `net` / `search_net_`.
- `cpp/include/grid.hpp` + `cpp/src/bindings.cpp` updated for the new signature.

## Empirical impact

`kct route boards/04-stm32-devboard/output/stm32_devboard.kicad_pcb --mfr jlcpcb-tier1 --auto-fix --auto-layers --auto-mfr-tier --timeout 600`:

| Build | 2L signal nets | NRST | BOOT0 |
|---|---|---|---|
| Pre-fix (HEAD) | 5/9 | PARTIAL (1/2) | PARTIAL (1/2) |
| **Post-fix** | **8/9** | PARTIAL (1/2) | **routes** |

BOOT0 is fully recovered. NRST remains blocked by the 95s per-net A* deadline -- a separate timing issue, documented in the curator analysis as a "secondary concern" hit on both pre- and post-#2958 builds. Not addressed by this PR.

## Hard limits honored

- PR #2928's `is_obstacle` painting is preserved (foreign-net obstacles still hard-reject).
- DRC tolerances unchanged.
- `pathfinder.py:1121-1149` (the rect-mask `_is_trace_blocked` negotiated branch, already correctly net-gated) was not touched.

## Test plan

- [x] New regression tests in `tests/test_escape.py::TestCanPlaceViaOwnNetObstacle` (own-net admits, foreign-net rejects, `None` net conservative reject) -- all 3 pass.
- [x] `pytest tests/test_escape.py tests/test_via_conflict.py tests/test_router_grid.py tests/test_collision_detection.py tests/test_router_collision.py tests/test_pathfinder_via_foreign_clearance.py tests/test_grid_cpp_parity.py` -- 530 passed, 5 skipped.
- [x] PR #2965 regression test (`_relax_same_component_clearance` `_is_obstacle` carve-out) still passes.
- [x] PR #2928 invariant (foreign-net obstacle cells hard-reject) preserved in all sites.
- [x] Board 04 `kct route --mfr jlcpcb-tier1 --auto-fix --auto-layers --auto-mfr-tier --timeout 600` returns 8/9 (vs 5/9 pre-fix).
- [ ] NRST 9/9 requires separate per-net A* timing work (not in scope here).

Closes #2963

🤖 Generated with [Claude Code](https://claude.com/claude-code)