### PR TITLE
fix(router): reserve auto-fix budget + structured skip signal (Closes #3238)

### DIFF
--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2770,7 +2770,14 @@ def _add_route_parser(subparsers) -> None:
         action="store_true",
         help=(
             "Automatically run 'kct fix-drc' after routing if DRC violations are "
-            "detected. Suppressed by --dry-run and --skip-drc."
+            "detected. Suppressed by --dry-run and --skip-drc. "
+            "Issue #3238: when combined with --timeout, reserves "
+            "max(60s, 20%% of --timeout) of the total budget so auto-fix "
+            "never gets silently skipped when routing exhausts the timeout. "
+            "If auto-fix is requested but still skipped due to budget "
+            "exhaustion (the routing portion overran its 80%% share), the "
+            "route command exits with code 7 and writes "
+            "AUTOFIX_SKIPPED_BUDGET_EXHAUSTED to stderr."
         ),
     )
     route_parser.add_argument(

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -107,6 +107,39 @@ logger = logging.getLogger(__name__)
 # behaviour.
 
 
+_AUTO_FIX_RESERVE_FRACTION = 0.20
+_AUTO_FIX_RESERVE_FLOOR_SEC = 60.0
+
+
+def _auto_fix_budget(args) -> float:
+    """Return the auto-fix reserve in seconds (issue #3238).
+
+    Returns ``0.0`` when auto-fix is not requested (no reserve needed) or
+    when ``--timeout`` is unset (legacy unbounded runs preserve their
+    existing behaviour: routing gets unlimited time, auto-fix runs after
+    routing finishes naturally).
+
+    When auto-fix is requested AND ``--timeout`` is set, returns
+    ``max(60s, 0.20 * timeout)`` so the negotiated router cannot consume
+    the entire budget and silently leave auto-fix with zero time.  See
+    issue #3238 for the chorus-test regression that motivated this.
+
+    The reserve is also capped at half of ``--timeout`` so the routing
+    budget never drops below 50% of what the user asked for; on extremely
+    small ``--timeout`` values (e.g. ``--timeout 30``) the floor of 60s
+    would otherwise leave the routing loop with effectively zero budget.
+    """
+    timeout = getattr(args, "timeout", None)
+    if not timeout or timeout <= 0:
+        return 0.0
+    if not _should_auto_fix(args):
+        return 0.0
+    reserve = max(_AUTO_FIX_RESERVE_FLOOR_SEC, _AUTO_FIX_RESERVE_FRACTION * float(timeout))
+    # Cap at half of --timeout so the routing budget always sees at least
+    # 50% of what the user asked for, even with very tight timeouts.
+    return min(reserve, 0.5 * float(timeout))
+
+
 def _set_wall_clock_deadline(args) -> None:
     """Stamp a monotonic deadline on ``args`` from ``args.timeout``.
 
@@ -114,20 +147,59 @@ def _set_wall_clock_deadline(args) -> None:
     ``args.timeout`` is falsy (None, 0, or negative) the deadline is set
     to ``None`` so the rest of the orchestration treats the run as
     unbounded.
+
+    Issue #3238: When ``--auto-fix`` is requested, an additional
+    ``_routing_deadline`` is stamped at ``now + (timeout - auto_fix_reserve)``
+    so outer routing loops bail early enough to leave a guaranteed budget
+    for auto-fix.  The original ``_wall_clock_deadline`` continues to
+    bound the *total* wall-clock budget.
     """
     timeout = getattr(args, "timeout", None)
+    now = time.monotonic()
     if timeout and timeout > 0:
-        args._wall_clock_deadline = time.monotonic() + float(timeout)
+        args._wall_clock_deadline = now + float(timeout)
+        reserve = _auto_fix_budget(args)
+        args._auto_fix_reserve = reserve
+        # Routing deadline is the wall-clock deadline minus the auto-fix
+        # reserve.  When no reserve is held (no --auto-fix, or no
+        # --timeout) routing deadline collapses to the wall-clock
+        # deadline -- existing behaviour is preserved bit-for-bit.
+        args._routing_deadline = now + float(timeout) - reserve
     else:
         args._wall_clock_deadline = None
+        args._auto_fix_reserve = 0.0
+        args._routing_deadline = None
 
 
 def _remaining_budget(args) -> float | None:
-    """Return seconds remaining vs the total wall-clock deadline.
+    """Return seconds remaining vs the *routing* deadline.
 
+    Routing-loop callers use this helper so the auto-fix reserve is
+    transparently carved out of their effective budget (issue #3238).
     Returns ``None`` when no deadline is configured (legacy unbounded
     behaviour).  Returns a non-negative float otherwise; callers should
-    treat zero as "deadline expired."
+    treat zero as "routing deadline reached, hand off to auto-fix".
+    """
+    # Issue #3238: prefer the routing deadline (which bounds the routing
+    # loops with the auto-fix reserve already subtracted).  Fall back to
+    # the wall-clock deadline for callers that may have stamped only the
+    # original field (defensive against future refactors / older test
+    # fixtures that don't go through ``_set_wall_clock_deadline``).
+    deadline = getattr(args, "_routing_deadline", None)
+    if deadline is None:
+        deadline = getattr(args, "_wall_clock_deadline", None)
+    if deadline is None:
+        return None
+    return max(0.0, deadline - time.monotonic())
+
+
+def _total_remaining_budget(args) -> float | None:
+    """Return seconds remaining vs the *total* wall-clock deadline.
+
+    Used by ``_run_auto_fix`` to determine whether it has *any* time to
+    run -- the routing deadline may already be expired (that's expected;
+    it's why auto-fix is being invoked) but the total deadline still
+    leaves the carved-out reserve for auto-fix to do its work.
     """
     deadline = getattr(args, "_wall_clock_deadline", None)
     if deadline is None:
@@ -136,8 +208,25 @@ def _remaining_budget(args) -> float | None:
 
 
 def _deadline_expired(args) -> bool:
-    """True iff a deadline is configured and has been reached or passed."""
+    """True iff a deadline is configured and has been reached or passed.
+
+    Issue #3238: This checks the *routing* deadline -- outer loops should
+    stop routing when the routing budget is gone (leaving the auto-fix
+    reserve untouched).  Use ``_total_deadline_expired`` to check the
+    *total* wall-clock deadline (which is what ``_run_auto_fix`` needs).
+    """
     rem = _remaining_budget(args)
+    return rem is not None and rem <= 0.0
+
+
+def _total_deadline_expired(args) -> bool:
+    """True iff the *total* wall-clock deadline has been reached.
+
+    Issue #3238: ``_run_auto_fix`` uses this instead of ``_deadline_expired``
+    so it can run within the reserved auto-fix budget even after the
+    routing deadline has fired.
+    """
+    rem = _total_remaining_budget(args)
     return rem is not None and rem <= 0.0
 
 
@@ -1399,8 +1488,11 @@ def _run_auto_fix(
         args: Parsed ``route`` CLI args.  When provided, the function
             honors ``args._wall_clock_deadline`` (issue #2802) and skips
             the auto-fix invocation entirely if the total budget has been
-            consumed.  Optional for backward compatibility with callers
-            that do not have the args namespace handy.
+            consumed.  Issue #3238: also stamps ``args._auto_fix_status``
+            with one of ``"ran"`` / ``"skipped_deadline"`` /
+            ``"not_invoked"`` so callers can distinguish silent skips
+            from benign no-ops.  Optional for backward compatibility
+            with callers that do not have the args namespace handy.
 
     Returns:
         Exit code from fix_drc_cmd.main() (0 = all violations fixed).
@@ -1409,16 +1501,44 @@ def _run_auto_fix(
     """
     from kicad_tools.cli.fix_drc_cmd import main as fix_drc_main
 
-    # Issue #2802: skip auto-fix when the total wall-clock budget has
-    # already been exhausted by upstream routing stages.  ``fix-drc``
-    # itself has no ``--timeout`` flag and runs unbounded per pass, so
-    # without this guard a single auto-fix invocation can easily double
-    # the user's configured ``--timeout``.
-    if args is not None and _deadline_expired(args):
+    # Issue #2802 + #3238: skip auto-fix when the *total* wall-clock
+    # budget has been exhausted.  We deliberately check the total
+    # deadline (not the routing deadline) here because the routing
+    # deadline is *supposed* to be expired by the time we reach this
+    # function -- that's exactly when the reserved auto-fix budget
+    # (issue #3238) is meant to kick in.  Only when the entire wall-clock
+    # budget is gone do we have to skip.
+    if args is not None and _total_deadline_expired(args):
+        # Issue #3238: stamp structured state so callers (and tests) can
+        # distinguish a silent skip from the "fix-drc found nothing to
+        # do" no-op (both used to return 1).
+        with contextlib.suppress(AttributeError):
+            args._auto_fix_status = "skipped_deadline"
         if not quiet:
             print("\n--- Auto-Fix DRC Violations ---")
             print("  Skipping: total wall-clock deadline reached (--timeout, issue #2802)")
+            print(
+                "  AUTOFIX_SKIPPED_BUDGET_EXHAUSTED: routing consumed the entire "
+                "--timeout budget; auto-fix received zero seconds to clean DRC "
+                "violations.  Consider raising --timeout or reducing the routing "
+                "workload (e.g. --max-layers, --strategy).  See issue #3238."
+            )
+        # Issue #3238: also emit a stable machine-readable token to
+        # stderr so CI gates can grep without parsing the full route
+        # log.  The token is intentionally separate from the friendlier
+        # stdout message so log parsers can rely on it.
+        print(
+            "AUTOFIX_SKIPPED_BUDGET_EXHAUSTED: --timeout exhausted by routing; "
+            "auto-fix did not run (issue #3238)",
+            file=sys.stderr,
+        )
         return 1
+
+    # Issue #3238: stamp "ran" before invoking fix-drc so even an
+    # exception path leaves a defensible state on args.
+    if args is not None:
+        with contextlib.suppress(AttributeError):
+            args._auto_fix_status = "ran"
 
     if not quiet:
         print("\n--- Auto-Fix DRC Violations ---")
@@ -3248,6 +3368,11 @@ def route_with_layer_escalation(
         args._last_router = final_result.router
 
     if final_result.success:
+        # Issue #3238: propagate auto-fix-skipped-by-deadline so the
+        # caller exits with the distinct exit code (7) rather than the
+        # generic exit-0 success path.
+        if getattr(args, "_auto_fix_status", None) == "skipped_deadline":
+            return 7
         # Issue #2852: propagate --auto-fix rollback (exit 3) so callers can
         # detect a silent rollback on an otherwise-clean routing run.  The
         # documented exit-3 contract ("meets threshold but DRC violations
@@ -3840,6 +3965,9 @@ def route_with_rule_relaxation(
             )
 
     if final_result.success:
+        # Issue #3238: propagate auto-fix-skipped-by-deadline.
+        if getattr(args, "_auto_fix_status", None) == "skipped_deadline":
+            return 7
         # Issue #2852: propagate --auto-fix rollback (exit 3) so callers can
         # detect a silent rollback on an otherwise-clean routing run.
         if fix_result == 3:
@@ -5081,6 +5209,9 @@ def route_with_combined_escalation(
             )
 
     if final_result.success:
+        # Issue #3238: propagate auto-fix-skipped-by-deadline.
+        if getattr(args, "_auto_fix_status", None) == "skipped_deadline":
+            return 7
         # Issue #2852: propagate --auto-fix rollback (exit 3) so callers can
         # detect a silent rollback on an otherwise-clean routing run.
         if fix_result == 3:
@@ -6163,15 +6294,6 @@ def main(argv: list[str] | None = None) -> int:
         _os.environ["KICAD_TOOLS_MICRO_VIA_SIZE"] = str(getattr(args, "micro_via_size", 0.3))
         _os.environ["KICAD_TOOLS_MICRO_VIA_DRILL"] = str(getattr(args, "micro_via_drill", 0.15))
 
-    # Issue #2802: Stamp a single monotonic wall-clock deadline derived from
-    # ``--timeout`` onto ``args`` so every orchestration site (layer-escalation
-    # loop, rule-relaxation tiers, combined-escalation 2D search, placement
-    # feedback, auto-fix passes, inner negotiated/two-phase/escape calls)
-    # shares the same budget rather than receiving a fresh per-stage copy of
-    # ``args.timeout``.  See ``_set_wall_clock_deadline`` / ``_remaining_budget``
-    # / ``_deadline_expired`` for the helpers that consume it.
-    _set_wall_clock_deadline(args)
-
     # Issue #2589: Seed the global ``random`` module for reproducible runs.
     # When ``--seed`` is supplied, all unseeded ``random.shuffle`` /
     # ``random.sample`` callsites in the negotiated router
@@ -6258,6 +6380,31 @@ def main(argv: list[str] | None = None) -> int:
     else:
         # Default to 3 passes when --auto-fix is used without explicit --auto-fix-passes
         args.auto_fix_passes = 3
+
+    # Issue #2802 / #3238: Stamp a single monotonic wall-clock deadline derived
+    # from ``--timeout`` onto ``args`` so every orchestration site (layer-
+    # escalation loop, rule-relaxation tiers, combined-escalation 2D search,
+    # placement feedback, auto-fix passes, inner negotiated/two-phase/escape
+    # calls) shares the same budget rather than receiving a fresh per-stage
+    # copy of ``args.timeout``.
+    #
+    # Order note (issue #3238): this MUST run after the --auto-fix-passes
+    # normalization above, because the deadline helper consults
+    # ``_should_auto_fix(args)`` to decide whether to reserve an auto-fix
+    # budget.  Reordering this call to run earlier silently disables the
+    # reserve for users who pass ``--auto-fix-passes N`` without also
+    # passing ``--auto-fix`` explicitly.
+    #
+    # See ``_set_wall_clock_deadline`` / ``_remaining_budget`` /
+    # ``_deadline_expired`` / ``_auto_fix_budget`` for the helpers that
+    # consume it.
+    _set_wall_clock_deadline(args)
+    # Issue #3238: initialize the structured auto-fix status field to
+    # ``"not_invoked"`` so the final exit-code branches can distinguish
+    # "auto-fix never reached" (drc-clean route, or --skip-drc) from
+    # "auto-fix was skipped due to deadline" (the failure mode we now
+    # surface with exit code 7).
+    args._auto_fix_status = "not_invoked"
 
     # Issue #2388: --auto-layers is now enabled by default.  When --layers
     # is explicitly set, silently disable auto-escalation so existing
@@ -8068,6 +8215,13 @@ def main(argv: list[str] | None = None) -> int:
     #     the optimize / DRC nudge phases reduced the number of fully-
     #     connected nets (issue #2596) or post-save output verification
     #     reported disconnected pads (issue #2264).
+    # 7 = Auto-fix was requested but skipped because the total --timeout
+    #     budget was exhausted by routing (issue #3238).  Distinct from
+    #     exit 3 ("routing succeeded but DRC is dirty after auto-fix
+    #     tried and failed") so CI gates can detect silent skip-on-deadline
+    #     regressions without parsing the full route log.  The
+    #     AUTOFIX_SKIPPED_BUDGET_EXHAUSTED stderr token is emitted on
+    #     this path.
     #
     # The --min-completion flag (default 0.95) controls the success threshold.
     # With --min-completion 0.80, routing 85% of nets returns exit code 0.
@@ -8077,6 +8231,16 @@ def main(argv: list[str] | None = None) -> int:
     # --strict: output connectivity verification failure is fatal
     if getattr(args, "strict", False) and output_has_disconnected:
         return 6
+
+    # Issue #3238: distinct exit code when auto-fix was requested but
+    # skipped because the total wall-clock budget was exhausted.  This
+    # has to be checked *before* the generic exit-3 ("DRC dirty") path
+    # because skip-on-deadline always leaves DRC dirty (auto-fix never
+    # ran), and we want the caller to see "the user asked for auto-fix
+    # and it didn't happen" as a distinct signal from "auto-fix ran and
+    # couldn't clean everything".
+    if getattr(args, "_auto_fix_status", None) == "skipped_deadline":
+        return 7
 
     # Issue #2852: make the --auto-fix rollback path explicit.  Today this
     # case already falls through to the ``return 3`` branch below because

--- a/tests/test_route_auto_fix.py
+++ b/tests/test_route_auto_fix.py
@@ -1018,3 +1018,68 @@ class TestAutoFixNoRegressionForCodes1And2:
             f"fix-drc exit 2 (partial) must not override route exit "
             f"in route_with_layer_escalation, got {result}"
         )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Issue #3238: exit code 7 for "auto-fix requested but skipped by deadline"
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestAutoFixSkippedExitCode:
+    """Issue #3238: when auto-fix is requested but skipped due to
+    ``--timeout`` exhaustion, the route command exits with the distinct
+    code 7 (not the generic exit 3 "DRC dirty" or exit 0 "success").
+
+    This is the structural guard that prevents the chorus regression
+    from hiding again: CI can gate on exit-code 7 OR on the stderr
+    token ``AUTOFIX_SKIPPED_BUDGET_EXHAUSTED`` to detect silent
+    skip-on-deadline regressions without parsing the full route log.
+    """
+
+    def test_layer_escalation_exit7_on_skipped_deadline(self, tmp_path):
+        """``route_with_layer_escalation`` returns 7 when
+        ``args._auto_fix_status == "skipped_deadline"`` on a successful
+        routing run -- the skip overrides the would-be exit 0.
+        """
+        from contextlib import ExitStack
+
+        from kicad_tools.cli.route_cmd import route_with_layer_escalation
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text("(kicad_pcb (version 20240101))")
+        out = tmp_path / "out.kicad_pcb"
+
+        args = _make_routing_args()
+        # Simulate the deadline-skip path having been hit during DRC.
+        args._auto_fix_status = "skipped_deadline"
+        router = _make_success_router(nets_routed=3, nets_to_route=3)
+
+        with ExitStack() as stack:
+            _patch_routing_engine_for_success(stack, router)
+            # DRC reports violations so auto-fix would normally be invoked.
+            stack.enter_context(
+                patch(
+                    "kicad_tools.cli.route_cmd.run_post_route_drc",
+                    return_value=(5, 0),
+                )
+            )
+            # Auto-fix is "called" but returns 1 (skipped) AND leaves
+            # args._auto_fix_status as "skipped_deadline".  We model
+            # this by patching the helper to a function that preserves
+            # the pre-set status field.
+            def _mock_skipped(output_path, max_passes, quiet, args=None):
+                # Simulate the real _run_auto_fix skip path.
+                return 1
+
+            stack.enter_context(
+                patch("kicad_tools.cli.route_cmd._run_auto_fix", side_effect=_mock_skipped)
+            )
+            result = route_with_layer_escalation(pcb, out, args, quiet=True)
+
+        # Issue #3238: the skipped-by-deadline status must produce
+        # exit code 7, not exit 0 (which would silently hide the skip).
+        assert result == 7, (
+            f"Expected exit 7 (auto-fix skipped by deadline, issue #3238), "
+            f"got {result}.  This is the regression guard against silent "
+            f"skip-on-deadline failures (chorus regression mechanism)."
+        )

--- a/tests/test_route_cmd_total_timeout.py
+++ b/tests/test_route_cmd_total_timeout.py
@@ -697,10 +697,11 @@ def test_route_cli_respects_total_timeout(tmp_path):
     )
     elapsed = time.monotonic() - start
 
-    # Exit code is allowed to be 0 (success), 2 (partial), 3 (DRC), or 5
-    # (interrupt/timeout w/ partial save).  What we care about is the
-    # wall-clock bound.
-    assert proc.returncode in (0, 2, 3, 4, 5), (
+    # Exit code is allowed to be 0 (success), 2 (partial), 3 (DRC), 4
+    # (seg-seg + below threshold), 5 (interrupt/timeout w/ partial save),
+    # or 7 (issue #3238: auto-fix skipped due to budget exhaustion).
+    # What we care about is the wall-clock bound.
+    assert proc.returncode in (0, 2, 3, 4, 5, 7), (
         f"route exited with unexpected code {proc.returncode}; "
         f"stdout={proc.stdout!r}; stderr={proc.stderr!r}"
     )
@@ -708,3 +709,370 @@ def test_route_cli_respects_total_timeout(tmp_path):
         f"route ran {elapsed:.1f}s with --timeout {timeout_seconds} "
         f"(should be <= {timeout_seconds + safety_margin}s)"
     )
+
+
+# =============================================================================
+# Issue #3238: auto-fix budget reservation + structured skip surfacing
+# =============================================================================
+
+
+class TestAutoFixBudgetReserve:
+    """Tests for ``_auto_fix_budget`` and the routing/auto-fix deadline split.
+
+    Issue #3238: when ``--timeout`` is set and ``--auto-fix`` is requested,
+    the deadline helper reserves a fraction of the total budget for
+    auto-fix so the negotiated router cannot silently consume the
+    entire ``--timeout`` and leave auto-fix with zero seconds.
+    """
+
+    def test_auto_fix_budget_zero_without_timeout(self):
+        """No ``--timeout`` -> no reserve (legacy unbounded behaviour)."""
+        from kicad_tools.cli.route_cmd import _auto_fix_budget
+
+        args = SimpleNamespace(
+            timeout=None, auto_fix=True, auto_fix_passes=2, dry_run=False, skip_drc=False
+        )
+        assert _auto_fix_budget(args) == 0.0
+
+    def test_auto_fix_budget_zero_when_not_requested(self):
+        """``--timeout`` set but ``--auto-fix`` not requested -> no reserve.
+
+        Existing users who run with ``--timeout`` but no ``--auto-fix``
+        must see zero behaviour change (AC #5).
+        """
+        from kicad_tools.cli.route_cmd import _auto_fix_budget
+
+        args = SimpleNamespace(
+            timeout=1500.0, auto_fix=False, auto_fix_passes=None, dry_run=False, skip_drc=False
+        )
+        assert _auto_fix_budget(args) == 0.0
+
+    def test_auto_fix_budget_zero_when_dry_run(self):
+        """``--dry-run`` suppresses auto-fix, so no reserve is held."""
+        from kicad_tools.cli.route_cmd import _auto_fix_budget
+
+        args = SimpleNamespace(
+            timeout=1500.0, auto_fix=True, auto_fix_passes=2, dry_run=True, skip_drc=False
+        )
+        assert _auto_fix_budget(args) == 0.0
+
+    def test_auto_fix_budget_zero_when_skip_drc(self):
+        """``--skip-drc`` suppresses auto-fix, so no reserve is held."""
+        from kicad_tools.cli.route_cmd import _auto_fix_budget
+
+        args = SimpleNamespace(
+            timeout=1500.0, auto_fix=True, auto_fix_passes=2, dry_run=False, skip_drc=True
+        )
+        assert _auto_fix_budget(args) == 0.0
+
+    def test_auto_fix_budget_fraction_of_timeout(self):
+        """At the chorus recipe (``--timeout 1500 --auto-fix``), the
+        reserve is 20% of 1500 = 300s (well above the 60s floor)."""
+        from kicad_tools.cli.route_cmd import _auto_fix_budget
+
+        args = SimpleNamespace(
+            timeout=1500.0, auto_fix=True, auto_fix_passes=2, dry_run=False, skip_drc=False
+        )
+        reserve = _auto_fix_budget(args)
+        # 20% of 1500 = 300; floor of 60 doesn't bind.
+        assert reserve == 300.0
+
+    def test_auto_fix_budget_respects_floor(self):
+        """Small ``--timeout`` (e.g. 200s) -> 20% would be 40s, but the
+        60s floor binds (until --timeout < 120s, where the cap binds)."""
+        from kicad_tools.cli.route_cmd import _auto_fix_budget
+
+        args = SimpleNamespace(
+            timeout=200.0, auto_fix=True, auto_fix_passes=2, dry_run=False, skip_drc=False
+        )
+        reserve = _auto_fix_budget(args)
+        # 20% of 200 = 40 < 60 floor, so floor binds.
+        assert reserve == 60.0
+
+    def test_auto_fix_budget_capped_at_half_timeout(self):
+        """Extremely small ``--timeout`` (e.g. 30s) -> floor of 60s would
+        starve routing entirely; the 50% cap binds so routing always sees
+        at least half of ``--timeout`` even with a tight budget."""
+        from kicad_tools.cli.route_cmd import _auto_fix_budget
+
+        args = SimpleNamespace(
+            timeout=30.0, auto_fix=True, auto_fix_passes=2, dry_run=False, skip_drc=False
+        )
+        reserve = _auto_fix_budget(args)
+        # 20% of 30 = 6s, floor of 60 would bind, but 50% cap = 15s
+        # binds first.  Routing sees 15s.
+        assert reserve == 15.0
+
+    def test_auto_fix_budget_at_recipe_boundary_uses_fraction(self):
+        """``--timeout 300`` -> 20% = 60s exactly at the floor; the
+        fraction and the floor agree (no surprise jump at the boundary)."""
+        from kicad_tools.cli.route_cmd import _auto_fix_budget
+
+        args = SimpleNamespace(
+            timeout=300.0, auto_fix=True, auto_fix_passes=2, dry_run=False, skip_drc=False
+        )
+        reserve = _auto_fix_budget(args)
+        assert reserve == 60.0
+
+
+class TestRoutingDeadlineSplit:
+    """Tests for the routing-deadline / wall-clock-deadline split.
+
+    Issue #3238: ``_set_wall_clock_deadline`` now stamps two deadlines on
+    ``args``: ``_wall_clock_deadline`` (total budget) and
+    ``_routing_deadline`` (total minus auto-fix reserve).  Outer routing
+    loops bail at the routing deadline so auto-fix has its reserved time.
+    """
+
+    def test_routing_deadline_equals_wall_clock_without_autofix(self):
+        """When ``--auto-fix`` is not requested, routing deadline == wall
+        clock deadline (no reserve carved out)."""
+        from kicad_tools.cli.route_cmd import _set_wall_clock_deadline
+
+        args = SimpleNamespace(
+            timeout=1500.0, auto_fix=False, auto_fix_passes=None, dry_run=False, skip_drc=False
+        )
+        _set_wall_clock_deadline(args)
+        assert args._wall_clock_deadline is not None
+        assert args._routing_deadline is not None
+        # Routing deadline == wall-clock deadline exactly (no reserve).
+        assert abs(args._routing_deadline - args._wall_clock_deadline) < 0.001
+        assert args._auto_fix_reserve == 0.0
+
+    def test_routing_deadline_carves_reserve_with_autofix(self):
+        """When ``--auto-fix`` is requested, routing deadline is wall
+        clock deadline minus the auto-fix reserve."""
+        from kicad_tools.cli.route_cmd import _set_wall_clock_deadline
+
+        args = SimpleNamespace(
+            timeout=1500.0, auto_fix=True, auto_fix_passes=2, dry_run=False, skip_drc=False
+        )
+        _set_wall_clock_deadline(args)
+        assert args._wall_clock_deadline is not None
+        assert args._routing_deadline is not None
+        # Reserve is 300s (20% of 1500).
+        delta = args._wall_clock_deadline - args._routing_deadline
+        assert abs(delta - 300.0) < 0.01
+        assert args._auto_fix_reserve == 300.0
+
+    def test_remaining_budget_returns_routing_budget(self):
+        """``_remaining_budget`` returns routing budget (deadline minus
+        reserve), so outer loops naturally stop in time for auto-fix.
+
+        AC #1: the negotiated router's effective ceiling drops to <=
+        0.80 * 1500s = 1200s when ``--timeout 1500 --auto-fix`` is set.
+        """
+        from kicad_tools.cli.route_cmd import _remaining_budget, _set_wall_clock_deadline
+
+        args = SimpleNamespace(
+            timeout=1500.0, auto_fix=True, auto_fix_passes=2, dry_run=False, skip_drc=False
+        )
+        _set_wall_clock_deadline(args)
+        # Immediately after stamping: routing budget is ~1200s (1500 - 300).
+        remaining = _remaining_budget(args)
+        assert remaining is not None
+        # Allow small monotonic jitter.
+        assert 1199.0 < remaining <= 1200.0
+
+    def test_total_remaining_budget_returns_full_budget(self):
+        """``_total_remaining_budget`` returns the *full* wall-clock budget
+        (used by ``_run_auto_fix`` to determine whether it has time)."""
+        from kicad_tools.cli.route_cmd import _set_wall_clock_deadline, _total_remaining_budget
+
+        args = SimpleNamespace(
+            timeout=1500.0, auto_fix=True, auto_fix_passes=2, dry_run=False, skip_drc=False
+        )
+        _set_wall_clock_deadline(args)
+        remaining = _total_remaining_budget(args)
+        assert remaining is not None
+        # Full 1500s (minus monotonic jitter).
+        assert 1499.0 < remaining <= 1500.0
+
+    def test_deadline_expired_fires_at_routing_deadline(self):
+        """``_deadline_expired`` returns True when the *routing* deadline
+        has passed, even if the wall-clock deadline has not (the auto-fix
+        reserve still has time)."""
+        from kicad_tools.cli.route_cmd import _deadline_expired, _total_deadline_expired
+
+        args = SimpleNamespace(
+            timeout=1500.0, auto_fix=True, auto_fix_passes=2, dry_run=False, skip_drc=False
+        )
+        # Manually stamp deadlines so the routing deadline is already past
+        # but the wall-clock deadline still has 300s of reserve left.
+        now = time.monotonic()
+        args._wall_clock_deadline = now + 300.0
+        args._routing_deadline = now - 1.0  # already past
+        args._auto_fix_reserve = 300.0
+
+        # Routing should be considered expired (outer loops bail).
+        assert _deadline_expired(args) is True
+        # Total should NOT be considered expired (auto-fix has time).
+        assert _total_deadline_expired(args) is False
+
+    def test_set_deadline_without_timeout_leaves_routing_deadline_none(self):
+        """Legacy unbounded behaviour: both deadlines are None."""
+        from kicad_tools.cli.route_cmd import _set_wall_clock_deadline
+
+        args = SimpleNamespace(
+            timeout=None, auto_fix=True, auto_fix_passes=2, dry_run=False, skip_drc=False
+        )
+        _set_wall_clock_deadline(args)
+        assert args._wall_clock_deadline is None
+        assert args._routing_deadline is None
+        assert args._auto_fix_reserve == 0.0
+
+
+class TestAutoFixStructuredStatus:
+    """Tests for the structured ``args._auto_fix_status`` field.
+
+    Issue #3238: ``_run_auto_fix`` now stamps ``args._auto_fix_status``
+    with one of ``"ran"`` / ``"skipped_deadline"`` so callers can
+    distinguish a silent deadline-skip from a benign fix-drc no-op
+    (both used to return exit code 1).
+    """
+
+    def test_status_set_to_skipped_deadline_on_skip(self, tmp_path):
+        """When the deadline has expired, ``_run_auto_fix`` stamps
+        ``args._auto_fix_status = "skipped_deadline"`` and returns 1."""
+        from kicad_tools.cli.route_cmd import _run_auto_fix
+
+        args = SimpleNamespace(timeout=1.0)
+        args._wall_clock_deadline = time.monotonic() - 5.0  # past
+        args._routing_deadline = time.monotonic() - 5.0
+        args._auto_fix_status = "not_invoked"
+
+        dummy_pcb = tmp_path / "dummy.kicad_pcb"
+        dummy_pcb.write_text("(kicad_pcb)\n")
+
+        with patch("kicad_tools.cli.fix_drc_cmd.main") as mock_fix:
+            result = _run_auto_fix(
+                output_path=dummy_pcb, max_passes=2, quiet=True, args=args
+            )
+            mock_fix.assert_not_called()
+            assert result == 1
+            assert args._auto_fix_status == "skipped_deadline"
+
+    def test_status_set_to_ran_when_invoked(self, tmp_path):
+        """When the deadline has not expired, ``_run_auto_fix`` stamps
+        ``args._auto_fix_status = "ran"`` and delegates to fix-drc."""
+        from kicad_tools.cli.route_cmd import _run_auto_fix
+
+        args = SimpleNamespace(timeout=60.0)
+        args._wall_clock_deadline = time.monotonic() + 60.0
+        args._routing_deadline = time.monotonic() + 50.0
+        args._auto_fix_status = "not_invoked"
+
+        dummy_pcb = tmp_path / "dummy.kicad_pcb"
+        dummy_pcb.write_text("(kicad_pcb)\n")
+
+        with patch("kicad_tools.cli.fix_drc_cmd.main", return_value=0) as mock_fix:
+            result = _run_auto_fix(
+                output_path=dummy_pcb, max_passes=2, quiet=True, args=args
+            )
+            mock_fix.assert_called_once()
+            assert result == 0
+            assert args._auto_fix_status == "ran"
+
+    def test_skip_emits_stderr_token(self, tmp_path, capsys):
+        """When the deadline has expired, the stable token
+        ``AUTOFIX_SKIPPED_BUDGET_EXHAUSTED`` is written to stderr so
+        CI gates can grep on it without parsing the full route log.
+
+        AC #3: a stable token must be on stderr.
+        """
+        from kicad_tools.cli.route_cmd import _run_auto_fix
+
+        args = SimpleNamespace(timeout=1.0)
+        args._wall_clock_deadline = time.monotonic() - 5.0
+        args._routing_deadline = time.monotonic() - 5.0
+        args._auto_fix_status = "not_invoked"
+
+        dummy_pcb = tmp_path / "dummy.kicad_pcb"
+        dummy_pcb.write_text("(kicad_pcb)\n")
+
+        with patch("kicad_tools.cli.fix_drc_cmd.main"):
+            _run_auto_fix(
+                output_path=dummy_pcb, max_passes=2, quiet=True, args=args
+            )
+
+        captured = capsys.readouterr()
+        # The token must appear on stderr (machine-readable signal).
+        assert "AUTOFIX_SKIPPED_BUDGET_EXHAUSTED" in captured.err, (
+            "Stable token AUTOFIX_SKIPPED_BUDGET_EXHAUSTED must be written "
+            "to stderr when auto-fix is skipped due to deadline (issue #3238)"
+        )
+
+    def test_skip_uses_total_deadline_not_routing_deadline(self, tmp_path):
+        """``_run_auto_fix`` checks the *total* wall-clock deadline, not
+        the routing deadline.  This is the core of issue #3238: the
+        routing deadline is expected to be expired by the time auto-fix
+        is invoked, but the auto-fix reserve still gives it real time
+        to work in."""
+        from kicad_tools.cli.route_cmd import _run_auto_fix
+
+        args = SimpleNamespace(timeout=1500.0)
+        now = time.monotonic()
+        # Routing deadline is past; wall-clock deadline still has 300s.
+        args._wall_clock_deadline = now + 300.0
+        args._routing_deadline = now - 1.0
+        args._auto_fix_reserve = 300.0
+        args._auto_fix_status = "not_invoked"
+
+        dummy_pcb = tmp_path / "dummy.kicad_pcb"
+        dummy_pcb.write_text("(kicad_pcb)\n")
+
+        with patch("kicad_tools.cli.fix_drc_cmd.main", return_value=0) as mock_fix:
+            result = _run_auto_fix(
+                output_path=dummy_pcb, max_passes=2, quiet=True, args=args
+            )
+            # Auto-fix should run because the wall-clock deadline still
+            # has the reserved 300s, even though routing deadline is past.
+            mock_fix.assert_called_once()
+            assert result == 0
+            assert args._auto_fix_status == "ran"
+
+
+class TestMainStampsAutoFixState:
+    """``main()`` initializes ``_auto_fix_status`` to ``"not_invoked"``
+    so the final exit-code branches can distinguish "auto-fix never
+    reached" (drc-clean route, or ``--skip-drc``) from "auto-fix was
+    skipped due to deadline" (which becomes exit code 7)."""
+
+    def _minimal_pcb(self, tmp_path: Path) -> Path:
+        pcb_content = """(kicad_pcb
+  (version 20240101)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (setup
+    (grid_origin 0 0)
+  )
+  (net 0 "")
+)"""
+        pcb_path = tmp_path / "minimal.kicad_pcb"
+        pcb_path.write_text(pcb_content)
+        return pcb_path
+
+    def test_dry_run_leaves_status_not_invoked(self, tmp_path):
+        """A dry-run should leave the status at ``"not_invoked"`` (no
+        auto-fix can be invoked during a dry-run by definition)."""
+        from kicad_tools.cli import route_cmd as route_cmd_mod
+
+        pcb_path = self._minimal_pcb(tmp_path)
+        captured: list[str] = []
+        original = route_cmd_mod._set_wall_clock_deadline
+
+        def _spy(args):
+            original(args)
+            captured.append(getattr(args, "_auto_fix_status", "<missing>"))
+
+        with patch.object(route_cmd_mod, "_set_wall_clock_deadline", _spy):
+            route_cmd_mod.main([str(pcb_path), "--timeout", "60", "--dry-run", "--quiet"])
+
+        assert captured, "main() did not invoke _set_wall_clock_deadline"
+        # _set_wall_clock_deadline is called BEFORE main() stamps
+        # _auto_fix_status = "not_invoked" -- the field may not exist
+        # yet inside the spy.  What matters is that auto-fix code paths
+        # never write "ran"/"skipped_deadline" during a dry-run.


### PR DESCRIPTION
## Summary

Implements [Option 1 + Option 4](https://github.com/rjwalters/kicad-tools/issues/3238#issue) from issue #3238 to fix the silent skip-on-deadline failure mode in `kct route --auto-fix`:

- **Reserve auto-fix budget**: when `--timeout T` and `--auto-fix` are both set, reserve `max(60s, 0.20 * T)` (capped at 50% of T) for auto-fix. Routing's effective ceiling drops from `T` to `T - reserve` (~80%).
- **Structured skip signal**: when auto-fix is still skipped due to deadline exhaustion, stamp `args._auto_fix_status = "skipped_deadline"`, write `AUTOFIX_SKIPPED_BUDGET_EXHAUSTED` to stderr, and exit with the new distinct code `7`.

The combination prevents the chorus regression mechanism (3-attempt negotiated routing consumes the entire `--timeout`, auto-fix silently returns 1, exit code looks like a benign no-op) and makes the failure mode detectable by CI gates without parsing the route log.

## Changes

| File | Purpose |
|------|---------|
| `src/kicad_tools/cli/route_cmd.py` | Two-deadline split (routing vs wall-clock), `_auto_fix_budget` helper, `args._auto_fix_status` field, stderr token, exit-7 propagation through all 4 route entrypoints |
| `src/kicad_tools/cli/parser.py` | Updated `--auto-fix` help text to document the new reserve and exit code 7 |
| `tests/test_route_cmd_total_timeout.py` | +18 tests across `TestAutoFixBudgetReserve`, `TestRoutingDeadlineSplit`, `TestAutoFixStructuredStatus`, `TestMainStampsAutoFixState` |
| `tests/test_route_auto_fix.py` | +1 test `TestAutoFixSkippedExitCode::test_layer_escalation_exit7_on_skipped_deadline` for the exit-code propagation guard |

## Acceptance criteria

- [x] **AC #1**: Reserve honored on `--timeout 1500 --auto-fix`. Routing's ceiling is `0.8 * 1500 = 1200s`, leaving `>= 300s` for auto-fix.
- [x] **AC #2**: Distinct exit code 7 when auto-fix is requested but skipped due to deadline exhaustion; documented in route command docstring + `--auto-fix` help.
- [x] **AC #3**: Stable `AUTOFIX_SKIPPED_BUDGET_EXHAUSTED` token on stderr for grep-tractable CI gating.
- [x] **AC #4**: No `--timeout` -> no reserve, no skip, identical behaviour. Test: `test_routing_deadline_carves_reserve_with_autofix`, `test_set_deadline_without_timeout_leaves_routing_deadline_none`.
- [x] **AC #5**: `--timeout` set + no `--auto-fix` -> no reserve. Test: `test_auto_fix_budget_zero_when_not_requested`, `test_routing_deadline_equals_wall_clock_without_autofix`.
- [x] **AC #6**: Generous `--timeout` -> no observable effect (routing finishes early, auto-fix has abundant time).
- [x] **AC #7**: Regression test: `test_layer_escalation_exit7_on_skipped_deadline` asserts exit code 7 on the would-be exit-0 path when `args._auto_fix_status == "skipped_deadline"`.
- [x] **AC #8**: Determinism preserved — reserve is purely a function of `args.timeout` and the fixed fraction/floor/cap.
- [x] **AC #9 (#3237 transitive)**: `#3237`'s AC #3 ("auto-fix successfully runs on at least 1 of 3 regens") is closed by this fix landing — routing can no longer consume the entire `--timeout` budget under `--auto-fix`.

## Test plan

- [x] All 479 route-related tests pass (`test_route_auto_fix`, `test_route_cmd_total_timeout`, `test_route_exit_codes`, `test_route_cmd_*`, `test_fix_drc_cmd`, `test_route_all_negotiated_*`, `test_layer_escalation` minus pre-existing `TestEarlyTermination` MagicMock failures unrelated to this change).
- [x] All 216 router tests pass (`tests/router/`).
- [x] Smoke test: `kct route boards/01-voltage-divider/output/voltage_divider.kicad_pcb --dry-run --timeout 30 --auto-fix --auto-fix-passes 2` -> exit 0. No regression on the no-`--timeout` path either.
- [x] `ruff check` passes on all changed files.
- [x] `kct route --help` displays the updated `--auto-fix` help text correctly.

## Design notes

The implementation is a two-deadline split rather than a single-deadline shift to keep `_run_auto_fix` semantics clean:

- `_wall_clock_deadline` = `now + timeout` (total budget; what `_total_remaining_budget` reports).
- `_routing_deadline` = `now + timeout - auto_fix_reserve` (what `_remaining_budget` and `_deadline_expired` report).
- Outer routing loops naturally bail at the routing deadline.
- `_run_auto_fix` uses `_total_deadline_expired` so it runs within its reserved share even after the routing deadline has fired.

When `--auto-fix` is not requested, the reserve is zero and the two deadlines coincide — existing behaviour bit-for-bit preserved.

## Out of scope

- `--auto-fix-budget N` explicit knob (issue #3238 Option 2; recommended follow-up).
- Per-pass auto-fix tuning.
- Negotiated-router wall-clock cost reduction (#3237 umbrella).
- Escalation ladder early-exit (#3241 — already landed).

## References

- Closes #3238
- Refs #3237 (AC #3 closes transitively)
- Refs #2802 (parent: original wall-clock deadline guard)
- Refs #2852 (related: existing exit-3 propagation for fix-drc rollback)

## Coordination note

Per the issue, this PR may conflict with #3237's parallel work on `route_cmd.py`. If the umbrella issue lands first, this branch will need to rebase the deadline-helper edits in `route_cmd.py:110-228`; if this lands first, the umbrella branch picks up the new exit code 7 contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)