### PR TITLE
feat(audit): net-level analog detection + GNDA-bridge flag (Phase 2)

### DIFF
--- a/src/kicad_tools/analysis/analog_detect.py
+++ b/src/kicad_tools/analysis/analog_detect.py
@@ -1,16 +1,29 @@
-"""Analog component detection for PCB designs.
+"""Analog detection for PCB designs.
 
-Identifies components that are sensitive to layout quality (analog DACs/ADCs,
-op-amps, precision voltage references, audio-frequency crystals, analog
-switches) by matching footprint library IDs and component values against
-known patterns.  The results are advisory only -- they do not block export.
+Two complementary, advisory-only detectors live here:
+
+* :func:`detect_analog_components` -- *component-level* detection (Phase 1).
+  Identifies components that are sensitive to layout quality (analog
+  DACs/ADCs, op-amps, precision voltage references, audio-frequency
+  crystals, analog switches) by matching footprint library IDs and
+  component values against known patterns.
+
+* :func:`detect_analog_nets` and :func:`check_analog_ground_bridge` --
+  *net-level* detection (Phase 2).  Names analog NETS (AUDIO_L/R, GNDA,
+  +3.3VA, VREF, ...) by reusing the router's
+  :func:`kicad_tools.router.net_class.classify_from_name` plus a thin
+  analog-specific naming layer, and flags an analog ground (GNDA/AGND)
+  that has no discrete bridge component (ferrite / net-tie) to digital
+  ground.
+
+Both are advisory only -- they never block export and never raise.
 
 Example::
 
     >>> from kicad_tools.analysis.analog_detect import detect_analog_components
     >>> components = detect_analog_components(pcb)
     >>> for c in components:
-    ...     print(f"{c['reference']}: {c['reason']}")
+    ...     print(f"{c.reference}: {c.reason}")
 """
 
 from __future__ import annotations
@@ -24,7 +37,10 @@ if TYPE_CHECKING:
 
 __all__ = [
     "AnalogComponent",
+    "AnalogNet",
+    "check_analog_ground_bridge",
     "detect_analog_components",
+    "detect_analog_nets",
 ]
 
 
@@ -42,6 +58,29 @@ class AnalogComponent:
             "reference": self.reference,
             "value": self.value,
             "footprint": self.footprint,
+            "reason": self.reason,
+        }
+
+
+@dataclass
+class AnalogNet:
+    """A detected analog net.
+
+    ``kind`` is one of ``"audio"``, ``"analog_supply"``, ``"analog_ground"``
+    or ``"analog_signal"``.  ``reason`` is a human-readable hint that already
+    bakes in the layout advice for that ``kind`` (e.g. "isolated analog
+    ground; keep separate from digital return, bridge to GND at a single
+    point").
+    """
+
+    name: str
+    kind: str
+    reason: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "name": self.name,
+            "kind": self.kind,
             "reason": self.reason,
         }
 
@@ -196,3 +235,243 @@ def _match_crystal_value(value: str) -> str | None:
     if freq in _AUDIO_CRYSTAL_FREQUENCIES_MHZ:
         return f"audio-frequency crystal ({freq} MHz)"
     return None
+
+
+# ===========================================================================
+# Net-level analog detection (Phase 2, issue #3170)
+# ===========================================================================
+#
+# The component detector above matches footprint name/value and never
+# inspects nets.  These functions are its *net-level* sibling: they classify
+# net NAMES and run a local 2-pad bridge scan for an isolated analog ground.
+#
+# Classification reuses the router's ``classify_from_name`` (issue #3151) so
+# analog-net detection stays consistent with the router's view, then layers a
+# thin analog-specific naming pass on top -- the generic NetClass.GROUND /
+# .POWER do not distinguish "analog ground" / "analog supply" specifically.
+# ---------------------------------------------------------------------------
+
+# Analog-supply suffix: a power-rail name ending in an "A" (analog) marker,
+# e.g. +3.3VA, 1.8VA, AVDD, +5VA.  We deliberately keep this conservative so
+# that plain digital rails (+3.3V, +5V, DVDD) are NOT flagged.
+_ANALOG_SUPPLY_RE = re.compile(
+    r"^(?:[+-]?\d+\.?\d*VA|[+-]?\d+V\d+A|AVDD|AVCC|VDDA|VCCA|VANA)$",
+    re.IGNORECASE,
+)
+
+# Analog-ground names: a ground net dedicated to the analog return path.
+_ANALOG_GROUND_RE = re.compile(r"^(?:GNDA|AGND)$|_AGND$", re.IGNORECASE)
+
+# Digital-ground names: the return we expect an analog ground to bridge TO.
+_DIGITAL_GROUND_RE = re.compile(r"^(?:GND|GNDD|DGND|VSS|GROUND)$|_DGND$", re.IGNORECASE)
+
+# Audio net names (subset of NetClass.ANALOG that is specifically audio).
+_AUDIO_RE = re.compile(
+    r"(?:AUDIO|MIC|SPK|LINE)(?:_[LRIO])?|(?:I2S|TDM|PDM)_(?:DIN|DOUT|SD|WS)",
+    re.IGNORECASE,
+)
+
+# Per-kind layout hint appended to the net name in the audit advisory.
+_KIND_REASONS: dict[str, str] = {
+    "audio": "audio signal; keep short, away from digital/switching nets",
+    "analog_supply": (
+        "analog supply rail; route separately from digital power, decouple close to the analog IC"
+    ),
+    "analog_ground": (
+        "isolated analog ground; keep separate from digital return, bridge to GND at a single point"
+    ),
+    "analog_signal": "analog signal; noise-sensitive, avoid crossing digital signals",
+}
+
+# Two-pad bridge component recognition.  A bridge ties the analog ground to
+# the digital ground at a single point; it is either a KiCad net-tie or a
+# ferrite bead.
+_NETTIE_NAME_RE = re.compile(r"NetTie", re.IGNORECASE)
+
+# Ferrite-bead value patterns.  Kept intentionally small and documented:
+#   FB / FB1                 -- ferrite-bead reference convention used as value
+#   BLM... / MPZ... / HZ...  -- common ferrite part-number prefixes
+#   600R@100MHz / 120@100MHz -- impedance-at-frequency value strings
+_FERRITE_VALUE_RE = re.compile(
+    r"^FB\d*$|^(?:BLM|MPZ|HZ|MMZ|BK)\w*|\d+\s*R?\s*@\s*\d+\s*MHZ",
+    re.IGNORECASE,
+)
+
+
+def detect_analog_nets(pcb: PCB) -> list[AnalogNet]:
+    """Scan a PCB's nets and return analog nets classified by name.
+
+    Detection is purely name-based.  Each net's name is run through the
+    router's :func:`classify_from_name` and a thin analog-specific naming
+    pass to assign a ``kind`` (``audio`` / ``analog_supply`` /
+    ``analog_ground`` / ``analog_signal``) and a human-readable layout hint.
+
+    Net 0 (the KiCad unconnected net) and nets with empty names are skipped.
+    Digital nets (``GND``, ``+3.3V``, ``D0``, ``SPI_MOSI``, ``USB_DP`` ...)
+    are NOT returned.
+
+    The function never raises; nets that cannot be inspected are skipped.
+
+    Parameters
+    ----------
+    pcb:
+        A loaded PCB object exposing ``nets`` (a mapping of net number to a
+        net with a ``.name`` attribute).
+
+    Returns
+    -------
+    list[AnalogNet]
+        Detected analog nets, sorted by net name.
+    """
+    results: list[AnalogNet] = []
+    seen: set[str] = set()
+
+    nets = getattr(pcb, "nets", None) or {}
+    for number, net in nets.items():
+        # Skip the unconnected net (KiCad reserves number 0).
+        if number == 0:
+            continue
+        name = getattr(net, "name", "") or ""
+        if not name or name in seen:
+            continue
+
+        kind = _classify_analog_net(name)
+        if kind is None:
+            continue
+
+        seen.add(name)
+        results.append(AnalogNet(name=name, kind=kind, reason=_KIND_REASONS[kind]))
+
+    results.sort(key=lambda n: n.name)
+    return results
+
+
+def check_analog_ground_bridge(pcb: PCB) -> list[str]:
+    """Flag an analog ground that has no discrete bridge to digital ground.
+
+    Local 2-pad heuristic (no connectivity graph required): when a board has
+    BOTH an analog-ground net (``GNDA`` / ``AGND``) AND a digital-ground net
+    (``GND`` / ``DGND`` / ``VSS``), this looks for a single 2-pad bridge
+    component -- a net-tie (footprint name contains ``NetTie``) or a ferrite
+    bead (value matches a ferrite pattern) -- with one pad on the analog
+    ground and one pad on the digital ground.  If no such component exists,
+    a missing-bridge message is returned for that analog ground.
+
+    Limitations (documented intentionally)
+    --------------------------------------
+    This is a *pad-membership scan only*.  It does NOT consult routed copper
+    or zone fills.  If a board ties the grounds with a 0R resistor that is
+    not recognised as a ferrite, or via a zone stitch / single bridge via
+    rather than a discrete net-tie or ferrite component, this check may emit
+    a false "no bridge" advisory.  Full connectivity-topology verification --
+    confirming GNDA and GND join through *exactly one* electrical path via
+    the copper/zone graph -- is deferred to Phase 2b (tracked separately) and
+    requires cross-net single-point-bridge modelling in
+    ``validate/connectivity.py``.
+
+    The function never raises; on any failure it returns an empty list.
+
+    Parameters
+    ----------
+    pcb:
+        A loaded PCB object exposing ``nets`` and ``footprints``.
+
+    Returns
+    -------
+    list[str]
+        One advisory string per analog ground lacking a recognised bridge.
+        Empty when every analog ground is bridged, when no analog ground is
+        present, or when no digital ground exists to bridge to.
+    """
+    findings: list[str] = []
+
+    nets = getattr(pcb, "nets", None) or {}
+    analog_grounds = {
+        net.name
+        for number, net in nets.items()
+        if number != 0 and getattr(net, "name", "") and _ANALOG_GROUND_RE.search(net.name)
+    }
+    digital_grounds = {
+        net.name
+        for number, net in nets.items()
+        if number != 0 and getattr(net, "name", "") and _DIGITAL_GROUND_RE.match(net.name)
+    }
+
+    # Nothing to bridge, or nothing to bridge to.
+    if not analog_grounds or not digital_grounds:
+        return findings
+
+    # Collect, per bridge component, the set of net names its pads land on.
+    bridged_pairs: list[tuple[set[str], str]] = []
+    for fp in getattr(pcb, "footprints", []) or []:
+        if not _is_bridge_component(fp):
+            continue
+        pads = getattr(fp, "pads", []) or []
+        if len(pads) != 2:
+            continue
+        pad_nets = {getattr(p, "net_name", "") or "" for p in pads}
+        ref = getattr(fp, "reference", "") or "?"
+        bridged_pairs.append((pad_nets, ref))
+
+    for agnd in sorted(analog_grounds):
+        # The analog ground is "bridged" if some 2-pad bridge component has
+        # one pad on this analog ground and one on a digital ground.
+        bridged = any(
+            agnd in pad_nets and (pad_nets & digital_grounds) for pad_nets, _ref in bridged_pairs
+        )
+        if not bridged:
+            dg = sorted(digital_grounds)[0]
+            findings.append(
+                f"analog ground {agnd} has no bridge to {dg} -- "
+                "add a ferrite/net-tie single-point bridge"
+            )
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers (net-level)
+# ---------------------------------------------------------------------------
+
+
+def _classify_analog_net(name: str) -> str | None:
+    """Return the analog ``kind`` for a net name, or ``None`` if not analog.
+
+    Reuses the router's ``classify_from_name`` and layers the analog-specific
+    naming pass on top.  Order matters: the most specific analog kinds
+    (audio, analog supply, analog ground) are checked before the generic
+    analog-signal class.
+    """
+    # Local import to avoid a heavy/circular import at module load.
+    from kicad_tools.router.net_class import NetClass, classify_from_name
+
+    net_class = classify_from_name(name)
+
+    # Audio is the most specific analog signal kind.
+    if _AUDIO_RE.search(name):
+        return "audio"
+
+    # Analog supply: a power rail with an explicit analog marker.
+    if net_class == NetClass.POWER and _ANALOG_SUPPLY_RE.match(name):
+        return "analog_supply"
+
+    # Analog ground: a ground net dedicated to the analog return.
+    if net_class == NetClass.GROUND and _ANALOG_GROUND_RE.search(name):
+        return "analog_ground"
+
+    # Generic analog signal (VREF, AIN*, ADC_*/DAC_*, I2S_*, SENSE ...).
+    if net_class == NetClass.ANALOG:
+        return "analog_signal"
+
+    return None
+
+
+def _is_bridge_component(fp: object) -> bool:
+    """Return True if a footprint looks like a ground-bridge (net-tie/ferrite)."""
+    name = getattr(fp, "name", "") or ""
+    value = getattr(fp, "value", "") or ""
+    if _NETTIE_NAME_RE.search(name) or _NETTIE_NAME_RE.search(value):
+        return True
+    if _FERRITE_VALUE_RE.search(value):
+        return True
+    return False

--- a/src/kicad_tools/audit/auditor.py
+++ b/src/kicad_tools/audit/auditor.py
@@ -1407,6 +1407,42 @@ class ManufacturingAudit:
         except Exception:
             logger.debug("Analog component detection skipped", exc_info=True)
 
+        # Analog net advisory (Phase 2, issue #3170).
+        #
+        # Mirror the per-component block above at the NET level: name each
+        # detected analog net (audio / analog supply / analog ground /
+        # analog signal) so the engineer knows WHICH nets need analog layout
+        # care, and flag an isolated analog ground whose discrete bridge
+        # (ferrite / net-tie) to digital ground is missing.  Like the
+        # component block, this degrades gracefully -- a detection failure is
+        # logged at debug and never raises.
+        try:
+            pcb = self._load_pcb()
+            from kicad_tools.analysis.analog_detect import (
+                check_analog_ground_bridge,
+                detect_analog_nets,
+            )
+
+            for net in detect_analog_nets(pcb):
+                items.append(
+                    ActionItem(
+                        priority=3,
+                        description=f"Analog net: {net.name} — {net.reason}",
+                        command=None,
+                    )
+                )
+
+            for warning in check_analog_ground_bridge(pcb):
+                items.append(
+                    ActionItem(
+                        priority=3,
+                        description=f"Audit: {warning}",
+                        command=None,
+                    )
+                )
+        except Exception:
+            logger.debug("Analog net detection skipped", exc_info=True)
+
         return sorted(items, key=lambda x: x.priority)
 
     # Helper methods for extracting PCB metrics

--- a/tests/test_analog_nets.py
+++ b/tests/test_analog_nets.py
@@ -1,0 +1,242 @@
+"""Tests for net-level analog detection (Phase 2, issue #3170).
+
+Verifies that :func:`detect_analog_nets` names analog NETS by pattern
+(audio / analog supply / analog ground / analog signal), does not flag
+digital nets, and that :func:`check_analog_ground_bridge` fires only when an
+analog ground lacks a discrete net-tie/ferrite bridge to a digital ground.
+
+The committed boards have no analog nets, so these tests use an extended
+MockPCB that adds a net-name surface (``MockNet`` / ``MockPCB.nets`` and
+``net_name`` on ``MockPad``) on top of the footprint/pad mocks used by
+``tests/test_analog_detect.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from kicad_tools.analysis.analog_detect import (
+    AnalogNet,
+    check_analog_ground_bridge,
+    detect_analog_nets,
+)
+
+# ---------------------------------------------------------------------------
+# Extended mock objects (net-name surface)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MockNet:
+    """Mirror of the real ``schema.pcb.Net`` shape (number + name)."""
+
+    number: int
+    name: str
+
+
+@dataclass
+class MockPad:
+    net_number: int = 0
+    net_name: str = ""
+    layers: list[str] = field(default_factory=lambda: ["F.Cu"])
+    size: tuple[float, float] = (1.0, 1.0)
+
+
+@dataclass
+class MockFootprint:
+    name: str = ""
+    layer: str = "F.Cu"
+    position: tuple[float, float] = (0.0, 0.0)
+    rotation: float = 0.0
+    reference: str = ""
+    value: str = ""
+    pads: list[MockPad] = field(default_factory=list)
+    texts: list[Any] = field(default_factory=list)
+    graphics: list[Any] = field(default_factory=list)
+    uuid: str = ""
+    description: str = ""
+    tags: str = ""
+    attr: str = "smd"
+
+
+@dataclass
+class MockPCB:
+    """Minimal PCB mock with both a footprint and a net surface."""
+
+    footprints: list[MockFootprint] = field(default_factory=list)
+    nets: dict[int, MockNet] = field(default_factory=dict)
+
+
+def _pcb_with_nets(*net_names: str) -> MockPCB:
+    """Build a MockPCB whose nets are named as given (net 0 is unconnected)."""
+    nets: dict[int, MockNet] = {0: MockNet(0, "")}
+    for i, name in enumerate(net_names, start=1):
+        nets[i] = MockNet(i, name)
+    return MockPCB(nets=nets)
+
+
+def _bridge_fp(ref: str, name: str, value: str, *pad_nets: str) -> MockFootprint:
+    """Build a 2-(or N-)pad footprint with pads on the named nets."""
+    return MockFootprint(
+        reference=ref,
+        name=name,
+        value=value,
+        pads=[MockPad(net_name=n) for n in pad_nets],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: analog net naming
+# ---------------------------------------------------------------------------
+
+
+class TestAnalogNetNaming:
+    """Analog nets are named with the correct kind."""
+
+    def _by_name(self, pcb: MockPCB) -> dict[str, AnalogNet]:
+        return {n.name: n for n in detect_analog_nets(pcb)}
+
+    def test_audio_left_right(self) -> None:
+        pcb = _pcb_with_nets("AUDIO_L", "AUDIO_R")
+        found = self._by_name(pcb)
+        assert set(found) == {"AUDIO_L", "AUDIO_R"}
+        assert all(n.kind == "audio" for n in found.values())
+
+    def test_audio_generic(self) -> None:
+        pcb = _pcb_with_nets("AUDIO_OUT", "MIC_IN", "SPK_L", "LINE_R")
+        found = self._by_name(pcb)
+        assert all(n.kind == "audio" for n in found.values())
+        assert set(found) == {"AUDIO_OUT", "MIC_IN", "SPK_L", "LINE_R"}
+
+    def test_i2s_is_audio(self) -> None:
+        pcb = _pcb_with_nets("I2S_SD", "I2S_WS")
+        found = self._by_name(pcb)
+        assert set(found) == {"I2S_SD", "I2S_WS"}
+        assert all(n.kind == "audio" for n in found.values())
+
+    def test_analog_supply(self) -> None:
+        pcb = _pcb_with_nets("+3.3VA", "AVDD", "+5VA")
+        found = self._by_name(pcb)
+        assert set(found) == {"+3.3VA", "AVDD", "+5VA"}
+        assert all(n.kind == "analog_supply" for n in found.values())
+
+    def test_analog_ground(self) -> None:
+        pcb = _pcb_with_nets("GNDA", "AGND")
+        found = self._by_name(pcb)
+        assert set(found) == {"GNDA", "AGND"}
+        assert all(n.kind == "analog_ground" for n in found.values())
+
+    def test_analog_signals(self) -> None:
+        pcb = _pcb_with_nets("VREF", "AIN0", "ADC_CH0", "DAC_0", "SENSE")
+        found = self._by_name(pcb)
+        assert set(found) == {"VREF", "AIN0", "ADC_CH0", "DAC_0", "SENSE"}
+        assert all(n.kind == "analog_signal" for n in found.values())
+
+    def test_reason_carries_layout_hint(self) -> None:
+        pcb = _pcb_with_nets("GNDA")
+        net = self._by_name(pcb)["GNDA"]
+        assert "bridge to GND at a single point" in net.reason
+
+    def test_results_sorted_by_name(self) -> None:
+        pcb = _pcb_with_nets("VREF", "AUDIO_L", "GNDA")
+        names = [n.name for n in detect_analog_nets(pcb)]
+        assert names == sorted(names)
+
+    def test_net_zero_skipped(self) -> None:
+        # Net 0 carrying an analog-looking name must never be reported.
+        pcb = MockPCB(nets={0: MockNet(0, "AUDIO_L")})
+        assert detect_analog_nets(pcb) == []
+
+    def test_empty_pcb(self) -> None:
+        assert detect_analog_nets(MockPCB()) == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: no false positives on digital nets
+# ---------------------------------------------------------------------------
+
+
+class TestNoFalsePositives:
+    """Standard digital nets must NOT be flagged as analog."""
+
+    def test_digital_nets_not_flagged(self) -> None:
+        pcb = _pcb_with_nets(
+            "GND",
+            "DGND",
+            "+3.3V",
+            "+5V",
+            "D0",
+            "D1",
+            "SPI_MOSI",
+            "USB_DP",
+            "CLK",
+        )
+        assert detect_analog_nets(pcb) == []
+
+    def test_digital_ground_not_analog_ground(self) -> None:
+        pcb = _pcb_with_nets("GND", "DGND", "VSS")
+        assert detect_analog_nets(pcb) == []
+
+    def test_digital_supply_not_analog_supply(self) -> None:
+        pcb = _pcb_with_nets("+3.3V", "+5V", "DVDD", "VCC")
+        assert detect_analog_nets(pcb) == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: isolated-analog-ground bridge flag (local 2-pad scan)
+# ---------------------------------------------------------------------------
+
+
+class TestGndaBridge:
+    """The missing-bridge advisory fires only when no bridge component spans
+    the analog and digital grounds."""
+
+    def test_nettie_bridge_no_flag(self) -> None:
+        pcb = _pcb_with_nets("GNDA", "GND")
+        pcb.footprints = [_bridge_fp("NT1", "NetTie-2_SMD", "NetTie", "GNDA", "GND")]
+        assert check_analog_ground_bridge(pcb) == []
+
+    def test_ferrite_bridge_no_flag(self) -> None:
+        pcb = _pcb_with_nets("GNDA", "GND")
+        pcb.footprints = [_bridge_fp("FB1", "L_0805", "600R@100MHz", "GNDA", "GND")]
+        assert check_analog_ground_bridge(pcb) == []
+
+    def test_missing_bridge_flagged(self) -> None:
+        pcb = _pcb_with_nets("GNDA", "GND")
+        # No bridge component at all.
+        warnings = check_analog_ground_bridge(pcb)
+        assert len(warnings) == 1
+        assert "GNDA" in warnings[0]
+        assert "GND" in warnings[0]
+        assert "no bridge" in warnings[0]
+
+    def test_unrelated_bridge_does_not_satisfy(self) -> None:
+        # A net-tie that does NOT touch GND (both pads on GNDA) is not a bridge.
+        pcb = _pcb_with_nets("GNDA", "GND")
+        pcb.footprints = [_bridge_fp("NT1", "NetTie-2_SMD", "NetTie", "GNDA", "GNDA")]
+        warnings = check_analog_ground_bridge(pcb)
+        assert len(warnings) == 1
+
+    def test_no_digital_ground_no_flag(self) -> None:
+        # Analog ground present but nothing digital to bridge to.
+        pcb = _pcb_with_nets("GNDA")
+        assert check_analog_ground_bridge(pcb) == []
+
+    def test_no_analog_ground_no_flag(self) -> None:
+        pcb = _pcb_with_nets("GND", "DGND")
+        assert check_analog_ground_bridge(pcb) == []
+
+    def test_agnd_dgnd_pair(self) -> None:
+        pcb = _pcb_with_nets("AGND", "DGND")
+        # No bridge -> flag.
+        warnings = check_analog_ground_bridge(pcb)
+        assert len(warnings) == 1
+        assert "AGND" in warnings[0]
+
+    def test_three_pad_component_not_a_bridge(self) -> None:
+        # A 3-pad part is not the 2-pad single-point bridge we look for.
+        pcb = _pcb_with_nets("GNDA", "GND")
+        pcb.footprints = [_bridge_fp("U1", "SOT-23", "NetTie", "GNDA", "GND", "VCC")]
+        warnings = check_analog_ground_bridge(pcb)
+        assert len(warnings) == 1

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -2786,3 +2786,123 @@ class TestAnalogActionItems:
         joined = " ".join(i["description"] for i in analog)
         assert "U2" in joined and "PCM5122" in joined
         assert "U3" in joined and "OPA2134" in joined
+
+
+class TestAnalogNetActionItems:
+    """Analog NETS are named in the audit action items (Phase 2, #3170).
+
+    Mirrors ``TestAnalogActionItems`` at the net level: ``_generate_action_items``
+    must surface one priority-3 item per analog net (audio / analog supply /
+    analog ground / analog signal) and flag an isolated analog ground that
+    lacks a discrete net-tie/ferrite bridge to digital ground.  Uses a mock
+    PCB extended with a net-name surface and monkeypatches ``_load_pcb`` so
+    no analog ``.kicad_pcb`` fixture is required.
+    """
+
+    @dataclass
+    class _MockNet:
+        number: int
+        name: str
+
+    @dataclass
+    class _MockPad:
+        net_name: str = ""
+
+    @dataclass
+    class _MockFootprint:
+        reference: str = ""
+        value: str = ""
+        name: str = ""
+        pads: list = field(default_factory=list)
+
+    @dataclass
+    class _MockPCB:
+        footprints: list = field(default_factory=list)
+        nets: dict = field(default_factory=dict)
+
+    def _make_audit(self, drc_clean_pcb: Path, monkeypatch, *, net_names, footprints=()):
+        audit = ManufacturingAudit(drc_clean_pcb, manufacturer="jlcpcb")
+        nets = {0: self._MockNet(0, "")}
+        for i, name in enumerate(net_names, start=1):
+            nets[i] = self._MockNet(i, name)
+        mock_pcb = self._MockPCB(footprints=list(footprints), nets=nets)
+        monkeypatch.setattr(audit, "_load_pcb", lambda: mock_pcb)
+        return audit
+
+    def _net_items(self, items):
+        return [i for i in items if i.description.startswith("Analog net:")]
+
+    def _bridge_items(self, items):
+        return [i for i in items if "no bridge to" in i.description]
+
+    def test_one_item_per_analog_net(self, drc_clean_pcb: Path, monkeypatch):
+        audit = self._make_audit(
+            drc_clean_pcb,
+            monkeypatch,
+            net_names=["AUDIO_L", "AUDIO_R", "+3.3VA", "VREF", "GND", "+3.3V"],
+        )
+        items = audit._generate_action_items(AuditResult())
+        net_items = self._net_items(items)
+
+        names = {d.description for d in net_items}
+        # 4 analog nets named; GND / +3.3V (digital) not named.
+        assert len(net_items) == 4
+        joined = " ".join(names)
+        assert "AUDIO_L" in joined and "AUDIO_R" in joined
+        assert "+3.3VA" in joined and "VREF" in joined
+        assert "GND" not in joined or "GNDA" in joined  # plain GND not flagged
+
+        for item in net_items:
+            assert item.priority == 3
+            assert item.command is None
+
+    def test_missing_bridge_flagged(self, drc_clean_pcb: Path, monkeypatch):
+        audit = self._make_audit(
+            drc_clean_pcb,
+            monkeypatch,
+            net_names=["GNDA", "GND"],
+        )
+        items = audit._generate_action_items(AuditResult())
+        bridge = self._bridge_items(items)
+        assert len(bridge) == 1
+        assert "GNDA" in bridge[0].description
+        assert bridge[0].priority == 3
+
+    def test_bridge_present_no_flag(self, drc_clean_pcb: Path, monkeypatch):
+        nettie = self._MockFootprint(
+            reference="NT1",
+            name="NetTie-2_SMD",
+            value="NetTie",
+            pads=[self._MockPad(net_name="GNDA"), self._MockPad(net_name="GND")],
+        )
+        audit = self._make_audit(
+            drc_clean_pcb,
+            monkeypatch,
+            net_names=["GNDA", "GND"],
+            footprints=[nettie],
+        )
+        items = audit._generate_action_items(AuditResult())
+        assert self._bridge_items(items) == []
+        # The analog ground is still named even though its bridge is fine.
+        assert any("GNDA" in i.description for i in self._net_items(items))
+
+    def test_purely_digital_board_no_net_items(self, drc_clean_pcb: Path, monkeypatch):
+        audit = self._make_audit(
+            drc_clean_pcb,
+            monkeypatch,
+            net_names=["GND", "+3.3V", "D0", "SPI_MOSI", "USB_DP"],
+        )
+        items = audit._generate_action_items(AuditResult())
+        assert self._net_items(items) == []
+        assert self._bridge_items(items) == []
+
+    def test_detection_exception_does_not_crash(self, drc_clean_pcb: Path, monkeypatch):
+        audit = ManufacturingAudit(drc_clean_pcb, manufacturer="jlcpcb")
+
+        def _boom():
+            raise RuntimeError("malformed PCB")
+
+        monkeypatch.setattr(audit, "_load_pcb", _boom)
+        items = audit._generate_action_items(AuditResult())
+        assert self._net_items(items) == []
+        assert self._bridge_items(items) == []


### PR DESCRIPTION
## Summary

Phase 2 of the analog-audit work (follow-up to #3156 / Phase 1 #3172). `kct audit`
now names analog **nets** (not just components) and flags an isolated analog
ground that lacks a discrete bridge to digital ground.

- New `detect_analog_nets(pcb)` and `check_analog_ground_bridge(pcb)` siblings
  to `detect_analog_components()` in `src/kicad_tools/analysis/analog_detect.py`.
  Net classification reuses the router's `net_class.classify_from_name` (#3151
  infra) with a thin analog-specific naming layer that distinguishes
  `audio` / `analog_supply` / `analog_ground` / `analog_signal` kinds.
- `auditor._generate_action_items` emits one priority-3 `ActionItem` per analog
  net (`Analog net: <name> — <reason>`) plus a missing-bridge advisory,
  mirroring the Phase-1 component block and degrading gracefully (debug log,
  never raises) if PCB load / detection fails.
- Test mocks extended with a net-name surface (`MockNet`, `MockPCB.nets`,
  `MockPad.net_name`) in new `tests/test_analog_nets.py`; net-level audit
  integration tests added to `tests/test_audit.py`.

## Scope & honest limitation

The GNDA-bridge check is a **local 2-pad pad-membership scan only** — it looks
for a net-tie (`NetTie` in footprint name) or ferrite (value like `600R@100MHz`,
`BLM*`, `FB1`) 2-pad component with one pad on the analog ground and one on the
digital ground. It does **not** consult routed copper or zone fills, so a
zone-stitched / 0R / single-via bridge can yield a false "no bridge" advisory.
This is documented in the `check_analog_ground_bridge` docstring. Full
connectivity-topology verification (exactly-one-path) is deferred to Phase 2b,
filed as **#3178**.

## Acceptance criteria

1. `detect_analog_nets` names analog nets with `kind` + human-readable reason; digital nets (`GND`, `+3.3V`, `D0`, `SPI_MOSI`, `USB_DP`, `CLK`) not flagged.
2. `kct audit` emits one priority-3 item per analog net; emission wrapped, degrades gracefully.
3. Isolated-GNDA flag fires only when no net-tie/ferrite 2-pad bridge spans GNDA-GND.
4. Reuses `net_class.classify_from_name`.
5. Extended MockPCB tests cover analog nets named, GNDA-isolated flagged, GNDA-bridged not flagged.
6. Phase 2b follow-up filed (#3178).

## Test plan

- [x] `uv run pytest tests/test_analog_nets.py tests/test_analog_detect.py tests/test_audit.py` (72 analog/audit tests pass; pre-existing `TestZoneConnectedNets::test_no_zones_regression` failure is unrelated and present on `origin/main`).
- [x] `uv run ruff check` + `ruff format --check` clean on all changed files.
- [x] `uv run mypy` clean on changed source files.

Note: repo-wide `pnpm check:ci` reports a large pre-existing `ruff format`
backlog (~425 files untouched by this PR) and the one pre-existing
`TestZoneConnectedNets` failure. New code in this PR is format/lint/mypy clean.

Closes #3170

Generated with Claude Code