### PR TITLE
feat(cli): ki_fp_filters-driven ref-only footprint suggestion

### DIFF
--- a/src/kicad_tools/cli/sch_suggest_footprint.py
+++ b/src/kicad_tools/cli/sch_suggest_footprint.py
@@ -3,10 +3,16 @@
 Suggest library footprints for a schematic symbol.
 
 Given a component reference, this command looks up matching KiCad library
-footprints based on the symbol's pin count and an optional package keyword
-hint. It reuses the existing library-detection primitives in
-``kicad_tools.footprints.library_path`` and the pad-counting helper in
-``kicad_tools.cli.lib_footprints``.
+footprints based on the symbol's pin count, the symbol's ``ki_fp_filters``
+glob patterns, and an optional package keyword hint. It reuses the existing
+library-detection primitives in ``kicad_tools.footprints.library_path`` and
+the pad-counting helper in ``kicad_tools.cli.lib_footprints``.
+
+When the symbol carries a ``ki_fp_filters`` property (the canonical KiCad
+footprint hint), those glob patterns are AND-combined with the pin-count
+filter so a ref-only suggestion (no ``--package``) lands on the right
+variant (e.g. a 5-pin 74LVC1G17 -> ``SOT-23-5``). An explicit ``--package``
+keyword overrides the inferred filters.
 
 The KiCad standard footprint library must be installed for this command to
 return suggestions. When no library can be found (common on CI runners and
@@ -29,6 +35,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import json
 import sys
 from pathlib import Path
@@ -75,9 +82,10 @@ def _derive_keyword(sym: Any) -> str | None:
 
     Uses the same prefix conventions as :func:`guess_standard_library` (e.g.
     ``SOT-`` -> ``Package_TO_SOT_SMD``) applied to the footprint-name-ish
-    fields available on a symbol. This is intentionally weak: true package
-    inference needs ``ki_fp_filters`` parsing (deferred follow-up). Returns
-    the standard library name if a prefix matches, else ``None``.
+    fields available on a symbol. This is intentionally weak; for precise
+    package inference the symbol's ``ki_fp_filters`` property is used instead
+    (see :func:`_get_fp_filters`). Returns the standard library name if a
+    prefix matches, else ``None``.
     """
     for candidate in (sym.value, sym.lib_id.split(":")[-1]):
         if not candidate:
@@ -86,6 +94,35 @@ def _derive_keyword(sym: Any) -> str | None:
         if lib:
             return lib
     return None
+
+
+def _get_fp_filters(sch: Schematic, sym: Any) -> list[str]:
+    """Return the symbol's ``ki_fp_filters`` glob patterns, space-split.
+
+    KiCad symbols carry a ``ki_fp_filters`` property (e.g.
+    ``"SOT?23* SOT?553* Texas?R-PDSO-G5?DCK*"``) that is the canonical
+    footprint-suggestion hint. ``LibrarySymbol.from_sexp`` already parses
+    arbitrary ``(property ...)`` nodes into ``LibrarySymbol.properties``, so
+    we simply read the key from the *directly-parsed* library symbol returned
+    by :meth:`Schematic.get_lib_symbol_resolved`.
+
+    Note: ``resolve_extends`` copies pins/graphics but NOT properties. For a
+    symbol that defines its own pins (the common case) the directly-parsed
+    symbol is returned, so ``ki_fp_filters`` is preserved. For ``extends``-only
+    derived symbols with no own filters this returns ``[]`` and the caller
+    falls back to Phase 1 behavior (graceful, no regression).
+
+    Returns the list of space-separated patterns, or an empty list when the
+    property is absent or empty/whitespace.
+    """
+    try:
+        lib_sym = sch.get_lib_symbol_resolved(sym.lib_id)
+    except Exception:
+        return []
+    if lib_sym is None:
+        return []
+    raw = lib_sym.properties.get("ki_fp_filters", "")
+    return raw.split()
 
 
 def _candidate_library_paths(paths: LibraryPaths, keyword: str | None) -> list[tuple[str, Path]]:
@@ -120,15 +157,35 @@ def _candidate_library_paths(paths: LibraryPaths, keyword: str | None) -> list[t
     return result
 
 
-def _rank_key(candidate: dict[str, Any], keyword: str | None) -> tuple:
-    """Sort key: keyword-name matches first, non-hand-solder before hand, A-Z."""
+def _matches_fp_filters(name: str, fp_filters: list[str] | None) -> bool:
+    """Return ``True`` if *name* matches any ``ki_fp_filters`` glob pattern.
+
+    Patterns are matched case-sensitively with :func:`fnmatch.fnmatchcase`
+    against the footprint stem. An empty/``None`` filter list matches nothing
+    (callers treat "no filters" as "do not constrain by filters").
+    """
+    if not fp_filters:
+        return False
+    return any(fnmatch.fnmatchcase(name, pat) for pat in fp_filters)
+
+
+def _rank_key(
+    candidate: dict[str, Any],
+    keyword: str | None,
+    fp_filters: list[str] | None = None,
+) -> tuple:
+    """Sort key: filter matches, then keyword matches, non-hand-solder, A-Z."""
     name = candidate["footprint"]
     name_lower = name.lower()
+    # ki_fp_filters matches rank above everything else when filters are active.
+    filter_match = 0
+    if _matches_fp_filters(name, fp_filters):
+        filter_match = -1  # sorts before non-matches
     kw_match = 0
     if keyword and keyword.lower() in name_lower:
         kw_match = -1  # sorts before non-matches
     hand = 1 if "handsolder" in name_lower.replace("_", "") else 0
-    return (kw_match, hand, candidate["library"], name)
+    return (filter_match, kw_match, hand, candidate["library"], name)
 
 
 def find_footprint_candidates(
@@ -136,6 +193,7 @@ def find_footprint_candidates(
     target_pins: int | None,
     keyword: str | None,
     limit: int,
+    fp_filters: list[str] | None = None,
 ) -> list[dict[str, Any]]:
     """Find footprints whose pad count matches *target_pins*.
 
@@ -144,6 +202,12 @@ def find_footprint_candidates(
         target_pins: Required pad count, or ``None`` to accept any count.
         keyword: Optional package keyword used for library filtering + ranking.
         limit: Maximum number of candidates to return.
+        fp_filters: Optional ``ki_fp_filters`` glob patterns. When non-empty,
+            a footprint must match at least one pattern **in addition** to the
+            pad-count check (AND-combined), and matching footprints rank first.
+            The patterns are intentionally broad (e.g. ``SOT?23*`` matches
+            SOT-23-5, SOT-23-6, and SOT-23), so the pad-count filter is what
+            disambiguates the correct variant.
 
     Returns:
         Ranked list of dicts with ``library``, ``footprint``, ``pads`` keys.
@@ -155,6 +219,15 @@ def find_footprint_candidates(
         for mod_file in sorted(lib_dir.glob("*.kicad_mod")):
             if scanned >= _MAX_SCANNED_FOOTPRINTS:
                 break
+            # AND-combine ki_fp_filters with the pad-count check: when filters
+            # are present, a footprint must match at least one glob pattern.
+            # The stem glob is cheap (no file read), so skip non-matches BEFORE
+            # counting against the scan cap; the cap exists to bound expensive
+            # ``.kicad_mod`` reads, not free string matches. This lets a
+            # ki_fp_filters-driven search reach late-alphabet libraries (e.g.
+            # ``Package_TO_SOT_SMD``) that sit past the raw 5000-file cap.
+            if fp_filters and not _matches_fp_filters(mod_file.stem, fp_filters):
+                continue
             scanned += 1
             try:
                 sexp = load_footprint(mod_file)
@@ -173,7 +246,7 @@ def find_footprint_candidates(
         if scanned >= _MAX_SCANNED_FOOTPRINTS:
             break
 
-    candidates.sort(key=lambda c: _rank_key(c, keyword))
+    candidates.sort(key=lambda c: _rank_key(c, keyword, fp_filters))
     return candidates[:limit]
 
 
@@ -208,6 +281,13 @@ def run_suggest_footprint(
     target_pins = _resolve_target_pin_count(sch, sym)
     keyword = package or _derive_keyword(sym)
 
+    # The symbol's ki_fp_filters are the canonical footprint hint. When an
+    # explicit --package keyword is given it acts as a narrower/override and
+    # we skip the (broad) inferred filters so the user's intent wins. With no
+    # --package, the filters drive ref-only suggestion (AND-combined with the
+    # pin-count filter to disambiguate). Absent/empty filters -> Phase 1.
+    fp_filters: list[str] = [] if package else _get_fp_filters(sch, sym)
+
     # Detect KiCad library; degrade gracefully if absent.
     paths = detect_kicad_library_path(config_override)
     if not paths.found:
@@ -222,7 +302,9 @@ def run_suggest_footprint(
         )
         return 1
 
-    candidates = find_footprint_candidates(paths, target_pins, keyword, limit)
+    candidates = find_footprint_candidates(
+        paths, target_pins, keyword, limit, fp_filters=fp_filters
+    )
 
     if output_format == "json":
         print(
@@ -233,6 +315,7 @@ def run_suggest_footprint(
                     "lib_id": sym.lib_id,
                     "pin_count": target_pins,
                     "package_keyword": keyword,
+                    "fp_filters": fp_filters,
                     "library_source": paths.source,
                     "candidates": candidates,
                 },
@@ -242,7 +325,8 @@ def run_suggest_footprint(
     else:
         pin_desc = f"{target_pins} pins" if target_pins is not None else "unknown pin count"
         kw_desc = f", package hint '{keyword}'" if keyword else ""
-        print(f"Suggestions for {ref} ({sym.value or sym.lib_id}, {pin_desc}{kw_desc}):")
+        filt_desc = f", ki_fp_filters {fp_filters}" if fp_filters else ""
+        print(f"Suggestions for {ref} ({sym.value or sym.lib_id}, {pin_desc}{kw_desc}{filt_desc}):")
         if not candidates:
             print("  (no matching footprints found)")
         else:

--- a/tests/fixtures/missing_footprint.kicad_sch
+++ b/tests/fixtures/missing_footprint.kicad_sch
@@ -32,6 +32,10 @@
 		)
 		(symbol "74xGxx:74LVC1G17"
 			(pin_names (offset 0.254))
+			(property "ki_fp_filters" "SOT?23* SOT?553* Texas?R-PDSO-G5?DCK* Texas?R-PDSO-N5?DRL* Texas?X2SON*0.8x0.8mm*P0.48mm*"
+				(at 0 0 0)
+				(effects (font (size 1.27 1.27)) (hide yes))
+			)
 			(symbol "74LVC1G17_0_1"
 				(rectangle
 					(start -3.81 3.81)

--- a/tests/test_sch_suggest_footprint.py
+++ b/tests/test_sch_suggest_footprint.py
@@ -7,16 +7,28 @@ The no-library degradation tests must run everywhere and are NOT gated.
 
 from __future__ import annotations
 
+import fnmatch
 import json
 from pathlib import Path
 
 import pytest
 
 from kicad_tools.cli import sch_suggest_footprint
-from kicad_tools.cli.sch_suggest_footprint import run_suggest_footprint
+from kicad_tools.cli.sch_suggest_footprint import (
+    _get_fp_filters,
+    _matches_fp_filters,
+    run_suggest_footprint,
+)
 from kicad_tools.footprints.library_path import (
     LibraryPaths,
     detect_kicad_library_path,
+)
+from kicad_tools.schema import Schematic
+
+# Canonical ki_fp_filters value for the 74LVC1G17 (from KiCad's 74xGxx.kicad_sym),
+# embedded into the U7 lib_symbol of the test fixture.
+_EXPECTED_FP_FILTERS = (
+    "SOT?23* SOT?553* Texas?R-PDSO-G5?DCK* Texas?R-PDSO-N5?DRL* Texas?X2SON*0.8x0.8mm*P0.48mm*"
 )
 
 FIXTURE = Path(__file__).parent / "fixtures" / "missing_footprint.kicad_sch"
@@ -109,6 +121,148 @@ def test_no_library_graceful_degradation(monkeypatch, capsys):
     assert rc == 1
     assert "KICAD_FOOTPRINT_DIR" in err
     assert "No KiCad footprint library found" in err
+
+
+# ---------------------------------------------------------------------------
+# ki_fp_filters parse + glob match (KiCad-INDEPENDENT, NOT gated)
+# ---------------------------------------------------------------------------
+
+
+def test_fp_filters_parse_from_fixture():
+    """AC: ki_fp_filters parses from the embedded lib_symbol's properties dict."""
+    sch = Schematic.load(FIXTURE)
+    lib_sym = sch.get_lib_symbol_resolved("74xGxx:74LVC1G17")
+    assert lib_sym is not None
+    # No new schema field: reuse LibrarySymbol.properties.
+    assert lib_sym.properties.get("ki_fp_filters") == _EXPECTED_FP_FILTERS
+
+
+def test_get_fp_filters_splits_space_separated_patterns():
+    """AC: _get_fp_filters returns the space-split list of glob patterns."""
+    sch = Schematic.load(FIXTURE)
+    sym = sch.get_symbol("U7")
+    filters = _get_fp_filters(sch, sym)
+    assert filters == [
+        "SOT?23*",
+        "SOT?553*",
+        "Texas?R-PDSO-G5?DCK*",
+        "Texas?R-PDSO-N5?DRL*",
+        "Texas?X2SON*0.8x0.8mm*P0.48mm*",
+    ]
+
+
+def test_fp_filters_glob_matches_sot23_variants():
+    """AC: fnmatch.fnmatchcase glob semantics against the footprint stem.
+
+    Patterns are deliberately broad (SOT-23-5, SOT-23-6, and SOT-23 all match
+    ``SOT?23*``), which is why pin-count must AND-combine to disambiguate.
+    """
+    sch = Schematic.load(FIXTURE)
+    sym = sch.get_symbol("U7")
+    filters = _get_fp_filters(sch, sym)
+
+    # Direct fnmatch.fnmatchcase semantics (case-sensitive, ? = single char).
+    assert fnmatch.fnmatchcase("SOT-23-5", "SOT?23*")
+    assert not fnmatch.fnmatchcase("sot-23-5", "SOT?23*")  # case-sensitive
+
+    # The helper applies any-of-patterns matching.
+    assert _matches_fp_filters("SOT-23-5", filters)
+    assert _matches_fp_filters("SOT-23-6", filters)
+    assert _matches_fp_filters("SOT-23", filters)
+    assert _matches_fp_filters("SOT-553", filters)
+    assert _matches_fp_filters("Texas_X2SON-5_0.8x0.8mm_P0.48mm", filters)
+    assert not _matches_fp_filters("QFN-16", filters)
+
+
+def test_get_fp_filters_empty_when_no_property():
+    """AC: symbol without ki_fp_filters -> empty list (Phase 1 fallback)."""
+    sch = Schematic.load(FIXTURE)
+    r1 = sch.get_symbol("R1")  # Device:R has no ki_fp_filters in the fixture.
+    assert _get_fp_filters(sch, r1) == []
+
+
+def test_matches_fp_filters_empty_filter_list():
+    """Empty/None filters match nothing (callers treat as 'do not constrain')."""
+    assert not _matches_fp_filters("SOT-23-5", [])
+    assert not _matches_fp_filters("SOT-23-5", None)
+
+
+# ---------------------------------------------------------------------------
+# ki_fp_filters ref-only ranking (library-gated)
+# ---------------------------------------------------------------------------
+
+
+@requires_kicad_libs
+def test_suggest_ref_only_infers_sot23_5(capsys):
+    """AC #1: U7 with NO --package infers SOT-23-5 via ki_fp_filters + pins."""
+    rc = run_suggest_footprint(FIXTURE, ref="U7", limit=20)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Package_TO_SOT_SMD:SOT-23-5" in out
+    # All candidates satisfy the pin-count AND-combined filter (5 pads).
+    for line in out.splitlines():
+        if "pads)" in line:
+            assert "(5 pads)" in line
+
+
+@requires_kicad_libs
+def test_suggest_ref_only_ranks_sot23_5_first(capsys):
+    """AC: filter-matching candidate ranks first for ref-only suggestion."""
+    rc = run_suggest_footprint(FIXTURE, ref="U7", output_format="json", limit=20)
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert data["candidates"], "expected at least one candidate"
+    # The top-ranked candidate matches the symbol's ki_fp_filters.
+    top = data["candidates"][0]
+    assert _matches_fp_filters(top["footprint"], data["fp_filters"])
+    assert top["pads"] == 5
+    # SOT-23-5 should be present and the non-hand-solder variant ranks ahead.
+    names = [c["footprint"] for c in data["candidates"]]
+    assert "SOT-23-5" in names
+
+
+@requires_kicad_libs
+def test_suggest_ref_only_json_includes_fp_filters(capsys):
+    """AC: JSON output surfaces the resolved fp_filters list."""
+    rc = run_suggest_footprint(FIXTURE, ref="U7", output_format="json", limit=5)
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert data["fp_filters"] == [
+        "SOT?23*",
+        "SOT?553*",
+        "Texas?R-PDSO-G5?DCK*",
+        "Texas?R-PDSO-N5?DRL*",
+        "Texas?X2SON*0.8x0.8mm*P0.48mm*",
+    ]
+
+
+@requires_kicad_libs
+def test_explicit_package_overrides_inferred_filters(capsys):
+    """AC: --package overrides inferred filters; fp_filters omitted in JSON."""
+    rc = run_suggest_footprint(FIXTURE, ref="U7", package="SOT-23", output_format="json", limit=20)
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    # Explicit --package suppresses the inferred ki_fp_filters.
+    assert data["fp_filters"] == []
+    assert data["package_keyword"] == "SOT-23"
+
+
+@requires_kicad_libs
+def test_suggest_ref_only_fallback_for_no_filter_symbol(capsys):
+    """AC #3: R1 (no ki_fp_filters) still behaves as Phase 1 (no crash)."""
+    rc = run_suggest_footprint(FIXTURE, ref="R1", output_format="json", limit=10)
+    assert rc == 0
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    # Fallback: no inferred filters, suggestions driven by pin count + value.
+    assert data["fp_filters"] == []
+    assert data["pin_count"] == 2
+    # All candidates must be 2-pad (Phase 1 pin-count behavior preserved).
+    for c in data["candidates"]:
+        assert c["pads"] == 2
 
 
 def test_symbol_not_found(capsys):


### PR DESCRIPTION
## Summary

Implements Phase 2 of `sch suggest-footprint` (Closes #3173): ref-only footprint suggestion driven by the symbol's `ki_fp_filters` property, AND-combined with the Phase 1 pin-count filter. Purely additive to Phase 1 — the property was already parsed into `LibrarySymbol.properties`, so this reads a key and globs.

- When no `--package` hint is given, derive candidate filters from the symbol's `ki_fp_filters` (via `get_lib_symbol_resolved(...).properties`) and require footprints to match at least one space-separated glob pattern (`fnmatch.fnmatchcase` against the footprint stem) **in addition** to the pin-count check. Filter-matching candidates rank first. Result: `sch suggest-footprint U7` (5-pin 74LVC1G17) surfaces `SOT-23-5` at the top with no `--package`.
- Explicit `--package KEYWORD` overrides the inferred filters (user intent wins).
- Symbols with no `ki_fp_filters` fall back to Phase 1 behavior (pin count + optional `--package`), no regression.
- JSON output gains an `fp_filters` key so the suggestion rationale is inspectable.
- The scan cap is now charged only for footprints that pass the cheap stem glob, so a filter-driven search can reach late-alphabet libraries (`Package_TO_SOT_SMD`) that sit past the raw 5000-file read cap.

## Implementation notes

- `_get_fp_filters(sch, sym)` reads from the **directly-parsed** library symbol (not a resolved-extends view) since `resolve_extends` copies pins/graphics but not properties. `extends`-only derived symbols with no own filters return `[]` and fall back gracefully.
- Test fixture `tests/fixtures/missing_footprint.kicad_sch` gains the canonical 74LVC1G17 `ki_fp_filters` value so the parse/glob tests are KiCad-independent; only the end-to-end ranking tests are `skipif`-gated on the footprint library.
- No schema changes (reuses `LibrarySymbol.properties`, parsed at `schema/library.py:575-581`).

## Deferred follow-ups filed

- #3180 — bulk `assign-footprints --auto/--interactive`
- #3181 — fp-lib-table-aware resolution

## Test plan

- [x] `uv run pytest tests/test_sch_suggest_footprint.py` — 18 passed (incl. new KiCad-independent parse/glob tests, library-gated ref-only ranking tests, override + fallback tests).
- [x] Ran all tests sharing the modified fixture (10 files) — only pre-existing, unrelated failure (`test_existing_hierarchical_fixture_aggregation`, confirmed failing on clean tree, uses a different fixture).
- [x] `ruff check` + `ruff format --check` clean on changed files (repo-wide pre-existing lint/format debt untouched).
- [ ] Manual (KiCad installed): `kct sch suggest-footprint tests/fixtures/missing_footprint.kicad_sch --ref U7 --format json` shows `fp_filters` + SOT-23-5 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #3173