### PR TITLE
test(board-04): verify post-#3286 mfr-ready state + refresh docstring (Closes #3298)

### DIFF
--- a/tests/test_board_04_mfr_gate.py
+++ b/tests/test_board_04_mfr_gate.py
@@ -27,14 +27,15 @@ The fleet-status fingerprint (54/55 pads ~ 98% manufacturer-readiness)
 is the higher-level invariant this pin is protecting.  Today board 04
 ships at:
 
-  * 9/9 signal nets routed (committed PCB; the fresh router can drop NRST
-    on some seeds -- see follow-on issue filed under #3261 for the
-    intermittent NRST regression).
-  * 1 blocking error (SWDIO/BOOT0 clearance at B.Cu (143.8, 119.7), the
-    historically-unstable cluster tracked under #2834).
-  * 1 advisory connectivity finding (U2.8 LQFP-48 corner GND pad the
-    stitcher could not reach even with --micro-via).
-  * CI gate: PASS (1 <= floor of 1; advisory excluded per ``DRCChecker``).
+  * 8/9 signal nets routed (committed PCB; NRST stranded as advisory
+    connectivity, documented as correct router behaviour per #3286 --
+    the U2.7/U2.8 channel is below the 0.127 mm jlcpcb-tier1 clearance
+    floor that the post-#3128 clearance cluster correctly enforces).
+  * 0 blocking errors (the SWDIO/BOOT0 ``clearance_segment_via`` that
+    drove the prior 1-error floor is gone in the post-#3286 routed PCB).
+  * 2 advisory connectivity findings: NRST (J1.5 -> U2.7 stranded per
+    #3286) plus the U2.8/U2.35 LQFP-48 corner GND stitch gap (#3267).
+  * CI gate: PASS (0 <= floor of 0; advisory excluded per ``DRCChecker``).
 
 This test is a stateless source pin -- it does NOT re-route the board.
 It checks the committed routed PCB against the gate that ships with the
@@ -47,7 +48,12 @@ References:
   ``manufacturers:`` override block.
 - PR #3218 -- ``--mfr jlcpcb-tier1`` in the recipe (closes #3208).
 - PR #3128 -- micro-via in-pad rescue (#3118), tightened floor 4 -> 1.
-- Issue #2834 -- the manufacturing-ready cluster the residual rides with.
+- PR #3286 -- documented NRST clearance regression, refreshed routed PCB,
+  tightened floor 1 -> 0 (closes #3266).
+- PR #3288 -- narrowed NC-pin plane-net classifier so stripped 2L recipe
+  also reaches 8/9 (closes #3281, #3268).
+- Issue #2834 -- the manufacturing-ready cluster the residuals ride with.
+- Issue #3298 -- post-#3286 refresh verification against current main.
 """
 
 from __future__ import annotations
@@ -180,13 +186,21 @@ def test_board_04_advisory_connectivity_does_not_balloon(
 ) -> None:
     """Advisory connectivity findings must stay within the documented bound.
 
-    The committed PCB carries ONE advisory connectivity finding (U2.8 GND
-    stitch gap, documented in ``.github/routed-drc-tolerance.yml`` lines
-    1140-1151).  If a future router change strands additional pads, the
-    fleet-status manufacturer-readiness percentage drops -- catching this
-    at PR time avoids silently regressing the board's functional
-    completeness even though the CI gate (which filters advisories)
-    still passes.
+    The post-#3286 committed PCB carries TWO advisory connectivity
+    findings:
+
+      1. NRST is stranded at J1.5 because the U2.7 NRST -> U2.8 GND
+         channel is below the 0.127 mm jlcpcb-tier1 clearance floor;
+         this is correct router behaviour per #3286.
+      2. The U2.8/U2.35 LQFP-48 corner GND stitch gap (#3267) -- the
+         standard 0.6 mm and 0.3 mm micro-vias both collide with
+         neighbouring escape traces.
+
+    Both are documented in ``.github/routed-drc-tolerance.yml``. If a
+    future router change strands additional pads, the fleet-status
+    manufacturer-readiness percentage drops -- catching this at PR time
+    avoids silently regressing the board's functional completeness even
+    though the CI gate (which filters advisories) still passes.
 
     The threshold is intentionally lenient (<= 3 connectivity findings)
     to avoid flapping on small router state changes; this catches
@@ -197,8 +211,9 @@ def test_board_04_advisory_connectivity_does_not_balloon(
     connectivity = [v for v in violations if v.get("rule_id") == "connectivity"]
     connectivity_count = len(connectivity)
 
-    # Soft cap: 3 advisory findings.  Today's count is 1.  A jump to 4+
-    # signals a multi-net stranding event worth investigating.
+    # Soft cap: 3 advisory findings.  Post-#3286 count is 2 (NRST
+    # strand + U2.8/U2.35 GND stitch gap).  A jump to 4+ signals a
+    # multi-net stranding event worth investigating.
     SOFT_CAP = 3
     assert connectivity_count <= SOFT_CAP, (
         f"Board 04 has {connectivity_count} advisory connectivity findings; "


### PR DESCRIPTION
## Summary

Verification pass requested by the user: bring `boards/04-stm32-devboard` to JLCPCB ready-to-manufacture state against current `main` (after PRs #3285/#3286/#3287/#3288 merged).

**Outcome:** board 04 is **already manufacturer-ready** on current `main` -- no code or PCB refresh required. This PR updates the stale docstring on `tests/test_board_04_mfr_gate.py` to describe the actual post-#3286 state (`8/9 routed, 0 blocking, 2 advisory`) instead of the obsolete pre-#3286 state (`9/9 routed, 1 blocking, 1 advisory`). The `SOFT_CAP=3` was already permissive enough to accommodate the new advisory count of 2, so this is purely a documentation refresh -- no functional test change.

## Verification table

Recipe: `uv run python boards/04-stm32-devboard/generate_design.py` against `main @ 956f9487` (post-#3290), `PYTHONHASHSEED=42`, C++ backend.

| Step | Result |
|---|---|
| ERC (`stm32_devboard.kicad_sch`) | **PASS** -- 0 errors, 1 advisory warning |
| Routing (`kct route --mfr jlcpcb-tier1 --auto-fix --auto-layers --auto-mfr-tier --placement-feedback --micro-via-in-pad-fallback --seed 42`) | **8/9 signal nets** (NRST stranded; expected per #3286) |
| Stitch (`kct stitch --net GND --mfr jlcpcb-tier1 --micro-via`) | **SUCCESS** (17/18 GND pads connected; U2.8 + U2.35 advisory per #3267) |
| DRC (`kct check --mfr jlcpcb-tier1`) | 2 `connectivity` errors (NRST + GND stitch) -- both **advisory** per `DRCChecker.ADVISORY_RULE_IDS` |
| CI gate (`scripts/ci/check_routed_drc.py`) | **PASS** (0 blocking <= floor 0; advisory excluded) |
| Manufacturing export (`kct export --mfr jlcpcb`) | **SUCCESS** -- BOM, CPL, gerbers.zip, report.pdf, manifest.json all produced |
| `pytest tests/test_board_04_*.py` | **13/13 PASS** (mfr-gate 4/4, erc 5/5, routing-regression 1/1 slow, drc-recipe-mfr 3/3) |

## Recipe reproducibility

Re-running the canonical recipe against current main produces a routed PCB **byte-identical mod UUIDs** to the committed `stm32_devboard_routed.kicad_pcb`:

- `segments=390, vias=25` in both
- `5071 sorted lines, 0 diff` after `UUID -> "UUID"` normalisation

No re-commit of `output/` artefacts needed.

## NRST + U2.35 GND advisory

These remain in the documented advisory bucket and are NOT in scope to "fix" per the original direction:

- **NRST**: U2.7/U2.8 channel is ~0.125 mm wide, below the jlcpcb-tier1 0.127 mm floor. PR #3286 documented this as correct router behaviour after the post-#3128 clearance cluster (#3225/#3227/#3232/#3248/#3250) tightened pad-clearance enforcement.
- **U2.8/U2.35 GND stitch**: standard 0.6 mm and 0.3 mm micro-vias collide with neighbouring escape traces in the dense LQFP-48 0.5 mm-pitch escape pattern. Tracked under #3267 / #2834.

## Follow-on filed

Issue **#3302** -- ``fleet: drift detector false-positive on board 04 (+3V3 vs +3.3V, unlabeled local nets)``. `kct fleet status` (the PR #3289 drift detector) reports board 04 as `routed PCB stale (schematic drift: 10 nets in schematic, 12 in PCB)` due to two false positives:

1. Schematic uses `+3V3`, PCB uses `+3.3V` (same conceptual rail, different string).
2. `LED_K` and `BOOT0` are local two-pin nets routed via unlabeled wire segments in the schematic; the detector's label-name comparison misses them.

This does NOT affect any of the actual manufacturer-readiness gates above (CI, tests, recipe). It is a presentation issue in the new `fleet_cmd.py` drift detector; #3302 proposes a fix.

## Heeded lessons

- **#3286 NRST**: not in scope to "fix". Stays as documented advisory.
- **#3273 impedance sidecar**: board 04 has no impedance net classes (per #3286 judge); no impedance work needed.
- **Other boards**: this PR only touches `tests/test_board_04_mfr_gate.py` (docstring). No regression risk to boards 01/02/03/05/06/07.

## Test plan

- [x] `uv run pytest tests/test_board_04_mfr_gate.py -v` -- 4/4 PASS
- [x] `uv run pytest tests/test_board_04_erc_regression.py tests/test_board_04_drc_recipe_mfr.py tests/test_board_04_routing_regression.py tests/test_board_04_mfr_gate.py -v` -- 13/13 PASS (includes the @slow routing-regression test at 8/9 floor)
- [x] End-to-end recipe run -- byte-identical mod UUIDs to committed PCB
- [x] `scripts/ci/check_routed_drc.py boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb` -- 0 errors (strict gate, --mfr jlcpcb-tier1; advisory: 2)

Closes #3298

🤖 Generated with [Claude Code](https://claude.com/claude-code)