### PR TITLE
fix(router): auto-grid-selector bumps memory budget for clearance-safe grid (#3239)

### DIFF
--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -620,6 +620,12 @@ class GridAutoSelection:
             memory constraints (None if no capping occurred)
         origin_offset: Optimal grid origin offset (x_mm, y_mm) that maximizes
             on-grid pad count. Default (0.0, 0.0) means no offset.
+        clearance_compliant_at_clearance_over_2: True if the selected resolution
+            is <= clearance/2, satisfying the recommended DRC margin. Set by
+            the clearance-aware retry path (issue #3239).
+        memory_budget_used: The effective ``max_cells`` value the selector
+            converged on. Equals the input ``max_cells`` for normal selection,
+            or the bumped budget if the clearance-aware retry was applied.
     """
 
     resolution: float
@@ -630,6 +636,8 @@ class GridAutoSelection:
     memory_capped: bool = False
     uncapped_resolution: float | None = None
     origin_offset: tuple[float, float] = (0.0, 0.0)
+    clearance_compliant_at_clearance_over_2: bool = False
+    memory_budget_used: int = 0
 
     def summary(self) -> str:
         """Human-readable summary of the selection."""
@@ -1040,21 +1048,88 @@ def auto_select_grid_resolution(
     # Further filter by memory constraint if board dimensions provided
     memory_capped = False
     pre_memory_candidates = list(valid_candidates)
-    if board_width is not None and board_height is not None:
-        board_area = board_width * board_height
-        memory_valid = []
-        for res in valid_candidates:
-            cells = board_area / (res * res)
-            if cells <= max_cells:
-                memory_valid.append(res)
-        if memory_valid:
-            if len(memory_valid) < len(valid_candidates):
-                memory_capped = True
-            valid_candidates = memory_valid
-        # If all are too memory-intensive, keep the coarsest DRC-compliant one
-        elif valid_candidates:
-            memory_capped = True
-            valid_candidates = [valid_candidates[0]]
+    effective_max_cells = max_cells
+
+    def _apply_memory_filter(
+        cands: list[float], budget: int
+    ) -> tuple[list[float], bool]:
+        """Apply memory filter to a candidate list with the given budget.
+
+        Returns (filtered_candidates, capped_flag).
+        """
+        if board_width is None or board_height is None:
+            return cands, False
+        board_area_local = board_width * board_height
+        memory_valid_local = [
+            res for res in cands if board_area_local / (res * res) <= budget
+        ]
+        if memory_valid_local:
+            return memory_valid_local, len(memory_valid_local) < len(cands)
+        # All are too memory-intensive, keep the coarsest DRC-compliant one
+        if cands:
+            return [cands[0]], True
+        return cands, False
+
+    valid_candidates, memory_capped = _apply_memory_filter(
+        valid_candidates, effective_max_cells
+    )
+
+    # ------------------------------------------------------------------
+    # Issue #3239: clearance-aware retry.
+    #
+    # The DRC filter above accepts any candidate ``<= clearance`` (issue
+    # #2387 relaxation), but a grid coarser than ``clearance / 2`` is at
+    # higher risk of clearance violations because the router's discrete
+    # quantisation can shift traces by up to ``resolution / 2`` per axis.
+    # If the memory cap forced the selector to a coarse-but-DRC-compliant
+    # grid AND a finer ``<= clearance/2`` candidate was available before
+    # the memory filter, try a one-shot budget bump (up to 4M cells, the
+    # same ceiling ``compute_multi_resolution_plan`` already uses).
+    #
+    # This makes the memory budget self-correcting: instead of silently
+    # picking a clearance-risky grid and letting the downstream warning
+    # in ``validate_grid_resolution`` paper over the regression, the
+    # auto-selector bumps the budget when (and only when) doing so unlocks
+    # a clearance-safe grid.  If even 4M cells can't reach ``clearance/2``,
+    # we keep the coarser-but-DRC-compliant selection -- the caller's
+    # ``validate_grid_resolution`` still fires the original warning so
+    # nothing is silently lost, plus we emit our own actionable warning
+    # naming the memory cap as the cause.
+    # ------------------------------------------------------------------
+    BUMP_CEILING = 4_000_000  # Matches compute_multi_resolution_plan ceiling
+    recommended_max = clearance / 2
+    bumped = False
+    if (
+        memory_capped
+        and board_width is not None
+        and board_height is not None
+        and valid_candidates
+        and min(valid_candidates) > recommended_max
+        and any(c <= recommended_max for c in pre_memory_candidates)
+    ):
+        # The memory cap is excluding candidates that would satisfy
+        # clearance/2.  Try a budget bump.
+        bumped_budget = min(max(max_cells * 4, max_cells + 1), BUMP_CEILING)
+        if bumped_budget > effective_max_cells:
+            bumped_candidates, bumped_capped = _apply_memory_filter(
+                pre_memory_candidates, bumped_budget
+            )
+            if bumped_candidates and min(bumped_candidates) <= recommended_max:
+                # The bump unlocked a clearance-safe grid -- adopt it.
+                old_cells = effective_max_cells
+                valid_candidates = bumped_candidates
+                memory_capped = bumped_capped
+                effective_max_cells = bumped_budget
+                bumped = True
+                logger.info(
+                    "Auto-grid: bumped memory cap from %s to %s cells "
+                    "to keep grid <= %.4fmm (clearance/2 = %.4f/2). "
+                    "Reason: memory cap was forcing a clearance-risky grid.",
+                    f"{old_cells:,}",
+                    f"{bumped_budget:,}",
+                    recommended_max,
+                    clearance,
+                )
 
     # Analyze off-grid pads for each candidate, using optimal origin offset.
     # For each candidate resolution, we find the grid origin offset that
@@ -1107,6 +1182,28 @@ def auto_select_grid_resolution(
         # (pre_memory_candidates is sorted coarsest-first)
         uncapped_resolution = pre_memory_candidates[-1]
 
+    # Issue #3239: if the memory cap (even after any bump) forced a grid
+    # coarser than clearance/2 AND there was a finer candidate available
+    # before memory filtering, emit an actionable warning that names the
+    # specific knob the user can turn.  This is more informative than the
+    # generic "may cause clearance violations" warning from
+    # validate_grid_resolution -- it tells the user that the memory budget,
+    # not the candidate list, is the binding constraint.
+    if (
+        memory_capped
+        and best_resolution > recommended_max
+        and any(c <= recommended_max for c in pre_memory_candidates)
+    ):
+        warnings.warn(
+            f"Auto-grid: memory budget cap forces grid {best_resolution}mm > "
+            f"clearance/2 ({recommended_max}mm) even at "
+            f"max_cells={effective_max_cells:,}. Routing may produce clearance "
+            f"violations at fine-pitch pads. Increase max_cells (currently "
+            f"capped at {BUMP_CEILING:,} by the auto-grid retry) or use a "
+            f"looser manufacturer profile.",
+            stacklevel=2,
+        )
+
     return GridAutoSelection(
         resolution=best_resolution,
         off_grid_pads=best_off_grid,
@@ -1116,6 +1213,8 @@ def auto_select_grid_resolution(
         memory_capped=memory_capped,
         uncapped_resolution=uncapped_resolution,
         origin_offset=best_offset,
+        clearance_compliant_at_clearance_over_2=best_resolution <= recommended_max,
+        memory_budget_used=effective_max_cells,
     )
 
 

--- a/tests/test_grid_auto_selection.py
+++ b/tests/test_grid_auto_selection.py
@@ -1,5 +1,8 @@
 """Tests for automatic grid resolution selection."""
 
+import logging
+import warnings
+
 import pytest
 
 from kicad_tools.router.io import (
@@ -389,6 +392,206 @@ class TestMemoryCapping:
         )
         summary = result.summary()
         assert "capped" not in summary.lower()
+
+
+class TestClearanceAwareMemoryBump:
+    """Tests for issue #3239: clearance-aware memory budget bump.
+
+    When the memory cap forces a grid coarser than ``clearance / 2``, the
+    auto-selector should attempt a one-shot budget bump (up to 4M cells)
+    so the selected grid stays clearance-safe.  If the bump cannot achieve
+    ``<= clearance/2``, an actionable warning naming the memory cap as the
+    cause is emitted instead of the generic ``may cause clearance
+    violations`` warning.
+    """
+
+    def _chorus_like_pads(self) -> list[PadPosition]:
+        """Pad layout that exercises the chorus-test-revA selection path.
+
+        A handful of metric pads on a grid coarse enough to align to 0.1mm,
+        plus a few on 0.05mm half-grid offsets to keep off-grid analysis
+        non-trivial.
+        """
+        return [
+            PadPosition(x=2.0, y=2.0),
+            PadPosition(x=4.0, y=2.0),
+            PadPosition(x=6.0, y=2.0),
+            PadPosition(x=2.0, y=4.0),
+            PadPosition(x=4.05, y=4.0),  # 0.05mm half-grid offset
+            PadPosition(x=6.0, y=4.05),
+        ]
+
+    def test_chorus_like_memory_cap_bumps_to_clearance_safe(self, caplog):
+        """Chorus-like board: memory cap forces 0.127mm, bump unlocks
+        a clearance-safe grid (<= 0.075mm).
+
+        Acceptance criterion #1: at clearance=0.15mm on a 65x56mm board
+        with default max_cells=500_000, the selector should bump and pick
+        a grid <= 0.075mm without emitting "may cause clearance violations".
+        """
+        pads = self._chorus_like_pads()
+
+        with caplog.at_level(logging.INFO, logger="kicad_tools.router.io"):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                result = auto_select_grid_resolution(
+                    pads,
+                    clearance=0.15,
+                    board_width=65.0,
+                    board_height=56.0,
+                    max_cells=500_000,
+                )
+
+        # Acceptance criterion #1: selected grid <= clearance/2 = 0.075mm
+        assert result.resolution <= 0.075, (
+            f"Expected grid <= 0.075mm, got {result.resolution}mm. "
+            f"Bump path did not engage or did not pick a safe grid."
+        )
+        assert result.clearance_compliant_at_clearance_over_2 is True
+
+        # No "may cause clearance violations" warning text
+        warning_texts = [str(w.message) for w in caught]
+        for text in warning_texts:
+            assert "may cause clearance violations" not in text, (
+                f"Unexpected clearance-violation warning emitted: {text}"
+            )
+
+        # Acceptance criterion #2: bump is logged at INFO level
+        bump_logs = [
+            r for r in caplog.records
+            if "bumped memory cap" in r.message.lower()
+        ]
+        assert bump_logs, (
+            f"Expected INFO log mentioning the memory cap bump. "
+            f"Got records: {[r.message for r in caplog.records]}"
+        )
+        # Bump log should reference the new cell count
+        assert any(
+            str(result.memory_budget_used) in r.message
+            or f"{result.memory_budget_used:,}" in r.message
+            for r in bump_logs
+        ), "Bump log should name the new max_cells value"
+
+        # Effective budget should have been bumped above the default
+        assert result.memory_budget_used > 500_000
+
+    def test_loose_clearance_pad_alignment_preserved(self):
+        """Issue #2387 regression guard: at clearance=0.30mm, the
+        selector still prefers a coarser-but-pad-aligned grid (the
+        original #2387 intent) when no memory cap is in play.
+
+        The clearance-aware retry should ONLY engage when memory_capped
+        is True -- otherwise the existing pad-alignment-first logic
+        wins.  This test asserts that #2387's relaxation survives: at
+        loose clearance with pad-aligned candidates available, the
+        coarser grid is still picked (no over-aggressive tightening),
+        and no memory-cap warning fires because memory_capped is False.
+        """
+        # Pads aligned to 0.25mm exactly (no fractional offsets)
+        pads = [
+            PadPosition(x=2.0, y=2.0),
+            PadPosition(x=2.5, y=2.0),
+            PadPosition(x=3.0, y=2.0),
+        ]
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = auto_select_grid_resolution(
+                pads,
+                clearance=0.30,
+                board_width=20.0,
+                board_height=20.0,
+            )
+
+        # The selector picks 0.25mm: pad-aligned and DRC-compliant
+        # (<= clearance).  This is intentional #2387 behaviour even
+        # though 0.25 > clearance/2 -- the router enforces edge-to-edge
+        # clearance directly, so pad-alignment dominates when memory
+        # is not binding.
+        assert result.memory_capped is False
+        # No memory-cap warning -- bump only engages when capped.
+        warning_texts = [str(w.message) for w in caught]
+        for text in warning_texts:
+            assert "memory budget cap" not in text.lower(), (
+                f"Unexpected memory-cap warning at loose clearance: {text}"
+            )
+        # Budget was NOT bumped (default 500_000 retained)
+        assert result.memory_budget_used == 500_000
+
+    def test_unsatisfiable_budget_emits_actionable_warning(self):
+        """When even the bumped budget (4M cells) cannot satisfy
+        clearance/2, the actionable warning naming the memory cap fires.
+
+        Construct a very large board where 0.075mm grid would need
+        > 4M cells: area > 4_000_000 * 0.075^2 = 22,500 mm^2, e.g.
+        200mm x 200mm.
+        """
+        pads = [
+            PadPosition(x=10.0, y=10.0),
+            PadPosition(x=20.0, y=10.0),
+        ]
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = auto_select_grid_resolution(
+                pads,
+                clearance=0.15,
+                board_width=200.0,
+                board_height=200.0,
+                max_cells=500_000,
+            )
+
+        # The selector should NOT silently pick a clearance-risky grid
+        # without naming the cause.
+        warning_texts = [str(w.message) for w in caught]
+        actionable = [
+            t for t in warning_texts
+            if "memory budget cap" in t.lower()
+            and "max_cells" in t
+        ]
+        assert actionable, (
+            f"Expected an actionable warning naming the memory cap. "
+            f"Got warnings: {warning_texts}"
+        )
+        # The selected grid is still memory-capped and > clearance/2
+        assert result.memory_capped is True
+        assert result.resolution > 0.075
+        assert result.clearance_compliant_at_clearance_over_2 is False
+
+    def test_no_capping_no_bump_no_warning(self):
+        """When memory is not the binding constraint, the existing
+        pad-alignment-first logic runs unchanged and the bump path is
+        a no-op (no INFO log, no warning)."""
+        pads = [
+            PadPosition(x=2.0, y=2.0),
+            PadPosition(x=2.5, y=2.0),
+        ]
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = auto_select_grid_resolution(
+                pads,
+                clearance=0.15,
+                board_width=10.0,
+                board_height=10.0,
+            )
+
+        # Memory cap should not engage on a tiny board
+        assert result.memory_capped is False
+        # Budget unchanged
+        assert result.memory_budget_used == 500_000
+        # No memory-cap warning
+        warning_texts = [str(w.message) for w in caught]
+        for text in warning_texts:
+            assert "memory budget cap" not in text.lower()
+
+    def test_new_fields_set_for_normal_path(self):
+        """The new GridAutoSelection fields are populated even when
+        the bump path doesn't engage."""
+        pads = [PadPosition(x=0.0, y=0.0), PadPosition(x=2.54, y=0.0)]
+        result = auto_select_grid_resolution(pads, clearance=0.3)
+        # Default max_cells when no board dimensions -> still recorded
+        assert result.memory_budget_used == 500_000
+        # 0.3mm clearance / 2 = 0.15mm.  Default candidates include 0.1
+        # which is <= 0.15.
+        assert result.clearance_compliant_at_clearance_over_2 is True
 
 
 class TestGridAutoSelectionSummary:


### PR DESCRIPTION
## Summary

Closes #3239.

The auto-grid-selector previously treated `max_cells=500_000` as a hard ceiling and let the downstream `validate_grid_resolution` warning "Grid resolution X may cause clearance violations" be cosmetic. On chorus-test-revA with `jlcpcb-tier1` (0.15mm clearance), the memory cap forced 0.127mm grid > clearance/2 = 0.075mm, and routing proceeded silently with quantisation-induced clearance risk that looked like router bugs.

This converts the warn-and-continue behaviour into a self-correcting clearance-aware retry in `auto_select_grid_resolution`. **Option A(a)+A(b) hybrid** as recommended by the curator:

1. After the existing memory filter, detect when `memory_capped` AND selected grid > `clearance/2` AND a finer candidate was filtered out by the cap.
2. Try a one-shot budget bump to `min(max_cells * 4, 4_000_000)` -- the same 4M ceiling `compute_multi_resolution_plan` already uses, so no new policy.
3. If the bump unlocks a candidate <= `clearance/2`, adopt it and log at INFO level naming the new cell count.
4. If even 4M cells cannot reach `clearance/2`, fall back to the coarsest DRC-compliant grid and emit an **actionable** warning that names the memory cap as the cause (not the generic "may cause clearance violations" string).

## Implementation notes

- The bump engages **only** when the cap is the binding constraint -- normal small-board routing (boards 01-07, softstart) is unchanged because no cap fires there.
- The pad-alignment-first behaviour from #2387 is preserved: the bump check is gated on `memory_capped`, so loose-clearance designs where pad alignment dominates still pick the coarser pad-aligned grid (e.g. 0.25mm at clearance=0.3mm).
- `validate_grid_resolution` is **unchanged**. Other callers (legacy scripts, user-supplied `DesignRules`, `optim/router_factory`) still get warn-and-continue. Only the auto-grid path becomes self-correcting.
- `GridAutoSelection` gains two informational fields (backward-compatible defaults): `clearance_compliant_at_clearance_over_2: bool` and `memory_budget_used: int`.
- The CLI's `strict_drc=False` policy is preserved -- no public API change.

## Acceptance criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Chorus-like: auto-selector picks <= 0.075mm with no "may cause clearance violations" warning | Covered by `test_chorus_like_memory_cap_bumps_to_clearance_safe` |
| 2 | Bump logged at INFO with new cell count | Covered by same test (caplog assertion) |
| 3 | Unsatisfiable-budget case emits actionable warning naming memory cap | Covered by `test_unsatisfiable_budget_emits_actionable_warning` |
| 4 | A* runtime on board 05 <= 110% of pre-fix baseline | See "Performance notes" below |
| 5 | No regression on boards 05/06/07/softstart | Full pytest suite (18,344 tests) passes |
| 6 | #2387 pad-alignment-first regression guard | Covered by `test_loose_clearance_pad_alignment_preserved` |

## Performance notes (criterion #4)

Board 05 (BLDC motor controller) is a small board (under the memory-cap threshold at clearance=jlcpcb-tier2's looser values), so the bump path **does not engage** for board 05 with default settings. A* runtime is therefore unchanged on this board -- the criterion is satisfied by construction. The board_05 regression tests (`test_board_05_routing_regression.py`, `test_board_05_drift_regression.py`) passed unchanged in the full test suite.

The only board where this code path engages is the chorus-test-revA case named in the issue, which has explicit acceptance for accepting some routing-time increase in exchange for clearance correctness.

## Tests

Added five regression tests in `tests/test_grid_auto_selection.py::TestClearanceAwareMemoryBump`:

- `test_chorus_like_memory_cap_bumps_to_clearance_safe`: 65x56mm board + 0.15mm clearance + default 500k budget -> selector bumps and picks <= 0.075mm, INFO log fires, no warning.
- `test_loose_clearance_pad_alignment_preserved`: clearance=0.3mm pad-aligned -> #2387 behaviour preserved, no bump, no warning.
- `test_unsatisfiable_budget_emits_actionable_warning`: 200x200mm board + 0.15mm clearance -> even 4M cells can't reach clearance/2, actionable warning naming memory cap fires.
- `test_no_capping_no_bump_no_warning`: 10x10mm board -> no cap, no bump, budget unchanged.
- `test_new_fields_set_for_normal_path`: confirms backward-compatible defaults are populated.

## Test plan

- [x] `uv run pytest tests/test_grid_auto_selection.py tests/test_router_grid_auto_bump.py tests/test_pad_grid_preflight.py` -- 208 passed
- [x] `uv run pytest tests/router/` -- 197 passed, 2 skipped (unrelated)
- [x] Full `uv run pytest tests/ --ignore=tests/placement ...` -- 18,344 tests collected, exit 0 (pre-existing nanobind leak warnings unchanged)
- [x] No "may cause clearance violations" warning text introduced in any test capture
- [x] `GridAutoSelection` consumers in `kicad_tools.router.__init__` still import cleanly

## Files changed

- `src/kicad_tools/router/io.py`: `auto_select_grid_resolution` extended with clearance-aware retry; `GridAutoSelection` gains two informational fields. `validate_grid_resolution` unchanged.
- `tests/test_grid_auto_selection.py`: new `TestClearanceAwareMemoryBump` class with 5 tests.