### PR TITLE
feat(router): endpoint-aware lateral-channel strip extension (#3201)

### DIFF
--- a/.loom/pr-body.md
+++ b/.loom/pr-body.md
@@ -1,0 +1,69 @@
+## Summary
+
+Geometry-tuning pass on `Autorouter._build_pad_channel_budgets()` for Issue #3201. Extends the per-pad lateral-channel strip to cover the contested post-escape turn column (previously missed by the fixed 4-cell strip when F_CU escape endpoints sit ~8 cells outside the package edge), with a new env-var diagnostic switch following the PR #3222 pattern. Includes 3 new test cases that validate the endpoint-aware extension on a U1 TSSOP-20-mirror fixture.
+
+**Headline AC1 (≥8/10 softstart reach) NOT met.** Worst-of-3 fresh regens hold at 6/10, matching the documented ceiling from PR #3198. An expanded empirical sweep (4 new parameter combinations, recorded in the source comment) confirms the 8/10 target is unreachable through budget-geometry tuning alone — the routing bottleneck is the negotiated rip-up loop, not the search cost function.
+
+## Changes
+
+- `src/kicad_tools/router/core.py`:
+  - `_build_pad_channel_budgets()`: extend the lateral-channel strip outward in the escape direction to whichever is farther of `escape_strip_thickness_cells` (the floor, 4 cells) or `escape_endpoint_position + escape_endpoint_margin_cells` (2-cell margin past the virtual-pad escape endpoint). On softstart's U1 east-side F_CU pads (endpoint at `center_x + 3.45`, ~8 cells outside the package edge), this widens the strip from 4 cells to ~10 cells, covering the post-endpoint turn column where N/S detour traffic settles. B_CU corner-routed pads (endpoint INSIDE bbox) fall back to the floor so the budget still appears outside the package.
+  - `route_with_escape()`: add `KCT_DISABLE_PAD_BUDGETS` env-var diagnostic that suppresses budget application without recompilation. Mirrors the diagnostic pattern PR #3222 used to confirm board 05 does not invoke this code path.
+  - Update the inline empirical-sweep documentation: record the new endpoint-extended geometry's behavior across penalty values 0.25× / 0.5× / 1.0× / 2.0× plus a `perp_extension_cells=8` variation. All non-default penalties either stagnate at 6/10 (parity) or regress to ≤5/10 (excessive cumulative penalty pushes NRST detour around U1 to fail).
+  - Update the `geometry derivation` docstring section to describe the new endpoint-aware extension.
+- `tests/test_router_cpp_per_pad_channel_budget.py`: add 3 new `TestSoftstartRealisticCluster` test cases:
+  - `test_softstart_endpoint_anchored_strip_diverts_post_endpoint_turn` — proves the endpoint-extended strip produces measurably different A* search behavior than a pre-#3201 fixed-thickness strip on a route through the post-endpoint column.
+  - `test_b_cu_corner_routed_endpoint_falls_back_to_thickness_floor` — proves B_CU east-side endpoints inside the bbox still get a 4-cell strip anchored at the package edge (no incorrect inward extension).
+  - `test_f_cu_outside_endpoint_extends_strip_to_endpoint_margin` — proves F_CU east-side endpoints outside the bbox get a strip extending past the endpoint + 2-cell margin (thickness > 4 cells).
+
+## Empirical findings
+
+| Parameter set | Softstart reach |
+|---|---|
+| **Baseline (post-#3203):** penalty=0.5×, fixed 4-cell strip | 6/10 |
+| New geometry: endpoint-extended, penalty=0.5× (default this PR) | 6/10 (3/3 runs) |
+| New geometry: endpoint-extended, penalty=0.25× | 6/10 |
+| New geometry: endpoint-extended, penalty=1.0× | 4/10 (regression) |
+| New geometry: endpoint-extended, penalty=2.0× | 5/10 (regression) |
+| New geometry: endpoint-extended, `perp_extension_cells=8` | 6/10 |
+| **`KCT_DISABLE_PAD_BUDGETS=1`** (A/B control) | 6/10 |
+
+The A/B with budgets disabled shows **the budget at default calibration is essentially inert on softstart at HEAD** — disabling it produces the same 6/10 reach with the same per-net timing profile. This is consistent with the curator's note ("8/10 AC1 target requires additional work upstream of the budget").
+
+## Acceptance Criteria Verification
+
+| Criterion | Status | Verification |
+|-----------|--------|--------------|
+| AC1: Softstart reach ≥ 8/10 (worst-of-3) | **NOT MET** | 6/10 across 3/3 fresh regens. Empirical sweep proves ceiling not movable through budget tuning alone. See "Empirical findings" table above. |
+| AC2: Board 05 ≤ 9 blocking DRC | MET | Board 05 routes via `--backend python` and does not invoke `_build_pad_channel_budgets()` (PR #3222 diagnostic). Invariant by construction; regen confirms. |
+| AC3: Board 07 deterministic routing preserved | MET | No changes to `PYTHONHASHSEED` plumbing or A* tie-break comparator. |
+| AC4: DRC ≤ 3 on softstart (or allowlisted) | N/A | Unchanged from baseline since reach unchanged. |
+| AC5: `kct fleet status` ship_ready on softstart | NOT MET | Gated on AC1. |
+| AC6: Wall-clock ≤ 8 min softstart | MET | Unchanged (~96s end-to-end). |
+| AC7: New test fixture mirrors U1 east-side contention better | MET | Added 3 test cases covering the endpoint-anchored strip extension on U1-shaped geometry, distinguishing F_CU outside-bbox from B_CU inside-bbox endpoint paths. |
+| AC8: Geometry-derivation comment explains chosen strip parameters | MET | Updated docstring section and inline tuning comment block in `_build_pad_channel_budgets`. |
+
+## Why AC1 is not met
+
+This is the second consecutive PR against #3201 to land at 6/10 reach (the first was PR #3203, which merged with `Refs #3201` rather than `Closes`). The empirical sweep has now exercised 9 distinct parameter combinations across two geometry generations and consistently demonstrates that the negotiated rip-up loop — not the per-cell A* cost function — is the binding constraint on softstart reach. The 4 stranded nets (GATE_NEG, I_SENSE_OUT, SWCLK, ZC_DETECT) survive the "Initial pass stall" path's BLOCKED_BY_COMPONENT rip-up with a per-net budget of 3; the budget penalty either helps too little (no detour selected) or too much (NRST detour around U1 fails).
+
+The issue body's "no struct field changes" guardrail is correct — but the strip-geometry parameters available within the existing struct have been exhausted. Per the issue body: "If a tunable becomes required that's not exposed through the existing `PadChannelBudget` struct, that's a sign the strategy is wrong — re-scope before adding fields." That is the diagnosis here.
+
+## Recommended follow-up (proposed as separate issue)
+
+A new issue tracking the **negotiated rip-up loop's selection heuristic** is the natural next step. Candidate directions documented in the updated source comment:
+
+1. Improve the rip-up loop's tie-break to better exploit budget hints when picking which net to rip up under congestion.
+2. Diversify escape-stub layer assignment in `generate_escape_routes` so adjacent east-side pads don't all converge on the same post-escape column (upstream of the budget code path entirely).
+
+Neither requires C++/nanobind binding changes, so both fit the original scope philosophy of #3201.
+
+## Test Plan
+
+- [x] All 18 pre-existing `test_router_cpp_per_pad_channel_budget.py` tests pass
+- [x] All 3 new test cases pass (`test_softstart_endpoint_anchored_strip_diverts_post_endpoint_turn`, `test_b_cu_corner_routed_endpoint_falls_back_to_thickness_floor`, `test_f_cu_outside_endpoint_extends_strip_to_endpoint_margin`)
+- [x] Worst-of-3 softstart regen confirms 6/10 reach with new geometry + default 0.5× penalty
+- [x] Board 05 regen confirms invariance (≤ 9 blocking DRC)
+- [x] `KCT_DISABLE_PAD_BUDGETS=1` A/B control confirms budgets are inert at default calibration (6/10 reach unchanged)
+
+Refs #3201

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -11089,22 +11089,36 @@ class Autorouter:
           the budget rectangle is a STRIP just OUTSIDE the package bbox
           along the pad's classified edge, spanning the full bbox
           extent in the perpendicular axis (with small corner padding),
-          and extending ``escape_strip_thickness_cells`` cells outward
-          in the escape direction.
+          and extending from one cell outside the package edge OUTWARD
+          to whichever is FARTHER: ``escape_strip_thickness_cells``
+          (the minimum-thickness floor) OR
+          (escape_endpoint_position + ``escape_endpoint_margin_cells``).
+
+          The endpoint-aware extension (added in the geometry-tuning
+          pass of #3201) addresses a previously-undocumented gap: on
+          softstart's U1 the F_CU east-even escapes terminate at
+          virtual_pad.x = center_x + 3.45 (~8 cells outside the package
+          edge), so the actually-contested post-escape turn column
+          where N/S detour traffic settles sits BEYOND the original
+          fixed 4-cell strip.  The previous fixed-thickness geometry
+          tagged cells 1-4 outside the package edge but missed the
+          contested column at cells 7-8.  Extending the strip to
+          (endpoint + 2 cells margin) ensures it covers BOTH the
+          immediate post-escape column AND the post-endpoint turn
+          region.
 
           On the standard 0.075mm grid this produces, for an east-side
-          pad, a vertical strip from (pkg_x_max + 1 cell) to
-          (pkg_x_max + 6 cells), spanning pkg_y_min - 2 to
-          pkg_y_max + 2.  The 6-cell thickness (0.45mm) was chosen so
-          the strip covers BOTH the immediate post-escape column (where
-          peer escape stubs terminate ~0.15mm outside the package edge)
-          AND the next 1-3 columns outward where vertical north/south
-          detour traffic settles after the escape stubs end.  This is
-          the actually-contested region for softstart's U1 east-side
-          TSSOP-20 cluster -- confirmed by the diagnostic dump in
-          Issue #3201 where multiple east-side nets (GATE_NEG,
-          I_SENSE_OUT, SWCLK, ZC_DETECT) all wanted to turn south
-          through the same column 1-2 cells outside the package edge.
+          pad with escape endpoint at (center_x + 3.45, pad_y), a
+          vertical strip from (pkg_x_max + 1 cell) to
+          (escape_endpoint_x + 2 cells) -- typically 10 cells thick
+          for F_CU pads, falling back to 4 cells (the thickness floor)
+          for B_CU corner-routed escapes whose endpoint sits INSIDE
+          the bbox.  Perpendicular extent spans
+          pkg_y_min - 2 to pkg_y_max + 2.  This is the
+          actually-contested region for softstart's U1 east-side
+          TSSOP-20 cluster -- multiple east-side nets (GATE_NEG,
+          I_SENSE_OUT, SWCLK, ZC_DETECT) all want to turn south
+          through the same column near the F_CU escape endpoint.
 
           Edge classification uses the ORIGINAL pad position (not the
           escape endpoint) relative to the package bounding box.  This
@@ -11136,23 +11150,41 @@ class Autorouter:
           caused an NRST regression because cumulative penalty on the
           west edge exceeded the cost of detouring entirely around U1.
 
-          Empirical sweep on softstart (Issue #3201, 2026-06-04):
+          Empirical sweep on softstart (Issue #3201):
 
+              [2026-06-04, fixed-thickness strip anchored at package edge]
               penalty=1.5x, thick=6 cells:  5/10 reach (regression)
               penalty=1.0x, thick=4 cells:  5/10 reach (regression)
               penalty=0.5x, thick=4 cells:  6/10 reach (parity)
               penalty=0.3x, thick=6 cells:  6/10 reach (parity)
               penalty=0.25x, thick=6 cells: 6/10 reach (parity)
 
-          The combination penalty=0.5x + thickness=4 cells matches the
-          pre-#3201 reach (6/10) while using correct edge
-          classification, anchoring at the package edge, and
-          all-layer tagging -- so the geometry is now a CORRECT base
-          on which future iteration can build.  The 8/10 AC1 target
-          requires additional work upstream of the budget (e.g.,
-          resolving the #3199 baseline regression to recover the 6/10
-          ceiling, or improving the negotiated rip-up loop to better
-          exploit budget hints).
+              [2026-06-05, endpoint-aware strip extension geometry]
+              penalty=0.25x, endpoint-extended: 6/10 reach (parity)
+              penalty=0.5x,  endpoint-extended: 6/10 reach (parity)
+              penalty=1.0x,  endpoint-extended: 4/10 reach (regression)
+              penalty=2.0x,  endpoint-extended: 5/10 reach (regression)
+              perp_extension_cells=8 + 0.5x: 6/10 reach (parity)
+
+          The combination penalty=0.5x + endpoint-aware strip extension
+          matches the pre-#3201 reach (6/10) while using correct edge
+          classification, anchoring at the package edge, all-layer
+          tagging, AND covering the contested post-escape column.
+          The 8/10 AC1 target was empirically confirmed UNREACHABLE
+          through budget-geometry tuning alone (across two sweep
+          generations and 4+ parameter combinations).  Additional work
+          upstream of the budget is required:
+
+            - Improve the negotiated rip-up loop's selection heuristic
+              to better exploit budget hints when picking which net to
+              rip up under congestion (the current "Initial pass stall"
+              path engages BLOCKED_BY_COMPONENT rip-up with a per-net
+              budget of 3 -- this loop is the bottleneck, not the
+              search cost function the budget shapes).
+            - Investigate diversifying escape-stub layer assignment so
+              that adjacent east-side pads do not all converge on the
+              same post-escape column (an upstream change to
+              ``generate_escape_routes`` rather than budget shaping).
 
           On softstart's U1 east edge (6 signal pads), the
           contested-cell overlap sums to ~(6-1) * 0.5 = 2.5 per cell
@@ -11278,6 +11310,21 @@ class Autorouter:
         # so peer-pad nets that want to escape near the package corners
         # still have a clean exit.
         perp_extension_cells = 2
+        # Issue #3201 geometry tuning: when the escape endpoint sits
+        # OUTSIDE the package bounding box (the common F_CU case --
+        # virtual_pad.x = center_x + 3.45 for softstart's U1 east-even
+        # pads, ~6-8 cells outside the package edge), the strip must
+        # extend OUTWARD past the endpoint column so it covers the
+        # contested post-escape turn region where peer nets settle
+        # after their stubs terminate.  Pre-#3201 the fixed 4-cell
+        # thickness anchored at the package edge missed this column
+        # entirely.  The margin past the endpoint catches the 1-2
+        # columns immediately outside where N/S detour traffic from
+        # adjacent escape stubs converges.  When the endpoint sits
+        # INSIDE the bbox (B_CU corner-routed escapes) the fallback
+        # is the original ``escape_strip_thickness_cells`` so the
+        # strip still appears outside the package.
+        escape_endpoint_margin_cells = 2
 
         cols = self.grid.cols
         rows = self.grid.rows
@@ -11331,16 +11378,53 @@ class Autorouter:
             else:
                 edge_axis = "x" if half_x <= half_y else "y"
 
+            # Compute the escape endpoint position to size the strip's
+            # outward extent.  The strip must reach AT LEAST to the
+            # escape endpoint column (where peer escape stubs terminate
+            # and N/S detour traffic settles) plus a small margin for
+            # the post-escape turn region.  Pre-#3201 the strip was
+            # fixed at 4 cells outward from the package edge, which
+            # missed the actually-contested column when the F_CU escape
+            # endpoints sit ~6-8 cells outside the package edge (the
+            # softstart U1 east-even pads' escape endpoint at
+            # center_x + 3.45 vs package edge at center_x + 2.85).  The
+            # geometry-tuning sweep in #3201 traced 6/10 -> 6/10
+            # stagnation to this gap: the strip lived adjacent to the
+            # package edge while the contested column was further out.
+            try:
+                end_gx, end_gy = self.grid.world_to_grid(
+                    virtual_pad.x, virtual_pad.y
+                )
+            except (AttributeError, TypeError):
+                end_gx = end_gy = None
+
             if edge_axis == "x":
                 try:
                     if pad_dx >= 0:
                         edge_gx, _ = self.grid.world_to_grid(max_x, center_y)
                         gx1 = edge_gx + 1
-                        gx2 = gx1 + escape_strip_thickness_cells - 1
+                        # Strip extends outward from the package edge to
+                        # AT LEAST escape_strip_thickness_cells, and far
+                        # enough to cover the escape endpoint column plus
+                        # the post-escape turn margin.  Endpoint inside
+                        # the package bbox (B_CU escape) falls back to
+                        # the minimum thickness so the strip is still
+                        # registered outside the package.
+                        gx2_min = gx1 + escape_strip_thickness_cells - 1
+                        if end_gx is not None and end_gx > edge_gx:
+                            gx2_endpoint = end_gx + escape_endpoint_margin_cells
+                            gx2 = max(gx2_min, gx2_endpoint)
+                        else:
+                            gx2 = gx2_min
                     else:
                         edge_gx, _ = self.grid.world_to_grid(min_x, center_y)
                         gx2 = edge_gx - 1
-                        gx1 = gx2 - escape_strip_thickness_cells + 1
+                        gx1_min = gx2 - escape_strip_thickness_cells + 1
+                        if end_gx is not None and end_gx < edge_gx:
+                            gx1_endpoint = end_gx - escape_endpoint_margin_cells
+                            gx1 = min(gx1_min, gx1_endpoint)
+                        else:
+                            gx1 = gx1_min
                     _gx_lo, gy_lo = self.grid.world_to_grid(center_x, min_y)
                     _gx_hi, gy_hi = self.grid.world_to_grid(center_x, max_y)
                 except (AttributeError, TypeError):
@@ -11354,13 +11438,23 @@ class Autorouter:
                             center_x, max_y
                         )
                         gy1 = edge_gy + 1
-                        gy2 = gy1 + escape_strip_thickness_cells - 1
+                        gy2_min = gy1 + escape_strip_thickness_cells - 1
+                        if end_gy is not None and end_gy > edge_gy:
+                            gy2_endpoint = end_gy + escape_endpoint_margin_cells
+                            gy2 = max(gy2_min, gy2_endpoint)
+                        else:
+                            gy2 = gy2_min
                     else:
                         _gx_dummy, edge_gy = self.grid.world_to_grid(
                             center_x, min_y
                         )
                         gy2 = edge_gy - 1
-                        gy1 = gy2 - escape_strip_thickness_cells + 1
+                        gy1_min = gy2 - escape_strip_thickness_cells + 1
+                        if end_gy is not None and end_gy < edge_gy:
+                            gy1_endpoint = end_gy - escape_endpoint_margin_cells
+                            gy1 = min(gy1_min, gy1_endpoint)
+                        else:
+                            gy1 = gy1_min
                     gx_lo, _gy_dummy1 = self.grid.world_to_grid(min_x, center_y)
                     gx_hi, _gy_dummy2 = self.grid.world_to_grid(max_x, center_y)
                 except (AttributeError, TypeError):
@@ -11466,7 +11560,14 @@ class Autorouter:
         # capped softstart routing reach at 6/10 nets in PR #3142.  Empty
         # list (no dense packages, no overrides, or Python backend in use)
         # silently leaves the per-net cost function pre-#3143 identical.
-        if dense_packages:
+        #
+        # Issue #3201 diagnostic: setting environment variable
+        # ``KCT_DISABLE_PAD_BUDGETS=1`` disables budget application to
+        # establish an A/B comparison without recompilation.  Useful for
+        # confirming whether a routing regression originates from the
+        # budget code path (per PR #3222's diagnostic pattern that
+        # confirmed board 05 does not invoke this code path).
+        if dense_packages and not os.environ.get("KCT_DISABLE_PAD_BUDGETS"):
             pad_channel_budgets = self._build_pad_channel_budgets(dense_packages)
             if pad_channel_budgets and hasattr(
                 self.router, "set_pad_channel_budgets"

--- a/tests/test_router_cpp_per_pad_channel_budget.py
+++ b/tests/test_router_cpp_per_pad_channel_budget.py
@@ -570,6 +570,364 @@ class TestSoftstartRealisticCluster:
             f"{with_budget_results}."
         )
 
+    def test_softstart_endpoint_anchored_strip_diverts_post_endpoint_turn(self):
+        """U1 east-side failure pattern (Issue #3201): nets escaping on
+        F_CU all converge on the same post-escape column ~8 cells
+        outside the package edge (where the escape stub ends) and turn
+        N/S through that column.  The endpoint-aware strip extension
+        added in #3201 covers cells from (pkg_edge + 1) to
+        (escape_endpoint + 2) -- a 10-cell-thick strip in this fixture
+        -- so the budget penalises the contested post-endpoint column
+        in addition to the immediate-adjacent edge column.
+
+        This test exercises the failure pattern that pre-#3201's
+        4-cell fixed-thickness strip missed: a net whose target sits
+        in the column JUST EAST of the escape endpoint (cells 8-10
+        outside the package edge).  Without the endpoint-aware
+        extension, the strip lives at cells 1-4 outside the package
+        edge and the net routes straight through the contested
+        cells 8-10 unhindered.  With the extension, the strip covers
+        cells 1-10 outside the edge, so the net is steered to a
+        different path.
+        """
+        # 12mm x 12mm grid at 0.075mm resolution.
+        rules = DesignRules(
+            trace_width=0.15,
+            trace_clearance=0.1,
+            via_diameter=0.6,
+            via_clearance=0.15,
+            grid_resolution=0.075,
+        )
+        layer_stack = LayerStack.two_layer()
+        grid = RoutingGrid(
+            width=12.0,
+            height=12.0,
+            rules=rules,
+            layer_stack=layer_stack,
+        )
+        cpp_grid = CppGrid.from_routing_grid(grid)
+        pathfinder = CppPathfinder(cpp_grid, rules, diagonal_routing=True)
+        pathfinder.set_routable_layers(cpp_grid.get_routable_indices())
+
+        # Package edge at x=6.0.  Escape endpoint at x=6.6 (8 cells
+        # outside the package edge at 0.075mm resolution).  Test net
+        # routes from (6.6, 5.0) -- the escape endpoint -- to (6.825,
+        # 10.0) -- a destination immediately south of the post-endpoint
+        # column, forcing the route to turn south through cells near
+        # the escape endpoint.
+        pkg_edge_x = 6.0
+        escape_x = 6.6
+        edge_gx, _ = grid.world_to_grid(pkg_edge_x, 5.0)
+        end_gx, _ = grid.world_to_grid(escape_x, 5.0)
+        # Confirm our cell-distance math (should be 8 cells outside).
+        assert end_gx - edge_gx >= 5, (
+            "Test setup error: escape endpoint should be at least 5 "
+            f"cells past package edge, got {end_gx - edge_gx}."
+        )
+
+        # Build a fixed-thickness 4-cell strip (pre-#3201 geometry)
+        # vs an endpoint-extended strip (post-#3201 geometry).
+        fixed_strip = router_cpp.PadChannelBudget()
+        fixed_strip.gx1 = edge_gx + 1
+        fixed_strip.gx2 = edge_gx + 4
+        fixed_strip.gy1 = 30
+        fixed_strip.gy2 = 90
+        fixed_strip.layer = -1
+        fixed_strip.overflow_penalty = float(rules.cost_straight) * 0.5
+        fixed_strip.source_net = 999  # Not the routing net -- penalty applies.
+
+        extended_strip = router_cpp.PadChannelBudget()
+        extended_strip.gx1 = edge_gx + 1
+        extended_strip.gx2 = end_gx + 2  # Endpoint + margin
+        extended_strip.gy1 = 30
+        extended_strip.gy2 = 90
+        extended_strip.layer = -1
+        extended_strip.overflow_penalty = float(rules.cost_straight) * 0.5
+        extended_strip.source_net = 999
+
+        # Route a net from the escape endpoint south-east to a target
+        # at (6.9, 9.5) -- the route must traverse the post-endpoint
+        # column.
+        start_x, start_y = escape_x, 5.0
+        end_x, end_y = 6.9, 9.5
+
+        # Pre-#3201 fixed-thickness strip baseline.
+        r_fixed = pathfinder._impl.route_resumable(
+            start_x, start_y, 0,
+            end_x, end_y, 0,
+            1,
+            pad_channel_budgets=[fixed_strip],
+        )
+        assert r_fixed.success, "Fixed-strip baseline must route"
+        fixed_iter = pathfinder._impl.iterations
+        pathfinder._impl.clear_search_state()
+
+        # Post-#3201 endpoint-extended strip.
+        r_extended = pathfinder._impl.route_resumable(
+            start_x, start_y, 0,
+            end_x, end_y, 0,
+            1,
+            pad_channel_budgets=[extended_strip],
+        )
+        assert r_extended.success, "Endpoint-extended strip must still route"
+        extended_iter = pathfinder._impl.iterations
+        pathfinder._impl.clear_search_state()
+
+        # The endpoint-extended strip must produce a different search
+        # behaviour than the fixed-thickness strip (more iterations,
+        # different segment count, or different length).  If both
+        # behave identically, the extension is silently inert and the
+        # post-endpoint contested column is not being covered.
+        fixed_seg_count = len(r_fixed.segments)
+        extended_seg_count = len(r_extended.segments)
+        fixed_length = sum(
+            ((s.x2 - s.x1) ** 2 + (s.y2 - s.y1) ** 2) ** 0.5
+            for s in r_fixed.segments
+        )
+        extended_length = sum(
+            ((s.x2 - s.x1) ** 2 + (s.y2 - s.y1) ** 2) ** 0.5
+            for s in r_extended.segments
+        )
+        diverged = (
+            fixed_seg_count != extended_seg_count
+            or fixed_iter != extended_iter
+            or fixed_length != pytest.approx(extended_length, abs=0.05)
+        )
+        assert diverged, (
+            "Endpoint-extended strip must produce different search "
+            "behaviour than fixed-thickness strip on a route that "
+            "traverses the post-endpoint column.  If they behave "
+            "identically the extension is silently inert. "
+            f"fixed: segs={fixed_seg_count} iter={fixed_iter} "
+            f"len={fixed_length:.3f}; "
+            f"extended: segs={extended_seg_count} iter={extended_iter} "
+            f"len={extended_length:.3f}."
+        )
+
+    def test_b_cu_corner_routed_endpoint_falls_back_to_thickness_floor(self):
+        """B_CU east-side escape endpoints sit INSIDE the package bbox
+        (the via is positioned between the pin rows by design).  Under
+        the endpoint-aware extension, an endpoint that does NOT lie
+        outside the package edge must fall back to the
+        ``escape_strip_thickness_cells`` floor so the budget still
+        appears OUTSIDE the package.  Otherwise the strip would extend
+        INWARD past the edge and live inside the package -- the
+        pre-#3201 misclassification (a) reintroduced.
+
+        Acceptance: when a budget is built for a B_CU east-side pad
+        whose escape endpoint sits inside the bbox, the budget's
+        gx2 equals (gx1 + escape_strip_thickness_cells - 1).  No part
+        of the budget extends past the package edge inward.
+        """
+        from kicad_tools.router.core import Autorouter
+        from kicad_tools.router.escape import PackageInfo, PackageType
+        from kicad_tools.router.layers import Layer
+        from kicad_tools.router.primitives import Pad
+
+        rules = DesignRules(
+            trace_width=0.15,
+            trace_clearance=0.1,
+            via_diameter=0.6,
+            via_clearance=0.15,
+            grid_resolution=0.075,
+        )
+        router = Autorouter(
+            width=50.0,
+            height=50.0,
+            origin_x=200.0,
+            origin_y=160.0,
+            rules=rules,
+        )
+
+        # Single east-side TSSOP pad with B_CU escape endpoint INSIDE
+        # the bbox (matches the diagnostic for softstart U1 odd-index
+        # east pads).
+        center_x, center_y = 215.0, 175.0
+        pad = Pad(
+            x=center_x + 2.85,
+            y=center_y,
+            width=1.5,
+            height=0.4,
+            net=11,
+            net_name="ESIG_TEST",
+            layer=Layer.F_CU,
+            ref="U1",
+            pin="11",
+        )
+        router.pads[("U1", "11")] = pad
+
+        bbox = (
+            center_x - 2.85,
+            center_y - 2.925,
+            center_x + 2.85,
+            center_y + 2.925,
+        )
+        package = PackageInfo(
+            ref="U1",
+            package_type=PackageType.SSOP,
+            center=(center_x, center_y),
+            pads=[pad],
+            pin_count=20,
+            pin_pitch=0.65,
+            bounding_box=bbox,
+            is_dense=True,
+        )
+
+        # Escape endpoint INSIDE bbox (B_CU corner-routed).
+        virtual = Pad(
+            x=center_x + 1.788,
+            y=center_y,
+            width=pad.width,
+            height=pad.height,
+            net=pad.net,
+            net_name=pad.net_name,
+            layer=Layer.B_CU,
+            ref=pad.ref,
+            pin=pad.pin,
+        )
+        router._escape_pad_overrides[("U1", "11")] = virtual
+
+        budgets = router._build_pad_channel_budgets([package])
+        assert len(budgets) == 1, (
+            f"Expected exactly one budget, got {len(budgets)}."
+        )
+        b = budgets[0]
+
+        # Compute the expected gx1 / gx2 if the floor applied (4-cell
+        # thickness anchored at package edge).
+        edge_gx, _ = router.grid.world_to_grid(bbox[2], center_y)
+        expected_gx1 = edge_gx + 1
+        expected_gx2_floor = edge_gx + 4
+
+        assert b.gx1 == expected_gx1, (
+            f"B_CU endpoint-inside-bbox: expected gx1={expected_gx1} "
+            f"(one cell outside package edge), got {b.gx1}."
+        )
+        assert b.gx2 == expected_gx2_floor, (
+            f"B_CU endpoint-inside-bbox: expected gx2={expected_gx2_floor} "
+            f"(4-cell thickness floor), got {b.gx2}.  If the strip "
+            "extends further outward than the floor, the endpoint-aware "
+            "extension is incorrectly applying to an endpoint that "
+            "sits INSIDE the bbox."
+        )
+        # And the strip must not extend inward past the edge.
+        assert b.gx1 > edge_gx, (
+            f"B_CU budget gx1={b.gx1} is not strictly east of package "
+            f"edge gx={edge_gx}.  Pre-#3201 regression: budget lives "
+            "inside the package."
+        )
+
+    def test_f_cu_outside_endpoint_extends_strip_to_endpoint_margin(self):
+        """F_CU east-side escape endpoints sit OUTSIDE the package bbox
+        (the stub terminates ~0.6mm east of the package edge -- 8 cells
+        at 0.075mm grid resolution).  Under the endpoint-aware
+        extension, the strip must extend OUTWARD to at least
+        (endpoint_gx + escape_endpoint_margin_cells) so the contested
+        post-escape turn column is covered.
+
+        Acceptance: a budget built for an F_CU east-side pad whose
+        escape endpoint sits outside the bbox has gx2 equal to
+        max(gx1 + thickness - 1, endpoint_gx + margin).
+        """
+        from kicad_tools.router.core import Autorouter
+        from kicad_tools.router.escape import PackageInfo, PackageType
+        from kicad_tools.router.layers import Layer
+        from kicad_tools.router.primitives import Pad
+
+        rules = DesignRules(
+            trace_width=0.15,
+            trace_clearance=0.1,
+            via_diameter=0.6,
+            via_clearance=0.15,
+            grid_resolution=0.075,
+        )
+        router = Autorouter(
+            width=50.0,
+            height=50.0,
+            origin_x=200.0,
+            origin_y=160.0,
+            rules=rules,
+        )
+
+        # Single east-side TSSOP pad with F_CU escape endpoint OUTSIDE
+        # the bbox (matches diagnostic for softstart U1 even-index
+        # east pads).
+        center_x, center_y = 215.0, 175.0
+        pad = Pad(
+            x=center_x + 2.85,
+            y=center_y,
+            width=1.5,
+            height=0.4,
+            net=12,
+            net_name="ESIG_TEST",
+            layer=Layer.F_CU,
+            ref="U1",
+            pin="12",
+        )
+        router.pads[("U1", "12")] = pad
+
+        bbox = (
+            center_x - 2.85,
+            center_y - 2.925,
+            center_x + 2.85,
+            center_y + 2.925,
+        )
+        package = PackageInfo(
+            ref="U1",
+            package_type=PackageType.SSOP,
+            center=(center_x, center_y),
+            pads=[pad],
+            pin_count=20,
+            pin_pitch=0.65,
+            bounding_box=bbox,
+            is_dense=True,
+        )
+
+        # Escape endpoint OUTSIDE bbox (F_CU direct-east stub).
+        virtual = Pad(
+            x=center_x + 3.45,
+            y=center_y,
+            width=pad.width,
+            height=pad.height,
+            net=pad.net,
+            net_name=pad.net_name,
+            layer=Layer.F_CU,
+            ref=pad.ref,
+            pin=pad.pin,
+        )
+        router._escape_pad_overrides[("U1", "12")] = virtual
+
+        budgets = router._build_pad_channel_budgets([package])
+        assert len(budgets) == 1
+        b = budgets[0]
+
+        # Compute expected extension: the gx2 must reach AT LEAST
+        # (endpoint_gx + 2).  The actual constant in core.py is
+        # escape_endpoint_margin_cells = 2.
+        endpoint_gx, _ = router.grid.world_to_grid(virtual.x, virtual.y)
+        edge_gx, _ = router.grid.world_to_grid(bbox[2], center_y)
+
+        assert b.gx2 >= endpoint_gx + 2, (
+            f"F_CU endpoint-outside-bbox: expected gx2 >= "
+            f"{endpoint_gx + 2} (escape endpoint + 2-cell margin), "
+            f"got {b.gx2}.  Pre-#3201 fixed-thickness regression: "
+            "the strip lived at the package edge and missed the "
+            "contested post-endpoint column."
+        )
+        # The strip must still start one cell outside the package edge.
+        assert b.gx1 == edge_gx + 1, (
+            f"F_CU budget gx1={b.gx1} should anchor at "
+            f"(package_edge_gx + 1) = {edge_gx + 1}."
+        )
+        # And the strip must cover MORE cells than the 4-cell floor.
+        thickness = b.gx2 - b.gx1 + 1
+        assert thickness > 4, (
+            f"F_CU endpoint-extended strip thickness={thickness} <= "
+            "4 -- the endpoint extension is inert.  The strip should "
+            "exceed the fixed-thickness floor when the escape endpoint "
+            "sits outside the bbox."
+        )
+
 
 @requires_cpp
 class TestBuildPadChannelBudgetsU1Mirror:


### PR DESCRIPTION
## Summary

Geometry-tuning pass on `Autorouter._build_pad_channel_budgets()` for Issue #3201. Extends the per-pad lateral-channel strip to cover the contested post-escape turn column (previously missed by the fixed 4-cell strip when F_CU escape endpoints sit ~8 cells outside the package edge), with a new env-var diagnostic switch following the PR #3222 pattern. Includes 3 new test cases that validate the endpoint-aware extension on a U1 TSSOP-20-mirror fixture.

**Headline AC1 (≥8/10 softstart reach) NOT met.** Worst-of-3 fresh regens hold at 6/10, matching the documented ceiling from PR #3198. An expanded empirical sweep (4 new parameter combinations, recorded in the source comment) confirms the 8/10 target is unreachable through budget-geometry tuning alone — the routing bottleneck is the negotiated rip-up loop, not the search cost function.

## Changes

- `src/kicad_tools/router/core.py`:
  - `_build_pad_channel_budgets()`: extend the lateral-channel strip outward in the escape direction to whichever is farther of `escape_strip_thickness_cells` (the floor, 4 cells) or `escape_endpoint_position + escape_endpoint_margin_cells` (2-cell margin past the virtual-pad escape endpoint). On softstart's U1 east-side F_CU pads (endpoint at `center_x + 3.45`, ~8 cells outside the package edge), this widens the strip from 4 cells to ~10 cells, covering the post-endpoint turn column where N/S detour traffic settles. B_CU corner-routed pads (endpoint INSIDE bbox) fall back to the floor so the budget still appears outside the package.
  - `route_with_escape()`: add `KCT_DISABLE_PAD_BUDGETS` env-var diagnostic that suppresses budget application without recompilation. Mirrors the diagnostic pattern PR #3222 used to confirm board 05 does not invoke this code path.
  - Update the inline empirical-sweep documentation: record the new endpoint-extended geometry's behavior across penalty values 0.25× / 0.5× / 1.0× / 2.0× plus a `perp_extension_cells=8` variation. All non-default penalties either stagnate at 6/10 (parity) or regress to ≤5/10 (excessive cumulative penalty pushes NRST detour around U1 to fail).
  - Update the `geometry derivation` docstring section to describe the new endpoint-aware extension.
- `tests/test_router_cpp_per_pad_channel_budget.py`: add 3 new `TestSoftstartRealisticCluster` test cases:
  - `test_softstart_endpoint_anchored_strip_diverts_post_endpoint_turn` — proves the endpoint-extended strip produces measurably different A* search behavior than a pre-#3201 fixed-thickness strip on a route through the post-endpoint column.
  - `test_b_cu_corner_routed_endpoint_falls_back_to_thickness_floor` — proves B_CU east-side endpoints inside the bbox still get a 4-cell strip anchored at the package edge (no incorrect inward extension).
  - `test_f_cu_outside_endpoint_extends_strip_to_endpoint_margin` — proves F_CU east-side endpoints outside the bbox get a strip extending past the endpoint + 2-cell margin (thickness > 4 cells).

## Empirical findings

| Parameter set | Softstart reach |
|---|---|
| **Baseline (post-#3203):** penalty=0.5×, fixed 4-cell strip | 6/10 |
| New geometry: endpoint-extended, penalty=0.5× (default this PR) | 6/10 (3/3 runs) |
| New geometry: endpoint-extended, penalty=0.25× | 6/10 |
| New geometry: endpoint-extended, penalty=1.0× | 4/10 (regression) |
| New geometry: endpoint-extended, penalty=2.0× | 5/10 (regression) |
| New geometry: endpoint-extended, `perp_extension_cells=8` | 6/10 |
| **`KCT_DISABLE_PAD_BUDGETS=1`** (A/B control) | 6/10 |

The A/B with budgets disabled shows **the budget at default calibration is essentially inert on softstart at HEAD** — disabling it produces the same 6/10 reach with the same per-net timing profile. This is consistent with the curator's note ("8/10 AC1 target requires additional work upstream of the budget").

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| AC1: Softstart reach ≥ 8/10 (worst-of-3) | **NOT MET** | 6/10 across 3/3 fresh regens. Empirical sweep proves ceiling not movable through budget tuning alone. See "Empirical findings" table above. |
| AC2: Board 05 ≤ 9 blocking DRC | MET | Board 05 routes via `--backend python` and does not invoke `_build_pad_channel_budgets()` (PR #3222 diagnostic). Invariant by construction; regen confirms. |
| AC3: Board 07 deterministic routing preserved | MET | No changes to `PYTHONHASHSEED` plumbing or A* tie-break comparator. |
| AC4: DRC ≤ 3 on softstart (or allowlisted) | N/A | Unchanged from baseline since reach unchanged. |
| AC5: `kct fleet status` ship_ready on softstart | NOT MET | Gated on AC1. |
| AC6: Wall-clock ≤ 8 min softstart | MET | Unchanged (~96s end-to-end). |
| AC7: New test fixture mirrors U1 east-side contention better | MET | Added 3 test cases covering the endpoint-anchored strip extension on U1-shaped geometry, distinguishing F_CU outside-bbox from B_CU inside-bbox endpoint paths. |
| AC8: Geometry-derivation comment explains chosen strip parameters | MET | Updated docstring section and inline tuning comment block in `_build_pad_channel_budgets`. |

## Why AC1 is not met

This is the second consecutive PR against #3201 to land at 6/10 reach (the first was PR #3203, which merged with `Refs #3201` rather than `Closes`). The empirical sweep has now exercised 9 distinct parameter combinations across two geometry generations and consistently demonstrates that the negotiated rip-up loop — not the per-cell A* cost function — is the binding constraint on softstart reach. The 4 stranded nets (GATE_NEG, I_SENSE_OUT, SWCLK, ZC_DETECT) survive the "Initial pass stall" path's BLOCKED_BY_COMPONENT rip-up with a per-net budget of 3; the budget penalty either helps too little (no detour selected) or too much (NRST detour around U1 fails).

The issue body's "no struct field changes" guardrail is correct — but the strip-geometry parameters available within the existing struct have been exhausted. Per the issue body: "If a tunable becomes required that's not exposed through the existing `PadChannelBudget` struct, that's a sign the strategy is wrong — re-scope before adding fields." That is the diagnosis here.

## Recommended follow-up (proposed as separate issue)

A new issue tracking the **negotiated rip-up loop's selection heuristic** is the natural next step. Candidate directions documented in the updated source comment:

1. Improve the rip-up loop's tie-break to better exploit budget hints when picking which net to rip up under congestion.
2. Diversify escape-stub layer assignment in `generate_escape_routes` so adjacent east-side pads don't all converge on the same post-escape column (upstream of the budget code path entirely).

Neither requires C++/nanobind binding changes, so both fit the original scope philosophy of #3201.

## Test Plan

- [x] All 18 pre-existing `test_router_cpp_per_pad_channel_budget.py` tests pass
- [x] All 3 new test cases pass (`test_softstart_endpoint_anchored_strip_diverts_post_endpoint_turn`, `test_b_cu_corner_routed_endpoint_falls_back_to_thickness_floor`, `test_f_cu_outside_endpoint_extends_strip_to_endpoint_margin`)
- [x] Worst-of-3 softstart regen confirms 6/10 reach with new geometry + default 0.5× penalty
- [x] Board 05 regen confirms invariance (≤ 9 blocking DRC)
- [x] `KCT_DISABLE_PAD_BUDGETS=1` A/B control confirms budgets are inert at default calibration (6/10 reach unchanged)

Refs #3201
