### PR TITLE
fix(router): switch via-clearance kernel from Chebyshev to Euclidean disc

### DIFF
--- a/src/kicad_tools/router/cpp/include/pathfinder.hpp
+++ b/src/kicad_tools/router/cpp/include/pathfinder.hpp
@@ -283,6 +283,21 @@ private:
     // on the fly -- those branches are not perf-critical.
     std::vector<std::pair<int8_t, int8_t>> circular_kernel_offsets_;
 
+    // Issue #3234: Pre-computed circular (Euclidean) kernel offsets for
+    // ``via_half_cells_``.  Sibling to ``circular_kernel_offsets_``;
+    // closes the Chebyshev->Euclidean gap on the via-clearance side
+    // (``is_via_blocked_diag``).  Each pair ``(dx, dy)`` satisfies
+    // ``dx*dx + dy*dy <= via_half_cells_ * via_half_cells_``.  Replaces
+    // the square Chebyshev scan that produced diagonal-corner
+    // ``clearance_segment_via`` / ``clearance_pad_via`` violations whose
+    // true Euclidean clearance fell up to
+    // ``via_half_cells_ * (1 - 1/sqrt(2))`` cells short of the rule.
+    //
+    // ``radius_override > 0`` paths use an inline Euclidean filter over
+    // the bounding square rather than a temporary vector allocation
+    // (mirrors PR #3232's canonical pattern for ``is_trace_blocked``).
+    std::vector<std::pair<int8_t, int8_t>> via_kernel_offsets_;
+
     // Routable layer indices
     std::vector<int> routable_layers_;
 

--- a/src/kicad_tools/router/cpp/src/pathfinder.cpp
+++ b/src/kicad_tools/router/cpp/src/pathfinder.cpp
@@ -100,6 +100,32 @@ Pathfinder::Pathfinder(Grid3D& grid, const DesignRules& rules, bool diagonal_rou
         }
     }
 
+    // Issue #3234: Pre-compute the circular (Euclidean) kernel offsets at
+    // ``via_half_cells_``.  Sibling to ``circular_kernel_offsets_`` --
+    // ``is_via_blocked_diag`` had the same Chebyshev/Euclidean mismatch as
+    // the trace kernel that PR #3232 closed.  Cells in the diagonal corners
+    // of the legacy ``[-r, r]`` square have Euclidean distance ``r * sqrt(2)``,
+    // so the square kernel admitted candidate via centers whose true
+    // Euclidean clearance fell up to ``r * (1 - 1/sqrt(2)) ~= 0.293 * r``
+    // cells short of the rule.  This matches the trace-side mechanism and
+    // contributes to ``clearance_segment_via`` / ``clearance_pad_via``
+    // violations on dense layouts.
+    {
+        const int r = via_half_cells_;
+        const int r_sq = r * r;
+        via_kernel_offsets_.clear();
+        via_kernel_offsets_.reserve(
+            static_cast<size_t>(3.15f * r_sq + 1));
+        for (int dy = -r; dy <= r; ++dy) {
+            for (int dx = -r; dx <= r; ++dx) {
+                if (dx * dx + dy * dy <= r_sq) {
+                    via_kernel_offsets_.emplace_back(
+                        static_cast<int8_t>(dx), static_cast<int8_t>(dy));
+                }
+            }
+        }
+    }
+
     // Default: all layers are routable
     for (int i = 0; i < grid.layers(); ++i) {
         routable_layers_.push_back(i);
@@ -350,35 +376,83 @@ bool Pathfinder::is_via_blocked_diag(int x, int y, int net, bool allow_sharing,
     out_world_y = 0.0f;
 
     int radius = (radius_override > 0) ? radius_override : via_half_cells_;
-    for (int layer = 0; layer < grid_.layers(); ++layer) {
-        for (int dy = -radius; dy <= radius; ++dy) {
-            for (int dx = -radius; dx <= radius; ++dx) {
-                int cx = x + dx, cy = y + dy;
+
+    // Issue #3234: Switch the via-clearance kernel from Chebyshev (square)
+    // to Euclidean (circular disc).  Sibling to PR #3232 (Issue #3229)
+    // which closed the same gap on the trace side.  The DRC measures
+    // Euclidean clearance; the legacy square kernel passed candidates at
+    // the diagonal corners whose true Euclidean clearance fell as short
+    // as ``radius * (1 - 1/sqrt(2)) ~= 0.293 * radius`` cells.
+    //
+    // Fast path: when ``radius_override`` is zero, use the cached
+    // ``via_kernel_offsets_`` populated in the constructor.  Slow path
+    // (per-net via radius override): iterate the bounding square and
+    // apply an inline Euclidean filter -- no temporary vector allocation
+    // (mirrors PR #3232's canonical approach for ``is_trace_blocked``).
+    const bool use_cached = (radius_override <= 0);
+    const int radius_sq = radius * radius;
+
+    if (use_cached) {
+        for (int layer = 0; layer < grid_.layers(); ++layer) {
+            for (const auto& [dx_off, dy_off] : via_kernel_offsets_) {
+                const int cx = x + static_cast<int>(dx_off);
+                const int cy = y + static_cast<int>(dy_off);
                 if (!grid_.is_valid(cx, cy, layer)) {
                     // Grid-cell rejection: no specific blocking net.
                     return true;
                 }
 
                 const auto& cell = grid_.at(cx, cy, layer);
-                if (cell.blocked) {
+                if (!cell.blocked) {
+                    continue;
+                }
+
+                if (allow_sharing) {
+                    // Negotiated mode: mirror Python
+                    // pathfinder.py::_is_via_blocked SoA branch.
+                    // Issue #2989: own-net ``is_obstacle`` cells must
+                    // remain passable so the routing net's own via can
+                    // land inside its destination pad's footprint.
+                    if (cell.is_obstacle && cell.net != net) {
+                        return true;  // Foreign-net obstacle blocks
+                    }
+                    if (cell.net == 0 && cell.usage_count == 0) {
+                        return true;
+                    }
+                    if (cell.net != net && cell.usage_count == 0) {
+                        return true;
+                    }
+                    // Allow with cost for routed cells / own-net obstacle.
+                } else {
+                    if (cell.is_obstacle || cell.net != net) {
+                        return true;
+                    }
+                }
+            }
+        }
+    } else {
+        // Slow path: per-net radius override.  Iterate the square and
+        // filter to the Euclidean disc inline.
+        for (int layer = 0; layer < grid_.layers(); ++layer) {
+            for (int dy = -radius; dy <= radius; ++dy) {
+                for (int dx = -radius; dx <= radius; ++dx) {
+                    const int dist_sq = dx * dx + dy * dy;
+                    if (dist_sq > radius_sq) {
+                        continue;  // Outside the disc.
+                    }
+                    const int cx = x + dx, cy = y + dy;
+                    if (!grid_.is_valid(cx, cy, layer)) {
+                        return true;
+                    }
+
+                    const auto& cell = grid_.at(cx, cy, layer);
+                    if (!cell.blocked) {
+                        continue;
+                    }
+
                     if (allow_sharing) {
-                        // Negotiated mode: mirror Python
-                        // pathfinder.py::_is_via_blocked SoA branch
-                        // (lines 1428-1453).  Issue #2989: own-net
-                        // ``is_obstacle`` cells (destination /
-                        // diff-pair-partner pad metal painted by
-                        // PR #2928 first-touch + PR #2942 rect-aware
-                        // halo) MUST remain passable so the routing
-                        // net's own via can land inside its
-                        // destination pad's footprint.  Without this
-                        // gate, partner B's pad rejects every via
-                        // candidate -> A* cannot reach partner ->
-                        // diff-pair lands 1-of-2 endpoints.  Matches
-                        // USB3/PCIE/MIPI failure on board 06 and
-                        // USB_D-/USB_CC2/JOY_Y on board 03.
-                        // Foreign-net obstacles still hard-reject.
                         if (cell.is_obstacle && cell.net != net) {
-                            return true;  // Foreign-net obstacle blocks
+                            return true;
                         }
                         if (cell.net == 0 && cell.usage_count == 0) {
                             return true;
@@ -386,8 +460,6 @@ bool Pathfinder::is_via_blocked_diag(int x, int y, int net, bool allow_sharing,
                         if (cell.net != net && cell.usage_count == 0) {
                             return true;
                         }
-                        // Allow with cost for routed cells / own-net
-                        // obstacle.
                     } else {
                         if (cell.is_obstacle || cell.net != net) {
                             return true;

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -242,10 +242,24 @@ class Router:
         )
 
         # Pre-compute via checking offsets for vectorized blocking check (Issue #966)
-        # Store all (dx, dy) pairs within via radius for batch cell lookup
+        # Issue #3234: Filter to the Euclidean disc (``dx*dx + dy*dy <= r*r``)
+        # rather than the full Chebyshev square.  Sibling to PR #3232 (#3229)
+        # which switched the trace kernel from Chebyshev to Euclidean.  The
+        # DRC measures Euclidean clearance, and the legacy square kernel
+        # admitted via centers at the diagonal corners whose true Euclidean
+        # clearance fell up to ``via_half_cells * (1 - 1/sqrt(2)) ~= 0.293 *
+        # via_half_cells`` cells short of the rule -- the via-side mirror of
+        # the trace-side diagonal corner gap.  At ``via_half_cells = 2`` the
+        # disc has 13 cells vs 25 for the square (-48%); at ``via_half_cells
+        # = 3`` it has 29 vs 49 (-41%) -- so the disc kernel is a small
+        # speedup at the via-check hot path, not a slowdown.
         via_r = self._via_half_cells
+        via_r_sq = via_r * via_r
         via_offsets = [
-            (dx, dy) for dy in range(-via_r, via_r + 1) for dx in range(-via_r, via_r + 1)
+            (dx, dy)
+            for dy in range(-via_r, via_r + 1)
+            for dx in range(-via_r, via_r + 1)
+            if dx * dx + dy * dy <= via_r_sq
         ]
         self._via_offset_dx = np.array([dx for dx, _ in via_offsets], dtype=np.int32)
         self._via_offset_dy = np.array([dy for _, dy in via_offsets], dtype=np.int32)
@@ -1618,16 +1632,25 @@ class Router:
         # When a custom radius is provided, compute offsets on the fly
         # rather than using the pre-computed arrays (which use the global
         # via diameter).
+        #
+        # Issue #3234: Filter the per-net override offsets to the
+        # Euclidean disc (``dx*dx + dy*dy <= radius*radius``) -- mirrors
+        # the constructor-time filter applied to ``_via_offset_dx`` /
+        # ``_via_offset_dy`` and the C++ ``via_kernel_offsets_``.  Without
+        # this filter the override path would silently revert to the
+        # legacy Chebyshev kernel, reintroducing the diagonal-corner gap
+        # for nets with custom via diameters.
         if radius is not None and radius != self._via_half_cells:
             via_r = radius
-            via_offset_dx = np.array(
-                [dx for dy in range(-via_r, via_r + 1) for dx in range(-via_r, via_r + 1)],
-                dtype=np.int32,
-            )
-            via_offset_dy = np.array(
-                [dy for dy in range(-via_r, via_r + 1) for dx in range(-via_r, via_r + 1)],
-                dtype=np.int32,
-            )
+            via_r_sq = via_r * via_r
+            via_offsets = [
+                (dx, dy)
+                for dy in range(-via_r, via_r + 1)
+                for dx in range(-via_r, via_r + 1)
+                if dx * dx + dy * dy <= via_r_sq
+            ]
+            via_offset_dx = np.array([dx for dx, _ in via_offsets], dtype=np.int32)
+            via_offset_dy = np.array([dy for _, dy in via_offsets], dtype=np.int32)
         else:
             via_offset_dx = self._via_offset_dx
             via_offset_dy = self._via_offset_dy

--- a/tests/test_router_via_kernel_diagonal.py
+++ b/tests/test_router_via_kernel_diagonal.py
@@ -1,0 +1,429 @@
+"""Regression tests for the via-clearance kernel (Issue #3234).
+
+Background
+----------
+PR #3232 (Issue #3229) switched the *trace* clearance kernel from a
+Chebyshev (square) scan to a Euclidean (circular disc) scan in both the
+C++ ``Pathfinder::is_trace_blocked`` / ``is_foreign_pad_metal_within_radius``
+and the Python ``Router._is_trace_blocked`` /
+``Router._is_foreign_pad_metal_within_radius``.  The same Chebyshev/
+Euclidean mismatch remained on the *via* side in
+``Pathfinder::is_via_blocked_diag`` (C++) and ``Router._is_via_blocked``
+(Python): the legacy nested ``dx/dy`` loops over a ``[-r, r]^2`` square
+admitted candidate via centers at the diagonal corners whose true
+Euclidean clearance to the blocking cell fell up to
+``via_half_cells * (1 - 1/sqrt(2)) ~= 0.293 * via_half_cells`` cells
+short of the rule.  This is the exact failure mode of residual
+``clearance_segment_via`` / ``clearance_pad_via`` violations on dense
+layouts.
+
+This file pins down the Euclidean-disc semantics that Issue #3234
+introduces.  Mirrors the structure of ``test_router_pad_exit_clearance_guard.py``
+(PR #3232's regression file for the trace side).
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from kicad_tools.router.cpp_backend import CppGrid, is_cpp_available, router_cpp
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import LayerStack
+from kicad_tools.router.pathfinder import Router as Pathfinder
+from kicad_tools.router.rules import DesignRules
+
+requires_cpp = pytest.mark.skipif(
+    not is_cpp_available(),
+    reason="C++ router backend not available; run `kct build-native`",
+)
+
+
+def _make_grid(
+    *,
+    width: float = 10.0,
+    height: float = 10.0,
+    resolution: float = 0.1,
+) -> tuple[RoutingGrid, DesignRules]:
+    rules = DesignRules(
+        trace_width=0.2,
+        trace_clearance=0.15,
+        via_drill=0.3,
+        via_diameter=0.6,
+        via_clearance=0.15,
+        grid_resolution=resolution,
+    )
+    layer_stack = LayerStack.two_layer()
+    grid = RoutingGrid(
+        width=width,
+        height=height,
+        rules=rules,
+        layer_stack=layer_stack,
+    )
+    return grid, rules
+
+
+def _make_cpp_pf_with_blocker(
+    blocker_xy: tuple[int, int],
+    layers: int = 2,
+    blocker_net: int = 2,
+) -> tuple[object, object]:
+    """Build a standalone C++ Pathfinder with a single blocked cell.
+
+    Returns ``(cpp_grid_impl, cpp_pathfinder)`` -- both unwrapped C++
+    objects so the test can probe ``is_via_blocked`` directly without
+    funneling through ``CppGrid``.
+    """
+    grid = router_cpp.Grid3D(101, 101, layers, 0.1, 0.0, 0.0)
+    rules = router_cpp.DesignRules()
+    rules.trace_width = 0.2
+    rules.trace_clearance = 0.15
+    rules.via_diameter = 0.6
+    rules.via_drill = 0.3
+    rules.via_clearance = 0.15
+    rules.grid_resolution = 0.1
+    rules.cost_straight = 1.0
+    rules.cost_turn = 1.5
+    rules.cost_via = 10.0
+    pf = router_cpp.Pathfinder(grid, rules, True)
+    grid.mark_blocked(
+        blocker_xy[0], blocker_xy[1], 0, blocker_net, False, False
+    )
+    return grid, pf
+
+
+# ---------------------------------------------------------------------------
+# Python kernel: direct unit tests on the precomputed offset list
+# ---------------------------------------------------------------------------
+
+
+class TestPythonViaKernelIsEuclidean:
+    """The precomputed ``Router._via_offset_dx`` / ``_via_offset_dy``
+    arrays must form a Euclidean disc, not a Chebyshev square."""
+
+    def test_kernel_offsets_form_euclidean_disc(self) -> None:
+        py_grid, rules = _make_grid()
+        pf = Pathfinder(py_grid, rules)
+        r = pf._via_half_cells
+        r_sq = r * r
+
+        offsets = sorted(
+            (int(dx), int(dy))
+            for dx, dy in zip(pf._via_offset_dx, pf._via_offset_dy, strict=True)
+        )
+
+        # Every offset must satisfy the Euclidean filter.
+        for dx, dy in offsets:
+            assert dx * dx + dy * dy <= r_sq, (
+                f"Offset ({dx},{dy}) violates disc: dist_sq={dx*dx+dy*dy} "
+                f"> r_sq={r_sq}"
+            )
+
+        # The kernel must be COMPLETE: every Chebyshev-square cell that
+        # satisfies the filter is present.  This catches accidental
+        # over-pruning (e.g. an off-by-one strict-vs-non-strict inequality).
+        expected = sorted(
+            (dx, dy)
+            for dy in range(-r, r + 1)
+            for dx in range(-r, r + 1)
+            if dx * dx + dy * dy <= r_sq
+        )
+        assert offsets == expected
+
+    def test_diagonal_corners_excluded(self) -> None:
+        """The four diagonal corners of the Chebyshev square --
+        ``(+/-r, +/-r)`` -- have Euclidean distance ``r * sqrt(2) > r``
+        and must NOT be in the kernel.  This is the exact failure mode
+        the legacy Chebyshev kernel admitted.
+        """
+        py_grid, rules = _make_grid()
+        pf = Pathfinder(py_grid, rules)
+        r = pf._via_half_cells
+
+        offsets_set = {
+            (int(dx), int(dy))
+            for dx, dy in zip(pf._via_offset_dx, pf._via_offset_dy, strict=True)
+        }
+        for sx in (-1, 1):
+            for sy in (-1, 1):
+                corner = (sx * r, sy * r)
+                assert corner not in offsets_set, (
+                    f"Diagonal corner {corner} present in via kernel: "
+                    f"dist_sq={r*r + r*r} > r_sq={r*r} -- the kernel is "
+                    f"still Chebyshev (legacy bug)"
+                )
+
+
+class TestPythonViaBlockedDiagonal:
+    """``Router._is_via_blocked`` must use the Euclidean disc.
+
+    Direct functional regressions on the helper.  Mirrors
+    ``test_router_pad_exit_clearance_guard.TestPythonForeignPadMetalGuard``.
+    """
+
+    def test_diagonal_corner_blocker_passes(self) -> None:
+        """Issue #3234: A foreign-net blocked cell at offset
+        ``(+via_half_cells, +via_half_cells)`` has Chebyshev distance
+        ``via_half_cells`` (legacy reject) but Euclidean distance
+        ``via_half_cells * sqrt(2)`` (Euclidean accept).
+        """
+        py_grid, rules = _make_grid()
+        pf = Pathfinder(py_grid, rules)
+        r = pf._via_half_cells
+        # Foreign blocked cell at (50 + r, 50 + r) on each layer.
+        for layer in range(py_grid.num_layers):
+            py_grid._blocked[layer, 50 + r, 50 + r] = True
+            py_grid._net[layer, 50 + r, 50 + r] = 2
+        # The candidate at (50, 50) puts the blocker at the diagonal corner
+        # of the kernel.  The Euclidean disc must EXCLUDE it -> accept.
+        for layer in range(py_grid.num_layers):
+            assert (
+                pf._is_via_blocked(50, 50, layer, net=1, allow_sharing=False)
+                is False
+            ), f"Diagonal corner blocker triggered rejection on layer {layer}"
+
+    def test_axial_blocker_at_radius_rejects(self) -> None:
+        """A foreign blocked cell on-axis at distance exactly
+        ``via_half_cells`` is INSIDE the Euclidean disc (boundary cell,
+        ``dist_sq = r^2``) and must still reject.  Pins down that the
+        new kernel does not lose orthogonal coverage.
+        """
+        py_grid, rules = _make_grid()
+        pf = Pathfinder(py_grid, rules)
+        r = pf._via_half_cells
+        for layer in range(py_grid.num_layers):
+            py_grid._blocked[layer, 50, 50 + r] = True
+            py_grid._net[layer, 50, 50 + r] = 2
+        # Layer 0 only -- candidate at (50, 50) sees the blocker on the
+        # disc boundary.
+        assert pf._is_via_blocked(50, 50, 0, net=1, allow_sharing=False) is True
+
+    def test_inside_disc_diagonal_rejects(self) -> None:
+        """A foreign blocked cell at offset ``(1, 2)`` has
+        ``dist_sq = 5``.  For any ``via_half_cells >= 3`` it is inside
+        both the Chebyshev square AND the Euclidean disc.  Both kernels
+        must reject -- non-regression check that the new kernel does
+        not over-tighten interior placements.
+        """
+        py_grid, rules = _make_grid()
+        pf = Pathfinder(py_grid, rules)
+        r = pf._via_half_cells
+        assert r >= 3, (
+            f"Test fixture assumes via_half_cells >= 3 (got {r}); "
+            f"adjust _make_grid() if the rule changes"
+        )
+        py_grid._blocked[0, 52, 51] = True  # offset (+1, +2) from (50, 50)
+        py_grid._net[0, 52, 51] = 2
+        assert pf._is_via_blocked(50, 50, 0, net=1, allow_sharing=False) is True
+
+
+# ---------------------------------------------------------------------------
+# C++ kernel: direct unit tests via ``Pathfinder.is_via_blocked``
+# ---------------------------------------------------------------------------
+
+
+@requires_cpp
+class TestCppViaBlockedDiagonal:
+    """``Pathfinder::is_via_blocked_diag`` must use the Euclidean disc.
+
+    Sibling of ``TestPythonViaBlockedDiagonal``.  C++ exposes
+    ``is_via_blocked`` which dispatches to ``is_via_blocked_diag`` with
+    dummy out-params.
+    """
+
+    def test_diagonal_corner_blocker_passes(self) -> None:
+        # Compute via_half_cells the same way the C++ ctor does:
+        # ceil((via_diameter/2 + via_clearance) / resolution).
+        r = math.ceil((0.6 / 2 + 0.15) / 0.1)
+        # Place the blocker at (50 + r, 50 + r); candidate at (50, 50)
+        # sees it at the diagonal corner -> Euclidean accept.
+        _, pf = _make_cpp_pf_with_blocker((50 + r, 50 + r))
+        assert pf.is_via_blocked(50, 50, 1, False, 0) is False
+
+    def test_axial_blocker_at_radius_rejects(self) -> None:
+        r = math.ceil((0.6 / 2 + 0.15) / 0.1)
+        # Blocker on-axis at distance r.
+        _, pf = _make_cpp_pf_with_blocker((50 + r, 50))
+        assert pf.is_via_blocked(50, 50, 1, False, 0) is True
+
+    def test_inside_disc_diagonal_rejects(self) -> None:
+        r = math.ceil((0.6 / 2 + 0.15) / 0.1)
+        assert r >= 3, f"Test assumes r >= 3 (got {r})"
+        # Blocker at offset (+1, +2) -- inside both square and disc.
+        _, pf = _make_cpp_pf_with_blocker((51, 52))
+        assert pf.is_via_blocked(50, 50, 1, False, 0) is True
+
+    def test_just_outside_disc_passes(self) -> None:
+        """Offset where dist_sq is just above r_sq must accept.
+
+        For r=5 (the via_half_cells under the fixture), pick offset
+        ``(5, 1)`` -- ``dist_sq = 26 > 25 = r_sq``.  This is inside the
+        Chebyshev square (legacy reject) but outside the Euclidean disc
+        (new accept).
+        """
+        r = math.ceil((0.6 / 2 + 0.15) / 0.1)
+        # Need r >= 5 so the offset (r, 1) has dist_sq = r^2 + 1 > r^2
+        # while still being inside the Chebyshev square.
+        assert r == 5, (
+            f"Test assumes r=5 with the fixture's via_diameter/clearance "
+            f"(got {r})"
+        )
+        _, pf = _make_cpp_pf_with_blocker((50 + r, 51))
+        assert pf.is_via_blocked(50, 50, 1, False, 0) is False
+
+
+# ---------------------------------------------------------------------------
+# Symmetry: Python and C++ via kernels return identical answers
+# ---------------------------------------------------------------------------
+
+
+@requires_cpp
+class TestPythonCppViaKernelSymmetry:
+    """Mirror of ``TestPythonCppGuardSymmetry`` (PR #3232) for the via
+    kernel.  Python and C++ ``is_via_blocked`` must agree at every cell
+    in a sweep, including the 4 diagonal corners that the Euclidean
+    kernel must accept (and the legacy Chebyshev kernel rejected)."""
+
+    def test_diagonal_corner_symmetry(self) -> None:
+        """Sweep a ``(2r+5) x (2r+5)`` window of candidate positions
+        around a single blocked cell.  Python and C++ verdicts must agree
+        on every cell, AND the 4 diagonal corners must all be ACCEPTED.
+        """
+        py_grid, rules = _make_grid()
+        pf = Pathfinder(py_grid, rules)
+        r = pf._via_half_cells
+
+        # Place the blocked cell on EVERY layer so the per-layer Python
+        # check and the all-layer C++ check return the same boolean
+        # without us having to OR across layers in the symmetry loop.
+        for layer in range(py_grid.num_layers):
+            py_grid._blocked[layer, 50, 50] = True
+            py_grid._net[layer, 50, 50] = 2
+
+        cpp_grid = CppGrid.from_routing_grid(py_grid)
+        cpp_rules = router_cpp.DesignRules()
+        cpp_rules.trace_width = 0.2
+        cpp_rules.trace_clearance = 0.15
+        cpp_rules.via_diameter = 0.6
+        cpp_rules.via_drill = 0.3
+        cpp_rules.via_clearance = 0.15
+        cpp_rules.grid_resolution = 0.1
+        cpp_rules.cost_straight = 1.0
+        cpp_rules.cost_turn = 1.5
+        cpp_rules.cost_via = 10.0
+        cpp_pf = router_cpp.Pathfinder(cpp_grid._impl, cpp_rules, True)
+
+        diag_accepts = 0
+        for dy in range(-r - 2, r + 3):
+            for dx in range(-r - 2, r + 3):
+                gx, gy = 50 + dx, 50 + dy
+                py_blocked = any(
+                    pf._is_via_blocked(gx, gy, layer, net=1, allow_sharing=False)
+                    for layer in range(py_grid.num_layers)
+                )
+                cpp_blocked = cpp_pf.is_via_blocked(gx, gy, 1, False, 0)
+                assert py_blocked == cpp_blocked, (
+                    f"Python/C++ via-kernel disagreement at offset "
+                    f"(dx={dx},dy={dy}): py={py_blocked} cpp={cpp_blocked}"
+                )
+                if abs(dx) == r and abs(dy) == r:
+                    assert py_blocked is False, (
+                        f"Diagonal corner ({dx},{dy}) at Chebyshev=r={r}, "
+                        f"Euclidean={r * math.sqrt(2):.2f} must be "
+                        f"ACCEPTED by the disc kernel"
+                    )
+                    diag_accepts += 1
+        assert diag_accepts == 4, (
+            f"Expected to test all 4 diagonal corners, tested {diag_accepts}"
+        )
+
+    def test_kernel_decision_matches_euclidean_distance(self) -> None:
+        """Cross-check: the C++ kernel's accept/reject decision must
+        correspond to actual Euclidean disc membership.  Closes the
+        "both backends agree on a wrong answer" loophole that a pure
+        Python<->C++ symmetry sweep alone would miss.
+        """
+        r = math.ceil((0.6 / 2 + 0.15) / 0.1)
+        r_sq = r * r
+        _, pf = _make_cpp_pf_with_blocker((25, 25))
+
+        cells_tested = 0
+        for dy in range(-r - 2, r + 3):
+            for dx in range(-r - 2, r + 3):
+                gx, gy = 25 + dx, 25 + dy
+                dist_sq = dx * dx + dy * dy
+                expected_reject = dist_sq <= r_sq
+                actual_reject = pf.is_via_blocked(gx, gy, 1, False, 0)
+                assert actual_reject == expected_reject, (
+                    f"Via-kernel/Euclidean mismatch at offset ({dx},{dy}): "
+                    f"dist_sq={dist_sq} r_sq={r_sq} "
+                    f"expected_reject={expected_reject} "
+                    f"actual_reject={actual_reject}"
+                )
+                cells_tested += 1
+        assert cells_tested == (2 * (r + 2) + 1) ** 2
+
+
+# ---------------------------------------------------------------------------
+# Per-net radius override: the slow path must also use Euclidean filter
+# ---------------------------------------------------------------------------
+
+
+class TestPythonViaRadiusOverrideIsEuclidean:
+    """Issue #3234: the per-net ``radius`` override branch in
+    ``Router._is_via_blocked`` (line ~1621) must apply the Euclidean
+    disc filter too -- without it, custom-via-diameter nets would
+    silently revert to the legacy Chebyshev kernel."""
+
+    def test_override_diagonal_corner_blocker_passes(self) -> None:
+        py_grid, rules = _make_grid()
+        pf = Pathfinder(py_grid, rules)
+        # Pick a radius that differs from ``_via_half_cells`` so the
+        # override branch is exercised.
+        override_r = pf._via_half_cells + 2
+        # Blocker at the diagonal corner of the OVERRIDE radius.
+        bx, by = 50 + override_r, 50 + override_r
+        for layer in range(py_grid.num_layers):
+            py_grid._blocked[layer, by, bx] = True
+            py_grid._net[layer, by, bx] = 2
+        # With radius=override_r, blocker at offset (+r,+r) is outside
+        # the Euclidean disc (dist_sq = 2*r^2 > r^2) -> accept.
+        assert (
+            pf._is_via_blocked(
+                50, 50, 0, net=1, allow_sharing=False, radius=override_r
+            )
+            is False
+        )
+
+    def test_override_axial_blocker_at_radius_rejects(self) -> None:
+        py_grid, rules = _make_grid()
+        pf = Pathfinder(py_grid, rules)
+        override_r = pf._via_half_cells + 2
+        # On-axis at distance == override_r: inside disc (boundary).
+        py_grid._blocked[0, 50, 50 + override_r] = True
+        py_grid._net[0, 50, 50 + override_r] = 2
+        assert (
+            pf._is_via_blocked(
+                50, 50, 0, net=1, allow_sharing=False, radius=override_r
+            )
+            is True
+        )
+
+
+@requires_cpp
+class TestCppViaRadiusOverrideIsEuclidean:
+    """Sibling for the C++ ``radius_override > 0`` slow path."""
+
+    def test_override_diagonal_corner_blocker_passes(self) -> None:
+        override_r = 7  # arbitrary; > default via_half_cells_=5
+        _, pf = _make_cpp_pf_with_blocker((50 + override_r, 50 + override_r))
+        # is_via_blocked(x, y, net, allow_sharing, radius_override)
+        assert (
+            pf.is_via_blocked(50, 50, 1, False, override_r) is False
+        )
+
+    def test_override_axial_blocker_at_radius_rejects(self) -> None:
+        override_r = 7
+        _, pf = _make_cpp_pf_with_blocker((50 + override_r, 50))
+        assert pf.is_via_blocked(50, 50, 1, False, override_r) is True


### PR DESCRIPTION
## Summary

Sibling to PR #3232 (Issue #3229).  That PR closed the conceptual
Chebyshev -> Euclidean gap in the **trace** clearance kernel
(`is_trace_blocked`, `is_foreign_pad_metal_within_radius`, Python
`_dilate_blocked`).  The **via** blocking kernel (`is_via_blocked_diag`
C++ / `_is_via_blocked` Python) still iterated a Chebyshev `[-r, r]^2`
square -- same mismatch, same direction, in a different code path.

The DRC measures Euclidean clearance, so the legacy square kernel
admitted candidate via centers at the diagonal corners whose true
Euclidean clearance to the blocking cell fell up to
`via_half_cells * (1 - 1/sqrt(2)) ~= 0.293 * via_half_cells` cells
short of the rule -- the via-side mirror of the trace-side gap that
PR #3232 documented for board 05's `clearance_pad_segment` errors.

This PR completes the Euclidean A* clearance enforcement across both
trace and via paths so the router's accept/reject decision matches
the DRC's geometric model end-to-end on both backends.

## Changes

* **`src/kicad_tools/router/cpp/include/pathfinder.hpp`** -- add new
  `via_kernel_offsets_` member next to PR #3232's
  `circular_kernel_offsets_`.

* **`src/kicad_tools/router/cpp/src/pathfinder.cpp`**:
  - Constructor pre-computes the disc offsets at `via_half_cells_`.
    Cell counts: r=2 13 vs 25 square (-48%); r=3 29 vs 49 (-41%);
    r=5 81 vs 121 (-33%).  Same shape and cell-count savings as
    PR #3232's trace kernel.
  - `is_via_blocked_diag` fast path iterates the cached offset list
    (called from `is_via_blocked` thin wrapper, A* expansion at
    line 951, and negotiated-mode A* expansion at line 1465).
  - `is_via_blocked_diag` slow path (per-net `radius_override > 0`)
    iterates the bounding square with an inline Euclidean filter --
    **no temporary vector allocation**, mirroring PR #3232's canonical
    pattern for `is_trace_blocked`.

* **`src/kicad_tools/router/pathfinder.py`**:
  - `Router.__init__` filters the precomputed `_via_offset_dx` /
    `_via_offset_dy` arrays to the Euclidean disc (smaller arrays =
    faster vectorized lookup, mirrors PR #3232's "smaller arrays"
    choice for the trace kernel).
  - `_is_via_blocked` per-net override path also applies the
    Euclidean filter.  Without this, custom-via-diameter nets would
    silently revert to the Chebyshev kernel and re-introduce the
    diagonal-corner gap for nets with overridden radii.

The kernel-shape change is **orthogonal** to the negotiated-mode
own-net obstacle gate (Issue #2989) and the stored-via geometric
clearance loop (which already uses true Euclidean distance via
`sqrt(dxw*dxw + dyw*dyw)`).  Both behaviours are preserved exactly.

## Tests

New file `tests/test_router_via_kernel_diagonal.py` (15 cases):

* **`TestPythonViaKernelIsEuclidean`** (2 cases) -- the precomputed
  `_via_offset_dx` / `_via_offset_dy` arrays form a Euclidean disc:
  every offset satisfies `dx*dx + dy*dy <= r^2`; the kernel is
  complete; the four diagonal corners `(+/-r, +/-r)` are excluded.

* **`TestPythonViaBlockedDiagonal`** (3 cases) -- direct functional
  regressions on `_is_via_blocked`: diagonal-corner blocker passes;
  axial-radius blocker rejects; inside-disc diagonal rejects.

* **`TestCppViaBlockedDiagonal`** (4 cases) -- sibling for the C++
  `is_via_blocked`; adds a just-outside-disc case that pins down
  the disc boundary (offset where `dist_sq > r^2` but inside the
  Chebyshev square).

* **`TestPythonCppViaKernelSymmetry`** (2 cases):
  - 13x13 sweep around a blocked cell; Python and C++ verdicts must
    agree on every cell AND the 4 diagonal corners must all be
    ACCEPTED.
  - Kernel-decision vs. raw Euclidean disc cross-check (closes the
    "both backends agree on a wrong answer" loophole that a pure
    Python<->C++ symmetry sweep would miss).

* **`TestPython/CppViaRadiusOverrideIsEuclidean`** (4 cases) -- the
  per-net `radius` override branch on both backends also applies
  the disc filter.

## Verification

### Unit tests

* New file: **15 / 15 pass** (`tests/test_router_via_kernel_diagonal.py`).
* `tests/test_router_cpp_via_clearance.py`,
  `tests/test_pathfinder_via_foreign_clearance.py`,
  `tests/test_main_router_segment_via_clearance.py`,
  `tests/test_main_router_via_segment_clearance.py`,
  `tests/test_router_cpp_via_blocked_failure.py` -- **67 / 67 pass**.
* `tests/test_router_escape_via.py`,
  `tests/test_escape_segment_via_clearance.py`,
  `tests/test_cpp_pathfinder_own_net_obstacle.py`,
  `tests/test_via_conflict.py`,
  `tests/test_via_placement_regression.py`,
  `tests/test_via_foreign_context_wiring.py` -- **115 / 115 pass**
  (2 unrelated skips).
* `tests/test_router_pad_exit_clearance_guard.py` (PR #3232's
  trace-side regression suite) -- **31 / 31 pass**.

### Board 05 `--backend cpp`

Routed `boards/05-bldc-motor-controller/output/bldc_controller.kicad_pcb`
with `--backend cpp --strategy negotiated --seed 42`:

| metric | this PR (cpp run) | issue-3234 Python baseline |
|---|---:|---:|
| clearance_segment_via | **0** | 3 |
| clearance_pad_via | **0** | 0 |

Both via-clearance categories are now at the Python baseline or below
on the C++ backend.  The board 05 design.py still pins
`--backend python` for unrelated reasons (`clearance_pad_segment`
floor) per the existing comment in `design.py:2324`.

### Pre-existing test failures (not caused by this PR)

Verified by stashing this PR's changes and rebuilding on `origin/main`
at HEAD `694af1c6` -- both fail identically without these changes:

* `tests/test_router_core.py::TestPadBlockedByAdjacentNetZero::test_route_to_pad_adjacent_to_net0_pad`
* `tests/test_router_core.py::TestAdaptiveAutorouterComponentTransform::test_add_component_rotation`

## Acceptance Criteria

| AC | Status | Notes |
|---|---|---|
| 1: board 05 `--backend cpp` `clearance_segment_via` <= Python baseline (3) | MET | Measured 0 |
| 2: board 05 `--backend cpp` `clearance_pad_via` <= Python baseline (0) | MET | Measured 0 |
| 3: diagonal-corner regression test (mirror PR #3232) | MET | `TestPython/CppViaBlockedDiagonal::test_diagonal_corner_blocker_passes` |
| 4: candidate at offset (1, 2) for r=3 rejects on both backends | MET | `test_inside_disc_diagonal_rejects` |
| 5: Python/C++ symmetry sweep including diagonal corners | MET | `TestPythonCppViaKernelSymmetry::test_diagonal_corner_symmetry` |
| 6: per-iter via kernel time no slower than before | MET | Disc has fewer cells than square at every radius used in practice (-33% to -48%) |
| 7: softstart 6/10 (or 8/10) reach preserved | NOT VERIFIED IN-PR | The softstart reach test is gated behind `KICAD_RUN_SLOW_SOFTSTART_REACH=1`; the kernel-shape change is orthogonal to the budget plumbing it exercises |
| 8: board 07 PYTHONHASHSEED determinism unaffected | NOT REGRESSED IN-CHANGE | No code touched the FIFO tie-break / `search_seq_counter_` |
| 9: existing via-related tests still pass | MET | 115 / 115 + 67 / 67 = **182 pass** across the relevant suites |

## Out of Scope (per issue body)

* The `_add_pad_unsafe` sub-cell margin (the dominant residual on
  board 05 `clearance_pad_segment` per PR #3232's verification).
* Per-net via clearance plumbing -- `is_via_blocked_diag` uses
  `rules_.via_diameter` / `rules_.via_clearance` from global rules.
* Stored-via geometric clearance loop (already true Euclidean).
* Negotiated-mode own-net obstacle handling (Issue #2989) -- kernel
  shape change is orthogonal.

Closes #3234