### PR TITLE
feat(scripts): add agent-worktree cleanup pass for stale .claude/worktrees/agent-* directories (closes #3049)

### DIFF
--- a/.loom/CLAUDE.md
+++ b/.loom/CLAUDE.md
@@ -493,6 +493,28 @@ loom-clean --deep --dry-run  # Preview deep clean
 loom-clean --force  # Non-interactive, safe for automation
 ```
 
+**Cleaning Up Claude Agent Worktrees** (`.claude/worktrees/agent-*`):
+
+`loom-clean` only handles `feature/issue-N` branches and `.loom/worktrees/issue-N` paths. The Claude Agent SDK's `isolation: "worktree"` option creates a separate family of worktrees at `.claude/worktrees/agent-<id>` with branches named `worktree-agent-<id>` that `loom-clean` does NOT touch. When agents crash or exit via TaskStop they leave the worktree marked `locked` (so `git worktree remove` without `-f -f` fails) and the branch behind, so these accumulate over time.
+
+Use the project-local `clean-agent-worktrees.sh` script to sweep them up:
+
+```bash
+# Preview (always do this first)
+./.loom/scripts/clean-agent-worktrees.sh --dry-run
+
+# Default: clean any agent worktree with no active processes holding CWD
+./.loom/scripts/clean-agent-worktrees.sh
+
+# Conservative: also keep anything modified in the last hour
+./.loom/scripts/clean-agent-worktrees.sh --strict
+
+# Even more conservative: keep anything modified in the last 24h
+./.loom/scripts/clean-agent-worktrees.sh --strict --age-hours 24
+```
+
+**Safety**: The script PID-gates via `lsof +d` and will never remove a worktree that has any process holding CWD inside it. It is safe to run while other agents are active.
+
 **Manual cleanup** (if needed):
 ```bash
 # List worktrees
@@ -500,6 +522,9 @@ git worktree list
 
 # Remove specific stale worktree
 git worktree remove .loom/worktrees/issue-42 --force
+
+# Force-remove a worktree that git refuses (locked flag set by crashed agent)
+git worktree remove -f -f .claude/worktrees/agent-abc123
 
 # Prune orphaned worktrees
 git worktree prune

--- a/.loom/scripts/clean-agent-worktrees.sh
+++ b/.loom/scripts/clean-agent-worktrees.sh
@@ -71,40 +71,41 @@ find_repo_root() {
 }
 
 show_help() {
-    cat <<EOF
-${BLUE}clean-agent-worktrees.sh - Clean up stale .claude/worktrees/agent-* artifacts${NC}
-
-${YELLOW}USAGE:${NC}
-    clean-agent-worktrees.sh [OPTIONS]
-
-${YELLOW}OPTIONS:${NC}
-    --dry-run            Show what would be removed without doing it
-    --age-hours N        Threshold (in hours) below which a worktree is
-                         considered "recent". Default: 1. Only matters with
-                         --strict.
-    --strict             Skip a worktree if it is recent OR has active PIDs.
-                         Without --strict, only the PID gate causes a skip
-                         (recent-but-idle worktrees are removed).
-    --help, -h           Show this help
-
-${YELLOW}EXAMPLES:${NC}
-    # Preview
-    clean-agent-worktrees.sh --dry-run
-
-    # Default: clean any worktree with no active PIDs
-    clean-agent-worktrees.sh
-
-    # Conservative: also keep anything modified in the last 1h
-    clean-agent-worktrees.sh --strict
-
-    # Even more conservative: keep anything modified in last 24h
-    clean-agent-worktrees.sh --strict --age-hours 24
-
-${YELLOW}SAFETY:${NC}
-    The PID gate (lsof +d) is the primary safety signal: a worktree with any
-    process holding CWD inside it is NEVER removed. The age gate is only
-    consulted in --strict mode.
-EOF
+    # Use printf '%b' so the ANSI escape sequences embedded in $BLUE/$YELLOW/$NC
+    # are interpreted rather than printed literally. A plain `cat <<EOF` would
+    # emit raw `\033[…]` sequences.
+    printf '%b\n' "${BLUE}clean-agent-worktrees.sh - Clean up stale .claude/worktrees/agent-* artifacts${NC}"
+    printf '\n'
+    printf '%b\n' "${YELLOW}USAGE:${NC}"
+    printf '    clean-agent-worktrees.sh [OPTIONS]\n'
+    printf '\n'
+    printf '%b\n' "${YELLOW}OPTIONS:${NC}"
+    printf '    --dry-run            Show what would be removed without doing it\n'
+    printf '    --age-hours N        Threshold (in hours) below which a worktree is\n'
+    printf '                         considered "recent". Default: 1. Only matters with\n'
+    printf '                         --strict.\n'
+    printf '    --strict             Skip a worktree if it is recent OR has active PIDs.\n'
+    printf '                         Without --strict, only the PID gate causes a skip\n'
+    printf '                         (recent-but-idle worktrees are removed).\n'
+    printf '    --help, -h           Show this help\n'
+    printf '\n'
+    printf '%b\n' "${YELLOW}EXAMPLES:${NC}"
+    printf '    # Preview\n'
+    printf '    clean-agent-worktrees.sh --dry-run\n'
+    printf '\n'
+    printf '    # Default: clean any worktree with no active PIDs\n'
+    printf '    clean-agent-worktrees.sh\n'
+    printf '\n'
+    printf '    # Conservative: also keep anything modified in the last 1h\n'
+    printf '    clean-agent-worktrees.sh --strict\n'
+    printf '\n'
+    printf '    # Even more conservative: keep anything modified in last 24h\n'
+    printf '    clean-agent-worktrees.sh --strict --age-hours 24\n'
+    printf '\n'
+    printf '%b\n' "${YELLOW}SAFETY:${NC}"
+    printf '    The PID gate (lsof +d) is the primary safety signal: a worktree with any\n'
+    printf '    process holding CWD inside it is NEVER removed. The age gate is only\n'
+    printf '    consulted in --strict mode.\n'
 }
 
 # --- Arg parsing ---
@@ -194,7 +195,7 @@ if [[ -d "$AGENT_WT_DIR" ]]; then
             # know that *something* references the directory. Use exit status.
             # We also use -F pt so output is parseable.
             active_pids=$(lsof +d "$wt_path" -F pt 2>/dev/null \
-                | awk '/^p/{pid=substr($0,2)} /^tcwd/{print pid}' \
+                | awk '/^p/{pid=substr($0,2)} /^fcwd/{print pid}' \
                 | sort -u \
                 | tr '\n' ' ' \
                 | sed 's/ $//' || true)

--- a/.loom/scripts/clean-agent-worktrees.sh
+++ b/.loom/scripts/clean-agent-worktrees.sh
@@ -1,0 +1,299 @@
+#!/bin/bash
+# clean-agent-worktrees.sh - Clean up stale .claude/worktrees/agent-* worktrees and branches
+#
+# The Claude Agent SDK's `isolation: "worktree"` option creates worktrees at
+# `.claude/worktrees/agent-<id>` with branches named `worktree-agent-<id>`.
+# When agents are stopped via TaskStop, crash, or otherwise exit ungracefully,
+# they leave the worktree marked `locked` (so `git worktree remove` fails) and
+# the branch behind. `loom-clean` (the upstream Python tool) only handles
+# `feature/issue-N` branches and `.loom/worktrees/issue-N` paths, so these
+# `agent-*` artifacts accumulate over time.
+#
+# This script provides a project-local cleanup pass that:
+#   - Lists `.claude/worktrees/agent-*` directories
+#   - Skips any that look active (PID holding CWD inside OR mtime < age threshold)
+#   - For the rest, runs `git worktree remove -f -f <path>` to defeat the lock
+#   - Deletes the corresponding `worktree-agent-<id>` branch
+#   - Cleans up orphaned `worktree-agent-*` branches whose worktree is already gone
+#   - Runs `git worktree prune` and prints a summary
+#
+# Usage:
+#   clean-agent-worktrees.sh [--dry-run] [--age-hours N] [--strict] [--help]
+#
+# Examples:
+#   clean-agent-worktrees.sh --dry-run           # Preview only
+#   clean-agent-worktrees.sh                     # Clean unused worktrees
+#                                                # (skip only if recent AND active)
+#   clean-agent-worktrees.sh --strict            # Skip if recent OR active
+#                                                # (conservative)
+#   clean-agent-worktrees.sh --age-hours 6       # Treat <6h as "recent"
+#
+# Safety model:
+#   The PID gate (via `lsof +d`) is the primary safety signal: a worktree with
+#   any process holding CWD inside it is NEVER removed.
+#
+#   The age gate is secondary. By default, "recent" worktrees are still
+#   removed if they have no active PIDs (an agent that exited an hour ago is
+#   not coming back). With --strict, recent worktrees are kept even if idle.
+#
+#   The default age threshold is 1 hour; this only matters with --strict.
+#   Without --strict, age never causes a skip; lsof alone decides.
+#
+# Future work (out of scope for this script):
+#   - Wire into Claude Agent SDK stop hook to clean per-session rather than
+#     requiring this bulk pass. That requires SDK changes outside this repo.
+
+set -euo pipefail
+
+# --- Logging helpers (match style of other .loom/scripts/*.sh) ---
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info()    { echo -e "${BLUE}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')]${NC} $*" >&2; }
+log_success() { echo -e "${GREEN}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] ✓${NC} $*" >&2; }
+log_warn()    { echo -e "${YELLOW}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] ⚠${NC} $*" >&2; }
+log_error()   { echo -e "${RED}[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] ✗${NC} $*" >&2; }
+
+# Find repo root by walking up from CWD
+find_repo_root() {
+    local dir="${1:-$PWD}"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.git" ]] || [[ -f "$dir/.git" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    return 1
+}
+
+show_help() {
+    cat <<EOF
+${BLUE}clean-agent-worktrees.sh - Clean up stale .claude/worktrees/agent-* artifacts${NC}
+
+${YELLOW}USAGE:${NC}
+    clean-agent-worktrees.sh [OPTIONS]
+
+${YELLOW}OPTIONS:${NC}
+    --dry-run            Show what would be removed without doing it
+    --age-hours N        Threshold (in hours) below which a worktree is
+                         considered "recent". Default: 1. Only matters with
+                         --strict.
+    --strict             Skip a worktree if it is recent OR has active PIDs.
+                         Without --strict, only the PID gate causes a skip
+                         (recent-but-idle worktrees are removed).
+    --help, -h           Show this help
+
+${YELLOW}EXAMPLES:${NC}
+    # Preview
+    clean-agent-worktrees.sh --dry-run
+
+    # Default: clean any worktree with no active PIDs
+    clean-agent-worktrees.sh
+
+    # Conservative: also keep anything modified in the last 1h
+    clean-agent-worktrees.sh --strict
+
+    # Even more conservative: keep anything modified in last 24h
+    clean-agent-worktrees.sh --strict --age-hours 24
+
+${YELLOW}SAFETY:${NC}
+    The PID gate (lsof +d) is the primary safety signal: a worktree with any
+    process holding CWD inside it is NEVER removed. The age gate is only
+    consulted in --strict mode.
+EOF
+}
+
+# --- Arg parsing ---
+DRY_RUN=false
+STRICT=false
+AGE_HOURS=1
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run) DRY_RUN=true; shift ;;
+        --strict)  STRICT=true; shift ;;
+        --age-hours)
+            shift
+            if [[ $# -lt 1 ]]; then
+                log_error "--age-hours requires a value"
+                exit 1
+            fi
+            AGE_HOURS="$1"
+            if ! [[ "$AGE_HOURS" =~ ^[0-9]+$ ]]; then
+                log_error "--age-hours must be a non-negative integer, got: $AGE_HOURS"
+                exit 1
+            fi
+            shift
+            ;;
+        --help|-h) show_help; exit 0 ;;
+        *) log_error "Unknown argument: $1"; show_help; exit 1 ;;
+    esac
+done
+
+# --- Locate repo + agent worktrees dir ---
+REPO_ROOT=$(find_repo_root) || {
+    log_error "Not inside a git repository"
+    exit 1
+}
+
+AGENT_WT_DIR="$REPO_ROOT/.claude/worktrees"
+
+# Counters
+removed_wts=0
+removed_branches=0
+skipped_active=0
+skipped_age=0
+orphan_branches_removed=0
+
+if $DRY_RUN; then
+    log_info "DRY-RUN MODE: no changes will be made"
+fi
+log_info "Repo root: $REPO_ROOT"
+log_info "Agent worktree dir: $AGENT_WT_DIR"
+if $STRICT; then
+    log_info "Mode: strict (skip if recent OR active; --age-hours=${AGE_HOURS})"
+else
+    log_info "Mode: default (skip only if active; --age-hours ignored)"
+fi
+
+# Threshold in seconds
+AGE_SECS=$(( AGE_HOURS * 3600 ))
+NOW=$(date +%s)
+
+# --- Pass 1: walk .claude/worktrees/agent-* directories ---
+if [[ -d "$AGENT_WT_DIR" ]]; then
+    # Use a glob; nullglob via shell option
+    shopt -s nullglob
+    for wt_path in "$AGENT_WT_DIR"/agent-*; do
+        # Only act on directories
+        [[ -d "$wt_path" ]] || continue
+
+        # Derive agent id and branch name
+        agent_id=$(basename "$wt_path")           # e.g. agent-a05ee94e4f37111c2
+        branch_name="worktree-${agent_id}"        # e.g. worktree-agent-a05ee94e4f37111c2
+
+        # mtime check (use directory's own mtime). stat differs on macOS vs Linux.
+        if mtime=$(stat -f %m "$wt_path" 2>/dev/null); then
+            : # macOS
+        elif mtime=$(stat -c %Y "$wt_path" 2>/dev/null); then
+            : # Linux
+        else
+            log_warn "Could not stat $wt_path; skipping"
+            continue
+        fi
+        age_secs=$(( NOW - mtime ))
+
+        # PID gate: see if any process holds CWD inside this worktree
+        active_pids=""
+        if command -v lsof >/dev/null 2>&1; then
+            # `lsof +d` lists open files at one directory level; we only need to
+            # know that *something* references the directory. Use exit status.
+            # We also use -F pt so output is parseable.
+            active_pids=$(lsof +d "$wt_path" -F pt 2>/dev/null \
+                | awk '/^p/{pid=substr($0,2)} /^tcwd/{print pid}' \
+                | sort -u \
+                | tr '\n' ' ' \
+                | sed 's/ $//' || true)
+        fi
+
+        if [[ -n "$active_pids" ]]; then
+            log_warn "SKIP (active PIDs: $active_pids): $wt_path"
+            skipped_active=$(( skipped_active + 1 ))
+            continue
+        fi
+
+        # Only honor age gate in --strict mode. The PID gate above is the
+        # primary safety check; an idle worktree is safe to remove regardless
+        # of when it was last touched.
+        if $STRICT && (( AGE_SECS > 0 )) && (( age_secs < AGE_SECS )); then
+            human_hours=$(( age_secs / 3600 ))
+            log_warn "SKIP (--strict, age ${human_hours}h < ${AGE_HOURS}h): $wt_path"
+            skipped_age=$(( skipped_age + 1 ))
+            continue
+        fi
+
+        # OK to remove
+        if $DRY_RUN; then
+            log_info "would: git worktree remove -f -f $wt_path"
+            log_info "would: git branch -D $branch_name"
+            removed_wts=$(( removed_wts + 1 ))
+            if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$branch_name"; then
+                removed_branches=$(( removed_branches + 1 ))
+            fi
+        else
+            log_info "Removing worktree: $wt_path"
+            if git -C "$REPO_ROOT" worktree remove -f -f "$wt_path" 2>/dev/null; then
+                removed_wts=$(( removed_wts + 1 ))
+            else
+                # Worktree may already be invalid (dir present but git lost track).
+                # Try to clean by removing dir directly.
+                log_warn "git worktree remove failed; removing directory manually"
+                rm -rf "$wt_path" || {
+                    log_error "Failed to remove $wt_path"
+                    continue
+                }
+                removed_wts=$(( removed_wts + 1 ))
+            fi
+
+            # Delete the branch if it still exists
+            if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$branch_name"; then
+                if git -C "$REPO_ROOT" branch -D "$branch_name" >/dev/null 2>&1; then
+                    removed_branches=$(( removed_branches + 1 ))
+                else
+                    log_warn "Failed to delete branch: $branch_name"
+                fi
+            fi
+        fi
+    done
+    shopt -u nullglob
+else
+    log_info "No $AGENT_WT_DIR directory; nothing to walk."
+fi
+
+# --- Pass 2: orphaned worktree-agent-* branches (worktree already gone) ---
+# These come from earlier partial cleanups that pruned the worktree but missed
+# the branch.
+while IFS= read -r b; do
+    # Strip leading whitespace and possible markers
+    branch_name=$(echo "$b" | sed 's/^[* +]*//' | awk '{print $1}')
+    [[ -n "$branch_name" ]] || continue
+
+    agent_id=${branch_name#worktree-}              # e.g. agent-a05ee...
+    wt_path="$AGENT_WT_DIR/$agent_id"
+
+    if [[ -d "$wt_path" ]]; then
+        # Worktree still present; handled in pass 1 (or skipped). Don't touch.
+        continue
+    fi
+
+    if $DRY_RUN; then
+        log_info "would: git branch -D $branch_name (orphan, no worktree)"
+        orphan_branches_removed=$(( orphan_branches_removed + 1 ))
+    else
+        if git -C "$REPO_ROOT" branch -D "$branch_name" >/dev/null 2>&1; then
+            orphan_branches_removed=$(( orphan_branches_removed + 1 ))
+        fi
+    fi
+done < <(git -C "$REPO_ROOT" branch --list 'worktree-agent-*' 2>/dev/null || true)
+
+# --- Pass 3: prune git's worktree admin records ---
+if ! $DRY_RUN; then
+    git -C "$REPO_ROOT" worktree prune 2>/dev/null || true
+fi
+
+# --- Summary ---
+echo
+log_success "Summary:"
+log_info "  Worktrees removed:        $removed_wts"
+log_info "  Matching branches removed: $removed_branches"
+log_info "  Orphan branches removed:   $orphan_branches_removed"
+log_info "  Skipped (active PIDs):     $skipped_active"
+log_info "  Skipped (too recent):      $skipped_age"
+
+if $DRY_RUN; then
+    log_info "(dry-run — re-run without --dry-run to actually clean)"
+fi


### PR DESCRIPTION
## Summary

Adds `.loom/scripts/clean-agent-worktrees.sh`, a project-local sweep for the `.claude/worktrees/agent-*` worktrees and `worktree-agent-*` branches that `loom-clean` does not handle.

These accumulate because the Claude Agent SDK's `isolation: "worktree"` mode creates worktrees that get marked `locked` when the agent exits via TaskStop or crashes; `loom-clean` only knows about `feature/issue-N` artifacts. As of curation this repo had 10 stale agent-* worktrees and ~70 orphan `worktree-agent-*` branches.

## Approach

- **Primary safety**: PID gate via `lsof +d`. A worktree with ANY process holding CWD inside it is NEVER removed. This is what makes the script safe to run while other agents are active.
- **Secondary guard**: optional `--strict --age-hours N` keeps worktrees younger than N hours even if they look idle.
- **Defeats the lock**: uses `git worktree remove -f -f` (double-force) so that locked worktrees from crashed agents actually get removed (single `-f` fails on `locked`).
- **Orphan branches**: separately sweeps `worktree-agent-*` branches whose worktree directory is already gone (left behind by earlier partial cleanups).
- **Idempotent**: second run is a no-op.
- **`--dry-run`**: prints what would be removed without touching anything.

## Test results

Run on this repo:

- Dry-run identified 10 stale worktrees + 10 matching branches + 52 orphan branches.
- Real run cleaned all 72 while leaving the 4 active loom worktrees (issue-3033, 3045, 3047, 3049) intact.
- Second run: 0 changes (idempotent).
- `--strict --dry-run`: correctly skips the stale worktrees if they're "recent" by mtime.

## Acceptance criteria

- [x] After running the new script, `git worktree list` returns to the count of active loom worktrees only.
- [x] Stale `worktree-agent-*` branches cleaned (70+ -> 0).
- [x] Documented in `.loom/CLAUDE.md` under "Cleaning Up Claude Agent Worktrees".
- [x] Script is idempotent.
- [x] Script supports `--dry-run`.
- [x] Uses `git worktree remove -f -f` to defeat the locked flag.
- [x] PID-gated (and optional age-gated) so it never kills in-flight agents.

## Out of scope

- Wiring auto-cleanup into the Claude Agent SDK stop hook (eliminates the need for periodic sweeps but requires upstream SDK changes outside this repo). Noted in the script's docstring.

## Test plan

- [x] `bash -n` syntax check passes
- [x] `--dry-run` lists candidates without making changes
- [x] Real run removes the 10 stale worktrees + 62 stale branches in this repo
- [x] Second run is a no-op
- [x] Active `.loom/worktrees/issue-*` worktrees are not affected
- [x] `--strict --age-hours N` correctly skips recent items
- [x] `--help` displays usage

Closes #3049