### PR TITLE
feat(escape): re-introduce --strict-in-pad-clearance flag with test coverage (closes #3062)

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -302,6 +302,16 @@ def run_route_command(args) -> int:
         sub_argv.extend(["--seed", str(args.seed)])
     if getattr(args, "strict", False):
         sub_argv.append("--strict")
+    # Issue #3033 / #3062: Forward --strict-in-pad-clearance opt-in to the
+    # inner route command.  The inner main() sets the
+    # KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE env var so EscapeRouter consumes
+    # it on lazy construction.  Outer parser uses the
+    # ``route_strict_in_pad_clearance`` dest, inner uses
+    # ``strict_in_pad_clearance``; check both for forward-compat.
+    if getattr(args, "route_strict_in_pad_clearance", False) or getattr(
+        args, "strict_in_pad_clearance", False
+    ):
+        sub_argv.append("--strict-in-pad-clearance")
     # Issue #2464: Forward differential pair routing flags
     if getattr(args, "differential_pairs", False):
         sub_argv.append("--differential-pairs")

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2636,6 +2636,19 @@ def _add_route_parser(subparsers) -> None:
         ),
     )
     route_parser.add_argument(
+        "--strict-in-pad-clearance",
+        action="store_true",
+        dest="route_strict_in_pad_clearance",
+        help=(
+            "Issue #3033 / #3062: refuse to commit in-pad rescue vias that "
+            "would clip a neighbouring foreign-net pad on a fine-pitch "
+            "QFP/SSOP.  Forwarded to the inner 'kct route' command, which "
+            "stamps KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE=1 so EscapeRouter "
+            "inherits the opt-in.  Default off preserves the legacy "
+            "'proceed anyway' behaviour bit-for-bit."
+        ),
+    )
+    route_parser.add_argument(
         "--differential-pairs",
         action="store_true",
         help=(

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -5356,6 +5356,21 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--strict-in-pad-clearance",
+        action="store_true",
+        dest="strict_in_pad_clearance",
+        help=(
+            "Issue #3033 / #3062: refuse to commit an in-pad rescue via that "
+            "would clip a neighbouring foreign-net pad on a fine-pitch "
+            "QFP/SSOP (the 'proceed anyway, defer DRC to the user' branch "
+            "from PR #2945).  Sets KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE=1 so "
+            "the lazily-constructed EscapeRouter inside the negotiated/two-"
+            "phase pipelines picks up the flag without each call site needing "
+            "an explicit pass-through.  Default off preserves the legacy "
+            "bit-for-bit behaviour."
+        ),
+    )
+    parser.add_argument(
         "--show-congestion",
         action="store_true",
         help=(
@@ -5366,6 +5381,16 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     args = parser.parse_args(argv)
+
+    # Issue #3033 / #3062: When --strict-in-pad-clearance is set, stamp the
+    # env var so EscapeRouter (lazily constructed several layers below the
+    # CLI) reads the same opt-in state.  See escape.py's __init__ for the
+    # env-var read site.  Defaults to "0" so absence preserves the legacy
+    # "proceed anyway" behaviour bit-for-bit.
+    import os as _os
+
+    if getattr(args, "strict_in_pad_clearance", False):
+        _os.environ["KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE"] = "1"
 
     # Issue #2802: Stamp a single monotonic wall-clock deadline derived from
     # ``--timeout`` onto ``args`` so every orchestration site (layer-escalation

--- a/src/kicad_tools/router/escape.py
+++ b/src/kicad_tools/router/escape.py
@@ -901,6 +901,29 @@ class EscapeRouter:
             self._mfr_limits is not None and self._mfr_limits.via_in_pad_supported
         )
 
+        # Issue #3033 / #3062: When True, the in-pad rescue path
+        # (``_try_in_pad_escape``) returns None instead of placing a
+        # via that would clip a neighbouring foreign-net pad (the
+        # "proceed anyway, defer DRC to the user" branch from PR #2945).
+        # Defaults to False so legacy callers preserve the historical
+        # behaviour exactly; opt-in callers (e.g. the QFP-alternating
+        # dispatcher) flip this to True when they prefer surfacing the
+        # deferral over committing a DRC violation that cascades into
+        # adjacent-pin routing failures (board-04 OSC_OUT clipping
+        # NRST/U2.8 was the original trigger).
+        #
+        # CLI knob: the route command's ``--strict-in-pad-clearance``
+        # flag sets ``KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE=1`` in the
+        # subprocess env before invoking the router; reading it here
+        # threads the user opt-in through to the lazily-constructed
+        # EscapeRouter without touching every call site between
+        # ``route_cmd`` and ``Autorouter._escape``.
+        import os as _os
+
+        self.strict_in_pad_clearance: bool = (
+            _os.environ.get("KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE", "0") == "1"
+        )
+
         # Issue #2881: Counter for "would-have-rescued" events -- bumped
         # every time the escape router would have invoked
         # ``_try_in_pad_escape`` for a fine-pitch QFP/SSOP pin but the
@@ -2215,12 +2238,19 @@ class EscapeRouter:
                         extra_pads=self._other_footprint_pads(package, pads),
                     )
                     if violation or pin_boxed:
+                        # Issue #3033 / #3062: forward the EscapeRouter-level
+                        # strict flag so the dispatcher inherits the "defer
+                        # rather than commit a violating via" policy.
+                        # Defaults to False on the EscapeRouter constructor,
+                        # preserving legacy behaviour exactly for every
+                        # existing caller.
                         in_pad_route = self._try_in_pad_escape(
                             pad=pad,
                             direction=direction,
                             effective_clearance=effective_clearance,
                             escape_width=escape_width,
                             package=package,
+                            skip_on_clearance_violation=self.strict_in_pad_clearance,
                         )
                         if in_pad_route is not None:
                             if pin_boxed and not violation:
@@ -2876,12 +2906,16 @@ class EscapeRouter:
                     # before deferring to the main router.  Only enabled
                     # for manufacturers that support via-in-pad processing
                     # (e.g. ``jlcpcb-tier1`` Capability+, PCBWay).
+                    # Issue #3033 / #3062: forward the EscapeRouter strict
+                    # flag so SSOP/TSSOP callers inherit the same defer-vs-
+                    # commit-violation policy as the QFP dispatcher.
                     in_pad_route = self._try_in_pad_escape(
                         pad=pad,
                         direction=direction,
                         effective_clearance=effective_clearance,
                         escape_width=escape_width,
                         package=package,
+                        skip_on_clearance_violation=self.strict_in_pad_clearance,
                     )
                     if in_pad_route is not None:
                         escapes.append(in_pad_route)
@@ -2960,12 +2994,17 @@ class EscapeRouter:
                 ):
                     # Issue #2605: Attempt in-pad via escape as a fallback
                     # before deferring to the main router.
+                    # Issue #3033 / #3062: forward the strict flag here too
+                    # so the even-pin branch inherits the same defer-vs-
+                    # commit-violation policy as the odd-pin/QFP branches
+                    # (curator-noted asymmetry from PR #3038 fixed).
                     in_pad_route = self._try_in_pad_escape(
                         pad=pad,
                         direction=direction,
                         effective_clearance=effective_clearance,
                         escape_width=escape_width,
                         package=package,
+                        skip_on_clearance_violation=self.strict_in_pad_clearance,
                     )
                     if in_pad_route is not None:
                         escapes.append(in_pad_route)
@@ -4385,6 +4424,7 @@ class EscapeRouter:
         effective_clearance: float,
         escape_width: float,
         package: PackageInfo | None = None,
+        skip_on_clearance_violation: bool = False,
     ) -> EscapeRoute | None:
         """Attempt an in-pad via escape for a fine-pitch SSOP/TSSOP pad.
 
@@ -4456,11 +4496,19 @@ class EscapeRouter:
                 dead-centre fallback.  When ``None`` (legacy call sites),
                 only the original geometry preconditions run and the
                 via is placed dead-centre without the neighbor check.
+            skip_on_clearance_violation: When True (default False),
+                return ``None`` instead of placing a violating via when
+                the long-axis nudge fails AND dead-centre would clip a
+                neighbouring foreign-net pad.  Opt-in flag for callers
+                that prefer surfacing the deferral as an explicit gap
+                over committing a DRC violation that cascades into
+                adjacent-pin routing failures.  Issue #3033 / #3062.
 
         Returns:
             An ``EscapeRoute`` with the in-pad via and inner-layer segment,
-            or ``None`` if in-pad escape is unavailable or geometrically
-            infeasible.
+            or ``None`` if in-pad escape is unavailable, geometrically
+            infeasible, or (when ``skip_on_clearance_violation=True``)
+            the rescue would introduce a foreign-pad clearance violation.
         """
         if not self.via_in_pad_supported:
             return None
@@ -4539,6 +4587,24 @@ class EscapeRouter:
                 other_pads=other_pads,
                 same_net=pad.net,
             ):
+                # Issue #3033 / #3062: ``skip_on_clearance_violation``
+                # switches the "proceed anyway" branch to "return None"
+                # so the caller can surface the rescue failure as an
+                # explicit deferral instead of producing downstream DRC
+                # noise that cascades into NRST/GND corner-pad routing
+                # failures (board-04 LQFP-48 OSC_OUT cluster).
+                if skip_on_clearance_violation:
+                    logger.info(
+                        "In-pad rescue DEFERRED for pad %s (ref=%s pin=%s) at "
+                        "(%.3f, %.3f): dead-centre clips neighbour pad on %s "
+                        "and long-axis nudge cannot rescue (short-axis "
+                        "violation).  Returning None per Issue #3033 strict "
+                        "mode so the caller can surface the deferral instead "
+                        "of committing a DRC violation.",
+                        pad.net_name, pad.ref, pad.pin,
+                        via_x, via_y, pad.ref,
+                    )
+                    return None
                 logger.warning(
                     "In-pad rescue for pad %s (ref=%s pin=%s) at (%.3f, %.3f) "
                     "violates clearance to a neighboring foreign-net pad on "

--- a/tests/fixtures/strict_in_pad_min.py
+++ b/tests/fixtures/strict_in_pad_min.py
@@ -1,0 +1,147 @@
+"""Minimal synthetic fixture for ``--strict-in-pad-clearance`` tests.
+
+Issue #3062: provides a programmatic ``PackageInfo`` plus a foreign-net
+neighbour pad placed close enough that an in-pad dead-centre via on the
+primary pad clips its neighbour by ~0.05 mm.  This is the failure mode
+the strict-mode flag (Issue #3033) exists to defer.
+
+The fixture is intentionally minimal (single primary pad + one
+neighbour) and NOT derived from board 04 -- the OSC_OUT-cluster
+lateral-recovery dependency that makes board 04 a real customer of the
+flag belongs to sub-B (#3063), not to this tests-only sub-issue.
+
+Geometry chosen so that:
+
+* Primary pad: 0.3 x 1.5 mm (LQFP-48-shaped: short axis along the row).
+* Foreign neighbour: identical shape, offset along the short axis at
+  0.5 mm pitch.  Centre-to-centre = 0.50 mm.
+* Via:           0.6 mm diameter dead-centre on the primary pad.
+* Clearance:    0.15 mm (board-04 production value).
+
+Distance from via centre to nearest neighbour-pad edge:
+
+    pitch - via_radius - (neighbour_short / 2)
+  = 0.50 - 0.30        - 0.15
+  = 0.05 mm     -- violates 0.15 mm by 0.10 mm.
+
+The long-axis nudge cannot rescue this because the violation is on the
+SHORT axis perpendicular to the nudge direction.  ``_try_in_pad_escape``
+must therefore either return None (strict=True) or commit the violating
+via with a warning (strict=False, legacy).
+"""
+
+from __future__ import annotations
+
+from kicad_tools.router.escape import PackageInfo, PackageType
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules
+
+# Constants pinned to the geometric reasoning above.  Changing any of
+# these without re-deriving the violation magnitude will silently
+# weaken the test.
+PAD_SHORT: float = 0.30
+PAD_LONG: float = 1.50
+PITCH: float = 0.50  # centre-to-centre along the short axis
+CLEARANCE: float = 0.15
+VIA_DRILL: float = 0.30
+VIA_DIAMETER: float = 0.60
+TRACE_WIDTH: float = 0.20
+GRID_RES: float = 0.05
+
+
+def make_violating_pair(
+    ref: str = "U1",
+    primary_net: int = 1,
+    neighbour_net: int = 2,
+) -> tuple[Pad, Pad]:
+    """Return ``(primary, neighbour)`` -- two LQFP-shape pads 0.50 mm apart.
+
+    The primary pad sits at ``(0.0, 0.0)`` on F.Cu; the neighbour is
+    offset +PITCH along the short axis (Y).  Both pads have unique
+    nets so the escape router treats the neighbour as foreign.
+    """
+    primary = Pad(
+        x=0.0,
+        y=0.0,
+        width=PAD_LONG,  # long axis along X
+        height=PAD_SHORT,  # short axis along Y
+        net=primary_net,
+        net_name=f"NET{primary_net}",
+        ref=ref,
+        pin="1",
+        layer=Layer.F_CU,
+    )
+    neighbour = Pad(
+        x=0.0,
+        y=PITCH,
+        width=PAD_LONG,
+        height=PAD_SHORT,
+        net=neighbour_net,
+        net_name=f"NET{neighbour_net}",
+        ref=ref,
+        pin="2",
+        layer=Layer.F_CU,
+    )
+    return primary, neighbour
+
+
+def make_package(
+    ref: str = "U1",
+    primary_net: int = 1,
+    neighbour_net: int = 2,
+) -> PackageInfo:
+    """Build a ``PackageInfo`` containing just the violating pair.
+
+    The package_type is set to ``QFP`` and ``pin_pitch`` to the actual
+    0.50 mm so callers exercising the QFP-alternating dispatcher's
+    pre-conditions see the same classification as a real LQFP-48 pad.
+    """
+    primary, neighbour = make_violating_pair(
+        ref=ref,
+        primary_net=primary_net,
+        neighbour_net=neighbour_net,
+    )
+    pads = [primary, neighbour]
+    xs = [p.x for p in pads]
+    ys = [p.y for p in pads]
+    return PackageInfo(
+        ref=ref,
+        package_type=PackageType.QFP,
+        center=(sum(xs) / len(xs), sum(ys) / len(ys)),
+        pads=pads,
+        pin_count=len(pads),
+        pin_pitch=PITCH,
+        bounding_box=(min(xs), min(ys), max(xs), max(ys)),
+        is_dense=True,
+    )
+
+
+def make_rules(manufacturer: str | None = "jlcpcb-tier1") -> DesignRules:
+    """Build DesignRules with via-in-pad-capable manufacturer.
+
+    The default is ``jlcpcb-tier1`` (Capability+) so
+    ``via_in_pad_supported`` evaluates to True; pass ``None`` or
+    ``"jlcpcb"`` to exercise the unsupported branch.
+    """
+    return DesignRules(
+        trace_width=TRACE_WIDTH,
+        trace_clearance=CLEARANCE,
+        via_drill=VIA_DRILL,
+        via_diameter=VIA_DIAMETER,
+        grid_resolution=GRID_RES,
+        manufacturer=manufacturer,
+    )
+
+
+def make_grid(rules: DesignRules) -> RoutingGrid:
+    """Build a small 4-layer routing grid centred on the violating pair."""
+    return RoutingGrid(
+        width=10.0,
+        height=10.0,
+        rules=rules,
+        origin_x=-5.0,
+        origin_y=-5.0,
+        layer_stack=LayerStack.four_layer_sig_sig_gnd_pwr(),
+    )

--- a/tests/test_cli_parser_drift.py
+++ b/tests/test_cli_parser_drift.py
@@ -330,3 +330,90 @@ def test_max_search_iterations_is_on_both_parsers():
         "--max-search-iterations is missing from the outer parser.py route "
         "subparser (this would regress #2610)"
     )
+
+
+def test_strict_in_pad_clearance_is_on_both_parsers_and_stamps_env():
+    """Direct regression test for #3033 / #3062.
+
+    ``--strict-in-pad-clearance`` is declared on BOTH the outer and
+    inner parsers and forwarded through the shim verbatim.  When set
+    on the inner parser, ``route_cmd.main`` stamps the
+    ``KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE=1`` env var so the
+    lazily-constructed ``EscapeRouter`` reads the opt-in without each
+    intermediate call site needing an explicit pass-through.
+
+    This test pins three invariants so the flag never drifts again:
+
+    1. The flag appears on the inner ``route_cmd.py`` parser.
+    2. The flag appears on the outer ``parser.py`` route subparser.
+    3. Running the inner parser with the flag stamps the env var to
+       ``"1"`` and the absence of the flag leaves the env var unset.
+    """
+    inner = _inner_route_parser_flags()
+    outer = _outer_route_parser_flags()
+
+    assert "--strict-in-pad-clearance" in inner, (
+        "--strict-in-pad-clearance is missing from the inner route_cmd.py "
+        "parser (this would regress #3033/#3062 -- the flag must be present "
+        "on the inner parser because that is where the env-var stamp "
+        "happens)"
+    )
+    assert "--strict-in-pad-clearance" in outer, (
+        "--strict-in-pad-clearance is missing from the outer parser.py "
+        "route subparser (this would regress #3033/#3062 -- the outer flag "
+        "is the user-facing 'kct route --strict-in-pad-clearance' surface)"
+    )
+
+    # Verify the inner parser stamps the env var when the flag is set.
+    # We intercept just before any routing work happens by mocking out
+    # the heavyweight downstream functions; the parse-args + env-stamp
+    # block runs first so we can observe it.
+    import os
+    from unittest.mock import patch
+
+    # Stage 1: flag set -> env var becomes "1".
+    saved = os.environ.pop("KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE", None)
+    try:
+        # We invoke the inner parser via the shim's sub_argv construction
+        # rather than executing the full routing pipeline.  Mock the
+        # inner main's exit point so we don't actually route.
+        from kicad_tools.cli import route_cmd
+
+        # Patch the function that runs after env-stamping but well
+        # before any real work.  ``_set_wall_clock_deadline`` is the
+        # very next line after the env-stamp block.
+        with patch.object(
+            route_cmd,
+            "_set_wall_clock_deadline",
+            side_effect=SystemExit(0),
+        ):
+            with pytest.raises(SystemExit):
+                route_cmd.main(["dummy.kicad_pcb", "--strict-in-pad-clearance"])
+        assert os.environ.get("KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE") == "1", (
+            "Inner route_cmd.main must stamp "
+            "KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE=1 when "
+            "--strict-in-pad-clearance is passed; got "
+            f"{os.environ.get('KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE')!r}"
+        )
+
+        # Stage 2: flag absent -> env var stays unset (we cleared it
+        # above; running without the flag should NOT set it).
+        del os.environ["KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE"]
+        with patch.object(
+            route_cmd,
+            "_set_wall_clock_deadline",
+            side_effect=SystemExit(0),
+        ):
+            with pytest.raises(SystemExit):
+                route_cmd.main(["dummy.kicad_pcb"])
+        assert "KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE" not in os.environ, (
+            "Inner route_cmd.main must NOT stamp the env var when the "
+            "flag is absent; legacy bit-for-bit behaviour requires the "
+            "env var be cleared in this code path"
+        )
+    finally:
+        # Restore env to original state.
+        if saved is None:
+            os.environ.pop("KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE", None)
+        else:
+            os.environ["KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE"] = saved

--- a/tests/test_escape_strict_in_pad_clearance.py
+++ b/tests/test_escape_strict_in_pad_clearance.py
@@ -1,0 +1,316 @@
+"""Tests for the ``--strict-in-pad-clearance`` opt-in (Issues #3033, #3062).
+
+This test pins three behaviours on ``EscapeRouter._try_in_pad_escape``:
+
+1. **Default (strict=False)**: when the dead-centre in-pad via clips a
+   foreign-net neighbour pad AND the long-axis nudge cannot rescue
+   (short-axis violation), the helper logs a warning and commits the
+   violating via -- preserving the historical "proceed anyway, defer
+   DRC to the user" branch introduced by PR #2945.
+
+2. **Constructor-level strict=True**: same input geometry, but the
+   helper returns ``None`` and emits an INFO log line describing the
+   deferral.  This is the path the QFP-alternating dispatcher,
+   SSOP/TSSOP dispatcher, and even-pin branch all consume via
+   ``self.strict_in_pad_clearance`` (re-introduced from the dropped
+   commit on PR #3038's branch).
+
+3. **Env-var KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE=1**: the CLI knob.
+   When the env var is set, ``EscapeRouter.__init__`` flips
+   ``self.strict_in_pad_clearance`` to True without any constructor
+   argument changes -- this is how the ``kct route
+   --strict-in-pad-clearance`` flag threads the opt-in through to
+   the lazily-constructed EscapeRouter without touching every call
+   site between ``route_cmd`` and ``Autorouter._escape``.
+
+Out-of-scope (covered by sub-B #3063):
+- Enabling the flag on any in-tree board.
+- The lateral-recovery main-router work that would let board 04 use
+  the flag without dropping completion from 11/12 to 3/12 nets.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import pytest
+
+from kicad_tools.router.escape import EscapeDirection, EscapeRouter
+from tests.fixtures.strict_in_pad_min import (
+    CLEARANCE,
+    make_grid,
+    make_package,
+    make_rules,
+    make_violating_pair,
+)
+
+# ----------------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------------
+
+
+def _build_router(manufacturer: str | None = "jlcpcb-tier1") -> EscapeRouter:
+    """Build an EscapeRouter pinned to the violating-pair geometry."""
+    rules = make_rules(manufacturer=manufacturer)
+    grid = make_grid(rules)
+    return EscapeRouter(grid, rules)
+
+
+@pytest.fixture(autouse=True)
+def _clear_env_strict(monkeypatch):
+    """Clear the env var before each test so the default state is
+    deterministic; tests that need it set use monkeypatch to set it
+    explicitly.
+    """
+    monkeypatch.delenv("KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE", raising=False)
+    yield
+
+
+# ----------------------------------------------------------------------------
+# Default behaviour (strict=False): legacy "proceed anyway"
+# ----------------------------------------------------------------------------
+
+
+class TestStrictDefaultProceedsAnyway:
+    """Pre-#3033 behaviour: violating via gets committed with a warning."""
+
+    def test_default_constructor_attribute_is_false(self):
+        """When no env var is set and no opt-in flag is passed, the
+        EscapeRouter's ``strict_in_pad_clearance`` attribute is False
+        and the legacy "proceed anyway" branch is selected.
+        """
+        router = _build_router()
+        assert router.strict_in_pad_clearance is False, (
+            "Default EscapeRouter must have strict_in_pad_clearance=False "
+            "to preserve legacy bit-for-bit behaviour"
+        )
+
+    def test_default_commits_violating_via_with_warning(self, caplog):
+        """With strict=False (default), ``_try_in_pad_escape`` returns
+        an EscapeRoute with the violating via and logs a warning.
+        """
+        router = _build_router()
+        # Verify the manufacturer supports via-in-pad (precondition for
+        # the helper to do anything other than early-return None).
+        assert router.via_in_pad_supported, (
+            "Test fixture must use a manufacturer with via_in_pad_supported"
+        )
+
+        package = make_package()
+        primary = package.pads[0]
+
+        # Invoke the helper with the same defaults the QFP dispatcher
+        # uses; explicitly NOT passing skip_on_clearance_violation so
+        # we exercise the default (False) path.
+        with caplog.at_level(logging.WARNING, logger="kicad_tools.router.escape"):
+            route = router._try_in_pad_escape(
+                pad=primary,
+                direction=EscapeDirection.SOUTH,
+                effective_clearance=CLEARANCE,
+                escape_width=0.2,
+                package=package,
+            )
+
+        assert route is not None, (
+            "Default (strict=False) path must commit the violating via, "
+            "not defer; got None which implies the strict branch fired"
+        )
+        assert route.via is not None
+        # Via lands dead-centre on the primary pad.
+        assert abs(route.via.x - primary.x) < 1e-3
+        assert abs(route.via.y - primary.y) < 1e-3
+        # The structured warning describing the clearance violation
+        # must appear in the log.
+        warning_records = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "violates clearance to a neighboring foreign-net pad" in r.message
+        ]
+        assert warning_records, (
+            "Expected the in-pad clearance-violation WARNING from _try_in_pad_escape; saw none"
+        )
+
+
+# ----------------------------------------------------------------------------
+# Strict=True via constructor-attribute opt-in
+# ----------------------------------------------------------------------------
+
+
+class TestStrictTrueDefers:
+    """With ``strict_in_pad_clearance=True`` set after construction,
+    the helper returns None and logs an INFO line instead of
+    committing the violation.
+    """
+
+    def test_strict_true_returns_none_and_logs_info(self, caplog):
+        router = _build_router()
+        # Flip the constructor-set attribute to True to simulate the
+        # env-var path that the CLI flag stamps (the equivalent
+        # behaviour without going through the env var).
+        router.strict_in_pad_clearance = True
+        assert router.via_in_pad_supported
+
+        package = make_package()
+        primary = package.pads[0]
+
+        with caplog.at_level(logging.INFO, logger="kicad_tools.router.escape"):
+            route = router._try_in_pad_escape(
+                pad=primary,
+                direction=EscapeDirection.SOUTH,
+                effective_clearance=CLEARANCE,
+                escape_width=0.2,
+                package=package,
+                # Pass through the dispatcher contract: dispatcher reads
+                # self.strict_in_pad_clearance and forwards it as kwarg.
+                skip_on_clearance_violation=router.strict_in_pad_clearance,
+            )
+
+        assert route is None, (
+            "strict=True path must defer (return None) instead of committing the violating via"
+        )
+        info_records = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.INFO and "In-pad rescue DEFERRED" in r.message
+        ]
+        assert info_records, (
+            "Expected the 'In-pad rescue DEFERRED' INFO log line from the "
+            "strict branch; saw none.  All records:\n  "
+            + "\n  ".join(f"{r.levelname}: {r.message}" for r in caplog.records)
+        )
+
+        # Also verify no warning about committed-anyway clearance violation
+        # was emitted in this branch (the strict branch returns BEFORE the
+        # legacy warning).
+        warning_records = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "violates clearance to a neighboring foreign-net pad" in r.message
+        ]
+        assert not warning_records, (
+            "strict=True must NOT emit the legacy proceed-anyway warning; "
+            "got " + str([r.message for r in warning_records])
+        )
+
+    def test_strict_true_kwarg_overrides_default(self, caplog):
+        """A False-default EscapeRouter still honours the kwarg when a
+        caller passes ``skip_on_clearance_violation=True`` directly --
+        this is the contract the dispatcher relies on.
+        """
+        router = _build_router()
+        assert router.strict_in_pad_clearance is False  # default
+
+        package = make_package()
+        primary = package.pads[0]
+
+        with caplog.at_level(logging.INFO, logger="kicad_tools.router.escape"):
+            route = router._try_in_pad_escape(
+                pad=primary,
+                direction=EscapeDirection.SOUTH,
+                effective_clearance=CLEARANCE,
+                escape_width=0.2,
+                package=package,
+                skip_on_clearance_violation=True,  # explicit override
+            )
+
+        assert route is None
+        assert any("In-pad rescue DEFERRED" in r.message for r in caplog.records)
+
+
+# ----------------------------------------------------------------------------
+# Env var KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE=1
+# ----------------------------------------------------------------------------
+
+
+class TestStrictEnvVar:
+    """The env var flips the default-state attribute at construction
+    time -- this is the CLI flag's transport layer.
+    """
+
+    def test_env_var_flips_constructor_attribute(self, monkeypatch):
+        """With KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE=1 in the env,
+        a fresh EscapeRouter has ``strict_in_pad_clearance=True``.
+        """
+        monkeypatch.setenv("KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE", "1")
+        router = _build_router()
+        assert router.strict_in_pad_clearance is True, (
+            "Env var KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE=1 must flip the "
+            "constructor-set strict_in_pad_clearance to True"
+        )
+
+    def test_env_var_off_keeps_attribute_false(self, monkeypatch):
+        """With KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE=0 (the explicit-off
+        spelling), the attribute remains False (default behaviour).
+        """
+        monkeypatch.setenv("KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE", "0")
+        router = _build_router()
+        assert router.strict_in_pad_clearance is False
+
+    def test_env_var_unset_keeps_attribute_false(self):
+        """With the env var unset (handled by the autouse fixture),
+        the attribute is False.  Pin the absence-of-env-var path
+        explicitly to guard against a regression in the os.environ.get
+        default-value argument.
+        """
+        assert "KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE" not in os.environ
+        router = _build_router()
+        assert router.strict_in_pad_clearance is False
+
+    def test_env_var_end_to_end_deferral(self, caplog, monkeypatch):
+        """End-to-end with env var set: constructor reads the env,
+        attribute becomes True, dispatcher reads the attribute and
+        forwards it as kwarg, helper defers with INFO log.
+        """
+        monkeypatch.setenv("KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE", "1")
+        router = _build_router()
+        assert router.strict_in_pad_clearance is True
+
+        package = make_package()
+        primary = package.pads[0]
+
+        with caplog.at_level(logging.INFO, logger="kicad_tools.router.escape"):
+            route = router._try_in_pad_escape(
+                pad=primary,
+                direction=EscapeDirection.SOUTH,
+                effective_clearance=CLEARANCE,
+                escape_width=0.2,
+                package=package,
+                # Dispatcher reads self.strict_in_pad_clearance and
+                # forwards it; this models the call shape from
+                # _escape_qfp_alternating.
+                skip_on_clearance_violation=router.strict_in_pad_clearance,
+            )
+
+        assert route is None
+        assert any("In-pad rescue DEFERRED" in r.message for r in caplog.records), (
+            "End-to-end env-var path must reach the DEFERRED INFO log; "
+            "saw " + str([r.message for r in caplog.records])
+        )
+
+
+# ----------------------------------------------------------------------------
+# Sanity: the violating-pair fixture is actually a violation
+# ----------------------------------------------------------------------------
+
+
+class TestFixtureSanity:
+    """Pin the fixture's geometric pre-condition so a future refactor
+    that accidentally weakens the violation (e.g. widens the pitch)
+    fails loudly instead of silently masking the strict-mode tests.
+    """
+
+    def test_violating_pair_actually_violates(self):
+        """The dead-centre via on primary clips neighbour by 0.10 mm."""
+        primary, neighbour = make_violating_pair()
+        # The via is 0.60 mm in diameter dead-centre on primary;
+        # neighbour's nearest edge is at primary.y + PITCH - neighbour_short/2.
+        via_radius = 0.30
+        primary_to_neighbour_edge = (neighbour.y - primary.y) - (neighbour.height / 2)
+        gap = primary_to_neighbour_edge - via_radius
+        assert gap < CLEARANCE, (
+            f"Fixture must violate the {CLEARANCE} mm clearance; got "
+            f"gap={gap:.3f} mm (deficit {CLEARANCE - gap:.3f} mm)"
+        )


### PR DESCRIPTION
## Summary

Sub-A of #3048 (which itself split #3033's earlier scope per the curator's recommendation).  PR #3038 dropped the `--strict-in-pad-clearance` source surface entirely during the judge-feedback scope-split.  This PR re-introduces the **minimal** source surface needed for the flag to exist, plus the tests-only deliverable that #3062 specifies.  The lateral-recovery main-router work that would make board 04 a real customer remains in sub-B (#3063).

## What this PR ships

### Source surface (re-introduced from the dropped commit on PR #3038's branch)

- `EscapeRouter.__init__` reads `KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE` env var and stores it as `self.strict_in_pad_clearance` (default False).
- `_try_in_pad_escape` gains a `skip_on_clearance_violation` kwarg.  When True AND the dead-centre via clips a foreign-net neighbour AND the long-axis nudge cannot rescue, returns `None` + emits an INFO log instead of committing the violating via.
- **THREE dispatcher call sites** in `escape.py` thread `self.strict_in_pad_clearance` consistently:
  - QFP-alternating (line ~2252)
  - SSOP/TSSOP odd-pin (line ~2917)
  - **Even-pin branch (line ~3006)** — this third site was flagged by the PR #3038 curator as a potential asymmetry; threading the flag here gives uniform defer-vs-commit policy across all in-pad rescue paths.
- `kct route --strict-in-pad-clearance` flag on BOTH the outer (`cli/parser.py`) and inner (`cli/route_cmd.py`) parsers, with forwarding shim in `cli/commands/routing.py` (matches the existing `--strict` plumbing pattern).
- Inner `route_cmd.main` stamps the env var to `"1"` when the flag is set so EscapeRouter (constructed lazily several layers below the CLI) picks up the opt-in without touching every intermediate call site.

### Tests (the actual subject of this PR)

- `tests/fixtures/strict_in_pad_min.py`: minimal synthetic fixture with one LQFP-shape pad + one foreign-net neighbour 0.05 mm too close.  NOT board 04.
- `tests/test_escape_strict_in_pad_clearance.py` (9 tests):
  - `TestStrictDefaultProceedsAnyway` (2 tests): default (`strict=False`) commits the violating via + emits warning.
  - `TestStrictTrueDefers` (2 tests): `strict=True` returns `None` + emits info log; explicit kwarg overrides default.
  - `TestStrictEnvVar` (4 tests): env var flips constructor attribute (on/off/unset/end-to-end).
  - `TestFixtureSanity` (1 test): pin the geometric violation so a future refactor can't silently weaken the fixture.
- `tests/test_cli_parser_drift.py` (1 new test): assert `--strict-in-pad-clearance` lives on BOTH parsers AND stamps the env var to `"1"` when set / leaves it unset when absent.

## What this PR does NOT do (sub-B / #3063 territory)

- No in-tree board enables the flag (verified: `grep -rn strict-in-pad-clearance boards/` returns zero matches).
- No lateral-recovery main-router work.  Today, enabling the flag on board 04 closes the OSC_OUT DRC cluster but cascades NRST/U2.8 GND into unrouted-net failure (per PR #3038's caveat).

## Acceptance Criteria Verification

| Criterion | Status | Notes |
|---|---|---|
| 4 new tests pass (positive + 2 strict + env var) | **Met** | 9 strict-mode tests + 1 parser-drift test = 10 new tests, all passing.  The AC-specified 4 are covered by the first 4 strict tests; remainder add fixture-sanity, kwarg-override, env-off, and env-unset coverage. |
| No in-tree board enables the flag | **Met** | `grep -rn strict-in-pad-clearance boards/` returns zero. |
| Re-introduced source surface does not regress other boards | **Met** | Boards 01/02/04 `generate_design.py` outputs are bit-identical vs. main (verified by stash-pop comparison: same routing percentages, same DRC counts, same connectivity warnings, same in-pad rescue warnings). |
| 3 dispatcher call sites all thread the flag consistently | **Met** | Fixed curator-noted asymmetry at the even-pin branch (~line 3006). |

## Test plan

- [x] `uv run pytest tests/test_escape_strict_in_pad_clearance.py tests/test_cli_parser_drift.py -v --no-cov` -- 16 passed (9 new + 7 existing parser-drift tests).
- [x] `uv run pytest tests/test_escape_strict_in_pad_clearance.py tests/test_cli_parser_drift.py tests/test_escape*.py -q --no-cov` -- 238 passed, 1 skipped (broad escape sweep).
- [x] Board 01/02/04 `generate_design.py` outputs are bit-identical vs. main.
- [x] `uv run ruff check` and `uv run ruff format --check` on touched files clean (one pre-existing F401 in `escape.py` is unrelated to this PR).
- [x] `uv run kct route --help | grep strict-in-pad` shows the outer flag; `uv run python -m kicad_tools.cli.route_cmd --help | grep strict-in-pad` shows the inner flag.

Closes #3062

🤖 Generated with [Claude Code](https://claude.com/claude-code)