### PR TITLE
fix(router): auto-gate --region-parallel on small/dense workloads (closes #3100)

### DIFF
--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2348,7 +2348,10 @@ def _add_route_parser(subparsers) -> None:
             "the routing grid into regions and routes non-adjacent regions "
             "in parallel during each negotiated-congestion iteration. "
             "Expected 2-3x speedup on dense multi-net boards. Default off "
-            "preserves single-threaded routing (deterministic with --seed)."
+            "preserves single-threaded routing (deterministic with --seed). "
+            "Auto-disabled on small / dense workloads where nets-per-region "
+            "< 16 (Issue #3100); recommended for >= 64-net boards with a "
+            "2x2 partition."
         ),
     )
     route_parser.add_argument(

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -5333,7 +5333,12 @@ def main(argv: list[str] | None = None) -> int:
         help=(
             "Enable region-based parallel routing (Issue #965). Partitions "
             "the routing grid into regions and routes non-adjacent regions "
-            "in parallel during each negotiated iteration. Default off."
+            "in parallel during each negotiated iteration. Default off. "
+            "NOTE: auto-disabled with a log warning on small / dense boards "
+            "where nets-per-region falls below 16 -- the partition + worker "
+            "overhead would exceed the per-region A* savings on those "
+            "workloads (Issue #3100; board-07 case showed +55% wall-clock). "
+            "Best used on >= 64-net boards with a 2x2 partition."
         ),
     )
     parser.add_argument(

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -5880,6 +5880,7 @@ class Autorouter:
         partition_rows: int = 2,
         partition_cols: int = 2,
         max_parallel_workers: int = 4,
+        region_parallel_min_nets_per_region: int = 16,
         batch_routing: bool = False,
         hierarchical: bool = False,
         neighborhood_stall_threshold: int = 2,
@@ -5928,6 +5929,16 @@ class Autorouter:
             partition_rows: Number of region rows for partitioning (default 2)
             partition_cols: Number of region columns for partitioning (default 2)
             max_parallel_workers: Maximum parallel workers per region group (default 4)
+            region_parallel_min_nets_per_region: Auto-gate threshold for
+                ``region_parallel`` (Issue #3100).  When ``region_parallel=True``
+                but the workload has fewer nets per region than this threshold,
+                region-based parallelism is auto-disabled with a warning because
+                the partitioning + worker overhead exceeds the per-region A*
+                savings (empirically +55% wall-clock on board 07: 31 nets / 4
+                regions = 7.75 nets/region).  Set to ``0`` to disable the gate
+                (advanced users / regression tests).  Default 16, chosen so the
+                board-07 workload trips the gate but boards 04/05 (60+ nets) do
+                not.
             batch_routing: If True, use GPU-accelerated batch routing (Issue #1092).
                 Routes multiple independent nets simultaneously using GPU compute.
                 Best results with 4+ independent nets and Metal/CUDA GPU.
@@ -6172,6 +6183,39 @@ class Autorouter:
         net_order = self._apply_byte_lane_inner_priority(net_order)
 
         total_nets = len(net_order)
+
+        # Issue #3100: Auto-gate ``region_parallel`` on small / dense workloads.
+        # PR #3068 wired ``--region-parallel`` through ``route_all_negotiated``
+        # but the docstring's "2-3x speedup" only materializes when each region
+        # has enough independent nets to amortize the worker startup, grid
+        # thread-safety conversion, and inter-iteration handoff costs.  The
+        # board-07 re-benchmark on #3045 showed +55% wall-clock with 31 nets
+        # split across a 2x2 partition (~7.75 nets/region) because the
+        # negotiated rip-up loop touches ~half the board per iteration
+        # regardless of partitioning, so per-iteration overhead dominates.
+        #
+        # When ``region_parallel_min_nets_per_region == 0`` the gate is fully
+        # disabled (used by ``tests/test_region_parallel.py`` which exercises
+        # the parallel path with a 4-net fixture).
+        if (
+            region_parallel
+            and region_parallel_min_nets_per_region > 0
+            and partition_rows > 0
+            and partition_cols > 0
+        ):
+            num_regions = partition_rows * partition_cols
+            nets_per_region = total_nets / num_regions
+            if nets_per_region < region_parallel_min_nets_per_region:
+                flush_print(
+                    f"  Region parallel: auto-disabled (Issue #3100) -- "
+                    f"{total_nets} nets / {num_regions} regions = "
+                    f"{nets_per_region:.1f} nets/region < threshold "
+                    f"{region_parallel_min_nets_per_region}.  Per-iteration "
+                    f"overhead would exceed per-region A* savings on this "
+                    f"workload (board-07 case: +55% wall-clock).  Pass "
+                    f"``region_parallel_min_nets_per_region=0`` to override."
+                )
+                region_parallel = False
 
         neg_router = NegotiatedRouter(
             self.grid, self.router, self.rules, self.net_class_map,

--- a/tests/test_region_parallel.py
+++ b/tests/test_region_parallel.py
@@ -357,6 +357,10 @@ class TestRouteAllNegotiatedWithRegionParallel:
             partition_rows=2,
             partition_cols=2,
             max_parallel_workers=4,
+            # Issue #3100: the 4-net fixture is below the default auto-gate
+            # threshold (16 nets/region).  Disable the gate so the parallel
+            # path is exercised end-to-end.
+            region_parallel_min_nets_per_region=0,
         )
 
         # Should route all 4 nets
@@ -391,9 +395,14 @@ class TestRouteAllNegotiatedWithRegionParallel:
         # Route with sequential mode
         routes_seq = router1.route_all_negotiated(max_iterations=3, region_parallel=False)
 
-        # Route with region parallel mode
+        # Route with region parallel mode (gate disabled — 2 nets / 4 regions is
+        # well below the default threshold; see Issue #3100).
         routes_par = router2.route_all_negotiated(
-            max_iterations=3, region_parallel=True, partition_rows=2, partition_cols=2
+            max_iterations=3,
+            region_parallel=True,
+            partition_rows=2,
+            partition_cols=2,
+            region_parallel_min_nets_per_region=0,
         )
 
         # Both should route all nets
@@ -407,9 +416,141 @@ class TestRouteAllNegotiatedWithRegionParallel:
         # Initially thread safety should be off
         assert not router_with_nets.grid.thread_safe
 
-        # After routing with region_parallel, grid should have thread safety
+        # After routing with region_parallel, grid should have thread safety.
+        # Disable the Issue #3100 auto-gate so the parallel path actually runs
+        # on the 4-net fixture.
         router_with_nets.route_all_negotiated(
-            max_iterations=1, region_parallel=True, partition_rows=2, partition_cols=2
+            max_iterations=1,
+            region_parallel=True,
+            partition_rows=2,
+            partition_cols=2,
+            region_parallel_min_nets_per_region=0,
         )
 
         assert router_with_nets.grid.thread_safe
+
+
+class TestRegionParallelAutoGate:
+    """Tests for the Issue #3100 nets-per-region auto-gate.
+
+    PR #3068 wired ``--region-parallel`` end-to-end, but the re-benchmark on
+    #3045 showed board 07 (31 nets, 2x2 partition -- 7.75 nets/region) ran
+    +55% slower with the flag enabled than the serial baseline.  The gate
+    auto-disables region-based parallelism on workloads where the nets per
+    region falls below a configurable threshold (default 16).
+    """
+
+    @pytest.fixture
+    def small_workload_router(self):
+        """4 nets in 4 quadrants -- well below the 16 nets/region threshold."""
+        router = Autorouter(width=100.0, height=100.0)
+        for idx, (qx, qy) in enumerate(
+            [(10.0, 10.0), (60.0, 10.0), (10.0, 60.0), (60.0, 60.0)], start=1
+        ):
+            router.add_component(
+                f"R{idx}",
+                [
+                    {"number": "1", "x": qx, "y": qy, "width": 1.0, "height": 1.0, "net": idx},
+                    {
+                        "number": "2",
+                        "x": qx + 15.0,
+                        "y": qy + 15.0,
+                        "width": 1.0,
+                        "height": 1.0,
+                        "net": idx,
+                    },
+                ],
+            )
+        return router
+
+    def test_gate_disables_region_parallel_on_small_workload(
+        self, small_workload_router, capsys
+    ):
+        """Default threshold disables region_parallel when 4 nets / 4 regions."""
+        small_workload_router.route_all_negotiated(
+            max_iterations=1,
+            region_parallel=True,
+            partition_rows=2,
+            partition_cols=2,
+            # Default region_parallel_min_nets_per_region=16 -> gate trips
+            # because 4/4 = 1.0 < 16.
+        )
+
+        captured = capsys.readouterr()
+        # The gate must announce itself so users / log scrapers see why their
+        # opt-in had no effect.
+        assert "Region parallel: auto-disabled" in captured.out
+        assert "Issue #3100" in captured.out
+        # Thread-safe grid conversion is only done inside the
+        # ``if region_parallel:`` branch, so the gate firing implies the
+        # parallel path was not taken.
+        assert not small_workload_router.grid.thread_safe
+
+    def test_gate_bypass_with_zero_threshold(self, small_workload_router, capsys):
+        """region_parallel_min_nets_per_region=0 disables the gate entirely."""
+        small_workload_router.route_all_negotiated(
+            max_iterations=1,
+            region_parallel=True,
+            partition_rows=2,
+            partition_cols=2,
+            region_parallel_min_nets_per_region=0,
+        )
+
+        captured = capsys.readouterr()
+        assert "Region parallel: auto-disabled" not in captured.out
+        # Gate bypass should let the parallel path run, which forces the
+        # thread-safe grid conversion.
+        assert small_workload_router.grid.thread_safe
+
+    def test_gate_allows_region_parallel_above_threshold(
+        self, small_workload_router, capsys
+    ):
+        """A low threshold lets a small workload through unchanged."""
+        # 4 nets / 4 regions = 1.0 nets/region.  Threshold = 1 means
+        # nets_per_region (1.0) is NOT < threshold (1), so gate does not fire.
+        small_workload_router.route_all_negotiated(
+            max_iterations=1,
+            region_parallel=True,
+            partition_rows=2,
+            partition_cols=2,
+            region_parallel_min_nets_per_region=1,
+        )
+
+        captured = capsys.readouterr()
+        assert "Region parallel: auto-disabled" not in captured.out
+        assert small_workload_router.grid.thread_safe
+
+    def test_gate_passthrough_when_region_parallel_false(
+        self, small_workload_router, capsys
+    ):
+        """Gate must not fire when region_parallel is not requested."""
+        small_workload_router.route_all_negotiated(
+            max_iterations=1,
+            region_parallel=False,
+            partition_rows=2,
+            partition_cols=2,
+        )
+
+        captured = capsys.readouterr()
+        # No gate message and no auto-disable noise when the user did not
+        # opt in.
+        assert "auto-disabled" not in captured.out
+        assert "Region parallel:" not in captured.out
+
+    def test_default_threshold_matches_board_07_finding(self):
+        """The default 16 nets/region threshold must trip board-07-shaped workloads.
+
+        Board 07 has 31 nets and a 2x2 partition (7.75 nets/region).  The
+        threshold must be high enough to catch this case but the documented
+        default is also a public-API contract -- spell it out in a test so a
+        future refactor cannot silently lower it back below board-07 density.
+        """
+        import inspect
+
+        sig = inspect.signature(Autorouter.route_all_negotiated)
+        threshold = sig.parameters["region_parallel_min_nets_per_region"].default
+        assert threshold >= 8, (
+            "Default region_parallel_min_nets_per_region must be >= 8 to trip "
+            "the board-07 case (31 nets / 4 regions = 7.75 nets/region).  "
+            "See Issue #3100."
+        )


### PR DESCRIPTION
## Summary

PR #3068 wired ``--region-parallel`` end-to-end, but the re-benchmark on #3045 showed **board 07 (31 nets, 2x2 partition -- 7.75 nets/region) ran +55% slower** with the flag enabled than the serial baseline (11:49 vs 7:37). The docstring's "2-3x speedup" only materializes when each region has enough independent nets to amortize worker startup, grid thread-safety conversion, and per-iteration handoff costs.

This PR implements the auto-gate fix (Option 2 from the issue's three acceptable fix paths):

- Adds ``region_parallel_min_nets_per_region: int = 16`` kwarg to ``Autorouter.route_all_negotiated()``
- When ``total_nets / (partition_rows * partition_cols) < threshold``, ``region_parallel`` is silently set to ``False`` after a clear log message naming Issue #3100, the actual ratio, and the override knob.
- ``= 0`` disables the gate (regression tests + power-user override).
- Default ``16`` chosen so the board-07 workload trips but boards 04/05 (60+ nets) do not.

Also documents the gate in both CLI parser surfaces (``parser.py`` outer and ``route_cmd.py`` inner) so ``kct route --help`` makes the behaviour discoverable without surprising users at runtime.

## Why Option 2 (auto-gate) over Option 1 (doc-and-refuse) or Option 3 (fix overhead)

- **vs Option 1 (doc-and-refuse)**: docs alone do nothing for users who already enabled the flag in scripts (e.g., ``boards/07-matchgroup-test/generate_design.py``). The runtime gate fixes them silently while still logging an explanation.
- **vs Option 3 (fix per-iteration overhead)**: the #3045 re-benchmark found the dominant cost is the negotiated rip-up loop touching ~half the board per iteration regardless of partitioning; per-region work amortization is structural, not a code defect. Fixing it requires fundamentally different partition-aware rip-up logic and belongs to #3101 ("reduce negotiated-loop iteration count on board 07").

## Files changed

- ``src/kicad_tools/router/core.py`` -- new parameter + gate logic + docstring
- ``src/kicad_tools/cli/parser.py`` -- outer-parser help text mentions the auto-gate
- ``src/kicad_tools/cli/route_cmd.py`` -- inner-parser help text mentions the auto-gate
- ``tests/test_region_parallel.py`` -- 3 existing tests updated to pass ``=0`` override; 5 new tests pin gate behaviour, override semantics, and the board-07 default-threshold guarantee

## Test plan

- [x] ``pytest tests/test_region_parallel.py`` -- 27 passed (3 updated + 5 new + 19 untouched)
- [x] ``pytest tests/test_cli_region_parallel.py`` -- 9 passed (CLI signature drift guard still green)
- [x] ``pytest tests/test_negotiated_adaptive.py tests/test_route_all_negotiated_overflow_regression.py tests/test_route_all_negotiated_partial_state.py tests/test_negotiated_per_net_timeout.py`` -- 147 passed (no regression in the broader negotiated suite)
- [x] ``kct route --help`` renders the updated help text cleanly

## Pre-existing failures observed (unrelated)

- ``tests/test_router_core.py::TestPadBlockedByAdjacentNetZero::test_route_to_pad_adjacent_to_net0_pad`` fails on current ``main`` (verified by stashing this PR's changes and re-running). Not in scope for #3100.

Closes #3100

🤖 Generated with [Claude Code](https://claude.com/claude-code)