### PR TITLE
fix(cli): clarify reporting in net-status, stitch, fix-drc, route

### DIFF
--- a/src/kicad_tools/cli/fix_drc_cmd.py
+++ b/src/kicad_tools/cli/fix_drc_cmd.py
@@ -259,7 +259,11 @@ Examples:
                 break
 
         if not args.quiet and args.format == "text" and pass_num == 1:
-            print(f"Found {total_targeted} repairable violation(s):")
+            # Engine-label the detection total so it cannot be read as a
+            # contradiction next to the pure-Python --verify counts. The
+            # detection report (from kicad-cli when available) is authoritative
+            # for what fix-drc actually repairs.
+            print(f"Found {total_targeted} repairable violation(s) (kicad-cli engine):")
             if clearance_violations:
                 print(f"  Clearance: {len(clearance_violations)}")
             if drill_violations:
@@ -695,7 +699,7 @@ def _get_drc_report(drc_report_path: str | None, pcb_path: Path) -> DRCReport | 
 
         kicad_cli = find_kicad_cli()
         if kicad_cli:
-            print(f"Running DRC on: {pcb_path.name}")
+            print(f"Running DRC (kicad-cli) on: {pcb_path.name}")
             drc_result = run_drc(pcb_path)
             if not drc_result.success:
                 print(f"Error running DRC: {drc_result.stderr}", file=sys.stderr)

--- a/src/kicad_tools/cli/net_status_cmd.py
+++ b/src/kicad_tools/cli/net_status_cmd.py
@@ -102,7 +102,17 @@ def main(argv: list[str] | None = None) -> int:
     if args.format == "json":
         output_json(filtered, pcb_path, args.by_class)
     else:
-        output_text(filtered, pcb_path, args.verbose, args.by_class, args.incomplete)
+        # The summary header must always describe the unfiltered board so its
+        # counts stay internally consistent (Complete + Incomplete + Unrouted ==
+        # total). The filtered set only drives the net *list* below the header.
+        output_text(
+            filtered,
+            pcb_path,
+            args.verbose,
+            args.by_class,
+            args.incomplete,
+            summary_result=result,
+        )
 
     # Exit code
     if result.incomplete_count > 0 or result.unrouted_count > 0:
@@ -116,15 +126,25 @@ def output_text(
     verbose: bool = False,
     by_class: bool = False,
     incomplete_only: bool = False,
+    summary_result: NetStatusResult | None = None,
 ) -> None:
-    """Output results as formatted text."""
+    """Output results as formatted text.
+
+    Args:
+        result: The (possibly filtered) result used to render the net list.
+        summary_result: The unfiltered result used for the Summary header. When
+            ``--incomplete`` filters complete nets out of ``result``, the header
+            must still describe the full board so its counts stay consistent
+            (Complete + Incomplete + Unrouted == total). Defaults to ``result``.
+    """
+    summary = summary_result if summary_result is not None else result
     print(f"Net Status: {pcb_path.name}")
     print("=" * 60)
     print()
-    print(f"Summary: {result.total_nets} nets total")
-    print(f"  Complete:   {result.complete_count} (100% connected)")
-    print(f"  Incomplete: {result.incomplete_count} (partially connected)")
-    print(f"  Unrouted:   {result.unrouted_count} (0% connected)")
+    print(f"Summary: {summary.total_nets} nets total")
+    print(f"  Complete:   {summary.complete_count} (100% connected)")
+    print(f"  Incomplete: {summary.incomplete_count} (partially connected)")
+    print(f"  Unrouted:   {summary.unrouted_count} (0% connected)")
     print()
 
     if by_class:

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -1096,7 +1096,19 @@ def _save_partial_results() -> bool:
 
             if not quiet:
                 stats = router.get_statistics()
-                print(f"\n  Partial results saved to: {save_path}")
+                # The _partial file is a raw router snapshot (routes inserted
+                # into the *unrouted* source) written BEFORE optimize/cleanup
+                # and DRC. It is therefore less-processed than the canonical
+                # -o output and should not be treated as authoritative. Only
+                # the adaptive best-completed case writes to output_path itself.
+                if save_path == output_path:
+                    print(f"\n  Partial results saved to: {save_path}")
+                else:
+                    print(
+                        f"\n  Raw partial snapshot saved to: {save_path} "
+                        f"(pre-optimize, pre-DRC; NOT canonical)"
+                    )
+                    print(f"  Canonical output remains: {output_path}")
                 print(f"    Nets routed: {stats['nets_routed']}")
                 print(f"    Segments: {stats['segments']}")
                 print(f"    Vias: {stats['vias']}")
@@ -7675,6 +7687,11 @@ def main(argv: list[str] | None = None) -> int:
     if not all_nets_routed and not args.dry_run and router.routes:
         partial_saved = _save_partial_results()
         if partial_saved and not quiet:
+            # Make the authoritative file unambiguous: the -o target (written
+            # by the routing pipeline with optimize + DRC applied) is canonical;
+            # the _partial file is a raw pre-optimize snapshot (see
+            # _save_partial_results). Emit exactly one canonical-output line.
+            print(f"  Canonical output: {output_path} (full route + optimize + DRC)")
             print("  Open in KiCad to complete remaining nets manually")
 
     # Export failed nets to file if requested

--- a/src/kicad_tools/cli/stitch_cmd.py
+++ b/src/kicad_tools/cli/stitch_cmd.py
@@ -3878,11 +3878,27 @@ def run_post_stitch_drc(pcb_path: Path) -> int:
     return 0
 
 
-def output_result(result: StitchResult, dry_run: bool = False, run_drc: bool = False) -> None:
-    """Output the stitching result."""
+def output_result(
+    result: StitchResult,
+    dry_run: bool = False,
+    run_drc: bool = False,
+    edited_path: Path | None = None,
+) -> None:
+    """Output the stitching result.
+
+    Args:
+        edited_path: Absolute path of the .kicad_pcb file actually edited. When
+            provided it is echoed in the header so the printed via coordinates
+            are unambiguously tied to that file's coordinate space (avoids the
+            ambiguity where a console summary is read against a different stage
+            file than the one stitch edited).
+    """
     import sys
 
-    print(f"\nStitching vias for {result.pcb_name}")
+    if edited_path is not None:
+        print(f"\nStitching vias for {edited_path.resolve()}")
+    else:
+        print(f"\nStitching vias for {result.pcb_name}")
     print("=" * 60)
 
     # Show warning for nets with no zone found (falling back to B.Cu)
@@ -4281,7 +4297,7 @@ def main(argv: list[str] | None = None) -> int:
                 micro_via_drill=args.micro_via_drill,
             )
 
-        output_result(result, dry_run=args.dry_run, run_drc=args.drc)
+        output_result(result, dry_run=args.dry_run, run_drc=args.drc, edited_path=pcb_path)
 
         # Run DRC if requested (and not dry run, and vias were actually added)
         if args.drc and not args.dry_run and result.vias_added:

--- a/tests/test_fix_drc_cmd.py
+++ b/tests/test_fix_drc_cmd.py
@@ -828,6 +828,78 @@ class TestFixDRCCLI:
         # Should contain repair count info
         assert "/" in captured.out
 
+    def test_detection_and_verify_totals_each_name_their_engine(
+        self, pcb_clearance: Path, report_clearance: Path, capsys
+    ):
+        """Bug #3 regression: dual totals in one run must each name their engine.
+
+        ``fix-drc`` shows a detection total (authoritative, kicad-cli engine)
+        and, with ``--verify``, a pure-Python snapshot total. When both appear
+        in one run they previously read as a contradiction because the
+        detection total was unlabeled. Each total line must now state its
+        engine so no two unlabeled totals appear together.
+        """
+        result = main(
+            [
+                str(pcb_clearance),
+                "--drc-report",
+                str(report_clearance),
+                "--verify",
+                "--dry-run",
+                "--format",
+                "text",
+            ]
+        )
+        assert result in (0, 1, 2, 3)
+
+        captured = capsys.readouterr()
+        out = captured.out
+
+        # The detection total is engine-labeled.
+        assert "Found" in out and "repairable violation(s) (kicad-cli engine)" in out
+        # The --verify snapshot total names its (different) engine.
+        assert "via pure-Python DRC" in out
+
+    def test_kicad_cli_detection_line_is_engine_labeled(self, monkeypatch, tmp_path):
+        """Bug #3 regression: the kicad-cli DRC run line names the engine.
+
+        When ``_get_drc_report`` runs DRC via kicad-cli (no ``--drc-report``),
+        the "Running DRC ..." status line must identify the kicad-cli engine.
+        """
+        import io
+        from contextlib import redirect_stdout
+
+        from kicad_tools.cli import fix_drc_cmd
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(PCB_WITH_CLEARANCE)
+
+        class _FakeDRCResult:
+            success = True
+            stderr = ""
+            output_path = None
+
+        def _fake_find_kicad_cli():
+            return "/usr/bin/kicad-cli"
+
+        def _fake_run_drc(_path):
+            return _FakeDRCResult()
+
+        def _fake_load(_path):
+            # The "Running DRC (kicad-cli) on:" status line is printed BEFORE
+            # the report is loaded, so the loaded value is irrelevant here.
+            return None
+
+        monkeypatch.setattr("kicad_tools.cli.runner.find_kicad_cli", _fake_find_kicad_cli)
+        monkeypatch.setattr("kicad_tools.cli.runner.run_drc", _fake_run_drc)
+        monkeypatch.setattr("kicad_tools.drc.report.DRCReport.load", staticmethod(_fake_load))
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            fix_drc_cmd._get_drc_report(None, pcb_file)
+
+        assert "Running DRC (kicad-cli) on:" in buf.getvalue()
+
     def test_quiet_mode(self, pcb_clearance: Path, report_clearance: Path, capsys):
         """--quiet should suppress all output."""
         main(

--- a/tests/test_net_status_cmd.py
+++ b/tests/test_net_status_cmd.py
@@ -238,6 +238,44 @@ class TestNetStatusCLI:
         # Should show incomplete/unrouted nets
         assert "Incomplete" in captured.out or "unconnected" in captured.out.lower()
 
+    def test_incomplete_summary_header_internally_consistent(self, incomplete_pcb: Path, capsys):
+        """Bug #1 regression: --incomplete summary must describe the full board.
+
+        Previously the ``--incomplete`` filter dropped the complete nets from
+        the result but kept the original ``total_nets``, so the Summary header
+        printed e.g. ``Complete: 0`` next to ``N nets total`` -- inconsistent.
+        The header must reflect the unfiltered board: Complete + Incomplete +
+        Unrouted == total, and Complete must equal the non-``--incomplete`` run.
+        """
+        import re
+
+        def _parse_summary(out: str) -> tuple[int, int, int, int]:
+            total = int(re.search(r"Summary: (\d+) nets total", out).group(1))
+            complete = int(re.search(r"Complete:\s+(\d+)", out).group(1))
+            incomplete = int(re.search(r"Incomplete:\s+(\d+)", out).group(1))
+            unrouted = int(re.search(r"Unrouted:\s+(\d+)", out).group(1))
+            return total, complete, incomplete, unrouted
+
+        # Unfiltered run establishes the ground-truth counts.
+        main([str(incomplete_pcb)])
+        full_out = capsys.readouterr().out
+        full_total, full_complete, full_incomplete, full_unrouted = _parse_summary(full_out)
+        # The fixture must actually exercise the bug: at least one complete net.
+        assert full_complete > 0
+
+        # --incomplete run: header must match the unfiltered board exactly.
+        main([str(incomplete_pcb), "--incomplete"])
+        inc_out = capsys.readouterr().out
+        inc_total, inc_complete, inc_incomplete, inc_unrouted = _parse_summary(inc_out)
+
+        # Internally consistent: the three buckets sum to the stated total.
+        assert inc_complete + inc_incomplete + inc_unrouted == inc_total
+        # And the header describes the full board, not the filtered subset.
+        assert inc_total == full_total
+        assert inc_complete == full_complete
+        assert inc_incomplete == full_incomplete
+        assert inc_unrouted == full_unrouted
+
     def test_net_filter_found(self, incomplete_pcb: Path, capsys):
         """Test --net filter for existing net."""
         result = main([str(incomplete_pcb), "--net", "VCC"])

--- a/tests/test_route_exit_codes.py
+++ b/tests/test_route_exit_codes.py
@@ -843,3 +843,91 @@ class TestPipelineCmdExitCodeHandling:
                 cwd=Path("/tmp"),
             )
             assert success is True, "Exit code 0 should be treated as success"
+
+
+class TestPartialOutputLabeling:
+    """Bug #4 regression: ``route`` must clarify the _partial vs -o relationship.
+
+    On partial routing ``route`` writes the canonical ``-o`` target (full route
+    + optimize + DRC) AND a separate ``<stem>_partial.kicad_pcb`` raw snapshot
+    built from the unrouted source (pre-optimize, pre-DRC). Previously nothing
+    distinguished them, so the less-processed ``_partial`` file could be mistaken
+    for authoritative. The output must name the canonical file and label
+    ``_partial`` as a raw pre-optimize snapshot.
+    """
+
+    def _make_fake_router(self):
+        router = MagicMock()
+        router.routes = [MagicMock()]  # non-empty so save proceeds
+        router.to_sexp.return_value = "(segment (start 0 0) (end 1 1) (net 1))"
+        router.get_statistics.return_value = {
+            "nets_routed": 2,
+            "segments": 5,
+            "vias": 1,
+        }
+        return router
+
+    def test_partial_snapshot_labeled_and_canonical_named(self, tmp_path, capsys):
+        """_save_partial_results labels _partial and names the canonical output."""
+        from kicad_tools.cli import route_cmd
+
+        pcb_path = tmp_path / "board.kicad_pcb"
+        pcb_path.write_text('(kicad_pcb (version 20240101) (generator "test"))')
+        output_path = tmp_path / "board_routed.kicad_pcb"
+
+        saved_state = dict(route_cmd._interrupt_state)
+        try:
+            route_cmd._interrupt_state["router"] = self._make_fake_router()
+            route_cmd._interrupt_state["output_path"] = output_path
+            route_cmd._interrupt_state["pcb_path"] = pcb_path
+            route_cmd._interrupt_state["quiet"] = False
+            route_cmd._interrupt_state["best_completed_attempt"] = False
+
+            saved = route_cmd._save_partial_results()
+        finally:
+            route_cmd._interrupt_state.clear()
+            route_cmd._interrupt_state.update(saved_state)
+
+        assert saved is True
+
+        # The _partial file is written separately from the canonical -o target.
+        partial_path = output_path.with_stem(output_path.stem + "_partial")
+        assert partial_path.exists()
+
+        out = capsys.readouterr().out
+        # _partial is explicitly labeled as a non-canonical raw snapshot.
+        assert "partial snapshot saved to" in out.lower()
+        assert "pre-optimize" in out.lower()
+        assert "not canonical" in out.lower()
+        # The canonical output is named so it is unambiguous.
+        assert str(output_path) in out
+        assert "Canonical output remains" in out
+
+    def test_best_completed_attempt_writes_canonical_not_partial(self, tmp_path, capsys):
+        """Adaptive best-completed result writes to -o, not a _partial snapshot."""
+        from kicad_tools.cli import route_cmd
+
+        pcb_path = tmp_path / "board.kicad_pcb"
+        pcb_path.write_text('(kicad_pcb (version 20240101) (generator "test"))')
+        output_path = tmp_path / "board_routed.kicad_pcb"
+
+        saved_state = dict(route_cmd._interrupt_state)
+        try:
+            route_cmd._interrupt_state["router"] = self._make_fake_router()
+            route_cmd._interrupt_state["output_path"] = output_path
+            route_cmd._interrupt_state["pcb_path"] = pcb_path
+            route_cmd._interrupt_state["quiet"] = False
+            route_cmd._interrupt_state["best_completed_attempt"] = True
+
+            saved = route_cmd._save_partial_results()
+        finally:
+            route_cmd._interrupt_state.clear()
+            route_cmd._interrupt_state.update(saved_state)
+
+        assert saved is True
+        # A full best-completed pass goes to the canonical path, no _partial file.
+        partial_path = output_path.with_stem(output_path.stem + "_partial")
+        assert output_path.exists()
+        assert not partial_path.exists()
+        out = capsys.readouterr().out
+        assert "not canonical" not in out.lower()

--- a/tests/test_stitch_cmd.py
+++ b/tests/test_stitch_cmd.py
@@ -649,6 +649,53 @@ class TestCLIMain:
         assert output_file.exists()
         assert "(via" in output_file.read_text()
 
+    def test_main_echoes_absolute_edited_path_with_matching_coords(
+        self, stitch_test_pcb: Path, tmp_path, capsys
+    ):
+        """Bug #2 regression: stitch must echo the absolute edited-file path.
+
+        The console previously printed only the bare filename, which let a
+        reader pair the printed via coordinates with the wrong stage file
+        (different coordinate space). Echo the absolute path of the file
+        actually edited, and verify the printed coords match the vias written
+        to that same file.
+        """
+        import re
+
+        output_file = tmp_path / "stitched_out.kicad_pcb"
+        exit_code = main([str(stitch_test_pcb), "--net", "GND", "-o", str(output_file)])
+        assert exit_code == 0
+
+        captured = capsys.readouterr()
+        out = captured.out
+
+        # The absolute path of the file actually edited must appear in stdout.
+        assert str(output_file.resolve()) in out
+
+        # Parse the via coordinates written into the edited file.
+        written_content = output_file.read_text()
+        written_coords: set[tuple[float, float]] = set()
+        for m in re.finditer(
+            r"\(via\b.*?\(at\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\)",
+            written_content,
+            re.DOTALL,
+        ):
+            written_coords.add((round(float(m.group(1)), 2), round(float(m.group(2)), 2)))
+        assert written_coords, "fixture produced no vias to verify"
+
+        # Parse the via coordinates printed to the console.
+        printed_coords = [
+            (round(float(x), 2), round(float(y), 2))
+            for x, y in re.findall(r"@ \((-?\d+\.?\d*), (-?\d+\.?\d*)\)", out)
+        ]
+        assert printed_coords, "no via coords were printed"
+
+        # Every printed coordinate must correspond to a written via (same space).
+        for coord in printed_coords:
+            assert coord in written_coords, (
+                f"printed via {coord} not found among written vias {written_coords}"
+            )
+
     def test_main_output_copies_project_file(self, stitch_test_pcb: Path, tmp_path):
         """Main with -o should copy matching .kicad_pro file."""
         # Create matching project file alongside the test PCB


### PR DESCRIPTION
## Summary

Closes #3160.

Final `/sweep` wave: a cluster of four small CLI output/reporting bugs surfaced during a chorus-test completion attempt. Each degraded trust in `kct` output. Implemented per the curator's root-caused, trimmed scope (~25 LOC + 4 regression tests).

### Bug #1 — net-status `--incomplete` contradictory header (real logic bug)
With `--incomplete`, the summary block was rendered from the *filtered* result (complete nets dropped) but kept the original `total_nets`, printing e.g. `Complete: 0` next to `3 nets total`. Fix: `output_text` now takes a `summary_result=` and renders the Summary header from the **unfiltered** `result`; only the net *list* is filtered. `Complete + Incomplete + Unrouted == total`, and `Complete` matches the non-`--incomplete` run.
- `src/kicad_tools/cli/net_status_cmd.py`

### Bug #2 — stitch via coords / file ambiguity (clarity)
The single print site already uses the exact written values; the symptom was an observation artifact (console read against a different stage file). Fix: `output_result` echoes the **absolute path of the file actually edited** so the printed coords are unambiguously tied to that file's space.
- `src/kicad_tools/cli/stitch_cmd.py`

### Bug #3 — fix-drc dual totals (label only; reconciliation already landed in #2083)
The pure-Python `--verify` numbers are already engine-labeled. Remaining gap: the kicad-cli **detection** lines were unlabeled, so they read as a contradiction next to the labeled verify counts. Fix: `Running DRC (kicad-cli) on:` and `Found N repairable violation(s) (kicad-cli engine)`. Deep engine parity remains out of scope (#3151).
- `src/kicad_tools/cli/fix_drc_cmd.py` (minimal — label only, to reduce conflict surface with sibling PR #3159 which touches a different region of this file)

### Bug #4 — route `_partial` ambiguity (clarity/log)
On partial routing, `<stem>_partial.kicad_pcb` is written from the unrouted source — a pre-optimize/pre-DRC snapshot, less-processed than the canonical `-o` output. Fix (doc/log-only): print a clear canonical-output line and label `_partial` as a raw pre-optimize, pre-DRC snapshot (not authoritative).
- `src/kicad_tools/cli/route_cmd.py`

## Acceptance criteria
- [x] net-status `--incomplete` header is internally consistent (Complete + Incomplete + Unrouted == total; Complete matches unfiltered run).
- [x] stitch echoes the absolute edited file path alongside via coords.
- [x] fix-drc kicad-cli detection lines are engine-labeled.
- [x] route prints a clear canonical-output line + labels `_partial` as a raw pre-optimize snapshot.
- [x] One regression test per bug in the existing test homes.

## Test plan
- [x] `tests/test_net_status_cmd.py` — `--incomplete` summary internally consistent + matches unfiltered counts.
- [x] `tests/test_stitch_cmd.py` — printed via coords match written `(via ... (at x y))`; absolute edited path appears in stdout.
- [x] `tests/test_fix_drc_cmd.py` — kicad-cli detection line and pure-Python verify line each name their engine.
- [x] `tests/test_route_exit_codes.py` — partial save prints canonical-output line naming `-o` and labels `_partial` as a raw snapshot.
- [x] All 4 target test files pass (418 passed locally).
- [x] No new lint errors and no new format drift introduced (verified each edited region is clean; pre-existing repo-wide ruff drift is unrelated and untouched).

## Notes
- Sibling PR #3159 also touches `fix_drc_cmd.py` (adds `--mfr`, argparse block + `_run_python_drc`). My bug #3 change is a label at the detection lines — a different region — but whichever merges second may need a trivial rebase.
- `uv.lock` had a pre-existing local modification at session start and was intentionally left out of this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)