### PR TITLE
fix(router): per-pair wall-clock budget for CoupledPathfinder (closes #3089)

### DIFF
--- a/.github/routed-drc-tolerance.yml
+++ b/.github/routed-drc-tolerance.yml
@@ -284,40 +284,68 @@ tolerances:
   # OR the router gains a per-pair time budget kwarg that the
   # board can pass at ``generate_design.py:436``.
   #
-  # Follow-up (out of scope for #3071, filed as #3089):
-  #   * CoupledPathfinder latency on USB3 SS pair clusters
-  #     blocks this PR from re-generating the routed PCB.
-  #     #3089 enumerates three plausible directions: (a)
-  #     escape-pattern caching across pairs of the same
-  #     protocol class, (b) layer-restriction during the inner
-  #     BGA-49 escape, (c) explicit per-pair wall-clock budget
-  #     surfaced through ``DifferentialPairConfig`` /
-  #     ``route_all_with_diffpairs(per_pair_timeout=...)`` so
-  #     callers can fail-fast rather than stall the whole CI
-  #     run.  Option (c) is the smallest change and composes
-  #     with the seed-pinning ``generate_design.py:436``
-  #     already does.
+  # Follow-up #3089 status (per-pair wall-clock budget LANDED):
+  #   ``DifferentialPairConfig.per_pair_timeout`` + the
+  #   ``CoupledPathfinder.route_coupled(timeout_seconds=...)`` kwarg
+  #   are now plumbed through.  ``generate_design.py`` passes
+  #   ``per_pair_timeout=30.0`` so each coupled-pair search is
+  #   bounded; pairs that hit the budget log a
+  #   ``diffpair coupled-routing budget exceeded`` diagnostic,
+  #   are deferred from ``diff_net_ids``, and are picked up by
+  #   the non-diff-pair main strategy (which board 06 now drives
+  #   via ``route_all_negotiated`` for proper per-net A* timeout
+  #   enforcement).  Two seed=42 runs under ``timeout 600`` now
+  #   complete end-to-end in 561-568s wall-clock (vs the prior
+  #   open-ended 96-min stall).
   #
-  # Exit clause for tightening: once one of the follow-ups
-  # above lands and the route completes end-to-end within
-  # CI's wall-clock budget, re-run ``generate_design.py``,
-  # commit the new routed PCB, and tighten this floor to
-  # reflect the post-Phase-B DRC count.  Until then the
-  # entry stays at 32 with this AC-clause-C narrative
-  # serving as the structured "Phase B could not eliminate
-  # residuals" diagnostic the issue's acceptance criteria
-  # explicitly allows.
+  # AC clause C narrative status: PARTIALLY UPDATED.  The
+  # latency root-cause of #3089 is resolved -- the run no
+  # longer stalls inside ``CoupledPathfinder``.  But the
+  # ROUTING QUALITY of the deferred pairs (5-6 of 9 hit the
+  # budget under seed=42 and fall through to the negotiated
+  # per-net router) is worse than the pre-migration
+  # ``route_all`` result: the re-routed PCB has ~959 hard
+  # DRC violations (mostly ``clearance_segment_via`` /
+  # ``clearance_pad_segment`` on the USB3 SS BGA-49 escapes
+  # the per-net A* picks up).  Committing that artifact would
+  # be a 30x regression on the committed PCB's 11-violation
+  # count, so the committed ``diffpair_test_routed.kicad_pcb``
+  # remains the pre-migration artifact for now.  Floor 32 is
+  # left in place -- it tolerates the pre-migration count
+  # with slack, and the routed PCB is unchanged.
   #
-  # Related CI soft-fail (PR for #3071): the
-  # ``diffpair-routing-regression`` job in
-  # ``.github/workflows/ci.yml`` re-routes board 06 from source
-  # on every PR.  The migration to
-  # ``route_all_with_diffpairs()`` makes that re-route stall on
-  # the USB3 SS BGA-49 escape past the 10-min job cap, so the
-  # job is marked ``continue-on-error`` for the board-06
-  # matrix entry only.  It remains an advisory signal until
-  # #3089 lands; future boards added to that matrix stay
-  # strictly required.
+  # The 3 ``diffpair_clearance_intra`` records this PR cannot
+  # eliminate come from the per-net router that quantised the
+  # USB2_D+ / USB2_D- traces onto coincident centerlines (see
+  # the violation messages at PCB-local (15.0, 9.0),
+  # (15.17, 8.714), (15.34, 8.43)).  These are exactly the
+  # failure mode Phase B (the rip-up-and-widen-spacing pass)
+  # was designed to remove.  With #3089's plumbing in place
+  # Phase B now runs against budget-exited pairs but cannot
+  # close them (the wider-spacing retry also hits the budget),
+  # so the residuals persist until a quality-focused follow-up
+  # lands.
+  #
+  # Exit clause for tightening: a follow-up issue (filed after
+  # #3089) needs to improve the routing QUALITY of the
+  # deferred pairs -- options include (a) escape-pattern
+  # caching across same-protocol pairs (option 2 of #3089's
+  # ranked list), (b) layer-restriction during the BGA-49
+  # escape (option 3), (c) a coupled-aware heuristic (option
+  # 4), or (d) the C++ port of CoupledPathfinder (option 5).
+  # Once the deferred-pair routing matches the pre-migration
+  # per-net A* quality, regenerate ``generate_design.py``,
+  # commit the resulting routed PCB, and tighten this floor
+  # to reflect the new post-Phase-B count.
+  #
+  # Related CI soft-fail: the ``diffpair-routing-regression``
+  # job in ``.github/workflows/ci.yml`` re-routes board 06
+  # from source on every PR.  With #3089 landed the re-route
+  # now COMPLETES in budget (no more 10-min timeout), but the
+  # resulting DRC count exceeds the floor -- so the entry
+  # stays ``continue-on-error: true`` until the
+  # quality follow-up above lands.  Future boards added to
+  # that matrix remain strictly required.
   boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb: 32
 
   # Match-group regression testbench (Epic #2661 Phase 3L, #2724).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,10 +373,25 @@ jobs:
     # runners; if the typical run creeps above 5 minutes, move to a
     # nightly schedule per the epic's runtime guidance.
     timeout-minutes: 10
-    # Board 06 (diffpair-test) re-routes via the migrated route_all_with_diffpairs()
-    # path which stalls on the USB3 SS BGA-49 escape past the 10-minute CI cap.
-    # Soft-fail until #3089 (CoupledPathfinder USB3 escape latency) lands;
-    # remove this line once the regression run completes in budget again.
+    # Board 06 (diffpair-test) status (post-#3089):
+    #
+    #   * LATENCY: #3089 landed a per-pair wall-clock budget plumbed
+    #     through ``DifferentialPairConfig.per_pair_timeout`` (default
+    #     30.0s for board 06).  The re-route now COMPLETES in ~560s
+    #     wall-clock (vs the prior 10-min+ stall on the USB3 SS BGA-49
+    #     escape at J3/J4).  See ``boards/06-diffpair-test/generate_design.py``.
+    #   * QUALITY: 5-6 of 9 diff pairs still defer to the per-net main
+    #     strategy under seed=42 and the resulting routed PCB has ~959
+    #     hard DRC violations (vs the committed PCB's 11).  The
+    #     committed routed PCB therefore remains the pre-migration
+    #     artifact for now.  The job's DRC-count gate fails against
+    #     the 32-floor in ``.github/routed-drc-tolerance.yml`` so the
+    #     soft-fail stays.
+    #
+    # Remove this line once the quality follow-up to #3089 lands and
+    # the re-routed DRC count drops at or under the (then-tightened)
+    # floor.  See the AC-clause-C narrative in
+    # ``.github/routed-drc-tolerance.yml`` for the exit conditions.
     #
     # Scoped via a matrix expression so any future board added to the matrix
     # (e.g. board 03 per the comment below) remains a STRICT required check;

--- a/boards/06-diffpair-test/generate_design.py
+++ b/boards/06-diffpair-test/generate_design.py
@@ -422,23 +422,71 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
     # which is what the diff-pair pre-pass and the inner per-net A*
     # loop both consult.
     #
-    # Note: ``route_all_with_diffpairs`` does not accept the
-    # ``per_net_timeout`` / ``timeout`` kwargs the prior ``route_all``
-    # call passed.  The diff-pair pre-pass uses its own internal
-    # budgeting (``DifferentialPairConfig`` controls
-    # ``max_retries_per_pair``); the per-net follow-up reuses
-    # ``Autorouter.route_all``'s configured defaults.  Two seed=42
-    # attempts (96 min and 25 min wall-clock) stalled inside
-    # ``CoupledPathfinder`` on the USB3_RX2+/USB3_RX2- BGA-49 escape
-    # at J3 / J4 -- 6 of 9 pairs route in the first ~5 min, then the
-    # 7th pair consumes the entire remaining budget without
-    # converging.  ``.github/routed-drc-tolerance.yml`` documents
-    # the AC-clause-C exit for issue #3071, and #3089 tracks the
-    # underlying latency.  When #3089 lands, regenerate this PCB
-    # and tighten the YAML floor in the same PR.
+    # Issue #3089: per-pair wall-clock budget for the inner
+    # ``CoupledPathfinder.route_coupled`` A*.  Two prior seed=42
+    # attempts (96 min and 25 min wall-clock) stalled inside the
+    # coupled pathfinder on the USB3_RX2+/USB3_RX2- BGA-49 escape
+    # at J3 / J4 -- 6 of 9 pairs routed in the first ~5 min, then the
+    # 7th pair consumed the entire remaining budget without
+    # converging.  With the per-pair budget below, each pair gets at
+    # most ``per_pair_timeout`` seconds of coupled A*; pairs that
+    # exceed the budget fall through to the independent per-net
+    # router (which the per-net A* C++ backend accelerates 10-100x).
+    # The prior open-ended runs reported 6 of 9 pairs converging
+    # in coupled mode in the first ~5 min of wall-clock; the failing
+    # pairs (USB3 SS BGA-49 escapes at J3/J4 and several MIPI nets)
+    # consume the entire remaining budget without converging.  We
+    # set a tight per-pair budget so the diff-pair phase finishes
+    # quickly and the C++-backed per-net A* in the main strategy
+    # picks up the deferred pairs.  Pairs that hit the budget are
+    # surfaced via a logger.warning + ``diffpair coupled-routing
+    # budget exceeded`` diagnostic and their nets are dropped from
+    # ``diff_net_ids`` so the main strategy routes them as ordinary
+    # nets.  Empirical observation: pairs that converge coupled do
+    # so in 0.05 -- 30 s; budget exits run for the full budget then
+    # defer.  A 30s budget bounds the diff-pair phase at 9 x 30 = 270s,
+    # leaving 330s for the per-net pass + optimisation + DRC nudge
+    # under the 600s ``timeout`` AC criterion of #3089.
     random.seed(42)
-    diffpair_config = DifferentialPairConfig(enabled=True)
-    router.route_all_with_diffpairs(diffpair_config=diffpair_config)
+
+    # Issue #3089: per-pair wall-clock budget for the inner
+    # ``CoupledPathfinder.route_coupled`` A*.  Two prior seed=42
+    # attempts (96 min and 25 min wall-clock) stalled inside the
+    # coupled pathfinder on the USB3 SS BGA-49 escape at J3/J4 --
+    # 6 of 9 pairs route in the first ~5 min, then the failing
+    # pairs consume the entire remaining budget without converging.
+    # The 30s per-pair budget bounds the diff-pair phase at
+    # 9 x 30 = 270s.  Pairs that exceed the budget surface a
+    # ``diffpair coupled-routing budget exceeded`` diagnostic, are
+    # excluded from ``diff_net_ids``, and are picked up by the
+    # non-diff-pair main strategy as ordinary nets.  When all 9
+    # converge coupled (the happy path), the diff-pair phase is
+    # observed at well under the budget.
+    diffpair_config = DifferentialPairConfig(
+        enabled=True,
+        per_pair_timeout=30.0,
+    )
+
+    # Issue #3089: route the non-diff-pair tail (including any
+    # budget-exit-deferred pairs) via ``Autorouter.route_all_negotiated``
+    # so the per-net A* honours the wall-clock ``per_net_timeout``
+    # bound.  Bare ``route_all`` only treats ``per_net_timeout`` as
+    # advisory and the BGA-49-escape nets on board 06 can monopolise
+    # the run for 5+ minutes per net (see #2794).  ``route_all_negotiated``
+    # is the strategy ``route_all`` recommends for dense boards and
+    # it composes with the diff-pair pre-pass via the
+    # ``non_diffpair_strategy`` callable hook (Issue #2464).
+    def _negotiated_non_diffpair_strategy() -> list:
+        return router.route_all_negotiated(
+            per_net_timeout=30.0,
+            timeout=240.0,
+            seed=42,
+        )
+
+    router.route_all_with_diffpairs(
+        diffpair_config=diffpair_config,
+        non_diffpair_strategy=_negotiated_non_diffpair_strategy,
+    )
 
     stats_raw = router.get_statistics()
     print(

--- a/src/kicad_tools/router/diffpair.py
+++ b/src/kicad_tools/router/diffpair.py
@@ -559,6 +559,17 @@ class DifferentialPairConfig:
         spacing: Override spacing for all pairs (None = use per-type defaults)
         max_length_delta: Override max length delta (None = use per-type defaults)
         add_serpentines: Add serpentine/meander for length matching
+        per_pair_timeout: Issue #3089: Optional per-pair wall-clock
+            budget (seconds) applied to each
+            :meth:`CoupledPathfinder.route_coupled` call.  When the
+            budget is exceeded the coupled search abandons that pair
+            and falls through to independent routing (or, in
+            ``coupled_only`` mode, returns ``([], None)``).  Bounds
+            the pathological-pair worst case so callers like
+            ``boards/06-diffpair-test/generate_design.py`` can fit
+            inside CI's 10-minute wall-clock cap even when the BGA-49
+            USB3 escape on J3/J4 fails to converge.  ``None`` (default)
+            preserves the legacy unbounded behaviour.
     """
 
     enabled: bool = False
@@ -566,6 +577,7 @@ class DifferentialPairConfig:
     spacing: float | None = None
     max_length_delta: float | None = None
     add_serpentines: bool = True
+    per_pair_timeout: float | None = None
 
     def get_rules(self, pair_type: DifferentialPairType) -> DifferentialPairRules:
         """Get rules with any config overrides applied."""

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import heapq
 import logging
 import math
+import time
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING
@@ -311,6 +312,16 @@ class CoupledPathfinder:
     spacing between them throughout the path.
     """
 
+    # Issue #3089: how often (in A* iterations) the wall-clock budget is
+    # consulted inside ``route_coupled``.  ``time.monotonic()`` is fast
+    # (~100 ns) but the coupled A* iteration body is heavy (path-history
+    # walk + neighbour generation + heap push), so the per-iter cost is
+    # 1-10 ms on board 06's BGA-49 escape.  Checking every 64 iterations
+    # keeps the overhead < 0.01 % while bounding the late-exit lateness
+    # to a few hundred milliseconds on any reasonable workload.  Must be
+    # a power of two (the check uses a bitmask).
+    _TIMEOUT_CHECK_INTERVAL = 64
+
     def __init__(
         self,
         grid: RoutingGrid,
@@ -355,6 +366,15 @@ class CoupledPathfinder:
         # Issue #3012: store the within-pair spacing floor.  ``0`` means
         # no floor (legacy behaviour).
         self.min_spacing_cells = max(0, int(min_spacing_cells))
+        # Issue #3089: set when the most-recent ``route_coupled`` call
+        # exited early due to ``timeout_seconds`` being exceeded.
+        # Callers (``route_differential_pair_coupled``) read this to
+        # distinguish a budget-exit (where the slow per-net independent
+        # fallback would also blow the budget) from a true "no path
+        # found" exit (where independent routing is still worth trying).
+        # Reset to ``False`` at the start of every ``route_coupled``
+        # invocation.
+        self.last_timeout_exceeded: bool = False
 
         # Pre-calculate trace clearance radius
         self._trace_half_width_cells = max(
@@ -865,6 +885,7 @@ class CoupledPathfinder:
         p_end: Pad,
         n_start: Pad,
         n_end: Pad,
+        timeout_seconds: float | None = None,
     ) -> tuple[Route, Route] | None:
         """Route a differential pair with coupled pathfinding.
 
@@ -873,10 +894,30 @@ class CoupledPathfinder:
             p_end: Positive trace end pad
             n_start: Negative trace start pad
             n_end: Negative trace end pad
+            timeout_seconds: Issue #3089: Optional wall-clock budget (in
+                seconds) for the A* search.  When set, the
+                ``while open_set`` loop checks ``time.monotonic()`` every
+                ``_TIMEOUT_CHECK_INTERVAL`` iterations and returns
+                ``None`` once the elapsed time exceeds the budget.  This
+                lets callers (``route_differential_pair_coupled`` /
+                ``route_all_with_diffpairs``) bound the per-pair cost
+                without changing the algorithm.  The caller is expected
+                to handle the ``None`` result the same way it handles
+                an exhausted-search ``None`` (fall back to independent
+                routing or log a skipped-budget diagnostic).
+                ``None`` (default) preserves the legacy unbounded
+                behaviour.
 
         Returns:
-            Tuple of (p_route, n_route) or None if routing failed
+            Tuple of (p_route, n_route) or None if routing failed (no
+            path found, ``max_iterations`` exhausted, or ``timeout_seconds``
+            wall-clock budget exceeded).
         """
+        # Issue #3089: reset the timeout-exit flag.  Callers consult
+        # this immediately after ``route_coupled`` returns ``None`` to
+        # decide whether to attempt an independent-routing fallback.
+        self.last_timeout_exceeded = False
+
         # Convert to grid coordinates
         p_start_gx, p_start_gy = self.grid.world_to_grid(p_start.x, p_start.y)
         p_end_gx, p_end_gy = self.grid.world_to_grid(p_end.x, p_end.y)
@@ -946,8 +987,37 @@ class CoupledPathfinder:
         max_iterations = self.grid.cols * self.grid.rows * 4
         iterations = 0
 
+        # Issue #3089: wall-clock budget bookkeeping.  When
+        # ``timeout_seconds`` is None, ``deadline`` stays None and the
+        # branch below is skipped for every iteration.
+        deadline: float | None = None
+        if timeout_seconds is not None and timeout_seconds > 0:
+            deadline = time.monotonic() + float(timeout_seconds)
+
         while open_set and iterations < max_iterations:
             iterations += 1
+
+            # Issue #3089: periodic wall-clock check.  Exits with ``None``
+            # so the caller can fall through to its existing "coupled
+            # routing failed" handler (which logs a structured message
+            # and either tries independent routing or marks the pair as
+            # skipped, depending on ``coupled_only``).
+            if (
+                deadline is not None
+                and (iterations & (self._TIMEOUT_CHECK_INTERVAL - 1)) == 0
+                and time.monotonic() >= deadline
+            ):
+                logger.warning(
+                    "CoupledPathfinder.route_coupled wall-clock budget "
+                    "exceeded after %.2fs (%d iterations); abandoning "
+                    "search (p_net=%r n_net=%r)",
+                    float(timeout_seconds),
+                    iterations,
+                    p_start.net_name,
+                    n_start.net_name,
+                )
+                self.last_timeout_exceeded = True
+                return None
 
             current = heapq.heappop(open_set)
             current_key = (current.state.p_pos, current.state.n_pos)
@@ -1473,6 +1543,15 @@ class DiffPairRouter:
         # observability-only; Phase B (separate PR) will consume this
         # list to drive a fine-grid repair sub-pass.
         self._intra_clearance_violations: list[IntraPairClearanceViolation] = []
+        # Issue #3089: True iff the most-recent call to
+        # ``route_differential_pair_coupled`` returned because the
+        # inner ``CoupledPathfinder.route_coupled`` exceeded its
+        # wall-clock budget (``per_pair_timeout``).  Used by
+        # ``route_all_with_diffpairs`` to distinguish a budget-exit
+        # (where the pair's nets should be deferred to the main
+        # strategy) from a genuine no-path-found exit (where the
+        # caller's existing handling is unchanged).
+        self._last_pair_budget_exit: bool = False
 
     def _resolve_detection_inputs(
         self,
@@ -1906,6 +1985,7 @@ class DiffPairRouter:
         spacing: float | None = None,
         coupled_only: bool = False,
         extra_spacing_cells: int = 0,
+        per_pair_timeout: float | None = None,
     ) -> tuple[list[Route], LengthMismatchWarning | None]:
         """Route a differential pair using coupled pathfinding.
 
@@ -1932,7 +2012,23 @@ class DiffPairRouter:
                 separation, which is normally enough to push the
                 routed clearance above the per-pair threshold.
                 Default ``0`` preserves legacy behaviour.
+            per_pair_timeout: Issue #3089: Optional wall-clock budget
+                (seconds) passed through to
+                :meth:`CoupledPathfinder.route_coupled` for each
+                coupled-segment search this pair triggers.  ``None``
+                preserves the legacy unbounded behaviour.  When the
+                budget is exceeded the coupled search returns ``None``
+                and this method falls through to the same
+                "coupled routing failed" handler used for genuine
+                no-path-found results (independent routing fallback
+                when ``coupled_only=False``; ``([], None)`` return
+                otherwise), so callers do not need a separate
+                code-path for budget exits.
         """
+        # Issue #3089: reset the budget-exit flag at the start of each
+        # call so callers see only the most-recent invocation's state.
+        self._last_pair_budget_exit = False
+
         if pair.rules is None:
             return [], None
 
@@ -2066,9 +2162,50 @@ class DiffPairRouter:
                 f"    Routing {pair.positive.net_name}/{pair.negative.net_name}{polarity_marker}..."
             )
 
-            result = pathfinder.route_coupled(spec.p_start, spec.p_end, spec.n_start, spec.n_end)
+            result = pathfinder.route_coupled(
+                spec.p_start,
+                spec.p_end,
+                spec.n_start,
+                spec.n_end,
+                timeout_seconds=per_pair_timeout,
+            )
 
             if result is None:
+                # Issue #3089: ``None`` may indicate (a) no path found,
+                # (b) max-iterations exhausted, or (c) the new per-pair
+                # wall-clock budget was exceeded.  CoupledPathfinder.
+                # route_coupled emits a structured ``logger.warning``
+                # for case (c) and sets ``last_timeout_exceeded=True``.
+                #
+                # When the budget fired, do NOT attempt an independent-
+                # routing fallback: the per-net A* on the same congested
+                # BGA-49 escape geometry is the slowest single-net case
+                # in the router (the per-net router has its own internal
+                # timeout but it is much larger than the coupled
+                # budget) and will blow the whole-run wall-clock budget.
+                # Instead, surface a clean "skipped: budget exceeded"
+                # diagnostic via the intra-clearance-violation buffer
+                # (so Phase B's repair pass still sees a buffer entry)
+                # and return ``([], None)`` so the main strategy picks
+                # up these nets normally.  This mirrors the AC of
+                # #3089: "with at least one pair surfacing a clean
+                # 'skipped: budget exceeded' diagnostic and continuing".
+                if pathfinder.last_timeout_exceeded:
+                    print(
+                        "    WARNING: Coupled routing budget exceeded "
+                        f"({per_pair_timeout:.0f}s); skipping diff-pair "
+                        "and leaving nets for the main strategy."
+                    )
+                    logger.warning(
+                        "diffpair coupled-routing budget exceeded: pair=%r "
+                        "p_net=%r n_net=%r budget=%.1fs",
+                        pair.name,
+                        pair.positive.net_name,
+                        pair.negative.net_name,
+                        float(per_pair_timeout) if per_pair_timeout else -1.0,
+                    )
+                    self._last_pair_budget_exit = True
+                    return [], None
                 if coupled_only:
                     print("    Skipping diff-pair pre-pass: coupled pathfinder found no path")
                     return [], None
@@ -2454,11 +2591,24 @@ class DiffPairRouter:
                     f"    Phase B attempt {attempt}/{max_retries_per_pair}: "
                     f"extra_spacing_cells={attempt}"
                 )
+                # Issue #3089: forward a tightened per-pair wall-clock
+                # budget so Phase B retries cannot stall the run with
+                # the same BGA-49-escape pathology that triggered the
+                # first-pass budget exit.  Phase B retries are
+                # known-likely-to-fail when the violation persists
+                # across attempts; we cap each retry at half the
+                # configured budget so the worst-case repair-loop
+                # cost is bounded at
+                # ``violating_pairs * max_retries_per_pair * (budget / 2)``.
+                phase_b_timeout: float | None = None
+                if diffpair_config is not None and diffpair_config.per_pair_timeout:
+                    phase_b_timeout = max(2.0, diffpair_config.per_pair_timeout / 2.0)
                 retry_routes, _retry_warning = self.route_differential_pair_coupled(
                     pair,
                     spacing=spacing_override,
                     coupled_only=True,
                     extra_spacing_cells=attempt,
+                    per_pair_timeout=phase_b_timeout,
                 )
 
                 # Capture any new violations the audit recorded for this
@@ -2541,6 +2691,7 @@ class DiffPairRouter:
         pair: DifferentialPair,
         spacing: float | None = None,
         use_coupled_routing: bool = True,
+        per_pair_timeout: float | None = None,
     ) -> tuple[list[Route], LengthMismatchWarning | None]:
         """Route a differential pair.
 
@@ -2549,13 +2700,20 @@ class DiffPairRouter:
             spacing: Override spacing (uses pair rules if None)
             use_coupled_routing: If True, use coupled A* routing.
                                 If False, use independent routing.
+            per_pair_timeout: Issue #3089: Optional per-pair wall-clock
+                budget (seconds) forwarded to
+                :meth:`route_differential_pair_coupled` when
+                ``use_coupled_routing`` is ``True``.  Ignored when the
+                independent fallback runs.
 
         Returns:
             Tuple of (routes, warning) where warning is set if
             length matching failed.
         """
         if use_coupled_routing:
-            return self.route_differential_pair_coupled(pair, spacing)
+            return self.route_differential_pair_coupled(
+                pair, spacing, per_pair_timeout=per_pair_timeout
+            )
         else:
             return self.route_differential_pair_independent(pair, spacing)
 
@@ -2663,6 +2821,7 @@ class DiffPairRouter:
         net_order: list[int] | None = None,
         non_diffpair_strategy: object = None,
         coupled_only: bool = False,
+        per_pair_timeout: float | None = None,
     ) -> tuple[list[Route], list[LengthMismatchWarning]]:
         """Route all nets with differential pair-aware routing.
 
@@ -2683,7 +2842,28 @@ class DiffPairRouter:
                 3-pad nets) are deferred to the main strategy.  When
                 False (default), preserves the legacy fall-back to
                 independent routing.
+            per_pair_timeout: Issue #3089: Optional per-pair wall-clock
+                budget (seconds) for the inner
+                :meth:`CoupledPathfinder.route_coupled` A*.  Forwarded
+                through :meth:`route_differential_pair_coupled` (and the
+                two-arg ``route_differential_pair`` indirection) so
+                callers like ``boards/06-diffpair-test/generate_design.py``
+                can bound any single coupled search and fall through to
+                independent routing for pairs whose BGA-49 escape (USB3
+                SS on board 06's J3/J4) would otherwise consume the
+                whole CI budget.  Takes precedence over
+                ``DifferentialPairConfig.per_pair_timeout`` when both
+                are supplied; ``None`` defers to the config value, and
+                if that is also ``None`` the legacy unbounded
+                behaviour is preserved.
         """
+        # Issue #3089: prefer the explicit kwarg, otherwise fall back to
+        # the config field so callers configuring everything via
+        # ``DifferentialPairConfig(per_pair_timeout=60.0)`` work without
+        # also having to pass the kwarg.
+        effective_per_pair_timeout = per_pair_timeout
+        if effective_per_pair_timeout is None and diffpair_config is not None:
+            effective_per_pair_timeout = diffpair_config.per_pair_timeout
         if diffpair_config is None or not diffpair_config.enabled:
             return self.autorouter.route_all(net_order), []
 
@@ -2718,6 +2898,12 @@ class DiffPairRouter:
         coupled_routed_nets: set[int] = set()
 
         refused_diff_nets: set[int] = set()
+        # Issue #3089: track diff-pair nets whose coupled search hit the
+        # ``per_pair_timeout`` budget.  Same handling as refused-engagement
+        # nets: drop them from ``diff_net_ids`` so the main strategy picks
+        # them up normally (the per-net C++ A* router is the right tool
+        # for any single net the coupled search couldn't converge on).
+        budget_exit_diff_nets: set[int] = set()
         for pair in diff_pairs:
             p_id, n_id = pair.get_net_ids()
             # Issue #2638, Epic #2556 Phase 2E: engagement gate.  Refuse
@@ -2740,13 +2926,25 @@ class DiffPairRouter:
                     pair,
                     diffpair_config.spacing,
                     coupled_only=True,
+                    per_pair_timeout=effective_per_pair_timeout,
                 )
             else:
                 pair_routes, warning = self.route_differential_pair(
                     pair,
                     diffpair_config.spacing,
                     use_coupled_routing=True,  # Use coupled routing by default
+                    per_pair_timeout=effective_per_pair_timeout,
                 )
+            # Issue #3089: detect budget-exit via the pair's last_budget_exit
+            # flag (set by route_differential_pair_coupled when the inner
+            # CoupledPathfinder's last_timeout_exceeded fired and we
+            # returned [], None to skip the slow independent fallback).
+            # This is more direct than inferring from pair_routes being
+            # empty (which could also mean engagement refusal or
+            # independent fallback that found nothing).
+            if not pair_routes and self._last_pair_budget_exit:
+                budget_exit_diff_nets.add(p_id)
+                budget_exit_diff_nets.add(n_id)
             if pair_routes:
                 routed_for_net: dict[int, int] = {}
                 for r in pair_routes:
@@ -2764,14 +2962,25 @@ class DiffPairRouter:
         # main strategy can pick them up.
         if coupled_only:
             diff_net_ids = coupled_routed_nets
-        elif refused_diff_nets:
-            # Issue #2638 Phase 2E: engagement-refused pairs produced no
-            # routes here; drop their nets from ``diff_net_ids`` so the
-            # main strategy routes them normally.  Non-refused pairs
-            # remain in ``diff_net_ids`` to preserve the pre-2638 behavior
-            # of treating coupled-routing fallbacks (independent routing
-            # inside route_differential_pair) as "handled".
-            diff_net_ids = diff_net_ids - refused_diff_nets
+        else:
+            if refused_diff_nets:
+                # Issue #2638 Phase 2E: engagement-refused pairs produced no
+                # routes here; drop their nets from ``diff_net_ids`` so the
+                # main strategy routes them normally.
+                diff_net_ids = diff_net_ids - refused_diff_nets
+            if budget_exit_diff_nets:
+                # Issue #3089: coupled-routing-budget-exit pairs also
+                # produced no routes; drop their nets from
+                # ``diff_net_ids`` so the main strategy's per-net A*
+                # (C++-accelerated) routes them normally.  Without this
+                # the budget-exit nets would be excluded from the
+                # main strategy AND have no coupled routes, leaving
+                # them unrouted in the final PCB.
+                print(
+                    f"  Diff pairs deferred to main strategy due to "
+                    f"per-pair budget: {len(budget_exit_diff_nets) // 2}"
+                )
+                diff_net_ids = diff_net_ids - budget_exit_diff_nets
 
         non_diff_nets = [n for n in self.autorouter.nets if n not in diff_net_ids and n != 0]
         if non_diff_nets:

--- a/tests/test_diffpair_per_pair_timeout.py
+++ b/tests/test_diffpair_per_pair_timeout.py
@@ -1,0 +1,290 @@
+"""Tests for the Issue #3089 per-pair wall-clock timeout in CoupledPathfinder.
+
+Background: ``CoupledPathfinder.route_coupled`` is a pure-Python A* over
+a joint ``(P-pos, N-pos)`` grid state.  On board 06's USB3 SS BGA-49
+escape (J3/J4) the search has been observed to spend 20+ minutes
+without converging, blowing past the CI 10-minute wall-clock cap.  The
+C++ router backend is NOT engaged for coupled diffpair routing.
+
+Issue #3089 adds a ``timeout_seconds`` kwarg to
+``CoupledPathfinder.route_coupled`` and threads a ``per_pair_timeout``
+kwarg through ``route_differential_pair_coupled``,
+``route_differential_pair``, ``route_all_with_diffpairs``, and
+``DifferentialPairConfig`` so callers can bound the per-pair cost
+without changing the algorithm.
+
+The contract:
+
+1. ``timeout_seconds=None`` preserves the legacy unbounded behaviour
+   (no time check, no observable change).
+2. ``timeout_seconds=<small>`` causes a pathological / unsolvable
+   search to return ``None`` within ~``timeout_seconds`` wall clock
+   instead of running to ``max_iterations`` exhaustion.
+3. ``timeout_seconds=<large>`` does NOT cause a clean fixture to
+   spuriously fail (the budget is large enough that the search
+   completes long before the deadline).
+4. The threaded kwargs preserve the legacy default at every layer.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import fields
+
+from kicad_tools.router.diffpair import DifferentialPairConfig
+from kicad_tools.router.diffpair_routing import CoupledPathfinder
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules
+
+# ---------------------------------------------------------------------------
+# DifferentialPairConfig field surface
+# ---------------------------------------------------------------------------
+
+
+def test_diffpair_config_has_per_pair_timeout_field():
+    """``DifferentialPairConfig`` exposes a ``per_pair_timeout`` field."""
+    field_names = {f.name for f in fields(DifferentialPairConfig)}
+    assert "per_pair_timeout" in field_names
+
+
+def test_diffpair_config_per_pair_timeout_default_none():
+    """The default value preserves the legacy unbounded behaviour."""
+    cfg = DifferentialPairConfig()
+    assert cfg.per_pair_timeout is None
+
+
+def test_diffpair_config_per_pair_timeout_accepts_float():
+    """Callers can configure the budget via the constructor."""
+    cfg = DifferentialPairConfig(enabled=True, per_pair_timeout=30.0)
+    assert cfg.per_pair_timeout == 30.0
+
+
+# ---------------------------------------------------------------------------
+# CoupledPathfinder.route_coupled timeout_seconds kwarg
+# ---------------------------------------------------------------------------
+
+
+def _make_simple_pair_pads() -> tuple[Pad, Pad, Pad, Pad]:
+    """Two-pad fixture that the coupled pathfinder routes in well under 1 s."""
+    p_start = Pad(
+        x=2.0, y=5.0, width=0.2, height=0.2, net=1, net_name="DP+",
+        layer=Layer.F_CU,
+    )
+    p_end = Pad(
+        x=10.0, y=5.0, width=0.2, height=0.2, net=1, net_name="DP+",
+        layer=Layer.F_CU,
+    )
+    n_start = Pad(
+        x=2.0, y=5.4, width=0.2, height=0.2, net=2, net_name="DP-",
+        layer=Layer.F_CU,
+    )
+    n_end = Pad(
+        x=10.0, y=5.4, width=0.2, height=0.2, net=2, net_name="DP-",
+        layer=Layer.F_CU,
+    )
+    return p_start, p_end, n_start, n_end
+
+
+def _make_unreachable_pair_pads() -> tuple[Pad, Pad, Pad, Pad]:
+    """Pair whose endpoints sit close enough that the coupled search
+    starts but the goal-state lattice is large enough that A* cannot
+    converge within a sub-second budget without the timeout firing.
+
+    We deliberately place the endpoints on opposite corners of a small
+    grid so the joint state space (rows*cols)^2 is non-trivial -- the
+    search will iterate over many heap pops before reaching the goal
+    (and will reach it eventually, but not within a 1 ms budget).
+    """
+    p_start = Pad(
+        x=1.0, y=1.0, width=0.2, height=0.2, net=1, net_name="LONG+",
+        layer=Layer.F_CU,
+    )
+    p_end = Pad(
+        x=11.0, y=11.0, width=0.2, height=0.2, net=1, net_name="LONG+",
+        layer=Layer.F_CU,
+    )
+    n_start = Pad(
+        x=1.0, y=1.4, width=0.2, height=0.2, net=2, net_name="LONG-",
+        layer=Layer.F_CU,
+    )
+    n_end = Pad(
+        x=11.0, y=11.4, width=0.2, height=0.2, net=2, net_name="LONG-",
+        layer=Layer.F_CU,
+    )
+    return p_start, p_end, n_start, n_end
+
+
+def test_route_coupled_default_timeout_preserves_legacy_behaviour():
+    """``timeout_seconds=None`` (the default) does not cause a clean
+    fixture to fail and matches the legacy result."""
+    rules = DesignRules()
+    grid = RoutingGrid(width=12.7, height=12.7, rules=rules)
+    pf = CoupledPathfinder(
+        grid=grid,
+        rules=rules,
+        target_spacing_cells=2,
+        min_spacing_cells=2,
+    )
+    p_start, p_end, n_start, n_end = _make_simple_pair_pads()
+
+    # No timeout
+    result_default = pf.route_coupled(p_start, p_end, n_start, n_end)
+    # Explicit None
+    result_none = pf.route_coupled(
+        p_start, p_end, n_start, n_end, timeout_seconds=None
+    )
+    assert result_default is not None
+    assert result_none is not None
+
+
+def test_route_coupled_generous_timeout_allows_clean_fixture():
+    """A budget that is much larger than the actual search time should
+    let the search complete normally."""
+    rules = DesignRules()
+    grid = RoutingGrid(width=12.7, height=12.7, rules=rules)
+    pf = CoupledPathfinder(
+        grid=grid,
+        rules=rules,
+        target_spacing_cells=2,
+        min_spacing_cells=2,
+    )
+    p_start, p_end, n_start, n_end = _make_simple_pair_pads()
+
+    # 60 seconds is enormous for a 12.7x12.7 mm two-pad fixture.
+    result = pf.route_coupled(
+        p_start, p_end, n_start, n_end, timeout_seconds=60.0
+    )
+    assert result is not None
+
+
+def test_route_coupled_tiny_timeout_returns_none_under_budget():
+    """A microscopic budget on a non-trivial fixture must fire the
+    timeout and return ``None`` quickly, not wait for
+    ``max_iterations`` to exhaust.
+
+    This is the load-bearing test for #3089: it proves the inner A*
+    loop actually consults the wall clock and exits early.
+    """
+    # A larger grid amplifies the joint state space so the search has
+    # work to do (the timeout-check only fires every 1024 iterations,
+    # so a 4x4-cell trivial fixture might solve before the first check).
+    rules = DesignRules()
+    grid = RoutingGrid(width=25.4, height=25.4, rules=rules)
+    pf = CoupledPathfinder(
+        grid=grid,
+        rules=rules,
+        target_spacing_cells=2,
+        min_spacing_cells=2,
+    )
+    p_start, p_end, n_start, n_end = _make_unreachable_pair_pads()
+
+    # Set a 1 ms budget.  The unbounded search on this fixture has
+    # been measured at 8+ seconds; the timeout-check fires every
+    # ``CoupledPathfinder._TIMEOUT_CHECK_INTERVAL`` iterations and
+    # each Python A* iteration can be slow (~10 ms on a synthetic
+    # 25mm grid).  The bound here is the EXIT bound -- the search
+    # must complete within ``one full check interval after deadline``,
+    # which is well under the unbounded ~25-minute USB3 stall.
+    # Bound at 30 s to leave plenty of margin for slow CI runners
+    # while still proving the timeout fires (the unbounded run on
+    # the same fixture is much slower than this).
+    t0 = time.monotonic()
+    result = pf.route_coupled(
+        p_start, p_end, n_start, n_end, timeout_seconds=0.001
+    )
+    elapsed = time.monotonic() - t0
+
+    assert result is None, (
+        "Microscopic timeout must abort the search; result is non-None"
+    )
+    assert elapsed < 30.0, (
+        f"Microscopic timeout must abort within one check interval "
+        f"after deadline; took {elapsed:.3f}s"
+    )
+
+
+def test_route_coupled_timeout_does_not_change_result_on_clean_fixture():
+    """A clean fixture that completes well under the budget must return
+    the SAME (non-None) result regardless of whether a budget was
+    supplied."""
+    rules = DesignRules()
+    grid = RoutingGrid(width=12.7, height=12.7, rules=rules)
+    pf = CoupledPathfinder(
+        grid=grid,
+        rules=rules,
+        target_spacing_cells=2,
+        min_spacing_cells=2,
+    )
+    p_start, p_end, n_start, n_end = _make_simple_pair_pads()
+
+    result_unbounded = pf.route_coupled(p_start, p_end, n_start, n_end)
+
+    # Rebuild the pathfinder so any grid mutations from the first call
+    # do not bias the second.
+    pf2 = CoupledPathfinder(
+        grid=RoutingGrid(width=12.7, height=12.7, rules=rules),
+        rules=rules,
+        target_spacing_cells=2,
+        min_spacing_cells=2,
+    )
+    result_bounded = pf2.route_coupled(
+        p_start, p_end, n_start, n_end, timeout_seconds=10.0
+    )
+
+    assert result_unbounded is not None
+    assert result_bounded is not None
+    # Same segment counts (deterministic A* with same inputs).
+    p_route_a, n_route_a = result_unbounded
+    p_route_b, n_route_b = result_bounded
+    assert len(p_route_a.segments) == len(p_route_b.segments)
+    assert len(n_route_a.segments) == len(n_route_b.segments)
+
+
+# ---------------------------------------------------------------------------
+# Threading: kwarg signatures preserve legacy defaults
+# ---------------------------------------------------------------------------
+
+
+def test_route_coupled_signature_accepts_timeout_seconds():
+    """The kwarg must be on the method (sanity check for callers)."""
+    import inspect
+
+    sig = inspect.signature(CoupledPathfinder.route_coupled)
+    assert "timeout_seconds" in sig.parameters
+    # Default must preserve legacy unbounded behaviour.
+    assert sig.parameters["timeout_seconds"].default is None
+
+
+def test_route_all_with_diffpairs_signature_accepts_per_pair_timeout():
+    """The plumbing reaches the top-level entry point."""
+    import inspect
+
+    from kicad_tools.router.diffpair_routing import DiffPairRouter
+
+    sig = inspect.signature(DiffPairRouter.route_all_with_diffpairs)
+    assert "per_pair_timeout" in sig.parameters
+    assert sig.parameters["per_pair_timeout"].default is None
+
+
+def test_route_differential_pair_signature_accepts_per_pair_timeout():
+    """The middle-layer convenience method also threads it."""
+    import inspect
+
+    from kicad_tools.router.diffpair_routing import DiffPairRouter
+
+    sig = inspect.signature(DiffPairRouter.route_differential_pair)
+    assert "per_pair_timeout" in sig.parameters
+    assert sig.parameters["per_pair_timeout"].default is None
+
+
+def test_route_differential_pair_coupled_signature_accepts_per_pair_timeout():
+    """The inner-layer coupled-only method also threads it."""
+    import inspect
+
+    from kicad_tools.router.diffpair_routing import DiffPairRouter
+
+    sig = inspect.signature(DiffPairRouter.route_differential_pair_coupled)
+    assert "per_pair_timeout" in sig.parameters
+    assert sig.parameters["per_pair_timeout"].default is None

--- a/tests/test_diffpair_phase_b.py
+++ b/tests/test_diffpair_phase_b.py
@@ -325,7 +325,13 @@ def test_repair_pass_resolves_violation_when_retry_succeeds():
     call_count = {"value": 0}
     original_method = dpr.route_differential_pair_coupled
 
-    def _succeeding_route(pair, spacing=None, coupled_only=False, extra_spacing_cells=0):
+    def _succeeding_route(
+        pair,
+        spacing=None,
+        coupled_only=False,
+        extra_spacing_cells=0,
+        per_pair_timeout=None,
+    ):
         # Simulate a clean retry: lay clean routes (wider spacing) and
         # add them to router.routes.  Do NOT append to
         # ``_intra_clearance_violations``.


### PR DESCRIPTION
## Summary

Closes #3089.

`CoupledPathfinder.route_coupled` is a pure-Python A* over a joint `(P-pos, N-pos)` state space.  On board 06's USB3 SS BGA-49 escape at J3/J4 it has been observed stalling for 20+ minutes (96 min and 25 min in the two prior seed=42 runs), blowing the CI 10-min cap.  The C++ router backend does NOT cover the coupled pathfinder, so the per-net 10-100x speedup does not apply.

This is option 1 from the curator's ranked attack-angle list: per-pair wall-clock budget.

### Plumbing

* `CoupledPathfinder.route_coupled` gains a `timeout_seconds` kwarg.  The A* loop consults `time.monotonic()` every 64 iterations and returns `None` once the budget is exceeded.  A `last_timeout_exceeded` flag lets callers distinguish a budget-exit from a no-path-found exit.
* `DifferentialPairConfig.per_pair_timeout` exposes the budget at the public API.
* `route_all_with_diffpairs` / `route_differential_pair` / `route_differential_pair_coupled` thread the kwarg through.  Budget-exit pairs are dropped from `diff_net_ids` and deferred to the non-diff-pair main strategy (so the per-net C++-accelerated A* picks them up).
* Phase B repair (`repair_intra_clearance_violations`) also honours the budget, capped at half the configured timeout so the retry loop cannot stall the run.

### Board 06 wiring

`boards/06-diffpair-test/generate_design.py` is updated to:
* Pass `per_pair_timeout=30.0` so each coupled pair search is bounded.
* Drive the non-diff-pair tail via `route_all_negotiated` (which enforces `per_net_timeout`, vs bare `route_all` which only treats it as advisory per #2794).

With both budgets in place, `timeout 600 uv run python boards/06-diffpair-test/generate_design.py` now completes end-to-end in **561-575s wall-clock** (vs the prior 96-min stall).

### AC status

| AC item | Status |
|---|---|
| `timeout 600` completes end-to-end | **DONE** -- 561-575s observed |
| routed PCB regenerated + committed | **PARTIAL** -- new PCB has ~959 DRC errors vs committed PCB's 11; committed artifact preserved |
| tolerance floor tightened to <=3 | **NOT DONE** -- requires the routing-quality follow-up |
| `continue-on-error` removed | **NOT DONE** -- DRC count regression keeps soft-fail in place |
| at least one `pytest -k "coupled"` test asserts new behaviour | **DONE** -- 11 new tests in `tests/test_diffpair_per_pair_timeout.py` |

The latency root-cause of #3089 is resolved; the routing-quality of the deferred pairs needs a follow-up (options 2-5 of the ranked attack-angle list).  The narrative in `.github/routed-drc-tolerance.yml` and the `continue-on-error` comment in `.github/workflows/ci.yml` are updated to reflect the partial AC resolution and document the exit conditions for the follow-up.

## Test plan
- [x] `pytest tests/test_diffpair_per_pair_timeout.py` -- 11 new tests pass
- [x] `pytest tests/test_diffpair.py tests/test_diffpair_*.py` -- 145 tests pass
- [x] `pytest tests/test_board_03_regression.py` -- 10 passed, 1 skipped (board 03 sibling unaffected)
- [x] `timeout 600 uv run python boards/06-diffpair-test/generate_design.py` -- completes in 575s
- [x] `uv run ruff check` on the changed files -- only pre-existing main lint failures remain

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>