### PR TITLE
test(cpp): skip chronic pre-existing C++ test failures

### DIFF
--- a/tests/test_cpp_clearance_enforcement.py
+++ b/tests/test_cpp_clearance_enforcement.py
@@ -62,6 +62,17 @@ class TestGap1UnblockedCellClearance:
     adjacent net's obstacle.
     """
 
+    @pytest.mark.skip(
+        reason=(
+            "Real C++ pathfinder bug (not a stale fixture): the C++ A* "
+            "emits a segment at 0.125mm from the foreign-net obstacle when "
+            "the rule's effective clearance is 0.375mm (trace_width/2 + "
+            "trace_clearance = 0.125 + 0.25). This is the Gap 1 leak from "
+            "Issue #1702 that the test was written to enforce. Tracked as a "
+            "router bug in #3135; this skip restores PR review hygiene per "
+            "#3133 while the underlying fix is in flight."
+        )
+    )
     def test_route_avoids_unblocked_cells_near_obstacle(self):
         """Route should not pass through unblocked cells whose clearance
         envelope overlaps a different-net obstacle."""

--- a/tests/test_cpp_performance.py
+++ b/tests/test_cpp_performance.py
@@ -195,6 +195,19 @@ class TestCppPerformance:
         assert python_result.nets_routed > 0
         assert cpp_result.nets_routed > 0
 
+    @pytest.mark.skip(
+        reason=(
+            "Benchmark fixture is broken: the 50x40mm 8-net board routes "
+            "only 2 of 8 nets; the remaining 6 deterministically hit "
+            "BLOCKED_BY_COMPONENT after exhausting A*. Both backends then "
+            "spend most of their time on failed searches with identical "
+            "bounds, so the wall-clock difference converges to ~1.1x and "
+            "fails the 1.5x threshold. The threshold is correct in "
+            "principle but the fixture doesn't exercise the C++ A* hot "
+            "path. Needs a routable board geometry or conversion to a "
+            "non-asserting benchmark. Tracked in #3133."
+        )
+    )
     @pytest.mark.skipif(not is_cpp_available(), reason="C++ backend not available")
     def test_cpp_faster_than_python(self):
         """Verify C++ backend is faster than Python on medium-sized board."""

--- a/tests/test_cpp_validation_parity.py
+++ b/tests/test_cpp_validation_parity.py
@@ -296,6 +296,15 @@ class TestSegmentPadClearanceParity:
         )
         assert result.valid is True
 
+    @pytest.mark.skip(
+        reason=(
+            "Stale fixture post-#2871/#2874: the segment runs through the pad "
+            "center (overlap=0 vs. trace_clearance=0.25), which the tightened "
+            "validator now correctly flags. Fixture needs to be rewritten to "
+            "exercise the signal-pad-escape path with realistic clearance. "
+            "Tracked in #3133."
+        )
+    )
     def test_exclude_ref_hash(self):
         """Segment near pad with excluded ref should pass (Issue #1764)."""
         from kicad_tools.router import router_cpp
@@ -320,6 +329,15 @@ class TestSegmentPadClearanceParity:
         )
         assert result.valid is True
 
+    @pytest.mark.skip(
+        reason=(
+            "Stale fixture post-#2871/#2874: the segment passes through the "
+            "pad center at (5,5), so pad-segment distance is 0 and the "
+            "validator correctly rejects it. Fixture needs to be reshaped "
+            "so the segment maintains realistic escape clearance from the "
+            "pad body (e.g. ends at x=4.5 before the pad). Tracked in #3133."
+        )
+    )
     def test_exclude_ref_hash_preserves_signal_pad_escape(self):
         """Issue #1764 regression guard: signal pads (net != 0) on a
         component in the exclude set MUST still be skipped so the chip's
@@ -734,6 +752,15 @@ class TestPythonValidateSegmentClearanceExcludeRefs:
     ``test_exclude_ref_hash_blocks_plane_net_pad`` above.
     """
 
+    @pytest.mark.skip(
+        reason=(
+            "Stale fixture post-#2871/#2874 (Python twin of the C++ test). "
+            "The segment passes through the pad center at (5,5), so the "
+            "Python validator now correctly rejects it. Fixture needs to be "
+            "reshaped so the segment maintains realistic escape clearance "
+            "from the pad body. Tracked in #3133."
+        )
+    )
     def test_validate_segment_clearance_preserves_signal_pad_escape_on_excluded_ref(
         self,
     ):

--- a/tests/test_router_cpp_backend.py
+++ b/tests/test_router_cpp_backend.py
@@ -5,6 +5,8 @@ import importlib
 import pathlib
 import sys
 
+import pytest
+
 from kicad_tools.router.cpp_backend import (
     LARGE_GRID_THRESHOLD,
     format_backend_status,
@@ -1011,6 +1013,15 @@ class TestCppPathfinderPythonFallback:
         assert stats["fallback_count"] == 0
         assert stats["fallback_nets"] == []
 
+    @pytest.mark.skip(
+        reason=(
+            "nanobind disallows attribute replacement on bound C++ objects "
+            "(pf._impl.route = MagicMock(...) raises 'route is read-only'). "
+            "The mock strategy here was authored under pybind11 and needs a "
+            "wrapper-layer rewrite (e.g. patch CppPathfinder._route_impl). "
+            "Tracked in #3133."
+        )
+    )
     def test_fallback_invoked_when_cpp_fails(self):
         """Test Python fallback is called when C++ route returns failure."""
         if not is_cpp_available():
@@ -1055,6 +1066,13 @@ class TestCppPathfinderPythonFallback:
         assert pf.fallback_stats["fallback_count"] == 1
         assert pf.fallback_stats["fallback_nets"] == ["N1"]
 
+    @pytest.mark.skip(
+        reason=(
+            "nanobind disallows attribute replacement on bound C++ objects "
+            "(pf._impl.route = MagicMock(...) raises 'route is read-only'). "
+            "Needs wrapper-layer mock rewrite. Tracked in #3133."
+        )
+    )
     def test_fallback_returns_none_when_python_also_fails(self):
         """Test that None is returned when both C++ and Python fail."""
         if not is_cpp_available():
@@ -1132,6 +1150,13 @@ class TestCppPathfinderPythonFallback:
             assert pf._py_router is None
             assert pf.fallback_stats["fallback_count"] == 0
 
+    @pytest.mark.skip(
+        reason=(
+            "nanobind disallows attribute replacement on bound C++ objects "
+            "(pf._impl.route = MagicMock(...) raises 'route is read-only'). "
+            "Needs wrapper-layer mock rewrite. Tracked in #3133."
+        )
+    )
     def test_fallback_skipped_when_no_py_grid(self):
         """Test that fallback is skipped when _py_grid is None."""
         if not is_cpp_available():
@@ -1167,6 +1192,13 @@ class TestCppPathfinderPythonFallback:
         assert pf._py_router is None
         assert pf.fallback_stats["fallback_count"] == 0
 
+    @pytest.mark.skip(
+        reason=(
+            "nanobind disallows attribute replacement on bound C++ objects "
+            "(pf._impl.route = MagicMock(...) raises 'route is read-only'). "
+            "Needs wrapper-layer mock rewrite. Tracked in #3133."
+        )
+    )
     def test_fallback_stats_accumulate(self):
         """Test that multiple fallbacks accumulate in stats."""
         if not is_cpp_available():
@@ -1216,6 +1248,13 @@ class TestCppPathfinderPythonFallback:
         assert pf.fallback_stats["fallback_count"] == 3
         assert pf.fallback_stats["fallback_nets"] == ["NET_A", "NET_B", "NET_C"]
 
+    @pytest.mark.skip(
+        reason=(
+            "nanobind disallows attribute replacement on bound C++ objects "
+            "(pf._impl.route = MagicMock(...) raises 'route is read-only'). "
+            "Needs wrapper-layer mock rewrite. Tracked in #3133."
+        )
+    )
     def test_py_router_reused_across_fallbacks(self):
         """Test that the Python Router is constructed once and reused."""
         if not is_cpp_available():
@@ -1303,7 +1342,10 @@ class TestCppBuildVersionGuard:
         import sys
 
         # Ensure cpp_backend is freshly imported so we see the live router_cpp.
-        sys.modules.pop("kicad_tools.router.cpp_backend", None)
+        # Snapshot the ORIGINAL module instance so we can restore it later --
+        # downstream importers (e.g. router.core) hold module-level references
+        # to its classes/functions and an isinstance() check against a
+        # different reload-generated class instance would fail (Issue #3133).
         original = importlib.import_module("kicad_tools.router.cpp_backend")
 
         # Snapshot the live router_cpp module (None if backend already disabled)
@@ -1329,17 +1371,21 @@ class TestCppBuildVersionGuard:
             assert "build-native" in reason
             assert "stale" in reason.lower() or "999999" in reason
         finally:
-            # Restore the real cpp_backend module so subsequent tests see the
-            # true backend state (monkeypatch will restore BUILD_VERSION).
-            sys.modules.pop("kicad_tools.router.cpp_backend", None)
-            importlib.import_module("kicad_tools.router.cpp_backend")
+            # Issue #3133: Restore the ORIGINAL cpp_backend module instance
+            # in sys.modules. Reloading creates a new module object with new
+            # class identities (CppPathfinder, CppGrid, ...) -- but
+            # downstream importers (router.core) captured the originals at
+            # their own import time, and isinstance() checks against the
+            # new classes would fail. Putting the original back leaves all
+            # captured references valid for the rest of the test session.
+            sys.modules["kicad_tools.router.cpp_backend"] = original
 
     def test_missing_build_version_attr_disables_cpp(self, monkeypatch):
         """If router_cpp lacks BUILD_VERSION (very old .so) the guard fires."""
         import sys
 
-        # Ensure cpp_backend is freshly imported so we see the live router_cpp.
-        sys.modules.pop("kicad_tools.router.cpp_backend", None)
+        # Snapshot the ORIGINAL module instance so we can restore it later
+        # (Issue #3133 -- see sibling test for full rationale).
         original = importlib.import_module("kicad_tools.router.cpp_backend")
 
         router_cpp_mod = original.router_cpp
@@ -1361,5 +1407,7 @@ class TestCppBuildVersionGuard:
             assert reason is not None
             assert "build-native" in reason
         finally:
-            sys.modules.pop("kicad_tools.router.cpp_backend", None)
-            importlib.import_module("kicad_tools.router.cpp_backend")
+            # Issue #3133: Restore the ORIGINAL cpp_backend module instance
+            # (see sibling test for full rationale: downstream importers
+            # hold class references that must remain valid).
+            sys.modules["kicad_tools.router.cpp_backend"] = original


### PR DESCRIPTION
Closes #3133

## Summary

Restores PR review hygiene by clearing the 12 pre-existing C++ test failures that 4 consecutive Judge reviews on PRs #3120/#3122/#3128/#3131 flagged as "verified unrelated to this PR."

Per the curator's verified inventory in #3133 (commit f653033f), the failures split into 5 clusters; each is handled with a precise skip whose `reason=` cites either #3133 (test-rot) or #3135 (real router bug).

## Cluster-by-cluster disposition

| # | File | Tests | Action | Reason cites |
|---|---|---|---|---|
| 1 | `tests/test_router_cpp_backend.py` | 5 (`TestCppPathfinderPythonFallback`) | Skip | #3133 (nanobind disallows attribute replacement; wrapper-layer mock rewrite out of scope) |
| 2 | `tests/test_cpp_validation_parity.py` | 3 (`test_exclude_ref_*` and Python twin) | Skip | #3133 (stale fixtures post-#2871/#2874; segments pass through pad centers) |
| 3 | `tests/test_cpp_clearance_enforcement.py` | 1 (Gap 1 unblocked-cell clearance) | Skip | **#3135** (real C++ pathfinder clearance under-count -- already filed by curator) |
| 4 | `tests/test_cpp_performance.py` | 1 (`test_cpp_faster_than_python`) | Skip | #3133 (benchmark fixture routes only 2/8 nets, so speedup measurement is meaningless) |
| 5 | `tests/test_cpp_performance.py` | 2 (polluted-state failures in `test_cpp_matches_python_results` and `test_autorouter_uses_cpp_by_default`) | Fix test pollution | #3133 (pre-existing pollution from `TestCppBuildVersionGuard`) |

### Cluster 5 details

Two of the 12 failures surfaced only when running the affected files together. Tracing the pollution showed that `TestCppBuildVersionGuard::test_stale_so_disables_cpp_with_actionable_error` and `::test_missing_build_version_attr_disables_cpp` pop `cpp_backend` from `sys.modules` and reload it. Their existing `finally` blocks restored a NEW module instance to `sys.modules`, but downstream importers (`router.core`) had captured class references to the ORIGINAL module at their own import time. `isinstance(self.router, CppPathfinder)` then failed on later tests because the two `CppPathfinder` classes were distinct objects.

Fix: in the `finally` blocks, restore the captured `original` module instance (already on hand) instead of creating yet another fresh import. This preserves class identity for the rest of the session.

## Acceptance criteria status

1. **Cluster 1**: skipped with reason citing #3133 -- `pytest tests/test_router_cpp_backend.py -k TestCppPathfinderPythonFallback` reports 5 skipped, 0 failed.
2. **Cluster 2**: skipped with reason citing #3133 -- `pytest tests/test_cpp_validation_parity.py` reports 0 failed.
3. **Cluster 3**: skipped with reason citing **#3135** -- `pytest tests/test_cpp_clearance_enforcement.py` reports 0 failed.
4. **Cluster 4**: skipped with reason citing #3133 -- `pytest tests/test_cpp_performance.py` reports 0 failed.
5. **Empirical CI signal recovery**: `pytest tests/test_router_cpp_backend.py tests/test_cpp_validation_parity.py tests/test_cpp_clearance_enforcement.py tests/test_cpp_performance.py --no-cov` reports **90 passed, 11 skipped, 0 failed** (was: 12 failed).
6. **Documentation**: every skip has an inline `reason=` explaining the root cause and citing the tracking issue.

## Out of scope (per #3133)

- Rewriting nanobind-friendly wrapper-layer mocks for Cluster 1
- Rewriting validator-fixture geometry for Cluster 2
- Fixing the underlying C++ Gap 1 clearance leak (Cluster 3) -- that is #3135's responsibility
- Building a proper benchmark suite (Cluster 4)

## Test plan

- [x] `uv run pytest tests/test_router_cpp_backend.py tests/test_cpp_validation_parity.py tests/test_cpp_clearance_enforcement.py tests/test_cpp_performance.py --no-cov` -- 90 passed, 11 skipped, 0 failed
- [x] `uv run pytest tests/router/` -- 173 passed, no new regressions
- [x] `uv run ruff check` on touched files -- 0 new errors (7 pre-existing on main, unchanged)
- [x] `uv run ruff format --check` on touched files -- 0 new format gaps from this PR (pre-existing repo-wide gap is untouched)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>