### PR TITLE
fix(router): use layer_to_index for C++ A* goal layer (closes #3304)

### DIFF
--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -1210,11 +1210,40 @@ class CppPathfinder:
         start_layer = self._grid.num_layers // 2  # Default to middle
         end_layer = self._grid.num_layers // 2
 
-        # Try to get actual layer from pad
+        # Try to get actual layer from pad.
+        #
+        # Issue #3304: Use the grid's ``layer_to_index`` mapping rather than
+        # ``layer.value % num_layers``.  The modulo trick happens to give
+        # the correct index for ``F.Cu`` (value=0) and for B.Cu only on
+        # 6-layer stacks (5 % 6 == 5).  For ALL other layer counts it
+        # produces the WRONG index for ``B.Cu`` (value=5):
+        #
+        #   - 2-layer: 5 % 2 = 1 ✓ (also happens to be correct)
+        #   - 4-layer: 5 % 4 = 1 ✗ (should be 3; In1.Cu picked instead)
+        #   - 6-layer: 5 % 6 = 5 ✓
+        #
+        # On 4-layer boards this caused the C++ A* to terminate on
+        # ``In1.Cu`` (the wrongly-mapped goal layer) whenever the
+        # destination virtual_pad was on ``B.Cu`` (the inner escape layer
+        # the 4L SIG-GND-PWR-SIG stack falls back to when no inner SIGNAL
+        # layers are present in ``_select_inner_escape_layer``).  The
+        # escape route lays its inner stub on B.Cu but the main router
+        # ends on In1.Cu -- they share an XY but no via bridges the layer
+        # gap, so the union-find connectivity check counts the pad as
+        # disconnected.  This was the root cause of the board 03
+        # USB_CC2 regression after #3278 narrowed the escape stub: the
+        # narrower stub stops blocking the main router's path so the
+        # A* now finds the wrong-layer goal cell instead of failing
+        # and falling back to a path that ends correctly.
+        #
+        # The ``layer_to_index`` lookup is what
+        # :meth:`Router.route` in ``pathfinder.py`` already uses
+        # (line 2348), so this brings the C++ backend into parity with
+        # the Python reference path.
         if hasattr(start.layer, "value"):
-            start_layer = start.layer.value % self._grid.num_layers
+            start_layer = self._grid.layer_to_index(start.layer.value)
         if hasattr(end.layer, "value"):
-            end_layer = end.layer.value % self._grid.num_layers
+            end_layer = self._grid.layer_to_index(end.layer.value)
 
         # Compute start/end layers for through-hole pads if not provided
         # Through-hole pads can be accessed on any routable layer
@@ -1943,7 +1972,11 @@ class CppPathfinder:
         end_gx, end_gy = self._grid._impl.world_to_grid(end.x, end.y)
 
         if layer is None:
-            layer = start.layer.value % self._grid.num_layers
+            # Issue #3304: use ``layer_to_index`` not ``layer.value %
+            # num_layers``.  See the comment in ``_route_impl`` for the
+            # full explanation of why the modulo trick mismaps B.Cu to
+            # an inner layer on 4-layer stacks.
+            layer = self._grid.layer_to_index(start.layer.value)
 
         # Trace a direct line from start to end using Bresenham's algorithm
         gx1, gy1 = start_gx, start_gy

--- a/tests/router/test_board03_routing_baseline.py
+++ b/tests/router/test_board03_routing_baseline.py
@@ -7,13 +7,14 @@ June 2026.
 Baseline measurement at HEAD (with ``kct route --backend cpp --seed 42
 --auto-fix --auto-fix-passes 2 --manufacturer jlcpcb-tier1``):
 
-- **Routed: 10/13 nets (77%)** post-#3278 escape contract correction
-  (PR #3300).  USB_D+, USB_D-, and USB_CC2 are partial.
-- **Layer count: 2** (the 2-layer attempt produces the best result)
+- **Routed: 11/13 nets (85%)** post-#3278 (PR #3300) and post-#3304
+  (this ratchet).  USB_D+ and USB_D- remain partial.
+- **Layer count: 4** (the 4-layer attempt produces the best result)
 - USB_D+ / USB_D- partial due to escape-geometry interactions with J1's
-  USB-C connector pad layout.  USB_CC2 regressed from 2/2 -> 1/2 pads
-  after the per-pad escape width fix shifted the main-router channel
-  topology — downstream gap tracked in #3304.
+  USB-C connector pad layout.  USB_CC2 recovered from 1/2 -> 2/2 pads
+  via the #3304 C++ backend layer-index fix (B.Cu was being mismapped
+  to In1.Cu on 4L stacks because of a ``layer.value % num_layers``
+  shortcut in ``_route_impl``).
 - The committed unrouted PCB has 16 nets total: 13 are routed, 3 are
   power/pour nets (VCC, VBUS, GND) that are skipped by the router and
   served by auto-pour zones instead.
@@ -28,46 +29,47 @@ Context (the "1/16" myth):
 June 7 2026 re-measurement (issue #3293):
     Re-measured after #3278 landed via PR #3300.  The fix was the
     primary blocker we expected to recover the 11/13 (or better)
-    floor, but it actually produced 10/13: the structural
+    floor, but it initially produced 10/13: the structural
     per-pad escape width fix corrected USB_D+/D- escape geometry,
-    but the new A* channel topology around J1 caused USB_CC2 to
-    regress from 2/2 -> 1/2 pads (now tracked under #3304).  Net
-    delta on board 03: 11/13 -> 10/13.  The committed routed PCB
+    but a long-latent C++ backend layer-index mismapping caused
+    USB_CC2 to regress from 2/2 -> 1/2 pads.  Issue #3304
+    diagnosed the mismapping (B.Cu mapped to In1.Cu on 4L stacks
+    via ``layer.value % num_layers``) and the fix recovered the
+    11/13 floor.  The committed routed PCB
     (``output/usb_joystick_routed.kicad_pcb``, last updated by PR
     #3195 on June 4) is still STRICTLY BETTER at 12/13 with 4 DRC
-    errors on jlcpcb-tier1.  We do NOT regenerate the committed PCB
-    on the June 7 refresh because doing so would overwrite the
-    better-quality 12/13 state with the current 10/13 floor.  The
-    route_demo.py vs ``kct route`` reach divergence is tracked in
-    issue #3308.
+    errors on jlcpcb-tier1.  The route_demo.py vs ``kct route``
+    reach divergence is tracked in issue #3308.
 
-Manufacturability verdict (June 7 2026):
-    Board 03 is NOT JLCPCB-tier1 ship-ready.  Even with #3278
-    landed (via PR #3300), a fresh route at HEAD produces only
-    10/13 nets (USB_D+, USB_D-, USB_CC2 partial).  The committed
-    routed PCB (the strictly better artifact we ship today) carries
+Manufacturability verdict (June 7 2026, post-#3304):
+    Board 03 is NOT JLCPCB-tier1 ship-ready.  After #3304's
+    C++ backend layer-index fix, a fresh route at HEAD produces
+    11/13 nets (USB_D+, USB_D- partial).  The committed routed
+    PCB (the strictly better artifact we ship today) carries
     4 DRC errors on jlcpcb-tier1:
       - 1 USB_D+ stranded pad
       - 1 diffpair_clearance_intra (USB_D+/USB_D-)
       - 1 clearance_segment_via
       - 1 clearance_pad_via
-    Recovering ship-ready will require fixing the USB_CC2
-    main-router regression (#3304) AND closing out the remaining
-    USB_D+/USB_D- partial routes (#3308 for the route_demo
-    divergence in the meantime).
+    Recovering ship-ready will require closing out the remaining
+    USB_D+/USB_D- partial routes (escape-geometry interactions
+    with J1's USB-C row -- separate work; #3308 for the
+    route_demo divergence in the meantime).
 
 Known follow-on issues that prevent a higher baseline:
     - **#3278** (closed by PR #3300): Escape generator used
       ``pads[0].net_name``'s net-class trace width for the whole
       row, pulling Power-class 0.5mm width into USB_D+/USB_D-
       HighSpeed escapes.  Fixed by per-pad ``escape_width``.
-      Landing it produced 10/13 (NOT the hoped-for 13/13) because
-      the corrected escapes shifted the main-router A* channel
-      topology and USB_CC2 regressed.
-    - **#3304**: Post-#3278 main-router gap — corrected escape
-      geometry shifts the A* channel topology near J1 and USB_CC2
-      regressed from 2/2 -> 1/2 pads.  Will ratchet the floor back
-      to 11 (or 12+) once USB_CC2 is recovered.
+    - **#3304** (THIS RATCHET): The C++ backend's ``_route_impl``
+      computed search-time goal layer as
+      ``end.layer.value % num_layers``.  For ``B.Cu`` (value=5)
+      on a 4L stack (num_layers=4), this gave index 1 (In1.Cu)
+      instead of 3 (B.Cu).  The narrower post-#3278 escape stub
+      stopped blocking the main router's path so the A* found
+      the wrong-layer goal cell.  Replaced with the canonical
+      ``self._grid.layer_to_index`` lookup that
+      ``Router.route`` in ``pathfinder.py`` already used.
     - **#3279**: 2-layer boards with GND pour on B.Cu have no
       pipeline step to stitch F.Cu SMD GND pads to the pour, so
       ``kct check`` reports ``Net 'GND' is partially routed: 26 of 29
@@ -82,10 +84,12 @@ Known follow-on issues that prevent a higher baseline:
 
 Acceptance criteria pinned by this test:
 
-1. **Reach floor**: ``kct route`` produces >= 10 routed signal nets
-   (out of 13).  Drops to 9 or fewer indicate a routing-quality
+1. **Reach floor**: ``kct route`` produces >= 11 routed signal nets
+   (out of 13).  Drops to 10 or fewer indicate a routing-quality
    regression on USB-C-class pad-density boards.  The floor was
-   temporarily relaxed from 11 to 10 by PR #3300 pending #3304.
+   temporarily relaxed from 11 to 10 by PR #3300 then ratcheted
+   back to 11 by the PR that closes #3304 (C++ backend layer-
+   index mismapping fix).
 2. **Deterministic across seeds**: seeds 1 / 42 / 99 all produce the
    same routed-net count, so a single-seed run is a reliable
    indicator of overall quality.
@@ -133,12 +137,24 @@ COMMITTED_ROUTED_PCB = BOARD_DIR / "output" / "usb_joystick_routed.kicad_pcb"
 # Post-#3278 escape contract correction (landed via PR #3300): the
 # per-pad ``escape_width`` fix corrected fine-pitch HighSpeed escapes
 # (USB_D+ improved 1/3 -> 2/3 pads), but the main router's A* path-finder
-# now sees a different B.Cu channel topology around J1 and regressed
-# USB_CC2 from 2/2 -> 1/2 pads.  Net delta on board 03: 11/13 -> 10/13.
-# The structural escape fix is correct and stays; the downstream
-# main-router gap is tracked in #3304 and will ratchet this floor back
-# to 11 (or 12+) once USB_CC2 is recovered.
-REQUIRED_NETS_ROUTED = 10
+# initially saw a different B.Cu channel topology around J1 and regressed
+# USB_CC2 from 2/2 -> 1/2 pads (10/13 fresh-route reach).
+#
+# Issue #3304 (THIS RATCHET): the regression was traced to a layer-
+# index mismapping in the C++ backend's ``_route_impl`` -- when a
+# destination virtual-pad sat on ``B.Cu`` (the inner-escape-layer
+# fallback the 4L SIG-GND-PWR-SIG stack picks when no inner SIGNAL
+# layer exists), the C++ A* used ``layer.value % num_layers`` to
+# compute the goal layer.  For B.Cu (enum value=5) on a 4L stack
+# (num_layers=4), the modulo gave index 1 (In1.Cu) instead of the
+# correct index 3 (B.Cu).  The A* then terminated on In1.Cu, the
+# escape stub laid down on B.Cu, and the union-find connectivity
+# check saw the pad as disconnected.  Replacing the modulo with
+# the canonical ``self._grid.layer_to_index`` lookup restores
+# USB_CC2 to 2/2 pads and lifts board 03 to 11/13.  USB_D+ /
+# USB_D- still defer to the main router due to escape-geometry
+# interactions with J1's USB-C row (separate work).
+REQUIRED_NETS_ROUTED = 11
 EXPECTED_TOTAL_NETS = 13
 
 # Committed-PCB ceiling pinned by the June 7 2026 measurement.  The
@@ -263,16 +279,16 @@ class TestBoard03RoutingBaseline:
     """
 
     def test_reach_meets_floor(self, route_stdout: str) -> None:
-        """``kct route --backend cpp`` produces at least 10/13 nets routed.
+        """``kct route --backend cpp`` produces at least 11/13 nets routed.
 
-        This is the post-#3278 baseline (PR #3300 corrected the per-pad
-        escape width).  USB_D+/USB_D- still defer to the main router due
-        to escape geometry on J1, and USB_CC2 regressed from 2/2 -> 1/2
-        pads after the corrected escapes shifted the channel topology.
-        Floor temporarily relaxed 11 -> 10 pending #3304.  A regression
-        below 10 means the router lost further ground on a USB-C-class
-        board — bisect against escape / diff-pair / negotiated-loop
-        changes.
+        This is the post-#3278 / post-#3304 baseline (PR #3300 corrected
+        the per-pad escape width; #3304 fixed the C++ backend layer-
+        index mismapping that prevented USB_CC2 from re-connecting).
+        USB_D+/USB_D- still defer to the main router due to escape
+        geometry on J1.  A regression below 11 means the router lost
+        ground on a USB-C-class board -- bisect against escape /
+        diff-pair / negotiated-loop changes and the layer_to_index
+        invariant in ``tests/router/test_cpp_backend_layer_mapping.py``.
         """
         parsed = _parse_routed_net_count(route_stdout)
         assert parsed is not None, (
@@ -291,11 +307,12 @@ class TestBoard03RoutingBaseline:
         assert routed >= REQUIRED_NETS_ROUTED, (
             f"Board 03 routing reach regressed: routed {routed}/{total}, "
             f"expected >= {REQUIRED_NETS_ROUTED}/{EXPECTED_TOTAL_NETS} "
-            "(post-#3278 baseline; floor relaxed pending #3304).  Common "
-            "regression sources to bisect:\n"
+            "(post-#3278 / post-#3304 baseline).  Common regression "
+            "sources to bisect:\n"
             "  - escape clearance / lateral_offset changes for USB-C "
-            "(escape contract is post-#3278; see #3304 for the "
-            "main-router downstream gap)\n"
+            "(escape contract is post-#3278)\n"
+            "  - C++ backend layer-index mapping in ``_route_impl`` "
+            "(post-#3304; should use ``layer_to_index`` not modulo)\n"
             "  - negotiated-loop rip-up policy on BLOCKED_BY_COMPONENT\n"
             "  - per-pad channel budget for J1's 12 SMT signal pads\n"
             "  - any change to ``_create_intra_ic_routes`` that affects "
@@ -329,7 +346,7 @@ class TestBoard03RoutingBaseline:
 
 @pytest.mark.slow
 def test_routing_reach_deterministic_across_seeds(unrouted_pcb_path: Path) -> None:
-    """The same reach (10/13) is produced for seeds 1, 42, and 99.
+    """The same reach (11/13) is produced for seeds 1, 42, and 99.
 
     The negotiated A* router uses the global seed for tie-breaks during
     A* and for the rip-up selection in BLOCKED_BY_COMPONENT.  For a

--- a/tests/router/test_cpp_backend_layer_mapping.py
+++ b/tests/router/test_cpp_backend_layer_mapping.py
@@ -1,0 +1,121 @@
+"""C++ backend pad-layer-to-index mapping invariant.
+
+Issue #3304: The C++ ``_route_impl`` (and the legacy
+``find_blocking_nets`` Bresenham path) historically computed the
+search-time start/end layer index as ``pad.layer.value % num_layers``.
+The modulo trick works for ``F.Cu`` (value=0 maps to index 0 on every
+stack) and for ``B.Cu`` only on 6-layer stacks (5 % 6 == 5), but it
+mismaps ``B.Cu`` on every other layer count:
+
+  - 2-layer: 5 % 2 == 1  ✓ (also correct)
+  - 4-layer: 5 % 4 == 1  ✗ (should be 3; B.Cu is at index 3)
+  - 6-layer: 5 % 6 == 5  ✓
+
+On 4-layer boards the bug made the A* terminate on ``In1.Cu`` (index 1)
+whenever the destination virtual-pad was on ``B.Cu``.  The escape route
+laid its inner stub on B.Cu but the main router ended on In1.Cu --
+same XY, different layer, no via to bridge the gap.  The union-find
+connectivity check then counted the pad as disconnected.
+
+This test pins the invariant: for every supported layer stack, the
+mapping the C++ backend uses (``self._grid.layer_to_index`` after the
+#3304 fix) must agree with the Python pathfinder's mapping (the
+canonical reference at ``pathfinder.py`` line 2348) and must NOT
+produce the wrong index for ``B.Cu`` on 4-layer boards.
+
+The board-03 regression test (``test_board03_routing_baseline.py``)
+covers the end-to-end behavioural consequence; this test pins the
+underlying invariant so future refactors of the layer-indexing path
+do not silently re-introduce the modulo-arithmetic regression.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.rules import DesignRules
+
+
+_STACKS = [
+    ("two_layer", LayerStack.two_layer()),
+    ("four_layer_sig_gnd_pwr_sig", LayerStack.four_layer_sig_gnd_pwr_sig()),
+    ("four_layer_all_signal", LayerStack.four_layer_all_signal()),
+    ("six_layer_sig_gnd_sig_sig_pwr_sig",
+     LayerStack.six_layer_sig_gnd_sig_sig_pwr_sig()),
+]
+
+
+@pytest.mark.parametrize("stack_name,stack", _STACKS)
+def test_b_cu_maps_to_outer_bottom_index(stack_name, stack):
+    """``B.Cu`` always maps to the LAST grid index on every stack.
+
+    This is the invariant the modulo-arithmetic regression
+    (``B.Cu.value % num_layers``) violated on 4-layer boards.
+    """
+    rules = DesignRules()
+    grid = RoutingGrid(width=60, height=40, rules=rules, layer_stack=stack)
+    expected_index = stack.num_layers - 1
+    actual_index = grid.layer_to_index(Layer.B_CU.value)
+    assert actual_index == expected_index, (
+        f"On stack {stack_name!r} (num_layers={stack.num_layers}), "
+        f"B.Cu should map to grid index {expected_index} (the last layer) "
+        f"but layer_to_index gave {actual_index}.  This is the index the "
+        f"C++ A* search uses as end_layer when the destination virtual-pad "
+        f"sits on B.Cu (the inner-escape-layer fallback the escape "
+        f"generator picks when no inner SIGNAL layer is available)."
+    )
+
+
+@pytest.mark.parametrize("stack_name,stack", _STACKS)
+def test_f_cu_maps_to_index_zero(stack_name, stack):
+    """``F.Cu`` always maps to grid index 0 (the first / top outer layer)."""
+    rules = DesignRules()
+    grid = RoutingGrid(width=60, height=40, rules=rules, layer_stack=stack)
+    actual_index = grid.layer_to_index(Layer.F_CU.value)
+    assert actual_index == 0, (
+        f"On stack {stack_name!r}, F.Cu should map to grid index 0 "
+        f"but layer_to_index gave {actual_index}."
+    )
+
+
+def test_modulo_trick_disagrees_with_layer_to_index_on_4l():
+    """Document the divergence the #3304 fix closes.
+
+    The historical ``layer.value % num_layers`` shortcut produced index
+    ``1`` (In1.Cu's slot in the 4L SIG-GND-PWR-SIG stack) when the
+    correct answer is ``3`` (B.Cu's slot).  This test pins the
+    regression scenario so future readers can locate the bug-and-fix
+    pair in code archaeology without needing to bisect.
+    """
+    stack = LayerStack.four_layer_sig_gnd_pwr_sig()
+    rules = DesignRules()
+    grid = RoutingGrid(width=60, height=40, rules=rules, layer_stack=stack)
+
+    modulo_index = Layer.B_CU.value % grid.num_layers
+    correct_index = grid.layer_to_index(Layer.B_CU.value)
+
+    assert modulo_index == 1
+    assert correct_index == 3
+    assert modulo_index != correct_index, (
+        "If this assertion ever fires it means the modulo shortcut "
+        "and ``layer_to_index`` have come back into accidental "
+        "agreement on 4L SIG-GND-PWR-SIG -- delete this test, but "
+        "first verify the test_b_cu_maps_to_outer_bottom_index "
+        "parametrization above is still passing for ALL stacks."
+    )
+
+
+@pytest.mark.parametrize("stack_name,stack", _STACKS)
+def test_inner_layer_round_trip(stack_name, stack):
+    """For 4L/6L stacks, ``In1.Cu`` maps to a non-zero, non-outer index."""
+    if stack.num_layers < 3:
+        pytest.skip("Inner layers don't exist on 2-layer stacks")
+    rules = DesignRules()
+    grid = RoutingGrid(width=60, height=40, rules=rules, layer_stack=stack)
+    in1_index = grid.layer_to_index(Layer.IN1_CU.value)
+    assert 0 < in1_index < stack.num_layers - 1, (
+        f"On stack {stack_name!r}, In1.Cu should be an INNER layer "
+        f"(index strictly between 0 and {stack.num_layers - 1}); got {in1_index}."
+    )


### PR DESCRIPTION
## Summary

Recovers board 03 USB_CC2 connectivity that regressed after PR #3300 (closes #3278).  Root cause was a long-latent C++ backend layer-index mismapping that PR #3300's narrower escape stub made manifest.

## Before / after measurement on board 03

Recipe: `kct route boards/03-usb-joystick/output/usb_joystick.kicad_pcb --backend cpp --seed 42 --auto-fix --auto-fix-passes 2 --manufacturer jlcpcb-tier1`

| Metric | Pre-#3304 (post-#3300) | Post-#3304 (this PR) | Delta |
|---|---|---|---|
| Nets routed | **10/13 (77%)** | **11/13 (85%)** | +1 |
| USB_CC2 | 1/2 pads (partial) | **2/2 pads (connected)** | recovered |
| USB_D+ | 2/3 pads (partial) | 2/3 pads (partial) | unchanged |
| USB_D- | 1/3 pads (partial) | 1/3 pads (partial) | unchanged |

USB_D+ / USB_D- partial routes are escape-geometry interactions with J1's USB-C row -- separate work outside this PR's scope.

## Root cause

The C++ backend's `_route_impl` historically computed the search-time start / end layer index as:

```python
end_layer = end.layer.value % self._grid.num_layers
```

The modulo trick gives the correct index for `F.Cu` (value=0) and for `B.Cu` only on 6-layer stacks (`5 % 6 == 5`), but mismaps `B.Cu` on every other layer count:

| Layers | `B.Cu.value % num_layers` | Correct index | Result |
|---|---|---|---|
| 2 | `5 % 2 == 1` | 1 | coincidentally correct |
| **4** | **`5 % 4 == 1`** | **3** | **WRONG -- In1.Cu picked instead of B.Cu** |
| 6 | `5 % 6 == 5` | 5 | correct |

On 4-layer boards the C++ A* terminated on `In1.Cu` (the wrongly-mapped goal layer) whenever the destination virtual_pad sat on `B.Cu` -- the inner-escape-layer fallback `_select_inner_escape_layer` picks under the `four_layer_sig_gnd_pwr_sig` stack (where neither inner layer is `LayerType.SIGNAL`).  The escape route's inner stub laid down on `B.Cu`, the main router ended on `In1.Cu`, and they shared an XY but no via bridged the layer gap.  The union-find connectivity check then counted the pad as disconnected.

## Why now (post-#3278)?

PR #3300 (closes #3278) narrowed the per-pad escape stub on J1's USB-C row from the row's worst-case 0.5mm Power width to each pad's own net-class width (0.2mm for USB_CC2).  The narrower stub stopped blocking the main router's path so the A* started finding the wrong-layer goal cell instead of failing and falling back to a route that ended correctly.  Board 03's USB_CC2 went 2/2 -> 1/2 pads as a result, even though the escape contract was correct.

## Fix

Replace the `pad.layer.value % num_layers` shortcut with the canonical `self._grid.layer_to_index(pad.layer.value)` lookup that `Router.route` in `pathfinder.py` (line 2348) already used.  Same change applied at the three modulo sites inside `cpp_backend.py`:

1. `_route_impl` `start_layer` / `end_layer` (the load-bearing fix)
2. `find_blocking_nets` default `layer` for the Bresenham direct-path trace (defensive parity)

Does NOT touch escape.py per-pad width logic from PR #3300 (the structural escape contract stays).

## Test plan

- [x] New unit test `tests/router/test_cpp_backend_layer_mapping.py` pins the invariant: `B.Cu` always maps to the LAST grid index on every supported stack (2L / 4L SIG-GND-PWR-SIG / 4L ALL-SIG / 6L).  Also documents the divergence the fix closes.
- [x] `tests/router/test_board03_routing_baseline.py` ratcheted `REQUIRED_NETS_ROUTED` 10 -> 11.  `test_reach_meets_floor` PASSES at 11/13.
- [x] `tests/router/test_fine_pitch_row_per_pad_width.py` (the #3278 contract): PASSES (5/5).
- [x] `tests/router/test_usb_c_fine_pitch.py`: PASSES (13/13).
- [x] `tests/router/test_escape_pad_layer_overrides.py`: PASSES (7/7).
- [x] `tests/router/test_negotiated_ripup.py`: PASSES (8/8).
- [x] `tests/router/test_astar_tiebreak_determinism.py`: PASSES (10/10).
- [x] `tests/router/test_board02_manufacturable_baseline.py`: PASSES (3/3).
- [x] Softstart slow regression (`KICAD_RUN_SLOW_SOFTSTART_REACH=1`): all 3 PASSES.
- [x] Full router test suite (excluding multi-minute slow tests): 230 passed, 1 skipped.

Closes #3304

🤖 Generated with [Claude Code](https://claude.com/claude-code)