### PR TITLE
fix(bom): back-fill blank Footprint column from PCB on spec-overlay boards (closes #3209)

### DIFF
--- a/boards/03-usb-joystick/output/manufacturing/bom_jlcpcb.csv
+++ b/boards/03-usb-joystick/output/manufacturing/bom_jlcpcb.csv
@@ -1,7 +1,7 @@
 Comment,Designator,Footprint,LCSC Part #
-100nF,"C1,C2,C3,C4",,C1525
-16MHz,Y1,,C13738
-Button,"SW1,SW2,SW3,SW4",,C318884
-Joystick,J2,,C50950
-MCU,U1,,C44854
-USB-C,J1,,C165948
+100nF,"C1,C2,C3,C4",Capacitor_SMD:C_0402_1005Metric,C1525
+16MHz,Y1,Crystal:Crystal_HC49-U_Vertical,C13738
+Button,"SW1,SW2,SW3,SW4",Button_Switch_SMD:SW_SPST_TL3342,C318884
+Joystick,J2,Module:Joystick_Analog,C50950
+MCU,U1,Package_QFP:TQFP-32_7x7mm_P0.8mm,C44854
+USB-C,J1,Connector_USB:USB_C_Receptacle_GCT_USB4105,C165948

--- a/src/kicad_tools/export/assembly.py
+++ b/src/kicad_tools/export/assembly.py
@@ -331,10 +331,29 @@ class AssemblyPackage:
                     ],
                 )
 
-            from ..schema.bom import extract_bom
+            from ..schema.bom import backfill_footprints_from_pcb, extract_bom
 
             bom = extract_bom(self.schematic_path)
             items = bom.items
+
+            # Back-fill empty BOMItem.footprint values from the PCB.
+            # Spec-overlay / programmatically generated schematics often
+            # leave the instance-level Footprint property blank; without
+            # this fallback the BOM CSV's Footprint column ends up empty.
+            # The helper never overwrites a non-empty footprint, so
+            # schematic-driven boards (e.g. board 01) are unaffected.
+            try:
+                filled = backfill_footprints_from_pcb(items, self.pcb_path)
+                if filled:
+                    logger.info(
+                        "Back-filled %d footprint ref(s) from PCB (schematic metadata was blank)",
+                        filled,
+                    )
+            except Exception as e:
+                logger.warning(
+                    "Footprint back-fill from PCB failed (continuing without): %s",
+                    e,
+                )
 
         # Filter excluded references
         if self.config.exclude_references:

--- a/src/kicad_tools/export/preflight.py
+++ b/src/kicad_tools/export/preflight.py
@@ -21,6 +21,7 @@ Example::
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from dataclasses import dataclass
 from pathlib import Path
@@ -842,9 +843,15 @@ class PreflightChecker:
         if self._bom_source == "auto":
             # Try schematic first, fall back to PCB
             if self.schematic_path and self.schematic_path.exists():
-                from ..schema.bom import extract_bom
+                from ..schema.bom import backfill_footprints_from_pcb, extract_bom
 
                 self._bom = extract_bom(str(self.schematic_path))
+                # Mirror the BOM CSV pipeline: back-fill blank footprints
+                # from the PCB so the schematic-only preflight check sees
+                # the same footprint metadata that ships in the BOM CSV.
+                # Best-effort -- bom_fields will still flag any real gaps.
+                with contextlib.suppress(Exception):
+                    backfill_footprints_from_pcb(self._bom.items, self.pcb_path)
             else:
                 from ..schema.bom import extract_bom_from_pcb
 
@@ -855,9 +862,16 @@ class PreflightChecker:
         if self.schematic_path is None or not self.schematic_path.exists():
             raise FileNotFoundError("Schematic file not available for BOM extraction")
 
-        from ..schema.bom import extract_bom
+        from ..schema.bom import backfill_footprints_from_pcb, extract_bom
 
         self._bom = extract_bom(str(self.schematic_path))
+        # Mirror the BOM CSV pipeline: back-fill blank footprints from the
+        # PCB so the preflight bom_fields check matches what is actually
+        # written to bom_<manufacturer>.csv (spec-overlay-style schematics
+        # leave instance-level Footprint properties blank).
+        # Best-effort -- bom_fields will still flag any real gaps.
+        with contextlib.suppress(Exception):
+            backfill_footprints_from_pcb(self._bom.items, self.pcb_path)
         return self._bom
 
     def _get_manufacturer_limits(self) -> tuple[float, float]:

--- a/src/kicad_tools/schema/bom.py
+++ b/src/kicad_tools/schema/bom.py
@@ -7,6 +7,7 @@ Extracts component information from schematics for manufacturing.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 
 from .hierarchy import build_hierarchy
 from .schematic import Schematic
@@ -386,3 +387,46 @@ def extract_bom_from_pcb(pcb_path: str) -> BOM:
         items.append(item)
 
     return BOM(items=items, source=pcb_path)
+
+
+def backfill_footprints_from_pcb(items: list[BOMItem], pcb_path: str | Path) -> int:
+    """Fill blank ``BOMItem.footprint`` fields from the PCB's footprint refs.
+
+    This is a strict fallback: only items whose ``footprint`` is empty or
+    whitespace are touched.  Items with any non-empty footprint string
+    (typically populated by the schematic-side ``Footprint`` property) are
+    preserved verbatim, so schematic-driven boards see no change.
+
+    Use case: schematics produced by spec-overlay / programmatic-generation
+    workflows often leave the instance-level ``Footprint`` property empty
+    on each symbol, even though the PCB has the correct footprint assigned.
+    The CPL writer reads ``fp.name`` directly off the PCB and is therefore
+    immune; the BOM writer reads ``BOMItem.footprint`` and ends up emitting
+    blank ``Footprint`` columns.  Calling this helper right after
+    :func:`extract_bom` repairs the BOM stream before grouping and CSV
+    output.
+
+    Args:
+        items: BOM items to back-fill in place.
+        pcb_path: Path to the ``.kicad_pcb`` file to source footprint refs
+            from.
+
+    Returns:
+        Number of items whose ``footprint`` field was populated.  Useful
+        for logging and test assertions; never raises on a no-op.
+    """
+    from .pcb import PCB
+
+    pcb = PCB.load(str(pcb_path))
+    ref_to_fp_name: dict[str, str] = {fp.reference: fp.name for fp in pcb.footprints}
+
+    filled = 0
+    for item in items:
+        if (item.footprint or "").strip():
+            # Preserve any existing schematic-side metadata.
+            continue
+        fp_name = ref_to_fp_name.get(item.reference)
+        if fp_name:
+            item.footprint = fp_name
+            filled += 1
+    return filled

--- a/tests/test_bom_footprint_backfill.py
+++ b/tests/test_bom_footprint_backfill.py
@@ -1,0 +1,232 @@
+"""Tests for ``backfill_footprints_from_pcb`` (Issue #3209).
+
+The helper is a strict fallback that fills empty ``BOMItem.footprint``
+fields from the PCB's footprint refs.  Items with any existing footprint
+string are preserved verbatim, so schematic-driven boards (e.g. board 01)
+must remain byte-identical before and after the fix.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kicad_tools.schema.bom import BOMItem, backfill_footprints_from_pcb
+
+BOARDS_DIR = Path(__file__).resolve().parent.parent / "boards"
+
+BOARD_01_PCB = BOARDS_DIR / "01-voltage-divider" / "output" / "voltage_divider_routed.kicad_pcb"
+BOARD_01_SCH = BOARDS_DIR / "01-voltage-divider" / "output" / "voltage_divider.kicad_sch"
+
+BOARD_03_PCB = BOARDS_DIR / "03-usb-joystick" / "output" / "usb_joystick_routed.kicad_pcb"
+BOARD_03_SCH = BOARDS_DIR / "03-usb-joystick" / "output" / "usb_joystick.kicad_sch"
+
+
+def _make_item(ref: str, value: str = "10k", footprint: str = "") -> BOMItem:
+    return BOMItem(
+        reference=ref,
+        value=value,
+        footprint=footprint,
+        lib_id="Device:R",
+    )
+
+
+def _mock_pcb(refs_to_names: dict[str, str]) -> MagicMock:
+    """Build a mock PCB with the given (reference -> footprint name) pairs."""
+    fps = []
+    for ref, name in refs_to_names.items():
+        fp = MagicMock()
+        fp.reference = ref
+        fp.name = name
+        fps.append(fp)
+    pcb = MagicMock()
+    pcb.footprints = fps
+    return pcb
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: three canonical scenarios (curator pattern)
+# ---------------------------------------------------------------------------
+
+
+class TestSchematicOnlyNoRegression:
+    """Schematic-side metadata must be preserved (board 01 gold standard)."""
+
+    def test_existing_footprint_preserved_even_when_pcb_differs(self):
+        # Schematic provides "R_0402"; PCB carries a different name.
+        # The helper must NOT overwrite the schematic-side value.
+        items = [_make_item("R1", footprint="R_0402")]
+        pcb = _mock_pcb({"R1": "R_0603"})
+
+        with patch("kicad_tools.schema.pcb.PCB.load", return_value=pcb):
+            filled = backfill_footprints_from_pcb(items, "/fake/path.kicad_pcb")
+
+        assert filled == 0
+        assert items[0].footprint == "R_0402"
+
+    def test_existing_footprint_with_only_whitespace_is_treated_as_empty(self):
+        # Whitespace-only footprints are considered empty and therefore
+        # eligible for back-fill.
+        items = [_make_item("R1", footprint="   ")]
+        pcb = _mock_pcb({"R1": "R_0805"})
+
+        with patch("kicad_tools.schema.pcb.PCB.load", return_value=pcb):
+            filled = backfill_footprints_from_pcb(items, "/fake/path.kicad_pcb")
+
+        assert filled == 1
+        assert items[0].footprint == "R_0805"
+
+    def test_returns_zero_when_nothing_to_backfill(self):
+        # All items populated -> no PCB-side overrides applied.
+        items = [
+            _make_item("R1", footprint="R_0402"),
+            _make_item("R2", footprint="R_0603"),
+        ]
+        pcb = _mock_pcb({"R1": "R_X", "R2": "R_Y"})
+
+        with patch("kicad_tools.schema.pcb.PCB.load", return_value=pcb):
+            filled = backfill_footprints_from_pcb(items, "/fake/path.kicad_pcb")
+
+        assert filled == 0
+        assert items[0].footprint == "R_0402"
+        assert items[1].footprint == "R_0603"
+
+
+class TestSpecOverlayBlank:
+    """Board 03 case: schematic Footprint blank, PCB has the real name."""
+
+    def test_blank_footprints_filled_from_pcb(self):
+        items = [
+            _make_item("U1", value="MCU", footprint=""),
+            _make_item("J1", value="USB-C", footprint=""),
+            _make_item("J2", value="Joystick", footprint=""),
+            _make_item("Y1", value="16MHz", footprint=""),
+            _make_item("SW1", value="Button", footprint=""),
+        ]
+        pcb = _mock_pcb(
+            {
+                "U1": "Package_QFP:TQFP-32_7x7mm_P0.8mm",
+                "J1": "Connector_USB:USB_C_Receptacle",
+                "J2": "Connector:Joystick_PSP",
+                "Y1": "Crystal:Crystal_SMD_3225",
+                "SW1": "Button_Switch_SMD:SW_SPST_6mm",
+            }
+        )
+
+        with patch("kicad_tools.schema.pcb.PCB.load", return_value=pcb):
+            filled = backfill_footprints_from_pcb(items, "/fake/path.kicad_pcb")
+
+        assert filled == 5
+        assert items[0].footprint == "Package_QFP:TQFP-32_7x7mm_P0.8mm"
+        assert items[1].footprint == "Connector_USB:USB_C_Receptacle"
+        assert items[2].footprint == "Connector:Joystick_PSP"
+        assert items[3].footprint == "Crystal:Crystal_SMD_3225"
+        assert items[4].footprint == "Button_Switch_SMD:SW_SPST_6mm"
+
+
+class TestMixed:
+    """Mixed: some refs in PCB, some not; some populated, some blank."""
+
+    def test_only_blank_items_with_pcb_match_are_filled(self):
+        items = [
+            _make_item("R1", footprint=""),  # blank, no PCB match -> stays blank
+            _make_item("U1", footprint=""),  # blank, PCB match -> filled
+            _make_item("J1", footprint="Connector_OldName"),  # populated, PCB differs -> preserved
+        ]
+        pcb = _mock_pcb(
+            {
+                "U1": "TQFP-32",
+                "J1": "Connector_NewName",
+                # No entry for R1.
+            }
+        )
+
+        with patch("kicad_tools.schema.pcb.PCB.load", return_value=pcb):
+            filled = backfill_footprints_from_pcb(items, "/fake/path.kicad_pcb")
+
+        assert filled == 1
+        assert items[0].footprint == ""  # no PCB match, no error
+        assert items[1].footprint == "TQFP-32"
+        assert items[2].footprint == "Connector_OldName"  # preserved
+
+    def test_empty_input_returns_zero(self):
+        with patch("kicad_tools.schema.pcb.PCB.load", return_value=_mock_pcb({})):
+            filled = backfill_footprints_from_pcb([], "/fake/path.kicad_pcb")
+        assert filled == 0
+
+
+# ---------------------------------------------------------------------------
+# Integration tests against real boards
+# ---------------------------------------------------------------------------
+
+
+class TestBoard03Integration:
+    """Integration test against board 03 (the AC scenario)."""
+
+    def test_board_03_blank_footprints_filled_from_pcb(self):
+        if not BOARD_03_PCB.exists() or not BOARD_03_SCH.exists():
+            pytest.skip("Board 03 artifacts not found")
+
+        from kicad_tools.schema.bom import extract_bom
+
+        bom = extract_bom(str(BOARD_03_SCH))
+        items = bom.items
+
+        # Sanity: schematic-source items should have blank footprints
+        # (this is the bug we are fixing).
+        assert any(not (it.footprint or "").strip() for it in items), (
+            "Expected at least one blank footprint on board 03 schematic-source BOM"
+        )
+
+        # Spec-overlay refs per project.kct (per the issue body).
+        target_refs = {"U1", "J1", "J2", "Y1", "SW1"}
+        target_items = [it for it in items if it.reference in target_refs]
+        assert target_items, "None of the spec-overlay refs found in BOM"
+        # Before back-fill, every spec-overlay ref should have a blank
+        # footprint (root cause).
+        assert all(not (it.footprint or "").strip() for it in target_items)
+
+        filled = backfill_footprints_from_pcb(items, str(BOARD_03_PCB))
+        assert filled > 0
+
+        # After back-fill: AC #1 — U1/J1/J2/Y1/SW1 must be non-blank.
+        for it in target_items:
+            assert (it.footprint or "").strip(), (
+                f"Footprint still blank for {it.reference} after back-fill"
+            )
+
+        # AC #2: every BOM row (caps, buttons too) should now have a
+        # populated footprint, because the PCB carries footprint refs for
+        # every placed component.
+        for it in items:
+            assert (it.footprint or "").strip(), (
+                f"Footprint still blank for {it.reference} after back-fill"
+            )
+
+
+class TestBoard01NoRegression:
+    """Board 01 is the gold-standard schematic-source board (AC #4)."""
+
+    def test_board_01_bom_unchanged_after_backfill(self):
+        if not BOARD_01_PCB.exists() or not BOARD_01_SCH.exists():
+            pytest.skip("Board 01 artifacts not found")
+
+        from kicad_tools.schema.bom import extract_bom
+
+        bom = extract_bom(str(BOARD_01_SCH))
+        items = bom.items
+
+        # Board 01 schematic populates Footprint for every instance.
+        assert all((it.footprint or "").strip() for it in items), (
+            "Precondition: board 01 schematic should populate all footprints"
+        )
+
+        snapshot = [(it.reference, it.footprint) for it in items]
+        filled = backfill_footprints_from_pcb(items, str(BOARD_01_PCB))
+
+        # No back-fill should occur and no field should change.
+        assert filled == 0
+        after = [(it.reference, it.footprint) for it in items]
+        assert after == snapshot


### PR DESCRIPTION
## Summary

- Adds `backfill_footprints_from_pcb(items, pcb_path) -> int` to `kicad_tools.schema.bom`: a strict fallback that fills only blank `BOMItem.footprint` fields from the PCB's footprint refs, never overwriting existing schematic-side metadata.
- Wires the back-fill into `AssemblyPackage._generate_bom()` (right after `extract_bom`, schematic source branch only) and into `PreflightChecker._load_bom()` so both the emitted CSV and the `bom_fields` preflight see the same metadata.
- Board 03 (USB joystick) is the visible AC; the underlying gap affects every spec-overlay-style board whose schematic has empty instance-level Footprint properties.

## Why

Spec-overlay / programmatically generated schematics leave each symbol's instance-level `Footprint` property empty even though the PCB carries the correct footprint refs.  The schematic-source BOM pipeline read those blanks straight through, so `bom_jlcpcb.csv` ended up with an empty `Footprint` column for every grouped row on board 03 (U1/J1/J2/Y1/SW1 plus C1-C4 and SW2-SW4).  The CPL writer was unaffected because it already reads `fp.name` off the PCB.

Before:
```
Comment,Designator,Footprint,LCSC Part #
100nF,"C1,C2,C3,C4",,C1525
16MHz,Y1,,C13738
Button,"SW1,SW2,SW3,SW4",,C318884
Joystick,J2,,C50950
MCU,U1,,C44854
USB-C,J1,,C165948
```

After:
```
Comment,Designator,Footprint,LCSC Part #
100nF,"C1,C2,C3,C4",Capacitor_SMD:C_0402_1005Metric,C1525
16MHz,Y1,Crystal:Crystal_HC49-U_Vertical,C13738
Button,"SW1,SW2,SW3,SW4",Button_Switch_SMD:SW_SPST_TL3342,C318884
Joystick,J2,Module:Joystick_Analog,C50950
MCU,U1,Package_QFP:TQFP-32_7x7mm_P0.8mm,C44854
USB-C,J1,Connector_USB:USB_C_Receptacle_GCT_USB4105,C165948
```

## Acceptance criteria

- [x] AC #1 — `bom_jlcpcb.csv` rows for U1/J1/J2/Y1/SW1 on board 03 have non-blank `Footprint` columns matching the CPL-side footprint refs.
- [x] AC #2 — All BOM rows on board 03 (C1-C4, SW2-SW4 too) have populated Footprint columns.
- [x] AC #3 — Preflight `bom_fields` no longer FAILs on board 03 (now OK / WARN due to unrelated LCSC enrichment ordering).
- [x] AC #4 — Board 01 BOM content is byte-identical pre/post fix (any `BOMItem` whose `.footprint` is a non-empty, non-whitespace string is never overwritten).  Asserted by `TestBoard01NoRegression::test_board_01_bom_unchanged_after_backfill`.
- [x] AC #5 — Only the schematic source branch invokes the fallback; the `pcb` and `auto`-without-schematic branches read `fp.name` directly and are untouched.
- [x] AC #6 — Helper signature is `backfill_footprints_from_pcb(items: list[BOMItem], pcb_path: str | Path) -> int`.

## Test plan

- [x] `pytest tests/test_bom_footprint_backfill.py` — 8 new unit/integration tests pass.
- [x] `pytest tests/test_bom_spec_overlay.py tests/test_bom_pcb_source.py tests/test_bom_enrich.py tests/test_bom_lcsc_merge.py tests/test_manufacturing_package.py` — 134 existing tests pass.
- [x] `pytest tests/test_preflight.py` — 59 preflight tests pass.
- [x] Regenerated board 03 via `cd boards/03-usb-joystick && PYTHONHASHSEED=42 uv run python generate_design.py` — Footprint column now populated for every row.
- [x] Regenerated board 01 — BOM CSV content byte-identical (line-ending normalization on commit is pre-existing and unrelated).
- [x] `uv run ruff check src/kicad_tools/schema/bom.py src/kicad_tools/export/preflight.py tests/test_bom_footprint_backfill.py` — clean.  (Pre-existing F401 in `assembly.py:18` for `GerberManufacturerPreset` is unrelated.)

Closes #3209

🤖 Generated with [Claude Code](https://claude.com/claude-code)