### PR TITLE
fix(board-02): route_demo regenerates mfg bundle to keep fleet status fresh

### DIFF
--- a/boards/02-charlieplex-led/route_demo.py
+++ b/boards/02-charlieplex-led/route_demo.py
@@ -76,6 +76,57 @@ def run_drc(pcb_path: Path) -> tuple[bool, int, int]:
         return False, -1, -1
 
 
+def export_manufacturing_bundle(routed_path: Path, output_dir: Path) -> bool:
+    """Regenerate the manufacturing bundle so ``kct fleet status`` stays fresh.
+
+    Issue #3264: ``kct fleet status`` flags a board ``ship_ready=false``
+    with the ``"artifacts stale"`` blocker whenever the routed PCB is
+    newer than ``output/manufacturing/manifest.json``.  Re-running
+    ``route_demo.py`` always rewrites the routed PCB, so the demo must
+    also regenerate the manufacturing bundle to keep the manifest current
+    (mirrors what ``generate_design.py:export_manufacturing_bundle()``
+    already does at the end of the full design flow).
+
+    ``kct export`` runs the standard JLCPCB recipe (gerbers + drill + BOM
+    + CPL + report.{md,pdf} + manifest.json).  ``--skip-preflight`` skips
+    the strict pre-flight DRC/ERC gate so the bundle is produced even for
+    boards that ship with allowlisted tolerances; for clean boards (like
+    board 02 post-#3207) it is harmless.
+    """
+    print("\n" + "=" * 60)
+    print("Exporting manufacturing bundle (Issue #3264)...")
+    print("=" * 60)
+
+    mfg_dir = output_dir / "manufacturing"
+    cmd = [
+        sys.executable,
+        "-m",
+        "kicad_tools.cli",
+        "export",
+        str(routed_path),
+        "--output",
+        str(mfg_dir),
+        "--mfr",
+        "jlcpcb",
+        "--skip-preflight",
+    ]
+    print(f"\n   Command: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.stdout:
+        for line in result.stdout.strip().split("\n")[-15:]:
+            print(f"   {line}")
+    if result.returncode != 0:
+        if result.stderr:
+            print(f"\n   Error: {result.stderr}")
+        return False
+    manifest = mfg_dir / "manifest.json"
+    if manifest.exists():
+        print(f"\n   Manifest: {manifest}")
+        return True
+    print("\n   WARNING: manifest.json not produced")
+    return False
+
+
 def _parse_routed_net_count(stdout: str) -> tuple[int, int] | None:
     """Extract ``Nets routed: N/M`` (or equivalent) from ``kct route`` output.
 
@@ -186,6 +237,14 @@ def main():
     parsed = _parse_routed_net_count(result.stdout)
     routed, total = parsed if parsed is not None else (None, None)
 
+    # Issue #3264: regenerate the manufacturing bundle so its
+    # ``manifest.json`` mtime is newer than the freshly-routed PCB.
+    # Otherwise ``kct fleet status`` reports ``ship_ready=false`` with
+    # blocker ``"artifacts stale"`` even though the route succeeded.
+    # This mirrors the post-route step in
+    # ``generate_design.py:export_manufacturing_bundle()``.
+    mfg_success = export_manufacturing_bundle(output_path, output_path.parent)
+
     # Run DRC validation on the routed output.
     print("\n--- DRC Validation ---")
     drc_passed, drc_errors, drc_warnings = run_drc(output_path)
@@ -219,6 +278,9 @@ def main():
             print(f"PARTIAL: `kct route` exited with code {result.returncode}")
         if not drc_passed:
             print(f"  Additionally, {drc_errors} DRC violation(s) detected.")
+    # Issue #3264: surface mfg bundle freshness so users can see whether
+    # fleet status will report ship_ready=true.
+    print(f"MFG bundle: {'FRESH' if mfg_success else 'STALE (fleet status will block)'}")
     print("=" * 60)
 
     # Return success only if all nets routed AND DRC passed.

--- a/tests/test_board02_route_demo_recipe.py
+++ b/tests/test_board02_route_demo_recipe.py
@@ -57,6 +57,7 @@ GENERATE_DESIGN_SCRIPT = BOARD_DIR / "generate_design.py"
 OUTPUT_DIR = BOARD_DIR / "output"
 UNROUTED_PCB = OUTPUT_DIR / "charlieplex_3x3.kicad_pcb"
 ROUTED_PCB = OUTPUT_DIR / "charlieplex_3x3_routed.kicad_pcb"
+MFG_MANIFEST = OUTPUT_DIR / "manufacturing" / "manifest.json"
 
 # Minimum number of signal nets ``route_demo.py`` must route on board 02.
 # Issue #3207 acceptance criterion #1: ">= 8/10 routed nets on board 02
@@ -242,6 +243,93 @@ def unrouted_pcb_present() -> Path:
             "regenerate via `python3 boards/02-charlieplex-led/generate_pcb.py`."
         )
     return UNROUTED_PCB
+
+
+def test_route_demo_invokes_mfg_bundle_export() -> None:
+    """``route_demo.py`` invokes ``kct export`` after routing (Issue #3264).
+
+    Issue #3264 regression guard: ``kct fleet status`` reports
+    ``ship_ready=false`` with blocker ``"artifacts stale"`` whenever the
+    routed PCB's mtime is newer than ``manufacturing/manifest.json``'s
+    mtime.  Re-running ``route_demo.py`` always rewrites the routed PCB,
+    so the demo MUST also regenerate the manufacturing bundle to keep
+    the manifest current.
+
+    This static test pins the existence of an ``export`` subprocess
+    invocation in ``route_demo.py`` that mirrors
+    ``generate_design.py:export_manufacturing_bundle()``.
+    """
+    assert ROUTE_DEMO_SCRIPT.exists(), f"route_demo.py missing: {ROUTE_DEMO_SCRIPT}"
+    source = ROUTE_DEMO_SCRIPT.read_text()
+
+    # The script must invoke ``kct export`` as a subprocess.
+    assert '"export"' in source or "'export'" in source, (
+        "route_demo.py does not invoke `kct export` — Issue #3264 fix "
+        "is missing.  Re-running the demo will leave manufacturing/"
+        "manifest.json older than the freshly-routed PCB, which makes "
+        "`kct fleet status` report ship_ready=false with blocker "
+        "'artifacts stale'.  Mirror "
+        "generate_design.py:export_manufacturing_bundle()."
+    )
+    # And it must call ``--mfr jlcpcb`` to match the canonical recipe.
+    assert "--mfr" in source and "jlcpcb" in source, (
+        "route_demo.py's mfg-bundle export must use `--mfr jlcpcb` to "
+        "match the canonical recipe in "
+        "generate_design.py:export_manufacturing_bundle()."
+    )
+
+
+def test_route_demo_refreshes_manifest_mtime(unrouted_pcb_present: Path) -> None:
+    """After ``route_demo.py`` runs, ``manifest.json`` mtime is newer
+    than the routed PCB's mtime (Issue #3264).
+
+    This is the load-bearing invariant that ``kct fleet status`` checks
+    at ``cli/fleet_cmd.py:634-639`` to decide whether to flag the board
+    ``ship_ready=false`` with blocker ``"artifacts stale"``.  Pre-fix
+    the demo re-routed the PCB but never re-exported the bundle, so the
+    manifest would be left older than the routed PCB and the board would
+    drop to non-ship-ready immediately after running the demo.
+
+    A hard timeout of 300 s guards against router or export hangs.
+    """
+    # Run the demo.  Exit code 0 (full success) or 1 (partial routing /
+    # DRC errors) are both acceptable here -- we pin freshness, not
+    # routing completion (the next test covers that).
+    proc = subprocess.run(
+        [sys.executable, str(ROUTE_DEMO_SCRIPT)],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+        cwd=str(BOARD_DIR),
+    )
+    assert proc.returncode in (0, 1), (
+        f"route_demo.py returned unexpected exit code {proc.returncode}\n"
+        f"stdout (last 4000 chars):\n{proc.stdout[-4000:]}\n"
+        f"stderr (last 2000 chars):\n{proc.stderr[-2000:]}"
+    )
+
+    assert ROUTED_PCB.exists(), (
+        f"route_demo.py did not produce routed PCB at {ROUTED_PCB}.\n"
+        f"stdout (last 4000 chars):\n{proc.stdout[-4000:]}"
+    )
+    assert MFG_MANIFEST.exists(), (
+        f"route_demo.py did not produce manufacturing manifest at "
+        f"{MFG_MANIFEST}.  Issue #3264 fix expects the demo to invoke "
+        f"`kct export` after routing.\n"
+        f"stdout (last 4000 chars):\n{proc.stdout[-4000:]}"
+    )
+
+    routed_mtime = ROUTED_PCB.stat().st_mtime
+    manifest_mtime = MFG_MANIFEST.stat().st_mtime
+    assert manifest_mtime >= routed_mtime, (
+        f"Issue #3264 regression: manifest.json ({manifest_mtime}) is "
+        f"older than routed PCB ({routed_mtime}) after running "
+        f"route_demo.py.  `kct fleet status` will report "
+        f"ship_ready=false with blocker 'artifacts stale'.  The demo "
+        f"must call `kct export` after `kct route` to refresh the "
+        f"manufacturing bundle."
+    )
 
 
 def test_route_demo_achieves_minimum_completion(unrouted_pcb_present: Path) -> None:


### PR DESCRIPTION
## Summary

- Fixes Issue #3264: ``boards/02-charlieplex-led/route_demo.py`` re-routes the PCB but never re-exports the manufacturing bundle, so ``kct fleet status`` reports ``ship_ready=false`` with blocker ``"artifacts stale"`` even after a successful route.
- Adds a small ``export_manufacturing_bundle()`` helper to ``route_demo.py`` (mirrors the helper already in ``generate_design.py``) and calls it from ``main()`` after ``kct route`` writes the routed PCB.
- Surfaces the bundle freshness in the demo's summary block (``MFG bundle: FRESH`` / ``STALE (fleet status will block)``) so users can see at a glance whether fleet status will be happy.
- Adds two regression tests in ``tests/test_board02_route_demo_recipe.py``:
  - Static check that ``route_demo.py`` invokes ``kct export --mfr jlcpcb``.
  - End-to-end check that after running the demo, ``manifest.json`` mtime is newer than the routed PCB (the exact invariant ``cli/fleet_cmd.py:634-639`` uses).

## Reproduction (pre-fix)

```bash
python boards/02-charlieplex-led/route_demo.py
uv run kct fleet status --format json | jq '.boards[] | select(.name=="02-charlieplex-led") | {ship_ready, blockers}'
# -> {"ship_ready": false, "blockers": ["artifacts stale"]}
```

After this PR:

```bash
python boards/02-charlieplex-led/route_demo.py
uv run kct fleet status --format json | jq '.boards[] | select(.name=="02-charlieplex-led") | {ship_ready, blockers}'
# -> {"ship_ready": true, "blockers": []}
```

## Scope

This PR fixes board 02 only, matching the issue body's Option 2 ("Most surgical fix. ~10 LOC per board"). The same gap exists in ``boards/03-usb-joystick/route_demo.py`` and likely any ``route.py``-style recipe across other boards that re-routes without re-exporting -- those can be addressed in follow-up issues if/when they hit a fleet-status false negative. The fix is mechanically identical for each board, so generalization is straightforward; I held off only to keep this PR scoped to the issue as filed.

Longer-term solutions discussed in the issue body (Option 3: content-hash routed PCB; Option 4: hash-based manifest) remain valid follow-ups for a more robust fix across all entry points.

## Test plan

- [x] ``uv run pytest tests/test_board02_route_demo_recipe.py`` -- 5/5 pass (including 2 new regression tests)
- [x] ``uv run pytest tests/router/test_board02_manufacturable_baseline.py`` -- 3/3 pass (no regression in routing baseline)
- [x] Manual reproduction: pre-fix flips ``ship_ready`` from true -> false; post-fix flips from false -> true.

Closes #3264

🤖 Generated with [Claude Code](https://claude.com/claude-code)