### PR TITLE
fix(schematic): GateDriveResistorArray emits stub wires for label connectivity (closes #2968)

### DIFF
--- a/src/kicad_tools/schematic/blocks/motor.py
+++ b/src/kicad_tools/schematic/blocks/motor.py
@@ -1243,18 +1243,33 @@ class GateDriveResistorArray(CircuitBlock):
             self.ports[in_port_name] = in_pos
             self.ports[out_port_name] = out_pos
 
-            # Optional net labels — emit a label at each pin and add an
-            # alias port keyed by the net suffix (the trailing token after
-            # the last '_').
+            # Optional net labels — emit short horizontal stub wires from
+            # each pin so the label has a wire to anchor to. KiCad's
+            # label-only connectivity requires the label coordinate to lie
+            # on a wire endpoint or segment; without these stubs, labels
+            # in columns beyond the first one float (see issue #2968).
+            # The stub length matches one schematic grid (2.54 mm).
+            #
+            # Pattern mirrors ``create_3phase_inverter`` (~line 350):
+            #     sch.add_wire(pos, (label_x, pos[1]))
+            #     sch.add_label(name, label_x, pos[1], rotation=0)
+            #
+            # Alias ports are keyed by the net suffix (the trailing token
+            # after the last ``_``).
+            STUB = 2.54
             if input_nets is not None:
                 in_net = input_nets[i]
-                sch.add_label(in_net, in_pos[0], in_pos[1], rotation=0)
+                in_label_x = in_pos[0] - STUB
+                sch.add_wire(in_pos, (in_label_x, in_pos[1]))
+                sch.add_label(in_net, in_label_x, in_pos[1], rotation=0)
                 alias = f"IN_{_net_suffix(in_net)}"
                 self.ports[alias] = in_pos
 
             if output_nets is not None:
                 out_net = output_nets[i]
-                sch.add_label(out_net, out_pos[0], out_pos[1], rotation=0)
+                out_label_x = out_pos[0] + STUB
+                sch.add_wire(out_pos, (out_label_x, out_pos[1]))
+                sch.add_label(out_net, out_label_x, out_pos[1], rotation=0)
                 alias = f"OUT_{_net_suffix(out_net)}"
                 self.ports[alias] = out_pos
 

--- a/tests/test_blocks_gate_drive_resistor_array.py
+++ b/tests/test_blocks_gate_drive_resistor_array.py
@@ -114,7 +114,11 @@ class TestGateDriveResistorArray:
             assert in_pos[0] < out_pos[0]
 
     def test_input_output_net_aliases(self, mock_schematic):
-        """When ``input_nets``/``output_nets`` provided, aliases and labels appear."""
+        """When ``input_nets``/``output_nets`` provided, aliases and labels appear.
+
+        Labels are offset by one schematic grid (2.54 mm) from the pin so
+        a stub wire can anchor them — see #2968.
+        """
         block = create_gate_drive_resistor_array(
             mock_schematic,
             x=100,
@@ -136,16 +140,55 @@ class TestGateDriveResistorArray:
         assert "GATE_DRV_AH" in labels_called
         assert "GATE_AH" in labels_called
 
-        # And each label sits at the corresponding pin position.
+        # Labels sit on the stub-wire endpoint, offset 2.54mm from the pin
+        # (left of pin 1, right of pin 2). The ports themselves remain at
+        # the pin positions so external blocks connect to the pin, not the
+        # label stub.
+        STUB = 2.54
         in_pos = block.ports["IN_1"]
         out_pos = block.ports["OUT_1"]
         for call in mock_schematic.add_label.call_args_list:
             args, _kw = call
             net_name, lx, ly = args[0], args[1], args[2]
             if net_name == "GATE_DRV_AH":
-                assert (lx, ly) == in_pos
+                assert (lx, ly) == (in_pos[0] - STUB, in_pos[1])
             elif net_name == "GATE_AH":
-                assert (lx, ly) == out_pos
+                assert (lx, ly) == (out_pos[0] + STUB, out_pos[1])
+
+    def test_labels_anchored_to_wire_endpoints(self, mock_schematic):
+        """Regression test for #2968.
+
+        Every ``add_label(text, x, y)`` call must have at least one matching
+        ``add_wire(a, b)`` call whose endpoints include ``(x, y)`` — otherwise
+        KiCad's label-only connectivity treats the label as floating.
+        """
+        create_gate_drive_resistor_array(
+            mock_schematic,
+            x=100,
+            y=100,
+            channels=3,
+            input_nets=["GATE_DRV_AH", "GATE_DRV_BH", "GATE_DRV_CH"],
+            output_nets=["GATE_AH", "GATE_BH", "GATE_CH"],
+        )
+
+        # Collect every wire endpoint (both ends of every add_wire call).
+        wire_endpoints: set[tuple[float, float]] = set()
+        for call in mock_schematic.add_wire.call_args_list:
+            args, _kw = call
+            a, b = args[0], args[1]
+            wire_endpoints.add((a[0], a[1]))
+            wire_endpoints.add((b[0], b[1]))
+
+        # Every label coordinate must be a wire endpoint.
+        label_calls = mock_schematic.add_label.call_args_list
+        assert len(label_calls) == 6, "expected 3 input + 3 output labels"
+        for call in label_calls:
+            args, _kw = call
+            net_name, lx, ly = args[0], args[1], args[2]
+            assert (lx, ly) in wire_endpoints, (
+                f"label {net_name!r} at ({lx}, {ly}) has no matching wire endpoint; "
+                f"KiCad will treat it as floating (regression of #2968)"
+            )
 
     def test_net_list_length_validation(self, mock_schematic):
         """Mismatched ``input_nets``/``output_nets`` length raises ValueError."""


### PR DESCRIPTION
## Summary

`GateDriveResistorArray.__init__` previously called `sch.add_label` at each resistor pin but emitted zero wires. KiCad's label-only connectivity requires the label coordinate to sit on a wire endpoint or segment; without a wire stub, labels in columns beyond the first one float — generating four `UserWarning: Label '...' is not on any wire` messages on board 05 (`GATE_DRV_BH`, `GATE_BH`, `GATE_DRV_CH`, `GATE_CH`) and a cascade of ERC `isolated_pin_label` / `pin_not_connected` violations.

This PR emits short horizontal stub wires (one schematic-grid = 2.54 mm) from each pin outward — pin 1 to the left, pin 2 to the right — and places the label on the stub endpoint. The pattern mirrors `create_3phase_inverter` at `motor.py:350`. External ports (`IN_i`, `OUT_i`, `IN_<suffix>`, `OUT_<suffix>`) remain at the pin positions so existing callers continue to wire to the pin, not the stub.

## Changes

- `src/kicad_tools/schematic/blocks/motor.py` — add stub wire before each label in `GateDriveResistorArray.__init__`.
- `tests/test_blocks_gate_drive_resistor_array.py`
  - Update `test_input_output_net_aliases` to assert labels sit at `pin ± STUB`, not at the pin itself (the previous assertion was the curator-flagged bad invariant).
  - New `test_labels_anchored_to_wire_endpoints` regression test: every `add_label(text, x, y)` must have a matching `add_wire` endpoint at `(x, y)`.

## Verification

- `tests/test_blocks_gate_drive_resistor_array.py`: 14/14 pass (was 13).
- Board 05 generation no longer emits the four named `UserWarning: Label '...' is not on any wire` messages for `GATE_DRV_BH`, `GATE_BH`, `GATE_DRV_CH`, `GATE_CH` (AC #2).
- All six gate-drive labels (`GATE_DRV_AH/BH/CH`, `GATE_AH/BH/CH`) are now properly anchored to stub wires in the generated schematic (verified by inspecting `.kicad_sch` content at the R20/R21/R22 columns).

## AC reconciliation

AC #1 (ERC errors drop from 100 to ≤4) is **not fully met by this PR alone**. The curator's analysis attributed all 100 errors to the gate-drive resistor floating-label root cause, predicting they would self-resolve once `R20/R21/R22` were electrically continuous. Investigation during implementation showed this is not the case:

- The DRV8308 (U3) symbol's gate-output and PWM-input pins are not labeled or wired anywhere in the schematic — `GateDriverBlock.__init__` only places the IC and bypass caps and never emits labels at the driver-IC pins. KiCad reports `U3 pins 1–41` as `pin_not_connected` regardless of the resistor-stub fix.
- The MOSFET gates `Q1/Q3/Q5.G` (and `Q2/Q4/Q6.G`) are not labeled or wired anywhere in the schematic either — `HalfBridge` / `ThreePhaseInverter` expose `GATE_HS`/`GATE_LS` ports at pin positions but never call `sch.add_label` for them, and `boards/05-bldc-motor-controller/design.py` does not label them either.
- Net `GATE_AH` therefore exists only at `R20.pin2`'s stub-wire endpoint (and now `GATE_BH` at `R21.pin2`, `GATE_CH` at `R22.pin2`) — a single-pin net, which ERC reports as `isolated_pin_label`. The same applies to `GATE_DRV_*H` at the driver-side stub endpoints.

The post-fix ERC count is still ~100. The targeted root cause (floating gate-drive labels + curator-named `UserWarning` messages) is fully resolved, but full electrical continuity through to Q1/Q3/Q5.G and U3.{33,36,39} additionally requires labeling the driver-IC outputs (`GateDriverBlock`) and the MOSFET gates (`HalfBridge` / `ThreePhaseInverter`). Per the issue's HARD LIMIT ("DO NOT modify `boards/05-bldc-motor-controller/design.py`") and "small, surgical fix" scope hint, that broader work is deferred to a follow-up issue.

ACs #2, #3, #4 are fully met. AC #5 (boards 00-04, 06, 07 fleet-status parity) is preserved: the change is gated on `input_nets is not None` / `output_nets is not None` and only affects schematics that pass those parameters (board 05 is the sole consumer in-tree).

## Test plan

- [x] `tests/test_blocks_gate_drive_resistor_array.py` — 14/14 pass.
- [x] `tests/test_schematic_blocks.py` + related — all pass.
- [x] Board 05 generation succeeds and the four named `UserWarning` messages are gone.
- [x] Inspect generated `.kicad_sch`: labels at `(307.34, 115.57)`, `(312.42, 123.19)`, `(317.5, 115.57)`, `(322.58, 123.19)`, `(327.66, 115.57)`, `(332.74, 123.19)`; matching stub wires present at each label coordinate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)