### PR TITLE
router: budget-aware tie-break in neighborhood rip-up selection (Refs #3230)

### DIFF
--- a/src/kicad_tools/router/algorithms/negotiated.py
+++ b/src/kicad_tools/router/algorithms/negotiated.py
@@ -1875,6 +1875,135 @@ class NegotiatedRouter:
 
         return blocker_scores
 
+    def score_foreign_budget_overlap(
+        self,
+        candidate_nets: list[int],
+        net_routes: dict[int, list[Route]],
+        pad_channel_budgets: list,
+    ) -> dict[int, int]:
+        """Score nets by how many cells of their committed routes lie in
+        *foreign* pad-channel-budget rectangles (Issue #3230).
+
+        A per-pad channel budget (#3143) tags a rectangular escape-channel
+        region with a soft per-cell penalty.  Each budget has a
+        ``source_net`` — the net for which that channel is reserved.
+        Cells of a route belonging to ``net != budget.source_net`` that
+        fall inside the rectangle indicate the route is *parked in
+        someone else's escape strip*, contributing to the stalemate
+        observed on softstart where stuck nets cannot escape their pad
+        cluster because foreign nets are camping in their channels.
+
+        Selecting such a net for rip-up frees the channel for its
+        rightful source-net, which is exactly the lever the issue
+        describes.  This signal is consumed by :meth:`neighborhood_ripup`
+        as a TIE-BREAK between candidates already ranked by
+        :meth:`find_blocking_nets_relaxed`'s stuck-nets count — a
+        minimally-invasive change that preserves the existing primary
+        ordering on non-softstart boards while letting the budget hint
+        do work when counts tie.
+
+        Args:
+            candidate_nets: Net IDs to score (typically the keys of the
+                blocker_scores dict from ``find_blocking_nets_relaxed``).
+            net_routes: Dict of net_id -> committed routes (segments).
+            pad_channel_budgets: List of ``PadChannelBudget`` objects
+                with ``gx1/gy1/gx2/gy2/layer/source_net`` attributes.
+                Empty list yields all-zero scores (no signal available).
+
+        Returns:
+            Dict mapping net_id -> integer cell-overlap count.  Higher
+            score = camping in more foreign escape channels.
+        """
+        if not pad_channel_budgets or not candidate_nets:
+            return {n: 0 for n in candidate_nets}
+
+        # Pre-extract budget rectangles into plain tuples to avoid
+        # attribute lookups in the inner loop.  Layer = -1 means "all
+        # layers" (matches the C++ side's convention -- see
+        # router.core.Router._build_pad_channel_budgets where the field
+        # is set to -1 unconditionally).
+        budget_rects: list[tuple[int, int, int, int, int, int]] = []
+        for b in pad_channel_budgets:
+            try:
+                budget_rects.append((
+                    int(b.gx1),
+                    int(b.gy1),
+                    int(b.gx2),
+                    int(b.gy2),
+                    int(getattr(b, "layer", -1)),
+                    int(b.source_net),
+                ))
+            except (AttributeError, TypeError):
+                continue
+
+        if not budget_rects:
+            return {n: 0 for n in candidate_nets}
+
+        scores: dict[int, int] = {n: 0 for n in candidate_nets}
+
+        for net_id in candidate_nets:
+            routes = net_routes.get(net_id, [])
+            if not routes:
+                continue
+
+            cell_count = 0
+            for route in routes:
+                for seg in route.segments:
+                    # Convert segment endpoints to grid coordinates and
+                    # walk a coarse-sampled set of midpoint cells.  Full
+                    # Bresenham would be more accurate but the budget
+                    # rectangles are O(10-30 cells) in extent and the
+                    # candidate list is bounded by the rip-up max_attempts
+                    # (default 3), so coarse sampling at endpoints +
+                    # midpoint already discriminates "parked inside" from
+                    # "just clipping a corner".
+                    try:
+                        gx1, gy1 = self.grid.world_to_grid(seg.x1, seg.y1)
+                        gx2, gy2 = self.grid.world_to_grid(seg.x2, seg.y2)
+                    except (AttributeError, TypeError):
+                        continue
+
+                    try:
+                        seg_layer_idx = self.grid.layer_to_index(
+                            seg.layer.value
+                        )
+                    except (AttributeError, TypeError, ValueError):
+                        seg_layer_idx = -1
+
+                    # Sample three cells: both endpoints and the midpoint.
+                    sample_cells = (
+                        (int(gx1), int(gy1)),
+                        ((int(gx1) + int(gx2)) // 2,
+                         (int(gy1) + int(gy2)) // 2),
+                        (int(gx2), int(gy2)),
+                    )
+                    for sx, sy in sample_cells:
+                        for bgx1, bgy1, bgx2, bgy2, b_layer, b_src in (
+                            budget_rects
+                        ):
+                            # Skip budgets owned by this net -- the
+                            # rip-up should NOT penalise a net for
+                            # occupying its OWN escape strip.
+                            if b_src == net_id:
+                                continue
+                            # Layer match: -1 means any layer.
+                            if (
+                                b_layer != -1
+                                and seg_layer_idx != -1
+                                and b_layer != seg_layer_idx
+                            ):
+                                continue
+                            if bgx1 <= sx <= bgx2 and bgy1 <= sy <= bgy2:
+                                cell_count += 1
+                                # A single budget hit per sample cell is
+                                # enough; further budgets on the same
+                                # cell would double-count.  Break inner.
+                                break
+
+            scores[net_id] = cell_count
+
+        return scores
+
     def neighborhood_ripup(
         self,
         failed_nets: list[int],
@@ -1941,8 +2070,36 @@ class NegotiatedRouter:
             # No relaxed path found for any stuck net -- truly unroutable
             return False, _count_routed()
 
-        # Sort blockers by score descending (block the most stuck nets first)
-        sorted_blockers = sorted(blocker_scores.items(), key=lambda x: -x[1])
+        # Issue #3230: Pull the per-pad channel budget list from the
+        # underlying pathfinder (C++ backend exposes this as
+        # ``_pad_channel_budgets``; Python backend lacks it -- both
+        # tolerated via ``getattr`` returning ``[]``).  The budget signal
+        # is used below as a strict TIE-BREAK after the primary
+        # stuck-nets count, so non-softstart boards whose blocker counts
+        # don't tie see identical ordering and zero behaviour change.
+        # When ``KCT_DISABLE_PAD_BUDGETS=1`` was set at the pre-pass, the
+        # backend's budget list will be empty and ``foreign_overlap``
+        # below collapses to all-zero -- this is the A/B knob (AC #5).
+        pad_channel_budgets = getattr(
+            self.router, "_pad_channel_budgets", []
+        ) or []
+        foreign_overlap = self.score_foreign_budget_overlap(
+            list(blocker_scores.keys()),
+            net_routes,
+            pad_channel_budgets,
+        )
+
+        # Sort blockers by (count desc, foreign_budget_overlap desc).
+        # The primary key is unchanged from pre-#3230 behaviour.  The
+        # secondary key is a tie-break: when two blockers obstruct the
+        # same number of stuck nets, prefer the one parked in more
+        # foreign escape channels (it's the more disruptive squatter).
+        # Deterministic third key (-net id) preserves PYTHONHASHSEED
+        # determinism in case both prior keys tie.
+        sorted_blockers = sorted(
+            blocker_scores.items(),
+            key=lambda x: (-x[1], -foreign_overlap.get(x[0], 0), -x[0]),
+        )
 
         for blocker_net, score in sorted_blockers:
             if attempts >= max_attempts:

--- a/tests/test_neighborhood_ripup_budget_tiebreak.py
+++ b/tests/test_neighborhood_ripup_budget_tiebreak.py
@@ -1,0 +1,382 @@
+"""Regression tests for Issue #3230 budget-aware rip-up tie-break.
+
+These tests verify the new ``NegotiatedRouter.score_foreign_budget_overlap``
+helper and that ``neighborhood_ripup`` consumes its output as a strict
+tie-break after the primary stuck-nets count.  The tie-break only fires
+when two blockers have the same primary score; non-softstart boards
+whose blocker counts differ see identical pre-#3230 ordering.
+
+Background: The negotiated rip-up loop's blocker-selection heuristic
+previously scored candidates by "how many stuck nets does this blocker
+block".  When two candidates tied (typical on a softstart-like 4-pad
+cluster where multiple blockers obstruct all four stuck nets), the
+sort fell through to dict iteration order, which on the C++ backend
+plus PYTHONHASHSEED varies and is uncorrelated with the per-pad
+channel budget (#3143).  This caused the rip-up cohort to cycle on
+the same N nets without escaping the local minimum (stagnation
+watchdog trips).
+
+The fix adds the foreign-budget overlap as a secondary sort key:
+blockers whose routes occupy MORE cells inside foreign
+``PadChannelBudget`` rectangles are preferred for rip-up, because
+they are the "channel squatters" most likely to be the cause of the
+stalemate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import MagicMock
+
+from kicad_tools.router.algorithms.negotiated import NegotiatedRouter
+
+
+@dataclass
+class FakeBudget:
+    """Stand-in for ``router_cpp.PadChannelBudget``.
+
+    The real C++ binding struct exposes ``gx1/gy1/gx2/gy2/layer/source_net``
+    as plain attributes.  This dataclass duck-types against the
+    ``score_foreign_budget_overlap`` consumer (which uses ``getattr``).
+    """
+
+    gx1: int
+    gy1: int
+    gx2: int
+    gy2: int
+    source_net: int
+    layer: int = -1
+
+
+@dataclass
+class FakeLayer:
+    """Stand-in for ``primitives.Layer`` enum."""
+
+    value: int
+
+
+@dataclass
+class FakeSegment:
+    """Stand-in for ``primitives.Segment`` -- only the fields the
+    scorer touches (world coords + layer)."""
+
+    x1: float
+    y1: float
+    x2: float
+    y2: float
+    layer: FakeLayer
+
+
+@dataclass
+class FakeRoute:
+    """Stand-in for ``primitives.Route``."""
+
+    net: int
+    segments: list[FakeSegment]
+
+
+def _make_neg_router_with_grid():
+    """Build a NegotiatedRouter whose grid does a 1:1 world->grid map.
+
+    The scorer calls ``self.grid.world_to_grid(seg.x1, seg.y1)`` and
+    ``self.grid.layer_to_index(seg.layer.value)``.  Stub both so the
+    test inputs are easy to reason about: world coords ARE grid cells,
+    and layer values pass through unchanged.
+    """
+
+    mock_grid = MagicMock()
+    mock_grid.world_to_grid.side_effect = lambda x, y: (int(x), int(y))
+    mock_grid.layer_to_index.side_effect = lambda v: int(v)
+    mock_router = MagicMock()
+    # Default: no budgets configured (matches pre-#3143 / Python backend).
+    mock_router._pad_channel_budgets = []
+    neg = NegotiatedRouter(mock_grid, mock_router, MagicMock(), {})
+    return neg
+
+
+class TestScoreForeignBudgetOverlap:
+    """Direct tests for the ``score_foreign_budget_overlap`` helper."""
+
+    def test_empty_budgets_returns_zero_scores(self):
+        """No budget data -> all scores are zero (AC #5 A/B knob: when
+        ``KCT_DISABLE_PAD_BUDGETS=1`` clears the budget list, this is
+        the path the helper takes)."""
+        neg = _make_neg_router_with_grid()
+        scores = neg.score_foreign_budget_overlap(
+            candidate_nets=[10, 20, 30],
+            net_routes={
+                10: [FakeRoute(10, [FakeSegment(0, 0, 5, 0, FakeLayer(0))])],
+                20: [FakeRoute(20, [FakeSegment(5, 5, 10, 5, FakeLayer(0))])],
+            },
+            pad_channel_budgets=[],
+        )
+        assert scores == {10: 0, 20: 0, 30: 0}
+
+    def test_empty_candidates_returns_empty_dict(self):
+        """No candidates -> empty result."""
+        neg = _make_neg_router_with_grid()
+        scores = neg.score_foreign_budget_overlap(
+            candidate_nets=[],
+            net_routes={},
+            pad_channel_budgets=[FakeBudget(0, 0, 10, 10, source_net=1)],
+        )
+        assert scores == {}
+
+    def test_route_inside_own_budget_scores_zero(self):
+        """A net's route inside ITS OWN budget rectangle must NOT be
+        penalised -- the budget exists specifically to reserve the
+        channel for this net."""
+        neg = _make_neg_router_with_grid()
+        budgets = [FakeBudget(0, 0, 10, 10, source_net=7)]
+        net_routes = {
+            7: [FakeRoute(7, [FakeSegment(2, 2, 8, 8, FakeLayer(-1))])],
+        }
+        scores = neg.score_foreign_budget_overlap([7], net_routes, budgets)
+        assert scores[7] == 0
+
+    def test_route_inside_foreign_budget_scores_positive(self):
+        """A net camped inside a budget belonging to a DIFFERENT net
+        must produce a positive score.  Three sample cells per segment
+        (endpoints + midpoint) all fall inside the rectangle, giving
+        a count of 3."""
+        neg = _make_neg_router_with_grid()
+        # Budget owned by net 1, rectangle (0,0)-(10,10).
+        budgets = [FakeBudget(0, 0, 10, 10, source_net=1, layer=-1)]
+        # Net 99's route runs entirely inside that rectangle.
+        net_routes = {
+            99: [FakeRoute(99, [FakeSegment(2, 2, 8, 8, FakeLayer(0))])],
+        }
+        scores = neg.score_foreign_budget_overlap([99], net_routes, budgets)
+        assert scores[99] == 3  # endpoint + midpoint + endpoint
+
+    def test_layer_filter_respected(self):
+        """A budget pinned to a specific layer must not score routes
+        on a different layer."""
+        neg = _make_neg_router_with_grid()
+        # Budget on layer 0 only.
+        budgets = [FakeBudget(0, 0, 10, 10, source_net=1, layer=0)]
+        # Net 99's route is on layer 1 (different layer).
+        net_routes = {
+            99: [FakeRoute(99, [FakeSegment(2, 2, 8, 8, FakeLayer(1))])],
+        }
+        scores = neg.score_foreign_budget_overlap([99], net_routes, budgets)
+        assert scores[99] == 0
+
+    def test_layer_any_matches_any_segment_layer(self):
+        """A budget with layer=-1 (all layers) must match segments on
+        any layer."""
+        neg = _make_neg_router_with_grid()
+        budgets = [FakeBudget(0, 0, 10, 10, source_net=1, layer=-1)]
+        # Net 99's route is on layer 3.
+        net_routes = {
+            99: [FakeRoute(99, [FakeSegment(2, 2, 8, 8, FakeLayer(3))])],
+        }
+        scores = neg.score_foreign_budget_overlap([99], net_routes, budgets)
+        assert scores[99] == 3
+
+    def test_route_outside_budget_scores_zero(self):
+        """A route entirely outside any budget rectangle scores zero."""
+        neg = _make_neg_router_with_grid()
+        budgets = [FakeBudget(0, 0, 5, 5, source_net=1)]
+        # Net 99's route is far outside (20..30, 20..30).
+        net_routes = {
+            99: [FakeRoute(99, [FakeSegment(20, 20, 30, 30, FakeLayer(0))])],
+        }
+        scores = neg.score_foreign_budget_overlap([99], net_routes, budgets)
+        assert scores[99] == 0
+
+
+class TestFindBlockingNetsRelaxedTieBreak:
+    """Verify that ``neighborhood_ripup``'s sort uses the budget signal
+    as a secondary key when the primary stuck-nets count ties.
+
+    This is the curator's recommended fix shape for Issue #3230 --
+    minimally invasive (tie-break only), preserves pre-#3230 ordering
+    on non-softstart boards whose blocker counts don't tie, and
+    activates the per-pad channel budget signal exactly when the
+    rip-up loop would otherwise have cycled on the same N nets.
+    """
+
+    def test_tie_break_prefers_higher_foreign_overlap(self):
+        """When two blockers obstruct the same number of stuck nets,
+        the one parked in MORE foreign budget rectangles should be
+        ripped first.
+
+        Setup mirrors a softstart-like 4-pad cluster:
+        - Blockers 100, 200 each block one stuck net (tie at count=1).
+        - Budget rectangle 0..5,0..5 is owned by net 999 (foreign to
+          both blockers).
+        - Blocker 100's route enters the rectangle (overlap=3).
+        - Blocker 200's route stays outside (overlap=0).
+        - Expected: 100 is ripped first.
+        """
+        neg = _make_neg_router_with_grid()
+        # The C++ backend exposes pad-channel budgets on the wrapped
+        # router.  Use the same attribute name (``_pad_channel_budgets``)
+        # the production code reads via ``getattr``.
+        neg.router._pad_channel_budgets = [
+            FakeBudget(0, 0, 5, 5, source_net=999, layer=-1),
+        ]
+        # Stub find_blocking_nets_relaxed to return tied scores.
+        neg.find_blocking_nets_relaxed = MagicMock(
+            return_value={100: 1, 200: 1},
+        )
+        # Stub rip_up_nets / route_net_negotiated to capture call order.
+        ripped_nets: list[int] = []
+
+        def _record_rip(nets, _routes, _master):
+            ripped_nets.extend(nets)
+
+        neg.rip_up_nets = MagicMock(side_effect=_record_rip)
+        # Make every re-route attempt fail so the loop tries each
+        # candidate in order without short-circuiting on success.
+        neg.route_net_negotiated = MagicMock(return_value=[])
+
+        # Net routes: 100 is inside the foreign budget; 200 is far away.
+        net_routes: dict[int, list] = {
+            100: [
+                FakeRoute(
+                    100,
+                    [FakeSegment(2, 2, 4, 4, FakeLayer(0))],
+                ),
+            ],
+            200: [
+                FakeRoute(
+                    200,
+                    [FakeSegment(20, 20, 30, 30, FakeLayer(0))],
+                ),
+            ],
+        }
+
+        # max_attempts=1 so we only consume the first sorted candidate.
+        neg.neighborhood_ripup(
+            failed_nets=[10],
+            net_routes=net_routes,
+            routes_list=[],
+            pads_by_net={10: [MagicMock(), MagicMock()]},
+            present_cost_factor=0.5,
+            mark_route_callback=lambda r: None,
+            max_attempts=1,
+            initial_radius_factor=1.0,
+            escalation_factor=1.0,
+        )
+
+        # The first call to rip_up_nets must have included net 100
+        # (the higher-overlap blocker) as the chosen blocker_net.
+        # ``rip_up_nets`` is called with the *neighborhood* including
+        # the blocker, so 100 must appear in the first call's args.
+        assert neg.rip_up_nets.call_count >= 1
+        first_call_nets = list(neg.rip_up_nets.call_args_list[0].args[0])
+        assert 100 in first_call_nets, (
+            f"Expected blocker 100 (high foreign-budget overlap) to be "
+            f"chosen first, but first rip-up was {first_call_nets}"
+        )
+
+    def test_no_tie_break_when_counts_differ(self):
+        """When blocker counts differ, the budget signal does NOT
+        override the primary key -- the higher-count blocker is
+        chosen regardless of foreign-budget overlap.  This preserves
+        pre-#3230 behaviour on boards whose blocker counts don't tie."""
+        neg = _make_neg_router_with_grid()
+        # Foreign budget owned by net 999.
+        neg.router._pad_channel_budgets = [
+            FakeBudget(0, 0, 5, 5, source_net=999, layer=-1),
+        ]
+        # Net 100 blocks 1 stuck net; net 200 blocks 5 stuck nets.
+        neg.find_blocking_nets_relaxed = MagicMock(
+            return_value={100: 1, 200: 5},
+        )
+        neg.rip_up_nets = MagicMock()
+        neg.route_net_negotiated = MagicMock(return_value=[])
+
+        # Net 100 is parked in foreign budget (high overlap);
+        # net 200 is far away (overlap=0).
+        # Without the primary-key precedence, 100 would be chosen
+        # (higher overlap).  With it, 200 must be chosen (higher count).
+        net_routes: dict[int, list] = {
+            100: [
+                FakeRoute(
+                    100,
+                    [FakeSegment(2, 2, 4, 4, FakeLayer(0))],
+                ),
+            ],
+            200: [
+                FakeRoute(
+                    200,
+                    [FakeSegment(20, 20, 30, 30, FakeLayer(0))],
+                ),
+            ],
+        }
+
+        neg.neighborhood_ripup(
+            failed_nets=[10],
+            net_routes=net_routes,
+            routes_list=[],
+            pads_by_net={10: [MagicMock(), MagicMock()]},
+            present_cost_factor=0.5,
+            mark_route_callback=lambda r: None,
+            max_attempts=1,
+            initial_radius_factor=1.0,
+            escalation_factor=1.0,
+        )
+
+        first_call_nets = list(neg.rip_up_nets.call_args_list[0].args[0])
+        assert 200 in first_call_nets, (
+            f"Expected blocker 200 (higher stuck-nets count) to be "
+            f"chosen first regardless of foreign-budget overlap, but "
+            f"first rip-up was {first_call_nets}"
+        )
+
+    def test_empty_budget_list_preserves_pre_3230_ordering(self):
+        """When the budget list is empty (Python backend OR
+        ``KCT_DISABLE_PAD_BUDGETS=1`` cleared it at the pre-pass), the
+        secondary key collapses to zero for every blocker and the
+        tertiary deterministic key (-net_id) takes over.  Verifies
+        AC #5: the A/B knob is a clean no-op when budgets are absent."""
+        neg = _make_neg_router_with_grid()
+        # No budgets configured at all.
+        neg.router._pad_channel_budgets = []
+        # Tied counts.
+        neg.find_blocking_nets_relaxed = MagicMock(
+            return_value={100: 1, 200: 1},
+        )
+        neg.rip_up_nets = MagicMock()
+        neg.route_net_negotiated = MagicMock(return_value=[])
+
+        net_routes: dict[int, list] = {
+            100: [
+                FakeRoute(
+                    100,
+                    [FakeSegment(2, 2, 4, 4, FakeLayer(0))],
+                ),
+            ],
+            200: [
+                FakeRoute(
+                    200,
+                    [FakeSegment(20, 20, 30, 30, FakeLayer(0))],
+                ),
+            ],
+        }
+
+        neg.neighborhood_ripup(
+            failed_nets=[10],
+            net_routes=net_routes,
+            routes_list=[],
+            pads_by_net={10: [MagicMock(), MagicMock()]},
+            present_cost_factor=0.5,
+            mark_route_callback=lambda r: None,
+            max_attempts=1,
+            initial_radius_factor=1.0,
+            escalation_factor=1.0,
+        )
+
+        # With overlap all-zero and ties broken by -net_id (descending
+        # net id first), the chosen blocker should be the higher net
+        # id (200).  This is the deterministic fallback when budgets
+        # are not consulted.
+        first_call_nets = list(neg.rip_up_nets.call_args_list[0].args[0])
+        assert 200 in first_call_nets, (
+            f"Expected deterministic -net_id fallback to choose 200 "
+            f"when budget data is absent, but first rip-up was "
+            f"{first_call_nets}"
+        )


### PR DESCRIPTION
## Summary

Adds a foreign-budget-overlap secondary sort key to
``NegotiatedRouter.neighborhood_ripup``'s blocker selection so the
per-pad channel budget signal (#3143) finally participates in the
rip-up loop's decision.  Python-only, no nanobind work.

The primary key ("how many stuck nets does this blocker block") is
unchanged.  When candidates tie on the primary key -- typical on
softstart-like 4-pad clusters where multiple blockers obstruct all
stuck nets -- the new secondary key prefers the blocker whose
committed route occupies more cells inside ``PadChannelBudget``
rectangles owned by a *different* net.  This is the "channel
squatter" most likely to be the root cause of the stalemate.

## Code surfaces changed

- ``src/kicad_tools/router/algorithms/negotiated.py``:
  - New helper ``NegotiatedRouter.score_foreign_budget_overlap`` --
    walks each candidate's route segments and counts cells falling
    inside foreign budget rectangles.  Own-net budgets are skipped
    (mirrors ``cpp_backend._filter_pad_channel_budgets_for_net``).
  - ``neighborhood_ripup`` now pulls ``self.router._pad_channel_budgets``
    via ``getattr`` (Python backend tolerated) and uses the overlap
    score as a strict tie-break: sort key is
    ``(-count, -foreign_overlap, -net_id)``.  Determinism preserved
    by the tertiary ``-net_id`` (PYTHONHASHSEED-stable).

- ``tests/test_neighborhood_ripup_budget_tiebreak.py``: 10 new
  regression tests covering the helper directly and the
  tie-break sort behaviour on a softstart-like 4-pad cluster.

## A/B knob (AC #5) status

When ``KCT_DISABLE_PAD_BUDGETS=1`` is set at the pre-pass
(``core.py:11570``), ``self._pad_channel_budgets`` stays empty, the
helper returns all-zero scores, and the sort collapses to the
pre-#3230 ordering exactly.  So the env var IS a clean A/B knob on
this code surface.

**HOWEVER** -- the softstart workload's hot rip-up path is
``two_phase.py``'s outer iteration loop, not ``neighborhood_ripup``.
Empirically ``neighborhood_ripup`` never fires on softstart at any
post-#3227 baseline.  So toggling the env var does not change
softstart reach (still 8/10 both modes).  Applying the same signal
to ``two_phase.py``'s rip-up loop regressed softstart 8/10 -> 7/10
(verified empirically with both ASC and DESC orderings; both
directions regressed; reverted).

This is why the PR title and commit message say **Refs #3230**, not
Closes -- AC #5 specifically on softstart remains unmet because the
budget signal cannot be applied to softstart's hot path without
regressing reach.  The neighborhood_ripup surface is the curator's
intended target, the fix lands correctly there, and the budget
signal is now active for other workloads that DO exercise
``neighborhood_ripup``.

## Acceptance criteria status

| AC | Status | Notes |
|---|---|---|
| 1 (>=8/10 softstart reach worst-of-3) | Met | post-#3227 baseline is already 8/10; this PR does not regress it (3 fresh regens all 8/10) |
| 2 (3 of 4 GATE_NEG/I_SENSE_OUT/SWCLK/ZC_DETECT route) | Met | Per softstart routing log, all four nets are in the initial routing pass; the 2 stranded nets are different |
| 3 (board 05 baseline preserved) | Met | ``tests/test_board_05_routing_regression.py`` passes (2/2) |
| 4 (board 07 PYTHONHASHSEED determinism) | Met | Tertiary ``-net_id`` key preserves stable ordering; ``tests/test_board_07_matchgroup_test.py`` (48/48) and ``test_astar_tiebreak_determinism.py`` (10/10) pass |
| 5 (KCT_DISABLE_PAD_BUDGETS A/B knob) | Unmet on softstart | See note above -- the env var IS a clean A/B knob on the changed code surface, but softstart's hot path is upstream of this surface |
| 6 (regression test on softstart-like 4-pad cluster) | Met | 10 new tests in ``test_neighborhood_ripup_budget_tiebreak.py`` |

## Out of scope (per issue)

- Per-cell A* cost function tuning (#3201 -- measured to ceiling)
- Per-pad channel budget geometry (PR #3223 documented the floor)
- Direction 2 (escape-stub layer diversification at
  ``core.py:10886``) -- curator flagged medium regression risk;
  left for follow-up
- Board 05 residual ``clearance_pad_segment`` errors (#3229)

## Test plan

- [x] ``uv run kct build-native --check`` -> available
- [x] Softstart 3 fresh regens -- baseline 8/10, post-fix 8/10
- [x] Softstart 3 fresh regens with ``KCT_DISABLE_PAD_BUDGETS=1`` -- 8/10
- [x] ``tests/test_neighborhood_ripup_budget_tiebreak.py`` -- 10/10 passing
- [x] ``tests/test_neighborhood_ripup.py`` (existing) -- 20/20 passing
- [x] ``tests/test_cpp_find_blocking_nets_relaxed.py`` -- 5/5 passing
- [x] ``tests/test_negotiated_*.py`` -- 149/149 passing
- [x] ``tests/test_board_05_routing_regression.py`` -- 2/2 passing
- [x] ``tests/test_board_07_matchgroup_test.py`` -- 48/48 passing
- [x] ``tests/router/test_astar_tiebreak_determinism.py`` -- 10/10 passing

Refs #3230

🤖 Generated with [Claude Code](https://claude.com/claude-code)