### PR TITLE
feat(check): add connectivity DRC rule for unrouted multi-pad nets (closes #3041)

### DIFF
--- a/src/kicad_tools/audit/auditor.py
+++ b/src/kicad_tools/audit/auditor.py
@@ -745,21 +745,41 @@ class ManufacturingAudit:
 
             results = checker.check_all()
 
-            status.error_count = results.error_count
-            status.warning_count = results.warning_count
-            status.blocking_count = results.error_count  # Errors block manufacturing
-            status.passed = results.error_count == 0
+            # The standalone ``connectivity`` rule (Issue #3041) reports
+            # unrouted multi-pad nets at error severity for ``kct check``.
+            # The audit framework, however, has its own
+            # :meth:`_check_connectivity` step that classifies the same
+            # gaps as advisory (WARNING) vs. blocking (NOT_READY) based
+            # on zone presence -- a board with zones may resolve the
+            # nominal gap via zone fill on KiCad re-open.  To avoid
+            # double-counting the same defect (once as blocking DRC,
+            # once as advisory-or-blocking connectivity) AND to preserve
+            # the existing audit verdict semantics, we strip
+            # ``connectivity`` rule_id violations from the audit's DRC
+            # error/blocking tally.  The connectivity status field still
+            # drives the verdict per its own zone-advisory rules.
+            other_violations = [v for v in results.violations if v.rule_id != "connectivity"]
+            other_errors = sum(1 for v in other_violations if v.is_error)
+            other_warnings = sum(1 for v in other_violations if v.is_warning)
 
-            # Build per-type violation breakdown (all severities)
+            status.error_count = other_errors
+            status.warning_count = other_warnings
+            status.blocking_count = other_errors  # Errors block manufacturing
+            status.passed = other_errors == 0
+
+            # Build per-type violation breakdown (all severities).  We
+            # include the connectivity rule_id in the breakdown so
+            # consumers can still introspect that the rule ran -- it
+            # just does not count toward the blocking verdict.
             by_rule: dict[str, int] = {}
             for v in results.violations:
                 by_rule[v.rule_id] = by_rule.get(v.rule_id, 0) + 1
             status.violations_by_type = by_rule
 
-            if results.error_count > 0:
+            if other_errors > 0:
                 # Get summary of errors for the details string
                 error_rules: dict[str, int] = {}
-                for v in results.violations:
+                for v in other_violations:
                     if v.is_error:
                         error_rules[v.rule_id] = error_rules.get(v.rule_id, 0) + 1
                 top_rules = sorted(error_rules.items(), key=lambda x: -x[1])[:3]

--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -59,6 +59,7 @@ def _find_pcb_file(directory: Path) -> Path | None:
 
 CHECK_CATEGORIES = [
     "clearance",
+    "connectivity",
     "diffpair_clearance_intra",
     "diffpair_length_skew",
     "diffpair_routing_continuity",
@@ -317,6 +318,7 @@ def run_selected_checks(
     # Issue #3046.
     check_methods = {
         "clearance": checker.check_clearances,
+        "connectivity": checker.check_connectivity,
         "diffpair_clearance_intra": checker.check_diffpair_clearance_intra,
         "diffpair_length_skew": checker.check_diffpair_length_skew,
         "diffpair_routing_continuity": checker.check_diffpair_routing_continuity,

--- a/src/kicad_tools/drc/violation.py
+++ b/src/kicad_tools/drc/violation.py
@@ -100,6 +100,8 @@ def _init_type_category_map() -> None:
             ViolationType.SHORTING_ITEMS: ViolationCategory.CONNECTIVITY,
             ViolationType.NET_UNDECLARED: ViolationCategory.CONNECTIVITY,
             ViolationType.SINGLE_PAD_NET: ViolationCategory.CONNECTIVITY,
+            # Multi-pad net unrouted/incomplete (Issue #3041).
+            ViolationType.CONNECTIVITY: ViolationCategory.CONNECTIVITY,
             # Cosmetic: visual only
             ViolationType.SILK_OVER_COPPER: ViolationCategory.COSMETIC,
             ViolationType.SILK_OVERLAP: ViolationCategory.COSMETIC,
@@ -220,6 +222,13 @@ class ViolationType(Enum):
     # Netlist integrity
     NET_UNDECLARED = "net_undeclared"
     SINGLE_PAD_NET = "single_pad_net"
+    # Multi-pad net not fully routed by traces/vias/zones (Issue #3041).
+    # Distinct from UNCONNECTED_ITEMS (KiCad-cli ratsnest residual) and
+    # from SINGLE_PAD_NET (structural one-pad declarations).  This rule
+    # fires when a multi-pad net's pads form more than one connected
+    # component in the routed copper, OR when no pads are connected at
+    # all.  Severity: error.
+    CONNECTIVITY = "connectivity"
 
     # Misc
     FOOTPRINT = "footprint"
@@ -334,6 +343,13 @@ class ViolationType(Enum):
             # netlist integrity rule from validate netlist checker
             "net_undeclared": cls.NET_UNDECLARED,
             "single_pad_net": cls.SINGLE_PAD_NET,
+            # Connectivity rule from validate connectivity checker
+            # (Issue #3041).  MUST be aliased explicitly: the fuzzy
+            # fallback at the bottom of from_string() does not have a
+            # branch for "connectivity" and would drop through to
+            # UNKNOWN, silently corrupting the violation ``type`` field
+            # for downstream consumers that filter by exact type value.
+            "connectivity": cls.CONNECTIVITY,
             # zone fill rules from validate zone_fill checker
             "zone_unfilled": cls.ZONE_UNFILLED,
             "zone_fill_disabled": cls.ZONE_FILL_DISABLED,

--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from kicad_tools.manufacturers import DesignRules, get_profile
 
 from .rules.clearance import ClearanceRule
+from .rules.connectivity import ConnectivityRule
 from .rules.diffpair_clearance_intra import DiffPairClearanceIntraRule
 from .rules.diffpair_length_skew import DiffPairLengthSkewRule
 from .rules.diffpair_routing_continuity import DiffPairRoutingContinuityRule
@@ -111,6 +112,7 @@ class DRCChecker:
     # ``tests/test_check_cmd_coverage.py`` enforces the second half.
     CHECK_ALL_METHODS: tuple[str, ...] = (
         "check_clearances",
+        "check_connectivity",
         "check_diffpair_clearance_intra",
         "check_diffpair_length_skew",
         "check_diffpair_routing_continuity",
@@ -171,6 +173,28 @@ class DRCChecker:
             DRCResults containing clearance violations
         """
         rule = ClearanceRule()
+        return rule.check(self.pcb, self.design_rules)
+
+    def check_connectivity(self) -> DRCResults:
+        """Check that every multi-pad net is fully connected.
+
+        Loads the netlist via
+        :class:`~kicad_tools.analysis.net_status.NetStatusAnalyzer` and
+        emits one error per net whose pads are not all connected through
+        traces, vias, or filled copper zones.  Single-pad nets are out
+        of scope (handled by :meth:`check_single_pad_nets`).
+
+        See Issue #3041: previously ``kct check`` reported ``DRC PASS``
+        on PCBs with unrouted nets because no rule cross-referenced the
+        netlist against actual copper connectivity.  This rule closes
+        that gap so partial-route boards fail DRC with a clear, per-net
+        diagnostic.
+
+        Returns:
+            DRCResults containing one error per incomplete or unrouted
+            multi-pad net (severity error).
+        """
+        rule = ConnectivityRule()
         return rule.check(self.pcb, self.design_rules)
 
     def check_diffpair_clearance_intra(self) -> DRCResults:

--- a/src/kicad_tools/validate/rules/connectivity.py
+++ b/src/kicad_tools/validate/rules/connectivity.py
@@ -1,0 +1,156 @@
+"""Connectivity DRC rule.
+
+Detects multi-pad nets that are not fully routed on the PCB.  A net
+that has two or more pads but does not connect them all with copper
+(traces, vias, or filled zones) is structurally unmanufacturable -- the
+finished board would have one or more pads literally disconnected from
+the rest of their net.
+
+This rule fills the gap noted in Issue #3041: previously, ``kct check``
+on a partially-routed PCB reported ``DRC PASS`` because no active rule
+cross-referenced the netlist against actual copper connectivity.  Board
+00 (simple-led) and board 01 (voltage-divider) both routed only 1/2
+nets but still passed DRC, misleading agents into believing the boards
+were manufacturable.
+
+Pour-net suppression
+--------------------
+
+Power and ground pour nets (``GND``, ``+3V3``, ``VCC``, etc.) are
+intentionally satisfied by copper zones rather than traces.  A multi-
+pad pour net with copper zones covering its pads is fully connected
+even without any trace segments.  This rule defers to
+:class:`NetStatusAnalyzer`, which already handles pour-zone connectivity
+correctly: pads inside filled-polygon coverage of a same-net zone are
+treated as connected, regardless of whether traces touch them.
+
+A pour-named net **without** copper zones is still reported -- the net
+is routable as traces, the missing zone is itself the bug, and a
+multi-pad pour-named net with no copper at all is structurally just as
+disconnected as any signal net.  Use ``--skip connectivity`` to suppress
+the rule entirely (e.g., for in-progress partial-route demos).
+
+Severity
+--------
+
+Errors (severity ``error``).  An unrouted pad is not manufacturable;
+agents need a hard signal that the build is incomplete.  The existing
+``--skip connectivity`` flag is the escape hatch for intentional
+partial-route fixtures.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..violations import DRCResults, DRCViolation
+from .base import DRCRule
+
+if TYPE_CHECKING:
+    from kicad_tools.manufacturers import DesignRules
+    from kicad_tools.schema.pcb import PCB
+
+
+class ConnectivityRule(DRCRule):
+    """Flag multi-pad nets that are not fully routed.
+
+    Loads the netlist via
+    :class:`~kicad_tools.analysis.net_status.NetStatusAnalyzer` and
+    emits one error per net whose ``status`` is ``"incomplete"`` or
+    ``"unrouted"``.  Single-pad nets are silently allowed (they are
+    handled by :class:`~kicad_tools.validate.rules.single_pad_net.SinglePadNetRule`,
+    which categorizes them as NC / connector-NC / defect with the
+    appropriate severity).
+
+    The rule consumes the same connectivity model used by ``kct fleet
+    status``'s :func:`_compute_routing`, so fleet status and ``kct
+    check`` agree on which nets count as "complete".
+    """
+
+    rule_id = "connectivity"
+    name = "Net Connectivity"
+    description = "Detects multi-pad nets that are not fully connected by traces, vias, or zones"
+
+    def check(
+        self,
+        pcb: PCB,
+        design_rules: DesignRules,
+    ) -> DRCResults:
+        """Check the PCB for unrouted multi-pad nets.
+
+        Args:
+            pcb: The PCB to check.
+            design_rules: Design rules (unused by this rule but required
+                by the base-class interface).
+
+        Returns:
+            DRCResults containing one error per incomplete / unrouted
+            multi-pad net.
+        """
+        from kicad_tools.analysis.net_status import NetStatusAnalyzer
+
+        results = DRCResults()
+        results.rules_checked = 1
+        results.rules_checked_by_rule[self.rule_id] = 1
+
+        analyzer = NetStatusAnalyzer(pcb)
+        analysis = analyzer.analyze()
+
+        for net_status in analysis.nets:
+            # Single-pad nets are handled by SinglePadNetRule; skip
+            # them here so the two rules stay orthogonal.  Zero-pad
+            # nets (declared headers with no pad assignments) are
+            # likewise out of scope -- the NetlistRule covers netlist
+            # integrity issues on the header side.
+            if net_status.total_pads < 2:
+                continue
+
+            if net_status.status == "complete":
+                continue
+
+            # Choose a representative location: the first unconnected
+            # pad (sorted alphabetically by REF.PAD inside
+            # NetStatusAnalyzer) gives a stable, reproducible coordinate
+            # for downstream consumers (CI diffs, fix-suggestion tools).
+            if net_status.unconnected_pads:
+                pad = net_status.unconnected_pads[0]
+                location: tuple[float, float] | None = pad.position
+                items: tuple[str, ...] = (pad.full_name,)
+            else:
+                # Degenerate case: status != "complete" but no pads in
+                # unconnected_pads.  This happens for total_pads == 0
+                # (caught above) or an unrouted net where the entire
+                # ``connected_pads`` partition is empty (all pads land
+                # in ``unconnected_pads``).  Defensive fallback to
+                # any-pad coordinates.
+                location = None
+                items = ()
+
+            if net_status.status == "unrouted":
+                message = (
+                    f"Net '{net_status.net_name}' is unrouted: "
+                    f"{net_status.total_pads} pads with no connecting copper "
+                    f"(0/{net_status.total_pads} connected)"
+                )
+            else:
+                # "incomplete": at least one pad on the main island,
+                # but at least one stranded.
+                message = (
+                    f"Net '{net_status.net_name}' is partially routed: "
+                    f"{net_status.unconnected_count} of {net_status.total_pads} "
+                    f"pads stranded (connected island has "
+                    f"{net_status.connected_count} pads)"
+                )
+
+            results.add(
+                DRCViolation(
+                    rule_id=self.rule_id,
+                    severity="error",
+                    message=message,
+                    location=location,
+                    items=items,
+                    nets=(net_status.net_name,),
+                )
+            )
+
+        return results

--- a/tests/test_connectivity_rule.py
+++ b/tests/test_connectivity_rule.py
@@ -1,0 +1,522 @@
+"""Unit + CLI tests for :class:`ConnectivityRule` (Issue #3041).
+
+The rule fires when a multi-pad net is not fully routed -- the original
+gap was that ``kct check`` reported ``DRC PASS`` on partial-route PCBs
+because no rule cross-referenced the netlist against actual copper
+connectivity.
+
+Test strategy
+-------------
+
+We exercise the rule against synthetic on-disk PCB fixtures because:
+
+* ``NetStatusAnalyzer`` consumes the loaded ``PCB`` object directly,
+  so an in-memory ``PCB.create()`` would work for the unit cases.  We
+  prefer on-disk fixtures here so each scenario doubles as an
+  end-to-end CLI smoke test (the ``kct check`` dispatcher path).
+* The fixtures are minimal-but-real KiCad S-expression sources.  They
+  declare nets, footprints with pads referencing those nets, and
+  (where relevant) segments / zones to control the connectivity
+  outcome.  This is the same approach used by
+  ``tests/test_cli_check_single_pad_net.py``.
+
+Scenarios
+---------
+
+1. **2-pad net with no segments -> 1 error.**  The simplest possible
+   case: a signal net that connects exactly two pads, with no copper
+   between them.  Must produce a single ``connectivity`` error.
+2. **3-pad net with 1 of 3 pads connected -> 1 error.**  A multi-pad
+   net where one segment connects two of three pads, leaving one
+   stranded.  Must produce a single ``incomplete``-flavored error.
+3. **GND pour-net WITH copper zone covering pads -> 0 errors.**
+   Validates that pour-net suppression works: ``NetStatusAnalyzer``
+   recognises pads inside a same-net filled polygon as connected, so
+   the connectivity rule sees ``status == "complete"`` and skips.
+4. **GND pour-named net WITHOUT zone -> 1 error.**  A net named ``GND``
+   but with no copper zone and no traces is still structurally
+   disconnected.  The rule does NOT special-case pour names; the
+   zone-based suppression is connectivity-driven, not name-driven.
+5. **Fully-routed 2-pad net -> 0 errors.**  Sanity check that the rule
+   does NOT fire on a happy-path board.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+# Minimal PCB skeleton.  Footprints / nets / segments / zones are
+# injected by the per-test builders below.  The layer block must match
+# what NetStatusAnalyzer expects (``F.Cu`` / ``B.Cu`` plus mask/silk).
+_PCB_HEADER = """(kicad_pcb (version 20240108) (generator "test_fixture")
+  (general (thickness 1.6))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (32 "B.Adhes" user "B.Adhesive")
+    (33 "F.Adhes" user "F.Adhesive")
+    (34 "B.Paste" user)
+    (35 "F.Paste" user)
+    (36 "B.SilkS" user "B.Silkscreen")
+    (37 "F.SilkS" user "F.Silkscreen")
+    (38 "B.Mask" user)
+    (39 "F.Mask" user)
+    (40 "Dwgs.User" user "User.Drawings")
+    (41 "Cmts.User" user "User.Comments")
+    (42 "Eco1.User" user "User.Eco1")
+    (43 "Eco2.User" user "User.Eco2")
+    (44 "Edge.Cuts" user)
+    (45 "Margin" user)
+    (46 "B.CrtYd" user "B.Courtyard")
+    (47 "F.CrtYd" user "F.Courtyard")
+    (48 "B.Fab" user)
+    (49 "F.Fab" user)
+  )
+  (setup
+    (pad_to_mask_clearance 0)
+  )
+"""
+
+
+def _two_pad_unrouted_pcb(net_name: str = "VIN") -> str:
+    """Two pads on the same named net, no segments between them.
+
+    Models a board where the schematic asserts a two-pad signal net
+    (e.g. ``VIN``) but the router never connected the pads.  This is
+    the simplest scenario the connectivity rule must catch.
+    """
+    return (
+        _PCB_HEADER
+        + f"""
+  (net 0 "")
+  (net 1 "{net_name}")
+  (footprint "Resistor_SMD:R_0805" (layer "F.Cu")
+    (at 100 100)
+    (property "Reference" "R1" (at 0 -2 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000001"))
+    (property "Value" "10k" (at 0 2 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000002"))
+    (pad "1" smd rect (at -1 0) (size 1 1) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "{net_name}") (uuid "00000000-0000-0000-0000-000000000003"))
+  )
+  (footprint "Resistor_SMD:R_0805" (layer "F.Cu")
+    (at 110 100)
+    (property "Reference" "R2" (at 0 -2 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000004"))
+    (property "Value" "10k" (at 0 2 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000005"))
+    (pad "1" smd rect (at -1 0) (size 1 1) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "{net_name}") (uuid "00000000-0000-0000-0000-000000000006"))
+  )
+)
+"""
+    )
+
+
+def _three_pad_partial_pcb() -> str:
+    """Three pads on net ``SIG``, with a single segment connecting two of them.
+
+    Pads land at world coordinates (99, 100), (109, 100), (119, 100).
+    A trace runs from (99, 100) -> (109, 100), so R1.1 and R2.1 are on
+    the routed island, R3.1 is stranded.  The rule must report one
+    ``incomplete`` error.
+    """
+    return (
+        _PCB_HEADER
+        + """
+  (net 0 "")
+  (net 1 "SIG")
+  (footprint "Resistor_SMD:R_0805" (layer "F.Cu")
+    (at 100 100)
+    (property "Reference" "R1" (at 0 -2 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000001"))
+    (property "Value" "10k" (at 0 2 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000002"))
+    (pad "1" smd rect (at -1 0) (size 1 1) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "SIG") (uuid "00000000-0000-0000-0000-000000000003"))
+  )
+  (footprint "Resistor_SMD:R_0805" (layer "F.Cu")
+    (at 110 100)
+    (property "Reference" "R2" (at 0 -2 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000004"))
+    (property "Value" "10k" (at 0 2 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000005"))
+    (pad "1" smd rect (at -1 0) (size 1 1) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "SIG") (uuid "00000000-0000-0000-0000-000000000006"))
+  )
+  (footprint "Resistor_SMD:R_0805" (layer "F.Cu")
+    (at 120 100)
+    (property "Reference" "R3" (at 0 -2 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000007"))
+    (property "Value" "10k" (at 0 2 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000008"))
+    (pad "1" smd rect (at -1 0) (size 1 1) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "SIG") (uuid "00000000-0000-0000-0000-000000000009"))
+  )
+  (segment (start 99 100) (end 109 100) (width 0.25) (layer "F.Cu") (net 1) (uuid "00000000-0000-0000-0000-00000000000a"))
+)
+"""
+    )
+
+
+def _three_pad_pour_with_zone_pcb() -> str:
+    """Three GND pads with a filled F.Cu zone covering them.
+
+    A multi-pad ``GND`` net with a copper zone that has filled polygons
+    covering every pad position is fully connected (each pad is inside
+    the same-net filled polygon).  The rule must NOT fire.
+
+    The zone's filled polygon is a large rectangle that covers all
+    three pad positions (98..121, 99..101).
+    """
+    return (
+        _PCB_HEADER
+        + """
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "Resistor_SMD:R_0805" (layer "F.Cu")
+    (at 100 100)
+    (property "Reference" "R1" (at 0 -2 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000001"))
+    (property "Value" "10k" (at 0 2 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000002"))
+    (pad "1" smd rect (at -1 0) (size 1 1) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "GND") (uuid "00000000-0000-0000-0000-000000000003"))
+  )
+  (footprint "Resistor_SMD:R_0805" (layer "F.Cu")
+    (at 110 100)
+    (property "Reference" "R2" (at 0 -2 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000004"))
+    (property "Value" "10k" (at 0 2 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000005"))
+    (pad "1" smd rect (at -1 0) (size 1 1) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "GND") (uuid "00000000-0000-0000-0000-000000000006"))
+  )
+  (footprint "Resistor_SMD:R_0805" (layer "F.Cu")
+    (at 120 100)
+    (property "Reference" "R3" (at 0 -2 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000007"))
+    (property "Value" "10k" (at 0 2 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000008"))
+    (pad "1" smd rect (at -1 0) (size 1 1) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "GND") (uuid "00000000-0000-0000-0000-000000000009"))
+  )
+  (zone (net 1) (net_name "GND") (layer "F.Cu") (uuid "00000000-0000-0000-0000-00000000000a") (hatch edge 0.5)
+    (connect_pads (clearance 0.2))
+    (min_thickness 0.25)
+    (filled_areas_thickness no)
+    (polygon (pts (xy 95 95) (xy 125 95) (xy 125 105) (xy 95 105)))
+    (filled_polygon
+      (layer "F.Cu")
+      (pts (xy 95 95) (xy 125 95) (xy 125 105) (xy 95 105))
+    )
+  )
+)
+"""
+    )
+
+
+def _three_pad_pour_no_zone_pcb() -> str:
+    """Three GND pads, no copper zone, no traces -- still an error.
+
+    A net named ``GND`` is conventionally a pour net, but the rule
+    does NOT special-case names.  Without an actual copper zone (or
+    traces) connecting the pads, the net is structurally disconnected
+    and must be flagged.
+    """
+    return (
+        _PCB_HEADER
+        + """
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "Resistor_SMD:R_0805" (layer "F.Cu")
+    (at 100 100)
+    (property "Reference" "R1" (at 0 -2 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000001"))
+    (property "Value" "10k" (at 0 2 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000002"))
+    (pad "1" smd rect (at -1 0) (size 1 1) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "GND") (uuid "00000000-0000-0000-0000-000000000003"))
+  )
+  (footprint "Resistor_SMD:R_0805" (layer "F.Cu")
+    (at 110 100)
+    (property "Reference" "R2" (at 0 -2 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000004"))
+    (property "Value" "10k" (at 0 2 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000005"))
+    (pad "1" smd rect (at -1 0) (size 1 1) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "GND") (uuid "00000000-0000-0000-0000-000000000006"))
+  )
+  (footprint "Resistor_SMD:R_0805" (layer "F.Cu")
+    (at 120 100)
+    (property "Reference" "R3" (at 0 -2 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000007"))
+    (property "Value" "10k" (at 0 2 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000008"))
+    (pad "1" smd rect (at -1 0) (size 1 1) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "GND") (uuid "00000000-0000-0000-0000-000000000009"))
+  )
+)
+"""
+    )
+
+
+def _two_pad_routed_pcb() -> str:
+    """Two pads on net ``SIG`` connected by a trace -- no error expected."""
+    return (
+        _PCB_HEADER
+        + """
+  (net 0 "")
+  (net 1 "SIG")
+  (footprint "Resistor_SMD:R_0805" (layer "F.Cu")
+    (at 100 100)
+    (property "Reference" "R1" (at 0 -2 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000001"))
+    (property "Value" "10k" (at 0 2 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000002"))
+    (pad "1" smd rect (at -1 0) (size 1 1) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "SIG") (uuid "00000000-0000-0000-0000-000000000003"))
+  )
+  (footprint "Resistor_SMD:R_0805" (layer "F.Cu")
+    (at 110 100)
+    (property "Reference" "R2" (at 0 -2 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000004"))
+    (property "Value" "10k" (at 0 2 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000005"))
+    (pad "1" smd rect (at -1 0) (size 1 1) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "SIG") (uuid "00000000-0000-0000-0000-000000000006"))
+  )
+  (segment (start 99 100) (end 109 100) (width 0.25) (layer "F.Cu") (net 1) (uuid "00000000-0000-0000-0000-000000000007"))
+)
+"""
+    )
+
+
+def _run_check_only_connectivity(pcb_path: Path) -> tuple[int, str]:
+    """Drive ``kct check --only connectivity`` end-to-end and return (rc, stdout)."""
+    from kicad_tools.cli.check_cmd import main
+
+    rc = main([str(pcb_path), "--only", "connectivity"])
+    return rc, ""  # capsys handled by individual tests
+
+
+class TestConnectivityRuleUnit:
+    """Direct invocation of :class:`ConnectivityRule.check`."""
+
+    def test_two_pad_unrouted_fires_one_error(self, tmp_path: Path) -> None:
+        from kicad_tools.manufacturers import get_profile
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate.rules.connectivity import ConnectivityRule
+
+        pcb_path = tmp_path / "two_pad_unrouted.kicad_pcb"
+        pcb_path.write_text(_two_pad_unrouted_pcb())
+        pcb = PCB.load(pcb_path)
+        rules = get_profile("jlcpcb").get_design_rules(2, 1.0)
+
+        results = ConnectivityRule().check(pcb, rules)
+
+        assert results.error_count == 1
+        v = results.errors[0]
+        assert v.rule_id == "connectivity"
+        assert v.severity == "error"
+        assert "VIN" in v.message
+        assert v.nets == ("VIN",)
+
+    def test_three_pad_partial_fires_one_error(self, tmp_path: Path) -> None:
+        from kicad_tools.manufacturers import get_profile
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate.rules.connectivity import ConnectivityRule
+
+        pcb_path = tmp_path / "three_pad_partial.kicad_pcb"
+        pcb_path.write_text(_three_pad_partial_pcb())
+        pcb = PCB.load(pcb_path)
+        rules = get_profile("jlcpcb").get_design_rules(2, 1.0)
+
+        results = ConnectivityRule().check(pcb, rules)
+
+        assert results.error_count == 1
+        v = results.errors[0]
+        assert v.nets == ("SIG",)
+        # "incomplete" wording, not "unrouted"
+        assert "partially routed" in v.message
+        assert "1 of 3" in v.message  # 1 stranded of 3 total
+
+    def test_pour_net_with_zone_no_error(self, tmp_path: Path) -> None:
+        from kicad_tools.manufacturers import get_profile
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate.rules.connectivity import ConnectivityRule
+
+        pcb_path = tmp_path / "pour_with_zone.kicad_pcb"
+        pcb_path.write_text(_three_pad_pour_with_zone_pcb())
+        pcb = PCB.load(pcb_path)
+        rules = get_profile("jlcpcb").get_design_rules(2, 1.0)
+
+        results = ConnectivityRule().check(pcb, rules)
+
+        # All three GND pads are inside the same-net filled polygon, so
+        # NetStatusAnalyzer reports status="complete" and the rule
+        # produces zero violations.
+        assert results.error_count == 0
+
+    def test_pour_named_net_without_zone_fires(self, tmp_path: Path) -> None:
+        """A GND-named net with no copper anywhere is still an error.
+
+        The rule does NOT name-suppress -- the zone-based escape hatch
+        is connectivity-driven (``NetStatusAnalyzer.status == "complete"``
+        because filled polygons cover the pads), not name-driven.  A
+        ``GND`` net without zones AND without traces is structurally
+        just as disconnected as a signal net.
+        """
+        from kicad_tools.manufacturers import get_profile
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate.rules.connectivity import ConnectivityRule
+
+        pcb_path = tmp_path / "pour_no_zone.kicad_pcb"
+        pcb_path.write_text(_three_pad_pour_no_zone_pcb())
+        pcb = PCB.load(pcb_path)
+        rules = get_profile("jlcpcb").get_design_rules(2, 1.0)
+
+        results = ConnectivityRule().check(pcb, rules)
+
+        assert results.error_count == 1
+        v = results.errors[0]
+        assert v.nets == ("GND",)
+
+    def test_fully_routed_no_error(self, tmp_path: Path) -> None:
+        from kicad_tools.manufacturers import get_profile
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate.rules.connectivity import ConnectivityRule
+
+        pcb_path = tmp_path / "two_pad_routed.kicad_pcb"
+        pcb_path.write_text(_two_pad_routed_pcb())
+        pcb = PCB.load(pcb_path)
+        rules = get_profile("jlcpcb").get_design_rules(2, 1.0)
+
+        results = ConnectivityRule().check(pcb, rules)
+
+        assert results.error_count == 0
+
+    def test_rules_checked_counter(self, tmp_path: Path) -> None:
+        """The per-rule counter must increment exactly once per check."""
+        from kicad_tools.manufacturers import get_profile
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate.rules.connectivity import ConnectivityRule
+
+        pcb_path = tmp_path / "fully_routed.kicad_pcb"
+        pcb_path.write_text(_two_pad_routed_pcb())
+        pcb = PCB.load(pcb_path)
+        rules = get_profile("jlcpcb").get_design_rules(2, 1.0)
+
+        results = ConnectivityRule().check(pcb, rules)
+        assert results.rules_checked == 1
+        assert results.rules_checked_by_rule.get("connectivity") == 1
+
+
+class TestConnectivityRuleCli:
+    """End-to-end CLI tests via :func:`check_cmd.main`."""
+
+    def test_only_connectivity_reports_errors(self, capsys, tmp_path: Path) -> None:
+        from kicad_tools.cli.check_cmd import main
+
+        pcb_path = tmp_path / "two_pad_unrouted.kicad_pcb"
+        pcb_path.write_text(_two_pad_unrouted_pcb())
+
+        rc = main([str(pcb_path), "--only", "connectivity"])
+        assert rc == 2  # Errors found.
+
+        captured = capsys.readouterr()
+        assert "connectivity" in captured.out
+        # The unrouted VIN net must surface by name.
+        assert "VIN" in captured.out
+
+    def test_skip_connectivity_excludes_rule(self, capsys, tmp_path: Path) -> None:
+        """``--skip connectivity`` is the documented escape hatch."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb_path = tmp_path / "two_pad_unrouted.kicad_pcb"
+        pcb_path.write_text(_two_pad_unrouted_pcb())
+
+        main([str(pcb_path), "--skip", "connectivity"])
+
+        captured = capsys.readouterr()
+        # The connectivity rule_id must NOT appear in the BY RULE block.
+        # We assert on the rule_id token rather than the literal word
+        # because the section header uses different framing.
+        assert "[X] connectivity" not in captured.out
+
+    def test_json_output_resolves_type(self, capsys, tmp_path: Path) -> None:
+        """JSON output round-trips rule_id -> type without 'unknown'."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb_path = tmp_path / "two_pad_unrouted.kicad_pcb"
+        pcb_path.write_text(_two_pad_unrouted_pcb())
+
+        rc = main(
+            [
+                str(pcb_path),
+                "--only",
+                "connectivity",
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == 2
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["summary"]["errors"] >= 1
+        assert data["summary"]["passed"] is False
+
+        violations = data["violations"]
+        assert len(violations) >= 1
+        for v in violations:
+            assert v["rule_id"] == "connectivity"
+            # Critical: must NOT resolve to 'unknown' -- verifies the
+            # ViolationType enum + alias entry are wired correctly
+            # (#3041 mirrors the #2521 precedent).
+            assert v["type"] == "connectivity"
+            assert v["severity"] == "error"
+
+    def test_check_all_includes_connectivity(self, capsys, tmp_path: Path) -> None:
+        """Running ``kct check`` (no --only) catches connectivity errors.
+
+        This is the headline regression for #3041: a board with
+        unrouted nets must NOT report ``DRC PASS`` from the default
+        ``kct check`` invocation.
+        """
+        from kicad_tools.cli.check_cmd import main
+
+        pcb_path = tmp_path / "two_pad_unrouted.kicad_pcb"
+        pcb_path.write_text(_two_pad_unrouted_pcb())
+
+        rc = main([str(pcb_path)])
+        # Exit 2 = errors found.  The "DRC PASS" misleading message
+        # from before #3041 would have produced exit 0 here.
+        assert rc == 2
+
+        captured = capsys.readouterr()
+        assert "DRC PASSED" not in captured.out
+        assert "connectivity" in captured.out
+
+
+class TestConnectivityRuleBoard01:
+    """Integration test against the committed board 01 routed PCB.
+
+    Board 01 (voltage-divider) is the headline #3041 example: it routes
+    only 1 of 2 nets but ``kct check`` previously reported PASS.  After
+    this rule lands, board 01 must produce at least one connectivity
+    error.
+    """
+
+    def test_board_01_routed_pcb_has_connectivity_errors(self, capsys) -> None:
+        from kicad_tools.cli.check_cmd import main
+
+        board_pcb = (
+            Path(__file__).resolve().parent.parent
+            / "boards"
+            / "01-voltage-divider"
+            / "output"
+            / "voltage_divider_routed.kicad_pcb"
+        )
+        if not board_pcb.exists():
+            # Skip rather than fail: the routed PCB is a committed
+            # artifact whose presence depends on the boards/01 build
+            # state.  Conditional skip preserves the test as a
+            # regression sentinel without flaking when the artifact is
+            # absent.
+            import pytest
+
+            pytest.skip(f"{board_pcb} not present in this checkout")
+
+        rc = main([str(board_pcb), "--only", "connectivity", "--mfr", "jlcpcb"])
+        assert rc == 2, (
+            "Board 01 routes 1/2 nets (Issue #3041); connectivity rule "
+            "must flag the unrouted net.  Pre-fix this returned 0."
+        )
+
+        captured = capsys.readouterr()
+        assert "connectivity" in captured.out
+
+
+class TestConnectivityRuleRegistry:
+    """Registry-level checks: the rule is properly wired into both
+    :attr:`DRCChecker.CHECK_ALL_METHODS` and the CLI dispatcher."""
+
+    def test_connectivity_in_check_all(self) -> None:
+        from kicad_tools.validate import DRCChecker
+
+        assert "check_connectivity" in DRCChecker.CHECK_ALL_METHODS
+
+    def test_connectivity_in_cli_categories(self) -> None:
+        from kicad_tools.cli import check_cmd
+
+        assert "connectivity" in check_cmd.CHECK_CATEGORIES
+
+    def test_violation_type_alias(self) -> None:
+        """Rule ID 'connectivity' must resolve to ViolationType.CONNECTIVITY."""
+        from kicad_tools.drc.violation import ViolationType
+
+        assert ViolationType.from_string("connectivity") is ViolationType.CONNECTIVITY


### PR DESCRIPTION
## Summary

Adds a new `connectivity` rule to `kct check` that loads the netlist and emits an error for each multi-pad net whose pads are not all connected through traces, vias, or filled copper zones.

Before this PR, `kct check` reported `DRC PASS` on PCBs with literally disconnected pads because no rule cross-referenced the netlist against actual copper connectivity. Board 00 (simple-led) and board 01 (voltage-divider) both routed only 1/2 nets but still showed `DRC PASSED`, misleading agents into believing the boards were manufacturable.

Closes #3041

## What changed

- **New rule**: `src/kicad_tools/validate/rules/connectivity.py` (`ConnectivityRule`, rule_id `connectivity`, severity `error`). Reuses `NetStatusAnalyzer` so fleet status and `kct check` agree on which nets count as complete.
- **New wrapper**: `DRCChecker.check_connectivity` in `src/kicad_tools/validate/checker.py`.
- **Wiring**: added to `DRCChecker.CHECK_ALL_METHODS` AND the CLI dispatcher's `check_methods` dict in `src/kicad_tools/cli/check_cmd.py` (parity invariant from PR #3055 enforced by `tests/test_check_cmd_coverage.py`).
- **Type registration**: new `ViolationType.CONNECTIVITY` enum entry plus alias-table + category-map entries (the #2521 precedent: prevents the fuzzy fallback in `from_string` from miscategorizing the new rule_id as `UNKNOWN`).
- **Audit integration**: the audit framework already classifies connectivity gaps as advisory-vs-blocking via `ConnectivityStatus.has_zones`. To avoid double-counting and preserve the existing WARNING-vs-NOT_READY verdict semantics, `auditor._check_drc` now excludes `connectivity` rule_id violations from the audit's blocking count. The rule is still visible in `violations_by_type` for introspection.
- **Tests**: `tests/test_connectivity_rule.py` covers 14 cases across 4 test classes (unit, CLI, board 01 integration, registry/alias wiring).

## Rule details

**Pour-net suppression is connectivity-driven, not name-driven.** `NetStatusAnalyzer` already treats pads inside a same-net filled polygon as connected, so a GND net with copper zones produces zero errors. A pour-named net WITHOUT zones is still reported (the missing zone is itself the bug).

**Single-pad nets are out of scope.** `SinglePadNetRule` handles them with finer NC / connector-NC / defect classification.

**Severity is `error`.** An unrouted pad is unmanufacturable; agents need a hard signal. The existing `--skip connectivity` flag is the documented escape hatch for intentional partial-route demos (no new CLI surface needed).

## Verification

```
$ uv run kct check --mfr jlcpcb boards/01-voltage-divider/output/voltage_divider_routed.kicad_pcb
...
Results:
  Errors:     1

BY RULE:
  connectivity: 1 error

ERRORS (must fix):
  [X] connectivity
      Net 'GND' is partially routed: 2 of 3 pads stranded (connected island has 1 pads)

DRC FAILED - Fix errors before manufacturing
exit=2
```

Pre-PR this returned exit 0 with `DRC PASSED`.

## Test plan

- [x] `uv run pytest tests/test_connectivity_rule.py -v --no-cov` (14 pass)
- [x] `uv run pytest tests/test_check_cmd_coverage.py --no-cov` (7 pass — parity invariant from #3055 holds)
- [x] `uv run pytest tests/test_check_cmd_coverage.py tests/test_drc.py tests/test_cli_check_single_pad_net.py tests/test_drc_violation_type_validate.py tests/test_drc_category.py tests/test_drc_report_formats.py tests/test_drc_suggestions.py tests/test_drc_summary.py tests/test_drc_regression.py tests/test_audit.py tests/test_fleet*.py --no-cov` (470 pass, 1 pre-existing failure `test_no_zones_regression` verified to fail on `main`)
- [x] `uv run pytest tests/test_fleet_status_drc.py tests/test_output_connectivity.py tests/test_pcb_nets_connectivity.py tests/test_optimize_connectivity_invariant.py tests/test_routing_connectivity.py tests/test_route_pipeline_connectivity.py --no-cov` (62 pass)
- [x] `uv run ruff check` clean on changed files
- [x] Manual verification: board 01 routed PCB now produces exit 2 with `connectivity: 1 error` (was exit 0, `DRC PASSED` before this PR)

## Out of scope

- Refactoring the rule registry further (#3044's work, partially done by #3055).
- New CLI `--skip-rule connectivity` flag — the existing `--skip connectivity` mechanism covers this.
- Fixing the underlying unrouted-nets problem on boards 00/01 (the boards' own work — this issue just adds the detection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)