### PR TITLE
fix(boards): auto-export mfg bundle in 6 recipes so fleet status is ship-ready

### DIFF
--- a/boards/00-simple-led/generate_design.py
+++ b/boards/00-simple-led/generate_design.py
@@ -622,6 +622,55 @@ def run_drc(pcb_path: Path) -> bool:
         return False
 
 
+def export_manufacturing_bundle(routed_path: Path, output_dir: Path) -> bool:
+    """Export the manufacturing bundle (gerbers, BOM, CPL, report, manifest).
+
+    Issue #3147: ``kct fleet status`` flags a board ``ship_ready=false``
+    with the ``"artifacts stale"`` blocker whenever the routed PCB is
+    newer than ``output/manufacturing/manifest.json``.  Re-running this
+    recipe always rewrites the routed PCB, so the recipe must also
+    regenerate the manufacturing bundle to keep the manifest current.
+
+    ``kct export`` runs the standard JLCPCB recipe (gerbers + drill + BOM
+    + CPL + report.{md,pdf} + manifest.json).  ``--skip-preflight`` skips
+    the strict pre-flight DRC/ERC gate so the bundle is produced even for
+    boards that ship with allowlisted tolerances (mirrors boards
+    03/04/05); for clean boards it is harmless.
+    """
+    print("\n" + "=" * 60)
+    print("Exporting manufacturing bundle...")
+    print("=" * 60)
+
+    mfg_dir = output_dir / "manufacturing"
+    cmd = [
+        sys.executable,
+        "-m",
+        "kicad_tools.cli",
+        "export",
+        str(routed_path),
+        "--output",
+        str(mfg_dir),
+        "--mfr",
+        "jlcpcb",
+        "--skip-preflight",
+    ]
+    print(f"\n   Command: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.stdout:
+        for line in result.stdout.strip().split("\n")[-15:]:
+            print(f"   {line}")
+    if result.returncode != 0:
+        if result.stderr:
+            print(f"\n   Error: {result.stderr}")
+        return False
+    manifest = mfg_dir / "manifest.json"
+    if manifest.exists():
+        print(f"\n   Manifest: {manifest}")
+        return True
+    print("\n   WARNING: manifest.json not produced")
+    return False
+
+
 def main() -> int:
     """Main entry point."""
     if len(sys.argv) > 1:
@@ -649,6 +698,13 @@ def main() -> int:
         # Step 6: Run DRC
         drc_success = run_drc(routed_path)
 
+        # Step 7: Export manufacturing bundle (#3147).  Run unconditionally
+        # so the manifest mtime stays newer than the routed PCB even when
+        # routing is incomplete (board 00 routing is tracked by #3148);
+        # keeping the bundle current is what clears the ``"artifacts
+        # stale"`` ship-ready blocker in ``kct fleet status``.
+        mfg_success = export_manufacturing_bundle(routed_path, output_dir)
+
         # Summary
         print("\n" + "=" * 60)
         print("SUMMARY")
@@ -663,6 +719,7 @@ def main() -> int:
         print(f"  ERC: {'PASS' if erc_success else 'FAIL'}")
         print(f"  Routing: {'SUCCESS' if route_success else 'PARTIAL'}")
         print(f"  DRC: {'PASS' if drc_success else 'FAIL'}")
+        print(f"  MFG bundle: {'PASS' if mfg_success else 'FAIL'}")
         print("\nCircuit description:")
         print("  - J1: 2-pin power input (VCC, GND)")
         print("  - R1: 330 ohm current limiter")

--- a/boards/01-voltage-divider/generate_design.py
+++ b/boards/01-voltage-divider/generate_design.py
@@ -676,6 +676,55 @@ def run_drc(pcb_path: Path) -> bool:
         return False
 
 
+def export_manufacturing_bundle(routed_path: Path, output_dir: Path) -> bool:
+    """Export the manufacturing bundle (gerbers, BOM, CPL, report, manifest).
+
+    Issue #3147: ``kct fleet status`` flags a board ``ship_ready=false``
+    with the ``"artifacts stale"`` blocker whenever the routed PCB is
+    newer than ``output/manufacturing/manifest.json``.  Re-running this
+    recipe always rewrites the routed PCB, so the recipe must also
+    regenerate the manufacturing bundle to keep the manifest current.
+
+    ``kct export`` runs the standard JLCPCB recipe (gerbers + drill + BOM
+    + CPL + report.{md,pdf} + manifest.json).  ``--skip-preflight`` skips
+    the strict pre-flight DRC/ERC gate so the bundle is produced even for
+    boards that ship with allowlisted tolerances (mirrors boards
+    03/04/05); for clean boards it is harmless.
+    """
+    print("\n" + "=" * 60)
+    print("Exporting manufacturing bundle...")
+    print("=" * 60)
+
+    mfg_dir = output_dir / "manufacturing"
+    cmd = [
+        sys.executable,
+        "-m",
+        "kicad_tools.cli",
+        "export",
+        str(routed_path),
+        "--output",
+        str(mfg_dir),
+        "--mfr",
+        "jlcpcb",
+        "--skip-preflight",
+    ]
+    print(f"\n   Command: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.stdout:
+        for line in result.stdout.strip().split("\n")[-15:]:
+            print(f"   {line}")
+    if result.returncode != 0:
+        if result.stderr:
+            print(f"\n   Error: {result.stderr}")
+        return False
+    manifest = mfg_dir / "manifest.json"
+    if manifest.exists():
+        print(f"\n   Manifest: {manifest}")
+        return True
+    print("\n   WARNING: manifest.json not produced")
+    return False
+
+
 def main() -> int:
     """Main entry point."""
     if len(sys.argv) > 1:
@@ -703,6 +752,11 @@ def main() -> int:
         # Step 6: Run DRC
         drc_success = run_drc(routed_path)
 
+        # Step 7: Export manufacturing bundle (#3147) so ``kct fleet
+        # status`` reports ``ship_ready=true`` (the bundle's manifest
+        # mtime must be newer than the freshly routed PCB).
+        mfg_success = export_manufacturing_bundle(routed_path, output_dir)
+
         # Summary
         print("\n" + "=" * 60)
         print("SUMMARY")
@@ -717,6 +771,7 @@ def main() -> int:
         print(f"  ERC: {'PASS' if erc_success else 'FAIL'}")
         print(f"  Routing: {'SUCCESS' if route_success else 'PARTIAL'}")
         print(f"  DRC: {'PASS' if drc_success else 'FAIL'}")
+        print(f"  MFG bundle: {'PASS' if mfg_success else 'FAIL'}")
         print("\nDesign summary:")
         print("  - J1: 2-pin input connector (VIN, GND)")
         print("  - R1, R2: 10k voltage divider")

--- a/boards/02-charlieplex-led/generate_design.py
+++ b/boards/02-charlieplex-led/generate_design.py
@@ -655,6 +655,55 @@ def run_drc(pcb_path: Path) -> bool:
         return False
 
 
+def export_manufacturing_bundle(routed_path: Path, output_dir: Path) -> bool:
+    """Export the manufacturing bundle (gerbers, BOM, CPL, report, manifest).
+
+    Issue #3147: ``kct fleet status`` flags a board ``ship_ready=false``
+    with the ``"artifacts stale"`` blocker whenever the routed PCB is
+    newer than ``output/manufacturing/manifest.json``.  Re-running this
+    recipe always rewrites the routed PCB, so the recipe must also
+    regenerate the manufacturing bundle to keep the manifest current.
+
+    ``kct export`` runs the standard JLCPCB recipe (gerbers + drill + BOM
+    + CPL + report.{md,pdf} + manifest.json).  ``--skip-preflight`` skips
+    the strict pre-flight DRC/ERC gate so the bundle is produced even for
+    boards that ship with allowlisted tolerances (mirrors boards
+    03/04/05); for clean boards it is harmless.
+    """
+    print("\n" + "=" * 60)
+    print("Exporting manufacturing bundle...")
+    print("=" * 60)
+
+    mfg_dir = output_dir / "manufacturing"
+    cmd = [
+        sys.executable,
+        "-m",
+        "kicad_tools.cli",
+        "export",
+        str(routed_path),
+        "--output",
+        str(mfg_dir),
+        "--mfr",
+        "jlcpcb",
+        "--skip-preflight",
+    ]
+    print(f"\n   Command: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.stdout:
+        for line in result.stdout.strip().split("\n")[-15:]:
+            print(f"   {line}")
+    if result.returncode != 0:
+        if result.stderr:
+            print(f"\n   Error: {result.stderr}")
+        return False
+    manifest = mfg_dir / "manifest.json"
+    if manifest.exists():
+        print(f"\n   Manifest: {manifest}")
+        return True
+    print("\n   WARNING: manifest.json not produced")
+    return False
+
+
 # =============================================================================
 # Main Entry Point
 # =============================================================================
@@ -693,6 +742,11 @@ def main() -> int:
         # Step 6: Run DRC
         drc_success = run_drc(routed_path)
 
+        # Step 7: Export manufacturing bundle (#3147) so ``kct fleet
+        # status`` reports ``ship_ready=true`` (the bundle's manifest
+        # mtime must be newer than the freshly routed PCB).
+        mfg_success = export_manufacturing_bundle(routed_path, output_dir)
+
         # Summary
         print("\n" + "=" * 60)
         print("SUMMARY")
@@ -707,6 +761,7 @@ def main() -> int:
         print(f"  ERC: {'PASS' if erc_success else 'FAIL'}")
         print(f"  Routing: {'SUCCESS' if route_success else 'PARTIAL'}")
         print(f"  DRC: {'PASS' if drc_success else 'FAIL'}")
+        print(f"  MFG bundle: {'PASS' if mfg_success else 'FAIL'}")
         print("\nCharlieplex LED mapping:")
         print("  LED   Anode    Cathode")
         for led_conn in LED_CONNECTIONS:

--- a/boards/06-diffpair-test/generate_design.py
+++ b/boards/06-diffpair-test/generate_design.py
@@ -629,6 +629,55 @@ def run_drc(pcb_path: Path) -> bool:
         return False
 
 
+def export_manufacturing_bundle(routed_path: Path, output_dir: Path) -> bool:
+    """Export the manufacturing bundle (gerbers, BOM, CPL, report, manifest).
+
+    Issue #3147: ``kct fleet status`` flags a board ``ship_ready=false``
+    with the ``"artifacts stale"`` blocker whenever the routed PCB is
+    newer than ``output/manufacturing/manifest.json``.  Re-running this
+    recipe always rewrites the routed PCB, so the recipe must also
+    regenerate the manufacturing bundle to keep the manifest current.
+
+    ``kct export`` runs the standard JLCPCB recipe (gerbers + drill + BOM
+    + CPL + report.{md,pdf} + manifest.json).  ``--skip-preflight`` skips
+    the strict pre-flight DRC/ERC gate so the bundle is produced even for
+    boards that ship with allowlisted tolerances (mirrors boards
+    03/04/05); for clean boards it is harmless.
+    """
+    print("\n" + "=" * 60)
+    print("Exporting manufacturing bundle...")
+    print("=" * 60)
+
+    mfg_dir = output_dir / "manufacturing"
+    cmd = [
+        sys.executable,
+        "-m",
+        "kicad_tools.cli",
+        "export",
+        str(routed_path),
+        "--output",
+        str(mfg_dir),
+        "--mfr",
+        "jlcpcb",
+        "--skip-preflight",
+    ]
+    print(f"\n   Command: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.stdout:
+        for line in result.stdout.strip().split("\n")[-15:]:
+            print(f"   {line}")
+    if result.returncode != 0:
+        if result.stderr:
+            print(f"\n   Error: {result.stderr}")
+        return False
+    manifest = mfg_dir / "manifest.json"
+    if manifest.exists():
+        print(f"\n   Manifest: {manifest}")
+        return True
+    print("\n   WARNING: manifest.json not produced")
+    return False
+
+
 def main() -> int:
     """Entry point.
 
@@ -714,6 +763,13 @@ def main() -> int:
             route_success = route_pcb(pcb_path, routed_path)
             drc_ok = run_drc(routed_path)
 
+            # Export manufacturing bundle (#3147) so ``kct fleet status``
+            # reports ``ship_ready=true`` (the bundle's manifest mtime must
+            # be newer than the freshly routed PCB).  Run unconditionally:
+            # routing is allowed to be PARTIAL on this board, and a current
+            # bundle still clears the ``"artifacts stale"`` blocker.
+            mfg_ok = export_manufacturing_bundle(routed_path, output_dir)
+
             print("\n" + "=" * 60)
             print("SUMMARY")
             print("=" * 60)
@@ -725,6 +781,7 @@ def main() -> int:
             print("\nResults:")
             print(f"  Routing: {'SUCCESS' if route_success else 'PARTIAL'}")
             print(f"  DRC:     {'PASS' if drc_ok else 'FAIL (see above)'}")
+            print(f"  MFG:     {'PASS' if mfg_ok else 'FAIL (see above)'}")
 
             return 0 if route_success else 1
 

--- a/boards/07-matchgroup-test/generate_design.py
+++ b/boards/07-matchgroup-test/generate_design.py
@@ -634,6 +634,55 @@ def run_drc(pcb_path: Path) -> bool:
         return False
 
 
+def export_manufacturing_bundle(routed_path: Path, output_dir: Path) -> bool:
+    """Export the manufacturing bundle (gerbers, BOM, CPL, report, manifest).
+
+    Issue #3147: ``kct fleet status`` flags a board ``ship_ready=false``
+    with the ``"artifacts stale"`` blocker whenever the routed PCB is
+    newer than ``output/manufacturing/manifest.json``.  Re-running this
+    recipe always rewrites the routed PCB, so the recipe must also
+    regenerate the manufacturing bundle to keep the manifest current.
+
+    ``kct export`` runs the standard JLCPCB recipe (gerbers + drill + BOM
+    + CPL + report.{md,pdf} + manifest.json).  ``--skip-preflight`` skips
+    the strict pre-flight DRC/ERC gate so the bundle is produced even for
+    boards that ship with allowlisted tolerances (mirrors boards
+    03/04/05); for clean boards it is harmless.
+    """
+    print("\n" + "=" * 60)
+    print("Exporting manufacturing bundle...")
+    print("=" * 60)
+
+    mfg_dir = output_dir / "manufacturing"
+    cmd = [
+        sys.executable,
+        "-m",
+        "kicad_tools.cli",
+        "export",
+        str(routed_path),
+        "--output",
+        str(mfg_dir),
+        "--mfr",
+        "jlcpcb",
+        "--skip-preflight",
+    ]
+    print(f"\n   Command: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.stdout:
+        for line in result.stdout.strip().split("\n")[-15:]:
+            print(f"   {line}")
+    if result.returncode != 0:
+        if result.stderr:
+            print(f"\n   Error: {result.stderr}")
+        return False
+    manifest = mfg_dir / "manifest.json"
+    if manifest.exists():
+        print(f"\n   Manifest: {manifest}")
+        return True
+    print("\n   WARNING: manifest.json not produced")
+    return False
+
+
 def main() -> int:
     """Entry point.
 
@@ -707,6 +756,13 @@ def main() -> int:
             route_success = route_pcb(pcb_path, routed_path)
             drc_ok = run_drc(routed_path)
 
+            # Export manufacturing bundle (#3147) so ``kct fleet status``
+            # reports ``ship_ready=true`` (the bundle's manifest mtime must
+            # be newer than the freshly routed PCB).  Run unconditionally:
+            # routing is allowed to be PARTIAL on this board, and a current
+            # bundle still clears the ``"artifacts stale"`` blocker.
+            mfg_ok = export_manufacturing_bundle(routed_path, output_dir)
+
             print("\n" + "=" * 60)
             print("SUMMARY")
             print("=" * 60)
@@ -718,6 +774,7 @@ def main() -> int:
             print("\nResults:")
             print(f"  Routing: {'SUCCESS' if route_success else 'PARTIAL'}")
             print(f"  DRC:     {'PASS' if drc_ok else 'FAIL (see above)'}")
+            print(f"  MFG:     {'PASS' if mfg_ok else 'FAIL (see above)'}")
 
             return 0 if route_success else 1
 

--- a/boards/external/softstart/generate_design.py
+++ b/boards/external/softstart/generate_design.py
@@ -1820,6 +1820,55 @@ def run_drc(pcb_path: Path) -> bool:
         return False
 
 
+def export_manufacturing_bundle(routed_path: Path, output_dir: Path) -> bool:
+    """Export the manufacturing bundle (gerbers, BOM, CPL, report, manifest).
+
+    Issue #3147: ``kct fleet status`` flags a board ``ship_ready=false``
+    with the ``"artifacts stale"`` blocker whenever the routed PCB is
+    newer than ``output/manufacturing/manifest.json``.  Re-running this
+    recipe always rewrites the routed PCB, so the recipe must also
+    regenerate the manufacturing bundle to keep the manifest current.
+
+    ``kct export`` runs the standard JLCPCB recipe (gerbers + drill + BOM
+    + CPL + report.{md,pdf} + manifest.json).  ``--skip-preflight`` skips
+    the strict pre-flight DRC/ERC gate so the bundle is produced even for
+    boards that ship with allowlisted tolerances (mirrors boards
+    03/04/05); for clean boards it is harmless.
+    """
+    print("\n" + "=" * 60)
+    print("Exporting manufacturing bundle...")
+    print("=" * 60)
+
+    mfg_dir = output_dir / "manufacturing"
+    cmd = [
+        sys.executable,
+        "-m",
+        "kicad_tools.cli",
+        "export",
+        str(routed_path),
+        "--output",
+        str(mfg_dir),
+        "--mfr",
+        "jlcpcb",
+        "--skip-preflight",
+    ]
+    print(f"\n   Command: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.stdout:
+        for line in result.stdout.strip().split("\n")[-15:]:
+            print(f"   {line}")
+    if result.returncode != 0:
+        if result.stderr:
+            print(f"\n   Error: {result.stderr}")
+        return False
+    manifest = mfg_dir / "manifest.json"
+    if manifest.exists():
+        print(f"\n   Manifest: {manifest}")
+        return True
+    print("\n   WARNING: manifest.json not produced")
+    return False
+
+
 def create_project(output_dir: Path, project_name: str) -> Path:
     """Create a KiCad project file."""
     print("\n" + "=" * 60)
@@ -1862,6 +1911,11 @@ def main() -> int:
         # Step 6: Run DRC
         drc_success = run_drc(routed_path)
 
+        # Step 7: Export manufacturing bundle (#3147) so ``kct fleet
+        # status`` reports ``ship_ready=true`` (the bundle's manifest
+        # mtime must be newer than the freshly routed PCB).
+        mfg_success = export_manufacturing_bundle(routed_path, output_dir)
+
         # Summary
         print("\n" + "=" * 60)
         print("SUMMARY")
@@ -1876,6 +1930,7 @@ def main() -> int:
         print(f"  ERC: {'PASS' if erc_success else 'FAIL'}")
         print(f"  Routing: {'SUCCESS' if route_success else 'PARTIAL'}")
         print(f"  DRC: {'PASS' if drc_success else 'FAIL'}")
+        print(f"  MFG bundle: {'PASS' if mfg_success else 'FAIL'}")
         print("\nComponent summary:")
         print("  AC Input: J1, J2, F1, RV1")
         print("  Voltage Sensing: R1, R2")

--- a/tests/test_fleet_ship_ready.py
+++ b/tests/test_fleet_ship_ready.py
@@ -19,11 +19,13 @@ import json
 import os
 from pathlib import Path
 
-from kicad_tools.cli.fleet_cmd import main
+from kicad_tools.cli.fleet_cmd import _survey_board, main
 
 # Re-import the synthetic-board builder from the sibling test module so we
 # stay in lockstep with its fixture coverage and avoid duplication.
 from tests.test_fleet_status import make_fake_board
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # ---------------------------------------------------------------------------
 # ERC report helpers
@@ -605,3 +607,162 @@ class TestShipReadyDispatcher:
         result = run_fleet_command(args)
         # Warn-only -> exit 0 despite the FAIL board.
         assert result == 0
+
+
+class TestManufacturingStaleness:
+    """Issue #3147: lock in the staleness blocker semantics in both directions.
+
+    The root cause of the false-positive ``ship_ready=false`` is that
+    ``_survey_board()`` sets ``mfg.stale = True`` when the routed PCB mtime
+    is newer than ``manufacturing/manifest.json`` (``fleet_cmd.py``:611-616),
+    which becomes the ``"artifacts stale"`` blocker (lines 582-583).
+
+    Option A (this PR) fixes the *recipes* so they regenerate the bundle,
+    keeping the manifest newer than the routed PCB.  These tests guard that
+    the surveyor's staleness logic behaves correctly in both directions so
+    Option A does not weaken the genuine-staleness detection.
+    """
+
+    def test_manifest_newer_than_routed_is_not_stale(self, tmp_path: Path):
+        """Manifest newer than routed PCB -> not stale, no blocker.
+
+        This is the post-``generate_design.py`` state Option A produces:
+        the export step runs after routing, so the manifest mtime exceeds
+        the routed-PCB mtime and the board is ship-ready.
+        """
+        boards = tmp_path / "boards"
+        routed_pcb = make_fake_board(
+            boards,
+            "fresh-board",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+
+        # Force the manifest to be NEWER than the routed PCB (mirrors a
+        # recipe that exports *after* routing).
+        manifest = routed_pcb.parent / "manufacturing" / "manifest.json"
+        routed_mtime = routed_pcb.stat().st_mtime
+        newer = routed_mtime + 3600.0
+        os.utime(manifest, (newer, newer))
+
+        status = _survey_board(boards / "fresh-board", "*_routed.kicad_pcb")
+
+        assert status.manufacturing.stale is False
+        assert "artifacts stale" not in status.blockers
+        assert status.ship_ready is True
+
+    def test_manifest_older_than_routed_is_stale(self, tmp_path: Path):
+        """Manifest older than routed PCB -> stale, blocker still fires.
+
+        Inverse of the above: this is the genuine "you re-routed but did
+        not re-export" condition.  The staleness detection MUST keep firing
+        so Option A does not paper over a real unshippable state.
+        """
+        boards = tmp_path / "boards"
+        routed_pcb = make_fake_board(
+            boards,
+            "stale-board",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+
+        # Force the manifest OLDER than the routed PCB (re-routed, not
+        # re-exported).
+        manifest = routed_pcb.parent / "manufacturing" / "manifest.json"
+        routed_mtime = routed_pcb.stat().st_mtime
+        older = routed_mtime - 3600.0
+        os.utime(manifest, (older, older))
+
+        status = _survey_board(boards / "stale-board", "*_routed.kicad_pcb")
+
+        assert status.manufacturing.stale is True
+        assert "artifacts stale" in status.blockers
+        assert status.ship_ready is False
+
+
+class TestBoardRecipeExportWiring:
+    """Issue #3147: guard that every board recipe wires a ``kct export`` step.
+
+    A lightweight source-level assertion that catches a future recipe edit
+    that drops the export step (which would silently regress the
+    ship-ready status back to the ``"artifacts stale"`` false-positive).
+
+    Boards 03/04/05 already exported before this PR; the other six gained
+    the step in #3147.  All nine are asserted so the invariant holds across
+    the whole fleet (board 05 uses ``design.py`` rather than
+    ``generate_design.py``).
+    """
+
+    # (board sub-path, recipe filename) for every fleet recipe.
+    RECIPES = [
+        ("00-simple-led", "generate_design.py"),
+        ("01-voltage-divider", "generate_design.py"),
+        ("02-charlieplex-led", "generate_design.py"),
+        ("03-usb-joystick", "generate_design.py"),
+        ("04-stm32-devboard", "generate_design.py"),
+        ("05-bldc-motor-controller", "design.py"),
+        ("06-diffpair-test", "generate_design.py"),
+        ("07-matchgroup-test", "generate_design.py"),
+        ("external/softstart", "generate_design.py"),
+    ]
+
+    def test_every_recipe_invokes_kct_export(self):
+        """Each recipe source must contain a ``kct export`` invocation.
+
+        We assert on the ``"export"`` CLI argument appearing alongside the
+        ``kicad_tools.cli`` module path -- the shape every recipe uses to
+        shell out to ``python -m kicad_tools.cli export ...``.
+        """
+        missing: list[str] = []
+        for board_subpath, filename in self.RECIPES:
+            recipe = REPO_ROOT / "boards" / board_subpath / filename
+            assert recipe.exists(), f"recipe not found: {recipe}"
+            text = recipe.read_text()
+            has_module = "kicad_tools.cli" in text
+            has_export_arg = '"export"' in text
+            if not (has_module and has_export_arg):
+                missing.append(board_subpath)
+        assert not missing, (
+            "These board recipes are missing a `kct export` invocation "
+            f"(regression of #3147): {missing}.  Every recipe must "
+            "regenerate the manufacturing bundle after routing so "
+            "`kct fleet status` does not report a false `artifacts stale` "
+            "blocker."
+        )
+
+    def test_six_fixed_recipes_call_export_from_main(self):
+        """The 6 boards fixed in #3147 call the export helper from ``main()``.
+
+        Stronger than the presence check above: confirms the export helper
+        is actually *reached* (a call site exists), not just defined.  The
+        six recipes fixed in #3147 share an ``export_manufacturing_bundle``
+        helper invoked from their ``main()`` flow.
+        """
+        six_fixed = [
+            "00-simple-led",
+            "01-voltage-divider",
+            "02-charlieplex-led",
+            "06-diffpair-test",
+            "07-matchgroup-test",
+            "external/softstart",
+        ]
+        missing_call: list[str] = []
+        for board_subpath in six_fixed:
+            recipe = REPO_ROOT / "boards" / board_subpath / "generate_design.py"
+            text = recipe.read_text()
+            # Helper must be both defined and invoked (a bare definition with
+            # no call site would not keep the manifest fresh).
+            defined = "def export_manufacturing_bundle(" in text
+            called = "export_manufacturing_bundle(routed_path" in text
+            if not (defined and called):
+                missing_call.append(board_subpath)
+        assert not missing_call, (
+            "These #3147 board recipes define but do not call "
+            f"export_manufacturing_bundle() from main(): {missing_call}"
+        )


### PR DESCRIPTION
Closes #3147

## Summary

Six of the nine board recipes re-route their PCB on every run but never re-ran `kct export`, so the committed `output/manufacturing/manifest.json` was older than the routed PCB. `fleet_cmd.py` sets `mfg.stale=True` on that mtime ordering (lines 611-616), which becomes the `"artifacts stale"` ship-ready blocker (lines 582-583). The result: clean boards (01, 02) falsely reported `ship_ready=false`.

This implements the curator's **Option A**: copy the proven export step from boards 03/04/05 into the 6 recipes that lacked it, invoked from `main()` after routing + DRC.

## Changes

Added `export_manufacturing_bundle()` + a `main()` call site (`kct export --mfr jlcpcb --skip-preflight`) to:

- `boards/00-simple-led/generate_design.py`
- `boards/01-voltage-divider/generate_design.py`
- `boards/02-charlieplex-led/generate_design.py`
- `boards/06-diffpair-test/generate_design.py` (in the `--step all` path)
- `boards/07-matchgroup-test/generate_design.py` (in the `--step all` path)
- `boards/external/softstart/generate_design.py`

The export helper mirrors `boards/03-usb-joystick/generate_design.py:1203` exactly (manufacturer-agnostic body, `--skip-preflight` to match boards 03/05's allowlisted-tolerance behavior; harmless on clean boards).

Regression coverage in `tests/test_fleet_ship_ready.py`:

- `TestManufacturingStaleness`: drives `_survey_board()` with `os.utime` in **both directions** — manifest newer than routed PCB asserts `mfg.stale==False` + `ship_ready==True`; manifest older asserts the `"artifacts stale"` blocker still fires (locks in that Option A does not weaken genuine-staleness detection). Modeled on `tests/test_board_05_export.py` / the `make_fake_board` fixture.
- `TestBoardRecipeExportWiring`: source-level guards that every one of the 9 recipes contains a `kct export` invocation, and that the 6 fixed recipes define **and** call `export_manufacturing_bundle()` from `main()` (catches a future recipe edit that drops the step).

## Out of scope (per curator)

- `src/kicad_tools/cli/fleet_cmd.py` — untouched. The `"artifacts stale"` blocker is a correct signal and stays.
- Boards 03/04/05 — already export; untouched.
- No shared helper module introduced (kept the diff reviewable, matches existing per-board convention).

## Verification

Manual end-to-end (ran the recipes, then `kct fleet status --format json`):

| Board | Before | After |
|-------|--------|-------|
| 01-voltage-divider | ship_ready=false (`artifacts stale`) | **ship_ready=true** |
| 02-charlieplex-led | ship_ready=false (`artifacts stale`) | **ship_ready=true** |
| 06-diffpair-test | `incomplete routing` + `artifacts stale` | only `incomplete routing` (genuine, pre-existing) |
| 07-matchgroup-test | `incomplete routing` + `artifacts stale` | only `incomplete routing` (genuine, pre-existing) |
| 00-simple-led | (no output dir) | export step runs; only `incomplete routing` remains (gated on #3148) |

- `uv run pytest tests/test_fleet_ship_ready.py tests/test_fleet_status.py tests/test_fleet_status_drc.py tests/test_board_05_export.py` -> **45 passed, 1 xfailed**.
- Board 00 export runs unconditionally even with PARTIAL routing (verified the manifest is produced), so the wiring is correct once #3148 lands.

### Note on committed board output

This PR commits **only** the recipe + test source. Manufacturing artifacts are deliberately not re-committed: git does not preserve mtimes, so a board's committed manifest/routed-PCB mtime ordering is undefined after `git checkout`. AC #1 is satisfied by *running* `generate_design.py` (which the recipe fix now makes regenerate a current bundle), verified above.

## Test plan

- [x] `_survey_board` staleness regression (both directions, `os.utime`)
- [x] Per-recipe export-wiring source guard (all 9 recipes)
- [x] Manual `generate_design.py` + `kct fleet status` for boards 00/01/02/06/07
- [x] No regression on boards 03/04/05 (untouched) or `fleet_cmd.py` (untouched)
- [x] Targeted fleet + board-export suites pass

## Pre-existing CI notes

`pnpm check:ci` runs `ruff` repo-wide, which has a large pre-existing baseline (823 lint errors, 429 files needing format, ~134 pre-existing pytest failures). The files touched here carry **27 pre-existing ruff F541/F401 errors** (all in `boards/external/softstart` and one line of `boards/02`) — verified identical (27 -> 27) with and without this change, i.e. this PR introduces **zero** new lint/format errors and no new test failures. My added code is fully `ruff format`-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)