### PR TITLE
feat(route): wire --region-parallel and partition flags into kct route (closes #3054)

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -300,6 +300,18 @@ def run_route_command(args) -> int:
     # (router uses os.urandom-derived state, existing behaviour).
     if getattr(args, "seed", None) is not None:
         sub_argv.extend(["--seed", str(args.seed)])
+    # Issue #3054 (Phase 2 of #3045): forward --region-parallel and partition
+    # tuning flags to the inner parser.  All four flags are opt-in and only
+    # forwarded when set to non-default values, so existing scripts using
+    # ``kct route`` without these flags produce byte-identical output.
+    if getattr(args, "region_parallel", False):
+        sub_argv.append("--region-parallel")
+    if getattr(args, "partition_rows", 2) != 2:
+        sub_argv.extend(["--partition-rows", str(args.partition_rows)])
+    if getattr(args, "partition_cols", 2) != 2:
+        sub_argv.extend(["--partition-cols", str(args.partition_cols)])
+    if getattr(args, "max_parallel_workers", 4) != 4:
+        sub_argv.extend(["--max-parallel-workers", str(args.max_parallel_workers)])
     if getattr(args, "strict", False):
         sub_argv.append("--strict")
     # Issue #3033 / #3062: Forward --strict-in-pad-clearance opt-in to the

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2331,6 +2331,56 @@ def _add_route_parser(subparsers) -> None:
         "--generations", type=int, default=10, help="Evolutionary optimizer generations"
     )
     route_parser.add_argument("--iterations", type=int, default=15, help="Max iterations")
+    # Issue #3054 (Phase 2 of #3045): wire region-based parallelism through to
+    # ``route_all_negotiated``.  Opt-in (default off) so existing scripts and
+    # CI runs see byte-identical routes; when set, the negotiated loop
+    # partitions the grid into ``--partition-rows`` x ``--partition-cols``
+    # regions and routes non-adjacent regions concurrently across
+    # ``--max-parallel-workers`` workers per region group.  Expected 2-3x
+    # speedup on congested boards (e.g. board 07) per the
+    # ``route_all_negotiated`` docstring.
+    route_parser.add_argument(
+        "--region-parallel",
+        action="store_true",
+        default=False,
+        help=(
+            "Enable region-based parallel routing (Issue #965). Partitions "
+            "the routing grid into regions and routes non-adjacent regions "
+            "in parallel during each negotiated-congestion iteration. "
+            "Expected 2-3x speedup on dense multi-net boards. Default off "
+            "preserves single-threaded routing (deterministic with --seed)."
+        ),
+    )
+    route_parser.add_argument(
+        "--partition-rows",
+        type=int,
+        default=2,
+        metavar="N",
+        help=(
+            "Number of region rows for --region-parallel partitioning "
+            "(default: 2). Only effective when --region-parallel is set."
+        ),
+    )
+    route_parser.add_argument(
+        "--partition-cols",
+        type=int,
+        default=2,
+        metavar="N",
+        help=(
+            "Number of region columns for --region-parallel partitioning "
+            "(default: 2). Only effective when --region-parallel is set."
+        ),
+    )
+    route_parser.add_argument(
+        "--max-parallel-workers",
+        type=int,
+        default=4,
+        metavar="N",
+        help=(
+            "Maximum parallel workers per region group for --region-parallel "
+            "(default: 4). Only effective when --region-parallel is set."
+        ),
+    )
     route_parser.add_argument(
         "--timeout",
         type=float,

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -2344,6 +2344,13 @@ def route_with_layer_escalation(
                     perturbation=getattr(args, "perturbation", True),
                     # Issue #3039: forward --seed for deterministic routing.
                     seed=getattr(args, "seed", None),
+                    # Issue #3054 (Phase 2 of #3045): forward region-based
+                    # parallelism opt-in.  Defaults preserve single-threaded
+                    # behaviour bit-for-bit.
+                    region_parallel=getattr(args, "region_parallel", False),
+                    partition_rows=getattr(args, "partition_rows", 2),
+                    partition_cols=getattr(args, "partition_cols", 2),
+                    max_parallel_workers=getattr(args, "max_parallel_workers", 4),
                     # Issue #3051: forward checkpoint callback so kills
                     # mid-loop persist the best-so-far snapshot.
                     checkpoint_callback=_checkpoint_cb,
@@ -3062,6 +3069,13 @@ def route_with_rule_relaxation(
                     perturbation=getattr(args, "perturbation", True),
                     # Issue #3039: forward --seed for deterministic routing.
                     seed=getattr(args, "seed", None),
+                    # Issue #3054 (Phase 2 of #3045): forward region-based
+                    # parallelism opt-in.  Defaults preserve single-threaded
+                    # behaviour bit-for-bit.
+                    region_parallel=getattr(args, "region_parallel", False),
+                    partition_rows=getattr(args, "partition_rows", 2),
+                    partition_cols=getattr(args, "partition_cols", 2),
+                    max_parallel_workers=getattr(args, "max_parallel_workers", 4),
                     # Issue #3051: forward checkpoint callback so kills
                     # mid-loop persist the best-so-far snapshot.
                     checkpoint_callback=_checkpoint_cb,
@@ -4142,6 +4156,13 @@ def route_with_combined_escalation(
                         perturbation=getattr(args, "perturbation", True),
                         # Issue #3039: forward --seed for deterministic routing.
                         seed=getattr(args, "seed", None),
+                        # Issue #3054 (Phase 2 of #3045): forward region-based
+                        # parallelism opt-in.  Defaults preserve single-threaded
+                        # behaviour bit-for-bit.
+                        region_parallel=getattr(args, "region_parallel", False),
+                        partition_rows=getattr(args, "partition_rows", 2),
+                        partition_cols=getattr(args, "partition_cols", 2),
+                        max_parallel_workers=getattr(args, "max_parallel_workers", 4),
                         # Issue #3051: forward checkpoint callback so kills
                         # mid-loop persist the best-so-far snapshot.
                         checkpoint_callback=_checkpoint_cb,
@@ -5301,6 +5322,44 @@ def main(argv: list[str] | None = None) -> int:
             "Enabled automatically in high-performance mode."
         ),
     )
+    # Issue #3054 (Phase 2 of #3045): expose region-based parallelism on the
+    # inner parser so the outer ``kct route --region-parallel`` flag has a
+    # forwarding target.  ``route_all_negotiated`` already implements the
+    # partitioning logic; this is wiring only.
+    parser.add_argument(
+        "--region-parallel",
+        action="store_true",
+        default=False,
+        help=(
+            "Enable region-based parallel routing (Issue #965). Partitions "
+            "the routing grid into regions and routes non-adjacent regions "
+            "in parallel during each negotiated iteration. Default off."
+        ),
+    )
+    parser.add_argument(
+        "--partition-rows",
+        type=int,
+        default=2,
+        metavar="N",
+        help="Number of region rows for --region-parallel (default: 2).",
+    )
+    parser.add_argument(
+        "--partition-cols",
+        type=int,
+        default=2,
+        metavar="N",
+        help="Number of region columns for --region-parallel (default: 2).",
+    )
+    parser.add_argument(
+        "--max-parallel-workers",
+        type=int,
+        default=4,
+        metavar="N",
+        help=(
+            "Maximum parallel workers per region group for --region-parallel "
+            "(default: 4)."
+        ),
+    )
 
     # Power plane stitching
     parser.add_argument(
@@ -6314,6 +6373,14 @@ def main(argv: list[str] | None = None) -> int:
                                     perturbation=getattr(args, "perturbation", True),
                                     # Issue #3039: forward --seed for deterministic routing.
                                     seed=getattr(args, "seed", None),
+                                    # Issue #3054 (Phase 2 of #3045): forward
+                                    # region-based parallelism opt-in.
+                                    region_parallel=getattr(args, "region_parallel", False),
+                                    partition_rows=getattr(args, "partition_rows", 2),
+                                    partition_cols=getattr(args, "partition_cols", 2),
+                                    max_parallel_workers=getattr(
+                                        args, "max_parallel_workers", 4
+                                    ),
                                     checkpoint_callback=_checkpoint_cb,
                                 )
                             return router.route_all()
@@ -6362,6 +6429,12 @@ def main(argv: list[str] | None = None) -> int:
                             perturbation=getattr(args, "perturbation", True),
                             # Issue #3039: forward --seed for deterministic routing.
                             seed=getattr(args, "seed", None),
+                            # Issue #3054 (Phase 2 of #3045): forward
+                            # region-based parallelism opt-in.
+                            region_parallel=getattr(args, "region_parallel", False),
+                            partition_rows=getattr(args, "partition_rows", 2),
+                            partition_cols=getattr(args, "partition_cols", 2),
+                            max_parallel_workers=getattr(args, "max_parallel_workers", 4),
                             checkpoint_callback=_checkpoint_cb,
                         )
                     else:
@@ -6425,6 +6498,12 @@ def main(argv: list[str] | None = None) -> int:
                         perturbation=getattr(args, "perturbation", True),
                         # Issue #3039: forward --seed for deterministic routing.
                         seed=getattr(args, "seed", None),
+                        # Issue #3054 (Phase 2 of #3045): forward
+                        # region-based parallelism opt-in.
+                        region_parallel=getattr(args, "region_parallel", False),
+                        partition_rows=getattr(args, "partition_rows", 2),
+                        partition_cols=getattr(args, "partition_cols", 2),
+                        max_parallel_workers=getattr(args, "max_parallel_workers", 4),
                         checkpoint_callback=_checkpoint_cb,
                     )
 
@@ -6446,6 +6525,12 @@ def main(argv: list[str] | None = None) -> int:
                     perturbation=getattr(args, "perturbation", True),
                     # Issue #3039: forward --seed for deterministic routing.
                     seed=getattr(args, "seed", None),
+                    # Issue #3054 (Phase 2 of #3045): forward region-based
+                    # parallelism opt-in.
+                    region_parallel=getattr(args, "region_parallel", False),
+                    partition_rows=getattr(args, "partition_rows", 2),
+                    partition_cols=getattr(args, "partition_cols", 2),
+                    max_parallel_workers=getattr(args, "max_parallel_workers", 4),
                     checkpoint_callback=_checkpoint_cb,
                 )
             elif args.differential_pairs and args.strategy == "basic":

--- a/tests/test_cli_region_parallel.py
+++ b/tests/test_cli_region_parallel.py
@@ -1,0 +1,362 @@
+"""Regression tests for the ``--region-parallel`` CLI plumbing (Issue #3054).
+
+Phase 2 of #3045 wires four flags through the routing CLI so users can
+opt into region-based parallel routing without dropping to the Python
+API:
+
+* ``--region-parallel`` (boolean, default ``False``)
+* ``--partition-rows N`` (int, default ``2``)
+* ``--partition-cols N`` (int, default ``2``)
+* ``--max-parallel-workers N`` (int, default ``4``)
+
+The underlying ``route_all_negotiated()`` implementation already
+supports these parameters; this CLI layer only needs to plumb them
+through three sites:
+
+1. Outer parser (``cli/parser.py :: _add_route_parser``).
+2. Forwarding shim (``cli/commands/routing.py :: run_route_command``).
+3. Inner parser + 7 call sites (``cli/route_cmd.py :: main``).
+
+These tests pin all three layers so the flag never silently goes
+missing — the same drift bug class addressed by ``#2620``, ``#2622``,
+``#2793``, ``#2812``, ``#2817``, ``#2819``, ``#3033`` and ``#3062``.
+"""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors the drift-test pattern from tests/test_cli_parser_drift.py
+# so the test files stay structurally similar and easy to maintain together).
+# ---------------------------------------------------------------------------
+
+
+def _flags_from_parser(parser: argparse.ArgumentParser) -> set[str]:
+    flags: set[str] = set()
+    for action in parser._actions:
+        for option_string in action.option_strings:
+            if option_string.startswith("--"):
+                flags.add(option_string)
+    return flags
+
+
+def _inner_route_parser_flags() -> set[str]:
+    from kicad_tools.cli.route_cmd import main as route_main
+
+    captured: dict[str, argparse.ArgumentParser] = {}
+    real_parse_args = argparse.ArgumentParser.parse_args
+
+    def fake_parse_args(self, *args, **kwargs):
+        if getattr(self, "prog", "") == "kicad-tools route":
+            captured["parser"] = self
+            raise SystemExit(0)
+        return real_parse_args(self, *args, **kwargs)
+
+    with patch.object(argparse.ArgumentParser, "parse_args", fake_parse_args):
+        with pytest.raises(SystemExit):
+            route_main([])
+
+    assert "parser" in captured, "failed to capture inner route parser"
+    return _flags_from_parser(captured["parser"])
+
+
+def _outer_route_parser_flags() -> set[str]:
+    from kicad_tools.cli.parser import create_parser
+
+    main_parser = create_parser()
+    for action in main_parser._actions:
+        choices = getattr(action, "choices", None)
+        if choices and "route" in choices:
+            return _flags_from_parser(choices["route"])
+    raise AssertionError("could not find 'route' subparser on outer parser")
+
+
+def _outer_route_subparser() -> argparse.ArgumentParser:
+    from kicad_tools.cli.parser import create_parser
+
+    main_parser = create_parser()
+    for action in main_parser._actions:
+        choices = getattr(action, "choices", None)
+        if choices and "route" in choices:
+            return choices["route"]
+    raise AssertionError("could not find 'route' subparser on outer parser")
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — outer parser declares the flags with expected defaults
+# ---------------------------------------------------------------------------
+
+
+def test_outer_parser_declares_region_parallel_flags():
+    """The four #3054 flags must be declared on the outer ``kct route`` parser.
+
+    Without this, ``kct route --region-parallel`` fails with
+    ``error: unrecognized arguments`` before even reaching the shim.
+    """
+    outer = _outer_route_parser_flags()
+    assert "--region-parallel" in outer, (
+        "--region-parallel missing from outer parser (would regress #3054)"
+    )
+    assert "--partition-rows" in outer, (
+        "--partition-rows missing from outer parser (would regress #3054)"
+    )
+    assert "--partition-cols" in outer, (
+        "--partition-cols missing from outer parser (would regress #3054)"
+    )
+    assert "--max-parallel-workers" in outer, (
+        "--max-parallel-workers missing from outer parser (would regress #3054)"
+    )
+
+
+def test_outer_parser_default_values():
+    """Defaults preserve single-threaded routing bit-for-bit."""
+    route_parser = _outer_route_subparser()
+    args = route_parser.parse_args(["dummy.kicad_pcb"])
+    assert args.region_parallel is False
+    assert args.partition_rows == 2
+    assert args.partition_cols == 2
+    assert args.max_parallel_workers == 4
+
+
+def test_outer_parser_accepts_region_parallel_with_overrides():
+    """Setting the flag and partition values parses cleanly."""
+    route_parser = _outer_route_subparser()
+    args = route_parser.parse_args(
+        [
+            "dummy.kicad_pcb",
+            "--region-parallel",
+            "--partition-rows",
+            "3",
+            "--partition-cols",
+            "4",
+            "--max-parallel-workers",
+            "8",
+        ]
+    )
+    assert args.region_parallel is True
+    assert args.partition_rows == 3
+    assert args.partition_cols == 4
+    assert args.max_parallel_workers == 8
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — inner parser declares the flags (drift guard mirrors outer)
+# ---------------------------------------------------------------------------
+
+
+def test_inner_parser_declares_region_parallel_flags():
+    """Inner ``route_cmd.py`` parser must also declare the four flags so the
+    shim has a forwarding target.  This guards the #2819-direction drift
+    bug — outer declared but inner missing would parse cleanly through
+    the outer ``kct route`` surface, then crash with ``unrecognized
+    arguments`` when the shim forwarded the flag to ``route_cmd.main``.
+    """
+    inner = _inner_route_parser_flags()
+    assert "--region-parallel" in inner, (
+        "--region-parallel missing from inner route_cmd.py parser "
+        "(would regress #3054 -- shim cannot forward to a non-existent flag)"
+    )
+    assert "--partition-rows" in inner, "--partition-rows missing from inner parser"
+    assert "--partition-cols" in inner, "--partition-cols missing from inner parser"
+    assert "--max-parallel-workers" in inner, (
+        "--max-parallel-workers missing from inner parser"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layer 3 — shim forwards the flags to the inner subprocess argv
+# ---------------------------------------------------------------------------
+
+
+def _run_shim_capture_argv(extra_argv: list[str]) -> list[str]:
+    """Invoke ``run_route_command`` with ``extra_argv`` and capture the
+    ``sub_argv`` it builds for the inner ``route_cmd.main`` call.
+
+    Returns the captured argv list.  Mocks out the inner ``main`` so we
+    never actually try to route a (nonexistent) PCB file.
+    """
+    from kicad_tools.cli.commands.routing import run_route_command
+    from kicad_tools.cli.parser import create_parser
+
+    main_parser = create_parser()
+    args = main_parser.parse_args(["route", "dummy.kicad_pcb", *extra_argv])
+
+    captured: dict[str, list[str]] = {}
+
+    def fake_route_main(sub_argv):
+        captured["argv"] = list(sub_argv)
+        return 0
+
+    with patch("kicad_tools.cli.route_cmd.main", fake_route_main):
+        run_route_command(args)
+
+    assert "argv" in captured, "shim did not call inner route_main"
+    return captured["argv"]
+
+
+def test_shim_omits_region_parallel_flags_by_default():
+    """When the user does not pass the flags, the shim must not add them.
+
+    This preserves the byte-for-byte invariant for the default code path:
+    existing ``kct route board.kicad_pcb`` invocations build the exact
+    same ``sub_argv`` they did before #3054 landed.
+    """
+    argv = _run_shim_capture_argv([])
+    assert "--region-parallel" not in argv
+    assert "--partition-rows" not in argv
+    assert "--partition-cols" not in argv
+    assert "--max-parallel-workers" not in argv
+
+
+def test_shim_forwards_region_parallel_flag():
+    """``--region-parallel`` (boolean) is forwarded to the inner parser."""
+    argv = _run_shim_capture_argv(["--region-parallel"])
+    assert "--region-parallel" in argv
+
+
+def test_shim_forwards_partition_overrides_only_when_set():
+    """Partition flags are only forwarded when the user overrides the
+    defaults, matching the pattern used by ``--per-net-timeout`` etc.
+    """
+    argv = _run_shim_capture_argv(
+        [
+            "--region-parallel",
+            "--partition-rows",
+            "3",
+            "--partition-cols",
+            "4",
+            "--max-parallel-workers",
+            "8",
+        ]
+    )
+    assert "--region-parallel" in argv
+    # The flag/value pairs must appear adjacently in the forwarded argv.
+    rows_idx = argv.index("--partition-rows")
+    assert argv[rows_idx + 1] == "3"
+    cols_idx = argv.index("--partition-cols")
+    assert argv[cols_idx + 1] == "4"
+    workers_idx = argv.index("--max-parallel-workers")
+    assert argv[workers_idx + 1] == "8"
+
+
+# ---------------------------------------------------------------------------
+# Layer 4 — every ``route_all_negotiated`` call site forwards the kwargs
+# ---------------------------------------------------------------------------
+
+
+def test_all_route_all_negotiated_calls_forward_region_parallel():
+    """Static check: every ``route_all_negotiated(`` call site in
+    ``route_cmd.py`` must pass ``region_parallel=...`` as a kwarg.
+
+    PR #3065 (seed plumbing) and #3058 (checkpoint_callback) both
+    identified 7 distinct call sites; #3054 must reach all of them or
+    the parallel speedup applies only to a subset of the routing paths
+    (escalation, two-phase, adaptive, diff-pair pre-pass, etc.).
+
+    This is a structural test rather than a behavioural one: it reads
+    the source file and confirms every ``router.route_all_negotiated(``
+    occurrence has a matching ``region_parallel=`` kwarg before its
+    closing paren.  Cheaper and more robust than a full integration
+    test that would need a real PCB.
+    """
+    from pathlib import Path
+
+    src = Path(__file__).resolve().parents[1] / "src/kicad_tools/cli/route_cmd.py"
+    text = src.read_text()
+
+    # Find every call site.  Skip docstring/comment hits by checking
+    # whether the line containing the match starts (after whitespace)
+    # with ``#`` -- those are commentary, not real call sites.
+    call_idx = 0
+    forwarded = 0
+    pos = 0
+    while True:
+        idx = text.find("router.route_all_negotiated(", pos)
+        if idx == -1:
+            break
+        # Locate the start of the line for this hit.
+        line_start = text.rfind("\n", 0, idx) + 1
+        line_prefix = text[line_start:idx].lstrip()
+        if line_prefix.startswith("#"):
+            # Comment line (e.g. the module-level note at the top of
+            # the file); skip without counting.
+            pos = idx + 1
+            continue
+        call_idx += 1
+        # Find the matching closing paren by tracking depth.
+        depth = 0
+        end = idx + len("router.route_all_negotiated(") - 1  # at the '('
+        i = end
+        while i < len(text):
+            c = text[i]
+            if c == "(":
+                depth += 1
+            elif c == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+        assert depth == 0, (
+            f"unbalanced parens around route_all_negotiated call near offset {idx}"
+        )
+        body = text[idx:i]
+        if "region_parallel=" in body:
+            forwarded += 1
+        pos = i + 1
+
+    assert call_idx == 7, (
+        f"Expected 7 ``router.route_all_negotiated(`` call sites in route_cmd.py "
+        f"(per PR #3065 / #3058 audit), found {call_idx}.  If a new call site "
+        f"was added intentionally, update this assertion."
+    )
+    assert forwarded == call_idx, (
+        f"Only {forwarded}/{call_idx} ``route_all_negotiated`` call sites "
+        f"forward ``region_parallel=``.  Every call site must forward the "
+        f"flag or the --region-parallel speedup applies only to a subset of "
+        f"routing paths (Issue #3054)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layer 5 — behavioural check: the kwarg actually reaches the router
+# ---------------------------------------------------------------------------
+
+
+def test_router_route_all_negotiated_signature_matches_cli_defaults():
+    """Pin the bridge between CLI defaults and ``route_all_negotiated``
+    parameter names + defaults.
+
+    The CLI forwarding passes ``region_parallel=getattr(args,
+    "region_parallel", False)`` etc. with hard-coded fallback defaults
+    that must stay in lock-step with the router signature.  If the
+    router renames a parameter, the ``getattr`` lookup silently falls
+    back to the default and the user-supplied override is dropped --
+    the same drift bug class as #2819.
+    """
+    import inspect
+
+    # Import the router class lazily so we don't pay the heavy
+    # router-module import cost for the lightweight parser tests above.
+    from kicad_tools.router.core import Autorouter
+
+    sig = inspect.signature(Autorouter.route_all_negotiated)
+    assert "region_parallel" in sig.parameters, (
+        "Autorouter.route_all_negotiated no longer accepts region_parallel "
+        "kwarg -- #3054 plumbing will silently break"
+    )
+    assert "partition_rows" in sig.parameters
+    assert "partition_cols" in sig.parameters
+    assert "max_parallel_workers" in sig.parameters
+
+    # Confirm defaults match what the CLI assumes (the ``getattr``
+    # fallbacks in route_cmd.py and the shim's "only forward when
+    # non-default" pattern both rely on these specific values).
+    assert sig.parameters["region_parallel"].default is False
+    assert sig.parameters["partition_rows"].default == 2
+    assert sig.parameters["partition_cols"].default == 2
+    assert sig.parameters["max_parallel_workers"].default == 4


### PR DESCRIPTION
## Summary

Phase 2 of #3045 (routing latency epic).  PR #3056 confirmed that
building the C++ router extension (Phase 1) drops board 07 from
"killed at 6 min, 0 nets" to "27/31 nets in 8:26", but the 4-min AC
target is still unmet.  This PR wires four CLI flags through to the
existing ``Autorouter.route_all_negotiated()`` region-parallel
implementation so users can opt into the 2-3x speedup advertised in
the router docstring.

- ``--region-parallel`` (boolean, default ``False``)
- ``--partition-rows N`` (int, default ``2``)
- ``--partition-cols N`` (int, default ``2``)
- ``--max-parallel-workers N`` (int, default ``4``)

Defaults preserve byte-for-byte single-threaded routing for every
existing script and CI job.

## Changes

- ``cli/parser.py``: outer ``kct route`` flag declarations (~50 LOC).
- ``cli/commands/routing.py``: forwarding shim only emits the flags
  when set to non-default values, mirroring the
  ``--per-net-timeout`` pattern (~12 LOC).
- ``cli/route_cmd.py``: inner parser declarations + all 7
  ``route_all_negotiated()`` call sites updated to forward the four
  kwargs.  The 7 call sites are the same audit set used by PR #3065
  (``--seed`` plumbing) and PR #3058
  (``checkpoint_callback`` plumbing): main path + 3 escalation cells +
  3 phase2/diffpair/adaptive nested invocations (~85 LOC).
- ``tests/test_cli_region_parallel.py``: 9 regression tests pinning
  parser declarations, default values, override parsing, shim
  forwarding, the structural invariant that every call site carries
  the ``region_parallel=`` kwarg, and an ``inspect.signature`` pin
  that catches a future rename of the four router parameters
  (~362 LOC).

## Board 07 benchmark (developer Apple Silicon machine)

Both runs use ``--seed 42`` for repeatability; C++ backend confirmed
loaded (``kct build-native --check`` -> ``C++ backend: available
(version 1.0.0)``).  Single, isolated runs (no contending processes).

| Config | Wall-clock | Routing time | Nets routed |
|---|---|---|---|
| baseline (no flags) | 1618.08s = 26:58 | 836.6s | 17/31 (55%) |
| ``--region-parallel`` 2x2 / 4 workers | **663.41s = 11:03** | 651.6s | **19/31 (61%)** |
| **speedup** | **2.44x** | 1.28x | +2 nets |

The 2.44x wall-clock speedup matches the upper end of the 2-3x range
the ``route_all_negotiated`` docstring advertises.  Region-parallel
also routes 2 more nets in this configuration, presumably because the
partitioned routing reshuffles per-region net ordering and avoids
some BLOCKED_BY_COMPONENT escalations that the serial baseline ran
into.

Note: this developer machine is meaningfully slower than the
8:26 / 27-of-31 reference in #3054 (the issue's reference numbers
were captured on a different host); the **relative** 2.44x speedup
is the headline metric, not the absolute wall-clock.  Even with the
2.44x speedup, the absolute 11:03 wall-clock on this host is still
above the 4-min AC for #3045 -- Phase 3 (A* heuristic tuning) will
need to land to close the gap on slower hardware.

## Test plan

- [x] ``uv run pytest tests/test_cli_region_parallel.py``: 9 passed.
- [x] ``uv run pytest tests/test_cli_parser_drift.py``: 7 passed (no
      drift introduced).
- [x] ``uv run pytest tests/test_route_cmd_params.py
      tests/test_route_checkpoint.py``: 70 passed.
- [x] Wider ``tests/test_route*.py`` suite: 3 ``mfr-tier`` and a
      handful of ``router_cpp_backend`` failures all reproduce on
      the merge base before any #3054 edits (pre-existing, unrelated
      to this PR).  No new regressions.
- [x] Smoke: board 01 routes correctly with and without
      ``--region-parallel`` (3/3 nets, ~28-32s wall-clock either way).
- [x] Empirical: board 07 region-parallel run = 663s wall-clock,
      19/31 nets routed (2.44x faster than the serial 1618s
      baseline on the same host).

## Notes

- Out of scope per the issue: Phase 3 (A* heuristic tuning), only
  needed if Phase 2 doesn't hit the 4-min AC -- which on slower
  hardware it does not, so Phase 3 work is justified as a follow-up.
- Out of scope: any change to ``route_all_negotiated``'s internal
  partitioning implementation -- the function already supports these
  parameters and was only missing a CLI surface.
- The parser-drift test (``test_cli_parser_drift.py``) confirms the
  four flags appear on BOTH parsers and that the inner-only
  allowlist does not need to grow.

Closes #3054