### PR TITLE
test(softstart): tighten manufacturable baseline floor 2->0 after #3287 verification

### DIFF
--- a/tests/router/test_softstart_manufacturable_baseline.py
+++ b/tests/router/test_softstart_manufacturable_baseline.py
@@ -2,7 +2,7 @@
 
 This test pins the **measured best-available** state of the softstart
 example board against the manufacturing pipeline as of June 2026
-(post-Wave-3 router fixes: PRs #3248 / #3249 / #3250).
+(post-Wave-3 router fixes: PRs #3248 / #3249 / #3250 / #3287).
 
 Baseline measurement at HEAD (worst-of-3 across PYTHONHASHSEED=42/43/44):
 
@@ -10,9 +10,8 @@ Baseline measurement at HEAD (worst-of-3 across PYTHONHASHSEED=42/43/44):
   * Multi-pad signal nets: 10
   * **Nets connected: 10 (topologically complete)** -- all 10 signal
     nets reach end-to-end pad connectivity
-  * Residual DRC: 4 ``clearance_segment_segment`` violations on B.Cu,
-    all between SWDIO (net 17) and STATUS_LED (net 20) in the U1
-    east-side TSSOP-20 cluster around grid (227-230, 173-176) mm
+  * Residual DRC: **0** ``clearance_segment_segment`` violations
+    (was 4 pre-PR #3287; drained by the D2/R12 placement nudge)
   * 8 ``connectivity`` errors are for the **intentionally-skipped
     power nets** (filled by copper pours, not the router)
 
@@ -23,8 +22,9 @@ The acceptance criteria pinned by this test:
    foundational A* / negotiated-loop regression -- bisect against
    PRs #3248 (Euclidean via-clearance) and #3250 (sub-cell pad-margin)
    first.
-2. ``clearance_segment_segment`` violation count <= 6 (current
-   baseline is 4; the +2 head-room absorbs noise across builds).
+2. ``clearance_segment_segment`` violation count == 0 (post-#3287
+   D2/R12 placement nudge drained the 4 pre-#3287 SWDIO/STATUS_LED
+   violations to 0; verified perfectly stable across seeds 42/43/44).
 3. No NEW ``clearance_pad_segment`` violations.  Pad-segment clearance
    is the regime PR #3250 was supposed to fix; a non-zero count here
    signals that fix regressed.
@@ -49,11 +49,12 @@ History:
 
 The 10/10 reach is achieved by the **adaptive-grid auto-resolution**
 path that ``kct route`` invokes when auto-grid selects 0.127mm (memory-
-budget-capped above the 0.075mm DRC-safe target).  The 4 residual
-SWDIO/STATUS_LED clearance violations are a known follow-up:
-``fix-drc`` nudging cannot resolve them because the U1 east-side
-cluster has no slack for trace displacement without regressing
-connectivity.
+budget-capped above the 0.075mm DRC-safe target).  The 4 pre-#3287
+SWDIO/STATUS_LED clearance violations were drained to **0** by the
+D2/R12 placement nudge in PR #3287 (Issue #3257): pushing the LED
+column 7 mm east (130 -> 137 mm) takes STATUS_LED's R12->D2 vertical
+leg out of the SWDIO B.Cu corridor at y~173.3 mm.  Issue #3297
+verified the post-#3287 state is fully JLCPCB ship-ready.
 
 This test is gated behind ``KICAD_RUN_SLOW_SOFTSTART_REACH=1`` and
 slated for the slow-tests CI workflow.
@@ -91,11 +92,17 @@ REQUIRED_NETS_TOTAL = 10
 # escape-layer or per-pad budget intervention could close (see the
 # direction-1 / direction-2 negative-results notes in the issue #3235
 # spike commentary at ``router/negotiated.py:1056-1066`` and
-# ``router/two_phase.py:711-736``).  Headroom kept at +2 to absorb
-# run-to-run noise observed when the placement re-spread re-balances
-# the U1-east escape cohort across PYTHONHASHSEED variants.
-MAX_SEG_SEG_CLEARANCE_VIOLATIONS = 2  # current baseline is 0, +2 headroom
-MAX_PAD_SEG_CLEARANCE_VIOLATIONS = 1  # PR #3250 closed pad-segment regime
+# ``router/two_phase.py:711-736``).
+#
+# Issue #3297: tightened 2 -> 0 after worst-of-3-seed (42/43/44)
+# verification confirmed the post-#3287 baseline is perfectly stable
+# at 0 segment-segment clearance violations across all seeds.  The
+# previous +2 headroom is no longer needed because the placement
+# nudge produces a deterministic clear B.Cu corridor independent of
+# PYTHONHASHSEED variants.  A regression here is now a true regression,
+# not noise.
+MAX_SEG_SEG_CLEARANCE_VIOLATIONS = 0  # current baseline is 0, no headroom (honest floor)
+MAX_PAD_SEG_CLEARANCE_VIOLATIONS = 0  # PR #3250 closed pad-segment regime; 0 across all seeds
 
 # Power nets that are intentionally skipped from the autorouter and
 # filled by copper pours / hand-routed by the user (see
@@ -294,21 +301,23 @@ class TestSoftstartManufacturableBaseline:
     def test_residual_clearance_within_budget(self, route_stdout: str) -> None:
         """Residual DRC clearance violations must stay within the documented budget.
 
-        The current baseline produces 4 ``clearance_segment_segment``
+        Post-PR #3287 baseline produces **0** ``clearance_segment_segment``
         violations + 0 ``clearance_pad_segment`` violations across
-        seeds 42/43/44 (perfectly stable).  These are all between
-        SWDIO and STATUS_LED on B.Cu in the U1 east-side cluster.
+        seeds 42/43/44 (perfectly stable).  Issue #3297 verified the
+        post-#3287 D2/R12 placement nudge drains all 4 pre-#3287
+        SWDIO/STATUS_LED B.Cu violations to 0 with no
+        PYTHONHASHSEED-dependent noise.
 
-        This test gates against new clearance violations creeping in
-        from elsewhere -- the current 4 are documented; any spike
-        above the budget indicates a regression in the negotiated
-        loop's clearance handling.
+        This test gates against ANY new clearance violation creeping
+        in -- with the floor now at 0 + 0, a non-zero violation count
+        is a true regression rather than noise.  Likely bisect targets:
+        PR #3287 (D2/R12 placement, may have been reverted),
+        PR #3248 (Euclidean via-clearance kernel),
+        PR #3250 (sub-cell pad-margin closure).
 
-        ``fix-drc`` cannot resolve the residual 4 because nudging
-        breaks connectivity in the tight U1 cluster (see
-        ``kct fix-drc`` output: "rolled back due to connectivity
-        regression").  This is the documented manufacturability gap
-        flagged for a separate follow-up issue.
+        The route summary's ``Violations: N`` line includes the 8
+        intentionally-skipped power-net connectivity errors plus any
+        true clearance violations.  Budget = 8 + 0 + 0 = 8.
         """
         total_violations = _parse_violations(route_stdout)
         # "Violations: N" includes connectivity errors for skipped


### PR DESCRIPTION
## Summary

Closes #3297 -- verifies post-PR #3287 softstart manufacturable state
end-to-end across worst-of-3 PYTHONHASHSEED variants and tightens the
regression-test floor accordingly.

**Verdict: softstart is fully JLCPCB ship-ready on current main.**

## Verification (worst-of-3 seeds 42 / 43 / 44)

Recipe: ``PYTHONHASHSEED=<s> kct route boards/external/softstart/output/softstart.kicad_pcb --backend cpp --layers 2 --no-auto-layers --skip-nets <power> --manufacturer jlcpcb-tier1 --seed <s>``

| Metric | Result (all 3 seeds, identical) |
|---|---|
| Nets connected (signal) | 10/10 |
| ``clearance_segment_segment`` violations | 0 |
| ``clearance_pad_segment`` violations | 0 |
| ``connectivity`` errors (skipped power nets) | 8 (advisory) |
| ``zone_unfilled`` warnings (SCAP_*_GND overlapping GND) | 2 (advisory) |
| **Blocking DRC errors** | **0** |
| ``kct check --mfr jlcpcb-tier1`` | 0 clearance violations, only 8 advisory connectivity + 2 zone_unfilled |
| ``kct export --mfr jlcpcb`` | clean (gerbers.zip, bom_jlcpcb.csv, cpl_jlcpcb.csv, kicad_project.zip, manifest.json, report.pdf) |

The D2/R12 nudge from PR #3287 (D2 east x=130 -> x=137 mm) is
deterministically clear of the SWDIO B.Cu corridor at y~173.3 mm
across all seeds tested.  Verified the nudge is present in
``boards/external/softstart/generate_design.py:1118-1119``::

    D2_POS = (BOARD_ORIGIN_X + 137, BOARD_ORIGIN_Y + 70)
    R12_POS = (BOARD_ORIGIN_X + 137, BOARD_ORIGIN_Y + 76)

## Changes

- **tests/router/test_softstart_manufacturable_baseline.py**:
  - ``MAX_SEG_SEG_CLEARANCE_VIOLATIONS``: 2 -> **0** (honest floor;
    no headroom because the placement nudge is deterministic, not
    noise-dependent).
  - ``MAX_PAD_SEG_CLEARANCE_VIOLATIONS``: 1 -> **0** (no pad-segment
    violations observed across 3 seeds; PR #3250 closed this regime).
  - Updated module docstring and test docstrings to reflect the
    post-#3287 0 + 0 state and Issue #3297 verification.
  - Total budget in ``test_residual_clearance_within_budget`` is now
    ``8 + 0 + 0 = 8`` (matching the 8 advisory connectivity errors
    for intentionally-skipped power nets).

## Test plan

- [x] ``KICAD_RUN_SLOW_SOFTSTART_REACH=1 uv run pytest tests/router/test_softstart_manufacturable_baseline.py -v --no-cov`` -- 2 passed (with tightened 0+0 floor)
- [x] ``uv run pytest tests/router/test_softstart_routing_reach_regression.py tests/router/test_escape_pad_layer_overrides.py -v --no-cov`` -- 7 passed, 1 skipped
- [x] End-to-end ``PYTHONHASHSEED={42,43,44} kct route --backend cpp --layers 2 --no-auto-layers --manufacturer jlcpcb-tier1`` -- 10/10 connected, 0 blocking DRC on every seed
- [x] ``kct check`` post-route -- 0 clearance violations, only 8 advisory connectivity (skipped power nets)
- [x] ``kct export --mfr jlcpcb`` -- gerbers + BOM + CPL + report generated cleanly

## Why this is honest, not aggressive

PR #3287's verification was at seed 42 only.  Issue #3297 ran
worst-of-3 (42/43/44) and observed exactly 0 clearance violations on
every seed, with no run-to-run noise: the route summary's
``Violations: 8`` matches across all three (8 = advisory connectivity
errors for skipped power nets only).  The +2 headroom in
``MAX_SEG_SEG_CLEARANCE_VIOLATIONS`` was a precaution against
seed-dependent variance; that variance is empirically 0, so the
headroom is no longer load-bearing.

Tightening the floor turns any future non-zero clearance count into a
true bisect signal rather than ambient noise.

Closes #3297