### PR TITLE
test(board-04): pin CI manufacturability gate state (refs #3261)

### DIFF
--- a/tests/test_board_04_mfr_gate.py
+++ b/tests/test_board_04_mfr_gate.py
@@ -1,0 +1,284 @@
+"""Regression guard: board 04 (stm32-devboard) passes the CI manufacturability gate.
+
+Issue #3261 (tracking) -- "Make board 04 manufacturable: verify fresh
+artifacts + close any residual gaps".
+
+This test pins the post-#3218 / post-#3128 manufacturability state of
+``boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb`` against
+the same gate the CI ``routed-pcb-drc-check`` job uses
+(``scripts/ci/check_routed_drc.py``).  Specifically it asserts:
+
+1. The committed routed PCB still passes the gate against the
+   ``jlcpcb-tier1`` profile declared in
+   ``.github/routed-drc-tolerance.yml``'s ``manufacturers:`` block.
+
+2. The gate's blocking error count stays at or below the floor declared
+   for board 04 in the same YAML (currently 1, post-#3118 micro-via
+   in-pad rescue).
+
+3. The advisory ``connectivity`` finding documented in
+   ``.github/routed-drc-tolerance.yml`` (a single stranded GND-stitch
+   pad) does NOT inflate to non-trivial regression -- if a future
+   router change strands more GND pads, the audit count rises and we
+   surface the issue at PR time rather than discovering it in fleet
+   status weeks later.
+
+The fleet-status fingerprint (54/55 pads ~ 98% manufacturer-readiness)
+is the higher-level invariant this pin is protecting.  Today board 04
+ships at:
+
+  * 9/9 signal nets routed (committed PCB; the fresh router can drop NRST
+    on some seeds -- see follow-on issue filed under #3261 for the
+    intermittent NRST regression).
+  * 1 blocking error (SWDIO/BOOT0 clearance at B.Cu (143.8, 119.7), the
+    historically-unstable cluster tracked under #2834).
+  * 1 advisory connectivity finding (U2.8 LQFP-48 corner GND pad the
+    stitcher could not reach even with --micro-via).
+  * CI gate: PASS (1 <= floor of 1; advisory excluded per ``DRCChecker``).
+
+This test is a stateless source pin -- it does NOT re-route the board.
+It checks the committed routed PCB against the gate that ships with the
+repository.  Re-routing is exercised by
+``tests/test_board_04_routing_regression.py`` under the ``@slow`` mark.
+
+References:
+- ``scripts/ci/check_routed_drc.py`` -- the CI gate this test mirrors.
+- ``.github/routed-drc-tolerance.yml`` -- the per-board allowlist + the
+  ``manufacturers:`` override block.
+- PR #3218 -- ``--mfr jlcpcb-tier1`` in the recipe (closes #3208).
+- PR #3128 -- micro-via in-pad rescue (#3118), tightened floor 4 -> 1.
+- Issue #2834 -- the manufacturing-ready cluster the residual rides with.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BOARD_04_ROUTED_PCB = (
+    REPO_ROOT / "boards" / "04-stm32-devboard" / "output" / "stm32_devboard_routed.kicad_pcb"
+)
+TOLERANCE_YAML = REPO_ROOT / ".github" / "routed-drc-tolerance.yml"
+BOARD_04_RELPATH = "boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb"
+
+
+def _load_tolerance_yaml() -> dict:
+    assert TOLERANCE_YAML.exists(), (
+        f"Tolerance YAML missing at {TOLERANCE_YAML}; the CI gate cannot "
+        f"function without it."
+    )
+    return yaml.safe_load(TOLERANCE_YAML.read_text()) or {}
+
+
+def _run_kct_check(pcb_path: Path, manufacturer: str) -> dict:
+    """Invoke ``kct check`` and return the parsed JSON payload.
+
+    Mirrors the CI gate's invocation in ``scripts/ci/check_routed_drc.py``
+    so the verdict here matches what CI would see.
+    """
+    cmd = [
+        sys.executable,
+        "-m",
+        "kicad_tools.cli",
+        "check",
+        str(pcb_path),
+        "--mfr",
+        manufacturer,
+        "--errors-only",
+        "--format",
+        "json",
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=120, check=False)
+    # ``kct check`` exit codes (see ``src/kicad_tools/cli/drc_cmd.py``):
+    #   0 = clean (no errors), 1 = warnings only, 2 = errors present.
+    # We accept 0, 1, and 2: the JSON payload is on stdout regardless of
+    # exit code and we extract the verdict ourselves below.  Higher exit
+    # codes indicate a tool crash.
+    if proc.returncode not in (0, 1, 2):
+        pytest.fail(
+            f"kct check returned unexpected exit code {proc.returncode}\n"
+            f"stderr (last 2000 chars):\n{proc.stderr[-2000:]}\n"
+            f"stdout (last 2000 chars):\n{proc.stdout[-2000:]}"
+        )
+    # Strip any leading warning lines kct emits to stdout (e.g. "WARNING: PCB
+    # out of sync with schematic").  The JSON payload starts at the first '{'.
+    stdout = proc.stdout
+    brace = stdout.find("{")
+    assert brace >= 0, (
+        f"kct check stdout has no JSON payload.  Full stdout:\n{stdout}"
+    )
+    try:
+        return json.loads(stdout[brace:])
+    except json.JSONDecodeError as exc:
+        pytest.fail(f"Could not parse kct check JSON output: {exc}\n{stdout}")
+        raise  # unreachable, satisfies typecheck
+
+
+@pytest.fixture(scope="module")
+def board_04_mfr_check() -> dict:
+    """Invoke ``kct check`` once per session against the committed routed PCB."""
+    if not BOARD_04_ROUTED_PCB.exists():
+        pytest.skip(
+            f"Board 04 routed PCB not found at {BOARD_04_ROUTED_PCB}; "
+            "regenerate via `uv run python boards/04-stm32-devboard/generate_design.py`."
+        )
+    return _run_kct_check(BOARD_04_ROUTED_PCB, "jlcpcb-tier1")
+
+
+def test_board_04_blocking_errors_within_ci_floor(board_04_mfr_check: dict) -> None:
+    """Committed board 04 PCB must stay at or below the CI gate's allowlist floor.
+
+    This is the primary regression guard: if a future router change adds
+    a blocking DRC error that the CI gate does not allowlist, this pin
+    fires immediately at PR time rather than after a fleet-status sweep.
+
+    The current floor is 1 (post-#3118).  If the floor is tightened, the
+    YAML and this test must move in lockstep -- the test reads the floor
+    from the YAML so a YAML edit is sufficient.
+    """
+    summary = board_04_mfr_check.get("summary", {})
+    violations = board_04_mfr_check.get("violations", [])
+
+    # Count blocking (non-advisory) errors the same way the CI gate does.
+    blocking = [
+        v
+        for v in violations
+        if v.get("severity") == "error" and v.get("rule_id") != "connectivity"
+    ]
+    blocking_count = len(blocking)
+
+    # Read the floor from the YAML rather than hard-coding it -- this
+    # keeps the two sources of truth in lockstep when the floor is
+    # tightened.
+    tolerance = _load_tolerance_yaml()
+    floor = (tolerance.get("tolerances") or {}).get(BOARD_04_RELPATH, 0)
+
+    assert blocking_count <= floor, (
+        f"Board 04 routed PCB has {blocking_count} blocking errors against "
+        f"jlcpcb-tier1; the CI gate's allowlist floor is {floor}.\n\n"
+        f"Blocking violations:\n"
+        + "\n".join(
+            f"  - {v.get('rule_id')}: {v.get('message')} at {v.get('location')}"
+            for v in blocking
+        )
+        + f"\n\nIf a router change has legitimately added a new error,"
+        f" bump the floor in {TOLERANCE_YAML.relative_to(REPO_ROOT)} and"
+        f" file a follow-on issue to track the regression.  If the error"
+        f" was inadvertent, revert the router change.\n\n"
+        f"Total summary errors: {summary.get('errors')}"
+    )
+
+
+def test_board_04_advisory_connectivity_does_not_balloon(
+    board_04_mfr_check: dict,
+) -> None:
+    """Advisory connectivity findings must stay within the documented bound.
+
+    The committed PCB carries ONE advisory connectivity finding (U2.8 GND
+    stitch gap, documented in ``.github/routed-drc-tolerance.yml`` lines
+    1140-1151).  If a future router change strands additional pads, the
+    fleet-status manufacturer-readiness percentage drops -- catching this
+    at PR time avoids silently regressing the board's functional
+    completeness even though the CI gate (which filters advisories)
+    still passes.
+
+    The threshold is intentionally lenient (<= 3 connectivity findings)
+    to avoid flapping on small router state changes; this catches
+    multi-pad strandings (e.g., NRST + multiple GND pads dropping out)
+    without breaking on every micro-routing tweak.
+    """
+    violations = board_04_mfr_check.get("violations", [])
+    connectivity = [v for v in violations if v.get("rule_id") == "connectivity"]
+    connectivity_count = len(connectivity)
+
+    # Soft cap: 3 advisory findings.  Today's count is 1.  A jump to 4+
+    # signals a multi-net stranding event worth investigating.
+    SOFT_CAP = 3
+    assert connectivity_count <= SOFT_CAP, (
+        f"Board 04 has {connectivity_count} advisory connectivity findings; "
+        f"the soft cap is {SOFT_CAP}.  This signals a multi-net stranding "
+        f"event -- check the recent router changes for a regression in "
+        f"escape, stitching, or rip-up handling.\n\n"
+        f"Advisory findings:\n"
+        + "\n".join(
+            f"  - {v.get('message')} at items={v.get('items')}"
+            for v in connectivity
+        )
+    )
+
+
+def test_board_04_tolerance_yaml_floor_matches_committed_state(
+    board_04_mfr_check: dict,
+) -> None:
+    """The tolerance YAML's floor for board 04 must not silently drift.
+
+    If a router improvement drops the committed PCB's blocking error
+    count below the floor, the slack is harmless for CI (the gate still
+    passes) but the floor is stale.  This test fails when the slack
+    exceeds 2 (a single-step tightening window), prompting the next PR
+    to tighten the floor in lockstep with the improvement.
+
+    A tightening PR updates the YAML and this test continues to pass; a
+    stale floor (slack > 2) prompts the maintainer to investigate why
+    the floor is too loose.
+    """
+    violations = board_04_mfr_check.get("violations", [])
+    blocking = [
+        v
+        for v in violations
+        if v.get("severity") == "error" and v.get("rule_id") != "connectivity"
+    ]
+    blocking_count = len(blocking)
+
+    tolerance = _load_tolerance_yaml()
+    floor = (tolerance.get("tolerances") or {}).get(BOARD_04_RELPATH, 0)
+
+    slack = floor - blocking_count
+    SLACK_BUDGET = 2
+
+    assert slack <= SLACK_BUDGET, (
+        f"Board 04 floor in {TOLERANCE_YAML.relative_to(REPO_ROOT)} is "
+        f"{floor} but the committed routed PCB only has {blocking_count} "
+        f"blocking errors -- slack is {slack}, budget is {SLACK_BUDGET}.\n\n"
+        f"Tighten the floor in the YAML to lock in the improvement, "
+        f"e.g.:\n"
+        f"  {BOARD_04_RELPATH}: {blocking_count}\n\n"
+        f"See the comment block above this entry in the YAML for the "
+        f"existing tightening history (#3028, #3118 etc.)."
+    )
+
+
+def test_board_04_tolerance_yaml_declares_jlcpcb_tier1() -> None:
+    """The board 04 entry in the manufacturers: block must still target jlcpcb-tier1.
+
+    The committed routed PCB uses ``--micro-via`` GND stitching that the
+    default ``jlcpcb`` (tier-0) profile forbids.  The CI gate measures
+    board 04 against ``jlcpcb-tier1`` via the ``manufacturers:`` block.
+    If this entry is dropped or retargeted to a different tier, the
+    floor logic above is measuring the wrong profile and would silently
+    pass or fail for the wrong reasons.
+    """
+    tolerance = _load_tolerance_yaml()
+    manufacturers = tolerance.get("manufacturers") or {}
+    assert manufacturers.get(BOARD_04_RELPATH) == "jlcpcb-tier1", (
+        f"{TOLERANCE_YAML.relative_to(REPO_ROOT)} no longer declares "
+        f"board 04 against jlcpcb-tier1 in its manufacturers: block "
+        f"(currently: {manufacturers.get(BOARD_04_RELPATH)!r}).\n\n"
+        f"This board's --micro-via GND stitching requires jlcpcb-tier1's "
+        f"Capability-Plus process.  If the board was retargeted to a "
+        f"different fab tier, update:\n"
+        f"  1. The ``manufacturers:`` block in this YAML.\n"
+        f"  2. The ``--mfr`` argv in ``boards/04-stm32-devboard/"
+        f"generate_design.py::run_drc``.\n"
+        f"  3. This test (or remove it if board 04 leaves tier-1)."
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover -- manual debugging convenience.
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Pins board 04 (stm32-devboard) manufacturability state against the same CI gate `scripts/ci/check_routed_drc.py` enforces in the routed-pcb-drc-check job. Discovered during fleet-status-driven verification (#3261, parent #2394 / #2834).

## Verdict: board 04 IS still CI-gate-manufacturable on committed artifacts

| Configuration | Routing | Blocking errs (CI-counted) | Advisory connectivity | CI gate |
|--------------|---------|----------------------------|----------------------|---------|
| **Committed routed PCB** (on disk) | 9/9 | 1 (SWDIO/BOOT0 at B.Cu 143.8,119.7) | 1 (U2.8 GND stranded) | PASS (1 <= floor of 1) |
| **Fresh build, seed 42 cpp** | 8/9 (NRST drops) | 0 | 2 (NRST + U2.35) | PASS (0 <= 1) |
| **Fresh build, seed 17 cpp** | 8/9 (NRST drops) | 0 | 2 | PASS |
| **Fresh build, seed 99 cpp** | 8/9 (NRST drops) | 0 | 2 | PASS |
| **Fresh build, seed 42 python** | 3/9 | many | many | n/a (slow test) |

The committed PCB still passes the CI manufacturability gate. Fresh rebuilds also pass the CI gate -- but functionally regress NRST (signal between U2.NRST and J1.5 SWD reset), which is filed as a follow-on.

## What this PR ships

`tests/test_board_04_mfr_gate.py` -- 4 fast assertions (no re-routing, milliseconds):

1. **Blocking errors within floor**: counts non-advisory errors on the committed PCB; asserts <= floor from `.github/routed-drc-tolerance.yml`. Primary catch for new blocking-error regressions.
2. **Advisory connectivity soft cap (<=3)**: catches multi-net stranding events (e.g., the NRST + U2.35 pattern we see in fresh builds) when they hit the committed PCB.
3. **Floor slack budget (<=2)**: prompts the next PR to tighten the YAML in lockstep with router improvements that drop the actual blocking count.
4. **manufacturers: block pinned to jlcpcb-tier1**: mirrors PR #3218's recipe pin; both move in lockstep if the board is retargeted.

## What this PR does NOT do

- Does NOT regenerate the committed routed PCB (the fresh build is functionally worse -- NRST stranded).
- Does NOT tighten the floor from 1 -> 0 (committed PCB still has 1 blocking error; tightening would break the gate on it).
- Does NOT touch shared router/auto-fix/stitcher infrastructure (per scope guidance).

## Follow-on issues filed

- **#3266** -- router: NRST routing regression on board 04 (fresh build drops NRST to advisory connectivity).
- **#3267** -- router/stitch: board 04 U2.35 GND stitch unreachable in fresh build (correlates with NRST drop).
- **#3268** -- test: tests/test_board_04_routing_regression.py fails on python backend (3/9 nets, was 9/9) -- pre-existing slow-test failure.

## Test plan

- [x] `uv run pytest tests/test_board_04_mfr_gate.py -v` -- 4/4 pass on this branch.
- [x] `uv run pytest tests/test_board_04_*.py tests/test_ci_routed_drc_workflow.py tests/test_stitch_mfr.py --no-cov` -- 75/75 pass.
- [x] Fresh `uv run python boards/04-stm32-devboard/generate_design.py` completed (routing PARTIAL but DRC gate passes).
- [x] C++ router backend rebuilt in worktree: `uv run kct build-native --check` reports v1.0.0.
- [x] Worst-of-3 seeds (42, 17, 99) on C++ backend all converge to 8/9 (NRST stranded) -- this PR does NOT regress that, it pins the committed-PCB-vs-CI-gate invariant.

## References

- Closes #3261 (tracking).
- Rides with #2834 (board 04 manufacturing-ready cluster), #2394 (manufacturability roadmap).
- Mirrors PR #3218 (#3208 fix) pattern: source-text pin + gate JSON pin in lockstep.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>