### PR TITLE
feat(schematic): add_pwr_symbol() synthesizes #PWR for arbitrary net names

### DIFF
--- a/src/kicad_tools/schematic/models/elements_mixin.py
+++ b/src/kicad_tools/schematic/models/elements_mixin.py
@@ -363,6 +363,214 @@ class SchematicElementsMixin:
         _log_info(f"Added power symbol {lib_id.split(':')[1]} at ({x}, {y})")
         return pwr
 
+    # Private lib prefix for synthesized power symbols.  Distinguishing
+    # these from KiCad's stock ``power:`` library makes round-trips
+    # unambiguous and prevents accidental collisions if a future KiCad
+    # release ships a ``power:VMOTOR`` symbol.
+    _PWR_SYNTH_LIB_PREFIX = "kicad_tools_pwr"
+
+    def add_pwr_symbol(
+        self,
+        net_name: str,
+        x: float,
+        y: float,
+        rotation: float = 0,
+        snap: bool = True,
+    ) -> PowerSymbol:
+        """Add a power symbol whose net name is set by the caller.
+
+        Unlike :meth:`add_power`, which reaches into KiCad's stock
+        ``power:`` library (where the symbol name and the published net
+        name are baked in together — ``power:+24V`` always publishes
+        ``+24V``), this helper **synthesizes** a one-pin power-input
+        symbol on the fly with ``net_name`` as the published global net.
+
+        The synthesized lib_symbol is cached per net name and registered
+        for emission via :meth:`_build_lib_symbols_node`, so the symbol
+        round-trips through save/load cycles (the next reader sees a
+        normal ``lib_symbols`` entry in the schematic file, identical in
+        structure to a stock ``power:+5V`` entry).
+
+        This is the right call site whenever a rail label uses a name
+        that doesn't match any stock ``power:`` symbol — most commonly
+        domain-specific rails like ``VMOTOR`` (no KiCad analogue) or
+        project-convention names like ``+3.3V`` (KiCad uses ``+3V3``).
+
+        Args:
+            net_name: The global net name to publish (e.g., ``"VMOTOR"``,
+                ``"+3.3V"``, ``"+5V"``).  Becomes the symbol's ``Value``
+                property AND its power-input pin name; KiCad uses the
+                ``Value`` property to determine the global power net.
+            x, y: Position (snapped to grid unless ``snap=False``).
+            rotation: Rotation in degrees (0 = arrow up, 180 = arrow
+                down, typical for GND).
+            snap: Whether to apply grid snapping (default: True).
+
+        Returns:
+            The :class:`PowerSymbol` instance placed in the schematic.
+
+        Example:
+            # VMOTOR rail has no stock analogue — synthesize one.
+            sch.add_rail(y=80, x_start=20, x_end=200, net_label="VMOTOR")
+            sch.add_pwr_symbol("VMOTOR", x=30, y=70)
+            sch.add_wire((30, 70), (30, 80))  # tie symbol pin to rail
+
+            # +3.3V (with the dot) matches project convention; KiCad's
+            # stock symbol is +3V3 which would publish a mismatched net.
+            sch.add_pwr_symbol("+3.3V", x=100, y=70)
+
+        See Also:
+            - add_power(): for stock ``power:`` symbols (when the symbol
+              name already matches the rail label).
+            - add_pwr_flag(): to mark a power net as externally driven.
+        """
+        ref = f"#PWR{self._pwr_counter:02d}"
+        self._pwr_counter += 1
+
+        if snap:
+            x = self._snap_coord(x, f"pwr_symbol {net_name}")
+            y = self._snap_coord(y, f"pwr_symbol {net_name}")
+        else:
+            x = round(x, 2)
+            y = round(y, 2)
+
+        lib_id = f"{self._PWR_SYNTH_LIB_PREFIX}:{net_name}"
+
+        # Build (or fetch from cache) the synthesized lib_symbol entry.
+        if net_name not in self._synthesized_pwr_defs:
+            sym_node = self._build_synth_pwr_lib_symbol(net_name)
+            self._synthesized_pwr_defs[net_name] = sym_node
+            # Register in _embedded_lib_symbols so _build_lib_symbols_node
+            # emits the entry on save.  Keyed by lib_id (full prefixed
+            # name), matching how loaded schematics key stock entries
+            # like ``power:+5V``.
+            self._embedded_lib_symbols[lib_id] = sym_node
+
+        pwr = PowerSymbol(
+            lib_id=lib_id,
+            x=x,
+            y=y,
+            rotation=rotation,
+            reference=ref,
+        )
+        self.power_symbols.append(pwr)
+        _log_info(f"Added synthesized power symbol '{net_name}' at ({x}, {y})")
+        return pwr
+
+    def _build_synth_pwr_lib_symbol(self, net_name: str):
+        """Construct a synthesized power-symbol lib_symbol S-expression.
+
+        The structure mirrors KiCad's stock ``power:+5V`` entry exactly,
+        differing only in:
+
+        * The outer symbol name (``"kicad_tools_pwr:{net_name}"``).
+        * The ``Value`` property (``"{net_name}"`` — this is what KiCad
+          uses to determine the published global net).
+        * The ``Description`` property (mentions ``net_name`` for
+          discoverability).
+        * The power_in pin's ``name`` field (set to ``net_name`` as a
+          belt-and-suspenders match; KiCad's stock symbols leave it
+          empty but the issue body specifies the pin name should match
+          for net unification on older KiCad readers).
+        * The graphical unit symbols are renamed to
+          ``"{net_name}_0_1"`` / ``"{net_name}_1_1"`` per KiCad's
+          parent/unit naming convention.
+
+        Args:
+            net_name: The net name to bake in.
+
+        Returns:
+            An :class:`SExp` node ready to insert into ``lib_symbols``.
+        """
+        from kicad_tools.sexp import parse_string
+
+        # Escape any embedded quotes in net_name for the Description
+        # property's quoted-string substitution (e.g., a hypothetical
+        # net name containing a double quote).  S-expression strings
+        # use backslash-escapes.
+        desc_net = net_name.replace("\\", "\\\\").replace('"', '\\"')
+
+        # Use a triple-quoted template so the structure is reviewable
+        # at a glance.  All five substitutions of ``net_name`` are
+        # explicit and use ``{nn}`` for legibility.
+        template = """
+        (symbol "{lib_id}"
+            (power)
+            (pin_numbers (hide yes))
+            (pin_names (offset 0) (hide yes))
+            (exclude_from_sim no)
+            (in_bom yes)
+            (on_board yes)
+            (duplicate_pin_numbers_are_jumpers no)
+            (property "Reference" "#PWR"
+                (at 0 -3.81 0)
+                (effects (font (size 1.27 1.27)) (hide yes))
+            )
+            (property "Value" "{nn}"
+                (at 0 3.556 0)
+                (effects (font (size 1.27 1.27)))
+            )
+            (property "Footprint" ""
+                (at 0 0 0)
+                (effects (font (size 1.27 1.27)) (hide yes))
+            )
+            (property "Datasheet" ""
+                (at 0 0 0)
+                (effects (font (size 1.27 1.27)) (hide yes))
+            )
+            (property "Description" "Synthesized power symbol for net \\"{desc_nn}\\""
+                (at 0 0 0)
+                (effects (font (size 1.27 1.27)) (hide yes))
+            )
+            (symbol "{nn}_0_1"
+                (polyline
+                    (pts (xy -0.762 1.27) (xy 0 2.54))
+                    (stroke (width 0) (type default))
+                    (fill (type none))
+                )
+                (polyline
+                    (pts (xy 0 2.54) (xy 0.762 1.27))
+                    (stroke (width 0) (type default))
+                    (fill (type none))
+                )
+                (polyline
+                    (pts (xy 0 0) (xy 0 2.54))
+                    (stroke (width 0) (type default))
+                    (fill (type none))
+                )
+            )
+            (symbol "{nn}_1_1"
+                (pin power_in line
+                    (at 0 0 90)
+                    (length 0)
+                    (name "{nn}" (effects (font (size 1.27 1.27))))
+                    (number "1" (effects (font (size 1.27 1.27))))
+                )
+            )
+            (embedded_fonts no)
+        )
+        """.format(
+            lib_id=f"{self._PWR_SYNTH_LIB_PREFIX}:{net_name}",
+            nn=net_name,
+            desc_nn=desc_net,
+        )
+
+        # parse_string returns a single top-level node when the input
+        # has one expression.  In some implementations the root may be
+        # the symbol node directly, in others wrapped in an anonymous
+        # container; handle both defensively.
+        parsed = parse_string(template.strip())
+        if parsed.name == "symbol":
+            return parsed
+        # Wrapped form: pick out the inner symbol child.
+        for child in parsed.children:
+            if not child.is_atom and child.name == "symbol":
+                return child
+        raise RuntimeError(
+            f"Failed to synthesize power lib_symbol for net '{net_name}': "
+            f"unexpected parse tree shape (root={parsed.name!r})"
+        )
+
     def add_pwr_flag(self, x: float, y: float) -> PowerSymbol:
         """Add a PWR_FLAG symbol to mark a power net as intentionally driven.
 
@@ -494,7 +702,9 @@ class SchematicElementsMixin:
         wires = []
         for i in range(len(points) - 1):
             wires.append(
-                self.add_wire(points[i], points[i + 1], snap=snap, warn_on_collision=warn_on_collision)
+                self.add_wire(
+                    points[i], points[i + 1], snap=snap, warn_on_collision=warn_on_collision
+                )
             )
         return wires
 

--- a/src/kicad_tools/schematic/models/schematic.py
+++ b/src/kicad_tools/schematic/models/schematic.py
@@ -159,6 +159,15 @@ class Schematic(
         # Embedded lib_symbols from loaded schematics (preserved for round-trip)
         self._embedded_lib_symbols: dict[str, SExp] = {}
 
+        # Synthesized power-symbol lib_symbol definitions (per net name).
+        # Populated by ``add_pwr_symbol()`` so that #PWR symbols can publish
+        # arbitrary global net names (e.g. ``VMOTOR``, ``+3.3V``) without
+        # relying on KiCad's stock ``power:`` library — whose symbol names
+        # bake in the net name (``+24V``, ``+3V3``) and therefore drive the
+        # WRONG global net when project convention uses ``VMOTOR`` / ``+3.3V``
+        # as rail labels.  Key is the net name (lib_id local part).
+        self._synthesized_pwr_defs: dict[str, SExp] = {}
+
         # Track continuous rails for T-connection warnings
         # Each entry: (y, x_start, x_end) for horizontal rails
         self._continuous_rails: list[tuple[float, float, float]] = []

--- a/tests/test_pwr_symbol_net_match.py
+++ b/tests/test_pwr_symbol_net_match.py
@@ -1,0 +1,353 @@
+"""Tests for ``Schematic.add_pwr_symbol`` — synthesized power-symbol helper.
+
+Covers issue #3010: KiCad's stock ``power:`` library bakes the published
+global-net name into each symbol (``power:+24V`` always publishes ``+24V``).
+When project convention uses rail labels like ``VMOTOR`` (no stock analogue)
+or ``+3.3V`` (KiCad uses ``+3V3``), placing a stock symbol on the rail
+creates two electrically distinct nets that look visually unified.
+
+``add_pwr_symbol(net_name=...)`` fixes this at the block level by
+synthesizing a one-pin power-input symbol whose Value field AND pin name
+both equal ``net_name``, so KiCad publishes the requested global net.
+
+Test surface:
+
+* The synthesized lib_symbol contains a ``pin power_in`` whose ``name``
+  matches the requested ``net_name``, and a ``Value`` property that also
+  matches.
+* The instantiated :class:`PowerSymbol` carries the synthesized ``lib_id``.
+* The synthesized lib_symbol is registered in ``_embedded_lib_symbols`` so
+  ``_build_lib_symbols_node`` emits it on save.
+* A schematic written-then-reloaded preserves the synthesized lib_symbol
+  (round-trip stability through ``_embedded_lib_symbols``).
+* Repeated calls with the same ``net_name`` reuse the cached lib_symbol
+  rather than creating duplicates.
+* Edge-case net names (``+3.3V`` with a dot, ``GND``) work as well as
+  alphanumeric names like ``VMOTOR``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.schematic.models.elements import PowerSymbol
+from kicad_tools.schematic.models.schematic import Schematic, SnapMode
+
+# ---------------------------------------------------------------------------
+# Synthesized lib_symbol structure
+# ---------------------------------------------------------------------------
+
+
+class TestSynthesizedLibSymbolStructure:
+    """Verify the lib_symbol entry produced by ``add_pwr_symbol``."""
+
+    def test_pin_name_matches_net_name_vmotor(self):
+        """For ``VMOTOR``, the power_in pin's name field must equal ``VMOTOR``."""
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sch.add_pwr_symbol("VMOTOR", x=100, y=100)
+
+        lib_node = sch._embedded_lib_symbols["kicad_tools_pwr:VMOTOR"]
+        out = lib_node.to_string(indent=0)
+        # The pin name appears inside the inner unit symbol VMOTOR_1_1.
+        assert "(pin power_in line" in out
+        assert '(name "VMOTOR"' in out
+
+    def test_pin_name_matches_net_name_with_dot(self):
+        """``+3.3V`` (with the dot — project convention) must be preserved."""
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sch.add_pwr_symbol("+3.3V", x=100, y=100)
+
+        lib_node = sch._embedded_lib_symbols["kicad_tools_pwr:+3.3V"]
+        out = lib_node.to_string(indent=0)
+        assert '(name "+3.3V"' in out
+
+    def test_value_property_matches_net_name(self):
+        """The ``Value`` property must equal the net name.
+
+        KiCad determines the published global net from the ``Value`` field
+        of a ``(power)`` symbol — this is the single most load-bearing
+        invariant.
+        """
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sch.add_pwr_symbol("VMOTOR", x=100, y=100)
+
+        lib_node = sch._embedded_lib_symbols["kicad_tools_pwr:VMOTOR"]
+        # Walk properties and find Value
+        value_prop = None
+        for prop in lib_node.find_all("property"):
+            atoms = prop.get_atoms()
+            if len(atoms) >= 2 and str(atoms[0]) == "Value":
+                value_prop = str(atoms[1])
+                break
+        assert value_prop == "VMOTOR", f"Value property must equal net name; got {value_prop!r}"
+
+    def test_symbol_has_power_flag(self):
+        """The synthesized symbol must carry the ``(power)`` flag.
+
+        Without it, KiCad treats the symbol as an ordinary component
+        instead of as a global-net driver.
+        """
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sch.add_pwr_symbol("VMOTOR", x=100, y=100)
+
+        lib_node = sch._embedded_lib_symbols["kicad_tools_pwr:VMOTOR"]
+        assert lib_node.get("power") is not None, (
+            "Synthesized lib_symbol missing (power) flag — KiCad will not "
+            "treat it as a global-net symbol"
+        )
+
+
+# ---------------------------------------------------------------------------
+# PowerSymbol instance returned by add_pwr_symbol
+# ---------------------------------------------------------------------------
+
+
+class TestAddPwrSymbolReturnValue:
+    def test_returns_power_symbol(self):
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        pwr = sch.add_pwr_symbol("VMOTOR", x=100, y=100)
+        assert isinstance(pwr, PowerSymbol)
+
+    def test_lib_id_uses_synth_prefix(self):
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        pwr = sch.add_pwr_symbol("VMOTOR", x=100, y=100)
+        assert pwr.lib_id == "kicad_tools_pwr:VMOTOR"
+
+    def test_lib_id_with_dot_net_name(self):
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        pwr = sch.add_pwr_symbol("+3.3V", x=100, y=100)
+        assert pwr.lib_id == "kicad_tools_pwr:+3.3V"
+
+    def test_reference_uses_pwr_counter(self):
+        """First call gets #PWR01, second gets #PWR02, etc."""
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        pwr1 = sch.add_pwr_symbol("VMOTOR", x=100, y=100)
+        pwr2 = sch.add_pwr_symbol("+5V", x=120, y=100)
+        assert pwr1.reference == "#PWR01"
+        assert pwr2.reference == "#PWR02"
+
+    def test_appended_to_power_symbols_list(self):
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        assert len(sch.power_symbols) == 0
+        sch.add_pwr_symbol("VMOTOR", x=100, y=100)
+        assert len(sch.power_symbols) == 1
+
+
+# ---------------------------------------------------------------------------
+# Caching: repeated net names reuse the same lib_symbol
+# ---------------------------------------------------------------------------
+
+
+class TestSynthesizedLibSymbolCaching:
+    def test_repeated_net_name_creates_one_lib_symbol(self):
+        """Two #PWR symbols on the same net share one lib_symbol entry."""
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sch.add_pwr_symbol("VMOTOR", x=100, y=100)
+        sch.add_pwr_symbol("VMOTOR", x=200, y=100)
+
+        assert len(sch._synthesized_pwr_defs) == 1
+        assert "VMOTOR" in sch._synthesized_pwr_defs
+        # The instances both reference the same lib_id
+        assert len(sch.power_symbols) == 2
+        assert all(p.lib_id == "kicad_tools_pwr:VMOTOR" for p in sch.power_symbols)
+
+    def test_different_net_names_create_distinct_lib_symbols(self):
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sch.add_pwr_symbol("VMOTOR", x=100, y=100)
+        sch.add_pwr_symbol("+3.3V", x=120, y=100)
+        sch.add_pwr_symbol("+5V", x=140, y=100)
+        sch.add_pwr_symbol("GND", x=160, y=100)
+
+        assert len(sch._synthesized_pwr_defs) == 4
+        assert set(sch._synthesized_pwr_defs.keys()) == {"VMOTOR", "+3.3V", "+5V", "GND"}
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: synthesized lib_symbols survive write -> load -> write -> load
+# ---------------------------------------------------------------------------
+
+
+class TestSynthesizedLibSymbolRoundTrip:
+    def test_save_and_reload_preserves_lib_symbol(self, tmp_path: Path):
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sch.add_pwr_symbol("VMOTOR", x=100, y=100)
+        sch.add_pwr_symbol("+3.3V", x=120, y=100)
+
+        p = tmp_path / "test.kicad_sch"
+        sch.write(p)
+
+        sch2 = Schematic.load(str(p))
+        # The reload must recover both #PWR instances
+        assert len(sch2.power_symbols) == 2
+        lib_ids = {p.lib_id for p in sch2.power_symbols}
+        assert lib_ids == {"kicad_tools_pwr:VMOTOR", "kicad_tools_pwr:+3.3V"}
+
+        # The lib_symbols block in the reloaded schematic must still carry
+        # the synthesized entries (these come back via _embedded_lib_symbols).
+        assert "kicad_tools_pwr:VMOTOR" in sch2._embedded_lib_symbols
+        assert "kicad_tools_pwr:+3.3V" in sch2._embedded_lib_symbols
+
+    def test_double_round_trip_is_stable(self, tmp_path: Path):
+        """Write -> load -> write -> load preserves the lib_symbols block."""
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sch.add_pwr_symbol("VMOTOR", x=100, y=100)
+
+        p1 = tmp_path / "test1.kicad_sch"
+        sch.write(p1)
+
+        sch2 = Schematic.load(str(p1))
+        p2 = tmp_path / "test2.kicad_sch"
+        sch2.write(p2)
+
+        sch3 = Schematic.load(str(p2))
+        assert len(sch3.power_symbols) == 1
+        assert sch3.power_symbols[0].lib_id == "kicad_tools_pwr:VMOTOR"
+        assert "kicad_tools_pwr:VMOTOR" in sch3._embedded_lib_symbols
+
+        # The lib_symbol structure on second reload must still have the
+        # right Value property and pin name.
+        lib_node = sch3._embedded_lib_symbols["kicad_tools_pwr:VMOTOR"]
+        out = lib_node.to_string(indent=0)
+        assert '(name "VMOTOR"' in out
+
+    def test_pin_name_preserved_across_round_trip(self, tmp_path: Path):
+        """The load-bearing invariant: pin name equals net_name after reload."""
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sch.add_pwr_symbol("+3.3V", x=100, y=100)
+
+        p = tmp_path / "test.kicad_sch"
+        sch.write(p)
+
+        sch2 = Schematic.load(str(p))
+        lib_node = sch2._embedded_lib_symbols["kicad_tools_pwr:+3.3V"]
+        out = lib_node.to_string(indent=0)
+        assert '(name "+3.3V"' in out
+
+
+# ---------------------------------------------------------------------------
+# Grid snapping
+# ---------------------------------------------------------------------------
+
+
+class TestSnapping:
+    def test_snap_off_preserves_coordinates(self):
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        pwr = sch.add_pwr_symbol("VMOTOR", x=100.5, y=100.7, snap=False)
+        # snap=False AND SnapMode.OFF means just round to 2dp
+        assert pwr.x == 100.5
+        assert pwr.y == 100.7
+
+    def test_snap_with_explicit_false_skips_snap(self):
+        sch = Schematic(title="Test", snap_mode=SnapMode.AUTO)
+        pwr = sch.add_pwr_symbol("VMOTOR", x=100.5, y=100.7, snap=False)
+        assert pwr.x == 100.5
+        assert pwr.y == 100.7
+
+    def test_rotation_passes_through(self):
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        pwr = sch.add_pwr_symbol("GND", x=100, y=100, rotation=180)
+        assert pwr.rotation == 180
+
+
+# ---------------------------------------------------------------------------
+# Integration: kicad-cli loads the synthesized schematic
+# ---------------------------------------------------------------------------
+
+
+def _find_kicad_cli() -> str | None:
+    """Locate kicad-cli on macOS or fall back to PATH."""
+    import shutil
+
+    mac_path = "/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli"
+    if Path(mac_path).exists():
+        return mac_path
+    return shutil.which("kicad-cli")
+
+
+@pytest.mark.skipif(_find_kicad_cli() is None, reason="kicad-cli not found")
+class TestKicadCliIntegration:
+    """End-to-end: write a schematic with a synthesized symbol and run ERC.
+
+    The load-bearing assertion is that kicad-cli accepts the file (no
+    parse errors) AND that the ERC violation, if any, reports the net
+    name we asked for — confirming the synthesized symbol unifies with
+    the rail label on the KiCad side, not just on ours.
+    """
+
+    def _run_erc(self, sch_path: Path, out_dir: Path) -> dict:
+        """Run kicad-cli sch erc and return the parsed JSON report."""
+        import json
+        import subprocess
+
+        cli = _find_kicad_cli()
+        report = out_dir / "erc.json"
+        subprocess.run(
+            [
+                cli,
+                "sch",
+                "erc",
+                str(sch_path),
+                "-o",
+                str(report),
+                "--format",
+                "json",
+                "--severity-error",
+            ],
+            capture_output=True,
+            check=False,
+        )
+        return json.loads(report.read_text())
+
+    def test_synthesized_symbol_publishes_requested_net(self, tmp_path: Path):
+        """ERC violation must reference net ``VMOTOR``, not ``+24V``."""
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        # Stub wire + label so the symbol pin meets a real wire endpoint
+        # and the rail carries the matching label.
+        sch.add_wire((100, 100), (100, 110), warn_on_collision=False)
+        sch.add_pwr_symbol("VMOTOR", x=100, y=100)
+        sch.add_label("VMOTOR", x=100, y=110, validate_connection=False)
+
+        p = tmp_path / "t.kicad_sch"
+        sch.write(p)
+        erc = self._run_erc(p, tmp_path)
+
+        # The synthesized symbol publishes VMOTOR.  Without a PWR_FLAG
+        # the net is undriven, so ERC emits power_pin_not_driven naming
+        # the symbol — and the pin description must include "VMOTOR" if
+        # the synthesized pin name took effect.
+        descriptions = []
+        for sheet in erc.get("sheets", []):
+            for v in sheet.get("violations", []):
+                for item in v.get("items", []):
+                    descriptions.append(item.get("description", ""))
+        # At least one violation item description should include the net name
+        assert any("VMOTOR" in d for d in descriptions), (
+            f"Expected VMOTOR in ERC item descriptions; got {descriptions!r}"
+        )
+
+    def test_pwr_flag_drives_synthesized_net(self, tmp_path: Path):
+        """Net unification check: PWR_FLAG on the rail clears ERC.
+
+        If the synthesized symbol unified the wrong net (e.g., ``+24V``
+        instead of ``VMOTOR``), then a ``PWR_FLAG`` on the ``VMOTOR``
+        rail would leave the symbol's net undriven.  Zero ERC errors
+        proves unification works.
+        """
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sch.add_wire((100, 100), (100, 110), warn_on_collision=False)
+        sch.add_wire((100, 110), (200, 110), warn_on_collision=False)
+        sch.add_pwr_symbol("VMOTOR", x=100, y=100)
+        sch.add_label("VMOTOR", x=150, y=110, validate_connection=False)
+        sch.add_pwr_flag(100, 110)
+
+        p = tmp_path / "t.kicad_sch"
+        sch.write(p)
+        erc = self._run_erc(p, tmp_path)
+
+        total = sum(len(s.get("violations", [])) for s in erc.get("sheets", []))
+        assert total == 0, (
+            f"Expected zero ERC errors with PWR_FLAG driving the synthesized "
+            f"VMOTOR symbol; got {total}. Report: {erc}"
+        )


### PR DESCRIPTION
## Summary

KiCad's stock `power:` library bakes the published global-net name
into each symbol (`power:+24V` always publishes `+24V`, with no way to
retarget that to a different rail label). Project convention across
the shared block library uses semantic rail names (`VMOTOR`, `+3.3V`,
`+5V`) which don't match the stock symbol names (no `power:VMOTOR`;
`power:+3V3` vs the rail's `+3.3V`).

When `add_power("power:+24V", ...)` is placed on a `VMOTOR` rail,
the symbol publishes net `+24V` while the rail carries `VMOTOR` —
two electrically distinct nets that look visually unified. ERC then
flags `power_pin_not_driven` on the symbol's ghost net, and the
compensation is brittle (depends on label-on-stub placement bridging
the two by accident, see #3011).

This PR adds `Schematic.add_pwr_symbol(net_name, x, y, ...)` which:

- Synthesizes a one-pin power-input lib_symbol on the fly with
  `net_name` as both the `Value` property AND the power_in pin name.
- Caches the synthesized symbol per net name so two #PWR symbols on
  the same net share one lib_symbol entry.
- Registers the synthesis in `_embedded_lib_symbols` so it
  round-trips through save/load cycles (the next reader sees a normal
  `lib_symbols` entry, identical in structure to a stock `power:+5V`).
- Uses a `kicad_tools_pwr:` lib prefix to distinguish from KiCad's
  stock `power:` and avoid future collisions if upstream ships
  `power:VMOTOR`.

**Hard constraints honored**:
- No changes to `add_power()` API — existing callers keep working.
- No rail renaming — project convention preserved.
- No changes to shared block library defaults.

**Curator strategy: code-only PR first** (per #3010 description). The
board-05 call-site swap (the surfacing fix) is deferred to a follow-up
PR to avoid merge churn with concurrent board-05 work (#3008, #3009,
#3011) that all regenerate `bldc_controller.kicad_sch`. The helper
ships standalone here so the follow-up PR can be a small ~4-line swap.

## Implementation

- `src/kicad_tools/schematic/models/elements_mixin.py:366-573` —
  `add_pwr_symbol()` and `_build_synth_pwr_lib_symbol()`.
- `src/kicad_tools/schematic/models/schematic.py:160-170` — new
  `_synthesized_pwr_defs` dict on the Schematic class.
- `tests/test_pwr_symbol_net_match.py` (new, 19 tests).

## Out of scope (deferred follow-ups)

- Board-05 call-site swap (next PR after this lands; isolated change
  in `boards/05-bldc-motor-controller/design.py` lines 124, 143, 155, 182).
- Board-04's same-class mismatch (`+3.3V` rail vs `power:+3V3` symbol
  at `boards/04-stm32-devboard/generate_design.py:121`) — sibling
  cleanup follow-up.
- `add_rail()` `start_pwr_net=` / `end_pwr_net=` kwarg sugar.

## Test plan

- [x] `pytest tests/test_pwr_symbol_net_match.py -v` — 19 tests pass
  (structure, return value, caching, round-trip, snapping, kicad-cli
  ERC integration).
- [x] `pytest tests/test_schematic_editing.py tests/test_auto_layout.py
  tests/test_blocks_three_phase_inverter.py tests/test_blocks_debug_header.py
  tests/test_blocks_half_bridge.py tests/test_board_05_drv8308_pin_nets.py
  tests/test_schematic_helpers.py` — 154 related tests pass.
- [x] Full sweep (1550 tests) — only pre-existing failures (5 in
  netlist_query/cli_netlist/report_cmd/board_05_routing_regression,
  none touching synthesized power-symbol code).
- [x] kicad-cli sch erc end-to-end: synthesized `VMOTOR` #PWR + label
  + PWR_FLAG produces zero ERC errors (net unification works).
- [x] Round-trip (write → load → write → load) preserves the
  synthesized lib_symbol with pin name == net_name intact.
- [x] `ruff check` clean on touched files (1 unrelated pre-existing
  lint warning at line 80 in unrelated function `_point_on_any_wire`).
- [x] `ruff format` applied.

Closes #3010