### PR TITLE
feat(check): auto-derive pad_grid tolerance from board's pad-offset histogram (closes #3061)

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -166,6 +166,31 @@ def main(argv: list[str] | None = None) -> int:
             "rules degrade to no-ops (Issue #2684)."
         ),
     )
+    # Issue #3061: auto-derive the pad_grid tolerance from each board's
+    # pad-offset histogram by default for the CLI.  Users can opt back into
+    # the fixed-0.05mm behaviour with --pad-grid-strict, or pin a custom
+    # value with --pad-grid-tolerance.
+    pad_grid_group = parser.add_mutually_exclusive_group()
+    pad_grid_group.add_argument(
+        "--pad-grid-strict",
+        action="store_true",
+        help=(
+            "Use the fixed 0.05mm pad_grid tolerance (PR #3057 default) "
+            "instead of auto-deriving per-board from the pad-offset "
+            "histogram (issue #3061).  Default: auto-derive."
+        ),
+    )
+    pad_grid_group.add_argument(
+        "--pad-grid-tolerance",
+        type=float,
+        default=None,
+        metavar="MM",
+        help=(
+            "Override the pad_grid L2 tolerance with an explicit value "
+            "in mm (e.g. ``--pad-grid-tolerance 0.02``).  Disables "
+            "auto-derivation."
+        ),
+    )
 
     args = parser.parse_args(argv)
 
@@ -267,8 +292,26 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Error: {e}", file=sys.stderr)
         return 1
 
+    # Resolve pad_grid tolerance policy (issue #3061).
+    # Precedence: explicit value > strict mode > auto-derive (CLI default).
+    if args.pad_grid_tolerance is not None:
+        pad_grid_threshold: float | None = args.pad_grid_tolerance
+        pad_grid_auto_derive = False
+    elif args.pad_grid_strict:
+        pad_grid_threshold = None  # Falls through to DEFAULT_PAD_GRID_TOLERANCE_MM
+        pad_grid_auto_derive = False
+    else:
+        pad_grid_threshold = None
+        pad_grid_auto_derive = True
+
     # Run selected checks
-    results = run_selected_checks(checker, only_set, skip_set)
+    results = run_selected_checks(
+        checker,
+        only_set,
+        skip_set,
+        pad_grid_threshold=pad_grid_threshold,
+        pad_grid_auto_derive=pad_grid_auto_derive,
+    )
 
     # Apply errors-only filter
     violations = list(results.violations)
@@ -306,9 +349,33 @@ def run_selected_checks(
     checker: DRCChecker,
     only_set: set[str] | None,
     skip_set: set[str],
+    pad_grid_threshold: float | None = None,
+    pad_grid_auto_derive: bool = True,
 ) -> DRCResults:
-    """Run the selected DRC checks based on filters."""
+    """Run the selected DRC checks based on filters.
+
+    Args:
+        checker: The DRC checker pre-loaded with the PCB and rules.
+        only_set: Optional whitelist of check category names.
+        skip_set: Set of check category names to skip.
+        pad_grid_threshold: Explicit pad_grid L2 tolerance in mm, or
+            ``None`` to use the threshold-resolution policy below.
+            Issue #3061.
+        pad_grid_auto_derive: When ``True`` and ``pad_grid_threshold``
+            is ``None``, the pad_grid check derives the threshold from
+            the board's pad-offset histogram (issue #3061).  Defaults
+            to ``True`` for the CLI; ``False`` preserves the PR #3057
+            fixed-0.05mm behaviour.
+    """
     results = DRCResults()
+
+    # Build the pad_grid invocation as a thunk so the map below can
+    # remain uniform (every value is a zero-arg callable).
+    def _pad_grid_check() -> DRCResults:
+        return checker.check_pad_grid_alignment(
+            threshold=pad_grid_threshold,
+            auto_derive_threshold=pad_grid_auto_derive,
+        )
 
     # Map of category to check method.  This dict MUST stay a superset
     # of the methods invoked by ``DRCChecker.check_all`` (i.e., every
@@ -327,7 +394,7 @@ def run_selected_checks(
         "impedance": checker.check_impedance,
         "match_group_length_skew": checker.check_match_group_length_skew,
         "netlist": checker.check_netlist,
-        "pad_grid": checker.check_pad_grid_alignment,
+        "pad_grid": _pad_grid_check,
         "placement": checker.check_footprint_placement,
         "silkscreen": checker.check_silkscreen,
         "single_pad_net": checker.check_single_pad_nets,

--- a/src/kicad_tools/cli/commands/validation.py
+++ b/src/kicad_tools/cli/commands/validation.py
@@ -225,6 +225,11 @@ def run_check_command(args) -> int:
         sub_argv.append("--suppress-library")
     if getattr(args, "net_class_map", None):
         sub_argv.extend(["--net-class-map", args.net_class_map])
+    # Issue #3061: forward pad_grid tolerance flags.
+    if getattr(args, "pad_grid_strict", False):
+        sub_argv.append("--pad-grid-strict")
+    if getattr(args, "pad_grid_tolerance", None) is not None:
+        sub_argv.extend(["--pad-grid-tolerance", str(args.pad_grid_tolerance)])
     return check_main(sub_argv)
 
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -428,6 +428,30 @@ def _add_check_parser(subparsers) -> None:
             "(Issue #2684)."
         ),
     )
+    # Issue #3061: per-board auto-derive of the pad_grid tolerance is the
+    # default for the CLI.  --pad-grid-strict opts back into the PR #3057
+    # fixed-0.05mm constant; --pad-grid-tolerance pins a custom value.
+    pad_grid_group = check_parser.add_mutually_exclusive_group()
+    pad_grid_group.add_argument(
+        "--pad-grid-strict",
+        action="store_true",
+        help=(
+            "Use the fixed 0.05mm pad_grid tolerance (PR #3057 default) "
+            "instead of auto-deriving per-board from the pad-offset "
+            "histogram (issue #3061).  Default: auto-derive."
+        ),
+    )
+    pad_grid_group.add_argument(
+        "--pad-grid-tolerance",
+        type=float,
+        default=None,
+        metavar="MM",
+        help=(
+            "Override the pad_grid L2 tolerance with an explicit value "
+            "in mm (e.g. ``--pad-grid-tolerance 0.02``).  Disables "
+            "auto-derivation."
+        ),
+    )
 
 
 def _add_sch_parser(subparsers) -> None:

--- a/src/kicad_tools/router/preflight.py
+++ b/src/kicad_tools/router/preflight.py
@@ -208,12 +208,138 @@ def _suggest_finer_grid(
 DEFAULT_PAD_GRID_TOLERANCE_MM: float = 0.05
 
 
+#: Absolute hard cap on auto-derived tolerance, in millimeters.
+#:
+#: The auto-derive logic builds the tolerance from each board's pad-offset
+#: histogram (``p99(offsets) + safety margin``).  This cap prevents truly
+#: pathological boards from pushing the threshold so high that real placement
+#: errors slip through.  ``0.15`` mm is the smallest clearance routed boards
+#: typically run with, so anything above this would be a routing problem
+#: irrespective of grid alignment.
+AUTO_DERIVED_TOLERANCE_HARD_CAP_MM: float = 0.15
+
+
+#: Floor for the auto-derived tolerance, in millimeters.
+#:
+#: Even on a perfectly on-grid board the auto-derive logic must not return
+#: a tolerance below the post-#3057 default.  This guarantees that
+#: ``auto_derive_threshold=True`` is always at least as permissive as
+#: ``auto_derive_threshold=False`` -- no surprise regressions for boards
+#: where every pad happens to land within 0.001 mm of grid.
+AUTO_DERIVED_TOLERANCE_FLOOR_MM: float = DEFAULT_PAD_GRID_TOLERANCE_MM
+
+
+#: Safety margin added to the p99 of the per-pad offsets when auto-deriving
+#: the tolerance, in millimeters.  Pads naturally cluster around their
+#: intrinsic metric/imperial-rounding offset; the margin gives the auto-derived
+#: threshold a little headroom over the highest observed legitimate offset
+#: so that a single placement error 0.005 mm above the cluster still flags.
+AUTO_DERIVED_TOLERANCE_MARGIN_MM: float = 0.005
+
+
+#: Percentile used to summarise the per-pad L2 offset distribution when
+#: auto-deriving the tolerance.  ``0.99`` means "absorb the noise floor of
+#: the 99% of pads that are clearly intrinsic, then add a small safety
+#: margin"; the top 1% (which empirically corresponds to the off-grid tail
+#: introduced by genuine placement errors and gross library bugs) still
+#: shows up as a violation.
+AUTO_DERIVED_TOLERANCE_PERCENTILE: float = 0.99
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    """Compute the (linearly-interpolated) percentile of a non-empty list.
+
+    Implemented locally to avoid pulling in NumPy as a hot-path
+    dependency for a one-shot DRC rule that the rest of the preflight
+    module never needs.  The signature matches ``numpy.percentile`` with
+    ``interpolation="linear"`` and ``percentile`` expressed as a fraction
+    (``0.99``) rather than a percent (``99``).
+    """
+    if not values:
+        raise ValueError("Cannot compute percentile of empty list")
+    sorted_values = sorted(values)
+    if percentile <= 0:
+        return sorted_values[0]
+    if percentile >= 1:
+        return sorted_values[-1]
+    # Linear interpolation between adjacent ranks (numpy.percentile default).
+    rank = percentile * (len(sorted_values) - 1)
+    lo = int(rank)
+    hi = min(lo + 1, len(sorted_values) - 1)
+    frac = rank - lo
+    return sorted_values[lo] + (sorted_values[hi] - sorted_values[lo]) * frac
+
+
+def compute_pad_grid_tolerance(
+    pcb_path: str | Path,
+    grid_resolution: float = 0.1,
+    grid_origin: tuple[float, float] = (0.0, 0.0),
+    percentile: float = AUTO_DERIVED_TOLERANCE_PERCENTILE,
+    margin: float = AUTO_DERIVED_TOLERANCE_MARGIN_MM,
+    floor: float = AUTO_DERIVED_TOLERANCE_FLOOR_MM,
+    cap: float = AUTO_DERIVED_TOLERANCE_HARD_CAP_MM,
+) -> float:
+    """Auto-derive the pad_grid tolerance from a board's offset histogram.
+
+    Builds the per-pad L2-distance-to-grid distribution for ``pcb_path``
+    and returns ``max(floor, min(cap, p99(offsets) + margin))``.  The
+    result is the smallest tolerance that absorbs ~99% of the intrinsic
+    library/metric-rounding noise on the board while leaving the top
+    ~1% of pads (genuine placement errors, gross library bugs) above
+    the threshold.
+
+    The threshold is *board-specific*: a board with only metric-on-metric
+    footprints lands near :data:`AUTO_DERIVED_TOLERANCE_FLOOR_MM`; a
+    board with fine-pitch QFN/BGA whose pad lattice naturally sits 0.07
+    mm off the 0.1 mm grid lands near 0.08 mm; both still flag a 0.15 mm
+    placement error.  See issue #3061 for context.
+
+    Args:
+        pcb_path: Path to a ``.kicad_pcb`` file (or the file contents).
+        grid_resolution: Router grid resolution in mm.  Defaults to the
+            same ``0.1`` mm used by :func:`check_pad_grid_alignment`.
+        grid_origin: Grid origin offset ``(x, y)`` in mm.
+        percentile: Fraction (0..1) of the offset distribution to absorb
+            below the threshold.  Defaults to
+            :data:`AUTO_DERIVED_TOLERANCE_PERCENTILE` (``0.99``).
+        margin: Safety margin added on top of the percentile, in mm.
+            Defaults to :data:`AUTO_DERIVED_TOLERANCE_MARGIN_MM`
+            (``0.005``).
+        floor: Minimum tolerance to return, in mm.  Defaults to
+            :data:`AUTO_DERIVED_TOLERANCE_FLOOR_MM` (``0.05``) so the
+            auto-derived rule is never stricter than the post-#3057
+            default.
+        cap: Maximum tolerance to return, in mm.  Defaults to
+            :data:`AUTO_DERIVED_TOLERANCE_HARD_CAP_MM` (``0.15``) so a
+            pathological board cannot push the threshold above the
+            typical minimum trace clearance.
+
+    Returns:
+        The derived tolerance in mm.  Falls back to ``floor`` when the
+        board has no pads (the answer is vacuous either way).
+    """
+    pads = load_pads_for_analysis(pcb_path)
+    if not pads:
+        return floor
+
+    x_off, y_off = grid_origin
+    offsets = [
+        _l2_distance_to_grid(pad.x, pad.y, grid_resolution, x_off, y_off)
+        for pad in pads
+    ]
+
+    raw = _percentile(offsets, percentile) + margin
+    bounded = min(cap, max(floor, raw))
+    return float(bounded)
+
+
 def check_pad_grid_alignment(
     pcb_path: str | Path,
     grid_resolution: float = 0.1,
     threshold: float | None = None,
     grid_origin: tuple[float, float] = (0.0, 0.0),
     clearance: float = 0.15,
+    auto_derive_threshold: bool = False,
 ) -> OffGridReport:
     """Check that every pad in the PCB aligns with the router grid.
 
@@ -226,17 +352,25 @@ def check_pad_grid_alignment(
         grid_resolution: Router grid resolution in mm (default ``0.1``,
             matching ``Autorouter`` defaults and ``KCT_ROUTE_GRID``).
         threshold: Maximum L2 deviation considered on-grid, in mm.
-            Defaults to :data:`DEFAULT_PAD_GRID_TOLERANCE_MM` (``0.05`` mm)
-            to clear stock KiCad library footprints whose pads sit
+            When omitted (and ``auto_derive_threshold`` is ``False``)
+            defaults to :data:`DEFAULT_PAD_GRID_TOLERANCE_MM` (``0.05``
+            mm) to clear stock KiCad library footprints whose pads sit
             0.03-0.05 mm off the 0.1 mm grid by design.  Pass an explicit
             value (e.g. ``grid_resolution / 10``) to enforce the
-            stricter router-side check.
+            stricter router-side check.  An explicit ``threshold``
+            always wins over ``auto_derive_threshold``.
         grid_origin: Optional grid origin offset ``(x, y)`` in mm.
             Grid points are at ``offset + k * resolution``.  Defaults to
             ``(0.0, 0.0)``.
         clearance: Default trace clearance in mm, used by the
             :func:`auto_select_grid_resolution` analysis when computing a
             "finer grid" suggestion.
+        auto_derive_threshold: When ``True`` and ``threshold`` is
+            ``None``, derive the threshold from the board's pad-offset
+            histogram via :func:`compute_pad_grid_tolerance`.  Defaults
+            to ``False`` to preserve backwards-compatibility with the
+            constant-default behaviour introduced in PR #3057.  The CLI
+            (``kct check``) overrides this to ``True`` by default.
 
     Returns:
         :class:`OffGridReport` with the list of off-grid pads (possibly
@@ -249,7 +383,14 @@ def check_pad_grid_alignment(
         ...     print(report.summary())
     """
     if threshold is None:
-        threshold = DEFAULT_PAD_GRID_TOLERANCE_MM
+        if auto_derive_threshold:
+            threshold = compute_pad_grid_tolerance(
+                pcb_path,
+                grid_resolution=grid_resolution,
+                grid_origin=grid_origin,
+            )
+        else:
+            threshold = DEFAULT_PAD_GRID_TOLERANCE_MM
 
     pads = load_pads_for_analysis(pcb_path)
 
@@ -293,8 +434,13 @@ def check_pad_grid_alignment(
 
 
 __all__ = [
+    "AUTO_DERIVED_TOLERANCE_FLOOR_MM",
+    "AUTO_DERIVED_TOLERANCE_HARD_CAP_MM",
+    "AUTO_DERIVED_TOLERANCE_MARGIN_MM",
+    "AUTO_DERIVED_TOLERANCE_PERCENTILE",
     "DEFAULT_PAD_GRID_TOLERANCE_MM",
     "PreflightOffGridPad",
     "OffGridReport",
     "check_pad_grid_alignment",
+    "compute_pad_grid_tolerance",
 ]

--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -583,6 +583,7 @@ class DRCChecker:
         self,
         grid_resolution: float = 0.1,
         threshold: float | None = None,
+        auto_derive_threshold: bool = False,
     ) -> DRCResults:
         """Check that every pad aligns to the router grid.
 
@@ -596,11 +597,19 @@ class DRCChecker:
             grid_resolution: Router grid resolution in mm (default ``0.1``,
                 matching the ``Autorouter`` and ``KCT_ROUTE_GRID`` default).
             threshold: Maximum L2 deviation considered "on-grid", in mm.
-                Defaults to
+                When ``None`` and ``auto_derive_threshold`` is ``False``,
+                defaults to
                 :data:`kicad_tools.router.preflight.DEFAULT_PAD_GRID_TOLERANCE_MM`
                 (``0.05`` mm), chosen to clear stock KiCad library footprints
                 whose pads sit 0.03-0.05 mm off the 0.1 mm grid by design.
-                Genuine placement errors at >= 0.06 mm still flag.
+                Genuine placement errors at >= 0.06 mm still flag.  An
+                explicit ``threshold`` always wins over
+                ``auto_derive_threshold``.
+            auto_derive_threshold: When ``True`` and ``threshold`` is
+                ``None``, derive the threshold per-board from the
+                pad-offset histogram (issue #3061).  Defaults to
+                ``False`` so the Python API preserves PR #3057 behaviour;
+                ``kct check`` opts in by default.
 
         Returns:
             :class:`DRCResults` with one ``pad_grid`` violation (severity
@@ -624,6 +633,7 @@ class DRCChecker:
             grid_resolution=grid_resolution,
             threshold=threshold,
             clearance=self.design_rules.min_clearance_mm,
+            auto_derive_threshold=auto_derive_threshold,
         )
 
         results.rules_checked += 1

--- a/tests/test_pad_grid_auto_derive.py
+++ b/tests/test_pad_grid_auto_derive.py
@@ -1,0 +1,561 @@
+"""Tests for the auto-derived pad_grid tolerance (issue #3061).
+
+PR #3057 raised the default ``pad_grid`` tolerance from 0.01mm to a
+fixed 0.05mm constant, clearing 65% of fleet-wide warnings.  The
+residual ~112 warnings were all fine-pitch packages (LQFP-48, BGA-49,
+HTSSOP-56) whose pad lattice naturally sits 0.057-0.071 mm off the 0.1
+mm grid.  Raising the constant further would risk false-negatives on
+real placement errors in the 0.06-0.075 mm band.
+
+The fix (this issue) derives the threshold per-board from the
+pad-offset histogram: a board with only metric-on-metric pads keeps
+the 0.05 mm floor; a board with fine-pitch QFN whose pads sit at 0.07
+mm intrinsic offset gets a slightly higher threshold; both still flag
+a 0.15 mm placement error.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.router.preflight import (
+    AUTO_DERIVED_TOLERANCE_FLOOR_MM,
+    AUTO_DERIVED_TOLERANCE_HARD_CAP_MM,
+    AUTO_DERIVED_TOLERANCE_MARGIN_MM,
+    DEFAULT_PAD_GRID_TOLERANCE_MM,
+    check_pad_grid_alignment,
+    compute_pad_grid_tolerance,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers (copied from test_pad_grid_preflight.py to keep this file
+# self-contained -- the helper is small and the duplication keeps the
+# regression tests independent of helper churn).
+
+
+def _pcb_with_pads(
+    footprints: list[tuple[str, str, float, float, float, list[tuple[str, float, float]]]],
+) -> str:
+    """Build a minimal .kicad_pcb text with the given footprints.
+
+    Each footprint is a tuple of:
+        (footprint_name, ref, fp_x, fp_y, fp_rot_degrees, list_of_pads)
+    where each pad is ``(pin, local_x, local_y)``.
+    """
+    lines = [
+        "(kicad_pcb",
+        "  (version 20240108)",
+        '  (generator "kicad-tools-test")',
+        "  (general (thickness 1.6))",
+        '  (paper "A4")',
+        '  (layers (0 "F.Cu" signal) (31 "B.Cu" signal))',
+        '  (net 0 "")',
+        '  (net 1 "TEST")',
+    ]
+    for footprint_name, ref, fp_x, fp_y, fp_rot, pads in footprints:
+        lines.append(f'  (footprint "{footprint_name}"')
+        lines.append('    (layer "F.Cu")')
+        lines.append(f"    (at {fp_x} {fp_y} {fp_rot})")
+        lines.append(
+            f'    (fp_text reference "{ref}" (at 0 -2) (layer "F.SilkS")'
+            "      (effects (font (size 1 1) (thickness 0.15))))"
+        )
+        for pin, lx, ly in pads:
+            lines.append(
+                f'    (pad "{pin}" smd rect (at {lx} {ly}) (size 0.5 0.5) '
+                '(layers "F.Cu" "F.Mask") (net 1 "TEST"))'
+            )
+        lines.append("  )")
+    lines.append(")")
+    return "\n".join(lines) + "\n"
+
+
+def _write_pcb(tmp_path: Path, content: str, name: str = "board.kicad_pcb") -> Path:
+    p = tmp_path / name
+    p.write_text(content)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# compute_pad_grid_tolerance: pure threshold-computation tests
+
+
+class TestComputeTolerance:
+    """The standalone histogram analyser."""
+
+    def test_empty_board_returns_floor(self, tmp_path: Path) -> None:
+        """No pads -> falls back to the floor (vacuous case)."""
+        pcb = _write_pcb(tmp_path, _pcb_with_pads([]))
+        tol = compute_pad_grid_tolerance(pcb, grid_resolution=0.1)
+        assert tol == AUTO_DERIVED_TOLERANCE_FLOOR_MM
+
+    def test_all_on_grid_returns_floor(self, tmp_path: Path) -> None:
+        """All pads exactly on grid -> floor (never stricter than #3057)."""
+        text = _pcb_with_pads(
+            [
+                (
+                    "Test:FP",
+                    "U1",
+                    100.0,
+                    100.0,
+                    0.0,
+                    [("1", 0.0, 0.0), ("2", 1.0, 0.0), ("3", 0.0, 1.0)],
+                )
+            ]
+        )
+        pcb = _write_pcb(tmp_path, text)
+        tol = compute_pad_grid_tolerance(pcb, grid_resolution=0.1)
+        # Auto-derived tolerance must never go below the post-#3057
+        # default -- even for a perfectly on-grid board.
+        assert tol == AUTO_DERIVED_TOLERANCE_FLOOR_MM
+        assert tol >= DEFAULT_PAD_GRID_TOLERANCE_MM
+
+    def test_fine_pitch_intrinsic_offset_lifts_tolerance(
+        self, tmp_path: Path
+    ) -> None:
+        """Fine-pitch package with intrinsic 0.07mm L2 offset lifts threshold.
+
+        On a 0.1 mm grid the per-axis distance-to-grid is bounded by
+        0.05 mm, so to reach an L2 offset of ~0.07 mm the pads must be
+        offset in both axes (e.g. (+0.05, +0.05) -> L2 = 0.0707 mm).
+        This mirrors the real-world fleet warnings on LQFP-48, BGA-49,
+        HTSSOP-56 from issue #3057 (residual 112 warnings at
+        L2=0.057-0.071 mm) where the footprint origin sits 0.05 mm off
+        in both axes due to metric/imperial rounding of the package
+        bbox.
+        """
+        # Synthesize a 20-pad LQFP-style package with both x and y
+        # offset by 0.05 mm -> L2 = 0.0707 mm intrinsic offset.
+        # Pads at multiples of 0.5 mm (a grid divisor of 0.1) + the
+        # (0.05, 0.05) component offset.
+        pads = [
+            (str(i), 0.5 * i + 0.05, 0.05) for i in range(10)
+        ] + [
+            (str(i + 10), 0.5 * i + 0.05, 1.05) for i in range(10)
+        ]
+        text = _pcb_with_pads(
+            [
+                (
+                    "Package_QFP:LQFP-48_7x7mm_P0.5mm",
+                    "U1",
+                    100.0,
+                    100.0,
+                    0.0,
+                    pads,
+                )
+            ]
+        )
+        pcb = _write_pcb(tmp_path, text)
+        tol = compute_pad_grid_tolerance(pcb, grid_resolution=0.1)
+
+        # Threshold should sit just above the 0.0707 mm intrinsic offset
+        # (with the safety margin) so the intrinsic pads clear.
+        intrinsic_l2 = (0.05 ** 2 + 0.05 ** 2) ** 0.5
+        assert tol >= intrinsic_l2 + AUTO_DERIVED_TOLERANCE_MARGIN_MM * 0.5, (
+            f"Auto-derived tolerance {tol} too tight for "
+            f"{intrinsic_l2:.4f} mm intrinsic offset"
+        )
+        # But still well below the hard cap.
+        assert tol <= AUTO_DERIVED_TOLERANCE_HARD_CAP_MM
+
+    def test_pathological_board_capped(self, tmp_path: Path) -> None:
+        """Pathological offsets get clamped by the hard cap.
+
+        On a 0.1 mm grid the largest possible per-axis distance-to-grid
+        is 0.05 mm, but on a coarser grid (here we use 0.5 mm) pads
+        can sit further off.  Use a 0.5 mm grid resolution so the
+        per-pad offsets exceed the 0.15 mm cap and exercise the clamp.
+        """
+        # Every pad sits at +0.2 mm in both axes from the nearest 0.5
+        # mm grid point -> L2 = 0.283 mm, well above the 0.15 mm cap.
+        pads = [(str(i), i * 1.0 + 0.2, 0.2) for i in range(10)]
+        text = _pcb_with_pads(
+            [("Test:FP", "U1", 100.0, 100.0, 0.0, pads)]
+        )
+        pcb = _write_pcb(tmp_path, text)
+        tol = compute_pad_grid_tolerance(pcb, grid_resolution=0.5)
+        assert tol == AUTO_DERIVED_TOLERANCE_HARD_CAP_MM
+
+    def test_outlier_does_not_dominate(self, tmp_path: Path) -> None:
+        """A single far-outlier pad does not push the p99 above the cluster."""
+        # 99 on-grid pads + 1 wildly off pad.  The p99 sits at the on-grid
+        # bulk so the outlier is well above the auto-derived threshold and
+        # flags as a violation.
+        pads = [(str(i), 0.1 * i, 0.0) for i in range(99)]
+        pads.append(("99", 5.0 + 0.3, 0.0))  # 0.3 mm off
+        text = _pcb_with_pads(
+            [("Test:FP", "U1", 100.0, 100.0, 0.0, pads)]
+        )
+        pcb = _write_pcb(tmp_path, text)
+        tol = compute_pad_grid_tolerance(pcb, grid_resolution=0.1)
+        # p99 of 99 zeros and one 0.3 lands between them -> with margin
+        # we should be well below 0.3 mm.
+        assert tol < 0.2
+        assert tol >= AUTO_DERIVED_TOLERANCE_FLOOR_MM
+
+
+# ---------------------------------------------------------------------------
+# check_pad_grid_alignment with auto_derive_threshold=True
+
+
+class TestAutoDeriveIntegration:
+    """End-to-end: the rule should respect the auto-derived threshold."""
+
+    def test_on_grid_plus_placement_error_flags_only_error(
+        self, tmp_path: Path
+    ) -> None:
+        """On-grid pads + 1 placement error -> only the error flags.
+
+        AC: board with all pads on-grid AND a placement error pad at
+        1.0mm-class offset -> only the placement error flags.
+
+        On a 0.1 mm grid an offset of 1.0 mm wraps back to on-grid
+        (the nearest grid point is 0.0 mm away).  We instead make the
+        board's router grid 0.5 mm so the placement error of 0.4 mm
+        (well past the 0.15 mm hard cap and any plausible auto-derived
+        threshold) shows up as a violation.
+        """
+        # 100 on-grid pads -> p99 lands at on-grid (0.0 mm offset), so
+        # the auto-derived threshold stays at the floor (0.05 mm).  One
+        # additional pad sits 0.4 mm off in both axes -> L2 ~ 0.566 mm,
+        # well above the 0.15 mm cap.
+        on_grid_pads = [
+            (str(i), 0.5 * (i % 10), 0.5 * (i // 10)) for i in range(100)
+        ]
+        text = _pcb_with_pads(
+            [
+                (
+                    "Test:OnGridBulk",
+                    "U1",
+                    100.0,
+                    100.0,
+                    0.0,
+                    on_grid_pads,
+                ),
+                (
+                    "Test:RealError",
+                    "U2",
+                    # Footprint origin sits 0.4 mm off in both axes
+                    # relative to the 0.5 mm router grid.
+                    110.4,
+                    110.4,
+                    0.0,
+                    [("1", 0.0, 0.0)],
+                ),
+            ]
+        )
+        pcb = _write_pcb(tmp_path, text)
+        report = check_pad_grid_alignment(
+            pcb, grid_resolution=0.5, auto_derive_threshold=True
+        )
+        assert not report.passed
+        # Exactly one violation -- and it must be U2
+        refs = [pad.ref for pad in report.off_grid_pads]
+        assert "U2" in refs
+        assert len(report.off_grid_pads) == 1
+        # No on-grid pads should be flagged
+        assert "U1" not in refs
+
+    def test_fine_pitch_intrinsic_does_not_warn(self, tmp_path: Path) -> None:
+        """Fine-pitch package at 0.07mm intrinsic -> no warning.
+
+        AC: fine-pitch package with intrinsic 0.07mm offset -> no warning.
+        """
+        # 20-pad fine-pitch package with intrinsic 0.07 mm offset.  Under
+        # the fixed-0.05mm rule this would generate 20 warnings; under the
+        # auto-derived rule it generates none because the threshold lifts
+        # to ~0.075 mm.
+        pads = [(str(i), 0.5 * i + 0.07, 0.0) for i in range(10)] + [
+            (str(i + 10), 0.5 * i + 0.07, 1.0) for i in range(10)
+        ]
+        text = _pcb_with_pads(
+            [
+                (
+                    "Package_QFP:LQFP-48_7x7mm_P0.5mm",
+                    "U1",
+                    100.0,
+                    100.0,
+                    0.0,
+                    pads,
+                )
+            ]
+        )
+        pcb = _write_pcb(tmp_path, text)
+        report = check_pad_grid_alignment(
+            pcb, grid_resolution=0.1, auto_derive_threshold=True
+        )
+        assert report.passed, (
+            f"Fine-pitch intrinsic offset should clear auto-derived "
+            f"threshold; got {len(report.off_grid_pads)} warnings."
+        )
+
+    def test_fine_pitch_with_separate_placement_error(self, tmp_path: Path) -> None:
+        """Fine-pitch intrinsic + 0.15mm placement error -> the error still flags.
+
+        AC: a separate placement error at 0.15mm on the same board -> flags.
+        """
+        # Same fine-pitch bulk + one additional component clearly off-grid.
+        pads = [(str(i), 0.5 * i + 0.07, 0.0) for i in range(10)] + [
+            (str(i + 10), 0.5 * i + 0.07, 1.0) for i in range(10)
+        ]
+        text = _pcb_with_pads(
+            [
+                (
+                    "Package_QFP:LQFP-48_7x7mm_P0.5mm",
+                    "U1",
+                    100.0,
+                    100.0,
+                    0.0,
+                    pads,
+                ),
+                (
+                    "Test:BadPlace",
+                    "U2",
+                    # 0.15 mm in both axes -> L2 ~0.212 mm, well above any
+                    # plausible auto-derived threshold for this board.
+                    110.15,
+                    100.15,
+                    0.0,
+                    [("1", 0.0, 0.0)],
+                ),
+            ]
+        )
+        pcb = _write_pcb(tmp_path, text)
+        report = check_pad_grid_alignment(
+            pcb, grid_resolution=0.1, auto_derive_threshold=True
+        )
+        assert not report.passed
+        # The single violation must be U2 (the placement error), not any
+        # of the fine-pitch intrinsic pads.
+        assert len(report.off_grid_pads) == 1
+        assert report.off_grid_pads[0].ref == "U2"
+
+    def test_explicit_threshold_wins_over_auto_derive(
+        self, tmp_path: Path
+    ) -> None:
+        """An explicit threshold argument always wins over auto-derive."""
+        pads = [(str(i), 0.5 * i + 0.07, 0.0) for i in range(10)]
+        text = _pcb_with_pads(
+            [
+                (
+                    "Test:FP",
+                    "U1",
+                    100.0,
+                    100.0,
+                    0.0,
+                    pads,
+                )
+            ]
+        )
+        pcb = _write_pcb(tmp_path, text)
+        # With an explicit strict threshold, all 10 pads should flag.
+        report = check_pad_grid_alignment(
+            pcb,
+            grid_resolution=0.1,
+            threshold=0.001,
+            auto_derive_threshold=True,
+        )
+        assert not report.passed
+        assert len(report.off_grid_pads) == 10
+
+
+# ---------------------------------------------------------------------------
+# Backwards compatibility: auto_derive_threshold=False must reproduce
+# PR #3057's behaviour exactly.
+
+
+class TestBackwardCompat:
+    """auto_derive_threshold=False (the default) is PR #3057 behaviour."""
+
+    def test_default_is_not_auto_derive(self, tmp_path: Path) -> None:
+        """Calling without auto_derive_threshold preserves PR #3057 default."""
+        # A board with 0.04 mm intrinsic offset -- this clears the 0.05 mm
+        # default but a stricter auto-derived threshold (~0.045 mm) would
+        # not.  By calling without the flag, we should see PR #3057's pass.
+        text = _pcb_with_pads(
+            [
+                (
+                    "Test:FP",
+                    "U1",
+                    100.0,
+                    100.0,
+                    0.0,
+                    [("1", 0.04, 0.0)],
+                )
+            ]
+        )
+        pcb = _write_pcb(tmp_path, text)
+        report = check_pad_grid_alignment(pcb, grid_resolution=0.1)
+        # PR #3057 default: 0.05 mm -> 0.04 mm offset passes.
+        assert report.passed
+        assert report.threshold == DEFAULT_PAD_GRID_TOLERANCE_MM
+
+    def test_explicit_false_matches_pr_3057(self, tmp_path: Path) -> None:
+        """auto_derive_threshold=False explicitly is the PR #3057 default."""
+        text = _pcb_with_pads(
+            [
+                (
+                    "Test:FP",
+                    "U1",
+                    100.0,
+                    100.0,
+                    0.0,
+                    [("1", 0.04, 0.0)],
+                )
+            ]
+        )
+        pcb = _write_pcb(tmp_path, text)
+        report = check_pad_grid_alignment(
+            pcb, grid_resolution=0.1, auto_derive_threshold=False
+        )
+        assert report.passed
+        assert report.threshold == DEFAULT_PAD_GRID_TOLERANCE_MM
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+
+
+class TestCLIDefaults:
+    """The CLI defaults to auto_derive=True; --pad-grid-strict opts out."""
+
+    def test_pad_grid_strict_flag_exists(self) -> None:
+        """The --pad-grid-strict flag is registered with the argparser."""
+        import argparse
+
+        from kicad_tools.cli.check_cmd import main as _main  # noqa: F401
+
+        # Recreate the parser by introspecting the module: easier to
+        # smoke-test from the help text.
+        from kicad_tools.cli import check_cmd
+
+        parser = argparse.ArgumentParser()
+        # Just verify the symbols exist in the module
+        assert hasattr(check_cmd, "run_selected_checks")
+        # Sanity check: run_selected_checks accepts the two new kwargs.
+        import inspect
+
+        sig = inspect.signature(check_cmd.run_selected_checks)
+        assert "pad_grid_threshold" in sig.parameters
+        assert "pad_grid_auto_derive" in sig.parameters
+
+    def test_pad_grid_strict_via_cli(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """--pad-grid-strict reproduces the PR #3057 behaviour at the CLI.
+
+        Build a board where every pad sits at the worst-case 0.0707 mm
+        L2 offset (0.05 mm in both axes).  Under strict mode this
+        flags every pad; under auto-derive the threshold lifts above
+        the p99 of the offset distribution so all pads clear.
+        """
+        # 20 pads, all at (0.05, 0.05) intrinsic offset -> L2 = 0.0707 mm.
+        pads = [
+            (str(i), 0.5 * i + 0.05, 0.05) for i in range(10)
+        ] + [
+            (str(i + 10), 0.5 * i + 0.05, 1.05) for i in range(10)
+        ]
+        text = _pcb_with_pads(
+            [
+                (
+                    "Package_QFP:LQFP-48_7x7mm_P0.5mm",
+                    "U1",
+                    100.0,
+                    100.0,
+                    0.0,
+                    pads,
+                )
+            ]
+        )
+        pcb = _write_pcb(tmp_path, text)
+
+        from kicad_tools.cli.check_cmd import main as check_main
+
+        # Default (auto-derive): should produce 0 pad_grid warnings.
+        check_main(
+            [
+                str(pcb),
+                "--format",
+                "summary",
+                "--only",
+                "pad_grid",
+            ]
+        )
+        default_output = capsys.readouterr().out
+        assert "DRC PASSED" in default_output, (
+            f"Auto-derive default should pass for intrinsic-offset board; "
+            f"got: {default_output}"
+        )
+
+        # --pad-grid-strict: should produce pad_grid warnings.
+        check_main(
+            [
+                str(pcb),
+                "--format",
+                "summary",
+                "--only",
+                "pad_grid",
+                "--pad-grid-strict",
+            ]
+        )
+        strict_output = capsys.readouterr().out
+        # Strict mode flagged at least one pad.
+        assert "pad_grid" in strict_output, (
+            f"Strict mode should flag intrinsic-offset board; "
+            f"got: {strict_output}"
+        )
+
+    def test_pad_grid_tolerance_explicit_via_cli(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """--pad-grid-tolerance overrides everything else."""
+        text = _pcb_with_pads(
+            [
+                (
+                    "Test:FP",
+                    "U1",
+                    100.0,
+                    100.0,
+                    0.0,
+                    [("1", 0.04, 0.0)],  # 0.04 mm offset
+                )
+            ]
+        )
+        pcb = _write_pcb(tmp_path, text)
+
+        from kicad_tools.cli.check_cmd import main as check_main
+
+        # Tight 0.01 mm threshold -> flag.
+        rc = check_main(
+            [
+                str(pcb),
+                "--format",
+                "summary",
+                "--only",
+                "pad_grid",
+                "--pad-grid-tolerance",
+                "0.01",
+            ]
+        )
+        tight_output = capsys.readouterr().out
+        assert "pad_grid" in tight_output
+        # rc 0 because warning != error
+        assert rc == 0
+
+        # Loose 0.1 mm threshold -> pass.
+        check_main(
+            [
+                str(pcb),
+                "--format",
+                "summary",
+                "--only",
+                "pad_grid",
+                "--pad-grid-tolerance",
+                "0.1",
+            ]
+        )
+        loose_output = capsys.readouterr().out
+        # Output should show no violations.
+        assert "no violations" in loose_output.lower() or "0" in loose_output


### PR DESCRIPTION
## Summary

Closes #3061.

PR #3057 raised the default `pad_grid` tolerance from 0.01mm to a fixed 0.05mm constant, dropping fleet-wide warnings 318 → 112 (~65%).  The residual 112 warnings came from fine-pitch packages (LQFP-48, BGA-49, HTSSOP-56) whose pad lattice naturally sits 0.057-0.071mm off the 0.1mm router grid — just past the new threshold.  Raising the constant further would risk false-negatives on real placement errors in the 0.06-0.075mm band.

This PR derives the threshold per-board from each board's pad-offset histogram:

```
threshold = clamp(p99(offsets) + 0.005mm, floor=0.05mm, cap=0.15mm)
```

- A board with only metric-on-metric footprints lands at the 0.05mm floor (no regression from PR #3057).
- A board with fine-pitch QFN at 0.07mm intrinsic L2 offset gets a threshold ~0.08mm so those pads clear.
- Any pad offset above 0.15mm hard cap still flags — the cap matches the typical minimum routed trace clearance, so anything worse than that is a routing problem regardless of grid alignment.

## Fleet result

After this PR, with the new CLI default (auto-derive):

| Board | auto-derive | strict (0.05mm) |
|-------|-------------|------------------|
| 01-voltage-divider | 0 | 0 |
| 02-charlieplex-led | 0 | 0 |
| 03-usb-joystick | 0 | 0 |
| 04-stm32-devboard | 0 | 48 |
| 05-bldc-motor-controller | 0 | 56 |
| 06-diffpair-test | 0 | 4 |
| 07-matchgroup-test | 0 | 4 |
| **Total** | **0** | **112** |

The `strict=112` column matches the PR #3057 residual, confirming `--pad-grid-strict` preserves the previous behaviour exactly.  The `auto=0` column is well below the issue's ≤35 target.

Per-board auto-derived tolerances (`kct check` default):

| Board | derived tolerance |
|-------|--------------------|
| 01 | 50 µm |
| 02 | 50 µm |
| 03 | 55 µm |
| 04 | 67.5 µm |
| 05 | 75.7 µm |
| 06 | 61.6 µm |
| 07 | 61.6 µm |

## API surface

- `compute_pad_grid_tolerance(pcb_path, ...)` — standalone histogram analyser.
- `check_pad_grid_alignment(..., auto_derive_threshold=False)` — new opt-in flag (defaults to False to preserve the Python API).
- `DRCChecker.check_pad_grid_alignment(..., auto_derive_threshold=False)` — same.
- `kct check` CLI: auto-derive is the new default; `--pad-grid-strict` and `--pad-grid-tolerance MM` opt out.
- New module constants: `AUTO_DERIVED_TOLERANCE_{FLOOR,HARD_CAP,MARGIN}_MM`, `AUTO_DERIVED_TOLERANCE_PERCENTILE`.

## Backward compatibility

- The Python API is unchanged for callers that don't set the new flag: default behaviour is still PR #3057 (fixed 0.05mm).
- All 16 pre-existing tests in `tests/test_pad_grid_preflight.py` still pass — including PR #3057's `TestStockLibraryFriendlyDefault`.
- `DEFAULT_PAD_GRID_TOLERANCE_MM = 0.05` constant is unchanged.
- `tests/test_check_cmd_coverage.py` (the dispatcher invariant test from #3046) still passes.

## Test plan

- [x] `uv run pytest tests/test_pad_grid_preflight.py tests/test_pad_grid_auto_derive.py -q --no-cov` — 30/30 pass.
- [x] `uv run pytest tests/test_check_cmd_coverage.py tests/test_validate.py tests/test_drc_category.py tests/test_drc.py tests/test_drc_summary.py tests/test_drc_report_formats.py tests/test_validate_via_in_pad.py -q --no-cov` — 340/340 pass (5 skipped, unrelated).
- [x] Fleet sweep: `kct check --mfr jlcpcb <board>` and `kct check --mfr jlcpcb <board> --pad-grid-strict` — auto = 0 fleet-wide; strict = 112 matches PR #3057 residual.
- [x] CLI smoke: `--pad-grid-strict`, `--pad-grid-tolerance MM`, and default auto-derive all routed through the wrapped argparser.

## Out of scope

- Replacing PR #3057's 0.05mm constant (kept as the fallback for `auto_derive_threshold=False` and `--pad-grid-strict`).
- Other DRC rules.
- Changing the grid_resolution itself — this PR tunes the tolerance, not the grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)