### PR TITLE
feat(route): add seed parameter to route_all_negotiated for deterministic routing (closes #3039)

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -2342,6 +2342,8 @@ def route_with_layer_escalation(
                     or getattr(args, "high_performance", False),
                     hierarchical=getattr(args, "hierarchical", False),
                     perturbation=getattr(args, "perturbation", True),
+                    # Issue #3039: forward --seed for deterministic routing.
+                    seed=getattr(args, "seed", None),
                     # Issue #3051: forward checkpoint callback so kills
                     # mid-loop persist the best-so-far snapshot.
                     checkpoint_callback=_checkpoint_cb,
@@ -3058,6 +3060,8 @@ def route_with_rule_relaxation(
                     or getattr(args, "high_performance", False),
                     hierarchical=getattr(args, "hierarchical", False),
                     perturbation=getattr(args, "perturbation", True),
+                    # Issue #3039: forward --seed for deterministic routing.
+                    seed=getattr(args, "seed", None),
                     # Issue #3051: forward checkpoint callback so kills
                     # mid-loop persist the best-so-far snapshot.
                     checkpoint_callback=_checkpoint_cb,
@@ -4136,6 +4140,8 @@ def route_with_combined_escalation(
                         or getattr(args, "high_performance", False),
                         hierarchical=getattr(args, "hierarchical", False),
                         perturbation=getattr(args, "perturbation", True),
+                        # Issue #3039: forward --seed for deterministic routing.
+                        seed=getattr(args, "seed", None),
                         # Issue #3051: forward checkpoint callback so kills
                         # mid-loop persist the best-so-far snapshot.
                         checkpoint_callback=_checkpoint_cb,
@@ -6281,6 +6287,8 @@ def main(argv: list[str] | None = None) -> int:
                                     or getattr(args, "high_performance", False),
                                     hierarchical=getattr(args, "hierarchical", False),
                                     perturbation=getattr(args, "perturbation", True),
+                                    # Issue #3039: forward --seed for deterministic routing.
+                                    seed=getattr(args, "seed", None),
                                     checkpoint_callback=_checkpoint_cb,
                                 )
                             return router.route_all()
@@ -6327,6 +6335,8 @@ def main(argv: list[str] | None = None) -> int:
                             or getattr(args, "high_performance", False),
                             hierarchical=getattr(args, "hierarchical", False),
                             perturbation=getattr(args, "perturbation", True),
+                            # Issue #3039: forward --seed for deterministic routing.
+                            seed=getattr(args, "seed", None),
                             checkpoint_callback=_checkpoint_cb,
                         )
                     else:
@@ -6388,6 +6398,8 @@ def main(argv: list[str] | None = None) -> int:
                         or getattr(args, "high_performance", False),
                         hierarchical=getattr(args, "hierarchical", False),
                         perturbation=getattr(args, "perturbation", True),
+                        # Issue #3039: forward --seed for deterministic routing.
+                        seed=getattr(args, "seed", None),
                         checkpoint_callback=_checkpoint_cb,
                     )
 
@@ -6407,6 +6419,8 @@ def main(argv: list[str] | None = None) -> int:
                     or getattr(args, "high_performance", False),
                     hierarchical=getattr(args, "hierarchical", False),
                     perturbation=getattr(args, "perturbation", True),
+                    # Issue #3039: forward --seed for deterministic routing.
+                    seed=getattr(args, "seed", None),
                     checkpoint_callback=_checkpoint_cb,
                 )
             elif args.differential_pairs and args.strategy == "basic":

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -843,6 +843,11 @@ class Autorouter:
         # explore alternative routing orders.
         self._perturbation_magnitude: float = 0.0
         self._perturbation_rng: random.Random = random.Random(42)
+        # Issue #3039: When ``route_all_negotiated(seed=...)`` is supplied,
+        # this holds the user-provided seed so ``_activate_perturbation``
+        # can re-seed deterministically per stagnation episode.  ``None``
+        # preserves the original (non-deterministic-trigger-timing) behaviour.
+        self._perturbation_seed: int | None = None
 
         # Routing failure tracking (Issue #688)
         self.routing_failures: list[RoutingFailure] = []
@@ -2287,7 +2292,16 @@ class Autorouter:
         self._perturbation_magnitude = 0.1 * stagnation_count
         # Re-seed the RNG each activation so different stagnation
         # episodes explore different orderings.
-        self._perturbation_rng = random.Random(stagnation_count * 7 + 13)
+        # Issue #3039: When the caller supplied ``seed`` to
+        # ``route_all_negotiated``, fold it into the per-episode re-seed so
+        # different ``--seed`` values produce different escape trajectories
+        # while a fixed ``--seed`` remains deterministic across runs.
+        if self._perturbation_seed is not None:
+            self._perturbation_rng = random.Random(
+                self._perturbation_seed + stagnation_count * 7 + 13
+            )
+        else:
+            self._perturbation_rng = random.Random(stagnation_count * 7 + 13)
 
     def _reset_perturbation(self) -> None:
         """Reset perturbation to zero (Issue #2334).
@@ -5830,6 +5844,7 @@ class Autorouter:
         congestion_auto_tune: bool = False,
         hotset_only: bool = False,
         perturbation: bool = True,
+        seed: int | None = None,
         checkpoint_callback: "Callable[[list[Route], IterationMetrics], None] | None" = None,
     ) -> list[Route]:
         """Route all nets using PathFinder-style negotiated congestion.
@@ -5906,6 +5921,20 @@ class Autorouter:
             perturbation: If True (default), enable stochastic cost perturbation
                 when oscillation is detected (Issue #2334). Adds random noise to
                 per-net priority scores to break symmetry and escape local minima.
+            seed: Optional integer seed for deterministic routing (Issue #3039).
+                When provided, the perturbation RNG (``self._perturbation_rng``)
+                and the global ``random`` module (used by the MST trial-pad
+                shuffle, ``algorithms/negotiated.py`` escape strategies, etc.)
+                are seeded so that two ``route_all_negotiated`` invocations on
+                the same inputs produce identical
+                ``(nets_routed, total_segments, total_vias, completion_pct)``
+                tuples.  When ``None`` (default), existing non-deterministic
+                behaviour is preserved (the perturbation RNG keeps its
+                construction-time seed of 42 but the global RNG is left at its
+                os.urandom-derived state).  Note: byte-identical .kicad_pcb
+                output is NOT guaranteed -- KiCad UUIDs are independently
+                random per element.  The seed only pins the routing-decision
+                RNGs, not the file-format ones.
             checkpoint_callback: Optional callable invoked whenever the
                 best-so-far snapshot is replaced (Issue #2808). Receives the
                 deep-copied ``best_routes`` list and the matching
@@ -5984,6 +6013,22 @@ class Autorouter:
         perturbation_best_overflow: int | None = None
         # Ensure perturbation is reset at the start of each routing call
         self._reset_perturbation()
+
+        # Issue #3039: Seed the perturbation RNG and global ``random`` module
+        # for deterministic routing when ``seed`` is supplied.  Stash the
+        # provided seed on ``self._perturbation_seed`` so
+        # ``_activate_perturbation`` can derive a deterministic-but-varying
+        # re-seed per stagnation episode instead of using a constant offset.
+        # When ``seed`` is None we leave the global RNG state alone (existing
+        # behaviour) -- we deliberately do NOT clobber any previously stashed
+        # seed so that wrapper methods (``route_with_subgrid``,
+        # ``route_all_multi_resolution``, ``route_with_progressive_clearance``)
+        # which delegate to this method do not accidentally drop a seed set
+        # by an outer caller that pre-seeded the global RNG via CLI ``--seed``.
+        if seed is not None:
+            self._perturbation_seed = seed
+            self._perturbation_rng = random.Random(seed)
+            random.seed(seed)
 
         net_order = sorted(self.nets.keys(), key=lambda n: self._get_net_priority(n))
         # Issue #1295: Filter out pour nets before negotiated routing

--- a/tests/test_router_determinism.py
+++ b/tests/test_router_determinism.py
@@ -211,3 +211,219 @@ def test_route_cmd_does_not_call_random_seed_when_seed_omitted():
         f"every route run deterministic, masking future regressions in "
         f"the unseeded code path."
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #3039: route_all_negotiated(seed=...) API
+# ---------------------------------------------------------------------------
+#
+# Issue #2589 (above) seeded only the GLOBAL random module from the CLI layer.
+# That fix did not cover the per-Autorouter perturbation RNG
+# (``self._perturbation_rng``, used by the stochastic-perturbation escape from
+# Issue #2334) -- so even with ``--seed 42``, the negotiated routing path
+# remained non-deterministic in the perturbation-activated branch.  PR #3034
+# and PR #3036 shipped boards whose verification numbers did not survive a
+# re-run; the curator's investigation traced this to the missing seed plumb
+# on the ``route_all_negotiated`` public API.
+#
+# The tests below verify the Issue #3039 fix: ``route_all_negotiated`` now
+# accepts a ``seed`` parameter that flows into both the perturbation RNG and
+# the global module, producing identical outcome tuples across runs.
+
+
+from kicad_tools.router.core import Autorouter  # noqa: E402  (test-section import)
+
+
+def _make_seed_test_router() -> Autorouter:
+    """Build a small router with overlapping nets that exercise the
+    negotiated rip-up loop.  Three two-pad nets whose obvious routes cross
+    -- forces the loop to iterate at least once.
+    """
+    router = Autorouter(width=40.0, height=30.0)
+
+    # Net 1: horizontal across the board.
+    router.add_component(
+        "R1",
+        [{"number": "1", "x": 5.0, "y": 15.0, "net": 1, "net_name": "NET1"}],
+    )
+    router.add_component(
+        "R2",
+        [{"number": "1", "x": 35.0, "y": 15.0, "net": 1, "net_name": "NET1"}],
+    )
+
+    # Net 2: vertical across the board (crosses net 1).
+    router.add_component(
+        "R3",
+        [{"number": "1", "x": 20.0, "y": 5.0, "net": 2, "net_name": "NET2"}],
+    )
+    router.add_component(
+        "R4",
+        [{"number": "1", "x": 20.0, "y": 25.0, "net": 2, "net_name": "NET2"}],
+    )
+
+    # Net 3: diagonal, adds congestion.
+    router.add_component(
+        "R5",
+        [{"number": "1", "x": 10.0, "y": 10.0, "net": 3, "net_name": "NET3"}],
+    )
+    router.add_component(
+        "R6",
+        [{"number": "1", "x": 30.0, "y": 20.0, "net": 3, "net_name": "NET3"}],
+    )
+
+    return router
+
+
+def _outcome_tuple(router: Autorouter) -> tuple[int, int, int]:
+    """Reduce a router's post-route state to the AC tuple from Issue #3039:
+    ``(nets_routed, total_segments, total_vias)``.  We deliberately drop
+    ``completion_pct`` because it is a derived ratio of ``nets_routed`` and
+    ``nets_to_route`` and adds no independent information.
+    """
+    stats = router.get_statistics()
+    return (
+        int(stats.get("nets_routed", 0)),
+        int(stats.get("segments", 0)),
+        int(stats.get("vias", 0)),
+    )
+
+
+class TestRouteAllNegotiatedSeedParameter:
+    """Issue #3039: ``route_all_negotiated`` exposes ``seed`` kwarg."""
+
+    def test_route_all_negotiated_accepts_seed_kwarg(self):
+        """Signature change: ``seed`` is now a keyword arg, not TypeError."""
+        router = _make_seed_test_router()
+        routes = router.route_all_negotiated(max_iterations=2, seed=42)
+        assert isinstance(routes, list)
+
+    def test_seed_is_stashed_on_router_instance(self):
+        """``seed`` flows into ``self._perturbation_seed`` so
+        ``_activate_perturbation`` can derive per-episode RNG seeds from it.
+        """
+        router = _make_seed_test_router()
+        assert router._perturbation_seed is None  # __init__ default
+        router.route_all_negotiated(max_iterations=1, seed=12345)
+        assert router._perturbation_seed == 12345
+
+    def test_seed_none_preserves_legacy_behaviour(self):
+        """``seed=None`` (default) leaves ``_perturbation_seed`` cleared.
+        Non-regression guard from Issue #3039: callers that do NOT opt in
+        must keep today's non-deterministic-trigger-timing behaviour.
+        """
+        router = _make_seed_test_router()
+        router.route_all_negotiated(max_iterations=1)
+        assert router._perturbation_seed is None
+
+
+class TestRouteAllNegotiatedDeterminism:
+    """Issue #3039 AC: identical outcome tuple across 3 seeded runs."""
+
+    def test_same_seed_produces_same_outcome_tuple(self):
+        """Three consecutive ``route_all_negotiated(seed=42)`` runs on the
+        same fixture must produce the same ``(nets_routed, segments, vias)``
+        tuple.  This is the acceptance criterion from Issue #3039.
+        """
+        outcomes: list[tuple[int, int, int]] = []
+        for _ in range(3):
+            router = _make_seed_test_router()
+            router.route_all_negotiated(max_iterations=3, seed=42)
+            outcomes.append(_outcome_tuple(router))
+
+        assert outcomes[0] == outcomes[1] == outcomes[2], (
+            f"Three runs with seed=42 produced different outcomes: {outcomes}. "
+            "route_all_negotiated must be deterministic when seeded."
+        )
+
+    def test_different_seeds_produce_distinct_perturbation_rng_state(self):
+        """Sanity check that the seed actually has an effect.
+
+        We do not assert outcome tuples *must* differ for distinct seeds
+        (this fixture may converge regardless of perturbation ordering),
+        but the underlying perturbation RNG state must differ -- otherwise
+        the seed parameter is a no-op.
+        """
+        router_a = _make_seed_test_router()
+        router_a.route_all_negotiated(max_iterations=1, seed=42)
+
+        router_b = _make_seed_test_router()
+        router_b.route_all_negotiated(max_iterations=1, seed=99)
+
+        assert router_a._perturbation_seed != router_b._perturbation_seed
+        sample_a = router_a._perturbation_rng.random()
+        sample_b = router_b._perturbation_rng.random()
+        assert sample_a != sample_b, (
+            "Different seeds (42 vs 99) produced identical perturbation RNG "
+            "samples -- the seed is not propagating to self._perturbation_rng."
+        )
+
+    def test_seed_kwarg_re_seeds_global_random_for_mst_shuffle(self):
+        """``seed`` re-seeds the global ``random`` module so the MST
+        trial-pad shuffle (``core.py:~11475``, used by the multi-resolution
+        path) becomes deterministic.  Verified indirectly: post-route
+        ``random.random()`` samples match across two seeded runs.
+        """
+        router1 = _make_seed_test_router()
+        router1.route_all_negotiated(max_iterations=1, seed=7)
+        sample1 = random.random()
+
+        router2 = _make_seed_test_router()
+        router2.route_all_negotiated(max_iterations=1, seed=7)
+        sample2 = random.random()
+
+        assert sample1 == sample2, (
+            "random.random() draw after route_all_negotiated(seed=7) "
+            "must be identical across two invocations -- otherwise the "
+            "seed did not propagate to the global RNG that drives the "
+            "MST trial shuffle and negotiated escape strategies."
+        )
+
+
+class TestActivatePerturbationSeed:
+    """``_activate_perturbation`` honors the stashed seed when present."""
+
+    def test_activate_perturbation_seed_none_uses_legacy_derivation(self):
+        """Without a stashed seed, ``_activate_perturbation(n)`` re-seeds
+        the RNG with ``Random(n * 7 + 13)`` -- the pre-Issue-#3039 formula.
+        """
+        router = Autorouter(width=20.0, height=20.0)
+        assert router._perturbation_seed is None
+
+        router._activate_perturbation(stagnation_count=5)
+        sample = router._perturbation_rng.random()
+
+        ref = random.Random(5 * 7 + 13)
+        assert sample == ref.random()
+
+    def test_activate_perturbation_seed_set_folds_seed_into_derivation(self):
+        """With a stashed seed S, ``_activate_perturbation(n)`` re-seeds
+        the RNG with ``Random(S + n * 7 + 13)`` -- distinct per stagnation
+        episode but deterministic across runs.
+        """
+        router = Autorouter(width=20.0, height=20.0)
+        router._perturbation_seed = 1000
+
+        router._activate_perturbation(stagnation_count=5)
+        sample = router._perturbation_rng.random()
+
+        ref = random.Random(1000 + 5 * 7 + 13)
+        assert sample == ref.random()
+
+    def test_activate_perturbation_distinct_episodes_use_distinct_rngs(self):
+        """Two stagnation episodes (different ``stagnation_count`` values)
+        produce different RNG streams even when seed is fixed -- the
+        escape-strategy variety guarantee from Issue #2334.
+        """
+        router = Autorouter(width=20.0, height=20.0)
+        router._perturbation_seed = 42
+
+        router._activate_perturbation(stagnation_count=2)
+        sample_episode_a = router._perturbation_rng.random()
+
+        router._activate_perturbation(stagnation_count=3)
+        sample_episode_b = router._perturbation_rng.random()
+
+        assert sample_episode_a != sample_episode_b, (
+            "Distinct stagnation_count values must seed distinct RNG streams "
+            "so successive perturbation episodes explore different orderings."
+        )


### PR DESCRIPTION
## Summary

Closes #3039.

PRs #3034 and #3036 shipped boards 01 and 02 with verification numbers that did not survive a re-run.  Root cause: the stochastic perturbation RNG in `route_all_negotiated` (Issue #2334) had no seed parameter on the public API, so even with CLI `--seed 42` (Issue #2589) the per-Autorouter `self._perturbation_rng` remained un-seeded and the negotiated path was non-deterministic.

This PR adds `seed: int | None = None` to `Autorouter.route_all_negotiated`, mirroring the pattern already present on `route_all_monte_carlo` / `route_all_evolutionary`, and plumbs it through every CLI call site.

## Changes

### `src/kicad_tools/router/core.py` (+47 LOC)
- New `_perturbation_seed: int | None = None` instance attribute (constructor).
- `route_all_negotiated` gains `seed` kwarg; when provided, seeds both `self._perturbation_rng` and the global `random` module.
- `_activate_perturbation(stagnation_count)` folds the stashed seed into its re-seed formula (`seed + stagnation_count * 7 + 13`) so distinct seeds still produce distinct escape trajectories per stagnation episode.
- `seed=None` deliberately does NOT clobber any previously stashed seed, so wrapper methods (`route_with_subgrid`, `route_all_multi_resolution`, `route_with_progressive_clearance`) which delegate to `route_all_negotiated` do not drop a seed set by an outer caller.

### `src/kicad_tools/cli/route_cmd.py` (+14 LOC)
- Forwards `seed=getattr(args, "seed", None)` from all 7 `route_all_negotiated` call sites:
  - `route_with_layer_escalation` (main layer-escalation loop)
  - `route_with_rule_relaxation` (per-tier rule-relaxation loop)
  - `route_with_combined_escalation` (combined layer x tier matrix)
  - `phase2_route_fn._phase2_strategy` (diff-pair + negotiated phase-2)
  - `phase2_route_fn` (negotiated phase-2, non-diffpair)
  - `_neg_strategy` (diff-pair pre-pass + negotiated)
  - Top-level `args.strategy == "negotiated"` direct call
- Preserves PR #3058's checkpoint-callback wiring at every site.

### `tests/test_router_determinism.py` (+216 LOC, new test classes)
Extends the existing Issue-#2589 CLI-level tests with 9 new tests covering the Issue-#3039 API:
- `TestRouteAllNegotiatedSeedParameter` (3 tests): kwarg acceptance, instance-level stashing, `seed=None` non-regression.
- `TestRouteAllNegotiatedDeterminism` (3 tests): identical outcome tuple across 3 seeded runs (the AC), distinct RNG state across distinct seeds, global RNG re-seed verified indirectly via `random.random()` sampling.
- `TestActivatePerturbationSeed` (3 tests): legacy formula (`seed=None`), seeded formula (`seed + n*7 + 13`), distinct stagnation episodes still produce distinct streams.

All 16 tests in the file pass (`uv run pytest tests/test_router_determinism.py` -> `16 passed in 3.96s`).

## Verification on the motivating boards

Tested on the two boards that motivated #3039 (M-A #3034 and M-B #3036).  Each invoked 3 times in fresh process:

| Board | Run 1 | Run 2 | Run 3 |
|-------|-------|-------|-------|
| 01 voltage-divider | `2/2 nets, 21 segments, 3 vias` | identical | identical |
| 02 charlieplex-led | `8/8 nets, 247 segments, 28 vias` | identical | identical |

Both boards now reproducibly hit their PR-#3034 / PR-#3036 verified outcomes when `--seed 42` is supplied (which both `boards/01-voltage-divider/generate_design.py` and `boards/02-charlieplex-led/generate_design.py` already pass).

## Acceptance criteria (curator-tightened, from issue body)

- [x] `kct route ... --seed 42` produces identical `(nets_routed, total_segments, total_vias)` tuples across 3 consecutive runs on board 01.
- [x] `route_all_negotiated(seed=42, ...)` exposes a seed parameter that propagates to all perturbation RNGs (verified by `TestRouteAllNegotiatedSeedParameter::test_seed_is_stashed_on_router_instance` and `TestActivatePerturbationSeed::test_activate_perturbation_seed_set_folds_seed_into_derivation`).
- [x] Board 01 and board 02 reproducibly hit their expected outcomes (PR #3034 / #3036 verified numbers) when invoked with `--seed 42`.

## Out of scope (per issue body)

- Per-board variance documentation (curator's option 3).
- N-times CI run job (curator's option 2).
- Changing the default behaviour (seed remains `None` by default, matching today's behaviour).

## Test plan

- [x] `uv run pytest tests/test_router_determinism.py` -> 16 passed
- [x] `uv run pytest tests/test_negotiated_congestion_model.py` -> 21 passed (no regression)
- [x] `uv run pytest tests/test_layer_escalation.py -k "not TestEarlyTermination"` -> all non-pre-existing tests pass (the 9 `TestEarlyTermination` failures are pre-existing on main; `MagicMock vs int` comparison in `router/io.py:2073`, unrelated to this change)
- [x] `uv run python boards/01-voltage-divider/generate_design.py` x3 -> identical 21 segments / 3 vias / 2 nets routed
- [x] `uv run python boards/02-charlieplex-led/generate_design.py` x3 -> identical 247 segments / 28 vias / 8 nets routed

## Coordination

- PR #3060 (connectivity rule) -- no overlap (only touches `validate/`).
- PR #3058 (checkpoint lift) -- this PR forwards `seed=` at the same 4 call sites #3058 touched; the checkpoint_callback wiring is preserved at every site.