### PR TITLE
feat(cli): kct pcb lock-footprints / unlock-footprints for anchor-weight recipe (closes #2977)

### DIFF
--- a/src/kicad_tools/cli/commands/pcb.py
+++ b/src/kicad_tools/cli/commands/pcb.py
@@ -11,7 +11,7 @@ def run_pcb_command(args) -> int:
     """Handle PCB subcommands."""
     if not args.pcb_command:
         print("Usage: kicad-tools pcb <command> [options] <file>")
-        print("Commands: summary, footprints, nets, traces, stackup, zones, strip, reannotate, sync-netlist, remove-footprint, move-footprint, add-zone, snap-rotation, edit-outline, net-audit, export-dsn, import-ses")
+        print("Commands: summary, footprints, nets, traces, stackup, zones, strip, reannotate, sync-netlist, remove-footprint, move-footprint, lock-footprints, unlock-footprints, add-zone, snap-rotation, edit-outline, net-audit, export-dsn, import-ses")
         return 1
 
     pcb_path = Path(args.pcb)
@@ -42,6 +42,10 @@ def run_pcb_command(args) -> int:
     # Handle move-footprint command
     if args.pcb_command == "move-footprint":
         return _run_move_footprint_command(args, pcb_path)
+
+    # Handle lock-footprints / unlock-footprints commands
+    if args.pcb_command in ("lock-footprints", "unlock-footprints"):
+        return _run_lock_footprints_command(args, pcb_path)
 
     # Handle add-zone command
     if args.pcb_command == "add-zone":
@@ -709,6 +713,38 @@ def _run_move_footprint_command(args, pcb_path: Path) -> int:
         to=to_tuple,
         rotation=rotation,
         batch_map=batch_map,
+        dry_run=dry_run,
+        output_path=output_path,
+        output_format=output_format,
+    )
+
+
+def _run_lock_footprints_command(args, pcb_path: Path) -> int:
+    """Handle the 'pcb lock-footprints' / 'pcb unlock-footprints' commands."""
+    from kicad_tools.cli.pcb_lock_footprints import run_lock_footprints
+
+    refs_str = getattr(args, "refs", None)
+    all_perimeter = getattr(args, "all_perimeter", False)
+    perimeter_margin = getattr(args, "perimeter_margin", None)
+    output = getattr(args, "output", None)
+    output_path = Path(output) if output else None
+    dry_run = getattr(args, "dry_run", False)
+    output_format = getattr(args, "format", "text")
+    unlock = args.pcb_command == "unlock-footprints"
+
+    refs: list[str] | None = None
+    if refs_str:
+        refs = [r.strip() for r in refs_str.split(",") if r.strip()]
+        if not refs:
+            print("Error: --refs must contain at least one reference", file=sys.stderr)
+            return 1
+
+    return run_lock_footprints(
+        pcb_path=pcb_path,
+        refs=refs,
+        all_perimeter=all_perimeter,
+        perimeter_margin=perimeter_margin,
+        unlock=unlock,
         dry_run=dry_run,
         output_path=output_path,
         output_format=output_format,

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1506,6 +1506,61 @@ def _add_pcb_parser(subparsers) -> None:
         help="Preview moves without modifying the PCB file",
     )
 
+    # pcb lock-footprints / unlock-footprints
+    for _cmd_name, _help_verb in (
+        ("lock-footprints", "Lock"),
+        ("unlock-footprints", "Unlock"),
+    ):
+        _lock_fp = pcb_subparsers.add_parser(
+            _cmd_name,
+            help=f"{_help_verb} footprints by reference (for anchor-weight recipe)",
+            description=(
+                f"{_help_verb} footprints in a PCB so the anchor-weight "
+                "recipe (kct optimize-placement --anchor-weight 1.0 "
+                "--allow-infeasible) can identify perimeter anchors. "
+                "Use --refs for explicit selection or --all-perimeter to "
+                "target every footprint whose bounding box touches the "
+                "Edge.Cuts outline.  Idempotent."
+            ),
+        )
+        _lock_fp.add_argument("pcb", help="Path to .kicad_pcb file")
+        _lock_fp.add_argument(
+            "--refs",
+            help="Comma-separated reference designators (e.g. J1,J2,MH1)",
+        )
+        _lock_fp.add_argument(
+            "--all-perimeter",
+            action="store_true",
+            help="Target all footprints whose bbox touches the board edge",
+        )
+        _lock_fp.add_argument(
+            "--perimeter-margin",
+            type=float,
+            default=None,
+            help=(
+                "Tolerance in mm for the --all-perimeter test "
+                "(default: 2.0). Set higher to include footprints "
+                "set further inboard."
+            ),
+        )
+        _lock_fp.add_argument(
+            "-o",
+            "--output",
+            dest="output",
+            help="Output file path (default: overwrite input PCB)",
+        )
+        _lock_fp.add_argument(
+            "--format",
+            choices=["text", "json"],
+            default="text",
+            help="Output format for results",
+        )
+        _lock_fp.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Preview changes without modifying the PCB file",
+        )
+
     # pcb add-zone
     pcb_add_zone = pcb_subparsers.add_parser(
         "add-zone",

--- a/src/kicad_tools/cli/pcb_lock_footprints.py
+++ b/src/kicad_tools/cli/pcb_lock_footprints.py
@@ -1,0 +1,274 @@
+"""Lock or unlock footprints in a PCB by reference designator.
+
+Sets KiCad's ``(locked yes)`` attribute on footprints so the anchor-weight
+recipe (``kct optimize-placement --anchor-weight 1.0 --allow-infeasible``)
+can identify perimeter anchors.  Without a CLI knob, agents previously had
+to hand-edit the .kicad_pcb s-expression.
+
+Two selection modes are supported:
+
+* ``--refs J1,J2,...`` — explicit comma-separated reference designators.
+* ``--all-perimeter`` — every footprint whose bounding box touches the
+  Edge.Cuts board outline (within a small tolerance).
+
+Mirror command ``unlock-footprints`` clears the attribute using the same
+selection semantics.
+
+Locking an already-locked footprint (or unlocking an unlocked one) is a
+no-op; the command remains idempotent.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import sys
+from pathlib import Path
+
+# Default tolerance (mm) used when checking whether a footprint bbox
+# touches the board outline rectangle.  Real PCBs typically place
+# mounting holes and edge connectors 1-3 mm inboard for clearance, so a
+# generous default makes ``--all-perimeter`` useful for the anchor-weight
+# recipe.  Override with ``--perimeter-margin``.
+_PERIMETER_TOUCH_TOLERANCE_MM = 2.0
+
+
+def run_lock_footprints(
+    pcb_path: Path,
+    refs: list[str] | None = None,
+    all_perimeter: bool = False,
+    perimeter_margin: float | None = None,
+    unlock: bool = False,
+    dry_run: bool = False,
+    output_path: Path | None = None,
+    output_format: str = "text",
+) -> int:
+    """Lock (or unlock) footprints in a PCB file.
+
+    Args:
+        pcb_path: Path to .kicad_pcb file.
+        refs: Reference designators to lock/unlock (e.g. ["J1", "J2"]).
+        all_perimeter: If True, target all footprints whose bbox touches
+            the board edge.  Mutually exclusive with ``refs``.
+        perimeter_margin: Tolerance in mm for the "touches the board
+            edge" test.  Defaults to ``_PERIMETER_TOUCH_TOLERANCE_MM``
+            when None.  Only meaningful with ``all_perimeter=True``.
+        unlock: If True, clear the locked flag instead of setting it.
+        dry_run: Preview changes without writing.
+        output_path: Alternative output path for the modified PCB.
+        output_format: "text" or "json".
+
+    Returns:
+        Exit code (0 success, 1 error).
+    """
+    from kicad_tools.schema.pcb import PCB
+
+    op = "unlock" if unlock else "lock"
+
+    if not refs and not all_perimeter:
+        _print_error(
+            "Either --refs or --all-perimeter is required",
+            output_format,
+        )
+        return 1
+
+    if refs and all_perimeter:
+        _print_error(
+            "--refs and --all-perimeter are mutually exclusive",
+            output_format,
+        )
+        return 1
+
+    try:
+        pcb = PCB.load(pcb_path)
+    except Exception as e:
+        _print_error(f"Failed to load PCB: {e}", output_format)
+        return 1
+
+    # Resolve target reference list
+    target_refs: list[str]
+    if all_perimeter:
+        tol = (
+            perimeter_margin
+            if perimeter_margin is not None
+            else _PERIMETER_TOUCH_TOLERANCE_MM
+        )
+        target_refs = _find_perimeter_footprints(pcb, tolerance_mm=tol)
+        if not target_refs:
+            _print_error(
+                "No footprints found touching the board edge "
+                "(is there an Edge.Cuts outline?)",
+                output_format,
+            )
+            return 1
+    else:
+        assert refs is not None
+        target_refs = list(refs)
+
+    # Validate all references exist before any modification
+    missing: list[str] = []
+    for ref in target_refs:
+        if pcb.get_footprint(ref) is None:
+            missing.append(ref)
+    if missing:
+        _print_error(
+            f"Footprint(s) not found in PCB: {', '.join(missing)}",
+            output_format,
+        )
+        return 1
+
+    changes: list[dict] = []
+    new_state = not unlock  # True if locking, False if unlocking
+    for ref in target_refs:
+        fp = pcb.get_footprint(ref)
+        assert fp is not None  # validated above
+        old_state = bool(getattr(fp, "locked", False))
+        changes.append({
+            "reference": ref,
+            "footprint": fp.name,
+            "was_locked": old_state,
+            "now_locked": new_state,
+            "changed": old_state != new_state,
+        })
+
+    n_changed = sum(1 for c in changes if c["changed"])
+
+    result = {
+        "pcb": str(pcb_path),
+        "operation": op,
+        "dry_run": dry_run,
+        "selection": "all-perimeter" if all_perimeter else "refs",
+        "targets": target_refs,
+        "changes": changes,
+        "n_changed": n_changed,
+        "written": False,
+    }
+
+    if not dry_run and n_changed > 0:
+        for ref in target_refs:
+            fp = pcb.get_footprint(ref)
+            assert fp is not None
+            # Idempotent: only assign when actually changing state.  This
+            # avoids invoking __setattr__ rebuild work on no-ops.
+            if bool(getattr(fp, "locked", False)) != new_state:
+                fp.locked = new_state
+
+        save_path = output_path or pcb_path
+        result["output"] = str(save_path)
+        try:
+            pcb.save(save_path)
+        except Exception as e:
+            _print_error(f"Failed to save PCB: {e}", output_format)
+            return 1
+        result["written"] = True
+
+    if output_format == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        label = (
+            f"PCB {'Unlock' if unlock else 'Lock'} Footprints"
+            f"{' (dry run)' if dry_run else ''}"
+        )
+        print(label)
+        print(f"  PCB: {pcb_path}")
+        print(f"  Selection: {result['selection']}")
+        print(f"  Targets: {len(target_refs)} footprint(s)")
+        print()
+        for c in changes:
+            mark = "*" if c["changed"] else " "
+            print(
+                f"  {mark} {c['reference']} ({c['footprint']}): "
+                f"locked {c['was_locked']} -> {c['now_locked']}"
+            )
+        print()
+        if dry_run:
+            print(f"  Would change {n_changed} footprint(s)")
+        elif n_changed == 0:
+            print("  No changes needed (already in desired state)")
+        else:
+            print(f"  Changed {n_changed} footprint(s)")
+            print(f"  Saved to: {result.get('output', pcb_path)}")
+
+    return 0
+
+
+def _find_perimeter_footprints(
+    pcb,
+    tolerance_mm: float = _PERIMETER_TOUCH_TOLERANCE_MM,
+) -> list[str]:
+    """Return refs of footprints whose bbox touches the board outline.
+
+    Uses the axis-aligned bounding box of the Edge.Cuts outline.  A
+    footprint is considered to touch the perimeter when its own pad-derived
+    bbox is within ``tolerance_mm`` of any edge of the board bbox.
+    """
+    outline = pcb.get_board_outline()
+    if not outline:
+        return []
+
+    xs = [p[0] for p in outline]
+    ys = [p[1] for p in outline]
+    bmin_x, bmax_x = min(xs), max(xs)
+    bmin_y, bmax_y = min(ys), max(ys)
+
+    tol = tolerance_mm
+    perimeter_refs: list[str] = []
+
+    for fp in pcb.footprints:
+        bbox = _footprint_bbox(fp)
+        if bbox is None:
+            continue
+        fmin_x, fmin_y, fmax_x, fmax_y = bbox
+        touches = (
+            (fmin_x <= bmin_x + tol)
+            or (fmax_x >= bmax_x - tol)
+            or (fmin_y <= bmin_y + tol)
+            or (fmax_y >= bmax_y - tol)
+        )
+        if touches:
+            perimeter_refs.append(fp.reference)
+
+    return perimeter_refs
+
+
+def _footprint_bbox(fp) -> tuple[float, float, float, float] | None:
+    """Compute (min_x, min_y, max_x, max_y) bbox for a footprint.
+
+    Pads carry footprint-local coordinates; this rotates them by the
+    footprint rotation and offsets by the footprint position to land in
+    board-relative coordinates that match ``get_board_outline()``.
+    Returns None if the footprint has no pads.
+    """
+    if not fp.pads:
+        return None
+
+    cos_a = math.cos(math.radians(fp.rotation))
+    sin_a = math.sin(math.radians(fp.rotation))
+
+    min_x = float("inf")
+    min_y = float("inf")
+    max_x = float("-inf")
+    max_y = float("-inf")
+
+    for pad in fp.pads:
+        lx, ly = pad.position
+        rx = lx * cos_a - ly * sin_a
+        ry = lx * sin_a + ly * cos_a
+        ax = fp.position[0] + rx
+        ay = fp.position[1] + ry
+        hw = pad.size[0] / 2
+        hh = pad.size[1] / 2
+        min_x = min(min_x, ax - hw)
+        min_y = min(min_y, ay - hh)
+        max_x = max(max_x, ax + hw)
+        max_y = max(max_y, ay + hh)
+
+    return (min_x, min_y, max_x, max_y)
+
+
+def _print_error(message: str, output_format: str) -> None:
+    """Print an error in the appropriate format."""
+    if output_format == "json":
+        print(json.dumps({"error": message}, indent=2))
+    else:
+        print(f"Error: {message}", file=sys.stderr)

--- a/tests/test_pcb_lock_footprints.py
+++ b/tests/test_pcb_lock_footprints.py
@@ -1,0 +1,360 @@
+"""Tests for pcb lock-footprints / unlock-footprints commands.
+
+Covers acceptance criteria for issue #2977:
+1. ``--refs J1,J2`` sets ``(locked yes)`` on the selected footprints.
+2. ``unlock-footprints --refs J1,J2`` clears the locks.
+3. ``--all-perimeter`` locks footprints whose bbox touches the board edge.
+4. Idempotent: locking an already-locked footprint is a no-op.
+5. Round-tripping through ``PCB.load`` / ``.save`` preserves the flag.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+# Minimal PCB with an Edge.Cuts outline (10mm x 10mm), two
+# perimeter-edge footprints (J1 at corner, J2 inboard), and a central
+# footprint (U1) that should NOT be perimeter.
+MINIMAL_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (gr_line (start 0 0) (end 10 0) (layer "Edge.Cuts") (width 0.05))
+  (gr_line (start 10 0) (end 10 10) (layer "Edge.Cuts") (width 0.05))
+  (gr_line (start 10 10) (end 0 10) (layer "Edge.Cuts") (width 0.05))
+  (gr_line (start 0 10) (end 0 0) (layer "Edge.Cuts") (width 0.05))
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "Connector_JST:JST_XH_B2B"
+    (layer "F.Cu")
+    (uuid "fp-j1")
+    (at 0.5 5)
+    (property "Reference" "J1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "Conn_01x02" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd rect (at 0 -1.25) (size 1 1) (layers "F.Cu") (net 1 "GND"))
+    (pad "2" smd rect (at 0 1.25) (size 1 1) (layers "F.Cu") (net 0 ""))
+  )
+  (footprint "Connector_JST:JST_XH_B3B"
+    (layer "F.Cu")
+    (uuid "fp-j2")
+    (at 5 0.5)
+    (property "Reference" "J2" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "Conn_01x03" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd rect (at -1.25 0) (size 1 1) (layers "F.Cu") (net 1 "GND"))
+    (pad "2" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 0 ""))
+    (pad "3" smd rect (at 1.25 0) (size 1 1) (layers "F.Cu") (net 0 ""))
+  )
+  (footprint "Package_DIP:DIP-8"
+    (layer "F.Cu")
+    (uuid "fp-u1")
+    (at 5 5)
+    (property "Reference" "U1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "DIP8" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd rect (at -1 -1) (size 1 1) (layers "F.Cu") (net 0 ""))
+    (pad "2" smd rect (at 1 1) (size 1 1) (layers "F.Cu") (net 0 ""))
+  )
+)
+"""
+
+
+def _write_pcb(tmp_path: Path) -> Path:
+    pcb = tmp_path / "test.kicad_pcb"
+    pcb.write_text(MINIMAL_PCB)
+    return pcb
+
+
+class TestRunLockFootprints:
+    """Tests for run_lock_footprints function."""
+
+    def test_locks_refs(self, tmp_path):
+        """--refs J1,J2 sets locked=True on both."""
+        from kicad_tools.cli.pcb_lock_footprints import run_lock_footprints
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = _write_pcb(tmp_path)
+        rc = run_lock_footprints(pcb, refs=["J1", "J2"])
+        assert rc == 0
+
+        board = PCB.load(pcb)
+        assert board.get_footprint("J1").locked is True
+        assert board.get_footprint("J2").locked is True
+        # U1 was not touched
+        assert board.get_footprint("U1").locked is False
+
+    def test_unlock_refs(self, tmp_path):
+        """unlock=True clears locked attribute on selected refs."""
+        from kicad_tools.cli.pcb_lock_footprints import run_lock_footprints
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = _write_pcb(tmp_path)
+        # First lock them
+        assert run_lock_footprints(pcb, refs=["J1", "J2"]) == 0
+        board = PCB.load(pcb)
+        assert board.get_footprint("J1").locked is True
+        assert board.get_footprint("J2").locked is True
+
+        # Then unlock
+        rc = run_lock_footprints(pcb, refs=["J1", "J2"], unlock=True)
+        assert rc == 0
+
+        board = PCB.load(pcb)
+        assert board.get_footprint("J1").locked is False
+        assert board.get_footprint("J2").locked is False
+
+    def test_idempotent_lock(self, tmp_path):
+        """Locking an already-locked footprint is a no-op (rc=0)."""
+        from kicad_tools.cli.pcb_lock_footprints import run_lock_footprints
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = _write_pcb(tmp_path)
+        assert run_lock_footprints(pcb, refs=["J1"]) == 0
+        # Second lock — still rc=0, still locked
+        assert run_lock_footprints(pcb, refs=["J1"]) == 0
+
+        board = PCB.load(pcb)
+        assert board.get_footprint("J1").locked is True
+
+    def test_idempotent_unlock_when_unlocked(self, tmp_path):
+        """Unlocking an unlocked footprint is a no-op (rc=0)."""
+        from kicad_tools.cli.pcb_lock_footprints import run_lock_footprints
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = _write_pcb(tmp_path)
+        rc = run_lock_footprints(pcb, refs=["J1"], unlock=True)
+        assert rc == 0
+
+        board = PCB.load(pcb)
+        assert board.get_footprint("J1").locked is False
+
+    def test_all_perimeter(self, tmp_path):
+        """--all-perimeter selects footprints touching the board edge."""
+        from kicad_tools.cli.pcb_lock_footprints import run_lock_footprints
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = _write_pcb(tmp_path)
+        rc = run_lock_footprints(pcb, all_perimeter=True)
+        assert rc == 0
+
+        board = PCB.load(pcb)
+        # J1 (at x=0.5, hits left edge) and J2 (at y=0.5, hits top edge)
+        # both have bboxes within 2mm of the board edge.
+        assert board.get_footprint("J1").locked is True
+        assert board.get_footprint("J2").locked is True
+        # U1 is at the center (5,5) → bbox well inside the board.
+        assert board.get_footprint("U1").locked is False
+
+    def test_all_perimeter_with_custom_margin(self, tmp_path):
+        """Wider margin can pull in central footprints; narrow excludes."""
+        from kicad_tools.cli.pcb_lock_footprints import run_lock_footprints
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = _write_pcb(tmp_path)
+        # 0.1mm tolerance — only footprints whose bbox literally touches
+        # the edge.  J1 bbox: x in [-0.5, 0.5] → touches x=0; J2 bbox
+        # y in [-0.5, 0.5] → touches y=0.
+        rc = run_lock_footprints(
+            pcb, all_perimeter=True, perimeter_margin=0.1
+        )
+        assert rc == 0
+        board = PCB.load(pcb)
+        assert board.get_footprint("J1").locked is True
+        assert board.get_footprint("J2").locked is True
+        assert board.get_footprint("U1").locked is False
+
+    def test_missing_ref_returns_error(self, tmp_path):
+        """Unknown ref produces rc=1 and no PCB modification."""
+        from kicad_tools.cli.pcb_lock_footprints import run_lock_footprints
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = _write_pcb(tmp_path)
+        rc = run_lock_footprints(pcb, refs=["J1", "DOES_NOT_EXIST"])
+        assert rc == 1
+
+        # Nothing was saved
+        board = PCB.load(pcb)
+        assert board.get_footprint("J1").locked is False
+
+    def test_missing_args_returns_error(self, tmp_path):
+        """Neither refs nor all_perimeter → rc=1."""
+        from kicad_tools.cli.pcb_lock_footprints import run_lock_footprints
+
+        pcb = _write_pcb(tmp_path)
+        rc = run_lock_footprints(pcb)
+        assert rc == 1
+
+    def test_mutually_exclusive_args_returns_error(self, tmp_path):
+        """--refs and --all-perimeter together → rc=1."""
+        from kicad_tools.cli.pcb_lock_footprints import run_lock_footprints
+
+        pcb = _write_pcb(tmp_path)
+        rc = run_lock_footprints(pcb, refs=["J1"], all_perimeter=True)
+        assert rc == 1
+
+    def test_dry_run_does_not_write(self, tmp_path):
+        """--dry-run reports changes but does not save."""
+        from kicad_tools.cli.pcb_lock_footprints import run_lock_footprints
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = _write_pcb(tmp_path)
+        original = pcb.read_text()
+        rc = run_lock_footprints(pcb, refs=["J1"], dry_run=True)
+        assert rc == 0
+        assert pcb.read_text() == original
+
+        board = PCB.load(pcb)
+        assert board.get_footprint("J1").locked is False
+
+    def test_output_path(self, tmp_path):
+        """-o writes to alternative path, leaves input untouched."""
+        from kicad_tools.cli.pcb_lock_footprints import run_lock_footprints
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = _write_pcb(tmp_path)
+        original = pcb.read_text()
+        out = tmp_path / "locked.kicad_pcb"
+        rc = run_lock_footprints(pcb, refs=["J1"], output_path=out)
+        assert rc == 0
+        assert out.exists()
+        assert pcb.read_text() == original
+
+        board = PCB.load(out)
+        assert board.get_footprint("J1").locked is True
+
+    def test_json_output(self, tmp_path, capsys):
+        """--format json emits a parseable JSON report."""
+        from kicad_tools.cli.pcb_lock_footprints import run_lock_footprints
+
+        pcb = _write_pcb(tmp_path)
+        rc = run_lock_footprints(pcb, refs=["J1"], output_format="json")
+        assert rc == 0
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["operation"] == "lock"
+        assert data["n_changed"] == 1
+        assert data["written"] is True
+        assert any(c["reference"] == "J1" and c["now_locked"] for c in data["changes"])
+
+    def test_load_save_roundtrip_preserves_lock(self, tmp_path):
+        """PCB.load -> .save preserves the locked flag set by this command."""
+        from kicad_tools.cli.pcb_lock_footprints import run_lock_footprints
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = _write_pcb(tmp_path)
+        assert run_lock_footprints(pcb, refs=["J1"]) == 0
+
+        # Round-trip once more
+        board = PCB.load(pcb)
+        out = tmp_path / "rt.kicad_pcb"
+        board.save(out)
+
+        board2 = PCB.load(out)
+        assert board2.get_footprint("J1").locked is True
+        assert board2.get_footprint("J2").locked is False
+
+
+class TestCliEntryPoint:
+    """Tests exercising the kct pcb lock-footprints CLI dispatch."""
+
+    def test_cli_lock_via_parser(self, tmp_path):
+        """End-to-end: parser -> dispatcher -> run_lock_footprints."""
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+        from kicad_tools.cli.parser import create_parser
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = _write_pcb(tmp_path)
+        parser = create_parser()
+        args = parser.parse_args([
+            "pcb", "lock-footprints", str(pcb), "--refs", "J1,J2"
+        ])
+        rc = run_pcb_command(args)
+        assert rc == 0
+
+        board = PCB.load(pcb)
+        assert board.get_footprint("J1").locked is True
+        assert board.get_footprint("J2").locked is True
+
+    def test_cli_unlock_via_parser(self, tmp_path):
+        """End-to-end unlock via parser."""
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+        from kicad_tools.cli.parser import create_parser
+        from kicad_tools.cli.pcb_lock_footprints import run_lock_footprints
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = _write_pcb(tmp_path)
+        # Pre-lock J1
+        assert run_lock_footprints(pcb, refs=["J1"]) == 0
+
+        parser = create_parser()
+        args = parser.parse_args([
+            "pcb", "unlock-footprints", str(pcb), "--refs", "J1"
+        ])
+        rc = run_pcb_command(args)
+        assert rc == 0
+
+        board = PCB.load(pcb)
+        assert board.get_footprint("J1").locked is False
+
+    def test_cli_refs_with_whitespace(self, tmp_path):
+        """--refs splits on commas and trims whitespace."""
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+        from kicad_tools.cli.parser import create_parser
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = _write_pcb(tmp_path)
+        parser = create_parser()
+        args = parser.parse_args([
+            "pcb", "lock-footprints", str(pcb), "--refs", " J1 , J2 "
+        ])
+        rc = run_pcb_command(args)
+        assert rc == 0
+
+        board = PCB.load(pcb)
+        assert board.get_footprint("J1").locked is True
+        assert board.get_footprint("J2").locked is True
+
+
+class TestSExpRoundtrip:
+    """Verify the (locked) attribute survives KiCad s-expression round-trip."""
+
+    def test_locked_attribute_in_sexp(self, tmp_path):
+        """After lock, the .kicad_pcb file contains 'locked' inside (attr ...)."""
+        from kicad_tools.cli.pcb_lock_footprints import run_lock_footprints
+
+        pcb = _write_pcb(tmp_path)
+        assert run_lock_footprints(pcb, refs=["J1"]) == 0
+
+        text = pcb.read_text()
+        # KiCad emits (attr "locked") or (attr smd locked).  Match either.
+        # The simple assertion is: somewhere in the file, an (attr ...)
+        # block now contains the literal `locked` token.
+        assert "locked" in text
+        # Specifically inside an (attr ...) block — sanity check we are
+        # not picking up some unrelated string.
+        # Find J1 footprint block and confirm.
+        # (Naive but sufficient for the fixture.)
+        j1_start = text.find('"fp-j1"')
+        assert j1_start >= 0
+        # Search forward until the matching close-paren of J1's footprint.
+        depth = 0
+        i = text.rfind("(footprint", 0, j1_start)
+        assert i >= 0
+        block_start = i
+        depth = 0
+        for j in range(block_start, len(text)):
+            if text[j] == "(":
+                depth += 1
+            elif text[j] == ")":
+                depth -= 1
+                if depth == 0:
+                    block_end = j
+                    break
+        else:
+            block_end = len(text)
+        block = text[block_start:block_end]
+        assert "locked" in block
+        assert "(attr" in block


### PR DESCRIPTION
## Summary

- Adds ``kct pcb lock-footprints`` and ``kct pcb unlock-footprints`` CLI commands to set/clear KiCad's ``(locked)`` footprint attribute.
- Removes the last hand-edit step from the anchor-weight recipe (lock perimeter footprints + ``kct optimize-placement --anchor-weight 1.0 --allow-infeasible``), which is documented in project memory and was previously inaccessible to builder agents.
- Two selection modes: ``--refs J1,J2,...`` for explicit refs and ``--all-perimeter`` for every footprint whose pad bbox is within ``--perimeter-margin`` (default 2 mm) of the Edge.Cuts outline.

## Design notes

- Re-uses the existing ``Footprint.locked`` field already wired through ``PCB.load`` / ``.save`` (see ``schema/pcb.py`` ``_rebuild_attr_node`` and the ``locked`` token in ``_ATTR_SYNCED_FIELDS``).  No schema changes; CLI surface only.
- Idempotent: locking an already-locked footprint (or unlocking an unlocked one) returns 0 and skips the ``__setattr__`` rebuild — no file write either.
- Validates all refs before any modification, so partial failure is impossible.
- Mirrors the layout of existing ``pcb_move_footprint.py`` / ``pcb_remove_footprint.py`` modules and their parser registration / dispatcher pattern in ``commands/pcb.py``.

## Acceptance criteria (issue #2977)

1. ``kct pcb lock-footprints --refs J1,J2 boards/05-bldc-motor-controller/output/bldc_controller.kicad_pcb`` sets ``(locked yes)`` on J1 and J2 — verified by ``test_locks_refs``, plus manual run against board 05.
2. ``kct pcb unlock-footprints --refs J1,J2 boards/05-bldc-motor-controller/output/bldc_controller.kicad_pcb`` clears the locks — verified by ``test_unlock_refs``.
3. ``--all-perimeter`` flag locks all footprints whose bounding box touches the board edge — verified by ``test_all_perimeter`` + manual run on board 05 (selects MH1-MH4 at default margin).
4. New unit tests for both commands — 17 tests in ``tests/test_pcb_lock_footprints.py`` covering both modules and CLI dispatch.
5. Idempotent — verified by ``test_idempotent_lock`` and ``test_idempotent_unlock_when_unlocked``.
6. Boards 00-07 fleet parity — no board source files modified; CLI is opt-in.

## Files

- ``src/kicad_tools/cli/pcb_lock_footprints.py`` (new) — ``run_lock_footprints`` entry point + perimeter helpers.
- ``src/kicad_tools/cli/parser.py`` — register ``lock-footprints`` and ``unlock-footprints`` subparsers under ``pcb``.
- ``src/kicad_tools/cli/commands/pcb.py`` — dispatch ``args.pcb_command`` to ``_run_lock_footprints_command``.
- ``tests/test_pcb_lock_footprints.py`` (new) — 17 unit tests.

## Test plan

- [x] ``uv run pytest tests/test_pcb_lock_footprints.py -x`` — 17 passed
- [x] ``uv run pytest tests/test_pcb_move_footprint.py tests/test_pcb_remove_footprint.py`` — 28 passed (related commands)
- [x] ``uv run ruff check`` on all touched files — clean
- [x] Manual: ``kct pcb lock-footprints /tmp/bldc_test.kicad_pcb --refs J1,J2`` sets locked; reload round-trip confirms; ``unlock-footprints`` clears it.
- [x] Manual: ``--all-perimeter`` on board 05 detects MH1-MH4 (default 2 mm margin) and J1-J4 + neighbours at ``--perimeter-margin 6``.
- [x] Board 05 source PCB unchanged on disk (``grep -c locked`` still 0).