### PR TITLE
feat(escape): lateral via-escape helper + _can_place_via origin bug fix (partial close of #3063)

### DIFF
--- a/boards/04-stm32-devboard/generate_design.py
+++ b/boards/04-stm32-devboard/generate_design.py
@@ -1008,6 +1008,21 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
     edge (OSC_IN/OSC_OUT/NRST). The --auto-mfr-tier flag is required to
     close the NRST gap on the default recipe (issue #2988).
 
+    Issue #3039: pins ``--seed 42`` so the routed PCB is byte-identical
+    across runs.  The board's ``--seed 42`` reference run is the
+    regression baseline (9/9 signal nets, ~6 DRC errors).
+
+    Note on ``--strict-in-pad-clearance``: PR #3063 added the lateral
+    via-escape recovery (see ``_try_lateral_via_escape`` in
+    ``src/kicad_tools/router/escape.py``) plus an ``_can_place_via``
+    grid-origin bug fix.  An earlier revision of this recipe enabled
+    ``--strict-in-pad-clearance`` here, but it regressed completion on
+    this board from 9/9 to 8/9 nets and added segment/segment overlaps,
+    so the flag was reverted.  A follow-up will investigate WHY the
+    lateral helper does not find a clean off-pad via for the dropped
+    net on this board.  The helper itself is exercised by the
+    synthetic-fixture tests in ``tests/test_escape_lateral_recovery.py``.
+
     Returns True if `kct route` exits successfully (>= --min-completion).
     """
     print("\n" + "=" * 60)
@@ -1028,6 +1043,10 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
         "--auto-layers",
         "--auto-mfr-tier",
         "--placement-feedback",
+        # Issue #3039: pin --seed 42 so the routed PCB is byte-identical
+        # across runs and PR #3063 measurements are reproducible.
+        "--seed",
+        "42",
         "--timeout",
         "600",
     ]

--- a/src/kicad_tools/router/escape.py
+++ b/src/kicad_tools/router/escape.py
@@ -2267,6 +2267,36 @@ class EscapeRouter:
                             escapes.append(in_pad_route)
                             continue
 
+                        # Issue #3063 (sub-B of #3048): when strict mode
+                        # caused the in-pad rescue to defer (return None
+                        # because the dead-centre via would clip a foreign
+                        # neighbour and the long-axis nudge cannot rescue),
+                        # try the lateral re-attempt before giving up.
+                        # The lateral helper probes off-pad via candidates
+                        # along ``primary_dir`` (perpendicular outward from
+                        # the chip body) -- NOT ``direction``, which for
+                        # odd-index pins is the along-edge alt_dir_cw/ccw
+                        # and would search into the next pin in the row.
+                        # The outward direction is the only one with
+                        # consistent room for an off-pad via because the
+                        # row's pin pitch is geometrically fixed and the
+                        # outward half-plane is open by construction.
+                        # This is the in-tree customer that lets board 04
+                        # ship with --strict-in-pad-clearance without
+                        # dropping completion vs the legacy "commit-anyway"
+                        # branch.
+                        if self.strict_in_pad_clearance:
+                            lateral_route = self._try_lateral_via_escape(
+                                pad=pad,
+                                direction=primary_dir,
+                                effective_clearance=effective_clearance,
+                                escape_width=escape_width,
+                                package=package,
+                            )
+                            if lateral_route is not None:
+                                escapes.append(lateral_route)
+                                continue
+
                 # Issue #2881: Missed-rescue detection.  When the package is
                 # fine-pitch enough to need via-in-pad rescue but the
                 # manufacturer doesn't support it, AND the unclipped surface
@@ -2920,6 +2950,20 @@ class EscapeRouter:
                     if in_pad_route is not None:
                         escapes.append(in_pad_route)
                         continue
+                    # Issue #3063 (sub-B of #3048): lateral re-attempt
+                    # when the strict in-pad rescue deferred.  See the
+                    # QFP-alternating dispatcher comment for rationale.
+                    if self.strict_in_pad_clearance:
+                        lateral_route = self._try_lateral_via_escape(
+                            pad=pad,
+                            direction=direction,
+                            effective_clearance=effective_clearance,
+                            escape_width=escape_width,
+                            package=package,
+                        )
+                        if lateral_route is not None:
+                            escapes.append(lateral_route)
+                            continue
                     skipped_count += 1
                     logger.debug(
                         "Escape for pad %s (pin %d) skipped: segment-to-pad "
@@ -3009,6 +3053,20 @@ class EscapeRouter:
                     if in_pad_route is not None:
                         escapes.append(in_pad_route)
                         continue
+                    # Issue #3063 (sub-B of #3048): lateral re-attempt
+                    # when the strict in-pad rescue deferred.  See the
+                    # QFP-alternating dispatcher comment for rationale.
+                    if self.strict_in_pad_clearance:
+                        lateral_route = self._try_lateral_via_escape(
+                            pad=pad,
+                            direction=direction,
+                            effective_clearance=effective_clearance,
+                            escape_width=escape_width,
+                            package=package,
+                        )
+                        if lateral_route is not None:
+                            escapes.append(lateral_route)
+                            continue
                     skipped_count += 1
                     logger.debug(
                         "Escape for pad %s (pin %d) skipped: segment-to-pad "
@@ -4057,8 +4115,20 @@ class EscapeRouter:
         Returns:
             True if the position is clear; False if blocked.
         """
-        # Check grid bounds
-        if not (0 <= x <= self.grid.width and 0 <= y <= self.grid.height):
+        # Check grid bounds.  Issue #3063: use origin-aware bounds so
+        # boards whose world coordinates don't start at (0, 0) (e.g.
+        # the board-04 STM32 PCB, whose origin sits around (95, 90))
+        # have their candidates correctly validated.  The pre-#3063
+        # form (``0 <= x <= grid.width``) was implicitly correct only
+        # for grids constructed with ``origin_x=origin_y=0``; on other
+        # boards every world-coord candidate fell out-of-bounds and
+        # the predicate defaulted to False, which masked the lateral
+        # re-attempt path (every off-pad candidate was rejected on
+        # bounds and the rescue never fired).
+        origin_x = getattr(self.grid, "origin_x", 0.0)
+        origin_y = getattr(self.grid, "origin_y", 0.0)
+        if not (origin_x <= x <= origin_x + self.grid.width
+                and origin_y <= y <= origin_y + self.grid.height):
             return False
 
         # Check for obstacles in grid
@@ -4670,6 +4740,254 @@ class EscapeRouter:
             via=in_pad_via,
             ring_index=0,
         )
+
+    def _try_lateral_via_escape(
+        self,
+        pad: Pad,
+        direction: EscapeDirection,
+        effective_clearance: float,
+        escape_width: float,
+        package: PackageInfo | None = None,
+        max_offset_mm: float | None = None,
+        step_mm: float = 0.05,
+    ) -> EscapeRoute | None:
+        """Probe off-pad via candidates along the pin's escape direction.
+
+        Issue #3063 (sub-B of #3048): when ``_try_in_pad_escape`` returns
+        ``None`` in strict mode (``skip_on_clearance_violation=True``),
+        the caller has no rescue path -- the in-pad via would clip a
+        foreign neighbour and the strict policy refuses to commit it.
+        This helper provides the lateral re-attempt: starting from the
+        pad center, step outward along ``direction`` at ``step_mm``
+        increments up to ``max_offset_mm``, looking for the first
+        position where :meth:`_can_place_via` accepts a candidate via
+        against the same foreign-pad context the in-pad rescue used.
+
+        The returned route is geometrically equivalent to an in-pad
+        rescue except the via has been pushed off the pad by a small
+        lateral offset: an L-shaped surface stub from the pad to the
+        via location, then an inner-layer escape segment continuing
+        the same outward direction so the main router picks up the net
+        cleanly.
+
+        Search strategy:
+        1. Skip offset 0 (that's what ``_try_in_pad_escape`` already
+           tried -- pointless to re-test the dead-centre position).
+        2. Step ``i = 1, 2, ...`` with ``offset = i * step_mm``.  At each
+           step, try the position ``(pad.x + dx * offset, pad.y + dy * offset)``
+           where ``(dx, dy)`` is the direction's unit vector.
+        3. Validate the candidate against the same foreign-pad set the
+           in-pad rescue uses (other pads on the same footprint that
+           belong to a different net).
+        4. The first candidate that passes is returned.  If none pass
+           up to ``max_offset_mm``, return ``None``.
+
+        This mirrors the surface-stub-then-via pattern from
+        :meth:`_create_alternating_escape` plus an inner-layer
+        continuation, but the via is placed AT the candidate position
+        rather than dead-centre on the pad.
+
+        Args:
+            pad: The pad whose in-pad rescue was just rejected.
+            direction: Escape direction inherited from the dispatcher;
+                the via search walks along this vector.
+            effective_clearance: Clearance value used by the dispatcher;
+                forwarded to ``_can_place_via`` for the foreign-copper
+                check.
+            escape_width: Trace width to use for both the surface stub
+                and the inner-layer escape segment.
+            package: Optional package context.  When supplied, the
+                foreign-pad set is restricted to other pads on the
+                same footprint with different nets (the same context
+                :meth:`_select_in_pad_via_position` uses).  When
+                ``None``, no neighbour-pad validation is performed
+                (the grid-cell check still runs inside ``_can_place_via``).
+            max_offset_mm: Maximum lateral travel distance in mm.
+                When ``None`` (default), the budget is auto-derived
+                from the pad geometry so the search reaches AT LEAST
+                ``pad_long_dim/2 + via_radius + clearance`` along
+                ``direction`` -- this is the minimum distance needed
+                to clear the own pad copper plus a neighbour's
+                clearance halo when the escape direction is along
+                the pad's long axis (the common LQFP-48 / fine-pitch
+                QFP case where the long axis points outward from the
+                chip body).  A 0.5 mm floor mirrors the issue spec
+                for small / square pads.  Pass an explicit value to
+                override for unit-test geometry where the auto-budget
+                would be unnecessarily large.
+            step_mm: Step granularity in mm.  Default 0.05 mm matches
+                the grid resolution and the existing in-pad nudge step.
+
+        Returns:
+            An ``EscapeRoute`` with the laterally-offset via and the
+            inner-layer escape segment when a valid candidate is found,
+            or ``None`` when every candidate inside the search budget
+            is rejected.
+        """
+        if not self.via_in_pad_supported:
+            # Mirror ``_try_in_pad_escape`` -- without a via-in-pad-capable
+            # manufacturer the lateral re-attempt cannot ship either
+            # (the resulting via would land on a fine-pitch pad neighbour
+            # without filled/plated processing).  Returning None here
+            # preserves the existing "defer to main router" behaviour
+            # for manufacturers that never supported the in-pad path
+            # to begin with.
+            return None
+
+        # Pull manufacturer-effective via geometry, mirroring the
+        # in-pad helper above so the lateral and in-pad rescues use
+        # geometrically-consistent vias.
+        if self._mfr_limits is not None:
+            via_drill = self._mfr_limits.min_via_drill
+            via_diameter = self._mfr_limits.min_via_diameter
+        else:
+            via_drill = self.rules.via_drill
+            via_diameter = self.rules.via_diameter
+
+        dx, dy = self._direction_to_vector(direction)
+        if dx == 0.0 and dy == 0.0:
+            # VIA_DOWN or unknown direction -- no axis to walk along.
+            return None
+
+        # Auto-derive search budget when caller didn't specify.  The
+        # binding constraint for fine-pitch QFP/SSOP pads is the OWN
+        # pad's long-axis extent: a via at offset ``L`` along the
+        # escape direction is only clear of the pad's own copper plus
+        # a neighbour pad's clearance halo when L is greater than the
+        # pad's half-extent in that direction PLUS the via radius PLUS
+        # clearance.  We compute the half-extent in the SPECIFIC
+        # direction by projecting the pad's half-width / half-height
+        # onto the unit vector ``(dx, dy)`` -- the same projection the
+        # in-pad rescue uses for its long-axis nudge.  Floors at 0.5
+        # mm so square pads (where the calculation gives a tiny value)
+        # still get the spec-mandated minimum search budget.
+        if max_offset_mm is None:
+            half_x = pad.width / 2
+            half_y = pad.height / 2
+            # Projected half-extent of the pad rectangle along (dx, dy).
+            # For axis-aligned escape directions this is exactly
+            # ``half_x`` (E/W) or ``half_y`` (N/S); for diagonals it
+            # blends both extents proportionally.
+            proj_half = abs(dx) * half_x + abs(dy) * half_y
+            auto_budget = proj_half + via_diameter / 2 + effective_clearance + step_mm
+            max_offset_mm = max(0.5, auto_budget)
+
+        # Foreign-net pads on the same footprint, mirroring the
+        # ``_select_in_pad_via_position`` filter so the lateral probe
+        # validates against the SAME neighbour set the in-pad rescue
+        # was rejected by.  This keeps the strict-mode contract
+        # symmetric: a lateral candidate "accepted" here would also
+        # have been accepted by the in-pad rescue's clearance check
+        # if it had landed at the same coordinates.
+        foreign_pads: list[Pad] | None = None
+        if package is not None:
+            foreign_pads = [
+                p for p in package.pads
+                if p is not pad and p.net != pad.net
+            ]
+
+        # Iterate offsets [step, 2*step, ..., max_offset]; skip 0 because
+        # the in-pad rescue already tested that position.
+        n_steps = int(round(max_offset_mm / step_mm))
+        for i in range(1, n_steps + 1):
+            offset = i * step_mm
+            cand_x = pad.x + dx * offset
+            cand_y = pad.y + dy * offset
+
+            if self._can_place_via(
+                x=cand_x,
+                y=cand_y,
+                net=pad.net,
+                foreign_pads=foreign_pads,
+                clearance=effective_clearance,
+                via_diameter=via_diameter,
+            ):
+                # Found a passing candidate -- build the EscapeRoute.
+                escape_layer = self._select_inner_escape_layer(pad.layer)
+
+                # Surface stub: pad → via location.  Width matches the
+                # dispatcher's ``escape_width`` (typically min_trace_width
+                # for fine-pitch packages, see _create_fine_pitch_row_escapes).
+                surface_seg = Segment(
+                    x1=pad.x,
+                    y1=pad.y,
+                    x2=cand_x,
+                    y2=cand_y,
+                    width=escape_width,
+                    layer=pad.layer,
+                    net=pad.net,
+                    net_name=pad.net_name,
+                )
+
+                # Via from surface to inner escape layer.  ``in_pad=False``
+                # because the via is geometrically OFF the pad copper
+                # (that's the whole point of the lateral offset).
+                lateral_via = Via(
+                    x=cand_x,
+                    y=cand_y,
+                    drill=via_drill,
+                    diameter=via_diameter,
+                    layers=(pad.layer, escape_layer),
+                    net=pad.net,
+                    net_name=pad.net_name,
+                    in_pad=False,
+                )
+
+                # Inner-layer escape point: continue the same direction
+                # past the via so the main router has a clean landing
+                # to pick up from, mirroring ``_try_in_pad_escape``.
+                inner_offset = (
+                    via_diameter / 2
+                    + effective_clearance
+                    + self.rules.trace_width
+                )
+                escape_x = cand_x + dx * inner_offset
+                escape_y = cand_y + dy * inner_offset
+
+                inner_seg = Segment(
+                    x1=cand_x,
+                    y1=cand_y,
+                    x2=escape_x,
+                    y2=escape_y,
+                    width=escape_width,
+                    layer=escape_layer,
+                    net=pad.net,
+                    net_name=pad.net_name,
+                )
+
+                logger.info(
+                    "Lateral via-escape rescue for pad %s (ref=%s pin=%s): "
+                    "in-pad deferred; off-pad via at (%.3f, %.3f) "
+                    "accepted at lateral offset=%.3fmm along %s. "
+                    "L-stub on %s -> via -> %s (Issue #3063).",
+                    pad.net_name, pad.ref, pad.pin,
+                    cand_x, cand_y, offset, direction.name,
+                    pad.layer.kicad_name, escape_layer.kicad_name,
+                )
+
+                return EscapeRoute(
+                    pad=pad,
+                    direction=direction,
+                    escape_point=(escape_x, escape_y),
+                    escape_layer=escape_layer,
+                    via_pos=(cand_x, cand_y),
+                    segments=[surface_seg, inner_seg],
+                    via=lateral_via,
+                    ring_index=0,
+                )
+
+        # No candidate in the budget passed.  Caller (dispatcher) will
+        # treat this as "defer to main router" -- the same outcome the
+        # strict branch had before this helper existed, but now we've
+        # at least attempted the local rescue first.
+        logger.debug(
+            "Lateral via-escape rescue for pad %s (ref=%s pin=%s) failed: "
+            "no candidate in [%.3fmm, %.3fmm] along %s passes clearance "
+            "(Issue #3063).",
+            pad.net_name, pad.ref, pad.pin,
+            step_mm, max_offset_mm, direction.name,
+        )
+        return None
 
     def _select_inner_escape_layer(self, surface_layer: Layer) -> Layer:
         """Select the best inner layer for via escape routing.

--- a/tests/test_escape_lateral_recovery.py
+++ b/tests/test_escape_lateral_recovery.py
@@ -1,0 +1,668 @@
+"""Tests for the lateral via-escape recovery (Issue #3063, sub-B of #3048).
+
+When ``--strict-in-pad-clearance`` causes ``_try_in_pad_escape`` to
+defer (return ``None`` because the dead-centre via would clip a
+foreign neighbour and the long-axis nudge cannot rescue), the
+dispatcher now retries with ``_try_lateral_via_escape``, probing
+off-pad via candidates along the natural escape direction within
+~0.5mm.
+
+This module pins three behaviours:
+
+1. **Success case**: a pad whose in-pad rescue would defer in strict
+   mode has an open lane along the escape direction within 0.5mm;
+   the lateral helper finds the first passing candidate and emits an
+   ``EscapeRoute`` with an L-stub + via + inner-layer escape.
+
+2. **Negative case**: a pad surrounded by foreign-net obstacles on
+   all approach lanes within the search budget; the lateral helper
+   returns ``None`` gracefully.
+
+3. **Regression case**: with strict mode OFF, the legacy
+   "commit-anyway" branch of ``_try_in_pad_escape`` still fires and
+   the lateral helper is never invoked (no behaviour change).
+
+The fixtures intentionally use a simpler geometry than
+``tests/fixtures/strict_in_pad_min.py`` -- there the violation is on
+the SHORT axis perpendicular to the long-axis nudge, so the in-pad
+helper falls through to the strict deferral.  We layer additional
+foreign pads (or lack thereof) along the SOUTH escape direction to
+gate the lateral rescue success/failure.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from kicad_tools.router.escape import EscapeDirection, EscapeRouter, PackageInfo, PackageType
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.primitives import Pad
+from tests.fixtures.strict_in_pad_min import (
+    CLEARANCE,
+    PAD_LONG,
+    PAD_SHORT,
+    PITCH,
+    make_rules,
+)
+
+
+# ----------------------------------------------------------------------------
+# Helpers
+#
+# These tests use a translated copy of the strict-in-pad violating-pair
+# fixture: the primary pad sits at (5.0, 5.0) world rather than (0.0, 0.0).
+# ``_can_place_via`` enforces world-coordinate bounds in [0, grid.width],
+# so a primary at the origin would have its SOUTH (-Y) candidates rejected
+# on bounds rather than on neighbour-clearance.  We translate up by half
+# the grid extent so the search budget stays comfortably inside bounds.
+# ----------------------------------------------------------------------------
+
+
+# Place the primary pad at the middle of the 10x10 grid (origin 0,0 ->
+# extents [0, 10]) so SOUTH (-Y) candidates have plenty of in-bounds
+# room.  The grid here uses a non-negative origin to avoid the
+# _can_place_via bounds quirk that rejects negative world coords.
+PRIMARY_X: float = 5.0
+PRIMARY_Y: float = 5.0
+
+
+def _make_grid_origin_zero(rules) -> RoutingGrid:
+    """RoutingGrid sized 10x10 mm with origin at (0, 0) -- world coords
+    map directly onto the grid bounds ``_can_place_via`` checks.
+    """
+    return RoutingGrid(
+        width=10.0,
+        height=10.0,
+        rules=rules,
+        origin_x=0.0,
+        origin_y=0.0,
+        layer_stack=LayerStack.four_layer_sig_sig_gnd_pwr(),
+    )
+
+
+def _make_translated_violating_pair() -> tuple[Pad, Pad]:
+    """Like ``make_violating_pair`` but translated so primary is at
+    (PRIMARY_X, PRIMARY_Y) world.
+    """
+    primary = Pad(
+        x=PRIMARY_X,
+        y=PRIMARY_Y,
+        width=PAD_LONG,
+        height=PAD_SHORT,
+        net=1,
+        net_name="NET1",
+        ref="U1",
+        pin="1",
+        layer=Layer.F_CU,
+    )
+    neighbour = Pad(
+        x=PRIMARY_X,
+        y=PRIMARY_Y + PITCH,
+        width=PAD_LONG,
+        height=PAD_SHORT,
+        net=2,
+        net_name="NET2",
+        ref="U1",
+        pin="2",
+        layer=Layer.F_CU,
+    )
+    return primary, neighbour
+
+
+def _make_translated_package() -> PackageInfo:
+    primary, neighbour = _make_translated_violating_pair()
+    pads = [primary, neighbour]
+    xs = [p.x for p in pads]
+    ys = [p.y for p in pads]
+    return PackageInfo(
+        ref="U1",
+        package_type=PackageType.QFP,
+        center=(sum(xs) / len(xs), sum(ys) / len(ys)),
+        pads=pads,
+        pin_count=len(pads),
+        pin_pitch=PITCH,
+        bounding_box=(min(xs), min(ys), max(xs), max(ys)),
+        is_dense=True,
+    )
+
+
+def _build_router(strict: bool = True) -> EscapeRouter:
+    """Build an EscapeRouter on the translated violating-pair geometry."""
+    rules = make_rules(manufacturer="jlcpcb-tier1")
+    grid = _make_grid_origin_zero(rules)
+    router = EscapeRouter(grid, rules)
+    router.strict_in_pad_clearance = strict
+    return router
+
+
+def _package_with_extra_obstacle(blocker_dy: float) -> PackageInfo:
+    """Violating pair + a third foreign pad south of the primary.
+
+    ``blocker_dy`` is the Y-offset of the blocker pad RELATIVE to the
+    primary (negative = SOUTH).  Choose a small ``blocker_dy`` (e.g.
+    -0.2 mm) to block every lateral candidate within ~0.5 mm; choose
+    a larger magnitude (e.g. -2.0) to leave the SOUTH lane open.
+    """
+    primary, neighbour = _make_translated_violating_pair()
+    blocker = Pad(
+        x=PRIMARY_X,
+        y=PRIMARY_Y + blocker_dy,
+        width=1.5,  # long axis along X
+        height=0.30,  # short axis along Y
+        net=99,
+        net_name="BLOCK",
+        ref="U1",
+        pin="99",
+        layer=Layer.F_CU,
+    )
+    pads = [primary, neighbour, blocker]
+    xs = [p.x for p in pads]
+    ys = [p.y for p in pads]
+    return PackageInfo(
+        ref="U1",
+        package_type=PackageType.QFP,
+        center=(sum(xs) / len(xs), sum(ys) / len(ys)),
+        pads=pads,
+        pin_count=len(pads),
+        pin_pitch=PITCH,
+        bounding_box=(min(xs), min(ys), max(xs), max(ys)),
+        is_dense=True,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_env_strict(monkeypatch):
+    """Clear KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE before each test so the
+    constructor-time strict resolution starts from a known state.
+    """
+    monkeypatch.delenv("KICAD_TOOLS_STRICT_IN_PAD_CLEARANCE", raising=False)
+    yield
+
+
+# ----------------------------------------------------------------------------
+# Success case: lateral lane available
+# ----------------------------------------------------------------------------
+
+
+class TestLateralRecoverySucceeds:
+    """Lateral helper finds an off-pad via within the search budget."""
+
+    def test_lateral_recovery_returns_route_when_lane_is_open(self, caplog):
+        """With the violating pair as the package context, the lateral
+        helper should find a passing candidate along the SOUTH
+        direction (-Y) since the neighbour is to the NORTH (+Y).
+        """
+        router = _build_router(strict=True)
+        # Primary at (PRIMARY_X, PRIMARY_Y) world; neighbour at primary + PITCH along Y.
+        package = _make_translated_package()
+        primary = package.pads[0]
+
+        with caplog.at_level(logging.INFO, logger="kicad_tools.router.escape"):
+            route = router._try_lateral_via_escape(
+                pad=primary,
+                direction=EscapeDirection.SOUTH,
+                effective_clearance=CLEARANCE,
+                escape_width=0.2,
+                package=package,
+            )
+
+        assert route is not None, (
+            "Lateral helper must find an off-pad via candidate when the "
+            "escape direction (SOUTH = -Y) has an open lane.  Got None."
+        )
+        # Via must be off-pad: the whole point is the lateral offset.
+        # Primary is at (0, 0); SOUTH means strictly negative Y.
+        assert route.via is not None, "Lateral route must have a via"
+        assert route.via.y < primary.y - 1e-6, (
+            f"Lateral via must be SOUTH of the pad center; got via.y="
+            f"{route.via.y} >= primary.y={primary.y}"
+        )
+        # Via should not be inside the pad copper (purpose of lateral)
+        assert route.via.in_pad is False, (
+            "Lateral via must have in_pad=False (it sits off the pad)"
+        )
+        # Route must have BOTH segments: surface stub + inner escape.
+        assert len(route.segments) == 2, (
+            f"Lateral route should have 2 segments (stub + inner); "
+            f"got {len(route.segments)}"
+        )
+        # First segment is the surface stub from pad to via.
+        stub = route.segments[0]
+        assert stub.layer == primary.layer, (
+            "Surface stub must stay on the pad's layer"
+        )
+        assert abs(stub.x1 - primary.x) < 1e-6 and abs(stub.y1 - primary.y) < 1e-6, (
+            "Surface stub must start at the pad center"
+        )
+        assert abs(stub.x2 - route.via.x) < 1e-6 and abs(stub.y2 - route.via.y) < 1e-6, (
+            "Surface stub must end at the via location"
+        )
+        # Inner segment continues outward past the via.
+        inner = route.segments[1]
+        assert inner.layer != primary.layer, (
+            "Inner escape segment must be on a different layer than the pad"
+        )
+        # Diagnostic INFO log line should be present.
+        info_records = [
+            r for r in caplog.records
+            if r.levelno == logging.INFO and "Lateral via-escape rescue" in r.message
+        ]
+        assert info_records, (
+            "Expected the 'Lateral via-escape rescue' INFO log line; "
+            "saw: " + str([r.message for r in caplog.records])
+        )
+
+    def test_lateral_recovery_picks_smallest_valid_offset(self):
+        """The search starts at step=0.05mm and walks outward; the
+        returned via should be at the SMALLEST offset that passes,
+        not an arbitrary one further away.
+
+        Geometry note: the neighbour is at primary.y + PITCH (0.50 mm),
+        with pad height 0.30 mm (so its south edge is at
+        primary.y + 0.35 mm).  A SOUTH-direction via at offset 0.05 mm
+        sits at via_y = primary.y - 0.05 mm; its rect-distance to the
+        neighbour pad is then 0.40 mm, which is below the
+        ``via_radius (0.30) + clearance (0.15) = 0.45`` mm required gap.
+        Offset 0.10 mm yields rect-distance 0.45 mm exactly, the first
+        offset that passes.  This pinning catches regressions in the
+        step size, search order, or clearance arithmetic.
+        """
+        router = _build_router(strict=True)
+        package = _make_translated_package()
+        primary = package.pads[0]
+
+        route = router._try_lateral_via_escape(
+            pad=primary,
+            direction=EscapeDirection.SOUTH,
+            effective_clearance=CLEARANCE,
+            escape_width=0.2,
+            package=package,
+        )
+        assert route is not None
+        assert route.via is not None
+        observed_offset = primary.y - route.via.y
+        assert observed_offset == pytest.approx(0.10, abs=1e-9), (
+            f"Expected smallest-valid offset of 0.10 mm (see geometry note "
+            f"in docstring); got {observed_offset:.4f} mm"
+        )
+
+
+# ----------------------------------------------------------------------------
+# Negative case: no lane open within the search budget
+# ----------------------------------------------------------------------------
+
+
+class TestLateralRecoveryFailsGracefully:
+    """When no lateral candidate fits, the helper returns None."""
+
+    def test_blocked_south_lane_returns_none(self):
+        """A foreign pad placed immediately south of the primary blocks
+        every lateral candidate within the 0.5 mm budget.  The helper
+        must return None rather than committing a violating via.
+        """
+        router = _build_router(strict=True)
+        # Blocker at primary.y - 0.20 mm (i.e. immediately south).
+        # With a 0.30 mm-tall pad it extends from primary.y - 0.35 to
+        # primary.y - 0.05.  Combined with via_radius (0.30) and
+        # clearance (0.15), every SOUTH offset in [0.05, 0.50] mm
+        # sits within ``via_radius + clearance`` of the blocker's
+        # bounding rectangle and is rejected.
+        package = _package_with_extra_obstacle(blocker_dy=-0.20)
+        primary = package.pads[0]
+
+        route = router._try_lateral_via_escape(
+            pad=primary,
+            direction=EscapeDirection.SOUTH,
+            effective_clearance=CLEARANCE,
+            escape_width=0.2,
+            package=package,
+        )
+        assert route is None, (
+            "With the SOUTH lane fully blocked, the lateral helper must "
+            "return None (deferring to the main router) instead of "
+            "committing a violating via."
+        )
+
+    def test_via_in_pad_unsupported_manufacturer_returns_none(self):
+        """When the manufacturer doesn't support via-in-pad processing,
+        the lateral helper short-circuits to None -- it can't ship a
+        lateral via on a fine-pitch pad without filled-and-plated
+        processing either.  This mirrors ``_try_in_pad_escape``.
+        """
+        rules = make_rules(manufacturer="jlcpcb")  # no via-in-pad support
+        grid = _make_grid_origin_zero(rules)
+        router = EscapeRouter(grid, rules)
+        assert router.via_in_pad_supported is False
+        router.strict_in_pad_clearance = True
+
+        package = _make_translated_package()
+        primary = package.pads[0]
+
+        route = router._try_lateral_via_escape(
+            pad=primary,
+            direction=EscapeDirection.SOUTH,
+            effective_clearance=CLEARANCE,
+            escape_width=0.2,
+            package=package,
+        )
+        assert route is None, (
+            "Without via-in-pad support the lateral helper must defer "
+            "(same outcome as the in-pad helper); got a route."
+        )
+
+    def test_via_down_direction_returns_none(self):
+        """The VIA_DOWN sentinel direction has no axis to walk along
+        (its unit vector is (0, 0)).  The helper must reject it
+        rather than spinning on zero-offset candidates.
+        """
+        router = _build_router(strict=True)
+        package = _make_translated_package()
+        primary = package.pads[0]
+
+        route = router._try_lateral_via_escape(
+            pad=primary,
+            direction=EscapeDirection.VIA_DOWN,
+            effective_clearance=CLEARANCE,
+            escape_width=0.2,
+            package=package,
+        )
+        assert route is None
+
+
+# ----------------------------------------------------------------------------
+# Regression case: with strict mode OFF, no behaviour change
+# ----------------------------------------------------------------------------
+
+
+class TestLateralRecoveryIsStrictGated:
+    """With ``strict_in_pad_clearance=False`` (default), the dispatcher
+    never invokes the lateral helper -- the legacy commit-anyway branch
+    fires inside ``_try_in_pad_escape`` and returns a violating route.
+
+    This pins the regression contract: enabling the lateral helper
+    must not change behaviour for legacy callers that have NOT opted
+    into strict mode.
+    """
+
+    def test_legacy_path_unchanged_when_strict_disabled(self, caplog):
+        """In legacy mode, ``_try_in_pad_escape`` commits the violating
+        via with a WARNING log -- no INFO line about lateral rescue
+        should appear (the helper is gated behind strict-mode in the
+        dispatcher).
+        """
+        router = _build_router(strict=False)
+        assert router.strict_in_pad_clearance is False
+
+        package = _make_translated_package()
+        primary = package.pads[0]
+
+        with caplog.at_level(logging.DEBUG, logger="kicad_tools.router.escape"):
+            route = router._try_in_pad_escape(
+                pad=primary,
+                direction=EscapeDirection.SOUTH,
+                effective_clearance=CLEARANCE,
+                escape_width=0.2,
+                package=package,
+                # Dispatcher contract: passes the attribute through.
+                skip_on_clearance_violation=router.strict_in_pad_clearance,
+            )
+
+        assert route is not None, (
+            "Legacy (strict=False) path must commit the violating via"
+        )
+        # The lateral helper's INFO log line must NOT appear when the
+        # legacy commit-anyway branch fires.  The dispatcher gates the
+        # lateral call on strict mode, so even though _try_in_pad_escape
+        # returned a value (no defer), no lateral path runs.  We assert
+        # this by inspecting the in-pad helper output directly: it
+        # should produce the warning, not the lateral info line.
+        lateral_logs = [
+            r for r in caplog.records
+            if "Lateral via-escape rescue" in r.message
+        ]
+        assert not lateral_logs, (
+            "Lateral rescue must NOT log when strict mode is off and "
+            "the in-pad helper commits the violating via; got: "
+            + str([r.message for r in lateral_logs])
+        )
+
+
+# ----------------------------------------------------------------------------
+# End-to-end via the QFP dispatcher
+# ----------------------------------------------------------------------------
+
+
+def _make_qfp_west_edge_package(n_pads: int = 6) -> PackageInfo:
+    """Build a fine-pitch QFP-shaped fixture with ``n_pads`` pads on
+    the WEST edge.
+
+    The minimum-viable fixture for the QFP dispatcher: pads laid out
+    along a single edge (west) so ``_escape_qfp_alternating`` actually
+    classifies them as a row.  Pads are at 0.50 mm pitch (LQFP-48
+    geometry) with oblong fingers (0.3 x 1.5 mm), and the package
+    bounding box spans both the row span AND a wider east extent so
+    ``edge_margin`` is non-zero (a pad whose y is within
+    ``edge_margin`` of ``min_y`` gets classified as a west pad).
+
+    All pads use different nets so the in-pad rescue would see foreign
+    neighbours; with the QFP dispatcher's clearance check, the deferral
+    path fires for inner pins.
+    """
+    pads = []
+    # West edge at x = 1.0; pads along +Y at 0.5 mm pitch
+    for i in range(n_pads):
+        pads.append(
+            Pad(
+                x=1.0,
+                y=2.0 + i * PITCH,
+                width=1.5,  # long axis (pointing east, into IC body)
+                height=0.30,  # short axis (along row)
+                net=i + 1,
+                net_name=f"NET{i + 1}",
+                ref="U1",
+                pin=str(i + 1),
+                layer=Layer.F_CU,
+            )
+        )
+    # Add a couple of east-edge pads so the bounding box has a real
+    # width -- otherwise edge_margin = min(0, height)*0.2 = 0 and no
+    # pad gets classified to any edge.
+    pads.append(
+        Pad(
+            x=6.0,
+            y=2.0,
+            width=1.5,
+            height=0.30,
+            net=100,
+            net_name="EAST1",
+            ref="U1",
+            pin="100",
+            layer=Layer.F_CU,
+        )
+    )
+    pads.append(
+        Pad(
+            x=6.0,
+            y=2.0 + (n_pads - 1) * PITCH,
+            width=1.5,
+            height=0.30,
+            net=101,
+            net_name="EAST2",
+            ref="U1",
+            pin="101",
+            layer=Layer.F_CU,
+        )
+    )
+    xs = [p.x for p in pads]
+    ys = [p.y for p in pads]
+    return PackageInfo(
+        ref="U1",
+        package_type=PackageType.QFP,
+        center=((min(xs) + max(xs)) / 2, (min(ys) + max(ys)) / 2),
+        pads=pads,
+        pin_count=len(pads),
+        pin_pitch=PITCH,
+        bounding_box=(min(xs), min(ys), max(xs), max(ys)),
+        is_dense=True,
+    )
+
+
+class TestCanPlaceViaBoundsAreOriginAware:
+    """Pin the origin-aware bounds fix on ``_can_place_via`` (Issue
+    #3063).  Prior to the fix, the bounds check was
+    ``0 <= x <= grid.width``, which was implicitly correct only for
+    grids constructed with ``origin_x=origin_y=0``.  Boards whose
+    routing grid sits at non-zero origin (e.g. board-04 STM32 PCB at
+    world coordinates around (95, 90)) had every world-coord candidate
+    rejected on bounds, which made the lateral re-attempt's
+    ``_can_place_via`` probe a no-op.
+    """
+
+    def test_can_place_via_accepts_in_bounds_world_coord_on_offset_grid(self):
+        """A grid with non-zero origin must accept a candidate whose
+        world coordinates fall within ``[origin, origin + extent]``.
+        """
+        from kicad_tools.router.escape import EscapeRouter
+        from kicad_tools.router.grid import RoutingGrid
+        from kicad_tools.router.layers import LayerStack
+        from tests.fixtures.strict_in_pad_min import make_rules
+
+        rules = make_rules(manufacturer="jlcpcb-tier1")
+        # Grid sized 10x10 with origin at (100, 100): valid world
+        # coords are [100, 110] x [100, 110].
+        grid = RoutingGrid(
+            width=10.0,
+            height=10.0,
+            rules=rules,
+            origin_x=100.0,
+            origin_y=100.0,
+            layer_stack=LayerStack.four_layer_sig_sig_gnd_pwr(),
+        )
+        router = EscapeRouter(grid, rules)
+        # A point inside the grid in world coords (105, 105) -- the
+        # pre-#3063 bounds check rejected this because 105 > grid.width
+        # (=10).  The origin-aware check must accept it.
+        ok = router._can_place_via(x=105.0, y=105.0, net=None)
+        assert ok is True, (
+            "Origin-aware bounds must accept a world-coord candidate "
+            "inside [origin, origin+extent]; pre-#3063 form rejected "
+            "this incorrectly."
+        )
+
+    def test_can_place_via_rejects_out_of_bounds_world_coord(self):
+        """A candidate outside the grid extent in world coords must
+        still be rejected (the origin-aware check tightens, not loosens).
+        """
+        from kicad_tools.router.escape import EscapeRouter
+        from kicad_tools.router.grid import RoutingGrid
+        from kicad_tools.router.layers import LayerStack
+        from tests.fixtures.strict_in_pad_min import make_rules
+
+        rules = make_rules(manufacturer="jlcpcb-tier1")
+        grid = RoutingGrid(
+            width=10.0,
+            height=10.0,
+            rules=rules,
+            origin_x=100.0,
+            origin_y=100.0,
+            layer_stack=LayerStack.four_layer_sig_sig_gnd_pwr(),
+        )
+        router = EscapeRouter(grid, rules)
+        # Outside the [100, 110] extent.
+        assert router._can_place_via(x=99.0, y=105.0, net=None) is False
+        assert router._can_place_via(x=111.0, y=105.0, net=None) is False
+        assert router._can_place_via(x=105.0, y=99.0, net=None) is False
+        assert router._can_place_via(x=105.0, y=111.0, net=None) is False
+
+
+class TestQfpDispatcherWiring:
+    """The QFP/SSOP/even-pin dispatcher sites must invoke the lateral
+    helper after a strict in-pad deferral.  We exercise the wiring by
+    monkey-patching the in-pad helper to force-defer and asserting the
+    lateral helper is called.
+    """
+
+    def test_dispatcher_invokes_lateral_after_strict_defer(self):
+        """Force ``_try_in_pad_escape`` to always return None (simulating
+        the strict-mode defer).  When the dispatcher hits the deferral
+        in strict mode, it must invoke ``_try_lateral_via_escape``.
+        """
+        router = _build_router(strict=True)
+        # Force the in-pad helper to defer unconditionally.  This
+        # simulates the strict-mode condition where every dead-centre
+        # via clips a neighbour and the long-axis nudge cannot rescue.
+        router._try_in_pad_escape = lambda **kwargs: None  # type: ignore[method-assign]
+
+        # Spy on the lateral helper to confirm it gets called.
+        calls: list[dict] = []
+        original_lateral = router._try_lateral_via_escape
+
+        def spy_lateral(**kwargs):
+            calls.append(kwargs)
+            return original_lateral(**kwargs)
+
+        router._try_lateral_via_escape = spy_lateral  # type: ignore[method-assign]
+
+        package = _make_qfp_west_edge_package(n_pads=6)
+        # Inject the pads into the grid so the dispatcher's clearance
+        # checks see real pad copper.
+        for pad in package.pads:
+            router.grid.add_pad(pad)
+
+        # Run the QFP dispatcher; with strict mode + forced in-pad
+        # deferral, any clearance violation should funnel through the
+        # lateral helper.
+        try:
+            router._escape_qfp_alternating(package)
+        except Exception:  # noqa: BLE001
+            # Minimal fixtures may trip downstream assertions; the
+            # spy is what matters here.
+            pass
+
+        assert calls, (
+            "Strict-mode dispatcher must invoke _try_lateral_via_escape "
+            "after _try_in_pad_escape returns None; the spy recorded "
+            "zero calls.  This indicates the dispatcher-site wiring is "
+            "broken at the QFP-alternating site (escape.py ~2247)."
+        )
+
+    def test_dispatcher_does_not_invoke_lateral_in_non_strict_mode(self):
+        """With strict mode OFF, the dispatcher must NOT invoke the
+        lateral helper -- it relies on the in-pad helper's
+        commit-anyway branch instead.  This pins the strict-gating
+        contract so a future refactor doesn't accidentally enable the
+        lateral path for legacy callers.
+        """
+        router = _build_router(strict=False)
+        # In-pad helper returns None to simulate the violation case
+        # (it would normally commit a violating route here; we force
+        # None to make the dispatcher's lateral-gate the ONLY remaining
+        # action).
+        router._try_in_pad_escape = lambda **kwargs: None  # type: ignore[method-assign]
+
+        calls: list[dict] = []
+        original_lateral = router._try_lateral_via_escape
+
+        def spy_lateral(**kwargs):
+            calls.append(kwargs)
+            return original_lateral(**kwargs)
+
+        router._try_lateral_via_escape = spy_lateral  # type: ignore[method-assign]
+
+        package = _make_qfp_west_edge_package(n_pads=6)
+        for pad in package.pads:
+            router.grid.add_pad(pad)
+
+        try:
+            router._escape_qfp_alternating(package)
+        except Exception:  # noqa: BLE001
+            pass
+
+        assert not calls, (
+            "Non-strict mode must NOT invoke the lateral helper -- the "
+            "lateral path is the strict-mode-only escape valve.  Got "
+            f"{len(calls)} call(s)."
+        )


### PR DESCRIPTION
## Summary (post-judge-feedback scope reduction)

Ships the infrastructure half of #3063: a new `_try_lateral_via_escape()` helper that retries strict-mode in-pad deferrals with an off-pad via along the natural escape direction, plus a fix for an origin-related bounds bug in `_can_place_via`, plus 10 synthetic-fixture tests.

**The board-04 customer half of #3063 was reverted in this PR.** The judge ran the originally-proposed strict-mode opt-in against a fresh baseline and found it regresses board 04 (9/9 nets -> 8/9 nets + 7 new DRC errors including segment/segment overlaps). The builder's "6/9 -> 8/9" comparison had been measured against a stale baseline.

**Follow-up filed**: #3073 (investigate WHY strict-mode + lateral helper regresses board 04; the helper SHOULD find a clean candidate for the dropped net's pin).

## Key changes (preserved)

- **`src/kicad_tools/router/escape.py`**
  - New `_try_lateral_via_escape()` helper: walks outward along the escape direction in 0.05 mm steps, validating each candidate via `_can_place_via` (same predicate as the in-pad rescue). The search budget is auto-derived from pad geometry (`proj_half + via_radius + clearance + step`) so fine-pitch oblong pads (LQFP-48 0.3 x 1.5 mm) get enough room to escape the own pad copper.
  - Wires the lateral helper into all 3 dispatcher call sites that forward `strict_in_pad_clearance` to `_try_in_pad_escape`. The QFP-alternating site uses `primary_dir` (perpendicular outward from chip body) -- NOT the alt direction, which for odd-index pins is along-edge and would search into the next pin in the row.
  - **Fixes `_can_place_via` grid bounds check to be origin-aware**: pre-fix was `0 <= x <= grid.width`, which was implicitly correct only for grids constructed with `origin_x=origin_y=0`. Boards whose grid sits at non-zero origin (e.g. board 04 at world coords ~(95, 90)) had every world-coord candidate rejected on bounds. The fix uses `origin_x <= x <= origin_x + grid.width`. Without this fix the lateral re-attempt is a no-op on real boards.

- **`tests/test_escape_lateral_recovery.py` (NEW, 10 tests)**: pins
  - Success case: open lane, lateral via found at smallest valid offset (0.10 mm with pinned geometry note)
  - Failure cases: blocked SOUTH lane, unsupported manufacturer, `VIA_DOWN` sentinel direction
  - Strict-gating contract: legacy mode (strict=False) skips the lateral helper
  - Dispatcher wiring: spy assertions on both strict-on and strict-off
  - `_can_place_via` bounds: origin-aware acceptance and rejection on offset grids (pins the grid-origin fix against regression)

## Changes (reverted post-judge-feedback)

- **`boards/04-stm32-devboard/generate_design.py`**: the `--strict-in-pad-clearance` opt-in has been removed. `--seed 42` is kept (generic determinism win from #3039, unrelated to strict mode). The docstring records the experiment outcome and references the follow-up investigation (#3073).
- **`boards/04-stm32-devboard/output/*`**: regenerated WITHOUT strict mode. Routing reports **9/9 nets (100%)**; `kct check --mfr jlcpcb-tier1` reports **6 DRC errors** (3 `clearance_segment_via`, 2 `clearance_pad_via`, 1 `connectivity` GND-stitch). Matches the origin/main baseline.

## Why the strict-mode opt-in was reverted

Judge's measurements at `--seed 42`:

| Metric | Pure baseline (origin/main) | This PR with `--strict-in-pad-clearance` |
|---|---|---|
| Nets connected | **9 / 9** | 8 / 9 |
| Total DRC errors | **6** | 13 |
| Includes severely overlapping copper (-0.200 mm clearance)? | no | **yes** |

The builder's earlier "6/9 -> 8/9" win was measured against a stale baseline that did not include the routing improvements that have since landed on `main`. Net-net the strict-mode opt-in is a regression on this customer board today.

The lateral helper itself is sound (10 synthetic-fixture tests pass).  The question of why it does not find a clean candidate for board 04's dropped pin is captured in follow-up issue #3073.

## Board 04 results (after revert, `--seed 42`, full `kct route` pipeline)

| Metric | Value |
|---|---|
| Nets connected (routing) | **9 / 9 (100%)** |
| Total DRC errors (`kct check --mfr jlcpcb-tier1`) | **6** |
| `clearance_segment_via` errors | 3 |
| `clearance_pad_via` errors | 2 |
| `connectivity` errors (GND stitch) | 1 |

Matches origin/main baseline. No regression.

## Test plan

- [x] `uv run pytest tests/test_escape_lateral_recovery.py -q --no-cov` — 10 / 10 pass (post-revert)
- [x] Board 04 regenerated; `kct check --mfr jlcpcb-tier1` reports 6 errors (== origin/main baseline)
- [x] Routing pipeline reports 9/9 nets (== origin/main baseline)

## Acceptance criteria (revised scope)

- [x] **Lateral helper exists and is wired into the 3 strict-mode call sites** (QFP-alternating + 2 SSOP/TSSOP sites)
- [x] **Synthetic-fixture regression test** in `tests/test_escape_lateral_recovery.py` covers the deferral-then-recovery case AND the grid-origin bounds bug
- [x] **`_can_place_via` grid-origin bounds bug fixed** (helper is non-no-op on real boards)
- [x] **No regression on board 04** (9/9 nets, 6 DRC errors == origin/main baseline)
- [ ] **Real customer board for strict-mode opt-in** — DEFERRED to #3073

## Issue close behaviour

This PR partially closes #3063: the lateral helper + bounds fix + tests ship here.  The "real customer for strict mode" half is deferred to follow-up #3073.  Recommend leaving #3063 OPEN with reduced scope (or rename it to "infrastructure"); #3073 covers the customer investigation.

(`Closes #3063` removed from PR body to avoid auto-close; the merge script's trailer scan still sees the commit message — but the commit message intentionally does NOT contain a `Closes #3063` trailer.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)