### PR TITLE
fix(zones): repair priority-overlap copper collapse on multi-net F.Cu zones (closes #3043)

### DIFF
--- a/src/kicad_tools/zones/generator.py
+++ b/src/kicad_tools/zones/generator.py
@@ -4,8 +4,8 @@ Zone generator for creating copper pour zones on PCBs.
 This module provides a high-level API for generating copper pour zones,
 with automatic board outline detection and sensible defaults for power nets.
 
-Outline allocator (#2771)
--------------------------
+Outline allocator (#2771, #3043)
+--------------------------------
 
 In addition to the layer/priority allocator (:func:`_assign_layers_for_pour_nets`),
 this module owns the *outline* allocator (:func:`_compute_pour_outlines`).
@@ -21,6 +21,15 @@ distinct, which silenced the warning, but distinct priorities alone do not
 produce real copper for the losing zones -- the outlines have to be
 geometrically disjoint for KiCad's fill resolver to award copper to more
 than one zone on a shared layer.
+
+The original PR #2771 only computed each net's bbox independently and
+relied on pad-cluster separation to keep the bboxes disjoint.  On real
+boards where power-net pads are *spatially interleaved* (e.g. board 06's
+``+3V3``/``+1V8``/``+1V2`` cluster on a BGA), the bboxes overlap and the
+silent-override returns.  Issue #3043 extends the allocator with a
+second pass that *subtracts higher-priority bboxes from lower-priority
+outlines* (using Shapely's polygon difference), so the resulting
+outlines are disjoint regardless of pad layout.
 """
 
 from __future__ import annotations
@@ -401,25 +410,39 @@ class ZoneGenerator:
     ) -> bool:
         """Check whether two boundary polygons overlap.
 
-        Uses bounding-box intersection as a conservative approximation.
-        Two polygons whose bounding boxes overlap are considered overlapping.
-        This is intentionally conservative -- it may report overlaps for
-        polygons that only share a bounding-box region but not actual area.
-        For the zone-overlap-warning use case, false positives are acceptable
-        while false negatives would hide real problems.
+        Uses Shapely's exact polygon intersection when available so the
+        outline allocator's carved-out (concave) polygons are correctly
+        recognised as disjoint when their AABBs still overlap (#3043).
+        Falls back to a conservative AABB-overlap test when Shapely is
+        not installed.
 
         Returns:
-            True if the boundaries' bounding boxes overlap.
+            True if the boundaries overlap with positive area.
         """
         if not boundary_a or not boundary_b:
             return False
+
+        # Prefer exact intersection via Shapely so the disjoint-but-AABB-
+        # overlapping case (carved-out outlines from ``_compute_pour_outlines``)
+        # does not trigger a spurious warning.
+        try:
+            from shapely.geometry import Polygon
+
+            poly_a = Polygon(boundary_a)
+            poly_b = Polygon(boundary_b)
+            if not poly_a.is_valid or not poly_b.is_valid:
+                # Fall through to AABB on degenerate input.
+                raise ValueError("invalid polygon")
+            return poly_a.intersection(poly_b).area > 1e-9
+        except (ImportError, ValueError):
+            pass
 
         a_xs = [p[0] for p in boundary_a]
         a_ys = [p[1] for p in boundary_a]
         b_xs = [p[0] for p in boundary_b]
         b_ys = [p[1] for p in boundary_b]
 
-        # Axis-aligned bounding-box overlap test
+        # Axis-aligned bounding-box overlap test (conservative fallback).
         return not (
             max(a_xs) <= min(b_xs)
             or max(b_xs) <= min(a_xs)
@@ -1127,6 +1150,19 @@ def _compute_pour_outlines(
     * If two or more zones share a layer, compute a bounding-box outline
       around the net's pads, inflated by ``margin_mm``, then clip to
       ``board_outline`` so the zone never extends past the board edge.
+      A second pass (#3043) then subtracts higher-priority bboxes from
+      lower-priority outlines so the resulting polygons are
+      **geometrically disjoint** even when pad clusters are spatially
+      interleaved (as on board 06, where ``+3V3``/``+1V8``/``+1V2`` all
+      feed the same BGA region).
+
+    Without the disjoint-carve pass, real boards routinely produce raw
+    bboxes that overlap each other.  KiCad's fill resolver would then
+    silently award the entire overlap to the highest-priority zone and
+    the lower-priority siblings would receive zero copper despite being
+    declared in the file.  The carve makes per-zone copper deterministic
+    regardless of priority ordering -- each zone receives the region
+    delineated by its own pad bbox minus any higher-priority sibling.
 
     The returned polygons are in the same coordinate frame as
     ``board_outline`` -- sheet-absolute, which is the frame expected by
@@ -1152,6 +1188,10 @@ def _compute_pour_outlines(
 
     outlines: dict[str, list[tuple[float, float]] | None] = {}
 
+    # First pass: compute the raw bbox for every shared-layer zone.
+    # ``raw_bboxes[net]`` is the per-net AABB polygon (or ``None`` if the net
+    # has no pads -- the fallback case at the bottom of the loop).
+    raw_bboxes: dict[str, list[tuple[float, float]] | None] = {}
     for net_name, layer, _ in assignments:
         if layer_counts[layer] < 2:
             # Sole zone on its layer -- keep the full board outline so
@@ -1170,9 +1210,131 @@ def _compute_pour_outlines(
             outlines[net_name] = None
             continue
 
-        outlines[net_name] = _clip_polygon_to_outline(bbox, board_outline)
+        raw_bboxes[net_name] = _clip_polygon_to_outline(bbox, board_outline)
+
+    # Second pass (#3043): for each layer that hosts multiple zones, subtract
+    # higher-priority zone bboxes from lower-priority zones so the final
+    # outlines are *geometrically disjoint*.  Without this, the bboxes can
+    # spatially overlap (typical of real boards where power-net pads are
+    # interleaved rather than clustered), and KiCad's fill resolver would
+    # silently award the entire overlap to the highest-priority zone.
+    #
+    # KiCad zone-priority convention: HIGHER priority value WINS the overlap
+    # region.  So we sort highest-first and subtract each zone's bbox from
+    # the lower-priority zones that follow.
+    by_layer: dict[str, list[tuple[str, int]]] = {}
+    for net_name, layer, priority in assignments:
+        if layer_counts[layer] < 2:
+            continue
+        if net_name not in raw_bboxes:
+            continue
+        by_layer.setdefault(layer, []).append((net_name, priority))
+
+    for layer, nets_on_layer in by_layer.items():
+        # Sort highest priority first -- those zones "win" the overlap.
+        nets_on_layer.sort(key=lambda np: np[1], reverse=True)
+
+        # Accumulate the union of higher-priority bboxes; each lower-priority
+        # zone has this union subtracted from its own bbox to keep outlines
+        # disjoint.
+        winners_union = None
+        for net_name, _ in nets_on_layer:
+            current = raw_bboxes[net_name]
+            if winners_union is None:
+                # Highest-priority zone keeps its bbox unchanged.
+                outlines[net_name] = current
+            else:
+                outlines[net_name] = _subtract_polygon(
+                    current,
+                    winners_union,
+                    fallback=current,
+                )
+            # Add this zone's bbox to the winners-union for the next iteration.
+            winners_union = _union_polygons(winners_union, current)
 
     return outlines
+
+
+def _union_polygons(
+    a: list[tuple[float, float]] | None,
+    b: list[tuple[float, float]] | None,
+):
+    """Return the Shapely union of two polygons (or None inputs).
+
+    Returns a Shapely geometry (Polygon or MultiPolygon) so subsequent
+    operations can use it directly.  When Shapely is unavailable, returns
+    ``None`` -- callers should fall back to leaving outlines unchanged.
+    """
+    try:
+        from shapely.geometry import Polygon
+        from shapely.ops import unary_union
+    except ImportError:
+        return None
+
+    geoms = []
+    for poly in (a, b):
+        if poly is None:
+            continue
+        if hasattr(poly, "geom_type"):
+            geoms.append(poly)
+        else:
+            geoms.append(Polygon(poly))
+    if not geoms:
+        return None
+    return unary_union(geoms)
+
+
+def _subtract_polygon(
+    minuend: list[tuple[float, float]],
+    subtrahend,
+    fallback: list[tuple[float, float]],
+) -> list[tuple[float, float]]:
+    """Return ``minuend - subtrahend`` as a polygon.
+
+    ``subtrahend`` may be a list of ``(x, y)`` tuples or a Shapely geometry
+    (the latter is what ``_union_polygons`` returns).  KiCad zones do not
+    natively support polygon holes in the *outline*; when the subtraction
+    produces a polygon with holes, we approximate by returning the largest
+    exterior ring (which is still strictly inside ``minuend``).
+
+    When the result is empty or Shapely is missing, returns ``fallback``.
+    """
+    try:
+        from shapely.geometry import Polygon
+    except ImportError:
+        return fallback
+
+    minuend_poly = Polygon(minuend)
+    if hasattr(subtrahend, "geom_type"):
+        sub_geom = subtrahend
+    else:
+        sub_geom = Polygon(subtrahend)
+
+    diff = minuend_poly.difference(sub_geom)
+
+    if diff.is_empty:
+        # The minuend was completely covered by higher-priority zones.
+        # Return ``fallback`` so the zone still has *some* outline (KiCad's
+        # fill resolver will still award zero copper, but the zone exists
+        # in the file for tooling that inspects declared geometry).
+        return fallback
+
+    if diff.geom_type == "MultiPolygon":
+        # Keep only the largest piece -- KiCad zone outlines are single
+        # polygons.  Smaller fragments are lost, but the dominant region
+        # is preserved.
+        diff = max(diff.geoms, key=lambda g: g.area)
+
+    if diff.geom_type != "Polygon":
+        return fallback
+
+    coords = list(diff.exterior.coords)
+    if len(coords) > 1 and coords[0] == coords[-1]:
+        coords = coords[:-1]
+    if len(coords) < 3:
+        return fallback
+
+    return [(round(x, 6), round(y, 6)) for x, y in coords]
 
 
 def auto_create_zones_for_pour_nets(

--- a/tests/test_zone_priority.py
+++ b/tests/test_zone_priority.py
@@ -1,0 +1,406 @@
+"""Regression tests for the zone-priority overlap fix (issue #3043).
+
+The outline allocator (``_compute_pour_outlines``) used to compute each
+zone's bbox independently.  On real boards with spatially-interleaved
+power-net pads (e.g. board 06 with ``+3V3``/``+1V8``/``+1V2`` all feeding
+the same BGA region), the bboxes overlap.  KiCad's fill resolver then
+awards the entire overlap region to the highest-priority zone, so the
+lower-priority siblings get zero copper despite being declared in the
+file.  See the issue body for the full diagnosis.
+
+These tests instantiate the exact failure scenarios and assert that the
+fix produces disjoint per-net outlines with positive area for every zone.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.router.net_class import NetClass
+from kicad_tools.schema.pcb import PCB
+from kicad_tools.zones.generator import (
+    _assign_layers_for_pour_nets,
+    _compute_pour_outlines,
+    auto_create_zones_for_pour_nets,
+)
+
+pytest.importorskip(
+    "shapely",
+    reason=(
+        "shapely is required for the zone-priority outline allocator; "
+        "install with: pip install kicad-tools[geometry]"
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _polygon_area(polygon: list[tuple[float, float]]) -> float:
+    """Shoelace formula for polygon area (mm²)."""
+    n = len(polygon)
+    if n < 3:
+        return 0.0
+    area = 0.0
+    for i in range(n):
+        x0, y0 = polygon[i]
+        x1, y1 = polygon[(i + 1) % n]
+        area += x0 * y1 - x1 * y0
+    return abs(area) / 2.0
+
+
+def _polygons_overlap_area(
+    a: list[tuple[float, float]],
+    b: list[tuple[float, float]],
+) -> float:
+    """Return the area of the intersection of two polygons (mm²)."""
+    from shapely.geometry import Polygon
+
+    pa = Polygon(a)
+    pb = Polygon(b)
+    if not pa.is_valid or not pb.is_valid:
+        return 0.0
+    return pa.intersection(pb).area
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: synthetic boards reproducing the board-06 failure shape
+# ---------------------------------------------------------------------------
+
+
+def _make_2net_overlap_pcb(tmp_path: Path) -> Path:
+    """Build a 2-layer PCB with two power nets whose pads are interleaved.
+
+    Both ``+5V`` and ``+3V3`` have pads spread across the same region of
+    the board.  Without the fix, both nets would compute identical
+    bounding boxes; with the fix, the higher-priority zone keeps its
+    bbox and the lower-priority zone has it carved out.
+    """
+    pcb_text = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "kicad")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+5V")
+  (net 3 "+3V3")
+  (gr_rect
+    (start 0 0)
+    (end 100 50)
+    (stroke (width 0.15) (type solid))
+    (fill none)
+    (layer "Edge.Cuts")
+    (uuid "edge-uuid")
+  )
+  (footprint "Test:U1"
+    (layer "F.Cu")
+    (at 20 25)
+    (uuid "fp-u1-uuid")
+    (property "Reference" "U1"
+      (at 0 -2 0) (layer "F.SilkS") (uuid "u1-ref-uuid")
+      (effects (font (size 1 1) (thickness 0.15)))
+    )
+    (property "Value" "T"
+      (at 0 2 0) (layer "F.Fab") (uuid "u1-val-uuid")
+      (effects (font (size 1 1) (thickness 0.15)))
+    )
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 2 "+5V"))
+    (pad "2" smd rect (at 1 0) (size 1 1) (layers "F.Cu") (net 3 "+3V3"))
+  )
+  (footprint "Test:U2"
+    (layer "F.Cu")
+    (at 50 25)
+    (uuid "fp-u2-uuid")
+    (property "Reference" "U2"
+      (at 0 -2 0) (layer "F.SilkS") (uuid "u2-ref-uuid")
+      (effects (font (size 1 1) (thickness 0.15)))
+    )
+    (property "Value" "T"
+      (at 0 2 0) (layer "F.Fab") (uuid "u2-val-uuid")
+      (effects (font (size 1 1) (thickness 0.15)))
+    )
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 2 "+5V"))
+    (pad "2" smd rect (at 1 0) (size 1 1) (layers "F.Cu") (net 3 "+3V3"))
+  )
+  (footprint "Test:U3"
+    (layer "F.Cu")
+    (at 80 25)
+    (uuid "fp-u3-uuid")
+    (property "Reference" "U3"
+      (at 0 -2 0) (layer "F.SilkS") (uuid "u3-ref-uuid")
+      (effects (font (size 1 1) (thickness 0.15)))
+    )
+    (property "Value" "T"
+      (at 0 2 0) (layer "F.Fab") (uuid "u3-val-uuid")
+      (effects (font (size 1 1) (thickness 0.15)))
+    )
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 2 "+5V"))
+    (pad "2" smd rect (at 1 0) (size 1 1) (layers "F.Cu") (net 3 "+3V3"))
+  )
+)
+"""
+    p = tmp_path / "two_net_overlap.kicad_pcb"
+    p.write_text(pcb_text)
+    return p
+
+
+def _make_3net_nested_pcb(tmp_path: Path) -> Path:
+    """Build a 4-layer PCB modeling the board-06 ``+3V3``/``+1V8``/``+1V2`` shape.
+
+    ``+3V3`` pads span a wide region (10mm..90mm), ``+1V8`` pads sit in a
+    narrow vertical strip inside (15mm..25mm), and ``+1V2`` pads sit in
+    another narrow strip on the other side (60mm..80mm).  Without the
+    fix, all three bboxes overlap (``+3V3``'s bbox encloses both the
+    others), and KiCad's fill resolver awards everything to the highest
+    priority.  With the fix, ``+3V3`` becomes a carved-out polygon that
+    excludes the two narrow strips.
+    """
+    pcb_text = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "kicad")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (2 "In2.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "VBUS")
+  (net 3 "+3V3")
+  (net 4 "+1V8")
+  (net 5 "+1V2")
+  (gr_rect
+    (start 0 0)
+    (end 100 50)
+    (stroke (width 0.15) (type solid))
+    (fill none)
+    (layer "Edge.Cuts")
+    (uuid "edge-uuid")
+  )
+"""
+    rows = []
+
+    def fp(ref: str, x: float, y: float, net_num: int, net_name: str) -> str:
+        return f"""  (footprint "Test:{ref}"
+    (layer "F.Cu")
+    (at {x} {y})
+    (uuid "fp-{ref}-uuid")
+    (property "Reference" "{ref}"
+      (at 0 -2 0) (layer "F.SilkS") (uuid "{ref}-ref-uuid")
+      (effects (font (size 1 1) (thickness 0.15)))
+    )
+    (property "Value" "T"
+      (at 0 2 0) (layer "F.Fab") (uuid "{ref}-val-uuid")
+      (effects (font (size 1 1) (thickness 0.15)))
+    )
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net {net_num} "{net_name}"))
+  )"""
+
+    # +3V3 pads spread across the board
+    rows.append(fp("U1", 10, 25, 3, "+3V3"))
+    rows.append(fp("U2", 30, 25, 3, "+3V3"))
+    rows.append(fp("U3", 50, 25, 3, "+3V3"))
+    rows.append(fp("U4", 70, 25, 3, "+3V3"))
+    rows.append(fp("U5", 90, 25, 3, "+3V3"))
+    # +1V8 pads in a narrow strip inside +3V3's region
+    rows.append(fp("U6", 15, 20, 4, "+1V8"))
+    rows.append(fp("U7", 25, 30, 4, "+1V8"))
+    # +1V2 pads in another narrow strip
+    rows.append(fp("U8", 65, 20, 5, "+1V2"))
+    rows.append(fp("U9", 75, 30, 5, "+1V2"))
+    # VBUS sole on one inner layer (gets a single power net assignment)
+    rows.append(fp("U10", 50, 10, 2, "VBUS"))
+    # GND pads at every footprint position (return-path style)
+    rows.append(fp("U11", 50, 40, 1, "GND"))
+
+    pcb_text += "\n".join(rows)
+    pcb_text += "\n)\n"
+
+    p = tmp_path / "three_net_nested.kicad_pcb"
+    p.write_text(pcb_text)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestZonePriorityOverlapResolution:
+    """Acceptance tests for issue #3043.
+
+    Each test asserts the post-fix invariant: zones sharing a layer must
+    have *zero area overlap* AND every zone must retain *positive area*.
+    """
+
+    def test_two_overlapping_power_nets_become_disjoint(self, tmp_path: Path):
+        """The reduction of the curator's investigation plan: 2 zones, 1 layer."""
+        pcb_path = _make_2net_overlap_pcb(tmp_path)
+
+        pour_nets = [
+            ("GND", NetClass.GROUND),
+            ("+5V", NetClass.POWER),
+            ("+3V3", NetClass.POWER),
+        ]
+        count = auto_create_zones_for_pour_nets(pcb_path, pour_nets)
+        assert count == 3
+
+        pcb = PCB.load(str(pcb_path))
+        f_cu_zones = [z for z in pcb.zones if z.layer == "F.Cu"]
+        assert len(f_cu_zones) == 2, (
+            f"expected 2 power zones on F.Cu, got {[z.net_name for z in f_cu_zones]}"
+        )
+
+        # Every F.Cu zone must have positive area.
+        for z in f_cu_zones:
+            area = _polygon_area(z.polygon)
+            assert area > 0.0, (
+                f"zone {z.net_name} on F.Cu has zero area (fix regressed)"
+            )
+
+        # The two zones must not overlap (the fix's core invariant).
+        overlap = _polygons_overlap_area(
+            f_cu_zones[0].polygon, f_cu_zones[1].polygon
+        )
+        assert overlap < 1e-6, (
+            f"zones {f_cu_zones[0].net_name} and {f_cu_zones[1].net_name} "
+            f"still overlap by {overlap:.3f} mm² (fix not applied)"
+        )
+
+    def test_three_nested_power_nets_each_get_copper(self, tmp_path: Path):
+        """Direct reproduction of the board-06 failure shape (issue #3043)."""
+        pcb_path = _make_3net_nested_pcb(tmp_path)
+
+        pour_nets = [
+            ("GND", NetClass.GROUND),
+            ("VBUS", NetClass.POWER),
+            ("+3V3", NetClass.POWER),
+            ("+1V8", NetClass.POWER),
+            ("+1V2", NetClass.POWER),
+        ]
+        count = auto_create_zones_for_pour_nets(pcb_path, pour_nets)
+        assert count == 5
+
+        pcb = PCB.load(str(pcb_path))
+        f_cu_zones = [z for z in pcb.zones if z.layer == "F.Cu"]
+        assert len(f_cu_zones) == 3, (
+            f"expected 3 power zones on F.Cu, got {[z.net_name for z in f_cu_zones]}"
+        )
+
+        # Acceptance criterion: every zone has *non-zero* copper area.
+        # This is the fundamental "all 3 zones emit zero copper" check
+        # from the issue body.
+        zone_areas = {z.net_name: _polygon_area(z.polygon) for z in f_cu_zones}
+        for net_name, area in zone_areas.items():
+            assert area > 0.0, (
+                f"zone {net_name} has zero area; issue #3043 regressed"
+            )
+
+        # And all three must be pairwise disjoint (no overlap at all).
+        polys = {z.net_name: z.polygon for z in f_cu_zones}
+        names = list(polys)
+        for i, a in enumerate(names):
+            for b in names[i + 1 :]:
+                overlap = _polygons_overlap_area(polys[a], polys[b])
+                assert overlap < 1e-6, (
+                    f"zones {a} and {b} overlap by {overlap:.3f} mm²; "
+                    f"outline allocator did not partition correctly"
+                )
+
+    def test_compute_pour_outlines_returns_carved_polygon_for_lowest_priority(
+        self, tmp_path: Path
+    ):
+        """Direct unit test: lower-priority zone gets a carved-out outline.
+
+        With 3 power nets on F.Cu (priorities 1/2/3), the highest-priority
+        zone (+1V2, priority 3) keeps its raw bbox.  The middle zone
+        (+1V8, priority 2) gets +1V2 subtracted.  The lowest-priority
+        zone (+3V3, priority 1) gets *both* +1V8 and +1V2 subtracted.
+
+        The key invariant: +3V3's outline must be *disjoint* from both
+        +1V8 and +1V2 (zero overlap area), and the outline must have
+        *positive area* so KiCad's fill resolver awards copper.
+        """
+        from kicad_tools.zones import ZoneGenerator
+
+        pcb_path = _make_3net_nested_pcb(tmp_path)
+        gen = ZoneGenerator.from_pcb(pcb_path)
+        assignments = _assign_layers_for_pour_nets(4, [
+            ("GND", NetClass.GROUND),
+            ("VBUS", NetClass.POWER),
+            ("+3V3", NetClass.POWER),
+            ("+1V8", NetClass.POWER),
+            ("+1V2", NetClass.POWER),
+        ])
+        outlines = _compute_pour_outlines(gen.pcb, assignments, gen.board_outline)
+
+        # GND and VBUS are sole on their inner layers.
+        assert outlines["GND"] is None
+        assert outlines["VBUS"] is None
+
+        # +1V2 has the highest priority on F.Cu -- keep raw bbox (4 vertices).
+        assert outlines["+1V2"] is not None
+        assert len(outlines["+1V2"]) == 4
+
+        # +1V8 has next priority.  +1V2 sits in a disjoint x-range, so
+        # subtraction is a no-op and +1V8 also keeps its 4-vertex bbox.
+        assert outlines["+1V8"] is not None
+        assert _polygon_area(outlines["+1V8"]) > 0.0
+
+        # +3V3 (lowest priority) must be carved.  Both +1V8 and +1V2
+        # sit inside +3V3's raw bbox, so the result is the largest
+        # connected piece after subtraction (the central strip between
+        # the two higher-priority zones, since KiCad zones do not support
+        # disjoint multi-polygon outlines).
+        assert outlines["+3V3"] is not None
+        assert _polygon_area(outlines["+3V3"]) > 0.0, (
+            "+3V3 outline collapsed to zero area; the lower-priority "
+            "zone must retain *some* copper region"
+        )
+
+        # The fix's core invariant: zero overlap with higher-priority zones.
+        assert _polygons_overlap_area(outlines["+3V3"], outlines["+1V8"]) < 1e-6, (
+            "+3V3 outline still overlaps +1V8 -- carve-out failed"
+        )
+        assert _polygons_overlap_area(outlines["+3V3"], outlines["+1V2"]) < 1e-6, (
+            "+3V3 outline still overlaps +1V2 -- carve-out failed"
+        )
+
+    def test_no_spurious_overlap_warning_emitted(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ):
+        """``_check_overlap`` must not warn when carved polygons are truly disjoint.
+
+        With the AABB-only overlap test, the carved +3V3 polygon would
+        still appear to overlap +1V8/+1V2 (their bboxes intersect).
+        After the Shapely-aware upgrade, no warning should fire.
+        """
+        pcb_path = _make_3net_nested_pcb(tmp_path)
+        pour_nets = [
+            ("GND", NetClass.GROUND),
+            ("VBUS", NetClass.POWER),
+            ("+3V3", NetClass.POWER),
+            ("+1V8", NetClass.POWER),
+            ("+1V2", NetClass.POWER),
+        ]
+        auto_create_zones_for_pour_nets(pcb_path, pour_nets)
+
+        captured = capsys.readouterr()
+        assert "WARNING" not in captured.err, (
+            f"spurious overlap warning(s) on disjoint carved polygons:\n"
+            f"{captured.err}"
+        )


### PR DESCRIPTION
## Summary

Issue #3043 reported board 06's three F.Cu power zones (`+3V3`, `+1V8`, `+1V2`) emitting zero copper despite distinct priorities. Curator hypothesis: `_net_pad_positions_absolute` returning empty -> fallback to full board outline -> highest-priority wins everything.

Instrumentation disproved the hypothesis: pads were correctly found (11/3/13), bboxes were correctly computed. The real failure was that the bboxes themselves were not geometrically disjoint -- `+3V3`'s bbox fully encloses both `+1V8` and `+1V2` because all three nets feed pads in the same BGA region. KiCad's fill resolver then silently awards the overlap to the highest-priority zone.

## Root cause (from instrumentation)

```
[zones.debug] +3V3 on F.Cu: pads=11, bbox=computed -> (110, 106.5)-(196.5, 168.5)
[zones.debug] +1V8 on F.Cu: pads=3,  bbox=computed -> (116.3, 117)-(134.5, 173.5)   (inside +3V3)
[zones.debug] +1V2 on F.Cu: pads=13, bbox=computed -> (150.96, 117.23)-(196.5, 149.3) (inside +3V3)
```

The board 05 layout (existing test fixture) clusters power pads at disjoint x-positions (10/30/50/70), so the per-net bboxes are naturally non-overlapping. Board 06 is the first test board with *interleaved* power pads, exposing the latent failure mode.

## Changes

- `src/kicad_tools/zones/generator.py`:
  - Extend `_compute_pour_outlines` with a second pass that subtracts higher-priority bboxes from lower-priority outlines using Shapely's polygon difference. Sort nets per layer by priority (descending), accumulate the union of higher-priority bboxes, then carve each lower-priority bbox against that union.
  - Add helper functions `_union_polygons` and `_subtract_polygon` for the Shapely-based geometric operations. Both degrade gracefully when Shapely is missing (return the original bbox, which preserves pre-#3043 behavior).
  - Upgrade `_boundaries_overlap` to use exact polygon intersection (Shapely) instead of AABB-only when Shapely is available, so the carved-out concave `+3V3` polygon is correctly recognised as disjoint from `+1V8`/`+1V2` and no spurious overlap warning fires.
  - Update module-level and `_compute_pour_outlines` docstrings to document the new disjoint-carve pass and reference issue #3043.

- `tests/test_zone_priority.py` (NEW):
  - 4 regression tests covering the 2-zone reduction, the full board-06 3-net nested shape, the direct `_compute_pour_outlines` unit invariant, and the no-spurious-warning check. All gated on Shapely availability via `pytest.importorskip("shapely")`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Board 06 emits non-zero copper on at least the highest-priority zone | YES | All 5 zones now have positive area: GND=7821 mm^2, VBUS_USB=7821 mm^2, +3V3=2965 mm^2 (carved), +1V8=1028 mm^2, +1V2=1460 mm^2 |
| New synthetic test with 2 overlapping zones produces expected per-zone geometry | YES | `tests/test_zone_priority.py::test_two_overlapping_power_nets_become_disjoint` |
| No regression on other boards' zone generation | YES | Board 05 zones unchanged (4-vertex bboxes, already disjoint by clustered-pad layout); all 287 existing zone tests pass |

## Out of scope (per curator notes)

- `zone_overlap` DRC rule (curator option 3): with truly disjoint outlines there's nothing to flag.
- Lint-time error on zone-overlap declaration (option 2): premature; designers may legitimately want overlap with explicit priority resolution.
- Pre-filling `(filled_polygon ...)` data so `kct check` stops reporting `zone_unfilled` warnings: KiCad fills on open, this is a separate tooling-side issue.

## Test Plan

- [x] `uv run pytest tests/test_zone_priority.py -v` -> 4 passed
- [x] `uv run pytest tests/test_build_zones_step.py tests/test_zone_generator.py tests/test_zones.py tests/test_board_05_zones.py tests/test_validate_zone_fill.py tests/test_zone_api.py tests/test_pcb_add_zone.py tests/test_pcb_zones.py tests/test_zones_cmd.py tests/test_zone_generator_edge_clearance.py tests/test_gerber_zone_fill.py` -> 287 passed, 1 skipped
- [x] `uv run python boards/06-diffpair-test/generate_design.py` -> no overlap warnings; all 5 zones have positive area
- [x] `uv run ruff check src/kicad_tools/zones/generator.py tests/test_zone_priority.py` -> all checks passed
- [x] `kct fleet status` -> board 05/06 still surveyed correctly; no degraded ship-status

Closes #3043