### PR TITLE
fix(ci): net-class-map-aware routed-DRC gate for diff-pair/match-group parity

### DIFF
--- a/.github/routed-drc-tolerance.yml
+++ b/.github/routed-drc-tolerance.yml
@@ -551,7 +551,32 @@ tolerances:
   # removed, this floor must be the strict gate.  Exit clause:
   # drop back to 34 (or lower) once #3144 lands and the
   # deterministic CI count is established.
-  boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb: 35
+  #
+  # Floor 35 -> 39 by Issue #3151 (DRC parity).  The strict
+  # error-count gate ``scripts/ci/check_routed_drc.py`` used to
+  # shell out to ``kct check`` with NO ``--net-class-map``, so
+  # the three metadata-gated rule families (diffpair_length_skew,
+  # diffpair_routing_continuity, match_group_length_skew) silently
+  # no-op'd and the gate never counted them on the COMMITTED
+  # routed artifact.  The gate is now net-class-map-aware: board
+  # 06 has no committed ``net_class_map.json`` sidecar, so the
+  # gate derives the map in-process from
+  # ``generate_design.build_net_class_map()`` and threads it via
+  # ``--net-class-map`` (Option B in the issue).  The committed
+  # ``diffpair_test_routed.kicad_pcb`` now measures 39 BLOCKING
+  # errors (45 total - 6 advisory connectivity):
+  #   25 clearance_pad_segment + 2 clearance_pad_via
+  #   + 1 diffpair_clearance_intra            (unchanged, was 28)
+  #   + 5 diffpair_length_skew                (newly counted)
+  #   + 6 diffpair_routing_continuity         (newly counted)
+  #   = 39 blocking.
+  # The +11 is the previously-hidden diff-pair families now being
+  # counted -- NOT a routing regression.  Exit clause unchanged:
+  # the clearance_pad_segment cluster (general fine-grid escape)
+  # and the structural diffpair_clearance_intra residual are the
+  # tightening targets; the diff-pair length/continuity counts
+  # tighten as the board's coupled routing improves.
+  boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb: 39
 
   # Match-group regression testbench (Epic #2661 Phase 3L, #2724).
   # Held at 70 by issue #2781's rect-pad fix.  Two CI jobs measure
@@ -736,6 +761,28 @@ tolerances:
   # back to the deterministic count (which AC4 of #3146 will
   # establish) and remove the soft-fail in the follow-up PR
   # that closes #3146.
+  #
+  # Issue #3151 (DRC parity) note: this floor is SHARED by two
+  # gates that measure different artifacts:
+  #   * ``check_matchgroup_coverage.py`` RE-ROUTES from source and
+  #     can land at 48 on the ubuntu-latest 2-core CI runner (the
+  #     cross-platform variance documented above, tracked by #3146).
+  #     This re-route count is the BINDING constraint on this floor.
+  #   * ``check_routed_drc.py`` measures the COMMITTED
+  #     ``matchgroup_test_routed.kicad_pcb`` artifact.  Issue #3151
+  #     made that gate net-class-map-aware: it now resolves board
+  #     07's committed ``output/net_class_map.json`` sidecar and
+  #     threads it via ``--net-class-map``, so it counts the 3
+  #     previously-missing families (diffpair_length_skew=4,
+  #     diffpair_routing_continuity=4, match_group_length_skew=1).
+  #     The committed-artifact blocking count rose 11 -> 20 (27
+  #     total - 7 advisory connectivity).  20 <= 48, so the gate
+  #     passes; it emits a drift warning (slack=28) flagging the
+  #     gap between the committed artifact and the re-route ceiling.
+  # The floor stays at 48 because it must accommodate the higher
+  # re-route count.  Exit clause: once #3146 lands a deterministic
+  # re-route count, split the committed-artifact floor (~20) from
+  # the re-route floor, or drop both to the deterministic value.
   boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb: 48
 
   # Board 04 (STM32F103C8T6 LQFP-48 devboard).  Tightened 60 -> 12 by

--- a/docs/guides/drc-and-validation.md
+++ b/docs/guides/drc-and-validation.md
@@ -86,6 +86,52 @@ Results:
 DRC PASSED - No violations found
 ```
 
+## CLI: Diff-Pair and Match-Group Rules (`--net-class-map`)
+
+Three DRC rule families need per-net routing metadata that a `.kicad_pcb`
+file does **not** persist on its own (length-match-group membership,
+`coupled_routing` flags, skew tolerances):
+
+- `diffpair_length_skew` — intra-pair length mismatch
+- `diffpair_routing_continuity` — broken / un-coupled diff-pair routing
+- `match_group_length_skew` — length skew across a declared match group
+
+These rules re-derive their working state from a **net-class map** and
+**no-op when no map is supplied**. This is an intentional
+graceful-degradation contract: a bare `kct check` on a board routed by an
+external tool (e.g. Freerouting) will not fire diff-pair / match-group rules
+it cannot meaningfully evaluate. Consequently, on a routed board with
+engaged diff pairs you will see *fewer* errors from a bare `kct check` than
+from the in-pipeline DRC that `generate_design.py` runs.
+
+To enable these rules, pass a net-class-map **sidecar** — a JSON file
+mapping net names to their routing class — via `--net-class-map`:
+
+```bash
+# Bare check: diff-pair / match-group rules no-op (external-router contract)
+kct check board_routed.kicad_pcb --mfr jlcpcb
+
+# With the sidecar: the three gated families fire
+kct check board_routed.kicad_pcb --mfr jlcpcb \
+    --net-class-map output/net_class_map.json
+```
+
+**Sidecar convention.** Boards that exercise these rules emit the sidecar
+next to their routed PCB as `output/net_class_map.json` (see board 07's
+`generate_design.py`, which writes it and then runs `kct check` with the
+flag — that is the entire difference between its in-pipeline error count and
+a bare CLI run). The sidecar is produced from the board's
+`build_net_class_map()` via `net_class_map_to_dict` and consumed via
+`net_class_map_from_dict`.
+
+**CI resolves the map automatically.** The strict routed-PCB DRC gate
+(`scripts/ci/check_routed_drc.py`) is net-class-map-aware: it prefers a
+committed `net_class_map.json` next to the routed PCB and, for boards that
+don't commit one (e.g. board 06), derives it in-process from the board's
+`build_net_class_map()`. This keeps the CI gate's error count in parity with
+the in-pipeline DRC while leaving the standalone `kct check` no-op contract
+unchanged.
+
 ## CLI: Compare Manufacturer Rules
 
 See how different fabs compare:

--- a/scripts/ci/check_diffpair_coverage.py
+++ b/scripts/ci/check_diffpair_coverage.py
@@ -65,7 +65,6 @@ Why a separate script (not folded into ``check_routed_drc.py``):
 from __future__ import annotations
 
 import argparse
-import importlib.util
 import json
 import subprocess
 import sys
@@ -162,8 +161,7 @@ def re_route_board(board_dir: Path, seed: int) -> bool:
     script = board_dir / "generate_design.py"
     if not script.is_file():
         print(
-            f"::error::generate_design.py not found at {script} -- "
-            "cannot re-route board.",
+            f"::error::generate_design.py not found at {script} -- cannot re-route board.",
             flush=True,
         )
         return False
@@ -208,47 +206,19 @@ def find_routed_pcb(board_dir: Path) -> Path | None:
     return candidates[0]
 
 
-def _import_module_from_path(module_name: str, path: Path):
-    """Import a module by file path without adding it to sys.path permanently."""
-    spec = importlib.util.spec_from_file_location(module_name, path)
-    if spec is None or spec.loader is None:
-        raise ImportError(f"Cannot create import spec for {path}")
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = module
-    spec.loader.exec_module(module)
-    return module
+# ``build_net_class_map_for_board`` was promoted to the shared
+# ``net_class_map_resolver`` module (Issue #3151) so both the diff-pair
+# coverage gate and the strict ``check_routed_drc`` error-count gate derive
+# the map the same way.  Re-export it here under the original name so this
+# script's public surface (and its tests) are unchanged.  ``scripts/ci`` is
+# on ``sys.path`` because this file lives in it.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from net_class_map_resolver import build_net_class_map_for_board  # noqa: E402
 
 
-def build_net_class_map_for_board(board_dir: Path) -> dict | None:
-    """Import ``generate_design.build_net_class_map()`` from a board dir.
-
-    Returns ``None`` if the board's ``generate_design.py`` does not
-    expose a ``build_net_class_map`` function (e.g., boards 01-05).
-    In that case the diff-pair routing-continuity rule will degrade to
-    a no-op (the design doesn't declare diff-pair net classes), which is
-    correct behaviour for non-diff-pair boards.
-    """
-    script = board_dir / "generate_design.py"
-    if not script.is_file():
-        return None
-
-    # The board's generate_design.py imports its sibling modules via a
-    # ``sys.path.insert(0, str(Path(__file__).parent))`` -- replicate that
-    # so the import resolves correctly.
-    saved_path = list(sys.path)
-    sys.path.insert(0, str(board_dir))
-    try:
-        mod = _import_module_from_path(
-            f"_diffpair_coverage_generate_design_{board_dir.name.replace('-', '_')}",
-            script,
-        )
-    finally:
-        sys.path[:] = saved_path
-
-    return getattr(mod, "build_net_class_map", lambda: None)()
-
-
-def _measure_skew_data_from_pcb(pcb, engaged_pairs: set[tuple[int, int]]) -> dict[tuple[str, str], float]:
+def _measure_skew_data_from_pcb(
+    pcb, engaged_pairs: set[tuple[int, int]]
+) -> dict[tuple[str, str], float]:
     """Compute per-pair length skew from segments on a routed PCB.
 
     The :class:`~kicad_tools.validate.rules.diffpair_length_skew.DiffPairLengthSkewRule`
@@ -360,9 +330,7 @@ def count_errors_via_kct_check(pcb_path: Path) -> int:
     try:
         data = json.loads(proc.stdout)
     except json.JSONDecodeError as e:
-        raise RuntimeError(
-            f"kct check produced invalid JSON on {pcb_path}: {e}"
-        ) from e
+        raise RuntimeError(f"kct check produced invalid JSON on {pcb_path}: {e}") from e
 
     summary = data.get("summary", {})
     errors = summary.get("errors")
@@ -558,10 +526,7 @@ def check_board(
         annotate_error(str(routed_pcb), msg)
         failed = True
     else:
-        print(
-            f"[diffpair-coverage] OK: all {len(DIFFPAIR_RULE_IDS)} diff-pair "
-            "rules exercised."
-        )
+        print(f"[diffpair-coverage] OK: all {len(DIFFPAIR_RULE_IDS)} diff-pair rules exercised.")
 
     # AC #1 (allowlist semantic): error count must be <= allowed.
     if error_count > allowed:
@@ -585,10 +550,7 @@ def check_board(
         if allowed == 0:
             print("[diffpair-coverage] OK: 0 errors (strict gate).")
         else:
-            print(
-                f"[diffpair-coverage] OK: {error_count} errors "
-                f"(within allowlist max {allowed})."
-            )
+            print(f"[diffpair-coverage] OK: {error_count} errors (within allowlist max {allowed}).")
 
     return 2 if failed else 0
 

--- a/scripts/ci/check_routed_drc.py
+++ b/scripts/ci/check_routed_drc.py
@@ -59,6 +59,16 @@ import yaml
 # ``uv run kct check``) so ``kicad_tools`` is always importable.
 from kicad_tools.validate.checker import DRCChecker  # noqa: E402
 
+# Issue #3151: the strict error-count gate must count the diff-pair and
+# match-group rule families, which only fire when ``kct check`` is given a
+# ``--net-class-map`` sidecar (the rules no-op without one -- the documented
+# graceful-degradation contract).  ``net_class_map_resolver`` lives next to
+# this script in ``scripts/ci``; add that directory to ``sys.path`` so the
+# import works whether the gate is launched as ``scripts/ci/check_routed_drc.py``
+# or imported as a module by the test suite.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from net_class_map_resolver import resolve_net_class_map_sidecar  # noqa: E402
+
 DEFAULT_ALLOWLIST = Path(".github/routed-drc-tolerance.yml")
 DEFAULT_MANUFACTURER = "jlcpcb"
 
@@ -251,6 +261,23 @@ def count_errors(pcb_path: Path, mfr: str = DEFAULT_MANUFACTURER) -> tuple[int, 
     classification.  Advisory findings are returned separately so the gate
     can still surface them in diagnostic output without gating on them.
 
+    Net-class-map awareness (Issue #3151):
+        ``kct check``'s diff-pair (``diffpair_length_skew``,
+        ``diffpair_routing_continuity``) and match-group
+        (``match_group_length_skew``) rules re-derive their working state
+        from a ``net_class_map`` and no-op when none is supplied -- the
+        documented graceful-degradation contract for external-router
+        boards.  ``generate_design.py``'s in-pipeline DRC counts those
+        families because it passes the board's sidecar; the bare ``kct
+        check`` this gate used to run did not, so the strict gate silently
+        missed 3 rule families on routed boards.  This function now
+        resolves a sidecar per board (committed ``net_class_map.json``
+        preferred, in-process ``build_net_class_map`` fallback for boards
+        like 06 that don't commit one) and threads it via ``--net-class-map``
+        so the gate counts the same errors the pipeline does.  Boards with
+        no derivable map (e.g. 01-05) run bare and the rules correctly
+        no-op -- the standalone-CLI contract is untouched.
+
     Args:
         pcb_path: Path to a ``.kicad_pcb`` file.
         mfr: Manufacturer-profile name to pass via ``--mfr`` (defaults to
@@ -279,7 +306,10 @@ def count_errors(pcb_path: Path, mfr: str = DEFAULT_MANUFACTURER) -> tuple[int, 
         "--format",
         "json",
     ]
-    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    with resolve_net_class_map_sidecar(pcb_path) as sidecar:
+        if sidecar is not None:
+            cmd.extend(["--net-class-map", str(sidecar)])
+        proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
 
     # Exit 1 = tool-level failure (file not found, parse error). Exit 0 = no
     # errors. Exit 2 = errors found. Both 0 and 2 produce valid JSON on stdout.

--- a/scripts/ci/net_class_map_resolver.py
+++ b/scripts/ci/net_class_map_resolver.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Net-class-map resolution shared by the routed-PCB CI gates (Issue #3151).
+
+Background
+----------
+
+Three DRC rule families -- ``diffpair_length_skew``,
+``diffpair_routing_continuity`` and ``match_group_length_skew`` -- re-derive
+their working state from ``(pcb, net_class_map)`` and **short-circuit to a
+no-op when ``net_class_map is None``**.  This is the documented
+graceful-degradation contract for external-router boards (#2684, #2652,
+#2675, #2710): a bare ``kct check`` on a Freerouting board must not fire
+diff-pair / match-group rules it cannot meaningfully evaluate.
+
+``kct check`` only populates the map when the user passes
+``--net-class-map <sidecar.json>``.  The strict CI error-count gate
+(:mod:`scripts.ci.check_routed_drc`) historically shelled out to ``kct
+check`` with NO sidecar, so it never counted those three families on
+routed boards -- a real CI-gate gap (Issue #3151).
+
+This module centralises the logic both gates need to close that gap
+WITHOUT changing the standalone-CLI no-op contract:
+
+* :func:`build_net_class_map_for_board` -- import a board's
+  ``generate_design.build_net_class_map()`` to derive the map in-process.
+  Promoted here from ``check_diffpair_coverage.py`` so both gates share one
+  implementation.
+* :func:`resolve_net_class_map_sidecar` -- a context manager that yields a
+  filesystem path suitable for ``--net-class-map``.  It prefers a committed
+  ``net_class_map.json`` sidecar next to the routed PCB (board 07 has one);
+  when none exists (board 06 does NOT commit one) it falls back to
+  in-process derivation, serialising the derived map to a temporary file
+  that is cleaned up on exit.
+
+The standalone ``kct check`` behaviour is unchanged: the no-op contract
+lives in the DRC rules, and this module only affects what the CI gates
+pass on the command line.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+# Canonical name of the committed sidecar a board's generate_design.py may
+# emit next to its routed PCB (Phase 3M pattern; board 07 emits one).
+SIDECAR_FILENAME = "net_class_map.json"
+
+
+def _import_module_from_path(module_name: str, path: Path) -> Any:
+    """Import a module by file path without permanently polluting sys.path."""
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot create import spec for {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def build_net_class_map_for_board(board_dir: Path) -> dict | None:
+    """Import ``generate_design.build_net_class_map()`` from a board dir.
+
+    Returns ``None`` if the board's ``generate_design.py`` does not exist
+    or does not expose a ``build_net_class_map`` function (e.g. boards
+    01-05).  In that case the diff-pair / match-group rules degrade to a
+    no-op, which is correct for non-diff-pair / non-match-group boards.
+
+    Args:
+        board_dir: Path to the board directory (e.g.
+            ``boards/06-diffpair-test``).
+
+    Returns:
+        The ``{net_name: NetClassRouting}`` map, or ``None``.
+    """
+    script = board_dir / "generate_design.py"
+    if not script.is_file():
+        return None
+
+    # The board's generate_design.py imports its sibling modules via a
+    # ``sys.path.insert(0, str(Path(__file__).parent))`` -- replicate that
+    # so the import resolves correctly.
+    saved_path = list(sys.path)
+    sys.path.insert(0, str(board_dir))
+    try:
+        mod = _import_module_from_path(
+            f"_ncm_resolver_generate_design_{board_dir.name.replace('-', '_')}",
+            script,
+        )
+    finally:
+        sys.path[:] = saved_path
+
+    builder = getattr(mod, "build_net_class_map", None)
+    if builder is None:
+        return None
+    return builder()
+
+
+def _board_dir_for_pcb(pcb_path: Path) -> Path:
+    """Return the board directory that owns a routed PCB.
+
+    The repo convention is ``boards/<name>/output/<board>_routed.kicad_pcb``,
+    so the board dir is the PCB's grandparent (``output/`` is the parent).
+    """
+    return pcb_path.resolve().parent.parent
+
+
+@contextlib.contextmanager
+def resolve_net_class_map_sidecar(pcb_path: Path) -> Iterator[Path | None]:
+    """Yield a ``--net-class-map`` sidecar path for a routed PCB.
+
+    Resolution order (Issue #3151, Option B):
+
+    1. **Committed sidecar** -- if ``<pcb_dir>/net_class_map.json`` exists
+       (board 07's ``generate_design.py`` emits one), yield it directly.
+       This is the same sidecar the board's in-pipeline ``run_drc`` uses,
+       so the CI gate counts exactly what ``generate_design.py`` counts.
+    2. **In-process derivation** -- otherwise import the board's
+       ``generate_design.build_net_class_map()`` and serialise the result
+       to a temporary JSON file (board 06 has no committed sidecar).  The
+       temp file is removed on context exit.
+    3. **No map** -- if neither path yields a map (non-diff-pair boards
+       like 01-05), yield ``None``; the caller runs ``kct check`` with no
+       sidecar and the rules correctly no-op.
+
+    Args:
+        pcb_path: Path to a ``*_routed.kicad_pcb`` file.
+
+    Yields:
+        A ``Path`` to a sidecar JSON usable with ``--net-class-map``, or
+        ``None`` when no net_class_map is available for this board.
+    """
+    pcb_path = Path(pcb_path)
+
+    # (1) Prefer a committed sidecar adjacent to the routed PCB.
+    committed = pcb_path.resolve().parent / SIDECAR_FILENAME
+    if committed.is_file():
+        yield committed
+        return
+
+    # (2) Fall back to in-process derivation from the board recipe.
+    board_dir = _board_dir_for_pcb(pcb_path)
+    try:
+        net_class_map = build_net_class_map_for_board(board_dir)
+    except Exception:
+        # A board whose recipe cannot be imported (or which raises while
+        # building the map) is treated as "no map available" -- the gate
+        # then runs bare, preserving the pre-3151 behaviour for that board
+        # rather than crashing the whole CI run.
+        net_class_map = None
+
+    if not net_class_map:
+        yield None
+        return
+
+    # Serialise the derived map to a temp sidecar for ``--net-class-map``.
+    # ``mkstemp`` returns an OS-level fd we close immediately after writing;
+    # the file outlives the open handle (the subprocess reads it by path)
+    # and is unlinked on context exit.
+    from kicad_tools.router.rules import net_class_map_to_dict
+
+    fd, tmp_name = tempfile.mkstemp(suffix=f"_{board_dir.name}_net_class_map.json")
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            json.dump(net_class_map_to_dict(net_class_map), fh, indent=2)
+        yield tmp_path
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            tmp_path.unlink()

--- a/tests/test_kct_check_parity.py
+++ b/tests/test_kct_check_parity.py
@@ -1,0 +1,358 @@
+"""DRC parity regression tests for ``kct check`` net_class_map handling.
+
+Issue #3151.  Three DRC rule families re-derive their working state from a
+``net_class_map`` and **no-op when none is supplied** -- the documented
+graceful-degradation contract for external-router boards (#2684, #2652,
+#2675, #2710):
+
+    * ``diffpair_length_skew``
+    * ``diffpair_routing_continuity``
+    * ``match_group_length_skew``
+
+``kct check`` only populates the map when ``--net-class-map <sidecar>`` is
+passed.  The in-pipeline DRC in ``generate_design.py::run_drc`` IS the same
+``kct check`` call plus the sidecar, which is the entire 18-vs-27 delta on
+board 07.  Before #3151 the strict CI gate
+(``scripts/ci/check_routed_drc.py``) shelled out to ``kct check`` with NO
+sidecar, so it silently missed those three families on routed boards.
+
+These tests pin two contracts so a future silent-no-op regression (cf.
+#3098 / PR #3145) is caught:
+
+1. **No-op contract (must be PRESERVED):** bare ``kct check`` on board 07's
+   routed PCB reports ZERO of the three families.  External-router boards
+   rely on this -- it must never start firing diff-pair / match-group rules
+   without a net_class_map.
+2. **Parity (the fix):** ``kct check --net-class-map <sidecar>`` reports the
+   bare error set PLUS exactly the three families, with the family-level
+   counts pinned (diffpair_length_skew=4, diffpair_routing_continuity=4,
+   match_group_length_skew=1 on board 07).
+
+It also exercises the CI gate's net-class-map resolver
+(``scripts/ci/net_class_map_resolver.py``) directly: committed-sidecar
+preference, in-process fallback for boards (like 06) that don't commit one,
+and ``None`` for boards that declare no net classes.
+
+The real-``kct check`` parity checks are marked ``integration`` + ``slow``
+(they run the full DRC engine on a routed BGA board, ~30s each).  The
+resolver unit tests are fast (temp dirs + a tiny derived map) and always
+run.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CI_DIR = REPO_ROOT / "scripts" / "ci"
+
+BOARD_07_PCB = (
+    REPO_ROOT / "boards" / "07-matchgroup-test" / "output" / "matchgroup_test_routed.kicad_pcb"
+)
+BOARD_07_SIDECAR = REPO_ROOT / "boards" / "07-matchgroup-test" / "output" / "net_class_map.json"
+
+# The three rule families gated on the net_class_map.  Pinning these by name
+# is the load-bearing assertion: a regression that disables any one of them
+# would drop it from the WITH-sidecar set and fail this test.
+NET_CLASS_GATED_FAMILIES: tuple[str, ...] = (
+    "diffpair_length_skew",
+    "diffpair_routing_continuity",
+    "match_group_length_skew",
+)
+
+# Expected per-family counts on board 07's committed routed artifact
+# (reproduced 2026-05-28 on current main after ``kct build-native --force``).
+# These are the exact "18 -> 27" delta the issue documents.
+BOARD_07_EXPECTED_FAMILY_DELTA: dict[str, int] = {
+    "diffpair_length_skew": 4,
+    "diffpair_routing_continuity": 4,
+    "match_group_length_skew": 1,
+}
+
+
+def _load_resolver_module():
+    """Import ``scripts/ci/net_class_map_resolver.py`` as a module."""
+    path = CI_DIR / "net_class_map_resolver.py"
+    spec = importlib.util.spec_from_file_location("net_class_map_resolver_test_mod", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["net_class_map_resolver_test_mod"] = module
+    # The resolver itself adds scripts/ci to sys.path for its own imports.
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run_kct_check(pcb: Path, sidecar: Path | None) -> dict:
+    """Run ``kct check ... --errors-only --format json`` and parse the JSON.
+
+    Mirrors the exact invocation used by ``scripts/ci/check_routed_drc.py``
+    and board 07's ``generate_design.py::run_drc`` so the parity comparison
+    is apples-to-apples.
+    """
+    cmd = [
+        "uv",
+        "run",
+        "kct",
+        "check",
+        str(pcb),
+        "--mfr",
+        "jlcpcb",
+        "--errors-only",
+        "--format",
+        "json",
+    ]
+    if sidecar is not None:
+        cmd.extend(["--net-class-map", str(sidecar)])
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False, cwd=REPO_ROOT)
+    assert proc.returncode in (0, 2), (
+        f"kct check exited {proc.returncode} on {pcb}.\nstderr:\n{proc.stderr}"
+    )
+    return json.loads(proc.stdout)
+
+
+def _family_counts(payload: dict) -> Counter:
+    """Counter of error-severity violations keyed by rule_id."""
+    return Counter(
+        v.get("rule_id")
+        for v in payload.get("violations", [])
+        if v.get("severity", "error") == "error"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Resolver unit tests (fast -- no real kct check)
+# ---------------------------------------------------------------------------
+
+
+class TestNetClassMapResolver:
+    """The CI gate's net_class_map resolution logic (Issue #3151, Option B)."""
+
+    def test_prefers_committed_sidecar(self, tmp_path: Path) -> None:
+        """A committed ``net_class_map.json`` next to the PCB is used directly."""
+        resolver = _load_resolver_module()
+        out = tmp_path / "boards" / "demo" / "output"
+        out.mkdir(parents=True)
+        pcb = out / "demo_routed.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+        sidecar = out / "net_class_map.json"
+        sidecar.write_text("{}")
+
+        with resolver.resolve_net_class_map_sidecar(pcb) as resolved:
+            assert resolved is not None
+            assert resolved.resolve() == sidecar.resolve()
+
+    def test_in_process_fallback_when_no_sidecar(self, tmp_path: Path, monkeypatch) -> None:
+        """No committed sidecar -> derive the map in-process to a temp file.
+
+        The temp file must exist (and contain the derived map) inside the
+        context, and be cleaned up on exit.
+        """
+        resolver = _load_resolver_module()
+        out = tmp_path / "boards" / "demo" / "output"
+        out.mkdir(parents=True)
+        pcb = out / "demo_routed.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+
+        from kicad_tools.router.rules import NetClassRouting
+
+        derived = {"NET_A": NetClassRouting(name="DiffPair", coupled_routing=True)}
+        monkeypatch.setattr(resolver, "build_net_class_map_for_board", lambda board_dir: derived)
+
+        with resolver.resolve_net_class_map_sidecar(pcb) as resolved:
+            assert resolved is not None
+            assert resolved != (out / "net_class_map.json")
+            assert resolved.is_file()
+            data = json.loads(resolved.read_text())
+            assert "NET_A" in data
+            tmp_name = resolved
+
+        # Cleaned up on exit.
+        assert not tmp_name.exists()
+
+    def test_none_when_no_map_available(self, tmp_path: Path, monkeypatch) -> None:
+        """A board with no committed sidecar AND no derivable map yields None.
+
+        This is the path that preserves the standalone-CLI no-op contract for
+        external-router boards: the gate runs bare and the rules no-op.
+        """
+        resolver = _load_resolver_module()
+        out = tmp_path / "boards" / "demo" / "output"
+        out.mkdir(parents=True)
+        pcb = out / "demo_routed.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+
+        monkeypatch.setattr(resolver, "build_net_class_map_for_board", lambda board_dir: None)
+
+        with resolver.resolve_net_class_map_sidecar(pcb) as resolved:
+            assert resolved is None
+
+    def test_build_failure_degrades_to_none(self, tmp_path: Path, monkeypatch) -> None:
+        """If the board recipe raises while building the map, run bare (not crash)."""
+        resolver = _load_resolver_module()
+        out = tmp_path / "boards" / "demo" / "output"
+        out.mkdir(parents=True)
+        pcb = out / "demo_routed.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+
+        def _boom(board_dir):
+            raise RuntimeError("recipe import blew up")
+
+        monkeypatch.setattr(resolver, "build_net_class_map_for_board", _boom)
+
+        with resolver.resolve_net_class_map_sidecar(pcb) as resolved:
+            assert resolved is None
+
+    def test_board_07_resolves_committed_sidecar(self) -> None:
+        """Board 07's real PCB resolves to its committed sidecar."""
+        if not BOARD_07_PCB.is_file():
+            pytest.skip("board 07 routed PCB not present")
+        assert BOARD_07_SIDECAR.is_file(), "board 07 should ship a committed sidecar"
+        resolver = _load_resolver_module()
+        with resolver.resolve_net_class_map_sidecar(BOARD_07_PCB) as resolved:
+            assert resolved is not None
+            assert resolved.resolve() == BOARD_07_SIDECAR.resolve()
+
+    def test_board_06_resolves_in_process(self) -> None:
+        """Board 06 has no committed sidecar -> the resolver derives one."""
+        pcb = (
+            REPO_ROOT / "boards" / "06-diffpair-test" / "output" / "diffpair_test_routed.kicad_pcb"
+        )
+        committed = pcb.parent / "net_class_map.json"
+        if not pcb.is_file():
+            pytest.skip("board 06 routed PCB not present")
+        assert not committed.exists(), (
+            "board 06 is expected to have NO committed sidecar (the in-process "
+            "fallback is what this test exercises)"
+        )
+        resolver = _load_resolver_module()
+        with resolver.resolve_net_class_map_sidecar(pcb) as resolved:
+            assert resolved is not None
+            # Derived to a temp file, not the (absent) committed location.
+            assert resolved != committed
+            data = json.loads(resolved.read_text())
+            assert len(data) > 0, "board 06's derived map should be non-empty"
+
+
+# ---------------------------------------------------------------------------
+# Real kct check parity (integration / slow)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+class TestBoard07KctCheckParity:
+    """End-to-end parity on board 07's committed routed PCB (Issue #3151).
+
+    Runs the real ``kct check`` engine both ways.  Slow (~30s/invocation) so
+    it is gated behind ``integration``/``slow``; deselect with
+    ``-m 'not slow'``.
+    """
+
+    @pytest.fixture(scope="class")
+    def bare(self) -> dict:
+        if not BOARD_07_PCB.is_file():
+            pytest.skip("board 07 routed PCB not present")
+        return _run_kct_check(BOARD_07_PCB, sidecar=None)
+
+    @pytest.fixture(scope="class")
+    def with_sidecar(self) -> dict:
+        if not (BOARD_07_PCB.is_file() and BOARD_07_SIDECAR.is_file()):
+            pytest.skip("board 07 routed PCB / sidecar not present")
+        return _run_kct_check(BOARD_07_PCB, sidecar=BOARD_07_SIDECAR)
+
+    def test_bare_check_noop_contract_preserved(self, bare: dict) -> None:
+        """Bare ``kct check`` reports ZERO of the net-class-gated families.
+
+        This is the graceful-degradation contract external-router boards
+        rely on; it must NEVER regress to firing these rules without a map.
+        """
+        counts = _family_counts(bare)
+        for family in NET_CLASS_GATED_FAMILIES:
+            assert counts.get(family, 0) == 0, (
+                f"bare kct check fired {family!r} without a net_class_map -- "
+                "the standalone no-op contract regressed (see Issue #3151)"
+            )
+
+    def test_sidecar_adds_exactly_the_three_families(self, bare: dict, with_sidecar: dict) -> None:
+        """WITH-sidecar set == bare set PLUS exactly the three families.
+
+        Pins the family-level delta so a silent-no-op regression in any one
+        rule is caught (cf. #3098 / PR #3145).
+        """
+        bare_counts = _family_counts(bare)
+        sidecar_counts = _family_counts(with_sidecar)
+
+        # Every family present bare must be unchanged with the sidecar
+        # (the sidecar only ADDS the gated families, it must not perturb the
+        # clearance/connectivity families).
+        for family, count in bare_counts.items():
+            assert sidecar_counts.get(family, 0) == count, (
+                f"sidecar perturbed an unrelated family {family!r}: "
+                f"bare={count} sidecar={sidecar_counts.get(family, 0)}"
+            )
+
+        # The added families are EXACTLY the three gated families.
+        added = {
+            family
+            for family in sidecar_counts
+            if sidecar_counts[family] > bare_counts.get(family, 0)
+        }
+        assert added == set(NET_CLASS_GATED_FAMILIES), (
+            f"sidecar added {sorted(added)}; expected exactly {sorted(NET_CLASS_GATED_FAMILIES)}"
+        )
+
+    def test_family_delta_counts_pinned(self, bare: dict, with_sidecar: dict) -> None:
+        """The per-family counts match the documented 18->27 delta."""
+        bare_counts = _family_counts(bare)
+        sidecar_counts = _family_counts(with_sidecar)
+        for family, expected in BOARD_07_EXPECTED_FAMILY_DELTA.items():
+            delta = sidecar_counts.get(family, 0) - bare_counts.get(family, 0)
+            assert delta == expected, (
+                f"{family!r} delta was {delta}, expected {expected} "
+                "(re-baseline this test AND the tolerance floor together "
+                "if the routed artifact legitimately changed)"
+            )
+
+    def test_total_error_count_delta(self, bare: dict, with_sidecar: dict) -> None:
+        """Total error count rises by the sum of the three family deltas."""
+        bare_total = bare["summary"]["errors"]
+        sidecar_total = with_sidecar["summary"]["errors"]
+        assert sidecar_total - bare_total == sum(BOARD_07_EXPECTED_FAMILY_DELTA.values())
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+class TestCiGateCountsGatedFamilies:
+    """The strict CI gate now counts the gated families (Issue #3151 AC #1)."""
+
+    def _load_gate(self):
+        path = CI_DIR / "check_routed_drc.py"
+        spec = importlib.util.spec_from_file_location("check_routed_drc_test_mod", path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules["check_routed_drc_test_mod"] = module
+        spec.loader.exec_module(module)
+        return module
+
+    def test_board_07_gate_counts_diffpair_and_matchgroup(self) -> None:
+        """``check_routed_drc.count_errors`` on board 07 includes the families.
+
+        Before #3151 the gate ran bare and saw 11 blocking errors; now it
+        resolves the sidecar and sees 20 (the +9 = 4+4+1 gated-family errors).
+        """
+        if not BOARD_07_PCB.is_file():
+            pytest.skip("board 07 routed PCB not present")
+        gate = self._load_gate()
+        blocking, advisory = gate.count_errors(BOARD_07_PCB)
+        # 27 total - 7 advisory connectivity = 20 blocking.
+        assert blocking == 20, (
+            f"expected 20 blocking errors with net_class_map awareness, got {blocking}"
+        )
+        assert advisory.get("connectivity", 0) == 7


### PR DESCRIPTION
## Summary

Closes #3151.

The strict routed-PCB DRC gate (`scripts/ci/check_routed_drc.py`) shelled out to `kct check` with **no** `--net-class-map`, so three metadata-gated rule families silently no-op'd and were never counted on routed boards:

- `diffpair_length_skew`
- `diffpair_routing_continuity`
- `match_group_length_skew`

`generate_design.py`'s in-pipeline DRC counts them because it passes the board's sidecar -- that sidecar is the entire 18-vs-27 delta on board 07. The gate is now net-class-map-aware (curator's recommended **Option B**), so it counts the same errors the pipeline does, while the standalone `kct check` no-op contract is left untouched.

## Changes

- **`scripts/ci/net_class_map_resolver.py` (new, shared):** promotes `build_net_class_map_for_board()` out of `check_diffpair_coverage.py` and adds `resolve_net_class_map_sidecar()` -- a context manager that:
  1. prefers a committed `net_class_map.json` next to the routed PCB (board 07 ships one),
  2. falls back to in-process derivation from `build_net_class_map()` for boards that don't (board 06), serialised to a temp file,
  3. yields `None` for boards with no net classes (01-05) so the gate runs bare and the rules correctly no-op.
- **`scripts/ci/check_routed_drc.py`:** `count_errors` threads the resolved sidecar via `--net-class-map`.
- **`scripts/ci/check_diffpair_coverage.py`:** re-uses the shared helper (no behavior change).
- **`tests/test_kct_check_parity.py` (new):** fast resolver unit tests + integration/slow parity tests pinning the board-07 family-level delta and asserting the bare no-op contract is preserved.
- **`docs/guides/drc-and-validation.md`:** new `--net-class-map` / sidecar / no-op-contract section (previously zero mentions).

## Tolerance re-baseline (justification per the allowlist's "loosening requires justification" rule)

These floors are **post-advisory-filter blocking counts** (advisory `connectivity` excluded), measured on the **committed** routed artifacts:

| Board | Old floor | New gate count | New floor | Why |
|-------|-----------|----------------|-----------|-----|
| 06 | 35 | **39** blocking | **39** | +11 = the previously-hidden families now counted (5 `diffpair_length_skew` + 6 `diffpair_routing_continuity`), **not** a routing regression. 35 -> 39 because the gate now sees them. |
| 07 | 48 | **20** blocking | **48** (unchanged) | The 48 floor is shared with the `matchgroup-routing-regression` re-route gate, which can land at 48 on the 2-core CI runner (variance tracked by #3146) -- that re-route count is the binding constraint. The committed-artifact count rose 11 -> 20 (+4+4+1) and passes 48 with a documented drift warning. |

Both YAML entries gain inline commentary explaining the bump and the exit clauses.

## Acceptance criteria

1. Gate counts diff-pair + match-group errors for boards 06 (39) and 07 (20). Verified by running `check_routed_drc.py` on both.
2. Floors re-baselined (board 06 -> 39; board 07 stays 48 with rationale).
3. Standalone `kct check` no-op contract preserved -- regression test asserts bare `kct check` on board 07 reports **zero** of the three families.
4. New `tests/test_kct_check_parity.py` pins the family-level delta (4/4/1 on board 07) and the total 18->27 count.
5. Doc note added in `docs/guides/drc-and-validation.md`.

## Test plan

- [x] Manual: bare `kct check` board 07 = 18; `--net-class-map` = 27 (adds 4/4/1).
- [x] Manual: `check_routed_drc.py` on board 06 (39, pass) and board 07 (20, pass).
- [x] Manual: `check_diffpair_coverage.py --skip-route boards/06-diffpair-test` still passes (all 3 rules exercised, 34 <= 39).
- [x] `tests/test_kct_check_parity.py` (11 tests: 6 fast + 5 integration/slow) all pass.
- [x] No regression in related CI-gate / board-07 test files (173 tests pass).
- [x] Changed Python files pass `ruff check` + `ruff format --check`.

## Notes

- Sibling PR #3150 in this /sweep wave also touches `.github/routed-drc-tolerance.yml` (board-03 section). Different sections (this PR touches board 06 line ~554 and board 07 line ~739), but a clean rebase may be needed if #3150 merges first.
- Repo-wide `pnpm check:ci` reports pre-existing `ruff`/format failures unrelated to this change; my changed files are clean.

Generated with Claude Code