### PR TITLE
fix(check): close bidirectional drift in CLI check dispatcher vs DRCChecker.check_all (closes #3046)

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -72,6 +72,7 @@ CHECK_CATEGORIES = [
     "silkscreen",
     "single_pad_net",
     "solder_mask",
+    "via_in_pad",
     "zones",
 ]
 
@@ -308,7 +309,12 @@ def run_selected_checks(
     """Run the selected DRC checks based on filters."""
     results = DRCResults()
 
-    # Map of category to check method
+    # Map of category to check method.  This dict MUST stay a superset
+    # of the methods invoked by ``DRCChecker.check_all`` (i.e., every
+    # name in ``DRCChecker.CHECK_ALL_METHODS`` must be referenced as a
+    # value here).  The regression test in
+    # ``tests/test_check_cmd_coverage.py`` enforces the invariant for
+    # Issue #3046.
     check_methods = {
         "clearance": checker.check_clearances,
         "diffpair_clearance_intra": checker.check_diffpair_clearance_intra,
@@ -324,6 +330,7 @@ def run_selected_checks(
         "silkscreen": checker.check_silkscreen,
         "single_pad_net": checker.check_single_pad_nets,
         "solder_mask": checker.check_solder_mask_pads,
+        "via_in_pad": checker.check_via_in_pad,
         "zones": checker.check_zones,
     }
 

--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -97,6 +97,37 @@ class DRCChecker:
         profile = get_profile(manufacturer)
         self.design_rules: DesignRules = profile.get_design_rules(layers, copper_oz)
 
+    # The canonical ordered list of bound-method names that
+    # :meth:`check_all` invokes.  Exposed as a class attribute so the CLI
+    # dispatcher (``cli/check_cmd.py::run_selected_checks``) can assert
+    # at test time that its category dict is a superset of every check
+    # ``check_all`` runs (regression test for Issue #3046 -- the CLI used
+    # to silently omit ``check_via_in_pad`` and ``check_all`` used to
+    # omit ``check_pad_grid_alignment``).
+    #
+    # Adding a new ``check_X`` method to this class therefore requires
+    # updating exactly two places: this tuple AND the ``check_methods``
+    # dict in ``cli/check_cmd.py``.  The regression test in
+    # ``tests/test_check_cmd_coverage.py`` enforces the second half.
+    CHECK_ALL_METHODS: tuple[str, ...] = (
+        "check_clearances",
+        "check_diffpair_clearance_intra",
+        "check_diffpair_length_skew",
+        "check_diffpair_routing_continuity",
+        "check_dimensions",
+        "check_edge_clearances",
+        "check_impedance",
+        "check_match_group_length_skew",
+        "check_silkscreen",
+        "check_solder_mask_pads",
+        "check_footprint_placement",
+        "check_netlist",
+        "check_single_pad_nets",
+        "check_pad_grid_alignment",
+        "check_via_in_pad",
+        "check_zones",
+    )
+
     def check_all(
         self,
         filters: list[ViolationFilter] | None = None,
@@ -114,22 +145,10 @@ class DRCChecker:
         """
         results = DRCResults()
 
-        # Run each category of checks
-        results.merge(self.check_clearances())
-        results.merge(self.check_diffpair_clearance_intra())
-        results.merge(self.check_diffpair_length_skew())
-        results.merge(self.check_diffpair_routing_continuity())
-        results.merge(self.check_dimensions())
-        results.merge(self.check_edge_clearances())
-        results.merge(self.check_impedance())
-        results.merge(self.check_match_group_length_skew())
-        results.merge(self.check_silkscreen())
-        results.merge(self.check_solder_mask_pads())
-        results.merge(self.check_footprint_placement())
-        results.merge(self.check_netlist())
-        results.merge(self.check_single_pad_nets())
-        results.merge(self.check_via_in_pad())
-        results.merge(self.check_zones())
+        # Run each category of checks (order matches CHECK_ALL_METHODS).
+        for method_name in self.CHECK_ALL_METHODS:
+            method = getattr(self, method_name)
+            results.merge(method())
 
         # Apply filters if provided
         if filters:

--- a/tests/test_check_cmd_coverage.py
+++ b/tests/test_check_cmd_coverage.py
@@ -1,0 +1,178 @@
+"""Regression test for bidirectional drift between ``kct check`` CLI
+dispatcher and :meth:`DRCChecker.check_all` (Issue #3046).
+
+Before the fix, the two code paths each silently omitted a check the
+other ran:
+
+* ``check_all`` invoked ``check_via_in_pad`` but the CLI dispatcher's
+  ``check_methods`` dict omitted ``via_in_pad`` -- so ``kct check``
+  could not surface in-pad-via errors that the audit/export path
+  flagged.  This is the primary leak the issue is about.
+* The CLI dispatcher invoked ``check_pad_grid_alignment`` but
+  ``check_all`` omitted it -- so the library API ran a different set
+  of checks than the CLI.
+
+The fix closes both gaps and adds the invariant test below, which fails
+on ``main`` (pre-fix) and passes after the dispatcher dict gains
+``via_in_pad`` AND ``check_all`` gains ``check_pad_grid_alignment``.
+
+To enable the introspection, ``check_all`` now drives its method calls
+from :attr:`DRCChecker.CHECK_ALL_METHODS` (a class-level tuple).  This
+test asserts:
+
+1. The CLI dispatcher's ``check_methods`` dict references every name
+   in ``CHECK_ALL_METHODS`` (the issue's main concern).
+2. Conversely, every method in ``CHECK_ALL_METHODS`` is a real
+   ``DRCChecker`` instance method (catches typos in the tuple).
+3. The CLI's category list and dispatcher dict stay in sync (a
+   sibling drift hazard).
+4. Specific spot-checks that ``via_in_pad`` is exposed via the CLI
+   (the exact regression #3046 reports).
+
+Out of scope: the actual ViaInPadRule logic -- that is tested in
+``tests/test_validate_via_in_pad.py`` and exercised end-to-end against
+board 02 via ``tests/test_audit.py``.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.cli import check_cmd
+from kicad_tools.schema.pcb import PCB
+from kicad_tools.validate import DRCChecker
+from kicad_tools.validate.violations import DRCResults
+
+
+def _build_minimal_checker() -> DRCChecker:
+    """Construct a ``DRCChecker`` against an in-memory empty PCB.
+
+    The check_methods dict only stores bound methods, so we just need a
+    valid ``DRCChecker`` instance to introspect against.  We do NOT
+    invoke any of the real check implementations (every check method is
+    stubbed before any of them runs).
+    """
+    pcb = PCB.create(width=10.0, height=10.0, layers=2)
+    return DRCChecker(pcb, manufacturer="jlcpcb", layers=2)
+
+
+def _extract_dispatcher_methods(checker: DRCChecker) -> dict[str, str]:
+    """Return the dispatcher's ``{category: underlying-method-name}`` map.
+
+    Works by stubbing every ``check_*`` method on the ``checker``
+    instance with a recording stub, then driving each known category
+    through :func:`run_selected_checks` once.  Each stub records the
+    name of the method it replaced under the active category, so the
+    returned dict tells us which method each CLI category actually
+    invokes.
+
+    We do NOT introspect the dispatcher dict directly because it lives
+    inside the function body.  Behavioural introspection is more robust
+    than syntactic introspection (no AST parsing, no source-file
+    coupling).
+    """
+    recorded: dict[str, str] = {}
+    active_category: list[str] = [""]
+
+    # All known check_* attributes on the checker instance.  We stub
+    # every one so accidentally invoking a real check (e.g. due to a
+    # category not in the dispatcher dict) is impossible.
+    check_attrs = [
+        name
+        for name in dir(checker)
+        if name.startswith("check_") and callable(getattr(checker, name))
+    ]
+
+    def make_stub(method_name: str):
+        def stub(*_args, **_kwargs) -> DRCResults:
+            # Record the FIRST method invoked for this category (the
+            # dispatcher dict only maps each category to one method).
+            recorded.setdefault(active_category[0], method_name)
+            return DRCResults()
+
+        return stub
+
+    for name in check_attrs:
+        setattr(checker, name, make_stub(name))
+
+    for category in check_cmd.CHECK_CATEGORIES:
+        active_category[0] = category
+        check_cmd.run_selected_checks(checker, only_set={category}, skip_set=set())
+
+    return recorded
+
+
+class TestCheckAllMethodsConstant:
+    """The introspection seam ``DRCChecker.CHECK_ALL_METHODS`` must be a
+    well-formed tuple of real method names; otherwise the rest of the
+    invariant tests can't run."""
+
+    def test_check_all_methods_is_tuple(self) -> None:
+        assert isinstance(DRCChecker.CHECK_ALL_METHODS, tuple)
+        assert DRCChecker.CHECK_ALL_METHODS, "CHECK_ALL_METHODS must not be empty"
+
+    def test_every_name_is_a_real_method(self) -> None:
+        for name in DRCChecker.CHECK_ALL_METHODS:
+            assert hasattr(DRCChecker, name), (
+                f"CHECK_ALL_METHODS lists {name!r} but DRCChecker has no such method"
+            )
+            assert callable(getattr(DRCChecker, name)), (
+                f"DRCChecker.{name} is not callable"
+            )
+
+    def test_names_are_unique(self) -> None:
+        names = list(DRCChecker.CHECK_ALL_METHODS)
+        assert len(names) == len(set(names)), (
+            f"CHECK_ALL_METHODS contains duplicates: {names}"
+        )
+
+
+class TestDispatcherIsSupersetOfCheckAll:
+    """The core regression test for Issue #3046."""
+
+    def test_cli_dispatcher_covers_every_check_all_method(self) -> None:
+        """Every method invoked by ``check_all`` MUST be reachable from
+        the CLI dispatcher.  Otherwise ``kct check`` silently skips
+        rules that the library API runs (the #3046 leak).
+        """
+        checker = _build_minimal_checker()
+        category_to_method = _extract_dispatcher_methods(checker)
+
+        dispatched_method_names = set(category_to_method.values())
+        check_all_method_names = set(DRCChecker.CHECK_ALL_METHODS)
+
+        missing = check_all_method_names - dispatched_method_names
+        assert not missing, (
+            f"CLI dispatcher omits checks that DRCChecker.check_all runs: "
+            f"{sorted(missing)}.  Add them to check_methods in "
+            f"src/kicad_tools/cli/check_cmd.py::run_selected_checks."
+        )
+
+    def test_via_in_pad_is_exposed_via_cli(self) -> None:
+        """Spot-check for the exact regression #3046 reports."""
+        checker = _build_minimal_checker()
+        category_to_method = _extract_dispatcher_methods(checker)
+        assert "via_in_pad" in category_to_method, (
+            "CLI dispatcher must expose via_in_pad so ``kct check`` "
+            "surfaces in-pad-via errors that audit/export flag.  See "
+            "Issue #3046 / board 02 (24.3, 9.9) on D2.1."
+        )
+        assert category_to_method["via_in_pad"] == "check_via_in_pad"
+
+    def test_pad_grid_alignment_in_check_all(self) -> None:
+        """The reciprocal of #3046: ``check_all`` must run the pad-grid
+        check the CLI runs.  Both paths now invoke the same set."""
+        assert "check_pad_grid_alignment" in DRCChecker.CHECK_ALL_METHODS
+
+
+class TestCategoryListMatchesDispatcher:
+    """``CHECK_CATEGORIES`` (the ``--only/--skip`` argparse choices) and
+    the dispatcher dict are two declarations of the same set; drift
+    between them produces silently-ignored CLI flags."""
+
+    def test_categories_list_equals_dispatcher_keys(self) -> None:
+        checker = _build_minimal_checker()
+        category_to_method = _extract_dispatcher_methods(checker)
+        assert set(check_cmd.CHECK_CATEGORIES) == set(category_to_method.keys()), (
+            "CHECK_CATEGORIES must equal the keys of run_selected_checks's "
+            "check_methods dict.  Drift means --only/--skip silently "
+            "accepts/rejects unknown categories."
+        )


### PR DESCRIPTION
## Summary

The CLI dispatcher (\`run_selected_checks\` in \`cli/check_cmd.py\`) and \`DRCChecker.check_all()\` each silently omitted a check the other ran:

- \`check_all\` invoked \`check_via_in_pad\` but the CLI omitted \`via_in_pad\` from its \`check_methods\` dict. **Result**: \`kct check\` could not surface in-pad-via errors on profiles where the audit and export pipelines flagged them. The latent example: board 02 has a real error at (24.300, 9.900) on D2-1 net NODE_A that PR #3036's judge flagged but \`kct check\` missed.
- The CLI invoked \`check_pad_grid_alignment\` but \`check_all\` omitted it. **Result**: the library API ran a different set of checks than the CLI.

This is the surgical, ~5-LOC fix the curator scoped on the issue. The structural fix (single rule registry shared across \`kct check\`, \`check_all\`, \`ManufacturingAudit\`, and export preflight) is tracked separately as #3044 and will subsume this when it lands. The regression test added here is exactly the invariant #3044 will need to keep passing.

## Changes

- \`src/kicad_tools/cli/check_cmd.py\`:
  - Add \`via_in_pad\` to \`CHECK_CATEGORIES\` (the \`--only\`/\`--skip\` choice list).
  - Add \`\"via_in_pad\": checker.check_via_in_pad\` to the dispatcher dict in \`run_selected_checks\`.
  - Document the superset invariant in a comment above the dict.
- \`src/kicad_tools/validate/checker.py\`:
  - Add \`check_pad_grid_alignment\` to \`check_all\`'s method set (the reciprocal gap).
  - Promote the method list to a class-level \`DRCChecker.CHECK_ALL_METHODS\` tuple so \`check_all\` and the new regression test reference a single source of truth. \`check_all\` now iterates this tuple instead of hard-coding 15 \`results.merge(...)\` calls.
- \`tests/test_check_cmd_coverage.py\` (new):
  - \`TestDispatcherIsSupersetOfCheckAll\` -- asserts every method invoked by \`check_all\` is reachable from the CLI dispatcher (the #3046 invariant). Spot-checks \`via_in_pad\` is present and bound to \`check_via_in_pad\`.
  - \`TestCheckAllMethodsConstant\` -- asserts \`CHECK_ALL_METHODS\` is a well-formed tuple of real, unique \`DRCChecker\` methods.
  - \`TestCategoryListMatchesDispatcher\` -- asserts \`CHECK_CATEGORIES\` equals the dispatcher dict's keys (a sibling drift hazard).
  - Verified to **FAIL on \`main\`** (pre-fix: \`CHECK_ALL_METHODS\` doesn't exist + \`via_in_pad\` not in dispatcher) and **PASS after the fix**.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| \`kct check\` reports the via_in_pad error at (24.3, 9.9) on board 02 | OK | \`uv run kct check --mfr jlcpcb boards/02-charlieplex-led/output/charlieplex_3x3_routed.kicad_pcb\` now reports \`[X] via_in_pad: Via at (24.300, 9.900) drilled inside pad D2-1 (net 'NODE_A')\` with exit code 2. Pre-fix this error was silently invisible. |
| Adding a new rule to \`DRCChecker\` cannot silently drift from the CLI dispatcher | OK | \`tests/test_check_cmd_coverage.py::TestDispatcherIsSupersetOfCheckAll::test_cli_dispatcher_covers_every_check_all_method\` fires on any missing dispatcher entry, with a helpful pointer to \`run_selected_checks\`. |
| New regression test fails on \`main\` today and passes after the fix | OK | Verified by stashing the production-code edits and re-running the test (6/7 failed, including \`AttributeError\` on \`CHECK_ALL_METHODS\` and the \`via_in_pad\` spot-check). After the fix, 7/7 pass. |
| No regression on existing check/DRC tests | OK | \`tests/test_check_cmd_coverage.py tests/test_drc.py tests/test_drc_category.py tests/test_drc_summary.py\`: 189/189 pass. \`tests/test_audit.py::TestZoneConnectedNets::test_no_zones_regression\` fails on this branch but **also fails on \`origin/main\`** (verified in a clean worktree) -- pre-existing, unrelated. |

## Test Plan

- [x] \`uv run pytest tests/test_check_cmd_coverage.py -v --no-cov\` -- 7 passed
- [x] \`uv run pytest tests/test_check_cmd_coverage.py tests/test_drc.py tests/test_drc_category.py tests/test_drc_summary.py -q --no-cov\` -- 189 passed
- [x] \`uv run kct check --mfr jlcpcb boards/02-charlieplex-led/output/charlieplex_3x3_routed.kicad_pcb\` -- reports the via_in_pad error (was silently passing pre-fix)
- [x] \`uv run ruff check src/kicad_tools/cli/check_cmd.py src/kicad_tools/validate/checker.py tests/test_check_cmd_coverage.py\` -- clean
- [x] Regression test confirmed to fail on \`origin/main\` (proves the invariant catches the bug)

## Out of Scope (per curator on #3046)

- The structural fix from #3044 (promote a single rule registry across \`kct check\`, \`check_all\`, \`ManufacturingAudit\`, and export preflight). #3044 will subsume this issue when it lands.
- Other rule gaps between \`kct check\`, \`check_all\`, \`ManufacturingAudit\`, and export preflight beyond \`via_in_pad\` / \`pad_grid_alignment\`. None observed in the dispatcher pair touched here, but the broader audit is what #3044 addresses.

Closes #3046

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>