### PR TITLE
docs: require kct build-native for C++ router performance (Phase 1 of #3045)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,27 @@
 <!-- BEGIN LOOM ORCHESTRATION -->
 This repository uses [Loom](https://github.com/rjwalters/loom) for AI-powered development orchestration. See `.loom/CLAUDE.md` for the full guide (roles, labels, worktrees, configuration).
 <!-- END LOOM ORCHESTRATION -->
+
+## Routing performance: build the C++ backend first
+
+Before benchmarking routing latency or filing "router is slow" issues,
+verify the C++ router extension (`src/kicad_tools/router/router_cpp.*.so`)
+is built in the active worktree:
+
+```bash
+uv run kct build-native --check
+# Expected: "C++ backend: available (version 1.0.0)"
+```
+
+If it reports "not installed", build it once:
+
+```bash
+uv run kct build-native
+```
+
+`uv sync` does **not** build the native extension — fresh checkouts and
+new git worktrees (`.loom/worktrees/issue-N/`) need this step explicitly.
+The C++ backend gives a 10-100x speedup for the A* loop, so a missing
+extension is the most likely cause of multi-minute-per-net routing.
+
+See `README.md` "Fresh worktree checklist" for the full setup sequence.

--- a/README.md
+++ b/README.md
@@ -583,6 +583,16 @@ cd kicad-tools
 # Set up development environment (installs all dev dependencies)
 uv sync --extra dev
 
+# Build the C++ router backend (REQUIRED for production routing speed,
+# delivers 10-100x A* speedup vs pure-Python; takes ~30s on first build,
+# cached thereafter). uv sync does NOT build this — fresh checkouts and
+# fresh worktrees need this step explicitly.
+uv run kct build-native
+
+# Verify the C++ backend is installed
+uv run kct build-native --check
+# Expected: "C++ backend: available (version 1.0.0)"
+
 # Run tests
 uv run pytest
 
@@ -592,6 +602,20 @@ uv run ruff check .
 # Format code
 uv run ruff format .
 ```
+
+> **Routing performance note**: Without the C++ backend, board routing falls
+> back to pure-Python A* — typically 5-10x slower per net, which can push
+> medium boards (e.g. board 07 in `boards/07-matchgroup-test/`) past the
+> default 6-minute CI cap. If `kct route` appears stuck or per-net log lines
+> take tens of seconds, run `kct build-native --check` first — a missing
+> extension is the most common cause.
+
+#### Fresh worktree checklist
+
+When creating a new git worktree (e.g. via `./.loom/scripts/worktree.sh`),
+the worktree's `.venv/` does not inherit the C++ extension built in the
+main checkout. After `cd` into the worktree, run `uv run kct build-native`
+once before any routing benchmarks.
 
 ### Available Commands
 

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -482,6 +482,53 @@ ladder). The two non-obvious cases:
 
 ## Performance
 
+### Native C++ Backend (Build First!)
+
+The router has a C++ A* implementation that delivers a **10-100x speedup**
+over pure Python for the inner pathfinding loop. **It is not built by
+`uv sync`** — you must explicitly run `kct build-native` once after every
+fresh checkout or new git worktree.
+
+```bash
+# Check whether the C++ extension is already built
+kct build-native --check
+# "C++ backend: available (version 1.0.0)"  <-- good
+# "C++ backend: not installed"              <-- run kct build-native
+
+# Build (takes ~30s; one-time cost per worktree)
+kct build-native
+```
+
+`kct route` automatically uses the C++ backend when it's present and falls
+back to pure-Python silently when it isn't. The routing log prints the
+active backend:
+
+```text
+Backend:    cpp v1.0.0 (native, 10-100x faster)   <-- C++ active
+Backend:    python (fallback)                     <-- C++ missing/broken
+```
+
+**If `kct route` appears stuck or per-net log lines show tens of seconds**,
+verify the backend before tuning anything else — a missing C++ extension is
+the single most common cause of router slowness on developer workstations
+and CI runners.
+
+```bash
+# Force backend selection (default = auto)
+kct route board.kicad_pcb --backend cpp     # require C++ (error if missing)
+kct route board.kicad_pcb --backend python  # force pure-Python
+```
+
+#### Fresh worktree gotcha
+
+When using git worktrees (`.loom/worktrees/issue-N/`), each worktree has
+its own `.venv/` and its own `src/kicad_tools/router/router_cpp.*.so`.
+Building in the main checkout does **not** propagate to worktrees. After
+`cd` into a new worktree, always run `uv run kct build-native` once
+before benchmarking routing performance.
+
+---
+
 ### Long-Running Routes (Checkpointing)
 
 Multi-layer boards with hundreds of nets can run for minutes. `kct route`


### PR DESCRIPTION
## Summary

Phase 1 of #3045. The curator's critical finding was that the C++
router extension (`router_cpp.*.so`) is not built in fresh
worktrees and `uv sync` does not run `kct build-native`, so the
router silently falls back to pure-Python — the root cause of the
"30 s per net" symptom in the original board 07 audit.

This PR is **documentation only**. It hard-codes the
`kct build-native` step into the dev setup sequence in three places
so future agents and developers cannot miss it:

- `README.md` (Development -> Quick Start): the canonical setup
  sequence now lists `uv run kct build-native` immediately after
  `uv sync --extra dev`, with `--check` verification and a routing
  performance call-out. New "Fresh worktree checklist" subsection
  covers the worktree-isolation gotcha.
- `CLAUDE.md` (project root): top-level note so any LLM agent
  reading the file before benchmarking the router sees the
  build-native requirement first.
- `docs/guides/routing.md` (Performance section): new "Native C++
  Backend (Build First!)" subsection inserted at the top of
  Performance, including the log lines that distinguish `cpp` vs
  `python` backends so triagers can spot a missing extension from
  a routing log.

## Phase 1 measurements (board 07, fresh worktree, M2 Mac)

| Metric | Pre-build (audit baseline) | Post-build (this PR) | AC target | Status |
|---|---|---|---|---|
| Board 07 wall-clock | killed at 6 min cap | 8:26 (506 s; routing 462 s) | < 4 min | FAIL |
| Nets persisted | 0 | 27/31 (87%) | all 31 | PARTIAL |
| Iteration-0 nets | killed mid-iter | 26/31 in 150 s | -- | OK |
| Convergence | -- | iter 1, 31/31 routed | converged | OK |
| Backend reported | n/a | `cpp v1.0.0 (native, 10-100x faster)` | cpp | OK |
| Boards 00 / 01 / 02 | n/a | 8 s / 26 s / 1:25 | unchanged | OK no regression |
| DRC errors (board 07) | n/a | 3 clearance errs | 0 | FAIL (separate from #3045) |

Per-net A* dropped from ~30 s (audit baseline) to ~1-5 s typical,
but a handful of high-conflict nets (TMDS_D0, MIPI_DAT0, DQ0) still
take 20-40 s and the rip-up phase adds another ~150 s. **Phase 1
alone does not satisfy AC #1 (< 4 min wall-clock).**

## Outcome classification (per curator's plan)

**Outcome B** — C++ build succeeded and the router is dramatically
faster (and now actually finishes board 07 vs being killed), but
the 4-minute wall-clock acceptance criterion is missed. Per the
playbook, Phase 1 docs land here and Phase 2 (region-parallel CLI
flag) is queued as a follow-up.

## Follow-ups filed

- **#3054** (`loom:curated`) — Phase 2: wire `--region-parallel`
  CLI flag and re-benchmark (expected 2-3x speedup from the
  docstring on `route_all_negotiated`).

## Out of scope

- Phase 2 (`--region-parallel` plumbing) — tracked in #3054.
- Phase 3 (heuristic experiment) — only if Phase 2 still misses AC.
- Issue #3051 (iteration-0 persistence) — tracked separately;
  observed working correctly during this run (checkpoint at iter 1
  wrote 27 nets to disk).

## Test plan

- [x] `kct build-native --check` reports "available" on fresh
      worktree after running `kct build-native`
- [x] `kct route` log on board 07 prints
      `Backend: cpp v1.0.0 (native, 10-100x faster)`
- [x] Board 07 generate_design.py completes (8:26 wall-clock,
      previously killed at 6 min)
- [x] No regression on boards 00 / 01 / 02 (all pass with same or
      faster timing)
- [x] Docs render correctly (manual review of markdown)
- [x] Lint clean on changed files (markdown only — ruff skips)
- [ ] Reviewer verifies the README + CLAUDE + routing-guide
      changes are sufficient for future agents to discover the
      `kct build-native` requirement before benchmarking

Phase 1 of #3045

🤖 Generated with [Claude Code](https://claude.com/claude-code)