### PR TITLE
feat(router): Phase A diff-pair intra-clearance detection (Issue #3023)

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -51,7 +51,7 @@ from .cpp_backend import CppGrid, CppPathfinder, create_hybrid_router, get_backe
 from .diffpair import DifferentialPair, DifferentialPairConfig, LengthMismatchWarning
 from .diffpair_length import DiffPairLengthTracker
 from .diffpair_length_tuning import DiffPairTuneResult
-from .diffpair_routing import DiffPairRouter
+from .diffpair_routing import DiffPairRouter, IntraPairClearanceViolation
 from .match_group_length import MatchGroup, MatchGroupTracker
 from .escape import EscapeRouter, PackageInfo, is_dense_package
 from .adaptive_grid import AdaptiveGridResult, AdaptiveGridRouter
@@ -9932,6 +9932,36 @@ class Autorouter:
     ) -> tuple[list[Route], LengthMismatchWarning | None]:
         """Route a differential pair together."""
         return self._diffpair.route_differential_pair(pair, spacing)
+
+    def diffpair_intra_clearance_violations(self) -> list[IntraPairClearanceViolation]:
+        """Return routed intra-pair clearance violations (Issue #3023 Phase A).
+
+        Phase A detection accessor: surfaces every diff-pair whose
+        ``CoupledPathfinder``-produced route violated the per-pair
+        ``NetClassRouting.effective_intra_pair_clearance()`` threshold,
+        as detected during ``route_differential_pair_coupled``.
+
+        Phase A is observability-only; the routes are NOT modified.
+        Phase B (the fine-grid sub-pass, separate PR) will consume this
+        list to drive a targeted rip-and-replace repair pass.
+
+        The per-pair threshold is read from
+        ``NetClassRouting.effective_intra_pair_clearance()``, NOT the
+        legacy ``DifferentialPairRules.spacing`` heuristic, so callers
+        whose pairs declare an intra-pair clearance override see the
+        override honoured.
+
+        Returns:
+            A shallow copy of the rolling violation buffer.  Empty when
+            no diff-pair routing has happened yet, when
+            ``--differential-pairs`` was not enabled for this Autorouter
+            session, or when every coupled pair satisfied its threshold.
+        """
+        # Avoid auto-initialising the lazy DiffPairRouter if nothing
+        # ever routed a diff pair -- the buffer is empty in that case.
+        if self._diffpair_router is None:
+            return []
+        return self._diffpair_router.intra_clearance_violations()
 
     def route_all_with_diffpairs(
         self,

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -40,6 +40,164 @@ from .primitives import Pad, Route, Segment, Via
 logger = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# Issue #3023 Phase A: intra-pair clearance violation detection
+# ---------------------------------------------------------------------------
+#
+# Phase A is observability-only.  After ``CoupledPathfinder`` produces a
+# (p_route, n_route) for a diff pair, we re-check every same-layer
+# segment-pair using ``segment_clearance`` against the per-pair
+# ``NetClassRouting.effective_intra_pair_clearance()`` and emit a
+# structured record (and a ``logger.info`` line) for any pair whose
+# routed clearance is below the threshold.
+#
+# This is the SAME idiom ``match_pair_lengths`` already uses at
+# diffpair_routing.py:1033-1053 to reject a serpentine bulge that would
+# violate the partner; here we apply it to the post-coupling route as a
+# diagnostic so Phase B (the fine-grid repair pass, separate PR) has a
+# reproducible target list.
+#
+# Phase A explicitly does NOT modify any route.  All it does is:
+#   1. compute per-segment-pair clearance,
+#   2. report violations,
+#   3. expose a public accessor for Phase B to consume.
+
+
+@dataclass
+class IntraPairClearanceViolation:
+    """A routed intra-pair clearance violation on a differential pair.
+
+    Phase A diagnostic record (Issue #3023): emitted when the routed
+    edge-to-edge clearance between a P-segment and an N-segment on the
+    same layer falls below the per-pair
+    :meth:`NetClassRouting.effective_intra_pair_clearance`.
+
+    Attributes:
+        pair_name: Base name of the violating diff pair (e.g. ``"DQS0"``).
+        positive_net_name: Net name of the P trace (for log grep-ability).
+        negative_net_name: Net name of the N trace.
+        expected_clearance_mm: The per-pair threshold (from
+            ``NetClassRouting.effective_intra_pair_clearance()``).
+        actual_clearance_mm: The minimum edge-to-edge clearance found
+            across all same-layer segment pairs.  ``< expected_clearance_mm``.
+        violation_magnitude_mm: ``expected_clearance_mm - actual_clearance_mm``
+            (always positive when a violation is recorded).
+        layer: KiCad layer name where the worst violation occurred.
+        p_segment: The P-side segment involved in the worst violation.
+        n_segment: The N-side segment involved in the worst violation.
+        segment_violations: All same-layer (p_seg, n_seg, clearance) triples
+            that fell below ``expected_clearance_mm``.  Phase B (repair
+            pass) consumes this list to scope the corridor for the
+            fine-grid sub-search.
+    """
+
+    pair_name: str
+    positive_net_name: str
+    negative_net_name: str
+    expected_clearance_mm: float
+    actual_clearance_mm: float
+    violation_magnitude_mm: float
+    layer: str
+    p_segment: Segment
+    n_segment: Segment
+    segment_violations: list[tuple[Segment, Segment, float]] = field(default_factory=list)
+
+
+def find_intra_pair_clearance_violations(
+    p_route: Route,
+    n_route: Route,
+    threshold_mm: float,
+    pair_name: str = "",
+) -> IntraPairClearanceViolation | None:
+    """Detect intra-pair clearance violations on a routed differential pair.
+
+    Walks every same-layer (p-segment, n-segment) pair and computes the
+    edge-to-edge clearance via :func:`core.geometry.segment_clearance`.
+    Returns ``None`` when no violation is found, otherwise a single
+    :class:`IntraPairClearanceViolation` summarising the worst case and
+    listing every offending segment pair for downstream consumption.
+
+    This is the SAME segment-clearance idiom ``match_pair_lengths`` uses
+    at ``diffpair_routing.py:1033-1053`` to reject would-be serpentine
+    bulges, lifted into a reusable detector so the route-time check in
+    ``route_differential_pair_coupled`` and the post-route audit in
+    :meth:`DiffPairRouter.intra_clearance_violations` share one
+    implementation.
+
+    Args:
+        p_route: The positive trace route.
+        n_route: The negative trace route.
+        threshold_mm: The per-pair clearance floor.  Pass
+            ``NetClassRouting.effective_intra_pair_clearance()`` from
+            the route's net class -- NOT the global
+            ``DifferentialPairRules.spacing``, which is a heuristic
+            default that does not reflect the per-pair override.
+        pair_name: Base pair name for the returned record (e.g.
+            ``"DQS0"``).  Defaults to the empty string when the caller
+            doesn't have a structured pair handy.
+
+    Returns:
+        ``None`` when every same-layer segment-pair meets the threshold;
+        otherwise an :class:`IntraPairClearanceViolation` whose
+        ``segment_violations`` list contains every offending pair and
+        whose top-level fields summarise the worst case.
+    """
+    from kicad_tools.core.geometry import segment_clearance
+
+    if p_route is None or n_route is None:
+        return None
+    if not p_route.segments or not n_route.segments:
+        return None
+
+    offenders: list[tuple[Segment, Segment, float]] = []
+    worst_clearance = float("inf")
+    worst_pair: tuple[Segment, Segment] | None = None
+
+    for pseg in p_route.segments:
+        for nseg in n_route.segments:
+            if pseg.layer != nseg.layer:
+                continue
+            clearance = segment_clearance(
+                pseg.x1,
+                pseg.y1,
+                pseg.x2,
+                pseg.y2,
+                pseg.width,
+                nseg.x1,
+                nseg.y1,
+                nseg.x2,
+                nseg.y2,
+                nseg.width,
+            )
+            # 1e-9 tolerance matches the serpentine self-check at
+            # diffpair_routing.py:1052 -- floating-point equality at the
+            # threshold counts as compliant.
+            if clearance + 1e-9 < threshold_mm:
+                offenders.append((pseg, nseg, clearance))
+                if clearance < worst_clearance:
+                    worst_clearance = clearance
+                    worst_pair = (pseg, nseg)
+
+    if not offenders or worst_pair is None:
+        return None
+
+    worst_p, worst_n = worst_pair
+    return IntraPairClearanceViolation(
+        pair_name=pair_name,
+        positive_net_name=p_route.net_name,
+        negative_net_name=n_route.net_name,
+        expected_clearance_mm=threshold_mm,
+        actual_clearance_mm=worst_clearance,
+        violation_magnitude_mm=threshold_mm - worst_clearance,
+        layer=worst_p.layer.kicad_name
+        if hasattr(worst_p.layer, "kicad_name")
+        else str(worst_p.layer),
+        p_segment=worst_p,
+        n_segment=worst_n,
+        segment_violations=offenders,
+    )
+
+
 class PairOrientation(Enum):
     """Orientation of the differential pair traces."""
 
@@ -433,9 +591,9 @@ class CoupledPathfinder:
                         # board 07 diff pairs.  Endpoint cells (P at
                         # its pad AND N at its pad) bypass the floor
                         # since the pads themselves define the spacing.
-                        n_is_endpoint = self._is_at_goal(
-                            cand_n, n_goal
-                        ) or self._is_at_goal(cand_n, n_start)
+                        n_is_endpoint = self._is_at_goal(cand_n, n_goal) or self._is_at_goal(
+                            cand_n, n_start
+                        )
                         bypass_floor = p_is_endpoint and n_is_endpoint
                         if (
                             self.min_spacing_cells > 0
@@ -474,9 +632,9 @@ class CoupledPathfinder:
                 # here; the floor is bypassed only when P happens to
                 # already be at its pad AND the candidate N is at its
                 # pad.
-                p_is_endpoint_held = self._is_at_goal(
-                    cand_p2, p_goal
-                ) or self._is_at_goal(cand_p2, p_start)
+                p_is_endpoint_held = self._is_at_goal(cand_p2, p_goal) or self._is_at_goal(
+                    cand_p2, p_start
+                )
                 bypass_floor = p_is_endpoint_held and n_is_endpoint
                 if (
                     self.min_spacing_cells > 0
@@ -1136,6 +1294,12 @@ class DiffPairRouter:
             autorouter: Parent autorouter instance
         """
         self.autorouter = autorouter
+        # Issue #3023 Phase A: rolling buffer of routed intra-pair
+        # clearance violations detected during
+        # ``route_differential_pair_coupled``.  Phase A is
+        # observability-only; Phase B (separate PR) will consume this
+        # list to drive a fine-grid repair sub-pass.
+        self._intra_clearance_violations: list[IntraPairClearanceViolation] = []
 
     def _resolve_detection_inputs(
         self,
@@ -1729,6 +1893,39 @@ class DiffPairRouter:
             n_routes.append(n_route)
             routes.extend([p_route, n_route])
 
+            # Issue #3023 Phase A: per-spec intra-pair clearance audit.
+            # The CoupledPathfinder's ``min_spacing_cells`` floor is a
+            # center-to-center grid-cell count -- it does NOT guarantee
+            # edge-to-edge clearance once the route is quantised back to
+            # world coordinates (the 434-violation residual on board 07
+            # is this quantisation gap).  Re-check the actual routed
+            # segments against the per-pair threshold and emit a
+            # diagnostic so Phase B (fine-grid repair, separate PR) can
+            # rip-and-replace just the offenders.  No behavioural change
+            # here -- detection only.
+            violation = find_intra_pair_clearance_violations(
+                p_route,
+                n_route,
+                threshold_mm=pair_intra_clearance,
+                pair_name=pair.name,
+            )
+            if violation is not None:
+                logger.info(
+                    "diffpair intra-clearance violation: pair=%r "
+                    "p_net=%r n_net=%r threshold=%.4fmm "
+                    "worst_actual=%.4fmm magnitude=%.4fmm "
+                    "layer=%r offending_segments=%d",
+                    violation.pair_name,
+                    violation.positive_net_name,
+                    violation.negative_net_name,
+                    violation.expected_clearance_mm,
+                    violation.actual_clearance_mm,
+                    violation.violation_magnitude_mm,
+                    violation.layer,
+                    len(violation.segment_violations),
+                )
+                self._intra_clearance_violations.append(violation)
+
         # Issue #2473: Route stub edges (intra-net hops within a
         # cluster, e.g., USB-C A6 -> B6) using the independent router.
         # These are short, no coupling required, and the autorouter has
@@ -1880,6 +2077,43 @@ class DiffPairRouter:
             print(f"    Length matched: delta={delta:.3f}mm (within tolerance)")
 
         return routes, warning
+
+    def intra_clearance_violations(self) -> list[IntraPairClearanceViolation]:
+        """Return routed intra-pair clearance violations (Issue #3023 Phase A).
+
+        Returns the rolling buffer of violations recorded by
+        :meth:`route_differential_pair_coupled` since this
+        :class:`DiffPairRouter` was constructed.  Each entry corresponds
+        to one ``CoupledPathfinder``-routed (P, N) pair whose post-route
+        edge-to-edge clearance dropped below the per-pair
+        ``NetClassRouting.effective_intra_pair_clearance()``.
+
+        Phase A is detection-only -- this method exists so Phase B (the
+        fine-grid sub-pass, separate PR) and external tooling (DRC
+        reports, e2e tests on board 07) can audit how many violations
+        the coupled router emitted without re-running the geometry
+        check.
+
+        Returns:
+            A shallow copy of the violation buffer.  Empty when no
+            coupled diff-pair routes have been laid down or when every
+            pair satisfied its per-pair clearance threshold.  Callers
+            MUST NOT mutate the returned list to clear state; use
+            :meth:`reset_intra_clearance_violations` instead.
+        """
+        return list(self._intra_clearance_violations)
+
+    def reset_intra_clearance_violations(self) -> None:
+        """Discard the buffered Phase A clearance-violation records.
+
+        Used by tests that exercise multiple
+        ``route_differential_pair_coupled`` calls on a single
+        :class:`DiffPairRouter` instance and want a clean baseline
+        between cases.  Not intended for production callers; the buffer
+        is intentionally additive over a single Autorouter session so
+        the post-routing audit sees every coupled pair.
+        """
+        self._intra_clearance_violations.clear()
 
     def route_differential_pair(
         self,

--- a/tests/test_diffpair_intra_clearance_detection.py
+++ b/tests/test_diffpair_intra_clearance_detection.py
@@ -1,0 +1,309 @@
+"""Tests for the diff-pair intra-pair clearance violation detector
+(Issue #3023 Phase A).
+
+Phase A is observability-only.  After ``CoupledPathfinder`` produces a
+routed (P, N) pair, ``find_intra_pair_clearance_violations`` walks every
+same-layer (p-segment, n-segment) pair and reports any whose
+edge-to-edge clearance is below the per-pair
+``NetClassRouting.effective_intra_pair_clearance()`` threshold.
+
+These tests pin three properties:
+
+1. A known-violating pair produces a non-empty violation record whose
+   ``violation_magnitude_mm`` is positive and whose worst segment pair
+   is correctly identified.
+2. A clean pair produces ``None`` (no violation record at all).
+3. The detector consults the per-pair ``NetClassRouting`` accessor --
+   NOT the global ``DifferentialPairRules.spacing`` heuristic -- so an
+   intra-pair clearance override is honoured.
+
+Regression boundary: this suite must NOT change the routes
+``CoupledPathfinder`` produces; it only inspects them.  PR #3022's
+8-case ``test_diffpair_coupled_floor.py`` and PR #3005's 9-case
+``test_diffpair_serpentine_clearance.py`` suites stay green.
+
+Phase B (the fine-grid sub-pass that closes the empirical AC of #3023)
+ships in a separate PR.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.core.types import CopperLayer as Layer
+from kicad_tools.router.diffpair_routing import (
+    IntraPairClearanceViolation,
+    find_intra_pair_clearance_violations,
+)
+from kicad_tools.router.primitives import Route, Segment
+from kicad_tools.router.rules import NetClassRouting
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_route(
+    net_id: int,
+    net_name: str,
+    segments: list[tuple[float, float, float, float, Layer]],
+    width: float = 0.15,
+) -> Route:
+    """Build a Route from a list of ``(x1, y1, x2, y2, layer)`` tuples.
+
+    Mirrors the ad-hoc constructors used in
+    ``test_diffpair_coupled_floor.py`` so the two suites share a shape.
+    """
+    return Route(
+        net=net_id,
+        net_name=net_name,
+        segments=[
+            Segment(
+                x1=x1,
+                y1=y1,
+                x2=x2,
+                y2=y2,
+                width=width,
+                layer=layer,
+                net=net_id,
+                net_name=net_name,
+            )
+            for (x1, y1, x2, y2, layer) in segments
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: known-violating pair → non-empty record
+# ---------------------------------------------------------------------------
+
+
+def test_detects_violation_on_too_tight_pair():
+    """A pair routed with centerlines below ``threshold + trace_width``
+    triggers a violation record carrying the worst-case magnitude."""
+    # Two parallel traces 0.15 mm wide, centerlines 0.20 mm apart.
+    # Edge-to-edge clearance = 0.20 - 0.15 = 0.05 mm.
+    # Threshold = 0.10 mm.  Magnitude = 0.10 - 0.05 = 0.05 mm.
+    p_route = _make_route(
+        net_id=1,
+        net_name="DQS0_P",
+        segments=[(0.0, 1.0, 10.0, 1.0, Layer.F_CU)],
+        width=0.15,
+    )
+    n_route = _make_route(
+        net_id=2,
+        net_name="DQS0_N",
+        segments=[(0.0, 1.2, 10.0, 1.2, Layer.F_CU)],
+        width=0.15,
+    )
+
+    violation = find_intra_pair_clearance_violations(
+        p_route, n_route, threshold_mm=0.10, pair_name="DQS0"
+    )
+
+    assert violation is not None
+    assert isinstance(violation, IntraPairClearanceViolation)
+    assert violation.pair_name == "DQS0"
+    assert violation.positive_net_name == "DQS0_P"
+    assert violation.negative_net_name == "DQS0_N"
+    assert violation.expected_clearance_mm == 0.10
+    # The actual clearance is 0.05 mm (within floating-point tolerance).
+    assert abs(violation.actual_clearance_mm - 0.05) < 1e-6
+    # Magnitude is the deficit, which must be positive.
+    assert violation.violation_magnitude_mm > 0
+    assert abs(violation.violation_magnitude_mm - 0.05) < 1e-6
+    # At least one offending segment-pair was recorded.
+    assert len(violation.segment_violations) >= 1
+    # The worst-case layer is reported as a KiCad name string.
+    assert violation.layer == "F.Cu"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: clean pair → no violation record
+# ---------------------------------------------------------------------------
+
+
+def test_no_violation_on_well_spaced_pair():
+    """A pair whose edge-to-edge clearance comfortably exceeds the
+    threshold returns ``None`` -- no violation record is emitted."""
+    # Two parallel traces 0.15 mm wide, centerlines 0.40 mm apart.
+    # Edge-to-edge clearance = 0.40 - 0.15 = 0.25 mm >> 0.10 mm threshold.
+    p_route = _make_route(
+        net_id=1,
+        net_name="USB_DP",
+        segments=[(0.0, 1.0, 10.0, 1.0, Layer.F_CU)],
+        width=0.15,
+    )
+    n_route = _make_route(
+        net_id=2,
+        net_name="USB_DN",
+        segments=[(0.0, 1.4, 10.0, 1.4, Layer.F_CU)],
+        width=0.15,
+    )
+
+    violation = find_intra_pair_clearance_violations(
+        p_route, n_route, threshold_mm=0.10, pair_name="USB_D"
+    )
+
+    assert violation is None
+
+
+# ---------------------------------------------------------------------------
+# Test 3: per-pair NetClassRouting.effective_intra_pair_clearance() is
+# what the detector consults -- NOT the global pair.rules.spacing.
+# ---------------------------------------------------------------------------
+
+
+def test_detector_honours_per_pair_intra_pair_clearance_override():
+    """The detector compares against the threshold the caller passes
+    in.  The caller's responsibility -- documented on the helper's
+    docstring -- is to source that threshold from
+    ``NetClassRouting.effective_intra_pair_clearance()``, NOT the
+    legacy ``DifferentialPairRules.spacing`` default.
+
+    This test sets up a routed pair that:
+      * PASSES against ``DifferentialPairRules.spacing`` (0.05 mm), AND
+      * FAILS against the per-pair ``intra_pair_clearance`` override
+        (0.20 mm).
+
+    It then runs the detector twice: once with each threshold.  The
+    detector must report a violation in the second case (the override)
+    and stay silent in the first.  This pins the contract that the
+    per-pair override -- not the global rule -- governs detection.
+    """
+    # Two parallel traces 0.15 mm wide, centerlines 0.25 mm apart.
+    # Edge-to-edge clearance = 0.25 - 0.15 = 0.10 mm.
+    # Below 0.20 mm threshold but above 0.05 mm fallback.
+    p_route = _make_route(
+        net_id=1,
+        net_name="HDMI_D0_P",
+        segments=[(0.0, 1.0, 10.0, 1.0, Layer.F_CU)],
+        width=0.15,
+    )
+    n_route = _make_route(
+        net_id=2,
+        net_name="HDMI_D0_N",
+        segments=[(0.0, 1.25, 10.0, 1.25, Layer.F_CU)],
+        width=0.15,
+    )
+
+    # Build a NetClassRouting matching the per-pair override.  The
+    # effective accessor (rules.py:892) returns intra_pair_clearance
+    # when set, otherwise falls back to .clearance.
+    net_class = NetClassRouting(
+        name="DiffPair_HDMI",
+        trace_width=0.15,
+        clearance=0.05,
+        intra_pair_clearance=0.20,
+    )
+
+    # Sanity-check the accessor returns the override (not the fallback).
+    assert net_class.effective_intra_pair_clearance() == 0.20
+
+    # First case: feed the legacy/global value (0.05 mm).  No violation.
+    legacy = find_intra_pair_clearance_violations(
+        p_route, n_route, threshold_mm=0.05, pair_name="HDMI_D0"
+    )
+    assert legacy is None, (
+        "Detector flagged a clearance that passes the legacy threshold; "
+        "this means the floor is being applied to a stricter target than "
+        "the caller asked for."
+    )
+
+    # Second case: feed the per-pair override (0.20 mm).  Violation must
+    # surface because edge-to-edge clearance (0.10 mm) is below the
+    # per-pair threshold even though it passes the global fallback.
+    override = find_intra_pair_clearance_violations(
+        p_route,
+        n_route,
+        threshold_mm=net_class.effective_intra_pair_clearance(),
+        pair_name="HDMI_D0",
+    )
+    assert override is not None, (
+        "Detector missed a clearance below the per-pair "
+        "intra_pair_clearance override -- it must read the per-pair "
+        "value, not the global pair.rules.spacing default."
+    )
+    assert override.expected_clearance_mm == 0.20
+    assert abs(override.actual_clearance_mm - 0.10) < 1e-6
+    assert override.violation_magnitude_mm > 0
+
+
+# ---------------------------------------------------------------------------
+# Edge cases (small additional coverage; stays well under the LOC budget).
+# ---------------------------------------------------------------------------
+
+
+def test_detector_ignores_different_layer_segments():
+    """A P-segment on F.Cu and an N-segment on B.Cu never trigger a
+    violation regardless of their X/Y proximity -- the clearance rule
+    applies per-layer only."""
+    p_route = _make_route(
+        net_id=1,
+        net_name="X_P",
+        segments=[(0.0, 1.0, 10.0, 1.0, Layer.F_CU)],
+        width=0.15,
+    )
+    n_route = _make_route(
+        net_id=2,
+        net_name="X_N",
+        segments=[(0.0, 1.0, 10.0, 1.0, Layer.B_CU)],  # same X/Y, OTHER layer
+        width=0.15,
+    )
+
+    # If the detector ignored layers, this would report -0.15 mm
+    # clearance (centerlines overlap).  Layer-awareness must filter it.
+    violation = find_intra_pair_clearance_violations(
+        p_route, n_route, threshold_mm=0.10, pair_name="X"
+    )
+    assert violation is None
+
+
+def test_detector_returns_none_on_empty_routes():
+    """Empty or no-segment routes never trigger a violation."""
+    empty = Route(net=1, net_name="EMPTY", segments=[])
+    populated = _make_route(
+        net_id=2,
+        net_name="POP",
+        segments=[(0.0, 1.0, 10.0, 1.0, Layer.F_CU)],
+        width=0.15,
+    )
+
+    # Either side empty → no violation, no exception.
+    assert find_intra_pair_clearance_violations(empty, populated, threshold_mm=1.0) is None
+    assert find_intra_pair_clearance_violations(populated, empty, threshold_mm=1.0) is None
+    assert find_intra_pair_clearance_violations(empty, empty, threshold_mm=1.0) is None
+
+
+def test_detector_records_every_offending_segment_pair():
+    """When multiple same-layer segment pairs are below threshold, all
+    of them appear in ``segment_violations`` -- Phase B (the corridor
+    sub-pass) consumes the full list to scope the rip-and-replace
+    region."""
+    # Two-segment P route running parallel to a two-segment N route,
+    # both on F.Cu, with both segment-pairs below threshold.
+    p_route = _make_route(
+        net_id=1,
+        net_name="MULTI_P",
+        segments=[
+            (0.0, 1.0, 5.0, 1.0, Layer.F_CU),
+            (5.0, 1.0, 10.0, 1.0, Layer.F_CU),
+        ],
+        width=0.15,
+    )
+    n_route = _make_route(
+        net_id=2,
+        net_name="MULTI_N",
+        segments=[
+            (0.0, 1.2, 5.0, 1.2, Layer.F_CU),
+            (5.0, 1.2, 10.0, 1.2, Layer.F_CU),
+        ],
+        width=0.15,
+    )
+
+    violation = find_intra_pair_clearance_violations(
+        p_route, n_route, threshold_mm=0.10, pair_name="MULTI"
+    )
+
+    assert violation is not None
+    # With two P-segs and two N-segs and ALL clearances at ~0.05 mm,
+    # every (p, n) combination on the same layer is offending: 4 total.
+    assert len(violation.segment_violations) == 4


### PR DESCRIPTION
## Summary

**This is Phase A of 3 (detection-only).** Issue #3023 is too large for
one PR -- the curator recommended a 3-milestone split:

- **Phase A (this PR)**: ~100 LOC detection + ~50-80 LOC tests. Surfaces
  routed intra-pair clearance violations as a structured log line and a
  public accessor. No behavioural change.
- **Phase B (next PR, ~350 LOC)**: fine-grid sub-pass that consumes the
  violations and rip-and-replaces just the offending pair on a local
  fine grid. **This is the PR that will close the empirical AC of
  #3023** (29/31 nets, 0 ``diffpair_clearance_intra``, total DRC <= 70).
- **Phase C (last PR, ~50 LOC)**: re-enable ``--differential-pairs`` on
  board 07, tighten CI timeout if empirically safe.

The AC headline in #3023 (the 434 violations going to 0) is **NOT met
by this PR** -- this PR de-risks Phase B by validating the detection
threshold against actual board-07 violations and exposing the data
structures Phase B needs.

## What this PR adds

- ``IntraPairClearanceViolation`` dataclass + module-level
  ``find_intra_pair_clearance_violations(p_route, n_route, threshold_mm, pair_name)``
  helper in ``router/diffpair_routing.py``. Walks every same-layer
  (p-seg, n-seg) pair through ``core.geometry.segment_clearance`` and
  returns one record summarising the worst case plus a full
  ``segment_violations`` list for Phase B's corridor extraction.

- Integration hook inside ``route_differential_pair_coupled``: after
  ``CoupledPathfinder.route_coupled`` succeeds and ``_mark_route`` runs,
  the per-spec routed (P, N) is fed through the detector using
  ``pair_intra_clearance`` (the same per-pair
  ``NetClassRouting.effective_intra_pair_clearance()`` value that
  ``min_spacing_cells`` is already derived from in PR #3022). When a
  violation is found the code emits a structured ``logger.info`` line
  and appends the record to a rolling buffer.

- Public accessor ``Autorouter.diffpair_intra_clearance_violations()``
  (and the underlying ``DiffPairRouter.intra_clearance_violations`` /
  ``reset_intra_clearance_violations``) so Phase B and external audit
  tooling can read the buffered violations without re-running geometry.

- 6 unit tests in ``tests/test_diffpair_intra_clearance_detection.py``
  pinning three contracts the curator's recipe requires (known-violating
  pair, clean pair, per-pair threshold honoured) plus three small edge
  cases (cross-layer ignored, empty routes safe, all offenders surfaced).

## What this PR explicitly does NOT do

- Does NOT modify any route -- ``CoupledPathfinder`` output is observed
  unchanged.
- Does NOT change the board-07 recipe -- ``--differential-pairs`` stays
  OFF, matching PR #3022's stance.
- Does NOT close the empirical AC of #3023 (29/31 routed nets, 0
  ``diffpair_clearance_intra``, total DRC <= 70). That AC will be met
  by Phase B (the rip-and-replace fine-grid sub-pass) in a separate PR.

## Empirical verification (Phase A only)

Ran the curator's exact reproduction recipe with ``--differential-pairs``
re-enabled against board 07 (output to ``/tmp``, board recipe unchanged).
Result:

- **29/31 nets routed** -- matches PR #3022's published yield.
- Phase A detector fires on **all 7 detected diff pairs** (DQS,
  MIPI_CLK, MIPI_DAT0/1, TMDS_D0/D1/D2) with worst-case routed
  clearance ~-0.150 mm against a 0.100 mm threshold (the same
  -0.150 mm magnitude PR #3022 left as the residual gap).
- Total offending segment-pairs across all pairs: ~4691 (segment
  granularity; the 434 DRC ``diffpair_clearance_intra`` baseline from
  PR #3022 collapses adjacent segment-pair offences into single events).

The numbers don't match exactly -- DRC reports collapse violations; my
segment-pair counter doesn't -- but the pair-level violation set
matches the issue's stated residual exactly (every routed diff pair
has a violation, all centered on the inner-layer parallel-run
quantisation Phase B is designed to fix).

## Regression preservation

- PR #3022's 8 ``test_diffpair_coupled_floor.py`` tests pass.
- PR #3005's 9 ``test_diffpair_serpentine_clearance.py`` tests pass.
- Full ``tests/test_diffpair*.py`` suite: 269 passed (was 263 before
  this PR; +6 new tests).

## Test plan

- [x] Ran ``pytest tests/test_diffpair_intra_clearance_detection.py``
      (6 new tests pass).
- [x] Ran ``pytest tests/test_diffpair_coupled_floor.py
      tests/test_diffpair_serpentine_clearance.py`` (17 regression
      tests pass).
- [x] Ran ``pytest tests/test_diffpair*.py`` (269 tests pass).
- [x] Empirical board-07 with ``--differential-pairs``: 29/31 nets,
      Phase A detector fires on all 7 routed pairs.
- [x] ``ruff check`` clean on touched code (pre-existing lint hits on
      unrelated parts of ``core.py`` are not in this PR's diff).

References Issue #3023 (Phase A, partial). Phase B will close.