### PR TITLE
fix(route): strip stale route blocks before insert to dedupe vias (closes #2976)

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -348,12 +348,121 @@ def _emit_single_pad_net_warning(
     )
 
 
+def _strip_route_blocks(pcb_content: str) -> tuple[str, int, int]:
+    """Strip top-level ``(segment ...)`` and ``(via ...)`` blocks from PCB content.
+
+    Issue #2976: When ``_stage_input_for_auto_pour`` aliases ``pcb_path`` to
+    ``output_path`` (so the user's input file isn't mutated by ``auto_pour``),
+    subsequent ``_write_routed_pcb`` calls re-read the **previous write's**
+    output rather than the original input.  Each write then *appends* the
+    current route s-expression on top of stale segments/vias from the prior
+    write, doubling (or worse) the via population in the output file.
+
+    The duplicated vias trigger ``dimension_drill_clearance`` errors --
+    -0.300mm clearance == two coincident drills on the same net -- because
+    they are literally the same physical via emitted twice with different
+    UUIDs.
+
+    The fix is to remove any top-level routed-element blocks before
+    inserting fresh ones: the in-memory router state is the source of
+    truth, and the new ``route_sexp`` already contains every segment and
+    via that should appear in the output.  Footprints, pads, zones, and
+    other PCB structure are preserved because we only strip blocks whose
+    first token is ``segment`` or ``via``.
+
+    Args:
+        pcb_content: Original PCB file content.
+
+    Returns:
+        Tuple of ``(stripped_content, segments_removed, vias_removed)``.
+        Counts are returned so callers can log a diagnostic when a stale
+        write is observed.
+    """
+    # Walk the content counting depth, identifying top-level forms whose
+    # first token is "segment" or "via" and excising them.  Footprints
+    # contain their own (pad ...) blocks, never (segment ...) or top-level
+    # (via ...), so stripping at depth=1 is safe.
+    out: list[str] = []
+    i = 0
+    n = len(pcb_content)
+    depth = 0
+    in_string = False
+    prev_char = ""
+    segments_removed = 0
+    vias_removed = 0
+    while i < n:
+        ch = pcb_content[i]
+        if ch == '"' and prev_char != "\\":
+            in_string = not in_string
+            out.append(ch)
+            prev_char = ch
+            i += 1
+            continue
+        if not in_string and ch == "(":
+            # Peek at the token following the paren.
+            j = i + 1
+            while j < n and pcb_content[j].isspace():
+                j += 1
+            token_start = j
+            while j < n and not pcb_content[j].isspace() and pcb_content[j] != "(" and pcb_content[j] != ")":
+                j += 1
+            token = pcb_content[token_start:j]
+            if depth == 1 and token in ("segment", "via"):
+                # Skip the entire form: find matching ")".
+                form_depth = 1
+                k = j
+                form_in_string = False
+                form_prev = ""
+                while k < n and form_depth > 0:
+                    c = pcb_content[k]
+                    if c == '"' and form_prev != "\\":
+                        form_in_string = not form_in_string
+                    elif not form_in_string:
+                        if c == "(":
+                            form_depth += 1
+                        elif c == ")":
+                            form_depth -= 1
+                    form_prev = c
+                    k += 1
+                if token == "segment":
+                    segments_removed += 1
+                else:
+                    vias_removed += 1
+                # Skip whitespace that was preceding this form (trailing
+                # newline/tab from the previous emission) to keep the
+                # resulting file tidy.
+                while out and out[-1] in (" ", "\t"):
+                    out.pop()
+                # Also drop a single trailing newline so we collapse the
+                # blank line the form previously occupied.
+                if out and out[-1] == "\n":
+                    out.pop()
+                i = k
+                prev_char = ")"
+                continue
+            depth += 1
+        elif not in_string and ch == ")":
+            depth -= 1
+        out.append(ch)
+        prev_char = ch
+        i += 1
+    return "".join(out), segments_removed, vias_removed
+
+
 def _insert_sexp_before_closing(pcb_content: str, sexp_fragments: str) -> str:
     """Insert S-expression fragments before the final closing parenthesis of a PCB file.
 
     This correctly removes only the last closing parenthesis from the PCB content
     and re-adds it after the inserted fragments. Unlike ``rstrip(")")``, which
     strips ALL trailing ``)``, this function preserves the S-expression structure.
+
+    Issue #2976: Before inserting fresh route s-expressions, any pre-existing
+    ``(segment ...)`` and ``(via ...)`` blocks at the top level are stripped.
+    This prevents accumulation when ``pcb_path == output_path`` (which happens
+    after ``_stage_input_for_auto_pour``): each ``_write_routed_pcb`` call
+    used to *append* the current route state on top of the previous write,
+    producing duplicate same-net vias that the DRC flagged with negative
+    drill-edge clearance.
 
     Args:
         pcb_content: Original PCB file content.
@@ -362,6 +471,7 @@ def _insert_sexp_before_closing(pcb_content: str, sexp_fragments: str) -> str:
     Returns:
         Modified PCB content with fragments inserted before the final ``)``.
     """
+    pcb_content, _stripped_segs, _stripped_vias = _strip_route_blocks(pcb_content)
     content = pcb_content.rstrip()
     if content.endswith(")"):
         content = content[:-1].rstrip()

--- a/tests/router/test_strip_route_blocks.py
+++ b/tests/router/test_strip_route_blocks.py
@@ -1,0 +1,263 @@
+"""Tests for Issue #2976: ``_strip_route_blocks`` prevents same-net via overlap.
+
+Background
+----------
+
+Running ``kct route`` on board 05 with the proven 2-layer recipe produced
+14 ``dimension_drill_clearance`` errors reading "-0.300mm < minimum
+0.127mm" between two vias on the **same** logical net (e.g. HALL_A vs
+HALL_A).  Negative clearance == two same-net drills literally on top of
+each other -- a manufacturing fault that breaks the drill file.
+
+Root cause: ``_stage_input_for_auto_pour`` aliases ``pcb_path`` to
+``output_path`` so ``auto_pour`` doesn't mutate the user's input file.
+After that aliasing, every subsequent ``_write_routed_pcb`` call re-reads
+the previous write's output instead of the original input, and the new
+route s-expression is *appended* on top of stale segments and vias from
+the prior write.  Two checkpoint writes + one final write yields three
+copies of every via in the output PCB.  The duplicates carry distinct
+UUIDs but identical (net, x, y, drill) tuples, so the DRC validator sees
+overlapping drills on the same net and flags ``dimension_drill_clearance``.
+
+Fix: ``_insert_sexp_before_closing`` now calls ``_strip_route_blocks``
+before inserting the new route s-expression.  The strip removes any
+top-level ``(segment ...)`` and ``(via ...)`` forms from the PCB content
+so the inserted s-expression is the only source of routed elements.
+
+These tests verify:
+
+1. ``_strip_route_blocks`` removes top-level ``(segment ...)`` and
+   ``(via ...)`` blocks and leaves footprints, zones, and other
+   structure intact.
+2. ``_insert_sexp_before_closing`` round-trips: applying it twice with
+   the same route s-expression yields the same number of vias as
+   applying it once.  This is the property that fails without the
+   strip step.
+3. A foreign-net via pair at the same coordinate is *not* deduplicated
+   by the strip itself (the strip operates on text, not on net IDs);
+   it only removes pre-existing routed elements that the new s-expression
+   is about to replace.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.cli.route_cmd import (
+    _insert_sexp_before_closing,
+    _strip_route_blocks,
+)
+
+# A minimal-but-valid KiCad PCB content fragment.  Includes a footprint
+# (which contains nested (pad ...) forms -- those must NOT be stripped),
+# a (zone ...) block (must not be stripped), and a (segment ...) and
+# (via ...) block (must be stripped).
+PCB_HEADER = """(kicad_pcb
+\t(version 20240108)
+\t(generator "test")
+\t(general
+\t\t(thickness 1.6)
+\t)
+\t(footprint "Capacitor_SMD:C_0805"
+\t\t(layer "F.Cu")
+\t\t(at 10.0 10.0)
+\t\t(pad "1" smd roundrect
+\t\t\t(at -0.95 0.0)
+\t\t\t(size 1.0 1.25)
+\t\t\t(layers "F.Cu")
+\t\t)
+\t\t(pad "2" smd roundrect
+\t\t\t(at 0.95 0.0)
+\t\t\t(size 1.0 1.25)
+\t\t\t(layers "F.Cu")
+\t\t)
+\t)
+\t(zone
+\t\t(net 1)
+\t\t(net_name "GND")
+\t\t(layer "F.Cu")
+\t\t(polygon
+\t\t\t(pts (xy 0 0) (xy 100 0) (xy 100 100) (xy 0 100))
+\t\t)
+\t)
+\t(segment
+\t\t(start 10.0 10.0)
+\t\t(end 20.0 10.0)
+\t\t(width 0.2)
+\t\t(layer "F.Cu")
+\t\t(uuid "aaa")
+\t\t(net 2)
+\t)
+\t(via
+\t\t(at 15.0 15.0)
+\t\t(size 0.6)
+\t\t(drill 0.3)
+\t\t(layers "F.Cu" "B.Cu")
+\t\t(uuid "bbb")
+\t\t(net 2)
+\t)
+)
+"""
+
+
+# Route s-expression that would be inserted into the PCB.  Same coords
+# as the stale via in PCB_HEADER -- this is the realistic case: the
+# router re-emits the same via on a re-route, and without the strip
+# both copies survive in the output.
+NEW_ROUTE_SEXP = """\t(segment
+\t\t(start 10.0 10.0)
+\t\t(end 20.0 10.0)
+\t\t(width 0.2)
+\t\t(layer "F.Cu")
+\t\t(uuid "ccc")
+\t\t(net 2)
+\t)
+\t(via
+\t\t(at 15.0 15.0)
+\t\t(size 0.6)
+\t\t(drill 0.3)
+\t\t(layers "F.Cu" "B.Cu")
+\t\t(uuid "ddd")
+\t\t(net 2)
+\t)"""
+
+
+class TestStripRouteBlocks:
+    """Verify the strip helper removes only top-level segments/vias."""
+
+    def test_strips_top_level_segment_and_via(self):
+        stripped, segs, vias = _strip_route_blocks(PCB_HEADER)
+        # The original had one segment and one via at the top level.
+        assert segs == 1
+        assert vias == 1
+        assert "(segment" not in stripped
+        # Footprint pads contain "(at" but never "(via"; double-check
+        # we haven't accidentally stripped pads.
+        assert "(via" not in stripped
+        # Footprint and zone must survive.
+        assert "(footprint" in stripped
+        assert "(zone" in stripped
+        # Pads inside the footprint must survive too.
+        assert '(pad "1"' in stripped
+        assert '(pad "2"' in stripped
+
+    def test_leaves_clean_pcb_untouched(self):
+        clean = """(kicad_pcb (version 20240108) (footprint "X" (at 0 0) (pad "1" smd (at 0 0))))"""
+        stripped, segs, vias = _strip_route_blocks(clean)
+        assert segs == 0
+        assert vias == 0
+        # The clean PCB is unchanged.
+        assert stripped == clean
+
+    def test_handles_quoted_parens(self):
+        # Quoted strings containing "(" or ")" must not affect depth.
+        content = '''(kicad_pcb
+\t(layer "Some (weird) Layer")
+\t(segment (start 0 0) (end 1 1) (width 0.1) (net 1))
+)'''
+        stripped, segs, vias = _strip_route_blocks(content)
+        assert segs == 1
+        assert vias == 0
+        assert "Some (weird) Layer" in stripped
+
+
+class TestInsertSexpBeforeClosing:
+    """Verify the insert + strip composition is idempotent."""
+
+    def test_no_via_accumulation_on_repeat_writes(self):
+        """Reproduces issue #2976: writing twice must not duplicate vias.
+
+        Before the fix, the second insert would re-read the first write
+        (after ``_stage_input_for_auto_pour`` aliased pcb_path == output_path)
+        and append NEW_ROUTE_SEXP on top of the existing route content,
+        yielding 2 vias for what should be 1.
+        """
+        # First write: clean PCB header (with stale 1 via + 1 seg).
+        first_write = _insert_sexp_before_closing(PCB_HEADER, NEW_ROUTE_SEXP)
+        first_via_count = first_write.count("(via\n")
+        first_seg_count = first_write.count("(segment\n")
+        assert first_via_count == 1, f"Expected 1 via in first write, got {first_via_count}"
+        assert first_seg_count == 1, f"Expected 1 segment in first write, got {first_seg_count}"
+
+        # Second write: read first write's output, insert same sexp.
+        # This is the alias-pcb_path case from #2976.
+        second_write = _insert_sexp_before_closing(first_write, NEW_ROUTE_SEXP)
+        second_via_count = second_write.count("(via\n")
+        second_seg_count = second_write.count("(segment\n")
+        assert second_via_count == 1, (
+            f"Issue #2976 regression: second write produced {second_via_count} vias "
+            "instead of 1 -- the stale via from the first write was not stripped"
+        )
+        assert second_seg_count == 1, (
+            f"Issue #2976 regression: second write produced {second_seg_count} segments"
+        )
+
+    def test_third_write_still_one_via(self):
+        """Three writes must still produce one via (the same coord)."""
+        c1 = _insert_sexp_before_closing(PCB_HEADER, NEW_ROUTE_SEXP)
+        c2 = _insert_sexp_before_closing(c1, NEW_ROUTE_SEXP)
+        c3 = _insert_sexp_before_closing(c2, NEW_ROUTE_SEXP)
+        assert c3.count("(via\n") == 1
+        assert c3.count("(segment\n") == 1
+
+    def test_footprints_and_zones_preserved_after_insert(self):
+        out = _insert_sexp_before_closing(PCB_HEADER, NEW_ROUTE_SEXP)
+        assert "(footprint" in out
+        assert "(zone" in out
+        assert '(pad "1"' in out
+        assert '(pad "2"' in out
+
+    def test_new_sexp_present_after_insert(self):
+        out = _insert_sexp_before_closing(PCB_HEADER, NEW_ROUTE_SEXP)
+        # The new UUIDs must be present; the stale UUIDs must be gone.
+        assert "ccc" in out, "New segment UUID missing"
+        assert "ddd" in out, "New via UUID missing"
+        assert "aaa" not in out, "Stale segment UUID survived"
+        assert "bbb" not in out, "Stale via UUID survived"
+
+    def test_empty_route_sexp_strips_stale_content(self):
+        """Writing with an empty route_sexp still strips stale routes."""
+        out = _insert_sexp_before_closing(PCB_HEADER, "")
+        assert "(via" not in out
+        assert "(segment" not in out
+        # But footprints and zones survive.
+        assert "(footprint" in out
+        assert "(zone" in out
+
+
+class TestForeignNetViasNotMerged:
+    """Confirm the strip does not erase the new sexp's own vias.
+
+    This test protects against an over-aggressive strip that would remove
+    everything matching ``(via`` -- if the strip ran on the inserted sexp
+    instead of the existing content, two foreign-net vias inserted at
+    nearby coordinates would silently lose one.  The strip only operates
+    on ``pcb_content`` BEFORE insertion, so both inserted vias must
+    survive.
+    """
+
+    def test_two_foreign_net_vias_both_present(self):
+        # No stale content.
+        clean_pcb = """(kicad_pcb
+\t(version 20240108)
+\t(footprint "X" (at 0 0) (pad "1" smd (at 0 0)))
+)"""
+        two_via_sexp = """\t(via
+\t\t(at 10.0 10.0)
+\t\t(size 0.6)
+\t\t(drill 0.3)
+\t\t(layers "F.Cu" "B.Cu")
+\t\t(uuid "eee")
+\t\t(net 1)
+\t)
+\t(via
+\t\t(at 10.1 10.0)
+\t\t(size 0.6)
+\t\t(drill 0.3)
+\t\t(layers "F.Cu" "B.Cu")
+\t\t(uuid "fff")
+\t\t(net 2)
+\t)"""
+        out = _insert_sexp_before_closing(clean_pcb, two_via_sexp)
+        # Both foreign-net vias must survive the insert.
+        assert out.count("(via\n") == 2
+        assert "eee" in out
+        assert "fff" in out


### PR DESCRIPTION
## Summary

Eliminates the 14 same-net ``dimension_drill_clearance`` errors observed
on board 05's 2L route by stripping stale ``(segment ...)`` and
``(via ...)`` blocks from the PCB content before inserting fresh route
s-expressions.

Closes #2976.

## Root cause

The negative-clearance violations were not a router algorithm bug.
``_stage_input_for_auto_pour`` aliases ``pcb_path`` to ``output_path``
so ``auto_pour`` can write zones in place without mutating the user's
input file.  After the aliasing, every ``_write_routed_pcb`` call
re-reads the previous write's output instead of the original input, and
the new route s-expression is *appended* on top of stale segments and
vias from the prior write.  Two checkpoint writes plus one final write
produce up to three copies of every via in the output PCB, each with a
distinct UUID but identical (net, x, y, drill).  The validator correctly
flags these as drill-overlap on the same net.

Validated empirically by patching ``_write_routed_pcb`` to log the
``pcb_path.read_text()`` size and via count: the second invocation read
710 763 bytes with 45 vias from the supposed "input" file (originally
61 685 bytes with 0 vias), confirming the prior checkpoint write was
being re-ingested.

## Fix

``_insert_sexp_before_closing`` now calls a new ``_strip_route_blocks``
helper before performing the insert.  The strip walks the PCB s-expression
character-by-character tracking depth and quoted strings, and removes any
top-level form whose first token is ``segment`` or ``via``.  Footprints
(which contain ``(pad ...)`` blocks at deeper nesting), zones, and other
PCB structure are preserved untouched.

## Test plan

- [x] ``kct route boards/05-bldc-motor-controller/output/bldc_controller.kicad_pcb --no-auto-layers --layers 2 --manufacturer jlcpcb --differential-pairs --seed 42``: 0 ``dimension_drill_clearance`` errors (was 14+); 57 vias in output, 0 duplicates.
- [x] Boards 01 (voltage divider) and 02 (charlieplex) full route: 0 duplicates, 0 ``dimension_drill_clearance`` errors.
- [x] ``tests/router/test_strip_route_blocks.py`` -- 9 new unit tests covering:
  - Strip removes only top-level segments/vias (not footprint pads or zones).
  - Quoted parens in layer names are handled correctly.
  - Two and three consecutive inserts of the same route_sexp yield one via (idempotency).
  - Foreign-net vias in the new sexp are both preserved (strip doesn't touch insert payload).
  - ``_strip_route_blocks`` on a clean PCB is a no-op.
- [x] ``tests/test_route_checkpoint.py`` -- all 17 tests still pass (no checkpoint-write regression).
- [x] ``tests/router/`` + route-cmd test suite -- 450 pass, only the 2 pre-existing ``TestRouteWriteSitesPattern`` failures remain (both fail on ``main`` independently of this change; they assert outdated source-level counts).
- [x] ``ruff check`` clean on the new file and the edit.

## Scope

- 1 new helper ``_strip_route_blocks`` (~85 LOC).
- 5-line change inside ``_insert_sexp_before_closing`` to call the helper and update the docstring.
- 1 new test file (~226 LOC) under ``tests/router/``.

Total production code change: ~110 LOC, within the 150 LOC cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)