### PR TITLE
feat(cli): surface --use-routing-fitness + --boundary-margin (partial #3111)

### DIFF
--- a/src/kicad_tools/cli/commands/placement.py
+++ b/src/kicad_tools/cli/commands/placement.py
@@ -101,8 +101,12 @@ def run_placement_command(args) -> int:
             sub_argv.append("--auto-keepout")
         if getattr(args, "routing_aware", False):
             sub_argv.append("--routing-aware")
+        if getattr(args, "use_routing_fitness", False):
+            sub_argv.append("--use-routing-fitness")
         if getattr(args, "check_routability", False):
             sub_argv.append("--check-routability")
+        if getattr(args, "boundary_margin", None) is not None:
+            sub_argv.extend(["--boundary-margin", str(args.boundary_margin)])
         if args.dry_run:
             sub_argv.append("--dry-run")
         if getattr(args, "format", "text") != "text":

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3632,10 +3632,29 @@ def _add_placement_parser(subparsers) -> None:
         help="Use integrated place-route optimization (iterates between placement and routing)",
     )
     placement_optimize.add_argument(
+        "--use-routing-fitness",
+        action="store_true",
+        dest="use_routing_fitness",
+        help=(
+            "(Issue #2720) Replace the evolutionary GA's average-pairwise-spacing "
+            "routability proxy with actual routing completion rate from the C++ A* "
+            "router (CppAstarRoutingEvaluator). Only effective with --strategy "
+            "evolutionary or hybrid. Default off."
+        ),
+    )
+    placement_optimize.add_argument(
         "--check-routability",
         action="store_true",
         dest="check_routability",
         help="Check routability before and after optimization to show impact",
+    )
+    placement_optimize.add_argument(
+        "--boundary-margin",
+        "--board-margin",
+        type=float,
+        default=None,
+        dest="boundary_margin",
+        help="Extra margin in mm between component courtyards and board edge (default: 1.0)",
     )
     placement_optimize.add_argument("--dry-run", action="store_true", help="Preview only")
     placement_optimize.add_argument(

--- a/tests/test_cli_placement_routing_aware.py
+++ b/tests/test_cli_placement_routing_aware.py
@@ -551,3 +551,261 @@ class TestFixedRefsPositionInvariance:
 
         # Should not error out due to missing fixed_refs handling.
         assert rc in (0, 1)
+
+
+# =============================================================================
+# --use-routing-fitness and --boundary-margin plumbing (issue #3111)
+# =============================================================================
+
+
+class TestUseRoutingFitnessFlag:
+    """Tests for the ``--use-routing-fitness`` flag wiring (issue #3111).
+
+    The underlying lever exists in
+    :class:`~kicad_tools.optim.evolutionary.EvolutionaryConfig`
+    (added by issue #2720) and was exposed in
+    :mod:`kicad_tools.cli.placement_cmd` directly. This issue surfaces it
+    on the main unified CLI parser so callers using
+    ``kct placement optimize`` (the supported user-facing entry point)
+    can engage the C++ A* routing-completion fitness function.
+    """
+
+    def test_flag_present_in_unified_parser(self):
+        """``--use-routing-fitness`` parses successfully on main parser."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(
+            [
+                "placement",
+                "optimize",
+                "test.kicad_pcb",
+                "--use-routing-fitness",
+            ]
+        )
+
+        assert hasattr(args, "use_routing_fitness")
+        assert args.use_routing_fitness is True
+
+    def test_flag_default_off(self):
+        """``--use-routing-fitness`` defaults to False (opt-in)."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(
+            [
+                "placement",
+                "optimize",
+                "test.kicad_pcb",
+            ]
+        )
+
+        assert hasattr(args, "use_routing_fitness")
+        assert args.use_routing_fitness is False
+
+    def test_flag_forwarded_to_placement_cmd(self, tmp_path: Path):
+        """``--use-routing-fitness`` is forwarded to placement_cmd."""
+        from unittest.mock import patch
+
+        from kicad_tools.cli.commands.placement import run_placement_command
+
+        class MockArgs:
+            placement_command = "optimize"
+            pcb = str(tmp_path / "test.kicad_pcb")
+            output = None
+            strategy = "evolutionary"
+            iterations = 10
+            generations = 5
+            population = 10
+            grid = 0.0
+            fixed = None
+            cluster = False
+            constraints = None
+            edge_detect = False
+            thermal = False
+            keepout = None
+            auto_keepout = False
+            routing_aware = False
+            use_routing_fitness = True  # Key flag being tested
+            check_routability = False
+            boundary_margin = None
+            dry_run = True
+            format = "text"
+            verbose = False
+            quiet = True
+            global_quiet = False
+
+        called_with: list[str] = []
+
+        def mock_main(argv):
+            called_with.extend(argv)
+            return 0
+
+        with patch("kicad_tools.cli.placement_cmd.main", mock_main):
+            run_placement_command(MockArgs())
+
+        assert "--use-routing-fitness" in called_with
+        # Strategy must also be forwarded so the GA path activates.
+        assert "evolutionary" in called_with
+
+    def test_flag_with_strategy_evolutionary(self):
+        """``--use-routing-fitness`` composes with ``--strategy evolutionary``."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(
+            [
+                "placement",
+                "optimize",
+                "test.kicad_pcb",
+                "--strategy",
+                "evolutionary",
+                "--use-routing-fitness",
+            ]
+        )
+
+        assert args.strategy == "evolutionary"
+        assert args.use_routing_fitness is True
+
+
+class TestBoundaryMarginFlag:
+    """Tests for the ``--boundary-margin`` flag wiring (issue #3111)."""
+
+    def test_flag_present_in_unified_parser(self):
+        """``--boundary-margin`` parses on main parser."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(
+            [
+                "placement",
+                "optimize",
+                "test.kicad_pcb",
+                "--boundary-margin",
+                "2.5",
+            ]
+        )
+
+        assert hasattr(args, "boundary_margin")
+        assert args.boundary_margin == pytest.approx(2.5)
+
+    def test_board_margin_alias_present(self):
+        """``--board-margin`` is an accepted alias of ``--boundary-margin``."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(
+            [
+                "placement",
+                "optimize",
+                "test.kicad_pcb",
+                "--board-margin",
+                "3.0",
+            ]
+        )
+
+        assert args.boundary_margin == pytest.approx(3.0)
+
+    def test_flag_default_none(self):
+        """``--boundary-margin`` defaults to None (use placement_cmd default)."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(
+            [
+                "placement",
+                "optimize",
+                "test.kicad_pcb",
+            ]
+        )
+
+        assert args.boundary_margin is None
+
+    def test_flag_forwarded_to_placement_cmd(self, tmp_path: Path):
+        """``--boundary-margin`` value is forwarded to placement_cmd."""
+        from unittest.mock import patch
+
+        from kicad_tools.cli.commands.placement import run_placement_command
+
+        class MockArgs:
+            placement_command = "optimize"
+            pcb = str(tmp_path / "test.kicad_pcb")
+            output = None
+            strategy = "force-directed"
+            iterations = 10
+            generations = 5
+            population = 10
+            grid = 0.0
+            fixed = None
+            cluster = False
+            constraints = None
+            edge_detect = False
+            thermal = False
+            keepout = None
+            auto_keepout = False
+            routing_aware = False
+            use_routing_fitness = False
+            check_routability = False
+            boundary_margin = 1.5  # Key field
+            dry_run = True
+            format = "text"
+            verbose = False
+            quiet = True
+            global_quiet = False
+
+        called_with: list[str] = []
+
+        def mock_main(argv):
+            called_with.extend(argv)
+            return 0
+
+        with patch("kicad_tools.cli.placement_cmd.main", mock_main):
+            run_placement_command(MockArgs())
+
+        assert "--boundary-margin" in called_with
+        # Value must follow the flag in argv.
+        idx = called_with.index("--boundary-margin")
+        assert called_with[idx + 1] == "1.5"
+
+    def test_no_forwarding_when_default(self, tmp_path: Path):
+        """When ``boundary_margin`` is None, no ``--boundary-margin`` flag is forwarded."""
+        from unittest.mock import patch
+
+        from kicad_tools.cli.commands.placement import run_placement_command
+
+        class MockArgs:
+            placement_command = "optimize"
+            pcb = str(tmp_path / "test.kicad_pcb")
+            output = None
+            strategy = "force-directed"
+            iterations = 10
+            generations = 5
+            population = 10
+            grid = 0.0
+            fixed = None
+            cluster = False
+            constraints = None
+            edge_detect = False
+            thermal = False
+            keepout = None
+            auto_keepout = False
+            routing_aware = False
+            use_routing_fitness = False
+            check_routability = False
+            boundary_margin = None  # Default sentinel
+            dry_run = True
+            format = "text"
+            verbose = False
+            quiet = True
+            global_quiet = False
+
+        called_with: list[str] = []
+
+        def mock_main(argv):
+            called_with.extend(argv)
+            return 0
+
+        with patch("kicad_tools.cli.placement_cmd.main", mock_main):
+            run_placement_command(MockArgs())
+
+        assert "--boundary-margin" not in called_with


### PR DESCRIPTION
## Summary

Surfaces two placement-optimize levers on the main user-facing CLI parser (`kct placement optimize`):

- **`--use-routing-fitness`** (Issue #2720): replaces the evolutionary GA's average-pairwise-spacing routability proxy with the C++ A* router's actual routing completion rate (`CppAstarRoutingEvaluator`). Only effective with `--strategy evolutionary` or `hybrid`.
- **`--boundary-margin`** / **`--board-margin`** (alias): per-component-courtyard-to-board-edge margin in mm.

Both flags were already implemented in `src/kicad_tools/cli/placement_cmd.py` but had not been wired through the main parser (`cli/parser.py`) and forwarding shim (`cli/commands/placement.py`). The wiring gap was called out explicitly in issue #3111 and PR #3108's curator notes as the recommended first sub-step.

## Scope (partial deliverable for #3111)

#3111 has three remaining ACs from the M-E (board-05) workstream:

| AC | Status in this PR |
|---|---|
| CLI lever surfaced (`--use-routing-fitness` on main parser) | DONE |
| Routing reach >=30/40 on board 05 | NOT addressed (see below) |
| DRC errors <=5 on board 05 | NOT addressed (see below) |

The routing-reach + DRC ACs require rebuilding board 05 with the new placement recipe, which touches `boards/05-bldc-motor-controller/design.py` and the regenerated PCB/manufacturing outputs.  **PR #3108 (in review) already modifies those exact files** (ERC + PWR_FLAG fixes + timeout extension) and re-running the board pipeline on this branch would conflict at merge time and obscure the smaller schematic-level diff #3108 needs reviewed.

The board-05 reflow should follow as a separate PR after #3108 merges. The recipe (recommended in the issue body) is:

```bash
uv run kct placement optimize boards/05-bldc-motor-controller/output/bldc_controller.kicad_pcb \
    --strategy evolutionary --use-routing-fitness \
    --generations 50 --population 16 \
    --boundary-margin 1.0 \
    --check-routability

# then re-route via kct route ... --backend python
```

This PR delivers the lever that the follow-up needs without touching files in flight on PR #3108.

## Test plan

- [x] `uv run pytest tests/test_cli_placement_routing_aware.py tests/test_routing_fitness.py tests/test_evolutionary_optimizer.py` -- 81 passed (9 new tests for parser registration + forwarding-shim drift coverage)
- [x] `uv run ruff check src/kicad_tools/cli/commands/placement.py src/kicad_tools/cli/parser.py` -- clean
- [x] `uv run ruff format --check` on changed files -- clean
- [x] `uv run kct placement optimize --help` shows `--use-routing-fitness` and `--boundary-margin` / `--board-margin`
- [x] End-to-end smoke: board 05's unrouted PCB with `--strategy evolutionary --use-routing-fitness --generations 10 --population 8` completed with exit code 0 (lever reaches the C++ A* routing-completion fitness path)

Note on pre-existing CI state: `tests/test_cli_parser_drift.py` has 7 pre-existing failures on `main` (Python 3.14 argparse strict help-string validation in `route_cmd.py:5371`, unrelated to placement). Confirmed by reverting this PR's changes and re-running -- same failures.

Partial: #3111
Refs: #3108, #2720, #3096, #2394

🤖 Generated with [Claude Code](https://claude.com/claude-code)