### PR TITLE
feat(router): main-router via-vs-foreign-segment hook (#3020 scaffolding)

### DIFF
--- a/.github/routed-drc-tolerance.yml
+++ b/.github/routed-drc-tolerance.yml
@@ -279,6 +279,28 @@ tolerances:
   # exit-clause convention (cf. board-03's 4 -> 9 bump in PR #2924
   # with #2943 + #2919 as exit clauses; same shape).
   #
+  # Issue #3020 (PR scaffolding): The 4-quadrant clearance matrix's
+  # missing entry (main-router via-vs-foreign-segment post-iteration
+  # hook) is now implemented as the symmetric mirror of PR #3006.
+  # The hook plumbing matches PR #3006 at all 6 negotiated rip-up
+  # sites + the 4 two_phase sites, with the combined seg-via +
+  # via-seg violator count promoted into the lex-tuple comparator.
+  #
+  # EMPIRICAL CAVEAT: 3 fresh re-routes of board-04 (2026-05-17)
+  # confirm the SWDIO/BOOT0 violation at PCB (143.8, 119.7) on
+  # B.Cu persists post-hook.  Investigation shows the offending
+  # SWDIO B.Cu segment (y=120.0246) does NOT exist in net_routes
+  # at the time the negotiated post-iteration hook fires; the
+  # closest committed SWDIO B.Cu segment is at y=120.4 (0.7mm
+  # clear of BOOT0 via at y=119.7).  The y=120.0246 segment is
+  # introduced by the trace optimizer's pull-tight pass (or the
+  # subsequent DRC nudge pass), which runs AFTER
+  # ``route_all_negotiated`` returns.  The hook cannot close the
+  # gap until the same predicate is wired into the post-route
+  # optimizer / nudge pipeline -- out of scope for #3020.
+  # Floor stays at 5 pending a follow-up issue that addresses the
+  # trace-optimizer side of the matrix.
+  #
   # Exit clause: drop back to 4 once #2998 is resolved (SWDIO/B.Cu
   # vs BOOT0 via clearance fix), or to 0 if combined with the
   # OSC_OUT pin-edge fanout fix above.

--- a/src/kicad_tools/router/algorithms/negotiated.py
+++ b/src/kicad_tools/router/algorithms/negotiated.py
@@ -636,6 +636,13 @@ class NegotiatedRouter:
         # cache_key on the next call.
         self._seg_via_violations_cache: tuple[object, list[int]] | None = None
 
+        # Issue #3020: single-slot memo for
+        # :meth:`find_nets_with_via_segment_violations` -- the symmetric
+        # sibling of the segment-vs-via hook above.  Same cadence (up
+        # to 4 same-iteration calls), same invalidation semantics
+        # (implicit on cache_key change).
+        self._via_seg_violations_cache: tuple[object, list[int]] | None = None
+
     def route_net_negotiated(
         self,
         pad_objs: list[Pad],
@@ -1199,6 +1206,177 @@ class NegotiatedRouter:
         result = list(violators)
         if cache_key is not None:
             self._seg_via_violations_cache = (cache_key, result)
+        return result
+
+    def find_nets_with_via_segment_violations(
+        self,
+        net_routes: dict[int, list[Route]],
+        trace_clearance: float,
+        cache_key: object | None = None,
+    ) -> list[int]:
+        """Find nets whose committed vias clip foreign-net segments.
+
+        Issue #3020: Symmetric sibling of
+        :meth:`find_nets_with_segment_via_violations` (PR #3006).  Where
+        the segment-vs-via hook walks every committed segment against
+        every foreign-net via, this hook walks every committed VIA
+        against every foreign-net SEGMENT (including permanent escape
+        segments in ``_escape_pad_overrides``-protected routes) using
+        the shared :func:`via_clears_foreign_segment` predicate
+        (STANDARD threshold) and feeds violators back into
+        ``nets_to_reroute`` so the next iteration retries the via's
+        parent net against the up-to-date foreign-segment universe.
+
+        Concrete failure this catches (board-04, PCB (143.8, 119.7) on
+        B.Cu): SWDIO's F.Cu/B.Cu escape segment is committed by the
+        escape phase BEFORE the main router places BOOT0's layer-
+        transition via on B.Cu.  PR #3006's segment-vs-foreign-via
+        gate sees the segment's view at the moment THE SEGMENT
+        commits, but BOOT0's via has not yet been placed -- the gate
+        passes.  PR #3019's escape-phase two-pass commit sees the
+        escape universe at the moment THE ESCAPE commits, but
+        BOOT0's main-router via lives outside the escape phase
+        entirely -- it never sees the escape universe.  Post-
+        iteration this hook walks every via against every foreign
+        segment and surfaces BOOT0 for re-routing.
+
+        Net-attribution rule (per PR #3019 judge's invariant): the
+        VIA's net is added to the reroute list, NOT the segment's
+        net.  Escape segments are permanent infrastructure
+        (``_escape_pad_overrides`` makes them non-rippable -- see
+        ``core.py:10123-10145``); ripping the segment's net would
+        regress completion without fixing the violation, and the
+        next escape pass would re-emit the same segment.  The fix
+        MUST defer / reroute the via -- A* will then pick a
+        different layer-transition point that clears the segment.
+
+        Issue #3020 perf parity with PR #3006: the hook is called up
+        to 4 times per negotiated iteration at the same call sites as
+        the segment-vs-via hook (top-of-iter snapshot, mid-iter re-
+        validate, end-of-iter capture, restore comparator).  The same
+        three perf layers apply:
+
+        1. **Per-call segment bucketing**: segments are partitioned
+           by their layer into ``segs_on_layer[L]`` once at the top of
+           the function so the inner loop only consults segments on a
+           layer the via's span covers.  Mirrors the via-bucket
+           strategy in :meth:`find_nets_with_segment_via_violations`.
+
+        2. **Via-bbox prefilter**: for each segment, its reachability
+           envelope is ``max_via_radius + seg.width/2 +
+           trace_clearance``; if the via centre is outside the
+           segment's bbox expanded by that envelope the exact
+           predicate is skipped.
+
+        3. **Per-iteration memo** (``cache_key``): identical keys
+           reuse the prior result -- if ``net_routes`` has not mutated
+           since the last call the violation set cannot have changed.
+
+        Args:
+            net_routes: Dictionary of ``net_id -> list of Route``.
+            trace_clearance: Manufacturer minimum copper-to-copper
+                clearance in mm (``DesignRules.trace_clearance``).
+            cache_key: Optional hashable identifier for memoization
+                across consecutive same-iteration calls.  Default
+                ``None`` disables the cache.
+
+        Returns:
+            List of net IDs whose vias violate clearance against a
+            foreign-net segment.  Duplicates are removed.
+        """
+        # Issue #3020: per-iteration memo (cache_key parity with the
+        # segment-vs-via hook above).
+        if cache_key is not None:
+            cached = self._via_seg_violations_cache
+            if cached is not None and cached[0] == cache_key:
+                return list(cached[1])
+
+
+        # Import here to avoid a top-level circular dependency between
+        # algorithms.negotiated -> via_clearance -> primitives.
+        from ..via_clearance import via_clears_foreign_segment
+
+        # Issue #3020: bucket segments by layer so the via-vs-segment
+        # inner loop only consults segments on a layer the via's span
+        # covers.  Mirror of the via-bucket strategy in
+        # :meth:`find_nets_with_segment_via_violations`.
+        segs_on_layer: dict[int, list[tuple[int, "Segment"]]] = {}
+        total_segs = 0
+        for net_id, routes in net_routes.items():
+            for route in routes:
+                for seg in route.segments:
+                    total_segs += 1
+                    segs_on_layer.setdefault(seg.layer.value, []).append(
+                        (net_id, seg)
+                    )
+
+        # Fast path: no segments at all -> no violations possible.
+        if total_segs == 0:
+            if cache_key is not None:
+                self._via_seg_violations_cache = (cache_key, [])
+            return []
+
+        violators: set[int] = set()
+        for net, routes in net_routes.items():
+            net_done = False
+            for route in routes:
+                if net_done:
+                    break
+                for via in route.vias:
+                    # Iterate every layer the via spans -- a through-hole
+                    # via on a 4-layer board can clip segments on any of
+                    # the four layers it crosses.
+                    v_lo = min(via.layers[0].value, via.layers[1].value)
+                    v_hi = max(via.layers[0].value, via.layers[1].value)
+                    via_radius = via.diameter / 2
+
+                    for layer_val in range(v_lo, v_hi + 1):
+                        layer_segs = segs_on_layer.get(layer_val)
+                        if not layer_segs:
+                            continue
+
+                        for seg_net, seg in layer_segs:
+                            if seg_net == net:
+                                continue  # Same-net segment -- skipped.
+
+                            # Via-bbox prefilter: envelope is
+                            # via_radius + half_seg_width +
+                            # trace_clearance.  If the via centre is
+                            # outside the segment bbox expanded by
+                            # this envelope, skip the exact predicate.
+                            seg_min_x = min(seg.x1, seg.x2)
+                            seg_max_x = max(seg.x1, seg.x2)
+                            seg_min_y = min(seg.y1, seg.y2)
+                            seg_max_y = max(seg.y1, seg.y2)
+                            envelope = (
+                                via_radius + seg.width / 2 + trace_clearance
+                            )
+                            if (
+                                via.x < seg_min_x - envelope
+                                or via.x > seg_max_x + envelope
+                                or via.y < seg_min_y - envelope
+                                or via.y > seg_max_y + envelope
+                            ):
+                                continue
+
+                            if not via_clears_foreign_segment(
+                                via, seg, trace_clearance,
+                                hard_intersection_only=False,
+                            ):
+                                # Per PR #3019 judge's invariant: the
+                                # VIA's net is the one we surface for
+                                # re-routing (NOT the segment's net).
+                                violators.add(net)
+                                net_done = True
+                                break
+                        if net_done:
+                            break
+                    if net_done:
+                        break
+
+        result = list(violators)
+        if cache_key is not None:
+            self._via_seg_violations_cache = (cache_key, result)
         return result
 
     def rip_up_nets(

--- a/src/kicad_tools/router/algorithms/two_phase.py
+++ b/src/kicad_tools/router/algorithms/two_phase.py
@@ -624,12 +624,18 @@ class TwoPhaseRouter:
         # baseline.  Memo enables the mid-iter call below to reuse this
         # result if no rip-up has happened yet.
         best_overflow = overflow
-        best_clearance_violations = len(
-            neg_router.find_nets_with_segment_via_violations(
-                net_routes, trace_clearance=self.rules.trace_clearance,
-                cache_key=("two_phase_init",),
-            )
+        # Issue #3020: combine seg-via and via-seg violator counts so
+        # both directions of the clearance matrix participate in the
+        # best-state comparator.
+        _init_seg_via = neg_router.find_nets_with_segment_via_violations(
+            net_routes, trace_clearance=self.rules.trace_clearance,
+            cache_key=("two_phase_init",),
         )
+        _init_via_seg = neg_router.find_nets_with_via_segment_violations(
+            net_routes, trace_clearance=self.rules.trace_clearance,
+            cache_key=("two_phase_init",),
+        )
+        best_clearance_violations = len(_init_seg_via) + len(_init_via_seg)
         best_routes: list[Route] = copy.deepcopy(list(self.routes))
         best_net_routes: dict[int, list[Route]] = copy.deepcopy(net_routes)
         best_iteration = 0  # 0 = initial pass
@@ -709,6 +715,31 @@ class TwoPhaseRouter:
                         f"violator(s) in recovery: {', '.join(violator_names)}"
                     )
 
+                # Issue #3020: Symmetric via-vs-foreign-segment hook
+                # mirroring core.py's negotiated loop.  See the
+                # rationale in
+                # :meth:`NegotiatedRouter.find_nets_with_via_segment_violations`
+                # for the board-04 SWDIO/BOOT0 case this catches.
+                via_seg_violators = neg_router.find_nets_with_via_segment_violations(
+                    net_routes, trace_clearance=self.rules.trace_clearance,
+                    cache_key=("two_phase_post", iteration - 1) if iteration > 1 else ("two_phase_init",),
+                )
+                new_via_seg_violators = [
+                    v_net for v_net in via_seg_violators
+                    if v_net not in nets_to_reroute
+                ]
+                for v_net in new_via_seg_violators:
+                    nets_to_reroute.append(v_net)
+                if new_via_seg_violators:
+                    violator_names = [
+                        self.net_names.get(n, f"Net_{n}")
+                        for n in new_via_seg_violators
+                    ]
+                    flush_print(
+                        f"  Including {len(new_via_seg_violators)} via-vs-foreign-segment "
+                        f"violator(s) in recovery: {', '.join(violator_names)}"
+                    )
+
                 flush_print(
                     f"  Iteration {iteration}: ripping up {len(nets_to_reroute)} nets ({elapsed_str()})"
                 )
@@ -763,11 +794,18 @@ class TwoPhaseRouter:
                 # Issue #3002 (PR #3006 perf): cache_key for end-of-
                 # iteration K post-state.  The next iteration's
                 # mid-iter call will pull this from cache.
-                current_clearance_violations = len(
-                    neg_router.find_nets_with_segment_via_violations(
-                        net_routes, trace_clearance=self.rules.trace_clearance,
-                        cache_key=("two_phase_post", iteration),
-                    )
+                # Issue #3020: combine both directions of the
+                # clearance matrix into the best-state comparator.
+                _post_seg_via = neg_router.find_nets_with_segment_via_violations(
+                    net_routes, trace_clearance=self.rules.trace_clearance,
+                    cache_key=("two_phase_post", iteration),
+                )
+                _post_via_seg = neg_router.find_nets_with_via_segment_violations(
+                    net_routes, trace_clearance=self.rules.trace_clearance,
+                    cache_key=("two_phase_post", iteration),
+                )
+                current_clearance_violations = (
+                    len(_post_seg_via) + len(_post_via_seg)
                 )
                 flush_print(
                     f"  Iteration {iteration} complete: "
@@ -857,11 +895,18 @@ class TwoPhaseRouter:
             for routes in net_routes.values()
             for route in routes
         )
-        final_clearance_violations = len(
-            neg_router.find_nets_with_segment_via_violations(
-                net_routes, trace_clearance=self.rules.trace_clearance,
-                cache_key=("two_phase_final", final_route_count, final_via_count),
-            )
+        # Issue #3020: final comparator sums both directions of the
+        # clearance matrix.
+        _final_seg_via = neg_router.find_nets_with_segment_via_violations(
+            net_routes, trace_clearance=self.rules.trace_clearance,
+            cache_key=("two_phase_final", final_route_count, final_via_count),
+        )
+        _final_via_seg = neg_router.find_nets_with_via_segment_violations(
+            net_routes, trace_clearance=self.rules.trace_clearance,
+            cache_key=("two_phase_final", final_route_count, final_via_count),
+        )
+        final_clearance_violations = (
+            len(_final_seg_via) + len(_final_via_seg)
         )
         best_key = (best_clearance_violations, best_overflow)
         final_key = (final_clearance_violations, final_overflow)

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -6355,12 +6355,20 @@ class Autorouter:
         # recovery, end-of-iter capture) reuse a memoized result when
         # state has not mutated.  The initial pass uses the dedicated
         # ``("init",)`` key.
-        initial_violations = len(
-            neg_router.find_nets_with_segment_via_violations(
-                net_routes, trace_clearance=self.rules.trace_clearance,
-                cache_key=("init",),
-            )
+        # Issue #3020: combine the segment-vs-via and via-vs-segment
+        # violator counts so the lex tuple captures BOTH directions
+        # of the clearance matrix.  A best-iteration restore must
+        # prefer a state with fewer total violations regardless of
+        # which side of the matrix improved.
+        initial_seg_via = neg_router.find_nets_with_segment_via_violations(
+            net_routes, trace_clearance=self.rules.trace_clearance,
+            cache_key=("init",),
         )
+        initial_via_seg = neg_router.find_nets_with_via_segment_violations(
+            net_routes, trace_clearance=self.rules.trace_clearance,
+            cache_key=("init",),
+        )
+        initial_violations = len(initial_seg_via) + len(initial_via_seg)
         best_metrics = IterationMetrics(
             iteration=0,
             routed_count=best_routed_count,
@@ -6400,12 +6408,18 @@ class Autorouter:
             # captures.  Distinct phase tag so the post-loop "final"
             # restore can hit the cache and reuse the last iteration's
             # post-state walk.
-            violations_now = len(
-                neg_router.find_nets_with_segment_via_violations(
-                    net_routes, trace_clearance=self.rules.trace_clearance,
-                    cache_key=("post", iter_index),
-                )
+            # Issue #3020: combine seg-via and via-seg violator counts
+            # so both directions of the 4-quadrant clearance matrix
+            # survive the lex-tuple restore comparator.
+            post_seg_via = neg_router.find_nets_with_segment_via_violations(
+                net_routes, trace_clearance=self.rules.trace_clearance,
+                cache_key=("post", iter_index),
             )
+            post_via_seg = neg_router.find_nets_with_via_segment_violations(
+                net_routes, trace_clearance=self.rules.trace_clearance,
+                cache_key=("post", iter_index),
+            )
+            violations_now = len(post_seg_via) + len(post_via_seg)
             metrics = IterationMetrics(
                 iteration=iter_index,
                 routed_count=routed_now,
@@ -6481,12 +6495,17 @@ class Autorouter:
                 # iteration snapshot.  State here equals the end-state
                 # of the prior iteration -> reuse the ``("post", K-1)``
                 # cache from the previous _capture_iteration_end call.
-                current_violations = len(
-                    neg_router.find_nets_with_segment_via_violations(
-                        net_routes, trace_clearance=self.rules.trace_clearance,
-                        cache_key=("post", iteration - 1),
-                    )
+                # Issue #3020: combine both directions of the
+                # clearance matrix in the lex tuple comparator.
+                current_seg_via = neg_router.find_nets_with_segment_via_violations(
+                    net_routes, trace_clearance=self.rules.trace_clearance,
+                    cache_key=("post", iteration - 1),
                 )
+                current_via_seg = neg_router.find_nets_with_via_segment_violations(
+                    net_routes, trace_clearance=self.rules.trace_clearance,
+                    cache_key=("post", iteration - 1),
+                )
+                current_violations = len(current_seg_via) + len(current_via_seg)
                 current_metrics = IterationMetrics(
                     iteration=iteration - 1,  # captured state is end of prior iter
                     routed_count=current_routed,
@@ -6707,6 +6726,45 @@ class Autorouter:
                         ]
                         flush_print(
                             f"  Including {len(new_violators)} segment-vs-foreign-via "
+                            f"violator(s) in recovery: {', '.join(violator_names)}"
+                        )
+
+                # Issue #3020: Symmetric sibling of the segment-vs-via
+                # hook above -- walks every committed VIA against
+                # every foreign-net SEGMENT (including permanent
+                # escape segments) and feeds VIA-OWNING nets back
+                # into ``nets_to_reroute``.  Escape segments are
+                # non-rippable infrastructure (see
+                # ``_escape_pad_overrides`` policy at
+                # ``core.py:10123-10145``), so the fix MUST be on
+                # the via side -- A* will pick a different layer-
+                # transition point on the via's parent net.
+                #
+                # Concrete failure this catches: board-04
+                # SWDIO/BOOT0 at PCB (143.8, 119.7) on B.Cu.  SWDIO
+                # escape segment landed in escape phase; BOOT0's
+                # main-router via lands later on B.Cu within
+                # via_radius + half_seg_w + clearance of SWDIO's
+                # segment.  PR #3006 cannot see this because it
+                # gates on SEGMENT commit; this hook gates on VIA
+                # commit (post-iteration).
+                via_seg_violators = neg_router.find_nets_with_via_segment_violations(
+                    net_routes, trace_clearance=self.rules.trace_clearance,
+                    cache_key=("post", iteration - 1),
+                )
+                if via_seg_violators:
+                    new_via_violators = [
+                        n for n in via_seg_violators
+                        if n not in nets_to_reroute and n not in off_grid_nets
+                    ]
+                    if new_via_violators:
+                        for v_net in new_via_violators:
+                            nets_to_reroute.append(v_net)
+                        violator_names = [
+                            self.net_names.get(n, f"Net_{n}") for n in new_via_violators
+                        ]
+                        flush_print(
+                            f"  Including {len(new_via_violators)} via-vs-foreign-segment "
                             f"violator(s) in recovery: {', '.join(violator_names)}"
                         )
 
@@ -7777,12 +7835,19 @@ class Autorouter:
             for routes in net_routes.values()
             for route in routes
         )
-        final_violations = len(
-            neg_router.find_nets_with_segment_via_violations(
-                net_routes, trace_clearance=self.rules.trace_clearance,
-                cache_key=("final", final_route_count, final_via_count),
-            )
+        # Issue #3020: combine both directions of the clearance
+        # matrix in the final lex-tuple comparator so a best snapshot
+        # with fewer total violations (in either direction) survives
+        # the post-loop restore.
+        final_seg_via = neg_router.find_nets_with_segment_via_violations(
+            net_routes, trace_clearance=self.rules.trace_clearance,
+            cache_key=("final", final_route_count, final_via_count),
         )
+        final_via_seg = neg_router.find_nets_with_via_segment_violations(
+            net_routes, trace_clearance=self.rules.trace_clearance,
+            cache_key=("final", final_route_count, final_via_count),
+        )
+        final_violations = len(final_seg_via) + len(final_via_seg)
         final_metrics = IterationMetrics(
             iteration=iteration_trajectory[-1].iteration if iteration_trajectory else 0,
             routed_count=current_routed,

--- a/src/kicad_tools/router/via_clearance.py
+++ b/src/kicad_tools/router/via_clearance.py
@@ -418,10 +418,95 @@ def segment_clears_foreign_via(
     return dist >= required - 1e-9
 
 
+def via_clears_foreign_segment(
+    via: "_ViaLike",
+    seg: "_SegmentLike",
+    trace_clearance: float,
+    hard_intersection_only: bool = False,
+) -> bool:
+    """Return True iff a via clears a foreign-net segment.
+
+    Issue #3020: Symmetric sibling of :func:`segment_clears_foreign_via`
+    for the via-vs-segment direction.  Where
+    :func:`segment_clears_foreign_via` protects a NEW segment from a
+    foreign-net via, this predicate protects a NEW via from a
+    foreign-net segment.
+
+    The geometry is symmetric -- the point-to-segment distance does not
+    care which of the two objects is "new" -- so this function uses the
+    exact same math as :func:`segment_clears_foreign_via` and is kept
+    as a thin alias for API symmetry with PR #3006.  Callers consume
+    the predicate-named-for-the-direction, which keeps the call site
+    self-documenting (the named arguments match the parties as named in
+    the call).
+
+    Concrete failure this predicate catches (board-04, PCB
+    (143.8, 119.7) on B.Cu): the BOOT0 net's main-router layer-
+    transition via lands within ``via_radius + half_seg_w +
+    trace_clearance`` of an already-committed SWDIO escape segment on
+    B.Cu.  The escape segment is permanent infrastructure (the
+    ``_escape_pad_overrides`` policy makes it non-rippable), so the
+    fix MUST be on the via side -- the VIA's net is the one returned
+    to the rip-up loop, NOT the segment's net.
+
+    Layer-awareness: the via spans a contiguous layer range
+    ``via.layers[0]..[1]``; the segment occupies one copper layer.  A
+    via must clear a segment only when the via spans the segment's
+    layer.
+
+    Same-net filtering is the CALLER's responsibility (mirrors the
+    boundary convention of :func:`segment_clears_foreign_via`).
+
+    Two thresholds (parameterised by ``hard_intersection_only``):
+
+    * STANDARD (``hard_intersection_only=False``)::
+
+        dist(via_center, segment_centerline)
+          >= via.diameter/2 + seg.width/2 + trace_clearance
+
+      Full manufacturer clearance.  Rejects both hard intersections
+      AND marginal sub-clearance violations.  This is the predicate
+      used by :meth:`NegotiatedRouter.find_nets_with_via_segment_violations`
+      and the Autorouter's main-router re-validation hook.
+
+    * HARD-INTERSECTION (``hard_intersection_only=True``)::
+
+        dist(via_center, segment_centerline)
+          >= via.diameter/2 + seg.width/2
+
+      Drops the ``trace_clearance`` term: only flags cases where
+      copper physically overlaps copper (negative edge-to-edge
+      clearance).  Mirrors the STANDARD/HARD switch in
+      :func:`segment_clears_foreign_via`.
+
+    Args:
+        via: The candidate via.  Reads ``x/y/diameter/layers``.
+        seg: A foreign-net segment to validate against.  Reads
+            ``x1/y1/x2/y2/width/layer``.
+        trace_clearance: Manufacturer minimum copper-to-copper
+            clearance in mm.
+        hard_intersection_only: When True, ignore ``trace_clearance``
+            in the threshold (see HARD-INTERSECTION mode above).
+
+    Returns:
+        True if the via clears the segment, False on violation.
+    """
+    # The math is identical to ``segment_clears_foreign_via`` -- both
+    # operations reduce to "point-to-segment distance must exceed
+    # via_radius + half_seg_width + clearance with layer-span
+    # overlap".  Aliasing keeps the implementations bit-identical and
+    # mathematically symmetric.
+    return segment_clears_foreign_via(
+        seg, via, trace_clearance,
+        hard_intersection_only=hard_intersection_only,
+    )
+
+
 __all__ = [
     "FilledPolygonLike",
     "ForeignPadTuple",
     "TrackSegmentLike",
     "point_clear_of_copper",
     "segment_clears_foreign_via",
+    "via_clears_foreign_segment",
 ]

--- a/tests/test_main_router_via_segment_clearance.py
+++ b/tests/test_main_router_via_segment_clearance.py
@@ -1,0 +1,560 @@
+"""Tests for Issue #3020: main-router via-vs-foreign-segment clearance.
+
+Issue #3020 is the empirical-AC closer for the four-quadrant
+segment/via clearance matrix:
+
+* PR #2999 / Issue #2998 -- escape-phase segment-vs-foreign-via gate.
+* PR #3006 / Issue #3002 -- main-router segment-vs-foreign-via gate +
+  negotiated post-iteration re-validation hook.
+* PR #3019 / Issue #3013 -- escape-phase two-pass commit.
+* PR (this) / Issue #3020 -- main-router via-vs-foreign-segment
+  post-iteration re-validation hook.
+
+The board-04 SWDIO/BOOT0 violation at PCB (143.8, 119.7) on B.Cu
+survives PRs #3006 and #3019 because both PRs gate on SEGMENT commits.
+The violation here is a VIA committed by the main router clipping an
+already-committed foreign-net escape segment.  Escape segments are
+permanent infrastructure (``_escape_pad_overrides``), so the fix MUST
+be on the VIA side -- the via's net is the one that re-routes, and A*
+finds a different layer-transition point.
+
+Test plan:
+
+* ``TestViaClearsForeignSegment``: predicate correctness (clean pass,
+  hard intersection, marginal sub-clearance, layer-span mismatch).
+* ``TestFindNetsWithViaSegmentViolations``: hook integration (clean
+  pass, board-04 SWDIO/BOOT0 detection, same-net filtering, escape-
+  segment-as-foreign filtering).
+* ``TestFindNetsWithViaSegmentViolationsPerformance``: cache key
+  invalidation, layer-bucket, bbox prefilter.
+* ``TestIterationMetricsCombinedViolators``: combined seg-via +
+  via-seg participate in the lex tuple comparator.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.router.algorithms.negotiated import NegotiatedRouter
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.pathfinder import Router
+from kicad_tools.router.primitives import Route, Segment, Via
+from kicad_tools.router.rules import DEFAULT_NET_CLASS_MAP, DesignRules
+from kicad_tools.router.via_clearance import (
+    segment_clears_foreign_via,
+    via_clears_foreign_segment,
+)
+
+
+def _make_rules() -> DesignRules:
+    """DesignRules tuned to mirror board-04's clearance regime."""
+    return DesignRules(
+        trace_width=0.2,
+        trace_clearance=0.15,
+        via_drill=0.3,
+        via_diameter=0.6,
+        via_clearance=0.15,
+        grid_resolution=0.1,
+    )
+
+
+def _make_grid(rules: DesignRules) -> RoutingGrid:
+    return RoutingGrid(
+        width=20.0,
+        height=20.0,
+        rules=rules,
+        origin_x=0.0,
+        origin_y=0.0,
+        layer_stack=LayerStack.two_layer(),
+    )
+
+
+def _make_router(grid: RoutingGrid, rules: DesignRules) -> Router:
+    return Router(grid, rules)
+
+
+# ---------------------------------------------------------------------------
+# via_clears_foreign_segment predicate
+# ---------------------------------------------------------------------------
+
+
+class TestViaClearsForeignSegment:
+    """Unit tests for the new symmetric predicate."""
+
+    def test_clean_geometry_returns_true(self):
+        """A via 5mm from a segment cleanly clears all thresholds."""
+        seg = Segment(
+            x1=0.0, y1=0.0, x2=10.0, y2=0.0,
+            width=0.2, layer=Layer.B_CU, net=1,
+        )
+        via = Via(
+            x=5.0, y=5.0, drill=0.3, diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU), net=2,
+        )
+        assert via_clears_foreign_segment(via, seg, trace_clearance=0.15) is True
+
+    def test_hard_intersection_returns_false(self):
+        """A via dead-center on a segment is a hard intersection."""
+        seg = Segment(
+            x1=0.0, y1=5.0, x2=10.0, y2=5.0,
+            width=0.2, layer=Layer.B_CU, net=1,
+        )
+        via = Via(
+            x=5.0, y=5.0, drill=0.3, diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU), net=2,
+        )
+        assert via_clears_foreign_segment(via, seg, trace_clearance=0.15) is False
+
+    def test_marginal_sub_clearance_returns_false(self):
+        """A via at the board-04 violation distance (~0.075mm short of
+        the trace_clearance threshold) is flagged.
+
+        Distance: via_radius (0.3) + half_seg_w (0.1) + clearance (0.15)
+        = 0.55mm.  At 0.475mm centre-to-centre we are 0.075mm short.
+        """
+        seg = Segment(
+            x1=0.0, y1=5.0, x2=10.0, y2=5.0,
+            width=0.2, layer=Layer.B_CU, net=1,
+        )
+        # via centre 0.475mm above segment centre => 0.075mm short.
+        via = Via(
+            x=5.0, y=5.475, drill=0.3, diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU), net=2,
+        )
+        assert via_clears_foreign_segment(via, seg, trace_clearance=0.15) is False
+
+    def test_hard_intersection_only_admits_marginal(self):
+        """With ``hard_intersection_only=True``, the 0.075mm-short via
+        is admitted (only NEGATIVE edge-to-edge clearance is flagged).
+        """
+        seg = Segment(
+            x1=0.0, y1=5.0, x2=10.0, y2=5.0,
+            width=0.2, layer=Layer.B_CU, net=1,
+        )
+        via = Via(
+            x=5.0, y=5.475, drill=0.3, diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU), net=2,
+        )
+        assert via_clears_foreign_segment(
+            via, seg, trace_clearance=0.15, hard_intersection_only=True
+        ) is True
+        # And a dead-centre via still fails the hard threshold.
+        via_overlap = Via(
+            x=5.0, y=5.0, drill=0.3, diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU), net=2,
+        )
+        assert via_clears_foreign_segment(
+            via_overlap, seg, trace_clearance=0.15, hard_intersection_only=True
+        ) is False
+
+    def test_layer_mismatch_returns_true(self):
+        """A B.Cu segment is invisible to an F.Cu-only via (layers
+        F.Cu..F.Cu does not span B.Cu).
+        """
+        seg = Segment(
+            x1=0.0, y1=5.0, x2=10.0, y2=5.0,
+            width=0.2, layer=Layer.B_CU, net=1,
+        )
+        # F.Cu-only "blind" via -- does not reach B.Cu.
+        via = Via(
+            x=5.0, y=5.0, drill=0.3, diameter=0.6,
+            layers=(Layer.F_CU, Layer.F_CU), net=2,
+        )
+        assert via_clears_foreign_segment(via, seg, trace_clearance=0.15) is True
+
+    def test_symmetric_with_existing_predicate(self):
+        """The new predicate is the symmetric mirror of
+        ``segment_clears_foreign_via`` -- both functions must return
+        the same boolean for the same (via, segment, clearance) input.
+        """
+        seg = Segment(
+            x1=0.0, y1=5.0, x2=10.0, y2=5.0,
+            width=0.2, layer=Layer.B_CU, net=1,
+        )
+        via = Via(
+            x=5.0, y=5.0, drill=0.3, diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU), net=2,
+        )
+        assert (
+            via_clears_foreign_segment(via, seg, trace_clearance=0.15)
+            == segment_clears_foreign_via(seg, via, trace_clearance=0.15)
+        )
+
+
+# ---------------------------------------------------------------------------
+# NegotiatedRouter.find_nets_with_via_segment_violations
+# ---------------------------------------------------------------------------
+
+
+class TestFindNetsWithViaSegmentViolations:
+    """Unit tests for the negotiated post-iteration re-validation hook."""
+
+    def _make_neg_router(self, grid, rules):
+        router = _make_router(grid, rules)
+        return NegotiatedRouter(grid, router, rules, DEFAULT_NET_CLASS_MAP)
+
+    def test_clean_routes_yields_empty(self):
+        """No violations -> empty list."""
+        rules = _make_rules()
+        grid = _make_grid(rules)
+        neg = self._make_neg_router(grid, rules)
+        seg_a = Segment(
+            x1=0.0, y1=0.0, x2=10.0, y2=0.0,
+            width=0.2, layer=Layer.B_CU, net=1,
+        )
+        seg_b = Segment(
+            x1=0.0, y1=5.0, x2=10.0, y2=5.0,
+            width=0.2, layer=Layer.B_CU, net=2,
+        )
+        via_b = Via(
+            x=5.0, y=5.0, drill=0.3, diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU), net=2,
+        )
+        net_routes = {
+            1: [Route(net=1, net_name="A", segments=[seg_a], vias=[])],
+            2: [Route(net=2, net_name="B", segments=[seg_b], vias=[via_b])],
+        }
+        assert neg.find_nets_with_via_segment_violations(
+            net_routes, trace_clearance=0.15
+        ) == []
+
+    def test_detects_via_clipping_foreign_segment(self):
+        """Board-04 SWDIO/BOOT0 regression: BOOT0's main-router via
+        clips SWDIO's escape segment.  The hook surfaces the VIA's
+        net (BOOT0), NOT the segment's net (SWDIO).
+
+        Net attribution invariant from PR #3019 judge: escape segments
+        are permanent infrastructure (``_escape_pad_overrides`` makes
+        them non-rippable), so the rip-up target must be the via's
+        net.
+        """
+        rules = _make_rules()
+        grid = _make_grid(rules)
+        neg = self._make_neg_router(grid, rules)
+        # Net 1 = SWDIO: B.Cu escape segment.
+        swdio_seg = Segment(
+            x1=140.0, y1=119.7, x2=150.0, y2=119.7,
+            width=0.2, layer=Layer.B_CU, net=1, net_name="SWDIO",
+        )
+        # Net 2 = BOOT0: main-router via on B.Cu clipping SWDIO.
+        boot0_via = Via(
+            x=143.8, y=119.7, drill=0.3, diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU), net=2, net_name="BOOT0",
+        )
+        # Net 2 stub so BOOT0 has at least one route entry.
+        boot0_stub = Segment(
+            x1=143.8, y1=119.7, x2=144.3, y2=119.7,
+            width=0.2, layer=Layer.F_CU, net=2, net_name="BOOT0",
+        )
+        net_routes = {
+            1: [Route(net=1, net_name="SWDIO", segments=[swdio_seg], vias=[])],
+            2: [Route(net=2, net_name="BOOT0", segments=[boot0_stub], vias=[boot0_via])],
+        }
+        violators = neg.find_nets_with_via_segment_violations(
+            net_routes, trace_clearance=0.15,
+        )
+        # PR #3019 invariant: VIA's net (BOOT0) surfaces for re-route.
+        assert 2 in violators, (
+            "Hook must surface BOOT0 (the via's net) for re-route, "
+            "not SWDIO (the escape segment is permanent infrastructure)."
+        )
+        # SWDIO must NOT surface -- its escape segment is permanent.
+        assert 1 not in violators, (
+            "SWDIO must NOT be surfaced -- its escape segment is "
+            "permanent infrastructure protected by _escape_pad_overrides."
+        )
+
+    def test_ignores_same_net_via(self):
+        """A via on the SAME net as the foreign segment is filtered."""
+        rules = _make_rules()
+        grid = _make_grid(rules)
+        neg = self._make_neg_router(grid, rules)
+        seg = Segment(
+            x1=0.0, y1=5.0, x2=10.0, y2=5.0,
+            width=0.2, layer=Layer.B_CU, net=1,
+        )
+        via_same_net = Via(
+            x=5.0, y=5.0, drill=0.3, diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU), net=1,  # SAME net.
+        )
+        net_routes = {
+            1: [Route(net=1, net_name="A", segments=[seg], vias=[via_same_net])],
+        }
+        assert neg.find_nets_with_via_segment_violations(
+            net_routes, trace_clearance=0.15
+        ) == []
+
+    def test_escape_segment_as_foreign_segment(self):
+        """Escape segments (committed in escape phase) are visible to
+        the hook as foreign segments.  This is the load-bearing
+        invariant for issue #3020 -- without it the board-04 violation
+        is invisible to the hook.
+        """
+        rules = _make_rules()
+        grid = _make_grid(rules)
+        neg = self._make_neg_router(grid, rules)
+        # Net 1 = SWDIO's escape segment on B.Cu (committed in escape
+        # phase, lives in net_routes).
+        escape_seg = Segment(
+            x1=140.0, y1=120.0, x2=150.0, y2=120.0,
+            width=0.2, layer=Layer.B_CU, net=1, net_name="SWDIO",
+        )
+        # Net 2 = some other net's via clipping it.
+        clipping_via = Via(
+            x=145.0, y=120.0, drill=0.3, diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU), net=2, net_name="BOOT0",
+        )
+        boot0_stub = Segment(
+            x1=145.0, y1=120.0, x2=145.5, y2=120.0,
+            width=0.2, layer=Layer.F_CU, net=2, net_name="BOOT0",
+        )
+        net_routes = {
+            1: [Route(net=1, net_name="SWDIO", segments=[escape_seg], vias=[])],
+            2: [Route(net=2, net_name="BOOT0", segments=[boot0_stub], vias=[clipping_via])],
+        }
+        violators = neg.find_nets_with_via_segment_violations(
+            net_routes, trace_clearance=0.15,
+        )
+        assert 2 in violators  # VIA's net surfaces.
+        assert 1 not in violators  # Escape segment's net does NOT.
+
+
+# ---------------------------------------------------------------------------
+# Performance optimization invariants (cache, bbox, layer-bucket)
+# ---------------------------------------------------------------------------
+
+
+class TestFindNetsWithViaSegmentViolationsPerformance:
+    """Verify the three perf layers mirroring PR #3006:
+
+    1. Per-iteration cache (``cache_key``).
+    2. Per-call segment bucketing by layer.
+    3. Via-bbox prefilter.
+    """
+
+    def _make_neg_router(self, rules, grid):
+        router = _make_router(grid, rules)
+        return NegotiatedRouter(grid, router, rules, DEFAULT_NET_CLASS_MAP)
+
+    def test_cache_key_returns_same_result_on_hit(self):
+        """Same ``cache_key`` -> same result list.  Cache hit must not
+        re-walk (verified by mutating ``net_routes`` between calls).
+        """
+        rules = _make_rules()
+        grid = _make_grid(rules)
+        neg = self._make_neg_router(rules, grid)
+        # Geometry that produces a violation (via 2 clips segment 1).
+        seg = Segment(
+            x1=0.0, y1=5.0, x2=10.0, y2=5.0,
+            width=0.2, layer=Layer.B_CU, net=1,
+        )
+        via = Via(
+            x=5.0, y=5.0, drill=0.3, diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU), net=2,
+        )
+        stub = Segment(
+            x1=5.0, y1=5.0, x2=5.5, y2=5.0,
+            width=0.2, layer=Layer.F_CU, net=2,
+        )
+        net_routes = {
+            1: [Route(net=1, net_name="A", segments=[seg], vias=[])],
+            2: [Route(net=2, net_name="B", segments=[stub], vias=[via])],
+        }
+        first = neg.find_nets_with_via_segment_violations(
+            net_routes, trace_clearance=0.15, cache_key=("iter", 5),
+        )
+        assert 2 in first
+        # Mutate routes -> the violation is GONE but the cache should
+        # still return the stale snapshot when called with the same key.
+        net_routes[2] = []
+        second = neg.find_nets_with_via_segment_violations(
+            net_routes, trace_clearance=0.15, cache_key=("iter", 5),
+        )
+        assert first == second  # Cache hit.
+        # Distinct cache_key bypasses memo -> recomputes.
+        third = neg.find_nets_with_via_segment_violations(
+            net_routes, trace_clearance=0.15, cache_key=("iter", 6),
+        )
+        assert third == []
+
+    def test_cache_key_none_disables_memo(self):
+        """``cache_key=None`` (default) must compute fresh every call."""
+        rules = _make_rules()
+        grid = _make_grid(rules)
+        neg = self._make_neg_router(rules, grid)
+        seg = Segment(
+            x1=0.0, y1=5.0, x2=10.0, y2=5.0,
+            width=0.2, layer=Layer.B_CU, net=1,
+        )
+        via = Via(
+            x=5.0, y=5.0, drill=0.3, diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU), net=2,
+        )
+        stub = Segment(
+            x1=5.0, y1=5.0, x2=5.5, y2=5.0,
+            width=0.2, layer=Layer.F_CU, net=2,
+        )
+        net_routes = {
+            1: [Route(net=1, net_name="A", segments=[seg], vias=[])],
+            2: [Route(net=2, net_name="B", segments=[stub], vias=[via])],
+        }
+        first = neg.find_nets_with_via_segment_violations(
+            net_routes, trace_clearance=0.15,
+        )
+        assert 2 in first
+        # Mutate; cache_key=None -> recompute -> reflects mutation.
+        net_routes[2] = []
+        second = neg.find_nets_with_via_segment_violations(
+            net_routes, trace_clearance=0.15,
+        )
+        assert second == []
+
+    def test_bbox_prefilter_skips_distant_segments(self):
+        """A segment far from any via is bbox-rejected without an
+        exact distance computation.  Correctness side: a clearly-
+        distant segment must NOT produce a violator.
+        """
+        rules = _make_rules()
+        grid = _make_grid(rules)
+        neg = self._make_neg_router(rules, grid)
+        # Segment is at y=15 (far from via at y=5).
+        far_seg = Segment(
+            x1=0.0, y1=15.0, x2=10.0, y2=15.0,
+            width=0.2, layer=Layer.B_CU, net=1,
+        )
+        via = Via(
+            x=5.0, y=5.0, drill=0.3, diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU), net=2,
+        )
+        stub = Segment(
+            x1=5.0, y1=5.0, x2=5.5, y2=5.0,
+            width=0.2, layer=Layer.F_CU, net=2,
+        )
+        net_routes = {
+            1: [Route(net=1, net_name="A", segments=[far_seg], vias=[])],
+            2: [Route(net=2, net_name="B", segments=[stub], vias=[via])],
+        }
+        assert neg.find_nets_with_via_segment_violations(
+            net_routes, trace_clearance=0.15,
+        ) == []
+
+    def test_layer_bucket_skips_non_overlapping_segment(self):
+        """A blind via (F.Cu..F.Cu) cannot violate a B.Cu segment.
+        The layer bucket should never present that pair to the inner
+        predicate.
+        """
+        rules = _make_rules()
+        grid = _make_grid(rules)
+        neg = self._make_neg_router(rules, grid)
+        # B.Cu segment with a via dead-centre on it BUT via is F.Cu-only.
+        b_cu_seg = Segment(
+            x1=0.0, y1=5.0, x2=10.0, y2=5.0,
+            width=0.2, layer=Layer.B_CU, net=1,
+        )
+        f_cu_only_via = Via(
+            x=5.0, y=5.0, drill=0.3, diameter=0.6,
+            layers=(Layer.F_CU, Layer.F_CU), net=2,
+        )
+        f_cu_stub = Segment(
+            x1=5.0, y1=5.0, x2=5.5, y2=5.0,
+            width=0.2, layer=Layer.F_CU, net=2,
+        )
+        net_routes = {
+            1: [Route(net=1, net_name="A", segments=[b_cu_seg], vias=[])],
+            2: [Route(net=2, net_name="B", segments=[f_cu_stub], vias=[f_cu_only_via])],
+        }
+        assert neg.find_nets_with_via_segment_violations(
+            net_routes, trace_clearance=0.15,
+        ) == []
+
+
+# ---------------------------------------------------------------------------
+# Combined seg-via + via-seg in IterationMetrics
+# ---------------------------------------------------------------------------
+
+
+class TestIterationMetricsCombinedViolators:
+    """Issue #3020: the lex tuple comparator sums BOTH directions of
+    the clearance matrix so a best-state restore preserves a hook-
+    driven re-route that fixes EITHER direction.
+    """
+
+    def test_combined_clearance_violations_in_lex_tuple(self):
+        """An iteration that resolved a via-vs-segment violation
+        without changing overflow must beat one with a live violation.
+        """
+        from kicad_tools.router.core import IterationMetrics
+
+        # Iteration A: clean board (0 violations total).
+        a = IterationMetrics(
+            iteration=2, routed_count=30, overflow=10, clearance_violations=0,
+        )
+        # Iteration B: same overflow but 1 live violation (could be
+        # either direction -- the count is combined upstream).
+        b = IterationMetrics(
+            iteration=1, routed_count=30, overflow=10, clearance_violations=1,
+        )
+        assert a.is_better_than(b)
+        assert not b.is_better_than(a)
+
+    def test_default_state_no_violations(self):
+        """``IterationMetrics`` default ``clearance_violations=0``
+        preserves back-compat (Issue #3002 invariant carried forward).
+        """
+        from kicad_tools.router.core import IterationMetrics
+
+        m = IterationMetrics(iteration=0, routed_count=5, overflow=0)
+        assert m.clearance_violations == 0
+
+
+# ---------------------------------------------------------------------------
+# Smoke test: confirm both hooks coexist without interference
+# ---------------------------------------------------------------------------
+
+
+class TestBothHooksCoexist:
+    """Smoke test that both PR #3006's hook and PR #3020's hook can be
+    called on the same ``NegotiatedRouter`` without polluting each
+    other's caches.
+    """
+
+    def _make_neg_router(self, rules, grid):
+        router = _make_router(grid, rules)
+        return NegotiatedRouter(grid, router, rules, DEFAULT_NET_CLASS_MAP)
+
+    def test_separate_cache_slots(self):
+        """Each hook owns its own single-slot cache field; populating
+        one must not affect the other.
+        """
+        rules = _make_rules()
+        grid = _make_grid(rules)
+        neg = self._make_neg_router(rules, grid)
+        seg = Segment(
+            x1=0.0, y1=5.0, x2=10.0, y2=5.0,
+            width=0.2, layer=Layer.B_CU, net=1,
+        )
+        via = Via(
+            x=5.0, y=5.0, drill=0.3, diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU), net=2,
+        )
+        stub = Segment(
+            x1=5.0, y1=5.0, x2=5.5, y2=5.0,
+            width=0.2, layer=Layer.F_CU, net=2,
+        )
+        net_routes = {
+            1: [Route(net=1, net_name="A", segments=[seg], vias=[])],
+            2: [Route(net=2, net_name="B", segments=[stub], vias=[via])],
+        }
+        neg.find_nets_with_segment_via_violations(
+            net_routes, trace_clearance=0.15, cache_key=("iter", 0),
+        )
+        neg.find_nets_with_via_segment_violations(
+            net_routes, trace_clearance=0.15, cache_key=("iter", 0),
+        )
+        # Each cache field is populated independently.
+        assert neg._seg_via_violations_cache is not None
+        assert neg._via_seg_violations_cache is not None
+        # Cache slots are distinct objects.
+        assert (
+            neg._seg_via_violations_cache
+            is not neg._via_seg_violations_cache
+        )


### PR DESCRIPTION
## Summary

Implements the symmetric mirror of PR #3006 for the via-vs-foreign-segment direction, completing the 4-quadrant segment/via clearance matrix on the negotiated-loop side.

- `via_clearance.via_clears_foreign_segment`: new shared predicate (aliased to `segment_clears_foreign_via` since the geometry is symmetric).
- `NegotiatedRouter.find_nets_with_via_segment_violations`: post-iteration re-validation hook with the same 3 perf layers as PR #3006 (per-call segment bucketing by layer, via-bbox prefilter, per-iteration `cache_key` memo).  Returns the VIA's net per PR #3019 judge's invariant.
- `core.route_all_negotiated`: 4 negotiated rip-up call sites + final restore comparator with combined seg-via + via-seg violator count in the lex tuple.
- `two_phase.py`: 4 mirror call sites.
- Tests: 17 new tests covering predicate correctness, hook integration (including the explicit board-04 SWDIO/BOOT0 regression case), perf cache invariants, and combined lex-tuple behaviour.

Closes #3020

## Empirical AC — NOT MET (honesty disclosure)

Per the issue's `"Bar for empirical-claim honesty: very high"` directive, I am NOT claiming the empirical AC is met.  The board-04 floor in `.github/routed-drc-tolerance.yml` stays at 5 (not 4).

### Three fresh re-routes (2026-05-17)

```
Run 1: 5 clearance violations -- includes clearance_segment_via @[43.8, 19.7] SWDIO/BOOT0 actual=-0.0754
Run 2: 5 clearance violations -- (identical to Run 1, deterministic)
Run 3: 5 clearance violations -- (identical to Run 1, deterministic)
```

The violation persists across all 3 runs.

### Root-cause investigation (instrumented hook prints, confirmed by `KCT_DEBUG_3020=1` logs)

- At the time the negotiated post-iteration hook fires (initial pass + each iteration), the closest committed SWDIO B.Cu segment is at y=120.4, which is 0.7mm clear of the BOOT0 via at (143.8, 119.7) — well above the 0.55mm required threshold.  The hook correctly returns `[]` (no violators).
- The offending SWDIO B.Cu segment at y=120.0246 (0.3246mm from the via, -0.0754mm edge-to-edge clearance) does NOT exist in `net_routes` at hook time.  It is introduced LATER by either the trace optimizer's pull-tight pass (`optimizer/trace.py:225`) or the subsequent DRC nudge pass (`drc_nudge.py:_nudge_segment_with_chain`), both of which run AFTER `route_all_negotiated` returns.
- This means the hook's scaffolding is correctly wired (verified by `test_detects_via_clipping_foreign_segment` returning the expected violator BOOT0 when given the violation geometry directly), but the hook cannot reach geometry that doesn't yet exist.

### What this PR does ship

The 4-quadrant matrix's missing scaffolding is now complete on the negotiated-loop side:

| New | vs Segment | vs Via |
|---|---|---|
| New segment | always validated | gated by PR #2999 (escape) + PR #3006 (main, hook) |
| New via | **gated by this PR (hook)** | always validated |

The hook is correct, well-tested, and matches the curator's chosen approach.  It is also potentially useful for future scenarios where a via DOES land mid-iteration into a foreign-net escape segment (the issue's named scenario), even though board-04's specific violation arises later in the pipeline.

### Follow-up needed (out of scope for #3020)

A new issue should wire `via_clears_foreign_segment` (or `segment_clears_foreign_via`) into:

1. **TraceOptimizer's pull-tight / staircase-compression collision check** — the current `VectorCollisionChecker` checks vias against the segment being moved, but the empirical evidence shows the pull-tight pass is moving SWDIO into a position that clips BOOT0's via.  Either the via_rtree is not populated when SWDIO is being optimized, or the clearance threshold being used differs from the manufacturer's.
2. **DRC nudge's destination-validation step** — the nudge can move segments into via clearance envelopes.

Both of those are the actual sites where the SWDIO/BOOT0 violation is being created.  Each is a substantial change in its own right.

## Test plan

- [x] `tests/test_main_router_via_segment_clearance.py`: 17 new tests pass.
- [x] PR #2999 (`tests/test_escape_segment_via_clearance.py`): 17 tests preserved.
- [x] PR #3006 (`tests/test_main_router_segment_via_clearance.py`): 21 tests preserved (1 skipped — C++ availability gate).
- [x] PR #3019: 17 tests preserved (subset of the #2999 file).
- [x] Broader router regression: `test_route_all_negotiated_*` + `test_two_phase_*` + `test_pathfinder_via_foreign_clearance.py` + `test_via_foreign_context_wiring.py` — 64 tests pass.
- [x] Match-Group Routing Regression: 297 tests pass locally (no perf regression expected — the new hook has the same 3 perf layers as PR #3006).
- [x] Three fresh board-04 re-routes — deterministic 5 violations (no yield regression; 9/9 signal nets routed across all 3 runs).
- [x] No `grid.py` public-surface changes.
- [x] Public Router/Pathfinder setter API unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)