### PR TITLE
fix(schematic): GateDriverBlock + HalfBridge + ThreePhaseInverter emit stub wires for label connectivity (closes #2980)

### DIFF
--- a/boards/05-bldc-motor-controller/design.py
+++ b/boards/05-bldc-motor-controller/design.py
@@ -438,6 +438,15 @@ def create_bldc_controller(output_dir: Path) -> Path:
     # we instantiate BootstrapCapacitorArray explicitly below to demonstrate
     # the new factory's composability).
     # Note: C10-C11 are used by CrystalOscillator, so start at C15 for bypass
+    # The DRV8308 KiCad symbol used by ``GateDriverBlock`` (3-phase mode)
+    # exposes gate outputs under symbol names ``UHSG``/``ULSG``/``VHSG``/
+    # ``VLSG``/``WHSG``/``WLSG`` (pin numbers 32/34/35/37/38/40 on the
+    # symbol -- distinct from the DRV8301 footprint pin numbers in
+    # ``DRV8301_PINS`` below).  Passing ``pin_nets`` makes the block emit
+    # a short stub wire + label at each pin so KiCad's label-on-wire ERC
+    # check is satisfied (see #2980).  HS outputs feed the slew-rate
+    # resistor array (``GATE_DRV_*``); LS outputs are direct-driven to the
+    # MOSFET gates (``GATE_*L``).
     gate_driver = GateDriverBlock(
         sch,
         x=X_GATE_DRV,
@@ -448,6 +457,16 @@ def create_bldc_controller(output_dir: Path) -> Path:
         bootstrap_caps=None,  # bootstrap caps created externally below
         bypass_caps=["100nF", "10uF"],
         cap_ref_start=15,  # C15-C16 for bypass (C12-C14 reserved for bootstrap)
+        pin_nets={
+            # High-side gate outputs (route through R20-R22 -> MOSFET gates).
+            "UHSG": "GATE_DRV_AH",
+            "VHSG": "GATE_DRV_BH",
+            "WHSG": "GATE_DRV_CH",
+            # Low-side gate outputs (direct-driven to MOSFET gates).
+            "ULSG": "GATE_AL",
+            "VLSG": "GATE_BL",
+            "WLSG": "GATE_CL",
+        },
     )
     gate_driver.connect_to_rails(vcc_rail_y=RAIL_5V, gnd_rail_y=RAIL_GND)
 
@@ -490,7 +509,12 @@ def create_bldc_controller(output_dir: Path) -> Path:
     print("\n7. Adding power stage (6 MOSFETs)...")
 
     # Create 3-phase inverter using ThreePhaseInverter block
-    # This creates 6 MOSFETs (Q1-Q6) in three half-bridge configuration
+    # This creates 6 MOSFETs (Q1-Q6) in three half-bridge configuration.
+    # ``gate_*_nets`` make each HalfBridge emit a stub wire + label at
+    # its Q.G pin so KiCad's label-on-wire ERC check sees a real
+    # connection -- this closes the second half of issue #2980 (without
+    # the kwargs, Q1-Q6 gate pins floated and ERC reported six
+    # ``pin_not_connected`` errors).
     inverter = ThreePhaseInverter(
         sch,
         x=X_PHASE_A,
@@ -501,6 +525,8 @@ def create_bldc_controller(output_dir: Path) -> Path:
         phase_labels=["A", "B", "C"],
         phase_spacing=75,
         hs_ls_spacing=40,
+        gate_hs_nets=["GATE_AH", "GATE_BH", "GATE_CH"],
+        gate_ls_nets=["GATE_AL", "GATE_BL", "GATE_CL"],
     )
     inverter.connect_to_rails(vin_rail_y=RAIL_VMOTOR, gnd_rail_y=RAIL_GND)
     print("   Three-phase inverter: Q1-Q6 (ThreePhaseInverter block)")

--- a/src/kicad_tools/schematic/blocks/motor.py
+++ b/src/kicad_tools/schematic/blocks/motor.py
@@ -78,6 +78,8 @@ class HalfBridge(CircuitBlock):
         cap_ref_start: int | None = None,
         diode_ref_start: int | None = None,
         hs_ls_spacing: float = 40,
+        gate_hs_net: str | None = None,
+        gate_ls_net: str | None = None,
     ):
         """
         Create a half-bridge circuit.
@@ -97,6 +99,15 @@ class HalfBridge(CircuitBlock):
             cap_ref_start: Starting reference for capacitor (defaults to ref_start)
             diode_ref_start: Starting reference for diode (defaults to ref_start)
             hs_ls_spacing: Vertical spacing between HS and LS MOSFETs
+            gate_hs_net: Optional net name to label at the high-side gate pin.
+                When provided, a short stub wire is drawn from the gate pin
+                outward (to the left, away from the MOSFET body) and the
+                label is placed on the stub endpoint so ERC's label-on-wire
+                check is satisfied (see issue #2980). When ``None`` (the
+                default), no label/stub is emitted and behavior is
+                unchanged.
+            gate_ls_net: Optional net name to label at the low-side gate
+                pin. Same semantics as ``gate_hs_net``.
         """
         super().__init__(sch, x, y)
         self.has_bootstrap = bootstrap_cap is not None
@@ -213,6 +224,24 @@ class HalfBridge(CircuitBlock):
         self._vin_pos = hs_drain
         self._gnd_pos = ls_source
 
+        # Optional gate-net labels.  KiCad's label-only connectivity requires
+        # the label coordinate to lie on a wire endpoint or segment; without
+        # a stub, labels at the bare gate pin float and trigger ERC's
+        # ``isolated_pin_label`` cascade (see issue #2980).  We draw a
+        # one-grid (2.54 mm) stub from each gate pin to the left (gates on
+        # ``Device:Q_NMOS`` exit the symbol to the left) and place the
+        # label on the stub endpoint.  External callers still wire to the
+        # ``GATE_HS``/``GATE_LS`` ports, which remain at the pin positions.
+        STUB = 2.54
+        if gate_hs_net is not None:
+            label_x = hs_gate[0] - STUB
+            sch.add_wire(hs_gate, (label_x, hs_gate[1]), warn_on_collision=False)
+            sch.add_label(gate_hs_net, label_x, hs_gate[1], rotation=0)
+        if gate_ls_net is not None:
+            label_x = ls_gate[0] - STUB
+            sch.add_wire(ls_gate, (label_x, ls_gate[1]), warn_on_collision=False)
+            sch.add_label(gate_ls_net, label_x, ls_gate[1], rotation=0)
+
     def connect_to_rails(
         self,
         vin_rail_y: float,
@@ -298,6 +327,8 @@ class ThreePhaseInverter(CircuitBlock):
         phase_labels: list[str] | None = None,
         phase_spacing: float = 75,
         hs_ls_spacing: float = 40,
+        gate_hs_nets: list[str] | None = None,
+        gate_ls_nets: list[str] | None = None,
     ):
         """
         Create a three-phase inverter.
@@ -314,11 +345,35 @@ class ThreePhaseInverter(CircuitBlock):
             phase_labels: Labels for phases (default: ["A", "B", "C"])
             phase_spacing: Horizontal spacing between phases
             hs_ls_spacing: Vertical spacing between HS and LS MOSFETs
+            gate_hs_nets: Optional list of per-phase high-side gate net
+                names (length must equal ``len(phase_labels)``).  When
+                provided, each phase's :class:`HalfBridge` emits a stub
+                wire + label at its HS gate pin so ERC sees a real
+                connection (see issue #2980).  When ``None`` (the
+                default), no labels are emitted.
+            gate_ls_nets: Optional list of per-phase low-side gate net
+                names.  Same semantics as ``gate_hs_nets``.
+
+        Raises:
+            ValueError: If ``gate_hs_nets`` or ``gate_ls_nets`` is provided
+                and its length does not match the phase count.
         """
         super().__init__(sch, x, y)
 
         if phase_labels is None:
             phase_labels = ["A", "B", "C"]
+
+        num_phases = len(phase_labels)
+        if gate_hs_nets is not None and len(gate_hs_nets) != num_phases:
+            raise ValueError(
+                f"gate_hs_nets length ({len(gate_hs_nets)}) must match "
+                f"phase_labels length ({num_phases})"
+            )
+        if gate_ls_nets is not None and len(gate_ls_nets) != num_phases:
+            raise ValueError(
+                f"gate_ls_nets length ({len(gate_ls_nets)}) must match "
+                f"phase_labels length ({num_phases})"
+            )
 
         self.phase_labels = phase_labels
         self.half_bridges: list[HalfBridge] = []
@@ -340,6 +395,8 @@ class ThreePhaseInverter(CircuitBlock):
                 cap_ref_start=i + 1 if bootstrap_cap else None,
                 diode_ref_start=i + 1 if bootstrap_cap else None,
                 hs_ls_spacing=hs_ls_spacing,
+                gate_hs_net=gate_hs_nets[i] if gate_hs_nets is not None else None,
+                gate_ls_net=gate_ls_nets[i] if gate_ls_nets is not None else None,
             )
             self.half_bridges.append(hb)
 
@@ -841,6 +898,7 @@ class GateDriverBlock(CircuitBlock):
         bootstrap_caps: str | None = "100nF",
         bypass_caps: list[str] | None = None,
         cap_ref_start: int = 1,
+        pin_nets: dict[str, str] | None = None,
     ):
         """
         Create a gate driver block.
@@ -858,6 +916,18 @@ class GateDriverBlock(CircuitBlock):
                 is composed and exposed via ``self._bootstrap_block``.
             bypass_caps: Bypass capacitor values (default: ["10uF", "100nF"])
             cap_ref_start: Starting reference number for capacitors
+            pin_nets: Optional mapping of driver-IC pin name or number to
+                net label.  For each entry, a one-grid (2.54 mm) stub wire
+                is drawn from the pin away from the symbol center and the
+                net label is placed on the stub endpoint so KiCad's
+                label-on-wire ERC check is satisfied (see issue #2980).
+                When ``None`` (the default), no labels are emitted and
+                behavior is unchanged.  The mapping keys must be valid
+                pin identifiers for the resolved ``driver_symbol``
+                (e.g. ``"UHSG"`` or ``"32"`` for ``Driver_Motor:DRV8308``).
+                For every entry, an alias port is also added under the
+                net name so callers can retrieve real pin coordinates via
+                ``block.port("<net>")``.
         """
         super().__init__(sch, x, y)
         self.driver_type = driver_type
@@ -935,6 +1005,39 @@ class GateDriverBlock(CircuitBlock):
                 # Avoid clobbering driver ports if names ever collide
                 if name not in self.ports:
                     self.ports[name] = pos
+
+        # Optional pin-net labels.  KiCad's label-only connectivity requires
+        # the label coordinate to lie on a wire endpoint or segment; without
+        # a stub, labels placed at the bare pin float and trigger ERC's
+        # ``isolated_pin_label`` cascade.  For each ``pin_nets`` entry we
+        # resolve the real pin position via ``self.driver.pin_position``
+        # (supporting either pin names or pin numbers), draw a one-grid
+        # (2.54 mm) horizontal stub *away from the symbol center* (left
+        # for pins on the symbol's left edge, right otherwise), and place
+        # the label on the stub endpoint.  See issue #2980.
+        #
+        # For every labelled pin we also add an alias port keyed by the
+        # net name, exposing the pin's real coordinates so callers can
+        # wire to ``block.port("<net>")`` instead of relying on the
+        # historical placeholder port coordinates.
+        if pin_nets is not None:
+            STUB = 2.54
+            for pin_key, net_name in pin_nets.items():
+                pin_pos = self.driver.pin_position(pin_key)
+                # Stub away from the symbol center.  When the pin lies
+                # exactly on the center column (pin_pos[0] == x) we
+                # default to stubbing right.
+                if pin_pos[0] < x:
+                    label_x = pin_pos[0] - STUB
+                else:
+                    label_x = pin_pos[0] + STUB
+                sch.add_wire(pin_pos, (label_x, pin_pos[1]), warn_on_collision=False)
+                sch.add_label(net_name, label_x, pin_pos[1], rotation=0)
+                # Expose the pin's real coordinate under the net name so
+                # external wiring can reach it.  Do not overwrite an
+                # existing port by the same name (preserves back-compat).
+                if net_name not in self.ports:
+                    self.ports[net_name] = pin_pos
 
     def connect_to_rails(
         self,

--- a/tests/test_blocks_gate_driver_block.py
+++ b/tests/test_blocks_gate_driver_block.py
@@ -1,0 +1,235 @@
+"""Tests for ``GateDriverBlock`` pin-net label/stub-wire emission.
+
+These tests use a mocked ``Schematic`` to exercise the new optional
+``pin_nets`` dict kwarg without producing real KiCad output.  Shape
+mirrors ``tests/test_blocks_gate_drive_resistor_array.py``; the
+load-bearing assertion for issue #2980 is
+``test_labels_anchored_to_wire_endpoints``.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from kicad_tools.schematic.blocks import GateDriverBlock
+
+
+@pytest.fixture
+def mock_schematic():
+    """Mock Schematic returning mock symbols with deterministic pin positions.
+
+    The driver mock advertises a small subset of DRV8308-shaped pins:
+    HSG / LSG outputs (left of symbol body) and PWM inputs (right of body).
+    The exact positions don't matter for these tests as long as some pins
+    are left-of-center (stub extends left) and others are right-of-center
+    (stub extends right).
+    """
+    sch = Mock()
+
+    # Driver pins are arranged so we can test both stub directions:
+    #   - Left-edge pins (x - 10): UHSG, ULSG, VHSG, VLSG, WHSG, WLSG
+    #   - Right-edge pins (x + 10): INHA, INLA, INHB, INLB, INHC, INLC
+    #   - Center / power: VCC, GND
+    driver_pin_map_template = {
+        "UHSG": (-10, -6),
+        "ULSG": (-10, -3),
+        "VHSG": (-10, 0),
+        "VLSG": (-10, 3),
+        "WHSG": (-10, 6),
+        "WLSG": (-10, 9),
+        "INHA": (10, -6),
+        "INLA": (10, -3),
+        "INHB": (10, 0),
+        "INLB": (10, 3),
+        "INHC": (10, 6),
+        "INLC": (10, 9),
+        "VCC": (0, -10),
+        "GND": (0, 10),
+        # Numeric pin alias for one entry to verify pin_position accepts numbers
+        "32": (-10, -6),  # same coord as UHSG
+        # Capacitor pins
+        "1": (-2, 0),
+        "2": (2, 0),
+    }
+
+    def create_mock_component(symbol, x, y, ref, *args, **kwargs):
+        comp = Mock()
+        comp.reference = ref
+        comp.symbol = symbol
+        comp.pin_position.side_effect = lambda name, _x=x, _y=y: (
+            (_x + driver_pin_map_template[name][0],
+             _y + driver_pin_map_template[name][1])
+            if name in driver_pin_map_template
+            else (_x, _y)
+        )
+        return comp
+
+    sch.add_symbol = Mock(side_effect=create_mock_component)
+    sch.add_wire = Mock()
+    sch.add_junction = Mock()
+    sch.add_label = Mock()
+    sch.wire_decoupling_cap = Mock()
+    return sch
+
+
+class TestGateDriverBlockPinNets:
+    """Tests for the new ``pin_nets`` kwarg on ``GateDriverBlock``."""
+
+    def test_default_emits_no_pin_labels(self, mock_schematic):
+        """Without ``pin_nets``, no pin-net labels are emitted (AC4)."""
+        GateDriverBlock(
+            mock_schematic, x=100, y=100,
+            bootstrap_caps=None,  # disable bootstrap to keep label count low
+        )
+        assert mock_schematic.add_label.call_count == 0
+
+    def test_pin_nets_left_edge_pin_stubs_left(self, mock_schematic):
+        """Pins to the left of the symbol center stub leftward."""
+        block = GateDriverBlock(
+            mock_schematic, x=100, y=100,
+            bootstrap_caps=None,
+            pin_nets={"UHSG": "GATE_DRV_AH"},
+        )
+
+        STUB = 2.54
+        # Pin is at (90, 94) in our mock (x - 10, y - 6).
+        # Stub should extend left to (90 - STUB, 94).
+        labels = mock_schematic.add_label.call_args_list
+        assert len(labels) == 1
+        net_name, lx, ly = labels[0].args[0], labels[0].args[1], labels[0].args[2]
+        assert net_name == "GATE_DRV_AH"
+        assert lx == 90 - STUB
+        assert ly == 94
+        # Alias port also exposed.
+        assert block.ports["GATE_DRV_AH"] == (90, 94)
+
+    def test_pin_nets_right_edge_pin_stubs_right(self, mock_schematic):
+        """Pins to the right of the symbol center stub rightward."""
+        GateDriverBlock(
+            mock_schematic, x=100, y=100,
+            bootstrap_caps=None,
+            pin_nets={"INHA": "PWM_AH"},
+        )
+
+        STUB = 2.54
+        # Pin is at (110, 94) — to the right of center x=100.
+        labels = mock_schematic.add_label.call_args_list
+        assert len(labels) == 1
+        net_name, lx, ly = labels[0].args[0], labels[0].args[1], labels[0].args[2]
+        assert net_name == "PWM_AH"
+        assert lx == 110 + STUB
+        assert ly == 94
+
+    def test_pin_nets_accepts_pin_numbers(self, mock_schematic):
+        """``pin_nets`` keys may be pin numbers, not just pin names."""
+        # Our mock advertises "32" as an alias for UHSG.
+        GateDriverBlock(
+            mock_schematic, x=100, y=100,
+            bootstrap_caps=None,
+            pin_nets={"32": "GATE_DRV_AH"},
+        )
+        labels = [call.args[0] for call in mock_schematic.add_label.call_args_list]
+        assert labels == ["GATE_DRV_AH"]
+
+    def test_pin_nets_multiple_entries(self, mock_schematic):
+        """Mapping with multiple entries emits one label per entry."""
+        pin_nets = {
+            "UHSG": "GATE_DRV_AH",
+            "VHSG": "GATE_DRV_BH",
+            "WHSG": "GATE_DRV_CH",
+            "ULSG": "GATE_AL",
+            "VLSG": "GATE_BL",
+            "WLSG": "GATE_CL",
+            "INHA": "PWM_AH",
+            "INLA": "PWM_AL",
+            "INHB": "PWM_BH",
+            "INLB": "PWM_BL",
+            "INHC": "PWM_CH",
+            "INLC": "PWM_CL",
+        }
+        GateDriverBlock(
+            mock_schematic, x=100, y=100,
+            bootstrap_caps=None,
+            pin_nets=pin_nets,
+        )
+
+        labels = sorted(call.args[0] for call in mock_schematic.add_label.call_args_list)
+        # 12 labels total, exactly the values from pin_nets.
+        assert sorted(pin_nets.values()) == labels
+
+    def test_alias_ports_added_for_each_pin_net(self, mock_schematic):
+        """Each ``pin_nets`` entry adds a port keyed by the net name."""
+        block = GateDriverBlock(
+            mock_schematic, x=100, y=100,
+            bootstrap_caps=None,
+            pin_nets={"UHSG": "GATE_DRV_AH", "INHA": "PWM_AH"},
+        )
+        assert "GATE_DRV_AH" in block.ports
+        assert "PWM_AH" in block.ports
+
+    def test_alias_port_does_not_clobber_existing(self, mock_schematic):
+        """A net name colliding with an existing port (e.g. ``GND``) keeps the old port."""
+        # The block already has a "GND" placeholder port at (x, y + 20).
+        original_gnd = (100, 120)
+        block = GateDriverBlock(
+            mock_schematic, x=100, y=100,
+            bootstrap_caps=None,
+            pin_nets={"GND": "GND"},  # try to overwrite
+        )
+        # Original placeholder still wins.
+        assert block.ports["GND"] == original_gnd
+
+    def test_labels_anchored_to_wire_endpoints(self, mock_schematic):
+        """Regression test for #2980.
+
+        Every emitted pin-net label must sit on a wire endpoint, otherwise
+        KiCad's label-only connectivity treats it as floating.  Mirror of
+        ``test_labels_anchored_to_wire_endpoints`` from
+        ``test_blocks_gate_drive_resistor_array.py``.
+        """
+        GateDriverBlock(
+            mock_schematic, x=100, y=100,
+            bootstrap_caps=None,
+            pin_nets={
+                "UHSG": "GATE_DRV_AH",
+                "VHSG": "GATE_DRV_BH",
+                "WHSG": "GATE_DRV_CH",
+                "ULSG": "GATE_AL",
+                "VLSG": "GATE_BL",
+                "WLSG": "GATE_CL",
+                "INHA": "PWM_AH",
+                "INLA": "PWM_AL",
+                "INHB": "PWM_BH",
+                "INLB": "PWM_BL",
+                "INHC": "PWM_CH",
+                "INLC": "PWM_CL",
+            },
+        )
+
+        wire_endpoints: set[tuple[float, float]] = set()
+        for call in mock_schematic.add_wire.call_args_list:
+            a, b = call.args[0], call.args[1]
+            wire_endpoints.add((a[0], a[1]))
+            wire_endpoints.add((b[0], b[1]))
+
+        label_calls = mock_schematic.add_label.call_args_list
+        assert len(label_calls) == 12, "expected one label per pin_nets entry"
+        for call in label_calls:
+            net_name, lx, ly = call.args[0], call.args[1], call.args[2]
+            assert (lx, ly) in wire_endpoints, (
+                f"label {net_name!r} at ({lx}, {ly}) has no matching wire endpoint; "
+                f"KiCad will treat it as floating (regression of #2980)"
+            )
+
+    def test_external_ports_unchanged_without_pin_nets(self, mock_schematic):
+        """Block ports unchanged when ``pin_nets`` is ``None`` (back-compat)."""
+        b1 = GateDriverBlock(
+            mock_schematic, x=100, y=100, bootstrap_caps=None,
+        )
+        b2 = GateDriverBlock(
+            mock_schematic, x=100, y=100, bootstrap_caps=None,
+            pin_nets={"UHSG": "GATE_DRV_AH"},
+        )
+        # Original placeholder ports survive in both blocks.
+        for key in ("VCC", "GND", "BOOT_A", "GATE_HS_A", "GATE_LS_A", "PWM_H_A"):
+            assert b1.ports[key] == b2.ports[key]

--- a/tests/test_blocks_half_bridge.py
+++ b/tests/test_blocks_half_bridge.py
@@ -1,0 +1,177 @@
+"""Tests for ``HalfBridge`` gate-net label/stub-wire emission.
+
+These tests use a mocked ``Schematic`` so they exercise the new optional
+``gate_hs_net`` / ``gate_ls_net`` kwargs without actually emitting KiCad
+schematic data.  Shape mirrors
+``tests/test_blocks_gate_drive_resistor_array.py`` (see PR #2979); the
+regression test ``test_labels_anchored_to_wire_endpoints`` is the
+load-bearing assertion for issue #2980.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from kicad_tools.schematic.blocks import HalfBridge
+
+
+@pytest.fixture
+def mock_schematic():
+    """Create a mock Schematic that returns mock symbols with deterministic pins.
+
+    MOSFET pins follow ``Device:Q_NMOS`` convention: ``G`` (gate) on the
+    left, ``D`` (drain) above, ``S`` (source) below.  Bootstrap diode /
+    cap pins follow ``Device:D`` / ``Device:C`` conventions.
+    """
+    sch = Mock()
+
+    def create_mock_component(symbol, x, y, ref, *args, **kwargs):
+        comp = Mock()
+        comp.reference = ref
+        comp.symbol = symbol
+        comp.pin_position.side_effect = lambda name, _x=x, _y=y: {
+            "D": (_x, _y - 10),
+            "G": (_x - 10, _y),
+            "S": (_x, _y + 10),
+            "A": (_x - 5, _y),
+            "K": (_x + 5, _y),
+            "1": (_x, _y - 5),
+            "2": (_x, _y + 5),
+        }.get(name, (_x, _y))
+        return comp
+
+    sch.add_symbol = Mock(side_effect=create_mock_component)
+    sch.add_wire = Mock()
+    sch.add_junction = Mock()
+    sch.add_label = Mock()
+    sch.wire_decoupling_cap = Mock()
+    return sch
+
+
+class TestHalfBridgeGateNets:
+    """Tests for the new ``gate_hs_net`` / ``gate_ls_net`` HalfBridge kwargs."""
+
+    def test_default_emits_no_gate_labels(self, mock_schematic):
+        """Without ``gate_*_net`` kwargs, HalfBridge emits zero gate labels.
+
+        Boards that don't opt in must see no behavioral change (AC4).
+        """
+        HalfBridge(mock_schematic, x=100, y=100)
+
+        # No labels emitted at all (HalfBridge itself never adds labels
+        # without the new kwargs).
+        assert mock_schematic.add_label.call_count == 0
+
+    def test_gate_hs_net_emits_label_and_stub(self, mock_schematic):
+        """``gate_hs_net`` triggers exactly one label + one stub wire."""
+        baseline_wires = 0  # we'll count delta below
+        hb = HalfBridge(
+            mock_schematic,
+            x=100,
+            y=100,
+            gate_hs_net="GATE_AH",
+        )
+
+        # Exactly one label for the HS gate.
+        labels = [call.args[0] for call in mock_schematic.add_label.call_args_list]
+        assert labels == ["GATE_AH"]
+
+        # The label sits at the stub endpoint (gate_x - STUB, gate_y).
+        STUB = 2.54
+        hs_gate = hb.ports["GATE_HS"]
+        label_call = mock_schematic.add_label.call_args_list[0]
+        net_name, lx, ly = label_call.args[0], label_call.args[1], label_call.args[2]
+        assert net_name == "GATE_AH"
+        assert (lx, ly) == (hs_gate[0] - STUB, hs_gate[1])
+        _ = baseline_wires  # suppress unused-var lint
+
+    def test_gate_ls_net_emits_label_and_stub(self, mock_schematic):
+        """``gate_ls_net`` triggers exactly one label + one stub wire."""
+        hb = HalfBridge(
+            mock_schematic,
+            x=100,
+            y=100,
+            gate_ls_net="GATE_AL",
+        )
+
+        labels = [call.args[0] for call in mock_schematic.add_label.call_args_list]
+        assert labels == ["GATE_AL"]
+
+        STUB = 2.54
+        ls_gate = hb.ports["GATE_LS"]
+        label_call = mock_schematic.add_label.call_args_list[0]
+        net_name, lx, ly = label_call.args[0], label_call.args[1], label_call.args[2]
+        assert net_name == "GATE_AL"
+        assert (lx, ly) == (ls_gate[0] - STUB, ls_gate[1])
+
+    def test_both_gate_nets_emit_two_labels(self, mock_schematic):
+        """When both HS and LS nets are set, two distinct labels are emitted."""
+        HalfBridge(
+            mock_schematic,
+            x=100,
+            y=100,
+            gate_hs_net="GATE_AH",
+            gate_ls_net="GATE_AL",
+        )
+        labels = sorted(call.args[0] for call in mock_schematic.add_label.call_args_list)
+        assert labels == ["GATE_AH", "GATE_AL"]
+
+    def test_external_ports_unchanged_when_labels_added(self, mock_schematic):
+        """The ``GATE_HS`` / ``GATE_LS`` ports still resolve to pin positions.
+
+        External callers wiring through the block's port API must see the
+        same pin coordinates regardless of whether the labels were emitted.
+        """
+        hb_with = HalfBridge(
+            mock_schematic, x=100, y=100,
+            gate_hs_net="GATE_AH", gate_ls_net="GATE_AL",
+        )
+        hb_without = HalfBridge(mock_schematic, x=100, y=100)
+
+        assert hb_with.ports["GATE_HS"] == hb_without.ports["GATE_HS"]
+        assert hb_with.ports["GATE_LS"] == hb_without.ports["GATE_LS"]
+
+    def test_labels_anchored_to_wire_endpoints(self, mock_schematic):
+        """Regression test for #2980.
+
+        Every emitted gate-net label must sit on a wire endpoint, otherwise
+        KiCad's label-only connectivity treats it as floating and ERC
+        cascades into ``isolated_pin_label`` / ``pin_not_connected``.
+        """
+        HalfBridge(
+            mock_schematic,
+            x=100,
+            y=100,
+            gate_hs_net="GATE_AH",
+            gate_ls_net="GATE_AL",
+        )
+
+        # Collect every wire endpoint.
+        wire_endpoints: set[tuple[float, float]] = set()
+        for call in mock_schematic.add_wire.call_args_list:
+            a, b = call.args[0], call.args[1]
+            wire_endpoints.add((a[0], a[1]))
+            wire_endpoints.add((b[0], b[1]))
+
+        # Every gate-net label coordinate must be a wire endpoint.
+        label_calls = mock_schematic.add_label.call_args_list
+        assert len(label_calls) == 2
+        for call in label_calls:
+            net_name, lx, ly = call.args[0], call.args[1], call.args[2]
+            assert (lx, ly) in wire_endpoints, (
+                f"label {net_name!r} at ({lx}, {ly}) has no matching wire endpoint; "
+                f"KiCad will treat it as floating (regression of #2980)"
+            )
+
+    def test_only_hs_set_only_ls_floating(self, mock_schematic):
+        """Setting only one side leaves the other free of labels.
+
+        Required to support designs where only one gate is direct-driven
+        and the other goes through a series resistor (board 05 pattern).
+        """
+        HalfBridge(
+            mock_schematic, x=100, y=100,
+            gate_hs_net="GATE_AH",  # gate_ls_net intentionally None
+        )
+        labels = [call.args[0] for call in mock_schematic.add_label.call_args_list]
+        assert labels == ["GATE_AH"]

--- a/tests/test_blocks_three_phase_inverter.py
+++ b/tests/test_blocks_three_phase_inverter.py
@@ -1,0 +1,182 @@
+"""Tests for ``ThreePhaseInverter`` gate-net label/stub-wire emission.
+
+These tests use a mocked ``Schematic`` to exercise the new optional
+``gate_hs_nets`` / ``gate_ls_nets`` list kwargs without producing real
+KiCad output.  Shape mirrors ``tests/test_blocks_gate_drive_resistor_array.py``
+and ``tests/test_blocks_half_bridge.py``; the load-bearing assertion for
+issue #2980 is ``test_labels_anchored_to_wire_endpoints``.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from kicad_tools.schematic.blocks import ThreePhaseInverter
+
+
+@pytest.fixture
+def mock_schematic():
+    """Mock Schematic returning mock symbols with deterministic pin positions.
+
+    MOSFET pins follow ``Device:Q_NMOS`` convention.
+    """
+    sch = Mock()
+
+    def create_mock_component(symbol, x, y, ref, *args, **kwargs):
+        comp = Mock()
+        comp.reference = ref
+        comp.symbol = symbol
+        comp.pin_position.side_effect = lambda name, _x=x, _y=y: {
+            "D": (_x, _y - 10),
+            "G": (_x - 10, _y),
+            "S": (_x, _y + 10),
+            "A": (_x - 5, _y),
+            "K": (_x + 5, _y),
+            "1": (_x, _y - 5),
+            "2": (_x, _y + 5),
+        }.get(name, (_x, _y))
+        return comp
+
+    sch.add_symbol = Mock(side_effect=create_mock_component)
+    sch.add_wire = Mock()
+    sch.add_junction = Mock()
+    sch.add_label = Mock()
+    sch.wire_decoupling_cap = Mock()
+    return sch
+
+
+class TestThreePhaseInverterGateNets:
+    """Tests for the new ``gate_hs_nets`` / ``gate_ls_nets`` kwargs."""
+
+    def test_default_emits_only_phase_labels(self, mock_schematic):
+        """Without gate-net kwargs, only the three ``PHASE_*`` labels appear.
+
+        Boards that don't opt in to the new feature must see unchanged
+        behavior (AC4).
+        """
+        ThreePhaseInverter(mock_schematic, x=100, y=100)
+
+        labels = sorted(
+            call.args[0] for call in mock_schematic.add_label.call_args_list
+        )
+        # Three phase-output labels (PHASE_A/B/C); zero gate-net labels.
+        assert labels == ["PHASE_A", "PHASE_B", "PHASE_C"]
+
+    def test_gate_hs_nets_emits_three_hs_labels(self, mock_schematic):
+        """``gate_hs_nets`` adds one label per phase at the HS gate stub."""
+        ThreePhaseInverter(
+            mock_schematic,
+            x=100,
+            y=100,
+            gate_hs_nets=["GATE_AH", "GATE_BH", "GATE_CH"],
+        )
+        labels = sorted(
+            call.args[0] for call in mock_schematic.add_label.call_args_list
+        )
+        assert "GATE_AH" in labels
+        assert "GATE_BH" in labels
+        assert "GATE_CH" in labels
+        # PHASE_* still emitted (the new feature is additive).
+        assert "PHASE_A" in labels
+        assert "PHASE_B" in labels
+        assert "PHASE_C" in labels
+
+    def test_gate_ls_nets_emits_three_ls_labels(self, mock_schematic):
+        """``gate_ls_nets`` adds one label per phase at the LS gate stub."""
+        ThreePhaseInverter(
+            mock_schematic,
+            x=100,
+            y=100,
+            gate_ls_nets=["GATE_AL", "GATE_BL", "GATE_CL"],
+        )
+        labels = sorted(
+            call.args[0] for call in mock_schematic.add_label.call_args_list
+        )
+        for ls in ("GATE_AL", "GATE_BL", "GATE_CL"):
+            assert ls in labels
+
+    def test_both_gate_lists_emit_six_gate_labels(self, mock_schematic):
+        """All six gate labels emitted when both kwargs provided."""
+        ThreePhaseInverter(
+            mock_schematic,
+            x=100,
+            y=100,
+            gate_hs_nets=["GATE_AH", "GATE_BH", "GATE_CH"],
+            gate_ls_nets=["GATE_AL", "GATE_BL", "GATE_CL"],
+        )
+        labels = sorted(
+            call.args[0] for call in mock_schematic.add_label.call_args_list
+        )
+        # 3 phase + 3 HS gate + 3 LS gate = 9 labels.
+        assert len(labels) == 9
+        for gate in ("GATE_AH", "GATE_BH", "GATE_CH", "GATE_AL", "GATE_BL", "GATE_CL"):
+            assert gate in labels
+
+    def test_length_mismatch_raises(self, mock_schematic):
+        """Lists shorter/longer than ``phase_labels`` raise ValueError."""
+        with pytest.raises(ValueError, match="gate_hs_nets length"):
+            ThreePhaseInverter(
+                mock_schematic,
+                x=100,
+                y=100,
+                gate_hs_nets=["GATE_AH", "GATE_BH"],  # 2 != 3
+            )
+        with pytest.raises(ValueError, match="gate_ls_nets length"):
+            ThreePhaseInverter(
+                mock_schematic,
+                x=100,
+                y=100,
+                gate_ls_nets=["A", "B", "C", "D"],  # 4 != 3
+            )
+
+    def test_custom_phase_labels_with_gate_nets(self, mock_schematic):
+        """Custom phase labels (e.g. U/V/W) compose with gate-net lists."""
+        ThreePhaseInverter(
+            mock_schematic,
+            x=100,
+            y=100,
+            phase_labels=["U", "V", "W"],
+            gate_hs_nets=["GATE_UH", "GATE_VH", "GATE_WH"],
+        )
+        labels = sorted(
+            call.args[0] for call in mock_schematic.add_label.call_args_list
+        )
+        for tag in ("PHASE_U", "PHASE_V", "PHASE_W", "GATE_UH", "GATE_VH", "GATE_WH"):
+            assert tag in labels
+
+    def test_labels_anchored_to_wire_endpoints(self, mock_schematic):
+        """Regression test for #2980.
+
+        Every emitted gate-net label must sit on a wire endpoint, otherwise
+        KiCad's label-only connectivity treats it as floating.
+        """
+        ThreePhaseInverter(
+            mock_schematic,
+            x=100,
+            y=100,
+            gate_hs_nets=["GATE_AH", "GATE_BH", "GATE_CH"],
+            gate_ls_nets=["GATE_AL", "GATE_BL", "GATE_CL"],
+        )
+
+        # Collect every wire endpoint.
+        wire_endpoints: set[tuple[float, float]] = set()
+        for call in mock_schematic.add_wire.call_args_list:
+            a, b = call.args[0], call.args[1]
+            wire_endpoints.add((a[0], a[1]))
+            wire_endpoints.add((b[0], b[1]))
+
+        # Every gate label must coincide with a wire endpoint.  PHASE_*
+        # labels were already wired prior to #2980 and aren't load-bearing
+        # here, but we still check them for symmetry.
+        gate_nets = {
+            "GATE_AH", "GATE_BH", "GATE_CH",
+            "GATE_AL", "GATE_BL", "GATE_CL",
+        }
+        for call in mock_schematic.add_label.call_args_list:
+            net_name, lx, ly = call.args[0], call.args[1], call.args[2]
+            if net_name in gate_nets:
+                assert (lx, ly) in wire_endpoints, (
+                    f"gate label {net_name!r} at ({lx}, {ly}) has no matching "
+                    f"wire endpoint; KiCad will treat it as floating "
+                    f"(regression of #2980)"
+                )


### PR DESCRIPTION
## Summary

Companion to PR #2979.  Three more motor-control blocks emitted floating labels (or no labels at all) at MOSFET-gate / driver-IC pins, causing board 05's ERC count to plateau at ~100 errors with cascading ``isolated_pin_label`` / ``pin_not_connected`` / ``pin_not_driven`` violations.

Adds three opt-in kwargs (all default to ``None``, so other boards are untouched):

- ``HalfBridge(..., gate_hs_net=..., gate_ls_net=...)`` — labels each MOSFET gate pin with a one-grid (2.54 mm) stub wire extending left.
- ``ThreePhaseInverter(..., gate_hs_nets=[...], gate_ls_nets=[...])`` — forwards per-phase net names to each underlying HalfBridge with length validation.
- ``GateDriverBlock(..., pin_nets={pin_key: net_name})`` — resolves real pin positions via ``self.driver.pin_position(...)``, stubs left for left-edge pins and right otherwise, and adds an alias port keyed by the net name (without clobbering existing ports).

Board 05 caller updates (``design.py:441, 494``) opt in for the DRV8308 gate pins and Q1-Q6 gates.

## Results

- **Board 05 ERC**: 100 -> 82 errors (-18).  All 6 ``U3`` gate-pin and 6 ``Q1``-``Q6``.G ``pin_not_connected`` cascades eliminated.
- **No ``UserWarning: Label '...' is not on any wire``** for ``GATE_*`` / ``GATE_DRV_*`` nets.
- **Fleet parity**: boards 00-04, 06, 07 unaffected (kwargs default to ``None``).

The residual 82 ERC errors are unrelated to this issue (SPI / discrete-control DRV8308 inputs + power-pin wiring needing MCU-side labels — outside the curator's stated scope).

## Test plan

- [x] Three new test files mirror ``tests/test_blocks_gate_drive_resistor_array.py``:
  - ``tests/test_blocks_half_bridge.py`` (7 tests, including ``test_labels_anchored_to_wire_endpoints``)
  - ``tests/test_blocks_three_phase_inverter.py`` (7 tests)
  - ``tests/test_blocks_gate_driver_block.py`` (9 tests — both stub directions, pin-name vs pin-number keys, alias-port no-clobber, wire-anchor regression)
- [x] Existing schematic-block test suite stays green (389 passed, 5 skipped, including the 16 pre-existing ``HalfBridge`` / ``ThreePhaseInverter`` / ``GateDriverBlock`` tests).
- [x] ``tests/test_board_05_zones.py`` stays green.
- [x] Board 05 ``design.py`` generates the schematic without floating-label warnings; ERC drops from 100 -> 82.

## References

- Closes #2980
- Pattern source: PR #2979 (``GateDriveResistorArray`` stub-wire fix for #2968)

🤖 Generated with [Claude Code](https://claude.com/claude-code)