### PR TITLE
feat(sync): wire schematic/PCB drift detection into route + check (closes #3154)

### DIFF
--- a/src/kicad_tools/audit/auditor.py
+++ b/src/kicad_tools/audit/auditor.py
@@ -510,28 +510,20 @@ class ManufacturingAudit:
         Resolution order:
         1. Check project.kct for artifacts.schematic
         2. Default to <basename>.kicad_sch
+
+        Delegates the project.kct + sibling lookup to the shared
+        :func:`kicad_tools.sync.discover.resolve_schematic_for_pcb` helper so
+        ``kct audit``, ``kct route``, and ``kct check`` agree on where the
+        schematic lives.  When the helper finds nothing, falls back to the
+        historical project-basename default so existing behaviour is preserved.
         """
-        project_dir = self.path.parent
+        from kicad_tools.sync.discover import resolve_schematic_for_pcb
 
-        # 1. Try to find project.kct and use artifacts.schematic
-        kct_path = project_dir / "project.kct"
-        if not kct_path.exists():
-            kct_path = project_dir.parent / "project.kct"
+        resolved = resolve_schematic_for_pcb(self.pcb_path)
+        if resolved is not None:
+            return resolved
 
-        if kct_path.exists():
-            try:
-                from kicad_tools.spec import load_spec
-
-                spec = load_spec(kct_path)
-                if spec.project and spec.project.artifacts and spec.project.artifacts.schematic:
-                    sch_path = kct_path.parent / spec.project.artifacts.schematic
-                    if sch_path.exists():
-                        logger.debug(f"Using schematic from project.kct: {sch_path}")
-                        return sch_path
-            except Exception as e:
-                logger.debug(f"Failed to load project.kct: {e}")
-
-        # 2. Default to <basename>.kicad_sch
+        # Fall back to <project-basename>.kicad_sch (historical default).
         return self.path.with_suffix(".kicad_sch")
 
     def _read_assembly_mode(self) -> str | None:

--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -57,6 +57,73 @@ def _find_pcb_file(directory: Path) -> Path | None:
     return None
 
 
+def _emit_drift_banner(pcb_path: Path, schematic: str | None) -> None:
+    """Print the advisory schematic/PCB drift banner (non-blocking).
+
+    No-op when no schematic can be resolved or the PCB is in sync.  This is
+    advisory only and never affects the caller's exit code (issue #3154).
+    """
+    from kicad_tools.sync.drift import analyze_drift, format_drift_banner
+
+    analysis, _resolved = analyze_drift(pcb_path, schematic)
+    if analysis is None:
+        return
+    banner = format_drift_banner(analysis, pcb_path)
+    if banner:
+        print(banner)
+
+
+def run_netlist_sync_gate(
+    pcb_path: Path,
+    schematic: str | None = None,
+    strict: bool = False,
+) -> int:
+    """Run the blocking schematic/PCB netlist-sync gate (issue #3154).
+
+    Reuses :class:`kicad_tools.sync.reconciler.Reconciler` (via the shared
+    drift helpers) to compare the schematic component set against the PCB
+    footprint set, then prints a full add/drop/orphan report.
+
+    Exit codes (mirroring ``kct check``'s convention):
+        0 - in sync, or only PCB-only/value/footprint drift without --strict
+        1 - no schematic could be resolved (cannot run the gate)
+        2 - components present in the schematic are missing from the PCB
+            (unbuildable BOM), or any drift with --strict
+
+    Args:
+        pcb_path: Path to the ``.kicad_pcb`` file.
+        schematic: Optional explicit schematic path override.
+        strict: When True, any drift (including PCB-only/value/footprint)
+            yields exit code 2.
+    """
+    from kicad_tools.sync.drift import analyze_drift, has_drift, render_drift_report
+
+    analysis, resolved = analyze_drift(pcb_path, schematic)
+    if analysis is None or resolved is None:
+        print(
+            "Error: --netlist-sync requires a schematic, but none was found "
+            f"for {Path(pcb_path).name}.",
+            file=sys.stderr,
+        )
+        print(
+            "Hint: pass --schematic <path>.kicad_sch, or place a sibling "
+            "<basename>.kicad_sch next to the PCB.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(render_drift_report(analysis, pcb_path, resolved))
+
+    # Schematic-only drift == unbuildable BOM == blocking (mirrors the
+    # auditor's NOT_READY verdict rule).  PCB-only / value / footprint drift
+    # is advisory unless --strict.
+    if analysis.schematic_orphans:
+        return 2
+    if strict and has_drift(analysis):
+        return 2
+    return 0
+
+
 CHECK_CATEGORIES = [
     "clearance",
     "connectivity",
@@ -155,6 +222,27 @@ def main(argv: list[str] | None = None) -> int:
         help="Suppress silkscreen warnings from standard KiCad library footprints",
     )
     parser.add_argument(
+        "--netlist-sync",
+        action="store_true",
+        help=(
+            "Run a blocking schematic/PCB netlist-sync gate (issue #3154). "
+            "Compares the schematic component set against the PCB footprint set "
+            "via the Reconciler and prints a full add/drop/orphan report. Exits "
+            "with code 2 when components present in the schematic are missing "
+            "from the PCB (unbuildable BOM). PCB-only/value/footprint drift is a "
+            "warning unless --strict. Skips silently if no schematic is found."
+        ),
+    )
+    parser.add_argument(
+        "--schematic",
+        default=None,
+        help=(
+            "Explicit path to the .kicad_sch file for the netlist-sync gate / "
+            "advisory drift banner. When omitted, the schematic is "
+            "auto-discovered from project.kct or the sibling <basename>.kicad_sch."
+        ),
+    )
+    parser.add_argument(
         "--net-class-map",
         dest="net_class_map",
         default=None,
@@ -242,11 +330,27 @@ def main(argv: list[str] | None = None) -> int:
     else:
         pcb_path = input_path
 
+    # Netlist-sync gate (issue #3154): a dedicated, blocking schematic/PCB
+    # drift check that runs *instead of* the DRC pipeline and returns its own
+    # exit code.  Reuses the Reconciler via the shared drift helpers.
+    if getattr(args, "netlist_sync", False):
+        return run_netlist_sync_gate(
+            pcb_path,
+            schematic=getattr(args, "schematic", None),
+            strict=args.strict,
+        )
+
     try:
         pcb = PCB.load(pcb_path)
     except Exception as e:
         print(f"Error loading PCB: {e}", file=sys.stderr)
         return 1
+
+    # Advisory drift banner (issue #3154): when a schematic is discovered (or
+    # passed via --schematic) and the component sets have drifted, print a
+    # one-line, non-blocking warning before running DRC.  Never affects the
+    # exit code on the default run -- the hard gate lives behind --netlist-sync.
+    _emit_drift_banner(pcb_path, getattr(args, "schematic", None))
 
     # Auto-detect layer count from PCB if not explicitly provided
     if args.layers is not None:

--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -253,6 +253,12 @@ def run_route_command(args) -> int:
         sub_argv.append("--high-performance")
     if getattr(args, "skip_drc", False):
         sub_argv.append("--skip-drc")
+    # Issue #3154: forward the advisory drift-banner flags.  --sync-check
+    # defaults on; forward --no-sync-check only when explicitly disabled.
+    if getattr(args, "sync_check", True) is False:
+        sub_argv.append("--no-sync-check")
+    if getattr(args, "schematic", None):
+        sub_argv.extend(["--schematic", args.schematic])
     if getattr(args, "auto_fix", False):
         sub_argv.append("--auto-fix")
     if getattr(args, "auto_fix_passes", None) is not None:

--- a/src/kicad_tools/cli/commands/validation.py
+++ b/src/kicad_tools/cli/commands/validation.py
@@ -223,6 +223,11 @@ def run_check_command(args) -> int:
         sub_argv.extend(["--output", args.output])
     if getattr(args, "suppress_library", False):
         sub_argv.append("--suppress-library")
+    # Issue #3154: forward the netlist-sync gate flags.
+    if getattr(args, "netlist_sync", False):
+        sub_argv.append("--netlist-sync")
+    if getattr(args, "schematic", None):
+        sub_argv.extend(["--schematic", args.schematic])
     if getattr(args, "net_class_map", None):
         sub_argv.extend(["--net-class-map", args.net_class_map])
     # Issue #3061: forward pad_grid tolerance flags.

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -418,6 +418,24 @@ def _add_check_parser(subparsers) -> None:
         help="Suppress silkscreen warnings from standard KiCad library footprints",
     )
     check_parser.add_argument(
+        "--netlist-sync",
+        action="store_true",
+        help=(
+            "Run a blocking schematic/PCB netlist-sync gate (issue #3154): "
+            "compares the schematic component set against the PCB footprint "
+            "set and exits with code 2 when schematic components are missing "
+            "from the PCB. Skips silently if no schematic is found."
+        ),
+    )
+    check_parser.add_argument(
+        "--schematic",
+        default=None,
+        help=(
+            "Explicit .kicad_sch path for --netlist-sync / the advisory drift "
+            "banner (default: auto-discover from project.kct or sibling file)."
+        ),
+    )
+    check_parser.add_argument(
         "--net-class-map",
         dest="net_class_map",
         default=None,
@@ -2564,6 +2582,28 @@ def _add_route_parser(subparsers) -> None:
             "Skip post-routing DRC validation. By default, the router runs "
             "a DRC check after routing and warns about violations. Use this "
             "flag for performance-critical use or when running separate validation."
+        ),
+    )
+    # Issue #3154: advisory schematic/PCB drift banner.  Mirror of the inner
+    # route_cmd.py flags; both sites must stay in sync per
+    # ``tests/test_cli_parser_drift.py``.
+    route_parser.add_argument(
+        "--sync-check",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Print an advisory banner when the PCB footprint set has drifted "
+            "from the schematic netlist (default: enabled, non-blocking). Use "
+            "--no-sync-check to suppress. See 'kct check --netlist-sync' for a "
+            "blocking gate."
+        ),
+    )
+    route_parser.add_argument(
+        "--schematic",
+        default=None,
+        help=(
+            "Explicit .kicad_sch path for the advisory drift banner "
+            "(default: auto-discover from project.kct or sibling file)."
         ),
     )
     route_parser.add_argument(

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -5051,6 +5051,30 @@ def main(argv: list[str] | None = None) -> int:
             "flag for performance-critical use or when running separate validation."
         ),
     )
+    # Issue #3154: advisory schematic/PCB drift banner.  When a schematic is
+    # auto-discovered (or passed via --schematic) and the component sets have
+    # drifted, kct route prints a one-line, non-blocking warning before
+    # routing so an engineer is not lulled by a "65% routed" number on a board
+    # that is missing a third of the netlist.  --no-sync-check opts out.
+    parser.add_argument(
+        "--sync-check",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Print an advisory banner when the PCB footprint set has drifted "
+            "from the schematic netlist (default: enabled). The banner is "
+            "non-blocking; use --no-sync-check to suppress it. See "
+            "'kct check --netlist-sync' for a blocking gate."
+        ),
+    )
+    parser.add_argument(
+        "--schematic",
+        default=None,
+        help=(
+            "Explicit .kicad_sch path for the advisory drift banner "
+            "(default: auto-discover from project.kct or sibling file)."
+        ),
+    )
     parser.add_argument(
         "--manufacturer",
         "--mfr",
@@ -5652,6 +5676,22 @@ def main(argv: list[str] | None = None) -> int:
 
     if pcb_path.suffix != ".kicad_pcb":
         print(f"Warning: Expected .kicad_pcb file, got {pcb_path.suffix}")
+
+    # Issue #3154: advisory schematic/PCB drift banner.  Non-blocking -- the
+    # hard gate lives behind 'kct check --netlist-sync'.  Skips silently when
+    # no schematic is discovered, when in sync, or when --no-sync-check / --quiet.
+    if getattr(args, "sync_check", True) and not getattr(args, "quiet", False):
+        try:
+            from kicad_tools.sync.drift import analyze_drift, format_drift_banner
+
+            _drift_analysis, _ = analyze_drift(pcb_path, getattr(args, "schematic", None))
+            if _drift_analysis is not None:
+                _banner = format_drift_banner(_drift_analysis, pcb_path)
+                if _banner:
+                    print(_banner)
+        except Exception:
+            # Drift detection is advisory; never let it block routing.
+            pass
 
     # Issue #2996: Validate and load the optional --net-class-map sidecar
     # early -- before dispatching to any of the route_with_* sub-flows --

--- a/src/kicad_tools/sync/__init__.py
+++ b/src/kicad_tools/sync/__init__.py
@@ -10,6 +10,13 @@ Key classes:
     Reconciler - Orchestrates analysis and application of fixes
 """
 
+from .discover import resolve_schematic_for_pcb
+from .drift import (
+    analyze_drift,
+    format_drift_banner,
+    has_drift,
+    render_drift_report,
+)
 from .reconciler import (
     Reconciler,
     SyncAnalysis,
@@ -20,4 +27,9 @@ __all__ = [
     "Reconciler",
     "SyncAnalysis",
     "SyncMatch",
+    "analyze_drift",
+    "format_drift_banner",
+    "has_drift",
+    "render_drift_report",
+    "resolve_schematic_for_pcb",
 ]

--- a/src/kicad_tools/sync/discover.py
+++ b/src/kicad_tools/sync/discover.py
@@ -1,0 +1,85 @@
+"""Schematic discovery helper for PCB-only command entry points.
+
+Commands like ``kct route`` and ``kct check`` receive only a ``.kicad_pcb``
+path, but schematic/PCB drift detection (the :class:`Reconciler`) needs both
+files.  This module factors out the single schematic-resolution heuristic so
+``route``, ``check``, and ``audit`` all agree on where the schematic lives.
+
+Resolution order (matches the historical ``Auditor._resolve_schematic_path``):
+    1. ``project.kct`` ``artifacts.schematic`` (looked up next to the PCB, then
+       one directory up), if it points at an existing file.
+    2. Sibling ``<pcb-basename>.kicad_sch``.
+
+A PCB basename may carry pipeline-stage suffixes (``_routed``, ``_optimized``,
+``_stitched``, ``_phase1``) that the schematic never has, so those are stripped
+before the sibling lookup.
+
+Returns ``None`` when no schematic can be found -- callers should treat that as
+"skip silently" rather than an error, since many PCB-only workflows are
+legitimate.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Pipeline-stage suffixes appended to a PCB basename by routing/optimization
+# stages.  The schematic keeps the bare project basename, so we strip these
+# before looking for a sibling ``.kicad_sch``.
+_PCB_STAGE_SUFFIXES = ("_routed", "_optimized", "_stitched", "_phase1")
+
+
+def _strip_stage_suffix(stem: str) -> str:
+    """Strip a single known pipeline-stage suffix from a PCB file stem."""
+    for suffix in _PCB_STAGE_SUFFIXES:
+        if stem.endswith(suffix):
+            return stem[: -len(suffix)]
+    return stem
+
+
+def resolve_schematic_for_pcb(pcb_path: str | Path) -> Path | None:
+    """Resolve the schematic file associated with a PCB.
+
+    Args:
+        pcb_path: Path to a ``.kicad_pcb`` file.
+
+    Returns:
+        Path to the resolved ``.kicad_sch`` file if one exists, else ``None``.
+    """
+    pcb_path = Path(pcb_path)
+    project_dir = pcb_path.parent
+
+    # 1. Try project.kct artifacts.schematic (next to the PCB, then one up).
+    kct_path = project_dir / "project.kct"
+    if not kct_path.exists():
+        kct_path = project_dir.parent / "project.kct"
+
+    if kct_path.exists():
+        try:
+            from kicad_tools.spec import load_spec
+
+            spec = load_spec(kct_path)
+            if spec.project and spec.project.artifacts and spec.project.artifacts.schematic:
+                sch_path = kct_path.parent / spec.project.artifacts.schematic
+                if sch_path.exists():
+                    logger.debug("Using schematic from project.kct: %s", sch_path)
+                    return sch_path
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug("Failed to load project.kct: %s", e)
+
+    # 2. Sibling <basename>.kicad_sch, trying the stage-stripped stem first
+    #    (e.g. board_routed.kicad_pcb -> board.kicad_sch), then the raw stem.
+    stripped_stem = _strip_stage_suffix(pcb_path.stem)
+    candidates = [project_dir / f"{stripped_stem}.kicad_sch"]
+    if pcb_path.stem != stripped_stem:
+        candidates.append(pcb_path.with_suffix(".kicad_sch"))
+
+    for candidate in candidates:
+        if candidate.exists():
+            logger.debug("Using sibling schematic: %s", candidate)
+            return candidate
+
+    return None

--- a/src/kicad_tools/sync/drift.py
+++ b/src/kicad_tools/sync/drift.py
@@ -1,0 +1,154 @@
+"""Shared schematic/PCB drift reporting for the route/check entry points.
+
+This module wires the existing :class:`kicad_tools.sync.reconciler.Reconciler`
+into the ``kct route`` and ``kct check`` commands so that a PCB whose footprint
+set has drifted from the schematic netlist is surfaced -- as an advisory banner
+on ``route``/plain ``check`` and as a blocking gate behind
+``kct check --netlist-sync``.
+
+Set-comparison logic is NOT re-implemented here; it lives in the ``Reconciler``.
+This module only renders the analysis and decides the exit-code policy, which
+mirrors the auditor's "schematic-only drift == unbuildable BOM == NOT_READY"
+rule (see ``Auditor`` verdict logic).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from kicad_tools.sync.discover import resolve_schematic_for_pcb
+
+if TYPE_CHECKING:
+    from kicad_tools.sync.reconciler import SyncAnalysis
+
+logger = logging.getLogger(__name__)
+
+
+def analyze_drift(pcb_path: str | Path, schematic_path: str | Path | None = None):
+    """Run the Reconciler for a PCB, discovering the schematic if needed.
+
+    Args:
+        pcb_path: Path to the ``.kicad_pcb`` file.
+        schematic_path: Optional explicit schematic override.  When ``None``
+            the schematic is auto-discovered via
+            :func:`resolve_schematic_for_pcb`.
+
+    Returns:
+        Tuple ``(analysis, resolved_schematic)``.  Both are ``None`` when no
+        schematic could be resolved or the analysis failed -- callers should
+        treat that as "skip silently".
+    """
+    from kicad_tools.sync.reconciler import Reconciler
+
+    resolved = Path(schematic_path) if schematic_path else resolve_schematic_for_pcb(pcb_path)
+    if resolved is None or not resolved.exists():
+        return None, None
+
+    try:
+        reconciler = Reconciler(schematic=resolved, pcb=pcb_path)
+        analysis = reconciler.analyze()
+    except Exception as e:  # pragma: no cover - defensive
+        logger.debug("Drift analysis failed for %s: %s", pcb_path, e)
+        return None, None
+
+    return analysis, resolved
+
+
+def _drift_summary_parts(analysis: SyncAnalysis) -> list[str]:
+    """Build the human-readable count-delta fragments shared by all renderers."""
+    parts: list[str] = []
+    if analysis.schematic_orphans:
+        parts.append(f"{len(analysis.schematic_orphans)} schematic-only")
+    if analysis.pcb_orphans:
+        parts.append(f"{len(analysis.pcb_orphans)} PCB-only")
+    if analysis.value_mismatches:
+        parts.append(f"{len(analysis.value_mismatches)} value mismatch(es)")
+    if analysis.footprint_mismatches:
+        parts.append(f"{len(analysis.footprint_mismatches)} footprint mismatch(es)")
+    return parts
+
+
+def has_drift(analysis: SyncAnalysis) -> bool:
+    """True when any of the four drift axes is non-empty."""
+    return bool(
+        analysis.schematic_orphans
+        or analysis.pcb_orphans
+        or analysis.value_mismatches
+        or analysis.footprint_mismatches
+    )
+
+
+def format_drift_banner(analysis: SyncAnalysis, pcb_path: str | Path) -> str | None:
+    """Render the one-line advisory drift banner, or ``None`` when in sync.
+
+    The banner names the count delta and points to the analysis/remediation
+    commands, matching the message style used elsewhere in ``route``/``check``.
+    """
+    parts = _drift_summary_parts(analysis)
+    if not parts:
+        return None
+
+    pcb_name = Path(pcb_path).name
+    return (
+        f"  WARNING: PCB out of sync with schematic -- {', '.join(parts)}. "
+        f"Run 'kct sync --analyze {pcb_name}' to inspect "
+        f"(apply with 'kct pcb sync-netlist')."
+    )
+
+
+def render_drift_report(analysis: SyncAnalysis, pcb_path: str | Path, schematic_path: Path) -> str:
+    """Render the full add/drop/orphan report for ``--netlist-sync``."""
+    lines: list[str] = []
+    lines.append("=" * 60)
+    lines.append("NETLIST SYNC CHECK")
+    lines.append("=" * 60)
+    lines.append(f"PCB:       {Path(pcb_path).name}")
+    lines.append(f"Schematic: {Path(schematic_path).name}")
+
+    if not has_drift(analysis):
+        lines.append("")
+        lines.append("IN SYNC - schematic and PCB component sets match.")
+        return "\n".join(lines)
+
+    parts = _drift_summary_parts(analysis)
+    lines.append("")
+    lines.append(f"OUT OF SYNC - {', '.join(parts)}.")
+
+    if analysis.schematic_orphans:
+        lines.append("")
+        lines.append(
+            f"Schematic-only (in schematic, missing from PCB) [{len(analysis.schematic_orphans)}]:"
+        )
+        for ref in analysis.schematic_orphans:
+            lines.append(f"  - {ref}")
+
+    if analysis.pcb_orphans:
+        lines.append("")
+        lines.append(f"PCB-only (on PCB, missing from schematic) [{len(analysis.pcb_orphans)}]:")
+        for ref in analysis.pcb_orphans:
+            lines.append(f"  - {ref}")
+
+    if analysis.value_mismatches:
+        lines.append("")
+        lines.append(f"Value mismatches [{len(analysis.value_mismatches)}]:")
+        for m in analysis.value_mismatches:
+            lines.append(
+                f"  - {m['reference']}: schematic={m['schematic_value']!r} pcb={m['pcb_value']!r}"
+            )
+
+    if analysis.footprint_mismatches:
+        lines.append("")
+        lines.append(f"Footprint mismatches [{len(analysis.footprint_mismatches)}]:")
+        for m in analysis.footprint_mismatches:
+            lines.append(
+                f"  - {m['reference']}: schematic={m['schematic_footprint']!r} "
+                f"pcb={m['pcb_footprint']!r}"
+            )
+
+    lines.append("")
+    lines.append("Remediation:")
+    lines.append(f"  kct sync --analyze {Path(pcb_path).name}      # inspect proposed changes")
+    lines.append(f"  kct pcb sync-netlist {Path(pcb_path).name}    # apply changes to the PCB")
+    return "\n".join(lines)

--- a/tests/test_netlist_sync_gate.py
+++ b/tests/test_netlist_sync_gate.py
@@ -1,0 +1,188 @@
+"""Tests for the schematic/PCB drift wiring in route + check (issue #3154).
+
+Covers:
+- ``resolve_schematic_for_pcb`` discovery (sibling, project.kct, stage suffix,
+  missing -> None).
+- ``kct check --netlist-sync`` blocking gate (schematic-only -> exit 2,
+  in-sync -> exit 0, PCB-only orphan -> exit 0 unless --strict, no schematic
+  -> exit 1).
+- Advisory drift banner on plain ``kct check`` and ``kct route`` (non-blocking).
+
+Fixtures reuse the in-repo S-expression strings from ``test_pcb_sync_netlist``
+(chorus-test is an external board and not available in-repo).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.check_cmd import main as check_main
+from kicad_tools.cli.route_cmd import main as route_main
+from kicad_tools.sync.discover import resolve_schematic_for_pcb
+
+# Reuse the in-repo S-expression fixtures from the sync-netlist test module.
+# Ensure this directory is importable regardless of pytest collection order
+# (the default prepend import mode only adds tests/ once a test in it loads).
+sys.path.insert(0, str(Path(__file__).parent))
+
+from test_pcb_sync_netlist import (  # noqa: E402
+    MINIMAL_PCB_MATCHING,
+    MINIMAL_SCHEMATIC,
+    PCB_MISSING_R1,
+    PCB_WITH_ORPHAN,
+)
+
+
+def _write_pair(directory: Path, basename: str, schematic: str, pcb: str) -> Path:
+    """Write a matching-basename schematic+PCB pair so auto-discovery resolves.
+
+    Returns the PCB path.
+    """
+    (directory / f"{basename}.kicad_sch").write_text(schematic)
+    pcb_path = directory / f"{basename}.kicad_pcb"
+    pcb_path.write_text(pcb)
+    return pcb_path
+
+
+# ---------------------------------------------------------------------------
+# resolve_schematic_for_pcb
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSchematicForPcb:
+    def test_returns_sibling_schematic(self, tmp_path):
+        pcb = _write_pair(tmp_path, "board", MINIMAL_SCHEMATIC, MINIMAL_PCB_MATCHING)
+        resolved = resolve_schematic_for_pcb(pcb)
+        assert resolved == tmp_path / "board.kicad_sch"
+
+    def test_returns_none_when_no_schematic(self, tmp_path):
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(MINIMAL_PCB_MATCHING)
+        assert resolve_schematic_for_pcb(pcb) is None
+
+    def test_strips_stage_suffix(self, tmp_path):
+        # Schematic keeps the bare basename; the PCB carries a _routed suffix.
+        (tmp_path / "board.kicad_sch").write_text(MINIMAL_SCHEMATIC)
+        routed = tmp_path / "board_routed.kicad_pcb"
+        routed.write_text(MINIMAL_PCB_MATCHING)
+        resolved = resolve_schematic_for_pcb(routed)
+        assert resolved == tmp_path / "board.kicad_sch"
+
+    def test_honors_project_kct_artifacts_schematic(self, tmp_path):
+        # project.kct points artifacts.schematic at a non-sibling name.
+        (tmp_path / "custom_name.kicad_sch").write_text(MINIMAL_SCHEMATIC)
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(MINIMAL_PCB_MATCHING)
+        (tmp_path / "project.kct").write_text(
+            'kct_version: "1.0"\n'
+            "project:\n"
+            '  name: "test"\n'
+            "  artifacts:\n"
+            '    schematic: "custom_name.kicad_sch"\n'
+            '    pcb: "board.kicad_pcb"\n'
+        )
+        resolved = resolve_schematic_for_pcb(pcb)
+        assert resolved == tmp_path / "custom_name.kicad_sch"
+
+
+# ---------------------------------------------------------------------------
+# kct check --netlist-sync (blocking gate, AC #1 / AC #2)
+# ---------------------------------------------------------------------------
+
+
+class TestNetlistSyncGate:
+    def test_schematic_only_drift_exits_nonzero(self, tmp_path, capsys):
+        # PCB_MISSING_R1 has C1 only; schematic has R1+C1 -> R1 schematic-only.
+        pcb = _write_pair(tmp_path, "board", MINIMAL_SCHEMATIC, PCB_MISSING_R1)
+        rc = check_main([str(pcb), "--netlist-sync"])
+        assert rc == 2
+        out = capsys.readouterr().out
+        # Names the schematic-only ref and the count delta.
+        assert "R1" in out
+        assert "1 schematic-only" in out
+        assert "OUT OF SYNC" in out
+
+    def test_in_sync_exits_zero(self, tmp_path, capsys):
+        pcb = _write_pair(tmp_path, "board", MINIMAL_SCHEMATIC, MINIMAL_PCB_MATCHING)
+        rc = check_main([str(pcb), "--netlist-sync"])
+        assert rc == 0
+        assert "IN SYNC" in capsys.readouterr().out
+
+    def test_pcb_only_orphan_nonfatal_without_strict(self, tmp_path, capsys):
+        # PCB_WITH_ORPHAN adds D1 (not in schematic) -> PCB-only orphan only.
+        pcb = _write_pair(tmp_path, "board", MINIMAL_SCHEMATIC, PCB_WITH_ORPHAN)
+        rc = check_main([str(pcb), "--netlist-sync"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "D1" in out
+        assert "1 PCB-only" in out
+
+    def test_pcb_only_orphan_fatal_with_strict(self, tmp_path):
+        pcb = _write_pair(tmp_path, "board", MINIMAL_SCHEMATIC, PCB_WITH_ORPHAN)
+        rc = check_main([str(pcb), "--netlist-sync", "--strict"])
+        assert rc == 2
+
+    def test_no_schematic_exits_one(self, tmp_path, capsys):
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(MINIMAL_PCB_MATCHING)
+        rc = check_main([str(pcb), "--netlist-sync"])
+        assert rc == 1
+        assert "none was found" in capsys.readouterr().err
+
+    def test_explicit_schematic_override(self, tmp_path, capsys):
+        # PCB next to a non-matching basename; point --schematic explicitly.
+        sch = tmp_path / "other.kicad_sch"
+        sch.write_text(MINIMAL_SCHEMATIC)
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(PCB_MISSING_R1)
+        rc = check_main([str(pcb), "--netlist-sync", "--schematic", str(sch)])
+        assert rc == 2
+        assert "R1" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Advisory drift banner (AC #2 of the issue: route + plain check, non-blocking)
+# ---------------------------------------------------------------------------
+
+
+class TestAdvisoryBanner:
+    def test_plain_check_prints_banner_without_changing_exit(self, tmp_path, capsys):
+        # Drift present but DRC clean -> banner appears, exit stays 0.
+        pcb = _write_pair(tmp_path, "board", MINIMAL_SCHEMATIC, PCB_MISSING_R1)
+        rc = check_main([str(pcb), "--format", "summary"])
+        out = capsys.readouterr().out
+        assert "PCB out of sync with schematic" in out
+        assert "1 schematic-only" in out
+        # Banner alone does not flip the exit code (DRC found no errors).
+        assert rc == 0
+
+    def test_plain_check_no_banner_when_in_sync(self, tmp_path, capsys):
+        pcb = _write_pair(tmp_path, "board", MINIMAL_SCHEMATIC, MINIMAL_PCB_MATCHING)
+        check_main([str(pcb), "--format", "summary"])
+        assert "out of sync" not in capsys.readouterr().out.lower()
+
+    def test_plain_check_no_banner_when_no_schematic(self, tmp_path, capsys):
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(PCB_MISSING_R1)
+        check_main([str(pcb), "--format", "summary"])
+        assert "out of sync" not in capsys.readouterr().out.lower()
+
+    def test_route_prints_banner(self, tmp_path, capsys):
+        pcb = _write_pair(tmp_path, "board", MINIMAL_SCHEMATIC, PCB_MISSING_R1)
+        rc = route_main([str(pcb), "--dry-run"])
+        out = capsys.readouterr().out
+        assert "PCB out of sync with schematic" in out
+        # The banner is advisory; a successful dry-run still returns 0.
+        assert rc == 0
+
+    def test_route_no_sync_check_suppresses_banner(self, tmp_path, capsys):
+        pcb = _write_pair(tmp_path, "board", MINIMAL_SCHEMATIC, PCB_MISSING_R1)
+        route_main([str(pcb), "--dry-run", "--no-sync-check"])
+        assert "out of sync" not in capsys.readouterr().out.lower()
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Closes #3154.

Wires the **existing** `kicad_tools.sync.reconciler.Reconciler` into the `kct route` and `kct check` entry points so schematic/PCB netlist drift is surfaced where engineers actually run the pipeline. Per the curator's verified scope correction, detection already existed (and `kct audit` already blocks on it) -- this PR is the missing wiring + a blocking flag + advisory banners. No set-comparison logic is reimplemented.

### What changed

- **`sync/discover.py` (new)** -- `resolve_schematic_for_pcb(pcb_path) -> Path | None`, factored out of `Auditor._resolve_schematic_path`. The auditor now delegates to it (single-sourced; no verdict change). Strips pipeline-stage suffixes (`_routed`, `_optimized`, `_stitched`, `_phase1`) so a routed PCB still resolves its sibling schematic. Returns `None` -> "skip silently".
- **`sync/drift.py` (new)** -- thin renderer over `Reconciler.analyze()`. Owns the exit-code policy and shared count-delta formatting. No mutation, no set logic.
- **`kct check --netlist-sync` (AC #1, #2)** -- blocking gate. Prints a full add/drop/orphan report; exits **2** on schematic-only drift (unbuildable BOM, mirroring the auditor's `NOT_READY` rule), **1** when no schematic resolves, **0** otherwise. PCB-only / value / footprint drift is advisory unless `--strict`. Adds `--schematic PATH` override.
- **`kct route` + plain `kct check` advisory banner (AC #2)** -- one-line, non-blocking warning naming the count delta and pointing to `kct sync --analyze` (inspect) / `kct pcb sync-netlist` (apply). `route` opts out with `--no-sync-check`; respects `--quiet`.
- **Parser symmetry** -- new flags declared on both the inner (`route_cmd.py`/`check_cmd.py`) and outer (`parser.py`) parsers and threaded through the forwarding shims (`commands/routing.py`, `commands/validation.py`). `test_cli_parser_drift.py` stays green.

### Reuse (AC #3)

All drift detection flows through `Reconciler.analyze()` / `SyncAnalysis`. The auditor's action items already point to the sync command, so the issue's AC about audit action-items was already satisfied; this PR leaves it intact.

## Test plan

- [x] New `tests/test_netlist_sync_gate.py` (15 tests) reuses the in-repo R1/C1 S-expression fixtures from `tests/test_pcb_sync_netlist.py` (chorus-test is external):
  - `resolve_schematic_for_pcb`: sibling, `project.kct` `artifacts.schematic`, `_routed` stage-suffix, and `None` cases.
  - `--netlist-sync`: schematic-only -> exit 2 (names ref + count); in-sync -> 0; PCB-only orphan -> 0 (2 with `--strict`); no schematic -> 1; explicit `--schematic` override.
  - Advisory banner present on plain `check` + `route`, absent when in sync / no schematic / `--no-sync-check`, and never flips the exit code.
- [x] `tests/test_pcb_sync_netlist.py` -- 105 passed (regression).
- [x] `tests/test_cli_parser_drift.py` -- 7 passed.
- [x] `tests/test_check_cmd_coverage.py` -- passed.
- [x] `tests/test_audit.py` -- 280 passed; the single `TestZoneConnectedNets::test_no_zones_regression` failure is **pre-existing on `main`** (verified by stashing this PR's auditor change) and unrelated to schematic resolution.
- [x] `ruff format --check` and `ruff check` clean on all changed files (repo-wide pre-existing lint/format debt is out of scope).

> Note: `uv.lock` shows an unrelated `pynng`/`ipc` extra change that predates this branch in the working tree; it was intentionally excluded from the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)