### PR TITLE
fix(zones): pad-safe fallback + ZonePartitionError for nested power-rail bboxes (Closes #3240)

### DIFF
--- a/src/kicad_tools/zones/__init__.py
+++ b/src/kicad_tools/zones/__init__.py
@@ -35,6 +35,7 @@ from .generator import (
     ZoneConfig,
     ZoneGenerator,
     ZoneOverlapWarning,
+    ZonePartitionError,
     auto_create_zones_for_pour_nets,
     parse_power_nets,
 )
@@ -43,6 +44,7 @@ __all__ = [
     "ZoneConfig",
     "ZoneGenerator",
     "ZoneOverlapWarning",
+    "ZonePartitionError",
     "auto_create_zones_for_pour_nets",
     "parse_power_nets",
 ]

--- a/src/kicad_tools/zones/generator.py
+++ b/src/kicad_tools/zones/generator.py
@@ -4,8 +4,8 @@ Zone generator for creating copper pour zones on PCBs.
 This module provides a high-level API for generating copper pour zones,
 with automatic board outline detection and sensible defaults for power nets.
 
-Outline allocator (#2771, #3043)
---------------------------------
+Outline allocator (#2771, #3043, #3240)
+---------------------------------------
 
 In addition to the layer/priority allocator (:func:`_assign_layers_for_pour_nets`),
 this module owns the *outline* allocator (:func:`_compute_pour_outlines`).
@@ -26,10 +26,24 @@ The original PR #2771 only computed each net's bbox independently and
 relied on pad-cluster separation to keep the bboxes disjoint.  On real
 boards where power-net pads are *spatially interleaved* (e.g. board 06's
 ``+3V3``/``+1V8``/``+1V2`` cluster on a BGA), the bboxes overlap and the
-silent-override returns.  Issue #3043 extends the allocator with a
+silent-override returns.  Issue #3043 extended the allocator with a
 second pass that *subtracts higher-priority bboxes from lower-priority
-outlines* (using Shapely's polygon difference), so the resulting
-outlines are disjoint regardless of pad layout.
+outlines* (using Shapely's polygon difference).
+
+Issue #3240 reported a remaining gap: when a lower-priority net's pads
+sit fully *inside* a higher-priority net's bbox, the Shapely difference
+returns empty and the legacy fallback returned the raw bbox -- producing
+zero copper for the failing net.  The fix adds:
+
+* A pad-safe-bbox fallback (tight 0.3 mm margin around the failing net's
+  own pads) used when the standard carve returns empty.
+* A "subtrahend downgrade" rule: the higher-priority net is allowed to
+  yield space by using its own pad-safe bbox (instead of the full
+  inflated raw bbox) whenever the raw bbox would over-claim a
+  lower-priority sibling's region.
+* :class:`ZonePartitionError` raised when neither fallback can produce
+  disjoint outlines (e.g. truly coincident pad layouts), so the user
+  sees an actionable error instead of a silent zero-copper failure.
 """
 
 from __future__ import annotations
@@ -66,6 +80,49 @@ class ZoneOverlapWarning:
     existing_net: str
     layer: str
     message: str
+
+
+class ZonePartitionError(RuntimeError):
+    """Raised when the outline allocator cannot produce disjoint per-net outlines.
+
+    Indicates that two or more zones sharing a layer would receive zero
+    copper because no carved-out outline can be derived for one of them.
+    This typically happens when a lower-priority net's pads sit fully
+    inside the higher-priority net's bounding region and even a tight
+    pad-bbox fallback would still overlap.
+
+    The error message lists the failing net, the layer, and the
+    higher-priority nets that fully cover it, together with suggested
+    remediations (e.g., move the failing net to another layer, shrink
+    the per-net margin, or accept routing the net as traces).
+    """
+
+    def __init__(
+        self,
+        failing_net: str,
+        layer: str,
+        covering_nets: list[str],
+        suggestion: str | None = None,
+    ):
+        self.failing_net = failing_net
+        self.layer = layer
+        self.covering_nets = list(covering_nets)
+        covering_list = ", ".join(self.covering_nets) if self.covering_nets else "(none)"
+        msg = (
+            f"Auto-pour: zone '{failing_net}' on {layer} would receive ZERO copper "
+            f"because its pad region is fully covered by higher-priority zones "
+            f"({covering_list}). "
+        )
+        if suggestion:
+            msg += suggestion
+        else:
+            msg += (
+                "Suggested fixes: (a) move one of the conflicting nets to a different "
+                "copper layer via manual zone assignment, (b) reduce the per-net pour "
+                "margin (currently ~1.5 mm), or (c) accept that this net should be "
+                "routed as traces rather than zone-filled."
+            )
+        super().__init__(msg)
 
 
 @dataclass
@@ -967,6 +1024,14 @@ def _assign_layers_for_pour_nets(
 # during the curator analysis of board 05.
 DEFAULT_POUR_BBOX_MARGIN_MM = 1.5
 
+# Tight pad-only margin used as a *fallback* when the normal carve pass
+# (#3043) would leave a zone with zero copper.  At 0.3 mm it just clears
+# typical KiCad fill rules around the pads themselves -- enough to give
+# the lower-priority net *some* copper, while staying inside the inflated
+# bbox of higher-priority neighbours (which use the 1.5 mm default).  See
+# issue #3240 for the failure shape this addresses.
+PAD_SAFE_MARGIN_MM = 0.3
+
 # Default side length of the fallback square emitted when a net has only a
 # single pad (or all its pads coincide).  Slightly larger than the margin
 # alone so single-pad nets still receive a usable copper patch.
@@ -1188,10 +1253,14 @@ def _compute_pour_outlines(
 
     outlines: dict[str, list[tuple[float, float]] | None] = {}
 
-    # First pass: compute the raw bbox for every shared-layer zone.
-    # ``raw_bboxes[net]`` is the per-net AABB polygon (or ``None`` if the net
-    # has no pads -- the fallback case at the bottom of the loop).
+    # First pass: compute the raw bbox AND a tighter pad-safe bbox for
+    # every shared-layer zone.  The pad-safe bbox is a fallback used when
+    # the carve subtraction would leave a zone with zero area; it tracks
+    # the actual pads with a minimal margin so even a fully-covered
+    # lower-priority net can still receive *some* copper around its own
+    # pads (issue #3240).
     raw_bboxes: dict[str, list[tuple[float, float]] | None] = {}
+    pad_safe_bboxes: dict[str, list[tuple[float, float]] | None] = {}
     for net_name, layer, _ in assignments:
         if layer_counts[layer] < 2:
             # Sole zone on its layer -- keep the full board outline so
@@ -1211,6 +1280,14 @@ def _compute_pour_outlines(
             continue
 
         raw_bboxes[net_name] = _clip_polygon_to_outline(bbox, board_outline)
+
+        # Pad-safe bbox: tight margin around the same pad positions.  Used
+        # as the carve fallback when the normal subtraction returns empty.
+        pad_safe = _bbox_polygon(positions, PAD_SAFE_MARGIN_MM)
+        if pad_safe is not None:
+            pad_safe_bboxes[net_name] = _clip_polygon_to_outline(
+                pad_safe, board_outline
+            )
 
     # Second pass (#3043): for each layer that hosts multiple zones, subtract
     # higher-priority zone bboxes from lower-priority zones so the final
@@ -1234,25 +1311,144 @@ def _compute_pour_outlines(
         # Sort highest priority first -- those zones "win" the overlap.
         nets_on_layer.sort(key=lambda np: np[1], reverse=True)
 
-        # Accumulate the union of higher-priority bboxes; each lower-priority
-        # zone has this union subtracted from its own bbox to keep outlines
-        # disjoint.
+        # Issue #3240 fix: when a high-priority net's RAW bbox (inflated
+        # by 1.5 mm) fully contains the pad clusters of lower-priority
+        # siblings, the legacy carve subtraction empties those siblings
+        # and they receive zero copper.  The cleanest disambiguation is
+        # to use the higher-priority net's PAD-SAFE bbox (tight 0.3 mm
+        # margin around the pads) as the subtrahend whenever the raw bbox
+        # would over-claim space that lower-priority siblings need.
+        #
+        # Strategy:
+        # 1. Each net's final outline starts as its raw bbox.
+        # 2. For each lower-priority sibling, if subtracting the
+        #    higher-priority RAW bbox would empty the sibling, we
+        #    instead subtract the higher-priority PAD-SAFE bbox.  KiCad
+        #    zones do not support holes in the outline, so we cannot
+        #    carve the higher-priority zone to make room; instead we
+        #    SHRINK its outline to the pad-safe bbox in the contested
+        #    region.
+        # 3. After the shrink decision, run the standard carve pass with
+        #    each net's "effective subtrahend" (raw or pad-safe).
+        #
+        # Note that this means the highest-priority zone may end up with
+        # a SMALLER (pad-safe) outline than its raw bbox -- but it still
+        # covers its own pads, and now the lower-priority siblings can
+        # claim the area between the pad clusters.
+
+        # Step 1: for each net, decide its "effective outline subtrahend"
+        # used when carving lower-priority siblings.  Default = raw bbox.
+        # If the raw bbox fully covers any lower-priority sibling's
+        # pad-safe bbox, downgrade this net's subtrahend to its OWN
+        # pad-safe bbox so the lower sibling can keep its copper.
+        effective_subtrahend: dict[str, list[tuple[float, float]] | None] = {}
+        for idx, (net_name, _priority) in enumerate(nets_on_layer):
+            raw = raw_bboxes.get(net_name)
+            if raw is None:
+                continue
+            pad_safe = pad_safe_bboxes.get(net_name)
+            downgrade = False
+            for lower_name, _lower_pri in nets_on_layer[idx + 1 :]:
+                lower_pad_safe = pad_safe_bboxes.get(lower_name)
+                if lower_pad_safe is None:
+                    continue
+                # Would subtracting RAW from lower_pad_safe leave empty?
+                test = _subtract_polygon(lower_pad_safe, raw)
+                if test is None:
+                    # Yes: the raw bbox over-claims this lower sibling's
+                    # pad region.  Downgrade to pad-safe so the lower
+                    # sibling survives.
+                    downgrade = True
+                    break
+            if downgrade and pad_safe is not None:
+                effective_subtrahend[net_name] = pad_safe
+            else:
+                effective_subtrahend[net_name] = raw
+
+        # Step 2: accumulate winners_union from EFFECTIVE subtrahends,
+        # not raw bboxes.  Each net's own outline is also clipped against
+        # the running winners_union.
         winners_union = None
+        winners_so_far: list[str] = []
         for net_name, _ in nets_on_layer:
             current = raw_bboxes[net_name]
+
+            # The net's own outline: start with its raw bbox, but if its
+            # effective subtrahend was downgraded to pad-safe (meaning the
+            # raw bbox was too greedy), use the pad-safe bbox so the
+            # outline matches what we subtract from siblings.
+            self_outline = effective_subtrahend.get(net_name) or current
+
+            # Subtract higher-priority effective subtrahends from this
+            # net's outline.
             if winners_union is None:
-                # Highest-priority zone keeps its bbox unchanged.
-                outlines[net_name] = current
+                final_outline = self_outline
             else:
-                outlines[net_name] = _subtract_polygon(
-                    current,
-                    winners_union,
-                    fallback=current,
-                )
-            # Add this zone's bbox to the winners-union for the next iteration.
-            winners_union = _union_polygons(winners_union, current)
+                carved = _subtract_polygon(self_outline, winners_union)
+                final_outline = carved  # may be None
+
+            if final_outline is not None:
+                outlines[net_name] = final_outline
+            else:
+                # Carve emptied the self-outline.  Try the strict pad-safe
+                # bbox of this net (in case self_outline was already the
+                # pad-safe bbox, this is redundant but cheap).
+                pad_safe = pad_safe_bboxes.get(net_name)
+                if pad_safe is None:
+                    raise ZonePartitionError(
+                        failing_net=net_name,
+                        layer=layer,
+                        covering_nets=list(winners_so_far),
+                        suggestion=(
+                            f"Net '{net_name}' has no physical pads on the "
+                            f"board; remove it from the pour-net list or "
+                            f"add the pads it needs."
+                        ),
+                    )
+
+                if winners_union is None:
+                    outlines[net_name] = pad_safe
+                else:
+                    pad_carved = _subtract_polygon(pad_safe, winners_union)
+                    if pad_carved is not None:
+                        outlines[net_name] = pad_carved
+                    else:
+                        # Numerical edge case: tiny but positive non-overlap
+                        # area below Shapely's empty-threshold.
+                        non_overlap_area = (
+                            _polygon_area_simple(pad_safe)
+                            - _polygon_overlap_area(pad_safe, winners_union)
+                        )
+                        if non_overlap_area > 1e-6:
+                            outlines[net_name] = pad_safe
+                        else:
+                            raise ZonePartitionError(
+                                failing_net=net_name,
+                                layer=layer,
+                                covering_nets=list(winners_so_far),
+                            )
+
+            # Use the EFFECTIVE subtrahend (raw or pad-safe) for the
+            # winners union, so lower-priority siblings can claim the
+            # space the higher-priority net yielded.
+            subtrahend_for_winners = effective_subtrahend.get(net_name) or current
+            winners_union = _union_polygons(winners_union, subtrahend_for_winners)
+            winners_so_far.append(net_name)
 
     return outlines
+
+
+def _polygon_area_simple(polygon: list[tuple[float, float]] | None) -> float:
+    """Shoelace polygon area (mm²); 0 for None/degenerate input."""
+    if not polygon or len(polygon) < 3:
+        return 0.0
+    area = 0.0
+    n = len(polygon)
+    for i in range(n):
+        x0, y0 = polygon[i]
+        x1, y1 = polygon[(i + 1) % n]
+        area += x0 * y1 - x1 * y0
+    return abs(area) / 2.0
 
 
 def _union_polygons(
@@ -1287,22 +1483,40 @@ def _union_polygons(
 def _subtract_polygon(
     minuend: list[tuple[float, float]],
     subtrahend,
-    fallback: list[tuple[float, float]],
-) -> list[tuple[float, float]]:
-    """Return ``minuend - subtrahend`` as a polygon.
+) -> list[tuple[float, float]] | None:
+    """Return ``minuend - subtrahend`` as a hole-free polygon, or ``None`` on failure.
 
     ``subtrahend`` may be a list of ``(x, y)`` tuples or a Shapely geometry
     (the latter is what ``_union_polygons`` returns).  KiCad zones do not
-    natively support polygon holes in the *outline*; when the subtraction
-    produces a polygon with holes, we approximate by returning the largest
-    exterior ring (which is still strictly inside ``minuend``).
+    natively support polygon holes in the *outline* (single-contour
+    polygons only).  This function therefore returns ``None`` in any of
+    these failure cases:
 
-    When the result is empty or Shapely is missing, returns ``fallback``.
+    * The difference is empty (minuend fully covered by subtrahend).
+    * The result is a MultiPolygon (multiple disjoint pieces -- only
+      the largest is returned to avoid silently dropping copper area).
+    * The result is a Polygon WITH interior holes (KiCad can't represent
+      the hole, and just using the exterior would silently overlap the
+      subtrahend -- precisely the issue #3240 failure mode).
+    * Shapely is unavailable.
+
+    Returning ``None`` lets the caller decide -- try a pad-safe fallback
+    or raise ``ZonePartitionError``.  The legacy behavior of returning
+    the un-carved minuend silently let the zone-priority resolver award
+    the entire region to higher-priority siblings, producing zero copper
+    for the failing net (issue #3240).
+
+    For the MultiPolygon case, we keep only the largest piece (a
+    pragmatic compromise -- KiCad zones can be defined multiple times
+    for the same net to cover multiple regions, but the current API
+    emits one zone per (net, layer) tuple).
     """
     try:
         from shapely.geometry import Polygon
     except ImportError:
-        return fallback
+        # Shapely unavailable: caller decides whether to keep the raw
+        # minuend (legacy behavior) or treat as failure.
+        return None
 
     minuend_poly = Polygon(minuend)
     if hasattr(subtrahend, "geom_type"):
@@ -1314,10 +1528,10 @@ def _subtract_polygon(
 
     if diff.is_empty:
         # The minuend was completely covered by higher-priority zones.
-        # Return ``fallback`` so the zone still has *some* outline (KiCad's
-        # fill resolver will still award zero copper, but the zone exists
-        # in the file for tooling that inspects declared geometry).
-        return fallback
+        # Returning None lets the caller try a pad-safe fallback or raise
+        # an actionable ZonePartitionError -- the legacy ``return fallback``
+        # path silently produced zero-copper zones (issue #3240).
+        return None
 
     if diff.geom_type == "MultiPolygon":
         # Keep only the largest piece -- KiCad zone outlines are single
@@ -1326,15 +1540,54 @@ def _subtract_polygon(
         diff = max(diff.geoms, key=lambda g: g.area)
 
     if diff.geom_type != "Polygon":
-        return fallback
+        return None
+
+    # Issue #3240: if the result has interior holes, the exterior ring
+    # alone overlaps the subtrahend (the hole is in the contested area).
+    # Returning the exterior would silently re-create the zero-copper bug
+    # -- KiCad would render the full exterior, which overlaps the
+    # subtrahend and gets zero copper from the priority resolver.  Signal
+    # failure so the caller can fall back to a pad-safe bbox that lives
+    # strictly outside the subtrahend.
+    if list(diff.interiors):
+        return None
 
     coords = list(diff.exterior.coords)
     if len(coords) > 1 and coords[0] == coords[-1]:
         coords = coords[:-1]
     if len(coords) < 3:
-        return fallback
+        return None
 
     return [(round(x, 6), round(y, 6)) for x, y in coords]
+
+
+def _polygon_overlap_area(
+    a: list[tuple[float, float]],
+    b,
+) -> float:
+    """Return the intersection area (mm²) of two polygons.
+
+    ``b`` may be a list of ``(x, y)`` tuples or a Shapely geometry.
+    Returns ``0.0`` if either operand is missing/invalid or Shapely is
+    not available.
+    """
+    if a is None or b is None:
+        return 0.0
+    try:
+        from shapely.geometry import Polygon
+    except ImportError:
+        return 0.0
+    try:
+        poly_a = Polygon(a)
+        if hasattr(b, "geom_type"):
+            poly_b = b
+        else:
+            poly_b = Polygon(b)
+        if not poly_a.is_valid or not poly_b.is_valid:
+            return 0.0
+        return poly_a.intersection(poly_b).area
+    except (ValueError, TypeError):
+        return 0.0
 
 
 def auto_create_zones_for_pour_nets(
@@ -1397,6 +1650,33 @@ def auto_create_zones_for_pour_nets(
     copper despite the file containing a zone definition for each
     (see #2771 for the board 05 reproduction).
 
+    Nested pad clusters (#3240)
+    ---------------------------
+
+    The carve pass (#3043) handles spatially-separated pad clusters
+    correctly.  Issue #3240 reported a different failure shape: when
+    a lower-priority net's pads sit fully *inside* the higher-priority
+    net's inflated bbox (chorus-test-revA case where ``+5V`` and
+    ``+3.3VA`` pads cluster inside the ``+3.3V`` bbox), the carve
+    subtraction returns empty and the legacy fallback was to return
+    the raw bbox -- which silently overlapped the higher-priority zone
+    and got zero copper from the fill resolver.
+
+    The fix has two pieces:
+
+    1. The higher-priority zone's effective subtrahend is *downgraded*
+       to its pad-safe bbox (a tight 0.3 mm margin around its pads
+       only) whenever its raw bbox would over-claim space that a
+       lower-priority sibling needs.  The higher-priority zone keeps
+       its pad-adjacent copper; the lower-priority siblings get the
+       inter-pad regions.
+    2. When even the pad-safe carve cannot produce a disjoint outline
+       (e.g. truly coincident pad layouts), the allocator raises
+       :class:`ZonePartitionError` naming the failing net, the layer,
+       and the higher-priority nets that cover it.  This replaces the
+       previous silent "zone exists but receives zero copper" behavior
+       with an actionable error.
+
     Args:
         pcb_path: Path to .kicad_pcb file (modified in place)
         pour_nets: List of (net_name, NetClass) tuples identifying
@@ -1409,6 +1689,11 @@ def auto_create_zones_for_pour_nets(
 
     Returns:
         Number of zones created
+
+    Raises:
+        ZonePartitionError: When the outline allocator cannot produce
+            disjoint per-net outlines and at least one zone would
+            receive zero copper (issue #3240).
     """
     pcb_path = Path(pcb_path)
     gen = ZoneGenerator.from_pcb(pcb_path, edge_clearance=edge_clearance)

--- a/tests/test_zone_priority.py
+++ b/tests/test_zone_priority.py
@@ -404,3 +404,422 @@ class TestZonePriorityOverlapResolution:
             f"spurious overlap warning(s) on disjoint carved polygons:\n"
             f"{captured.err}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #3240: nested-in-both-axes power-net failure shape
+# ---------------------------------------------------------------------------
+
+# The fixtures above (board-06 reproduction) place the lower-priority
+# zone's pad cluster in a strip that's narrower in y but wider in x than
+# the higher-priority zones; the carve subtraction then leaves a
+# connected central region for the lower-priority zone.  Issue #3240
+# describes a different shape: the chorus-test-revA case where +5V's pads
+# sit *inside* the +3.3V bbox in BOTH x and y.  When the union of
+# higher-priority bboxes fully covers a lower-priority bbox, the Shapely
+# difference returns empty and the legacy code returned the raw bbox --
+# producing zero copper for the failing net.  The fix (pad-safe fallback
+# + ZonePartitionError) is verified here.
+
+
+def _make_3net_nested_in_xy_pcb(tmp_path: Path) -> Path:
+    """Build a 4-layer PCB modelling the chorus-test-revA failure shape.
+
+    Layout (issue #3240 reproduction):
+    - +3.3V pads cluster in a wide region but with a non-pad gap in the
+      middle (15-40 in x at y=15, plus 60-85 in x at y=35).  This mirrors
+      the real chorus layout where +3.3V is a major rail but not
+      uniformly distributed.
+    - +5V pads cluster in the middle (45mm..55mm in x, 22mm..28mm in y)
+      -- strictly inside the +3.3V raw bbox in both dimensions.
+    - +3.3VA pads cluster in a different region (15mm..30mm in x,
+      33mm..38mm in y) -- also fully inside +3.3V's raw bbox.
+    - VBUS sits alone on one inner layer.
+    - GND on its own inner layer.
+
+    Without the fix (issue #3240), +5V and +3.3VA's raw bboxes are fully
+    inside +3.3V's raw bbox.  When +3.3V wins overlap (highest priority),
+    the Shapely difference of +5V/+3.3VA minus +3.3V returns empty and
+    the legacy ``_subtract_polygon`` returned the original raw bbox --
+    so the priority resolver awarded their full area to +3.3V, leaving
+    +5V and +3.3VA with zero copper.
+
+    With the fix:
+    1. +3.3V's effective subtrahend is downgraded to its pad-safe bbox
+       (tight 0.3 mm margin around the +3.3V pads only) because the
+       raw bbox would over-claim space lower-priority siblings need.
+    2. +3.3VA carves its raw bbox against +3.3V's pad-safe bbox --
+       producing a disjoint outline with positive area.
+    3. +5V does the same against the union of +3.3V's pad-safe bbox and
+       +3.3VA's effective subtrahend.
+    """
+    pcb_text = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "kicad")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (2 "In2.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "VBUS")
+  (net 3 "+3.3V")
+  (net 4 "+5V")
+  (net 5 "+3.3VA")
+  (gr_rect
+    (start 0 0)
+    (end 100 50)
+    (stroke (width 0.15) (type solid))
+    (fill none)
+    (layer "Edge.Cuts")
+    (uuid "edge-uuid")
+  )
+"""
+
+    rows = []
+
+    def fp(ref: str, x: float, y: float, net_num: int, net_name: str) -> str:
+        return f"""  (footprint "Test:{ref}"
+    (layer "F.Cu")
+    (at {x} {y})
+    (uuid "fp-{ref}-uuid")
+    (property "Reference" "{ref}"
+      (at 0 -2 0) (layer "F.SilkS") (uuid "{ref}-ref-uuid")
+      (effects (font (size 1 1) (thickness 0.15)))
+    )
+    (property "Value" "T"
+      (at 0 2 0) (layer "F.Fab") (uuid "{ref}-val-uuid")
+      (effects (font (size 1 1) (thickness 0.15)))
+    )
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net {net_num} "{net_name}"))
+  )"""
+
+    # +3.3V pads clustered in a smallish region (not the whole board).
+    # This mirrors the chorus-test-revA layout where +3.3V is dense in
+    # the MCU area but doesn't span the entire PCB.  Raw bbox is
+    # 18.5..51.5 x 13.5..36.5; pad-safe is 19.7..50.3 x 14.7..35.3.
+    rows.append(fp("U1", 20, 15, 3, "+3.3V"))
+    rows.append(fp("U2", 50, 15, 3, "+3.3V"))
+    rows.append(fp("U3", 20, 35, 3, "+3.3V"))
+    rows.append(fp("U4", 50, 35, 3, "+3.3V"))
+    rows.append(fp("U5", 35, 25, 3, "+3.3V"))
+    # +5V pads clustered NEAR the right edge of +3.3V's region, with
+    # raw bbox extending OUTSIDE +3.3V's pad-safe.  +5V raw =
+    # 43.5..56.5 x 20.5..29.5; the right edge (51.5..56.5) sits OUTSIDE
+    # +3.3V's pad-safe (which ends at 50.3 in x).  That sliver is what
+    # the carve preserves -- without the issue #3240 fix, the whole +5V
+    # bbox would be returned and the priority resolver would give it
+    # zero copper.
+    rows.append(fp("U6", 45, 22, 4, "+5V"))
+    rows.append(fp("U7", 55, 22, 4, "+5V"))
+    rows.append(fp("U8", 50, 28, 4, "+5V"))
+    # +3.3VA pads near the BOTTOM of +3.3V's region; +3.3VA raw bbox
+    # extends BELOW +3.3V's pad-safe.  +3.3VA raw = 18.5..36.5 x
+    # 31.5..39.5; the lower strip (35.3..39.5) sits OUTSIDE +3.3V's
+    # pad-safe (which ends at 35.3 in y).
+    rows.append(fp("U9", 20, 33, 5, "+3.3VA"))
+    rows.append(fp("U10", 35, 33, 5, "+3.3VA"))
+    rows.append(fp("U11", 27, 38, 5, "+3.3VA"))
+    # VBUS sole on inner layer.
+    rows.append(fp("U12", 80, 45, 2, "VBUS"))
+    # GND pad (sole on the other inner layer).
+    rows.append(fp("U13", 80, 5, 1, "GND"))
+
+    pcb_text += "\n".join(rows)
+    pcb_text += "\n)\n"
+
+    p = tmp_path / "three_net_nested_xy.kicad_pcb"
+    p.write_text(pcb_text)
+    return p
+
+
+def _make_3net_coincident_pads_pcb(tmp_path: Path) -> Path:
+    """Build a PCB where all three power-net pads share the same location.
+
+    Degenerate "unsolvable" case for the partition algorithm: every net's
+    pad-safe bbox covers the same point, so no carve can produce disjoint
+    outlines.  The fix should raise ``ZonePartitionError`` listing all
+    three nets rather than silently producing zero-copper zones.
+    """
+    pcb_text = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "kicad")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (2 "In2.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "VBUS")
+  (net 3 "+3.3V")
+  (net 4 "+5V")
+  (net 5 "+3.3VA")
+  (gr_rect
+    (start 0 0)
+    (end 100 50)
+    (stroke (width 0.15) (type solid))
+    (fill none)
+    (layer "Edge.Cuts")
+    (uuid "edge-uuid")
+  )
+"""
+
+    rows = []
+
+    def fp(ref: str, x: float, y: float, net_num: int, net_name: str) -> str:
+        return f"""  (footprint "Test:{ref}"
+    (layer "F.Cu")
+    (at {x} {y})
+    (uuid "fp-{ref}-uuid")
+    (property "Reference" "{ref}"
+      (at 0 -2 0) (layer "F.SilkS") (uuid "{ref}-ref-uuid")
+      (effects (font (size 1 1) (thickness 0.15)))
+    )
+    (property "Value" "T"
+      (at 0 2 0) (layer "F.Fab") (uuid "{ref}-val-uuid")
+      (effects (font (size 1 1) (thickness 0.15)))
+    )
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net {net_num} "{net_name}"))
+  )"""
+
+    # All three power-net pads at the SAME location (50, 25).  Each net's
+    # single-pad-fallback bbox is the 4x4 mm square centered at (50, 25)
+    # -- identical for all three.  No partition exists.
+    rows.append(fp("U1", 50, 25, 3, "+3.3V"))
+    rows.append(fp("U2", 50, 25, 4, "+5V"))
+    rows.append(fp("U3", 50, 25, 5, "+3.3VA"))
+    # Aux nets so the assignment path goes through the multi-power branch.
+    rows.append(fp("U4", 50, 45, 2, "VBUS"))
+    rows.append(fp("U5", 50, 5, 1, "GND"))
+
+    pcb_text += "\n".join(rows)
+    pcb_text += "\n)\n"
+
+    p = tmp_path / "three_net_coincident.kicad_pcb"
+    p.write_text(pcb_text)
+    return p
+
+
+class TestZonePartitionErrorAndPadSafeFallback:
+    """Regression tests for issue #3240.
+
+    Issue #3240 reported that on chorus-test-revA, three overlapping power
+    zones (``+5V``, ``+3.3VA``, ``+3.3V``) on F.Cu produced "zone will get
+    zero copper" warnings -- the lower-priority +3.3V net was fully covered
+    by the union of +5V and +3.3VA, the Shapely difference returned empty,
+    and the legacy ``_subtract_polygon`` silently fell back to the raw
+    +3.3V bbox.
+
+    The fix:
+    1. ``_subtract_polygon`` returns ``None`` instead of the raw fallback
+       on empty/degenerate diff results.
+    2. ``_compute_pour_outlines`` catches the ``None`` and tries a
+       pad-safe fallback (tight 0.3 mm bbox around just the net's pads).
+    3. When even the pad-safe fallback overlaps the winners union with
+       no positive non-overlap area, ``ZonePartitionError`` is raised
+       with an actionable message naming the failing net and competing
+       nets.
+    """
+
+    def test_three_power_nets_nested_in_xy_get_carved_to_pad_safe(
+        self, tmp_path: Path
+    ):
+        """The chorus-test-revA failure shape: +3.3V fully covered by +5V/+3.3VA bboxes.
+
+        With +5V and +3.3VA both having higher priority than +3.3V, the
+        union of their inflated (1.5 mm) bboxes might fully cover the
+        +3.3V raw bbox region in the contested area.  The fix's pad-safe
+        fallback ensures +3.3V still receives copper around its actual
+        pads, even when the carve subtraction returns empty.
+        """
+        from kicad_tools.zones import ZoneGenerator
+        from kicad_tools.zones.generator import _compute_pour_outlines
+
+        pcb_path = _make_3net_nested_in_xy_pcb(tmp_path)
+
+        # Order matters: +3.3V is listed LAST so it gets the lowest priority
+        # on F.Cu.  In the chorus case, +5V was priority 1 (lowest) and
+        # +3.3V was priority 3 (highest), but the failure shape is
+        # symmetric -- whichever net gets the lowest priority will have
+        # its bbox carved away by the higher-priority ones.
+        pour_nets = [
+            ("GND", NetClass.GROUND),
+            ("VBUS", NetClass.POWER),
+            ("+5V", NetClass.POWER),
+            ("+3.3VA", NetClass.POWER),
+            ("+3.3V", NetClass.POWER),
+        ]
+        count = auto_create_zones_for_pour_nets(pcb_path, pour_nets)
+        assert count == 5
+
+        pcb = PCB.load(str(pcb_path))
+        f_cu_zones = [z for z in pcb.zones if z.layer == "F.Cu"]
+        assert len(f_cu_zones) == 3, (
+            f"expected 3 power zones on F.Cu, got "
+            f"{[z.net_name for z in f_cu_zones]}"
+        )
+
+        # CORE ASSERTION (issue #3240 acceptance criterion 1, Option A):
+        # every zone has *non-zero* copper area.  Before the fix, the
+        # lowest-priority zone had its raw bbox returned (overlapping the
+        # winners), so KiCad's fill resolver would award it zero copper.
+        zone_areas = {z.net_name: _polygon_area(z.polygon) for z in f_cu_zones}
+        for net_name, area in zone_areas.items():
+            assert area > 0.0, (
+                f"zone {net_name} has zero area; issue #3240 regressed"
+            )
+
+        # Disjointness: no two power zones may overlap (otherwise the
+        # priority resolver would still silently win one and zero the other).
+        polys = {z.net_name: z.polygon for z in f_cu_zones}
+        names = list(polys)
+        for i, a in enumerate(names):
+            for b in names[i + 1 :]:
+                overlap = _polygons_overlap_area(polys[a], polys[b])
+                assert overlap < 1e-6, (
+                    f"zones {a} and {b} overlap by {overlap:.3f} mm²; "
+                    f"#3240 fix should have produced disjoint outlines"
+                )
+
+        # Direct unit-level check: the unit-level outline allocator must
+        # produce a non-None outline for the lowest-priority net.
+        gen = ZoneGenerator.from_pcb(pcb_path)
+        from kicad_tools.zones.generator import _assign_layers_for_pour_nets
+
+        assignments = _assign_layers_for_pour_nets(4, pour_nets)
+        outlines = _compute_pour_outlines(gen.pcb, assignments, gen.board_outline)
+        # Find the lowest-priority F.Cu net by inspecting assignments.
+        f_cu_assignments = [
+            (n, p) for n, layer, p in assignments if layer == "F.Cu"
+        ]
+        if f_cu_assignments:
+            lowest = min(f_cu_assignments, key=lambda np: np[1])[0]
+            assert outlines.get(lowest) is not None, (
+                f"lowest-priority net {lowest} got None outline; "
+                f"pad-safe fallback should have returned a polygon"
+            )
+
+    def test_no_zero_copper_warning_for_xy_nested_layout(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ):
+        """Issue #3240 acceptance criterion 2: no zero-copper warnings.
+
+        After the fix, the literal warning text "zero copper because the
+        other zone has equal or higher priority" must not appear in
+        stderr for the xy-nested layout.
+        """
+        pcb_path = _make_3net_nested_in_xy_pcb(tmp_path)
+        pour_nets = [
+            ("GND", NetClass.GROUND),
+            ("VBUS", NetClass.POWER),
+            ("+5V", NetClass.POWER),
+            ("+3.3VA", NetClass.POWER),
+            ("+3.3V", NetClass.POWER),
+        ]
+        auto_create_zones_for_pour_nets(pcb_path, pour_nets)
+
+        captured = capsys.readouterr()
+        assert "zero copper" not in captured.err.lower(), (
+            f"#3240 fix did not eliminate the zero-copper warning:\n"
+            f"{captured.err}"
+        )
+
+    def test_zone_partition_error_on_coincident_pad_layout(self, tmp_path: Path):
+        """Issue #3240 acceptance criterion 4 (Option B fallback).
+
+        When the failure is truly unsolvable -- three nets whose pads all
+        share the exact same location -- the fix raises
+        ``ZonePartitionError`` rather than silently producing zero-copper
+        zones.  The error message must name the failing net AND list the
+        higher-priority nets that fully cover it.
+        """
+        from kicad_tools.zones import ZonePartitionError
+
+        pcb_path = _make_3net_coincident_pads_pcb(tmp_path)
+        pour_nets = [
+            ("GND", NetClass.GROUND),
+            ("VBUS", NetClass.POWER),
+            ("+5V", NetClass.POWER),
+            ("+3.3VA", NetClass.POWER),
+            ("+3.3V", NetClass.POWER),
+        ]
+        with pytest.raises(ZonePartitionError) as exc_info:
+            auto_create_zones_for_pour_nets(pcb_path, pour_nets)
+
+        err = exc_info.value
+        # The error must name a failing net and at least one covering net.
+        assert err.failing_net in {"+5V", "+3.3VA", "+3.3V"}, (
+            f"failing net should be one of the power nets, got {err.failing_net}"
+        )
+        assert err.layer == "F.Cu", (
+            f"layer should be F.Cu (the contested layer), got {err.layer}"
+        )
+        assert len(err.covering_nets) >= 1, (
+            f"covering_nets should list at least one higher-priority net, "
+            f"got {err.covering_nets}"
+        )
+        # The error message must be actionable.
+        msg = str(err)
+        assert "zero copper" in msg.lower() or "would receive" in msg.lower(), (
+            f"error message must mention zero copper / would receive: {msg}"
+        )
+
+    def test_subtract_polygon_returns_none_on_empty_diff(self):
+        """Unit test: ``_subtract_polygon`` returns ``None`` (not fallback) when fully covered.
+
+        This is the API-level guarantee that backs the
+        ``ZonePartitionError`` plumbing -- ``_compute_pour_outlines``
+        relies on this signal to decide between pad-safe fallback and
+        partition error.
+        """
+        from kicad_tools.zones.generator import _subtract_polygon
+
+        # Minuend is a 10x10 square at origin; subtrahend is a 20x20
+        # square that fully covers it.
+        minuend = [(0, 0), (10, 0), (10, 10), (0, 10)]
+        subtrahend = [(-5, -5), (15, -5), (15, 15), (-5, 15)]
+
+        result = _subtract_polygon(minuend, subtrahend)
+        assert result is None, (
+            f"_subtract_polygon must return None on empty diff "
+            f"(legacy fallback path is the #3240 bug); got {result!r}"
+        )
+
+    def test_subtract_polygon_returns_carved_polygon_on_partial_diff(self):
+        """Unit test: ``_subtract_polygon`` returns the carved polygon when partial."""
+        from kicad_tools.zones.generator import _subtract_polygon
+
+        # Subtrahend covers only the right half of the minuend.
+        # Left half of 10x10 = 5 mm wide × 10 mm tall = 50 mm².
+        minuend = [(0, 0), (10, 0), (10, 10), (0, 10)]
+        subtrahend = [(5, -1), (11, -1), (11, 11), (5, 11)]
+
+        result = _subtract_polygon(minuend, subtrahend)
+        assert result is not None, (
+            "_subtract_polygon must return a carved polygon when "
+            "diff is non-empty"
+        )
+        # The result must have positive area strictly smaller than the
+        # original 100 mm² minuend.
+        from shapely.geometry import Polygon
+
+        result_area = Polygon(result).area
+        assert 0 < result_area < 100.0, (
+            f"carved polygon should be smaller than the full 10x10 "
+            f"(100 mm²); got {result_area}"
+        )
+        # The carved region must be disjoint from the subtrahend.
+        overlap = Polygon(result).intersection(Polygon(subtrahend)).area
+        assert overlap < 1e-6, (
+            f"carved polygon still overlaps the subtrahend by {overlap}"
+        )


### PR DESCRIPTION
## Summary

Issue #3240 reported that on chorus-test-revA, `auto-pour` produced these warnings:

```
WARNING: Zone '+3.3VA' on F.Cu (priority 2) overlaps queued zone '+3.3V' (priority 3). The new zone will get zero copper because the other zone has equal or higher priority.
WARNING: Zone '+5V'   on F.Cu (priority 1) overlaps queued zone '+3.3V' (priority 3). The new zone will get zero copper because the other zone has equal or higher priority.
WARNING: Zone '+5V'   on F.Cu (priority 1) overlaps queued zone '+3.3VA' (priority 2). The new zone will get zero copper because the other zone has equal or higher priority.
```

`+5V` and `+3.3VA` ended up with zero copper because their pads sat fully inside `+3.3V`'s inflated bbox (the carve subtraction in `_compute_pour_outlines` returned empty, and the legacy fallback returned the raw bbox).

This PR implements **Option A** (carve so all power rails get copper) with a **safety net of Option B** (raise `ZonePartitionError` when the partition is truly unsolvable). The fix lives entirely in `src/kicad_tools/zones/generator.py`.

### What changed

* **`_subtract_polygon`**: now returns `None` (not the un-carved fallback) on (a) empty diff, (b) MultiPolygon, (c) Polygon-with-holes, or (d) missing Shapely. The polygon-with-holes case was the precise #3240 failure mode -- the exterior ring alone overlaps the subtrahend and re-creates the zero-copper bug. KiCad zones don't support holes, so we signal failure to the caller instead.
* **`_compute_pour_outlines`**: pre-computes both a raw bbox (1.5 mm margin, existing) and a **pad-safe bbox** (0.3 mm margin, new) for every shared-layer net. Adds an "effective subtrahend downgrade" pass: when a high-priority net's raw bbox would over-claim a lower-priority sibling's pad region, the high-priority net is downgraded to use its own pad-safe bbox as the subtrahend. The high-priority zone keeps pad-adjacent copper; the lower-priority siblings get the inter-pad regions.
* **`ZonePartitionError`** (new): raised by `auto_create_zones_for_pour_nets` when neither the carve nor the pad-safe fallback can produce a disjoint outline (truly coincident pad layouts). Names the failing net, the layer, and the higher-priority covering nets. This replaces the previous silent zero-copper behavior with an actionable error (Option B from the issue body).

### Verification on chorus-test-revA

Before fix: `+5V` and `+3.3VA` produced zero-copper warnings.
After fix:

```
F.Cu zones: +3.3V pri=3 area=3185.6 mm²
           +3.3VA pri=2 area=101.0 mm² (6 verts, carved L-shape)
           +5V    pri=1 area=32.9 mm²
Pairwise overlap: all zero
```

No `zero copper` strings in the routing log.

### Trade-offs

* The Option-A path requires the lower-priority net's raw bbox (1.5 mm margin) to extend at least 1.2 mm outside the higher-priority net's pad-safe bbox (0.3 mm margin). When pad clusters are very close together but distinguishable, this works; when they're fully coincident, `ZonePartitionError` surfaces.
* The carved outlines may be small (~30-100 mm²) -- still positive copper, still disjoint, still avoids the silent failure. A future enhancement could emit multiple zones per net to cover non-convex regions, but that's out of scope here.

## Test plan

- [x] `tests/test_zone_priority.py` (4 existing + 5 new = 9 tests, all passing)
- [x] `tests/test_board_05_zones.py`, `tests/test_pour_net_auto_skip.py`, `tests/test_route_cmd_zone_fill.py`, `tests/test_zones.py`, `tests/test_zone_generator.py`, `tests/test_zones_cmd.py`, etc. — 256/256 zone-related tests passing
- [x] Live verification on chorus-test-revA: all 3 F.Cu power zones have positive disjoint area, no zero-copper warnings
- [x] Pre-existing test failures in `tests/test_route_zones_preserved.py::TestRouteWriteSitesPattern` confirmed to also fail on `main` (unrelated to this change)

### New regression tests

* `test_three_power_nets_nested_in_xy_get_carved_to_pad_safe` — the chorus-test-revA reproduction shape
* `test_no_zero_copper_warning_for_xy_nested_layout` — asserts the issue's literal warning text doesn't appear
* `test_zone_partition_error_on_coincident_pad_layout` — degenerate case raises `ZonePartitionError`
* `test_subtract_polygon_returns_none_on_empty_diff` — API guarantee that backs the partition-error plumbing
* `test_subtract_polygon_returns_carved_polygon_on_partial_diff` — happy path still works

Closes #3240

🤖 Generated with [Claude Code](https://claude.com/claude-code)