### PR TITLE
fix(fleet): power-rail alias + unlabeled-local-net drift tolerance (#3302)

### DIFF
--- a/src/kicad_tools/cli/fleet_cmd.py
+++ b/src/kicad_tools/cli/fleet_cmd.py
@@ -45,8 +45,28 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from kicad_tools.analysis.net_status import NetStatusAnalyzer
+from kicad_tools.schema.pcb import canonicalize_power_nets
 
 SCHEMA_VERSION = "1.1"
+
+# Issue #3302: tolerate at most this many added-only nets (after
+# power-rail alias normalisation) before flagging source drift.
+#
+# The kicad-tools schematic style routinely leaves short
+# component-to-component nets unlabeled (e.g. ``LED_K`` between D1.K and
+# R1, ``BOOT0`` between U2.44 and R2 on board 04). KiCad synthesises
+# a net name during PCB sync, so the PCB-net set is a strict superset
+# of the schematic-label set even when the design is in perfect sync.
+# Without tolerance, every unlabeled local net becomes a false-positive
+# drift signal.
+#
+# Bound at 2 (a conservative default chosen empirically from the
+# in-repo board set): board 04 has exactly 2 such unlabeled local
+# nets, while board 03's 3 real adds (``VBUS``, ``USB_CC1``,
+# ``USB_CC2``) -- a genuine schematic-vs-PCB mismatch -- still
+# trigger. Boards that grow more than two unlabeled local nets
+# without re-routing will still surface the drift correctly.
+_DRIFT_ADDED_ONLY_TOLERANCE = 2
 
 # Default location for the per-board DRC tolerance allowlist (mirrors
 # ``scripts/ci/check_routed_drc.py``). Boards listed here have a
@@ -636,13 +656,36 @@ def _detect_source_drift(
     board_dir: Path,
     *,
     sample_limit: int = 8,
+    added_only_tolerance: int = _DRIFT_ADDED_ONLY_TOLERANCE,
 ) -> tuple[bool, int | None, int | None, list[str], list[str]]:
-    """Detect schematic-vs-PCB net-set drift (issue #3280).
+    """Detect schematic-vs-PCB net-set drift (issues #3280, #3302).
 
     Compares the set of named labels in the source ``.kicad_sch`` to the
     set of named nets in the routed PCB. When the sets differ, the routed
     PCB is treated as **source-stale**: its ``X/Y nets`` count is no
     longer a trustworthy signal of current-design routing progress.
+
+    Two normalisation passes are applied before the symmetric difference
+    is computed (issue #3302):
+
+      1. **Power-rail alias canonicalisation.** KiCad's stock
+         ``power:+3V3`` symbol publishes ``+3V3`` while kicad-tools'
+         netlist-sync emits ``+3.3V``; both forms refer to the same
+         electrical net. :func:`canonicalize_power_nets` rewrites both
+         sides to a single canonical form (``+3.3V``) so fractional
+         rails compare equal across the schematic-vs-PCB boundary.
+         See ``src/kicad_tools/schema/pcb.py`` for the alias table.
+
+      2. **Sub-threshold added-only tolerance.** kicad-tools schematics
+         routinely leave short component-to-component nets unlabeled
+         (e.g. ``LED_K`` on board 04). The PCB synthesises a name for
+         each such net during sync, so the PCB-net set is a strict
+         superset of the schematic-label set even when the design is in
+         perfect sync. When the residual diff after canonicalisation
+         has **no removals** AND at most ``added_only_tolerance`` added
+         names, those adds are attributed to unlabeled-local-net
+         synthesis and drift is *not* reported. Genuine schematic edits
+         (adds beyond the threshold, OR any removals) still surface.
 
     The check is deliberately conservative:
       * If the schematic cannot be located or parsed, we return
@@ -657,7 +700,9 @@ def _detect_source_drift(
         ``(source_stale, schematic_net_count, pcb_net_count,
         added_in_pcb, removed_from_pcb)``. The ``added`` / ``removed``
         samples are sorted and capped at ``sample_limit`` for bounded
-        JSON output.
+        JSON output. Counts are the raw (pre-canonicalisation) set
+        sizes so the JSON ``schematic_net_count`` /
+        ``pcb_net_count`` keys keep their previous meaning.
     """
     sch_path = _find_source_schematic(board_dir)
     if sch_path is None:
@@ -669,9 +714,23 @@ def _detect_source_drift(
     if pcb_nets is None:
         return (False, len(sch_nets), None, [], [])
 
-    added = sorted(pcb_nets - sch_nets)
-    removed = sorted(sch_nets - pcb_nets)
-    source_stale = bool(added) or bool(removed)
+    # Step 1: canonicalise power-rail aliases on both sides before the
+    # set diff. Non-power names pass through unchanged.
+    sch_canon = canonicalize_power_nets(sch_nets)
+    pcb_canon = canonicalize_power_nets(pcb_nets)
+
+    added = sorted(pcb_canon - sch_canon)
+    removed = sorted(sch_canon - pcb_canon)
+
+    # Step 2: sub-threshold added-only tolerance. Only applies when
+    # there are NO removals (a removed schematic label is always a
+    # real signal) AND the residual add count is within the
+    # unlabeled-local-net headroom.
+    if not removed and 0 < len(added) <= added_only_tolerance:
+        source_stale = False
+    else:
+        source_stale = bool(added) or bool(removed)
+
     return (
         source_stale,
         len(sch_nets),

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -49,6 +49,89 @@ def _is_power_net(name: str, pattern: re.Pattern[str] | None = None) -> bool:
     return pat.search(name) is not None
 
 
+# ---------------------------------------------------------------------------
+# Power-rail name canonicalisation (issue #3302)
+# ---------------------------------------------------------------------------
+#
+# KiCad's stock ``power:`` library uses ``V`` as a decimal separator for
+# sub-volt fractional rails (``+3V3``, ``+1V8``, ``+2V5``) while the
+# kicad-tools netlist-sync convention emits the same rails with a decimal
+# point (``+3.3V``, ``+1.8V``, ``+2.5V``). The two forms refer to the
+# same electrical net but the strings differ, so a naive set-difference
+# between schematic-label names and PCB-net names sees a spurious add
+# and a spurious remove for every fractional rail.
+#
+# ``_POWER_RAIL_ALIAS_RE`` recognises the canonical-form pair and
+# ``canonicalize_power_net`` rewrites both forms to a single canonical
+# string (``+N.MV``, no decimal-point removal) so the two sides of a
+# drift comparison agree without affecting non-power names. Whole-volt
+# rails (``+5V`` / ``+5.0V``) are also normalised; this keeps the table
+# closed and avoids drift surprises on boards that emit ``+5.0V``.
+#
+# The table is deliberately limited to the ``+N`` and ``+N.M`` rails
+# called out in the schema convention documentation
+# (``src/kicad_tools/schematic/models/elements_mixin.py:394-397``). It
+# is *not* a general fuzzy net matcher; non-matching names are returned
+# unchanged.
+
+# ``+3V3`` / ``+3.3V`` / ``+3.0V`` (whole volt with explicit fraction)
+_POWER_RAIL_V_DECIMAL_RE = re.compile(r"^([+\-])(\d+)V(\d+)$")
+_POWER_RAIL_DOT_DECIMAL_RE = re.compile(r"^([+\-])(\d+)\.(\d+)V$")
+_POWER_RAIL_WHOLE_RE = re.compile(r"^([+\-])(\d+)V$")
+
+
+def canonicalize_power_net(name: str) -> str:
+    """Return the canonical form of a power-rail net name.
+
+    The canonical form is ``+N.MV`` for fractional rails (``+3V3`` ->
+    ``+3.3V``) and ``+NV`` for whole-volt rails (``+5.0V`` -> ``+5V``).
+    Names that don't match the power-rail-alias grammar are returned
+    unchanged, so the function is a pure no-op for signal names like
+    ``BOOT0``, ``LED_K`` or ``USB_CC1``.
+
+    Examples:
+        ``+3V3``    -> ``+3.3V``
+        ``+3.3V``   -> ``+3.3V``
+        ``+1V8``    -> ``+1.8V``
+        ``+5V``     -> ``+5V``
+        ``+5.0V``   -> ``+5V``
+        ``-3V3``    -> ``-3.3V``
+        ``VBUS``    -> ``VBUS`` (no change)
+        ``BOOT0``   -> ``BOOT0`` (no change)
+    """
+    if not name:
+        return name
+    m = _POWER_RAIL_V_DECIMAL_RE.match(name)
+    if m:
+        sign, whole, frac = m.group(1), m.group(2), m.group(3)
+        # Strip a trailing zero fraction (``+3V0`` -> ``+3V`` canonical).
+        if frac == "0":
+            return f"{sign}{whole}V"
+        return f"{sign}{whole}.{frac}V"
+    m = _POWER_RAIL_DOT_DECIMAL_RE.match(name)
+    if m:
+        sign, whole, frac = m.group(1), m.group(2), m.group(3)
+        # Whole-volt rail expressed with explicit ``.0`` fraction.
+        if frac == "0":
+            return f"{sign}{whole}V"
+        return f"{sign}{whole}.{frac}V"
+    m = _POWER_RAIL_WHOLE_RE.match(name)
+    if m:
+        sign, whole = m.group(1), m.group(2)
+        return f"{sign}{whole}V"
+    return name
+
+
+def canonicalize_power_nets(names: set[str]) -> set[str]:
+    """Apply :func:`canonicalize_power_net` to every name in a set.
+
+    Returns a new set; the input is not mutated. Non-power-rail names
+    pass through unchanged so the caller can treat the result as a
+    drop-in replacement for the original set.
+    """
+    return {canonicalize_power_net(n) for n in names}
+
+
 @dataclass
 class Layer:
     """PCB layer definition."""

--- a/tests/test_fleet_status.py
+++ b/tests/test_fleet_status.py
@@ -905,8 +905,10 @@ MATCHING_NETS_PCB = """(kicad_pcb
 """
 
 
-# A PCB with an EXTRA net (USB_CC1) that does not appear in THREE_NET_SCH.
-# This is the board-03 condition: routed PCB has more nets than schematic.
+# A PCB with EXTRA nets (USB_CC1, USB_CC2, VBUS) that do not appear in
+# THREE_NET_SCH. This mirrors the real board-03 condition (routed PCB has
+# more nets than schematic) and intentionally exceeds the issue #3302
+# ``_DRIFT_ADDED_ONLY_TOLERANCE`` headroom so a real drift still fires.
 EXTRA_NET_DRIFT_PCB = """(kicad_pcb
   (version 20240108)
   (generator "test")
@@ -920,6 +922,8 @@ EXTRA_NET_DRIFT_PCB = """(kicad_pcb
   (net 2 "GND")
   (net 3 "SIG1")
   (net 4 "USB_CC1")
+  (net 5 "USB_CC2")
+  (net 6 "VBUS")
   (gr_rect (start 0 0) (end 30 30) (stroke (width 0.1)) (layer "Edge.Cuts"))
   (footprint "Resistor_SMD:R_0402"
     (layer "F.Cu")
@@ -934,6 +938,13 @@ EXTRA_NET_DRIFT_PCB = """(kicad_pcb
     (property "Reference" "R2")
     (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 3 "SIG1"))
     (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 4 "USB_CC1"))
+  )
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (at 25 10)
+    (property "Reference" "R3")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 5 "USB_CC2"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 6 "VBUS"))
   )
 )
 """
@@ -1015,7 +1026,7 @@ class TestFleetStatusSourceDrift:
         routing = b["routing"]
         assert routing["source_stale"] is True
         assert routing["schematic_net_count"] == 3
-        assert routing["pcb_net_count"] == 4
+        assert routing["pcb_net_count"] == 6
         assert "USB_CC1" in routing.get("drift_added", [])
 
     def test_no_drift_preserves_routing_blocker(self, tmp_path: Path, capsys):
@@ -1094,7 +1105,7 @@ class TestFleetStatusSourceDrift:
         assert len(drift_blockers) == 1, b["blockers"]
         # Format: "routed PCB stale (schematic drift: N nets in schematic, M in PCB)"
         assert "3 nets in schematic" in drift_blockers[0]
-        assert "4 in PCB" in drift_blockers[0]
+        assert "6 in PCB" in drift_blockers[0]
 
     def test_drift_ship_ready_false(self, tmp_path: Path, capsys):
         """Drift forces ship_ready=False even when routing looks complete.
@@ -1119,3 +1130,272 @@ class TestFleetStatusSourceDrift:
         b = data["boards"][0]
         assert b["ship_ready"] is False
         assert b["routing"]["routing_complete"] is False
+
+
+# ---------------------------------------------------------------------------
+# Issue #3302: power-rail alias + unlabeled-local-net tolerance
+# ---------------------------------------------------------------------------
+
+
+# Schematic that uses the stock ``power:+3V3`` symbol name (KiCad
+# convention) plus a labeled signal net SIG1.
+POWER_ALIAS_SCH = """(kicad_sch
+  (version 20240108)
+  (generator "test")
+  (paper "A4")
+  (label "+3V3" (at 10 10 0))
+  (label "GND" (at 10 20 0))
+  (label "SIG1" (at 10 30 0))
+)
+"""
+
+
+# PCB that uses the kicad-tools netlist-sync convention (``+3.3V``)
+# for the same rail. Functionally identical to POWER_ALIAS_SCH.
+POWER_ALIAS_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "+3.3V")
+  (net 2 "GND")
+  (net 3 "SIG1")
+  (gr_rect (start 0 0) (end 30 30) (stroke (width 0.1)) (layer "Edge.Cuts"))
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (at 10 10)
+    (property "Reference" "R1")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 1 "+3.3V"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 2 "GND"))
+  )
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (at 20 10)
+    (property "Reference" "R2")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 1 "+3.3V"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 3 "SIG1"))
+  )
+)
+"""
+
+
+# PCB that adds TWO unlabeled-local synthesised nets (BOOT0, LED_K) on
+# top of the matching schematic. This mirrors the board-04 condition:
+# kicad-tools synthesises a net name during sync for short
+# component-to-component segments that the schematic leaves unlabeled.
+UNLABELED_LOCAL_NETS_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "VCC")
+  (net 2 "GND")
+  (net 3 "SIG1")
+  (net 4 "BOOT0")
+  (net 5 "LED_K")
+  (gr_rect (start 0 0) (end 30 30) (stroke (width 0.1)) (layer "Edge.Cuts"))
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (at 10 10)
+    (property "Reference" "R1")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 1 "VCC"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 2 "GND"))
+  )
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (at 20 10)
+    (property "Reference" "R2")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 3 "SIG1"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 4 "BOOT0"))
+  )
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (at 25 10)
+    (property "Reference" "R3")
+    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 4 "BOOT0"))
+    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu" "F.Mask") (net 5 "LED_K"))
+  )
+)
+"""
+
+
+class TestFleetStatusDriftFalsePositiveFixes:
+    """Issue #3302 -- false-positive drift on board 04 (and similar).
+
+    Two distinct false-positive classes are tolerated here:
+
+      1. Power-rail naming format mismatch (``+3V3`` vs ``+3.3V``):
+         normalised by the canonical-form table in
+         ``kicad_tools.schema.pcb.canonicalize_power_net``.
+
+      2. Sub-threshold added-only diff: kicad-tools schematics routinely
+         leave short component-to-component nets unlabeled, so the PCB
+         net set is a strict superset of the schematic-label set even
+         when the design is in sync. A residual added-only diff of at
+         most ``_DRIFT_ADDED_ONLY_TOLERANCE`` (default 2) is attributed
+         to unlabeled-local-net synthesis and not flagged.
+
+    The regression we MUST preserve: PR #3289's board-03 protection
+    where the PCB has more than two added nets relative to the
+    schematic -- that still triggers ``routed PCB stale``.
+    """
+
+    def test_power_rail_alias_not_flagged(self, tmp_path: Path, capsys):
+        """``+3V3`` (schematic) vs ``+3.3V`` (PCB) -> not source-stale.
+
+        This is the board-04 root cause: KiCad's stock ``power:+3V3``
+        symbol writes ``+3V3`` into the schematic-label set while the
+        kicad-tools netlist-sync convention emits ``+3.3V`` into the
+        PCB-net set. Both names refer to the same rail; the drift
+        detector must canonicalise both sides before the diff.
+        """
+        boards = tmp_path / "boards"
+        _make_board_with_schematic(
+            boards,
+            "alias-board",
+            sch_text=POWER_ALIAS_SCH,
+            pcb_text=POWER_ALIAS_PCB,
+        )
+
+        main(["status", "--boards-dir", str(boards), "--format", "json"])
+        data = json.loads(capsys.readouterr().out)
+        b = data["boards"][0]
+
+        routing = b["routing"]
+        assert routing["source_stale"] is False, (
+            f"+3V3<->+3.3V should canonicalise; got {routing}"
+        )
+        # Raw counts are preserved for back-compat (issue #3302 AC).
+        assert routing["schematic_net_count"] == 3
+        assert routing["pcb_net_count"] == 3
+        # No drift blocker.
+        assert not any(
+            "routed PCB stale" in blocker for blocker in b["blockers"]
+        ), b["blockers"]
+
+    def test_two_unlabeled_local_nets_not_flagged(self, tmp_path: Path, capsys):
+        """<= 2 added unlabeled local nets in PCB -> not source-stale.
+
+        Board 04's `LED_K` / `BOOT0` condition: short component-to-
+        component segments are unlabeled in the schematic but
+        synthesised in the PCB. The PCB-net set is a strict superset
+        but the design is in sync.
+        """
+        boards = tmp_path / "boards"
+        _make_board_with_schematic(
+            boards,
+            "unlabeled-board",
+            sch_text=THREE_NET_SCH,  # VCC, GND, SIG1
+            pcb_text=UNLABELED_LOCAL_NETS_PCB,  # ...+ BOOT0, LED_K
+        )
+
+        main(["status", "--boards-dir", str(boards), "--format", "json"])
+        data = json.loads(capsys.readouterr().out)
+        b = data["boards"][0]
+
+        routing = b["routing"]
+        assert routing["source_stale"] is False, (
+            f"two added local nets should be tolerated; got {routing}"
+        )
+        # Raw counts are preserved for back-compat.
+        assert routing["schematic_net_count"] == 3
+        assert routing["pcb_net_count"] == 5
+        # No drift blocker -- only routing/manufacturing gates remain.
+        assert not any(
+            "routed PCB stale" in blocker for blocker in b["blockers"]
+        ), b["blockers"]
+
+    def test_board03_style_three_adds_still_flagged(self, tmp_path: Path, capsys):
+        """Three added non-alias nets -> still flagged (board 03 case).
+
+        The regression guard for PR #3289: a real schematic drift
+        where the PCB has three or more added nets (e.g. ``VBUS``,
+        ``USB_CC1``, ``USB_CC2`` on board 03) is NOT masked by the
+        sub-threshold tolerance.
+        """
+        boards = tmp_path / "boards"
+        _make_board_with_schematic(
+            boards,
+            "real-drift-board",
+            sch_text=THREE_NET_SCH,
+            pcb_text=EXTRA_NET_DRIFT_PCB,  # adds USB_CC1, USB_CC2, VBUS
+        )
+
+        main(["status", "--boards-dir", str(boards), "--format", "json"])
+        data = json.loads(capsys.readouterr().out)
+        b = data["boards"][0]
+
+        routing = b["routing"]
+        assert routing["source_stale"] is True
+        assert any(
+            "routed PCB stale" in blocker for blocker in b["blockers"]
+        ), b["blockers"]
+
+    def test_removal_always_flagged(self, tmp_path: Path, capsys):
+        """A removed schematic label is ALWAYS a real signal.
+
+        The added-only tolerance only applies when there are zero
+        removals. A net present in the schematic but missing from the
+        PCB indicates the PCB was rebuilt against a stale schematic and
+        must surface even if the count is sub-threshold.
+        """
+        # Schematic has one extra label (SIG_REMOVED) that the PCB lacks.
+        sch_with_extra = """(kicad_sch
+          (version 20240108)
+          (generator "test")
+          (paper "A4")
+          (label "VCC" (at 10 10 0))
+          (label "GND" (at 10 20 0))
+          (label "SIG1" (at 10 30 0))
+          (label "SIG_REMOVED" (at 10 40 0))
+        )
+        """
+        boards = tmp_path / "boards"
+        _make_board_with_schematic(
+            boards,
+            "removed-board",
+            sch_text=sch_with_extra,
+            pcb_text=MATCHING_NETS_PCB,  # VCC, GND, SIG1 only
+        )
+
+        main(["status", "--boards-dir", str(boards), "--format", "json"])
+        data = json.loads(capsys.readouterr().out)
+        b = data["boards"][0]
+
+        routing = b["routing"]
+        assert routing["source_stale"] is True
+        assert "SIG_REMOVED" in routing.get("drift_removed", [])
+
+    def test_canonicalize_power_net_unit(self):
+        """Unit-level check on the canonicaliser used by the detector."""
+        from kicad_tools.schema.pcb import canonicalize_power_net
+
+        # Fractional rail forms canonicalise to ``+N.MV``.
+        assert canonicalize_power_net("+3V3") == "+3.3V"
+        assert canonicalize_power_net("+3.3V") == "+3.3V"
+        assert canonicalize_power_net("+1V8") == "+1.8V"
+        assert canonicalize_power_net("+1.8V") == "+1.8V"
+        assert canonicalize_power_net("+2V5") == "+2.5V"
+        assert canonicalize_power_net("-3V3") == "-3.3V"
+
+        # Whole-volt forms canonicalise to ``+NV``.
+        assert canonicalize_power_net("+5V") == "+5V"
+        assert canonicalize_power_net("+5.0V") == "+5V"
+        assert canonicalize_power_net("+12V") == "+12V"
+        assert canonicalize_power_net("+12.0V") == "+12V"
+
+        # Non-power names pass through unchanged.
+        assert canonicalize_power_net("VBUS") == "VBUS"
+        assert canonicalize_power_net("GND") == "GND"
+        assert canonicalize_power_net("BOOT0") == "BOOT0"
+        assert canonicalize_power_net("LED_K") == "LED_K"
+        assert canonicalize_power_net("USB_CC1") == "USB_CC1"
+        assert canonicalize_power_net("") == ""


### PR DESCRIPTION
## Summary

Closes #3302.

The schematic-vs-PCB drift detector introduced in PR #3289 was flagging
board 04 as ``routed PCB stale (schematic drift: 10 nets in schematic,
12 in PCB)`` even though the committed routed PCB is a byte-identical-
mod-UUIDs reproduction of the canonical recipe against current main.

Two distinct false-positive classes existed:

1. **Power-rail naming format mismatch.** KiCad's stock ``power:+3V3``
   symbol writes ``+3V3`` into the schematic-label set while the
   kicad-tools netlist-sync convention emits ``+3.3V`` into the PCB-net
   set. Both names refer to the same electrical rail.
2. **Unlabeled local nets.** kicad-tools schematics routinely leave
   short component-to-component nets (e.g. ``LED_K`` on board 04)
   unlabeled. The PCB synthesises a name during sync, so the PCB-net
   set is a strict superset of the schematic-label set even when the
   design is in perfect sync.

This PR ships **Option A** from the curator-enriched issue body:
- New canonicaliser ``canonicalize_power_net`` in
  ``src/kicad_tools/schema/pcb.py`` rewrites the ``+NVM`` <-> ``+N.MV``
  pair (and ``+NV`` <-> ``+N.0V``) into a single canonical form so the
  two sides agree before the diff. Non-power names pass through
  unchanged.
- ``_detect_source_drift`` in ``src/kicad_tools/cli/fleet_cmd.py``
  applies the canonicaliser to both sides AND tolerates an added-only
  residual diff of at most ``_DRIFT_ADDED_ONLY_TOLERANCE`` (default 2)
  attributed to unlabeled-local-net synthesis. Removals are always a
  real signal, so the tolerance only applies when ``|removed| == 0``.

Per AC, the alias table lives in ``src/kicad_tools/schema/pcb.py`` (next
to ``_is_power_net``) so future drift consumers can reuse it without
copy-pasting into ``fleet_cmd.py``. Raw schematic/PCB net counts in JSON
output are preserved (pre-canonicalisation set sizes) for back-compat.

## Fleet status: before / after

| Board | Before #3302 fix | After #3302 fix |
|---|---|---|
| 01-voltage-divider | NO (artifacts stale) | NO (artifacts stale) - unchanged |
| 02-charlieplex-led | YES | YES - unchanged |
| 03-usb-joystick | NO (routed PCB stale: 13 sch / 16 PCB) | NO (routed PCB stale: 13 sch / 16 PCB) - **real drift preserved** |
| 04-stm32-devboard | NO (routed PCB stale: 10 sch / 12 PCB) | NO (incomplete routing 1/12 nets) - **drift false-positive cleared**, surfaces pre-existing NRST advisory |
| 05-bldc-motor-controller | NO (routed PCB stale: 51 sch / 40 PCB) | NO (routed PCB stale: 51 sch / 40 PCB) - **real drift preserved** |
| 06-diffpair-test | NO (incomplete routing 4/26) | NO (incomplete routing 4/26) - unchanged |
| 07-matchgroup-test | NO (incomplete routing 4/34) | NO (incomplete routing 4/34) - unchanged |

Board 04 now correctly shows its pre-existing ``incomplete routing
(1/12 nets)`` blocker (the NRST advisory connectivity that
``scripts/ci/check_routed_drc.py`` and
``.github/routed-drc-tolerance.yml`` already classify as advisory). The
``Ship?=YES`` AC item for board 04 in the original issue depends on a
separate fix to the routing-completion gate (or running the NRST
advisory through the same tolerance YAML as DRC); that is out of scope
for #3302 per the issue's "Out of scope" section.

Boards 03 and 05 continue to report real drift (3 and 14 non-alias
deltas respectively, both above the tolerance threshold). Boards 02,
06, 07 stay unchanged.

## Test plan

- [x] ``uv run pytest tests/test_fleet_status*.py tests/test_fleet_ship_ready.py`` (61 passed)
- [x] New test ``test_power_rail_alias_not_flagged`` covers ``+3V3`` vs ``+3.3V`` (AC item 1)
- [x] New test ``test_two_unlabeled_local_nets_not_flagged`` covers board-04's ``BOOT0`` / ``LED_K`` synthesis case (AC item 2)
- [x] New test ``test_board03_style_three_adds_still_flagged`` is the PR #3289 regression guard (AC: real adds still surface)
- [x] New test ``test_removal_always_flagged`` ensures sub-threshold tolerance never masks a removed schematic label
- [x] New unit test ``test_canonicalize_power_net_unit`` directly exercises the alias table
- [x] Existing ``TestFleetStatusSourceDrift`` (5 tests) updated for the new tolerance and continue to pass
- [x] Live fleet status on the in-repo board set confirms board 04 cleared while boards 03 and 05 still flag

## JSON schema

No schema bump. The ``schematic_net_count`` / ``pcb_net_count`` keys
remain the raw (pre-canonicalisation) set sizes for back-compat with
existing consumers. The blocker text format is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)