### PR TITLE
fix(router): byte-lane corridor reservation for inner-corner DDR escapes (closes #2983)

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -4407,20 +4407,100 @@ class Autorouter:
 
             # Inner-corner indices in the sorted row.  Position 1 (one in
             # from the top corner) and position n-2 (one in from the
-            # bottom corner) are the inner-corner members.  These are
-            # the rows for which the PR #2969 R1/R2/R3 attempts failed
-            # to land a net-ordering-only fix; see the method docstring
-            # for the full trace.
-            _inner_corner_indices = (1, n - 2)  # noqa: F841 -- kept as the future-PR target
-            _ = sorted_nets  # noqa: F841 -- referenced for static analyzers; future PR consumes
+            # bottom corner) are the inner-corner members.  PR #2969
+            # R1/R2/R3 proved net-ordering alone could not resolve the
+            # geometric collision (DQ5 still blocked by DQ4 via at
+            # 0.44mm).  Issue #2983 lands the **corridor reservation
+            # strategy** as the layered-escape fix: for each
+            # inner-corner net, pre-reserve a lateral corridor on an
+            # inner signal layer BEFORE any corner-net through-hole
+            # vias are placed.  The reservation is consulted per-cell
+            # by ``RoutingGrid._mark_via`` so partner vias detour
+            # around the corridor (see ``EscapeRouter.
+            # reserve_inner_corner_lane_corridor`` docstring for the
+            # full mechanic).
+            inner_corner_indices = (1, n - 2)
 
-        # Scaffolding fallback: return the input unchanged.  The three
-        # integration hooks (route_all, route_all_negotiated,
-        # TwoPhaseRouter) call this helper through the same surface,
-        # so a future PR can replace this block with a real reorder
-        # without touching the callers.  See follow-up issue:
-        #   "router: layered-escape strategy for mirrored byte-lane DDR
-        #    (decouples via placement from net ordering)"
+            # Compute the primary component's centroid from the row pad
+            # positions.  The launch direction for each inner-corner pad
+            # is OUTWARD from the centroid (perpendicular to the row
+            # axis: x-axis for vertical rows, y-axis for horizontal
+            # rows).  The QFN row in a mirrored byte-lane topology has
+            # pads on one face of the package; the centroid x/y on the
+            # row's *cross* axis sits inside the package body, so the
+            # outward direction is the sign of (pad - centroid) on that
+            # axis.
+            cx = sum(p[0] for p in net_to_pad.values()) / len(net_to_pad)
+            cy = sum(p[1] for p in net_to_pad.values()) / len(net_to_pad)
+
+            try:
+                escape = self._escape
+            except Exception:
+                # Defensive: lazy escape router init may fail on a
+                # malformed grid; fall back to identity ordering.
+                continue
+
+            for idx in inner_corner_indices:
+                if idx < 0 or idx >= len(sorted_nets):
+                    continue
+                nid = sorted_nets[idx]
+                pad_key: tuple[float, float] | None = net_to_pad.get(nid)
+                if pad_key is None:
+                    continue
+                px, py = pad_key
+
+                # Launch direction: perpendicular to the row long axis,
+                # outward from the primary-component centroid.
+                if y_span >= x_span:
+                    # Vertical row -- escape outward along x.
+                    launch_dx = 1.0 if px >= cx else -1.0
+                    launch_dy = 0.0
+                else:
+                    # Horizontal row -- escape outward along y.
+                    launch_dx = 0.0
+                    launch_dy = 1.0 if py >= cy else -1.0
+
+                # Resolve the actual Pad object for the helper.  We need
+                # the full Pad (with .net, .net_name, .layer) -- the
+                # ``net_to_pad`` dict only has (x, y).  Look it up via
+                # the primary component's pad table.
+                pad_obj = None
+                for pkey, p in self.pads.items():
+                    if (
+                        p.ref == primary_ref
+                        and p.net is not None
+                        and int(p.net) == nid
+                    ):
+                        pad_obj = p
+                        break
+                if pad_obj is None:
+                    continue
+
+                try:
+                    escape.reserve_inner_corner_lane_corridor(
+                        pad=pad_obj,
+                        launch_dx=launch_dx,
+                        launch_dy=launch_dy,
+                    )
+                except Exception:
+                    # Reservation is advisory; failure must not abort
+                    # routing.  The pre-fix behaviour (no reservation)
+                    # is the worst case.
+                    logger.debug(
+                        "Byte-lane corridor reservation failed for "
+                        "net %d (group %s); continuing without it",
+                        nid,
+                        grp_name,
+                        exc_info=True,
+                    )
+
+        # Identity ordering preserved: the corridor reservation is the
+        # mechanism that breaks the geometric collision (PR #2969 proved
+        # net-ordering changes alone could not).  Callers
+        # (``route_all``, ``route_all_negotiated``, ``TwoPhaseRouter``)
+        # consume the unchanged order and the escape pre-pass + main
+        # routing loop honour the per-cell reservation via
+        # ``RoutingGrid._mark_via``.
         return net_order
 
     def _compute_mst_edges(self, net_id: int) -> list[MSTEdgeInfo]:

--- a/src/kicad_tools/router/escape.py
+++ b/src/kicad_tools/router/escape.py
@@ -869,6 +869,17 @@ class EscapeRouter:
         # the total number of grid cells reserved across all calls.
         self.pair_corridor_reservations: int = 0
         self.pair_corridor_reserved_cells: int = 0
+        # Issue #2983: Instrumentation counters for single-ended byte-lane
+        # inner-corner corridor reservations.  Mirrors the diff-pair
+        # ``pair_corridor_*`` pattern but tracks calls into
+        # ``_reserve_inner_corner_lane_corridor`` which generalises the
+        # mechanism to mirrored byte-lane (e.g. board 07 DDR data) pads
+        # at sorted positions 1 and N-2 of a co-located row.  Tests in
+        # ``tests/router/test_byte_lane_corridor_reservation.py`` assert
+        # both the call count (one per inner-corner net) and the cell
+        # count (non-zero on a 4-layer board with an inner signal layer).
+        self.byte_lane_corridor_reservations: int = 0
+        self.byte_lane_corridor_reserved_cells: int = 0
 
         # Issue #2605: Resolve manufacturer capability flags.  Caller-supplied
         # arg wins; otherwise fall back to ``rules.manufacturer``.  If the
@@ -1619,6 +1630,196 @@ class EscapeRouter:
                 sorted(owner_nets),
                 len(members),
                 members[0].direction.name,
+            )
+        return count
+
+    def reserve_inner_corner_lane_corridor(
+        self,
+        pad: Pad,
+        launch_dx: float,
+        launch_dy: float,
+        target_inner_layer: Layer | None = None,
+        corridor_length: float | None = None,
+        corridor_half_width: float | None = None,
+    ) -> int:
+        """Reserve an inner-layer lateral corridor for a single-ended pad.
+
+        Issue #2983: Generalises ``_reserve_pair_continuation_corridor``
+        to the **single-ended inner-corner case** on mirrored byte-lane
+        packages (e.g. board 07's DDR data byte on a mirrored QFN-48
+        pair).  Pin row order on U1.25-35 is
+        ``DQ0, DQ1, DQ2, DQ3, DM0, DQS_P, DQS_N, DQ4, DQ5, DQ6, DQ7``
+        (mirrored on U2.1-11) — the pads at sorted positions 1 and N-2
+        ("inner-corner") are squeezed by their corner neighbour's
+        through-hole via placement.  Reserving a lateral corridor on
+        an inner signal layer (typically In1.Cu on the JLCPCB 4-layer
+        tier-1 stack-up) BEFORE any corner-net escapes prevents the
+        partner via from colonising the only continuation lane.
+
+        This is the single-ended sibling of the diff-pair corridor
+        primitive: same grid mechanic
+        (``RoutingGrid.reserve_corridor_cells``), same per-cell
+        consultation in ``RoutingGrid._mark_via`` (non-matching nets
+        skip the cell), same instrumentation pattern.  The geometry
+        is simpler — one pad, one launch direction — so no centroid
+        or partner projection is needed.
+
+        Geometry:
+            * Origin = pad centre.
+            * Corridor extends ``corridor_length`` mm along the launch
+              vector (dx, dy).
+            * Corridor width = ``2 * corridor_half_width`` mm,
+              centred on the pad and oriented perpendicular to launch.
+
+        Defaults are sized for board 07's 0.8mm-pitch QFN-48: the
+        launch step is ``escape_clearance + 2 * trace_width`` and the
+        corridor extrudes ~3 launch steps long (matching the PR #2911
+        diff-pair recipe).  The lateral half-width is one launch step
+        — narrower than the diff-pair recipe because we only need to
+        protect ONE net, not a pair, and a wider reservation would
+        starve the second-inward neighbour (the same trade-off that
+        led PR #2911 to NOT widen ``lat_half`` for the partner-via
+        halo; see ``_reserve_pair_continuation_corridor`` AC6 note).
+
+        Args:
+            pad: The inner-corner pad whose lane is being protected.
+                Must have a non-zero ``pad.net``.
+            launch_dx: Outward x-component of launch direction.
+            launch_dy: Outward y-component of launch direction.
+                ``(launch_dx, launch_dy)`` will be normalised to a unit
+                vector; the caller can pass component-centroid
+                differences directly.
+            target_inner_layer: Inner copper layer for the reservation.
+                Defaults to ``_select_inner_escape_layer(pad.layer)``
+                which returns the first inner signal layer (In1.Cu on
+                a 4-layer board) or B.Cu on 2-layer boards.  The 2-layer
+                fallback path is short-circuited inside this helper
+                (same guard as the diff-pair version): reserving B.Cu
+                would block the pad's own through-hole vias.
+            corridor_length: Optional override for forward extent.
+                Defaults to ``3 * (escape_clearance + 2 * trace_w)``.
+            corridor_half_width: Optional override for lateral
+                half-width.  Defaults to ``escape_clearance + trace_w``.
+
+        Returns:
+            Number of grid cells reserved.  Returns 0 if the helper is
+            a no-op (e.g. zero net id, layer not in stack, 2-layer
+            board, zero launch vector).
+        """
+        # Skip no-op cases up front.
+        net_id = int(pad.net) if pad.net else 0
+        if net_id == 0:
+            return 0
+
+        length_norm = math.hypot(launch_dx, launch_dy)
+        if length_norm == 0:
+            return 0
+        dx = launch_dx / length_norm
+        dy = launch_dy / length_norm
+
+        # Select target layer.  Default mirrors the diff-pair primitive
+        # (first inner signal layer; B.Cu fallback when no inner signal
+        # layers are available — e.g. board 07's 4-layer stack-up where
+        # In1.Cu/In2.Cu are PLANES).  For the single-ended inner-corner
+        # case the B.Cu fallback is *valid*: a pad-specific reservation
+        # on B.Cu blocks OTHER nets' through-hole vias from invading
+        # the corridor while still allowing the pad's own escape via
+        # (which carries the same net id and matches the reservation).
+        # The 2-layer fallback (where B.Cu is the ONLY alternate signal
+        # layer) is still excluded because reserving cells on the only
+        # alternate routable surface would starve partner-net escapes
+        # — same hazard as the diff-pair primitive's 2-layer guard.
+        if target_inner_layer is None:
+            target_inner_layer = self._select_inner_escape_layer(pad.layer)
+
+        # Require at least 3 routable layers in the stack-up.  On
+        # 2-layer boards this fix is unnecessary (no via-blocking
+        # contention to resolve) and *harmful* (would block partner-net
+        # vias from completing).  On 4-layer (and deeper) stacks the
+        # corridor reservation is safe regardless of whether the
+        # selected layer is an inner signal layer (In1.Cu) or an outer
+        # routing layer (B.Cu) — partner-net vias will detour because
+        # the cells are reserved for *this* net only.
+        if self.grid.layer_stack is not None:
+            if self.grid.layer_stack.num_layers < 3:
+                logger.debug(
+                    "Inner-corner corridor skipped: 2-layer stack-up "
+                    "(no contention to resolve, reservation would starve "
+                    "partner escapes)"
+                )
+                return 0
+            target_def = self.grid.layer_stack.get_layer_by_name(
+                target_inner_layer.kicad_name
+            )
+            if target_def is None:
+                logger.debug(
+                    "Inner-corner corridor skipped: layer %s not in stack",
+                    target_inner_layer.name,
+                )
+                return 0
+
+        try:
+            target_idx = self.grid.layer_to_index(target_inner_layer.value)
+        except Exception:
+            logger.debug(
+                "Inner-corner corridor skipped: layer %s not in grid stack",
+                target_inner_layer.name,
+            )
+            return 0
+
+        # Resolve trace width from net class (same idiom as the diff-pair
+        # primitive).
+        trace_w = self._get_trace_width_for_net(pad.net_name or "")
+        launch_step = self.escape_clearance + 2 * trace_w
+        if corridor_length is None:
+            corridor_length = launch_step * 3.0
+        if corridor_half_width is None:
+            # One launch step — narrower than the diff-pair half-width
+            # (which spans the pair extent plus padding).  See docstring
+            # for the starvation-avoidance rationale.
+            corridor_half_width = launch_step
+
+        # Lateral unit vector (right-hand-rule perpendicular).
+        lat_dx, lat_dy = -dy, dx
+        cx, cy = pad.x, pad.y
+
+        step = self.grid.resolution * 0.5
+        cells: set[tuple[int, int]] = set()
+        t = 0.0
+        while t <= corridor_length:
+            u = -corridor_half_width
+            while u <= corridor_half_width:
+                wx = cx + dx * t + lat_dx * u
+                wy = cy + dy * t + lat_dy * u
+                gx, gy = self.grid.world_to_grid(wx, wy)
+                cells.add((gx, gy))
+                u += step
+            t += step
+
+        if not cells:
+            return 0
+
+        count = self.grid.reserve_corridor_cells(
+            layer_idx=target_idx,
+            cells=cells,
+            net_ids={net_id},
+        )
+        if count > 0:
+            self.byte_lane_corridor_reservations += 1
+            self.byte_lane_corridor_reserved_cells += count
+            logger.debug(
+                "Byte-lane inner-corner corridor reserved: "
+                "layer=%s cells=%d net=%d pad=%s.%s launch=(%.2f,%.2f) "
+                "length=%.2fmm half_width=%.2fmm",
+                target_inner_layer.name,
+                count,
+                net_id,
+                pad.ref,
+                pad.pin,
+                dx,
+                dy,
+                corridor_length,
+                corridor_half_width,
             )
         return count
 

--- a/tests/router/test_byte_lane_corridor_reservation.py
+++ b/tests/router/test_byte_lane_corridor_reservation.py
@@ -162,9 +162,7 @@ class TestCorridorReservationOnPlaneStackup:
     def test_reservation_count_equals_two_per_byte_lane(self) -> None:
         """Mirrored 10-net byte-lane => 2 inner-corner pads => 2 calls."""
         stack = LayerStack.four_layer_sig_gnd_pwr_sig()
-        router, net_ids, _ = _make_byte_lane_router(
-            group_size=10, layer_stack=stack
-        )
+        router, net_ids, _ = _make_byte_lane_router(group_size=10, layer_stack=stack)
 
         # Force escape router init so counters are accessible.
         escape = router._escape
@@ -185,9 +183,7 @@ class TestCorridorReservationOnPlaneStackup:
     def test_nine_net_byte_lane_two_reservations(self) -> None:
         """9-net byte-lane (DDR-byte minus DQS pair) — still 2 inner corners."""
         stack = LayerStack.four_layer_sig_gnd_pwr_sig()
-        router, net_ids, _ = _make_byte_lane_router(
-            group_size=9, layer_stack=stack
-        )
+        router, net_ids, _ = _make_byte_lane_router(group_size=9, layer_stack=stack)
 
         out = router._apply_byte_lane_inner_priority(net_ids)
         assert out == net_ids
@@ -209,9 +205,7 @@ class TestCorridorReservationOnSignalStackup:
 
     def test_reserves_on_inner_signal_layer(self) -> None:
         stack = LayerStack.four_layer_all_signal()
-        router, net_ids, _ = _make_byte_lane_router(
-            group_size=10, layer_stack=stack
-        )
+        router, net_ids, _ = _make_byte_lane_router(group_size=10, layer_stack=stack)
 
         out = router._apply_byte_lane_inner_priority(net_ids)
         assert out == net_ids
@@ -238,9 +232,7 @@ class TestReservationSequencingBeforeViaMarking:
 
     def test_counters_bump_within_apply_helper(self) -> None:
         stack = LayerStack.four_layer_sig_gnd_pwr_sig()
-        router, net_ids, _ = _make_byte_lane_router(
-            group_size=10, layer_stack=stack
-        )
+        router, net_ids, _ = _make_byte_lane_router(group_size=10, layer_stack=stack)
 
         # Before helper: no reservations.
         assert router._escape.byte_lane_corridor_reservations == 0
@@ -270,9 +262,7 @@ class TestTwoLayerStackupGuard:
 
     def test_no_reservation_on_two_layer_stack(self) -> None:
         stack = LayerStack.two_layer()
-        router, net_ids, _ = _make_byte_lane_router(
-            group_size=10, layer_stack=stack
-        )
+        router, net_ids, _ = _make_byte_lane_router(group_size=10, layer_stack=stack)
 
         router._apply_byte_lane_inner_priority(net_ids)
         # No reservations on 2-layer stack-up.
@@ -286,9 +276,7 @@ class TestTwoLayerStackupGuard:
         produces no reservations, matching the test_byte_lane_priority
         existing assertions where no stack is supplied.
         """
-        router, net_ids, _ = _make_byte_lane_router(
-            group_size=10, layer_stack=None
-        )
+        router, net_ids, _ = _make_byte_lane_router(group_size=10, layer_stack=None)
 
         router._apply_byte_lane_inner_priority(net_ids)
         assert router._escape.byte_lane_corridor_reservations == 0
@@ -313,9 +301,7 @@ class TestOrderingStillIdentity:
 
     def test_identity_on_4_layer_signal_stack(self) -> None:
         stack = LayerStack.four_layer_all_signal()
-        router, net_ids, _ = _make_byte_lane_router(
-            group_size=10, layer_stack=stack
-        )
+        router, net_ids, _ = _make_byte_lane_router(group_size=10, layer_stack=stack)
         out = router._apply_byte_lane_inner_priority(net_ids)
         assert out == net_ids
         assert set(out) == set(net_ids)
@@ -323,9 +309,7 @@ class TestOrderingStillIdentity:
 
     def test_identity_on_plane_stack(self) -> None:
         stack = LayerStack.four_layer_sig_gnd_pwr_sig()
-        router, net_ids, _ = _make_byte_lane_router(
-            group_size=10, layer_stack=stack
-        )
+        router, net_ids, _ = _make_byte_lane_router(group_size=10, layer_stack=stack)
         out = router._apply_byte_lane_inner_priority(net_ids)
         assert out == net_ids
 
@@ -347,9 +331,7 @@ class TestNoReservationOnUnsupportedInputs:
     def test_four_member_group_no_reservation(self) -> None:
         """Below MIN_BYTE_LANE_SIZE=5 => no reservation."""
         stack = LayerStack.four_layer_all_signal()
-        router, net_ids, _ = _make_byte_lane_router(
-            group_size=4, layer_stack=stack
-        )
+        router, net_ids, _ = _make_byte_lane_router(group_size=4, layer_stack=stack)
         out = router._apply_byte_lane_inner_priority(net_ids)
         assert out == net_ids
         assert router._escape.byte_lane_corridor_reservations == 0

--- a/tests/router/test_byte_lane_corridor_reservation.py
+++ b/tests/router/test_byte_lane_corridor_reservation.py
@@ -1,0 +1,374 @@
+"""Tests for the byte-lane inner-corner corridor reservation (Issue #2983).
+
+Background
+----------
+
+PR #2969 (closes #2962) landed a scaffolding-only detection hook,
+:meth:`Autorouter._apply_byte_lane_inner_priority`, that detected
+mirrored byte-lane match groups (e.g. board 07's DDR data byte on a
+mirrored QFN-48 pair) but did NOT act on the detection.  PR #2969's
+R1/R2/R3 rounds proved net-ordering alone could not break the
+geometric DQ5/DQ4 0.44mm via-clearance collision.
+
+Issue #2983 adds the **corridor reservation strategy** as the
+layered-escape fix: for each inner-corner net (sorted positions 1
+and N-2 of the co-located row), pre-reserve a lateral corridor on
+an inner signal layer (or B.Cu on plane-stack-up 4-layer boards)
+BEFORE any corner-net through-hole vias are placed.  The mechanic
+is identical to the diff-pair continuation corridor from PR #2911
+(:meth:`EscapeRouter._reserve_pair_continuation_corridor`) — the
+new helper :meth:`EscapeRouter.reserve_inner_corner_lane_corridor`
+generalises it to single-ended pads.
+
+Tests in this module pin the contract:
+
+1. ``byte_lane_corridor_reservations`` counter equals 2 per
+   detected mirrored byte-lane group (one per inner-corner pad).
+2. ``byte_lane_corridor_reserved_cells`` is non-zero when a valid
+   inner routable layer exists in the stack-up.
+3. The reservation runs as part of
+   :meth:`_apply_byte_lane_inner_priority` (so it lands BEFORE
+   any corner-net via marking in the escape pre-pass).
+4. The ordering output is still identity (PR #2969 contract
+   preserved — corridor reservation does not perturb net order).
+5. The 2-layer guard is honoured (no reservation on 2-layer
+   stack-ups; that case has no via-blocking contention to
+   resolve and would actively starve partner-net escapes).
+6. Small groups, no-group boards, and non-mirrored topologies
+   skip the reservation cleanly.
+
+The synthetic fixture uses the same mirrored QFN-48 geometry as
+``test_byte_lane_priority.py`` so the regression fingerprint
+matches PR #2969's scaffolding contract — only the new counter
+assertions are added on top.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.layers import LayerStack
+from kicad_tools.router.rules import NetClassRouting
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _make_byte_lane_router(
+    *,
+    group_name: str = "DDR_DATA_BYTE_0",
+    group_size: int = 10,
+    pitch: float = 0.8,
+    priority: int = 1,
+    layer_stack: LayerStack | None = None,
+) -> tuple[Autorouter, list[int], list[str]]:
+    """Build a synthetic router with a mirrored byte-lane match group.
+
+    Mirrors the test_byte_lane_priority.py fixture but exposes a
+    ``layer_stack`` parameter so each test can pin the contract on
+    the specific stack-up topology it cares about
+    (4-layer plane vs 4-layer signal vs 2-layer).
+
+    Args:
+        group_name: ``length_match_group`` name (also class name).
+        group_size: Number of nets in the byte-lane.
+        pitch: Vertical spacing between pads on each component.
+        priority: Net-class priority.
+        layer_stack: Stack-up to pass to the Autorouter constructor.
+            ``None`` defaults the constructor's internal 2-layer
+            fallback.
+
+    Returns:
+        Tuple of (router, net_ids_in_creation_order, net_names).
+    """
+    cls = NetClassRouting(
+        name=group_name,
+        priority=priority,
+        trace_width=0.15,
+        clearance=0.10,
+        length_critical=True,
+        length_match_group=group_name,
+        length_match_reference=None,
+        length_match_tolerance_mm=0.1,
+    )
+    net_class_map: dict[str, NetClassRouting] = {}
+    router = Autorouter(
+        width=120.0,
+        height=80.0,
+        net_class_map=net_class_map,
+        layer_stack=layer_stack,
+    )
+
+    centre_y = 40.0
+    base_y = centre_y - (group_size - 1) * pitch / 2.0
+
+    net_ids: list[int] = []
+    net_names: list[str] = []
+    for i in range(group_size):
+        net_id = i + 1
+        net_name = f"DQ{i}"
+        net_ids.append(net_id)
+        net_names.append(net_name)
+        y = base_y + i * pitch
+
+        # Pad on U1 (left component, pads face east)
+        router.add_component(
+            "U1",
+            [
+                {
+                    "number": str(25 + i),
+                    "x": 40.0,
+                    "y": y,
+                    "net": net_id,
+                    "net_name": net_name,
+                }
+            ],
+        )
+        # Mirrored pad on U2 (right component, pads face west)
+        router.add_component(
+            "U2",
+            [
+                {
+                    "number": str(1 + i),
+                    "x": 80.0,
+                    "y": y,
+                    "net": net_id,
+                    "net_name": net_name,
+                }
+            ],
+        )
+        net_class_map[net_name] = cls
+
+    router.net_class_map = net_class_map
+    return router, net_ids, net_names
+
+
+# =============================================================================
+# Tests: Corridor reservation contract on 4-layer plane stack-up (board 07)
+# =============================================================================
+
+
+class TestCorridorReservationOnPlaneStackup:
+    """Board 07's 4-layer SIG-GND-PWR-SIG stack-up (In1/In2 are PLANES).
+
+    ``_select_inner_escape_layer`` falls back to B.Cu (no inner
+    signal layers available).  The single-ended corridor helper
+    SHOULD still reserve cells on B.Cu — this is safe because the
+    reservation is per-net and partner-net through-hole vias will
+    detour around it on B.Cu, while the inner-corner pad's own via
+    matches the reservation owner set and lands freely.
+    """
+
+    def test_reservation_count_equals_two_per_byte_lane(self) -> None:
+        """Mirrored 10-net byte-lane => 2 inner-corner pads => 2 calls."""
+        stack = LayerStack.four_layer_sig_gnd_pwr_sig()
+        router, net_ids, _ = _make_byte_lane_router(
+            group_size=10, layer_stack=stack
+        )
+
+        # Force escape router init so counters are accessible.
+        escape = router._escape
+        assert escape.byte_lane_corridor_reservations == 0
+        assert escape.byte_lane_corridor_reserved_cells == 0
+
+        # Drive the detection + reservation pass.
+        out = router._apply_byte_lane_inner_priority(net_ids)
+
+        # Identity contract preserved.
+        assert out == net_ids
+        # Two inner-corner pads (positions 1 and N-2) on the primary
+        # component (U1 or U2 — both host all 10 group members; the
+        # tie-break picks one deterministically).
+        assert escape.byte_lane_corridor_reservations == 2
+        assert escape.byte_lane_corridor_reserved_cells > 0
+
+    def test_nine_net_byte_lane_two_reservations(self) -> None:
+        """9-net byte-lane (DDR-byte minus DQS pair) — still 2 inner corners."""
+        stack = LayerStack.four_layer_sig_gnd_pwr_sig()
+        router, net_ids, _ = _make_byte_lane_router(
+            group_size=9, layer_stack=stack
+        )
+
+        out = router._apply_byte_lane_inner_priority(net_ids)
+        assert out == net_ids
+        assert router._escape.byte_lane_corridor_reservations == 2
+        assert router._escape.byte_lane_corridor_reserved_cells > 0
+
+
+# =============================================================================
+# Tests: Corridor reservation contract on 4-layer all-signal stack-up
+# =============================================================================
+
+
+class TestCorridorReservationOnSignalStackup:
+    """4-layer all-signal stack-up (inner layers ARE signal).
+
+    ``_select_inner_escape_layer`` picks In1.Cu (first inner SIGNAL
+    layer).  The corridor reservation lands there.
+    """
+
+    def test_reserves_on_inner_signal_layer(self) -> None:
+        stack = LayerStack.four_layer_all_signal()
+        router, net_ids, _ = _make_byte_lane_router(
+            group_size=10, layer_stack=stack
+        )
+
+        out = router._apply_byte_lane_inner_priority(net_ids)
+        assert out == net_ids
+        assert router._escape.byte_lane_corridor_reservations == 2
+        assert router._escape.byte_lane_corridor_reserved_cells > 0
+
+
+# =============================================================================
+# Tests: Reservation runs BEFORE corner-net via marking
+# =============================================================================
+
+
+class TestReservationSequencingBeforeViaMarking:
+    """The reservation MUST land before any via marking.
+
+    ``_apply_byte_lane_inner_priority`` is invoked from
+    ``route_all`` / ``route_all_negotiated`` / ``TwoPhaseRouter``
+    AFTER ``_interleave_match_groups`` and BEFORE the subgrid
+    escape pre-pass (which is where corner-net through-hole vias
+    are first placed via ``_run_subgrid_prepass``).  Calling the
+    helper directly should bump the counters immediately —
+    verifying the sequence without driving a full route.
+    """
+
+    def test_counters_bump_within_apply_helper(self) -> None:
+        stack = LayerStack.four_layer_sig_gnd_pwr_sig()
+        router, net_ids, _ = _make_byte_lane_router(
+            group_size=10, layer_stack=stack
+        )
+
+        # Before helper: no reservations.
+        assert router._escape.byte_lane_corridor_reservations == 0
+        # After helper: 2 reservations (one per inner-corner pad).
+        router._apply_byte_lane_inner_priority(net_ids)
+        assert router._escape.byte_lane_corridor_reservations == 2
+
+        # The cells are recorded on the grid's reservation map.
+        # ``RoutingGrid.reserved_cell_count()`` returns the total
+        # number of currently reserved cells across all layers.
+        assert router.grid.reserved_cell_count() > 0
+
+
+# =============================================================================
+# Tests: 2-layer guard — no reservation on 2-layer stack-ups
+# =============================================================================
+
+
+class TestTwoLayerStackupGuard:
+    """The single-ended helper must NOT reserve cells on a 2-layer board.
+
+    Mirrors the diff-pair primitive's 2-layer guard (#2677): on a
+    2-layer board there are exactly two routable layers (F.Cu and
+    B.Cu) and partner-net vias MUST be free to land on both.
+    Reserving cells on B.Cu would starve partner-net escapes.
+    """
+
+    def test_no_reservation_on_two_layer_stack(self) -> None:
+        stack = LayerStack.two_layer()
+        router, net_ids, _ = _make_byte_lane_router(
+            group_size=10, layer_stack=stack
+        )
+
+        router._apply_byte_lane_inner_priority(net_ids)
+        # No reservations on 2-layer stack-up.
+        assert router._escape.byte_lane_corridor_reservations == 0
+        assert router._escape.byte_lane_corridor_reserved_cells == 0
+
+    def test_no_reservation_when_no_stack_provided(self) -> None:
+        """Autorouter default (layer_stack=None) => internal 2-layer fallback.
+
+        Same guard applies: the synthetic 2-layer fallback path
+        produces no reservations, matching the test_byte_lane_priority
+        existing assertions where no stack is supplied.
+        """
+        router, net_ids, _ = _make_byte_lane_router(
+            group_size=10, layer_stack=None
+        )
+
+        router._apply_byte_lane_inner_priority(net_ids)
+        assert router._escape.byte_lane_corridor_reservations == 0
+
+
+# =============================================================================
+# Tests: Identity preservation (PR #2969 ordering contract)
+# =============================================================================
+
+
+class TestOrderingStillIdentity:
+    """Corridor reservation must NOT change net ordering.
+
+    PR #2969's R1/R2/R3 trace proved net-ordering changes alone are
+    insufficient AND, in R1, actively regressed DRC.  The Issue #2983
+    fix is corridor-reservation-only: the helper's return value must
+    remain identical to the input order so the downstream priority
+    semantics (PR #2914 starvation fairness, PR #2482 connector
+    sibling promotion, complexity-tier ordering, etc.) are
+    preserved verbatim.
+    """
+
+    def test_identity_on_4_layer_signal_stack(self) -> None:
+        stack = LayerStack.four_layer_all_signal()
+        router, net_ids, _ = _make_byte_lane_router(
+            group_size=10, layer_stack=stack
+        )
+        out = router._apply_byte_lane_inner_priority(net_ids)
+        assert out == net_ids
+        assert set(out) == set(net_ids)
+        assert len(out) == len(net_ids)
+
+    def test_identity_on_plane_stack(self) -> None:
+        stack = LayerStack.four_layer_sig_gnd_pwr_sig()
+        router, net_ids, _ = _make_byte_lane_router(
+            group_size=10, layer_stack=stack
+        )
+        out = router._apply_byte_lane_inner_priority(net_ids)
+        assert out == net_ids
+
+
+# =============================================================================
+# Tests: Small / non-mirrored / no-group inputs short-circuit cleanly
+# =============================================================================
+
+
+class TestNoReservationOnUnsupportedInputs:
+    """The helper must skip the reservation for inputs that don't
+    look like a mirrored byte-lane.
+
+    Mirrors the test_byte_lane_priority small-group / no-group
+    coverage: in all cases the counters remain at zero AND the
+    ordering is identity.
+    """
+
+    def test_four_member_group_no_reservation(self) -> None:
+        """Below MIN_BYTE_LANE_SIZE=5 => no reservation."""
+        stack = LayerStack.four_layer_all_signal()
+        router, net_ids, _ = _make_byte_lane_router(
+            group_size=4, layer_stack=stack
+        )
+        out = router._apply_byte_lane_inner_priority(net_ids)
+        assert out == net_ids
+        assert router._escape.byte_lane_corridor_reservations == 0
+
+    def test_no_match_group_no_reservation(self) -> None:
+        """Plain unrelated nets => no group detection => no reservation."""
+        stack = LayerStack.four_layer_all_signal()
+        router = Autorouter(width=80.0, height=80.0, layer_stack=stack)
+        net_ids = [1, 2, 3, 4, 5, 6]
+        for nid in net_ids:
+            nm = f"NET{nid}"
+            router.add_component(
+                f"R{nid}_A",
+                [{"number": "1", "x": float(nid), "y": 5.0, "net": nid, "net_name": nm}],
+            )
+            router.add_component(
+                f"R{nid}_B",
+                [{"number": "1", "x": float(nid) + 1.0, "y": 5.0, "net": nid, "net_name": nm}],
+            )
+        out = router._apply_byte_lane_inner_priority(net_ids)
+        assert out == net_ids
+        assert router._escape.byte_lane_corridor_reservations == 0

--- a/tests/router/test_byte_lane_priority.py
+++ b/tests/router/test_byte_lane_priority.py
@@ -22,10 +22,18 @@ net-ordering exploration):
   (well under 70 allowlist), but DQ5 still blocked by DQ4 with the
   identical 0.44mm clearance failure as round 2 -- the underlying
   constraint is geometric, not orderable.
-- **Terminal outcome** (this PR / contract): scaffolding-only.  The
-  helper detects but does not act; a follow-up issue tracks the
-  layered-escape strategy that decouples via placement from net
-  ordering.
+- **Terminal outcome** (PR #2969): scaffolding-only.  The helper
+  detects but does not reorder.
+- **Issue #2983** (this contract): adds **corridor reservation**
+  on top of the scaffolding.  Ordering remains identity (PR #2969's
+  R1/R2/R3 contract preserved), but on multi-layer stack-ups the
+  helper now reserves a per-net lateral corridor for each
+  inner-corner pad (positions 1 and N-2 of the sorted row).  See
+  ``test_byte_lane_corridor_reservation.py`` for the
+  reservation-count contract.  The reservation primitive itself
+  is :meth:`EscapeRouter.reserve_inner_corner_lane_corridor`, a
+  single-ended generalisation of the diff-pair corridor primitive
+  from PR #2911.
 
 Root cause that motivates the eventual implementation (per the
 issue):
@@ -217,26 +225,39 @@ class TestIdentityOnSmallGroups:
 
 
 class TestScaffoldingIdentityOnByteLane:
-    """Mirrored byte-lane groups currently return identity (scaffolding cut).
+    """Mirrored byte-lane groups return identity, with corridor reservation.
 
-    The helper detects the byte-lane row -- the projection / sort
-    machinery runs eagerly so future analysis hooks see consistent
-    intermediate state -- but no reorder is applied.  A follow-up PR
-    will replace the scaffolding fallback with a layered-escape
-    strategy (corridor reservation, deferred via stitching, or
-    explicit lateral-lane assignment) without touching the three
-    integration hooks.
+    Issue #2983 updates the contract: the helper still returns the
+    input net order unchanged (PR #2969 R1/R2/R3 proved net-ordering
+    changes alone are insufficient and, in R1, regressed DRC), but
+    the **corridor reservation** side-effect now runs for each
+    detected mirrored byte-lane group.  The reservation lands ONLY
+    when a routable inner layer is available in the stack-up; the
+    fixture here does NOT pass a ``layer_stack`` so the internal
+    2-layer fallback is in effect and the reservation is correctly
+    skipped (the 2-layer guard prevents starving partner-net
+    escapes — see ``test_byte_lane_corridor_reservation.py`` for
+    the multi-layer reservation contract).
+
+    The detection / projection / sort machinery runs eagerly so
+    callers observe consistent intermediate state.  The integration
+    hooks (``route_all``, ``route_all_negotiated``, ``TwoPhaseRouter``)
+    consume the unchanged order and the escape pre-pass + main
+    routing loop honour the per-cell reservation via
+    ``RoutingGrid._mark_via``.
     """
 
     def test_nine_net_byte_lane_identity(self) -> None:
         """9-net byte-lane (DDR-byte minus DQS pair): detection runs,
-        no reorder applied -- output equals input.
+        no reorder applied — output equals input.
 
-        Scaffolding contract per PR #2969 round-4 terminal outcome:
-        net-ordering alone cannot resolve the geometric DQ5/DQ4
-        0.44mm clearance constraint observed across R1/R2/R3.  The
-        helper retains its detection logic and signature so a future
-        layered-escape PR can swap the body without touching callers.
+        Issue #2983 contract: ordering is identity, AND on a
+        multi-layer stack-up the corridor reservation runs as a
+        side effect.  This fixture uses the default 2-layer
+        Autorouter (no ``layer_stack``), so the reservation is
+        correctly skipped here by the 2-layer guard.  See
+        ``test_byte_lane_corridor_reservation.py`` for the
+        reservation count assertions on 4-layer stack-ups.
         """
         router, net_ids, _ = _make_byte_lane_router(group_size=9)
 
@@ -247,13 +268,18 @@ class TestScaffoldingIdentityOnByteLane:
         # Membership + length invariants hold trivially under identity.
         assert len(out) == len(net_ids)
         assert set(out) == set(net_ids)
+        # 2-layer fallback => no reservation on this fixture.
+        assert router._escape.byte_lane_corridor_reservations == 0
 
     def test_ten_net_byte_lane_identity(self) -> None:
         """A 10-net byte-lane (full DDR-byte): detection runs, but
-        no reorder is applied -- output equals input.
+        no reorder is applied — output equals input.
 
         See the module docstring for the R1/R2/R3 design-history
-        trace explaining why net-ordering alone is insufficient.
+        trace explaining why net-ordering alone is insufficient,
+        and ``test_byte_lane_corridor_reservation.py`` for the
+        Issue #2983 reservation-count assertions on multi-layer
+        stack-ups (where the corridor is actually carved out).
         """
         router, net_ids, _ = _make_byte_lane_router(group_size=10)
         out = router._apply_byte_lane_inner_priority(net_ids)
@@ -262,6 +288,8 @@ class TestScaffoldingIdentityOnByteLane:
         assert out == net_ids
         assert len(out) == len(net_ids)
         assert set(out) == set(net_ids)
+        # 2-layer fallback => no reservation on this fixture.
+        assert router._escape.byte_lane_corridor_reservations == 0
 
 
 class TestMultiGroupPreservation:


### PR DESCRIPTION
## Summary

Adds the **corridor reservation strategy** (Curator strategy A) for mirrored byte-lane DDR escapes on multi-layer boards. Generalises the diff-pair continuation corridor primitive from PR #2911 to single-ended inner-corner pads, so the inner-corner DQ pads (sorted positions 1 and N-2 on a co-located row) get a protected lateral lane on an inner signal layer BEFORE any corner-net through-hole vias are placed.

PR #2969's R1/R2/R3 trace proved net-ordering alone could not resolve the DQ5/DQ4 0.44mm via-clearance collision; this PR adds the layered-escape mechanism while preserving the identity-return scaffolding contract from #2969.

## Changes

- `src/kicad_tools/router/escape.py`: new `EscapeRouter.reserve_inner_corner_lane_corridor()` helper (single-ended generalisation of `_reserve_pair_continuation_corridor`), plus `byte_lane_corridor_reservations` / `byte_lane_corridor_reserved_cells` instrumentation counters mirroring the diff-pair pattern.
- `src/kicad_tools/router/core.py`: `Autorouter._apply_byte_lane_inner_priority()` now invokes the new helper for each inner-corner net (positions 1 and N-2 of the sorted row); ordering remains identity. Launch direction is computed from the primary-component centroid; pad-object lookup walks `self.pads` filtering by `ref + net`. The reservation call is wrapped in a try/except so a failure cannot abort routing (advisory mechanism).
- `tests/router/test_byte_lane_corridor_reservation.py`: new contract tests covering (a) reservation count = 2 per detected mirrored byte-lane group on 4-layer plane and 4-layer all-signal stack-ups, (b) `byte_lane_corridor_reserved_cells` > 0 when a valid inner routable layer exists, (c) reservation lands BEFORE corner-net via marking, (d) 2-layer guard (no reservation on 2-layer boards — would starve partner escapes), (e) ordering identity preserved, (f) small-group / non-mirrored / no-group inputs short-circuit cleanly.
- `tests/router/test_byte_lane_priority.py`: existing `TestScaffoldingIdentityOnByteLane` assertions extended to document that the reservation side-effect runs on multi-layer stack-ups while ordering stays identity. 2-layer fixture confirms the guard fires.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| 1. Board 07: yield improves (target 30/31) | Partial | Implementation is correct; current main is 23/31 (8 failures are MIPI/TMDS/DQS_N diff-pair pin-access, NOT DQ inner-corner pads). DQ4/DQ5/DQ2 already route in current main. Reservation infrastructure now protects DQ inner-corner pads preventatively; subsequent diff-pair fixes will unblock the remaining failures. |
| 2. DRC ≤70 (no widening of `.github/routed-drc-tolerance.yml`) | Met | `check_matchgroup_coverage.py boards/07-matchgroup-test --seed 42` reports DRC error count: 9 (allowed: 70). |
| 3. `match_group_length_skew` rule exercised | Met | `rules_checked_by_rule` includes `match_group_length_skew: 2`. |
| 4. Corridor counter assertions in `tests/router/test_byte_lane_corridor_reservation.py` | Met | 10 new tests pin `byte_lane_corridor_reservations == 2` per byte-lane, plus 4-layer stack-up coverage, 2-layer guard, identity preservation, and unsupported-input short-circuit. |
| 5. Boards 01-06 fleet parity | Met | `tests/router/` 173 tests pass; `tests/test_board_06_diffpair_test.py` 80 tests pass; boards 01-05 unaffected (no byte-lane match groups). |
| 6. `_interleave_match_groups` starvation-fairness (PR #2914) preserved | Met | Helper is identity-return — fairness invariants from PR #2914 are bit-exact unchanged. |
| 7. `TestScaffoldingIdentityOnByteLane` assertions updated | Met | Docstring + assertions document the new reservation side-effect on multi-layer stack-ups while preserving identity ordering. 2-layer fixture's `byte_lane_corridor_reservations == 0` assertion confirms the guard fires. |
| 8. Match-group CI gate passes | Met | `scripts/ci/check_matchgroup_coverage.py boards/07-matchgroup-test --seed 42` exits 0: "OK: all 1 match-group rule(s) exercised. OK: 9 errors (within allowlist max 70)." |
| HARD: No widening of `routed-drc-tolerance.yml` | Met | File untouched. |
| HARD: Don't undo PR #2914 / PR #2969 | Met | Both preserved verbatim. |
| HARD: Don't modify board 07 `generate_design.py` | Met | File untouched. |

## Test Plan

- [x] `uv run pytest tests/router/test_byte_lane_corridor_reservation.py -v` — 10/10 pass
- [x] `uv run pytest tests/router/test_byte_lane_priority.py -v` — 10/10 pass
- [x] `uv run pytest tests/router/ --no-cov -q` — 173 pass
- [x] `uv run pytest tests/test_board_06_diffpair_test.py tests/test_board_07_matchgroup_test.py --no-cov` — 80 pass
- [x] `uv run python scripts/ci/check_matchgroup_coverage.py boards/07-matchgroup-test --seed 42` — exit 0, DRC=9 (<=70), match_group_length_skew exercised

## Notes for Reviewer

The board 07 yield did not change vs. current main (23/31 either way), because the failing nets in current main are no longer the DQ inner-corner pads named in the issue body (DQ4/DQ5/DQ2 — all routing in main); they are MIPI/TMDS diff pairs and DQS_N, blocked by their own per-net via-clearance contention at the J1/U3/U4 connectors. The corridor reservation infrastructure landed here is preventative for the DQ pads and is the correct generalisation of PR #2911's diff-pair primitive that the issue prescribed (Curator strategy A). The metric "was 24/31" in the issue spec appears to be from a stale codebase snapshot; the original DQ5/DQ4 0.44mm collision documented in the issue is no longer observable on `main` after subsequent unrelated routing fixes.

Closes #2983