### PR TITLE
fix(fleet): detect schematic-vs-PCB drift, suppress misleading routing blocker (#3280)

### DIFF
--- a/src/kicad_tools/cli/fleet_cmd.py
+++ b/src/kicad_tools/cli/fleet_cmd.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import argparse
 import datetime as _dt
 import json
+import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -81,6 +82,20 @@ class RoutingStatus:
     blocking_incomplete_nets: int = 0
     unrouted_nets: int = 0
     error: str | None = None
+    # Issue #3280: when True, the routed PCB's net set disagrees with the
+    # source schematic's named-label set, so any ``X/Y nets`` count derived
+    # from the PCB is misleading as a current-routing signal. Filled in by
+    # ``_survey_board`` via ``_detect_source_drift``.
+    source_stale: bool = False
+    # Distinct counts that produced the drift verdict above. ``None`` means
+    # we could not extract them (no schematic alongside the PCB, parse
+    # failure, etc.) -- treated as "not source-stale".
+    schematic_net_count: int | None = None
+    pcb_net_count: int | None = None
+    # Sample of drifted nets (added/removed in PCB vs schematic), capped to
+    # keep JSON output bounded. Empty when ``source_stale`` is False.
+    drift_added: list[str] = field(default_factory=list)
+    drift_removed: list[str] = field(default_factory=list)
 
     @property
     def completion_pct(self) -> float:
@@ -92,15 +107,17 @@ class RoutingStatus:
     def routing_complete(self) -> bool:
         if self.error is not None:
             return False
+        # If the routed PCB is stale relative to its source schematic, its
+        # routed-net count is not a trustworthy signal for "is the current
+        # design routed?" -- treat as not complete (issue #3280).
+        if self.source_stale:
+            return False
         # A board is routing-complete iff every multi-pad net is fully
         # connected -- with one exception: plane/pour stitching residuals
         # (advisory connectivity per ``ADVISORY_RULE_IDS``) are excluded
         # because the CI gate at ``check_routed_drc`` already ignores
         # them. Single-pad nets are not counted by NetStatusAnalyzer.
-        return (
-            (self.blocking_incomplete_nets + self.unrouted_nets) == 0
-            and self.total_nets > 0
-        )
+        return (self.blocking_incomplete_nets + self.unrouted_nets) == 0 and self.total_nets > 0
 
     def to_dict(self) -> dict:
         data: dict = {
@@ -113,7 +130,14 @@ class RoutingStatus:
             "blocking_incomplete_nets": self.blocking_incomplete_nets,
             "unrouted_nets": self.unrouted_nets,
             "routing_complete": self.routing_complete,
+            "source_stale": self.source_stale,
+            "schematic_net_count": self.schematic_net_count,
+            "pcb_net_count": self.pcb_net_count,
         }
+        if self.drift_added:
+            data["drift_added"] = list(self.drift_added)
+        if self.drift_removed:
+            data["drift_removed"] = list(self.drift_removed)
         if self.error is not None:
             data["error"] = self.error
         return data
@@ -541,6 +565,122 @@ def _detect_erc(board_dir: Path) -> ERCStatus:
     return erc
 
 
+_SCH_LABEL_RE = re.compile(r'\(\s*(?:label|global_label|hierarchical_label)\s+"([^"]+)"')
+_PCB_NET_RE = re.compile(r'\(net\s+\d+\s+"([^"]+)"\)')
+
+
+def _extract_schematic_nets(sch_path: Path) -> set[str] | None:
+    """Return the set of named labels declared in a KiCad schematic.
+
+    The detection is intentionally lightweight: we only collect text from
+    ``label`` / ``global_label`` / ``hierarchical_label`` s-expression
+    leaves. Auto-generated ``Net-(...)`` placeholders (KiCad's default
+    unconnected names) are skipped because they cannot be reliably
+    mapped to a PCB net name without a full netlister pass.
+
+    Returns ``None`` if the file cannot be read so callers can treat
+    that as "unknown source state" and skip drift gating.
+    """
+    try:
+        text = sch_path.read_text()
+    except OSError:
+        return None
+    labels: set[str] = set()
+    for m in _SCH_LABEL_RE.finditer(text):
+        name = m.group(1)
+        if not name:
+            continue
+        if name.startswith("Net-("):
+            continue
+        labels.add(name)
+    return labels
+
+
+def _extract_pcb_named_nets(pcb_path: Path) -> set[str] | None:
+    """Return the set of non-empty named nets declared in a KiCad PCB.
+
+    Only top-level ``(net N "name")`` declarations are matched; the
+    empty net 0 is dropped. Returns ``None`` on read failure.
+    """
+    try:
+        text = pcb_path.read_text()
+    except OSError:
+        return None
+    nets: set[str] = set()
+    for m in _PCB_NET_RE.finditer(text):
+        name = m.group(1)
+        if name:
+            nets.add(name)
+    return nets
+
+
+def _find_source_schematic(board_dir: Path) -> Path | None:
+    """Locate the source ``.kicad_sch`` for a board.
+
+    Looks in ``board_dir/output/`` first (where generators emit) and
+    falls back to ``board_dir/`` (legacy layout). Returns the first
+    matching schematic by sort order, or ``None`` if none exists.
+    """
+    for candidate_dir in (board_dir / "output", board_dir):
+        try:
+            matches = sorted(candidate_dir.glob("*.kicad_sch"))
+        except OSError:
+            continue
+        if matches:
+            return matches[0]
+    return None
+
+
+def _detect_source_drift(
+    routed_pcb: Path,
+    board_dir: Path,
+    *,
+    sample_limit: int = 8,
+) -> tuple[bool, int | None, int | None, list[str], list[str]]:
+    """Detect schematic-vs-PCB net-set drift (issue #3280).
+
+    Compares the set of named labels in the source ``.kicad_sch`` to the
+    set of named nets in the routed PCB. When the sets differ, the routed
+    PCB is treated as **source-stale**: its ``X/Y nets`` count is no
+    longer a trustworthy signal of current-design routing progress.
+
+    The check is deliberately conservative:
+      * If the schematic cannot be located or parsed, we return
+        ``(False, None, None, [], [])`` -- "unknown source state, do not
+        gate". This preserves the pre-fix behavior for boards where
+        drift detection cannot run.
+      * If the PCB nets cannot be parsed (extremely unlikely since
+        NetStatusAnalyzer already loaded the same file), we likewise
+        return "no drift".
+
+    Returns:
+        ``(source_stale, schematic_net_count, pcb_net_count,
+        added_in_pcb, removed_from_pcb)``. The ``added`` / ``removed``
+        samples are sorted and capped at ``sample_limit`` for bounded
+        JSON output.
+    """
+    sch_path = _find_source_schematic(board_dir)
+    if sch_path is None:
+        return (False, None, None, [], [])
+    sch_nets = _extract_schematic_nets(sch_path)
+    if sch_nets is None:
+        return (False, None, None, [], [])
+    pcb_nets = _extract_pcb_named_nets(routed_pcb)
+    if pcb_nets is None:
+        return (False, len(sch_nets), None, [], [])
+
+    added = sorted(pcb_nets - sch_nets)
+    removed = sorted(sch_nets - pcb_nets)
+    source_stale = bool(added) or bool(removed)
+    return (
+        source_stale,
+        len(sch_nets),
+        len(pcb_nets),
+        added[:sample_limit],
+        removed[:sample_limit],
+    )
+
+
 def _compute_routing(routed_pcb: Path) -> RoutingStatus:
     """Run NetStatusAnalyzer on a routed PCB and tally pads/nets."""
     status = RoutingStatus()
@@ -585,7 +725,21 @@ def _compute_blockers(
     if routing.error is not None:
         blockers.append(f"routing analysis failed: {routing.error}")
         return blockers
-    if not routing.routing_complete:
+    if routing.source_stale:
+        # Issue #3280: the routed PCB's net set disagrees with the source
+        # schematic, so the ``X/Y nets`` figure derived from the PCB is
+        # not a trustworthy current-routing signal. Emit a clearer blocker
+        # and suppress the misleading count. The schematic net count is
+        # surfaced when available so triage can see the actual target.
+        if routing.schematic_net_count is not None:
+            blockers.append(
+                "routed PCB stale (schematic drift: "
+                f"{routing.schematic_net_count} nets in schematic, "
+                f"{routing.pcb_net_count} in PCB)"
+            )
+        else:
+            blockers.append("routed PCB stale (schematic drift)")
+    elif not routing.routing_complete:
         # Use the advisory-filtered count so the blocker message agrees
         # with the verdict (plane/pour stitching residuals do not show
         # up here even though `incomplete_nets` may be non-zero).
@@ -630,6 +784,21 @@ def _survey_board(
         except OSError:
             routed_mtime = None
         routing = _compute_routing(routed_pcb)
+        # Issue #3280: detect schematic-vs-PCB net-set drift so the
+        # ``X/Y nets`` blocker does not lie when the routed PCB no longer
+        # reflects the current schematic.
+        (
+            source_stale,
+            sch_count,
+            pcb_count,
+            added,
+            removed,
+        ) = _detect_source_drift(routed_pcb, board_dir)
+        routing.source_stale = source_stale
+        routing.schematic_net_count = sch_count
+        routing.pcb_net_count = pcb_count
+        routing.drift_added = added
+        routing.drift_removed = removed
         mfg = _detect_manufacturing(board_dir)
         if (
             routed_mtime is not None

--- a/tests/test_fleet_status.py
+++ b/tests/test_fleet_status.py
@@ -380,9 +380,7 @@ class TestFleetStatusBasics:
             artifacts_older_than_routed=True,
         )
 
-        result = main(
-            ["status", "--boards-dir", str(boards), "--format", "json"]
-        )
+        result = main(["status", "--boards-dir", str(boards), "--format", "json"])
         assert result == 2
 
         captured = capsys.readouterr()
@@ -504,9 +502,7 @@ class TestFleetStatusBasics:
 
         # Plain ASCII only (no Unicode glyphs, no checkmarks/x-marks).
         forbidden_chars = "✓✗✅❌─━│"
-        assert not any(c in out for c in forbidden_chars), (
-            "Unicode glyphs leaked into table output"
-        )
+        assert not any(c in out for c in forbidden_chars), "Unicode glyphs leaked into table output"
 
         # YES / NO ship status appears.
         assert "YES" in out
@@ -743,9 +739,7 @@ class TestFleetStatusAdvisoryFilter:
             has_manifest=True,
         )
 
-        result = main(
-            ["status", "--boards-dir", str(boards), "--format", "json"]
-        )
+        result = main(["status", "--boards-dir", str(boards), "--format", "json"])
         # All boards ship-ready -> exit 0.
         assert result == 0
 
@@ -760,9 +754,7 @@ class TestFleetStatusAdvisoryFilter:
         assert b["ship_ready"] is True
         assert b["blockers"] == []
 
-    def test_fleet_status_blocking_signal_does_not_ship(
-        self, tmp_path: Path, capsys
-    ):
+    def test_fleet_status_blocking_signal_does_not_ship(self, tmp_path: Path, capsys):
         """Board with a genuine signal-net gap must still fail ship-ready."""
         boards = tmp_path / "boards"
         make_fake_board(
@@ -775,9 +767,7 @@ class TestFleetStatusAdvisoryFilter:
             has_manifest=True,
         )
 
-        result = main(
-            ["status", "--boards-dir", str(boards), "--format", "json"]
-        )
+        result = main(["status", "--boards-dir", str(boards), "--format", "json"])
         # Not ship-ready -> exit 2.
         assert result == 2
 
@@ -789,13 +779,9 @@ class TestFleetStatusAdvisoryFilter:
         assert b["routing"]["routing_complete"] is False
         # Blocker message should use the filtered count -- one blocking
         # signal-net gap, not "0 nets" or the raw count.
-        assert any(
-            "incomplete routing (1/" in blocker for blocker in b["blockers"]
-        ), b["blockers"]
+        assert any("incomplete routing (1/" in blocker for blocker in b["blockers"]), b["blockers"]
 
-    def test_fleet_status_advisory_table_shows_yes(
-        self, tmp_path: Path, capsys
-    ):
+    def test_fleet_status_advisory_table_shows_yes(self, tmp_path: Path, capsys):
         """The Ship? column reads YES even when the raw incomplete>0."""
         boards = tmp_path / "boards"
         make_fake_board(
@@ -866,3 +852,270 @@ class TestFleetStatusAdvisoryFilter:
         assert "blocking_incomplete_nets" in data["boards"][0]["routing"]
         # Raw field preserved.
         assert "incomplete_nets" in data["boards"][0]["routing"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #3280: schematic-vs-PCB drift detection
+# ---------------------------------------------------------------------------
+
+
+# A minimal schematic with three named labels (matches the EXTRA_NET_PCB
+# below for the no-drift case and EXTRA_NET_DRIFT_PCB for the drift case).
+THREE_NET_SCH = """(kicad_sch
+  (version 20240108)
+  (generator "test")
+  (paper "A4")
+  (label "VCC" (at 10 10 0))
+  (label "GND" (at 10 20 0))
+  (label "SIG1" (at 10 30 0))
+)
+"""
+
+
+# A PCB whose named-net set matches THREE_NET_SCH exactly (VCC, GND, SIG1).
+# No drift -> blocker text is the normal "incomplete routing" form.
+MATCHING_NETS_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "VCC")
+  (net 2 "GND")
+  (net 3 "SIG1")
+  (gr_rect (start 0 0) (end 30 30) (stroke (width 0.1)) (layer "Edge.Cuts"))
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (at 10 10)
+    (property "Reference" "R1")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 1 "VCC"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 2 "GND"))
+  )
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (at 20 10)
+    (property "Reference" "R2")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 1 "VCC"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 3 "SIG1"))
+  )
+)
+"""
+
+
+# A PCB with an EXTRA net (USB_CC1) that does not appear in THREE_NET_SCH.
+# This is the board-03 condition: routed PCB has more nets than schematic.
+EXTRA_NET_DRIFT_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "VCC")
+  (net 2 "GND")
+  (net 3 "SIG1")
+  (net 4 "USB_CC1")
+  (gr_rect (start 0 0) (end 30 30) (stroke (width 0.1)) (layer "Edge.Cuts"))
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (at 10 10)
+    (property "Reference" "R1")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 1 "VCC"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 2 "GND"))
+  )
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (at 20 10)
+    (property "Reference" "R2")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 3 "SIG1"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 4 "USB_CC1"))
+  )
+)
+"""
+
+
+def _make_board_with_schematic(
+    boards_dir: Path,
+    name: str,
+    *,
+    sch_text: str,
+    pcb_text: str,
+    has_gerbers: bool = True,
+    has_bom: bool = True,
+    has_cpl: bool = True,
+    has_manifest: bool = True,
+) -> tuple[Path, Path]:
+    """Build a board fixture that includes a ``.kicad_sch`` alongside the
+    routed PCB so source-drift detection (issue #3280) has something to
+    compare against.
+
+    Returns ``(routed_pcb_path, schematic_path)``.
+    """
+    routed_pcb = make_fake_board(
+        boards_dir,
+        name,
+        pcb_text=pcb_text,
+        has_gerbers=has_gerbers,
+        has_bom=has_bom,
+        has_cpl=has_cpl,
+        has_manifest=has_manifest,
+    )
+    # Schematic lives alongside the routed PCB under output/ to match the
+    # real-board layout used by all in-repo boards (see boards/0*-*/output).
+    sch_path = routed_pcb.parent / f"{name.replace('-', '_')}.kicad_sch"
+    sch_path.write_text(sch_text)
+    return routed_pcb, sch_path
+
+
+class TestFleetStatusSourceDrift:
+    """Issue #3280 -- routed PCB stale relative to source schematic.
+
+    When a board's committed ``_routed.kicad_pcb`` carries a different
+    set of named nets than its ``.kicad_sch`` (because the schematic was
+    regenerated but the PCB was not re-routed), the ``X/Y nets`` figure
+    derived from the PCB is meaningless as a current-routing signal. The
+    fleet-status command must suppress the misleading
+    ``incomplete routing (X/Y nets)`` blocker and surface a clearer
+    ``routed PCB stale (schematic drift)`` blocker instead.
+
+    Real-world trigger: board 03 (`03-usb-joystick`) reported
+    ``1/16 nets`` from a stale PCB while ``kct route`` against the
+    current schematic produces 11/13.
+    """
+
+    def test_drift_suppresses_incomplete_routing_blocker(self, tmp_path: Path, capsys):
+        """Drift detected -> no ``incomplete routing`` blocker."""
+        boards = tmp_path / "boards"
+        _make_board_with_schematic(
+            boards,
+            "drift-board",
+            sch_text=THREE_NET_SCH,
+            pcb_text=EXTRA_NET_DRIFT_PCB,
+        )
+
+        main(["status", "--boards-dir", str(boards), "--format", "json"])
+        data = json.loads(capsys.readouterr().out)
+        b = data["boards"][0]
+
+        # The misleading "incomplete routing (X/Y nets)" blocker must
+        # NOT fire -- this is the core regression guard.
+        assert not any("incomplete routing" in blocker for blocker in b["blockers"]), b["blockers"]
+        # A drift-specific blocker fires instead, and surfaces the
+        # schematic net count (3) so triage can see the actual target.
+        assert any(
+            "routed PCB stale" in blocker and "schematic drift" in blocker
+            for blocker in b["blockers"]
+        ), b["blockers"]
+        # JSON exposes the structured drift signal.
+        routing = b["routing"]
+        assert routing["source_stale"] is True
+        assert routing["schematic_net_count"] == 3
+        assert routing["pcb_net_count"] == 4
+        assert "USB_CC1" in routing.get("drift_added", [])
+
+    def test_no_drift_preserves_routing_blocker(self, tmp_path: Path, capsys):
+        """No drift -> existing ``incomplete routing`` / ship behavior wins.
+
+        Guards that boards with a fresh schematic-matching routed PCB
+        still report routing status via the original code path.
+        """
+        boards = tmp_path / "boards"
+        _make_board_with_schematic(
+            boards,
+            "matched-board",
+            sch_text=THREE_NET_SCH,
+            pcb_text=MATCHING_NETS_PCB,
+        )
+
+        main(["status", "--boards-dir", str(boards), "--format", "json"])
+        data = json.loads(capsys.readouterr().out)
+        b = data["boards"][0]
+
+        routing = b["routing"]
+        assert routing["source_stale"] is False
+        assert routing["schematic_net_count"] == 3
+        assert routing["pcb_net_count"] == 3
+        # No drift blocker.
+        assert not any("routed PCB stale" in blocker for blocker in b["blockers"]), b["blockers"]
+
+    def test_missing_schematic_does_not_gate(self, tmp_path: Path, capsys):
+        """No ``.kicad_sch`` -> drift detection is a no-op (back-compat).
+
+        Boards without a schematic alongside the routed PCB cannot be
+        evaluated for drift; the surveyor must NOT synthesize a false
+        ``routed PCB stale`` blocker in that case. This preserves the
+        pre-fix behavior for legacy/fixture boards.
+        """
+        boards = tmp_path / "boards"
+        # make_fake_board creates ONLY a routed PCB -- no schematic.
+        make_fake_board(
+            boards,
+            "no-sch-board",
+            pcb_text=MATCHING_NETS_PCB,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+
+        main(["status", "--boards-dir", str(boards), "--format", "json"])
+        data = json.loads(capsys.readouterr().out)
+        b = data["boards"][0]
+        routing = b["routing"]
+
+        assert routing["source_stale"] is False
+        assert routing["schematic_net_count"] is None
+        assert not any("routed PCB stale" in blocker for blocker in b["blockers"])
+
+    def test_drift_blocker_message_format(self, tmp_path: Path, capsys):
+        """Blocker text surfaces both the schematic and PCB net counts.
+
+        Curators reading the blocker should know exactly how far apart
+        the two sides have drifted without parsing JSON.
+        """
+        boards = tmp_path / "boards"
+        _make_board_with_schematic(
+            boards,
+            "drift-board",
+            sch_text=THREE_NET_SCH,
+            pcb_text=EXTRA_NET_DRIFT_PCB,
+        )
+
+        main(["status", "--boards-dir", str(boards), "--format", "json"])
+        data = json.loads(capsys.readouterr().out)
+        b = data["boards"][0]
+
+        drift_blockers = [blocker for blocker in b["blockers"] if "routed PCB stale" in blocker]
+        assert len(drift_blockers) == 1, b["blockers"]
+        # Format: "routed PCB stale (schematic drift: N nets in schematic, M in PCB)"
+        assert "3 nets in schematic" in drift_blockers[0]
+        assert "4 in PCB" in drift_blockers[0]
+
+    def test_drift_ship_ready_false(self, tmp_path: Path, capsys):
+        """Drift forces ship_ready=False even when routing looks complete.
+
+        The dangerous false-negative this guards: a stale PCB whose
+        nets happen to be all 100% connected would otherwise read as
+        ship-ready, hiding the schematic drift entirely. The drift
+        blocker MUST gate ship-readiness.
+        """
+        boards = tmp_path / "boards"
+        _make_board_with_schematic(
+            boards,
+            "drift-board",
+            sch_text=THREE_NET_SCH,
+            pcb_text=EXTRA_NET_DRIFT_PCB,
+        )
+
+        result = main(["status", "--boards-dir", str(boards), "--format", "json"])
+        # Not ship-ready -> exit 2.
+        assert result == 2
+        data = json.loads(capsys.readouterr().out)
+        b = data["boards"][0]
+        assert b["ship_ready"] is False
+        assert b["routing"]["routing_complete"] is False


### PR DESCRIPTION
## Summary

`kct fleet status` was reporting board 03 (`03-usb-joystick`) as `incomplete routing (1/16 nets)` even though running `kct route` against the source schematic produces 11/13. The blocker text was driven by the committed `_routed.kicad_pcb` whose net set (16) no longer matched the source `.kicad_sch` (13). Catastrophic-looking 1/16 figures steered curator triage toward this board over genuinely worse boards.

This PR implements **Option A** from the issue's acceptance criteria (with the lightweight detection sketched as Option B): detect schematic-vs-PCB net-set drift, surface a clearer blocker, and suppress the misleading routed-PCB-net count.

## Behavior change

Before:
```
03-usb-joystick     1/13   ...  NO  (incomplete routing (1/16 nets))
```

After:
```
03-usb-joystick   70/71  99% ...  NO  (routed PCB stale (schematic drift: 13 nets in schematic, 16 in PCB))
```

Boards with no drift (02, 06, 07) keep their existing `incomplete routing` semantics. Boards without a `.kicad_sch` alongside the routed PCB (fixtures, legacy layouts) skip drift detection entirely so `make_fake_board`-based tests continue to pass unchanged.

## Implementation

`src/kicad_tools/cli/fleet_cmd.py`:
- `RoutingStatus` gains `source_stale`, `schematic_net_count`, `pcb_net_count`, `drift_added`, `drift_removed` fields. When `source_stale` is True, `routing_complete` is forced False so ship-readiness is gated.
- New `_detect_source_drift(routed_pcb, board_dir)` compares the schematic's `label`/`global_label`/`hierarchical_label` names against the PCB's `(net N "name")` declarations. Conservative: missing schematic / parse failure -> no drift (back-compat).
- `_compute_blockers` emits `routed PCB stale (schematic drift: N nets in schematic, M in PCB)` instead of `incomplete routing (X/Y nets)` when drift is detected.
- `_survey_board` wires the new check after `_compute_routing`.

The change is **scoped to `fleet_cmd.py` and its tests**; it does not touch the manifest-vs-routed staleness path covered by #3264 / PR #3277.

## Test plan

- [x] New `TestFleetStatusSourceDrift` class with 5 regression tests:
  - `test_drift_suppresses_incomplete_routing_blocker` — drift fixture suppresses `incomplete routing` blocker
  - `test_no_drift_preserves_routing_blocker` — matched fixture preserves existing behavior
  - `test_missing_schematic_does_not_gate` — back-compat: no schematic, no drift gating
  - `test_drift_blocker_message_format` — blocker text surfaces both counts
  - `test_drift_ship_ready_false` — drift forces ship-ready=false even when routing looks 100%
- [x] All 51 pre-existing fleet tests still pass (`tests/test_fleet_status*.py`, `tests/test_fleet_ship_ready.py`, `tests/test_fleet_status_drc.py`)
- [x] Real-repo smoke: `uv run kct fleet status` against `boards/` no longer reports `1/16` for board 03; instead shows `routed PCB stale (schematic drift: 13 nets in schematic, 16 in PCB)`. Boards 02/06/07 (no drift) unchanged.
- [x] `ruff check` + `ruff format` clean on touched files.

Closes #3280

🤖 Generated with [Claude Code](https://claude.com/claude-code)