### PR TITLE
fix(softstart): tie R11 pad2 to SWCLK net to match schematic (closes #3087)

### DIFF
--- a/boards/external/softstart/generate_design.py
+++ b/boards/external/softstart/generate_design.py
@@ -1589,7 +1589,7 @@ def create_softstart_pcb(output_dir: Path) -> Path:
     parts.append(generate_switch("SW1", SW1_POS))
     parts.append(generate_resistor_0805("R10", R10_POS, "10k", "+3.3V", "NRST"))
     parts.append(generate_cap_0805("C5", C5_POS, "100nF", "NRST", "GND"))
-    parts.append(generate_resistor_0805("R11", R11_POS, "10k", "GND", ""))  # BOOT0 pull-down
+    parts.append(generate_resistor_0805("R11", R11_POS, "10k", "GND", "SWCLK"))  # BOOT0 pull-down; pad2 ties to SWCLK to match schematic (issue #3087)
 
     parts.append(")")  # Close kicad_pcb
 


### PR DESCRIPTION
## Summary

- Fixes #3087: softstart R11 schematic-vs-PCB drift.
- Change `generate_resistor_0805(\"R11\", ..., \"GND\", \"\")` to `(..., \"GND\", \"SWCLK\")` so PCB pad2 matches the schematic label added in PR #3086.
- One-line change in `boards/external/softstart/generate_design.py:1592`.

## Background

PR #3086 repaired the softstart schematic so R11's high-side pad ties to `SWCLK` (BOOT0 pull-down observable from PA14 at reset). However the PCB-side netlist generator still passed the empty string for R11 pad2, leaving the PCB out of sync with the schematic.

DRC didn't flag this as `single_pad_net` because the empty net string makes pad2 an unconnected pad rather than an orphan single-pad net, so it slipped past the AC criteria that closed #3050.

## Verification

Regenerated softstart design with the fix:

- **PCB pad output**: R11 pad2 now reads `(net 18 \"SWCLK\")`, matching `NETS[\"SWCLK\"] = 18`. (See `boards/external/softstart/output/softstart.kicad_pcb`.)
- **ERC**: PASS (unchanged).
- **`kct check` connectivity**: SWCLK now reports \"1 of 3 pads stranded (connected island has 2 pads)\" — confirms R11 is a real SWCLK terminal (was 2 pads = MCU PA14 + J5; now 3 pads with R11 added). The 1 stranded pad is the autorouter's known partial-routing gap, tracked in #3085.
- **DRC**: Remaining failures (`via_in_pad` on R1/R5/R7/R8 and `connectivity` on unrelated nets like FUSED_LINE, GATE_*, GND, ISENSE_*, V_AC_SENSE, etc.) are pre-existing routing/manufacturing issues tracked in #3085. None involve R11.

Per the issue's AC: \"Routed PCB on softstart includes R11 as a SWCLK terminal (or remains intentionally unrouted if R11 is a placeholder — document in the comment).\" The PCB now declares R11 as a SWCLK terminal; the partial routing is the known #3085 router gap and is explicitly out of scope.

## Test plan

- [x] R11 pad2 declared on net `SWCLK` (verified in regenerated `softstart.kicad_pcb`)
- [x] ERC PASS on softstart
- [x] No new DRC errors introduced (remaining errors all pre-existing and unrelated to R11)
- [x] No unintended changes (single-line diff, `uv.lock` drift reverted)
- [x] Comment updated to document R11 pad2 -> SWCLK tie

## References

- Issue #3087 (this PR closes it)
- PR #3086 (the schematic repair this completes)
- Issue #3050 (parent issue: single_pad_net DRC)
- Issue #3085 (router partial-route follow-up — explicitly out of scope here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)