### PR TITLE
feat(sch): project fp-lib-table awareness for suggest-footprint + preflight

### DIFF
--- a/src/kicad_tools/cli/commands/schematic.py
+++ b/src/kicad_tools/cli/commands/schematic.py
@@ -191,6 +191,7 @@ def run_sch_command(args) -> int:
             package=getattr(args, "package", None),
             output_format=getattr(args, "format", "text"),
             limit=getattr(args, "limit", 20),
+            no_project_lib=getattr(args, "no_project_lib", False),
         )
 
     elif args.sch_command == "set-value":

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -692,6 +692,14 @@ def _add_sch_parser(subparsers) -> None:
     sch_suggest_fp.add_argument(
         "--limit", type=int, default=20, help="Maximum number of suggestions (default: 20)"
     )
+    sch_suggest_fp.add_argument(
+        "--no-project-lib",
+        action="store_true",
+        help=(
+            "Ignore the project's fp-lib-table and only use global "
+            "footprint libraries (CI / reproducibility opt-out)."
+        ),
+    )
 
     # sch set-value
     sch_set_val = sch_subparsers.add_parser("set-value", help="Set value property for symbols")

--- a/src/kicad_tools/cli/sch_preflight.py
+++ b/src/kicad_tools/cli/sch_preflight.py
@@ -26,6 +26,10 @@ import json
 import sys
 from pathlib import Path
 
+from kicad_tools.footprints.library_path import (
+    detect_kicad_library_path,
+    list_project_libraries,
+)
 from kicad_tools.schema import Schematic
 from kicad_tools.schema.hierarchy import build_hierarchy
 
@@ -48,18 +52,37 @@ _GENERIC_VALUES = frozenset({"R", "C", "L", "D", "Q", "U", "J", "FB", "LED"})
 
 
 def check_footprint_library_resolution(schematic_path: str) -> list[ValidationIssue]:
-    """Verify that every ``Library:Footprint`` reference resolves.
+    """Verify that every ``Library:Footprint`` reference resolves on disk.
 
-    This walks the schematic hierarchy and, for each symbol that has a
-    Footprint property of the form ``Library:Footprint``, verifies that both
-    parts are non-empty.  A missing library prefix (e.g. bare footprint name)
-    or obviously placeholder value is flagged.
+    This walks the schematic hierarchy and, for each symbol that carries a
+    Footprint property of the form ``Library:Footprint``:
 
-    Full filesystem resolution of ``.kicad_mod`` files is intentionally
-    deferred -- it requires ``fp-lib-table`` parsing which varies by
-    installation.  This check catches the most common authoring mistakes.
+    1. Sanity-checks the textual form (non-empty library and footprint parts,
+       presence of a ``:`` separator).
+    2. Resolves the library nickname through the merged
+       ``project fp-lib-table`` + global libraries, and confirms the
+       ``<footprint>.kicad_mod`` file exists in the resolved directory.
+
+    The on-disk check is only performed when the local environment has at
+    least one library source (project table or global libraries).  When
+    neither is available (e.g. CI runners), the check degrades to the
+    text-only sanity checks above so it does not produce false positives.
     """
     issues: list[ValidationIssue] = []
+
+    # Pre-compute the merged library map ONCE per call -- candidate
+    # discovery is the same for every symbol.  An empty list means we
+    # only run the cheap text-form checks.
+    sch_path = Path(schematic_path)
+    global_paths = detect_kicad_library_path()
+    lib_map: dict[str, Path] = {}
+    try:
+        for nick, lib_dir, _origin in list_project_libraries(sch_path, global_paths):
+            lib_map.setdefault(nick, lib_dir)
+    except Exception:
+        # Discovery failures are non-fatal -- fall back to text-only checks.
+        lib_map = {}
+
     try:
         hierarchy = build_hierarchy(schematic_path)
         for node in hierarchy.all_nodes():
@@ -87,20 +110,56 @@ def check_footprint_library_resolution(schematic_path: str) -> list[ValidationIs
                                 location=node.get_path_string(),
                             )
                         )
-                    else:
-                        lib, name = fp.split(":", 1)
-                        if not lib.strip() or not name.strip():
-                            issues.append(
-                                ValidationIssue(
-                                    severity="error",
-                                    category="footprint_resolution",
-                                    message=(
-                                        f"{sym.reference} footprint '{fp}' "
-                                        "has empty library or footprint name"
-                                    ),
-                                    location=node.get_path_string(),
-                                )
+                        continue
+
+                    lib, name = fp.split(":", 1)
+                    if not lib.strip() or not name.strip():
+                        issues.append(
+                            ValidationIssue(
+                                severity="error",
+                                category="footprint_resolution",
+                                message=(
+                                    f"{sym.reference} footprint '{fp}' "
+                                    "has empty library or footprint name"
+                                ),
+                                location=node.get_path_string(),
                             )
+                        )
+                        continue
+
+                    # On-disk resolution -- only when we have at least one
+                    # library source.  Absence of any source means the
+                    # environment cannot answer this question; do not flag.
+                    if not lib_map:
+                        continue
+                    lib_dir = lib_map.get(lib)
+                    if lib_dir is None:
+                        issues.append(
+                            ValidationIssue(
+                                severity="error",
+                                category="footprint_resolution",
+                                message=(
+                                    f"{sym.reference} footprint '{fp}': "
+                                    f"library nickname '{lib}' not found in "
+                                    "project or global fp-lib-table"
+                                ),
+                                location=node.get_path_string(),
+                            )
+                        )
+                        continue
+                    mod_file = lib_dir / f"{name}.kicad_mod"
+                    if not mod_file.is_file():
+                        issues.append(
+                            ValidationIssue(
+                                severity="error",
+                                category="footprint_resolution",
+                                message=(
+                                    f"{sym.reference} footprint '{fp}': "
+                                    f"file not found at {mod_file}"
+                                ),
+                                location=node.get_path_string(),
+                            )
+                        )
             except Exception:
                 pass
     except Exception as e:

--- a/src/kicad_tools/cli/sch_suggest_footprint.py
+++ b/src/kicad_tools/cli/sch_suggest_footprint.py
@@ -43,11 +43,12 @@ from typing import Any
 
 from kicad_tools.cli.lib_footprints import _count_pads
 from kicad_tools.core.sexp_file import load_footprint
+from kicad_tools.footprints.fp_lib_table import find_project_fp_lib_table
 from kicad_tools.footprints.library_path import (
     LibraryPaths,
     detect_kicad_library_path,
     guess_standard_library,
-    list_available_libraries,
+    list_project_libraries,
 )
 from kicad_tools.schema import Schematic
 
@@ -125,34 +126,44 @@ def _get_fp_filters(sch: Schematic, sym: Any) -> list[str]:
     return raw.split()
 
 
-def _candidate_library_paths(paths: LibraryPaths, keyword: str | None) -> list[tuple[str, Path]]:
-    """Return (library_name, library_dir) pairs to scan for candidates.
+def _candidate_library_paths(
+    paths: LibraryPaths,
+    keyword: str | None,
+    schematic_path: Path | None = None,
+    *,
+    use_project_table: bool = True,
+) -> list[tuple[str, Path, str]]:
+    """Return ``(library_name, library_dir, origin)`` triples to scan.
+
+    Sources are the project ``fp-lib-table`` (if *schematic_path* is given
+    and the table exists) plus the global library directory scan.  Project
+    entries always appear first and override global libraries on nickname
+    collision -- matching KiCad's own resolution order.
 
     When *keyword* is given, libraries whose name OR whose standard-library
-    mapping matches the keyword are preferred. If nothing matches (or no
-    keyword), all available libraries are returned.
+    mapping matches the keyword are preferred.  If nothing matches (or no
+    keyword), all merged libraries are returned in their merged order.
     """
-    all_libs = list_available_libraries(paths)
-    result: list[tuple[str, Path]] = []
+    merged = list_project_libraries(
+        schematic_path,
+        paths,
+        use_project_table=use_project_table,
+    )
+    result: list[tuple[str, Path, str]] = []
 
     if keyword:
         kw_lower = keyword.lower()
         # A keyword may itself be a footprint-name prefix (e.g. "SOT-23",
         # "R_0603"); map it to a standard library when possible.
         mapped_lib = guess_standard_library(keyword)
-        for lib in all_libs:
-            lib_lower = lib.lower()
-            if kw_lower in lib_lower or (mapped_lib and lib == mapped_lib):
-                lib_path = paths.get_library_path(lib)
-                if lib_path is not None:
-                    result.append((lib, lib_path))
+        for lib_name, lib_dir, origin in merged:
+            lib_lower = lib_name.lower()
+            if kw_lower in lib_lower or (mapped_lib and lib_name == mapped_lib):
+                result.append((lib_name, lib_dir, origin))
 
     if not result:
         # No keyword, or keyword did not match any library name: scan all.
-        for lib in all_libs:
-            lib_path = paths.get_library_path(lib)
-            if lib_path is not None:
-                result.append((lib, lib_path))
+        result = list(merged)
 
     return result
 
@@ -174,7 +185,13 @@ def _rank_key(
     keyword: str | None,
     fp_filters: list[str] | None = None,
 ) -> tuple:
-    """Sort key: filter matches, then keyword matches, non-hand-solder, A-Z."""
+    """Sort key: filter matches, project-origin, keyword, non-hand-solder, A-Z.
+
+    Project libraries rank above globals (after the strongest signals --
+    fp_filters and keyword -- have been applied) so that a designer's
+    intentional project nicknames are surfaced before sheer KiCad-stock
+    matches.  This mirrors KiCad's own table-precedence behavior.
+    """
     name = candidate["footprint"]
     name_lower = name.lower()
     # ki_fp_filters matches rank above everything else when filters are active.
@@ -184,8 +201,9 @@ def _rank_key(
     kw_match = 0
     if keyword and keyword.lower() in name_lower:
         kw_match = -1  # sorts before non-matches
+    origin_rank = 0 if candidate.get("origin") == "project" else 1
     hand = 1 if "handsolder" in name_lower.replace("_", "") else 0
-    return (filter_match, kw_match, hand, candidate["library"], name)
+    return (filter_match, kw_match, origin_rank, hand, candidate["library"], name)
 
 
 def find_footprint_candidates(
@@ -194,6 +212,9 @@ def find_footprint_candidates(
     keyword: str | None,
     limit: int,
     fp_filters: list[str] | None = None,
+    schematic_path: Path | None = None,
+    *,
+    use_project_table: bool = True,
 ) -> list[dict[str, Any]]:
     """Find footprints whose pad count matches *target_pins*.
 
@@ -208,14 +229,22 @@ def find_footprint_candidates(
             The patterns are intentionally broad (e.g. ``SOT?23*`` matches
             SOT-23-5, SOT-23-6, and SOT-23), so the pad-count filter is what
             disambiguates the correct variant.
+        schematic_path: Optional path to the source ``.kicad_sch``.  When
+            provided, candidate libraries are widened to include the
+            project's ``fp-lib-table`` entries (in addition to globals).
+        use_project_table: When ``False``, the project table is not
+            consulted (CI / reproducibility opt-out).
 
     Returns:
-        Ranked list of dicts with ``library``, ``footprint``, ``pads`` keys.
+        Ranked list of dicts with ``library``, ``footprint``, ``pads``,
+        ``origin`` keys.  ``origin`` is ``"project"`` or ``"global"``.
     """
     candidates: list[dict[str, Any]] = []
     scanned = 0
 
-    for lib_name, lib_dir in _candidate_library_paths(paths, keyword):
+    for lib_name, lib_dir, origin in _candidate_library_paths(
+        paths, keyword, schematic_path, use_project_table=use_project_table
+    ):
         for mod_file in sorted(lib_dir.glob("*.kicad_mod")):
             if scanned >= _MAX_SCANNED_FOOTPRINTS:
                 break
@@ -241,6 +270,7 @@ def find_footprint_candidates(
                     "library": lib_name,
                     "footprint": mod_file.stem,
                     "pads": pad_count,
+                    "origin": origin,
                 }
             )
         if scanned >= _MAX_SCANNED_FOOTPRINTS:
@@ -257,11 +287,17 @@ def run_suggest_footprint(
     output_format: str = "text",
     limit: int = 20,
     config_override: str | Path | None = None,
+    no_project_lib: bool = False,
 ) -> int:
     """Suggest library footprints for the symbol *ref*.
 
     Returns 0 when at least one candidate is found, 1 otherwise (including the
     no-library and symbol-not-found cases).
+
+    When the schematic's project carries an ``fp-lib-table``, its KiCad-type
+    entries are merged into the candidate library set ahead of the global
+    libraries; pass ``no_project_lib=True`` to disable that and restore
+    global-only behavior (CI / reproducibility opt-out).
     """
     if not schematic_path.exists():
         print(f"Error: File not found: {schematic_path}", file=sys.stderr)
@@ -288,12 +324,17 @@ def run_suggest_footprint(
     # pin-count filter to disambiguate). Absent/empty filters -> Phase 1.
     fp_filters: list[str] = [] if package else _get_fp_filters(sch, sym)
 
-    # Detect KiCad library; degrade gracefully if absent.
+    # Detect KiCad library.  Even if the global library is missing, we
+    # can still serve candidates from the project's fp-lib-table.
     paths = detect_kicad_library_path(config_override)
-    if not paths.found:
+    project_table = (
+        find_project_fp_lib_table(schematic_path) if not no_project_lib else None
+    )
+    if not paths.found and project_table is None:
         print(
             "Error: No KiCad footprint library found. "
-            "suggest-footprint requires the standard KiCad footprint libraries.\n"
+            "suggest-footprint requires the standard KiCad footprint libraries "
+            "or a project fp-lib-table.\n"
             "Set the KICAD_FOOTPRINT_DIR environment variable to the directory "
             "containing your '*.pretty' footprint libraries, e.g.\n"
             "  export KICAD_FOOTPRINT_DIR="
@@ -303,7 +344,13 @@ def run_suggest_footprint(
         return 1
 
     candidates = find_footprint_candidates(
-        paths, target_pins, keyword, limit, fp_filters=fp_filters
+        paths,
+        target_pins,
+        keyword,
+        limit,
+        fp_filters=fp_filters,
+        schematic_path=schematic_path,
+        use_project_table=not no_project_lib,
     )
 
     if output_format == "json":
@@ -317,6 +364,9 @@ def run_suggest_footprint(
                     "package_keyword": keyword,
                     "fp_filters": fp_filters,
                     "library_source": paths.source,
+                    "project_lib_table": (
+                        str(project_table) if project_table is not None else None
+                    ),
                     "candidates": candidates,
                 },
                 indent=2,
@@ -327,11 +377,18 @@ def run_suggest_footprint(
         kw_desc = f", package hint '{keyword}'" if keyword else ""
         filt_desc = f", ki_fp_filters {fp_filters}" if fp_filters else ""
         print(f"Suggestions for {ref} ({sym.value or sym.lib_id}, {pin_desc}{kw_desc}{filt_desc}):")
+        if project_table is not None:
+            print(f"  (using project fp-lib-table: {project_table})")
         if not candidates:
             print("  (no matching footprints found)")
         else:
             for c in candidates:
-                print(f"  {c['library']}:{c['footprint']} ({c['pads']} pads)")
+                origin_tag = (
+                    " [project]" if c.get("origin") == "project" else ""
+                )
+                print(
+                    f"  {c['library']}:{c['footprint']} ({c['pads']} pads){origin_tag}"
+                )
 
     if not candidates:
         hint = ""
@@ -363,6 +420,14 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--limit", type=int, default=20, help="Maximum number of suggestions (default: 20)"
     )
+    parser.add_argument(
+        "--no-project-lib",
+        action="store_true",
+        help=(
+            "Ignore the project's fp-lib-table and only use global "
+            "footprint libraries (CI / reproducibility opt-out)."
+        ),
+    )
 
     args = parser.parse_args(argv)
 
@@ -372,6 +437,7 @@ def main(argv: list[str] | None = None) -> int:
         package=args.package,
         output_format=args.format,
         limit=args.limit,
+        no_project_lib=args.no_project_lib,
     )
 
 

--- a/src/kicad_tools/footprints/fp_lib_table.py
+++ b/src/kicad_tools/footprints/fp_lib_table.py
@@ -1,0 +1,207 @@
+"""Parse KiCad ``fp-lib-table`` files and resolve library nicknames.
+
+KiCad maintains two ``fp-lib-table`` files:
+
+* The **global** table (per KiCad install), typically at
+  ``~/Library/Preferences/kicad/<ver>/fp-lib-table`` on macOS,
+  ``~/.config/kicad/<ver>/fp-lib-table`` on Linux, etc.
+* The **project** table, a sibling of the ``.kicad_pro`` file in the
+  project root.
+
+Both tables map library *nicknames* (e.g. ``MCU_ST_STM32F0``) to URIs that
+contain ``${KIPRJMOD}`` (project root), ``${KICAD<N>_FOOTPRINT_DIR}``
+(install footprint root), and other environment variables.
+
+This module only handles the project table (and serves as a helper for
+shipping `(lib_name, .pretty dir)` pairs for the project-aware
+``suggest-footprint`` and ``preflight`` commands).  The existing
+directory-scan over the global ``footprints/`` root is a reasonable proxy
+for the global table because KiCad ships the global table pre-populated
+with every shipped ``.pretty`` library.
+
+Only ``type="KiCad"`` entries (raw ``.pretty`` directories on disk) are
+honored.  Legacy- and Github-typed entries are intentionally skipped with a
+warning -- KiCad 6+ deprecates Legacy, and Github type is rare and remote.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+from kicad_tools.sexp import parse_string
+
+# ${VAR} expansion -- matches both ${KIPRJMOD} and ${KICAD8_FOOTPRINT_DIR}
+# style references in fp-lib-table URIs.
+_VAR_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+@dataclass
+class FpLibEntry:
+    """One ``(lib ...)`` row from an ``fp-lib-table`` file.
+
+    Attributes:
+        name: The library nickname (e.g. ``"MyLib"``).
+        type: The library type (``"KiCad"``, ``"Legacy"``, ``"Github"``, ...).
+        uri: The raw URI string before environment-variable expansion.
+        resolved_path: The absolute directory on disk after expansion, or
+            ``None`` if expansion failed (unknown variable, type not
+            ``"KiCad"``, or the directory does not exist).
+    """
+
+    name: str
+    type: str
+    uri: str
+    resolved_path: Path | None
+
+
+def find_project_fp_lib_table(start: Path) -> Path | None:
+    """Locate the project ``fp-lib-table`` for a ``.kicad_sch`` or ``.kicad_pro``.
+
+    Walks upward from *start* (or its parent if *start* is a file) until it
+    finds a sibling ``fp-lib-table``.  Walking stops at the first directory
+    that contains a ``.kicad_pro`` file (the project root) regardless of
+    whether ``fp-lib-table`` is present -- ``${KIPRJMOD}`` always resolves
+    against the project root, not against an arbitrary ancestor.
+
+    Returns the path to the ``fp-lib-table`` file, or ``None`` if there is
+    no project table (a perfectly valid configuration that means "use
+    only the global table").
+    """
+    if start.is_file():
+        current = start.parent
+    else:
+        current = start
+
+    current = current.resolve()
+    # Walk upward until filesystem root.
+    while True:
+        # If we hit a project root (.kicad_pro sibling), check for the
+        # table there and stop.  KIPRJMOD == project root, never an ancestor.
+        if any(current.glob("*.kicad_pro")):
+            table = current / "fp-lib-table"
+            return table if table.is_file() else None
+
+        # No .kicad_pro yet -- still look for a sibling fp-lib-table
+        # (some project layouts ship the table without a .kicad_pro nearby).
+        table = current / "fp-lib-table"
+        if table.is_file():
+            return table
+
+        parent = current.parent
+        if parent == current:
+            return None
+        current = parent
+
+
+def expand_kicad_vars(
+    uri: str,
+    kiprjmod: Path | None,
+    env: Mapping[str, str] | None = None,
+) -> Path | None:
+    """Expand ``${VAR}`` references in a fp-lib-table URI to an absolute Path.
+
+    Substitutes:
+
+    * ``${KIPRJMOD}`` with *kiprjmod* (the project root).
+    * Any other ``${VAR}`` with the corresponding entry in *env* (which
+      defaults to ``os.environ``).
+
+    Returns ``None`` if any referenced variable is missing or *kiprjmod*
+    is required but not provided.  Returns a ``Path`` (not validated to
+    exist on disk -- callers do that separately).
+
+    File URIs (``file://``) are stripped of their scheme prefix.
+    """
+    if env is None:
+        env = os.environ
+
+    # Strip file:// scheme if present (rare but valid in KiCad URIs).
+    if uri.startswith("file://"):
+        uri = uri[len("file://") :]
+
+    def _replace(match: re.Match) -> str:
+        var = match.group(1)
+        if var == "KIPRJMOD":
+            if kiprjmod is None:
+                # Signal failure by raising; the outer try/except converts
+                # this into ``None``.
+                raise KeyError(var)
+            return str(kiprjmod)
+        if var in env:
+            return env[var]
+        raise KeyError(var)
+
+    try:
+        expanded = _VAR_PATTERN.sub(_replace, uri)
+    except KeyError:
+        return None
+
+    return Path(expanded)
+
+
+def parse_fp_lib_table(path: Path) -> list[FpLibEntry]:
+    """Parse an ``fp-lib-table`` file into a list of :class:`FpLibEntry`.
+
+    The fp-lib-table grammar is a small s-expression::
+
+        (fp_lib_table
+            (version 7)
+            (lib (name "X") (type "KiCad") (uri "${KIPRJMOD}/X.pretty")
+                 (options "") (descr ""))
+            ...)
+
+    Only ``type="KiCad"`` entries get a non-``None`` ``resolved_path``;
+    Legacy/Github/etc. are returned with ``resolved_path=None`` so callers
+    can choose to log and skip them.  KIPRJMOD is set to *path*'s parent
+    directory.
+    """
+    if not path.is_file():
+        return []
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+
+    try:
+        root = parse_string(text)
+    except Exception:
+        # Malformed file -- treat as empty rather than crashing the caller.
+        return []
+
+    kiprjmod = path.parent.resolve()
+    entries: list[FpLibEntry] = []
+
+    for lib in root.find_all("lib"):
+        name = ""
+        lib_type = ""
+        uri = ""
+        for field in lib.children:
+            if field.name == "name":
+                name = field.get_string(0) or ""
+            elif field.name == "type":
+                lib_type = field.get_string(0) or ""
+            elif field.name == "uri":
+                uri = field.get_string(0) or ""
+
+        if not name or not uri:
+            continue
+
+        resolved: Path | None = None
+        if lib_type == "KiCad":
+            resolved = expand_kicad_vars(uri, kiprjmod)
+            # We do NOT require the directory to exist here.  Callers
+            # interested in "valid library nicknames" should check
+            # ``resolved_path.is_dir()`` themselves; that lets us still
+            # surface an entry whose directory has been deleted, which is
+            # often the bug we want to diagnose.
+
+        entries.append(
+            FpLibEntry(name=name, type=lib_type, uri=uri, resolved_path=resolved)
+        )
+
+    return entries

--- a/src/kicad_tools/footprints/library_path.py
+++ b/src/kicad_tools/footprints/library_path.py
@@ -275,3 +275,74 @@ def list_available_libraries(paths: LibraryPaths) -> list[str]:
             libraries.append(item.name.removesuffix(".pretty"))
 
     return sorted(libraries)
+
+
+def list_project_libraries(
+    schematic_path: Path | None,
+    global_paths: LibraryPaths,
+    *,
+    use_project_table: bool = True,
+) -> list[tuple[str, Path, str]]:
+    """Return ``(nickname, .pretty_dir, origin)`` triples merged from sources.
+
+    Discovers the project ``fp-lib-table`` co-located with *schematic_path*
+    (walked upward to the ``.kicad_pro`` root) and merges it with the
+    global library scan (the existing ``footprints_path/*.pretty`` walker).
+
+    Project entries are listed first and "win" on nickname collision -- this
+    matches KiCad's own resolution order (project table is consulted before
+    the global table).  Each tuple's third element is ``"project"`` or
+    ``"global"`` so callers can surface provenance.
+
+    Args:
+        schematic_path: Path to a ``.kicad_sch`` or ``.kicad_pro`` file used
+            to locate the project fp-lib-table.  When ``None``, only the
+            global libraries are returned.
+        global_paths: Detected global library paths.
+        use_project_table: When ``False``, the project table is skipped
+            (useful for ``--no-project-lib`` and CI reproducibility).
+
+    Returns:
+        List of ``(nickname, library_dir, origin)``.  Empty when nothing is
+        discoverable in either source.
+    """
+    # Local import to avoid a top-level cycle (fp_lib_table imports the
+    # sexp parser, which is fine, but library_path is a low-level helper
+    # that other footprints code imports broadly).
+    from kicad_tools.footprints.fp_lib_table import (
+        find_project_fp_lib_table,
+        parse_fp_lib_table,
+    )
+
+    result: list[tuple[str, Path, str]] = []
+    seen: set[str] = set()
+
+    # Project libraries first -- they win on collision.
+    if use_project_table and schematic_path is not None:
+        table_path = find_project_fp_lib_table(Path(schematic_path))
+        if table_path is not None:
+            for entry in parse_fp_lib_table(table_path):
+                if entry.type != "KiCad":
+                    # Legacy/Github types are skipped silently here; callers
+                    # who need to warn can re-parse via parse_fp_lib_table.
+                    continue
+                if entry.resolved_path is None:
+                    continue
+                if not entry.resolved_path.is_dir():
+                    continue
+                if entry.name in seen:
+                    continue
+                seen.add(entry.name)
+                result.append((entry.name, entry.resolved_path, "project"))
+
+    # Global libraries from the directory scan.
+    for lib_name in list_available_libraries(global_paths):
+        if lib_name in seen:
+            continue
+        lib_dir = global_paths.get_library_path(lib_name)
+        if lib_dir is None:
+            continue
+        seen.add(lib_name)
+        result.append((lib_name, lib_dir, "global"))
+
+    return result

--- a/tests/test_fp_lib_table.py
+++ b/tests/test_fp_lib_table.py
@@ -1,0 +1,157 @@
+"""Unit tests for the ``fp-lib-table`` parser and var-expansion helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.footprints.fp_lib_table import (
+    FpLibEntry,
+    expand_kicad_vars,
+    find_project_fp_lib_table,
+    parse_fp_lib_table,
+)
+
+_CANONICAL = """(fp_lib_table
+    (version 7)
+    (lib (name "MyLib") (type "KiCad") (uri "${KIPRJMOD}/MyLib.pretty") (options "") (descr "Project local"))
+    (lib (name "Resistor_SMD") (type "KiCad") (uri "${KICAD8_FOOTPRINT_DIR}/Resistor_SMD.pretty") (options "") (descr "Standard"))
+    (lib (name "LegacyLib") (type "Legacy") (uri "${KIPRJMOD}/LegacyLib.mod") (options "") (descr "old"))
+    (lib (name "GitHubLib") (type "Github") (uri "https://example.com/Lib.pretty") (options "") (descr "remote"))
+)
+"""
+
+
+def test_parse_canonical_table(tmp_path: Path) -> None:
+    table = tmp_path / "fp-lib-table"
+    table.write_text(_CANONICAL, encoding="utf-8")
+    entries = parse_fp_lib_table(table)
+    by_name = {e.name: e for e in entries}
+    assert set(by_name.keys()) == {"MyLib", "Resistor_SMD", "LegacyLib", "GitHubLib"}
+    # KIPRJMOD resolves to the table's parent dir.
+    assert by_name["MyLib"].resolved_path == tmp_path.resolve() / "MyLib.pretty"
+    assert by_name["MyLib"].type == "KiCad"
+
+
+def test_kiprjmod_resolves_against_table_parent(tmp_path: Path) -> None:
+    sub = tmp_path / "project"
+    sub.mkdir()
+    table = sub / "fp-lib-table"
+    table.write_text(
+        '(fp_lib_table (lib (name "X") (type "KiCad") (uri "${KIPRJMOD}/X.pretty")'
+        ' (options "") (descr "")))',
+        encoding="utf-8",
+    )
+    entries = parse_fp_lib_table(table)
+    assert len(entries) == 1
+    assert entries[0].resolved_path == sub.resolve() / "X.pretty"
+
+
+def test_kicad_env_var_resolves_from_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("KICAD8_FOOTPRINT_DIR", "/opt/kicad/footprints")
+    table = tmp_path / "fp-lib-table"
+    table.write_text(
+        '(fp_lib_table (lib (name "R") (type "KiCad") (uri'
+        ' "${KICAD8_FOOTPRINT_DIR}/Resistor_SMD.pretty") (options "") (descr "")))',
+        encoding="utf-8",
+    )
+    entries = parse_fp_lib_table(table)
+    assert entries[0].resolved_path == Path("/opt/kicad/footprints/Resistor_SMD.pretty")
+
+
+def test_unresolved_var_yields_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Remove any inherited value so the lookup definitely fails.
+    monkeypatch.delenv("KICAD9_FOOTPRINT_DIR", raising=False)
+    table = tmp_path / "fp-lib-table"
+    table.write_text(
+        '(fp_lib_table (lib (name "R") (type "KiCad") (uri'
+        ' "${KICAD9_FOOTPRINT_DIR}/Resistor_SMD.pretty") (options "") (descr "")))',
+        encoding="utf-8",
+    )
+    entries = parse_fp_lib_table(table)
+    assert len(entries) == 1
+    assert entries[0].resolved_path is None
+    # The raw URI is preserved for diagnostics.
+    assert "${KICAD9_FOOTPRINT_DIR}" in entries[0].uri
+
+
+def test_non_kicad_types_keep_resolved_none(tmp_path: Path) -> None:
+    table = tmp_path / "fp-lib-table"
+    table.write_text(_CANONICAL, encoding="utf-8")
+    entries = parse_fp_lib_table(table)
+    by_name = {e.name: e for e in entries}
+    assert by_name["LegacyLib"].type == "Legacy"
+    assert by_name["LegacyLib"].resolved_path is None
+    assert by_name["GitHubLib"].type == "Github"
+    assert by_name["GitHubLib"].resolved_path is None
+
+
+def test_parse_missing_file_returns_empty(tmp_path: Path) -> None:
+    assert parse_fp_lib_table(tmp_path / "no-such-file") == []
+
+
+def test_parse_malformed_file_returns_empty(tmp_path: Path) -> None:
+    bad = tmp_path / "fp-lib-table"
+    bad.write_text("not an s-expression at all", encoding="utf-8")
+    # Should not raise.
+    parse_fp_lib_table(bad)
+
+
+def test_find_project_fp_lib_table_in_project_root(tmp_path: Path) -> None:
+    (tmp_path / "proj.kicad_pro").write_text("{}", encoding="utf-8")
+    table = tmp_path / "fp-lib-table"
+    table.write_text("(fp_lib_table)", encoding="utf-8")
+    sch = tmp_path / "proj.kicad_sch"
+    sch.write_text("(kicad_sch)", encoding="utf-8")
+    found = find_project_fp_lib_table(sch)
+    assert found == table
+
+
+def test_find_project_fp_lib_table_for_subsheet(tmp_path: Path) -> None:
+    """KIPRJMOD always resolves to the project root, even from a sub-sheet."""
+    (tmp_path / "proj.kicad_pro").write_text("{}", encoding="utf-8")
+    table = tmp_path / "fp-lib-table"
+    table.write_text("(fp_lib_table)", encoding="utf-8")
+    sub = tmp_path / "sheets"
+    sub.mkdir()
+    sub_sheet = sub / "page2.kicad_sch"
+    sub_sheet.write_text("(kicad_sch)", encoding="utf-8")
+    found = find_project_fp_lib_table(sub_sheet)
+    assert found == table
+
+
+def test_find_project_fp_lib_table_missing(tmp_path: Path) -> None:
+    (tmp_path / "proj.kicad_pro").write_text("{}", encoding="utf-8")
+    # No fp-lib-table sibling.
+    sch = tmp_path / "proj.kicad_sch"
+    sch.write_text("(kicad_sch)", encoding="utf-8")
+    assert find_project_fp_lib_table(sch) is None
+
+
+def test_expand_kicad_vars_with_file_scheme(tmp_path: Path) -> None:
+    path = expand_kicad_vars("file://${KIPRJMOD}/Lib.pretty", kiprjmod=tmp_path)
+    assert path == tmp_path / "Lib.pretty"
+
+
+def test_expand_kicad_vars_pure_literal() -> None:
+    # No variables: passes through untouched.
+    assert expand_kicad_vars("/abs/path/Lib.pretty", kiprjmod=None) == Path(
+        "/abs/path/Lib.pretty"
+    )
+
+
+def test_expand_kicad_vars_missing_kiprjmod_when_required() -> None:
+    assert expand_kicad_vars("${KIPRJMOD}/X.pretty", kiprjmod=None) is None
+
+
+def test_fp_lib_entry_dataclass_roundtrip() -> None:
+    entry = FpLibEntry(
+        name="X", type="KiCad", uri="${KIPRJMOD}/X.pretty", resolved_path=Path("/x")
+    )
+    assert entry.name == "X"
+    assert entry.resolved_path == Path("/x")

--- a/tests/test_sch_preflight.py
+++ b/tests/test_sch_preflight.py
@@ -402,6 +402,117 @@ class TestCheckFootprintLibraryResolution:
         fp_issues = [i for i in issues if i.category == "footprint_resolution"]
         assert len(fp_issues) == 0
 
+    def test_on_disk_check_flags_missing_kicad_mod(self, tmp_path: Path):
+        """Project fp-lib-table + missing .kicad_mod => 'file not found' error."""
+        from kicad_tools.cli.sch_preflight import check_footprint_library_resolution
+
+        # Synthesize a project with a CustomLib in fp-lib-table but no
+        # actual .kicad_mod file -- the on-disk check must flag this.
+        (tmp_path / "proj.kicad_pro").write_text("{}", encoding="utf-8")
+        (tmp_path / "fp-lib-table").write_text(
+            '(fp_lib_table (lib (name "CustomLib") (type "KiCad")'
+            ' (uri "${KIPRJMOD}/CustomLib.pretty") (options "") (descr "")))',
+            encoding="utf-8",
+        )
+        (tmp_path / "CustomLib.pretty").mkdir()
+        # Note: NO MissingPart.kicad_mod -- this is the failure we want to flag.
+
+        sch = tmp_path / "proj.kicad_sch"
+        sch.write_text(
+            '(kicad_sch (version 20231120) (generator "test")'
+            ' (uuid "00000000-0000-0000-0000-000000000001") (paper "A4")'
+            ' (lib_symbols)'
+            ' (symbol (lib_id "Device:R") (at 0 0 0)'
+            '   (uuid "00000000-0000-0000-0000-000000000002")'
+            '   (property "Reference" "R1" (at 0 0 0))'
+            '   (property "Value" "10k" (at 0 0 0))'
+            '   (property "Footprint" "CustomLib:MissingPart" (at 0 0 0))'
+            '   (property "Datasheet" "" (at 0 0 0))'
+            '   (pin "1" (uuid "00000000-0000-0000-0000-000000000003"))'
+            '   (pin "2" (uuid "00000000-0000-0000-0000-000000000004"))))',
+            encoding="utf-8",
+        )
+
+        issues = check_footprint_library_resolution(str(sch))
+        msgs = [i.message for i in issues if i.category == "footprint_resolution"]
+        assert any("file not found" in m for m in msgs), msgs
+        # The mod-file failure is an error, not just a warning.
+        assert any(
+            i.severity == "error" and "file not found" in i.message
+            for i in issues
+        )
+
+    def test_on_disk_check_flags_unknown_nickname(self, tmp_path: Path):
+        """Reference to a library nickname absent from both tables => error."""
+        from kicad_tools.cli.sch_preflight import check_footprint_library_resolution
+
+        # Project table exists but with a different nickname.  Symbol
+        # footprint references an unknown nickname.
+        (tmp_path / "proj.kicad_pro").write_text("{}", encoding="utf-8")
+        (tmp_path / "fp-lib-table").write_text(
+            '(fp_lib_table (lib (name "OtherLib") (type "KiCad")'
+            ' (uri "${KIPRJMOD}/OtherLib.pretty") (options "") (descr "")))',
+            encoding="utf-8",
+        )
+        (tmp_path / "OtherLib.pretty").mkdir()
+
+        sch = tmp_path / "proj.kicad_sch"
+        sch.write_text(
+            '(kicad_sch (version 20231120) (generator "test")'
+            ' (uuid "00000000-0000-0000-0000-000000000001") (paper "A4")'
+            ' (lib_symbols)'
+            ' (symbol (lib_id "Device:R") (at 0 0 0)'
+            '   (uuid "00000000-0000-0000-0000-000000000002")'
+            '   (property "Reference" "R1" (at 0 0 0))'
+            '   (property "Value" "10k" (at 0 0 0))'
+            '   (property "Footprint" "TotallyUnknownLib:Foo" (at 0 0 0))'
+            '   (property "Datasheet" "" (at 0 0 0))'
+            '   (pin "1" (uuid "00000000-0000-0000-0000-000000000003"))'
+            '   (pin "2" (uuid "00000000-0000-0000-0000-000000000004"))))',
+            encoding="utf-8",
+        )
+
+        issues = check_footprint_library_resolution(str(sch))
+        msgs = [i.message for i in issues if i.category == "footprint_resolution"]
+        assert any("not found in" in m and "TotallyUnknownLib" in m for m in msgs), msgs
+
+    def test_on_disk_check_passes_for_valid_project_lib(self, tmp_path: Path):
+        """Synthesized project fp-lib-table + matching .kicad_mod => no errors."""
+        from kicad_tools.cli.sch_preflight import check_footprint_library_resolution
+
+        (tmp_path / "proj.kicad_pro").write_text("{}", encoding="utf-8")
+        (tmp_path / "fp-lib-table").write_text(
+            '(fp_lib_table (lib (name "CustomLib") (type "KiCad")'
+            ' (uri "${KIPRJMOD}/CustomLib.pretty") (options "") (descr "")))',
+            encoding="utf-8",
+        )
+        lib_dir = tmp_path / "CustomLib.pretty"
+        lib_dir.mkdir()
+        (lib_dir / "MyPart.kicad_mod").write_text(
+            '(footprint "MyPart" (version 20240108) (generator "test") (layer "F.Cu"))',
+            encoding="utf-8",
+        )
+
+        sch = tmp_path / "proj.kicad_sch"
+        sch.write_text(
+            '(kicad_sch (version 20231120) (generator "test")'
+            ' (uuid "00000000-0000-0000-0000-000000000001") (paper "A4")'
+            ' (lib_symbols)'
+            ' (symbol (lib_id "Device:R") (at 0 0 0)'
+            '   (uuid "00000000-0000-0000-0000-000000000002")'
+            '   (property "Reference" "R1" (at 0 0 0))'
+            '   (property "Value" "10k" (at 0 0 0))'
+            '   (property "Footprint" "CustomLib:MyPart" (at 0 0 0))'
+            '   (property "Datasheet" "" (at 0 0 0))'
+            '   (pin "1" (uuid "00000000-0000-0000-0000-000000000003"))'
+            '   (pin "2" (uuid "00000000-0000-0000-0000-000000000004"))))',
+            encoding="utf-8",
+        )
+
+        issues = check_footprint_library_resolution(str(sch))
+        fp_issues = [i for i in issues if i.category == "footprint_resolution"]
+        assert fp_issues == [], [i.message for i in fp_issues]
+
 
 class TestCheckGenericValues:
     """Tests for check_generic_values."""

--- a/tests/test_sch_suggest_footprint.py
+++ b/tests/test_sch_suggest_footprint.py
@@ -277,3 +277,180 @@ def test_missing_schematic_file(capsys):
     err = capsys.readouterr().err
     assert rc == 1
     assert "not found" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Project fp-lib-table integration (KiCad-INDEPENDENT, NOT gated)
+# ---------------------------------------------------------------------------
+
+# A minimal 2-pad footprint for the synthesized project library.
+_MINI_FP = """(footprint "MyPart"
+    (version 20240108)
+    (generator "kicadtools_test")
+    (layer "F.Cu")
+    (attr smd)
+    (pad "1" smd roundrect (at -1 0) (size 1 1) (layers "F.Cu"))
+    (pad "2" smd roundrect (at 1 0) (size 1 1) (layers "F.Cu"))
+)
+"""
+
+# A trivial 2-pin schematic with one Device:R reference R1.  Pure-resistor
+# symbol shape keeps the test KiCad-independent (no external libraries
+# touched -- only the project's fp-lib-table is consulted).
+_TRIVIAL_RC_SCH = """(kicad_sch
+    (version 20231120)
+    (generator "kicadtools_test")
+    (uuid "00000000-0000-0000-0000-0000000000bb")
+    (paper "A4")
+    (lib_symbols
+        (symbol "Device:R"
+            (pin_numbers hide)
+            (pin_names hide)
+            (symbol "R_0_1"
+                (rectangle
+                    (start -1.016 -2.54)
+                    (end 1.016 2.54)
+                    (stroke (width 0.254))
+                    (fill (type none))
+                )
+            )
+            (symbol "R_1_1"
+                (pin passive line
+                    (at 0 3.81 270)
+                    (length 1.27)
+                    (name "~")
+                    (number "1")
+                )
+                (pin passive line
+                    (at 0 -3.81 90)
+                    (length 1.27)
+                    (name "~")
+                    (number "2")
+                )
+            )
+        )
+    )
+    (symbol
+        (lib_id "Device:R")
+        (at 100 100 0)
+        (uuid "00000000-0000-0000-0000-0000000000b1")
+        (property "Reference" "R1" (at 0 0 0))
+        (property "Value" "10k" (at 0 0 0))
+        (property "Footprint" "" (at 0 0 0))
+        (property "Datasheet" "" (at 0 0 0))
+        (pin "1" (uuid "00000000-0000-0000-0000-0000000000b2"))
+        (pin "2" (uuid "00000000-0000-0000-0000-0000000000b3"))
+    )
+)
+"""
+
+
+def _make_project(tmp_path: Path, *, fp_filename: str = "MyPart.kicad_mod") -> Path:
+    """Build a tmp project with .kicad_pro, fp-lib-table, schematic and lib."""
+    (tmp_path / "proj.kicad_pro").write_text("{}", encoding="utf-8")
+    (tmp_path / "fp-lib-table").write_text(
+        '(fp_lib_table\n'
+        '  (version 7)\n'
+        '  (lib (name "CustomLib") (type "KiCad") (uri "${KIPRJMOD}/CustomLib.pretty")'
+        '       (options "") (descr "Project local"))\n'
+        ')',
+        encoding="utf-8",
+    )
+    lib_dir = tmp_path / "CustomLib.pretty"
+    lib_dir.mkdir()
+    (lib_dir / fp_filename).write_text(_MINI_FP, encoding="utf-8")
+    sch = tmp_path / "proj.kicad_sch"
+    sch.write_text(_TRIVIAL_RC_SCH, encoding="utf-8")
+    return sch
+
+
+def test_project_library_surfaces_local_footprint(tmp_path, capsys):
+    """AC: a project fp-lib-table makes its libraries visible to suggest."""
+    sch = _make_project(tmp_path)
+    rc = run_suggest_footprint(sch, ref="R1", output_format="json", limit=50)
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert data["project_lib_table"] == str(tmp_path / "fp-lib-table")
+    names = [(c["library"], c["footprint"], c.get("origin")) for c in data["candidates"]]
+    assert ("CustomLib", "MyPart", "project") in names
+
+
+def test_no_project_lib_flag_hides_project_libraries(tmp_path, capsys):
+    """AC: --no-project-lib restores Phase-1 global-only behavior."""
+    sch = _make_project(tmp_path)
+    # Return code may be 0 or 1 depending on whether global libs are available;
+    # we only assert the project entry is absent from the JSON.
+    run_suggest_footprint(
+        sch, ref="R1", output_format="json", limit=50, no_project_lib=True
+    )
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["project_lib_table"] is None
+    libs = {(c["library"], c["footprint"]) for c in data["candidates"]}
+    assert ("CustomLib", "MyPart") not in libs
+
+
+def test_project_library_ranks_first_over_global_collision(
+    tmp_path, monkeypatch, capsys
+):
+    """AC: project entries win on nickname collision and rank ahead."""
+    # Two libraries sharing the nickname "CustomLib": one in the project,
+    # one in a fake "global" footprints root.  The project entry must win.
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "proj.kicad_pro").write_text("{}", encoding="utf-8")
+    (project / "fp-lib-table").write_text(
+        '(fp_lib_table (lib (name "CustomLib") (type "KiCad")'
+        ' (uri "${KIPRJMOD}/CustomLib.pretty") (options "") (descr "")))',
+        encoding="utf-8",
+    )
+    proj_lib = project / "CustomLib.pretty"
+    proj_lib.mkdir()
+    (proj_lib / "MyPart.kicad_mod").write_text(_MINI_FP, encoding="utf-8")
+    sch = project / "proj.kicad_sch"
+    sch.write_text(_TRIVIAL_RC_SCH, encoding="utf-8")
+
+    # Fake global root with a SAME-nickname library containing a different fp.
+    fake_global = tmp_path / "global_footprints"
+    fake_global_lib = fake_global / "CustomLib.pretty"
+    fake_global_lib.mkdir(parents=True)
+    fake_global_fp = (fake_global_lib / "GlobalPart.kicad_mod")
+    fake_global_fp.write_text(_MINI_FP.replace("MyPart", "GlobalPart"), encoding="utf-8")
+
+    def _global_paths(*_a, **_kw):
+        return LibraryPaths(footprints_path=fake_global, source="env")
+
+    monkeypatch.setattr(
+        sch_suggest_footprint, "detect_kicad_library_path", _global_paths
+    )
+
+    rc = run_suggest_footprint(sch, ref="R1", output_format="json", limit=50)
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    # The project entry MyPart must appear; the colliding-nickname global
+    # entry must NOT appear because the project nickname wins.
+    libs = [(c["library"], c["footprint"], c.get("origin")) for c in data["candidates"]]
+    assert ("CustomLib", "MyPart", "project") in libs
+    assert ("CustomLib", "GlobalPart", "global") not in libs
+
+
+def test_project_library_works_without_global_kicad(tmp_path, monkeypatch, capsys):
+    """AC: project fp-lib-table alone is sufficient -- no global libs needed."""
+
+    def _no_global(*_a, **_kw):
+        return LibraryPaths(footprints_path=None, source="auto")
+
+    monkeypatch.setattr(sch_suggest_footprint, "detect_kicad_library_path", _no_global)
+
+    sch = _make_project(tmp_path)
+    rc = run_suggest_footprint(sch, ref="R1", output_format="json", limit=10)
+    out = capsys.readouterr().out
+    # Without project fp-lib-table this would fail with rc=1 (covered by
+    # test_no_library_graceful_degradation).  With a project table, the
+    # command should succeed and surface the local footprint.
+    assert rc == 0
+    data = json.loads(out)
+    names = [(c["library"], c["footprint"]) for c in data["candidates"]]
+    assert ("CustomLib", "MyPart") in names


### PR DESCRIPTION
## Summary

Wire `sch suggest-footprint` and `sch preflight` through the project `fp-lib-table` so they no longer ignore project-local libraries (the existing code only ever saw the global KiCad install).

- **New module** `kicad_tools.footprints.fp_lib_table`: parses the s-expression table; resolves `${KIPRJMOD}` to the project root and `${KICAD<N>_FOOTPRINT_DIR}` / generic env vars from `os.environ`. Only `type="KiCad"` entries get a resolved path; Legacy/Github types are surfaced but left unresolved.
- **`list_project_libraries`** merges project entries (first, win on nickname collision) with the existing global directory scan. Mirrors KiCad's own resolution order.
- **`suggest-footprint`** plumbing: `_candidate_library_paths`, `find_footprint_candidates`, and `run_suggest_footprint` thread `schematic_path` and a `--no-project-lib` flag through to the merged library list. JSON output gains `project_lib_table` and per-candidate `origin: "project"|"global"`. Suggest can now succeed even without a global KiCad install as long as the project ships its own table.
- **Bonus**: `check_footprint_library_resolution` in `sch_preflight.py` now performs the previously-deferred on-disk verification of the referenced `.kicad_mod` file. Unblocks the TODO that was originally at `sch_preflight.py:50-59`. Gracefully degrades to text-form checks on environments with neither a global library nor a project table.
- **Out of scope** (as agreed): bulk assign-footprints (#3180, parallel work) and 3D-model assignment.

## Test plan

All new functionality lands with KiCad-independent tests so the suite stays green on CI runners with no KiCad install:

- [x] `tests/test_fp_lib_table.py` (14 tests): parser, `${KIPRJMOD}` + env var expansion, sub-sheet KIPRJMOD walking, malformed-file handling, non-KiCad type behavior.
- [x] `tests/test_sch_suggest_footprint.py` (+4 tests): project-library surfaces local fp, `--no-project-lib` opt-out, project wins on nickname collision against a synthesized "global" root, project-only operation without any global KiCad library.
- [x] `tests/test_sch_preflight.py` (+3 tests): on-disk missing `.kicad_mod` flagged as error, unknown library nickname flagged, fully-valid project resolves cleanly.
- [x] Local run: `uv run pytest tests/test_fp_lib_table.py tests/test_sch_suggest_footprint.py tests/test_sch_preflight.py` -> 61 passed.
- [x] Local run: `uv run pytest tests/test_footprints.py tests/test_footprint_library.py tests/test_footprint_validator.py tests/test_footprint_dsl.py tests/test_footprint_selector.py tests/test_pad_grid_preflight.py tests/test_preflight.py` -> 261 passed (no regression in adjacent surface).
- [x] Smoke: `kct sch suggest-footprint --help` shows the new `--no-project-lib` flag; runs against existing fixture; `kct sch preflight` runs against `boards/01-voltage-divider` with no false-positive footprint_resolution errors.

Closes #3181