### PR TITLE
docs(boards): document routing entry point conventions (Option C for #3072)

### DIFF
--- a/boards/README.md
+++ b/boards/README.md
@@ -83,6 +83,70 @@ kct bom output/voltage_divider.kicad_sch --format csv
 
 See individual board READMEs for board-specific details.
 
+## Routing Entry Point Conventions
+
+When writing a new board's `generate_design.py`, pick the routing entry point
+that matches the design's signal characteristics.  The recommended pattern,
+derived from the architectural review in [#3072], is:
+
+| Design has... | Recommended entry | Boards using this pattern |
+|---|---|---|
+| No differential pairs and no length-matching | `subprocess.run(["kct", "route", ...])` *or* in-process `router.route_all()` | 00, 01, 02, 04 |
+| Differential pairs (USB2/USB3/PCIe/MIPI/HDMI/etc.) | `subprocess.run(["kct", "route", ..., "--differential-pairs"])` *or* in-process `router.route_all_with_diffpairs(diffpair_config=...)` | 03, 05, 06 |
+| Match-groups (DDR, address buses) | Same as above; see `boards/07-matchgroup-test/` for the in-development pattern | 07 (work in progress) |
+
+### Why this matters
+
+`router.route_all()` (and `kct route` without `--differential-pairs`) run a
+per-net A* loop that is unaware of `DifferentialPair` metadata.  On a board
+with diff pairs, this path silently bypasses Phase A (`CoupledPathfinder`)
+and Phase B (intra-pair clearance rip-up), producing routes that violate
+the `intra_pair_clearance`, `coupled_continuity_threshold`, and
+`target_diff_impedance` constraints declared in the project.
+
+`router.route_all_with_diffpairs()` (and `kct route --differential-pairs`)
+invoke the Phase A/B pipeline explicitly.  PR #3069 (board 03) and PR #3090
+(board 06) migrated to this entry after the bypass bug was diagnosed.
+
+### Subprocess (`kct route`) vs. in-process (`router.route_all_*`)
+
+Both are supported.  The subprocess path (`subprocess.run(["kct", "route", ...])`)
+is preferred for new boards because:
+
+- It is the production routing path; in-process tests can drift from it.
+- CLI flags (`--strategy`, `--iterations`, `--differential-pairs`,
+  `--net-class-map`, `--seed`) are validated end-to-end by CI.
+- Zone-fill, post-route DRC, and routed-PCB artifact emission are handled
+  automatically (see `route_cmd._fill_zones_after_route`).
+
+The in-process path remains the right choice when a board needs to:
+
+- Inject custom logic between routing and post-processing (e.g. board 06's
+  custom diff-pair config plumbing).
+- Exercise router internals that the CLI does not yet expose (e.g. the
+  `diffpair_config` object with non-default `intra_pair_clearance` values
+  that don't survive the JSON-roundtrip the CLI uses).
+
+### Architectural decision: auto-detect was rejected
+
+[#3072] explicitly considered teaching `router.route_all()` (and the CLI's
+default path) to auto-detect diff pairs and short-circuit to the
+Phase-A/B-aware entry.  The decision was to **not** auto-detect, for two
+reasons:
+
+1. The remaining footgun is procedural (new boards forget the right entry),
+   not active --- every existing diff-pair-bearing board is already wired
+   correctly as of PR #3090 (board 06 migration).
+2. An auto-detect change would have to land on both surfaces (in-process
+   and CLI) to be complete, and the `CoupledPathfinder` latency issue
+   tracked in [#3089] makes a CLI-default flip premature.
+
+Re-promote the auto-detect work as a separate issue once [#3089] resolves
+and a regression baseline exists for board 06's escape-time behavior.
+
+[#3072]: https://github.com/rjwalters/kicad-tools/issues/3072
+[#3089]: https://github.com/rjwalters/kicad-tools/issues/3089
+
 ## Known Issues
 
 These are known limitations that may affect your experience:


### PR DESCRIPTION
## Summary

Implements the architectural decision on #3072 as **Option C (status quo + docs)**.

The A/B/C decision was recorded as a comment on #3072 prior to this PR (per the first acceptance criterion). Full rationale: https://github.com/rjwalters/kicad-tools/issues/3072#issuecomment-4515025825

### What changed

- `boards/README.md`: new "Routing Entry Point Conventions" section documenting
  - Per-board entry-point matrix (subprocess `kct route` vs in-process `router.route_all*`)
  - When to use each (diff-pair-aware vs not)
  - Subprocess-vs-in-process tradeoffs for new boards
  - Why auto-detect (Option B) was explicitly rejected and what would re-open it

### Why Option C (not A or B)

Re-audit of `main` post-PR #3090 shows every diff-pair-bearing board is **already** correctly wired:

| Board | Entry | Diff pairs? |
|---|---|---|
| 03-usb-joystick | `router.route_all_with_diffpairs()` (PR #3069) | Yes |
| 05-bldc-motor-controller | `kct route --differential-pairs` | Yes |
| 06-diffpair-test | `router.route_all_with_diffpairs()` (PR #3090) | Yes |
| 07-matchgroup-test | `kct route` (no `--differential-pairs` flag, intentional per #3025) | Yes (opt-out) |

- **Option A is empty**: no remaining migration target. Board 07's opt-out is documented and deliberate (`generate_design.py:483-491`).
- **Option B is premature**: would need to land on both in-process AND CLI paths (5/8 boards now use the CLI), and #3089's `CoupledPathfinder` latency work is still in flight for board 06.
- **Option C is sufficient**: remaining risk is procedural (new boards forgetting the right entry); a docs convention closes that.

The PR explicitly leaves the door open to re-open Option B as a separate issue once #3089 resolves.

## Acceptance criteria (from #3072)

- [x] Architectural decision recorded in #3072's comments **before** implementation (https://github.com/rjwalters/kicad-tools/issues/3072#issuecomment-4515025825).
- [x] Chosen path (C) implemented: docs convention added to `boards/README.md`.
- [x] **N/A for C**: no code changes, so `.github/routed-drc-tolerance.yml` floors do not need updating and no 8-board CI sweep is required.
- [x] Docs entry captures the migration convention so future board authors know the recommended pattern.

## Test plan

- [x] Built docs section locally; renders correctly as a new section under "Routing Entry Point Conventions" between "Advanced: Manual Build" and "Known Issues".
- [x] Verified the per-board matrix against current `main` via `grep -n "router\.route_all\|subprocess\.run.*kct.*route" boards/*/generate_design.py boards/*/design.py` -- matches the table in the docs and the issue comment.
- [x] No source or test code changed; no CI sweep needed.

Closes #3072