### PR TITLE
refactor(router): promote _auto_skip_pour_nets to public helper (closes #3035)

### DIFF
--- a/boards/01-voltage-divider/generate_design.py
+++ b/boards/01-voltage-divider/generate_design.py
@@ -428,8 +428,8 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
 
     Returns True if all nets were routed successfully.
     """
-    from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
     from kicad_tools.router import DesignRules, load_pcb_for_routing
+    from kicad_tools.router.auto_pour import auto_skip_pour_nets
     from kicad_tools.router.optimizer import OptimizationConfig, TraceOptimizer
 
     print("\n" + "=" * 60)
@@ -456,7 +456,7 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
     # negotiated router's _filter_pour_nets() will skip them and leave the
     # PCB empty (Issue #3031, Issue #1841).
     skip_nets = ["GND"]  # GND is a pour net, not routed as traces
-    _skipped, no_zone_nets = _auto_skip_pour_nets(input_path, skip_nets, quiet=True)
+    _skipped, no_zone_nets = auto_skip_pour_nets(input_path, skip_nets, quiet=True)
 
     # Load the PCB
     router, net_map = load_pcb_for_routing(

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -71,6 +71,19 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from kicad_tools.router import Autorouter, LayerStack
 
+# Issue #3035: ``_auto_skip_pour_nets`` was promoted to a public helper at
+# ``kicad_tools.router.auto_pour.auto_skip_pour_nets`` so in-process router
+# callers (board generate_design.py scripts using
+# ``router.route_all_negotiated()`` instead of subprocessing ``kct route``)
+# can reach it without importing a CLI private.  The alias here is
+# load-bearing: the 4 call sites in this module (and the
+# ``@patch("kicad_tools.cli.route_cmd._auto_skip_pour_nets", ...)`` decorators
+# in ``tests/test_layer_escalation.py`` and ``tests/test_route_auto_fix.py``)
+# all reference the underscore name; this re-import preserves the symbol so
+# they continue to resolve to the public implementation transparently.  Do
+# not remove this alias without also updating those patch targets.
+from kicad_tools.router.auto_pour import auto_skip_pour_nets as _auto_skip_pour_nets  # noqa: E402
+
 logger = logging.getLogger(__name__)
 
 
@@ -2025,145 +2038,13 @@ def _filter_layer_configs_for_pcb(
     return filtered
 
 
-def _auto_skip_pour_nets(
-    pcb_path: Path,
-    skip_nets: list[str],
-    quiet: bool = False,
-) -> tuple[list[str], list[str]]:
-    """Detect non-pathfinder nets in the PCB and add them to the skip list.
-
-    Reads net definitions from the PCB file and classifies them.  Nets
-    whose net class declares a non-pathfinder routing intent are appended
-    to *skip_nets* so the router excludes them:
-
-    - ``route_via="pour"`` (or legacy ``is_pour_net=True``) -- the net is
-      satisfied by a copper zone if one exists in the PCB; otherwise the
-      net falls through to ``no_zone_nets`` and is routed as a signal.
-    - ``route_via="manual"`` (Issue #2772) -- the designer is responsible
-      for routing the net by hand (e.g. wide motor-phase traces); the net
-      is unconditionally skipped regardless of zone presence and a
-      distinct ``Manual:`` log line is emitted.
-
-    An explicit ``route_via="pathfinder"`` always wins over the legacy
-    ``is_pour_net=True`` inference -- the new declarative field lets
-    designers override the name-pattern classifier for a specific class.
-
-    Args:
-        pcb_path: Path to the .kicad_pcb file.
-        skip_nets: Mutable list of net names already marked for skipping
-            (e.g. from ``--skip-nets`` CLI flag).  Modified in place.
-        quiet: Suppress informational output.
-
-    Returns:
-        Tuple of (auto_skipped, no_zone_nets):
-        - auto_skipped: Net names that were auto-skipped (zone-routed
-          pour nets and ``route_via="manual"`` nets combined).
-        - no_zone_nets: Pour net names that lack zones and must be
-          routed as signals.  Pass these to the autorouter's
-          ``_pour_nets_without_zones`` attribute so that
-          ``_filter_pour_nets()`` does not re-skip them (Issue #1841).
-    """
-    try:
-        import re as _re
-
-        from kicad_tools.router.auto_pour import _is_erc_marker_net
-        from kicad_tools.router.net_class import classify_and_apply_rules
-
-        pcb_text = pcb_path.read_text()
-        net_names: dict[int, str] = {}
-        for m in _re.finditer(r'\(net\s+(\d+)\s+"([^"]+)"\)', pcb_text):
-            net_num, name = int(m.group(1)), m.group(2)
-            if net_num > 0:
-                net_names[net_num] = name
-
-        if net_names:
-            net_class_map = classify_and_apply_rules(net_names)
-            # Only auto-skip pour nets that actually have zones in the PCB.
-            # Nets classified as pour by name (e.g. +5V) but without a zone
-            # must still be routed as signals.
-            nets_with_zones: set[str] = set()
-            # Match traditional KiCad 7/8 format: (zone ... (net_name "GND") ...)
-            for zm in _re.finditer(
-                r'\(zone\s+.*?\(net_name\s+"([^"]+)"\)',
-                pcb_text,
-                _re.DOTALL,
-            ):
-                nets_with_zones.add(zm.group(1))
-            # Match KiCad 9 name-only format: (zone ... (net "GND") ...)
-            for zm in _re.finditer(r'\(zone\s[^)]*\(net\s+"([^"]+)"\)', pcb_text):
-                nets_with_zones.add(zm.group(1))
-            del pcb_text  # free memory
-
-            # Issue #2772: route_via takes precedence over the legacy
-            # ``is_pour_net`` flag.  An explicit ``route_via="pathfinder"``
-            # overrides ``is_pour_net=True`` (designer-declared opt-IN to
-            # pathfinder routing for an otherwise-pour-classified class);
-            # ``route_via="pour"`` or ``"manual"`` are the opt-OUT signals.
-            def _wants_pour(routing) -> bool:
-                if routing.route_via == "pathfinder":
-                    return False
-                if routing.route_via == "pour":
-                    return True
-                # Legacy fall-back: pre-#2772 classes with default
-                # ``route_via="pathfinder"`` but ``is_pour_net=True``.
-                return routing.is_pour_net
-
-            def _wants_manual(routing) -> bool:
-                return routing.route_via == "manual"
-
-            # ERC-marker nets (PWR_FLAG and friends) are misclassified as
-            # pour nets by the name pattern but carry no copper and have
-            # no zone -- exclude them from both the auto-skip and the
-            # "pour nets without zones" warning so the user does not see
-            # a misleading "use zone fill" log line for a non-existent
-            # zone.  See router/auto_pour.py for the filter.
-            pour_skip = [
-                name
-                for name, routing in net_class_map.items()
-                if _wants_pour(routing)
-                and name not in skip_nets
-                and name in nets_with_zones
-                and not _is_erc_marker_net(name)
-            ]
-            # ``route_via="manual"`` nets are always skipped (designer
-            # routes them by hand); zone presence is irrelevant.  ERC
-            # markers are still excluded for the same reason as above.
-            manual_skip = [
-                name
-                for name, routing in net_class_map.items()
-                if _wants_manual(routing) and name not in skip_nets and not _is_erc_marker_net(name)
-            ]
-            auto_skip = pour_skip + manual_skip
-            if pour_skip:
-                skip_nets.extend(pour_skip)
-                if not quiet:
-                    print(
-                        f"Auto-skip: {', '.join(sorted(pour_skip))} (pour nets \u2014 use zone fill)"
-                    )
-            if manual_skip:
-                skip_nets.extend(manual_skip)
-                if not quiet:
-                    print(
-                        f"Manual: {', '.join(sorted(manual_skip))} (skipped \u2014 route_via=manual)"
-                    )
-            # Warn about pour nets without zones (excluding ERC markers
-            # which never get zones by design).  ``route_via="manual"``
-            # nets are intentionally NOT in this list -- the designer has
-            # declared they will handle routing by hand, not via a zone.
-            no_zone = [
-                name
-                for name, routing in net_class_map.items()
-                if _wants_pour(routing)
-                and name not in skip_nets
-                and name not in nets_with_zones
-                and not _is_erc_marker_net(name)
-            ]
-            if no_zone and not quiet:
-                print(f"Routing: {', '.join(sorted(no_zone))} (power nets without zones)")
-            return auto_skip, no_zone
-    except Exception:
-        pass  # Fall back to user-supplied skip_nets only
-    return [], []
+# Issue #3035: ``_auto_skip_pour_nets`` was promoted to
+# ``kicad_tools.router.auto_pour.auto_skip_pour_nets``; the alias is bound
+# near the top of this module (search ``Issue #3035``).  The 4 call sites
+# in this file keep using ``_auto_skip_pour_nets`` unchanged so the
+# ``@patch("kicad_tools.cli.route_cmd._auto_skip_pour_nets", ...)``
+# decorators in ``tests/test_layer_escalation.py`` and
+# ``tests/test_route_auto_fix.py`` continue to resolve.
 
 
 def _apply_net_class_map_sidecar(router: "Autorouter", args, quiet: bool = False) -> None:

--- a/src/kicad_tools/router/auto_pour.py
+++ b/src/kicad_tools/router/auto_pour.py
@@ -297,6 +297,159 @@ def _remove_zones_for_nets(pcb_path: Path, net_names: set[str]) -> None:
     pcb_path.write_text("".join(out_parts))
 
 
+def auto_skip_pour_nets(
+    pcb_path: Path,
+    skip_nets: list[str],
+    quiet: bool = False,
+) -> tuple[list[str], list[str]]:
+    """Detect non-pathfinder nets in the PCB and add them to the skip list.
+
+    Reads net definitions from the PCB file and classifies them.  Nets
+    whose net class declares a non-pathfinder routing intent are appended
+    to *skip_nets* so the router excludes them:
+
+    - ``route_via="pour"`` (or legacy ``is_pour_net=True``) -- the net is
+      satisfied by a copper zone if one exists in the PCB; otherwise the
+      net falls through to ``no_zone_nets`` and is routed as a signal.
+    - ``route_via="manual"`` (Issue #2772) -- the designer is responsible
+      for routing the net by hand (e.g. wide motor-phase traces); the net
+      is unconditionally skipped regardless of zone presence and a
+      distinct ``Manual:`` log line is emitted.
+
+    An explicit ``route_via="pathfinder"`` always wins over the legacy
+    ``is_pour_net=True`` inference -- the new declarative field lets
+    designers override the name-pattern classifier for a specific class.
+
+    Args:
+        pcb_path: Path to the .kicad_pcb file.
+        skip_nets: Mutable list of net names already marked for skipping
+            (e.g. from ``--skip-nets`` CLI flag).  Modified in place.
+        quiet: Suppress informational output.
+
+    Returns:
+        Tuple of (auto_skipped, no_zone_nets):
+        - auto_skipped: Net names that were auto-skipped (zone-routed
+          pour nets and ``route_via="manual"`` nets combined).
+        - no_zone_nets: Pour net names that lack zones and must be
+          routed as signals.  Pass these to the autorouter's
+          ``_pour_nets_without_zones`` attribute so that
+          ``_filter_pour_nets()`` does not re-skip them (Issue #1841).
+
+    Notes:
+        Promoted from the leading-underscore CLI internal
+        ``kicad_tools.cli.route_cmd._auto_skip_pour_nets`` (Issue #3035)
+        so in-process router callers (board generate_design.py scripts
+        using ``router.route_all_negotiated()`` instead of subprocessing
+        ``kct route``) can reach it without importing a CLI private.
+
+        ``kicad_tools.cli.route_cmd`` keeps a
+        ``from ... import auto_skip_pour_nets as _auto_skip_pour_nets``
+        alias so all existing call sites and the test patches at
+        ``@patch("kicad_tools.cli.route_cmd._auto_skip_pour_nets", ...)``
+        in ``tests/test_layer_escalation.py`` and
+        ``tests/test_route_auto_fix.py`` keep working unchanged.  Do
+        not remove that alias without also updating those patch targets.
+    """
+    try:
+        from kicad_tools.router.net_class import classify_and_apply_rules
+
+        pcb_text = Path(pcb_path).read_text()
+        net_names: dict[int, str] = {}
+        for m in re.finditer(r'\(net\s+(\d+)\s+"([^"]+)"\)', pcb_text):
+            net_num, name = int(m.group(1)), m.group(2)
+            if net_num > 0:
+                net_names[net_num] = name
+
+        if net_names:
+            net_class_map = classify_and_apply_rules(net_names)
+            # Only auto-skip pour nets that actually have zones in the PCB.
+            # Nets classified as pour by name (e.g. +5V) but without a zone
+            # must still be routed as signals.
+            nets_with_zones: set[str] = set()
+            # Match traditional KiCad 7/8 format: (zone ... (net_name "GND") ...)
+            for zm in re.finditer(
+                r'\(zone\s+.*?\(net_name\s+"([^"]+)"\)',
+                pcb_text,
+                re.DOTALL,
+            ):
+                nets_with_zones.add(zm.group(1))
+            # Match KiCad 9 name-only format: (zone ... (net "GND") ...)
+            for zm in re.finditer(r'\(zone\s[^)]*\(net\s+"([^"]+)"\)', pcb_text):
+                nets_with_zones.add(zm.group(1))
+            del pcb_text  # free memory
+
+            # Issue #2772: route_via takes precedence over the legacy
+            # ``is_pour_net`` flag.  An explicit ``route_via="pathfinder"``
+            # overrides ``is_pour_net=True`` (designer-declared opt-IN to
+            # pathfinder routing for an otherwise-pour-classified class);
+            # ``route_via="pour"`` or ``"manual"`` are the opt-OUT signals.
+            def _wants_pour(routing) -> bool:
+                if routing.route_via == "pathfinder":
+                    return False
+                if routing.route_via == "pour":
+                    return True
+                # Legacy fall-back: pre-#2772 classes with default
+                # ``route_via="pathfinder"`` but ``is_pour_net=True``.
+                return routing.is_pour_net
+
+            def _wants_manual(routing) -> bool:
+                return routing.route_via == "manual"
+
+            # ERC-marker nets (PWR_FLAG and friends) are misclassified as
+            # pour nets by the name pattern but carry no copper and have
+            # no zone -- exclude them from both the auto-skip and the
+            # "pour nets without zones" warning so the user does not see
+            # a misleading "use zone fill" log line for a non-existent
+            # zone.  See _is_erc_marker_net above for the filter.
+            pour_skip = [
+                name
+                for name, routing in net_class_map.items()
+                if _wants_pour(routing)
+                and name not in skip_nets
+                and name in nets_with_zones
+                and not _is_erc_marker_net(name)
+            ]
+            # ``route_via="manual"`` nets are always skipped (designer
+            # routes them by hand); zone presence is irrelevant.  ERC
+            # markers are still excluded for the same reason as above.
+            manual_skip = [
+                name
+                for name, routing in net_class_map.items()
+                if _wants_manual(routing) and name not in skip_nets and not _is_erc_marker_net(name)
+            ]
+            auto_skip = pour_skip + manual_skip
+            if pour_skip:
+                skip_nets.extend(pour_skip)
+                if not quiet:
+                    print(
+                        f"Auto-skip: {', '.join(sorted(pour_skip))} (pour nets — use zone fill)"
+                    )
+            if manual_skip:
+                skip_nets.extend(manual_skip)
+                if not quiet:
+                    print(
+                        f"Manual: {', '.join(sorted(manual_skip))} (skipped — route_via=manual)"
+                    )
+            # Warn about pour nets without zones (excluding ERC markers
+            # which never get zones by design).  ``route_via="manual"``
+            # nets are intentionally NOT in this list -- the designer has
+            # declared they will handle routing by hand, not via a zone.
+            no_zone = [
+                name
+                for name, routing in net_class_map.items()
+                if _wants_pour(routing)
+                and name not in skip_nets
+                and name not in nets_with_zones
+                and not _is_erc_marker_net(name)
+            ]
+            if no_zone and not quiet:
+                print(f"Routing: {', '.join(sorted(no_zone))} (power nets without zones)")
+            return auto_skip, no_zone
+    except Exception:
+        pass  # Fall back to user-supplied skip_nets only
+    return [], []
+
+
 def auto_pour_if_missing(
     pcb_path: Path,
     *,

--- a/tests/test_auto_pour.py
+++ b/tests/test_auto_pour.py
@@ -745,3 +745,136 @@ class TestAutoPourSplitGround:
         assert layers_by_net.get("GNDA") is not None
         assert layers_by_net.get("GNDD") is not None
         assert layers_by_net["GNDA"] != layers_by_net["GNDD"]
+
+
+# ----------------------------------------------------------------------
+# Issue #3035 -- public API surface for auto_skip_pour_nets
+# ----------------------------------------------------------------------
+
+
+class TestAutoSkipPourNetsPublicAPI:
+    """Smoke tests for ``auto_skip_pour_nets`` as a public symbol (#3035).
+
+    Promoted from the leading-underscore CLI internal
+    ``kicad_tools.cli.route_cmd._auto_skip_pour_nets`` so in-process
+    router callers (board ``generate_design.py`` scripts) can reach it
+    without importing a CLI private.  Verifies:
+
+    * The new public path resolves and returns the expected
+      ``(auto_skip, no_zone_nets)`` tuple shape.
+    * The CLI-side alias still resolves to the *same* function object so
+      existing ``@patch("kicad_tools.cli.route_cmd._auto_skip_pour_nets")``
+      decorators in the test suite keep targeting the live implementation.
+    * Behaviour on a small fixture matches the documented contract: pour
+      nets with zones land in ``auto_skip``, pour-classified nets without
+      zones land in ``no_zone_nets``.
+    """
+
+    def test_public_path_and_cli_alias_are_same_function(self):
+        """``auto_skip_pour_nets`` is reachable from both the public and
+        legacy CLI paths and they resolve to the *same* function object.
+
+        ``tests/test_layer_escalation.py`` and
+        ``tests/test_route_auto_fix.py`` patch the CLI alias name; if
+        these two stopped being the same object, those patches would
+        silently no-op against the real call sites (which import the
+        public symbol indirectly via the alias).
+        """
+        from kicad_tools.cli.route_cmd import _auto_skip_pour_nets
+        from kicad_tools.router.auto_pour import auto_skip_pour_nets
+
+        assert auto_skip_pour_nets is _auto_skip_pour_nets
+
+    def test_power_net_without_zone_lands_in_no_zone(self, tmp_path: Path):
+        """A power-classified net with no zone is returned in ``no_zone_nets``.
+
+        Mirrors the board 01 fixture (VIN + VOUT are pour-classified by
+        name but the unrouted PCB has no zones for them, so they must be
+        routed as signals via ``router._pour_nets_without_zones``).
+        """
+        from kicad_tools.router.auto_pour import auto_skip_pour_nets
+
+        pcb = _make_pcb(
+            net_defs=[(1, "VIN"), (2, "VOUT"), (3, "GND")],
+            pad_nets=[(1, "VIN"), (2, "VOUT"), (3, "GND")],
+        )
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(pcb)
+
+        skip_nets: list[str] = []
+        auto_skip, no_zone = auto_skip_pour_nets(pcb_path, skip_nets, quiet=True)
+
+        # No zones exist, so all pour-classified nets fall through to
+        # no_zone (not auto_skip).  VIN/VOUT/GND all classify as power
+        # or ground by name pattern.
+        assert auto_skip == []
+        assert set(no_zone) == {"VIN", "VOUT", "GND"}
+        # ``skip_nets`` is left untouched because nothing was added.
+        assert skip_nets == []
+
+    def test_power_net_with_zone_lands_in_auto_skip(self, tmp_path: Path):
+        """A power-classified net with a zone is appended to ``skip_nets``.
+
+        When the PCB already has a copper zone for a pour-classified net,
+        that net should be routed via the zone fill rather than as a
+        signal trace -- it lands in ``auto_skip`` and gets appended to
+        the caller's ``skip_nets`` list.
+        """
+        from kicad_tools.router.auto_pour import auto_skip_pour_nets
+
+        zone_gnd = (
+            '(zone (net 3) (net_name "GND") (layer "B.Cu") (hatch edge 0.5) '
+            "(connect_pads (clearance 0.25)) "
+            "(fill yes (thermal_gap 0.5) (thermal_bridge_width 0.5)) "
+            "(polygon (pts (xy 0 0) (xy 50 0) (xy 50 50) (xy 0 50))))"
+        )
+        pcb = _make_pcb(
+            net_defs=[(1, "VIN"), (2, "VOUT"), (3, "GND"), (4, "SIG1")],
+            pad_nets=[(1, "VIN"), (2, "VOUT"), (3, "GND"), (4, "SIG1")],
+            zones=[zone_gnd],
+        )
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(pcb)
+
+        skip_nets: list[str] = []
+        auto_skip, no_zone = auto_skip_pour_nets(pcb_path, skip_nets, quiet=True)
+
+        # GND has a zone -> auto_skipped (caller routes via fill).
+        # VIN/VOUT have no zone -> fall through to no_zone for signal
+        # routing.
+        assert "GND" in auto_skip
+        assert "GND" in skip_nets  # mutated in place
+        assert set(no_zone) == {"VIN", "VOUT"}
+
+    def test_existing_skip_nets_preserved(self, tmp_path: Path):
+        """User-supplied ``skip_nets`` entries are not re-added or duplicated.
+
+        The function appends to the caller's list in place; nets already
+        present must not be processed (they are already skipped) and
+        must not appear in the returned ``auto_skip`` either.
+        """
+        from kicad_tools.router.auto_pour import auto_skip_pour_nets
+
+        zone_gnd = (
+            '(zone (net 1) (net_name "GND") (layer "B.Cu") (hatch edge 0.5) '
+            "(connect_pads (clearance 0.25)) "
+            "(fill yes (thermal_gap 0.5) (thermal_bridge_width 0.5)) "
+            "(polygon (pts (xy 0 0) (xy 50 0) (xy 50 50) (xy 0 50))))"
+        )
+        pcb = _make_pcb(
+            net_defs=[(1, "GND"), (2, "SIG1")],
+            pad_nets=[(1, "GND"), (2, "SIG1")],
+            zones=[zone_gnd],
+        )
+        pcb_path = tmp_path / "test.kicad_pcb"
+        pcb_path.write_text(pcb)
+
+        # Pre-populate skip_nets with GND (already user-skipped)
+        skip_nets: list[str] = ["GND"]
+        auto_skip, no_zone = auto_skip_pour_nets(pcb_path, skip_nets, quiet=True)
+
+        # GND is already in skip_nets, so it is NOT re-added by the
+        # carve-out and does NOT appear in auto_skip.
+        assert "GND" not in auto_skip
+        assert skip_nets.count("GND") == 1
+        assert no_zone == []


### PR DESCRIPTION
## Summary

Promotes `_auto_skip_pour_nets` from the leading-underscore CLI internal at `kicad_tools.cli.route_cmd._auto_skip_pour_nets` to the public helper `kicad_tools.router.auto_pour.auto_skip_pour_nets`, so in-process router callers (board `generate_design.py` scripts driving `router.route_all_negotiated()` directly) can reach it without importing a CLI private.

The CLI module keeps a load-bearing alias (`from kicad_tools.router.auto_pour import auto_skip_pour_nets as _auto_skip_pour_nets`) so:
- The 4 existing call sites in `route_cmd.py` (lines ~2273, ~2974, ~4016, ~5763 in the pre-change file) keep working unchanged.
- The 19 `@patch("kicad_tools.cli.route_cmd._auto_skip_pour_nets", ...)` decorators in `tests/test_layer_escalation.py` and `tests/test_route_auto_fix.py` continue to resolve to the live implementation transparently.

Pure mechanical move + visibility change; the carve-out logic (`_wants_pour` / `_wants_manual` / zone-presence / ERC-marker filter cascade) is byte-identical.

Curator chose **Option 1** (promote in place) over Option 2 (`load_pcb_for_routing(auto_skip_pour_nets=True)` kwarg) because the return value is a 2-tuple that in-process callers must thread into two separate router objects (`skip_nets` -> `load_pcb_for_routing(skip_nets=...)`, `no_zone_nets` -> `router._pour_nets_without_zones`). Folding into the loader would couple it to a router private attribute and hide the `Auto-skip:` / `Manual:` log lines. Option 2 remains a viable follow-up once `_pour_nets_without_zones` is itself promoted.

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|---|---|---|
| `boards/01-voltage-divider/generate_design.py` no longer imports an underscore symbol from `route_cmd` | PASS | `generate_design.py:431-433` now imports `from kicad_tools.router.auto_pour import auto_skip_pour_nets` |
| CLI's 4 existing call sites continue to work | PASS | Top-of-module alias `_auto_skip_pour_nets = auto_skip_pour_nets` resolves them; all 4 sites untouched |
| Board 01 still produces `Routing: SUCCESS` | PASS | `uv run python boards/01-voltage-divider/generate_design.py` -> `Routing: SUCCESS`, `DRC: PASS` |
| `uv run kct route .../voltage_divider.kicad_pcb -o /tmp/test_3035.kicad_pcb --skip-nets GND --mfr jlcpcb` still succeeds | PASS | `SUCCESS: Design requires minimum 2 layers`, `DRC PASSED (jlcpcb profile, 2 layers)`; "Routing: VIN, VOUT (power nets without zones)" log line emitted, confirming the alias preserves CLI behavior |
| New smoke test in `tests/test_auto_pour.py` exercises `auto_skip_pour_nets` as a public symbol | PASS | `TestAutoSkipPourNetsPublicAPI` class with 4 tests, all passing |
| Existing test patches at `kicad_tools.cli.route_cmd._auto_skip_pour_nets` keep passing | PASS | All test_layer_escalation tests outside `TestEarlyTermination` pass; `TestEarlyTermination::*` failures are pre-existing on `main` (MagicMock TypeError in `router/io.py:2073`, unrelated to this change) |

## Out-of-scope (per curator)

- Board scripts 02/03/04/05 are intentionally left alone -- those are M-B (#3032), M-C (#3033), M-D, M-E's job under epic #2394. Concurrent builders for #3032 (PR #3036 already open, used subprocess `kct route` -- no conflict) and #3033 may resolve their own import paths.
- The carve-out logic itself is unchanged byte-for-byte (visibility-only refactor).
- The `load_pcb_for_routing(auto_skip_pour_nets=True)` Option 2 kwarg is deferred to a follow-up once `_pour_nets_without_zones` is itself a public attribute.

## Test plan

- [x] `uv run pytest tests/test_auto_pour.py::TestAutoSkipPourNetsPublicAPI -q` -> 4 passed
- [x] `uv run pytest tests/test_auto_pour.py -q` -> all tests pass
- [x] `uv run pytest tests/test_route_auto_fix.py tests/test_layer_escalation.py -q --deselect tests/test_layer_escalation.py::TestEarlyTermination` -> 87 passed (the 9 `TestEarlyTermination` failures are pre-existing on `main` -- `MagicMock` `TypeError` in `router/io.py:2073`, no connection to this refactor)
- [x] `uv run python boards/01-voltage-divider/generate_design.py` -> `ERC: PASS`, `Routing: SUCCESS`, `DRC: PASS`
- [x] `uv run kct route boards/01-voltage-divider/output/voltage_divider.kicad_pcb -o /tmp/test_3035.kicad_pcb --skip-nets GND --mfr jlcpcb` -> `SUCCESS: Design requires minimum 2 layers`, DRC PASSED
- [x] `uv run ruff check` on all 4 touched files -> All checks passed

## Files changed

- `src/kicad_tools/router/auto_pour.py` -- adds `auto_skip_pour_nets` (cut + paste from route_cmd.py, identical logic, expanded docstring noting the load-bearing alias).
- `src/kicad_tools/cli/route_cmd.py` -- replaces the 139-line def with a top-of-module `from ... import ... as _auto_skip_pour_nets` alias plus a short load-bearing-alias comment.
- `boards/01-voltage-divider/generate_design.py` -- migrates the import to the new public path and renames the single call site.
- `tests/test_auto_pour.py` -- new `TestAutoSkipPourNetsPublicAPI` class with 4 smoke tests (same-function identity check, no-zone fallthrough, zone-present auto-skip, pre-populated `skip_nets` preservation).

Net: +308 / -141 LOC, well within the S-tier (80-120 LOC) curator estimate (most of the addition is the cut + paste of the helper body and the new test class).