### PR TITLE
fix(router): sync pad_blocked bit into C++ grid to refuse foreign-pad-metal A* traversal

### DIFF
--- a/src/kicad_tools/router/cpp/include/grid.hpp
+++ b/src/kicad_tools/router/cpp/include/grid.hpp
@@ -53,8 +53,24 @@ public:
         return {origin_x_ + gx * resolution_, origin_y_ + gy * resolution_};
     }
 
-    // Bulk operations for obstacle marking
-    void mark_blocked(int x, int y, int layer, int net, bool is_obstacle = false);
+    // Bulk operations for obstacle marking.
+    //
+    // Issue #3224: ``pad_blocked`` (default ``false``) marks the cell as
+    // foreign pad copper -- the A* clearance branch in ``pathfinder.cpp``
+    // refuses to step the trace centerline into a foreign pad's metal
+    // even during pad-exit (where clearance-halo cells are otherwise
+    // allowed).  Without this bit, ``cell.pad_blocked`` defaults to
+    // ``false`` for every cell and the pad-exit exemption permits traces
+    // to step through foreign pad metal, producing the
+    // ``clearance_pad_segment`` regression on dense fine-pitch packages
+    // (board 05 / U3 QFN-56 / U10 LQFP-32).  The Python sync
+    // (``cpp_backend.py::from_routing_grid`` and
+    // ``grid.py::_sync_pad_to_cpp_grid``) sets this bit only for cells
+    // inside a pad's metal area (NOT the surrounding clearance halo),
+    // mirroring the Python grid's ``_pad_blocked[metal_slice] = True``
+    // at ``grid.py:4458``.
+    void mark_blocked(int x, int y, int layer, int net, bool is_obstacle = false,
+                      bool pad_blocked = false);
     void mark_rect_blocked(int x1, int y1, int x2, int y2, int layer, int net,
                            bool is_obstacle = false);
 

--- a/src/kicad_tools/router/cpp/include/types.hpp
+++ b/src/kicad_tools/router/cpp/include/types.hpp
@@ -46,7 +46,21 @@ namespace router {
 // the post-#3199 (f_score, g_score, seq) comparison restores 6/10.
 // Bumping the version forces a rebuild so the regression fix takes
 // effect.
-constexpr int ROUTER_CPP_BUILD_VERSION = 8;
+//
+// Bump to 9 for Issue #3224 (foreign-pad-metal A* rejection).
+// ``Grid3D::mark_blocked`` gained an optional trailing ``pad_blocked``
+// parameter so the Python sync (``cpp_backend.py::from_routing_grid``
+// and ``grid.py::_sync_pad_to_cpp_grid``) can forward the
+// ``_pad_blocked[metal_slice] = True`` bit set by
+// ``RoutingGrid._add_pad_unsafe``.  Without the rebuild, ``cell.pad_blocked``
+// remains ``false`` for every cell, and the ``is_clearance_only =
+// !cell.pad_blocked`` check at ``pathfinder.cpp:680`` / ``pathfinder.cpp:1173``
+// always reports "clearance halo", allowing the A* pad-exit branch to
+// step trace centerlines through foreign pad metal -- the 16
+// ``clearance_pad_segment`` errors on board 05 with --backend cpp.
+// Bumping the build version forces ``kct build-native`` so the fix takes
+// effect.
+constexpr int ROUTER_CPP_BUILD_VERSION = 9;
 
 // Grid cell state
 struct GridCell {

--- a/src/kicad_tools/router/cpp/src/bindings.cpp
+++ b/src/kicad_tools/router/cpp/src/bindings.cpp
@@ -154,9 +154,21 @@ NB_MODULE(router_cpp, m) {
         // Coordinate conversion
         .def("world_to_grid", &Grid3D::world_to_grid, "x"_a, "y"_a)
         .def("grid_to_world", &Grid3D::grid_to_world, "gx"_a, "gy"_a)
-        // Blocking operations
+        // Blocking operations.
+        //
+        // Issue #3224: ``pad_blocked`` (default ``false``) marks the cell as
+        // foreign pad copper.  The A* clearance branch in
+        // ``pathfinder.cpp`` (lines 680 and 1173 -- the one-shot and
+        // resumable / negotiated paths) reads ``cell.pad_blocked`` to
+        // distinguish foreign-pad metal from foreign-pad clearance halo;
+        // only halo cells participate in the pad-exit exemption.
+        // Without the bit, the C++ A* accepted traces stepping through
+        // foreign pad copper.  Defaults to ``false`` so existing callers
+        // that mark obstacle cells (board outline, copper-pour clearance
+        // halos) preserve their pre-#3224 behavior.
         .def("mark_blocked", &Grid3D::mark_blocked,
-             "x"_a, "y"_a, "layer"_a, "net"_a, "is_obstacle"_a = false)
+             "x"_a, "y"_a, "layer"_a, "net"_a, "is_obstacle"_a = false,
+             "pad_blocked"_a = false)
         .def("mark_rect_blocked", &Grid3D::mark_rect_blocked,
              "x1"_a, "y1"_a, "x2"_a, "y2"_a, "layer"_a, "net"_a, "is_obstacle"_a = false)
         // Route marking

--- a/src/kicad_tools/router/cpp/src/grid.cpp
+++ b/src/kicad_tools/router/cpp/src/grid.cpp
@@ -35,12 +35,27 @@ Grid3D::Grid3D(int cols, int rows, int layers, float resolution,
     congestion_.resize(static_cast<size_t>(layers) * congestion_rows_ * congestion_cols_, 0);
 }
 
-void Grid3D::mark_blocked(int x, int y, int layer, int net, bool is_obstacle) {
+void Grid3D::mark_blocked(int x, int y, int layer, int net, bool is_obstacle,
+                          bool pad_blocked) {
     if (!is_valid(x, y, layer)) return;
     auto& cell = at(x, y, layer);
     cell.blocked = true;
     cell.net = net;
     cell.is_obstacle = is_obstacle;
+    // Issue #3224: Forward the pad-metal bit so the A* clearance branch in
+    // ``pathfinder.cpp`` can distinguish foreign-pad metal (where the trace
+    // centerline must NOT enter) from foreign-pad clearance halo (where
+    // pad-exit may step through to escape an adjacent same-net pad).  The
+    // OR keeps the bit "sticky" -- if a cell is touched by two pads and
+    // either is pad metal, the cell remains pad-blocked.  ``original_net``
+    // mirrors the Python grid's bookkeeping: ``unmark_segment`` /
+    // ``unmark_via`` consult it to restore the pad's net id when ripping
+    // up a route that crossed the pad's clearance halo (see grid.cpp:146,
+    // grid.cpp:188).
+    if (pad_blocked) {
+        cell.pad_blocked = true;
+        cell.original_net = net;
+    }
 }
 
 void Grid3D::mark_rect_blocked(int x1, int y1, int x2, int y2, int layer, int net,

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 # ``AttributeError`` deep in the routing code (e.g. ``router_cpp.PadBounds``
 # missing).  The guard below catches that at import time and falls back to the
 # pure-Python router with an actionable ``kct build-native`` hint.
-_REQUIRED_CPP_BUILD_VERSION = 8
+_REQUIRED_CPP_BUILD_VERSION = 9
 
 # Try to import C++ module with detailed error tracking
 _CPP_IMPORT_ERROR: str | None = None
@@ -564,13 +564,36 @@ class CppGrid:
         # Copy routable layer indices from Python grid
         cpp_grid._routable_layers = grid.get_routable_indices()
 
-        # Copy blocked cells from Python grid to C++ grid
+        # Copy blocked cells from Python grid to C++ grid.
+        #
+        # Issue #3224: Forward the ``pad_blocked`` bit (set by
+        # ``RoutingGrid._add_pad_unsafe`` at grid.py:4458 for cells inside a
+        # pad's metal area) so the C++ A* clearance branch at
+        # ``pathfinder.cpp:680`` (one-shot) and ``pathfinder.cpp:1173``
+        # (resumable / negotiated) can distinguish pad metal from pad
+        # clearance halo.  Without this bit, ``cell.pad_blocked`` defaults to
+        # ``false`` on every C++ cell and the pad-exit exemption admits
+        # traces stepping through foreign pad copper -- the
+        # ``clearance_pad_segment`` regression on board 05 (16 errors at HEAD
+        # with --backend cpp vs 1 on python).  The bulk sync here is
+        # complemented by the incremental sync at
+        # ``grid.py::_sync_pad_to_cpp_grid`` for pads added AFTER this
+        # bulk-copy completes (the typical ``Autorouter.add_component``
+        # flow).
+        py_pad_blocked = grid._pad_blocked
         for layer in range(grid.num_layers):
             for y in range(grid.rows):
                 for x in range(grid.cols):
                     py_cell = grid.grid[layer][y][x]
                     if py_cell.blocked:
-                        cpp_grid._impl.mark_blocked(x, y, layer, py_cell.net, py_cell.is_obstacle)
+                        cpp_grid._impl.mark_blocked(
+                            x,
+                            y,
+                            layer,
+                            py_cell.net,
+                            py_cell.is_obstacle,
+                            bool(py_pad_blocked[layer, y, x]),
+                        )
 
         # Issue #2439: Populate pad data for C++ geometric validation.
         # Pre-compute per-component clearance overrides and FNV-1a ref hashes

--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -188,6 +188,99 @@ def _sync_pad_to_cpp_grid(
         return
 
 
+def _sync_pad_cells_to_cpp_grid(
+    py_grid: "RoutingGrid",
+    cpp_grid: Any,
+    layers_to_block: list[int],
+    gx1: int,
+    gy1: int,
+    gx2: int,
+    gy2: int,
+) -> None:
+    """Push a pad's blocked-cell envelope to the paired C++ grid.
+
+    Issue #3224: ``CppGrid.from_routing_grid`` snapshots the Python grid at
+    ``Autorouter.__init__`` time -- when no pads have been added yet (the
+    typical CLI flow constructs the empty grid, then ``add_component`` is
+    called per-component AFTER the C++ grid exists).  Without this
+    incremental sync, the C++ A* searches against an empty obstacle grid
+    and relies entirely on post-route validation to reject pad-clearance
+    violations.  That works for most patterns but leaks 16
+    ``clearance_pad_segment`` errors on board 05 (fine-pitch QFN-56 / LQFP-32)
+    because the pad-exit exemption at ``pathfinder.cpp:680`` / ``:1173``
+    can step the trace centerline through foreign pad metal when
+    ``cell.pad_blocked`` is uniformly ``false``.
+
+    This helper walks the rectangular envelope the pad just claimed on
+    the Python grid and forwards each blocked cell -- with its post-update
+    ``net``, ``is_obstacle``, and ``pad_blocked`` flags -- to the C++ grid.
+    The Python-side ``_add_pad_unsafe`` MUST have completed its in-place
+    array updates before this is called; we read the freshly-written
+    state out of ``py_grid._blocked``, ``py_grid._net``,
+    ``py_grid._is_obstacle``, and ``py_grid._pad_blocked``.
+
+    Args:
+        py_grid: The Python ``RoutingGrid`` whose pad-cells were just
+            updated by ``_add_pad_unsafe``.
+        cpp_grid: The paired ``CppGrid`` (back-reference established by
+            ``CppGrid.from_routing_grid``).
+        layers_to_block: Layer indices the pad affected (typically a
+            single layer for SMD pads, all routable layers for THT pads).
+        gx1, gy1, gx2, gy2: Inclusive grid-cell bounding box of the pad's
+            blocked envelope.  Already clamped to grid bounds by the
+            caller's ``_add_pad_unsafe`` loop.
+    """
+    try:
+        from . import router_cpp  # type: ignore[attr-defined]  # noqa: F401
+    except ImportError:
+        return
+
+    # Use numpy slices to read the post-update Python grid state.  Reading
+    # via the slow per-cell ``Cell`` proxy (``grid.grid[layer][y][x]``) for
+    # every cell would re-traverse the GPU-aware accessor path; the raw
+    # arrays are the same data source the proxy reads from.
+    py_blocked = py_grid._blocked
+    py_net = py_grid._net
+    py_is_obstacle = py_grid._is_obstacle
+    py_pad_blocked = py_grid._pad_blocked
+
+    # Clamp the envelope defensively -- callers already clamp, but the
+    # numpy slice would silently return empty arrays if the caller's
+    # ``_add_pad_unsafe`` ever shipped an unclamped rectangle.
+    gx1 = max(0, gx1)
+    gy1 = max(0, gy1)
+    gx2 = min(py_grid.cols - 1, gx2)
+    gy2 = min(py_grid.rows - 1, gy2)
+    if gx2 < gx1 or gy2 < gy1:
+        return
+
+    try:
+        impl_mark_blocked = cpp_grid._impl.mark_blocked
+    except AttributeError:
+        return
+
+    for layer_idx in layers_to_block:
+        # Iterate the envelope.  Per-cell ``mark_blocked`` calls match the
+        # bulk-sync pattern in ``CppGrid.from_routing_grid`` -- there is
+        # no rectangular bulk setter that takes per-cell ``pad_blocked``
+        # bits, so a small inner loop is the cleanest port.  The envelope
+        # is bounded (typically <= 30x30 cells for a 1mm pad at 0.1mm
+        # resolution) so the Python overhead is negligible relative to a
+        # full board's route time.
+        for gy in range(gy1, gy2 + 1):
+            for gx in range(gx1, gx2 + 1):
+                if not py_blocked[layer_idx, gy, gx]:
+                    continue
+                impl_mark_blocked(
+                    int(gx),
+                    int(gy),
+                    int(layer_idx),
+                    int(py_net[layer_idx, gy, gx]),
+                    bool(py_is_obstacle[layer_idx, gy, gx]),
+                    bool(py_pad_blocked[layer_idx, gy, gx]),
+                )
+
+
 def _is_plane_net_pad(pad: "Pad") -> bool:
     """Return True if ``pad`` belongs to a plane net (power/ground topology).
 
@@ -1443,6 +1536,36 @@ class RoutingGrid:
                 effective_height=effective_height,
                 pin_pitch=pin_pitch,
                 layers_to_block=layers_to_block,
+            )
+
+        # Issue #3224: Push the freshly-updated pad envelope into the paired
+        # C++ grid so the C++ A* sees the same blocked cells (including the
+        # ``pad_blocked`` metal bit) the Python A* does.  Without this, the
+        # ``Autorouter.__init__`` -> ``create_hybrid_router`` -> ``add_component``
+        # ordering leaves the C++ grid with zero pad obstacles -- relying on
+        # post-route validation to reject pad-clearance violations.  That
+        # works for most cases but leaks 16 ``clearance_pad_segment``
+        # errors on board 05 (QFN-56 / LQFP-32 fine-pitch corridors) because
+        # the pad-exit exemption at ``pathfinder.cpp:680`` / ``:1173`` can
+        # step the trace centerline through foreign pad metal when
+        # ``cell.pad_blocked`` is uniformly ``false``.
+        #
+        # The sync is intentionally done AFTER the same-component / stitch
+        # halo / narrow-channel helpers above so the C++ grid receives the
+        # FINAL post-update state (carve-outs applied, halos extended, etc.).
+        # The standard envelope ``(gx1, gy1) - (gx2, gy2)`` covers the pad
+        # metal and standard clearance; the auxiliary halo helpers
+        # (``_apply_stitch_via_halo``, ``_apply_narrow_channel_halo``)
+        # extend outward but only operate on plane-net or same-component
+        # pads -- those zones are visited again when their owning pads are
+        # added (or already covered by the standard envelope of the
+        # neighbour pad).  The pad-metal protection that closes the
+        # foreign-pad-metal A* gap is the standard-envelope zone, which is
+        # what we sync here.
+        cpp_grid = self._cpp_grid
+        if cpp_grid is not None:
+            _sync_pad_cells_to_cpp_grid(
+                self, cpp_grid, layers_to_block, gx1, gy1, gx2, gy2
             )
 
     def _apply_stitch_via_halo(

--- a/tests/test_router_cpp_foreign_pad_metal_rejection.py
+++ b/tests/test_router_cpp_foreign_pad_metal_rejection.py
@@ -1,0 +1,469 @@
+"""Regression tests for the foreign-pad-metal A* rejection fix.
+
+Issue #3224: The C++ A* clearance branch at ``pathfinder.cpp:680`` (one-shot)
+and ``pathfinder.cpp:1173`` (resumable / negotiated) reads
+``cell.pad_blocked`` to distinguish foreign-pad metal (which a trace
+centerline must never cross even during pad-exit) from foreign-pad
+clearance halo (which a same-net pad-exit may step through).  Before
+this fix, no C++ code path ever set ``cell.pad_blocked = true`` -- the
+field was declared in ``types.hpp:51`` with default ``false`` and the
+Python-to-C++ sync at ``cpp_backend.py:572-573`` (bulk) and
+``grid.py::_sync_pad_to_cpp_grid`` (incremental) both omitted it.
+
+The Python side already populates ``_pad_blocked[metal_slice] = True``
+at ``grid.py:4458`` for pad metal cells.  The fix forwards that bit
+into the paired C++ grid so the A* clearance branch behaves the same
+way the Python sibling at ``pathfinder.py:2600-2602`` does.
+
+Test plan (mirrors PR #2931's reference pattern in
+``tests/router/test_validate_route_clearance_rect.py``):
+
+1.  Direct grid binding: ``Grid3D.mark_blocked(..., pad_blocked=True)``
+    sets ``GridCell.pad_blocked = True`` (round-trip through nanobind).
+
+2.  Bulk-sync (``CppGrid.from_routing_grid``): a Python ``RoutingGrid``
+    with a pad already added at construction time carries ``pad_blocked
+    = True`` into the C++ grid metal cells, but ``pad_blocked = False``
+    on the surrounding clearance halo cells.
+
+3.  Incremental-sync (``_sync_pad_to_cpp_grid`` via the
+    ``_add_pad_unsafe`` path): a pad added AFTER ``from_routing_grid``
+    (the normal ``Autorouter.add_component`` flow) still ends up with
+    ``cell.pad_blocked = True`` on the C++ grid metal cells.
+
+4.  A* rejects foreign-pad-metal: with a foreign-net pad whose metal
+    cells carry ``pad_blocked = true``, ``Pathfinder::route()`` (the
+    one-shot path at ``pathfinder.cpp:680``) and ``route_resumable()``
+    (the resumable/negotiated path at ``pathfinder.cpp:1173``) refuse
+    to step the trace centerline through the foreign metal even when
+    the search is exiting a same-net pad immediately adjacent.
+
+The fourth check is the load-bearing acceptance test for AC #6 of
+the issue and must exercise BOTH A* call sites (one-shot and
+resumable) per the curator's review note.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.router.cpp_backend import CppGrid, is_cpp_available, router_cpp
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules
+
+
+# C++ backend is mandatory for these tests -- the bug they regress is
+# C++-only by construction (the Python A* uses Python's own grid).
+requires_cpp = pytest.mark.skipif(
+    not is_cpp_available(),
+    reason="C++ router backend not available; run `kct build-native`",
+)
+
+
+def _make_rules(
+    *,
+    trace_width: float = 0.127,
+    trace_clearance: float = 0.127,
+    resolution: float = 0.1,
+) -> DesignRules:
+    return DesignRules(
+        trace_width=trace_width,
+        trace_clearance=trace_clearance,
+        via_drill=0.3,
+        via_diameter=0.6,
+        via_clearance=trace_clearance,
+        grid_resolution=resolution,
+    )
+
+
+def _make_grid(
+    *,
+    width: float = 10.0,
+    height: float = 10.0,
+    resolution: float = 0.1,
+) -> tuple[RoutingGrid, DesignRules]:
+    rules = _make_rules(resolution=resolution)
+    layer_stack = LayerStack.two_layer()
+    grid = RoutingGrid(
+        width=width,
+        height=height,
+        rules=rules,
+        layer_stack=layer_stack,
+    )
+    return grid, rules
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: direct binding round-trip
+# ---------------------------------------------------------------------------
+
+
+@requires_cpp
+class TestMarkBlockedPadBlockedParameter:
+    """Round-trip the new ``pad_blocked`` argument through ``Grid3D.mark_blocked``."""
+
+    def test_mark_blocked_default_pad_blocked_false(self) -> None:
+        """Calling ``mark_blocked`` without ``pad_blocked`` preserves the
+        pre-#3224 default (``cell.pad_blocked == False``).  This is the
+        defaults-preserve regression that protects all existing callers
+        (board outline blocks, copper-pour clearance halos, etc.)."""
+        grid = router_cpp.Grid3D(20, 20, 2, 0.1, 0.0, 0.0)
+        grid.mark_blocked(5, 5, 0, 42, False)
+        cell = grid.at(5, 5, 0)
+        assert cell.blocked is True
+        assert cell.net == 42
+        assert cell.is_obstacle is False
+        assert cell.pad_blocked is False
+
+    def test_mark_blocked_pad_blocked_true_sets_bit(self) -> None:
+        """The new ``pad_blocked=True`` kwarg flips the field.  This is the
+        bit the A* clearance branch reads at ``pathfinder.cpp:680`` /
+        ``:1173`` to refuse pad-metal traversal during pad-exit."""
+        grid = router_cpp.Grid3D(20, 20, 2, 0.1, 0.0, 0.0)
+        grid.mark_blocked(5, 5, 0, 42, False, True)
+        cell = grid.at(5, 5, 0)
+        assert cell.blocked is True
+        assert cell.net == 42
+        assert cell.pad_blocked is True
+
+    def test_mark_blocked_pad_blocked_sticky_on_overlap(self) -> None:
+        """When two pads' envelopes overlap, the second ``mark_blocked``
+        call with ``pad_blocked=False`` must NOT clear an earlier
+        ``pad_blocked=True`` mark.  This preserves the rip-up contract
+        in ``unmark_segment``/``unmark_via`` at ``grid.cpp:146/188``
+        which assumes pad-metal cells stay flagged."""
+        grid = router_cpp.Grid3D(20, 20, 2, 0.1, 0.0, 0.0)
+        grid.mark_blocked(5, 5, 0, 42, False, True)
+        grid.mark_blocked(5, 5, 0, 99, False, False)
+        cell = grid.at(5, 5, 0)
+        assert cell.pad_blocked is True, (
+            "pad_blocked should be sticky -- once set, halo overlap from a "
+            "neighbour pad must not clear the metal bit"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: bulk sync via CppGrid.from_routing_grid
+# ---------------------------------------------------------------------------
+
+
+@requires_cpp
+class TestBulkSyncPadBlocked:
+    """When ``CppGrid.from_routing_grid`` runs on a populated Python
+    grid, the per-cell ``pad_blocked`` bit must flow through."""
+
+    def test_pad_metal_cells_synced_as_pad_blocked(self) -> None:
+        py_grid, _ = _make_grid()
+        # Add the pad BEFORE building the C++ grid so the bulk sync sees
+        # the post-update Python state.
+        pad = Pad(
+            x=5.0,
+            y=5.0,
+            width=1.0,
+            height=0.5,
+            net=1,
+            net_name="N1",
+            layer=Layer.F_CU,
+            ref="U1",
+            pin="1",
+        )
+        py_grid.add_pad(pad)
+        cpp_grid = CppGrid.from_routing_grid(py_grid)
+
+        # Pad center: must be pad_blocked on BOTH grids.
+        gx, gy = py_grid.world_to_grid(pad.x, pad.y)
+        assert bool(py_grid._pad_blocked[0, gy, gx]) is True
+        cell = cpp_grid._impl.at(gx, gy, 0)
+        assert cell.blocked is True
+        assert cell.pad_blocked is True
+
+    def test_clearance_halo_cells_blocked_but_not_pad_blocked(self) -> None:
+        """The cells just outside the pad metal (the clearance halo) are
+        ``blocked=True`` but ``pad_blocked=False`` -- this is the
+        distinction the pad-exit exemption depends on."""
+        py_grid, _ = _make_grid()
+        # Use a small SMD pad so metal vs halo cells are easy to address.
+        pad = Pad(
+            x=5.0,
+            y=5.0,
+            width=0.4,
+            height=0.4,
+            net=1,
+            net_name="N1",
+            layer=Layer.F_CU,
+            ref="U1",
+            pin="1",
+        )
+        py_grid.add_pad(pad)
+        cpp_grid = CppGrid.from_routing_grid(py_grid)
+
+        # Walk outward from the centre until we find a halo cell (blocked
+        # but not pad_blocked).  The exact distance depends on grid
+        # resolution / clearance, but we just need one halo cell.
+        cgx, cgy = py_grid.world_to_grid(pad.x, pad.y)
+        halo_found = False
+        for radius in range(3, 15):
+            for dy, dx in [(0, radius), (0, -radius), (radius, 0), (-radius, 0)]:
+                gx, gy = cgx + dx, cgy + dy
+                if not (0 <= gx < py_grid.cols and 0 <= gy < py_grid.rows):
+                    continue
+                py_blocked = bool(py_grid._blocked[0, gy, gx])
+                py_pad_blocked = bool(py_grid._pad_blocked[0, gy, gx])
+                if py_blocked and not py_pad_blocked:
+                    cell = cpp_grid._impl.at(gx, gy, 0)
+                    assert cell.blocked is True, (
+                        f"halo cell at ({gx},{gy}) should be blocked on C++"
+                    )
+                    assert cell.pad_blocked is False, (
+                        f"halo cell at ({gx},{gy}) must NOT be pad_blocked "
+                        "on C++ -- this is the cell the pad-exit exemption "
+                        "allows the trace to step through"
+                    )
+                    halo_found = True
+                    break
+            if halo_found:
+                break
+        assert halo_found, (
+            "Expected at least one halo cell (blocked=True, pad_blocked=False) "
+            "in the radius around the pad"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: incremental sync via _sync_pad_to_cpp_grid (the post-init flow)
+# ---------------------------------------------------------------------------
+
+
+@requires_cpp
+class TestIncrementalSyncPadBlocked:
+    """The realistic ``Autorouter.__init__`` flow: empty Python grid is
+    handed to ``CppGrid.from_routing_grid`` first, THEN pads are added
+    via ``add_component`` -> ``RoutingGrid.add_pad`` -> ``_add_pad_unsafe``.
+    The incremental sync must forward ``pad_blocked`` for those pads."""
+
+    def test_incremental_pad_sync_propagates_pad_blocked(self) -> None:
+        py_grid, _ = _make_grid()
+        # C++ grid built BEFORE the pad is added (matches Autorouter flow).
+        cpp_grid = CppGrid.from_routing_grid(py_grid)
+        # Pre-condition: empty grid has zero blocked cells on both sides.
+        assert cpp_grid._impl.count_blocked() == 0
+
+        pad = Pad(
+            x=5.0,
+            y=5.0,
+            width=1.0,
+            height=0.5,
+            net=1,
+            net_name="N1",
+            layer=Layer.F_CU,
+            ref="U1",
+            pin="1",
+        )
+        py_grid.add_pad(pad)
+
+        gx, gy = py_grid.world_to_grid(pad.x, pad.y)
+        # Python grid: pad metal is pad_blocked.
+        assert bool(py_grid._blocked[0, gy, gx]) is True
+        assert bool(py_grid._pad_blocked[0, gy, gx]) is True
+        # C++ grid: incremental sync forwarded both bits.
+        cell = cpp_grid._impl.at(gx, gy, 0)
+        assert cell.blocked is True, (
+            "Incremental sync must mark the pad-metal cell as blocked on C++"
+        )
+        assert cell.pad_blocked is True, (
+            "Incremental sync must forward the pad_blocked bit on C++ -- "
+            "without this, A* steps trace centerlines through foreign pad "
+            "metal during pad-exit (Issue #3224 root cause)"
+        )
+
+    def test_incremental_sync_through_hole_pad_all_layers(self) -> None:
+        """Through-hole pads span all routable layers -- the incremental
+        sync must propagate ``pad_blocked`` on each layer."""
+        py_grid, _ = _make_grid()
+        cpp_grid = CppGrid.from_routing_grid(py_grid)
+        pad = Pad(
+            x=5.0,
+            y=5.0,
+            width=1.2,
+            height=1.2,
+            net=2,
+            net_name="N2",
+            layer=Layer.F_CU,
+            ref="J1",
+            pin="1",
+            through_hole=True,
+            drill=0.8,
+        )
+        py_grid.add_pad(pad)
+        gx, gy = py_grid.world_to_grid(pad.x, pad.y)
+        for layer in range(py_grid.num_layers):
+            cell = cpp_grid._impl.at(gx, gy, layer)
+            assert cell.blocked is True, f"layer {layer}: not blocked"
+            assert cell.pad_blocked is True, (
+                f"layer {layer}: through-hole pad metal must be pad_blocked"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Layer 4: A* rejection of foreign-pad-metal traversal -- the AC #6 fixture.
+# Exercises BOTH the one-shot ``route()`` path (pathfinder.cpp:680) AND the
+# resumable / negotiated ``route_resumable()`` path (pathfinder.cpp:1173).
+# ---------------------------------------------------------------------------
+
+
+def _build_two_pad_fixture(
+    *,
+    resumable: bool,
+) -> tuple[router_cpp.Grid3D, router_cpp.Pathfinder, dict]:
+    """Build a small fixture: a foreign-net pad sits between the start
+    and end so the cheap straight-line route would have to cross it.
+
+    Geometry (cell coordinates):
+        - Start pad: own net N1, cells (10,30..40) on layer 0.
+        - Foreign pad N2: cells (20..30, 30..40) on layer 0,
+          ``pad_blocked = True``.
+        - End pad: own net N1, cells (40,30..40) on layer 0.
+        - 50x70 grid with 0.1mm resolution.
+
+    The straight-line path from start to end on layer 0 passes through
+    the foreign pad rectangle.  With ``pad_blocked = True``, the A*
+    must either detour or fail; without it (the pre-#3224 bug), the
+    pad-exit exemption admits the foreign-metal cells and the trace
+    centerline crosses through the foreign pad.
+
+    Args:
+        resumable: When True, return the resumable-search call info;
+            when False, return the one-shot call info.  The two paths
+            share grid setup but call different Pathfinder methods.
+
+    Returns:
+        ``(grid, pathfinder, call_info)`` where ``call_info`` is a dict
+        carrying the kwargs for the chosen route method.
+    """
+    cols, rows, layers = 50, 70, 2
+    resolution = 0.1
+    grid = router_cpp.Grid3D(cols, rows, layers, resolution, 0.0, 0.0)
+
+    rules = router_cpp.DesignRules()
+    rules.trace_width = 0.127
+    rules.trace_clearance = 0.127
+    rules.via_diameter = 0.6
+    rules.via_drill = 0.3
+    rules.via_clearance = 0.127
+    rules.grid_resolution = resolution
+    rules.cost_straight = 1.0
+    rules.cost_turn = 1.5
+    rules.cost_via = 10.0
+
+    own_net = 1
+    foreign_net = 2
+
+    # Mark foreign pad as pad_blocked metal cells.  The block is on
+    # layer 0 only (the routing layer of interest); layer 1 stays
+    # clear, but we still want the A* to prefer layer 0 because layer
+    # transitions cost cost_via (10.0) which is far more than any
+    # in-layer detour.
+    for x in range(20, 31):
+        for y in range(30, 41):
+            grid.mark_blocked(x, y, 0, foreign_net, True, True)
+
+    # Build pathfinder.  Diagonal routing enabled so detour around the
+    # foreign pad is cheap if reachable.
+    pathfinder = router_cpp.Pathfinder(grid, rules, True)
+    routable = [0, 1]
+    pathfinder.set_routable_layers(routable)
+
+    info = {
+        "start_x": 10 * resolution,
+        "start_y": 35 * resolution,
+        "start_layer": 0,
+        "end_x": 40 * resolution,
+        "end_y": 35 * resolution,
+        "end_layer": 0,
+        "net": own_net,
+        "start_layers": routable,
+        "end_layers": routable,
+        "trace_radius_cells": 1,
+        "via_radius_cells": 3,
+    }
+    return grid, pathfinder, info
+
+
+def _route_crosses_foreign_pad(
+    result: router_cpp.RouteResult,
+    foreign_layer: int = 0,
+) -> bool:
+    """Test whether ``result``'s segment centerline crosses the foreign
+    pad's metal rectangle (cells x=20..30, y=30..40 in 0.1mm units =
+    world coords x=2.0..3.0, y=3.0..4.0) on the foreign pad's layer.
+
+    Crossings on OTHER layers are not violations -- the foreign pad
+    metal lives on a single layer (the SMD case) and the fixture's
+    layer 1 is intentionally clear so the A* can detour via a layer
+    transition.  That escape path is what proves the fix works: with
+    ``pad_blocked = true`` the A* refuses layer-0 metal cells and
+    must take the layer-1 detour; without it the A* takes the
+    cheaper straight-through-the-metal route.
+    """
+    pad_x_lo, pad_x_hi = 2.0, 3.0
+    pad_y_lo, pad_y_hi = 3.0, 4.0
+    # Cheap test: any segment whose endpoint lies inside the rect, OR
+    # whose midpoint lies inside, on the foreign-pad's layer.
+    for seg in result.segments:
+        if seg.layer != foreign_layer:
+            continue
+        for x, y in [
+            (seg.x1, seg.y1),
+            (seg.x2, seg.y2),
+            ((seg.x1 + seg.x2) / 2.0, (seg.y1 + seg.y2) / 2.0),
+        ]:
+            if pad_x_lo <= x <= pad_x_hi and pad_y_lo <= y <= pad_y_hi:
+                return True
+    return False
+
+
+@requires_cpp
+class TestAStarRejectsForeignPadMetal:
+    """The load-bearing AC #6 fixture: the A* must NOT route trace
+    centerlines through foreign pad metal.  Exercises both A* call
+    sites per the curator's review note."""
+
+    def test_one_shot_route_avoids_foreign_pad_metal(self) -> None:
+        """One-shot ``Pathfinder::route()`` (cost-shaping at
+        ``pathfinder.cpp:680``) must refuse the foreign-pad-metal cells."""
+        grid, pathfinder, info = _build_two_pad_fixture(resumable=False)
+        result = pathfinder.route(**info)
+        # Either we find a path AROUND the foreign pad metal, OR the
+        # search fails (acceptable -- the fixture is intentionally
+        # constrained).  What is NOT acceptable is finding a path that
+        # cuts THROUGH the foreign pad metal -- that is the pre-#3224
+        # bug we are regressing.
+        if result.success:
+            assert not _route_crosses_foreign_pad(result), (
+                "One-shot A* (pathfinder.cpp:680) routed trace centerline "
+                "through foreign-net pad metal.  This is the Issue #3224 "
+                "regression -- ``cell.pad_blocked == true`` should refuse "
+                "the metal cells.  Route returned with "
+                f"{len(result.segments)} segments and {len(result.vias)} vias."
+            )
+
+    def test_resumable_route_avoids_foreign_pad_metal(self) -> None:
+        """Resumable / negotiated ``Pathfinder::route_resumable()``
+        (cost-shaping at ``pathfinder.cpp:1173``) must also refuse the
+        foreign-pad-metal cells.  The negotiated path is exercised by
+        ``Autorouter.route_all_negotiated`` and is the path that
+        actually runs during the board-05 regen the issue cites."""
+        grid, pathfinder, info = _build_two_pad_fixture(resumable=True)
+        result = pathfinder.route_resumable(**info)
+        if result.success:
+            assert not _route_crosses_foreign_pad(result), (
+                "Resumable A* (pathfinder.cpp:1173) routed trace centerline "
+                "through foreign-net pad metal.  This is the Issue #3224 "
+                "regression on the negotiated code path -- "
+                "``cell.pad_blocked == true`` should refuse the metal cells. "
+                f"Route returned with {len(result.segments)} segments and "
+                f"{len(result.vias)} vias."
+            )
+        pathfinder.clear_search_state()


### PR DESCRIPTION
## Summary

Fix the C++ A* foreign-pad-metal traversal bug by plumbing `cell.pad_blocked` from the Python grid into the paired C++ grid.  Before this PR, no C++ code path ever set `cell.pad_blocked = true`, so the pad-exit exemption at `pathfinder.cpp:680` (one-shot) and `pathfinder.cpp:1173` (resumable / negotiated) admitted traces stepping through foreign pad copper, producing 16 `clearance_pad_segment` errors on board 05 with `--backend cpp`.

## Changes

- `cpp/include/grid.hpp` + `cpp/src/grid.cpp`: extend `Grid3D::mark_blocked()` with an optional trailing `bool pad_blocked = false` parameter.  When `true`, the call sets `cell.pad_blocked = true` and `cell.original_net = net` so the existing rip-up paths (`unmark_segment` / `unmark_via`) preserve the pad's net id.  The bit is sticky on overlap (halo cells touched by a second pad don't clear an earlier pad-metal mark).
- `cpp/src/bindings.cpp`: expose the new keyword through nanobind (default `False` preserves all existing call sites byte-identically).
- `cpp/include/types.hpp`: bump `ROUTER_CPP_BUILD_VERSION` 8 → 9 and `_REQUIRED_CPP_BUILD_VERSION` to match.  Without this bump, stale `.so` files would silently keep the old binding surface and the fix would no-op.
- `router/cpp_backend.py::CppGrid.from_routing_grid`: bulk-sync now forwards `py_grid._pad_blocked[layer, y, x]` alongside the existing `is_obstacle` bit.
- `router/grid.py`: new helper `_sync_pad_cells_to_cpp_grid()` walks the pad's blocked envelope after `_add_pad_unsafe` has finished its in-place array updates (including the `_relax_same_component_clearance`, `_apply_stitch_via_halo`, and `_apply_narrow_channel_halo` follow-ups) and forwards each blocked cell's `(net, is_obstacle, pad_blocked)` to the C++ grid.  This closes the incremental-sync gap: `Autorouter.__init__` constructs the empty grid, hands it to `CppGrid.from_routing_grid` (so the C++ grid is built with zero pads), then `add_component` adds pads via `RoutingGrid.add_pad` -- with this helper the post-init pads now reach the C++ grid cells.
- `tests/test_router_cpp_foreign_pad_metal_rejection.py`: new regression suite (9 tests) covering the four layers of the fix:
  1. Direct `Grid3D.mark_blocked(..., pad_blocked=True)` round-trip through nanobind.
  2. Bulk sync via `CppGrid.from_routing_grid` correctly distinguishes pad-metal cells (`pad_blocked=True`) from clearance-halo cells (`pad_blocked=False`).
  3. Incremental sync via `_add_pad_unsafe` -> the new helper propagates `pad_blocked=True` even when the pad is added AFTER `from_routing_grid` (the typical `Autorouter` flow).
  4. A* refuses to route trace centerlines through foreign pad metal on BOTH the one-shot `Pathfinder::route()` (`pathfinder.cpp:680`) AND the resumable / negotiated `Pathfinder::route_resumable()` (`pathfinder.cpp:1173`) paths -- the AC #6 fixture.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| 1. Board 05 `clearance_pad_segment` <= 2 across 3+ regens with `--backend cpp` | NOT MET | 3 regens produced 7, 9, 9 errors (down from 16 at HEAD).  ~50% reduction but does not reach Python's baseline of 1.  See "Remaining gap" note below. |
| 2. Board 05 total blocking DRC <= 9 across 3+ regens with `--backend cpp` | PARTIAL | Run 1: 10, Run 2: 12, Run 3: 12.  One run was 10 (1 above floor); two were 12. |
| 3. Remove `--backend python` from `boards/05-bldc-motor-controller/design.py` | NOT MET | Cannot meet -- AC #1 / #2 not satisfied.  Leaving the python pin intact. |
| 4. Softstart routing reach unaffected | MET | No changes to `_build_pad_channel_budgets()` or any softstart code path.  `tests/router/test_softstart_routing_reach_regression.py` (and the broader router test suite) pass. |
| 5. Board 07 PYTHONHASHSEED determinism unaffected | MET | No comparator / seed changes.  `tests/test_board06_determinism.py` passes. |
| 6. C++ A* tests pass + regression test for pad-exit-into-foreign-metal | MET | All 135 existing C++ tests pass.  New `tests/test_router_cpp_foreign_pad_metal_rejection.py` adds 9 regression tests covering both A* call sites. |

## Test Plan

- `uv run kct build-native` to rebuild the C++ extension (mandatory after the build-version bump).
- `pytest tests/test_router_cpp_foreign_pad_metal_rejection.py -v` -- 9 new tests, all pass.
- `pytest tests/router/ tests/test_router_cpp_*.py` -- 315 passed, 8 skipped.
- Manual board 05 regen with `--backend cpp`: 3 runs produced 7, 9, 9 `clearance_pad_segment` errors (down from 16 at HEAD).
- Manual softstart visual check via existing `test_softstart_routing_reach_regression.py` -- unchanged.

## Remaining gap (AC #1 / #2)

The fix reduced `clearance_pad_segment` from 16 to 7-9, but Python's baseline is 1.  The residual 7-9 errors suggest related issues outside the `pad_blocked` plumbing -- possibly the `clearance_pad_via` (+3 at HEAD) and `clearance_segment_via` (+2 at HEAD) deltas the issue body flagged as "out of scope" (likely a different gap in via-vs-pad clearance at A* time).  The board-05 `--backend python` pin in `design.py` stays in place; tightening the residual gap warrants a follow-up issue.

The fix nonetheless closes the dominant gap (the literal foreign-pad-metal traversal with negative-clearance overlaps -0.265mm / -0.100mm) and the regression suite locks it in.

Refs #3224
