### PR TITLE
fix(board-02): route_demo.py uses kct route subprocess (closes #3207)

### DIFF
--- a/boards/02-charlieplex-led/route_demo.py
+++ b/boards/02-charlieplex-led/route_demo.py
@@ -2,11 +2,24 @@
 """
 Demonstrate autorouting on the charlieplexed LED grid PCB.
 
-This script:
-1. Loads the generated PCB file
-2. Creates an Autorouter instance
-3. Routes all nets
-4. Saves the routed result
+This script invokes ``kct route`` with the proven flag recipe used by
+``generate_design.py:route_pcb()``.  Using the orchestrator path
+(rather than a bare in-process ``router.route_all()`` call) is what
+unlocks ≥ 8/10 nets DRC-clean on this geometry, because ``kct route``:
+
+  1. uses the negotiated congestion router with adaptive rip-up,
+  2. emits auto-pour zones for GND/VCC after routing (so power pads
+     reach ``status=complete`` via plane connectivity),
+  3. runs auto-layer-escalation when 1-layer routing is blocked, and
+  4. runs ``drc_verify_and_nudge`` post-route (Issue #3112) to slide
+     same-net via-in-pad escape vias off offending pads.
+
+Issue #3207: this script previously called the bare ``router.route_all()``
+in-process path, which regressed to 4/8 nets routed with 6 DRC errors
+on board 02 even though ``kct route`` direct on the same PCB reaches
+8/10 + DRC-clean.  Replacing the in-process path with a subprocess
+call to ``kct route`` (matching ``generate_design.py:route_pcb()``)
+guarantees the two recipes can't drift again.
 
 Usage:
     python route_demo.py [input_pcb] [output_pcb]
@@ -16,7 +29,6 @@ Example:
 """
 
 import contextlib
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -25,8 +37,6 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 
 from kicad_tools.dev import warn_if_stale
-from kicad_tools.router import DesignRules, load_pcb_for_routing, show_routing_summary
-from kicad_tools.router.optimizer import GridCollisionChecker, OptimizationConfig, TraceOptimizer
 
 # Warn if running source scripts with stale pipx install
 warn_if_stale()
@@ -66,27 +76,31 @@ def run_drc(pcb_path: Path) -> tuple[bool, int, int]:
         return False, -1, -1
 
 
-def _get_routing_params() -> dict[str, float]:
-    """Get routing parameters from environment variables (set by kct build) or defaults.
+def _parse_routed_net_count(stdout: str) -> tuple[int, int] | None:
+    """Extract ``Nets routed: N/M`` (or equivalent) from ``kct route`` output.
 
-    When run via 'kct build', routing parameters from project.kct are passed as
-    environment variables. This allows custom route scripts to use project settings
-    while still supporting standalone execution with defaults.
+    ``kct route`` emits a summary block of the form::
 
-    Returns:
-        Dict with grid_resolution, trace_width, trace_clearance, via_drill, via_diameter
+        Nets routed: 8/10
+        ...
+
+    Returns ``(routed, total)`` or ``None`` if no match.
     """
-    return {
-        "grid_resolution": float(os.environ.get("KCT_ROUTE_GRID", "0.1")),
-        "trace_width": float(os.environ.get("KCT_ROUTE_TRACE_WIDTH", "0.3")),
-        "trace_clearance": float(os.environ.get("KCT_ROUTE_CLEARANCE", "0.2")),
-        "via_drill": float(os.environ.get("KCT_ROUTE_VIA_DRILL", "0.3")),
-        "via_diameter": float(os.environ.get("KCT_ROUTE_VIA_DIAMETER", "0.6")),
-    }
+    import re
+
+    for pattern in (
+        r"Nets routed:\s+(\d+)/(\d+)",
+        r"Routed\s+(\d+)/(\d+)\s+nets",
+        r"(\d+)/(\d+)\s+nets\s+complete",
+    ):
+        m = re.search(pattern, stdout)
+        if m:
+            return int(m.group(1)), int(m.group(2))
+    return None
 
 
 def main():
-    """Run the routing demo."""
+    """Run the routing demo via ``kct route`` (matching generate_design.py)."""
     # Parse arguments
     demo_dir = Path(__file__).parent
     input_pcb = sys.argv[1] if len(sys.argv) > 1 else "output/charlieplex_3x3.kicad_pcb"
@@ -106,111 +120,73 @@ def main():
     print(f"\nInput:  {input_path}")
     print(f"Output: {output_path}")
 
-    # Configure design rules for this board
-    # Parameters come from project.kct (via env vars when run by kct build)
-    # or fall back to sensible defaults for standalone execution
-    params = _get_routing_params()
-    rules = DesignRules(
-        grid_resolution=params["grid_resolution"],
-        trace_width=params["trace_width"],
-        trace_clearance=params["trace_clearance"],
-        via_drill=params["via_drill"],
-        via_diameter=params["via_diameter"],
-    )
+    # GND is a pour net (auto-poured into a copper zone by ``kct route``).
+    # Excluded from the per-net pathfinder to avoid wasted iterations.
+    # This matches ``generate_design.py:route_pcb()`` exactly.
+    skip_nets = ["GND"]
 
-    # Skip power nets (we won't route VCC/GND in this demo)
-    skip_nets = ["VCC", "GND"]
-
-    print("\n--- Loading PCB ---")
-    print(f"  Grid resolution: {rules.grid_resolution}mm")
-    print(f"  Trace width: {rules.trace_width}mm")
-    print(f"  Clearance: {rules.trace_clearance}mm")
-    print(f"  Skipping nets: {skip_nets}")
-
-    # Load the PCB and create autorouter
-    router, net_map = load_pcb_for_routing(
+    # Same recipe as ``boards/02-charlieplex-led/generate_design.py:route_pcb()``.
+    # Keeping these two recipes byte-identical is the whole point of Issue #3207:
+    # the in-process ``router.route_all()`` path drifted from the orchestrator
+    # path and silently regressed board 02 to 4/8 nets + 6 DRC errors.  This
+    # subprocess invocation re-uses the same code path that ``kct build``,
+    # ``kct route``, and the canonical board-05 / board-07 recipes use.
+    cmd = [
+        sys.executable,
+        "-m",
+        "kicad_tools.cli",
+        "route",
         str(input_path),
-        skip_nets=skip_nets,
-        rules=rules,
-    )
+        "--output",
+        str(output_path),
+        "--strategy",
+        "negotiated",
+        "--iterations",
+        "30",
+        "--per-net-timeout",
+        "30",
+        "--timeout",
+        "240",
+        "--seed",
+        "42",
+        "--skip-nets",
+        ",".join(skip_nets),
+        # Issue #3112: pass the manufacturer through so the post-route
+        # ``drc_verify_and_nudge`` sweep can consult ``via_in_pad_supported``
+        # and slide any same-net via-in-pad escape vias off the offending pad.
+        # The default jlcpcb profile does NOT support via-in-pad, so this is
+        # the case that exercises the sweep.
+        "--manufacturer",
+        "jlcpcb",
+    ]
 
-    print(f"\n  Board size: {router.grid.width}mm x {router.grid.height}mm")
-    print(f"  Nets loaded: {len(net_map)}")
-    print(f"  Nets to route: {len([n for n in router.nets if n > 0])}")
+    print("\n--- Routing via `kct route` (orchestrator path) ---")
+    print(f"  Skipping nets: {skip_nets}")
+    print(f"  Command: {' '.join(cmd)}")
 
-    # Route all nets using standard routing (DRC-safe)
-    print("\n--- Routing (standard mode) ---")
-    router.route_all()
+    # ``kct route`` streams its own progress output; do NOT capture it.
+    # It returns 0 on full success and a non-zero code on partial routing
+    # (in which case it still writes the partially-routed PCB).  We capture
+    # stdout for net-count parsing by tee-ing through subprocess.PIPE.
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    # Echo subprocess output so users can see routing progress, errors, etc.
+    if result.stdout:
+        print(result.stdout)
+    if result.stderr:
+        print(result.stderr, file=sys.stderr)
 
-    # Get statistics before optimization
-    stats_before = router.get_statistics()
+    if not output_path.exists():
+        print(
+            f"\nERROR: `kct route` did not produce {output_path} (exit code {result.returncode})",
+            file=sys.stderr,
+        )
+        return 1
 
-    print("\n--- Raw Results (before optimization) ---")
-    print(f"  Routes created: {stats_before['routes']}")
-    print(f"  Segments: {stats_before['segments']}")
-    print(f"  Vias: {stats_before['vias']}")
-    print(f"  Total length: {stats_before['total_length_mm']:.2f}mm")
-    print(f"  Nets routed: {stats_before['nets_routed']}")
+    # Parse the routed-net summary so the demo can print a final tally.
+    parsed = _parse_routed_net_count(result.stdout)
+    routed, total = parsed if parsed is not None else (None, None)
 
-    # Optimize traces - merge collinear segments, eliminate zigzags, etc.
-    # Use collision checker to prevent optimizations that create DRC violations
-    print("\n--- Optimizing traces ---")
-    opt_config = OptimizationConfig(
-        merge_collinear=True,
-        eliminate_zigzags=True,
-        compress_staircase=True,
-        convert_45_corners=True,
-        minimize_vias=True,
-    )
-    collision_checker = GridCollisionChecker(router.grid)
-    optimizer = TraceOptimizer(config=opt_config, collision_checker=collision_checker)
-
-    optimized_routes = []
-    for route in router.routes:
-        optimized_route = optimizer.optimize_route(route)
-        optimized_routes.append(optimized_route)
-    router.routes = optimized_routes
-
-    # Get statistics after optimization
-    stats = router.get_statistics()
-
-    segments_before = stats_before["segments"]
-    segments_after = stats["segments"]
-    reduction = (1 - segments_after / segments_before) * 100 if segments_before > 0 else 0
-
-    print(f"  Segments: {segments_before} -> {segments_after} ({reduction:.1f}% reduction)")
-    print(f"  Vias: {stats_before['vias']} -> {stats['vias']}")
-
-    print("\n--- Final Results ---")
-    print(f"  Routes created: {stats['routes']}")
-    print(f"  Segments: {stats['segments']}")
-    print(f"  Vias: {stats['vias']}")
-    print(f"  Total length: {stats['total_length_mm']:.2f}mm")
-    print(f"  Nets routed: {stats['nets_routed']}")
-
-    # Generate output PCB with routes
-    print("\n--- Saving routed PCB ---")
-
-    # Read original PCB content
-    original_content = input_path.read_text()
-
-    # Get route S-expressions
-    route_sexp = router.to_sexp()
-
-    # Insert routes before final closing parenthesis
-    if route_sexp:
-        output_content = original_content.rstrip().rstrip(")")
-        output_content += "\n"
-        output_content += f"  {route_sexp}\n"
-        output_content += ")\n"
-    else:
-        output_content = original_content
-        print("  Warning: No routes generated!")
-
-    output_path.write_text(output_content)
-    print(f"  Saved to: {output_path}")
-
-    # Run DRC validation
+    # Run DRC validation on the routed output.
     print("\n--- DRC Validation ---")
     drc_passed, drc_errors, drc_warnings = run_drc(output_path)
     if drc_passed:
@@ -224,16 +200,12 @@ def main():
 
     # Summary
     print("\n" + "=" * 60)
-    # Issue #2498: Restrict the routing-summary target population to multi-pad
-    # nets that are still routable post-skip.  ``router.nets`` reflects the
-    # state after ``load_pcb_for_routing`` rewrote skip-net pads to net=0, so
-    # this matches the convention used by ``cli/route_cmd.py`` and prevents
-    # skipped power nets (VCC/GND) from being mis-reported as "No path found".
-    multi_pad_net_ids = {
-        net_id for net_id, pads in router.nets.items() if net_id > 0 and len(pads) >= 2
-    }
-    total_nets = len(multi_pad_net_ids)
-    all_nets_routed = stats["nets_routed"] == total_nets
+    if parsed is None:
+        print("WARNING: Could not parse routed-net count from `kct route` output")
+        all_nets_routed = result.returncode == 0
+    else:
+        all_nets_routed = routed == total
+        print(f"Nets routed: {routed}/{total}")
 
     if all_nets_routed and drc_passed:
         print("SUCCESS: All nets routed, DRC passed!")
@@ -241,19 +213,15 @@ def main():
         print(f"WARNING: All nets routed, but {drc_errors} DRC violation(s) detected!")
         print("  Review DRC errors before manufacturing.")
     else:
-        print(f"PARTIAL: Routed {stats['nets_routed']}/{total_nets} nets")
+        if parsed is not None:
+            print(f"PARTIAL: Routed {routed}/{total} nets")
+        else:
+            print(f"PARTIAL: `kct route` exited with code {result.returncode}")
         if not drc_passed:
             print(f"  Additionally, {drc_errors} DRC violation(s) detected.")
-        # Show comprehensive routing summary with successes, failures, and suggestions
-        show_routing_summary(
-            router,
-            net_map,
-            total_nets,
-            nets_to_route_ids=multi_pad_net_ids,
-        )
     print("=" * 60)
 
-    # Return success only if all nets routed AND DRC passed
+    # Return success only if all nets routed AND DRC passed.
     return 0 if all_nets_routed and drc_passed else 1
 
 

--- a/tests/test_board02_route_demo_recipe.py
+++ b/tests/test_board02_route_demo_recipe.py
@@ -1,0 +1,294 @@
+"""Regression tests for ``boards/02-charlieplex-led/route_demo.py``.
+
+This module pins the recipe Issue #3207 ported into ``route_demo.py``
+so it cannot silently drift back to the bare ``router.route_all()``
+in-process path.
+
+**Background (Issue #3207, 2026-06-05):** board 02's documented recipe
+``route_demo.py`` (invoked by ``kct build --step route``) had regressed
+to **4/8 nets routed with 6 DRC errors** because it called the bare
+``router.route_all()`` in-process path.  The orchestrator path (``kct
+route`` direct on the placed PCB) achieves **8/8 signal nets routed,
+10/10 with auto-pour zones, DRC-clean** via
+``route_all_negotiated`` + ``--auto-layers`` + the post-route
+``drc_verify_and_nudge`` sweep added in #3112.
+
+The fix (this PR) replaces ``route_demo.py``'s in-process call with a
+subprocess invocation of ``kct route`` that mirrors the proven recipe
+already in ``generate_design.py:route_pcb()`` byte-for-byte.  Because
+the two recipes now share the same code path (``kct route``), they
+cannot drift again — the only way to break board 02 is to break
+``kct route`` itself, which has its own dense test coverage.
+
+The tests below pin the two load-bearing properties:
+
+* ``test_route_demo_invokes_orchestrator_path`` — the source file at
+  ``route_demo.py`` invokes ``kct route`` with the negotiated strategy
+  and matches the recipe in ``generate_design.py``.  Fast, no actual
+  routing run.
+* ``test_route_demo_achieves_minimum_completion`` — runs the script
+  end-to-end and asserts ≥ ``MIN_FULLY_ROUTED_NETS`` nets routed with
+  zero blocking DRC errors.  Slow (~30-60 s wall-clock) but bounded.
+
+References:
+- ``boards/02-charlieplex-led/route_demo.py`` -- the #3207 fix lives here
+- ``boards/02-charlieplex-led/generate_design.py:528`` -- canonical
+  ``route_pcb()`` recipe that the demo must mirror
+- ``src/kicad_tools/cli/build_cmd.py:1189`` -- ``route_demo.py``
+  invocation site (``kct build --step route``)
+- ``src/kicad_tools/router/core.py:4994`` -- the UserWarning that
+  bare ``route_all()`` emits, telling callers to migrate
+- Issue #3207 -- root-cause + acceptance criteria
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BOARD_DIR = REPO_ROOT / "boards" / "02-charlieplex-led"
+ROUTE_DEMO_SCRIPT = BOARD_DIR / "route_demo.py"
+GENERATE_DESIGN_SCRIPT = BOARD_DIR / "generate_design.py"
+OUTPUT_DIR = BOARD_DIR / "output"
+UNROUTED_PCB = OUTPUT_DIR / "charlieplex_3x3.kicad_pcb"
+ROUTED_PCB = OUTPUT_DIR / "charlieplex_3x3_routed.kicad_pcb"
+
+# Minimum number of signal nets ``route_demo.py`` must route on board 02.
+# Issue #3207 acceptance criterion #1: ">= 8/10 routed nets on board 02
+# with no blocking DRC errors".  Board 02 has 8 multi-pad signal nets
+# (NODE_A-D + ROW_1-3 + COL_1; GND/VCC are pour-net populated by
+# auto-pour and excluded from the per-net pathfinder).  Post-fix the
+# typical run completes 8/8.  Floor of 8 means any regression to the
+# pre-fix 4/8 state will fail this test immediately.
+MIN_FULLY_ROUTED_NETS = 8
+
+
+# ---------------------------------------------------------------------------
+# Static (fast) test: route_demo.py source uses the orchestrator path
+# ---------------------------------------------------------------------------
+
+
+def test_route_demo_invokes_kct_route_subprocess() -> None:
+    """``route_demo.py`` invokes ``kct route`` as a subprocess.
+
+    Issue #3207 regression guard: catches a future refactor that
+    re-introduces the bare ``router.route_all()`` in-process call.
+    The bare path emits a UserWarning at ``router/core.py:4994``
+    instructing callers to migrate to ``route_all_negotiated`` AND
+    silently falls back to a non-escalating, non-nudged 1-layer
+    pathfinder that only reaches 4/8 nets on this board's geometry.
+
+    The fix is to delegate to ``kct route``, which runs the full
+    ``route_all_negotiated`` + auto-layer-escalation +
+    ``drc_verify_and_nudge`` pipeline.  This test pins that delegation
+    by asserting the source file invokes ``kct route`` as a subprocess
+    with ``--strategy negotiated`` and DOES NOT call the legacy bare
+    ``router.route_all()`` entry point.
+    """
+    assert ROUTE_DEMO_SCRIPT.exists(), (
+        f"route_demo.py not found at {ROUTE_DEMO_SCRIPT!s} — board 02 "
+        "directory layout changed; update this test or the route script."
+    )
+    source = ROUTE_DEMO_SCRIPT.read_text()
+
+    # Positive: the script must invoke ``kct route`` via subprocess.
+    # Match the literal CLI invocation pattern used by both
+    # ``generate_design.py:route_pcb`` and the post-#3207 demo.
+    assert '"route"' in source or "'route'" in source, (
+        "route_demo.py does not invoke `kct route` — Issue #3207 fix is "
+        "missing.  Expected a subprocess.run([...,'-m','kicad_tools.cli',"
+        "'route',...]) call that mirrors generate_design.py:route_pcb()."
+    )
+    assert "kicad_tools.cli" in source, (
+        "route_demo.py does not invoke kicad_tools.cli as a module — "
+        "Issue #3207 fix expects ``[sys.executable, '-m', "
+        "'kicad_tools.cli', 'route', ...]``."
+    )
+    assert "negotiated" in source, (
+        "route_demo.py does not pass `--strategy negotiated` — the "
+        "negotiated congestion router with adaptive rip-up is what "
+        "unlocks 8/8 nets on board 02 (Issue #3207).  Without it the "
+        "default strategy regresses to 4/8."
+    )
+
+    # Negative: the bare in-process route_all() call must NOT reappear
+    # in *executable* code.  Match the specific call site
+    # (``router.route_all()`` with empty arglist) that #3207 fixed;
+    # allow the negotiated variant ``router.route_all_negotiated`` and
+    # the diff-pair variant which are legitimate in-process entry points.
+    #
+    # We parse with ``ast`` instead of regex so docstrings / comments /
+    # string literals (which may mention the deprecated entry point for
+    # historical context) don't false-positive the test.
+    import ast
+
+    tree = ast.parse(source)
+
+    class _BareRouteAllVisitor(ast.NodeVisitor):
+        """Find ``<something>.route_all()`` calls with zero arguments."""
+
+        def __init__(self) -> None:
+            self.found: list[tuple[int, str]] = []
+
+        def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+            func = node.func
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr == "route_all"
+                and not node.args
+                and not node.keywords
+            ):
+                self.found.append((node.lineno, ast.unparse(node)))
+            self.generic_visit(node)
+
+    visitor = _BareRouteAllVisitor()
+    visitor.visit(tree)
+    assert not visitor.found, (
+        "route_demo.py contains a bare ``.route_all()`` call (no "
+        "args) — this is the Issue #3207 regression.  Use a subprocess "
+        "invocation of ``kct route`` (matching "
+        "generate_design.py:route_pcb()) instead.  Found at: "
+        f"{visitor.found!r}"
+    )
+
+
+def test_route_demo_recipe_mirrors_generate_design() -> None:
+    """``route_demo.py`` and ``generate_design.py:route_pcb()`` use the
+    same flag recipe.
+
+    Issue #3207 acceptance criterion #4: the two recipes must call the
+    same underlying flags so they cannot drift again.  This test pins
+    that by checking the load-bearing flags appear in BOTH source files
+    with the same values.
+    """
+    assert ROUTE_DEMO_SCRIPT.exists(), f"route_demo.py missing: {ROUTE_DEMO_SCRIPT}"
+    assert GENERATE_DESIGN_SCRIPT.exists(), f"generate_design.py missing: {GENERATE_DESIGN_SCRIPT}"
+
+    demo_src = ROUTE_DEMO_SCRIPT.read_text()
+    design_src = GENERATE_DESIGN_SCRIPT.read_text()
+
+    # The flag/value pairs both scripts MUST send to ``kct route``.
+    # Keeping these in sync is the whole point of Issue #3207's "no
+    # drift" acceptance criterion.
+    required_flag_value_pairs = [
+        ("--strategy", "negotiated"),
+        ("--iterations", "30"),
+        ("--per-net-timeout", "30"),
+        ("--timeout", "240"),
+        ("--seed", "42"),
+        ("--manufacturer", "jlcpcb"),
+    ]
+
+    for flag, value in required_flag_value_pairs:
+        assert flag in demo_src, (
+            f"route_demo.py is missing flag {flag!r} — Issue #3207 "
+            f"recipe drift.  Mirror the flag from "
+            f"generate_design.py:route_pcb()."
+        )
+        assert flag in design_src, (
+            f"generate_design.py:route_pcb() is missing flag {flag!r}. "
+            f"If this changed intentionally, update route_demo.py to "
+            f"match and update this test's expected pairs."
+        )
+        # Sanity: both files should also reference the value somewhere
+        # near the flag.  We don't enforce strict positional adjacency
+        # (the CLI accepts ``--flag value`` and ``--flag=value``) so
+        # this is a coarse co-occurrence check.
+        assert value in demo_src, f"route_demo.py is missing value {value!r} for {flag!r}."
+        assert value in design_src, f"generate_design.py is missing value {value!r} for {flag!r}."
+
+
+# ---------------------------------------------------------------------------
+# End-to-end test: run route_demo.py and assert routing completion floor
+# ---------------------------------------------------------------------------
+
+
+def _parse_routed_net_count(stdout: str) -> tuple[int, int] | None:
+    """Extract ``Nets routed: N/M`` (or equivalent) from ``kct route`` output.
+
+    ``kct route`` (and route_demo.py's own summary block) emits a line
+    of the form::
+
+        Nets routed: 8/8
+
+    or, on partial routing::
+
+        PARTIAL: Routed 8/8 nets
+
+    Returns ``(routed, total)`` or ``None`` if no match.
+    """
+    for pattern in (
+        r"Nets routed:\s+(\d+)/(\d+)",
+        r"Routed\s+(\d+)/(\d+)\s+nets",
+        r"(\d+)/(\d+)\s+nets\s+complete",
+    ):
+        m = re.search(pattern, stdout)
+        if m:
+            return int(m.group(1)), int(m.group(2))
+    return None
+
+
+@pytest.fixture(scope="module")
+def unrouted_pcb_present() -> Path:
+    """Verify the committed unrouted board 02 PCB exists for the demo to consume."""
+    if not UNROUTED_PCB.exists():
+        pytest.skip(
+            f"Board 02 unrouted PCB not found at {UNROUTED_PCB!s}; "
+            "regenerate via `python3 boards/02-charlieplex-led/generate_pcb.py`."
+        )
+    return UNROUTED_PCB
+
+
+def test_route_demo_achieves_minimum_completion(unrouted_pcb_present: Path) -> None:
+    """``route_demo.py`` routes at least ``MIN_FULLY_ROUTED_NETS`` signal nets.
+
+    Issue #3207 acceptance criterion #1: ">= 8/10 routed nets on board
+    02 with no blocking DRC errors".  Pre-fix the in-process bare
+    ``router.route_all()`` path completed 4/8.  Post-fix the orchestrator
+    path consistently completes 8/8.
+
+    A hard timeout of 300 s guards against router hangs.  Board 02 is
+    small (~37 mm x ~22 mm) so the negotiated routing typically finishes
+    in 10-15 s; the timeout is conservative.
+    """
+    proc = subprocess.run(
+        [sys.executable, str(ROUTE_DEMO_SCRIPT)],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+        cwd=str(BOARD_DIR),
+    )
+
+    # ``route_demo.py`` returns 0 on full success + DRC-clean, 1 on
+    # partial routing or DRC errors.  Either exit code is acceptable
+    # here -- we pin routing completion, not exit-code semantics.
+    assert proc.returncode in (0, 1), (
+        f"route_demo.py returned unexpected exit code {proc.returncode}\n"
+        f"stdout (last 4000 chars):\n{proc.stdout[-4000:]}\n"
+        f"stderr (last 2000 chars):\n{proc.stderr[-2000:]}"
+    )
+
+    parsed = _parse_routed_net_count(proc.stdout)
+    assert parsed is not None, (
+        "Could not find 'Nets routed: N/M' line in route_demo.py output. "
+        "This typically means the router crashed before producing a "
+        "summary, or the output format changed (update "
+        "_parse_routed_net_count in this test).\n"
+        f"stdout (last 4000 chars):\n{proc.stdout[-4000:]}"
+    )
+    routed, total = parsed
+    assert routed >= MIN_FULLY_ROUTED_NETS, (
+        f"Board 02 fully-routed net count regressed: routed {routed}/{total}, "
+        f"expected >= {MIN_FULLY_ROUTED_NETS} (Issue #3207 floor).  "
+        f"This typically indicates either (a) route_demo.py reverted to "
+        f"the bare ``router.route_all()`` in-process path (catching this "
+        f"is the whole point of this test) or (b) a router-quality "
+        f"regression in ``kct route``'s negotiated strategy on small "
+        f"2-layer boards."
+    )


### PR DESCRIPTION
## Summary

- Replaces ``boards/02-charlieplex-led/route_demo.py``'s bare ``router.route_all()`` in-process call with a subprocess invocation of ``kct route`` matching the proven recipe in ``generate_design.py:route_pcb()``.
- Restores board 02 to ``ship_ready=YES``: pre-fix 4/8 nets + 6 DRC errors → post-fix 8/8 nets + DRC PASSED (10/10 with auto-pour zones).
- Adds ``tests/test_board02_route_demo_recipe.py`` regression test pinning both the static recipe (subprocess invocation, no bare ``.route_all()`` AST node) AND end-to-end completion floor (>= 8 routed nets).

Closes #3207

## Root cause

The in-process ``router.route_all()`` path bypasses three orchestrator-only features that ``kct route`` runs end-to-end:
1. Auto-layer-escalation (1L → 2L → 4L until convergence).
2. Post-route ``drc_verify_and_nudge`` sweep (Issue #3112).
3. Auto-pour zone emission for GND/VCC (so power pads reach ``status=complete`` via plane connectivity).

This is the "orchestrator vs autorouter split" memory: fixes that ship to ``kct route`` (the orchestrator) don't automatically reach in-process callers. Issue #3207 is the symptom of that split for board 02.

## Fix

Per curator Option A (recommended): replace the in-process plumbing in ``route_demo.py:130-189`` with a subprocess invocation of ``kct route`` that mirrors ``generate_design.py:route_pcb()`` byte-for-byte. Because the two recipes now share the same code path, they cannot drift again — the only way to break board 02 is to break ``kct route`` itself, which has dense test coverage.

## Verification

```
$ uv run python boards/02-charlieplex-led/route_demo.py
...
Nets routed: 8/8
SUCCESS: All nets routed, DRC passed!
$ echo $?
0

$ uv run kct build  # full pipeline
[OK] route: Script route_demo.py completed successfully
[OK] preflight-routing: 10/10 nets complete
[OK] verify: DRC passed (sync OK)
Build completed successfully (13/13 steps)

$ uv run kct fleet status
02-charlieplex-led             34/34  100% B/C/G/M  fresh      0 YES
```

## Test plan

- [x] ``uv run python boards/02-charlieplex-led/route_demo.py`` exits 0 with "Nets routed: 8/8" + "DRC PASSED"
- [x] ``uv run kct build`` end-to-end on board 02 completes 13/13 steps
- [x] ``uv run kct fleet status`` reports board 02 ``ship_ready=YES``
- [x] ``uv run pytest tests/test_board02_route_demo_recipe.py -v`` — 3/3 pass
- [x] ``uv run pytest tests/test_blocks_charlieplex.py`` — 20/20 pass (no regression in existing charlieplex coverage)
- [x] ``uv run ruff check`` + ``uv run ruff format --check`` on modified files

## Acceptance criteria

- [x] AC #1: ``route_demo.py`` achieves >= 8/10 routed nets with no blocking DRC errors (achieved 8/8 signal + auto-pour for 10/10 total).
- [x] AC #2: ``kct build`` end-to-end reaches ``ship_ready=YES``.
- [x] AC #3: ``kct build --step route`` no longer exits 1 due to the bare ``route_all()`` UserWarning.
- [x] AC #4: Regression test pins the post-fix net count floor and the subprocess-recipe-mirroring invariant.

## File references

- ``boards/02-charlieplex-led/route_demo.py`` — the recipe port (256 lines refactored to subprocess invocation)
- ``tests/test_board02_route_demo_recipe.py`` — new regression test (294 lines)
- ``boards/02-charlieplex-led/generate_design.py:528-626`` — the canonical ``route_pcb()`` recipe that this PR mirrors (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)