### PR TITLE
feat(router): surface partial-route count alongside strict-connect headline

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -1115,6 +1115,19 @@ def _finalize_routes(
         flush_print(f"  Vias:            {stats['vias']}")
         flush_print(f"  Total length:    {stats['total_length_mm']:.2f}mm")
         flush_print(f"  Nets routed:     {stats['nets_routed']}/{nets_to_route}")
+        # Issue #3311 / #3255: partial-route count is meaningful signal
+        # that today's strict-connect headline hides.  Surfaced here so
+        # CI / loom-summary scrapers see both numbers next to each other.
+        partial_count = stats.get("nets_partial", 0)
+        unrouted_count = stats.get("nets_unrouted", 0)
+        flush_print(
+            f"  Partial routes:  {partial_count}/{nets_to_route} "
+            f"-- have segments, not all pads connected"
+        )
+        flush_print(
+            f"  Unrouted:        {unrouted_count}/{nets_to_route} "
+            f"-- no segments at all"
+        )
 
     return route_sexp, stats, cleanup_stats
 
@@ -1349,6 +1362,22 @@ def show_preview(
     print("SUMMARY")
     print("=" * 60)
     print(f"  Nets routed:  {nets_routed}/{nets_to_route} ({success_rate:.0f}%)")
+    # Issue #3311 / #3255: surface partial / unrouted breakdown alongside
+    # the strict-connect headline so dashboards and humans see the full
+    # picture (e.g. chorus: 5/48 strict but 28/48 partial -- meaningful
+    # work that the headline alone obscures).
+    partial_count = overall_stats.get("nets_partial", 0)
+    unrouted_count = overall_stats.get("nets_unrouted", 0)
+    partial_pct = (partial_count / nets_to_route * 100) if nets_to_route > 0 else 0
+    unrouted_pct = (unrouted_count / nets_to_route * 100) if nets_to_route > 0 else 0
+    print(
+        f"  Partial routes: {partial_count}/{nets_to_route} ({partial_pct:.0f}%) "
+        f"-- have segments, not all pads connected"
+    )
+    print(
+        f"  Unrouted:     {unrouted_count}/{nets_to_route} ({unrouted_pct:.0f}%) "
+        f"-- no segments at all"
+    )
     print(f"  Total length: {overall_stats['total_length_mm']:.2f}mm")
     print(f"  Total vias:   {overall_stats['vias']}")
     print(f"  Segments:     {overall_stats['segments']}")

--- a/src/kicad_tools/router/observability.py
+++ b/src/kicad_tools/router/observability.py
@@ -205,6 +205,12 @@ def compute_routing_statistics(
           :func:`validate_net_connectivity`
         - ``nets_fully_connected``: count of nets where all pads are in
           one connected component
+        - ``nets_partial``: count of nets that have at least one
+          routed segment but not all pads connected (Issue #3311 /
+          #3255).  These nets contribute geometry to the PCB but are
+          not strictly complete.
+        - ``nets_unrouted``: count of multi-pad target nets that have
+          no segments at all
         - ``has_disconnected_islands``: ``True`` when any targeted net
           has pads that are not connected
     """
@@ -220,6 +226,8 @@ def compute_routing_statistics(
     # --- Connectivity-aware routing count ---
     connectivity: dict[int, dict] | None = None
     nets_fully_connected = 0
+    nets_partial = 0
+    nets_unrouted = 0
     has_disconnected_islands = False
 
     if net_pads is not None:
@@ -237,14 +245,37 @@ def compute_routing_statistics(
             not info["connected"] for info in connectivity.values()
             if info["total_pads"] >= 2
         )
+
+        # Issue #3311 / #3255: partial vs unrouted breakdown.
+        # A "partial" net has at least one routed segment but not all
+        # pads in a single connected component.  An "unrouted" net has
+        # no segments at all.  Single-pad nets (total_pads < 2) are
+        # trivially "connected" and excluded from both buckets.
+        for nid, info in connectivity.items():
+            if info["total_pads"] < 2:
+                continue
+            if info["connected"]:
+                continue
+            # Not fully connected — partial if it has any geometry,
+            # otherwise unrouted.
+            if nid in all_routed_nets:
+                nets_partial += 1
+            else:
+                nets_unrouted += 1
         # nets_routed = only nets that are fully connected
         nets_routed = nets_fully_connected
     else:
         # Legacy path: count any net with at least one route
         if nets_to_route_ids is not None:
             nets_routed = len(all_routed_nets & nets_to_route_ids)
+            # In legacy mode (no pad info) we cannot distinguish
+            # partial from strict-connect.  Anything that has a route
+            # is counted as routed; everything else is "unrouted".
+            nets_unrouted = len(nets_to_route_ids - all_routed_nets)
         else:
             nets_routed = len(all_routed_nets)
+            nets_unrouted = 0
+        nets_partial = 0
 
     result = {
         "routes": len(routes),
@@ -252,6 +283,8 @@ def compute_routing_statistics(
         "vias": sum(len(r.vias) for r in routes),
         "total_length_mm": total_length,
         "nets_routed": nets_routed,
+        "nets_partial": nets_partial,
+        "nets_unrouted": nets_unrouted,
         "max_congestion": congestion_stats["max_congestion"],
         "avg_congestion": congestion_stats["avg_congestion"],
         "congested_regions": congestion_stats["congested_regions"],

--- a/src/kicad_tools/router/output.py
+++ b/src/kicad_tools/router/output.py
@@ -156,6 +156,28 @@ def show_routing_summary(
         routed_line += f" -- {single_pad_count} single-pad net(s) excluded"
     print(routed_line)
 
+    # Issue #3311 / #3255: surface partial-route count alongside the
+    # strict-connect headline.  Distinguishing "partial" (has segments
+    # but not all pads connected) from "unrouted" (no segments at all)
+    # turns a single misleading "5/48 routed" number into the more
+    # informative "5 strict / 28 partial / 15 unrouted" breakdown.
+    partial_count = len(partially_connected_nets)
+    unrouted_count = len(unrouted_ids)
+    if nets_to_route > 0:
+        partial_pct = partial_count / nets_to_route * 100
+        unrouted_pct = unrouted_count / nets_to_route * 100
+    else:
+        partial_pct = 0.0
+        unrouted_pct = 0.0
+    print(
+        f"  Partial routes: {partial_count}/{nets_to_route} "
+        f"({partial_pct:.0f}%) -- have segments, not all pads connected"
+    )
+    print(
+        f"  Unrouted: {unrouted_count}/{nets_to_route} "
+        f"({unrouted_pct:.0f}%) -- no segments at all"
+    )
+
     # Show partially-connected nets (have segments but not all pads connected)
     if partially_connected_nets:
         print(f"\n  Partially connected nets ({len(partially_connected_nets)}):")
@@ -789,11 +811,24 @@ def get_routing_diagnostics_json(
             }
         )
 
+    # Issue #3311 / #3255: surface partial / unrouted breakdown in JSON
+    # so machine-readable consumers (CI, dashboards, agent prompts) can
+    # report something more honest than the strict-connect headline.
+    partial_count = len(partially_connected)
+    unrouted_count = len(unrouted_ids)
     summary_dict: dict = {
         "nets_requested": nets_to_route,
         "nets_routed": len(routed_net_ids),
-        "nets_failed": len(unrouted_ids),
+        "nets_partial": partial_count,
+        "nets_unrouted": unrouted_count,
+        "nets_failed": unrouted_count,
         "success_rate": round(len(routed_net_ids) / nets_to_route * 100, 1)
+        if nets_to_route > 0
+        else 0,
+        "partial_rate": round(partial_count / nets_to_route * 100, 1)
+        if nets_to_route > 0
+        else 0,
+        "unrouted_rate": round(unrouted_count / nets_to_route * 100, 1)
         if nets_to_route > 0
         else 0,
         "has_disconnected_islands": has_disconnected_islands,

--- a/tests/test_routing_output.py
+++ b/tests/test_routing_output.py
@@ -742,3 +742,185 @@ class TestIssue2498SkipNetFallback:
         assert "GND" not in output
         assert "SIG_B" in output  # genuine failure shown
         assert "1/2" in output  # 1 routed of 2 candidates
+
+
+# ---------------------------------------------------------------------------
+# Issue #3311 / #3255: partial-route count surfaced alongside strict-connect
+# ---------------------------------------------------------------------------
+
+
+class TestPartialRouteHeadline:
+    """The route summary must report partial-route count alongside the
+    strict-connect headline so CI and humans see the full picture instead
+    of the misleading "X/Y routed" snapshot that hides 28 partial routes
+    behind a 5/48 strict-connect number (chorus Wave 8 motivating case).
+    """
+
+    def _make_route(self, net_id):
+        route = MagicMock()
+        route.net = net_id
+        route.segments = []
+        route.vias = []
+        return route
+
+    def test_summary_always_includes_partial_routes_line(self, capsys):
+        """Even when there are no partial nets, the breakdown line MUST
+        be emitted so scrapers can pin both values."""
+        router = _make_router(routes=[self._make_route(1)])
+        net_map = {"NetA": 1}
+
+        show_routing_summary(
+            router,
+            net_map,
+            nets_to_route=1,
+        )
+
+        output = capsys.readouterr().out
+        # The new lines must always appear so consumers can pin them.
+        assert "Nets routed:" in output
+        assert "Partial routes:" in output
+        assert "Unrouted:" in output
+
+    def test_summary_includes_unrouted_line(self, capsys):
+        """The Unrouted: line should report nets with no segments at all."""
+        # 2 nets requested, 1 routed, 1 unrouted (no route, no pad data)
+        router = _make_router(routes=[self._make_route(1)])
+        net_map = {"NetA": 1, "NetB": 2}
+
+        show_routing_summary(
+            router,
+            net_map,
+            nets_to_route=2,
+        )
+
+        output = capsys.readouterr().out
+        # 1 unrouted of 2 total
+        assert "Unrouted: 1/2" in output
+
+    def test_summary_counts_partial_separately(self, capsys):
+        """A net with at least one routed segment but not all pads
+        connected must be counted as 'partial', not strict-connect."""
+        # Build a Pad-like object so connectivity validation runs.
+        @dataclass
+        class _Pad:
+            x: float
+            y: float
+
+        # Net 1: 2 pads at (0,0) and (10,0).  A route segment at
+        # (0,0)-(2,0) covers only pad 1 — pad 2 is far away, so the
+        # net is "partial".
+        seg = MagicMock()
+        seg.x1, seg.y1, seg.x2, seg.y2 = 0.0, 0.0, 2.0, 0.0
+        seg.layer.value = 0
+        route = MagicMock()
+        route.net = 1
+        route.segments = [seg]
+        route.vias = []
+
+        router = _make_router(routes=[route])
+        # Real dicts so the partially-connected branch runs.
+        router.pads = {
+            ("U1", "1"): _Pad(0.0, 0.0),
+            ("U1", "2"): _Pad(10.0, 0.0),
+        }
+        router.nets = {1: [("U1", "1"), ("U1", "2")]}
+        net_map = {"NetA": 1}
+
+        show_routing_summary(
+            router,
+            net_map,
+            nets_to_route=1,
+            nets_to_route_ids={1},
+        )
+
+        output = capsys.readouterr().out
+        # Net 1 has a segment but its 2 pads are not in the same
+        # connected component, so it must be counted as PARTIAL, not
+        # strict-connect.
+        assert "Nets routed: 0/1" in output
+        assert "Partial routes: 1/1" in output
+
+    def test_json_summary_includes_partial_and_unrouted_keys(self):
+        """get_routing_diagnostics_json must include nets_partial and
+        nets_unrouted keys at the top level so dashboards can read them."""
+        router = _make_router(routes=[self._make_route(1)])
+        net_map = {"NetA": 1, "NetB": 2}
+
+        result = get_routing_diagnostics_json(
+            router,
+            net_map,
+            nets_to_route=2,
+        )
+
+        assert "nets_partial" in result["summary"]
+        assert "nets_unrouted" in result["summary"]
+        assert "partial_rate" in result["summary"]
+        assert "unrouted_rate" in result["summary"]
+        # No pad data here, so all 1 missing net is "unrouted", not "partial".
+        assert result["summary"]["nets_partial"] == 0
+        assert result["summary"]["nets_unrouted"] == 1
+
+    def test_chorus_wave8_style_breakdown(self, capsys):
+        """Reproduce the chorus Wave 8 motivating case in miniature:
+        out of 4 multi-pad nets, 1 is strict-connect, 2 are partial
+        (have geometry but not all pads), 1 is fully unrouted.  The
+        headline alone would say 1/4 (25%); the new breakdown surfaces
+        the 2 partials that the strict number hides.
+        """
+        @dataclass
+        class _Pad:
+            x: float
+            y: float
+
+        def _seg(x1, y1, x2, y2, net):
+            seg = MagicMock()
+            seg.x1, seg.y1, seg.x2, seg.y2 = x1, y1, x2, y2
+            seg.layer.value = 0
+            return seg
+
+        def _route(net, segments):
+            r = MagicMock()
+            r.net = net
+            r.segments = segments
+            r.vias = []
+            return r
+
+        # Net 1: fully connected (segment runs pad-to-pad)
+        # Net 2: partial (segment only covers one pad)
+        # Net 3: partial (segment only covers one pad)
+        # Net 4: no segment at all -> unrouted
+        routes = [
+            _route(1, [_seg(0.0, 0.0, 5.0, 0.0, 1)]),
+            _route(2, [_seg(0.0, 0.0, 1.0, 0.0, 2)]),
+            _route(3, [_seg(0.0, 0.0, 1.0, 0.0, 3)]),
+        ]
+        router = _make_router(routes=routes)
+        router.pads = {
+            ("U1", "1"): _Pad(0.0, 0.0),
+            ("U1", "2"): _Pad(5.0, 0.0),
+            ("U2", "1"): _Pad(0.0, 0.0),
+            ("U2", "2"): _Pad(20.0, 0.0),
+            ("U3", "1"): _Pad(0.0, 0.0),
+            ("U3", "2"): _Pad(30.0, 0.0),
+            ("U4", "1"): _Pad(0.0, 0.0),
+            ("U4", "2"): _Pad(40.0, 0.0),
+        }
+        router.nets = {
+            1: [("U1", "1"), ("U1", "2")],
+            2: [("U2", "1"), ("U2", "2")],
+            3: [("U3", "1"), ("U3", "2")],
+            4: [("U4", "1"), ("U4", "2")],
+        }
+        net_map = {"NetA": 1, "NetB": 2, "NetC": 3, "NetD": 4}
+
+        show_routing_summary(
+            router,
+            net_map,
+            nets_to_route=4,
+            nets_to_route_ids={1, 2, 3, 4},
+        )
+
+        output = capsys.readouterr().out
+        assert "Nets routed: 1/4" in output
+        assert "Partial routes: 2/4" in output
+        assert "Unrouted: 1/4" in output


### PR DESCRIPTION
## Summary

Today's CLI output reports `Nets routed: X/Y` (strict connectivity:
all pads in one connected component) but hides "partial routes" —
nets with at least one routed segment but not all pads connected.
Chorus Wave 8 showed 28 partial vs 3 strict — meaningful work that
CI gates and Loom summaries grepping for "Nets routed:" never saw.

This PR adds two new lines immediately after the existing headline
so consumers see the full picture without breaking any existing
regex-based scrapers (the original "Nets routed:" line keeps its
format byte-for-byte, including the chorus regression test in #3237).

## New output format sample

```
============================================================
Routing Incomplete (25% connected)
  Nets routed: 1/4 (25%)
  Partial routes: 2/4 (50%) -- have segments, not all pads connected
  Unrouted: 1/4 (25%) -- no segments at all

  Partially connected nets (2):
    NetB: 1/2 pads connected
    NetC: 1/2 pads connected
============================================================
```

And in the `--- Results ---` block from `route_cmd.py`:

```
--- Results ---
  Routes created:  3
  Segments:        3
  Vias:            0
  Total length:    8.00mm
  Nets routed:     1/4
  Partial routes:  2/4 -- have segments, not all pads connected
  Unrouted:        1/4 -- no segments at all
```

## JSON output

`get_routing_diagnostics_json` now includes:

```json
{
  "summary": {
    "nets_requested": 48,
    "nets_routed": 5,
    "nets_partial": 28,
    "nets_unrouted": 15,
    "success_rate": 10.4,
    "partial_rate": 58.3,
    "unrouted_rate": 31.3,
    ...
  }
}
```

## Implementation

- `compute_routing_statistics` (`router/observability.py`) now computes
  `nets_partial` and `nets_unrouted` whenever pad data is available,
  using the existing connectivity validation pass.  Legacy callers
  (no pad data) fall back to "any segment counts as routed".
- `show_routing_summary` (`router/output.py`) prints the new
  `Partial routes:` and `Unrouted:` lines immediately after `Nets routed:`.
- `route_cmd.py` adds matching lines to both the `--- Results ---`
  block (line 1117) and the `SUMMARY` block (line 1351).
- Existing `Nets routed:` line format is unchanged so all fixtures
  (board 04 regression, route-auto mfr tier, board 02 demo, chorus
  reach floor #3237) keep working.

## Tests

- 5 new tests in `TestPartialRouteHeadline` covering:
  - both new lines are always emitted (even when counts are zero)
  - `Unrouted:` correctly reports nets with no segments
  - partial nets (with geometry but not all pads connected) are
    counted as partial, not strict-connect
  - JSON summary exposes `nets_partial` / `nets_unrouted` /
    `partial_rate` / `unrouted_rate`
  - chorus Wave 8-style mixed case (1 strict + 2 partial + 1 unrouted
    out of 4) shows all three buckets correctly

## Test plan

- [x] `uv run pytest tests/test_routing_output.py` (34 passed, +5 new)
- [x] `uv run pytest tests/test_routing_connectivity.py tests/test_output_connectivity.py` (30 passed)
- [x] `uv run pytest tests/test_route_cmd_*` (134 passed)
- [x] `uv run pytest tests/test_board_04_routing_regression.py` (1 passed in 173s)
- [x] Manual sample run confirms the new format matches issue spec

Closes #3311
Closes #3255