### PR TITLE
feat(sch): suggest-footprint + pin-count validation in set-footprint

### DIFF
--- a/src/kicad_tools/cli/commands/schematic.py
+++ b/src/kicad_tools/cli/commands/schematic.py
@@ -10,9 +10,12 @@ def run_sch_command(args) -> int:
     """Handle schematic subcommands."""
     if not args.sch_command:
         print("Usage: kicad-tools sch <command> [options] <file>")
-        print("Commands: summary, hierarchy, labels, validate, preflight, wires, info, pins, pin-map,")
         print(
-            "          connections, unconnected, set-footprint, set-value, set-reference,"
+            "Commands: summary, hierarchy, labels, validate, preflight, wires, info, pins, pin-map,"
+        )
+        print(
+            "          connections, unconnected, set-footprint, suggest-footprint,"
+            " set-value, set-reference,"
             " set-symbol-property, replace,"
             " sync-hierarchy, rename-signal,"
         )
@@ -24,9 +27,7 @@ def run_sch_command(args) -> int:
             "          add-wire, add-junction,"
             " add-label, cleanup-wires, remove-wire, insert-inline,"
         )
-        print(
-            "          disconnect, reconnect-pin, move-component, remove-component, re-annotate,"
-        )
+        print("          disconnect, reconnect-pin, move-component, remove-component, re-annotate,")
         print("          repair-instances")
         return 1
 
@@ -177,6 +178,19 @@ def run_sch_command(args) -> int:
             map_path=map_path,
             dry_run=getattr(args, "dry_run", False),
             backup=getattr(args, "backup", True),
+            validate=getattr(args, "validate", True),
+            strict=getattr(args, "strict", False),
+        )
+
+    elif args.sch_command == "suggest-footprint":
+        from ..sch_suggest_footprint import run_suggest_footprint
+
+        return run_suggest_footprint(
+            schematic_path=schematic_path,
+            ref=args.ref,
+            package=getattr(args, "package", None),
+            output_format=getattr(args, "format", "text"),
+            limit=getattr(args, "limit", 20),
         )
 
     elif args.sch_command == "set-value":
@@ -512,7 +526,15 @@ def run_sch_command(args) -> int:
     elif args.sch_command == "reconnect-pin":
         from ..sch_reconnect_pin import main as reconnect_pin_main
 
-        sub_argv = [str(schematic_path), "--ref", args.ref, "--pin", args.pin, "--to-net", args.to_net]
+        sub_argv = [
+            str(schematic_path),
+            "--ref",
+            args.ref,
+            "--pin",
+            args.pin,
+            "--to-net",
+            args.to_net,
+        ]
         if args.lib_paths:
             for path in args.lib_paths:
                 sub_argv.extend(["--lib-path", path])

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -623,6 +623,36 @@ def _add_sch_parser(subparsers) -> None:
         "--dry-run", "-n", action="store_true", help="Preview changes without modifying files"
     )
     sch_set_fp.add_argument("--backup", action="store_true", help="Create backup before modifying")
+    sch_set_fp.add_argument(
+        "--no-validate",
+        dest="validate",
+        action="store_false",
+        default=True,
+        help="Skip pin-count validation against the footprint library",
+    )
+    sch_set_fp.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail on any pin-count mismatch, even in batch mode",
+    )
+
+    # sch suggest-footprint
+    sch_suggest_fp = sch_subparsers.add_parser(
+        "suggest-footprint",
+        help="Suggest library footprints for a symbol by pin count / package",
+    )
+    sch_suggest_fp.add_argument("schematic", help="Path to .kicad_sch file")
+    sch_suggest_fp.add_argument("--ref", required=True, help="Symbol reference (e.g., U7, R1)")
+    sch_suggest_fp.add_argument(
+        "--package",
+        help="Package keyword hint to filter/rank candidates (e.g., SOT-23, R_0603)",
+    )
+    sch_suggest_fp.add_argument(
+        "--format", choices=["text", "json"], default="text", help="Output format"
+    )
+    sch_suggest_fp.add_argument(
+        "--limit", type=int, default=20, help="Maximum number of suggestions (default: 20)"
+    )
 
     # sch set-value
     sch_set_val = sch_subparsers.add_parser("set-value", help="Set value property for symbols")

--- a/src/kicad_tools/cli/sch_set_footprint.py
+++ b/src/kicad_tools/cli/sch_set_footprint.py
@@ -24,11 +24,19 @@ import re
 import sys
 from pathlib import Path
 
+from kicad_tools.cli.lib_footprints import _count_pads
 from kicad_tools.cli.modify_schematic import (
     create_backup,
     find_symbol_text_range,
     set_footprint_text,
 )
+from kicad_tools.core.sexp_file import load_footprint
+from kicad_tools.footprints.library_path import (
+    LibraryPaths,
+    detect_kicad_library_path,
+    parse_library_id,
+)
+from kicad_tools.schema import Schematic
 
 
 def _find_subsheet_files(text: str, schematic_dir: Path) -> list[Path]:
@@ -103,6 +111,66 @@ def _load_mapping(map_path: Path) -> dict[str, str]:
     return mapping
 
 
+def _footprint_pad_count(paths: LibraryPaths, footprint: str) -> int | None:
+    """Resolve a ``Library:Footprint`` (or bare name) to its pad count.
+
+    Returns ``None`` when the footprint file cannot be located -- e.g. no
+    library is installed, an unknown library/footprint, or a parse error.
+    Validation callers treat ``None`` as "cannot validate" and skip silently.
+    """
+    if not paths.found:
+        return None
+
+    lib, name = parse_library_id(footprint)
+    fp_path: Path | None = None
+    if lib:
+        fp_path = paths.get_footprint_file(lib, name, fallback_search=True)
+    else:
+        fp_path = paths.find_footprint_by_name(name)
+
+    if fp_path is None:
+        return None
+
+    try:
+        sexp = load_footprint(fp_path)
+        return _count_pads(sexp)
+    except Exception:
+        return None
+
+
+def _build_symbol_pin_counts(schematic_path: Path) -> dict[str, int]:
+    """Map symbol reference -> expected pin count for the whole hierarchy.
+
+    Prefers the resolved library-symbol pin count, falling back to the
+    instance pin list. Failures are swallowed so validation can degrade to
+    "no data" rather than aborting the assignment.
+    """
+    counts: dict[str, int] = {}
+    for sch_file in _collect_schematic_files(schematic_path):
+        try:
+            sch = Schematic.load(sch_file)
+        except Exception:
+            continue
+        for sym in sch.symbols:
+            ref = sym.reference
+            if not ref:
+                continue
+            pin_count: int | None = None
+            try:
+                lib_sym = sch.get_lib_symbol_resolved(sym.lib_id)
+                if lib_sym is not None and lib_sym.pin_count > 0:
+                    pin_count = lib_sym.pin_count
+            except Exception:
+                pin_count = None
+            if pin_count is None:
+                inst = len(sym.pins)
+                if inst > 0:
+                    pin_count = inst
+            if pin_count is not None:
+                counts[ref] = pin_count
+    return counts
+
+
 def run_set_footprint(
     schematic_path: Path,
     ref: str | None = None,
@@ -110,8 +178,18 @@ def run_set_footprint(
     map_path: Path | None = None,
     dry_run: bool = False,
     backup: bool = True,
+    validate: bool = True,
+    strict: bool = False,
+    config_override: str | Path | None = None,
 ) -> int:
     """Run the set-footprint operation.
+
+    When *validate* is True and a KiCad footprint library is available, each
+    assigned footprint's pad count is compared against the symbol's pin count
+    and a warning is emitted on mismatch. In single-ref mode (or under
+    *strict*), a mismatch makes the command exit non-zero; in batch mode the
+    mismatch only warns so existing bulk-assign workflows are unaffected.
+    When no library is available, validation is silently skipped.
 
     Returns 0 on success, 1 on error.
     """
@@ -137,6 +215,40 @@ def run_set_footprint(
     else:
         print("Error: Provide either --ref/--footprint or --map", file=sys.stderr)
         return 1
+
+    single_ref_mode = map_path is None
+
+    # --- Pin-count validation (best-effort, before any modification) ---
+    if validate:
+        paths = detect_kicad_library_path(config_override)
+        if paths.found:
+            symbol_pins = _build_symbol_pin_counts(schematic_path)
+            mismatches: list[str] = []
+            for r, fp in mapping.items():
+                expected = symbol_pins.get(r)
+                if expected is None:
+                    continue
+                pad_count = _footprint_pad_count(paths, fp)
+                if pad_count is None:
+                    continue
+                if pad_count != expected:
+                    mismatches.append(
+                        f"  {r}: symbol has {expected} pins but footprint "
+                        f"'{fp}' has {pad_count} pads"
+                    )
+            if mismatches:
+                print(
+                    "Warning: pin-count mismatch between symbol and footprint:",
+                    file=sys.stderr,
+                )
+                for m in mismatches:
+                    print(m, file=sys.stderr)
+                if single_ref_mode or strict:
+                    print(
+                        "Aborting due to pin-count mismatch (use --no-validate to override).",
+                        file=sys.stderr,
+                    )
+                    return 1
 
     # Collect all schematic files (root + sub-sheets)
     all_files = _collect_schematic_files(schematic_path)
@@ -233,8 +345,18 @@ def main(argv: list[str] | None = None):
     parser.add_argument(
         "--dry-run", "-n", action="store_true", help="Preview changes without modifying files"
     )
+    parser.add_argument("--no-backup", action="store_true", help="Skip creating backup files")
     parser.add_argument(
-        "--no-backup", action="store_true", help="Skip creating backup files"
+        "--no-validate",
+        dest="validate",
+        action="store_false",
+        default=True,
+        help="Skip pin-count validation against the footprint library",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail on any pin-count mismatch, even in batch mode",
     )
 
     args = parser.parse_args(argv)
@@ -260,6 +382,8 @@ def main(argv: list[str] | None = None):
         map_path=args.map_file,
         dry_run=args.dry_run,
         backup=not args.no_backup,
+        validate=args.validate,
+        strict=args.strict,
     )
 
 

--- a/src/kicad_tools/cli/sch_suggest_footprint.py
+++ b/src/kicad_tools/cli/sch_suggest_footprint.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""
+Suggest library footprints for a schematic symbol.
+
+Given a component reference, this command looks up matching KiCad library
+footprints based on the symbol's pin count and an optional package keyword
+hint. It reuses the existing library-detection primitives in
+``kicad_tools.footprints.library_path`` and the pad-counting helper in
+``kicad_tools.cli.lib_footprints``.
+
+The KiCad standard footprint library must be installed for this command to
+return suggestions. When no library can be found (common on CI runners and
+fresh checkouts), the command prints an actionable message suggesting the
+``KICAD_FOOTPRINT_DIR`` environment variable and exits non-zero rather than
+crashing.
+
+Usage:
+    kicad-tools sch suggest-footprint board.kicad_sch --ref U7 --package SOT-23
+
+    # Limit candidate libraries searched and number of results
+    kicad-tools sch suggest-footprint board.kicad_sch --ref R1 \\
+        --package R_0603 --limit 10
+
+    # JSON output
+    kicad-tools sch suggest-footprint board.kicad_sch --ref U7 \\
+        --package SOT-23 --format json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from kicad_tools.cli.lib_footprints import _count_pads
+from kicad_tools.core.sexp_file import load_footprint
+from kicad_tools.footprints.library_path import (
+    LibraryPaths,
+    detect_kicad_library_path,
+    guess_standard_library,
+    list_available_libraries,
+)
+from kicad_tools.schema import Schematic
+
+# Cap how many footprint files we read while ranking, so a no-keyword search
+# across all 150+ libraries cannot blow up into reading tens of thousands of
+# .kicad_mod files.
+_MAX_SCANNED_FOOTPRINTS = 5000
+
+
+def _resolve_target_pin_count(sch: Schematic, sym: Any) -> int | None:
+    """Determine the expected pad count for a symbol.
+
+    Prefers the resolved library-symbol pin count (handles ``extends``
+    chains via :meth:`Schematic.get_lib_symbol_resolved`); falls back to the
+    instance pin list. Returns ``None`` if neither yields a positive count.
+    """
+    try:
+        lib_sym = sch.get_lib_symbol_resolved(sym.lib_id)
+        if lib_sym is not None and lib_sym.pin_count > 0:
+            return lib_sym.pin_count
+    except Exception:
+        pass
+
+    instance_count = len(sym.pins)
+    if instance_count > 0:
+        return instance_count
+    return None
+
+
+def _derive_keyword(sym: Any) -> str | None:
+    """Best-effort package keyword from the symbol's value or lib_id.
+
+    Uses the same prefix conventions as :func:`guess_standard_library` (e.g.
+    ``SOT-`` -> ``Package_TO_SOT_SMD``) applied to the footprint-name-ish
+    fields available on a symbol. This is intentionally weak: true package
+    inference needs ``ki_fp_filters`` parsing (deferred follow-up). Returns
+    the standard library name if a prefix matches, else ``None``.
+    """
+    for candidate in (sym.value, sym.lib_id.split(":")[-1]):
+        if not candidate:
+            continue
+        lib = guess_standard_library(candidate)
+        if lib:
+            return lib
+    return None
+
+
+def _candidate_library_paths(paths: LibraryPaths, keyword: str | None) -> list[tuple[str, Path]]:
+    """Return (library_name, library_dir) pairs to scan for candidates.
+
+    When *keyword* is given, libraries whose name OR whose standard-library
+    mapping matches the keyword are preferred. If nothing matches (or no
+    keyword), all available libraries are returned.
+    """
+    all_libs = list_available_libraries(paths)
+    result: list[tuple[str, Path]] = []
+
+    if keyword:
+        kw_lower = keyword.lower()
+        # A keyword may itself be a footprint-name prefix (e.g. "SOT-23",
+        # "R_0603"); map it to a standard library when possible.
+        mapped_lib = guess_standard_library(keyword)
+        for lib in all_libs:
+            lib_lower = lib.lower()
+            if kw_lower in lib_lower or (mapped_lib and lib == mapped_lib):
+                lib_path = paths.get_library_path(lib)
+                if lib_path is not None:
+                    result.append((lib, lib_path))
+
+    if not result:
+        # No keyword, or keyword did not match any library name: scan all.
+        for lib in all_libs:
+            lib_path = paths.get_library_path(lib)
+            if lib_path is not None:
+                result.append((lib, lib_path))
+
+    return result
+
+
+def _rank_key(candidate: dict[str, Any], keyword: str | None) -> tuple:
+    """Sort key: keyword-name matches first, non-hand-solder before hand, A-Z."""
+    name = candidate["footprint"]
+    name_lower = name.lower()
+    kw_match = 0
+    if keyword and keyword.lower() in name_lower:
+        kw_match = -1  # sorts before non-matches
+    hand = 1 if "handsolder" in name_lower.replace("_", "") else 0
+    return (kw_match, hand, candidate["library"], name)
+
+
+def find_footprint_candidates(
+    paths: LibraryPaths,
+    target_pins: int | None,
+    keyword: str | None,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Find footprints whose pad count matches *target_pins*.
+
+    Args:
+        paths: Detected library paths (must be ``found``).
+        target_pins: Required pad count, or ``None`` to accept any count.
+        keyword: Optional package keyword used for library filtering + ranking.
+        limit: Maximum number of candidates to return.
+
+    Returns:
+        Ranked list of dicts with ``library``, ``footprint``, ``pads`` keys.
+    """
+    candidates: list[dict[str, Any]] = []
+    scanned = 0
+
+    for lib_name, lib_dir in _candidate_library_paths(paths, keyword):
+        for mod_file in sorted(lib_dir.glob("*.kicad_mod")):
+            if scanned >= _MAX_SCANNED_FOOTPRINTS:
+                break
+            scanned += 1
+            try:
+                sexp = load_footprint(mod_file)
+                pad_count = _count_pads(sexp)
+            except Exception:
+                continue
+            if target_pins is not None and pad_count != target_pins:
+                continue
+            candidates.append(
+                {
+                    "library": lib_name,
+                    "footprint": mod_file.stem,
+                    "pads": pad_count,
+                }
+            )
+        if scanned >= _MAX_SCANNED_FOOTPRINTS:
+            break
+
+    candidates.sort(key=lambda c: _rank_key(c, keyword))
+    return candidates[:limit]
+
+
+def run_suggest_footprint(
+    schematic_path: Path,
+    ref: str,
+    package: str | None = None,
+    output_format: str = "text",
+    limit: int = 20,
+    config_override: str | Path | None = None,
+) -> int:
+    """Suggest library footprints for the symbol *ref*.
+
+    Returns 0 when at least one candidate is found, 1 otherwise (including the
+    no-library and symbol-not-found cases).
+    """
+    if not schematic_path.exists():
+        print(f"Error: File not found: {schematic_path}", file=sys.stderr)
+        return 1
+
+    try:
+        sch = Schematic.load(schematic_path)
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"Error loading schematic: {e}", file=sys.stderr)
+        return 1
+
+    sym = sch.get_symbol(ref)
+    if sym is None:
+        print(f"Error: Symbol '{ref}' not found in {schematic_path.name}", file=sys.stderr)
+        return 1
+
+    target_pins = _resolve_target_pin_count(sch, sym)
+    keyword = package or _derive_keyword(sym)
+
+    # Detect KiCad library; degrade gracefully if absent.
+    paths = detect_kicad_library_path(config_override)
+    if not paths.found:
+        print(
+            "Error: No KiCad footprint library found. "
+            "suggest-footprint requires the standard KiCad footprint libraries.\n"
+            "Set the KICAD_FOOTPRINT_DIR environment variable to the directory "
+            "containing your '*.pretty' footprint libraries, e.g.\n"
+            "  export KICAD_FOOTPRINT_DIR="
+            "/Applications/KiCad/KiCad.app/Contents/SharedSupport/footprints",
+            file=sys.stderr,
+        )
+        return 1
+
+    candidates = find_footprint_candidates(paths, target_pins, keyword, limit)
+
+    if output_format == "json":
+        print(
+            json.dumps(
+                {
+                    "reference": ref,
+                    "value": sym.value,
+                    "lib_id": sym.lib_id,
+                    "pin_count": target_pins,
+                    "package_keyword": keyword,
+                    "library_source": paths.source,
+                    "candidates": candidates,
+                },
+                indent=2,
+            )
+        )
+    else:
+        pin_desc = f"{target_pins} pins" if target_pins is not None else "unknown pin count"
+        kw_desc = f", package hint '{keyword}'" if keyword else ""
+        print(f"Suggestions for {ref} ({sym.value or sym.lib_id}, {pin_desc}{kw_desc}):")
+        if not candidates:
+            print("  (no matching footprints found)")
+        else:
+            for c in candidates:
+                print(f"  {c['library']}:{c['footprint']} ({c['pads']} pads)")
+
+    if not candidates:
+        hint = ""
+        if not package:
+            hint = " Try narrowing with --package (e.g. --package SOT-23)."
+        print(
+            f"No matching footprints found for {ref}.{hint}",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for standalone usage."""
+    parser = argparse.ArgumentParser(
+        description="Suggest library footprints for a schematic symbol",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("schematic", type=Path, help="Path to .kicad_sch file")
+    parser.add_argument("--ref", required=True, help="Symbol reference (e.g., U7, R1)")
+    parser.add_argument(
+        "--package",
+        help="Package keyword hint to filter/rank candidates (e.g., SOT-23, R_0603)",
+    )
+    parser.add_argument("--format", choices=["text", "json"], default="text", help="Output format")
+    parser.add_argument(
+        "--limit", type=int, default=20, help="Maximum number of suggestions (default: 20)"
+    )
+
+    args = parser.parse_args(argv)
+
+    return run_suggest_footprint(
+        schematic_path=args.schematic,
+        ref=args.ref,
+        package=args.package,
+        output_format=args.format,
+        limit=args.limit,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/fixtures/missing_footprint.kicad_sch
+++ b/tests/fixtures/missing_footprint.kicad_sch
@@ -1,0 +1,204 @@
+(kicad_sch
+	(version 20231120)
+	(generator "kicadtools_test")
+	(uuid "00000000-0000-0000-0000-0000000000aa")
+	(paper "A4")
+	(lib_symbols
+		(symbol "Device:R"
+			(pin_numbers hide)
+			(pin_names hide)
+			(symbol "R_0_1"
+				(rectangle
+					(start -1.016 -2.54)
+					(end 1.016 2.54)
+					(stroke (width 0.254))
+					(fill (type none))
+				)
+			)
+			(symbol "R_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 1.27)
+					(name "~")
+					(number "1")
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 1.27)
+					(name "~")
+					(number "2")
+				)
+			)
+		)
+		(symbol "74xGxx:74LVC1G17"
+			(pin_names (offset 0.254))
+			(symbol "74LVC1G17_0_1"
+				(rectangle
+					(start -3.81 3.81)
+					(end 3.81 -3.81)
+					(stroke (width 0.254))
+					(fill (type background))
+				)
+			)
+			(symbol "74LVC1G17_1_1"
+				(pin input line
+					(at -6.35 0 0)
+					(length 2.54)
+					(name "A")
+					(number "2")
+				)
+				(pin output line
+					(at 6.35 0 180)
+					(length 2.54)
+					(name "Y")
+					(number "4")
+				)
+				(pin power_in line
+					(at 0 6.35 270)
+					(length 2.54)
+					(name "VCC")
+					(number "5")
+				)
+				(pin power_in line
+					(at 0 -6.35 90)
+					(length 2.54)
+					(name "GND")
+					(number "3")
+				)
+				(pin no_connect line
+					(at -6.35 -2.54 0)
+					(length 2.54)
+					(name "NC")
+					(number "1")
+				)
+			)
+		)
+		(symbol "Device:NetTie_2"
+			(pin_numbers hide)
+			(pin_names hide)
+			(symbol "NetTie_2_0_1"
+				(polyline
+					(pts (xy -1.016 0) (xy 1.016 0))
+					(stroke (width 0.254))
+					(fill (type none))
+				)
+			)
+			(symbol "NetTie_2_1_1"
+				(pin passive line
+					(at -2.54 0 0)
+					(length 1.524)
+					(name "1")
+					(number "1")
+				)
+				(pin passive line
+					(at 2.54 0 180)
+					(length 1.524)
+					(name "2")
+					(number "2")
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 50 50 0)
+		(unit 1)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "11111111-1111-1111-1111-111111111111")
+		(property "Reference" "R1"
+			(at 52 48 0)
+			(effects (font (size 1.27 1.27)) (justify left))
+		)
+		(property "Value" "10k"
+			(at 52 50 0)
+			(effects (font (size 1.27 1.27)) (justify left))
+		)
+		(property "Footprint" ""
+			(at 50 50 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(property "Datasheet" "~"
+			(at 50 50 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(pin "1" (uuid "aaaa0001-0000-0000-0000-000000000001"))
+		(pin "2" (uuid "aaaa0001-0000-0000-0000-000000000002"))
+		(instances
+			(project "test"
+				(path "/" (reference "R1") (unit 1))
+			)
+		)
+	)
+	(symbol
+		(lib_id "74xGxx:74LVC1G17")
+		(at 100 50 0)
+		(unit 1)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "22222222-2222-2222-2222-222222222222")
+		(property "Reference" "U7"
+			(at 104 46 0)
+			(effects (font (size 1.27 1.27)) (justify left))
+		)
+		(property "Value" "74LVC1G17"
+			(at 104 48 0)
+			(effects (font (size 1.27 1.27)) (justify left))
+		)
+		(property "Footprint" ""
+			(at 100 50 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(property "Datasheet" "~"
+			(at 100 50 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(pin "1" (uuid "bbbb0001-0000-0000-0000-000000000001"))
+		(pin "2" (uuid "bbbb0001-0000-0000-0000-000000000002"))
+		(pin "3" (uuid "bbbb0001-0000-0000-0000-000000000003"))
+		(pin "4" (uuid "bbbb0001-0000-0000-0000-000000000004"))
+		(pin "5" (uuid "bbbb0001-0000-0000-0000-000000000005"))
+		(instances
+			(project "test"
+				(path "/" (reference "U7") (unit 1))
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:NetTie_2")
+		(at 150 50 0)
+		(unit 1)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "33333333-3333-3333-3333-333333333333")
+		(property "Reference" "NT2"
+			(at 152 48 0)
+			(effects (font (size 1.27 1.27)) (justify left))
+		)
+		(property "Value" "NetTie_2"
+			(at 152 50 0)
+			(effects (font (size 1.27 1.27)) (justify left))
+		)
+		(property "Footprint" ""
+			(at 150 50 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(property "Datasheet" "~"
+			(at 150 50 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(pin "1" (uuid "cccc0001-0000-0000-0000-000000000001"))
+		(pin "2" (uuid "cccc0001-0000-0000-0000-000000000002"))
+		(instances
+			(project "test"
+				(path "/" (reference "NT2") (unit 1))
+			)
+		)
+	)
+	(sheet_instances
+		(path "/" (page "1"))
+	)
+)

--- a/tests/test_sch_set_footprint.py
+++ b/tests/test_sch_set_footprint.py
@@ -119,7 +119,9 @@ SPACE_INDENTED_SCHEMATIC = """\
 """
 
 
-def _write_sch(tmp_path: Path, content: str = MINIMAL_SCHEMATIC, name: str = "test.kicad_sch") -> Path:
+def _write_sch(
+    tmp_path: Path, content: str = MINIMAL_SCHEMATIC, name: str = "test.kicad_sch"
+) -> Path:
     p = tmp_path / name
     p.write_text(content)
     return p
@@ -253,7 +255,9 @@ class TestLoadMapping:
 
     def test_csv_with_comments(self, tmp_path):
         p = tmp_path / "map.csv"
-        p.write_text("# Header comment\nR1,Resistor_SMD:R_0805\n\n# Another comment\nC1,Capacitor_SMD:C_0603\n")
+        p.write_text(
+            "# Header comment\nR1,Resistor_SMD:R_0805\n\n# Another comment\nC1,Capacitor_SMD:C_0603\n"
+        )
         result = _load_mapping(p)
         assert len(result) == 2
 
@@ -325,10 +329,14 @@ class TestRunSetFootprint:
     def test_batch_json_mapping(self, tmp_path):
         sch = _write_sch(tmp_path)
         map_path = tmp_path / "map.json"
-        map_path.write_text(json.dumps({
-            "R1": "Resistor_SMD:R_0805_2012Metric",
-            "C1": "Capacitor_SMD:C_0603_1608Metric",
-        }))
+        map_path.write_text(
+            json.dumps(
+                {
+                    "R1": "Resistor_SMD:R_0805_2012Metric",
+                    "C1": "Capacitor_SMD:C_0603_1608Metric",
+                }
+            )
+        )
         ret = run_set_footprint(
             schematic_path=sch,
             map_path=map_path,
@@ -492,10 +500,14 @@ class TestHierarchicalSchematic:
         child.write_text(CHILD_SCHEMATIC)
 
         map_path = tmp_path / "map.json"
-        map_path.write_text(json.dumps({
-            "R1": "Resistor_SMD:R_0805_2012Metric",
-            "C2": "Capacitor_SMD:C_0805_2012Metric",
-        }))
+        map_path.write_text(
+            json.dumps(
+                {
+                    "R1": "Resistor_SMD:R_0805_2012Metric",
+                    "C2": "Capacitor_SMD:C_0805_2012Metric",
+                }
+            )
+        )
         ret = run_set_footprint(
             schematic_path=parent,
             map_path=map_path,
@@ -523,3 +535,141 @@ class TestHierarchicalSchematic:
         assert ret == 0
         # File should be unchanged
         assert child.read_text() == original_child
+
+
+# ---------------------------------------------------------------------------
+# Pin-count validation tests (require KiCad footprint libraries)
+# ---------------------------------------------------------------------------
+
+from kicad_tools.cli.sch_set_footprint import (  # noqa: E402
+    _build_symbol_pin_counts,
+    _footprint_pad_count,
+)
+from kicad_tools.footprints.library_path import detect_kicad_library_path  # noqa: E402
+
+FIXTURE_MISSING_FP = Path(__file__).parent / "fixtures" / "missing_footprint.kicad_sch"
+
+_LIBS_AVAILABLE = detect_kicad_library_path().found
+
+requires_kicad_libs = pytest.mark.skipif(
+    not _LIBS_AVAILABLE,
+    reason="KiCad footprint libraries not installed in this environment",
+)
+
+
+def _copy_fixture(tmp_path: Path) -> Path:
+    dest = tmp_path / "missing_footprint.kicad_sch"
+    dest.write_text(FIXTURE_MISSING_FP.read_text())
+    return dest
+
+
+class TestPinCountValidation:
+    def test_build_symbol_pin_counts(self):
+        counts = _build_symbol_pin_counts(FIXTURE_MISSING_FP)
+        assert counts["R1"] == 2
+        assert counts["U7"] == 5
+        assert counts["NT2"] == 2
+
+    @requires_kicad_libs
+    def test_footprint_pad_count(self):
+        paths = detect_kicad_library_path()
+        assert _footprint_pad_count(paths, "Package_TO_SOT_SMD:SOT-23-5") == 5
+        assert _footprint_pad_count(paths, "Resistor_SMD:R_0603_1608Metric") == 2
+
+    @requires_kicad_libs
+    def test_mismatch_single_ref_aborts(self, tmp_path, capsys):
+        """AC #4: assigning a 5-pad footprint to a 2-pin part fails."""
+        sch = _copy_fixture(tmp_path)
+        original = sch.read_text()
+        ret = run_set_footprint(
+            schematic_path=sch,
+            ref="R1",
+            footprint="Package_TO_SOT_SMD:SOT-23-5",
+            backup=False,
+        )
+        err = capsys.readouterr().err
+        assert ret == 1
+        assert "pin-count mismatch" in err
+        assert "2 pins" in err and "5 pads" in err
+        # File must not be modified when validation aborts.
+        assert sch.read_text() == original
+
+    @requires_kicad_libs
+    def test_match_single_ref_succeeds(self, tmp_path):
+        """AC #4: a pad-count-matching footprint assigns cleanly."""
+        sch = _copy_fixture(tmp_path)
+        ret = run_set_footprint(
+            schematic_path=sch,
+            ref="R1",
+            footprint="Resistor_SMD:R_0603_1608Metric",
+            backup=False,
+        )
+        assert ret == 0
+        assert "Resistor_SMD:R_0603_1608Metric" in sch.read_text()
+
+    @requires_kicad_libs
+    def test_no_validate_overrides_mismatch(self, tmp_path):
+        """--no-validate (validate=False) lets a mismatch through."""
+        sch = _copy_fixture(tmp_path)
+        ret = run_set_footprint(
+            schematic_path=sch,
+            ref="R1",
+            footprint="Package_TO_SOT_SMD:SOT-23-5",
+            validate=False,
+            backup=False,
+        )
+        assert ret == 0
+        assert "Package_TO_SOT_SMD:SOT-23-5" in sch.read_text()
+
+    @requires_kicad_libs
+    def test_batch_mismatch_warns_but_succeeds(self, tmp_path, capsys):
+        """Batch mode warns on mismatch but does not abort (backward compat)."""
+        sch = _copy_fixture(tmp_path)
+        map_path = tmp_path / "map.json"
+        map_path.write_text(json.dumps({"R1": "Package_TO_SOT_SMD:SOT-23-5"}))
+        ret = run_set_footprint(
+            schematic_path=sch,
+            map_path=map_path,
+            backup=False,
+        )
+        err = capsys.readouterr().err
+        assert ret == 0
+        assert "pin-count mismatch" in err
+        # Despite the warning, the assignment is applied in batch mode.
+        assert "Package_TO_SOT_SMD:SOT-23-5" in sch.read_text()
+
+    @requires_kicad_libs
+    def test_batch_strict_aborts_on_mismatch(self, tmp_path, capsys):
+        """--strict makes a batch mismatch abort with non-zero exit."""
+        sch = _copy_fixture(tmp_path)
+        original = sch.read_text()
+        map_path = tmp_path / "map.json"
+        map_path.write_text(json.dumps({"R1": "Package_TO_SOT_SMD:SOT-23-5"}))
+        ret = run_set_footprint(
+            schematic_path=sch,
+            map_path=map_path,
+            strict=True,
+            backup=False,
+        )
+        assert ret == 1
+        assert sch.read_text() == original
+
+    def test_no_library_skips_validation(self, tmp_path, monkeypatch):
+        """AC #5: no library -> validation skipped, assignment still applies."""
+        import kicad_tools.cli.sch_set_footprint as sf
+        from kicad_tools.footprints.library_path import LibraryPaths
+
+        monkeypatch.setattr(
+            sf,
+            "detect_kicad_library_path",
+            lambda *a, **k: LibraryPaths(footprints_path=None, source="auto"),
+        )
+        sch = _copy_fixture(tmp_path)
+        ret = run_set_footprint(
+            schematic_path=sch,
+            ref="R1",
+            footprint="Package_TO_SOT_SMD:SOT-23-5",
+            backup=False,
+        )
+        assert ret == 0
+        assert "Package_TO_SOT_SMD:SOT-23-5" in sch.read_text()

--- a/tests/test_sch_suggest_footprint.py
+++ b/tests/test_sch_suggest_footprint.py
@@ -1,0 +1,125 @@
+"""Tests for the ``sch suggest-footprint`` command.
+
+The tests that need real ``.kicad_mod`` files are gated behind
+``LibraryPaths.found`` so the suite stays green on KiCad-less CI runners.
+The no-library degradation tests must run everywhere and are NOT gated.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli import sch_suggest_footprint
+from kicad_tools.cli.sch_suggest_footprint import run_suggest_footprint
+from kicad_tools.footprints.library_path import (
+    LibraryPaths,
+    detect_kicad_library_path,
+)
+
+FIXTURE = Path(__file__).parent / "fixtures" / "missing_footprint.kicad_sch"
+
+_LIBS_AVAILABLE = detect_kicad_library_path().found
+
+requires_kicad_libs = pytest.mark.skipif(
+    not _LIBS_AVAILABLE,
+    reason="KiCad footprint libraries not installed in this environment",
+)
+
+
+# ---------------------------------------------------------------------------
+# Tests that need real library files (gated)
+# ---------------------------------------------------------------------------
+
+
+@requires_kicad_libs
+def test_suggest_sot23_for_5pin_buffer(capsys):
+    """AC #1: U7 (74LVC1G17, 5 pins) + --package SOT-23 yields SOT-23-5."""
+    rc = run_suggest_footprint(FIXTURE, ref="U7", package="SOT-23", limit=20)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Package_TO_SOT_SMD:SOT-23-5" in out
+    assert "TSOT-23-5" in out
+    # Every suggestion must have 5 pads (the symbol pin count).
+    for line in out.splitlines():
+        if "pads)" in line:
+            assert "(5 pads)" in line
+
+
+@requires_kicad_libs
+def test_suggest_ranks_non_handsolder_first(capsys):
+    """Plain SOT-23-5 should rank before its _HandSoldering variant."""
+    run_suggest_footprint(FIXTURE, ref="U7", package="SOT-23", limit=20)
+    out = capsys.readouterr().out
+    plain = out.find("Package_TO_SOT_SMD:SOT-23-5 ")
+    hand = out.find("SOT-23-5_HandSoldering")
+    assert plain != -1 and hand != -1
+    assert plain < hand
+
+
+@requires_kicad_libs
+def test_suggest_r0603_for_resistor(capsys):
+    """AC #2: R1 (2 pins) + --package R_0603 yields R_0603 footprints."""
+    rc = run_suggest_footprint(FIXTURE, ref="R1", package="R_0603", limit=10)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Resistor_SMD:R_0603_1608Metric" in out
+
+
+@requires_kicad_libs
+def test_suggest_json_format(capsys):
+    rc = run_suggest_footprint(FIXTURE, ref="U7", package="SOT-23", output_format="json", limit=5)
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert data["reference"] == "U7"
+    assert data["pin_count"] == 5
+    assert data["package_keyword"] == "SOT-23"
+    assert len(data["candidates"]) >= 1
+    for c in data["candidates"]:
+        assert c["pads"] == 5
+
+
+@requires_kicad_libs
+def test_suggest_no_candidates_when_padcount_unmatched(capsys):
+    """A 5-pin part with a 2-pad-only package keyword yields no candidates."""
+    rc = run_suggest_footprint(FIXTURE, ref="U7", package="R_0603", limit=10)
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "No matching footprints" in err
+
+
+# ---------------------------------------------------------------------------
+# Tests that run everywhere (NOT gated)
+# ---------------------------------------------------------------------------
+
+
+def test_no_library_graceful_degradation(monkeypatch, capsys):
+    """AC #3: no library -> actionable message + non-zero exit, no traceback."""
+
+    def _no_libs(*_args, **_kwargs):
+        return LibraryPaths(footprints_path=None, source="auto")
+
+    monkeypatch.setattr(sch_suggest_footprint, "detect_kicad_library_path", _no_libs)
+
+    rc = run_suggest_footprint(FIXTURE, ref="U7", package="SOT-23")
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "KICAD_FOOTPRINT_DIR" in err
+    assert "No KiCad footprint library found" in err
+
+
+def test_symbol_not_found(capsys):
+    rc = run_suggest_footprint(FIXTURE, ref="ZZ99", package="SOT-23")
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "not found" in err
+
+
+def test_missing_schematic_file(capsys):
+    rc = run_suggest_footprint(Path("/nonexistent/board.kicad_sch"), ref="U7")
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "not found" in err.lower()


### PR DESCRIPTION
Closes #3158. Filed follow-up #3173 for deferred phases.

## Summary
Phase 1 of the footprint-assignment helper from #3158 (curator-scoped):

- **`kct sch suggest-footprint <sch> --ref <REF> [--package KEYWORD] [--format text|json] [--limit N]`** — suggests KiCad library footprints for a symbol, filtered by pin/pad-count match plus an optional `--package` keyword hint, ranked (keyword-name match > non-hand-solder > alphabetical). New module `src/kicad_tools/cli/sch_suggest_footprint.py`.
- **Pin-count validation in `sch set-footprint`** — resolves the assigned footprint's pad count and compares it to the symbol's pin count. Warns on mismatch; aborts non-zero in single-ref mode or under `--strict`; batch mode only warns (backward-compatible). New `--no-validate` / `--strict` flags.

Both reuse the existing primitives (no new detection/search code):
- `footprints/library_path.py` (`detect_kicad_library_path`, `list_available_libraries`, `get_footprint_file`, `find_footprint_by_name`, `parse_library_id`, `guess_standard_library`)
- `cli/lib_footprints.py::_count_pads`
- `Schematic.get_lib_symbol_resolved(...).pin_count` (handles `extends` chains), falling back to instance `len(sym.pins)`.

## Graceful degradation (key requirement)
When no KiCad footprint library is found (CI runners / fresh checkouts):
- `suggest-footprint` prints an actionable `KICAD_FOOTPRINT_DIR` message and exits non-zero (no traceback).
- `set-footprint` silently skips validation and still assigns (no crash, backward-compatible).

## Acceptance criteria
1. `suggest-footprint U7 --package SOT-23` returns `Package_TO_SOT_SMD:SOT-23-5` / `TSOT-23-5` (5-pad) candidates for the 5-pin 74LVC1G17.
2. `suggest-footprint R1 --package R_0603` returns `Resistor_SMD:R_0603_*`.
3. No-library path: actionable message + non-zero exit, no traceback.
4. `set-footprint` rejects a 5-pad footprint on a 2-pin part (non-zero); accepts a pad-count match (zero).
5. No-library: `set-footprint` still assigns (validation skipped).
6. New fixture `tests/fixtures/missing_footprint.kicad_sch` (R1 2-pin, U7 5-pin buffer, NT2 2-pin NetTie) exercises both flows.

## Test plan
- [x] `tests/test_sch_suggest_footprint.py` — KiCad-dependent tests gated behind `skipif(not detect_kicad_library_path().found)`; no-library + symbol-not-found tests run everywhere.
- [x] `tests/test_sch_set_footprint.py` — new `TestPinCountValidation` (mismatch abort, match success, `--no-validate` override, batch warn-but-succeed, `--strict` abort, no-library skip). All 27 pre-existing tests still pass.
- [x] Targeted suite green locally: 43 passed (KiCad libs present in this environment).
- [x] `ruff check` + `ruff format --check` clean on all changed files.
- Note: repo-wide full `pytest` / `ruff` surface large pre-existing failures (unrelated router/orchestrator tests, missing optional `cmaes` dep, ~400 files with pre-existing format drift) independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)