### PR TITLE
fix(boards): route board 00 simple-led through pour-aware pipeline

### DIFF
--- a/boards/00-simple-led/generate_design.py
+++ b/boards/00-simple-led/generate_design.py
@@ -511,6 +511,46 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
 
     output_path.write_text(output_content)
 
+    # Step 7: Create + fill copper pours for power/ground nets.
+    #
+    # VCC and GND are classified as power/pour nets (is_pour_net=True in
+    # DEFAULT_NET_CLASS_MAP), so the router auto-skips them -- they are
+    # meant to be connected via copper zones, not traces.  Without this
+    # step no zones are generated and both power nets are left stranded,
+    # producing connectivity DRC errors (issue #3148).  This mirrors what
+    # the official ``kct route`` CLI does -- ``auto_pour_if_missing()``
+    # creates the zone outlines and ``_fill_zones_after_route()`` fills
+    # them via kicad-cli (see ``src/kicad_tools/cli/route_cmd.py``).
+    # Calling both here keeps the board script in lock-step with the
+    # supported pipeline.
+    from kicad_tools.cli.route_cmd import _fill_zones_after_route
+    from kicad_tools.router.auto_pour import auto_pour_if_missing
+
+    # Inset zones from the board edge so they satisfy the copper-to-edge
+    # clearance DRC rule (jlcpcb minimum is 0.30mm).  Without this the
+    # zone outlines sit flush with the edge cuts and DRC flags
+    # ``edge_clearance_zone`` violations.
+    edge_clearance = 0.3
+
+    print("\n7. Creating copper zones for power nets (VCC, GND)...")
+    zones_created, pour_nets = auto_pour_if_missing(
+        output_path,
+        edge_clearance=edge_clearance,
+        # GND is explicitly committed to a pour above (skip_nets=["GND"]),
+        # so force it through the all-power-board guard alongside VCC.
+        force_pour_nets=["VCC", "GND"],
+    )
+    if zones_created:
+        print(f"   Created {zones_created} zone(s) for: {', '.join(pour_nets)}")
+    else:
+        print("   Warning: No copper zones created!")
+
+    # Step 8: Fill the zones so DRC sees plane copper rather than bare
+    # outlines (issue #2516).  Must run after traces exist so the fill
+    # respects trace clearances.
+    print("\n8. Filling copper zones...")
+    _fill_zones_after_route(output_path)
+
     total_nets = len([n for n in router.nets if n > 0])
     success = stats["nets_routed"] == total_nets
 

--- a/tests/test_board_00_simple_led.py
+++ b/tests/test_board_00_simple_led.py
@@ -1,0 +1,198 @@
+"""Regression test for ``boards/00-simple-led/`` power-net stranding.
+
+Issue #3148 — Board 00 (the "Hello World" LED board) routed only the
+single signal net ``LED_ANODE`` and left both power nets (``VCC`` and
+``GND``) stranded, producing 2 connectivity DRC errors.
+
+The board defines **3 nets**: ``VCC``, ``LED_ANODE``, ``GND``.  ``VCC``
+and ``GND`` are power/pour nets (``is_pour_net=True`` in
+``DEFAULT_NET_CLASS_MAP``) that are meant to be connected via copper
+zones, not traces.  The router correctly auto-skips them, but the
+board's hand-rolled ``route_pcb()`` never created copper pours -- so
+both power nets ended up with neither a trace nor a zone and DRC
+reported "1 of 2 pads stranded" for each.
+
+This was NOT a router regression (it reproduced on commits predating
+all suspected router PRs).  The fix routes board 00 through the same
+pour-aware path the official ``kct route`` CLI uses:
+``auto_pour_if_missing()`` creates the VCC/GND zone outlines and
+``_fill_zones_after_route()`` fills them.
+
+This test pins the post-fix behavior by running the generator
+end-to-end and asserting:
+
+- The routable signal net ``LED_ANODE`` is routed (>= 1 segment).
+- The routed PCB has at least 2 filled copper zones (VCC + GND).
+- ``kct check`` reports 0 connectivity errors (no stranded pads).
+
+It FAILS against the unpatched ``route_pcb()`` (0 zones, 2 connectivity
+errors) and PASSES after the fix.
+
+Requires ``kicad-cli`` for ERC + zone fill; skipped otherwise.  Marked
+``@pytest.mark.slow`` (full generate + route is ~15-20s).  The nightly
+slow-tests workflow (``.github/workflows/slow-tests.yml``, ``-m slow``)
+picks this up; PR-time CI excludes it.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BOARD_DIR = REPO_ROOT / "boards" / "00-simple-led"
+GENERATOR = BOARD_DIR / "generate_design.py"
+
+# Net 2 is the only routable signal net on board 00 (R1.2 -> D1.1).
+# Nets 1 (VCC) and 3 (GND) are pour nets connected via copper zones.
+LED_ANODE_NET_NUM = 2
+LED_ANODE_NET_NAME = "LED_ANODE"
+
+
+def _kicad_cli_available() -> bool:
+    """Whether kicad-cli is installed (needed for ERC + zone fill)."""
+    from kicad_tools.cli.runner import find_kicad_cli
+
+    return find_kicad_cli() is not None
+
+
+def _count_filled_zones(pcb_text: str) -> int:
+    """Count ``(zone ...)`` blocks that contain a ``filled_polygon``.
+
+    A zone with ``fill enabled`` but no ``filled_polygon`` is an empty
+    outline that contributes no plane copper -- it does NOT connect the
+    net.  We only count zones that were actually filled.
+    """
+    # Split on zone openings (both single-line and newline-wrapped forms).
+    chunks = re.split(r"\(zone[\s\(]", pcb_text)
+    return sum(1 for chunk in chunks[1:] if "filled_polygon" in chunk)
+
+
+def _count_segments_on_net(pcb_text: str, net_num: int) -> int:
+    """Count routed copper segments belonging to ``net_num``.
+
+    Segments serialize as ``(segment ... (net N) ...)``.  We match the
+    ``(net N)`` reference form used inside segment/via blocks (distinct
+    from the ``(net N "name")`` header declarations).
+    """
+    return len(re.findall(rf"\(segment\b[^()]*?(?:\([^)]*\)[^()]*?)*\(net {net_num}\)", pcb_text))
+
+
+def _connectivity_error_count(check_stdout: str) -> int:
+    """Count connectivity DRC errors in ``kct check`` output.
+
+    The pre-fix failure mode prints lines like::
+
+        [X] connectivity
+            Net 'GND' is partially routed: 1 of 2 pads stranded
+    """
+    return len(
+        re.findall(
+            r"\bpartially routed\b|\bpads stranded\b|\bstranded\b",
+            check_stdout,
+        )
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    not _kicad_cli_available(),
+    reason="kicad-cli not installed (required for ERC + zone fill)",
+)
+class TestBoard00SimpleLed:
+    """Pin board 00's pour-aware routing against the #3148 fix.
+
+    Runs the generator script as a subprocess (the same path the fleet
+    audit / a developer invokes), then inspects the routed artifact and
+    runs ``kct check`` on it.  The fixture runs once per class; each test
+    asserts a distinct aspect for sharp failure attribution.
+    """
+
+    @pytest.fixture(scope="class")
+    def routed_pcb(self, tmp_path_factory: pytest.TempPathFactory) -> Path:
+        """Run ``generate_design.py`` and return the routed PCB path."""
+        out_dir = tmp_path_factory.mktemp("board00")
+        proc = subprocess.run(
+            [sys.executable, str(GENERATOR), str(out_dir)],
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=False,
+        )
+        routed = out_dir / "simple_led_routed.kicad_pcb"
+        if not routed.exists():
+            pytest.fail(
+                f"Generator did not produce {routed.name} "
+                f"(exit {proc.returncode}).\n"
+                f"stdout (last 2000 chars):\n{proc.stdout[-2000:]}\n"
+                f"stderr (last 2000 chars):\n{proc.stderr[-2000:]}"
+            )
+        # The generator's exit gate is ``0 if erc_success and drc_success``.
+        # Post-fix, DRC must pass, so a non-zero exit is itself a regression.
+        assert proc.returncode == 0, (
+            f"generate_design.py exited {proc.returncode} (expected 0; "
+            "ERC + DRC must both pass after the #3148 pour fix).\n"
+            f"stdout (last 2000 chars):\n{proc.stdout[-2000:]}"
+        )
+        return routed
+
+    def test_led_anode_routed(self, routed_pcb: Path) -> None:
+        """The only routable signal net (LED_ANODE) must have a trace."""
+        text = routed_pcb.read_text()
+        # Sanity: confirm the net numbering matches our assumption.
+        assert f'(net {LED_ANODE_NET_NUM} "{LED_ANODE_NET_NAME}")' in text, (
+            f"Expected net {LED_ANODE_NET_NUM} to be '{LED_ANODE_NET_NAME}' "
+            "in the routed PCB header; the board's net map may have changed. "
+            "Update LED_ANODE_NET_NUM in this test if so."
+        )
+        segments = _count_segments_on_net(text, LED_ANODE_NET_NUM)
+        assert segments >= 1, (
+            f"LED_ANODE (net {LED_ANODE_NET_NUM}) has no routed segments. "
+            "The only routable signal net on board 00 was not routed."
+        )
+
+    def test_power_nets_have_filled_zones(self, routed_pcb: Path) -> None:
+        """VCC + GND must be connected via filled copper zones.
+
+        Pre-fix, ``route_pcb()`` created zero zones (it never called
+        ``auto_pour_if_missing()``), so this asserts the fix wired the
+        pour step in.  Empty zone outlines (fill enabled, no
+        ``filled_polygon``) do NOT count -- they carry no copper.
+        """
+        text = routed_pcb.read_text()
+        filled = _count_filled_zones(text)
+        assert filled >= 2, (
+            f"Routed PCB has only {filled} filled copper zone(s); expected "
+            ">= 2 (one VCC, one GND).  This is the #3148 failure: the board "
+            "script bypassed auto_pour_if_missing()/zone-fill, leaving both "
+            "power nets without copper."
+        )
+
+    def test_no_connectivity_errors(self, routed_pcb: Path) -> None:
+        """``kct check`` must report 0 connectivity errors.
+
+        This is the user-visible DRC failure from #3148 ("Net 'GND'/'VCC'
+        is partially routed: 1 of 2 pads stranded").
+        """
+        proc = subprocess.run(
+            [sys.executable, "-m", "kicad_tools.cli", "check", str(routed_pcb)],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+        conn_errors = _connectivity_error_count(proc.stdout)
+        assert conn_errors == 0, (
+            f"kct check reported {conn_errors} connectivity issue(s) "
+            "(stranded / partially-routed pads).  VCC/GND should be fully "
+            "connected via filled copper zones after the #3148 fix.\n"
+            f"stdout (last 2000 chars):\n{proc.stdout[-2000:]}"
+        )
+        assert proc.returncode == 0, (
+            f"kct check exited {proc.returncode} (expected 0 -- DRC clean).\n"
+            f"stdout (last 2000 chars):\n{proc.stdout[-2000:]}"
+        )


### PR DESCRIPTION
## Summary

Closes #3148

Board 00 (simple-led) has **3 nets** — `VCC`, `LED_ANODE`, `GND` — not 2. `VCC`/`GND` are power/pour nets connected via copper zones; `LED_ANODE` is the only routable signal trace. The router correctly auto-skips the pour nets (`is_pour_net=True` in `DEFAULT_NET_CLASS_MAP`), but the board's hand-rolled `route_pcb()` never created copper pours for them. With neither traces nor zones, both power nets were left stranded → **2 connectivity DRC errors** ("1 of 2 pads stranded").

Per the curator's empirical root-cause analysis, this is **not a router regression** — it reproduced on commits predating all suspected router PRs (#3120/#3126/#3128/#3131/#3140/#3142). The masking dates back to PR #1528, which added `GND` to `skip_nets` without ever generating its pour.

## Fix (Option A — in-process, mirrors the CLI)

`boards/00-simple-led/generate_design.py` `route_pcb()` now routes through the same pour-aware path the official `kct route` CLI uses:
- `auto_pour_if_missing()` creates the VCC/GND zone outlines (inset 0.3mm so they satisfy the copper-to-edge clearance rule), forcing both nets through the all-power-board guard.
- `_fill_zones_after_route()` fills the zones via kicad-cli after traces exist.

Net effect: `LED_ANODE` stays a trace; `VCC` + `GND` become filled copper pours; `kct check` passes with 0 errors.

**Scope guard:** no changes to the A* router, `_is_pour_net`, `_filter_pour_nets`, or `DEFAULT_NET_CLASS_MAP` — only the board script + a new test. Confirmed via `git diff --name-only`.

## Verification

- `uv run python boards/00-simple-led/generate_design.py /tmp/b00` → ERC PASS, **DRC PASS**, exit 0
- `grep -c '(zone' …/simple_led_routed.kicad_pcb` → **2** (VCC + GND); `filled_polygon` count → **2**
- `uv run kct check …/simple_led_routed.kicad_pcb` → **0 errors, 0 warnings**, exit 0

## Test plan

- [x] `tests/test_board_00_simple_led.py` (modeled on `tests/test_board_04_routing_regression.py`): asserts LED_ANODE routed, >= 2 filled zones, 0 connectivity errors. Passes post-fix (3 passed).
- [x] Verified the test **FAILS against the unpatched** `route_pcb()` (2 connectivity errors, generator exits non-zero).
- [x] `tests/test_auto_pour.py` — 28 passed (path I exercise is unaffected).
- [x] `ruff check` + `ruff format --check` clean on both changed files. (Pre-existing repo-wide lint/format debt is unrelated and untouched.)
- [x] `kct build-native --force` built the C++ backend in the worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)