### PR TITLE
test(board-05): align allowlist test with CI advisory filter + tighten floor 9->6

### DIFF
--- a/.github/routed-drc-tolerance.yml
+++ b/.github/routed-drc-tolerance.yml
@@ -173,7 +173,32 @@ tolerances:
   # Floor tightened 37 -> 9 (preserves the pre-#3131 measurement
   # bracket; 3-blocking room for run-to-run variance documented in
   # the {9, 9, 15} comment block above).
-  boards/05-bldc-motor-controller/output/bldc_controller_routed.kicad_pcb: 9
+  #
+  # Floor tightened 9 -> 6 by Issue #3294 (2026-06-07).  Re-measured
+  # the committed routed PCB at HEAD with current main:
+  #   * 29 total violations (under ``kct check --mfr jlcpcb``)
+  #   * 23 connectivity (advisory; excluded from the gate)
+  #   *  6 blocking = 6 clearance_pad_segment
+  # All 6 ``clearance_pad_segment`` are at the documented hot-spots
+  # (U3-30 ISENSE_B+, U10-12 HALL_B, U10-3 OSC_OUT) with shortfalls
+  # in 21-113um band -- pinned by
+  # ``tests/test_board_05_drc_hotspot_regression.py::MAX_PAD_SEGMENT=6``
+  # (PR #3258).  The CI gate's slack-tightening warning
+  # (``annotate_drift_warning``) was firing every PR with "actual=6,
+  # allowlist=9, slack=3"; this tightening closes that drift loop.
+  #
+  # A fresh re-route from current main produces 11 blocking errors
+  # (4 clearance_pad_segment + 4 clearance_segment_segment + 3
+  # clearance_segment_via) -- WORSE than the committed snapshot,
+  # confirming the committed file is the better-than-average snapshot
+  # documented in PR #3258.  ``test_board_05_drc_hotspot_regression.py
+  # ::test_committed_pcb_has_no_segment_segment_or_segment_via``
+  # added in this PR makes that asymmetry loud if a fresh re-route
+  # is ever committed by accident.  Therefore regenerating board 05
+  # requires care; see also Issue #2944 (U3 in-pad rescue "Proceeding
+  # anyway" mechanism, the underlying cause of the residual 6,
+  # explicitly out of scope for #3294).
+  boards/05-bldc-motor-controller/output/bldc_controller_routed.kicad_pcb: 6
 
   # Board 03 (USB-C joystick) was 22 (post-#2753 coord-space fix), then
   # 19 ``clearance_pad_segment`` after PR #2762 re-route.  All 19

--- a/tests/test_board_05_drc_allowlist.py
+++ b/tests/test_board_05_drc_allowlist.py
@@ -25,6 +25,19 @@ from 53 → 30, this test automatically pins the new lower floor without
 requiring a code change here.  The complement (drift warning when the
 actual count goes BELOW the allowlist) is implemented by the CI script's
 ``annotate_drift_warning``; this test only asserts the upper bound.
+
+**Advisory-rule filter (Issue #3294)**: the CI gate
+(``scripts/ci/check_routed_drc.py::_count_blocking_errors``) filters
+advisory rules (currently just ``connectivity``) out of the count it
+compares against the allowlist, mirroring
+``DRCChecker.ADVISORY_RULE_IDS`` and the audit pipeline's
+``ManufacturingAudit._check_drc``.  This test now applies the same filter
+so the developer-laptop result matches the CI verdict.  Before the fix
+this test was failing on board 05 (29 unfiltered errors vs allowlist 9)
+even though CI happily passed (6 blocking vs allowlist 9) — a noisy
+false positive that masked real regressions.  See PR #3258's notes
+"pre-existing failure in ``test_board_05_drc_allowlist`` (advisory rule
+filter mismatch with CI) is unchanged by this PR".
 """
 
 from __future__ import annotations
@@ -36,6 +49,8 @@ from pathlib import Path
 
 import pytest
 import yaml
+
+from kicad_tools.validate.checker import DRCChecker
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BOARD_DIR = REPO_ROOT / "boards" / "05-bldc-motor-controller"
@@ -96,11 +111,18 @@ def board_05_allowlist_value() -> int:
 
 
 def _run_kct_check(pcb_path: Path) -> int:
-    """Run ``kct check`` on *pcb_path* and return the error count.
+    """Run ``kct check`` on *pcb_path* and return the *blocking* error count.
 
-    Mirrors ``scripts/ci/check_routed_drc.py::count_errors`` -- uses
-    ``--mfr jlcpcb --errors-only --format json`` to get a machine-parsable
-    count.  Tool-level failures (exit 1) raise ``RuntimeError`` so a
+    Mirrors ``scripts/ci/check_routed_drc.py::_count_blocking_errors`` --
+    uses ``--mfr jlcpcb --errors-only --format json`` to get a
+    machine-parsable count and applies the same advisory-rule filter
+    (currently ``connectivity``) the CI gate uses.  Without the filter
+    this test diverged from CI on boards that ship with non-zero
+    partial-route reports (board 05's committed PCB had 23 connectivity
+    advisories that the CI gate correctly excluded but this test was
+    counting against the allowlist).
+
+    Tool-level failures (exit 1) raise ``RuntimeError`` so a
     misconfigured environment surfaces clearly rather than masquerading
     as a zero-error count.
     """
@@ -144,11 +166,32 @@ def _run_kct_check(pcb_path: Path) -> int:
             f"stdout (first 500 chars):\n{proc.stdout[:500]}"
         ) from e
 
+    # Filter advisory rules (e.g. ``connectivity``) out of the count so
+    # the test's comparison matches the CI gate's verdict.  Prefer the
+    # per-violation ``violations`` list (richer payload) and fall back to
+    # the unfiltered ``summary.errors`` for legacy/malformed payloads.
+    violations = data.get("violations")
+    if isinstance(violations, list):
+        blocking = 0
+        for v in violations:
+            if not isinstance(v, dict):
+                continue
+            if v.get("severity", "error") != "error":
+                continue
+            rule_id = v.get("rule_id", "")
+            if not isinstance(rule_id, str):
+                continue
+            if DRCChecker.is_advisory_rule(rule_id):
+                continue
+            blocking += 1
+        return blocking
+
     summary = data.get("summary", {})
     errors = summary.get("errors")
     if not isinstance(errors, int):
         raise RuntimeError(
-            f"kct check JSON missing summary.errors field for {pcb_path}: keys={list(summary)!r}"
+            f"kct check JSON missing both violations array and summary.errors "
+            f"field for {pcb_path}: keys={list(summary)!r}"
         )
     return errors
 
@@ -161,12 +204,19 @@ class TestBoard05DRCAllowlistGuard:
         routed_pcb_path: Path,
         board_05_allowlist_value: int,
     ) -> None:
-        """Routed PCB DRC error count must be ≤ allowlist (currently 53).
+        """Routed PCB DRC blocking-error count must be ≤ allowlist.
 
         Reads the allowlist value from
         ``.github/routed-drc-tolerance.yml`` so this test auto-tightens
         when the allowlist drops -- no need to update a hard-coded
         constant here when a router improvement reduces the floor.
+
+        The count compared here is the *blocking* error count (advisory
+        rules such as ``connectivity`` are excluded), matching
+        ``scripts/ci/check_routed_drc.py::_count_blocking_errors`` and
+        the audit pipeline's classifier
+        (``DRCChecker.is_advisory_rule``).  This keeps the developer-
+        laptop verdict aligned with what CI gates the build on.
 
         A failure here typically indicates one of:
 
@@ -184,9 +234,11 @@ class TestBoard05DRCAllowlistGuard:
         """
         errors = _run_kct_check(routed_pcb_path)
         assert errors <= board_05_allowlist_value, (
-            f"Board 05 routed PCB reports {errors} DRC error(s) under "
-            f"JLCPCB rules; allowlist max is {board_05_allowlist_value} "
-            f"(from {ALLOWLIST_PATH.relative_to(REPO_ROOT)!s}).  This is "
+            f"Board 05 routed PCB reports {errors} blocking DRC error(s) "
+            f"under JLCPCB rules (excluding advisory rules per "
+            f"DRCChecker.ADVISORY_RULE_IDS); allowlist max is "
+            f"{board_05_allowlist_value} (from "
+            f"{ALLOWLIST_PATH.relative_to(REPO_ROOT)!s}).  This is "
             f"a routing regression -- either revert the offending change "
             f"or raise the allowlist value with reviewer justification "
             f"and a tracking-issue link in the PR description."

--- a/tests/test_board_05_drc_hotspot_regression.py
+++ b/tests/test_board_05_drc_hotspot_regression.py
@@ -76,6 +76,26 @@ HOT_SPOT_REFS = frozenset({"U3", "U10", "R10", "R11", "R12"})
 # shortfall, with a tracking-issue link in the PR description.
 MAX_SHORTFALL_UM = 130
 
+# Rule families that the committed PCB at HEAD does NOT exhibit (Issue
+# #3294 measurement, 2026-06-07): a fresh re-route from current main
+# introduces ``clearance_segment_segment`` and ``clearance_segment_via``
+# violations that the committed file does not have, because the
+# committed file is a better-than-average snapshot of board-05's
+# stochastic routing (the design pins ``--backend python``).  Pinning
+# the absence of these rule families on the committed file makes the
+# "fresh re-route accidentally got committed" regression loud -- the
+# refresh would widen the blocking-error band from 6 (only
+# ``clearance_pad_segment``) to 11 (adding segment-segment + segment-
+# via), and the regression would still be under the allowlist of 9 only
+# if measured at the wrong cut.  Refresh policy: when a router
+# improvement legitimately makes the fresh re-route strictly better
+# than the committed snapshot, re-route AND drop the entries below in
+# the same PR; the hot-spot count test above will then re-pin the new
+# floor.
+ABSENT_RULES_ON_COMMITTED_PCB = frozenset(
+    {"clearance_segment_segment", "clearance_segment_via"}
+)
+
 
 @pytest.fixture(scope="module")
 def routed_pcb_path() -> Path:
@@ -228,3 +248,42 @@ class TestBoard05DRCHotspotRegression:
                 f"items={v.get('items')!r}.  Likely a new mechanism — "
                 f"investigate before merge (Issue #3251 hot-spot table)."
             )
+
+    def test_committed_pcb_has_no_segment_segment_or_segment_via(
+        self,
+        routed_pcb_path: Path,
+    ) -> None:
+        """No ``clearance_segment_segment`` / ``clearance_segment_via`` on the committed PCB.
+
+        Issue #3294 measurement (2026-06-07): a fresh re-route from
+        current main produces 4 ``clearance_segment_segment`` and
+        3 ``clearance_segment_via`` violations on top of 4
+        ``clearance_pad_segment``, which is *worse* than the committed
+        snapshot's 0 + 0 + 6.  Pinning the absence of these two rule
+        families on the committed file makes the "fresh re-route
+        accidentally got committed" regression loud — without this
+        guard a refresh that widened blocking errors from 6 to 11 would
+        still pass the allowlist if the allowlist were ever raised
+        above 11 for unrelated reasons.
+
+        Refresh policy: when a router improvement legitimately makes
+        the fresh re-route strictly better than the committed snapshot,
+        re-route AND drop the entries in
+        :data:`ABSENT_RULES_ON_COMMITTED_PCB` in the same PR.
+        """
+        viols = _kct_check_violations(routed_pcb_path)
+        offenders: dict[str, int] = {}
+        for v in viols:
+            rid = v.get("rule_id")
+            if rid in ABSENT_RULES_ON_COMMITTED_PCB:
+                offenders[rid] = offenders.get(rid, 0) + 1
+        assert not offenders, (
+            f"Board 05 committed routed PCB now reports rule families "
+            f"that the historical snapshot does not have: {offenders!r}. "
+            f"This usually means an unintended re-route was committed — "
+            f"the fresh ``--backend python`` re-route under current main "
+            f"introduces these mechanisms (Issue #3294 measurement).  "
+            f"Either revert the routed-PCB change or, if the re-route is "
+            f"intentional and strictly better, remove the offending "
+            f"rule(s) from ABSENT_RULES_ON_COMMITTED_PCB in the same PR."
+        )


### PR DESCRIPTION
## Summary

- Closes #3294 — board 05 bldc-motor-controller verification refresh against current main.
- Fix long-standing mismatch between ``test_board_05_drc_allowlist.py`` and the CI gate (PR #3258 flagged this as a pre-existing failure).
- Tighten board 05 DRC allowlist 9 → 6 to match the measured blocking count, closing the slack-tightening drift warning.
- Add a regression assertion that catches accidental re-route commits (the committed snapshot is strictly better than a fresh re-route from current main).

## Measurement (2026-06-07)

| Configuration | Total | Blocking | Notes |
|---|---|---|---|
| Committed routed PCB (HEAD) | 29 | **6** | 6 ``clearance_pad_segment`` + 23 ``connectivity`` advisory |
| Fresh re-route from ``design.py`` | 32 | **11** | 4 ``clearance_pad_segment`` + 4 ``clearance_segment_segment`` + 3 ``clearance_segment_via`` + 21 connectivity |

The committed file is the better-than-average snapshot documented in PR #3258.  Re-routing would regress, so **verification only** — no PCB refresh.

## Changes

1. **``tests/test_board_05_drc_allowlist.py``** — apply the same advisory-rule filter the CI gate uses (``DRCChecker.is_advisory_rule``).  Without this filter the test was counting 29 against the allowlist of 9 and failing on every run, even though the CI gate passed (6 blocking < 9).  PR #3258 had explicitly documented this divergence as "pre-existing failure ... unchanged by this PR".

2. **``tests/test_board_05_drc_hotspot_regression.py``** — add ``test_committed_pcb_has_no_segment_segment_or_segment_via`` to pin the absence of two rule families on the committed PCB that a fresh re-route introduces.  A future accidental re-route commit would otherwise widen blocking errors from 6 to 11 silently if the allowlist were ever raised for unrelated reasons.

3. **``.github/routed-drc-tolerance.yml``** — tighten board 05 floor from 9 to 6 (matches measured blocking count, closes the CI slack warning).

## Out of scope

- U3 in-pad rescue \"Proceeding anyway\" mechanism (#2944).
- C++ backend U3 hot-spot mechanism (#3251 investigation).
- Routing-yield improvements; board 05 design pins ``--backend python`` per PR #3222 / Issue #3221.

## Test plan

- [x] ``uv run pytest tests/test_board_05_drc_allowlist.py tests/test_board_05_drc_hotspot_regression.py -v`` — all 6 pass.
- [x] ``uv run pytest tests/test_board_05_*.py`` — 32 pass + 1 xpass, no new failures.
- [x] ``uv run pytest tests/test_check_routed_drc_advisory.py`` — 16 pass.
- [x] ``uv run python scripts/ci/check_routed_drc.py boards/05-bldc-motor-controller/output/bldc_controller_routed.kicad_pcb`` reports "6 errors, allowlist max 6" with no slack warning.
- [x] ``uv run kct fleet status`` — board 05 still shows fresh / B/C/G/M (no manufacturing-bundle regression).
- Pre-existing ``test_drc_tolerance.py`` MockPCB attribute failures on main are unchanged by this PR (verified by stash-and-rerun against ``origin/main``; orthogonal issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)