### PR TITLE
fix(ci): exclude advisory rules from Routed PCB DRC Check gate (closes #3074)

### DIFF
--- a/.github/routed-drc-tolerance.yml
+++ b/.github/routed-drc-tolerance.yml
@@ -379,6 +379,19 @@ tolerances:
   #   `manufacturers:` mapping below (see the schema at the top of
   #   the file).  The floor of 4 continues to track ONLY real OSC_OUT
   #   geometry violations under the profile this board ships against.
+  #
+  # Issue #3074: PR #3060 introduced the `connectivity` rule.  Re-routes
+  # of this board on `main` produce 4 blocking errors (2
+  # `clearance_segment_via` + 2 `clearance_pad_via` at the OSC_OUT
+  # cluster above) PLUS 1 advisory `connectivity` finding for a
+  # GND-stitch pad the router could not reach.  The CI gate now mirrors
+  # the audit pipeline's classification (`DRCChecker.is_advisory_rule`)
+  # and excludes advisory rules from the verdict, so the 1
+  # `connectivity` finding does NOT count toward the 4-error allowlist
+  # here.  The advisory still surfaces in the gate's diagnostic output
+  # (an `[advisory (excluded from gate): connectivity=N]` suffix on the
+  # OK message).  Underlying GND stitch follow-up rides with #2834
+  # (manufacturing-ready cluster).
   boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb: 4
 
 # Per-board manufacturer overrides for the CI gate (optional).

--- a/scripts/ci/check_routed_drc.py
+++ b/scripts/ci/check_routed_drc.py
@@ -17,6 +17,16 @@ files not listed in the allowlist must report 0 errors. This implements the
 "allowed minus epsilon" semantic: regressions (count going UP) are caught,
 even on boards that are grandfathered in with non-zero counts.
 
+Advisory-rule classification (issue #3074):
+    The gate's verdict mirrors the audit pipeline's classification
+    (``src/kicad_tools/audit/auditor.py``).  Rules registered in
+    ``DRCChecker.ADVISORY_RULE_IDS`` (currently just ``connectivity``) are
+    surfaced in the printed report but excluded from the count that gates
+    the build.  This keeps the gate's verdict aligned with what blocks
+    manufacturability per ``ManufacturingAudit._check_drc`` -- the
+    standalone ``kct check`` CLI still reports the unfiltered count, so a
+    PR may see ``kct check`` report N+1 errors while CI counts N.
+
 Exit codes:
     0 -- All inputs within tolerance (job passes).
     1 -- Tool failure (allowlist parse error, kct check crash, etc.).
@@ -36,6 +46,18 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+
+# The CI gate mirrors the audit pipeline's advisory-rule classification
+# (``src/kicad_tools/audit/auditor.py:768``) so any rule classified as
+# advisory by :class:`DRCChecker.ADVISORY_RULE_IDS` does NOT block the gate.
+# Today that is just ``connectivity`` (partial-route reports surface in the
+# diagnostic output but do not gate manufacturability).
+#
+# The import lives here at module scope so a missing/renamed classifier
+# surfaces immediately at script start, not deep inside ``count_errors``.
+# The helper script runs under ``uv run`` (see ``main()`` call to
+# ``uv run kct check``) so ``kicad_tools`` is always importable.
+from kicad_tools.validate.checker import DRCChecker  # noqa: E402
 
 DEFAULT_ALLOWLIST = Path(".github/routed-drc-tolerance.yml")
 DEFAULT_MANUFACTURER = "jlcpcb"
@@ -154,8 +176,80 @@ def load_manufacturers(allowlist_path: Path) -> dict[str, str]:
     return result
 
 
-def count_errors(pcb_path: Path, mfr: str = DEFAULT_MANUFACTURER) -> int:
-    """Run ``kct check`` and return the error count.
+def _count_blocking_errors(data: dict[str, Any]) -> tuple[int, dict[str, int]]:
+    """Filter advisory rules out of a ``kct check --format json`` payload.
+
+    The gating verdict mirrors the audit pipeline's classifier
+    (``DRCChecker.is_advisory_rule``): rules in
+    :attr:`DRCChecker.ADVISORY_RULE_IDS` (currently just ``connectivity``)
+    surface to consumers but do not block manufacturability.  PR #3060 added
+    the ``connectivity`` rule and PR #3064 introduced the central classifier;
+    this helper makes the CI gate honour the same severity model as
+    ``ManufacturingAudit._check_drc``.
+
+    Args:
+        data: Parsed JSON object emitted by ``kct check --format json``.
+            Expected to contain ``violations`` (a list with per-violation
+            ``rule_id`` and ``severity`` fields) and a ``summary.errors``
+            integer (the unfiltered count, used as a fall-back when no
+            ``violations`` array is present).
+
+    Returns:
+        Tuple of ``(blocking_errors, advisory_by_rule)``:
+
+        * ``blocking_errors`` -- number of error-severity violations whose
+          ``rule_id`` is NOT in ``ADVISORY_RULE_IDS``.  This is what the
+          gate compares to the allowlist.
+        * ``advisory_by_rule`` -- mapping of advisory ``rule_id`` to count
+          of error-severity violations of that rule, so callers can still
+          print the connectivity findings for diagnostic visibility per
+          the issue #3074 AC ("connectivity rule still appears in
+          violation reports").
+
+    Raises:
+        RuntimeError: If the JSON lacks both a ``violations`` array and a
+            ``summary.errors`` integer (the payload is malformed).
+    """
+    violations = data.get("violations")
+    if isinstance(violations, list):
+        blocking = 0
+        advisory_by_rule: dict[str, int] = {}
+        for v in violations:
+            if not isinstance(v, dict):
+                continue
+            # Only error-severity violations count toward the gate; warnings
+            # are filtered upstream by ``--errors-only`` but we re-check
+            # defensively in case a future flag change loosens that.
+            severity = v.get("severity", "error")
+            if severity != "error":
+                continue
+            rule_id = v.get("rule_id", "")
+            if not isinstance(rule_id, str):
+                continue
+            if DRCChecker.is_advisory_rule(rule_id):
+                advisory_by_rule[rule_id] = advisory_by_rule.get(rule_id, 0) + 1
+            else:
+                blocking += 1
+        return blocking, advisory_by_rule
+
+    # Fall-back: no per-violation array (legacy format).  Trust
+    # ``summary.errors``.  Advisory awareness degrades gracefully -- the
+    # gate behaves exactly as it did before this change in that path.
+    summary = data.get("summary", {})
+    errors = summary.get("errors")
+    if not isinstance(errors, int):
+        raise RuntimeError(f"kct check JSON missing both violations and summary.errors: {data!r}")
+    return errors, {}
+
+
+def count_errors(pcb_path: Path, mfr: str = DEFAULT_MANUFACTURER) -> tuple[int, dict[str, int]]:
+    """Run ``kct check`` and return the (blocking) error count.
+
+    Advisory-rule violations (per :attr:`DRCChecker.ADVISORY_RULE_IDS`,
+    currently ``connectivity``) are excluded from the returned count so the
+    gate's verdict matches the audit pipeline's blocking-vs-advisory
+    classification.  Advisory findings are returned separately so the gate
+    can still surface them in diagnostic output without gating on them.
 
     Args:
         pcb_path: Path to a ``.kicad_pcb`` file.
@@ -164,7 +258,10 @@ def count_errors(pcb_path: Path, mfr: str = DEFAULT_MANUFACTURER) -> int:
             come from ``load_manufacturers``.
 
     Returns:
-        Number of errors reported (0 if the gate passes natively).
+        Tuple ``(blocking_errors, advisory_by_rule)``.  ``blocking_errors``
+        is what the gate compares to the per-board allowlist;
+        ``advisory_by_rule`` maps each advisory ``rule_id`` to its
+        error-severity count for diagnostic surfacing.
 
     Raises:
         RuntimeError: If kct check fails to run (exit code 1) or emits
@@ -205,11 +302,10 @@ def count_errors(pcb_path: Path, mfr: str = DEFAULT_MANUFACTURER) -> int:
             f"stdout (first 500 chars):\n{proc.stdout[:500]}"
         ) from e
 
-    summary = data.get("summary", {})
-    errors = summary.get("errors")
-    if not isinstance(errors, int):
-        raise RuntimeError(f"kct check JSON missing summary.errors field for {pcb_path}: {data!r}")
-    return errors
+    try:
+        return _count_blocking_errors(data)
+    except RuntimeError as e:
+        raise RuntimeError(f"{e} (source: {pcb_path})") from e
 
 
 def annotate_error(file: str, message: str) -> None:
@@ -253,48 +349,78 @@ def annotate_drift_warning(file: str, errors: int, allowed: int) -> None:
     )
 
 
+def _format_advisory_suffix(advisory_by_rule: dict[str, int]) -> str:
+    """Render an advisory-rule summary for log messages.
+
+    Per issue #3074: the gate excludes advisory rules from its verdict but
+    must still surface them in the printed report so reviewers can see the
+    connectivity findings.  Returns an empty string when no advisory
+    violations are present so the common case (no advisories) leaves the
+    OK/FAIL message unchanged.
+    """
+    if not advisory_by_rule:
+        return ""
+    parts = ", ".join(f"{rule_id}={count}" for rule_id, count in sorted(advisory_by_rule.items()))
+    return f" [advisory (excluded from gate): {parts}]"
+
+
 def check_file(
     pcb_path: Path, allowed: int, mfr: str = DEFAULT_MANUFACTURER
 ) -> tuple[bool, str, int]:
     """Check a single PCB against its allowed error count.
 
+    The gate's verdict excludes advisory rules (see
+    :attr:`DRCChecker.ADVISORY_RULE_IDS`, currently ``connectivity``) so
+    advisory findings do not block CI even when they appear in the per-
+    violation list emitted by ``kct check --format json``.  This mirrors
+    the audit pipeline's blocking-vs-advisory classification.
+
     Args:
         pcb_path: Path to a ``.kicad_pcb`` file.
-        allowed: Maximum error count this PCB may report before failing.
+        allowed: Maximum (blocking) error count this PCB may report before
+            failing.  Advisory-rule errors are excluded from the count
+            being compared, so a board listed at ``allowed=4`` with
+            ``4 blocking + N connectivity`` passes regardless of ``N``.
         mfr: Manufacturer-profile name to pass via ``--mfr``.
 
     Returns:
         ``(passed, message, errors)`` tuple. ``passed`` is True if
-        ``errors <= allowed``. ``message`` is a human-readable summary
-        suitable for both stdout and GitHub annotation. ``errors`` is the
-        actual count returned by ``kct check`` so callers can compute drift
-        slack without re-running the (expensive) DRC check.
+        ``errors <= allowed`` (advisory-filtered count).  ``message`` is a
+        human-readable summary suitable for both stdout and GitHub
+        annotation; when advisory violations are present it includes a
+        ``[advisory (excluded from gate): ...]`` suffix so reviewers see
+        them.  ``errors`` is the blocking-only count so callers compute
+        drift slack against the gate's actual floor.
     """
-    errors = count_errors(pcb_path, mfr=mfr)
+    errors, advisory_by_rule = count_errors(pcb_path, mfr=mfr)
+    advisory_suffix = _format_advisory_suffix(advisory_by_rule)
     if errors <= allowed:
         if allowed == 0:
-            msg = f"OK: {pcb_path} -- 0 errors (strict gate, --mfr {mfr})."
+            msg = f"OK: {pcb_path} -- 0 errors (strict gate, --mfr {mfr}).{advisory_suffix}"
         else:
             msg = (
                 f"OK: {pcb_path} -- {errors} errors (--mfr {mfr}, allowlist "
                 f"max {allowed}; reduce the allowlist value in "
                 f".github/routed-drc-tolerance.yml if this count drops further)."
+                f"{advisory_suffix}"
             )
         return True, msg, errors
 
     if allowed == 0:
         msg = (
             f"DRC errors detected by `kct check --mfr {mfr} --errors-only`: "
-            f"{errors} error(s). Boards NOT in .github/routed-drc-tolerance.yml "
-            f"must report 0 errors. Either fix the routing or, if grandfathering "
-            f"is justified, add an explicit allowlist entry with reviewer sign-off."
+            f"{errors} blocking error(s) (advisory rules excluded). Boards NOT "
+            f"in .github/routed-drc-tolerance.yml must report 0 errors. Either "
+            f"fix the routing or, if grandfathering is justified, add an "
+            f"explicit allowlist entry with reviewer sign-off.{advisory_suffix}"
         )
     else:
         msg = (
-            f"DRC regression: {errors} error(s) (--mfr {mfr}) exceeds allowlist "
-            f"value {allowed} in .github/routed-drc-tolerance.yml. Either fix "
-            f"the new violations, or (if intentional) raise the allowlist value "
-            f"with reviewer sign-off."
+            f"DRC regression: {errors} blocking error(s) (--mfr {mfr}, "
+            f"advisory rules excluded) exceeds allowlist value {allowed} in "
+            f".github/routed-drc-tolerance.yml. Either fix the new violations, "
+            f"or (if intentional) raise the allowlist value with reviewer "
+            f"sign-off.{advisory_suffix}"
         )
     return False, msg, errors
 

--- a/tests/test_check_routed_drc_advisory.py
+++ b/tests/test_check_routed_drc_advisory.py
@@ -1,0 +1,317 @@
+"""Tests for advisory-rule exclusion in the routed-PCB DRC CI gate (issue #3074).
+
+PR #3060 added the ``connectivity`` rule to ``DRCChecker``; the rule
+reports partial-route GND/VCC nets that the audit pipeline classifies as
+*advisory* (``DRCChecker.ADVISORY_RULE_IDS = frozenset({"connectivity"})``)
+because they reflect routing completeness rather than manufacturability.
+PR #3064 introduced the ``DRCChecker.is_advisory_rule()`` classifier so
+every entry point can filter consistently.
+
+Issue #3074 found that ``scripts/ci/check_routed_drc.py`` was still
+trusting the unfiltered ``summary.errors`` from ``kct check --format
+json``, so board 04's main-routed PCB produced 5 errors (4 blocking + 1
+``connectivity``) and tripped its allowlist of 4.  Bumping the allowlist
+to 5 would have to be repeated every time a new advisory rule shipped;
+the right fix is for the gate to honour the same advisory classification
+the audit pipeline already uses (``ManufacturingAudit._check_drc`` at
+``src/kicad_tools/audit/auditor.py:768``).
+
+These tests stub the subprocess boundary (``kct check`` is expensive and
+needs KiCad data) so they exercise the gate's filtering logic in
+isolation.  The synthetic JSON payloads mirror the shape produced by
+``DRCViolation.to_dict()`` (per ``src/kicad_tools/validate/models.py``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HELPER_SCRIPT_PATH = REPO_ROOT / "scripts" / "ci" / "check_routed_drc.py"
+
+
+def _load_helper_module():
+    """Import ``scripts/ci/check_routed_drc.py`` as a module."""
+    spec = importlib.util.spec_from_file_location("check_routed_drc", HELPER_SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_routed_drc"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_violation(rule_id: str, severity: str = "error", message: str = "synthetic") -> dict:
+    """Synthesize a single violation dict matching ``DRCViolation.to_dict()``.
+
+    Only the fields the gate reads (``rule_id`` and ``severity``) are
+    load-bearing; the rest are filled in so the payload looks like real
+    ``kct check`` JSON output for any future caller that inspects more
+    fields.
+    """
+    return {
+        "rule_id": rule_id,
+        "type": rule_id,
+        "severity": severity,
+        "message": message,
+        "location": [10.0, 20.0],
+        "layer": "F.Cu",
+        "actual_value": 0.1,
+        "required_value": 0.127,
+        "items": [],
+    }
+
+
+def _make_kct_json(violations: list[dict]) -> str:
+    """Build a ``kct check --format json`` payload around a violation list.
+
+    Mirrors ``src/kicad_tools/cli/drc_cmd.py::output_json``.
+    """
+    payload = {
+        "source": "synthetic.kicad_pcb",
+        "pcb_name": "synthetic",
+        "summary": {
+            "errors": sum(1 for v in violations if v.get("severity") == "error"),
+            "warnings": sum(1 for v in violations if v.get("severity") != "error"),
+        },
+        "violations": violations,
+    }
+    return json.dumps(payload)
+
+
+class TestAdvisoryRuleIdsImport:
+    """Pin that the helper imports the classifier from the canonical source.
+
+    A future refactor that hardcodes a local set instead of using
+    ``DRCChecker.is_advisory_rule`` would silently drift -- the audit
+    pipeline and the gate must stay in lockstep.
+    """
+
+    def setup_method(self) -> None:
+        self.helper = _load_helper_module()
+
+    def test_helper_imports_drcchecker(self) -> None:
+        """The helper module must expose the imported ``DRCChecker`` so
+        the gate's filtering uses the same classifier as the audit
+        pipeline (``src/kicad_tools/audit/auditor.py:768``)."""
+        assert hasattr(self.helper, "DRCChecker"), (
+            "scripts/ci/check_routed_drc.py must import DRCChecker so the "
+            "advisory-rule classifier stays in lockstep with the audit "
+            "pipeline (issue #3074)."
+        )
+
+    def test_connectivity_is_currently_advisory(self) -> None:
+        """Document the current ADVISORY_RULE_IDS membership so a future
+        refactor that drops ``connectivity`` (or adds a new rule whose
+        severity should NOT block the gate) surfaces a test failure that
+        triggers an explicit re-think rather than a silent CI drift."""
+        assert self.helper.DRCChecker.is_advisory_rule("connectivity")
+        # Non-advisory blocking rules must NOT be misclassified.
+        assert not self.helper.DRCChecker.is_advisory_rule("clearance_segment_via")
+        assert not self.helper.DRCChecker.is_advisory_rule("clearance_pad_via")
+
+
+class TestCountBlockingErrorsDirect:
+    """Unit tests for the pure ``_count_blocking_errors`` filter (no
+    subprocess required).  These exercise the load-bearing JSON-shape
+    handling in isolation."""
+
+    def setup_method(self) -> None:
+        self.helper = _load_helper_module()
+
+    def test_empty_violations_is_zero(self) -> None:
+        """A clean PCB returns 0 blocking with no advisory entries."""
+        data = json.loads(_make_kct_json([]))
+        blocking, advisory = self.helper._count_blocking_errors(data)
+        assert blocking == 0
+        assert advisory == {}
+
+    def test_pure_blocking_passes_through(self) -> None:
+        """No advisory rules -> the count matches summary.errors verbatim
+        (this is the historical behaviour the original gate produced)."""
+        violations = [
+            _make_violation("clearance_segment_via"),
+            _make_violation("clearance_pad_via"),
+            _make_violation("clearance_pad_segment"),
+        ]
+        data = json.loads(_make_kct_json(violations))
+        blocking, advisory = self.helper._count_blocking_errors(data)
+        assert blocking == 3
+        assert advisory == {}
+
+    def test_pure_advisory_does_not_block(self) -> None:
+        """A board whose only errors are advisory must report 0 blocking
+        so the gate's verdict passes regardless of allowlist value.
+
+        This is the headline AC for issue #3074: the connectivity rule
+        is a routing-completeness signal, not a manufacturability
+        blocker."""
+        violations = [
+            _make_violation("connectivity"),
+            _make_violation("connectivity"),
+        ]
+        data = json.loads(_make_kct_json(violations))
+        blocking, advisory = self.helper._count_blocking_errors(data)
+        assert blocking == 0
+        assert advisory == {"connectivity": 2}
+
+    def test_mixed_keeps_blocking_drops_advisory(self) -> None:
+        """The board 04 scenario from issue #3074: 4 blocking +
+        1 connectivity -> gate counts 4."""
+        violations = [
+            _make_violation("clearance_segment_via"),
+            _make_violation("clearance_segment_via"),
+            _make_violation("clearance_pad_via"),
+            _make_violation("clearance_pad_via"),
+            _make_violation("connectivity"),
+        ]
+        data = json.loads(_make_kct_json(violations))
+        blocking, advisory = self.helper._count_blocking_errors(data)
+        assert blocking == 4
+        assert advisory == {"connectivity": 1}
+
+    def test_warning_severity_excluded_from_blocking(self) -> None:
+        """``--errors-only`` filters warnings upstream, but the helper
+        defends against a future flag change by re-checking severity."""
+        violations = [
+            _make_violation("clearance_segment_via", severity="error"),
+            _make_violation("clearance_segment_via", severity="warning"),
+        ]
+        data = json.loads(_make_kct_json(violations))
+        blocking, advisory = self.helper._count_blocking_errors(data)
+        assert blocking == 1
+        assert advisory == {}
+
+    def test_legacy_payload_no_violations_array_falls_back(self) -> None:
+        """If a future ``kct check`` mode omits per-violation entries,
+        the helper degrades to trusting ``summary.errors`` so the gate
+        keeps working with no advisory awareness (the original
+        pre-#3074 behaviour)."""
+        data = {"summary": {"errors": 7, "warnings": 0}}  # no "violations" key
+        blocking, advisory = self.helper._count_blocking_errors(data)
+        assert blocking == 7
+        assert advisory == {}
+
+    def test_malformed_payload_raises_runtimeerror(self) -> None:
+        """Neither a ``violations`` list nor a ``summary.errors`` int
+        means the JSON is corrupt -- the helper must surface that
+        rather than silently report 0."""
+        data: dict = {}  # empty payload
+        with pytest.raises(RuntimeError, match="missing both violations and summary.errors"):
+            self.helper._count_blocking_errors(data)
+
+
+class TestCheckFileAdvisoryFiltering:
+    """Integration of ``count_errors`` + ``check_file`` -- the gate's
+    public surface -- with the advisory filter enabled.
+
+    These stub the subprocess so we exercise the full message-formatting
+    flow without needing a real ``kct check`` run.
+    """
+
+    def setup_method(self) -> None:
+        self.helper = _load_helper_module()
+
+    def _stub_kct(self, json_payload: str, returncode: int = 2):
+        """Build a ``subprocess.run`` patch that returns the given JSON.
+
+        ``returncode=2`` matches ``kct check`` exiting with errors found
+        (the natural state for any payload with blocking violations).
+        """
+        mock_proc = MagicMock()
+        mock_proc.returncode = returncode
+        mock_proc.stdout = json_payload
+        mock_proc.stderr = ""
+        return patch.object(subprocess, "run", return_value=mock_proc)
+
+    def test_board04_scenario_passes_with_advisory_exclusion(self) -> None:
+        """4 blocking + 1 connectivity -> reports 4 errors, exits 0
+        against allowlist 4.
+
+        This is the exact scenario from issue #3074 (board 04 on main).
+        Without advisory filtering the count would be 5 and the gate
+        would fail; with filtering it passes and the connectivity
+        finding shows up in the message suffix."""
+        violations = [
+            _make_violation("clearance_segment_via"),
+            _make_violation("clearance_segment_via"),
+            _make_violation("clearance_pad_via"),
+            _make_violation("clearance_pad_via"),
+            _make_violation("connectivity"),
+        ]
+        with self._stub_kct(_make_kct_json(violations)):
+            passed, msg, errors = self.helper.check_file(
+                Path("boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb"),
+                allowed=4,
+                mfr="jlcpcb-tier1",
+            )
+        assert passed
+        assert errors == 4
+        # The OK message must mention the advisory finding so reviewers
+        # can still see the connectivity violation for debugging.
+        assert "connectivity=1" in msg
+        assert "advisory" in msg.lower()
+
+    def test_blocking_only_regression_still_fails(self) -> None:
+        """5 blocking + 1 connectivity vs allowlist 4 -> still fails on
+        the 5 blocking.  Advisory exclusion must NOT mask a real
+        regression."""
+        violations = [
+            _make_violation("clearance_segment_via"),
+            _make_violation("clearance_segment_via"),
+            _make_violation("clearance_pad_via"),
+            _make_violation("clearance_pad_via"),
+            _make_violation("clearance_segment_segment"),
+            _make_violation("connectivity"),
+        ]
+        with self._stub_kct(_make_kct_json(violations)):
+            passed, msg, errors = self.helper.check_file(
+                Path("boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb"),
+                allowed=4,
+                mfr="jlcpcb-tier1",
+            )
+        assert not passed
+        assert errors == 5
+        assert "regression" in msg.lower()
+        # Advisory is still surfaced even on FAIL so the reviewer sees
+        # the complete picture in the diagnostic.
+        assert "connectivity=1" in msg
+
+    def test_pure_advisory_on_strict_board_passes(self) -> None:
+        """A board not in the allowlist (allowed=0) with only advisory
+        violations passes the strict gate.  Issue #3074 scenario for
+        clean boards like 01: 0 blocking + 1 connectivity = pass."""
+        violations = [_make_violation("connectivity")]
+        # kct check exits 2 when ANY error is reported (advisory or not);
+        # the helper must still produce a clean-pass verdict.
+        with self._stub_kct(_make_kct_json(violations)):
+            passed, msg, errors = self.helper.check_file(
+                Path("boards/01-voltage-divider/output/voltage_divider_routed.kicad_pcb"),
+                allowed=0,
+                mfr="jlcpcb",
+            )
+        assert passed
+        assert errors == 0
+        assert "0 errors" in msg
+        assert "connectivity=1" in msg
+
+    def test_no_advisory_no_suffix(self) -> None:
+        """Common case: no advisory violations -> message has no
+        advisory suffix, preserving the historical log shape so the
+        existing CI-output parsers / human reviewers don't see noise."""
+        violations = [_make_violation("clearance_segment_via")]
+        with self._stub_kct(_make_kct_json(violations)):
+            passed, msg, errors = self.helper.check_file(
+                Path("boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb"),
+                allowed=4,
+                mfr="jlcpcb",
+            )
+        assert passed
+        assert errors == 1
+        assert "advisory" not in msg.lower()

--- a/tests/test_ci_routed_drc_workflow.py
+++ b/tests/test_ci_routed_drc_workflow.py
@@ -347,7 +347,10 @@ class TestHelperCheckFile:
         self.helper = _load_helper_module()
 
     def test_zero_errors_zero_allowed_passes(self) -> None:
-        with patch.object(self.helper, "count_errors", return_value=0):
+        # Issue #3074: count_errors now returns (blocking_errors,
+        # advisory_by_rule).  Stub with the no-advisory tuple to keep
+        # the historical semantics of "0 blocking + 0 advisory".
+        with patch.object(self.helper, "count_errors", return_value=(0, {})):
             passed, msg, errors = self.helper.check_file(Path("foo.kicad_pcb"), allowed=0)
         assert passed
         assert "0 errors" in msg
@@ -356,7 +359,7 @@ class TestHelperCheckFile:
     def test_under_allowed_passes(self) -> None:
         """A board grandfathered at 17 errors that drops to 5 must pass --
         the gate is "allowed minus epsilon", not "exact match"."""
-        with patch.object(self.helper, "count_errors", return_value=5):
+        with patch.object(self.helper, "count_errors", return_value=(5, {})):
             passed, msg, errors = self.helper.check_file(Path("foo.kicad_pcb"), allowed=17)
         assert passed
         assert "5 errors" in msg
@@ -367,14 +370,14 @@ class TestHelperCheckFile:
 
     def test_at_allowed_passes(self) -> None:
         """Equal-to-allowed is the steady state for a grandfathered board."""
-        with patch.object(self.helper, "count_errors", return_value=17):
+        with patch.object(self.helper, "count_errors", return_value=(17, {})):
             passed, _, errors = self.helper.check_file(Path("foo.kicad_pcb"), allowed=17)
         assert passed
         assert errors == 17
 
     def test_over_allowed_fails_grandfathered(self) -> None:
         """Regression on a grandfathered board: 17 -> 22. Must fail."""
-        with patch.object(self.helper, "count_errors", return_value=22):
+        with patch.object(self.helper, "count_errors", return_value=(22, {})):
             passed, msg, errors = self.helper.check_file(Path("foo.kicad_pcb"), allowed=17)
         assert not passed
         assert "regression" in msg.lower()
@@ -387,7 +390,7 @@ class TestHelperCheckFile:
         report 0 errors. Any errors mean the gate fails. This is the
         critical assertion that PR #2538's merge state would have
         triggered (board 04 with 5 errors)."""
-        with patch.object(self.helper, "count_errors", return_value=5):
+        with patch.object(self.helper, "count_errors", return_value=(5, {})):
             passed, msg, errors = self.helper.check_file(
                 Path("boards/04-x/output/x_routed.kicad_pcb"), allowed=0
             )
@@ -395,7 +398,7 @@ class TestHelperCheckFile:
         # Message must point the contributor at the allowlist for the
         # grandfathering escape hatch.
         assert "routed-drc-tolerance.yml" in msg
-        assert "5 error" in msg
+        assert "5 " in msg and "error" in msg
         assert errors == 5
 
     def test_mfr_override_forwards_to_count_errors(self) -> None:
@@ -403,7 +406,7 @@ class TestHelperCheckFile:
         must reach ``count_errors`` as the ``mfr`` keyword (not be silently
         dropped).  Pin this so a future refactor of the call chain doesn't
         regress board-04's tier-aware measurement."""
-        with patch.object(self.helper, "count_errors", return_value=4) as mock:
+        with patch.object(self.helper, "count_errors", return_value=(4, {})) as mock:
             passed, msg, errors = self.helper.check_file(
                 Path("foo.kicad_pcb"), allowed=4, mfr="jlcpcb-tier1"
             )
@@ -420,7 +423,7 @@ class TestHelperCheckFile:
     def test_mfr_default_is_jlcpcb(self) -> None:
         """When no override is supplied, ``check_file`` must fall back to
         the strict ``jlcpcb`` profile (the historical default)."""
-        with patch.object(self.helper, "count_errors", return_value=0) as mock:
+        with patch.object(self.helper, "count_errors", return_value=(0, {})) as mock:
             self.helper.check_file(Path("foo.kicad_pcb"), allowed=0)
         call_kwargs = mock.call_args.kwargs
         # Default may be passed explicitly or omitted; both routes resolve
@@ -576,7 +579,8 @@ class TestMainDriftWarningEmission:
         but a ``::warning file=...::`` MUST be emitted so the reviewer
         sees the stale entry. This is the regression test for #2590."""
         pcb, allowlist = self._make_pcb_and_allowlist(tmp_path, allowlist_value=17)
-        with patch.object(self.helper, "count_errors", return_value=15):
+        # Issue #3074: count_errors returns (blocking, advisory_by_rule).
+        with patch.object(self.helper, "count_errors", return_value=(15, {})):
             rc = self.helper.main(["--allowlist", str(allowlist), str(pcb)])
         assert rc == 0  # gate still passes
         captured = capsys.readouterr()
@@ -591,7 +595,7 @@ class TestMainDriftWarningEmission:
         """Steady state: actual=17, allowlist=17. No warning -- the
         floor matches reality. (The OK message still goes to stdout.)"""
         pcb, allowlist = self._make_pcb_and_allowlist(tmp_path, allowlist_value=17)
-        with patch.object(self.helper, "count_errors", return_value=17):
+        with patch.object(self.helper, "count_errors", return_value=(17, {})):
             rc = self.helper.main(["--allowlist", str(allowlist), str(pcb)])
         assert rc == 0
         captured = capsys.readouterr()
@@ -607,7 +611,7 @@ class TestMainDriftWarningEmission:
         ::error::, and we must NOT also emit a drift warning -- the
         problem here is too many errors, not a stale floor."""
         pcb, allowlist = self._make_pcb_and_allowlist(tmp_path, allowlist_value=17)
-        with patch.object(self.helper, "count_errors", return_value=22):
+        with patch.object(self.helper, "count_errors", return_value=(22, {})):
             rc = self.helper.main(["--allowlist", str(allowlist), str(pcb)])
         assert rc == 2  # gate fails (regression)
         captured = capsys.readouterr()
@@ -622,7 +626,7 @@ class TestMainDriftWarningEmission:
         importantly the ``allowed > 0`` guard suppresses the warning so
         every clean PR doesn't get nagged."""
         pcb, allowlist = self._make_pcb_and_allowlist(tmp_path, allowlist_value=None)
-        with patch.object(self.helper, "count_errors", return_value=0):
+        with patch.object(self.helper, "count_errors", return_value=(0, {})):
             rc = self.helper.main(["--allowlist", str(allowlist), str(pcb)])
         assert rc == 0
         captured = capsys.readouterr()
@@ -636,7 +640,7 @@ class TestMainDriftWarningEmission:
         that triggers the drift warning must still exit 0 so the gate
         doesn't become accidentally blocking."""
         pcb, allowlist = self._make_pcb_and_allowlist(tmp_path, allowlist_value=10)
-        with patch.object(self.helper, "count_errors", return_value=3):
+        with patch.object(self.helper, "count_errors", return_value=(3, {})):
             rc = self.helper.main(["--allowlist", str(allowlist), str(pcb)])
         assert rc == 0  # warning emitted, but gate still passes
         captured = capsys.readouterr()
@@ -682,7 +686,8 @@ class TestMainDriftWarningEmission:
                 module = importlib.util.module_from_spec(spec)
                 spec.loader.exec_module(module)
 
-                with patch.object(module, "count_errors", return_value=15):
+                # Issue #3074: count_errors returns (blocking, advisory_by_rule).
+                with patch.object(module, "count_errors", return_value=(15, {{}})):
                     sys.exit(module.main([
                         "--allowlist", {str(allowlist)!r},
                         {rel_pcb!r},
@@ -745,7 +750,8 @@ class TestMainManufacturerOverride:
         rel = "boards/04-test/output/test_routed.kicad_pcb"
         allowlist = tmp_path / "tolerance.yml"
         allowlist.write_text(f"tolerances:\n  {rel}: 4\nmanufacturers:\n  {rel}: jlcpcb-tier1\n")
-        with patch.object(self.helper, "count_errors", return_value=4) as mock:
+        # Issue #3074: count_errors returns (blocking, advisory_by_rule).
+        with patch.object(self.helper, "count_errors", return_value=(4, {})) as mock:
             rc = self.helper.main(["--allowlist", str(allowlist), rel])
         assert rc == 0
         mock.assert_called_once()
@@ -762,7 +768,7 @@ class TestMainManufacturerOverride:
         allowlist = tmp_path / "tolerance.yml"
         # tolerances entry only; no manufacturers section at all.
         allowlist.write_text(f"tolerances:\n  {rel}: 4\n")
-        with patch.object(self.helper, "count_errors", return_value=4) as mock:
+        with patch.object(self.helper, "count_errors", return_value=(4, {})) as mock:
             rc = self.helper.main(["--allowlist", str(allowlist), rel])
         assert rc == 0
         mock.assert_called_once()


### PR DESCRIPTION
## Summary

The CI gate (`scripts/ci/check_routed_drc.py`) trusted the unfiltered `summary.errors` from `kct check --format json`.  PR #3060 added the `connectivity` rule and PR #3064 classified it as advisory via `DRCChecker.ADVISORY_RULE_IDS`, but the gate never adopted the classifier.  Board 04's main-routed PCB reported 5 errors (4 blocking + 1 connectivity) and exceeded its allowlist of 4.

This change makes the gate mirror the audit pipeline's blocking-vs-advisory model (`src/kicad_tools/audit/auditor.py:768`).  Advisory findings still surface in the diagnostic output (`[advisory (excluded from gate): connectivity=N]` suffix on OK/FAIL messages) but no longer count toward the verdict.

Closes #3074.

## Changes

- `scripts/ci/check_routed_drc.py`:
  - `count_errors` returns `(blocking_errors, advisory_by_rule)` after walking `data["violations"]` through `DRCChecker.is_advisory_rule`.
  - `_count_blocking_errors` is a pure helper for the filtering (testable without subprocess).
  - `check_file` adds an advisory suffix to OK and FAIL messages so reviewers still see connectivity findings.
  - Module docstring documents the advisory-rule classification semantics.
- `.github/routed-drc-tolerance.yml`: board-04 comment documents that the 1 connectivity finding is filtered as advisory (no floor change; 4 stays at 4).
- `tests/test_check_routed_drc_advisory.py`: 13 new tests covering the classifier import, the pure filter, and the end-to-end board-04 scenario (4 blocking + 1 connectivity passes against allowlist 4).
- `tests/test_ci_routed_drc_workflow.py`: existing tests updated to stub `count_errors` with the new `(int, dict)` tuple return.

## Before / after error counts (allowlisted boards)

| Board | Pre-fix (unfiltered) | Post-fix (blocking only) | Advisory (connectivity) | Floor | Verdict |
|-------|----------------------|--------------------------|-------------------------|-------|---------|
| 03 (usb-joystick)      | 17 | 10 | 7  | 17 | pass + drift warning |
| 04 (stm32-devboard)    | 5  | 4  | 1  | 4  | **was FAILING, now passes** |
| 05 (bldc-motor-ctrl)   | 37 | 11 | 26 | 53 | pass + drift warning |
| 06 (diffpair-test)     | 11 | 7  | 4  | 32 | pass + drift warning |
| 07 (matchgroup-test)   | 10 | 3  | 7  | 70 | pass + drift warning |

(Boards 01 / 02 are not in the allowlist; gate behavior on them is unchanged by this fix.)

## Test plan

- [x] `uv run pytest tests/test_check_routed_drc_advisory.py tests/test_ci_routed_drc_workflow.py` -- 62 passed
- [x] `uv run ruff check scripts/ci/check_routed_drc.py tests/test_check_routed_drc_advisory.py tests/test_ci_routed_drc_workflow.py` -- All checks passed
- [x] `uv run ruff format --check ...` -- 3 files already formatted
- [x] End-to-end: `uv run python scripts/ci/check_routed_drc.py boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb` -- exits 0 (was exit 2)
- [x] Board sweep across all 5 allowlisted boards (table above) -- no regression

## Out of scope (filed as follow-up)

- The 1 stranded GND pad on board 04 is a real routing-completeness gap tracked under #3075 (rides with #2834 manufacturing-ready cluster).  Filtering it from the CI gate does not erase the underlying defect; this PR follows the curator's explicit option-3 boundary (the audit pipeline already classifies connectivity as advisory; this aligns the CI gate with that model).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>