### PR TITLE
feat(router): lex-tuple primary key = nets_fully_connected (closes #3117)

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -184,17 +184,31 @@ class IterationMetrics:
 
     Lex order (used by :meth:`is_better_than`):
 
-    1. ``routed_count`` descending — more routed nets is always better.
-    2. ``clearance_violations`` ascending — Issue #3002 (PR #3006
+    1. ``nets_fully_connected`` descending — Issue #3117: the canonical
+       "did the router actually wire up the design" signal.  More nets
+       whose pads are all electrically joined is unconditionally
+       better than a state where the per-net A* dropped fragments but
+       failed to close every pad-to-pad path.  Promoted ABOVE
+       ``routed_count`` because that older field counts nets with ANY
+       route fragment and so cannot distinguish a 4-pad net at 2/4
+       connected from the same net at 4/4 connected (the softstart
+       failure mode for board #3085: iter-0 logged 9/10 ``routed_count``
+       but only 4/10 ``nets_fully_connected``).
+    2. ``routed_count`` descending — kept as the tertiary "incremental
+       progress" signal: with equal fully-connected counts, a state
+       that has more nets with at least some fragment is preferred so
+       the loop still rewards partial progress that the next iteration
+       may finish.
+    3. ``clearance_violations`` ascending — Issue #3002 (PR #3006
        follow-up): a re-route that fixes a segment-vs-foreign-via
        clearance violation without reducing overflow must NOT be rolled
        back to the prior state.  Promoted ABOVE overflow because a
        DRC-clean board with marginally higher overflow is strictly
        preferable to a DRC-dirty board with lower overflow.
-    3. ``overflow`` ascending — with equal route counts and equal
+    4. ``overflow`` ascending — with equal route counts and equal
        clearance violations, lower overflow is better (the Issue #2803
        dimension).
-    4. ``iteration`` descending — on a complete tie, prefer the later
+    5. ``iteration`` descending — on a complete tie, prefer the later
        iteration so perturbation/escape strategies have a chance to bake
        in.
 
@@ -206,21 +220,31 @@ class IterationMetrics:
             clearance violations at iter end (Issue #3002; lower is
             better).  Defaults to 0 for back-compat with existing call
             sites that don't compute the count.
+        nets_fully_connected: Count of nets whose pads are all in a
+            single connected component per
+            :func:`observability.validate_net_connectivity` (Issue
+            #3117; higher is better).  Defaults to 0 for back-compat
+            with existing call sites and tests that don't compute the
+            value -- on a default-zeroed tuple the older
+            ``routed_count``-then-overflow ordering still applies, so
+            existing comparator tests continue to pass.
     """
 
     iteration: int
     routed_count: int
     overflow: int
     clearance_violations: int = 0
+    nets_fully_connected: int = 0
 
     @property
-    def sort_key(self) -> tuple[int, int, int, int]:
+    def sort_key(self) -> tuple[int, int, int, int, int]:
         """Tuple suitable for ``min()`` / sort key.
 
         Negated where descending is desired so the *smallest* tuple is the
         *best* iteration.
         """
         return (
+            -self.nets_fully_connected,
             -self.routed_count,
             self.clearance_violations,
             self.overflow,
@@ -6547,11 +6571,47 @@ class Autorouter:
             extra_routes=_extra_init,
         )
         initial_violations = len(initial_seg_via) + len(initial_via_seg)
+
+        # Issue #3117: compute ``nets_fully_connected`` for the lex tuple.
+        # ``validate_net_connectivity`` is already called once per
+        # iteration inside ``_get_partially_routed_nets`` (line ~6917) so
+        # adding a second call per iteration end and one per top-of-iter
+        # snapshot is the budget for this feature; the cost is amortized
+        # against the partial-route detector that the rip-up loop
+        # already requires.
+        from .observability import validate_net_connectivity as _validate_conn
+
+        def _compute_nets_fully_connected() -> int:
+            """Return the count of nets in ``net_routes`` whose pads
+            are all in one connected component.
+
+            Reads the live closure ``net_routes`` / ``pads_by_net`` so
+            the caller does not need to re-thread the dicts.  Mirrors the
+            net-pads filtering used by ``_get_partially_routed_nets``:
+            only nets with at least 2 pads are eligible (single-pad
+            nets are trivially connected but excluded so the count is
+            comparable to ``routed_count``).
+            """
+            net_pads: dict[int, list[Pad]] = {}
+            for net_id in net_routes:
+                pads = pads_by_net.get(net_id)
+                if pads and len(pads) >= 2:
+                    net_pads[net_id] = pads
+            if not net_pads:
+                return 0
+            all_routes: list[Route] = []
+            for routes_list_local in net_routes.values():
+                all_routes.extend(routes_list_local)
+            conn = _validate_conn(all_routes, net_pads)
+            return sum(1 for info in conn.values() if info.get("connected"))
+
+        initial_connected = _compute_nets_fully_connected()
         best_metrics = IterationMetrics(
             iteration=0,
             routed_count=best_routed_count,
             overflow=overflow,
             clearance_violations=initial_violations,
+            nets_fully_connected=initial_connected,
         )
 
         # Issue #2803: Lightweight trajectory log (three ints per iteration,
@@ -6605,11 +6665,19 @@ class Autorouter:
                 extra_routes=_extra_post,
             )
             violations_now = len(post_seg_via) + len(post_via_seg)
+            # Issue #3117: compute ``nets_fully_connected`` so the lex
+            # tuple primary key can reward iterations that closed more
+            # pad-to-pad paths (not just iterations that produced more
+            # route fragments).  Same cost as the
+            # ``_get_partially_routed_nets`` walk that the rip-up loop
+            # already requires.
+            connected_now = _compute_nets_fully_connected()
             metrics = IterationMetrics(
                 iteration=iter_index,
                 routed_count=routed_now,
                 overflow=overflow_val,
                 clearance_violations=violations_now,
+                nets_fully_connected=connected_now,
             )
             iteration_trajectory.append(metrics)
 
@@ -6652,15 +6720,24 @@ class Autorouter:
             if improved:
                 suffix = " (new best)"
             else:
+                # Issue #3117: include ``connected`` in the best-so-far
+                # suffix so operators can see whether the running best
+                # actually closed pad-to-pad paths or just produced
+                # fragments.
                 suffix = (
                     f" | best-so-far=iter-{best_metrics.iteration} "
-                    f"(routed={best_metrics.routed_count}, "
+                    f"(connected={best_metrics.nets_fully_connected}, "
+                    f"routed={best_metrics.routed_count}, "
                     f"clearance_viol={best_metrics.clearance_violations}, "
                     f"overflow={best_metrics.overflow}) "
                     f"| stall={best_stall_count}"
                 )
+            # Issue #3117: surface ``connected`` ahead of ``routed`` in
+            # the canonical per-iter line so the new lex-tuple primary
+            # key is visible at runtime.
             flush_print(
-                f"  iter {iter_index} | routed={routed_now}/{total_nets} | "
+                f"  iter {iter_index} | connected={connected_now}/{total_nets} | "
+                f"routed={routed_now}/{total_nets} | "
                 f"clearance_viol={violations_now} | "
                 f"overflow={overflow_val}{suffix}"
             )
@@ -6709,11 +6786,18 @@ class Autorouter:
                     extra_routes=_extra_top,
                 )
                 current_violations = len(current_seg_via) + len(current_via_seg)
+                # Issue #3117: mirror the lex-tuple primary key at the
+                # top-of-iteration snapshot site so a prior iteration's
+                # end-state can still be promoted to "best" when it had
+                # more fully-connected nets than what
+                # ``_capture_iteration_end`` last recorded.
+                current_connected = _compute_nets_fully_connected()
                 current_metrics = IterationMetrics(
                     iteration=iteration - 1,  # captured state is end of prior iter
                     routed_count=current_routed,
                     overflow=overflow,
                     clearance_violations=current_violations,
+                    nets_fully_connected=current_connected,
                 )
                 if current_metrics.is_better_than(best_metrics):
                     best_metrics = current_metrics
@@ -8101,19 +8185,28 @@ class Autorouter:
             extra_routes=_extra_final,
         )
         final_violations = len(final_seg_via) + len(final_via_seg)
+        # Issue #3117: include ``nets_fully_connected`` in the final
+        # lex-tuple comparator so the post-loop restore preserves a
+        # best snapshot whose pad-to-pad paths are more thoroughly
+        # closed -- even when the live final state has marginally
+        # higher ``routed_count``.
+        final_connected = _compute_nets_fully_connected()
         final_metrics = IterationMetrics(
             iteration=iteration_trajectory[-1].iteration if iteration_trajectory else 0,
             routed_count=current_routed,
             overflow=overflow,
             clearance_violations=final_violations,
+            nets_fully_connected=final_connected,
         )
         if best_metrics.is_better_than(final_metrics):
             flush_print(
                 f"  Restoring iteration {best_iteration} state "
-                f"(routed={best_metrics.routed_count}, "
+                f"(connected={best_metrics.nets_fully_connected}, "
+                f"routed={best_metrics.routed_count}, "
                 f"clearance_viol={best_metrics.clearance_violations}, "
                 f"overflow={best_metrics.overflow}) instead of final "
-                f"(routed={final_metrics.routed_count}, "
+                f"(connected={final_metrics.nets_fully_connected}, "
+                f"routed={final_metrics.routed_count}, "
                 f"clearance_viol={final_metrics.clearance_violations}, "
                 f"overflow={final_metrics.overflow})"
             )

--- a/tests/test_best_metric_patience.py
+++ b/tests/test_best_metric_patience.py
@@ -278,6 +278,130 @@ class TestPatienceLogLine:
             )
 
 
+class TestNetsFullyConnectedLexKey:
+    """Issue #3117: the lex-tuple primary key must be
+    ``nets_fully_connected``, not ``routed_count``.
+
+    Background:
+        ``routed_count`` only checks whether each net has any route
+        fragment.  A 4-pad net with one fragment connecting 2/4 pads
+        contributes 1 to ``routed_count`` even though the design is not
+        electrically connected.  Softstart (board #3085) hit this
+        exactly: iter-0 logged ``routed_count = 9/10`` but
+        ``validate_net_connectivity`` reported ``4/10`` -- the lex
+        comparator preserved the 4/10 floor because the metric it
+        optimized couldn't distinguish fragments from connections.
+
+    These tests pin the new ordering behaviour so a careless refactor
+    cannot re-elevate ``routed_count`` above ``nets_fully_connected``.
+    """
+
+    def test_nets_fully_connected_dominates_routed_count(self):
+        """State A connects more pads than state B; even though B has
+        more route fragments, A must win the comparator.
+
+        Concrete numbers from the issue: softstart iter-0 had
+        ``routed_count=9, nets_fully_connected=4``.  A hypothetical
+        re-route that produced ``routed_count=8, nets_fully_connected=8``
+        is unambiguously better -- it closed more pad-to-pad paths
+        even though one fragment was dropped.
+        """
+        a = IterationMetrics(
+            iteration=1,
+            routed_count=8,
+            overflow=10,
+            clearance_violations=0,
+            nets_fully_connected=8,
+        )
+        b = IterationMetrics(
+            iteration=2,
+            routed_count=9,
+            overflow=10,
+            clearance_violations=0,
+            nets_fully_connected=4,
+        )
+        # A has fewer fragments but more closed nets -- must win.
+        assert a.is_better_than(b)
+        assert not b.is_better_than(a)
+
+    def test_default_zero_preserves_routed_count_ordering(self):
+        """When ``nets_fully_connected`` defaults to 0 on both sides
+        (i.e. older call sites that haven't been updated), the
+        comparator must fall through to the legacy ordering
+        (``routed_count`` desc, then ``clearance_violations``, etc.).
+
+        Back-compat guarantee for Issue #3117: existing tests in
+        ``TestPatienceComparatorBehavior`` above construct
+        ``IterationMetrics`` without ``nets_fully_connected`` and rely
+        on the old ordering.  This test pins the property explicitly
+        so it can't drift.
+        """
+        # Both default-zero; ordering should mirror legacy
+        # routed-count-then-overflow.
+        more_routed = IterationMetrics(
+            iteration=1, routed_count=10, overflow=10,
+        )
+        fewer_routed = IterationMetrics(
+            iteration=2, routed_count=8, overflow=5,
+        )
+        # Old behaviour: routed_count dominates overflow.
+        assert more_routed.is_better_than(fewer_routed)
+        assert not fewer_routed.is_better_than(more_routed)
+
+        # And the explicit-zero form is identical to the default form.
+        more_routed_explicit = IterationMetrics(
+            iteration=1, routed_count=10, overflow=10,
+            nets_fully_connected=0,
+        )
+        assert more_routed.sort_key == more_routed_explicit.sort_key
+
+    def test_fragment_only_net_loses_to_smaller_fully_connected(self):
+        """End-to-end style: a state with N nets that each have one
+        fragment but only N-1 fully connected loses to a state with
+        N-1 nets where all N-1 are fully connected.
+
+        This is the inverse direction of
+        ``test_nets_fully_connected_dominates_routed_count``: it
+        verifies the comparator treats ``routed_count`` as a tertiary
+        signal that cannot override ``nets_fully_connected`` even
+        when the two states differ by a single fragment.
+        """
+        # State with N fragments but one is incomplete (N-1 connected)
+        fragment_state = IterationMetrics(
+            iteration=5,
+            routed_count=10,
+            overflow=20,
+            clearance_violations=0,
+            nets_fully_connected=9,
+        )
+        # State with N-1 fragments, all fully connected (N-1 connected)
+        smaller_connected_state = IterationMetrics(
+            iteration=6,
+            routed_count=9,
+            overflow=20,
+            clearance_violations=0,
+            nets_fully_connected=9,
+        )
+        # Equal ``nets_fully_connected`` -> tertiary key
+        # (``routed_count``) breaks the tie in favour of the fragment
+        # state.  This is the "incremental progress" signal described
+        # in the docstring: a fragment-only iteration that did not
+        # lose any pad-connectivity is still preferred to a fully-
+        # connected-only iteration that lost a fragment.
+        assert fragment_state.is_better_than(smaller_connected_state)
+
+        # But if the smaller-fragment state strictly improves
+        # ``nets_fully_connected``, IT wins regardless of routed_count.
+        better_connected_state = IterationMetrics(
+            iteration=6,
+            routed_count=9,
+            overflow=20,
+            clearance_violations=0,
+            nets_fully_connected=10,
+        )
+        assert better_connected_state.is_better_than(fragment_state)
+
+
 class TestCLIFlagWiredThrough:
     """The ``--early-stop-patience`` flag must exist on both the outer
     ``parser.py`` route subparser and the inner ``route_cmd.py`` parser


### PR DESCRIPTION
## Summary

- Promote ``nets_fully_connected`` above ``routed_count`` in the ``IterationMetrics`` lex tuple so the best-state snapshot machinery rewards iterations that close pad-to-pad paths, not iterations that merely produce route fragments.
- Compute the new field via ``validate_net_connectivity`` at the four sites that construct ``IterationMetrics`` (initial, ``_capture_iteration_end``, top-of-iteration snapshot, post-loop restore comparator).
- Surface ``connected=N/T`` in the canonical per-iter log line and in the best-so-far / restore log lines so the new primary key is visible at runtime.

## Background

``routed_count`` counts a net as "routed" if it has *any* segment. A 4-pad net with a fragment connecting only 2/4 pads contributes 1 to ``routed_count`` even though the design is not electrically connected. On softstart (board #3085), iter-0 logged ``routed_count = 9/10`` but ``validate_net_connectivity`` reported ``4/10`` -- and the lex comparator preserved the 4/10 floor because the metric it optimized could not distinguish fragments from connections.

## Empirical verification on softstart

The new log shows:

```
--- Iteration 0: Initial routing with sharing ---
  Routed 9/10 nets, overflow: 15 (80.3s)

--- Iteration 1: Rip-up and reroute ---
  iter 1 | connected=3/10 | routed=9/10 | clearance_viol=0 | overflow=21 | best-so-far=iter-0 (connected=4, routed=9, clearance_viol=0, overflow=15) | stall=1

--- Iteration 2: Rip-up and reroute ---
  iter 2 | connected=4/10 | routed=9/10 | clearance_viol=0 | overflow=16 | best-so-far=iter-0 (connected=4, routed=9, clearance_viol=0, overflow=15) | stall=2
  Best-metric early-stop: no improvement to (routed=9, clearance_viol=0, overflow=15) for 2 consecutive iter(s); patience=2

  Restoring iteration 0 state (connected=4, routed=9, clearance_viol=0, overflow=15) instead of final (connected=4, routed=9, clearance_viol=0, overflow=16)
```

The comparator correctly identifies the iter-1 regression (3 connected vs iter-0's 4) and the post-loop restore picks iter-0.

## AC #4 result

Softstart still blocks at 4/10 connected with the new metric. This is the expected "valid result" outcome the issue body called out:

> AC #4 may be satisfied by re-confirming the board still blocks at 4/10 even with the new metric -- that would be a valid result (and would suggest the root cause is in placement, not negotiation).

The metric fix is the foundation; pushing softstart above 4/10 is a separate (placement / clearance / via-in-pad on U1-13 GATE_POS) issue.

## Back-compat

``nets_fully_connected`` defaults to 0, so existing call sites and tests that construct ``IterationMetrics`` without the new field fall through to the legacy ``routed_count``-then-overflow ordering.

## Test plan

- [x] 3 new tests in ``tests/test_best_metric_patience.py`` under ``TestNetsFullyConnectedLexKey``: primary-key dominance, default-zero back-compat, tertiary-key tiebreak.
- [x] 13 existing tests in the same file continue to pass.
- [x] 43 IterationMetrics-touching tests in ``test_main_router_segment_via_clearance.py``, ``test_main_router_via_segment_clearance.py``, ``test_checkpoint_in_escalation.py`` continue to pass.
- [x] 173 tests in ``tests/router/`` continue to pass.
- [x] Softstart empirical run completes with iter-0 correctly preserved at the 4/10 floor.
- [x] Board 01 (1.2s routing) and Board 02 (5.7s routing) show no regression in latency.

Closes #3117