### PR TITLE
feat(router): analog-aware routing flags --analog-nets / --auto-analog (closes #3171)

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -392,6 +392,12 @@ def run_route_command(args) -> int:
     # autorouter's net_class_map at routing time.
     if getattr(args, "net_class_map", None) is not None:
         sub_argv.extend(["--net-class-map", args.net_class_map])
+    # Issue #3171 (Phase 3): forward the analog-aware routing flags so the
+    # inner route_cmd injects the boosted analog NetClassRouting class.
+    if getattr(args, "analog_nets", None):
+        sub_argv.extend(["--analog-nets", args.analog_nets])
+    if getattr(args, "auto_analog", False):
+        sub_argv.append("--auto-analog")
     return route_main(sub_argv)
 
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2930,6 +2930,31 @@ def _add_route_parser(subparsers) -> None:
             "diff-pair sibling traces under tight mfr profiles."
         ),
     )
+    route_parser.add_argument(
+        "--analog-nets",
+        dest="analog_nets",
+        default=None,
+        help=(
+            "Comma-separated list of analog net names (e.g. "
+            '"AUDIO_L,AUDIO_R") to route with a boosted analog class '
+            "(Issue #3171, Phase 3).  Selected nets get priority=2 (route "
+            "before digital signals) and cost_multiplier=0.85 (shorter-path "
+            "bias).  Pour/ground nets (e.g. GNDA) are never forced into the "
+            "pathfinder.  NOTE: guard-trace / shield-copper generation is NOT "
+            "implemented and is deferred to a follow-up (Phase 4)."
+        ),
+    )
+    route_parser.add_argument(
+        "--auto-analog",
+        dest="auto_analog",
+        action="store_true",
+        help=(
+            "Auto-detect analog nets via the Phase 2 detector "
+            "(detect_analog_nets) and route them with the boosted analog "
+            "class (Issue #3171).  May be combined with --analog-nets (the "
+            "two sets are unioned)."
+        ),
+    )
 
 
 def _add_route_auto_parser(subparsers) -> None:

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -2276,6 +2276,127 @@ def _apply_net_class_map_sidecar(router: "Autorouter", args, quiet: bool = False
         flush_print(f"  Net-class map: merged {len(loaded)} sidecar entries")
 
 
+def _resolve_analog_net_names(router: "Autorouter", args) -> set[str]:
+    """Resolve the set of analog net names selected by the analog flags (#3171).
+
+    The union of:
+
+    * ``--analog-nets "NET1,NET2,..."`` -- explicit, comma-separated, with
+      surrounding whitespace stripped and empty entries dropped (mirrors the
+      ``--skip-nets`` comma-split pattern).
+    * ``--auto-analog`` -- auto-detected via Phase 2's
+      :func:`detect_analog_nets`, run against the router's loaded net names.
+
+    Returns an empty set when neither flag is supplied (the feature is a
+    strict no-op when absent).  Never raises: auto-detection failures are
+    swallowed so a detection edge case never blocks routing.
+    """
+    names: set[str] = set()
+
+    explicit = getattr(args, "analog_nets", None)
+    if explicit:
+        names |= {n.strip() for n in explicit.split(",") if n.strip()}
+
+    if getattr(args, "auto_analog", False):
+        try:
+            from kicad_tools.analysis.analog_detect import detect_analog_nets
+
+            # ``detect_analog_nets`` consumes a PCB exposing ``.nets`` as a
+            # ``{number: net-with-.name}`` mapping.  The router already holds
+            # the loaded ``net_names`` (``{net_id: name}``); wrap it in a tiny
+            # adapter so we reuse the Phase 2 classifier verbatim rather than
+            # duplicating its naming rules here.
+            net_names = getattr(router, "net_names", {}) or {}
+            adapter = _AnalogDetectAdapter(net_names)
+            names |= {a.name for a in detect_analog_nets(adapter)}
+        except Exception:
+            # Auto-detection is advisory; never let it block routing.
+            pass
+
+    return names
+
+
+class _AnalogDetectAdapter:
+    """Minimal PCB-shaped adapter exposing ``.nets`` for ``detect_analog_nets``.
+
+    ``detect_analog_nets`` only touches ``pcb.nets`` as a mapping of
+    ``{number: net}`` where each ``net`` has a ``.name`` attribute.  This
+    adapter projects the router's ``{net_id: name}`` mapping into that shape
+    so the Phase 2 (#3170) classifier can be reused without re-loading the
+    PCB at the per-attempt routing callsites.
+    """
+
+    class _Net:
+        __slots__ = ("name",)
+
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+    def __init__(self, net_names: dict[int, str]) -> None:
+        self.nets = {num: self._Net(name) for num, name in net_names.items()}
+
+
+def _apply_analog_net_class(router: "Autorouter", args, quiet: bool = False) -> None:
+    """Inject the boosted analog routing class for selected nets (Issue #3171).
+
+    Phase 3 of analog-aware routing.  For each net selected by ``--analog-nets``
+    and/or ``--auto-analog`` (resolved via :func:`_resolve_analog_net_names`)
+    that is present on the board, set ``router.net_class_map[net]`` to
+    :data:`NET_CLASS_ANALOG` -- a priority- and cost-boosted class
+    (``priority=2``, ``cost_multiplier=0.85``) so the net routes earlier and
+    shorter.  No A*/pathfinder changes: the existing per-net priority
+    (``_get_net_priority``) and per-net ``cost_multiplier`` consumers do the
+    work.
+
+    Pour/ground guard (AC #5): a selected net whose *existing* class is a pour
+    net (``is_pour_net=True`` or ``route_via="pour"`` -- e.g. ``GNDA``) is
+    LEFT UNTOUCHED.  Those nets are satisfied by a copper zone, not the
+    pathfinder; forcing the analog (pathfinder) class onto them would drag a
+    pour/ground net into the router as an ordinary trace.
+
+    Idempotent and a strict no-op when neither flag is supplied.  Called at
+    every post-load callsite alongside :func:`_apply_net_class_map_sidecar`.
+    """
+    selected = _resolve_analog_net_names(router, args)
+    if not selected:
+        return
+
+    from kicad_tools.router.rules import NET_CLASS_ANALOG
+
+    # Only act on nets actually present on the board (AC: missing names are
+    # silently ignored).  ``router.net_names`` is {net_id: name}.
+    present = {name for name in router.net_names.values() if name}
+
+    applied: list[str] = []
+    skipped_pour: list[str] = []
+    for name in sorted(selected & present):
+        existing = router.net_class_map.get(name)
+        # Pour/ground guard: never force a poured net into the pathfinder.
+        if existing is not None and (
+            getattr(existing, "is_pour_net", False) or getattr(existing, "route_via", "") == "pour"
+        ):
+            skipped_pour.append(name)
+            continue
+        router.net_class_map[name] = NET_CLASS_ANALOG
+        applied.append(name)
+
+    if not quiet and (applied or skipped_pour):
+        from kicad_tools.cli.progress import flush_print
+
+        if applied:
+            flush_print(
+                f"  Analog routing: boosted {len(applied)} net(s) "
+                f"(priority={NET_CLASS_ANALOG.priority}, "
+                f"cost_multiplier={NET_CLASS_ANALOG.cost_multiplier}): "
+                f"{', '.join(applied)}"
+            )
+        if skipped_pour:
+            flush_print(
+                f"  Analog routing: left {len(skipped_pour)} pour/ground net(s) "
+                f"as-is (not forced into pathfinder): {', '.join(skipped_pour)}"
+            )
+
+
 def route_with_layer_escalation(
     pcb_path: Path,
     output_path: Path,
@@ -2495,6 +2616,10 @@ def route_with_layer_escalation(
 
         # Issue #2996: merge --net-class-map sidecar onto router's map.
         _apply_net_class_map_sidecar(router, args, quiet=quiet)
+
+        # Issue #3171: inject boosted analog routing class for --analog-nets /
+        # --auto-analog selected nets (pour/ground nets are left untouched).
+        _apply_analog_net_class(router, args, quiet=quiet)
 
         # Issue #2396: Ensure pristine per-attempt state.  Today this is a
         # no-op (load_pcb_for_routing creates a fresh Autorouter) but it
@@ -3246,6 +3371,10 @@ def route_with_rule_relaxation(
 
         # Issue #2996: merge --net-class-map sidecar onto router's map.
         _apply_net_class_map_sidecar(router, args, quiet=quiet)
+
+        # Issue #3171: inject boosted analog routing class for --analog-nets /
+        # --auto-analog selected nets (pour/ground nets are left untouched).
+        _apply_analog_net_class(router, args, quiet=quiet)
 
         # Issue #1841: Tell the autorouter which pour nets lack zones
         router._pour_nets_without_zones = set(_no_zone)
@@ -4361,6 +4490,10 @@ def route_with_combined_escalation(
             # Issue #2996: merge --net-class-map sidecar onto router's map.
             _apply_net_class_map_sidecar(router, args, quiet=quiet)
 
+            # Issue #3171: inject boosted analog routing class for --analog-nets
+            # / --auto-analog selected nets (pour/ground nets left untouched).
+            _apply_analog_net_class(router, args, quiet=quiet)
+
             # Issue #1841: Tell the autorouter which pour nets lack zones
             router._pour_nets_without_zones = set(_no_zone)
 
@@ -5127,6 +5260,31 @@ def main(argv: list[str] | None = None) -> int:
             "coupled_continuity_threshold, target_diff_impedance, "
             "length_match_group) project through to the routing-time "
             "pathfinder.  Mirrors the kct check --net-class-map flag."
+        ),
+    )
+    parser.add_argument(
+        "--analog-nets",
+        dest="analog_nets",
+        default=None,
+        help=(
+            "Comma-separated list of analog net names (e.g. "
+            '"AUDIO_L,AUDIO_R") to route with a boosted analog class '
+            "(Issue #3171, Phase 3).  Selected nets get priority=2 (route "
+            "before digital signals) and cost_multiplier=0.85 (shorter-path "
+            "bias).  Pour/ground nets (e.g. GNDA) are never forced into the "
+            "pathfinder.  NOTE: guard-trace / shield-copper generation is NOT "
+            "implemented and is deferred to a follow-up (Phase 4)."
+        ),
+    )
+    parser.add_argument(
+        "--auto-analog",
+        dest="auto_analog",
+        action="store_true",
+        help=(
+            "Auto-detect analog nets via the Phase 2 detector "
+            "(detect_analog_nets) and route them with the boosted analog "
+            "class (Issue #3171).  May be combined with --analog-nets (the "
+            "two sets are unioned)."
         ),
     )
     parser.add_argument(
@@ -6329,6 +6487,10 @@ def main(argv: list[str] | None = None) -> int:
 
     # Issue #2996: merge --net-class-map sidecar onto router's map.
     _apply_net_class_map_sidecar(router, args, quiet=quiet)
+
+    # Issue #3171: inject boosted analog routing class for --analog-nets /
+    # --auto-analog selected nets (pour/ground nets are left untouched).
+    _apply_analog_net_class(router, args, quiet=quiet)
 
     # Pass fine zones from multi-resolution plan to the router (Issue #1828).
     # This enables SubGridRouter to use fine-grid resolution for escape

--- a/src/kicad_tools/router/rules.py
+++ b/src/kicad_tools/router/rules.py
@@ -446,9 +446,7 @@ class DesignRules:
             # clearance is only sound when a trace centred between
             # two adjacent pads can satisfy full manufacturer
             # clearance against both.
-            effective_channel = (
-                pin_pitch - 2.0 * self.fine_pitch_clearance - self.trace_width
-            )
+            effective_channel = pin_pitch - 2.0 * self.fine_pitch_clearance - self.trace_width
             required_channel = 2.0 * self.trace_clearance + self.trace_width
             if effective_channel >= required_channel:
                 return self.fine_pitch_clearance
@@ -1175,6 +1173,33 @@ NET_CLASS_AUDIO = NetClassRouting(
     trace_width=0.2,
     clearance=0.15,
     cost_multiplier=1.0,
+    noise_sensitive=True,
+)
+
+# Issue #3171 (Phase 3: analog-aware routing).  The ``kct route
+# --analog-nets`` / ``--auto-analog`` flags inject this class onto the
+# router's name-pattern-classified ``net_class_map`` for designer-named (or
+# auto-detected) analog nets.  It *boosts* ``NET_CLASS_AUDIO``:
+#
+#   * ``priority=2`` (vs Audio's 3 and Digital's 4) so listed analog nets
+#     sort ahead of ordinary digital signals in ``_get_net_priority`` and get
+#     first pick of routing corridors before channels congest.
+#   * ``cost_multiplier=0.85`` (< 1.0) so the pathfinder applies a shorter-
+#     path bias to these nets (keeps noise-sensitive analog runs short).
+#   * ``noise_sensitive=True`` (carry-over from Audio).
+#
+# ``trace_width``/``clearance`` deliberately stay at the digital defaults --
+# width/impedance sizing is a separate concern (out of scope for Phase 3).
+# Critically this class is NOT a pour net (``is_pour_net=False``,
+# ``route_via="pathfinder"`` default); the injection helper additionally
+# refuses to overwrite any net whose existing class is a pour net (e.g.
+# ``GNDA``) so a pour/ground net is never forced into the pathfinder.
+NET_CLASS_ANALOG = NetClassRouting(
+    name="Analog",
+    priority=2,
+    trace_width=0.2,
+    clearance=0.15,
+    cost_multiplier=0.85,
     noise_sensitive=True,
 )
 

--- a/tests/test_cli_route_analog_nets.py
+++ b/tests/test_cli_route_analog_nets.py
@@ -1,0 +1,541 @@
+"""Tests for the ``kct route --analog-nets`` / ``--auto-analog`` flags (Issue #3171).
+
+Phase 3 of analog-aware routing.  The flags inject a priority- and
+cost-boosted analog :class:`NetClassRouting` (``NET_CLASS_ANALOG``) onto the
+autorouter's name-pattern-classified ``net_class_map`` for designer-named
+(``--analog-nets "AUDIO_L,AUDIO_R"``) and/or auto-detected (``--auto-analog``,
+via the Phase 2 ``detect_analog_nets``) analog nets.  No A*/pathfinder
+changes -- the existing per-net ``priority`` (route order) and per-net
+``cost_multiplier`` (cost bias) consumers do the work.
+
+This module mirrors ``tests/test_cli_route_net_class_map.py`` (the
+``--net-class-map`` precedent, Issue #2996).
+
+Coverage:
+
+1. **AC #1 / #2: flags declared in both parsers** -- the unified
+   ``cli/parser.py`` and the standalone ``route_cmd.py`` parser, with the
+   documented defaults (``analog_nets=None``, ``auto_analog=False``).
+2. **AC #3: map injection** -- after the analog helper runs, the boosted
+   class lands on ``router.net_class_map`` with ``priority`` < digital and
+   ``cost_multiplier`` <= 0.9.
+3. **AC #4: ordering** -- ``_get_net_priority(analog)[0] < _get_net_priority(digital)[0]``.
+4. **AC #2: auto-detect** -- ``--auto-analog`` selects an analog net without
+   an explicit list; union behaviour when both flags are set.
+5. **AC #5: pour-net guard** -- a pour/ground net (``GNDA``) selected as
+   analog keeps its pour semantics (not forced into the pathfinder).
+6. **AC #6: forwarding** -- ``run_route_command`` propagates the flags into
+   the inner ``route_cmd.main`` argv.
+7. **AC #7: no-op when absent** -- without the flags the map and net-priority
+   ordering are unchanged vs. baseline.
+8. **Edge cases** -- empty list, unknown net name, dedup, zero-analog board.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+from io import StringIO
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.rules import (
+    NET_CLASS_ANALOG,
+    NET_CLASS_DIGITAL,
+    DesignRules,
+)
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _make_router(grid_resolution: float = 0.5) -> Autorouter:
+    """Create a small Autorouter for testing (mirrors test_off_grid_priority)."""
+    rules = DesignRules(grid_resolution=grid_resolution)
+    return Autorouter(width=40.0, height=40.0, origin_x=100.0, origin_y=100.0, rules=rules)
+
+
+def _add_2pin_net(router: Autorouter, ref: str, x: float, y: float, net: int, name: str) -> None:
+    """Add a simple 2-pin net so the router populates net_names/nets."""
+    router.add_component(
+        ref,
+        [
+            {"number": "1", "x": x, "y": y, "net": net, "net_name": name},
+            {"number": "2", "x": x + 2.0, "y": y, "net": net, "net_name": name},
+        ],
+    )
+
+
+def _populate_synthetic_board(router: Autorouter) -> dict[str, int]:
+    """Populate a synthetic board with one audio + several digital nets.
+
+    Returns a {net_name: net_id} mapping for convenience.
+    """
+    nets = {
+        "AUDIO_L": 1,
+        "AUDIO_R": 2,
+        "D0": 3,
+        "D1": 4,
+        "SPI_CLK": 5,
+    }
+    y = 105.0
+    for name, nid in nets.items():
+        _add_2pin_net(router, f"U{nid}", 105.0, y, nid, name)
+        y += 4.0
+    return nets
+
+
+def _analog_args(**overrides) -> SimpleNamespace:
+    """Build a minimal args namespace exercising the analog helper."""
+    base: dict[str, object] = {"analog_nets": None, "auto_analog": False}
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+# =============================================================================
+# AC #1 / #2: Flags declared in both parsers
+# =============================================================================
+
+
+class TestFlagsDefinedInBothParsers:
+    """Both flags must appear in the unified and standalone parsers."""
+
+    def test_analog_nets_in_unified_parser_help(self):
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        help_output = StringIO()
+        with patch.object(sys, "stdout", help_output):
+            with contextlib.suppress(SystemExit):
+                parser.parse_args(["route", "--help"])
+        help_text = help_output.getvalue()
+        assert "--analog-nets" in help_text
+        assert "--auto-analog" in help_text
+
+    def test_analog_nets_in_route_cmd_help(self):
+        from kicad_tools.cli.route_cmd import main as route_main
+
+        help_output = StringIO()
+        with patch.object(sys, "stdout", help_output):
+            with contextlib.suppress(SystemExit):
+                route_main(["--help"])
+        help_text = help_output.getvalue()
+        assert "--analog-nets" in help_text
+        assert "--auto-analog" in help_text
+
+    def test_help_notes_guard_traces_deferred(self):
+        """AC #8: the --help text flags that guard-trace generation is deferred."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        help_output = StringIO()
+        with patch.object(sys, "stdout", help_output):
+            with contextlib.suppress(SystemExit):
+                parser.parse_args(["route", "--help"])
+        help_text = help_output.getvalue().lower()
+        assert "guard" in help_text and "deferred" in help_text
+
+    def test_analog_nets_parses_via_unified_parser(self):
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(
+            ["route", "test.kicad_pcb", "--analog-nets", "AUDIO_L,AUDIO_R", "--auto-analog"]
+        )
+        assert args.analog_nets == "AUDIO_L,AUDIO_R"
+        assert args.auto_analog is True
+
+    def test_defaults_in_unified_parser(self):
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["route", "test.kicad_pcb"])
+        assert args.analog_nets is None
+        assert args.auto_analog is False
+
+    def test_analog_nets_accepted_by_route_cmd_parser(self, tmp_path, capsys):
+        """``route_cmd.main`` accepts the flags (no argparse 'unrecognized')."""
+        from kicad_tools.cli.route_cmd import main as route_main
+
+        missing = tmp_path / "does_not_exist.kicad_pcb"
+        # The flags must parse cleanly; the run then fails on the missing PCB
+        # (exit 1) rather than argparse rejecting the flags (exit 2 / SystemExit).
+        result = route_main(
+            [
+                str(missing),
+                "--dry-run",
+                "--quiet",
+                "--analog-nets",
+                "AUDIO_L,AUDIO_R",
+                "--auto-analog",
+                "--output",
+                str(tmp_path / "out.kicad_pcb"),
+            ]
+        )
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "unrecognized arguments" not in captured.err
+
+
+# =============================================================================
+# AC #3: Map injection (explicit --analog-nets)
+# =============================================================================
+
+
+class TestExplicitAnalogNetInjection:
+    """``--analog-nets`` injects the boosted class onto the router's map."""
+
+    def test_boosted_class_lands_on_map(self):
+        from kicad_tools.cli.route_cmd import _apply_analog_net_class
+
+        router = _make_router()
+        _populate_synthetic_board(router)
+
+        _apply_analog_net_class(router, _analog_args(analog_nets="AUDIO_L,AUDIO_R"), quiet=True)
+
+        # AC #3: priority strictly below digital, cost_multiplier <= 0.9.
+        for name in ("AUDIO_L", "AUDIO_R"):
+            nc = router.net_class_map[name]
+            assert nc.priority < NET_CLASS_DIGITAL.priority
+            assert nc.cost_multiplier <= 0.9
+            assert nc.noise_sensitive is True
+
+        # Digital nets are untouched.
+        assert router.net_class_map.get("D0") != NET_CLASS_ANALOG
+
+    def test_whitespace_and_empty_entries_stripped(self):
+        from kicad_tools.cli.route_cmd import _apply_analog_net_class
+
+        router = _make_router()
+        _populate_synthetic_board(router)
+
+        _apply_analog_net_class(
+            router, _analog_args(analog_nets=" AUDIO_L , , AUDIO_R "), quiet=True
+        )
+        assert router.net_class_map["AUDIO_L"] == NET_CLASS_ANALOG
+        assert router.net_class_map["AUDIO_R"] == NET_CLASS_ANALOG
+
+
+# =============================================================================
+# AC #4: Routing-order injection
+# =============================================================================
+
+
+class TestAnalogRoutesAheadOfDigital:
+    """After injection, the analog net sorts ahead of digital nets."""
+
+    def test_analog_net_priority_below_digital(self):
+        from kicad_tools.cli.route_cmd import _apply_analog_net_class
+
+        router = _make_router()
+        nets = _populate_synthetic_board(router)
+
+        before_audio = router._get_net_priority(nets["AUDIO_L"])[0]
+        before_d0 = router._get_net_priority(nets["D0"])[0]
+        # Without the flag, both classify by name pattern; AUDIO is already
+        # ahead of D0 here, so we assert on the post-injection STRICT gap.
+
+        _apply_analog_net_class(router, _analog_args(analog_nets="AUDIO_L"), quiet=True)
+
+        after_audio = router._get_net_priority(nets["AUDIO_L"])[0]
+        after_d0 = router._get_net_priority(nets["D0"])[0]
+
+        # AC #4: analog sorts strictly ahead of digital.
+        assert after_audio < after_d0
+        # The boost moved (or kept) audio at the analog priority (2).
+        assert after_audio == NET_CLASS_ANALOG.priority
+        # Digital net ordering is unchanged by the flag.
+        assert after_d0 == before_d0
+        # And the audio net is now at least as early as before.
+        assert after_audio <= before_audio
+
+
+# =============================================================================
+# AC #2: Auto-detect via detect_analog_nets
+# =============================================================================
+
+
+class TestAutoAnalog:
+    """``--auto-analog`` selects analog nets via the Phase 2 detector."""
+
+    def test_auto_analog_selects_audio_without_explicit_list(self):
+        from kicad_tools.cli.route_cmd import _apply_analog_net_class
+
+        router = _make_router()
+        _populate_synthetic_board(router)
+
+        _apply_analog_net_class(router, _analog_args(auto_analog=True), quiet=True)
+
+        # detect_analog_nets classifies AUDIO_L / AUDIO_R as audio.
+        assert router.net_class_map["AUDIO_L"] == NET_CLASS_ANALOG
+        assert router.net_class_map["AUDIO_R"] == NET_CLASS_ANALOG
+        # Pure-digital nets are not selected.
+        assert router.net_class_map.get("D0") != NET_CLASS_ANALOG
+        assert router.net_class_map.get("D1") != NET_CLASS_ANALOG
+
+    def test_union_of_explicit_and_auto(self):
+        """Explicit + auto are unioned; an extra analog signal is added."""
+        from kicad_tools.cli.route_cmd import _apply_analog_net_class
+
+        router = _make_router()
+        nets = _populate_synthetic_board(router)
+        # Add an analog signal net that detect_analog_nets recognises (VREF)
+        # plus a digital net that is NOT auto-detected (CUSTOM_BUS) so the
+        # explicit list is the only way it gets boosted.
+        _add_2pin_net(router, "U10", 130.0, 105.0, 10, "VREF")
+        _add_2pin_net(router, "U11", 130.0, 110.0, 11, "CUSTOM_BUS")
+
+        _apply_analog_net_class(
+            router,
+            _analog_args(analog_nets="CUSTOM_BUS", auto_analog=True),
+            quiet=True,
+        )
+
+        # Auto-detected analog: AUDIO_L/R + VREF.
+        assert router.net_class_map["AUDIO_L"] == NET_CLASS_ANALOG
+        assert router.net_class_map["VREF"] == NET_CLASS_ANALOG
+        # Explicit-only net (not auto-detected) also boosted via the union.
+        assert router.net_class_map["CUSTOM_BUS"] == NET_CLASS_ANALOG
+        # Untouched digital.
+        assert nets["D0"]  # sanity
+        assert router.net_class_map.get("D0") != NET_CLASS_ANALOG
+
+    def test_auto_analog_zero_analog_board_is_noop(self):
+        from kicad_tools.cli.route_cmd import _apply_analog_net_class
+
+        router = _make_router()
+        # Purely digital board.
+        _add_2pin_net(router, "U1", 105.0, 105.0, 1, "D0")
+        _add_2pin_net(router, "U2", 105.0, 110.0, 2, "D1")
+        _add_2pin_net(router, "U3", 105.0, 115.0, 3, "SPI_CLK")
+        baseline = dict(router.net_class_map)
+
+        _apply_analog_net_class(router, _analog_args(auto_analog=True), quiet=True)
+
+        assert router.net_class_map == baseline
+
+
+# =============================================================================
+# AC #5: Pour-net guard
+# =============================================================================
+
+
+class TestPourNetGuard:
+    """A pour/ground net selected as analog keeps its pour semantics."""
+
+    def test_gnda_pour_net_not_forced_into_pathfinder(self):
+        from kicad_tools.cli.route_cmd import _apply_analog_net_class
+        from kicad_tools.router.rules import NetClassRouting
+
+        router = _make_router()
+        _add_2pin_net(router, "U1", 105.0, 105.0, 1, "GNDA")
+        _add_2pin_net(router, "U2", 105.0, 110.0, 2, "AUDIO_L")
+
+        # Pin GNDA to an explicit pour class so the guard has something to see.
+        pour_class = NetClassRouting(
+            name="AnalogGround",
+            priority=1,
+            is_pour_net=True,
+            route_via="pour",
+        )
+        router.net_class_map["GNDA"] = pour_class
+
+        _apply_analog_net_class(router, _analog_args(analog_nets="GNDA,AUDIO_L"), quiet=True)
+
+        # GNDA pour semantics are unchanged: still the pour class, still poured.
+        assert router.net_class_map["GNDA"] is pour_class
+        assert router.net_class_map["GNDA"].is_pour_net is True
+        assert router.net_class_map["GNDA"].route_via == "pour"
+        # AUDIO_L (an ordinary pathfinder net) was still boosted.
+        assert router.net_class_map["AUDIO_L"] == NET_CLASS_ANALOG
+
+    def test_auto_analog_does_not_force_default_gnda_pour(self):
+        """GNDA defaults to the pour POWER class; --auto-analog must not flip it."""
+        from kicad_tools.cli.route_cmd import _apply_analog_net_class
+
+        router = _make_router()
+        _add_2pin_net(router, "U1", 105.0, 105.0, 1, "GNDA")
+        _add_2pin_net(router, "U2", 105.0, 110.0, 2, "AUDIO_L")
+
+        # GNDA maps to the pour POWER class via DEFAULT_NET_CLASS_MAP.
+        assert router.net_class_map["GNDA"].is_pour_net is True
+
+        _apply_analog_net_class(router, _analog_args(auto_analog=True), quiet=True)
+
+        assert router.net_class_map["GNDA"].is_pour_net is True
+        assert router.net_class_map["GNDA"] != NET_CLASS_ANALOG
+
+
+# =============================================================================
+# AC #6: Forwarding through run_route_command
+# =============================================================================
+
+
+def _forwarding_args(**overrides) -> SimpleNamespace:
+    """Minimal args namespace for run_route_command forwarding tests."""
+    base: dict[str, object] = {
+        "pcb": "test.kicad_pcb",
+        "output": None,
+        "strategy": "negotiated",
+        "skip_nets": None,
+        "grid": "auto",
+        "trace_width": 0.2,
+        "clearance": 0.15,
+        "via_drill": 0.3,
+        "via_diameter": 0.6,
+        "mc_trials": 10,
+        "iterations": 15,
+        "verbose": False,
+        "dry_run": True,
+        "quiet": True,
+        "power_nets": None,
+        "layers": "auto",
+        "force": False,
+        "no_optimize": False,
+        "auto_layers": False,
+        "max_layers": 6,
+        "min_completion": 0.95,
+        "adaptive_rules": False,
+        "min_trace": None,
+        "min_clearance_floor": None,
+        "manufacturer": "jlcpcb",
+        "high_performance": False,
+        "skip_drc": False,
+        "auto_fix": False,
+        "auto_fix_passes": None,
+        "export_failed_nets": None,
+        "differential_pairs": False,
+        "diffpair_spacing": None,
+        "diffpair_max_delta": None,
+        "length_match_diffpairs": False,
+        "length_match_groups": False,
+        "strict": False,
+        "net_class_map": None,
+        "analog_nets": None,
+        "auto_analog": False,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class TestForwarding:
+    """``run_route_command`` forwards the flags when set, omits otherwise."""
+
+    def test_analog_nets_forwarded_when_set(self):
+        from kicad_tools.cli.commands.routing import run_route_command
+
+        args = _forwarding_args(analog_nets="AUDIO_L,AUDIO_R")
+        with patch("kicad_tools.cli.route_cmd.main") as mock_main:
+            mock_main.return_value = 0
+            run_route_command(args)
+            call_args = mock_main.call_args[0][0]
+            assert "--analog-nets" in call_args
+            idx = call_args.index("--analog-nets")
+            assert call_args[idx + 1] == "AUDIO_L,AUDIO_R"
+            assert "--auto-analog" not in call_args
+
+    def test_auto_analog_forwarded_when_set(self):
+        from kicad_tools.cli.commands.routing import run_route_command
+
+        args = _forwarding_args(auto_analog=True)
+        with patch("kicad_tools.cli.route_cmd.main") as mock_main:
+            mock_main.return_value = 0
+            run_route_command(args)
+            call_args = mock_main.call_args[0][0]
+            assert "--auto-analog" in call_args
+            assert "--analog-nets" not in call_args
+
+    def test_flags_not_forwarded_when_absent(self):
+        from kicad_tools.cli.commands.routing import run_route_command
+
+        args = _forwarding_args()
+        with patch("kicad_tools.cli.route_cmd.main") as mock_main:
+            mock_main.return_value = 0
+            run_route_command(args)
+            call_args = mock_main.call_args[0][0]
+            assert "--analog-nets" not in call_args
+            assert "--auto-analog" not in call_args
+
+
+# =============================================================================
+# AC #7: No-op when absent + edge cases
+# =============================================================================
+
+
+class TestNoOpAndEdgeCases:
+    """The feature is a strict no-op when absent and degrades gracefully."""
+
+    def test_no_flags_leaves_map_and_ordering_unchanged(self):
+        from kicad_tools.cli.route_cmd import _apply_analog_net_class
+
+        router = _make_router()
+        nets = _populate_synthetic_board(router)
+        baseline_map = dict(router.net_class_map)
+        baseline_order = {name: router._get_net_priority(nid)[0] for name, nid in nets.items()}
+
+        _apply_analog_net_class(router, _analog_args(), quiet=True)
+
+        assert router.net_class_map == baseline_map
+        after_order = {name: router._get_net_priority(nid)[0] for name, nid in nets.items()}
+        assert after_order == baseline_order
+
+    def test_empty_analog_nets_string_is_noop(self):
+        from kicad_tools.cli.route_cmd import _apply_analog_net_class
+
+        router = _make_router()
+        _populate_synthetic_board(router)
+        baseline = dict(router.net_class_map)
+
+        _apply_analog_net_class(router, _analog_args(analog_nets=""), quiet=True)
+
+        assert router.net_class_map == baseline
+
+    def test_unknown_net_name_ignored(self):
+        from kicad_tools.cli.route_cmd import _apply_analog_net_class
+
+        router = _make_router()
+        _populate_synthetic_board(router)
+
+        # NOT_A_NET is not on the board; AUDIO_L is.
+        _apply_analog_net_class(router, _analog_args(analog_nets="NOT_A_NET,AUDIO_L"), quiet=True)
+
+        assert "NOT_A_NET" not in router.net_class_map
+        assert router.net_class_map["AUDIO_L"] == NET_CLASS_ANALOG
+
+    def test_duplicate_explicit_and_auto_deduped(self):
+        """AUDIO_L appearing in both the explicit list and auto-detect is fine."""
+        from kicad_tools.cli.route_cmd import _apply_analog_net_class
+
+        router = _make_router()
+        _populate_synthetic_board(router)
+
+        _apply_analog_net_class(
+            router,
+            _analog_args(analog_nets="AUDIO_L", auto_analog=True),
+            quiet=True,
+        )
+
+        assert router.net_class_map["AUDIO_L"] == NET_CLASS_ANALOG
+
+
+# =============================================================================
+# NET_CLASS_ANALOG constant contract
+# =============================================================================
+
+
+class TestAnalogClassConstant:
+    """The boosted class has the documented priority/cost contract."""
+
+    def test_priority_and_cost_boost(self):
+        assert NET_CLASS_ANALOG.priority == 2
+        assert NET_CLASS_ANALOG.priority < NET_CLASS_DIGITAL.priority
+        assert NET_CLASS_ANALOG.cost_multiplier == 0.85
+        assert NET_CLASS_ANALOG.cost_multiplier <= 0.9
+        assert NET_CLASS_ANALOG.noise_sensitive is True
+
+    def test_not_a_pour_net(self):
+        """The analog class is a pathfinder net, never a pour net."""
+        assert NET_CLASS_ANALOG.is_pour_net is False
+        assert NET_CLASS_ANALOG.route_via == "pathfinder"


### PR DESCRIPTION
## Summary

Phase 3 of analog-aware routing (#3171). Adds two opt-in `kct route` flags that give designer-named or auto-detected analog nets preferential routing treatment, by injecting a priority- and cost-boosted net class onto the autorouter's `net_class_map`. **No A*/pathfinder changes** — the existing per-net `priority` (route order, `_get_net_priority`) and per-net `cost_multiplier` (cost bias) consumers do the work, mirroring the merged `--net-class-map` injection path (#2996).

- `--analog-nets "AUDIO_L,AUDIO_R"` — explicit, comma-separated analog net names.
- `--auto-analog` — auto-detect via Phase 2's `detect_analog_nets` (#3170); unioned with the explicit list when both are set.

New `NET_CLASS_ANALOG` (`priority=2`, `cost_multiplier=0.85`, `noise_sensitive=True`) boosts `NET_CLASS_AUDIO` so listed nets route before digital signals (priority 4) and along a shorter-path bias. `trace_width`/`clearance` stay at digital defaults.

**Pour/ground guard (AC #5):** a selected net whose existing class is a pour net (`is_pour_net=True` or `route_via="pour"`, e.g. `GNDA`) is left untouched and never forced into the pathfinder.

## Changes

- `src/kicad_tools/router/rules.py` — new `NET_CLASS_ANALOG` constant near `NET_CLASS_AUDIO`.
- `src/kicad_tools/cli/route_cmd.py` — flags on the standalone parser; new `_apply_analog_net_class` helper (+ `_resolve_analog_net_names` and a tiny `_AnalogDetectAdapter` so Phase 2's `detect_analog_nets` is reused verbatim against the router's net names); wired at all four post-load callsites alongside `_apply_net_class_map_sidecar`.
- `src/kicad_tools/cli/parser.py` — flags on the unified `_add_route_parser`.
- `src/kicad_tools/cli/commands/routing.py` — forwarding in `run_route_command`.
- `tests/test_cli_route_analog_nets.py` — new module (mirrors `test_cli_route_net_class_map.py`).

Guard-trace / shield-copper generation is **not** implemented and is deferred to a Phase 4 follow-up (noted in `--help`, AC #8).

## Acceptance criteria

- [x] AC #1/#2: both flags on both parsers, in `--help`, defaults `analog_nets=None` / `auto_analog=False`.
- [x] AC #2: `--auto-analog` calls `detect_analog_nets`; unions with `--analog-nets`.
- [x] AC #3: selected nets get `priority` < digital (4) and `cost_multiplier <= 0.9`.
- [x] AC #4: `_get_net_priority(analog)[0] < _get_net_priority(digital)[0]` after injection.
- [x] AC #5: pour/ground nets (`GNDA`) retain pour semantics (not forced into pathfinder).
- [x] AC #6: flags forwarded from `run_route_command` to inner `route_cmd.main` argv.
- [x] AC #7: strict no-op when absent (map + ordering unchanged).
- [x] AC #8: guard-trace generation deferred, noted in `--help`.

## Test plan

- [x] New `tests/test_cli_route_analog_nets.py` (23 tests): parser declaration/defaults, map injection, ordering, auto-detect + union, pour-net guard (explicit + default-GNDA), forwarding, no-op/edge cases (empty list, unknown net, dedup, zero-analog board), class-constant contract.
- [x] Regression: `tests/test_cli_route_net_class_map.py`, `tests/test_cli_parser_drift.py`, `tests/test_net_class.py`, `tests/test_route_cmd_params.py`, `tests/test_off_grid_priority.py` all pass.
- [x] Manual: `kct route <board> --analog-nets "VOUT,GND" --dry-run -v` runs end-to-end; pour nets correctly left as-is.
- [x] `ruff format --check` / `ruff check` clean on all changed files. (Repo-wide `pnpm check:ci` has pre-existing baseline lint debt and the pre-existing `test_layer_escalation::TestEarlyTermination` failures — both confirmed present on `main` and unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)