### PR TITLE
feat(cli): kct fleet ship-ready warn-only gate + nightly action (closes #3099)

### DIFF
--- a/.github/workflows/nightly-ship-ready.yml
+++ b/.github/workflows/nightly-ship-ready.yml
@@ -1,0 +1,114 @@
+name: Nightly Ship-Ready Gate
+
+# Issue #3099: nightly fleet-wide ship-readiness gate.
+#
+# Runs `kct fleet ship-ready` across every PCB-bearing board under
+# `boards/` and uploads each board's manufacturing artifacts plus the
+# JSON survey output. WARN-ONLY by design (per the steering decision
+# of 2026-05-21): the job exits 0 even when boards fail, and is NOT
+# wired into the required-status checks on the default branch.
+#
+# Rationale: a hard gate on cross-board manufacturing readiness would
+# stall unrelated PRs whenever one board regresses on a slow follow-up.
+# Warn-only mode keeps the signal visible (job summary, uploaded
+# artifacts, in-output ::warning:: annotation) without ever blocking
+# integration. Can be tightened later via a follow-up issue once all
+# 7 PCB-bearing boards are reliably PASS.
+
+on:
+  schedule:
+    # 06:00 UTC daily -- after slow-tests (03:00) and routing-benchmark
+    # (Sundays 04:00) so we are not contending for free runner capacity.
+    - cron: "0 6 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  ship-ready:
+    name: Fleet ship-ready (warn-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run ship-ready survey (table)
+        id: ship_ready_table
+        # `continue-on-error: true` is belt-and-braces -- the command
+        # itself exits 0 in warn-only mode, but if a future maintainer
+        # accidentally adds --strict here, this stops the failure from
+        # propagating to job-level success.
+        continue-on-error: true
+        run: |
+          mkdir -p ship-ready-output
+          uv run kct fleet ship-ready \
+            --boards-dir boards \
+            --format table \
+            | tee ship-ready-output/ship-ready.txt
+
+      - name: Run ship-ready survey (JSON)
+        id: ship_ready_json
+        continue-on-error: true
+        run: |
+          uv run kct fleet ship-ready \
+            --boards-dir boards \
+            --format json \
+            > ship-ready-output/ship-ready.json
+
+      - name: Collect per-board manufacturing artifacts
+        if: always()
+        run: |
+          mkdir -p ship-ready-output/manufacturing
+          for d in boards/*/output/manufacturing; do
+            if [ -d "$d" ]; then
+              board=$(basename "$(dirname "$(dirname "$d")")")
+              mkdir -p "ship-ready-output/manufacturing/$board"
+              cp -r "$d"/* "ship-ready-output/manufacturing/$board/" || true
+            fi
+          done
+
+      - name: Upload ship-ready artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ship-ready-${{ github.run_id }}
+          path: ship-ready-output/
+          retention-days: 30
+
+      - name: Job summary
+        if: always()
+        run: |
+          {
+            echo "## Fleet Ship-Ready Summary (warn-only)"
+            echo ""
+            echo "Mode: warn-only (this job NEVER blocks PRs)."
+            echo ""
+            if [ -f ship-ready-output/ship-ready.txt ]; then
+              echo '```'
+              cat ship-ready-output/ship-ready.txt
+              echo '```'
+            else
+              echo "No table output produced -- see job logs."
+            fi
+            echo ""
+            echo "Artifacts (per-board manufacturing bundles + JSON survey)"
+            echo "uploaded under the run's Artifacts tab as"
+            echo "\`ship-ready-${{ github.run_id }}\` (30-day retention)."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Force success (warn-only)
+        # Final safeguard: even if the artifact collection or summary
+        # step exits non-zero for I/O reasons, the workflow as a whole
+        # MUST exit 0 so it cannot become a hidden required-check
+        # blocker.
+        run: |
+          echo "Ship-ready workflow finished in warn-only mode -- forcing exit 0."
+          exit 0

--- a/src/kicad_tools/cli/commands/fleet.py
+++ b/src/kicad_tools/cli/commands/fleet.py
@@ -45,4 +45,24 @@ def run_fleet_command(args) -> int:
         if drc_tolerance_file:
             sub_argv.extend(["--drc-tolerance-file", drc_tolerance_file])
 
+    elif fleet_command == "ship-ready":
+        boards_dir = getattr(args, "fleet_ship_boards_dir", None)
+        if boards_dir:
+            sub_argv.extend(["--boards-dir", boards_dir])
+
+        fmt = getattr(args, "fleet_ship_format", None)
+        if fmt:
+            sub_argv.extend(["--format", fmt])
+
+        pattern = getattr(args, "fleet_ship_pattern", None)
+        if pattern:
+            sub_argv.extend(["--pattern", pattern])
+
+        drc_tolerance_file = getattr(args, "fleet_ship_drc_tolerance_file", None)
+        if drc_tolerance_file:
+            sub_argv.extend(["--drc-tolerance-file", drc_tolerance_file])
+
+        if getattr(args, "fleet_ship_strict", False):
+            sub_argv.append("--strict")
+
     return fleet_main(sub_argv)

--- a/src/kicad_tools/cli/fleet_cmd.py
+++ b/src/kicad_tools/cli/fleet_cmd.py
@@ -14,11 +14,24 @@ Usage::
     kct fleet status --include-stale
     kct fleet status --pattern '*_routed.kicad_pcb'
 
+    kct fleet ship-ready                       # warn-only PASS/FAIL summary
+    kct fleet ship-ready --strict              # exit 2 if any board fails
+    kct fleet ship-ready --format json         # machine-readable
+    kct fleet ship-ready --boards-dir boards/  # custom root
+
 Exit Codes:
-    0 - All surveyed boards are ship-ready
+    0 - All surveyed boards are ship-ready (or warn-only mode regardless)
     1 - Argparse / IO error
-    2 - One or more boards are not ship-ready (default semantics, matches
-        ``net-status``)
+    2 - ``status``: one or more boards are not ship-ready (default semantics,
+        matches ``net-status``).
+        ``ship-ready --strict``: one or more boards are not ship-ready.
+        ``ship-ready`` (warn-only default): never returned -- always exit 0.
+
+Warn-only semantics (``ship-ready`` default, per issue #3099 steering
+decision 2026-05-21):
+    The ``ship-ready`` subcommand exits 0 by default even when boards fail,
+    so it can be wired into nightly CI as a non-blocking gate. Pass
+    ``--strict`` to opt into non-zero exit semantics for human users.
 """
 
 from __future__ import annotations
@@ -182,6 +195,76 @@ class BoardStatus:
 
 
 # ---------------------------------------------------------------------------
+# Ship-ready data classes (issue #3099)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ERCStatus:
+    """ERC report presence + violation counts for a single board.
+
+    Mirrors :class:`DRCStatus` shape for symmetry. When ``report_exists``
+    is False the ERC step has not yet run for this board, so it does NOT
+    contribute a blocker (warn-only treats missing as unknown).
+    """
+
+    report_exists: bool = False
+    errors: int = 0
+    warnings: int = 0
+    report_path: str | None = None
+
+    @property
+    def has_errors(self) -> bool:
+        return self.report_exists and self.errors > 0
+
+    def to_dict(self) -> dict:
+        return {
+            "report_exists": self.report_exists,
+            "errors": self.errors,
+            "warnings": self.warnings,
+            "report_path": self.report_path,
+            "has_errors": self.has_errors,
+        }
+
+
+@dataclass
+class ShipReadyStatus:
+    """Per-board aggregate for the ``kct fleet ship-ready`` gate.
+
+    Composes :class:`BoardStatus` (which already aggregates routing,
+    manufacturing, and DRC) with an :class:`ERCStatus` field and a
+    PASS/FAIL verdict driven by the union of all blocker sources.
+
+    Designed for warn-only nightly CI: every aspect is surfaced for
+    humans to triage even when the workflow exits 0.
+    """
+
+    board: BoardStatus
+    erc: ERCStatus = field(default_factory=ERCStatus)
+    blockers: list[str] = field(default_factory=list)
+
+    @property
+    def name(self) -> str:
+        return self.board.name
+
+    @property
+    def passed(self) -> bool:
+        return not self.blockers
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.board.name,
+            "passed": self.passed,
+            "blockers": list(self.blockers),
+            "routed_pcb": (str(self.board.routed_pcb) if self.board.routed_pcb else None),
+            "routing": self.board.routing.to_dict(),
+            "manufacturing": self.board.manufacturing.to_dict(),
+            "drc": self.board.drc.to_dict(),
+            "erc": self.erc.to_dict(),
+        }
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -189,10 +272,7 @@ class BoardStatus:
 def _iso_or_none(mtime: float | None) -> str | None:
     if mtime is None:
         return None
-    return (
-        _dt.datetime.fromtimestamp(mtime, tz=_dt.timezone.utc)
-        .isoformat(timespec="seconds")
-    )
+    return _dt.datetime.fromtimestamp(mtime, tz=_dt.timezone.utc).isoformat(timespec="seconds")
 
 
 def _now_iso() -> str:
@@ -358,6 +438,90 @@ def _detect_drc(
     return drc
 
 
+def _detect_erc(board_dir: Path) -> ERCStatus:
+    """Look for an ERC report under common locations in ``board_dir``.
+
+    Tries (in order):
+      * ``<board>/output/erc_report.json``
+      * ``<board>/output/<sch_stem>-erc.json`` for any sibling ``.kicad_sch``
+      * ``<board>/erc_report.json``
+
+    Returns ``ERCStatus`` with ``report_exists=False`` when nothing is
+    found -- in warn-only mode this surfaces as ``ERC -`` in the table
+    and does not block ship-ready (consistent with the DRC
+    backwards-compat rule from issue #2932).
+    """
+    erc = ERCStatus()
+
+    candidates: list[Path] = [
+        board_dir / "output" / "erc_report.json",
+        board_dir / "erc_report.json",
+    ]
+    # KiCad's own convention: ``<sch_stem>-erc.json`` next to the .kicad_sch.
+    try:
+        for sch in sorted((board_dir).glob("*.kicad_sch")):
+            candidates.append(board_dir / "output" / f"{sch.stem}-erc.json")
+            candidates.append(board_dir / f"{sch.stem}-erc.json")
+    except OSError:
+        pass
+
+    report_path: Path | None = None
+    for candidate in candidates:
+        if candidate.is_file():
+            report_path = candidate
+            break
+    if report_path is None:
+        return erc
+
+    erc.report_path = str(report_path)
+    try:
+        with report_path.open() as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        # Malformed report behaves like missing -- do not block.
+        return erc
+
+    # Two shapes are common:
+    #   1. Our ERCReport.to_dict() with ``violations``/``errors``/``warnings``
+    #   2. KiCad's native dump with ``sheets[].violations[].severity``
+    errors = 0
+    warnings = 0
+    if isinstance(data, dict):
+        summary = data.get("summary")
+        if isinstance(summary, dict):
+            if isinstance(summary.get("errors"), int):
+                errors = summary["errors"]
+            if isinstance(summary.get("warnings"), int):
+                warnings = summary["warnings"]
+
+        if errors == 0 and warnings == 0:
+            # Fall back to walking violations / sheets[].violations.
+            violations: list = []
+            top_violations = data.get("violations")
+            if isinstance(top_violations, list):
+                violations.extend(top_violations)
+            sheets = data.get("sheets")
+            if isinstance(sheets, list):
+                for sheet in sheets:
+                    if isinstance(sheet, dict):
+                        sv = sheet.get("violations")
+                        if isinstance(sv, list):
+                            violations.extend(sv)
+            for v in violations:
+                if not isinstance(v, dict):
+                    continue
+                severity = str(v.get("severity", "")).lower()
+                if severity == "error":
+                    errors += 1
+                elif severity == "warning":
+                    warnings += 1
+
+    erc.report_exists = True
+    erc.errors = errors
+    erc.warnings = warnings
+    return erc
+
+
 def _compute_routing(routed_pcb: Path) -> RoutingStatus:
     """Run NetStatusAnalyzer on a routed PCB and tally pads/nets."""
     status = RoutingStatus()
@@ -403,9 +567,7 @@ def _compute_blockers(
         return blockers
     if not routing.routing_complete:
         incomplete = routing.incomplete_nets + routing.unrouted_nets
-        blockers.append(
-            f"incomplete routing ({incomplete}/{routing.total_nets} nets)"
-        )
+        blockers.append(f"incomplete routing ({incomplete}/{routing.total_nets} nets)")
     if not mfg.dir_exists:
         blockers.append("no manufacturing/ dir")
         return blockers
@@ -421,9 +583,7 @@ def _compute_blockers(
         blockers.append("artifacts stale")
     if drc is not None and drc.over_tolerance:
         if drc.tolerance > 0:
-            blockers.append(
-                f"DRC errors: {drc.errors} (allowed {drc.tolerance})"
-            )
+            blockers.append(f"DRC errors: {drc.errors} (allowed {drc.tolerance})")
         else:
             blockers.append(f"DRC errors: {drc.errors}")
     return blockers
@@ -505,6 +665,156 @@ def _discover_boards(
 
 
 # ---------------------------------------------------------------------------
+# Ship-ready survey + formatters (issue #3099)
+# ---------------------------------------------------------------------------
+
+
+def _compute_ship_ready_blockers(
+    board: BoardStatus,
+    erc: ERCStatus,
+) -> list[str]:
+    """Aggregate blockers from routing/manufacturing/DRC/ERC.
+
+    Reuses ``board.blockers`` (already filled by ``_compute_blockers``)
+    and appends ERC errors when the report exists and reports any
+    severity-error rows. Missing reports never add a blocker -- they
+    surface as ``-`` in the table per the warn-only philosophy.
+    """
+    blockers: list[str] = list(board.blockers)
+    if erc.has_errors:
+        blockers.append(f"ERC errors: {erc.errors}")
+    return blockers
+
+
+def _survey_board_ship_ready(
+    board_dir: Path,
+    pattern: str,
+    drc_tolerances: dict[str, int] | None = None,
+) -> ShipReadyStatus:
+    """Build a ``ShipReadyStatus`` for a single board directory."""
+    board = _survey_board(board_dir, pattern, drc_tolerances)
+    erc = _detect_erc(board_dir)
+    blockers = _compute_ship_ready_blockers(board, erc)
+    return ShipReadyStatus(board=board, erc=erc, blockers=blockers)
+
+
+def _discover_ship_ready(
+    boards_dir: Path,
+    pattern: str,
+    drc_tolerance_path: Path | None = None,
+) -> list[ShipReadyStatus]:
+    """Survey every board sub-directory for ship-readiness.
+
+    Mirrors :func:`_discover_boards` (same skip rules) but builds the
+    richer :class:`ShipReadyStatus` per board.
+    """
+    if not boards_dir.is_dir():
+        return []
+    tolerances = _load_drc_tolerances(
+        drc_tolerance_path if drc_tolerance_path is not None else _DRC_TOLERANCE_PATH
+    )
+    results: list[ShipReadyStatus] = []
+    for entry in sorted(boards_dir.iterdir()):
+        if not entry.is_dir():
+            continue
+        if entry.name.startswith("."):
+            continue
+        output_dir = entry / "output"
+        if not output_dir.is_dir():
+            continue
+        if _discover_routed_pcb(entry, pattern) is None:
+            continue
+        results.append(_survey_board_ship_ready(entry, pattern, tolerances))
+    return results
+
+
+def _erc_label(erc: ERCStatus) -> str:
+    """Render the ERC column cell.
+
+    ``-``       : no ERC report found (no signal yet, do not block).
+    ``N``       : N errors found (any value -- a non-zero count drives the
+                  ship-ready ``FAIL`` blocker).
+    """
+    if not erc.report_exists:
+        return "-"
+    return str(erc.errors)
+
+
+def _format_ship_ready_table(
+    statuses: list[ShipReadyStatus],
+    boards_dir: Path,
+    *,
+    warn_only: bool,
+) -> str:
+    """Plain-ASCII per-board PASS/FAIL table for nightly summaries."""
+    lines: list[str] = []
+    header = f"{'Board':<28} {'Route':>7} {'DRC':>5} {'ERC':>5} {'Mfr':<8} {'Stale':<6} Verdict"
+    sep = "-" * len(header)
+    lines.append(header)
+    lines.append(sep)
+
+    if not statuses:
+        lines.append("No boards found")
+    else:
+        for s in statuses:
+            route_cell = f"{s.board.routing.connected_pads}/{s.board.routing.total_pads}"
+            drc_cell = _drc_label(s.board.drc)
+            erc_cell = _erc_label(s.erc)
+            mfr_cell = _mfr_letters(s.board.manufacturing)
+            stale_cell = _stale_label(s.board.manufacturing)
+            if s.passed:
+                verdict = "PASS"
+            else:
+                verdict = f"FAIL ({s.blockers[0]})"
+            lines.append(
+                f"{s.name[:28]:<28} {route_cell:>7} {drc_cell:>5} "
+                f"{erc_cell:>5} {mfr_cell:<8} {stale_cell:<6} {verdict}"
+            )
+
+    # Footer.
+    if statuses:
+        lines.append("")
+        passing = sum(1 for s in statuses if s.passed)
+        failing = len(statuses) - passing
+        mode = "warn-only" if warn_only else "strict"
+        lines.append(
+            f"{len(statuses)} boards surveyed, {passing} PASS, {failing} FAIL ({mode} mode)"
+        )
+        lines.append(f"boards-dir: {boards_dir}")
+        if warn_only and failing > 0:
+            lines.append(
+                "::warning::ship-ready: "
+                f"{failing}/{len(statuses)} board(s) FAIL "
+                "(warn-only mode -- exit 0)"
+            )
+
+    return "\n".join(lines)
+
+
+def _format_ship_ready_json(
+    statuses: list[ShipReadyStatus],
+    boards_dir: Path,
+    *,
+    warn_only: bool,
+) -> str:
+    summary = {
+        "total": len(statuses),
+        "passed": sum(1 for s in statuses if s.passed),
+        "failed": sum(1 for s in statuses if not s.passed),
+        "warn_only": warn_only,
+    }
+    doc = {
+        "schema_version": SCHEMA_VERSION,
+        "command": "ship-ready",
+        "surveyed_at": _now_iso(),
+        "boards_dir": str(boards_dir),
+        "summary": summary,
+        "boards": [s.to_dict() for s in statuses],
+    }
+    return json.dumps(doc, indent=2)
+
+
+# ---------------------------------------------------------------------------
 # Output formatters
 # ---------------------------------------------------------------------------
 
@@ -553,10 +863,7 @@ def _format_table(
 ) -> str:
     """Format a fixed-width plain-ASCII table."""
     lines: list[str] = []
-    header = (
-        f"{'Board':<28} {'Pads':>7} {'%':>5} {'Mfr':<8} {'Stale':<6} "
-        f"{'DRC':>5} Ship?"
-    )
+    header = f"{'Board':<28} {'Pads':>7} {'%':>5} {'Mfr':<8} {'Stale':<6} {'DRC':>5} Ship?"
     sep = "-" * len(header)
     lines.append(header)
     lines.append(sep)
@@ -580,8 +887,7 @@ def _format_table(
             else:
                 ship = f"NO  ({b.blockers[0]})"
             lines.append(
-                f"{b.name[:28]:<28} {pads:>7} {pct:>5} {mfr:<8} {stale:<6} "
-                f"{drc_cell:>5} {ship}"
+                f"{b.name[:28]:<28} {pads:>7} {pct:>5} {mfr:<8} {stale:<6} {drc_cell:>5} {ship}"
             )
 
     # Footer (always uses full board list, not filtered view).
@@ -589,9 +895,7 @@ def _format_table(
         lines.append("")
         ship_ready = sum(1 for b in boards if b.ship_ready)
         incomplete = sum(
-            1
-            for b in boards
-            if not b.routing.routing_complete and b.routing.error is None
+            1 for b in boards if not b.routing.routing_complete and b.routing.error is None
         )
         stale_count = sum(1 for b in boards if b.manufacturing.stale)
         drc_failing = sum(1 for b in boards if b.drc.over_tolerance)
@@ -610,16 +914,10 @@ def _format_json(boards: list[BoardStatus], boards_dir: Path) -> str:
         "total": len(boards),
         "ship_ready": sum(1 for b in boards if b.ship_ready),
         "incomplete_routing": sum(
-            1
-            for b in boards
-            if not b.routing.routing_complete and b.routing.error is None
+            1 for b in boards if not b.routing.routing_complete and b.routing.error is None
         ),
         "stale_artifacts": sum(1 for b in boards if b.manufacturing.stale),
-        "missing_artifacts": sum(
-            1
-            for b in boards
-            if not b.manufacturing.has_all
-        ),
+        "missing_artifacts": sum(1 for b in boards if not b.manufacturing.has_all),
         "drc_over_tolerance": sum(1 for b in boards if b.drc.over_tolerance),
     }
     doc = {
@@ -690,6 +988,50 @@ def _build_parser() -> argparse.ArgumentParser:
             "ship-ready."
         ),
     )
+
+    # ------------------------------------------------------------------
+    # fleet ship-ready (issue #3099)
+    # ------------------------------------------------------------------
+    ship_parser = subparsers.add_parser(
+        "ship-ready",
+        help=(
+            "Per-board PASS/FAIL gate (routing + DRC + ERC + manufacturing). "
+            "Warn-only by default; pass --strict for non-zero exit on failure."
+        ),
+    )
+    ship_parser.add_argument(
+        "--boards-dir",
+        default="boards",
+        help="Root directory containing per-board subdirs (default: boards)",
+    )
+    ship_parser.add_argument(
+        "--format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    ship_parser.add_argument(
+        "--pattern",
+        default="*_routed.kicad_pcb",
+        help="Glob to identify routed PCB inside output/ (default: *_routed.kicad_pcb)",
+    )
+    ship_parser.add_argument(
+        "--drc-tolerance-file",
+        default=str(_DRC_TOLERANCE_PATH),
+        help=(
+            "Path to the per-board DRC tolerance allowlist (default: "
+            ".github/routed-drc-tolerance.yml)."
+        ),
+    )
+    ship_parser.add_argument(
+        "--strict",
+        action="store_true",
+        help=(
+            "Exit non-zero (2) if any board fails. Default is warn-only "
+            "(always exit 0) so the command is safe to wire into a "
+            "non-blocking nightly CI gate."
+        ),
+    )
     return parser
 
 
@@ -711,6 +1053,36 @@ def run_status(args: argparse.Namespace) -> int:
     return 2
 
 
+def run_ship_ready(args: argparse.Namespace) -> int:
+    """Execute the ``fleet ship-ready`` sub-action.
+
+    Warn-only by default: prints PASS/FAIL summary and always returns 0.
+    When ``--strict`` is passed, returns 2 if any board failed (or if no
+    boards were found, mirroring ``status``).
+    """
+    boards_dir = Path(args.boards_dir)
+    tolerance_path = Path(getattr(args, "drc_tolerance_file", _DRC_TOLERANCE_PATH))
+    warn_only = not getattr(args, "strict", False)
+
+    statuses = _discover_ship_ready(boards_dir, args.pattern, tolerance_path)
+
+    if args.format == "json":
+        print(_format_ship_ready_json(statuses, boards_dir, warn_only=warn_only))
+    else:
+        print(_format_ship_ready_table(statuses, boards_dir, warn_only=warn_only))
+
+    if warn_only:
+        # Warn-only: never block. Surface non-zero only via the table's
+        # ::warning:: annotation (parsed by GitHub Actions).
+        return 0
+
+    if not statuses:
+        return 2
+    if all(s.passed for s in statuses):
+        return 0
+    return 2
+
+
 def main(argv: list[str] | None = None) -> int:
     """Main entry point for the fleet command."""
     parser = _build_parser()
@@ -722,6 +1094,8 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.fleet_command == "status":
         return run_status(args)
+    if args.fleet_command == "ship-ready":
+        return run_ship_ready(args)
 
     parser.print_help()
     return 0

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -4555,6 +4555,58 @@ def _add_fleet_parser(subparsers) -> None:
         ),
     )
 
+    # ------------------------------------------------------------------
+    # fleet ship-ready (issue #3099)
+    # ------------------------------------------------------------------
+    fleet_ship_ready = fleet_subparsers.add_parser(
+        "ship-ready",
+        help=(
+            "Per-board PASS/FAIL gate across routing + DRC + ERC + manufacturing. "
+            "Warn-only by default; pass --strict for non-zero exit on failure."
+        ),
+        description=(
+            "Aggregate ship-readiness gate. Reads the routed PCB, "
+            "drc_report.json, manifest.json, and any erc_report.json under "
+            "each board's output/ directory and emits a PASS/FAIL row per "
+            "board. Designed for nightly CI use in warn-only mode: --strict "
+            "opts into non-zero exits for humans."
+        ),
+    )
+    fleet_ship_ready.add_argument(
+        "--boards-dir",
+        dest="fleet_ship_boards_dir",
+        default="boards",
+        help="Root directory containing per-board subdirs (default: boards)",
+    )
+    fleet_ship_ready.add_argument(
+        "--format",
+        dest="fleet_ship_format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    fleet_ship_ready.add_argument(
+        "--pattern",
+        dest="fleet_ship_pattern",
+        default="*_routed.kicad_pcb",
+        help="Glob to identify routed PCB inside output/ (default: *_routed.kicad_pcb)",
+    )
+    fleet_ship_ready.add_argument(
+        "--drc-tolerance-file",
+        dest="fleet_ship_drc_tolerance_file",
+        default=".github/routed-drc-tolerance.yml",
+        help=(
+            "Path to the per-board DRC tolerance allowlist (default: "
+            ".github/routed-drc-tolerance.yml)."
+        ),
+    )
+    fleet_ship_ready.add_argument(
+        "--strict",
+        dest="fleet_ship_strict",
+        action="store_true",
+        help=("Exit non-zero (2) if any board fails. Default is warn-only (always exit 0)."),
+    )
+
 
 def _add_clean_parser(subparsers) -> None:
     """Add clean subcommand parser for project cleanup."""

--- a/tests/test_fleet_ship_ready.py
+++ b/tests/test_fleet_ship_ready.py
@@ -1,0 +1,607 @@
+"""Tests for the ``kct fleet ship-ready`` CLI command (issue #3099).
+
+The ``ship-ready`` subcommand is the warn-only nightly CI gate. These
+tests exercise:
+
+* The default warn-only exit code (always 0 even when boards fail).
+* The ``--strict`` mode flip (exit 2 on failure).
+* JSON output schema (consumed by the nightly workflow's artifact step).
+* ERC report detection (presence/absence behavior).
+* DRC + manufacturing + ERC blocker aggregation.
+
+The fake-board builder reuses the synthetic PCB fixtures from
+``test_fleet_status``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from kicad_tools.cli.fleet_cmd import main
+
+# Re-import the synthetic-board builder from the sibling test module so we
+# stay in lockstep with its fixture coverage and avoid duplication.
+from tests.test_fleet_status import make_fake_board
+
+# ---------------------------------------------------------------------------
+# ERC report helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_erc_report(
+    board_dir: Path,
+    *,
+    errors: int = 0,
+    warnings: int = 0,
+    location: str = "output",
+) -> Path:
+    """Write an ``erc_report.json`` for a fake board.
+
+    Uses the same shape as :class:`kicad_tools.erc.report.ERCReport`'s
+    summary block so the detector's first parsing branch matches.
+    """
+    if location == "output":
+        path = board_dir / "output" / "erc_report.json"
+    else:
+        path = board_dir / "erc_report.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "source": f"{board_dir.name}.kicad_sch",
+        "summary": {
+            "errors": errors,
+            "warnings": warnings,
+        },
+        "violations": [],
+    }
+    path.write_text(json.dumps(payload))
+    return path
+
+
+def _write_drc_report(
+    board_dir: Path,
+    routed_pcb_name: str,
+    *,
+    errors: int = 0,
+) -> Path:
+    """Write a ``drc_report.json`` next to the routed PCB."""
+    path = board_dir / "output" / "drc_report.json"
+    payload = {
+        "source": routed_pcb_name,
+        "summary": {
+            "errors": errors,
+            "warnings": 0,
+        },
+    }
+    path.write_text(json.dumps(payload))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestShipReadyWarnOnly:
+    """Default ``warn-only`` semantics: always exit 0."""
+
+    def test_warn_only_exit_zero_on_all_pass(self, tmp_path: Path, capsys):
+        """3 ship-ready boards -> warn-only exit 0."""
+        boards = tmp_path / "boards"
+        for name in ["a-board", "b-board", "c-board"]:
+            make_fake_board(
+                boards,
+                name,
+                routed_complete=True,
+                has_gerbers=True,
+                has_bom=True,
+                has_cpl=True,
+                has_manifest=True,
+            )
+
+        result = main(
+            [
+                "ship-ready",
+                "--boards-dir",
+                str(boards),
+                "--format",
+                "json",
+            ]
+        )
+        assert result == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["summary"]["total"] == 3
+        assert data["summary"]["passed"] == 3
+        assert data["summary"]["failed"] == 0
+        assert data["summary"]["warn_only"] is True
+        assert data["command"] == "ship-ready"
+
+    def test_warn_only_exit_zero_even_when_boards_fail(self, tmp_path: Path, capsys):
+        """Boards FAILING must NOT escalate the warn-only exit code."""
+        boards = tmp_path / "boards"
+        # One PASS, one FAIL (missing manufacturing).
+        make_fake_board(
+            boards,
+            "good-board",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        make_fake_board(
+            boards,
+            "bad-board",
+            routed_complete=False,  # incomplete routing -> blocker
+        )
+
+        result = main(
+            [
+                "ship-ready",
+                "--boards-dir",
+                str(boards),
+                "--format",
+                "json",
+            ]
+        )
+        # Warn-only: ALWAYS exit 0 even on failure.
+        assert result == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["summary"]["total"] == 2
+        assert data["summary"]["passed"] == 1
+        assert data["summary"]["failed"] == 1
+        # FAIL board is identified by name.
+        failing = [b for b in data["boards"] if not b["passed"]]
+        assert len(failing) == 1
+        assert failing[0]["name"] == "bad-board"
+        assert failing[0]["blockers"]  # at least one reason listed
+
+    def test_warn_only_exit_zero_on_empty_boards_dir(self, tmp_path: Path, capsys):
+        """No boards discovered -> still exit 0 in warn-only mode."""
+        boards = tmp_path / "boards"
+        boards.mkdir()
+        result = main(
+            [
+                "ship-ready",
+                "--boards-dir",
+                str(boards),
+                "--format",
+                "json",
+            ]
+        )
+        assert result == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["summary"]["total"] == 0
+        assert data["summary"]["passed"] == 0
+
+
+class TestShipReadyStrict:
+    """``--strict`` mode opts into non-zero exit semantics."""
+
+    def test_strict_exit_zero_on_all_pass(self, tmp_path: Path, capsys):
+        """All boards PASS -> strict mode still exits 0."""
+        boards = tmp_path / "boards"
+        for name in ["a", "b"]:
+            make_fake_board(
+                boards,
+                name,
+                routed_complete=True,
+                has_gerbers=True,
+                has_bom=True,
+                has_cpl=True,
+                has_manifest=True,
+            )
+
+        result = main(
+            [
+                "ship-ready",
+                "--boards-dir",
+                str(boards),
+                "--format",
+                "json",
+                "--strict",
+            ]
+        )
+        assert result == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["summary"]["warn_only"] is False
+        assert data["summary"]["passed"] == 2
+
+    def test_strict_exit_two_on_any_fail(self, tmp_path: Path, capsys):
+        """One board FAILing under --strict -> exit 2."""
+        boards = tmp_path / "boards"
+        make_fake_board(
+            boards,
+            "good",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        make_fake_board(
+            boards,
+            "bad",
+            routed_complete=False,
+        )
+        result = main(
+            [
+                "ship-ready",
+                "--boards-dir",
+                str(boards),
+                "--format",
+                "json",
+                "--strict",
+            ]
+        )
+        assert result == 2
+
+    def test_strict_exit_two_on_empty_boards_dir(self, tmp_path: Path, capsys):
+        """No boards -> strict mode exits 2 (matches ``fleet status``)."""
+        boards = tmp_path / "boards"
+        boards.mkdir()
+        result = main(
+            [
+                "ship-ready",
+                "--boards-dir",
+                str(boards),
+                "--format",
+                "json",
+                "--strict",
+            ]
+        )
+        assert result == 2
+
+
+class TestShipReadyERCDetection:
+    """Verify ERC reports drive a blocker only when the report exists."""
+
+    def test_erc_missing_does_not_block(self, tmp_path: Path, capsys):
+        """No erc_report.json -> warn-only, no ERC blocker."""
+        boards = tmp_path / "boards"
+        make_fake_board(
+            boards,
+            "no-erc-board",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        result = main(
+            [
+                "ship-ready",
+                "--boards-dir",
+                str(boards),
+                "--format",
+                "json",
+                "--strict",
+            ]
+        )
+        # No ERC report present -> board still PASS.
+        assert result == 0
+        data = json.loads(capsys.readouterr().out)
+        board = data["boards"][0]
+        assert board["passed"] is True
+        assert board["erc"]["report_exists"] is False
+
+    def test_erc_zero_errors_does_not_block(self, tmp_path: Path, capsys):
+        """erc_report.json with 0 errors -> PASS."""
+        boards = tmp_path / "boards"
+        make_fake_board(
+            boards,
+            "erc-clean",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        _write_erc_report(boards / "erc-clean", errors=0, warnings=2)
+
+        result = main(
+            [
+                "ship-ready",
+                "--boards-dir",
+                str(boards),
+                "--format",
+                "json",
+                "--strict",
+            ]
+        )
+        assert result == 0
+        data = json.loads(capsys.readouterr().out)
+        board = data["boards"][0]
+        assert board["passed"] is True
+        assert board["erc"]["report_exists"] is True
+        assert board["erc"]["errors"] == 0
+        assert board["erc"]["warnings"] == 2
+
+    def test_erc_with_errors_blocks_under_strict(self, tmp_path: Path, capsys):
+        """erc_report.json with errors -> blocker, strict exits 2."""
+        boards = tmp_path / "boards"
+        make_fake_board(
+            boards,
+            "erc-broken",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        _write_erc_report(boards / "erc-broken", errors=3)
+
+        result = main(
+            [
+                "ship-ready",
+                "--boards-dir",
+                str(boards),
+                "--format",
+                "json",
+                "--strict",
+            ]
+        )
+        assert result == 2
+        data = json.loads(capsys.readouterr().out)
+        board = data["boards"][0]
+        assert board["passed"] is False
+        assert board["erc"]["errors"] == 3
+        assert any("ERC errors: 3" in b for b in board["blockers"])
+
+    def test_erc_kicad_native_shape_parsed(self, tmp_path: Path, capsys):
+        """KiCad-native shape (``sheets[].violations[].severity``) is parsed."""
+        boards = tmp_path / "boards"
+        make_fake_board(
+            boards,
+            "kicad-shape",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        report_path = boards / "kicad-shape" / "output" / "erc_report.json"
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(
+            json.dumps(
+                {
+                    "source": "kicad-shape.kicad_sch",
+                    "sheets": [
+                        {
+                            "path": "/",
+                            "violations": [
+                                {"severity": "error", "type": "pin_no_connection"},
+                                {"severity": "error", "type": "pin_no_connection"},
+                                {"severity": "warning", "type": "label_dangling"},
+                            ],
+                        }
+                    ],
+                }
+            )
+        )
+
+        result = main(
+            [
+                "ship-ready",
+                "--boards-dir",
+                str(boards),
+                "--format",
+                "json",
+            ]
+        )
+        assert result == 0  # warn-only
+        data = json.loads(capsys.readouterr().out)
+        board = data["boards"][0]
+        assert board["erc"]["report_exists"] is True
+        assert board["erc"]["errors"] == 2
+        assert board["erc"]["warnings"] == 1
+
+    def test_erc_malformed_report_treated_as_missing(self, tmp_path: Path, capsys):
+        """Malformed JSON in erc_report.json -> behaves like missing."""
+        boards = tmp_path / "boards"
+        make_fake_board(
+            boards,
+            "bad-erc",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        report_path = boards / "bad-erc" / "output" / "erc_report.json"
+        report_path.write_text("{not valid json")
+
+        result = main(
+            [
+                "ship-ready",
+                "--boards-dir",
+                str(boards),
+                "--format",
+                "json",
+                "--strict",
+            ]
+        )
+        # Malformed report is silently treated as missing -> board PASS.
+        assert result == 0
+        data = json.loads(capsys.readouterr().out)
+        board = data["boards"][0]
+        assert board["passed"] is True
+        assert board["erc"]["report_exists"] is False
+
+
+class TestShipReadyDRCAggregation:
+    """Verify DRC tolerance is honored alongside ERC + manufacturing."""
+
+    def test_drc_over_tolerance_blocks_with_zero_default(self, tmp_path: Path, capsys):
+        """DRC errors > 0 with no allowlist entry -> blocker."""
+        boards = tmp_path / "boards"
+        routed = make_fake_board(
+            boards,
+            "drc-board",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        _write_drc_report(boards / "drc-board", routed.name, errors=2)
+
+        # Use a non-existent tolerance file so default is 0.
+        result = main(
+            [
+                "ship-ready",
+                "--boards-dir",
+                str(boards),
+                "--format",
+                "json",
+                "--strict",
+                "--drc-tolerance-file",
+                str(tmp_path / "does-not-exist.yml"),
+            ]
+        )
+        assert result == 2
+        data = json.loads(capsys.readouterr().out)
+        board = data["boards"][0]
+        assert board["passed"] is False
+        assert any("DRC errors" in b for b in board["blockers"])
+
+    def test_drc_under_tolerance_does_not_block(self, tmp_path: Path, capsys):
+        """DRC errors within an allowlist tolerance -> board PASS."""
+        boards = tmp_path / "boards"
+        routed = make_fake_board(
+            boards,
+            "tolerated-board",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        _write_drc_report(boards / "tolerated-board", routed.name, errors=2)
+
+        # Allowlist that permits up to 5 errors for this board.
+        tolerance_file = tmp_path / "tol.yml"
+        tolerance_file.write_text(f"tolerances:\n  {routed.relative_to(tmp_path).as_posix()}: 5\n")
+
+        # Re-route the board under the tmp_path-relative key by chdir.
+        cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            result = main(
+                [
+                    "ship-ready",
+                    "--boards-dir",
+                    str(boards.relative_to(tmp_path)),
+                    "--format",
+                    "json",
+                    "--strict",
+                    "--drc-tolerance-file",
+                    str(tolerance_file.relative_to(tmp_path)),
+                ]
+            )
+        finally:
+            os.chdir(cwd)
+
+        assert result == 0
+        data = json.loads(capsys.readouterr().out)
+        board = data["boards"][0]
+        assert board["passed"] is True
+
+
+class TestShipReadyTableOutput:
+    """Verify the table format is human-readable for nightly summaries."""
+
+    def test_table_lists_pass_and_fail(self, tmp_path: Path, capsys):
+        boards = tmp_path / "boards"
+        make_fake_board(
+            boards,
+            "good-board",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        make_fake_board(boards, "bad-board", routed_complete=False)
+
+        result = main(
+            [
+                "ship-ready",
+                "--boards-dir",
+                str(boards),
+                "--format",
+                "table",
+            ]
+        )
+        assert result == 0  # warn-only default
+        out = capsys.readouterr().out
+        assert "good-board" in out
+        assert "bad-board" in out
+        assert "PASS" in out
+        assert "FAIL" in out
+        # Footer mode marker.
+        assert "warn-only mode" in out
+        # GitHub Actions warning annotation surfaces failure count.
+        assert "::warning::ship-ready" in out
+
+    def test_table_no_boards_message(self, tmp_path: Path, capsys):
+        boards = tmp_path / "boards"
+        boards.mkdir()
+        result = main(
+            [
+                "ship-ready",
+                "--boards-dir",
+                str(boards),
+                "--format",
+                "table",
+            ]
+        )
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "No boards found" in out
+
+
+class TestShipReadyDispatcher:
+    """Verify the ``kct fleet ship-ready`` dispatcher forwards all args."""
+
+    def test_dispatcher_forwards_strict(self, tmp_path: Path, capsys):
+        """``run_fleet_command`` re-serializes args correctly for ship-ready."""
+        from argparse import Namespace
+
+        from kicad_tools.cli.commands.fleet import run_fleet_command
+
+        boards = tmp_path / "boards"
+        make_fake_board(boards, "x", routed_complete=False)
+
+        args = Namespace(
+            fleet_command="ship-ready",
+            fleet_ship_boards_dir=str(boards),
+            fleet_ship_format="json",
+            fleet_ship_pattern="*_routed.kicad_pcb",
+            fleet_ship_drc_tolerance_file=str(tmp_path / "nope.yml"),
+            fleet_ship_strict=True,
+        )
+        result = run_fleet_command(args)
+        # The board has incomplete routing -> strict exit 2.
+        assert result == 2
+
+    def test_dispatcher_default_warn_only(self, tmp_path: Path, capsys):
+        from argparse import Namespace
+
+        from kicad_tools.cli.commands.fleet import run_fleet_command
+
+        boards = tmp_path / "boards"
+        make_fake_board(boards, "x", routed_complete=False)
+
+        args = Namespace(
+            fleet_command="ship-ready",
+            fleet_ship_boards_dir=str(boards),
+            fleet_ship_format="json",
+            fleet_ship_pattern="*_routed.kicad_pcb",
+            fleet_ship_drc_tolerance_file=str(tmp_path / "nope.yml"),
+            fleet_ship_strict=False,
+        )
+        result = run_fleet_command(args)
+        # Warn-only -> exit 0 despite the FAIL board.
+        assert result == 0


### PR DESCRIPTION
Closes #3099

## Summary

Adds the `kct fleet ship-ready` per-board PASS/FAIL aggregate command and a nightly GitHub Action that runs it across all PCB-bearing boards in warn-only mode (per the steering decision of 2026-05-21).

- `kct fleet ship-ready` reuses the existing fleet surveyor machinery (`_discover_boards`, `_compute_routing`, `_detect_drc`, manifest staleness) and adds a symmetric `ERCStatus` detector that reads `erc_report.json` in either the `ERCReport.to_dict()` summary shape or KiCad's native `sheets[].violations[].severity` shape.
- Default exit code is 0 even when boards FAIL (warn-only), keeping the gate non-blocking. `--strict` opts into exit 2 on failure for human use.
- New workflow `.github/workflows/nightly-ship-ready.yml` runs at 06:00 UTC daily, uploads per-board manufacturing bundles + JSON survey artifacts (30-day retention), and surfaces results via a job summary. Belt-and-braces: `continue-on-error: true` on the command step AND a final `exit 0` step so the workflow can never be wired up as a required check by accident.

On the current `main` checkout the command produces this signal (run from the worktree):

```
Board                          Route   DRC   ERC Mfr      Stale  Verdict
------------------------------------------------------------------------
01-voltage-divider               8/8     -     - B/C/G/M  STALE  FAIL (artifacts stale)
02-charlieplex-led             34/34     -     - B/C/G/M  fresh  PASS
03-usb-joystick                70/71     -     - -        -      FAIL (incomplete routing (1/16 nets))
04-stm32-devboard              54/55     -     - B/C/G/M  STALE  FAIL (incomplete routing (1/12 nets))
05-bldc-motor-controller     126/206     -     - -        -      FAIL (incomplete routing (26/40 nets))
06-diffpair-test              74/198     -     - B/C/G/M  fresh  FAIL (incomplete routing (4/26 nets))
07-matchgroup-test            81/244     -     - B/C/G/M  STALE  FAIL (incomplete routing (7/34 nets))

7 boards surveyed, 1 PASS, 6 FAIL (warn-only mode)
::warning::ship-ready: 6/7 board(s) FAIL (warn-only mode -- exit 0)
```

This matches the AC's "per-board PASS/FAIL summary visible in action output" and exits 0 so it cannot block PRs.

## Test plan

- [x] `uv run pytest tests/test_fleet_ship_ready.py` -- 17 new tests pass
- [x] `uv run pytest tests/test_fleet_status.py tests/test_fleet_status_drc.py` -- 22 existing tests still pass
- [x] `uv run ruff check` and `uv run ruff format --check` on touched files clean
- [x] `uv run kct fleet ship-ready --help` shows usage
- [x] `uv run kct fleet ship-ready --boards-dir boards` exits 0 (warn-only) and FAILs with exit 2 under `--strict` on the current `boards/` directory
- [x] `yaml.safe_load(open('.github/workflows/nightly-ship-ready.yml'))` parses cleanly
- [ ] CI: `Nightly Ship-Ready Gate` job runs on `workflow_dispatch` and uploads the artifact bundle (deferred until merge -- the workflow is schedule + workflow_dispatch only, not PR-triggered, by design)

## Notes

- Issue body called out "Blocked by: M-A, M-B, M-C (at minimum)" but M-A (#3092) and M-B (#3093) have merged and the curator-supplied implementation checklist explicitly notes the scaffolding can land independently of the dependencies (the dependencies affect signal quality, not implementation feasibility). The board-02 PASS in the output above confirms the gate already produces useful signal on the boards that have shipped.
- `tolerances:` in `.github/routed-drc-tolerance.yml` is honored unchanged -- board 03/05/06/07 grandfathered DRC counts will not produce DRC blockers even when their `drc_report.json` lands.
- The 1 pre-existing failure in `tests/test_cli_parser_drift.py` (`route_cmd.py` "badly formed help string" under Python 3.14) is unrelated to this change and reproduces on `origin/main` without my edits.