### PR TITLE
fix(router): include escape-phase routes in negotiated re-validation hooks

### DIFF
--- a/src/kicad_tools/router/algorithms/negotiated.py
+++ b/src/kicad_tools/router/algorithms/negotiated.py
@@ -1036,6 +1036,7 @@ class NegotiatedRouter:
         net_routes: dict[int, list[Route]],
         trace_clearance: float,
         cache_key: object | None = None,
+        extra_routes: list["Route"] | None = None,
     ) -> list[int]:
         """Find nets whose committed segments clip foreign-net vias.
 
@@ -1047,6 +1048,27 @@ class NegotiatedRouter:
         report only) to LIVE -- the rip-up loop feeds violators back
         into ``nets_to_reroute`` so the next iteration re-routes them
         against the up-to-date foreign-via geometry.
+
+        Issue #3077 (``extra_routes``): the negotiated rip-up loop in
+        ``core.py`` and ``two_phase.py`` only tracks main-router
+        committed routes in ``net_routes``; escape-phase routes
+        (added to ``self.routes`` by :meth:`Autorouter.generate_escape_routes`
+        and :meth:`Autorouter._run_subgrid_prepass`) are not present
+        in ``net_routes`` and therefore their vias were invisible to
+        this hook.  Concretely, the lateral via-escape helper added
+        in PR #3070 places off-pad vias for boxed-in fine-pitch pads
+        (e.g. board-04 OSC_OUT lateral via at ``(125.7875, 121.75)``)
+        whose halos extend into the escape corridors of adjacent
+        pins.  The main router subsequently committed BOOT0 / SWDIO
+        / SWCLK / SWO segments that overlap those halos because the
+        post-iteration re-validation hook never saw the escape vias.
+
+        ``extra_routes`` accepts a list of Route objects whose vias
+        contribute to the foreign-via universe but whose nets are
+        NOT walked as segment owners (they are non-rippable
+        infrastructure).  The segment owners surfaced for re-route
+        remain restricted to ``net_routes`` so the existing rip-up
+        semantics are preserved.
 
         Concrete failure this catches (board-04, PCB (143.8, 119.7) on
         B.Cu): net A's SWDIO segment commits in iteration N BEFORE net
@@ -1100,6 +1122,14 @@ class NegotiatedRouter:
             cache_key: Optional hashable identifier for memoization
                 across consecutive same-iteration calls.  Default
                 ``None`` disables the cache.
+            extra_routes: Optional list of Route objects whose vias
+                contribute to the foreign-via universe but whose
+                nets are NOT eligible for inclusion in the violator
+                set (Issue #3077).  Use this to inject escape-phase
+                routes (whose vias live in ``self.routes`` but not in
+                ``net_routes``) so the post-iteration hook sees the
+                complete foreign-via context.  Same-net filtering
+                still applies (segment net == via net is skipped).
 
         Returns:
             List of net IDs whose segments violate clearance against
@@ -1109,6 +1139,11 @@ class NegotiatedRouter:
         # in the negotiated loop pass a ``cache_key`` that captures
         # iteration index + route count; identical keys reuse the
         # result because ``net_routes`` cannot have mutated.
+        # Issue #3077: cache invalidation also reacts implicitly to
+        # ``extra_routes`` because every caller that supplies it
+        # passes a distinct ``cache_key`` (or None).  The cache
+        # contract -- "identical key implies identical state" -- is
+        # the caller's responsibility.
         if cache_key is not None:
             cached = self._seg_via_violations_cache
             if cached is not None and cached[0] == cache_key:
@@ -1138,6 +1173,25 @@ class NegotiatedRouter:
                     for layer_val in range(v_lo, v_hi + 1):
                         vias_on_layer.setdefault(layer_val, []).append(
                             (net_id, via)
+                        )
+
+        # Issue #3077: Fold in vias from ``extra_routes`` (typically
+        # escape-phase routes) so segment-vs-foreign-via detection
+        # accounts for off-pad lateral / in-pad rescue vias whose
+        # halos can collide with main-router segments.  The via's
+        # owner net (``route.net``) is still used for same-net
+        # filtering downstream, so a main-router segment that
+        # happens to belong to the escape route's owner net is
+        # correctly skipped.
+        if extra_routes:
+            for route in extra_routes:
+                for via in route.vias:
+                    total_vias += 1
+                    v_lo = min(via.layers[0].value, via.layers[1].value)
+                    v_hi = max(via.layers[0].value, via.layers[1].value)
+                    for layer_val in range(v_lo, v_hi + 1):
+                        vias_on_layer.setdefault(layer_val, []).append(
+                            (route.net, via)
                         )
 
         # Fast path: no vias at all -> no violations possible.
@@ -1213,6 +1267,7 @@ class NegotiatedRouter:
         net_routes: dict[int, list[Route]],
         trace_clearance: float,
         cache_key: object | None = None,
+        extra_routes: list["Route"] | None = None,
     ) -> list[int]:
         """Find nets whose committed vias clip foreign-net segments.
 
@@ -1226,6 +1281,14 @@ class NegotiatedRouter:
         (STANDARD threshold) and feeds violators back into
         ``nets_to_reroute`` so the next iteration retries the via's
         parent net against the up-to-date foreign-segment universe.
+
+        Issue #3077 (``extra_routes``): mirrors the segment-vs-via
+        hook's extra-routes parameter.  Escape-phase routes live in
+        ``self.routes`` but not in ``net_routes``; supplying them as
+        ``extra_routes`` extends the foreign-segment universe so a
+        main-router via that clips an escape-phase stub is correctly
+        surfaced.  Vias INSIDE ``extra_routes`` are not walked as
+        violators (escape vias are non-rippable infrastructure).
 
         Concrete failure this catches (board-04, PCB (143.8, 119.7) on
         B.Cu): SWDIO's F.Cu/B.Cu escape segment is committed by the
@@ -1279,6 +1342,12 @@ class NegotiatedRouter:
             cache_key: Optional hashable identifier for memoization
                 across consecutive same-iteration calls.  Default
                 ``None`` disables the cache.
+            extra_routes: Optional list of Route objects whose
+                segments contribute to the foreign-segment universe
+                but whose nets are NOT eligible for the violator set
+                (Issue #3077).  Use for escape-phase routes that live
+                outside ``net_routes`` (typically the lateral-via /
+                in-pad rescue helpers in ``escape.py``).
 
         Returns:
             List of net IDs whose vias violate clearance against a
@@ -1308,6 +1377,19 @@ class NegotiatedRouter:
                     total_segs += 1
                     segs_on_layer.setdefault(seg.layer.value, []).append(
                         (net_id, seg)
+                    )
+
+        # Issue #3077: extend the foreign-segment universe with
+        # ``extra_routes`` (typically escape-phase routes).  Their
+        # segments participate in the universe but their nets are
+        # not walked for vias (escape vias are non-rippable; see
+        # ``_escape_pad_overrides`` policy at ``core.py:10123-10145``).
+        if extra_routes:
+            for route in extra_routes:
+                for seg in route.segments:
+                    total_segs += 1
+                    segs_on_layer.setdefault(seg.layer.value, []).append(
+                        (route.net, seg)
                     )
 
         # Fast path: no segments at all -> no violations possible.

--- a/src/kicad_tools/router/algorithms/negotiated.py
+++ b/src/kicad_tools/router/algorithms/negotiated.py
@@ -1143,18 +1143,20 @@ class NegotiatedRouter:
         # into the effective cache key so a prior call WITHOUT
         # ``extra_routes`` (cache_key="X") does not return a stale
         # result for a subsequent call WITH ``extra_routes`` under
-        # the same nominal key.  We use ``(cache_key, id(extra),
-        # len(extra))`` -- the ``id`` rejects two distinct-but-equal
-        # caller lists from colliding, ``len`` provides a cheap
-        # change detector when the same list is mutated in place.
+        # the same nominal key.  We fingerprint by the tuple of
+        # ``id(r)`` values for each member -- ``id()`` is stable
+        # within a process so two callers that pass the same Route
+        # objects (typical case: both compute ``extra_routes`` from
+        # the same ``self.routes``) hit the cache.  A caller that
+        # mutates ``self.routes`` between calls produces a different
+        # fingerprint and gets a fresh walk.
         effective_cache_key: object | None
         if cache_key is not None:
-            if extra_routes is None:
-                effective_cache_key = (cache_key, None, 0)
+            if extra_routes:
+                extras_fingerprint = tuple(id(r) for r in extra_routes)
             else:
-                effective_cache_key = (
-                    cache_key, id(extra_routes), len(extra_routes),
-                )
+                extras_fingerprint = ()
+            effective_cache_key = (cache_key, extras_fingerprint)
             cached = self._seg_via_violations_cache
             if cached is not None and cached[0] == effective_cache_key:
                 return list(cached[1])
@@ -1368,18 +1370,17 @@ class NegotiatedRouter:
         # Issue #3020: per-iteration memo (cache_key parity with the
         # segment-vs-via hook above).
         # Issue #3077: incorporate ``extra_routes`` into the effective
-        # cache key so a prior call WITHOUT ``extra_routes`` does not
-        # leak its result into a subsequent call WITH ``extra_routes``
-        # under the same nominal key.  See the matching block in
-        # :meth:`find_nets_with_segment_via_violations` for the rationale.
+        # cache key via a per-route ``id()`` fingerprint.  See the
+        # matching block in :meth:`find_nets_with_segment_via_violations`
+        # for the rationale (cache hits when the same Route objects are
+        # supplied across consecutive calls).
         effective_cache_key: object | None
         if cache_key is not None:
-            if extra_routes is None:
-                effective_cache_key = (cache_key, None, 0)
+            if extra_routes:
+                extras_fingerprint = tuple(id(r) for r in extra_routes)
             else:
-                effective_cache_key = (
-                    cache_key, id(extra_routes), len(extra_routes),
-                )
+                extras_fingerprint = ()
+            effective_cache_key = (cache_key, extras_fingerprint)
             cached = self._via_seg_violations_cache
             if cached is not None and cached[0] == effective_cache_key:
                 return list(cached[1])

--- a/src/kicad_tools/router/algorithms/negotiated.py
+++ b/src/kicad_tools/router/algorithms/negotiated.py
@@ -1139,15 +1139,27 @@ class NegotiatedRouter:
         # in the negotiated loop pass a ``cache_key`` that captures
         # iteration index + route count; identical keys reuse the
         # result because ``net_routes`` cannot have mutated.
-        # Issue #3077: cache invalidation also reacts implicitly to
-        # ``extra_routes`` because every caller that supplies it
-        # passes a distinct ``cache_key`` (or None).  The cache
-        # contract -- "identical key implies identical state" -- is
-        # the caller's responsibility.
+        # Issue #3077: incorporate an ``extra_routes`` discriminator
+        # into the effective cache key so a prior call WITHOUT
+        # ``extra_routes`` (cache_key="X") does not return a stale
+        # result for a subsequent call WITH ``extra_routes`` under
+        # the same nominal key.  We use ``(cache_key, id(extra),
+        # len(extra))`` -- the ``id`` rejects two distinct-but-equal
+        # caller lists from colliding, ``len`` provides a cheap
+        # change detector when the same list is mutated in place.
+        effective_cache_key: object | None
         if cache_key is not None:
+            if extra_routes is None:
+                effective_cache_key = (cache_key, None, 0)
+            else:
+                effective_cache_key = (
+                    cache_key, id(extra_routes), len(extra_routes),
+                )
             cached = self._seg_via_violations_cache
-            if cached is not None and cached[0] == cache_key:
+            if cached is not None and cached[0] == effective_cache_key:
                 return list(cached[1])
+        else:
+            effective_cache_key = None
 
         # Import here to avoid a top-level circular dependency between
         # algorithms.negotiated -> via_clearance -> primitives.
@@ -1196,8 +1208,8 @@ class NegotiatedRouter:
 
         # Fast path: no vias at all -> no violations possible.
         if total_vias == 0:
-            if cache_key is not None:
-                self._seg_via_violations_cache = (cache_key, [])
+            if effective_cache_key is not None:
+                self._seg_via_violations_cache = (effective_cache_key, [])
             return []
 
         violators: set[int] = set()
@@ -1258,8 +1270,8 @@ class NegotiatedRouter:
                         break
 
         result = list(violators)
-        if cache_key is not None:
-            self._seg_via_violations_cache = (cache_key, result)
+        if effective_cache_key is not None:
+            self._seg_via_violations_cache = (effective_cache_key, result)
         return result
 
     def find_nets_with_via_segment_violations(
@@ -1355,10 +1367,24 @@ class NegotiatedRouter:
         """
         # Issue #3020: per-iteration memo (cache_key parity with the
         # segment-vs-via hook above).
+        # Issue #3077: incorporate ``extra_routes`` into the effective
+        # cache key so a prior call WITHOUT ``extra_routes`` does not
+        # leak its result into a subsequent call WITH ``extra_routes``
+        # under the same nominal key.  See the matching block in
+        # :meth:`find_nets_with_segment_via_violations` for the rationale.
+        effective_cache_key: object | None
         if cache_key is not None:
+            if extra_routes is None:
+                effective_cache_key = (cache_key, None, 0)
+            else:
+                effective_cache_key = (
+                    cache_key, id(extra_routes), len(extra_routes),
+                )
             cached = self._via_seg_violations_cache
-            if cached is not None and cached[0] == cache_key:
+            if cached is not None and cached[0] == effective_cache_key:
                 return list(cached[1])
+        else:
+            effective_cache_key = None
 
 
         # Import here to avoid a top-level circular dependency between
@@ -1394,8 +1420,8 @@ class NegotiatedRouter:
 
         # Fast path: no segments at all -> no violations possible.
         if total_segs == 0:
-            if cache_key is not None:
-                self._via_seg_violations_cache = (cache_key, [])
+            if effective_cache_key is not None:
+                self._via_seg_violations_cache = (effective_cache_key, [])
             return []
 
         violators: set[int] = set()
@@ -1457,8 +1483,8 @@ class NegotiatedRouter:
                         break
 
         result = list(violators)
-        if cache_key is not None:
-            self._via_seg_violations_cache = (cache_key, result)
+        if effective_cache_key is not None:
+            self._via_seg_violations_cache = (effective_cache_key, result)
         return result
 
     def rip_up_nets(

--- a/src/kicad_tools/router/algorithms/two_phase.py
+++ b/src/kicad_tools/router/algorithms/two_phase.py
@@ -113,6 +113,28 @@ class TwoPhaseRouter:
         #   - ``"max_iterations"`` — outer loop ran to ``max_iterations``.
         self.last_termination_reason: str | None = None
 
+    def _collect_extra_routes_for_revalidation(
+        self,
+        net_routes: dict[int, list[Route]],
+    ) -> list[Route]:
+        """Mirror of :meth:`Autorouter._collect_extra_routes_for_revalidation`.
+
+        Issue #3077: Return routes in ``self.routes`` that are not
+        referenced by any entry in ``net_routes``.  These are
+        typically escape-phase routes (lateral / in-pad rescue vias
+        from PR #3070) whose halos must participate in the
+        post-iteration re-validation hooks' foreign-via universe.
+        See the helper of the same name on :class:`Autorouter` for
+        the full rationale.
+        """
+        if not self.routes:
+            return []
+        tracked_ids: set[int] = set()
+        for routes in net_routes.values():
+            for r in routes:
+                tracked_ids.add(id(r))
+        return [r for r in self.routes if id(r) not in tracked_ids]
+
     def route_all(
         self,
         use_negotiated: bool = True,
@@ -627,13 +649,18 @@ class TwoPhaseRouter:
         # Issue #3020: combine seg-via and via-seg violator counts so
         # both directions of the clearance matrix participate in the
         # best-state comparator.
+        # Issue #3077: extend the via/segment universe with
+        # escape-phase routes (lateral / in-pad helpers from PR #3070).
+        _extra_init = self._collect_extra_routes_for_revalidation(net_routes)
         _init_seg_via = neg_router.find_nets_with_segment_via_violations(
             net_routes, trace_clearance=self.rules.trace_clearance,
             cache_key=("two_phase_init",),
+            extra_routes=_extra_init,
         )
         _init_via_seg = neg_router.find_nets_with_via_segment_violations(
             net_routes, trace_clearance=self.rules.trace_clearance,
             cache_key=("two_phase_init",),
+            extra_routes=_extra_init,
         )
         best_clearance_violations = len(_init_seg_via) + len(_init_via_seg)
         best_routes: list[Route] = copy.deepcopy(list(self.routes))
@@ -690,9 +717,13 @@ class TwoPhaseRouter:
                 # state as "pre-iter K" -- same content as the end of
                 # iteration K-1 from the prior pass's ``post`` capture
                 # (or ``two_phase_init`` for iteration 1).
+                # Issue #3077: extend the via universe with escape-phase
+                # routes.
+                _extra_iter = self._collect_extra_routes_for_revalidation(net_routes)
                 seg_via_violators = neg_router.find_nets_with_segment_via_violations(
                     net_routes, trace_clearance=self.rules.trace_clearance,
                     cache_key=("two_phase_post", iteration - 1) if iteration > 1 else ("two_phase_init",),
+                    extra_routes=_extra_iter,
                 )
                 new_seg_via_violators = [
                     v_net for v_net in seg_via_violators
@@ -723,6 +754,7 @@ class TwoPhaseRouter:
                 via_seg_violators = neg_router.find_nets_with_via_segment_violations(
                     net_routes, trace_clearance=self.rules.trace_clearance,
                     cache_key=("two_phase_post", iteration - 1) if iteration > 1 else ("two_phase_init",),
+                    extra_routes=_extra_iter,
                 )
                 new_via_seg_violators = [
                     v_net for v_net in via_seg_violators
@@ -796,13 +828,18 @@ class TwoPhaseRouter:
                 # mid-iter call will pull this from cache.
                 # Issue #3020: combine both directions of the
                 # clearance matrix into the best-state comparator.
+                # Issue #3077: extend the via/segment universe with
+                # escape-phase routes for the end-of-iteration capture.
+                _extra_post = self._collect_extra_routes_for_revalidation(net_routes)
                 _post_seg_via = neg_router.find_nets_with_segment_via_violations(
                     net_routes, trace_clearance=self.rules.trace_clearance,
                     cache_key=("two_phase_post", iteration),
+                    extra_routes=_extra_post,
                 )
                 _post_via_seg = neg_router.find_nets_with_via_segment_violations(
                     net_routes, trace_clearance=self.rules.trace_clearance,
                     cache_key=("two_phase_post", iteration),
+                    extra_routes=_extra_post,
                 )
                 current_clearance_violations = (
                     len(_post_seg_via) + len(_post_via_seg)
@@ -897,13 +934,18 @@ class TwoPhaseRouter:
         )
         # Issue #3020: final comparator sums both directions of the
         # clearance matrix.
+        # Issue #3077: extend the via/segment universe with
+        # escape-phase routes for the post-loop best-vs-final compare.
+        _extra_final = self._collect_extra_routes_for_revalidation(net_routes)
         _final_seg_via = neg_router.find_nets_with_segment_via_violations(
             net_routes, trace_clearance=self.rules.trace_clearance,
             cache_key=("two_phase_final", final_route_count, final_via_count),
+            extra_routes=_extra_final,
         )
         _final_via_seg = neg_router.find_nets_with_via_segment_violations(
             net_routes, trace_clearance=self.rules.trace_clearance,
             cache_key=("two_phase_final", final_route_count, final_via_count),
+            extra_routes=_extra_final,
         )
         final_clearance_violations = (
             len(_final_seg_via) + len(_final_via_seg)

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -1677,6 +1677,56 @@ class Autorouter:
 
         self.router.set_segment_foreign_context(foreign_vias=foreign_vias)
 
+    def _collect_extra_routes_for_revalidation(
+        self,
+        net_routes: dict[int, list[Route]],
+    ) -> list[Route]:
+        """Return routes in ``self.routes`` not tracked in ``net_routes``.
+
+        Issue #3077: The negotiated post-iteration re-validation hooks
+        (:meth:`NegotiatedRouter.find_nets_with_segment_via_violations`
+        and the symmetric via-vs-segment sibling) iterate
+        ``net_routes`` only.  Escape-phase routes -- added to
+        ``self.routes`` by :meth:`generate_escape_routes` and
+        :meth:`_run_subgrid_prepass` -- are never folded into
+        ``net_routes`` because they are non-rippable infrastructure
+        (the main router pivots on ``_escape_pad_overrides`` so the
+        escape stub stays in place across rip-up iterations).
+
+        Without this helper, escape vias produced by the lateral via
+        helper (PR #3070's ``_try_lateral_via_escape``) and the
+        in-pad rescue (``_try_in_pad_escape``) are invisible to the
+        re-validation hooks.  Board-04 OSC_OUT's lateral via at
+        ``(125.7875, 121.75)`` sits in the escape corridor for the
+        adjacent NRST pin; subsequent main-router segments for BOOT0
+        / SWDIO / SWCLK / SWO commit on top of the via halo because
+        the hook never surfaces them as violators.
+
+        This helper materialises the delta as a list of Route
+        objects the caller passes to the hooks via the
+        ``extra_routes`` kwarg.  Membership is tested by ``id()``
+        rather than equality so identical-looking escape stubs (e.g.
+        two pins escaped to the same grid coordinate) are not
+        deduplicated by accident.
+
+        Args:
+            net_routes: The dict of ``net_id -> [Route]`` that the
+                re-validation hooks consume.
+
+        Returns:
+            List of Route objects that appear in ``self.routes`` but
+            are NOT referenced by any ``net_routes[net]`` list.
+            Empty list when no escape pass has run or the caller has
+            no escape routes to inject.
+        """
+        if not self.routes:
+            return []
+        tracked_ids: set[int] = set()
+        for routes in net_routes.values():
+            for r in routes:
+                tracked_ids.add(id(r))
+        return [r for r in self.routes if id(r) not in tracked_ids]
+
     def route_net(
         self,
         net: int,
@@ -6405,13 +6455,22 @@ class Autorouter:
         # of the clearance matrix.  A best-iteration restore must
         # prefer a state with fewer total violations regardless of
         # which side of the matrix improved.
+        # Issue #3077: Include escape-phase routes in the foreign-
+        # via universe so the post-iteration re-validation hooks see
+        # vias produced by the lateral / in-pad escape helpers
+        # (PR #3070).  Without this, the hooks operate against an
+        # incomplete via universe and main-router segments commit on
+        # top of escape via halos.
+        _extra_init = self._collect_extra_routes_for_revalidation(net_routes)
         initial_seg_via = neg_router.find_nets_with_segment_via_violations(
             net_routes, trace_clearance=self.rules.trace_clearance,
             cache_key=("init",),
+            extra_routes=_extra_init,
         )
         initial_via_seg = neg_router.find_nets_with_via_segment_violations(
             net_routes, trace_clearance=self.rules.trace_clearance,
             cache_key=("init",),
+            extra_routes=_extra_init,
         )
         initial_violations = len(initial_seg_via) + len(initial_via_seg)
         best_metrics = IterationMetrics(
@@ -6456,13 +6515,18 @@ class Autorouter:
             # Issue #3020: combine seg-via and via-seg violator counts
             # so both directions of the 4-quadrant clearance matrix
             # survive the lex-tuple restore comparator.
+            # Issue #3077: extend the via/segment universe with
+            # escape-phase routes; see _collect_extra_routes_for_revalidation.
+            _extra_post = self._collect_extra_routes_for_revalidation(net_routes)
             post_seg_via = neg_router.find_nets_with_segment_via_violations(
                 net_routes, trace_clearance=self.rules.trace_clearance,
                 cache_key=("post", iter_index),
+                extra_routes=_extra_post,
             )
             post_via_seg = neg_router.find_nets_with_via_segment_violations(
                 net_routes, trace_clearance=self.rules.trace_clearance,
                 cache_key=("post", iter_index),
+                extra_routes=_extra_post,
             )
             violations_now = len(post_seg_via) + len(post_via_seg)
             metrics = IterationMetrics(
@@ -6542,13 +6606,18 @@ class Autorouter:
                 # cache from the previous _capture_iteration_end call.
                 # Issue #3020: combine both directions of the
                 # clearance matrix in the lex tuple comparator.
+                # Issue #3077: extend the via/segment universe with
+                # escape-phase routes.
+                _extra_top = self._collect_extra_routes_for_revalidation(net_routes)
                 current_seg_via = neg_router.find_nets_with_segment_via_violations(
                     net_routes, trace_clearance=self.rules.trace_clearance,
                     cache_key=("post", iteration - 1),
+                    extra_routes=_extra_top,
                 )
                 current_via_seg = neg_router.find_nets_with_via_segment_violations(
                     net_routes, trace_clearance=self.rules.trace_clearance,
                     cache_key=("post", iteration - 1),
+                    extra_routes=_extra_top,
                 )
                 current_violations = len(current_seg_via) + len(current_via_seg)
                 current_metrics = IterationMetrics(
@@ -6754,9 +6823,13 @@ class Autorouter:
                 # between this call site and the iteration boundary.
                 # Hot path: this is the third call within an iteration
                 # that reads the same ``("post", K-1)`` state.
+                # Issue #3077: extend the via universe with escape-phase
+                # routes (lateral / in-pad helpers from PR #3070 etc).
+                _extra_mid = self._collect_extra_routes_for_revalidation(net_routes)
                 seg_via_violators = neg_router.find_nets_with_segment_via_violations(
                     net_routes, trace_clearance=self.rules.trace_clearance,
                     cache_key=("post", iteration - 1),
+                    extra_routes=_extra_mid,
                 )
                 if seg_via_violators:
                     new_violators = [
@@ -6796,6 +6869,7 @@ class Autorouter:
                 via_seg_violators = neg_router.find_nets_with_via_segment_violations(
                     net_routes, trace_clearance=self.rules.trace_clearance,
                     cache_key=("post", iteration - 1),
+                    extra_routes=_extra_mid,
                 )
                 if via_seg_violators:
                     new_via_violators = [
@@ -7884,13 +7958,18 @@ class Autorouter:
         # matrix in the final lex-tuple comparator so a best snapshot
         # with fewer total violations (in either direction) survives
         # the post-loop restore.
+        # Issue #3077: extend the via/segment universe with
+        # escape-phase routes for the post-loop best-vs-final compare.
+        _extra_final = self._collect_extra_routes_for_revalidation(net_routes)
         final_seg_via = neg_router.find_nets_with_segment_via_violations(
             net_routes, trace_clearance=self.rules.trace_clearance,
             cache_key=("final", final_route_count, final_via_count),
+            extra_routes=_extra_final,
         )
         final_via_seg = neg_router.find_nets_with_via_segment_violations(
             net_routes, trace_clearance=self.rules.trace_clearance,
             cache_key=("final", final_route_count, final_via_count),
+            extra_routes=_extra_final,
         )
         final_violations = len(final_seg_via) + len(final_via_seg)
         final_metrics = IterationMetrics(

--- a/tests/test_escape_via_revalidation.py
+++ b/tests/test_escape_via_revalidation.py
@@ -203,6 +203,100 @@ class TestSegmentVsExtraEscapeVia:
         )
         assert set(baseline) == set(with_empty)
 
+    def test_cache_invalidates_when_extra_routes_added(self):
+        """Regression: a prior call WITHOUT ``extra_routes`` must NOT
+        leak its result to a subsequent call WITH ``extra_routes`` under
+        the same nominal ``cache_key``.
+
+        This is the bug surfaced by board-04's two-phase end-of-iteration
+        capture: the initial call (``cache_key=("two_phase_init",)``)
+        ran before extra_routes was wired, was cached with the same key,
+        then the mid-iter call (also ``("two_phase_init",)`` on
+        iteration 1) hit the cache and returned a stale empty list even
+        though escape vias were now in the universe.
+        """
+        rules = _make_rules()
+        grid = _make_grid(rules)
+        neg = _make_neg_router(grid, rules)
+
+        seg_a = Segment(
+            x1=0.0, y1=5.0, x2=10.0, y2=5.0,
+            width=0.2, layer=Layer.B_CU, net=1, net_name="BOOT0",
+        )
+        net_routes = {
+            1: [Route(net=1, net_name="BOOT0", segments=[seg_a], vias=[])],
+        }
+        via_b = Via(
+            x=5.0, y=5.0, drill=0.3, diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU), net=2, net_name="OSC_OUT",
+        )
+        extra_routes = [
+            Route(net=2, net_name="OSC_OUT", segments=[], vias=[via_b]),
+        ]
+
+        # First call: no extra_routes -- no violations seen, cache stores [].
+        empty = neg.find_nets_with_segment_via_violations(
+            net_routes, trace_clearance=0.15, cache_key=("k",),
+        )
+        assert empty == []
+
+        # Second call: SAME cache_key but extra_routes provided -- the
+        # cache MUST be invalidated by the extra_routes discriminator so
+        # the violator surfaces.
+        violators = neg.find_nets_with_segment_via_violations(
+            net_routes, trace_clearance=0.15, cache_key=("k",),
+            extra_routes=extra_routes,
+        )
+        assert 1 in violators, (
+            "Cache must not leak the no-extra-routes empty result into "
+            "a with-extra-routes call under the same nominal key."
+        )
+
+        # Third call: same extra_routes -- cache should hit and return the
+        # same answer.
+        violators2 = neg.find_nets_with_segment_via_violations(
+            net_routes, trace_clearance=0.15, cache_key=("k",),
+            extra_routes=extra_routes,
+        )
+        assert set(violators) == set(violators2)
+
+    def test_cache_invalidates_via_seg_too(self):
+        """Mirror of :meth:`test_cache_invalidates_when_extra_routes_added`
+        for the symmetric :meth:`find_nets_with_via_segment_violations`
+        hook.
+        """
+        rules = _make_rules()
+        grid = _make_grid(rules)
+        neg = _make_neg_router(grid, rules)
+
+        via_a = Via(
+            x=5.0, y=5.0, drill=0.3, diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU), net=1, net_name="BOOT0",
+        )
+        stub_a = Segment(
+            x1=5.0, y1=5.0, x2=5.5, y2=5.0,
+            width=0.2, layer=Layer.F_CU, net=1, net_name="BOOT0",
+        )
+        net_routes = {
+            1: [Route(net=1, net_name="BOOT0", segments=[stub_a], vias=[via_a])],
+        }
+        seg_b = Segment(
+            x1=0.0, y1=5.0, x2=10.0, y2=5.0,
+            width=0.2, layer=Layer.B_CU, net=2, net_name="SWDIO",
+        )
+        extra_routes = [
+            Route(net=2, net_name="SWDIO", segments=[seg_b], vias=[]),
+        ]
+        empty = neg.find_nets_with_via_segment_violations(
+            net_routes, trace_clearance=0.15, cache_key=("k",),
+        )
+        assert empty == []
+        violators = neg.find_nets_with_via_segment_violations(
+            net_routes, trace_clearance=0.15, cache_key=("k",),
+            extra_routes=extra_routes,
+        )
+        assert 1 in violators
+
     def test_extra_route_vias_do_not_self_violate(self):
         """A via in ``extra_routes`` whose net only appears in
         ``extra_routes`` (not in ``net_routes``) is NEVER surfaced as a

--- a/tests/test_escape_via_revalidation.py
+++ b/tests/test_escape_via_revalidation.py
@@ -1,0 +1,431 @@
+"""Tests for Issue #3077: negotiated rip-up re-validation against
+escape-phase vias (post-PR-#3070 lateral via halos).
+
+PR #3006 (Issue #3002) and PR #3019 (Issue #3020) wired the
+post-iteration re-validation hooks
+:meth:`NegotiatedRouter.find_nets_with_segment_via_violations` and
+:meth:`NegotiatedRouter.find_nets_with_via_segment_violations` into
+the negotiated and two-phase rip-up loops.  Both hooks consume
+``net_routes`` only.
+
+Issue #3077: escape-phase routes (lateral / in-pad rescue helpers
+from PR #3070) live in ``self.routes`` but are NEVER folded into
+``net_routes`` because ``_escape_pad_overrides`` makes them
+non-rippable infrastructure.  As a result, the lateral helper's
+off-pad via (board-04 OSC_OUT at PCB ``(125.7875, 121.75)``) was
+invisible to the post-iteration hook -- subsequent main-router
+segments for BOOT0 / SWDIO / SWCLK / SWO committed on top of the
+via halo and produced segment-via clearance violations the
+post-route DRC report flagged but the live re-validation hook
+never surfaced.
+
+The fix adds an ``extra_routes`` kwarg to both hooks.  Callers
+(``Autorouter.route_all_negotiated`` and
+``TwoPhaseRouter._detailed_negotiated``) supply the delta between
+``self.routes`` and ``net_routes`` (computed via the new
+``_collect_extra_routes_for_revalidation`` helper) so the foreign-
+via / foreign-segment universe seen by the hooks matches the
+universe seen by the pre-commit gate in
+``Router._validate_route_clearance``.
+
+These tests pin:
+
+1. The hook detects a segment-vs-via violation where the OFFENDING
+   via lives in ``extra_routes`` (not ``net_routes``).
+2. The symmetric via-vs-segment hook detects a violation where the
+   OFFENDING segment lives in ``extra_routes``.
+3. ``extra_routes`` does NOT add segments / vias whose nets are
+   eligible to be surfaced as violators -- only the segment / via
+   owner from ``net_routes`` can be surfaced.
+4. Backward compatibility: omitting ``extra_routes`` (default
+   ``None``) yields the pre-#3077 behaviour.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.router.algorithms.negotiated import NegotiatedRouter
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.pathfinder import Router
+from kicad_tools.router.primitives import Route, Segment, Via
+from kicad_tools.router.rules import DEFAULT_NET_CLASS_MAP, DesignRules
+
+
+def _make_rules() -> DesignRules:
+    """DesignRules tuned to mirror board-04's clearance regime."""
+    return DesignRules(
+        trace_width=0.2,
+        trace_clearance=0.15,
+        via_drill=0.3,
+        via_diameter=0.6,
+        via_clearance=0.15,
+        grid_resolution=0.1,
+    )
+
+
+def _make_grid(rules: DesignRules) -> RoutingGrid:
+    return RoutingGrid(
+        width=20.0,
+        height=20.0,
+        rules=rules,
+        origin_x=0.0,
+        origin_y=0.0,
+        layer_stack=LayerStack.two_layer(),
+    )
+
+
+def _make_router(grid: RoutingGrid, rules: DesignRules) -> Router:
+    return Router(grid, rules)
+
+
+def _make_neg_router(grid: RoutingGrid, rules: DesignRules) -> NegotiatedRouter:
+    router = _make_router(grid, rules)
+    return NegotiatedRouter(grid, router, rules, DEFAULT_NET_CLASS_MAP)
+
+
+# ---------------------------------------------------------------------------
+# find_nets_with_segment_via_violations + extra_routes
+# ---------------------------------------------------------------------------
+
+
+class TestSegmentVsExtraEscapeVia:
+    """Pins the board-04 OSC_OUT scenario from Issue #3077."""
+
+    def test_escape_via_clipped_by_main_router_segment_surfaces_main_net(self):
+        """The lateral escape via (in ``extra_routes``) is clipped by a
+        main-router segment in ``net_routes`` -- the SEGMENT's net
+        surfaces as a violator.
+
+        Mirrors the OSC_OUT escape via at ``(125.7875, 121.75)`` whose
+        halo clips BOOT0 / SWDIO / SWCLK / SWO main-router segments.
+        """
+        rules = _make_rules()
+        grid = _make_grid(rules)
+        neg = _make_neg_router(grid, rules)
+
+        # Net A (main router): segment running through (5.0, 5.0) on B.Cu.
+        seg_a = Segment(
+            x1=0.0, y1=5.0, x2=10.0, y2=5.0,
+            width=0.2, layer=Layer.B_CU, net=1, net_name="BOOT0",
+        )
+        net_routes = {
+            1: [Route(net=1, net_name="BOOT0", segments=[seg_a], vias=[])],
+        }
+
+        # Net B (escape phase): a lateral via centered on net A's segment.
+        # This via lives in self.routes but NOT in net_routes -- emulating
+        # the lateral-helper output from PR #3070.
+        via_b = Via(
+            x=5.0, y=5.0, drill=0.3, diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU), net=2, net_name="OSC_OUT",
+        )
+        extra_routes = [
+            Route(net=2, net_name="OSC_OUT", segments=[], vias=[via_b]),
+        ]
+
+        # Without extra_routes, the hook can't see the escape via and
+        # reports no violation.
+        violators_no_extra = neg.find_nets_with_segment_via_violations(
+            net_routes, trace_clearance=0.15
+        )
+        assert 1 not in violators_no_extra, (
+            "Baseline: extra_routes=None must NOT see the escape via "
+            "(this is the bug the issue describes)."
+        )
+
+        # With extra_routes, the hook surfaces net A (the segment's net)
+        # for re-routing.
+        violators = neg.find_nets_with_segment_via_violations(
+            net_routes, trace_clearance=0.15, extra_routes=extra_routes,
+        )
+        assert 1 in violators, (
+            "Fix: extra_routes=[escape] surfaces the main-router net "
+            "whose segment clips the escape via."
+        )
+        # The escape via's net is NOT surfaced -- it's non-rippable.
+        assert 2 not in violators
+
+    def test_same_net_filtering_with_extra_routes(self):
+        """A segment in ``net_routes`` and a via in ``extra_routes`` that
+        share a net are NOT a violation -- the same-net convention
+        applies to the extra-routes universe too.
+        """
+        rules = _make_rules()
+        grid = _make_grid(rules)
+        neg = _make_neg_router(grid, rules)
+        seg = Segment(
+            x1=0.0, y1=5.0, x2=10.0, y2=5.0,
+            width=0.2, layer=Layer.B_CU, net=1,
+        )
+        via = Via(
+            x=5.0, y=5.0, drill=0.3, diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU), net=1,  # SAME net as seg.
+        )
+        net_routes = {
+            1: [Route(net=1, net_name="A", segments=[seg], vias=[])],
+        }
+        extra_routes = [
+            Route(net=1, net_name="A", segments=[], vias=[via]),
+        ]
+        violators = neg.find_nets_with_segment_via_violations(
+            net_routes, trace_clearance=0.15, extra_routes=extra_routes,
+        )
+        assert violators == []
+
+    def test_extra_routes_empty_list_is_noop(self):
+        """``extra_routes=[]`` is identical to ``extra_routes=None`` --
+        the foreign universe is unchanged.
+        """
+        rules = _make_rules()
+        grid = _make_grid(rules)
+        neg = _make_neg_router(grid, rules)
+        seg_a = Segment(
+            x1=0.0, y1=5.0, x2=10.0, y2=5.0,
+            width=0.2, layer=Layer.B_CU, net=1,
+        )
+        via_b = Via(
+            x=5.0, y=5.0, drill=0.3, diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU), net=2,
+        )
+        stub_b = Segment(
+            x1=5.0, y1=5.0, x2=5.5, y2=5.0,
+            width=0.2, layer=Layer.F_CU, net=2,
+        )
+        net_routes = {
+            1: [Route(net=1, net_name="A", segments=[seg_a], vias=[])],
+            2: [Route(net=2, net_name="B", segments=[stub_b], vias=[via_b])],
+        }
+        baseline = neg.find_nets_with_segment_via_violations(
+            net_routes, trace_clearance=0.15,
+        )
+        with_empty = neg.find_nets_with_segment_via_violations(
+            net_routes, trace_clearance=0.15, extra_routes=[],
+        )
+        assert set(baseline) == set(with_empty)
+
+    def test_extra_route_vias_do_not_self_violate(self):
+        """A via in ``extra_routes`` whose net only appears in
+        ``extra_routes`` (not in ``net_routes``) is NEVER surfaced as a
+        violator -- its segments aren't walked.  This is the "escape
+        infrastructure is non-rippable" invariant.
+        """
+        rules = _make_rules()
+        grid = _make_grid(rules)
+        neg = _make_neg_router(grid, rules)
+
+        # net_routes is empty -- no main-router progress yet.
+        net_routes: dict[int, list[Route]] = {}
+
+        # Two escape routes with vias that would clip each other (net 1
+        # via at (5,5), net 2 via at (5.1, 5)) -- but neither is
+        # main-routed, so neither can be surfaced.
+        via1 = Via(
+            x=5.0, y=5.0, drill=0.3, diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU), net=1,
+        )
+        via2 = Via(
+            x=5.1, y=5.0, drill=0.3, diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU), net=2,
+        )
+        seg1 = Segment(
+            x1=5.0, y1=5.0, x2=6.0, y2=5.0,
+            width=0.2, layer=Layer.B_CU, net=1,
+        )
+        seg2 = Segment(
+            x1=5.1, y1=5.0, x2=6.1, y2=5.0,
+            width=0.2, layer=Layer.B_CU, net=2,
+        )
+        extra_routes = [
+            Route(net=1, net_name="A", segments=[seg1], vias=[via1]),
+            Route(net=2, net_name="B", segments=[seg2], vias=[via2]),
+        ]
+        violators = neg.find_nets_with_segment_via_violations(
+            net_routes, trace_clearance=0.15, extra_routes=extra_routes,
+        )
+        # Nothing in net_routes -> nothing to walk for segments -> empty.
+        assert violators == []
+
+
+# ---------------------------------------------------------------------------
+# find_nets_with_via_segment_violations + extra_routes
+# ---------------------------------------------------------------------------
+
+
+class TestViaVsExtraEscapeSegment:
+    """Symmetric sibling of TestSegmentVsExtraEscapeVia."""
+
+    def test_main_via_clipping_extra_escape_segment_surfaces_via_net(self):
+        """A main-router via clips an escape-phase segment (in
+        ``extra_routes``) -- the VIA's net surfaces as a violator.
+        """
+        rules = _make_rules()
+        grid = _make_grid(rules)
+        neg = _make_neg_router(grid, rules)
+
+        # Net A (main router): a through-hole via at (5, 5).
+        via_a = Via(
+            x=5.0, y=5.0, drill=0.3, diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU), net=1, net_name="BOOT0",
+        )
+        # And a tiny stub so net_routes has something to iterate.
+        stub_a = Segment(
+            x1=5.0, y1=5.0, x2=5.5, y2=5.0,
+            width=0.2, layer=Layer.F_CU, net=1, net_name="BOOT0",
+        )
+        net_routes = {
+            1: [Route(net=1, net_name="BOOT0", segments=[stub_a], vias=[via_a])],
+        }
+
+        # Net B (escape phase): a segment running through (5, 5) on B.Cu.
+        seg_b = Segment(
+            x1=0.0, y1=5.0, x2=10.0, y2=5.0,
+            width=0.2, layer=Layer.B_CU, net=2, net_name="SWDIO",
+        )
+        extra_routes = [
+            Route(net=2, net_name="SWDIO", segments=[seg_b], vias=[]),
+        ]
+
+        # Without extra_routes the escape segment is invisible.
+        violators_no_extra = neg.find_nets_with_via_segment_violations(
+            net_routes, trace_clearance=0.15,
+        )
+        assert 1 not in violators_no_extra
+
+        # With extra_routes the via's net surfaces.
+        violators = neg.find_nets_with_via_segment_violations(
+            net_routes, trace_clearance=0.15, extra_routes=extra_routes,
+        )
+        assert 1 in violators
+        assert 2 not in violators  # Escape segment owner -- not rippable.
+
+    def test_extra_routes_empty_list_is_noop_via_seg(self):
+        rules = _make_rules()
+        grid = _make_grid(rules)
+        neg = _make_neg_router(grid, rules)
+        via_a = Via(
+            x=5.0, y=5.0, drill=0.3, diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU), net=1,
+        )
+        stub_a = Segment(
+            x1=5.0, y1=5.0, x2=5.5, y2=5.0,
+            width=0.2, layer=Layer.F_CU, net=1,
+        )
+        seg_b = Segment(
+            x1=0.0, y1=2.0, x2=10.0, y2=2.0,
+            width=0.2, layer=Layer.B_CU, net=2,
+        )
+        net_routes = {
+            1: [Route(net=1, net_name="A", segments=[stub_a], vias=[via_a])],
+            2: [Route(net=2, net_name="B", segments=[seg_b], vias=[])],
+        }
+        baseline = neg.find_nets_with_via_segment_violations(
+            net_routes, trace_clearance=0.15,
+        )
+        with_empty = neg.find_nets_with_via_segment_violations(
+            net_routes, trace_clearance=0.15, extra_routes=[],
+        )
+        assert set(baseline) == set(with_empty)
+
+
+# ---------------------------------------------------------------------------
+# Autorouter._collect_extra_routes_for_revalidation
+# ---------------------------------------------------------------------------
+
+
+class TestCollectExtraRoutesHelper:
+    """Pins the helper on :class:`Autorouter` and :class:`TwoPhaseRouter`
+    that materialises the delta between ``self.routes`` and ``net_routes``.
+    """
+
+    def test_returns_routes_not_in_net_routes(self):
+        """Routes appended to ``self.routes`` that are not referenced
+        by any ``net_routes`` entry are returned.  This is the typical
+        shape after escape-phase routes land before the main router
+        starts.
+        """
+        # Import here so test collection doesn't pay the cost when
+        # this module is filtered out.
+        from kicad_tools.router.core import Autorouter
+
+        # Construct a minimal Autorouter shape: we only need ``self.routes``
+        # and the helper, which doesn't touch any other state.
+        ar = Autorouter.__new__(Autorouter)
+        seg_escape = Segment(
+            x1=0.0, y1=0.0, x2=1.0, y2=0.0,
+            width=0.2, layer=Layer.F_CU, net=10,
+        )
+        seg_main = Segment(
+            x1=5.0, y1=5.0, x2=6.0, y2=5.0,
+            width=0.2, layer=Layer.F_CU, net=20,
+        )
+        route_escape = Route(net=10, net_name="ESC", segments=[seg_escape], vias=[])
+        route_main = Route(net=20, net_name="MAIN", segments=[seg_main], vias=[])
+        ar.routes = [route_escape, route_main]
+        net_routes = {20: [route_main]}
+
+        extras = ar._collect_extra_routes_for_revalidation(net_routes)
+        assert extras == [route_escape]
+
+    def test_returns_empty_when_routes_empty(self):
+        from kicad_tools.router.core import Autorouter
+        ar = Autorouter.__new__(Autorouter)
+        ar.routes = []
+        assert ar._collect_extra_routes_for_revalidation({}) == []
+
+    def test_returns_empty_when_all_routes_tracked(self):
+        from kicad_tools.router.core import Autorouter
+        ar = Autorouter.__new__(Autorouter)
+        seg = Segment(
+            x1=0.0, y1=0.0, x2=1.0, y2=0.0,
+            width=0.2, layer=Layer.F_CU, net=5,
+        )
+        route = Route(net=5, net_name="A", segments=[seg], vias=[])
+        ar.routes = [route]
+        net_routes = {5: [route]}
+        assert ar._collect_extra_routes_for_revalidation(net_routes) == []
+
+    def test_id_based_membership_not_equality(self):
+        """Membership is tested by ``id()`` so two distinct Route
+        objects with identical contents are NOT collapsed.  This
+        matters when the rip-up flow creates a fresh Route object
+        with the same net + segments as an escape stub.
+        """
+        from kicad_tools.router.core import Autorouter
+        ar = Autorouter.__new__(Autorouter)
+        seg = Segment(
+            x1=0.0, y1=0.0, x2=1.0, y2=0.0,
+            width=0.2, layer=Layer.F_CU, net=5,
+        )
+        route_a = Route(net=5, net_name="A", segments=[seg], vias=[])
+        # Build an identical-content but distinct Route.
+        route_b = Route(net=5, net_name="A", segments=[seg], vias=[])
+        ar.routes = [route_a, route_b]
+        # net_routes references route_b only.
+        net_routes = {5: [route_b]}
+        extras = ar._collect_extra_routes_for_revalidation(net_routes)
+        assert extras == [route_a]
+        # id() identification: route_a survives because it's not the
+        # SAME object as route_b, even though their fields match.
+
+    def test_two_phase_helper_parity(self):
+        """``TwoPhaseRouter._collect_extra_routes_for_revalidation``
+        is a bit-for-bit mirror of the Autorouter helper.
+        """
+        from kicad_tools.router.algorithms.two_phase import TwoPhaseRouter
+
+        tp = TwoPhaseRouter.__new__(TwoPhaseRouter)
+        seg_escape = Segment(
+            x1=0.0, y1=0.0, x2=1.0, y2=0.0,
+            width=0.2, layer=Layer.F_CU, net=10,
+        )
+        seg_main = Segment(
+            x1=5.0, y1=5.0, x2=6.0, y2=5.0,
+            width=0.2, layer=Layer.F_CU, net=20,
+        )
+        route_escape = Route(net=10, net_name="ESC", segments=[seg_escape], vias=[])
+        route_main = Route(net=20, net_name="MAIN", segments=[seg_main], vias=[])
+        tp.routes = [route_escape, route_main]
+        net_routes = {20: [route_main]}
+
+        extras = tp._collect_extra_routes_for_revalidation(net_routes)
+        assert extras == [route_escape]


### PR DESCRIPTION
## Summary

Closes the architectural gap that issue #3077 identifies: the negotiated post-iteration re-validation hooks (`find_nets_with_segment_via_violations` and `find_nets_with_via_segment_violations`, added by PRs #3006 and #3019) only consulted `net_routes` for vias and segments. Escape-phase routes (lateral via helper from PR #3070, in-pad rescue, sub-grid pre-pass) live in `self.routes` but are NOT mirrored into `net_routes` because `_escape_pad_overrides` makes them non-rippable infrastructure. As a result, escape vias were invisible to the live re-validation -- the OSC_OUT lateral via at PCB ``(125.7875, 121.75)`` could be clipped by subsequent main-router segments for BOOT0 / SWDIO / SWCLK / SWO without the hook ever surfacing the violator for re-routing.

## Changes

### Hook API (`src/kicad_tools/router/algorithms/negotiated.py`)
- **New `extra_routes` kwarg** on both `find_nets_with_segment_via_violations` and `find_nets_with_via_segment_violations`. Vias / segments in `extra_routes` participate in the foreign-via / foreign-segment universe but their nets are NOT walked as violation candidates (escape infrastructure is non-rippable; the rip-up surfaces only the main-router nets whose work crosses the escape geometry).
- **Cache-key fingerprint update** for the per-iteration memo: the effective key now incorporates a per-route `id()` tuple so that a prior call WITHOUT `extra_routes` does NOT leak its empty-result into a subsequent call WITH `extra_routes` under the same nominal cache key. Cache still hits when the same Route objects are supplied across consecutive calls.

### Caller wiring (`src/kicad_tools/router/core.py` and `algorithms/two_phase.py`)
- New helper `_collect_extra_routes_for_revalidation(net_routes)` on both `Autorouter` and `TwoPhaseRouter` -- returns routes in `self.routes` whose `id()` is NOT referenced by any `net_routes[net]` list (the escape / sub-grid delta).
- All **9** call sites (5 in `core.py`, 4 in `two_phase.py`) now compute the delta and pass it through as `extra_routes`. Covers the initial pass, top-of-iteration snapshot, mid-iteration recovery, end-of-iteration capture, and the post-loop final compare.

### Tests (`tests/test_escape_via_revalidation.py`, 13 new tests)
- `TestSegmentVsExtraEscapeVia` -- pins the OSC_OUT regression scenario (escape via in `extra_routes` clipped by main-router segment in `net_routes` -> segment's net surfaces as violator).
- `TestViaVsExtraEscapeSegment` -- symmetric (main-router via clips escape segment -> via's net surfaces).
- `test_cache_invalidates_when_extra_routes_added` / `test_cache_invalidates_via_seg_too` -- regression guard for the cache-key bug.
- `TestCollectExtraRoutesHelper` -- pins the new helper's id-based membership semantics on both `Autorouter` and `TwoPhaseRouter`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Negotiated rip-up re-validates each candidate route against ALL foreign vias (including escape-time vias added by `_try_lateral_via_escape`, `_try_in_pad_escape`, etc.) before committing it to the route plan. | Met | The post-iteration hooks consume `extra_routes` containing the escape-phase delta of `self.routes`; the pre-commit gate (`_validate_route_clearance` via `_update_router_segment_foreign_context`) was already walking `self.routes` and continues to do so unchanged. 13 new unit tests pin the new behaviour including the cache-key bug regression. |
| Board 04 with `--strict-in-pad-clearance` reaches 9/9 nets with <= 6 DRC errors at `--seed 42`. | Partial / out-of-scope context | The architectural acceptance is met (the hooks now see escape vias and feed violators back into the rip-up cohort). The empirical target is NOT achieved by this PR alone -- board 04 with strict mode produces 4-7/9 nets depending on layer escalation, because the lateral-via geometry on LQFP-48 0.5 mm pitch has fundamental conflicts the rip-up cannot always resolve (the issue's "out of scope" section acknowledges that finding alternative customers is a separate concern, Branch C from #3073's curator scaffolding). With this PR, when violations DO occur the hook correctly surfaces them, and DRC clearance counts drop versus pre-#3077 baseline on board 04 strict (5 vs 14 errors observed in fresh re-routing on this branch). |

## Test Plan

- [x] `uv run pytest tests/test_escape_via_revalidation.py` -- 13 / 13 pass
- [x] `uv run pytest tests/test_main_router_segment_via_clearance.py tests/test_main_router_via_segment_clearance.py tests/test_escape_lateral_recovery.py tests/test_escape_segment_via_clearance.py` -- 65 / 65 pass (no regressions in the directly-coupled suites from PRs #3006 / #3019 / #3070).
- [x] `uv run pytest tests/test_negotiated_adaptive.py tests/test_route_all_negotiated_overflow_regression.py tests/test_route_all_negotiated_partial_state.py` -- 217 / 217 pass (broader negotiated regression).
- [x] C++ backend built (`uv run kct build-native`) and used for the live re-validation path.

## Out of scope

- The empirical 9/9 board-04 target is gated on additional work (likely alternative-pad-pitch customers and/or further rip-up improvements). This PR closes the specific architectural gap #3077 names and lays the foundation so future work to surface and act on escape-via violations sees them through the existing rip-up machinery.

Closes #3077