### PR TITLE
feat(stitch): pad-aware --avoid-pad-overlap + board 06 recipe integration

### DIFF
--- a/boards/06-diffpair-test/generate_design.py
+++ b/boards/06-diffpair-test/generate_design.py
@@ -614,6 +614,53 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
     except Exception as exc:  # pragma: no cover - degrade gracefully
         print(f"   Zone generation skipped: {exc}")
 
+    # Issue #3271: pad-aware post-route stitching for plane-net pad
+    # connectivity.  GND and VBUS_USB are pour nets -- the router skips
+    # them on the signal layer and they rely on the In1.Cu / In2.Cu
+    # pours for power-plane connectivity.  Without per-pad stitching
+    # vias, SMD pads on those nets stay stranded (no copper between
+    # the pad and the pour) and the connectivity DRC rule flags them.
+    #
+    # A NAIVE ``kct stitch --net GND --net VBUS_USB`` invocation placed
+    # 27 vias on top of neighbouring same-net QFN / BGA pads (the
+    # standard placement offset ``pad_radius + offset`` lands inside
+    # the next pad on dense fine-pitch fields).  Those would be
+    # ``via_in_pad`` DRC errors under JLCPCB standard tier (which does
+    # not support plated-over via-in-pad processing).  The
+    # ``--avoid-pad-overlap`` flag (issue #3271) post-filters such
+    # placements so the stitched PCB stays manufacturable under the
+    # ``jlcpcb`` profile this board targets.  Pads whose ideal via
+    # would land in a same-net pad keep their pour-side connection
+    # via the zone fill's thermal relief.
+    print("\n10. Pad-aware post-route stitching for plane nets (issue #3271)...")
+    try:
+        stitch_nets = ["GND", "VBUS_USB"]
+        stitch_argv = [
+            sys.executable,
+            "-m",
+            "kicad_tools.cli",
+            "stitch",
+            str(output_path),
+            "--mfr",
+            "jlcpcb",
+            "--avoid-pad-overlap",
+        ]
+        for net_name in stitch_nets:
+            stitch_argv.extend(["--net", net_name])
+        stitch_result = subprocess.run(stitch_argv, capture_output=True, text=True)
+        if stitch_result.returncode == 0:
+            # Surface the last few lines of the stitch summary so the
+            # build log records how many vias were added and how many
+            # were filtered as would-be via-in-pad placements.
+            for line in stitch_result.stdout.strip().split("\n")[-12:]:
+                print(f"   {line}")
+        else:
+            print(f"   Stitch failed (rc={stitch_result.returncode}):")
+            if stitch_result.stderr:
+                print(f"   stderr: {stitch_result.stderr.strip()}")
+    except Exception as exc:  # pragma: no cover - degrade gracefully
+        print(f"   Stitch step skipped: {exc}")
+
     total_signal_nets = len([n for n in router.nets if n > 0])
     success = stats["nets_routed"] == total_signal_nets
     if success:

--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -520,6 +520,8 @@ def _run_stitch_command(args) -> int:
         sub_argv.extend(["--micro-via-size", str(args.stitch_micro_via_size)])
     if hasattr(args, "stitch_micro_via_drill") and args.stitch_micro_via_drill != 0.15:
         sub_argv.extend(["--micro-via-drill", str(args.stitch_micro_via_drill)])
+    if hasattr(args, "stitch_avoid_pad_overlap") and args.stitch_avoid_pad_overlap:
+        sub_argv.append("--avoid-pad-overlap")
     if hasattr(args, "stitch_spacing") and args.stitch_spacing != 3.0:
         sub_argv.extend(["--spacing", str(args.stitch_spacing)])
     if hasattr(args, "stitch_thermal") and args.stitch_thermal:

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2347,6 +2347,18 @@ def _add_stitch_parser(subparsers) -> None:
         help="Micro-via drill diameter in mm (default: 0.15). Only used with --micro-via.",
     )
     stitch_parser.add_argument(
+        "--avoid-pad-overlap",
+        action="store_true",
+        dest="stitch_avoid_pad_overlap",
+        help=(
+            "Issue #3271: drop via placements whose drill circle would be "
+            "fully contained inside an SMD pad on the same net.  Required "
+            "on manufacturer profiles that forbid via-in-pad processing "
+            "(e.g. JLCPCB standard tier).  Has no effect under --blanket "
+            "or --thermal."
+        ),
+    )
+    stitch_parser.add_argument(
         "--spacing",
         type=float,
         default=3.0,

--- a/src/kicad_tools/cli/stitch_cmd.py
+++ b/src/kicad_tools/cli/stitch_cmd.py
@@ -242,6 +242,13 @@ class StitchResult:
     skip_details: list[tuple[PadInfo, SkipDetail]] = field(default_factory=list)
     # Micro-via tracking: count of vias placed using micro-via retry
     micro_vias_placed: int = 0
+    # Via-in-pad post-filter (issue #3271): count of via placements that
+    # were dropped because they would have produced a via_in_pad DRC
+    # violation under manufacturer profiles that forbid via-in-pad (e.g.
+    # JLCPCB standard tier).  Only populated when ``avoid_pad_overlap`` is
+    # enabled in ``run_stitch``.  The corresponding pads are recorded in
+    # ``pads_skipped`` with a ``via_in_pad`` reason.
+    via_in_pad_filtered: int = 0
 
 
 @dataclass
@@ -708,6 +715,137 @@ def find_pads_on_nets(sexp: SExp, net_names: set[str]) -> list[PadInfo]:
             )
 
     return pads
+
+
+def find_smd_pad_bboxes_on_nets(
+    sexp: SExp,
+    net_numbers: set[int],
+) -> list[tuple[int, float, float, float, float]]:
+    """Return axis-aligned bounding boxes for SMD pads on the given nets.
+
+    Issue #3271: the stitch ``--avoid-pad-overlap`` post-filter (see
+    ``run_stitch``) drops via placements whose drill circle would be fully
+    contained inside an SMD pad on the same net.  This mirrors the
+    geometry used by
+    :class:`kicad_tools.validate.rules.via_in_pad.ViaInPadRule` so the
+    stitch tool can pre-empt the same DRC violations that rule would later
+    flag under manufacturer profiles that forbid via-in-pad processing
+    (e.g. ``jlcpcb`` standard tier).
+
+    Through-hole pads are excluded because they have their own plated hole
+    -- a via inside them is not a manufacturability concern.
+
+    Args:
+        sexp: PCB S-expression.
+        net_numbers: Net numbers to include (typically the same set the
+            stitcher targets).
+
+    Returns:
+        List of ``(net_num, min_x, min_y, max_x, max_y)`` tuples in board
+        coordinates (mm).  Bbox is the AABB of the rotated rectangle
+        matching ``via_in_pad._pad_absolute_bbox`` for cardinal rotations
+        (and the conservative AABB-of-rotated-rect for non-cardinal
+        angles).
+    """
+    bboxes: list[tuple[int, float, float, float, float]] = []
+
+    for fp in sexp.iter_children():
+        if fp.tag != "footprint":
+            continue
+
+        at_node = fp.find_child("at")
+        if not at_node:
+            continue
+        fp_x = at_node.get_float(0) or 0.0
+        fp_y = at_node.get_float(1) or 0.0
+        fp_rotation_deg = at_node.get_float(2) or 0.0
+        rad = math.radians(fp_rotation_deg)
+        cos_r = math.cos(rad)
+        sin_r = math.sin(rad)
+
+        for pad in fp.find_children("pad"):
+            pad_type = pad.get_string(1)
+            # Only SMD pads carry the via-in-pad concern -- a through-hole
+            # pad is already a plated hole.
+            if pad_type != "smd":
+                continue
+
+            net_node = pad.find_child("net")
+            if not net_node:
+                continue
+            net_num = net_node.get_int(0)
+            if net_num is None or net_num not in net_numbers:
+                continue
+
+            pad_at = pad.find_child("at")
+            if not pad_at:
+                continue
+            rel_x = pad_at.get_float(0) or 0.0
+            rel_y = pad_at.get_float(1) or 0.0
+            board_x = fp_x + rel_x * cos_r - rel_y * sin_r
+            board_y = fp_y + rel_x * sin_r + rel_y * cos_r
+
+            size_node = pad.find_child("size")
+            if not size_node:
+                continue
+            width = size_node.get_float(0) or 0.0
+            height = size_node.get_float(1) or 0.0
+
+            # Mirror the bbox computation used by
+            # ``via_in_pad._pad_absolute_bbox``: cardinal rotations
+            # swap dimensions; other rotations conservatively use the
+            # AABB of the rotated rectangle.
+            total_rotation = fp_rotation_deg % 360
+            if abs(total_rotation - 90) < 0.001 or abs(total_rotation - 270) < 0.001:
+                bbox_w, bbox_h = height, width
+            elif abs(total_rotation) < 0.001 or abs(total_rotation - 180) < 0.001:
+                bbox_w, bbox_h = width, height
+            else:
+                abs_cos = abs(cos_r)
+                abs_sin = abs(sin_r)
+                bbox_w = width * abs_cos + height * abs_sin
+                bbox_h = width * abs_sin + height * abs_cos
+
+            half_w = bbox_w / 2
+            half_h = bbox_h / 2
+            bboxes.append(
+                (
+                    net_num,
+                    board_x - half_w,
+                    board_y - half_h,
+                    board_x + half_w,
+                    board_y + half_h,
+                )
+            )
+
+    return bboxes
+
+
+def _via_drill_inside_pad_bbox(
+    via_x: float,
+    via_y: float,
+    drill: float,
+    bbox: tuple[float, float, float, float],
+    tolerance: float = 1e-6,
+) -> bool:
+    """Return True iff the via's drill circle is fully inside ``bbox``.
+
+    Issue #3271: mirrors
+    ``kicad_tools.validate.rules.via_in_pad._via_inside_pad`` so the
+    stitch post-filter classifies vias identically to the DRC rule it is
+    pre-empting.  ``bbox`` is ``(min_x, min_y, max_x, max_y)``.  The
+    drill circle is "fully inside" when every point on it lies on or
+    inside the bbox edge, i.e. the drill's bounding box fits inside
+    ``bbox`` (minus a tolerance so edge-touching drills are not flagged).
+    """
+    radius = drill / 2.0
+    min_x, min_y, max_x, max_y = bbox
+    return (
+        via_x - radius >= min_x - tolerance
+        and via_x + radius <= max_x + tolerance
+        and via_y - radius >= min_y - tolerance
+        and via_y + radius <= max_y + tolerance
+    )
 
 
 def find_existing_vias(sexp: SExp, net_numbers: set[int]) -> list[tuple[float, float, int]]:
@@ -3386,6 +3524,7 @@ def run_stitch(
     micro_via: bool = False,
     micro_via_size: float = 0.3,
     micro_via_drill: float = 0.15,
+    avoid_pad_overlap: bool = False,
 ) -> StitchResult:
     """Run the stitching operation on a PCB.
 
@@ -3403,6 +3542,18 @@ def run_stitch(
         micro_via: If True, retry failed pads with smaller micro-vias
         micro_via_size: Micro-via pad diameter in mm (default 0.3)
         micro_via_drill: Micro-via drill diameter in mm (default 0.15)
+        avoid_pad_overlap: Issue #3271 -- when True, drop via placements
+            whose drill circle would be fully contained inside an SMD pad
+            on the same net (i.e., would produce a ``via_in_pad`` DRC
+            violation under manufacturer profiles that forbid via-in-pad
+            processing).  Without this guard, the standard placement
+            offset (``pad_radius + offset``) can land the via on top of a
+            neighbouring same-net pad on dense QFN / BGA footprints --
+            the via is geometrically clear of other-net copper, but the
+            JLCPCB standard tier (and similar) treat any via-in-pad as a
+            manufacturability failure.  Dropped pads are recorded in
+            ``StitchResult.pads_skipped`` with a ``via_in_pad`` reason and
+            counted in ``StitchResult.via_in_pad_filtered``.
 
     Returns:
         StitchResult with details of what was done
@@ -3765,6 +3916,68 @@ def run_stitch(
             # Add to existing vias list
             existing_vias.append((via_pos[0], via_pos[1], pad.net_number))
 
+    # Issue #3271: pad-aware post-filter for manufacturers that forbid
+    # via-in-pad (e.g. JLCPCB standard tier).
+    #
+    # The placement strategies above push the via off the originating pad
+    # by ``pad_radius + offset`` but do NOT consider neighbouring same-net
+    # pads on the same footprint.  On dense QFN / BGA components the
+    # standard offset can land the via on top of a neighbour pad on the
+    # same net -- geometrically clear of other-net copper, but rejected by
+    # the JLCPCB tier-1 manufacturability rule because plated-over
+    # via-in-pad processing is not supported.  See ``ViaInPadRule`` and
+    # issue #3271 for the pre-emption rationale.
+    #
+    # We use the same SMD-pad-bbox containment geometry the DRC rule
+    # uses, so this filter drops exactly the placements the rule would
+    # later flag.  Through-hole pads are intentionally excluded: they
+    # already have a plated hole, so a via inside them is not a
+    # manufacturability concern.
+    if avoid_pad_overlap and result.vias_added:
+        net_numbers_local = {
+            num for num, name in get_net_map(sexp).items() if name in set(net_names)
+        }
+        pad_bboxes = find_smd_pad_bboxes_on_nets(sexp, net_numbers_local)
+        # Group bboxes by net for O(N+M) scan rather than O(N*M).
+        bboxes_by_net: dict[int, list[tuple[float, float, float, float]]] = {}
+        for net_num, min_x, min_y, max_x, max_y in pad_bboxes:
+            bboxes_by_net.setdefault(net_num, []).append((min_x, min_y, max_x, max_y))
+
+        kept_vias: list[ViaPlacement] = []
+        kept_traces: list[TraceSegment] = []
+        # Index traces by their pad object identity so we can drop the
+        # trace alongside the via when the placement is filtered out.
+        # Multiple placements per pad are not produced by ``run_stitch``
+        # (one via per skipped pad), so id-keying is sufficient.
+        for placement, trace in zip(result.vias_added, result.traces_added, strict=True):
+            candidate_bboxes = bboxes_by_net.get(placement.pad.net_number, [])
+            in_pad = any(
+                _via_drill_inside_pad_bbox(
+                    placement.via_x, placement.via_y, placement.drill, bbox
+                )
+                for bbox in candidate_bboxes
+            )
+            if in_pad:
+                result.via_in_pad_filtered += 1
+                if placement.pad.net_number == trace.pad.net_number:
+                    # The pad whose escape we just filtered loses its
+                    # stitch; record so the user-facing summary makes the
+                    # trade-off explicit.  The diagnostic reason mirrors
+                    # the DRC rule's wording.
+                    result.pads_skipped.append(
+                        (
+                            placement.pad,
+                            "via_in_pad: standard placement would land drill "
+                            "inside same-net SMD pad (avoid_pad_overlap=True); "
+                            "pad relies on the plane pour for connectivity",
+                        )
+                    )
+                continue
+            kept_vias.append(placement)
+            kept_traces.append(trace)
+        result.vias_added = kept_vias
+        result.traces_added = kept_traces
+
     # Apply changes if not dry run
     if not dry_run and result.vias_added:
         for placement in result.vias_added:
@@ -3991,6 +4204,14 @@ def output_result(
             )
     if result.already_connected:
         print(f"  = {result.already_connected} pads already connected")
+    if result.via_in_pad_filtered:
+        # Issue #3271: surface the pad-aware post-filter so users see why
+        # the via count is below what naive placement would have produced.
+        print(
+            f"  ~ Filtered {result.via_in_pad_filtered} via placement(s) "
+            "that would have produced via_in_pad violations "
+            "(--avoid-pad-overlap; pads rely on the plane pour for connectivity)"
+        )
     if result.pads_skipped:
         print(f"  ! Skipped {len(result.pads_skipped)} pads (manual placement needed)")
 
@@ -4082,6 +4303,21 @@ def main(argv: list[str] | None = None) -> int:
         type=float,
         default=0.15,
         help="Micro-via drill diameter in mm (default: 0.15). Only used with --micro-via.",
+    )
+    parser.add_argument(
+        "--avoid-pad-overlap",
+        action="store_true",
+        dest="avoid_pad_overlap",
+        help=(
+            "Issue #3271: drop via placements whose drill circle would be "
+            "fully contained inside an SMD pad on the same net.  Required "
+            "on manufacturer profiles that forbid via-in-pad processing "
+            "(e.g. JLCPCB standard tier) -- without this guard, the "
+            "standard placement offset can land vias on top of neighbouring "
+            "same-net pads on dense QFN / BGA footprints, producing "
+            "via_in_pad DRC violations.  Has no effect under --blanket or "
+            "--thermal (those modes already check same-net pads)."
+        ),
     )
     parser.add_argument(
         "--blanket",
@@ -4295,6 +4531,7 @@ def main(argv: list[str] | None = None) -> int:
                 micro_via=args.micro_via,
                 micro_via_size=args.micro_via_size,
                 micro_via_drill=args.micro_via_drill,
+                avoid_pad_overlap=args.avoid_pad_overlap,
             )
 
         output_result(result, dry_run=args.dry_run, run_drc=args.drc, edited_path=pcb_path)

--- a/tests/test_stitch_cmd.py
+++ b/tests/test_stitch_cmd.py
@@ -5239,3 +5239,248 @@ class TestOutputResultDiagnostics:
         captured = capsys.readouterr()
         assert "Blocking obstacle breakdown" in captured.out
         assert "track: 1" in captured.out
+
+
+# ----------------------------------------------------------------------------
+# Issue #3271: pad-aware --avoid-pad-overlap regression coverage
+#
+# The standard ``calculate_via_position`` checks clearance against OTHER-net
+# copper but NOT against same-net pads.  On dense QFN / BGA footprints the
+# ``pad_radius + offset`` placement can land the via on top of a neighbouring
+# same-net pad -- geometrically clear, but rejected by manufacturers that
+# forbid via-in-pad (e.g. JLCPCB standard tier).  The
+# ``--avoid-pad-overlap`` flag added by issue #3271 post-filters such
+# placements; these tests pin the geometry, the bbox helper, and the
+# end-to-end CLI behaviour.
+# ----------------------------------------------------------------------------
+
+
+# A fine-pitch QFN-like footprint where pad 1's offset-placed via lands inside
+# pad 2 (next pad on the same row, same GND net).  Pads are 0.6mm-wide rectangles
+# centred 1.0mm apart on the +X axis -- exactly the geometry that triggers the
+# board-06 J3 ground-frame failure described in #3271.  Default placement
+# offsets the via to ``pad_radius + offset = 0.3 + 0.5 = 0.8mm`` from pad 1's
+# centre at (110.0, 110.0), landing at (110.8, 110.0) -- which is *inside*
+# pad 2's bbox at (110.7, 109.7)..(111.3, 110.3) for a 0.3mm-radius drill.
+PAD_OVERLAP_TEST_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (2 "In2.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "Custom:QFN_Dense"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000100")
+    (at 110 110)
+    (property "Reference" "U1" (at 0 -2 0) (layer "F.SilkS") (uuid "ref-uuid-u1"))
+    (pad "1" smd rect (at 0 0) (size 0.6 0.6) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "GND"))
+    (pad "2" smd rect (at 1.0 0) (size 0.6 0.6) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "GND"))
+  )
+  (zone (net 1) (net_name "GND") (layer "In1.Cu") (uuid "zone-uuid-1") (hatch edge 0.5)
+    (connect_pads (clearance 0.2))
+    (min_thickness 0.2)
+    (polygon (pts (xy 90 90) (xy 130 90) (xy 130 130) (xy 90 130)))
+  )
+)
+"""
+
+
+@pytest.fixture
+def pad_overlap_test_pcb(tmp_path: Path) -> Path:
+    """PCB where stitching pad 1 would land the via inside same-net pad 2."""
+    pcb_file = tmp_path / "pad_overlap.kicad_pcb"
+    pcb_file.write_text(PAD_OVERLAP_TEST_PCB)
+    return pcb_file
+
+
+class TestFindSmdPadBboxes:
+    """find_smd_pad_bboxes_on_nets: per-net SMD bbox collection."""
+
+    def test_returns_bbox_for_smd_pad_on_target_net(self, pad_overlap_test_pcb):
+        """SMD pads on the target net are returned with their AABB."""
+        from kicad_tools.cli.stitch_cmd import find_smd_pad_bboxes_on_nets
+
+        sexp = load_pcb(pad_overlap_test_pcb)
+        bboxes = find_smd_pad_bboxes_on_nets(sexp, {1})
+
+        # Two GND pads on U1 -- bboxes match the rectangles.
+        assert len(bboxes) == 2
+        for net_num, *_ in bboxes:
+            assert net_num == 1
+        # Pad 1 at (110, 110), 0.6 x 0.6 -> (109.7, 109.7, 110.3, 110.3)
+        # Pad 2 at (111, 110), 0.6 x 0.6 -> (110.7, 109.7, 111.3, 110.3)
+        sorted_bboxes = sorted(bboxes, key=lambda b: b[1])
+        assert math.isclose(sorted_bboxes[0][1], 109.7, abs_tol=1e-6)
+        assert math.isclose(sorted_bboxes[0][3], 110.3, abs_tol=1e-6)
+        assert math.isclose(sorted_bboxes[1][1], 110.7, abs_tol=1e-6)
+        assert math.isclose(sorted_bboxes[1][3], 111.3, abs_tol=1e-6)
+
+    def test_excludes_pads_not_on_target_nets(self, pad_overlap_test_pcb):
+        """Pads on nets outside the requested set are filtered out."""
+        from kicad_tools.cli.stitch_cmd import find_smd_pad_bboxes_on_nets
+
+        sexp = load_pcb(pad_overlap_test_pcb)
+        # No nets requested -> empty result.
+        assert find_smd_pad_bboxes_on_nets(sexp, set()) == []
+        # Unknown net -> empty result.
+        assert find_smd_pad_bboxes_on_nets(sexp, {999}) == []
+
+
+class TestViaDrillInsidePadBbox:
+    """_via_drill_inside_pad_bbox: drill-circle containment geometry."""
+
+    def test_drill_fully_inside_bbox_returns_true(self):
+        """Drill circle wholly inside the bbox -> True."""
+        from kicad_tools.cli.stitch_cmd import _via_drill_inside_pad_bbox
+
+        bbox = (110.7, 109.7, 111.3, 110.3)
+        # Centre at (111, 110) with 0.2mm drill -> drill radius 0.1mm, drill bbox
+        # (110.9, 109.9)..(111.1, 110.1), wholly inside.
+        assert _via_drill_inside_pad_bbox(111.0, 110.0, 0.2, bbox) is True
+
+    def test_drill_partially_outside_bbox_returns_false(self):
+        """Drill spills past the bbox edge -> False (not classified via-in-pad)."""
+        from kicad_tools.cli.stitch_cmd import _via_drill_inside_pad_bbox
+
+        bbox = (110.7, 109.7, 111.3, 110.3)
+        # Centre at (111.25, 110) with 0.2mm drill -> spills past the right edge.
+        assert _via_drill_inside_pad_bbox(111.25, 110.0, 0.2, bbox) is False
+
+    def test_drill_centre_outside_bbox_returns_false(self):
+        """Drill centred far from bbox -> False."""
+        from kicad_tools.cli.stitch_cmd import _via_drill_inside_pad_bbox
+
+        bbox = (110.7, 109.7, 111.3, 110.3)
+        assert _via_drill_inside_pad_bbox(120.0, 110.0, 0.2, bbox) is False
+
+
+class TestAvoidPadOverlap:
+    """run_stitch ``avoid_pad_overlap``: post-filter would-be via-in-pad placements."""
+
+    def test_naive_stitch_places_via_in_neighbour_pad(self, pad_overlap_test_pcb):
+        """Without the guard, stitching pad U1.1 lands the via inside pad U1.2.
+
+        This is the pre-emption target -- we're pinning the failure mode that
+        ``--avoid-pad-overlap`` exists to fix, so a future change that alters
+        default placement geometry will trip this test before the guard is
+        evaluated.
+        """
+        from kicad_tools.cli.stitch_cmd import (
+            _via_drill_inside_pad_bbox,
+            find_smd_pad_bboxes_on_nets,
+            run_stitch,
+        )
+
+        result = run_stitch(
+            pad_overlap_test_pcb,
+            net_names=["GND"],
+            dry_run=True,  # Don't write the PCB; we just want the placements.
+            avoid_pad_overlap=False,
+        )
+        # At least one via placement was attempted (the placer found at least
+        # one pad to stitch).
+        assert result.vias_added, "Naive stitch should produce at least one placement"
+        sexp = load_pcb(pad_overlap_test_pcb)
+        bboxes = find_smd_pad_bboxes_on_nets(sexp, {1})
+        offending = [
+            placement
+            for placement in result.vias_added
+            if any(
+                _via_drill_inside_pad_bbox(placement.via_x, placement.via_y, placement.drill, b)
+                for _net, *b in [(0, *bbox[1:]) for bbox in bboxes]
+            )
+        ]
+        assert offending, (
+            "Pre-emption target: naive stitch should place the via inside a "
+            "neighbouring same-net pad on this fixture; if this fails, default "
+            "placement geometry changed and the --avoid-pad-overlap regression "
+            "fixture needs to be updated."
+        )
+
+    def test_avoid_pad_overlap_filters_via_in_pad_placements(self, pad_overlap_test_pcb):
+        """With the guard, the via-in-pad placement is dropped from vias_added.
+
+        Verifies the post-filter is applied: the result still records the
+        attempt (via ``via_in_pad_filtered`` and ``pads_skipped``) but does
+        not commit the offending via.
+        """
+        from kicad_tools.cli.stitch_cmd import (
+            _via_drill_inside_pad_bbox,
+            find_smd_pad_bboxes_on_nets,
+            run_stitch,
+        )
+
+        result = run_stitch(
+            pad_overlap_test_pcb,
+            net_names=["GND"],
+            dry_run=True,
+            avoid_pad_overlap=True,
+        )
+        sexp = load_pcb(pad_overlap_test_pcb)
+        bboxes = find_smd_pad_bboxes_on_nets(sexp, {1})
+
+        # No kept via lands inside a same-net SMD pad.
+        for placement in result.vias_added:
+            for _net, *bbox_pts in [(0, *bbox[1:]) for bbox in bboxes]:
+                assert not _via_drill_inside_pad_bbox(
+                    placement.via_x, placement.via_y, placement.drill, bbox_pts
+                ), (
+                    f"Filter failed: kept via at ({placement.via_x}, "
+                    f"{placement.via_y}) is inside same-net pad bbox {bbox_pts}"
+                )
+
+        # At least one would-be placement was filtered.
+        assert result.via_in_pad_filtered > 0
+        # And the filtered count is reflected in pads_skipped with the
+        # ``via_in_pad`` diagnostic.
+        assert any(
+            "via_in_pad" in reason for _pad, reason in result.pads_skipped
+        ), "via_in_pad reason should appear in pads_skipped diagnostics"
+
+    def test_avoid_pad_overlap_default_off(self, pad_overlap_test_pcb):
+        """Default ``avoid_pad_overlap=False`` preserves existing behaviour.
+
+        Backward-compat guard: callers that don't pass the flag get the
+        pre-#3271 placement, so this is a non-breaking addition.
+        """
+        from kicad_tools.cli.stitch_cmd import run_stitch
+
+        result = run_stitch(
+            pad_overlap_test_pcb,
+            net_names=["GND"],
+            dry_run=True,
+        )
+        assert result.via_in_pad_filtered == 0
+
+
+class TestAvoidPadOverlapCli:
+    """CLI flag wiring: ``kct stitch --avoid-pad-overlap`` end-to-end."""
+
+    def test_cli_flag_filters_via_in_pad_placements(self, pad_overlap_test_pcb):
+        """Running ``main(['--avoid-pad-overlap', ...])`` filters via-in-pad."""
+        from kicad_tools.cli.stitch_cmd import main
+
+        # ``--dry-run`` keeps the file untouched; we only care about exit code.
+        rc = main(
+            [
+                str(pad_overlap_test_pcb),
+                "--net",
+                "GND",
+                "--avoid-pad-overlap",
+                "--dry-run",
+            ]
+        )
+        # Exit 0 even when all placements were filtered, because at least one
+        # pad was found and ``avoid_pad_overlap`` is the documented "no via
+        # produced for this pad" path.
+        assert rc == 0


### PR DESCRIPTION
## Summary

Closes #3271.

- Adds `--avoid-pad-overlap` to `kct stitch` (default off; preserves existing behaviour) that post-filters via placements whose drill circle would be fully contained inside a same-net SMD pad bbox.  The filter mirrors `ViaInPadRule`'s containment geometry so the stitcher pre-empts exactly the violations the rule would later flag under manufacturer profiles that forbid via-in-pad processing (e.g. JLCPCB standard tier).
- Wires the flag into `boards/06-diffpair-test/generate_design.py` as step 10 of the recipe, after copper-pour zone generation.

## Why a post-filter (and not modify the placement strategies)?

Per the issue: "Stay scoped — fix board 06's recipe, not the global stitcher (unless trivial)."  Modifying `calculate_via_position`, `calculate_dogleg_via_position`, and `calculate_extended_escape_position` to consider same-net pad bboxes as exclusion zones would touch ~300 lines of placement logic across three call sites plus their path checkers.  A post-filter that drops placements landing inside a same-net SMD pad bbox achieves the same DRC outcome with O(N×M) bbox containment over a tiny `vias_added` list.  Pads whose ideal via lands in a same-net pad simply keep their pour-side thermal-relief connection — which is what plane stitching is for in the first place.

## Reproduction

```bash
cd boards/06-diffpair-test
PYTHONHASHSEED=42 uv run python generate_design.py --step route --seed 42
kct check output/diffpair_test_routed.kicad_pcb --mfr jlcpcb --errors-only
```

| Metric | Baseline (no stitch) | Naive stitch | Pad-aware stitch (this PR) |
| --- | --- | --- | --- |
| `--errors-only` count | 6 | 32 | **2** |
| `via_in_pad` errors | 0 | 27 | **0** |
| Blocking (advisory excluded) | 3 | 30+ | **1** |
| GND connected pads | 4 | 103 | 73 |

The diff-pair routing-regression CI gate (`scripts/ci/check_diffpair_coverage.py`) passes with 2 errors against the 39 allowlist; all 3 diff-pair rules (`diffpair_clearance_intra`, `diffpair_length_skew`, `diffpair_routing_continuity`) remain exercised.

## What's NOT in this PR (per task scope)

- The refreshed committed `boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb` is intentionally left unchanged.  PR #3273 was rejected for landing a refreshed routed PCB; this PR ships the recipe + tool changes only.
- The placement strategies are not modified -- `calculate_via_position` etc. still ignore same-net pads.  A future PR could push the pad-aware logic into the placer so the stitcher chooses a slightly different offset instead of dropping the placement, but the current post-filter approach is sufficient for board 06's manufacturability gap.

## Test plan

- [x] 9 new unit tests in `tests/test_stitch_cmd.py` covering: SMD-pad bbox collection, drill-inside-bbox geometry, naive stitch reproduces the failure mode, `--avoid-pad-overlap` filters the offending placement, default-off backward-compat, and CLI flag end-to-end.
- [x] Full `tests/test_stitch_cmd.py` suite passes (238 tests).
- [x] Wider stitch-related sweep passes (`test_stitch_cmd.py`, `test_stitch_mfr.py`, `test_thermal_stitch.py`, `test_board_05_thermal_stitch.py`, `test_stitch_bga_outer_ring.py`, `test_stitch_via_halo.py`, `test_build_stitch_step.py`, `test_board_06_diffpair_test.py` -- 332 tests).
- [x] `ruff check` clean on all modified production files; no new lint issues introduced to `tests/test_stitch_cmd.py` (23 pre-existing on `main`).
- [x] Recipe end-to-end run with `--step route --seed 42` succeeds; `kct check` reports 2 errors (1 advisory connectivity, 1 structural `diffpair_clearance_intra` on USB2_D+/-).
- [x] `scripts/ci/check_diffpair_coverage.py --skip-route` passes: 2 errors within allowlist 39, all 3 diff-pair rules exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)