### PR TITLE
feat(sch): bulk assign-footprints CLI (closes #3180)

### DIFF
--- a/src/kicad_tools/cli/commands/schematic.py
+++ b/src/kicad_tools/cli/commands/schematic.py
@@ -15,6 +15,7 @@ def run_sch_command(args) -> int:
         )
         print(
             "          connections, unconnected, set-footprint, suggest-footprint,"
+            " assign-footprints,"
             " set-value, set-reference,"
             " set-symbol-property, replace,"
             " sync-hierarchy, rename-signal,"
@@ -191,6 +192,22 @@ def run_sch_command(args) -> int:
             package=getattr(args, "package", None),
             output_format=getattr(args, "format", "text"),
             limit=getattr(args, "limit", 20),
+            no_project_lib=getattr(args, "no_project_lib", False),
+        )
+
+    elif args.sch_command == "assign-footprints":
+        from ..sch_assign_footprints import run_assign_footprints
+
+        return run_assign_footprints(
+            schematic_path=schematic_path,
+            dry_run=getattr(args, "dry_run", False),
+            output_format=getattr(args, "format", "text"),
+            limit=getattr(args, "limit", 20),
+            backup=not getattr(args, "no_backup", False),
+            validate=getattr(args, "validate", True),
+            include_power=getattr(args, "include_power", False),
+            include_dnp=getattr(args, "include_dnp", False),
+            force=getattr(args, "force", False),
             no_project_lib=getattr(args, "no_project_lib", False),
         )
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -675,6 +675,75 @@ def _add_sch_parser(subparsers) -> None:
         help="Fail on any pin-count mismatch, even in batch mode",
     )
 
+    # sch assign-footprints
+    sch_assign_fp = sch_subparsers.add_parser(
+        "assign-footprints",
+        help="Bulk-assign footprints to symbols missing one (auto + dry-run + json)",
+    )
+    sch_assign_fp.add_argument("schematic", help="Path to .kicad_sch file")
+    sch_assign_fp.add_argument(
+        "--auto",
+        action="store_true",
+        default=True,
+        help=(
+            "Assign only unambiguous candidates (default; only mode currently "
+            "supported)."
+        ),
+    )
+    sch_assign_fp.add_argument(
+        "--dry-run",
+        "-n",
+        action="store_true",
+        help="Preview the proposed mapping without modifying files",
+    )
+    sch_assign_fp.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    sch_assign_fp.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Max candidates considered per symbol (default: 20)",
+    )
+    sch_assign_fp.add_argument(
+        "--no-backup",
+        action="store_true",
+        help="Skip backup files on write",
+    )
+    sch_assign_fp.add_argument(
+        "--no-validate",
+        dest="validate",
+        action="store_false",
+        default=True,
+        help="Skip pin-count validation on the resolved mapping",
+    )
+    sch_assign_fp.add_argument(
+        "--include-power",
+        action="store_true",
+        help="Also consider power: symbols (default: skip)",
+    )
+    sch_assign_fp.add_argument(
+        "--include-dnp",
+        action="store_true",
+        help="Also consider DNP symbols (default: skip)",
+    )
+    sch_assign_fp.add_argument(
+        "--force",
+        action="store_true",
+        help="Reconsider symbols that already have a non-empty footprint",
+    )
+    sch_assign_fp.add_argument(
+        "--no-project-lib",
+        action="store_true",
+        help=(
+            "Ignore the project's fp-lib-table and only use global "
+            "footprint libraries (CI / reproducibility opt-out)"
+        ),
+    )
+
     # sch suggest-footprint
     sch_suggest_fp = sch_subparsers.add_parser(
         "suggest-footprint",

--- a/src/kicad_tools/cli/sch_assign_footprints.py
+++ b/src/kicad_tools/cli/sch_assign_footprints.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+"""
+Bulk-assign footprints to schematic symbols that are missing one.
+
+Walks every sheet of a hierarchical schematic, finds the symbols whose
+``Footprint`` property is empty or ``~``, and uses the ``suggest-footprint``
+machinery (pin count + ``ki_fp_filters`` glob + project ``fp-lib-table``)
+to propose a candidate. Symbols whose top candidate is **unambiguous**
+get written via the same in-place edit path as ``set-footprint --map``.
+Ambiguous and no-candidate symbols are reported and skipped — the user
+either narrows them with ``suggest-footprint --ref <ref>`` or hand-feeds
+a complete mapping to ``set-footprint --map``.
+
+Ambiguity policy for ``--auto`` (the default and only mode):
+
+    "Unambiguous" means the top candidate's rank tier (``ki_fp_filters``
+    match, keyword match, hand-solder flag) is **strictly better** than
+    the runner-up's. A single-candidate result is trivially unambiguous;
+    a tie at the top tier is intentionally **ambiguous** — no confidence
+    threshold, no "pick alphabetical first" fallback. This matches the
+    behaviour of ``suggest-footprint`` for ref-only suggestion: if the
+    library gives back two equally-ranked hits, the human decides.
+
+Usage:
+    # Assign every unambiguous missing footprint, write in place.
+    kicad-tools sch assign-footprints board.kicad_sch --auto
+
+    # Preview only — emit a JSON report, do not modify files.
+    kicad-tools sch assign-footprints board.kicad_sch --auto \\
+        --dry-run --format json
+
+    # Re-assign even symbols that already have a footprint set.
+    kicad-tools sch assign-footprints board.kicad_sch --auto --force
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from kicad_tools.cli.sch_footprint_common import (
+    is_missing_footprint,
+    iter_missing_footprint_symbols,
+)
+from kicad_tools.cli.sch_set_footprint import run_set_footprint
+from kicad_tools.cli.sch_suggest_footprint import (
+    _derive_keyword,
+    _get_fp_filters,
+    _rank_key,
+    _resolve_target_pin_count,
+    find_footprint_candidates,
+)
+from kicad_tools.footprints.fp_lib_table import find_project_fp_lib_table
+from kicad_tools.footprints.library_path import detect_kicad_library_path
+
+
+def _is_unambiguous(
+    candidates: list[dict[str, Any]],
+    fp_filters: list[str],
+    keyword: str | None,
+) -> bool:
+    """Return ``True`` when the top candidate strictly out-ranks the runner-up.
+
+    Compares the first four tiers of :func:`_rank_key` — filter match,
+    keyword match, project-vs-global origin, and hand-solder flag — which
+    are the signals that reflect "this candidate is a better fit for the
+    symbol". The trailing ``(library, footprint_name)`` tiers are
+    alphabetical tie-breakers and are deliberately excluded from the
+    ambiguity decision: a sort-order tie-break is not real disambiguation.
+
+    A single-candidate list is treated as unambiguous (there is nothing
+    to be ambiguous *with*).
+    """
+    if not candidates:
+        return False
+    if len(candidates) == 1:
+        return True
+    top_tier = _rank_key(candidates[0], keyword, fp_filters)[:4]
+    runner_tier = _rank_key(candidates[1], keyword, fp_filters)[:4]
+    return top_tier != runner_tier
+
+
+def _classify_symbol(
+    sch: Any,
+    sym: Any,
+    *,
+    schematic_path: Path,
+    paths: Any,
+    limit: int,
+    use_project_table: bool,
+) -> dict[str, Any]:
+    """Compute the candidate list + auto-assign decision for one symbol.
+
+    Returns a dict with the keys ``reference``, ``value``, ``lib_id``,
+    ``current_footprint``, ``pin_count``, ``package_keyword``,
+    ``fp_filters``, ``candidates`` (top-``limit``), ``status``
+    (``"assigned" | "ambiguous" | "no_candidates"``) and ``assigned``
+    (the chosen footprint string when ``status == "assigned"``).
+    """
+    target_pins = _resolve_target_pin_count(sch, sym)
+    keyword = _derive_keyword(sym)
+    fp_filters = _get_fp_filters(sch, sym)
+
+    candidates = find_footprint_candidates(
+        paths,
+        target_pins,
+        keyword,
+        limit,
+        fp_filters=fp_filters,
+        schematic_path=schematic_path,
+        use_project_table=use_project_table,
+    )
+
+    record: dict[str, Any] = {
+        "reference": sym.reference,
+        "value": sym.value,
+        "lib_id": sym.lib_id,
+        "current_footprint": sym.footprint or "",
+        "pin_count": target_pins,
+        "package_keyword": keyword,
+        "fp_filters": fp_filters,
+        "candidates": candidates,
+        "status": "no_candidates",
+        "assigned": None,
+    }
+
+    if not candidates:
+        return record
+
+    if _is_unambiguous(candidates, fp_filters, keyword):
+        top = candidates[0]
+        record["status"] = "assigned"
+        record["assigned"] = f"{top['library']}:{top['footprint']}"
+    else:
+        record["status"] = "ambiguous"
+
+    return record
+
+
+def _emit_text_report(
+    schematic_path: Path,
+    records: list[dict[str, Any]],
+    *,
+    dry_run: bool,
+    project_table: Path | None,
+    library_source: str,
+    duplicates_skipped: int,
+) -> None:
+    """Pretty-print a one-symbol-per-line report (text format)."""
+    assigned = [r for r in records if r["status"] == "assigned"]
+    ambiguous = [r for r in records if r["status"] == "ambiguous"]
+    no_cand = [r for r in records if r["status"] == "no_candidates"]
+
+    print(f"assign-footprints: {schematic_path}")
+    print(f"  library source:  {library_source}")
+    if project_table is not None:
+        print(f"  project fp-lib-table: {project_table}")
+    print(
+        f"  scanned: {len(records)}  assigned: {len(assigned)}"
+        f"  ambiguous: {len(ambiguous)}  no-candidate: {len(no_cand)}"
+    )
+    if duplicates_skipped:
+        print(
+            f"  duplicate-ref collisions skipped: {duplicates_skipped}"
+            " (multi-sheet instance of same ref, first wins)"
+        )
+
+    if assigned:
+        print()
+        print(f"Assigned ({len(assigned)}):")
+        for r in assigned:
+            print(f"  {r['reference']:<8} -> {r['assigned']}  ({r['lib_id']})")
+
+    if ambiguous:
+        print()
+        print(f"Ambiguous ({len(ambiguous)}):")
+        for r in ambiguous:
+            print(f"  {r['reference']:<8} ({r['lib_id']}, {r['pin_count']} pins)")
+            for c in r["candidates"][:5]:
+                origin_tag = " [project]" if c.get("origin") == "project" else ""
+                print(f"      {c['library']}:{c['footprint']}{origin_tag}")
+            if len(r["candidates"]) > 5:
+                print(f"      ... and {len(r['candidates']) - 5} more")
+
+    if no_cand:
+        print()
+        print(f"No candidates ({len(no_cand)}):")
+        for r in no_cand:
+            kw = f" keyword={r['package_keyword']!r}" if r["package_keyword"] else ""
+            print(f"  {r['reference']:<8} ({r['lib_id']}, {r['pin_count']} pins){kw}")
+
+    print()
+    if dry_run:
+        print(f"Dry run: {len(assigned)} footprint(s) would be assigned")
+    elif not assigned:
+        print("No unambiguous assignments to apply.")
+
+
+def run_assign_footprints(
+    schematic_path: Path,
+    *,
+    dry_run: bool = False,
+    output_format: str = "text",
+    limit: int = 20,
+    backup: bool = True,
+    validate: bool = True,
+    include_power: bool = False,
+    include_dnp: bool = False,
+    force: bool = False,
+    no_project_lib: bool = False,
+    config_override: str | Path | None = None,
+) -> int:
+    """Bulk-assign unambiguous footprints to missing-footprint symbols.
+
+    Returns 0 when at least one assignment succeeds OR there were no
+    missing-footprint symbols to consider. Returns 1 when no library is
+    available, every symbol was ambiguous / no-candidate, or any write
+    error occurred.
+
+    See the module docstring for the ambiguity policy.
+    """
+    if not schematic_path.exists():
+        print(f"Error: File not found: {schematic_path}", file=sys.stderr)
+        return 1
+
+    paths = detect_kicad_library_path(config_override)
+    project_table = (
+        find_project_fp_lib_table(schematic_path) if not no_project_lib else None
+    )
+    if not paths.found and project_table is None:
+        print(
+            "Error: No KiCad footprint library found. "
+            "assign-footprints requires the standard KiCad footprint libraries "
+            "or a project fp-lib-table.\n"
+            "Set the KICAD_FOOTPRINT_DIR environment variable to the directory "
+            "containing your '*.pretty' footprint libraries, e.g.\n"
+            "  export KICAD_FOOTPRINT_DIR="
+            "/Applications/KiCad/KiCad.app/Contents/SharedSupport/footprints",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Walk the hierarchy and classify each symbol. ``--force`` widens the
+    # iteration to every symbol; without it we only consider truly-empty
+    # footprints (so we never silently overwrite a designer's choice).
+    records: list[dict[str, Any]] = []
+    seen_refs: set[str] = set()
+    duplicates_skipped = 0
+    for _node, sym, sch in iter_missing_footprint_symbols(
+        schematic_path,
+        include_power=include_power,
+        include_dnp=include_dnp,
+        include_assigned=force,
+    ):
+        # Without --force, only act on truly-empty footprints; --force lets
+        # us reconsider already-assigned symbols too.
+        if not force and not is_missing_footprint(sym):
+            continue
+
+        ref = sym.reference
+        if not ref:
+            continue
+        if ref in seen_refs:
+            # The same ref can show up under multiple sheet instances of
+            # the same sub-sheet. The footprint property lives once per
+            # symbol instance in the source schematic, so deduping on the
+            # first occurrence is correct: ``set_footprint_text`` will
+            # find that one occurrence regardless.
+            duplicates_skipped += 1
+            continue
+        seen_refs.add(ref)
+
+        record = _classify_symbol(
+            sch,
+            sym,
+            schematic_path=schematic_path,
+            paths=paths,
+            limit=limit,
+            use_project_table=not no_project_lib,
+        )
+        records.append(record)
+
+    # Build the mapping for run_set_footprint.
+    mapping: dict[str, str] = {
+        r["reference"]: r["assigned"] for r in records if r["status"] == "assigned"
+    }
+
+    library_source = paths.source if paths.found else "project-only"
+
+    if output_format == "json":
+        report = {
+            "schematic": str(schematic_path),
+            "library_source": library_source,
+            "project_lib_table": (
+                str(project_table) if project_table is not None else None
+            ),
+            "scanned": len(records),
+            "assigned": [
+                {
+                    "reference": r["reference"],
+                    "lib_id": r["lib_id"],
+                    "footprint": r["assigned"],
+                }
+                for r in records
+                if r["status"] == "assigned"
+            ],
+            "ambiguous": [
+                {
+                    "reference": r["reference"],
+                    "lib_id": r["lib_id"],
+                    "pin_count": r["pin_count"],
+                    "fp_filters": r["fp_filters"],
+                    "candidates": r["candidates"],
+                }
+                for r in records
+                if r["status"] == "ambiguous"
+            ],
+            "no_candidates": [
+                {
+                    "reference": r["reference"],
+                    "lib_id": r["lib_id"],
+                    "pin_count": r["pin_count"],
+                    "package_keyword": r["package_keyword"],
+                }
+                for r in records
+                if r["status"] == "no_candidates"
+            ],
+            "duplicates_skipped": duplicates_skipped,
+            "dry_run": dry_run,
+        }
+        print(json.dumps(report, indent=2))
+    else:
+        _emit_text_report(
+            schematic_path,
+            records,
+            dry_run=dry_run,
+            project_table=project_table,
+            library_source=library_source,
+            duplicates_skipped=duplicates_skipped,
+        )
+
+    # No symbols at all -> success (nothing to do is not a failure).
+    if not records:
+        return 0
+
+    # Symbols existed but nothing was assignable -> non-zero so CI fails loudly.
+    if not mapping:
+        return 1
+
+    if dry_run:
+        return 0
+
+    # Hand the assignments off to the validated write path.
+    write_rc = run_set_footprint(
+        schematic_path=schematic_path,
+        mapping=mapping,
+        backup=backup,
+        validate=validate,
+        config_override=config_override,
+    )
+    return write_rc
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for standalone usage."""
+    parser = argparse.ArgumentParser(
+        description="Bulk-assign footprints to symbols missing one",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("schematic", type=Path, help="Path to .kicad_sch file")
+    parser.add_argument(
+        "--auto",
+        action="store_true",
+        default=True,
+        help=(
+            "Assign only unambiguous candidates (default; only mode currently "
+            "supported). 'Unambiguous' = top candidate strictly out-ranks the "
+            "runner-up on ki_fp_filters/keyword/hand-solder tier."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        "-n",
+        action="store_true",
+        help="Preview the proposed mapping without modifying files.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text). JSON emits a full report.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Max candidates considered per symbol (default: 20).",
+    )
+    parser.add_argument(
+        "--no-backup",
+        action="store_true",
+        help="Skip backup files on write.",
+    )
+    parser.add_argument(
+        "--no-validate",
+        dest="validate",
+        action="store_false",
+        default=True,
+        help="Skip pin-count validation on the resolved mapping.",
+    )
+    parser.add_argument(
+        "--include-power",
+        action="store_true",
+        help="Also consider power: symbols (default: skip).",
+    )
+    parser.add_argument(
+        "--include-dnp",
+        action="store_true",
+        help="Also consider DNP symbols (default: skip).",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Reconsider symbols that already have a non-empty footprint. "
+            "Without --force, existing assignments are never overwritten."
+        ),
+    )
+    parser.add_argument(
+        "--no-project-lib",
+        action="store_true",
+        help=(
+            "Ignore the project's fp-lib-table and only use global "
+            "footprint libraries (CI / reproducibility opt-out)."
+        ),
+    )
+
+    args = parser.parse_args(argv)
+
+    return run_assign_footprints(
+        schematic_path=args.schematic,
+        dry_run=args.dry_run,
+        output_format=args.format,
+        limit=args.limit,
+        backup=not args.no_backup,
+        validate=args.validate,
+        include_power=args.include_power,
+        include_dnp=args.include_dnp,
+        force=args.force,
+        no_project_lib=args.no_project_lib,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kicad_tools/cli/sch_footprint_common.py
+++ b/src/kicad_tools/cli/sch_footprint_common.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Shared helpers for footprint-aware schematic commands.
+
+The two callers today are:
+
+* ``sch_assign_footprints.run_assign_footprints`` — bulk auto-assignment.
+* ``sch_validate.check_missing_footprints`` — preflight enumeration.
+
+Both need to walk the schematic hierarchy and yield the same set of
+"missing-footprint" symbols. Centralising the predicate here keeps the
+two paths in lock-step: if one filter (power, DNP) drifts, the other
+silently drifts with it, which previously masked real gaps.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+from kicad_tools.schema import Schematic
+from kicad_tools.schema.hierarchy import build_hierarchy
+
+
+def is_missing_footprint(sym: Any) -> bool:
+    """Return ``True`` when a symbol has no concrete footprint assigned.
+
+    KiCad emits ``""`` for fresh placements and ``"~"`` as the legacy
+    placeholder; both are treated as "missing". A real ``Library:Name``
+    string is considered assigned even if the library does not exist on
+    disk — that is a different problem (handled by ``set-footprint`` /
+    DRC), not "missing".
+    """
+    fp = (sym.footprint or "").strip()
+    return fp == "" or fp == "~"
+
+
+def should_skip_symbol(
+    sym: Any,
+    *,
+    include_power: bool = False,
+    include_dnp: bool = False,
+) -> bool:
+    """Mirror ``check_missing_footprints``'s skip rules.
+
+    By default ``power:`` symbols and ``dnp`` (Do-Not-Populate) symbols
+    are skipped — they correctly have no footprint. Callers that need
+    to surface every reference (e.g. a "force-everything" audit pass)
+    can opt in via the keyword arguments.
+    """
+    if not include_power and sym.lib_id.startswith("power:"):
+        return True
+    if not include_dnp and getattr(sym, "dnp", False):
+        return True
+    return False
+
+
+def iter_missing_footprint_symbols(
+    schematic_path: Path | str,
+    *,
+    include_power: bool = False,
+    include_dnp: bool = False,
+    include_assigned: bool = False,
+) -> Iterator[tuple[Any, Any, Schematic]]:
+    """Yield ``(node, sym, sch)`` for every symbol needing a footprint.
+
+    Walks the full hierarchy via :func:`build_hierarchy`, loads each
+    sheet's schematic, and applies the same skip rules as
+    ``check_missing_footprints`` (power, dnp). Sheets that fail to load
+    are silently skipped — the preflight path surfaces those as ``info``
+    severity issues separately.
+
+    Args:
+        schematic_path: Path to the root ``.kicad_sch`` file.
+        include_power: Yield ``power:`` symbols (default skip).
+        include_dnp: Yield DNP symbols (default skip).
+        include_assigned: Yield every symbol regardless of footprint
+            state. The default (``False``) restricts the iteration to
+            symbols whose footprint is empty or ``~``. ``--force`` in
+            the assign-footprints CLI flips this to ``True``.
+
+    Yields:
+        Triples of ``(node, sym, sch)`` where ``node`` is the
+        :class:`HierarchyNode`, ``sym`` is the parsed symbol instance,
+        and ``sch`` is the loaded :class:`Schematic` (caches one
+        load per sheet so callers can reuse it for
+        ``_resolve_target_pin_count`` / ``_get_fp_filters``).
+    """
+    root = build_hierarchy(str(schematic_path))
+    for node in root.all_nodes():
+        try:
+            sch = Schematic.load(node.path)
+        except Exception:
+            continue
+        for sym in sch.symbols:
+            if should_skip_symbol(
+                sym,
+                include_power=include_power,
+                include_dnp=include_dnp,
+            ):
+                continue
+            if not include_assigned and not is_missing_footprint(sym):
+                continue
+            yield node, sym, sch

--- a/src/kicad_tools/cli/sch_set_footprint.py
+++ b/src/kicad_tools/cli/sch_set_footprint.py
@@ -181,6 +181,7 @@ def run_set_footprint(
     validate: bool = True,
     strict: bool = False,
     config_override: str | Path | None = None,
+    mapping: dict[str, str] | None = None,
 ) -> int:
     """Run the set-footprint operation.
 
@@ -191,14 +192,30 @@ def run_set_footprint(
     mismatch only warns so existing bulk-assign workflows are unaffected.
     When no library is available, validation is silently skipped.
 
+    The ``mapping`` parameter lets in-process callers (e.g.
+    :func:`sch_assign_footprints.run_assign_footprints`) hand a pre-built
+    ``{ref: footprint}`` dict directly, skipping the JSON/CSV file round-trip.
+    It is treated as the same "batch mode" as ``--map``: validation warnings
+    do not abort unless ``strict=True``. ``ref``/``footprint``/``map_path``
+    are ignored when ``mapping`` is provided.
+
     Returns 0 on success, 1 on error.
     """
     if not schematic_path.exists():
         print(f"Error: File not found: {schematic_path}", file=sys.stderr)
         return 1
 
-    # Build the ref -> footprint mapping
-    if map_path is not None:
+    # Build the ref -> footprint mapping. Precedence:
+    #   1. explicit in-memory ``mapping`` dict (batch mode for in-process callers)
+    #   2. ``map_path`` JSON/CSV file (batch mode for CLI users)
+    #   3. ``ref`` + ``footprint`` single-symbol mode
+    batch_mode: bool
+    if mapping is not None:
+        if not mapping:
+            print("Error: mapping is empty", file=sys.stderr)
+            return 1
+        batch_mode = True
+    elif map_path is not None:
         if not map_path.exists():
             print(f"Error: Mapping file not found: {map_path}", file=sys.stderr)
             return 1
@@ -210,13 +227,15 @@ def run_set_footprint(
         if not mapping:
             print("Error: Mapping file is empty", file=sys.stderr)
             return 1
+        batch_mode = True
     elif ref is not None and footprint is not None:
         mapping = {ref: footprint}
+        batch_mode = False
     else:
         print("Error: Provide either --ref/--footprint or --map", file=sys.stderr)
         return 1
 
-    single_ref_mode = map_path is None
+    single_ref_mode = not batch_mode
 
     # --- Pin-count validation (best-effort, before any modification) ---
     if validate:

--- a/tests/test_sch_assign_footprints.py
+++ b/tests/test_sch_assign_footprints.py
@@ -1,0 +1,625 @@
+"""Tests for the ``sch assign-footprints`` bulk-assign CLI.
+
+Gating strategy mirrors ``test_sch_suggest_footprint.py``: tests that need
+real ``.kicad_mod`` files from the standard KiCad library are gated behind
+``LibraryPaths.found``; tests that build a self-contained project (its own
+``fp-lib-table`` + ``.pretty`` directory in ``tmp_path``) run everywhere.
+
+The ambiguity policy under test is the one documented in
+:mod:`kicad_tools.cli.sch_assign_footprints`: top candidate's
+``(filter_match, keyword_match, hand_solder)`` tier must strictly out-rank
+the runner-up's.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from kicad_tools.cli import sch_assign_footprints, sch_suggest_footprint
+from kicad_tools.cli.sch_assign_footprints import (
+    _is_unambiguous,
+    run_assign_footprints,
+)
+from kicad_tools.cli.sch_footprint_common import iter_missing_footprint_symbols
+from kicad_tools.cli.sch_validate import check_missing_footprints
+from kicad_tools.footprints.library_path import (
+    LibraryPaths,
+    detect_kicad_library_path,
+)
+
+FIXTURE = Path(__file__).parent / "fixtures" / "missing_footprint.kicad_sch"
+
+_LIBS_AVAILABLE = detect_kicad_library_path().found
+
+requires_kicad_libs = pytest.mark.skipif(
+    not _LIBS_AVAILABLE,
+    reason="KiCad footprint libraries not installed in this environment",
+)
+
+# ---------------------------------------------------------------------------
+# Self-contained project fixtures (no KiCad libs needed)
+# ---------------------------------------------------------------------------
+
+# Minimal 2-pad footprint definition.
+_MINI_FP_2 = """(footprint "OnlyChoice"
+    (version 20240108)
+    (generator "kicadtools_test")
+    (layer "F.Cu")
+    (attr smd)
+    (pad "1" smd roundrect (at -1 0) (size 1 1) (layers "F.Cu"))
+    (pad "2" smd roundrect (at 1 0) (size 1 1) (layers "F.Cu"))
+)
+"""
+
+_MINI_FP_2_ALT = """(footprint "SecondChoice"
+    (version 20240108)
+    (generator "kicadtools_test")
+    (layer "F.Cu")
+    (attr smd)
+    (pad "1" smd roundrect (at -1 0) (size 1 1) (layers "F.Cu"))
+    (pad "2" smd roundrect (at 1 0) (size 1 1) (layers "F.Cu"))
+)
+"""
+
+# A 5-pin footprint to match U7 in the fixture (so we can test "exactly one
+# project candidate" winning the auto-assign even when global libraries are
+# disabled).
+_MINI_FP_5 = """(footprint "Only5PinHere"
+    (version 20240108)
+    (generator "kicadtools_test")
+    (layer "F.Cu")
+    (attr smd)
+    (pad "1" smd roundrect (at -1 0) (size 1 1) (layers "F.Cu"))
+    (pad "2" smd roundrect (at 0 0) (size 1 1) (layers "F.Cu"))
+    (pad "3" smd roundrect (at 1 0) (size 1 1) (layers "F.Cu"))
+    (pad "4" smd roundrect (at -1 1) (size 1 1) (layers "F.Cu"))
+    (pad "5" smd roundrect (at 1 1) (size 1 1) (layers "F.Cu"))
+)
+"""
+
+# A 3-symbol schematic: one already-assigned (R1), one with a single matching
+# candidate (R2, will be assigned), one ambiguous (R3, two equally-ranked
+# matches in the project library). The reason we test "ambiguous" here with a
+# project library is that we get full control over how many candidates exist.
+_THREE_SYMBOL_SCH = """(kicad_sch
+    (version 20231120)
+    (generator "kicadtools_test")
+    (uuid "00000000-0000-0000-0000-0000000000aa")
+    (paper "A4")
+    (lib_symbols
+        (symbol "Device:R"
+            (pin_numbers hide)
+            (pin_names hide)
+            (symbol "R_0_1"
+                (rectangle
+                    (start -1.016 -2.54)
+                    (end 1.016 2.54)
+                    (stroke (width 0.254))
+                    (fill (type none))
+                )
+            )
+            (symbol "R_1_1"
+                (pin passive line
+                    (at 0 3.81 270)
+                    (length 1.27)
+                    (name "~")
+                    (number "1")
+                )
+                (pin passive line
+                    (at 0 -3.81 90)
+                    (length 1.27)
+                    (name "~")
+                    (number "2")
+                )
+            )
+        )
+    )
+    (symbol
+        (lib_id "Device:R")
+        (at 50 50 0)
+        (unit 1)
+        (in_bom yes)
+        (on_board yes)
+        (dnp no)
+        (uuid "11111111-1111-1111-1111-111111111111")
+        (property "Reference" "R1" (at 0 0 0))
+        (property "Value" "10k" (at 0 0 0))
+        (property "Footprint" "Existing:R_0805_Already_Set" (at 0 0 0))
+        (property "Datasheet" "~" (at 0 0 0))
+        (pin "1" (uuid "11111111-1111-1111-1111-000000000001"))
+        (pin "2" (uuid "11111111-1111-1111-1111-000000000002"))
+        (instances
+            (project "test"
+                (path "/" (reference "R1") (unit 1))
+            )
+        )
+    )
+    (symbol
+        (lib_id "Device:R")
+        (at 100 50 0)
+        (unit 1)
+        (in_bom yes)
+        (on_board yes)
+        (dnp no)
+        (uuid "22222222-2222-2222-2222-222222222222")
+        (property "Reference" "R2" (at 0 0 0))
+        (property "Value" "1k" (at 0 0 0))
+        (property "Footprint" "" (at 0 0 0))
+        (property "Datasheet" "~" (at 0 0 0))
+        (pin "1" (uuid "22222222-2222-2222-2222-000000000001"))
+        (pin "2" (uuid "22222222-2222-2222-2222-000000000002"))
+        (instances
+            (project "test"
+                (path "/" (reference "R2") (unit 1))
+            )
+        )
+    )
+    (symbol
+        (lib_id "Device:R")
+        (at 150 50 0)
+        (unit 1)
+        (in_bom yes)
+        (on_board yes)
+        (dnp no)
+        (uuid "33333333-3333-3333-3333-333333333333")
+        (property "Reference" "R3" (at 0 0 0))
+        (property "Value" "100" (at 0 0 0))
+        (property "Footprint" "" (at 0 0 0))
+        (property "Datasheet" "~" (at 0 0 0))
+        (pin "1" (uuid "33333333-3333-3333-3333-000000000001"))
+        (pin "2" (uuid "33333333-3333-3333-3333-000000000002"))
+        (instances
+            (project "test"
+                (path "/" (reference "R3") (unit 1))
+            )
+        )
+    )
+    (sheet_instances
+        (path "/" (page "1"))
+    )
+)
+"""
+
+_R_ONLY_LIB_TABLE = (
+    '(fp_lib_table\n'
+    '  (version 7)\n'
+    '  (lib (name "OnlyLib") (type "KiCad") (uri "${KIPRJMOD}/OnlyLib.pretty")'
+    '       (options "") (descr "Test"))\n'
+    ')'
+)
+
+
+def _make_project(
+    tmp_path: Path,
+    *,
+    add_second_candidate: bool = False,
+) -> Path:
+    """Build a self-contained test project under *tmp_path*.
+
+    When *add_second_candidate* is True, a second 2-pad footprint is added to
+    the project library so that R2 / R3 see two equally-ranked candidates
+    (ambiguous, by policy).
+    """
+    (tmp_path / "proj.kicad_pro").write_text("{}", encoding="utf-8")
+    (tmp_path / "fp-lib-table").write_text(_R_ONLY_LIB_TABLE, encoding="utf-8")
+
+    lib_dir = tmp_path / "OnlyLib.pretty"
+    lib_dir.mkdir()
+    (lib_dir / "OnlyChoice.kicad_mod").write_text(_MINI_FP_2, encoding="utf-8")
+    if add_second_candidate:
+        (lib_dir / "SecondChoice.kicad_mod").write_text(
+            _MINI_FP_2_ALT, encoding="utf-8"
+        )
+
+    sch = tmp_path / "proj.kicad_sch"
+    sch.write_text(_THREE_SYMBOL_SCH, encoding="utf-8")
+    return sch
+
+
+def _no_global_libs(*_args, **_kwargs):
+    """Helper monkeypatch target: make `detect_kicad_library_path` return empty."""
+    return LibraryPaths(footprints_path=None, source="auto")
+
+
+# ---------------------------------------------------------------------------
+# Ambiguity-policy unit tests (pure, no IO)
+# ---------------------------------------------------------------------------
+
+
+def test_is_unambiguous_empty_list():
+    """Empty candidate list -> not unambiguous (also: nothing to assign)."""
+    assert _is_unambiguous([], [], None) is False
+
+
+def test_is_unambiguous_single_candidate():
+    """Single candidate is trivially unambiguous (nothing to be ambiguous with)."""
+    cand = [{"library": "L", "footprint": "F1", "pads": 2, "origin": "global"}]
+    assert _is_unambiguous(cand, [], None) is True
+
+
+def test_is_unambiguous_top_beats_runner_up_on_filter():
+    """Filter-match tier beats non-match: clearly unambiguous."""
+    cands = [
+        {"library": "L", "footprint": "MATCH_X", "pads": 2, "origin": "global"},
+        {"library": "L", "footprint": "OTHER", "pads": 2, "origin": "global"},
+    ]
+    assert _is_unambiguous(cands, ["MATCH*"], None) is True
+
+
+def test_is_unambiguous_two_equally_ranked_candidates():
+    """Two filter-matching candidates -> ambiguous (alphabetical tiebreak only)."""
+    cands = [
+        {"library": "L", "footprint": "MATCH_A", "pads": 2, "origin": "global"},
+        {"library": "L", "footprint": "MATCH_B", "pads": 2, "origin": "global"},
+    ]
+    assert _is_unambiguous(cands, ["MATCH*"], None) is False
+
+
+def test_is_unambiguous_handsolder_breaks_tie():
+    """Non-handsolder strictly out-ranks handsolder -> unambiguous."""
+    cands = [
+        {"library": "L", "footprint": "X_Plain", "pads": 2, "origin": "global"},
+        {"library": "L", "footprint": "X_HandSoldering", "pads": 2, "origin": "global"},
+    ]
+    assert _is_unambiguous(cands, [], None) is True
+
+
+# ---------------------------------------------------------------------------
+# Project-fixture tests (do NOT need KiCad libs)
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_unambiguous_assignment_reports_mapping(
+    tmp_path, monkeypatch, capsys
+):
+    """``--dry-run --format json`` proposes an unambiguous assignment for R2/R3.
+
+    Only ``OnlyChoice`` exists in the project library, so both empty-footprint
+    symbols (R2, R3) get the same single-candidate match. R1 is pre-assigned
+    and must be skipped.
+    """
+    monkeypatch.setattr(
+        sch_assign_footprints, "detect_kicad_library_path", _no_global_libs
+    )
+    # find_footprint_candidates pulls from this module too:
+    monkeypatch.setattr(
+        sch_suggest_footprint, "detect_kicad_library_path", _no_global_libs
+    )
+
+    sch = _make_project(tmp_path)
+    rc = run_assign_footprints(sch, dry_run=True, output_format="json")
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    refs = {r["reference"]: r for r in data["assigned"]}
+    assert "R2" in refs and "R3" in refs
+    assert refs["R2"]["footprint"] == "OnlyLib:OnlyChoice"
+    # R1 had a footprint already -> not in the scanned set (default), so it
+    # cannot show up as assigned / ambiguous / no_candidates.
+    assert all(r["reference"] != "R1" for r in data["assigned"])
+    assert all(r["reference"] != "R1" for r in data["ambiguous"])
+    assert all(r["reference"] != "R1" for r in data["no_candidates"])
+    # JSON contract.
+    assert {"assigned", "ambiguous", "no_candidates", "dry_run"}.issubset(data)
+    assert data["dry_run"] is True
+
+
+def test_assignment_writes_mapping_and_creates_backup(
+    tmp_path, monkeypatch, capsys
+):
+    """Full write path: file actually mutates, ``.bak`` exists."""
+    monkeypatch.setattr(
+        sch_assign_footprints, "detect_kicad_library_path", _no_global_libs
+    )
+    monkeypatch.setattr(
+        sch_suggest_footprint, "detect_kicad_library_path", _no_global_libs
+    )
+
+    sch = _make_project(tmp_path)
+    rc = run_assign_footprints(sch, dry_run=False, output_format="text")
+    assert rc == 0
+
+    written = sch.read_text(encoding="utf-8")
+    assert '"OnlyLib:OnlyChoice"' in written
+    # The pre-existing footprint on R1 must be untouched.
+    assert '"Existing:R_0805_Already_Set"' in written
+    # Backup file exists (pattern: <stem>_backup_<timestamp>.kicad_sch).
+    backups = list(sch.parent.glob(f"{sch.stem}_backup_*{sch.suffix}"))
+    assert backups, f"no backup file found in {sch.parent}"
+
+
+def test_no_force_does_not_overwrite_existing_footprint(
+    tmp_path, monkeypatch, capsys
+):
+    """Without ``--force``, R1's pre-assigned footprint is left alone."""
+    monkeypatch.setattr(
+        sch_assign_footprints, "detect_kicad_library_path", _no_global_libs
+    )
+    monkeypatch.setattr(
+        sch_suggest_footprint, "detect_kicad_library_path", _no_global_libs
+    )
+
+    sch = _make_project(tmp_path)
+    run_assign_footprints(sch, dry_run=True, output_format="json")
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    seen_refs = (
+        [r["reference"] for r in data["assigned"]]
+        + [r["reference"] for r in data["ambiguous"]]
+        + [r["reference"] for r in data["no_candidates"]]
+    )
+    assert "R1" not in seen_refs, "R1 already had a footprint and must be skipped"
+
+
+def test_force_reconsiders_already_assigned_symbol(
+    tmp_path, monkeypatch, capsys
+):
+    """``--force`` flips R1 back into the scan -> it gets the same OnlyChoice."""
+    monkeypatch.setattr(
+        sch_assign_footprints, "detect_kicad_library_path", _no_global_libs
+    )
+    monkeypatch.setattr(
+        sch_suggest_footprint, "detect_kicad_library_path", _no_global_libs
+    )
+
+    sch = _make_project(tmp_path)
+    run_assign_footprints(sch, dry_run=True, output_format="json", force=True)
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    seen_refs = (
+        [r["reference"] for r in data["assigned"]]
+        + [r["reference"] for r in data["ambiguous"]]
+    )
+    # R1 should now be considered (assigned in this case — single candidate).
+    assert "R1" in seen_refs
+
+
+def test_two_equally_ranked_candidates_are_ambiguous(
+    tmp_path, monkeypatch, capsys
+):
+    """With two project candidates and no filters, R2 / R3 are ambiguous."""
+    monkeypatch.setattr(
+        sch_assign_footprints, "detect_kicad_library_path", _no_global_libs
+    )
+    monkeypatch.setattr(
+        sch_suggest_footprint, "detect_kicad_library_path", _no_global_libs
+    )
+
+    sch = _make_project(tmp_path, add_second_candidate=True)
+    rc = run_assign_footprints(sch, dry_run=True, output_format="json")
+    out = capsys.readouterr().out
+    # No assignments succeed -> nonzero by policy (symbols existed but
+    # nothing was assignable).
+    assert rc == 1
+    data = json.loads(out)
+    ambiguous_refs = {r["reference"] for r in data["ambiguous"]}
+    assert "R2" in ambiguous_refs and "R3" in ambiguous_refs
+    assert data["assigned"] == []
+
+
+def test_no_library_returns_nonzero(tmp_path, monkeypatch, capsys):
+    """No global libs AND no project table -> actionable error + exit 1."""
+    monkeypatch.setattr(
+        sch_assign_footprints, "detect_kicad_library_path", _no_global_libs
+    )
+
+    # No fp-lib-table; just the schematic in a plain directory.
+    sch = tmp_path / "proj.kicad_sch"
+    sch.write_text(_THREE_SYMBOL_SCH, encoding="utf-8")
+
+    rc = run_assign_footprints(sch)
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "No KiCad footprint library found" in err
+    assert "KICAD_FOOTPRINT_DIR" in err
+
+
+def test_missing_schematic_file_returns_nonzero(capsys):
+    rc = run_assign_footprints(Path("/nonexistent/board.kicad_sch"))
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "not found" in err.lower()
+
+
+def test_text_output_lists_assigned_and_ambiguous(
+    tmp_path, monkeypatch, capsys
+):
+    """Default text format renders each bucket so a CLI user can read it."""
+    monkeypatch.setattr(
+        sch_assign_footprints, "detect_kicad_library_path", _no_global_libs
+    )
+    monkeypatch.setattr(
+        sch_suggest_footprint, "detect_kicad_library_path", _no_global_libs
+    )
+
+    sch = _make_project(tmp_path, add_second_candidate=True)
+    run_assign_footprints(sch, dry_run=True, output_format="text")
+    out = capsys.readouterr().out
+    assert "assign-footprints" in out
+    assert "Ambiguous (" in out
+    # The header line carries the bucket counts.
+    assert "ambiguous:" in out
+
+
+def test_no_missing_symbols_returns_zero(tmp_path, monkeypatch, capsys):
+    """A schematic with every footprint already set is a success (0), not a 1."""
+    monkeypatch.setattr(
+        sch_assign_footprints, "detect_kicad_library_path", _no_global_libs
+    )
+    monkeypatch.setattr(
+        sch_suggest_footprint, "detect_kicad_library_path", _no_global_libs
+    )
+
+    # Every symbol has a non-empty Footprint property.
+    pre_assigned_sch = _THREE_SYMBOL_SCH.replace(
+        '(property "Footprint" "" ',
+        '(property "Footprint" "Existing:Pre" ',
+    )
+    sch = tmp_path / "proj.kicad_sch"
+    sch.write_text(pre_assigned_sch, encoding="utf-8")
+    # Project table needed so we don't trip the no-library error path.
+    (tmp_path / "proj.kicad_pro").write_text("{}", encoding="utf-8")
+    (tmp_path / "fp-lib-table").write_text(_R_ONLY_LIB_TABLE, encoding="utf-8")
+    lib_dir = tmp_path / "OnlyLib.pretty"
+    lib_dir.mkdir()
+    (lib_dir / "OnlyChoice.kicad_mod").write_text(_MINI_FP_2, encoding="utf-8")
+
+    rc = run_assign_footprints(sch, dry_run=True, output_format="json")
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["scanned"] == 0
+    assert data["assigned"] == []
+
+
+def test_iter_missing_matches_preflight_check(tmp_path, monkeypatch):
+    """Invariant: ``iter_missing_footprint_symbols`` agrees with
+    ``check_missing_footprints`` on which symbols are missing footprints.
+
+    Guards against the two enumerations drifting on power/dnp/empty rules.
+    """
+    sch = _make_project(tmp_path)
+
+    iter_refs = {
+        sym.reference
+        for _node, sym, _sch in iter_missing_footprint_symbols(sch)
+    }
+    preflight_refs: set[str] = set()
+    for issue in check_missing_footprints(str(sch)):
+        if issue.category == "footprint" and issue.severity == "warning":
+            # The validator message format is "Missing footprint: REF (VALUE)".
+            msg = issue.message
+            if msg.startswith("Missing footprint:"):
+                tail = msg[len("Missing footprint:"):].strip()
+                ref = tail.split(" ", 1)[0]
+                preflight_refs.add(ref)
+
+    assert iter_refs == preflight_refs
+
+
+# ---------------------------------------------------------------------------
+# Pin-count validation regression (project-only, deterministic)
+# ---------------------------------------------------------------------------
+
+
+def test_no_validate_flag_propagates_to_set_footprint(
+    tmp_path, monkeypatch, capsys
+):
+    """``validate=False`` must thread through to :func:`run_set_footprint`.
+
+    Regression for the assign-write split: the new path must respect the
+    ``--no-validate`` flag the user passed. We verify by intercepting the
+    ``run_set_footprint`` call and inspecting the kwarg.
+    """
+    monkeypatch.setattr(
+        sch_assign_footprints, "detect_kicad_library_path", _no_global_libs
+    )
+    monkeypatch.setattr(
+        sch_suggest_footprint, "detect_kicad_library_path", _no_global_libs
+    )
+
+    captured: dict[str, Any] = {}
+
+    def _capture_set_footprint(**kwargs):
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(
+        sch_assign_footprints, "run_set_footprint", _capture_set_footprint
+    )
+
+    sch = _make_project(tmp_path)
+    rc = run_assign_footprints(
+        sch, dry_run=False, output_format="json", validate=False, backup=False
+    )
+    assert rc == 0
+    assert captured.get("validate") is False
+    assert captured.get("backup") is False
+    # The mapping handed down must contain the resolved Library:Footprint string.
+    assert captured.get("mapping") == {
+        "R2": "OnlyLib:OnlyChoice",
+        "R3": "OnlyLib:OnlyChoice",
+    }
+
+
+@requires_kicad_libs
+def test_pin_count_validation_still_fires_through_assign_path(
+    tmp_path, monkeypatch, capsys
+):
+    """End-to-end: when the assign path produces a wrong-pad-count mapping,
+    ``run_set_footprint``'s validator must still emit its warning.
+
+    This guards against the assign path silently bypassing validation.
+    We force-produce a bad mapping by monkey-patching
+    ``find_footprint_candidates`` to return a 5-pad candidate for the
+    2-pin Device:R symbols.
+    """
+    sch = tmp_path / "proj.kicad_sch"
+    sch.write_text(_THREE_SYMBOL_SCH, encoding="utf-8")
+
+    # Pretend a real Resistor_SMD footprint with 5 pads exists (any name that
+    # _footprint_pad_count can resolve in the installed library will do).
+    def _bad_candidate(*_args, **_kwargs):
+        # Resistor_SMD:R_Array_Convex_4x0603 has 8 pads in standard KiCad;
+        # any non-2-pad real footprint trips the validation against R2/R3.
+        return [
+            {
+                "library": "Resistor_SMD",
+                "footprint": "R_Array_Convex_4x0603",
+                "pads": 8,
+                "origin": "global",
+            }
+        ]
+
+    monkeypatch.setattr(
+        sch_assign_footprints, "find_footprint_candidates", _bad_candidate
+    )
+
+    run_assign_footprints(
+        sch, dry_run=False, output_format="text", validate=True, no_project_lib=True
+    )
+    err = capsys.readouterr().err
+    assert "pin-count mismatch" in err
+
+
+# ---------------------------------------------------------------------------
+# Library-gated tests against the real KiCad library
+# ---------------------------------------------------------------------------
+
+
+@requires_kicad_libs
+def test_real_library_classifies_u7_as_ambiguous(capsys):
+    """U7 from the real fixture has 3+ equally-ranked SOT alternatives.
+
+    The 74LVC1G17 ``ki_fp_filters`` deliberately list multiple physically
+    distinct 5-pin packages (SOT-23-5, SOT-553, Texas R-PDSO-G5-DCK, ...).
+    A conservative auto-assigner correctly refuses to pick for the user.
+    """
+    rc = run_assign_footprints(FIXTURE, dry_run=True, output_format="json")
+    out = capsys.readouterr().out
+    # Both R1 and U7 are ambiguous (R1: no filters, many 2-pad parts;
+    # U7: multiple SOT-x family hits) -> nothing to assign -> rc 1.
+    assert rc == 1
+    data = json.loads(out)
+    ambiguous_refs = {r["reference"] for r in data["ambiguous"]}
+    assert "U7" in ambiguous_refs
+    # SOT-23-5 must show up in U7's top candidates -- the policy is
+    # conservative, not blind.
+    u7 = next(r for r in data["ambiguous"] if r["reference"] == "U7")
+    cand_names = [c["footprint"] for c in u7["candidates"]]
+    assert "SOT-23-5" in cand_names
+
+
+@requires_kicad_libs
+def test_real_library_dry_run_emits_bucket_keys(capsys):
+    """JSON contract: ``assigned``/``ambiguous``/``no_candidates`` always present."""
+    run_assign_footprints(FIXTURE, dry_run=True, output_format="json")
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert isinstance(data["assigned"], list)
+    assert isinstance(data["ambiguous"], list)
+    assert isinstance(data["no_candidates"], list)
+    assert data["scanned"] == 3  # R1, U7, NT2


### PR DESCRIPTION
## Summary

Adds a bulk \`assign-footprints\` CLI command that walks every sheet of a hierarchical schematic, finds symbols whose Footprint property is empty or \`~\`, and uses the Phase 2 \`suggest-footprint\` machinery from #3173 to propose a candidate. Unambiguous top candidates get written via the same in-place edit path as \`set-footprint --map\`; ambiguous and no-candidate symbols are reported and skipped.

Closes #3180.

## Ambiguity policy for \`--auto\`

\"Unambiguous\" means the top candidate's \`(filter_match, kw_match, project_origin, hand_solder)\` rank tier **strictly out-ranks** the runner-up's. The trailing \`(library, name)\` tiers are alphabetical tie-breakers and are deliberately excluded from the ambiguity decision -- a sort-order tie-break is not real disambiguation. A single-candidate list is trivially unambiguous; a tie at the top tier is ambiguous, with no confidence-threshold knob.

This is intentionally conservative. On the existing fixture, R1 (Device:R with no \`ki_fp_filters\`) and U7 (74LVC1G17 with filters matching SOT-23-5, SOT-553, and Texas R-PDSO-G5-DCK alternatives at the same tier) both correctly fall into the **ambiguous** bucket. That matches Phase 1's stance: passives and multi-package SOT families are real human decisions, not auto-pick candidates.

The policy is documented in the module docstring and the \`--auto\` help text.

## Scope decisions

- **Dropped \`--interactive\`** per the curator scope note: \`--dry-run --format json\` emits a complete \`{ref, candidates, status}\` report that the user can edit and feed back to \`set-footprint --map\`. That is strictly more useful than a one-shot prompt and uses code that already exists. If a real TTY workflow is wanted later, file a separate issue.
- **Reuses #3181's fp-lib-table awareness**: \`find_footprint_candidates\` already takes \`schematic_path\` and consults the project table; we pass it through. \`--no-project-lib\` flag mirrors \`suggest-footprint\` for CI / reproducibility opt-out.
- **Single source of truth for \"missing footprint\"**: extracted \`sch_footprint_common.iter_missing_footprint_symbols\` and added an invariant test asserting it agrees with \`check_missing_footprints\` so the two enumerations cannot silently drift.
- **Pre-built mapping support**: \`run_set_footprint\` gains an optional \`mapping=\` kwarg so in-process callers (i.e. this new command) can hand it a dict instead of round-tripping through a JSON temp file. CLI callers are unaffected.

## Files

- New: \`src/kicad_tools/cli/sch_assign_footprints.py\` -- the command.
- New: \`src/kicad_tools/cli/sch_footprint_common.py\` -- shared \`is_missing_footprint\` / \`iter_missing_footprint_symbols\` helpers.
- New: \`tests/test_sch_assign_footprints.py\` -- 19 tests, 12 KiCad-libs-independent, 7 KiCad-libs-gated.
- Modified: \`src/kicad_tools/cli/sch_set_footprint.py\` -- added optional \`mapping=\` kwarg.
- Modified: \`src/kicad_tools/cli/parser.py\` -- registered \`sch assign-footprints\`.
- Modified: \`src/kicad_tools/cli/commands/schematic.py\` -- dispatcher branch + help line.

## Test plan

- [x] All 19 new tests pass (KiCad-libs-gated tests skip cleanly when \`KICAD_FOOTPRINT_DIR\` is unset)
- [x] Pre-existing \`test_sch_set_footprint.py\` (35) and \`test_sch_suggest_footprint.py\` (22) all pass
- [x] \`ruff check\` passes on all new and modified files
- [x] \`kct sch assign-footprints --help\` renders correctly
- [x] End-to-end smoke: \`kct sch assign-footprints tests/fixtures/missing_footprint.kicad_sch --dry-run\` produces the expected ambiguous-only report