### PR TITLE
feat(route): --preserve-existing incremental routing mode (closes #3155)

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -171,6 +171,11 @@ def run_route_command(args) -> int:
         sub_argv.extend(["--strategy", args.strategy])
     if args.skip_nets:
         sub_argv.extend(["--skip-nets", args.skip_nets])
+    # Issue #3155: forward --preserve-existing (incremental routing).  Both
+    # outer (parser.py) and inner (route_cmd.py) parsers declare it as a
+    # store_true defaulting to False, so only forward when the user set it.
+    if getattr(args, "preserve_existing", False):
+        sub_argv.append("--preserve-existing")
     grid_val = str(args.grid)
     if grid_val.lower() != "auto":
         sub_argv.extend(["--grid", grid_val])

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2304,6 +2304,19 @@ def _add_route_parser(subparsers) -> None:
     )
     route_parser.add_argument("--skip-nets", help="Comma-separated nets to skip")
     route_parser.add_argument(
+        "--preserve-existing",
+        action="store_true",
+        default=False,
+        help=(
+            "Incremental routing: load existing (segment ...)/(via ...) copper "
+            "as immovable obstacles and re-emit it unchanged, so only "
+            "unconnected nets are routed. Preserves manually-routed nets, "
+            "skipped nets' geometry, and standalone stitch vias across a "
+            "route pass. Default off (full re-route, existing copper is "
+            "replaced by freshly routed nets)."
+        ),
+    )
+    route_parser.add_argument(
         "--grid",
         type=str,
         default="auto",

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -70,6 +70,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from kicad_tools.router import Autorouter, LayerStack
+    from kicad_tools.router.primitives import Route
 
 # Issue #3035: ``_auto_skip_pour_nets`` was promoted to a public helper at
 # ``kicad_tools.router.auto_pour.auto_skip_pour_nets`` so in-process router
@@ -685,6 +686,8 @@ def _make_checkpoint_callback(
     output_path: Path,
     interval: float,
     quiet: bool = False,
+    *,
+    preserved_sexp: str = "",
 ):
     """Build a checkpoint callback for ``route_all_negotiated`` (Issue #2808).
 
@@ -709,6 +712,14 @@ def _make_checkpoint_callback(
         interval: Minimum seconds between checkpoint writes.  ``0`` (or
             negative) disables checkpointing entirely.
         quiet: Suppress the "checkpoint: wrote ..." log line.
+        preserved_sexp: Issue #3155.  S-expression of preserved existing
+            copper (segments/vias from ``--preserve-existing``).  Appended
+            to every checkpoint write so the staged input file -- which
+            ``_write_routed_pcb`` strips clean before inserting the
+            snapshot, and which the layer-escalation loop *re-reads* on the
+            next attempt -- never loses the preserved geometry.  Empty (the
+            default) means no preservation, preserving pre-#3155 checkpoint
+            bytes exactly.
 
     Returns:
         Callback or ``None``.
@@ -732,6 +743,11 @@ def _make_checkpoint_callback(
         # Route has its own to_sexp() so we can serialize directly without
         # touching the router's live state.
         route_sexp = "\n\t".join(r.to_sexp() for r in best_routes)
+        # Issue #3155: carry preserved existing copper through every
+        # checkpoint so the strip-then-rewrite (#2976) inside
+        # _write_routed_pcb does not erase it from the staged input.
+        if preserved_sexp:
+            route_sexp = f"{route_sexp}\n\t{preserved_sexp}" if route_sexp else preserved_sexp
         _write_routed_pcb(
             pcb_path,
             output_path,
@@ -751,6 +767,63 @@ def _make_checkpoint_callback(
     return _checkpoint
 
 
+def _capture_preserved_routes(pcb_path: Path) -> list["Route"]:
+    """Parse existing copper from ``pcb_path`` for --preserve-existing (#3155).
+
+    Returns one :class:`Route` per net that has top-level
+    ``(segment ...)`` / ``(via ...)`` geometry.  This is captured *once* from
+    the freshly-staged input (before any routing or checkpoint write mutates
+    it) so the preserved geometry can be re-emitted by both the checkpoint
+    callback and the final write -- independent of the per-attempt
+    ``router.existing_routes``, which the layer-escalation loop would otherwise
+    lose when it re-reads a checkpoint-overwritten staged file.
+
+    Returns an empty list when the file has no routed copper or cannot be read.
+    """
+    from kicad_tools.router.optimizer.pcb import parse_segments, parse_vias
+    from kicad_tools.router.primitives import Route
+
+    try:
+        text = Path(pcb_path).read_text()
+    except OSError:
+        return []
+
+    segments_by_net = parse_segments(text)
+    vias_by_net = parse_vias(text)
+    all_net_names = set(segments_by_net) | set(vias_by_net)
+
+    routes: list[Route] = []
+    for net_name in sorted(all_net_names):
+        segs = segments_by_net.get(net_name, [])
+        vias = vias_by_net.get(net_name, [])
+        if not segs and not vias:
+            continue
+        net_id = segs[0].net if segs else vias[0].net
+        routes.append(Route(net=net_id, net_name=net_name, segments=segs, vias=vias))
+    return routes
+
+
+def _serialize_preserved_routes(
+    preserved_routes: list["Route"],
+    exclude_net_ids: set[int] | None = None,
+) -> str:
+    """Serialize preserved routes, skipping any net in ``exclude_net_ids``.
+
+    The exclusion set is the freshly-routed net ids: a net that was both
+    pre-existing *and* re-routed must be emitted from the routed copy only,
+    never twice (#3155 defensive dedupe).
+    """
+    exclude = exclude_net_ids or set()
+    parts: list[str] = []
+    for route in preserved_routes:
+        if route.net in exclude:
+            continue
+        sexp = route.to_sexp()
+        if sexp:
+            parts.append(sexp)
+    return "\n\t".join(parts)
+
+
 def _finalize_routes(
     router: "Autorouter",
     multi_pad_net_ids: set[int],
@@ -760,6 +833,8 @@ def _finalize_routes(
     strict: bool = False,
     verbose: bool = False,
     aggregate_segment_drop_threshold: float = 0.5,
+    preserve_existing: bool = False,
+    preserved_routes: list["Route"] | None = None,
 ) -> tuple[str, dict, dict]:
     """Run cleanup, compute statistics, and generate S-expressions.
 
@@ -799,6 +874,20 @@ def _finalize_routes(
             drops more than 50% of segments).  This warning fires
             *after* per-net revert so it reflects the final state
             written to disk.
+        preserve_existing: Issue #3155 incremental routing.  When True,
+            append the S-expression of every preserved route to
+            ``route_sexp`` so pre-existing copper -- manually routed nets,
+            ``--skip-nets`` geometry, and standalone stitch vias -- survives
+            the strip-then-rewrite in ``_write_routed_pcb``.  Preserved
+            routes whose net id was also (re-)routed into ``router.routes``
+            are skipped to avoid double-emission.
+        preserved_routes: The list of preserved :class:`Route` objects to
+            re-emit when ``preserve_existing`` is True.  Captured once from
+            the freshly-staged input via :func:`_capture_preserved_routes`
+            (NOT ``router.existing_routes``, which the escalation loop can
+            lose to a checkpoint-overwritten staged file).  ``None`` falls
+            back to ``router.existing_routes`` for callers that load fresh
+            and never checkpoint.
 
     Returns:
         Tuple of (route_sexp, stats, cleanup_stats) where:
@@ -894,6 +983,38 @@ def _finalize_routes(
 
     # Step 2: Generate S-expressions from the cleaned routes
     route_sexp = router.to_sexp(skip_cleanup=True)
+
+    # Issue #3155: re-emit preserved copper.  The preserved routes were
+    # captured once from the freshly-staged input (``preserved_routes``),
+    # falling back to ``router.existing_routes`` (populated by
+    # ``load_pcb_for_routing(load_existing_routes=True)``) for callers that
+    # load fresh and never checkpoint.  Neither source is touched by
+    # ``cleanup_artifacts()`` (which only walks ``router.routes``), so the
+    # geometry is re-emitted verbatim and survives the destructive strip in
+    # ``_write_routed_pcb`` (#2976).  ``Autorouter.to_sexp()`` is left
+    # untouched (regression-safe); we serialize each preserved Route directly.
+    #
+    # Defensive dedupe: a net that already exists *and* was re-routed would
+    # otherwise appear twice (once from ``router.routes``, once from the
+    # preserved set).  Skip any preserved route whose net id is present in
+    # the freshly-routed set so the freshly-routed copper wins.
+    if preserve_existing:
+        source_routes = preserved_routes if preserved_routes is not None else router.existing_routes
+        if source_routes:
+            routed_net_ids = {r.net for r in router.routes}
+            preserved_sexp = _serialize_preserved_routes(
+                source_routes, exclude_net_ids=routed_net_ids
+            )
+            if preserved_sexp:
+                emitted = [r for r in source_routes if r.net not in routed_net_ids]
+                preserved_segments = sum(len(r.segments) for r in emitted)
+                preserved_vias = sum(len(r.vias) for r in emitted)
+                route_sexp = f"{route_sexp}\n\t{preserved_sexp}" if route_sexp else preserved_sexp
+                if not quiet:
+                    flush_print(
+                        f"  Preserved existing: {preserved_segments} segments, "
+                        f"{preserved_vias} vias ({len(emitted)} routes)"
+                    )
 
     # Step 3: Compute statistics from the cleaned routes
     stats = router.get_statistics(nets_to_route_ids=multi_pad_net_ids)
@@ -2232,6 +2353,16 @@ def route_with_layer_escalation(
     # Auto-classify pour nets and extend skip_nets
     _skipped, _no_zone = _auto_skip_pour_nets(pcb_path, skip_nets, quiet=quiet)
 
+    # Issue #3155: capture preserved copper ONCE from the staged input before
+    # any routing or checkpoint write mutates it.  The escalation loop below
+    # re-reads ``pcb_path`` (== the staged ``output_path``) on every attempt,
+    # and checkpoint writes overwrite it with routed-only geometry, so the
+    # per-attempt ``router.existing_routes`` cannot be trusted to retain the
+    # original copper.  Capturing here keeps it stable across all attempts.
+    _preserve = bool(getattr(args, "preserve_existing", False))
+    _preserved_routes = _capture_preserved_routes(pcb_path) if _preserve else []
+    _preserved_sexp = _serialize_preserved_routes(_preserved_routes) if _preserve else ""
+
     # Layer stacks to try (in escalation order)
     layer_configs = [
         (2, LayerStack.two_layer()),
@@ -2287,6 +2418,7 @@ def route_with_layer_escalation(
         output_path,
         float(getattr(args, "checkpoint_interval", 30.0) or 0.0),
         quiet=quiet,
+        preserved_sexp=_preserved_sexp,
     )
 
     for attempt_num, (layer_count, layer_stack) in enumerate(layer_configs, 1):
@@ -2339,6 +2471,10 @@ def route_with_layer_escalation(
                     force_python=force_python,
                     validate_drc=not args.force,
                     strict_drc=False,
+                    # Issue #3155: incremental routing.  When set, existing
+                    # copper is loaded as grid obstacles + populated into
+                    # router.existing_routes so it survives the route pass.
+                    load_existing_routes=getattr(args, "preserve_existing", False),
                 )
         except Exception as e:
             if not quiet:
@@ -2787,6 +2923,8 @@ def route_with_layer_escalation(
         quiet=quiet,
         strict=bool(getattr(args, "strict", False)),
         verbose=bool(getattr(args, "verbose", False)),
+        preserve_existing=bool(getattr(args, "preserve_existing", False)),
+        preserved_routes=_preserved_routes,
     )
     # Update result with post-cleanup stats
     final_result.nets_routed = final_stats["nets_routed"]
@@ -2978,6 +3116,11 @@ def route_with_rule_relaxation(
         min_clearance_floor=args.min_clearance_floor,
     )
 
+    # Issue #3155: capture preserved copper once before routing/checkpoints.
+    _preserve = bool(getattr(args, "preserve_existing", False))
+    _preserved_routes = _capture_preserved_routes(pcb_path) if _preserve else []
+    _preserved_sexp = _serialize_preserved_routes(_preserved_routes) if _preserve else ""
+
     # Determine layer stack
     if args.layers == "auto":
         pcb_text = pcb_path.read_text()
@@ -3028,6 +3171,7 @@ def route_with_rule_relaxation(
         output_path,
         float(getattr(args, "checkpoint_interval", 30.0) or 0.0),
         quiet=quiet,
+        preserved_sexp=_preserved_sexp,
     )
 
     # Issue #2823: precompute total tier count so per-attempt budget can
@@ -3080,6 +3224,8 @@ def route_with_rule_relaxation(
                     force_python=force_python,
                     validate_drc=not args.force,
                     strict_drc=False,
+                    # Issue #3155: incremental routing (see route_with_layer_escalation).
+                    load_existing_routes=getattr(args, "preserve_existing", False),
                 )
         except Exception as e:
             if not quiet:
@@ -3372,6 +3518,8 @@ def route_with_rule_relaxation(
         quiet=quiet,
         strict=bool(getattr(args, "strict", False)),
         verbose=bool(getattr(args, "verbose", False)),
+        preserve_existing=bool(getattr(args, "preserve_existing", False)),
+        preserved_routes=_preserved_routes,
     )
     # Update result with post-cleanup stats
     final_result.nets_routed = final_stats["nets_routed"]
@@ -4051,6 +4199,11 @@ def route_with_combined_escalation(
         min_clearance_floor=args.min_clearance_floor,
     )
 
+    # Issue #3155: capture preserved copper once before routing/checkpoints.
+    _preserve = bool(getattr(args, "preserve_existing", False))
+    _preserved_routes = _capture_preserved_routes(pcb_path) if _preserve else []
+    _preserved_sexp = _serialize_preserved_routes(_preserved_routes) if _preserve else ""
+
     # Layer stacks to try (in escalation order)
     layer_configs = [
         (2, LayerStack.two_layer()),
@@ -4111,6 +4264,7 @@ def route_with_combined_escalation(
         output_path,
         float(getattr(args, "checkpoint_interval", 30.0) or 0.0),
         quiet=quiet,
+        preserved_sexp=_preserved_sexp,
     )
 
     # 2D search: prioritize fewer layers first, then stricter rules.
@@ -4183,6 +4337,8 @@ def route_with_combined_escalation(
                         force_python=force_python,
                         validate_drc=not args.force,
                         strict_drc=False,
+                        # Issue #3155: incremental routing (see route_with_layer_escalation).
+                        load_existing_routes=getattr(args, "preserve_existing", False),
                     )
             except Exception as e:
                 if not quiet:
@@ -4495,6 +4651,8 @@ def route_with_combined_escalation(
         quiet=quiet,
         strict=bool(getattr(args, "strict", False)),
         verbose=bool(getattr(args, "verbose", False)),
+        preserve_existing=bool(getattr(args, "preserve_existing", False)),
+        preserved_routes=_preserved_routes,
     )
     # Update result with post-cleanup stats
     final_result.nets_routed = final_stats["nets_routed"]
@@ -4680,6 +4838,19 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--skip-nets",
         help="Comma-separated nets to skip (e.g., GND,VCC,VBUS)",
+    )
+    parser.add_argument(
+        "--preserve-existing",
+        action="store_true",
+        default=False,
+        help=(
+            "Incremental routing (Issue #3155): load existing "
+            "(segment ...)/(via ...) copper as immovable obstacles and "
+            "re-emit it unchanged, so only unconnected nets are routed. "
+            "Preserves manually-routed nets, skipped nets' geometry, and "
+            "standalone stitch vias across a route pass. Default off (full "
+            "re-route, existing copper is replaced by freshly routed nets)."
+        ),
     )
     parser.add_argument(
         "--grid",
@@ -5942,6 +6113,11 @@ def main(argv: list[str] | None = None) -> int:
     # Auto-classify pour nets and extend skip_nets
     _skipped, _no_zone = _auto_skip_pour_nets(pcb_path, skip_nets, quiet=args.quiet)
 
+    # Issue #3155: capture preserved copper once before routing/checkpoints.
+    _preserve = bool(getattr(args, "preserve_existing", False))
+    _preserved_routes = _capture_preserved_routes(pcb_path) if _preserve else []
+    _preserved_sexp = _serialize_preserved_routes(_preserved_routes) if _preserve else ""
+
     # Import router modules
     from kicad_tools.analysis import ComplexityAnalyzer, ComplexityRating
     from kicad_tools.router import (
@@ -6085,6 +6261,8 @@ def main(argv: list[str] | None = None) -> int:
                 force_python=force_python,
                 validate_drc=not args.force,
                 strict_drc=False,  # Only fail on hard constraint (grid > clearance)
+                # Issue #3155: incremental routing (see route_with_layer_escalation).
+                load_existing_routes=getattr(args, "preserve_existing", False),
                 # Issue #2610: thread --max-search-iterations through.
                 # The inner parser declares this flag with default=0 (Issue
                 # #2819), so the attribute is guaranteed to exist; the
@@ -6490,6 +6668,7 @@ def main(argv: list[str] | None = None) -> int:
             output_path,
             float(getattr(args, "checkpoint_interval", 30.0) or 0.0),
             quiet=quiet,
+            preserved_sexp=_preserved_sexp,
         )
 
         # Define routing function for profiling
@@ -7091,6 +7270,8 @@ def main(argv: list[str] | None = None) -> int:
         quiet=quiet,
         strict=bool(getattr(args, "strict", False)),
         verbose=bool(getattr(args, "verbose", False)),
+        preserve_existing=bool(getattr(args, "preserve_existing", False)),
+        preserved_routes=_preserved_routes,
     )
 
     # Report differential pair length mismatch warnings

--- a/tests/router/test_preserve_existing.py
+++ b/tests/router/test_preserve_existing.py
@@ -1,0 +1,326 @@
+"""Tests for Issue #3155: ``kct route --preserve-existing`` incremental routing.
+
+Background
+----------
+
+Re-running ``kct route`` on a partially-routed board used to DESTROY existing
+good routes.  ``--skip-nets`` only zeroed a skipped net's *pads* (so it was
+not re-routed) but did nothing with that net's existing ``(segment ...)`` /
+``(via ...)`` geometry.  Meanwhile the writer strips ALL top-level segment/via
+blocks (``_strip_route_blocks``, added #2976) and re-inserts only
+``Autorouter.to_sexp()`` (which serializes freshly-routed ``self.routes``
+only).  Net effect: skipped-net copper, manually-routed nets, and standalone
+stitch vias were all deleted on every route pass.
+
+Fix (Issue #3155): the new ``--preserve-existing`` flag wires up the existing
+but dormant ``load_pcb_for_routing(load_existing_routes=True)`` infrastructure
+at all four route entry points (so existing copper is loaded as grid
+obstacles AND populated into ``router.existing_routes``).  Preserved copper is
+captured once from the freshly-staged input (``_capture_preserved_routes``)
+and re-emitted both by the checkpoint callback (so the escalation loop, which
+re-reads a checkpoint-overwritten staged file, never loses it) and by
+``_finalize_routes`` after cleanup (so it survives the strip-then-rewrite).
+
+These tests verify:
+
+1. Re-routing a board with ``--preserve-existing`` (skipping all-but-one net)
+   leaves every skipped net's geometry byte-identical and only routes the
+   requested net (AC #1, #2).
+2. The default (no ``--preserve-existing``) is unchanged: skipped-net copper
+   is still stripped (regression-safe behaviour preserved bit-for-bit, AC #5).
+3. ``_capture_preserved_routes`` parses existing copper (segments + standalone
+   stitch vias) and ``_serialize_preserved_routes`` re-emits it with a
+   defensive net-id dedupe so a re-routed net is never double-emitted
+   (AC #3, #4 -- deterministic, environment-independent).
+4. ``load_pcb_for_routing(load_existing_routes=True)`` populates
+   ``router.existing_routes`` and ``_finalize_routes(preserve_existing=True)``
+   appends the preserved geometry to ``route_sexp`` (and does NOT when the
+   flag is off).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.route_cmd import (
+    _capture_preserved_routes,
+    _finalize_routes,
+    _serialize_preserved_routes,
+)
+from kicad_tools.cli.route_cmd import main as route_main
+from kicad_tools.router.io import load_pcb_for_routing
+from kicad_tools.router.optimizer.pcb import parse_net_names, parse_segments
+
+# A real routed board with eight 2-pad signal nets (LINE_*/NODE_*) and full
+# segment geometry.  Reused as the fixture so the tests exercise real KiCad
+# parsing/serialization rather than a hand-rolled stub.
+_BOARD = (
+    Path(__file__).resolve().parents[2]
+    / "boards"
+    / "02-charlieplex-led"
+    / "output"
+    / "charlieplex_3x3_routed.kicad_pcb"
+)
+
+# All routable signal nets except LINE_A.  Skipping these makes the router
+# touch only LINE_A, which is the curator's reproduction recipe.  LINE_A
+# routes in one 2-layer attempt, keeping the CLI test fast.
+_SKIP_ALL_BUT_LINE_A = "LINE_B,LINE_C,LINE_D,NODE_A,NODE_B,NODE_C,NODE_D"
+
+_ALL_SIGNAL_NETS = (
+    "LINE_A",
+    "LINE_B",
+    "LINE_C",
+    "LINE_D",
+    "NODE_A",
+    "NODE_B",
+    "NODE_C",
+    "NODE_D",
+)
+
+
+def _seg_key(seg) -> tuple:
+    """Geometry identity for a segment (endpoints, width, layer, net).
+
+    UUIDs are intentionally excluded -- ``Segment.to_sexp()`` mints a fresh
+    UUID on every emission, so byte-identity is defined on the electrical
+    geometry, exactly as the acceptance criteria require.
+    """
+    return (
+        round(seg.x1, 4),
+        round(seg.y1, 4),
+        round(seg.x2, 4),
+        round(seg.y2, 4),
+        round(seg.width, 4),
+        seg.layer.name,
+        seg.net,
+    )
+
+
+def _geom_set(seg_lists) -> set[tuple]:
+    return {_seg_key(s) for s in seg_lists}
+
+
+@pytest.fixture
+def board_text() -> str:
+    if not _BOARD.exists():  # pragma: no cover - guards against fixture drift
+        pytest.skip(f"fixture board not found: {_BOARD}")
+    return _BOARD.read_text()
+
+
+def _run_route(
+    tmp_path: Path,
+    pcb_text: str,
+    *,
+    preserve: bool,
+    skip_nets: str | None = None,
+) -> str:
+    """Write ``pcb_text`` to a temp file, run ``kct route``, return output text.
+
+    Uses ``--no-optimize`` and ``--force`` for determinism/speed and to skip
+    the DRC gate (the fixture board carries real geometry that need not be
+    DRC-clean for this test's purposes).
+    """
+    in_path = tmp_path / "in.kicad_pcb"
+    out_path = tmp_path / "out.kicad_pcb"
+    in_path.write_text(pcb_text)
+
+    argv = [
+        str(in_path),
+        "--output",
+        str(out_path),
+        "--no-optimize",
+        "--force",
+        "--quiet",
+    ]
+    if skip_nets:
+        argv += ["--skip-nets", skip_nets]
+    if preserve:
+        argv.append("--preserve-existing")
+
+    route_main(argv)
+    assert out_path.exists(), "route did not produce an output file"
+    return out_path.read_text()
+
+
+def _inject_stitch_via(pcb_text: str, *, net: int, x: float, y: float) -> str:
+    """Insert a standalone top-level ``(via ...)`` before the final ``)``.
+
+    Models a ``kct stitch`` via: a plane-net via not owned by any routed
+    signal net.
+    """
+    via_block = (
+        "\t(via\n"
+        f"\t\t(at {x:.4f} {y:.4f})\n"
+        "\t\t(size 0.6000)\n"
+        "\t\t(drill 0.3000)\n"
+        '\t\t(layers "F.Cu" "B.Cu")\n'
+        f"\t\t(net {net})\n"
+        '\t\t(uuid "00000000-0000-0000-0000-0000deadbeef")\n'
+        "\t)\n"
+    )
+    stripped = pcb_text.rstrip()
+    last_paren = stripped.rfind(")")
+    return stripped[:last_paren] + via_block + stripped[last_paren:]
+
+
+class TestPreserveExistingCLI:
+    """End-to-end CLI behaviour of ``kct route --preserve-existing``."""
+
+    def test_preserve_keeps_skipped_nets_byte_identical(self, tmp_path, board_text):
+        """AC #1/#2: skipped nets keep byte-identical geometry; only LINE_A routes."""
+        orig = parse_segments(board_text)
+        # Sanity: the fixture really does carry the eight signal nets.
+        assert set(orig) == set(_ALL_SIGNAL_NETS)
+
+        out_text = _run_route(tmp_path, board_text, preserve=True, skip_nets=_SKIP_ALL_BUT_LINE_A)
+        out = parse_segments(out_text)
+
+        # Every skipped net survived with byte-identical geometry.
+        for net in ("LINE_B", "LINE_C", "LINE_D", "NODE_A", "NODE_B", "NODE_C", "NODE_D"):
+            assert net in out, f"{net} geometry was destroyed under --preserve-existing"
+            assert _geom_set(out[net]) == _geom_set(orig[net]), (
+                f"{net} geometry changed under --preserve-existing"
+            )
+
+        # The one routable net is still present (re-routed in place).
+        assert "LINE_A" in out
+        assert len(out["LINE_A"]) > 0
+
+    def test_default_still_strips_skipped_nets(self, tmp_path, board_text):
+        """AC #5: without the flag, behaviour is unchanged (skipped copper stripped)."""
+        out_text = _run_route(tmp_path, board_text, preserve=False, skip_nets=_SKIP_ALL_BUT_LINE_A)
+        out = parse_segments(out_text)
+
+        # The skipped nets are NOT preserved in default mode -- their copper
+        # is stripped exactly as before this issue.  Only LINE_A (the routed
+        # net) remains.  This locks in regression-safe default behaviour.
+        assert set(out) == {"LINE_A"}
+
+
+class TestPreservedRouteHelpers:
+    """Deterministic unit coverage for the capture/serialize/dedupe helpers.
+
+    These exercise the preservation guarantee (including standalone stitch
+    vias) without depending on the optional external ``kicad-cli`` zone-fill
+    pass, so they behave identically in CI and locally.
+    """
+
+    def test_capture_parses_segments_and_stitch_via(self, tmp_path, board_text):
+        """AC #4: capture includes a standalone stitch via on a plane net."""
+        net_names = parse_net_names(board_text)
+        gnd_net = next(nid for nid, name in net_names.items() if name == "GND")
+        stitched = _inject_stitch_via(board_text, net=gnd_net, x=12.3456, y=23.4567)
+
+        in_path = tmp_path / "stitched.kicad_pcb"
+        in_path.write_text(stitched)
+
+        preserved = _capture_preserved_routes(in_path)
+        by_name = {r.net_name: r for r in preserved}
+
+        # All eight signal nets plus the GND stitch via are captured.
+        for net in _ALL_SIGNAL_NETS:
+            assert net in by_name, f"{net} not captured"
+        assert "GND" in by_name, "stitch-via net not captured"
+        gnd_vias = by_name["GND"].vias
+        assert any(abs(v.x - 12.3456) < 1e-4 and abs(v.y - 23.4567) < 1e-4 for v in gnd_vias), (
+            "captured GND route is missing the stitch via"
+        )
+
+    def test_serialize_emits_segments_and_vias(self, tmp_path, board_text):
+        """AC #3/#4: serialization round-trips segments and the stitch via."""
+        net_names = parse_net_names(board_text)
+        gnd_net = next(nid for nid, name in net_names.items() if name == "GND")
+        stitched = _inject_stitch_via(board_text, net=gnd_net, x=12.3456, y=23.4567)
+
+        in_path = tmp_path / "stitched.kicad_pcb"
+        in_path.write_text(stitched)
+
+        preserved = _capture_preserved_routes(in_path)
+        sexp = _serialize_preserved_routes(preserved)
+
+        total_segments = sum(len(r.segments) for r in preserved)
+        assert sexp.count("(segment") == total_segments
+        # The standalone stitch via must appear in the serialized output.
+        assert "(at 12.3456 23.4567)" in sexp
+
+    def test_serialize_dedupes_rerouted_net(self, tmp_path, board_text):
+        """AC #3: a net in ``exclude_net_ids`` is not re-emitted (no double-emit)."""
+        in_path = tmp_path / "board.kicad_pcb"
+        in_path.write_text(board_text)
+
+        preserved = _capture_preserved_routes(in_path)
+        line_a = next(r for r in preserved if r.net_name == "LINE_A")
+
+        full = _serialize_preserved_routes(preserved)
+        deduped = _serialize_preserved_routes(preserved, exclude_net_ids={line_a.net})
+
+        # Excluding LINE_A drops exactly LINE_A's segments from the output.
+        assert full.count("(segment") - deduped.count("(segment") == len(line_a.segments)
+        # And LINE_A's specific geometry is absent from the deduped sexp.
+        first_seg = line_a.segments[0]
+        token = f"(start {first_seg.x1:.4f} {first_seg.y1:.4f})"
+        # Only assert absence if the start point is unique to LINE_A (it is on
+        # this board); guard against a shared coordinate causing a flake.
+        if full.count(token) == 1:
+            assert token not in deduped
+
+
+class TestPreserveExistingFinalize:
+    """Unit-level companion: existing-routes load + finalize re-emission."""
+
+    def test_load_existing_routes_populates_router(self, tmp_path, board_text):
+        """load_existing_routes=True parses existing copper into existing_routes."""
+        in_path = tmp_path / "board.kicad_pcb"
+        in_path.write_text(board_text)
+
+        router, _net_map = load_pcb_for_routing(
+            str(in_path),
+            load_existing_routes=True,
+            validate_drc=False,
+            strict_drc=False,
+        )
+        assert len(router.existing_routes) >= 1
+        loaded_nets = {r.net_name for r in router.existing_routes}
+        assert "NODE_A" in loaded_nets
+
+    def test_finalize_appends_preserved_geometry(self, tmp_path, board_text):
+        """preserve_existing=True appends preserved_routes to route_sexp; off does not."""
+        in_path = tmp_path / "board.kicad_pcb"
+        in_path.write_text(board_text)
+
+        router, _net_map = load_pcb_for_routing(
+            str(in_path),
+            skip_nets=_SKIP_ALL_BUT_LINE_A.split(","),
+            validate_drc=False,
+            strict_drc=False,
+        )
+        multi_pad = {n for n, p in router.nets.items() if n > 0 and len(p) >= 2}
+        preserved = _capture_preserved_routes(in_path)
+
+        # No nets routed in this synthetic call (router.routes is empty), so
+        # every preserved route should be re-emitted.
+        route_sexp, _stats, _cleanup = _finalize_routes(
+            router,
+            multi_pad,
+            len(multi_pad),
+            quiet=True,
+            preserve_existing=True,
+            preserved_routes=preserved,
+        )
+        total_preserved_segments = sum(len(r.segments) for r in preserved)
+        assert route_sexp.count("(segment") == total_preserved_segments
+
+        # With preserve_existing=False the existing geometry is NOT re-emitted
+        # (regression-safe: matches pre-#3155 behaviour).
+        route_sexp_off, _s, _c = _finalize_routes(
+            router,
+            multi_pad,
+            len(multi_pad),
+            quiet=True,
+            preserve_existing=False,
+            preserved_routes=preserved,
+        )
+        assert route_sexp_off.count("(segment") == 0


### PR DESCRIPTION
## Summary

Adds an opt-in `kct route --preserve-existing` mode so re-routing a
partially-routed board no longer clobbers existing copper. Default (flag
off) is bit-for-bit identical to today. Closes #3155.

The infrastructure already existed (`load_pcb_for_routing` had a dormant
`load_existing_routes` param + `router.existing_routes`); this wires it
up on the CLI path and adds the missing re-serialization.

### Root cause (3 gaps, all on the CLI route path)
1. `--skip-nets` only zeroed a skipped net's pads, never its geometry.
2. The writer strips all top-level `(segment)`/`(via)` (#2976) then
   re-inserts only `Autorouter.to_sexp()` (freshly-routed `self.routes`),
   so skipped-net copper + stitch vias were deleted.
3. `load_existing_routes` was never enabled by any of the 4 route entry
   points, and the loaded routes were never re-emitted.

### What changed
- **Flag**: `--preserve-existing` (store_true) added to both the outer
  (`parser.py`) and inner (`route_cmd.py`) route parsers, plus the
  forwarding shim (`commands/routing.py`). Verified by the existing
  parser-drift guard test.
- **Plumbing**: `load_existing_routes=getattr(args,"preserve_existing",False)`
  at all four `load_pcb_for_routing` call sites
  (layer-escalation, rule-relaxation, combined-escalation, main).
- **Re-emission**: preserved copper is captured ONCE from the
  freshly-staged input (`_capture_preserved_routes`) and re-emitted both
  in the checkpoint callback (`_make_checkpoint_callback`) and in
  `_finalize_routes` after cleanup. Capturing once is required because
  the escalation loop re-reads the staged file (== output path) and
  checkpoint writes overwrite it with routed-only geometry, so the
  per-attempt `router.existing_routes` cannot be trusted across attempts.
- **Dedupe**: a net that is both pre-existing and re-routed is emitted
  from the routed copy only.
- `Autorouter.to_sexp()` is left untouched (regression-safe).

### Verification (curator's reproduction)
On `boards/02-charlieplex-led/output/charlieplex_3x3_routed.kicad_pcb`,
re-routing while skipping all-but-one net:
- **Before**: output collapsed to 4 segments (skipped nets + vias gone).
- **After (`--preserve-existing`)**: 232 -> 234 segments; all 7 skipped
  nets preserved byte-identically (geometry, widths, layers), only the
  target net re-routed. Preservation also survives multi-attempt layer
  escalation (2L -> 6L).
- **Default (no flag)**: still strips skipped-net copper exactly as
  before (regression-safe).

## Test plan
- [x] New `tests/router/test_preserve_existing.py` (7 tests): byte-identical
      preservation, default-strips, capture/serialize/dedupe helpers
      (incl. standalone stitch via), `load_existing_routes` population, and
      finalize append on/off. All green (~27s).
- [x] `tests/test_cli_parser_drift.py` passes (outer/inner/shim flag sync).
- [x] `tests/router/test_strip_route_blocks.py` + checkpoint-in-escalation
      tests pass (no regression to the #2976 strip or #2808 checkpoint paths).
- [x] Changed files pass `ruff format --check` and `ruff check`.

## Notes
- `tests/test_layer_escalation.py::TestEarlyTermination` (9 tests) fail on
  this branch, but they ALSO fail on the unmodified baseline (verified by
  stashing this PR's changes) -- pre-existing, unrelated (`MagicMock > int`
  in DRC nudge `_edge_clearance`).
- Repo-wide `ruff` reports many pre-existing format/lint findings unrelated
  to this PR; only this PR's files were touched and they are clean.
- `uv.lock` was modified in the working tree before this work (unrelated
  `ipc`/`pynng` extra) and is intentionally NOT included in this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)