### PR TITLE
fix(router): forward --early-stop-patience to inner do_routing() negotiator calls (#3132 Step A)

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -6544,6 +6544,13 @@ def main(argv: list[str] | None = None) -> int:
                                     partition_cols=getattr(args, "partition_cols", 2),
                                     max_parallel_workers=getattr(args, "max_parallel_workers", 4),
                                     checkpoint_callback=_checkpoint_cb,
+                                    # Issue #3132: forward --early-stop-patience
+                                    # to the inner main-path negotiator call so
+                                    # the CLI flag is honored (the previous
+                                    # implementation silently defaulted to 2).
+                                    best_stall_patience=(
+                                        getattr(args, "early_stop_patience", 2) or None
+                                    ),
                                 )
                             return router.route_all()
 
@@ -6598,6 +6605,10 @@ def main(argv: list[str] | None = None) -> int:
                             partition_cols=getattr(args, "partition_cols", 2),
                             max_parallel_workers=getattr(args, "max_parallel_workers", 4),
                             checkpoint_callback=_checkpoint_cb,
+                            # Issue #3132: forward --early-stop-patience to the
+                            # inner main-path negotiator call so the CLI flag
+                            # is honored (default 2 was silently overriding it).
+                            best_stall_patience=(getattr(args, "early_stop_patience", 2) or None),
                         )
                     else:
                         return router.route_all()
@@ -6667,6 +6678,13 @@ def main(argv: list[str] | None = None) -> int:
                         partition_cols=getattr(args, "partition_cols", 2),
                         max_parallel_workers=getattr(args, "max_parallel_workers", 4),
                         checkpoint_callback=_checkpoint_cb,
+                        # Issue #3132: forward --early-stop-patience to the
+                        # inner negotiator so the CLI flag is honored.  This
+                        # is the call site board 05's
+                        # `--differential-pairs --strategy negotiated` recipe
+                        # actually hits; previously the parameter silently
+                        # defaulted to 2.
+                        best_stall_patience=(getattr(args, "early_stop_patience", 2) or None),
                     )
 
                 result, dp_warnings = router.route_all_with_diffpairs(
@@ -6694,6 +6712,11 @@ def main(argv: list[str] | None = None) -> int:
                     partition_cols=getattr(args, "partition_cols", 2),
                     max_parallel_workers=getattr(args, "max_parallel_workers", 4),
                     checkpoint_callback=_checkpoint_cb,
+                    # Issue #3132: forward --early-stop-patience to the inner
+                    # negotiator call so the CLI flag is honored.  Previously
+                    # the parameter silently defaulted to 2 even when the
+                    # CLI passed a higher value.
+                    best_stall_patience=(getattr(args, "early_stop_patience", 2) or None),
                 )
             elif args.differential_pairs and args.strategy == "basic":
                 result, dp_warnings = router.route_all_with_diffpairs(diffpair_config)

--- a/tests/test_best_metric_patience.py
+++ b/tests/test_best_metric_patience.py
@@ -97,11 +97,15 @@ class TestPatienceComparatorBehavior:
         increment here, not reset.
         """
         best = IterationMetrics(
-            iteration=0, routed_count=27, overflow=16,
+            iteration=0,
+            routed_count=27,
+            overflow=16,
             clearance_violations=12,
         )
         regressed = IterationMetrics(
-            iteration=1, routed_count=27, overflow=36,
+            iteration=1,
+            routed_count=27,
+            overflow=36,
             clearance_violations=12,
         )
         # Strictly worse on overflow -- not "better than" the best.
@@ -111,11 +115,15 @@ class TestPatienceComparatorBehavior:
         """A re-route that adds a clearance violation must not reset
         the patience counter even if it nudges overflow down."""
         best = IterationMetrics(
-            iteration=0, routed_count=27, overflow=16,
+            iteration=0,
+            routed_count=27,
+            overflow=16,
             clearance_violations=12,
         )
         worse_drc = IterationMetrics(
-            iteration=1, routed_count=27, overflow=14,
+            iteration=1,
+            routed_count=27,
+            overflow=14,
             clearance_violations=15,
         )
         assert not worse_drc.is_better_than(best)
@@ -268,13 +276,13 @@ class TestPatienceLogLine:
         # If the iteration body printed any "iter N" line *without* a
         # "new best" suffix, it must include the stall counter.
         import re
+
         iter_lines = re.findall(r"iter \d+ \| routed=.*", out)
         for line in iter_lines:
             if "new best" in line:
                 continue
             assert "stall=" in line, (
-                f"Expected '| stall=N' suffix on non-improving iter "
-                f"line; got: {line!r}"
+                f"Expected '| stall=N' suffix on non-improving iter line; got: {line!r}"
             )
 
 
@@ -339,10 +347,14 @@ class TestNetsFullyConnectedLexKey:
         # Both default-zero; ordering should mirror legacy
         # routed-count-then-overflow.
         more_routed = IterationMetrics(
-            iteration=1, routed_count=10, overflow=10,
+            iteration=1,
+            routed_count=10,
+            overflow=10,
         )
         fewer_routed = IterationMetrics(
-            iteration=2, routed_count=8, overflow=5,
+            iteration=2,
+            routed_count=8,
+            overflow=5,
         )
         # Old behaviour: routed_count dominates overflow.
         assert more_routed.is_better_than(fewer_routed)
@@ -350,7 +362,9 @@ class TestNetsFullyConnectedLexKey:
 
         # And the explicit-zero form is identical to the default form.
         more_routed_explicit = IterationMetrics(
-            iteration=1, routed_count=10, overflow=10,
+            iteration=1,
+            routed_count=10,
+            overflow=10,
             nets_fully_connected=0,
         )
         assert more_routed.sort_key == more_routed_explicit.sort_key
@@ -413,6 +427,7 @@ class TestCLIFlagWiredThrough:
         # Import lazily so we don't pay the cost in the common case
         # where this whole module is collected but not run.
         from kicad_tools.cli import route_cmd
+
         # ``_build_parser`` is the conventional name; if it isn't
         # exposed we walk the module for the parser constructor.
         builder = getattr(route_cmd, "_build_parser", None)
@@ -435,12 +450,101 @@ class TestCLIFlagWiredThrough:
 
     def test_flag_on_outer_parser(self):
         from kicad_tools.cli import parser as parser_mod
+
         src = inspect.getsource(parser_mod)
         # Outer parser declares the flag in build_parser; substring
         # search keeps this test cheap and independent of parser
         # construction details.
-        assert "--early-stop-patience" in src, (
-            "--early-stop-patience missing from outer parser.py"
+        assert "--early-stop-patience" in src, "--early-stop-patience missing from outer parser.py"
+
+
+class TestAllInnerCallsForwardPatience:
+    """Issue #3132: Every ``router.route_all_negotiated(...)`` call site
+    inside ``route_cmd.py`` must forward ``best_stall_patience`` derived
+    from ``args.early_stop_patience``.  Without that forwarding, the
+    parameter silently defaults to 2 in the router signature even when
+    the user passes ``--early-stop-patience 4`` on the CLI -- the bug
+    that wasted ~83% of the wall-clock budget on board 05's M-E run
+    (issue #3132).
+
+    The mechanism: ``route_cmd.do_routing()`` defines four inner
+    invocations of ``route_all_negotiated`` (one per branch of the
+    multi-resolution / diff-pair / standard strategy fork).  Earlier
+    revisions only wired ``best_stall_patience`` to the *outer*
+    layer-escalation and clearance-relaxation loops at lines 2438,
+    3171, and 4266, missing the four main-path sites at ~6530, ~6584,
+    ~6653, ~6680.  This regression test pins the wiring so any new
+    call site that misses the forwarding fails the suite immediately
+    instead of in production.
+    """
+
+    def test_every_route_all_negotiated_call_forwards_patience(self):
+        from kicad_tools.cli import route_cmd
+
+        src = inspect.getsource(route_cmd)
+
+        # Find every ``route_all_negotiated(`` invocation and pair each
+        # one with the closing paren of its argument list.  The
+        # argument-list block must contain a ``best_stall_patience=``
+        # kwarg.  We walk character-by-character to track parenthesis
+        # depth (string literals contain no parens in this file -- a
+        # cheap assumption verified by the test running green).
+        #
+        # Skip occurrences that sit inside a Python comment (the file
+        # has several ``# ...route_all_negotiated()`` prose mentions in
+        # docstrings/comments that would otherwise produce false
+        # positives at e.g. line 77).
+        call_marker = "router.route_all_negotiated("
+        start = 0
+        call_count = 0
+        missing_lines: list[int] = []
+        while True:
+            idx = src.find(call_marker, start)
+            if idx < 0:
+                break
+            # Ignore matches inside a single-line comment.  Find the
+            # start-of-line and check whether a ``#`` precedes the
+            # match on the same line.
+            line_start = src.rfind("\n", 0, idx) + 1
+            preceding = src[line_start:idx]
+            if "#" in preceding:
+                # Comment — skip without advancing call_count.
+                start = idx + len(call_marker)
+                continue
+            # Walk forward to find the matching close paren.
+            depth = 1
+            cursor = idx + len(call_marker)
+            while cursor < len(src) and depth > 0:
+                ch = src[cursor]
+                if ch == "(":
+                    depth += 1
+                elif ch == ")":
+                    depth -= 1
+                cursor += 1
+            arg_block = src[idx + len(call_marker) : cursor - 1]
+            call_count += 1
+            if "best_stall_patience" not in arg_block:
+                # Translate idx -> 1-based line number for diagnostics.
+                line_no = src.count("\n", 0, idx) + 1
+                missing_lines.append(line_no)
+            start = cursor
+
+        # Sanity floor: at least the four main-path sites plus the
+        # three outer-escalation sites must exist (7 total).  If this
+        # drops, the test itself may be missing call sites.
+        assert call_count >= 7, (
+            f"Expected ≥7 route_all_negotiated invocations in route_cmd.py; "
+            f"found {call_count}.  Did the test marker text drift?"
+        )
+
+        assert not missing_lines, (
+            f"Issue #3132 regression: {len(missing_lines)} of {call_count} "
+            f"router.route_all_negotiated(...) call(s) in route_cmd.py do "
+            f"not forward ``best_stall_patience``.  Missing at line(s) "
+            f"{missing_lines}.  The CLI flag ``--early-stop-patience`` "
+            f"will be silently ignored at these sites because the router "
+            f"signature default is 2 even when args.early_stop_patience is "
+            f"larger."
         )
 
 


### PR DESCRIPTION
## Summary

**Step A of issue #3132 (M-E Round 4): fix the wiring bug that ignores `--early-stop-patience` on the main routing path.**

The ``route_all_negotiated`` outer loop was respecting the CLI flag at the *outer* layer-escalation / clearance-relaxation sites (``route_cmd.py`` lines 2438, 3171, 4266) but the four *inner* ``do_routing()`` call sites at lines ~6530, ~6584, ~6653, ~6680 - the branches the main routing path actually hits (diff-pair / multi-resolution / standard / two-phase forks) - were missing the kwarg.  Without it, the router signature default ``best_stall_patience: int | None = 2`` silently overrode the CLI value.

The curator's empirical evidence (issue #3132): board 05's M-E recipe passes ``--early-stop-patience 4`` but the log emitted ``patience=2 (Issue #3101)`` and the negotiator bailed out at iter 2, leaving ~745 s (83 %) of the 900 s ``--timeout`` budget unused.

## Changes

- `src/kicad_tools/cli/route_cmd.py`: thread `best_stall_patience=(getattr(args, "early_stop_patience", 2) or None)` through all four inner `route_all_negotiated()` invocations in `do_routing()` using the same idiom the outer call sites already use.
- `tests/test_best_metric_patience.py`: add `TestAllInnerCallsForwardPatience` regression test that inspects `route_cmd.py` source and asserts every `router.route_all_negotiated(...)` invocation carries `best_stall_patience=` (skipping comment matches). The test fails at HEAD pre-fix.

## Empirical results (board 05 BLDC controller)

Re-ran `boards/05-bldc-motor-controller/design.py` on this branch:

| metric | HEAD (pre-fix) | this PR (Step A) |
|---|---|---|
| log emits | `patience=2 (Issue #3101)` | (loop continues; iter 3 runs) |
| iter count | 2 (early-stop) | 3 (continues until "No nets to rip up") |
| iter 0 connected | 17/32 | 17/32 |
| iter 3 connected | n/a | 16 (stall=3) |
| final connected (restored to iter 0) | 17/32 | 17/32 |
| wall-clock | 155 s | 172 s |
| DRC connectivity errors | 20 | 20 |

The fix restores honest CLI-flag behaviour from the negotiator.

## What this PR does NOT do

**This PR does not close #3132's milestone gap (>=28/32).**  The structural ceiling at iter-0 (17/32 connected, 24/56 U3 pads with "no grid point reachable") is a placement problem, not a router-tuning one.  The curator's recommended Step B (`kct placement optimize --strategy evolutionary --use-routing-fitness`, ~3-6 h wall-clock) is required to close the gap and is out of scope for this Builder iteration.

I will:
1. Mark #3132 as `loom:blocked` after this PR merges (since the milestone closure depends on a multi-hour offline reflow).
2. Comment on #3132 with the current empirical numbers and recommend a follow-up issue for Step B that explicitly budgets the placement reflow as a separate iteration.

## Test plan

- [x] `uv run pytest tests/test_best_metric_patience.py` -- 17/17 pass (16 pre-existing + 1 new wiring test).
- [x] `uv run pytest tests/test_route_cmd_params.py tests/test_route_cmd_help_string.py tests/test_cli_parser_drift.py` -- 80/80 pass.
- [x] `uv run ruff check src/kicad_tools/cli/route_cmd.py tests/test_best_metric_patience.py` -- clean.
- [x] `uv run ruff format src/kicad_tools/cli/route_cmd.py tests/test_best_metric_patience.py` -- clean.
- [x] Empirical board 05 run confirms iter 3 now runs (vs. stop at iter 2 pre-fix); log no longer shows `patience=2 (Issue #3101)` because the loop now exits via the "No nets to rip up" path instead.
- [x] Pre-existing failing tests in `tests/test_adaptive_early_stop.py` (7 failures) -- verified these fail identically on origin/main and are unrelated to this change (MagicMock + shutil.copy2 issue, not patience-related).

Refs #3132 (Step A only -- milestone closure still requires Step B follow-up)