### PR TITLE
feat(audit): name detected analog components instead of a bare count

### DIFF
--- a/src/kicad_tools/audit/auditor.py
+++ b/src/kicad_tools/audit/auditor.py
@@ -1386,14 +1386,20 @@ class ManufacturingAudit:
             from kicad_tools.analysis.analog_detect import detect_analog_components
 
             analog = detect_analog_components(pcb)
-            if analog:
-                count = len(analog)
+            for component in analog:
+                # Name each detected component (reference + value + reason)
+                # so the engineer knows WHICH parts need analog layout care,
+                # not just how many. Detection logic itself is unchanged --
+                # this only surfaces the detail the detector already produced.
+                ref = component.reference or "?"
+                value = component.value.strip()
+                ref_value = f"{ref} ({value})" if value else ref
                 items.append(
                     ActionItem(
                         priority=3,
                         description=(
-                            f"{count} analog-sensitive component{'s' if count != 1 else ''}"
-                            " detected — manual layout review recommended"
+                            f"Analog-sensitive: {ref_value} — {component.reason}"
+                            "; manual layout review recommended"
                         ),
                         command=None,
                     )

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,6 +1,7 @@
 """Tests for manufacturing readiness audit (kct audit command)."""
 
 import json
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import pytest
@@ -2660,3 +2661,128 @@ class TestConnectivityStatusZoneVerification:
         d = status.to_dict()
         assert d["zone_connected_nets"] == 3
         assert d["has_zones"] is True
+
+
+class TestAnalogActionItems:
+    """Analog-sensitive components are NAMED in the audit action items.
+
+    Phase 1 of issue #3156: ``_generate_action_items`` must surface the
+    reference / value / reason that ``detect_analog_components`` already
+    produces, rather than collapsing the list to a count. Uses the
+    mock-PCB pattern (a minimal object exposing ``.footprints`` with
+    ``.reference`` / ``.value`` / ``.name``) and monkeypatches
+    ``_load_pcb`` so no analog ``.kicad_pcb`` fixture is required.
+    """
+
+    @dataclass
+    class _MockFootprint:
+        reference: str = ""
+        value: str = ""
+        name: str = ""
+
+    @dataclass
+    class _MockPCB:
+        footprints: list = field(default_factory=list)
+
+    def _make_audit(self, drc_clean_pcb: Path, monkeypatch, footprints):
+        """Build an Auditor whose PCB load returns the given footprints."""
+        audit = ManufacturingAudit(drc_clean_pcb, manufacturer="jlcpcb")
+        mock_pcb = self._MockPCB(footprints=list(footprints))
+        monkeypatch.setattr(audit, "_load_pcb", lambda: mock_pcb)
+        return audit
+
+    def _analog_items(self, items):
+        return [i for i in items if i.description.startswith("Analog-sensitive:")]
+
+    def test_names_each_detected_component(self, drc_clean_pcb: Path, monkeypatch):
+        """Every detected analog component is named with ref, value, reason."""
+        audit = self._make_audit(
+            drc_clean_pcb,
+            monkeypatch,
+            [
+                self._MockFootprint(reference="U2", value="PCM5122", name="PCM5122"),
+                self._MockFootprint(reference="U3", value="OPA2134", name="OPA2134"),
+            ],
+        )
+        items = audit._generate_action_items(AuditResult())
+        analog = self._analog_items(items)
+
+        assert len(analog) == 2
+        descriptions = [i.description for i in analog]
+
+        # U2 is an audio DAC; U3 is an op-amp -- both named with ref+value+reason.
+        assert any(
+            "U2" in d and "PCM5122" in d and "audio DAC (PCM51xx family)" in d for d in descriptions
+        )
+        assert any("U3" in d and "OPA2134" in d and "op-amp" in d for d in descriptions)
+
+        # Advisory priority (non-blocking gate), no fix command.
+        for item in analog:
+            assert item.priority == 3
+            assert item.command is None
+
+    def test_single_component_named(self, drc_clean_pcb: Path, monkeypatch):
+        """A single analog component is still named (not a bare count)."""
+        audit = self._make_audit(
+            drc_clean_pcb,
+            monkeypatch,
+            [self._MockFootprint(reference="U7", value="REF3025", name="REF3025")],
+        )
+        items = audit._generate_action_items(AuditResult())
+        analog = self._analog_items(items)
+
+        assert len(analog) == 1
+        assert "U7" in analog[0].description
+        assert "REF3025" in analog[0].description
+        assert "precision voltage reference" in analog[0].description
+        # The vague count-only wording must be gone.
+        assert "analog-sensitive component" not in analog[0].description.lower()
+
+    def test_no_analog_components_emits_no_item(self, drc_clean_pcb: Path, monkeypatch):
+        """A purely digital board produces no analog action item."""
+        audit = self._make_audit(
+            drc_clean_pcb,
+            monkeypatch,
+            [
+                self._MockFootprint(reference="U1", value="STM32F407", name="STM32F407"),
+                self._MockFootprint(reference="R1", value="10k", name="R_0402"),
+            ],
+        )
+        items = audit._generate_action_items(AuditResult())
+        assert self._analog_items(items) == []
+
+    def test_detection_exception_does_not_crash(self, drc_clean_pcb: Path, monkeypatch):
+        """A detector/PCB-load failure is swallowed; audit still returns."""
+        audit = ManufacturingAudit(drc_clean_pcb, manufacturer="jlcpcb")
+
+        def _boom():
+            raise RuntimeError("malformed PCB")
+
+        monkeypatch.setattr(audit, "_load_pcb", _boom)
+
+        # Must not raise, and must still return the (non-analog) items.
+        items = audit._generate_action_items(AuditResult())
+        assert self._analog_items(items) == []
+
+    def test_json_path_carries_per_component_detail(self, drc_clean_pcb: Path, monkeypatch):
+        """The JSON serialization of action items keeps the per-component names."""
+        audit = self._make_audit(
+            drc_clean_pcb,
+            monkeypatch,
+            [
+                self._MockFootprint(reference="U2", value="PCM5122", name="PCM5122"),
+                self._MockFootprint(reference="U3", value="OPA2134", name="OPA2134"),
+            ],
+        )
+        result = AuditResult()
+        result.action_items = audit._generate_action_items(result)
+
+        payload = json.dumps(result.to_dict(), default=str)
+        data = json.loads(payload)
+        analog = [
+            i for i in data["action_items"] if i["description"].startswith("Analog-sensitive:")
+        ]
+        assert len(analog) == 2
+        joined = " ".join(i["description"] for i in analog)
+        assert "U2" in joined and "PCM5122" in joined
+        assert "U3" in joined and "OPA2134" in joined


### PR DESCRIPTION
## Summary

Phase 1 of #3156. `kct audit` previously reported "N analog-sensitive components detected" and threw away the per-component detail that `detect_analog_components()` already produces. The fix is a one-spot data-plumbing change in `_generate_action_items` (`src/kicad_tools/audit/auditor.py`): stop collapsing the `AnalogComponent` list to `count = len(analog)`, and instead emit one `priority=3` `ActionItem` per component naming its **reference**, **value**, and **detection reason**.

Example output for a board with `U2=PCM5122` and `U3=OPA2134`:

```
[OPTIONAL] Analog-sensitive: U2 (PCM5122) — audio DAC (PCM51xx family); manual layout review recommended
[OPTIONAL] Analog-sensitive: U3 (OPA2134) — op-amp (TI OPA); manual layout review recommended
```

- Detection logic (`src/kicad_tools/analysis/analog_detect.py`) is **unchanged** — this only surfaces detail the detector already found.
- The CLI renderer (`src/kicad_tools/cli/audit_cmd.py:339-349`) and JSON path (`AuditResult.to_dict` -> `action_items`) already iterate `action_items`, so no renderer change was needed; both table and JSON output inherit the names for free.
- The `try/except` guard and `priority=3` (advisory, non-blocking) are preserved.

## Scope (Phase 1 only)

The current detector is **component-level, not net-level**. The net-centric examples in the original issue (isolated `GNDA` ground, `+3.3VA` plane vias, `AUDIO_L/R`, unbridged ferrite/net-tie) cannot be produced by today's code and require a new net classifier. Those are explicitly deferred:

- **Phase 2 (#3170)** — net-level analog detection + GNDA-bridge flagging (original ACs #2, #3).
- **Phase 3 (#3171)** — analog-aware routing flags (`--analog-nets`).

## Tests

New `TestAnalogActionItems` class in `tests/test_audit.py` (MockPCB/MockFootprint pattern + monkeypatched `Auditor._load_pcb`, per curator guidance — no committed PCB has analog parts):

- Multiple components named (ref + value + reason).
- Single component named (no bare count).
- Zero analog components -> no action item.
- Detection failure swallowed -> audit does not crash.
- JSON serialization carries per-component detail.

## Test plan

- [x] `uv run pytest tests/test_analog_detect.py tests/test_audit.py::TestAnalogActionItems` — 46 passed (analog detector suite unmodified and green).
- [x] Manual: `_generate_action_items` on a mock PCB with PCM5122 + OPA2134 emits the named items shown above.
- [x] `ruff check` / `ruff format` clean on changed files (`auditor.py`, new test region).
- [ ] Note: `tests/test_audit.py::TestZoneConnectedNets::test_no_zones_regression` fails pre-existing on `main` (unrelated to this change).

Closes #3156

Generated with Claude Code