### PR TITLE
fix(motor): GateDriverBlock bypass cap footprint kwargs (closes #3009)

### DIFF
--- a/boards/05-bldc-motor-controller/design.py
+++ b/boards/05-bldc-motor-controller/design.py
@@ -591,6 +591,9 @@ def create_bldc_controller(output_dir: Path) -> Path:
         bootstrap_caps=None,  # bootstrap caps created externally below
         bypass_caps=["100nF", "10uF"],
         cap_ref_start=15,  # C15-C16 for bypass (C12-C14 reserved for bootstrap)
+        # Match the rest of the board's 0805 passives so C15/C16 land in the
+        # netlist with a non-empty footprint field (see issue #3009).
+        bypass_cap_footprint="Capacitor_SMD:C_0805_2012Metric",
         pin_nets={
             # --- Category 1: SPI + discrete control (left edge) ---
             # SPI inputs: tied to +3.3V (idle high) since no MCU pin is

--- a/boards/05-bldc-motor-controller/output/bldc_controller.kicad_pcb
+++ b/boards/05-bldc-motor-controller/output/bldc_controller.kicad_pcb
@@ -77,16 +77,16 @@
 		)
 		(fill none)
 		(layer "Edge.Cuts")
-		(uuid "c78c028b-8829-4d8e-84f5-b7bf5b92d4e2")
+		(uuid "8aa7a4f6-ef77-418a-9b92-2c85970838a1")
 	)
 	(footprint "MountingHole:MountingHole_3.2mm_M3"
 		(layer "F.Cu")
-		(uuid "a440d02f-d12e-4e44-88df-a916a2090788")
+		(uuid "17969256-76a5-4929-8964-fc1624452ffc")
 		(at 103.0 103.0)
 		(fp_text reference "MH1"
 			(at 0 -3)
 			(layer "F.SilkS")
-			(uuid "8181c4bf-5a1b-4772-9ddf-8d57215f8581")
+			(uuid "9db74959-5a1c-4224-b6a7-d789f4fc2bb1")
 			(effects
 				(font
 					(size 1 1)
@@ -97,7 +97,7 @@
 		(fp_text value "MountingHole"
 			(at 0 3)
 			(layer "F.Fab")
-			(uuid "ba497499-4d92-41be-b5a9-7a4db7700383")
+			(uuid "53877111-47b4-4a72-b70a-2f4cb930a70d")
 			(effects
 				(font
 					(size 1 1)
@@ -115,12 +115,12 @@
 	)
 	(footprint "MountingHole:MountingHole_3.2mm_M3"
 		(layer "F.Cu")
-		(uuid "ad4650dd-846e-47e9-a26d-33537cc3d880")
+		(uuid "d74534f2-15b6-46dc-9b14-1f8576391f07")
 		(at 167.0 103.0)
 		(fp_text reference "MH2"
 			(at 0 -3)
 			(layer "F.SilkS")
-			(uuid "fde13119-ccf1-494c-8f67-d834022913f6")
+			(uuid "90f8003f-9555-4d69-82a5-fab5c6d633b9")
 			(effects
 				(font
 					(size 1 1)
@@ -131,7 +131,7 @@
 		(fp_text value "MountingHole"
 			(at 0 3)
 			(layer "F.Fab")
-			(uuid "03b73468-74a6-4906-acb1-8c9112745e1f")
+			(uuid "8aab22ba-d9b8-4bdf-885c-f661f7296b9a")
 			(effects
 				(font
 					(size 1 1)
@@ -149,12 +149,12 @@
 	)
 	(footprint "MountingHole:MountingHole_3.2mm_M3"
 		(layer "F.Cu")
-		(uuid "b810d9dc-c247-4798-9ceb-c4ad2e4c4bb5")
+		(uuid "6da168a4-9feb-4401-a9dd-0b2e81492f36")
 		(at 103.0 187.0)
 		(fp_text reference "MH3"
 			(at 0 -3)
 			(layer "F.SilkS")
-			(uuid "6b13ae51-0b33-41fd-9159-b9b9a3404742")
+			(uuid "5a7acd49-2b25-4ced-9a2c-3382c4d0479c")
 			(effects
 				(font
 					(size 1 1)
@@ -165,7 +165,7 @@
 		(fp_text value "MountingHole"
 			(at 0 3)
 			(layer "F.Fab")
-			(uuid "43ed4182-8f79-41de-9a56-1551e65bd3aa")
+			(uuid "178ee0b5-330c-4b5e-8ad4-2c9628fc2dee")
 			(effects
 				(font
 					(size 1 1)
@@ -183,12 +183,12 @@
 	)
 	(footprint "MountingHole:MountingHole_3.2mm_M3"
 		(layer "F.Cu")
-		(uuid "01a15e4d-5bd5-4a35-a939-95e9be9bf91f")
+		(uuid "b4db4d94-ad44-4148-8104-c36e51fabe8a")
 		(at 167.0 187.0)
 		(fp_text reference "MH4"
 			(at 0 -3)
 			(layer "F.SilkS")
-			(uuid "13cd2043-aa16-420f-93a6-3d16fe242a23")
+			(uuid "1016d71e-4b16-4700-a2f5-b693c8f3102e")
 			(effects
 				(font
 					(size 1 1)
@@ -199,7 +199,7 @@
 		(fp_text value "MountingHole"
 			(at 0 3)
 			(layer "F.Fab")
-			(uuid "934783f6-5be1-4654-90ad-6d967dbf58fe")
+			(uuid "05201156-911b-4780-911c-24e8e4a11c1a")
 			(effects
 				(font
 					(size 1 1)
@@ -217,12 +217,12 @@
 	)
 	(footprint "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical"
 		(layer "F.Cu")
-		(uuid "bdca1f42-b357-4294-bce3-e61505b280e5")
+		(uuid "785c334d-6c61-40fa-898e-8ec688f04058")
 		(at 105.0 108.0)
 		(fp_text reference "J1"
 			(at 0 -3.5)
 			(layer "F.SilkS")
-			(uuid "482bb9a5-d157-4c66-8956-5d3fac6b39db")
+			(uuid "5321d975-b118-4202-a6c2-d55acca1e1ed")
 			(effects
 				(font
 					(size 1 1)
@@ -233,7 +233,7 @@
 		(fp_text value "Power Input"
 			(at 0 3.5)
 			(layer "F.Fab")
-			(uuid "b6fa069f-59b1-4213-b098-d7ea36841a77")
+			(uuid "3cf89430-f767-4e6f-8727-23eb6ae79023")
 			(effects
 				(font
 					(size 1 1)
@@ -258,12 +258,12 @@
 	)
 	(footprint "Fuse:Fuse_1206_3216Metric"
 		(layer "F.Cu")
-		(uuid "81ad1693-ec23-42f6-a8a1-b25c97c52996")
+		(uuid "b0b5d404-d9d5-4cba-bfea-76390047a4d7")
 		(at 114.0 108.0)
 		(fp_text reference "F1"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "7de1818f-6ba9-4cdd-a675-230533fd0053")
+			(uuid "18958db6-a8a9-4afe-b222-fa5744a23bcd")
 			(effects
 				(font
 					(size 1 1)
@@ -274,7 +274,7 @@
 		(fp_text value "15A"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "4e524e3c-610b-472e-94cb-67c27552d8de")
+			(uuid "ae98f78e-cc8c-4ecb-9acc-266dfb9f0b8c")
 			(effects
 				(font
 					(size 1 1)
@@ -299,12 +299,12 @@
 	)
 	(footprint "Diode_SMD:D_SMA"
 		(layer "F.Cu")
-		(uuid "e6e28862-e524-4056-9cde-86c0aa1779c8")
+		(uuid "e379f406-4959-4efd-a7ba-2b5ff1037ab1")
 		(at 122.0 108.0)
 		(fp_text reference "D1"
 			(at 0 -2)
 			(layer "F.SilkS")
-			(uuid "e63702a5-0e26-4853-8987-61449dd4b38a")
+			(uuid "87adb7e2-dbc2-4353-978a-dd25f4a992d6")
 			(effects
 				(font
 					(size 1 1)
@@ -315,7 +315,7 @@
 		(fp_text value "SMBJ24A"
 			(at 0 2)
 			(layer "F.Fab")
-			(uuid "6c27fcd0-829a-487c-82ed-7704708dbdc3")
+			(uuid "f52ce358-36b6-4208-a99f-bac9215e0e44")
 			(effects
 				(font
 					(size 1 1)
@@ -340,12 +340,12 @@
 	)
 	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "3b0175dc-c2e1-4174-ab42-a3a19b912459")
+		(uuid "a5d0792e-ee5f-4ade-9209-429b8bcbb895")
 		(at 130.0 108.0)
 		(fp_text reference "C1"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "597a9b25-cea1-416c-85c8-212540d22e93")
+			(uuid "6b72df6f-7cf4-4fd8-a3d8-00baf0f957d1")
 			(effects
 				(font
 					(size 1 1)
@@ -356,7 +356,7 @@
 		(fp_text value "470uF"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "183fc89f-c171-438a-91d0-cdedf7c9833b")
+			(uuid "0d50e2af-f117-40b2-a77d-174d274db404")
 			(effects
 				(font
 					(size 1 1)
@@ -381,12 +381,12 @@
 	)
 	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "91443c8b-1234-4971-8937-72f0c965307d")
+		(uuid "27d2f36a-a277-4bb9-a590-94dbd2e2f41a")
 		(at 130.0 114.0)
 		(fp_text reference "C2"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "d74adee8-6eb1-480f-805e-7f07412ee2a4")
+			(uuid "d89fec4d-1555-4962-a118-a2a24fd817ca")
 			(effects
 				(font
 					(size 1 1)
@@ -397,7 +397,7 @@
 		(fp_text value "100nF"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "8f92974d-3028-4e8c-9a8f-54050a59ccd9")
+			(uuid "b7183f10-0c70-4c26-ad2d-690697f0c7af")
 			(effects
 				(font
 					(size 1 1)
@@ -422,12 +422,12 @@
 	)
 	(footprint "Package_TO_SOT_SMD:TO-263-5_TabPin3"
 		(layer "F.Cu")
-		(uuid "ac09e915-c0a8-4188-b1ea-e631c77ae2f3")
+		(uuid "200c416e-bd97-450b-b7a6-c14076e2c1b0")
 		(at 112.0 122.0)
 		(fp_text reference "U1"
 			(at 0 -5)
 			(layer "F.SilkS")
-			(uuid "95f68b4b-2de2-4f9c-92f5-21611862940b")
+			(uuid "a2880f8f-02ba-4823-a512-922680b197cf")
 			(effects
 				(font
 					(size 1 1)
@@ -438,7 +438,7 @@
 		(fp_text value "LM2596-5.0"
 			(at 0 5)
 			(layer "F.Fab")
-			(uuid "910a9ec1-5ac3-47a2-9b16-c8dcb038ba8b")
+			(uuid "f1393627-8dd9-4f22-8164-66af02d30095")
 			(effects
 				(font
 					(size 1 1)
@@ -479,12 +479,12 @@
 	)
 	(footprint "Inductor_SMD:L_1210_3225Metric"
 		(layer "F.Cu")
-		(uuid "db13a9ee-132c-46f5-815c-febce60fcb16")
+		(uuid "e5429d3e-87ad-45ba-adc3-54aadfc313ad")
 		(at 126.0 122.0)
 		(fp_text reference "L1"
 			(at 0 -2)
 			(layer "F.SilkS")
-			(uuid "6b53a690-f64d-4dd6-9f06-f04340a743ea")
+			(uuid "51a8a097-1c35-4500-a2c4-08704036181f")
 			(effects
 				(font
 					(size 1 1)
@@ -495,7 +495,7 @@
 		(fp_text value "33uH"
 			(at 0 2)
 			(layer "F.Fab")
-			(uuid "76ec90b0-dff8-4f9f-9823-022c24a682a6")
+			(uuid "867c8578-19a0-4940-b554-7176f314c299")
 			(effects
 				(font
 					(size 1 1)
@@ -520,12 +520,12 @@
 	)
 	(footprint "Diode_SMD:D_SMA"
 		(layer "F.Cu")
-		(uuid "3c9920fe-cd6a-4322-8573-63e990c6fbc9")
+		(uuid "dab752f9-6597-4485-ba2b-51bba0085c05")
 		(at 119.0 130.0)
 		(fp_text reference "D2"
 			(at 0 -2)
 			(layer "F.SilkS")
-			(uuid "148d3d6b-bfc6-4754-a826-5d2b82390ed2")
+			(uuid "27ffaa67-57a0-4c73-8170-7f89d1f1184b")
 			(effects
 				(font
 					(size 1 1)
@@ -536,7 +536,7 @@
 		(fp_text value "SS34"
 			(at 0 2)
 			(layer "F.Fab")
-			(uuid "e57148e1-2eec-4ee7-bd1e-cf41224f02ab")
+			(uuid "897a3a29-98d6-4c51-bee2-df90da6fb30c")
 			(effects
 				(font
 					(size 1 1)
@@ -561,12 +561,12 @@
 	)
 	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "2082b01a-78af-4cff-87e5-946d82ceebe9")
+		(uuid "a625bfa7-e8ce-4818-8396-0cc4d96b1b0b")
 		(at 106.0 130.0)
 		(fp_text reference "C3"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "14e326e8-8fa0-4fec-b614-4a041e495d79")
+			(uuid "eecbab42-e1ff-458f-aeef-1fcafb8f8e78")
 			(effects
 				(font
 					(size 1 1)
@@ -577,7 +577,7 @@
 		(fp_text value "220uF"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "c26f552d-dc7b-4ebc-9bad-18acb2c21910")
+			(uuid "60457708-f5d6-4c46-a9b8-0fd4e167f072")
 			(effects
 				(font
 					(size 1 1)
@@ -602,12 +602,12 @@
 	)
 	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "edf7d654-3d15-42c4-80bc-c2b42c23dff4")
+		(uuid "68293477-6ef9-485b-bb26-a114fd3f1678")
 		(at 130.0 130.0)
 		(fp_text reference "C4"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "883a9dc4-ff63-4cb0-8cba-24169e76481a")
+			(uuid "6b3f0085-ef2f-4b3a-858a-69bbcd5476a2")
 			(effects
 				(font
 					(size 1 1)
@@ -618,7 +618,7 @@
 		(fp_text value "220uF"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "9fd14cc6-f254-441d-b3f6-0eac963bd3a6")
+			(uuid "144a4863-664d-4624-8914-c095c5fe2bb3")
 			(effects
 				(font
 					(size 1 1)
@@ -643,12 +643,12 @@
 	)
 	(footprint "Package_TO_SOT_SMD:SOT-223-3_TabPin2"
 		(layer "F.Cu")
-		(uuid "71a40cc1-c047-4ea6-be62-fbf2290e97bc")
+		(uuid "2d5e98dc-ce58-48bf-aa36-1a555ea4847e")
 		(at 144.0 122.0)
 		(fp_text reference "U2"
 			(at 0 -4)
 			(layer "F.SilkS")
-			(uuid "eeb880e2-ef97-4266-b32d-f55b72db169b")
+			(uuid "4b371681-9921-448e-93a5-f45e000fb976")
 			(effects
 				(font
 					(size 1 1)
@@ -659,7 +659,7 @@
 		(fp_text value "AMS1117-3.3"
 			(at 0 4)
 			(layer "F.Fab")
-			(uuid "fc8aef40-c023-402e-a81b-781718cc16c1")
+			(uuid "82a6f473-b2a3-4c01-b89a-b9503d60efe6")
 			(effects
 				(font
 					(size 1 1)
@@ -694,12 +694,12 @@
 	)
 	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "7d5d1c24-28a2-4961-99db-c8bf56b357ae")
+		(uuid "777e2e57-3fcf-4449-ae9d-6eca7008c207")
 		(at 138.0 130.0)
 		(fp_text reference "C5"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "14cf26db-4b37-419d-9e12-4b7d26bfbf8e")
+			(uuid "1dd5e74f-b7d8-488e-abac-459382b81b97")
 			(effects
 				(font
 					(size 1 1)
@@ -710,7 +710,7 @@
 		(fp_text value "10uF"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "8a987d79-2432-4f6e-af28-75063657ed9c")
+			(uuid "4156f1f2-f73b-4e4e-ac32-85bb0406dd81")
 			(effects
 				(font
 					(size 1 1)
@@ -735,12 +735,12 @@
 	)
 	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "5d1776e0-8b8f-482d-bb61-6cdb61556375")
+		(uuid "0520301e-bd12-43b7-9bc9-4055fb466253")
 		(at 150.0 130.0)
 		(fp_text reference "C6"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "d7a9516f-1748-4ff6-9d45-1eb0c7983708")
+			(uuid "8f015670-e677-4b17-8647-5067d360d33e")
 			(effects
 				(font
 					(size 1 1)
@@ -751,7 +751,7 @@
 		(fp_text value "10uF"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "49b6a66d-22c3-4b0a-8ccc-4ba0cb9e80c3")
+			(uuid "284ab9c7-2c22-47b3-9e46-0c5f8d28cda5")
 			(effects
 				(font
 					(size 1 1)
@@ -776,12 +776,12 @@
 	)
 	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "a8ca578b-1866-49a5-8165-faf7473e9b9a")
+		(uuid "c4b615dd-43e7-4351-9e3b-c0cdc727a1c7")
 		(at 134.0 137.0)
 		(fp_text reference "C7"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "98d5cd95-92ea-4387-842b-837171ce5f0b")
+			(uuid "13f2a97f-b20b-480d-90a9-11478d659ab3")
 			(effects
 				(font
 					(size 1 1)
@@ -792,7 +792,7 @@
 		(fp_text value "100nF"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "a3fc3102-f4dc-4ccf-a6ea-8b13934ef54e")
+			(uuid "e564cf3f-f1a7-4e4e-88a1-e9d1e11e7607")
 			(effects
 				(font
 					(size 1 1)
@@ -817,12 +817,12 @@
 	)
 	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "e5caa138-6ecf-40fd-9fb7-bbddf08f666d")
+		(uuid "278faa03-28e1-49fe-b5e9-5600fdbb923e")
 		(at 140.0 137.0)
 		(fp_text reference "C8"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "379db366-6937-4020-9baf-7ff8da4fa4bd")
+			(uuid "c6311014-f763-4361-beff-1dd5d2a9e913")
 			(effects
 				(font
 					(size 1 1)
@@ -833,7 +833,7 @@
 		(fp_text value "100nF"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "ca133648-11ac-46e1-900d-10d3bd9dba3f")
+			(uuid "ed698c21-ebc1-4b78-afef-93ee7838e5ab")
 			(effects
 				(font
 					(size 1 1)
@@ -858,12 +858,12 @@
 	)
 	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "385fdce1-652c-4205-a8e5-b06e6304f351")
+		(uuid "258e7e37-73ec-42d6-af52-d60068dc50a9")
 		(at 146.0 137.0)
 		(fp_text reference "C9"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "c94d2c26-069b-4c5f-aa6b-a58c987e8033")
+			(uuid "0c8882c6-262b-4f2c-b98f-35bb1bf0c1d3")
 			(effects
 				(font
 					(size 1 1)
@@ -874,7 +874,7 @@
 		(fp_text value "4.7uF"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "a698092e-c444-4adb-a650-68b0104c61ef")
+			(uuid "8eb065d2-f610-4713-ac6f-1f10ec7b2507")
 			(effects
 				(font
 					(size 1 1)
@@ -899,12 +899,12 @@
 	)
 	(footprint "Crystal:Crystal_HC49-4H_Vertical"
 		(layer "F.Cu")
-		(uuid "46909929-3206-484c-b8bc-ce6149c2aaca")
+		(uuid "d870c4ff-5ff1-4e2a-955b-050c32693d21")
 		(at 152.0 137.0)
 		(fp_text reference "Y1"
 			(at 0 -3)
 			(layer "F.SilkS")
-			(uuid "e0804c9a-f109-4924-9fc8-aa5447bda491")
+			(uuid "1e655979-fc70-4a6a-813f-dac9896c26b2")
 			(effects
 				(font
 					(size 1 1)
@@ -915,7 +915,7 @@
 		(fp_text value "8MHz"
 			(at 0 3)
 			(layer "F.Fab")
-			(uuid "8349e9e9-2403-40ea-bdeb-b64fc6736507")
+			(uuid "7a5d8be1-a54c-47fe-a283-5e877b2a68a6")
 			(effects
 				(font
 					(size 1 1)
@@ -940,12 +940,12 @@
 	)
 	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "4fe6349e-c403-4b7e-a78f-cd81cd0c5ebc")
+		(uuid "ccfe7c3a-29e5-4444-a0c5-9af4f4beb6e6")
 		(at 160.0 137.0)
 		(fp_text reference "C10"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "6ef8dfda-0b0e-43ac-a312-0f35a92ff380")
+			(uuid "197556ed-4e85-4176-9045-7649b7ef9702")
 			(effects
 				(font
 					(size 1 1)
@@ -956,7 +956,7 @@
 		(fp_text value "20pF"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "70909369-99c2-41e5-a920-8f619a5892ba")
+			(uuid "707c2ea3-04a0-47e5-8cf3-735d96989829")
 			(effects
 				(font
 					(size 1 1)
@@ -981,12 +981,12 @@
 	)
 	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "6834ffba-6213-432d-a7ca-598641e96e8d")
+		(uuid "570ea3b0-0ef6-474e-9a63-d5c92a2dfa4c")
 		(at 160.0 143.0)
 		(fp_text reference "C11"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "a5761c09-3372-4257-941a-539acd5e920d")
+			(uuid "6102bac9-467b-4806-bce9-51a10bbf01ed")
 			(effects
 				(font
 					(size 1 1)
@@ -997,7 +997,7 @@
 		(fp_text value "20pF"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "9e3810cd-d6c7-4d20-aa11-3c6f0c600f5c")
+			(uuid "b577524f-1a83-40a3-ab01-219736db57ee")
 			(effects
 				(font
 					(size 1 1)
@@ -1022,12 +1022,12 @@
 	)
 	(footprint "Package_SO:HTSSOP-56-1EP_6.1x14mm_P0.5mm_EP3.61x6.35mm"
 		(layer "F.Cu")
-		(uuid "edd7f8d9-9872-4d0d-8485-cacf87e16648")
+		(uuid "9d9cc03c-e0c9-4dcb-9cf5-91f4276be3ff")
 		(at 114.0 150.0)
 		(fp_text reference "U3"
 			(at 0 -8)
 			(layer "F.SilkS")
-			(uuid "db737865-d497-46b6-a30e-51139b6f3895")
+			(uuid "b109e319-2f88-416f-8c32-835687ee2b35")
 			(effects
 				(font
 					(size 1 1)
@@ -1038,7 +1038,7 @@
 		(fp_text value "DRV8301"
 			(at 0 8)
 			(layer "F.Fab")
-			(uuid "744aca7d-13cc-403c-865b-e7b93fd721c0")
+			(uuid "3b0dda6f-28c1-4b14-8d1f-d16710632363")
 			(effects
 				(font
 					(size 1 1)
@@ -1447,12 +1447,12 @@
 	)
 	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "406a0482-0467-4bdf-996b-621abca394aa")
+		(uuid "05ad0a61-6296-40e4-9dbd-854ad51abf64")
 		(at 104.0 147.0)
 		(fp_text reference "C12"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "6d55303a-5eac-4714-b184-be00c1688162")
+			(uuid "1babc7db-ffae-4acd-b3f3-7183f8b0e8b5")
 			(effects
 				(font
 					(size 1 1)
@@ -1463,7 +1463,7 @@
 		(fp_text value "100nF"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "e9c1c905-9ddf-4be2-aae8-bed11f605108")
+			(uuid "7581430c-b0f1-48e9-9fec-0d8b2008dc44")
 			(effects
 				(font
 					(size 1 1)
@@ -1488,12 +1488,12 @@
 	)
 	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "1990955c-cf87-4c65-93c1-f9786ae79ef6")
+		(uuid "c66bf486-cd65-4271-92e7-97f33cad806f")
 		(at 104.0 153.0)
 		(fp_text reference "C13"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "1cf7d96c-8e7a-436c-98f4-ff6db265173d")
+			(uuid "1fc38f22-31ed-47a6-aa0e-7ce5aa45f968")
 			(effects
 				(font
 					(size 1 1)
@@ -1504,7 +1504,7 @@
 		(fp_text value "100nF"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "09805460-d3b0-46cf-b042-8c8de707fd0a")
+			(uuid "8d7ae2cf-f0b7-44eb-b735-db6b8d4b7bcf")
 			(effects
 				(font
 					(size 1 1)
@@ -1529,12 +1529,12 @@
 	)
 	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "874b69c1-b53d-4b16-99fc-1d4c83668d94")
+		(uuid "40c9ff34-569f-411f-b8e3-770d3f596694")
 		(at 104.0 159.0)
 		(fp_text reference "C14"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "3c7580fa-41c7-45fc-95b6-078e5dec2973")
+			(uuid "4f6450e9-3728-47cd-9187-c420f5aef4b2")
 			(effects
 				(font
 					(size 1 1)
@@ -1545,7 +1545,7 @@
 		(fp_text value "100nF"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "1804bd3c-55dc-4b01-8d39-6a1423d45d47")
+			(uuid "65d4d0df-b3be-4993-bdfa-e92fb0a5f9be")
 			(effects
 				(font
 					(size 1 1)
@@ -1570,12 +1570,12 @@
 	)
 	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "27627456-7631-4c02-acf6-16beb26a6704")
+		(uuid "ed65af59-a609-46be-acfb-71f085d05598")
 		(at 124.0 147.0)
 		(fp_text reference "C15"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "d11e30a0-344a-4bc9-9cf3-b938be81314d")
+			(uuid "397521bc-82ca-4bc5-96c1-61f6a53e16a1")
 			(effects
 				(font
 					(size 1 1)
@@ -1586,7 +1586,7 @@
 		(fp_text value "100nF"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "8cdd4c03-0328-4f4d-90b2-09f9a5cb4fe7")
+			(uuid "ba3dcc9d-d981-4c45-b3d0-b58252ea2b7b")
 			(effects
 				(font
 					(size 1 1)
@@ -1611,12 +1611,12 @@
 	)
 	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "5795825a-ecba-4929-aa36-01eafe985e04")
+		(uuid "ec1fb045-f436-489b-ac13-c53ec12b0725")
 		(at 124.0 153.0)
 		(fp_text reference "C16"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "f48d36e9-cd12-4b3c-8de0-6c8e1eac89fc")
+			(uuid "c4ea2202-0416-4443-8383-494b3904bb9c")
 			(effects
 				(font
 					(size 1 1)
@@ -1627,7 +1627,7 @@
 		(fp_text value "10uF"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "9aa4c569-fef3-427d-9bf3-07d216c6e962")
+			(uuid "a3d0b16f-19d5-434b-9b73-ab79ed033d34")
 			(effects
 				(font
 					(size 1 1)
@@ -1652,12 +1652,12 @@
 	)
 	(footprint "Package_QFP:LQFP-32_7x7mm_P0.8mm"
 		(layer "F.Cu")
-		(uuid "8c0fc7ec-e855-4497-b29d-0984432fc63f")
+		(uuid "527237e1-9a6e-4a20-b526-3df833bc5da2")
 		(at 140.0 150.0)
 		(fp_text reference "U10"
 			(at 0 -5)
 			(layer "F.SilkS")
-			(uuid "974b3d0f-7993-4982-8c77-700e9ddf34ab")
+			(uuid "43dc94f9-334b-4b49-9088-df783399f2f5")
 			(effects
 				(font
 					(size 1 1)
@@ -1668,7 +1668,7 @@
 		(fp_text value "STM32G431K8Tx"
 			(at 0 5)
 			(layer "F.Fab")
-			(uuid "e308474b-5e84-4e87-87a2-cbb9d762d6e5")
+			(uuid "40e1052c-f145-49f2-a220-f303a042a592")
 			(effects
 				(font
 					(size 1 1)
@@ -1903,12 +1903,12 @@
 	)
 	(footprint "Package_TO_SOT_THT:TO-220-3_Vertical"
 		(layer "F.Cu")
-		(uuid "ca8309e6-dfb2-4f08-909d-2ba6b51d8a4b")
+		(uuid "fb551f4e-c7aa-4c72-85e2-f9de6905b903")
 		(at 108.0 168.0)
 		(fp_text reference "Q1"
 			(at 0 -5)
 			(layer "F.SilkS")
-			(uuid "747f43ff-3c6c-4ba0-8a3e-5f6cdee35fd8")
+			(uuid "2afc9eca-a0b6-4c7d-84d8-ada40f0769b7")
 			(effects
 				(font
 					(size 1 1)
@@ -1919,7 +1919,7 @@
 		(fp_text value "IRLZ44N"
 			(at 0 5)
 			(layer "F.Fab")
-			(uuid "530d542c-e3df-4e8f-a8e8-26d4a0327ddb")
+			(uuid "3480f0cb-899d-4beb-ac02-f5dc68db5f3a")
 			(effects
 				(font
 					(size 1 1)
@@ -1951,12 +1951,12 @@
 	)
 	(footprint "Package_TO_SOT_THT:TO-220-3_Vertical"
 		(layer "F.Cu")
-		(uuid "a414b6b5-7e69-42a5-8f94-d13304efebb9")
+		(uuid "7de2da34-983e-4c0b-9089-d36b648f1b07")
 		(at 108.0 176.0)
 		(fp_text reference "Q2"
 			(at 0 -5)
 			(layer "F.SilkS")
-			(uuid "b9c84aa2-cc0d-49d5-89d2-0ae3a13c40ed")
+			(uuid "a1d5c63d-58b3-4bb0-99f1-dc1b7def55e2")
 			(effects
 				(font
 					(size 1 1)
@@ -1967,7 +1967,7 @@
 		(fp_text value "IRLZ44N"
 			(at 0 5)
 			(layer "F.Fab")
-			(uuid "9d344565-18eb-4453-a8c3-cdef5801e60e")
+			(uuid "0dcb06d9-1620-4ebc-8823-583c5e371d38")
 			(effects
 				(font
 					(size 1 1)
@@ -1999,12 +1999,12 @@
 	)
 	(footprint "Package_TO_SOT_THT:TO-220-3_Vertical"
 		(layer "F.Cu")
-		(uuid "dd636bc8-984f-4bf8-aca7-550224496a03")
+		(uuid "a0d92a23-53f1-4b3b-9ad5-8fca2ae631d9")
 		(at 124.0 168.0)
 		(fp_text reference "Q3"
 			(at 0 -5)
 			(layer "F.SilkS")
-			(uuid "503470ad-46d7-48a6-be0a-b1c5ebedbcda")
+			(uuid "faab756d-51fb-4411-8caa-854ddbc014a6")
 			(effects
 				(font
 					(size 1 1)
@@ -2015,7 +2015,7 @@
 		(fp_text value "IRLZ44N"
 			(at 0 5)
 			(layer "F.Fab")
-			(uuid "d26439ad-1bd9-4da7-bbd4-146540202cda")
+			(uuid "4ef3e442-aa03-429c-8fb8-b567182698df")
 			(effects
 				(font
 					(size 1 1)
@@ -2047,12 +2047,12 @@
 	)
 	(footprint "Package_TO_SOT_THT:TO-220-3_Vertical"
 		(layer "F.Cu")
-		(uuid "9e6710f1-d8d5-4fd9-bf48-974b8068433a")
+		(uuid "cf422510-b16b-44b8-bf70-587bd88e761c")
 		(at 124.0 176.0)
 		(fp_text reference "Q4"
 			(at 0 -5)
 			(layer "F.SilkS")
-			(uuid "34b8c602-e5d6-4aa2-b1a3-e89bcb54feb2")
+			(uuid "4e62caa7-41c6-4ad4-a11e-5e4bd7a5798f")
 			(effects
 				(font
 					(size 1 1)
@@ -2063,7 +2063,7 @@
 		(fp_text value "IRLZ44N"
 			(at 0 5)
 			(layer "F.Fab")
-			(uuid "0e32d3b1-0ff9-4911-8e50-8b16201a2867")
+			(uuid "349d0f75-5d6e-428b-ae59-e79b4654d56e")
 			(effects
 				(font
 					(size 1 1)
@@ -2095,12 +2095,12 @@
 	)
 	(footprint "Package_TO_SOT_THT:TO-220-3_Vertical"
 		(layer "F.Cu")
-		(uuid "dfeb52ff-17e3-427c-a109-f31fe1bbaf62")
+		(uuid "cc340d10-bb98-4b8c-91a9-8c8fedfb267e")
 		(at 140.0 168.0)
 		(fp_text reference "Q5"
 			(at 0 -5)
 			(layer "F.SilkS")
-			(uuid "77a75323-44aa-46dd-8f3f-af80a83cb252")
+			(uuid "a3283243-a997-4a1a-871c-ee14a0f300c1")
 			(effects
 				(font
 					(size 1 1)
@@ -2111,7 +2111,7 @@
 		(fp_text value "IRLZ44N"
 			(at 0 5)
 			(layer "F.Fab")
-			(uuid "b69163b1-2b52-495a-a726-52cef2e2a9ac")
+			(uuid "9a235b28-9b40-4637-b3f0-74e37cd44028")
 			(effects
 				(font
 					(size 1 1)
@@ -2143,12 +2143,12 @@
 	)
 	(footprint "Package_TO_SOT_THT:TO-220-3_Vertical"
 		(layer "F.Cu")
-		(uuid "a547ca64-5cb2-4688-ae83-863ee7b8aeee")
+		(uuid "7cd1ede2-a084-4c50-ba08-843ce47c5c9c")
 		(at 140.0 176.0)
 		(fp_text reference "Q6"
 			(at 0 -5)
 			(layer "F.SilkS")
-			(uuid "efc11bd0-3816-45e0-ac8e-01cd99a3a7d9")
+			(uuid "4041558e-e88b-4499-9606-3017ec71c7a2")
 			(effects
 				(font
 					(size 1 1)
@@ -2159,7 +2159,7 @@
 		(fp_text value "IRLZ44N"
 			(at 0 5)
 			(layer "F.Fab")
-			(uuid "591337f2-e01a-44c1-93bd-2a9ee81efd7e")
+			(uuid "7ecf1de0-3ec6-4304-bd9e-1bce1dd6f64a")
 			(effects
 				(font
 					(size 1 1)
@@ -2191,12 +2191,12 @@
 	)
 	(footprint "Resistor_SMD:R_2512_6332Metric"
 		(layer "F.Cu")
-		(uuid "7706729f-e0aa-4dec-bb7d-59cd4b7faf3a")
+		(uuid "622348a9-84ff-4615-b8cb-86479c7c5147")
 		(at 108.0 184.0)
 		(fp_text reference "R10"
 			(at 0 -2)
 			(layer "F.SilkS")
-			(uuid "5dcf244d-40b0-4d10-8fb6-09bbf036ae89")
+			(uuid "782a8122-29af-4dac-9e9f-1bd5cbbd2172")
 			(effects
 				(font
 					(size 1 1)
@@ -2207,7 +2207,7 @@
 		(fp_text value "5mR"
 			(at 0 2)
 			(layer "F.Fab")
-			(uuid "c2a63cf2-d836-49dd-ae1e-b974b48b1962")
+			(uuid "a1560938-261c-4a51-90ab-87aa6ac2f0c7")
 			(effects
 				(font
 					(size 1 1)
@@ -2232,12 +2232,12 @@
 	)
 	(footprint "Resistor_SMD:R_2512_6332Metric"
 		(layer "F.Cu")
-		(uuid "63640572-956b-40ce-9148-a3b913c1fc54")
+		(uuid "f30e3695-e5f0-4252-9407-65dd947bb5ef")
 		(at 124.0 184.0)
 		(fp_text reference "R11"
 			(at 0 -2)
 			(layer "F.SilkS")
-			(uuid "33c72fdb-9f9c-40dd-9918-969b9303c47f")
+			(uuid "49a774c2-1dc5-47be-8c78-ce321aba44a1")
 			(effects
 				(font
 					(size 1 1)
@@ -2248,7 +2248,7 @@
 		(fp_text value "5mR"
 			(at 0 2)
 			(layer "F.Fab")
-			(uuid "bd8baa73-25aa-463c-a674-149167daec18")
+			(uuid "dfdd8e33-4345-4a58-bf5b-8e8f17a46641")
 			(effects
 				(font
 					(size 1 1)
@@ -2273,12 +2273,12 @@
 	)
 	(footprint "Resistor_SMD:R_2512_6332Metric"
 		(layer "F.Cu")
-		(uuid "ac036ed7-d7ed-4007-9774-3eda473e77fb")
+		(uuid "bf463182-b21b-4663-9b27-859ab4e0fce6")
 		(at 140.0 184.0)
 		(fp_text reference "R12"
 			(at 0 -2)
 			(layer "F.SilkS")
-			(uuid "27288011-7223-49df-980a-eca1f5225888")
+			(uuid "171d7883-05a5-410c-bfb3-1915dcf2ebee")
 			(effects
 				(font
 					(size 1 1)
@@ -2289,7 +2289,7 @@
 		(fp_text value "5mR"
 			(at 0 2)
 			(layer "F.Fab")
-			(uuid "c8e6004f-4bde-4e03-becb-b183862f0157")
+			(uuid "2cb10848-7abb-4c86-8e49-975ccf9c37dc")
 			(effects
 				(font
 					(size 1 1)
@@ -2314,12 +2314,12 @@
 	)
 	(footprint "Resistor_SMD:R_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "b69143a4-7c4d-41de-9a92-7b34dc47fbca")
+		(uuid "4fb232c7-2848-451c-9340-851502e22e7a")
 		(at 108.0 162.0)
 		(fp_text reference "R20"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "4c5a1679-ea4e-4c78-b2ec-73c29d070549")
+			(uuid "d019fac0-9fed-431b-8ac8-2fcc5be054ed")
 			(effects
 				(font
 					(size 1 1)
@@ -2330,7 +2330,7 @@
 		(fp_text value "22"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "c22ce486-8e9e-4f4c-a914-759cffb23539")
+			(uuid "73274ae2-0e2d-433c-b99d-f2572202db99")
 			(effects
 				(font
 					(size 1 1)
@@ -2355,12 +2355,12 @@
 	)
 	(footprint "Resistor_SMD:R_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "74d23b11-0324-43be-b7e3-d5f6bff7ff86")
+		(uuid "7d53fae7-0241-4ee2-ab0e-a498b26a0f0b")
 		(at 124.0 162.0)
 		(fp_text reference "R21"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "af2d9327-5122-4919-9bb9-be79b670492f")
+			(uuid "1885344d-b26b-4f12-bf37-1c4c016348e7")
 			(effects
 				(font
 					(size 1 1)
@@ -2371,7 +2371,7 @@
 		(fp_text value "22"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "f91e175d-ab26-4a6a-a491-f83b2e2e68a5")
+			(uuid "fba70875-8db1-4455-b70e-9eba31c9cdf3")
 			(effects
 				(font
 					(size 1 1)
@@ -2396,12 +2396,12 @@
 	)
 	(footprint "Resistor_SMD:R_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "0c2a3fdf-8c01-4116-a0ed-5b61dd56eb8b")
+		(uuid "095f33c7-3fb0-4edd-8d2e-08ebd0e107ac")
 		(at 140.0 162.0)
 		(fp_text reference "R22"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "68a50a69-1684-49f3-8025-5fda96a290ed")
+			(uuid "e01c4838-24aa-4646-ade0-00085f23135f")
 			(effects
 				(font
 					(size 1 1)
@@ -2412,7 +2412,7 @@
 		(fp_text value "22"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "74b27ce1-8f89-4b94-b88c-8c5b8facb465")
+			(uuid "281fbc66-a115-4d20-be2f-384166161b54")
 			(effects
 				(font
 					(size 1 1)
@@ -2437,12 +2437,12 @@
 	)
 	(footprint "Connector_PinHeader_2.54mm:PinHeader_1x03_P2.54mm_Vertical"
 		(layer "F.Cu")
-		(uuid "c25f2325-5eaa-4ba5-b93a-8736c570235e")
+		(uuid "7309cd15-e4af-4e79-9f59-3d1412eb1ab1")
 		(at 165.0 176.0)
 		(fp_text reference "J2"
 			(at 0 -4.8)
 			(layer "F.SilkS")
-			(uuid "58c5beab-2dca-48fe-b899-c3dc19dcbbdb")
+			(uuid "74f98a89-a85d-4785-ba3f-6b9804980de8")
 			(effects
 				(font
 					(size 1 1)
@@ -2453,7 +2453,7 @@
 		(fp_text value "Motor Output"
 			(at 0 4.8)
 			(layer "F.Fab")
-			(uuid "131f7a36-a119-465c-b01a-6d3f5c9fcb4e")
+			(uuid "84a187d7-8c34-458e-ac23-b0fe5b43259f")
 			(effects
 				(font
 					(size 1 1)
@@ -2485,12 +2485,12 @@
 	)
 	(footprint "Connector_PinHeader_2.54mm:PinHeader_1x05_P2.54mm_Vertical"
 		(layer "F.Cu")
-		(uuid "733f5a5d-f74d-425f-9f4d-59544d9fd285")
+		(uuid "48fb9789-a92c-451c-b3b2-e46fa7a9c7ed")
 		(at 165.0 158.0)
 		(fp_text reference "J3"
 			(at 0 -7.3)
 			(layer "F.SilkS")
-			(uuid "0e40b8b1-2f36-43e2-99e5-e5466f8fee83")
+			(uuid "24851407-632c-4b82-acf5-661d392e978f")
 			(effects
 				(font
 					(size 1 1)
@@ -2501,7 +2501,7 @@
 		(fp_text value "Hall Sensors"
 			(at 0 7.3)
 			(layer "F.Fab")
-			(uuid "df70ad75-d829-402a-9645-683cee7c2772")
+			(uuid "ba8e2db7-c8df-48b2-803d-cd28811843c0")
 			(effects
 				(font
 					(size 1 1)
@@ -2547,12 +2547,12 @@
 	)
 	(footprint "Connector_PinHeader_2.54mm:PinHeader_1x06_P2.54mm_Vertical"
 		(layer "F.Cu")
-		(uuid "6af90cf6-c0a8-4d0f-b3ee-0eec5ce9cfbc")
+		(uuid "45aa7077-5efb-4eae-976b-cf082b4758f6")
 		(at 165.0 122.0)
 		(fp_text reference "J4"
 			(at 0 -8.6)
 			(layer "F.SilkS")
-			(uuid "40690489-8882-435b-b4e4-4a76cf34fbad")
+			(uuid "ed39db10-13c5-40f8-8742-8b9ddea51504")
 			(effects
 				(font
 					(size 1 1)
@@ -2563,7 +2563,7 @@
 		(fp_text value "SWD Debug"
 			(at 0 8.6)
 			(layer "F.Fab")
-			(uuid "35fb75c1-7793-4a1a-9fdf-667165ee3027")
+			(uuid "e86cd0c4-8ef3-4696-a471-e1ba32505b06")
 			(effects
 				(font
 					(size 1 1)
@@ -2616,12 +2616,12 @@
 	)
 	(footprint "Resistor_SMD:R_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "4c37090a-b133-43fd-b50b-5716039b3a30")
+		(uuid "5149da9b-11e7-4039-b6c3-a8e3972e52b4")
 		(at 156.0 113.0)
 		(fp_text reference "R3"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "83a188f7-3fc3-4230-ad48-b2f308735248")
+			(uuid "f6849292-19d7-4039-9b2b-fd9fe1e36fb2")
 			(effects
 				(font
 					(size 1 1)
@@ -2632,7 +2632,7 @@
 		(fp_text value "1k"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "856b2dd8-96ce-4c29-89d5-113e8e9444e0")
+			(uuid "8d2ad18e-da96-437e-8c58-1b923c0ef5c2")
 			(effects
 				(font
 					(size 1 1)
@@ -2657,12 +2657,12 @@
 	)
 	(footprint "LED_SMD:LED_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "707d29d2-2a30-4b95-9d1d-7d5b8197ad21")
+		(uuid "93994ed5-cbaa-409a-afc0-0e3f734251fe")
 		(at 156.0 108.0)
 		(fp_text reference "D3"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "5d914b00-d2b4-4f76-b66d-aa1bb74f6a19")
+			(uuid "00e65167-54eb-4d75-9690-c4b59fa75c6e")
 			(effects
 				(font
 					(size 1 1)
@@ -2673,7 +2673,7 @@
 		(fp_text value "LED"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "ae393950-1f22-450d-a748-e87a2643eda1")
+			(uuid "d05ff1cf-92d3-4bb0-ac1a-c4ad3be284eb")
 			(effects
 				(font
 					(size 1 1)
@@ -2698,12 +2698,12 @@
 	)
 	(footprint "Resistor_SMD:R_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "d0e58e6f-43be-4ea4-872e-1d8d5ff08c0b")
+		(uuid "72a81ac9-314f-4bda-a18f-37903a6f3524")
 		(at 162.0 113.0)
 		(fp_text reference "R4"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "92a9eb10-8937-4fc2-aa4f-a19d019f83db")
+			(uuid "5c636986-1572-41d7-bbeb-d7ec0058de4e")
 			(effects
 				(font
 					(size 1 1)
@@ -2714,7 +2714,7 @@
 		(fp_text value "1k"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "4dc3bbe3-a25d-4594-9b27-e1b76905b46d")
+			(uuid "5b4c4561-6346-43c9-8816-527992b8fb89")
 			(effects
 				(font
 					(size 1 1)
@@ -2739,12 +2739,12 @@
 	)
 	(footprint "LED_SMD:LED_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "00818bf4-02d5-4676-9cae-7a24b305e38e")
+		(uuid "2a10cd20-e0ee-4b3b-91a8-a6c581aa80f6")
 		(at 162.0 108.0)
 		(fp_text reference "D4"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "118f86fa-b111-4e67-83cb-7d12424d045c")
+			(uuid "e935da1c-bea0-47d1-8431-6f5cabe42099")
 			(effects
 				(font
 					(size 1 1)
@@ -2755,7 +2755,7 @@
 		(fp_text value "LED"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "f7d4084b-fde3-4a3c-b266-6a602595b7b3")
+			(uuid "ec6dd032-f4a8-43cf-ae14-8466052304c4")
 			(effects
 				(font
 					(size 1 1)
@@ -2780,12 +2780,12 @@
 	)
 	(footprint "Resistor_SMD:R_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "932e01aa-838e-44a2-b891-79bf580bb404")
+		(uuid "70dc559d-e2d4-413e-a766-06e85c6b7dae")
 		(at 149.0 157.0)
 		(fp_text reference "R30"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "cccf9491-d1fb-42a9-ad46-8600003b88b5")
+			(uuid "a8fd364a-b338-42e9-94ee-1940d66bb986")
 			(effects
 				(font
 					(size 1 1)
@@ -2796,7 +2796,7 @@
 		(fp_text value "10k"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "f0f65fde-9dbe-4d5b-bdcb-b744f11aee4c")
+			(uuid "bf6c8a19-ea5a-42b0-b032-ffc3163664b0")
 			(effects
 				(font
 					(size 1 1)
@@ -2821,12 +2821,12 @@
 	)
 	(footprint "Resistor_SMD:R_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "dfaba3f1-0576-432d-a26d-918e2d9ad3a4")
+		(uuid "7a0752ad-daff-4a89-80ff-c5e067264fda")
 		(at 155.0 157.0)
 		(fp_text reference "R31"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "8e325429-78e8-453e-96af-3dc7ec0ea2ed")
+			(uuid "30239a60-b2b5-4f3c-8b0e-a1cd1874cb49")
 			(effects
 				(font
 					(size 1 1)
@@ -2837,7 +2837,7 @@
 		(fp_text value "10k"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "3af1e54a-36da-4bbc-8736-e022946277b7")
+			(uuid "b4ee07da-0bec-440b-b5f4-504627ed62b4")
 			(effects
 				(font
 					(size 1 1)
@@ -2862,12 +2862,12 @@
 	)
 	(footprint "Resistor_SMD:R_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "4c46c27a-0c79-4d76-9a91-8c98e9f2ed54")
+		(uuid "7853ed47-2e33-430b-84f6-cd838dee467a")
 		(at 161.0 157.0)
 		(fp_text reference "R32"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "871bb751-dbb4-4204-8ab8-397f4358b5f9")
+			(uuid "49b534ac-3406-4ce2-a5ff-e1f7a978bc70")
 			(effects
 				(font
 					(size 1 1)
@@ -2878,7 +2878,7 @@
 		(fp_text value "10k"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "53058c33-7ec2-42e6-af87-a656ffe489d1")
+			(uuid "f2d2063d-bab2-4659-a3fc-cdd216ea3346")
 			(effects
 				(font
 					(size 1 1)
@@ -2903,12 +2903,12 @@
 	)
 	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "743ddcc5-da41-4111-8c5c-5874faaf3311")
+		(uuid "f8b59a52-306e-469f-b75a-d4a608f84d97")
 		(at 149.0 161.0)
 		(fp_text reference "C30"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "f958013f-1ee2-4e99-9d2e-83471f10b1fb")
+			(uuid "fe3503cf-098a-4cfc-b687-b37fe6210b61")
 			(effects
 				(font
 					(size 1 1)
@@ -2919,7 +2919,7 @@
 		(fp_text value "10nF"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "f1fcfa7a-daed-4efc-b007-2f7072fccf79")
+			(uuid "d5b159d2-5a4e-4725-8bd5-891bdc586680")
 			(effects
 				(font
 					(size 1 1)
@@ -2944,12 +2944,12 @@
 	)
 	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "f185cba6-c25f-4d45-b523-bdb18b1c8adf")
+		(uuid "a8f5144d-52b5-449b-8c41-697e3c4acfab")
 		(at 155.0 161.0)
 		(fp_text reference "C31"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "30d33343-4af0-4043-932a-dfbff0b31f49")
+			(uuid "f6bc7c2e-cfbf-421f-b946-a7699cf84930")
 			(effects
 				(font
 					(size 1 1)
@@ -2960,7 +2960,7 @@
 		(fp_text value "10nF"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "8959b7ee-5e92-4e84-9f98-f4212fa6345d")
+			(uuid "ca16458b-9b39-4de2-b21f-56143d470efd")
 			(effects
 				(font
 					(size 1 1)
@@ -2985,12 +2985,12 @@
 	)
 	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "a4c45388-9d66-4d1d-976a-c00750e10031")
+		(uuid "66d610b5-5557-4b83-a0ed-414c437437fa")
 		(at 161.0 161.0)
 		(fp_text reference "C32"
 			(at 0 -1.5)
 			(layer "F.SilkS")
-			(uuid "735605c6-f0d4-40e5-8916-e4a4ce698129")
+			(uuid "c43d4711-9bed-4476-91bf-575929855ad6")
 			(effects
 				(font
 					(size 1 1)
@@ -3001,7 +3001,7 @@
 		(fp_text value "10nF"
 			(at 0 1.5)
 			(layer "F.Fab")
-			(uuid "2e2cf815-7269-4a8e-898f-c1d4fab4a81c")
+			(uuid "24695503-0e60-43dd-a9a5-02f8c74afaba")
 			(effects
 				(font
 					(size 1 1)
@@ -3028,7 +3028,7 @@
 		(net 4)
 		(net_name "GND")
 		(layer "B.Cu")
-		(uuid "24691c83-1510-4224-a177-56ddf50233d5")
+		(uuid "5299d3e7-8549-43e4-b9d8-65f27e74ef5d")
 		(hatch edge 0.5)
 		(priority 1)
 		(connect_pads (clearance 0.3)
@@ -3044,7 +3044,7 @@
 		(net 1)
 		(net_name "VMOTOR")
 		(layer "F.Cu")
-		(uuid "3c343e8b-48cd-40bf-80b1-e552b93ceca2")
+		(uuid "9a3f5aad-2a8e-4fd2-a2b5-c9b7bae9bfb4")
 		(hatch edge 0.5)
 		(priority 4)
 		(connect_pads (clearance 0.3)
@@ -3060,7 +3060,7 @@
 		(net 2)
 		(net_name "+5V")
 		(layer "F.Cu")
-		(uuid "527442d2-6d03-4491-93c6-52fc1b4e8417")
+		(uuid "420c13e8-b9aa-44ef-8ebe-43b82dc25a8c")
 		(hatch edge 0.5)
 		(priority 3)
 		(connect_pads (clearance 0.3)
@@ -3076,7 +3076,7 @@
 		(net 3)
 		(net_name "+3.3V")
 		(layer "F.Cu")
-		(uuid "6da8d0f2-cc2c-4085-8e01-b06fb4eda243")
+		(uuid "c694c44d-3a82-43a4-90b6-aab260be17ea")
 		(hatch edge 0.5)
 		(priority 2)
 		(connect_pads (clearance 0.3)
@@ -3092,7 +3092,7 @@
 		(net 29)
 		(net_name "PWR_LED")
 		(layer "F.Cu")
-		(uuid "44fd6928-361f-4ad2-b053-e891e5badfcc")
+		(uuid "63eabdc1-31b5-46ae-b555-94299d487b18")
 		(hatch edge 0.5)
 		(priority 1)
 		(connect_pads (clearance 0.3)

--- a/boards/05-bldc-motor-controller/output/bldc_controller.kicad_sch
+++ b/boards/05-bldc-motor-controller/output/bldc_controller.kicad_sch
@@ -2,7 +2,7 @@
 	(version 20231120)
 	(generator "eeschema")
 	(generator_version "9.0")
-	(uuid "c2ad6d06-79e5-4d23-9b3c-4c2187540d5e")
+	(uuid "7145dd34-def2-4dd7-8afe-9c7c611ff298")
 	(paper "A4")
 	(title_block
 		(title "BLDC Motor Controller")
@@ -1077,39 +1077,6 @@
 					(justify left)
 				)
 			)
-			(property "ki_keywords" "Step-Down Voltage Regulator 5V 3A"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "ki_fp_filters" "TO?263*"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "Description" "5V 3A Step-Down Voltage Regulator, TO-263"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
 			(property "Footprint" "Package_TO_SOT_SMD:TO-263-5_TabPin3"
 				(at 1.27 -6.35 0)
 				(show_name no)
@@ -1134,6 +1101,17 @@
 					)
 				)
 			)
+			(property "ki_keywords" "Step-Down Voltage Regulator 5V 3A"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
 			(property "Reference" "U"
 				(at -10.16 6.35 0)
 				(show_name no)
@@ -1143,6 +1121,28 @@
 						(size 1.27 1.27)
 					)
 					(justify left)
+				)
+			)
+			(property "Description" "5V 3A Step-Down Voltage Regulator, TO-263"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "TO?263*"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
 				)
 			)
 			(in_pos_files yes)
@@ -1712,39 +1712,6 @@
 					(justify left)
 				)
 			)
-			(property "ki_keywords" "linear regulator ldo fixed positive"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "ki_fp_filters" "SOT?223*TabPin2*"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "Description" "1A Low Dropout regulator, positive, 3.3V fixed output, SOT-223"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
 			(property "Footprint" "Package_TO_SOT_SMD:SOT-223-3_TabPin2"
 				(at 0 5.08 0)
 				(show_name no)
@@ -1767,10 +1734,43 @@
 					)
 				)
 			)
+			(property "ki_keywords" "linear regulator ldo fixed positive"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
 			(property "Reference" "U"
 				(at -3.81 3.175 0)
 				(show_name no)
 				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "1A Low Dropout regulator, positive, 3.3V fixed output, SOT-223"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "SOT?223*TabPin2*"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -1857,39 +1857,6 @@
 					(justify left)
 				)
 			)
-			(property "ki_keywords" "Arm Cortex-M4 STM32G4 STM32G4x1"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "ki_fp_filters" "LQFP*7x7mm*P0.8mm*"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "Description" "STMicroelectronics Arm Cortex-M4 MCU, 64KB flash, 32KB RAM, 170 MHz, 1.71-3.6V, 26 GPIO, LQFP32"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
 			(property "Footprint" "Package_QFP:LQFP-32_7x7mm_P0.8mm"
 				(at -10.16 -22.86 0)
 				(show_name no)
@@ -1913,6 +1880,17 @@
 					)
 				)
 			)
+			(property "ki_keywords" "Arm Cortex-M4 STM32G4 STM32G4x1"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
 			(property "Reference" "U"
 				(at -10.16 26.67 0)
 				(show_name no)
@@ -1922,6 +1900,28 @@
 						(size 1.27 1.27)
 					)
 					(justify left)
+				)
+			)
+			(property "Description" "STMicroelectronics Arm Cortex-M4 MCU, 64KB flash, 32KB RAM, 170 MHz, 1.71-3.6V, 26 GPIO, LQFP32"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "LQFP*7x7mm*P0.8mm*"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
 				)
 			)
 			(in_pos_files yes)
@@ -4902,7 +4902,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "aae83e15-f7b9-40db-8795-c3c8574b9df2")
+		(uuid "7b0385ef-3c01-4456-8b2d-5ca6ed5dd6ef")
 		(property "Reference" "J1"
 			(at 25.4 95.25 0)
 			(effects
@@ -4937,13 +4937,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "d2ff0898-0af9-43d7-b02d-79351867d394")
+		(pin "1" (uuid "ed8be2f7-9f82-40f4-9e21-7633ab0b0a9b")
 		)
-		(pin "2" (uuid "a9c6ec80-de52-44ef-aaf4-7e92ed043e99")
+		(pin "2" (uuid "c2d4c9ac-6d95-4042-af5a-f188fe5e816a")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "J1") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "J1") (unit 1)
 				)
 			)
 		)
@@ -4956,7 +4956,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "7eb5d73e-e70f-4141-8f38-35f294291a79")
+		(uuid "fc0df867-644c-44b3-aeb2-8ff4a783d92a")
 		(property "Reference" "F1"
 			(at 44.45 95.25 0)
 			(effects
@@ -4991,13 +4991,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "162c2b95-a17f-4752-bca0-a6caf9e878b8")
+		(pin "1" (uuid "79d8d82b-4b80-4912-83de-93e75b60727e")
 		)
-		(pin "2" (uuid "2ff4dbb1-c91f-4671-9cce-68f08429d844")
+		(pin "2" (uuid "0c0c8475-52ec-476c-9848-d155e21781ee")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "F1") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "F1") (unit 1)
 				)
 			)
 		)
@@ -5010,7 +5010,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "891b7291-9e4f-42e4-94b3-69bf0b20453d")
+		(uuid "fad8153f-4758-4377-bae1-285766dd8b99")
 		(property "Reference" "D1"
 			(at 64.77 114.3 0)
 			(effects
@@ -5045,13 +5045,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "eaa581f5-2860-4d9f-99a2-66ebf962e77c")
+		(pin "1" (uuid "8cf3d68c-b090-4ea3-87dd-db3d6702bc45")
 		)
-		(pin "2" (uuid "c071df6d-96b5-4579-bcd9-2f4cca5f7a7f")
+		(pin "2" (uuid "3423020c-3953-4cd1-8542-99675b1e5d66")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "D1") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "D1") (unit 1)
 				)
 			)
 		)
@@ -5064,7 +5064,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "394af47a-f02a-4d38-be64-d8a50746f43e")
+		(uuid "ed5f1787-dac7-429a-aacf-359c3cc6d531")
 		(property "Reference" "C1"
 			(at 80.01 114.3 0)
 			(effects
@@ -5099,13 +5099,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "4610c1d7-6230-4727-9d92-ed930bb3399a")
+		(pin "1" (uuid "31cab738-08c7-493d-a40c-85506451ebbb")
 		)
-		(pin "2" (uuid "19933385-a3f6-4a20-b08e-68c6676cc256")
+		(pin "2" (uuid "b5b9bb35-6476-4900-91bb-b38b7f54e8b9")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "C1") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "C1") (unit 1)
 				)
 			)
 		)
@@ -5118,7 +5118,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "99653466-b06a-4929-884e-fb2fe6f7c359")
+		(uuid "a6ae53f5-e191-407f-8b34-9944c11d592e")
 		(property "Reference" "C2"
 			(at 95.25 114.3 0)
 			(effects
@@ -5153,13 +5153,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "05135b50-abe3-46b6-afdd-c499812bdb9e")
+		(pin "1" (uuid "af0c76ac-f501-48d0-a268-b6a3c87e54b4")
 		)
-		(pin "2" (uuid "9ac9483e-1083-4756-a988-ab604825029b")
+		(pin "2" (uuid "7ca1ff88-08a7-4808-b5fd-f77ca4c9cc25")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "C2") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "C2") (unit 1)
 				)
 			)
 		)
@@ -5172,7 +5172,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "6efffef2-a4bc-4f33-933d-f86fb611fc56")
+		(uuid "c6630b1e-536c-447e-9926-11ef64e0c262")
 		(property "Reference" "U1"
 			(at 80.01 95.25 0)
 			(effects
@@ -5207,19 +5207,19 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "a7532aa1-d7ec-4361-ac34-8d8fc2156705")
+		(pin "1" (uuid "0edf747f-b45f-41fe-a8be-f8b3adf13d58")
 		)
-		(pin "2" (uuid "4a51bc22-01ba-4830-9975-fd657d2e3c55")
+		(pin "2" (uuid "36f9baa5-bd26-413f-b708-f83e7901fe4d")
 		)
-		(pin "3" (uuid "72f5cb19-3233-404d-9af1-90879c476f3a")
+		(pin "3" (uuid "ec5466f3-9b0e-4112-931c-e74fcfd8a657")
 		)
-		(pin "4" (uuid "c7cd46b1-08ae-4996-b76e-4797fe45fccb")
+		(pin "4" (uuid "a8bc2967-f584-4f9f-bcb9-237d2cf416da")
 		)
-		(pin "5" (uuid "82d3de1f-26b5-4aac-9d77-79b9562ebb4a")
+		(pin "5" (uuid "4adfa028-151e-4914-97fb-509e6e70bd20")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "U1") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "U1") (unit 1)
 				)
 			)
 		)
@@ -5232,7 +5232,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "abd4dd8e-0232-4964-b382-998c35b60398")
+		(uuid "557237ee-5b8d-42c6-90a4-820be7c451e4")
 		(property "Reference" "C3"
 			(at 54.61 110.49 0)
 			(effects
@@ -5267,13 +5267,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "8aaf1b8f-042c-4014-a26c-ad78fe308750")
+		(pin "1" (uuid "ec4b9d2a-2efc-48ad-b3c0-e1e4a3a48e47")
 		)
-		(pin "2" (uuid "51edfc53-912d-4ad3-9d7f-60c52a4745b4")
+		(pin "2" (uuid "97ccae67-8e50-4aee-813e-798bb67e8c96")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "C3") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "C3") (unit 1)
 				)
 			)
 		)
@@ -5286,7 +5286,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "4df075df-f6c5-4ebf-b0f7-26b3f1d97e6f")
+		(uuid "807f7c39-ee0e-4987-879b-ec8e3db952fd")
 		(property "Reference" "L1"
 			(at 105.41 95.25 0)
 			(effects
@@ -5321,13 +5321,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "a78d5863-69b9-4d74-964b-e72dabfd8c2f")
+		(pin "1" (uuid "6e6d4701-2f5f-4f0d-9361-d7e4bbce3768")
 		)
-		(pin "2" (uuid "1d0b2512-1002-4439-be28-9894b5302b2e")
+		(pin "2" (uuid "b1ab94d0-19bf-4102-b14d-5bbb19612b05")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "L1") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "L1") (unit 1)
 				)
 			)
 		)
@@ -5340,7 +5340,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "6673acc4-f5f7-4640-a7ad-132793aef084")
+		(uuid "4f328d22-0472-40e6-817f-6703ff303031")
 		(property "Reference" "C4"
 			(at 129.54 110.49 0)
 			(effects
@@ -5375,13 +5375,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "2485fb43-dfd7-441c-bcb7-be784a3aa4fc")
+		(pin "1" (uuid "a9c3bbb2-6f1a-4ac9-9ee2-15e6b6ca087c")
 		)
-		(pin "2" (uuid "2e2c3786-2d7e-4f43-bd04-6a4e9320b973")
+		(pin "2" (uuid "c7a88629-d6fd-4766-8e48-aee5d7ba122a")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "C4") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "C4") (unit 1)
 				)
 			)
 		)
@@ -5394,7 +5394,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "e43f3153-8f0a-495e-a121-cbd2fec3b339")
+		(uuid "cf02356b-a120-4440-b1c2-5accfd10841b")
 		(property "Reference" "D2"
 			(at 105.41 114.3 0)
 			(effects
@@ -5429,13 +5429,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "a8c49c5e-6797-4c67-a15a-33b8575525b3")
+		(pin "1" (uuid "b433244e-7644-4e2d-85c1-bb706b708254")
 		)
-		(pin "2" (uuid "403456a6-80ae-44b6-95e0-573e9db6f434")
+		(pin "2" (uuid "98666b59-0130-4fa2-8a83-df22864b8fd5")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "D2") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "D2") (unit 1)
 				)
 			)
 		)
@@ -5448,7 +5448,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "c469f323-90da-455c-a2b5-af10f7f0efa1")
+		(uuid "f55bcc70-3628-492c-9c91-9b694b51e6b1")
 		(property "Reference" "U2"
 			(at 139.7 95.25 0)
 			(effects
@@ -5483,15 +5483,15 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "414949ce-4aff-45f7-a578-819c15771726")
+		(pin "1" (uuid "40021fa0-3ce1-4643-878e-083c64abebb0")
 		)
-		(pin "2" (uuid "6323d147-9824-4ef1-a77f-c1f4b65173c4")
+		(pin "2" (uuid "e8abbd31-cb56-4190-bea0-6338982a3363")
 		)
-		(pin "3" (uuid "7442d219-4d85-41fb-ac5e-9aa534a29aa5")
+		(pin "3" (uuid "5443428a-0993-4c6c-b58f-c43fc5dd227f")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "U2") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "U2") (unit 1)
 				)
 			)
 		)
@@ -5504,7 +5504,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "138803fd-9c45-49d9-b88b-d51ae5356c56")
+		(uuid "a3995abb-b300-47cd-97d3-3667757ca6e6")
 		(property "Reference" "C5"
 			(at 119.38 110.49 0)
 			(effects
@@ -5539,13 +5539,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "35cbb587-0da3-4944-92bb-be9b2b8a82a7")
+		(pin "1" (uuid "670fe391-07da-4312-8b8a-ce540e3f0be9")
 		)
-		(pin "2" (uuid "89a44e30-8d44-433f-8325-18bc515bbf7c")
+		(pin "2" (uuid "d6092b94-855f-4186-9a0e-234970f55e87")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "C5") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "C5") (unit 1)
 				)
 			)
 		)
@@ -5558,7 +5558,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "8355bce6-631e-4d07-b64f-03c63365c2ef")
+		(uuid "7a7e7196-344c-4117-ac7a-3a56b845f4f5")
 		(property "Reference" "C6"
 			(at 160.02 110.49 0)
 			(effects
@@ -5593,13 +5593,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "28bf7d78-8a9d-423b-8e01-7546badf9343")
+		(pin "1" (uuid "8e5f92a9-4830-4138-b994-dc822d0ee5c6")
 		)
-		(pin "2" (uuid "291b241d-3eb1-4756-a69e-070b57cc6c1b")
+		(pin "2" (uuid "5100fcaa-23b3-48e3-b665-b4a9be9bdfbf")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "C6") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "C6") (unit 1)
 				)
 			)
 		)
@@ -5612,7 +5612,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "a8725a8f-6b79-4416-88e4-32651c77e967")
+		(uuid "4072570c-08ba-4568-a0ad-7f607ee4f648")
 		(property "Reference" "C7"
 			(at 199.39 95.25 0)
 			(effects
@@ -5647,13 +5647,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "6140d590-c043-4afb-ac89-b20d20d6c97b")
+		(pin "1" (uuid "28637673-3639-4db0-aed4-275acf24712c")
 		)
-		(pin "2" (uuid "9cc6ac2f-2b3b-4e9a-af6f-63202fe48709")
+		(pin "2" (uuid "387903d1-dd05-4cec-a61e-e467abb7c602")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "C7") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "C7") (unit 1)
 				)
 			)
 		)
@@ -5666,7 +5666,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "13d11215-3ab3-4a79-a923-eae01e2df363")
+		(uuid "b394fd29-cadb-49c6-be75-e85a5f553717")
 		(property "Reference" "C8"
 			(at 209.55 95.25 0)
 			(effects
@@ -5701,13 +5701,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "6b70cff3-5796-4708-8836-e66c5a972dfd")
+		(pin "1" (uuid "3beda429-60aa-44d5-b882-cc4f19bf1ab0")
 		)
-		(pin "2" (uuid "c150f986-17cb-4a03-a72b-c4e51ad7a1d7")
+		(pin "2" (uuid "49f11e08-dc94-4ca8-8a58-fa0a8d6e4e31")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "C8") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "C8") (unit 1)
 				)
 			)
 		)
@@ -5720,7 +5720,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "d31557af-fa05-4802-8172-663d69889412")
+		(uuid "0e403e3b-97cd-476a-a8b4-b985a301fd04")
 		(property "Reference" "C9"
 			(at 219.71 95.25 0)
 			(effects
@@ -5755,13 +5755,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "a0e39942-b278-416d-90d7-2ea3bbd9f591")
+		(pin "1" (uuid "b1d0e194-d87c-4dba-a9c6-a82a04a62165")
 		)
-		(pin "2" (uuid "0d38537d-541a-45c0-8cc6-5fe4feebc759")
+		(pin "2" (uuid "8626134a-2251-439e-8fad-6ae49c677f55")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "C9") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "C9") (unit 1)
 				)
 			)
 		)
@@ -5774,7 +5774,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "d338c274-81c6-425d-9719-fcc32c6deec3")
+		(uuid "3539d3f4-ab12-49cf-afbd-fbc90af683e5")
 		(property "Reference" "U10"
 			(at 229.87 160.02 0)
 			(effects
@@ -5809,73 +5809,73 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "de1bddb7-638f-4cba-aaa8-940af949fdad")
+		(pin "1" (uuid "3b1ca54a-f907-4e9d-91aa-6311f7c9c3f7")
 		)
-		(pin "2" (uuid "affc270a-6951-4baf-94a6-81f6ad8dd9e0")
+		(pin "2" (uuid "3899c845-8f45-45a7-9e80-2a58177ceb27")
 		)
-		(pin "3" (uuid "7ec3975a-2f80-4cac-86d2-25b81326af81")
+		(pin "3" (uuid "3e006794-e907-4bb6-9a34-4e44227d7e27")
 		)
-		(pin "4" (uuid "521193f5-2857-40a9-bae1-9c843bb75266")
+		(pin "4" (uuid "4b8fd05e-18fe-45ee-922e-39b911fffdc7")
 		)
-		(pin "5" (uuid "13969bbe-46ff-482e-8dd8-33934c5ce8f0")
+		(pin "5" (uuid "12ccdfb5-0577-4bed-b768-be9bffc32d7a")
 		)
-		(pin "6" (uuid "e3274377-7314-404d-803c-a9e2bdfad788")
+		(pin "6" (uuid "4c00dd65-3b9f-479b-a888-b0b16c9f5c93")
 		)
-		(pin "7" (uuid "bc46fb0a-04f3-43eb-969b-1b0fc0f3d5c6")
+		(pin "7" (uuid "cd7036a5-0e61-4fa1-942c-1f78c92307fc")
 		)
-		(pin "8" (uuid "db66dd60-7733-45fe-bc05-f384cf40f7c4")
+		(pin "8" (uuid "9bd8d23a-0d53-4fdb-b8fb-1b9f0ed27690")
 		)
-		(pin "9" (uuid "c995400b-8bf6-4de7-a0f9-cc6e62653c45")
+		(pin "9" (uuid "f3649dd7-aafb-48bd-ada9-647a258d4897")
 		)
-		(pin "10" (uuid "d67564dd-c07f-4bd0-a07b-70ba049d4e74")
+		(pin "10" (uuid "81fd89c4-8506-4f7f-b073-b2b643279d0a")
 		)
-		(pin "11" (uuid "fa4983dd-8ba5-4ccf-bfef-fea933d10a31")
+		(pin "11" (uuid "1e588cb6-de4f-41b2-8dad-cd67b3d24215")
 		)
-		(pin "12" (uuid "d7d3dbb5-38b6-49a2-8cb9-89985c938601")
+		(pin "12" (uuid "ef76961a-b0f1-4e00-815b-ccc022a2c4a7")
 		)
-		(pin "13" (uuid "f358432d-86a8-4d92-b037-186250432060")
+		(pin "13" (uuid "bf147213-8dd0-462b-abf5-2b1bcaaded38")
 		)
-		(pin "14" (uuid "3e5ca0f3-648c-4bdf-a0e8-655fcc4335ee")
+		(pin "14" (uuid "9112eb5f-2aa2-45ca-8a89-a1e39aa9e712")
 		)
-		(pin "15" (uuid "fb7c9613-6a69-4c2e-a92d-ca18d706c9aa")
+		(pin "15" (uuid "1ae89812-47a0-480a-8ce5-94e281f0b823")
 		)
-		(pin "16" (uuid "9006f3d6-1893-4896-85bd-2d3aa56fbf37")
+		(pin "16" (uuid "8506509e-2b0e-4ca7-8cf2-05d7c8dddfc2")
 		)
-		(pin "17" (uuid "dd3052ba-8be7-4c6b-a701-5c9b165a4a17")
+		(pin "17" (uuid "68886460-1831-4e9c-ba3b-ab2b006f1345")
 		)
-		(pin "18" (uuid "c294faeb-d7d4-4ead-995e-b27bddc4ad5a")
+		(pin "18" (uuid "bdcc2781-6c1e-44b9-a474-c88f7de6120e")
 		)
-		(pin "19" (uuid "2ec7450c-24c3-40f8-90b6-018d5ce2e787")
+		(pin "19" (uuid "51e473f0-1e6f-492f-a36a-3d0ea25798f9")
 		)
-		(pin "20" (uuid "af50de02-5934-44f8-901d-98278a450518")
+		(pin "20" (uuid "7fe633f8-5236-4a79-a658-ee15da7e7d9d")
 		)
-		(pin "21" (uuid "28b9fd6e-227e-4ab2-8b86-61ec59365814")
+		(pin "21" (uuid "f0e299ba-b366-4c8f-86ee-cc7351acd722")
 		)
-		(pin "22" (uuid "78ecc17f-409a-4235-87d9-1f2c69861031")
+		(pin "22" (uuid "1647e59d-7b94-4b38-8dc8-78835653b165")
 		)
-		(pin "23" (uuid "36ef5485-737b-4498-9d96-e69becde6729")
+		(pin "23" (uuid "a3467c75-af12-40c1-b121-ec1c9ee4b1ff")
 		)
-		(pin "24" (uuid "8b2cfaaa-2c75-4005-9a26-f2c04be8a7dd")
+		(pin "24" (uuid "21b006f8-be98-4b0b-bedf-c5aae8744c9d")
 		)
-		(pin "25" (uuid "8e5f57df-8fa1-48ca-90bc-835f013e1ce0")
+		(pin "25" (uuid "9a11bec6-96e0-4dc7-a11c-2bcf22dc456e")
 		)
-		(pin "26" (uuid "4ae3ea61-63f6-43f8-aafd-961e0be4bc0a")
+		(pin "26" (uuid "7250e227-bba8-4c5b-ab5d-fdb0139b732b")
 		)
-		(pin "27" (uuid "dbcf99bc-56a6-4ec2-b4ad-7330aff72f74")
+		(pin "27" (uuid "c65b3e44-6e6b-48f2-95a7-cae2411ab5f0")
 		)
-		(pin "28" (uuid "86b9d777-aec1-4e18-904b-e5d9e76e3a12")
+		(pin "28" (uuid "7de0323a-f13a-477b-b906-3b7068fa71be")
 		)
-		(pin "29" (uuid "fef7de0f-ffb4-48ec-b49c-1847c6f0d47c")
+		(pin "29" (uuid "ea225f2d-ce93-4362-af3a-bc7c4902d41d")
 		)
-		(pin "30" (uuid "0d0e8677-485d-47c8-a561-94f043772674")
+		(pin "30" (uuid "23431cc2-1357-4d36-9917-6d7f6f1fca96")
 		)
-		(pin "31" (uuid "5f1fb72b-6857-419e-bb21-3d2f535cbee6")
+		(pin "31" (uuid "f4f00813-c940-48c0-bbcf-b507ac7d6ca2")
 		)
-		(pin "32" (uuid "4eb5d9ba-2776-48aa-a9b2-b4f6c5510e32")
+		(pin "32" (uuid "28e157ba-eac8-4cd5-b9f9-1aec43a41123")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "U10") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "U10") (unit 1)
 				)
 			)
 		)
@@ -5888,7 +5888,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "5b17a330-8fc8-417d-a986-2bdff0446cf1")
+		(uuid "e668cffd-e20f-44c9-8912-9983ec21ace9")
 		(property "Reference" "Y1"
 			(at 270.51 95.25 0)
 			(effects
@@ -5923,13 +5923,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "95dc014c-f312-4586-b6b3-b5c456a83f14")
+		(pin "1" (uuid "705918b5-89ff-449e-8967-1d42a00bb9a2")
 		)
-		(pin "2" (uuid "ff5fc074-331c-4f26-a815-3588b48c9077")
+		(pin "2" (uuid "0a2018ba-5b40-4eb7-8746-6e8825d3111c")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "Y1") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "Y1") (unit 1)
 				)
 			)
 		)
@@ -5942,7 +5942,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "5ad681ef-4da4-476c-9929-2ba97716fd43")
+		(uuid "97fd2abd-7dab-41cb-bbb6-6082b513e03d")
 		(property "Reference" "C10"
 			(at 262.89 110.49 0)
 			(effects
@@ -5977,13 +5977,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "282356b5-5d41-4a47-9f0a-6e1bc1611a1c")
+		(pin "1" (uuid "32762026-ee7d-48e6-a8d7-079c49fddf1e")
 		)
-		(pin "2" (uuid "fcb09bac-a335-4fee-8f65-fd2a916ebf43")
+		(pin "2" (uuid "d9f783bc-1821-41c3-b410-08f53a7c4de1")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "C10") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "C10") (unit 1)
 				)
 			)
 		)
@@ -5996,7 +5996,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "eae66a34-e1f7-4fcb-a452-0062077534ad")
+		(uuid "ea5cb702-5119-44d1-89cc-231e1edc94da")
 		(property "Reference" "C11"
 			(at 278.13 110.49 0)
 			(effects
@@ -6031,13 +6031,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "4707007e-e22a-4f0a-8f74-28467148b27c")
+		(pin "1" (uuid "81eef589-3e90-472a-a815-7fc3c6477c81")
 		)
-		(pin "2" (uuid "bd090265-99c3-457a-b237-164d3e64eed0")
+		(pin "2" (uuid "c2afea26-15e1-4296-99ff-7234ffefcc9a")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "C11") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "C11") (unit 1)
 				)
 			)
 		)
@@ -6050,7 +6050,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "72aa5fb3-f35a-4aeb-b85b-6ace71e5c7ec")
+		(uuid "16fee54d-f318-4936-948d-9aea286032d4")
 		(property "Reference" "J4"
 			(at 299.72 95.25 0)
 			(effects
@@ -6085,21 +6085,21 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "93078b81-57b7-4f51-93da-2146162646dd")
+		(pin "1" (uuid "75066b84-d6ea-42cc-bf41-8ab5223eacb2")
 		)
-		(pin "2" (uuid "26d991a2-5e27-41a2-a1bf-2b2e710556d0")
+		(pin "2" (uuid "f33b52a0-cf6c-4597-a041-03b665e3c807")
 		)
-		(pin "3" (uuid "a3812240-2869-49f5-941b-e99ae38f6bfc")
+		(pin "3" (uuid "291daf87-7359-4db2-800e-2fb0dabebfdd")
 		)
-		(pin "4" (uuid "55d13a6b-4129-45b1-a541-3ba62b189710")
+		(pin "4" (uuid "ac94f266-99ca-4caf-827f-0672b02cfe7d")
 		)
-		(pin "5" (uuid "f72c3b30-255d-4c4f-a344-3b974226cfbb")
+		(pin "5" (uuid "4ec35f27-a133-41e3-83bd-11939c50137c")
 		)
-		(pin "6" (uuid "7c11ce93-3638-419c-924e-d49c45b47b5b")
+		(pin "6" (uuid "e11dbf19-dd1c-409f-b1f3-0df98c856260")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "J4") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "J4") (unit 1)
 				)
 			)
 		)
@@ -6112,7 +6112,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "ce6a3ff4-4e21-4049-9636-fcb6fbfdd1c4")
+		(uuid "45151834-32c1-44c8-af71-088d2b417ae4")
 		(property "Reference" "U3"
 			(at 279.4 90.17 0)
 			(effects
@@ -6147,91 +6147,91 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "891b3af7-4a6c-4350-9dac-7a4c9c39cb73")
+		(pin "1" (uuid "64a60379-57e0-4445-b0fe-294f03fa6860")
 		)
-		(pin "2" (uuid "56074de1-3c1f-48fa-9ae6-b91c41f77523")
+		(pin "2" (uuid "8687eddb-1582-44c4-9bd8-0b75286d5036")
 		)
-		(pin "3" (uuid "ef7cfd5f-33a6-42ff-9b66-074eb68839a9")
+		(pin "3" (uuid "7acf844c-f9d7-4128-b925-0710e779bc3a")
 		)
-		(pin "4" (uuid "6221b4b9-3a07-4d30-9efb-95be5883fc77")
+		(pin "4" (uuid "c31d4285-1d10-4241-a1dd-08d0b48cb6bb")
 		)
-		(pin "5" (uuid "b5e64046-67d0-403c-b6d4-b2288b318bb4")
+		(pin "5" (uuid "2e086b00-826f-465c-aa89-118e732444b6")
 		)
-		(pin "6" (uuid "fccdac0e-c53a-4cbb-b472-683059019e4f")
+		(pin "6" (uuid "67f20f56-442d-47ae-93dd-eb79f2e9cb8d")
 		)
-		(pin "7" (uuid "139cfe83-7447-435d-9b67-ad376b732146")
+		(pin "7" (uuid "80dd4ec7-5c29-4552-a466-5e5d1d2c933e")
 		)
-		(pin "8" (uuid "14077a77-8fb1-463c-8931-3194af8b404d")
+		(pin "8" (uuid "b10bac95-4b93-40bf-9217-6a8a64108073")
 		)
-		(pin "9" (uuid "0e6bfa26-e0b7-4181-8c4c-6f5453133ef1")
+		(pin "9" (uuid "6f686318-c3f9-429e-81bc-12cc1c4552b8")
 		)
-		(pin "10" (uuid "f57152f4-c356-4bf6-8e17-9e14cae71f07")
+		(pin "10" (uuid "9b7a14e1-0dd0-469f-accf-5bb631afdace")
 		)
-		(pin "11" (uuid "ee5a4254-b08c-415c-ae0d-3a70b3312ad2")
+		(pin "11" (uuid "7ffeb231-04a1-4b68-81fd-be7328263139")
 		)
-		(pin "12" (uuid "1b3a329b-0517-4d79-8739-e26e9c7ddd90")
+		(pin "12" (uuid "b10719da-3996-4b9d-9365-4b0bd56f8c11")
 		)
-		(pin "13" (uuid "4322a20d-abf5-4f6d-8e3b-17dd5a737ec2")
+		(pin "13" (uuid "61825744-8f25-4b1b-8158-b180c57489bf")
 		)
-		(pin "14" (uuid "9210f95b-299c-41a8-94dd-cf979d305ac6")
+		(pin "14" (uuid "f0a42604-a1a6-4ac6-a9a1-fe1a5d2da2d3")
 		)
-		(pin "15" (uuid "5a6cf42b-e4d2-4ae9-b615-998283503143")
+		(pin "15" (uuid "9efe20f8-04df-4680-bc3a-32db1e6ba485")
 		)
-		(pin "16" (uuid "95ecd635-3f9b-4629-b1fd-e008c55ce250")
+		(pin "16" (uuid "f93895c9-e2c4-4218-9f59-b9f214d8b8e3")
 		)
-		(pin "17" (uuid "ca681845-63a8-488d-b405-c537e7c5d88f")
+		(pin "17" (uuid "503c5037-963b-4923-a3a0-c2d50ecc7cea")
 		)
-		(pin "18" (uuid "32b8e2ea-2294-4963-a4ab-b9a437870a97")
+		(pin "18" (uuid "12d3da1b-0767-45fa-9f3f-62ab02a8c7f7")
 		)
-		(pin "19" (uuid "25f3cc99-169c-4a51-a373-59f580d5f14d")
+		(pin "19" (uuid "93345f9b-bab9-4031-9987-bd4a0f2f6a36")
 		)
-		(pin "20" (uuid "a905d93a-5b83-4552-aad0-9c04436e099b")
+		(pin "20" (uuid "5a8840e9-f5a0-46f2-bc4a-c867c6ec775c")
 		)
-		(pin "21" (uuid "af2428a2-d12a-44af-bb5d-ab220c5d5257")
+		(pin "21" (uuid "daae978a-df9f-444f-af65-daf442c55232")
 		)
-		(pin "22" (uuid "01c832f4-2d1e-4cc2-838d-cdad11528a71")
+		(pin "22" (uuid "9b30fd82-98c6-40c4-8977-5e551a5b0ab6")
 		)
-		(pin "23" (uuid "2b32bf96-0648-45ef-9cc7-c16369d33bd3")
+		(pin "23" (uuid "e76866ff-91b7-4bdc-9859-03f649ea8aa4")
 		)
-		(pin "24" (uuid "4d355c04-13de-4151-a40e-3f4de427459d")
+		(pin "24" (uuid "b43016f0-eec7-4b42-bff6-0c1df7bdeae4")
 		)
-		(pin "25" (uuid "a1a83ad1-caf7-4e92-8990-3ff38c87f345")
+		(pin "25" (uuid "c1523228-3489-4b8a-ad07-ab8db969ef99")
 		)
-		(pin "26" (uuid "f8f9e3b7-a614-4a42-8fcf-b342c3357ad0")
+		(pin "26" (uuid "e734f497-df28-46d9-9c5f-b4b09a87b386")
 		)
-		(pin "27" (uuid "3e94f6c1-ab85-4feb-bf2c-c6237d17849b")
+		(pin "27" (uuid "3e34f498-e00e-44bd-874e-4354afb1dcb8")
 		)
-		(pin "28" (uuid "6f7537af-b577-4ca0-b4ce-d1c5718ee55e")
+		(pin "28" (uuid "ce7af54d-c8e2-46b9-84c7-5a8fb08ee704")
 		)
-		(pin "29" (uuid "63830f15-b388-45d3-8ada-a9a0a5279cdc")
+		(pin "29" (uuid "737887a1-65f9-4465-a695-16a3069c3737")
 		)
-		(pin "30" (uuid "ca7a3448-dbed-4bae-8c65-ca3e53069b8f")
+		(pin "30" (uuid "54fe2e3a-2962-4744-98a4-a33354597197")
 		)
-		(pin "31" (uuid "651224ab-123a-48f8-9448-253341790301")
+		(pin "31" (uuid "bc0b1029-8ac2-47cd-97f1-85b6c213f1ad")
 		)
-		(pin "32" (uuid "87ac2fb0-b3f0-476f-9408-afb0ad9a9ba2")
+		(pin "32" (uuid "76b4ab2a-72c2-4dfa-abda-7f25f4abd4f7")
 		)
-		(pin "33" (uuid "46ab702c-f7af-4331-9441-b9a68287747f")
+		(pin "33" (uuid "7f52e184-2930-4d31-8faa-19dd50134105")
 		)
-		(pin "34" (uuid "f32e17af-a858-4b73-929b-eaea8b5fc763")
+		(pin "34" (uuid "fa5ff928-e2b9-41a5-83d4-54c513702f14")
 		)
-		(pin "35" (uuid "2d3a9974-f159-4ba0-8446-12060837d678")
+		(pin "35" (uuid "4fd7029a-cea3-4f03-875a-c1b43f4ade36")
 		)
-		(pin "36" (uuid "15ff6dee-f552-48b4-ade7-63f5630697ec")
+		(pin "36" (uuid "a8006107-2293-4f3d-9a15-4626c60baa76")
 		)
-		(pin "37" (uuid "f10f0486-5f7a-41c1-91b2-32e74f0420ae")
+		(pin "37" (uuid "40576216-71fd-4d65-9e88-043b1fb7ba85")
 		)
-		(pin "38" (uuid "4d4fb64c-7c33-4f1c-bea1-e50b11a52799")
+		(pin "38" (uuid "b397f64b-66a5-4a8d-94ef-197caf66a981")
 		)
-		(pin "39" (uuid "1888d06e-f3eb-4bf9-bad8-2f6aec265cc6")
+		(pin "39" (uuid "77469d97-bf7b-440e-bcaa-0cd344ea758f")
 		)
-		(pin "40" (uuid "b51e08ea-c738-4a22-9e34-5809aa88c4ed")
+		(pin "40" (uuid "69e0637f-43e8-4cee-9d45-3c4345c7e1d3")
 		)
-		(pin "41" (uuid "bc222045-5696-4abb-bba3-ea002e186035")
+		(pin "41" (uuid "2108747b-33c3-4aef-8bba-ff854508bbe7")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "U3") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "U3") (unit 1)
 				)
 			)
 		)
@@ -6244,7 +6244,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "3c2833cc-f46e-481e-bfc0-5f5f87dcabe8")
+		(uuid "4130739e-798a-4459-bfc0-0dedf3b9920f")
 		(property "Reference" "C18"
 			(at 299.72 74.93 0)
 			(effects
@@ -6261,7 +6261,7 @@
 				)
 			)
 		)
-		(property "Footprint" ""
+		(property "Footprint" "Capacitor_SMD:C_0805_2012Metric"
 			(at 299.72 80.01 0)
 			(effects
 				(font
@@ -6279,13 +6279,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "9b8b1b18-92f7-4660-96e9-e23cd79b47b6")
+		(pin "1" (uuid "565029fd-a25c-45f3-b15b-a66529ee32c3")
 		)
-		(pin "2" (uuid "a9f8a199-85ac-469e-a9c4-309de518934e")
+		(pin "2" (uuid "a2752dd6-f800-438f-a2e4-4f640af3ad0e")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "C18") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "C18") (unit 1)
 				)
 			)
 		)
@@ -6298,7 +6298,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "f5b6c03e-024a-43c9-ae64-e86b3a186e16")
+		(uuid "d97dede6-805e-4524-8b1f-22a7491ba884")
 		(property "Reference" "C19"
 			(at 309.88 74.93 0)
 			(effects
@@ -6315,7 +6315,7 @@
 				)
 			)
 		)
-		(property "Footprint" ""
+		(property "Footprint" "Capacitor_SMD:C_0805_2012Metric"
 			(at 309.88 80.01 0)
 			(effects
 				(font
@@ -6333,13 +6333,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "7d5a4f4b-968d-41b9-8112-a3beb3777146")
+		(pin "1" (uuid "9f65d16b-6fd4-4c8c-9b7b-2b8b5998adf8")
 		)
-		(pin "2" (uuid "e2ecd90e-7855-4441-8929-15db47480520")
+		(pin "2" (uuid "58e08c17-55bc-4b7a-9b3f-e76f85fd72e9")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "C19") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "C19") (unit 1)
 				)
 			)
 		)
@@ -6352,7 +6352,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "0f98bc11-c848-4b99-b57e-3edecd7d43e7")
+		(uuid "f0e0fb17-58df-4329-8bc8-3ad83b33b0cd")
 		(property "Reference" "C12"
 			(at 260.35 74.93 0)
 			(effects
@@ -6387,13 +6387,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "bef34513-fbbe-4057-b1b9-f443e1425c20")
+		(pin "1" (uuid "b3b22e78-b8fa-4d6a-a3fc-373708961c30")
 		)
-		(pin "2" (uuid "48c66287-6baa-4e92-bb35-cb2394dc3323")
+		(pin "2" (uuid "d0d94b32-2da9-466a-aaee-c59fd0ff89f3")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "C12") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "C12") (unit 1)
 				)
 			)
 		)
@@ -6406,7 +6406,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "d39845e3-f749-4b4c-b138-36944e7d6b37")
+		(uuid "fffd68cd-9890-4edb-804a-b6c1e1eb020e")
 		(property "Reference" "C13"
 			(at 270.51 74.93 0)
 			(effects
@@ -6441,13 +6441,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "bcc94d88-f831-4a73-8a7b-d76cc35275d9")
+		(pin "1" (uuid "036802a1-54a7-4ccb-88e2-155e6d085641")
 		)
-		(pin "2" (uuid "f85aaa3c-babe-47b7-9719-3defdc7b3e3d")
+		(pin "2" (uuid "93988961-7277-4126-9241-83f838ffb61e")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "C13") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "C13") (unit 1)
 				)
 			)
 		)
@@ -6460,7 +6460,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "8b9bdef9-4344-4ced-83c8-4a8b4b3eb7bd")
+		(uuid "68df7146-8ba4-4778-a27b-8f286e6cbe2d")
 		(property "Reference" "C14"
 			(at 279.4 74.93 0)
 			(effects
@@ -6495,13 +6495,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "5d884dfe-6bdc-4f3d-9a4c-fe6558ee6adf")
+		(pin "1" (uuid "2e9a2df8-15dd-4871-981f-0b248c29388c")
 		)
-		(pin "2" (uuid "1325beca-6737-493c-bb5b-194a8e694330")
+		(pin "2" (uuid "9c7af119-30f5-4842-a3a6-67b6a9687b42")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "C14") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "C14") (unit 1)
 				)
 			)
 		)
@@ -6514,7 +6514,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "7eb1aa48-95b2-4588-b005-d72c3cd26239")
+		(uuid "33f06755-50d3-4083-a1b7-65ee336c5c78")
 		(property "Reference" "R20"
 			(at 309.88 114.3 0)
 			(effects
@@ -6558,13 +6558,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "924d5bb1-f830-4abf-baa9-55118eadd5d2")
+		(pin "1" (uuid "546e4f05-32e6-497e-b8a0-71c994d9cbab")
 		)
-		(pin "2" (uuid "3aeaea3d-cf01-40c3-8ee2-2858a430519f")
+		(pin "2" (uuid "54dfd0c5-14e6-452f-a1ac-165735bf61be")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "R20") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "R20") (unit 1)
 				)
 			)
 		)
@@ -6577,7 +6577,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "11f1499a-7e74-44a9-8db2-456ce661603f")
+		(uuid "7a30e663-c7ca-41ac-8809-5983a36fda97")
 		(property "Reference" "R21"
 			(at 320.04 114.3 0)
 			(effects
@@ -6621,13 +6621,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "262b0f16-3be1-4872-a217-74426bc4985b")
+		(pin "1" (uuid "e56b66d7-198d-4495-98f7-0120b847ac03")
 		)
-		(pin "2" (uuid "06ccd885-396f-4279-a3b7-8ee7d07db585")
+		(pin "2" (uuid "e17f41e4-16eb-48a4-91ad-cea911ff3d73")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "R21") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "R21") (unit 1)
 				)
 			)
 		)
@@ -6640,7 +6640,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "cfbb2253-baa6-42de-be61-08b4a2ddd5a4")
+		(uuid "7afd89bd-80bd-4172-b643-caabb88245f2")
 		(property "Reference" "R22"
 			(at 330.2 114.3 0)
 			(effects
@@ -6684,13 +6684,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "346781d7-bb16-4999-8e12-dc34943326f5")
+		(pin "1" (uuid "cd70dbb1-625a-4b99-863b-46316d12ab5f")
 		)
-		(pin "2" (uuid "08eee206-e793-488e-a5b2-4c4869e2c433")
+		(pin "2" (uuid "1f5dc670-5e66-4adc-9649-02ba4aa04578")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "R22") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "R22") (unit 1)
 				)
 			)
 		)
@@ -6703,7 +6703,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "035421d5-4e32-4cb9-af21-5701e9908d59")
+		(uuid "9ff4fb94-0932-447d-bc3d-2b9d54dd7e6f")
 		(property "Reference" "Q1"
 			(at 25.4 154.94 0)
 			(effects
@@ -6756,15 +6756,15 @@
 				(hide yes)
 			)
 		)
-		(pin "D" (uuid "5632888d-4c17-440a-80fe-126deed57aa8")
+		(pin "D" (uuid "68f85077-f00d-4553-b634-439efbab90ed")
 		)
-		(pin "G" (uuid "4aa53df8-5b22-4384-aa44-5045de73619a")
+		(pin "G" (uuid "dc805017-4bd5-488f-8801-4bd1b91db4c0")
 		)
-		(pin "S" (uuid "3ef8914b-8589-495c-8bd7-d39ab7395e56")
+		(pin "S" (uuid "12bf1d14-27c8-44ae-84f2-e6240249e146")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "Q1") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "Q1") (unit 1)
 				)
 			)
 		)
@@ -6777,7 +6777,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "7ab92e56-16a1-49a7-9939-440738a3d04d")
+		(uuid "dff99a6a-2775-417d-bae4-eb9a9e9b2b46")
 		(property "Reference" "Q2"
 			(at 25.4 194.31 0)
 			(effects
@@ -6830,15 +6830,15 @@
 				(hide yes)
 			)
 		)
-		(pin "D" (uuid "5bab97a4-303b-4ab2-be4d-26c46b95182a")
+		(pin "D" (uuid "eb5c36d8-637b-4d44-9139-9b39fe72cfd4")
 		)
-		(pin "G" (uuid "8ae2be6a-d1a4-4410-9a2d-369b8aaefa30")
+		(pin "G" (uuid "2e6c7c8c-33f3-4940-a69a-6cccdf8df006")
 		)
-		(pin "S" (uuid "d1af9aae-c541-4bb0-b01f-f946ac66a490")
+		(pin "S" (uuid "c2e29110-c25a-4c4c-87a3-9329211cdf8b")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "Q2") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "Q2") (unit 1)
 				)
 			)
 		)
@@ -6851,7 +6851,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "5fb75b80-bd94-4bc4-9212-7a91861aead2")
+		(uuid "d9fd9e94-aa93-4c31-b55c-a5188b17816c")
 		(property "Reference" "Q3"
 			(at 100.33 154.94 0)
 			(effects
@@ -6904,15 +6904,15 @@
 				(hide yes)
 			)
 		)
-		(pin "D" (uuid "3efdbeaa-45f6-4730-b0b5-b699a5857528")
+		(pin "D" (uuid "5c031e48-a062-43ad-9e78-d8c8e8d1eddf")
 		)
-		(pin "G" (uuid "348bc0eb-2fc8-4602-9a31-28f65a0eab0a")
+		(pin "G" (uuid "c310aeb9-1c91-419d-84f1-8e49b039c633")
 		)
-		(pin "S" (uuid "70c25342-3b65-4378-8f1b-bd263772c33c")
+		(pin "S" (uuid "bbdbafae-4726-44b5-b832-24796960f940")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "Q3") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "Q3") (unit 1)
 				)
 			)
 		)
@@ -6925,7 +6925,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "a197c6dc-7964-439c-bbdf-7488a9b2fba4")
+		(uuid "23d75fb1-fcef-4552-b53e-f821c421acdb")
 		(property "Reference" "Q4"
 			(at 100.33 194.31 0)
 			(effects
@@ -6978,15 +6978,15 @@
 				(hide yes)
 			)
 		)
-		(pin "D" (uuid "6f82938f-0cd7-460e-a813-bd4bc8fea019")
+		(pin "D" (uuid "22f79078-3f3c-408a-aa0d-9bf2fa0ddfc2")
 		)
-		(pin "G" (uuid "c1b6ce19-c541-401d-b35b-ad2ddf5dc07f")
+		(pin "G" (uuid "5ee62298-bcba-4d63-b601-a6daf3c6bcd6")
 		)
-		(pin "S" (uuid "721140d7-73cb-4d9a-a5e2-b9962264f7c8")
+		(pin "S" (uuid "c023ad7d-78f7-411d-a469-43ce3699592c")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "Q4") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "Q4") (unit 1)
 				)
 			)
 		)
@@ -6999,7 +6999,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "0bf6a652-0ac4-46bb-a8b6-d546e62443bf")
+		(uuid "778ea284-632e-4239-a3a6-d177495af9ba")
 		(property "Reference" "Q5"
 			(at 175.26 154.94 0)
 			(effects
@@ -7052,15 +7052,15 @@
 				(hide yes)
 			)
 		)
-		(pin "D" (uuid "9c049111-ea82-45c7-900a-258e1e35a39e")
+		(pin "D" (uuid "d2c7808e-9540-4259-ba1c-b5a6c715375e")
 		)
-		(pin "G" (uuid "21b1658d-b615-42aa-a6d1-b84627f3c00f")
+		(pin "G" (uuid "b099ab83-0bc8-4187-8452-9850216dc2bc")
 		)
-		(pin "S" (uuid "5c337a6f-31b2-4be7-8dab-eb4f0c3492de")
+		(pin "S" (uuid "4466dd5a-19a6-49cc-b699-440a45ff1c4f")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "Q5") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "Q5") (unit 1)
 				)
 			)
 		)
@@ -7073,7 +7073,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "7db2e16b-bf1b-4554-9512-1cd543fbabb4")
+		(uuid "25396400-2646-4301-8501-5644291e9f3e")
 		(property "Reference" "Q6"
 			(at 175.26 194.31 0)
 			(effects
@@ -7126,15 +7126,15 @@
 				(hide yes)
 			)
 		)
-		(pin "D" (uuid "37f702c9-3ead-42ba-a624-352e7f598701")
+		(pin "D" (uuid "bd6fa632-1c09-4028-b635-64ecf009d64e")
 		)
-		(pin "G" (uuid "26874e56-5daa-4989-82e8-c1b6a002106e")
+		(pin "G" (uuid "66c1b166-6dd2-4d14-ab26-89d58b86fa50")
 		)
-		(pin "S" (uuid "277e919c-5a57-4ed8-8f6e-b8c0252bbbdb")
+		(pin "S" (uuid "36e12737-e90b-4552-ba63-006d015a1723")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "Q6") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "Q6") (unit 1)
 				)
 			)
 		)
@@ -7147,7 +7147,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "1847a040-3a04-4eb4-8a93-f5714ea6b356")
+		(uuid "de6eb12b-afae-40de-a3bf-2310f1615d1d")
 		(property "Reference" "R10"
 			(at 25.4 234.95 0)
 			(effects
@@ -7200,13 +7200,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "c8938ffd-de9c-489f-89b7-552c482a7ebc")
+		(pin "1" (uuid "dbd2bc28-4dc1-4607-bbec-dce83a33b99d")
 		)
-		(pin "2" (uuid "dab52ef1-8262-44ec-b049-fd2e74c24a3e")
+		(pin "2" (uuid "ca608bc5-ef60-477b-a939-3e6b17ee400e")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "R10") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "R10") (unit 1)
 				)
 			)
 		)
@@ -7219,7 +7219,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "72f0cd4d-7988-44ff-bb94-642c47570448")
+		(uuid "93d18186-44ba-46aa-ba6e-73bd26ce03ec")
 		(property "Reference" "R11"
 			(at 100.33 234.95 0)
 			(effects
@@ -7272,13 +7272,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "b4eeb023-47c0-47df-91e9-b98a835d8db8")
+		(pin "1" (uuid "38598ac0-ccd2-4354-92a4-335e7af2a55a")
 		)
-		(pin "2" (uuid "80ec15d4-cb1f-4e5c-af5e-4d1cf87aa746")
+		(pin "2" (uuid "27da76d2-48cd-4133-8d79-9edc3d6526b1")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "R11") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "R11") (unit 1)
 				)
 			)
 		)
@@ -7291,7 +7291,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "3c6b47e6-8594-4f82-96d4-294d9c206749")
+		(uuid "f84286d6-90f8-4abe-84be-20e734186fbc")
 		(property "Reference" "R12"
 			(at 175.26 234.95 0)
 			(effects
@@ -7344,13 +7344,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "7d5e0f10-20a1-474c-85e1-a75cb4619720")
+		(pin "1" (uuid "7de2d7ed-f073-494f-9d0b-af240c835a3a")
 		)
-		(pin "2" (uuid "773de1d0-764c-4447-8348-e35ea06f4771")
+		(pin "2" (uuid "ae870805-0ea5-4fdb-a77f-b355efc37dd4")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "R12") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "R12") (unit 1)
 				)
 			)
 		)
@@ -7363,7 +7363,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "c914eccd-0eb5-4b80-96c1-1ef88e6e6ab3")
+		(uuid "ea04e5c2-6881-4c5e-98bb-489bc1c11ea9")
 		(property "Reference" "J2"
 			(at 260.35 175.26 0)
 			(effects
@@ -7398,15 +7398,15 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "8715fb7c-e3e9-45d3-b1cb-bd86372f3fc7")
+		(pin "1" (uuid "bb4044d9-9c21-427e-b245-28b45434d509")
 		)
-		(pin "2" (uuid "1ca6df4d-2adf-48be-8c05-c7d02cffc90e")
+		(pin "2" (uuid "f68b2533-078f-43a4-ac82-bd3ec9e0643e")
 		)
-		(pin "3" (uuid "cdf3b99d-e1c8-4ee6-903f-2182c0012f89")
+		(pin "3" (uuid "c8a1ffb1-c1c8-42ac-a62a-46c317a39fe3")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "J2") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "J2") (unit 1)
 				)
 			)
 		)
@@ -7419,7 +7419,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "a27bd55e-4c10-4ddf-8a98-a2e24437fc11")
+		(uuid "a68e07a8-7d19-4ca6-a5d0-de814fb1a1b4")
 		(property "Reference" "J3"
 			(at 260.35 95.25 0)
 			(effects
@@ -7454,19 +7454,19 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "cde6e1ff-9afc-4fd9-844d-b23a81a35834")
+		(pin "1" (uuid "229d0b7f-6860-43f7-8769-b09e1495c189")
 		)
-		(pin "2" (uuid "fd70cc60-6b6e-4d1d-85cb-98e66fba62d0")
+		(pin "2" (uuid "98a14fbf-3e10-4b9e-8c34-ccefcf912143")
 		)
-		(pin "3" (uuid "1a1d535d-585e-4ee0-89cc-130e4e98a710")
+		(pin "3" (uuid "d68c1662-753f-4ecb-982d-d5540f14fce1")
 		)
-		(pin "4" (uuid "89077632-b4ef-47e0-9b60-7dd83112e32a")
+		(pin "4" (uuid "b6db71cb-6f37-48b3-a9a0-5cf27cacf125")
 		)
-		(pin "5" (uuid "2d06f2e1-e692-4682-ad6b-c9200fea3c0b")
+		(pin "5" (uuid "6dca0bab-a682-4e32-8873-bf24392f99af")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "J3") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "J3") (unit 1)
 				)
 			)
 		)
@@ -7479,7 +7479,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "102972df-f90d-4175-914e-d0db68d8594d")
+		(uuid "b2dfffd4-ace2-4e17-b18c-7ea3aecd4028")
 		(property "Reference" "R30"
 			(at 232.41 74.93 0)
 			(effects
@@ -7514,13 +7514,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "3a09d449-bbf4-43d1-bce1-ecc8642da004")
+		(pin "1" (uuid "b56eb98f-8824-40af-9d06-e45b4ae00812")
 		)
-		(pin "2" (uuid "aa3754f0-a09b-4efa-ad14-b8d864e5b8c4")
+		(pin "2" (uuid "dcf5e339-74c6-4913-bc1e-1d7d75f0b808")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "R30") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "R30") (unit 1)
 				)
 			)
 		)
@@ -7533,7 +7533,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "fbb9b1a7-60c7-4341-8c71-70b828c00eee")
+		(uuid "55f22e2e-942c-4981-82c7-50e33818b231")
 		(property "Reference" "C30"
 			(at 232.41 105.41 0)
 			(effects
@@ -7568,13 +7568,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "6e35ea74-c188-4f32-b706-7cc295e86a61")
+		(pin "1" (uuid "5037b51f-7dfc-4f91-96bd-d61e9c494825")
 		)
-		(pin "2" (uuid "8b1a063a-75d7-417b-87c9-c98d31529554")
+		(pin "2" (uuid "fdb8975e-d4fb-4ca8-9a7a-0c15abd83680")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "C30") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "C30") (unit 1)
 				)
 			)
 		)
@@ -7587,7 +7587,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "f6be633a-6280-4132-82ac-ba385d728b40")
+		(uuid "868339b5-b372-42ab-a775-7e332a00d0de")
 		(property "Reference" "R31"
 			(at 223.52 77.47 0)
 			(effects
@@ -7622,13 +7622,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "66de226e-4e1c-4404-9505-9c1ed3dc31ef")
+		(pin "1" (uuid "8594fc59-7c45-4bfb-af10-62c6ee5af7a8")
 		)
-		(pin "2" (uuid "1a5a37a1-225f-4f72-98ae-430ecf8b0867")
+		(pin "2" (uuid "833c7162-db36-4278-a089-432da7090c5b")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "R31") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "R31") (unit 1)
 				)
 			)
 		)
@@ -7641,7 +7641,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "f189adb0-d0c4-4779-924f-9d2e241171f8")
+		(uuid "600f93a5-418e-443f-92ca-9ad3d3007194")
 		(property "Reference" "C31"
 			(at 223.52 107.95 0)
 			(effects
@@ -7676,13 +7676,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "39399b04-9875-40c6-89f7-5619cebc09b2")
+		(pin "1" (uuid "476dbc1b-9fa9-4e14-9083-f03acab69705")
 		)
-		(pin "2" (uuid "22a93ddf-909d-4633-97c9-cd4cfbd955ae")
+		(pin "2" (uuid "6cff8a75-d922-4c6b-891c-fc51f6d8d799")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "C31") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "C31") (unit 1)
 				)
 			)
 		)
@@ -7695,7 +7695,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "573b53dd-4043-484d-8100-d5d650990e26")
+		(uuid "d5135302-c1e6-473e-99f8-752dab8c50ad")
 		(property "Reference" "R32"
 			(at 215.9 80.01 0)
 			(effects
@@ -7730,13 +7730,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "568717ab-8ef2-409c-a5ff-3cd03d85d175")
+		(pin "1" (uuid "4257e7f9-fcbc-4e77-b6dd-dba83bad6f2b")
 		)
-		(pin "2" (uuid "5eea26ed-c62b-4c62-ac24-42e7be9bb134")
+		(pin "2" (uuid "925453bd-0a68-42f1-80e5-701d431aae32")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "R32") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "R32") (unit 1)
 				)
 			)
 		)
@@ -7749,7 +7749,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "4c37e403-cef0-42af-a2ce-8b09f141b490")
+		(uuid "4dfb2912-4749-4545-9c99-e4d4fc106241")
 		(property "Reference" "C32"
 			(at 215.9 110.49 0)
 			(effects
@@ -7784,13 +7784,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "7e16edd0-3147-4e4d-a94f-8478f8e8d038")
+		(pin "1" (uuid "24f05fc1-337c-42a5-9081-d35c44a074a3")
 		)
-		(pin "2" (uuid "6186e411-a87a-4c9e-bcd4-b5ca5e02ff9d")
+		(pin "2" (uuid "a7599f51-4e39-47ac-a7ad-781193887145")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "C32") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "C32") (unit 1)
 				)
 			)
 		)
@@ -7803,7 +7803,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "f943a6d3-725d-4098-9bbd-f7a002dc6827")
+		(uuid "492ede1a-e48f-4329-9dc5-ef0b826fcbd8")
 		(property "Reference" "D3"
 			(at 190.5 114.3 0)
 			(effects
@@ -7838,13 +7838,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "5c986611-3d41-4331-b05a-19bbae2af225")
+		(pin "1" (uuid "ec34c6e8-7f24-4f69-a79b-d777562e25bc")
 		)
-		(pin "2" (uuid "c8dad725-df9f-467d-b36b-03744af07d7e")
+		(pin "2" (uuid "8eae7a9f-6ad7-4e21-b671-dcb2143ea689")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "D3") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "D3") (unit 1)
 				)
 			)
 		)
@@ -7857,7 +7857,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "1caee6e4-fb3b-4fbd-8656-e4ad1706ba31")
+		(uuid "3038eb3c-57be-4eb4-9780-fe51eef25f45")
 		(property "Reference" "R3"
 			(at 190.5 129.54 0)
 			(effects
@@ -7892,13 +7892,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "978da975-2a60-4659-a852-794a314c9578")
+		(pin "1" (uuid "2adaf3fc-4581-4532-a893-c1a155f86bd1")
 		)
-		(pin "2" (uuid "30fc576f-8e25-45f9-a883-f89d6f4504b9")
+		(pin "2" (uuid "4a22cfd2-d10e-4388-95ed-c06f3d7d6e49")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "R3") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "R3") (unit 1)
 				)
 			)
 		)
@@ -7911,7 +7911,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "ac004296-8864-4bb0-a058-961b562bf38a")
+		(uuid "0cef846d-6025-44e7-8e6e-ed389396045e")
 		(property "Reference" "D4"
 			(at 209.55 114.3 0)
 			(effects
@@ -7946,13 +7946,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "6894d347-6c63-47da-83cb-f31f47214006")
+		(pin "1" (uuid "0176dd74-f144-41e3-b814-6950d18fecbd")
 		)
-		(pin "2" (uuid "2fb0bfb5-86cd-4ce9-993e-bd0fee1b4466")
+		(pin "2" (uuid "0d8a2d0a-3f3c-4e33-8e76-b9e5d649a7d3")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "D4") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "D4") (unit 1)
 				)
 			)
 		)
@@ -7965,7 +7965,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "a1ac978b-80b9-423d-99a8-946e93955de5")
+		(uuid "d355d400-d818-4e52-8db0-a339e60f43a7")
 		(property "Reference" "R4"
 			(at 209.55 129.54 0)
 			(effects
@@ -8000,13 +8000,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "1bed3647-589f-4058-a313-aacf7fef251f")
+		(pin "1" (uuid "9639c203-a489-4e3a-9657-82c8aa5fdc96")
 		)
-		(pin "2" (uuid "3d8ee71a-2de4-48f8-9ff3-2f5f95d01f04")
+		(pin "2" (uuid "bb358608-65c6-4855-b5b9-3eabc7e81ab1")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "R4") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "R4") (unit 1)
 				)
 			)
 		)
@@ -8019,7 +8019,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "566b185f-ab54-409d-9bd1-72d665b2df08")
+		(uuid "cb89c71d-1a79-458f-99b0-137f942a261f")
 		(property "Reference" "#PWR01"
 			(at 25.4 17.78 0)
 			(effects
@@ -8055,11 +8055,11 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "e143a1cc-7807-46e8-801e-218572c509f0")
+		(pin "1" (uuid "3fb0cba8-2c0b-4ac0-8096-7f0ca4c84d4f")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "#PWR01") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "#PWR01") (unit 1)
 				)
 			)
 		)
@@ -8072,7 +8072,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "54fbad98-43eb-4221-b808-f889c6defe55")
+		(uuid "23d42d8d-97d4-414a-936a-d11d8c993397")
 		(property "Reference" "#PWR02"
 			(at 105.41 38.1 0)
 			(effects
@@ -8108,11 +8108,11 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "af899e0c-c318-4475-b7e5-bf42d39b71f8")
+		(pin "1" (uuid "41b63485-2ac1-4469-aaf4-c6f4e38de954")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "#PWR02") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "#PWR02") (unit 1)
 				)
 			)
 		)
@@ -8125,7 +8125,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "5358db3d-c84b-497c-aa4e-66c7c5b2b4e2")
+		(uuid "60e42d80-6352-4f98-a20f-d53ccd0436b0")
 		(property "Reference" "#PWR03"
 			(at 165.1 57.15 0)
 			(effects
@@ -8161,11 +8161,11 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "ef975384-d6cb-413f-b5d4-a3a22b4196a0")
+		(pin "1" (uuid "469222ce-1079-4b23-9efa-636d33e35c1d")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "#PWR03") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "#PWR03") (unit 1)
 				)
 			)
 		)
@@ -8178,7 +8178,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "29c84736-5ffb-4fe9-b52d-0c04d070fd05")
+		(uuid "f6992e66-005f-4614-885a-743e611193c0")
 		(property "Reference" "#PWR04"
 			(at 25.4 292.1 0)
 			(effects
@@ -8214,11 +8214,11 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "b8efb40e-1160-4010-873a-27781073d357")
+		(pin "1" (uuid "431c45fb-ca61-4894-8cd3-f072c5f2f342")
 		)
 		(instances
 			(project "project"
-				(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (reference "#PWR04") (unit 1)
+				(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (reference "#PWR04") (unit 1)
 				)
 			)
 		)
@@ -8229,7 +8229,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "8130ee99-fc95-4cdf-8e1d-b4f7339b5f13")
+		(uuid "cd0665bb-728a-4435-9a27-02fc2ab37087")
 	)
 	(wire
 		(pts (xy 25.4 15.24) (xy 25.4 25.4))
@@ -8237,7 +8237,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "2d68662d-ba70-4d9a-b781-526a9734ac2d")
+		(uuid "aaa19002-3af5-448c-99fa-62d58d1ab3ef")
 	)
 	(wire
 		(pts (xy 105.41 44.45) (xy 309.88 44.45))
@@ -8245,7 +8245,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "6e3b0f82-9619-4de4-b979-0b202553601a")
+		(uuid "080a236c-97b7-4cc2-8729-df544445113f")
 	)
 	(wire
 		(pts (xy 105.41 35.56) (xy 105.41 44.45))
@@ -8253,7 +8253,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "4b53c580-1875-401e-918b-9851e39ff2b3")
+		(uuid "1c4b1b85-8a20-4b91-afde-de032f21a67e")
 	)
 	(wire
 		(pts (xy 147.32 64.77) (xy 279.4 64.77))
@@ -8261,7 +8261,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "f397db2c-56b3-4ebb-b2c4-77c097528add")
+		(uuid "daeeb200-63c4-4173-a0c9-dbf9c902aef9")
 	)
 	(wire
 		(pts (xy 165.1 54.61) (xy 165.1 64.77))
@@ -8269,7 +8269,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "f7292344-63d0-4128-89ab-037ccfcd2bae")
+		(uuid "88c41ab7-f7d2-4c1e-95d6-3802e1e6f98b")
 	)
 	(wire
 		(pts (xy 25.4 279.4) (xy 299.72 279.4))
@@ -8277,7 +8277,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "1968d473-3308-42c9-9565-682b253e77e2")
+		(uuid "9eb75297-b919-4360-942b-f86594b283e0")
 	)
 	(wire
 		(pts (xy 25.4 289.56) (xy 25.4 279.4))
@@ -8285,7 +8285,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "fa71c49b-29b2-47c6-abff-9c8aabffa468")
+		(uuid "f23cb17f-d785-46af-8f7a-6122d70bd879")
 	)
 	(wire
 		(pts (xy 299.72 279.4) (xy 309.88 279.4))
@@ -8293,7 +8293,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "35715083-75b1-4c1f-8912-cc324dc4fb2a")
+		(uuid "35ac2bbf-d5ed-472d-b6b6-de6f719dd995")
 	)
 	(wire
 		(pts (xy 30.48 100.33) (xy 44.45 96.52))
@@ -8301,7 +8301,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "8ed5102e-859c-4548-9e40-7c45bf8a4e72")
+		(uuid "6c6a1499-f5e3-4e61-9c30-f3fc5d8056e9")
 	)
 	(wire
 		(pts (xy 44.45 104.14) (xy 44.45 25.4))
@@ -8309,7 +8309,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "c3042f42-7061-480f-b687-8e0016bcb36b")
+		(uuid "d8343cb0-e6c9-491c-8c50-c97e6b1e4d51")
 	)
 	(wire
 		(pts (xy 64.77 123.19) (xy 64.77 25.4))
@@ -8317,7 +8317,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "0ecece15-aef8-49c8-8f5c-34ba8316ecd6")
+		(uuid "837e20e9-a267-4673-9a10-c96c50c7b301")
 	)
 	(wire
 		(pts (xy 64.77 115.57) (xy 64.77 279.4))
@@ -8325,7 +8325,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "6d6ce074-37e9-4984-a2e4-008bdcae05d1")
+		(uuid "8472ae99-8851-4e81-bc10-ba18595af0b8")
 	)
 	(wire
 		(pts (xy 80.01 115.57) (xy 80.01 25.4))
@@ -8333,7 +8333,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "2335e2ba-fa34-43db-88a2-9f1bd212074b")
+		(uuid "898a98e2-8b8a-435a-be6d-920225253e7c")
 	)
 	(wire
 		(pts (xy 80.01 123.19) (xy 80.01 279.4))
@@ -8341,7 +8341,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "11053790-c605-4632-8dd3-ae33e0ab0651")
+		(uuid "51d2252f-7aa2-4023-a19e-be107eea0112")
 	)
 	(wire
 		(pts (xy 95.25 115.57) (xy 95.25 25.4))
@@ -8349,7 +8349,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "48ad6d4d-53a0-4d94-b503-3aa032b02970")
+		(uuid "62c40d11-8c0d-460d-a764-e90c7550f62e")
 	)
 	(wire
 		(pts (xy 95.25 123.19) (xy 95.25 279.4))
@@ -8357,7 +8357,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "195091c2-992e-4ae3-8eb8-5312af9ad85a")
+		(uuid "5de11bca-ee7c-4309-9e2d-dce18ddfe36c")
 	)
 	(wire
 		(pts (xy 30.48 102.87) (xy 30.48 279.4))
@@ -8365,7 +8365,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "e82fa89c-a9c9-4403-be9f-af0a52f996df")
+		(uuid "dd45de78-15bc-4d05-97b8-866fd23965e8")
 	)
 	(wire
 		(pts (xy 92.71 102.87) (xy 105.41 96.52))
@@ -8373,7 +8373,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "2bb852e0-4205-442d-987b-338700d963c1")
+		(uuid "75d447ea-778a-4d2c-8dfc-dcbb91795abb")
 	)
 	(wire
 		(pts (xy 105.41 123.19) (xy 105.41 123.19))
@@ -8381,7 +8381,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "39f476ea-7a8e-489d-b948-66adc80027a7")
+		(uuid "8fe2966b-d36e-4af9-8030-aa97dfb8e120")
 	)
 	(wire
 		(pts (xy 105.41 123.19) (xy 105.41 96.52))
@@ -8389,7 +8389,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "f1fe7c72-f409-42de-bc09-ba804829f762")
+		(uuid "6fde29c3-c479-4cc9-8f60-271355893fe0")
 	)
 	(wire
 		(pts (xy 105.41 104.14) (xy 105.41 111.76))
@@ -8397,7 +8397,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "602b12b2-e12a-4a96-b5ec-547efba93972")
+		(uuid "f9551441-5336-4dbc-a483-6db24a980eb6")
 	)
 	(wire
 		(pts (xy 105.41 111.76) (xy 129.54 111.76))
@@ -8405,7 +8405,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "76fcfab5-7ff2-4f28-accd-0f836e78c425")
+		(uuid "de533c24-0059-4b26-b52b-fa92daf062c4")
 	)
 	(wire
 		(pts (xy 67.31 97.79) (xy 64.77 97.79))
@@ -8413,7 +8413,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "0a0cf939-2624-49e9-ba0f-16f897edc17c")
+		(uuid "b73e89a6-b866-4040-a17b-2f295d9f8046")
 	)
 	(wire
 		(pts (xy 80.01 107.95) (xy 82.55 107.95))
@@ -8421,7 +8421,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "e6348ea3-7c1f-4346-969b-7c5fab5f68c2")
+		(uuid "fc0e2cfc-21b2-42a8-a89a-3507f3a0ca21")
 	)
 	(wire
 		(pts (xy 92.71 97.79) (xy 95.25 97.79))
@@ -8429,7 +8429,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "90d05e05-3000-4ac7-a740-051edbf52a48")
+		(uuid "2b1f52fa-ef34-4ac5-9b3a-6b6f356fe8a3")
 	)
 	(wire
 		(pts (xy 132.08 100.33) (xy 129.54 100.33))
@@ -8437,7 +8437,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "393e104a-8069-49d4-82fb-aba5bde409e4")
+		(uuid "02e9cc7c-4541-43c7-96d4-a2767457349c")
 	)
 	(wire
 		(pts (xy 147.32 100.33) (xy 149.86 100.33))
@@ -8445,7 +8445,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "ba91a315-83ca-408c-9e49-ba6f1407218b")
+		(uuid "66d6fe8d-0fe1-44c8-a888-a0237a1d7dad")
 	)
 	(wire
 		(pts (xy 139.7 107.95) (xy 137.16 107.95))
@@ -8453,7 +8453,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "426bac99-9aee-4e70-9208-2104ed231619")
+		(uuid "fcea0c7b-95d9-407f-b412-f95ecdd4ed1d")
 	)
 	(wire
 		(pts (xy 67.31 97.79) (xy 67.31 25.4))
@@ -8461,7 +8461,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "b55c22f1-e638-411c-832d-5bccef7f4b11")
+		(uuid "cb7cdca2-7d99-4dd2-ab30-d766cc890df8")
 	)
 	(wire
 		(pts (xy 80.01 107.95) (xy 80.01 279.4))
@@ -8469,7 +8469,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "16694960-4348-4939-9b58-9e72ea80afe1")
+		(uuid "e6caeb90-2b2f-49a8-80ff-2b7cc143ffca")
 	)
 	(wire
 		(pts (xy 54.61 111.76) (xy 54.61 25.4))
@@ -8477,7 +8477,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "bafa2916-1bda-45c7-8d41-e26e902bf00f")
+		(uuid "6b6de5fe-037f-4438-bb41-bb013979cd99")
 	)
 	(wire
 		(pts (xy 54.61 119.38) (xy 54.61 279.4))
@@ -8485,7 +8485,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "bafd65bc-8f9d-43a8-819b-8cc4f27a73c7")
+		(uuid "2af0c28a-788f-42f7-8677-757890ec825a")
 	)
 	(wire
 		(pts (xy 129.54 111.76) (xy 129.54 44.45))
@@ -8493,7 +8493,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "7ef697cc-97d6-40f0-9021-df717a818f48")
+		(uuid "21fb2f39-61c2-4afa-a540-0f9e08e88e77")
 	)
 	(wire
 		(pts (xy 129.54 119.38) (xy 129.54 279.4))
@@ -8501,7 +8501,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "b1487aec-79b5-4bd7-85cf-d780979ec9db")
+		(uuid "20187702-f26d-46eb-999a-19a2f80ebaf0")
 	)
 	(wire
 		(pts (xy 129.54 111.76) (xy 129.54 44.45))
@@ -8509,7 +8509,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "0d63b394-f6e5-4347-9aa6-6c73e3e661a0")
+		(uuid "76e3ba51-ea76-47a9-aeb4-53d1d6a5dcaf")
 	)
 	(wire
 		(pts (xy 105.41 115.57) (xy 105.41 279.4))
@@ -8517,7 +8517,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "872dc146-48a8-4b35-a4db-83439589141d")
+		(uuid "3463f376-b324-4ec5-916b-f7db0ce349c7")
 	)
 	(wire
 		(pts (xy 132.08 100.33) (xy 132.08 44.45))
@@ -8525,7 +8525,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "0928373b-4589-4ec0-86b7-d6c88a34d05c")
+		(uuid "725f542d-2ba6-46a2-a4a9-6c7d9d3562a2")
 	)
 	(wire
 		(pts (xy 147.32 100.33) (xy 147.32 64.77))
@@ -8533,7 +8533,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "8906ca42-adb5-43cb-a4fe-15f96fd7e68b")
+		(uuid "cdc3fccf-5f29-446b-802c-17ee887bbb17")
 	)
 	(wire
 		(pts (xy 139.7 107.95) (xy 139.7 279.4))
@@ -8541,7 +8541,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "f2648371-151a-40dc-97ea-d94536403a93")
+		(uuid "a7c3a3c8-691d-4e59-b2b5-cab36cfa4108")
 	)
 	(wire
 		(pts (xy 119.38 111.76) (xy 119.38 44.45))
@@ -8549,7 +8549,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "ee91dfff-d469-461f-95b7-4df3476165db")
+		(uuid "94c00678-e6f2-4f7c-a834-de400baf1dbc")
 	)
 	(wire
 		(pts (xy 119.38 119.38) (xy 119.38 279.4))
@@ -8557,7 +8557,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "77241d24-b4a8-438b-aa5f-8baf82d00a09")
+		(uuid "0f3b95bf-01b8-42b1-9f20-e4bd6b73791b")
 	)
 	(wire
 		(pts (xy 160.02 111.76) (xy 160.02 64.77))
@@ -8565,7 +8565,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "5e63833a-2ad2-4bc3-8195-5005e323760f")
+		(uuid "8e0663e8-d545-4e00-af90-8bb537cea7bb")
 	)
 	(wire
 		(pts (xy 160.02 119.38) (xy 160.02 279.4))
@@ -8573,7 +8573,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "08d7146f-e9d0-4beb-b3bc-ce358dc506d2")
+		(uuid "7bee84aa-dcf3-4c9a-ae6a-80227dc81c14")
 	)
 	(wire
 		(pts (xy 67.31 102.87) (xy 67.31 279.4))
@@ -8581,7 +8581,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "bdbdca4f-f656-4b58-a5f8-5e9a432cac46")
+		(uuid "4c730c32-f5e6-4745-af58-04af34613058")
 	)
 	(wire
 		(pts (xy 199.39 96.52) (xy 199.39 64.77))
@@ -8589,7 +8589,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "54460834-ef24-46f1-a2ef-49fc76a1fe45")
+		(uuid "7b15ccb1-f700-4a75-a178-9c06e3281112")
 	)
 	(wire
 		(pts (xy 199.39 104.14) (xy 199.39 279.4))
@@ -8597,7 +8597,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "a7f9ab35-80b7-4a7e-93ed-cbc74b58aa30")
+		(uuid "b1d2c29b-893c-4c59-a7f2-831711449f6d")
 	)
 	(wire
 		(pts (xy 209.55 96.52) (xy 209.55 64.77))
@@ -8605,7 +8605,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "47977cd4-04f4-40a9-ad9d-b9b939d8381c")
+		(uuid "00a9ebfb-7bdc-4fb0-a4e5-a511adae7d48")
 	)
 	(wire
 		(pts (xy 209.55 104.14) (xy 209.55 279.4))
@@ -8613,7 +8613,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "94abc8ff-7f39-4590-a60b-763ad1311f59")
+		(uuid "1bc5f568-ad27-4a0d-b94b-a9cbe909d329")
 	)
 	(wire
 		(pts (xy 219.71 96.52) (xy 219.71 64.77))
@@ -8621,7 +8621,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "5c4c2727-0175-4cba-9d31-ea45cc823cb1")
+		(uuid "b477e3a3-9954-4f5a-a923-7435e658043f")
 	)
 	(wire
 		(pts (xy 219.71 104.14) (xy 219.71 279.4))
@@ -8629,7 +8629,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "7416fcbd-0dc6-47a8-a972-025f3f8d0d04")
+		(uuid "de98718a-978e-47fb-ac9a-46834aa9a386")
 	)
 	(wire
 		(pts (xy 227.33 137.16) (xy 222.25 137.16))
@@ -8637,7 +8637,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "7c3279ff-958b-43be-bb16-f7b6fe4b5d85")
+		(uuid "060104d6-9934-45d0-b580-36e54e50eb29")
 	)
 	(wire
 		(pts (xy 229.87 137.16) (xy 224.79 137.16))
@@ -8645,7 +8645,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "da774158-1b15-4e1e-80d6-12e96ca89c83")
+		(uuid "2e83869e-09b7-43f6-aaec-8ed101930f7e")
 	)
 	(wire
 		(pts (xy 232.41 137.16) (xy 227.33 137.16))
@@ -8653,7 +8653,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "31e4f520-bedd-4475-b9bc-51302f1dda9d")
+		(uuid "f21b709a-af2c-469f-b4c6-d3415484e27f")
 	)
 	(wire
 		(pts (xy 232.41 190.5) (xy 227.33 190.5))
@@ -8661,7 +8661,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "c02d34c6-14ff-47b3-8b06-fab6c735afc2")
+		(uuid "7730ec9d-f8b7-4a65-b1d9-ea53409247af")
 	)
 	(wire
 		(pts (xy 229.87 190.5) (xy 224.79 190.5))
@@ -8669,7 +8669,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "1c4d7b85-0084-4f69-8077-8fdd95f75651")
+		(uuid "225de9e9-95ca-4466-9f6f-0c3645facb4e")
 	)
 	(wire
 		(pts (xy 229.87 190.5) (xy 224.79 190.5))
@@ -8677,7 +8677,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "ab5db51d-9868-4ba4-8e93-c70adf08d400")
+		(uuid "c3f0313a-68b0-4cd7-a5b1-79f957274cf7")
 	)
 	(wire
 		(pts (xy 217.17 144.78) (xy 212.09 144.78))
@@ -8685,7 +8685,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "d279e0d1-c27a-4af2-84d1-daa4ac0ed3bf")
+		(uuid "ce3970cb-0cdf-454b-a3c1-fc9aa617607d")
 	)
 	(wire
 		(pts (xy 242.57 144.78) (xy 247.65 144.78))
@@ -8693,7 +8693,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "27753e58-e15a-4db6-8806-37f1c17ca987")
+		(uuid "22228bc0-9290-4363-bc1f-b5be294dab73")
 	)
 	(wire
 		(pts (xy 242.57 147.32) (xy 247.65 147.32))
@@ -8701,7 +8701,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "ad1f5cf8-dcb0-4e09-91d0-e0e12175cccf")
+		(uuid "2c3f9ade-8424-4a25-9158-5a7ba3dbff8e")
 	)
 	(wire
 		(pts (xy 242.57 149.86) (xy 247.65 149.86))
@@ -8709,7 +8709,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "5db1ac85-ed77-456f-ab70-022fdfee07f3")
+		(uuid "40283cbf-a599-49e7-bd22-f7f6262c2576")
 	)
 	(wire
 		(pts (xy 242.57 160.02) (xy 247.65 160.02))
@@ -8717,7 +8717,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "f6a7f9c4-1d58-404f-ba50-4cc70e7c69f8")
+		(uuid "e3cbf396-d55a-47e4-bff9-7806c0c97900")
 	)
 	(wire
 		(pts (xy 242.57 162.56) (xy 247.65 162.56))
@@ -8725,7 +8725,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "fa688346-3d1b-4adb-805d-cab96cdf142b")
+		(uuid "be011166-c097-4edb-8242-23d0c0b5545d")
 	)
 	(wire
 		(pts (xy 217.17 157.48) (xy 222.25 157.48))
@@ -8733,7 +8733,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "2e379bb5-83df-4474-80db-7fb85cb93d9a")
+		(uuid "5a3d9921-af5f-42c4-a055-f72b4f82db28")
 	)
 	(wire
 		(pts (xy 242.57 165.1) (xy 247.65 165.1))
@@ -8741,7 +8741,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "61fa0883-a258-4bca-ac93-4707fbbc161c")
+		(uuid "0b468e0c-88d0-49ad-a558-a317d5ae0c7d")
 	)
 	(wire
 		(pts (xy 242.57 167.64) (xy 247.65 167.64))
@@ -8749,7 +8749,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "eac472f1-17cd-4206-b261-110f3bc9536d")
+		(uuid "56c18a07-dd9a-4dae-9517-05af21a5c566")
 	)
 	(wire
 		(pts (xy 242.57 170.18) (xy 247.65 170.18))
@@ -8757,7 +8757,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "92f45704-2608-4145-808b-fefb7742ed8e")
+		(uuid "3aa5c637-2f5d-458e-adc2-f7080fe89087")
 	)
 	(wire
 		(pts (xy 242.57 177.8) (xy 247.65 177.8))
@@ -8765,7 +8765,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "bf9a3564-626f-445f-9a7b-a71317a3a019")
+		(uuid "54701167-47da-461f-85ad-1ea6a99e8d6e")
 	)
 	(wire
 		(pts (xy 242.57 180.34) (xy 247.65 180.34))
@@ -8773,7 +8773,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "b566163b-cc78-4d40-a2e4-9ba45bee7b19")
+		(uuid "13b2c262-5989-434a-a7fe-f3e57178e4d8")
 	)
 	(wire
 		(pts (xy 217.17 160.02) (xy 222.25 160.02))
@@ -8781,7 +8781,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "387b4dc6-918a-4fd5-b834-a6315e29dd0e")
+		(uuid "cde6d266-296a-44c7-977d-92ebb4217a12")
 	)
 	(wire
 		(pts (xy 217.17 167.64) (xy 222.25 167.64))
@@ -8789,7 +8789,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "3c39ef30-83b5-473d-9eb2-b9ce7666e37c")
+		(uuid "96aa27ea-a232-4cdd-be68-3cd34420aa04")
 	)
 	(wire
 		(pts (xy 217.17 170.18) (xy 222.25 170.18))
@@ -8797,7 +8797,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "40590cdc-a121-4fc0-99ab-6618893f8b8a")
+		(uuid "11369610-aaa2-4ecd-8d29-362ce3047ae5")
 	)
 	(wire
 		(pts (xy 217.17 172.72) (xy 222.25 172.72))
@@ -8805,7 +8805,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "4699159c-ce3d-40cf-be20-ccc0a45593e7")
+		(uuid "fda76ce2-7ad2-4ca2-ba75-0e742608436f")
 	)
 	(wire
 		(pts (xy 217.17 149.86) (xy 212.09 149.86))
@@ -8813,7 +8813,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "ca54028a-0c18-4dd0-beaf-5cc3fddc2681")
+		(uuid "c3feb0b4-c0aa-4c4e-9a3d-63c07e999728")
 	)
 	(wire
 		(pts (xy 217.17 152.4) (xy 212.09 152.4))
@@ -8821,7 +8821,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "d5756ddb-180b-45a8-b11f-77aa7d36d3d2")
+		(uuid "b413bf43-4d09-4045-a38f-9181d8b3edba")
 	)
 	(wire
 		(pts (xy 266.7 100.33) (xy 262.89 100.33))
@@ -8829,7 +8829,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "a6f644cd-b080-4edd-b562-0c057e476e6a")
+		(uuid "c967855d-4788-4952-a28d-1b3f45721c56")
 	)
 	(wire
 		(pts (xy 262.89 100.33) (xy 262.89 111.76))
@@ -8837,7 +8837,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "9125d5cc-49cc-4f3e-9b49-69821b4eeed2")
+		(uuid "c5a3be30-3789-47c7-8ae3-ff8ca725edd2")
 	)
 	(wire
 		(pts (xy 274.32 100.33) (xy 278.13 100.33))
@@ -8845,7 +8845,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "3918d46d-85eb-48ab-8bca-35b3c1741ebe")
+		(uuid "a4c48044-2aa7-4db2-874c-5c727420b82b")
 	)
 	(wire
 		(pts (xy 278.13 100.33) (xy 278.13 111.76))
@@ -8853,7 +8853,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "60fe5e6a-62b5-4501-9b19-94450e2e592b")
+		(uuid "1098f5e8-e696-48a3-a571-6ac28a21a8e8")
 	)
 	(wire
 		(pts (xy 262.89 119.38) (xy 278.13 119.38))
@@ -8861,7 +8861,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "81951a41-88f4-44e2-ad39-0219b3c9620a")
+		(uuid "e5f7c165-7085-42ce-ada3-bbffe0d8fbcd")
 	)
 	(wire
 		(pts (xy 270.51 119.38) (xy 270.51 279.4))
@@ -8869,7 +8869,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "1a3669c8-d5ee-420b-a5b3-9d52c8f27293")
+		(uuid "4fe245a5-aa2d-4995-9162-ccd03ac3e64f")
 	)
 	(wire
 		(pts (xy 266.7 100.33) (xy 261.62 100.33))
@@ -8877,7 +8877,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "d497b381-4f32-4926-9b15-bfd50417b763")
+		(uuid "e29fa17b-4ec8-4657-bcd4-a4a0719682eb")
 	)
 	(wire
 		(pts (xy 274.32 100.33) (xy 279.4 100.33))
@@ -8885,7 +8885,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "6cc43c11-b883-4317-b496-8f88fead531a")
+		(uuid "a96fcc7a-4ce4-4076-8ee9-1b41d54a523f")
 	)
 	(wire
 		(pts (xy 294.64 95.25) (xy 292.1 95.25))
@@ -8893,7 +8893,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "74af8e24-fd89-4a92-b584-b944d10f879a")
+		(uuid "4f05ed36-501a-4ac9-a542-1a9ff53d8864")
 	)
 	(wire
 		(pts (xy 294.64 97.79) (xy 292.1 97.79))
@@ -8901,7 +8901,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "8cdd4986-23b2-4cd6-8f75-1bf4529ceac0")
+		(uuid "e04e633b-55cc-4686-a3e9-9c23829249cd")
 	)
 	(wire
 		(pts (xy 294.64 100.33) (xy 292.1 100.33))
@@ -8909,7 +8909,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "8b0450ca-80ee-459e-affd-454e57240b64")
+		(uuid "3f0a8654-e361-4f93-a608-bd8e5e97dae5")
 	)
 	(wire
 		(pts (xy 294.64 102.87) (xy 292.1 102.87))
@@ -8917,7 +8917,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "0ab51c62-1b0f-42a9-8a7a-3cc1688212da")
+		(uuid "549f2732-c6ae-4174-99ab-9bb9819bb091")
 	)
 	(wire
 		(pts (xy 294.64 105.41) (xy 292.1 105.41))
@@ -8925,7 +8925,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "44e4ace6-33a2-448e-a481-ecebc5d693bd")
+		(uuid "d7fd963f-6a78-4e50-801b-f08f4138b652")
 	)
 	(wire
 		(pts (xy 294.64 107.95) (xy 292.1 107.95))
@@ -8933,7 +8933,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "c235b36b-12fa-4bca-a130-7167e7aa78f7")
+		(uuid "cf75a690-7431-4d19-8980-82f12f094e62")
 	)
 	(wire
 		(pts (xy 294.64 95.25) (xy 294.64 64.77))
@@ -8941,7 +8941,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "c7e79f97-82fa-4b49-9c87-bf2cadc3ee13")
+		(uuid "af84fa39-fd69-468b-8c30-d8259b26f657")
 	)
 	(wire
 		(pts (xy 294.64 100.33) (xy 294.64 279.4))
@@ -8949,7 +8949,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "337a0332-99bf-41c2-9714-dd436ff6f977")
+		(uuid "10e36be8-70a6-47af-800e-d2634f280ffc")
 	)
 	(wire
 		(pts (xy 259.08 72.39) (xy 256.54 72.39))
@@ -8957,7 +8957,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "384277a6-6416-44b2-b8ce-cc626e958a89")
+		(uuid "a4562438-8a60-43d2-9902-74cc3e64c65b")
 	)
 	(wire
 		(pts (xy 259.08 69.85) (xy 256.54 69.85))
@@ -8965,7 +8965,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "15a372a6-e91e-4eae-b549-17bf2b9d327f")
+		(uuid "68b83efe-2ee5-47f1-ba94-34838f606d86")
 	)
 	(wire
 		(pts (xy 259.08 74.93) (xy 256.54 74.93))
@@ -8973,7 +8973,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "67dcfefc-c343-4772-9eed-a1d82e5a763c")
+		(uuid "0eb27895-937a-4d3f-9c0b-fa4ed05e6878")
 	)
 	(wire
 		(pts (xy 259.08 80.01) (xy 256.54 80.01))
@@ -8981,7 +8981,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "789dc0a2-b517-4605-a2c6-4a18ec280064")
+		(uuid "7a202702-eb70-4320-9b76-576299d536f8")
 	)
 	(wire
 		(pts (xy 259.08 95.25) (xy 256.54 95.25))
@@ -8989,7 +8989,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "4bbee533-febe-48ef-850f-bd2aaed63cc7")
+		(uuid "ad2c0d3b-f428-4c3a-a346-ceca08e46e5f")
 	)
 	(wire
 		(pts (xy 259.08 85.09) (xy 256.54 85.09))
@@ -8997,7 +8997,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "5a9ebddd-4a9b-4971-94c0-94dd7125bf83")
+		(uuid "a515e099-2646-4608-931b-1c0007b0ee15")
 	)
 	(wire
 		(pts (xy 259.08 87.63) (xy 256.54 87.63))
@@ -9005,7 +9005,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "13a71c16-c4ad-47b0-bc05-5de8565feba1")
+		(uuid "02d239dd-fdc7-4e0f-b15f-b544628209fa")
 	)
 	(wire
 		(pts (xy 259.08 92.71) (xy 256.54 92.71))
@@ -9013,7 +9013,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "3503aa64-ba0b-4519-af4f-bdf5f222b189")
+		(uuid "2cc3dbb3-64fe-4745-ba18-fc958b85c5d7")
 	)
 	(wire
 		(pts (xy 259.08 90.17) (xy 256.54 90.17))
@@ -9021,7 +9021,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "5684f428-9186-4cb0-80c0-136cba586888")
+		(uuid "f581ee39-d4bb-4cab-af3e-93609b466e8c")
 	)
 	(wire
 		(pts (xy 259.08 105.41) (xy 256.54 105.41))
@@ -9029,7 +9029,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "42dc6eed-9fc4-4a68-a046-b0ddf857adca")
+		(uuid "0da338a5-a343-4036-9621-562af32410aa")
 	)
 	(wire
 		(pts (xy 259.08 102.87) (xy 256.54 102.87))
@@ -9037,7 +9037,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "abcec819-0065-4f8a-96d3-c1e25ee66451")
+		(uuid "48647aae-451e-41bc-9388-4c9f6a4c2d8f")
 	)
 	(wire
 		(pts (xy 259.08 77.47) (xy 256.54 77.47))
@@ -9045,7 +9045,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "35112615-d562-4d81-b579-7e0a3af35fe6")
+		(uuid "705ede31-eaf9-4670-abca-c5dcc3023538")
 	)
 	(wire
 		(pts (xy 259.08 100.33) (xy 256.54 100.33))
@@ -9053,7 +9053,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "0a5d5a71-5bd7-43d1-b0ad-cb0394923277")
+		(uuid "23daf370-88f7-4425-9de0-dfd85db56564")
 	)
 	(wire
 		(pts (xy 259.08 107.95) (xy 256.54 107.95))
@@ -9061,7 +9061,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "18881a46-5368-4908-97c8-39519946ffa3")
+		(uuid "c3a71a85-4303-41f9-8557-c7a44860f342")
 	)
 	(wire
 		(pts (xy 259.08 110.49) (xy 256.54 110.49))
@@ -9069,7 +9069,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "5b73a784-2fb8-485d-b6e6-3dd2d1a6eb20")
+		(uuid "8c07bcea-7fee-4eca-be5a-f49c9c0c160f")
 	)
 	(wire
 		(pts (xy 259.08 113.03) (xy 256.54 113.03))
@@ -9077,7 +9077,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "fe088815-fac9-43ea-83da-5a8422fe8157")
+		(uuid "60720a57-7ae4-4817-b553-13eca5443c0b")
 	)
 	(wire
 		(pts (xy 299.72 62.23) (xy 302.26 62.23))
@@ -9085,7 +9085,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "b0347c60-95d3-4cb2-a07e-9a11278a492f")
+		(uuid "9d2f56f9-b4c3-4c7a-b0ec-3bd925cb5606")
 	)
 	(wire
 		(pts (xy 299.72 72.39) (xy 302.26 72.39))
@@ -9093,7 +9093,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "3e215716-9df8-470c-8dc5-31ee2fd49479")
+		(uuid "4931620f-f2b4-4c27-8152-215ece045eb5")
 	)
 	(wire
 		(pts (xy 299.72 82.55) (xy 302.26 82.55))
@@ -9101,7 +9101,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "553eff81-69f7-4ad3-9644-3348a5371bc4")
+		(uuid "1d7fcd9f-fffd-4774-b202-52d0fe5959a6")
 	)
 	(wire
 		(pts (xy 299.72 67.31) (xy 302.26 67.31))
@@ -9109,7 +9109,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "601601a0-dc36-429e-88c4-78e577f8a6fc")
+		(uuid "4ec041d6-3b42-4d8c-a28c-71ca2dca203b")
 	)
 	(wire
 		(pts (xy 299.72 77.47) (xy 302.26 77.47))
@@ -9117,7 +9117,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "770d9e41-e3c9-4e2b-8299-84d2bc2eef25")
+		(uuid "1921ca03-9ee5-4761-8ce2-ff0993bf724b")
 	)
 	(wire
 		(pts (xy 299.72 87.63) (xy 302.26 87.63))
@@ -9125,7 +9125,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "4a2229a9-e94f-430e-b6e2-533161b17cd8")
+		(uuid "562942ac-67b0-42b6-9ba0-6a26b9501459")
 	)
 	(wire
 		(pts (xy 299.72 100.33) (xy 302.26 100.33))
@@ -9133,7 +9133,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "f801f7b3-39c4-4014-b94f-73b98b1fe932")
+		(uuid "d12a683a-3dbd-4940-9054-df7b6b1e688b")
 	)
 	(wire
 		(pts (xy 299.72 102.87) (xy 302.26 102.87))
@@ -9141,7 +9141,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "e5d08668-0215-46f7-84eb-638ddbbd9dc0")
+		(uuid "043c24f3-37d7-441c-af74-ea423dafc34c")
 	)
 	(wire
 		(pts (xy 299.72 105.41) (xy 302.26 105.41))
@@ -9149,7 +9149,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "f1c5ebd7-3d22-45a5-b5fe-e4b29c76d8d6")
+		(uuid "6b4d171e-bcca-4e27-9fef-5d1711688ae8")
 	)
 	(wire
 		(pts (xy 299.72 107.95) (xy 302.26 107.95))
@@ -9157,7 +9157,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "10e02249-8459-4783-a036-d05fcb8bc609")
+		(uuid "10cbb2c3-7ddd-4b53-bfa9-fe9b3fb20a9f")
 	)
 	(wire
 		(pts (xy 299.72 110.49) (xy 302.26 110.49))
@@ -9165,7 +9165,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "e3273d1d-901d-4569-a04d-d9dda86cd78e")
+		(uuid "a8dc2b56-3f11-43eb-ba8f-3a4aee4d642b")
 	)
 	(wire
 		(pts (xy 299.72 113.03) (xy 302.26 113.03))
@@ -9173,7 +9173,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "7eb249c0-f3ad-40fa-9601-5a1004787b57")
+		(uuid "293402b2-b83d-41ed-b5c0-885f8ac8929d")
 	)
 	(wire
 		(pts (xy 299.72 64.77) (xy 302.26 64.77))
@@ -9181,7 +9181,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "41d771bd-a0c2-45da-bbe1-3f878f9ae236")
+		(uuid "27e3b0c3-0cdc-4544-882e-333a5e5da391")
 	)
 	(wire
 		(pts (xy 299.72 74.93) (xy 302.26 74.93))
@@ -9189,7 +9189,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "353160c9-a962-482c-abb1-0acb5a0e1f3e")
+		(uuid "012898ad-297f-49a4-9727-64bac8332fdd")
 	)
 	(wire
 		(pts (xy 299.72 85.09) (xy 302.26 85.09))
@@ -9197,7 +9197,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "2f269a0f-9dd8-4597-b651-7e0bfdc37d50")
+		(uuid "0a48c4ce-2d7a-4390-ba3f-faa79b915798")
 	)
 	(wire
 		(pts (xy 299.72 95.25) (xy 302.26 95.25))
@@ -9205,7 +9205,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "89b9d5cf-f9ea-42ff-a128-a3b9f4cea5a8")
+		(uuid "e821ab45-edb3-4933-b818-d27c09c2d174")
 	)
 	(wire
 		(pts (xy 276.86 118.11) (xy 274.32 118.11))
@@ -9213,7 +9213,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "40fd0abb-a45e-4c26-bd30-2c884db365a8")
+		(uuid "a14191bf-68e0-4748-9c05-a91fccc4100a")
 	)
 	(wire
 		(pts (xy 281.94 118.11) (xy 284.48 118.11))
@@ -9221,7 +9221,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "b58bccd6-764f-4b99-9e77-b805aefa91ce")
+		(uuid "167942f0-69d7-46cc-b6dc-0894885fe76d")
 	)
 	(wire
 		(pts (xy 259.08 62.23) (xy 256.54 62.23))
@@ -9229,7 +9229,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "1c4c08e5-ec41-48cf-8d19-e50e3b4a2841")
+		(uuid "6afb53c5-0bd7-427c-b67d-6c77a958108a")
 	)
 	(wire
 		(pts (xy 259.08 64.77) (xy 256.54 64.77))
@@ -9237,7 +9237,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "ba9fa13e-a6c9-4fe7-89e5-91407449ece8")
+		(uuid "9cacb3cf-05c0-4538-a031-5951372b337b")
 	)
 	(wire
 		(pts (xy 271.78 57.15) (xy 271.78 54.61))
@@ -9245,7 +9245,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "df1354fb-cafb-4bd3-9497-c69ac060874c")
+		(uuid "235b32f1-89ab-4b18-8505-20325e3547eb")
 	)
 	(wire
 		(pts (xy 274.32 57.15) (xy 274.32 54.61))
@@ -9253,7 +9253,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "09af8081-55df-44bc-b9c0-8d058c65d181")
+		(uuid "2a87b9d7-013a-4891-9fef-6ae29b47266f")
 	)
 	(wire
 		(pts (xy 279.4 57.15) (xy 279.4 54.61))
@@ -9261,7 +9261,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "95801e60-dfb0-4b76-9d99-facc3a91d7d3")
+		(uuid "11c0e0fb-374e-47be-82a1-966be89fb1a1")
 	)
 	(wire
 		(pts (xy 281.94 57.15) (xy 281.94 54.61))
@@ -9269,7 +9269,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "fc62f2cf-959a-45a0-9a78-f9ef2caa7c7d")
+		(uuid "183c49b0-6849-4e2a-8427-509dc7ba8645")
 	)
 	(wire
 		(pts (xy 284.48 57.15) (xy 284.48 54.61))
@@ -9277,7 +9277,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "5750fdad-eb92-4f13-a5dd-7ef079bedbb7")
+		(uuid "8ce1229f-bd5f-4757-9210-746696f8ee8b")
 	)
 	(wire
 		(pts (xy 299.72 76.2) (xy 299.72 44.45))
@@ -9285,7 +9285,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "dbf04278-4078-4b45-8a8e-361347887e55")
+		(uuid "1a40cd21-74f1-4ef9-b1c0-61f45accaf0a")
 	)
 	(wire
 		(pts (xy 299.72 83.82) (xy 299.72 279.4))
@@ -9293,7 +9293,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "1654c142-1fbc-4806-b529-4875092a698a")
+		(uuid "9ad5d94c-70fa-4fff-ac6f-cf025314f2cb")
 	)
 	(wire
 		(pts (xy 309.88 76.2) (xy 309.88 44.45))
@@ -9301,7 +9301,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "b29387dd-0e9d-4e0b-b450-70a7f74a7bb2")
+		(uuid "3513a475-5e4d-4062-a0d3-2f69e4652661")
 	)
 	(wire
 		(pts (xy 309.88 83.82) (xy 309.88 279.4))
@@ -9309,7 +9309,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "a0fbe776-be73-4b10-a6f5-b08ea901e07e")
+		(uuid "65ce4015-1613-480d-93ee-75273e649975")
 	)
 	(wire
 		(pts (xy 260.35 76.2) (xy 260.35 73.66))
@@ -9317,7 +9317,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "904422ef-c482-4fa6-a8c4-114e5c827b17")
+		(uuid "61cbeeb1-31be-42c9-b122-12c957ca5f9f")
 	)
 	(wire
 		(pts (xy 260.35 83.82) (xy 260.35 86.36))
@@ -9325,7 +9325,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "14d79b94-80b0-4b1a-afe0-da7e1abb1ca6")
+		(uuid "80715e81-2614-473e-b8c5-8fe11a6a050d")
 	)
 	(wire
 		(pts (xy 270.51 76.2) (xy 270.51 73.66))
@@ -9333,7 +9333,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "a76fce05-b675-4993-99df-6dc36e9471ec")
+		(uuid "658f55d5-43c2-458c-9fca-764385f220e1")
 	)
 	(wire
 		(pts (xy 270.51 83.82) (xy 270.51 86.36))
@@ -9341,7 +9341,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "7f29d69a-f717-4555-8b75-1a3d46551d30")
+		(uuid "13e71b89-9480-4df9-b7c9-5504d984040c")
 	)
 	(wire
 		(pts (xy 279.4 76.2) (xy 279.4 73.66))
@@ -9349,7 +9349,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "03ebf9a2-fe84-42fa-ae5c-cc5e590a171a")
+		(uuid "49fe26dd-5bb2-43a0-98b8-725c1dff48d5")
 	)
 	(wire
 		(pts (xy 279.4 83.82) (xy 279.4 86.36))
@@ -9357,7 +9357,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "8635af07-0225-4a52-bbbc-e4a8ce86607a")
+		(uuid "01b364a5-eaff-497c-932e-01572bbc44cf")
 	)
 	(wire
 		(pts (xy 309.88 115.57) (xy 307.34 115.57))
@@ -9365,7 +9365,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "c2985ebc-c34d-4c82-9a0d-4380672ec571")
+		(uuid "edc17241-b253-4638-9072-e2b88fdd9285")
 	)
 	(wire
 		(pts (xy 309.88 123.19) (xy 312.42 123.19))
@@ -9373,7 +9373,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "91a22bf0-68d3-44ce-893a-fd065525bc59")
+		(uuid "fc999d33-7d2d-4e99-b949-a120c98beed8")
 	)
 	(wire
 		(pts (xy 320.04 115.57) (xy 317.5 115.57))
@@ -9381,7 +9381,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "397635a8-5365-4922-9e75-024be415dbbc")
+		(uuid "5f30d223-e894-4fa4-8422-8a255fc8ae35")
 	)
 	(wire
 		(pts (xy 320.04 123.19) (xy 322.58 123.19))
@@ -9389,7 +9389,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "1d7c3810-1086-43ab-9d7e-1d7d74e775f8")
+		(uuid "81170157-4249-49ec-9524-61e8e3b46bdc")
 	)
 	(wire
 		(pts (xy 330.2 115.57) (xy 327.66 115.57))
@@ -9397,7 +9397,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "b1d07aec-7ad6-4e5a-872f-a0d8c744b41c")
+		(uuid "5ed7e203-e24d-4405-9cc4-57890e4ab09e")
 	)
 	(wire
 		(pts (xy 330.2 123.19) (xy 332.74 123.19))
@@ -9405,7 +9405,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "55bc9b19-b843-474e-9968-b74e7c12b3d3")
+		(uuid "490b0927-5ca8-424b-a7db-5286a9e904f3")
 	)
 	(wire
 		(pts (xy 27.94 165.1) (xy 27.94 194.31))
@@ -9413,7 +9413,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "52588d9c-be4f-45ee-87e2-c97e459d6eb2")
+		(uuid "c658fc0c-aaaa-4326-af40-9b381a102e8f")
 	)
 	(wire
 		(pts (xy 20.32 160.02) (xy 17.78 160.02))
@@ -9421,7 +9421,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "33f42882-1f03-4cc2-9182-598eb4c2d307")
+		(uuid "0cd39d00-fa44-4255-84cc-65da363f6e5e")
 	)
 	(wire
 		(pts (xy 20.32 199.39) (xy 17.78 199.39))
@@ -9429,7 +9429,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "b58f65c3-e75e-4b91-b79f-9285b7ddb146")
+		(uuid "de415f94-2cf8-43da-8934-1b2b3e359c0f")
 	)
 	(wire
 		(pts (xy 27.94 179.07) (xy 38.1 179.07))
@@ -9437,7 +9437,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "c01da445-b51b-4513-9aaf-0a0ffcfe1d8c")
+		(uuid "ba5d9dda-3e49-4a06-a33b-b16b826e3ebb")
 	)
 	(wire
 		(pts (xy 102.87 165.1) (xy 102.87 194.31))
@@ -9445,7 +9445,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "852f8788-30bf-45e0-a788-9a7ec9a7d0fe")
+		(uuid "f698f9b0-48dc-4dda-928f-5f93cb3e9fa8")
 	)
 	(wire
 		(pts (xy 95.25 160.02) (xy 92.71 160.02))
@@ -9453,7 +9453,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "f5f6bc13-d058-4837-b894-ec1b2010c393")
+		(uuid "2c4dcb2e-4acd-4fd3-a116-ef0229afa274")
 	)
 	(wire
 		(pts (xy 95.25 199.39) (xy 92.71 199.39))
@@ -9461,7 +9461,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "3457dbc9-bb52-4d5c-8895-5d72babf2107")
+		(uuid "67f31a08-ceee-41f6-9c35-f30a7fa3857f")
 	)
 	(wire
 		(pts (xy 102.87 179.07) (xy 113.03 179.07))
@@ -9469,7 +9469,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "dbc052b9-06ee-4d2c-9d76-cd731297ac4f")
+		(uuid "aa4ae613-36fb-4023-9c77-6cf40be0d619")
 	)
 	(wire
 		(pts (xy 177.8 165.1) (xy 177.8 194.31))
@@ -9477,7 +9477,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "71755fa5-1613-4189-bbc9-a703806d903a")
+		(uuid "5012f7e2-d57d-4216-98e9-c21e369e55b5")
 	)
 	(wire
 		(pts (xy 170.18 160.02) (xy 167.64 160.02))
@@ -9485,7 +9485,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "af503fcc-61dd-4994-ae95-c58a56864b8d")
+		(uuid "87632559-0ef4-43bb-9e3e-27cf5bcee5c1")
 	)
 	(wire
 		(pts (xy 170.18 199.39) (xy 167.64 199.39))
@@ -9493,7 +9493,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "d2cf0856-534c-4db0-a415-a71356912cee")
+		(uuid "085fac77-9c76-4854-aa36-49f25e262c2c")
 	)
 	(wire
 		(pts (xy 177.8 179.07) (xy 187.96 179.07))
@@ -9501,7 +9501,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "1bf71e13-043f-4b07-84e2-b48eaa455b8c")
+		(uuid "dd386a92-8cb9-455e-993b-8143a7a2909b")
 	)
 	(wire
 		(pts (xy 27.94 154.94) (xy 27.94 25.4))
@@ -9509,7 +9509,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "1f196fbd-24bb-450e-bbda-69d89df176d4")
+		(uuid "241651df-2810-46f7-b663-6bfcc9fea642")
 	)
 	(wire
 		(pts (xy 27.94 204.47) (xy 27.94 279.4))
@@ -9517,7 +9517,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "2b7eafc2-bd2d-469d-926c-14a16560276c")
+		(uuid "6580e4fb-9869-4224-b28c-e562d3acb320")
 	)
 	(wire
 		(pts (xy 102.87 154.94) (xy 102.87 25.4))
@@ -9525,7 +9525,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "ea2b245c-0bb4-417d-b89f-9e6c7e6b3904")
+		(uuid "f497e70c-f933-45d4-bd10-fa59a999fdcf")
 	)
 	(wire
 		(pts (xy 102.87 204.47) (xy 102.87 279.4))
@@ -9533,7 +9533,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "7be03994-b841-4e08-bba5-193a5c120ff2")
+		(uuid "436c236f-8efb-404f-b76a-1e34a786158e")
 	)
 	(wire
 		(pts (xy 177.8 154.94) (xy 177.8 25.4))
@@ -9541,7 +9541,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "68880c7d-f0ec-4480-b646-f01069dcdb24")
+		(uuid "98b49832-19fd-4f2e-9483-0b2756c116e0")
 	)
 	(wire
 		(pts (xy 177.8 204.47) (xy 177.8 279.4))
@@ -9549,7 +9549,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "0e5ed31c-9f39-4870-bf72-21606acbe2e1")
+		(uuid "28f27dad-a7bf-4919-8231-900e7cd5a8a0")
 	)
 	(wire
 		(pts (xy 25.4 243.84) (xy 25.4 279.4))
@@ -9557,7 +9557,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "dbe5ff33-0f37-4f54-bd93-7b023092a2ce")
+		(uuid "d99dfb16-d06b-4242-b57c-70963156dca0")
 	)
 	(wire
 		(pts (xy 27.94 204.47) (xy 25.4 236.22))
@@ -9565,7 +9565,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "dbe10b25-fe3d-4dbd-93ae-e0e64e37918e")
+		(uuid "678e2bb0-a395-4044-b5a9-ef7665ca6883")
 	)
 	(wire
 		(pts (xy 25.4 236.22) (xy 15.24 236.22))
@@ -9573,7 +9573,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "a2f9e092-aee9-4e18-aa7d-ad33aec257be")
+		(uuid "aed823c4-a286-4532-ad5d-3c133665b2df")
 	)
 	(wire
 		(pts (xy 25.4 243.84) (xy 15.24 243.84))
@@ -9581,7 +9581,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "9f303b23-7782-42b9-8f81-a89f052bdef4")
+		(uuid "e8b181cd-c89d-4363-b7b9-9243f2b30113")
 	)
 	(wire
 		(pts (xy 100.33 243.84) (xy 100.33 279.4))
@@ -9589,7 +9589,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "31c595f7-cfff-49c1-8f02-c91e71c00bcc")
+		(uuid "95678c17-a51d-4987-8fe3-1c397603d113")
 	)
 	(wire
 		(pts (xy 102.87 204.47) (xy 100.33 236.22))
@@ -9597,7 +9597,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "e00ced5e-c22c-4a7b-8f09-b1ae1a7d02f3")
+		(uuid "f9c163c7-7898-472f-9483-9feb662c284d")
 	)
 	(wire
 		(pts (xy 100.33 236.22) (xy 90.17 236.22))
@@ -9605,7 +9605,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "58ae02a4-202c-460a-a2de-fd46639e3a2e")
+		(uuid "90debbef-58d2-4b8e-969e-03a5a650afa5")
 	)
 	(wire
 		(pts (xy 100.33 243.84) (xy 90.17 243.84))
@@ -9613,7 +9613,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "cbecca60-43f2-45f6-a68d-6e92c41ff1b1")
+		(uuid "27de98ab-1782-4d40-bf07-84f5a96e3c04")
 	)
 	(wire
 		(pts (xy 175.26 243.84) (xy 175.26 279.4))
@@ -9621,7 +9621,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "3ed7031e-d122-4848-8f38-3188780784f8")
+		(uuid "79c3066c-6e7d-4e09-b627-6a4c37e44a5f")
 	)
 	(wire
 		(pts (xy 177.8 204.47) (xy 175.26 236.22))
@@ -9629,7 +9629,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "9f5ef677-557f-486f-b2bf-c7b8792f9738")
+		(uuid "ee7657f6-b5f1-484a-bba8-a998d888d5f1")
 	)
 	(wire
 		(pts (xy 175.26 236.22) (xy 165.1 236.22))
@@ -9637,7 +9637,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "08de8b54-6810-4356-9f59-202b77a58990")
+		(uuid "21b85bfb-2284-48aa-9471-17bbe086e21a")
 	)
 	(wire
 		(pts (xy 175.26 243.84) (xy 165.1 243.84))
@@ -9645,7 +9645,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "42ae7b9d-9f52-4e26-857f-f6da5b257376")
+		(uuid "6fb7ae69-b0ef-47cb-9ed8-24e23810a126")
 	)
 	(wire
 		(pts (xy 265.43 177.8) (xy 43.18 177.8))
@@ -9653,7 +9653,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "e0461f1f-e63b-4657-8765-dc7dab2d4ac5")
+		(uuid "a51719b8-c343-40a6-a611-1523a31eef49")
 	)
 	(wire
 		(pts (xy 43.18 177.8) (xy 43.18 179.07))
@@ -9661,7 +9661,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "3f0d7d2c-7341-4b0e-8539-b72de4bfa12a")
+		(uuid "7a79d359-db26-4d4c-8359-51f0a17fbcde")
 	)
 	(wire
 		(pts (xy 43.18 179.07) (xy 27.94 179.07))
@@ -9669,7 +9669,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "5da25daf-e935-4945-9e34-b6667f95949b")
+		(uuid "adca6ccb-0fa8-4db4-8675-f7af4de6d742")
 	)
 	(wire
 		(pts (xy 265.43 180.34) (xy 118.11 180.34))
@@ -9677,7 +9677,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "ee175b15-ed5d-4cee-9fcc-520944f61d7e")
+		(uuid "c87b9485-1c47-48b6-9c9d-32badb3147b0")
 	)
 	(wire
 		(pts (xy 118.11 180.34) (xy 118.11 179.07))
@@ -9685,7 +9685,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "42525221-e2d8-4ec2-ba01-6b7c90dcbcd1")
+		(uuid "0cda01c3-ea10-4d6d-a8e7-4f2ff59b4c27")
 	)
 	(wire
 		(pts (xy 118.11 179.07) (xy 102.87 179.07))
@@ -9693,7 +9693,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "5318a32c-66df-4fe3-9e8d-d749014e9b5f")
+		(uuid "0f0b52da-6818-4371-abb7-332bea2bb530")
 	)
 	(wire
 		(pts (xy 265.43 182.88) (xy 193.04 182.88))
@@ -9701,7 +9701,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "b196bf36-81ea-46f1-b0ac-734fae710aba")
+		(uuid "93529c7e-2fb0-428f-8b50-fa2a3a73f63c")
 	)
 	(wire
 		(pts (xy 193.04 182.88) (xy 193.04 179.07))
@@ -9709,7 +9709,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "4faf0ef6-8727-49c5-b69e-ee0d837d6e0f")
+		(uuid "cd92782e-4bf4-4527-89fe-b7e45698ea42")
 	)
 	(wire
 		(pts (xy 193.04 179.07) (xy 177.8 179.07))
@@ -9717,7 +9717,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "910d1c6a-fc52-4346-9ec2-5a69d462f9b0")
+		(uuid "99a19f41-0433-4942-8546-9506cbdce8c1")
 	)
 	(wire
 		(pts (xy 236.22 80.01) (xy 228.6 110.49))
@@ -9725,7 +9725,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "b2bb1c29-3cb6-4dd2-9b71-096cf59014fc")
+		(uuid "be9ea2d8-4743-4b3b-9e69-22b855552be0")
 	)
 	(wire
 		(pts (xy 265.43 95.25) (xy 236.22 80.01))
@@ -9733,7 +9733,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "d7151dfc-c5ee-480b-a24b-be8516ed64b8")
+		(uuid "fc174524-44f4-4a7f-9b6d-f9da228cd055")
 	)
 	(wire
 		(pts (xy 236.22 80.01) (xy 240.03 95.25))
@@ -9741,7 +9741,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "fcc4cfd7-90fe-4e26-9515-c0ed64169028")
+		(uuid "6baf2283-4085-4aed-8703-e00ec24b49ee")
 	)
 	(wire
 		(pts (xy 228.6 80.01) (xy 228.6 64.77))
@@ -9749,7 +9749,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "5cade788-3b4c-4621-902a-d7ce5257e0da")
+		(uuid "3aae8223-354a-4b68-868d-742c8b424afa")
 	)
 	(wire
 		(pts (xy 236.22 110.49) (xy 236.22 279.4))
@@ -9757,7 +9757,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "574a5fb5-bbe9-481a-a698-c0ee7b80bbe8")
+		(uuid "f4231f0a-16fc-421b-90ba-4cad12155136")
 	)
 	(wire
 		(pts (xy 227.33 82.55) (xy 219.71 113.03))
@@ -9765,7 +9765,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "d59d2c78-a294-4762-995e-7d265920d297")
+		(uuid "2b1fdec1-24c3-4aa8-9fa9-547cca9519da")
 	)
 	(wire
 		(pts (xy 265.43 97.79) (xy 227.33 82.55))
@@ -9773,7 +9773,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "15240fe0-3858-4f8a-9af9-2cc02dfcfa22")
+		(uuid "35cbff02-54c2-4ea2-9686-5655fbe96bed")
 	)
 	(wire
 		(pts (xy 227.33 82.55) (xy 240.03 97.79))
@@ -9781,7 +9781,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "b48f7605-6a7a-4945-a3bd-52bf81989602")
+		(uuid "64db7362-0af7-4746-83d9-ccda0fd0faac")
 	)
 	(wire
 		(pts (xy 219.71 82.55) (xy 219.71 64.77))
@@ -9789,7 +9789,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "c015a07f-3d5d-4fac-9643-b6b5c9e68a0e")
+		(uuid "40aa788c-9a5a-4926-8a02-2bf887841bb3")
 	)
 	(wire
 		(pts (xy 227.33 113.03) (xy 227.33 279.4))
@@ -9797,7 +9797,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "70c1832c-026c-4bc9-8e63-070952b2d56c")
+		(uuid "bd8ec410-fb8b-46c6-a11b-13fb360c7b15")
 	)
 	(wire
 		(pts (xy 219.71 85.09) (xy 212.09 115.57))
@@ -9805,7 +9805,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "46950b2b-b4fd-44f0-b710-4662ba0adff5")
+		(uuid "e430c0fa-bdec-46f4-a8fe-3e9a20b41ad5")
 	)
 	(wire
 		(pts (xy 265.43 100.33) (xy 219.71 85.09))
@@ -9813,7 +9813,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "b883cf3b-2c9e-4185-8410-ba7d84ecbfad")
+		(uuid "3631375a-dc58-49fc-a8cb-a3410f7699ac")
 	)
 	(wire
 		(pts (xy 219.71 85.09) (xy 240.03 100.33))
@@ -9821,7 +9821,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "4b540674-e666-44e0-b8ce-60b764a9a055")
+		(uuid "78a19318-ca6c-4ead-9b70-6b342994a72c")
 	)
 	(wire
 		(pts (xy 212.09 85.09) (xy 212.09 64.77))
@@ -9829,7 +9829,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "4c7d8b75-6997-4f7b-912d-e193f401c418")
+		(uuid "8d9f3f2d-7207-45ee-b9f0-8eedc2c20b53")
 	)
 	(wire
 		(pts (xy 219.71 115.57) (xy 219.71 279.4))
@@ -9837,7 +9837,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "0318096d-56e9-4aa4-9ff7-62db4d83fe0c")
+		(uuid "8eb2b07f-dda4-493e-97a2-3e357580b99d")
 	)
 	(wire
 		(pts (xy 265.43 102.87) (xy 265.43 64.77))
@@ -9845,7 +9845,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "2956ab88-f69d-4ce5-ba7c-f785050d406b")
+		(uuid "c4f1c113-c6cb-4fc6-a132-160cb1fcf744")
 	)
 	(wire
 		(pts (xy 265.43 105.41) (xy 265.43 279.4))
@@ -9853,7 +9853,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "be2b2565-53cc-4013-938b-935cb837d49e")
+		(uuid "24d46b7a-530e-4daf-b4e9-32db9a228f6c")
 	)
 	(wire
 		(pts (xy 190.5 123.19) (xy 190.5 130.81))
@@ -9861,7 +9861,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "1524491f-aa09-4316-9f77-1309380d620f")
+		(uuid "89a0f62d-6b3b-41b2-8083-18c8f7f1790b")
 	)
 	(wire
 		(pts (xy 190.5 115.57) (xy 190.5 64.77))
@@ -9869,7 +9869,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "346cea9a-8946-409f-be53-e6acad16f3fe")
+		(uuid "15fa7eea-8e8d-4dce-802b-d5752aa408ab")
 	)
 	(wire
 		(pts (xy 190.5 138.43) (xy 190.5 279.4))
@@ -9877,7 +9877,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "aa5acfd6-221e-43ee-a822-8ce2ca52f44d")
+		(uuid "df6f9868-6b56-4e4c-8d14-373fbf2c5efd")
 	)
 	(wire
 		(pts (xy 209.55 123.19) (xy 209.55 130.81))
@@ -9885,7 +9885,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "5e5d70d1-7bda-42ab-85ed-b2e4aad816c4")
+		(uuid "4dd82e90-320f-4716-8194-f2788b8b6b1a")
 	)
 	(wire
 		(pts (xy 209.55 115.57) (xy 209.55 64.77))
@@ -9893,7 +9893,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "be6934ad-219f-4d06-b6a9-1a304805b0ad")
+		(uuid "85d1883a-0d43-4bbb-be61-8054e94f9f3a")
 	)
 	(wire
 		(pts (xy 209.55 138.43) (xy 209.55 279.4))
@@ -9901,373 +9901,373 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "7831a149-f2a2-41ef-bcc1-2caa8e2007a8")
+		(uuid "640ef0fb-97ab-45b2-85a1-1f3f5a37864e")
 	)
 	(junction
 		(at 165.1 64.77)
 		(diameter 0)
-		(uuid "278d6c4b-d0e5-489b-979c-d4571d0bee7b")
+		(uuid "1c1d8ed5-624f-47bf-87e6-8420bfd5f41d")
 	)
 	(junction
 		(at 299.72 279.4)
 		(diameter 0)
-		(uuid "a5c4f8fa-d0d9-410d-80ce-5869286211bf")
+		(uuid "045c7598-a133-4e5b-bf0e-02011ebd3d66")
 	)
 	(junction
 		(at 44.45 25.4)
 		(diameter 0)
-		(uuid "b898e47e-c8b4-46bc-9216-66d962894c9d")
+		(uuid "eada23f7-e669-4800-947b-44818d0f1d61")
 	)
 	(junction
 		(at 64.77 25.4)
 		(diameter 0)
-		(uuid "a67312e2-ad2e-4d21-9c64-4b706a5bdfe0")
+		(uuid "34f45bd0-f843-4019-86bd-b4c525159f06")
 	)
 	(junction
 		(at 64.77 279.4)
 		(diameter 0)
-		(uuid "d54db73b-1d24-44ec-a644-05b14eb0fed2")
+		(uuid "d79d4911-c0e3-4ad0-812b-d0d233204ab6")
 	)
 	(junction
 		(at 80.01 25.4)
 		(diameter 0)
-		(uuid "7a7af5c2-bdae-4cf7-935a-be2b528940c7")
+		(uuid "3215a7fc-fbe9-4ba9-9cba-56fb508ed4aa")
 	)
 	(junction
 		(at 80.01 279.4)
 		(diameter 0)
-		(uuid "5c6edcd4-02a1-470b-a55f-e5b5ddc8e580")
+		(uuid "23352723-5b12-4529-b4e5-c3dfcc808f97")
 	)
 	(junction
 		(at 95.25 25.4)
 		(diameter 0)
-		(uuid "225efd21-5e3f-4fad-86da-64ac544ce3d1")
+		(uuid "26234a76-8b74-437d-80a4-e9134f25fd89")
 	)
 	(junction
 		(at 95.25 279.4)
 		(diameter 0)
-		(uuid "1c33ac91-4875-4c6b-84b4-0c83ef3547a9")
+		(uuid "ca4d4c99-f5d1-480d-b04e-52b207a9376b")
 	)
 	(junction
 		(at 30.48 279.4)
 		(diameter 0)
-		(uuid "1767dd5d-2584-40f9-a886-85fe3d1082b0")
+		(uuid "a586152b-6919-40c6-8678-bfa8a6be2e6a")
 	)
 	(junction
 		(at 105.41 96.52)
 		(diameter 0)
-		(uuid "e3dd7660-2821-4a9b-a7a5-a2912c5982c8")
+		(uuid "eed63614-6791-4ee9-8ad2-cdc24566a22b")
 	)
 	(junction
 		(at 105.41 111.76)
 		(diameter 0)
-		(uuid "8ad468b2-efb5-4432-89ff-d9ccadf89de5")
+		(uuid "7835ffe4-2a62-420b-8132-a448ffe1a316")
 	)
 	(junction
 		(at 54.61 25.4)
 		(diameter 0)
-		(uuid "edc4d3b5-5e42-45ff-90aa-bf8d13fcb3ab")
+		(uuid "899c0b36-2da6-4c3f-b636-ae4372b3059c")
 	)
 	(junction
 		(at 54.61 279.4)
 		(diameter 0)
-		(uuid "53d67dc6-62d8-4e96-8ed2-d4704f89c9b8")
+		(uuid "8467e0fc-2a6a-497d-ba74-30da527341fe")
 	)
 	(junction
 		(at 129.54 44.45)
 		(diameter 0)
-		(uuid "63ace52c-3bb7-46cc-9c74-93bd706faa1f")
+		(uuid "0807c220-d5ed-495d-8b0d-ea2c3d7015a0")
 	)
 	(junction
 		(at 129.54 279.4)
 		(diameter 0)
-		(uuid "0beab443-7555-404b-a163-63514a22357a")
+		(uuid "9649d14c-1495-4b3f-a409-4a8fbf481324")
 	)
 	(junction
 		(at 105.41 279.4)
 		(diameter 0)
-		(uuid "814b2994-95e3-4a02-b228-0e1d70d27aa0")
+		(uuid "1dcb0a75-e639-4079-bf83-05cdf1d3bb2a")
 	)
 	(junction
 		(at 67.31 25.4)
 		(diameter 0)
-		(uuid "518490cd-836d-4862-b10c-367fa251bda3")
+		(uuid "00243d45-6f40-4aee-b93b-10686dc29ba4")
 	)
 	(junction
 		(at 80.01 279.4)
 		(diameter 0)
-		(uuid "6cfb8ac5-816b-440d-a9b5-bd0acd6b85a4")
+		(uuid "7396326f-f584-42d6-bb6d-0f7d62ee66ad")
 	)
 	(junction
 		(at 129.54 44.45)
 		(diameter 0)
-		(uuid "598ebc56-3214-49d4-a7bb-3fbb28431119")
+		(uuid "35c5ce2f-8267-4f85-881b-a023bcad47e2")
 	)
 	(junction
 		(at 132.08 44.45)
 		(diameter 0)
-		(uuid "76e75d4f-8167-463f-b369-4ce0c51b38cd")
+		(uuid "13df9427-16f1-432c-adf4-4ce3247e93b2")
 	)
 	(junction
 		(at 147.32 64.77)
 		(diameter 0)
-		(uuid "e80d31c0-771b-4e49-8a07-b93bbc575210")
+		(uuid "72c646ae-5175-4b65-8971-141f5b990300")
 	)
 	(junction
 		(at 139.7 279.4)
 		(diameter 0)
-		(uuid "af95424e-a6f4-4c49-ae43-5b8b725cb95c")
+		(uuid "9f5b6c7e-bcad-4826-8e84-f2eae8247ae7")
 	)
 	(junction
 		(at 119.38 44.45)
 		(diameter 0)
-		(uuid "434c7bf1-4060-4c7d-8aab-0b49bf1a287d")
+		(uuid "e474564b-2f84-475d-b160-8cce9c728aa5")
 	)
 	(junction
 		(at 119.38 279.4)
 		(diameter 0)
-		(uuid "51892ad1-e6fe-43ff-99a3-9682e2e07d44")
+		(uuid "dc2f2fb3-f0a6-4b98-905d-2de656c99a43")
 	)
 	(junction
 		(at 160.02 64.77)
 		(diameter 0)
-		(uuid "b909f20c-16f7-4975-9091-65673fcb2ee7")
+		(uuid "cc76d1e9-c59a-42cb-a2bd-fbbeceabefac")
 	)
 	(junction
 		(at 160.02 279.4)
 		(diameter 0)
-		(uuid "30fe26e6-d74e-4f8e-bb08-ff03c39899a0")
+		(uuid "d1f7a914-90ef-425e-ad49-c242242b49da")
 	)
 	(junction
 		(at 67.31 279.4)
 		(diameter 0)
-		(uuid "f6655df1-d0be-4f25-bb65-eac551471add")
+		(uuid "b6c05f00-5d01-46f9-9d55-60f3bd018a1b")
 	)
 	(junction
 		(at 199.39 64.77)
 		(diameter 0)
-		(uuid "d0276c04-05f7-4175-be14-e07989241794")
+		(uuid "7249d7a6-9782-43ce-b14c-90d12d5fc7a6")
 	)
 	(junction
 		(at 199.39 279.4)
 		(diameter 0)
-		(uuid "3070d585-f8e8-447c-9163-d1d5d55dcef4")
+		(uuid "f918b76d-6c87-4fad-a94e-a96ba61ece42")
 	)
 	(junction
 		(at 209.55 64.77)
 		(diameter 0)
-		(uuid "d1a72d80-4b2f-4775-8a41-4a473f3177de")
+		(uuid "baff9de9-59c4-4633-bacc-64ec9c4154bd")
 	)
 	(junction
 		(at 209.55 279.4)
 		(diameter 0)
-		(uuid "4644c837-d3d2-4982-9977-ed3dd4f0b9fd")
+		(uuid "9c67fbd7-086f-4a3c-99a1-8eb574a0cff9")
 	)
 	(junction
 		(at 219.71 64.77)
 		(diameter 0)
-		(uuid "ea4be8d3-5542-4d0b-9b2d-7fc91a17cc46")
+		(uuid "2277f209-1e33-4dc0-ba6f-8e6e9aaadf6d")
 	)
 	(junction
 		(at 219.71 279.4)
 		(diameter 0)
-		(uuid "8d4e8e0b-9401-463e-ba75-ea1ebc3c0699")
+		(uuid "2e8b2089-3cc4-488f-b11a-3dc6f0df5d82")
 	)
 	(junction
 		(at 262.89 100.33)
 		(diameter 0)
-		(uuid "df22506a-4db3-4fb5-a5e6-cadefcd44a7e")
+		(uuid "9186d4dc-4dea-4771-9bc8-8a5c053e1c67")
 	)
 	(junction
 		(at 278.13 100.33)
 		(diameter 0)
-		(uuid "8faa700b-a866-4375-976b-55e92051c760")
+		(uuid "6b23f413-cfdc-4491-95b9-af5c0c466775")
 	)
 	(junction
 		(at 270.51 279.4)
 		(diameter 0)
-		(uuid "86634a48-0324-41de-b95e-2fbfd2bc325f")
+		(uuid "e30298a3-54aa-4283-9b1a-9d94244413b9")
 	)
 	(junction
 		(at 294.64 64.77)
 		(diameter 0)
-		(uuid "9e37948a-b633-459b-b677-4d12c13c141a")
+		(uuid "e5c35917-f9f7-4b68-8e27-5165c4443acb")
 	)
 	(junction
 		(at 294.64 279.4)
 		(diameter 0)
-		(uuid "a16cd359-6668-4a40-9b94-a8fd7454471c")
+		(uuid "085c4935-486f-4cf5-b30a-5398d6fc644d")
 	)
 	(junction
 		(at 299.72 44.45)
 		(diameter 0)
-		(uuid "2df9402c-fbee-4670-b277-545630d2dbcc")
+		(uuid "be32ba4c-6cd2-4669-8ba0-60d3b54ee2b7")
 	)
 	(junction
 		(at 299.72 279.4)
 		(diameter 0)
-		(uuid "0903aeb8-f88f-45a1-b80d-0a4c3623126a")
+		(uuid "f3b4e6ac-a9d2-43e6-8745-912fcefeb8cf")
 	)
 	(junction
 		(at 309.88 44.45)
 		(diameter 0)
-		(uuid "93dcba98-44b5-469c-8061-8aec68de7efb")
+		(uuid "ac477864-79dd-43b8-b5f2-8aec09ce55b8")
 	)
 	(junction
 		(at 309.88 279.4)
 		(diameter 0)
-		(uuid "a8d117ce-6747-4e72-9317-f601ec986af2")
+		(uuid "721dfa47-096e-4666-80fc-9844aa8d2941")
 	)
 	(junction
 		(at 27.94 179.07)
 		(diameter 0)
-		(uuid "5a15f36e-81b2-4fa2-ae6b-8ac760908e8b")
+		(uuid "be29fe9a-c71d-42fc-80b0-a8d866d632d2")
 	)
 	(junction
 		(at 102.87 179.07)
 		(diameter 0)
-		(uuid "cd743c39-4aec-48e2-81ba-39b6f5e248b4")
+		(uuid "36670db0-9e55-4e78-9535-e3d25c50b24c")
 	)
 	(junction
 		(at 177.8 179.07)
 		(diameter 0)
-		(uuid "7299ff4f-3a8a-46e2-acc7-b00c5b5e88b8")
+		(uuid "b5ae9cf8-f007-47da-848a-52ed94371d23")
 	)
 	(junction
 		(at 27.94 25.4)
 		(diameter 0)
-		(uuid "3a4a1b69-c45f-49df-9b96-b76f67ad573b")
+		(uuid "13a2a877-4db0-4fdd-81b3-44316ba8334b")
 	)
 	(junction
 		(at 27.94 279.4)
 		(diameter 0)
-		(uuid "acb5055a-003c-417d-a1b4-fed8d3a4b331")
+		(uuid "e15b1758-799a-4758-a65d-81796fa45d86")
 	)
 	(junction
 		(at 102.87 25.4)
 		(diameter 0)
-		(uuid "11716050-35b8-4304-a107-a7fa3d355d7c")
+		(uuid "a8677d76-eb52-4584-9d75-d27358ae8990")
 	)
 	(junction
 		(at 102.87 279.4)
 		(diameter 0)
-		(uuid "6a655801-69ad-4d8d-abd8-da5116fd4d0f")
+		(uuid "c87cacc4-22e5-47d3-868a-485896ef28d8")
 	)
 	(junction
 		(at 177.8 25.4)
 		(diameter 0)
-		(uuid "87f22581-d305-4dc1-8a67-6327c5d646c3")
+		(uuid "2e11f0a1-52c2-4d56-85de-a40cdd61b4b6")
 	)
 	(junction
 		(at 177.8 279.4)
 		(diameter 0)
-		(uuid "8608d803-8040-465f-be63-8b7d1afdc61d")
+		(uuid "cd3ff427-e0f3-4a61-8730-78a178ddcb9a")
 	)
 	(junction
 		(at 25.4 279.4)
 		(diameter 0)
-		(uuid "75fe46cd-3689-4a7d-8df4-0d702f850803")
+		(uuid "c33aee44-ce57-418a-a91e-178690bea82b")
 	)
 	(junction
 		(at 100.33 279.4)
 		(diameter 0)
-		(uuid "007c7d37-3a0e-4e7a-ba47-35ec79b85a8b")
+		(uuid "8cc63bd6-12c1-4797-b46f-796a37081d2c")
 	)
 	(junction
 		(at 175.26 279.4)
 		(diameter 0)
-		(uuid "c3fc5ca4-09f4-4d04-9057-3970c59e3de1")
+		(uuid "4d343ab2-9e48-4a2b-aa73-63df1cfdacf7")
 	)
 	(junction
 		(at 27.94 179.07)
 		(diameter 0)
-		(uuid "c6f44c21-96f8-4aae-bc36-f9f1548cf83e")
+		(uuid "f10b0843-e65a-4006-b675-6d8e8eaca2ba")
 	)
 	(junction
 		(at 102.87 179.07)
 		(diameter 0)
-		(uuid "563c47cb-8365-4942-8c46-d352576238c1")
+		(uuid "7b663568-2136-4319-b6db-228601573918")
 	)
 	(junction
 		(at 177.8 179.07)
 		(diameter 0)
-		(uuid "688c90b7-9dda-442f-8566-d2948c777e11")
+		(uuid "7b40b6a8-2e5f-4b31-8666-f61d9e895284")
 	)
 	(junction
 		(at 228.6 64.77)
 		(diameter 0)
-		(uuid "0d96ae3c-99a3-49fe-a2fe-3f13f63f345a")
+		(uuid "b0e74c1d-a016-46e7-abb0-ac6666eb38e6")
 	)
 	(junction
 		(at 236.22 279.4)
 		(diameter 0)
-		(uuid "b5e2fc5a-1c7d-46fb-8298-768fdd3bdab5")
+		(uuid "6a4b4a9a-db6b-4ae3-a91d-4c06a163c613")
 	)
 	(junction
 		(at 219.71 64.77)
 		(diameter 0)
-		(uuid "ba59c70e-0d04-493e-9862-9f3ea3fc5497")
+		(uuid "1272e3fd-57bf-4370-abb4-2ef5984314f4")
 	)
 	(junction
 		(at 227.33 279.4)
 		(diameter 0)
-		(uuid "5c9f8f15-6cea-4f10-9268-162bfc5807a2")
+		(uuid "046c5ec9-d961-470a-89a0-2f37f509f9cf")
 	)
 	(junction
 		(at 212.09 64.77)
 		(diameter 0)
-		(uuid "a67f61ec-efe1-4e97-b4dc-824db9107853")
+		(uuid "5853b545-27fa-4a40-9ed0-30605492aaa7")
 	)
 	(junction
 		(at 219.71 279.4)
 		(diameter 0)
-		(uuid "62fb5fd2-c8d3-43d4-8829-020910c22c26")
+		(uuid "916d63d0-34b9-427c-bec7-1cb1ff00b9f8")
 	)
 	(junction
 		(at 265.43 64.77)
 		(diameter 0)
-		(uuid "9c79fd82-483c-4726-ba0a-35596bdf413c")
+		(uuid "befe71d6-8e7f-4c53-bd8e-7dc9e07d861f")
 	)
 	(junction
 		(at 265.43 279.4)
 		(diameter 0)
-		(uuid "c1ad5b43-119e-4f4e-b5bf-7ef6240e9ce8")
+		(uuid "9d227678-8230-4e27-9643-6ec30ede811b")
 	)
 	(junction
 		(at 190.5 64.77)
 		(diameter 0)
-		(uuid "b35b4927-91f8-4bd6-bf00-da910d7fabdb")
+		(uuid "a7d6e523-130b-43e5-9cec-28baf65e0e8b")
 	)
 	(junction
 		(at 190.5 279.4)
 		(diameter 0)
-		(uuid "2662a89b-50bb-4365-a881-f1cf1dc2b33d")
+		(uuid "a6d2e202-244f-41e9-8347-49e68c09a170")
 	)
 	(junction
 		(at 209.55 64.77)
 		(diameter 0)
-		(uuid "1371d4e5-ac3e-4729-b315-296e08ec0874")
+		(uuid "57e636f2-db67-4b3f-968e-81f454b198e6")
 	)
 	(junction
 		(at 209.55 279.4)
 		(diameter 0)
-		(uuid "0149f6f6-da3a-4f6b-b1d8-0a8ecc6ab9ae")
+		(uuid "3a29f35c-b64a-45d5-8ce0-1a0c57a0831c")
 	)
-	(no_connect (at 242.57 152.4) (uuid "3aa1f8e2-e782-4d3a-a955-79394dc0277f")
+	(no_connect (at 242.57 152.4) (uuid "3a6710e9-56b3-4123-a374-feba2d16f5f6")
 	)
-	(no_connect (at 242.57 154.94) (uuid "1f082a29-a236-4c11-a134-d1366e723519")
+	(no_connect (at 242.57 154.94) (uuid "968626c2-1fd2-439e-9191-534bfa896b5e")
 	)
-	(no_connect (at 242.57 157.48) (uuid "f6ab6b79-979d-4611-84d1-02b700676eae")
+	(no_connect (at 242.57 157.48) (uuid "e17f900e-c80b-41e4-9daa-4ea9371c1cf1")
 	)
-	(no_connect (at 242.57 172.72) (uuid "070e3a74-e941-4342-a039-607931be9446")
+	(no_connect (at 242.57 172.72) (uuid "8fd70ffc-9264-4542-a11f-f9c8f9273df0")
 	)
-	(no_connect (at 242.57 175.26) (uuid "6cf66651-5110-413a-8f68-94c7e5385fc8")
+	(no_connect (at 242.57 175.26) (uuid "b070533f-2ae5-4c03-ad08-860763236960")
 	)
-	(no_connect (at 242.57 182.88) (uuid "58f9bd26-cfe7-4f42-854c-4f4ee1501662")
+	(no_connect (at 242.57 182.88) (uuid "c8054250-a7c2-4ca2-b05e-463d9faef24a")
 	)
-	(no_connect (at 217.17 162.56) (uuid "9ce5fad0-dfac-47c9-87b5-af02c0837092")
+	(no_connect (at 217.17 162.56) (uuid "8bef2a9b-7f27-4537-85a8-540222d4389a")
 	)
-	(no_connect (at 217.17 165.1) (uuid "66c6582d-cd79-405e-a874-e890105e751b")
+	(no_connect (at 217.17 165.1) (uuid "bdd53287-5457-4dba-af7c-477836e4fee0")
 	)
 	(label "VMOTOR"
 		(at 25.4 25.4 0)
@@ -10278,7 +10278,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "4e3c799d-cb8f-44df-bb2c-dd3eadbba917")
+		(uuid "c4b8f4b8-5d8f-4b8a-bd74-7ff7a6e844bc")
 	)
 	(label "+5V"
 		(at 105.41 44.45 0)
@@ -10289,7 +10289,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "3a0912a4-adda-4d80-8c74-226596207368")
+		(uuid "8a1f737a-1924-463e-a0d8-779c01608d4d")
 	)
 	(label "+3.3V"
 		(at 147.32 64.77 0)
@@ -10300,7 +10300,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "36b3e99e-9f74-40d0-8558-769aa1bd9c88")
+		(uuid "57488d49-5395-4ef0-822f-babc9ee3b562")
 	)
 	(label "GND"
 		(at 25.4 279.4 0)
@@ -10311,7 +10311,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "110196c8-dd68-4006-845a-999eef419659")
+		(uuid "0cd5d000-e08c-4974-bf11-2a5337c9098b")
 	)
 	(label "VMOTOR"
 		(at 64.77 97.79 0)
@@ -10322,7 +10322,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "1fed5ade-331f-4029-999d-a3d05f0145b7")
+		(uuid "04687d67-de12-4c7d-8590-d69c16881f71")
 	)
 	(label "GND"
 		(at 82.55 107.95 0)
@@ -10333,7 +10333,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "61578280-def0-4a97-a886-b6de5683a2aa")
+		(uuid "9f7e63ec-fcf9-4ca7-ab75-888968d67b47")
 	)
 	(label "+5V"
 		(at 95.25 97.79 0)
@@ -10344,7 +10344,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "fdeb5f67-b6a9-488e-8818-c27bb5754a54")
+		(uuid "fe441315-47c6-4ad8-ab68-a5ba0d756ed1")
 	)
 	(label "+5V"
 		(at 129.54 100.33 0)
@@ -10355,7 +10355,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "10b20fba-4240-4a5d-8306-4f1fa3d5afb7")
+		(uuid "602493e0-29ed-4642-b79c-63754efc47c5")
 	)
 	(label "+3.3V"
 		(at 149.86 100.33 0)
@@ -10366,7 +10366,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "4b58f421-bd12-43ba-a251-62aca9620fe3")
+		(uuid "ddb19928-1edf-4517-bece-5f47684d78c4")
 	)
 	(label "GND"
 		(at 137.16 107.95 0)
@@ -10377,7 +10377,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "93aeb39a-669f-468a-98f4-0c3eef1daf1c")
+		(uuid "0c1b7c1c-5f35-489a-90e5-d94165a9e219")
 	)
 	(label "+3.3V"
 		(at 222.25 137.16 0)
@@ -10388,7 +10388,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "ddbbf64f-d378-49dc-96e9-d02b60f3abc6")
+		(uuid "2948fe8e-217a-42ec-8323-aec7c6dd9ee1")
 	)
 	(label "+3.3V"
 		(at 224.79 137.16 0)
@@ -10399,7 +10399,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "7352377d-a13c-40bb-a285-0e860b807407")
+		(uuid "e06f6827-6667-4fc4-ac07-3dbaaa30b4fa")
 	)
 	(label "+3.3V"
 		(at 227.33 137.16 0)
@@ -10410,7 +10410,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "43399d73-e6de-406b-ae67-a45d2abb5976")
+		(uuid "d4b21b80-487f-4736-8649-0cecc01dd79d")
 	)
 	(label "GND"
 		(at 227.33 190.5 0)
@@ -10421,7 +10421,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "20f5d2ae-6ebf-49d6-b6ea-4e116ea2b7c0")
+		(uuid "2ae077d4-82c0-4f13-866c-0ab3b29242d8")
 	)
 	(label "GND"
 		(at 224.79 190.5 0)
@@ -10432,7 +10432,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "22ada106-5765-4dfa-94aa-90ac163a5752")
+		(uuid "bf14931f-ba84-44bd-86c6-0ec401eb147e")
 	)
 	(label "GND"
 		(at 224.79 190.5 0)
@@ -10443,7 +10443,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "5f114646-9886-4a1e-b1a8-59b4cb48748b")
+		(uuid "83dc93ae-9133-473d-b238-bedeef2871a6")
 	)
 	(label "NRST"
 		(at 212.09 144.78 0)
@@ -10454,7 +10454,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "c2b4e059-14a1-4e59-bb40-cab7eb6aeefd")
+		(uuid "f0bce76e-d668-412b-aea4-aaaff685818a")
 	)
 	(label "ISENSE_A-"
 		(at 247.65 144.78 0)
@@ -10465,7 +10465,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "b0b292af-044d-43d0-ba63-8c646bef40c8")
+		(uuid "411008b3-3408-4f4b-bc6b-646648608056")
 	)
 	(label "ISENSE_B-"
 		(at 247.65 147.32 0)
@@ -10476,7 +10476,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "83e0f81d-4cd7-4ebe-b24d-d92368f78968")
+		(uuid "f2d66782-37ed-4c3d-b041-0a384dcc915d")
 	)
 	(label "ISENSE_C-"
 		(at 247.65 149.86 0)
@@ -10487,7 +10487,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "46567812-39bf-4c35-b6a1-f2619c424366")
+		(uuid "dc0c299a-5379-4ffd-a72f-fae6e1e89f14")
 	)
 	(label "HALL_A"
 		(at 247.65 160.02 0)
@@ -10498,7 +10498,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "15b9e779-91b6-4f8b-aed4-754b49fc70fd")
+		(uuid "2860dc09-305d-4d4f-80b3-b5029f7f55f9")
 	)
 	(label "HALL_B"
 		(at 247.65 162.56 0)
@@ -10509,7 +10509,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "82ebfb9a-2513-4e53-a984-0aa3d702ef5f")
+		(uuid "cd5d7f09-f898-4731-9558-dc719118a1b1")
 	)
 	(label "HALL_C"
 		(at 222.25 157.48 0)
@@ -10520,7 +10520,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "cd54780c-99d1-4125-a2e5-a57b49c48e2a")
+		(uuid "46bba65b-3ae9-491d-a4b1-c2897ed10a9f")
 	)
 	(label "PWM_AH"
 		(at 247.65 165.1 0)
@@ -10531,7 +10531,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "f391d529-5e7f-4c22-bf71-888e14dd1cad")
+		(uuid "142aec21-3600-4533-8eee-88cc06f89c33")
 	)
 	(label "PWM_BH"
 		(at 247.65 167.64 0)
@@ -10542,7 +10542,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "3a11057b-9a9f-4b08-9b69-ce3fc4ce71de")
+		(uuid "26aa872f-a852-4d4c-b456-86dbf1dcbd51")
 	)
 	(label "PWM_CH"
 		(at 247.65 170.18 0)
@@ -10553,7 +10553,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "3572caec-0e8c-4244-ba57-7a438a411873")
+		(uuid "0ec2261a-aeb4-4cf4-8853-fab6542f8e4f")
 	)
 	(label "SWDIO"
 		(at 247.65 177.8 0)
@@ -10564,7 +10564,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "6f678637-b3e3-4f90-97c2-339377ed68e6")
+		(uuid "ccbf82cc-cd75-4200-b150-f261b9de446a")
 	)
 	(label "SWCLK"
 		(at 247.65 180.34 0)
@@ -10575,7 +10575,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "698b003c-6910-46a6-af04-03d7f2a938fa")
+		(uuid "f17a88b8-6dc6-4ba9-8774-48b0ad3b23d2")
 	)
 	(label "SWO"
 		(at 222.25 160.02 0)
@@ -10586,7 +10586,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "ef51e645-437f-4081-86d6-086ff3eb1f79")
+		(uuid "69ede7cf-e81f-4b94-b9be-fed998cfe949")
 	)
 	(label "PWM_AL"
 		(at 222.25 167.64 0)
@@ -10597,7 +10597,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "377c20dc-c4a5-4f30-9a84-0dfbde09fcf3")
+		(uuid "5db8a6fc-f405-4370-947b-d28887aca60a")
 	)
 	(label "PWM_BL"
 		(at 222.25 170.18 0)
@@ -10608,7 +10608,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "8daa4076-4e9a-45f9-a7ad-415eee0c4bed")
+		(uuid "ac70b119-9e9f-46d2-93e3-9d47790fa591")
 	)
 	(label "PWM_CL"
 		(at 222.25 172.72 0)
@@ -10619,7 +10619,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "18a168d2-d6ac-47ad-a4bb-781c6ca0830b")
+		(uuid "53da7a61-7ea3-4275-89c4-e324e26e4638")
 	)
 	(label "OSC_IN"
 		(at 212.09 149.86 0)
@@ -10630,7 +10630,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "5bdd55c2-6a52-4325-8451-578df1e31d42")
+		(uuid "709d4831-1849-4e27-9506-236835bf42eb")
 	)
 	(label "OSC_OUT"
 		(at 212.09 152.4 0)
@@ -10641,7 +10641,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "1e75358c-4264-407d-8aaf-d2ae4b0910d6")
+		(uuid "c90fed67-eb98-4a07-ae1f-264bca3fad87")
 	)
 	(label "OSC_IN"
 		(at 261.62 100.33 0)
@@ -10652,7 +10652,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "b4f3a9a9-eac1-4a40-ae84-8deb42a2eb74")
+		(uuid "56d66b6b-0ed9-43e8-914d-7c9ff2ff50fb")
 	)
 	(label "OSC_OUT"
 		(at 279.4 100.33 0)
@@ -10663,7 +10663,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "74117a69-2452-44ee-987e-2886fa6c0768")
+		(uuid "ec4b4507-ac12-4185-93a6-0a25dcb321fb")
 	)
 	(label "+3.3V"
 		(at 292.1 95.25 0)
@@ -10674,7 +10674,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "fce941fa-ea73-4588-8008-59f5a0cc9abb")
+		(uuid "d3f80930-d970-4fa4-8fbe-9401978d3770")
 	)
 	(label "SWDIO"
 		(at 292.1 97.79 0)
@@ -10685,7 +10685,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "8b512200-4c08-4551-bfd0-7cfe671ce968")
+		(uuid "70a362a3-435d-45ef-a2e5-aa5f793a6cc7")
 	)
 	(label "GND"
 		(at 292.1 100.33 0)
@@ -10696,7 +10696,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "d4e51ab7-4c6a-4e26-836a-47b8abe78e7c")
+		(uuid "d4bdd3f5-1885-4f43-af2b-872ca4a300e8")
 	)
 	(label "SWCLK"
 		(at 292.1 102.87 0)
@@ -10707,7 +10707,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "7cec0942-65df-41fb-8a7e-a92800793a16")
+		(uuid "66d8a8d8-a33c-495b-a3c6-14176c3d49fe")
 	)
 	(label "GND"
 		(at 292.1 105.41 0)
@@ -10718,7 +10718,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "d1c7cc10-d6af-45dc-a0ac-a778fde665d4")
+		(uuid "906beff4-3df5-433d-bb6a-642eb0c57278")
 	)
 	(label "NRST"
 		(at 292.1 107.95 0)
@@ -10729,7 +10729,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "82e1bacd-f576-431c-acfa-89ee63107685")
+		(uuid "04bbf7bb-f3b2-4efc-a284-1e3aed6284ba")
 	)
 	(label "+3.3V"
 		(at 256.54 72.39 0)
@@ -10740,7 +10740,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "a1c61235-f1fd-4264-a2f1-78b56dd333e4")
+		(uuid "0fc4556b-ac14-4ca3-a6b3-a417dae3f0ae")
 	)
 	(label "+3.3V"
 		(at 256.54 69.85 0)
@@ -10751,7 +10751,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "526c1eec-f565-4aeb-9cb5-c2952d8bfc9b")
+		(uuid "77a88e74-0a36-4548-b6ee-13b132d94a14")
 	)
 	(label "+3.3V"
 		(at 256.54 74.93 0)
@@ -10762,7 +10762,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "f5dcd599-aa48-4768-8ec9-a52e0a6c9efd")
+		(uuid "1fa46e41-b61d-49db-9f6c-49889fa63052")
 	)
 	(label "+3.3V"
 		(at 256.54 80.01 0)
@@ -10773,7 +10773,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "8ad8abc8-466b-46fd-b674-6c22a29b42cf")
+		(uuid "53bbe246-1600-4cb1-b937-9b5706876443")
 	)
 	(label "+3.3V"
 		(at 256.54 95.25 0)
@@ -10784,7 +10784,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "bbee512a-4128-46f2-a09c-2da759906ff0")
+		(uuid "385632e8-aba1-4d2e-9233-264f29c91025")
 	)
 	(label "+3.3V"
 		(at 256.54 85.09 0)
@@ -10795,7 +10795,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "148a0584-d0bf-4234-91b6-9127aad3b5e5")
+		(uuid "7c1a840f-ffa3-48f7-9d35-0e40c70543a2")
 	)
 	(label "+3.3V"
 		(at 256.54 87.63 0)
@@ -10806,7 +10806,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "d97f24e0-02ec-41b3-9021-cb2e49e14481")
+		(uuid "82871103-b507-4252-986d-a2c6262f5808")
 	)
 	(label "+3.3V"
 		(at 256.54 92.71 0)
@@ -10817,7 +10817,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "e7f5919d-de17-4e1f-8ee7-0118bce6e4c8")
+		(uuid "21b07c5f-b4fa-495f-a7b0-a451f596107a")
 	)
 	(label "GND"
 		(at 256.54 90.17 0)
@@ -10828,7 +10828,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "89b334a4-d56e-469c-8a4c-96f7de9d6471")
+		(uuid "a0af6e72-b2a9-4f5f-be1b-8e5306cd1d02")
 	)
 	(label "GND"
 		(at 256.54 105.41 0)
@@ -10839,7 +10839,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "dbefc9cf-a8dd-4f1a-ad63-6c9e7585f716")
+		(uuid "62290731-1e55-4037-9771-b30ad65cbe96")
 	)
 	(label "GND"
 		(at 256.54 102.87 0)
@@ -10850,7 +10850,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "6c1fad8e-e2dd-4a50-b426-641c2d5b1ad3")
+		(uuid "0389f165-9f4e-420a-b7cf-9058393d60e9")
 	)
 	(label "SPI_MISO"
 		(at 256.54 77.47 0)
@@ -10861,7 +10861,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "cb128451-1ef3-45aa-9b6f-a49bb4c52659")
+		(uuid "122b7d62-8898-46e8-bbdc-255ecdaa8aa3")
 	)
 	(label "FGFB"
 		(at 256.54 100.33 0)
@@ -10872,7 +10872,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "9c6dd85b-f0b6-45fa-b207-6b085cad0dcd")
+		(uuid "a4e8efad-f5a8-4c66-a569-991beabd08f0")
 	)
 	(label "FGOUT"
 		(at 256.54 107.95 0)
@@ -10883,7 +10883,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "8398ac3e-5810-405b-90da-0605de0359c1")
+		(uuid "dd27d227-b43d-43fe-a835-7e729f4c7f4d")
 	)
 	(label "DRV_FAULTn"
 		(at 256.54 110.49 0)
@@ -10894,7 +10894,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "5b75573c-afb7-4cb1-a3cc-484080cdcd8c")
+		(uuid "6c82137e-7fc6-4487-966f-2bc3a6b0183d")
 	)
 	(label "DRV_LOCKn"
 		(at 256.54 113.03 0)
@@ -10905,7 +10905,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "4ae0f31b-0950-4d96-aac2-b750aaa883c6")
+		(uuid "f0a58c7b-84eb-4df6-8fc3-d781ad7bcf43")
 	)
 	(label "GATE_DRV_AH"
 		(at 302.26 62.23 0)
@@ -10916,7 +10916,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "ffd606c1-9098-47af-a478-bd53af1ea437")
+		(uuid "c39a1783-b57d-4ebf-99a8-b563ef2a5c1a")
 	)
 	(label "GATE_DRV_BH"
 		(at 302.26 72.39 0)
@@ -10927,7 +10927,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "68512293-e08b-40ed-9d40-a338ace54847")
+		(uuid "89ef3f4a-39ea-4cab-91b0-3e4fe379857d")
 	)
 	(label "GATE_DRV_CH"
 		(at 302.26 82.55 0)
@@ -10938,7 +10938,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "6a165e30-d125-4b07-976d-0548a71fdc5a")
+		(uuid "b6d47b70-d9b9-4ec7-a7b9-f48979b9dc41")
 	)
 	(label "GATE_AL"
 		(at 302.26 67.31 0)
@@ -10949,7 +10949,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "dd23028c-f0c4-4c65-984a-52bdbb7cf2f1")
+		(uuid "a545c383-b7fa-4c64-aa34-a05959936417")
 	)
 	(label "GATE_BL"
 		(at 302.26 77.47 0)
@@ -10960,7 +10960,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "8accf09a-9be1-40b3-b48c-bab1630cc0b6")
+		(uuid "328bb28b-5bc8-4eb3-b39e-ffa3e46d7195")
 	)
 	(label "GATE_CL"
 		(at 302.26 87.63 0)
@@ -10971,7 +10971,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "11ee8ae6-6ab1-4325-bc2c-476546ca252d")
+		(uuid "f5975c7f-88be-47aa-8c0e-5ec9a9a108c7")
 	)
 	(label "BST_A"
 		(at 302.26 100.33 0)
@@ -10982,7 +10982,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "3285e7c3-bd52-4bdf-a36a-b71dd7324a11")
+		(uuid "b4e71121-1d1b-457d-9e52-f567fd6008ac")
 	)
 	(label "PHASE_A"
 		(at 302.26 102.87 0)
@@ -10993,7 +10993,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "3c17d820-59c5-4744-a891-3bb48465e041")
+		(uuid "e5ab3169-1591-4cce-8741-73c992237d31")
 	)
 	(label "BST_B"
 		(at 302.26 105.41 0)
@@ -11004,7 +11004,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "40ba8ecf-80ef-4088-8b0b-0777c8c34f86")
+		(uuid "9753bdfc-9e39-4f31-8d03-2bd86e644856")
 	)
 	(label "PHASE_B"
 		(at 302.26 107.95 0)
@@ -11015,7 +11015,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "00ff3a37-83ef-4085-9048-f3aaa64e8516")
+		(uuid "d6828814-6446-4e84-b3bf-19b270d34267")
 	)
 	(label "BST_C"
 		(at 302.26 110.49 0)
@@ -11026,7 +11026,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "5074370a-d88d-4d47-95c5-4e1adb0f12d1")
+		(uuid "3faebeee-04a0-4fa2-8c3b-34bc8bd73ad8")
 	)
 	(label "PHASE_C"
 		(at 302.26 113.03 0)
@@ -11037,7 +11037,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "6d97db5e-30b9-4dca-ba9f-8e6451687a44")
+		(uuid "feb97db6-5715-4782-a8e3-cb1c760f9c18")
 	)
 	(label "PHASE_A"
 		(at 302.26 64.77 0)
@@ -11048,7 +11048,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "b04269be-c64b-4e75-9193-8491bfed8ae7")
+		(uuid "ca11e605-cdcd-40e8-9847-cb5f0e79b1da")
 	)
 	(label "PHASE_B"
 		(at 302.26 74.93 0)
@@ -11059,7 +11059,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "e0ad860a-08ed-4e34-9421-fc9a83579c64")
+		(uuid "bf8cc823-ef2d-4d3e-a12f-b75c46f4420f")
 	)
 	(label "PHASE_C"
 		(at 302.26 85.09 0)
@@ -11070,7 +11070,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "41d93fb0-8636-4596-b777-2673aee2cd9a")
+		(uuid "c492abb8-1da8-4ae0-969f-d10e768c62c5")
 	)
 	(label "GND"
 		(at 302.26 95.25 0)
@@ -11081,7 +11081,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "44b63f0d-e9ef-4fb3-8e93-36a7143147fd")
+		(uuid "375e3d0e-8a62-4310-9dbb-aa5d02498f08")
 	)
 	(label "GND"
 		(at 274.32 118.11 0)
@@ -11092,7 +11092,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "23a860bf-1628-414d-8d99-8d54fed48a2f")
+		(uuid "5c509b49-69bf-49b9-988a-738042a46dcb")
 	)
 	(label "GND"
 		(at 284.48 118.11 0)
@@ -11103,7 +11103,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "72e2b875-0b94-4f18-aba4-f0bc2973ad3b")
+		(uuid "c10ed4d9-bc22-4ea5-b250-4d84503ca5c2")
 	)
 	(label "DRV_CP1"
 		(at 256.54 62.23 0)
@@ -11114,7 +11114,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "4ddab7f7-3281-4119-beb4-6e3f6dad6756")
+		(uuid "9f4e0502-e2b6-4e19-92a7-bbdb99b378bc")
 	)
 	(label "DRV_CP2"
 		(at 256.54 64.77 0)
@@ -11125,7 +11125,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "c79135b4-bcf9-4be3-b699-62a918493071")
+		(uuid "7e7c394c-7989-4770-a9f7-66e7bb48fcb7")
 	)
 	(label "DRV_VINT"
 		(at 271.78 54.61 90)
@@ -11136,7 +11136,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "fbb0c73f-840e-44bb-87a7-2e254758c250")
+		(uuid "169a42b5-d312-4bea-b3c3-08384be0d917")
 	)
 	(label "DRV_VCP"
 		(at 274.32 54.61 90)
@@ -11147,7 +11147,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "18bbecdc-fb6b-41ec-94c9-acf02887cf60")
+		(uuid "d795fcd8-7814-4444-a540-533c5621254d")
 	)
 	(label "VMOTOR"
 		(at 279.4 54.61 90)
@@ -11158,7 +11158,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "0e1e9436-df1d-4db0-9246-27783732c288")
+		(uuid "427337a8-e990-4848-9e09-04524e218d1f")
 	)
 	(label "DRV_VSW"
 		(at 281.94 54.61 90)
@@ -11169,7 +11169,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "9c38e8cd-054a-4a46-ae92-752ca27e505b")
+		(uuid "8fdce316-add3-400e-b50b-f7cc6bf3f758")
 	)
 	(label "DRV_VREG"
 		(at 284.48 54.61 90)
@@ -11180,7 +11180,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "cee73469-65a7-4621-94ef-a9f80907492a")
+		(uuid "82fa222d-bb3a-47c4-bb4b-292c3964c0ee")
 	)
 	(label "BST_A"
 		(at 260.35 73.66 0)
@@ -11191,7 +11191,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "039c4505-6379-42b6-a41d-f3168f079331")
+		(uuid "da275e0c-97e9-4f1f-b814-54dde970cc7f")
 	)
 	(label "PHASE_A"
 		(at 260.35 86.36 0)
@@ -11202,7 +11202,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "b0c9d27d-28ff-4f75-8ece-98ba79e83db4")
+		(uuid "1f0cb755-7d66-4b28-893a-6f0858fa6479")
 	)
 	(label "BST_B"
 		(at 270.51 73.66 0)
@@ -11213,7 +11213,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "8c0ba289-cbc7-4615-8535-291f9aabe22c")
+		(uuid "13dc8a2c-feab-473f-91b6-7db62744e132")
 	)
 	(label "PHASE_B"
 		(at 270.51 86.36 0)
@@ -11224,7 +11224,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "cf4a6790-c196-4d13-b285-e7a34aeafd01")
+		(uuid "0e2f9d52-42f0-48c3-8bd9-d841b3f70180")
 	)
 	(label "BST_C"
 		(at 279.4 73.66 0)
@@ -11235,7 +11235,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "6fc178b7-0234-43d4-9588-ada161befae5")
+		(uuid "6ac0b641-db63-417c-b98b-b002045e41b9")
 	)
 	(label "PHASE_C"
 		(at 279.4 86.36 0)
@@ -11246,7 +11246,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "a9318763-de7f-4e35-aa0c-a1c4dd4a0cf8")
+		(uuid "4f2e0379-eb02-4043-bd84-a86a0814a4ac")
 	)
 	(label "GATE_DRV_AH"
 		(at 307.34 115.57 0)
@@ -11257,7 +11257,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "927255f0-9b1b-4a69-8bad-97d3fb0190e4")
+		(uuid "aac07291-b3d8-417d-99ab-23bd6c80bd85")
 	)
 	(label "GATE_AH"
 		(at 312.42 123.19 0)
@@ -11268,7 +11268,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "25c9d8b7-08a8-454a-9cc3-276eee30cdff")
+		(uuid "aa04ec0c-cdc1-49bc-a43b-d622b7dd3eb2")
 	)
 	(label "GATE_DRV_BH"
 		(at 317.5 115.57 0)
@@ -11279,7 +11279,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "6930068f-3992-4c5b-a72a-a4770f2d990a")
+		(uuid "78ff4dcd-04e3-45ac-ad61-0bc91aca51e3")
 	)
 	(label "GATE_BH"
 		(at 322.58 123.19 0)
@@ -11290,7 +11290,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "6f4779fc-548c-444f-9888-7b040433008e")
+		(uuid "b1eb8e54-88b3-4f21-86e3-20059dac222c")
 	)
 	(label "GATE_DRV_CH"
 		(at 327.66 115.57 0)
@@ -11301,7 +11301,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "73101c4d-05f7-4d42-9ba9-2fed5b831287")
+		(uuid "cea06eae-e102-49fa-ad3f-1b6f0f9e1fc9")
 	)
 	(label "GATE_CH"
 		(at 332.74 123.19 0)
@@ -11312,7 +11312,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "fec5fb21-4067-4bf4-9205-90b6b902b814")
+		(uuid "0652483b-6436-44a1-9611-778838383c59")
 	)
 	(label "GATE_AH"
 		(at 17.78 160.02 0)
@@ -11323,7 +11323,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "45e809ad-4843-4008-a6e6-7ba41a6292d2")
+		(uuid "1f6b007e-bf09-4c34-b6cc-02d2d21c4acf")
 	)
 	(label "GATE_AL"
 		(at 17.78 199.39 0)
@@ -11334,7 +11334,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "13ef8c30-713c-4d4b-9377-cdd396edf05a")
+		(uuid "4ff18f12-34be-491a-83a5-0b1a828d815f")
 	)
 	(label "PHASE_A"
 		(at 38.1 179.07 0)
@@ -11345,7 +11345,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "28f7c3bd-f6f4-491e-80b5-f13e1c165e30")
+		(uuid "251644c9-ae0e-4567-a71a-1b81fa636bf2")
 	)
 	(label "GATE_BH"
 		(at 92.71 160.02 0)
@@ -11356,7 +11356,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "8ebe0fa1-a2c4-4e31-8918-e9f0823cd021")
+		(uuid "1b1bf2d7-9474-46b8-8fbf-f274c8b3a84f")
 	)
 	(label "GATE_BL"
 		(at 92.71 199.39 0)
@@ -11367,7 +11367,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "0c7b659b-349a-4ed8-9dbe-091180fb7156")
+		(uuid "7a66c8c2-d32a-4fe9-b440-dafa0381f44b")
 	)
 	(label "PHASE_B"
 		(at 113.03 179.07 0)
@@ -11378,7 +11378,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "8d056955-5c19-4ad8-9c9b-7e6f88bdaa1e")
+		(uuid "d4af73ea-ffb0-4df2-9a10-4011d44470c2")
 	)
 	(label "GATE_CH"
 		(at 167.64 160.02 0)
@@ -11389,7 +11389,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "122eec25-ab92-4ce0-93c6-b6ec852818af")
+		(uuid "713e49b0-37ab-4730-8a31-cd951181beaf")
 	)
 	(label "GATE_CL"
 		(at 167.64 199.39 0)
@@ -11400,7 +11400,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "e2690906-b20f-439d-b8c4-04c87c2964fd")
+		(uuid "89a21bf6-c578-46ce-a902-982e79dd3bb3")
 	)
 	(label "PHASE_C"
 		(at 187.96 179.07 0)
@@ -11411,7 +11411,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "fdd3185a-ea14-482c-a6aa-65ae7a1a29de")
+		(uuid "936877d7-532c-4d62-9c53-5cec444c7186")
 	)
 	(label "ISENSE_A+"
 		(at 15.24 236.22 0)
@@ -11422,7 +11422,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "46061136-a54a-4e97-883e-a3281b963176")
+		(uuid "f57b729f-d1ce-454e-8b52-5c06f5ad5d72")
 	)
 	(label "ISENSE_A-"
 		(at 15.24 243.84 0)
@@ -11433,7 +11433,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "dbcdf59b-34ca-4c42-aca2-d004af49a4f9")
+		(uuid "fbe4293c-a580-4b8d-9235-86b3b47dab2e")
 	)
 	(label "ISENSE_B+"
 		(at 90.17 236.22 0)
@@ -11444,7 +11444,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "42a4965b-9db0-4008-82f4-ccfb615498fc")
+		(uuid "c73837c4-d614-440b-b630-9d659ec540c3")
 	)
 	(label "ISENSE_B-"
 		(at 90.17 243.84 0)
@@ -11455,7 +11455,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "86350c1a-23c4-48fd-a505-e4e0764904bb")
+		(uuid "de23d384-e1c4-4b6e-96b1-a7a6d5eea1c8")
 	)
 	(label "ISENSE_C+"
 		(at 165.1 236.22 0)
@@ -11466,7 +11466,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "797dca1c-b2e2-415f-a27f-697b6ac41f8e")
+		(uuid "99d4f70b-0eb1-4d9f-b630-c2c44ced3541")
 	)
 	(label "ISENSE_C-"
 		(at 165.1 243.84 0)
@@ -11477,7 +11477,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "aa21d7de-4cf0-4a55-bebb-f904da2dafa2")
+		(uuid "3d2a40de-4cd2-4698-96e9-f9325aa3ce5f")
 	)
 	(label "HALL_A"
 		(at 240.03 95.25 0)
@@ -11488,7 +11488,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "a67309ac-b56b-4763-beef-4f41813e76fe")
+		(uuid "86774bc0-ce68-464f-b521-38e86671bda1")
 	)
 	(label "HALL_B"
 		(at 240.03 97.79 0)
@@ -11499,7 +11499,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "ca2d9e83-fa8d-421f-ae86-5c355b541aff")
+		(uuid "4cba4f07-cd8a-479c-8143-3cfdf27fd6df")
 	)
 	(label "HALL_C"
 		(at 240.03 100.33 0)
@@ -11510,7 +11510,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "016b0d72-02cc-4821-a8ef-199bcab96f77")
+		(uuid "d446a0b3-4cc1-493a-bff7-4b74d2d5dfdb")
 	)
 	(text "BLDC Motor Controller Design Notes:\n=====================================\n1. MOSFETs Q1-Q6 require thermal vias (min 6 per device)\n2. Use 2mm+ trace width for motor phase and power traces\n3. Ground plane on bottom layer for heat spreading\n4. Keep gate drive traces short (<10mm)\n5. Kelvin connection for current sense resistors\n6. Separate analog ground near current sense\n7. Bulk capacitors near MOSFETs for motor current\n" (exclude_from_sim no) (at 25.4 299.72 0)
 		(effects
@@ -11519,10 +11519,10 @@
 			)
 			(justify left)
 		)
-		(uuid "72f2db7a-e07d-4494-aa4a-4229afce6f26")
+		(uuid "bafa9703-782c-477f-8780-cecbd9ec4ac3")
 	)
 	(sheet_instances
-		(path "/c2ad6d06-79e5-4d23-9b3c-4c2187540d5e" (page "1")
+		(path "/7145dd34-def2-4dd7-8afe-9c7c611ff298" (page "1")
 		)
 	)
 )

--- a/boards/05-bldc-motor-controller/output/bldc_controller_routed.kicad_pcb
+++ b/boards/05-bldc-motor-controller/output/bldc_controller_routed.kicad_pcb
@@ -114,14 +114,14 @@
 	(net 38 "PWM_BL")
 	(net 39 "PWM_CH")
 	(net 40 "PWM_CL")
-	(footprint "LED_SMD:LED_0805_2012Metric"
+	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "00818bf4-02d5-4676-9cae-7a24b305e38e")
-		(at 162 108)
-		(property "Reference" "D4"
+		(uuid "0520301e-bd12-43b7-9bc9-4055fb466253")
+		(at 150 130)
+		(property "Reference" "C6"
 			(at 0 -1.5 0)
 			(layer "F.SilkS")
-			(uuid "118f86fa-b111-4e67-83cb-7d12424d045c")
+			(uuid "8f015670-e677-4b17-8647-5067d360d33e")
 			(effects
 				(font
 					(size 1 1)
@@ -129,10 +129,10 @@
 				)
 			)
 		)
-		(property "Value" "LED"
+		(property "Value" "10uF"
 			(at 0 1.5 0)
 			(layer "F.Fab")
-			(uuid "f7d4084b-fde3-4a3c-b266-6a602595b7b3")
+			(uuid "284ab9c7-2c22-47b3-9e46-0c5f8d28cda5")
 			(effects
 				(font
 					(size 1 1)
@@ -144,7 +144,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "cadf64cb-18de-494f-8317-5da24a0731cf")
+			(uuid "f31302bb-8ea0-448a-91b8-d83200478db4")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -155,7 +155,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "bf9067ca-2ef3-428c-8b18-698e2b1a1906")
+			(uuid "0c8aa0c5-2315-45b6-86a6-be97580e97db")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -164,31 +164,165 @@
 		)
 		(duplicate_pad_numbers_are_jumpers no)
 		(pad "1" smd roundrect
-			(at -1.05 0)
-			(size 1 1.2)
+			(at -1 0)
+			(size 1 1.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "09e37cec-56cc-43b5-b755-9f0fe2d6159c")
-			(net 30 "STATUS_LED")
+			(uuid "f43706ad-1c58-42f3-95ab-aa40776bf02e")
+			(net 3 "+3.3V")
 		)
 		(pad "2" smd roundrect
-			(at 1.05 0)
-			(size 1 1.2)
+			(at 1 0)
+			(size 1 1.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "8f1f9e93-cd0b-463e-983c-89ddd66906a1")
+			(uuid "ace59fdb-1e58-48c9-92c3-317bca2ea341")
 			(net 4 "GND")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Capacitor_SMD:C_0805_2012Metric"
+		(layer "F.Cu")
+		(uuid "05ad0a61-6296-40e4-9dbd-854ad51abf64")
+		(at 104 147)
+		(property "Reference" "C12"
+			(at 0 -1.5 0)
+			(layer "F.SilkS")
+			(uuid "1babc7db-ffae-4acd-b3f3-7183f8b0e8b5")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100nF"
+			(at 0 1.5 0)
+			(layer "F.Fab")
+			(uuid "7581430c-b0f1-48e9-9fec-0d8b2008dc44")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "a2bd7c91-66ec-40a6-a24a-b1aa8a10d7e3")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "e935530b-2c11-4a45-99cd-aa16ffa370df")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" smd roundrect
+			(at -1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "1dc5a188-434c-4074-8cc3-b9e7ab9f9233")
+			(net 1 "VMOTOR")
+		)
+		(pad "2" smd roundrect
+			(at 1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "fc6a4066-4bcd-44cc-ac9d-9edd06bcfb57")
+			(net 5 "PHASE_A")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Resistor_SMD:R_0805_2012Metric"
+		(layer "F.Cu")
+		(uuid "095f33c7-3fb0-4edd-8d2e-08ebd0e107ac")
+		(at 140 162)
+		(property "Reference" "R22"
+			(at 0 -1.5 0)
+			(layer "F.SilkS")
+			(uuid "e01c4838-24aa-4646-ade0-00085f23135f")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "22"
+			(at 0 1.5 0)
+			(layer "F.Fab")
+			(uuid "281fbc66-a115-4d20-be2f-384166161b54")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "3e410252-7528-4973-84b5-6e42070c0b03")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "4b825d84-ad25-4db9-ae59-0d93e913d8bd")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" smd roundrect
+			(at -1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "3d328a55-bb93-4664-bcfd-c8ee39e54149")
+			(net 34 "GATE_DRV_CH")
+		)
+		(pad "2" smd roundrect
+			(at 1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "e39caaef-185c-418d-9696-556525a2c6c1")
+			(net 12 "GATE_CH")
 		)
 		(embedded_fonts no)
 	)
 	(footprint "MountingHole:MountingHole_3.2mm_M3"
 		(layer "F.Cu")
-		(uuid "01a15e4d-5bd5-4a35-a939-95e9be9bf91f")
-		(at 167 187)
-		(property "Reference" "MH4"
+		(uuid "17969256-76a5-4929-8964-fc1624452ffc")
+		(at 103 103)
+		(property "Reference" "MH1"
 			(at 0 -3 0)
 			(layer "F.SilkS")
-			(uuid "13cd2043-aa16-420f-93a6-3d16fe242a23")
+			(uuid "9db74959-5a1c-4224-b6a7-d789f4fc2bb1")
 			(effects
 				(font
 					(size 1 1)
@@ -199,7 +333,7 @@
 		(property "Value" "MountingHole"
 			(at 0 3 0)
 			(layer "F.Fab")
-			(uuid "934783f6-5be1-4654-90ad-6d967dbf58fe")
+			(uuid "53877111-47b4-4a72-b70a-2f4cb930a70d")
 			(effects
 				(font
 					(size 1 1)
@@ -211,7 +345,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "d931da42-3c90-4a7b-8b0d-c00d06806c89")
+			(uuid "c6eda1ea-4053-41a4-943f-97eab2b1df5e")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -222,7 +356,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "c6ca827f-4cf1-48af-a6ac-74ef99b72e61")
+			(uuid "5bdd7bfe-6c52-4cab-935b-5c2a31f11b0e")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -236,18 +370,18 @@
 			(size 3.2 3.2)
 			(drill 3.2)
 			(layers "*.Cu" "*.Mask")
-			(uuid "98420eff-899d-4fdd-9ca6-d277f9a568a1")
+			(uuid "515d6cc2-ea5f-4b05-993e-046b5e566120")
 		)
 		(embedded_fonts no)
 	)
-	(footprint "Resistor_SMD:R_0805_2012Metric"
+	(footprint "Package_TO_SOT_SMD:TO-263-5_TabPin3"
 		(layer "F.Cu")
-		(uuid "0c2a3fdf-8c01-4116-a0ed-5b61dd56eb8b")
-		(at 140 162)
-		(property "Reference" "R22"
-			(at 0 -1.5 0)
+		(uuid "200c416e-bd97-450b-b7a6-c14076e2c1b0")
+		(at 112 122)
+		(property "Reference" "U1"
+			(at 0 -5 0)
 			(layer "F.SilkS")
-			(uuid "68a50a69-1684-49f3-8025-5fda96a290ed")
+			(uuid "a2880f8f-02ba-4823-a512-922680b197cf")
 			(effects
 				(font
 					(size 1 1)
@@ -255,10 +389,10 @@
 				)
 			)
 		)
-		(property "Value" "22"
-			(at 0 1.5 0)
+		(property "Value" "LM2596-5.0"
+			(at 0 5 0)
 			(layer "F.Fab")
-			(uuid "74b27ce1-8f89-4b94-b88c-8c5b8facb465")
+			(uuid "f1393627-8dd9-4f22-8164-66af02d30095")
 			(effects
 				(font
 					(size 1 1)
@@ -270,7 +404,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "25e703ed-dca9-449a-a52c-78a7d011c4ba")
+			(uuid "aff385c5-e076-45bd-bacd-edbf5cf6a758")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -281,7 +415,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "5b786e5c-a16f-4b06-bfb5-596063422be0")
+			(uuid "3ed02e86-c37a-46c2-84b2-2c8a8390df40")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -289,233 +423,51 @@
 			)
 		)
 		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" smd roundrect
-			(at -1 0)
-			(size 1 1.3)
+		(pad "1" smd rect
+			(at -3.4 3.3)
+			(size 3 1.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "7d8ecfee-9f95-424d-8b7d-1415226c7fa0")
-			(net 34 "GATE_DRV_CH")
-		)
-		(pad "2" smd roundrect
-			(at 1 0)
-			(size 1 1.3)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "1012bd2c-3f90-4915-85f0-03a278e27484")
-			(net 12 "GATE_CH")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "Capacitor_SMD:C_0805_2012Metric"
-		(layer "F.Cu")
-		(uuid "1990955c-cf87-4c65-93c1-f9786ae79ef6")
-		(at 104 153)
-		(property "Reference" "C13"
-			(at 0 -1.5 0)
-			(layer "F.SilkS")
-			(uuid "1cf7d96c-8e7a-436c-98f4-ff6db265173d")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "100nF"
-			(at 0 1.5 0)
-			(layer "F.Fab")
-			(uuid "09805460-d3b0-46cf-b042-8c8de707fd0a")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "9c3d9457-6722-4446-a1f7-2f60830bfaa2")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "bac893dd-1dba-4e0c-810a-38c08ee70c58")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" smd roundrect
-			(at -1 0)
-			(size 1 1.3)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "600d7eec-01e7-4b76-a4f2-8788047c5fef")
+			(uuid "8e5e129a-c84c-45a6-b026-94f8dd6b2b87")
 			(net 1 "VMOTOR")
 		)
-		(pad "2" smd roundrect
-			(at 1 0)
-			(size 1 1.3)
+		(pad "2" smd rect
+			(at -3.4 1.1)
+			(size 3 1.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "ac86c772-98ec-4dc5-a2de-3b694413d4f1")
-			(net 6 "PHASE_B")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "Capacitor_SMD:C_0805_2012Metric"
-		(layer "F.Cu")
-		(uuid "2082b01a-78af-4cff-87e5-946d82ceebe9")
-		(at 106 130)
-		(property "Reference" "C3"
-			(at 0 -1.5 0)
-			(layer "F.SilkS")
-			(uuid "14e326e8-8fa0-4fec-b614-4a041e495d79")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "220uF"
-			(at 0 1.5 0)
-			(layer "F.Fab")
-			(uuid "c26f552d-dc7b-4ebc-9bad-18acb2c21910")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "b53530b3-28d2-440b-bb8d-f64b97b4081b")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "4c68a485-f46f-4f89-9140-e6022cee9b01")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" smd roundrect
-			(at -1 0)
-			(size 1 1.3)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "9af17f72-80fc-4400-8339-8accde4360c2")
-			(net 1 "VMOTOR")
-		)
-		(pad "2" smd roundrect
-			(at 1 0)
-			(size 1 1.3)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "faa8c6ad-8912-4ed0-9b03-89cc4a1478db")
-			(net 4 "GND")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "Capacitor_SMD:C_0805_2012Metric"
-		(layer "F.Cu")
-		(uuid "27627456-7631-4c02-acf6-16beb26a6704")
-		(at 124 147)
-		(property "Reference" "C15"
-			(at 0 -1.5 0)
-			(layer "F.SilkS")
-			(uuid "d11e30a0-344a-4bc9-9cf3-b938be81314d")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "100nF"
-			(at 0 1.5 0)
-			(layer "F.Fab")
-			(uuid "8cdd4c03-0328-4f4d-90b2-09f9a5cb4fe7")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "c2c8ce04-e6c7-412c-a82b-301c7d934c0b")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "173baa59-0e12-4597-8de6-b6bd673c798f")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" smd roundrect
-			(at -1 0)
-			(size 1 1.3)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "61ddf8b6-349a-4882-bb4a-6cbafcfbf084")
+			(uuid "286bc191-2d96-4a36-905b-c5a2b157ac78")
 			(net 2 "+5V")
 		)
-		(pad "2" smd roundrect
-			(at 1 0)
-			(size 1 1.3)
+		(pad "3" smd rect
+			(at -3.4 -1.1)
+			(size 3 1.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "7c086ac6-f337-4741-88e6-1f4f1b4d2abf")
+			(uuid "ad617b2b-39d5-445d-8c4c-5aa9f50723fc")
+			(net 31 "SW_OUT")
+		)
+		(pad "4" smd rect
+			(at -3.4 -3.3)
+			(size 3 1.5)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(uuid "cf70224f-5dc9-469e-a690-a7c8ea0aa408")
+			(net 4 "GND")
+		)
+		(pad "5" smd rect
+			(at 3.4 0)
+			(size 3 8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(uuid "8f8d9992-fbf1-43f7-b616-923bf87c8977")
 			(net 4 "GND")
 		)
 		(embedded_fonts no)
 	)
 	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "385fdce1-652c-4205-a8e5-b06e6304f351")
+		(uuid "258e7e37-73ec-42d6-af52-d60068dc50a9")
 		(at 146 137)
 		(property "Reference" "C9"
 			(at 0 -1.5 0)
 			(layer "F.SilkS")
-			(uuid "c94d2c26-069b-4c5f-aa6b-a58c987e8033")
+			(uuid "0c8882c6-262b-4f2c-b98f-35bb1bf0c1d3")
 			(effects
 				(font
 					(size 1 1)
@@ -526,7 +478,7 @@
 		(property "Value" "4.7uF"
 			(at 0 1.5 0)
 			(layer "F.Fab")
-			(uuid "a698092e-c444-4adb-a650-68b0104c61ef")
+			(uuid "8eb065d2-f610-4713-ac6f-1f10ec7b2507")
 			(effects
 				(font
 					(size 1 1)
@@ -538,7 +490,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "412c6205-3f2c-4370-aa5c-9b103bfebc16")
+			(uuid "aec72ff9-d972-4363-8c0f-48fd4ccf51df")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -549,7 +501,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "60356967-233f-473c-b141-18fd92230edd")
+			(uuid "cc5e13c0-8dc0-4605-a587-1e3d80576f69")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -562,7 +514,7 @@
 			(size 1 1.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "98d09afb-5678-4443-b566-08b8c62961db")
+			(uuid "db7b29dd-4568-4907-b147-189876cb3916")
 			(net 3 "+3.3V")
 		)
 		(pad "2" smd roundrect
@@ -570,153 +522,19 @@
 			(size 1 1.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "9bf4254a-37a2-494a-b322-0399c22f002a")
+			(uuid "1bdcc93d-64d9-4e08-a992-154a4a7062f4")
 			(net 4 "GND")
 		)
 		(embedded_fonts no)
 	)
 	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "3b0175dc-c2e1-4174-ab42-a3a19b912459")
-		(at 130 108)
-		(property "Reference" "C1"
+		(uuid "278faa03-28e1-49fe-b5e9-5600fdbb923e")
+		(at 140 137)
+		(property "Reference" "C8"
 			(at 0 -1.5 0)
 			(layer "F.SilkS")
-			(uuid "597a9b25-cea1-416c-85c8-212540d22e93")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "470uF"
-			(at 0 1.5 0)
-			(layer "F.Fab")
-			(uuid "183fc89f-c171-438a-91d0-cdedf7c9833b")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "fdd4e50e-8ab3-4875-bbd1-cd0747d3e668")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "b96cb565-1b05-40c9-934f-819aa03ac1f1")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" smd roundrect
-			(at -1 0)
-			(size 1 1.3)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "2d0c5d00-40b4-4389-93ea-98755928e3bc")
-			(net 1 "VMOTOR")
-		)
-		(pad "2" smd roundrect
-			(at 1 0)
-			(size 1 1.3)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "7e11d53f-9c1b-48bf-a2f3-4cbc2a97aa3f")
-			(net 4 "GND")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "Diode_SMD:D_SMA"
-		(layer "F.Cu")
-		(uuid "3c9920fe-cd6a-4322-8573-63e990c6fbc9")
-		(at 119 130)
-		(property "Reference" "D2"
-			(at 0 -2 0)
-			(layer "F.SilkS")
-			(uuid "148d3d6b-bfc6-4754-a826-5d2b82390ed2")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "SS34"
-			(at 0 2 0)
-			(layer "F.Fab")
-			(uuid "e57148e1-2eec-4ee7-bd1e-cf41224f02ab")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "c8700ef9-b224-481a-8da4-01e22d000450")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "f7b58efd-3b9d-4af1-8a4e-d1635e3ab490")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" smd roundrect
-			(at -2 0)
-			(size 1.5 1.7)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "be7fb594-154e-44c6-beb3-3ee84e396bd2")
-			(net 31 "SW_OUT")
-		)
-		(pad "2" smd roundrect
-			(at 2 0)
-			(size 1.5 1.7)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "c947eb5c-7a63-421b-bf32-38ad918d2f8d")
-			(net 4 "GND")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "Capacitor_SMD:C_0805_2012Metric"
-		(layer "F.Cu")
-		(uuid "406a0482-0467-4bdf-996b-621abca394aa")
-		(at 104 147)
-		(property "Reference" "C12"
-			(at 0 -1.5 0)
-			(layer "F.SilkS")
-			(uuid "6d55303a-5eac-4714-b184-be00c1688162")
+			(uuid "c6311014-f763-4361-beff-1dd5d2a9e913")
 			(effects
 				(font
 					(size 1 1)
@@ -727,7 +545,7 @@
 		(property "Value" "100nF"
 			(at 0 1.5 0)
 			(layer "F.Fab")
-			(uuid "e9c1c905-9ddf-4be2-aae8-bed11f605108")
+			(uuid "ed698c21-ebc1-4b78-afef-93ee7838e5ab")
 			(effects
 				(font
 					(size 1 1)
@@ -739,7 +557,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "195b7ca5-c8a6-4001-bb7c-edee1c411c83")
+			(uuid "81f1ae33-5fc0-4256-9396-a90dd0c7d99d")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -750,7 +568,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "b9b41b2b-84ea-4ec7-992f-e95b120271b3")
+			(uuid "65a5ef98-7baa-4cc2-9a10-1415eb50e6ed")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -763,7 +581,74 @@
 			(size 1 1.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "eb1c4c72-bc00-4a20-b049-b7a826989918")
+			(uuid "2306af16-c324-4bea-9ab3-c8468d5089da")
+			(net 3 "+3.3V")
+		)
+		(pad "2" smd roundrect
+			(at 1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "dfb2c3aa-96e8-46ec-bf3b-b6823e2a5739")
+			(net 4 "GND")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Capacitor_SMD:C_0805_2012Metric"
+		(layer "F.Cu")
+		(uuid "27d2f36a-a277-4bb9-a590-94dbd2e2f41a")
+		(at 130 114)
+		(property "Reference" "C2"
+			(at 0 -1.5 0)
+			(layer "F.SilkS")
+			(uuid "d89fec4d-1555-4962-a118-a2a24fd817ca")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100nF"
+			(at 0 1.5 0)
+			(layer "F.Fab")
+			(uuid "b7183f10-0c70-4c26-ad2d-690697f0c7af")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "771d71cb-60e5-426b-9770-3d5042abd57a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "0e709b0a-c207-4cbd-88e4-4bfb308dc74c")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" smd roundrect
+			(at -1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "c986171c-2aed-4db9-a87d-fbbd6276a835")
 			(net 1 "VMOTOR")
 		)
 		(pad "2" smd roundrect
@@ -771,289 +656,19 @@
 			(size 1 1.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "c5f22472-f568-4244-8654-c03775903806")
-			(net 5 "PHASE_A")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "Crystal:Crystal_HC49-4H_Vertical"
-		(layer "F.Cu")
-		(uuid "46909929-3206-484c-b8bc-ce6149c2aaca")
-		(at 152 137)
-		(property "Reference" "Y1"
-			(at 0 -3 0)
-			(layer "F.SilkS")
-			(uuid "e0804c9a-f109-4924-9fc8-aa5447bda491")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "8MHz"
-			(at 0 3 0)
-			(layer "F.Fab")
-			(uuid "8349e9e9-2403-40ea-bdeb-b64fc6736507")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "44abe749-e5ba-4e25-b82e-f759ff7333b5")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "5a051db5-6952-46d6-8977-387080220343")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" thru_hole circle
-			(at -2.44 0)
-			(size 1.5 1.5)
-			(drill 0.8)
-			(layers "*.Cu" "*.Mask")
-			(remove_unused_layers no)
-			(uuid "f9b31e27-af3e-4543-b344-fc82bf363beb")
-			(net 27 "OSC_IN")
-		)
-		(pad "2" thru_hole circle
-			(at 2.44 0)
-			(size 1.5 1.5)
-			(drill 0.8)
-			(layers "*.Cu" "*.Mask")
-			(remove_unused_layers no)
-			(uuid "9f27acb3-18f7-472e-a584-48facc45a9a9")
-			(net 28 "OSC_OUT")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "Resistor_SMD:R_0805_2012Metric"
-		(layer "F.Cu")
-		(uuid "4c37090a-b133-43fd-b50b-5716039b3a30")
-		(at 156 113)
-		(property "Reference" "R3"
-			(at 0 -1.5 0)
-			(layer "F.SilkS")
-			(uuid "83a188f7-3fc3-4230-ad48-b2f308735248")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "1k"
-			(at 0 1.5 0)
-			(layer "F.Fab")
-			(uuid "856b2dd8-96ce-4c29-89d5-113e8e9444e0")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "9bf8697a-6191-4a63-ac5f-3a0c43372a63")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "5c76cc56-d35b-4722-8473-101ef8ae278b")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" smd roundrect
-			(at -1 0)
-			(size 1 1.3)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "68372889-4e82-48b0-a393-b7297cd5e5c1")
-			(net 3 "+3.3V")
-		)
-		(pad "2" smd roundrect
-			(at 1 0)
-			(size 1 1.3)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "533a9772-27d9-4d72-a737-2b12d7138e36")
-			(net 29 "PWR_LED")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "Resistor_SMD:R_0805_2012Metric"
-		(layer "F.Cu")
-		(uuid "4c46c27a-0c79-4d76-9a91-8c98e9f2ed54")
-		(at 161 157)
-		(property "Reference" "R32"
-			(at 0 -1.5 0)
-			(layer "F.SilkS")
-			(uuid "871bb751-dbb4-4204-8ab8-397f4358b5f9")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "10k"
-			(at 0 1.5 0)
-			(layer "F.Fab")
-			(uuid "53058c33-7ec2-42e6-af87-a656ffe489d1")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "bfb7a63b-f31c-457a-93a5-ac0e6426f88f")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "bd87f2bd-4eb3-4365-9915-33b9caa50b7f")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" smd roundrect
-			(at -1 0)
-			(size 1 1.3)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "8b4e6687-6cc6-4a32-9e74-90edc35a95fe")
-			(net 3 "+3.3V")
-		)
-		(pad "2" smd roundrect
-			(at 1 0)
-			(size 1 1.3)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "da7529ff-44bd-4afa-90b6-5635d93aeda6")
-			(net 22 "HALL_C")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "Capacitor_SMD:C_0805_2012Metric"
-		(layer "F.Cu")
-		(uuid "4fe6349e-c403-4b7e-a78f-cd81cd0c5ebc")
-		(at 160 137)
-		(property "Reference" "C10"
-			(at 0 -1.5 0)
-			(layer "F.SilkS")
-			(uuid "6ef8dfda-0b0e-43ac-a312-0f35a92ff380")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "20pF"
-			(at 0 1.5 0)
-			(layer "F.Fab")
-			(uuid "70909369-99c2-41e5-a920-8f619a5892ba")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "90fa85c2-4161-4a6f-b0e8-931fc7c6c108")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "3b13ebf1-a226-4078-80e7-21eeb1e06224")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" smd roundrect
-			(at -1 0)
-			(size 1 1.3)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "b05a7f25-671c-4773-af44-99af66df93ce")
-			(net 27 "OSC_IN")
-		)
-		(pad "2" smd roundrect
-			(at 1 0)
-			(size 1 1.3)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "ec1b3428-5a2e-41fe-b3b0-34490fe2207b")
+			(uuid "8b5ff97e-e8ee-4ce7-8433-b1185a3d6fc5")
 			(net 4 "GND")
 		)
 		(embedded_fonts no)
 	)
-	(footprint "Capacitor_SMD:C_0805_2012Metric"
+	(footprint "LED_SMD:LED_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "5795825a-ecba-4929-aa36-01eafe985e04")
-		(at 124 153)
-		(property "Reference" "C16"
+		(uuid "2a10cd20-e0ee-4b3b-91a8-a6c581aa80f6")
+		(at 162 108)
+		(property "Reference" "D4"
 			(at 0 -1.5 0)
 			(layer "F.SilkS")
-			(uuid "f48d36e9-cd12-4b3c-8de0-6c8e1eac89fc")
+			(uuid "e935da1c-bea0-47d1-8431-6f5cabe42099")
 			(effects
 				(font
 					(size 1 1)
@@ -1061,10 +676,10 @@
 				)
 			)
 		)
-		(property "Value" "10uF"
+		(property "Value" "LED"
 			(at 0 1.5 0)
 			(layer "F.Fab")
-			(uuid "9aa4c569-fef3-427d-9bf3-07d216c6e962")
+			(uuid "ec6dd032-f4a8-43cf-ae14-8466052304c4")
 			(effects
 				(font
 					(size 1 1)
@@ -1076,7 +691,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "845e3c7f-16d9-424e-8431-ae0c6d8bda02")
+			(uuid "c3488fc4-00d1-445a-ace8-333b32c3ddd9")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1087,7 +702,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "8f14f53b-99d1-4c68-8467-fcc35ea5494d")
+			(uuid "60f63433-df83-43bb-b884-a1c1f23ebb7e")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1096,165 +711,110 @@
 		)
 		(duplicate_pad_numbers_are_jumpers no)
 		(pad "1" smd roundrect
-			(at -1 0)
-			(size 1 1.3)
+			(at -1.05 0)
+			(size 1 1.2)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "2d0eaaee-86c6-4442-bd4f-d6c13a05b300")
+			(uuid "fc2509fd-2681-4749-90b1-08a9058d8a01")
+			(net 30 "STATUS_LED")
+		)
+		(pad "2" smd roundrect
+			(at 1.05 0)
+			(size 1 1.2)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "507e383a-f599-444a-8aee-120090df083d")
+			(net 4 "GND")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Package_TO_SOT_SMD:SOT-223-3_TabPin2"
+		(layer "F.Cu")
+		(uuid "2d5e98dc-ce58-48bf-aa36-1a555ea4847e")
+		(at 144 122)
+		(property "Reference" "U2"
+			(at 0 -4 0)
+			(layer "F.SilkS")
+			(uuid "4b371681-9921-448e-93a5-f45e000fb976")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "AMS1117-3.3"
+			(at 0 4 0)
+			(layer "F.Fab")
+			(uuid "82a6f473-b2a3-4c01-b89a-b9503d60efe6")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d8eab07c-8cf4-4d3c-ac4e-7e1a8575f5ee")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "aa76ed70-08e9-4595-936a-7b9059897323")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" smd rect
+			(at -3.15 2.3)
+			(size 2 1.5)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(uuid "8bc8234f-8744-49de-82c8-868da9de2e57")
 			(net 2 "+5V")
 		)
-		(pad "2" smd roundrect
-			(at 1 0)
-			(size 1 1.3)
+		(pad "2" smd rect
+			(at -3.15 0)
+			(size 2 1.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "6ba5cb8f-8642-4285-99e8-8a5af97a96ab")
+			(uuid "32601292-cbd2-4746-ac47-f10f6c7b6987")
 			(net 4 "GND")
 		)
-		(embedded_fonts no)
-	)
-	(footprint "Capacitor_SMD:C_0805_2012Metric"
-		(layer "F.Cu")
-		(uuid "5d1776e0-8b8f-482d-bb61-6cdb61556375")
-		(at 150 130)
-		(property "Reference" "C6"
-			(at 0 -1.5 0)
-			(layer "F.SilkS")
-			(uuid "d7a9516f-1748-4ff6-9d45-1eb0c7983708")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "10uF"
-			(at 0 1.5 0)
-			(layer "F.Fab")
-			(uuid "49b6a66d-22c3-4b0a-8ccc-4ba0cb9e80c3")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "d735993f-0460-4aa3-872d-ddf0a057d6f5")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "7dbed77f-2aa4-47c8-88f3-d91d938c12f9")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" smd roundrect
-			(at -1 0)
-			(size 1 1.3)
+		(pad "2" smd rect
+			(at 3.15 0)
+			(size 2 3.8)
 			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "bb28bddd-f91c-4d9f-964b-62957ca03c11")
+			(uuid "dfe78572-68b4-4d48-984e-b9b503f96d37")
+			(net 4 "GND")
+		)
+		(pad "3" smd rect
+			(at -3.15 -2.3)
+			(size 2 1.5)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(uuid "f273bcd7-b034-49e5-ae88-c5e6f08722dc")
 			(net 3 "+3.3V")
 		)
-		(pad "2" smd roundrect
-			(at 1 0)
-			(size 1 1.3)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "173a5573-5b54-42c9-bc7a-435e73894bfd")
-			(net 4 "GND")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "Resistor_SMD:R_2512_6332Metric"
-		(layer "F.Cu")
-		(uuid "63640572-956b-40ce-9148-a3b913c1fc54")
-		(at 124 184)
-		(property "Reference" "R11"
-			(at 0 -2 0)
-			(layer "F.SilkS")
-			(uuid "33c72fdb-9f9c-40dd-9918-969b9303c47f")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "5mR"
-			(at 0 2 0)
-			(layer "F.Fab")
-			(uuid "bd8baa73-25aa-463c-a674-149167daec18")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "ac949525-4641-47d5-bc20-399bbd28ff17")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "ab6c9c56-559e-46d8-9879-acc67e749f23")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" smd roundrect
-			(at -3.1 0)
-			(size 1.6 2.7)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "48e1e99b-f30e-4a42-a088-3cbcb736fa3b")
-			(net 16 "ISENSE_B+")
-		)
-		(pad "2" smd roundrect
-			(at 3.1 0)
-			(size 1.6 2.7)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "0440a482-b66f-4e92-86a7-494ba4a061fe")
-			(net 17 "ISENSE_B-")
-		)
 		(embedded_fonts no)
 	)
 	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "6834ffba-6213-432d-a7ca-598641e96e8d")
-		(at 160 143)
-		(property "Reference" "C11"
+		(uuid "40c9ff34-569f-411f-b8e3-770d3f596694")
+		(at 104 159)
+		(property "Reference" "C14"
 			(at 0 -1.5 0)
 			(layer "F.SilkS")
-			(uuid "a5761c09-3372-4257-941a-539acd5e920d")
+			(uuid "4f6450e9-3728-47cd-9187-c420f5aef4b2")
 			(effects
 				(font
 					(size 1 1)
@@ -1262,10 +822,10 @@
 				)
 			)
 		)
-		(property "Value" "20pF"
+		(property "Value" "100nF"
 			(at 0 1.5 0)
 			(layer "F.Fab")
-			(uuid "9e3810cd-d6c7-4d20-aa11-3c6f0c600f5c")
+			(uuid "65d4d0df-b3be-4993-bdfa-e92fb0a5f9be")
 			(effects
 				(font
 					(size 1 1)
@@ -1277,7 +837,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "f12e653c-7749-4895-9be7-18f8acab07b1")
+			(uuid "31e48623-6d40-4863-8c6b-2ec72e83fd64")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1288,7 +848,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "395da53b-eea4-4123-a5dc-b94f30fddfc8")
+			(uuid "ec27c743-c705-42d5-bd9a-91c53329678d")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1301,27 +861,27 @@
 			(size 1 1.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "dd67416f-e013-44fb-a17c-8ca6eddc5c57")
-			(net 28 "OSC_OUT")
+			(uuid "933f252f-fe97-4b22-9144-043c2693af8b")
+			(net 1 "VMOTOR")
 		)
 		(pad "2" smd roundrect
 			(at 1 0)
 			(size 1 1.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "5e1e4bb9-ab14-4e0a-8e23-4c679c9dff05")
-			(net 4 "GND")
+			(uuid "4b5fa80d-9242-455d-ad99-9723abbb5c77")
+			(net 7 "PHASE_C")
 		)
 		(embedded_fonts no)
 	)
 	(footprint "Connector_PinHeader_2.54mm:PinHeader_1x06_P2.54mm_Vertical"
 		(layer "F.Cu")
-		(uuid "6af90cf6-c0a8-4d0f-b3ee-0eec5ce9cfbc")
+		(uuid "45aa7077-5efb-4eae-976b-cf082b4758f6")
 		(at 165 122)
 		(property "Reference" "J4"
 			(at 0 -8.6 0)
 			(layer "F.SilkS")
-			(uuid "40690489-8882-435b-b4e4-4a76cf34fbad")
+			(uuid "ed39db10-13c5-40f8-8742-8b9ddea51504")
 			(effects
 				(font
 					(size 1 1)
@@ -1332,7 +892,7 @@
 		(property "Value" "SWD Debug"
 			(at 0 8.6 0)
 			(layer "F.Fab")
-			(uuid "35fb75c1-7793-4a1a-9fdf-667165ee3027")
+			(uuid "e86cd0c4-8ef3-4696-a471-e1ba32505b06")
 			(effects
 				(font
 					(size 1 1)
@@ -1344,7 +904,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "6f1f2a7e-4929-42dd-96b5-cf92bc757acb")
+			(uuid "6fb8a844-c2b9-4f2f-82aa-1514b63ecf55")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1355,7 +915,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "e82bcb47-691a-4ca6-bee6-a4325a302b2e")
+			(uuid "74029689-c8be-448e-b0b1-b65d3998be66")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1369,7 +929,7 @@
 			(drill 1)
 			(layers "*.Cu" "*.Mask")
 			(remove_unused_layers no)
-			(uuid "6918ed27-16bd-42b0-b135-0636cc12d76d")
+			(uuid "ad45693d-46da-455a-9353-755cf56b2876")
 			(net 3 "+3.3V")
 		)
 		(pad "2" thru_hole oval
@@ -1378,7 +938,7 @@
 			(drill 1)
 			(layers "*.Cu" "*.Mask")
 			(remove_unused_layers no)
-			(uuid "64b4f119-71d0-4ad8-97c6-48f79e951bf8")
+			(uuid "6704e09a-f4c1-44b8-9ecd-1411a8023ccf")
 			(net 23 "SWDIO")
 		)
 		(pad "3" thru_hole oval
@@ -1387,7 +947,7 @@
 			(drill 1)
 			(layers "*.Cu" "*.Mask")
 			(remove_unused_layers no)
-			(uuid "1974b09a-383e-4eff-8a96-17abc3f71423")
+			(uuid "594a5932-1c58-42a8-baab-7e91cfa218d5")
 			(net 24 "SWCLK")
 		)
 		(pad "4" thru_hole oval
@@ -1396,7 +956,7 @@
 			(drill 1)
 			(layers "*.Cu" "*.Mask")
 			(remove_unused_layers no)
-			(uuid "2d122425-2e54-4e21-b455-f3c0eef3ca6c")
+			(uuid "200430ac-7005-4a99-8ca9-1c475f57f63a")
 			(net 25 "SWO")
 		)
 		(pad "5" thru_hole oval
@@ -1405,7 +965,7 @@
 			(drill 1)
 			(layers "*.Cu" "*.Mask")
 			(remove_unused_layers no)
-			(uuid "4eaa111e-7a97-4052-aa7f-759423448fb3")
+			(uuid "87633df7-a5b9-4d71-8879-7b130cb18ed7")
 			(net 26 "NRST")
 		)
 		(pad "6" thru_hole oval
@@ -1414,165 +974,19 @@
 			(drill 1)
 			(layers "*.Cu" "*.Mask")
 			(remove_unused_layers no)
-			(uuid "9bd20239-a338-4d5d-9c0a-06cecaf2a2d3")
+			(uuid "35b908cd-276e-42ae-8e38-1bab05add8e8")
 			(net 4 "GND")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "LED_SMD:LED_0805_2012Metric"
-		(layer "F.Cu")
-		(uuid "707d29d2-2a30-4b95-9d1d-7d5b8197ad21")
-		(at 156 108)
-		(property "Reference" "D3"
-			(at 0 -1.5 0)
-			(layer "F.SilkS")
-			(uuid "5d914b00-d2b4-4f76-b66d-aa1bb74f6a19")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "LED"
-			(at 0 1.5 0)
-			(layer "F.Fab")
-			(uuid "ae393950-1f22-450d-a748-e87a2643eda1")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "c55be61b-d7e1-4ebe-830f-b46eb318374e")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "e03b9428-1e85-4859-83c7-94086ac45580")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" smd roundrect
-			(at -1.05 0)
-			(size 1 1.2)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "26c3382b-d7c2-48d5-a58e-be2dcede2938")
-			(net 29 "PWR_LED")
-		)
-		(pad "2" smd roundrect
-			(at 1.05 0)
-			(size 1 1.2)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "c8c780bd-539e-4825-9b66-2a8d9a5fb9b6")
-			(net 4 "GND")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "Package_TO_SOT_SMD:SOT-223-3_TabPin2"
-		(layer "F.Cu")
-		(uuid "71a40cc1-c047-4ea6-be62-fbf2290e97bc")
-		(at 144 122)
-		(property "Reference" "U2"
-			(at 0 -4 0)
-			(layer "F.SilkS")
-			(uuid "eeb880e2-ef97-4266-b32d-f55b72db169b")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "AMS1117-3.3"
-			(at 0 4 0)
-			(layer "F.Fab")
-			(uuid "fc8aef40-c023-402e-a81b-781718cc16c1")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "5ca3007a-240f-49c4-8470-59eaadee5351")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "fe962f3c-7582-436c-a3b3-0259c5385978")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" smd rect
-			(at -3.15 2.3)
-			(size 2 1.5)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(uuid "dc5b0836-a0e9-470b-9273-638a9ffb8144")
-			(net 2 "+5V")
-		)
-		(pad "2" smd rect
-			(at -3.15 0)
-			(size 2 1.5)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(uuid "16b3f411-6199-447a-88bc-f1a59599b147")
-			(net 4 "GND")
-		)
-		(pad "2" smd rect
-			(at 3.15 0)
-			(size 2 3.8)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(uuid "73b2a963-083c-43c5-a001-a19fc12ad658")
-			(net 4 "GND")
-		)
-		(pad "3" smd rect
-			(at -3.15 -2.3)
-			(size 2 1.5)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(uuid "799739fd-6323-4a19-a0cd-deb2e8e68fef")
-			(net 3 "+3.3V")
 		)
 		(embedded_fonts no)
 	)
 	(footprint "Connector_PinHeader_2.54mm:PinHeader_1x05_P2.54mm_Vertical"
 		(layer "F.Cu")
-		(uuid "733f5a5d-f74d-425f-9f4d-59544d9fd285")
+		(uuid "48fb9789-a92c-451c-b3b2-e46fa7a9c7ed")
 		(at 165 158)
 		(property "Reference" "J3"
 			(at 0 -7.3 0)
 			(layer "F.SilkS")
-			(uuid "0e40b8b1-2f36-43e2-99e5-e5466f8fee83")
+			(uuid "24851407-632c-4b82-acf5-661d392e978f")
 			(effects
 				(font
 					(size 1 1)
@@ -1583,7 +997,7 @@
 		(property "Value" "Hall Sensors"
 			(at 0 7.3 0)
 			(layer "F.Fab")
-			(uuid "df70ad75-d829-402a-9645-683cee7c2772")
+			(uuid "ba8e2db7-c8df-48b2-803d-cd28811843c0")
 			(effects
 				(font
 					(size 1 1)
@@ -1595,7 +1009,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "2ae8ac2b-d7a6-44ac-aab6-bf0bace6782e")
+			(uuid "657631e4-f043-42f9-8899-c224df37e655")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1606,7 +1020,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "5f0c9074-1cc2-4437-ba5c-52f89a314213")
+			(uuid "c3108e57-263f-4bdb-9927-112c5faa02f8")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1620,7 +1034,7 @@
 			(drill 1)
 			(layers "*.Cu" "*.Mask")
 			(remove_unused_layers no)
-			(uuid "f0abec19-41e8-4af3-8e0c-9b4fee5fc092")
+			(uuid "6d962a35-2a82-4d06-9640-016c8e408f71")
 			(net 20 "HALL_A")
 		)
 		(pad "2" thru_hole oval
@@ -1629,7 +1043,7 @@
 			(drill 1)
 			(layers "*.Cu" "*.Mask")
 			(remove_unused_layers no)
-			(uuid "5f57d574-bac7-4060-b423-740f16c8d2c4")
+			(uuid "f2a2b084-49f6-4e5c-9479-fa218682ae84")
 			(net 21 "HALL_B")
 		)
 		(pad "3" thru_hole oval
@@ -1638,7 +1052,7 @@
 			(drill 1)
 			(layers "*.Cu" "*.Mask")
 			(remove_unused_layers no)
-			(uuid "10677818-76a8-4180-b04a-f2f0742643a5")
+			(uuid "2d8e5647-ee80-4fa6-86a8-25efc3da5a2f")
 			(net 22 "HALL_C")
 		)
 		(pad "4" thru_hole oval
@@ -1647,7 +1061,7 @@
 			(drill 1)
 			(layers "*.Cu" "*.Mask")
 			(remove_unused_layers no)
-			(uuid "3bc072e5-cfba-4217-8571-d5bb6103449d")
+			(uuid "7a4a1093-501d-4286-b548-ea6489a49587")
 			(net 3 "+3.3V")
 		)
 		(pad "5" thru_hole oval
@@ -1656,86 +1070,19 @@
 			(drill 1)
 			(layers "*.Cu" "*.Mask")
 			(remove_unused_layers no)
-			(uuid "28c7a2b2-2fa3-464c-bb11-03ea4d4474ad")
-			(net 4 "GND")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "Capacitor_SMD:C_0805_2012Metric"
-		(layer "F.Cu")
-		(uuid "743ddcc5-da41-4111-8c5c-5874faaf3311")
-		(at 149 161)
-		(property "Reference" "C30"
-			(at 0 -1.5 0)
-			(layer "F.SilkS")
-			(uuid "f958013f-1ee2-4e99-9d2e-83471f10b1fb")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "10nF"
-			(at 0 1.5 0)
-			(layer "F.Fab")
-			(uuid "f1fcfa7a-daed-4efc-b007-2f7072fccf79")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "6eeeb69c-cedb-4bf2-8303-bd1f7c728ebe")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "6f99f56b-35f5-4ef3-8c90-1177ac838f9c")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" smd roundrect
-			(at -1 0)
-			(size 1 1.3)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "ccf5f5cb-f69f-427a-bc2f-71ca933f792a")
-			(net 20 "HALL_A")
-		)
-		(pad "2" smd roundrect
-			(at 1 0)
-			(size 1 1.3)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "07205e31-d769-4a50-bd37-fec1db505aa7")
+			(uuid "aacfe720-ba5b-4bc6-8818-cd263982ca8b")
 			(net 4 "GND")
 		)
 		(embedded_fonts no)
 	)
 	(footprint "Resistor_SMD:R_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "74d23b11-0324-43be-b7e3-d5f6bff7ff86")
-		(at 124 162)
-		(property "Reference" "R21"
+		(uuid "4fb232c7-2848-451c-9340-851502e22e7a")
+		(at 108 162)
+		(property "Reference" "R20"
 			(at 0 -1.5 0)
 			(layer "F.SilkS")
-			(uuid "af2d9327-5122-4919-9bb9-be79b670492f")
+			(uuid "d019fac0-9fed-431b-8ac8-2fcc5be054ed")
 			(effects
 				(font
 					(size 1 1)
@@ -1746,7 +1093,7 @@
 		(property "Value" "22"
 			(at 0 1.5 0)
 			(layer "F.Fab")
-			(uuid "f91e175d-ab26-4a6a-a491-f83b2e2e68a5")
+			(uuid "73274ae2-0e2d-433c-b99d-f2572202db99")
 			(effects
 				(font
 					(size 1 1)
@@ -1758,7 +1105,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "3365a43e-48fe-4d9e-8b6c-31d8baa985b2")
+			(uuid "51f705ad-4010-4d3c-8097-90af71b2067d")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1769,7 +1116,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "a4f570ac-78c2-4b4f-b9cc-a25afaafae4c")
+			(uuid "110fb284-56b9-488a-a5d1-1fb8b224cece")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1782,94 +1129,27 @@
 			(size 1 1.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "611237d2-30fb-4487-ba01-62b06698ba0c")
-			(net 33 "GATE_DRV_BH")
+			(uuid "0aa9c5ef-08ec-460e-aece-6b9ea11f904f")
+			(net 32 "GATE_DRV_AH")
 		)
 		(pad "2" smd roundrect
 			(at 1 0)
 			(size 1 1.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "c4833aaa-d080-4dca-847e-5528fcdf979c")
-			(net 10 "GATE_BH")
+			(uuid "38977e5d-eccf-417d-8e12-200df31f79de")
+			(net 8 "GATE_AH")
 		)
 		(embedded_fonts no)
 	)
-	(footprint "Resistor_SMD:R_2512_6332Metric"
+	(footprint "Resistor_SMD:R_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "7706729f-e0aa-4dec-bb7d-59cd4b7faf3a")
-		(at 108 184)
-		(property "Reference" "R10"
-			(at 0 -2 0)
-			(layer "F.SilkS")
-			(uuid "5dcf244d-40b0-4d10-8fb6-09bbf036ae89")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "5mR"
-			(at 0 2 0)
-			(layer "F.Fab")
-			(uuid "c2a63cf2-d836-49dd-ae1e-b974b48b1962")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "5aee9738-9b2b-40cc-8c51-705257205edd")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "4f57687f-6ec3-4bf7-ba32-f3e9e35a89e9")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" smd roundrect
-			(at -3.1 0)
-			(size 1.6 2.7)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "29fbbf26-1889-4c89-90e4-39a8f9218559")
-			(net 14 "ISENSE_A+")
-		)
-		(pad "2" smd roundrect
-			(at 3.1 0)
-			(size 1.6 2.7)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "0d050f29-2efb-4711-8b6a-37a91f594fa6")
-			(net 15 "ISENSE_A-")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "Capacitor_SMD:C_0805_2012Metric"
-		(layer "F.Cu")
-		(uuid "7d5d1c24-28a2-4961-99db-c8bf56b357ae")
-		(at 138 130)
-		(property "Reference" "C5"
+		(uuid "5149da9b-11e7-4039-b6c3-a8e3972e52b4")
+		(at 156 113)
+		(property "Reference" "R3"
 			(at 0 -1.5 0)
 			(layer "F.SilkS")
-			(uuid "14cf26db-4b37-419d-9e12-4b7d26bfbf8e")
+			(uuid "f6849292-19d7-4039-9b2b-fd9fe1e36fb2")
 			(effects
 				(font
 					(size 1 1)
@@ -1877,10 +1157,10 @@
 				)
 			)
 		)
-		(property "Value" "10uF"
+		(property "Value" "1k"
 			(at 0 1.5 0)
 			(layer "F.Fab")
-			(uuid "8a987d79-2432-4f6e-af28-75063657ed9c")
+			(uuid "8d2ad18e-da96-437e-8c58-1b923c0ef5c2")
 			(effects
 				(font
 					(size 1 1)
@@ -1892,7 +1172,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "7c5245f1-40ad-423f-85f7-993d41285c85")
+			(uuid "980b6479-e6f1-4a7d-98e8-140dc779315d")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1903,7 +1183,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "9b482506-98b7-4132-b455-4835e59c590e")
+			(uuid "4784637f-7600-4906-a424-2a7bc584f29f")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1916,161 +1196,27 @@
 			(size 1 1.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "22592fe1-556c-499c-9bf0-65297634e7a7")
-			(net 2 "+5V")
+			(uuid "6319cd2c-e56c-4f04-b168-4511b9cafd89")
+			(net 3 "+3.3V")
 		)
 		(pad "2" smd roundrect
 			(at 1 0)
 			(size 1 1.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "c937d849-74fd-4837-b50c-cbe5be2e9795")
-			(net 4 "GND")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "Fuse:Fuse_1206_3216Metric"
-		(layer "F.Cu")
-		(uuid "81ad1693-ec23-42f6-a8a1-b25c97c52996")
-		(at 114 108)
-		(property "Reference" "F1"
-			(at 0 -1.5 0)
-			(layer "F.SilkS")
-			(uuid "7de1818f-6ba9-4cdd-a675-230533fd0053")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "15A"
-			(at 0 1.5 0)
-			(layer "F.Fab")
-			(uuid "4e524e3c-610b-472e-94cb-67c27552d8de")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "8eaa37b7-6ffc-4c59-81eb-f2a035930e1d")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "28fe666a-68aa-43b0-9205-fe2d029cc1d7")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" smd roundrect
-			(at -1.5 0)
-			(size 1.2 1.7)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "8ac40e2e-8a68-4e6a-b2bc-4694dc98720d")
-			(net 1 "VMOTOR")
-		)
-		(pad "2" smd roundrect
-			(at 1.5 0)
-			(size 1.2 1.7)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "0cf63052-7648-41d3-b271-a0acc0585c6b")
-			(net 1 "VMOTOR")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "Capacitor_SMD:C_0805_2012Metric"
-		(layer "F.Cu")
-		(uuid "874b69c1-b53d-4b16-99fc-1d4c83668d94")
-		(at 104 159)
-		(property "Reference" "C14"
-			(at 0 -1.5 0)
-			(layer "F.SilkS")
-			(uuid "3c7580fa-41c7-45fc-95b6-078e5dec2973")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "100nF"
-			(at 0 1.5 0)
-			(layer "F.Fab")
-			(uuid "1804bd3c-55dc-4b01-8d39-6a1423d45d47")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "589cbefc-9f2c-499b-ac14-f402c332737b")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "222d7b72-7a62-4091-905b-f924bde06ccd")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" smd roundrect
-			(at -1 0)
-			(size 1 1.3)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "aa52b0ff-2869-4f45-b398-82cef1891b37")
-			(net 1 "VMOTOR")
-		)
-		(pad "2" smd roundrect
-			(at 1 0)
-			(size 1 1.3)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "26499d79-3899-4183-b461-3a5eba672335")
-			(net 7 "PHASE_C")
+			(uuid "69957b2d-1b05-41b0-9d8f-4fda6fc9d474")
+			(net 29 "PWR_LED")
 		)
 		(embedded_fonts no)
 	)
 	(footprint "Package_QFP:LQFP-32_7x7mm_P0.8mm"
 		(layer "F.Cu")
-		(uuid "8c0fc7ec-e855-4497-b29d-0984432fc63f")
+		(uuid "527237e1-9a6e-4a20-b526-3df833bc5da2")
 		(at 140 150)
 		(property "Reference" "U10"
 			(at 0 -5 0)
 			(layer "F.SilkS")
-			(uuid "974b3d0f-7993-4982-8c77-700e9ddf34ab")
+			(uuid "43dc94f9-334b-4b49-9088-df783399f2f5")
 			(effects
 				(font
 					(size 1 1)
@@ -2081,7 +1227,7 @@
 		(property "Value" "STM32G431K8Tx"
 			(at 0 5 0)
 			(layer "F.Fab")
-			(uuid "e308474b-5e84-4e87-87a2-cbb9d762d6e5")
+			(uuid "40e1052c-f145-49f2-a220-f303a042a592")
 			(effects
 				(font
 					(size 1 1)
@@ -2093,7 +1239,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "7d26e3de-182c-4709-8ea4-a0e058d951e4")
+			(uuid "1c48883b-7c09-4b52-b4b2-6e96d3614663")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2104,7 +1250,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "31d2ccf8-f837-498d-a084-ae6f2495331e")
+			(uuid "50e13785-ef14-4522-bdcd-cd774a6913db")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2117,7 +1263,7 @@
 			(size 1.5 0.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "2d9f60ba-e03f-4f87-b94f-8cc55754f113")
+			(uuid "a5cbdc29-6060-4b20-b9d8-860fdcf5dafe")
 			(net 3 "+3.3V")
 		)
 		(pad "2" smd roundrect
@@ -2125,7 +1271,7 @@
 			(size 1.5 0.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "cda3da7b-cbc4-4b59-a2e3-bb04feaef111")
+			(uuid "846eb4ac-62ed-4b11-8cf7-da1d8fe1edcc")
 			(net 27 "OSC_IN")
 		)
 		(pad "3" smd roundrect
@@ -2133,7 +1279,7 @@
 			(size 1.5 0.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "082b0789-52b1-41a2-a664-140e5dc8ac01")
+			(uuid "220c8b98-84c3-456c-88fe-755c06dbec84")
 			(net 28 "OSC_OUT")
 		)
 		(pad "4" smd roundrect
@@ -2141,7 +1287,7 @@
 			(size 1.5 0.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "14923598-6edc-47dd-8052-aa978112e62b")
+			(uuid "ff613842-5b75-471c-a20e-390412d36dc5")
 			(net 26 "NRST")
 		)
 		(pad "5" smd roundrect
@@ -2149,7 +1295,7 @@
 			(size 1.5 0.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "2cafeb94-b99a-413d-9cb8-9a8cf6b9750f")
+			(uuid "fde822d2-fbca-469e-becd-8db976788953")
 			(net 15 "ISENSE_A-")
 		)
 		(pad "6" smd roundrect
@@ -2157,7 +1303,7 @@
 			(size 1.5 0.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "330634c3-a8f5-4f33-ac07-a746540fdc47")
+			(uuid "eab754c6-707f-42e4-be61-1bd71f8c433f")
 			(net 17 "ISENSE_B-")
 		)
 		(pad "7" smd roundrect
@@ -2165,7 +1311,7 @@
 			(size 1.5 0.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "34b081f8-02bd-43b8-9ea6-7da39a3a942f")
+			(uuid "a0c5a8a6-147c-435a-b7c3-f25dab7141af")
 			(net 19 "ISENSE_C-")
 		)
 		(pad "8" smd roundrect
@@ -2173,7 +1319,7 @@
 			(size 1.5 0.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "662faed2-8eae-4125-8f80-b71c0742999a")
+			(uuid "0fb52abe-48c9-4e24-8553-356f4a70bfa7")
 			(net 4 "GND")
 		)
 		(pad "9" smd roundrect
@@ -2181,7 +1327,7 @@
 			(size 0.5 1.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "fe8c478b-c3dc-46f9-af7a-b52ba64b9cc3")
+			(uuid "9802a3b8-84fd-442d-9909-7352c05acb98")
 			(net 4 "GND")
 		)
 		(pad "10" smd roundrect
@@ -2189,7 +1335,7 @@
 			(size 0.5 1.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "190bc7c8-2ac7-49ab-be72-1cfe9648d80e")
+			(uuid "e1755c06-44b4-4502-9740-f018aec18bf2")
 			(net 4 "GND")
 		)
 		(pad "11" smd roundrect
@@ -2197,7 +1343,7 @@
 			(size 0.5 1.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "95990370-6812-4b09-93a0-1ceb3637c5e5")
+			(uuid "6ca30066-6429-4c81-a5fa-386d53cd23b2")
 			(net 20 "HALL_A")
 		)
 		(pad "12" smd roundrect
@@ -2205,7 +1351,7 @@
 			(size 0.5 1.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "7f0683cf-3959-4d5b-8551-9c27c93b6a3b")
+			(uuid "1ed05005-e51d-4cf4-b3ae-81b8b65308ca")
 			(net 21 "HALL_B")
 		)
 		(pad "13" smd roundrect
@@ -2213,7 +1359,7 @@
 			(size 0.5 1.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "b8d428e6-59dc-4678-97da-b31d68484b8c")
+			(uuid "2d891aa5-af21-4a20-aa38-e3018942f2f2")
 			(net 22 "HALL_C")
 		)
 		(pad "14" smd roundrect
@@ -2221,7 +1367,7 @@
 			(size 0.5 1.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "7ff2c106-ecf3-41a9-be3e-6e2bf3ab827a")
+			(uuid "ce94ef5a-2eda-4f6e-b71f-7715e04f2324")
 			(net 4 "GND")
 		)
 		(pad "15" smd roundrect
@@ -2229,7 +1375,7 @@
 			(size 0.5 1.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "000a0641-3761-41c0-8679-0371a56fbb10")
+			(uuid "d75664ab-a41c-40f1-82b8-8358ea22957d")
 			(net 3 "+3.3V")
 		)
 		(pad "16" smd roundrect
@@ -2237,7 +1383,7 @@
 			(size 0.5 1.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "5fa0ef1b-5f6e-4873-93fc-4eb7a367aca6")
+			(uuid "30b9b746-5c19-4c3a-b6be-d027249ac0b5")
 			(net 4 "GND")
 		)
 		(pad "17" smd roundrect
@@ -2245,7 +1391,7 @@
 			(size 1.5 0.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "d889927d-f7db-4d04-abb2-a8106c0d4d8f")
+			(uuid "bb800469-1c92-44e2-bf3e-456ff6c4a02b")
 			(net 3 "+3.3V")
 		)
 		(pad "18" smd roundrect
@@ -2253,7 +1399,7 @@
 			(size 1.5 0.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "87f24b91-8150-4927-865e-32bb0e36641b")
+			(uuid "0b49f5b3-b457-419e-8f03-72d45430bcab")
 			(net 35 "PWM_AH")
 		)
 		(pad "19" smd roundrect
@@ -2261,7 +1407,7 @@
 			(size 1.5 0.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "4e9a5eb5-84a2-4316-9551-17bf2c927eb0")
+			(uuid "9a123d15-4bdb-4019-9c87-dab2633bf6d2")
 			(net 37 "PWM_BH")
 		)
 		(pad "20" smd roundrect
@@ -2269,7 +1415,7 @@
 			(size 1.5 0.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "d47ff205-dedc-4399-adbf-f343dc79a236")
+			(uuid "48f9c6fd-4eaa-4fc6-a384-8cacd4465eb2")
 			(net 39 "PWM_CH")
 		)
 		(pad "21" smd roundrect
@@ -2277,7 +1423,7 @@
 			(size 1.5 0.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "bece951a-8e48-477a-83c3-1f1cda5df383")
+			(uuid "665dfe6b-ce1d-42fd-8f64-dfe2a8719383")
 			(net 4 "GND")
 		)
 		(pad "22" smd roundrect
@@ -2285,7 +1431,7 @@
 			(size 1.5 0.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "ba2d5138-d4a3-4bdb-9b5f-0f550fe9db27")
+			(uuid "23e92707-a172-4bca-b5d9-cc5a22194daa")
 			(net 4 "GND")
 		)
 		(pad "23" smd roundrect
@@ -2293,7 +1439,7 @@
 			(size 1.5 0.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "c656b398-1a93-41f8-9406-1934258dfbeb")
+			(uuid "701bab3f-82a7-47d4-89cd-52770040821b")
 			(net 23 "SWDIO")
 		)
 		(pad "24" smd roundrect
@@ -2301,7 +1447,7 @@
 			(size 1.5 0.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "5c8cd1ca-d99e-4cc2-bfb6-57a422fa347e")
+			(uuid "eb5fcdf8-659a-4b92-9ab8-137eb54defe6")
 			(net 24 "SWCLK")
 		)
 		(pad "25" smd roundrect
@@ -2309,7 +1455,7 @@
 			(size 0.5 1.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "2647c052-48b5-45d2-abf5-f447927e4cab")
+			(uuid "b6cb49d9-42d5-46ee-90a7-f804865ae5db")
 			(net 4 "GND")
 		)
 		(pad "26" smd roundrect
@@ -2317,7 +1463,7 @@
 			(size 0.5 1.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "4ea8d186-c323-46b6-a91a-7d7e1bb65f83")
+			(uuid "627018cf-ee21-4158-b65d-7a970b43a374")
 			(net 25 "SWO")
 		)
 		(pad "27" smd roundrect
@@ -2325,7 +1471,7 @@
 			(size 0.5 1.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "72c6a73e-a176-40ab-9182-da4b6d5a3d47")
+			(uuid "5c49cf4a-0d37-431c-860a-372b0c42a4e3")
 			(net 4 "GND")
 		)
 		(pad "28" smd roundrect
@@ -2333,7 +1479,7 @@
 			(size 0.5 1.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "d8dd0e59-74e9-4f74-a759-1af178ad63d4")
+			(uuid "d9432fcd-57b8-4d6b-a5dd-e034a0085286")
 			(net 4 "GND")
 		)
 		(pad "29" smd roundrect
@@ -2341,7 +1487,7 @@
 			(size 0.5 1.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "88dc4245-665d-4d63-a3f7-02be8a130061")
+			(uuid "cde6efd2-b01d-4086-8f66-629bbbd66940")
 			(net 36 "PWM_AL")
 		)
 		(pad "30" smd roundrect
@@ -2349,7 +1495,7 @@
 			(size 0.5 1.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "443f8d65-822d-40f2-aa82-6250a22e44d2")
+			(uuid "bc824f2d-9b5e-408f-957f-d1a2a9ed7e97")
 			(net 38 "PWM_BL")
 		)
 		(pad "31" smd roundrect
@@ -2357,7 +1503,7 @@
 			(size 0.5 1.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "156bee79-248a-4a0c-b1cc-25b9761e43e1")
+			(uuid "b02d4d04-b386-4fcd-ae1d-f87057697c24")
 			(net 40 "PWM_CL")
 		)
 		(pad "32" smd roundrect
@@ -2365,19 +1511,19 @@
 			(size 0.5 1.5)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "12332042-bfe3-4e75-8bbd-ea3dd6a6ad79")
+			(uuid "6e5ee699-b0eb-40c9-934c-a8e64b0d19e6")
 			(net 4 "GND")
 		)
 		(embedded_fonts no)
 	)
 	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "91443c8b-1234-4971-8937-72f0c965307d")
-		(at 130 114)
-		(property "Reference" "C2"
+		(uuid "570ea3b0-0ef6-474e-9a63-d5c92a2dfa4c")
+		(at 160 143)
+		(property "Reference" "C11"
 			(at 0 -1.5 0)
 			(layer "F.SilkS")
-			(uuid "d74adee8-6eb1-480f-805e-7f07412ee2a4")
+			(uuid "6102bac9-467b-4806-bce9-51a10bbf01ed")
 			(effects
 				(font
 					(size 1 1)
@@ -2385,10 +1531,10 @@
 				)
 			)
 		)
-		(property "Value" "100nF"
+		(property "Value" "20pF"
 			(at 0 1.5 0)
 			(layer "F.Fab")
-			(uuid "8f92974d-3028-4e8c-9a8f-54050a59ccd9")
+			(uuid "b577524f-1a83-40a3-ab01-219736db57ee")
 			(effects
 				(font
 					(size 1 1)
@@ -2400,7 +1546,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "67022974-8aef-4e48-8bc3-2fde5f2b50c7")
+			(uuid "347207e5-29aa-4a6e-bb49-2485945ca490")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2411,7 +1557,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "46fb7178-bd67-4a90-97d4-a864e9836730")
+			(uuid "7682459e-feb3-4007-bebb-6097a9a16442")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2424,521 +1570,27 @@
 			(size 1 1.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "a6620f22-ffd2-4b2b-8680-e84eecedff18")
-			(net 1 "VMOTOR")
+			(uuid "e346b5a7-6471-4108-b832-fe0254196d51")
+			(net 28 "OSC_OUT")
 		)
 		(pad "2" smd roundrect
 			(at 1 0)
 			(size 1 1.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "678aae0a-b237-4a87-aba8-0268f66fc64d")
-			(net 4 "GND")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "Resistor_SMD:R_0805_2012Metric"
-		(layer "F.Cu")
-		(uuid "932e01aa-838e-44a2-b891-79bf580bb404")
-		(at 149 157)
-		(property "Reference" "R30"
-			(at 0 -1.5 0)
-			(layer "F.SilkS")
-			(uuid "cccf9491-d1fb-42a9-ad46-8600003b88b5")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "10k"
-			(at 0 1.5 0)
-			(layer "F.Fab")
-			(uuid "f0f65fde-9dbe-4d5b-bdcb-b744f11aee4c")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "ed502ca1-c5e7-422f-8f8d-039dd4ad0ad7")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "14aaeaec-38b2-49ff-884c-4e7d33a796a0")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" smd roundrect
-			(at -1 0)
-			(size 1 1.3)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "a873b614-1d04-4cfb-a1fa-a62694d9875f")
-			(net 3 "+3.3V")
-		)
-		(pad "2" smd roundrect
-			(at 1 0)
-			(size 1 1.3)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "5d4da248-0f9a-4c50-864d-d5ed44ffabd0")
-			(net 20 "HALL_A")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "Package_TO_SOT_THT:TO-220-3_Vertical"
-		(layer "F.Cu")
-		(uuid "9e6710f1-d8d5-4fd9-bf48-974b8068433a")
-		(at 124 176)
-		(property "Reference" "Q4"
-			(at 0 -5 0)
-			(layer "F.SilkS")
-			(uuid "34b8c602-e5d6-4aa2-b1a3-e89bcb54feb2")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "IRLZ44N"
-			(at 0 5 0)
-			(layer "F.Fab")
-			(uuid "0e32d3b1-0ff9-4911-8e50-8b16201a2867")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "068f11f7-5a2d-4cac-bc37-5ca0092ed10b")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "e782979c-e763-4e41-bf72-9325d3240117")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" thru_hole rect
-			(at -2.54 0)
-			(size 1.8 1.8)
-			(drill 1)
-			(layers "*.Cu" "*.Mask")
-			(remove_unused_layers no)
-			(uuid "2e6d846f-6005-4bfc-a21e-be2aa01c6776")
-			(net 11 "GATE_BL")
-		)
-		(pad "2" thru_hole oval
-			(at 0 0)
-			(size 1.8 1.8)
-			(drill 1)
-			(layers "*.Cu" "*.Mask")
-			(remove_unused_layers no)
-			(uuid "210206fd-a099-4b88-b4c1-083fc9301405")
-			(net 6 "PHASE_B")
-		)
-		(pad "3" thru_hole oval
-			(at 2.54 0)
-			(size 1.8 1.8)
-			(drill 1)
-			(layers "*.Cu" "*.Mask")
-			(remove_unused_layers no)
-			(uuid "767dc9ef-ea43-4c9e-9dcb-d03e7a852258")
-			(net 16 "ISENSE_B+")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "Package_TO_SOT_THT:TO-220-3_Vertical"
-		(layer "F.Cu")
-		(uuid "a414b6b5-7e69-42a5-8f94-d13304efebb9")
-		(at 108 176)
-		(property "Reference" "Q2"
-			(at 0 -5 0)
-			(layer "F.SilkS")
-			(uuid "b9c84aa2-cc0d-49d5-89d2-0ae3a13c40ed")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "IRLZ44N"
-			(at 0 5 0)
-			(layer "F.Fab")
-			(uuid "9d344565-18eb-4453-a8c3-cdef5801e60e")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "49f72a6f-5770-4851-988d-1c5dd7fe39c1")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "859fd201-866f-4edd-8465-7860467c4d33")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" thru_hole rect
-			(at -2.54 0)
-			(size 1.8 1.8)
-			(drill 1)
-			(layers "*.Cu" "*.Mask")
-			(remove_unused_layers no)
-			(uuid "34bc9d52-1ea9-4ba2-9d7e-6644cba037b5")
-			(net 9 "GATE_AL")
-		)
-		(pad "2" thru_hole oval
-			(at 0 0)
-			(size 1.8 1.8)
-			(drill 1)
-			(layers "*.Cu" "*.Mask")
-			(remove_unused_layers no)
-			(uuid "0ca81a8d-1d18-43a2-89ea-a5a333378fcc")
-			(net 5 "PHASE_A")
-		)
-		(pad "3" thru_hole oval
-			(at 2.54 0)
-			(size 1.8 1.8)
-			(drill 1)
-			(layers "*.Cu" "*.Mask")
-			(remove_unused_layers no)
-			(uuid "b8ac0e3f-bb61-4ca9-b988-61fb86a49b6f")
-			(net 14 "ISENSE_A+")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "MountingHole:MountingHole_3.2mm_M3"
-		(layer "F.Cu")
-		(uuid "a440d02f-d12e-4e44-88df-a916a2090788")
-		(at 103 103)
-		(property "Reference" "MH1"
-			(at 0 -3 0)
-			(layer "F.SilkS")
-			(uuid "8181c4bf-5a1b-4772-9ddf-8d57215f8581")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "MountingHole"
-			(at 0 3 0)
-			(layer "F.Fab")
-			(uuid "ba497499-4d92-41be-b5a9-7a4db7700383")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "38e416b4-f107-4163-81bf-f323934e67ff")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "8f4ef10d-326d-4cfc-ac73-ca2db36b5a66")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(attr exclude_from_pos_files exclude_from_bom)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "" np_thru_hole circle
-			(at 0 0)
-			(size 3.2 3.2)
-			(drill 3.2)
-			(layers "*.Cu" "*.Mask")
-			(uuid "b089399a-eb14-42b4-ba3b-f93dc7b4cfcd")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "Capacitor_SMD:C_0805_2012Metric"
-		(layer "F.Cu")
-		(uuid "a4c45388-9d66-4d1d-976a-c00750e10031")
-		(at 161 161)
-		(property "Reference" "C32"
-			(at 0 -1.5 0)
-			(layer "F.SilkS")
-			(uuid "735605c6-f0d4-40e5-8916-e4a4ce698129")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "10nF"
-			(at 0 1.5 0)
-			(layer "F.Fab")
-			(uuid "2e2cf815-7269-4a8e-898f-c1d4fab4a81c")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "bfadac34-83e1-4303-8ec6-5febde53e216")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "aa6528c9-f90e-41e8-8ed1-b15b76e8292b")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" smd roundrect
-			(at -1 0)
-			(size 1 1.3)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "6945be27-fda3-434a-adff-0b6691c564ba")
-			(net 22 "HALL_C")
-		)
-		(pad "2" smd roundrect
-			(at 1 0)
-			(size 1 1.3)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "e75c890d-c6ed-4a05-b82b-28c42318b578")
-			(net 4 "GND")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "Package_TO_SOT_THT:TO-220-3_Vertical"
-		(layer "F.Cu")
-		(uuid "a547ca64-5cb2-4688-ae83-863ee7b8aeee")
-		(at 140 176)
-		(property "Reference" "Q6"
-			(at 0 -5 0)
-			(layer "F.SilkS")
-			(uuid "efc11bd0-3816-45e0-ac8e-01cd99a3a7d9")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "IRLZ44N"
-			(at 0 5 0)
-			(layer "F.Fab")
-			(uuid "591337f2-e01a-44c1-93bd-2a9ee81efd7e")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "6f572ae8-3e25-46c6-acc8-013ae31dc5f8")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "afe360c0-58d1-4063-8e2a-b327ec44b00f")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" thru_hole rect
-			(at -2.54 0)
-			(size 1.8 1.8)
-			(drill 1)
-			(layers "*.Cu" "*.Mask")
-			(remove_unused_layers no)
-			(uuid "1f177acb-9759-463c-aed6-2395c8cd3608")
-			(net 13 "GATE_CL")
-		)
-		(pad "2" thru_hole oval
-			(at 0 0)
-			(size 1.8 1.8)
-			(drill 1)
-			(layers "*.Cu" "*.Mask")
-			(remove_unused_layers no)
-			(uuid "05856c8c-baeb-47fb-92c6-a55c1e9d4f4b")
-			(net 7 "PHASE_C")
-		)
-		(pad "3" thru_hole oval
-			(at 2.54 0)
-			(size 1.8 1.8)
-			(drill 1)
-			(layers "*.Cu" "*.Mask")
-			(remove_unused_layers no)
-			(uuid "ce77f25b-da4f-4f8e-9eea-cc9b947c5ff5")
-			(net 18 "ISENSE_C+")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "Capacitor_SMD:C_0805_2012Metric"
-		(layer "F.Cu")
-		(uuid "a8ca578b-1866-49a5-8165-faf7473e9b9a")
-		(at 134 137)
-		(property "Reference" "C7"
-			(at 0 -1.5 0)
-			(layer "F.SilkS")
-			(uuid "98d5cd95-92ea-4387-842b-837171ce5f0b")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "100nF"
-			(at 0 1.5 0)
-			(layer "F.Fab")
-			(uuid "a3fc3102-f4dc-4ccf-a6ea-8b13934ef54e")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "fc821535-5afe-4320-a181-3d883f36a287")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "39244686-5076-4e90-90e2-9e3d0fc0b1a8")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" smd roundrect
-			(at -1 0)
-			(size 1 1.3)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "5a250fb5-6eab-4314-9391-657cc8de657e")
-			(net 3 "+3.3V")
-		)
-		(pad "2" smd roundrect
-			(at 1 0)
-			(size 1 1.3)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "6d7bec52-277d-4d8a-88c8-25e854dfb88f")
+			(uuid "a80452b6-e58e-49f6-ba4c-b99233cc0db0")
 			(net 4 "GND")
 		)
 		(embedded_fonts no)
 	)
 	(footprint "Resistor_SMD:R_2512_6332Metric"
 		(layer "F.Cu")
-		(uuid "ac036ed7-d7ed-4007-9774-3eda473e77fb")
-		(at 140 184)
-		(property "Reference" "R12"
+		(uuid "622348a9-84ff-4615-b8cb-86479c7c5147")
+		(at 108 184)
+		(property "Reference" "R10"
 			(at 0 -2 0)
 			(layer "F.SilkS")
-			(uuid "27288011-7223-49df-980a-eca1f5225888")
+			(uuid "782a8122-29af-4dac-9e9f-1bd5cbbd2172")
 			(effects
 				(font
 					(size 1 1)
@@ -2949,7 +1601,7 @@
 		(property "Value" "5mR"
 			(at 0 2 0)
 			(layer "F.Fab")
-			(uuid "c8e6004f-4bde-4e03-becb-b183862f0157")
+			(uuid "a1560938-261c-4a51-90ab-87aa6ac2f0c7")
 			(effects
 				(font
 					(size 1 1)
@@ -2961,7 +1613,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "81d4a0d0-238b-447c-9227-57135c85b4b4")
+			(uuid "b034dd27-c62d-43ab-9b06-a13573aa3db9")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2972,7 +1624,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "42791480-2ddd-4f7a-afc8-e0016d98d3b5")
+			(uuid "d5d55b3e-e471-4a1b-b621-8d204f4bc475")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2985,172 +1637,27 @@
 			(size 1.6 2.7)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "bcdd5488-e911-49b7-ad52-6b6d8e43660a")
-			(net 18 "ISENSE_C+")
+			(uuid "fa21fe3e-9926-4351-ac49-17db05a9d559")
+			(net 14 "ISENSE_A+")
 		)
 		(pad "2" smd roundrect
 			(at 3.1 0)
 			(size 1.6 2.7)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "854d6076-5f87-44c6-85d7-f33a7f665ad3")
-			(net 19 "ISENSE_C-")
+			(uuid "a1b51bef-aba6-451f-a411-7c9a77a8bc2a")
+			(net 15 "ISENSE_A-")
 		)
 		(embedded_fonts no)
 	)
-	(footprint "Package_TO_SOT_SMD:TO-263-5_TabPin3"
+	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "ac09e915-c0a8-4188-b1ea-e631c77ae2f3")
-		(at 112 122)
-		(property "Reference" "U1"
-			(at 0 -5 0)
-			(layer "F.SilkS")
-			(uuid "95f68b4b-2de2-4f9c-92f5-21611862940b")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "LM2596-5.0"
-			(at 0 5 0)
-			(layer "F.Fab")
-			(uuid "910a9ec1-5ac3-47a2-9b16-c8dcb038ba8b")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "34413ce5-137f-4fbf-bb17-98d74176a862")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "3c57b15c-4128-4178-a3ea-19dc9ca042f4")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" smd rect
-			(at -3.4 3.3)
-			(size 3 1.5)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(uuid "304f9b0d-748d-4a3d-b302-3f2f4a3b2e34")
-			(net 1 "VMOTOR")
-		)
-		(pad "2" smd rect
-			(at -3.4 1.1)
-			(size 3 1.5)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(uuid "b5efe8ff-5fd8-496b-9168-67e8a136e57a")
-			(net 2 "+5V")
-		)
-		(pad "3" smd rect
-			(at -3.4 -1.1)
-			(size 3 1.5)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(uuid "5cbe58cf-fd88-486f-96fa-c6a904140d12")
-			(net 31 "SW_OUT")
-		)
-		(pad "4" smd rect
-			(at -3.4 -3.3)
-			(size 3 1.5)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(uuid "b9ced78f-aad0-4dd4-bbdf-8555ca0d88f7")
-			(net 4 "GND")
-		)
-		(pad "5" smd rect
-			(at 3.4 0)
-			(size 3 8)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(uuid "97593bf3-6d61-4b62-a8af-b922a74dbcc4")
-			(net 4 "GND")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "MountingHole:MountingHole_3.2mm_M3"
-		(layer "F.Cu")
-		(uuid "ad4650dd-846e-47e9-a26d-33537cc3d880")
-		(at 167 103)
-		(property "Reference" "MH2"
-			(at 0 -3 0)
-			(layer "F.SilkS")
-			(uuid "fde13119-ccf1-494c-8f67-d834022913f6")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "MountingHole"
-			(at 0 3 0)
-			(layer "F.Fab")
-			(uuid "03b73468-74a6-4906-acb1-8c9112745e1f")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "d8b53580-8212-4209-9b13-75c78485b2c7")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "24d3b99b-54ea-4b61-aa4f-54cb5df44674")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(attr exclude_from_pos_files exclude_from_bom)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "" np_thru_hole circle
-			(at 0 0)
-			(size 3.2 3.2)
-			(drill 3.2)
-			(layers "*.Cu" "*.Mask")
-			(uuid "6d7bf238-9e5c-4c1d-8254-4dbf5f17ea1b")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "Resistor_SMD:R_0805_2012Metric"
-		(layer "F.Cu")
-		(uuid "b69143a4-7c4d-41de-9a92-7b34dc47fbca")
-		(at 108 162)
-		(property "Reference" "R20"
+		(uuid "66d610b5-5557-4b83-a0ed-414c437437fa")
+		(at 161 161)
+		(property "Reference" "C32"
 			(at 0 -1.5 0)
 			(layer "F.SilkS")
-			(uuid "4c5a1679-ea4e-4c78-b2ec-73c29d070549")
+			(uuid "c43d4711-9bed-4476-91bf-575929855ad6")
 			(effects
 				(font
 					(size 1 1)
@@ -3158,10 +1665,10 @@
 				)
 			)
 		)
-		(property "Value" "22"
+		(property "Value" "10nF"
 			(at 0 1.5 0)
 			(layer "F.Fab")
-			(uuid "c22ce486-8e9e-4f4c-a914-759cffb23539")
+			(uuid "24695503-0e60-43dd-a9a5-02f8c74afaba")
 			(effects
 				(font
 					(size 1 1)
@@ -3173,7 +1680,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "96145528-16f9-4def-b25b-a41b42319536")
+			(uuid "31a2d0d2-3ac4-437d-8fb3-c7ba68826ea9")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3184,7 +1691,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "19b57e02-9ca6-4c1f-ad84-43ab75eac439")
+			(uuid "99a6e053-f4e2-4a72-ad30-3ee7d1d3addb")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3197,27 +1704,27 @@
 			(size 1 1.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "e1f02986-c312-4d08-9331-142486513d3f")
-			(net 32 "GATE_DRV_AH")
+			(uuid "94da1fd6-3a55-480e-bb30-f7678c68b978")
+			(net 22 "HALL_C")
 		)
 		(pad "2" smd roundrect
 			(at 1 0)
 			(size 1 1.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "c6a4759b-f66f-44bf-908b-a1f5bb3fd42c")
-			(net 8 "GATE_AH")
+			(uuid "7f8f14e8-55f0-4f84-9f56-97b9134c9d7a")
+			(net 4 "GND")
 		)
 		(embedded_fonts no)
 	)
-	(footprint "MountingHole:MountingHole_3.2mm_M3"
+	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "b810d9dc-c247-4798-9ceb-c4ad2e4c4bb5")
-		(at 103 187)
-		(property "Reference" "MH3"
-			(at 0 -3 0)
+		(uuid "68293477-6ef9-485b-bb26-a114fd3f1678")
+		(at 130 130)
+		(property "Reference" "C4"
+			(at 0 -1.5 0)
 			(layer "F.SilkS")
-			(uuid "6b13ae51-0b33-41fd-9159-b9b9a3404742")
+			(uuid "6b3f0085-ef2f-4b3a-858a-69bbcd5476a2")
 			(effects
 				(font
 					(size 1 1)
@@ -3225,10 +1732,10 @@
 				)
 			)
 		)
-		(property "Value" "MountingHole"
-			(at 0 3 0)
+		(property "Value" "220uF"
+			(at 0 1.5 0)
 			(layer "F.Fab")
-			(uuid "43ed4182-8f79-41de-9a56-1551e65bd3aa")
+			(uuid "144a4863-664d-4624-8914-c095c5fe2bb3")
 			(effects
 				(font
 					(size 1 1)
@@ -3240,7 +1747,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "0a9f7acc-e74c-4664-8a71-dfea5862234a")
+			(uuid "0d45a2a9-cac6-4188-a5bc-4d912be08686")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3251,7 +1758,74 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "9b981e6f-fcf9-491f-b5e2-a538077c89c2")
+			(uuid "6d99a706-36d1-4dda-8a29-68830c3f90e1")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" smd roundrect
+			(at -1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "337c317c-44f0-4fbd-be9e-1fd61c3765e6")
+			(net 2 "+5V")
+		)
+		(pad "2" smd roundrect
+			(at 1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "8e428143-bb80-4050-a2ec-18dbcf35aa0a")
+			(net 4 "GND")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "MountingHole:MountingHole_3.2mm_M3"
+		(layer "F.Cu")
+		(uuid "6da168a4-9feb-4401-a9dd-0b2e81492f36")
+		(at 103 187)
+		(property "Reference" "MH3"
+			(at 0 -3 0)
+			(layer "F.SilkS")
+			(uuid "5a7acd49-2b25-4ced-9a2c-3382c4d0479c")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "MountingHole"
+			(at 0 3 0)
+			(layer "F.Fab")
+			(uuid "178ee0b5-330c-4b5e-8ad4-2c9628fc2dee")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d3497f52-68ec-4ff1-a7d3-6a48ef3db967")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9897956f-dcf5-4bbd-aeec-26a6ad2bd3d3")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3265,18 +1839,18 @@
 			(size 3.2 3.2)
 			(drill 3.2)
 			(layers "*.Cu" "*.Mask")
-			(uuid "e0abfefd-2e80-4e43-bebe-622908ba1e9a")
+			(uuid "bf75e8b0-0380-42c1-8daf-dd46f4e0eb98")
 		)
 		(embedded_fonts no)
 	)
-	(footprint "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical"
+	(footprint "Resistor_SMD:R_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "bdca1f42-b357-4294-bce3-e61505b280e5")
-		(at 105 108)
-		(property "Reference" "J1"
-			(at 0 -3.5 0)
+		(uuid "70dc559d-e2d4-413e-a766-06e85c6b7dae")
+		(at 149 157)
+		(property "Reference" "R30"
+			(at 0 -1.5 0)
 			(layer "F.SilkS")
-			(uuid "482bb9a5-d157-4c66-8956-5d3fac6b39db")
+			(uuid "a8fd364a-b338-42e9-94ee-1940d66bb986")
 			(effects
 				(font
 					(size 1 1)
@@ -3284,10 +1858,10 @@
 				)
 			)
 		)
-		(property "Value" "Power Input"
-			(at 0 3.5 0)
+		(property "Value" "10k"
+			(at 0 1.5 0)
 			(layer "F.Fab")
-			(uuid "b6fa069f-59b1-4213-b098-d7ea36841a77")
+			(uuid "bf6c8a19-ea5a-42b0-b032-ffc3163664b0")
 			(effects
 				(font
 					(size 1 1)
@@ -3299,7 +1873,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "15059337-bdf1-4ea1-9532-3ba408b0e277")
+			(uuid "ebce47cd-0738-4fc5-a7db-f0dda4d99940")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3310,7 +1884,353 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "90ca4510-e0b1-4cab-a050-c2682d1fbb76")
+			(uuid "03ef08ec-3ad0-46fb-ac4b-04cdf46e5ef9")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" smd roundrect
+			(at -1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "c1fa3108-cfe1-4168-973c-ceb2e9e0e097")
+			(net 3 "+3.3V")
+		)
+		(pad "2" smd roundrect
+			(at 1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "0e0a2a77-3ed0-4fd4-9888-bb66b0aa5c20")
+			(net 20 "HALL_A")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Resistor_SMD:R_0805_2012Metric"
+		(layer "F.Cu")
+		(uuid "72a81ac9-314f-4bda-a18f-37903a6f3524")
+		(at 162 113)
+		(property "Reference" "R4"
+			(at 0 -1.5 0)
+			(layer "F.SilkS")
+			(uuid "5c636986-1572-41d7-bbeb-d7ec0058de4e")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "1k"
+			(at 0 1.5 0)
+			(layer "F.Fab")
+			(uuid "5b4c4561-6346-43c9-8816-527992b8fb89")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d45e1258-fb22-4f4c-8490-c9457cb4f590")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "e45bacd8-c4bd-41d9-b825-37773802533d")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" smd roundrect
+			(at -1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "91e56768-a56d-4d42-a304-e4b3df68d57f")
+			(net 3 "+3.3V")
+		)
+		(pad "2" smd roundrect
+			(at 1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "6b05f165-83c3-42cd-a2ca-5065a0e85af3")
+			(net 30 "STATUS_LED")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Connector_PinHeader_2.54mm:PinHeader_1x03_P2.54mm_Vertical"
+		(layer "F.Cu")
+		(uuid "7309cd15-e4af-4e79-9f59-3d1412eb1ab1")
+		(at 165 176)
+		(property "Reference" "J2"
+			(at 0 -4.8 0)
+			(layer "F.SilkS")
+			(uuid "74f98a89-a85d-4785-ba3f-6b9804980de8")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "Motor Output"
+			(at 0 4.8 0)
+			(layer "F.Fab")
+			(uuid "84a187d7-8c34-458e-ac23-b0fe5b43259f")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "bbe0b181-05a1-4d40-8bdb-6d3832ab0593")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "61cbea5c-9b4f-44e4-aaa9-df1c124f81ce")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" thru_hole rect
+			(at 0 -2.54)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "a2f1a43a-1f09-4466-8f85-d2efae53e4e5")
+			(net 5 "PHASE_A")
+		)
+		(pad "2" thru_hole oval
+			(at 0 0)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "ce88da54-a489-4dbc-b1b8-2c7f2e4e96da")
+			(net 6 "PHASE_B")
+		)
+		(pad "3" thru_hole oval
+			(at 0 2.54)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "139c72d6-18f1-4e31-abf2-a61ef85640f7")
+			(net 7 "PHASE_C")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Capacitor_SMD:C_0805_2012Metric"
+		(layer "F.Cu")
+		(uuid "777e2e57-3fcf-4449-ae9d-6eca7008c207")
+		(at 138 130)
+		(property "Reference" "C5"
+			(at 0 -1.5 0)
+			(layer "F.SilkS")
+			(uuid "1dd5e74f-b7d8-488e-abac-459382b81b97")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "10uF"
+			(at 0 1.5 0)
+			(layer "F.Fab")
+			(uuid "4156f1f2-f73b-4e4e-ac32-85bb0406dd81")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "cc732bb5-1c10-4770-ada7-5969030138a2")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b60e3cb7-e32f-4b79-b0a8-d251c394f1a2")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" smd roundrect
+			(at -1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "8db57c57-012f-4509-8360-01521c0454aa")
+			(net 2 "+5V")
+		)
+		(pad "2" smd roundrect
+			(at 1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "e3717ee4-e401-4b69-a15e-b77d64fb16d3")
+			(net 4 "GND")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Resistor_SMD:R_0805_2012Metric"
+		(layer "F.Cu")
+		(uuid "7853ed47-2e33-430b-84f6-cd838dee467a")
+		(at 161 157)
+		(property "Reference" "R32"
+			(at 0 -1.5 0)
+			(layer "F.SilkS")
+			(uuid "49b534ac-3406-4ce2-a5ff-e1f7a978bc70")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 0 1.5 0)
+			(layer "F.Fab")
+			(uuid "f2d2063d-bab2-4659-a3fc-cdd216ea3346")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "69908da8-1d2e-42ef-a078-c5a70b51fec9")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d04a6af1-27d4-493a-89d5-5853bf52f153")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" smd roundrect
+			(at -1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "979ed74a-da39-48dc-aa8f-0c6230cff9a9")
+			(net 3 "+3.3V")
+		)
+		(pad "2" smd roundrect
+			(at 1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "845391fe-e414-4f92-be39-481e50a9dc61")
+			(net 22 "HALL_C")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical"
+		(layer "F.Cu")
+		(uuid "785c334d-6c61-40fa-898e-8ec688f04058")
+		(at 105 108)
+		(property "Reference" "J1"
+			(at 0 -3.5 0)
+			(layer "F.SilkS")
+			(uuid "5321d975-b118-4202-a6c2-d55acca1e1ed")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "Power Input"
+			(at 0 3.5 0)
+			(layer "F.Fab")
+			(uuid "3cf89430-f767-4e6f-8727-23eb6ae79023")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "e5c0a276-05ad-43fc-8a59-2b90584cd8f6")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7be982ba-f703-48a7-978e-6073abbbee1b")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3324,7 +2244,7 @@
 			(drill 1)
 			(layers "*.Cu" "*.Mask")
 			(remove_unused_layers no)
-			(uuid "e4dc8db7-c5f9-40b4-85e2-a5d34636b4d3")
+			(uuid "eed020b5-20a3-43f1-9e39-b19a0b62e99b")
 			(net 1 "VMOTOR")
 		)
 		(pad "2" thru_hole oval
@@ -3333,387 +2253,19 @@
 			(drill 1)
 			(layers "*.Cu" "*.Mask")
 			(remove_unused_layers no)
-			(uuid "85840fcb-a34c-4470-b24b-e7007a626e74")
+			(uuid "287f9723-f886-413e-a847-11e138fa1701")
 			(net 4 "GND")
 		)
 		(embedded_fonts no)
 	)
-	(footprint "Connector_PinHeader_2.54mm:PinHeader_1x03_P2.54mm_Vertical"
-		(layer "F.Cu")
-		(uuid "c25f2325-5eaa-4ba5-b93a-8736c570235e")
-		(at 165 176)
-		(property "Reference" "J2"
-			(at 0 -4.8 0)
-			(layer "F.SilkS")
-			(uuid "58c5beab-2dca-48fe-b899-c3dc19dcbbdb")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "Motor Output"
-			(at 0 4.8 0)
-			(layer "F.Fab")
-			(uuid "131f7a36-a119-465c-b01a-6d3f5c9fcb4e")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "43f250d0-b84a-4d50-a3df-20c9954c1387")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "b937fe98-7bdd-4a45-8078-8bbe9a681d7b")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" thru_hole rect
-			(at 0 -2.54)
-			(size 1.7 1.7)
-			(drill 1)
-			(layers "*.Cu" "*.Mask")
-			(remove_unused_layers no)
-			(uuid "e14cdffd-d6af-45b6-a295-3bebb2a51a93")
-			(net 5 "PHASE_A")
-		)
-		(pad "2" thru_hole oval
-			(at 0 0)
-			(size 1.7 1.7)
-			(drill 1)
-			(layers "*.Cu" "*.Mask")
-			(remove_unused_layers no)
-			(uuid "e617cdf4-09b0-4014-a3fb-1caacfadcdd2")
-			(net 6 "PHASE_B")
-		)
-		(pad "3" thru_hole oval
-			(at 0 2.54)
-			(size 1.7 1.7)
-			(drill 1)
-			(layers "*.Cu" "*.Mask")
-			(remove_unused_layers no)
-			(uuid "e393de7e-3d55-4bc5-99cd-d9ccaf496903")
-			(net 7 "PHASE_C")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "Package_TO_SOT_THT:TO-220-3_Vertical"
-		(layer "F.Cu")
-		(uuid "ca8309e6-dfb2-4f08-909d-2ba6b51d8a4b")
-		(at 108 168)
-		(property "Reference" "Q1"
-			(at 0 -5 0)
-			(layer "F.SilkS")
-			(uuid "747f43ff-3c6c-4ba0-8a3e-5f6cdee35fd8")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "IRLZ44N"
-			(at 0 5 0)
-			(layer "F.Fab")
-			(uuid "530d542c-e3df-4e8f-a8e8-26d4a0327ddb")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "943c2496-8db5-4c82-915d-673cc9be6cc3")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "1fe0c770-6487-4350-a0fe-4154166ce2e9")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" thru_hole rect
-			(at -2.54 0)
-			(size 1.8 1.8)
-			(drill 1)
-			(layers "*.Cu" "*.Mask")
-			(remove_unused_layers no)
-			(uuid "ee1d6645-cd70-47b2-816e-6b5a1c3ab9e0")
-			(net 8 "GATE_AH")
-		)
-		(pad "2" thru_hole oval
-			(at 0 0)
-			(size 1.8 1.8)
-			(drill 1)
-			(layers "*.Cu" "*.Mask")
-			(remove_unused_layers no)
-			(uuid "de3d78ac-50e5-435f-bd74-18ad739620eb")
-			(net 1 "VMOTOR")
-		)
-		(pad "3" thru_hole oval
-			(at 2.54 0)
-			(size 1.8 1.8)
-			(drill 1)
-			(layers "*.Cu" "*.Mask")
-			(remove_unused_layers no)
-			(uuid "89c767b5-f263-4841-8a27-e8402d84f161")
-			(net 5 "PHASE_A")
-		)
-		(embedded_fonts no)
-	)
 	(footprint "Resistor_SMD:R_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "d0e58e6f-43be-4ea4-872e-1d8d5ff08c0b")
-		(at 162 113)
-		(property "Reference" "R4"
-			(at 0 -1.5 0)
-			(layer "F.SilkS")
-			(uuid "92a9eb10-8937-4fc2-aa4f-a19d019f83db")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "1k"
-			(at 0 1.5 0)
-			(layer "F.Fab")
-			(uuid "4dc3bbe3-a25d-4594-9b27-e1b76905b46d")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "d115fe32-da29-493c-9d09-ed7dba6f3c8e")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "f4ad3a71-bec2-41b0-a7ff-2f6ae8cffe85")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" smd roundrect
-			(at -1 0)
-			(size 1 1.3)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "e8169644-dde7-4554-adc5-694419594d3d")
-			(net 3 "+3.3V")
-		)
-		(pad "2" smd roundrect
-			(at 1 0)
-			(size 1 1.3)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "11626be8-71d2-4c55-82f1-7777ce26dfaa")
-			(net 30 "STATUS_LED")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "Inductor_SMD:L_1210_3225Metric"
-		(layer "F.Cu")
-		(uuid "db13a9ee-132c-46f5-815c-febce60fcb16")
-		(at 126 122)
-		(property "Reference" "L1"
-			(at 0 -2 0)
-			(layer "F.SilkS")
-			(uuid "6b53a690-f64d-4dd6-9f06-f04340a743ea")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "33uH"
-			(at 0 2 0)
-			(layer "F.Fab")
-			(uuid "76ec90b0-dff8-4f9f-9823-022c24a682a6")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "70ce6b5e-a724-4383-b9b6-d56158804b19")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "0b8311f2-9b4d-485e-9262-6b5367012ebd")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" smd roundrect
-			(at -1.5 0)
-			(size 1.2 2.5)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "08d935e9-bcc7-4c52-ac23-105a9fa982ac")
-			(net 31 "SW_OUT")
-		)
-		(pad "2" smd roundrect
-			(at 1.5 0)
-			(size 1.2 2.5)
-			(layers "F.Cu" "F.Mask" "F.Paste")
-			(roundrect_rratio 0.25)
-			(uuid "39e77458-bd5c-4941-aa70-86155c240c24")
-			(net 2 "+5V")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "Package_TO_SOT_THT:TO-220-3_Vertical"
-		(layer "F.Cu")
-		(uuid "dd636bc8-984f-4bf8-aca7-550224496a03")
-		(at 124 168)
-		(property "Reference" "Q3"
-			(at 0 -5 0)
-			(layer "F.SilkS")
-			(uuid "503470ad-46d7-48a6-be0a-b1c5ebedbcda")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Value" "IRLZ44N"
-			(at 0 5 0)
-			(layer "F.Fab")
-			(uuid "d26439ad-1bd9-4da7-bbd4-146540202cda")
-			(effects
-				(font
-					(size 1 1)
-					(thickness 0.15)
-				)
-			)
-		)
-		(property "Datasheet" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "ac0d5d43-0d73-48da-b448-ce25692fc49f")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Description" ""
-			(at 0 0 0)
-			(layer "F.Fab")
-			(hide yes)
-			(uuid "073f8fdb-486a-4845-b6b8-5bbe26ae7776")
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(duplicate_pad_numbers_are_jumpers no)
-		(pad "1" thru_hole rect
-			(at -2.54 0)
-			(size 1.8 1.8)
-			(drill 1)
-			(layers "*.Cu" "*.Mask")
-			(remove_unused_layers no)
-			(uuid "7ffa9d3f-0838-4022-a470-29dd3f15812d")
-			(net 10 "GATE_BH")
-		)
-		(pad "2" thru_hole oval
-			(at 0 0)
-			(size 1.8 1.8)
-			(drill 1)
-			(layers "*.Cu" "*.Mask")
-			(remove_unused_layers no)
-			(uuid "7f581bfe-6295-4a61-8e3f-00e2e591ea73")
-			(net 1 "VMOTOR")
-		)
-		(pad "3" thru_hole oval
-			(at 2.54 0)
-			(size 1.8 1.8)
-			(drill 1)
-			(layers "*.Cu" "*.Mask")
-			(remove_unused_layers no)
-			(uuid "8c96c3f9-5a10-4ac4-9e29-e3df0828e577")
-			(net 6 "PHASE_B")
-		)
-		(embedded_fonts no)
-	)
-	(footprint "Resistor_SMD:R_0805_2012Metric"
-		(layer "F.Cu")
-		(uuid "dfaba3f1-0576-432d-a26d-918e2d9ad3a4")
+		(uuid "7a0752ad-daff-4a89-80ff-c5e067264fda")
 		(at 155 157)
 		(property "Reference" "R31"
 			(at 0 -1.5 0)
 			(layer "F.SilkS")
-			(uuid "8e325429-78e8-453e-96af-3dc7ec0ea2ed")
+			(uuid "30239a60-b2b5-4f3c-8b0e-a1cd1874cb49")
 			(effects
 				(font
 					(size 1 1)
@@ -3724,7 +2276,7 @@
 		(property "Value" "10k"
 			(at 0 1.5 0)
 			(layer "F.Fab")
-			(uuid "3af1e54a-36da-4bbc-8736-e022946277b7")
+			(uuid "b4ee07da-0bec-440b-b5f4-504627ed62b4")
 			(effects
 				(font
 					(size 1 1)
@@ -3736,7 +2288,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "860c6130-5a30-44ee-8de0-6129ffa7419f")
+			(uuid "9c2ad1b5-effd-45a2-a19d-6cff764726ee")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3747,7 +2299,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "f6f7bd0a-9ae4-4313-9187-efe1a042579c")
+			(uuid "b990234b-cff9-42c2-aaf3-d418a4ae0a72")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3760,7 +2312,7 @@
 			(size 1 1.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "69a721e0-5c05-4fbf-858a-559407b1b168")
+			(uuid "2ce8098d-f72b-4134-9a80-cd529c009b83")
 			(net 3 "+3.3V")
 		)
 		(pad "2" smd roundrect
@@ -3768,19 +2320,19 @@
 			(size 1 1.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "b8860ec9-dff5-479a-8efc-12e80fbf855f")
+			(uuid "80e1e8e8-bfe5-47e6-ab27-7db0ee549055")
 			(net 21 "HALL_B")
 		)
 		(embedded_fonts no)
 	)
 	(footprint "Package_TO_SOT_THT:TO-220-3_Vertical"
 		(layer "F.Cu")
-		(uuid "dfeb52ff-17e3-427c-a109-f31fe1bbaf62")
-		(at 140 168)
-		(property "Reference" "Q5"
+		(uuid "7cd1ede2-a084-4c50-ba08-843ce47c5c9c")
+		(at 140 176)
+		(property "Reference" "Q6"
 			(at 0 -5 0)
 			(layer "F.SilkS")
-			(uuid "77a75323-44aa-46dd-8f3f-af80a83cb252")
+			(uuid "4041558e-e88b-4499-9606-3017ec71c7a2")
 			(effects
 				(font
 					(size 1 1)
@@ -3791,7 +2343,7 @@
 		(property "Value" "IRLZ44N"
 			(at 0 5 0)
 			(layer "F.Fab")
-			(uuid "b69163b1-2b52-495a-a726-52cef2e2a9ac")
+			(uuid "7ecf1de0-3ec6-4304-bd9e-1bce1dd6f64a")
 			(effects
 				(font
 					(size 1 1)
@@ -3803,7 +2355,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "39ccdb51-8f54-40c2-9be0-1ead2bed9327")
+			(uuid "e54b2728-1127-443a-aa18-16d89cec89b4")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3814,7 +2366,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "f7d17f92-3706-46d9-b8b4-84d499475e21")
+			(uuid "b714ec10-ad61-417c-90db-20f5ec357634")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3828,8 +2380,8 @@
 			(drill 1)
 			(layers "*.Cu" "*.Mask")
 			(remove_unused_layers no)
-			(uuid "321b8608-8e27-492a-a0ca-ba8fae2af5b0")
-			(net 12 "GATE_CH")
+			(uuid "2730c91a-7f63-4a70-aa63-0fba5e193324")
+			(net 13 "GATE_CL")
 		)
 		(pad "2" thru_hole oval
 			(at 0 0)
@@ -3837,8 +2389,8 @@
 			(drill 1)
 			(layers "*.Cu" "*.Mask")
 			(remove_unused_layers no)
-			(uuid "f5172e7c-eaa8-4718-840f-1a46dbd16ba2")
-			(net 1 "VMOTOR")
+			(uuid "42d2c94b-74f9-4c92-88c9-ccbefa12b50f")
+			(net 7 "PHASE_C")
 		)
 		(pad "3" thru_hole oval
 			(at 2.54 0)
@@ -3846,19 +2398,19 @@
 			(drill 1)
 			(layers "*.Cu" "*.Mask")
 			(remove_unused_layers no)
-			(uuid "f9d10564-95f7-4d07-a2cb-204dca6c8f3f")
-			(net 7 "PHASE_C")
+			(uuid "da78cfac-c377-4bc2-85a5-9678ac141da7")
+			(net 18 "ISENSE_C+")
 		)
 		(embedded_fonts no)
 	)
-	(footprint "Capacitor_SMD:C_0805_2012Metric"
+	(footprint "Resistor_SMD:R_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "e5caa138-6ecf-40fd-9fb7-bbddf08f666d")
-		(at 140 137)
-		(property "Reference" "C8"
+		(uuid "7d53fae7-0241-4ee2-ab0e-a498b26a0f0b")
+		(at 124 162)
+		(property "Reference" "R21"
 			(at 0 -1.5 0)
 			(layer "F.SilkS")
-			(uuid "379db366-6937-4020-9baf-7ff8da4fa4bd")
+			(uuid "1885344d-b26b-4f12-bf37-1c4c016348e7")
 			(effects
 				(font
 					(size 1 1)
@@ -3866,10 +2418,10 @@
 				)
 			)
 		)
-		(property "Value" "100nF"
+		(property "Value" "22"
 			(at 0 1.5 0)
 			(layer "F.Fab")
-			(uuid "ca133648-11ac-46e1-900d-10d3bd9dba3f")
+			(uuid "fba70875-8db1-4455-b70e-9eba31c9cdf3")
 			(effects
 				(font
 					(size 1 1)
@@ -3881,7 +2433,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "72d057df-2585-4a99-b209-fccd5fceb5c9")
+			(uuid "9eb97755-4033-4858-86ca-362320e741b9")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3892,7 +2444,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "4d2a7981-4473-4a3d-a3d0-47bd76f80418")
+			(uuid "a7ad867b-024a-4592-9578-4b36ae98b72d")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3905,27 +2457,27 @@
 			(size 1 1.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "18be4a5b-f6a2-4063-b3a7-5b9333d40d34")
-			(net 3 "+3.3V")
+			(uuid "5607569f-364f-4e08-b672-054bfca0baa4")
+			(net 33 "GATE_DRV_BH")
 		)
 		(pad "2" smd roundrect
 			(at 1 0)
 			(size 1 1.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "a473be1d-7d06-47f3-8cf9-24258650a633")
-			(net 4 "GND")
+			(uuid "fdf88089-bb39-4727-bff7-87e30b08f0d1")
+			(net 10 "GATE_BH")
 		)
 		(embedded_fonts no)
 	)
-	(footprint "Diode_SMD:D_SMA"
+	(footprint "Package_TO_SOT_THT:TO-220-3_Vertical"
 		(layer "F.Cu")
-		(uuid "e6e28862-e524-4056-9cde-86c0aa1779c8")
-		(at 122 108)
-		(property "Reference" "D1"
-			(at 0 -2 0)
+		(uuid "7de2da34-983e-4c0b-9089-d36b648f1b07")
+		(at 108 176)
+		(property "Reference" "Q2"
+			(at 0 -5 0)
 			(layer "F.SilkS")
-			(uuid "e63702a5-0e26-4853-8987-61449dd4b38a")
+			(uuid "a1d5c63d-58b3-4bb0-99f1-dc1b7def55e2")
 			(effects
 				(font
 					(size 1 1)
@@ -3933,10 +2485,10 @@
 				)
 			)
 		)
-		(property "Value" "SMBJ24A"
-			(at 0 2 0)
+		(property "Value" "IRLZ44N"
+			(at 0 5 0)
 			(layer "F.Fab")
-			(uuid "6c27fcd0-829a-487c-82ed-7704708dbdc3")
+			(uuid "0dcb06d9-1620-4ebc-8823-583c5e371d38")
 			(effects
 				(font
 					(size 1 1)
@@ -3948,7 +2500,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "bd2efc96-6076-4ec9-8908-3d14f5f475c9")
+			(uuid "60c5b391-ad4e-4165-a5f0-9216b4320c38")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3959,7 +2511,85 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "9ccd2ca2-495b-44f6-8f27-70d793d876a0")
+			(uuid "b2f78861-2275-46ef-b3d6-00aefae8842c")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" thru_hole rect
+			(at -2.54 0)
+			(size 1.8 1.8)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "73a90fe1-c6ae-429c-81f2-2aaa06ec6f44")
+			(net 9 "GATE_AL")
+		)
+		(pad "2" thru_hole oval
+			(at 0 0)
+			(size 1.8 1.8)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "6fc85dbc-5b01-4a7e-9800-fd2d23c5b3e1")
+			(net 5 "PHASE_A")
+		)
+		(pad "3" thru_hole oval
+			(at 2.54 0)
+			(size 1.8 1.8)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "54bea0d7-6b69-42f2-9dd1-1da779773a10")
+			(net 14 "ISENSE_A+")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "LED_SMD:LED_0805_2012Metric"
+		(layer "F.Cu")
+		(uuid "93994ed5-cbaa-409a-afc0-0e3f734251fe")
+		(at 156 108)
+		(property "Reference" "D3"
+			(at 0 -1.5 0)
+			(layer "F.SilkS")
+			(uuid "00e65167-54eb-4d75-9690-c4b59fa75c6e")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "LED"
+			(at 0 1.5 0)
+			(layer "F.Fab")
+			(uuid "d05ff1cf-92d3-4bb0-ac1a-c4ad3be284eb")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d9d943a5-199e-4034-9b9f-7ff0960ba38b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d0f10ef2-4e7a-4c07-a704-09fb96a47a43")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3968,31 +2598,31 @@
 		)
 		(duplicate_pad_numbers_are_jumpers no)
 		(pad "1" smd roundrect
-			(at -2 0)
-			(size 1.5 1.7)
+			(at -1.05 0)
+			(size 1 1.2)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "ca91cf52-01f0-4d3d-8bc7-d06435a8e0d2")
-			(net 4 "GND")
+			(uuid "4db36c47-c534-4f32-8368-2a3ed06e1672")
+			(net 29 "PWR_LED")
 		)
 		(pad "2" smd roundrect
-			(at 2 0)
-			(size 1.5 1.7)
+			(at 1.05 0)
+			(size 1 1.2)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "d3144c25-c85e-4ca0-9ec7-37aab3582028")
-			(net 1 "VMOTOR")
+			(uuid "63d71d32-b4a7-4f5b-ac3e-cad5a2855f07")
+			(net 4 "GND")
 		)
 		(embedded_fonts no)
 	)
 	(footprint "Package_SO:HTSSOP-56-1EP_6.1x14mm_P0.5mm_EP3.61x6.35mm"
 		(layer "F.Cu")
-		(uuid "edd7f8d9-9872-4d0d-8485-cacf87e16648")
+		(uuid "9d9cc03c-e0c9-4dcb-9cf5-91f4276be3ff")
 		(at 114 150)
 		(property "Reference" "U3"
 			(at 0 -8 0)
 			(layer "F.SilkS")
-			(uuid "db737865-d497-46b6-a30e-51139b6f3895")
+			(uuid "b109e319-2f88-416f-8c32-835687ee2b35")
 			(effects
 				(font
 					(size 1 1)
@@ -4003,7 +2633,7 @@
 		(property "Value" "DRV8301"
 			(at 0 8 0)
 			(layer "F.Fab")
-			(uuid "744aca7d-13cc-403c-865b-e7b93fd721c0")
+			(uuid "3b0dda6f-28c1-4b14-8d1f-d16710632363")
 			(effects
 				(font
 					(size 1 1)
@@ -4015,7 +2645,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "1fe9d1ed-e0ce-4e8b-a498-ee4ca75cb3f1")
+			(uuid "150e0ecd-a3c8-4ce0-977c-f21a8732efe1")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4026,7 +2656,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "940c042b-6a8f-4fa9-bdf6-14fe9416e9cc")
+			(uuid "2e618ce0-f6ea-4318-9ef5-5fc1924fdafd")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4039,7 +2669,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "02ff7098-358b-4ba8-be27-3f07fb0726f7")
+			(uuid "f53106e9-cb75-4c08-853d-61dd693225b1")
 			(net 4 "GND")
 		)
 		(pad "2" smd roundrect
@@ -4047,7 +2677,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "c2ac248b-51ef-488f-ac14-e0fe6fe25efb")
+			(uuid "1a376102-ff4e-4957-872c-4a4688847aab")
 			(net 4 "GND")
 		)
 		(pad "3" smd roundrect
@@ -4055,7 +2685,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "2ba0c324-ff08-417a-ac3c-9c37e4de712a")
+			(uuid "e0a40cb6-2945-4fb8-9a43-465ffc8819e1")
 			(net 2 "+5V")
 		)
 		(pad "4" smd roundrect
@@ -4063,7 +2693,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "2b24caf4-8162-4c69-b500-6c9dc55d0bfe")
+			(uuid "8907d9ee-8d66-48c6-be74-c1a02992d77a")
 			(net 3 "+3.3V")
 		)
 		(pad "5" smd roundrect
@@ -4071,7 +2701,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "386a3c44-74ba-47a3-8a55-37164c7138ea")
+			(uuid "78965acf-20d1-4fe1-81c2-eb51abdacc2c")
 			(net 3 "+3.3V")
 		)
 		(pad "6" smd roundrect
@@ -4079,7 +2709,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "64696a64-f45d-4609-817a-776e3f1e7a16")
+			(uuid "bd3f133b-fa3a-4e07-a3ac-310ad0a819fd")
 			(net 3 "+3.3V")
 		)
 		(pad "7" smd roundrect
@@ -4087,7 +2717,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "280eb2af-0177-4e11-b7eb-629d9f0ac990")
+			(uuid "71b50186-2f57-4fc8-8fb4-0fa70508c2fe")
 			(net 4 "GND")
 		)
 		(pad "8" smd roundrect
@@ -4095,7 +2725,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "297e9d09-ed96-4382-9a78-72fa7d340a7d")
+			(uuid "cf41947a-a567-424e-bb88-112614621ccf")
 			(net 3 "+3.3V")
 		)
 		(pad "9" smd roundrect
@@ -4103,7 +2733,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "d3884c3a-8d6b-43e5-bd9c-6659903335a6")
+			(uuid "27db8338-0670-4f69-8a67-9f47a8bbf251")
 			(net 3 "+3.3V")
 		)
 		(pad "10" smd roundrect
@@ -4111,7 +2741,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "dd9682e0-9244-4725-8295-7d6edac50847")
+			(uuid "20306330-d8b9-44a0-8e01-42e197a71c0b")
 			(net 3 "+3.3V")
 		)
 		(pad "11" smd roundrect
@@ -4119,7 +2749,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "3a2733a1-cb1c-41e8-8cf7-b919c9e14f57")
+			(uuid "78e4213c-27e4-42e5-b110-b1260cce713d")
 			(net 3 "+3.3V")
 		)
 		(pad "12" smd roundrect
@@ -4127,7 +2757,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "97974ca9-ed0e-4189-919f-36ee8d53707e")
+			(uuid "a6f9ea93-bb63-4eab-a4b1-335c4bd3734f")
 			(net 4 "GND")
 		)
 		(pad "13" smd roundrect
@@ -4135,7 +2765,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "eb5b01f1-aa4c-48dd-ac02-62cc6cc122ae")
+			(uuid "34ac7b85-73d4-4c80-9fab-32ef97733075")
 			(net 2 "+5V")
 		)
 		(pad "14" smd roundrect
@@ -4143,7 +2773,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "aa764b0e-a134-49a8-a4bd-9e16a2b3c36b")
+			(uuid "79ad047b-e061-4a65-9507-9ccd2cbc0372")
 			(net 2 "+5V")
 		)
 		(pad "15" smd roundrect
@@ -4151,7 +2781,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "6f415800-a07e-4423-ad76-557f047bad5e")
+			(uuid "d3e90358-4205-40e7-a37e-22be610a6ad4")
 			(net 2 "+5V")
 		)
 		(pad "16" smd roundrect
@@ -4159,7 +2789,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "d6b8e128-2049-4951-9d1d-12a3ef5b8c87")
+			(uuid "11fef9d8-7893-4735-9233-2391011f949d")
 			(net 3 "+3.3V")
 		)
 		(pad "17" smd roundrect
@@ -4167,7 +2797,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "b605d460-401e-42af-93e7-ac29d74d80f5")
+			(uuid "12e0e85c-444c-48d7-9eea-cbe4d33ac02a")
 			(net 35 "PWM_AH")
 		)
 		(pad "18" smd roundrect
@@ -4175,7 +2805,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "03c49110-78e2-47d8-a894-9096f18e9810")
+			(uuid "80b43557-c421-489d-b1b0-c8c1f47ea780")
 			(net 36 "PWM_AL")
 		)
 		(pad "19" smd roundrect
@@ -4183,7 +2813,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "ba1b8cf2-6d9d-4fcd-a2b6-018aa9b8ce4c")
+			(uuid "c40e9f9c-b94c-4206-88ca-546d4fe08423")
 			(net 37 "PWM_BH")
 		)
 		(pad "20" smd roundrect
@@ -4191,7 +2821,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "12cb90e2-96df-4ec5-92e6-82a260988a5a")
+			(uuid "e968f882-a9bd-4f1c-8c8a-e0eda80f411a")
 			(net 38 "PWM_BL")
 		)
 		(pad "21" smd roundrect
@@ -4199,7 +2829,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "d4f6ddf2-732a-4deb-9294-160a31a8f9bf")
+			(uuid "820c377c-fb74-4ee3-acc9-321215321002")
 			(net 39 "PWM_CH")
 		)
 		(pad "22" smd roundrect
@@ -4207,7 +2837,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "5cc89669-db90-4c29-9b0d-e77a8d4f1150")
+			(uuid "6bfa648a-0e41-4349-83b1-9ecae2ba4139")
 			(net 40 "PWM_CL")
 		)
 		(pad "23" smd roundrect
@@ -4215,7 +2845,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "d9611a81-13fc-4d00-9c85-458cd188e6d7")
+			(uuid "2eb734cc-41a0-4ee0-b48f-657000aad4da")
 			(net 3 "+3.3V")
 		)
 		(pad "24" smd roundrect
@@ -4223,7 +2853,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "be051368-e1c5-4f5e-b88d-dd4402570cec")
+			(uuid "95bafd04-64f9-4c39-96ab-6ec470f83ec7")
 			(net 3 "+3.3V")
 		)
 		(pad "25" smd roundrect
@@ -4231,7 +2861,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "8e12e621-eba0-4463-8771-d221f554bdbb")
+			(uuid "068c38f6-8c7e-4e11-baff-bf182d1b72f7")
 			(net 14 "ISENSE_A+")
 		)
 		(pad "26" smd roundrect
@@ -4239,7 +2869,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "f55471b3-0204-4751-9cac-5e7a19dec7c2")
+			(uuid "1fb8f42c-93aa-45f6-9da2-c79217a53c57")
 			(net 16 "ISENSE_B+")
 		)
 		(pad "27" smd roundrect
@@ -4247,7 +2877,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "42f0ac9e-a9c3-4593-9549-383e071f995d")
+			(uuid "720f1f5f-a427-4e04-a599-c9395abd0854")
 			(net 2 "+5V")
 		)
 		(pad "28" smd roundrect
@@ -4255,7 +2885,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "1bc550d5-d444-4740-9188-79bf5d2048c9")
+			(uuid "b1d85954-c86c-4856-8fb1-7f8f307cae44")
 			(net 4 "GND")
 		)
 		(pad "29" smd roundrect
@@ -4263,7 +2893,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "b9f5eb71-865b-4639-b74e-3f56e747f5dd")
+			(uuid "f58168e9-bbf8-4ac6-b259-6389433fdb90")
 			(net 1 "VMOTOR")
 		)
 		(pad "30" smd roundrect
@@ -4271,7 +2901,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "bdcc9a8a-2cfd-4c97-a11c-7d214fded7d9")
+			(uuid "e1003b26-a00b-4518-9601-4ab617dae032")
 			(net 16 "ISENSE_B+")
 		)
 		(pad "31" smd roundrect
@@ -4279,7 +2909,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "8c5588ca-9a54-491b-814c-0df9319f41c5")
+			(uuid "951cba8d-210d-464e-8443-ee3f518a02e7")
 			(net 17 "ISENSE_B-")
 		)
 		(pad "32" smd roundrect
@@ -4287,7 +2917,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "9e2839ca-ef08-4443-afac-ac5c3c8e0ed3")
+			(uuid "b9d23ce2-4598-449e-94b2-9a46f11e3c31")
 			(net 14 "ISENSE_A+")
 		)
 		(pad "33" smd roundrect
@@ -4295,7 +2925,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "1bad591a-b1c8-43ab-b82c-c0dcf87f8ff8")
+			(uuid "71565686-9c7c-40cd-a011-fdd26ce60118")
 			(net 15 "ISENSE_A-")
 		)
 		(pad "34" smd roundrect
@@ -4303,7 +2933,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "86404e5d-a950-4000-8de3-f99408dd5f2f")
+			(uuid "a15005e4-c70d-46e2-92f0-6f8a9469b013")
 			(net 19 "ISENSE_C-")
 		)
 		(pad "35" smd roundrect
@@ -4311,7 +2941,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "2b632450-83db-46a9-bef5-c54b6b3593b6")
+			(uuid "841c3773-774e-4add-9049-bc9b683a3345")
 			(net 13 "GATE_CL")
 		)
 		(pad "36" smd roundrect
@@ -4319,7 +2949,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "e9c44c76-3fc7-40a4-8391-3e7eebe26856")
+			(uuid "3ac51f14-391c-4a03-8e14-c497b799302e")
 			(net 7 "PHASE_C")
 		)
 		(pad "37" smd roundrect
@@ -4327,7 +2957,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "5c86f237-3056-4eac-ab0d-1eff0b8c253a")
+			(uuid "8c88ffe3-f4f2-42c5-9434-be324d6ff99a")
 			(net 34 "GATE_DRV_CH")
 		)
 		(pad "38" smd roundrect
@@ -4335,7 +2965,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "b9510106-421d-4ee2-a469-69965c494ba5")
+			(uuid "e9bcb790-5c83-410e-b70a-578c24c04fe4")
 			(net 1 "VMOTOR")
 		)
 		(pad "39" smd roundrect
@@ -4343,7 +2973,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "1223c349-b316-4913-89b7-e6b6d00492bd")
+			(uuid "aa8fbbc2-21f9-412c-8a75-da7103d76e1d")
 			(net 17 "ISENSE_B-")
 		)
 		(pad "40" smd roundrect
@@ -4351,7 +2981,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "51896c07-9d96-4a05-acef-348d2c2e8c7a")
+			(uuid "ad07b5b2-686e-46dd-96c9-9c00785a8c92")
 			(net 11 "GATE_BL")
 		)
 		(pad "41" smd roundrect
@@ -4359,7 +2989,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "d5ddf197-9d49-43f7-9388-a5b5b654c958")
+			(uuid "9bccc1f0-d320-4eef-ba28-a103a7c9d703")
 			(net 6 "PHASE_B")
 		)
 		(pad "42" smd roundrect
@@ -4367,7 +2997,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "3a13cb24-abcd-4022-9991-c62fc1b91ad8")
+			(uuid "744f93a2-be95-4e42-b938-dc29a33d4411")
 			(net 33 "GATE_DRV_BH")
 		)
 		(pad "43" smd roundrect
@@ -4375,7 +3005,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "7336dd87-f686-4436-a519-2236f35d140a")
+			(uuid "ef2ef4ff-77fe-4f1f-a2db-700478b01992")
 			(net 1 "VMOTOR")
 		)
 		(pad "44" smd roundrect
@@ -4383,7 +3013,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "fb325de5-067b-4d66-9b0d-5481431ccbc7")
+			(uuid "1b3a40a7-3a2e-4ffb-83ba-86265b851ff6")
 			(net 15 "ISENSE_A-")
 		)
 		(pad "45" smd roundrect
@@ -4391,7 +3021,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "ff3acf93-1dcb-4471-9f5e-ef3563f09503")
+			(uuid "26494cc7-0530-465f-b5cd-05e881ec733e")
 			(net 9 "GATE_AL")
 		)
 		(pad "46" smd roundrect
@@ -4399,7 +3029,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "edaf4199-be19-4ce9-a718-5c424f0424a4")
+			(uuid "b9e4a51a-43b2-4761-87aa-60b29af598ad")
 			(net 5 "PHASE_A")
 		)
 		(pad "47" smd roundrect
@@ -4407,7 +3037,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "95917e27-33c7-4680-add4-ce2de855ae3c")
+			(uuid "ba0d091d-bd7c-4dc6-8690-a799e02fddde")
 			(net 32 "GATE_DRV_AH")
 		)
 		(pad "48" smd roundrect
@@ -4415,7 +3045,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "b44ecb55-54ae-4d7b-a470-ab60952aef37")
+			(uuid "7012184e-01e9-40e5-8a11-64ef2a9bac88")
 			(net 1 "VMOTOR")
 		)
 		(pad "49" smd roundrect
@@ -4423,7 +3053,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "02055dbd-99f5-4463-bc5f-de557899d6b9")
+			(uuid "9dd8c4ba-39a9-4350-bd93-a39fe23edb56")
 			(net 3 "+3.3V")
 		)
 		(pad "50" smd roundrect
@@ -4431,7 +3061,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "12ad8177-d3cb-494d-a93d-b5e03f3fb494")
+			(uuid "aebbe5ca-8a7a-45a4-80d3-d6fb389c8370")
 			(net 31 "SW_OUT")
 		)
 		(pad "51" smd roundrect
@@ -4439,7 +3069,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "39629293-b290-41f6-bc8c-0b17f203cde9")
+			(uuid "da05281d-de34-4a77-b5df-14db7612c6cb")
 			(net 31 "SW_OUT")
 		)
 		(pad "52" smd roundrect
@@ -4447,7 +3077,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "11779352-9d15-4ea8-b9e8-a69920c74571")
+			(uuid "57709bb0-dfd5-462b-aaf6-58a544b139b8")
 			(net 1 "VMOTOR")
 		)
 		(pad "53" smd roundrect
@@ -4455,7 +3085,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "7b981edc-59e1-4e73-a98b-7486ba297829")
+			(uuid "32098605-fb3d-498a-b49f-8c92e3db4ca7")
 			(net 1 "VMOTOR")
 		)
 		(pad "54" smd roundrect
@@ -4463,7 +3093,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "b7900782-41ea-4f22-8a8f-525c3115fcd6")
+			(uuid "ab4f5e24-2d2e-4100-a0d6-ce38024e1d4f")
 			(net 1 "VMOTOR")
 		)
 		(pad "55" smd roundrect
@@ -4471,7 +3101,7 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "e9845521-300d-4f23-a3e0-5a65c3d7e061")
+			(uuid "5d232bed-757b-41ab-916d-72af77f68db4")
 			(net 3 "+3.3V")
 		)
 		(pad "56" smd roundrect
@@ -4479,26 +3109,171 @@
 			(size 1.55 0.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "efdbba17-e81e-4ade-bbf9-68ab0dce151f")
+			(uuid "57ff6949-ac39-4c23-b918-6dd2d39c2c58")
 			(net 4 "GND")
 		)
 		(pad "57" smd rect
 			(at 0 0)
 			(size 3.61 6.35)
 			(layers "F.Cu" "F.Mask" "F.Paste")
-			(uuid "1023e201-7a68-4391-9b61-870c9bc822ff")
+			(uuid "2c4fde3d-a9c7-4e11-8581-c57c492730f4")
+			(net 4 "GND")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Package_TO_SOT_THT:TO-220-3_Vertical"
+		(layer "F.Cu")
+		(uuid "a0d92a23-53f1-4b3b-9ad5-8fca2ae631d9")
+		(at 124 168)
+		(property "Reference" "Q3"
+			(at 0 -5 0)
+			(layer "F.SilkS")
+			(uuid "faab756d-51fb-4411-8caa-854ddbc014a6")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "IRLZ44N"
+			(at 0 5 0)
+			(layer "F.Fab")
+			(uuid "4ef3e442-aa03-429c-8fb8-b567182698df")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "da855146-e4c1-4f4d-90bd-2106852ac6ab")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "f0b294d9-72a4-4bb3-9b3b-6e09606b3786")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" thru_hole rect
+			(at -2.54 0)
+			(size 1.8 1.8)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "6c1502cd-59d4-482d-aed4-d2fd36cbd402")
+			(net 10 "GATE_BH")
+		)
+		(pad "2" thru_hole oval
+			(at 0 0)
+			(size 1.8 1.8)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "47da723b-8a82-41f4-87cf-de1ade98bcf5")
+			(net 1 "VMOTOR")
+		)
+		(pad "3" thru_hole oval
+			(at 2.54 0)
+			(size 1.8 1.8)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "1cd11b84-0b14-4e57-a918-2863b675478e")
+			(net 6 "PHASE_B")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Capacitor_SMD:C_0805_2012Metric"
+		(layer "F.Cu")
+		(uuid "a5d0792e-ee5f-4ade-9209-429b8bcbb895")
+		(at 130 108)
+		(property "Reference" "C1"
+			(at 0 -1.5 0)
+			(layer "F.SilkS")
+			(uuid "6b72df6f-7cf4-4fd8-a3d8-00baf0f957d1")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "470uF"
+			(at 0 1.5 0)
+			(layer "F.Fab")
+			(uuid "0d50e2af-f117-40b2-a77d-174d274db404")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "ea56cea9-ac4a-4ac8-ac0a-849cf5b6e1cd")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "985c917c-5bfd-4518-b373-e1cf9292585f")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" smd roundrect
+			(at -1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "1bf47288-3691-4cb2-9e2c-93387258e70b")
+			(net 1 "VMOTOR")
+		)
+		(pad "2" smd roundrect
+			(at 1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "db83293e-5a1f-4037-8637-8fa3d3810672")
 			(net 4 "GND")
 		)
 		(embedded_fonts no)
 	)
 	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "edf7d654-3d15-42c4-80bc-c2b42c23dff4")
-		(at 130 130)
-		(property "Reference" "C4"
+		(uuid "a625bfa7-e8ce-4818-8396-0cc4d96b1b0b")
+		(at 106 130)
+		(property "Reference" "C3"
 			(at 0 -1.5 0)
 			(layer "F.SilkS")
-			(uuid "883a9dc4-ff63-4cb0-8cba-24169e76481a")
+			(uuid "eecbab42-e1ff-458f-aeef-1fcafb8f8e78")
 			(effects
 				(font
 					(size 1 1)
@@ -4509,7 +3284,7 @@
 		(property "Value" "220uF"
 			(at 0 1.5 0)
 			(layer "F.Fab")
-			(uuid "9fd14cc6-f254-441d-b3f6-0eac963bd3a6")
+			(uuid "60457708-f5d6-4c46-a9b8-0fd4e167f072")
 			(effects
 				(font
 					(size 1 1)
@@ -4521,7 +3296,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "5d4d4bcc-1579-462a-b16b-8d040e78ee30")
+			(uuid "85e3df16-8dfd-44a6-b4ee-9e8b8943f096")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4532,7 +3307,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "29e347f8-f12f-4889-acb8-c73dfc4d5849")
+			(uuid "560eda4b-a46a-4293-b036-c33c37421f2c")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4545,27 +3320,27 @@
 			(size 1 1.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "3d1e25bb-fb86-4e62-993d-6cead6557289")
-			(net 2 "+5V")
+			(uuid "36b085fd-879a-46ad-898f-e44dbda2c12f")
+			(net 1 "VMOTOR")
 		)
 		(pad "2" smd roundrect
 			(at 1 0)
 			(size 1 1.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "9fa6f368-f29a-4d8d-92bf-d355a4e99947")
+			(uuid "7fce3fe6-a253-4f56-ade6-8b6b89ca4b11")
 			(net 4 "GND")
 		)
 		(embedded_fonts no)
 	)
 	(footprint "Capacitor_SMD:C_0805_2012Metric"
 		(layer "F.Cu")
-		(uuid "f185cba6-c25f-4d45-b523-bdb18b1c8adf")
+		(uuid "a8f5144d-52b5-449b-8c41-697e3c4acfab")
 		(at 155 161)
 		(property "Reference" "C31"
 			(at 0 -1.5 0)
 			(layer "F.SilkS")
-			(uuid "30d33343-4af0-4043-932a-dfbff0b31f49")
+			(uuid "f6bc7c2e-cfbf-421f-b946-a7699cf84930")
 			(effects
 				(font
 					(size 1 1)
@@ -4576,7 +3351,7 @@
 		(property "Value" "10nF"
 			(at 0 1.5 0)
 			(layer "F.Fab")
-			(uuid "8959b7ee-5e92-4e84-9f98-f4212fa6345d")
+			(uuid "ca16458b-9b39-4de2-b21f-56143d470efd")
 			(effects
 				(font
 					(size 1 1)
@@ -4588,7 +3363,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "c17e2de1-660a-4450-bf33-be5bfa16b296")
+			(uuid "f41807fe-214d-4c25-9044-896383ed9ef9")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4599,7 +3374,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "929ec12e-a09f-471b-b18b-a87151b13592")
+			(uuid "6cb9787e-cf52-4c82-9d7b-eb6b118920cb")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4612,7 +3387,7 @@
 			(size 1 1.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "a2c7c94f-774c-4cd5-a7c5-29047ee83dff")
+			(uuid "3bdc2308-ea64-4ae9-bcec-eeaec0937686")
 			(net 21 "HALL_B")
 		)
 		(pad "2" smd roundrect
@@ -4620,8 +3395,1233 @@
 			(size 1 1.3)
 			(layers "F.Cu" "F.Mask" "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "fad81733-6624-41eb-8757-791b167b18cd")
+			(uuid "ddea1dd2-fc56-4e00-9559-8bd83ccccedb")
 			(net 4 "GND")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Fuse:Fuse_1206_3216Metric"
+		(layer "F.Cu")
+		(uuid "b0b5d404-d9d5-4cba-bfea-76390047a4d7")
+		(at 114 108)
+		(property "Reference" "F1"
+			(at 0 -1.5 0)
+			(layer "F.SilkS")
+			(uuid "18958db6-a8a9-4afe-b222-fa5744a23bcd")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "15A"
+			(at 0 1.5 0)
+			(layer "F.Fab")
+			(uuid "ae98f78e-cc8c-4ecb-9acc-266dfb9f0b8c")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "cc879f02-de7f-4c2d-96c6-3942fbb4686f")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "8a686440-298a-4772-a261-9e3c61b0b30d")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" smd roundrect
+			(at -1.5 0)
+			(size 1.2 1.7)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "76bdc1e0-ba15-45de-9649-0caaaba1845d")
+			(net 1 "VMOTOR")
+		)
+		(pad "2" smd roundrect
+			(at 1.5 0)
+			(size 1.2 1.7)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "ceb6d3e9-5608-4f21-8a69-9da249ab451c")
+			(net 1 "VMOTOR")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "MountingHole:MountingHole_3.2mm_M3"
+		(layer "F.Cu")
+		(uuid "b4db4d94-ad44-4148-8104-c36e51fabe8a")
+		(at 167 187)
+		(property "Reference" "MH4"
+			(at 0 -3 0)
+			(layer "F.SilkS")
+			(uuid "1016d71e-4b16-4700-a2f5-b693c8f3102e")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "MountingHole"
+			(at 0 3 0)
+			(layer "F.Fab")
+			(uuid "05201156-911b-4780-911c-24e8e4a11c1a")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "a6b103ea-4114-4572-9160-1af23347ba9c")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9d345aed-8d05-4a7d-b247-0002c942dd4e")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(attr exclude_from_pos_files exclude_from_bom)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "" np_thru_hole circle
+			(at 0 0)
+			(size 3.2 3.2)
+			(drill 3.2)
+			(layers "*.Cu" "*.Mask")
+			(uuid "479f2d90-6251-4ff7-90c1-eddb0c2635fa")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Resistor_SMD:R_2512_6332Metric"
+		(layer "F.Cu")
+		(uuid "bf463182-b21b-4663-9b27-859ab4e0fce6")
+		(at 140 184)
+		(property "Reference" "R12"
+			(at 0 -2 0)
+			(layer "F.SilkS")
+			(uuid "171d7883-05a5-410c-bfb3-1915dcf2ebee")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "5mR"
+			(at 0 2 0)
+			(layer "F.Fab")
+			(uuid "2cb10848-7abb-4c86-8e49-975ccf9c37dc")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "ef716078-ec36-41d3-b3d8-1d5600ad4bf3")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "aeee1364-ff8d-4137-8b60-cab88e25bd41")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" smd roundrect
+			(at -3.1 0)
+			(size 1.6 2.7)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "c222dc0a-b728-44e6-93e8-a55225763442")
+			(net 18 "ISENSE_C+")
+		)
+		(pad "2" smd roundrect
+			(at 3.1 0)
+			(size 1.6 2.7)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "9386fc71-46d0-47ff-b23a-3e32c346dabc")
+			(net 19 "ISENSE_C-")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Capacitor_SMD:C_0805_2012Metric"
+		(layer "F.Cu")
+		(uuid "c4b615dd-43e7-4351-9e3b-c0cdc727a1c7")
+		(at 134 137)
+		(property "Reference" "C7"
+			(at 0 -1.5 0)
+			(layer "F.SilkS")
+			(uuid "13f2a97f-b20b-480d-90a9-11478d659ab3")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100nF"
+			(at 0 1.5 0)
+			(layer "F.Fab")
+			(uuid "e564cf3f-f1a7-4e4e-88a1-e9d1e11e7607")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "3cb1fa76-c751-4ff8-acd0-e7e91da69c0a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "0d7b15b6-28ab-4a38-b3d4-eea9ca2cdc1a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" smd roundrect
+			(at -1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "de93710a-a428-4452-86cc-c015a536c33a")
+			(net 3 "+3.3V")
+		)
+		(pad "2" smd roundrect
+			(at 1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "848e4d74-c918-4f73-aac0-5d9668e4f022")
+			(net 4 "GND")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Capacitor_SMD:C_0805_2012Metric"
+		(layer "F.Cu")
+		(uuid "c66bf486-cd65-4271-92e7-97f33cad806f")
+		(at 104 153)
+		(property "Reference" "C13"
+			(at 0 -1.5 0)
+			(layer "F.SilkS")
+			(uuid "1fc38f22-31ed-47a6-aa0e-7ce5aa45f968")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100nF"
+			(at 0 1.5 0)
+			(layer "F.Fab")
+			(uuid "8d7ae2cf-f0b7-44eb-b735-db6b8d4b7bcf")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "87cf2035-f935-4988-8037-e8ece179aed0")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "bbecb87d-ddd4-4e86-b119-db8d5d20d282")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" smd roundrect
+			(at -1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "3fdf2ed3-60e3-420d-8ca8-00901a807941")
+			(net 1 "VMOTOR")
+		)
+		(pad "2" smd roundrect
+			(at 1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "8657a240-ebee-4b21-99e9-50f962db41b3")
+			(net 6 "PHASE_B")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Package_TO_SOT_THT:TO-220-3_Vertical"
+		(layer "F.Cu")
+		(uuid "cc340d10-bb98-4b8c-91a9-8c8fedfb267e")
+		(at 140 168)
+		(property "Reference" "Q5"
+			(at 0 -5 0)
+			(layer "F.SilkS")
+			(uuid "a3283243-a997-4a1a-871c-ee14a0f300c1")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "IRLZ44N"
+			(at 0 5 0)
+			(layer "F.Fab")
+			(uuid "9a235b28-9b40-4637-b3f0-74e37cd44028")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "52c391bf-86f2-4d12-9800-b00930e14a01")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "3dfe7336-69c3-4bb2-949e-4f48810f4c2b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" thru_hole rect
+			(at -2.54 0)
+			(size 1.8 1.8)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "eab96321-bba9-43e5-a9d7-0442637e2f3c")
+			(net 12 "GATE_CH")
+		)
+		(pad "2" thru_hole oval
+			(at 0 0)
+			(size 1.8 1.8)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "216db71f-4c70-4944-b4b5-6a2d3ba5d475")
+			(net 1 "VMOTOR")
+		)
+		(pad "3" thru_hole oval
+			(at 2.54 0)
+			(size 1.8 1.8)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "6ef33532-6116-4404-8e6a-47451509cd3d")
+			(net 7 "PHASE_C")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Capacitor_SMD:C_0805_2012Metric"
+		(layer "F.Cu")
+		(uuid "ccfe7c3a-29e5-4444-a0c5-9af4f4beb6e6")
+		(at 160 137)
+		(property "Reference" "C10"
+			(at 0 -1.5 0)
+			(layer "F.SilkS")
+			(uuid "197556ed-4e85-4176-9045-7649b7ef9702")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "20pF"
+			(at 0 1.5 0)
+			(layer "F.Fab")
+			(uuid "707c2ea3-04a0-47e5-8cf3-735d96989829")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b0b7013e-cce6-4fac-bee6-d0714e8f9559")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7e2e451a-4a68-473f-aaa5-a4247014d5d1")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" smd roundrect
+			(at -1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "0fc9a023-177d-4a54-bf8a-c945177f061a")
+			(net 27 "OSC_IN")
+		)
+		(pad "2" smd roundrect
+			(at 1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "4109a433-bd1e-422d-ab7f-06e7f5f2fc3c")
+			(net 4 "GND")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Package_TO_SOT_THT:TO-220-3_Vertical"
+		(layer "F.Cu")
+		(uuid "cf422510-b16b-44b8-bf70-587bd88e761c")
+		(at 124 176)
+		(property "Reference" "Q4"
+			(at 0 -5 0)
+			(layer "F.SilkS")
+			(uuid "4e62caa7-41c6-4ad4-a11e-5e4bd7a5798f")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "IRLZ44N"
+			(at 0 5 0)
+			(layer "F.Fab")
+			(uuid "349d0f75-5d6e-428b-ae59-e79b4654d56e")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "2d46e53f-2292-4519-987f-b19e9aaab4f0")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "e0bf9a8a-5527-41ee-9808-258bef03201c")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" thru_hole rect
+			(at -2.54 0)
+			(size 1.8 1.8)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "0937a305-7b9d-4fe5-af6e-acc7ec627d69")
+			(net 11 "GATE_BL")
+		)
+		(pad "2" thru_hole oval
+			(at 0 0)
+			(size 1.8 1.8)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "03f64ded-3f6b-4378-91e9-48936f8f8962")
+			(net 6 "PHASE_B")
+		)
+		(pad "3" thru_hole oval
+			(at 2.54 0)
+			(size 1.8 1.8)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "4316f663-8fa9-426d-a7ca-41ca56130101")
+			(net 16 "ISENSE_B+")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "MountingHole:MountingHole_3.2mm_M3"
+		(layer "F.Cu")
+		(uuid "d74534f2-15b6-46dc-9b14-1f8576391f07")
+		(at 167 103)
+		(property "Reference" "MH2"
+			(at 0 -3 0)
+			(layer "F.SilkS")
+			(uuid "90f8003f-9555-4d69-82a5-fab5c6d633b9")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "MountingHole"
+			(at 0 3 0)
+			(layer "F.Fab")
+			(uuid "8aab22ba-d9b8-4bdf-885c-f661f7296b9a")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "384814ae-4cf4-4cc7-a7ef-8728957c77cf")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "a141d5b4-c205-4b9a-a1f4-84eb11db1ff0")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(attr exclude_from_pos_files exclude_from_bom)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "" np_thru_hole circle
+			(at 0 0)
+			(size 3.2 3.2)
+			(drill 3.2)
+			(layers "*.Cu" "*.Mask")
+			(uuid "326462aa-6e0c-4611-9ff7-7f09b468bb9d")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Crystal:Crystal_HC49-4H_Vertical"
+		(layer "F.Cu")
+		(uuid "d870c4ff-5ff1-4e2a-955b-050c32693d21")
+		(at 152 137)
+		(property "Reference" "Y1"
+			(at 0 -3 0)
+			(layer "F.SilkS")
+			(uuid "1e655979-fc70-4a6a-813f-dac9896c26b2")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "8MHz"
+			(at 0 3 0)
+			(layer "F.Fab")
+			(uuid "7a5d8be1-a54c-47fe-a283-5e877b2a68a6")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c062d120-ef23-4206-8b3b-1d788bc9cf3c")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "fcd42157-245f-4f54-bc29-bcb4cd5a9a99")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" thru_hole circle
+			(at -2.44 0)
+			(size 1.5 1.5)
+			(drill 0.8)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "f2a5fba8-5d97-4d67-a913-1ff17db27048")
+			(net 27 "OSC_IN")
+		)
+		(pad "2" thru_hole circle
+			(at 2.44 0)
+			(size 1.5 1.5)
+			(drill 0.8)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "3543c6f1-935c-42aa-9caf-68ec4057c880")
+			(net 28 "OSC_OUT")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Diode_SMD:D_SMA"
+		(layer "F.Cu")
+		(uuid "dab752f9-6597-4485-ba2b-51bba0085c05")
+		(at 119 130)
+		(property "Reference" "D2"
+			(at 0 -2 0)
+			(layer "F.SilkS")
+			(uuid "27ffaa67-57a0-4c73-8170-7f89d1f1184b")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "SS34"
+			(at 0 2 0)
+			(layer "F.Fab")
+			(uuid "897a3a29-98d6-4c51-bee2-df90da6fb30c")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "3e124e62-48a4-4104-a088-b84f0d914613")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "cb6393ef-368a-4504-a198-d87504be1608")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" smd roundrect
+			(at -2 0)
+			(size 1.5 1.7)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "f7373b6c-0ce7-4b56-bd5f-db9cf489aa84")
+			(net 31 "SW_OUT")
+		)
+		(pad "2" smd roundrect
+			(at 2 0)
+			(size 1.5 1.7)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "1f1c420a-2da5-4a48-9ac7-701832bb5dff")
+			(net 4 "GND")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Diode_SMD:D_SMA"
+		(layer "F.Cu")
+		(uuid "e379f406-4959-4efd-a7ba-2b5ff1037ab1")
+		(at 122 108)
+		(property "Reference" "D1"
+			(at 0 -2 0)
+			(layer "F.SilkS")
+			(uuid "87adb7e2-dbc2-4353-978a-dd25f4a992d6")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "SMBJ24A"
+			(at 0 2 0)
+			(layer "F.Fab")
+			(uuid "f52ce358-36b6-4208-a99f-bac9215e0e44")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "a884fb5b-0748-4382-8c15-c28279354e96")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "1205a6cd-d115-4557-aa0c-9b36ab72fb77")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" smd roundrect
+			(at -2 0)
+			(size 1.5 1.7)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "0434926c-d8c1-4130-805c-f1cd7c717117")
+			(net 4 "GND")
+		)
+		(pad "2" smd roundrect
+			(at 2 0)
+			(size 1.5 1.7)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "a23f5bbe-5125-4dfb-a4d2-327b6071fcfd")
+			(net 1 "VMOTOR")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Inductor_SMD:L_1210_3225Metric"
+		(layer "F.Cu")
+		(uuid "e5429d3e-87ad-45ba-adc3-54aadfc313ad")
+		(at 126 122)
+		(property "Reference" "L1"
+			(at 0 -2 0)
+			(layer "F.SilkS")
+			(uuid "51a8a097-1c35-4500-a2c4-08704036181f")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "33uH"
+			(at 0 2 0)
+			(layer "F.Fab")
+			(uuid "867c8578-19a0-4940-b554-7176f314c299")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b134b2b6-3aa9-4d2d-8447-5606cc76df61")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "241391cb-2b55-498c-8c68-87825cc7bcb8")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" smd roundrect
+			(at -1.5 0)
+			(size 1.2 2.5)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "8c6654b6-1eb5-4158-a010-f4ba89478ce8")
+			(net 31 "SW_OUT")
+		)
+		(pad "2" smd roundrect
+			(at 1.5 0)
+			(size 1.2 2.5)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "e45278c3-5f1c-4bd4-b801-34a599c7d78b")
+			(net 2 "+5V")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Capacitor_SMD:C_0805_2012Metric"
+		(layer "F.Cu")
+		(uuid "ec1fb045-f436-489b-ac13-c53ec12b0725")
+		(at 124 153)
+		(property "Reference" "C16"
+			(at 0 -1.5 0)
+			(layer "F.SilkS")
+			(uuid "c4ea2202-0416-4443-8383-494b3904bb9c")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "10uF"
+			(at 0 1.5 0)
+			(layer "F.Fab")
+			(uuid "a3d0b16f-19d5-434b-9b73-ab79ed033d34")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "690ce203-aa3c-4395-af51-f8c20527a414")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "5985cec9-3367-4f69-86cf-2be687e8f4ca")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" smd roundrect
+			(at -1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "7678fd71-b183-4953-bc84-06d2d741f9f0")
+			(net 2 "+5V")
+		)
+		(pad "2" smd roundrect
+			(at 1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "292275d4-9780-41b5-8e9d-6639ab77cdd4")
+			(net 4 "GND")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Capacitor_SMD:C_0805_2012Metric"
+		(layer "F.Cu")
+		(uuid "ed65af59-a609-46be-acfb-71f085d05598")
+		(at 124 147)
+		(property "Reference" "C15"
+			(at 0 -1.5 0)
+			(layer "F.SilkS")
+			(uuid "397521bc-82ca-4bc5-96c1-61f6a53e16a1")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100nF"
+			(at 0 1.5 0)
+			(layer "F.Fab")
+			(uuid "ba3dcc9d-d981-4c45-b3d0-b58252ea2b7b")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "2b35fae7-3123-4fab-85b6-b1ef9262b422")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "6059efcd-4b74-4b47-9aad-12eb21dcae7e")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" smd roundrect
+			(at -1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "1957363e-cae0-4c38-871a-a5ac6f89a8a0")
+			(net 2 "+5V")
+		)
+		(pad "2" smd roundrect
+			(at 1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "7e1277ea-d7f5-4153-8a66-aa807036ff6c")
+			(net 4 "GND")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Resistor_SMD:R_2512_6332Metric"
+		(layer "F.Cu")
+		(uuid "f30e3695-e5f0-4252-9407-65dd947bb5ef")
+		(at 124 184)
+		(property "Reference" "R11"
+			(at 0 -2 0)
+			(layer "F.SilkS")
+			(uuid "49a774c2-1dc5-47be-8c78-ce321aba44a1")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "5mR"
+			(at 0 2 0)
+			(layer "F.Fab")
+			(uuid "dfdd8e33-4345-4a58-bf5b-8e8f17a46641")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "2f1d82ca-35c8-4ccb-9d56-0519efacf6fe")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "369cfdbf-d350-4bf3-8df7-c8eaa7020124")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" smd roundrect
+			(at -3.1 0)
+			(size 1.6 2.7)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "ab182fe7-0bc4-4943-89df-630a98faba79")
+			(net 16 "ISENSE_B+")
+		)
+		(pad "2" smd roundrect
+			(at 3.1 0)
+			(size 1.6 2.7)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "fb1fa6f0-487f-4347-9d4d-4828f253f9da")
+			(net 17 "ISENSE_B-")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Capacitor_SMD:C_0805_2012Metric"
+		(layer "F.Cu")
+		(uuid "f8b59a52-306e-469f-b75a-d4a608f84d97")
+		(at 149 161)
+		(property "Reference" "C30"
+			(at 0 -1.5 0)
+			(layer "F.SilkS")
+			(uuid "fe3503cf-098a-4cfc-b687-b37fe6210b61")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "10nF"
+			(at 0 1.5 0)
+			(layer "F.Fab")
+			(uuid "d5b159d2-5a4e-4725-8bd5-891bdc586680")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "01014ec0-c10e-4d8a-af6a-c557a703f669")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "5e6abd04-0af0-4d4b-a9bc-de569e774f06")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" smd roundrect
+			(at -1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "3a1731b3-2c27-4eaf-b9e3-40615aa2a196")
+			(net 20 "HALL_A")
+		)
+		(pad "2" smd roundrect
+			(at 1 0)
+			(size 1 1.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "a4345c70-6d39-46d0-a1c7-91779e25697e")
+			(net 4 "GND")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Package_TO_SOT_THT:TO-220-3_Vertical"
+		(layer "F.Cu")
+		(uuid "fb551f4e-c7aa-4c72-85e2-f9de6905b903")
+		(at 108 168)
+		(property "Reference" "Q1"
+			(at 0 -5 0)
+			(layer "F.SilkS")
+			(uuid "2afc9eca-a0b6-4c7d-84d8-ada40f0769b7")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "IRLZ44N"
+			(at 0 5 0)
+			(layer "F.Fab")
+			(uuid "3480f0cb-899d-4beb-ac02-f5dc68db5f3a")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "ce19c899-29f6-4c34-b2b2-7dd404f82d47")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b22e00e4-75aa-41bb-b572-d9c1dab6180c")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(duplicate_pad_numbers_are_jumpers no)
+		(pad "1" thru_hole rect
+			(at -2.54 0)
+			(size 1.8 1.8)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "4929d8d7-8e60-4579-8033-548f8bd574d4")
+			(net 8 "GATE_AH")
+		)
+		(pad "2" thru_hole oval
+			(at 0 0)
+			(size 1.8 1.8)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "1552980a-28f9-40e3-ae2d-2f79ef54e5ef")
+			(net 1 "VMOTOR")
+		)
+		(pad "3" thru_hole oval
+			(at 2.54 0)
+			(size 1.8 1.8)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "b7e8d018-13d4-447c-b06e-1f5dcbd4701e")
+			(net 5 "PHASE_A")
 		)
 		(embedded_fonts no)
 	)
@@ -4634,22 +4634,14 @@
 		)
 		(fill no)
 		(layer "Edge.Cuts")
-		(uuid "c78c028b-8829-4d8e-84f5-b7bf5b92d4e2")
-	)
-	(segment
-		(start 108.8076 163.0786)
-		(end 109.1986 162.5438)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "0b9cf380-b1e9-4154-a5f9-5561e7443549")
-		(net 8)
+		(uuid "8aa7a4f6-ef77-418a-9b92-2c85970838a1")
 	)
 	(segment
 		(start 109.1986 162.5438)
 		(end 109 162)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "47d222bf-cc1e-4e5e-a9fe-aba775bb8c68")
+		(uuid "2fcc9d5f-21d6-49fc-861c-1d4e40346576")
 		(net 8)
 	)
 	(segment
@@ -4657,7 +4649,15 @@
 		(end 108.996 163.6553)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "59b663db-23ee-4af7-9179-3536fb1b3d82")
+		(uuid "4cf195f6-88a4-496d-9634-dd44b82ac3c6")
+		(net 8)
+	)
+	(segment
+		(start 108.8076 163.0786)
+		(end 109.1986 162.5438)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "604190fb-3c56-42d0-a096-a9c1f768d741")
 		(net 8)
 	)
 	(segment
@@ -4665,7 +4665,7 @@
 		(end 108.8076 163.0786)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "c5ea0137-b9c6-4253-a7de-bcb3a66a3203")
+		(uuid "8e7eba54-00f1-4a23-96a2-f4ae1de3b882")
 		(net 8)
 	)
 	(segment
@@ -4673,15 +4673,7 @@
 		(end 124.2219 162.6276)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "4b4a4307-7b80-4ddb-9457-d35b9e1058ae")
-		(net 10)
-	)
-	(segment
-		(start 121.46 168)
-		(end 124.2219 164.6748)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "636fc1e1-d4f4-47f2-98d5-04f85efdaadd")
+		(uuid "13db3af6-2048-4208-820f-e14ac2dfe51b")
 		(net 10)
 	)
 	(segment
@@ -4689,23 +4681,31 @@
 		(end 125 162)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "9cff67b2-fd98-4ec8-a393-e998ad94d808")
+		(uuid "1dcc5fab-7cb4-49a9-8ec8-ef774f8b4836")
 		(net 10)
 	)
 	(segment
-		(start 140.2378 162.6276)
-		(end 141 162)
+		(start 121.46 168)
+		(end 124.2219 164.6748)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "447faa85-c4dd-453b-9a94-9d718435b689")
-		(net 12)
+		(uuid "94c19a5f-0bf7-4e49-a756-079f4b567e5c")
+		(net 10)
 	)
 	(segment
 		(start 137.46 168)
 		(end 140.2378 164.6415)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "52aded46-08fb-4d96-b32e-4815efd2e763")
+		(uuid "1ecd6094-8925-47e7-9be3-1c19feba7923")
+		(net 12)
+	)
+	(segment
+		(start 140.2378 162.6276)
+		(end 141 162)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "4489681b-80e1-4cf4-b407-6c379a744608")
 		(net 12)
 	)
 	(segment
@@ -4713,175 +4713,15 @@
 		(end 140.2378 162.6276)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "f3fbe522-f067-4c58-b49b-99091e8978e4")
+		(uuid "a4ca2152-84a1-401e-95aa-931714cfd206")
 		(net 12)
-	)
-	(segment
-		(start 108.9111 155.422)
-		(end 106.2121 158.1827)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "0112138f-e421-4011-8e9f-443022090770")
-		(net 14)
-	)
-	(segment
-		(start 104.0853 178.5021)
-		(end 104.0853 180.7245)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "13dc3f32-7ac5-4374-b3d3-e171e1241721")
-		(net 14)
-	)
-	(segment
-		(start 113.4792 166.9285)
-		(end 114.3875 160.8447)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "18aad81d-a4d6-4c0d-885c-329b6b479c53")
-		(net 14)
-	)
-	(segment
-		(start 104.0853 180.7245)
-		(end 104.4597 181.4813)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "199cae16-f66e-4e34-ae1a-25825f03ce41")
-		(net 14)
-	)
-	(segment
-		(start 104.9421 161.5163)
-		(end 104.9421 165.485)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "1cd31fb2-af3a-4075-a8d9-589001f11b6e")
-		(net 14)
-	)
-	(segment
-		(start 110.25 155.25)
-		(end 109.3873 155.422)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "248b9d27-9aef-4af6-afbb-11899ef428ef")
-		(net 14)
-	)
-	(segment
-		(start 111.8226 155.3315)
-		(end 110.3939 155.3315)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "3c41e876-8062-450b-87c2-1d44d5004f07")
-		(net 14)
-	)
-	(segment
-		(start 104.7956 182.7806)
-		(end 104.9 184)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "3ca7c300-87a2-43f3-ac03-1912738473ba")
-		(net 14)
-	)
-	(segment
-		(start 102.799 167.6713)
-		(end 102.7775 173.4222)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "577c6829-ac44-4fe1-93e5-539b47a7bca4")
-		(net 14)
-	)
-	(segment
-		(start 103.4246 175.6086)
-		(end 103.4246 176.3157)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "5cbb9194-7ebb-4a67-9bd5-ccbde66552b5")
-		(net 14)
-	)
-	(segment
-		(start 105.396 182.609)
-		(end 109.7477 177.5877)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "67ed5047-ce93-4027-b428-fd9edbafa34e")
-		(net 14)
-	)
-	(segment
-		(start 109.9289 176.6557)
-		(end 110.54 176)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "7a5c36d4-bbd9-46f6-8906-d0650e8388c5")
-		(net 14)
-	)
-	(segment
-		(start 104.9 184)
-		(end 105.396 182.609)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "8322a98c-138f-49ee-a78a-20f641ae5579")
-		(net 14)
-	)
-	(segment
-		(start 109.3873 155.422)
-		(end 108.9111 155.422)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "9452e229-4052-4abd-9877-5c30a2c27110")
-		(net 14)
-	)
-	(segment
-		(start 102.7775 173.4222)
-		(end 103.4246 175.6086)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "9b5be818-876c-4495-9d33-a7d8e64af5fc")
-		(net 14)
 	)
 	(segment
 		(start 110.54 176)
 		(end 110.3836 174.1086)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "abbb14e6-cf3b-4c8c-8670-6ac78f02527d")
-		(net 14)
-	)
-	(segment
-		(start 114.3875 160.8447)
-		(end 111.8226 155.3315)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "b1b0b243-3821-4c2d-9d39-9a3762e7c4c0")
-		(net 14)
-	)
-	(segment
-		(start 104.472 182.1808)
-		(end 104.7956 182.7806)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "b4b4ab42-c3bd-497f-a26c-14bfc3196b57")
-		(net 14)
-	)
-	(segment
-		(start 110.3836 174.1086)
-		(end 113.4792 166.9285)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "cb2d4a19-4348-45ca-9619-c752a59851f5")
-		(net 14)
-	)
-	(segment
-		(start 106.2121 160.2464)
-		(end 104.9421 161.5163)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "d7288436-75dc-4986-b280-62500c12f276")
-		(net 14)
-	)
-	(segment
-		(start 109.7477 177.5877)
-		(end 109.9289 176.6557)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "eca0e1af-0dc3-40ef-9faa-e36d72d95486")
+		(uuid "0dbae6d2-8b55-424d-925a-3b8a56bbced1")
 		(net 14)
 	)
 	(segment
@@ -4889,23 +4729,39 @@
 		(end 104.472 182.1808)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "ecdd8954-e750-4cb7-83b7-1a6acea71a49")
+		(uuid "0dd0d432-cd87-4644-80ee-df7ba3dc6c87")
 		(net 14)
 	)
 	(segment
-		(start 106.2121 158.1827)
-		(end 106.2121 160.2464)
+		(start 105.396 182.609)
+		(end 109.7477 177.5877)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "ef7f60ae-4eb7-4bd7-8773-5a7b0b3f37f9")
+		(uuid "1f99d8b4-a07f-4027-a30d-dd1243141b74")
 		(net 14)
 	)
 	(segment
-		(start 103.4246 176.3157)
-		(end 104.0853 178.5021)
+		(start 110.3836 174.1086)
+		(end 113.4792 166.9285)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "f1f0ff35-62af-473b-a37f-832aa696a486")
+		(uuid "21defdd1-ff51-4d67-ba60-b69f5e4f7cfa")
+		(net 14)
+	)
+	(segment
+		(start 104.0853 178.5021)
+		(end 104.0853 180.7245)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "2c3601d8-8b52-446e-ba66-2039fda55241")
+		(net 14)
+	)
+	(segment
+		(start 113.4792 166.9285)
+		(end 114.3875 160.8447)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "43a249d7-9835-4520-994e-803235e84232")
 		(net 14)
 	)
 	(segment
@@ -4913,47 +4769,159 @@
 		(end 102.799 167.6713)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "fc2e86d6-087d-4c8c-b040-a03e31cc2154")
+		(uuid "4600ee96-376d-47e2-9e1d-3057e4882250")
 		(net 14)
 	)
 	(segment
-		(start 111.1 184)
-		(end 111.7681 182.7882)
+		(start 111.8226 155.3315)
+		(end 110.3939 155.3315)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "53d3779d-72d4-459e-8031-8962c7abbf17")
-		(net 15)
+		(uuid "648731c7-d7f4-457e-a9b5-6151ddc1874c")
+		(net 14)
 	)
 	(segment
-		(start 137.6436 151.0392)
-		(end 137.1673 150.5629)
+		(start 108.9111 155.422)
+		(end 106.2121 158.1827)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "685807d2-6a29-4938-a5ed-e01bc6b8525e")
-		(net 15)
+		(uuid "65280686-77f0-4093-87cf-607f764d874a")
+		(net 14)
 	)
 	(segment
-		(start 111.1 184)
-		(end 111.6094 182.7882)
+		(start 104.7956 182.7806)
+		(end 104.9 184)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "80c17d60-7ff3-4616-aa74-94054c7afa84")
-		(net 15)
+		(uuid "71a8cb4d-6445-47d3-a3fc-8997b611db52")
+		(net 14)
 	)
 	(segment
-		(start 137.1673 150.5629)
-		(end 136.5324 150.5629)
+		(start 104.9 184)
+		(end 105.396 182.609)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "a87022b6-7210-460d-b9f1-0ae80b62dafc")
-		(net 15)
+		(uuid "7532db51-dc33-42bd-b940-4216905f4251")
+		(net 14)
 	)
 	(segment
-		(start 119.5466 149.928)
-		(end 118.9117 149.293)
+		(start 103.4246 176.3157)
+		(end 104.0853 178.5021)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "c84c1cc2-d5c4-4e1a-a24f-3560c0b50225")
+		(uuid "812af244-a8fd-402c-9697-49d200fb51cb")
+		(net 14)
+	)
+	(segment
+		(start 102.799 167.6713)
+		(end 102.7775 173.4222)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "8e105ee3-c8af-4d6c-89e1-cd20c36097e2")
+		(net 14)
+	)
+	(segment
+		(start 109.3873 155.422)
+		(end 108.9111 155.422)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "a068b91b-8ba9-4149-9abb-46059467617e")
+		(net 14)
+	)
+	(segment
+		(start 109.7477 177.5877)
+		(end 109.9289 176.6557)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "a938b013-894b-4bd5-9aec-c3db143dc58b")
+		(net 14)
+	)
+	(segment
+		(start 104.9421 161.5163)
+		(end 104.9421 165.485)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "b951f1e9-6d6d-4448-91bd-a5cbab0b20f3")
+		(net 14)
+	)
+	(segment
+		(start 104.472 182.1808)
+		(end 104.7956 182.7806)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "beb06d1c-d5d2-48fd-a237-b96931b6811b")
+		(net 14)
+	)
+	(segment
+		(start 110.25 155.25)
+		(end 109.3873 155.422)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "c05d3b9e-cf87-46bf-b266-4f37559fd7a6")
+		(net 14)
+	)
+	(segment
+		(start 106.2121 160.2464)
+		(end 104.9421 161.5163)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "c8e656c7-7c8f-44a3-9a54-704f6c3000d8")
+		(net 14)
+	)
+	(segment
+		(start 106.2121 158.1827)
+		(end 106.2121 160.2464)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "cfc3a4a4-9b4a-414d-9f36-080b48c39829")
+		(net 14)
+	)
+	(segment
+		(start 104.0853 180.7245)
+		(end 104.4597 181.4813)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "d82b77a3-b401-4b3c-9e92-8eb079804052")
+		(net 14)
+	)
+	(segment
+		(start 102.7775 173.4222)
+		(end 103.4246 175.6086)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "db6d6bc0-c040-4f02-b99b-c85a38e58272")
+		(net 14)
+	)
+	(segment
+		(start 103.4246 175.6086)
+		(end 103.4246 176.3157)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "dcdaa3f2-8d88-404a-b72d-ec87b7622ccd")
+		(net 14)
+	)
+	(segment
+		(start 114.3875 160.8447)
+		(end 111.8226 155.3315)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "f3a7c300-065f-409d-9a9a-b916b521ab45")
+		(net 14)
+	)
+	(segment
+		(start 109.9289 176.6557)
+		(end 110.54 176)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "fc829732-2b16-4f70-ab6b-a3dfcc6c57bc")
+		(net 14)
+	)
+	(segment
+		(start 111.6094 182.7882)
+		(end 119.0704 175.3272)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "05f0ca8d-7704-4eb3-9388-056c1eb116dd")
 		(net 15)
 	)
 	(segment
@@ -4961,7 +4929,15 @@
 		(end 118.4354 149.293)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "cda7a5ea-ebe6-4f1c-85da-aee8e3325d69")
+		(uuid "4d8a4549-b940-4386-b8d4-a7c118f4390c")
+		(net 15)
+	)
+	(segment
+		(start 111.1 184)
+		(end 111.6094 182.7882)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "57023b52-6ad6-4461-bb8a-aa290cd03153")
 		(net 15)
 	)
 	(segment
@@ -4969,7 +4945,31 @@
 		(end 135.825 150.4)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "d19f72f6-2008-4bf7-9da7-f6e1fbe3bd84")
+		(uuid "619b3edd-b48a-46d5-b0de-924fd78f56a6")
+		(net 15)
+	)
+	(segment
+		(start 137.6436 151.0392)
+		(end 137.1673 150.5629)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "74b33f2b-2179-4caa-8fc7-807ecba59160")
+		(net 15)
+	)
+	(segment
+		(start 119.5466 149.928)
+		(end 118.9117 149.293)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "8142c919-ee2f-4b8a-817e-e9ff0f619192")
+		(net 15)
+	)
+	(segment
+		(start 137.1673 150.5629)
+		(end 136.5324 150.5629)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "ac1f258e-6568-4b22-92f1-5f4d3cb1dd7e")
 		(net 15)
 	)
 	(segment
@@ -4977,23 +4977,15 @@
 		(end 117.75 149.25)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "d6a3289c-2ccd-4e0a-89e0-47f7b06ea4c0")
+		(uuid "b55f1143-c84a-41e7-b35b-2aa6831e9f65")
 		(net 15)
 	)
 	(segment
-		(start 111.6094 182.7882)
-		(end 119.0704 175.3272)
+		(start 111.1 184)
+		(end 111.7681 182.7882)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "f2c6c665-a036-41c8-b190-e70a15a14993")
-		(net 15)
-	)
-	(via
-		(at 137.6436 151.0392)
-		(size 0.6)
-		(drill 0.3)
-		(layers "F.Cu" "B.Cu")
-		(uuid "3fad4c0a-2234-44e4-a95f-32911850c66c")
+		(uuid "de38366a-eaaf-4e28-93ae-320f9818596e")
 		(net 15)
 	)
 	(via
@@ -5001,15 +4993,7 @@
 		(size 0.6)
 		(drill 0.3)
 		(layers "F.Cu" "B.Cu")
-		(uuid "5dc48792-3992-44e3-a79f-09321bab347d")
-		(net 15)
-	)
-	(via
-		(at 119.5466 149.928)
-		(size 0.6)
-		(drill 0.3)
-		(layers "F.Cu" "B.Cu")
-		(uuid "b510c26f-632c-4c53-b79f-44c6a70f0055")
+		(uuid "0dfd39d7-728e-4284-9a2b-4057fbe7c746")
 		(net 15)
 	)
 	(via
@@ -5017,15 +5001,23 @@
 		(size 0.6)
 		(drill 0.3)
 		(layers "F.Cu" "B.Cu")
-		(uuid "fdf03597-4768-45b2-8560-189f252840f7")
+		(uuid "343ea39d-21c6-44c1-9517-61fdafa40ed4")
 		(net 15)
 	)
-	(segment
-		(start 127.5633 169.2155)
-		(end 135.5006 161.2783)
-		(width 0.2)
-		(layer "B.Cu")
-		(uuid "079b3e81-c4df-4bfa-b36e-37eb46e6bff0")
+	(via
+		(at 119.5466 149.928)
+		(size 0.6)
+		(drill 0.3)
+		(layers "F.Cu" "B.Cu")
+		(uuid "a5cd4103-81a8-4bdb-ac2d-12b6098c7e83")
+		(net 15)
+	)
+	(via
+		(at 137.6436 151.0392)
+		(size 0.6)
+		(drill 0.3)
+		(layers "F.Cu" "B.Cu")
+		(uuid "cc49f076-729e-426d-82ec-19b58bf44369")
 		(net 15)
 	)
 	(segment
@@ -5033,15 +5025,7 @@
 		(end 124.7852 169.6123)
 		(width 0.2)
 		(layer "B.Cu")
-		(uuid "10cb0a7c-c974-492a-923c-121aa6149029")
-		(net 15)
-	)
-	(segment
-		(start 135.8974 152.7854)
-		(end 137.6436 151.0392)
-		(width 0.2)
-		(layer "B.Cu")
-		(uuid "56f48fc9-5b6e-4446-a6c0-c7e3eda4edf6")
+		(uuid "0d643d7a-638f-4ced-bbe4-817aa96a7ec3")
 		(net 15)
 	)
 	(segment
@@ -5049,15 +5033,15 @@
 		(end 135.8974 152.7854)
 		(width 0.2)
 		(layer "B.Cu")
-		(uuid "bbdf46d1-915a-414d-9202-25a5337f3ede")
+		(uuid "359e61c1-dd0a-487d-8b51-fe29af23dc5e")
 		(net 15)
 	)
 	(segment
-		(start 119.5466 175.0097)
-		(end 119.5466 149.928)
+		(start 127.5633 169.2155)
+		(end 135.5006 161.2783)
 		(width 0.2)
 		(layer "B.Cu")
-		(uuid "ca3e2176-16b1-4363-8d73-002814589e91")
+		(uuid "6b013016-ba4f-405d-81b3-6648cd9d1edc")
 		(net 15)
 	)
 	(segment
@@ -5065,7 +5049,7 @@
 		(end 127.5633 169.2155)
 		(width 0.2)
 		(layer "B.Cu")
-		(uuid "dbb116ce-5561-4e3a-bbab-0cd1eea9b54e")
+		(uuid "b1d134d7-d0d0-4cc5-93ec-975c1a1f0817")
 		(net 15)
 	)
 	(segment
@@ -5073,39 +5057,31 @@
 		(end 119.5466 175.0097)
 		(width 0.2)
 		(layer "B.Cu")
-		(uuid "f6acdecd-fb02-4b9b-966b-a8c6e31ae492")
+		(uuid "b523b744-e6d1-4c56-92b9-bb299a6ab382")
 		(net 15)
 	)
 	(segment
-		(start 127.6663 184.0596)
-		(end 127.1 184)
+		(start 135.8974 152.7854)
+		(end 137.6436 151.0392)
 		(width 0.2)
-		(layer "F.Cu")
-		(uuid "235a9d67-7978-454f-9721-9cf4e66baf1d")
-		(net 17)
+		(layer "B.Cu")
+		(uuid "b52d47f1-11ca-4ab0-b465-78088a2d7d95")
+		(net 15)
 	)
 	(segment
-		(start 135.2884 183.8976)
-		(end 135.0097 184.0664)
+		(start 119.5466 175.0097)
+		(end 119.5466 149.928)
 		(width 0.2)
-		(layer "F.Cu")
-		(uuid "2de678c5-52e9-43b9-a775-2726facbe625")
-		(net 17)
-	)
-	(segment
-		(start 135.3012 184.227)
-		(end 135.0097 184.0664)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "51b0d8a3-f02a-4f97-bb29-aaf0f2364c02")
-		(net 17)
+		(layer "B.Cu")
+		(uuid "d585ba66-a576-4096-9fb3-85e514b4f5c0")
+		(net 15)
 	)
 	(segment
 		(start 135.825 184)
 		(end 135.0097 184.0664)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "5331196b-2c88-49ad-9722-3159baf81dd7")
+		(uuid "75aed2a3-c84c-462d-bede-517a1ea1ffac")
 		(net 17)
 	)
 	(segment
@@ -5113,15 +5089,15 @@
 		(end 135.2884 183.8976)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "78f9af03-60be-408e-ad71-3531de5b9264")
+		(uuid "85db87ca-4405-4829-b7f4-18c6d7cd7dca")
 		(net 17)
 	)
 	(segment
-		(start 135.0097 184.0664)
-		(end 127.6663 184.0596)
+		(start 135.3012 184.227)
+		(end 135.0097 184.0664)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "90b67e5e-8cc3-4ee6-84d7-56cfdda90696")
+		(uuid "86d998fd-8c3a-4b2d-92ed-0337d9c57969")
 		(net 17)
 	)
 	(segment
@@ -5129,7 +5105,31 @@
 		(end 135.3012 184.227)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "e39f1f81-4f71-4a7f-a307-50d9ee662aa9")
+		(uuid "9009b7b3-71c8-4f43-af99-0d9313d8801f")
+		(net 17)
+	)
+	(segment
+		(start 127.6663 184.0596)
+		(end 127.1 184)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "c6d12170-bcfc-4155-8b7f-7c14325256e3")
+		(net 17)
+	)
+	(segment
+		(start 135.0097 184.0664)
+		(end 127.6663 184.0596)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "d9c05423-15b7-4ac1-9426-1b1349224812")
+		(net 17)
+	)
+	(segment
+		(start 135.2884 183.8976)
+		(end 135.0097 184.0664)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "ea38de12-8b1f-49a0-b5ff-17856b8360c9")
 		(net 17)
 	)
 	(segment
@@ -5137,7 +5137,7 @@
 		(end 136.9 184)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "363b5249-0feb-4fe4-ab2f-5d1d7cecf8ec")
+		(uuid "67e48325-7109-4504-a0c6-e83aa5a7052a")
 		(net 18)
 	)
 	(segment
@@ -5145,63 +5145,15 @@
 		(end 136.9 181.64)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "aa54b197-7b08-4c1e-adba-dccb5146f4a9")
+		(uuid "fee3f8ef-5982-4f96-bea0-8a74274ceb9d")
 		(net 18)
-	)
-	(segment
-		(start 139.0723 152.3091)
-		(end 139.0173 152.1149)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "114c058f-e298-4100-a729-96db39a1a125")
-		(net 19)
-	)
-	(segment
-		(start 143.7553 182.7882)
-		(end 143.7553 179.772)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "166df57d-1bdc-4993-8c6d-f4417ff9d100")
-		(net 19)
-	)
-	(segment
-		(start 139.0173 152.1149)
-		(end 136.6361 152.1149)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "589327cc-6028-415c-a37e-91dd021e4d95")
-		(net 19)
 	)
 	(segment
 		(start 143.1 184)
 		(end 143.7553 182.7882)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "83c3b7b0-5d48-4f9a-b7e8-4d5d6ca50063")
-		(net 19)
-	)
-	(segment
-		(start 143.7553 179.772)
-		(end 144.0728 176.7919)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "be0027c5-70ee-41e8-a79c-5939ba9c0f11")
-		(net 19)
-	)
-	(segment
-		(start 144.0728 176.7919)
-		(end 144.0728 176.0848)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "ca11a2d7-0ec3-46ff-9c5b-feb081599609")
-		(net 19)
-	)
-	(segment
-		(start 144.0728 176.0848)
-		(end 144.1521 174.8509)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "d9ad70b7-5472-46d2-81ae-3510f1a39b22")
+		(uuid "1b47ac96-dbf4-45f3-b8cb-5c56067d12e0")
 		(net 19)
 	)
 	(segment
@@ -5209,7 +5161,47 @@
 		(end 135.825 152)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "e538a156-6158-4290-a5c4-9e6637a4c6b8")
+		(uuid "68faab34-2427-4c4e-98b2-db89cfb3c270")
+		(net 19)
+	)
+	(segment
+		(start 143.7553 182.7882)
+		(end 143.7553 179.772)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "74f72c9a-ea61-4e11-a325-14e7e9cb45ad")
+		(net 19)
+	)
+	(segment
+		(start 139.0173 152.1149)
+		(end 136.6361 152.1149)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "8fc11b18-4c57-4324-ba83-9f763401bd5e")
+		(net 19)
+	)
+	(segment
+		(start 144.0728 176.7919)
+		(end 144.0728 176.0848)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "93c8ea6b-9b2d-4b5e-80f5-da3a99e25e9b")
+		(net 19)
+	)
+	(segment
+		(start 139.0723 152.3091)
+		(end 139.0173 152.1149)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "9509b87e-8249-4438-8f1f-e55e175e4648")
+		(net 19)
+	)
+	(segment
+		(start 144.0728 176.0848)
+		(end 144.1521 174.8509)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "9f3d87f6-88c8-432c-9875-a5388e772e17")
 		(net 19)
 	)
 	(segment
@@ -5217,15 +5209,15 @@
 		(end 144.1521 158.8177)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "fc59090e-a77d-427b-82c0-1ab82ba3935f")
+		(uuid "b273a58c-ee65-4a5b-b1c6-6e032d1a79d9")
 		(net 19)
 	)
-	(via
-		(at 144.1521 158.8177)
-		(size 0.6)
-		(drill 0.3)
-		(layers "F.Cu" "B.Cu")
-		(uuid "47927bfa-8769-4a6d-96b5-6fac76d20f66")
+	(segment
+		(start 143.7553 179.772)
+		(end 144.0728 176.7919)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "e81d188a-a422-4f75-b149-5a3b0554e458")
 		(net 19)
 	)
 	(via
@@ -5233,15 +5225,15 @@
 		(size 0.6)
 		(drill 0.3)
 		(layers "F.Cu" "B.Cu")
-		(uuid "e3c79e8b-fe80-4d6d-8743-354074ed8698")
+		(uuid "12161398-314f-4707-a3da-781e57275829")
 		(net 19)
 	)
-	(segment
-		(start 144.1521 158.8177)
-		(end 144.1521 157.389)
-		(width 0.2)
-		(layer "B.Cu")
-		(uuid "35ab2f9b-3d6d-4abf-9d91-b8109ff7d865")
+	(via
+		(at 144.1521 158.8177)
+		(size 0.6)
+		(drill 0.3)
+		(layers "F.Cu" "B.Cu")
+		(uuid "302efc39-9625-4955-b8ed-a2efa62d8894")
 		(net 19)
 	)
 	(segment
@@ -5249,7 +5241,15 @@
 		(end 139.0723 152.3091)
 		(width 0.2)
 		(layer "B.Cu")
-		(uuid "815e87c0-63f7-4e19-ace1-2b89f89ac116")
+		(uuid "453865ea-bbcd-4754-9c86-185e9a6f1f29")
+		(net 19)
+	)
+	(segment
+		(start 144.1521 158.8177)
+		(end 144.1521 157.389)
+		(width 0.2)
+		(layer "B.Cu")
+		(uuid "52914c08-75d9-463b-97d6-35cf683039aa")
 		(net 19)
 	)
 	(segment
@@ -5257,31 +5257,7 @@
 		(end 154.1705 154.549)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "13779220-19cc-4a7f-890e-4f09eee91310")
-		(net 20)
-	)
-	(segment
-		(start 154.1705 154.549)
-		(end 151.3131 157.4064)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "281e1ac1-4fc0-40ea-b752-8a001847f05d")
-		(net 20)
-	)
-	(segment
-		(start 150 157)
-		(end 148 159)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "62c95175-60a8-40b3-a39b-521180d0832b")
-		(net 20)
-	)
-	(segment
-		(start 148 159)
-		(end 148 161)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "859bcb6a-bc4f-4a08-8bb8-0f9f9ebc4b40")
+		(uuid "3afba613-1305-479f-bf31-036338bd1618")
 		(net 20)
 	)
 	(segment
@@ -5289,7 +5265,23 @@
 		(end 164.154 153.7378)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "b70c521b-e756-4905-a5d6-5e4c0c027d63")
+		(uuid "57890640-2616-4b04-bec2-2ccbec64cd91")
+		(net 20)
+	)
+	(segment
+		(start 148 159)
+		(end 148 161)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "7a797f26-51ca-4fe1-858d-3bd4df32d88f")
+		(net 20)
+	)
+	(segment
+		(start 154.1705 154.549)
+		(end 151.3131 157.4064)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "ae6aa559-b428-4f87-bf0f-6832f1d59fa0")
 		(net 20)
 	)
 	(segment
@@ -5297,23 +5289,23 @@
 		(end 150 157)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "b8cb7aea-74a1-41bb-8cf8-6535ea4132d0")
+		(uuid "bf6fc6aa-01c6-4f5e-b477-0c9d83bf71f4")
 		(net 20)
 	)
 	(segment
-		(start 154 161)
-		(end 154.1531 160.7226)
+		(start 150 157)
+		(end 148 159)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "0196563f-c2ef-4e32-8815-cbeb77683532")
-		(net 21)
+		(uuid "eda76986-9f3d-46a8-bd97-69557174414d")
+		(net 20)
 	)
 	(segment
-		(start 154.4706 161.5163)
-		(end 154.4706 161.9926)
+		(start 156.5342 157.5477)
+		(end 156 157)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "15ac69a3-a8f1-4034-87b1-a44246c479d2")
+		(uuid "6464fd0d-2003-4744-9c86-f2bd8816d39e")
 		(net 21)
 	)
 	(segment
@@ -5321,15 +5313,7 @@
 		(end 154.4706 161.5163)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "19fed90f-4b4e-4bb7-b187-c94d1b797a2e")
-		(net 21)
-	)
-	(segment
-		(start 156.5342 157.5477)
-		(end 156 157)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "5f3ad6e4-869b-4d59-b100-4199df61107f")
+		(uuid "6e8bd1c2-07c2-45bc-bc3d-aaea8627e8a7")
 		(net 21)
 	)
 	(segment
@@ -5337,15 +5321,7 @@
 		(end 164.154 155.3253)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "66bc81dd-08c4-4c70-b79e-770d23481edb")
-		(net 21)
-	)
-	(segment
-		(start 156.5342 158.3414)
-		(end 156.5342 157.5477)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "6fd5ae4f-96ad-42b9-a207-58c7c6e56a6c")
+		(uuid "720172a8-79e6-4266-9304-f2eead5d873b")
 		(net 21)
 	)
 	(segment
@@ -5353,15 +5329,31 @@
 		(end 165 155.46)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "ff50e8b5-d697-4bba-b834-1a67e3414e1a")
+		(uuid "96eb6a13-5f28-4b1b-8704-db58d38850f4")
 		(net 21)
 	)
-	(via
-		(at 163.3603 155.3253)
-		(size 0.6)
-		(drill 0.3)
-		(layers "F.Cu" "B.Cu")
-		(uuid "3a3525b4-753d-4e09-bb0c-7b35f0dabae6")
+	(segment
+		(start 154.4706 161.5163)
+		(end 154.4706 161.9926)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "9fb56a89-5bb5-4a84-9c5a-38191b992aa5")
+		(net 21)
+	)
+	(segment
+		(start 154 161)
+		(end 154.1531 160.7226)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "c3682a0a-bd4c-4af4-bd9f-cbf689233ae1")
+		(net 21)
+	)
+	(segment
+		(start 156.5342 158.3414)
+		(end 156.5342 157.5477)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "ee4b3156-7f51-4220-ad23-b7b51f5d7f0f")
 		(net 21)
 	)
 	(via
@@ -5369,15 +5361,15 @@
 		(size 0.6)
 		(drill 0.3)
 		(layers "F.Cu" "B.Cu")
-		(uuid "5bd43527-1b85-48dd-845c-25cc7fddf6df")
+		(uuid "54607188-aef5-486d-b8af-a81f2a4c7859")
 		(net 21)
 	)
 	(via
-		(at 154.1531 160.7226)
+		(at 163.3603 155.3253)
 		(size 0.6)
 		(drill 0.3)
 		(layers "F.Cu" "B.Cu")
-		(uuid "cb525d7f-9c8b-4681-84d1-459da87e6c7d")
+		(uuid "bdd8aca7-279a-4aa5-bef2-11000f6b148e")
 		(net 21)
 	)
 	(via
@@ -5385,23 +5377,15 @@
 		(size 0.6)
 		(drill 0.3)
 		(layers "F.Cu" "B.Cu")
-		(uuid "f1990e4b-0e25-4b3b-bda8-1e056eb95319")
+		(uuid "cb1967bc-9a73-47d5-a5a1-520488951222")
 		(net 21)
 	)
-	(segment
-		(start 157.1169 160.6703)
-		(end 162.038 155.7492)
-		(width 0.2)
-		(layer "B.Cu")
-		(uuid "00685879-af41-4803-bbc0-96df4eaef2c8")
-		(net 21)
-	)
-	(segment
-		(start 162.038 155.7492)
-		(end 163.3603 155.3253)
-		(width 0.2)
-		(layer "B.Cu")
-		(uuid "40eb7a8c-aa16-4257-ba22-3f0e14703c6e")
+	(via
+		(at 154.1531 160.7226)
+		(size 0.6)
+		(drill 0.3)
+		(layers "F.Cu" "B.Cu")
+		(uuid "ef918c29-962b-446c-ac8d-cc912f681070")
 		(net 21)
 	)
 	(segment
@@ -5409,7 +5393,23 @@
 		(end 156.5342 158.3414)
 		(width 0.2)
 		(layer "B.Cu")
-		(uuid "6f535c4d-b6e8-42e4-9444-5c7067745d62")
+		(uuid "8a1ef0ab-56e8-4ce6-b1d5-50d259e59508")
+		(net 21)
+	)
+	(segment
+		(start 162.038 155.7492)
+		(end 163.3603 155.3253)
+		(width 0.2)
+		(layer "B.Cu")
+		(uuid "93b1fb10-686d-4ab0-a7af-0d94deb2fe52")
+		(net 21)
+	)
+	(segment
+		(start 157.1169 160.6703)
+		(end 162.038 155.7492)
+		(width 0.2)
+		(layer "B.Cu")
+		(uuid "ab1d2cd4-69e9-4c84-9f6b-934ec075e46f")
 		(net 21)
 	)
 	(segment
@@ -5417,39 +5417,15 @@
 		(end 157.1169 160.6703)
 		(width 0.2)
 		(layer "B.Cu")
-		(uuid "88971ce8-7a14-4a22-8d84-6cce0cf43de3")
+		(uuid "ffd591b6-1f92-4b93-8d80-1399f35a4d41")
 		(net 21)
 	)
 	(segment
-		(start 159.1324 160.9819)
-		(end 160 161)
+		(start 162 157)
+		(end 162.4078 157.4271)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "17b3bb7c-ebcd-4e61-a41d-651d9127852d")
-		(net 22)
-	)
-	(segment
-		(start 140.4 154.175)
-		(end 140.501 153.5791)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "1b99ce54-6120-4684-aa37-147e8a82c2d4")
-		(net 22)
-	)
-	(segment
-		(start 160 161)
-		(end 162 159)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "1c745f6e-d2df-4c53-9629-566270c42240")
-		(net 22)
-	)
-	(segment
-		(start 153.2006 159.6114)
-		(end 158.1799 160.0294)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "66018b27-987d-40af-b38d-e395b2984ae5")
+		(uuid "21539ceb-9935-4914-bb6c-beeb7777cbcf")
 		(net 22)
 	)
 	(segment
@@ -5457,39 +5433,15 @@
 		(end 153.2006 159.6114)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "7192156a-4e7d-40db-8249-32b9700e0c6f")
+		(uuid "288d5f9b-4457-4ffa-a08c-9a4bf95753be")
 		(net 22)
 	)
 	(segment
-		(start 162 159)
-		(end 162 157)
+		(start 160 161)
+		(end 162 159)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "7ba80a8d-0002-4f75-aefe-10ebff033e87")
-		(net 22)
-	)
-	(segment
-		(start 164.154 157.4271)
-		(end 165 158)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "87d44202-612d-4258-aebb-8f0e0d5cff5b")
-		(net 22)
-	)
-	(segment
-		(start 140.501 153.5791)
-		(end 140.501 149.1342)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "972c87b3-5299-4489-9972-c8afb4b4c214")
-		(net 22)
-	)
-	(segment
-		(start 162 157)
-		(end 162.4078 157.4271)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "b563ea26-2230-41f1-bab3-81a6db21f62d")
+		(uuid "3f038682-2c42-4c75-89bb-849af6a642c8")
 		(net 22)
 	)
 	(segment
@@ -5497,23 +5449,63 @@
 		(end 164.154 157.4271)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "be405a70-7e72-4efa-9a53-91c10344de26")
+		(uuid "49113985-858b-4bc9-af9d-82cf2a1b39ff")
 		(net 22)
 	)
 	(segment
-		(start 158.1799 160.0294)
-		(end 159.1324 160.9819)
+		(start 153.2006 159.6114)
+		(end 158.3598 159.8495)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "d258bbb8-3998-4866-b355-ffb3546a56c2")
+		(uuid "51f9a515-831d-4777-ac29-353f06f4b65c")
 		(net 22)
 	)
-	(via
-		(at 151.6132 158.024)
-		(size 0.6)
-		(drill 0.3)
-		(layers "F.Cu" "B.Cu")
-		(uuid "0f896cf2-5f0c-483e-9bbb-7d20c7a2af47")
+	(segment
+		(start 159.3123 160.802)
+		(end 160 161)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "71dd95a7-debe-4062-a284-9695a2734d5f")
+		(net 22)
+	)
+	(segment
+		(start 158.3598 159.8495)
+		(end 159.3123 160.802)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "76bc6e7e-c904-40bc-a31c-1422a9f865fa")
+		(net 22)
+	)
+	(segment
+		(start 164.154 157.4271)
+		(end 165 158)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "9c1cd5e6-602f-42cd-8bf4-47633ef26ab3")
+		(net 22)
+	)
+	(segment
+		(start 140.501 153.5791)
+		(end 140.501 149.1342)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "a72654f3-76a4-443d-bd03-caaca495a781")
+		(net 22)
+	)
+	(segment
+		(start 140.4 154.175)
+		(end 140.501 153.5791)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "ad454b56-ffe9-4225-a3e9-a4a50c01bce0")
+		(net 22)
+	)
+	(segment
+		(start 162 159)
+		(end 162 157)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "d6b2d4a2-5ec0-4a9b-bf3e-a6e2ba2bbc07")
 		(net 22)
 	)
 	(via
@@ -5521,7 +5513,15 @@
 		(size 0.6)
 		(drill 0.3)
 		(layers "F.Cu" "B.Cu")
-		(uuid "d7255e80-e50a-4010-8aff-2d96ebc4fade")
+		(uuid "4004b63d-7b7f-49c5-825a-5a47411f5f24")
+		(net 22)
+	)
+	(via
+		(at 151.6132 158.024)
+		(size 0.6)
+		(drill 0.3)
+		(layers "F.Cu" "B.Cu")
+		(uuid "8668788e-553f-4ae7-a799-e601d49cb4cd")
 		(net 22)
 	)
 	(segment
@@ -5529,7 +5529,7 @@
 		(end 151.6132 158.024)
 		(width 0.2)
 		(layer "B.Cu")
-		(uuid "4781a642-935c-48c6-a370-13ce57e776d3")
+		(uuid "19e3e03f-9c83-479d-be7b-b48c802952d2")
 		(net 22)
 	)
 	(segment
@@ -5537,207 +5537,15 @@
 		(end 142.7234 149.1342)
 		(width 0.2)
 		(layer "B.Cu")
-		(uuid "7abf2ce9-b53f-4517-94ba-891d7d256ae6")
+		(uuid "933d98f4-245b-49da-819c-54739e546347")
 		(net 22)
 	)
 	(segment
-		(start 143.5172 147.7849)
-		(end 142.7234 147.7849)
+		(start 157.5017 138.4983)
+		(end 155.2643 138.4983)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "c3061d13-40d6-45f7-87c4-5d8ac64b0e02")
-		(net 23)
-	)
-	(segment
-		(start 142.7234 147.7849)
-		(end 142.4059 147.5468)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "d0a126bc-1836-46d2-a16c-557ac48701f2")
-		(net 23)
-	)
-	(segment
-		(start 144.175 148)
-		(end 143.5172 147.7849)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "fa0bf575-c499-4ced-ba2d-91e6b476066b")
-		(net 23)
-	)
-	(via
-		(at 142.4059 147.5468)
-		(size 0.6)
-		(drill 0.3)
-		(layers "F.Cu" "B.Cu")
-		(uuid "d7f72246-6aef-49f4-bf65-01d07296a57e")
-		(net 23)
-	)
-	(segment
-		(start 142.4059 147.5468)
-		(end 142.8028 140.0064)
-		(width 0.2)
-		(layer "B.Cu")
-		(uuid "0ab4f949-a9e6-45e9-b108-a4fefcaaf856")
-		(net 23)
-	)
-	(segment
-		(start 164.5509 118.2583)
-		(end 165 118.19)
-		(width 0.2)
-		(layer "B.Cu")
-		(uuid "58f21ebc-adcf-44cf-b5b2-5700a94caff9")
-		(net 23)
-	)
-	(segment
-		(start 142.8028 140.0064)
-		(end 164.5509 118.2583)
-		(width 0.2)
-		(layer "B.Cu")
-		(uuid "ceb90116-770d-48ce-a261-b3cbb45e0d0d")
-		(net 23)
-	)
-	(segment
-		(start 144.7871 147.0705)
-		(end 144.7871 144.3719)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "5125c301-26fd-42b6-8804-05d3d372b6d1")
-		(net 24)
-	)
-	(segment
-		(start 144.175 147.2)
-		(end 144.7871 147.0705)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "f96feba3-a5a1-4c24-9512-f0f43683bfdb")
-		(net 24)
-	)
-	(via
-		(at 144.7871 144.3719)
-		(size 0.6)
-		(drill 0.3)
-		(layers "F.Cu" "B.Cu")
-		(uuid "e911fcab-87dd-40f7-b97d-60f1ab780eb2")
-		(net 24)
-	)
-	(segment
-		(start 163.7523 120.3268)
-		(end 165 120.73)
-		(width 0.2)
-		(layer "B.Cu")
-		(uuid "0844b321-04e0-4dc7-84e2-8c13a98d122b")
-		(net 24)
-	)
-	(segment
-		(start 144.8665 139.0539)
-		(end 163.6729 120.2475)
-		(width 0.2)
-		(layer "B.Cu")
-		(uuid "cf94799d-9750-4392-990d-295f8158dafb")
-		(net 24)
-	)
-	(segment
-		(start 163.6729 120.2475)
-		(end 163.7523 120.3268)
-		(width 0.2)
-		(layer "B.Cu")
-		(uuid "ddd34048-3a82-41c0-9e24-33667ee6b18d")
-		(net 24)
-	)
-	(segment
-		(start 144.7871 144.3719)
-		(end 144.8665 139.0539)
-		(width 0.2)
-		(layer "B.Cu")
-		(uuid "de4caa42-d1f4-4600-bd3c-5246d28ca5b8")
-		(net 24)
-	)
-	(segment
-		(start 142.3266 145.1656)
-		(end 142.407 144.61)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "3b525b34-98aa-484e-9f2d-4078ac1ef912")
-		(net 25)
-	)
-	(segment
-		(start 148.3942 139.3657)
-		(end 150.2187 139.2864)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "3f4bf59b-197e-4cf6-a7fb-c592d89dc5dd")
-		(net 25)
-	)
-	(segment
-		(start 142 145.825)
-		(end 142.3266 145.1656)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "69dfe140-929a-4ea3-a351-ed8c9d37f5a4")
-		(net 25)
-	)
-	(segment
-		(start 150.2187 139.2864)
-		(end 150.5019 138.8158)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "e9a2f60c-7e58-4178-b045-6818fba3bfbf")
-		(net 25)
-	)
-	(segment
-		(start 142.407 144.61)
-		(end 148.3942 139.3657)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "f56c933f-b3a3-427e-b6d9-062fe69c826c")
-		(net 25)
-	)
-	(via
-		(at 150.5019 138.8158)
-		(size 0.6)
-		(drill 0.3)
-		(layers "F.Cu" "B.Cu")
-		(uuid "9fe8ed95-06c2-4154-8893-5fb57649fdcd")
-		(net 25)
-	)
-	(segment
-		(start 150.5019 138.8158)
-		(end 153.0419 136.2759)
-		(width 0.2)
-		(layer "B.Cu")
-		(uuid "11269321-711e-438c-805c-6ac341a8904c")
-		(net 25)
-	)
-	(segment
-		(start 153.1212 134.7677)
-		(end 164.2333 123.6556)
-		(width 0.2)
-		(layer "B.Cu")
-		(uuid "545d7852-36a4-4625-9ff6-539f5583be5c")
-		(net 25)
-	)
-	(segment
-		(start 164.2333 123.6556)
-		(end 165 123.27)
-		(width 0.2)
-		(layer "B.Cu")
-		(uuid "7bbfb6c7-d2eb-4251-a1d5-681bd5aa3cfb")
-		(net 25)
-	)
-	(segment
-		(start 153.0419 136.2759)
-		(end 153.1212 134.7677)
-		(width 0.2)
-		(layer "B.Cu")
-		(uuid "bf79faa0-f2ff-421a-85b4-a86f3f68d5ee")
-		(net 25)
-	)
-	(segment
-		(start 158.7252 137.8616)
-		(end 158.8045 137.4884)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "7a44de64-2362-48de-a2d8-ea1590cdd9da")
+		(uuid "02d85de6-5f35-40ab-8619-7a7275018dc9")
 		(net 27)
 	)
 	(segment
@@ -5745,23 +5553,7 @@
 		(end 159 137)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "7ed93214-9818-4dda-9b1f-574bf1911c95")
-		(net 27)
-	)
-	(segment
-		(start 149.56 137)
-		(end 150.2638 136.9902)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "80adf0c2-d74f-480f-8c98-d5caaa49cc99")
-		(net 27)
-	)
-	(segment
-		(start 151.6925 138.4189)
-		(end 158.4948 138.4189)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "8b450cb7-1158-45cb-bfb5-033ca8017b2f")
+		(uuid "21147a22-dfdd-452e-a648-ee2dc82cfa44")
 		(net 27)
 	)
 	(segment
@@ -5769,7 +5561,7 @@
 		(end 158.7252 137.8616)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "94dc56a6-4496-44b4-be70-5fb40db08c54")
+		(uuid "2b0d2f71-0841-4343-bbdc-644a305a3658")
 		(net 27)
 	)
 	(segment
@@ -5777,7 +5569,23 @@
 		(end 157.5017 138.4983)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "cf473c94-c3f2-4d2c-a1c9-7b921c8b6833")
+		(uuid "2f84ee32-df56-481c-9c10-ecad5a7a8327")
+		(net 27)
+	)
+	(segment
+		(start 151.6925 138.4189)
+		(end 158.4948 138.4189)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "8f642764-39c0-4091-9a54-d82dbe0a0dd0")
+		(net 27)
+	)
+	(segment
+		(start 149.56 137)
+		(end 150.2638 136.9902)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "d1bf0259-1302-4f78-8d8b-b922ffcf23dc")
 		(net 27)
 	)
 	(segment
@@ -5785,135 +5593,23 @@
 		(end 151.6925 138.4189)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "ee06dc31-0c0b-4b35-adea-5bf947e1ff30")
+		(uuid "ec924b9c-00cb-4750-b405-d8786f550b60")
 		(net 27)
 	)
 	(segment
-		(start 157.5017 138.4983)
-		(end 155.2643 138.4983)
+		(start 158.7252 137.8616)
+		(end 158.8045 137.4884)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "ff1e6bdf-3080-4c0e-95d2-561fd0292a5a")
+		(uuid "f720aca5-7455-4af2-aa29-fe1dce67aa09")
 		(net 27)
-	)
-	(segment
-		(start 159.7091 142.3082)
-		(end 159.5504 142.4669)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "0e4e56e7-bb8b-4f5b-970d-d318470864b8")
-		(net 28)
-	)
-	(segment
-		(start 158.3697 143.3485)
-		(end 143.8623 155.0162)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "1145d872-6396-4217-a39e-b0f8c5056bb6")
-		(net 28)
 	)
 	(segment
 		(start 134.901 153.6529)
 		(end 134.3893 153.1584)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "16b2bdf8-32f5-4992-8f32-9902a0b74288")
-		(net 28)
-	)
-	(segment
-		(start 134.3892 149.2136)
-		(end 134.548 149.0549)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "1adef116-a7c4-497e-8414-53be814943e2")
-		(net 28)
-	)
-	(segment
-		(start 136.3974 155.5634)
-		(end 135.9308 155.1324)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "2cd14cac-d624-4ec7-ba17-34384c60393c")
-		(net 28)
-	)
-	(segment
-		(start 159.5504 142.4669)
-		(end 159 143)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "2d62225d-2074-4c21-b74e-e9920119b743")
-		(net 28)
-	)
-	(segment
-		(start 159 143)
-		(end 158.3697 143.3485)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "5820a581-544e-4739-8e6a-20d15c9b364a")
-		(net 28)
-	)
-	(segment
-		(start 158.9154 141.5145)
-		(end 159.7091 142.3082)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "5976f85d-b73f-43e0-b02e-2b595a7d8c9a")
-		(net 28)
-	)
-	(segment
-		(start 143.8623 155.0162)
-		(end 142.7234 155.5634)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "7b0f75eb-d81e-4bf7-98da-f1bad112d489")
-		(net 28)
-	)
-	(segment
-		(start 135.0936 154.0569)
-		(end 134.901 153.6529)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "8917435b-eed0-40f0-8c7e-536b569ca9ae")
-		(net 28)
-	)
-	(segment
-		(start 134.548 149.0549)
-		(end 135.1037 148.9755)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "93c0f31a-a8db-4699-8e41-b43db3ecea1d")
-		(net 28)
-	)
-	(segment
-		(start 135.1037 148.9755)
-		(end 135.825 148.8)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "ce74c309-5356-4943-a21a-cf2d8062c5d2")
-		(net 28)
-	)
-	(segment
-		(start 135.9308 155.1324)
-		(end 135.6152 154.5521)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "e8c09183-7647-4317-a51f-7cca48f109ce")
-		(net 28)
-	)
-	(segment
-		(start 135.6152 154.5521)
-		(end 135.0936 154.0569)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "ec552c9b-d216-447b-a539-e4c38ddd76c4")
-		(net 28)
-	)
-	(segment
-		(start 134.3893 153.1584)
-		(end 134.3892 149.2136)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "f145e159-1dba-467d-8a3c-11205aee819b")
+		(uuid "169f92d1-141b-49a5-9a92-c9d84d2561ad")
 		(net 28)
 	)
 	(segment
@@ -5921,7 +5617,119 @@
 		(end 136.3974 155.5634)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "f36ef1ba-ca55-4ec5-9c6a-b22192672075")
+		(uuid "24d0aaf3-21c2-4b24-9431-4bde352508f6")
+		(net 28)
+	)
+	(segment
+		(start 158.9154 141.5145)
+		(end 159.7091 142.3082)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "2f04c3d3-8557-4dea-bc45-c0c254535206")
+		(net 28)
+	)
+	(segment
+		(start 135.0936 154.0569)
+		(end 134.901 153.6529)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "30360f27-2f54-4297-9867-abbe97eb2c52")
+		(net 28)
+	)
+	(segment
+		(start 143.8623 155.0162)
+		(end 142.7234 155.5634)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "43ee535b-8dd3-4fa1-a886-b3b139d898b3")
+		(net 28)
+	)
+	(segment
+		(start 134.3892 149.2136)
+		(end 134.548 149.0549)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "4d10e285-c8b4-4b2a-9965-4db51b8a5e26")
+		(net 28)
+	)
+	(segment
+		(start 136.3974 155.5634)
+		(end 135.9308 155.1324)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "514f108c-2d63-4546-8498-efa14fbda654")
+		(net 28)
+	)
+	(segment
+		(start 158.3697 143.3485)
+		(end 143.8623 155.0162)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "54191d6c-cb52-447d-a85b-76a223fcbf18")
+		(net 28)
+	)
+	(segment
+		(start 159.7091 142.3082)
+		(end 159.5504 142.4669)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "5e3dd3eb-c64c-4a6d-b5e3-2c1d605b0e3d")
+		(net 28)
+	)
+	(segment
+		(start 159.5504 142.4669)
+		(end 159 143)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "5e94f728-65aa-4d85-a821-08ae65ba8e1e")
+		(net 28)
+	)
+	(segment
+		(start 135.9308 155.1324)
+		(end 135.6152 154.5521)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "6f162672-59a5-490c-b9e8-ae35fc333c46")
+		(net 28)
+	)
+	(segment
+		(start 135.6152 154.5521)
+		(end 135.0936 154.0569)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "75ccd5fd-a307-4fe8-9634-036fb4019bfc")
+		(net 28)
+	)
+	(segment
+		(start 159 143)
+		(end 158.3697 143.3485)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "a0fc9488-3c54-4eb0-b423-68d5a3f5b6e5")
+		(net 28)
+	)
+	(segment
+		(start 134.3893 153.1584)
+		(end 134.3892 149.2136)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "ad152473-467e-42b1-80f8-ebb7d286bf16")
+		(net 28)
+	)
+	(segment
+		(start 135.1037 148.9755)
+		(end 135.825 148.8)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "c635c89f-c8c1-45ef-920d-4c141d1b1610")
+		(net 28)
+	)
+	(segment
+		(start 134.548 149.0549)
+		(end 135.1037 148.9755)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "e0074f81-b74c-4fec-8662-a5a325369775")
 		(net 28)
 	)
 	(via
@@ -5929,7 +5737,7 @@
 		(size 0.6)
 		(drill 0.3)
 		(layers "F.Cu" "B.Cu")
-		(uuid "01e5321a-2262-4c0b-ab88-6eb24407c2e1")
+		(uuid "fc405c51-bf96-4562-9db4-928d4a6f5df0")
 		(net 28)
 	)
 	(segment
@@ -5937,7 +5745,7 @@
 		(end 158.9154 141.5145)
 		(width 0.2)
 		(layer "B.Cu")
-		(uuid "4775b1c1-8f9b-4b2c-b814-178a3cd6381c")
+		(uuid "794beeed-b6ab-4497-80a0-f13b22687968")
 		(net 28)
 	)
 	(segment
@@ -5945,15 +5753,23 @@
 		(end 155.1055 137.7046)
 		(width 0.2)
 		(layer "B.Cu")
-		(uuid "7b70ebf8-3823-4ddf-a039-c18b44e42e5b")
+		(uuid "ad9d71ea-4218-40a1-b3e1-9801034b7eb1")
 		(net 28)
+	)
+	(segment
+		(start 161.6147 108.4955)
+		(end 160.95 108)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "14bda8a9-1f3c-4c9d-b28c-770651e60370")
+		(net 30)
 	)
 	(segment
 		(start 161.6147 111.1379)
 		(end 161.6147 108.4955)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "8495472e-30a7-4f14-ad42-45795dc24c63")
+		(uuid "5dcf8c22-bade-46d3-ad9f-4bfe02ba6260")
 		(net 30)
 	)
 	(segment
@@ -5961,79 +5777,15 @@
 		(end 161.6147 111.1379)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "b712baef-00ae-44b4-9e63-67918f801ba5")
+		(uuid "ac24c167-c362-4f20-bf10-72b5e6527b0c")
 		(net 30)
-	)
-	(segment
-		(start 161.6147 108.4955)
-		(end 160.95 108)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "e8d1a14c-a257-4233-aeaf-849dd458d642")
-		(net 30)
-	)
-	(segment
-		(start 123.901 122.8508)
-		(end 124.5 122)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "110919bf-df52-42cd-a5d3-0b1ae8dfb092")
-		(net 31)
 	)
 	(segment
 		(start 116.4412 145.5626)
 		(end 115.8955 145.6418)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "1b5eec65-6339-4787-9426-d5cb3916d089")
-		(net 31)
-	)
-	(segment
-		(start 117.5512 129.2006)
-		(end 123.901 122.8508)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "1c061a2b-fe19-4f95-9e06-6d2937e5adcc")
-		(net 31)
-	)
-	(segment
-		(start 116.848 130.7198)
-		(end 117 130)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "2298d981-7746-4324-b80b-c35a1046178a")
-		(net 31)
-	)
-	(segment
-		(start 115.8955 131.6723)
-		(end 116.848 130.7198)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "3b950a30-009b-4e76-9978-9ff0c6806676")
-		(net 31)
-	)
-	(segment
-		(start 124.5 122)
-		(end 123.9915 123.1)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "a893167e-432a-4240-8d84-c325f5061d13")
-		(net 31)
-	)
-	(segment
-		(start 116.9174 146.0389)
-		(end 116.4412 145.5626)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "c095586a-a6e9-45ae-b687-3c6659a6989d")
-		(net 31)
-	)
-	(segment
-		(start 123.9915 123.1)
-		(end 123.8328 123.1)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "ddd0a15a-9fbb-469f-a4f7-0de9c6aeddd3")
+		(uuid "1f6af1d5-81c0-4c39-b37a-581a6c6131fd")
 		(net 31)
 	)
 	(segment
@@ -6041,7 +5793,7 @@
 		(end 117.75 146.25)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "e077dbb7-adc8-4ec6-bef8-7cd202c6a900")
+		(uuid "324bcdf5-b123-4df7-a7db-cf9278588ac4")
 		(net 31)
 	)
 	(segment
@@ -6049,7 +5801,63 @@
 		(end 117.5512 129.2006)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "e3728c4f-398a-4f6e-8baa-f1405a85adb2")
+		(uuid "43b6f973-32d6-4ba2-a96b-ec2f8ff34688")
+		(net 31)
+	)
+	(segment
+		(start 117.5512 129.2006)
+		(end 123.901 122.8508)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "7d43118c-392d-4575-972e-32e5450a55fc")
+		(net 31)
+	)
+	(segment
+		(start 116.9174 146.0389)
+		(end 116.4412 145.5626)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "7eca783f-b1c5-4cc2-923c-6d877dc6a598")
+		(net 31)
+	)
+	(segment
+		(start 123.9915 123.1)
+		(end 123.8328 123.1)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "86ae9ffd-7338-49b0-939e-fd94e436f5d7")
+		(net 31)
+	)
+	(segment
+		(start 123.901 122.8508)
+		(end 124.5 122)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "b559e898-dba3-4e38-9d13-4656d5e1c44e")
+		(net 31)
+	)
+	(segment
+		(start 116.848 130.7198)
+		(end 117 130)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "b5ab5ba9-24b5-4b8f-85b9-de541a8bba25")
+		(net 31)
+	)
+	(segment
+		(start 124.5 122)
+		(end 123.9915 123.1)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "c24ab8fc-ceb1-40f1-88b7-f571fe707ea3")
+		(net 31)
+	)
+	(segment
+		(start 115.8955 131.6723)
+		(end 116.848 130.7198)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "c43ca3f6-14bf-4b1d-9870-29ce66ba481c")
 		(net 31)
 	)
 	(segment
@@ -6057,15 +5865,7 @@
 		(end 116.9174 146.0389)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "f84481ef-61df-4616-a5c6-bbf0dc411653")
-		(net 31)
-	)
-	(via
-		(at 115.8955 145.6418)
-		(size 0.6)
-		(drill 0.3)
-		(layers "F.Cu" "B.Cu")
-		(uuid "807a038f-6197-4c1f-a6d3-8164bb16c01d")
+		(uuid "ccaf1710-3117-4587-a36d-a816e840ec7c")
 		(net 31)
 	)
 	(via
@@ -6073,7 +5873,15 @@
 		(size 0.6)
 		(drill 0.3)
 		(layers "F.Cu" "B.Cu")
-		(uuid "8edee12c-c611-415f-a0ca-5b67402135c2")
+		(uuid "34dea14f-ab4c-45f5-b653-b989925d1375")
+		(net 31)
+	)
+	(via
+		(at 115.8955 145.6418)
+		(size 0.6)
+		(drill 0.3)
+		(layers "F.Cu" "B.Cu")
+		(uuid "3e8cb0c1-4a6f-4317-9e02-0fe25271b32c")
 		(net 31)
 	)
 	(segment
@@ -6081,31 +5889,23 @@
 		(end 115.8955 131.6723)
 		(width 0.2)
 		(layer "B.Cu")
-		(uuid "dfc56309-33e3-483f-b2b6-9e25524583a7")
+		(uuid "5877343e-59b1-431c-87aa-404851c5fdbb")
 		(net 31)
+	)
+	(segment
+		(start 107.0058 161.6751)
+		(end 107 162)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "5ad3f885-694a-4198-8462-465a87d57f3b")
+		(net 32)
 	)
 	(segment
 		(start 119.129 147.4347)
 		(end 119.4672 147.1341)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "38ac7ffa-4bce-48c4-b8c8-d00297f04461")
-		(net 32)
-	)
-	(segment
-		(start 117.75 147.75)
-		(end 118.5734 147.53)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "763d6b22-fb1b-4ee0-8018-48a3794b29be")
-		(net 32)
-	)
-	(segment
-		(start 118.5734 147.53)
-		(end 119.129 147.4347)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "87f0d4dd-1dbd-4e61-bc8a-f1c7b01a81ce")
+		(uuid "8d70ef02-1d0a-42cc-a44c-f3ee081f8de8")
 		(net 32)
 	)
 	(segment
@@ -6113,23 +5913,23 @@
 		(end 119.5466 145.9593)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "9f367570-5d95-43a5-9ecd-e537a0a44ea2")
+		(uuid "9e4adf59-8fe1-4001-bacc-2eac83817005")
 		(net 32)
 	)
 	(segment
-		(start 107.0058 161.6751)
-		(end 107 162)
+		(start 118.5734 147.53)
+		(end 119.129 147.4347)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "e1b06576-4330-4fa7-90d5-999db737acd2")
+		(uuid "a0cb029d-ce28-4a28-be33-13e9b21a2f1f")
 		(net 32)
 	)
-	(via
-		(at 107.0058 161.6751)
-		(size 0.6)
-		(drill 0.3)
-		(layers "F.Cu" "B.Cu")
-		(uuid "1df63d84-7360-40c7-9d7a-32a5714bd238")
+	(segment
+		(start 117.75 147.75)
+		(end 118.5734 147.53)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "e9070eba-e350-4cdd-b088-2d29b0815b00")
 		(net 32)
 	)
 	(via
@@ -6137,15 +5937,15 @@
 		(size 0.6)
 		(drill 0.3)
 		(layers "F.Cu" "B.Cu")
-		(uuid "c797390a-21c3-49c2-9cf7-b8d2fbae6d6c")
+		(uuid "b26b2750-fc53-4e38-a71a-cb32cc4391a5")
 		(net 32)
 	)
-	(segment
-		(start 111.3009 155.5168)
-		(end 107.0058 161.6751)
-		(width 0.2)
-		(layer "B.Cu")
-		(uuid "2a4436df-be3f-432c-a4c9-003c3101c6f4")
+	(via
+		(at 107.0058 161.6751)
+		(size 0.6)
+		(drill 0.3)
+		(layers "F.Cu" "B.Cu")
+		(uuid "bca4bdc5-f860-4fa9-9599-72e8162cd94e")
 		(net 32)
 	)
 	(segment
@@ -6153,7 +5953,15 @@
 		(end 114.7842 150.7217)
 		(width 0.2)
 		(layer "B.Cu")
-		(uuid "9d4a3857-38c3-47f4-8678-1cf690876422")
+		(uuid "33ab44df-fa37-43f5-9397-423ce79e6d18")
+		(net 32)
+	)
+	(segment
+		(start 111.3009 155.5168)
+		(end 107.0058 161.6751)
+		(width 0.2)
+		(layer "B.Cu")
+		(uuid "d300b873-6f85-48ea-9231-f153eba020b7")
 		(net 32)
 	)
 	(segment
@@ -6161,7 +5969,7 @@
 		(end 111.3009 155.5168)
 		(width 0.2)
 		(layer "B.Cu")
-		(uuid "b8950910-a8d7-4423-808e-c89ce62a8fd9")
+		(uuid "dee57cee-e73c-45fd-9723-c03f17d31f45")
 		(net 32)
 	)
 	(segment
@@ -6169,39 +5977,15 @@
 		(end 111.8009 155.0168)
 		(width 0.2)
 		(layer "B.Cu")
-		(uuid "fc214822-7bb5-4289-a3e9-c4548c03e0be")
+		(uuid "fd198bb7-6725-4537-b4d7-c5a49703dece")
 		(net 32)
-	)
-	(segment
-		(start 117.75 152.75)
-		(end 118.7823 152.8929)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "002008ad-a93d-4ee5-b407-500a10d81bed")
-		(net 34)
-	)
-	(segment
-		(start 118.7823 152.8929)
-		(end 120.6873 152.8929)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "2f20e855-5539-498d-bbc0-02f0796ecf0b")
-		(net 34)
 	)
 	(segment
 		(start 129.5476 161.9926)
 		(end 138.5961 161.9926)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "8c14bd36-bc27-4f15-81e5-b779642f8ebf")
-		(net 34)
-	)
-	(segment
-		(start 120.6873 152.8929)
-		(end 129.5476 161.9926)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "cb1ec803-d57b-4519-898d-c39d8ff28b90")
+		(uuid "19501292-a1c6-414e-8c82-479fe4e791d1")
 		(net 34)
 	)
 	(segment
@@ -6209,15 +5993,39 @@
 		(end 139 162)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "d55ce85e-9d6d-428e-bbbd-f80a756595eb")
+		(uuid "2a7ac94b-bec3-4759-a513-83d4e2cf0353")
 		(net 34)
 	)
 	(segment
-		(start 109.5457 151.3567)
-		(end 108.4345 151.3567)
+		(start 117.75 152.75)
+		(end 118.7823 152.8929)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "12fa21e7-c77b-4020-988a-d42ebf56b833")
+		(uuid "5a6fdbe7-b603-4e78-9848-ef83ecaf5999")
+		(net 34)
+	)
+	(segment
+		(start 118.7823 152.8929)
+		(end 120.6873 152.8929)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "81b1d1ad-fb3d-4b7a-8375-8d3033176968")
+		(net 34)
+	)
+	(segment
+		(start 120.6873 152.8929)
+		(end 129.5476 161.9926)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "d7a0181a-4bc7-428e-906f-ca99ef3593c0")
+		(net 34)
+	)
+	(segment
+		(start 143.0409 151.9123)
+		(end 143.5172 151.9123)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "37d97898-441a-406b-a0c9-47c7c76d7792")
 		(net 35)
 	)
 	(segment
@@ -6225,23 +6033,7 @@
 		(end 144.175 152)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "19fa4854-7338-4506-8f2f-72af9a8d6d3c")
-		(net 35)
-	)
-	(segment
-		(start 110.25 151.25)
-		(end 109.5457 151.3567)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "4ac1b047-a396-4ca9-8cb2-6b99138bdd4d")
-		(net 35)
-	)
-	(segment
-		(start 143.0409 151.9123)
-		(end 143.5172 151.9123)
-		(width 0.2)
-		(layer "F.Cu")
-		(uuid "983e279c-3e3c-447e-8920-91d8481e5513")
+		(uuid "5bba39f1-3613-4692-a96f-01ebdee7f027")
 		(net 35)
 	)
 	(segment
@@ -6249,7 +6041,23 @@
 		(end 143.0409 151.9123)
 		(width 0.2)
 		(layer "F.Cu")
-		(uuid "bc9cb3c4-0b70-49b8-b2fb-aa011ca00559")
+		(uuid "6bf1c089-a58e-4aeb-8f0e-f61293a19e30")
+		(net 35)
+	)
+	(segment
+		(start 110.25 151.25)
+		(end 109.5457 151.3567)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "7a66684c-a263-4e48-b48e-96ea7228367a")
+		(net 35)
+	)
+	(segment
+		(start 109.5457 151.3567)
+		(end 108.4345 151.3567)
+		(width 0.2)
+		(layer "F.Cu")
+		(uuid "b68ee11e-2cdd-4b10-bd1c-4664f7962527")
 		(net 35)
 	)
 	(via
@@ -6257,7 +6065,7 @@
 		(size 0.6)
 		(drill 0.3)
 		(layers "F.Cu" "B.Cu")
-		(uuid "38a8c5b9-e415-42db-9f37-56b1b740b488")
+		(uuid "a044f048-f71c-4f6b-bcfa-89c3a07215e5")
 		(net 35)
 	)
 	(via
@@ -6265,15 +6073,7 @@
 		(size 0.6)
 		(drill 0.3)
 		(layers "F.Cu" "B.Cu")
-		(uuid "f94be33b-6744-4103-b71b-48221b7c309d")
-		(net 35)
-	)
-	(segment
-		(start 118.8756 151.0736)
-		(end 119.5828 151.0736)
-		(width 0.2)
-		(layer "B.Cu")
-		(uuid "4a87cb8a-eb1d-44e8-a989-4e34bdc4a8fd")
+		(uuid "c46cf6a3-4e7f-488b-b855-dee4a0a5e86e")
 		(net 35)
 	)
 	(segment
@@ -6281,7 +6081,7 @@
 		(end 141.771 150.7217)
 		(width 0.2)
 		(layer "B.Cu")
-		(uuid "6a6c6e72-07b5-459f-a1d1-89c5ebbfebed")
+		(uuid "48348a14-73a6-4234-9415-19f065a73cd8")
 		(net 35)
 	)
 	(segment
@@ -6289,15 +6089,7 @@
 		(end 118.8756 151.0736)
 		(width 0.2)
 		(layer "B.Cu")
-		(uuid "a4519a29-f179-42b6-9262-f891dad1b9e1")
-		(net 35)
-	)
-	(segment
-		(start 108.4345 151.3567)
-		(end 115.2605 151.3567)
-		(width 0.2)
-		(layer "B.Cu")
-		(uuid "b5e9bff0-c522-428e-8f5f-a797d83a565c")
+		(uuid "661e82ce-a961-4246-855e-05ea6a247a42")
 		(net 35)
 	)
 	(segment
@@ -6305,13 +6097,58 @@
 		(end 123.8328 150.7468)
 		(width 0.2)
 		(layer "B.Cu")
-		(uuid "dd0906c9-e3fd-4da2-80eb-b5a3bd6891cd")
+		(uuid "9a6059f8-5bb1-44dc-9a12-261a6cfb7470")
 		(net 35)
+	)
+	(segment
+		(start 108.4345 151.3567)
+		(end 115.2605 151.3567)
+		(width 0.2)
+		(layer "B.Cu")
+		(uuid "a175fe4c-542a-4cc2-9510-b602cbf5687a")
+		(net 35)
+	)
+	(segment
+		(start 118.8756 151.0736)
+		(end 119.5828 151.0736)
+		(width 0.2)
+		(layer "B.Cu")
+		(uuid "a995e548-6e5c-4b47-92a4-cef48c1d0380")
+		(net 35)
+	)
+	(zone
+		(net "VMOTOR")
+		(layer "F.Cu")
+		(uuid "95eab984-0bf3-4e0d-9fb8-ceb4e9caf40e")
+		(hatch edge 0.5)
+		(priority 4)
+		(connect_pads (clearance 0.3)
+		)
+		(min_thickness 0.25)
+		(fill yes (thermal_gap 0.3) (thermal_bridge_width 0.4) (island_removal_mode 0)
+		)
+		(polygon (pts (xy 101.5 105.23) (xy 141.5 105.23) (xy 141.5 169.5) (xy 101.5 169.5))
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts (xy 141.443039 105.249685) (xy 141.488794 105.302489) (xy 141.5 105.354) (xy 141.5 118.5255) (xy 141.480315 118.592539) (xy 141.427511 118.638294) (xy 141.376 118.6495) (xy 139.805143 118.6495) (xy 139.805117 118.649502) (xy 139.780012 118.652413) (xy 139.780008 118.652415) (xy 139.677235 118.697793) (xy 139.597794 118.777234) (xy 139.552415 118.880006) (xy 139.552415 118.880008) (xy 139.5495 118.905131) (xy 139.5495 120.494856) (xy 139.549502 120.494882) (xy 139.552413 120.519987) (xy 139.552415 120.519991) (xy 139.597793 120.622764) (xy 139.597794 120.622765) (xy 139.677235 120.702206) (xy 139.741952 120.730781) (xy 139.755053 120.736566) (xy 139.808429 120.781652) (xy 139.828956 120.848438) (xy 139.810118 120.91572) (xy 139.757894 120.962137) (xy 139.755053 120.963434) (xy 139.677234 120.997794) (xy 139.597794 121.077234) (xy 139.552415 121.180006) (xy 139.552415 121.180008) (xy 139.5495 121.205131) (xy 139.5495 122.794856) (xy 139.549502 122.794882) (xy 139.552413 122.819987) (xy 139.552415 122.819991) (xy 139.597793 122.922764) (xy 139.597794 122.922765) (xy 139.677235 123.002206) (xy 139.741952 123.030781) (xy 139.755053 123.036566) (xy 139.808429 123.081652) (xy 139.828956 123.148438) (xy 139.810118 123.21572) (xy 139.757894 123.262137) (xy 139.755053 123.263434) (xy 139.677234 123.297794) (xy 139.597794 123.377234) (xy 139.552415 123.480006) (xy 139.552415 123.480008) (xy 139.5495 123.505131) (xy 139.5495 125.094856) (xy 139.549502 125.094882) (xy 139.552413 125.119987) (xy 139.552415 125.119991) (xy 139.597793 125.222764) (xy 139.597794 125.222765) (xy 139.677235 125.302206) (xy 139.780009 125.347585) (xy 139.805135 125.3505) (xy 141.376 125.350499) (xy 141.443039 125.370184) (xy 141.488794 125.422987) (xy 141.5 125.474499) (xy 141.5 135.934563) (xy 141.480315 136.001602) (xy 141.427511 136.047357) (xy 141.361218 136.057679) (xy 141.319884 136.052716) (xy 141.293102 136.0495) (xy 140.706898 136.0495) (xy 140.667853 136.054188) (xy 140.618438 136.060122) (xy 140.477656 136.115639) (xy 140.357077 136.207077) (xy 140.265639 136.327656) (xy 140.210122 136.468438) (xy 140.204188 136.517853) (xy 140.1995 136.556898) (xy 140.1995 137.443102) (xy 140.205126 137.489954) (xy 140.210122 137.531561) (xy 140.265639 137.672343) (xy 140.357077 137.792922) (xy 140.477656 137.88436) (xy 140.477657 137.88436) (xy 140.477658 137.884361) (xy 140.618436 137.939877) (xy 140.706898 137.9505) (xy 140.706903 137.9505) (xy 141.293096 137.9505) (xy 141.293102 137.9505) (xy 141.361217 137.94232) (xy 141.430124 137.953872) (xy 141.481848 138.000844) (xy 141.5 138.065436) (xy 141.5 144.651727) (xy 141.480315 144.718766) (xy 141.427511 144.764521) (xy 141.363442 144.773733) (xy 141.363352 144.774882) (xy 141.358495 144.7745) (xy 141.358488 144.7745) (xy 141.041512 144.7745) (xy 141.041507 144.7745) (xy 140.941876 144.790279) (xy 140.856294 144.833886) (xy 140.787625 144.846782) (xy 140.743706 144.833886) (xy 140.658123 144.790279) (xy 140.558493 144.7745) (xy 140.558488 144.7745) (xy 140.241512 144.7745) (xy 140.241507 144.7745) (xy 140.141876 144.790279) (xy 140.056294 144.833886) (xy 139.987625 144.846782) (xy 139.943706 144.833886) (xy 139.858123 144.790279) (xy 139.758493 144.7745) (xy 139.758488 144.7745) (xy 139.441512 144.7745) (xy 139.441507 144.7745) (xy 139.341876 144.790279) (xy 139.256294 144.833886) (xy 139.187625 144.846782) (xy 139.143706 144.833886) (xy 139.058123 144.790279) (xy 138.958493 144.7745) (xy 138.958488 144.7745) (xy 138.641512 144.7745) (xy 138.641507 144.7745) (xy 138.541876 144.790279) (xy 138.456294 144.833886) (xy 138.387625 144.846782) (xy 138.343706 144.833886) (xy 138.258123 144.790279) (xy 138.158493 144.7745) (xy 138.158488 144.7745) (xy 137.841512 144.7745) (xy 137.841507 144.7745) (xy 137.741876 144.790279) (xy 137.656294 144.833886) (xy 137.587625 144.846782) (xy 137.543706 144.833886) (xy 137.458123 144.790279) (xy 137.358493 144.7745) (xy 137.358488 144.7745) (xy 137.041512 144.7745) (xy 137.041507 144.7745) (xy 136.941878 144.790279) (xy 136.821778 144.851473) (xy 136.821774 144.851476) (xy 136.726476 144.946774) (xy 136.726473 144.946778) (xy 136.665279 145.066878) (xy 136.6495 145.166506) (xy 136.6495 146.483493) (xy 136.654042 146.512171) (xy 136.645087 146.581465) (xy 136.600091 146.634917) (xy 136.533339 146.655556) (xy 136.512171 146.654042) (xy 136.483493 146.6495) (xy 136.483488 146.6495) (xy 135.166512 146.6495) (xy 135.166507 146.6495) (xy 135.066878 146.665279) (xy 134.946778 146.726473) (xy 134.946774 146.726476) (xy 134.851476 146.821774) (xy 134.851473 146.821778) (xy 134.790279 146.941878) (xy 134.7745 147.041506) (xy 134.7745 147.358493) (xy 134.790279 147.458123) (xy 134.833886 147.543706) (xy 134.846782 147.612375) (xy 134.833886 147.656294) (xy 134.790279 147.741876) (xy 134.7745 147.841506) (xy 134.7745 148.158493) (xy 134.790279 148.258121) (xy 134.79028 148.258124) (xy 134.790281 148.258126) (xy 134.833886 148.343705) (xy 134.834683 148.34795) (xy 134.837431 148.351284) (xy 134.841074 148.38198) (xy 134.846782 148.412373) (xy 134.845301 148.417591) (xy 134.845666 148.420667) (xy 134.836937 148.447065) (xy 134.834891 148.454276) (xy 134.834388 148.455309) (xy 134.790281 148.541874) (xy 134.789333 148.547855) (xy 134.782562 148.561765) (xy 134.76461 148.581478) (xy 134.749562 148.603484) (xy 134.741247 148.607133) (xy 134.735519 148.613425) (xy 134.71356 148.619288) (xy 134.688611 148.630241) (xy 134.528343 148.65314) (xy 134.510772 148.654387) (xy 134.495403 148.654383) (xy 134.495396 148.654383) (xy 134.474782 148.6599) (xy 134.474781 148.659899) (xy 134.467605 148.661819) (xy 134.439154 148.665885) (xy 134.416905 148.675388) (xy 134.408369 148.677673) (xy 134.408366 148.677672) (xy 134.393534 148.681643) (xy 134.393533 148.681643) (xy 134.375046 148.692308) (xy 134.3618 148.698928) (xy 134.342179 148.70731) (xy 134.342174 148.707313) (xy 134.330093 148.716797) (xy 134.32314 148.722254) (xy 134.302188 148.734343) (xy 134.281853 148.754663) (xy 134.276017 148.759245) (xy 134.276018 148.759245) (xy 134.259231 148.772423) (xy 134.259224 148.77243) (xy 134.250009 148.784717) (xy 134.238465 148.798023) (xy 134.148912 148.887519) (xy 134.143334 148.893093) (xy 134.143279 148.893126) (xy 134.106996 148.929409) (xy 134.105395 148.93101) (xy 134.105368 148.931037) (xy 134.068793 148.967589) (xy 134.068714 148.967694) (xy 134.041959 149.014036) (xy 134.04194 149.01407) (xy 134.016042 149.058893) (xy 134.015988 149.059022) (xy 134.002553 149.109169) (xy 134.002543 149.109209) (xy 133.988716 149.160745) (xy 133.988699 149.160871) (xy 133.9887 149.211035) (xy 133.9887 149.211074) (xy 133.988681 149.273933) (xy 133.988701 149.274248) (xy 133.988797 153.0981) (xy 133.988797 153.109158) (xy 133.987957 153.112526) (xy 133.988798 153.161835) (xy 133.988799 153.162898) (xy 133.9888 153.21114) (xy 133.988848 153.2115) (xy 133.988901 153.21221) (xy 133.989091 153.213483) (xy 133.989391 153.215615) (xy 133.989561 153.216908) (xy 133.989706 153.217605) (xy 133.98976 153.217969) (xy 134.003038 153.264339) (xy 134.003602 153.266374) (xy 134.016097 153.312998) (xy 134.016229 153.313316) (xy 134.01623 153.313316) (xy 134.017836 153.317194) (xy 134.018325 153.318376) (xy 134.018644 153.319008) (xy 134.01879 153.319346) (xy 134.043642 153.360739) (xy 134.043643 153.360739) (xy 134.044169 153.361615) (xy 134.068826 153.404321) (xy 134.071283 153.406778) (xy 134.07307 153.409754) (xy 134.073073 153.409757) (xy 134.073074 153.409758) (xy 134.107732 153.443251) (xy 134.109241 153.444734) (xy 134.143397 153.478888) (xy 134.143666 153.479094) (xy 134.154354 153.488306) (xy 134.181372 153.514416) (xy 134.554516 153.875017) (xy 134.580275 153.91082) (xy 134.718512 154.200786) (xy 134.724531 154.221122) (xy 134.741114 154.248196) (xy 134.743909 154.254058) (xy 134.743909 154.254059) (xy 134.754771 154.276844) (xy 134.754772 154.276846) (xy 134.7622 154.285547) (xy 134.773627 154.301281) (xy 134.779607 154.311043) (xy 134.779611 154.311048) (xy 134.797917 154.328428) (xy 134.806843 154.337837) (xy 134.823241 154.357044) (xy 134.832671 154.363527) (xy 134.847787 154.375773) (xy 135.279382 154.785523) (xy 135.302938 154.816208) (xy 135.554244 155.278292) (xy 135.554245 155.278292) (xy 135.560089 155.289038) (xy 135.564013 155.301656) (xy 135.585197 155.335204) (xy 135.587127 155.338752) (xy 135.587127 155.338753) (xy 135.604155 155.370063) (xy 135.604156 155.370065) (xy 135.604158 155.370067) (xy 135.613261 155.379646) (xy 135.620317 155.39082) (xy 135.649465 155.417744) (xy 135.664557 155.433625) (xy 135.6768 155.446509) (xy 135.676802 155.44651) (xy 135.677636 155.447021) (xy 135.697055 155.461705) (xy 136.118019 155.85055) (xy 136.119827 155.85222) (xy 136.151487 155.88388) (xy 136.158459 155.887905) (xy 136.164376 155.89337) (xy 136.164378 155.893372) (xy 136.164381 155.893374) (xy 136.201863 155.913077) (xy 136.206128 155.915427) (xy 136.242813 155.936607) (xy 136.247933 155.937978) (xy 136.250593 155.938691) (xy 136.257724 155.94244) (xy 136.301414 155.952308) (xy 136.344673 155.9639) (xy 136.344677 155.9639) (xy 136.352589 155.964942) (xy 136.360576 155.965672) (xy 136.360586 155.965675) (xy 136.402896 155.963996) (xy 136.40781 155.9639) (xy 141.376 155.9639) (xy 141.443039 155.983585) (xy 141.488794 156.036389) (xy 141.5 156.0879) (xy 141.5 160.934563) (xy 141.480315 161.001602) (xy 141.427511 161.047357) (xy 141.361218 161.057679) (xy 141.319884 161.052716) (xy 141.293102 161.0495) (xy 140.706898 161.0495) (xy 140.667853 161.054188) (xy 140.618438 161.060122) (xy 140.477656 161.115639) (xy 140.357077 161.207077) (xy 140.265639 161.327656) (xy 140.210122 161.468438) (xy 140.204666 161.513876) (xy 140.1995 161.556898) (xy 140.1995 161.556903) (xy 140.1995 162.081813) (xy 140.199043 162.083366) (xy 140.199461 162.084931) (xy 140.18923 162.116785) (xy 140.179815 162.148852) (xy 140.178433 162.150406) (xy 140.178097 162.151454) (xy 140.154321 162.177538) (xy 140.016751 162.290814) (xy 139.999935 162.302472) (xy 139.991887 162.30712) (xy 139.991886 162.30712) (xy 139.986501 162.31023) (xy 139.918601 162.326703) (xy 139.852574 162.303851) (xy 139.809383 162.24893) (xy 139.8005 162.202843) (xy 139.8005 161.556903) (xy 139.8005 161.556898) (xy 139.789877 161.468436) (xy 139.734361 161.327658) (xy 139.73436 161.327657) (xy 139.73436 161.327656) (xy 139.642922 161.207077) (xy 139.522343 161.115639) (xy 139.381561 161.060122) (xy 139.335926 161.054642) (xy 139.293102 161.0495) (xy 138.706898 161.0495) (xy 138.667853 161.054188) (xy 138.618438 161.060122) (xy 138.477656 161.115639) (xy 138.357077 161.207077) (xy 138.265639 161.327656) (xy 138.210121 161.468441) (xy 138.208387 161.482885) (xy 138.18085 161.547099) (xy 138.122967 161.586232) (xy 138.085272 161.5921) (xy 129.768961 161.5921) (xy 129.701922 161.572415) (xy 129.680119 161.554605) (xy 129.67281 161.547099) (xy 125.077389 156.827511) (xy 122.448666 154.127761) (xy 122.416001 154.065997) (xy 122.421914 153.996378) (xy 122.464527 153.941007) (xy 122.530311 153.917465) (xy 122.582997 153.925901) (xy 122.618436 153.939877) (xy 122.706898 153.9505) (xy 122.706903 153.9505) (xy 123.293097 153.9505) (xy 123.293102 153.9505) (xy 123.381564 153.939877) (xy 123.522342 153.884361) (xy 123.642922 153.792922) (xy 123.734361 153.672342) (xy 123.789877 153.531564) (xy 123.8005 153.443102) (xy 123.8005 152.556898) (xy 124.1995 152.556898) (xy 124.1995 153.443102) (xy 124.203822 153.479094) (xy 124.210122 153.531561) (xy 124.265639 153.672343) (xy 124.357077 153.792922) (xy 124.477656 153.88436) (xy 124.477657 153.88436) (xy 124.477658 153.884361) (xy 124.618436 153.939877) (xy 124.706898 153.9505) (xy 124.706903 153.9505) (xy 125.293097 153.9505) (xy 125.293102 153.9505) (xy 125.381564 153.939877) (xy 125.522342 153.884361) (xy 125.642922 153.792922) (xy 125.734361 153.672342) (xy 125.789877 153.531564) (xy 125.8005 153.443102) (xy 125.8005 152.556898) (xy 125.789877 152.468436) (xy 125.734361 152.327658) (xy 125.73436 152.327657) (xy 125.73436 152.327656) (xy 125.642922 152.207077) (xy 125.522343 152.115639) (xy 125.425144 152.077309) (xy 125.381564 152.060123) (xy 125.381563 152.060122) (xy 125.381561 152.060122) (xy 125.334389 152.054458) (xy 125.293102 152.0495) (xy 124.706898 152.0495) (xy 124.667853 152.054188) (xy 124.618438 152.060122) (xy 124.477656 152.115639) (xy 124.357077 152.207077) (xy 124.265639 152.327656) (xy 124.210122 152.468438) (xy 124.205524 152.506736) (xy 124.1995 152.556898) (xy 123.8005 152.556898) (xy 123.789877 152.468436) (xy 123.734361 152.327658) (xy 123.73436 152.327657) (xy 123.73436 152.327656) (xy 123.642922 152.207077) (xy 123.522343 152.115639) (xy 123.425144 152.077309) (xy 123.381564 152.060123) (xy 123.381563 152.060122) (xy 123.381561 152.060122) (xy 123.334389 152.054458) (xy 123.293102 152.0495) (xy 122.706898 152.0495) (xy 122.667853 152.054188) (xy 122.618438 152.060122) (xy 122.477656 152.115639) (xy 122.357077 152.207077) (xy 122.265639 152.327656) (xy 122.210122 152.468438) (xy 122.205524 152.506736) (xy 122.1995 152.556898) (xy 122.1995 153.443102) (xy 122.203391 153.4755) (xy 122.210122 153.531563) (xy 122.21642 153.547532) (xy 122.222701 153.617119) (xy 122.190364 153.679055) (xy 122.129674 153.713675) (xy 122.059902 153.709989) (xy 122.012223 153.679526) (xy 122.011764 153.679055) (xy 121.66119 153.319008) (xy 121.016335 152.656729) (xy 121.016335 152.656728) (xy 121.009135 152.649334) (xy 121.00778 152.646987) (xy 120.972362 152.611569) (xy 120.937462 152.575726) (xy 120.937292 152.575551) (xy 120.936011 152.574568) (xy 120.934709 152.573555) (xy 120.933425 152.572542) (xy 120.890532 152.547778) (xy 120.890531 152.547777) (xy 120.889828 152.547371) (xy 120.846848 152.521787) (xy 120.844242 152.521051) (xy 120.841888 152.519692) (xy 120.794332 152.506949) (xy 120.79344 152.50671) (xy 120.74536 152.493138) (xy 120.742646 152.493101) (xy 120.740027 152.4924) (xy 120.740024 152.4924) (xy 120.690841 152.4924) (xy 120.689188 152.492389) (xy 120.638613 152.491714) (xy 120.626964 152.4924) (xy 118.949171 152.4924) (xy 118.895347 152.480109) (xy 118.703576 152.387709) (xy 118.697812 152.382502) (xy 118.690361 152.380315) (xy 118.674368 152.367428) (xy 118.671213 152.365175) (xy 118.663493 152.361401) (xy 118.61191 152.314274) (xy 118.593995 152.246741) (xy 118.615435 152.180242) (xy 118.663493 152.138599) (xy 118.671211 152.134826) (xy 118.671213 152.134824) (xy 118.679575 152.128855) (xy 118.680644 152.130353) (xy 118.731042 152.102834) (xy 118.7574 152.1) (xy 118.819258 152.1) (xy 118.819258 152.099999) (xy 118.81438 152.06652) (xy 118.808765 152.055035) (xy 118.797003 151.986162) (xy 118.808763 151.946107) (xy 118.814866 151.933625) (xy 118.8255 151.860636) (xy 118.8255 151.639364) (xy 118.814866 151.566375) (xy 118.809041 151.55446) (xy 118.797281 151.485592) (xy 118.80904 151.445541) (xy 118.814866 151.433625) (xy 118.8255 151.360636) (xy 118.8255 151.139364) (xy 118.814866 151.066375) (xy 118.809041 151.05446) (xy 118.797281 150.985592) (xy 118.80904 150.945541) (xy 118.814866 150.933625) (xy 118.8255 150.860636) (xy 118.8255 150.639364) (xy 118.814866 150.566375) (xy 118.809041 150.55446) (xy 118.797281 150.485592) (xy 118.798507 150.477461) (xy 118.80159 150.46078) (xy 118.814866 150.433625) (xy 118.8255 150.360636) (xy 118.8255 150.33143) (xy 118.827566 150.320254) (xy 118.838414 150.29881) (xy 118.845185 150.275754) (xy 118.8539 150.268201) (xy 118.859108 150.257909) (xy 118.879829 150.245734) (xy 118.897989 150.229999) (xy 118.909404 150.228357) (xy 118.919349 150.222515) (xy 118.94336 150.223475) (xy 118.967147 150.220055) (xy 118.977638 150.224846) (xy 118.989163 150.225307) (xy 119.008844 150.239097) (xy 119.030703 150.24908) (xy 119.04115 150.261734) (xy 119.046384 150.265401) (xy 119.048551 150.270697) (xy 119.056888 150.280795) (xy 119.066077 150.296712) (xy 119.066079 150.296715) (xy 119.06608 150.296716) (xy 119.177884 150.40852) (xy 119.177886 150.408521) (xy 119.17789 150.408524) (xy 119.297294 150.477461) (xy 119.314816 150.487577) (xy 119.467543 150.5285) (xy 119.467545 150.5285) (xy 119.625655 150.5285) (xy 119.625657 150.5285) (xy 119.778384 150.487577) (xy 119.915316 150.40852) (xy 120.02712 150.296716) (xy 120.106177 150.159784) (xy 120.1471 150.007057) (xy 120.1471 149.848943) (xy 120.106177 149.696216) (xy 120.062443 149.620466) (xy 120.027124 149.55929) (xy 120.027118 149.559282) (xy 119.915317 149.447481) (xy 119.915309 149.447475) (xy 119.77839 149.368426) (xy 119.778386 149.368424) (xy 119.778384 149.368423) (xy 119.625657 149.3275) (xy 119.625656 149.3275) (xy 119.56391 149.3275) (xy 119.496871 149.307815) (xy 119.476222 149.291174) (xy 119.237328 149.052241) (xy 119.237328 149.05224) (xy 119.232187 149.047098) (xy 119.23218 149.047087) (xy 119.195308 149.010215) (xy 119.157638 148.972539) (xy 119.157636 148.972538) (xy 119.157618 148.972524) (xy 119.157615 148.972522) (xy 119.157613 148.97252) (xy 119.11546 148.948183) (xy 119.099078 148.938723) (xy 119.06922 148.921481) (xy 119.069215 148.921478) (xy 119.066317 148.919805) (xy 119.066299 148.9198) (xy 119.066287 148.919793) (xy 119.065211 148.919504) (xy 119.06521 148.919504) (xy 119.017509 148.906722) (xy 119.017503 148.906721) (xy 118.964456 148.892503) (xy 118.964434 148.8925) (xy 118.964427 148.8925) (xy 118.9495 148.8925) (xy 118.882461 148.872815) (xy 118.836706 148.820011) (xy 118.8255 148.7685) (xy 118.8255 148.639369) (xy 118.8255 148.639364) (xy 118.814866 148.566375) (xy 118.809041 148.55446) (xy 118.797281 148.485592) (xy 118.80904 148.445541) (xy 118.814866 148.433625) (xy 118.8255 148.360636) (xy 118.8255 148.139364) (xy 118.814866 148.066375) (xy 118.810229 148.056891) (xy 118.805789 148.03089) (xy 118.797673 148.005785) (xy 118.799999 147.996987) (xy 118.798468 147.98802) (xy 118.80879 147.963744) (xy 118.815536 147.938237) (xy 118.822248 147.932094) (xy 118.825809 147.923722) (xy 118.84762 147.908878) (xy 118.867082 147.89107) (xy 118.879856 147.88694) (xy 118.883571 147.884412) (xy 118.900653 147.880215) (xy 119.137338 147.839617) (xy 119.150043 147.838921) (xy 119.149991 147.838193) (xy 119.158095 147.837607) (xy 119.158096 147.837606) (xy 119.158103 147.837607) (xy 119.203269 147.828309) (xy 119.248676 147.820521) (xy 119.254793 147.817703) (xy 119.261391 147.816345) (xy 119.300782 147.796592) (xy 119.304454 147.794827) (xy 119.313976 147.79044) (xy 119.344455 147.776401) (xy 119.344459 147.776396) (xy 119.350117 147.77283) (xy 119.355651 147.769078) (xy 119.355657 147.769076) (xy 119.390106 147.738456) (xy 119.425553 147.708994) (xy 119.429443 147.703492) (xy 119.731645 147.434886) (xy 119.732213 147.434386) (xy 119.770368 147.401064) (xy 119.770374 147.401053) (xy 119.771877 147.399349) (xy 119.771878 147.399348) (xy 119.772619 147.398505) (xy 119.772675 147.398419) (xy 119.772677 147.398418) (xy 119.800727 147.355826) (xy 119.829133 147.313501) (xy 119.829701 147.311834) (xy 119.830675 147.310357) (xy 119.830676 147.310353) (xy 119.830679 147.310349) (xy 119.84675 147.261945) (xy 119.863233 147.213714) (xy 119.863351 147.211949) (xy 119.863909 147.210272) (xy 119.863909 147.21027) (xy 119.86391 147.210268) (xy 119.866877 147.159851) (xy 119.866944 147.158798) (xy 119.907623 146.556898) (xy 122.1995 146.556898) (xy 122.1995 147.443102) (xy 122.204602 147.485592) (xy 122.210122 147.531561) (xy 122.265639 147.672343) (xy 122.357077 147.792922) (xy 122.477656 147.88436) (xy 122.477657 147.88436) (xy 122.477658 147.884361) (xy 122.618436 147.939877) (xy 122.706898 147.9505) (xy 122.706903 147.9505) (xy 123.293097 147.9505) (xy 123.293102 147.9505) (xy 123.381564 147.939877) (xy 123.522342 147.884361) (xy 123.642922 147.792922) (xy 123.734361 147.672342) (xy 123.789877 147.531564) (xy 123.8005 147.443102) (xy 123.8005 146.556898) (xy 124.1995 146.556898) (xy 124.1995 147.443102) (xy 124.204602 147.485592) (xy 124.210122 147.531561) (xy 124.265639 147.672343) (xy 124.357077 147.792922) (xy 124.477656 147.88436) (xy 124.477657 147.88436) (xy 124.477658 147.884361) (xy 124.618436 147.939877) (xy 124.706898 147.9505) (xy 124.706903 147.9505) (xy 125.293097 147.9505) (xy 125.293102 147.9505) (xy 125.381564 147.939877) (xy 125.522342 147.884361) (xy 125.642922 147.792922) (xy 125.734361 147.672342) (xy 125.789877 147.531564) (xy 125.8005 147.443102) (xy 125.8005 146.556898) (xy 125.789877 146.468436) (xy 125.734361 146.327658) (xy 125.73436 146.327657) (xy 125.73436 146.327656) (xy 125.642922 146.207077) (xy 125.522343 146.115639) (xy 125.397415 146.066374) (xy 125.381564 146.060123) (xy 125.381563 146.060122) (xy 125.381561 146.060122) (xy 125.334389 146.054458) (xy 125.293102 146.0495) (xy 124.706898 146.0495) (xy 124.667853 146.054188) (xy 124.618438 146.060122) (xy 124.477656 146.115639) (xy 124.357077 146.207077) (xy 124.265639 146.327656) (xy 124.210122 146.468438) (xy 124.204871 146.512171) (xy 124.1995 146.556898) (xy 123.8005 146.556898) (xy 123.789877 146.468436) (xy 123.734361 146.327658) (xy 123.73436 146.327657) (xy 123.73436 146.327656) (xy 123.642922 146.207077) (xy 123.522343 146.115639) (xy 123.397415 146.066374) (xy 123.381564 146.060123) (xy 123.381563 146.060122) (xy 123.381561 146.060122) (xy 123.334389 146.054458) (xy 123.293102 146.0495) (xy 122.706898 146.0495) (xy 122.667853 146.054188) (xy 122.618438 146.060122) (xy 122.477656 146.115639) (xy 122.357077 146.207077) (xy 122.265639 146.327656) (xy 122.210122 146.468438) (xy 122.204871 146.512171) (xy 122.1995 146.556898) (xy 119.907623 146.556898) (xy 119.912415 146.485999) (xy 119.936576 146.420443) (xy 119.948453 146.406682) (xy 119.976365 146.378771) (xy 120.02712 146.328016) (xy 120.029789 146.323394) (xy 120.071037 146.251948) (xy 120.106177 146.191084) (xy 120.1471 146.038357) (xy 120.1471 145.880243) (xy 120.106177 145.727516) (xy 120.106173 145.727509) (xy 120.027124 145.59059) (xy 120.027118 145.590582) (xy 119.915317 145.478781) (xy 119.915309 145.478775) (xy 119.77839 145.399726) (xy 119.778386 145.399724) (xy 119.778384 145.399723) (xy 119.625657 145.3588) (xy 119.467543 145.3588) (xy 119.314816 145.399723) (xy 119.314809 145.399726) (xy 119.17789 145.478775) (xy 119.177882 145.478781) (xy 119.066081 145.590582) (xy 119.066075 145.59059) (xy 119.046895 145.623811) (xy 118.996328 145.672026) (xy 118.927721 145.685248) (xy 118.862856 145.65928) (xy 118.822328 145.602365) (xy 118.821074 145.59854) (xy 118.818203 145.589285) (xy 118.814866 145.566375) (xy 118.804561 145.545297) (xy 118.801728 145.53616) (xy 118.801338 145.510408) (xy 118.797003 145.485018) (xy 118.80076 145.472221) (xy 118.800671 145.466299) (xy 118.804137 145.46072) (xy 118.808764 145.444967) (xy 118.81438 145.433479) (xy 118.81438 145.433477) (xy 118.819258 145.4) (xy 118.7574 145.4) (xy 118.696701 145.384128) (xy 118.6818 145.375763) (xy 118.671211 145.365174) (xy 118.607142 145.333852) (xy 118.60407 145.332128) (xy 118.582016 145.309551) (xy 118.558726 145.288272) (xy 118.557792 145.284751) (xy 118.555247 145.282146) (xy 118.548901 145.251233) (xy 118.540812 145.220738) (xy 118.541929 145.217272) (xy 118.541197 145.213704) (xy 118.552571 145.184266) (xy 118.562253 145.15424) (xy 118.565066 145.151928) (xy 118.56638 145.14853) (xy 118.591865 145.129914) (xy 118.616242 145.10989) (xy 118.620455 145.109031) (xy 118.622801 145.107318) (xy 118.631375 145.106805) (xy 118.664769 145.1) (xy 118.819258 145.1) (xy 118.819258 145.099999) (xy 118.81438 145.06652) (xy 118.814379 145.066517) (xy 118.808487 145.054465) (xy 118.796725 144.985592) (xy 118.808487 144.945535) (xy 118.814379 144.933482) (xy 118.81438 144.933479) (xy 118.819258 144.9) (xy 117.9 144.9) (xy 117.9 145.126) (xy 117.897449 145.134685) (xy 117.898738 145.143647) (xy 117.887759 145.167687) (xy 117.880315 145.193039) (xy 117.873474 145.198966) (xy 117.869713 145.207203) (xy 117.847478 145.221492) (xy 117.827511 145.238794) (xy 117.816996 145.241081) (xy 117.810935 145.244977) (xy 117.776 145.25) (xy 117.724 145.25) (xy 117.656961 145.230315) (xy 117.611206 145.177511) (xy 117.6 145.126) (xy 117.6 144.9) (xy 116.680742 144.9) (xy 116.685619 144.933479) (xy 116.691516 144.945542) (xy 116.696764 144.976289) (xy 116.703936 145.006637) (xy 116.702734 145.011262) (xy 116.703273 145.014415) (xy 116.697051 145.041253) (xy 116.679824 145.090085) (xy 116.666174 145.109013) (xy 116.65644 145.130218) (xy 116.646122 145.136819) (xy 116.638957 145.146757) (xy 116.617241 145.1553) (xy 116.597588 145.167877) (xy 116.581977 145.169175) (xy 116.573939 145.172338) (xy 116.565096 145.170579) (xy 116.548327 145.171974) (xy 116.525846 145.169316) (xy 116.508304 145.165947) (xy 116.493971 145.162105) (xy 116.493964 145.162104) (xy 116.4721 145.162101) (xy 116.4721 145.1621) (xy 116.464798 145.162099) (xy 116.435856 145.158679) (xy 116.412311 145.162095) (xy 116.40335 145.162095) (xy 116.388514 145.162093) (xy 116.367388 145.167751) (xy 116.353127 145.170685) (xy 116.337661 145.17293) (xy 116.268489 145.16308) (xy 116.257849 145.157604) (xy 116.127284 145.082223) (xy 115.974557 145.0413) (xy 115.816443 145.0413) (xy 115.663716 145.082223) (xy 115.663709 145.082226) (xy 115.52679 145.161275) (xy 115.526782 145.161281) (xy 115.414981 145.273082) (xy 115.414975 145.27309) (xy 115.335926 145.410009) (xy 115.335923 145.410016) (xy 115.295 145.562743) (xy 115.295 145.720857) (xy 115.296785 145.727516) (xy 115.335923 145.873583) (xy 115.335926 145.87359) (xy 115.414975 146.010509) (xy 115.414979 146.010514) (xy 115.41498 146.010516) (xy 115.526784 146.12232) (xy 115.526786 146.122321) (xy 115.52679 146.122324) (xy 115.645886 146.191083) (xy 115.663716 146.201377) (xy 115.816443 146.2423) (xy 115.816445 146.2423) (xy 115.974555 146.2423) (xy 115.974557 146.2423) (xy 116.127284 146.201377) (xy 116.264216 146.12232) (xy 116.264219 146.122316) (xy 116.270666 146.117371) (xy 116.27133 146.118237) (xy 116.275042 146.113281) (xy 116.299787 146.104054) (xy 116.322965 146.091394) (xy 116.332011 146.092039) (xy 116.340509 146.088871) (xy 116.366313 146.094487) (xy 116.392657 146.096367) (xy 116.401725 146.102194) (xy 116.40878 146.10373) (xy 116.437032 146.124884) (xy 116.591515 146.279399) (xy 116.599416 146.288286) (xy 116.635484 146.323394) (xy 116.636685 146.324578) (xy 116.645717 146.333612) (xy 116.679195 146.394939) (xy 116.68073 146.403404) (xy 116.681208 146.406682) (xy 116.685134 146.433625) (xy 116.690957 146.445536) (xy 116.69096 146.445542) (xy 116.702717 146.514416) (xy 116.69096 146.554456) (xy 116.685134 146.566375) (xy 116.6745 146.639364) (xy 116.6745 146.860636) (xy 116.682475 146.915377) (xy 116.685134 146.933627) (xy 116.691237 146.94611) (xy 116.702995 147.014983) (xy 116.691237 147.055028) (xy 116.685619 147.066518) (xy 116.685619 147.066519) (xy 116.680741 147.099999) (xy 116.680742 147.1) (xy 116.7426 147.1) (xy 116.809639 147.119685) (xy 116.81084 147.120466) (xy 116.821368 147.127405) (xy 116.828789 147.134826) (xy 116.843647 147.14209) (xy 116.850287 147.146466) (xy 116.86793 147.167308) (xy 116.88809 147.185728) (xy 116.890174 147.193588) (xy 116.895429 147.199795) (xy 116.899002 147.226868) (xy 116.906004 147.253262) (xy 116.903508 147.261001) (xy 116.904573 147.269064) (xy 116.892943 147.293768) (xy 116.884563 147.319761) (xy 116.878052 147.325402) (xy 116.874815 147.33228) (xy 116.857847 147.342909) (xy 116.836508 147.3614) (xy 116.828788 147.365174) (xy 116.820425 147.371145) (xy 116.819355 147.369646) (xy 116.768958 147.397166) (xy 116.7426 147.4) (xy 116.680742 147.4) (xy 116.685619 147.43348) (xy 116.691236 147.444969) (xy 116.702996 147.513842) (xy 116.691239 147.553885) (xy 116.685135 147.566371) (xy 116.685134 147.566374) (xy 116.685134 147.566375) (xy 116.6745 147.639364) (xy 116.6745 147.860636) (xy 116.679352 147.893939) (xy 116.685134 147.933625) (xy 116.69096 147.945542) (xy 116.702717 148.014416) (xy 116.69096 148.054458) (xy 116.685135 148.066373) (xy 116.685134 148.066375) (xy 116.6745 148.139364) (xy 116.6745 148.360636) (xy 116.680235 148.4) (xy 116.685134 148.433625) (xy 116.69096 148.445542) (xy 116.702717 148.514416) (xy 116.69096 148.554458) (xy 116.687388 148.561765) (xy 116.685134 148.566375) (xy 116.6745 148.639364) (xy 116.6745 148.860636) (xy 116.681215 148.906723) (xy 116.685134 148.933625) (xy 116.69096 148.945542) (xy 116.702717 149.014416) (xy 116.69096 149.054456) (xy 116.685134 149.066375) (xy 116.6745 149.139364) (xy 116.6745 149.360636) (xy 116.682475 149.415377) (xy 116.685134 149.433627) (xy 116.691237 149.44611) (xy 116.702995 149.514983) (xy 116.691237 149.555028) (xy 116.685619 149.566518) (xy 116.685619 149.566519) (xy 116.680741 149.599999) (xy 116.680742 149.6) (xy 116.7426 149.6) (xy 116.809639 149.619685) (xy 116.81084 149.620466) (xy 116.821368 149.627405) (xy 116.828789 149.634826) (xy 116.843647 149.64209) (xy 116.850287 149.646466) (xy 116.86793 149.667308) (xy 116.88809 149.685728) (xy 116.890174 149.693588) (xy 116.895429 149.699795) (xy 116.899002 149.726868) (xy 116.906004 149.753262) (xy 116.903508 149.761001) (xy 116.904573 149.769064) (xy 116.892943 149.793768) (xy 116.884563 149.819761) (xy 116.878052 149.825402) (xy 116.874815 149.83228) (xy 116.857847 149.842909) (xy 116.836508 149.8614) (xy 116.828788 149.865174) (xy 116.820425 149.871145) (xy 116.819355 149.869646) (xy 116.768958 149.897166) (xy 116.7426 149.9) (xy 116.680742 149.9) (xy 116.685619 149.93348) (xy 116.691236 149.944969) (xy 116.702996 150.013842) (xy 116.691239 150.053885) (xy 116.685135 150.066371) (xy 116.685134 150.066374) (xy 116.685134 150.066375) (xy 116.6745 150.139364) (xy 116.6745 150.360636) (xy 116.685134 150.433625) (xy 116.69096 150.445542) (xy 116.702717 150.514416) (xy 116.69096 150.554456) (xy 116.685134 150.566375) (xy 116.6745 150.639364) (xy 116.6745 150.860636) (xy 116.680988 150.905166) (xy 116.685134 150.933625) (xy 116.69096 150.945542) (xy 116.702717 151.014416) (xy 116.69096 151.054456) (xy 116.685134 151.066375) (xy 116.6745 151.139364) (xy 116.6745 151.360636) (xy 116.681389 151.407917) (xy 116.685134 151.433625) (xy 116.69096 151.445542) (xy 116.702717 151.514416) (xy 116.69096 151.554456) (xy 116.685134 151.566375) (xy 116.6745 151.639364) (xy 116.6745 151.860636) (xy 116.682475 151.915377) (xy 116.685134 151.933627) (xy 116.691237 151.94611) (xy 116.702995 152.014983) (xy 116.691237 152.055028) (xy 116.685619 152.066518) (xy 116.685619 152.066519) (xy 116.680741 152.099999) (xy 116.680742 152.1) (xy 116.7426 152.1) (xy 116.809639 152.119685) (xy 116.81084 152.120466) (xy 116.821368 152.127405) (xy 116.828789 152.134826) (xy 116.843647 152.14209) (xy 116.850287 152.146466) (xy 116.86793 152.167308) (xy 116.88809 152.185728) (xy 116.890174 152.193588) (xy 116.895429 152.199795) (xy 116.899002 152.226868) (xy 116.906004 152.253262) (xy 116.903508 152.261001) (xy 116.904573 152.269064) (xy 116.892943 152.293768) (xy 116.884563 152.319761) (xy 116.878052 152.325402) (xy 116.874815 152.33228) (xy 116.857847 152.342909) (xy 116.836508 152.3614) (xy 116.828788 152.365174) (xy 116.820425 152.371145) (xy 116.819355 152.369646) (xy 116.768958 152.397166) (xy 116.7426 152.4) (xy 116.680742 152.4) (xy 116.685619 152.43348) (xy 116.691236 152.444969) (xy 116.702996 152.513842) (xy 116.691239 152.553885) (xy 116.685135 152.566371) (xy 116.685134 152.566374) (xy 116.684088 152.573555) (xy 116.6745 152.639364) (xy 116.6745 152.860636) (xy 116.675672 152.868677) (xy 116.685134 152.933625) (xy 116.69096 152.945542) (xy 116.702717 153.014416) (xy 116.69096 153.054456) (xy 116.685134 153.066375) (xy 116.6745 153.139364) (xy 116.6745 153.360636) (xy 116.682886 153.418192) (xy 116.685134 153.433625) (xy 116.69096 153.445542) (xy 116.702717 153.514416) (xy 116.69096 153.554456) (xy 116.685134 153.566375) (xy 116.6745 153.639364) (xy 116.6745 153.860636) (xy 116.681812 153.910821) (xy 116.685134 153.933625) (xy 116.69096 153.945542) (xy 116.702717 154.014416) (xy 116.69096 154.054458) (xy 116.685319 154.065997) (xy 116.685134 154.066375) (xy 116.6745 154.139364) (xy 116.6745 154.360636) (xy 116.681604 154.409395) (xy 116.685134 154.433625) (xy 116.69096 154.445542) (xy 116.702717 154.514416) (xy 116.69096 154.554456) (xy 116.685134 154.566375) (xy 116.6745 154.639364) (xy 116.6745 154.860636) (xy 116.684752 154.931) (xy 116.685134 154.933625) (xy 116.69096 154.945542) (xy 116.702717 155.014416) (xy 116.69096 155.054456) (xy 116.685134 155.066375) (xy 116.6745 155.139364) (xy 116.6745 155.360636) (xy 116.675978 155.370778) (xy 116.685134 155.433625) (xy 116.69096 155.445542) (xy 116.702717 155.514416) (xy 116.69096 155.554456) (xy 116.685134 155.566375) (xy 116.6745 155.639364) (xy 116.6745 155.860636) (xy 116.685134 155.933625) (xy 116.69096 155.945542) (xy 116.702717 156.014416) (xy 116.69096 156.054456) (xy 116.685134 156.066375) (xy 116.6745 156.139364) (xy 116.6745 156.360636) (xy 116.682475 156.415377) (xy 116.685134 156.433627) (xy 116.691237 156.44611) (xy 116.702995 156.514983) (xy 116.691237 156.555028) (xy 116.685619 156.566518) (xy 116.685619 156.566519) (xy 116.680741 156.599999) (xy 116.680742 156.6) (xy 116.7426 156.6) (xy 116.803299 156.615872) (xy 116.818199 156.624236) (xy 116.828789 156.634826) (xy 116.892857 156.666147) (xy 116.89593 156.667872) (xy 116.917983 156.690448) (xy 116.941274 156.711728) (xy 116.942207 156.715248) (xy 116.944753 156.717854) (xy 116.951098 156.748766) (xy 116.959188 156.779262) (xy 116.95807 156.782727) (xy 116.958803 156.786296) (xy 116.947428 156.815733) (xy 116.937747 156.84576) (xy 116.934933 156.848071) (xy 116.93362 156.85147) (xy 116.908134 156.870085) (xy 116.883758 156.89011) (xy 116.879544 156.890968) (xy 116.877199 156.892682) (xy 116.868624 156.893194) (xy 116.835231 156.9) (xy 116.680742 156.9) (xy 116.685619 156.933479) (xy 116.740587 157.045918) (xy 116.829081 157.134412) (xy 116.941517 157.189379) (xy 117.014418 157.2) (xy 117.6 157.2) (xy 117.6 156.890935) (xy 117.587068 156.876011) (xy 117.585151 156.862679) (xy 117.578696 156.850858) (xy 117.580275 156.828771) (xy 117.577124 156.806853) (xy 117.582719 156.794601) (xy 117.58368 156.781166) (xy 117.59695 156.763439) (xy 117.606149 156.743297) (xy 117.61748 156.736014) (xy 117.625552 156.725233) (xy 117.646297 156.717495) (xy 117.664927 156.705523) (xy 117.686845 156.702371) (xy 117.691016 156.700816) (xy 117.699862 156.7005) (xy 117.800138 156.7005) (xy 117.867177 156.720185) (xy 117.912932 156.772989) (xy 117.922876 156.842147) (xy 117.9 156.892238) (xy 117.9 157.2) (xy 118.485582 157.2) (xy 118.558482 157.189379) (xy 118.670918 157.134412) (xy 118.759412 157.045918) (xy 118.81438 156.933479) (xy 118.819258 156.9) (xy 118.664769 156.9) (xy 118.661099 156.898922) (xy 118.657374 156.899779) (xy 118.627838 156.889155) (xy 118.59773 156.880315) (xy 118.595227 156.877426) (xy 118.591628 156.876132) (xy 118.572523 156.851224) (xy 118.551975 156.827511) (xy 118.55143 156.823726) (xy 118.549104 156.820693) (xy 118.546498 156.78942) (xy 118.542031 156.758353) (xy 118.543619 156.754874) (xy 118.543302 156.751065) (xy 118.558018 156.723345) (xy 118.571056 156.694797) (xy 118.574792 156.691749) (xy 118.576065 156.689353) (xy 118.59072 156.678759) (xy 118.60407 156.667872) (xy 118.607142 156.666147) (xy 118.671211 156.634826) (xy 118.6818 156.624236) (xy 118.696701 156.615872) (xy 118.71477 156.611718) (xy 118.731042 156.602834) (xy 118.7574 156.6) (xy 118.819258 156.6) (xy 118.819258 156.599999) (xy 118.81438 156.56652) (xy 118.808765 156.555035) (xy 118.797003 156.486162) (xy 118.808763 156.446107) (xy 118.814866 156.433625) (xy 118.8255 156.360636) (xy 118.8255 156.139364) (xy 118.814866 156.066375) (xy 118.809041 156.05446) (xy 118.797281 155.985592) (xy 118.80904 155.945541) (xy 118.814866 155.933625) (xy 118.8255 155.860636) (xy 118.8255 155.639364) (xy 118.814866 155.566375) (xy 118.809041 155.55446) (xy 118.797281 155.485592) (xy 118.80904 155.445541) (xy 118.814866 155.433625) (xy 118.8255 155.360636) (xy 118.8255 155.139364) (xy 118.814866 155.066375) (xy 118.809041 155.05446) (xy 118.797281 154.985592) (xy 118.80904 154.945541) (xy 118.814866 154.933625) (xy 118.8255 154.860636) (xy 118.8255 154.639364) (xy 118.814866 154.566375) (xy 118.809041 154.55446) (xy 118.797281 154.485592) (xy 118.80904 154.445541) (xy 118.814866 154.433625) (xy 118.8255 154.360636) (xy 118.8255 154.139364) (xy 118.814866 154.066375) (xy 118.809041 154.05446) (xy 118.797281 153.985592) (xy 118.80904 153.945541) (xy 118.814866 153.933625) (xy 118.8255 153.860636) (xy 118.8255 153.639364) (xy 118.814866 153.566375) (xy 118.809041 153.55446) (xy 118.797281 153.485592) (xy 118.800654 153.467953) (xy 118.80376 153.456341) (xy 118.814866 153.433625) (xy 118.820878 153.392354) (xy 118.822752 153.385353) (xy 118.837306 153.361453) (xy 118.848979 153.336021) (xy 118.855231 153.332019) (xy 118.859093 153.325679) (xy 118.884256 153.313443) (xy 118.907828 153.298357) (xy 118.91838 153.29685) (xy 118.921928 153.295125) (xy 118.926578 153.295679) (xy 118.942539 153.2934) (xy 120.465939 153.2934) (xy 120.532978 153.313085) (xy 120.554778 153.330893) (xy 125.00422 157.900556) (xy 129.218567 162.228773) (xy 129.226202 162.237596) (xy 129.26193 162.273323) (xy 129.263092 162.2745) (xy 129.297437 162.309773) (xy 129.300175 162.311932) (xy 129.300233 162.311977) (xy 129.301481 162.312961) (xy 129.301686 162.313079) (xy 129.301687 162.31308) (xy 129.345051 162.338116) (xy 129.388052 162.363713) (xy 129.390654 162.364446) (xy 129.393005 162.365804) (xy 129.39301 162.365805) (xy 129.393013 162.365807) (xy 129.441367 162.378763) (xy 129.48954 162.392362) (xy 129.492253 162.392398) (xy 129.494873 162.3931) (xy 129.544059 162.3931) (xy 129.545711 162.39311) (xy 129.594984 162.393768) (xy 129.594985 162.393767) (xy 129.596286 162.393785) (xy 129.607936 162.3931) (xy 138.083495 162.3931) (xy 138.150534 162.412785) (xy 138.196289 162.465589) (xy 138.206611 162.502316) (xy 138.210122 162.531562) (xy 138.265639 162.672343) (xy 138.357077 162.792922) (xy 138.477656 162.88436) (xy 138.477657 162.88436) (xy 138.477658 162.884361) (xy 138.618436 162.939877) (xy 138.706898 162.9505) (xy 138.706903 162.9505) (xy 139.293097 162.9505) (xy 139.293102 162.9505) (xy 139.381564 162.939877) (xy 139.522342 162.884361) (xy 139.638376 162.796369) (xy 139.703686 162.771547) (xy 139.77205 162.785975) (xy 139.821761 162.835072) (xy 139.8373 162.895174) (xy 139.8373 164.452699) (xy 139.817615 164.519738) (xy 139.808852 164.53173) (xy 137.970382 166.754531) (xy 137.912486 166.793644) (xy 137.87483 166.7995) (xy 136.515143 166.7995) (xy 136.515117 166.799502) (xy 136.490012 166.802413) (xy 136.490008 166.802415) (xy 136.387235 166.847793) (xy 136.307794 166.927234) (xy 136.262415 167.030006) (xy 136.262415 167.030008) (xy 136.2595 167.055131) (xy 136.2595 168.944856) (xy 136.259502 168.944882) (xy 136.262413 168.969987) (xy 136.262415 168.969991) (xy 136.307793 169.072764) (xy 136.307794 169.072765) (xy 136.387235 169.152206) (xy 136.490009 169.197585) (xy 136.515135 169.2005) (xy 138.404864 169.200499) (xy 138.404879 169.200497) (xy 138.404882 169.200497) (xy 138.429987 169.197586) (xy 138.429988 169.197585) (xy 138.429991 169.197585) (xy 138.532765 169.152206) (xy 138.612206 169.072765) (xy 138.657585 168.969991) (xy 138.6605 168.944865) (xy 138.660499 168.530805) (xy 138.680183 168.463769) (xy 138.732987 168.418014) (xy 138.802146 168.40807) (xy 138.865702 168.437095) (xy 138.894983 168.474513) (xy 138.973666 168.628935) (xy 138.973667 168.628936) (xy 139.084685 168.781741) (xy 139.084689 168.781746) (xy 139.218253 168.91531) (xy 139.218258 168.915314) (xy 139.371059 169.026329) (xy 139.539362 169.112085) (xy 139.718996 169.170451) (xy 139.8 169.183281) (xy 139.8 168.461879) (xy 139.807007 168.465925) (xy 139.934174 168.5) (xy 140.065826 168.5) (xy 140.192993 168.465925) (xy 140.2 168.461879) (xy 140.2 169.18328) (xy 140.281001 169.170451) (xy 140.281004 169.170451) (xy 140.460637 169.112085) (xy 140.62894 169.026329) (xy 140.781741 168.915314) (xy 140.781746 168.91531) (xy 140.91531 168.781746) (xy 140.915314 168.781741) (xy 141.026329 168.62894) (xy 141.112086 168.460635) (xy 141.151806 168.338389) (xy 141.191243 168.280713) (xy 141.255601 168.253514) (xy 141.324448 168.265428) (xy 141.375924 168.312672) (xy 141.387668 168.338387) (xy 141.427454 168.460836) (xy 141.44741 168.5) (xy 141.486485 168.57669) (xy 141.5 168.632983) (xy 141.5 169.376) (xy 141.480315 169.443039) (xy 141.427511 169.488794) (xy 141.376 169.5) (xy 112.995165 169.5) (xy 112.928126 169.480315) (xy 112.882371 169.427511) (xy 112.872427 169.358353) (xy 112.881297 169.326907) (xy 113.846734 167.087619) (xy 113.846742 167.087601) (xy 113.846764 167.087547) (xy 113.860854 167.055131) (xy 120.2595 167.055131) (xy 120.2595 168.944856) (xy 120.259502 168.944882) (xy 120.262413 168.969987) (xy 120.262415 168.969991) (xy 120.307793 169.072764) (xy 120.307794 169.072765) (xy 120.387235 169.152206) (xy 120.490009 169.197585) (xy 120.515135 169.2005) (xy 122.404864 169.200499) (xy 122.404879 169.200497) (xy 122.404882 169.200497) (xy 122.429987 169.197586) (xy 122.429988 169.197585) (xy 122.429991 169.197585) (xy 122.532765 169.152206) (xy 122.612206 169.072765) (xy 122.657585 168.969991) (xy 122.6605 168.944865) (xy 122.660499 168.530805) (xy 122.680183 168.463769) (xy 122.732987 168.418014) (xy 122.802146 168.40807) (xy 122.865702 168.437095) (xy 122.894983 168.474513) (xy 122.973666 168.628935) (xy 122.973667 168.628936) (xy 123.084685 168.781741) (xy 123.084689 168.781746) (xy 123.218253 168.91531) (xy 123.218258 168.915314) (xy 123.371059 169.026329) (xy 123.539362 169.112085) (xy 123.718996 169.170451) (xy 123.8 169.183281) (xy 123.8 168.461879) (xy 123.807007 168.465925) (xy 123.934174 168.5) (xy 124.065826 168.5) (xy 124.192993 168.465925) (xy 124.2 168.461879) (xy 124.2 169.18328) (xy 124.281001 169.170451) (xy 124.281004 169.170451) (xy 124.460637 169.112085) (xy 124.62894 169.026329) (xy 124.781741 168.915314) (xy 124.781746 168.91531) (xy 124.91531 168.781746) (xy 124.915314 168.781741) (xy 125.026329 168.62894) (xy 125.112086 168.460635) (xy 125.151806 168.338389) (xy 125.191243 168.280713) (xy 125.255601 168.253514) (xy 125.324448 168.265428) (xy 125.375924 168.312672) (xy 125.387668 168.338387) (xy 125.427454 168.460836) (xy 125.463107 168.530808) (xy 125.51324 168.629199) (xy 125.62431 168.782073) (xy 125.757927 168.91569) (xy 125.910801 169.02676) (xy 125.990347 169.06729) (xy 126.079163 169.112545) (xy 126.079165 169.112545) (xy 126.079168 169.112547) (xy 126.175497 169.143846) (xy 126.258881 169.17094) (xy 126.445514 169.2005) (xy 126.445519 169.2005) (xy 126.634486 169.2005) (xy 126.821118 169.17094) (xy 126.822623 169.170451) (xy 127.000832 169.112547) (xy 127.169199 169.02676) (xy 127.322073 168.91569) (xy 127.45569 168.782073) (xy 127.56676 168.629199) (xy 127.652547 168.460832) (xy 127.71094 168.281118) (xy 127.715312 168.253514) (xy 127.7405 168.094486) (xy 127.7405 167.905513) (xy 127.71094 167.718881) (xy 127.67228 167.599901) (xy 127.652547 167.539168) (xy 127.652545 167.539165) (xy 127.652545 167.539163) (xy 127.575736 167.388418) (xy 127.56676 167.370801) (xy 127.45569 167.217927) (xy 127.322073 167.08431) (xy 127.169199 166.97324) (xy 127.163476 166.970324) (xy 127.000836 166.887454) (xy 126.821118 166.829059) (xy 126.634486 166.7995) (xy 126.634481 166.7995) (xy 126.445519 166.7995) (xy 126.445514 166.7995) (xy 126.258881 166.829059) (xy 126.079163 166.887454) (xy 125.9108 166.97324) (xy 125.827716 167.033605) (xy 125.757927 167.08431) (xy 125.757925 167.084312) (xy 125.757924 167.084312) (xy 125.624312 167.217924) (xy 125.624312 167.217925) (xy 125.62431 167.217927) (xy 125.618261 167.226253) (xy 125.51324 167.3708) (xy 125.427454 167.539163) (xy 125.387668 167.661612) (xy 125.34823 167.719287) (xy 125.283871 167.746485) (xy 125.215025 167.73457) (xy 125.163549 167.687325) (xy 125.151806 167.661611) (xy 125.112085 167.539362) (xy 125.026329 167.371059) (xy 124.915314 167.218258) (xy 124.91531 167.218253) (xy 124.781746 167.084689) (xy 124.781741 167.084685) (xy 124.62894 166.97367) (xy 124.460635 166.887913) (xy 124.280999 166.829547) (xy 124.2 166.816718) (xy 124.2 167.53812) (xy 124.192993 167.534075) (xy 124.065826 167.5) (xy 123.934174 167.5) (xy 123.807007 167.534075) (xy 123.8 167.53812) (xy 123.8 166.816718) (xy 123.799999 166.816718) (xy 123.719 166.829547) (xy 123.539364 166.887913) (xy 123.371059 166.97367) (xy 123.218258 167.084685) (xy 123.218253 167.084689) (xy 123.084689 167.218253) (xy 123.084685 167.218258) (xy 122.973667 167.371063) (xy 122.973666 167.371064) (xy 122.894983 167.525487) (xy 122.847009 167.576283) (xy 122.779188 167.593078) (xy 122.713053 167.57054) (xy 122.669602 167.515825) (xy 122.660499 167.469192) (xy 122.660499 167.226253) (xy 122.680184 167.159214) (xy 122.689111 167.147024) (xy 122.692845 167.142529) (xy 124.51817 164.944922) (xy 124.54238 164.920713) (xy 124.551729 164.904518) (xy 124.563676 164.890136) (xy 124.575592 164.864243) (xy 124.58085 164.85408) (xy 124.595105 164.82939) (xy 124.595104 164.82939) (xy 124.595107 164.829387) (xy 124.599946 164.811324) (xy 124.607763 164.794341) (xy 124.613538 164.760597) (xy 124.6224 164.727527) (xy 124.6224 164.708829) (xy 124.625555 164.690398) (xy 124.6224 164.656304) (xy 124.6224 163.0745) (xy 124.642085 163.007461) (xy 124.694889 162.961706) (xy 124.7464 162.9505) (xy 125.293097 162.9505) (xy 125.293102 162.9505) (xy 125.381564 162.939877) (xy 125.522342 162.884361) (xy 125.642922 162.792922) (xy 125.734361 162.672342) (xy 125.789877 162.531564) (xy 125.8005 162.443102) (xy 125.8005 161.556898) (xy 125.789877 161.468436) (xy 125.734361 161.327658) (xy 125.73436 161.327657) (xy 125.73436 161.327656) (xy 125.642922 161.207077) (xy 125.522343 161.115639) (xy 125.381561 161.060122) (xy 125.335926 161.054642) (xy 125.293102 161.0495) (xy 124.706898 161.0495) (xy 124.667853 161.054188) (xy 124.618438 161.060122) (xy 124.477656 161.115639) (xy 124.357077 161.207077) (xy 124.265639 161.327656) (xy 124.210122 161.468438) (xy 124.204666 161.513876) (xy 124.1995 161.556898) (xy 124.1995 161.556903) (xy 124.1995 162.071833) (xy 124.198861 162.074007) (xy 124.199423 162.076204) (xy 124.189061 162.10738) (xy 124.179815 162.138872) (xy 124.17788 162.141027) (xy 124.177388 162.142508) (xy 124.153349 162.16835) (xy 124.002349 162.290144) (xy 123.93781 162.316911) (xy 123.869045 162.304536) (xy 123.817886 162.256948) (xy 123.8005 162.193627) (xy 123.8005 161.556903) (xy 123.8005 161.556898) (xy 123.789877 161.468436) (xy 123.734361 161.327658) (xy 123.73436 161.327657) (xy 123.73436 161.327656) (xy 123.642922 161.207077) (xy 123.522343 161.115639) (xy 123.381561 161.060122) (xy 123.335926 161.054642) (xy 123.293102 161.0495) (xy 122.706898 161.0495) (xy 122.667853 161.054188) (xy 122.618438 161.060122) (xy 122.477656 161.115639) (xy 122.357077 161.207077) (xy 122.265639 161.327656) (xy 122.210122 161.468438) (xy 122.204666 161.513876) (xy 122.1995 161.556898) (xy 122.1995 162.443102) (xy 122.203092 162.473013) (xy 122.210122 162.531561) (xy 122.265639 162.672343) (xy 122.357077 162.792922) (xy 122.477656 162.88436) (xy 122.477657 162.88436) (xy 122.477658 162.884361) (xy 122.618436 162.939877) (xy 122.706898 162.9505) (xy 122.706903 162.9505) (xy 123.293097 162.9505) (xy 123.293102 162.9505) (xy 123.381564 162.939877) (xy 123.522342 162.884361) (xy 123.622474 162.808427) (xy 123.687785 162.783604) (xy 123.756149 162.798032) (xy 123.805861 162.847129) (xy 123.8214 162.907231) (xy 123.8214 164.485383) (xy 123.801715 164.552422) (xy 123.792788 164.564612) (xy 121.973684 166.754729) (xy 121.915707 166.793722) (xy 121.878296 166.7995) (xy 120.515143 166.7995) (xy 120.515117 166.799502) (xy 120.490012 166.802413) (xy 120.490008 166.802415) (xy 120.387235 166.847793) (xy 120.307794 166.927234) (xy 120.262415 167.030006) (xy 120.262415 167.030008) (xy 120.2595 167.055131) (xy 113.860854 167.055131) (xy 113.867524 167.039787) (xy 113.867606 167.039227) (xy 113.867833 167.038703) (xy 113.867849 167.038647) (xy 113.868586 167.033609) (xy 113.875414 166.986938) (xy 114.777623 160.943934) (xy 114.781803 160.932482) (xy 114.785386 160.891933) (xy 114.791395 160.85169) (xy 114.791394 160.851686) (xy 114.791395 160.851683) (xy 114.791416 160.850463) (xy 114.791139 160.828654) (xy 114.791087 160.827438) (xy 114.791087 160.827437) (xy 114.784054 160.787346) (xy 114.779442 160.746916) (xy 114.774972 160.735575) (xy 114.772867 160.72357) (xy 114.757274 160.690054) (xy 114.75434 160.683218) (xy 114.740779 160.648806) (xy 114.740779 160.648805) (xy 114.740776 160.648802) (xy 114.740188 160.647739) (xy 114.728232 160.627629) (xy 112.200431 155.194173) (xy 112.195807 155.176913) (xy 112.178272 155.146541) (xy 112.163485 155.114757) (xy 112.158947 155.109339) (xy 112.146615 155.091711) (xy 112.143079 155.085586) (xy 112.133392 155.075899) (xy 112.118283 155.06079) (xy 112.095773 155.033915) (xy 112.081148 155.023655) (xy 112.068513 155.01102) (xy 112.068512 155.011019) (xy 112.042883 154.996223) (xy 112.042882 154.996222) (xy 112.038143 154.993486) (xy 112.009444 154.973352) (xy 111.992659 154.967226) (xy 111.98331 154.961828) (xy 111.983309 154.961827) (xy 111.983308 154.961827) (xy 111.977187 154.958293) (xy 111.977183 154.958291) (xy 111.948595 154.95063) (xy 111.948595 154.950631) (xy 111.943311 154.949215) (xy 111.910382 154.937197) (xy 111.89259 154.935624) (xy 111.882165 154.932831) (xy 111.88216 154.932831) (xy 111.875327 154.931) (xy 111.875326 154.931) (xy 111.845739 154.931) (xy 111.834824 154.930519) (xy 111.805339 154.927913) (xy 111.805331 154.927913) (xy 111.79837 154.929135) (xy 111.776947 154.931) (xy 111.4495 154.931) (xy 111.382461 154.911315) (xy 111.336706 154.858511) (xy 111.3255 154.807) (xy 111.3255 154.639369) (xy 111.3255 154.639364) (xy 111.314866 154.566375) (xy 111.309041 154.55446) (xy 111.297281 154.485592) (xy 111.30904 154.445541) (xy 111.314866 154.433625) (xy 111.3255 154.360636) (xy 111.3255 154.139364) (xy 111.314866 154.066375) (xy 111.309041 154.05446) (xy 111.297281 153.985592) (xy 111.30904 153.945541) (xy 111.314866 153.933625) (xy 111.3255 153.860636) (xy 111.3255 153.639364) (xy 111.314866 153.566375) (xy 111.309041 153.55446) (xy 111.297281 153.485592) (xy 111.30904 153.445541) (xy 111.314866 153.433625) (xy 111.3255 153.360636) (xy 111.3255 153.139364) (xy 111.314866 153.066375) (xy 111.309041 153.05446) (xy 111.297281 152.985592) (xy 111.30904 152.945541) (xy 111.314866 152.933625) (xy 111.3255 152.860636) (xy 111.3255 152.639364) (xy 111.314866 152.566375) (xy 111.309041 152.55446) (xy 111.297281 152.485592) (xy 111.30904 152.445541) (xy 111.314866 152.433625) (xy 111.3255 152.360636) (xy 111.3255 152.139364) (xy 111.314866 152.066375) (xy 111.309041 152.05446) (xy 111.297281 151.985592) (xy 111.30904 151.945541) (xy 111.314866 151.933625) (xy 111.3255 151.860636) (xy 111.3255 151.639364) (xy 111.314866 151.566375) (xy 111.309041 151.55446) (xy 111.297281 151.485592) (xy 111.30904 151.445541) (xy 111.314866 151.433625) (xy 111.3255 151.360636) (xy 111.3255 151.139364) (xy 111.314866 151.066375) (xy 111.309041 151.05446) (xy 111.297281 150.985592) (xy 111.30904 150.945541) (xy 111.314866 150.933625) (xy 111.3255 150.860636) (xy 111.3255 150.639364) (xy 111.314866 150.566375) (xy 111.309041 150.55446) (xy 111.297281 150.485592) (xy 111.30904 150.445541) (xy 111.314866 150.433625) (xy 111.3255 150.360636) (xy 111.3255 150.139364) (xy 111.314866 150.066375) (xy 111.309041 150.05446) (xy 111.297281 149.985592) (xy 111.30904 149.945541) (xy 111.314866 149.933625) (xy 111.3255 149.860636) (xy 111.3255 149.639364) (xy 111.314866 149.566375) (xy 111.309041 149.55446) (xy 111.297281 149.485592) (xy 111.30904 149.445541) (xy 111.314866 149.433625) (xy 111.3255 149.360636) (xy 111.3255 149.139364) (xy 111.314866 149.066375) (xy 111.309041 149.05446) (xy 111.297281 148.985592) (xy 111.30904 148.945541) (xy 111.314866 148.933625) (xy 111.3255 148.860636) (xy 111.3255 148.639364) (xy 111.314866 148.566375) (xy 111.309041 148.55446) (xy 111.297281 148.485592) (xy 111.30904 148.445541) (xy 111.314866 148.433625) (xy 111.3255 148.360636) (xy 111.3255 148.139364) (xy 111.314866 148.066375) (xy 111.309041 148.05446) (xy 111.297281 147.985592) (xy 111.30904 147.945541) (xy 111.314866 147.933625) (xy 111.3255 147.860636) (xy 111.3255 147.639364) (xy 111.314866 147.566375) (xy 111.309041 147.55446) (xy 111.297281 147.485592) (xy 111.30904 147.445541) (xy 111.314866 147.433625) (xy 111.3255 147.360636) (xy 111.3255 147.139364) (xy 111.314866 147.066375) (xy 111.309041 147.05446) (xy 111.297281 146.985592) (xy 111.297476 146.984009) (xy 111.3001 146.963828) (xy 111.314866 146.933625) (xy 111.3255 146.860636) (xy 111.3255 146.780131) (xy 111.8945 146.780131) (xy 111.8945 153.219856) (xy 111.894502 153.219882) (xy 111.897413 153.244987) (xy 111.897415 153.244991) (xy 111.942793 153.347764) (xy 111.942794 153.347765) (xy 112.022235 153.427206) (xy 112.125009 153.472585) (xy 112.150135 153.4755) (xy 115.849864 153.475499) (xy 115.849879 153.475497) (xy 115.849882 153.475497) (xy 115.874987 153.472586) (xy 115.874988 153.472585) (xy 115.874991 153.472585) (xy 115.977765 153.427206) (xy 116.057206 153.347765) (xy 116.102585 153.244991) (xy 116.1055 153.219865) (xy 116.105499 146.780136) (xy 116.104152 146.768521) (xy 116.102586 146.755012) (xy 116.102585 146.75501) (xy 116.102585 146.755009) (xy 116.057206 146.652235) (xy 115.977765 146.572794) (xy 115.963225 146.566374) (xy 115.874992 146.527415) (xy 115.849865 146.5245) (xy 112.150143 146.5245) (xy 112.150117 146.524502) (xy 112.125012 146.527413) (xy 112.125008 146.527415) (xy 112.022235 146.572793) (xy 111.942794 146.652234) (xy 111.897415 146.755006) (xy 111.897415 146.755008) (xy 111.8945 146.780131) (xy 111.3255 146.780131) (xy 111.3255 146.639364) (xy 111.314866 146.566375) (xy 111.309041 146.55446) (xy 111.297281 146.485592) (xy 111.30904 146.445541) (xy 111.314866 146.433625) (xy 111.3255 146.360636) (xy 111.3255 146.139364) (xy 111.314866 146.066375) (xy 111.309041 146.05446) (xy 111.297281 145.985592) (xy 111.30904 145.945541) (xy 111.314866 145.933625) (xy 111.3255 145.860636) (xy 111.3255 145.639364) (xy 111.314866 145.566375) (xy 111.309041 145.55446) (xy 111.297281 145.485592) (xy 111.30904 145.445541) (xy 111.314866 145.433625) (xy 111.3255 145.360636) (xy 111.3255 145.139364) (xy 111.314866 145.066375) (xy 111.309041 145.05446) (xy 111.297281 144.985592) (xy 111.30904 144.945541) (xy 111.314866 144.933625) (xy 111.3255 144.860636) (xy 111.3255 144.639364) (xy 111.314866 144.566375) (xy 111.309041 144.55446) (xy 111.297281 144.485592) (xy 111.30904 144.445541) (xy 111.314866 144.433625) (xy 111.3255 144.360636) (xy 111.3255 144.139364) (xy 111.314866 144.066375) (xy 111.302265 144.0406) (xy 111.299093 144.02551) (xy 111.300669 144.005437) (xy 111.297281 143.985592) (xy 111.304036 143.962584) (xy 111.304565 143.955855) (xy 111.306924 143.952749) (xy 111.30904 143.945541) (xy 111.314866 143.933625) (xy 111.3255 143.860636) (xy 111.3255 143.639364) (xy 111.314866 143.566375) (xy 111.309041 143.55446) (xy 111.297281 143.485592) (xy 111.30904 143.445541) (xy 111.314866 143.433625) (xy 111.3255 143.360636) (xy 111.3255 143.139364) (xy 116.6745 143.139364) (xy 116.6745 143.360636) (xy 116.685134 143.433625) (xy 116.69096 143.445542) (xy 116.702717 143.514416) (xy 116.69096 143.554456) (xy 116.685134 143.566375) (xy 116.6745 143.639364) (xy 116.6745 143.860636) (xy 116.682475 143.915377) (xy 116.685134 143.933627) (xy 116.691237 143.94611) (xy 116.702995 144.014983) (xy 116.691237 144.055028) (xy 116.685619 144.066518) (xy 116.685619 144.066519) (xy 116.680741 144.099999) (xy 116.680742 144.1) (xy 116.7426 144.1) (xy 116.803299 144.115872) (xy 116.818199 144.124236) (xy 116.828789 144.134826) (xy 116.892857 144.166147) (xy 116.89593 144.167872) (xy 116.917983 144.190448) (xy 116.941274 144.211728) (xy 116.942207 144.215248) (xy 116.944753 144.217854) (xy 116.951098 144.248766) (xy 116.959188 144.279262) (xy 116.95807 144.282727) (xy 116.958803 144.286296) (xy 116.947428 144.315733) (xy 116.937747 144.34576) (xy 116.934933 144.348071) (xy 116.93362 144.35147) (xy 116.908134 144.370085) (xy 116.883758 144.39011) (xy 116.879544 144.390968) (xy 116.877199 144.392682) (xy 116.868624 144.393194) (xy 116.835231 144.4) (xy 116.680742 144.4) (xy 116.685619 144.433479) (xy 116.691516 144.445542) (xy 116.703273 144.514415) (xy 116.691516 144.554458) (xy 116.685619 144.56652) (xy 116.680741 144.599999) (xy 116.680742 144.6) (xy 117.6 144.6) (xy 117.6 144.390935) (xy 117.587068 144.376011) (xy 117.585151 144.362679) (xy 117.578696 144.350858) (xy 117.580275 144.328771) (xy 117.577124 144.306853) (xy 117.582719 144.294601) (xy 117.58368 144.281166) (xy 117.59695 144.263439) (xy 117.606149 144.243297) (xy 117.61748 144.236014) (xy 117.625552 144.225233) (xy 117.646297 144.217495) (xy 117.664927 144.205523) (xy 117.686845 144.202371) (xy 117.691016 144.200816) (xy 117.699862 144.2005) (xy 117.800138 144.2005) (xy 117.867177 144.220185) (xy 117.912932 144.272989) (xy 117.922876 144.342147) (xy 117.9 144.392238) (xy 117.9 144.6) (xy 118.819258 144.6) (xy 118.819258 144.599999) (xy 118.81438 144.56652) (xy 118.814379 144.566517) (xy 118.808487 144.554465) (xy 118.796725 144.485592) (xy 118.808487 144.445535) (xy 118.814379 144.433482) (xy 118.81438 144.433479) (xy 118.819258 144.4) (xy 118.664769 144.4) (xy 118.661099 144.398922) (xy 118.657374 144.399779) (xy 118.627838 144.389155) (xy 118.59773 144.380315) (xy 118.595227 144.377426) (xy 118.591628 144.376132) (xy 118.572523 144.351224) (xy 118.551975 144.327511) (xy 118.55143 144.323726) (xy 118.549104 144.320693) (xy 118.546498 144.28942) (xy 118.542031 144.258353) (xy 118.543619 144.254874) (xy 118.543302 144.251065) (xy 118.558018 144.223345) (xy 118.571056 144.194797) (xy 118.574792 144.191749) (xy 118.576065 144.189353) (xy 118.59072 144.178759) (xy 118.60407 144.167872) (xy 118.607142 144.166147) (xy 118.671211 144.134826) (xy 118.6818 144.124236) (xy 118.696701 144.115872) (xy 118.71477 144.111718) (xy 118.731042 144.102834) (xy 118.7574 144.1) (xy 118.819258 144.1) (xy 118.819258 144.099999) (xy 118.81438 144.06652) (xy 118.808765 144.055035) (xy 118.797003 143.986162) (xy 118.808763 143.946107) (xy 118.814866 143.933625) (xy 118.8255 143.860636) (xy 118.8255 143.639364) (xy 118.814866 143.566375) (xy 118.809041 143.55446) (xy 118.797281 143.485592) (xy 118.80904 143.445541) (xy 118.814866 143.433625) (xy 118.8255 143.360636) (xy 118.8255 143.139364) (xy 118.814866 143.066375) (xy 118.812518 143.061572) (xy 118.759827 142.953789) (xy 118.67121 142.865172) (xy 118.558628 142.810135) (xy 118.558626 142.810134) (xy 118.558625 142.810134) (xy 118.485636 142.7995) (xy 117.014364 142.7995) (xy 116.941375 142.810134) (xy 116.941373 142.810134) (xy 116.941371 142.810135) (xy 116.828789 142.865172) (xy 116.740172 142.953789) (xy 116.685135 143.066371) (xy 116.685134 143.066373) (xy 116.685134 143.066375) (xy 116.6745 143.139364) (xy 111.3255 143.139364) (xy 111.314866 143.066375) (xy 111.312518 143.061572) (xy 111.259827 142.953789) (xy 111.17121 142.865172) (xy 111.058628 142.810135) (xy 111.058626 142.810134) (xy 111.058625 142.810134) (xy 110.985636 142.7995) (xy 109.514364 142.7995) (xy 109.441375 142.810134) (xy 109.441373 142.810134) (xy 109.441371 142.810135) (xy 109.328789 142.865172) (xy 109.240172 142.953789) (xy 109.185135 143.066371) (xy 109.185134 143.066373) (xy 109.185134 143.066375) (xy 109.1745 143.139364) (xy 109.1745 143.360636) (xy 109.185134 143.433625) (xy 109.19096 143.445542) (xy 109.202717 143.514416) (xy 109.19096 143.554456) (xy 109.185134 143.566375) (xy 109.1745 143.639364) (xy 109.1745 143.860636) (xy 109.185134 143.933625) (xy 109.19096 143.945542) (xy 109.202717 144.014416) (xy 109.19096 144.054456) (xy 109.185134 144.066375) (xy 109.1745 144.139364) (xy 109.1745 144.360636) (xy 109.185134 144.433625) (xy 109.190956 144.445535) (xy 109.19096 144.445542) (xy 109.202717 144.514416) (xy 109.19096 144.554456) (xy 109.185134 144.566375) (xy 109.1745 144.639364) (xy 109.1745 144.860636) (xy 109.185134 144.933625) (xy 109.190956 144.945535) (xy 109.19096 144.945542) (xy 109.202717 145.014416) (xy 109.19096 145.054456) (xy 109.185134 145.066375) (xy 109.1745 145.139364) (xy 109.1745 145.360636) (xy 109.185112 145.433477) (xy 109.185134 145.433625) (xy 109.19096 145.445542) (xy 109.202717 145.514416) (xy 109.19096 145.554458) (xy 109.18691 145.562743) (xy 109.185134 145.566375) (xy 109.1745 145.639364) (xy 109.1745 145.860636) (xy 109.185134 145.933625) (xy 109.19096 145.945542) (xy 109.202717 146.014416) (xy 109.19096 146.054456) (xy 109.185134 146.066375) (xy 109.1745 146.139364) (xy 109.1745 146.360636) (xy 109.185133 146.43362) (xy 109.185134 146.433625) (xy 109.19096 146.445542) (xy 109.202717 146.514416) (xy 109.19096 146.554456) (xy 109.185134 146.566375) (xy 109.1745 146.639364) (xy 109.1745 146.860636) (xy 109.184567 146.92973) (xy 109.185134 146.933625) (xy 109.19096 146.945542) (xy 109.202717 147.014416) (xy 109.19096 147.054456) (xy 109.185134 147.066375) (xy 109.1745 147.139364) (xy 109.1745 147.360636) (xy 109.185113 147.43348) (xy 109.185134 147.433625) (xy 109.19096 147.445542) (xy 109.202717 147.514416) (xy 109.19096 147.554458) (xy 109.185136 147.566371) (xy 109.185134 147.566375) (xy 109.1745 147.639364) (xy 109.1745 147.860636) (xy 109.179352 147.893939) (xy 109.185134 147.933625) (xy 109.19096 147.945542) (xy 109.202717 148.014416) (xy 109.19096 148.054458) (xy 109.185135 148.066373) (xy 109.185134 148.066375) (xy 109.1745 148.139364) (xy 109.1745 148.360636) (xy 109.180235 148.4) (xy 109.185134 148.433625) (xy 109.19096 148.445542) (xy 109.202717 148.514416) (xy 109.19096 148.554458) (xy 109.187388 148.561765) (xy 109.185134 148.566375) (xy 109.1745 148.639364) (xy 109.1745 148.860636) (xy 109.181215 148.906723) (xy 109.185134 148.933625) (xy 109.19096 148.945542) (xy 109.202717 149.014416) (xy 109.19096 149.054456) (xy 109.185134 149.066375) (xy 109.1745 149.139364) (xy 109.1745 149.360636) (xy 109.185134 149.433625) (xy 109.19096 149.445542) (xy 109.202717 149.514416) (xy 109.19096 149.554456) (xy 109.185134 149.566375) (xy 109.1745 149.639364) (xy 109.1745 149.860636) (xy 109.180235 149.9) (xy 109.185134 149.933625) (xy 109.19096 149.945542) (xy 109.202717 150.014416) (xy 109.19096 150.054458) (xy 109.185136 150.066371) (xy 109.185134 150.066375) (xy 109.1745 150.139364) (xy 109.1745 150.360636) (xy 109.185134 150.433625) (xy 109.19096 150.445542) (xy 109.202717 150.514416) (xy 109.19096 150.554456) (xy 109.185134 150.566375) (xy 109.1745 150.639364) (xy 109.1745 150.639369) (xy 109.1745 150.8322) (xy 109.171949 150.840885) (xy 109.173238 150.849847) (xy 109.162259 150.873887) (xy 109.154815 150.899239) (xy 109.147974 150.905166) (xy 109.144213 150.913403) (xy 109.121978 150.927692) (xy 109.102011 150.944994) (xy 109.091496 150.947281) (xy 109.085435 150.951177) (xy 109.0505 150.9562) (xy 108.934598 150.9562) (xy 108.867559 150.936515) (xy 108.846917 150.919881) (xy 108.803217 150.876181) (xy 108.803209 150.876175) (xy 108.66629 150.797126) (xy 108.666286 150.797124) (xy 108.666284 150.797123) (xy 108.513557 150.7562) (xy 108.355443 150.7562) (xy 108.202716 150.797123) (xy 108.202709 150.797126) (xy 108.06579 150.876175) (xy 108.065782 150.876181) (xy 107.953981 150.987982) (xy 107.953975 150.98799) (xy 107.874926 151.124909) (xy 107.874923 151.124916) (xy 107.834 151.277643) (xy 107.834 151.435757) (xy 107.865808 151.554464) (xy 107.874923 151.588483) (xy 107.874926 151.58849) (xy 107.953975 151.725409) (xy 107.953979 151.725414) (xy 107.95398 151.725416) (xy 108.065784 151.83722) (xy 108.065786 151.837221) (xy 108.06579 151.837224) (xy 108.202709 151.916273) (xy 108.202716 151.916277) (xy 108.355443 151.9572) (xy 108.355445 151.9572) (xy 108.513555 151.9572) (xy 108.513557 151.9572) (xy 108.666284 151.916277) (xy 108.803216 151.83722) (xy 108.846917 151.793519) (xy 108.873844 151.778815) (xy 108.899663 151.762223) (xy 108.905863 151.761331) (xy 108.90824 151.760034) (xy 108.934598 151.7572) (xy 109.052187 151.7572) (xy 109.119226 151.776885) (xy 109.164981 151.829689) (xy 109.17489 151.863319) (xy 109.182606 151.916273) (xy 109.185134 151.933625) (xy 109.19096 151.945542) (xy 109.202717 152.014416) (xy 109.19096 152.054456) (xy 109.185134 152.066375) (xy 109.1745 152.139364) (xy 109.1745 152.360636) (xy 109.180235 152.4) (xy 109.185134 152.433625) (xy 109.19096 152.445542) (xy 109.202717 152.514416) (xy 109.19096 152.554456) (xy 109.189742 152.556949) (xy 109.185134 152.566374) (xy 109.184088 152.573555) (xy 109.1745 152.639364) (xy 109.1745 152.860636) (xy 109.175672 152.868677) (xy 109.185134 152.933625) (xy 109.19096 152.945542) (xy 109.202717 153.014416) (xy 109.19096 153.054456) (xy 109.185134 153.066375) (xy 109.1745 153.139364) (xy 109.1745 153.360636) (xy 109.182886 153.418192) (xy 109.185134 153.433625) (xy 109.19096 153.445542) (xy 109.202717 153.514416) (xy 109.19096 153.554456) (xy 109.185134 153.566375) (xy 109.1745 153.639364) (xy 109.1745 153.860636) (xy 109.181812 153.910821) (xy 109.185134 153.933625) (xy 109.19096 153.945542) (xy 109.202717 154.014416) (xy 109.19096 154.054458) (xy 109.185319 154.065997) (xy 109.185134 154.066375) (xy 109.1745 154.139364) (xy 109.1745 154.360636) (xy 109.181604 154.409395) (xy 109.185134 154.433625) (xy 109.19096 154.445542) (xy 109.202717 154.514416) (xy 109.19096 154.554456) (xy 109.185134 154.566375) (xy 109.1745 154.639364) (xy 109.1745 154.860636) (xy 109.177266 154.879626) (xy 109.174746 154.897388) (xy 109.1773 154.915147) (xy 109.16994 154.931262) (xy 109.167452 154.948801) (xy 109.155728 154.962381) (xy 109.148275 154.978703) (xy 109.133371 154.988281) (xy 109.121796 155.00169) (xy 109.10459 155.006776) (xy 109.089497 155.016477) (xy 109.055013 155.021435) (xy 109.054794 155.0215) (xy 108.971464 155.0215) (xy 108.961522 155.020904) (xy 108.910012 155.021486) (xy 108.909538 155.021492) (xy 108.908139 155.0215) (xy 108.858373 155.0215) (xy 108.855412 155.021888) (xy 108.855397 155.021891) (xy 108.854032 155.02207) (xy 108.805902 155.03555) (xy 108.805901 155.035549) (xy 108.805113 155.035769) (xy 108.756513 155.048793) (xy 108.75452 155.049943) (xy 108.752305 155.050564) (xy 108.752302 155.050565) (xy 108.752301 155.050566) (xy 108.709544 155.075899) (xy 108.708342 155.076602) (xy 108.665186 155.10152) (xy 108.662799 155.10335) (xy 108.662796 155.103354) (xy 108.661715 155.104183) (xy 108.661581 155.104319) (xy 108.661581 155.10432) (xy 108.626725 155.139971) (xy 108.625821 155.140885) (xy 108.589053 155.177653) (xy 108.58252 155.185187) (xy 105.927836 157.900556) (xy 105.927837 157.900557) (xy 105.927311 157.901094) (xy 105.89162 157.936787) (xy 105.890471 157.938775) (xy 105.888863 157.940421) (xy 105.86449 157.983759) (xy 105.8638 157.98497) (xy 105.838888 158.02812) (xy 105.837781 158.030791) (xy 105.837761 158.030842) (xy 105.837216 158.032155) (xy 105.824827 158.080574) (xy 105.824473 158.081928) (xy 105.813679 158.122211) (xy 105.777313 158.181871) (xy 105.714466 158.2124) (xy 105.645091 158.204105) (xy 105.618979 158.188921) (xy 105.522343 158.115639) (xy 105.426192 158.077722) (xy 105.381564 158.060123) (xy 105.381563 158.060122) (xy 105.381561 158.060122) (xy 105.335926 158.054642) (xy 105.293102 158.0495) (xy 104.706898 158.0495) (xy 104.667853 158.054188) (xy 104.618438 158.060122) (xy 104.477656 158.115639) (xy 104.357077 158.207077) (xy 104.265639 158.327656) (xy 104.210122 158.468438) (xy 104.204188 158.517853) (xy 104.1995 158.556898) (xy 104.1995 159.443102) (xy 104.205126 159.489954) (xy 104.210122 159.531561) (xy 104.265639 159.672343) (xy 104.357077 159.792922) (xy 104.477656 159.88436) (xy 104.477657 159.88436) (xy 104.477658 159.884361) (xy 104.618436 159.939877) (xy 104.706898 159.9505) (xy 104.706903 159.9505) (xy 105.293097 159.9505) (xy 105.293102 159.9505) (xy 105.381564 159.939877) (xy 105.522342 159.884361) (xy 105.612676 159.815858) (xy 105.625623 159.810937) (xy 105.636089 159.801869) (xy 105.657634 159.798771) (xy 105.677986 159.791036) (xy 105.691538 159.793896) (xy 105.705247 159.791925) (xy 105.725049 159.800968) (xy 105.74635 159.805464) (xy 105.756203 159.815196) (xy 105.768803 159.82095) (xy 105.780572 159.839263) (xy 105.796061 159.854561) (xy 105.799869 159.86929) (xy 105.806577 159.879728) (xy 105.8116 159.914663) (xy 105.8116 160.029131) (xy 105.791915 160.09617) (xy 105.775278 160.116816) (xy 104.700532 161.191477) (xy 104.700479 161.191526) (xy 104.653298 161.238708) (xy 104.653206 161.2388) (xy 104.653004 161.239003) (xy 104.62163 161.270375) (xy 104.621627 161.270379) (xy 104.62162 161.270387) (xy 104.621143 161.271212) (xy 104.62114 161.271216) (xy 104.593952 161.318307) (xy 104.593929 161.318347) (xy 104.593371 161.319315) (xy 104.568899 161.361698) (xy 104.568896 161.361706) (xy 104.568893 161.361713) (xy 104.567915 161.365361) (xy 104.567914 161.365364) (xy 104.559041 161.398481) (xy 104.55904 161.398486) (xy 104.54239 161.460613) (xy 104.542389 161.460616) (xy 104.541602 161.463557) (xy 104.541601 161.463565) (xy 104.5416 161.463573) (xy 104.5416 161.513876) (xy 104.541599 161.51473) (xy 104.541599 161.514797) (xy 104.541598 161.577634) (xy 104.5416 161.577663) (xy 104.5416 165.270803) (xy 104.521915 165.337842) (xy 104.506152 165.357605) (xy 102.515465 167.388417) (xy 102.515466 167.388418) (xy 102.514887 167.389009) (xy 102.479442 167.424191) (xy 102.478038 167.426601) (xy 102.47608 167.428599) (xy 102.45191 167.471445) (xy 102.451909 167.471444) (xy 102.451445 167.472266) (xy 102.426374 167.515319) (xy 102.425642 167.518009) (xy 102.424269 167.520444) (xy 102.424268 167.520446) (xy 102.424268 167.520447) (xy 102.412017 167.568056) (xy 102.412018 167.568057) (xy 102.411793 167.568929) (xy 102.3987 167.617076) (xy 102.398688 167.619868) (xy 102.397993 167.622574) (xy 102.398483 167.671723) (xy 102.398488 167.673421) (xy 102.392122 169.376464) (xy 102.372187 169.443429) (xy 102.319212 169.488986) (xy 102.268123 169.5) (xy 101.624 169.5) (xy 101.556961 169.480315) (xy 101.511206 169.427511) (xy 101.5 169.376) (xy 101.5 159.443053) (xy 102.2 159.443053) (xy 102.210613 159.531443) (xy 102.266079 159.672095) (xy 102.357435 159.792564) (xy 102.477904 159.88392) (xy 102.618556 159.939386) (xy 102.706946 159.95) (xy 102.8 159.95) (xy 103.2 159.95) (xy 103.293054 159.95) (xy 103.381443 159.939386) (xy 103.522095 159.88392) (xy 103.642564 159.792564) (xy 103.73392 159.672095) (xy 103.789386 159.531443) (xy 103.8 159.443053) (xy 103.8 159.2) (xy 103.2 159.2) (xy 103.2 159.95) (xy 102.8 159.95) (xy 102.8 159.2) (xy 102.2 159.2) (xy 102.2 159.443053) (xy 101.5 159.443053) (xy 101.5 158.556946) (xy 102.2 158.556946) (xy 102.2 158.8) (xy 102.8 158.8) (xy 103.2 158.8) (xy 103.8 158.8) (xy 103.8 158.556946) (xy 103.789386 158.468556) (xy 103.73392 158.327904) (xy 103.642564 158.207435) (xy 103.522095 158.116079) (xy 103.381443 158.060613) (xy 103.293054 158.05) (xy 103.2 158.05) (xy 103.2 158.8) (xy 102.8 158.8) (xy 102.8 158.05) (xy 102.706946 158.05) (xy 102.618556 158.060613) (xy 102.477904 158.116079) (xy 102.357435 158.207435) (xy 102.266079 158.327904) (xy 102.210613 158.468556) (xy 102.2 158.556946) (xy 101.5 158.556946) (xy 101.5 153.443053) (xy 102.2 153.443053) (xy 102.210613 153.531443) (xy 102.266079 153.672095) (xy 102.357435 153.792564) (xy 102.477904 153.88392) (xy 102.618556 153.939386) (xy 102.706946 153.95) (xy 102.8 153.95) (xy 103.2 153.95) (xy 103.293054 153.95) (xy 103.381443 153.939386) (xy 103.522095 153.88392) (xy 103.642564 153.792564) (xy 103.73392 153.672095) (xy 103.789386 153.531443) (xy 103.8 153.443053) (xy 103.8 153.2) (xy 103.2 153.2) (xy 103.2 153.95) (xy 102.8 153.95) (xy 102.8 153.2) (xy 102.2 153.2) (xy 102.2 153.443053) (xy 101.5 153.443053) (xy 101.5 152.556946) (xy 102.2 152.556946) (xy 102.2 152.8) (xy 102.8 152.8) (xy 103.2 152.8) (xy 103.8 152.8) (xy 103.8 152.556949) (xy 103.799999 152.556943) (xy 103.799994 152.556898) (xy 104.1995 152.556898) (xy 104.1995 153.443102) (xy 104.203822 153.479094) (xy 104.210122 153.531561) (xy 104.265639 153.672343) (xy 104.357077 153.792922) (xy 104.477656 153.88436) (xy 104.477657 153.88436) (xy 104.477658 153.884361) (xy 104.618436 153.939877) (xy 104.706898 153.9505) (xy 104.706903 153.9505) (xy 105.293097 153.9505) (xy 105.293102 153.9505) (xy 105.381564 153.939877) (xy 105.522342 153.884361) (xy 105.642922 153.792922) (xy 105.734361 153.672342) (xy 105.789877 153.531564) (xy 105.8005 153.443102) (xy 105.8005 152.556898) (xy 105.789877 152.468436) (xy 105.734361 152.327658) (xy 105.73436 152.327657) (xy 105.73436 152.327656) (xy 105.642922 152.207077) (xy 105.522343 152.115639) (xy 105.425144 152.077309) (xy 105.381564 152.060123) (xy 105.381563 152.060122) (xy 105.381561 152.060122) (xy 105.334389 152.054458) (xy 105.293102 152.0495) (xy 104.706898 152.0495) (xy 104.667853 152.054188) (xy 104.618438 152.060122) (xy 104.477656 152.115639) (xy 104.357077 152.207077) (xy 104.265639 152.327656) (xy 104.210122 152.468438) (xy 104.205524 152.506736) (xy 104.1995 152.556898) (xy 103.799994 152.556898) (xy 103.789386 152.468556) (xy 103.73392 152.327904) (xy 103.642564 152.207435) (xy 103.522095 152.116079) (xy 103.381443 152.060613) (xy 103.293054 152.05) (xy 103.2 152.05) (xy 103.2 152.8) (xy 102.8 152.8) (xy 102.8 152.05) (xy 102.706946 152.05) (xy 102.618556 152.060613) (xy 102.477904 152.116079) (xy 102.357435 152.207435) (xy 102.266079 152.327904) (xy 102.210613 152.468556) (xy 102.2 152.556946) (xy 101.5 152.556946) (xy 101.5 147.443053) (xy 102.2 147.443053) (xy 102.210613 147.531443) (xy 102.266079 147.672095) (xy 102.357435 147.792564) (xy 102.477904 147.88392) (xy 102.618556 147.939386) (xy 102.706946 147.95) (xy 102.8 147.95) (xy 103.2 147.95) (xy 103.293054 147.95) (xy 103.381443 147.939386) (xy 103.522095 147.88392) (xy 103.642564 147.792564) (xy 103.73392 147.672095) (xy 103.789386 147.531443) (xy 103.8 147.443053) (xy 103.8 147.2) (xy 103.2 147.2) (xy 103.2 147.95) (xy 102.8 147.95) (xy 102.8 147.2) (xy 102.2 147.2) (xy 102.2 147.443053) (xy 101.5 147.443053) (xy 101.5 146.556946) (xy 102.2 146.556946) (xy 102.2 146.8) (xy 102.8 146.8) (xy 103.2 146.8) (xy 103.8 146.8) (xy 103.8 146.556949) (xy 103.799999 146.556943) (xy 103.799994 146.556898) (xy 104.1995 146.556898) (xy 104.1995 147.443102) (xy 104.204602 147.485592) (xy 104.210122 147.531561) (xy 104.265639 147.672343) (xy 104.357077 147.792922) (xy 104.477656 147.88436) (xy 104.477657 147.88436) (xy 104.477658 147.884361) (xy 104.618436 147.939877) (xy 104.706898 147.9505) (xy 104.706903 147.9505) (xy 105.293097 147.9505) (xy 105.293102 147.9505) (xy 105.381564 147.939877) (xy 105.522342 147.884361) (xy 105.642922 147.792922) (xy 105.734361 147.672342) (xy 105.789877 147.531564) (xy 105.8005 147.443102) (xy 105.8005 146.556898) (xy 105.789877 146.468436) (xy 105.734361 146.327658) (xy 105.73436 146.327657) (xy 105.73436 146.327656) (xy 105.642922 146.207077) (xy 105.522343 146.115639) (xy 105.397415 146.066374) (xy 105.381564 146.060123) (xy 105.381563 146.060122) (xy 105.381561 146.060122) (xy 105.334389 146.054458) (xy 105.293102 146.0495) (xy 104.706898 146.0495) (xy 104.667853 146.054188) (xy 104.618438 146.060122) (xy 104.477656 146.115639) (xy 104.357077 146.207077) (xy 104.265639 146.327656) (xy 104.210122 146.468438) (xy 104.204871 146.512171) (xy 104.1995 146.556898) (xy 103.799994 146.556898) (xy 103.789386 146.468556) (xy 103.73392 146.327904) (xy 103.642564 146.207435) (xy 103.522095 146.116079) (xy 103.381443 146.060613) (xy 103.293054 146.05) (xy 103.2 146.05) (xy 103.2 146.8) (xy 102.8 146.8) (xy 102.8 146.05) (xy 102.706946 146.05) (xy 102.618556 146.060613) (xy 102.477904 146.116079) (xy 102.357435 146.207435) (xy 102.266079 146.327904) (xy 102.210613 146.468556) (xy 102.2 146.556946) (xy 101.5 146.556946) (xy 101.5 136.556898) (xy 132.1995 136.556898) (xy 132.1995 137.443102) (xy 132.205126 137.489954) (xy 132.210122 137.531561) (xy 132.265639 137.672343) (xy 132.357077 137.792922) (xy 132.477656 137.88436) (xy 132.477657 137.88436) (xy 132.477658 137.884361) (xy 132.618436 137.939877) (xy 132.706898 137.9505) (xy 132.706903 137.9505) (xy 133.293097 137.9505) (xy 133.293102 137.9505) (xy 133.381564 137.939877) (xy 133.522342 137.884361) (xy 133.642922 137.792922) (xy 133.734361 137.672342) (xy 133.789877 137.531564) (xy 133.8005 137.443102) (xy 133.8005 136.556898) (xy 134.1995 136.556898) (xy 134.1995 137.443102) (xy 134.205126 137.489954) (xy 134.210122 137.531561) (xy 134.265639 137.672343) (xy 134.357077 137.792922) (xy 134.477656 137.88436) (xy 134.477657 137.88436) (xy 134.477658 137.884361) (xy 134.618436 137.939877) (xy 134.706898 137.9505) (xy 134.706903 137.9505) (xy 135.293097 137.9505) (xy 135.293102 137.9505) (xy 135.381564 137.939877) (xy 135.522342 137.884361) (xy 135.642922 137.792922) (xy 135.734361 137.672342) (xy 135.789877 137.531564) (xy 135.8005 137.443102) (xy 135.8005 136.556898) (xy 138.1995 136.556898) (xy 138.1995 137.443102) (xy 138.205126 137.489954) (xy 138.210122 137.531561) (xy 138.265639 137.672343) (xy 138.357077 137.792922) (xy 138.477656 137.88436) (xy 138.477657 137.88436) (xy 138.477658 137.884361) (xy 138.618436 137.939877) (xy 138.706898 137.9505) (xy 138.706903 137.9505) (xy 139.293097 137.9505) (xy 139.293102 137.9505) (xy 139.381564 137.939877) (xy 139.522342 137.884361) (xy 139.642922 137.792922) (xy 139.734361 137.672342) (xy 139.789877 137.531564) (xy 139.8005 137.443102) (xy 139.8005 136.556898) (xy 139.789877 136.468436) (xy 139.734361 136.327658) (xy 139.73436 136.327657) (xy 139.73436 136.327656) (xy 139.642922 136.207077) (xy 139.522343 136.115639) (xy 139.381561 136.060122) (xy 139.335926 136.054642) (xy 139.293102 136.0495) (xy 138.706898 136.0495) (xy 138.667853 136.054188) (xy 138.618438 136.060122) (xy 138.477656 136.115639) (xy 138.357077 136.207077) (xy 138.265639 136.327656) (xy 138.210122 136.468438) (xy 138.204188 136.517853) (xy 138.1995 136.556898) (xy 135.8005 136.556898) (xy 135.789877 136.468436) (xy 135.734361 136.327658) (xy 135.73436 136.327657) (xy 135.73436 136.327656) (xy 135.642922 136.207077) (xy 135.522343 136.115639) (xy 135.381561 136.060122) (xy 135.335926 136.054642) (xy 135.293102 136.0495) (xy 134.706898 136.0495) (xy 134.667853 136.054188) (xy 134.618438 136.060122) (xy 134.477656 136.115639) (xy 134.357077 136.207077) (xy 134.265639 136.327656) (xy 134.210122 136.468438) (xy 134.204188 136.517853) (xy 134.1995 136.556898) (xy 133.8005 136.556898) (xy 133.789877 136.468436) (xy 133.734361 136.327658) (xy 133.73436 136.327657) (xy 133.73436 136.327656) (xy 133.642922 136.207077) (xy 133.522343 136.115639) (xy 133.381561 136.060122) (xy 133.335926 136.054642) (xy 133.293102 136.0495) (xy 132.706898 136.0495) (xy 132.667853 136.054188) (xy 132.618438 136.060122) (xy 132.477656 136.115639) (xy 132.357077 136.207077) (xy 132.265639 136.327656) (xy 132.210122 136.468438) (xy 132.204188 136.517853) (xy 132.1995 136.556898) (xy 101.5 136.556898) (xy 101.5 131.593243) (xy 115.295 131.593243) (xy 115.295 131.751356) (xy 115.335923 131.904083) (xy 115.335926 131.90409) (xy 115.414975 132.041009) (xy 115.414979 132.041014) (xy 115.41498 132.041016) (xy 115.526784 132.15282) (xy 115.526786 132.152821) (xy 115.52679 132.152824) (xy 115.663709 132.231873) (xy 115.663716 132.231877) (xy 115.816443 132.2728) (xy 115.816445 132.2728) (xy 115.974555 132.2728) (xy 115.974557 132.2728) (xy 116.127284 132.231877) (xy 116.264216 132.15282) (xy 116.37602 132.041016) (xy 116.455077 131.904084) (xy 116.496 131.751357) (xy 116.496 131.689555) (xy 116.515685 131.622516) (xy 116.532319 131.601874) (xy 116.947374 131.186819) (xy 117.008697 131.153334) (xy 117.035055 131.1505) (xy 117.429591 131.1505) (xy 117.429594 131.1505) (xy 117.497657 131.144315) (xy 117.65427 131.095512) (xy 117.794653 131.010648) (xy 117.910648 130.894653) (xy 117.995512 130.75427) (xy 118.044315 130.597657) (xy 118.0505 130.529594) (xy 118.0505 129.470406) (xy 119.9495 129.470406) (xy 119.9495 130.529594) (xy 119.955685 130.597657) (xy 119.955686 130.597662) (xy 119.955687 130.597664) (xy 120.004485 130.754263) (xy 120.004488 130.754272) (xy 120.089348 130.894648) (xy 120.089351 130.894652) (xy 120.205347 131.010648) (xy 120.205351 131.010651) (xy 120.345727 131.095511) (xy 120.34573 131.095512) (xy 120.502343 131.144315) (xy 120.570406 131.1505) (xy 120.570409 131.1505) (xy 121.429591 131.1505) (xy 121.429594 131.1505) (xy 121.497657 131.144315) (xy 121.65427 131.095512) (xy 121.794653 131.010648) (xy 121.910648 130.894653) (xy 121.995512 130.75427) (xy 122.044315 130.597657) (xy 122.0505 130.529594) (xy 122.0505 129.556898) (xy 128.1995 129.556898) (xy 128.1995 130.443102) (xy 128.205126 130.489954) (xy 128.210122 130.531561) (xy 128.265639 130.672343) (xy 128.357077 130.792922) (xy 128.477656 130.88436) (xy 128.477657 130.88436) (xy 128.477658 130.884361) (xy 128.618436 130.939877) (xy 128.706898 130.9505) (xy 128.706903 130.9505) (xy 129.293097 130.9505) (xy 129.293102 130.9505) (xy 129.381564 130.939877) (xy 129.522342 130.884361) (xy 129.642922 130.792922) (xy 129.734361 130.672342) (xy 129.789877 130.531564) (xy 129.8005 130.443102) (xy 129.8005 129.556898) (xy 130.1995 129.556898) (xy 130.1995 130.443102) (xy 130.205126 130.489954) (xy 130.210122 130.531561) (xy 130.265639 130.672343) (xy 130.357077 130.792922) (xy 130.477656 130.88436) (xy 130.477657 130.88436) (xy 130.477658 130.884361) (xy 130.618436 130.939877) (xy 130.706898 130.9505) (xy 130.706903 130.9505) (xy 131.293097 130.9505) (xy 131.293102 130.9505) (xy 131.381564 130.939877) (xy 131.522342 130.884361) (xy 131.642922 130.792922) (xy 131.734361 130.672342) (xy 131.789877 130.531564) (xy 131.8005 130.443102) (xy 131.8005 129.556898) (xy 136.1995 129.556898) (xy 136.1995 130.443102) (xy 136.205126 130.489954) (xy 136.210122 130.531561) (xy 136.265639 130.672343) (xy 136.357077 130.792922) (xy 136.477656 130.88436) (xy 136.477657 130.88436) (xy 136.477658 130.884361) (xy 136.618436 130.939877) (xy 136.706898 130.9505) (xy 136.706903 130.9505) (xy 137.293097 130.9505) (xy 137.293102 130.9505) (xy 137.381564 130.939877) (xy 137.522342 130.884361) (xy 137.642922 130.792922) (xy 137.734361 130.672342) (xy 137.789877 130.531564) (xy 137.8005 130.443102) (xy 137.8005 129.556898) (xy 138.1995 129.556898) (xy 138.1995 130.443102) (xy 138.205126 130.489954) (xy 138.210122 130.531561) (xy 138.265639 130.672343) (xy 138.357077 130.792922) (xy 138.477656 130.88436) (xy 138.477657 130.88436) (xy 138.477658 130.884361) (xy 138.618436 130.939877) (xy 138.706898 130.9505) (xy 138.706903 130.9505) (xy 139.293097 130.9505) (xy 139.293102 130.9505) (xy 139.381564 130.939877) (xy 139.522342 130.884361) (xy 139.642922 130.792922) (xy 139.734361 130.672342) (xy 139.789877 130.531564) (xy 139.8005 130.443102) (xy 139.8005 129.556898) (xy 139.789877 129.468436) (xy 139.734361 129.327658) (xy 139.73436 129.327657) (xy 139.73436 129.327656) (xy 139.642922 129.207077) (xy 139.522343 129.115639) (xy 139.426192 129.077722) (xy 139.381564 129.060123) (xy 139.381563 129.060122) (xy 139.381561 129.060122) (xy 139.335926 129.054642) (xy 139.293102 129.0495) (xy 138.706898 129.0495) (xy 138.667853 129.054188) (xy 138.618438 129.060122) (xy 138.477656 129.115639) (xy 138.357077 129.207077) (xy 138.265639 129.327656) (xy 138.210122 129.468438) (xy 138.209071 129.477194) (xy 138.1995 129.556898) (xy 137.8005 129.556898) (xy 137.789877 129.468436) (xy 137.734361 129.327658) (xy 137.73436 129.327657) (xy 137.73436 129.327656) (xy 137.642922 129.207077) (xy 137.522343 129.115639) (xy 137.426192 129.077722) (xy 137.381564 129.060123) (xy 137.381563 129.060122) (xy 137.381561 129.060122) (xy 137.335926 129.054642) (xy 137.293102 129.0495) (xy 136.706898 129.0495) (xy 136.667853 129.054188) (xy 136.618438 129.060122) (xy 136.477656 129.115639) (xy 136.357077 129.207077) (xy 136.265639 129.327656) (xy 136.210122 129.468438) (xy 136.209071 129.477194) (xy 136.1995 129.556898) (xy 131.8005 129.556898) (xy 131.789877 129.468436) (xy 131.734361 129.327658) (xy 131.73436 129.327657) (xy 131.73436 129.327656) (xy 131.642922 129.207077) (xy 131.522343 129.115639) (xy 131.426192 129.077722) (xy 131.381564 129.060123) (xy 131.381563 129.060122) (xy 131.381561 129.060122) (xy 131.335926 129.054642) (xy 131.293102 129.0495) (xy 130.706898 129.0495) (xy 130.667853 129.054188) (xy 130.618438 129.060122) (xy 130.477656 129.115639) (xy 130.357077 129.207077) (xy 130.265639 129.327656) (xy 130.210122 129.468438) (xy 130.209071 129.477194) (xy 130.1995 129.556898) (xy 129.8005 129.556898) (xy 129.789877 129.468436) (xy 129.734361 129.327658) (xy 129.73436 129.327657) (xy 129.73436 129.327656) (xy 129.642922 129.207077) (xy 129.522343 129.115639) (xy 129.426192 129.077722) (xy 129.381564 129.060123) (xy 129.381563 129.060122) (xy 129.381561 129.060122) (xy 129.335926 129.054642) (xy 129.293102 129.0495) (xy 128.706898 129.0495) (xy 128.667853 129.054188) (xy 128.618438 129.060122) (xy 128.477656 129.115639) (xy 128.357077 129.207077) (xy 128.265639 129.327656) (xy 128.210122 129.468438) (xy 128.209071 129.477194) (xy 128.1995 129.556898) (xy 122.0505 129.556898) (xy 122.0505 129.470406) (xy 122.044315 129.402343) (xy 121.995512 129.24573) (xy 121.995511 129.245727) (xy 121.910651 129.105351) (xy 121.910648 129.105347) (xy 121.794652 128.989351) (xy 121.794648 128.989348) (xy 121.654272 128.904488) (xy 121.654263 128.904485) (xy 121.497664 128.855687) (xy 121.497662 128.855686) (xy 121.497657 128.855685) (xy 121.429594 128.8495) (xy 120.570406 128.8495) (xy 120.502343 128.855685) (xy 120.502339 128.855686) (xy 120.502335 128.855687) (xy 120.345736 128.904485) (xy 120.345727 128.904488) (xy 120.205351 128.989348) (xy 120.205347 128.989351) (xy 120.089351 129.105347) (xy 120.089348 129.105351) (xy 120.004488 129.245727) (xy 120.004485 129.245736) (xy 119.955687 129.402335) (xy 119.955685 129.402343) (xy 119.9495 129.470406) (xy 118.0505 129.470406) (xy 118.044315 129.402343) (xy 118.033366 129.367208) (xy 118.031957 129.35816) (xy 118.035372 129.332247) (xy 118.034941 129.306108) (xy 118.039953 129.297499) (xy 118.041088 129.28889) (xy 118.05352 129.274197) (xy 118.066796 129.251395) (xy 123.781374 123.536819) (xy 123.842697 123.503334) (xy 123.869055 123.5005) (xy 123.935176 123.5005) (xy 123.982628 123.509939) (xy 124.019434 123.525184) (xy 124.043238 123.535044) (xy 124.160639 123.5505) (xy 124.83936 123.550499) (xy 124.839363 123.550499) (xy 124.956753 123.535046) (xy 124.956757 123.535044) (xy 124.956762 123.535044) (xy 125.102841 123.474536) (xy 125.228282 123.378282) (xy 125.324536 123.252841) (xy 125.385044 123.106762) (xy 125.4005 122.989361) (xy 125.400499 121.010645) (xy 126.5995 121.010645) (xy 126.5995 122.989363) (xy 126.614953 123.106753) (xy 126.614956 123.106762) (xy 126.675287 123.252415) (xy 126.675464 123.252841) (xy 126.771718 123.378282) (xy 126.897159 123.474536) (xy 127.043238 123.535044) (xy 127.160639 123.5505) (xy 127.83936 123.550499) (xy 127.839363 123.550499) (xy 127.956753 123.535046) (xy 127.956757 123.535044) (xy 127.956762 123.535044) (xy 128.102841 123.474536) (xy 128.228282 123.378282) (xy 128.324536 123.252841) (xy 128.385044 123.106762) (xy 128.4005 122.989361) (xy 128.400499 121.01064) (xy 128.400499 121.010639) (xy 128.400499 121.010636) (xy 128.385046 120.893246) (xy 128.385044 120.893239) (xy 128.385044 120.893238) (xy 128.324536 120.747159) (xy 128.228282 120.621718) (xy 128.102841 120.525464) (xy 128.089618 120.519987) (xy 127.956762 120.464956) (xy 127.95676 120.464955) (xy 127.839361 120.4495) (xy 127.160636 120.4495) (xy 127.043246 120.464953) (xy 127.043237 120.464956) (xy 126.89716 120.525463) (xy 126.771718 120.621718) (xy 126.675463 120.74716) (xy 126.614956 120.893237) (xy 126.614955 120.893239) (xy 126.601191 120.997794) (xy 126.599501 121.010636) (xy 126.5995 121.010645) (xy 125.400499 121.010645) (xy 125.400499 121.01064) (xy 125.400499 121.010639) (xy 125.400499 121.010636) (xy 125.385046 120.893246) (xy 125.385044 120.893239) (xy 125.385044 120.893238) (xy 125.324536 120.747159) (xy 125.228282 120.621718) (xy 125.102841 120.525464) (xy 125.089618 120.519987) (xy 124.956762 120.464956) (xy 124.95676 120.464955) (xy 124.839361 120.4495) (xy 124.160636 120.4495) (xy 124.043246 120.464953) (xy 124.043237 120.464956) (xy 123.89716 120.525463) (xy 123.771718 120.621718) (xy 123.675463 120.74716) (xy 123.614956 120.893237) (xy 123.614955 120.893239) (xy 123.601191 120.997794) (xy 123.599501 121.010636) (xy 123.5995 121.010645) (xy 123.5995 122.534544) (xy 123.579815 122.601583) (xy 123.563181 122.622225) (xy 117.372226 128.813181) (xy 117.310903 128.846666) (xy 117.284545 128.8495) (xy 116.570406 128.8495) (xy 116.502343 128.855685) (xy 116.502339 128.855686) (xy 116.502335 128.855687) (xy 116.345736 128.904485) (xy 116.345727 128.904488) (xy 116.205351 128.989348) (xy 116.205347 128.989351) (xy 116.089351 129.105347) (xy 116.089348 129.105351) (xy 116.004488 129.245727) (xy 116.004485 129.245736) (xy 115.955687 129.402335) (xy 115.955685 129.402343) (xy 115.9495 129.470406) (xy 115.9495 130.529594) (xy 115.955685 130.597657) (xy 115.955686 130.597662) (xy 115.955687 130.597664) (xy 116.004485 130.754263) (xy 116.004489 130.754272) (xy 116.04565 130.822362) (xy 116.053063 130.850442) (xy 116.063217 130.877664) (xy 116.061877 130.883823) (xy 116.063486 130.889917) (xy 116.05454 130.91755) (xy 116.048366 130.945937) (xy 116.043055 130.953031) (xy 116.041968 130.95639) (xy 116.027215 130.974192) (xy 115.965924 131.035482) (xy 115.904604 131.068966) (xy 115.878245 131.0718) (xy 115.816443 131.0718) (xy 115.663716 131.112723) (xy 115.663709 131.112726) (xy 115.52679 131.191775) (xy 115.526782 131.191781) (xy 115.414981 131.303582) (xy 115.414975 131.30359) (xy 115.335926 131.440509) (xy 115.335923 131.440516) (xy 115.295 131.593243) (xy 101.5 131.593243) (xy 101.5 130.443053) (xy 104.2 130.443053) (xy 104.210613 130.531443) (xy 104.266079 130.672095) (xy 104.357435 130.792564) (xy 104.477904 130.88392) (xy 104.618556 130.939386) (xy 104.706946 130.95) (xy 104.8 130.95) (xy 105.2 130.95) (xy 105.293054 130.95) (xy 105.381443 130.939386) (xy 105.522095 130.88392) (xy 105.642564 130.792564) (xy 105.73392 130.672095) (xy 105.789386 130.531443) (xy 105.8 130.443053) (xy 105.8 130.2) (xy 105.2 130.2) (xy 105.2 130.95) (xy 104.8 130.95) (xy 104.8 130.2) (xy 104.2 130.2) (xy 104.2 130.443053) (xy 101.5 130.443053) (xy 101.5 129.556946) (xy 104.2 129.556946) (xy 104.2 129.8) (xy 104.8 129.8) (xy 105.2 129.8) (xy 105.8 129.8) (xy 105.8 129.556949) (xy 105.799999 129.556943) (xy 105.799994 129.556898) (xy 106.1995 129.556898) (xy 106.1995 130.443102) (xy 106.205126 130.489954) (xy 106.210122 130.531561) (xy 106.265639 130.672343) (xy 106.357077 130.792922) (xy 106.477656 130.88436) (xy 106.477657 130.88436) (xy 106.477658 130.884361) (xy 106.618436 130.939877) (xy 106.706898 130.9505) (xy 106.706903 130.9505) (xy 107.293097 130.9505) (xy 107.293102 130.9505) (xy 107.381564 130.939877) (xy 107.522342 130.884361) (xy 107.642922 130.792922) (xy 107.734361 130.672342) (xy 107.789877 130.531564) (xy 107.8005 130.443102) (xy 107.8005 129.556898) (xy 107.789877 129.468436) (xy 107.734361 129.327658) (xy 107.73436 129.327657) (xy 107.73436 129.327656) (xy 107.642922 129.207077) (xy 107.522343 129.115639) (xy 107.426192 129.077722) (xy 107.381564 129.060123) (xy 107.381563 129.060122) (xy 107.381561 129.060122) (xy 107.335926 129.054642) (xy 107.293102 129.0495) (xy 106.706898 129.0495) (xy 106.667853 129.054188) (xy 106.618438 129.060122) (xy 106.477656 129.115639) (xy 106.357077 129.207077) (xy 106.265639 129.327656) (xy 106.210122 129.468438) (xy 106.209071 129.477194) (xy 106.1995 129.556898) (xy 105.799994 129.556898) (xy 105.789386 129.468556) (xy 105.73392 129.327904) (xy 105.642564 129.207435) (xy 105.522095 129.116079) (xy 105.381443 129.060613) (xy 105.293054 129.05) (xy 105.2 129.05) (xy 105.2 129.8) (xy 104.8 129.8) (xy 104.8 129.05) (xy 104.706946 129.05) (xy 104.618556 129.060613) (xy 104.477904 129.116079) (xy 104.357435 129.207435) (xy 104.266079 129.327904) (xy 104.210613 129.468556) (xy 104.2 129.556946) (xy 101.5 129.556946) (xy 101.5 126.094785) (xy 106.800001 126.094785) (xy 106.800002 126.094808) (xy 106.802908 126.119869) (xy 106.802909 126.119873) (xy 106.848211 126.222474) (xy 106.848214 126.222479) (xy 106.92752 126.301785) (xy 106.927525 126.301788) (xy 107.030123 126.347089) (xy 107.055206 126.349999) (xy 108.399999 126.349999) (xy 108.8 126.349999) (xy 110.144786 126.349999) (xy 110.144808 126.349997) (xy 110.169869 126.347091) (xy 110.169873 126.34709) (xy 110.272474 126.301788) (xy 110.272479 126.301785) (xy 110.351785 126.222479) (xy 110.351788 126.222474) (xy 110.397089 126.119877) (xy 110.397089 126.119875) (xy 110.399999 126.094794) (xy 110.4 126.094791) (xy 110.4 125.5) (xy 108.8 125.5) (xy 108.8 126.349999) (xy 108.399999 126.349999) (xy 108.4 126.349998) (xy 108.4 125.5) (xy 106.800001 125.5) (xy 106.800001 126.094785) (xy 101.5 126.094785) (xy 101.5 117.905131) (xy 106.7995 117.905131) (xy 106.7995 119.494856) (xy 106.799502 119.494882) (xy 106.802413 119.519987) (xy 106.802415 119.519991) (xy 106.847793 119.622764) (xy 106.93536 119.710331) (xy 106.932942 119.712748) (xy 106.964842 119.751829) (xy 106.972747 119.82125) (xy 106.941865 119.883924) (xy 106.935301 119.88961) (xy 106.93536 119.889669) (xy 106.847794 119.977234) (xy 106.802415 120.080006) (xy 106.802415 120.080008) (xy 106.7995 120.105131) (xy 106.7995 121.694856) (xy 106.799502 121.694882) (xy 106.802413 121.719987) (xy 106.802415 121.719991) (xy 106.847793 121.822764) (xy 106.93536 121.910331) (xy 106.932942 121.912748) (xy 106.964842 121.951829) (xy 106.972747 122.02125) (xy 106.941865 122.083924) (xy 106.935301 122.08961) (xy 106.93536 122.089669) (xy 106.847794 122.177234) (xy 106.802415 122.280006) (xy 106.802415 122.280008) (xy 106.7995 122.305131) (xy 106.7995 123.894856) (xy 106.799502 123.894882) (xy 106.802413 123.919987) (xy 106.802415 123.919991) (xy 106.847793 124.022764) (xy 106.93536 124.110331) (xy 106.93305 124.11264) (xy 106.965285 124.152122) (xy 106.973198 124.221542) (xy 106.942324 124.28422) (xy 106.935603 124.290044) (xy 106.935647 124.290088) (xy 106.848214 124.37752) (xy 106.848211 124.377525) (xy 106.80291 124.480122) (xy 106.80291 124.480124) (xy 106.8 124.505205) (xy 106.8 125.1) (xy 110.399999 125.1) (xy 110.399999 124.505214) (xy 110.399997 124.505191) (xy 110.397091 124.48013) (xy 110.39709 124.480126) (xy 110.351788 124.377525) (xy 110.351785 124.37752) (xy 110.264353 124.290088) (xy 110.26673 124.28771) (xy 110.234705 124.24847) (xy 110.226805 124.179048) (xy 110.257692 124.116376) (xy 110.264654 124.110345) (xy 110.26464 124.110331) (xy 110.272765 124.102206) (xy 110.352206 124.022765) (xy 110.397585 123.919991) (xy 110.4005 123.894865) (xy 110.400499 122.305136) (xy 110.400497 122.305117) (xy 110.397586 122.280012) (xy 110.397585 122.28001) (xy 110.397585 122.280009) (xy 110.352206 122.177235) (xy 110.272765 122.097794) (xy 110.26464 122.089669) (xy 110.267058 122.08725) (xy 110.235165 122.04819) (xy 110.227249 121.97877) (xy 110.258121 121.91609) (xy 110.264699 121.91039) (xy 110.26464 121.910331) (xy 110.272765 121.902206) (xy 110.352206 121.822765) (xy 110.397585 121.719991) (xy 110.4005 121.694865) (xy 110.400499 120.105136) (xy 110.400497 120.105117) (xy 110.397586 120.080012) (xy 110.397585 120.08001) (xy 110.397585 120.080009) (xy 110.352206 119.977235) (xy 110.272765 119.897794) (xy 110.26464 119.889669) (xy 110.267058 119.88725) (xy 110.235165 119.84819) (xy 110.227249 119.77877) (xy 110.258121 119.71609) (xy 110.264699 119.71039) (xy 110.26464 119.710331) (xy 110.272765 119.702206) (xy 110.352206 119.622765) (xy 110.397585 119.519991) (xy 110.4005 119.494865) (xy 110.400499 117.955131) (xy 113.5995 117.955131) (xy 113.5995 126.044856) (xy 113.599502 126.044882) (xy 113.602413 126.069987) (xy 113.602415 126.069991) (xy 113.647793 126.172764) (xy 113.647794 126.172765) (xy 113.727235 126.252206) (xy 113.830009 126.297585) (xy 113.855135 126.3005) (xy 116.944864 126.300499) (xy 116.944879 126.300497) (xy 116.944882 126.300497) (xy 116.969987 126.297586) (xy 116.969988 126.297585) (xy 116.969991 126.297585) (xy 117.072765 126.252206) (xy 117.152206 126.172765) (xy 117.197585 126.069991) (xy 117.2005 126.044865) (xy 117.200499 117.955136) (xy 117.200497 117.955117) (xy 117.197586 117.930012) (xy 117.197585 117.93001) (xy 117.197585 117.930009) (xy 117.152206 117.827235) (xy 117.072765 117.747794) (xy 117.072763 117.747793) (xy 116.969992 117.702415) (xy 116.944865 117.6995) (xy 113.855143 117.6995) (xy 113.855117 117.699502) (xy 113.830012 117.702413) (xy 113.830008 117.702415) (xy 113.727235 117.747793) (xy 113.647794 117.827234) (xy 113.602415 117.930006) (xy 113.602415 117.930008) (xy 113.5995 117.955131) (xy 110.400499 117.955131) (xy 110.400499 117.905136) (xy 110.400497 117.905117) (xy 110.397586 117.880012) (xy 110.397585 117.88001) (xy 110.397585 117.880009) (xy 110.352206 117.777235) (xy 110.272765 117.697794) (xy 110.272763 117.697793) (xy 110.169992 117.652415) (xy 110.144865 117.6495) (xy 107.055143 117.6495) (xy 107.055117 117.649502) (xy 107.030012 117.652413) (xy 107.030008 117.652415) (xy 106.927235 117.697793) (xy 106.847794 117.777234) (xy 106.802415 117.880006) (xy 106.802415 117.880008) (xy 106.7995 117.905131) (xy 101.5 117.905131) (xy 101.5 114.443053) (xy 128.2 114.443053) (xy 128.210613 114.531443) (xy 128.266079 114.672095) (xy 128.357435 114.792564) (xy 128.477904 114.88392) (xy 128.618556 114.939386) (xy 128.706946 114.95) (xy 128.8 114.95) (xy 129.2 114.95) (xy 129.293054 114.95) (xy 129.381443 114.939386) (xy 129.522095 114.88392) (xy 129.642564 114.792564) (xy 129.73392 114.672095) (xy 129.789386 114.531443) (xy 129.8 114.443053) (xy 129.8 114.2) (xy 129.2 114.2) (xy 129.2 114.95) (xy 128.8 114.95) (xy 128.8 114.2) (xy 128.2 114.2) (xy 128.2 114.443053) (xy 101.5 114.443053) (xy 101.5 113.556946) (xy 128.2 113.556946) (xy 128.2 113.8) (xy 128.8 113.8) (xy 129.2 113.8) (xy 129.8 113.8) (xy 129.8 113.556949) (xy 129.799999 113.556943) (xy 129.799994 113.556898) (xy 130.1995 113.556898) (xy 130.1995 114.443102) (xy 130.205126 114.489954) (xy 130.210122 114.531561) (xy 130.265639 114.672343) (xy 130.357077 114.792922) (xy 130.477656 114.88436) (xy 130.477657 114.88436) (xy 130.477658 114.884361) (xy 130.618436 114.939877) (xy 130.706898 114.9505) (xy 130.706903 114.9505) (xy 131.293097 114.9505) (xy 131.293102 114.9505) (xy 131.381564 114.939877) (xy 131.522342 114.884361) (xy 131.642922 114.792922) (xy 131.734361 114.672342) (xy 131.789877 114.531564) (xy 131.8005 114.443102) (xy 131.8005 113.556898) (xy 131.789877 113.468436) (xy 131.734361 113.327658) (xy 131.73436 113.327657) (xy 131.73436 113.327656) (xy 131.642922 113.207077) (xy 131.522343 113.115639) (xy 131.426192 113.077722) (xy 131.381564 113.060123) (xy 131.381563 113.060122) (xy 131.381561 113.060122) (xy 131.335926 113.054642) (xy 131.293102 113.0495) (xy 130.706898 113.0495) (xy 130.667853 113.054188) (xy 130.618438 113.060122) (xy 130.477656 113.115639) (xy 130.357077 113.207077) (xy 130.265639 113.327656) (xy 130.210122 113.468438) (xy 130.204188 113.517853) (xy 130.1995 113.556898) (xy 129.799994 113.556898) (xy 129.789386 113.468556) (xy 129.73392 113.327904) (xy 129.642564 113.207435) (xy 129.522095 113.116079) (xy 129.381443 113.060613) (xy 129.293054 113.05) (xy 129.2 113.05) (xy 129.2 113.8) (xy 128.8 113.8) (xy 128.8 113.05) (xy 128.706946 113.05) (xy 128.618556 113.060613) (xy 128.477904 113.116079) (xy 128.357435 113.207435) (xy 128.266079 113.327904) (xy 128.210613 113.468556) (xy 128.2 113.556946) (xy 101.5 113.556946) (xy 101.5 109.179448) (xy 103.8495 109.179448) (xy 103.8495 109.360551) (xy 103.877829 109.53941) (xy 103.933787 109.711636) (xy 103.933788 109.711639) (xy 104.016006 109.872997) (xy 104.122441 110.019494) (xy 104.122445 110.019499) (xy 104.2505 110.147554) (xy 104.250505 110.147558) (xy 104.378287 110.240396) (xy 104.397006 110.253996) (xy 104.502484 110.30774) (xy 104.55836 110.336211) (xy 104.558363 110.336212) (xy 104.644476 110.364191) (xy 104.730591 110.392171) (xy 104.813429 110.405291) (xy 104.909449 110.4205) (xy 104.909454 110.4205) (xy 105.090551 110.4205) (xy 105.177259 110.406765) (xy 105.269409 110.392171) (xy 105.441639 110.336211) (xy 105.602994 110.253996) (xy 105.749501 110.147553) (xy 105.877553 110.019501) (xy 105.983996 109.872994) (xy 106.066211 109.711639) (xy 106.122171 109.539409) (xy 106.136765 109.447259) (xy 106.1505 109.360551) (xy 106.1505 109.179448) (xy 106.123764 109.010651) (xy 106.122171 109.000591) (xy 106.066211 108.828361) (xy 106.066211 108.82836) (xy 106.03774 108.772484) (xy 105.983996 108.667006) (xy 105.970396 108.648287) (xy 105.927557 108.589324) (xy 111.600001 108.589324) (xy 111.615442 108.706628) (xy 111.615444 108.706633) (xy 111.675899 108.852585) (xy 111.772075 108.977924) (xy 111.897413 109.0741) (xy 112.043365 109.134554) (xy 112.043369 109.134555) (xy 112.160676 109.149999) (xy 112.299999 109.149999) (xy 112.7 109.149999) (xy 112.839324 109.149999) (xy 112.956628 109.134557) (xy 112.956633 109.134555) (xy 113.102585 109.0741) (xy 113.227924 108.977924) (xy 113.3241 108.852586) (xy 113.384554 108.706634) (xy 113.384555 108.70663) (xy 113.399999 108.58933) (xy 113.399999 108.589324) (xy 114.600001 108.589324) (xy 114.615442 108.706628) (xy 114.615444 108.706633) (xy 114.675899 108.852585) (xy 114.772075 108.977924) (xy 114.897413 109.0741) (xy 115.043365 109.134554) (xy 115.043369 109.134555) (xy 115.160676 109.149999) (xy 115.299999 109.149999) (xy 115.7 109.149999) (xy 115.839324 109.149999) (xy 115.956628 109.134557) (xy 115.956633 109.134555) (xy 116.102585 109.0741) (xy 116.227924 108.977924) (xy 116.3241 108.852586) (xy 116.384554 108.706634) (xy 116.384555 108.70663) (xy 116.399999 108.58933) (xy 116.4 108.589316) (xy 116.4 108.2) (xy 115.7 108.2) (xy 115.7 109.149999) (xy 115.299999 109.149999) (xy 115.3 109.149998) (xy 115.3 108.2) (xy 114.600001 108.2) (xy 114.600001 108.589324) (xy 113.399999 108.589324) (xy 113.4 108.589316) (xy 113.4 108.2) (xy 112.7 108.2) (xy 112.7 109.149999) (xy 112.299999 109.149999) (xy 112.3 109.149998) (xy 112.3 108.2) (xy 111.600001 108.2) (xy 111.600001 108.589324) (xy 105.927557 108.589324) (xy 105.877558 108.520505) (xy 105.877554 108.5205) (xy 105.749499 108.392445) (xy 105.749494 108.392441) (xy 105.602997 108.286006) (xy 105.602996 108.286005) (xy 105.602994 108.286004) (xy 105.531797 108.249727) (xy 105.441639 108.203788) (xy 105.441636 108.203787) (xy 105.26941 108.147829) (xy 105.134571 108.126472) (xy 105.071437 108.096542) (xy 105.034506 108.037231) (xy 105.035504 107.967368) (xy 105.074114 107.909136) (xy 105.138078 107.881022) (xy 105.15397 107.879999) (xy 105.894786 107.879999) (xy 105.894808 107.879997) (xy 105.919869 107.877091) (xy 105.919873 107.87709) (xy 106.022474 107.831788) (xy 106.022479 107.831785) (xy 106.101785 107.752479) (xy 106.101788 107.752474) (xy 106.147089 107.649877) (xy 106.147089 107.649875) (xy 106.149999 107.624794) (xy 106.15 107.624791) (xy 106.15 107.410669) (xy 111.6 107.410669) (xy 111.6 107.8) (xy 112.3 107.8) (xy 112.7 107.8) (xy 113.399999 107.8) (xy 113.399999 107.410675) (xy 113.399998 107.410669) (xy 114.6 107.410669) (xy 114.6 107.8) (xy 115.3 107.8) (xy 115.7 107.8) (xy 116.399999 107.8) (xy 116.399999 107.470406) (xy 118.9495 107.470406) (xy 118.9495 108.529594) (xy 118.955685 108.597657) (xy 118.955686 108.597662) (xy 118.955687 108.597664) (xy 119.004485 108.754263) (xy 119.004488 108.754272) (xy 119.089348 108.894648) (xy 119.089351 108.894652) (xy 119.205347 109.010648) (xy 119.205351 109.010651) (xy 119.345727 109.095511) (xy 119.34573 109.095512) (xy 119.502343 109.144315) (xy 119.570406 109.1505) (xy 119.570409 109.1505) (xy 120.429591 109.1505) (xy 120.429594 109.1505) (xy 120.497657 109.144315) (xy 120.65427 109.095512) (xy 120.65503 109.095053) (xy 120.794648 109.010651) (xy 120.794647 109.010651) (xy 120.794653 109.010648) (xy 120.910648 108.894653) (xy 120.936079 108.852585) (xy 120.995511 108.754272) (xy 120.995514 108.754263) (xy 121.010358 108.706628) (xy 121.044315 108.597657) (xy 121.0505 108.529594) (xy 121.0505 108.529566) (xy 122.950001 108.529566) (xy 122.956178 108.597561) (xy 122.956181 108.597572) (xy 123.004944 108.75406) (xy 123.004946 108.754064) (xy 123.089743 108.894337) (xy 123.089747 108.894342) (xy 123.205657 109.010252) (xy 123.205662 109.010256) (xy 123.345934 109.095052) (xy 123.502437 109.14382) (xy 123.570443 109.149999) (xy 123.799999 109.149999) (xy 124.2 109.149999) (xy 124.429565 109.149999) (xy 124.497561 109.143821) (xy 124.497572 109.143818) (xy 124.65406 109.095055) (xy 124.654064 109.095053) (xy 124.794337 109.010256) (xy 124.794342 109.010252) (xy 124.910252 108.894342) (xy 124.910256 108.894337) (xy 124.995052 108.754065) (xy 125.04382 108.597562) (xy 125.05 108.529556) (xy 125.05 108.443053) (xy 128.2 108.443053) (xy 128.210613 108.531443) (xy 128.266079 108.672095) (xy 128.357435 108.792564) (xy 128.477904 108.88392) (xy 128.618556 108.939386) (xy 128.706946 108.95) (xy 128.8 108.95) (xy 129.2 108.95) (xy 129.293054 108.95) (xy 129.381443 108.939386) (xy 129.522095 108.88392) (xy 129.642564 108.792564) (xy 129.73392 108.672095) (xy 129.789386 108.531443) (xy 129.8 108.443053) (xy 129.8 108.2) (xy 129.2 108.2) (xy 129.2 108.95) (xy 128.8 108.95) (xy 128.8 108.2) (xy 128.2 108.2) (xy 128.2 108.443053) (xy 125.05 108.443053) (xy 125.05 108.2) (xy 124.2 108.2) (xy 124.2 109.149999) (xy 123.799999 109.149999) (xy 123.8 109.149998) (xy 123.8 108.2) (xy 122.950001 108.2) (xy 122.950001 108.529566) (xy 121.0505 108.529566) (xy 121.0505 107.470443) (xy 122.95 107.470443) (xy 122.95 107.8) (xy 123.8 107.8) (xy 124.2 107.8) (xy 125.049999 107.8) (xy 125.049999 107.556946) (xy 128.2 107.556946) (xy 128.2 107.8) (xy 128.8 107.8) (xy 129.2 107.8) (xy 129.8 107.8) (xy 129.8 107.556949) (xy 129.799999 107.556943) (xy 129.799994 107.556898) (xy 130.1995 107.556898) (xy 130.1995 108.443102) (xy 130.205126 108.489954) (xy 130.210122 108.531561) (xy 130.265639 108.672343) (xy 130.357077 108.792922) (xy 130.477656 108.88436) (xy 130.477657 108.88436) (xy 130.477658 108.884361) (xy 130.618436 108.939877) (xy 130.706898 108.9505) (xy 130.706903 108.9505) (xy 131.293097 108.9505) (xy 131.293102 108.9505) (xy 131.381564 108.939877) (xy 131.522342 108.884361) (xy 131.642922 108.792922) (xy 131.734361 108.672342) (xy 131.789877 108.531564) (xy 131.8005 108.443102) (xy 131.8005 107.556898) (xy 131.789877 107.468436) (xy 131.734361 107.327658) (xy 131.73436 107.327657) (xy 131.73436 107.327656) (xy 131.642922 107.207077) (xy 131.522343 107.115639) (xy 131.426192 107.077722) (xy 131.381564 107.060123) (xy 131.381563 107.060122) (xy 131.381561 107.060122) (xy 131.335926 107.054642) (xy 131.293102 107.0495) (xy 130.706898 107.0495) (xy 130.667853 107.054188) (xy 130.618438 107.060122) (xy 130.477656 107.115639) (xy 130.357077 107.207077) (xy 130.265639 107.327656) (xy 130.210122 107.468438) (xy 130.204188 107.517853) (xy 130.1995 107.556898) (xy 129.799994 107.556898) (xy 129.789386 107.468556) (xy 129.73392 107.327904) (xy 129.642564 107.207435) (xy 129.522095 107.116079) (xy 129.381443 107.060613) (xy 129.293054 107.05) (xy 129.2 107.05) (xy 129.2 107.8) (xy 128.8 107.8) (xy 128.8 107.05) (xy 128.706946 107.05) (xy 128.618556 107.060613) (xy 128.477904 107.116079) (xy 128.357435 107.207435) (xy 128.266079 107.327904) (xy 128.210613 107.468556) (xy 128.2 107.556946) (xy 125.049999 107.556946) (xy 125.049999 107.470433) (xy 125.043821 107.402438) (xy 125.043818 107.402427) (xy 124.995055 107.245939) (xy 124.995053 107.245935) (xy 124.910256 107.105662) (xy 124.910252 107.105657) (xy 124.794342 106.989747) (xy 124.794337 106.989743) (xy 124.654065 106.904947) (xy 124.497562 106.856179) (xy 124.429556 106.85) (xy 124.2 106.85) (xy 124.2 107.8) (xy 123.8 107.8) (xy 123.8 106.85) (xy 123.570433 106.85) (xy 123.502438 106.856178) (xy 123.502427 106.856181) (xy 123.345939 106.904944) (xy 123.345935 106.904946) (xy 123.205662 106.989743) (xy 123.205657 106.989747) (xy 123.089747 107.105657) (xy 123.089743 107.105662) (xy 123.004947 107.245934) (xy 122.956179 107.402437) (xy 122.95 107.470443) (xy 121.0505 107.470443) (xy 121.0505 107.470406) (xy 121.044315 107.402343) (xy 120.995512 107.24573) (xy 120.995511 107.245727) (xy 120.910651 107.105351) (xy 120.910648 107.105347) (xy 120.794652 106.989351) (xy 120.794648 106.989348) (xy 120.654272 106.904488) (xy 120.654263 106.904485) (xy 120.497664 106.855687) (xy 120.497662 106.855686) (xy 120.497657 106.855685) (xy 120.429594 106.8495) (xy 119.570406 106.8495) (xy 119.502343 106.855685) (xy 119.502339 106.855686) (xy 119.502335 106.855687) (xy 119.345736 106.904485) (xy 119.345727 106.904488) (xy 119.205351 106.989348) (xy 119.205347 106.989351) (xy 119.089351 107.105347) (xy 119.089348 107.105351) (xy 119.004488 107.245727) (xy 119.004485 107.245736) (xy 118.978881 107.327904) (xy 118.955685 107.402343) (xy 118.9495 107.470406) (xy 116.399999 107.470406) (xy 116.399999 107.410675) (xy 116.384557 107.293371) (xy 116.384555 107.293366) (xy 116.3241 107.147414) (xy 116.227924 107.022075) (xy 116.102586 106.925899) (xy 115.956634 106.865445) (xy 115.95663 106.865444) (xy 115.83933 106.85) (xy 115.7 106.85) (xy 115.7 107.8) (xy 115.3 107.8) (xy 115.3 106.85) (xy 115.160676 106.85) (xy 115.043371 106.865442) (xy 115.043366 106.865444) (xy 114.897414 106.925899) (xy 114.772075 107.022075) (xy 114.675899 107.147413) (xy 114.615445 107.293365) (xy 114.615444 107.293369) (xy 114.6 107.410669) (xy 113.399998 107.410669) (xy 113.384557 107.293371) (xy 113.384555 107.293366) (xy 113.3241 107.147414) (xy 113.227924 107.022075) (xy 113.102586 106.925899) (xy 112.956634 106.865445) (xy 112.95663 106.865444) (xy 112.83933 106.85) (xy 112.7 106.85) (xy 112.7 107.8) (xy 112.3 107.8) (xy 112.3 106.85) (xy 112.160676 106.85) (xy 112.043371 106.865442) (xy 112.043366 106.865444) (xy 111.897414 106.925899) (xy 111.772075 107.022075) (xy 111.675899 107.147413) (xy 111.615445 107.293365) (xy 111.615444 107.293369) (xy 111.6 107.410669) (xy 106.15 107.410669) (xy 106.15 106.93) (xy 105.46188 106.93) (xy 105.465925 106.922993) (xy 105.5 106.795826) (xy 105.5 106.664174) (xy 105.465925 106.537007) (xy 105.46188 106.53) (xy 106.149999 106.53) (xy 106.149999 105.835214) (xy 106.149997 105.835191) (xy 106.147091 105.81013) (xy 106.14709 105.810126) (xy 106.101788 105.707525) (xy 106.101785 105.70752) (xy 106.022479 105.628214) (xy 106.022474 105.628211) (xy 105.919876 105.58291) (xy 105.894794 105.58) (xy 105.2 105.58) (xy 105.2 106.26812) (xy 105.192993 106.264075) (xy 105.065826 106.23) (xy 104.934174 106.23) (xy 104.807007 106.264075) (xy 104.8 106.26812) (xy 104.8 105.58) (xy 104.105214 105.58) (xy 104.105191 105.580002) (xy 104.08013 105.582908) (xy 104.080126 105.582909) (xy 103.977525 105.628211) (xy 103.97752 105.628214) (xy 103.898214 105.70752) (xy 103.898211 105.707525) (xy 103.85291 105.810122) (xy 103.85291 105.810124) (xy 103.85 105.835205) (xy 103.85 106.53) (xy 104.53812 106.53) (xy 104.534075 106.537007) (xy 104.5 106.664174) (xy 104.5 106.795826) (xy 104.534075 106.922993) (xy 104.53812 106.93) (xy 103.850001 106.93) (xy 103.850001 107.624785) (xy 103.850002 107.624808) (xy 103.852908 107.649869) (xy 103.852909 107.649873) (xy 103.898211 107.752474) (xy 103.898214 107.752479) (xy 103.97752 107.831785) (xy 103.977525 107.831788) (xy 104.080123 107.877089) (xy 104.105206 107.879999) (xy 104.846028 107.879999) (xy 104.913067 107.899683) (xy 104.958822 107.952487) (xy 104.968766 108.021646) (xy 104.939741 108.085202) (xy 104.880963 108.122976) (xy 104.865427 108.126472) (xy 104.730589 108.147829) (xy 104.558363 108.203787) (xy 104.55836 108.203788) (xy 104.397002 108.286006) (xy 104.250505 108.392441) (xy 104.2505 108.392445) (xy 104.122445 108.5205) (xy 104.122441 108.520505) (xy 104.016006 108.667002) (xy 103.933788 108.82836) (xy 103.933787 108.828363) (xy 103.877829 109.000589) (xy 103.8495 109.179448) (xy 101.5 109.179448) (xy 101.5 105.354) (xy 101.519685 105.286961) (xy 101.572489 105.241206) (xy 101.624 105.23) (xy 141.376 105.23)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts (xy 111.555169 155.751685) (xy 111.600558 155.803693) (xy 112.683879 158.13227) (xy 113.957912 160.870778) (xy 113.968342 160.939865) (xy 113.968124 160.941393) (xy 113.093171 166.801842) (xy 113.084398 166.832625) (xy 111.966692 169.425093) (xy 111.922074 169.478861) (xy 111.85547 169.499972) (xy 111.852824 169.5) (xy 103.317129 169.5) (xy 103.25009 169.480315) (xy 103.204335 169.427511) (xy 103.19313 169.375539) (xy 103.198699 167.885844) (xy 103.218634 167.818882) (xy 103.23414 167.799516) (xy 104.046948 166.970323) (xy 104.107934 166.936229) (xy 104.177672 166.940518) (xy 104.234021 166.981829) (xy 104.25909 167.047046) (xy 104.2595 167.057126) (xy 104.2595 168.944856) (xy 104.259502 168.944882) (xy 104.262413 168.969987) (xy 104.262415 168.969991) (xy 104.307793 169.072764) (xy 104.307794 169.072765) (xy 104.387235 169.152206) (xy 104.490009 169.197585) (xy 104.515135 169.2005) (xy 106.404864 169.200499) (xy 106.404879 169.200497) (xy 106.404882 169.200497) (xy 106.429987 169.197586) (xy 106.429988 169.197585) (xy 106.429991 169.197585) (xy 106.532765 169.152206) (xy 106.612206 169.072765) (xy 106.657585 168.969991) (xy 106.6605 168.944865) (xy 106.660499 168.530805) (xy 106.680183 168.463769) (xy 106.732987 168.418014) (xy 106.802146 168.40807) (xy 106.865702 168.437095) (xy 106.894983 168.474513) (xy 106.973666 168.628935) (xy 106.973667 168.628936) (xy 107.084685 168.781741) (xy 107.084689 168.781746) (xy 107.218253 168.91531) (xy 107.218258 168.915314) (xy 107.371059 169.026329) (xy 107.539362 169.112085) (xy 107.718996 169.170451) (xy 107.8 169.183281) (xy 107.8 168.461879) (xy 107.807007 168.465925) (xy 107.934174 168.5) (xy 108.065826 168.5) (xy 108.192993 168.465925) (xy 108.2 168.461879) (xy 108.2 169.18328) (xy 108.281001 169.170451) (xy 108.281004 169.170451) (xy 108.460637 169.112085) (xy 108.62894 169.026329) (xy 108.781741 168.915314) (xy 108.781746 168.91531) (xy 108.91531 168.781746) (xy 108.915314 168.781741) (xy 109.026329 168.62894) (xy 109.112086 168.460635) (xy 109.151806 168.338389) (xy 109.191243 168.280713) (xy 109.255601 168.253514) (xy 109.324448 168.265428) (xy 109.375924 168.312672) (xy 109.387668 168.338387) (xy 109.427454 168.460836) (xy 109.463107 168.530808) (xy 109.51324 168.629199) (xy 109.62431 168.782073) (xy 109.757927 168.91569) (xy 109.910801 169.02676) (xy 109.990347 169.06729) (xy 110.079163 169.112545) (xy 110.079165 169.112545) (xy 110.079168 169.112547) (xy 110.175497 169.143846) (xy 110.258881 169.17094) (xy 110.445514 169.2005) (xy 110.445519 169.2005) (xy 110.634486 169.2005) (xy 110.821118 169.17094) (xy 110.822623 169.170451) (xy 111.000832 169.112547) (xy 111.169199 169.02676) (xy 111.322073 168.91569) (xy 111.45569 168.782073) (xy 111.56676 168.629199) (xy 111.652547 168.460832) (xy 111.71094 168.281118) (xy 111.715312 168.253514) (xy 111.7405 168.094486) (xy 111.7405 167.905513) (xy 111.71094 167.718881) (xy 111.67228 167.599901) (xy 111.652547 167.539168) (xy 111.652545 167.539165) (xy 111.652545 167.539163) (xy 111.575736 167.388418) (xy 111.56676 167.370801) (xy 111.45569 167.217927) (xy 111.322073 167.08431) (xy 111.169199 166.97324) (xy 111.163476 166.970324) (xy 111.000836 166.887454) (xy 110.821118 166.829059) (xy 110.634486 166.7995) (xy 110.634481 166.7995) (xy 110.445519 166.7995) (xy 110.445514 166.7995) (xy 110.258881 166.829059) (xy 110.079163 166.887454) (xy 109.9108 166.97324) (xy 109.827716 167.033605) (xy 109.757927 167.08431) (xy 109.757925 167.084312) (xy 109.757924 167.084312) (xy 109.624312 167.217924) (xy 109.624312 167.217925) (xy 109.62431 167.217927) (xy 109.618261 167.226253) (xy 109.51324 167.3708) (xy 109.427454 167.539163) (xy 109.387668 167.661612) (xy 109.34823 167.719287) (xy 109.283871 167.746485) (xy 109.215025 167.73457) (xy 109.163549 167.687325) (xy 109.151806 167.661611) (xy 109.112085 167.539362) (xy 109.026329 167.371059) (xy 108.915314 167.218258) (xy 108.91531 167.218253) (xy 108.781746 167.084689) (xy 108.781741 167.084685) (xy 108.62894 166.97367) (xy 108.460635 166.887913) (xy 108.280999 166.829547) (xy 108.2 166.816718) (xy 108.2 167.53812) (xy 108.192993 167.534075) (xy 108.065826 167.5) (xy 107.934174 167.5) (xy 107.807007 167.534075) (xy 107.8 167.53812) (xy 107.8 166.816718) (xy 107.799999 166.816718) (xy 107.719 166.829547) (xy 107.539364 166.887913) (xy 107.371059 166.97367) (xy 107.218258 167.084685) (xy 107.218253 167.084689) (xy 107.084689 167.218253) (xy 107.084685 167.218258) (xy 106.973667 167.371063) (xy 106.973666 167.371064) (xy 106.894983 167.525487) (xy 106.847009 167.576283) (xy 106.779188 167.593078) (xy 106.713053 167.57054) (xy 106.669602 167.515825) (xy 106.660499 167.469192) (xy 106.660499 167.203499) (xy 106.680184 167.13646) (xy 106.688325 167.125226) (xy 106.72132 167.084685) (xy 109.300515 163.915616) (xy 109.329276 163.883571) (xy 109.333716 163.874822) (xy 109.339909 163.867213) (xy 109.357515 163.827928) (xy 109.377001 163.789535) (xy 109.379025 163.779934) (xy 109.383038 163.770982) (xy 109.389878 163.728472) (xy 109.398761 163.686351) (xy 109.398232 163.676556) (xy 109.399791 163.666868) (xy 109.395697 163.626978) (xy 109.395235 163.621084) (xy 109.393074 163.581051) (xy 109.393071 163.581043) (xy 109.391579 163.573061) (xy 109.391752 163.573028) (xy 109.391074 163.569833) (xy 109.390904 163.569874) (xy 109.389026 163.561964) (xy 109.374762 163.524531) (xy 109.372765 163.518885) (xy 109.271759 163.209704) (xy 109.271585 163.203945) (xy 109.268768 163.198922) (xy 109.270543 163.16941) (xy 109.269653 163.139866) (xy 109.272709 163.13343) (xy 109.272965 163.129178) (xy 109.289525 163.098019) (xy 109.393502 162.9558) (xy 109.44811 162.913633) (xy 109.522342 162.884361) (xy 109.642922 162.792922) (xy 109.734361 162.672342) (xy 109.789877 162.531564) (xy 109.8005 162.443102) (xy 109.8005 161.556898) (xy 109.789877 161.468436) (xy 109.734361 161.327658) (xy 109.73436 161.327657) (xy 109.73436 161.327656) (xy 109.642922 161.207077) (xy 109.522343 161.115639) (xy 109.381561 161.060122) (xy 109.335926 161.054642) (xy 109.293102 161.0495) (xy 108.706898 161.0495) (xy 108.667853 161.054188) (xy 108.618438 161.060122) (xy 108.477656 161.115639) (xy 108.357077 161.207077) (xy 108.265639 161.327656) (xy 108.210122 161.468438) (xy 108.204666 161.513876) (xy 108.1995 161.556898) (xy 108.1995 162.443102) (xy 108.203092 162.473013) (xy 108.210122 162.531561) (xy 108.265639 162.672343) (xy 108.357077 162.792922) (xy 108.381952 162.811785) (xy 108.392156 162.825594) (xy 108.405949 162.83582) (xy 108.412488 162.853108) (xy 108.423476 162.867977) (xy 108.424709 162.885415) (xy 108.430669 162.901171) (xy 108.42753 162.92531) (xy 108.428314 162.936386) (xy 108.426629 162.944304) (xy 108.426599 162.944365) (xy 108.42446 162.954501) (xy 108.424441 162.954595) (xy 108.424402 162.954666) (xy 108.418788 162.973572) (xy 108.415088 162.983126) (xy 108.412245 163.009416) (xy 108.410297 163.021662) (xy 108.404839 163.047548) (xy 108.404838 163.047559) (xy 108.40539 163.057782) (xy 108.404853 163.077778) (xy 108.403752 163.087965) (xy 108.403752 163.087973) (xy 108.406608 163.106361) (xy 108.408764 163.120241) (xy 108.410526 163.152849) (xy 108.416823 163.172128) (xy 108.418365 163.182051) (xy 108.419937 163.192172) (xy 108.419937 163.192173) (xy 108.430622 163.216366) (xy 108.435061 163.227954) (xy 108.526436 163.507656) (xy 108.528542 163.577493) (xy 108.50474 163.624435) (xy 105.957882 166.753773) (xy 105.900297 166.793343) (xy 105.861708 166.7995) (xy 104.511556 166.799501) (xy 104.511556 166.798251) (xy 104.448516 166.783608) (xy 104.39981 166.733513) (xy 104.385918 166.665039) (xy 104.411252 166.599924) (xy 104.420906 166.588827) (xy 105.226669 165.766823) (xy 105.26258 165.730913) (xy 105.263588 165.729163) (xy 105.26501 165.727714) (xy 105.265015 165.727704) (xy 105.265017 165.727703) (xy 105.289668 165.684002) (xy 105.290157 165.683144) (xy 105.315307 165.639587) (xy 105.315311 165.639571) (xy 105.316303 165.637178) (xy 105.316307 165.63717) (xy 105.316797 165.635986) (xy 105.329314 165.587329) (xy 105.329587 165.586286) (xy 105.3426 165.537727) (xy 105.3426 165.53772) (xy 105.34294 165.53514) (xy 105.34294 165.535138) (xy 105.342944 165.535112) (xy 105.343107 165.533872) (xy 105.342606 165.483609) (xy 105.3426 165.482372) (xy 105.3426 161.733567) (xy 105.362285 161.666528) (xy 105.378918 161.645886) (xy 105.467913 161.556898) (xy 106.1995 161.556898) (xy 106.1995 162.443102) (xy 106.203092 162.473013) (xy 106.210122 162.531561) (xy 106.265639 162.672343) (xy 106.357077 162.792922) (xy 106.477656 162.88436) (xy 106.477657 162.88436) (xy 106.477658 162.884361) (xy 106.618436 162.939877) (xy 106.706898 162.9505) (xy 106.706903 162.9505) (xy 107.293097 162.9505) (xy 107.293102 162.9505) (xy 107.381564 162.939877) (xy 107.522342 162.884361) (xy 107.642922 162.792922) (xy 107.734361 162.672342) (xy 107.789877 162.531564) (xy 107.8005 162.443102) (xy 107.8005 161.556898) (xy 107.789877 161.468436) (xy 107.734361 161.327658) (xy 107.73436 161.327657) (xy 107.73436 161.327656) (xy 107.642922 161.207077) (xy 107.522343 161.115639) (xy 107.381561 161.060122) (xy 107.335926 161.054642) (xy 107.293102 161.0495) (xy 106.706898 161.0495) (xy 106.667853 161.054188) (xy 106.618438 161.060122) (xy 106.477656 161.115639) (xy 106.357077 161.207077) (xy 106.265639 161.327656) (xy 106.210122 161.468438) (xy 106.204666 161.513876) (xy 106.1995 161.556898) (xy 105.467913 161.556898) (xy 106.458006 160.566883) (xy 106.458013 160.56688) (xy 106.494517 160.530375) (xy 106.52775 160.497145) (xy 106.53068 160.494523) (xy 106.532548 160.492347) (xy 106.532571 160.492325) (xy 106.532575 160.492317) (xy 106.53258 160.492313) (xy 106.532583 160.492306) (xy 106.532914 160.491922) (xy 106.534417 160.489131) (xy 106.555654 160.452347) (xy 106.555656 160.452342) (xy 106.555657 160.452341) (xy 106.585301 160.401002) (xy 106.585303 160.400995) (xy 106.585303 160.400991) (xy 106.585307 160.400987) (xy 106.596115 160.360649) (xy 106.612599 160.299142) (xy 106.612599 160.299141) (xy 106.6126 160.299138) (xy 106.6126 160.272779) (xy 106.6126 160.272776) (xy 106.612603 160.193689) (xy 106.612601 160.193684) (xy 106.612602 160.186114) (xy 106.6126 160.186064) (xy 106.6126 158.39649) (xy 106.632285 158.329451) (xy 106.647934 158.309805) (xy 106.766117 158.188921) (xy 108.990883 155.913295) (xy 109.017511 155.898362) (xy 109.042955 155.881504) (xy 109.04769 155.881437) (xy 109.051823 155.87912) (xy 109.082296 155.880953) (xy 109.112818 155.880527) (xy 109.116838 155.883032) (xy 109.121567 155.883317) (xy 109.146208 155.901332) (xy 109.172118 155.917477) (xy 109.175714 155.922904) (xy 109.17797 155.924554) (xy 109.191612 155.946898) (xy 109.191621 155.946917) (xy 109.20253 156.01593) (xy 109.19096 156.054456) (xy 109.185134 156.066375) (xy 109.1745 156.139364) (xy 109.1745 156.360636) (xy 109.185134 156.433625) (xy 109.19096 156.445542) (xy 109.202717 156.514416) (xy 109.19096 156.554456) (xy 109.185134 156.566375) (xy 109.1745 156.639364) (xy 109.1745 156.860636) (xy 109.185134 156.933625) (xy 109.185134 156.933626) (xy 109.185135 156.933628) (xy 109.240172 157.04621) (xy 109.328789 157.134827) (xy 109.436572 157.187518) (xy 109.441375 157.189866) (xy 109.514364 157.2005) (xy 109.51437 157.2005) (xy 110.98563 157.2005) (xy 110.985636 157.2005) (xy 111.058625 157.189866) (xy 111.116118 157.161759) (xy 111.17121 157.134827) (xy 111.259827 157.04621) (xy 111.286759 156.991118) (xy 111.314866 156.933625) (xy 111.3255 156.860636) (xy 111.3255 156.639364) (xy 111.314866 156.566375) (xy 111.309041 156.55446) (xy 111.297281 156.485592) (xy 111.30904 156.445541) (xy 111.314866 156.433625) (xy 111.3255 156.360636) (xy 111.3255 156.139364) (xy 111.314866 156.066375) (xy 111.309041 156.05446) (xy 111.297281 155.985592) (xy 111.298891 155.975471) (xy 111.302041 155.959856) (xy 111.314866 155.933625) (xy 111.3255 155.860636) (xy 111.3255 155.843611) (xy 111.32795 155.831471) (xy 111.338691 155.811073) (xy 111.345185 155.788961) (xy 111.354661 155.780749) (xy 111.360507 155.76965) (xy 111.380572 155.758297) (xy 111.397989 155.743206) (xy 111.41303 155.739933) (xy 111.421318 155.735245) (xy 111.431853 155.735838) (xy 111.4495 155.732) (xy 111.48813 155.732)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts (xy 141.430124 162.953872) (xy 141.481848 163.000844) (xy 141.5 163.065436) (xy 141.5 167.367015) (xy 141.486485 167.423309) (xy 141.427455 167.539161) (xy 141.387668 167.661612) (xy 141.34823 167.719287) (xy 141.283871 167.746485) (xy 141.215025 167.73457) (xy 141.163549 167.687325) (xy 141.151806 167.661611) (xy 141.112085 167.539362) (xy 141.026329 167.371059) (xy 140.915314 167.218258) (xy 140.91531 167.218253) (xy 140.781746 167.084689) (xy 140.781741 167.084685) (xy 140.62894 166.97367) (xy 140.460635 166.887913) (xy 140.280999 166.829547) (xy 140.2 166.816718) (xy 140.2 167.53812) (xy 140.192993 167.534075) (xy 140.065826 167.5) (xy 139.934174 167.5) (xy 139.807007 167.534075) (xy 139.8 167.53812) (xy 139.8 166.816718) (xy 139.799999 166.816718) (xy 139.719 166.829547) (xy 139.539364 166.887913) (xy 139.371059 166.97367) (xy 139.218258 167.084685) (xy 139.218253 167.084689) (xy 139.084689 167.218253) (xy 139.084685 167.218258) (xy 138.973667 167.371063) (xy 138.973666 167.371064) (xy 138.894983 167.525487) (xy 138.847009 167.576283) (xy 138.779188 167.593078) (xy 138.713053 167.57054) (xy 138.669602 167.515825) (xy 138.660499 167.469192) (xy 138.660499 167.22156) (xy 138.680184 167.154521) (xy 138.688941 167.142537) (xy 140.534363 164.911329) (xy 140.55828 164.887413) (xy 140.567839 164.870854) (xy 140.580022 164.856126) (xy 140.591664 164.830688) (xy 140.597013 164.820323) (xy 140.611007 164.796087) (xy 140.613259 164.787679) (xy 140.620285 164.768159) (xy 140.623911 164.760239) (xy 140.629547 164.726892) (xy 140.6383 164.694227) (xy 140.6383 164.675109) (xy 140.641486 164.65626) (xy 140.638852 164.628426) (xy 140.6383 164.616743) (xy 140.6383 163.0745) (xy 140.657985 163.007461) (xy 140.710789 162.961706) (xy 140.7623 162.9505) (xy 141.293096 162.9505) (xy 141.293102 162.9505) (xy 141.361217 162.94232)
+			)
+		)
 	)
 	(zone
 		(net "+5V")
 		(layer "F.Cu")
-		(uuid "122a41c1-c337-45ee-9b6c-59047d2266c1")
+		(uuid "9f068b0f-7069-45bf-ac62-ab4b8141a290")
 		(hatch edge 0.5)
 		(priority 3)
 		(connect_pads (clearance 0.3)
@@ -6328,38 +6165,48 @@
 		)
 	)
 	(zone
-		(net "VMOTOR")
+		(net "+3.3V")
 		(layer "F.Cu")
-		(uuid "3a97bae6-b601-408e-a6f4-9c4b25eda0fc")
+		(uuid "a6ad611c-b5cb-466e-8c24-95c18459a4ad")
 		(hatch edge 0.5)
-		(priority 4)
+		(priority 2)
 		(connect_pads (clearance 0.3)
 		)
 		(min_thickness 0.25)
 		(fill yes (thermal_gap 0.3) (thermal_bridge_width 0.4) (island_removal_mode 0)
 		)
-		(polygon (pts (xy 101.5 105.23) (xy 141.5 105.23) (xy 141.5 169.5) (xy 101.5 169.5))
+		(polygon (pts (xy 108.75 111.5) (xy 166.5 111.5) (xy 166.5 162.04) (xy 108.75 162.04))
 		)
 		(filled_polygon
 			(layer "F.Cu")
-			(pts (xy 141.443039 105.249685) (xy 141.488794 105.302489) (xy 141.5 105.354) (xy 141.5 118.5255) (xy 141.480315 118.592539) (xy 141.427511 118.638294) (xy 141.376 118.6495) (xy 139.805143 118.6495) (xy 139.805117 118.649502) (xy 139.780012 118.652413) (xy 139.780008 118.652415) (xy 139.677235 118.697793) (xy 139.597794 118.777234) (xy 139.552415 118.880006) (xy 139.552415 118.880008) (xy 139.5495 118.905131) (xy 139.5495 120.494856) (xy 139.549502 120.494882) (xy 139.552413 120.519987) (xy 139.552415 120.519991) (xy 139.597793 120.622764) (xy 139.597794 120.622765) (xy 139.677235 120.702206) (xy 139.741952 120.730781) (xy 139.755053 120.736566) (xy 139.808429 120.781652) (xy 139.828956 120.848438) (xy 139.810118 120.91572) (xy 139.757894 120.962137) (xy 139.755053 120.963434) (xy 139.677234 120.997794) (xy 139.597794 121.077234) (xy 139.552415 121.180006) (xy 139.552415 121.180008) (xy 139.5495 121.205131) (xy 139.5495 122.794856) (xy 139.549502 122.794882) (xy 139.552413 122.819987) (xy 139.552415 122.819991) (xy 139.597793 122.922764) (xy 139.597794 122.922765) (xy 139.677235 123.002206) (xy 139.741952 123.030781) (xy 139.755053 123.036566) (xy 139.808429 123.081652) (xy 139.828956 123.148438) (xy 139.810118 123.21572) (xy 139.757894 123.262137) (xy 139.755053 123.263434) (xy 139.677234 123.297794) (xy 139.597794 123.377234) (xy 139.552415 123.480006) (xy 139.552415 123.480008) (xy 139.5495 123.505131) (xy 139.5495 125.094856) (xy 139.549502 125.094882) (xy 139.552413 125.119987) (xy 139.552415 125.119991) (xy 139.597793 125.222764) (xy 139.597794 125.222765) (xy 139.677235 125.302206) (xy 139.780009 125.347585) (xy 139.805135 125.3505) (xy 141.376 125.350499) (xy 141.443039 125.370184) (xy 141.488794 125.422987) (xy 141.5 125.474499) (xy 141.5 135.934563) (xy 141.480315 136.001602) (xy 141.427511 136.047357) (xy 141.361218 136.057679) (xy 141.319884 136.052716) (xy 141.293102 136.0495) (xy 140.706898 136.0495) (xy 140.667853 136.054188) (xy 140.618438 136.060122) (xy 140.477656 136.115639) (xy 140.357077 136.207077) (xy 140.265639 136.327656) (xy 140.210122 136.468438) (xy 140.204188 136.517853) (xy 140.1995 136.556898) (xy 140.1995 137.443102) (xy 140.205126 137.489954) (xy 140.210122 137.531561) (xy 140.265639 137.672343) (xy 140.357077 137.792922) (xy 140.477656 137.88436) (xy 140.477657 137.88436) (xy 140.477658 137.884361) (xy 140.618436 137.939877) (xy 140.706898 137.9505) (xy 140.706903 137.9505) (xy 141.293096 137.9505) (xy 141.293102 137.9505) (xy 141.361217 137.94232) (xy 141.430124 137.953872) (xy 141.481848 138.000844) (xy 141.5 138.065436) (xy 141.5 144.651727) (xy 141.480315 144.718766) (xy 141.427511 144.764521) (xy 141.363442 144.773733) (xy 141.363352 144.774882) (xy 141.358495 144.7745) (xy 141.358488 144.7745) (xy 141.041512 144.7745) (xy 141.041507 144.7745) (xy 140.941876 144.790279) (xy 140.856294 144.833886) (xy 140.787625 144.846782) (xy 140.743706 144.833886) (xy 140.658123 144.790279) (xy 140.558493 144.7745) (xy 140.558488 144.7745) (xy 140.241512 144.7745) (xy 140.241507 144.7745) (xy 140.141876 144.790279) (xy 140.056294 144.833886) (xy 139.987625 144.846782) (xy 139.943706 144.833886) (xy 139.858123 144.790279) (xy 139.758493 144.7745) (xy 139.758488 144.7745) (xy 139.441512 144.7745) (xy 139.441507 144.7745) (xy 139.341876 144.790279) (xy 139.256294 144.833886) (xy 139.187625 144.846782) (xy 139.143706 144.833886) (xy 139.058123 144.790279) (xy 138.958493 144.7745) (xy 138.958488 144.7745) (xy 138.641512 144.7745) (xy 138.641507 144.7745) (xy 138.541876 144.790279) (xy 138.456294 144.833886) (xy 138.387625 144.846782) (xy 138.343706 144.833886) (xy 138.258123 144.790279) (xy 138.158493 144.7745) (xy 138.158488 144.7745) (xy 137.841512 144.7745) (xy 137.841507 144.7745) (xy 137.741876 144.790279) (xy 137.656294 144.833886) (xy 137.587625 144.846782) (xy 137.543706 144.833886) (xy 137.458123 144.790279) (xy 137.358493 144.7745) (xy 137.358488 144.7745) (xy 137.041512 144.7745) (xy 137.041507 144.7745) (xy 136.941878 144.790279) (xy 136.821778 144.851473) (xy 136.821774 144.851476) (xy 136.726476 144.946774) (xy 136.726473 144.946778) (xy 136.665279 145.066878) (xy 136.6495 145.166506) (xy 136.6495 146.483493) (xy 136.654042 146.512171) (xy 136.645087 146.581465) (xy 136.600091 146.634917) (xy 136.533339 146.655556) (xy 136.512171 146.654042) (xy 136.483493 146.6495) (xy 136.483488 146.6495) (xy 135.166512 146.6495) (xy 135.166507 146.6495) (xy 135.066878 146.665279) (xy 134.946778 146.726473) (xy 134.946774 146.726476) (xy 134.851476 146.821774) (xy 134.851473 146.821778) (xy 134.790279 146.941878) (xy 134.7745 147.041506) (xy 134.7745 147.358493) (xy 134.790279 147.458123) (xy 134.833886 147.543706) (xy 134.846782 147.612375) (xy 134.833886 147.656294) (xy 134.790279 147.741876) (xy 134.7745 147.841506) (xy 134.7745 148.158493) (xy 134.790279 148.258121) (xy 134.79028 148.258124) (xy 134.790281 148.258126) (xy 134.833886 148.343705) (xy 134.834683 148.34795) (xy 134.837431 148.351284) (xy 134.841074 148.38198) (xy 134.846782 148.412373) (xy 134.845301 148.417591) (xy 134.845666 148.420667) (xy 134.836937 148.447065) (xy 134.834891 148.454276) (xy 134.834388 148.455309) (xy 134.790281 148.541874) (xy 134.789333 148.547855) (xy 134.782562 148.561765) (xy 134.76461 148.581478) (xy 134.749562 148.603484) (xy 134.741247 148.607133) (xy 134.735519 148.613425) (xy 134.71356 148.619288) (xy 134.688611 148.630241) (xy 134.528343 148.65314) (xy 134.510772 148.654387) (xy 134.495403 148.654383) (xy 134.495396 148.654383) (xy 134.474782 148.6599) (xy 134.474781 148.659899) (xy 134.467605 148.661819) (xy 134.439154 148.665885) (xy 134.416905 148.675388) (xy 134.408369 148.677673) (xy 134.408366 148.677672) (xy 134.393534 148.681643) (xy 134.393533 148.681643) (xy 134.375046 148.692308) (xy 134.3618 148.698928) (xy 134.342179 148.70731) (xy 134.342174 148.707313) (xy 134.330093 148.716797) (xy 134.32314 148.722254) (xy 134.302188 148.734343) (xy 134.281853 148.754663) (xy 134.276017 148.759245) (xy 134.276018 148.759245) (xy 134.259231 148.772423) (xy 134.259224 148.77243) (xy 134.250009 148.784717) (xy 134.238465 148.798023) (xy 134.148912 148.887519) (xy 134.143334 148.893093) (xy 134.143279 148.893126) (xy 134.106996 148.929409) (xy 134.105395 148.93101) (xy 134.105368 148.931037) (xy 134.068793 148.967589) (xy 134.068714 148.967694) (xy 134.041959 149.014036) (xy 134.04194 149.01407) (xy 134.016042 149.058893) (xy 134.015988 149.059022) (xy 134.002553 149.109169) (xy 134.002543 149.109209) (xy 133.988716 149.160745) (xy 133.988699 149.160871) (xy 133.9887 149.211035) (xy 133.9887 149.211074) (xy 133.988681 149.273933) (xy 133.988701 149.274248) (xy 133.988797 153.0981) (xy 133.988797 153.109158) (xy 133.987957 153.112526) (xy 133.988798 153.161835) (xy 133.988799 153.162898) (xy 133.9888 153.21114) (xy 133.988848 153.2115) (xy 133.988901 153.21221) (xy 133.989091 153.213483) (xy 133.989391 153.215615) (xy 133.989561 153.216908) (xy 133.989706 153.217605) (xy 133.98976 153.217969) (xy 134.003038 153.264339) (xy 134.003602 153.266374) (xy 134.016097 153.312998) (xy 134.016229 153.313316) (xy 134.01623 153.313316) (xy 134.017836 153.317194) (xy 134.018325 153.318376) (xy 134.018644 153.319008) (xy 134.01879 153.319346) (xy 134.043642 153.360739) (xy 134.043643 153.360739) (xy 134.044169 153.361615) (xy 134.068826 153.404321) (xy 134.071283 153.406778) (xy 134.07307 153.409754) (xy 134.073073 153.409757) (xy 134.073074 153.409758) (xy 134.107732 153.443251) (xy 134.109241 153.444734) (xy 134.143397 153.478888) (xy 134.143666 153.479094) (xy 134.154354 153.488306) (xy 134.181372 153.514416) (xy 134.554516 153.875017) (xy 134.580275 153.91082) (xy 134.718512 154.200786) (xy 134.724531 154.221122) (xy 134.741114 154.248196) (xy 134.743909 154.254058) (xy 134.743909 154.254059) (xy 134.754771 154.276844) (xy 134.754772 154.276846) (xy 134.7622 154.285547) (xy 134.773627 154.301281) (xy 134.779607 154.311043) (xy 134.779611 154.311048) (xy 134.797917 154.328428) (xy 134.806843 154.337837) (xy 134.823241 154.357044) (xy 134.832671 154.363527) (xy 134.847787 154.375773) (xy 135.279382 154.785523) (xy 135.302938 154.816208) (xy 135.554244 155.278292) (xy 135.554245 155.278292) (xy 135.560089 155.289038) (xy 135.564013 155.301656) (xy 135.585197 155.335204) (xy 135.587127 155.338752) (xy 135.587127 155.338753) (xy 135.604155 155.370063) (xy 135.604156 155.370065) (xy 135.604158 155.370067) (xy 135.613261 155.379646) (xy 135.620317 155.39082) (xy 135.649465 155.417744) (xy 135.664557 155.433625) (xy 135.6768 155.446509) (xy 135.676802 155.44651) (xy 135.677636 155.447021) (xy 135.697055 155.461705) (xy 136.118019 155.85055) (xy 136.119827 155.85222) (xy 136.151487 155.88388) (xy 136.158459 155.887905) (xy 136.164376 155.89337) (xy 136.164378 155.893372) (xy 136.164381 155.893374) (xy 136.201863 155.913077) (xy 136.206128 155.915427) (xy 136.242813 155.936607) (xy 136.247933 155.937978) (xy 136.250593 155.938691) (xy 136.257724 155.94244) (xy 136.301414 155.952308) (xy 136.344673 155.9639) (xy 136.344677 155.9639) (xy 136.352589 155.964942) (xy 136.360576 155.965672) (xy 136.360586 155.965675) (xy 136.402896 155.963996) (xy 136.40781 155.9639) (xy 141.376 155.9639) (xy 141.443039 155.983585) (xy 141.488794 156.036389) (xy 141.5 156.0879) (xy 141.5 160.934563) (xy 141.480315 161.001602) (xy 141.427511 161.047357) (xy 141.361218 161.057679) (xy 141.319884 161.052716) (xy 141.293102 161.0495) (xy 140.706898 161.0495) (xy 140.667853 161.054188) (xy 140.618438 161.060122) (xy 140.477656 161.115639) (xy 140.357077 161.207077) (xy 140.265639 161.327656) (xy 140.210122 161.468438) (xy 140.204666 161.513876) (xy 140.1995 161.556898) (xy 140.1995 161.556903) (xy 140.1995 162.081813) (xy 140.199043 162.083366) (xy 140.199461 162.084931) (xy 140.18923 162.116785) (xy 140.179815 162.148852) (xy 140.178433 162.150406) (xy 140.178097 162.151454) (xy 140.154321 162.177538) (xy 140.016751 162.290814) (xy 139.999935 162.302472) (xy 139.991887 162.30712) (xy 139.991886 162.30712) (xy 139.986501 162.31023) (xy 139.918601 162.326703) (xy 139.852574 162.303851) (xy 139.809383 162.24893) (xy 139.8005 162.202843) (xy 139.8005 161.556903) (xy 139.8005 161.556898) (xy 139.789877 161.468436) (xy 139.734361 161.327658) (xy 139.73436 161.327657) (xy 139.73436 161.327656) (xy 139.642922 161.207077) (xy 139.522343 161.115639) (xy 139.381561 161.060122) (xy 139.335926 161.054642) (xy 139.293102 161.0495) (xy 138.706898 161.0495) (xy 138.667853 161.054188) (xy 138.618438 161.060122) (xy 138.477656 161.115639) (xy 138.357077 161.207077) (xy 138.265639 161.327656) (xy 138.210121 161.468441) (xy 138.208387 161.482885) (xy 138.18085 161.547099) (xy 138.122967 161.586232) (xy 138.085272 161.5921) (xy 129.768961 161.5921) (xy 129.701922 161.572415) (xy 129.680119 161.554605) (xy 129.67281 161.547099) (xy 125.077389 156.827511) (xy 122.448666 154.127761) (xy 122.416001 154.065997) (xy 122.421914 153.996378) (xy 122.464527 153.941007) (xy 122.530311 153.917465) (xy 122.582997 153.925901) (xy 122.618436 153.939877) (xy 122.706898 153.9505) (xy 122.706903 153.9505) (xy 123.293097 153.9505) (xy 123.293102 153.9505) (xy 123.381564 153.939877) (xy 123.522342 153.884361) (xy 123.642922 153.792922) (xy 123.734361 153.672342) (xy 123.789877 153.531564) (xy 123.8005 153.443102) (xy 123.8005 152.556898) (xy 124.1995 152.556898) (xy 124.1995 153.443102) (xy 124.203822 153.479094) (xy 124.210122 153.531561) (xy 124.265639 153.672343) (xy 124.357077 153.792922) (xy 124.477656 153.88436) (xy 124.477657 153.88436) (xy 124.477658 153.884361) (xy 124.618436 153.939877) (xy 124.706898 153.9505) (xy 124.706903 153.9505) (xy 125.293097 153.9505) (xy 125.293102 153.9505) (xy 125.381564 153.939877) (xy 125.522342 153.884361) (xy 125.642922 153.792922) (xy 125.734361 153.672342) (xy 125.789877 153.531564) (xy 125.8005 153.443102) (xy 125.8005 152.556898) (xy 125.789877 152.468436) (xy 125.734361 152.327658) (xy 125.73436 152.327657) (xy 125.73436 152.327656) (xy 125.642922 152.207077) (xy 125.522343 152.115639) (xy 125.425144 152.077309) (xy 125.381564 152.060123) (xy 125.381563 152.060122) (xy 125.381561 152.060122) (xy 125.334389 152.054458) (xy 125.293102 152.0495) (xy 124.706898 152.0495) (xy 124.667853 152.054188) (xy 124.618438 152.060122) (xy 124.477656 152.115639) (xy 124.357077 152.207077) (xy 124.265639 152.327656) (xy 124.210122 152.468438) (xy 124.205524 152.506736) (xy 124.1995 152.556898) (xy 123.8005 152.556898) (xy 123.789877 152.468436) (xy 123.734361 152.327658) (xy 123.73436 152.327657) (xy 123.73436 152.327656) (xy 123.642922 152.207077) (xy 123.522343 152.115639) (xy 123.425144 152.077309) (xy 123.381564 152.060123) (xy 123.381563 152.060122) (xy 123.381561 152.060122) (xy 123.334389 152.054458) (xy 123.293102 152.0495) (xy 122.706898 152.0495) (xy 122.667853 152.054188) (xy 122.618438 152.060122) (xy 122.477656 152.115639) (xy 122.357077 152.207077) (xy 122.265639 152.327656) (xy 122.210122 152.468438) (xy 122.205524 152.506736) (xy 122.1995 152.556898) (xy 122.1995 153.443102) (xy 122.203391 153.4755) (xy 122.210122 153.531563) (xy 122.21642 153.547532) (xy 122.222701 153.617119) (xy 122.190364 153.679055) (xy 122.129674 153.713675) (xy 122.059902 153.709989) (xy 122.012223 153.679526) (xy 122.011764 153.679055) (xy 121.66119 153.319008) (xy 121.016335 152.656729) (xy 121.016335 152.656728) (xy 121.009135 152.649334) (xy 121.00778 152.646987) (xy 120.972362 152.611569) (xy 120.937462 152.575726) (xy 120.937292 152.575551) (xy 120.936011 152.574568) (xy 120.934709 152.573555) (xy 120.933425 152.572542) (xy 120.890532 152.547778) (xy 120.890531 152.547777) (xy 120.889828 152.547371) (xy 120.846848 152.521787) (xy 120.844242 152.521051) (xy 120.841888 152.519692) (xy 120.794332 152.506949) (xy 120.79344 152.50671) (xy 120.74536 152.493138) (xy 120.742646 152.493101) (xy 120.740027 152.4924) (xy 120.740024 152.4924) (xy 120.690841 152.4924) (xy 120.689188 152.492389) (xy 120.638613 152.491714) (xy 120.626964 152.4924) (xy 118.949171 152.4924) (xy 118.895347 152.480109) (xy 118.703576 152.387709) (xy 118.697812 152.382502) (xy 118.690361 152.380315) (xy 118.674368 152.367428) (xy 118.671213 152.365175) (xy 118.663493 152.361401) (xy 118.61191 152.314274) (xy 118.593995 152.246741) (xy 118.615435 152.180242) (xy 118.663493 152.138599) (xy 118.671211 152.134826) (xy 118.671213 152.134824) (xy 118.679575 152.128855) (xy 118.680644 152.130353) (xy 118.731042 152.102834) (xy 118.7574 152.1) (xy 118.819258 152.1) (xy 118.819258 152.099999) (xy 118.81438 152.06652) (xy 118.808765 152.055035) (xy 118.797003 151.986162) (xy 118.808763 151.946107) (xy 118.814866 151.933625) (xy 118.8255 151.860636) (xy 118.8255 151.639364) (xy 118.814866 151.566375) (xy 118.809041 151.55446) (xy 118.797281 151.485592) (xy 118.80904 151.445541) (xy 118.814866 151.433625) (xy 118.8255 151.360636) (xy 118.8255 151.139364) (xy 118.814866 151.066375) (xy 118.809041 151.05446) (xy 118.797281 150.985592) (xy 118.80904 150.945541) (xy 118.814866 150.933625) (xy 118.8255 150.860636) (xy 118.8255 150.639364) (xy 118.814866 150.566375) (xy 118.809041 150.55446) (xy 118.797281 150.485592) (xy 118.798507 150.477461) (xy 118.80159 150.46078) (xy 118.814866 150.433625) (xy 118.8255 150.360636) (xy 118.8255 150.33143) (xy 118.827566 150.320254) (xy 118.838414 150.29881) (xy 118.845185 150.275754) (xy 118.8539 150.268201) (xy 118.859108 150.257909) (xy 118.879829 150.245734) (xy 118.897989 150.229999) (xy 118.909404 150.228357) (xy 118.919349 150.222515) (xy 118.94336 150.223475) (xy 118.967147 150.220055) (xy 118.977638 150.224846) (xy 118.989163 150.225307) (xy 119.008844 150.239097) (xy 119.030703 150.24908) (xy 119.04115 150.261734) (xy 119.046384 150.265401) (xy 119.048551 150.270697) (xy 119.056888 150.280795) (xy 119.066077 150.296712) (xy 119.066079 150.296715) (xy 119.06608 150.296716) (xy 119.177884 150.40852) (xy 119.177886 150.408521) (xy 119.17789 150.408524) (xy 119.297294 150.477461) (xy 119.314816 150.487577) (xy 119.467543 150.5285) (xy 119.467545 150.5285) (xy 119.625655 150.5285) (xy 119.625657 150.5285) (xy 119.778384 150.487577) (xy 119.915316 150.40852) (xy 120.02712 150.296716) (xy 120.106177 150.159784) (xy 120.1471 150.007057) (xy 120.1471 149.848943) (xy 120.106177 149.696216) (xy 120.062443 149.620466) (xy 120.027124 149.55929) (xy 120.027118 149.559282) (xy 119.915317 149.447481) (xy 119.915309 149.447475) (xy 119.77839 149.368426) (xy 119.778386 149.368424) (xy 119.778384 149.368423) (xy 119.625657 149.3275) (xy 119.625656 149.3275) (xy 119.56391 149.3275) (xy 119.496871 149.307815) (xy 119.476222 149.291174) (xy 119.237328 149.052241) (xy 119.237328 149.05224) (xy 119.232187 149.047098) (xy 119.23218 149.047087) (xy 119.195308 149.010215) (xy 119.157638 148.972539) (xy 119.157636 148.972538) (xy 119.157618 148.972524) (xy 119.157615 148.972522) (xy 119.157613 148.97252) (xy 119.11546 148.948183) (xy 119.099078 148.938723) (xy 119.06922 148.921481) (xy 119.069215 148.921478) (xy 119.066317 148.919805) (xy 119.066299 148.9198) (xy 119.066287 148.919793) (xy 119.065211 148.919504) (xy 119.06521 148.919504) (xy 119.017509 148.906722) (xy 119.017503 148.906721) (xy 118.964456 148.892503) (xy 118.964434 148.8925) (xy 118.964427 148.8925) (xy 118.9495 148.8925) (xy 118.882461 148.872815) (xy 118.836706 148.820011) (xy 118.8255 148.7685) (xy 118.8255 148.639369) (xy 118.8255 148.639364) (xy 118.814866 148.566375) (xy 118.809041 148.55446) (xy 118.797281 148.485592) (xy 118.80904 148.445541) (xy 118.814866 148.433625) (xy 118.8255 148.360636) (xy 118.8255 148.139364) (xy 118.814866 148.066375) (xy 118.810229 148.056891) (xy 118.805789 148.03089) (xy 118.797673 148.005785) (xy 118.799999 147.996987) (xy 118.798468 147.98802) (xy 118.80879 147.963744) (xy 118.815536 147.938237) (xy 118.822248 147.932094) (xy 118.825809 147.923722) (xy 118.84762 147.908878) (xy 118.867082 147.89107) (xy 118.879856 147.88694) (xy 118.883571 147.884412) (xy 118.900653 147.880215) (xy 119.137338 147.839617) (xy 119.150043 147.838921) (xy 119.149991 147.838193) (xy 119.158095 147.837607) (xy 119.158096 147.837606) (xy 119.158103 147.837607) (xy 119.203269 147.828309) (xy 119.248676 147.820521) (xy 119.254793 147.817703) (xy 119.261391 147.816345) (xy 119.300782 147.796592) (xy 119.304454 147.794827) (xy 119.313976 147.79044) (xy 119.344455 147.776401) (xy 119.344459 147.776396) (xy 119.350117 147.77283) (xy 119.355651 147.769078) (xy 119.355657 147.769076) (xy 119.390106 147.738456) (xy 119.425553 147.708994) (xy 119.429443 147.703492) (xy 119.731645 147.434886) (xy 119.732213 147.434386) (xy 119.770368 147.401064) (xy 119.770374 147.401053) (xy 119.771877 147.399349) (xy 119.771878 147.399348) (xy 119.772619 147.398505) (xy 119.772675 147.398419) (xy 119.772677 147.398418) (xy 119.800727 147.355826) (xy 119.829133 147.313501) (xy 119.829701 147.311834) (xy 119.830675 147.310357) (xy 119.830676 147.310353) (xy 119.830679 147.310349) (xy 119.84675 147.261945) (xy 119.863233 147.213714) (xy 119.863351 147.211949) (xy 119.863909 147.210272) (xy 119.863909 147.21027) (xy 119.86391 147.210268) (xy 119.866877 147.159851) (xy 119.866944 147.158798) (xy 119.907623 146.556898) (xy 122.1995 146.556898) (xy 122.1995 147.443102) (xy 122.202459 147.467743) (xy 122.210122 147.531561) (xy 122.265639 147.672343) (xy 122.357077 147.792922) (xy 122.477656 147.88436) (xy 122.477657 147.88436) (xy 122.477658 147.884361) (xy 122.618436 147.939877) (xy 122.706898 147.9505) (xy 122.706903 147.9505) (xy 123.293097 147.9505) (xy 123.293102 147.9505) (xy 123.381564 147.939877) (xy 123.522342 147.884361) (xy 123.642922 147.792922) (xy 123.734361 147.672342) (xy 123.789877 147.531564) (xy 123.8005 147.443102) (xy 123.8005 146.556898) (xy 124.1995 146.556898) (xy 124.1995 147.443102) (xy 124.202459 147.467743) (xy 124.210122 147.531561) (xy 124.265639 147.672343) (xy 124.357077 147.792922) (xy 124.477656 147.88436) (xy 124.477657 147.88436) (xy 124.477658 147.884361) (xy 124.618436 147.939877) (xy 124.706898 147.9505) (xy 124.706903 147.9505) (xy 125.293097 147.9505) (xy 125.293102 147.9505) (xy 125.381564 147.939877) (xy 125.522342 147.884361) (xy 125.642922 147.792922) (xy 125.734361 147.672342) (xy 125.789877 147.531564) (xy 125.8005 147.443102) (xy 125.8005 146.556898) (xy 125.789877 146.468436) (xy 125.734361 146.327658) (xy 125.73436 146.327657) (xy 125.73436 146.327656) (xy 125.642922 146.207077) (xy 125.522343 146.115639) (xy 125.397415 146.066374) (xy 125.381564 146.060123) (xy 125.381563 146.060122) (xy 125.381561 146.060122) (xy 125.334389 146.054458) (xy 125.293102 146.0495) (xy 124.706898 146.0495) (xy 124.667853 146.054188) (xy 124.618438 146.060122) (xy 124.477656 146.115639) (xy 124.357077 146.207077) (xy 124.265639 146.327656) (xy 124.210122 146.468438) (xy 124.204871 146.512171) (xy 124.1995 146.556898) (xy 123.8005 146.556898) (xy 123.789877 146.468436) (xy 123.734361 146.327658) (xy 123.73436 146.327657) (xy 123.73436 146.327656) (xy 123.642922 146.207077) (xy 123.522343 146.115639) (xy 123.397415 146.066374) (xy 123.381564 146.060123) (xy 123.381563 146.060122) (xy 123.381561 146.060122) (xy 123.334389 146.054458) (xy 123.293102 146.0495) (xy 122.706898 146.0495) (xy 122.667853 146.054188) (xy 122.618438 146.060122) (xy 122.477656 146.115639) (xy 122.357077 146.207077) (xy 122.265639 146.327656) (xy 122.210122 146.468438) (xy 122.204871 146.512171) (xy 122.1995 146.556898) (xy 119.907623 146.556898) (xy 119.912415 146.485999) (xy 119.936576 146.420443) (xy 119.948453 146.406682) (xy 119.976365 146.378771) (xy 120.02712 146.328016) (xy 120.029789 146.323394) (xy 120.071037 146.251948) (xy 120.106177 146.191084) (xy 120.1471 146.038357) (xy 120.1471 145.880243) (xy 120.106177 145.727516) (xy 120.106173 145.727509) (xy 120.027124 145.59059) (xy 120.027118 145.590582) (xy 119.915317 145.478781) (xy 119.915309 145.478775) (xy 119.77839 145.399726) (xy 119.778386 145.399724) (xy 119.778384 145.399723) (xy 119.625657 145.3588) (xy 119.467543 145.3588) (xy 119.314816 145.399723) (xy 119.314809 145.399726) (xy 119.17789 145.478775) (xy 119.177882 145.478781) (xy 119.066081 145.590582) (xy 119.066075 145.59059) (xy 119.046895 145.623811) (xy 118.996328 145.672026) (xy 118.927721 145.685248) (xy 118.862856 145.65928) (xy 118.822328 145.602365) (xy 118.821074 145.59854) (xy 118.818203 145.589285) (xy 118.814866 145.566375) (xy 118.804561 145.545297) (xy 118.801728 145.53616) (xy 118.801338 145.510408) (xy 118.797003 145.485018) (xy 118.80076 145.472221) (xy 118.800671 145.466299) (xy 118.804137 145.46072) (xy 118.808764 145.444967) (xy 118.81438 145.433479) (xy 118.81438 145.433477) (xy 118.819258 145.4) (xy 118.7574 145.4) (xy 118.696701 145.384128) (xy 118.6818 145.375763) (xy 118.671211 145.365174) (xy 118.607142 145.333852) (xy 118.60407 145.332128) (xy 118.582016 145.309551) (xy 118.558726 145.288272) (xy 118.557792 145.284751) (xy 118.555247 145.282146) (xy 118.548901 145.251233) (xy 118.540812 145.220738) (xy 118.541929 145.217272) (xy 118.541197 145.213704) (xy 118.552571 145.184266) (xy 118.562253 145.15424) (xy 118.565066 145.151928) (xy 118.56638 145.14853) (xy 118.591865 145.129914) (xy 118.616242 145.10989) (xy 118.620455 145.109031) (xy 118.622801 145.107318) (xy 118.631375 145.106805) (xy 118.664769 145.1) (xy 118.819258 145.1) (xy 118.819258 145.099999) (xy 118.81438 145.06652) (xy 118.814379 145.066517) (xy 118.808487 145.054465) (xy 118.796725 144.985592) (xy 118.808487 144.945535) (xy 118.814379 144.933482) (xy 118.81438 144.933479) (xy 118.819258 144.9) (xy 117.9 144.9) (xy 117.9 145.126) (xy 117.897449 145.134685) (xy 117.898738 145.143647) (xy 117.887759 145.167687) (xy 117.880315 145.193039) (xy 117.873474 145.198966) (xy 117.869713 145.207203) (xy 117.847478 145.221492) (xy 117.827511 145.238794) (xy 117.816996 145.241081) (xy 117.810935 145.244977) (xy 117.776 145.25) (xy 117.724 145.25) (xy 117.656961 145.230315) (xy 117.611206 145.177511) (xy 117.6 145.126) (xy 117.6 144.9) (xy 116.680742 144.9) (xy 116.685619 144.933479) (xy 116.691516 144.945542) (xy 116.696764 144.976289) (xy 116.703936 145.006637) (xy 116.702734 145.011262) (xy 116.703273 145.014415) (xy 116.697051 145.041253) (xy 116.679824 145.090085) (xy 116.666174 145.109013) (xy 116.65644 145.130218) (xy 116.646122 145.136819) (xy 116.638957 145.146757) (xy 116.617241 145.1553) (xy 116.597588 145.167877) (xy 116.581977 145.169175) (xy 116.573939 145.172338) (xy 116.565096 145.170579) (xy 116.548327 145.171974) (xy 116.525846 145.169316) (xy 116.508304 145.165947) (xy 116.493971 145.162105) (xy 116.493964 145.162104) (xy 116.4721 145.162101) (xy 116.4721 145.1621) (xy 116.464798 145.162099) (xy 116.435856 145.158679) (xy 116.412311 145.162095) (xy 116.40335 145.162095) (xy 116.388514 145.162093) (xy 116.367388 145.167751) (xy 116.353127 145.170685) (xy 116.337661 145.17293) (xy 116.268489 145.16308) (xy 116.257849 145.157604) (xy 116.127284 145.082223) (xy 115.974557 145.0413) (xy 115.816443 145.0413) (xy 115.663716 145.082223) (xy 115.663709 145.082226) (xy 115.52679 145.161275) (xy 115.526782 145.161281) (xy 115.414981 145.273082) (xy 115.414975 145.27309) (xy 115.335926 145.410009) (xy 115.335923 145.410016) (xy 115.295 145.562743) (xy 115.295 145.720857) (xy 115.296785 145.727516) (xy 115.335923 145.873583) (xy 115.335926 145.87359) (xy 115.414975 146.010509) (xy 115.414979 146.010514) (xy 115.41498 146.010516) (xy 115.526784 146.12232) (xy 115.526786 146.122321) (xy 115.52679 146.122324) (xy 115.645886 146.191083) (xy 115.663716 146.201377) (xy 115.816443 146.2423) (xy 115.816445 146.2423) (xy 115.974555 146.2423) (xy 115.974557 146.2423) (xy 116.127284 146.201377) (xy 116.264216 146.12232) (xy 116.264219 146.122316) (xy 116.270666 146.117371) (xy 116.27133 146.118237) (xy 116.275042 146.113281) (xy 116.299787 146.104054) (xy 116.322965 146.091394) (xy 116.332011 146.092039) (xy 116.340509 146.088871) (xy 116.366313 146.094487) (xy 116.392657 146.096367) (xy 116.401725 146.102194) (xy 116.40878 146.10373) (xy 116.437032 146.124884) (xy 116.591515 146.279399) (xy 116.599416 146.288286) (xy 116.635484 146.323394) (xy 116.636685 146.324578) (xy 116.645717 146.333612) (xy 116.679195 146.394939) (xy 116.68073 146.403404) (xy 116.681208 146.406682) (xy 116.685134 146.433625) (xy 116.690957 146.445536) (xy 116.69096 146.445542) (xy 116.702717 146.514416) (xy 116.69096 146.554456) (xy 116.685134 146.566375) (xy 116.6745 146.639364) (xy 116.6745 146.860636) (xy 116.682475 146.915377) (xy 116.685134 146.933627) (xy 116.691237 146.94611) (xy 116.702995 147.014983) (xy 116.691237 147.055028) (xy 116.685619 147.066518) (xy 116.685619 147.066519) (xy 116.680741 147.099999) (xy 116.680742 147.1) (xy 116.7426 147.1) (xy 116.809639 147.119685) (xy 116.81084 147.120466) (xy 116.821368 147.127405) (xy 116.828789 147.134826) (xy 116.843647 147.14209) (xy 116.850287 147.146466) (xy 116.86793 147.167308) (xy 116.88809 147.185728) (xy 116.890174 147.193588) (xy 116.895429 147.199795) (xy 116.899002 147.226868) (xy 116.906004 147.253262) (xy 116.903508 147.261001) (xy 116.904573 147.269064) (xy 116.892943 147.293768) (xy 116.884563 147.319761) (xy 116.878052 147.325402) (xy 116.874815 147.33228) (xy 116.857847 147.342909) (xy 116.836508 147.3614) (xy 116.828788 147.365174) (xy 116.820425 147.371145) (xy 116.819355 147.369646) (xy 116.768958 147.397166) (xy 116.7426 147.4) (xy 116.680742 147.4) (xy 116.685619 147.43348) (xy 116.691236 147.444969) (xy 116.702996 147.513842) (xy 116.691239 147.553885) (xy 116.685135 147.566371) (xy 116.685134 147.566374) (xy 116.685134 147.566375) (xy 116.6745 147.639364) (xy 116.6745 147.860636) (xy 116.679352 147.893939) (xy 116.685134 147.933625) (xy 116.69096 147.945542) (xy 116.702717 148.014416) (xy 116.69096 148.054458) (xy 116.685135 148.066373) (xy 116.685134 148.066375) (xy 116.6745 148.139364) (xy 116.6745 148.360636) (xy 116.680235 148.4) (xy 116.685134 148.433625) (xy 116.69096 148.445542) (xy 116.702717 148.514416) (xy 116.69096 148.554458) (xy 116.687388 148.561765) (xy 116.685134 148.566375) (xy 116.6745 148.639364) (xy 116.6745 148.860636) (xy 116.681215 148.906723) (xy 116.685134 148.933625) (xy 116.69096 148.945542) (xy 116.702717 149.014416) (xy 116.69096 149.054456) (xy 116.685134 149.066375) (xy 116.6745 149.139364) (xy 116.6745 149.360636) (xy 116.682475 149.415377) (xy 116.685134 149.433627) (xy 116.691237 149.44611) (xy 116.702995 149.514983) (xy 116.691237 149.555028) (xy 116.685619 149.566518) (xy 116.685619 149.566519) (xy 116.680741 149.599999) (xy 116.680742 149.6) (xy 116.7426 149.6) (xy 116.809639 149.619685) (xy 116.81084 149.620466) (xy 116.821368 149.627405) (xy 116.828789 149.634826) (xy 116.843647 149.64209) (xy 116.850287 149.646466) (xy 116.86793 149.667308) (xy 116.88809 149.685728) (xy 116.890174 149.693588) (xy 116.895429 149.699795) (xy 116.899002 149.726868) (xy 116.906004 149.753262) (xy 116.903508 149.761001) (xy 116.904573 149.769064) (xy 116.892943 149.793768) (xy 116.884563 149.819761) (xy 116.878052 149.825402) (xy 116.874815 149.83228) (xy 116.857847 149.842909) (xy 116.836508 149.8614) (xy 116.828788 149.865174) (xy 116.820425 149.871145) (xy 116.819355 149.869646) (xy 116.768958 149.897166) (xy 116.7426 149.9) (xy 116.680742 149.9) (xy 116.685619 149.93348) (xy 116.691236 149.944969) (xy 116.702996 150.013842) (xy 116.691239 150.053885) (xy 116.685135 150.066371) (xy 116.685134 150.066374) (xy 116.685134 150.066375) (xy 116.6745 150.139364) (xy 116.6745 150.360636) (xy 116.685134 150.433625) (xy 116.69096 150.445542) (xy 116.702717 150.514416) (xy 116.69096 150.554456) (xy 116.685134 150.566375) (xy 116.6745 150.639364) (xy 116.6745 150.860636) (xy 116.680988 150.905166) (xy 116.685134 150.933625) (xy 116.69096 150.945542) (xy 116.702717 151.014416) (xy 116.69096 151.054456) (xy 116.685134 151.066375) (xy 116.6745 151.139364) (xy 116.6745 151.360636) (xy 116.681389 151.407917) (xy 116.685134 151.433625) (xy 116.69096 151.445542) (xy 116.702717 151.514416) (xy 116.69096 151.554456) (xy 116.685134 151.566375) (xy 116.6745 151.639364) (xy 116.6745 151.860636) (xy 116.682475 151.915377) (xy 116.685134 151.933627) (xy 116.691237 151.94611) (xy 116.702995 152.014983) (xy 116.691237 152.055028) (xy 116.685619 152.066518) (xy 116.685619 152.066519) (xy 116.680741 152.099999) (xy 116.680742 152.1) (xy 116.7426 152.1) (xy 116.809639 152.119685) (xy 116.81084 152.120466) (xy 116.821368 152.127405) (xy 116.828789 152.134826) (xy 116.843647 152.14209) (xy 116.850287 152.146466) (xy 116.86793 152.167308) (xy 116.88809 152.185728) (xy 116.890174 152.193588) (xy 116.895429 152.199795) (xy 116.899002 152.226868) (xy 116.906004 152.253262) (xy 116.903508 152.261001) (xy 116.904573 152.269064) (xy 116.892943 152.293768) (xy 116.884563 152.319761) (xy 116.878052 152.325402) (xy 116.874815 152.33228) (xy 116.857847 152.342909) (xy 116.836508 152.3614) (xy 116.828788 152.365174) (xy 116.820425 152.371145) (xy 116.819355 152.369646) (xy 116.768958 152.397166) (xy 116.7426 152.4) (xy 116.680742 152.4) (xy 116.685619 152.43348) (xy 116.691236 152.444969) (xy 116.702996 152.513842) (xy 116.691239 152.553885) (xy 116.685135 152.566371) (xy 116.685134 152.566374) (xy 116.684088 152.573555) (xy 116.6745 152.639364) (xy 116.6745 152.860636) (xy 116.675672 152.868677) (xy 116.685134 152.933625) (xy 116.69096 152.945542) (xy 116.702717 153.014416) (xy 116.69096 153.054456) (xy 116.685134 153.066375) (xy 116.6745 153.139364) (xy 116.6745 153.360636) (xy 116.682886 153.418192) (xy 116.685134 153.433625) (xy 116.69096 153.445542) (xy 116.702717 153.514416) (xy 116.69096 153.554456) (xy 116.685134 153.566375) (xy 116.6745 153.639364) (xy 116.6745 153.860636) (xy 116.681812 153.910821) (xy 116.685134 153.933625) (xy 116.69096 153.945542) (xy 116.702717 154.014416) (xy 116.69096 154.054458) (xy 116.685319 154.065997) (xy 116.685134 154.066375) (xy 116.6745 154.139364) (xy 116.6745 154.360636) (xy 116.681604 154.409395) (xy 116.685134 154.433625) (xy 116.69096 154.445542) (xy 116.702717 154.514416) (xy 116.69096 154.554456) (xy 116.685134 154.566375) (xy 116.6745 154.639364) (xy 116.6745 154.860636) (xy 116.684752 154.931) (xy 116.685134 154.933625) (xy 116.69096 154.945542) (xy 116.702717 155.014416) (xy 116.69096 155.054456) (xy 116.685134 155.066375) (xy 116.6745 155.139364) (xy 116.6745 155.360636) (xy 116.675978 155.370778) (xy 116.685134 155.433625) (xy 116.69096 155.445542) (xy 116.702717 155.514416) (xy 116.69096 155.554456) (xy 116.685134 155.566375) (xy 116.6745 155.639364) (xy 116.6745 155.860636) (xy 116.685134 155.933625) (xy 116.69096 155.945542) (xy 116.702717 156.014416) (xy 116.69096 156.054456) (xy 116.685134 156.066375) (xy 116.6745 156.139364) (xy 116.6745 156.360636) (xy 116.682475 156.415377) (xy 116.685134 156.433627) (xy 116.691237 156.44611) (xy 116.702995 156.514983) (xy 116.691237 156.555028) (xy 116.685619 156.566518) (xy 116.685619 156.566519) (xy 116.680741 156.599999) (xy 116.680742 156.6) (xy 116.7426 156.6) (xy 116.803299 156.615872) (xy 116.818199 156.624236) (xy 116.828789 156.634826) (xy 116.892857 156.666147) (xy 116.89593 156.667872) (xy 116.917983 156.690448) (xy 116.941274 156.711728) (xy 116.942207 156.715248) (xy 116.944753 156.717854) (xy 116.951098 156.748766) (xy 116.959188 156.779262) (xy 116.95807 156.782727) (xy 116.958803 156.786296) (xy 116.947428 156.815733) (xy 116.937747 156.84576) (xy 116.934933 156.848071) (xy 116.93362 156.85147) (xy 116.908134 156.870085) (xy 116.883758 156.89011) (xy 116.879544 156.890968) (xy 116.877199 156.892682) (xy 116.868624 156.893194) (xy 116.835231 156.9) (xy 116.680742 156.9) (xy 116.685619 156.933479) (xy 116.740587 157.045918) (xy 116.829081 157.134412) (xy 116.941517 157.189379) (xy 117.014418 157.2) (xy 117.6 157.2) (xy 117.6 156.890935) (xy 117.587068 156.876011) (xy 117.585151 156.862679) (xy 117.578696 156.850858) (xy 117.580275 156.828771) (xy 117.577124 156.806853) (xy 117.582719 156.794601) (xy 117.58368 156.781166) (xy 117.59695 156.763439) (xy 117.606149 156.743297) (xy 117.61748 156.736014) (xy 117.625552 156.725233) (xy 117.646297 156.717495) (xy 117.664927 156.705523) (xy 117.686845 156.702371) (xy 117.691016 156.700816) (xy 117.699862 156.7005) (xy 117.800138 156.7005) (xy 117.867177 156.720185) (xy 117.912932 156.772989) (xy 117.922876 156.842147) (xy 117.9 156.892238) (xy 117.9 157.2) (xy 118.485582 157.2) (xy 118.558482 157.189379) (xy 118.670918 157.134412) (xy 118.759412 157.045918) (xy 118.81438 156.933479) (xy 118.819258 156.9) (xy 118.664769 156.9) (xy 118.661099 156.898922) (xy 118.657374 156.899779) (xy 118.627838 156.889155) (xy 118.59773 156.880315) (xy 118.595227 156.877426) (xy 118.591628 156.876132) (xy 118.572523 156.851224) (xy 118.551975 156.827511) (xy 118.55143 156.823726) (xy 118.549104 156.820693) (xy 118.546498 156.78942) (xy 118.542031 156.758353) (xy 118.543619 156.754874) (xy 118.543302 156.751065) (xy 118.558018 156.723345) (xy 118.571056 156.694797) (xy 118.574792 156.691749) (xy 118.576065 156.689353) (xy 118.59072 156.678759) (xy 118.60407 156.667872) (xy 118.607142 156.666147) (xy 118.671211 156.634826) (xy 118.6818 156.624236) (xy 118.696701 156.615872) (xy 118.71477 156.611718) (xy 118.731042 156.602834) (xy 118.7574 156.6) (xy 118.819258 156.6) (xy 118.819258 156.599999) (xy 118.81438 156.56652) (xy 118.808765 156.555035) (xy 118.797003 156.486162) (xy 118.808763 156.446107) (xy 118.814866 156.433625) (xy 118.8255 156.360636) (xy 118.8255 156.139364) (xy 118.814866 156.066375) (xy 118.809041 156.05446) (xy 118.797281 155.985592) (xy 118.80904 155.945541) (xy 118.814866 155.933625) (xy 118.8255 155.860636) (xy 118.8255 155.639364) (xy 118.814866 155.566375) (xy 118.809041 155.55446) (xy 118.797281 155.485592) (xy 118.80904 155.445541) (xy 118.814866 155.433625) (xy 118.8255 155.360636) (xy 118.8255 155.139364) (xy 118.814866 155.066375) (xy 118.809041 155.05446) (xy 118.797281 154.985592) (xy 118.80904 154.945541) (xy 118.814866 154.933625) (xy 118.8255 154.860636) (xy 118.8255 154.639364) (xy 118.814866 154.566375) (xy 118.809041 154.55446) (xy 118.797281 154.485592) (xy 118.80904 154.445541) (xy 118.814866 154.433625) (xy 118.8255 154.360636) (xy 118.8255 154.139364) (xy 118.814866 154.066375) (xy 118.809041 154.05446) (xy 118.797281 153.985592) (xy 118.80904 153.945541) (xy 118.814866 153.933625) (xy 118.8255 153.860636) (xy 118.8255 153.639364) (xy 118.814866 153.566375) (xy 118.809041 153.55446) (xy 118.797281 153.485592) (xy 118.800654 153.467953) (xy 118.80376 153.456341) (xy 118.814866 153.433625) (xy 118.820878 153.392354) (xy 118.822752 153.385353) (xy 118.837306 153.361453) (xy 118.848979 153.336021) (xy 118.855231 153.332019) (xy 118.859093 153.325679) (xy 118.884256 153.313443) (xy 118.907828 153.298357) (xy 118.91838 153.29685) (xy 118.921928 153.295125) (xy 118.926578 153.295679) (xy 118.942539 153.2934) (xy 120.465939 153.2934) (xy 120.532978 153.313085) (xy 120.554778 153.330893) (xy 125.00422 157.900556) (xy 129.218567 162.228773) (xy 129.226202 162.237596) (xy 129.26193 162.273323) (xy 129.263092 162.2745) (xy 129.297437 162.309773) (xy 129.300175 162.311932) (xy 129.300233 162.311977) (xy 129.301481 162.312961) (xy 129.301686 162.313079) (xy 129.301687 162.31308) (xy 129.345051 162.338116) (xy 129.388052 162.363713) (xy 129.390654 162.364446) (xy 129.393005 162.365804) (xy 129.39301 162.365805) (xy 129.393013 162.365807) (xy 129.441367 162.378763) (xy 129.48954 162.392362) (xy 129.492253 162.392398) (xy 129.494873 162.3931) (xy 129.544059 162.3931) (xy 129.545711 162.39311) (xy 129.594984 162.393768) (xy 129.594985 162.393767) (xy 129.596286 162.393785) (xy 129.607936 162.3931) (xy 138.083495 162.3931) (xy 138.150534 162.412785) (xy 138.196289 162.465589) (xy 138.206611 162.502316) (xy 138.210122 162.531562) (xy 138.265639 162.672343) (xy 138.357077 162.792922) (xy 138.477656 162.88436) (xy 138.477657 162.88436) (xy 138.477658 162.884361) (xy 138.618436 162.939877) (xy 138.706898 162.9505) (xy 138.706903 162.9505) (xy 139.293097 162.9505) (xy 139.293102 162.9505) (xy 139.381564 162.939877) (xy 139.522342 162.884361) (xy 139.638376 162.796369) (xy 139.703686 162.771547) (xy 139.77205 162.785975) (xy 139.821761 162.835072) (xy 139.8373 162.895174) (xy 139.8373 164.452699) (xy 139.817615 164.519738) (xy 139.808852 164.53173) (xy 137.970382 166.754531) (xy 137.912486 166.793644) (xy 137.87483 166.7995) (xy 136.515143 166.7995) (xy 136.515117 166.799502) (xy 136.490012 166.802413) (xy 136.490008 166.802415) (xy 136.387235 166.847793) (xy 136.307794 166.927234) (xy 136.262415 167.030006) (xy 136.262415 167.030008) (xy 136.2595 167.055131) (xy 136.2595 168.944856) (xy 136.259502 168.944882) (xy 136.262413 168.969987) (xy 136.262415 168.969991) (xy 136.307793 169.072764) (xy 136.307794 169.072765) (xy 136.387235 169.152206) (xy 136.490009 169.197585) (xy 136.515135 169.2005) (xy 138.404864 169.200499) (xy 138.404879 169.200497) (xy 138.404882 169.200497) (xy 138.429987 169.197586) (xy 138.429988 169.197585) (xy 138.429991 169.197585) (xy 138.532765 169.152206) (xy 138.612206 169.072765) (xy 138.657585 168.969991) (xy 138.6605 168.944865) (xy 138.660499 168.530805) (xy 138.680183 168.463769) (xy 138.732987 168.418014) (xy 138.802146 168.40807) (xy 138.865702 168.437095) (xy 138.894983 168.474513) (xy 138.973666 168.628935) (xy 138.973667 168.628936) (xy 139.084685 168.781741) (xy 139.084689 168.781746) (xy 139.218253 168.91531) (xy 139.218258 168.915314) (xy 139.371059 169.026329) (xy 139.539362 169.112085) (xy 139.718996 169.170451) (xy 139.8 169.183281) (xy 139.8 168.461879) (xy 139.807007 168.465925) (xy 139.934174 168.5) (xy 140.065826 168.5) (xy 140.192993 168.465925) (xy 140.2 168.461879) (xy 140.2 169.18328) (xy 140.281001 169.170451) (xy 140.281004 169.170451) (xy 140.460637 169.112085) (xy 140.62894 169.026329) (xy 140.781741 168.915314) (xy 140.781746 168.91531) (xy 140.91531 168.781746) (xy 140.915314 168.781741) (xy 141.026329 168.62894) (xy 141.112086 168.460635) (xy 141.151806 168.338389) (xy 141.191243 168.280713) (xy 141.255601 168.253514) (xy 141.324448 168.265428) (xy 141.375924 168.312672) (xy 141.387668 168.338387) (xy 141.427454 168.460836) (xy 141.44741 168.5) (xy 141.486485 168.57669) (xy 141.5 168.632983) (xy 141.5 169.376) (xy 141.480315 169.443039) (xy 141.427511 169.488794) (xy 141.376 169.5) (xy 112.995165 169.5) (xy 112.928126 169.480315) (xy 112.882371 169.427511) (xy 112.872427 169.358353) (xy 112.881297 169.326907) (xy 113.846734 167.087619) (xy 113.846742 167.087601) (xy 113.846764 167.087547) (xy 113.860854 167.055131) (xy 120.2595 167.055131) (xy 120.2595 168.944856) (xy 120.259502 168.944882) (xy 120.262413 168.969987) (xy 120.262415 168.969991) (xy 120.307793 169.072764) (xy 120.307794 169.072765) (xy 120.387235 169.152206) (xy 120.490009 169.197585) (xy 120.515135 169.2005) (xy 122.404864 169.200499) (xy 122.404879 169.200497) (xy 122.404882 169.200497) (xy 122.429987 169.197586) (xy 122.429988 169.197585) (xy 122.429991 169.197585) (xy 122.532765 169.152206) (xy 122.612206 169.072765) (xy 122.657585 168.969991) (xy 122.6605 168.944865) (xy 122.660499 168.530805) (xy 122.680183 168.463769) (xy 122.732987 168.418014) (xy 122.802146 168.40807) (xy 122.865702 168.437095) (xy 122.894983 168.474513) (xy 122.973666 168.628935) (xy 122.973667 168.628936) (xy 123.084685 168.781741) (xy 123.084689 168.781746) (xy 123.218253 168.91531) (xy 123.218258 168.915314) (xy 123.371059 169.026329) (xy 123.539362 169.112085) (xy 123.718996 169.170451) (xy 123.8 169.183281) (xy 123.8 168.461879) (xy 123.807007 168.465925) (xy 123.934174 168.5) (xy 124.065826 168.5) (xy 124.192993 168.465925) (xy 124.2 168.461879) (xy 124.2 169.18328) (xy 124.281001 169.170451) (xy 124.281004 169.170451) (xy 124.460637 169.112085) (xy 124.62894 169.026329) (xy 124.781741 168.915314) (xy 124.781746 168.91531) (xy 124.91531 168.781746) (xy 124.915314 168.781741) (xy 125.026329 168.62894) (xy 125.112086 168.460635) (xy 125.151806 168.338389) (xy 125.191243 168.280713) (xy 125.255601 168.253514) (xy 125.324448 168.265428) (xy 125.375924 168.312672) (xy 125.387668 168.338387) (xy 125.427454 168.460836) (xy 125.463107 168.530808) (xy 125.51324 168.629199) (xy 125.62431 168.782073) (xy 125.757927 168.91569) (xy 125.910801 169.02676) (xy 125.990347 169.06729) (xy 126.079163 169.112545) (xy 126.079165 169.112545) (xy 126.079168 169.112547) (xy 126.175497 169.143846) (xy 126.258881 169.17094) (xy 126.445514 169.2005) (xy 126.445519 169.2005) (xy 126.634486 169.2005) (xy 126.821118 169.17094) (xy 126.822623 169.170451) (xy 127.000832 169.112547) (xy 127.169199 169.02676) (xy 127.322073 168.91569) (xy 127.45569 168.782073) (xy 127.56676 168.629199) (xy 127.652547 168.460832) (xy 127.71094 168.281118) (xy 127.715312 168.253514) (xy 127.7405 168.094486) (xy 127.7405 167.905513) (xy 127.71094 167.718881) (xy 127.67228 167.599901) (xy 127.652547 167.539168) (xy 127.652545 167.539165) (xy 127.652545 167.539163) (xy 127.575736 167.388418) (xy 127.56676 167.370801) (xy 127.45569 167.217927) (xy 127.322073 167.08431) (xy 127.169199 166.97324) (xy 127.163476 166.970324) (xy 127.000836 166.887454) (xy 126.821118 166.829059) (xy 126.634486 166.7995) (xy 126.634481 166.7995) (xy 126.445519 166.7995) (xy 126.445514 166.7995) (xy 126.258881 166.829059) (xy 126.079163 166.887454) (xy 125.9108 166.97324) (xy 125.827716 167.033605) (xy 125.757927 167.08431) (xy 125.757925 167.084312) (xy 125.757924 167.084312) (xy 125.624312 167.217924) (xy 125.624312 167.217925) (xy 125.62431 167.217927) (xy 125.618261 167.226253) (xy 125.51324 167.3708) (xy 125.427454 167.539163) (xy 125.387668 167.661612) (xy 125.34823 167.719287) (xy 125.283871 167.746485) (xy 125.215025 167.73457) (xy 125.163549 167.687325) (xy 125.151806 167.661611) (xy 125.112085 167.539362) (xy 125.026329 167.371059) (xy 124.915314 167.218258) (xy 124.91531 167.218253) (xy 124.781746 167.084689) (xy 124.781741 167.084685) (xy 124.62894 166.97367) (xy 124.460635 166.887913) (xy 124.280999 166.829547) (xy 124.2 166.816718) (xy 124.2 167.53812) (xy 124.192993 167.534075) (xy 124.065826 167.5) (xy 123.934174 167.5) (xy 123.807007 167.534075) (xy 123.8 167.53812) (xy 123.8 166.816718) (xy 123.799999 166.816718) (xy 123.719 166.829547) (xy 123.539364 166.887913) (xy 123.371059 166.97367) (xy 123.218258 167.084685) (xy 123.218253 167.084689) (xy 123.084689 167.218253) (xy 123.084685 167.218258) (xy 122.973667 167.371063) (xy 122.973666 167.371064) (xy 122.894983 167.525487) (xy 122.847009 167.576283) (xy 122.779188 167.593078) (xy 122.713053 167.57054) (xy 122.669602 167.515825) (xy 122.660499 167.469192) (xy 122.660499 167.226253) (xy 122.680184 167.159214) (xy 122.689111 167.147024) (xy 122.692845 167.142529) (xy 124.51817 164.944922) (xy 124.54238 164.920713) (xy 124.551729 164.904518) (xy 124.563676 164.890136) (xy 124.575592 164.864243) (xy 124.58085 164.85408) (xy 124.595105 164.82939) (xy 124.595104 164.82939) (xy 124.595107 164.829387) (xy 124.599946 164.811324) (xy 124.607763 164.794341) (xy 124.613538 164.760597) (xy 124.6224 164.727527) (xy 124.6224 164.708829) (xy 124.625555 164.690398) (xy 124.6224 164.656304) (xy 124.6224 163.0745) (xy 124.642085 163.007461) (xy 124.694889 162.961706) (xy 124.7464 162.9505) (xy 125.293097 162.9505) (xy 125.293102 162.9505) (xy 125.381564 162.939877) (xy 125.522342 162.884361) (xy 125.642922 162.792922) (xy 125.734361 162.672342) (xy 125.789877 162.531564) (xy 125.8005 162.443102) (xy 125.8005 161.556898) (xy 125.789877 161.468436) (xy 125.734361 161.327658) (xy 125.73436 161.327657) (xy 125.73436 161.327656) (xy 125.642922 161.207077) (xy 125.522343 161.115639) (xy 125.381561 161.060122) (xy 125.335926 161.054642) (xy 125.293102 161.0495) (xy 124.706898 161.0495) (xy 124.667853 161.054188) (xy 124.618438 161.060122) (xy 124.477656 161.115639) (xy 124.357077 161.207077) (xy 124.265639 161.327656) (xy 124.210122 161.468438) (xy 124.204666 161.513876) (xy 124.1995 161.556898) (xy 124.1995 161.556903) (xy 124.1995 162.071833) (xy 124.198861 162.074007) (xy 124.199423 162.076204) (xy 124.189061 162.10738) (xy 124.179815 162.138872) (xy 124.17788 162.141027) (xy 124.177388 162.142508) (xy 124.153349 162.16835) (xy 124.002349 162.290144) (xy 123.93781 162.316911) (xy 123.869045 162.304536) (xy 123.817886 162.256948) (xy 123.8005 162.193627) (xy 123.8005 161.556903) (xy 123.8005 161.556898) (xy 123.789877 161.468436) (xy 123.734361 161.327658) (xy 123.73436 161.327657) (xy 123.73436 161.327656) (xy 123.642922 161.207077) (xy 123.522343 161.115639) (xy 123.381561 161.060122) (xy 123.335926 161.054642) (xy 123.293102 161.0495) (xy 122.706898 161.0495) (xy 122.667853 161.054188) (xy 122.618438 161.060122) (xy 122.477656 161.115639) (xy 122.357077 161.207077) (xy 122.265639 161.327656) (xy 122.210122 161.468438) (xy 122.204666 161.513876) (xy 122.1995 161.556898) (xy 122.1995 162.443102) (xy 122.203092 162.473013) (xy 122.210122 162.531561) (xy 122.265639 162.672343) (xy 122.357077 162.792922) (xy 122.477656 162.88436) (xy 122.477657 162.88436) (xy 122.477658 162.884361) (xy 122.618436 162.939877) (xy 122.706898 162.9505) (xy 122.706903 162.9505) (xy 123.293097 162.9505) (xy 123.293102 162.9505) (xy 123.381564 162.939877) (xy 123.522342 162.884361) (xy 123.622474 162.808427) (xy 123.687785 162.783604) (xy 123.756149 162.798032) (xy 123.805861 162.847129) (xy 123.8214 162.907231) (xy 123.8214 164.485383) (xy 123.801715 164.552422) (xy 123.792788 164.564612) (xy 121.973684 166.754729) (xy 121.915707 166.793722) (xy 121.878296 166.7995) (xy 120.515143 166.7995) (xy 120.515117 166.799502) (xy 120.490012 166.802413) (xy 120.490008 166.802415) (xy 120.387235 166.847793) (xy 120.307794 166.927234) (xy 120.262415 167.030006) (xy 120.262415 167.030008) (xy 120.2595 167.055131) (xy 113.860854 167.055131) (xy 113.867524 167.039787) (xy 113.867606 167.039227) (xy 113.867833 167.038703) (xy 113.867849 167.038647) (xy 113.868586 167.033609) (xy 113.875414 166.986938) (xy 114.777623 160.943934) (xy 114.781803 160.932482) (xy 114.785386 160.891933) (xy 114.791395 160.85169) (xy 114.791394 160.851686) (xy 114.791395 160.851683) (xy 114.791416 160.850463) (xy 114.791139 160.828654) (xy 114.791087 160.827438) (xy 114.791087 160.827437) (xy 114.784054 160.787346) (xy 114.779442 160.746916) (xy 114.774972 160.735575) (xy 114.772867 160.72357) (xy 114.757274 160.690054) (xy 114.75434 160.683218) (xy 114.740779 160.648806) (xy 114.740779 160.648805) (xy 114.740776 160.648802) (xy 114.740188 160.647739) (xy 114.728232 160.627629) (xy 112.200431 155.194173) (xy 112.195807 155.176913) (xy 112.178272 155.146541) (xy 112.163485 155.114757) (xy 112.158947 155.109339) (xy 112.146615 155.091711) (xy 112.143079 155.085586) (xy 112.133392 155.075899) (xy 112.118283 155.06079) (xy 112.095773 155.033915) (xy 112.081148 155.023655) (xy 112.068513 155.01102) (xy 112.068512 155.011019) (xy 112.042883 154.996223) (xy 112.042882 154.996222) (xy 112.038143 154.993486) (xy 112.009444 154.973352) (xy 111.992659 154.967226) (xy 111.98331 154.961828) (xy 111.983309 154.961827) (xy 111.983308 154.961827) (xy 111.977187 154.958293) (xy 111.977183 154.958291) (xy 111.948595 154.95063) (xy 111.948595 154.950631) (xy 111.943311 154.949215) (xy 111.910382 154.937197) (xy 111.89259 154.935624) (xy 111.882165 154.932831) (xy 111.88216 154.932831) (xy 111.875327 154.931) (xy 111.875326 154.931) (xy 111.845739 154.931) (xy 111.834824 154.930519) (xy 111.805339 154.927913) (xy 111.805331 154.927913) (xy 111.79837 154.929135) (xy 111.776947 154.931) (xy 111.4495 154.931) (xy 111.382461 154.911315) (xy 111.336706 154.858511) (xy 111.3255 154.807) (xy 111.3255 154.639369) (xy 111.3255 154.639364) (xy 111.314866 154.566375) (xy 111.309041 154.55446) (xy 111.297281 154.485592) (xy 111.30904 154.445541) (xy 111.314866 154.433625) (xy 111.3255 154.360636) (xy 111.3255 154.139364) (xy 111.314866 154.066375) (xy 111.309041 154.05446) (xy 111.297281 153.985592) (xy 111.30904 153.945541) (xy 111.314866 153.933625) (xy 111.3255 153.860636) (xy 111.3255 153.639364) (xy 111.314866 153.566375) (xy 111.309041 153.55446) (xy 111.297281 153.485592) (xy 111.30904 153.445541) (xy 111.314866 153.433625) (xy 111.3255 153.360636) (xy 111.3255 153.139364) (xy 111.314866 153.066375) (xy 111.309041 153.05446) (xy 111.297281 152.985592) (xy 111.30904 152.945541) (xy 111.314866 152.933625) (xy 111.3255 152.860636) (xy 111.3255 152.639364) (xy 111.314866 152.566375) (xy 111.309041 152.55446) (xy 111.297281 152.485592) (xy 111.30904 152.445541) (xy 111.314866 152.433625) (xy 111.3255 152.360636) (xy 111.3255 152.139364) (xy 111.314866 152.066375) (xy 111.309041 152.05446) (xy 111.297281 151.985592) (xy 111.30904 151.945541) (xy 111.314866 151.933625) (xy 111.3255 151.860636) (xy 111.3255 151.639364) (xy 111.314866 151.566375) (xy 111.309041 151.55446) (xy 111.297281 151.485592) (xy 111.30904 151.445541) (xy 111.314866 151.433625) (xy 111.3255 151.360636) (xy 111.3255 151.139364) (xy 111.314866 151.066375) (xy 111.309041 151.05446) (xy 111.297281 150.985592) (xy 111.30904 150.945541) (xy 111.314866 150.933625) (xy 111.3255 150.860636) (xy 111.3255 150.639364) (xy 111.314866 150.566375) (xy 111.309041 150.55446) (xy 111.297281 150.485592) (xy 111.30904 150.445541) (xy 111.314866 150.433625) (xy 111.3255 150.360636) (xy 111.3255 150.139364) (xy 111.314866 150.066375) (xy 111.309041 150.05446) (xy 111.297281 149.985592) (xy 111.30904 149.945541) (xy 111.314866 149.933625) (xy 111.3255 149.860636) (xy 111.3255 149.639364) (xy 111.314866 149.566375) (xy 111.309041 149.55446) (xy 111.297281 149.485592) (xy 111.30904 149.445541) (xy 111.314866 149.433625) (xy 111.3255 149.360636) (xy 111.3255 149.139364) (xy 111.314866 149.066375) (xy 111.309041 149.05446) (xy 111.297281 148.985592) (xy 111.30904 148.945541) (xy 111.314866 148.933625) (xy 111.3255 148.860636) (xy 111.3255 148.639364) (xy 111.314866 148.566375) (xy 111.309041 148.55446) (xy 111.297281 148.485592) (xy 111.30904 148.445541) (xy 111.314866 148.433625) (xy 111.3255 148.360636) (xy 111.3255 148.139364) (xy 111.314866 148.066375) (xy 111.309041 148.05446) (xy 111.297281 147.985592) (xy 111.30904 147.945541) (xy 111.314866 147.933625) (xy 111.3255 147.860636) (xy 111.3255 147.639364) (xy 111.314866 147.566375) (xy 111.309041 147.55446) (xy 111.297281 147.485592) (xy 111.30904 147.445541) (xy 111.314866 147.433625) (xy 111.3255 147.360636) (xy 111.3255 147.139364) (xy 111.314866 147.066375) (xy 111.309041 147.05446) (xy 111.297281 146.985592) (xy 111.297476 146.984009) (xy 111.3001 146.963828) (xy 111.314866 146.933625) (xy 111.3255 146.860636) (xy 111.3255 146.780131) (xy 111.8945 146.780131) (xy 111.8945 153.219856) (xy 111.894502 153.219882) (xy 111.897413 153.244987) (xy 111.897415 153.244991) (xy 111.942793 153.347764) (xy 111.942794 153.347765) (xy 112.022235 153.427206) (xy 112.125009 153.472585) (xy 112.150135 153.4755) (xy 115.849864 153.475499) (xy 115.849879 153.475497) (xy 115.849882 153.475497) (xy 115.874987 153.472586) (xy 115.874988 153.472585) (xy 115.874991 153.472585) (xy 115.977765 153.427206) (xy 116.057206 153.347765) (xy 116.102585 153.244991) (xy 116.1055 153.219865) (xy 116.105499 146.780136) (xy 116.104152 146.768521) (xy 116.102586 146.755012) (xy 116.102585 146.75501) (xy 116.102585 146.755009) (xy 116.057206 146.652235) (xy 115.977765 146.572794) (xy 115.963225 146.566374) (xy 115.874992 146.527415) (xy 115.849865 146.5245) (xy 112.150143 146.5245) (xy 112.150117 146.524502) (xy 112.125012 146.527413) (xy 112.125008 146.527415) (xy 112.022235 146.572793) (xy 111.942794 146.652234) (xy 111.897415 146.755006) (xy 111.897415 146.755008) (xy 111.8945 146.780131) (xy 111.3255 146.780131) (xy 111.3255 146.639364) (xy 111.314866 146.566375) (xy 111.309041 146.55446) (xy 111.297281 146.485592) (xy 111.30904 146.445541) (xy 111.314866 146.433625) (xy 111.3255 146.360636) (xy 111.3255 146.139364) (xy 111.314866 146.066375) (xy 111.309041 146.05446) (xy 111.297281 145.985592) (xy 111.30904 145.945541) (xy 111.314866 145.933625) (xy 111.3255 145.860636) (xy 111.3255 145.639364) (xy 111.314866 145.566375) (xy 111.309041 145.55446) (xy 111.297281 145.485592) (xy 111.30904 145.445541) (xy 111.314866 145.433625) (xy 111.3255 145.360636) (xy 111.3255 145.139364) (xy 111.314866 145.066375) (xy 111.309041 145.05446) (xy 111.297281 144.985592) (xy 111.30904 144.945541) (xy 111.314866 144.933625) (xy 111.3255 144.860636) (xy 111.3255 144.639364) (xy 111.314866 144.566375) (xy 111.309041 144.55446) (xy 111.297281 144.485592) (xy 111.30904 144.445541) (xy 111.314866 144.433625) (xy 111.3255 144.360636) (xy 111.3255 144.139364) (xy 111.314866 144.066375) (xy 111.302265 144.0406) (xy 111.299093 144.02551) (xy 111.300669 144.005437) (xy 111.297281 143.985592) (xy 111.304036 143.962584) (xy 111.304565 143.955855) (xy 111.306924 143.952749) (xy 111.30904 143.945541) (xy 111.314866 143.933625) (xy 111.3255 143.860636) (xy 111.3255 143.639364) (xy 111.314866 143.566375) (xy 111.309041 143.55446) (xy 111.297281 143.485592) (xy 111.30904 143.445541) (xy 111.314866 143.433625) (xy 111.3255 143.360636) (xy 111.3255 143.139364) (xy 116.6745 143.139364) (xy 116.6745 143.360636) (xy 116.685134 143.433625) (xy 116.69096 143.445542) (xy 116.702717 143.514416) (xy 116.69096 143.554456) (xy 116.685134 143.566375) (xy 116.6745 143.639364) (xy 116.6745 143.860636) (xy 116.682475 143.915377) (xy 116.685134 143.933627) (xy 116.691237 143.94611) (xy 116.702995 144.014983) (xy 116.691237 144.055028) (xy 116.685619 144.066518) (xy 116.685619 144.066519) (xy 116.680741 144.099999) (xy 116.680742 144.1) (xy 116.7426 144.1) (xy 116.803299 144.115872) (xy 116.818199 144.124236) (xy 116.828789 144.134826) (xy 116.892857 144.166147) (xy 116.89593 144.167872) (xy 116.917983 144.190448) (xy 116.941274 144.211728) (xy 116.942207 144.215248) (xy 116.944753 144.217854) (xy 116.951098 144.248766) (xy 116.959188 144.279262) (xy 116.95807 144.282727) (xy 116.958803 144.286296) (xy 116.947428 144.315733) (xy 116.937747 144.34576) (xy 116.934933 144.348071) (xy 116.93362 144.35147) (xy 116.908134 144.370085) (xy 116.883758 144.39011) (xy 116.879544 144.390968) (xy 116.877199 144.392682) (xy 116.868624 144.393194) (xy 116.835231 144.4) (xy 116.680742 144.4) (xy 116.685619 144.433479) (xy 116.691516 144.445542) (xy 116.703273 144.514415) (xy 116.691516 144.554458) (xy 116.685619 144.56652) (xy 116.680741 144.599999) (xy 116.680742 144.6) (xy 117.6 144.6) (xy 117.6 144.390935) (xy 117.587068 144.376011) (xy 117.585151 144.362679) (xy 117.578696 144.350858) (xy 117.580275 144.328771) (xy 117.577124 144.306853) (xy 117.582719 144.294601) (xy 117.58368 144.281166) (xy 117.59695 144.263439) (xy 117.606149 144.243297) (xy 117.61748 144.236014) (xy 117.625552 144.225233) (xy 117.646297 144.217495) (xy 117.664927 144.205523) (xy 117.686845 144.202371) (xy 117.691016 144.200816) (xy 117.699862 144.2005) (xy 117.800138 144.2005) (xy 117.867177 144.220185) (xy 117.912932 144.272989) (xy 117.922876 144.342147) (xy 117.9 144.392238) (xy 117.9 144.6) (xy 118.819258 144.6) (xy 118.819258 144.599999) (xy 118.81438 144.56652) (xy 118.814379 144.566517) (xy 118.808487 144.554465) (xy 118.796725 144.485592) (xy 118.808487 144.445535) (xy 118.814379 144.433482) (xy 118.81438 144.433479) (xy 118.819258 144.4) (xy 118.664769 144.4) (xy 118.661099 144.398922) (xy 118.657374 144.399779) (xy 118.627838 144.389155) (xy 118.59773 144.380315) (xy 118.595227 144.377426) (xy 118.591628 144.376132) (xy 118.572523 144.351224) (xy 118.551975 144.327511) (xy 118.55143 144.323726) (xy 118.549104 144.320693) (xy 118.546498 144.28942) (xy 118.542031 144.258353) (xy 118.543619 144.254874) (xy 118.543302 144.251065) (xy 118.558018 144.223345) (xy 118.571056 144.194797) (xy 118.574792 144.191749) (xy 118.576065 144.189353) (xy 118.59072 144.178759) (xy 118.60407 144.167872) (xy 118.607142 144.166147) (xy 118.671211 144.134826) (xy 118.6818 144.124236) (xy 118.696701 144.115872) (xy 118.71477 144.111718) (xy 118.731042 144.102834) (xy 118.7574 144.1) (xy 118.819258 144.1) (xy 118.819258 144.099999) (xy 118.81438 144.06652) (xy 118.808765 144.055035) (xy 118.797003 143.986162) (xy 118.808763 143.946107) (xy 118.814866 143.933625) (xy 118.8255 143.860636) (xy 118.8255 143.639364) (xy 118.814866 143.566375) (xy 118.809041 143.55446) (xy 118.797281 143.485592) (xy 118.80904 143.445541) (xy 118.814866 143.433625) (xy 118.8255 143.360636) (xy 118.8255 143.139364) (xy 118.814866 143.066375) (xy 118.812518 143.061572) (xy 118.759827 142.953789) (xy 118.67121 142.865172) (xy 118.558628 142.810135) (xy 118.558626 142.810134) (xy 118.558625 142.810134) (xy 118.485636 142.7995) (xy 117.014364 142.7995) (xy 116.941375 142.810134) (xy 116.941373 142.810134) (xy 116.941371 142.810135) (xy 116.828789 142.865172) (xy 116.740172 142.953789) (xy 116.685135 143.066371) (xy 116.685134 143.066373) (xy 116.685134 143.066375) (xy 116.6745 143.139364) (xy 111.3255 143.139364) (xy 111.314866 143.066375) (xy 111.312518 143.061572) (xy 111.259827 142.953789) (xy 111.17121 142.865172) (xy 111.058628 142.810135) (xy 111.058626 142.810134) (xy 111.058625 142.810134) (xy 110.985636 142.7995) (xy 109.514364 142.7995) (xy 109.441375 142.810134) (xy 109.441373 142.810134) (xy 109.441371 142.810135) (xy 109.328789 142.865172) (xy 109.240172 142.953789) (xy 109.185135 143.066371) (xy 109.185134 143.066373) (xy 109.185134 143.066375) (xy 109.1745 143.139364) (xy 109.1745 143.360636) (xy 109.185134 143.433625) (xy 109.19096 143.445542) (xy 109.202717 143.514416) (xy 109.19096 143.554456) (xy 109.185134 143.566375) (xy 109.1745 143.639364) (xy 109.1745 143.860636) (xy 109.185134 143.933625) (xy 109.19096 143.945542) (xy 109.202717 144.014416) (xy 109.19096 144.054456) (xy 109.185134 144.066375) (xy 109.1745 144.139364) (xy 109.1745 144.360636) (xy 109.185134 144.433625) (xy 109.190956 144.445535) (xy 109.19096 144.445542) (xy 109.202717 144.514416) (xy 109.19096 144.554456) (xy 109.185134 144.566375) (xy 109.1745 144.639364) (xy 109.1745 144.860636) (xy 109.185134 144.933625) (xy 109.190956 144.945535) (xy 109.19096 144.945542) (xy 109.202717 145.014416) (xy 109.19096 145.054456) (xy 109.185134 145.066375) (xy 109.1745 145.139364) (xy 109.1745 145.360636) (xy 109.185112 145.433477) (xy 109.185134 145.433625) (xy 109.19096 145.445542) (xy 109.202717 145.514416) (xy 109.19096 145.554458) (xy 109.18691 145.562743) (xy 109.185134 145.566375) (xy 109.1745 145.639364) (xy 109.1745 145.860636) (xy 109.185134 145.933625) (xy 109.19096 145.945542) (xy 109.202717 146.014416) (xy 109.19096 146.054456) (xy 109.185134 146.066375) (xy 109.1745 146.139364) (xy 109.1745 146.360636) (xy 109.185133 146.43362) (xy 109.185134 146.433625) (xy 109.19096 146.445542) (xy 109.202717 146.514416) (xy 109.19096 146.554456) (xy 109.185134 146.566375) (xy 109.1745 146.639364) (xy 109.1745 146.860636) (xy 109.184567 146.92973) (xy 109.185134 146.933625) (xy 109.19096 146.945542) (xy 109.202717 147.014416) (xy 109.19096 147.054456) (xy 109.185134 147.066375) (xy 109.1745 147.139364) (xy 109.1745 147.360636) (xy 109.185113 147.43348) (xy 109.185134 147.433625) (xy 109.19096 147.445542) (xy 109.202717 147.514416) (xy 109.19096 147.554458) (xy 109.185136 147.566371) (xy 109.185134 147.566375) (xy 109.1745 147.639364) (xy 109.1745 147.860636) (xy 109.179352 147.893939) (xy 109.185134 147.933625) (xy 109.19096 147.945542) (xy 109.202717 148.014416) (xy 109.19096 148.054458) (xy 109.185135 148.066373) (xy 109.185134 148.066375) (xy 109.1745 148.139364) (xy 109.1745 148.360636) (xy 109.180235 148.4) (xy 109.185134 148.433625) (xy 109.19096 148.445542) (xy 109.202717 148.514416) (xy 109.19096 148.554458) (xy 109.187388 148.561765) (xy 109.185134 148.566375) (xy 109.1745 148.639364) (xy 109.1745 148.860636) (xy 109.181215 148.906723) (xy 109.185134 148.933625) (xy 109.19096 148.945542) (xy 109.202717 149.014416) (xy 109.19096 149.054456) (xy 109.185134 149.066375) (xy 109.1745 149.139364) (xy 109.1745 149.360636) (xy 109.185134 149.433625) (xy 109.19096 149.445542) (xy 109.202717 149.514416) (xy 109.19096 149.554456) (xy 109.185134 149.566375) (xy 109.1745 149.639364) (xy 109.1745 149.860636) (xy 109.180235 149.9) (xy 109.185134 149.933625) (xy 109.19096 149.945542) (xy 109.202717 150.014416) (xy 109.19096 150.054458) (xy 109.185136 150.066371) (xy 109.185134 150.066375) (xy 109.1745 150.139364) (xy 109.1745 150.360636) (xy 109.185134 150.433625) (xy 109.19096 150.445542) (xy 109.202717 150.514416) (xy 109.19096 150.554456) (xy 109.185134 150.566375) (xy 109.1745 150.639364) (xy 109.1745 150.639369) (xy 109.1745 150.8322) (xy 109.171949 150.840885) (xy 109.173238 150.849847) (xy 109.162259 150.873887) (xy 109.154815 150.899239) (xy 109.147974 150.905166) (xy 109.144213 150.913403) (xy 109.121978 150.927692) (xy 109.102011 150.944994) (xy 109.091496 150.947281) (xy 109.085435 150.951177) (xy 109.0505 150.9562) (xy 108.934598 150.9562) (xy 108.867559 150.936515) (xy 108.846917 150.919881) (xy 108.803217 150.876181) (xy 108.803209 150.876175) (xy 108.66629 150.797126) (xy 108.666286 150.797124) (xy 108.666284 150.797123) (xy 108.513557 150.7562) (xy 108.355443 150.7562) (xy 108.202716 150.797123) (xy 108.202709 150.797126) (xy 108.06579 150.876175) (xy 108.065782 150.876181) (xy 107.953981 150.987982) (xy 107.953975 150.98799) (xy 107.874926 151.124909) (xy 107.874923 151.124916) (xy 107.834 151.277643) (xy 107.834 151.435757) (xy 107.865808 151.554464) (xy 107.874923 151.588483) (xy 107.874926 151.58849) (xy 107.953975 151.725409) (xy 107.953979 151.725414) (xy 107.95398 151.725416) (xy 108.065784 151.83722) (xy 108.065786 151.837221) (xy 108.06579 151.837224) (xy 108.202709 151.916273) (xy 108.202716 151.916277) (xy 108.355443 151.9572) (xy 108.355445 151.9572) (xy 108.513555 151.9572) (xy 108.513557 151.9572) (xy 108.666284 151.916277) (xy 108.803216 151.83722) (xy 108.846917 151.793519) (xy 108.873844 151.778815) (xy 108.899663 151.762223) (xy 108.905863 151.761331) (xy 108.90824 151.760034) (xy 108.934598 151.7572) (xy 109.052187 151.7572) (xy 109.119226 151.776885) (xy 109.164981 151.829689) (xy 109.17489 151.863319) (xy 109.182606 151.916273) (xy 109.185134 151.933625) (xy 109.19096 151.945542) (xy 109.202717 152.014416) (xy 109.19096 152.054456) (xy 109.185134 152.066375) (xy 109.1745 152.139364) (xy 109.1745 152.360636) (xy 109.180235 152.4) (xy 109.185134 152.433625) (xy 109.19096 152.445542) (xy 109.202717 152.514416) (xy 109.19096 152.554456) (xy 109.189742 152.556949) (xy 109.185134 152.566374) (xy 109.184088 152.573555) (xy 109.1745 152.639364) (xy 109.1745 152.860636) (xy 109.175672 152.868677) (xy 109.185134 152.933625) (xy 109.19096 152.945542) (xy 109.202717 153.014416) (xy 109.19096 153.054456) (xy 109.185134 153.066375) (xy 109.1745 153.139364) (xy 109.1745 153.360636) (xy 109.182886 153.418192) (xy 109.185134 153.433625) (xy 109.19096 153.445542) (xy 109.202717 153.514416) (xy 109.19096 153.554456) (xy 109.185134 153.566375) (xy 109.1745 153.639364) (xy 109.1745 153.860636) (xy 109.181812 153.910821) (xy 109.185134 153.933625) (xy 109.19096 153.945542) (xy 109.202717 154.014416) (xy 109.19096 154.054458) (xy 109.185319 154.065997) (xy 109.185134 154.066375) (xy 109.1745 154.139364) (xy 109.1745 154.360636) (xy 109.181604 154.409395) (xy 109.185134 154.433625) (xy 109.19096 154.445542) (xy 109.202717 154.514416) (xy 109.19096 154.554456) (xy 109.185134 154.566375) (xy 109.1745 154.639364) (xy 109.1745 154.860636) (xy 109.177266 154.879626) (xy 109.174746 154.897388) (xy 109.1773 154.915147) (xy 109.16994 154.931262) (xy 109.167452 154.948801) (xy 109.155728 154.962381) (xy 109.148275 154.978703) (xy 109.133371 154.988281) (xy 109.121796 155.00169) (xy 109.10459 155.006776) (xy 109.089497 155.016477) (xy 109.055013 155.021435) (xy 109.054794 155.0215) (xy 108.971464 155.0215) (xy 108.961522 155.020904) (xy 108.910012 155.021486) (xy 108.909538 155.021492) (xy 108.908139 155.0215) (xy 108.858373 155.0215) (xy 108.855412 155.021888) (xy 108.855397 155.021891) (xy 108.854032 155.02207) (xy 108.805902 155.03555) (xy 108.805901 155.035549) (xy 108.805113 155.035769) (xy 108.756513 155.048793) (xy 108.75452 155.049943) (xy 108.752305 155.050564) (xy 108.752302 155.050565) (xy 108.752301 155.050566) (xy 108.709544 155.075899) (xy 108.708342 155.076602) (xy 108.665186 155.10152) (xy 108.662799 155.10335) (xy 108.662796 155.103354) (xy 108.661715 155.104183) (xy 108.661581 155.104319) (xy 108.661581 155.10432) (xy 108.626725 155.139971) (xy 108.625821 155.140885) (xy 108.589053 155.177653) (xy 108.58252 155.185187) (xy 105.927836 157.900556) (xy 105.927837 157.900557) (xy 105.927311 157.901094) (xy 105.89162 157.936787) (xy 105.890471 157.938775) (xy 105.888863 157.940421) (xy 105.86449 157.983759) (xy 105.8638 157.98497) (xy 105.838888 158.02812) (xy 105.837781 158.030791) (xy 105.837761 158.030842) (xy 105.837216 158.032155) (xy 105.824827 158.080574) (xy 105.824473 158.081928) (xy 105.813679 158.122211) (xy 105.777313 158.181871) (xy 105.714466 158.2124) (xy 105.645091 158.204105) (xy 105.618979 158.188921) (xy 105.522343 158.115639) (xy 105.426192 158.077722) (xy 105.381564 158.060123) (xy 105.381563 158.060122) (xy 105.381561 158.060122) (xy 105.335926 158.054642) (xy 105.293102 158.0495) (xy 104.706898 158.0495) (xy 104.667853 158.054188) (xy 104.618438 158.060122) (xy 104.477656 158.115639) (xy 104.357077 158.207077) (xy 104.265639 158.327656) (xy 104.210122 158.468438) (xy 104.204188 158.517853) (xy 104.1995 158.556898) (xy 104.1995 159.443102) (xy 104.205126 159.489954) (xy 104.210122 159.531561) (xy 104.265639 159.672343) (xy 104.357077 159.792922) (xy 104.477656 159.88436) (xy 104.477657 159.88436) (xy 104.477658 159.884361) (xy 104.618436 159.939877) (xy 104.706898 159.9505) (xy 104.706903 159.9505) (xy 105.293097 159.9505) (xy 105.293102 159.9505) (xy 105.381564 159.939877) (xy 105.522342 159.884361) (xy 105.612676 159.815858) (xy 105.625623 159.810937) (xy 105.636089 159.801869) (xy 105.657634 159.798771) (xy 105.677986 159.791036) (xy 105.691538 159.793896) (xy 105.705247 159.791925) (xy 105.725049 159.800968) (xy 105.74635 159.805464) (xy 105.756203 159.815196) (xy 105.768803 159.82095) (xy 105.780572 159.839263) (xy 105.796061 159.854561) (xy 105.799869 159.86929) (xy 105.806577 159.879728) (xy 105.8116 159.914663) (xy 105.8116 160.029131) (xy 105.791915 160.09617) (xy 105.775278 160.116816) (xy 104.700532 161.191477) (xy 104.700479 161.191526) (xy 104.653298 161.238708) (xy 104.653206 161.2388) (xy 104.653004 161.239003) (xy 104.62163 161.270375) (xy 104.621627 161.270379) (xy 104.62162 161.270387) (xy 104.621143 161.271212) (xy 104.62114 161.271216) (xy 104.593952 161.318307) (xy 104.593929 161.318347) (xy 104.593371 161.319315) (xy 104.568899 161.361698) (xy 104.568896 161.361706) (xy 104.568893 161.361713) (xy 104.567915 161.365361) (xy 104.567914 161.365364) (xy 104.559041 161.398481) (xy 104.55904 161.398486) (xy 104.54239 161.460613) (xy 104.542389 161.460616) (xy 104.541602 161.463557) (xy 104.541601 161.463565) (xy 104.5416 161.463573) (xy 104.5416 161.513876) (xy 104.541599 161.51473) (xy 104.541599 161.514797) (xy 104.541598 161.577634) (xy 104.5416 161.577663) (xy 104.5416 165.270803) (xy 104.521915 165.337842) (xy 104.506152 165.357605) (xy 102.515465 167.388417) (xy 102.515466 167.388418) (xy 102.514887 167.389009) (xy 102.479442 167.424191) (xy 102.478038 167.426601) (xy 102.47608 167.428599) (xy 102.45191 167.471445) (xy 102.451909 167.471444) (xy 102.451445 167.472266) (xy 102.426374 167.515319) (xy 102.425642 167.518009) (xy 102.424269 167.520444) (xy 102.424268 167.520446) (xy 102.424268 167.520447) (xy 102.412017 167.568056) (xy 102.412018 167.568057) (xy 102.411793 167.568929) (xy 102.3987 167.617076) (xy 102.398688 167.619868) (xy 102.397993 167.622574) (xy 102.398483 167.671723) (xy 102.398488 167.673421) (xy 102.392122 169.376464) (xy 102.372187 169.443429) (xy 102.319212 169.488986) (xy 102.268123 169.5) (xy 101.624 169.5) (xy 101.556961 169.480315) (xy 101.511206 169.427511) (xy 101.5 169.376) (xy 101.5 159.443053) (xy 102.2 159.443053) (xy 102.210613 159.531443) (xy 102.266079 159.672095) (xy 102.357435 159.792564) (xy 102.477904 159.88392) (xy 102.618556 159.939386) (xy 102.706946 159.95) (xy 102.8 159.95) (xy 103.2 159.95) (xy 103.293054 159.95) (xy 103.381443 159.939386) (xy 103.522095 159.88392) (xy 103.642564 159.792564) (xy 103.73392 159.672095) (xy 103.789386 159.531443) (xy 103.8 159.443053) (xy 103.8 159.2) (xy 103.2 159.2) (xy 103.2 159.95) (xy 102.8 159.95) (xy 102.8 159.2) (xy 102.2 159.2) (xy 102.2 159.443053) (xy 101.5 159.443053) (xy 101.5 158.556946) (xy 102.2 158.556946) (xy 102.2 158.8) (xy 102.8 158.8) (xy 103.2 158.8) (xy 103.8 158.8) (xy 103.8 158.556946) (xy 103.789386 158.468556) (xy 103.73392 158.327904) (xy 103.642564 158.207435) (xy 103.522095 158.116079) (xy 103.381443 158.060613) (xy 103.293054 158.05) (xy 103.2 158.05) (xy 103.2 158.8) (xy 102.8 158.8) (xy 102.8 158.05) (xy 102.706946 158.05) (xy 102.618556 158.060613) (xy 102.477904 158.116079) (xy 102.357435 158.207435) (xy 102.266079 158.327904) (xy 102.210613 158.468556) (xy 102.2 158.556946) (xy 101.5 158.556946) (xy 101.5 153.443053) (xy 102.2 153.443053) (xy 102.210613 153.531443) (xy 102.266079 153.672095) (xy 102.357435 153.792564) (xy 102.477904 153.88392) (xy 102.618556 153.939386) (xy 102.706946 153.95) (xy 102.8 153.95) (xy 103.2 153.95) (xy 103.293054 153.95) (xy 103.381443 153.939386) (xy 103.522095 153.88392) (xy 103.642564 153.792564) (xy 103.73392 153.672095) (xy 103.789386 153.531443) (xy 103.8 153.443053) (xy 103.8 153.2) (xy 103.2 153.2) (xy 103.2 153.95) (xy 102.8 153.95) (xy 102.8 153.2) (xy 102.2 153.2) (xy 102.2 153.443053) (xy 101.5 153.443053) (xy 101.5 152.556946) (xy 102.2 152.556946) (xy 102.2 152.8) (xy 102.8 152.8) (xy 103.2 152.8) (xy 103.8 152.8) (xy 103.8 152.556949) (xy 103.799999 152.556943) (xy 103.799994 152.556898) (xy 104.1995 152.556898) (xy 104.1995 153.443102) (xy 104.203822 153.479094) (xy 104.210122 153.531561) (xy 104.265639 153.672343) (xy 104.357077 153.792922) (xy 104.477656 153.88436) (xy 104.477657 153.88436) (xy 104.477658 153.884361) (xy 104.618436 153.939877) (xy 104.706898 153.9505) (xy 104.706903 153.9505) (xy 105.293097 153.9505) (xy 105.293102 153.9505) (xy 105.381564 153.939877) (xy 105.522342 153.884361) (xy 105.642922 153.792922) (xy 105.734361 153.672342) (xy 105.789877 153.531564) (xy 105.8005 153.443102) (xy 105.8005 152.556898) (xy 105.789877 152.468436) (xy 105.734361 152.327658) (xy 105.73436 152.327657) (xy 105.73436 152.327656) (xy 105.642922 152.207077) (xy 105.522343 152.115639) (xy 105.425144 152.077309) (xy 105.381564 152.060123) (xy 105.381563 152.060122) (xy 105.381561 152.060122) (xy 105.334389 152.054458) (xy 105.293102 152.0495) (xy 104.706898 152.0495) (xy 104.667853 152.054188) (xy 104.618438 152.060122) (xy 104.477656 152.115639) (xy 104.357077 152.207077) (xy 104.265639 152.327656) (xy 104.210122 152.468438) (xy 104.205524 152.506736) (xy 104.1995 152.556898) (xy 103.799994 152.556898) (xy 103.789386 152.468556) (xy 103.73392 152.327904) (xy 103.642564 152.207435) (xy 103.522095 152.116079) (xy 103.381443 152.060613) (xy 103.293054 152.05) (xy 103.2 152.05) (xy 103.2 152.8) (xy 102.8 152.8) (xy 102.8 152.05) (xy 102.706946 152.05) (xy 102.618556 152.060613) (xy 102.477904 152.116079) (xy 102.357435 152.207435) (xy 102.266079 152.327904) (xy 102.210613 152.468556) (xy 102.2 152.556946) (xy 101.5 152.556946) (xy 101.5 147.443053) (xy 102.2 147.443053) (xy 102.210613 147.531443) (xy 102.266079 147.672095) (xy 102.357435 147.792564) (xy 102.477904 147.88392) (xy 102.618556 147.939386) (xy 102.706946 147.95) (xy 102.8 147.95) (xy 103.2 147.95) (xy 103.293054 147.95) (xy 103.381443 147.939386) (xy 103.522095 147.88392) (xy 103.642564 147.792564) (xy 103.73392 147.672095) (xy 103.789386 147.531443) (xy 103.8 147.443053) (xy 103.8 147.2) (xy 103.2 147.2) (xy 103.2 147.95) (xy 102.8 147.95) (xy 102.8 147.2) (xy 102.2 147.2) (xy 102.2 147.443053) (xy 101.5 147.443053) (xy 101.5 146.556946) (xy 102.2 146.556946) (xy 102.2 146.8) (xy 102.8 146.8) (xy 103.2 146.8) (xy 103.8 146.8) (xy 103.8 146.556949) (xy 103.799999 146.556943) (xy 103.799994 146.556898) (xy 104.1995 146.556898) (xy 104.1995 147.443102) (xy 104.202459 147.467743) (xy 104.210122 147.531561) (xy 104.265639 147.672343) (xy 104.357077 147.792922) (xy 104.477656 147.88436) (xy 104.477657 147.88436) (xy 104.477658 147.884361) (xy 104.618436 147.939877) (xy 104.706898 147.9505) (xy 104.706903 147.9505) (xy 105.293097 147.9505) (xy 105.293102 147.9505) (xy 105.381564 147.939877) (xy 105.522342 147.884361) (xy 105.642922 147.792922) (xy 105.734361 147.672342) (xy 105.789877 147.531564) (xy 105.8005 147.443102) (xy 105.8005 146.556898) (xy 105.789877 146.468436) (xy 105.734361 146.327658) (xy 105.73436 146.327657) (xy 105.73436 146.327656) (xy 105.642922 146.207077) (xy 105.522343 146.115639) (xy 105.397415 146.066374) (xy 105.381564 146.060123) (xy 105.381563 146.060122) (xy 105.381561 146.060122) (xy 105.334389 146.054458) (xy 105.293102 146.0495) (xy 104.706898 146.0495) (xy 104.667853 146.054188) (xy 104.618438 146.060122) (xy 104.477656 146.115639) (xy 104.357077 146.207077) (xy 104.265639 146.327656) (xy 104.210122 146.468438) (xy 104.204871 146.512171) (xy 104.1995 146.556898) (xy 103.799994 146.556898) (xy 103.789386 146.468556) (xy 103.73392 146.327904) (xy 103.642564 146.207435) (xy 103.522095 146.116079) (xy 103.381443 146.060613) (xy 103.293054 146.05) (xy 103.2 146.05) (xy 103.2 146.8) (xy 102.8 146.8) (xy 102.8 146.05) (xy 102.706946 146.05) (xy 102.618556 146.060613) (xy 102.477904 146.116079) (xy 102.357435 146.207435) (xy 102.266079 146.327904) (xy 102.210613 146.468556) (xy 102.2 146.556946) (xy 101.5 146.556946) (xy 101.5 136.556898) (xy 132.1995 136.556898) (xy 132.1995 137.443102) (xy 132.205126 137.489954) (xy 132.210122 137.531561) (xy 132.265639 137.672343) (xy 132.357077 137.792922) (xy 132.477656 137.88436) (xy 132.477657 137.88436) (xy 132.477658 137.884361) (xy 132.618436 137.939877) (xy 132.706898 137.9505) (xy 132.706903 137.9505) (xy 133.293097 137.9505) (xy 133.293102 137.9505) (xy 133.381564 137.939877) (xy 133.522342 137.884361) (xy 133.642922 137.792922) (xy 133.734361 137.672342) (xy 133.789877 137.531564) (xy 133.8005 137.443102) (xy 133.8005 136.556898) (xy 134.1995 136.556898) (xy 134.1995 137.443102) (xy 134.205126 137.489954) (xy 134.210122 137.531561) (xy 134.265639 137.672343) (xy 134.357077 137.792922) (xy 134.477656 137.88436) (xy 134.477657 137.88436) (xy 134.477658 137.884361) (xy 134.618436 137.939877) (xy 134.706898 137.9505) (xy 134.706903 137.9505) (xy 135.293097 137.9505) (xy 135.293102 137.9505) (xy 135.381564 137.939877) (xy 135.522342 137.884361) (xy 135.642922 137.792922) (xy 135.734361 137.672342) (xy 135.789877 137.531564) (xy 135.8005 137.443102) (xy 135.8005 136.556898) (xy 138.1995 136.556898) (xy 138.1995 137.443102) (xy 138.205126 137.489954) (xy 138.210122 137.531561) (xy 138.265639 137.672343) (xy 138.357077 137.792922) (xy 138.477656 137.88436) (xy 138.477657 137.88436) (xy 138.477658 137.884361) (xy 138.618436 137.939877) (xy 138.706898 137.9505) (xy 138.706903 137.9505) (xy 139.293097 137.9505) (xy 139.293102 137.9505) (xy 139.381564 137.939877) (xy 139.522342 137.884361) (xy 139.642922 137.792922) (xy 139.734361 137.672342) (xy 139.789877 137.531564) (xy 139.8005 137.443102) (xy 139.8005 136.556898) (xy 139.789877 136.468436) (xy 139.734361 136.327658) (xy 139.73436 136.327657) (xy 139.73436 136.327656) (xy 139.642922 136.207077) (xy 139.522343 136.115639) (xy 139.381561 136.060122) (xy 139.335926 136.054642) (xy 139.293102 136.0495) (xy 138.706898 136.0495) (xy 138.667853 136.054188) (xy 138.618438 136.060122) (xy 138.477656 136.115639) (xy 138.357077 136.207077) (xy 138.265639 136.327656) (xy 138.210122 136.468438) (xy 138.204188 136.517853) (xy 138.1995 136.556898) (xy 135.8005 136.556898) (xy 135.789877 136.468436) (xy 135.734361 136.327658) (xy 135.73436 136.327657) (xy 135.73436 136.327656) (xy 135.642922 136.207077) (xy 135.522343 136.115639) (xy 135.381561 136.060122) (xy 135.335926 136.054642) (xy 135.293102 136.0495) (xy 134.706898 136.0495) (xy 134.667853 136.054188) (xy 134.618438 136.060122) (xy 134.477656 136.115639) (xy 134.357077 136.207077) (xy 134.265639 136.327656) (xy 134.210122 136.468438) (xy 134.204188 136.517853) (xy 134.1995 136.556898) (xy 133.8005 136.556898) (xy 133.789877 136.468436) (xy 133.734361 136.327658) (xy 133.73436 136.327657) (xy 133.73436 136.327656) (xy 133.642922 136.207077) (xy 133.522343 136.115639) (xy 133.381561 136.060122) (xy 133.335926 136.054642) (xy 133.293102 136.0495) (xy 132.706898 136.0495) (xy 132.667853 136.054188) (xy 132.618438 136.060122) (xy 132.477656 136.115639) (xy 132.357077 136.207077) (xy 132.265639 136.327656) (xy 132.210122 136.468438) (xy 132.204188 136.517853) (xy 132.1995 136.556898) (xy 101.5 136.556898) (xy 101.5 131.593243) (xy 115.295 131.593243) (xy 115.295 131.751356) (xy 115.335923 131.904083) (xy 115.335926 131.90409) (xy 115.414975 132.041009) (xy 115.414979 132.041014) (xy 115.41498 132.041016) (xy 115.526784 132.15282) (xy 115.526786 132.152821) (xy 115.52679 132.152824) (xy 115.663709 132.231873) (xy 115.663716 132.231877) (xy 115.816443 132.2728) (xy 115.816445 132.2728) (xy 115.974555 132.2728) (xy 115.974557 132.2728) (xy 116.127284 132.231877) (xy 116.264216 132.15282) (xy 116.37602 132.041016) (xy 116.455077 131.904084) (xy 116.496 131.751357) (xy 116.496 131.689555) (xy 116.515685 131.622516) (xy 116.532319 131.601874) (xy 116.947374 131.186819) (xy 117.008697 131.153334) (xy 117.035055 131.1505) (xy 117.429591 131.1505) (xy 117.429594 131.1505) (xy 117.497657 131.144315) (xy 117.65427 131.095512) (xy 117.794653 131.010648) (xy 117.910648 130.894653) (xy 117.995512 130.75427) (xy 118.044315 130.597657) (xy 118.0505 130.529594) (xy 118.0505 129.470406) (xy 119.9495 129.470406) (xy 119.9495 130.529594) (xy 119.955685 130.597657) (xy 119.955686 130.597662) (xy 119.955687 130.597664) (xy 120.004485 130.754263) (xy 120.004488 130.754272) (xy 120.089348 130.894648) (xy 120.089351 130.894652) (xy 120.205347 131.010648) (xy 120.205351 131.010651) (xy 120.345727 131.095511) (xy 120.34573 131.095512) (xy 120.502343 131.144315) (xy 120.570406 131.1505) (xy 120.570409 131.1505) (xy 121.429591 131.1505) (xy 121.429594 131.1505) (xy 121.497657 131.144315) (xy 121.65427 131.095512) (xy 121.794653 131.010648) (xy 121.910648 130.894653) (xy 121.995512 130.75427) (xy 122.044315 130.597657) (xy 122.0505 130.529594) (xy 122.0505 129.556898) (xy 128.1995 129.556898) (xy 128.1995 130.443102) (xy 128.205126 130.489954) (xy 128.210122 130.531561) (xy 128.265639 130.672343) (xy 128.357077 130.792922) (xy 128.477656 130.88436) (xy 128.477657 130.88436) (xy 128.477658 130.884361) (xy 128.618436 130.939877) (xy 128.706898 130.9505) (xy 128.706903 130.9505) (xy 129.293097 130.9505) (xy 129.293102 130.9505) (xy 129.381564 130.939877) (xy 129.522342 130.884361) (xy 129.642922 130.792922) (xy 129.734361 130.672342) (xy 129.789877 130.531564) (xy 129.8005 130.443102) (xy 129.8005 129.556898) (xy 130.1995 129.556898) (xy 130.1995 130.443102) (xy 130.205126 130.489954) (xy 130.210122 130.531561) (xy 130.265639 130.672343) (xy 130.357077 130.792922) (xy 130.477656 130.88436) (xy 130.477657 130.88436) (xy 130.477658 130.884361) (xy 130.618436 130.939877) (xy 130.706898 130.9505) (xy 130.706903 130.9505) (xy 131.293097 130.9505) (xy 131.293102 130.9505) (xy 131.381564 130.939877) (xy 131.522342 130.884361) (xy 131.642922 130.792922) (xy 131.734361 130.672342) (xy 131.789877 130.531564) (xy 131.8005 130.443102) (xy 131.8005 129.556898) (xy 136.1995 129.556898) (xy 136.1995 130.443102) (xy 136.205126 130.489954) (xy 136.210122 130.531561) (xy 136.265639 130.672343) (xy 136.357077 130.792922) (xy 136.477656 130.88436) (xy 136.477657 130.88436) (xy 136.477658 130.884361) (xy 136.618436 130.939877) (xy 136.706898 130.9505) (xy 136.706903 130.9505) (xy 137.293097 130.9505) (xy 137.293102 130.9505) (xy 137.381564 130.939877) (xy 137.522342 130.884361) (xy 137.642922 130.792922) (xy 137.734361 130.672342) (xy 137.789877 130.531564) (xy 137.8005 130.443102) (xy 137.8005 129.556898) (xy 138.1995 129.556898) (xy 138.1995 130.443102) (xy 138.205126 130.489954) (xy 138.210122 130.531561) (xy 138.265639 130.672343) (xy 138.357077 130.792922) (xy 138.477656 130.88436) (xy 138.477657 130.88436) (xy 138.477658 130.884361) (xy 138.618436 130.939877) (xy 138.706898 130.9505) (xy 138.706903 130.9505) (xy 139.293097 130.9505) (xy 139.293102 130.9505) (xy 139.381564 130.939877) (xy 139.522342 130.884361) (xy 139.642922 130.792922) (xy 139.734361 130.672342) (xy 139.789877 130.531564) (xy 139.8005 130.443102) (xy 139.8005 129.556898) (xy 139.789877 129.468436) (xy 139.734361 129.327658) (xy 139.73436 129.327657) (xy 139.73436 129.327656) (xy 139.642922 129.207077) (xy 139.522343 129.115639) (xy 139.426192 129.077722) (xy 139.381564 129.060123) (xy 139.381563 129.060122) (xy 139.381561 129.060122) (xy 139.335926 129.054642) (xy 139.293102 129.0495) (xy 138.706898 129.0495) (xy 138.667853 129.054188) (xy 138.618438 129.060122) (xy 138.477656 129.115639) (xy 138.357077 129.207077) (xy 138.265639 129.327656) (xy 138.210122 129.468438) (xy 138.209071 129.477194) (xy 138.1995 129.556898) (xy 137.8005 129.556898) (xy 137.789877 129.468436) (xy 137.734361 129.327658) (xy 137.73436 129.327657) (xy 137.73436 129.327656) (xy 137.642922 129.207077) (xy 137.522343 129.115639) (xy 137.426192 129.077722) (xy 137.381564 129.060123) (xy 137.381563 129.060122) (xy 137.381561 129.060122) (xy 137.335926 129.054642) (xy 137.293102 129.0495) (xy 136.706898 129.0495) (xy 136.667853 129.054188) (xy 136.618438 129.060122) (xy 136.477656 129.115639) (xy 136.357077 129.207077) (xy 136.265639 129.327656) (xy 136.210122 129.468438) (xy 136.209071 129.477194) (xy 136.1995 129.556898) (xy 131.8005 129.556898) (xy 131.789877 129.468436) (xy 131.734361 129.327658) (xy 131.73436 129.327657) (xy 131.73436 129.327656) (xy 131.642922 129.207077) (xy 131.522343 129.115639) (xy 131.426192 129.077722) (xy 131.381564 129.060123) (xy 131.381563 129.060122) (xy 131.381561 129.060122) (xy 131.335926 129.054642) (xy 131.293102 129.0495) (xy 130.706898 129.0495) (xy 130.667853 129.054188) (xy 130.618438 129.060122) (xy 130.477656 129.115639) (xy 130.357077 129.207077) (xy 130.265639 129.327656) (xy 130.210122 129.468438) (xy 130.209071 129.477194) (xy 130.1995 129.556898) (xy 129.8005 129.556898) (xy 129.789877 129.468436) (xy 129.734361 129.327658) (xy 129.73436 129.327657) (xy 129.73436 129.327656) (xy 129.642922 129.207077) (xy 129.522343 129.115639) (xy 129.426192 129.077722) (xy 129.381564 129.060123) (xy 129.381563 129.060122) (xy 129.381561 129.060122) (xy 129.335926 129.054642) (xy 129.293102 129.0495) (xy 128.706898 129.0495) (xy 128.667853 129.054188) (xy 128.618438 129.060122) (xy 128.477656 129.115639) (xy 128.357077 129.207077) (xy 128.265639 129.327656) (xy 128.210122 129.468438) (xy 128.209071 129.477194) (xy 128.1995 129.556898) (xy 122.0505 129.556898) (xy 122.0505 129.470406) (xy 122.044315 129.402343) (xy 121.995512 129.24573) (xy 121.995511 129.245727) (xy 121.910651 129.105351) (xy 121.910648 129.105347) (xy 121.794652 128.989351) (xy 121.794648 128.989348) (xy 121.654272 128.904488) (xy 121.654263 128.904485) (xy 121.497664 128.855687) (xy 121.497662 128.855686) (xy 121.497657 128.855685) (xy 121.429594 128.8495) (xy 120.570406 128.8495) (xy 120.502343 128.855685) (xy 120.502339 128.855686) (xy 120.502335 128.855687) (xy 120.345736 128.904485) (xy 120.345727 128.904488) (xy 120.205351 128.989348) (xy 120.205347 128.989351) (xy 120.089351 129.105347) (xy 120.089348 129.105351) (xy 120.004488 129.245727) (xy 120.004485 129.245736) (xy 119.955687 129.402335) (xy 119.955685 129.402343) (xy 119.9495 129.470406) (xy 118.0505 129.470406) (xy 118.044315 129.402343) (xy 118.033366 129.367208) (xy 118.031957 129.35816) (xy 118.035372 129.332247) (xy 118.034941 129.306108) (xy 118.039953 129.297499) (xy 118.041088 129.28889) (xy 118.05352 129.274197) (xy 118.066796 129.251395) (xy 123.781374 123.536819) (xy 123.842697 123.503334) (xy 123.869055 123.5005) (xy 123.935176 123.5005) (xy 123.982628 123.509939) (xy 124.019434 123.525184) (xy 124.043238 123.535044) (xy 124.160639 123.5505) (xy 124.83936 123.550499) (xy 124.839363 123.550499) (xy 124.956753 123.535046) (xy 124.956757 123.535044) (xy 124.956762 123.535044) (xy 125.102841 123.474536) (xy 125.228282 123.378282) (xy 125.324536 123.252841) (xy 125.385044 123.106762) (xy 125.4005 122.989361) (xy 125.400499 121.010645) (xy 126.5995 121.010645) (xy 126.5995 122.989363) (xy 126.614953 123.106753) (xy 126.614956 123.106762) (xy 126.675287 123.252415) (xy 126.675464 123.252841) (xy 126.771718 123.378282) (xy 126.897159 123.474536) (xy 127.043238 123.535044) (xy 127.160639 123.5505) (xy 127.83936 123.550499) (xy 127.839363 123.550499) (xy 127.956753 123.535046) (xy 127.956757 123.535044) (xy 127.956762 123.535044) (xy 128.102841 123.474536) (xy 128.228282 123.378282) (xy 128.324536 123.252841) (xy 128.385044 123.106762) (xy 128.4005 122.989361) (xy 128.400499 121.01064) (xy 128.400499 121.010639) (xy 128.400499 121.010636) (xy 128.385046 120.893246) (xy 128.385044 120.893239) (xy 128.385044 120.893238) (xy 128.324536 120.747159) (xy 128.228282 120.621718) (xy 128.102841 120.525464) (xy 128.089618 120.519987) (xy 127.956762 120.464956) (xy 127.95676 120.464955) (xy 127.839361 120.4495) (xy 127.160636 120.4495) (xy 127.043246 120.464953) (xy 127.043237 120.464956) (xy 126.89716 120.525463) (xy 126.771718 120.621718) (xy 126.675463 120.74716) (xy 126.614956 120.893237) (xy 126.614955 120.893239) (xy 126.601191 120.997794) (xy 126.599501 121.010636) (xy 126.5995 121.010645) (xy 125.400499 121.010645) (xy 125.400499 121.01064) (xy 125.400499 121.010639) (xy 125.400499 121.010636) (xy 125.385046 120.893246) (xy 125.385044 120.893239) (xy 125.385044 120.893238) (xy 125.324536 120.747159) (xy 125.228282 120.621718) (xy 125.102841 120.525464) (xy 125.089618 120.519987) (xy 124.956762 120.464956) (xy 124.95676 120.464955) (xy 124.839361 120.4495) (xy 124.160636 120.4495) (xy 124.043246 120.464953) (xy 124.043237 120.464956) (xy 123.89716 120.525463) (xy 123.771718 120.621718) (xy 123.675463 120.74716) (xy 123.614956 120.893237) (xy 123.614955 120.893239) (xy 123.601191 120.997794) (xy 123.599501 121.010636) (xy 123.5995 121.010645) (xy 123.5995 122.534544) (xy 123.579815 122.601583) (xy 123.563181 122.622225) (xy 117.372226 128.813181) (xy 117.310903 128.846666) (xy 117.284545 128.8495) (xy 116.570406 128.8495) (xy 116.502343 128.855685) (xy 116.502339 128.855686) (xy 116.502335 128.855687) (xy 116.345736 128.904485) (xy 116.345727 128.904488) (xy 116.205351 128.989348) (xy 116.205347 128.989351) (xy 116.089351 129.105347) (xy 116.089348 129.105351) (xy 116.004488 129.245727) (xy 116.004485 129.245736) (xy 115.955687 129.402335) (xy 115.955685 129.402343) (xy 115.9495 129.470406) (xy 115.9495 130.529594) (xy 115.955685 130.597657) (xy 115.955686 130.597662) (xy 115.955687 130.597664) (xy 116.004485 130.754263) (xy 116.004489 130.754272) (xy 116.04565 130.822362) (xy 116.053063 130.850442) (xy 116.063217 130.877664) (xy 116.061877 130.883823) (xy 116.063486 130.889917) (xy 116.05454 130.91755) (xy 116.048366 130.945937) (xy 116.043055 130.953031) (xy 116.041968 130.95639) (xy 116.027215 130.974192) (xy 115.965924 131.035482) (xy 115.904604 131.068966) (xy 115.878245 131.0718) (xy 115.816443 131.0718) (xy 115.663716 131.112723) (xy 115.663709 131.112726) (xy 115.52679 131.191775) (xy 115.526782 131.191781) (xy 115.414981 131.303582) (xy 115.414975 131.30359) (xy 115.335926 131.440509) (xy 115.335923 131.440516) (xy 115.295 131.593243) (xy 101.5 131.593243) (xy 101.5 130.443053) (xy 104.2 130.443053) (xy 104.210613 130.531443) (xy 104.266079 130.672095) (xy 104.357435 130.792564) (xy 104.477904 130.88392) (xy 104.618556 130.939386) (xy 104.706946 130.95) (xy 104.8 130.95) (xy 105.2 130.95) (xy 105.293054 130.95) (xy 105.381443 130.939386) (xy 105.522095 130.88392) (xy 105.642564 130.792564) (xy 105.73392 130.672095) (xy 105.789386 130.531443) (xy 105.8 130.443053) (xy 105.8 130.2) (xy 105.2 130.2) (xy 105.2 130.95) (xy 104.8 130.95) (xy 104.8 130.2) (xy 104.2 130.2) (xy 104.2 130.443053) (xy 101.5 130.443053) (xy 101.5 129.556946) (xy 104.2 129.556946) (xy 104.2 129.8) (xy 104.8 129.8) (xy 105.2 129.8) (xy 105.8 129.8) (xy 105.8 129.556949) (xy 105.799999 129.556943) (xy 105.799994 129.556898) (xy 106.1995 129.556898) (xy 106.1995 130.443102) (xy 106.205126 130.489954) (xy 106.210122 130.531561) (xy 106.265639 130.672343) (xy 106.357077 130.792922) (xy 106.477656 130.88436) (xy 106.477657 130.88436) (xy 106.477658 130.884361) (xy 106.618436 130.939877) (xy 106.706898 130.9505) (xy 106.706903 130.9505) (xy 107.293097 130.9505) (xy 107.293102 130.9505) (xy 107.381564 130.939877) (xy 107.522342 130.884361) (xy 107.642922 130.792922) (xy 107.734361 130.672342) (xy 107.789877 130.531564) (xy 107.8005 130.443102) (xy 107.8005 129.556898) (xy 107.789877 129.468436) (xy 107.734361 129.327658) (xy 107.73436 129.327657) (xy 107.73436 129.327656) (xy 107.642922 129.207077) (xy 107.522343 129.115639) (xy 107.426192 129.077722) (xy 107.381564 129.060123) (xy 107.381563 129.060122) (xy 107.381561 129.060122) (xy 107.335926 129.054642) (xy 107.293102 129.0495) (xy 106.706898 129.0495) (xy 106.667853 129.054188) (xy 106.618438 129.060122) (xy 106.477656 129.115639) (xy 106.357077 129.207077) (xy 106.265639 129.327656) (xy 106.210122 129.468438) (xy 106.209071 129.477194) (xy 106.1995 129.556898) (xy 105.799994 129.556898) (xy 105.789386 129.468556) (xy 105.73392 129.327904) (xy 105.642564 129.207435) (xy 105.522095 129.116079) (xy 105.381443 129.060613) (xy 105.293054 129.05) (xy 105.2 129.05) (xy 105.2 129.8) (xy 104.8 129.8) (xy 104.8 129.05) (xy 104.706946 129.05) (xy 104.618556 129.060613) (xy 104.477904 129.116079) (xy 104.357435 129.207435) (xy 104.266079 129.327904) (xy 104.210613 129.468556) (xy 104.2 129.556946) (xy 101.5 129.556946) (xy 101.5 126.094785) (xy 106.800001 126.094785) (xy 106.800002 126.094808) (xy 106.802908 126.119869) (xy 106.802909 126.119873) (xy 106.848211 126.222474) (xy 106.848214 126.222479) (xy 106.92752 126.301785) (xy 106.927525 126.301788) (xy 107.030123 126.347089) (xy 107.055206 126.349999) (xy 108.399999 126.349999) (xy 108.8 126.349999) (xy 110.144786 126.349999) (xy 110.144808 126.349997) (xy 110.169869 126.347091) (xy 110.169873 126.34709) (xy 110.272474 126.301788) (xy 110.272479 126.301785) (xy 110.351785 126.222479) (xy 110.351788 126.222474) (xy 110.397089 126.119877) (xy 110.397089 126.119875) (xy 110.399999 126.094794) (xy 110.4 126.094791) (xy 110.4 125.5) (xy 108.8 125.5) (xy 108.8 126.349999) (xy 108.399999 126.349999) (xy 108.4 126.349998) (xy 108.4 125.5) (xy 106.800001 125.5) (xy 106.800001 126.094785) (xy 101.5 126.094785) (xy 101.5 117.905131) (xy 106.7995 117.905131) (xy 106.7995 119.494856) (xy 106.799502 119.494882) (xy 106.802413 119.519987) (xy 106.802415 119.519991) (xy 106.847793 119.622764) (xy 106.93536 119.710331) (xy 106.932942 119.712748) (xy 106.964842 119.751829) (xy 106.972747 119.82125) (xy 106.941865 119.883924) (xy 106.935301 119.88961) (xy 106.93536 119.889669) (xy 106.847794 119.977234) (xy 106.802415 120.080006) (xy 106.802415 120.080008) (xy 106.7995 120.105131) (xy 106.7995 121.694856) (xy 106.799502 121.694882) (xy 106.802413 121.719987) (xy 106.802415 121.719991) (xy 106.847793 121.822764) (xy 106.93536 121.910331) (xy 106.932942 121.912748) (xy 106.964842 121.951829) (xy 106.972747 122.02125) (xy 106.941865 122.083924) (xy 106.935301 122.08961) (xy 106.93536 122.089669) (xy 106.847794 122.177234) (xy 106.802415 122.280006) (xy 106.802415 122.280008) (xy 106.7995 122.305131) (xy 106.7995 123.894856) (xy 106.799502 123.894882) (xy 106.802413 123.919987) (xy 106.802415 123.919991) (xy 106.847793 124.022764) (xy 106.93536 124.110331) (xy 106.93305 124.11264) (xy 106.965285 124.152122) (xy 106.973198 124.221542) (xy 106.942324 124.28422) (xy 106.935603 124.290044) (xy 106.935647 124.290088) (xy 106.848214 124.37752) (xy 106.848211 124.377525) (xy 106.80291 124.480122) (xy 106.80291 124.480124) (xy 106.8 124.505205) (xy 106.8 125.1) (xy 110.399999 125.1) (xy 110.399999 124.505214) (xy 110.399997 124.505191) (xy 110.397091 124.48013) (xy 110.39709 124.480126) (xy 110.351788 124.377525) (xy 110.351785 124.37752) (xy 110.264353 124.290088) (xy 110.26673 124.28771) (xy 110.234705 124.24847) (xy 110.226805 124.179048) (xy 110.257692 124.116376) (xy 110.264654 124.110345) (xy 110.26464 124.110331) (xy 110.272765 124.102206) (xy 110.352206 124.022765) (xy 110.397585 123.919991) (xy 110.4005 123.894865) (xy 110.400499 122.305136) (xy 110.400497 122.305117) (xy 110.397586 122.280012) (xy 110.397585 122.28001) (xy 110.397585 122.280009) (xy 110.352206 122.177235) (xy 110.272765 122.097794) (xy 110.26464 122.089669) (xy 110.267058 122.08725) (xy 110.235165 122.04819) (xy 110.227249 121.97877) (xy 110.258121 121.91609) (xy 110.264699 121.91039) (xy 110.26464 121.910331) (xy 110.272765 121.902206) (xy 110.352206 121.822765) (xy 110.397585 121.719991) (xy 110.4005 121.694865) (xy 110.400499 120.105136) (xy 110.400497 120.105117) (xy 110.397586 120.080012) (xy 110.397585 120.08001) (xy 110.397585 120.080009) (xy 110.352206 119.977235) (xy 110.272765 119.897794) (xy 110.26464 119.889669) (xy 110.267058 119.88725) (xy 110.235165 119.84819) (xy 110.227249 119.77877) (xy 110.258121 119.71609) (xy 110.264699 119.71039) (xy 110.26464 119.710331) (xy 110.272765 119.702206) (xy 110.352206 119.622765) (xy 110.397585 119.519991) (xy 110.4005 119.494865) (xy 110.400499 117.955131) (xy 113.5995 117.955131) (xy 113.5995 126.044856) (xy 113.599502 126.044882) (xy 113.602413 126.069987) (xy 113.602415 126.069991) (xy 113.647793 126.172764) (xy 113.647794 126.172765) (xy 113.727235 126.252206) (xy 113.830009 126.297585) (xy 113.855135 126.3005) (xy 116.944864 126.300499) (xy 116.944879 126.300497) (xy 116.944882 126.300497) (xy 116.969987 126.297586) (xy 116.969988 126.297585) (xy 116.969991 126.297585) (xy 117.072765 126.252206) (xy 117.152206 126.172765) (xy 117.197585 126.069991) (xy 117.2005 126.044865) (xy 117.200499 117.955136) (xy 117.200497 117.955117) (xy 117.197586 117.930012) (xy 117.197585 117.93001) (xy 117.197585 117.930009) (xy 117.152206 117.827235) (xy 117.072765 117.747794) (xy 117.072763 117.747793) (xy 116.969992 117.702415) (xy 116.944865 117.6995) (xy 113.855143 117.6995) (xy 113.855117 117.699502) (xy 113.830012 117.702413) (xy 113.830008 117.702415) (xy 113.727235 117.747793) (xy 113.647794 117.827234) (xy 113.602415 117.930006) (xy 113.602415 117.930008) (xy 113.5995 117.955131) (xy 110.400499 117.955131) (xy 110.400499 117.905136) (xy 110.400497 117.905117) (xy 110.397586 117.880012) (xy 110.397585 117.88001) (xy 110.397585 117.880009) (xy 110.352206 117.777235) (xy 110.272765 117.697794) (xy 110.272763 117.697793) (xy 110.169992 117.652415) (xy 110.144865 117.6495) (xy 107.055143 117.6495) (xy 107.055117 117.649502) (xy 107.030012 117.652413) (xy 107.030008 117.652415) (xy 106.927235 117.697793) (xy 106.847794 117.777234) (xy 106.802415 117.880006) (xy 106.802415 117.880008) (xy 106.7995 117.905131) (xy 101.5 117.905131) (xy 101.5 114.443053) (xy 128.2 114.443053) (xy 128.210613 114.531443) (xy 128.266079 114.672095) (xy 128.357435 114.792564) (xy 128.477904 114.88392) (xy 128.618556 114.939386) (xy 128.706946 114.95) (xy 128.8 114.95) (xy 129.2 114.95) (xy 129.293054 114.95) (xy 129.381443 114.939386) (xy 129.522095 114.88392) (xy 129.642564 114.792564) (xy 129.73392 114.672095) (xy 129.789386 114.531443) (xy 129.8 114.443053) (xy 129.8 114.2) (xy 129.2 114.2) (xy 129.2 114.95) (xy 128.8 114.95) (xy 128.8 114.2) (xy 128.2 114.2) (xy 128.2 114.443053) (xy 101.5 114.443053) (xy 101.5 113.556946) (xy 128.2 113.556946) (xy 128.2 113.8) (xy 128.8 113.8) (xy 129.2 113.8) (xy 129.8 113.8) (xy 129.8 113.556949) (xy 129.799999 113.556943) (xy 129.799994 113.556898) (xy 130.1995 113.556898) (xy 130.1995 114.443102) (xy 130.205126 114.489954) (xy 130.210122 114.531561) (xy 130.265639 114.672343) (xy 130.357077 114.792922) (xy 130.477656 114.88436) (xy 130.477657 114.88436) (xy 130.477658 114.884361) (xy 130.618436 114.939877) (xy 130.706898 114.9505) (xy 130.706903 114.9505) (xy 131.293097 114.9505) (xy 131.293102 114.9505) (xy 131.381564 114.939877) (xy 131.522342 114.884361) (xy 131.642922 114.792922) (xy 131.734361 114.672342) (xy 131.789877 114.531564) (xy 131.8005 114.443102) (xy 131.8005 113.556898) (xy 131.789877 113.468436) (xy 131.734361 113.327658) (xy 131.73436 113.327657) (xy 131.73436 113.327656) (xy 131.642922 113.207077) (xy 131.522343 113.115639) (xy 131.426192 113.077722) (xy 131.381564 113.060123) (xy 131.381563 113.060122) (xy 131.381561 113.060122) (xy 131.335926 113.054642) (xy 131.293102 113.0495) (xy 130.706898 113.0495) (xy 130.667853 113.054188) (xy 130.618438 113.060122) (xy 130.477656 113.115639) (xy 130.357077 113.207077) (xy 130.265639 113.327656) (xy 130.210122 113.468438) (xy 130.204188 113.517853) (xy 130.1995 113.556898) (xy 129.799994 113.556898) (xy 129.789386 113.468556) (xy 129.73392 113.327904) (xy 129.642564 113.207435) (xy 129.522095 113.116079) (xy 129.381443 113.060613) (xy 129.293054 113.05) (xy 129.2 113.05) (xy 129.2 113.8) (xy 128.8 113.8) (xy 128.8 113.05) (xy 128.706946 113.05) (xy 128.618556 113.060613) (xy 128.477904 113.116079) (xy 128.357435 113.207435) (xy 128.266079 113.327904) (xy 128.210613 113.468556) (xy 128.2 113.556946) (xy 101.5 113.556946) (xy 101.5 109.179448) (xy 103.8495 109.179448) (xy 103.8495 109.360551) (xy 103.877829 109.53941) (xy 103.933787 109.711636) (xy 103.933788 109.711639) (xy 104.016006 109.872997) (xy 104.122441 110.019494) (xy 104.122445 110.019499) (xy 104.2505 110.147554) (xy 104.250505 110.147558) (xy 104.378287 110.240396) (xy 104.397006 110.253996) (xy 104.502484 110.30774) (xy 104.55836 110.336211) (xy 104.558363 110.336212) (xy 104.644476 110.364191) (xy 104.730591 110.392171) (xy 104.813429 110.405291) (xy 104.909449 110.4205) (xy 104.909454 110.4205) (xy 105.090551 110.4205) (xy 105.177259 110.406765) (xy 105.269409 110.392171) (xy 105.441639 110.336211) (xy 105.602994 110.253996) (xy 105.749501 110.147553) (xy 105.877553 110.019501) (xy 105.983996 109.872994) (xy 106.066211 109.711639) (xy 106.122171 109.539409) (xy 106.136765 109.447259) (xy 106.1505 109.360551) (xy 106.1505 109.179448) (xy 106.123764 109.010651) (xy 106.122171 109.000591) (xy 106.066211 108.828361) (xy 106.066211 108.82836) (xy 106.03774 108.772484) (xy 105.983996 108.667006) (xy 105.970396 108.648287) (xy 105.927557 108.589324) (xy 111.600001 108.589324) (xy 111.615442 108.706628) (xy 111.615444 108.706633) (xy 111.675899 108.852585) (xy 111.772075 108.977924) (xy 111.897413 109.0741) (xy 112.043365 109.134554) (xy 112.043369 109.134555) (xy 112.160676 109.149999) (xy 112.299999 109.149999) (xy 112.7 109.149999) (xy 112.839324 109.149999) (xy 112.956628 109.134557) (xy 112.956633 109.134555) (xy 113.102585 109.0741) (xy 113.227924 108.977924) (xy 113.3241 108.852586) (xy 113.384554 108.706634) (xy 113.384555 108.70663) (xy 113.399999 108.58933) (xy 113.399999 108.589324) (xy 114.600001 108.589324) (xy 114.615442 108.706628) (xy 114.615444 108.706633) (xy 114.675899 108.852585) (xy 114.772075 108.977924) (xy 114.897413 109.0741) (xy 115.043365 109.134554) (xy 115.043369 109.134555) (xy 115.160676 109.149999) (xy 115.299999 109.149999) (xy 115.7 109.149999) (xy 115.839324 109.149999) (xy 115.956628 109.134557) (xy 115.956633 109.134555) (xy 116.102585 109.0741) (xy 116.227924 108.977924) (xy 116.3241 108.852586) (xy 116.384554 108.706634) (xy 116.384555 108.70663) (xy 116.399999 108.58933) (xy 116.4 108.589316) (xy 116.4 108.2) (xy 115.7 108.2) (xy 115.7 109.149999) (xy 115.299999 109.149999) (xy 115.3 109.149998) (xy 115.3 108.2) (xy 114.600001 108.2) (xy 114.600001 108.589324) (xy 113.399999 108.589324) (xy 113.4 108.589316) (xy 113.4 108.2) (xy 112.7 108.2) (xy 112.7 109.149999) (xy 112.299999 109.149999) (xy 112.3 109.149998) (xy 112.3 108.2) (xy 111.600001 108.2) (xy 111.600001 108.589324) (xy 105.927557 108.589324) (xy 105.877558 108.520505) (xy 105.877554 108.5205) (xy 105.749499 108.392445) (xy 105.749494 108.392441) (xy 105.602997 108.286006) (xy 105.602996 108.286005) (xy 105.602994 108.286004) (xy 105.531797 108.249727) (xy 105.441639 108.203788) (xy 105.441636 108.203787) (xy 105.26941 108.147829) (xy 105.134571 108.126472) (xy 105.071437 108.096542) (xy 105.034506 108.037231) (xy 105.035504 107.967368) (xy 105.074114 107.909136) (xy 105.138078 107.881022) (xy 105.15397 107.879999) (xy 105.894786 107.879999) (xy 105.894808 107.879997) (xy 105.919869 107.877091) (xy 105.919873 107.87709) (xy 106.022474 107.831788) (xy 106.022479 107.831785) (xy 106.101785 107.752479) (xy 106.101788 107.752474) (xy 106.147089 107.649877) (xy 106.147089 107.649875) (xy 106.149999 107.624794) (xy 106.15 107.624791) (xy 106.15 107.410669) (xy 111.6 107.410669) (xy 111.6 107.8) (xy 112.3 107.8) (xy 112.7 107.8) (xy 113.399999 107.8) (xy 113.399999 107.410675) (xy 113.399998 107.410669) (xy 114.6 107.410669) (xy 114.6 107.8) (xy 115.3 107.8) (xy 115.7 107.8) (xy 116.399999 107.8) (xy 116.399999 107.470406) (xy 118.9495 107.470406) (xy 118.9495 108.529594) (xy 118.955685 108.597657) (xy 118.955686 108.597662) (xy 118.955687 108.597664) (xy 119.004485 108.754263) (xy 119.004488 108.754272) (xy 119.089348 108.894648) (xy 119.089351 108.894652) (xy 119.205347 109.010648) (xy 119.205351 109.010651) (xy 119.345727 109.095511) (xy 119.34573 109.095512) (xy 119.502343 109.144315) (xy 119.570406 109.1505) (xy 119.570409 109.1505) (xy 120.429591 109.1505) (xy 120.429594 109.1505) (xy 120.497657 109.144315) (xy 120.65427 109.095512) (xy 120.65503 109.095053) (xy 120.794648 109.010651) (xy 120.794647 109.010651) (xy 120.794653 109.010648) (xy 120.910648 108.894653) (xy 120.936079 108.852585) (xy 120.995511 108.754272) (xy 120.995514 108.754263) (xy 121.010358 108.706628) (xy 121.044315 108.597657) (xy 121.0505 108.529594) (xy 121.0505 108.529566) (xy 122.950001 108.529566) (xy 122.956178 108.597561) (xy 122.956181 108.597572) (xy 123.004944 108.75406) (xy 123.004946 108.754064) (xy 123.089743 108.894337) (xy 123.089747 108.894342) (xy 123.205657 109.010252) (xy 123.205662 109.010256) (xy 123.345934 109.095052) (xy 123.502437 109.14382) (xy 123.570443 109.149999) (xy 123.799999 109.149999) (xy 124.2 109.149999) (xy 124.429565 109.149999) (xy 124.497561 109.143821) (xy 124.497572 109.143818) (xy 124.65406 109.095055) (xy 124.654064 109.095053) (xy 124.794337 109.010256) (xy 124.794342 109.010252) (xy 124.910252 108.894342) (xy 124.910256 108.894337) (xy 124.995052 108.754065) (xy 125.04382 108.597562) (xy 125.05 108.529556) (xy 125.05 108.443053) (xy 128.2 108.443053) (xy 128.210613 108.531443) (xy 128.266079 108.672095) (xy 128.357435 108.792564) (xy 128.477904 108.88392) (xy 128.618556 108.939386) (xy 128.706946 108.95) (xy 128.8 108.95) (xy 129.2 108.95) (xy 129.293054 108.95) (xy 129.381443 108.939386) (xy 129.522095 108.88392) (xy 129.642564 108.792564) (xy 129.73392 108.672095) (xy 129.789386 108.531443) (xy 129.8 108.443053) (xy 129.8 108.2) (xy 129.2 108.2) (xy 129.2 108.95) (xy 128.8 108.95) (xy 128.8 108.2) (xy 128.2 108.2) (xy 128.2 108.443053) (xy 125.05 108.443053) (xy 125.05 108.2) (xy 124.2 108.2) (xy 124.2 109.149999) (xy 123.799999 109.149999) (xy 123.8 109.149998) (xy 123.8 108.2) (xy 122.950001 108.2) (xy 122.950001 108.529566) (xy 121.0505 108.529566) (xy 121.0505 107.470443) (xy 122.95 107.470443) (xy 122.95 107.8) (xy 123.8 107.8) (xy 124.2 107.8) (xy 125.049999 107.8) (xy 125.049999 107.556946) (xy 128.2 107.556946) (xy 128.2 107.8) (xy 128.8 107.8) (xy 129.2 107.8) (xy 129.8 107.8) (xy 129.8 107.556949) (xy 129.799999 107.556943) (xy 129.799994 107.556898) (xy 130.1995 107.556898) (xy 130.1995 108.443102) (xy 130.205126 108.489954) (xy 130.210122 108.531561) (xy 130.265639 108.672343) (xy 130.357077 108.792922) (xy 130.477656 108.88436) (xy 130.477657 108.88436) (xy 130.477658 108.884361) (xy 130.618436 108.939877) (xy 130.706898 108.9505) (xy 130.706903 108.9505) (xy 131.293097 108.9505) (xy 131.293102 108.9505) (xy 131.381564 108.939877) (xy 131.522342 108.884361) (xy 131.642922 108.792922) (xy 131.734361 108.672342) (xy 131.789877 108.531564) (xy 131.8005 108.443102) (xy 131.8005 107.556898) (xy 131.789877 107.468436) (xy 131.734361 107.327658) (xy 131.73436 107.327657) (xy 131.73436 107.327656) (xy 131.642922 107.207077) (xy 131.522343 107.115639) (xy 131.426192 107.077722) (xy 131.381564 107.060123) (xy 131.381563 107.060122) (xy 131.381561 107.060122) (xy 131.335926 107.054642) (xy 131.293102 107.0495) (xy 130.706898 107.0495) (xy 130.667853 107.054188) (xy 130.618438 107.060122) (xy 130.477656 107.115639) (xy 130.357077 107.207077) (xy 130.265639 107.327656) (xy 130.210122 107.468438) (xy 130.204188 107.517853) (xy 130.1995 107.556898) (xy 129.799994 107.556898) (xy 129.789386 107.468556) (xy 129.73392 107.327904) (xy 129.642564 107.207435) (xy 129.522095 107.116079) (xy 129.381443 107.060613) (xy 129.293054 107.05) (xy 129.2 107.05) (xy 129.2 107.8) (xy 128.8 107.8) (xy 128.8 107.05) (xy 128.706946 107.05) (xy 128.618556 107.060613) (xy 128.477904 107.116079) (xy 128.357435 107.207435) (xy 128.266079 107.327904) (xy 128.210613 107.468556) (xy 128.2 107.556946) (xy 125.049999 107.556946) (xy 125.049999 107.470433) (xy 125.043821 107.402438) (xy 125.043818 107.402427) (xy 124.995055 107.245939) (xy 124.995053 107.245935) (xy 124.910256 107.105662) (xy 124.910252 107.105657) (xy 124.794342 106.989747) (xy 124.794337 106.989743) (xy 124.654065 106.904947) (xy 124.497562 106.856179) (xy 124.429556 106.85) (xy 124.2 106.85) (xy 124.2 107.8) (xy 123.8 107.8) (xy 123.8 106.85) (xy 123.570433 106.85) (xy 123.502438 106.856178) (xy 123.502427 106.856181) (xy 123.345939 106.904944) (xy 123.345935 106.904946) (xy 123.205662 106.989743) (xy 123.205657 106.989747) (xy 123.089747 107.105657) (xy 123.089743 107.105662) (xy 123.004947 107.245934) (xy 122.956179 107.402437) (xy 122.95 107.470443) (xy 121.0505 107.470443) (xy 121.0505 107.470406) (xy 121.044315 107.402343) (xy 120.995512 107.24573) (xy 120.995511 107.245727) (xy 120.910651 107.105351) (xy 120.910648 107.105347) (xy 120.794652 106.989351) (xy 120.794648 106.989348) (xy 120.654272 106.904488) (xy 120.654263 106.904485) (xy 120.497664 106.855687) (xy 120.497662 106.855686) (xy 120.497657 106.855685) (xy 120.429594 106.8495) (xy 119.570406 106.8495) (xy 119.502343 106.855685) (xy 119.502339 106.855686) (xy 119.502335 106.855687) (xy 119.345736 106.904485) (xy 119.345727 106.904488) (xy 119.205351 106.989348) (xy 119.205347 106.989351) (xy 119.089351 107.105347) (xy 119.089348 107.105351) (xy 119.004488 107.245727) (xy 119.004485 107.245736) (xy 118.978881 107.327904) (xy 118.955685 107.402343) (xy 118.9495 107.470406) (xy 116.399999 107.470406) (xy 116.399999 107.410675) (xy 116.384557 107.293371) (xy 116.384555 107.293366) (xy 116.3241 107.147414) (xy 116.227924 107.022075) (xy 116.102586 106.925899) (xy 115.956634 106.865445) (xy 115.95663 106.865444) (xy 115.83933 106.85) (xy 115.7 106.85) (xy 115.7 107.8) (xy 115.3 107.8) (xy 115.3 106.85) (xy 115.160676 106.85) (xy 115.043371 106.865442) (xy 115.043366 106.865444) (xy 114.897414 106.925899) (xy 114.772075 107.022075) (xy 114.675899 107.147413) (xy 114.615445 107.293365) (xy 114.615444 107.293369) (xy 114.6 107.410669) (xy 113.399998 107.410669) (xy 113.384557 107.293371) (xy 113.384555 107.293366) (xy 113.3241 107.147414) (xy 113.227924 107.022075) (xy 113.102586 106.925899) (xy 112.956634 106.865445) (xy 112.95663 106.865444) (xy 112.83933 106.85) (xy 112.7 106.85) (xy 112.7 107.8) (xy 112.3 107.8) (xy 112.3 106.85) (xy 112.160676 106.85) (xy 112.043371 106.865442) (xy 112.043366 106.865444) (xy 111.897414 106.925899) (xy 111.772075 107.022075) (xy 111.675899 107.147413) (xy 111.615445 107.293365) (xy 111.615444 107.293369) (xy 111.6 107.410669) (xy 106.15 107.410669) (xy 106.15 106.93) (xy 105.46188 106.93) (xy 105.465925 106.922993) (xy 105.5 106.795826) (xy 105.5 106.664174) (xy 105.465925 106.537007) (xy 105.46188 106.53) (xy 106.149999 106.53) (xy 106.149999 105.835214) (xy 106.149997 105.835191) (xy 106.147091 105.81013) (xy 106.14709 105.810126) (xy 106.101788 105.707525) (xy 106.101785 105.70752) (xy 106.022479 105.628214) (xy 106.022474 105.628211) (xy 105.919876 105.58291) (xy 105.894794 105.58) (xy 105.2 105.58) (xy 105.2 106.26812) (xy 105.192993 106.264075) (xy 105.065826 106.23) (xy 104.934174 106.23) (xy 104.807007 106.264075) (xy 104.8 106.26812) (xy 104.8 105.58) (xy 104.105214 105.58) (xy 104.105191 105.580002) (xy 104.08013 105.582908) (xy 104.080126 105.582909) (xy 103.977525 105.628211) (xy 103.97752 105.628214) (xy 103.898214 105.70752) (xy 103.898211 105.707525) (xy 103.85291 105.810122) (xy 103.85291 105.810124) (xy 103.85 105.835205) (xy 103.85 106.53) (xy 104.53812 106.53) (xy 104.534075 106.537007) (xy 104.5 106.664174) (xy 104.5 106.795826) (xy 104.534075 106.922993) (xy 104.53812 106.93) (xy 103.850001 106.93) (xy 103.850001 107.624785) (xy 103.850002 107.624808) (xy 103.852908 107.649869) (xy 103.852909 107.649873) (xy 103.898211 107.752474) (xy 103.898214 107.752479) (xy 103.97752 107.831785) (xy 103.977525 107.831788) (xy 104.080123 107.877089) (xy 104.105206 107.879999) (xy 104.846028 107.879999) (xy 104.913067 107.899683) (xy 104.958822 107.952487) (xy 104.968766 108.021646) (xy 104.939741 108.085202) (xy 104.880963 108.122976) (xy 104.865427 108.126472) (xy 104.730589 108.147829) (xy 104.558363 108.203787) (xy 104.55836 108.203788) (xy 104.397002 108.286006) (xy 104.250505 108.392441) (xy 104.2505 108.392445) (xy 104.122445 108.5205) (xy 104.122441 108.520505) (xy 104.016006 108.667002) (xy 103.933788 108.82836) (xy 103.933787 108.828363) (xy 103.877829 109.000589) (xy 103.8495 109.179448) (xy 101.5 109.179448) (xy 101.5 105.354) (xy 101.519685 105.286961) (xy 101.572489 105.241206) (xy 101.624 105.23) (xy 141.376 105.23)
+			(pts (xy 161.339712 111.505023) (xy 161.361437 111.511402) (xy 161.372766 111.517863) (xy 161.382157 111.519571) (xy 161.411121 111.539739) (xy 161.413906 111.542339) (xy 161.428775 111.558965) (xy 161.727536 111.960556) (xy 161.744358 111.991583) (xy 161.746475 111.997311) (xy 161.751252 112.067017) (xy 161.717584 112.12824) (xy 161.656162 112.161542) (xy 161.586485 112.15635) (xy 161.586483 112.156349) (xy 161.580957 112.154269) (xy 161.549714 112.137022) (xy 161.522098 112.11608) (xy 161.381441 112.060612) (xy 161.327933 112.054188) (xy 161.293054 112.05) (xy 161.293049 112.05) (xy 161.2 112.05) (xy 161.2 112.8) (xy 161.8 112.8) (xy 161.8 112.556946) (xy 161.789386 112.468556) (xy 161.78202 112.449879) (xy 161.780524 112.433308) (xy 161.773877 112.415532) (xy 161.773328 112.409447) (xy 161.776791 112.391966) (xy 161.775738 112.380295) (xy 161.781164 112.369901) (xy 161.786909 112.34091) (xy 161.807407 112.319635) (xy 161.808074 112.318359) (xy 161.811186 112.315241) (xy 161.814559 112.31198) (xy 161.815013 112.311741) (xy 161.835388 112.290596) (xy 161.871813 112.28196) (xy 161.876439 112.279535) (xy 161.880519 112.279896) (xy 161.903373 112.274478) (xy 161.931615 112.284418) (xy 161.946037 112.285695) (xy 161.955012 112.292653) (xy 161.969279 112.297675) (xy 161.969282 112.297677) (xy 161.973204 112.300501) (xy 162.000236 112.327115) (xy 162.164346 112.547709) (xy 162.181167 112.578732) (xy 162.191809 112.607527) (xy 162.1995 112.650514) (xy 162.1995 113.443102) (xy 162.205126 113.489954) (xy 162.210122 113.531561) (xy 162.210122 113.531563) (xy 162.210123 113.531564) (xy 162.213885 113.541106) (xy 162.213888 113.541115) (xy 162.227721 113.576191) (xy 162.227721 113.576192) (xy 162.265637 113.672339) (xy 162.26564 113.672345) (xy 162.357076 113.792922) (xy 162.470904 113.87924) (xy 162.477656 113.88436) (xy 162.477657 113.88436) (xy 162.477876 113.884526) (xy 162.480596 113.885519) (xy 162.618436 113.939877) (xy 162.706898 113.9505) (xy 162.706903 113.9505) (xy 163.293097 113.9505) (xy 163.293102 113.9505) (xy 163.381564 113.939877) (xy 163.522342 113.884361) (xy 163.642922 113.792922) (xy 163.734361 113.672342) (xy 163.789877 113.531564) (xy 163.8005 113.443102) (xy 163.8005 112.556898) (xy 163.789877 112.468436) (xy 163.734361 112.327658) (xy 163.73436 112.327657) (xy 163.73436 112.327656) (xy 163.73063 112.322737) (xy 163.730318 112.32214) (xy 163.72924 112.320904) (xy 163.642922 112.207076) (xy 163.522345 112.11564) (xy 163.522339 112.115637) (xy 163.426193 112.077721) (xy 163.426191 112.077721) (xy 163.382543 112.060508) (xy 163.380583 112.059716) (xy 163.380311 112.059603) (xy 163.374199 112.059238) (xy 163.335926 112.054642) (xy 163.335925 112.054641) (xy 163.30822 112.051315) (xy 163.293102 112.0495) (xy 163.293098 112.0495) (xy 162.872185 112.0495) (xy 162.872182 112.049499) (xy 162.872181 112.0495) (xy 162.837247 112.044476) (xy 162.815521 112.038096) (xy 162.76584 112.00976) (xy 162.763055 112.00716) (xy 162.757198 112.000612) (xy 162.756744 112.00032) (xy 162.756542 111.999878) (xy 162.748193 111.990543) (xy 162.541206 111.712313) (xy 162.52439 111.681299) (xy 162.519968 111.669335) (xy 162.518903 111.653803) (xy 162.512968 111.639409) (xy 162.516562 111.61966) (xy 162.51519 111.599634) (xy 162.522692 111.58599) (xy 162.525481 111.57067) (xy 162.539182 111.555999) (xy 162.548855 111.538409) (xy 162.563201 111.530282) (xy 162.573172 111.519607) (xy 162.605799 111.506152) (xy 162.608097 111.505569) (xy 162.615061 111.503804) (xy 162.645538 111.5) (xy 166.35817 111.5) (xy 166.393106 111.505023) (xy 166.408104 111.509427) (xy 166.466855 111.547172) (xy 166.468042 111.548541) (xy 166.495518 111.603402) (xy 166.497163 111.61096) (xy 166.5 111.637331) (xy 166.5 161.89817) (xy 166.499999 161.898176) (xy 166.5 161.898179) (xy 166.494975 161.933114) (xy 166.49057 161.948112) (xy 166.452827 162.006855) (xy 166.452792 162.006885) (xy 166.452791 162.006887) (xy 166.452789 162.006887) (xy 166.451458 162.008042) (xy 166.396597 162.035518) (xy 166.389039 162.037163) (xy 166.362668 162.04) (xy 165.537529 162.04) (xy 165.508579 162.036573) (xy 165.480824 162.029909) (xy 165.453477 162.01982) (xy 165.441643 162.01379) (xy 165.441634 162.013786) (xy 165.269411 161.957828) (xy 165.14523 161.93816) (xy 165.125328 161.935007) (xy 165.113044 161.929184) (xy 165.091607 161.92458) (xy 165.085323 161.921601) (xy 165.072021 161.909737) (xy 165.062195 161.905079) (xy 165.056444 161.895843) (xy 165.033183 161.875096) (xy 165.014461 161.807781) (xy 165.035104 161.741031) (xy 165.06598 161.714663) (xy 165.074761 161.704119) (xy 165.080414 161.702337) (xy 165.086944 161.69676) (xy 165.092337 161.694298) (xy 165.124437 161.684625) (xy 165.269292 161.661683) (xy 165.269298 161.661681) (xy 165.441442 161.605749) (xy 165.441444 161.605748) (xy 165.441447 161.605747) (xy 165.602734 161.523565) (xy 165.749169 161.417176) (xy 165.877176 161.289169) (xy 165.983565 161.142734) (xy 166.065747 160.981447) (xy 166.065748 160.981444) (xy 166.080981 160.934563) (xy 166.084852 160.922646) (xy 166.121683 160.809293) (xy 166.132658 160.74) (xy 165.623731 160.74) (xy 165.615045 160.737449) (xy 165.606084 160.738738) (xy 165.582043 160.727759) (xy 165.556692 160.720315) (xy 165.550764 160.713474) (xy 165.542528 160.709713) (xy 165.528238 160.687478) (xy 165.510937 160.667511) (xy 165.508649 160.656996) (xy 165.504754 160.650935) (xy 165.503325 160.632521) (xy 165.499731 160.616) (xy 165.499731 160.606829) (xy 165.5 160.605826) (xy 165.5 160.474174) (xy 165.499731 160.47317) (xy 165.499731 160.464) (xy 165.507379 160.437952) (xy 165.511567 160.411131) (xy 165.517077 160.404924) (xy 165.519416 160.396961) (xy 165.53993 160.379184) (xy 165.557956 160.358883) (xy 165.566037 160.356562) (xy 165.57222 160.351206) (xy 165.597217 160.347611) (xy 165.623731 160.34) (xy 166.132658 160.34) (xy 166.121683 160.270705) (xy 166.104965 160.219253) (xy 166.065746 160.09855) (xy 166.061579 160.090373) (xy 166.003817 159.977011) (xy 165.983565 159.937265) (xy 165.877176 159.79083) (xy 165.749169 159.662823) (xy 165.602734 159.556434) (xy 165.602727 159.55643) (xy 165.441447 159.474252) (xy 165.441371 159.474226) (xy 165.269295 159.418317) (xy 165.269296 159.418317) (xy 165.12533 159.395515) (xy 165.113062 159.389699) (xy 165.091606 159.385087) (xy 165.085326 159.38211) (xy 165.072023 159.370245) (xy 165.062195 159.365586) (xy 165.056443 159.356348) (xy 165.033184 159.335603) (xy 165.014462 159.268288) (xy 165.035105 159.201538) (xy 165.066036 159.175118) (xy 165.074807 159.164595) (xy 165.080428 159.162826) (xy 165.086926 159.157275) (xy 165.092327 159.154809) (xy 165.124428 159.145133) (xy 165.269409 159.122171) (xy 165.441639 159.066211) (xy 165.602994 158.983996) (xy 165.749501 158.877553) (xy 165.877553 158.749501) (xy 165.983996 158.602994) (xy 166.066211 158.441639) (xy 166.122171 158.269409) (xy 166.130439 158.217201) (xy 166.136765 158.177262) (xy 166.136765 158.177259) (xy 166.1505 158.090551) (xy 166.1505 157.909448) (xy 166.132043 157.792922) (xy 166.122171 157.730591) (xy 166.121723 157.729213) (xy 166.070393 157.571232) (xy 166.070392 157.571231) (xy 166.066211 157.558361) (xy 166.066211 157.55836) (xy 166.018347 157.464423) (xy 165.983996 157.397006) (xy 165.901839 157.283926) (xy 165.889698 157.267215) (xy 165.87756 157.250507) (xy 165.877554 157.2505) (xy 165.877546 157.250491) (xy 165.749507 157.122452) (xy 165.749498 157.122444) (xy 165.749474 157.122426) (xy 165.613605 157.023712) (xy 165.613591 157.023703) (xy 165.602997 157.016006) (xy 165.602996 157.016005) (xy 165.602994 157.016004) (xy 165.586383 157.00754) (xy 165.551301 156.989664) (xy 165.5513 156.989664) (xy 165.441639 156.933788) (xy 165.441636 156.933787) (xy 165.441633 156.933786) (xy 165.441631 156.933785) (xy 165.441612 156.933778) (xy 165.269412 156.877829) (xy 165.269413 156.877829) (xy 165.126931 156.855262) (xy 165.114645 156.849438) (xy 165.093207 156.844834) (xy 165.086927 156.841857) (xy 165.073624 156.829992) (xy 165.063796 156.825333) (xy 165.058044 156.816095) (xy 165.034785 156.79535) (xy 165.016063 156.728035) (xy 165.036706 156.661285) (xy 165.067582 156.634917) (xy 165.076363 156.624373) (xy 165.082016 156.622591) (xy 165.088549 156.617013) (xy 165.093937 156.614553) (xy 165.126032 156.604879) (xy 165.179425 156.596422) (xy 165.269409 156.582171) (xy 165.441639 156.526211) (xy 165.602994 156.443996) (xy 165.749501 156.337553) (xy 165.877553 156.209501) (xy 165.983996 156.062994) (xy 166.066211 155.901639) (xy 166.122171 155.729409) (xy 166.136765 155.637259) (xy 166.1505 155.550551) (xy 166.1505 155.369448) (xy 166.122738 155.194173) (xy 166.122171 155.190591) (xy 166.090628 155.093509) (xy 166.079398 155.058947) (xy 166.06622 155.018386) (xy 166.066212 155.018363) (xy 166.066211 155.01836) (xy 166.030768 154.948801) (xy 165.983996 154.857006) (xy 165.942216 154.7995) (xy 165.877558 154.710505) (xy 165.877554 154.7105) (xy 165.87755 154.710496) (xy 165.877548 154.710493) (xy 165.749507 154.582452) (xy 165.749498 154.582444) (xy 165.749474 154.582426) (xy 165.613587 154.483699) (xy 165.613574 154.48369) (xy 165.602997 154.476006) (xy 165.602996 154.476005) (xy 165.602994 154.476004) (xy 165.596921 154.472909) (xy 165.596917 154.472907) (xy 165.543196 154.445535) (xy 165.543196 154.445534) (xy 165.543194 154.445534) (xy 165.441639 154.393788) (xy 165.441635 154.393786) (xy 165.441612 154.393778) (xy 165.269412 154.337829) (xy 165.269413 154.337829) (xy 165.155337 154.319761) (xy 165.15107 154.31831) (xy 165.148559 154.318494) (xy 165.121607 154.30933) (xy 165.116088 154.306713) (xy 165.115556 154.306238) (xy 165.115472 154.30621) (xy 165.110346 154.303421) (xy 165.09292 154.286047) (xy 165.063947 154.260204) (xy 165.062776 154.255994) (xy 165.060866 154.25409) (xy 165.055734 154.230667) (xy 165.045229 154.192888) (xy 165.046532 154.188672) (xy 165.045912 154.185839) (xy 165.054883 154.161673) (xy 165.065875 154.126138) (xy 165.069077 154.123442) (xy 165.07023 154.120338) (xy 165.09377 154.10266) (xy 165.119332 154.081148) (xy 165.119892 154.080902) (xy 165.123849 154.080073) (xy 165.126101 154.078383) (xy 165.135056 154.077728) (xy 165.169609 154.070499) (xy 165.89488 154.070499) (xy 165.894978 154.070492) (xy 165.895733 154.070398) (xy 165.919987 154.067586) (xy 165.919987 154.067585) (xy 165.91999 154.067585) (xy 165.919991 154.067585) (xy 165.919991 154.067584) (xy 165.920102 154.067572) (xy 165.921862 154.066758) (xy 166.022765 154.022206) (xy 166.102206 153.942765) (xy 166.147585 153.839991) (xy 166.1505 153.814865) (xy 166.150499 152.025136) (xy 166.149256 152.014416) (xy 166.147586 152.000012) (xy 166.147585 152.00001) (xy 166.147585 152.000009) (xy 166.102206 151.897235) (xy 166.022765 151.817794) (xy 166.022763 151.817793) (xy 166.022762 151.817792) (xy 166.000107 151.807789) (xy 165.981374 151.799518) (xy 165.919993 151.772415) (xy 165.919994 151.772415) (xy 165.894868 151.7695) (xy 165.894865 151.7695) (xy 164.105143 151.7695) (xy 164.105127 151.769501) (xy 164.105113 151.769502) (xy 164.087255 151.771573) (xy 164.080012 151.772413) (xy 164.080011 151.772413) (xy 164.080005 151.772414) (xy 164.079559 151.772547) (xy 164.077303 151.773609) (xy 163.977236 151.817792) (xy 163.897793 151.897234) (xy 163.852414 152.000005) (xy 163.851844 152.00271) (xy 163.851589 152.007124) (xy 163.8495 152.025127) (xy 163.8495 153.228557) (xy 163.849499 153.228563) (xy 163.8495 153.228566) (xy 163.844475 153.263501) (xy 163.84007 153.278499) (xy 163.802307 153.33726) (xy 163.798924 153.340192) (xy 163.748973 153.366482) (xy 163.746002 153.367256) (xy 163.724783 153.370854) (xy 154.159267 154.148093) (xy 154.159263 154.148093) (xy 154.154252 154.1485) (xy 154.117773 154.1485) (xy 154.101896 154.152752) (xy 154.097177 154.153135) (xy 154.090698 154.153662) (xy 154.090696 154.153661) (xy 154.078649 154.154641) (xy 154.077516 154.154734) (xy 154.077421 154.154737) (xy 154.077422 154.154742) (xy 154.077238 154.154756) (xy 154.063889 154.161801) (xy 154.055854 154.164668) (xy 154.046282 154.167653) (xy 154.015911 154.175792) (xy 154.015908 154.175793) (xy 154.011393 154.1784) (xy 154.011081 154.17858) (xy 154.001496 154.184074) (xy 153.991097 154.187788) (xy 153.991095 154.187788) (xy 153.986203 154.189534) (xy 153.986194 154.189539) (xy 153.960323 154.207416) (xy 153.955939 154.210189) (xy 153.955907 154.210208) (xy 153.953954 154.211445) (xy 153.949677 154.214031) (xy 153.946993 154.215581) (xy 153.934057 154.219047) (xy 153.920892 154.232211) (xy 153.903726 154.246526) (xy 153.899442 154.249487) (xy 153.899441 154.249487) (xy 153.87908 154.273448) (xy 153.872297 154.280806) (xy 153.868878 154.284226) (xy 153.867143 154.285962) (xy 151.266224 156.88688) (xy 151.237969 156.908032) (xy 151.222576 156.916437) (xy 151.157823 156.93149) (xy 151.145289 156.930951) (xy 151.113954 156.925521) (xy 150.904873 156.86081) (xy 150.904872 156.86081) (xy 150.872984 156.845683) (xy 150.859957 156.837041) (xy 150.814974 156.783578) (xy 150.81497 156.783569) (xy 150.810965 156.774449) (xy 150.8005 156.724591) (xy 150.8005 156.556903) (xy 150.8005 156.556901) (xy 150.8005 156.556898) (xy 150.789877 156.468436) (xy 150.734361 156.327658) (xy 150.73436 156.327657) (xy 150.73436 156.327656) (xy 150.73063 156.322737) (xy 150.730318 156.32214) (xy 150.72924 156.320904) (xy 150.642922 156.207076) (xy 150.522345 156.11564) (xy 150.522339 156.115637) (xy 150.426193 156.077721) (xy 150.426191 156.077721) (xy 150.382543 156.060508) (xy 150.380583 156.059716) (xy 150.380311 156.059603) (xy 150.374199 156.059238) (xy 150.334389 156.054458) (xy 150.293102 156.0495) (xy 150.293097 156.0495) (xy 149.706901 156.0495) (xy 149.706898 156.0495) (xy 149.69656 156.050741) (xy 149.667853 156.054187) (xy 149.667853 156.054188) (xy 149.665605 156.054458) (xy 149.618439 156.060121) (xy 149.477653 156.11564) (xy 149.357076 156.207076) (xy 149.26564 156.327653) (xy 149.265541 156.327904) (xy 149.210122 156.468438) (xy 149.204601 156.514416) (xy 149.200062 156.552224) (xy 149.1995 156.556901) (xy 149.1995 157.164915) (xy 149.195234 157.197161) (xy 149.194874 157.198495) (xy 149.190855 157.212184) (xy 149.189455 157.218615) (xy 149.188663 157.22156) (xy 149.171975 157.248858) (xy 149.15661 157.276995) (xy 149.024288 157.409317) (xy 148.996038 157.430466) (xy 148.986111 157.435887) (xy 148.917838 157.450741) (xy 148.852373 157.426327) (xy 148.8105 157.370395) (xy 148.807813 157.363189) (xy 148.8 157.319869) (xy 148.8 157.2) (xy 148.2 157.2) (xy 148.2 157.95) (xy 148.206549 157.956549) (xy 148.212202 157.958209) (xy 148.227194 157.967843) (xy 148.244296 157.972863) (xy 148.255976 157.986339) (xy 148.27098 157.995982) (xy 148.278384 158.012194) (xy 148.290056 158.025662) (xy 148.292595 158.043313) (xy 148.300005 158.059537) (xy 148.297468 158.07718) (xy 148.300007 158.09482) (xy 148.290066 158.128685) (xy 148.286881 158.135661) (xy 148.261763 158.171842) (xy 147.679526 158.754078) (xy 147.679522 158.754083) (xy 147.679521 158.754084) (xy 147.62679 158.845414) (xy 147.62679 158.845415) (xy 147.611905 158.900972) (xy 147.611905 158.900973) (xy 147.5995 158.947269) (xy 147.5995 159.965366) (xy 147.599499 159.965372) (xy 147.5995 159.965375) (xy 147.594475 160.00031) (xy 147.59007 160.015308) (xy 147.552304 160.074071) (xy 147.552292 160.074081) (xy 147.552291 160.074083) (xy 147.552289 160.074083) (xy 147.542632 160.082453) (xy 147.506916 160.104099) (xy 147.477663 160.115635) (xy 147.477657 160.115638) (xy 147.357076 160.207076) (xy 147.26564 160.327653) (xy 147.210121 160.468439) (xy 147.2049 160.51192) (xy 147.204188 160.517853) (xy 147.1995 160.556898) (xy 147.1995 161.443102) (xy 147.202543 161.46844) (xy 147.20533 161.49165) (xy 147.209238 161.524198) (xy 147.209603 161.530312) (xy 147.209728 161.530613) (xy 147.210521 161.532574) (xy 147.220251 161.557247) (xy 147.220251 161.557249) (xy 147.261435 161.661683) (xy 147.265639 161.672343) (xy 147.357078 161.792922) (xy 147.37488 161.806422) (xy 147.39968 161.831532) (xy 147.406403 161.84063) (xy 147.430414 161.906245) (xy 147.415138 161.974424) (xy 147.365442 162.023514) (xy 147.362326 162.025191) (xy 147.303561 162.04) (xy 144.69443 162.04) (xy 144.659489 162.034975) (xy 144.64449 162.03057) (xy 144.629502 162.02094) (xy 144.612424 162.015932) (xy 144.585744 161.992827) (xy 144.584557 161.991458) (xy 144.557077 161.936583) (xy 144.555432 161.929021) (xy 144.5526 161.902668) (xy 144.5526 159.335627) (xy 144.557622 159.300694) (xy 144.565034 159.275449) (xy 144.596336 159.222699) (xy 144.601782 159.217254) (xy 144.63262 159.186416) (xy 144.711677 159.049484) (xy 144.7526 158.896757) (xy 144.7526 158.738643) (xy 144.711677 158.585916) (xy 144.664686 158.504524) (xy 144.664686 158.504523) (xy 144.649211 158.47772) (xy 144.632624 158.44899) (xy 144.632618 158.448982) (xy 144.632614 158.448978) (xy 144.632613 158.448976) (xy 144.520822 158.337185) (xy 144.52082 158.337184) (xy 144.520817 158.337181) (xy 144.520809 158.337175) (xy 144.494247 158.32184) (xy 144.383907 158.258135) (xy 144.383883 158.258122) (xy 144.272079 158.228164) (xy 144.231157 158.2172) (xy 144.231156 158.2172) (xy 144.073043 158.2172) (xy 143.920318 158.258122) (xy 143.920311 158.258124) (xy 143.92031 158.258125) (xy 143.9203 158.25813) (xy 143.783398 158.33717) (xy 143.783394 158.337172) (xy 143.78339 158.337175) (xy 143.783382 158.337181) (xy 143.783378 158.337184) (xy 143.783376 158.337185) (xy 143.671585 158.448976) (xy 143.671584 158.448978) (xy 143.671581 158.448981) (xy 143.671581 158.448982) (xy 143.671575 158.44899) (xy 143.671572 158.448994) (xy 143.67157 158.448998) (xy 143.59253 158.5859) (xy 143.592525 158.58591) (xy 143.592524 158.585911) (xy 143.592522 158.585918) (xy 143.5516 158.738643) (xy 143.5516 158.896756) (xy 143.552727 158.900962) (xy 143.552728 158.900975) (xy 143.552731 158.900975) (xy 143.552731 158.900976) (xy 143.564152 158.943601) (xy 143.592523 159.049484) (xy 143.592524 159.049487) (xy 143.592525 159.049488) (xy 143.59253 159.049498) (xy 143.647662 159.14499) (xy 143.671575 159.186409) (xy 143.671581 159.186417) (xy 143.702675 159.217511) (xy 143.706557 159.222697) (xy 143.723825 159.245764) (xy 143.736432 159.268852) (xy 143.7516 159.328279) (xy 143.7516 161.89817) (xy 143.746575 161.933114) (xy 143.74217 161.948112) (xy 143.704427 162.006855) (xy 143.703058 162.008042) (xy 143.648197 162.035518) (xy 143.640639 162.037163) (xy 143.614268 162.04) (xy 141.94233 162.04) (xy 141.942325 162.039999) (xy 141.942323 162.04) (xy 141.907389 162.034975) (xy 141.89239 162.03057) (xy 141.833644 161.992827) (xy 141.833615 161.992793) (xy 141.833614 161.992793) (xy 141.833613 161.992791) (xy 141.832457 161.991458) (xy 141.804977 161.936583) (xy 141.803332 161.929021) (xy 141.8005 161.902668) (xy 141.8005 161.556903) (xy 141.8005 161.556898) (xy 141.789877 161.468436) (xy 141.734361 161.327658) (xy 141.73436 161.327657) (xy 141.73436 161.327656) (xy 141.730629 161.322736) (xy 141.728661 161.318969) (xy 141.727366 161.316994) (xy 141.727562 161.316865) (xy 141.725815 161.313521) (xy 141.723099 161.299835) (xy 141.709536 161.274995) (xy 141.71452 161.205303) (xy 141.72017 161.192434) (xy 141.72255 161.187752) (xy 141.722553 161.18775) (xy 141.773439 161.087674) (xy 141.793124 161.020635) (xy 141.8055 160.934563) (xy 141.8055 158.1795) (xy 141.825185 158.112461) (xy 141.877989 158.066706) (xy 141.9295 158.0555) (xy 142.212667 158.0555) (xy 142.212668 158.0555) (xy 142.245345 158.053747) (xy 142.271716 158.05091) (xy 142.30401 158.045674) (xy 142.311568 158.044029) (xy 142.383402 158.018675) (xy 142.438263 157.991199) (xy 142.438267 157.991195) (xy 142.43827 157.991195) (xy 142.477554 157.964931) (xy 142.501591 157.948861) (xy 142.50296 157.947674) (xy 142.533766 157.916849) (xy 142.556871 157.890169) (xy 142.568235 157.876238) (xy 142.583124 157.84693) (xy 142.589346 157.83608) (xy 142.591568 157.832623) (xy 142.597587 157.823255) (xy 142.633689 157.744203) (xy 142.638094 157.729205) (xy 142.647364 157.686598) (xy 142.652389 157.651654) (xy 142.6555 157.60817) (xy 142.6555 157.443053) (xy 147.2 157.443053) (xy 147.201023 157.451571) (xy 147.210612 157.531441) (xy 147.266078 157.672094) (xy 147.266079 157.672095) (xy 147.357435 157.792564) (xy 147.477903 157.883919) (xy 147.477904 157.88392) (xy 147.618556 157.939386) (xy 147.706946 157.95) (xy 147.8 157.95) (xy 147.8 157.2) (xy 147.2 157.2) (xy 147.2 157.443053) (xy 142.6555 157.443053) (xy 142.6555 156.556946) (xy 147.2 156.556946) (xy 147.2 156.8) (xy 147.8 156.8) (xy 148.2 156.8) (xy 148.8 156.8) (xy 148.8 156.556946) (xy 148.789386 156.468556) (xy 148.73392 156.327904) (xy 148.642564 156.207435) (xy 148.522095 156.116079) (xy 148.522096 156.116079) (xy 148.381441 156.060612) (xy 148.327933 156.054188) (xy 148.293054 156.05) (xy 148.293049 156.05) (xy 148.2 156.05) (xy 148.2 156.8) (xy 147.8 156.8) (xy 147.8 156.05) (xy 147.706952 156.05) (xy 147.706946 156.05) (xy 147.669818 156.054458) (xy 147.618557 156.060612) (xy 147.477904 156.116078) (xy 147.477903 156.116079) (xy 147.357435 156.207435) (xy 147.266079 156.327903) (xy 147.266078 156.327904) (xy 147.210612 156.468557) (xy 147.205106 156.514417) (xy 147.2 156.556946) (xy 142.6555 156.556946) (xy 142.6555 156.101231) (xy 142.655141 156.094543) (xy 142.671205 156.026547) (xy 142.721481 155.978028) (xy 142.75389 155.966461) (xy 142.766293 155.9639) (xy 142.776127 155.9639) (xy 142.807893 155.955387) (xy 142.814769 155.953821) (xy 142.819272 155.952885) (xy 142.849319 155.947229) (xy 142.849323 155.947226) (xy 142.850365 155.946886) (xy 142.858131 155.943588) (xy 142.868912 155.939593) (xy 142.876963 155.937031) (xy 142.877981 155.936609) (xy 142.877982 155.936608) (xy 142.877987 155.936607) (xy 142.904466 155.921317) (xy 142.908525 155.919075) (xy 142.91268 155.916882) (xy 142.916802 155.914805) (xy 144.028181 155.380827) (xy 144.031647 155.37923) (xy 144.072213 155.361333) (xy 144.072223 155.361324) (xy 144.077218 155.358287) (xy 144.079007 155.357016) (xy 144.0827 155.354715) (xy 144.083254 155.354374) (xy 144.083269 155.35436) (xy 144.083271 155.35436) (xy 144.116153 155.32611) (xy 144.117607 155.324882) (xy 144.119117 155.323627) (xy 144.120624 155.322395) (xy 144.284507 155.190591) (xy 158.318838 143.903361) (xy 158.349205 143.885385) (xy 158.363654 143.879416) (xy 158.433124 143.872018) (xy 158.445627 143.874286) (xy 158.468882 143.880901) (xy 158.469665 143.881209) (xy 158.476448 143.884431) (xy 158.484554 143.887081) (xy 158.581412 143.925276) (xy 158.618436 143.939877) (xy 158.706898 143.9505) (xy 158.706903 143.9505) (xy 159.293097 143.9505) (xy 159.293102 143.9505) (xy 159.381564 143.939877) (xy 159.522342 143.884361) (xy 159.642922 143.792922) (xy 159.734361 143.672342) (xy 159.789877 143.531564) (xy 159.8005 143.443102) (xy 159.8005 142.852575) (xy 159.804758 142.820359) (xy 159.805124 142.818997) (xy 159.809103 142.805446) (xy 159.810426 142.79929) (xy 159.811245 142.796248) (xy 159.827867 142.769039) (xy 159.84308 142.741009) (xy 159.84466 142.739449) (xy 159.866913 142.717898) (xy 159.866914 142.717894) (xy 159.867688 142.717146) (xy 159.86906 142.715514) (xy 159.87385 142.710134) (xy 159.878764 142.704926) (xy 159.975214 142.608476) (xy 160.003465 142.587328) (xy 160.013392 142.581907) (xy 160.081664 142.567056) (xy 160.147128 142.591473) (xy 160.188994 142.647392) (xy 160.188998 142.647403) (xy 160.189 142.647406) (xy 160.189 142.647408) (xy 160.191676 142.65458) (xy 160.1995 142.697928) (xy 160.1995 143.443098) (xy 160.204602 143.485591) (xy 160.210121 143.531559) (xy 160.26564 143.672345) (xy 160.357076 143.792922) (xy 160.464371 143.874286) (xy 160.477656 143.88436) (xy 160.477657 143.88436) (xy 160.477876 143.884526) (xy 160.480596 143.885519) (xy 160.618436 143.939877) (xy 160.706898 143.9505) (xy 160.706903 143.9505) (xy 161.293097 143.9505) (xy 161.293102 143.9505) (xy 161.381564 143.939877) (xy 161.522342 143.884361) (xy 161.642922 143.792922) (xy 161.734361 143.672342) (xy 161.789877 143.531564) (xy 161.8005 143.443102) (xy 161.8005 142.556898) (xy 161.789877 142.468436) (xy 161.734361 142.327658) (xy 161.73436 142.327657) (xy 161.73436 142.327656) (xy 161.73063 142.322737) (xy 161.730318 142.32214) (xy 161.72924 142.320904) (xy 161.642922 142.207076) (xy 161.522345 142.11564) (xy 161.522339 142.115637) (xy 161.426193 142.077721) (xy 161.426191 142.077721) (xy 161.382543 142.060508) (xy 161.380583 142.059716) (xy 161.380311 142.059603) (xy 161.374199 142.059238) (xy 161.335926 142.054642) (xy 161.335925 142.054641) (xy 161.30822 142.051315) (xy 161.293102 142.0495) (xy 161.293098 142.0495) (xy 160.706901 142.0495) (xy 160.706898 142.0495) (xy 160.69656 142.050741) (xy 160.667853 142.054187) (xy 160.667853 142.054188) (xy 160.66192 142.0549) (xy 160.618439 142.060121) (xy 160.477653 142.11564) (xy 160.35708 142.207074) (xy 160.357074 142.20708) (xy 160.328433 142.244849) (xy 160.328432 142.244849) (xy 160.328432 142.24485) (xy 160.303321 142.269651) (xy 160.293374 142.277001) (xy 160.227758 142.30101) (xy 160.159579 142.285733) (xy 160.112104 142.238939) (xy 160.107102 142.230212) (xy 160.094909 142.200645) (xy 160.082307 142.153612) (xy 160.02958 142.062287) (xy 159.955013 141.98772) (xy 159.564821 141.597528) (xy 159.543674 141.569277) (xy 159.531067 141.546188) (xy 159.5159 141.486763) (xy 159.5159 141.435445) (xy 159.5159 141.435443) (xy 159.474977 141.282716) (xy 159.474973 141.282709) (xy 159.395924 141.14579) (xy 159.395918 141.145782) (xy 159.395914 141.145778) (xy 159.395913 141.145776) (xy 159.284122 141.033985) (xy 159.28412 141.033984) (xy 159.284117 141.033981) (xy 159.284109 141.033975) (xy 159.257547 141.01864) (xy 159.147207 140.954935) (xy 159.147183 140.954922) (xy 159.035379 140.924964) (xy 158.994457 140.914) (xy 158.994456 140.914) (xy 158.836343 140.914) (xy 158.683618 140.954922) (xy 158.683611 140.954924) (xy 158.68361 140.954925) (xy 158.6836 140.95493) (xy 158.546698 141.03397) (xy 158.546694 141.033972) (xy 158.54669 141.033975) (xy 158.546682 141.033981) (xy 158.546678 141.033984) (xy 158.546676 141.033985) (xy 158.434885 141.145776) (xy 158.434884 141.145778) (xy 158.434881 141.145781) (xy 158.434881 141.145782) (xy 158.434875 141.14579) (xy 158.434872 141.145794) (xy 158.43487 141.145798) (xy 158.35583 141.2827) (xy 158.355825 141.28271) (xy 158.355824 141.282711) (xy 158.355823 141.282715) (xy 158.355823 141.282716) (xy 158.3149 141.435443) (xy 158.3149 141.593556) (xy 158.315966 141.597533) (xy 158.355822 141.74628) (xy 158.355824 141.746287) (xy 158.355825 141.746288) (xy 158.35583 141.746298) (xy 158.41585 141.850256) (xy 158.434875 141.883209) (xy 158.434881 141.883217) (xy 158.434884 141.88322) (xy 158.434884 141.883221) (xy 158.472348 141.920684) (xy 158.47235 141.920687) (xy 158.472352 141.920688) (xy 158.493502 141.948943) (xy 158.500215 141.961238) (xy 158.515065 142.029512) (xy 158.490877 142.094664) (xy 158.48272 142.105631) (xy 158.45815 142.130432) (xy 158.357074 142.20708) (xy 158.26564 142.327653) (xy 158.210121 142.468439) (xy 158.204188 142.517854) (xy 158.1995 142.556901) (xy 158.1995 142.894001) (xy 158.199499 142.894004) (xy 158.1995 142.894006) (xy 158.194476 142.92894) (xy 158.188225 142.950226) (xy 158.150448 143.009003) (xy 158.131598 143.022166) (xy 158.129762 143.023521) (xy 158.111352 143.041261) (xy 158.107666 143.044671) (xy 158.10267 143.049109) (xy 158.098032 143.053031) (xy 145.362372 153.295794) (xy 145.332 153.313774) (xy 145.323062 153.317466) (xy 145.253585 153.324867) (xy 145.191136 153.293531) (xy 145.155543 153.233407) (xy 145.155698 153.171707) (xy 145.156887 153.167127) (xy 145.166418 153.142003) (xy 145.209237 153.05797) (xy 145.209239 153.057963) (xy 145.218419 153) (xy 144.375 153) (xy 144.375 153.349999) (xy 144.833449 153.349999) (xy 144.833454 153.349999) (xy 144.833454 153.349998) (xy 144.862248 153.345438) (xy 144.920474 153.336217) (xy 144.92721 153.336407) (xy 144.930944 153.335012) (xy 144.936321 153.334741) (xy 144.942898 153.334552) (xy 144.942899 153.334553) (xy 144.957029 153.334148) (xy 145.024603 153.351905) (xy 145.071851 153.403378) (xy 145.077075 153.433554) (xy 145.078428 153.436028) (xy 145.078159 153.439816) (xy 145.08377 153.472223) (xy 145.07416 153.496251) (xy 145.073489 153.505723) (xy 145.066786 153.514688) (xy 145.059537 153.532816) (xy 145.056239 153.537184) (xy 145.034992 153.559092) (xy 143.663941 154.661771) (xy 143.652366 154.670033) (xy 143.640394 154.677582) (xy 143.627958 154.684461) (xy 143.544274 154.724668) (xy 143.544273 154.72467) (xy 143.510609 154.735272) (xy 143.496912 154.737515) (xy 143.427573 154.728923) (xy 143.373886 154.684208) (xy 143.371601 154.680801) (xy 143.352012 154.630458) (xy 143.351921 154.629862) (xy 143.3505 154.611146) (xy 143.3505 153.516512) (xy 143.3505 153.516509) (xy 143.348663 153.504917) (xy 143.34816 153.469631) (xy 143.349939 153.455864) (xy 143.378052 153.3919) (xy 143.436281 153.353291) (xy 143.442965 153.351224) (xy 143.498989 153.347218) (xy 143.516547 153.349999) (xy 143.974999 153.349999) (xy 143.975 153.349998) (xy 143.975 153) (xy 143.13158 153) (xy 143.12726 153.005057) (xy 143.125497 153.0187) (xy 143.118324 153.035017) (xy 143.116041 153.052694) (xy 143.104557 153.066337) (xy 143.097381 153.082663) (xy 143.082523 153.092514) (xy 143.071048 153.106148) (xy 143.039157 153.121269) (xy 143.03248 153.123334) (xy 142.976447 153.127344) (xy 142.958489 153.1245) (xy 142.958488 153.1245) (xy 142.779201 153.1245) (xy 142.712162 153.104815) (xy 142.666407 153.052011) (xy 142.655933 152.995615) (xy 142.6555 152.995615) (xy 142.6555 152.993284) (xy 142.655433 152.992924) (xy 142.6555 152.991829) (xy 142.6555 152.367292) (xy 142.656638 152.363415) (xy 142.655747 152.359476) (xy 142.666399 152.330172) (xy 142.675185 152.300253) (xy 142.678237 152.297607) (xy 142.679618 152.293811) (xy 142.704426 152.274915) (xy 142.727989 152.254498) (xy 142.731986 152.253923) (xy 142.735201 152.251475) (xy 142.766281 152.248991) (xy 142.797147 152.244554) (xy 142.801979 152.24614) (xy 142.804848 152.245911) (xy 142.838012 152.257966) (xy 142.843592 152.260952) (xy 142.845286 152.261877) (xy 142.847085 152.262877) (xy 142.848841 152.263872) (xy 142.888059 152.286515) (xy 142.890446 152.287289) (xy 142.890447 152.287289) (xy 142.890465 152.287295) (xy 142.8907 152.287372) (xy 142.892237 152.28796) (xy 142.89234 152.288003) (xy 142.89289 152.28821) (xy 142.893012 152.288257) (xy 142.893121 152.28834) (xy 142.893655 152.288573) (xy 142.893862 152.288648) (xy 142.893951 152.28867) (xy 142.894147 152.288751) (xy 142.898418 152.290294) (xy 142.913469 152.293811) (xy 142.941563 152.300376) (xy 142.945356 152.301326) (xy 142.988173 152.3128) (xy 142.988175 152.3128) (xy 142.988522 152.312845) (xy 142.995082 152.312884) (xy 143.001102 152.314291) (xy 143.036947 152.313134) (xy 143.039305 152.313149) (xy 143.043162 152.314306) (xy 143.073501 152.31817) (xy 143.085637 152.321734) (xy 143.101168 152.331716) (xy 143.106226 152.333234) (xy 143.109523 152.337086) (xy 143.144414 152.35951) (xy 143.173436 152.423067) (xy 143.173437 152.42307) (xy 143.173912 152.426375) (xy 143.169383 152.481464) (xy 143.168789 152.483339) (xy 143.161064 152.502184) (xy 143.140762 152.542027) (xy 143.14076 152.542032) (xy 143.14076 152.542033) (xy 143.13158 152.599995) (xy 143.13158 152.599999) (xy 143.13158 152.6) (xy 145.21842 152.6) (xy 145.222132 152.591036) (xy 145.219595 152.587201) (xy 145.214322 152.574131) (xy 145.209239 152.542036) (xy 145.209237 152.542031) (xy 145.171452 152.467874) (xy 145.169418 152.462831) (xy 145.168958 152.458151) (xy 145.162542 152.439321) (xy 145.158431 152.417428) (xy 145.161325 152.359605) (xy 145.162581 152.355328) (xy 145.171073 152.333971) (xy 145.181101 152.314291) (xy 145.209719 152.258126) (xy 145.210385 152.253923) (xy 145.212505 152.240538) (xy 145.212505 152.240532) (xy 145.213215 152.236054) (xy 145.2255 152.158493) (xy 145.2255 151.841506) (xy 145.214557 151.772414) (xy 145.211246 151.751509) (xy 145.211246 151.751508) (xy 145.20972 151.741877) (xy 145.209719 151.741875) (xy 145.209719 151.741874) (xy 145.174205 151.672174) (xy 145.171608 151.664555) (xy 145.162821 151.638767) (xy 145.158711 151.61688) (xy 145.161603 151.559064) (xy 145.162859 151.554786) (xy 145.165642 151.547784) (xy 145.165685 151.547359) (xy 145.165938 151.547039) (xy 145.171349 151.533429) (xy 145.209719 151.458126) (xy 145.2136 151.433625) (xy 145.2255 151.358493) (xy 145.2255 151.041506) (xy 145.225499 151.0415) (xy 145.211246 150.951509) (xy 145.211246 150.951508) (xy 145.20972 150.941877) (xy 145.209719 150.941875) (xy 145.209719 150.941874) (xy 145.174205 150.872174) (xy 145.171608 150.864555) (xy 145.162821 150.838767) (xy 145.158711 150.81688) (xy 145.161603 150.759064) (xy 145.162859 150.754786) (xy 145.165642 150.747785) (xy 145.165685 150.747359) (xy 145.165938 150.747039) (xy 145.17135 150.733426) (xy 145.209719 150.658126) (xy 145.212171 150.642645) (xy 145.2255 150.558493) (xy 145.2255 150.241506) (xy 145.220937 150.212697) (xy 145.211246 150.151509) (xy 145.211246 150.151508) (xy 145.20972 150.141877) (xy 145.209719 150.141875) (xy 145.209719 150.141874) (xy 145.174205 150.072174) (xy 145.171608 150.064555) (xy 145.162821 150.038767) (xy 145.158711 150.01688) (xy 145.161603 149.959064) (xy 145.162859 149.954786) (xy 145.165642 149.947785) (xy 145.165685 149.947359) (xy 145.165938 149.947039) (xy 145.17135 149.933426) (xy 145.209719 149.858126) (xy 145.211173 149.848945) (xy 145.2255 149.758493) (xy 145.2255 149.441506) (xy 145.225499 149.4415) (xy 145.211246 149.351509) (xy 145.211246 149.351508) (xy 145.20972 149.341877) (xy 145.209719 149.341875) (xy 145.209719 149.341874) (xy 145.174205 149.272174) (xy 145.171608 149.264555) (xy 145.162821 149.238767) (xy 145.158711 149.21688) (xy 145.161603 149.159064) (xy 145.162859 149.154786) (xy 145.165642 149.147784) (xy 145.165685 149.147359) (xy 145.165938 149.147039) (xy 145.171349 149.133429) (xy 145.209719 149.058126) (xy 145.210191 149.055145) (xy 145.2255 148.958493) (xy 145.2255 148.641506) (xy 145.225499 148.6415) (xy 145.211246 148.551509) (xy 145.211246 148.551508) (xy 145.20972 148.541877) (xy 145.209719 148.541875) (xy 145.209719 148.541874) (xy 145.174205 148.472174) (xy 145.171608 148.464555) (xy 145.162821 148.438767) (xy 145.158711 148.41688) (xy 145.161603 148.359064) (xy 145.162859 148.354786) (xy 145.165642 148.347785) (xy 145.165685 148.347359) (xy 145.165938 148.347039) (xy 145.17135 148.333426) (xy 145.209719 148.258126) (xy 145.209719 148.258124) (xy 145.20972 148.258122) (xy 145.220028 148.193041) (xy 145.220028 148.193039) (xy 145.2255 148.158493) (xy 145.2255 147.841506) (xy 145.225499 147.8415) (xy 145.211246 147.751509) (xy 145.211246 147.751508) (xy 145.20972 147.741877) (xy 145.209719 147.741875) (xy 145.209719 147.741874) (xy 145.174205 147.672174) (xy 145.171608 147.664555) (xy 145.162821 147.638767) (xy 145.158711 147.61688) (xy 145.161603 147.559064) (xy 145.162859 147.554786) (xy 145.165642 147.547784) (xy 145.165685 147.547359) (xy 145.165938 147.547039) (xy 145.171349 147.533429) (xy 145.209719 147.458126) (xy 145.209744 147.457967) (xy 145.2255 147.358493) (xy 145.2255 147.041506) (xy 145.219716 147.004986) (xy 145.211246 146.951509) (xy 145.211246 146.951508) (xy 145.20972 146.941877) (xy 145.209719 146.941875) (xy 145.209719 146.941874) (xy 145.148528 146.82178) (xy 145.148526 146.821778) (xy 145.148523 146.821774) (xy 145.053225 146.726476) (xy 145.053221 146.726473) (xy 145.05322 146.726472) (xy 144.933126 146.665281) (xy 144.933124 146.66528) (xy 144.933121 146.665279) (xy 144.933119 146.665278) (xy 144.93312 146.665278) (xy 144.833497 146.6495) (xy 144.833493 146.6495) (xy 144.833488 146.6495) (xy 143.516512 146.6495) (xy 143.516505 146.6495) (xy 143.516501 146.6495) (xy 143.50543 146.651253) (xy 143.47015 146.651757) (xy 143.458769 146.650286) (xy 143.456386 146.649978) (xy 143.392422 146.621867) (xy 143.353812 146.56364) (xy 143.351742 146.556948) (xy 143.347739 146.500915) (xy 143.349507 146.489757) (xy 143.349507 146.489756) (xy 143.3505 146.483489) (xy 143.3505 145.166506) (xy 143.336246 145.076509) (xy 143.336246 145.076508) (xy 143.33472 145.066877) (xy 143.334719 145.066875) (xy 143.334719 145.066874) (xy 143.273528 144.94678) (xy 143.273526 144.946778) (xy 143.273523 144.946774) (xy 143.178225 144.851476) (xy 143.178221 144.851473) (xy 143.17822 144.851472) (xy 143.058126 144.790281) (xy 143.058124 144.79028) (xy 143.058121 144.790279) (xy 143.058119 144.790278) (xy 143.05812 144.790278) (xy 142.958497 144.7745) (xy 142.958493 144.7745) (xy 142.958488 144.7745) (xy 142.779196 144.7745) (xy 142.712157 144.754815) (xy 142.666402 144.702011) (xy 142.655941 144.64405) (xy 142.655421 144.644032) (xy 142.6555 144.641819) (xy 142.6555 137.443053) (xy 144.2 137.443053) (xy 144.205164 137.486066) (xy 144.210612 137.531441) (xy 144.266078 137.672094) (xy 144.266079 137.672095) (xy 144.357435 137.792564) (xy 144.477903 137.883919) (xy 144.477904 137.88392) (xy 144.618556 137.939386) (xy 144.706946 137.95) (xy 144.8 137.95) (xy 145.2 137.95) (xy 145.293049 137.95) (xy 145.293054 137.95) (xy 145.381443 137.939386) (xy 145.522095 137.88392) (xy 145.642564 137.792564) (xy 145.73392 137.672095) (xy 145.789386 137.531443) (xy 145.8 137.443053) (xy 145.8 137.2) (xy 145.2 137.2) (xy 145.2 137.95) (xy 144.8 137.95) (xy 144.8 137.2) (xy 144.2 137.2) (xy 144.2 137.443053) (xy 142.6555 137.443053) (xy 142.6555 136.556946) (xy 144.2 136.556946) (xy 144.2 136.8) (xy 144.8 136.8) (xy 145.2 136.8) (xy 145.8 136.8) (xy 145.8 136.556949) (xy 145.799999 136.556943) (xy 145.799994 136.556898) (xy 146.1995 136.556898) (xy 146.1995 137.443102) (xy 146.205126 137.489954) (xy 146.210122 137.531561) (xy 146.264578 137.669652) (xy 146.26564 137.672345) (xy 146.357076 137.792922) (xy 146.470904 137.87924) (xy 146.477656 137.88436) (xy 146.477657 137.88436) (xy 146.477876 137.884526) (xy 146.480596 137.885519) (xy 146.618436 137.939877) (xy 146.706898 137.9505) (xy 146.706903 137.9505) (xy 147.293097 137.9505) (xy 147.293102 137.9505) (xy 147.381564 137.939877) (xy 147.522342 137.884361) (xy 147.642922 137.792922) (xy 147.734361 137.672342) (xy 147.789877 137.531564) (xy 147.8005 137.443102) (xy 147.8005 137.103471) (xy 148.509499 137.103471) (xy 148.549864 137.306394) (xy 148.54987 137.306421) (xy 148.606464 137.443051) (xy 148.62906 137.4976) (xy 148.651751 137.531561) (xy 148.74402 137.669652) (xy 148.744026 137.66966) (xy 148.890336 137.81597) (xy 148.89034 137.815973) (xy 148.890342 137.815975) (xy 148.890345 137.815977) (xy 148.890349 137.81598) (xy 148.890348 137.81598) (xy 148.890411 137.816032) (xy 148.890448 137.816046) (xy 149.062402 137.930941) (xy 149.25358 138.01013) (xy 149.44454 138.048114) (xy 149.453559 138.049908) (xy 149.455794 138.050409) (xy 149.456532 138.0505) (xy 149.663466 138.0505) (xy 149.667586 138.0505) (xy 149.675435 138.048118) (xy 149.86642 138.01013) (xy 150.057598 137.930941) (xy 150.229655 137.815977) (xy 150.253068 137.792564) (xy 150.276133 137.769499) (xy 150.304384 137.74835) (xy 150.318108 137.740856) (xy 150.33553 137.737066) (xy 150.337454 137.736016) (xy 150.339639 137.736172) (xy 150.386366 137.726005) (xy 150.388176 137.726134) (xy 150.446373 137.7455) (xy 150.452891 137.749689) (xy 150.473526 137.766319) (xy 151.446587 138.73938) (xy 151.537912 138.792107) (xy 151.639773 138.8194) (xy 151.745227 138.8194) (xy 154.969911 138.8194) (xy 155.001999 138.823623) (xy 155.032467 138.831787) (xy 155.062371 138.844173) (xy 155.109713 138.871507) (xy 155.211573 138.8988) (xy 155.211575 138.8988) (xy 157.554425 138.8988) (xy 157.554427 138.8988) (xy 157.656288 138.871507) (xy 157.672931 138.861897) (xy 157.703633 138.844172) (xy 157.733534 138.831788) (xy 157.764 138.823625) (xy 157.796092 138.8194) (xy 158.4606 138.8194) (xy 158.476701 138.82045) (xy 158.495073 138.822856) (xy 158.495074 138.822856) (xy 158.502238 138.821907) (xy 158.513129 138.820466) (xy 158.51408 138.820345) (xy 158.521691 138.8194) (xy 158.547527 138.8194) (xy 158.565424 138.814603) (xy 158.577336 138.81223) (xy 158.585219 138.810925) (xy 158.590106 138.810278) (xy 158.590139 138.810283) (xy 158.590138 138.810274) (xy 158.590139 138.810274) (xy 158.599615 138.809021) (xy 158.616413 138.802049) (xy 158.631824 138.796812) (xy 158.649387 138.792107) (xy 158.665433 138.782841) (xy 158.679892 138.775705) (xy 158.697015 138.7686) (xy 158.717903 138.752549) (xy 158.740713 138.73938) (xy 158.75953 138.720562) (xy 158.765947 138.715631) (xy 158.765948 138.715631) (xy 158.78063 138.704349) (xy 158.780629 138.704349) (xy 158.780633 138.704347) (xy 158.789199 138.693164) (xy 158.794365 138.686862) (xy 158.799749 138.68072) (xy 158.805313 138.67478) (xy 158.815274 138.664819) (xy 158.815274 138.664818) (xy 158.81528 138.664813) (xy 158.824546 138.648761) (xy 158.833499 138.635352) (xy 158.844772 138.620642) (xy 158.851708 138.603861) (xy 158.858914 138.589236) (xy 158.864877 138.578906) (xy 158.868007 138.573487) (xy 158.871761 138.55947) (xy 158.874102 138.551752) (xy 158.876692 138.544114) (xy 158.879519 138.53659) (xy 159.084267 138.041338) (xy 159.108716 138.003568) (xy 159.118871 137.992818) (xy 159.176636 137.958274) (xy 159.189482 137.9548) (xy 159.221853 137.9505) (xy 159.293097 137.9505) (xy 159.293102 137.9505) (xy 159.381564 137.939877) (xy 159.522342 137.884361) (xy 159.642922 137.792922) (xy 159.734361 137.672342) (xy 159.789877 137.531564) (xy 159.8005 137.443102) (xy 159.8005 136.556898) (xy 160.1995 136.556898) (xy 160.1995 137.443102) (xy 160.205126 137.489954) (xy 160.210122 137.531561) (xy 160.264578 137.669652) (xy 160.26564 137.672345) (xy 160.357076 137.792922) (xy 160.470904 137.87924) (xy 160.477656 137.88436) (xy 160.477657 137.88436) (xy 160.477876 137.884526) (xy 160.480596 137.885519) (xy 160.618436 137.939877) (xy 160.706898 137.9505) (xy 160.706903 137.9505) (xy 161.293097 137.9505) (xy 161.293102 137.9505) (xy 161.381564 137.939877) (xy 161.522342 137.884361) (xy 161.642922 137.792922) (xy 161.734361 137.672342) (xy 161.789877 137.531564) (xy 161.8005 137.443102) (xy 161.8005 136.556898) (xy 161.789877 136.468436) (xy 161.734361 136.327658) (xy 161.73436 136.327657) (xy 161.73436 136.327656) (xy 161.73063 136.322737) (xy 161.730318 136.32214) (xy 161.72924 136.320904) (xy 161.642922 136.207076) (xy 161.522345 136.11564) (xy 161.522339 136.115637) (xy 161.404224 136.069058) (xy 161.404219 136.069057) (xy 161.382574 136.060521) (xy 161.380613 136.059728) (xy 161.380312 136.059603) (xy 161.374199 136.059238) (xy 161.335926 136.054642) (xy 161.335925 136.054641) (xy 161.30822 136.051315) (xy 161.293102 136.0495) (xy 161.293098 136.0495) (xy 160.706901 136.0495) (xy 160.706898 136.0495) (xy 160.69656 136.050741) (xy 160.667853 136.054187) (xy 160.667853 136.054188) (xy 160.66192 136.0549) (xy 160.618439 136.060121) (xy 160.477653 136.11564) (xy 160.357076 136.207076) (xy 160.26564 136.327653) (xy 160.264577 136.330348) (xy 160.210122 136.468438) (xy 160.206044 136.502402) (xy 160.1995 136.556898) (xy 159.8005 136.556898) (xy 159.789877 136.468436) (xy 159.734361 136.327658) (xy 159.73436 136.327657) (xy 159.73436 136.327656) (xy 159.73063 136.322737) (xy 159.730318 136.32214) (xy 159.72924 136.320904) (xy 159.642922 136.207076) (xy 159.522345 136.11564) (xy 159.522339 136.115637) (xy 159.404224 136.069058) (xy 159.404219 136.069057) (xy 159.382574 136.060521) (xy 159.380613 136.059728) (xy 159.380312 136.059603) (xy 159.374199 136.059238) (xy 159.335926 136.054642) (xy 159.335925 136.054641) (xy 159.30822 136.051315) (xy 159.293102 136.0495) (xy 159.293098 136.0495) (xy 158.706901 136.0495) (xy 158.706898 136.0495) (xy 158.69656 136.050741) (xy 158.667853 136.054187) (xy 158.667853 136.054188) (xy 158.66192 136.0549) (xy 158.618439 136.060121) (xy 158.477653 136.11564) (xy 158.357076 136.207076) (xy 158.26564 136.327653) (xy 158.264577 136.330348) (xy 158.210122 136.468438) (xy 158.206044 136.502402) (xy 158.200062 136.552224) (xy 158.1995 136.556902) (xy 158.1995 137.164915) (xy 158.199499 137.164917) (xy 158.1995 137.164918) (xy 158.194476 137.199852) (xy 158.187064 137.225093) (xy 158.155769 137.277837) (xy 157.464133 137.969473) (xy 157.435882 137.990622) (xy 157.412794 138.00323) (xy 157.353364 138.0184) (xy 155.224425 138.0184) (xy 155.18949 138.013377) (xy 155.178636 138.01019) (xy 155.119858 137.972416) (xy 155.090833 137.90886) (xy 155.100776 137.839703) (xy 155.103966 137.83272) (xy 155.129075 137.796558) (xy 155.255975 137.669658) (xy 155.255975 137.669657) (xy 155.255977 137.669655) (xy 155.370941 137.497598) (xy 155.45013 137.30642) (xy 155.4905 137.103465) (xy 155.4905 136.896535) (xy 155.45013 136.69358) (xy 155.370941 136.502402) (xy 155.348248 136.46844) (xy 155.345162 136.463821) (xy 155.256046 136.330449) (xy 155.256036 136.330417) (xy 155.25598 136.330348) (xy 155.25598 136.330349) (xy 155.255977 136.330345) (xy 155.255975 136.330342) (xy 155.255973 136.33034) (xy 155.25597 136.330336) (xy 155.109662 136.184028) (xy 155.109655 136.184022) (xy 155.00731 136.115638) (xy 154.937599 136.069059) (xy 154.916024 136.060123) (xy 154.916022 136.060121) (xy 154.916022 136.060122) (xy 154.74642 135.98987) (xy 154.746412 135.989868) (xy 154.746404 135.989866) (xy 154.746394 135.989864) (xy 154.543471 135.9495) (xy 154.543469 135.9495) (xy 154.543465 135.9495) (xy 154.336535 135.9495) (xy 154.33653 135.9495) (xy 154.336528 135.9495) (xy 154.133604 135.989864) (xy 154.133579 135.98987) (xy 153.942404 136.069057) (xy 153.770337 136.184027) (xy 153.624027 136.330337) (xy 153.509057 136.502404) (xy 153.42987 136.693579) (xy 153.429864 136.693604) (xy 153.3895 136.896527) (xy 153.3895 136.89653) (xy 153.3895 137.103469) (xy 153.3895 137.103471) (xy 153.389499 137.103471) (xy 153.429864 137.306394) (xy 153.42987 137.306421) (xy 153.486464 137.443051) (xy 153.50906 137.4976) (xy 153.531751 137.531561) (xy 153.62402 137.669652) (xy 153.624026 137.66966) (xy 153.748478 137.794112) (xy 153.768074 137.820286) (xy 153.769625 137.822358) (xy 153.775046 137.832284) (xy 153.789903 137.900556) (xy 153.765491 137.966022) (xy 153.709561 138.007897) (xy 153.709552 138.007901) (xy 153.702364 138.010582) (xy 153.65903 138.0184) (xy 151.927585 138.0184) (xy 151.892649 138.013377) (xy 151.867407 138.005965) (xy 151.814662 137.974669) (xy 150.618412 136.778419) (xy 150.597261 136.750165) (xy 150.580959 136.72031) (xy 150.571128 136.696871) (xy 150.570129 136.693579) (xy 150.490941 136.502402) (xy 150.468248 136.46844) (xy 150.465162 136.463821) (xy 150.376046 136.330449) (xy 150.376036 136.330417) (xy 150.37598 136.330348) (xy 150.37598 136.330349) (xy 150.375977 136.330345) (xy 150.375975 136.330342) (xy 150.375973 136.33034) (xy 150.37597 136.330336) (xy 150.229662 136.184028) (xy 150.229655 136.184022) (xy 150.12731 136.115638) (xy 150.057599 136.069059) (xy 150.036024 136.060123) (xy 150.036022 136.060121) (xy 150.036022 136.060122) (xy 149.86642 135.98987) (xy 149.866412 135.989868) (xy 149.866404 135.989866) (xy 149.866394 135.989864) (xy 149.663471 135.9495) (xy 149.663469 135.9495) (xy 149.663465 135.9495) (xy 149.456535 135.9495) (xy 149.45653 135.9495) (xy 149.456528 135.9495) (xy 149.253604 135.989864) (xy 149.253579 135.98987) (xy 149.062404 136.069057) (xy 148.890337 136.184027) (xy 148.744027 136.330337) (xy 148.629057 136.502404) (xy 148.54987 136.693579) (xy 148.549864 136.693604) (xy 148.5095 136.896527) (xy 148.5095 136.89653) (xy 148.5095 137.103469) (xy 148.5095 137.103471) (xy 148.509499 137.103471) (xy 147.8005 137.103471) (xy 147.8005 136.556898) (xy 147.789877 136.468436) (xy 147.734361 136.327658) (xy 147.73436 136.327657) (xy 147.73436 136.327656) (xy 147.73063 136.322737) (xy 147.730318 136.32214) (xy 147.72924 136.320904) (xy 147.642922 136.207076) (xy 147.522345 136.11564) (xy 147.522339 136.115637) (xy 147.404224 136.069058) (xy 147.404219 136.069057) (xy 147.382574 136.060521) (xy 147.380613 136.059728) (xy 147.380312 136.059603) (xy 147.374199 136.059238) (xy 147.335926 136.054642) (xy 147.335925 136.054641) (xy 147.30822 136.051315) (xy 147.293102 136.0495) (xy 147.293098 136.0495) (xy 146.706901 136.0495) (xy 146.706898 136.0495) (xy 146.69656 136.050741) (xy 146.667853 136.054187) (xy 146.667853 136.054188) (xy 146.66192 136.0549) (xy 146.618439 136.060121) (xy 146.477653 136.11564) (xy 146.357076 136.207076) (xy 146.26564 136.327653) (xy 146.264577 136.330348) (xy 146.210122 136.468438) (xy 146.206044 136.502402) (xy 146.1995 136.556898) (xy 145.799994 136.556898) (xy 145.789386 136.468556) (xy 145.73392 136.327904) (xy 145.642564 136.207435) (xy 145.522095 136.116079) (xy 145.522096 136.116079) (xy 145.381441 136.060612) (xy 145.327933 136.054188) (xy 145.293054 136.05) (xy 145.293049 136.05) (xy 145.2 136.05) (xy 145.2 136.8) (xy 144.8 136.8) (xy 144.8 136.05) (xy 144.706952 136.05) (xy 144.706946 136.05) (xy 144.668294 136.054641) (xy 144.618557 136.060612) (xy 144.477904 136.116078) (xy 144.477903 136.116079) (xy 144.357435 136.207435) (xy 144.266079 136.327903) (xy 144.266078 136.327904) (xy 144.210612 136.468557) (xy 144.206549 136.5024) (xy 144.2 136.556946) (xy 142.6555 136.556946) (xy 142.6555 130.443053) (xy 148.2 130.443053) (xy 148.205164 130.486066) (xy 148.210612 130.531441) (xy 148.266078 130.672094) (xy 148.266079 130.672095) (xy 148.357435 130.792564) (xy 148.477903 130.883919) (xy 148.477904 130.88392) (xy 148.618556 130.939386) (xy 148.706946 130.95) (xy 148.8 130.95) (xy 149.2 130.95) (xy 149.293049 130.95) (xy 149.293054 130.95) (xy 149.381443 130.939386) (xy 149.522095 130.88392) (xy 149.642564 130.792564) (xy 149.73392 130.672095) (xy 149.789386 130.531443) (xy 149.8 130.443053) (xy 149.8 130.2) (xy 149.2 130.2) (xy 149.2 130.95) (xy 148.8 130.95) (xy 148.8 130.2) (xy 148.2 130.2) (xy 148.2 130.443053) (xy 142.6555 130.443053) (xy 142.6555 129.556946) (xy 148.2 129.556946) (xy 148.2 129.8) (xy 148.8 129.8) (xy 149.2 129.8) (xy 149.8 129.8) (xy 149.8 129.556949) (xy 149.799999 129.556943) (xy 149.799994 129.556898) (xy 150.1995 129.556898) (xy 150.1995 130.443102) (xy 150.205126 130.489954) (xy 150.210122 130.531561) (xy 150.265541 130.672094) (xy 150.26564 130.672345) (xy 150.357076 130.792922) (xy 150.470904 130.87924) (xy 150.477656 130.88436) (xy 150.477657 130.88436) (xy 150.477876 130.884526) (xy 150.480596 130.885519) (xy 150.618436 130.939877) (xy 150.706898 130.9505) (xy 150.706903 130.9505) (xy 151.293097 130.9505) (xy 151.293102 130.9505) (xy 151.381564 130.939877) (xy 151.522342 130.884361) (xy 151.642922 130.792922) (xy 151.734361 130.672342) (xy 151.789877 130.531564) (xy 151.8005 130.443102) (xy 151.8005 129.556898) (xy 151.789877 129.468436) (xy 151.734361 129.327658) (xy 151.73436 129.327657) (xy 151.73436 129.327656) (xy 151.73063 129.322737) (xy 151.730318 129.32214) (xy 151.72924 129.320904) (xy 151.642922 129.207076) (xy 151.522345 129.11564) (xy 151.522339 129.115637) (xy 151.426193 129.077721) (xy 151.426191 129.077721) (xy 151.382543 129.060508) (xy 151.380583 129.059716) (xy 151.380311 129.059603) (xy 151.374199 129.059238) (xy 151.335926 129.054642) (xy 151.335925 129.054641) (xy 151.30822 129.051315) (xy 151.293102 129.0495) (xy 151.293098 129.0495) (xy 150.706901 129.0495) (xy 150.706898 129.0495) (xy 150.69656 129.050741) (xy 150.667853 129.054187) (xy 150.667853 129.054188) (xy 150.66192 129.0549) (xy 150.618439 129.060121) (xy 150.477653 129.11564) (xy 150.357076 129.207076) (xy 150.26564 129.327653) (xy 150.210121 129.468439) (xy 150.208098 129.485289) (xy 150.204188 129.517853) (xy 150.1995 129.556898) (xy 149.799994 129.556898) (xy 149.789386 129.468556) (xy 149.73392 129.327904) (xy 149.642564 129.207435) (xy 149.522095 129.116079) (xy 149.522096 129.116079) (xy 149.381441 129.060612) (xy 149.327933 129.054188) (xy 149.293054 129.05) (xy 149.293049 129.05) (xy 149.2 129.05) (xy 149.2 129.8) (xy 148.8 129.8) (xy 148.8 129.05) (xy 148.706952 129.05) (xy 148.706946 129.05) (xy 148.668294 129.054641) (xy 148.618557 129.060612) (xy 148.477904 129.116078) (xy 148.477903 129.116079) (xy 148.357435 129.207435) (xy 148.266079 129.327903) (xy 148.266078 129.327904) (xy 148.210612 129.468557) (xy 148.206777 129.5005) (xy 148.2 129.556946) (xy 142.6555 129.556946) (xy 142.6555 125.261886) (xy 142.6555 125.26188) (xy 142.653645 125.228265) (xy 142.650642 125.201139) (xy 142.645098 125.167924) (xy 142.644045 125.163227) (xy 142.617821 125.090726) (xy 142.61782 125.090724) (xy 142.617817 125.090717) (xy 142.589511 125.035484) (xy 142.589498 125.035461) (xy 142.562189 124.991719) (xy 142.497719 124.932452) (xy 142.479537 124.915737) (xy 142.464724 124.906479) (xy 142.420292 124.87871) (xy 142.420282 124.878705) (xy 142.365134 124.851534) (xy 142.365132 124.851533) (xy 142.365131 124.851533) (xy 142.365127 124.851532) (xy 142.365126 124.851532) (xy 142.253253 124.832076) (xy 142.190578 124.801196) (xy 142.154547 124.741334) (xy 142.150499 124.70991) (xy 142.150499 123.893925) (xy 142.170184 123.826886) (xy 142.222988 123.781131) (xy 142.250461 123.77369) (xy 142.250292 123.77301) (xy 142.258899 123.77087) (xy 142.2589 123.770871) (xy 142.367857 123.743795) (xy 142.431414 123.714772) (xy 142.484488 123.683735) (xy 142.56151 123.602051) (xy 142.599287 123.543274) (xy 142.635413 123.464178) (xy 142.638093 123.455051) (xy 142.638095 123.455047) (xy 142.639789 123.447262) (xy 142.647366 123.412437) (xy 142.65239 123.377498) (xy 142.6555 123.334016) (xy 142.6555 122.963117) (xy 142.6555 122.963106) (xy 142.653642 122.929484) (xy 142.653641 122.929479) (xy 142.653641 122.92947) (xy 142.650633 122.902325) (xy 142.645082 122.869095) (xy 142.644028 122.864397) (xy 142.631478 122.82266) (xy 142.61893 122.789672) (xy 142.612051 122.773074) (xy 142.596252 122.750329) (xy 142.596438 122.750234) (xy 142.589503 122.736703) (xy 142.562204 122.692977) (xy 142.527578 122.661141) (xy 142.526239 122.659384) (xy 142.513777 122.647083) (xy 142.513778 122.647083) (xy 142.498279 122.631784) (xy 142.450405 122.593219) (xy 142.450404 122.593218) (xy 142.435124 122.586891) (xy 142.435102 122.586883) (xy 142.424115 122.582334) (xy 142.420304 122.579952) (xy 142.365163 122.552781) (xy 142.318848 122.544722) (xy 142.316766 122.543967) (xy 142.278291 122.53586) (xy 142.261267 122.534033) (xy 142.196711 122.507307) (xy 142.156852 122.449922) (xy 142.150499 122.410741) (xy 142.150499 121.592691) (xy 142.158919 121.564014) (xy 142.164884 121.53472) (xy 142.16866 121.530841) (xy 142.170184 121.525652) (xy 142.192766 121.506084) (xy 142.213626 121.484661) (xy 142.219718 121.48273) (xy 142.222988 121.479897) (xy 142.246528 121.471887) (xy 142.256647 121.469543) (xy 142.258879 121.469638) (xy 142.294966 121.460671) (xy 142.295936 121.460447) (xy 142.296005 121.460451) (xy 142.29832 121.45992) (xy 142.323791 121.454547) (xy 142.323792 121.454548) (xy 142.345092 121.450056) (xy 142.403691 121.43137) (xy 142.42728 121.415427) (xy 142.431367 121.413562) (xy 142.484472 121.382513) (xy 142.516815 121.348214) (xy 142.5186 121.346888) (xy 142.530918 121.334725) (xy 142.530919 121.334726) (xy 142.546409 121.319432) (xy 142.585601 121.272038) (xy 142.59318 121.254373) (xy 142.598309 121.243827) (xy 142.599256 121.242091) (xy 142.59927 121.24207) (xy 142.635403 121.162974) (xy 142.638089 121.15383) (xy 142.647361 121.111225) (xy 142.652388 121.076277) (xy 142.6555 121.032781) (xy 142.6555 120.663117) (xy 142.6555 120.663106) (xy 142.653642 120.629484) (xy 142.653641 120.629479) (xy 142.653641 120.62947) (xy 142.650633 120.602325) (xy 142.645082 120.569095) (xy 142.644028 120.564397) (xy 142.644025 120.564387) (xy 142.617809 120.491932) (xy 142.617808 120.49193) (xy 142.589501 120.436701) (xy 142.562203 120.392975) (xy 142.479555 120.316987) (xy 142.453517 120.300712) (xy 142.420303 120.279951) (xy 142.365157 120.252778) (xy 142.365155 120.252777) (xy 142.365154 120.252777) (xy 142.36515 120.252776) (xy 142.365149 120.252776) (xy 142.252748 120.233223) (xy 142.222992 120.21856) (xy 142.192797 120.204771) (xy 142.191772 120.203176) (xy 142.190074 120.20234) (xy 142.172963 120.173908) (xy 142.155023 120.145993) (xy 142.154665 120.143504) (xy 142.154046 120.142476) (xy 142.15 120.111058) (xy 142.15 120.055127) (xy 145.8495 120.055127) (xy 145.8495 123.944849) (xy 145.849502 123.944885) (xy 145.852414 123.969993) (xy 145.852546 123.970438) (xy 145.853609 123.972696) (xy 145.874275 124.019501) (xy 145.897793 124.072764) (xy 145.897794 124.072765) (xy 145.977235 124.152206) (xy 146.080009 124.197585) (xy 146.105135 124.2005) (xy 148.194864 124.200499) (xy 148.194879 124.200497) (xy 148.194882 124.200497) (xy 148.194888 124.200496) (xy 148.195019 124.200487) (xy 148.195736 124.200397) (xy 148.219987 124.197586) (xy 148.219987 124.197585) (xy 148.21999 124.197585) (xy 148.219991 124.197585) (xy 148.219991 124.197584) (xy 148.220102 124.197572) (xy 148.221862 124.196758) (xy 148.322765 124.152206) (xy 148.402206 124.072765) (xy 148.447585 123.969991) (xy 148.4505 123.944865) (xy 148.450499 120.055136) (xy 148.450497 120.055117) (xy 148.447586 120.030012) (xy 148.447585 120.03001) (xy 148.447585 120.030009) (xy 148.402206 119.927235) (xy 148.322765 119.847794) (xy 148.322764 119.847793) (xy 148.322765 119.847793) (xy 148.322045 119.847476) (xy 148.322029 119.847469) (xy 148.219993 119.802415) (xy 148.219994 119.802415) (xy 148.194868 119.7995) (xy 148.194865 119.7995) (xy 146.105143 119.7995) (xy 146.105127 119.799501) (xy 146.105113 119.799502) (xy 146.087255 119.801573) (xy 146.080012 119.802413) (xy 146.080011 119.802413) (xy 146.080005 119.802414) (xy 146.079559 119.802547) (xy 146.077303 119.803609) (xy 145.977236 119.847792) (xy 145.897793 119.927234) (xy 145.852414 120.030005) (xy 145.851844 120.03271) (xy 145.851589 120.037124) (xy 145.8495 120.055127) (xy 142.15 120.055127) (xy 142.15 119.9) (xy 140.991833 119.9) (xy 140.970381 119.89813) (xy 140.96105 119.896491) (xy 140.95822 119.89509) (xy 140.956892 119.894975) (xy 140.95252 119.893691) (xy 140.952803 119.892724) (xy 140.93669 119.888611) (xy 140.936435 119.889297) (xy 140.933587 119.888234) (xy 140.932747 119.887605) (xy 140.930999 119.887159) (xy 140.928292 119.885923) (xy 140.928854 119.88469) (xy 140.916878 119.875723) (xy 140.907123 119.872855) (xy 140.902509 119.867525) (xy 140.898427 119.865506) (xy 140.894512 119.858977) (xy 140.882434 119.849933) (xy 140.881407 119.850824) (xy 140.880492 119.849768) (xy 140.879597 119.847809) (xy 140.877684 119.846377) (xy 140.875858 119.843938) (xy 140.877327 119.842837) (xy 140.873077 119.83353) (xy 140.86139 119.820032) (xy 140.851488 119.786257) (xy 140.851468 119.786212) (xy 140.851461 119.786163) (xy 140.851255 119.784726) (xy 140.85 119.76713) (xy 140.85 119.641829) (xy 140.855023 119.606893) (xy 140.859427 119.591895) (xy 140.897172 119.533144) (xy 140.898541 119.531957) (xy 140.95342 119.504477) (xy 140.960979 119.502833) (xy 140.987332 119.5) (xy 142.149999 119.5) (xy 142.149999 118.90522) (xy 142.149998 118.905202) (xy 142.149997 118.905191) (xy 142.147091 118.88013) (xy 142.14709 118.880126) (xy 142.101788 118.777525) (xy 142.101788 118.777524) (xy 142.101783 118.777517) (xy 142.022481 118.698215) (xy 142.022475 118.698211) (xy 141.919875 118.652909) (xy 141.919871 118.652908) (xy 141.915203 118.652367) (xy 141.85088 118.625084) (xy 141.811519 118.567357) (xy 141.8055 118.529194) (xy 141.8055 118.099448) (xy 163.8495 118.099448) (xy 163.8495 118.28055) (xy 163.877829 118.459413) (xy 163.933778 118.631612) (xy 163.933786 118.631635) (xy 163.933788 118.631639) (xy 164.016006 118.792997) (xy 164.09754 118.90522) (xy 164.122445 118.939499) (xy 164.122452 118.939507) (xy 164.250493 119.067548) (xy 164.250497 119.067551) (xy 164.2505 119.067554) (xy 164.250505 119.067558) (xy 164.378287 119.160396) (xy 164.397006 119.173996) (xy 164.502484 119.22774) (xy 164.55836 119.256211) (xy 164.558363 119.256212) (xy 164.644476 119.284191) (xy 164.730591 119.312171) (xy 164.772733 119.318845) (xy 164.803478 119.323715) (xy 164.803577 119.32373) (xy 164.803639 119.32374) (xy 164.873071 119.334738) (xy 164.906787 119.345163) (xy 164.913071 119.348142) (xy 164.926374 119.360007) (xy 164.936203 119.364667) (xy 164.941954 119.373903) (xy 164.965213 119.394649) (xy 164.983935 119.461964) (xy 164.963292 119.528714) (xy 164.911466 119.572978) (xy 164.906078 119.575439) (xy 164.873958 119.585121) (xy 164.730585 119.607829) (xy 164.558386 119.663778) (xy 164.558363 119.663786) (xy 164.558359 119.663788) (xy 164.397005 119.746004) (xy 164.250499 119.852445) (xy 164.250491 119.852452) (xy 164.122452 119.980491) (xy 164.122445 119.980499) (xy 164.016004 120.127005) (xy 163.933788 120.288359) (xy 163.933786 120.288363) (xy 163.933778 120.288386) (xy 163.877829 120.460585) (xy 163.8495 120.639448) (xy 163.8495 120.82055) (xy 163.877829 120.999413) (xy 163.933778 121.171612) (xy 163.933786 121.171635) (xy 163.933788 121.171639) (xy 164.016006 121.332997) (xy 164.122441 121.479494) (xy 164.122445 121.479499) (xy 164.122452 121.479507) (xy 164.250491 121.607546) (xy 164.2505 121.607554) (xy 164.250524 121.607572) (xy 164.364733 121.690549) (xy 164.364736 121.690551) (xy 164.370673 121.694864) (xy 164.397006 121.713996) (xy 164.502484 121.76774) (xy 164.55836 121.796211) (xy 164.558363 121.796212) (xy 164.640087 121.822765) (xy 164.730591 121.852171) (xy 164.772733 121.858845) (xy 164.803478 121.863715) (xy 164.803577 121.86373) (xy 164.803639 121.86374) (xy 164.873071 121.874738) (xy 164.906787 121.885163) (xy 164.913071 121.888142) (xy 164.926374 121.900007) (xy 164.936203 121.904667) (xy 164.941954 121.913903) (xy 164.965213 121.934649) (xy 164.983935 122.001964) (xy 164.963292 122.068714) (xy 164.911466 122.112978) (xy 164.906078 122.115439) (xy 164.873958 122.125121) (xy 164.730585 122.147829) (xy 164.558386 122.203778) (xy 164.558363 122.203786) (xy 164.558359 122.203788) (xy 164.397005 122.286004) (xy 164.397002 122.286005) (xy 164.397002 122.286006) (xy 164.348169 122.321484) (xy 164.250499 122.392445) (xy 164.250491 122.392452) (xy 164.122452 122.520491) (xy 164.122445 122.520499) (xy 164.016004 122.667005) (xy 163.933788 122.828359) (xy 163.933786 122.828363) (xy 163.933778 122.828386) (xy 163.877829 123.000585) (xy 163.8495 123.179448) (xy 163.8495 123.36055) (xy 163.877829 123.539413) (xy 163.933778 123.711612) (xy 163.933786 123.711635) (xy 163.933788 123.711639) (xy 164.016006 123.872997) (xy 164.088441 123.972696) (xy 164.122445 124.019499) (xy 164.122452 124.019507) (xy 164.250493 124.147548) (xy 164.250497 124.147551) (xy 164.2505 124.147554) (xy 164.250505 124.147558) (xy 164.305459 124.187484) (xy 164.37253 124.236214) (xy 164.372534 124.236216) (xy 164.378287 124.240396) (xy 164.397006 124.253996) (xy 164.467018 124.289669) (xy 164.55836 124.336211) (xy 164.558363 124.336212) (xy 164.644476 124.364191) (xy 164.730591 124.392171) (xy 164.803639 124.40374) (xy 164.873071 124.414738) (xy 164.906787 124.425163) (xy 164.913071 124.428142) (xy 164.965213 124.474649) (xy 164.983935 124.541964) (xy 164.963292 124.608714) (xy 164.911466 124.652978) (xy 164.906078 124.655439) (xy 164.873958 124.665121) (xy 164.730585 124.687829) (xy 164.558386 124.743778) (xy 164.558363 124.743786) (xy 164.558359 124.743788) (xy 164.397005 124.826004) (xy 164.397002 124.826005) (xy 164.397002 124.826006) (xy 164.381772 124.837071) (xy 164.250499 124.932445) (xy 164.250491 124.932452) (xy 164.122452 125.060491) (xy 164.122445 125.060499) (xy 164.122441 125.060505) (xy 164.020259 125.201149) (xy 164.016004 125.207005) (xy 163.933788 125.368359) (xy 163.933786 125.368363) (xy 163.933778 125.368386) (xy 163.877829 125.540585) (xy 163.8495 125.719448) (xy 163.8495 125.90055) (xy 163.877829 126.079413) (xy 163.933778 126.251612) (xy 163.933785 126.251631) (xy 163.933787 126.251636) (xy 163.933788 126.251639) (xy 163.989664 126.3613) (xy 164.013184 126.40746) (xy 164.016006 126.412997) (xy 164.122441 126.559494) (xy 164.122445 126.559499) (xy 164.122452 126.559507) (xy 164.250493 126.687548) (xy 164.250497 126.687551) (xy 164.2505 126.687554) (xy 164.250505 126.687558) (xy 164.378287 126.780396) (xy 164.397006 126.793996) (xy 164.502484 126.84774) (xy 164.55836 126.876211) (xy 164.558363 126.876212) (xy 164.644476 126.904191) (xy 164.730591 126.932171) (xy 164.772733 126.938845) (xy 164.803478 126.943715) (xy 164.803577 126.94373) (xy 164.803639 126.94374) (xy 164.873071 126.954738) (xy 164.906787 126.965163) (xy 164.913071 126.968142) (xy 164.926374 126.980007) (xy 164.936203 126.984667) (xy 164.941954 126.993903) (xy 164.965213 127.014649) (xy 164.983935 127.081964) (xy 164.963292 127.148714) (xy 164.911466 127.192978) (xy 164.906078 127.195439) (xy 164.873958 127.205121) (xy 164.730585 127.227829) (xy 164.558386 127.283778) (xy 164.558363 127.283786) (xy 164.558359 127.283788) (xy 164.397005 127.366004) (xy 164.397002 127.366005) (xy 164.397002 127.366006) (xy 164.348169 127.401484) (xy 164.250499 127.472445) (xy 164.250491 127.472452) (xy 164.122452 127.600491) (xy 164.122445 127.600499) (xy 164.016004 127.747005) (xy 163.933788 127.908359) (xy 163.933786 127.908363) (xy 163.933778 127.908386) (xy 163.877829 128.080585) (xy 163.8495 128.259448) (xy 163.8495 128.44055) (xy 163.877829 128.619413) (xy 163.933778 128.791612) (xy 163.933786 128.791635) (xy 163.933788 128.791639) (xy 164.016006 128.952997) (xy 164.106623 129.077722) (xy 164.122445 129.099499) (xy 164.122452 129.099507) (xy 164.250493 129.227548) (xy 164.250496 129.22755) (xy 164.2505 129.227554) (xy 164.250505 129.227558) (xy 164.337072 129.290452) (xy 164.358619 129.306107) (xy 164.373363 129.316818) (xy 164.397006 129.333996) (xy 164.502484 129.38774) (xy 164.55836 129.416211) (xy 164.558363 129.416212) (xy 164.644476 129.444191) (xy 164.648379 129.445459) (xy 164.730584 129.472169) (xy 164.730585 129.472169) (xy 164.730591 129.472171) (xy 164.813429 129.485291) (xy 164.909449 129.5005) (xy 164.909454 129.5005) (xy 165.090548 129.5005) (xy 165.090551 129.5005) (xy 165.177259 129.486765) (xy 165.269409 129.472171) (xy 165.441639 129.416211) (xy 165.602994 129.333996) (xy 165.749501 129.227553) (xy 165.877553 129.099501) (xy 165.983996 128.952994) (xy 166.066211 128.791639) (xy 166.122171 128.619409) (xy 166.136765 128.527259) (xy 166.1505 128.440551) (xy 166.1505 128.259448) (xy 166.134019 128.155397) (xy 166.122171 128.080591) (xy 166.066211 127.908361) (xy 166.066211 127.90836) (xy 166.03774 127.852484) (xy 165.983996 127.747006) (xy 165.983995 127.747004) (xy 165.970397 127.728289) (xy 165.970395 127.728285) (xy 165.87757 127.600522) (xy 165.877558 127.600505) (xy 165.877554 127.6005) (xy 165.877551 127.600497) (xy 165.877548 127.600493) (xy 165.749507 127.472452) (xy 165.749498 127.472444) (xy 165.749474 127.472426) (xy 165.613605 127.373712) (xy 165.613591 127.373703) (xy 165.602997 127.366006) (xy 165.602996 127.366005) (xy 165.602994 127.366004) (xy 165.596871 127.362884) (xy 165.551301 127.339664) (xy 165.5513 127.339664) (xy 165.441639 127.283788) (xy 165.441636 127.283787) (xy 165.441633 127.283786) (xy 165.441631 127.283785) (xy 165.441612 127.283778) (xy 165.269412 127.227829) (xy 165.269413 127.227829) (xy 165.126931 127.205262) (xy 165.114645 127.199438) (xy 165.093207 127.194834) (xy 165.086927 127.191857) (xy 165.073624 127.179992) (xy 165.063796 127.175333) (xy 165.058044 127.166095) (xy 165.034785 127.14535) (xy 165.016063 127.078035) (xy 165.036706 127.011285) (xy 165.067582 126.984917) (xy 165.076363 126.974373) (xy 165.082016 126.972591) (xy 165.088549 126.967013) (xy 165.093937 126.964553) (xy 165.126032 126.954879) (xy 165.179425 126.946422) (xy 165.269409 126.932171) (xy 165.441639 126.876211) (xy 165.602994 126.793996) (xy 165.749501 126.687553) (xy 165.877553 126.559501) (xy 165.983996 126.412994) (xy 166.066211 126.251639) (xy 166.122171 126.079409) (xy 166.136765 125.987259) (xy 166.1505 125.900551) (xy 166.1505 125.719448) (xy 166.134019 125.615397) (xy 166.122171 125.540591) (xy 166.067718 125.372999) (xy 166.066656 125.369234) (xy 166.032503 125.302205) (xy 166.032503 125.302204) (xy 165.983995 125.207004) (xy 165.920778 125.119993) (xy 165.920777 125.11999) (xy 165.877572 125.060524) (xy 165.877554 125.0605) (xy 165.877546 125.060491) (xy 165.749507 124.932452) (xy 165.749498 124.932444) (xy 165.749474 124.932426) (xy 165.613605 124.833712) (xy 165.613591 124.833703) (xy 165.602997 124.826006) (xy 165.602996 124.826005) (xy 165.602994 124.826004) (xy 165.596871 124.822884) (xy 165.551301 124.799664) (xy 165.5513 124.799664) (xy 165.441639 124.743788) (xy 165.441636 124.743787) (xy 165.441633 124.743786) (xy 165.441631 124.743785) (xy 165.441612 124.743778) (xy 165.269412 124.687829) (xy 165.269413 124.687829) (xy 165.126931 124.665262) (xy 165.114645 124.659438) (xy 165.093207 124.654834) (xy 165.086927 124.651857) (xy 165.073624 124.639992) (xy 165.063796 124.635333) (xy 165.058044 124.626095) (xy 165.034785 124.60535) (xy 165.016063 124.538035) (xy 165.036706 124.471285) (xy 165.067582 124.444917) (xy 165.076363 124.434373) (xy 165.082016 124.432591) (xy 165.088549 124.427013) (xy 165.093937 124.424553) (xy 165.126032 124.414879) (xy 165.179425 124.406422) (xy 165.269409 124.392171) (xy 165.441639 124.336211) (xy 165.602994 124.253996) (xy 165.749501 124.147553) (xy 165.877553 124.019501) (xy 165.983996 123.872994) (xy 166.066211 123.711639) (xy 166.122171 123.539409) (xy 166.128008 123.502549) (xy 166.136765 123.447262) (xy 166.136765 123.447259) (xy 166.1505 123.360551) (xy 166.1505 123.179448) (xy 166.130076 123.0505) (xy 166.122171 123.000591) (xy 166.066977 122.830719) (xy 166.066433 122.828796) (xy 166.063306 122.82266) (xy 166.03774 122.772484) (xy 165.983996 122.667006) (xy 165.923209 122.583339) (xy 165.923208 122.583336) (xy 165.877572 122.520524) (xy 165.877554 122.5205) (xy 165.877546 122.520491) (xy 165.749507 122.392452) (xy 165.749498 122.392444) (xy 165.749474 122.392426) (xy 165.613605 122.293712) (xy 165.613591 122.293703) (xy 165.602997 122.286006) (xy 165.602996 122.286005) (xy 165.602994 122.286004) (xy 165.596871 122.282884) (xy 165.551301 122.259664) (xy 165.5513 122.259664) (xy 165.441639 122.203788) (xy 165.441636 122.203787) (xy 165.441633 122.203786) (xy 165.441631 122.203785) (xy 165.441612 122.203778) (xy 165.269412 122.147829) (xy 165.269413 122.147829) (xy 165.126931 122.125262) (xy 165.114645 122.119438) (xy 165.093207 122.114834) (xy 165.086927 122.111857) (xy 165.073624 122.099992) (xy 165.063796 122.095333) (xy 165.058044 122.086095) (xy 165.034785 122.06535) (xy 165.016063 121.998035) (xy 165.036706 121.931285) (xy 165.067582 121.904917) (xy 165.076363 121.894373) (xy 165.082016 121.892591) (xy 165.088549 121.887013) (xy 165.093937 121.884553) (xy 165.126032 121.874879) (xy 165.179425 121.866422) (xy 165.269409 121.852171) (xy 165.441639 121.796211) (xy 165.602994 121.713996) (xy 165.749501 121.607553) (xy 165.877553 121.479501) (xy 165.983996 121.332994) (xy 166.066211 121.171639) (xy 166.122171 120.999409) (xy 166.136765 120.907259) (xy 166.1505 120.820551) (xy 166.1505 120.639448) (xy 166.131561 120.519877) (xy 166.122171 120.460591) (xy 166.066211 120.288361) (xy 166.066211 120.28836) (xy 166.03774 120.232484) (xy 165.983996 120.127006) (xy 165.931766 120.055117) (xy 165.931765 120.055115) (xy 165.931764 120.055113) (xy 165.877572 119.980524) (xy 165.877554 119.9805) (xy 165.877546 119.980491) (xy 165.749507 119.852452) (xy 165.749498 119.852444) (xy 165.749474 119.852426) (xy 165.613597 119.753706) (xy 165.613581 119.753695) (xy 165.602997 119.746006) (xy 165.602996 119.746005) (xy 165.602994 119.746004) (xy 165.596914 119.742906) (xy 165.596911 119.742904) (xy 165.533098 119.71039) (xy 165.533098 119.710389) (xy 165.533096 119.710389) (xy 165.441639 119.663788) (xy 165.441563 119.663762) (xy 165.269412 119.607829) (xy 165.269413 119.607829) (xy 165.126931 119.585262) (xy 165.114645 119.579438) (xy 165.093207 119.574834) (xy 165.086927 119.571857) (xy 165.073624 119.559992) (xy 165.063796 119.555333) (xy 165.058044 119.546095) (xy 165.034785 119.52535) (xy 165.016063 119.458035) (xy 165.036706 119.391285) (xy 165.067582 119.364917) (xy 165.076363 119.354373) (xy 165.082016 119.352591) (xy 165.088549 119.347013) (xy 165.093937 119.344553) (xy 165.126032 119.334879) (xy 165.179425 119.326422) (xy 165.269409 119.312171) (xy 165.441639 119.256211) (xy 165.602994 119.173996) (xy 165.749501 119.067553) (xy 165.877553 118.939501) (xy 165.983996 118.792994) (xy 166.066211 118.631639) (xy 166.122171 118.459409) (xy 166.136765 118.367259) (xy 166.1505 118.280551) (xy 166.1505 118.099448) (xy 166.127642 117.955135) (xy 166.122171 117.920591) (xy 166.067131 117.751195) (xy 166.066606 117.749392) (xy 166.066606 117.749136) (xy 166.03774 117.692484) (xy 166.037739 117.692483) (xy 165.983996 117.587006) (xy 165.93931 117.5255) (xy 165.877558 117.440505) (xy 165.877554 117.4405) (xy 165.87755 117.440496) (xy 165.877548 117.440493) (xy 165.749507 117.312452) (xy 165.749498 117.312444) (xy 165.749474 117.312426) (xy 165.613605 117.213712) (xy 165.613591 117.213703) (xy 165.602997 117.206006) (xy 165.602996 117.206005) (xy 165.602994 117.206004) (xy 165.596871 117.202884) (xy 165.551301 117.179664) (xy 165.5513 117.179664) (xy 165.441639 117.123788) (xy 165.441636 117.123787) (xy 165.441633 117.123786) (xy 165.441631 117.123785) (xy 165.441612 117.123778) (xy 165.269412 117.067829) (xy 165.269415 117.067829) (xy 165.152181 117.049261) (xy 165.147914 117.04781) (xy 165.145404 117.047994) (xy 165.118452 117.03883) (xy 165.112933 117.036213) (xy 165.112401 117.035738) (xy 165.112317 117.03571) (xy 165.107191 117.032921) (xy 165.089765 117.015547) (xy 165.060792 116.989704) (xy 165.059621 116.985494) (xy 165.057711 116.98359) (xy 165.052579 116.960167) (xy 165.042074 116.922388) (xy 165.043377 116.918172) (xy 165.042757 116.915339) (xy 165.051728 116.891173) (xy 165.06272 116.855638) (xy 165.065922 116.852942) (xy 165.067075 116.849838) (xy 165.090615 116.83216) (xy 165.116177 116.810648) (xy 165.116737 116.810402) (xy 165.120694 116.809573) (xy 165.122946 116.807883) (xy 165.131901 116.807228) (xy 165.166454 116.799999) (xy 165.894791 116.799999) (xy 165.894791 116.799998) (xy 165.894808 116.799997) (xy 165.894808 116.799996) (xy 165.894824 116.799996) (xy 165.915922 116.797548) (xy 165.919869 116.797091) (xy 165.919873 116.79709) (xy 166.022474 116.751788) (xy 166.022479 116.751785) (xy 166.101785 116.672479) (xy 166.101788 116.672474) (xy 166.147089 116.569877) (xy 166.147089 116.569875) (xy 166.14766 116.56717) (xy 166.147915 116.562761) (xy 166.149673 116.547602) (xy 166.15 116.545248) (xy 166.15 115.85) (xy 165.623731 115.85) (xy 165.615045 115.847449) (xy 165.606084 115.848738) (xy 165.582043 115.837759) (xy 165.556692 115.830315) (xy 165.550764 115.823474) (xy 165.542528 115.819713) (xy 165.528238 115.797478) (xy 165.510937 115.777511) (xy 165.508649 115.766996) (xy 165.504754 115.760935) (xy 165.503325 115.742521) (xy 165.499731 115.726) (xy 165.499731 115.716829) (xy 165.5 115.715826) (xy 165.5 115.584174) (xy 165.499731 115.58317) (xy 165.499731 115.574) (xy 165.507379 115.547952) (xy 165.511567 115.521131) (xy 165.517077 115.514924) (xy 165.519416 115.506961) (xy 165.53993 115.489184) (xy 165.557956 115.468883) (xy 165.566037 115.466562) (xy 165.57222 115.461206) (xy 165.597217 115.457611) (xy 165.623731 115.45) (xy 166.149999 115.45) (xy 166.149999 114.75522) (xy 166.149998 114.755202) (xy 166.149997 114.755191) (xy 166.147091 114.73013) (xy 166.14709 114.730126) (xy 166.101788 114.627525) (xy 166.101788 114.627524) (xy 166.101783 114.627517) (xy 166.022481 114.548215) (xy 166.022475 114.548211) (xy 165.919876 114.50291) (xy 165.894795 114.5) (xy 165.894794 114.5) (xy 165.2 114.5) (xy 165.2 115.026269) (xy 165.197449 115.034954) (xy 165.198738 115.043916) (xy 165.187759 115.067956) (xy 165.180315 115.093308) (xy 165.173474 115.099235) (xy 165.169713 115.107472) (xy 165.147478 115.121761) (xy 165.127511 115.139063) (xy 165.116996 115.14135) (xy 165.110935 115.145246) (xy 165.092521 115.146674) (xy 165.076 115.150269) (xy 165.06683 115.150269) (xy 165.065826 115.15) (xy 164.934174 115.15) (xy 164.93317 115.150269) (xy 164.924 115.150269) (xy 164.897952 115.14262) (xy 164.871131 115.138433) (xy 164.864924 115.132922) (xy 164.856961 115.130584) (xy 164.839184 115.110069) (xy 164.818883 115.092044) (xy 164.816562 115.083962) (xy 164.811206 115.07778) (xy 164.807611 115.052782) (xy 164.8 115.026269) (xy 164.8 114.5) (xy 164.105214 114.5) (xy 164.105202 114.5) (xy 164.080126 114.502908) (xy 163.977526 114.54821) (xy 163.977524 114.54821) (xy 163.977517 114.548215) (xy 163.898216 114.627516) (xy 163.898214 114.62752) (xy 163.898211 114.627525) (xy 163.898211 114.627526) (xy 163.898208 114.627532) (xy 163.852909 114.730121) (xy 163.852339 114.732827) (xy 163.852084 114.737242) (xy 163.85 114.7552) (xy 163.85 114.755202) (xy 163.85 114.755205) (xy 163.85 115.45) (xy 164.376269 115.45) (xy 164.384954 115.45255) (xy 164.393916 115.451262) (xy 164.417956 115.46224) (xy 164.443308 115.469685) (xy 164.449235 115.476525) (xy 164.457472 115.480287) (xy 164.471761 115.502521) (xy 164.489063 115.522489) (xy 164.49135 115.533003) (xy 164.495246 115.539065) (xy 164.496674 115.557478) (xy 164.500269 115.574) (xy 164.500269 115.58317) (xy 164.5 115.584174) (xy 164.5 115.715826) (xy 164.500269 115.716829) (xy 164.500269 115.726) (xy 164.49262 115.752047) (xy 164.488433 115.778869) (xy 164.482922 115.785075) (xy 164.480584 115.793039) (xy 164.460069 115.810815) (xy 164.442044 115.831117) (xy 164.433962 115.833437) (xy 164.42778 115.838794) (xy 164.402782 115.842388) (xy 164.376269 115.85) (xy 163.850001 115.85) (xy 163.850001 116.544805) (xy 163.852908 116.569872) (xy 163.89821 116.672472) (xy 163.89821 116.672474) (xy 163.898215 116.672481) (xy 163.977517 116.751783) (xy 163.97752 116.751785) (xy 163.977525 116.751788) (xy 164.080123 116.797089) (xy 164.105206 116.799999) (xy 164.828201 116.799999) (xy 164.832644 116.800764) (xy 164.835094 116.800191) (xy 164.863127 116.805019) (xy 164.868989 116.80674) (xy 164.869596 116.807131) (xy 164.869695 116.807148) (xy 164.875192 116.8091) (xy 164.895112 116.823527) (xy 164.927768 116.844511) (xy 164.929587 116.848495) (xy 164.93178 116.850083) (xy 164.940512 116.872411) (xy 164.956797 116.908065) (xy 164.956167 116.912444) (xy 164.957227 116.915154) (xy 164.952145 116.940427) (xy 164.946857 116.977224) (xy 164.94411 116.980394) (xy 164.943455 116.983653) (xy 164.922966 117.004798) (xy 164.901105 117.030031) (xy 164.900968 117.030119) (xy 164.900606 117.030351) (xy 164.896807 117.031795) (xy 164.894835 117.033832) (xy 164.886046 117.035889) (xy 164.853097 117.048424) (xy 164.730585 117.067829) (xy 164.558386 117.123778) (xy 164.558363 117.123786) (xy 164.558359 117.123788) (xy 164.397005 117.206004) (xy 164.397002 117.206005) (xy 164.397002 117.206006) (xy 164.348169 117.241484) (xy 164.250499 117.312445) (xy 164.250491 117.312452) (xy 164.122452 117.440491) (xy 164.122445 117.440499) (xy 164.016004 117.587005) (xy 163.933788 117.748359) (xy 163.933786 117.748363) (xy 163.933778 117.748386) (xy 163.877829 117.920585) (xy 163.8495 118.099448) (xy 141.8055 118.099448) (xy 141.8055 113.443053) (xy 154.2 113.443053) (xy 154.205164 113.486066) (xy 154.210612 113.531441) (xy 154.266078 113.672094) (xy 154.266079 113.672095) (xy 154.357435 113.792564) (xy 154.477903 113.883919) (xy 154.477904 113.88392) (xy 154.618556 113.939386) (xy 154.706946 113.95) (xy 154.8 113.95) (xy 155.2 113.95) (xy 155.293049 113.95) (xy 155.293054 113.95) (xy 155.381443 113.939386) (xy 155.522095 113.88392) (xy 155.642564 113.792564) (xy 155.73392 113.672095) (xy 155.789386 113.531443) (xy 155.8 113.443053) (xy 155.8 113.2) (xy 155.2 113.2) (xy 155.2 113.95) (xy 154.8 113.95) (xy 154.8 113.2) (xy 154.2 113.2) (xy 154.2 113.443053) (xy 141.8055 113.443053) (xy 141.8055 112.556946) (xy 154.2 112.556946) (xy 154.2 112.8) (xy 154.8 112.8) (xy 155.2 112.8) (xy 155.8 112.8) (xy 155.8 112.556949) (xy 155.799999 112.556943) (xy 155.799994 112.556898) (xy 156.1995 112.556898) (xy 156.1995 113.443102) (xy 156.205126 113.489954) (xy 156.210122 113.531561) (xy 156.210122 113.531563) (xy 156.210123 113.531564) (xy 156.213885 113.541106) (xy 156.213888 113.541115) (xy 156.227721 113.576191) (xy 156.227721 113.576192) (xy 156.265637 113.672339) (xy 156.26564 113.672345) (xy 156.357076 113.792922) (xy 156.470904 113.87924) (xy 156.477656 113.88436) (xy 156.477657 113.88436) (xy 156.477876 113.884526) (xy 156.480596 113.885519) (xy 156.618436 113.939877) (xy 156.706898 113.9505) (xy 156.706903 113.9505) (xy 157.293097 113.9505) (xy 157.293102 113.9505) (xy 157.381564 113.939877) (xy 157.522342 113.884361) (xy 157.642922 113.792922) (xy 157.734361 113.672342) (xy 157.789877 113.531564) (xy 157.8005 113.443102) (xy 157.8005 113.443053) (xy 160.2 113.443053) (xy 160.205164 113.486066) (xy 160.210612 113.531441) (xy 160.266078 113.672094) (xy 160.266079 113.672095) (xy 160.357435 113.792564) (xy 160.477903 113.883919) (xy 160.477904 113.88392) (xy 160.618556 113.939386) (xy 160.706946 113.95) (xy 160.8 113.95) (xy 161.2 113.95) (xy 161.293049 113.95) (xy 161.293054 113.95) (xy 161.381443 113.939386) (xy 161.522095 113.88392) (xy 161.642564 113.792564) (xy 161.73392 113.672095) (xy 161.789386 113.531443) (xy 161.8 113.443053) (xy 161.8 113.2) (xy 161.2 113.2) (xy 161.2 113.95) (xy 160.8 113.95) (xy 160.8 113.2) (xy 160.2 113.2) (xy 160.2 113.443053) (xy 157.8005 113.443053) (xy 157.8005 112.556946) (xy 160.2 112.556946) (xy 160.2 112.8) (xy 160.8 112.8) (xy 160.8 112.05) (xy 160.706952 112.05) (xy 160.706946 112.05) (xy 160.668294 112.054641) (xy 160.618557 112.060612) (xy 160.477904 112.116078) (xy 160.477903 112.116079) (xy 160.357435 112.207435) (xy 160.266079 112.327903) (xy 160.266078 112.327904) (xy 160.210612 112.468557) (xy 160.204694 112.517853) (xy 160.2 112.556946) (xy 157.8005 112.556946) (xy 157.8005 112.556898) (xy 157.789877 112.468436) (xy 157.734361 112.327658) (xy 157.73436 112.327657) (xy 157.73436 112.327656) (xy 157.73063 112.322737) (xy 157.730318 112.32214) (xy 157.72924 112.320904) (xy 157.642922 112.207076) (xy 157.522345 112.11564) (xy 157.522339 112.115637) (xy 157.426193 112.077721) (xy 157.426191 112.077721) (xy 157.382543 112.060508) (xy 157.380583 112.059716) (xy 157.380311 112.059603) (xy 157.374199 112.059238) (xy 157.335926 112.054642) (xy 157.335925 112.054641) (xy 157.30822 112.051315) (xy 157.293102 112.0495) (xy 157.293098 112.0495) (xy 156.706901 112.0495) (xy 156.706898 112.0495) (xy 156.69656 112.050741) (xy 156.667853 112.054187) (xy 156.667853 112.054188) (xy 156.66192 112.0549) (xy 156.618439 112.060121) (xy 156.477653 112.11564) (xy 156.357076 112.207076) (xy 156.26564 112.327653) (xy 156.210121 112.468439) (xy 156.2049 112.51192) (xy 156.204188 112.517853) (xy 156.1995 112.556898) (xy 155.799994 112.556898) (xy 155.789386 112.468556) (xy 155.73392 112.327904) (xy 155.642564 112.207435) (xy 155.522095 112.116079) (xy 155.522096 112.116079) (xy 155.381441 112.060612) (xy 155.327933 112.054188) (xy 155.293054 112.05) (xy 155.293049 112.05) (xy 155.2 112.05) (xy 155.2 112.8) (xy 154.8 112.8) (xy 154.8 112.05) (xy 154.706952 112.05) (xy 154.706946 112.05) (xy 154.668294 112.054641) (xy 154.618557 112.060612) (xy 154.477904 112.116078) (xy 154.477903 112.116079) (xy 154.357435 112.207435) (xy 154.266079 112.327903) (xy 154.266078 112.327904) (xy 154.210612 112.468557) (xy 154.204694 112.517853) (xy 154.2 112.556946) (xy 141.8055 112.556946) (xy 141.8055 111.624) (xy 141.825185 111.556961) (xy 141.877989 111.511206) (xy 141.9295 111.5) (xy 161.304777 111.5)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
-			(pts (xy 111.555169 155.751685) (xy 111.600558 155.803693) (xy 112.683879 158.13227) (xy 113.957912 160.870778) (xy 113.968342 160.939865) (xy 113.968124 160.941393) (xy 113.093171 166.801842) (xy 113.084398 166.832625) (xy 111.966692 169.425093) (xy 111.922074 169.478861) (xy 111.85547 169.499972) (xy 111.852824 169.5) (xy 103.317129 169.5) (xy 103.25009 169.480315) (xy 103.204335 169.427511) (xy 103.19313 169.375539) (xy 103.198699 167.885844) (xy 103.218634 167.818882) (xy 103.23414 167.799516) (xy 104.046948 166.970323) (xy 104.107934 166.936229) (xy 104.177672 166.940518) (xy 104.234021 166.981829) (xy 104.25909 167.047046) (xy 104.2595 167.057126) (xy 104.2595 168.944856) (xy 104.259502 168.944882) (xy 104.262413 168.969987) (xy 104.262415 168.969991) (xy 104.307793 169.072764) (xy 104.307794 169.072765) (xy 104.387235 169.152206) (xy 104.490009 169.197585) (xy 104.515135 169.2005) (xy 106.404864 169.200499) (xy 106.404879 169.200497) (xy 106.404882 169.200497) (xy 106.429987 169.197586) (xy 106.429988 169.197585) (xy 106.429991 169.197585) (xy 106.532765 169.152206) (xy 106.612206 169.072765) (xy 106.657585 168.969991) (xy 106.6605 168.944865) (xy 106.660499 168.530805) (xy 106.680183 168.463769) (xy 106.732987 168.418014) (xy 106.802146 168.40807) (xy 106.865702 168.437095) (xy 106.894983 168.474513) (xy 106.973666 168.628935) (xy 106.973667 168.628936) (xy 107.084685 168.781741) (xy 107.084689 168.781746) (xy 107.218253 168.91531) (xy 107.218258 168.915314) (xy 107.371059 169.026329) (xy 107.539362 169.112085) (xy 107.718996 169.170451) (xy 107.8 169.183281) (xy 107.8 168.461879) (xy 107.807007 168.465925) (xy 107.934174 168.5) (xy 108.065826 168.5) (xy 108.192993 168.465925) (xy 108.2 168.461879) (xy 108.2 169.18328) (xy 108.281001 169.170451) (xy 108.281004 169.170451) (xy 108.460637 169.112085) (xy 108.62894 169.026329) (xy 108.781741 168.915314) (xy 108.781746 168.91531) (xy 108.91531 168.781746) (xy 108.915314 168.781741) (xy 109.026329 168.62894) (xy 109.112086 168.460635) (xy 109.151806 168.338389) (xy 109.191243 168.280713) (xy 109.255601 168.253514) (xy 109.324448 168.265428) (xy 109.375924 168.312672) (xy 109.387668 168.338387) (xy 109.427454 168.460836) (xy 109.463107 168.530808) (xy 109.51324 168.629199) (xy 109.62431 168.782073) (xy 109.757927 168.91569) (xy 109.910801 169.02676) (xy 109.990347 169.06729) (xy 110.079163 169.112545) (xy 110.079165 169.112545) (xy 110.079168 169.112547) (xy 110.175497 169.143846) (xy 110.258881 169.17094) (xy 110.445514 169.2005) (xy 110.445519 169.2005) (xy 110.634486 169.2005) (xy 110.821118 169.17094) (xy 110.822623 169.170451) (xy 111.000832 169.112547) (xy 111.169199 169.02676) (xy 111.322073 168.91569) (xy 111.45569 168.782073) (xy 111.56676 168.629199) (xy 111.652547 168.460832) (xy 111.71094 168.281118) (xy 111.715312 168.253514) (xy 111.7405 168.094486) (xy 111.7405 167.905513) (xy 111.71094 167.718881) (xy 111.67228 167.599901) (xy 111.652547 167.539168) (xy 111.652545 167.539165) (xy 111.652545 167.539163) (xy 111.575736 167.388418) (xy 111.56676 167.370801) (xy 111.45569 167.217927) (xy 111.322073 167.08431) (xy 111.169199 166.97324) (xy 111.163476 166.970324) (xy 111.000836 166.887454) (xy 110.821118 166.829059) (xy 110.634486 166.7995) (xy 110.634481 166.7995) (xy 110.445519 166.7995) (xy 110.445514 166.7995) (xy 110.258881 166.829059) (xy 110.079163 166.887454) (xy 109.9108 166.97324) (xy 109.827716 167.033605) (xy 109.757927 167.08431) (xy 109.757925 167.084312) (xy 109.757924 167.084312) (xy 109.624312 167.217924) (xy 109.624312 167.217925) (xy 109.62431 167.217927) (xy 109.618261 167.226253) (xy 109.51324 167.3708) (xy 109.427454 167.539163) (xy 109.387668 167.661612) (xy 109.34823 167.719287) (xy 109.283871 167.746485) (xy 109.215025 167.73457) (xy 109.163549 167.687325) (xy 109.151806 167.661611) (xy 109.112085 167.539362) (xy 109.026329 167.371059) (xy 108.915314 167.218258) (xy 108.91531 167.218253) (xy 108.781746 167.084689) (xy 108.781741 167.084685) (xy 108.62894 166.97367) (xy 108.460635 166.887913) (xy 108.280999 166.829547) (xy 108.2 166.816718) (xy 108.2 167.53812) (xy 108.192993 167.534075) (xy 108.065826 167.5) (xy 107.934174 167.5) (xy 107.807007 167.534075) (xy 107.8 167.53812) (xy 107.8 166.816718) (xy 107.799999 166.816718) (xy 107.719 166.829547) (xy 107.539364 166.887913) (xy 107.371059 166.97367) (xy 107.218258 167.084685) (xy 107.218253 167.084689) (xy 107.084689 167.218253) (xy 107.084685 167.218258) (xy 106.973667 167.371063) (xy 106.973666 167.371064) (xy 106.894983 167.525487) (xy 106.847009 167.576283) (xy 106.779188 167.593078) (xy 106.713053 167.57054) (xy 106.669602 167.515825) (xy 106.660499 167.469192) (xy 106.660499 167.203499) (xy 106.680184 167.13646) (xy 106.688325 167.125226) (xy 106.72132 167.084685) (xy 109.300515 163.915616) (xy 109.329276 163.883571) (xy 109.333716 163.874822) (xy 109.339909 163.867213) (xy 109.357515 163.827928) (xy 109.377001 163.789535) (xy 109.379025 163.779934) (xy 109.383038 163.770982) (xy 109.389878 163.728472) (xy 109.398761 163.686351) (xy 109.398232 163.676556) (xy 109.399791 163.666868) (xy 109.395697 163.626978) (xy 109.395235 163.621084) (xy 109.393074 163.581051) (xy 109.393071 163.581043) (xy 109.391579 163.573061) (xy 109.391752 163.573028) (xy 109.391074 163.569833) (xy 109.390904 163.569874) (xy 109.389026 163.561964) (xy 109.374762 163.524531) (xy 109.372765 163.518885) (xy 109.271759 163.209704) (xy 109.271585 163.203945) (xy 109.268768 163.198922) (xy 109.270543 163.16941) (xy 109.269653 163.139866) (xy 109.272709 163.13343) (xy 109.272965 163.129178) (xy 109.289525 163.098019) (xy 109.393502 162.9558) (xy 109.44811 162.913633) (xy 109.522342 162.884361) (xy 109.642922 162.792922) (xy 109.734361 162.672342) (xy 109.789877 162.531564) (xy 109.8005 162.443102) (xy 109.8005 161.556898) (xy 109.789877 161.468436) (xy 109.734361 161.327658) (xy 109.73436 161.327657) (xy 109.73436 161.327656) (xy 109.642922 161.207077) (xy 109.522343 161.115639) (xy 109.381561 161.060122) (xy 109.335926 161.054642) (xy 109.293102 161.0495) (xy 108.706898 161.0495) (xy 108.667853 161.054188) (xy 108.618438 161.060122) (xy 108.477656 161.115639) (xy 108.357077 161.207077) (xy 108.265639 161.327656) (xy 108.210122 161.468438) (xy 108.204666 161.513876) (xy 108.1995 161.556898) (xy 108.1995 162.443102) (xy 108.203092 162.473013) (xy 108.210122 162.531561) (xy 108.265639 162.672343) (xy 108.357077 162.792922) (xy 108.381952 162.811785) (xy 108.392156 162.825594) (xy 108.405949 162.83582) (xy 108.412488 162.853108) (xy 108.423476 162.867977) (xy 108.424709 162.885415) (xy 108.430669 162.901171) (xy 108.42753 162.92531) (xy 108.428314 162.936386) (xy 108.426629 162.944304) (xy 108.426599 162.944365) (xy 108.42446 162.954501) (xy 108.424441 162.954595) (xy 108.424402 162.954666) (xy 108.418788 162.973572) (xy 108.415088 162.983126) (xy 108.412245 163.009416) (xy 108.410297 163.021662) (xy 108.404839 163.047548) (xy 108.404838 163.047559) (xy 108.40539 163.057782) (xy 108.404853 163.077778) (xy 108.403752 163.087965) (xy 108.403752 163.087973) (xy 108.406608 163.106361) (xy 108.408764 163.120241) (xy 108.410526 163.152849) (xy 108.416823 163.172128) (xy 108.418365 163.182051) (xy 108.419937 163.192172) (xy 108.419937 163.192173) (xy 108.430622 163.216366) (xy 108.435061 163.227954) (xy 108.526436 163.507656) (xy 108.528542 163.577493) (xy 108.50474 163.624435) (xy 105.957882 166.753773) (xy 105.900297 166.793343) (xy 105.861708 166.7995) (xy 104.511556 166.799501) (xy 104.511556 166.798251) (xy 104.448516 166.783608) (xy 104.39981 166.733513) (xy 104.385918 166.665039) (xy 104.411252 166.599924) (xy 104.420906 166.588827) (xy 105.226669 165.766823) (xy 105.26258 165.730913) (xy 105.263588 165.729163) (xy 105.26501 165.727714) (xy 105.265015 165.727704) (xy 105.265017 165.727703) (xy 105.289668 165.684002) (xy 105.290157 165.683144) (xy 105.315307 165.639587) (xy 105.315311 165.639571) (xy 105.316303 165.637178) (xy 105.316307 165.63717) (xy 105.316797 165.635986) (xy 105.329314 165.587329) (xy 105.329587 165.586286) (xy 105.3426 165.537727) (xy 105.3426 165.53772) (xy 105.34294 165.53514) (xy 105.34294 165.535138) (xy 105.342944 165.535112) (xy 105.343107 165.533872) (xy 105.342606 165.483609) (xy 105.3426 165.482372) (xy 105.3426 161.733567) (xy 105.362285 161.666528) (xy 105.378918 161.645886) (xy 105.467913 161.556898) (xy 106.1995 161.556898) (xy 106.1995 162.443102) (xy 106.203092 162.473013) (xy 106.210122 162.531561) (xy 106.265639 162.672343) (xy 106.357077 162.792922) (xy 106.477656 162.88436) (xy 106.477657 162.88436) (xy 106.477658 162.884361) (xy 106.618436 162.939877) (xy 106.706898 162.9505) (xy 106.706903 162.9505) (xy 107.293097 162.9505) (xy 107.293102 162.9505) (xy 107.381564 162.939877) (xy 107.522342 162.884361) (xy 107.642922 162.792922) (xy 107.734361 162.672342) (xy 107.789877 162.531564) (xy 107.8005 162.443102) (xy 107.8005 161.556898) (xy 107.789877 161.468436) (xy 107.734361 161.327658) (xy 107.73436 161.327657) (xy 107.73436 161.327656) (xy 107.642922 161.207077) (xy 107.522343 161.115639) (xy 107.381561 161.060122) (xy 107.335926 161.054642) (xy 107.293102 161.0495) (xy 106.706898 161.0495) (xy 106.667853 161.054188) (xy 106.618438 161.060122) (xy 106.477656 161.115639) (xy 106.357077 161.207077) (xy 106.265639 161.327656) (xy 106.210122 161.468438) (xy 106.204666 161.513876) (xy 106.1995 161.556898) (xy 105.467913 161.556898) (xy 106.458006 160.566883) (xy 106.458013 160.56688) (xy 106.494517 160.530375) (xy 106.52775 160.497145) (xy 106.53068 160.494523) (xy 106.532548 160.492347) (xy 106.532571 160.492325) (xy 106.532575 160.492317) (xy 106.53258 160.492313) (xy 106.532583 160.492306) (xy 106.532914 160.491922) (xy 106.534417 160.489131) (xy 106.555654 160.452347) (xy 106.555656 160.452342) (xy 106.555657 160.452341) (xy 106.585301 160.401002) (xy 106.585303 160.400995) (xy 106.585303 160.400991) (xy 106.585307 160.400987) (xy 106.596115 160.360649) (xy 106.612599 160.299142) (xy 106.612599 160.299141) (xy 106.6126 160.299138) (xy 106.6126 160.272779) (xy 106.6126 160.272776) (xy 106.612603 160.193689) (xy 106.612601 160.193684) (xy 106.612602 160.186114) (xy 106.6126 160.186064) (xy 106.6126 158.39649) (xy 106.632285 158.329451) (xy 106.647934 158.309805) (xy 106.766117 158.188921) (xy 108.990883 155.913295) (xy 109.017511 155.898362) (xy 109.042955 155.881504) (xy 109.04769 155.881437) (xy 109.051823 155.87912) (xy 109.082296 155.880953) (xy 109.112818 155.880527) (xy 109.116838 155.883032) (xy 109.121567 155.883317) (xy 109.146208 155.901332) (xy 109.172118 155.917477) (xy 109.175714 155.922904) (xy 109.17797 155.924554) (xy 109.191612 155.946898) (xy 109.191621 155.946917) (xy 109.20253 156.01593) (xy 109.19096 156.054456) (xy 109.185134 156.066375) (xy 109.1745 156.139364) (xy 109.1745 156.360636) (xy 109.185134 156.433625) (xy 109.19096 156.445542) (xy 109.202717 156.514416) (xy 109.19096 156.554456) (xy 109.185134 156.566375) (xy 109.1745 156.639364) (xy 109.1745 156.860636) (xy 109.185134 156.933625) (xy 109.185134 156.933626) (xy 109.185135 156.933628) (xy 109.240172 157.04621) (xy 109.328789 157.134827) (xy 109.436572 157.187518) (xy 109.441375 157.189866) (xy 109.514364 157.2005) (xy 109.51437 157.2005) (xy 110.98563 157.2005) (xy 110.985636 157.2005) (xy 111.058625 157.189866) (xy 111.116118 157.161759) (xy 111.17121 157.134827) (xy 111.259827 157.04621) (xy 111.286759 156.991118) (xy 111.314866 156.933625) (xy 111.3255 156.860636) (xy 111.3255 156.639364) (xy 111.314866 156.566375) (xy 111.309041 156.55446) (xy 111.297281 156.485592) (xy 111.30904 156.445541) (xy 111.314866 156.433625) (xy 111.3255 156.360636) (xy 111.3255 156.139364) (xy 111.314866 156.066375) (xy 111.309041 156.05446) (xy 111.297281 155.985592) (xy 111.298891 155.975471) (xy 111.302041 155.959856) (xy 111.314866 155.933625) (xy 111.3255 155.860636) (xy 111.3255 155.843611) (xy 111.32795 155.831471) (xy 111.338691 155.811073) (xy 111.345185 155.788961) (xy 111.354661 155.780749) (xy 111.360507 155.76965) (xy 111.380572 155.758297) (xy 111.397989 155.743206) (xy 111.41303 155.739933) (xy 111.421318 155.735245) (xy 111.431853 155.735838) (xy 111.4495 155.732) (xy 111.48813 155.732)
+			(pts (xy 163.742606 157.832623) (xy 163.757604 157.837027) (xy 163.772594 157.846657) (xy 163.789675 157.851667) (xy 163.816355 157.874772) (xy 163.817542 157.876141) (xy 163.845018 157.931002) (xy 163.846663 157.93856) (xy 163.8495 157.964931) (xy 163.8495 158.09055) (xy 163.877829 158.269413) (xy 163.933762 158.441563) (xy 163.933788 158.441639) (xy 163.96655 158.505936) (xy 163.96655 158.505938) (xy 163.966551 158.505938) (xy 164.007302 158.585916) (xy 164.016006 158.602997) (xy 164.058016 158.660819) (xy 164.122432 158.749482) (xy 164.122444 158.749498) (xy 164.122452 158.749507) (xy 164.250491 158.877546) (xy 164.2505 158.877554) (xy 164.250524 158.877572) (xy 164.341405 158.943601) (xy 164.341413 158.943605) (xy 164.346458 158.947271) (xy 164.397006 158.983996) (xy 164.502484 159.03774) (xy 164.55836 159.066211) (xy 164.558363 159.066212) (xy 164.644476 159.094191) (xy 164.730591 159.122171) (xy 164.850038 159.141089) (xy 164.874676 159.144991) (xy 164.908388 159.155416) (xy 164.914672 159.158395) (xy 164.927975 159.170261) (xy 164.937805 159.174921) (xy 164.943555 159.184157) (xy 164.966814 159.204902) (xy 164.985536 159.272217) (xy 164.964893 159.338967) (xy 164.913067 159.383231) (xy 164.907679 159.385692) (xy 164.875559 159.395374) (xy 164.730702 159.418317) (xy 164.558627 159.474226) (xy 164.558551 159.474252) (xy 164.397271 159.55643) (xy 164.397264 159.556434) (xy 164.250831 159.662822) (xy 164.250828 159.662824) (xy 164.122824 159.790828) (xy 164.122824 159.790829) (xy 164.016434 159.937264) (xy 164.016433 159.937266) (xy 163.934254 160.098548) (xy 163.878317 160.270699) (xy 163.877242 160.277486) (xy 163.867342 160.34) (xy 164.376269 160.34) (xy 164.384954 160.34255) (xy 164.393916 160.341262) (xy 164.417956 160.35224) (xy 164.443308 160.359685) (xy 164.449235 160.366525) (xy 164.457472 160.370287) (xy 164.471761 160.392521) (xy 164.489063 160.412489) (xy 164.49135 160.423003) (xy 164.495246 160.429065) (xy 164.496674 160.447478) (xy 164.500269 160.464) (xy 164.500269 160.47317) (xy 164.5 160.474174) (xy 164.5 160.605826) (xy 164.500269 160.606829) (xy 164.500269 160.616) (xy 164.49262 160.642047) (xy 164.488433 160.668869) (xy 164.482922 160.675075) (xy 164.480584 160.683039) (xy 164.460069 160.700815) (xy 164.442044 160.721117) (xy 164.433962 160.723437) (xy 164.42778 160.728794) (xy 164.402782 160.732388) (xy 164.376269 160.74) (xy 163.867342 160.74) (xy 163.877295 160.802845) (xy 163.878317 160.809299) (xy 163.934249 160.981442) (xy 163.934251 160.981446) (xy 164.006114 161.122481) (xy 164.016434 161.142734) (xy 164.122823 161.289169) (xy 164.25083 161.417176) (xy 164.397265 161.523565) (xy 164.558552 161.605747) (xy 164.558555 161.605748) (xy 164.558591 161.605759) (xy 164.558627 161.605772) (xy 164.723819 161.659444) (xy 164.730706 161.661682) (xy 164.87467 161.684483) (xy 164.886951 161.690305) (xy 164.908388 161.694909) (xy 164.914675 161.69789) (xy 164.927976 161.709753) (xy 164.937803 161.714412) (xy 164.943553 161.723647) (xy 164.966815 161.744395) (xy 164.985537 161.81171) (xy 164.964894 161.87846) (xy 164.934002 161.904843) (xy 164.925233 161.915375) (xy 164.919591 161.917152) (xy 164.913068 161.922724) (xy 164.90768 161.925185) (xy 164.87556 161.934867) (xy 164.730585 161.957829) (xy 164.558366 162.013785) (xy 164.558362 162.013787) (xy 164.558349 162.013793) (xy 164.546519 162.019821) (xy 164.519176 162.029909) (xy 164.491422 162.036573) (xy 164.462471 162.04) (xy 162.703668 162.04) (xy 162.668733 162.034977) (xy 162.657879 162.03179) (xy 162.599101 161.994016) (xy 162.570076 161.93046) (xy 162.580018 161.861306) (xy 162.58149 161.858082) (xy 162.619349 161.810798) (xy 162.623327 161.807781) (xy 162.628873 161.803574) (xy 162.628886 161.803569) (xy 162.628884 161.803567) (xy 162.63567 161.79842) (xy 162.642922 161.792922) (xy 162.734361 161.672342) (xy 162.789877 161.531564) (xy 162.8005 161.443102) (xy 162.8005 160.556898) (xy 162.789877 160.468436) (xy 162.734361 160.327658) (xy 162.73436 160.327657) (xy 162.73436 160.327656) (xy 162.73063 160.322737) (xy 162.730318 160.32214) (xy 162.72924 160.320904) (xy 162.642922 160.207076) (xy 162.522345 160.11564) (xy 162.522343 160.115639) (xy 162.416959 160.074081) (xy 162.381559 160.060121) (xy 162.342152 160.055389) (xy 162.335926 160.054642) (xy 162.335925 160.054641) (xy 162.306527 160.051112) (xy 162.293102 160.0495) (xy 162.293098 160.0495) (xy 161.834084 160.0495) (xy 161.799149 160.044477) (xy 161.788295 160.04129) (xy 161.729517 160.003516) (xy 161.700492 159.93996) (xy 161.701476 159.933116) (xy 161.710432 159.870811) (xy 161.713622 159.863824) (xy 161.738732 159.827659) (xy 161.775562 159.79083) (xy 162.32048 159.245913) (xy 162.373207 159.154588) (xy 162.4005 159.052727) (xy 162.4005 158.947273) (xy 162.4005 158.034632) (xy 162.405522 157.9997) (xy 162.406614 157.995982) (xy 162.410772 157.981819) (xy 162.444426 157.926776) (xy 162.448081 157.92331) (xy 162.487913 157.897937) (xy 162.507613 157.890169) (xy 162.522342 157.884361) (xy 162.554071 157.860299) (xy 162.55842 157.858058) (xy 162.560191 157.855944) (xy 162.57519 157.849418) (xy 162.592041 157.840738) (xy 162.596184 157.839444) (xy 162.603903 157.837617) (xy 162.612486 157.834354) (xy 162.616073 157.833235) (xy 162.62298 157.833117) (xy 162.653028 157.8276) (xy 163.70767 157.8276)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
-			(pts (xy 141.430124 162.953872) (xy 141.481848 163.000844) (xy 141.5 163.065436) (xy 141.5 167.367015) (xy 141.486485 167.423309) (xy 141.427455 167.539161) (xy 141.387668 167.661612) (xy 141.34823 167.719287) (xy 141.283871 167.746485) (xy 141.215025 167.73457) (xy 141.163549 167.687325) (xy 141.151806 167.661611) (xy 141.112085 167.539362) (xy 141.026329 167.371059) (xy 140.915314 167.218258) (xy 140.91531 167.218253) (xy 140.781746 167.084689) (xy 140.781741 167.084685) (xy 140.62894 166.97367) (xy 140.460635 166.887913) (xy 140.280999 166.829547) (xy 140.2 166.816718) (xy 140.2 167.53812) (xy 140.192993 167.534075) (xy 140.065826 167.5) (xy 139.934174 167.5) (xy 139.807007 167.534075) (xy 139.8 167.53812) (xy 139.8 166.816718) (xy 139.799999 166.816718) (xy 139.719 166.829547) (xy 139.539364 166.887913) (xy 139.371059 166.97367) (xy 139.218258 167.084685) (xy 139.218253 167.084689) (xy 139.084689 167.218253) (xy 139.084685 167.218258) (xy 138.973667 167.371063) (xy 138.973666 167.371064) (xy 138.894983 167.525487) (xy 138.847009 167.576283) (xy 138.779188 167.593078) (xy 138.713053 167.57054) (xy 138.669602 167.515825) (xy 138.660499 167.469192) (xy 138.660499 167.22156) (xy 138.680184 167.154521) (xy 138.688941 167.142537) (xy 140.534363 164.911329) (xy 140.55828 164.887413) (xy 140.567839 164.870854) (xy 140.580022 164.856126) (xy 140.591664 164.830688) (xy 140.597013 164.820323) (xy 140.611007 164.796087) (xy 140.613259 164.787679) (xy 140.620285 164.768159) (xy 140.623911 164.760239) (xy 140.629547 164.726892) (xy 140.6383 164.694227) (xy 140.6383 164.675109) (xy 140.641486 164.65626) (xy 140.638852 164.628426) (xy 140.6383 164.616743) (xy 140.6383 163.0745) (xy 140.657985 163.007461) (xy 140.710789 162.961706) (xy 140.7623 162.9505) (xy 141.293096 162.9505) (xy 141.293102 162.9505) (xy 141.361217 162.94232)
+			(pts (xy 164.859962 154.075517) (xy 164.863837 154.076654) (xy 164.865823 154.077237) (xy 164.924607 154.115002) (xy 164.953641 154.178554) (xy 164.943708 154.247714) (xy 164.897961 154.300524) (xy 164.897945 154.300535) (xy 164.897584 154.300767) (xy 164.849944 154.318924) (xy 164.730585 154.337829) (xy 164.558386 154.393778) (xy 164.558363 154.393786) (xy 164.558359 154.393788) (xy 164.397005 154.476004) (xy 164.397002 154.476005) (xy 164.397002 154.476006) (xy 164.348169 154.511484) (xy 164.250499 154.582445) (xy 164.250491 154.582452) (xy 164.12245 154.710493) (xy 164.122446 154.710499) (xy 164.122445 154.7105) (xy 164.122441 154.710505) (xy 164.057783 154.7995) (xy 164.020568 154.850722) (xy 164.01435 154.858589) (xy 164.012408 154.860851) (xy 164.00551 154.868157) (xy 164.004794 154.869723) (xy 163.998492 154.877068) (xy 163.994513 154.879652) (xy 163.983583 154.891734) (xy 163.979914 154.894779) (xy 163.950999 154.912711) (xy 163.948174 154.913964) (xy 163.915633 154.923338) (xy 163.914339 154.923525) (xy 163.896604 154.9248) (xy 163.878228 154.9248) (xy 163.843292 154.919777) (xy 163.81805 154.912365) (xy 163.765304 154.881068) (xy 163.729021 154.844784) (xy 163.729017 154.844781) (xy 163.729009 154.844775) (xy 163.702447 154.82944) (xy 163.592107 154.765735) (xy 163.592083 154.765722) (xy 163.478439 154.735272) (xy 163.439357 154.7248) (xy 163.439356 154.7248) (xy 163.281243 154.7248) (xy 163.128518 154.765722) (xy 163.128511 154.765724) (xy 163.12851 154.765725) (xy 163.1285 154.76573) (xy 162.991598 154.84477) (xy 162.991594 154.844772) (xy 162.99159 154.844775) (xy 162.991582 154.844781) (xy 162.991578 154.844784) (xy 162.991576 154.844785) (xy 162.879785 154.956576) (xy 162.879784 154.956578) (xy 162.879781 154.956581) (xy 162.879781 154.956582) (xy 162.879775 154.95659) (xy 162.879772 154.956594) (xy 162.87977 154.956598) (xy 162.80073 155.0935) (xy 162.800722 155.093518) (xy 162.7598 155.246243) (xy 162.7598 155.404357) (xy 162.80002 155.554458) (xy 162.800723 155.557083) (xy 162.800726 155.55709) (xy 162.878725 155.69219) (xy 162.879508 155.693632) (xy 162.879517 155.693676) (xy 162.879698 155.693934) (xy 162.991583 155.805819) (xy 162.992276 155.806319) (xy 162.994787 155.80767) (xy 163.086529 155.860636) (xy 163.128516 155.884877) (xy 163.281243 155.9258) (xy 163.281245 155.9258) (xy 163.439355 155.9258) (xy 163.439357 155.9258) (xy 163.592084 155.884877) (xy 163.651541 155.85055) (xy 163.720272 155.810869) (xy 163.737538 155.802607) (xy 163.758367 155.794551) (xy 163.827994 155.788731) (xy 163.889709 155.821473) (xy 163.89425 155.825906) (xy 163.925561 155.876317) (xy 163.931546 155.894739) (xy 163.93378 155.901613) (xy 163.933789 155.901643) (xy 163.976564 155.98559) (xy 163.976564 155.985591) (xy 164.014786 156.060605) (xy 164.016 156.062988) (xy 164.016003 156.062992) (xy 164.016006 156.062997) (xy 164.120685 156.207077) (xy 164.122445 156.209499) (xy 164.122452 156.209507) (xy 164.250491 156.337546) (xy 164.250499 156.337553) (xy 164.2505 156.337554) (xy 164.250505 156.337558) (xy 164.282187 156.360576) (xy 164.282269 156.360635) (xy 164.282271 156.360637) (xy 164.29059 156.366681) (xy 164.397006 156.443996) (xy 164.502484 156.49774) (xy 164.55836 156.526211) (xy 164.558363 156.526212) (xy 164.644476 156.554191) (xy 164.730591 156.582171) (xy 164.772733 156.588845) (xy 164.803478 156.593715) (xy 164.803577 156.59373) (xy 164.803639 156.59374) (xy 164.873071 156.604738) (xy 164.906787 156.615163) (xy 164.913071 156.618142) (xy 164.926374 156.630007) (xy 164.936203 156.634667) (xy 164.941954 156.643903) (xy 164.965213 156.664649) (xy 164.983935 156.731964) (xy 164.963292 156.798714) (xy 164.911466 156.842978) (xy 164.906078 156.845439) (xy 164.873958 156.855121) (xy 164.730585 156.877829) (xy 164.558386 156.933778) (xy 164.558367 156.933785) (xy 164.558366 156.933785) (xy 164.397013 157.015999) (xy 164.395824 157.016727) (xy 164.384984 157.023661) (xy 164.382485 157.025058) (xy 164.377241 157.026253) (xy 164.366083 157.031785) (xy 164.366227 157.032186) (xy 164.365195 157.032555) (xy 164.365095 157.032275) (xy 164.359732 157.034935) (xy 164.348167 157.038631) (xy 164.343882 157.04016) (xy 164.274126 157.044142) (xy 164.261642 157.040538) (xy 164.235261 157.0314) (xy 164.235258 157.031399) (xy 164.235259 157.031399) (xy 164.232537 157.031204) (xy 164.209342 157.0273) (xy 164.206732 157.0266) (xy 164.206727 157.0266) (xy 164.172804 157.0266) (xy 164.170616 157.026581) (xy 164.16727 157.026521) (xy 164.163927 157.026282) (xy 164.163924 157.026282) (xy 164.130078 157.023852) (xy 164.127418 157.024365) (xy 164.114562 157.025591) (xy 164.114559 157.025591) (xy 164.111977 157.025837) (xy 164.109851 157.02604) (xy 164.098083 157.0266) (xy 162.94233 157.0266) (xy 162.907389 157.021575) (xy 162.89239 157.01717) (xy 162.877402 157.00754) (xy 162.860324 157.002532) (xy 162.833644 156.979427) (xy 162.832457 156.978058) (xy 162.804977 156.923183) (xy 162.803332 156.915621) (xy 162.8005 156.889268) (xy 162.8005 156.556903) (xy 162.8005 156.556901) (xy 162.8005 156.556898) (xy 162.789877 156.468436) (xy 162.734361 156.327658) (xy 162.73436 156.327657) (xy 162.73436 156.327656) (xy 162.73063 156.322737) (xy 162.730318 156.32214) (xy 162.72924 156.320904) (xy 162.642922 156.207076) (xy 162.522345 156.11564) (xy 162.522339 156.115637) (xy 162.426193 156.077721) (xy 162.426191 156.077721) (xy 162.382543 156.060508) (xy 162.380583 156.059716) (xy 162.380311 156.059603) (xy 162.374199 156.059238) (xy 162.334389 156.054458) (xy 162.293102 156.0495) (xy 162.293097 156.0495) (xy 161.706901 156.0495) (xy 161.706898 156.0495) (xy 161.69656 156.050741) (xy 161.667853 156.054187) (xy 161.667853 156.054188) (xy 161.665605 156.054458) (xy 161.618439 156.060121) (xy 161.477653 156.11564) (xy 161.357076 156.207076) (xy 161.26564 156.327653) (xy 161.265541 156.327904) (xy 161.210122 156.468438) (xy 161.204601 156.514416) (xy 161.200062 156.552224) (xy 161.1995 156.556901) (xy 161.1995 157.443103) (xy 161.20206 157.464423) (xy 161.204658 157.486051) (xy 161.205755 157.495192) (xy 161.209238 157.524197) (xy 161.209603 157.530313) (xy 161.209723 157.530601) (xy 161.210517 157.532564) (xy 161.22069 157.558362) (xy 161.265638 157.672341) (xy 161.26564 157.672345) (xy 161.357076 157.792922) (xy 161.477058 157.883907) (xy 161.477656 157.88436) (xy 161.477657 157.884361) (xy 161.480607 157.885524) (xy 161.504407 157.894909) (xy 161.53506 157.912396) (xy 161.547398 157.921996) (xy 161.588218 157.978695) (xy 161.592467 157.990768) (xy 161.5995 158.031934) (xy 161.5995 158.764914) (xy 161.594476 158.799851) (xy 161.587064 158.825092) (xy 161.555769 158.877836) (xy 160.429577 160.004027) (xy 160.414508 160.015308) (xy 160.401324 160.025178) (xy 160.380696 160.036442) (xy 160.327151 160.05147) (xy 160.324877 160.051578) (xy 160.313071 160.051152) (xy 160.312423 160.051294) (xy 160.311935 160.051112) (xy 160.304214 160.050834) (xy 160.29665 160.049926) (xy 160.296648 160.049925) (xy 160.293103 160.0495) (xy 160.293102 160.0495) (xy 159.706898 160.0495) (xy 159.69656 160.050741) (xy 159.667853 160.054187) (xy 159.667853 160.054188) (xy 159.66192 160.0549) (xy 159.618439 160.060121) (xy 159.477653 160.11564) (xy 159.477649 160.115643) (xy 159.415745 160.162587) (xy 159.384878 160.179693) (xy 159.370264 160.185248) (xy 159.300607 160.190667) (xy 159.298783 160.190282) (xy 159.294485 160.189375) (xy 159.232959 160.156263) (xy 159.232425 160.155732) (xy 158.651549 159.574856) (xy 158.647599 159.57072) (xy 158.620227 159.540699) (xy 158.614016 159.535461) (xy 158.614177 159.535269) (xy 158.612317 159.533772) (xy 158.612166 159.53397) (xy 158.605715 159.529021) (xy 158.605714 159.52902) (xy 158.588119 159.518861) (xy 158.570523 159.508701) (xy 158.569656 159.508196) (xy 158.569639 159.508186) (xy 158.565644 159.505733) (xy 158.531428 159.483816) (xy 158.531427 159.483815) (xy 158.531426 159.483815) (xy 158.531239 159.483727) (xy 158.522111 159.48075) (xy 158.51439 159.476293) (xy 158.481031 159.467354) (xy 158.481016 159.46735) (xy 158.4751 159.465764) (xy 158.469639 159.464165) (xy 158.430932 159.451856) (xy 158.430904 159.451852) (xy 158.421524 159.451409) (xy 158.41253 159.449) (xy 158.412527 159.449) (xy 158.371885 159.449) (xy 158.368948 159.448932) (xy 158.368923 159.448931) (xy 158.367554 159.448899) (xy 158.364733 159.448801) (xy 153.439871 159.221514) (xy 153.405208 159.214887) (xy 153.379295 159.205962) (xy 153.331994 159.176402) (xy 152.262626 158.107033) (xy 152.262625 158.107032) (xy 152.262621 158.107028) (xy 152.241474 158.078777) (xy 152.228867 158.055688) (xy 152.2137 157.996263) (xy 152.2137 157.944945) (xy 152.2137 157.944943) (xy 152.172777 157.792216) (xy 152.131456 157.720645) (xy 152.093724 157.65529) (xy 152.093718 157.655282) (xy 151.981915 157.543479) (xy 151.981912 157.543477) (xy 151.975464 157.538529) (xy 151.975877 157.53799) (xy 151.957726 157.523715) (xy 151.948149 157.513672) (xy 151.916129 157.451571) (xy 151.916942 157.443053) (xy 153.2 157.443053) (xy 153.201023 157.451571) (xy 153.210612 157.531441) (xy 153.266078 157.672094) (xy 153.266079 157.672095) (xy 153.357435 157.792564) (xy 153.477903 157.883919) (xy 153.477904 157.88392) (xy 153.618556 157.939386) (xy 153.706946 157.95) (xy 153.8 157.95) (xy 154.2 157.95) (xy 154.293049 157.95) (xy 154.293054 157.95) (xy 154.381443 157.939386) (xy 154.522095 157.88392) (xy 154.642564 157.792564) (xy 154.73392 157.672095) (xy 154.789386 157.531443) (xy 154.8 157.443053) (xy 154.8 157.2) (xy 154.2 157.2) (xy 154.2 157.95) (xy 153.8 157.95) (xy 153.8 157.2) (xy 153.2 157.2) (xy 153.2 157.443053) (xy 151.916942 157.443053) (xy 151.922766 157.382019) (xy 151.925929 157.374118) (xy 151.953363 157.332527) (xy 153.032132 156.253758) (xy 153.034773 156.252316) (xy 153.06039 156.232606) (xy 153.068634 156.228105) (xy 153.08605 156.224317) (xy 153.093453 156.220275) (xy 153.11179 156.218718) (xy 153.136908 156.213256) (xy 153.202371 156.237677) (xy 153.244239 156.293613) (xy 153.250622 156.355738) (xy 153.24988 156.360576) (xy 153.249021 156.363755) (xy 153.249135 156.364915) (xy 153.24823 156.366681) (xy 153.242669 156.387265) (xy 153.210613 156.468556) (xy 153.207109 156.49774) (xy 153.2 156.556946) (xy 153.2 156.8) (xy 153.8 156.8) (xy 154.2 156.8) (xy 154.8 156.8) (xy 154.8 156.556949) (xy 154.799999 156.556943) (xy 154.799994 156.556901) (xy 155.1995 156.556901) (xy 155.1995 157.443103) (xy 155.20206 157.464423) (xy 155.204658 157.486051) (xy 155.205755 157.495192) (xy 155.209238 157.524197) (xy 155.209603 157.530313) (xy 155.209723 157.530601) (xy 155.210517 157.532564) (xy 155.22069 157.558362) (xy 155.265638 157.672341) (xy 155.26564 157.672345) (xy 155.357076 157.792922) (xy 155.466951 157.876242) (xy 155.477656 157.88436) (xy 155.477657 157.88436) (xy 155.477876 157.884526) (xy 155.480596 157.885519) (xy 155.618436 157.939877) (xy 155.706898 157.9505) (xy 155.837828 157.9505) (xy 155.868907 157.954968) (xy 155.87276 157.955521) (xy 155.886079 157.959432) (xy 155.944857 157.997206) (xy 155.973883 158.060761) (xy 155.975093 158.069176) (xy 155.97213 158.118918) (xy 155.945796 158.2172) (xy 155.9337 158.262343) (xy 155.9337 158.420457) (xy 155.970456 158.55763) (xy 155.974623 158.573183) (xy 155.974626 158.57319) (xy 156.053106 158.709124) (xy 156.053537 158.709947) (xy 156.053598 158.710034) (xy 156.165487 158.821923) (xy 156.166169 158.822414) (xy 156.168675 158.823763) (xy 156.252948 158.872417) (xy 156.295102 158.896755) (xy 156.295103 158.896755) (xy 156.302412 158.900975) (xy 156.302416 158.900977) (xy 156.455143 158.9419) (xy 156.455145 158.9419) (xy 156.613255 158.9419) (xy 156.613257 158.9419) (xy 156.765984 158.900977) (xy 156.902916 158.82192) (xy 157.01472 158.710116) (xy 157.093777 158.573184) (xy 157.1347 158.420457) (xy 157.1347 158.262343) (xy 157.093777 158.109616) (xy 157.059882 158.050908) (xy 157.052527 158.038168) (xy 157.052525 158.038166) (xy 157.049162 158.03234) (xy 157.014724 157.97269) (xy 157.014718 157.972682) (xy 156.976881 157.934845) (xy 156.971254 157.927159) (xy 156.969793 157.923111) (xy 156.962472 157.913331) (xy 156.961961 157.912396) (xy 156.954067 157.897937) (xy 156.949866 157.890243) (xy 156.9347 157.83082) (xy 156.9347 157.550959) (xy 156.93471 157.54941) (xy 156.935327 157.499978) (xy 156.934943 157.49675) (xy 156.934943 157.496748) (xy 156.93494 157.496723) (xy 156.934758 157.495192) (xy 156.9347 157.494975) (xy 156.9347 157.494973) (xy 156.921697 157.446446) (xy 156.920833 157.443053) (xy 159.2 157.443053) (xy 159.201023 157.451571) (xy 159.210612 157.531441) (xy 159.266078 157.672094) (xy 159.266079 157.672095) (xy 159.357435 157.792564) (xy 159.477903 157.883919) (xy 159.477904 157.88392) (xy 159.618556 157.939386) (xy 159.706946 157.95) (xy 159.8 157.95) (xy 160.2 157.95) (xy 160.293049 157.95) (xy 160.293054 157.95) (xy 160.381443 157.939386) (xy 160.522095 157.88392) (xy 160.642564 157.792564) (xy 160.73392 157.672095) (xy 160.789386 157.531443) (xy 160.8 157.443053) (xy 160.8 157.2) (xy 160.2 157.2) (xy 160.2 157.95) (xy 159.8 157.95) (xy 159.8 157.2) (xy 159.2 157.2) (xy 159.2 157.443053) (xy 156.920833 157.443053) (xy 156.909306 157.397781) (xy 156.908065 157.39557) (xy 156.907408 157.393115) (xy 156.907407 157.393113) (xy 156.882778 157.350455) (xy 156.882546 157.350049) (xy 156.882049 157.349176) (xy 156.881842 157.348811) (xy 156.857724 157.305806) (xy 156.855719 157.303125) (xy 156.85483 157.301937) (xy 156.854826 157.301933) (xy 156.854824 157.30193) (xy 156.849425 157.296531) (xy 156.849423 157.29653) (xy 156.828273 157.268275) (xy 156.815667 157.245188) (xy 156.8005 157.185763) (xy 156.8005 156.556946) (xy 159.2 156.556946) (xy 159.2 156.8) (xy 159.8 156.8) (xy 160.2 156.8) (xy 160.8 156.8) (xy 160.8 156.556946) (xy 160.789386 156.468556) (xy 160.73392 156.327904) (xy 160.642564 156.207435) (xy 160.522095 156.116079) (xy 160.522096 156.116079) (xy 160.381441 156.060612) (xy 160.327933 156.054188) (xy 160.293054 156.05) (xy 160.293049 156.05) (xy 160.2 156.05) (xy 160.2 156.8) (xy 159.8 156.8) (xy 159.8 156.05) (xy 159.706952 156.05) (xy 159.706946 156.05) (xy 159.669818 156.054458) (xy 159.618557 156.060612) (xy 159.477904 156.116078) (xy 159.477903 156.116079) (xy 159.357435 156.207435) (xy 159.266079 156.327903) (xy 159.266078 156.327904) (xy 159.210612 156.468557) (xy 159.205106 156.514417) (xy 159.2 156.556946) (xy 156.8005 156.556946) (xy 156.8005 156.556903) (xy 156.8005 156.556901) (xy 156.8005 156.556898) (xy 156.789877 156.468436) (xy 156.734361 156.327658) (xy 156.73436 156.327657) (xy 156.73436 156.327656) (xy 156.73063 156.322737) (xy 156.730318 156.32214) (xy 156.72924 156.320904) (xy 156.642922 156.207076) (xy 156.522345 156.11564) (xy 156.522339 156.115637) (xy 156.426193 156.077721) (xy 156.426191 156.077721) (xy 156.382543 156.060508) (xy 156.380583 156.059716) (xy 156.380311 156.059603) (xy 156.374199 156.059238) (xy 156.334389 156.054458) (xy 156.293102 156.0495) (xy 156.293097 156.0495) (xy 155.706901 156.0495) (xy 155.706898 156.0495) (xy 155.69656 156.050741) (xy 155.667853 156.054187) (xy 155.667853 156.054188) (xy 155.665605 156.054458) (xy 155.618439 156.060121) (xy 155.477653 156.11564) (xy 155.357076 156.207076) (xy 155.26564 156.327653) (xy 155.265541 156.327904) (xy 155.210122 156.468438) (xy 155.204601 156.514416) (xy 155.200062 156.552224) (xy 155.1995 156.556901) (xy 154.799994 156.556901) (xy 154.789386 156.468556) (xy 154.73392 156.327904) (xy 154.642564 156.207435) (xy 154.522095 156.116079) (xy 154.522096 156.116079) (xy 154.381441 156.060612) (xy 154.327933 156.054188) (xy 154.293054 156.05) (xy 154.293049 156.05) (xy 154.2 156.05) (xy 154.2 156.8) (xy 153.8 156.8) (xy 153.8 156.05) (xy 153.706952 156.05) (xy 153.706946 156.05) (xy 153.669821 156.054458) (xy 153.618556 156.060613) (xy 153.540907 156.091233) (xy 153.53792 156.091502) (xy 153.506575 156.099374) (xy 153.49722 156.100219) (xy 153.479726 156.096754) (xy 153.47132 156.097513) (xy 153.453905 156.09164) (xy 153.428682 156.086645) (xy 153.378362 156.038172) (xy 153.362237 155.970188) (xy 153.381129 155.910658) (xy 153.383741 155.90651) (xy 153.385806 155.903922) (xy 153.386167 155.902805) (xy 153.38771 155.901537) (xy 153.400989 155.884901) (xy 154.304801 154.981089) (xy 154.333048 154.959943) (xy 154.357976 154.946332) (xy 154.407354 154.931573) (xy 164.166852 154.138575) (xy 164.199932 154.139136) (xy 164.219198 154.134322) (xy 164.238989 154.132714) (xy 164.257408 154.126138) (xy 164.261562 154.124655) (xy 164.267304 154.122761) (xy 164.273156 154.12099) (xy 164.278966 154.119387) (xy 164.302241 154.113573) (xy 164.309762 154.109398) (xy 164.311638 154.108378) (xy 164.312726 154.107799) (xy 164.329321 154.100467) (xy 164.338304 154.097262) (xy 164.338306 154.09726) (xy 164.340631 154.096068) (xy 164.341043 154.095616) (xy 164.342907 154.094901) (xy 164.345537 154.093553) (xy 164.345682 154.093837) (xy 164.355166 154.090202) (xy 164.373488 154.081725) (xy 164.378079 154.080495) (xy 164.385979 154.079018) (xy 164.3962 154.07564) (xy 164.399631 154.074722) (xy 164.404718 154.074843) (xy 164.431716 154.070499) (xy 164.825045 154.070499)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts (xy 110.293106 146.705523) (xy 110.308104 146.709927) (xy 110.366855 146.747672) (xy 110.368042 146.749041) (xy 110.395518 146.803902) (xy 110.397163 146.81146) (xy 110.4 146.837831) (xy 110.4 148.10817) (xy 110.399999 148.108176) (xy 110.4 148.108179) (xy 110.394975 148.143114) (xy 110.39057 148.158112) (xy 110.352827 148.216855) (xy 110.352792 148.216885) (xy 110.352791 148.216887) (xy 110.352789 148.216887) (xy 110.351458 148.218042) (xy 110.296597 148.245518) (xy 110.289039 148.247163) (xy 110.262668 148.25) (xy 110.24183 148.25) (xy 110.241825 148.249999) (xy 110.241823 148.25) (xy 110.206889 148.244975) (xy 110.19189 148.24057) (xy 110.133144 148.202827) (xy 110.133115 148.202793) (xy 110.133114 148.202793) (xy 110.133113 148.202791) (xy 110.131957 148.201458) (xy 110.104477 148.146583) (xy 110.102832 148.139021) (xy 110.1 148.112668) (xy 110.1 146.842324) (xy 110.101869 146.820875) (xy 110.103506 146.811554) (xy 110.104905 146.808724) (xy 110.105022 146.807393) (xy 110.106305 146.803023) (xy 110.107276 146.803308) (xy 110.111379 146.787235) (xy 110.110687 146.786977) (xy 110.111748 146.784131) (xy 110.112391 146.783271) (xy 110.112849 146.781478) (xy 110.114087 146.778768) (xy 110.115334 146.779338) (xy 110.124277 146.767388) (xy 110.127157 146.757603) (xy 110.132476 146.752998) (xy 110.13449 146.74893) (xy 110.14102 146.745014) (xy 110.15002 146.732987) (xy 110.149123 146.731952) (xy 110.150179 146.731036) (xy 110.152158 146.73013) (xy 110.15361 146.728191) (xy 110.153647 146.728164) (xy 110.156086 146.726339) (xy 110.157198 146.727825) (xy 110.166454 146.723592) (xy 110.179988 146.71188) (xy 110.213593 146.702034) (xy 110.213716 146.701978) (xy 110.2153 146.70175) (xy 110.23287 146.7005) (xy 110.25817 146.7005)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts (xy 110.293106 144.755023) (xy 110.308104 144.759427) (xy 110.366855 144.797172) (xy 110.368042 144.798541) (xy 110.395518 144.853402) (xy 110.397163 144.86096) (xy 110.4 144.887331) (xy 110.4 145.65767) (xy 110.399999 145.657676) (xy 110.4 145.657679) (xy 110.394975 145.692614) (xy 110.39057 145.707612) (xy 110.352827 145.766355) (xy 110.352792 145.766385) (xy 110.352791 145.766387) (xy 110.352789 145.766387) (xy 110.351458 145.767542) (xy 110.296597 145.795018) (xy 110.289039 145.796663) (xy 110.262668 145.7995) (xy 110.24183 145.7995) (xy 110.241825 145.799499) (xy 110.241823 145.7995) (xy 110.206889 145.794475) (xy 110.19189 145.79007) (xy 110.133144 145.752327) (xy 110.133115 145.752293) (xy 110.133114 145.752293) (xy 110.133113 145.752291) (xy 110.131957 145.750958) (xy 110.104477 145.696083) (xy 110.102832 145.688521) (xy 110.1 145.662168) (xy 110.1 144.891824) (xy 110.101869 144.870375) (xy 110.103506 144.861054) (xy 110.104905 144.858224) (xy 110.105022 144.856893) (xy 110.106305 144.852523) (xy 110.107276 144.852808) (xy 110.111379 144.836735) (xy 110.110687 144.836477) (xy 110.111748 144.833631) (xy 110.112391 144.832771) (xy 110.112849 144.830978) (xy 110.114087 144.828268) (xy 110.115334 144.828838) (xy 110.127465 144.812627) (xy 110.13449 144.79843) (xy 110.14102 144.794514) (xy 110.15002 144.782487) (xy 110.149123 144.781452) (xy 110.150179 144.780536) (xy 110.152158 144.77963) (xy 110.15361 144.777691) (xy 110.153647 144.777664) (xy 110.156086 144.775839) (xy 110.157198 144.777325) (xy 110.213716 144.751478) (xy 110.2153 144.75125) (xy 110.23287 144.75) (xy 110.25817 144.75)
 			)
 		)
 	)
 	(zone
 		(net "PWR_LED")
 		(layer "F.Cu")
-		(uuid "5199c288-b32c-444c-b3b7-5094954f081d")
+		(uuid "c0322f12-b11d-44c3-9119-3ec2699047f5")
 		(hatch edge 0.5)
 		(priority 1)
 		(connect_pads (clearance 0.3)
@@ -6376,48 +6223,9 @@
 		)
 	)
 	(zone
-		(net "+3.3V")
-		(layer "F.Cu")
-		(uuid "f44e9ed5-145b-4f88-bbe0-02f28cfcc8ba")
-		(hatch edge 0.5)
-		(priority 2)
-		(connect_pads (clearance 0.3)
-		)
-		(min_thickness 0.25)
-		(fill yes (thermal_gap 0.3) (thermal_bridge_width 0.4) (island_removal_mode 0)
-		)
-		(polygon (pts (xy 108.75 111.5) (xy 166.5 111.5) (xy 166.5 162.04) (xy 108.75 162.04))
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts (xy 161.339712 111.505023) (xy 161.361437 111.511402) (xy 161.372766 111.517863) (xy 161.382157 111.519571) (xy 161.411121 111.539739) (xy 161.413906 111.542339) (xy 161.428775 111.558965) (xy 161.727536 111.960556) (xy 161.744358 111.991583) (xy 161.746475 111.997311) (xy 161.751252 112.067017) (xy 161.717584 112.12824) (xy 161.656162 112.161542) (xy 161.586485 112.15635) (xy 161.586483 112.156349) (xy 161.580957 112.154269) (xy 161.549714 112.137022) (xy 161.522098 112.11608) (xy 161.381441 112.060612) (xy 161.327933 112.054188) (xy 161.293054 112.05) (xy 161.293049 112.05) (xy 161.2 112.05) (xy 161.2 112.8) (xy 161.8 112.8) (xy 161.8 112.556946) (xy 161.789386 112.468556) (xy 161.78202 112.449879) (xy 161.780524 112.433308) (xy 161.773877 112.415532) (xy 161.773328 112.409447) (xy 161.776791 112.391966) (xy 161.775738 112.380295) (xy 161.781164 112.369901) (xy 161.786909 112.34091) (xy 161.807407 112.319635) (xy 161.808074 112.318359) (xy 161.811186 112.315241) (xy 161.814559 112.31198) (xy 161.815013 112.311741) (xy 161.835388 112.290596) (xy 161.871813 112.28196) (xy 161.876439 112.279535) (xy 161.880519 112.279896) (xy 161.903373 112.274478) (xy 161.931615 112.284418) (xy 161.946037 112.285695) (xy 161.955012 112.292653) (xy 161.969279 112.297675) (xy 161.969282 112.297677) (xy 161.973204 112.300501) (xy 162.000236 112.327115) (xy 162.164346 112.547709) (xy 162.181167 112.578732) (xy 162.191809 112.607527) (xy 162.1995 112.650514) (xy 162.1995 113.443102) (xy 162.205126 113.489954) (xy 162.210122 113.531561) (xy 162.210122 113.531563) (xy 162.210123 113.531564) (xy 162.213885 113.541106) (xy 162.213888 113.541115) (xy 162.227721 113.576191) (xy 162.227721 113.576192) (xy 162.265637 113.672339) (xy 162.26564 113.672345) (xy 162.357076 113.792922) (xy 162.470904 113.87924) (xy 162.477656 113.88436) (xy 162.477657 113.88436) (xy 162.477876 113.884526) (xy 162.480596 113.885519) (xy 162.618436 113.939877) (xy 162.706898 113.9505) (xy 162.706903 113.9505) (xy 163.293097 113.9505) (xy 163.293102 113.9505) (xy 163.381564 113.939877) (xy 163.522342 113.884361) (xy 163.642922 113.792922) (xy 163.734361 113.672342) (xy 163.789877 113.531564) (xy 163.8005 113.443102) (xy 163.8005 112.556898) (xy 163.789877 112.468436) (xy 163.734361 112.327658) (xy 163.73436 112.327657) (xy 163.73436 112.327656) (xy 163.73063 112.322737) (xy 163.730318 112.32214) (xy 163.72924 112.320904) (xy 163.642922 112.207076) (xy 163.522345 112.11564) (xy 163.522339 112.115637) (xy 163.426193 112.077721) (xy 163.426191 112.077721) (xy 163.382543 112.060508) (xy 163.380583 112.059716) (xy 163.380311 112.059603) (xy 163.374199 112.059238) (xy 163.335926 112.054642) (xy 163.335925 112.054641) (xy 163.30822 112.051315) (xy 163.293102 112.0495) (xy 163.293098 112.0495) (xy 162.872185 112.0495) (xy 162.872182 112.049499) (xy 162.872181 112.0495) (xy 162.837247 112.044476) (xy 162.815521 112.038096) (xy 162.76584 112.00976) (xy 162.763055 112.00716) (xy 162.757198 112.000612) (xy 162.756744 112.00032) (xy 162.756542 111.999878) (xy 162.748193 111.990543) (xy 162.541206 111.712313) (xy 162.52439 111.681299) (xy 162.519968 111.669335) (xy 162.518903 111.653803) (xy 162.512968 111.639409) (xy 162.516562 111.61966) (xy 162.51519 111.599634) (xy 162.522692 111.58599) (xy 162.525481 111.57067) (xy 162.539182 111.555999) (xy 162.548855 111.538409) (xy 162.563201 111.530282) (xy 162.573172 111.519607) (xy 162.605799 111.506152) (xy 162.608097 111.505569) (xy 162.615061 111.503804) (xy 162.645538 111.5) (xy 166.35817 111.5) (xy 166.393106 111.505023) (xy 166.408104 111.509427) (xy 166.466855 111.547172) (xy 166.468042 111.548541) (xy 166.495518 111.603402) (xy 166.497163 111.61096) (xy 166.5 111.637331) (xy 166.5 161.89817) (xy 166.499999 161.898176) (xy 166.5 161.898179) (xy 166.494975 161.933114) (xy 166.49057 161.948112) (xy 166.452827 162.006855) (xy 166.452792 162.006885) (xy 166.452791 162.006887) (xy 166.452789 162.006887) (xy 166.451458 162.008042) (xy 166.396597 162.035518) (xy 166.389039 162.037163) (xy 166.362668 162.04) (xy 165.537529 162.04) (xy 165.508579 162.036573) (xy 165.480824 162.029909) (xy 165.453477 162.01982) (xy 165.441643 162.01379) (xy 165.441634 162.013786) (xy 165.269411 161.957828) (xy 165.14523 161.93816) (xy 165.125328 161.935007) (xy 165.113044 161.929184) (xy 165.091607 161.92458) (xy 165.085323 161.921601) (xy 165.072021 161.909737) (xy 165.062195 161.905079) (xy 165.056444 161.895843) (xy 165.033183 161.875096) (xy 165.014461 161.807781) (xy 165.035104 161.741031) (xy 165.06598 161.714663) (xy 165.074761 161.704119) (xy 165.080414 161.702337) (xy 165.086944 161.69676) (xy 165.092337 161.694298) (xy 165.124437 161.684625) (xy 165.269292 161.661683) (xy 165.269298 161.661681) (xy 165.441442 161.605749) (xy 165.441444 161.605748) (xy 165.441447 161.605747) (xy 165.602734 161.523565) (xy 165.749169 161.417176) (xy 165.877176 161.289169) (xy 165.983565 161.142734) (xy 166.065747 160.981447) (xy 166.065748 160.981444) (xy 166.080981 160.934563) (xy 166.084852 160.922646) (xy 166.121683 160.809293) (xy 166.132658 160.74) (xy 165.623731 160.74) (xy 165.615045 160.737449) (xy 165.606084 160.738738) (xy 165.582043 160.727759) (xy 165.556692 160.720315) (xy 165.550764 160.713474) (xy 165.542528 160.709713) (xy 165.528238 160.687478) (xy 165.510937 160.667511) (xy 165.508649 160.656996) (xy 165.504754 160.650935) (xy 165.503325 160.632521) (xy 165.499731 160.616) (xy 165.499731 160.606829) (xy 165.5 160.605826) (xy 165.5 160.474174) (xy 165.499731 160.47317) (xy 165.499731 160.464) (xy 165.507379 160.437952) (xy 165.511567 160.411131) (xy 165.517077 160.404924) (xy 165.519416 160.396961) (xy 165.53993 160.379184) (xy 165.557956 160.358883) (xy 165.566037 160.356562) (xy 165.57222 160.351206) (xy 165.597217 160.347611) (xy 165.623731 160.34) (xy 166.132658 160.34) (xy 166.121683 160.270705) (xy 166.107597 160.227353) (xy 166.065746 160.09855) (xy 166.041574 160.051112) (xy 165.983568 159.937271) (xy 165.983565 159.937265) (xy 165.877176 159.79083) (xy 165.749169 159.662823) (xy 165.602734 159.556434) (xy 165.602727 159.55643) (xy 165.441447 159.474252) (xy 165.441371 159.474226) (xy 165.269295 159.418317) (xy 165.269296 159.418317) (xy 165.12533 159.395515) (xy 165.113062 159.389699) (xy 165.091606 159.385087) (xy 165.085326 159.38211) (xy 165.072023 159.370245) (xy 165.062195 159.365586) (xy 165.056443 159.356348) (xy 165.033184 159.335603) (xy 165.014462 159.268288) (xy 165.035105 159.201538) (xy 165.066036 159.175118) (xy 165.074807 159.164595) (xy 165.080428 159.162826) (xy 165.086926 159.157275) (xy 165.092327 159.154809) (xy 165.124428 159.145133) (xy 165.269409 159.122171) (xy 165.441639 159.066211) (xy 165.602994 158.983996) (xy 165.749501 158.877553) (xy 165.877553 158.749501) (xy 165.983996 158.602994) (xy 166.066211 158.441639) (xy 166.122171 158.269409) (xy 166.130439 158.217201) (xy 166.136765 158.177262) (xy 166.136765 158.177259) (xy 166.1505 158.090551) (xy 166.1505 157.909448) (xy 166.132043 157.792922) (xy 166.122171 157.730591) (xy 166.121723 157.729213) (xy 166.070393 157.571232) (xy 166.070392 157.571231) (xy 166.066211 157.558361) (xy 166.066211 157.55836) (xy 166.018347 157.464423) (xy 165.983996 157.397006) (xy 165.901839 157.283926) (xy 165.889698 157.267215) (xy 165.87756 157.250507) (xy 165.877554 157.2505) (xy 165.877546 157.250491) (xy 165.749507 157.122452) (xy 165.749498 157.122444) (xy 165.749474 157.122426) (xy 165.613605 157.023712) (xy 165.613591 157.023703) (xy 165.602997 157.016006) (xy 165.602996 157.016005) (xy 165.602994 157.016004) (xy 165.586383 157.00754) (xy 165.551301 156.989664) (xy 165.5513 156.989664) (xy 165.441639 156.933788) (xy 165.441636 156.933787) (xy 165.441633 156.933786) (xy 165.441631 156.933785) (xy 165.441612 156.933778) (xy 165.269412 156.877829) (xy 165.269413 156.877829) (xy 165.126931 156.855262) (xy 165.114645 156.849438) (xy 165.093207 156.844834) (xy 165.086927 156.841857) (xy 165.073624 156.829992) (xy 165.063796 156.825333) (xy 165.058044 156.816095) (xy 165.034785 156.79535) (xy 165.016063 156.728035) (xy 165.036706 156.661285) (xy 165.067582 156.634917) (xy 165.076363 156.624373) (xy 165.082016 156.622591) (xy 165.088549 156.617013) (xy 165.093937 156.614553) (xy 165.126032 156.604879) (xy 165.179425 156.596422) (xy 165.269409 156.582171) (xy 165.441639 156.526211) (xy 165.602994 156.443996) (xy 165.749501 156.337553) (xy 165.877553 156.209501) (xy 165.983996 156.062994) (xy 166.066211 155.901639) (xy 166.122171 155.729409) (xy 166.136765 155.637259) (xy 166.1505 155.550551) (xy 166.1505 155.369448) (xy 166.122738 155.194173) (xy 166.122171 155.190591) (xy 166.090628 155.093509) (xy 166.079398 155.058947) (xy 166.06622 155.018386) (xy 166.066212 155.018363) (xy 166.066211 155.01836) (xy 166.030768 154.948801) (xy 165.983996 154.857006) (xy 165.942216 154.7995) (xy 165.877558 154.710505) (xy 165.877554 154.7105) (xy 165.87755 154.710496) (xy 165.877548 154.710493) (xy 165.749507 154.582452) (xy 165.749498 154.582444) (xy 165.749474 154.582426) (xy 165.613587 154.483699) (xy 165.613574 154.48369) (xy 165.602997 154.476006) (xy 165.602996 154.476005) (xy 165.602994 154.476004) (xy 165.596921 154.472909) (xy 165.596917 154.472907) (xy 165.543196 154.445535) (xy 165.543196 154.445534) (xy 165.543194 154.445534) (xy 165.441639 154.393788) (xy 165.441635 154.393786) (xy 165.441612 154.393778) (xy 165.269412 154.337829) (xy 165.269413 154.337829) (xy 165.155337 154.319761) (xy 165.15107 154.31831) (xy 165.148559 154.318494) (xy 165.121607 154.30933) (xy 165.116088 154.306713) (xy 165.115556 154.306238) (xy 165.115472 154.30621) (xy 165.110346 154.303421) (xy 165.09292 154.286047) (xy 165.063947 154.260204) (xy 165.062776 154.255994) (xy 165.060866 154.25409) (xy 165.055734 154.230667) (xy 165.045229 154.192888) (xy 165.046532 154.188672) (xy 165.045912 154.185839) (xy 165.054883 154.161673) (xy 165.065875 154.126138) (xy 165.069077 154.123442) (xy 165.07023 154.120338) (xy 165.09377 154.10266) (xy 165.119332 154.081148) (xy 165.119892 154.080902) (xy 165.123849 154.080073) (xy 165.126101 154.078383) (xy 165.135056 154.077728) (xy 165.169609 154.070499) (xy 165.89488 154.070499) (xy 165.894978 154.070492) (xy 165.895733 154.070398) (xy 165.919987 154.067586) (xy 165.919987 154.067585) (xy 165.91999 154.067585) (xy 165.919991 154.067585) (xy 165.919991 154.067584) (xy 165.920102 154.067572) (xy 165.921862 154.066758) (xy 166.022765 154.022206) (xy 166.102206 153.942765) (xy 166.147585 153.839991) (xy 166.1505 153.814865) (xy 166.150499 152.025136) (xy 166.149256 152.014416) (xy 166.147586 152.000012) (xy 166.147585 152.00001) (xy 166.147585 152.000009) (xy 166.102206 151.897235) (xy 166.022765 151.817794) (xy 166.022763 151.817793) (xy 166.022762 151.817792) (xy 166.000107 151.807789) (xy 165.981374 151.799518) (xy 165.919993 151.772415) (xy 165.919994 151.772415) (xy 165.894868 151.7695) (xy 165.894865 151.7695) (xy 164.105143 151.7695) (xy 164.105127 151.769501) (xy 164.105113 151.769502) (xy 164.087255 151.771573) (xy 164.080012 151.772413) (xy 164.080011 151.772413) (xy 164.080005 151.772414) (xy 164.079559 151.772547) (xy 164.077303 151.773609) (xy 163.977236 151.817792) (xy 163.897793 151.897234) (xy 163.852414 152.000005) (xy 163.851844 152.00271) (xy 163.851589 152.007124) (xy 163.8495 152.025127) (xy 163.8495 153.228557) (xy 163.849499 153.228563) (xy 163.8495 153.228566) (xy 163.844475 153.263501) (xy 163.84007 153.278499) (xy 163.802307 153.33726) (xy 163.798924 153.340192) (xy 163.748973 153.366482) (xy 163.746002 153.367256) (xy 163.724783 153.370854) (xy 154.159267 154.148093) (xy 154.159263 154.148093) (xy 154.154252 154.1485) (xy 154.117773 154.1485) (xy 154.101896 154.152752) (xy 154.097177 154.153135) (xy 154.090698 154.153662) (xy 154.090696 154.153661) (xy 154.078649 154.154641) (xy 154.077516 154.154734) (xy 154.077421 154.154737) (xy 154.077422 154.154742) (xy 154.077238 154.154756) (xy 154.063889 154.161801) (xy 154.055854 154.164668) (xy 154.046282 154.167653) (xy 154.015911 154.175792) (xy 154.015908 154.175793) (xy 154.011393 154.1784) (xy 154.011081 154.17858) (xy 154.001496 154.184074) (xy 153.991097 154.187788) (xy 153.991095 154.187788) (xy 153.986203 154.189534) (xy 153.986194 154.189539) (xy 153.960323 154.207416) (xy 153.955939 154.210189) (xy 153.955907 154.210208) (xy 153.953954 154.211445) (xy 153.949677 154.214031) (xy 153.946993 154.215581) (xy 153.934057 154.219047) (xy 153.920892 154.232211) (xy 153.903726 154.246526) (xy 153.899442 154.249487) (xy 153.899441 154.249487) (xy 153.87908 154.273448) (xy 153.872297 154.280806) (xy 153.868878 154.284226) (xy 153.867143 154.285962) (xy 151.266224 156.88688) (xy 151.237969 156.908032) (xy 151.222576 156.916437) (xy 151.157823 156.93149) (xy 151.145289 156.930951) (xy 151.113954 156.925521) (xy 150.904873 156.86081) (xy 150.904872 156.86081) (xy 150.872984 156.845683) (xy 150.859957 156.837041) (xy 150.814974 156.783578) (xy 150.81497 156.783569) (xy 150.810965 156.774449) (xy 150.8005 156.724591) (xy 150.8005 156.556903) (xy 150.8005 156.556901) (xy 150.8005 156.556898) (xy 150.789877 156.468436) (xy 150.734361 156.327658) (xy 150.73436 156.327657) (xy 150.73436 156.327656) (xy 150.73063 156.322737) (xy 150.730318 156.32214) (xy 150.72924 156.320904) (xy 150.642922 156.207076) (xy 150.522345 156.11564) (xy 150.522339 156.115637) (xy 150.426193 156.077721) (xy 150.426191 156.077721) (xy 150.382543 156.060508) (xy 150.380583 156.059716) (xy 150.380311 156.059603) (xy 150.374199 156.059238) (xy 150.334389 156.054458) (xy 150.293102 156.0495) (xy 150.293097 156.0495) (xy 149.706901 156.0495) (xy 149.706898 156.0495) (xy 149.69656 156.050741) (xy 149.667853 156.054187) (xy 149.667853 156.054188) (xy 149.665605 156.054458) (xy 149.618439 156.060121) (xy 149.477653 156.11564) (xy 149.357076 156.207076) (xy 149.26564 156.327653) (xy 149.265541 156.327904) (xy 149.210122 156.468438) (xy 149.204601 156.514416) (xy 149.200062 156.552224) (xy 149.1995 156.556901) (xy 149.1995 157.164915) (xy 149.195234 157.197161) (xy 149.194874 157.198495) (xy 149.190855 157.212184) (xy 149.189455 157.218615) (xy 149.188663 157.22156) (xy 149.171975 157.248858) (xy 149.15661 157.276995) (xy 149.024288 157.409317) (xy 148.996038 157.430466) (xy 148.986111 157.435887) (xy 148.917838 157.450741) (xy 148.852373 157.426327) (xy 148.8105 157.370395) (xy 148.807813 157.363189) (xy 148.8 157.319869) (xy 148.8 157.2) (xy 148.2 157.2) (xy 148.2 157.95) (xy 148.206549 157.956549) (xy 148.212202 157.958209) (xy 148.227194 157.967843) (xy 148.244296 157.972863) (xy 148.255976 157.986339) (xy 148.27098 157.995982) (xy 148.278384 158.012194) (xy 148.290056 158.025662) (xy 148.292595 158.043313) (xy 148.300005 158.059537) (xy 148.297468 158.07718) (xy 148.300007 158.09482) (xy 148.290066 158.128685) (xy 148.286881 158.135661) (xy 148.261763 158.171842) (xy 147.679526 158.754078) (xy 147.679522 158.754083) (xy 147.679521 158.754084) (xy 147.62679 158.845414) (xy 147.62679 158.845415) (xy 147.611905 158.900972) (xy 147.611905 158.900973) (xy 147.5995 158.947269) (xy 147.5995 159.965366) (xy 147.599499 159.965372) (xy 147.5995 159.965375) (xy 147.594475 160.00031) (xy 147.59007 160.015308) (xy 147.552304 160.074071) (xy 147.552292 160.074081) (xy 147.552291 160.074083) (xy 147.552289 160.074083) (xy 147.542632 160.082453) (xy 147.506916 160.104099) (xy 147.477663 160.115635) (xy 147.477657 160.115638) (xy 147.357076 160.207076) (xy 147.26564 160.327653) (xy 147.210121 160.468439) (xy 147.208512 160.481844) (xy 147.204188 160.517853) (xy 147.1995 160.556898) (xy 147.1995 161.443102) (xy 147.202543 161.46844) (xy 147.205687 161.494626) (xy 147.209238 161.524198) (xy 147.209603 161.530312) (xy 147.209728 161.530613) (xy 147.210521 161.532574) (xy 147.220251 161.557247) (xy 147.220251 161.557249) (xy 147.261435 161.661683) (xy 147.265639 161.672343) (xy 147.357078 161.792922) (xy 147.37488 161.806422) (xy 147.39968 161.831532) (xy 147.406403 161.84063) (xy 147.430414 161.906245) (xy 147.415138 161.974424) (xy 147.365442 162.023514) (xy 147.362326 162.025191) (xy 147.303561 162.04) (xy 144.69443 162.04) (xy 144.659489 162.034975) (xy 144.64449 162.03057) (xy 144.629502 162.02094) (xy 144.612424 162.015932) (xy 144.585744 161.992827) (xy 144.584557 161.991458) (xy 144.557077 161.936583) (xy 144.555432 161.929021) (xy 144.5526 161.902668) (xy 144.5526 159.335627) (xy 144.557622 159.300694) (xy 144.565034 159.275449) (xy 144.596336 159.222699) (xy 144.601782 159.217254) (xy 144.63262 159.186416) (xy 144.711677 159.049484) (xy 144.7526 158.896757) (xy 144.7526 158.738643) (xy 144.711677 158.585916) (xy 144.664686 158.504524) (xy 144.664686 158.504523) (xy 144.649211 158.47772) (xy 144.632624 158.44899) (xy 144.632618 158.448982) (xy 144.632614 158.448978) (xy 144.632613 158.448976) (xy 144.520822 158.337185) (xy 144.52082 158.337184) (xy 144.520817 158.337181) (xy 144.520809 158.337175) (xy 144.494247 158.32184) (xy 144.383907 158.258135) (xy 144.383883 158.258122) (xy 144.272079 158.228164) (xy 144.231157 158.2172) (xy 144.231156 158.2172) (xy 144.073043 158.2172) (xy 143.920318 158.258122) (xy 143.920311 158.258124) (xy 143.92031 158.258125) (xy 143.9203 158.25813) (xy 143.783398 158.33717) (xy 143.783394 158.337172) (xy 143.78339 158.337175) (xy 143.783382 158.337181) (xy 143.783378 158.337184) (xy 143.783376 158.337185) (xy 143.671585 158.448976) (xy 143.671584 158.448978) (xy 143.671581 158.448981) (xy 143.671581 158.448982) (xy 143.671575 158.44899) (xy 143.671572 158.448994) (xy 143.67157 158.448998) (xy 143.59253 158.5859) (xy 143.592525 158.58591) (xy 143.592524 158.585911) (xy 143.592522 158.585918) (xy 143.5516 158.738643) (xy 143.5516 158.896756) (xy 143.552727 158.900962) (xy 143.552728 158.900975) (xy 143.552731 158.900975) (xy 143.552731 158.900976) (xy 143.564152 158.943601) (xy 143.592523 159.049484) (xy 143.592524 159.049487) (xy 143.592525 159.049488) (xy 143.59253 159.049498) (xy 143.647662 159.14499) (xy 143.671575 159.186409) (xy 143.671581 159.186417) (xy 143.702675 159.217511) (xy 143.712684 159.230881) (xy 143.723825 159.245764) (xy 143.736432 159.268852) (xy 143.7516 159.328279) (xy 143.7516 161.89817) (xy 143.746575 161.933114) (xy 143.74217 161.948112) (xy 143.704427 162.006855) (xy 143.703058 162.008042) (xy 143.648197 162.035518) (xy 143.640639 162.037163) (xy 143.614268 162.04) (xy 141.94233 162.04) (xy 141.942325 162.039999) (xy 141.942323 162.04) (xy 141.907389 162.034975) (xy 141.89239 162.03057) (xy 141.833644 161.992827) (xy 141.833615 161.992793) (xy 141.833614 161.992793) (xy 141.833613 161.992791) (xy 141.832457 161.991458) (xy 141.804977 161.936583) (xy 141.803332 161.929021) (xy 141.8005 161.902668) (xy 141.8005 161.556903) (xy 141.8005 161.556898) (xy 141.789877 161.468436) (xy 141.755515 161.3813) (xy 141.737932 161.336713) (xy 141.737931 161.336711) (xy 141.734361 161.327658) (xy 141.73436 161.327657) (xy 141.73436 161.327656) (xy 141.730629 161.322736) (xy 141.728661 161.318969) (xy 141.727366 161.316994) (xy 141.727562 161.316865) (xy 141.725815 161.313521) (xy 141.723099 161.299835) (xy 141.709536 161.274995) (xy 141.71452 161.205303) (xy 141.72017 161.192434) (xy 141.72255 161.187752) (xy 141.722553 161.18775) (xy 141.773439 161.087674) (xy 141.793124 161.020635) (xy 141.8055 160.934563) (xy 141.8055 158.1795) (xy 141.825185 158.112461) (xy 141.877989 158.066706) (xy 141.9295 158.0555) (xy 142.212667 158.0555) (xy 142.212668 158.0555) (xy 142.245345 158.053747) (xy 142.271716 158.05091) (xy 142.30401 158.045674) (xy 142.311568 158.044029) (xy 142.383402 158.018675) (xy 142.438263 157.991199) (xy 142.438267 157.991195) (xy 142.43827 157.991195) (xy 142.477554 157.964931) (xy 142.501591 157.948861) (xy 142.50296 157.947674) (xy 142.533766 157.916849) (xy 142.556871 157.890169) (xy 142.568235 157.876238) (xy 142.583124 157.84693) (xy 142.589346 157.83608) (xy 142.591568 157.832623) (xy 142.597587 157.823255) (xy 142.633689 157.744203) (xy 142.638094 157.729205) (xy 142.647364 157.686598) (xy 142.652389 157.651654) (xy 142.6555 157.60817) (xy 142.6555 157.443053) (xy 147.2 157.443053) (xy 147.201023 157.451571) (xy 147.210612 157.531441) (xy 147.266078 157.672094) (xy 147.266079 157.672095) (xy 147.357435 157.792564) (xy 147.477903 157.883919) (xy 147.477904 157.88392) (xy 147.618556 157.939386) (xy 147.706946 157.95) (xy 147.8 157.95) (xy 147.8 157.2) (xy 147.2 157.2) (xy 147.2 157.443053) (xy 142.6555 157.443053) (xy 142.6555 156.556946) (xy 147.2 156.556946) (xy 147.2 156.8) (xy 147.8 156.8) (xy 148.2 156.8) (xy 148.8 156.8) (xy 148.8 156.556946) (xy 148.789386 156.468556) (xy 148.73392 156.327904) (xy 148.642564 156.207435) (xy 148.522095 156.116079) (xy 148.522096 156.116079) (xy 148.381441 156.060612) (xy 148.327933 156.054188) (xy 148.293054 156.05) (xy 148.293049 156.05) (xy 148.2 156.05) (xy 148.2 156.8) (xy 147.8 156.8) (xy 147.8 156.05) (xy 147.706952 156.05) (xy 147.706946 156.05) (xy 147.669818 156.054458) (xy 147.618557 156.060612) (xy 147.477904 156.116078) (xy 147.477903 156.116079) (xy 147.357435 156.207435) (xy 147.266079 156.327903) (xy 147.266078 156.327904) (xy 147.210612 156.468557) (xy 147.205106 156.514417) (xy 147.2 156.556946) (xy 142.6555 156.556946) (xy 142.6555 156.101231) (xy 142.655141 156.094543) (xy 142.671205 156.026547) (xy 142.721481 155.978028) (xy 142.75389 155.966461) (xy 142.766293 155.9639) (xy 142.776127 155.9639) (xy 142.807893 155.955387) (xy 142.814769 155.953821) (xy 142.819272 155.952885) (xy 142.849319 155.947229) (xy 142.849323 155.947226) (xy 142.850365 155.946886) (xy 142.858131 155.943588) (xy 142.868912 155.939593) (xy 142.876963 155.937031) (xy 142.877981 155.936609) (xy 142.877982 155.936608) (xy 142.877987 155.936607) (xy 142.904466 155.921317) (xy 142.908525 155.919075) (xy 142.91268 155.916882) (xy 142.916802 155.914805) (xy 144.028181 155.380827) (xy 144.031647 155.37923) (xy 144.072213 155.361333) (xy 144.072223 155.361324) (xy 144.077218 155.358287) (xy 144.079007 155.357016) (xy 144.0827 155.354715) (xy 144.083254 155.354374) (xy 144.083269 155.35436) (xy 144.083271 155.35436) (xy 144.116153 155.32611) (xy 144.117607 155.324882) (xy 144.119117 155.323627) (xy 144.120624 155.322395) (xy 144.284507 155.190591) (xy 158.318838 143.903361) (xy 158.349205 143.885385) (xy 158.363654 143.879416) (xy 158.433124 143.872018) (xy 158.445627 143.874286) (xy 158.468882 143.880901) (xy 158.469665 143.881209) (xy 158.476448 143.884431) (xy 158.484554 143.887081) (xy 158.581412 143.925276) (xy 158.618436 143.939877) (xy 158.706898 143.9505) (xy 158.706903 143.9505) (xy 159.293097 143.9505) (xy 159.293102 143.9505) (xy 159.381564 143.939877) (xy 159.522342 143.884361) (xy 159.642922 143.792922) (xy 159.734361 143.672342) (xy 159.789877 143.531564) (xy 159.8005 143.443102) (xy 159.8005 142.852575) (xy 159.804758 142.820359) (xy 159.805124 142.818997) (xy 159.809103 142.805446) (xy 159.810426 142.79929) (xy 159.811245 142.796248) (xy 159.827867 142.769039) (xy 159.84308 142.741009) (xy 159.84466 142.739449) (xy 159.866913 142.717898) (xy 159.866914 142.717894) (xy 159.867688 142.717146) (xy 159.86906 142.715514) (xy 159.87385 142.710134) (xy 159.878764 142.704926) (xy 159.975214 142.608476) (xy 160.003465 142.587328) (xy 160.013392 142.581907) (xy 160.081664 142.567056) (xy 160.147128 142.591473) (xy 160.188994 142.647392) (xy 160.188998 142.647403) (xy 160.189 142.647406) (xy 160.189 142.647408) (xy 160.191676 142.65458) (xy 160.1995 142.697928) (xy 160.1995 143.443098) (xy 160.204602 143.485591) (xy 160.210121 143.531559) (xy 160.23788 143.601952) (xy 160.258428 143.654058) (xy 160.26564 143.672345) (xy 160.357076 143.792922) (xy 160.464371 143.874286) (xy 160.477656 143.88436) (xy 160.477657 143.88436) (xy 160.477876 143.884526) (xy 160.480596 143.885519) (xy 160.618436 143.939877) (xy 160.706898 143.9505) (xy 160.706903 143.9505) (xy 161.293097 143.9505) (xy 161.293102 143.9505) (xy 161.381564 143.939877) (xy 161.522342 143.884361) (xy 161.642922 143.792922) (xy 161.734361 143.672342) (xy 161.789877 143.531564) (xy 161.8005 143.443102) (xy 161.8005 142.556898) (xy 161.789877 142.468436) (xy 161.734361 142.327658) (xy 161.73436 142.327657) (xy 161.73436 142.327656) (xy 161.73063 142.322737) (xy 161.730318 142.32214) (xy 161.72924 142.320904) (xy 161.642922 142.207076) (xy 161.522345 142.11564) (xy 161.522339 142.115637) (xy 161.426193 142.077721) (xy 161.426191 142.077721) (xy 161.382543 142.060508) (xy 161.380583 142.059716) (xy 161.380311 142.059603) (xy 161.374199 142.059238) (xy 161.335926 142.054642) (xy 161.335925 142.054641) (xy 161.30822 142.051315) (xy 161.293102 142.0495) (xy 161.293098 142.0495) (xy 160.706901 142.0495) (xy 160.706898 142.0495) (xy 160.69656 142.050741) (xy 160.667853 142.054187) (xy 160.667853 142.054188) (xy 160.66192 142.0549) (xy 160.618439 142.060121) (xy 160.477653 142.11564) (xy 160.35708 142.207074) (xy 160.357074 142.20708) (xy 160.328433 142.244849) (xy 160.328432 142.244849) (xy 160.328432 142.24485) (xy 160.303321 142.269651) (xy 160.293374 142.277001) (xy 160.227758 142.30101) (xy 160.159579 142.285733) (xy 160.112104 142.238939) (xy 160.107102 142.230212) (xy 160.094909 142.200645) (xy 160.082307 142.153612) (xy 160.02958 142.062287) (xy 159.955013 141.98772) (xy 159.564821 141.597528) (xy 159.543674 141.569277) (xy 159.531067 141.546188) (xy 159.5159 141.486763) (xy 159.5159 141.435445) (xy 159.5159 141.435443) (xy 159.474977 141.282716) (xy 159.474973 141.282709) (xy 159.395924 141.14579) (xy 159.395918 141.145782) (xy 159.395914 141.145778) (xy 159.395913 141.145776) (xy 159.284122 141.033985) (xy 159.28412 141.033984) (xy 159.284117 141.033981) (xy 159.284109 141.033975) (xy 159.257547 141.01864) (xy 159.147207 140.954935) (xy 159.147183 140.954922) (xy 159.035379 140.924964) (xy 158.994457 140.914) (xy 158.994456 140.914) (xy 158.836343 140.914) (xy 158.683618 140.954922) (xy 158.683611 140.954924) (xy 158.68361 140.954925) (xy 158.6836 140.95493) (xy 158.546698 141.03397) (xy 158.546694 141.033972) (xy 158.54669 141.033975) (xy 158.546682 141.033981) (xy 158.546678 141.033984) (xy 158.546676 141.033985) (xy 158.434885 141.145776) (xy 158.434884 141.145778) (xy 158.434881 141.145781) (xy 158.434881 141.145782) (xy 158.434875 141.14579) (xy 158.434872 141.145794) (xy 158.43487 141.145798) (xy 158.35583 141.2827) (xy 158.355825 141.28271) (xy 158.355824 141.282711) (xy 158.355823 141.282715) (xy 158.355823 141.282716) (xy 158.3149 141.435443) (xy 158.3149 141.593556) (xy 158.315966 141.597533) (xy 158.355822 141.74628) (xy 158.355824 141.746287) (xy 158.355825 141.746288) (xy 158.35583 141.746298) (xy 158.41585 141.850256) (xy 158.434875 141.883209) (xy 158.434881 141.883217) (xy 158.434884 141.88322) (xy 158.434884 141.883221) (xy 158.472348 141.920684) (xy 158.47235 141.920687) (xy 158.472352 141.920688) (xy 158.493502 141.948943) (xy 158.500215 141.961238) (xy 158.515065 142.029512) (xy 158.490877 142.094664) (xy 158.48272 142.105631) (xy 158.45815 142.130432) (xy 158.357074 142.20708) (xy 158.26564 142.327653) (xy 158.210121 142.468439) (xy 158.204188 142.517854) (xy 158.1995 142.556901) (xy 158.1995 142.894001) (xy 158.199499 142.894004) (xy 158.1995 142.894006) (xy 158.194476 142.92894) (xy 158.188225 142.950226) (xy 158.150448 143.009003) (xy 158.131598 143.022166) (xy 158.129762 143.023521) (xy 158.111352 143.041261) (xy 158.107666 143.044671) (xy 158.10267 143.049109) (xy 158.098032 143.053031) (xy 145.362372 153.295794) (xy 145.332 153.313774) (xy 145.323062 153.317466) (xy 145.253585 153.324867) (xy 145.191136 153.293531) (xy 145.155543 153.233407) (xy 145.155698 153.171707) (xy 145.156887 153.167127) (xy 145.166418 153.142003) (xy 145.209237 153.05797) (xy 145.209239 153.057963) (xy 145.218419 153) (xy 144.375 153) (xy 144.375 153.349999) (xy 144.833449 153.349999) (xy 144.833454 153.349999) (xy 144.833454 153.349998) (xy 144.862248 153.345438) (xy 144.920474 153.336217) (xy 144.92721 153.336407) (xy 144.930944 153.335012) (xy 144.936321 153.334741) (xy 144.942898 153.334552) (xy 144.942899 153.334553) (xy 144.957029 153.334148) (xy 145.024603 153.351905) (xy 145.071851 153.403378) (xy 145.077075 153.433554) (xy 145.078428 153.436028) (xy 145.078159 153.439816) (xy 145.08377 153.472223) (xy 145.07416 153.496251) (xy 145.073489 153.505723) (xy 145.066786 153.514688) (xy 145.059537 153.532816) (xy 145.056239 153.537184) (xy 145.034992 153.559092) (xy 143.663941 154.661771) (xy 143.652366 154.670033) (xy 143.640394 154.677582) (xy 143.627958 154.684461) (xy 143.544274 154.724668) (xy 143.544273 154.72467) (xy 143.510609 154.735272) (xy 143.496912 154.737515) (xy 143.427573 154.728923) (xy 143.373886 154.684208) (xy 143.371601 154.680801) (xy 143.352012 154.630458) (xy 143.351921 154.629862) (xy 143.3505 154.611146) (xy 143.3505 153.516512) (xy 143.3505 153.516509) (xy 143.348663 153.504917) (xy 143.34816 153.469631) (xy 143.349939 153.455864) (xy 143.378052 153.3919) (xy 143.436281 153.353291) (xy 143.442965 153.351224) (xy 143.498989 153.347218) (xy 143.516547 153.349999) (xy 143.974999 153.349999) (xy 143.975 153.349998) (xy 143.975 153) (xy 143.13158 153) (xy 143.12726 153.005057) (xy 143.125497 153.0187) (xy 143.118324 153.035017) (xy 143.116041 153.052694) (xy 143.104557 153.066337) (xy 143.097381 153.082663) (xy 143.082523 153.092514) (xy 143.071048 153.106148) (xy 143.039157 153.121269) (xy 143.03248 153.123334) (xy 142.976447 153.127344) (xy 142.958489 153.1245) (xy 142.958488 153.1245) (xy 142.779201 153.1245) (xy 142.712162 153.104815) (xy 142.666407 153.052011) (xy 142.655933 152.995615) (xy 142.6555 152.995615) (xy 142.6555 152.993284) (xy 142.655433 152.992924) (xy 142.6555 152.991829) (xy 142.6555 152.367292) (xy 142.656638 152.363415) (xy 142.655747 152.359476) (xy 142.666399 152.330172) (xy 142.675185 152.300253) (xy 142.678237 152.297607) (xy 142.679618 152.293811) (xy 142.704426 152.274915) (xy 142.727989 152.254498) (xy 142.731986 152.253923) (xy 142.735201 152.251475) (xy 142.766281 152.248991) (xy 142.797147 152.244554) (xy 142.801979 152.24614) (xy 142.804848 152.245911) (xy 142.838012 152.257966) (xy 142.843592 152.260952) (xy 142.845286 152.261877) (xy 142.847085 152.262877) (xy 142.848841 152.263872) (xy 142.888059 152.286515) (xy 142.890446 152.287289) (xy 142.890447 152.287289) (xy 142.890465 152.287295) (xy 142.8907 152.287372) (xy 142.892237 152.28796) (xy 142.89234 152.288003) (xy 142.89289 152.28821) (xy 142.893012 152.288257) (xy 142.893121 152.28834) (xy 142.893655 152.288573) (xy 142.893862 152.288648) (xy 142.893951 152.28867) (xy 142.894147 152.288751) (xy 142.898418 152.290294) (xy 142.913469 152.293811) (xy 142.941563 152.300376) (xy 142.945356 152.301326) (xy 142.988173 152.3128) (xy 142.988175 152.3128) (xy 142.988522 152.312845) (xy 142.995082 152.312884) (xy 143.001102 152.314291) (xy 143.036947 152.313134) (xy 143.039305 152.313149) (xy 143.043162 152.314306) (xy 143.073501 152.31817) (xy 143.085637 152.321734) (xy 143.101168 152.331716) (xy 143.106226 152.333234) (xy 143.109523 152.337086) (xy 143.144414 152.35951) (xy 143.173436 152.423067) (xy 143.173437 152.42307) (xy 143.173912 152.426375) (xy 143.169383 152.481464) (xy 143.168789 152.483339) (xy 143.161064 152.502184) (xy 143.140762 152.542027) (xy 143.14076 152.542032) (xy 143.14076 152.542033) (xy 143.13158 152.599995) (xy 143.13158 152.599999) (xy 143.13158 152.6) (xy 145.21842 152.6) (xy 145.222132 152.591036) (xy 145.219595 152.587201) (xy 145.214322 152.574131) (xy 145.209239 152.542036) (xy 145.209237 152.542031) (xy 145.171452 152.467874) (xy 145.169418 152.462831) (xy 145.168958 152.458151) (xy 145.162542 152.439321) (xy 145.158431 152.417428) (xy 145.161325 152.359605) (xy 145.162581 152.355328) (xy 145.171073 152.333971) (xy 145.181101 152.314291) (xy 145.209719 152.258126) (xy 145.210385 152.253923) (xy 145.212505 152.240538) (xy 145.212505 152.240532) (xy 145.213215 152.236054) (xy 145.2255 152.158493) (xy 145.2255 151.841506) (xy 145.214557 151.772414) (xy 145.211246 151.751509) (xy 145.211246 151.751508) (xy 145.20972 151.741877) (xy 145.209719 151.741875) (xy 145.209719 151.741874) (xy 145.174205 151.672174) (xy 145.171608 151.664555) (xy 145.162821 151.638767) (xy 145.158711 151.61688) (xy 145.161603 151.559064) (xy 145.162859 151.554786) (xy 145.165642 151.547784) (xy 145.165685 151.547359) (xy 145.165938 151.547039) (xy 145.171349 151.533429) (xy 145.209719 151.458126) (xy 145.2136 151.433625) (xy 145.2255 151.358493) (xy 145.2255 151.041506) (xy 145.225499 151.0415) (xy 145.211246 150.951509) (xy 145.211246 150.951508) (xy 145.20972 150.941877) (xy 145.209719 150.941875) (xy 145.209719 150.941874) (xy 145.174205 150.872174) (xy 145.171608 150.864555) (xy 145.162821 150.838767) (xy 145.158711 150.81688) (xy 145.161603 150.759064) (xy 145.162859 150.754786) (xy 145.165642 150.747785) (xy 145.165685 150.747359) (xy 145.165938 150.747039) (xy 145.17135 150.733426) (xy 145.209719 150.658126) (xy 145.212171 150.642645) (xy 145.2255 150.558493) (xy 145.2255 150.241506) (xy 145.220937 150.212697) (xy 145.211246 150.151509) (xy 145.211246 150.151508) (xy 145.20972 150.141877) (xy 145.209719 150.141875) (xy 145.209719 150.141874) (xy 145.174205 150.072174) (xy 145.171608 150.064555) (xy 145.162821 150.038767) (xy 145.158711 150.01688) (xy 145.161603 149.959064) (xy 145.162859 149.954786) (xy 145.165642 149.947785) (xy 145.165685 149.947359) (xy 145.165938 149.947039) (xy 145.17135 149.933426) (xy 145.209719 149.858126) (xy 145.211173 149.848945) (xy 145.2255 149.758493) (xy 145.2255 149.441506) (xy 145.225499 149.4415) (xy 145.211246 149.351509) (xy 145.211246 149.351508) (xy 145.20972 149.341877) (xy 145.209719 149.341875) (xy 145.209719 149.341874) (xy 145.174205 149.272174) (xy 145.171608 149.264555) (xy 145.162821 149.238767) (xy 145.158711 149.21688) (xy 145.161603 149.159064) (xy 145.162859 149.154786) (xy 145.165642 149.147784) (xy 145.165685 149.147359) (xy 145.165938 149.147039) (xy 145.171349 149.133429) (xy 145.209719 149.058126) (xy 145.210191 149.055145) (xy 145.2255 148.958493) (xy 145.2255 148.641506) (xy 145.225499 148.6415) (xy 145.211246 148.551509) (xy 145.211246 148.551508) (xy 145.20972 148.541877) (xy 145.209719 148.541875) (xy 145.209719 148.541874) (xy 145.174205 148.472174) (xy 145.171608 148.464555) (xy 145.162821 148.438767) (xy 145.158711 148.41688) (xy 145.161603 148.359064) (xy 145.162859 148.354786) (xy 145.165642 148.347785) (xy 145.165685 148.347359) (xy 145.165938 148.347039) (xy 145.17135 148.333426) (xy 145.209719 148.258126) (xy 145.214124 148.230315) (xy 145.21446 148.228197) (xy 145.2255 148.158492) (xy 145.2255 147.841506) (xy 145.211246 147.751509) (xy 145.211246 147.751508) (xy 145.20972 147.741877) (xy 145.209719 147.741875) (xy 145.209719 147.741874) (xy 145.174205 147.672174) (xy 145.171608 147.664555) (xy 145.162821 147.638767) (xy 145.158711 147.61688) (xy 145.161603 147.559064) (xy 145.162859 147.554786) (xy 145.165642 147.547784) (xy 145.165685 147.547359) (xy 145.165938 147.547039) (xy 145.171349 147.533429) (xy 145.209719 147.458126) (xy 145.209744 147.457967) (xy 145.2255 147.358493) (xy 145.2255 147.041506) (xy 145.2255 147.041505) (xy 145.209721 146.941879) (xy 145.20972 146.941877) (xy 145.20972 146.941876) (xy 145.207774 146.938058) (xy 145.197688 146.910714) (xy 145.191025 146.882959) (xy 145.1876 146.854017) (xy 145.1876 144.889827) (xy 145.192622 144.854894) (xy 145.19306 144.853402) (xy 145.200034 144.829649) (xy 145.231334 144.776901) (xy 145.238728 144.769508) (xy 145.26762 144.740616) (xy 145.346677 144.603684) (xy 145.3876 144.450957) (xy 145.3876 144.292843) (xy 145.346677 144.140116) (xy 145.304103 144.066375) (xy 145.267629 144.003198) (xy 145.267628 144.003196) (xy 145.26762 144.003184) (xy 145.267613 144.003176) (xy 145.155822 143.891385) (xy 145.15582 143.891384) (xy 145.155817 143.891381) (xy 145.155809 143.891375) (xy 145.122281 143.872018) (xy 145.018907 143.812335) (xy 145.018883 143.812322) (xy 144.907079 143.782364) (xy 144.866157 143.7714) (xy 144.866156 143.7714) (xy 144.708043 143.7714) (xy 144.555318 143.812322) (xy 144.555311 143.812324) (xy 144.55531 143.812325) (xy 144.5553 143.81233) (xy 144.418398 143.89137) (xy 144.418394 143.891372) (xy 144.41839 143.891375) (xy 144.418382 143.891381) (xy 144.418378 143.891384) (xy 144.418376 143.891385) (xy 144.306585 144.003176) (xy 144.306584 144.003178) (xy 144.306581 144.003181) (xy 144.306581 144.003182) (xy 144.306575 144.00319) (xy 144.306572 144.003194) (xy 144.30657 144.003198) (xy 144.22753 144.1401) (xy 144.227525 144.14011) (xy 144.227524 144.140111) (xy 144.227523 144.140116) (xy 144.1866 144.292843) (xy 144.1866 144.450957) (xy 144.208037 144.530959) (xy 144.227523 144.603683) (xy 144.227524 144.603687) (xy 144.227525 144.603688) (xy 144.22753 144.603698) (xy 144.270059 144.677361) (xy 144.306575 144.740609) (xy 144.306581 144.740617) (xy 144.337675 144.771711) (xy 144.344564 144.780914) (xy 144.358824 144.799963) (xy 144.371125 144.822489) (xy 144.371432 144.823052) (xy 144.3866 144.882479) (xy 144.3866 146.50767) (xy 144.381575 146.542614) (xy 144.37717 146.557612) (xy 144.339427 146.616355) (xy 144.338058 146.617542) (xy 144.283197 146.645018) (xy 144.275639 146.646663) (xy 144.249268 146.6495) (xy 143.516501 146.6495) (xy 143.50543 146.651253) (xy 143.47015 146.651757) (xy 143.458769 146.650286) (xy 143.456386 146.649978) (xy 143.392422 146.621867) (xy 143.353812 146.56364) (xy 143.351742 146.556948) (xy 143.347739 146.500915) (xy 143.349507 146.489757) (xy 143.349507 146.489756) (xy 143.3505 146.483489) (xy 143.3505 145.166506) (xy 143.336246 145.076509) (xy 143.336246 145.076508) (xy 143.33472 145.066877) (xy 143.334719 145.066875) (xy 143.334719 145.066874) (xy 143.273528 144.94678) (xy 143.273526 144.946778) (xy 143.273523 144.946774) (xy 143.178225 144.851476) (xy 143.178221 144.851473) (xy 143.17822 144.851472) (xy 143.166774 144.84564) (xy 143.079655 144.801249) (xy 143.079654 144.801249) (xy 143.079651 144.801247) (xy 143.079649 144.801246) (xy 143.050806 144.780914) (xy 143.040718 144.771387) (xy 143.005494 144.711046) (xy 143.008483 144.641243) (xy 143.010256 144.636042) (xy 143.045921 144.582769) (xy 148.506023 139.800164) (xy 148.535601 139.78093) (xy 148.562207 139.768607) (xy 148.60893 139.757244) (xy 150.219974 139.687222) (xy 150.221981 139.687151) (xy 150.224778 139.687075) (xy 150.264157 139.68779) (xy 150.272198 139.68579) (xy 150.282317 139.685516) (xy 150.286775 139.684625) (xy 150.288581 139.684291) (xy 150.288764 139.684233) (xy 150.288769 139.684233) (xy 150.323682 139.673231) (xy 150.330981 139.671176) (xy 150.366495 139.662348) (xy 150.366524 139.662331) (xy 150.389326 139.652548) (xy 150.389347 139.652542) (xy 150.420299 139.63283) (xy 150.421886 139.631839) (xy 150.424277 139.630369) (xy 150.458762 139.611286) (xy 150.464785 139.605475) (xy 150.475467 139.598912) (xy 150.475848 139.598571) (xy 150.478296 139.595899) (xy 150.478298 139.595899) (xy 150.50303 139.568917) (xy 150.508348 139.563464) (xy 150.534668 139.538083) (xy 150.534798 139.537867) (xy 150.541183 139.527298) (xy 150.549556 139.518165) (xy 150.566459 139.485707) (xy 150.569257 139.480715) (xy 150.571165 139.477434) (xy 150.578144 139.465836) (xy 150.600461 139.438491) (xy 150.620125 139.42041) (xy 150.671961 139.391914) (xy 150.733684 139.375377) (xy 150.870616 139.29632) (xy 150.98242 139.184516) (xy 151.061477 139.047584) (xy 151.1024 138.894857) (xy 151.1024 138.736743) (xy 151.101772 138.734399) (xy 151.101778 138.732023) (xy 151.101339 138.728689) (xy 151.101786 138.72863) (xy 151.101813 138.71814) (xy 151.097569 138.704622) (xy 151.097582 138.699359) (xy 151.097851 138.688051) (xy 151.101924 138.67531) (xy 151.101939 138.6696) (xy 151.104646 138.659701) (xy 151.109355 138.652063) (xy 151.119125 138.6215) (xy 151.137611 138.606235) (xy 151.141316 138.600228) (xy 151.149832 138.596144) (xy 151.173002 138.577014) (xy 151.195323 138.574334) (xy 151.204319 138.570022) (xy 151.217525 138.571669) (xy 151.242265 138.5687) (xy 151.242874 138.568802) (xy 151.263747 138.577437) (xy 151.273651 138.578673) (xy 151.280452 138.584347) (xy 151.294346 138.590095) (xy 151.296185 138.591404) (xy 151.311935 138.604728) (xy 151.446587 138.73938) (xy 151.537912 138.792107) (xy 151.639773 138.8194) (xy 151.745227 138.8194) (xy 154.969911 138.8194) (xy 155.001999 138.823623) (xy 155.032467 138.831787) (xy 155.062371 138.844173) (xy 155.109713 138.871507) (xy 155.211573 138.8988) (xy 155.211575 138.8988) (xy 157.554425 138.8988) (xy 157.554427 138.8988) (xy 157.656288 138.871507) (xy 157.672931 138.861897) (xy 157.703633 138.844172) (xy 157.733534 138.831788) (xy 157.764 138.823625) (xy 157.796092 138.8194) (xy 158.4606 138.8194) (xy 158.476701 138.82045) (xy 158.495073 138.822856) (xy 158.495074 138.822856) (xy 158.502238 138.821907) (xy 158.513129 138.820466) (xy 158.51408 138.820345) (xy 158.521691 138.8194) (xy 158.547527 138.8194) (xy 158.565424 138.814603) (xy 158.577336 138.81223) (xy 158.585219 138.810925) (xy 158.590106 138.810278) (xy 158.590139 138.810283) (xy 158.590138 138.810274) (xy 158.590139 138.810274) (xy 158.599615 138.809021) (xy 158.616413 138.802049) (xy 158.631824 138.796812) (xy 158.649387 138.792107) (xy 158.665433 138.782841) (xy 158.679892 138.775705) (xy 158.697015 138.7686) (xy 158.717903 138.752549) (xy 158.740713 138.73938) (xy 158.75953 138.720562) (xy 158.765947 138.715631) (xy 158.765948 138.715631) (xy 158.78063 138.704349) (xy 158.780629 138.704349) (xy 158.780633 138.704347) (xy 158.789199 138.693164) (xy 158.794365 138.686862) (xy 158.799749 138.68072) (xy 158.805313 138.67478) (xy 158.815274 138.664819) (xy 158.815274 138.664818) (xy 158.81528 138.664813) (xy 158.824546 138.648761) (xy 158.833499 138.635352) (xy 158.844772 138.620642) (xy 158.851708 138.603861) (xy 158.858914 138.589236) (xy 158.86597 138.577014) (xy 158.868007 138.573487) (xy 158.871761 138.55947) (xy 158.874102 138.551752) (xy 158.876692 138.544114) (xy 158.879515 138.5366) (xy 158.916521 138.44709) (xy 159.084267 138.041338) (xy 159.108716 138.003568) (xy 159.118871 137.992818) (xy 159.133547 137.984041) (xy 159.144224 137.972243) (xy 159.176636 137.958274) (xy 159.189482 137.9548) (xy 159.221853 137.9505) (xy 159.293097 137.9505) (xy 159.293102 137.9505) (xy 159.381564 137.939877) (xy 159.522342 137.884361) (xy 159.642922 137.792922) (xy 159.734361 137.672342) (xy 159.789877 137.531564) (xy 159.8005 137.443102) (xy 159.8005 136.556898) (xy 160.1995 136.556898) (xy 160.1995 137.443102) (xy 160.205126 137.489954) (xy 160.210122 137.531561) (xy 160.264578 137.669652) (xy 160.26564 137.672345) (xy 160.357076 137.792922) (xy 160.470904 137.87924) (xy 160.477656 137.88436) (xy 160.477657 137.88436) (xy 160.477876 137.884526) (xy 160.480596 137.885519) (xy 160.618436 137.939877) (xy 160.706898 137.9505) (xy 160.706903 137.9505) (xy 161.293097 137.9505) (xy 161.293102 137.9505) (xy 161.381564 137.939877) (xy 161.522342 137.884361) (xy 161.642922 137.792922) (xy 161.734361 137.672342) (xy 161.789877 137.531564) (xy 161.8005 137.443102) (xy 161.8005 136.556898) (xy 161.789877 136.468436) (xy 161.734361 136.327658) (xy 161.73436 136.327657) (xy 161.73436 136.327656) (xy 161.73063 136.322737) (xy 161.730318 136.32214) (xy 161.72924 136.320904) (xy 161.642922 136.207076) (xy 161.522345 136.11564) (xy 161.522339 136.115637) (xy 161.404224 136.069058) (xy 161.404219 136.069057) (xy 161.382574 136.060521) (xy 161.380613 136.059728) (xy 161.380312 136.059603) (xy 161.374199 136.059238) (xy 161.335926 136.054642) (xy 161.335925 136.054641) (xy 161.30822 136.051315) (xy 161.293102 136.0495) (xy 161.293098 136.0495) (xy 160.706901 136.0495) (xy 160.706898 136.0495) (xy 160.69656 136.050741) (xy 160.667853 136.054187) (xy 160.667853 136.054188) (xy 160.66192 136.0549) (xy 160.618439 136.060121) (xy 160.477653 136.11564) (xy 160.357076 136.207076) (xy 160.26564 136.327653) (xy 160.264577 136.330348) (xy 160.210122 136.468438) (xy 160.206044 136.502402) (xy 160.1995 136.556898) (xy 159.8005 136.556898) (xy 159.789877 136.468436) (xy 159.734361 136.327658) (xy 159.73436 136.327657) (xy 159.73436 136.327656) (xy 159.73063 136.322737) (xy 159.730318 136.32214) (xy 159.72924 136.320904) (xy 159.642922 136.207076) (xy 159.522345 136.11564) (xy 159.522339 136.115637) (xy 159.404224 136.069058) (xy 159.404219 136.069057) (xy 159.382574 136.060521) (xy 159.380613 136.059728) (xy 159.380312 136.059603) (xy 159.374199 136.059238) (xy 159.335926 136.054642) (xy 159.335925 136.054641) (xy 159.30822 136.051315) (xy 159.293102 136.0495) (xy 159.293098 136.0495) (xy 158.706901 136.0495) (xy 158.706898 136.0495) (xy 158.69656 136.050741) (xy 158.667853 136.054187) (xy 158.667853 136.054188) (xy 158.66192 136.0549) (xy 158.618439 136.060121) (xy 158.477653 136.11564) (xy 158.357076 136.207076) (xy 158.26564 136.327653) (xy 158.264577 136.330348) (xy 158.210122 136.468438) (xy 158.206044 136.502402) (xy 158.200062 136.552224) (xy 158.1995 136.556902) (xy 158.1995 137.164915) (xy 158.199499 137.164917) (xy 158.1995 137.164918) (xy 158.194476 137.199852) (xy 158.187064 137.225093) (xy 158.155769 137.277837) (xy 157.464133 137.969473) (xy 157.435882 137.990622) (xy 157.412794 138.00323) (xy 157.353364 138.0184) (xy 155.224425 138.0184) (xy 155.18949 138.013377) (xy 155.178636 138.01019) (xy 155.119858 137.972416) (xy 155.090833 137.90886) (xy 155.100776 137.839703) (xy 155.103966 137.83272) (xy 155.129075 137.796558) (xy 155.255975 137.669658) (xy 155.255975 137.669657) (xy 155.255977 137.669655) (xy 155.370941 137.497598) (xy 155.45013 137.30642) (xy 155.4905 137.103465) (xy 155.4905 136.896535) (xy 155.45013 136.69358) (xy 155.370941 136.502402) (xy 155.348248 136.46844) (xy 155.345162 136.463821) (xy 155.256046 136.330449) (xy 155.256036 136.330417) (xy 155.25598 136.330348) (xy 155.25598 136.330349) (xy 155.255977 136.330345) (xy 155.255975 136.330342) (xy 155.255973 136.33034) (xy 155.25597 136.330336) (xy 155.109662 136.184028) (xy 155.109655 136.184022) (xy 155.00731 136.115638) (xy 154.937599 136.069059) (xy 154.916024 136.060123) (xy 154.916022 136.060121) (xy 154.916022 136.060122) (xy 154.74642 135.98987) (xy 154.746412 135.989868) (xy 154.746404 135.989866) (xy 154.746394 135.989864) (xy 154.543471 135.9495) (xy 154.543469 135.9495) (xy 154.543465 135.9495) (xy 154.336535 135.9495) (xy 154.33653 135.9495) (xy 154.336528 135.9495) (xy 154.133604 135.989864) (xy 154.133579 135.98987) (xy 153.942404 136.069057) (xy 153.770337 136.184027) (xy 153.624027 136.330337) (xy 153.509057 136.502404) (xy 153.42987 136.693579) (xy 153.429864 136.693604) (xy 153.3895 136.896527) (xy 153.3895 136.89653) (xy 153.3895 137.103469) (xy 153.3895 137.103471) (xy 153.389499 137.103471) (xy 153.429864 137.306394) (xy 153.42987 137.306421) (xy 153.486464 137.443051) (xy 153.50906 137.4976) (xy 153.531751 137.531561) (xy 153.62402 137.669652) (xy 153.624026 137.66966) (xy 153.748478 137.794112) (xy 153.768074 137.820286) (xy 153.769625 137.822358) (xy 153.775046 137.832284) (xy 153.789903 137.900556) (xy 153.765491 137.966022) (xy 153.709561 138.007897) (xy 153.709552 138.007901) (xy 153.702364 138.010582) (xy 153.65903 138.0184) (xy 151.927585 138.0184) (xy 151.892649 138.013377) (xy 151.867407 138.005965) (xy 151.814662 137.974669) (xy 150.618412 136.778419) (xy 150.597261 136.750165) (xy 150.580959 136.72031) (xy 150.571128 136.696871) (xy 150.570129 136.693579) (xy 150.490941 136.502402) (xy 150.468248 136.46844) (xy 150.465162 136.463821) (xy 150.376046 136.330449) (xy 150.376036 136.330417) (xy 150.37598 136.330348) (xy 150.37598 136.330349) (xy 150.375977 136.330345) (xy 150.375975 136.330342) (xy 150.375973 136.33034) (xy 150.37597 136.330336) (xy 150.229662 136.184028) (xy 150.229655 136.184022) (xy 150.12731 136.115638) (xy 150.057599 136.069059) (xy 150.036024 136.060123) (xy 150.036022 136.060121) (xy 150.036022 136.060122) (xy 149.86642 135.98987) (xy 149.866412 135.989868) (xy 149.866404 135.989866) (xy 149.866394 135.989864) (xy 149.663471 135.9495) (xy 149.663469 135.9495) (xy 149.663465 135.9495) (xy 149.456535 135.9495) (xy 149.45653 135.9495) (xy 149.456528 135.9495) (xy 149.253604 135.989864) (xy 149.253579 135.98987) (xy 149.062404 136.069057) (xy 148.890337 136.184027) (xy 148.744027 136.330337) (xy 148.629057 136.502404) (xy 148.54987 136.693579) (xy 148.549864 136.693604) (xy 148.5095 136.896527) (xy 148.5095 136.89653) (xy 148.5095 137.103469) (xy 148.5095 137.103471) (xy 148.509499 137.103471) (xy 148.549864 137.306394) (xy 148.54987 137.306421) (xy 148.606464 137.443051) (xy 148.62906 137.4976) (xy 148.651751 137.531561) (xy 148.74402 137.669652) (xy 148.744026 137.66966) (xy 148.890336 137.81597) (xy 148.89034 137.815973) (xy 148.890342 137.815975) (xy 148.890345 137.815977) (xy 148.890349 137.81598) (xy 148.890348 137.81598) (xy 148.890411 137.816032) (xy 148.890448 137.816046) (xy 149.062402 137.930941) (xy 149.25358 138.01013) (xy 149.44454 138.048114) (xy 149.453559 138.049908) (xy 149.455794 138.050409) (xy 149.456532 138.0505) (xy 149.663466 138.0505) (xy 149.667586 138.0505) (xy 149.675435 138.048118) (xy 149.86642 138.01013) (xy 150.057598 137.930941) (xy 150.229655 137.815977) (xy 150.253068 137.792564) (xy 150.276133 137.769499) (xy 150.304384 137.74835) (xy 150.318108 137.740856) (xy 150.33553 137.737066) (xy 150.337454 137.736016) (xy 150.339639 137.736172) (xy 150.386366 137.726005) (xy 150.388176 137.726134) (xy 150.446373 137.7455) (xy 150.452891 137.749689) (xy 150.473526 137.766319) (xy 150.707684 138.000477) (xy 150.715772 138.014565) (xy 150.726194 138.024131) (xy 150.728833 138.028727) (xy 150.734254 138.038654) (xy 150.737091 138.051696) (xy 150.739931 138.056642) (xy 150.74254 138.06657) (xy 150.742282 138.075556) (xy 150.749108 138.106927) (xy 150.740742 138.129357) (xy 150.740541 138.136411) (xy 150.735199 138.144221) (xy 150.724694 138.172392) (xy 150.706745 138.185829) (xy 150.7011 138.194084) (xy 150.688746 138.199304) (xy 150.668762 138.214265) (xy 150.66872 138.214281) (xy 150.668143 138.214496) (xy 150.645869 138.217421) (xy 150.63674 138.221279) (xy 150.628008 138.219767) (xy 150.613028 138.221735) (xy 150.610793 138.221521) (xy 150.59053 138.217864) (xy 150.580957 138.2153) (xy 150.422843 138.2153) (xy 150.270118 138.256222) (xy 150.270111 138.256224) (xy 150.27011 138.256225) (xy 150.2701 138.25623) (xy 150.133198 138.33527) (xy 150.133194 138.335272) (xy 150.13319 138.335275) (xy 150.133182 138.335281) (xy 150.133178 138.335284) (xy 150.133176 138.335285) (xy 150.021385 138.447076) (xy 150.021384 138.447078) (xy 150.021382 138.447081) (xy 150.021381 138.447082) (xy 150.021375 138.44709) (xy 149.985381 138.509433) (xy 149.94233 138.584) (xy 149.942325 138.58401) (xy 149.942324 138.584011) (xy 149.942322 138.584018) (xy 149.9014 138.736743) (xy 149.9014 138.762754) (xy 149.901399 138.76276) (xy 149.9014 138.762763) (xy 149.896375 138.797698) (xy 149.89197 138.812696) (xy 149.854221 138.871445) (xy 149.851771 138.873569) (xy 149.799518 138.900444) (xy 149.794412 138.901671) (xy 149.770823 138.904986) (xy 148.40551 138.964327) (xy 148.398714 138.964622) (xy 148.368021 138.962593) (xy 148.346292 138.9669) (xy 148.336845 138.967311) (xy 148.336841 138.967312) (xy 148.324692 138.96784) (xy 148.324683 138.967842) (xy 148.32413 138.967866) (xy 148.304484 138.974056) (xy 148.297959 138.975917) (xy 148.291405 138.977594) (xy 148.284795 138.979094) (xy 148.264585 138.983103) (xy 148.264583 138.983103) (xy 148.264581 138.983104) (xy 148.264579 138.983104) (xy 148.264562 138.98311) (xy 148.26426 138.983261) (xy 148.253182 138.988716) (xy 148.234812 138.992993) (xy 148.235677 138.995736) (xy 148.223557 138.999556) (xy 148.223552 138.999558) (xy 148.203324 139.012438) (xy 148.194603 139.017505) (xy 148.193031 139.018334) (xy 148.191495 139.019091) (xy 148.191493 139.019091) (xy 148.16998 139.029686) (xy 148.169976 139.029688) (xy 148.169975 139.029689) (xy 148.169973 139.02969) (xy 148.169968 139.029694) (xy 148.167635 139.031736) (xy 148.167523 139.031796) (xy 148.166899 139.032381) (xy 148.160397 139.038075) (xy 148.145315 139.049378) (xy 148.134604 139.056199) (xy 148.118389 139.073886) (xy 148.117535 139.073103) (xy 148.108692 139.083366) (xy 142.861203 143.679738) (xy 142.797804 143.709103) (xy 142.728593 143.699529) (xy 142.675545 143.654058) (xy 142.655502 143.587125) (xy 142.6555 143.586461) (xy 142.6555 137.443053) (xy 144.2 137.443053) (xy 144.205164 137.486066) (xy 144.210612 137.531441) (xy 144.266078 137.672094) (xy 144.266079 137.672095) (xy 144.357435 137.792564) (xy 144.477903 137.883919) (xy 144.477904 137.88392) (xy 144.618556 137.939386) (xy 144.706946 137.95) (xy 144.8 137.95) (xy 145.2 137.95) (xy 145.293049 137.95) (xy 145.293054 137.95) (xy 145.381443 137.939386) (xy 145.522095 137.88392) (xy 145.642564 137.792564) (xy 145.73392 137.672095) (xy 145.789386 137.531443) (xy 145.8 137.443053) (xy 145.8 137.2) (xy 145.2 137.2) (xy 145.2 137.95) (xy 144.8 137.95) (xy 144.8 137.2) (xy 144.2 137.2) (xy 144.2 137.443053) (xy 142.6555 137.443053) (xy 142.6555 136.556946) (xy 144.2 136.556946) (xy 144.2 136.8) (xy 144.8 136.8) (xy 145.2 136.8) (xy 145.8 136.8) (xy 145.8 136.556949) (xy 145.799999 136.556943) (xy 145.799994 136.556898) (xy 146.1995 136.556898) (xy 146.1995 137.443102) (xy 146.205126 137.489954) (xy 146.210122 137.531561) (xy 146.264578 137.669652) (xy 146.26564 137.672345) (xy 146.357076 137.792922) (xy 146.470904 137.87924) (xy 146.477656 137.88436) (xy 146.477657 137.88436) (xy 146.477876 137.884526) (xy 146.480596 137.885519) (xy 146.618436 137.939877) (xy 146.706898 137.9505) (xy 146.706903 137.9505) (xy 147.293097 137.9505) (xy 147.293102 137.9505) (xy 147.381564 137.939877) (xy 147.522342 137.884361) (xy 147.642922 137.792922) (xy 147.734361 137.672342) (xy 147.789877 137.531564) (xy 147.8005 137.443102) (xy 147.8005 136.556898) (xy 147.789877 136.468436) (xy 147.734361 136.327658) (xy 147.73436 136.327657) (xy 147.73436 136.327656) (xy 147.73063 136.322737) (xy 147.730318 136.32214) (xy 147.72924 136.320904) (xy 147.642922 136.207076) (xy 147.522345 136.11564) (xy 147.522339 136.115637) (xy 147.404224 136.069058) (xy 147.404219 136.069057) (xy 147.382574 136.060521) (xy 147.380613 136.059728) (xy 147.380312 136.059603) (xy 147.374199 136.059238) (xy 147.335926 136.054642) (xy 147.335925 136.054641) (xy 147.30822 136.051315) (xy 147.293102 136.0495) (xy 147.293098 136.0495) (xy 146.706901 136.0495) (xy 146.706898 136.0495) (xy 146.69656 136.050741) (xy 146.667853 136.054187) (xy 146.667853 136.054188) (xy 146.66192 136.0549) (xy 146.618439 136.060121) (xy 146.477653 136.11564) (xy 146.357076 136.207076) (xy 146.26564 136.327653) (xy 146.264577 136.330348) (xy 146.210122 136.468438) (xy 146.206044 136.502402) (xy 146.1995 136.556898) (xy 145.799994 136.556898) (xy 145.789386 136.468556) (xy 145.73392 136.327904) (xy 145.642564 136.207435) (xy 145.522095 136.116079) (xy 145.522096 136.116079) (xy 145.381441 136.060612) (xy 145.327933 136.054188) (xy 145.293054 136.05) (xy 145.293049 136.05) (xy 145.2 136.05) (xy 145.2 136.8) (xy 144.8 136.8) (xy 144.8 136.05) (xy 144.706952 136.05) (xy 144.706946 136.05) (xy 144.668294 136.054641) (xy 144.618557 136.060612) (xy 144.477904 136.116078) (xy 144.477903 136.116079) (xy 144.357435 136.207435) (xy 144.266079 136.327903) (xy 144.266078 136.327904) (xy 144.210612 136.468557) (xy 144.206549 136.5024) (xy 144.2 136.556946) (xy 142.6555 136.556946) (xy 142.6555 130.443053) (xy 148.2 130.443053) (xy 148.205164 130.486066) (xy 148.210612 130.531441) (xy 148.266078 130.672094) (xy 148.266079 130.672095) (xy 148.357435 130.792564) (xy 148.477903 130.883919) (xy 148.477904 130.88392) (xy 148.618556 130.939386) (xy 148.706946 130.95) (xy 148.8 130.95) (xy 149.2 130.95) (xy 149.293049 130.95) (xy 149.293054 130.95) (xy 149.381443 130.939386) (xy 149.522095 130.88392) (xy 149.642564 130.792564) (xy 149.73392 130.672095) (xy 149.789386 130.531443) (xy 149.8 130.443053) (xy 149.8 130.2) (xy 149.2 130.2) (xy 149.2 130.95) (xy 148.8 130.95) (xy 148.8 130.2) (xy 148.2 130.2) (xy 148.2 130.443053) (xy 142.6555 130.443053) (xy 142.6555 129.556946) (xy 148.2 129.556946) (xy 148.2 129.8) (xy 148.8 129.8) (xy 149.2 129.8) (xy 149.8 129.8) (xy 149.8 129.556949) (xy 149.799999 129.556943) (xy 149.799994 129.556898) (xy 150.1995 129.556898) (xy 150.1995 130.443102) (xy 150.205126 130.489954) (xy 150.210122 130.531561) (xy 150.265541 130.672094) (xy 150.26564 130.672345) (xy 150.357076 130.792922) (xy 150.470904 130.87924) (xy 150.477656 130.88436) (xy 150.477657 130.88436) (xy 150.477876 130.884526) (xy 150.480596 130.885519) (xy 150.618436 130.939877) (xy 150.706898 130.9505) (xy 150.706903 130.9505) (xy 151.293097 130.9505) (xy 151.293102 130.9505) (xy 151.381564 130.939877) (xy 151.522342 130.884361) (xy 151.642922 130.792922) (xy 151.734361 130.672342) (xy 151.789877 130.531564) (xy 151.8005 130.443102) (xy 151.8005 129.556898) (xy 151.789877 129.468436) (xy 151.734361 129.327658) (xy 151.73436 129.327657) (xy 151.73436 129.327656) (xy 151.73063 129.322737) (xy 151.730318 129.32214) (xy 151.72924 129.320904) (xy 151.642922 129.207076) (xy 151.522345 129.11564) (xy 151.522339 129.115637) (xy 151.426193 129.077721) (xy 151.426191 129.077721) (xy 151.382543 129.060508) (xy 151.380583 129.059716) (xy 151.380311 129.059603) (xy 151.374199 129.059238) (xy 151.335926 129.054642) (xy 151.335925 129.054641) (xy 151.30822 129.051315) (xy 151.293102 129.0495) (xy 151.293098 129.0495) (xy 150.706901 129.0495) (xy 150.706898 129.0495) (xy 150.69656 129.050741) (xy 150.667853 129.054187) (xy 150.667853 129.054188) (xy 150.66192 129.0549) (xy 150.618439 129.060121) (xy 150.477653 129.11564) (xy 150.357076 129.207076) (xy 150.26564 129.327653) (xy 150.210121 129.468439) (xy 150.208098 129.485289) (xy 150.204188 129.517853) (xy 150.1995 129.556898) (xy 149.799994 129.556898) (xy 149.789386 129.468556) (xy 149.73392 129.327904) (xy 149.642564 129.207435) (xy 149.522095 129.116079) (xy 149.522096 129.116079) (xy 149.381441 129.060612) (xy 149.327933 129.054188) (xy 149.293054 129.05) (xy 149.293049 129.05) (xy 149.2 129.05) (xy 149.2 129.8) (xy 148.8 129.8) (xy 148.8 129.05) (xy 148.706952 129.05) (xy 148.706946 129.05) (xy 148.668294 129.054641) (xy 148.618557 129.060612) (xy 148.477904 129.116078) (xy 148.477903 129.116079) (xy 148.357435 129.207435) (xy 148.266079 129.327903) (xy 148.266078 129.327904) (xy 148.210612 129.468557) (xy 148.206777 129.5005) (xy 148.2 129.556946) (xy 142.6555 129.556946) (xy 142.6555 125.261886) (xy 142.6555 125.26188) (xy 142.653645 125.228265) (xy 142.650642 125.201139) (xy 142.645098 125.167924) (xy 142.644045 125.163227) (xy 142.617821 125.090726) (xy 142.61782 125.090724) (xy 142.617817 125.090717) (xy 142.589511 125.035484) (xy 142.589498 125.035461) (xy 142.562189 124.991719) (xy 142.497719 124.932452) (xy 142.479537 124.915737) (xy 142.464724 124.906479) (xy 142.420292 124.87871) (xy 142.420282 124.878705) (xy 142.365134 124.851534) (xy 142.365132 124.851533) (xy 142.365131 124.851533) (xy 142.365127 124.851532) (xy 142.365126 124.851532) (xy 142.253253 124.832076) (xy 142.190578 124.801196) (xy 142.154547 124.741334) (xy 142.150499 124.70991) (xy 142.150499 123.893925) (xy 142.170184 123.826886) (xy 142.222988 123.781131) (xy 142.250461 123.77369) (xy 142.250292 123.77301) (xy 142.258899 123.77087) (xy 142.2589 123.770871) (xy 142.367857 123.743795) (xy 142.431414 123.714772) (xy 142.484488 123.683735) (xy 142.56151 123.602051) (xy 142.599287 123.543274) (xy 142.635413 123.464178) (xy 142.638093 123.455051) (xy 142.638095 123.455047) (xy 142.639789 123.447262) (xy 142.647366 123.412437) (xy 142.65239 123.377498) (xy 142.6555 123.334016) (xy 142.6555 122.963117) (xy 142.6555 122.963106) (xy 142.653642 122.929484) (xy 142.653641 122.929479) (xy 142.653641 122.92947) (xy 142.650633 122.902325) (xy 142.645082 122.869095) (xy 142.644028 122.864397) (xy 142.631478 122.82266) (xy 142.61893 122.789672) (xy 142.612051 122.773074) (xy 142.596252 122.750329) (xy 142.596438 122.750234) (xy 142.589503 122.736703) (xy 142.562204 122.692977) (xy 142.527578 122.661141) (xy 142.526239 122.659384) (xy 142.513777 122.647083) (xy 142.513778 122.647083) (xy 142.498279 122.631784) (xy 142.450405 122.593219) (xy 142.450404 122.593218) (xy 142.435124 122.586891) (xy 142.435102 122.586883) (xy 142.424115 122.582334) (xy 142.420304 122.579952) (xy 142.365163 122.552781) (xy 142.318848 122.544722) (xy 142.316766 122.543967) (xy 142.278291 122.53586) (xy 142.261267 122.534033) (xy 142.196711 122.507307) (xy 142.156852 122.449922) (xy 142.150499 122.410741) (xy 142.150499 121.592691) (xy 142.158919 121.564014) (xy 142.164884 121.53472) (xy 142.16866 121.530841) (xy 142.170184 121.525652) (xy 142.192766 121.506084) (xy 142.213626 121.484661) (xy 142.219718 121.48273) (xy 142.222988 121.479897) (xy 142.246528 121.471887) (xy 142.256647 121.469543) (xy 142.258879 121.469638) (xy 142.294966 121.460671) (xy 142.295936 121.460447) (xy 142.296005 121.460451) (xy 142.29832 121.45992) (xy 142.323791 121.454547) (xy 142.323792 121.454548) (xy 142.345092 121.450056) (xy 142.403691 121.43137) (xy 142.42728 121.415427) (xy 142.431367 121.413562) (xy 142.484472 121.382513) (xy 142.516815 121.348214) (xy 142.5186 121.346888) (xy 142.530918 121.334725) (xy 142.530919 121.334726) (xy 142.546409 121.319432) (xy 142.585601 121.272038) (xy 142.59318 121.254373) (xy 142.598309 121.243827) (xy 142.599256 121.242091) (xy 142.59927 121.24207) (xy 142.635403 121.162974) (xy 142.638089 121.15383) (xy 142.647361 121.111225) (xy 142.652388 121.076277) (xy 142.6555 121.032781) (xy 142.6555 120.663117) (xy 142.6555 120.663106) (xy 142.653642 120.629484) (xy 142.653641 120.629479) (xy 142.653641 120.62947) (xy 142.650633 120.602325) (xy 142.645082 120.569095) (xy 142.644028 120.564397) (xy 142.644025 120.564387) (xy 142.617809 120.491932) (xy 142.617808 120.49193) (xy 142.589501 120.436701) (xy 142.562203 120.392975) (xy 142.479555 120.316987) (xy 142.453517 120.300712) (xy 142.420303 120.279951) (xy 142.365157 120.252778) (xy 142.365155 120.252777) (xy 142.365154 120.252777) (xy 142.36515 120.252776) (xy 142.365149 120.252776) (xy 142.252748 120.233223) (xy 142.222992 120.21856) (xy 142.192797 120.204771) (xy 142.191772 120.203176) (xy 142.190074 120.20234) (xy 142.172963 120.173908) (xy 142.155023 120.145993) (xy 142.154665 120.143504) (xy 142.154046 120.142476) (xy 142.15 120.111058) (xy 142.15 120.055127) (xy 145.8495 120.055127) (xy 145.8495 123.944849) (xy 145.849502 123.944885) (xy 145.852414 123.969993) (xy 145.852546 123.970438) (xy 145.853609 123.972696) (xy 145.874275 124.019501) (xy 145.897793 124.072764) (xy 145.897794 124.072765) (xy 145.977235 124.152206) (xy 146.080009 124.197585) (xy 146.105135 124.2005) (xy 148.194864 124.200499) (xy 148.194879 124.200497) (xy 148.194882 124.200497) (xy 148.194888 124.200496) (xy 148.195019 124.200487) (xy 148.195736 124.200397) (xy 148.219987 124.197586) (xy 148.219987 124.197585) (xy 148.21999 124.197585) (xy 148.219991 124.197585) (xy 148.219991 124.197584) (xy 148.220102 124.197572) (xy 148.221862 124.196758) (xy 148.322765 124.152206) (xy 148.402206 124.072765) (xy 148.447585 123.969991) (xy 148.4505 123.944865) (xy 148.450499 120.055136) (xy 148.450497 120.055117) (xy 148.447586 120.030012) (xy 148.447585 120.03001) (xy 148.447585 120.030009) (xy 148.402206 119.927235) (xy 148.322765 119.847794) (xy 148.322764 119.847793) (xy 148.322765 119.847793) (xy 148.322045 119.847476) (xy 148.322029 119.847469) (xy 148.219993 119.802415) (xy 148.219994 119.802415) (xy 148.194868 119.7995) (xy 148.194865 119.7995) (xy 146.105143 119.7995) (xy 146.105127 119.799501) (xy 146.105113 119.799502) (xy 146.087255 119.801573) (xy 146.080012 119.802413) (xy 146.080011 119.802413) (xy 146.080005 119.802414) (xy 146.079559 119.802547) (xy 146.077303 119.803609) (xy 145.977236 119.847792) (xy 145.897793 119.927234) (xy 145.852414 120.030005) (xy 145.851844 120.03271) (xy 145.851589 120.037124) (xy 145.8495 120.055127) (xy 142.15 120.055127) (xy 142.15 119.9) (xy 140.991833 119.9) (xy 140.970381 119.89813) (xy 140.96105 119.896491) (xy 140.95822 119.89509) (xy 140.956892 119.894975) (xy 140.95252 119.893691) (xy 140.952803 119.892724) (xy 140.93669 119.888611) (xy 140.936435 119.889297) (xy 140.933587 119.888234) (xy 140.932747 119.887605) (xy 140.930999 119.887159) (xy 140.928292 119.885923) (xy 140.928854 119.88469) (xy 140.916878 119.875723) (xy 140.907123 119.872855) (xy 140.902509 119.867525) (xy 140.898427 119.865506) (xy 140.894512 119.858977) (xy 140.882434 119.849933) (xy 140.881407 119.850824) (xy 140.880492 119.849768) (xy 140.879597 119.847809) (xy 140.877684 119.846377) (xy 140.875858 119.843938) (xy 140.877327 119.842837) (xy 140.873077 119.83353) (xy 140.86139 119.820032) (xy 140.851488 119.786257) (xy 140.851468 119.786212) (xy 140.851461 119.786163) (xy 140.851255 119.784726) (xy 140.85 119.76713) (xy 140.85 119.641829) (xy 140.855023 119.606893) (xy 140.859427 119.591895) (xy 140.897172 119.533144) (xy 140.898541 119.531957) (xy 140.95342 119.504477) (xy 140.960979 119.502833) (xy 140.987332 119.5) (xy 142.149999 119.5) (xy 142.149999 118.90522) (xy 142.149998 118.905202) (xy 142.149997 118.905191) (xy 142.147091 118.88013) (xy 142.14709 118.880126) (xy 142.101788 118.777525) (xy 142.101788 118.777524) (xy 142.101783 118.777517) (xy 142.022481 118.698215) (xy 142.022475 118.698211) (xy 141.919875 118.652909) (xy 141.919871 118.652908) (xy 141.915203 118.652367) (xy 141.85088 118.625084) (xy 141.811519 118.567357) (xy 141.8055 118.529194) (xy 141.8055 118.099448) (xy 163.8495 118.099448) (xy 163.8495 118.28055) (xy 163.877829 118.459413) (xy 163.933778 118.631612) (xy 163.933786 118.631635) (xy 163.933788 118.631639) (xy 164.016006 118.792997) (xy 164.09754 118.90522) (xy 164.122445 118.939499) (xy 164.122452 118.939507) (xy 164.250493 119.067548) (xy 164.250497 119.067551) (xy 164.2505 119.067554) (xy 164.250505 119.067558) (xy 164.378287 119.160396) (xy 164.397006 119.173996) (xy 164.502484 119.22774) (xy 164.55836 119.256211) (xy 164.558363 119.256212) (xy 164.644476 119.284191) (xy 164.730591 119.312171) (xy 164.772733 119.318845) (xy 164.803478 119.323715) (xy 164.803577 119.32373) (xy 164.803639 119.32374) (xy 164.873071 119.334738) (xy 164.906787 119.345163) (xy 164.913071 119.348142) (xy 164.926374 119.360007) (xy 164.936203 119.364667) (xy 164.941954 119.373903) (xy 164.965213 119.394649) (xy 164.983935 119.461964) (xy 164.963292 119.528714) (xy 164.911466 119.572978) (xy 164.906078 119.575439) (xy 164.873958 119.585121) (xy 164.730585 119.607829) (xy 164.558386 119.663778) (xy 164.558363 119.663786) (xy 164.558359 119.663788) (xy 164.397005 119.746004) (xy 164.250499 119.852445) (xy 164.250491 119.852452) (xy 164.122452 119.980491) (xy 164.122445 119.980499) (xy 164.016004 120.127005) (xy 163.933788 120.288359) (xy 163.933786 120.288363) (xy 163.933778 120.288386) (xy 163.877829 120.460585) (xy 163.8495 120.639448) (xy 163.8495 120.82055) (xy 163.877829 120.999413) (xy 163.933778 121.171612) (xy 163.933786 121.171635) (xy 163.933788 121.171639) (xy 164.016006 121.332997) (xy 164.122441 121.479494) (xy 164.122445 121.479499) (xy 164.122452 121.479507) (xy 164.250491 121.607546) (xy 164.2505 121.607554) (xy 164.250524 121.607572) (xy 164.364733 121.690549) (xy 164.364736 121.690551) (xy 164.370673 121.694864) (xy 164.397006 121.713996) (xy 164.502484 121.76774) (xy 164.55836 121.796211) (xy 164.558363 121.796212) (xy 164.640087 121.822765) (xy 164.730591 121.852171) (xy 164.772733 121.858845) (xy 164.803478 121.863715) (xy 164.803577 121.86373) (xy 164.803639 121.86374) (xy 164.873071 121.874738) (xy 164.906787 121.885163) (xy 164.913071 121.888142) (xy 164.926374 121.900007) (xy 164.936203 121.904667) (xy 164.941954 121.913903) (xy 164.965213 121.934649) (xy 164.983935 122.001964) (xy 164.963292 122.068714) (xy 164.911466 122.112978) (xy 164.906078 122.115439) (xy 164.873958 122.125121) (xy 164.730585 122.147829) (xy 164.558386 122.203778) (xy 164.558363 122.203786) (xy 164.558359 122.203788) (xy 164.397005 122.286004) (xy 164.397002 122.286005) (xy 164.397002 122.286006) (xy 164.348169 122.321484) (xy 164.250499 122.392445) (xy 164.250491 122.392452) (xy 164.122452 122.520491) (xy 164.122445 122.520499) (xy 164.016004 122.667005) (xy 163.933788 122.828359) (xy 163.933786 122.828363) (xy 163.933778 122.828386) (xy 163.877829 123.000585) (xy 163.8495 123.179448) (xy 163.8495 123.36055) (xy 163.877829 123.539413) (xy 163.933778 123.711612) (xy 163.933786 123.711635) (xy 163.933788 123.711639) (xy 164.016006 123.872997) (xy 164.088441 123.972696) (xy 164.122445 124.019499) (xy 164.122452 124.019507) (xy 164.250493 124.147548) (xy 164.250497 124.147551) (xy 164.2505 124.147554) (xy 164.250505 124.147558) (xy 164.305459 124.187484) (xy 164.37253 124.236214) (xy 164.372534 124.236216) (xy 164.378287 124.240396) (xy 164.397006 124.253996) (xy 164.467018 124.289669) (xy 164.55836 124.336211) (xy 164.558363 124.336212) (xy 164.644476 124.364191) (xy 164.730591 124.392171) (xy 164.803639 124.40374) (xy 164.873071 124.414738) (xy 164.906787 124.425163) (xy 164.913071 124.428142) (xy 164.965213 124.474649) (xy 164.983935 124.541964) (xy 164.963292 124.608714) (xy 164.911466 124.652978) (xy 164.906078 124.655439) (xy 164.873958 124.665121) (xy 164.730585 124.687829) (xy 164.558386 124.743778) (xy 164.558363 124.743786) (xy 164.558359 124.743788) (xy 164.397005 124.826004) (xy 164.397002 124.826005) (xy 164.397002 124.826006) (xy 164.381772 124.837071) (xy 164.250499 124.932445) (xy 164.250491 124.932452) (xy 164.122452 125.060491) (xy 164.122445 125.060499) (xy 164.122441 125.060505) (xy 164.020259 125.201149) (xy 164.016004 125.207005) (xy 163.933788 125.368359) (xy 163.933786 125.368363) (xy 163.933778 125.368386) (xy 163.877829 125.540585) (xy 163.8495 125.719448) (xy 163.8495 125.90055) (xy 163.877829 126.079413) (xy 163.933778 126.251612) (xy 163.933785 126.251631) (xy 163.933787 126.251636) (xy 163.933788 126.251639) (xy 163.989664 126.3613) (xy 164.013184 126.40746) (xy 164.016006 126.412997) (xy 164.122441 126.559494) (xy 164.122445 126.559499) (xy 164.122452 126.559507) (xy 164.250493 126.687548) (xy 164.250497 126.687551) (xy 164.2505 126.687554) (xy 164.250505 126.687558) (xy 164.378287 126.780396) (xy 164.397006 126.793996) (xy 164.502484 126.84774) (xy 164.55836 126.876211) (xy 164.558363 126.876212) (xy 164.644476 126.904191) (xy 164.730591 126.932171) (xy 164.772733 126.938845) (xy 164.803478 126.943715) (xy 164.803577 126.94373) (xy 164.803639 126.94374) (xy 164.873071 126.954738) (xy 164.906787 126.965163) (xy 164.913071 126.968142) (xy 164.926374 126.980007) (xy 164.936203 126.984667) (xy 164.941954 126.993903) (xy 164.965213 127.014649) (xy 164.983935 127.081964) (xy 164.963292 127.148714) (xy 164.911466 127.192978) (xy 164.906078 127.195439) (xy 164.873958 127.205121) (xy 164.730585 127.227829) (xy 164.558386 127.283778) (xy 164.558363 127.283786) (xy 164.558359 127.283788) (xy 164.397005 127.366004) (xy 164.397002 127.366005) (xy 164.397002 127.366006) (xy 164.348169 127.401484) (xy 164.250499 127.472445) (xy 164.250491 127.472452) (xy 164.122452 127.600491) (xy 164.122445 127.600499) (xy 164.016004 127.747005) (xy 163.933788 127.908359) (xy 163.933786 127.908363) (xy 163.933778 127.908386) (xy 163.877829 128.080585) (xy 163.8495 128.259448) (xy 163.8495 128.44055) (xy 163.877829 128.619413) (xy 163.933778 128.791612) (xy 163.933786 128.791635) (xy 163.933788 128.791639) (xy 164.016006 128.952997) (xy 164.106623 129.077722) (xy 164.122445 129.099499) (xy 164.122452 129.099507) (xy 164.250493 129.227548) (xy 164.250496 129.22755) (xy 164.2505 129.227554) (xy 164.250505 129.227558) (xy 164.337072 129.290452) (xy 164.358619 129.306107) (xy 164.373363 129.316818) (xy 164.397006 129.333996) (xy 164.502484 129.38774) (xy 164.55836 129.416211) (xy 164.558363 129.416212) (xy 164.644476 129.444191) (xy 164.648379 129.445459) (xy 164.730584 129.472169) (xy 164.730585 129.472169) (xy 164.730591 129.472171) (xy 164.813429 129.485291) (xy 164.909449 129.5005) (xy 164.909454 129.5005) (xy 165.090548 129.5005) (xy 165.090551 129.5005) (xy 165.177259 129.486765) (xy 165.269409 129.472171) (xy 165.441639 129.416211) (xy 165.602994 129.333996) (xy 165.749501 129.227553) (xy 165.877553 129.099501) (xy 165.983996 128.952994) (xy 166.066211 128.791639) (xy 166.122171 128.619409) (xy 166.136765 128.527259) (xy 166.1505 128.440551) (xy 166.1505 128.259448) (xy 166.134019 128.155397) (xy 166.122171 128.080591) (xy 166.066211 127.908361) (xy 166.066211 127.90836) (xy 166.03774 127.852484) (xy 165.983996 127.747006) (xy 165.983995 127.747004) (xy 165.970397 127.728289) (xy 165.970395 127.728285) (xy 165.87757 127.600522) (xy 165.877558 127.600505) (xy 165.877554 127.6005) (xy 165.877551 127.600497) (xy 165.877548 127.600493) (xy 165.749507 127.472452) (xy 165.749498 127.472444) (xy 165.749474 127.472426) (xy 165.613605 127.373712) (xy 165.613591 127.373703) (xy 165.602997 127.366006) (xy 165.602996 127.366005) (xy 165.602994 127.366004) (xy 165.596871 127.362884) (xy 165.551301 127.339664) (xy 165.5513 127.339664) (xy 165.441639 127.283788) (xy 165.441636 127.283787) (xy 165.441633 127.283786) (xy 165.441631 127.283785) (xy 165.441612 127.283778) (xy 165.269412 127.227829) (xy 165.269413 127.227829) (xy 165.126931 127.205262) (xy 165.114645 127.199438) (xy 165.093207 127.194834) (xy 165.086927 127.191857) (xy 165.073624 127.179992) (xy 165.063796 127.175333) (xy 165.058044 127.166095) (xy 165.034785 127.14535) (xy 165.016063 127.078035) (xy 165.036706 127.011285) (xy 165.067582 126.984917) (xy 165.076363 126.974373) (xy 165.082016 126.972591) (xy 165.088549 126.967013) (xy 165.093937 126.964553) (xy 165.126032 126.954879) (xy 165.179425 126.946422) (xy 165.269409 126.932171) (xy 165.441639 126.876211) (xy 165.602994 126.793996) (xy 165.749501 126.687553) (xy 165.877553 126.559501) (xy 165.983996 126.412994) (xy 166.066211 126.251639) (xy 166.122171 126.079409) (xy 166.136765 125.987259) (xy 166.1505 125.900551) (xy 166.1505 125.719448) (xy 166.134019 125.615397) (xy 166.122171 125.540591) (xy 166.067718 125.372999) (xy 166.066656 125.369234) (xy 166.032503 125.302205) (xy 166.032503 125.302204) (xy 165.983995 125.207004) (xy 165.920778 125.119993) (xy 165.920777 125.11999) (xy 165.877572 125.060524) (xy 165.877554 125.0605) (xy 165.877546 125.060491) (xy 165.749507 124.932452) (xy 165.749498 124.932444) (xy 165.749474 124.932426) (xy 165.613605 124.833712) (xy 165.613591 124.833703) (xy 165.602997 124.826006) (xy 165.602996 124.826005) (xy 165.602994 124.826004) (xy 165.596871 124.822884) (xy 165.551301 124.799664) (xy 165.5513 124.799664) (xy 165.441639 124.743788) (xy 165.441636 124.743787) (xy 165.441633 124.743786) (xy 165.441631 124.743785) (xy 165.441612 124.743778) (xy 165.269412 124.687829) (xy 165.269413 124.687829) (xy 165.126931 124.665262) (xy 165.114645 124.659438) (xy 165.093207 124.654834) (xy 165.086927 124.651857) (xy 165.073624 124.639992) (xy 165.063796 124.635333) (xy 165.058044 124.626095) (xy 165.034785 124.60535) (xy 165.016063 124.538035) (xy 165.036706 124.471285) (xy 165.067582 124.444917) (xy 165.076363 124.434373) (xy 165.082016 124.432591) (xy 165.088549 124.427013) (xy 165.093937 124.424553) (xy 165.126032 124.414879) (xy 165.179425 124.406422) (xy 165.269409 124.392171) (xy 165.441639 124.336211) (xy 165.602994 124.253996) (xy 165.749501 124.147553) (xy 165.877553 124.019501) (xy 165.983996 123.872994) (xy 166.066211 123.711639) (xy 166.122171 123.539409) (xy 166.128008 123.502549) (xy 166.136765 123.447262) (xy 166.136765 123.447259) (xy 166.1505 123.360551) (xy 166.1505 123.179448) (xy 166.130076 123.0505) (xy 166.122171 123.000591) (xy 166.066977 122.830719) (xy 166.066433 122.828796) (xy 166.063306 122.82266) (xy 166.03774 122.772484) (xy 165.983996 122.667006) (xy 165.923209 122.583339) (xy 165.923208 122.583336) (xy 165.877572 122.520524) (xy 165.877554 122.5205) (xy 165.877546 122.520491) (xy 165.749507 122.392452) (xy 165.749498 122.392444) (xy 165.749474 122.392426) (xy 165.613605 122.293712) (xy 165.613591 122.293703) (xy 165.602997 122.286006) (xy 165.602996 122.286005) (xy 165.602994 122.286004) (xy 165.596871 122.282884) (xy 165.551301 122.259664) (xy 165.5513 122.259664) (xy 165.441639 122.203788) (xy 165.441636 122.203787) (xy 165.441633 122.203786) (xy 165.441631 122.203785) (xy 165.441612 122.203778) (xy 165.269412 122.147829) (xy 165.269413 122.147829) (xy 165.126931 122.125262) (xy 165.114645 122.119438) (xy 165.093207 122.114834) (xy 165.086927 122.111857) (xy 165.073624 122.099992) (xy 165.063796 122.095333) (xy 165.058044 122.086095) (xy 165.034785 122.06535) (xy 165.016063 121.998035) (xy 165.036706 121.931285) (xy 165.067582 121.904917) (xy 165.076363 121.894373) (xy 165.082016 121.892591) (xy 165.088549 121.887013) (xy 165.093937 121.884553) (xy 165.126032 121.874879) (xy 165.179425 121.866422) (xy 165.269409 121.852171) (xy 165.441639 121.796211) (xy 165.602994 121.713996) (xy 165.749501 121.607553) (xy 165.877553 121.479501) (xy 165.983996 121.332994) (xy 166.066211 121.171639) (xy 166.122171 120.999409) (xy 166.136765 120.907259) (xy 166.1505 120.820551) (xy 166.1505 120.639448) (xy 166.131561 120.519877) (xy 166.122171 120.460591) (xy 166.066211 120.288361) (xy 166.066211 120.28836) (xy 166.03774 120.232484) (xy 165.983996 120.127006) (xy 165.931766 120.055117) (xy 165.931765 120.055115) (xy 165.931764 120.055113) (xy 165.877572 119.980524) (xy 165.877554 119.9805) (xy 165.877546 119.980491) (xy 165.749507 119.852452) (xy 165.749498 119.852444) (xy 165.749474 119.852426) (xy 165.613597 119.753706) (xy 165.613581 119.753695) (xy 165.602997 119.746006) (xy 165.602996 119.746005) (xy 165.602994 119.746004) (xy 165.596914 119.742906) (xy 165.596911 119.742904) (xy 165.533098 119.71039) (xy 165.533098 119.710389) (xy 165.533096 119.710389) (xy 165.441639 119.663788) (xy 165.441563 119.663762) (xy 165.269412 119.607829) (xy 165.269413 119.607829) (xy 165.126931 119.585262) (xy 165.114645 119.579438) (xy 165.093207 119.574834) (xy 165.086927 119.571857) (xy 165.073624 119.559992) (xy 165.063796 119.555333) (xy 165.058044 119.546095) (xy 165.034785 119.52535) (xy 165.016063 119.458035) (xy 165.036706 119.391285) (xy 165.067582 119.364917) (xy 165.076363 119.354373) (xy 165.082016 119.352591) (xy 165.088549 119.347013) (xy 165.093937 119.344553) (xy 165.126032 119.334879) (xy 165.179425 119.326422) (xy 165.269409 119.312171) (xy 165.441639 119.256211) (xy 165.602994 119.173996) (xy 165.749501 119.067553) (xy 165.877553 118.939501) (xy 165.983996 118.792994) (xy 166.066211 118.631639) (xy 166.122171 118.459409) (xy 166.136765 118.367259) (xy 166.1505 118.280551) (xy 166.1505 118.099448) (xy 166.127642 117.955135) (xy 166.122171 117.920591) (xy 166.067131 117.751195) (xy 166.066606 117.749392) (xy 166.066606 117.749136) (xy 166.03774 117.692484) (xy 166.037739 117.692483) (xy 165.983996 117.587006) (xy 165.93931 117.5255) (xy 165.877558 117.440505) (xy 165.877554 117.4405) (xy 165.87755 117.440496) (xy 165.877548 117.440493) (xy 165.749507 117.312452) (xy 165.749498 117.312444) (xy 165.749474 117.312426) (xy 165.613605 117.213712) (xy 165.613591 117.213703) (xy 165.602997 117.206006) (xy 165.602996 117.206005) (xy 165.602994 117.206004) (xy 165.596871 117.202884) (xy 165.551301 117.179664) (xy 165.5513 117.179664) (xy 165.441639 117.123788) (xy 165.441636 117.123787) (xy 165.441633 117.123786) (xy 165.441631 117.123785) (xy 165.441612 117.123778) (xy 165.269412 117.067829) (xy 165.269415 117.067829) (xy 165.152181 117.049261) (xy 165.147914 117.04781) (xy 165.145404 117.047994) (xy 165.118452 117.03883) (xy 165.112933 117.036213) (xy 165.112401 117.035738) (xy 165.112317 117.03571) (xy 165.107191 117.032921) (xy 165.089765 117.015547) (xy 165.060792 116.989704) (xy 165.059621 116.985494) (xy 165.057711 116.98359) (xy 165.052579 116.960167) (xy 165.042074 116.922388) (xy 165.043377 116.918172) (xy 165.042757 116.915339) (xy 165.051728 116.891173) (xy 165.06272 116.855638) (xy 165.065922 116.852942) (xy 165.067075 116.849838) (xy 165.090615 116.83216) (xy 165.116177 116.810648) (xy 165.116737 116.810402) (xy 165.120694 116.809573) (xy 165.122946 116.807883) (xy 165.131901 116.807228) (xy 165.166454 116.799999) (xy 165.894791 116.799999) (xy 165.894791 116.799998) (xy 165.894808 116.799997) (xy 165.894808 116.799996) (xy 165.894824 116.799996) (xy 165.915922 116.797548) (xy 165.919869 116.797091) (xy 165.919873 116.79709) (xy 166.022474 116.751788) (xy 166.022479 116.751785) (xy 166.101785 116.672479) (xy 166.101788 116.672474) (xy 166.147089 116.569877) (xy 166.147089 116.569875) (xy 166.14766 116.56717) (xy 166.147915 116.562761) (xy 166.149673 116.547602) (xy 166.15 116.545248) (xy 166.15 115.85) (xy 165.623731 115.85) (xy 165.615045 115.847449) (xy 165.606084 115.848738) (xy 165.582043 115.837759) (xy 165.556692 115.830315) (xy 165.550764 115.823474) (xy 165.542528 115.819713) (xy 165.528238 115.797478) (xy 165.510937 115.777511) (xy 165.508649 115.766996) (xy 165.504754 115.760935) (xy 165.503325 115.742521) (xy 165.499731 115.726) (xy 165.499731 115.716829) (xy 165.5 115.715826) (xy 165.5 115.584174) (xy 165.499731 115.58317) (xy 165.499731 115.574) (xy 165.507379 115.547952) (xy 165.511567 115.521131) (xy 165.517077 115.514924) (xy 165.519416 115.506961) (xy 165.53993 115.489184) (xy 165.557956 115.468883) (xy 165.566037 115.466562) (xy 165.57222 115.461206) (xy 165.597217 115.457611) (xy 165.623731 115.45) (xy 166.149999 115.45) (xy 166.149999 114.75522) (xy 166.149998 114.755202) (xy 166.149997 114.755191) (xy 166.147091 114.73013) (xy 166.14709 114.730126) (xy 166.101788 114.627525) (xy 166.101788 114.627524) (xy 166.101783 114.627517) (xy 166.022481 114.548215) (xy 166.022475 114.548211) (xy 165.919876 114.50291) (xy 165.894795 114.5) (xy 165.894794 114.5) (xy 165.2 114.5) (xy 165.2 115.026269) (xy 165.197449 115.034954) (xy 165.198738 115.043916) (xy 165.187759 115.067956) (xy 165.180315 115.093308) (xy 165.173474 115.099235) (xy 165.169713 115.107472) (xy 165.147478 115.121761) (xy 165.127511 115.139063) (xy 165.116996 115.14135) (xy 165.110935 115.145246) (xy 165.092521 115.146674) (xy 165.076 115.150269) (xy 165.06683 115.150269) (xy 165.065826 115.15) (xy 164.934174 115.15) (xy 164.93317 115.150269) (xy 164.924 115.150269) (xy 164.897952 115.14262) (xy 164.871131 115.138433) (xy 164.864924 115.132922) (xy 164.856961 115.130584) (xy 164.839184 115.110069) (xy 164.818883 115.092044) (xy 164.816562 115.083962) (xy 164.811206 115.07778) (xy 164.807611 115.052782) (xy 164.8 115.026269) (xy 164.8 114.5) (xy 164.105214 114.5) (xy 164.105202 114.5) (xy 164.080126 114.502908) (xy 163.977526 114.54821) (xy 163.977524 114.54821) (xy 163.977517 114.548215) (xy 163.898216 114.627516) (xy 163.898214 114.62752) (xy 163.898211 114.627525) (xy 163.898211 114.627526) (xy 163.898208 114.627532) (xy 163.852909 114.730121) (xy 163.852339 114.732827) (xy 163.852084 114.737242) (xy 163.85 114.7552) (xy 163.85 114.755202) (xy 163.85 114.755205) (xy 163.85 115.45) (xy 164.376269 115.45) (xy 164.384954 115.45255) (xy 164.393916 115.451262) (xy 164.417956 115.46224) (xy 164.443308 115.469685) (xy 164.449235 115.476525) (xy 164.457472 115.480287) (xy 164.471761 115.502521) (xy 164.489063 115.522489) (xy 164.49135 115.533003) (xy 164.495246 115.539065) (xy 164.496674 115.557478) (xy 164.500269 115.574) (xy 164.500269 115.58317) (xy 164.5 115.584174) (xy 164.5 115.715826) (xy 164.500269 115.716829) (xy 164.500269 115.726) (xy 164.49262 115.752047) (xy 164.488433 115.778869) (xy 164.482922 115.785075) (xy 164.480584 115.793039) (xy 164.460069 115.810815) (xy 164.442044 115.831117) (xy 164.433962 115.833437) (xy 164.42778 115.838794) (xy 164.402782 115.842388) (xy 164.376269 115.85) (xy 163.850001 115.85) (xy 163.850001 116.544805) (xy 163.852908 116.569872) (xy 163.89821 116.672472) (xy 163.89821 116.672474) (xy 163.898215 116.672481) (xy 163.977517 116.751783) (xy 163.97752 116.751785) (xy 163.977525 116.751788) (xy 164.080123 116.797089) (xy 164.105206 116.799999) (xy 164.828201 116.799999) (xy 164.832644 116.800764) (xy 164.835094 116.800191) (xy 164.863127 116.805019) (xy 164.868989 116.80674) (xy 164.869596 116.807131) (xy 164.869695 116.807148) (xy 164.875192 116.8091) (xy 164.895112 116.823527) (xy 164.927768 116.844511) (xy 164.929587 116.848495) (xy 164.93178 116.850083) (xy 164.940512 116.872411) (xy 164.956797 116.908065) (xy 164.956167 116.912444) (xy 164.957227 116.915154) (xy 164.952145 116.940427) (xy 164.946857 116.977224) (xy 164.94411 116.980394) (xy 164.943455 116.983653) (xy 164.922966 117.004798) (xy 164.901105 117.030031) (xy 164.900968 117.030119) (xy 164.900606 117.030351) (xy 164.896807 117.031795) (xy 164.894835 117.033832) (xy 164.886046 117.035889) (xy 164.853097 117.048424) (xy 164.730585 117.067829) (xy 164.558386 117.123778) (xy 164.558363 117.123786) (xy 164.558359 117.123788) (xy 164.397005 117.206004) (xy 164.397002 117.206005) (xy 164.397002 117.206006) (xy 164.348169 117.241484) (xy 164.250499 117.312445) (xy 164.250491 117.312452) (xy 164.122452 117.440491) (xy 164.122445 117.440499) (xy 164.016004 117.587005) (xy 163.933788 117.748359) (xy 163.933786 117.748363) (xy 163.933778 117.748386) (xy 163.877829 117.920585) (xy 163.8495 118.099448) (xy 141.8055 118.099448) (xy 141.8055 113.443053) (xy 154.2 113.443053) (xy 154.205164 113.486066) (xy 154.210612 113.531441) (xy 154.266078 113.672094) (xy 154.266079 113.672095) (xy 154.357435 113.792564) (xy 154.477903 113.883919) (xy 154.477904 113.88392) (xy 154.618556 113.939386) (xy 154.706946 113.95) (xy 154.8 113.95) (xy 155.2 113.95) (xy 155.293049 113.95) (xy 155.293054 113.95) (xy 155.381443 113.939386) (xy 155.522095 113.88392) (xy 155.642564 113.792564) (xy 155.73392 113.672095) (xy 155.789386 113.531443) (xy 155.8 113.443053) (xy 155.8 113.2) (xy 155.2 113.2) (xy 155.2 113.95) (xy 154.8 113.95) (xy 154.8 113.2) (xy 154.2 113.2) (xy 154.2 113.443053) (xy 141.8055 113.443053) (xy 141.8055 112.556946) (xy 154.2 112.556946) (xy 154.2 112.8) (xy 154.8 112.8) (xy 155.2 112.8) (xy 155.8 112.8) (xy 155.8 112.556949) (xy 155.799999 112.556943) (xy 155.799994 112.556898) (xy 156.1995 112.556898) (xy 156.1995 113.443102) (xy 156.205126 113.489954) (xy 156.210122 113.531561) (xy 156.210122 113.531563) (xy 156.210123 113.531564) (xy 156.213885 113.541106) (xy 156.213888 113.541115) (xy 156.227721 113.576191) (xy 156.227721 113.576192) (xy 156.265637 113.672339) (xy 156.26564 113.672345) (xy 156.357076 113.792922) (xy 156.470904 113.87924) (xy 156.477656 113.88436) (xy 156.477657 113.88436) (xy 156.477876 113.884526) (xy 156.480596 113.885519) (xy 156.618436 113.939877) (xy 156.706898 113.9505) (xy 156.706903 113.9505) (xy 157.293097 113.9505) (xy 157.293102 113.9505) (xy 157.381564 113.939877) (xy 157.522342 113.884361) (xy 157.642922 113.792922) (xy 157.734361 113.672342) (xy 157.789877 113.531564) (xy 157.8005 113.443102) (xy 157.8005 113.443053) (xy 160.2 113.443053) (xy 160.205164 113.486066) (xy 160.210612 113.531441) (xy 160.266078 113.672094) (xy 160.266079 113.672095) (xy 160.357435 113.792564) (xy 160.477903 113.883919) (xy 160.477904 113.88392) (xy 160.618556 113.939386) (xy 160.706946 113.95) (xy 160.8 113.95) (xy 161.2 113.95) (xy 161.293049 113.95) (xy 161.293054 113.95) (xy 161.381443 113.939386) (xy 161.522095 113.88392) (xy 161.642564 113.792564) (xy 161.73392 113.672095) (xy 161.789386 113.531443) (xy 161.8 113.443053) (xy 161.8 113.2) (xy 161.2 113.2) (xy 161.2 113.95) (xy 160.8 113.95) (xy 160.8 113.2) (xy 160.2 113.2) (xy 160.2 113.443053) (xy 157.8005 113.443053) (xy 157.8005 112.556946) (xy 160.2 112.556946) (xy 160.2 112.8) (xy 160.8 112.8) (xy 160.8 112.05) (xy 160.706952 112.05) (xy 160.706946 112.05) (xy 160.668294 112.054641) (xy 160.618557 112.060612) (xy 160.477904 112.116078) (xy 160.477903 112.116079) (xy 160.357435 112.207435) (xy 160.266079 112.327903) (xy 160.266078 112.327904) (xy 160.210612 112.468557) (xy 160.204694 112.517853) (xy 160.2 112.556946) (xy 157.8005 112.556946) (xy 157.8005 112.556898) (xy 157.789877 112.468436) (xy 157.734361 112.327658) (xy 157.73436 112.327657) (xy 157.73436 112.327656) (xy 157.73063 112.322737) (xy 157.730318 112.32214) (xy 157.72924 112.320904) (xy 157.642922 112.207076) (xy 157.522345 112.11564) (xy 157.522339 112.115637) (xy 157.426193 112.077721) (xy 157.426191 112.077721) (xy 157.382543 112.060508) (xy 157.380583 112.059716) (xy 157.380311 112.059603) (xy 157.374199 112.059238) (xy 157.335926 112.054642) (xy 157.335925 112.054641) (xy 157.30822 112.051315) (xy 157.293102 112.0495) (xy 157.293098 112.0495) (xy 156.706901 112.0495) (xy 156.706898 112.0495) (xy 156.69656 112.050741) (xy 156.667853 112.054187) (xy 156.667853 112.054188) (xy 156.66192 112.0549) (xy 156.618439 112.060121) (xy 156.477653 112.11564) (xy 156.357076 112.207076) (xy 156.26564 112.327653) (xy 156.210121 112.468439) (xy 156.2049 112.51192) (xy 156.204188 112.517853) (xy 156.1995 112.556898) (xy 155.799994 112.556898) (xy 155.789386 112.468556) (xy 155.73392 112.327904) (xy 155.642564 112.207435) (xy 155.522095 112.116079) (xy 155.522096 112.116079) (xy 155.381441 112.060612) (xy 155.327933 112.054188) (xy 155.293054 112.05) (xy 155.293049 112.05) (xy 155.2 112.05) (xy 155.2 112.8) (xy 154.8 112.8) (xy 154.8 112.05) (xy 154.706952 112.05) (xy 154.706946 112.05) (xy 154.668294 112.054641) (xy 154.618557 112.060612) (xy 154.477904 112.116078) (xy 154.477903 112.116079) (xy 154.357435 112.207435) (xy 154.266079 112.327903) (xy 154.266078 112.327904) (xy 154.210612 112.468557) (xy 154.204694 112.517853) (xy 154.2 112.556946) (xy 141.8055 112.556946) (xy 141.8055 111.624) (xy 141.825185 111.556961) (xy 141.877989 111.511206) (xy 141.9295 111.5) (xy 161.304777 111.5)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts (xy 163.742606 157.832623) (xy 163.757604 157.837027) (xy 163.772594 157.846657) (xy 163.789675 157.851667) (xy 163.816355 157.874772) (xy 163.817542 157.876141) (xy 163.845018 157.931002) (xy 163.846663 157.93856) (xy 163.8495 157.964931) (xy 163.8495 158.09055) (xy 163.877829 158.269413) (xy 163.933762 158.441563) (xy 163.933788 158.441639) (xy 163.96655 158.505936) (xy 163.96655 158.505938) (xy 163.966551 158.505938) (xy 164.007302 158.585916) (xy 164.016006 158.602997) (xy 164.058016 158.660819) (xy 164.122432 158.749482) (xy 164.122444 158.749498) (xy 164.122452 158.749507) (xy 164.250491 158.877546) (xy 164.2505 158.877554) (xy 164.250524 158.877572) (xy 164.341405 158.943601) (xy 164.341413 158.943605) (xy 164.346458 158.947271) (xy 164.397006 158.983996) (xy 164.502484 159.03774) (xy 164.55836 159.066211) (xy 164.558363 159.066212) (xy 164.644476 159.094191) (xy 164.730591 159.122171) (xy 164.850038 159.141089) (xy 164.874676 159.144991) (xy 164.908388 159.155416) (xy 164.914672 159.158395) (xy 164.927975 159.170261) (xy 164.937805 159.174921) (xy 164.943555 159.184157) (xy 164.966814 159.204902) (xy 164.985536 159.272217) (xy 164.964893 159.338967) (xy 164.913067 159.383231) (xy 164.907679 159.385692) (xy 164.875559 159.395374) (xy 164.730702 159.418317) (xy 164.558627 159.474226) (xy 164.558551 159.474252) (xy 164.397271 159.55643) (xy 164.397264 159.556434) (xy 164.250831 159.662822) (xy 164.250828 159.662824) (xy 164.122824 159.790828) (xy 164.122822 159.790831) (xy 164.016434 159.937264) (xy 164.016433 159.937266) (xy 163.934254 160.098548) (xy 163.878317 160.270699) (xy 163.878316 160.270705) (xy 163.878316 160.270706) (xy 163.867342 160.34) (xy 164.376269 160.34) (xy 164.384954 160.34255) (xy 164.393916 160.341262) (xy 164.417956 160.35224) (xy 164.443308 160.359685) (xy 164.449235 160.366525) (xy 164.457472 160.370287) (xy 164.471761 160.392521) (xy 164.489063 160.412489) (xy 164.49135 160.423003) (xy 164.495246 160.429065) (xy 164.496674 160.447478) (xy 164.500269 160.464) (xy 164.500269 160.47317) (xy 164.5 160.474174) (xy 164.5 160.605826) (xy 164.500269 160.606829) (xy 164.500269 160.616) (xy 164.49262 160.642047) (xy 164.488433 160.668869) (xy 164.482922 160.675075) (xy 164.480584 160.683039) (xy 164.460069 160.700815) (xy 164.442044 160.721117) (xy 164.433962 160.723437) (xy 164.42778 160.728794) (xy 164.402782 160.732388) (xy 164.376269 160.74) (xy 163.867342 160.74) (xy 163.877295 160.802845) (xy 163.878317 160.809299) (xy 163.934249 160.981442) (xy 163.934251 160.981446) (xy 164.01643 161.142727) (xy 164.016434 161.142734) (xy 164.122823 161.289169) (xy 164.25083 161.417176) (xy 164.397265 161.523565) (xy 164.558552 161.605747) (xy 164.558555 161.605748) (xy 164.558591 161.605759) (xy 164.558627 161.605772) (xy 164.723819 161.659444) (xy 164.730706 161.661682) (xy 164.87467 161.684483) (xy 164.886951 161.690305) (xy 164.908388 161.694909) (xy 164.914675 161.69789) (xy 164.927976 161.709753) (xy 164.937803 161.714412) (xy 164.943553 161.723647) (xy 164.966815 161.744395) (xy 164.985537 161.81171) (xy 164.964894 161.87846) (xy 164.934002 161.904843) (xy 164.925233 161.915375) (xy 164.919591 161.917152) (xy 164.913068 161.922724) (xy 164.90768 161.925185) (xy 164.87556 161.934867) (xy 164.730585 161.957829) (xy 164.558366 162.013785) (xy 164.558362 162.013787) (xy 164.558349 162.013793) (xy 164.546519 162.019821) (xy 164.519176 162.029909) (xy 164.491422 162.036573) (xy 164.462471 162.04) (xy 162.703668 162.04) (xy 162.668733 162.034977) (xy 162.657879 162.03179) (xy 162.599101 161.994016) (xy 162.570076 161.93046) (xy 162.580018 161.861306) (xy 162.58149 161.858082) (xy 162.619349 161.810798) (xy 162.623327 161.807781) (xy 162.628873 161.803574) (xy 162.628886 161.803569) (xy 162.628884 161.803567) (xy 162.63567 161.79842) (xy 162.642922 161.792922) (xy 162.734361 161.672342) (xy 162.789877 161.531564) (xy 162.8005 161.443102) (xy 162.8005 160.556898) (xy 162.789877 160.468436) (xy 162.734361 160.327658) (xy 162.73436 160.327657) (xy 162.73436 160.327656) (xy 162.73063 160.322737) (xy 162.730318 160.32214) (xy 162.72924 160.320904) (xy 162.642922 160.207076) (xy 162.522345 160.11564) (xy 162.522343 160.115639) (xy 162.416959 160.074081) (xy 162.381559 160.060121) (xy 162.342152 160.055389) (xy 162.335926 160.054642) (xy 162.335925 160.054641) (xy 162.306527 160.051112) (xy 162.293102 160.0495) (xy 162.293098 160.0495) (xy 161.834084 160.0495) (xy 161.799149 160.044477) (xy 161.788295 160.04129) (xy 161.729517 160.003516) (xy 161.700492 159.93996) (xy 161.701476 159.933116) (xy 161.710432 159.870811) (xy 161.713622 159.863824) (xy 161.738729 159.827662) (xy 161.835777 159.730615) (xy 162.32048 159.245913) (xy 162.373207 159.154588) (xy 162.4005 159.052727) (xy 162.4005 158.947273) (xy 162.4005 158.034632) (xy 162.405522 157.9997) (xy 162.406614 157.995982) (xy 162.410772 157.981819) (xy 162.444426 157.926776) (xy 162.448081 157.92331) (xy 162.487913 157.897937) (xy 162.507613 157.890169) (xy 162.522342 157.884361) (xy 162.554071 157.860299) (xy 162.55842 157.858058) (xy 162.560191 157.855944) (xy 162.57519 157.849418) (xy 162.592041 157.840738) (xy 162.596184 157.839444) (xy 162.603903 157.837617) (xy 162.612486 157.834354) (xy 162.616073 157.833235) (xy 162.62298 157.833117) (xy 162.653028 157.8276) (xy 163.70767 157.8276)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts (xy 164.859962 154.075517) (xy 164.863837 154.076654) (xy 164.865823 154.077237) (xy 164.924607 154.115002) (xy 164.953641 154.178554) (xy 164.943708 154.247714) (xy 164.897961 154.300524) (xy 164.897945 154.300535) (xy 164.897584 154.300767) (xy 164.849944 154.318924) (xy 164.730585 154.337829) (xy 164.558386 154.393778) (xy 164.558363 154.393786) (xy 164.558359 154.393788) (xy 164.397005 154.476004) (xy 164.397002 154.476005) (xy 164.397002 154.476006) (xy 164.348169 154.511484) (xy 164.250499 154.582445) (xy 164.250491 154.582452) (xy 164.12245 154.710493) (xy 164.122446 154.710499) (xy 164.122445 154.7105) (xy 164.122441 154.710505) (xy 164.057783 154.7995) (xy 164.020568 154.850722) (xy 164.01435 154.858589) (xy 164.012408 154.860851) (xy 164.00551 154.868157) (xy 164.004794 154.869723) (xy 163.998492 154.877068) (xy 163.994513 154.879652) (xy 163.983583 154.891734) (xy 163.979914 154.894779) (xy 163.950999 154.912711) (xy 163.948174 154.913964) (xy 163.915633 154.923338) (xy 163.914339 154.923525) (xy 163.896604 154.9248) (xy 163.878228 154.9248) (xy 163.843292 154.919777) (xy 163.81805 154.912365) (xy 163.765304 154.881068) (xy 163.729021 154.844784) (xy 163.729017 154.844781) (xy 163.729009 154.844775) (xy 163.702447 154.82944) (xy 163.592107 154.765735) (xy 163.592083 154.765722) (xy 163.478439 154.735272) (xy 163.439357 154.7248) (xy 163.439356 154.7248) (xy 163.281243 154.7248) (xy 163.128518 154.765722) (xy 163.128511 154.765724) (xy 163.12851 154.765725) (xy 163.1285 154.76573) (xy 162.991598 154.84477) (xy 162.991594 154.844772) (xy 162.99159 154.844775) (xy 162.991582 154.844781) (xy 162.991578 154.844784) (xy 162.991576 154.844785) (xy 162.879785 154.956576) (xy 162.879784 154.956578) (xy 162.879781 154.956581) (xy 162.879781 154.956582) (xy 162.879775 154.95659) (xy 162.879772 154.956594) (xy 162.87977 154.956598) (xy 162.80073 155.0935) (xy 162.800722 155.093518) (xy 162.7598 155.246243) (xy 162.7598 155.404357) (xy 162.80002 155.554458) (xy 162.800723 155.557083) (xy 162.800726 155.55709) (xy 162.878725 155.69219) (xy 162.879508 155.693632) (xy 162.879517 155.693676) (xy 162.879698 155.693934) (xy 162.991583 155.805819) (xy 162.992276 155.806319) (xy 162.994787 155.80767) (xy 163.086529 155.860636) (xy 163.128516 155.884877) (xy 163.281243 155.9258) (xy 163.281245 155.9258) (xy 163.439355 155.9258) (xy 163.439357 155.9258) (xy 163.592084 155.884877) (xy 163.651541 155.85055) (xy 163.720272 155.810869) (xy 163.737538 155.802607) (xy 163.758367 155.794551) (xy 163.827994 155.788731) (xy 163.889709 155.821473) (xy 163.89425 155.825906) (xy 163.925561 155.876317) (xy 163.931546 155.894739) (xy 163.93378 155.901613) (xy 163.933789 155.901643) (xy 163.976564 155.98559) (xy 163.976564 155.985591) (xy 164.014786 156.060605) (xy 164.016 156.062988) (xy 164.016003 156.062992) (xy 164.016006 156.062997) (xy 164.120685 156.207077) (xy 164.122445 156.209499) (xy 164.122452 156.209507) (xy 164.250491 156.337546) (xy 164.250499 156.337553) (xy 164.2505 156.337554) (xy 164.250505 156.337558) (xy 164.282187 156.360576) (xy 164.282269 156.360635) (xy 164.282271 156.360637) (xy 164.29059 156.366681) (xy 164.397006 156.443996) (xy 164.502484 156.49774) (xy 164.55836 156.526211) (xy 164.558363 156.526212) (xy 164.644476 156.554191) (xy 164.730591 156.582171) (xy 164.772733 156.588845) (xy 164.803478 156.593715) (xy 164.803577 156.59373) (xy 164.803639 156.59374) (xy 164.873071 156.604738) (xy 164.906787 156.615163) (xy 164.913071 156.618142) (xy 164.926374 156.630007) (xy 164.936203 156.634667) (xy 164.941954 156.643903) (xy 164.965213 156.664649) (xy 164.983935 156.731964) (xy 164.963292 156.798714) (xy 164.911466 156.842978) (xy 164.906078 156.845439) (xy 164.873958 156.855121) (xy 164.730585 156.877829) (xy 164.558386 156.933778) (xy 164.558367 156.933785) (xy 164.558366 156.933785) (xy 164.397013 157.015999) (xy 164.395824 157.016727) (xy 164.384984 157.023661) (xy 164.382485 157.025058) (xy 164.377241 157.026253) (xy 164.366083 157.031785) (xy 164.366227 157.032186) (xy 164.365195 157.032555) (xy 164.365095 157.032275) (xy 164.359732 157.034935) (xy 164.348167 157.038631) (xy 164.343882 157.04016) (xy 164.274126 157.044142) (xy 164.261642 157.040538) (xy 164.235261 157.0314) (xy 164.235258 157.031399) (xy 164.235259 157.031399) (xy 164.232537 157.031204) (xy 164.209342 157.0273) (xy 164.206732 157.0266) (xy 164.206727 157.0266) (xy 164.172804 157.0266) (xy 164.170616 157.026581) (xy 164.16727 157.026521) (xy 164.163927 157.026282) (xy 164.163924 157.026282) (xy 164.130078 157.023852) (xy 164.127418 157.024365) (xy 164.114562 157.025591) (xy 164.114559 157.025591) (xy 164.111977 157.025837) (xy 164.109851 157.02604) (xy 164.098083 157.0266) (xy 162.94233 157.0266) (xy 162.907389 157.021575) (xy 162.89239 157.01717) (xy 162.877402 157.00754) (xy 162.860324 157.002532) (xy 162.833644 156.979427) (xy 162.832457 156.978058) (xy 162.804977 156.923183) (xy 162.803332 156.915621) (xy 162.8005 156.889268) (xy 162.8005 156.556903) (xy 162.8005 156.556901) (xy 162.8005 156.556898) (xy 162.789877 156.468436) (xy 162.734361 156.327658) (xy 162.73436 156.327657) (xy 162.73436 156.327656) (xy 162.73063 156.322737) (xy 162.730318 156.32214) (xy 162.72924 156.320904) (xy 162.642922 156.207076) (xy 162.522345 156.11564) (xy 162.522339 156.115637) (xy 162.426193 156.077721) (xy 162.426191 156.077721) (xy 162.382543 156.060508) (xy 162.380583 156.059716) (xy 162.380311 156.059603) (xy 162.374199 156.059238) (xy 162.334389 156.054458) (xy 162.293102 156.0495) (xy 162.293097 156.0495) (xy 161.706901 156.0495) (xy 161.706898 156.0495) (xy 161.69656 156.050741) (xy 161.667853 156.054187) (xy 161.667853 156.054188) (xy 161.665605 156.054458) (xy 161.618439 156.060121) (xy 161.477653 156.11564) (xy 161.357076 156.207076) (xy 161.26564 156.327653) (xy 161.265541 156.327904) (xy 161.210122 156.468438) (xy 161.204601 156.514416) (xy 161.200062 156.552224) (xy 161.1995 156.556901) (xy 161.1995 157.443103) (xy 161.20206 157.464423) (xy 161.204658 157.486051) (xy 161.205755 157.495192) (xy 161.209238 157.524197) (xy 161.209603 157.530313) (xy 161.209723 157.530601) (xy 161.210517 157.532564) (xy 161.22069 157.558362) (xy 161.265638 157.672341) (xy 161.26564 157.672345) (xy 161.357076 157.792922) (xy 161.477058 157.883907) (xy 161.477656 157.88436) (xy 161.477657 157.884361) (xy 161.480607 157.885524) (xy 161.504407 157.894909) (xy 161.53506 157.912396) (xy 161.547398 157.921996) (xy 161.588218 157.978695) (xy 161.592467 157.990768) (xy 161.5995 158.031934) (xy 161.5995 158.764914) (xy 161.594476 158.799851) (xy 161.587064 158.825092) (xy 161.555769 158.877836) (xy 160.429577 160.004027) (xy 160.418188 160.012553) (xy 160.401324 160.025178) (xy 160.380696 160.036442) (xy 160.327151 160.05147) (xy 160.324877 160.051578) (xy 160.313071 160.051152) (xy 160.312423 160.051294) (xy 160.311935 160.051112) (xy 160.304214 160.050834) (xy 160.29665 160.049926) (xy 160.296648 160.049925) (xy 160.293103 160.0495) (xy 160.293102 160.0495) (xy 159.706898 160.0495) (xy 159.69656 160.050741) (xy 159.667853 160.054187) (xy 159.667853 160.054188) (xy 159.66192 160.0549) (xy 159.618439 160.060121) (xy 159.477653 160.11564) (xy 159.357081 160.207073) (xy 159.357076 160.207077) (xy 159.272554 160.318538) (xy 159.260321 160.33239) (xy 159.243498 160.348795) (xy 159.181759 160.381506) (xy 159.112135 160.375645) (xy 159.112134 160.375645) (xy 159.104537 160.372702) (xy 159.061649 160.344756) (xy 158.478637 159.761744) (xy 158.47161 159.754103) (xy 158.451761 159.730616) (xy 158.45176 159.730615) (xy 158.446898 159.727236) (xy 158.435819 159.718563) (xy 158.432822 159.715929) (xy 158.425813 159.70892) (xy 158.42581 159.708918) (xy 158.425806 159.708915) (xy 158.422993 159.707291) (xy 158.422991 159.707289) (xy 158.399173 159.693538) (xy 158.398694 159.69326) (xy 158.398682 159.693253) (xy 158.390406 159.687975) (xy 158.365165 159.670433) (xy 158.365163 159.670432) (xy 158.35961 159.668433) (xy 158.339624 159.659157) (xy 158.339622 159.659156) (xy 158.334495 159.656197) (xy 158.334485 159.656191) (xy 158.304764 159.648227) (xy 158.294864 159.645124) (xy 158.265953 159.634717) (xy 158.265942 159.634714) (xy 158.260061 159.634221) (xy 158.259661 159.634187) (xy 158.248835 159.633242) (xy 158.238339 159.63043) (xy 158.238338 159.630429) (xy 158.232632 159.6289) (xy 158.232627 159.6289) (xy 158.201867 159.6289) (xy 158.196482 159.628674) (xy 158.196469 159.628673) (xy 158.194069 159.628573) (xy 158.188902 159.628247) (xy 153.443142 159.229851) (xy 153.408752 159.221924) (xy 153.382198 159.211645) (xy 153.33928 159.183688) (xy 152.262626 158.107033) (xy 152.262625 158.107032) (xy 152.262621 158.107028) (xy 152.241474 158.078777) (xy 152.228867 158.055688) (xy 152.2137 157.996263) (xy 152.2137 157.944945) (xy 152.2137 157.944943) (xy 152.172777 157.792216) (xy 152.131456 157.720645) (xy 152.093724 157.65529) (xy 152.093718 157.655282) (xy 151.981915 157.543479) (xy 151.981912 157.543477) (xy 151.975464 157.538529) (xy 151.975877 157.53799) (xy 151.957726 157.523715) (xy 151.948149 157.513672) (xy 151.916129 157.451571) (xy 151.916942 157.443053) (xy 153.2 157.443053) (xy 153.201023 157.451571) (xy 153.210612 157.531441) (xy 153.266078 157.672094) (xy 153.266079 157.672095) (xy 153.357435 157.792564) (xy 153.477903 157.883919) (xy 153.477904 157.88392) (xy 153.618556 157.939386) (xy 153.706946 157.95) (xy 153.8 157.95) (xy 154.2 157.95) (xy 154.293049 157.95) (xy 154.293054 157.95) (xy 154.381443 157.939386) (xy 154.522095 157.88392) (xy 154.642564 157.792564) (xy 154.73392 157.672095) (xy 154.789386 157.531443) (xy 154.8 157.443053) (xy 154.8 157.2) (xy 154.2 157.2) (xy 154.2 157.95) (xy 153.8 157.95) (xy 153.8 157.2) (xy 153.2 157.2) (xy 153.2 157.443053) (xy 151.916942 157.443053) (xy 151.922766 157.382019) (xy 151.925929 157.374118) (xy 151.953363 157.332527) (xy 153.032132 156.253758) (xy 153.034773 156.252316) (xy 153.06039 156.232606) (xy 153.068634 156.228105) (xy 153.08605 156.224317) (xy 153.093453 156.220275) (xy 153.11179 156.218718) (xy 153.136908 156.213256) (xy 153.202371 156.237677) (xy 153.244239 156.293613) (xy 153.250622 156.355738) (xy 153.24988 156.360576) (xy 153.249021 156.363755) (xy 153.249135 156.364915) (xy 153.24823 156.366681) (xy 153.242669 156.387265) (xy 153.210613 156.468556) (xy 153.207109 156.49774) (xy 153.2 156.556946) (xy 153.2 156.8) (xy 153.8 156.8) (xy 154.2 156.8) (xy 154.8 156.8) (xy 154.8 156.556949) (xy 154.799999 156.556943) (xy 154.799994 156.556901) (xy 155.1995 156.556901) (xy 155.1995 157.443103) (xy 155.20206 157.464423) (xy 155.204658 157.486051) (xy 155.205755 157.495192) (xy 155.209238 157.524197) (xy 155.209603 157.530313) (xy 155.209723 157.530601) (xy 155.210517 157.532564) (xy 155.22069 157.558362) (xy 155.265638 157.672341) (xy 155.26564 157.672345) (xy 155.357076 157.792922) (xy 155.466951 157.876242) (xy 155.477656 157.88436) (xy 155.477657 157.88436) (xy 155.477876 157.884526) (xy 155.480596 157.885519) (xy 155.618436 157.939877) (xy 155.706898 157.9505) (xy 155.837828 157.9505) (xy 155.868907 157.954968) (xy 155.87276 157.955521) (xy 155.886079 157.959432) (xy 155.944857 157.997206) (xy 155.973883 158.060761) (xy 155.975093 158.069176) (xy 155.97213 158.118918) (xy 155.945796 158.2172) (xy 155.9337 158.262343) (xy 155.9337 158.420457) (xy 155.970456 158.55763) (xy 155.974623 158.573183) (xy 155.974626 158.57319) (xy 156.053106 158.709124) (xy 156.053537 158.709947) (xy 156.053598 158.710034) (xy 156.165487 158.821923) (xy 156.166169 158.822414) (xy 156.168675 158.823763) (xy 156.252948 158.872417) (xy 156.295102 158.896755) (xy 156.295103 158.896755) (xy 156.302412 158.900975) (xy 156.302416 158.900977) (xy 156.455143 158.9419) (xy 156.455145 158.9419) (xy 156.613255 158.9419) (xy 156.613257 158.9419) (xy 156.765984 158.900977) (xy 156.902916 158.82192) (xy 157.01472 158.710116) (xy 157.093777 158.573184) (xy 157.1347 158.420457) (xy 157.1347 158.262343) (xy 157.093777 158.109616) (xy 157.059882 158.050908) (xy 157.052527 158.038168) (xy 157.052525 158.038166) (xy 157.049162 158.03234) (xy 157.014724 157.97269) (xy 157.014718 157.972682) (xy 156.976881 157.934845) (xy 156.971254 157.927159) (xy 156.969793 157.923111) (xy 156.962472 157.913331) (xy 156.961961 157.912396) (xy 156.954067 157.897937) (xy 156.949866 157.890243) (xy 156.9347 157.83082) (xy 156.9347 157.550959) (xy 156.93471 157.54941) (xy 156.935327 157.499978) (xy 156.934943 157.49675) (xy 156.934943 157.496748) (xy 156.93494 157.496723) (xy 156.934758 157.495192) (xy 156.9347 157.494975) (xy 156.9347 157.494973) (xy 156.921697 157.446446) (xy 156.920833 157.443053) (xy 159.2 157.443053) (xy 159.201023 157.451571) (xy 159.210612 157.531441) (xy 159.266078 157.672094) (xy 159.266079 157.672095) (xy 159.357435 157.792564) (xy 159.477903 157.883919) (xy 159.477904 157.88392) (xy 159.618556 157.939386) (xy 159.706946 157.95) (xy 159.8 157.95) (xy 160.2 157.95) (xy 160.293049 157.95) (xy 160.293054 157.95) (xy 160.381443 157.939386) (xy 160.522095 157.88392) (xy 160.642564 157.792564) (xy 160.73392 157.672095) (xy 160.789386 157.531443) (xy 160.8 157.443053) (xy 160.8 157.2) (xy 160.2 157.2) (xy 160.2 157.95) (xy 159.8 157.95) (xy 159.8 157.2) (xy 159.2 157.2) (xy 159.2 157.443053) (xy 156.920833 157.443053) (xy 156.909306 157.397781) (xy 156.908065 157.39557) (xy 156.907408 157.393115) (xy 156.907407 157.393113) (xy 156.882778 157.350455) (xy 156.882546 157.350049) (xy 156.882049 157.349176) (xy 156.881842 157.348811) (xy 156.857724 157.305806) (xy 156.855719 157.303125) (xy 156.85483 157.301937) (xy 156.854826 157.301933) (xy 156.854824 157.30193) (xy 156.849425 157.296531) (xy 156.849423 157.29653) (xy 156.828273 157.268275) (xy 156.815667 157.245188) (xy 156.8005 157.185763) (xy 156.8005 156.556946) (xy 159.2 156.556946) (xy 159.2 156.8) (xy 159.8 156.8) (xy 160.2 156.8) (xy 160.8 156.8) (xy 160.8 156.556946) (xy 160.789386 156.468556) (xy 160.73392 156.327904) (xy 160.642564 156.207435) (xy 160.522095 156.116079) (xy 160.522096 156.116079) (xy 160.381441 156.060612) (xy 160.327933 156.054188) (xy 160.293054 156.05) (xy 160.293049 156.05) (xy 160.2 156.05) (xy 160.2 156.8) (xy 159.8 156.8) (xy 159.8 156.05) (xy 159.706952 156.05) (xy 159.706946 156.05) (xy 159.669818 156.054458) (xy 159.618557 156.060612) (xy 159.477904 156.116078) (xy 159.477903 156.116079) (xy 159.357435 156.207435) (xy 159.266079 156.327903) (xy 159.266078 156.327904) (xy 159.210612 156.468557) (xy 159.205106 156.514417) (xy 159.2 156.556946) (xy 156.8005 156.556946) (xy 156.8005 156.556903) (xy 156.8005 156.556901) (xy 156.8005 156.556898) (xy 156.789877 156.468436) (xy 156.734361 156.327658) (xy 156.73436 156.327657) (xy 156.73436 156.327656) (xy 156.73063 156.322737) (xy 156.730318 156.32214) (xy 156.72924 156.320904) (xy 156.642922 156.207076) (xy 156.522345 156.11564) (xy 156.522339 156.115637) (xy 156.426193 156.077721) (xy 156.426191 156.077721) (xy 156.382543 156.060508) (xy 156.380583 156.059716) (xy 156.380311 156.059603) (xy 156.374199 156.059238) (xy 156.334389 156.054458) (xy 156.293102 156.0495) (xy 156.293097 156.0495) (xy 155.706901 156.0495) (xy 155.706898 156.0495) (xy 155.69656 156.050741) (xy 155.667853 156.054187) (xy 155.667853 156.054188) (xy 155.665605 156.054458) (xy 155.618439 156.060121) (xy 155.477653 156.11564) (xy 155.357076 156.207076) (xy 155.26564 156.327653) (xy 155.265541 156.327904) (xy 155.210122 156.468438) (xy 155.204601 156.514416) (xy 155.200062 156.552224) (xy 155.1995 156.556901) (xy 154.799994 156.556901) (xy 154.789386 156.468556) (xy 154.73392 156.327904) (xy 154.642564 156.207435) (xy 154.522095 156.116079) (xy 154.522096 156.116079) (xy 154.381441 156.060612) (xy 154.327933 156.054188) (xy 154.293054 156.05) (xy 154.293049 156.05) (xy 154.2 156.05) (xy 154.2 156.8) (xy 153.8 156.8) (xy 153.8 156.05) (xy 153.706952 156.05) (xy 153.706946 156.05) (xy 153.669821 156.054458) (xy 153.618556 156.060613) (xy 153.540907 156.091233) (xy 153.53792 156.091502) (xy 153.506575 156.099374) (xy 153.49722 156.100219) (xy 153.479726 156.096754) (xy 153.47132 156.097513) (xy 153.453905 156.09164) (xy 153.428682 156.086645) (xy 153.378362 156.038172) (xy 153.362237 155.970188) (xy 153.381129 155.910658) (xy 153.383741 155.90651) (xy 153.385806 155.903922) (xy 153.386167 155.902805) (xy 153.38771 155.901537) (xy 153.400989 155.884901) (xy 154.304801 154.981089) (xy 154.333048 154.959943) (xy 154.357976 154.946332) (xy 154.407354 154.931573) (xy 164.166852 154.138575) (xy 164.199932 154.139136) (xy 164.219198 154.134322) (xy 164.238989 154.132714) (xy 164.257408 154.126138) (xy 164.261562 154.124655) (xy 164.267304 154.122761) (xy 164.273156 154.12099) (xy 164.278966 154.119387) (xy 164.302241 154.113573) (xy 164.309762 154.109398) (xy 164.311638 154.108378) (xy 164.312726 154.107799) (xy 164.329321 154.100467) (xy 164.338304 154.097262) (xy 164.338306 154.09726) (xy 164.340631 154.096068) (xy 164.341043 154.095616) (xy 164.342907 154.094901) (xy 164.345537 154.093553) (xy 164.345682 154.093837) (xy 164.355166 154.090202) (xy 164.373488 154.081725) (xy 164.378079 154.080495) (xy 164.385979 154.079018) (xy 164.3962 154.07564) (xy 164.399631 154.074722) (xy 164.404718 154.074843) (xy 164.431716 154.070499) (xy 164.825045 154.070499)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts (xy 110.293106 146.705523) (xy 110.308104 146.709927) (xy 110.366855 146.747672) (xy 110.368042 146.749041) (xy 110.395518 146.803902) (xy 110.397163 146.81146) (xy 110.4 146.837831) (xy 110.4 148.10817) (xy 110.399999 148.108176) (xy 110.4 148.108179) (xy 110.394975 148.143114) (xy 110.39057 148.158112) (xy 110.352827 148.216855) (xy 110.352792 148.216885) (xy 110.352791 148.216887) (xy 110.352789 148.216887) (xy 110.351458 148.218042) (xy 110.296597 148.245518) (xy 110.289039 148.247163) (xy 110.262668 148.25) (xy 110.24183 148.25) (xy 110.241825 148.249999) (xy 110.241823 148.25) (xy 110.206889 148.244975) (xy 110.19189 148.24057) (xy 110.133144 148.202827) (xy 110.133115 148.202793) (xy 110.133114 148.202793) (xy 110.133113 148.202791) (xy 110.131957 148.201458) (xy 110.104477 148.146583) (xy 110.102832 148.139021) (xy 110.1 148.112668) (xy 110.1 146.842324) (xy 110.101869 146.820875) (xy 110.103506 146.811554) (xy 110.104905 146.808724) (xy 110.105022 146.807393) (xy 110.106305 146.803023) (xy 110.107276 146.803308) (xy 110.111379 146.787235) (xy 110.110687 146.786977) (xy 110.111748 146.784131) (xy 110.112391 146.783271) (xy 110.112849 146.781478) (xy 110.114087 146.778768) (xy 110.115334 146.779338) (xy 110.124277 146.767388) (xy 110.127157 146.757603) (xy 110.132476 146.752998) (xy 110.13449 146.74893) (xy 110.14102 146.745014) (xy 110.15002 146.732987) (xy 110.149123 146.731952) (xy 110.150179 146.731036) (xy 110.152158 146.73013) (xy 110.15361 146.728191) (xy 110.153647 146.728164) (xy 110.156086 146.726339) (xy 110.157198 146.727825) (xy 110.166454 146.723592) (xy 110.179988 146.71188) (xy 110.213593 146.702034) (xy 110.213716 146.701978) (xy 110.2153 146.70175) (xy 110.23287 146.7005) (xy 110.25817 146.7005)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts (xy 110.293106 144.755023) (xy 110.308104 144.759427) (xy 110.366855 144.797172) (xy 110.368042 144.798541) (xy 110.395518 144.853402) (xy 110.397163 144.86096) (xy 110.4 144.887331) (xy 110.4 145.65767) (xy 110.399999 145.657676) (xy 110.4 145.657679) (xy 110.394975 145.692614) (xy 110.39057 145.707612) (xy 110.352827 145.766355) (xy 110.352792 145.766385) (xy 110.352791 145.766387) (xy 110.352789 145.766387) (xy 110.351458 145.767542) (xy 110.296597 145.795018) (xy 110.289039 145.796663) (xy 110.262668 145.7995) (xy 110.24183 145.7995) (xy 110.241825 145.799499) (xy 110.241823 145.7995) (xy 110.206889 145.794475) (xy 110.19189 145.79007) (xy 110.133144 145.752327) (xy 110.133115 145.752293) (xy 110.133114 145.752293) (xy 110.133113 145.752291) (xy 110.131957 145.750958) (xy 110.104477 145.696083) (xy 110.102832 145.688521) (xy 110.1 145.662168) (xy 110.1 144.891824) (xy 110.101869 144.870375) (xy 110.103506 144.861054) (xy 110.104905 144.858224) (xy 110.105022 144.856893) (xy 110.106305 144.852523) (xy 110.107276 144.852808) (xy 110.111379 144.836735) (xy 110.110687 144.836477) (xy 110.111748 144.833631) (xy 110.112391 144.832771) (xy 110.112849 144.830978) (xy 110.114087 144.828268) (xy 110.115334 144.828838) (xy 110.127465 144.812627) (xy 110.13449 144.79843) (xy 110.14102 144.794514) (xy 110.15002 144.782487) (xy 110.149123 144.781452) (xy 110.150179 144.780536) (xy 110.152158 144.77963) (xy 110.15361 144.777691) (xy 110.153647 144.777664) (xy 110.156086 144.775839) (xy 110.157198 144.777325) (xy 110.213716 144.751478) (xy 110.2153 144.75125) (xy 110.23287 144.75) (xy 110.25817 144.75)
-			)
-		)
-	)
-	(zone
 		(net "GND")
 		(layer "B.Cu")
-		(uuid "a0d437fc-bfb3-4a0f-8943-7992d420954c")
+		(uuid "278a8536-0909-46ea-a80e-85b413580582")
 		(hatch edge 0.5)
 		(priority 1)
 		(connect_pads (clearance 0.3)
@@ -6429,7 +6237,7 @@
 		)
 		(filled_polygon
 			(layer "B.Cu")
-			(pts (xy 169.442539 100.520185) (xy 169.488294 100.572989) (xy 169.4995 100.6245) (xy 169.4995 189.3755) (xy 169.479815 189.442539) (xy 169.427011 189.488294) (xy 169.3755 189.4995) (xy 100.6245 189.4995) (xy 100.557461 189.479815) (xy 100.511706 189.427011) (xy 100.5005 189.3755) (xy 100.5005 186.878711) (xy 101.1495 186.878711) (xy 101.1495 187.121288) (xy 101.181161 187.361785) (xy 101.243947 187.596104) (xy 101.336773 187.820205) (xy 101.336776 187.820212) (xy 101.458064 188.030289) (xy 101.458066 188.030292) (xy 101.458067 188.030293) (xy 101.605733 188.222736) (xy 101.605739 188.222743) (xy 101.777256 188.39426) (xy 101.777262 188.394265) (xy 101.969711 188.541936) (xy 102.179788 188.663224) (xy 102.4039 188.756054) (xy 102.638211 188.818838) (xy 102.818586 188.842584) (xy 102.878711 188.8505) (xy 102.878712 188.8505) (xy 103.121289 188.8505) (xy 103.169388 188.844167) (xy 103.361789 188.818838) (xy 103.5961 188.756054) (xy 103.820212 188.663224) (xy 104.030289 188.541936) (xy 104.222738 188.394265) (xy 104.394265 188.222738) (xy 104.541936 188.030289) (xy 104.663224 187.820212) (xy 104.756054 187.5961) (xy 104.818838 187.361789) (xy 104.8505 187.121288) (xy 104.8505 186.878712) (xy 104.8505 186.878711) (xy 165.1495 186.878711) (xy 165.1495 187.121288) (xy 165.181161 187.361785) (xy 165.243947 187.596104) (xy 165.336773 187.820205) (xy 165.336776 187.820212) (xy 165.458064 188.030289) (xy 165.458066 188.030292) (xy 165.458067 188.030293) (xy 165.605733 188.222736) (xy 165.605739 188.222743) (xy 165.777256 188.39426) (xy 165.777262 188.394265) (xy 165.969711 188.541936) (xy 166.179788 188.663224) (xy 166.4039 188.756054) (xy 166.638211 188.818838) (xy 166.818586 188.842584) (xy 166.878711 188.8505) (xy 166.878712 188.8505) (xy 167.121289 188.8505) (xy 167.169388 188.844167) (xy 167.361789 188.818838) (xy 167.5961 188.756054) (xy 167.820212 188.663224) (xy 168.030289 188.541936) (xy 168.222738 188.394265) (xy 168.394265 188.222738) (xy 168.541936 188.030289) (xy 168.663224 187.820212) (xy 168.756054 187.5961) (xy 168.818838 187.361789) (xy 168.8505 187.121288) (xy 168.8505 186.878712) (xy 168.818838 186.638211) (xy 168.756054 186.4039) (xy 168.663224 186.179788) (xy 168.541936 185.969711) (xy 168.394265 185.777262) (xy 168.39426 185.777256) (xy 168.222743 185.605739) (xy 168.222736 185.605733) (xy 168.030293 185.458067) (xy 168.030292 185.458066) (xy 168.030289 185.458064) (xy 167.820212 185.336776) (xy 167.820205 185.336773) (xy 167.596104 185.243947) (xy 167.361785 185.181161) (xy 167.121289 185.1495) (xy 167.121288 185.1495) (xy 166.878712 185.1495) (xy 166.878711 185.1495) (xy 166.638214 185.181161) (xy 166.403895 185.243947) (xy 166.179794 185.336773) (xy 166.179785 185.336777) (xy 165.969706 185.458067) (xy 165.777263 185.605733) (xy 165.777256 185.605739) (xy 165.605739 185.777256) (xy 165.605733 185.777263) (xy 165.458067 185.969706) (xy 165.336777 186.179785) (xy 165.336773 186.179794) (xy 165.243947 186.403895) (xy 165.181161 186.638214) (xy 165.1495 186.878711) (xy 104.8505 186.878711) (xy 104.818838 186.638211) (xy 104.756054 186.4039) (xy 104.663224 186.179788) (xy 104.541936 185.969711) (xy 104.394265 185.777262) (xy 104.39426 185.777256) (xy 104.222743 185.605739) (xy 104.222736 185.605733) (xy 104.030293 185.458067) (xy 104.030292 185.458066) (xy 104.030289 185.458064) (xy 103.820212 185.336776) (xy 103.820205 185.336773) (xy 103.596104 185.243947) (xy 103.361785 185.181161) (xy 103.121289 185.1495) (xy 103.121288 185.1495) (xy 102.878712 185.1495) (xy 102.878711 185.1495) (xy 102.638214 185.181161) (xy 102.403895 185.243947) (xy 102.179794 185.336773) (xy 102.179785 185.336777) (xy 101.969706 185.458067) (xy 101.777263 185.605733) (xy 101.777256 185.605739) (xy 101.605739 185.777256) (xy 101.605733 185.777263) (xy 101.458067 185.969706) (xy 101.336777 186.179785) (xy 101.336773 186.179794) (xy 101.243947 186.403895) (xy 101.181161 186.638214) (xy 101.1495 186.878711) (xy 100.5005 186.878711) (xy 100.5005 175.055131) (xy 104.2595 175.055131) (xy 104.2595 176.944856) (xy 104.259502 176.944882) (xy 104.262413 176.969987) (xy 104.262415 176.969991) (xy 104.307793 177.072764) (xy 104.307794 177.072765) (xy 104.387235 177.152206) (xy 104.490009 177.197585) (xy 104.515135 177.2005) (xy 106.404864 177.200499) (xy 106.404879 177.200497) (xy 106.404882 177.200497) (xy 106.429987 177.197586) (xy 106.429988 177.197585) (xy 106.429991 177.197585) (xy 106.532765 177.152206) (xy 106.612206 177.072765) (xy 106.657585 176.969991) (xy 106.6605 176.944865) (xy 106.660499 176.531906) (xy 106.680183 176.46487) (xy 106.732987 176.419115) (xy 106.802146 176.409171) (xy 106.865702 176.438196) (xy 106.894984 176.475614) (xy 106.923668 176.531909) (xy 106.97324 176.629199) (xy 107.08431 176.782073) (xy 107.217927 176.91569) (xy 107.370801 177.02676) (xy 107.448228 177.066211) (xy 107.539163 177.112545) (xy 107.539165 177.112545) (xy 107.539168 177.112547) (xy 107.635497 177.143846) (xy 107.718881 177.17094) (xy 107.905514 177.2005) (xy 107.905519 177.2005) (xy 108.094486 177.2005) (xy 108.281118 177.17094) (xy 108.460832 177.112547) (xy 108.629199 177.02676) (xy 108.782073 176.91569) (xy 108.91569 176.782073) (xy 109.02676 176.629199) (xy 109.112547 176.460832) (xy 109.152069 176.339195) (xy 109.191507 176.281521) (xy 109.255866 176.254323) (xy 109.324712 176.266238) (xy 109.376188 176.313482) (xy 109.387931 176.339196) (xy 109.427454 176.460836) (xy 109.463668 176.531909) (xy 109.51324 176.629199) (xy 109.62431 176.782073) (xy 109.757927 176.91569) (xy 109.910801 177.02676) (xy 109.988228 177.066211) (xy 110.079163 177.112545) (xy 110.079165 177.112545) (xy 110.079168 177.112547) (xy 110.175497 177.143846) (xy 110.258881 177.17094) (xy 110.445514 177.2005) (xy 110.445519 177.2005) (xy 110.634486 177.2005) (xy 110.821118 177.17094) (xy 111.000832 177.112547) (xy 111.169199 177.02676) (xy 111.322073 176.91569) (xy 111.45569 176.782073) (xy 111.56676 176.629199) (xy 111.652547 176.460832) (xy 111.71094 176.281118) (xy 111.712794 176.26941) (xy 111.7405 176.094486) (xy 111.7405 175.905513) (xy 111.71094 175.718881) (xy 111.669706 175.591977) (xy 111.652547 175.539168) (xy 111.652545 175.539165) (xy 111.652545 175.539163) (xy 111.595301 175.426816) (xy 111.56676 175.370801) (xy 111.45569 175.217927) (xy 111.322073 175.08431) (xy 111.169199 174.97324) (xy 111.000836 174.887454) (xy 110.821118 174.829059) (xy 110.634486 174.7995) (xy 110.634481 174.7995) (xy 110.445519 174.7995) (xy 110.445514 174.7995) (xy 110.258881 174.829059) (xy 110.079163 174.887454) (xy 109.9108 174.97324) (xy 109.832661 175.030012) (xy 109.757927 175.08431) (xy 109.757925 175.084312) (xy 109.757924 175.084312) (xy 109.624312 175.217924) (xy 109.624312 175.217925) (xy 109.62431 175.217927) (xy 109.596929 175.255614) (xy 109.51324 175.3708) (xy 109.427454 175.539163) (xy 109.387931 175.660803) (xy 109.348493 175.718478) (xy 109.284134 175.745676) (xy 109.215288 175.733761) (xy 109.163812 175.686516) (xy 109.152069 175.660803) (xy 109.124249 175.575182) (xy 109.112547 175.539168) (xy 109.112545 175.539165) (xy 109.112545 175.539163) (xy 109.055301 175.426816) (xy 109.02676 175.370801) (xy 108.91569 175.217927) (xy 108.782073 175.08431) (xy 108.629199 174.97324) (xy 108.460836 174.887454) (xy 108.281118 174.829059) (xy 108.094486 174.7995) (xy 108.094481 174.7995) (xy 107.905519 174.7995) (xy 107.905514 174.7995) (xy 107.718881 174.829059) (xy 107.539163 174.887454) (xy 107.3708 174.97324) (xy 107.292661 175.030012) (xy 107.217927 175.08431) (xy 107.217925 175.084312) (xy 107.217924 175.084312) (xy 107.084312 175.217924) (xy 107.084312 175.217925) (xy 107.08431 175.217927) (xy 107.056929 175.255614) (xy 106.97324 175.3708) (xy 106.894984 175.524386) (xy 106.847009 175.575182) (xy 106.779188 175.591977) (xy 106.713053 175.569439) (xy 106.669602 175.514724) (xy 106.660499 175.468091) (xy 106.660499 175.055143) (xy 106.660499 175.055136) (xy 106.658605 175.038802) (xy 106.657586 175.030012) (xy 106.657585 175.03001) (xy 106.657585 175.030009) (xy 106.612206 174.927235) (xy 106.532765 174.847794) (xy 106.530231 174.846675) (xy 106.429992 174.802415) (xy 106.404865 174.7995) (xy 104.515143 174.7995) (xy 104.515117 174.799502) (xy 104.490012 174.802413) (xy 104.490008 174.802415) (xy 104.387235 174.847793) (xy 104.307794 174.927234) (xy 104.262415 175.030006) (xy 104.262415 175.030008) (xy 104.2595 175.055131) (xy 100.5005 175.055131) (xy 100.5005 167.055131) (xy 104.2595 167.055131) (xy 104.2595 168.944856) (xy 104.259502 168.944882) (xy 104.262413 168.969987) (xy 104.262415 168.969991) (xy 104.307793 169.072764) (xy 104.307794 169.072765) (xy 104.387235 169.152206) (xy 104.490009 169.197585) (xy 104.515135 169.2005) (xy 106.404864 169.200499) (xy 106.404879 169.200497) (xy 106.404882 169.200497) (xy 106.429987 169.197586) (xy 106.429988 169.197585) (xy 106.429991 169.197585) (xy 106.532765 169.152206) (xy 106.612206 169.072765) (xy 106.657585 168.969991) (xy 106.6605 168.944865) (xy 106.660499 168.531906) (xy 106.680183 168.46487) (xy 106.732987 168.419115) (xy 106.802146 168.409171) (xy 106.865702 168.438196) (xy 106.894984 168.475614) (xy 106.923668 168.531909) (xy 106.97324 168.629199) (xy 107.08431 168.782073) (xy 107.217927 168.91569) (xy 107.370801 169.02676) (xy 107.438478 169.061243) (xy 107.539163 169.112545) (xy 107.539165 169.112545) (xy 107.539168 169.112547) (xy 107.635497 169.143846) (xy 107.718881 169.17094) (xy 107.905514 169.2005) (xy 107.905519 169.2005) (xy 108.094486 169.2005) (xy 108.281118 169.17094) (xy 108.335466 169.153281) (xy 108.460832 169.112547) (xy 108.629199 169.02676) (xy 108.782073 168.91569) (xy 108.91569 168.782073) (xy 109.02676 168.629199) (xy 109.112547 168.460832) (xy 109.152069 168.339195) (xy 109.191507 168.281521) (xy 109.255866 168.254323) (xy 109.324712 168.266238) (xy 109.376188 168.313482) (xy 109.387931 168.339196) (xy 109.427454 168.460836) (xy 109.463668 168.531909) (xy 109.51324 168.629199) (xy 109.62431 168.782073) (xy 109.757927 168.91569) (xy 109.910801 169.02676) (xy 109.978478 169.061243) (xy 110.079163 169.112545) (xy 110.079165 169.112545) (xy 110.079168 169.112547) (xy 110.175497 169.143846) (xy 110.258881 169.17094) (xy 110.445514 169.2005) (xy 110.445519 169.2005) (xy 110.634486 169.2005) (xy 110.821118 169.17094) (xy 110.875466 169.153281) (xy 111.000832 169.112547) (xy 111.169199 169.02676) (xy 111.322073 168.91569) (xy 111.45569 168.782073) (xy 111.56676 168.629199) (xy 111.652547 168.460832) (xy 111.71094 168.281118) (xy 111.715184 168.254323) (xy 111.7405 168.094486) (xy 111.7405 167.905513) (xy 111.71094 167.718881) (xy 111.669706 167.591977) (xy 111.652547 167.539168) (xy 111.652545 167.539165) (xy 111.652545 167.539163) (xy 111.566759 167.3708) (xy 111.45569 167.217927) (xy 111.322073 167.08431) (xy 111.169199 166.97324) (xy 111.150813 166.963872) (xy 111.000836 166.887454) (xy 110.821118 166.829059) (xy 110.634486 166.7995) (xy 110.634481 166.7995) (xy 110.445519 166.7995) (xy 110.445514 166.7995) (xy 110.258881 166.829059) (xy 110.079163 166.887454) (xy 109.9108 166.97324) (xy 109.832661 167.030012) (xy 109.757927 167.08431) (xy 109.757925 167.084312) (xy 109.757924 167.084312) (xy 109.624312 167.217924) (xy 109.624312 167.217925) (xy 109.62431 167.217927) (xy 109.57661 167.283579) (xy 109.51324 167.3708) (xy 109.427454 167.539163) (xy 109.387931 167.660803) (xy 109.348493 167.718478) (xy 109.284134 167.745676) (xy 109.215288 167.733761) (xy 109.163812 167.686516) (xy 109.152069 167.660803) (xy 109.124249 167.575182) (xy 109.112547 167.539168) (xy 109.112545 167.539165) (xy 109.112545 167.539163) (xy 109.026759 167.3708) (xy 108.91569 167.217927) (xy 108.782073 167.08431) (xy 108.629199 166.97324) (xy 108.610813 166.963872) (xy 108.460836 166.887454) (xy 108.281118 166.829059) (xy 108.094486 166.7995) (xy 108.094481 166.7995) (xy 107.905519 166.7995) (xy 107.905514 166.7995) (xy 107.718881 166.829059) (xy 107.539163 166.887454) (xy 107.3708 166.97324) (xy 107.292661 167.030012) (xy 107.217927 167.08431) (xy 107.217925 167.084312) (xy 107.217924 167.084312) (xy 107.084312 167.217924) (xy 107.084312 167.217925) (xy 107.08431 167.217927) (xy 107.03661 167.283579) (xy 106.97324 167.3708) (xy 106.894984 167.524386) (xy 106.847009 167.575182) (xy 106.779188 167.591977) (xy 106.713053 167.569439) (xy 106.669602 167.514724) (xy 106.660499 167.468091) (xy 106.660499 167.055143) (xy 106.660499 167.055136) (xy 106.660497 167.055117) (xy 106.657586 167.030012) (xy 106.657585 167.03001) (xy 106.657585 167.030009) (xy 106.612206 166.927235) (xy 106.532765 166.847794) (xy 106.532763 166.847793) (xy 106.429992 166.802415) (xy 106.404865 166.7995) (xy 104.515143 166.7995) (xy 104.515117 166.799502) (xy 104.490012 166.802413) (xy 104.490008 166.802415) (xy 104.387235 166.847793) (xy 104.307794 166.927234) (xy 104.262415 167.030006) (xy 104.262415 167.030008) (xy 104.2595 167.055131) (xy 100.5005 167.055131) (xy 100.5005 161.596043) (xy 106.4053 161.596043) (xy 106.4053 161.754157) (xy 106.44575 161.905116) (xy 106.446223 161.906883) (xy 106.446226 161.90689) (xy 106.525275 162.043809) (xy 106.525279 162.043814) (xy 106.52528 162.043816) (xy 106.637084 162.15562) (xy 106.637086 162.155621) (xy 106.63709 162.155624) (xy 106.756186 162.224383) (xy 106.774016 162.234677) (xy 106.926743 162.2756) (xy 106.926745 162.2756) (xy 107.084855 162.2756) (xy 107.084857 162.2756) (xy 107.237584 162.234677) (xy 107.374516 162.15562) (xy 107.48632 162.043816) (xy 107.565377 161.906884) (xy 107.6063 161.754157) (xy 107.6063 161.596043) (xy 107.605388 161.592639) (xy 107.605458 161.589656) (xy 107.605239 161.587986) (xy 107.605499 161.587951) (xy 107.607049 161.52279) (xy 107.623456 161.489609) (xy 107.623765 161.489166) (xy 111.602868 155.783943) (xy 111.616882 155.767209) (xy 112.072263 155.311828) (xy 112.099758 155.28858) (xy 112.109414 155.274677) (xy 112.12138 155.262712) (xy 112.136797 155.236007) (xy 112.142326 155.227293) (xy 114.41733 151.951939) (xy 114.515598 151.810461) (xy 114.570009 151.76663) (xy 114.617441 151.7572) (xy 115.223621 151.7572) (xy 115.239202 151.760094) (xy 115.276157 151.7572) (xy 115.313227 151.7572) (xy 115.317499 151.756055) (xy 115.33991 151.752207) (xy 118.88643 151.474477) (xy 118.896111 151.4741) (xy 119.0221 151.4741) (xy 119.089139 151.493785) (xy 119.134894 151.546589) (xy 119.1461 151.5981) (xy 119.1461 174.6027) (xy 119.126415 174.669739) (xy 119.073611 174.715494) (xy 119.0221 174.7267) (xy 118.991343 174.7267) (xy 118.838616 174.767623) (xy 118.838609 174.767626) (xy 118.70169 174.846675) (xy 118.701682 174.846681) (xy 118.589881 174.958482) (xy 118.589875 174.95849) (xy 118.510826 175.095409) (xy 118.510823 175.095416) (xy 118.4699 175.248143) (xy 118.4699 175.406256) (xy 118.475409 175.426816) (xy 118.473746 175.496666) (xy 118.443315 175.54659) (xy 111.838526 182.151381) (xy 111.777203 182.184866) (xy 111.750845 182.1877) (xy 111.689043 182.1877) (xy 111.536316 182.228623) (xy 111.536309 182.228626) (xy 111.39939 182.307675) (xy 111.399382 182.307681) (xy 111.287581 182.419482) (xy 111.287575 182.41949) (xy 111.208526 182.556409) (xy 111.208523 182.556416) (xy 111.1676 182.709143) (xy 111.1676 182.867256) (xy 111.208523 183.019983) (xy 111.208526 183.01999) (xy 111.287575 183.156909) (xy 111.287579 183.156914) (xy 111.28758 183.156916) (xy 111.399384 183.26872) (xy 111.399386 183.268721) (xy 111.39939 183.268724) (xy 111.536309 183.347773) (xy 111.536316 183.347777) (xy 111.689043 183.3887) (xy 111.689045 183.3887) (xy 111.847155 183.3887) (xy 111.847157 183.3887) (xy 111.999884 183.347777) (xy 112.136816 183.26872) (xy 112.24862 183.156916) (xy 112.327677 183.019984) (xy 112.3686 182.867257) (xy 112.3686 182.805454) (xy 112.388285 182.738415) (xy 112.404914 182.717778) (xy 119.188166 175.934525) (xy 119.243753 175.902433) (xy 119.302182 175.886778) (xy 119.302186 175.886776) (xy 119.439109 175.807724) (xy 119.439108 175.807724) (xy 119.439116 175.80772) (xy 119.55092 175.695916) (xy 119.629977 175.558984) (xy 119.629978 175.558981) (xy 119.645633 175.500554) (xy 119.677725 175.444966) (xy 119.86708 175.255613) (xy 119.919807 175.164288) (xy 119.9471 175.062427) (xy 119.9471 175.062418) (xy 119.948161 175.054367) (xy 119.951062 175.054748) (xy 119.955744 175.038802) (xy 119.962267 175.008817) (xy 119.966022 175.0038) (xy 119.966785 175.001203) (xy 119.983418 174.980562) (xy 119.99074 174.97324) (xy 120.055412 174.908566) (xy 120.116732 174.875082) (xy 120.186424 174.880066) (xy 120.242358 174.921936) (xy 120.266776 174.9874) (xy 120.262745 175.028793) (xy 120.262415 175.030003) (xy 120.2595 175.055131) (xy 120.2595 176.944856) (xy 120.259502 176.944882) (xy 120.262413 176.969987) (xy 120.262415 176.969991) (xy 120.307793 177.072764) (xy 120.307794 177.072765) (xy 120.387235 177.152206) (xy 120.490009 177.197585) (xy 120.515135 177.2005) (xy 122.404864 177.200499) (xy 122.404879 177.200497) (xy 122.404882 177.200497) (xy 122.429987 177.197586) (xy 122.429988 177.197585) (xy 122.429991 177.197585) (xy 122.532765 177.152206) (xy 122.612206 177.072765) (xy 122.657585 176.969991) (xy 122.6605 176.944865) (xy 122.660499 176.531906) (xy 122.680183 176.46487) (xy 122.732987 176.419115) (xy 122.802146 176.409171) (xy 122.865702 176.438196) (xy 122.894984 176.475614) (xy 122.923668 176.531909) (xy 122.97324 176.629199) (xy 123.08431 176.782073) (xy 123.217927 176.91569) (xy 123.370801 177.02676) (xy 123.448228 177.066211) (xy 123.539163 177.112545) (xy 123.539165 177.112545) (xy 123.539168 177.112547) (xy 123.635497 177.143846) (xy 123.718881 177.17094) (xy 123.905514 177.2005) (xy 123.905519 177.2005) (xy 124.094486 177.2005) (xy 124.281118 177.17094) (xy 124.460832 177.112547) (xy 124.629199 177.02676) (xy 124.782073 176.91569) (xy 124.91569 176.782073) (xy 125.02676 176.629199) (xy 125.112547 176.460832) (xy 125.152069 176.339195) (xy 125.191507 176.281521) (xy 125.255866 176.254323) (xy 125.324712 176.266238) (xy 125.376188 176.313482) (xy 125.387931 176.339196) (xy 125.427454 176.460836) (xy 125.463668 176.531909) (xy 125.51324 176.629199) (xy 125.62431 176.782073) (xy 125.757927 176.91569) (xy 125.910801 177.02676) (xy 125.988228 177.066211) (xy 126.079163 177.112545) (xy 126.079165 177.112545) (xy 126.079168 177.112547) (xy 126.175497 177.143846) (xy 126.258881 177.17094) (xy 126.445514 177.2005) (xy 126.445519 177.2005) (xy 126.634486 177.2005) (xy 126.821118 177.17094) (xy 127.000832 177.112547) (xy 127.169199 177.02676) (xy 127.322073 176.91569) (xy 127.45569 176.782073) (xy 127.56676 176.629199) (xy 127.652547 176.460832) (xy 127.71094 176.281118) (xy 127.712794 176.26941) (xy 127.7405 176.094486) (xy 127.7405 175.905513) (xy 127.71094 175.718881) (xy 127.669706 175.591977) (xy 127.652547 175.539168) (xy 127.652545 175.539165) (xy 127.652545 175.539163) (xy 127.595301 175.426816) (xy 127.56676 175.370801) (xy 127.45569 175.217927) (xy 127.322073 175.08431) (xy 127.281912 175.055131) (xy 136.2595 175.055131) (xy 136.2595 176.944856) (xy 136.259502 176.944882) (xy 136.262413 176.969987) (xy 136.262415 176.969991) (xy 136.307793 177.072764) (xy 136.307794 177.072765) (xy 136.387235 177.152206) (xy 136.490009 177.197585) (xy 136.515135 177.2005) (xy 138.404864 177.200499) (xy 138.404879 177.200497) (xy 138.404882 177.200497) (xy 138.429987 177.197586) (xy 138.429988 177.197585) (xy 138.429991 177.197585) (xy 138.532765 177.152206) (xy 138.612206 177.072765) (xy 138.657585 176.969991) (xy 138.6605 176.944865) (xy 138.660499 176.531906) (xy 138.680183 176.46487) (xy 138.732987 176.419115) (xy 138.802146 176.409171) (xy 138.865702 176.438196) (xy 138.894984 176.475614) (xy 138.923668 176.531909) (xy 138.97324 176.629199) (xy 139.08431 176.782073) (xy 139.217927 176.91569) (xy 139.370801 177.02676) (xy 139.448228 177.066211) (xy 139.539163 177.112545) (xy 139.539165 177.112545) (xy 139.539168 177.112547) (xy 139.635497 177.143846) (xy 139.718881 177.17094) (xy 139.905514 177.2005) (xy 139.905519 177.2005) (xy 140.094486 177.2005) (xy 140.281118 177.17094) (xy 140.460832 177.112547) (xy 140.629199 177.02676) (xy 140.782073 176.91569) (xy 140.91569 176.782073) (xy 141.02676 176.629199) (xy 141.112547 176.460832) (xy 141.152069 176.339195) (xy 141.191507 176.281521) (xy 141.255866 176.254323) (xy 141.324712 176.266238) (xy 141.376188 176.313482) (xy 141.387931 176.339196) (xy 141.427454 176.460836) (xy 141.463668 176.531909) (xy 141.51324 176.629199) (xy 141.62431 176.782073) (xy 141.757927 176.91569) (xy 141.910801 177.02676) (xy 141.988228 177.066211) (xy 142.079163 177.112545) (xy 142.079165 177.112545) (xy 142.079168 177.112547) (xy 142.175497 177.143846) (xy 142.258881 177.17094) (xy 142.445514 177.2005) (xy 142.445519 177.2005) (xy 142.634486 177.2005) (xy 142.821118 177.17094) (xy 143.000832 177.112547) (xy 143.169199 177.02676) (xy 143.322073 176.91569) (xy 143.45569 176.782073) (xy 143.56676 176.629199) (xy 143.652547 176.460832) (xy 143.71094 176.281118) (xy 143.712794 176.26941) (xy 143.7405 176.094486) (xy 143.7405 175.905513) (xy 143.71094 175.718881) (xy 143.669706 175.591977) (xy 143.652547 175.539168) (xy 143.652545 175.539165) (xy 143.652545 175.539163) (xy 143.595301 175.426816) (xy 143.56676 175.370801) (xy 143.45569 175.217927) (xy 143.322073 175.08431) (xy 143.169199 174.97324) (xy 143.000836 174.887454) (xy 142.821118 174.829059) (xy 142.634486 174.7995) (xy 142.634481 174.7995) (xy 142.445519 174.7995) (xy 142.445514 174.7995) (xy 142.258881 174.829059) (xy 142.079163 174.887454) (xy 141.9108 174.97324) (xy 141.832661 175.030012) (xy 141.757927 175.08431) (xy 141.757925 175.084312) (xy 141.757924 175.084312) (xy 141.624312 175.217924) (xy 141.624312 175.217925) (xy 141.62431 175.217927) (xy 141.596929 175.255614) (xy 141.51324 175.3708) (xy 141.427454 175.539163) (xy 141.387931 175.660803) (xy 141.348493 175.718478) (xy 141.284134 175.745676) (xy 141.215288 175.733761) (xy 141.163812 175.686516) (xy 141.152069 175.660803) (xy 141.124249 175.575182) (xy 141.112547 175.539168) (xy 141.112545 175.539165) (xy 141.112545 175.539163) (xy 141.055301 175.426816) (xy 141.02676 175.370801) (xy 140.91569 175.217927) (xy 140.782073 175.08431) (xy 140.629199 174.97324) (xy 140.460836 174.887454) (xy 140.281118 174.829059) (xy 140.094486 174.7995) (xy 140.094481 174.7995) (xy 139.905519 174.7995) (xy 139.905514 174.7995) (xy 139.718881 174.829059) (xy 139.539163 174.887454) (xy 139.3708 174.97324) (xy 139.292661 175.030012) (xy 139.217927 175.08431) (xy 139.217925 175.084312) (xy 139.217924 175.084312) (xy 139.084312 175.217924) (xy 139.084312 175.217925) (xy 139.08431 175.217927) (xy 139.056929 175.255614) (xy 138.97324 175.3708) (xy 138.894984 175.524386) (xy 138.847009 175.575182) (xy 138.779188 175.591977) (xy 138.713053 175.569439) (xy 138.669602 175.514724) (xy 138.660499 175.468091) (xy 138.660499 175.055143) (xy 138.660499 175.055136) (xy 138.658605 175.038802) (xy 138.657586 175.030012) (xy 138.657585 175.03001) (xy 138.657585 175.030009) (xy 138.612206 174.927235) (xy 138.532765 174.847794) (xy 138.530231 174.846675) (xy 138.429992 174.802415) (xy 138.404865 174.7995) (xy 136.515143 174.7995) (xy 136.515117 174.799502) (xy 136.490012 174.802413) (xy 136.490008 174.802415) (xy 136.387235 174.847793) (xy 136.307794 174.927234) (xy 136.262415 175.030006) (xy 136.262415 175.030008) (xy 136.2595 175.055131) (xy 127.281912 175.055131) (xy 127.169199 174.97324) (xy 127.000836 174.887454) (xy 126.821118 174.829059) (xy 126.634486 174.7995) (xy 126.634481 174.7995) (xy 126.445519 174.7995) (xy 126.445514 174.7995) (xy 126.258881 174.829059) (xy 126.079163 174.887454) (xy 125.9108 174.97324) (xy 125.832661 175.030012) (xy 125.757927 175.08431) (xy 125.757925 175.084312) (xy 125.757924 175.084312) (xy 125.624312 175.217924) (xy 125.624312 175.217925) (xy 125.62431 175.217927) (xy 125.596929 175.255614) (xy 125.51324 175.3708) (xy 125.427454 175.539163) (xy 125.387931 175.660803) (xy 125.348493 175.718478) (xy 125.284134 175.745676) (xy 125.215288 175.733761) (xy 125.163812 175.686516) (xy 125.152069 175.660803) (xy 125.124249 175.575182) (xy 125.112547 175.539168) (xy 125.112545 175.539165) (xy 125.112545 175.539163) (xy 125.055301 175.426816) (xy 125.02676 175.370801) (xy 124.91569 175.217927) (xy 124.782073 175.08431) (xy 124.629199 174.97324) (xy 124.460836 174.887454) (xy 124.281118 174.829059) (xy 124.094486 174.7995) (xy 124.094481 174.7995) (xy 123.905519 174.7995) (xy 123.905514 174.7995) (xy 123.718881 174.829059) (xy 123.539163 174.887454) (xy 123.3708 174.97324) (xy 123.292661 175.030012) (xy 123.217927 175.08431) (xy 123.217925 175.084312) (xy 123.217924 175.084312) (xy 123.084312 175.217924) (xy 123.084312 175.217925) (xy 123.08431 175.217927) (xy 123.056929 175.255614) (xy 122.97324 175.3708) (xy 122.894984 175.524386) (xy 122.847009 175.575182) (xy 122.779188 175.591977) (xy 122.713053 175.569439) (xy 122.669602 175.514724) (xy 122.660499 175.468091) (xy 122.660499 175.055143) (xy 122.660499 175.055136) (xy 122.658605 175.038802) (xy 122.657586 175.030012) (xy 122.657585 175.03001) (xy 122.657585 175.030009) (xy 122.612206 174.927235) (xy 122.532765 174.847794) (xy 122.530231 174.846675) (xy 122.429992 174.802415) (xy 122.404865 174.7995) (xy 120.515143 174.7995) (xy 120.515117 174.799502) (xy 120.490008 174.802414) (xy 120.488782 174.802748) (xy 120.487375 174.802719) (xy 120.480742 174.803489) (xy 120.480637 174.802584) (xy 120.418927 174.801347) (xy 120.360918 174.762401) (xy 120.333173 174.698277) (xy 120.344501 174.629331) (xy 120.368553 174.595419) (xy 122.398806 172.565131) (xy 163.8495 172.565131) (xy 163.8495 174.354856) (xy 163.849502 174.354882) (xy 163.852413 174.379987) (xy 163.852415 174.379991) (xy 163.897793 174.482764) (xy 163.897794 174.482765) (xy 163.977235 174.562206) (xy 164.080009 174.607585) (xy 164.105135 174.6105) (xy 164.842873 174.610499) (xy 164.90991 174.630183) (xy 164.955665 174.682987) (xy 164.965609 174.752146) (xy 164.936584 174.815702) (xy 164.877806 174.853476) (xy 164.86227 174.856972) (xy 164.730589 174.877829) (xy 164.558363 174.933787) (xy 164.55836 174.933788) (xy 164.397002 175.016006) (xy 164.250505 175.122441) (xy 164.2505 175.122445) (xy 164.122445 175.2505) (xy 164.122441 175.250505) (xy 164.016006 175.397002) (xy 163.933788 175.55836) (xy 163.933787 175.558363) (xy 163.877829 175.730589) (xy 163.8495 175.909448) (xy 163.8495 176.090551) (xy 163.877829 176.26941) (xy 163.933787 176.441636) (xy 163.933788 176.441639) (xy 164.016006 176.602997) (xy 164.122441 176.749494) (xy 164.122445 176.749499) (xy 164.2505 176.877554) (xy 164.250505 176.877558) (xy 164.34317 176.944882) (xy 164.397006 176.983996) (xy 164.480933 177.026759) (xy 164.55836 177.066211) (xy 164.558363 177.066212) (xy 164.578529 177.072764) (xy 164.730591 177.122171) (xy 164.803639 177.13374) (xy 164.890678 177.147527) (xy 164.953813 177.177456) (xy 164.990744 177.236768) (xy 164.989746 177.306631) (xy 164.951136 177.364863) (xy 164.890678 177.392473) (xy 164.730589 177.417829) (xy 164.558363 177.473787) (xy 164.55836 177.473788) (xy 164.397002 177.556006) (xy 164.250505 177.662441) (xy 164.2505 177.662445) (xy 164.122445 177.7905) (xy 164.122441 177.790505) (xy 164.016006 177.937002) (xy 163.933788 178.09836) (xy 163.933787 178.098363) (xy 163.877829 178.270589) (xy 163.8495 178.449448) (xy 163.8495 178.630551) (xy 163.877829 178.80941) (xy 163.933787 178.981636) (xy 163.933788 178.981639) (xy 164.016006 179.142997) (xy 164.122441 179.289494) (xy 164.122445 179.289499) (xy 164.2505 179.417554) (xy 164.250505 179.417558) (xy 164.378287 179.510396) (xy 164.397006 179.523996) (xy 164.502484 179.57774) (xy 164.55836 179.606211) (xy 164.558363 179.606212) (xy 164.644476 179.634191) (xy 164.730591 179.662171) (xy 164.813429 179.675291) (xy 164.909449 179.6905) (xy 164.909454 179.6905) (xy 165.090551 179.6905) (xy 165.177259 179.676765) (xy 165.269409 179.662171) (xy 165.441639 179.606211) (xy 165.602994 179.523996) (xy 165.749501 179.417553) (xy 165.877553 179.289501) (xy 165.983996 179.142994) (xy 166.066211 178.981639) (xy 166.122171 178.809409) (xy 166.136765 178.717259) (xy 166.1505 178.630551) (xy 166.1505 178.449448) (xy 166.134019 178.345397) (xy 166.122171 178.270591) (xy 166.066211 178.098361) (xy 166.066211 178.09836) (xy 166.03774 178.042484) (xy 165.983996 177.937006) (xy 165.970396 177.918287) (xy 165.877558 177.790505) (xy 165.877554 177.7905) (xy 165.749499 177.662445) (xy 165.749494 177.662441) (xy 165.602997 177.556006) (xy 165.602996 177.556005) (xy 165.602994 177.556004) (xy 165.5513 177.529664) (xy 165.441639 177.473788) (xy 165.441636 177.473787) (xy 165.26941 177.417829) (xy 165.109321 177.392473) (xy 165.046186 177.362544) (xy 165.009255 177.303232) (xy 165.010253 177.23337) (xy 165.048863 177.175137) (xy 165.109321 177.147527) (xy 165.179425 177.136422) (xy 165.269409 177.122171) (xy 165.441639 177.066211) (xy 165.602994 176.983996) (xy 165.749501 176.877553) (xy 165.877553 176.749501) (xy 165.983996 176.602994) (xy 166.066211 176.441639) (xy 166.122171 176.269409) (xy 166.136765 176.177259) (xy 166.1505 176.090551) (xy 166.1505 175.909448) (xy 166.12456 175.745676) (xy 166.122171 175.730591) (xy 166.094191 175.644476) (xy 166.066212 175.558363) (xy 166.066211 175.55836) (xy 166.020216 175.468091) (xy 165.983996 175.397006) (xy 165.964956 175.3708) (xy 165.877558 175.250505) (xy 165.877554 175.2505) (xy 165.749499 175.122445) (xy 165.749494 175.122441) (xy 165.602997 175.016006) (xy 165.602996 175.016005) (xy 165.602994 175.016004) (xy 165.533436 174.980562) (xy 165.441639 174.933788) (xy 165.441636 174.933787) (xy 165.26941 174.877829) (xy 165.137728 174.856972) (xy 165.074594 174.827042) (xy 165.037663 174.767731) (xy 165.038661 174.697868) (xy 165.077271 174.639636) (xy 165.141235 174.611522) (xy 165.15712 174.610499) (xy 165.894864 174.610499) (xy 165.894879 174.610497) (xy 165.894882 174.610497) (xy 165.919987 174.607586) (xy 165.919988 174.607585) (xy 165.919991 174.607585) (xy 166.022765 174.562206) (xy 166.102206 174.482765) (xy 166.147585 174.379991) (xy 166.1505 174.354865) (xy 166.150499 172.565136) (xy 166.150497 172.565117) (xy 166.147586 172.540012) (xy 166.147585 172.54001) (xy 166.147585 172.540009) (xy 166.102206 172.437235) (xy 166.022765 172.357794) (xy 166.022763 172.357793) (xy 165.919992 172.312415) (xy 165.894865 172.3095) (xy 164.105143 172.3095) (xy 164.105117 172.309502) (xy 164.080012 172.312413) (xy 164.080008 172.312415) (xy 163.977235 172.357793) (xy 163.897794 172.437234) (xy 163.852415 172.540006) (xy 163.852415 172.540008) (xy 163.8495 172.565131) (xy 122.398806 172.565131) (xy 124.944767 170.019127) (xy 125.006089 169.985642) (xy 125.014906 169.984055) (xy 127.591754 169.616) (xy 127.616024 169.616001) (xy 127.64373 169.608576) (xy 127.651099 169.607524) (xy 127.6511 169.607524) (xy 127.663385 169.605769) (xy 127.672127 169.604521) (xy 127.694442 169.594989) (xy 127.717885 169.588708) (xy 127.742727 169.574365) (xy 127.769104 169.563099) (xy 127.788194 169.548114) (xy 127.809211 169.535981) (xy 127.829491 169.5157) (xy 127.852057 169.497989) (xy 127.861336 169.485615) (xy 127.87284 169.47235) (xy 130.29009 167.055131) (xy 136.2595 167.055131) (xy 136.2595 168.944856) (xy 136.259502 168.944882) (xy 136.262413 168.969987) (xy 136.262415 168.969991) (xy 136.307793 169.072764) (xy 136.307794 169.072765) (xy 136.387235 169.152206) (xy 136.490009 169.197585) (xy 136.515135 169.2005) (xy 138.404864 169.200499) (xy 138.404879 169.200497) (xy 138.404882 169.200497) (xy 138.429987 169.197586) (xy 138.429988 169.197585) (xy 138.429991 169.197585) (xy 138.532765 169.152206) (xy 138.612206 169.072765) (xy 138.657585 168.969991) (xy 138.6605 168.944865) (xy 138.660499 168.531906) (xy 138.680183 168.46487) (xy 138.732987 168.419115) (xy 138.802146 168.409171) (xy 138.865702 168.438196) (xy 138.894984 168.475614) (xy 138.923668 168.531909) (xy 138.97324 168.629199) (xy 139.08431 168.782073) (xy 139.217927 168.91569) (xy 139.370801 169.02676) (xy 139.438478 169.061243) (xy 139.539163 169.112545) (xy 139.539165 169.112545) (xy 139.539168 169.112547) (xy 139.635497 169.143846) (xy 139.718881 169.17094) (xy 139.905514 169.2005) (xy 139.905519 169.2005) (xy 140.094486 169.2005) (xy 140.281118 169.17094) (xy 140.335466 169.153281) (xy 140.460832 169.112547) (xy 140.629199 169.02676) (xy 140.782073 168.91569) (xy 140.91569 168.782073) (xy 141.02676 168.629199) (xy 141.112547 168.460832) (xy 141.152069 168.339195) (xy 141.191507 168.281521) (xy 141.255866 168.254323) (xy 141.324712 168.266238) (xy 141.376188 168.313482) (xy 141.387931 168.339196) (xy 141.427454 168.460836) (xy 141.463668 168.531909) (xy 141.51324 168.629199) (xy 141.62431 168.782073) (xy 141.757927 168.91569) (xy 141.910801 169.02676) (xy 141.978478 169.061243) (xy 142.079163 169.112545) (xy 142.079165 169.112545) (xy 142.079168 169.112547) (xy 142.175497 169.143846) (xy 142.258881 169.17094) (xy 142.445514 169.2005) (xy 142.445519 169.2005) (xy 142.634486 169.2005) (xy 142.821118 169.17094) (xy 142.875466 169.153281) (xy 143.000832 169.112547) (xy 143.169199 169.02676) (xy 143.322073 168.91569) (xy 143.45569 168.782073) (xy 143.56676 168.629199) (xy 143.652547 168.460832) (xy 143.71094 168.281118) (xy 143.715184 168.254323) (xy 143.7405 168.094486) (xy 143.7405 167.905513) (xy 143.71094 167.718881) (xy 143.669706 167.591977) (xy 143.652547 167.539168) (xy 143.652545 167.539165) (xy 143.652545 167.539163) (xy 143.566759 167.3708) (xy 143.45569 167.217927) (xy 143.322073 167.08431) (xy 143.169199 166.97324) (xy 143.150813 166.963872) (xy 143.000836 166.887454) (xy 142.821118 166.829059) (xy 142.634486 166.7995) (xy 142.634481 166.7995) (xy 142.445519 166.7995) (xy 142.445514 166.7995) (xy 142.258881 166.829059) (xy 142.079163 166.887454) (xy 141.9108 166.97324) (xy 141.832661 167.030012) (xy 141.757927 167.08431) (xy 141.757925 167.084312) (xy 141.757924 167.084312) (xy 141.624312 167.217924) (xy 141.624312 167.217925) (xy 141.62431 167.217927) (xy 141.57661 167.283579) (xy 141.51324 167.3708) (xy 141.427454 167.539163) (xy 141.387931 167.660803) (xy 141.348493 167.718478) (xy 141.284134 167.745676) (xy 141.215288 167.733761) (xy 141.163812 167.686516) (xy 141.152069 167.660803) (xy 141.124249 167.575182) (xy 141.112547 167.539168) (xy 141.112545 167.539165) (xy 141.112545 167.539163) (xy 141.026759 167.3708) (xy 140.91569 167.217927) (xy 140.782073 167.08431) (xy 140.629199 166.97324) (xy 140.610813 166.963872) (xy 140.460836 166.887454) (xy 140.281118 166.829059) (xy 140.094486 166.7995) (xy 140.094481 166.7995) (xy 139.905519 166.7995) (xy 139.905514 166.7995) (xy 139.718881 166.829059) (xy 139.539163 166.887454) (xy 139.3708 166.97324) (xy 139.292661 167.030012) (xy 139.217927 167.08431) (xy 139.217925 167.084312) (xy 139.217924 167.084312) (xy 139.084312 167.217924) (xy 139.084312 167.217925) (xy 139.08431 167.217927) (xy 139.03661 167.283579) (xy 138.97324 167.3708) (xy 138.894984 167.524386) (xy 138.847009 167.575182) (xy 138.779188 167.591977) (xy 138.713053 167.569439) (xy 138.669602 167.514724) (xy 138.660499 167.468091) (xy 138.660499 167.055143) (xy 138.660499 167.055136) (xy 138.660497 167.055117) (xy 138.657586 167.030012) (xy 138.657585 167.03001) (xy 138.657585 167.030009) (xy 138.612206 166.927235) (xy 138.532765 166.847794) (xy 138.532763 166.847793) (xy 138.429992 166.802415) (xy 138.404865 166.7995) (xy 136.515143 166.7995) (xy 136.515117 166.799502) (xy 136.490012 166.802413) (xy 136.490008 166.802415) (xy 136.387235 166.847793) (xy 136.307794 166.927234) (xy 136.262415 167.030006) (xy 136.262415 167.030008) (xy 136.2595 167.055131) (xy 130.29009 167.055131) (xy 135.777176 161.568116) (xy 135.809254 161.538902) (xy 135.814374 161.530918) (xy 135.821079 161.524214) (xy 135.841336 161.489125) (xy 135.844316 161.484231) (xy 135.866186 161.450136) (xy 135.86793 161.44466) (xy 135.869064 161.441099) (xy 135.873806 161.43289) (xy 135.885033 161.39099) (xy 135.898203 161.349661) (xy 135.898203 161.349658) (xy 135.898204 161.349656) (xy 135.899638 161.341665) (xy 135.899865 161.341705) (xy 135.900268 161.339117) (xy 135.900039 161.339087) (xy 135.9011 161.33103) (xy 135.9011 161.290543) (xy 135.901235 161.284756) (xy 135.931193 160.643543) (xy 153.5526 160.643543) (xy 153.5526 160.801657) (xy 153.583234 160.915982) (xy 153.593523 160.954383) (xy 153.593526 160.95439) (xy 153.672575 161.091309) (xy 153.672579 161.091314) (xy 153.67258 161.091316) (xy 153.784384 161.20312) (xy 153.784386 161.203121) (xy 153.78439 161.203124) (xy 153.921309 161.282173) (xy 153.921316 161.282177) (xy 154.03759 161.313332) (xy 154.097249 161.349696) (xy 154.127778 161.412542) (xy 154.119484 161.481918) (xy 154.093177 161.520787) (xy 153.990078 161.623886) (xy 153.990075 161.62389) (xy 153.911026 161.760809) (xy 153.911023 161.760816) (xy 153.8701 161.913543) (xy 153.8701 162.071657) (xy 153.892598 162.155618) (xy 153.911023 162.224383) (xy 153.911026 162.22439) (xy 153.990075 162.361309) (xy 153.990079 162.361314) (xy 153.99008 162.361316) (xy 154.101884 162.47312) (xy 154.101886 162.473121) (xy 154.10189 162.473124) (xy 154.109063 162.477265) (xy 154.238816 162.552177) (xy 154.391543 162.5931) (xy 154.391545 162.5931) (xy 154.549655 162.5931) (xy 154.549657 162.5931) (xy 154.702384 162.552177) (xy 154.839316 162.47312) (xy 154.95112 162.361316) (xy 155.030177 162.224384) (xy 155.035437 162.204752) (xy 155.071799 162.145094) (xy 155.099779 162.125926) (xy 157.259679 161.046671) (xy 157.271488 161.043507) (xy 157.306717 161.023167) (xy 157.343083 161.004996) (xy 157.343087 161.004991) (xy 157.343987 161.004385) (xy 157.361921 160.991463) (xy 157.3628 160.990786) (xy 157.362813 160.99078) (xy 157.388934 160.964658) (xy 157.391568 160.962024) (xy 157.422002 160.935052) (xy 157.428739 160.924853) (xy 162.231386 156.122205) (xy 162.281208 156.091808) (xy 163.004172 155.860042) (xy 163.07402 155.858323) (xy 163.104024 155.870736) (xy 163.128516 155.884877) (xy 163.281243 155.9258) (xy 163.281245 155.9258) (xy 163.439355 155.9258) (xy 163.439357 155.9258) (xy 163.592084 155.884877) (xy 163.64468 155.85451) (xy 163.736055 155.801757) (xy 163.736727 155.802921) (xy 163.793959 155.780788) (xy 163.862406 155.794818) (xy 163.912401 155.843626) (xy 163.922222 155.86604) (xy 163.933786 155.901633) (xy 163.933788 155.901639) (xy 164.016006 156.062997) (xy 164.122441 156.209494) (xy 164.122445 156.209499) (xy 164.2505 156.337554) (xy 164.250505 156.337558) (xy 164.378287 156.430396) (xy 164.397006 156.443996) (xy 164.502484 156.49774) (xy 164.55836 156.526211) (xy 164.558363 156.526212) (xy 164.644476 156.554191) (xy 164.730591 156.582171) (xy 164.803639 156.59374) (xy 164.890678 156.607527) (xy 164.953813 156.637456) (xy 164.990744 156.696768) (xy 164.989746 156.766631) (xy 164.951136 156.824863) (xy 164.890678 156.852473) (xy 164.730589 156.877829) (xy 164.558363 156.933787) (xy 164.55836 156.933788) (xy 164.397002 157.016006) (xy 164.250505 157.122441) (xy 164.2505 157.122445) (xy 164.122445 157.2505) (xy 164.122441 157.250505) (xy 164.016006 157.397002) (xy 163.933788 157.55836) (xy 163.933787 157.558363) (xy 163.877829 157.730589) (xy 163.8495 157.909448) (xy 163.8495 158.090551) (xy 163.877829 158.26941) (xy 163.933787 158.441636) (xy 163.933788 158.441639) (xy 163.989664 158.5513) (xy 164.007302 158.585916) (xy 164.016006 158.602997) (xy 164.122441 158.749494) (xy 164.122445 158.749499) (xy 164.2505 158.877554) (xy 164.250505 158.877558) (xy 164.342966 158.944734) (xy 164.397006 158.983996) (xy 164.502484 159.03774) (xy 164.55836 159.066211) (xy 164.558363 159.066212) (xy 164.644476 159.094191) (xy 164.730591 159.122171) (xy 164.803639 159.13374) (xy 164.890678 159.147527) (xy 164.953813 159.177456) (xy 164.990744 159.236768) (xy 164.989746 159.306631) (xy 164.951136 159.364863) (xy 164.890678 159.392473) (xy 164.730589 159.417829) (xy 164.558363 159.473787) (xy 164.55836 159.473788) (xy 164.397002 159.556006) (xy 164.250505 159.662441) (xy 164.2505 159.662445) (xy 164.122445 159.7905) (xy 164.122441 159.790505) (xy 164.016006 159.937002) (xy 163.933788 160.09836) (xy 163.933787 160.098363) (xy 163.877829 160.270589) (xy 163.8495 160.449448) (xy 163.8495 160.630551) (xy 163.877829 160.80941) (xy 163.933787 160.981636) (xy 163.933788 160.981639) (xy 163.985514 161.083155) (xy 164.005729 161.122829) (xy 164.016006 161.142997) (xy 164.122441 161.289494) (xy 164.122445 161.289499) (xy 164.2505 161.417554) (xy 164.250505 161.417558) (xy 164.349066 161.489166) (xy 164.397006 161.523996) (xy 164.483596 161.568116) (xy 164.55836 161.606211) (xy 164.558363 161.606212) (xy 164.61276 161.623886) (xy 164.730591 161.662171) (xy 164.850038 161.681089) (xy 164.892279 161.68778) (xy 164.955414 161.717709) (xy 164.992345 161.777021) (xy 164.991347 161.846883) (xy 164.952737 161.905116) (xy 164.892279 161.932726) (xy 164.730706 161.958317) (xy 164.558555 162.014251) (xy 164.558552 162.014252) (xy 164.397265 162.096434) (xy 164.25083 162.202823) (xy 164.122823 162.33083) (xy 164.016434 162.477265) (xy 163.934252 162.638552) (xy 163.934251 162.638555) (xy 163.878316 162.810706) (xy 163.867342 162.88) (xy 164.53812 162.88) (xy 164.534075 162.887007) (xy 164.5 163.014174) (xy 164.5 163.145826) (xy 164.534075 163.272993) (xy 164.53812 163.28) (xy 163.867342 163.28) (xy 163.878316 163.349293) (xy 163.934251 163.521444) (xy 163.934252 163.521447) (xy 164.016434 163.682734) (xy 164.122823 163.829169) (xy 164.25083 163.957176) (xy 164.397265 164.063565) (xy 164.558552 164.145747) (xy 164.558555 164.145748) (xy 164.7307 164.20168) (xy 164.8 164.212656) (xy 164.8 163.541879) (xy 164.807007 163.545925) (xy 164.934174 163.58) (xy 165.065826 163.58) (xy 165.192993 163.545925) (xy 165.2 163.541879) (xy 165.2 164.212655) (xy 165.269299 164.20168) (xy 165.441444 164.145748) (xy 165.441447 164.145747) (xy 165.602734 164.063565) (xy 165.749169 163.957176) (xy 165.877176 163.829169) (xy 165.983565 163.682734) (xy 166.065747 163.521447) (xy 166.065748 163.521444) (xy 166.121683 163.349293) (xy 166.132658 163.28) (xy 165.46188 163.28) (xy 165.465925 163.272993) (xy 165.5 163.145826) (xy 165.5 163.014174) (xy 165.465925 162.887007) (xy 165.46188 162.88) (xy 166.132658 162.88) (xy 166.121683 162.810706) (xy 166.065748 162.638555) (xy 166.065747 162.638552) (xy 165.983565 162.477265) (xy 165.877176 162.33083) (xy 165.749169 162.202823) (xy 165.602734 162.096434) (xy 165.441447 162.014252) (xy 165.441444 162.014251) (xy 165.269293 161.958317) (xy 165.10772 161.932726) (xy 165.044585 161.902797) (xy 165.007654 161.843485) (xy 165.008652 161.773623) (xy 165.047262 161.71539) (xy 165.10772 161.68778) (xy 165.12227 161.685475) (xy 165.269409 161.662171) (xy 165.441639 161.606211) (xy 165.602994 161.523996) (xy 165.749501 161.417553) (xy 165.877553 161.289501) (xy 165.983996 161.142994) (xy 166.066211 160.981639) (xy 166.122171 160.809409) (xy 166.136765 160.717259) (xy 166.1505 160.630551) (xy 166.1505 160.449448) (xy 166.13334 160.34111) (xy 166.122171 160.270591) (xy 166.073924 160.1221) (xy 166.066212 160.098363) (xy 166.066211 160.09836) (xy 166.03774 160.042484) (xy 165.983996 159.937006) (xy 165.970396 159.918287) (xy 165.877558 159.790505) (xy 165.877554 159.7905) (xy 165.749499 159.662445) (xy 165.749494 159.662441) (xy 165.602997 159.556006) (xy 165.602996 159.556005) (xy 165.602994 159.556004) (xy 165.5513 159.529664) (xy 165.441639 159.473788) (xy 165.441636 159.473787) (xy 165.26941 159.417829) (xy 165.109321 159.392473) (xy 165.046186 159.362544) (xy 165.009255 159.303232) (xy 165.010253 159.23337) (xy 165.048863 159.175137) (xy 165.109321 159.147527) (xy 165.179425 159.136422) (xy 165.269409 159.122171) (xy 165.441639 159.066211) (xy 165.602994 158.983996) (xy 165.749501 158.877553) (xy 165.877553 158.749501) (xy 165.983996 158.602994) (xy 166.066211 158.441639) (xy 166.122171 158.269409) (xy 166.147481 158.109609) (xy 166.1505 158.090551) (xy 166.1505 157.909448) (xy 166.130285 157.781823) (xy 166.122171 157.730591) (xy 166.081771 157.606251) (xy 166.066212 157.558363) (xy 166.066211 157.55836) (xy 165.997495 157.4235) (xy 165.983996 157.397006) (xy 165.939874 157.336277) (xy 165.877558 157.250505) (xy 165.877554 157.2505) (xy 165.749499 157.122445) (xy 165.749494 157.122441) (xy 165.602997 157.016006) (xy 165.602996 157.016005) (xy 165.602994 157.016004) (xy 165.5513 156.989664) (xy 165.441639 156.933788) (xy 165.441636 156.933787) (xy 165.26941 156.877829) (xy 165.109321 156.852473) (xy 165.046186 156.822544) (xy 165.009255 156.763232) (xy 165.010253 156.69337) (xy 165.048863 156.635137) (xy 165.109321 156.607527) (xy 165.179425 156.596422) (xy 165.269409 156.582171) (xy 165.441639 156.526211) (xy 165.602994 156.443996) (xy 165.749501 156.337553) (xy 165.877553 156.209501) (xy 165.983996 156.062994) (xy 166.066211 155.901639) (xy 166.122171 155.729409) (xy 166.136765 155.637259) (xy 166.1505 155.550551) (xy 166.1505 155.369448) (xy 166.1307 155.244444) (xy 166.122171 155.190591) (xy 166.066211 155.018361) (xy 166.066211 155.01836) (xy 166.025139 154.937753) (xy 165.983996 154.857006) (xy 165.970396 154.838287) (xy 165.877558 154.710505) (xy 165.877554 154.7105) (xy 165.749499 154.582445) (xy 165.749494 154.582441) (xy 165.602997 154.476006) (xy 165.602996 154.476005) (xy 165.602994 154.476004) (xy 165.5513 154.449664) (xy 165.441639 154.393788) (xy 165.441636 154.393787) (xy 165.26941 154.337829) (xy 165.137728 154.316972) (xy 165.074594 154.287042) (xy 165.037663 154.227731) (xy 165.038661 154.157868) (xy 165.077271 154.099636) (xy 165.141235 154.071522) (xy 165.15712 154.070499) (xy 165.894864 154.070499) (xy 165.894879 154.070497) (xy 165.894882 154.070497) (xy 165.919987 154.067586) (xy 165.919988 154.067585) (xy 165.919991 154.067585) (xy 166.022765 154.022206) (xy 166.102206 153.942765) (xy 166.147585 153.839991) (xy 166.1505 153.814865) (xy 166.150499 152.025136) (xy 166.150497 152.025117) (xy 166.147586 152.000012) (xy 166.147585 152.00001) (xy 166.147585 152.000009) (xy 166.102206 151.897235) (xy 166.022765 151.817794) (xy 166.006157 151.810461) (xy 165.919992 151.772415) (xy 165.894865 151.7695) (xy 164.105143 151.7695) (xy 164.105117 151.769502) (xy 164.080012 151.772413) (xy 164.080008 151.772415) (xy 163.977235 151.817793) (xy 163.897794 151.897234) (xy 163.852415 152.000006) (xy 163.852415 152.000008) (xy 163.8495 152.025131) (xy 163.8495 153.814856) (xy 163.849502 153.814882) (xy 163.852413 153.839987) (xy 163.852415 153.839991) (xy 163.897793 153.942764) (xy 163.897794 153.942765) (xy 163.977235 154.022206) (xy 164.080009 154.067585) (xy 164.105135 154.0705) (xy 164.842873 154.070499) (xy 164.90991 154.090183) (xy 164.955665 154.142987) (xy 164.965609 154.212146) (xy 164.936584 154.275702) (xy 164.877806 154.313476) (xy 164.86227 154.316972) (xy 164.730589 154.337829) (xy 164.558363 154.393787) (xy 164.55836 154.393788) (xy 164.397002 154.476006) (xy 164.250505 154.582441) (xy 164.2505 154.582445) (xy 164.122445 154.7105) (xy 164.122441 154.710505) (xy 164.016004 154.857004) (xy 164.000741 154.886958) (xy 163.952765 154.937753) (xy 163.884944 154.954546) (xy 163.818809 154.932006) (xy 163.802577 154.918341) (xy 163.729017 154.844781) (xy 163.729009 154.844775) (xy 163.59209 154.765726) (xy 163.592086 154.765724) (xy 163.592084 154.765723) (xy 163.439357 154.7248) (xy 163.281243 154.7248) (xy 163.128516 154.765723) (xy 163.128509 154.765726) (xy 162.99159 154.844775) (xy 162.991582 154.844781) (xy 162.879781 154.956582) (xy 162.879777 154.956587) (xy 162.831325 155.04051) (xy 162.780758 155.088726) (xy 162.761792 155.096591) (xy 161.927816 155.363944) (xy 161.927815 155.363943) (xy 161.924928 155.364868) (xy 161.883412 155.375994) (xy 161.874899 155.380908) (xy 161.865533 155.383911) (xy 161.865523 155.383915) (xy 161.83187 155.40558) (xy 161.831871 155.405581) (xy 161.829327 155.407218) (xy 161.792087 155.42872) (xy 161.785131 155.435674) (xy 161.776865 155.440997) (xy 161.776858 155.441003) (xy 161.749958 155.470642) (xy 161.745819 155.474986) (xy 156.893936 160.326869) (xy 156.861681 160.350111) (xy 154.739311 161.410615) (xy 154.712644 161.415406) (xy 154.686836 161.423657) (xy 154.674763 161.422213) (xy 154.670543 161.422972) (xy 154.651794 161.419467) (xy 154.58611 161.401867) (xy 154.52645 161.365503) (xy 154.495921 161.302656) (xy 154.504216 161.233281) (xy 154.530518 161.194417) (xy 154.63362 161.091316) (xy 154.712677 160.954384) (xy 154.7536 160.801657) (xy 154.7536 160.739839) (xy 154.773285 160.6728) (xy 154.789917 160.65216) (xy 154.811526 160.630551) (xy 156.07948 159.362544) (xy 156.463787 158.978221) (xy 156.525109 158.944734) (xy 156.55147 158.9419) (xy 156.613255 158.9419) (xy 156.613257 158.9419) (xy 156.765984 158.900977) (xy 156.902916 158.82192) (xy 157.01472 158.710116) (xy 157.093777 158.573184) (xy 157.1347 158.420457) (xy 157.1347 158.262343) (xy 157.093777 158.109616) (xy 157.024655 157.989892) (xy 157.014724 157.97269) (xy 157.014718 157.972682) (xy 156.902917 157.860881) (xy 156.902909 157.860875) (xy 156.76599 157.781826) (xy 156.765986 157.781824) (xy 156.765984 157.781823) (xy 156.613257 157.7409) (xy 156.455143 157.7409) (xy 156.302416 157.781823) (xy 156.302409 157.781826) (xy 156.16549 157.860875) (xy 156.165482 157.860881) (xy 156.053681 157.972682) (xy 156.053675 157.97269) (xy 155.974626 158.109609) (xy 155.974623 158.109616) (xy 155.9337 158.262343) (xy 155.9337 158.324159) (xy 155.914015 158.391198) (xy 155.897383 158.411838) (xy 154.223513 160.085779) (xy 154.162191 160.119266) (xy 154.13583 160.1221) (xy 154.074043 160.1221) (xy 153.921316 160.163023) (xy 153.921309 160.163026) (xy 153.78439 160.242075) (xy 153.784382 160.242081) (xy 153.672581 160.353882) (xy 153.672575 160.35389) (xy 153.593526 160.490809) (xy 153.593523 160.490816) (xy 153.5526 160.643543) (xy 135.931193 160.643543) (xy 136.287986 153.006912) (xy 136.310778 152.940867) (xy 136.324164 152.925027) (xy 137.019149 152.230043) (xy 138.4718 152.230043) (xy 138.4718 152.388157) (xy 138.512349 152.539486) (xy 138.512723 152.540883) (xy 138.512726 152.54089) (xy 138.591775 152.677809) (xy 138.591779 152.677814) (xy 138.59178 152.677816) (xy 138.703584 152.78962) (xy 138.703586 152.789621) (xy 138.70359 152.789624) (xy 138.840509 152.868673) (xy 138.840516 152.868677) (xy 138.993243 152.9096) (xy 139.055039 152.9096) (xy 139.122078 152.929285) (xy 139.142721 152.94592) (xy 140.955688 154.758923) (xy 143.583894 157.387181) (xy 143.715282 157.518571) (xy 143.748766 157.579894) (xy 143.7516 157.606251) (xy 143.7516 158.317602) (xy 143.731915 158.384641) (xy 143.715281 158.405283) (xy 143.671581 158.448982) (xy 143.671575 158.44899) (xy 143.592526 158.585909) (xy 143.592523 158.585916) (xy 143.5516 158.738643) (xy 143.5516 158.896757) (xy 143.564456 158.944734) (xy 143.592523 159.049483) (xy 143.592526 159.04949) (xy 143.671575 159.186409) (xy 143.671579 159.186414) (xy 143.67158 159.186416) (xy 143.783384 159.29822) (xy 143.783386 159.298221) (xy 143.78339 159.298224) (xy 143.797952 159.306631) (xy 143.920316 159.377277) (xy 144.073043 159.4182) (xy 144.073045 159.4182) (xy 144.231155 159.4182) (xy 144.231157 159.4182) (xy 144.383884 159.377277) (xy 144.520816 159.29822) (xy 144.63262 159.186416) (xy 144.711677 159.049484) (xy 144.7526 158.896757) (xy 144.7526 158.738643) (xy 144.711677 158.585916) (xy 144.664686 158.504524) (xy 144.632624 158.44899) (xy 144.632618 158.448982) (xy 144.588919 158.405283) (xy 144.555434 158.34396) (xy 144.5526 158.317602) (xy 144.5526 157.40746) (xy 144.5526 157.397006) (xy 144.552601 157.336277) (xy 144.525308 157.234416) (xy 144.525307 157.234415) (xy 144.525307 157.234413) (xy 144.47258 157.143087) (xy 144.398013 157.06852) (xy 144.390945 157.061452) (xy 144.39094 157.061448) (xy 139.709118 152.379532) (xy 139.675634 152.318209) (xy 139.6728 152.291852) (xy 139.6728 152.230045) (xy 139.6728 152.230043) (xy 139.631877 152.077316) (xy 139.587246 152.000012) (xy 139.552824 151.94039) (xy 139.552818 151.940382) (xy 139.441017 151.828581) (xy 139.441009 151.828575) (xy 139.30409 151.749526) (xy 139.304086 151.749524) (xy 139.304084 151.749523) (xy 139.151357 151.7086) (xy 138.993243 151.7086) (xy 138.840516 151.749523) (xy 138.840509 151.749526) (xy 138.70359 151.828575) (xy 138.703582 151.828581) (xy 138.591781 151.940382) (xy 138.591775 151.94039) (xy 138.512726 152.077309) (xy 138.512723 152.077316) (xy 138.4718 152.230043) (xy 137.019149 152.230043) (xy 137.573173 151.676019) (xy 137.634496 151.642534) (xy 137.660854 151.6397) (xy 137.722655 151.6397) (xy 137.722657 151.6397) (xy 137.875384 151.598777) (xy 138.012316 151.51972) (xy 138.12412 151.407916) (xy 138.203177 151.270984) (xy 138.217129 151.21891) (xy 138.253494 151.159251) (xy 138.31634 151.128722) (xy 138.33673 151.127005) (xy 141.271428 151.122899) (xy 141.338494 151.14249) (xy 141.359282 151.159218) (xy 141.402284 151.20222) (xy 141.402286 151.202221) (xy 141.40229 151.202224) (xy 141.521386 151.270983) (xy 141.539216 151.281277) (xy 141.691943 151.3222) (xy 141.691945 151.3222) (xy 141.850055 151.3222) (xy 141.850057 151.3222) (xy 142.002784 151.281277) (xy 142.139716 151.20222) (xy 142.25152 151.090416) (xy 142.330577 150.953484) (xy 142.3715 150.800757) (xy 142.3715 150.642643) (xy 142.330577 150.489916) (xy 142.294066 150.426676) (xy 142.251524 150.35299) (xy 142.251518 150.352982) (xy 142.139717 150.241181) (xy 142.139709 150.241175) (xy 142.00279 150.162126) (xy 142.002786 150.162124) (xy 142.002784 150.162123) (xy 141.850057 150.1212) (xy 141.691943 150.1212) (xy 141.539216 150.162123) (xy 141.539209 150.162126) (xy 141.402283 150.241179) (xy 141.357879 150.285582) (xy 141.296556 150.319066) (xy 141.270374 150.321899) (xy 123.881278 150.346229) (xy 123.881279 150.34623) (xy 123.869681 150.346246) (xy 123.854666 150.343436) (xy 123.817162 150.346319) (xy 123.812475 150.346326) (xy 123.812475 150.346327) (xy 123.779509 150.346374) (xy 123.775939 150.347336) (xy 123.753199 150.351237) (xy 120.080607 150.633638) (xy 120.067109 150.630777) (xy 120.053453 150.632741) (xy 120.033602 150.623675) (xy 120.012255 150.619151) (xy 120.002447 150.609447) (xy 119.989897 150.603716) (xy 119.978099 150.585358) (xy 119.962587 150.570011) (xy 119.958795 150.555321) (xy 119.952123 150.544938) (xy 119.9471 150.510003) (xy 119.9471 150.428098) (xy 119.966785 150.361059) (xy 119.983419 150.340417) (xy 120.00477 150.319066) (xy 120.02712 150.296716) (xy 120.106177 150.159784) (xy 120.1471 150.007057) (xy 120.1471 149.848943) (xy 120.106177 149.696216) (xy 120.059125 149.614718) (xy 120.027124 149.55929) (xy 120.027118 149.559282) (xy 119.915317 149.447481) (xy 119.915309 149.447475) (xy 119.77839 149.368426) (xy 119.778386 149.368424) (xy 119.778384 149.368423) (xy 119.625657 149.3275) (xy 119.467543 149.3275) (xy 119.314816 149.368423) (xy 119.314809 149.368426) (xy 119.17789 149.447475) (xy 119.177882 149.447481) (xy 119.066081 149.559282) (xy 119.066075 149.55929) (xy 118.987026 149.696209) (xy 118.987023 149.696216) (xy 118.9461 149.848943) (xy 118.9461 150.007057) (xy 118.976685 150.1212) (xy 118.987023 150.159783) (xy 118.987026 150.15979) (xy 119.066075 150.296709) (xy 119.066081 150.296717) (xy 119.109781 150.340417) (xy 119.124484 150.367344) (xy 119.141077 150.393163) (xy 119.141968 150.399363) (xy 119.143266 150.40174) (xy 119.1461 150.428098) (xy 119.1461 150.5491) (xy 119.126415 150.616139) (xy 119.073611 150.661894) (xy 119.0221 150.6731) (xy 118.923898 150.6731) (xy 118.901256 150.671015) (xy 118.896899 150.670206) (xy 118.864771 150.672722) (xy 118.864768 150.672722) (xy 118.859939 150.6731) (xy 118.822873 150.6731) (xy 118.80757 150.677199) (xy 118.79619 150.67809) (xy 118.796187 150.678091) (xy 115.440044 150.940913) (xy 115.371672 150.926522) (xy 115.321934 150.877451) (xy 115.306622 150.80928) (xy 115.330596 150.743652) (xy 115.342676 150.729616) (xy 117.017149 149.055143) (xy 139.9005 149.055143) (xy 139.9005 149.213257) (xy 139.931112 149.3275) (xy 139.941423 149.365983) (xy 139.941426 149.36599) (xy 140.020475 149.502909) (xy 140.020479 149.502914) (xy 140.02048 149.502916) (xy 140.132284 149.61472) (xy 140.132286 149.614721) (xy 140.13229 149.614724) (xy 140.269209 149.693773) (xy 140.269216 149.693777) (xy 140.421943 149.7347) (xy 140.421945 149.7347) (xy 140.580055 149.7347) (xy 140.580057 149.7347) (xy 140.732784 149.693777) (xy 140.869716 149.61472) (xy 140.913417 149.571019) (xy 140.97474 149.537534) (xy 141.001098 149.5347) (xy 142.506145 149.5347) (xy 142.573184 149.554385) (xy 142.593826 149.571019) (xy 150.976381 157.953573) (xy 151.009866 158.014896) (xy 151.0127 158.041254) (xy 151.0127 158.103057) (xy 151.014458 158.109616) (xy 151.053623 158.255783) (xy 151.053626 158.25579) (xy 151.132675 158.392709) (xy 151.132679 158.392714) (xy 151.13268 158.392716) (xy 151.244484 158.50452) (xy 151.244486 158.504521) (xy 151.24449 158.504524) (xy 151.363425 158.57319) (xy 151.381416 158.583577) (xy 151.534143 158.6245) (xy 151.534145 158.6245) (xy 151.692255 158.6245) (xy 151.692257 158.6245) (xy 151.844984 158.583577) (xy 151.981916 158.50452) (xy 152.09372 158.392716) (xy 152.172777 158.255784) (xy 152.2137 158.103057) (xy 152.2137 157.944943) (xy 152.172777 157.792216) (xy 152.137197 157.730589) (xy 152.093724 157.65529) (xy 152.093718 157.655282) (xy 151.981917 157.543481) (xy 151.981909 157.543475) (xy 151.84499 157.464426) (xy 151.844986 157.464424) (xy 151.844984 157.464423) (xy 151.692257 157.4235) (xy 151.692256 157.4235) (xy 151.630454 157.4235) (xy 151.563415 157.403815) (xy 151.542773 157.387181) (xy 142.969315 148.813722) (xy 142.969314 148.813721) (xy 142.969313 148.81372) (xy 142.92365 148.787356) (xy 142.877989 148.760993) (xy 142.827057 148.747346) (xy 142.776127 148.7337) (xy 142.776126 148.7337) (xy 141.001098 148.7337) (xy 140.934059 148.714015) (xy 140.913417 148.697381) (xy 140.869717 148.653681) (xy 140.869709 148.653675) (xy 140.73279 148.574626) (xy 140.732786 148.574624) (xy 140.732784 148.574623) (xy 140.580057 148.5337) (xy 140.421943 148.5337) (xy 140.269216 148.574623) (xy 140.269209 148.574626) (xy 140.13229 148.653675) (xy 140.132282 148.653681) (xy 140.020481 148.765482) (xy 140.020475 148.76549) (xy 139.941426 148.902409) (xy 139.941423 148.902416) (xy 139.9005 149.055143) (xy 117.017149 149.055143) (xy 118.604548 147.467743) (xy 141.8054 147.467743) (xy 141.8054 147.625856) (xy 141.846323 147.778583) (xy 141.846326 147.77859) (xy 141.925375 147.915509) (xy 141.925379 147.915514) (xy 141.92538 147.915516) (xy 142.037184 148.02732) (xy 142.037186 148.027321) (xy 142.03719 148.027324) (xy 142.174109 148.106373) (xy 142.174116 148.106377) (xy 142.326843 148.1473) (xy 142.326845 148.1473) (xy 142.484955 148.1473) (xy 142.484957 148.1473) (xy 142.637684 148.106377) (xy 142.774616 148.02732) (xy 142.88642 147.915516) (xy 142.965477 147.778584) (xy 143.0064 147.625857) (xy 143.0064 147.467743) (xy 142.965477 147.315016) (xy 142.965473 147.315009) (xy 142.886424 147.17809) (xy 142.886421 147.178086) (xy 142.88642 147.178084) (xy 142.868415 147.160079) (xy 142.83493 147.098756) (xy 142.832267 147.065886) (xy 143.192167 140.228436) (xy 143.215348 140.162528) (xy 143.228308 140.147283) (xy 144.251911 139.12368) (xy 144.313232 139.090197) (xy 144.382924 139.095181) (xy 144.438857 139.137053) (xy 144.463274 139.202517) (xy 144.463576 139.213214) (xy 144.394105 143.866131) (xy 144.373422 143.932869) (xy 144.357802 143.95196) (xy 144.306578 144.003185) (xy 144.227526 144.140109) (xy 144.227523 144.140116) (xy 144.1866 144.292843) (xy 144.1866 144.450956) (xy 144.227523 144.603683) (xy 144.227526 144.60369) (xy 144.306575 144.740609) (xy 144.306579 144.740614) (xy 144.30658 144.740616) (xy 144.418384 144.85242) (xy 144.418386 144.852421) (xy 144.41839 144.852424) (xy 144.555309 144.931473) (xy 144.555316 144.931477) (xy 144.708043 144.9724) (xy 144.708045 144.9724) (xy 144.866155 144.9724) (xy 144.866157 144.9724) (xy 145.018884 144.931477) (xy 145.155816 144.85242) (xy 145.26762 144.740616) (xy 145.346677 144.603684) (xy 145.3876 144.450957) (xy 145.3876 144.292843) (xy 145.346677 144.140116) (xy 145.346673 144.140109) (xy 145.267624 144.00319) (xy 145.267621 144.003186) (xy 145.26762 144.003184) (xy 145.231333 143.966897) (xy 145.197848 143.905574) (xy 145.195028 143.877365) (xy 145.223132 141.995018) (xy 145.26378 139.272534) (xy 145.284463 139.205798) (xy 145.30008 139.186711) (xy 147.590261 136.89653) (xy 148.5095 136.89653) (xy 148.5095 137.103469) (xy 148.549868 137.306412) (xy 148.54987 137.30642) (xy 148.629058 137.497596) (xy 148.744024 137.669657) (xy 148.890342 137.815975) (xy 148.890345 137.815977) (xy 149.062402 137.930941) (xy 149.25358 138.01013) (xy 149.402863 138.039824) (xy 149.45653 138.050499) (xy 149.456534 138.0505) (xy 149.456535 138.0505) (xy 149.663466 138.0505) (xy 149.663467 138.050499) (xy 149.86642 138.01013) (xy 150.057598 137.930941) (xy 150.229655 137.815977) (xy 150.375977 137.669655) (xy 150.490941 137.497598) (xy 150.57013 137.30642) (xy 150.6105 137.103465) (xy 150.6105 136.896535) (xy 150.57013 136.69358) (xy 150.490941 136.502402) (xy 150.375977 136.330345) (xy 150.375975 136.330342) (xy 150.229657 136.184024) (xy 150.10597 136.10138) (xy 150.057598 136.069059) (xy 149.86642 135.98987) (xy 149.866412 135.989868) (xy 149.663469 135.9495) (xy 149.663465 135.9495) (xy 149.456535 135.9495) (xy 149.45653 135.9495) (xy 149.253587 135.989868) (xy 149.253579 135.98987) (xy 149.062403 136.069058) (xy 148.890342 136.184024) (xy 148.744024 136.330342) (xy 148.629058 136.502403) (xy 148.54987 136.693579) (xy 148.549868 136.693587) (xy 148.5095 136.89653) (xy 147.590261 136.89653) (xy 163.652361 120.83443) (xy 163.713682 120.800947) (xy 163.783374 120.805931) (xy 163.839307 120.847803) (xy 163.862513 120.902714) (xy 163.877829 120.99941) (xy 163.933787 121.171636) (xy 163.933788 121.171639) (xy 164.016006 121.332997) (xy 164.122441 121.479494) (xy 164.122445 121.479499) (xy 164.2505 121.607554) (xy 164.250505 121.607558) (xy 164.378287 121.700396) (xy 164.397006 121.713996) (xy 164.502484 121.76774) (xy 164.55836 121.796211) (xy 164.558363 121.796212) (xy 164.644476 121.824191) (xy 164.730591 121.852171) (xy 164.803639 121.86374) (xy 164.890678 121.877527) (xy 164.953813 121.907456) (xy 164.990744 121.966768) (xy 164.989746 122.036631) (xy 164.951136 122.094863) (xy 164.890678 122.122473) (xy 164.730589 122.147829) (xy 164.558363 122.203787) (xy 164.55836 122.203788) (xy 164.397002 122.286006) (xy 164.250505 122.392441) (xy 164.2505 122.392445) (xy 164.122445 122.5205) (xy 164.122441 122.520505) (xy 164.016006 122.667002) (xy 163.933788 122.82836) (xy 163.933787 122.828363) (xy 163.877829 123.000589) (xy 163.8495 123.179448) (xy 163.8495 123.360551) (xy 163.854992 123.395228) (xy 163.846037 123.464521) (xy 163.8202 123.502306) (xy 152.847751 134.474754) (xy 152.845431 134.477073) (xy 152.814074 134.505299) (xy 152.808263 134.514241) (xy 152.80072 134.521785) (xy 152.781233 134.555535) (xy 152.781232 134.555534) (xy 152.779589 134.558379) (xy 152.756625 134.593731) (xy 152.753329 134.603864) (xy 152.747995 134.613105) (xy 152.747992 134.613113) (xy 152.73791 134.650734) (xy 152.737911 134.650735) (xy 152.737062 134.653901) (xy 152.724021 134.694017) (xy 152.72346 134.704668) (xy 152.7207 134.714973) (xy 152.7207 134.714974) (xy 152.7207 134.753919) (xy 152.720529 134.76043) (xy 152.65252 136.053856) (xy 152.629342 136.119769) (xy 152.616371 136.135028) (xy 150.572338 138.178983) (xy 150.511014 138.212467) (xy 150.484658 138.2153) (xy 150.422843 138.2153) (xy 150.270116 138.256223) (xy 150.270109 138.256226) (xy 150.13319 138.335275) (xy 150.133182 138.335281) (xy 150.021381 138.447082) (xy 150.021375 138.44709) (xy 149.942326 138.584009) (xy 149.942323 138.584016) (xy 149.9014 138.736743) (xy 149.9014 138.894857) (xy 149.929888 139.001173) (xy 149.942323 139.047583) (xy 149.942326 139.04759) (xy 150.021375 139.184509) (xy 150.021379 139.184514) (xy 150.02138 139.184516) (xy 150.133184 139.29632) (xy 150.133186 139.296321) (xy 150.13319 139.296324) (xy 150.270109 139.375373) (xy 150.270116 139.375377) (xy 150.422843 139.4163) (xy 150.422845 139.4163) (xy 150.580955 139.4163) (xy 150.580957 139.4163) (xy 150.733684 139.375377) (xy 150.870616 139.29632) (xy 150.98242 139.184516) (xy 151.061477 139.047584) (xy 151.1024 138.894857) (xy 151.1024 138.833068) (xy 151.122085 138.766029) (xy 151.13872 138.745385) (xy 153.200237 136.683949) (xy 153.261558 136.650467) (xy 153.33125 136.655453) (xy 153.387183 136.697325) (xy 153.411598 136.76279) (xy 153.409532 136.795824) (xy 153.3895 136.896536) (xy 153.3895 137.103469) (xy 153.429868 137.306412) (xy 153.42987 137.30642) (xy 153.509058 137.497596) (xy 153.624024 137.669657) (xy 153.770342 137.815975) (xy 153.770345 137.815977) (xy 153.942402 137.930941) (xy 154.13358 138.01013) (xy 154.282863 138.039824) (xy 154.33653 138.050499) (xy 154.336534 138.0505) (xy 154.336535 138.0505) (xy 154.543466 138.0505) (xy 154.543467 138.050499) (xy 154.74642 138.01013) (xy 154.746429 138.010126) (xy 154.750643 138.008848) (xy 154.820509 138.008217) (xy 154.874331 138.039824) (xy 158.278581 141.444074) (xy 158.312066 141.505397) (xy 158.3149 141.531755) (xy 158.3149 141.593556) (xy 158.355823 141.746283) (xy 158.355826 141.74629) (xy 158.434875 141.883209) (xy 158.434879 141.883214) (xy 158.43488 141.883216) (xy 158.546684 141.99502) (xy 158.546686 141.995021) (xy 158.54669 141.995024) (xy 158.683609 142.074073) (xy 158.683616 142.074077) (xy 158.836343 142.115) (xy 158.836345 142.115) (xy 158.994455 142.115) (xy 158.994457 142.115) (xy 159.147184 142.074077) (xy 159.284116 141.99502) (xy 159.39592 141.883216) (xy 159.474977 141.746284) (xy 159.5159 141.593557) (xy 159.5159 141.435443) (xy 159.474977 141.282716) (xy 159.474973 141.282709) (xy 159.395924 141.14579) (xy 159.395918 141.145782) (xy 159.284117 141.033981) (xy 159.284109 141.033975) (xy 159.14719 140.954926) (xy 159.147186 140.954924) (xy 159.147184 140.954923) (xy 158.994457 140.914) (xy 158.994456 140.914) (xy 158.932655 140.914) (xy 158.865616 140.894315) (xy 158.844974 140.877681) (xy 155.457045 137.489752) (xy 155.42356 137.428429) (xy 155.428544 137.358737) (xy 155.43015 137.354655) (xy 155.45013 137.30642) (xy 155.4905 137.103465) (xy 155.4905 136.896535) (xy 155.45013 136.69358) (xy 155.370941 136.502402) (xy 155.255977 136.330345) (xy 155.255975 136.330342) (xy 155.109657 136.184024) (xy 154.98597 136.10138) (xy 154.937598 136.069059) (xy 154.74642 135.98987) (xy 154.746412 135.989868) (xy 154.543469 135.9495) (xy 154.543465 135.9495) (xy 154.336535 135.9495) (xy 154.33653 135.9495) (xy 154.133587 135.989868) (xy 154.133579 135.98987) (xy 153.942403 136.069058) (xy 153.770344 136.184023) (xy 153.658358 136.296009) (xy 153.597035 136.329493) (xy 153.527343 136.324509) (xy 153.47141 136.282637) (xy 153.446993 136.217173) (xy 153.446848 136.201816) (xy 153.510578 134.989733) (xy 153.533755 134.923822) (xy 153.54672 134.908571) (xy 164.208766 124.246524) (xy 164.270087 124.213041) (xy 164.339779 124.218025) (xy 164.36933 124.233889) (xy 164.386724 124.246526) (xy 164.397006 124.253996) (xy 164.502484 124.30774) (xy 164.55836 124.336211) (xy 164.558363 124.336212) (xy 164.644476 124.364191) (xy 164.730591 124.392171) (xy 164.803639 124.40374) (xy 164.890678 124.417527) (xy 164.953813 124.447456) (xy 164.990744 124.506768) (xy 164.989746 124.576631) (xy 164.951136 124.634863) (xy 164.890678 124.662473) (xy 164.730589 124.687829) (xy 164.558363 124.743787) (xy 164.55836 124.743788) (xy 164.397002 124.826006) (xy 164.250505 124.932441) (xy 164.2505 124.932445) (xy 164.122445 125.0605) (xy 164.122441 125.060505) (xy 164.016006 125.207002) (xy 163.933788 125.36836) (xy 163.933787 125.368363) (xy 163.877829 125.540589) (xy 163.8495 125.719448) (xy 163.8495 125.900551) (xy 163.877829 126.07941) (xy 163.933787 126.251636) (xy 163.933788 126.251639) (xy 164.016006 126.412997) (xy 164.122441 126.559494) (xy 164.122445 126.559499) (xy 164.2505 126.687554) (xy 164.250505 126.687558) (xy 164.378287 126.780396) (xy 164.397006 126.793996) (xy 164.502484 126.84774) (xy 164.55836 126.876211) (xy 164.558363 126.876212) (xy 164.644476 126.904191) (xy 164.730591 126.932171) (xy 164.850038 126.951089) (xy 164.892279 126.95778) (xy 164.955414 126.987709) (xy 164.992345 127.047021) (xy 164.991347 127.116883) (xy 164.952737 127.175116) (xy 164.892279 127.202726) (xy 164.730706 127.228317) (xy 164.558555 127.284251) (xy 164.558552 127.284252) (xy 164.397265 127.366434) (xy 164.25083 127.472823) (xy 164.122823 127.60083) (xy 164.016434 127.747265) (xy 163.934252 127.908552) (xy 163.934251 127.908555) (xy 163.878316 128.080706) (xy 163.867342 128.15) (xy 164.53812 128.15) (xy 164.534075 128.157007) (xy 164.5 128.284174) (xy 164.5 128.415826) (xy 164.534075 128.542993) (xy 164.53812 128.55) (xy 163.867342 128.55) (xy 163.878316 128.619293) (xy 163.934251 128.791444) (xy 163.934252 128.791447) (xy 164.016434 128.952734) (xy 164.122823 129.099169) (xy 164.25083 129.227176) (xy 164.397265 129.333565) (xy 164.558552 129.415747) (xy 164.558555 129.415748) (xy 164.7307 129.47168) (xy 164.8 129.482656) (xy 164.8 128.811879) (xy 164.807007 128.815925) (xy 164.934174 128.85) (xy 165.065826 128.85) (xy 165.192993 128.815925) (xy 165.2 128.811879) (xy 165.2 129.482655) (xy 165.269299 129.47168) (xy 165.441444 129.415748) (xy 165.441447 129.415747) (xy 165.602734 129.333565) (xy 165.749169 129.227176) (xy 165.877176 129.099169) (xy 165.983565 128.952734) (xy 166.065747 128.791447) (xy 166.065748 128.791444) (xy 166.121683 128.619293) (xy 166.132658 128.55) (xy 165.46188 128.55) (xy 165.465925 128.542993) (xy 165.5 128.415826) (xy 165.5 128.284174) (xy 165.465925 128.157007) (xy 165.46188 128.15) (xy 166.132658 128.15) (xy 166.121683 128.080706) (xy 166.065748 127.908555) (xy 166.065747 127.908552) (xy 165.983565 127.747265) (xy 165.877176 127.60083) (xy 165.749169 127.472823) (xy 165.602734 127.366434) (xy 165.441447 127.284252) (xy 165.441444 127.284251) (xy 165.269293 127.228317) (xy 165.10772 127.202726) (xy 165.044585 127.172797) (xy 165.007654 127.113485) (xy 165.008652 127.043623) (xy 165.047262 126.98539) (xy 165.10772 126.95778) (xy 165.12227 126.955475) (xy 165.269409 126.932171) (xy 165.441639 126.876211) (xy 165.602994 126.793996) (xy 165.749501 126.687553) (xy 165.877553 126.559501) (xy 165.983996 126.412994) (xy 166.066211 126.251639) (xy 166.122171 126.079409) (xy 166.136765 125.987259) (xy 166.1505 125.900551) (xy 166.1505 125.719448) (xy 166.134019 125.615397) (xy 166.122171 125.540591) (xy 166.066211 125.368361) (xy 166.066211 125.36836) (xy 166.03774 125.312484) (xy 165.983996 125.207006) (xy 165.970396 125.188287) (xy 165.877558 125.060505) (xy 165.877554 125.0605) (xy 165.749499 124.932445) (xy 165.749494 124.932441) (xy 165.602997 124.826006) (xy 165.602996 124.826005) (xy 165.602994 124.826004) (xy 165.5513 124.799664) (xy 165.441639 124.743788) (xy 165.441636 124.743787) (xy 165.26941 124.687829) (xy 165.109321 124.662473) (xy 165.046186 124.632544) (xy 165.009255 124.573232) (xy 165.010253 124.50337) (xy 165.048863 124.445137) (xy 165.109321 124.417527) (xy 165.179425 124.406422) (xy 165.269409 124.392171) (xy 165.441639 124.336211) (xy 165.602994 124.253996) (xy 165.749501 124.147553) (xy 165.877553 124.019501) (xy 165.983996 123.872994) (xy 166.066211 123.711639) (xy 166.122171 123.539409) (xy 166.145007 123.395228) (xy 166.1505 123.360551) (xy 166.1505 123.179448) (xy 166.134019 123.075397) (xy 166.122171 123.000591) (xy 166.066211 122.828361) (xy 166.066211 122.82836) (xy 166.03774 122.772484) (xy 165.983996 122.667006) (xy 165.970396 122.648287) (xy 165.877558 122.520505) (xy 165.877554 122.5205) (xy 165.749499 122.392445) (xy 165.749494 122.392441) (xy 165.602997 122.286006) (xy 165.602996 122.286005) (xy 165.602994 122.286004) (xy 165.5513 122.259664) (xy 165.441639 122.203788) (xy 165.441636 122.203787) (xy 165.26941 122.147829) (xy 165.109321 122.122473) (xy 165.046186 122.092544) (xy 165.009255 122.033232) (xy 165.010253 121.96337) (xy 165.048863 121.905137) (xy 165.109321 121.877527) (xy 165.179425 121.866422) (xy 165.269409 121.852171) (xy 165.441639 121.796211) (xy 165.602994 121.713996) (xy 165.749501 121.607553) (xy 165.877553 121.479501) (xy 165.983996 121.332994) (xy 166.066211 121.171639) (xy 166.122171 120.999409) (xy 166.148301 120.834432) (xy 166.1505 120.820551) (xy 166.1505 120.639448) (xy 166.134019 120.535397) (xy 166.122171 120.460591) (xy 166.066211 120.288361) (xy 166.066211 120.28836) (xy 166.03774 120.232484) (xy 165.983996 120.127006) (xy 165.970396 120.108287) (xy 165.877558 119.980505) (xy 165.877554 119.9805) (xy 165.749499 119.852445) (xy 165.749494 119.852441) (xy 165.602997 119.746006) (xy 165.602996 119.746005) (xy 165.602994 119.746004) (xy 165.5513 119.719664) (xy 165.441639 119.663788) (xy 165.441636 119.663787) (xy 165.26941 119.607829) (xy 165.109321 119.582473) (xy 165.046186 119.552544) (xy 165.009255 119.493232) (xy 165.010253 119.42337) (xy 165.048863 119.365137) (xy 165.109321 119.337527) (xy 165.179425 119.326422) (xy 165.269409 119.312171) (xy 165.441639 119.256211) (xy 165.602994 119.173996) (xy 165.749501 119.067553) (xy 165.877553 118.939501) (xy 165.983996 118.792994) (xy 166.066211 118.631639) (xy 166.122171 118.459409) (xy 166.136765 118.367259) (xy 166.1505 118.280551) (xy 166.1505 118.099448) (xy 166.134019 117.995397) (xy 166.122171 117.920591) (xy 166.066211 117.748361) (xy 166.066211 117.74836) (xy 166.03774 117.692484) (xy 165.983996 117.587006) (xy 165.970396 117.568287) (xy 165.877558 117.440505) (xy 165.877554 117.4405) (xy 165.749499 117.312445) (xy 165.749494 117.312441) (xy 165.602997 117.206006) (xy 165.602996 117.206005) (xy 165.602994 117.206004) (xy 165.5513 117.179664) (xy 165.441639 117.123788) (xy 165.441636 117.123787) (xy 165.26941 117.067829) (xy 165.137728 117.046972) (xy 165.074594 117.017042) (xy 165.037663 116.957731) (xy 165.038661 116.887868) (xy 165.077271 116.829636) (xy 165.141235 116.801522) (xy 165.15712 116.800499) (xy 165.894864 116.800499) (xy 165.894879 116.800497) (xy 165.894882 116.800497) (xy 165.919987 116.797586) (xy 165.919988 116.797585) (xy 165.919991 116.797585) (xy 166.022765 116.752206) (xy 166.102206 116.672765) (xy 166.147585 116.569991) (xy 166.1505 116.544865) (xy 166.150499 114.755136) (xy 166.150497 114.755117) (xy 166.147586 114.730012) (xy 166.147585 114.73001) (xy 166.147585 114.730009) (xy 166.102206 114.627235) (xy 166.022765 114.547794) (xy 166.022763 114.547793) (xy 165.919992 114.502415) (xy 165.894865 114.4995) (xy 164.105143 114.4995) (xy 164.105117 114.499502) (xy 164.080012 114.502413) (xy 164.080008 114.502415) (xy 163.977235 114.547793) (xy 163.897794 114.627234) (xy 163.852415 114.730006) (xy 163.852415 114.730008) (xy 163.8495 114.755131) (xy 163.8495 116.544856) (xy 163.849502 116.544882) (xy 163.852413 116.569987) (xy 163.852415 116.569991) (xy 163.897793 116.672764) (xy 163.897794 116.672765) (xy 163.977235 116.752206) (xy 164.080009 116.797585) (xy 164.105135 116.8005) (xy 164.842873 116.800499) (xy 164.90991 116.820183) (xy 164.955665 116.872987) (xy 164.965609 116.942146) (xy 164.936584 117.005702) (xy 164.877806 117.043476) (xy 164.86227 117.046972) (xy 164.730589 117.067829) (xy 164.558363 117.123787) (xy 164.55836 117.123788) (xy 164.397002 117.206006) (xy 164.250505 117.312441) (xy 164.2505 117.312445) (xy 164.122445 117.4405) (xy 164.122441 117.440505) (xy 164.016006 117.587002) (xy 163.933788 117.74836) (xy 163.933787 117.748363) (xy 163.877829 117.920589) (xy 163.8495 118.099448) (xy 163.8495 118.28055) (xy 163.855033 118.315485) (xy 163.846078 118.384779) (xy 163.820241 118.422564) (xy 142.527035 139.715769) (xy 142.495689 139.743982) (xy 142.489873 139.752931) (xy 142.482321 139.760484) (xy 142.462844 139.794215) (xy 142.462845 139.794216) (xy 142.461216 139.797038) (xy 142.438235 139.83241) (xy 142.434934 139.842558) (xy 142.429593 139.85181) (xy 142.429591 139.851815) (xy 142.419509 139.889438) (xy 142.41951 139.889439) (xy 142.418665 139.89259) (xy 142.405625 139.932695) (xy 142.405063 139.943358) (xy 142.4023 139.953673) (xy 142.4023 139.992594) (xy 142.402129 139.999112) (xy 142.032247 147.0262) (xy 142.009065 147.092112) (xy 141.9961 147.107363) (xy 141.925377 147.178085) (xy 141.846326 147.315009) (xy 141.846323 147.315016) (xy 141.8054 147.467743) (xy 118.604548 147.467743) (xy 119.476173 146.596118) (xy 119.537496 146.562634) (xy 119.563854 146.5598) (xy 119.625655 146.5598) (xy 119.625657 146.5598) (xy 119.778384 146.518877) (xy 119.915316 146.43982) (xy 120.02712 146.328016) (xy 120.106177 146.191084) (xy 120.1471 146.038357) (xy 120.1471 145.880243) (xy 120.106177 145.727516) (xy 120.106173 145.727509) (xy 120.027124 145.59059) (xy 120.027118 145.590582) (xy 119.915317 145.478781) (xy 119.915309 145.478775) (xy 119.77839 145.399726) (xy 119.778386 145.399724) (xy 119.778384 145.399723) (xy 119.625657 145.3588) (xy 119.467543 145.3588) (xy 119.314816 145.399723) (xy 119.314809 145.399726) (xy 119.17789 145.478775) (xy 119.177882 145.478781) (xy 119.066081 145.590582) (xy 119.066075 145.59059) (xy 118.987026 145.727509) (xy 118.987023 145.727516) (xy 118.9461 145.880243) (xy 118.9461 145.942044) (xy 118.926415 146.009083) (xy 118.909781 146.029725) (xy 114.516498 150.423007) (xy 114.512823 150.426681) (xy 114.485342 150.44992) (xy 114.475689 150.463815) (xy 114.467859 150.471646) (xy 114.463722 150.475782) (xy 114.463718 150.475788) (xy 114.448303 150.502487) (xy 114.442762 150.511221) (xy 114.170682 150.90294) (xy 114.116273 150.946769) (xy 114.068841 150.9562) (xy 108.934598 150.9562) (xy 108.867559 150.936515) (xy 108.846917 150.919881) (xy 108.803217 150.876181) (xy 108.803209 150.876175) (xy 108.66629 150.797126) (xy 108.666286 150.797124) (xy 108.666284 150.797123) (xy 108.513557 150.7562) (xy 108.355443 150.7562) (xy 108.202716 150.797123) (xy 108.202709 150.797126) (xy 108.06579 150.876175) (xy 108.065782 150.876181) (xy 107.953981 150.987982) (xy 107.953975 150.98799) (xy 107.874926 151.124909) (xy 107.874923 151.124916) (xy 107.834 151.277643) (xy 107.834 151.435757) (xy 107.863698 151.546589) (xy 107.874923 151.588483) (xy 107.874926 151.58849) (xy 107.953975 151.725409) (xy 107.953979 151.725414) (xy 107.95398 151.725416) (xy 108.065784 151.83722) (xy 108.065786 151.837221) (xy 108.06579 151.837224) (xy 108.169732 151.897234) (xy 108.202716 151.916277) (xy 108.355443 151.9572) (xy 108.355445 151.9572) (xy 108.513555 151.9572) (xy 108.513557 151.9572) (xy 108.666284 151.916277) (xy 108.803216 151.83722) (xy 108.846917 151.793519) (xy 108.90824 151.760034) (xy 108.934598 151.7572) (xy 113.340223 151.7572) (xy 113.407262 151.776885) (xy 113.453017 151.829689) (xy 113.462961 151.898847) (xy 113.442066 151.951938) (xy 113.39122 152.025143) (xy 111.498706 154.74982) (xy 111.484544 154.766762) (xy 111.033553 155.217752) (xy 111.029796 155.221508) (xy 111.002567 155.244444) (xy 110.992667 155.258636) (xy 110.984924 155.26638) (xy 110.984919 155.266387) (xy 110.980419 155.270886) (xy 110.980418 155.270889) (xy 110.965259 155.297143) (xy 110.959582 155.306073) (xy 106.964427 161.034315) (xy 106.909931 161.078041) (xy 106.894814 161.083155) (xy 106.774014 161.115523) (xy 106.774009 161.115526) (xy 106.63709 161.194575) (xy 106.637082 161.194581) (xy 106.525281 161.306382) (xy 106.525275 161.30639) (xy 106.446226 161.443309) (xy 106.446223 161.443316) (xy 106.4053 161.596043) (xy 100.5005 161.596043) (xy 100.5005 131.593243) (xy 115.295 131.593243) (xy 115.295 131.751356) (xy 115.335923 131.904083) (xy 115.335926 131.90409) (xy 115.414975 132.041009) (xy 115.414981 132.041017) (xy 115.458681 132.084717) (xy 115.492166 132.14604) (xy 115.495 132.172398) (xy 115.495 145.141702) (xy 115.475315 145.208741) (xy 115.458681 145.229383) (xy 115.414981 145.273082) (xy 115.414975 145.27309) (xy 115.335926 145.410009) (xy 115.335923 145.410016) (xy 115.295 145.562743) (xy 115.295 145.720857) (xy 115.296785 145.727516) (xy 115.335923 145.873583) (xy 115.335926 145.87359) (xy 115.414975 146.010509) (xy 115.414979 146.010514) (xy 115.41498 146.010516) (xy 115.526784 146.12232) (xy 115.526786 146.122321) (xy 115.52679 146.122324) (xy 115.645886 146.191083) (xy 115.663716 146.201377) (xy 115.816443 146.2423) (xy 115.816445 146.2423) (xy 115.974555 146.2423) (xy 115.974557 146.2423) (xy 116.127284 146.201377) (xy 116.264216 146.12232) (xy 116.37602 146.010516) (xy 116.455077 145.873584) (xy 116.496 145.720857) (xy 116.496 145.562743) (xy 116.455077 145.410016) (xy 116.425508 145.3588) (xy 116.376024 145.27309) (xy 116.376018 145.273082) (xy 116.332319 145.229383) (xy 116.298834 145.16806) (xy 116.296 145.141702) (xy 116.296 132.172398) (xy 116.315685 132.105359) (xy 116.332319 132.084717) (xy 116.37602 132.041016) (xy 116.455077 131.904084) (xy 116.496 131.751357) (xy 116.496 131.593243) (xy 116.455077 131.440516) (xy 116.455073 131.440509) (xy 116.376024 131.30359) (xy 116.376018 131.303582) (xy 116.264217 131.191781) (xy 116.264209 131.191775) (xy 116.12729 131.112726) (xy 116.127286 131.112724) (xy 116.127284 131.112723) (xy 115.974557 131.0718) (xy 115.816443 131.0718) (xy 115.663716 131.112723) (xy 115.663709 131.112726) (xy 115.52679 131.191775) (xy 115.526782 131.191781) (xy 115.414981 131.303582) (xy 115.414975 131.30359) (xy 115.335926 131.440509) (xy 115.335923 131.440516) (xy 115.295 131.593243) (xy 100.5005 131.593243) (xy 100.5005 105.835131) (xy 103.8495 105.835131) (xy 103.8495 107.624856) (xy 103.849502 107.624882) (xy 103.852413 107.649987) (xy 103.852415 107.649991) (xy 103.897793 107.752764) (xy 103.897794 107.752765) (xy 103.977235 107.832206) (xy 104.080009 107.877585) (xy 104.105135 107.8805) (xy 104.846073 107.880499) (xy 104.913111 107.900183) (xy 104.958866 107.952987) (xy 104.96881 108.022146) (xy 104.939785 108.085702) (xy 104.881007 108.123476) (xy 104.86547 108.126972) (xy 104.730706 108.148316) (xy 104.558555 108.204251) (xy 104.558552 108.204252) (xy 104.397265 108.286434) (xy 104.25083 108.392823) (xy 104.122823 108.52083) (xy 104.016434 108.667265) (xy 103.934252 108.828552) (xy 103.934251 108.828555) (xy 103.878316 109.000706) (xy 103.867342 109.07) (xy 104.53812 109.07) (xy 104.534075 109.077007) (xy 104.5 109.204174) (xy 104.5 109.335826) (xy 104.534075 109.462993) (xy 104.53812 109.47) (xy 103.867342 109.47) (xy 103.878316 109.539293) (xy 103.934251 109.711444) (xy 103.934252 109.711447) (xy 104.016434 109.872734) (xy 104.122823 110.019169) (xy 104.25083 110.147176) (xy 104.397265 110.253565) (xy 104.558552 110.335747) (xy 104.558555 110.335748) (xy 104.7307 110.39168) (xy 104.8 110.402656) (xy 104.8 109.731879) (xy 104.807007 109.735925) (xy 104.934174 109.77) (xy 105.065826 109.77) (xy 105.192993 109.735925) (xy 105.2 109.731879) (xy 105.2 110.402655) (xy 105.269299 110.39168) (xy 105.441444 110.335748) (xy 105.441447 110.335747) (xy 105.602734 110.253565) (xy 105.749169 110.147176) (xy 105.877176 110.019169) (xy 105.983565 109.872734) (xy 106.065747 109.711447) (xy 106.065748 109.711444) (xy 106.121683 109.539293) (xy 106.132658 109.47) (xy 105.46188 109.47) (xy 105.465925 109.462993) (xy 105.5 109.335826) (xy 105.5 109.204174) (xy 105.465925 109.077007) (xy 105.46188 109.07) (xy 106.132658 109.07) (xy 106.121683 109.000706) (xy 106.065748 108.828555) (xy 106.065747 108.828552) (xy 105.983565 108.667265) (xy 105.877176 108.52083) (xy 105.749169 108.392823) (xy 105.602734 108.286434) (xy 105.441447 108.204252) (xy 105.441444 108.204251) (xy 105.269293 108.148317) (xy 105.134528 108.126972) (xy 105.071393 108.097043) (xy 105.034462 108.037731) (xy 105.03546 107.967869) (xy 105.07407 107.909636) (xy 105.138034 107.881522) (xy 105.153919 107.880499) (xy 105.894864 107.880499) (xy 105.894879 107.880497) (xy 105.894882 107.880497) (xy 105.919987 107.877586) (xy 105.919988 107.877585) (xy 105.919991 107.877585) (xy 106.022765 107.832206) (xy 106.102206 107.752765) (xy 106.147585 107.649991) (xy 106.1505 107.624865) (xy 106.150499 105.835136) (xy 106.150497 105.835117) (xy 106.147586 105.810012) (xy 106.147585 105.81001) (xy 106.147585 105.810009) (xy 106.102206 105.707235) (xy 106.022765 105.627794) (xy 106.022763 105.627793) (xy 105.919992 105.582415) (xy 105.894865 105.5795) (xy 104.105143 105.5795) (xy 104.105117 105.579502) (xy 104.080012 105.582413) (xy 104.080008 105.582415) (xy 103.977235 105.627793) (xy 103.897794 105.707234) (xy 103.852415 105.810006) (xy 103.852415 105.810008) (xy 103.8495 105.835131) (xy 100.5005 105.835131) (xy 100.5005 102.878711) (xy 101.1495 102.878711) (xy 101.1495 103.121288) (xy 101.181161 103.361785) (xy 101.243947 103.596104) (xy 101.336773 103.820205) (xy 101.336776 103.820212) (xy 101.458064 104.030289) (xy 101.458066 104.030292) (xy 101.458067 104.030293) (xy 101.605733 104.222736) (xy 101.605739 104.222743) (xy 101.777256 104.39426) (xy 101.777262 104.394265) (xy 101.969711 104.541936) (xy 102.179788 104.663224) (xy 102.4039 104.756054) (xy 102.638211 104.818838) (xy 102.818586 104.842584) (xy 102.878711 104.8505) (xy 102.878712 104.8505) (xy 103.121289 104.8505) (xy 103.169388 104.844167) (xy 103.361789 104.818838) (xy 103.5961 104.756054) (xy 103.820212 104.663224) (xy 104.030289 104.541936) (xy 104.222738 104.394265) (xy 104.394265 104.222738) (xy 104.541936 104.030289) (xy 104.663224 103.820212) (xy 104.756054 103.5961) (xy 104.818838 103.361789) (xy 104.8505 103.121288) (xy 104.8505 102.878712) (xy 104.8505 102.878711) (xy 165.1495 102.878711) (xy 165.1495 103.121288) (xy 165.181161 103.361785) (xy 165.243947 103.596104) (xy 165.336773 103.820205) (xy 165.336776 103.820212) (xy 165.458064 104.030289) (xy 165.458066 104.030292) (xy 165.458067 104.030293) (xy 165.605733 104.222736) (xy 165.605739 104.222743) (xy 165.777256 104.39426) (xy 165.777262 104.394265) (xy 165.969711 104.541936) (xy 166.179788 104.663224) (xy 166.4039 104.756054) (xy 166.638211 104.818838) (xy 166.818586 104.842584) (xy 166.878711 104.8505) (xy 166.878712 104.8505) (xy 167.121289 104.8505) (xy 167.169388 104.844167) (xy 167.361789 104.818838) (xy 167.5961 104.756054) (xy 167.820212 104.663224) (xy 168.030289 104.541936) (xy 168.222738 104.394265) (xy 168.394265 104.222738) (xy 168.541936 104.030289) (xy 168.663224 103.820212) (xy 168.756054 103.5961) (xy 168.818838 103.361789) (xy 168.8505 103.121288) (xy 168.8505 102.878712) (xy 168.818838 102.638211) (xy 168.756054 102.4039) (xy 168.663224 102.179788) (xy 168.541936 101.969711) (xy 168.394265 101.777262) (xy 168.39426 101.777256) (xy 168.222743 101.605739) (xy 168.222736 101.605733) (xy 168.030293 101.458067) (xy 168.030292 101.458066) (xy 168.030289 101.458064) (xy 167.820212 101.336776) (xy 167.820205 101.336773) (xy 167.596104 101.243947) (xy 167.361785 101.181161) (xy 167.121289 101.1495) (xy 167.121288 101.1495) (xy 166.878712 101.1495) (xy 166.878711 101.1495) (xy 166.638214 101.181161) (xy 166.403895 101.243947) (xy 166.179794 101.336773) (xy 166.179785 101.336777) (xy 165.969706 101.458067) (xy 165.777263 101.605733) (xy 165.777256 101.605739) (xy 165.605739 101.777256) (xy 165.605733 101.777263) (xy 165.458067 101.969706) (xy 165.336777 102.179785) (xy 165.336773 102.179794) (xy 165.243947 102.403895) (xy 165.181161 102.638214) (xy 165.1495 102.878711) (xy 104.8505 102.878711) (xy 104.818838 102.638211) (xy 104.756054 102.4039) (xy 104.663224 102.179788) (xy 104.541936 101.969711) (xy 104.394265 101.777262) (xy 104.39426 101.777256) (xy 104.222743 101.605739) (xy 104.222736 101.605733) (xy 104.030293 101.458067) (xy 104.030292 101.458066) (xy 104.030289 101.458064) (xy 103.820212 101.336776) (xy 103.820205 101.336773) (xy 103.596104 101.243947) (xy 103.361785 101.181161) (xy 103.121289 101.1495) (xy 103.121288 101.1495) (xy 102.878712 101.1495) (xy 102.878711 101.1495) (xy 102.638214 101.181161) (xy 102.403895 101.243947) (xy 102.179794 101.336773) (xy 102.179785 101.336777) (xy 101.969706 101.458067) (xy 101.777263 101.605733) (xy 101.777256 101.605739) (xy 101.605739 101.777256) (xy 101.605733 101.777263) (xy 101.458067 101.969706) (xy 101.336777 102.179785) (xy 101.336773 102.179794) (xy 101.243947 102.403895) (xy 101.181161 102.638214) (xy 101.1495 102.878711) (xy 100.5005 102.878711) (xy 100.5005 100.6245) (xy 100.520185 100.557461) (xy 100.572989 100.511706) (xy 100.6245 100.5005) (xy 169.3755 100.5005)
+			(pts (xy 169.442539 100.520185) (xy 169.488294 100.572989) (xy 169.4995 100.6245) (xy 169.4995 189.3755) (xy 169.479815 189.442539) (xy 169.427011 189.488294) (xy 169.3755 189.4995) (xy 100.6245 189.4995) (xy 100.557461 189.479815) (xy 100.511706 189.427011) (xy 100.5005 189.3755) (xy 100.5005 186.878711) (xy 101.1495 186.878711) (xy 101.1495 187.121288) (xy 101.181161 187.361785) (xy 101.243947 187.596104) (xy 101.336773 187.820205) (xy 101.336776 187.820212) (xy 101.458064 188.030289) (xy 101.458066 188.030292) (xy 101.458067 188.030293) (xy 101.605733 188.222736) (xy 101.605739 188.222743) (xy 101.777256 188.39426) (xy 101.777262 188.394265) (xy 101.969711 188.541936) (xy 102.179788 188.663224) (xy 102.4039 188.756054) (xy 102.638211 188.818838) (xy 102.818586 188.842584) (xy 102.878711 188.8505) (xy 102.878712 188.8505) (xy 103.121289 188.8505) (xy 103.169388 188.844167) (xy 103.361789 188.818838) (xy 103.5961 188.756054) (xy 103.820212 188.663224) (xy 104.030289 188.541936) (xy 104.222738 188.394265) (xy 104.394265 188.222738) (xy 104.541936 188.030289) (xy 104.663224 187.820212) (xy 104.756054 187.5961) (xy 104.818838 187.361789) (xy 104.8505 187.121288) (xy 104.8505 186.878712) (xy 104.8505 186.878711) (xy 165.1495 186.878711) (xy 165.1495 187.121288) (xy 165.181161 187.361785) (xy 165.243947 187.596104) (xy 165.336773 187.820205) (xy 165.336776 187.820212) (xy 165.458064 188.030289) (xy 165.458066 188.030292) (xy 165.458067 188.030293) (xy 165.605733 188.222736) (xy 165.605739 188.222743) (xy 165.777256 188.39426) (xy 165.777262 188.394265) (xy 165.969711 188.541936) (xy 166.179788 188.663224) (xy 166.4039 188.756054) (xy 166.638211 188.818838) (xy 166.818586 188.842584) (xy 166.878711 188.8505) (xy 166.878712 188.8505) (xy 167.121289 188.8505) (xy 167.169388 188.844167) (xy 167.361789 188.818838) (xy 167.5961 188.756054) (xy 167.820212 188.663224) (xy 168.030289 188.541936) (xy 168.222738 188.394265) (xy 168.394265 188.222738) (xy 168.541936 188.030289) (xy 168.663224 187.820212) (xy 168.756054 187.5961) (xy 168.818838 187.361789) (xy 168.8505 187.121288) (xy 168.8505 186.878712) (xy 168.818838 186.638211) (xy 168.756054 186.4039) (xy 168.663224 186.179788) (xy 168.541936 185.969711) (xy 168.394265 185.777262) (xy 168.39426 185.777256) (xy 168.222743 185.605739) (xy 168.222736 185.605733) (xy 168.030293 185.458067) (xy 168.030292 185.458066) (xy 168.030289 185.458064) (xy 167.820212 185.336776) (xy 167.820205 185.336773) (xy 167.596104 185.243947) (xy 167.361785 185.181161) (xy 167.121289 185.1495) (xy 167.121288 185.1495) (xy 166.878712 185.1495) (xy 166.878711 185.1495) (xy 166.638214 185.181161) (xy 166.403895 185.243947) (xy 166.179794 185.336773) (xy 166.179785 185.336777) (xy 165.969706 185.458067) (xy 165.777263 185.605733) (xy 165.777256 185.605739) (xy 165.605739 185.777256) (xy 165.605733 185.777263) (xy 165.458067 185.969706) (xy 165.336777 186.179785) (xy 165.336773 186.179794) (xy 165.243947 186.403895) (xy 165.181161 186.638214) (xy 165.1495 186.878711) (xy 104.8505 186.878711) (xy 104.818838 186.638211) (xy 104.756054 186.4039) (xy 104.663224 186.179788) (xy 104.541936 185.969711) (xy 104.394265 185.777262) (xy 104.39426 185.777256) (xy 104.222743 185.605739) (xy 104.222736 185.605733) (xy 104.030293 185.458067) (xy 104.030292 185.458066) (xy 104.030289 185.458064) (xy 103.820212 185.336776) (xy 103.820205 185.336773) (xy 103.596104 185.243947) (xy 103.361785 185.181161) (xy 103.121289 185.1495) (xy 103.121288 185.1495) (xy 102.878712 185.1495) (xy 102.878711 185.1495) (xy 102.638214 185.181161) (xy 102.403895 185.243947) (xy 102.179794 185.336773) (xy 102.179785 185.336777) (xy 101.969706 185.458067) (xy 101.777263 185.605733) (xy 101.777256 185.605739) (xy 101.605739 185.777256) (xy 101.605733 185.777263) (xy 101.458067 185.969706) (xy 101.336777 186.179785) (xy 101.336773 186.179794) (xy 101.243947 186.403895) (xy 101.181161 186.638214) (xy 101.1495 186.878711) (xy 100.5005 186.878711) (xy 100.5005 175.055131) (xy 104.2595 175.055131) (xy 104.2595 176.944856) (xy 104.259502 176.944882) (xy 104.262413 176.969987) (xy 104.262415 176.969991) (xy 104.307793 177.072764) (xy 104.307794 177.072765) (xy 104.387235 177.152206) (xy 104.490009 177.197585) (xy 104.515135 177.2005) (xy 106.404864 177.200499) (xy 106.404879 177.200497) (xy 106.404882 177.200497) (xy 106.429987 177.197586) (xy 106.429988 177.197585) (xy 106.429991 177.197585) (xy 106.532765 177.152206) (xy 106.612206 177.072765) (xy 106.657585 176.969991) (xy 106.6605 176.944865) (xy 106.660499 176.531906) (xy 106.680183 176.46487) (xy 106.732987 176.419115) (xy 106.802146 176.409171) (xy 106.865702 176.438196) (xy 106.894984 176.475614) (xy 106.923668 176.531909) (xy 106.97324 176.629199) (xy 107.08431 176.782073) (xy 107.217927 176.91569) (xy 107.370801 177.02676) (xy 107.448228 177.066211) (xy 107.539163 177.112545) (xy 107.539165 177.112545) (xy 107.539168 177.112547) (xy 107.635497 177.143846) (xy 107.718881 177.17094) (xy 107.905514 177.2005) (xy 107.905519 177.2005) (xy 108.094486 177.2005) (xy 108.281118 177.17094) (xy 108.460832 177.112547) (xy 108.629199 177.02676) (xy 108.782073 176.91569) (xy 108.91569 176.782073) (xy 109.02676 176.629199) (xy 109.112547 176.460832) (xy 109.152069 176.339195) (xy 109.191507 176.281521) (xy 109.255866 176.254323) (xy 109.324712 176.266238) (xy 109.376188 176.313482) (xy 109.387931 176.339196) (xy 109.427454 176.460836) (xy 109.463668 176.531909) (xy 109.51324 176.629199) (xy 109.62431 176.782073) (xy 109.757927 176.91569) (xy 109.910801 177.02676) (xy 109.988228 177.066211) (xy 110.079163 177.112545) (xy 110.079165 177.112545) (xy 110.079168 177.112547) (xy 110.175497 177.143846) (xy 110.258881 177.17094) (xy 110.445514 177.2005) (xy 110.445519 177.2005) (xy 110.634486 177.2005) (xy 110.821118 177.17094) (xy 111.000832 177.112547) (xy 111.169199 177.02676) (xy 111.322073 176.91569) (xy 111.45569 176.782073) (xy 111.56676 176.629199) (xy 111.652547 176.460832) (xy 111.71094 176.281118) (xy 111.712794 176.26941) (xy 111.7405 176.094486) (xy 111.7405 175.905513) (xy 111.71094 175.718881) (xy 111.669706 175.591977) (xy 111.652547 175.539168) (xy 111.652545 175.539165) (xy 111.652545 175.539163) (xy 111.595301 175.426816) (xy 111.56676 175.370801) (xy 111.45569 175.217927) (xy 111.322073 175.08431) (xy 111.169199 174.97324) (xy 111.000836 174.887454) (xy 110.821118 174.829059) (xy 110.634486 174.7995) (xy 110.634481 174.7995) (xy 110.445519 174.7995) (xy 110.445514 174.7995) (xy 110.258881 174.829059) (xy 110.079163 174.887454) (xy 109.9108 174.97324) (xy 109.832661 175.030012) (xy 109.757927 175.08431) (xy 109.757925 175.084312) (xy 109.757924 175.084312) (xy 109.624312 175.217924) (xy 109.624312 175.217925) (xy 109.62431 175.217927) (xy 109.596929 175.255614) (xy 109.51324 175.3708) (xy 109.427454 175.539163) (xy 109.387931 175.660803) (xy 109.348493 175.718478) (xy 109.284134 175.745676) (xy 109.215288 175.733761) (xy 109.163812 175.686516) (xy 109.152069 175.660803) (xy 109.124249 175.575182) (xy 109.112547 175.539168) (xy 109.112545 175.539165) (xy 109.112545 175.539163) (xy 109.055301 175.426816) (xy 109.02676 175.370801) (xy 108.91569 175.217927) (xy 108.782073 175.08431) (xy 108.629199 174.97324) (xy 108.460836 174.887454) (xy 108.281118 174.829059) (xy 108.094486 174.7995) (xy 108.094481 174.7995) (xy 107.905519 174.7995) (xy 107.905514 174.7995) (xy 107.718881 174.829059) (xy 107.539163 174.887454) (xy 107.3708 174.97324) (xy 107.292661 175.030012) (xy 107.217927 175.08431) (xy 107.217925 175.084312) (xy 107.217924 175.084312) (xy 107.084312 175.217924) (xy 107.084312 175.217925) (xy 107.08431 175.217927) (xy 107.056929 175.255614) (xy 106.97324 175.3708) (xy 106.894984 175.524386) (xy 106.847009 175.575182) (xy 106.779188 175.591977) (xy 106.713053 175.569439) (xy 106.669602 175.514724) (xy 106.660499 175.468091) (xy 106.660499 175.055143) (xy 106.660499 175.055136) (xy 106.658605 175.038802) (xy 106.657586 175.030012) (xy 106.657585 175.03001) (xy 106.657585 175.030009) (xy 106.612206 174.927235) (xy 106.532765 174.847794) (xy 106.530231 174.846675) (xy 106.429992 174.802415) (xy 106.404865 174.7995) (xy 104.515143 174.7995) (xy 104.515117 174.799502) (xy 104.490012 174.802413) (xy 104.490008 174.802415) (xy 104.387235 174.847793) (xy 104.307794 174.927234) (xy 104.262415 175.030006) (xy 104.262415 175.030008) (xy 104.2595 175.055131) (xy 100.5005 175.055131) (xy 100.5005 167.055131) (xy 104.2595 167.055131) (xy 104.2595 168.944856) (xy 104.259502 168.944882) (xy 104.262413 168.969987) (xy 104.262415 168.969991) (xy 104.307793 169.072764) (xy 104.307794 169.072765) (xy 104.387235 169.152206) (xy 104.490009 169.197585) (xy 104.515135 169.2005) (xy 106.404864 169.200499) (xy 106.404879 169.200497) (xy 106.404882 169.200497) (xy 106.429987 169.197586) (xy 106.429988 169.197585) (xy 106.429991 169.197585) (xy 106.532765 169.152206) (xy 106.612206 169.072765) (xy 106.657585 168.969991) (xy 106.6605 168.944865) (xy 106.660499 168.531906) (xy 106.680183 168.46487) (xy 106.732987 168.419115) (xy 106.802146 168.409171) (xy 106.865702 168.438196) (xy 106.894984 168.475614) (xy 106.923668 168.531909) (xy 106.97324 168.629199) (xy 107.08431 168.782073) (xy 107.217927 168.91569) (xy 107.370801 169.02676) (xy 107.438478 169.061243) (xy 107.539163 169.112545) (xy 107.539165 169.112545) (xy 107.539168 169.112547) (xy 107.635497 169.143846) (xy 107.718881 169.17094) (xy 107.905514 169.2005) (xy 107.905519 169.2005) (xy 108.094486 169.2005) (xy 108.281118 169.17094) (xy 108.335466 169.153281) (xy 108.460832 169.112547) (xy 108.629199 169.02676) (xy 108.782073 168.91569) (xy 108.91569 168.782073) (xy 109.02676 168.629199) (xy 109.112547 168.460832) (xy 109.152069 168.339195) (xy 109.191507 168.281521) (xy 109.255866 168.254323) (xy 109.324712 168.266238) (xy 109.376188 168.313482) (xy 109.387931 168.339196) (xy 109.427454 168.460836) (xy 109.463668 168.531909) (xy 109.51324 168.629199) (xy 109.62431 168.782073) (xy 109.757927 168.91569) (xy 109.910801 169.02676) (xy 109.978478 169.061243) (xy 110.079163 169.112545) (xy 110.079165 169.112545) (xy 110.079168 169.112547) (xy 110.175497 169.143846) (xy 110.258881 169.17094) (xy 110.445514 169.2005) (xy 110.445519 169.2005) (xy 110.634486 169.2005) (xy 110.821118 169.17094) (xy 110.875466 169.153281) (xy 111.000832 169.112547) (xy 111.169199 169.02676) (xy 111.322073 168.91569) (xy 111.45569 168.782073) (xy 111.56676 168.629199) (xy 111.652547 168.460832) (xy 111.71094 168.281118) (xy 111.715184 168.254323) (xy 111.7405 168.094486) (xy 111.7405 167.905513) (xy 111.71094 167.718881) (xy 111.669706 167.591977) (xy 111.652547 167.539168) (xy 111.652545 167.539165) (xy 111.652545 167.539163) (xy 111.566759 167.3708) (xy 111.45569 167.217927) (xy 111.322073 167.08431) (xy 111.169199 166.97324) (xy 111.150813 166.963872) (xy 111.000836 166.887454) (xy 110.821118 166.829059) (xy 110.634486 166.7995) (xy 110.634481 166.7995) (xy 110.445519 166.7995) (xy 110.445514 166.7995) (xy 110.258881 166.829059) (xy 110.079163 166.887454) (xy 109.9108 166.97324) (xy 109.832661 167.030012) (xy 109.757927 167.08431) (xy 109.757925 167.084312) (xy 109.757924 167.084312) (xy 109.624312 167.217924) (xy 109.624312 167.217925) (xy 109.62431 167.217927) (xy 109.57661 167.283579) (xy 109.51324 167.3708) (xy 109.427454 167.539163) (xy 109.387931 167.660803) (xy 109.348493 167.718478) (xy 109.284134 167.745676) (xy 109.215288 167.733761) (xy 109.163812 167.686516) (xy 109.152069 167.660803) (xy 109.124249 167.575182) (xy 109.112547 167.539168) (xy 109.112545 167.539165) (xy 109.112545 167.539163) (xy 109.026759 167.3708) (xy 108.91569 167.217927) (xy 108.782073 167.08431) (xy 108.629199 166.97324) (xy 108.610813 166.963872) (xy 108.460836 166.887454) (xy 108.281118 166.829059) (xy 108.094486 166.7995) (xy 108.094481 166.7995) (xy 107.905519 166.7995) (xy 107.905514 166.7995) (xy 107.718881 166.829059) (xy 107.539163 166.887454) (xy 107.3708 166.97324) (xy 107.292661 167.030012) (xy 107.217927 167.08431) (xy 107.217925 167.084312) (xy 107.217924 167.084312) (xy 107.084312 167.217924) (xy 107.084312 167.217925) (xy 107.08431 167.217927) (xy 107.03661 167.283579) (xy 106.97324 167.3708) (xy 106.894984 167.524386) (xy 106.847009 167.575182) (xy 106.779188 167.591977) (xy 106.713053 167.569439) (xy 106.669602 167.514724) (xy 106.660499 167.468091) (xy 106.660499 167.055143) (xy 106.660499 167.055136) (xy 106.660497 167.055117) (xy 106.657586 167.030012) (xy 106.657585 167.03001) (xy 106.657585 167.030009) (xy 106.612206 166.927235) (xy 106.532765 166.847794) (xy 106.532763 166.847793) (xy 106.429992 166.802415) (xy 106.404865 166.7995) (xy 104.515143 166.7995) (xy 104.515117 166.799502) (xy 104.490012 166.802413) (xy 104.490008 166.802415) (xy 104.387235 166.847793) (xy 104.307794 166.927234) (xy 104.262415 167.030006) (xy 104.262415 167.030008) (xy 104.2595 167.055131) (xy 100.5005 167.055131) (xy 100.5005 161.596043) (xy 106.4053 161.596043) (xy 106.4053 161.754157) (xy 106.44575 161.905116) (xy 106.446223 161.906883) (xy 106.446226 161.90689) (xy 106.525275 162.043809) (xy 106.525279 162.043814) (xy 106.52528 162.043816) (xy 106.637084 162.15562) (xy 106.637086 162.155621) (xy 106.63709 162.155624) (xy 106.756186 162.224383) (xy 106.774016 162.234677) (xy 106.926743 162.2756) (xy 106.926745 162.2756) (xy 107.084855 162.2756) (xy 107.084857 162.2756) (xy 107.237584 162.234677) (xy 107.374516 162.15562) (xy 107.48632 162.043816) (xy 107.565377 161.906884) (xy 107.6063 161.754157) (xy 107.6063 161.596043) (xy 107.605388 161.592639) (xy 107.605458 161.589656) (xy 107.605239 161.587986) (xy 107.605499 161.587951) (xy 107.607049 161.52279) (xy 107.623456 161.489609) (xy 107.623765 161.489166) (xy 111.602868 155.783943) (xy 111.616882 155.767209) (xy 112.072263 155.311828) (xy 112.099758 155.28858) (xy 112.109414 155.274677) (xy 112.12138 155.262712) (xy 112.136797 155.236007) (xy 112.142326 155.227293) (xy 114.41733 151.951939) (xy 114.515598 151.810461) (xy 114.570009 151.76663) (xy 114.617441 151.7572) (xy 115.223621 151.7572) (xy 115.239202 151.760094) (xy 115.276157 151.7572) (xy 115.313227 151.7572) (xy 115.317499 151.756055) (xy 115.33991 151.752207) (xy 118.88643 151.474477) (xy 118.896111 151.4741) (xy 119.0221 151.4741) (xy 119.089139 151.493785) (xy 119.134894 151.546589) (xy 119.1461 151.5981) (xy 119.1461 174.6027) (xy 119.126415 174.669739) (xy 119.073611 174.715494) (xy 119.0221 174.7267) (xy 118.991343 174.7267) (xy 118.838616 174.767623) (xy 118.838609 174.767626) (xy 118.70169 174.846675) (xy 118.701682 174.846681) (xy 118.589881 174.958482) (xy 118.589875 174.95849) (xy 118.510826 175.095409) (xy 118.510823 175.095416) (xy 118.4699 175.248143) (xy 118.4699 175.406256) (xy 118.475409 175.426816) (xy 118.473746 175.496666) (xy 118.443315 175.54659) (xy 111.838526 182.151381) (xy 111.777203 182.184866) (xy 111.750845 182.1877) (xy 111.689043 182.1877) (xy 111.536316 182.228623) (xy 111.536309 182.228626) (xy 111.39939 182.307675) (xy 111.399382 182.307681) (xy 111.287581 182.419482) (xy 111.287575 182.41949) (xy 111.208526 182.556409) (xy 111.208523 182.556416) (xy 111.1676 182.709143) (xy 111.1676 182.867256) (xy 111.208523 183.019983) (xy 111.208526 183.01999) (xy 111.287575 183.156909) (xy 111.287579 183.156914) (xy 111.28758 183.156916) (xy 111.399384 183.26872) (xy 111.399386 183.268721) (xy 111.39939 183.268724) (xy 111.536309 183.347773) (xy 111.536316 183.347777) (xy 111.689043 183.3887) (xy 111.689045 183.3887) (xy 111.847155 183.3887) (xy 111.847157 183.3887) (xy 111.999884 183.347777) (xy 112.136816 183.26872) (xy 112.24862 183.156916) (xy 112.327677 183.019984) (xy 112.3686 182.867257) (xy 112.3686 182.805454) (xy 112.388285 182.738415) (xy 112.404914 182.717778) (xy 119.188166 175.934525) (xy 119.243753 175.902433) (xy 119.302182 175.886778) (xy 119.302186 175.886776) (xy 119.439109 175.807724) (xy 119.439108 175.807724) (xy 119.439116 175.80772) (xy 119.55092 175.695916) (xy 119.629977 175.558984) (xy 119.629978 175.558981) (xy 119.645633 175.500554) (xy 119.677725 175.444966) (xy 119.86708 175.255613) (xy 119.919807 175.164288) (xy 119.9471 175.062427) (xy 119.9471 175.062418) (xy 119.948161 175.054367) (xy 119.951062 175.054748) (xy 119.955744 175.038802) (xy 119.962267 175.008817) (xy 119.966022 175.0038) (xy 119.966785 175.001203) (xy 119.983418 174.980562) (xy 119.99074 174.97324) (xy 120.055412 174.908566) (xy 120.116732 174.875082) (xy 120.186424 174.880066) (xy 120.242358 174.921936) (xy 120.266776 174.9874) (xy 120.262745 175.028793) (xy 120.262415 175.030003) (xy 120.2595 175.055131) (xy 120.2595 176.944856) (xy 120.259502 176.944882) (xy 120.262413 176.969987) (xy 120.262415 176.969991) (xy 120.307793 177.072764) (xy 120.307794 177.072765) (xy 120.387235 177.152206) (xy 120.490009 177.197585) (xy 120.515135 177.2005) (xy 122.404864 177.200499) (xy 122.404879 177.200497) (xy 122.404882 177.200497) (xy 122.429987 177.197586) (xy 122.429988 177.197585) (xy 122.429991 177.197585) (xy 122.532765 177.152206) (xy 122.612206 177.072765) (xy 122.657585 176.969991) (xy 122.6605 176.944865) (xy 122.660499 176.531906) (xy 122.680183 176.46487) (xy 122.732987 176.419115) (xy 122.802146 176.409171) (xy 122.865702 176.438196) (xy 122.894984 176.475614) (xy 122.923668 176.531909) (xy 122.97324 176.629199) (xy 123.08431 176.782073) (xy 123.217927 176.91569) (xy 123.370801 177.02676) (xy 123.448228 177.066211) (xy 123.539163 177.112545) (xy 123.539165 177.112545) (xy 123.539168 177.112547) (xy 123.635497 177.143846) (xy 123.718881 177.17094) (xy 123.905514 177.2005) (xy 123.905519 177.2005) (xy 124.094486 177.2005) (xy 124.281118 177.17094) (xy 124.460832 177.112547) (xy 124.629199 177.02676) (xy 124.782073 176.91569) (xy 124.91569 176.782073) (xy 125.02676 176.629199) (xy 125.112547 176.460832) (xy 125.152069 176.339195) (xy 125.191507 176.281521) (xy 125.255866 176.254323) (xy 125.324712 176.266238) (xy 125.376188 176.313482) (xy 125.387931 176.339196) (xy 125.427454 176.460836) (xy 125.463668 176.531909) (xy 125.51324 176.629199) (xy 125.62431 176.782073) (xy 125.757927 176.91569) (xy 125.910801 177.02676) (xy 125.988228 177.066211) (xy 126.079163 177.112545) (xy 126.079165 177.112545) (xy 126.079168 177.112547) (xy 126.175497 177.143846) (xy 126.258881 177.17094) (xy 126.445514 177.2005) (xy 126.445519 177.2005) (xy 126.634486 177.2005) (xy 126.821118 177.17094) (xy 127.000832 177.112547) (xy 127.169199 177.02676) (xy 127.322073 176.91569) (xy 127.45569 176.782073) (xy 127.56676 176.629199) (xy 127.652547 176.460832) (xy 127.71094 176.281118) (xy 127.712794 176.26941) (xy 127.7405 176.094486) (xy 127.7405 175.905513) (xy 127.71094 175.718881) (xy 127.669706 175.591977) (xy 127.652547 175.539168) (xy 127.652545 175.539165) (xy 127.652545 175.539163) (xy 127.595301 175.426816) (xy 127.56676 175.370801) (xy 127.45569 175.217927) (xy 127.322073 175.08431) (xy 127.281912 175.055131) (xy 136.2595 175.055131) (xy 136.2595 176.944856) (xy 136.259502 176.944882) (xy 136.262413 176.969987) (xy 136.262415 176.969991) (xy 136.307793 177.072764) (xy 136.307794 177.072765) (xy 136.387235 177.152206) (xy 136.490009 177.197585) (xy 136.515135 177.2005) (xy 138.404864 177.200499) (xy 138.404879 177.200497) (xy 138.404882 177.200497) (xy 138.429987 177.197586) (xy 138.429988 177.197585) (xy 138.429991 177.197585) (xy 138.532765 177.152206) (xy 138.612206 177.072765) (xy 138.657585 176.969991) (xy 138.6605 176.944865) (xy 138.660499 176.531906) (xy 138.680183 176.46487) (xy 138.732987 176.419115) (xy 138.802146 176.409171) (xy 138.865702 176.438196) (xy 138.894984 176.475614) (xy 138.923668 176.531909) (xy 138.97324 176.629199) (xy 139.08431 176.782073) (xy 139.217927 176.91569) (xy 139.370801 177.02676) (xy 139.448228 177.066211) (xy 139.539163 177.112545) (xy 139.539165 177.112545) (xy 139.539168 177.112547) (xy 139.635497 177.143846) (xy 139.718881 177.17094) (xy 139.905514 177.2005) (xy 139.905519 177.2005) (xy 140.094486 177.2005) (xy 140.281118 177.17094) (xy 140.460832 177.112547) (xy 140.629199 177.02676) (xy 140.782073 176.91569) (xy 140.91569 176.782073) (xy 141.02676 176.629199) (xy 141.112547 176.460832) (xy 141.152069 176.339195) (xy 141.191507 176.281521) (xy 141.255866 176.254323) (xy 141.324712 176.266238) (xy 141.376188 176.313482) (xy 141.387931 176.339196) (xy 141.427454 176.460836) (xy 141.463668 176.531909) (xy 141.51324 176.629199) (xy 141.62431 176.782073) (xy 141.757927 176.91569) (xy 141.910801 177.02676) (xy 141.988228 177.066211) (xy 142.079163 177.112545) (xy 142.079165 177.112545) (xy 142.079168 177.112547) (xy 142.175497 177.143846) (xy 142.258881 177.17094) (xy 142.445514 177.2005) (xy 142.445519 177.2005) (xy 142.634486 177.2005) (xy 142.821118 177.17094) (xy 143.000832 177.112547) (xy 143.169199 177.02676) (xy 143.322073 176.91569) (xy 143.45569 176.782073) (xy 143.56676 176.629199) (xy 143.652547 176.460832) (xy 143.71094 176.281118) (xy 143.712794 176.26941) (xy 143.7405 176.094486) (xy 143.7405 175.905513) (xy 143.71094 175.718881) (xy 143.669706 175.591977) (xy 143.652547 175.539168) (xy 143.652545 175.539165) (xy 143.652545 175.539163) (xy 143.595301 175.426816) (xy 143.56676 175.370801) (xy 143.45569 175.217927) (xy 143.322073 175.08431) (xy 143.169199 174.97324) (xy 143.000836 174.887454) (xy 142.821118 174.829059) (xy 142.634486 174.7995) (xy 142.634481 174.7995) (xy 142.445519 174.7995) (xy 142.445514 174.7995) (xy 142.258881 174.829059) (xy 142.079163 174.887454) (xy 141.9108 174.97324) (xy 141.832661 175.030012) (xy 141.757927 175.08431) (xy 141.757925 175.084312) (xy 141.757924 175.084312) (xy 141.624312 175.217924) (xy 141.624312 175.217925) (xy 141.62431 175.217927) (xy 141.596929 175.255614) (xy 141.51324 175.3708) (xy 141.427454 175.539163) (xy 141.387931 175.660803) (xy 141.348493 175.718478) (xy 141.284134 175.745676) (xy 141.215288 175.733761) (xy 141.163812 175.686516) (xy 141.152069 175.660803) (xy 141.124249 175.575182) (xy 141.112547 175.539168) (xy 141.112545 175.539165) (xy 141.112545 175.539163) (xy 141.055301 175.426816) (xy 141.02676 175.370801) (xy 140.91569 175.217927) (xy 140.782073 175.08431) (xy 140.629199 174.97324) (xy 140.460836 174.887454) (xy 140.281118 174.829059) (xy 140.094486 174.7995) (xy 140.094481 174.7995) (xy 139.905519 174.7995) (xy 139.905514 174.7995) (xy 139.718881 174.829059) (xy 139.539163 174.887454) (xy 139.3708 174.97324) (xy 139.292661 175.030012) (xy 139.217927 175.08431) (xy 139.217925 175.084312) (xy 139.217924 175.084312) (xy 139.084312 175.217924) (xy 139.084312 175.217925) (xy 139.08431 175.217927) (xy 139.056929 175.255614) (xy 138.97324 175.3708) (xy 138.894984 175.524386) (xy 138.847009 175.575182) (xy 138.779188 175.591977) (xy 138.713053 175.569439) (xy 138.669602 175.514724) (xy 138.660499 175.468091) (xy 138.660499 175.055143) (xy 138.660499 175.055136) (xy 138.658605 175.038802) (xy 138.657586 175.030012) (xy 138.657585 175.03001) (xy 138.657585 175.030009) (xy 138.612206 174.927235) (xy 138.532765 174.847794) (xy 138.530231 174.846675) (xy 138.429992 174.802415) (xy 138.404865 174.7995) (xy 136.515143 174.7995) (xy 136.515117 174.799502) (xy 136.490012 174.802413) (xy 136.490008 174.802415) (xy 136.387235 174.847793) (xy 136.307794 174.927234) (xy 136.262415 175.030006) (xy 136.262415 175.030008) (xy 136.2595 175.055131) (xy 127.281912 175.055131) (xy 127.169199 174.97324) (xy 127.000836 174.887454) (xy 126.821118 174.829059) (xy 126.634486 174.7995) (xy 126.634481 174.7995) (xy 126.445519 174.7995) (xy 126.445514 174.7995) (xy 126.258881 174.829059) (xy 126.079163 174.887454) (xy 125.9108 174.97324) (xy 125.832661 175.030012) (xy 125.757927 175.08431) (xy 125.757925 175.084312) (xy 125.757924 175.084312) (xy 125.624312 175.217924) (xy 125.624312 175.217925) (xy 125.62431 175.217927) (xy 125.596929 175.255614) (xy 125.51324 175.3708) (xy 125.427454 175.539163) (xy 125.387931 175.660803) (xy 125.348493 175.718478) (xy 125.284134 175.745676) (xy 125.215288 175.733761) (xy 125.163812 175.686516) (xy 125.152069 175.660803) (xy 125.124249 175.575182) (xy 125.112547 175.539168) (xy 125.112545 175.539165) (xy 125.112545 175.539163) (xy 125.055301 175.426816) (xy 125.02676 175.370801) (xy 124.91569 175.217927) (xy 124.782073 175.08431) (xy 124.629199 174.97324) (xy 124.460836 174.887454) (xy 124.281118 174.829059) (xy 124.094486 174.7995) (xy 124.094481 174.7995) (xy 123.905519 174.7995) (xy 123.905514 174.7995) (xy 123.718881 174.829059) (xy 123.539163 174.887454) (xy 123.3708 174.97324) (xy 123.292661 175.030012) (xy 123.217927 175.08431) (xy 123.217925 175.084312) (xy 123.217924 175.084312) (xy 123.084312 175.217924) (xy 123.084312 175.217925) (xy 123.08431 175.217927) (xy 123.056929 175.255614) (xy 122.97324 175.3708) (xy 122.894984 175.524386) (xy 122.847009 175.575182) (xy 122.779188 175.591977) (xy 122.713053 175.569439) (xy 122.669602 175.514724) (xy 122.660499 175.468091) (xy 122.660499 175.055143) (xy 122.660499 175.055136) (xy 122.658605 175.038802) (xy 122.657586 175.030012) (xy 122.657585 175.03001) (xy 122.657585 175.030009) (xy 122.612206 174.927235) (xy 122.532765 174.847794) (xy 122.530231 174.846675) (xy 122.429992 174.802415) (xy 122.404865 174.7995) (xy 120.515143 174.7995) (xy 120.515117 174.799502) (xy 120.490008 174.802414) (xy 120.488782 174.802748) (xy 120.487375 174.802719) (xy 120.480742 174.803489) (xy 120.480637 174.802584) (xy 120.418927 174.801347) (xy 120.360918 174.762401) (xy 120.333173 174.698277) (xy 120.344501 174.629331) (xy 120.368553 174.595419) (xy 122.398806 172.565131) (xy 163.8495 172.565131) (xy 163.8495 174.354856) (xy 163.849502 174.354882) (xy 163.852413 174.379987) (xy 163.852415 174.379991) (xy 163.897793 174.482764) (xy 163.897794 174.482765) (xy 163.977235 174.562206) (xy 164.080009 174.607585) (xy 164.105135 174.6105) (xy 164.842873 174.610499) (xy 164.90991 174.630183) (xy 164.955665 174.682987) (xy 164.965609 174.752146) (xy 164.936584 174.815702) (xy 164.877806 174.853476) (xy 164.86227 174.856972) (xy 164.730589 174.877829) (xy 164.558363 174.933787) (xy 164.55836 174.933788) (xy 164.397002 175.016006) (xy 164.250505 175.122441) (xy 164.2505 175.122445) (xy 164.122445 175.2505) (xy 164.122441 175.250505) (xy 164.016006 175.397002) (xy 163.933788 175.55836) (xy 163.933787 175.558363) (xy 163.877829 175.730589) (xy 163.8495 175.909448) (xy 163.8495 176.090551) (xy 163.877829 176.26941) (xy 163.933787 176.441636) (xy 163.933788 176.441639) (xy 164.016006 176.602997) (xy 164.122441 176.749494) (xy 164.122445 176.749499) (xy 164.2505 176.877554) (xy 164.250505 176.877558) (xy 164.34317 176.944882) (xy 164.397006 176.983996) (xy 164.480933 177.026759) (xy 164.55836 177.066211) (xy 164.558363 177.066212) (xy 164.578529 177.072764) (xy 164.730591 177.122171) (xy 164.803639 177.13374) (xy 164.890678 177.147527) (xy 164.953813 177.177456) (xy 164.990744 177.236768) (xy 164.989746 177.306631) (xy 164.951136 177.364863) (xy 164.890678 177.392473) (xy 164.730589 177.417829) (xy 164.558363 177.473787) (xy 164.55836 177.473788) (xy 164.397002 177.556006) (xy 164.250505 177.662441) (xy 164.2505 177.662445) (xy 164.122445 177.7905) (xy 164.122441 177.790505) (xy 164.016006 177.937002) (xy 163.933788 178.09836) (xy 163.933787 178.098363) (xy 163.877829 178.270589) (xy 163.8495 178.449448) (xy 163.8495 178.630551) (xy 163.877829 178.80941) (xy 163.933787 178.981636) (xy 163.933788 178.981639) (xy 164.016006 179.142997) (xy 164.122441 179.289494) (xy 164.122445 179.289499) (xy 164.2505 179.417554) (xy 164.250505 179.417558) (xy 164.378287 179.510396) (xy 164.397006 179.523996) (xy 164.502484 179.57774) (xy 164.55836 179.606211) (xy 164.558363 179.606212) (xy 164.644476 179.634191) (xy 164.730591 179.662171) (xy 164.813429 179.675291) (xy 164.909449 179.6905) (xy 164.909454 179.6905) (xy 165.090551 179.6905) (xy 165.177259 179.676765) (xy 165.269409 179.662171) (xy 165.441639 179.606211) (xy 165.602994 179.523996) (xy 165.749501 179.417553) (xy 165.877553 179.289501) (xy 165.983996 179.142994) (xy 166.066211 178.981639) (xy 166.122171 178.809409) (xy 166.136765 178.717259) (xy 166.1505 178.630551) (xy 166.1505 178.449448) (xy 166.134019 178.345397) (xy 166.122171 178.270591) (xy 166.066211 178.098361) (xy 166.066211 178.09836) (xy 166.03774 178.042484) (xy 165.983996 177.937006) (xy 165.970396 177.918287) (xy 165.877558 177.790505) (xy 165.877554 177.7905) (xy 165.749499 177.662445) (xy 165.749494 177.662441) (xy 165.602997 177.556006) (xy 165.602996 177.556005) (xy 165.602994 177.556004) (xy 165.5513 177.529664) (xy 165.441639 177.473788) (xy 165.441636 177.473787) (xy 165.26941 177.417829) (xy 165.109321 177.392473) (xy 165.046186 177.362544) (xy 165.009255 177.303232) (xy 165.010253 177.23337) (xy 165.048863 177.175137) (xy 165.109321 177.147527) (xy 165.179425 177.136422) (xy 165.269409 177.122171) (xy 165.441639 177.066211) (xy 165.602994 176.983996) (xy 165.749501 176.877553) (xy 165.877553 176.749501) (xy 165.983996 176.602994) (xy 166.066211 176.441639) (xy 166.122171 176.269409) (xy 166.136765 176.177259) (xy 166.1505 176.090551) (xy 166.1505 175.909448) (xy 166.12456 175.745676) (xy 166.122171 175.730591) (xy 166.094191 175.644476) (xy 166.066212 175.558363) (xy 166.066211 175.55836) (xy 166.020216 175.468091) (xy 165.983996 175.397006) (xy 165.964956 175.3708) (xy 165.877558 175.250505) (xy 165.877554 175.2505) (xy 165.749499 175.122445) (xy 165.749494 175.122441) (xy 165.602997 175.016006) (xy 165.602996 175.016005) (xy 165.602994 175.016004) (xy 165.533436 174.980562) (xy 165.441639 174.933788) (xy 165.441636 174.933787) (xy 165.26941 174.877829) (xy 165.137728 174.856972) (xy 165.074594 174.827042) (xy 165.037663 174.767731) (xy 165.038661 174.697868) (xy 165.077271 174.639636) (xy 165.141235 174.611522) (xy 165.15712 174.610499) (xy 165.894864 174.610499) (xy 165.894879 174.610497) (xy 165.894882 174.610497) (xy 165.919987 174.607586) (xy 165.919988 174.607585) (xy 165.919991 174.607585) (xy 166.022765 174.562206) (xy 166.102206 174.482765) (xy 166.147585 174.379991) (xy 166.1505 174.354865) (xy 166.150499 172.565136) (xy 166.150497 172.565117) (xy 166.147586 172.540012) (xy 166.147585 172.54001) (xy 166.147585 172.540009) (xy 166.102206 172.437235) (xy 166.022765 172.357794) (xy 166.022763 172.357793) (xy 165.919992 172.312415) (xy 165.894865 172.3095) (xy 164.105143 172.3095) (xy 164.105117 172.309502) (xy 164.080012 172.312413) (xy 164.080008 172.312415) (xy 163.977235 172.357793) (xy 163.897794 172.437234) (xy 163.852415 172.540006) (xy 163.852415 172.540008) (xy 163.8495 172.565131) (xy 122.398806 172.565131) (xy 124.944767 170.019127) (xy 125.006089 169.985642) (xy 125.014906 169.984055) (xy 127.591754 169.616) (xy 127.616024 169.616001) (xy 127.64373 169.608576) (xy 127.651099 169.607524) (xy 127.6511 169.607524) (xy 127.663385 169.605769) (xy 127.672127 169.604521) (xy 127.694442 169.594989) (xy 127.717885 169.588708) (xy 127.742727 169.574365) (xy 127.769104 169.563099) (xy 127.788194 169.548114) (xy 127.809211 169.535981) (xy 127.829491 169.5157) (xy 127.852057 169.497989) (xy 127.861336 169.485615) (xy 127.87284 169.47235) (xy 130.29009 167.055131) (xy 136.2595 167.055131) (xy 136.2595 168.944856) (xy 136.259502 168.944882) (xy 136.262413 168.969987) (xy 136.262415 168.969991) (xy 136.307793 169.072764) (xy 136.307794 169.072765) (xy 136.387235 169.152206) (xy 136.490009 169.197585) (xy 136.515135 169.2005) (xy 138.404864 169.200499) (xy 138.404879 169.200497) (xy 138.404882 169.200497) (xy 138.429987 169.197586) (xy 138.429988 169.197585) (xy 138.429991 169.197585) (xy 138.532765 169.152206) (xy 138.612206 169.072765) (xy 138.657585 168.969991) (xy 138.6605 168.944865) (xy 138.660499 168.531906) (xy 138.680183 168.46487) (xy 138.732987 168.419115) (xy 138.802146 168.409171) (xy 138.865702 168.438196) (xy 138.894984 168.475614) (xy 138.923668 168.531909) (xy 138.97324 168.629199) (xy 139.08431 168.782073) (xy 139.217927 168.91569) (xy 139.370801 169.02676) (xy 139.438478 169.061243) (xy 139.539163 169.112545) (xy 139.539165 169.112545) (xy 139.539168 169.112547) (xy 139.635497 169.143846) (xy 139.718881 169.17094) (xy 139.905514 169.2005) (xy 139.905519 169.2005) (xy 140.094486 169.2005) (xy 140.281118 169.17094) (xy 140.335466 169.153281) (xy 140.460832 169.112547) (xy 140.629199 169.02676) (xy 140.782073 168.91569) (xy 140.91569 168.782073) (xy 141.02676 168.629199) (xy 141.112547 168.460832) (xy 141.152069 168.339195) (xy 141.191507 168.281521) (xy 141.255866 168.254323) (xy 141.324712 168.266238) (xy 141.376188 168.313482) (xy 141.387931 168.339196) (xy 141.427454 168.460836) (xy 141.463668 168.531909) (xy 141.51324 168.629199) (xy 141.62431 168.782073) (xy 141.757927 168.91569) (xy 141.910801 169.02676) (xy 141.978478 169.061243) (xy 142.079163 169.112545) (xy 142.079165 169.112545) (xy 142.079168 169.112547) (xy 142.175497 169.143846) (xy 142.258881 169.17094) (xy 142.445514 169.2005) (xy 142.445519 169.2005) (xy 142.634486 169.2005) (xy 142.821118 169.17094) (xy 142.875466 169.153281) (xy 143.000832 169.112547) (xy 143.169199 169.02676) (xy 143.322073 168.91569) (xy 143.45569 168.782073) (xy 143.56676 168.629199) (xy 143.652547 168.460832) (xy 143.71094 168.281118) (xy 143.715184 168.254323) (xy 143.7405 168.094486) (xy 143.7405 167.905513) (xy 143.71094 167.718881) (xy 143.669706 167.591977) (xy 143.652547 167.539168) (xy 143.652545 167.539165) (xy 143.652545 167.539163) (xy 143.566759 167.3708) (xy 143.45569 167.217927) (xy 143.322073 167.08431) (xy 143.169199 166.97324) (xy 143.150813 166.963872) (xy 143.000836 166.887454) (xy 142.821118 166.829059) (xy 142.634486 166.7995) (xy 142.634481 166.7995) (xy 142.445519 166.7995) (xy 142.445514 166.7995) (xy 142.258881 166.829059) (xy 142.079163 166.887454) (xy 141.9108 166.97324) (xy 141.832661 167.030012) (xy 141.757927 167.08431) (xy 141.757925 167.084312) (xy 141.757924 167.084312) (xy 141.624312 167.217924) (xy 141.624312 167.217925) (xy 141.62431 167.217927) (xy 141.57661 167.283579) (xy 141.51324 167.3708) (xy 141.427454 167.539163) (xy 141.387931 167.660803) (xy 141.348493 167.718478) (xy 141.284134 167.745676) (xy 141.215288 167.733761) (xy 141.163812 167.686516) (xy 141.152069 167.660803) (xy 141.124249 167.575182) (xy 141.112547 167.539168) (xy 141.112545 167.539165) (xy 141.112545 167.539163) (xy 141.026759 167.3708) (xy 140.91569 167.217927) (xy 140.782073 167.08431) (xy 140.629199 166.97324) (xy 140.610813 166.963872) (xy 140.460836 166.887454) (xy 140.281118 166.829059) (xy 140.094486 166.7995) (xy 140.094481 166.7995) (xy 139.905519 166.7995) (xy 139.905514 166.7995) (xy 139.718881 166.829059) (xy 139.539163 166.887454) (xy 139.3708 166.97324) (xy 139.292661 167.030012) (xy 139.217927 167.08431) (xy 139.217925 167.084312) (xy 139.217924 167.084312) (xy 139.084312 167.217924) (xy 139.084312 167.217925) (xy 139.08431 167.217927) (xy 139.03661 167.283579) (xy 138.97324 167.3708) (xy 138.894984 167.524386) (xy 138.847009 167.575182) (xy 138.779188 167.591977) (xy 138.713053 167.569439) (xy 138.669602 167.514724) (xy 138.660499 167.468091) (xy 138.660499 167.055143) (xy 138.660499 167.055136) (xy 138.660497 167.055117) (xy 138.657586 167.030012) (xy 138.657585 167.03001) (xy 138.657585 167.030009) (xy 138.612206 166.927235) (xy 138.532765 166.847794) (xy 138.532763 166.847793) (xy 138.429992 166.802415) (xy 138.404865 166.7995) (xy 136.515143 166.7995) (xy 136.515117 166.799502) (xy 136.490012 166.802413) (xy 136.490008 166.802415) (xy 136.387235 166.847793) (xy 136.307794 166.927234) (xy 136.262415 167.030006) (xy 136.262415 167.030008) (xy 136.2595 167.055131) (xy 130.29009 167.055131) (xy 135.777176 161.568116) (xy 135.809254 161.538902) (xy 135.814374 161.530918) (xy 135.821079 161.524214) (xy 135.841336 161.489125) (xy 135.844316 161.484231) (xy 135.866186 161.450136) (xy 135.86793 161.44466) (xy 135.869064 161.441099) (xy 135.873806 161.43289) (xy 135.885033 161.39099) (xy 135.898203 161.349661) (xy 135.898203 161.349658) (xy 135.898204 161.349656) (xy 135.899638 161.341665) (xy 135.899865 161.341705) (xy 135.900268 161.339117) (xy 135.900039 161.339087) (xy 135.9011 161.33103) (xy 135.9011 161.290543) (xy 135.901235 161.284756) (xy 135.931193 160.643543) (xy 153.5526 160.643543) (xy 153.5526 160.801657) (xy 153.583234 160.915982) (xy 153.593523 160.954383) (xy 153.593526 160.95439) (xy 153.672575 161.091309) (xy 153.672579 161.091314) (xy 153.67258 161.091316) (xy 153.784384 161.20312) (xy 153.784386 161.203121) (xy 153.78439 161.203124) (xy 153.921309 161.282173) (xy 153.921316 161.282177) (xy 154.03759 161.313332) (xy 154.097249 161.349696) (xy 154.127778 161.412542) (xy 154.119484 161.481918) (xy 154.093177 161.520787) (xy 153.990078 161.623886) (xy 153.990075 161.62389) (xy 153.911026 161.760809) (xy 153.911023 161.760816) (xy 153.8701 161.913543) (xy 153.8701 162.071657) (xy 153.892598 162.155618) (xy 153.911023 162.224383) (xy 153.911026 162.22439) (xy 153.990075 162.361309) (xy 153.990079 162.361314) (xy 153.99008 162.361316) (xy 154.101884 162.47312) (xy 154.101886 162.473121) (xy 154.10189 162.473124) (xy 154.109063 162.477265) (xy 154.238816 162.552177) (xy 154.391543 162.5931) (xy 154.391545 162.5931) (xy 154.549655 162.5931) (xy 154.549657 162.5931) (xy 154.702384 162.552177) (xy 154.839316 162.47312) (xy 154.95112 162.361316) (xy 155.030177 162.224384) (xy 155.035437 162.204752) (xy 155.071799 162.145094) (xy 155.099779 162.125926) (xy 157.259679 161.046671) (xy 157.271488 161.043507) (xy 157.306717 161.023167) (xy 157.343083 161.004996) (xy 157.343087 161.004991) (xy 157.343987 161.004385) (xy 157.361921 160.991463) (xy 157.3628 160.990786) (xy 157.362813 160.99078) (xy 157.388934 160.964658) (xy 157.391568 160.962024) (xy 157.422002 160.935052) (xy 157.428739 160.924853) (xy 162.231386 156.122205) (xy 162.281208 156.091808) (xy 163.004172 155.860042) (xy 163.07402 155.858323) (xy 163.104024 155.870736) (xy 163.128516 155.884877) (xy 163.281243 155.9258) (xy 163.281245 155.9258) (xy 163.439355 155.9258) (xy 163.439357 155.9258) (xy 163.592084 155.884877) (xy 163.64468 155.85451) (xy 163.736055 155.801757) (xy 163.736727 155.802921) (xy 163.793959 155.780788) (xy 163.862406 155.794818) (xy 163.912401 155.843626) (xy 163.922222 155.86604) (xy 163.933786 155.901633) (xy 163.933788 155.901639) (xy 164.016006 156.062997) (xy 164.122441 156.209494) (xy 164.122445 156.209499) (xy 164.2505 156.337554) (xy 164.250505 156.337558) (xy 164.378287 156.430396) (xy 164.397006 156.443996) (xy 164.502484 156.49774) (xy 164.55836 156.526211) (xy 164.558363 156.526212) (xy 164.644476 156.554191) (xy 164.730591 156.582171) (xy 164.803639 156.59374) (xy 164.890678 156.607527) (xy 164.953813 156.637456) (xy 164.990744 156.696768) (xy 164.989746 156.766631) (xy 164.951136 156.824863) (xy 164.890678 156.852473) (xy 164.730589 156.877829) (xy 164.558363 156.933787) (xy 164.55836 156.933788) (xy 164.397002 157.016006) (xy 164.250505 157.122441) (xy 164.2505 157.122445) (xy 164.122445 157.2505) (xy 164.122441 157.250505) (xy 164.016006 157.397002) (xy 163.933788 157.55836) (xy 163.933787 157.558363) (xy 163.877829 157.730589) (xy 163.8495 157.909448) (xy 163.8495 158.090551) (xy 163.877829 158.26941) (xy 163.933787 158.441636) (xy 163.933788 158.441639) (xy 163.989664 158.5513) (xy 164.007302 158.585916) (xy 164.016006 158.602997) (xy 164.122441 158.749494) (xy 164.122445 158.749499) (xy 164.2505 158.877554) (xy 164.250505 158.877558) (xy 164.342966 158.944734) (xy 164.397006 158.983996) (xy 164.502484 159.03774) (xy 164.55836 159.066211) (xy 164.558363 159.066212) (xy 164.644476 159.094191) (xy 164.730591 159.122171) (xy 164.803639 159.13374) (xy 164.890678 159.147527) (xy 164.953813 159.177456) (xy 164.990744 159.236768) (xy 164.989746 159.306631) (xy 164.951136 159.364863) (xy 164.890678 159.392473) (xy 164.730589 159.417829) (xy 164.558363 159.473787) (xy 164.55836 159.473788) (xy 164.397002 159.556006) (xy 164.250505 159.662441) (xy 164.2505 159.662445) (xy 164.122445 159.7905) (xy 164.122441 159.790505) (xy 164.016006 159.937002) (xy 163.933788 160.09836) (xy 163.933787 160.098363) (xy 163.877829 160.270589) (xy 163.8495 160.449448) (xy 163.8495 160.630551) (xy 163.877829 160.80941) (xy 163.933787 160.981636) (xy 163.933788 160.981639) (xy 163.985514 161.083155) (xy 164.005729 161.122829) (xy 164.016006 161.142997) (xy 164.122441 161.289494) (xy 164.122445 161.289499) (xy 164.2505 161.417554) (xy 164.250505 161.417558) (xy 164.349066 161.489166) (xy 164.397006 161.523996) (xy 164.483596 161.568116) (xy 164.55836 161.606211) (xy 164.558363 161.606212) (xy 164.61276 161.623886) (xy 164.730591 161.662171) (xy 164.850038 161.681089) (xy 164.892279 161.68778) (xy 164.955414 161.717709) (xy 164.992345 161.777021) (xy 164.991347 161.846883) (xy 164.952737 161.905116) (xy 164.892279 161.932726) (xy 164.730706 161.958317) (xy 164.558555 162.014251) (xy 164.558552 162.014252) (xy 164.397265 162.096434) (xy 164.25083 162.202823) (xy 164.122823 162.33083) (xy 164.016434 162.477265) (xy 163.934252 162.638552) (xy 163.934251 162.638555) (xy 163.878316 162.810706) (xy 163.867342 162.88) (xy 164.53812 162.88) (xy 164.534075 162.887007) (xy 164.5 163.014174) (xy 164.5 163.145826) (xy 164.534075 163.272993) (xy 164.53812 163.28) (xy 163.867342 163.28) (xy 163.878316 163.349293) (xy 163.934251 163.521444) (xy 163.934252 163.521447) (xy 164.016434 163.682734) (xy 164.122823 163.829169) (xy 164.25083 163.957176) (xy 164.397265 164.063565) (xy 164.558552 164.145747) (xy 164.558555 164.145748) (xy 164.7307 164.20168) (xy 164.8 164.212656) (xy 164.8 163.541879) (xy 164.807007 163.545925) (xy 164.934174 163.58) (xy 165.065826 163.58) (xy 165.192993 163.545925) (xy 165.2 163.541879) (xy 165.2 164.212655) (xy 165.269299 164.20168) (xy 165.441444 164.145748) (xy 165.441447 164.145747) (xy 165.602734 164.063565) (xy 165.749169 163.957176) (xy 165.877176 163.829169) (xy 165.983565 163.682734) (xy 166.065747 163.521447) (xy 166.065748 163.521444) (xy 166.121683 163.349293) (xy 166.132658 163.28) (xy 165.46188 163.28) (xy 165.465925 163.272993) (xy 165.5 163.145826) (xy 165.5 163.014174) (xy 165.465925 162.887007) (xy 165.46188 162.88) (xy 166.132658 162.88) (xy 166.121683 162.810706) (xy 166.065748 162.638555) (xy 166.065747 162.638552) (xy 165.983565 162.477265) (xy 165.877176 162.33083) (xy 165.749169 162.202823) (xy 165.602734 162.096434) (xy 165.441447 162.014252) (xy 165.441444 162.014251) (xy 165.269293 161.958317) (xy 165.10772 161.932726) (xy 165.044585 161.902797) (xy 165.007654 161.843485) (xy 165.008652 161.773623) (xy 165.047262 161.71539) (xy 165.10772 161.68778) (xy 165.12227 161.685475) (xy 165.269409 161.662171) (xy 165.441639 161.606211) (xy 165.602994 161.523996) (xy 165.749501 161.417553) (xy 165.877553 161.289501) (xy 165.983996 161.142994) (xy 166.066211 160.981639) (xy 166.122171 160.809409) (xy 166.136765 160.717259) (xy 166.1505 160.630551) (xy 166.1505 160.449448) (xy 166.13334 160.34111) (xy 166.122171 160.270591) (xy 166.073924 160.1221) (xy 166.066212 160.098363) (xy 166.066211 160.09836) (xy 166.03774 160.042484) (xy 165.983996 159.937006) (xy 165.970396 159.918287) (xy 165.877558 159.790505) (xy 165.877554 159.7905) (xy 165.749499 159.662445) (xy 165.749494 159.662441) (xy 165.602997 159.556006) (xy 165.602996 159.556005) (xy 165.602994 159.556004) (xy 165.5513 159.529664) (xy 165.441639 159.473788) (xy 165.441636 159.473787) (xy 165.26941 159.417829) (xy 165.109321 159.392473) (xy 165.046186 159.362544) (xy 165.009255 159.303232) (xy 165.010253 159.23337) (xy 165.048863 159.175137) (xy 165.109321 159.147527) (xy 165.179425 159.136422) (xy 165.269409 159.122171) (xy 165.441639 159.066211) (xy 165.602994 158.983996) (xy 165.749501 158.877553) (xy 165.877553 158.749501) (xy 165.983996 158.602994) (xy 166.066211 158.441639) (xy 166.122171 158.269409) (xy 166.147481 158.109609) (xy 166.1505 158.090551) (xy 166.1505 157.909448) (xy 166.130285 157.781823) (xy 166.122171 157.730591) (xy 166.081771 157.606251) (xy 166.066212 157.558363) (xy 166.066211 157.55836) (xy 165.997495 157.4235) (xy 165.983996 157.397006) (xy 165.939874 157.336277) (xy 165.877558 157.250505) (xy 165.877554 157.2505) (xy 165.749499 157.122445) (xy 165.749494 157.122441) (xy 165.602997 157.016006) (xy 165.602996 157.016005) (xy 165.602994 157.016004) (xy 165.5513 156.989664) (xy 165.441639 156.933788) (xy 165.441636 156.933787) (xy 165.26941 156.877829) (xy 165.109321 156.852473) (xy 165.046186 156.822544) (xy 165.009255 156.763232) (xy 165.010253 156.69337) (xy 165.048863 156.635137) (xy 165.109321 156.607527) (xy 165.179425 156.596422) (xy 165.269409 156.582171) (xy 165.441639 156.526211) (xy 165.602994 156.443996) (xy 165.749501 156.337553) (xy 165.877553 156.209501) (xy 165.983996 156.062994) (xy 166.066211 155.901639) (xy 166.122171 155.729409) (xy 166.136765 155.637259) (xy 166.1505 155.550551) (xy 166.1505 155.369448) (xy 166.1307 155.244444) (xy 166.122171 155.190591) (xy 166.066211 155.018361) (xy 166.066211 155.01836) (xy 166.025139 154.937753) (xy 165.983996 154.857006) (xy 165.970396 154.838287) (xy 165.877558 154.710505) (xy 165.877554 154.7105) (xy 165.749499 154.582445) (xy 165.749494 154.582441) (xy 165.602997 154.476006) (xy 165.602996 154.476005) (xy 165.602994 154.476004) (xy 165.5513 154.449664) (xy 165.441639 154.393788) (xy 165.441636 154.393787) (xy 165.26941 154.337829) (xy 165.137728 154.316972) (xy 165.074594 154.287042) (xy 165.037663 154.227731) (xy 165.038661 154.157868) (xy 165.077271 154.099636) (xy 165.141235 154.071522) (xy 165.15712 154.070499) (xy 165.894864 154.070499) (xy 165.894879 154.070497) (xy 165.894882 154.070497) (xy 165.919987 154.067586) (xy 165.919988 154.067585) (xy 165.919991 154.067585) (xy 166.022765 154.022206) (xy 166.102206 153.942765) (xy 166.147585 153.839991) (xy 166.1505 153.814865) (xy 166.150499 152.025136) (xy 166.150497 152.025117) (xy 166.147586 152.000012) (xy 166.147585 152.00001) (xy 166.147585 152.000009) (xy 166.102206 151.897235) (xy 166.022765 151.817794) (xy 166.006157 151.810461) (xy 165.919992 151.772415) (xy 165.894865 151.7695) (xy 164.105143 151.7695) (xy 164.105117 151.769502) (xy 164.080012 151.772413) (xy 164.080008 151.772415) (xy 163.977235 151.817793) (xy 163.897794 151.897234) (xy 163.852415 152.000006) (xy 163.852415 152.000008) (xy 163.8495 152.025131) (xy 163.8495 153.814856) (xy 163.849502 153.814882) (xy 163.852413 153.839987) (xy 163.852415 153.839991) (xy 163.897793 153.942764) (xy 163.897794 153.942765) (xy 163.977235 154.022206) (xy 164.080009 154.067585) (xy 164.105135 154.0705) (xy 164.842873 154.070499) (xy 164.90991 154.090183) (xy 164.955665 154.142987) (xy 164.965609 154.212146) (xy 164.936584 154.275702) (xy 164.877806 154.313476) (xy 164.86227 154.316972) (xy 164.730589 154.337829) (xy 164.558363 154.393787) (xy 164.55836 154.393788) (xy 164.397002 154.476006) (xy 164.250505 154.582441) (xy 164.2505 154.582445) (xy 164.122445 154.7105) (xy 164.122441 154.710505) (xy 164.016004 154.857004) (xy 164.000741 154.886958) (xy 163.952765 154.937753) (xy 163.884944 154.954546) (xy 163.818809 154.932006) (xy 163.802577 154.918341) (xy 163.729017 154.844781) (xy 163.729009 154.844775) (xy 163.59209 154.765726) (xy 163.592086 154.765724) (xy 163.592084 154.765723) (xy 163.439357 154.7248) (xy 163.281243 154.7248) (xy 163.128516 154.765723) (xy 163.128509 154.765726) (xy 162.99159 154.844775) (xy 162.991582 154.844781) (xy 162.879781 154.956582) (xy 162.879777 154.956587) (xy 162.831325 155.04051) (xy 162.780758 155.088726) (xy 162.761792 155.096591) (xy 161.927816 155.363944) (xy 161.927815 155.363943) (xy 161.924928 155.364868) (xy 161.883412 155.375994) (xy 161.874899 155.380908) (xy 161.865533 155.383911) (xy 161.865523 155.383915) (xy 161.83187 155.40558) (xy 161.831871 155.405581) (xy 161.829327 155.407218) (xy 161.792087 155.42872) (xy 161.785131 155.435674) (xy 161.776865 155.440997) (xy 161.776858 155.441003) (xy 161.749958 155.470642) (xy 161.745819 155.474986) (xy 156.893936 160.326869) (xy 156.861681 160.350111) (xy 154.739311 161.410615) (xy 154.712644 161.415406) (xy 154.686836 161.423657) (xy 154.674763 161.422213) (xy 154.670543 161.422972) (xy 154.651794 161.419467) (xy 154.58611 161.401867) (xy 154.52645 161.365503) (xy 154.495921 161.302656) (xy 154.504216 161.233281) (xy 154.530518 161.194417) (xy 154.63362 161.091316) (xy 154.712677 160.954384) (xy 154.7536 160.801657) (xy 154.7536 160.739839) (xy 154.773285 160.6728) (xy 154.789917 160.65216) (xy 154.811526 160.630551) (xy 156.07948 159.362544) (xy 156.463787 158.978221) (xy 156.525109 158.944734) (xy 156.55147 158.9419) (xy 156.613255 158.9419) (xy 156.613257 158.9419) (xy 156.765984 158.900977) (xy 156.902916 158.82192) (xy 157.01472 158.710116) (xy 157.093777 158.573184) (xy 157.1347 158.420457) (xy 157.1347 158.262343) (xy 157.093777 158.109616) (xy 157.024655 157.989892) (xy 157.014724 157.97269) (xy 157.014718 157.972682) (xy 156.902917 157.860881) (xy 156.902909 157.860875) (xy 156.76599 157.781826) (xy 156.765986 157.781824) (xy 156.765984 157.781823) (xy 156.613257 157.7409) (xy 156.455143 157.7409) (xy 156.302416 157.781823) (xy 156.302409 157.781826) (xy 156.16549 157.860875) (xy 156.165482 157.860881) (xy 156.053681 157.972682) (xy 156.053675 157.97269) (xy 155.974626 158.109609) (xy 155.974623 158.109616) (xy 155.9337 158.262343) (xy 155.9337 158.324159) (xy 155.914015 158.391198) (xy 155.897383 158.411838) (xy 154.223513 160.085779) (xy 154.162191 160.119266) (xy 154.13583 160.1221) (xy 154.074043 160.1221) (xy 153.921316 160.163023) (xy 153.921309 160.163026) (xy 153.78439 160.242075) (xy 153.784382 160.242081) (xy 153.672581 160.353882) (xy 153.672575 160.35389) (xy 153.593526 160.490809) (xy 153.593523 160.490816) (xy 153.5526 160.643543) (xy 135.931193 160.643543) (xy 136.287986 153.006912) (xy 136.310778 152.940867) (xy 136.324164 152.925027) (xy 137.019149 152.230043) (xy 138.4718 152.230043) (xy 138.4718 152.388157) (xy 138.512349 152.539486) (xy 138.512723 152.540883) (xy 138.512726 152.54089) (xy 138.591775 152.677809) (xy 138.591779 152.677814) (xy 138.59178 152.677816) (xy 138.703584 152.78962) (xy 138.703586 152.789621) (xy 138.70359 152.789624) (xy 138.840509 152.868673) (xy 138.840516 152.868677) (xy 138.993243 152.9096) (xy 139.055039 152.9096) (xy 139.122078 152.929285) (xy 139.142721 152.94592) (xy 140.955688 154.758923) (xy 143.583894 157.387181) (xy 143.715282 157.518571) (xy 143.748766 157.579894) (xy 143.7516 157.606251) (xy 143.7516 158.317602) (xy 143.731915 158.384641) (xy 143.715281 158.405283) (xy 143.671581 158.448982) (xy 143.671575 158.44899) (xy 143.592526 158.585909) (xy 143.592523 158.585916) (xy 143.5516 158.738643) (xy 143.5516 158.896757) (xy 143.564456 158.944734) (xy 143.592523 159.049483) (xy 143.592526 159.04949) (xy 143.671575 159.186409) (xy 143.671579 159.186414) (xy 143.67158 159.186416) (xy 143.783384 159.29822) (xy 143.783386 159.298221) (xy 143.78339 159.298224) (xy 143.797952 159.306631) (xy 143.920316 159.377277) (xy 144.073043 159.4182) (xy 144.073045 159.4182) (xy 144.231155 159.4182) (xy 144.231157 159.4182) (xy 144.383884 159.377277) (xy 144.520816 159.29822) (xy 144.63262 159.186416) (xy 144.711677 159.049484) (xy 144.7526 158.896757) (xy 144.7526 158.738643) (xy 144.711677 158.585916) (xy 144.664686 158.504524) (xy 144.632624 158.44899) (xy 144.632618 158.448982) (xy 144.588919 158.405283) (xy 144.555434 158.34396) (xy 144.5526 158.317602) (xy 144.5526 157.40746) (xy 144.5526 157.397006) (xy 144.552601 157.336277) (xy 144.525308 157.234416) (xy 144.525307 157.234415) (xy 144.525307 157.234413) (xy 144.47258 157.143087) (xy 144.398013 157.06852) (xy 144.390945 157.061452) (xy 144.39094 157.061448) (xy 139.709118 152.379532) (xy 139.675634 152.318209) (xy 139.6728 152.291852) (xy 139.6728 152.230045) (xy 139.6728 152.230043) (xy 139.631877 152.077316) (xy 139.587246 152.000012) (xy 139.552824 151.94039) (xy 139.552818 151.940382) (xy 139.441017 151.828581) (xy 139.441009 151.828575) (xy 139.30409 151.749526) (xy 139.304086 151.749524) (xy 139.304084 151.749523) (xy 139.151357 151.7086) (xy 138.993243 151.7086) (xy 138.840516 151.749523) (xy 138.840509 151.749526) (xy 138.70359 151.828575) (xy 138.703582 151.828581) (xy 138.591781 151.940382) (xy 138.591775 151.94039) (xy 138.512726 152.077309) (xy 138.512723 152.077316) (xy 138.4718 152.230043) (xy 137.019149 152.230043) (xy 137.573173 151.676019) (xy 137.634496 151.642534) (xy 137.660854 151.6397) (xy 137.722655 151.6397) (xy 137.722657 151.6397) (xy 137.875384 151.598777) (xy 138.012316 151.51972) (xy 138.12412 151.407916) (xy 138.203177 151.270984) (xy 138.217129 151.21891) (xy 138.253494 151.159251) (xy 138.31634 151.128722) (xy 138.33673 151.127005) (xy 141.271428 151.122899) (xy 141.338494 151.14249) (xy 141.359282 151.159218) (xy 141.402284 151.20222) (xy 141.402286 151.202221) (xy 141.40229 151.202224) (xy 141.521386 151.270983) (xy 141.539216 151.281277) (xy 141.691943 151.3222) (xy 141.691945 151.3222) (xy 141.850055 151.3222) (xy 141.850057 151.3222) (xy 142.002784 151.281277) (xy 142.139716 151.20222) (xy 142.25152 151.090416) (xy 142.330577 150.953484) (xy 142.3715 150.800757) (xy 142.3715 150.642643) (xy 142.330577 150.489916) (xy 142.294066 150.426676) (xy 142.251524 150.35299) (xy 142.251518 150.352982) (xy 142.139717 150.241181) (xy 142.139709 150.241175) (xy 142.00279 150.162126) (xy 142.002786 150.162124) (xy 142.002784 150.162123) (xy 141.850057 150.1212) (xy 141.691943 150.1212) (xy 141.539216 150.162123) (xy 141.539209 150.162126) (xy 141.402283 150.241179) (xy 141.357879 150.285582) (xy 141.296556 150.319066) (xy 141.270374 150.321899) (xy 123.881278 150.346229) (xy 123.881279 150.34623) (xy 123.869681 150.346246) (xy 123.854666 150.343436) (xy 123.817162 150.346319) (xy 123.812475 150.346326) (xy 123.812475 150.346327) (xy 123.779509 150.346374) (xy 123.775939 150.347336) (xy 123.753199 150.351237) (xy 120.080607 150.633638) (xy 120.067109 150.630777) (xy 120.053453 150.632741) (xy 120.033602 150.623675) (xy 120.012255 150.619151) (xy 120.002447 150.609447) (xy 119.989897 150.603716) (xy 119.978099 150.585358) (xy 119.962587 150.570011) (xy 119.958795 150.555321) (xy 119.952123 150.544938) (xy 119.9471 150.510003) (xy 119.9471 150.428098) (xy 119.966785 150.361059) (xy 119.983419 150.340417) (xy 120.00477 150.319066) (xy 120.02712 150.296716) (xy 120.106177 150.159784) (xy 120.1471 150.007057) (xy 120.1471 149.848943) (xy 120.106177 149.696216) (xy 120.059125 149.614718) (xy 120.027124 149.55929) (xy 120.027118 149.559282) (xy 119.915317 149.447481) (xy 119.915309 149.447475) (xy 119.77839 149.368426) (xy 119.778386 149.368424) (xy 119.778384 149.368423) (xy 119.625657 149.3275) (xy 119.467543 149.3275) (xy 119.314816 149.368423) (xy 119.314809 149.368426) (xy 119.17789 149.447475) (xy 119.177882 149.447481) (xy 119.066081 149.559282) (xy 119.066075 149.55929) (xy 118.987026 149.696209) (xy 118.987023 149.696216) (xy 118.9461 149.848943) (xy 118.9461 150.007057) (xy 118.976685 150.1212) (xy 118.987023 150.159783) (xy 118.987026 150.15979) (xy 119.066075 150.296709) (xy 119.066081 150.296717) (xy 119.109781 150.340417) (xy 119.124484 150.367344) (xy 119.141077 150.393163) (xy 119.141968 150.399363) (xy 119.143266 150.40174) (xy 119.1461 150.428098) (xy 119.1461 150.5491) (xy 119.126415 150.616139) (xy 119.073611 150.661894) (xy 119.0221 150.6731) (xy 118.923898 150.6731) (xy 118.901256 150.671015) (xy 118.896899 150.670206) (xy 118.864771 150.672722) (xy 118.864768 150.672722) (xy 118.859939 150.6731) (xy 118.822873 150.6731) (xy 118.80757 150.677199) (xy 118.79619 150.67809) (xy 118.796187 150.678091) (xy 115.440044 150.940913) (xy 115.371672 150.926522) (xy 115.321934 150.877451) (xy 115.306622 150.80928) (xy 115.330596 150.743652) (xy 115.342676 150.729616) (xy 117.017149 149.055143) (xy 139.9005 149.055143) (xy 139.9005 149.213257) (xy 139.931112 149.3275) (xy 139.941423 149.365983) (xy 139.941426 149.36599) (xy 140.020475 149.502909) (xy 140.020479 149.502914) (xy 140.02048 149.502916) (xy 140.132284 149.61472) (xy 140.132286 149.614721) (xy 140.13229 149.614724) (xy 140.269209 149.693773) (xy 140.269216 149.693777) (xy 140.421943 149.7347) (xy 140.421945 149.7347) (xy 140.580055 149.7347) (xy 140.580057 149.7347) (xy 140.732784 149.693777) (xy 140.869716 149.61472) (xy 140.913417 149.571019) (xy 140.97474 149.537534) (xy 141.001098 149.5347) (xy 142.506145 149.5347) (xy 142.573184 149.554385) (xy 142.593826 149.571019) (xy 150.976381 157.953573) (xy 151.009866 158.014896) (xy 151.0127 158.041254) (xy 151.0127 158.103057) (xy 151.014458 158.109616) (xy 151.053623 158.255783) (xy 151.053626 158.25579) (xy 151.132675 158.392709) (xy 151.132679 158.392714) (xy 151.13268 158.392716) (xy 151.244484 158.50452) (xy 151.244486 158.504521) (xy 151.24449 158.504524) (xy 151.363425 158.57319) (xy 151.381416 158.583577) (xy 151.534143 158.6245) (xy 151.534145 158.6245) (xy 151.692255 158.6245) (xy 151.692257 158.6245) (xy 151.844984 158.583577) (xy 151.981916 158.50452) (xy 152.09372 158.392716) (xy 152.172777 158.255784) (xy 152.2137 158.103057) (xy 152.2137 157.944943) (xy 152.172777 157.792216) (xy 152.137197 157.730589) (xy 152.093724 157.65529) (xy 152.093718 157.655282) (xy 151.981917 157.543481) (xy 151.981909 157.543475) (xy 151.84499 157.464426) (xy 151.844986 157.464424) (xy 151.844984 157.464423) (xy 151.692257 157.4235) (xy 151.692256 157.4235) (xy 151.630454 157.4235) (xy 151.563415 157.403815) (xy 151.542773 157.387181) (xy 142.969315 148.813722) (xy 142.969314 148.813721) (xy 142.969313 148.81372) (xy 142.92365 148.787356) (xy 142.877989 148.760993) (xy 142.827057 148.747346) (xy 142.776127 148.7337) (xy 142.776126 148.7337) (xy 141.001098 148.7337) (xy 140.934059 148.714015) (xy 140.913417 148.697381) (xy 140.869717 148.653681) (xy 140.869709 148.653675) (xy 140.73279 148.574626) (xy 140.732786 148.574624) (xy 140.732784 148.574623) (xy 140.580057 148.5337) (xy 140.421943 148.5337) (xy 140.269216 148.574623) (xy 140.269209 148.574626) (xy 140.13229 148.653675) (xy 140.132282 148.653681) (xy 140.020481 148.765482) (xy 140.020475 148.76549) (xy 139.941426 148.902409) (xy 139.941423 148.902416) (xy 139.9005 149.055143) (xy 117.017149 149.055143) (xy 119.476173 146.596118) (xy 119.537496 146.562634) (xy 119.563854 146.5598) (xy 119.625655 146.5598) (xy 119.625657 146.5598) (xy 119.778384 146.518877) (xy 119.915316 146.43982) (xy 120.02712 146.328016) (xy 120.106177 146.191084) (xy 120.1471 146.038357) (xy 120.1471 145.880243) (xy 120.106177 145.727516) (xy 120.106173 145.727509) (xy 120.027124 145.59059) (xy 120.027118 145.590582) (xy 119.915317 145.478781) (xy 119.915309 145.478775) (xy 119.77839 145.399726) (xy 119.778386 145.399724) (xy 119.778384 145.399723) (xy 119.625657 145.3588) (xy 119.467543 145.3588) (xy 119.314816 145.399723) (xy 119.314809 145.399726) (xy 119.17789 145.478775) (xy 119.177882 145.478781) (xy 119.066081 145.590582) (xy 119.066075 145.59059) (xy 118.987026 145.727509) (xy 118.987023 145.727516) (xy 118.9461 145.880243) (xy 118.9461 145.942044) (xy 118.926415 146.009083) (xy 118.909781 146.029725) (xy 114.516498 150.423007) (xy 114.512823 150.426681) (xy 114.485342 150.44992) (xy 114.475689 150.463815) (xy 114.467859 150.471646) (xy 114.463722 150.475782) (xy 114.463718 150.475788) (xy 114.448303 150.502487) (xy 114.442762 150.511221) (xy 114.170682 150.90294) (xy 114.116273 150.946769) (xy 114.068841 150.9562) (xy 108.934598 150.9562) (xy 108.867559 150.936515) (xy 108.846917 150.919881) (xy 108.803217 150.876181) (xy 108.803209 150.876175) (xy 108.66629 150.797126) (xy 108.666286 150.797124) (xy 108.666284 150.797123) (xy 108.513557 150.7562) (xy 108.355443 150.7562) (xy 108.202716 150.797123) (xy 108.202709 150.797126) (xy 108.06579 150.876175) (xy 108.065782 150.876181) (xy 107.953981 150.987982) (xy 107.953975 150.98799) (xy 107.874926 151.124909) (xy 107.874923 151.124916) (xy 107.834 151.277643) (xy 107.834 151.435757) (xy 107.863698 151.546589) (xy 107.874923 151.588483) (xy 107.874926 151.58849) (xy 107.953975 151.725409) (xy 107.953979 151.725414) (xy 107.95398 151.725416) (xy 108.065784 151.83722) (xy 108.065786 151.837221) (xy 108.06579 151.837224) (xy 108.169732 151.897234) (xy 108.202716 151.916277) (xy 108.355443 151.9572) (xy 108.355445 151.9572) (xy 108.513555 151.9572) (xy 108.513557 151.9572) (xy 108.666284 151.916277) (xy 108.803216 151.83722) (xy 108.846917 151.793519) (xy 108.90824 151.760034) (xy 108.934598 151.7572) (xy 113.340223 151.7572) (xy 113.407262 151.776885) (xy 113.453017 151.829689) (xy 113.462961 151.898847) (xy 113.442066 151.951938) (xy 113.39122 152.025143) (xy 111.498706 154.74982) (xy 111.484544 154.766762) (xy 111.033553 155.217752) (xy 111.029796 155.221508) (xy 111.002567 155.244444) (xy 110.992667 155.258636) (xy 110.984924 155.26638) (xy 110.984919 155.266387) (xy 110.980419 155.270886) (xy 110.980418 155.270889) (xy 110.965259 155.297143) (xy 110.959582 155.306073) (xy 106.964427 161.034315) (xy 106.909931 161.078041) (xy 106.894814 161.083155) (xy 106.774014 161.115523) (xy 106.774009 161.115526) (xy 106.63709 161.194575) (xy 106.637082 161.194581) (xy 106.525281 161.306382) (xy 106.525275 161.30639) (xy 106.446226 161.443309) (xy 106.446223 161.443316) (xy 106.4053 161.596043) (xy 100.5005 161.596043) (xy 100.5005 131.593243) (xy 115.295 131.593243) (xy 115.295 131.751356) (xy 115.335923 131.904083) (xy 115.335926 131.90409) (xy 115.414975 132.041009) (xy 115.414981 132.041017) (xy 115.458681 132.084717) (xy 115.492166 132.14604) (xy 115.495 132.172398) (xy 115.495 145.141702) (xy 115.475315 145.208741) (xy 115.458681 145.229383) (xy 115.414981 145.273082) (xy 115.414975 145.27309) (xy 115.335926 145.410009) (xy 115.335923 145.410016) (xy 115.295 145.562743) (xy 115.295 145.720857) (xy 115.296785 145.727516) (xy 115.335923 145.873583) (xy 115.335926 145.87359) (xy 115.414975 146.010509) (xy 115.414979 146.010514) (xy 115.41498 146.010516) (xy 115.526784 146.12232) (xy 115.526786 146.122321) (xy 115.52679 146.122324) (xy 115.645886 146.191083) (xy 115.663716 146.201377) (xy 115.816443 146.2423) (xy 115.816445 146.2423) (xy 115.974555 146.2423) (xy 115.974557 146.2423) (xy 116.127284 146.201377) (xy 116.264216 146.12232) (xy 116.37602 146.010516) (xy 116.455077 145.873584) (xy 116.496 145.720857) (xy 116.496 145.562743) (xy 116.455077 145.410016) (xy 116.425508 145.3588) (xy 116.376024 145.27309) (xy 116.376018 145.273082) (xy 116.332319 145.229383) (xy 116.298834 145.16806) (xy 116.296 145.141702) (xy 116.296 136.89653) (xy 148.5095 136.89653) (xy 148.5095 137.103469) (xy 148.549868 137.306412) (xy 148.54987 137.30642) (xy 148.629058 137.497596) (xy 148.744024 137.669657) (xy 148.890342 137.815975) (xy 148.890345 137.815977) (xy 149.062402 137.930941) (xy 149.25358 138.01013) (xy 149.402863 138.039824) (xy 149.45653 138.050499) (xy 149.456534 138.0505) (xy 149.456535 138.0505) (xy 149.663466 138.0505) (xy 149.663467 138.050499) (xy 149.86642 138.01013) (xy 150.057598 137.930941) (xy 150.229655 137.815977) (xy 150.375977 137.669655) (xy 150.490941 137.497598) (xy 150.57013 137.30642) (xy 150.6105 137.103465) (xy 150.6105 136.896535) (xy 150.610499 136.89653) (xy 153.3895 136.89653) (xy 153.3895 137.103469) (xy 153.429868 137.306412) (xy 153.42987 137.30642) (xy 153.509058 137.497596) (xy 153.624024 137.669657) (xy 153.770342 137.815975) (xy 153.770345 137.815977) (xy 153.942402 137.930941) (xy 154.13358 138.01013) (xy 154.282863 138.039824) (xy 154.33653 138.050499) (xy 154.336534 138.0505) (xy 154.336535 138.0505) (xy 154.543466 138.0505) (xy 154.543467 138.050499) (xy 154.74642 138.01013) (xy 154.746429 138.010126) (xy 154.750643 138.008848) (xy 154.820509 138.008217) (xy 154.874331 138.039824) (xy 158.278581 141.444074) (xy 158.312066 141.505397) (xy 158.3149 141.531755) (xy 158.3149 141.593556) (xy 158.355823 141.746283) (xy 158.355826 141.74629) (xy 158.434875 141.883209) (xy 158.434879 141.883214) (xy 158.43488 141.883216) (xy 158.546684 141.99502) (xy 158.546686 141.995021) (xy 158.54669 141.995024) (xy 158.683609 142.074073) (xy 158.683616 142.074077) (xy 158.836343 142.115) (xy 158.836345 142.115) (xy 158.994455 142.115) (xy 158.994457 142.115) (xy 159.147184 142.074077) (xy 159.284116 141.99502) (xy 159.39592 141.883216) (xy 159.474977 141.746284) (xy 159.5159 141.593557) (xy 159.5159 141.435443) (xy 159.474977 141.282716) (xy 159.474973 141.282709) (xy 159.395924 141.14579) (xy 159.395918 141.145782) (xy 159.284117 141.033981) (xy 159.284109 141.033975) (xy 159.14719 140.954926) (xy 159.147186 140.954924) (xy 159.147184 140.954923) (xy 158.994457 140.914) (xy 158.994456 140.914) (xy 158.932655 140.914) (xy 158.865616 140.894315) (xy 158.844974 140.877681) (xy 155.457045 137.489752) (xy 155.42356 137.428429) (xy 155.428544 137.358737) (xy 155.43015 137.354655) (xy 155.45013 137.30642) (xy 155.4905 137.103465) (xy 155.4905 136.896535) (xy 155.45013 136.69358) (xy 155.370941 136.502402) (xy 155.255977 136.330345) (xy 155.255975 136.330342) (xy 155.109657 136.184024) (xy 155.023626 136.126541) (xy 154.937598 136.069059) (xy 154.74642 135.98987) (xy 154.746412 135.989868) (xy 154.543469 135.9495) (xy 154.543465 135.9495) (xy 154.336535 135.9495) (xy 154.33653 135.9495) (xy 154.133587 135.989868) (xy 154.133579 135.98987) (xy 153.942403 136.069058) (xy 153.770342 136.184024) (xy 153.624024 136.330342) (xy 153.509058 136.502403) (xy 153.42987 136.693579) (xy 153.429868 136.693587) (xy 153.3895 136.89653) (xy 150.610499 136.89653) (xy 150.57013 136.69358) (xy 150.490941 136.502402) (xy 150.375977 136.330345) (xy 150.375975 136.330342) (xy 150.229657 136.184024) (xy 150.143626 136.126541) (xy 150.057598 136.069059) (xy 149.86642 135.98987) (xy 149.866412 135.989868) (xy 149.663469 135.9495) (xy 149.663465 135.9495) (xy 149.456535 135.9495) (xy 149.45653 135.9495) (xy 149.253587 135.989868) (xy 149.253579 135.98987) (xy 149.062403 136.069058) (xy 148.890342 136.184024) (xy 148.744024 136.330342) (xy 148.629058 136.502403) (xy 148.54987 136.693579) (xy 148.549868 136.693587) (xy 148.5095 136.89653) (xy 116.296 136.89653) (xy 116.296 132.172398) (xy 116.315685 132.105359) (xy 116.332319 132.084717) (xy 116.37602 132.041016) (xy 116.455077 131.904084) (xy 116.496 131.751357) (xy 116.496 131.593243) (xy 116.455077 131.440516) (xy 116.455073 131.440509) (xy 116.376024 131.30359) (xy 116.376018 131.303582) (xy 116.264217 131.191781) (xy 116.264209 131.191775) (xy 116.12729 131.112726) (xy 116.127286 131.112724) (xy 116.127284 131.112723) (xy 115.974557 131.0718) (xy 115.816443 131.0718) (xy 115.663716 131.112723) (xy 115.663709 131.112726) (xy 115.52679 131.191775) (xy 115.526782 131.191781) (xy 115.414981 131.303582) (xy 115.414975 131.30359) (xy 115.335926 131.440509) (xy 115.335923 131.440516) (xy 115.295 131.593243) (xy 100.5005 131.593243) (xy 100.5005 114.755131) (xy 163.8495 114.755131) (xy 163.8495 116.544856) (xy 163.849502 116.544882) (xy 163.852413 116.569987) (xy 163.852415 116.569991) (xy 163.897793 116.672764) (xy 163.897794 116.672765) (xy 163.977235 116.752206) (xy 164.080009 116.797585) (xy 164.105135 116.8005) (xy 164.842873 116.800499) (xy 164.90991 116.820183) (xy 164.955665 116.872987) (xy 164.965609 116.942146) (xy 164.936584 117.005702) (xy 164.877806 117.043476) (xy 164.86227 117.046972) (xy 164.730589 117.067829) (xy 164.558363 117.123787) (xy 164.55836 117.123788) (xy 164.397002 117.206006) (xy 164.250505 117.312441) (xy 164.2505 117.312445) (xy 164.122445 117.4405) (xy 164.122441 117.440505) (xy 164.016006 117.587002) (xy 163.933788 117.74836) (xy 163.933787 117.748363) (xy 163.877829 117.920589) (xy 163.8495 118.099448) (xy 163.8495 118.280551) (xy 163.877829 118.45941) (xy 163.933787 118.631636) (xy 163.933788 118.631639) (xy 164.016006 118.792997) (xy 164.122441 118.939494) (xy 164.122445 118.939499) (xy 164.2505 119.067554) (xy 164.250505 119.067558) (xy 164.378287 119.160396) (xy 164.397006 119.173996) (xy 164.502484 119.22774) (xy 164.55836 119.256211) (xy 164.558363 119.256212) (xy 164.644476 119.284191) (xy 164.730591 119.312171) (xy 164.803639 119.32374) (xy 164.890678 119.337527) (xy 164.953813 119.367456) (xy 164.990744 119.426768) (xy 164.989746 119.496631) (xy 164.951136 119.554863) (xy 164.890678 119.582473) (xy 164.730589 119.607829) (xy 164.558363 119.663787) (xy 164.55836 119.663788) (xy 164.397002 119.746006) (xy 164.250505 119.852441) (xy 164.2505 119.852445) (xy 164.122445 119.9805) (xy 164.122441 119.980505) (xy 164.016006 120.127002) (xy 163.933788 120.28836) (xy 163.933787 120.288363) (xy 163.877829 120.460589) (xy 163.8495 120.639448) (xy 163.8495 120.820551) (xy 163.877829 120.99941) (xy 163.933787 121.171636) (xy 163.933788 121.171639) (xy 164.016006 121.332997) (xy 164.122441 121.479494) (xy 164.122445 121.479499) (xy 164.2505 121.607554) (xy 164.250505 121.607558) (xy 164.378287 121.700396) (xy 164.397006 121.713996) (xy 164.502484 121.76774) (xy 164.55836 121.796211) (xy 164.558363 121.796212) (xy 164.644476 121.824191) (xy 164.730591 121.852171) (xy 164.803639 121.86374) (xy 164.890678 121.877527) (xy 164.953813 121.907456) (xy 164.990744 121.966768) (xy 164.989746 122.036631) (xy 164.951136 122.094863) (xy 164.890678 122.122473) (xy 164.730589 122.147829) (xy 164.558363 122.203787) (xy 164.55836 122.203788) (xy 164.397002 122.286006) (xy 164.250505 122.392441) (xy 164.2505 122.392445) (xy 164.122445 122.5205) (xy 164.122441 122.520505) (xy 164.016006 122.667002) (xy 163.933788 122.82836) (xy 163.933787 122.828363) (xy 163.877829 123.000589) (xy 163.8495 123.179448) (xy 163.8495 123.360551) (xy 163.877829 123.53941) (xy 163.933787 123.711636) (xy 163.933788 123.711639) (xy 164.016006 123.872997) (xy 164.122441 124.019494) (xy 164.122445 124.019499) (xy 164.2505 124.147554) (xy 164.250505 124.147558) (xy 164.378287 124.240396) (xy 164.397006 124.253996) (xy 164.502484 124.30774) (xy 164.55836 124.336211) (xy 164.558363 124.336212) (xy 164.644476 124.364191) (xy 164.730591 124.392171) (xy 164.803639 124.40374) (xy 164.890678 124.417527) (xy 164.953813 124.447456) (xy 164.990744 124.506768) (xy 164.989746 124.576631) (xy 164.951136 124.634863) (xy 164.890678 124.662473) (xy 164.730589 124.687829) (xy 164.558363 124.743787) (xy 164.55836 124.743788) (xy 164.397002 124.826006) (xy 164.250505 124.932441) (xy 164.2505 124.932445) (xy 164.122445 125.0605) (xy 164.122441 125.060505) (xy 164.016006 125.207002) (xy 163.933788 125.36836) (xy 163.933787 125.368363) (xy 163.877829 125.540589) (xy 163.8495 125.719448) (xy 163.8495 125.900551) (xy 163.877829 126.07941) (xy 163.933787 126.251636) (xy 163.933788 126.251639) (xy 164.016006 126.412997) (xy 164.122441 126.559494) (xy 164.122445 126.559499) (xy 164.2505 126.687554) (xy 164.250505 126.687558) (xy 164.378287 126.780396) (xy 164.397006 126.793996) (xy 164.502484 126.84774) (xy 164.55836 126.876211) (xy 164.558363 126.876212) (xy 164.644476 126.904191) (xy 164.730591 126.932171) (xy 164.850038 126.951089) (xy 164.892279 126.95778) (xy 164.955414 126.987709) (xy 164.992345 127.047021) (xy 164.991347 127.116883) (xy 164.952737 127.175116) (xy 164.892279 127.202726) (xy 164.730706 127.228317) (xy 164.558555 127.284251) (xy 164.558552 127.284252) (xy 164.397265 127.366434) (xy 164.25083 127.472823) (xy 164.122823 127.60083) (xy 164.016434 127.747265) (xy 163.934252 127.908552) (xy 163.934251 127.908555) (xy 163.878316 128.080706) (xy 163.867342 128.15) (xy 164.53812 128.15) (xy 164.534075 128.157007) (xy 164.5 128.284174) (xy 164.5 128.415826) (xy 164.534075 128.542993) (xy 164.53812 128.55) (xy 163.867342 128.55) (xy 163.878316 128.619293) (xy 163.934251 128.791444) (xy 163.934252 128.791447) (xy 164.016434 128.952734) (xy 164.122823 129.099169) (xy 164.25083 129.227176) (xy 164.397265 129.333565) (xy 164.558552 129.415747) (xy 164.558555 129.415748) (xy 164.7307 129.47168) (xy 164.8 129.482656) (xy 164.8 128.811879) (xy 164.807007 128.815925) (xy 164.934174 128.85) (xy 165.065826 128.85) (xy 165.192993 128.815925) (xy 165.2 128.811879) (xy 165.2 129.482655) (xy 165.269299 129.47168) (xy 165.441444 129.415748) (xy 165.441447 129.415747) (xy 165.602734 129.333565) (xy 165.749169 129.227176) (xy 165.877176 129.099169) (xy 165.983565 128.952734) (xy 166.065747 128.791447) (xy 166.065748 128.791444) (xy 166.121683 128.619293) (xy 166.132658 128.55) (xy 165.46188 128.55) (xy 165.465925 128.542993) (xy 165.5 128.415826) (xy 165.5 128.284174) (xy 165.465925 128.157007) (xy 165.46188 128.15) (xy 166.132658 128.15) (xy 166.121683 128.080706) (xy 166.065748 127.908555) (xy 166.065747 127.908552) (xy 165.983565 127.747265) (xy 165.877176 127.60083) (xy 165.749169 127.472823) (xy 165.602734 127.366434) (xy 165.441447 127.284252) (xy 165.441444 127.284251) (xy 165.269293 127.228317) (xy 165.10772 127.202726) (xy 165.044585 127.172797) (xy 165.007654 127.113485) (xy 165.008652 127.043623) (xy 165.047262 126.98539) (xy 165.10772 126.95778) (xy 165.12227 126.955475) (xy 165.269409 126.932171) (xy 165.441639 126.876211) (xy 165.602994 126.793996) (xy 165.749501 126.687553) (xy 165.877553 126.559501) (xy 165.983996 126.412994) (xy 166.066211 126.251639) (xy 166.122171 126.079409) (xy 166.136765 125.987259) (xy 166.1505 125.900551) (xy 166.1505 125.719448) (xy 166.134019 125.615397) (xy 166.122171 125.540591) (xy 166.066211 125.368361) (xy 166.066211 125.36836) (xy 166.03774 125.312484) (xy 165.983996 125.207006) (xy 165.970396 125.188287) (xy 165.877558 125.060505) (xy 165.877554 125.0605) (xy 165.749499 124.932445) (xy 165.749494 124.932441) (xy 165.602997 124.826006) (xy 165.602996 124.826005) (xy 165.602994 124.826004) (xy 165.5513 124.799664) (xy 165.441639 124.743788) (xy 165.441636 124.743787) (xy 165.26941 124.687829) (xy 165.109321 124.662473) (xy 165.046186 124.632544) (xy 165.009255 124.573232) (xy 165.010253 124.50337) (xy 165.048863 124.445137) (xy 165.109321 124.417527) (xy 165.179425 124.406422) (xy 165.269409 124.392171) (xy 165.441639 124.336211) (xy 165.602994 124.253996) (xy 165.749501 124.147553) (xy 165.877553 124.019501) (xy 165.983996 123.872994) (xy 166.066211 123.711639) (xy 166.122171 123.539409) (xy 166.136765 123.447259) (xy 166.1505 123.360551) (xy 166.1505 123.179448) (xy 166.134019 123.075397) (xy 166.122171 123.000591) (xy 166.066211 122.828361) (xy 166.066211 122.82836) (xy 166.03774 122.772484) (xy 165.983996 122.667006) (xy 165.970396 122.648287) (xy 165.877558 122.520505) (xy 165.877554 122.5205) (xy 165.749499 122.392445) (xy 165.749494 122.392441) (xy 165.602997 122.286006) (xy 165.602996 122.286005) (xy 165.602994 122.286004) (xy 165.5513 122.259664) (xy 165.441639 122.203788) (xy 165.441636 122.203787) (xy 165.26941 122.147829) (xy 165.109321 122.122473) (xy 165.046186 122.092544) (xy 165.009255 122.033232) (xy 165.010253 121.96337) (xy 165.048863 121.905137) (xy 165.109321 121.877527) (xy 165.179425 121.866422) (xy 165.269409 121.852171) (xy 165.441639 121.796211) (xy 165.602994 121.713996) (xy 165.749501 121.607553) (xy 165.877553 121.479501) (xy 165.983996 121.332994) (xy 166.066211 121.171639) (xy 166.122171 120.999409) (xy 166.136765 120.907259) (xy 166.1505 120.820551) (xy 166.1505 120.639448) (xy 166.134019 120.535397) (xy 166.122171 120.460591) (xy 166.066211 120.288361) (xy 166.066211 120.28836) (xy 166.03774 120.232484) (xy 165.983996 120.127006) (xy 165.970396 120.108287) (xy 165.877558 119.980505) (xy 165.877554 119.9805) (xy 165.749499 119.852445) (xy 165.749494 119.852441) (xy 165.602997 119.746006) (xy 165.602996 119.746005) (xy 165.602994 119.746004) (xy 165.5513 119.719664) (xy 165.441639 119.663788) (xy 165.441636 119.663787) (xy 165.26941 119.607829) (xy 165.109321 119.582473) (xy 165.046186 119.552544) (xy 165.009255 119.493232) (xy 165.010253 119.42337) (xy 165.048863 119.365137) (xy 165.109321 119.337527) (xy 165.179425 119.326422) (xy 165.269409 119.312171) (xy 165.441639 119.256211) (xy 165.602994 119.173996) (xy 165.749501 119.067553) (xy 165.877553 118.939501) (xy 165.983996 118.792994) (xy 166.066211 118.631639) (xy 166.122171 118.459409) (xy 166.136765 118.367259) (xy 166.1505 118.280551) (xy 166.1505 118.099448) (xy 166.134019 117.995397) (xy 166.122171 117.920591) (xy 166.066211 117.748361) (xy 166.066211 117.74836) (xy 166.03774 117.692484) (xy 165.983996 117.587006) (xy 165.970396 117.568287) (xy 165.877558 117.440505) (xy 165.877554 117.4405) (xy 165.749499 117.312445) (xy 165.749494 117.312441) (xy 165.602997 117.206006) (xy 165.602996 117.206005) (xy 165.602994 117.206004) (xy 165.5513 117.179664) (xy 165.441639 117.123788) (xy 165.441636 117.123787) (xy 165.26941 117.067829) (xy 165.137728 117.046972) (xy 165.074594 117.017042) (xy 165.037663 116.957731) (xy 165.038661 116.887868) (xy 165.077271 116.829636) (xy 165.141235 116.801522) (xy 165.15712 116.800499) (xy 165.894864 116.800499) (xy 165.894879 116.800497) (xy 165.894882 116.800497) (xy 165.919987 116.797586) (xy 165.919988 116.797585) (xy 165.919991 116.797585) (xy 166.022765 116.752206) (xy 166.102206 116.672765) (xy 166.147585 116.569991) (xy 166.1505 116.544865) (xy 166.150499 114.755136) (xy 166.150497 114.755117) (xy 166.147586 114.730012) (xy 166.147585 114.73001) (xy 166.147585 114.730009) (xy 166.102206 114.627235) (xy 166.022765 114.547794) (xy 166.022763 114.547793) (xy 165.919992 114.502415) (xy 165.894865 114.4995) (xy 164.105143 114.4995) (xy 164.105117 114.499502) (xy 164.080012 114.502413) (xy 164.080008 114.502415) (xy 163.977235 114.547793) (xy 163.897794 114.627234) (xy 163.852415 114.730006) (xy 163.852415 114.730008) (xy 163.8495 114.755131) (xy 100.5005 114.755131) (xy 100.5005 105.835131) (xy 103.8495 105.835131) (xy 103.8495 107.624856) (xy 103.849502 107.624882) (xy 103.852413 107.649987) (xy 103.852415 107.649991) (xy 103.897793 107.752764) (xy 103.897794 107.752765) (xy 103.977235 107.832206) (xy 104.080009 107.877585) (xy 104.105135 107.8805) (xy 104.846073 107.880499) (xy 104.913111 107.900183) (xy 104.958866 107.952987) (xy 104.96881 108.022146) (xy 104.939785 108.085702) (xy 104.881007 108.123476) (xy 104.86547 108.126972) (xy 104.730706 108.148316) (xy 104.558555 108.204251) (xy 104.558552 108.204252) (xy 104.397265 108.286434) (xy 104.25083 108.392823) (xy 104.122823 108.52083) (xy 104.016434 108.667265) (xy 103.934252 108.828552) (xy 103.934251 108.828555) (xy 103.878316 109.000706) (xy 103.867342 109.07) (xy 104.53812 109.07) (xy 104.534075 109.077007) (xy 104.5 109.204174) (xy 104.5 109.335826) (xy 104.534075 109.462993) (xy 104.53812 109.47) (xy 103.867342 109.47) (xy 103.878316 109.539293) (xy 103.934251 109.711444) (xy 103.934252 109.711447) (xy 104.016434 109.872734) (xy 104.122823 110.019169) (xy 104.25083 110.147176) (xy 104.397265 110.253565) (xy 104.558552 110.335747) (xy 104.558555 110.335748) (xy 104.7307 110.39168) (xy 104.8 110.402656) (xy 104.8 109.731879) (xy 104.807007 109.735925) (xy 104.934174 109.77) (xy 105.065826 109.77) (xy 105.192993 109.735925) (xy 105.2 109.731879) (xy 105.2 110.402655) (xy 105.269299 110.39168) (xy 105.441444 110.335748) (xy 105.441447 110.335747) (xy 105.602734 110.253565) (xy 105.749169 110.147176) (xy 105.877176 110.019169) (xy 105.983565 109.872734) (xy 106.065747 109.711447) (xy 106.065748 109.711444) (xy 106.121683 109.539293) (xy 106.132658 109.47) (xy 105.46188 109.47) (xy 105.465925 109.462993) (xy 105.5 109.335826) (xy 105.5 109.204174) (xy 105.465925 109.077007) (xy 105.46188 109.07) (xy 106.132658 109.07) (xy 106.121683 109.000706) (xy 106.065748 108.828555) (xy 106.065747 108.828552) (xy 105.983565 108.667265) (xy 105.877176 108.52083) (xy 105.749169 108.392823) (xy 105.602734 108.286434) (xy 105.441447 108.204252) (xy 105.441444 108.204251) (xy 105.269293 108.148317) (xy 105.134528 108.126972) (xy 105.071393 108.097043) (xy 105.034462 108.037731) (xy 105.03546 107.967869) (xy 105.07407 107.909636) (xy 105.138034 107.881522) (xy 105.153919 107.880499) (xy 105.894864 107.880499) (xy 105.894879 107.880497) (xy 105.894882 107.880497) (xy 105.919987 107.877586) (xy 105.919988 107.877585) (xy 105.919991 107.877585) (xy 106.022765 107.832206) (xy 106.102206 107.752765) (xy 106.147585 107.649991) (xy 106.1505 107.624865) (xy 106.150499 105.835136) (xy 106.150497 105.835117) (xy 106.147586 105.810012) (xy 106.147585 105.81001) (xy 106.147585 105.810009) (xy 106.102206 105.707235) (xy 106.022765 105.627794) (xy 106.022763 105.627793) (xy 105.919992 105.582415) (xy 105.894865 105.5795) (xy 104.105143 105.5795) (xy 104.105117 105.579502) (xy 104.080012 105.582413) (xy 104.080008 105.582415) (xy 103.977235 105.627793) (xy 103.897794 105.707234) (xy 103.852415 105.810006) (xy 103.852415 105.810008) (xy 103.8495 105.835131) (xy 100.5005 105.835131) (xy 100.5005 102.878711) (xy 101.1495 102.878711) (xy 101.1495 103.121288) (xy 101.181161 103.361785) (xy 101.243947 103.596104) (xy 101.336773 103.820205) (xy 101.336776 103.820212) (xy 101.458064 104.030289) (xy 101.458066 104.030292) (xy 101.458067 104.030293) (xy 101.605733 104.222736) (xy 101.605739 104.222743) (xy 101.777256 104.39426) (xy 101.777262 104.394265) (xy 101.969711 104.541936) (xy 102.179788 104.663224) (xy 102.4039 104.756054) (xy 102.638211 104.818838) (xy 102.818586 104.842584) (xy 102.878711 104.8505) (xy 102.878712 104.8505) (xy 103.121289 104.8505) (xy 103.169388 104.844167) (xy 103.361789 104.818838) (xy 103.5961 104.756054) (xy 103.820212 104.663224) (xy 104.030289 104.541936) (xy 104.222738 104.394265) (xy 104.394265 104.222738) (xy 104.541936 104.030289) (xy 104.663224 103.820212) (xy 104.756054 103.5961) (xy 104.818838 103.361789) (xy 104.8505 103.121288) (xy 104.8505 102.878712) (xy 104.8505 102.878711) (xy 165.1495 102.878711) (xy 165.1495 103.121288) (xy 165.181161 103.361785) (xy 165.243947 103.596104) (xy 165.336773 103.820205) (xy 165.336776 103.820212) (xy 165.458064 104.030289) (xy 165.458066 104.030292) (xy 165.458067 104.030293) (xy 165.605733 104.222736) (xy 165.605739 104.222743) (xy 165.777256 104.39426) (xy 165.777262 104.394265) (xy 165.969711 104.541936) (xy 166.179788 104.663224) (xy 166.4039 104.756054) (xy 166.638211 104.818838) (xy 166.818586 104.842584) (xy 166.878711 104.8505) (xy 166.878712 104.8505) (xy 167.121289 104.8505) (xy 167.169388 104.844167) (xy 167.361789 104.818838) (xy 167.5961 104.756054) (xy 167.820212 104.663224) (xy 168.030289 104.541936) (xy 168.222738 104.394265) (xy 168.394265 104.222738) (xy 168.541936 104.030289) (xy 168.663224 103.820212) (xy 168.756054 103.5961) (xy 168.818838 103.361789) (xy 168.8505 103.121288) (xy 168.8505 102.878712) (xy 168.818838 102.638211) (xy 168.756054 102.4039) (xy 168.663224 102.179788) (xy 168.541936 101.969711) (xy 168.394265 101.777262) (xy 168.39426 101.777256) (xy 168.222743 101.605739) (xy 168.222736 101.605733) (xy 168.030293 101.458067) (xy 168.030292 101.458066) (xy 168.030289 101.458064) (xy 167.820212 101.336776) (xy 167.820205 101.336773) (xy 167.596104 101.243947) (xy 167.361785 101.181161) (xy 167.121289 101.1495) (xy 167.121288 101.1495) (xy 166.878712 101.1495) (xy 166.878711 101.1495) (xy 166.638214 101.181161) (xy 166.403895 101.243947) (xy 166.179794 101.336773) (xy 166.179785 101.336777) (xy 165.969706 101.458067) (xy 165.777263 101.605733) (xy 165.777256 101.605739) (xy 165.605739 101.777256) (xy 165.605733 101.777263) (xy 165.458067 101.969706) (xy 165.336777 102.179785) (xy 165.336773 102.179794) (xy 165.243947 102.403895) (xy 165.181161 102.638214) (xy 165.1495 102.878711) (xy 104.8505 102.878711) (xy 104.818838 102.638211) (xy 104.756054 102.4039) (xy 104.663224 102.179788) (xy 104.541936 101.969711) (xy 104.394265 101.777262) (xy 104.39426 101.777256) (xy 104.222743 101.605739) (xy 104.222736 101.605733) (xy 104.030293 101.458067) (xy 104.030292 101.458066) (xy 104.030289 101.458064) (xy 103.820212 101.336776) (xy 103.820205 101.336773) (xy 103.596104 101.243947) (xy 103.361785 101.181161) (xy 103.121289 101.1495) (xy 103.121288 101.1495) (xy 102.878712 101.1495) (xy 102.878711 101.1495) (xy 102.638214 101.181161) (xy 102.403895 101.243947) (xy 102.179794 101.336773) (xy 102.179785 101.336777) (xy 101.969706 101.458067) (xy 101.777263 101.605733) (xy 101.777256 101.605739) (xy 101.605739 101.777256) (xy 101.605733 101.777263) (xy 101.458067 101.969706) (xy 101.336777 102.179785) (xy 101.336773 102.179794) (xy 101.243947 102.403895) (xy 101.181161 102.638214) (xy 101.1495 102.878711) (xy 100.5005 102.878711) (xy 100.5005 100.6245) (xy 100.520185 100.557461) (xy 100.572989 100.511706) (xy 100.6245 100.5005) (xy 169.3755 100.5005)
 			)
 		)
 	)

--- a/src/kicad_tools/schematic/blocks/motor.py
+++ b/src/kicad_tools/schematic/blocks/motor.py
@@ -899,6 +899,8 @@ class GateDriverBlock(CircuitBlock):
         bypass_caps: list[str] | None = None,
         cap_ref_start: int = 1,
         pin_nets: dict[str, str] | None = None,
+        bypass_cap_footprint: str | None = None,
+        auto_footprint: bool = False,
     ):
         """
         Create a gate driver block.
@@ -928,6 +930,17 @@ class GateDriverBlock(CircuitBlock):
                 For every entry, an alias port is also added under the
                 net name so callers can retrieve real pin coordinates via
                 ``block.port("<net>")``.
+            bypass_cap_footprint: Explicit footprint string (e.g.,
+                ``"Capacitor_SMD:C_0805_2012Metric"``) forwarded to each
+                bypass cap's ``add_symbol`` call.  When ``None`` (default),
+                no explicit footprint is set, preserving back-compat for
+                existing callers.  Takes precedence over ``auto_footprint``
+                when both are provided.  Mirrors the convention used by
+                :class:`DecouplingCaps` and the regulator blocks.
+            auto_footprint: If ``True``, forwarded as ``auto_footprint=True``
+                to each bypass cap's ``add_symbol`` call so the schematic's
+                footprint-selector profile chooses a footprint based on the
+                cap value.  Default ``False`` preserves back-compat.
         """
         super().__init__(sch, x, y)
         self.driver_type = driver_type
@@ -973,13 +986,22 @@ class GateDriverBlock(CircuitBlock):
             self.bootstrap_caps = []
 
         # Add bypass capacitors
+        # Build add_symbol kwargs once -- mirrors the DecouplingCaps pattern
+        # at blocks/power/passives.py:64-66 so the bypass caps inherit a
+        # footprint (explicit or auto-selected) rather than landing in the
+        # schematic with an empty footprint field (see issue #3009).
+        bypass_add_kwargs: dict = {"auto_footprint": auto_footprint}
+        if bypass_cap_footprint is not None:
+            bypass_add_kwargs["footprint"] = bypass_cap_footprint
         self.bypass_caps = []
         bypass_start = cap_ref_start + num_phases
         for i, cap_value in enumerate(bypass_caps):
             cap_ref = f"C{bypass_start + i}"
             cap_x = x + 20 + i * 10
             cap_y = y - 15
-            cap = sch.add_symbol("Device:C", cap_x, cap_y, cap_ref, cap_value)
+            cap = sch.add_symbol(
+                "Device:C", cap_x, cap_y, cap_ref, cap_value, **bypass_add_kwargs
+            )
             self.bypass_caps.append(cap)
             self.components[f"C_BYPASS{i + 1}"] = cap
 

--- a/tests/test_schematic_blocks.py
+++ b/tests/test_schematic_blocks.py
@@ -4044,6 +4044,12 @@ class TestGateDriverBlockMocked:
 
         def create_mock_component(symbol, x, y, ref, *args, **kwargs):
             comp = Mock()
+            # Reflect the footprint kwarg (if any) onto the mock component
+            # so tests can assert `.footprint` after construction -- mirrors
+            # the real SymbolInstance.footprint attribute populated by
+            # `Schematic.add_symbol`.  Empty string default matches the
+            # production default for back-compat callers.
+            comp.footprint = kwargs.get("footprint", "")
             comp.pin_position.side_effect = lambda name: {
                 "1": (x, y - 5),
                 "2": (x, y + 5),
@@ -4101,6 +4107,76 @@ class TestGateDriverBlockMocked:
 
         # Should wire bypass caps
         assert mock_schematic.wire_decoupling_cap.called
+
+    def test_gate_driver_explicit_bypass_cap_footprint(self, mock_schematic):
+        """Explicit bypass_cap_footprint sets .footprint on every bypass cap."""
+        # Regression for issue #3009 -- bypass caps used to land in the
+        # schematic with footprint="" because GateDriverBlock didn't forward
+        # any footprint kwarg to add_symbol.  Pass ``bootstrap_caps=None`` so
+        # the only ``Device:C`` add_symbol calls come from the bypass loop
+        # (matches board-05's GateDriverBlock invocation).
+        fp = "Capacitor_SMD:C_0805_2012Metric"
+        driver = GateDriverBlock(
+            mock_schematic,
+            x=100,
+            y=100,
+            bootstrap_caps=None,
+            bypass_cap_footprint=fp,
+        )
+
+        assert len(driver.bypass_caps) == 2
+        for cap in driver.bypass_caps:
+            assert cap.footprint == fp
+
+        # Every bypass-cap call to add_symbol must carry footprint=fp.
+        bypass_calls = [
+            call for call in mock_schematic.add_symbol.call_args_list
+            if call.args and call.args[0] == "Device:C"
+        ]
+        assert len(bypass_calls) == 2
+        for call in bypass_calls:
+            assert call.kwargs.get("footprint") == fp
+
+    def test_gate_driver_auto_footprint_forwarded(self, mock_schematic):
+        """auto_footprint=True is forwarded to every bypass-cap add_symbol call."""
+        driver = GateDriverBlock(
+            mock_schematic,
+            x=100,
+            y=100,
+            bootstrap_caps=None,
+            auto_footprint=True,
+        )
+
+        assert len(driver.bypass_caps) == 2
+        bypass_calls = [
+            call for call in mock_schematic.add_symbol.call_args_list
+            if call.args and call.args[0] == "Device:C"
+        ]
+        assert len(bypass_calls) == 2
+        for call in bypass_calls:
+            assert call.kwargs.get("auto_footprint") is True
+
+    def test_gate_driver_default_back_compat(self, mock_schematic):
+        """Default construction (no footprint kwargs) preserves back-compat."""
+        # Should not raise, bypass caps land with footprint="" (matches the
+        # pre-#3009 production behavior so existing callers see no change).
+        driver = GateDriverBlock(
+            mock_schematic, x=100, y=100, bootstrap_caps=None
+        )
+
+        assert len(driver.bypass_caps) == 2
+        for cap in driver.bypass_caps:
+            assert cap.footprint == ""
+
+        bypass_calls = [
+            call for call in mock_schematic.add_symbol.call_args_list
+            if call.args and call.args[0] == "Device:C"
+        ]
+        assert len(bypass_calls) == 2
+        for call in bypass_calls:
+            # Default forwards auto_footprint=False, no explicit footprint kwarg.
+            assert call.kwargs.get("auto_footprint") is False
+            assert "footprint" not in call.kwargs
 
 
 class TestMotorControlFactoryFunctions:


### PR DESCRIPTION
## Summary

- Adds `bypass_cap_footprint: str | None = None` and `auto_footprint: bool = False` kwargs to `GateDriverBlock.__init__`, mirroring the `DecouplingCaps` curator pattern. Bypass caps now carry the requested footprint instead of landing in the schematic with an empty `Footprint` field.
- Board-05 passes `bypass_cap_footprint="Capacitor_SMD:C_0805_2012Metric"` for C15/C16 (schematic refs C18/C19) so the BOM stays consistent with the rest of the 0805 passives on that board. Regenerated `bldc_controller.kicad_sch` now shows `Footprint "Capacitor_SMD:C_0805_2012Metric"` on C18 and C19.
- Defaults preserve byte-identical back-compat for existing callers (no kwarg = same behaviour as before).
- Extends `TestGateDriverBlockMocked` with three new tests: explicit footprint sets `.footprint` on every cap, `auto_footprint=True` is forwarded to every `add_symbol` call, and default construction stays back-compat.

## Scope

- Source: `src/kicad_tools/schematic/blocks/motor.py` — `GateDriverBlock.__init__` signature + docstring + bypass-cap loop (~25 LOC).
- Caller: `boards/05-bldc-motor-controller/design.py` — one new kwarg on the existing `GateDriverBlock(...)` call (3 LOC).
- Tests: `tests/test_schematic_blocks.py::TestGateDriverBlockMocked` — fixture captures `footprint=` kwarg on the mock component; three new tests (~50 LOC).
- Regenerated: `boards/05-bldc-motor-controller/output/bldc_controller.kicad_sch`, `.kicad_pcb`, `_routed.kicad_pcb`.

`BootstrapCapacitorArray` at `motor.py:816` has the same bug shape but is not exercised by board-05 (`bootstrap_caps=None`); follow-up issue filed.

## Test plan

- [x] `uv run pytest tests/test_schematic_blocks.py::TestGateDriverBlockMocked` — 7/7 pass (was 4 tests, now 7).
- [x] `uv run pytest tests/test_schematic_blocks.py tests/test_blocks_bootstrap_cap_array.py tests/test_board_05_drv8308_pin_nets.py` — 361/361 pass.
- [x] Regenerated board-05 — ERC count = 1 (below the ≤4 bound from PR #3007).
- [x] `grep -A1 'Reference" "C1[89]"' bldc_controller.kicad_sch` shows `Footprint "Capacitor_SMD:C_0805_2012Metric"` (was `""`).

Closes #3009