### PR TITLE
fix(router): forward --timeout to CoupledPathfinder pre-pass (Closes #3321)

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -7339,10 +7339,17 @@ def main(argv: list[str] | None = None) -> int:
                         # etc.) fall through to the main strategy
                         # rather than being half-routed independently
                         # and then skipped.  Issue #2464.
+                        # Issue #3321: forward --timeout so the diff-pair
+                        # pre-pass derives a per-pair budget when the user
+                        # has not opted in via --diffpair-per-pair-timeout.
+                        # Without this, the CoupledPathfinder could peg
+                        # CPU for >40min on board 07's MIPI lanes despite
+                        # --timeout being set.
                         result, dp_warnings = router.route_all_with_diffpairs(
                             diffpair_config,
                             non_diffpair_strategy=_phase2_strategy,
                             coupled_only=(args.strategy == "negotiated"),
+                            timeout=_budgeted_timeout(args),
                         )
                         diffpair_warnings.extend(dp_warnings)
                         return result
@@ -7467,10 +7474,14 @@ def main(argv: list[str] | None = None) -> int:
                         best_stall_patience=(getattr(args, "early_stop_patience", 2) or None),
                     )
 
+                # Issue #3321: forward --timeout so the diff-pair
+                # pre-pass derives a per-pair budget when the user
+                # has not opted in via --diffpair-per-pair-timeout.
                 result, dp_warnings = router.route_all_with_diffpairs(
                     diffpair_config,
                     non_diffpair_strategy=_neg_strategy,
                     coupled_only=True,
+                    timeout=_budgeted_timeout(args),
                 )
                 diffpair_warnings.extend(dp_warnings)
                 return result
@@ -7499,7 +7510,13 @@ def main(argv: list[str] | None = None) -> int:
                     best_stall_patience=(getattr(args, "early_stop_patience", 2) or None),
                 )
             elif args.differential_pairs and args.strategy == "basic":
-                result, dp_warnings = router.route_all_with_diffpairs(diffpair_config)
+                # Issue #3321: forward --timeout so the diff-pair pre-pass
+                # derives a per-pair budget when the user has not opted in
+                # via --diffpair-per-pair-timeout.
+                result, dp_warnings = router.route_all_with_diffpairs(
+                    diffpair_config,
+                    timeout=_budgeted_timeout(args),
+                )
                 diffpair_warnings.extend(dp_warnings)
                 return result
             elif args.bus_routing and args.strategy == "basic":

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -10523,6 +10523,7 @@ class Autorouter:
         net_order: list[int] | None = None,
         non_diffpair_strategy: object = None,
         coupled_only: bool = False,
+        timeout: float | None = None,
     ) -> tuple[list[Route], list[LengthMismatchWarning]]:
         """Route all nets with differential pair-aware routing.
 
@@ -10536,12 +10537,57 @@ class Autorouter:
                 routes pairs that the CoupledPathfinder can handle (no
                 fall-back to independent routing); pairs that fall through
                 are deferred to the main strategy.
+            timeout: Issue #3321: Optional total wall-clock budget (seconds)
+                for the entire diff-pair pre-pass.  When set AND
+                ``diffpair_config.per_pair_timeout`` is not explicitly
+                configured, a per-pair budget is auto-derived as
+                ``min(timeout * 0.3, 60.0)`` (capped at 60s, never less
+                than 5s).  This guarantees that a CLI caller passing
+                ``--timeout 600`` without ``--diffpair-per-pair-timeout``
+                still gets a bounded CoupledPathfinder, preventing the
+                pathological >40min CPU peg observed on board 07's MIPI
+                lanes.  Pairs that exceed the derived budget fall through
+                to the negotiated single-ended router via the standard
+                budget-exit path (see ``route_all_with_diffpairs`` in
+                ``diffpair_routing.py``).  When ``None`` (default) the
+                legacy unbounded behaviour is preserved for back-compat.
         """
+        # Issue #3321: derive a per-pair budget from --timeout when the
+        # caller has not explicitly configured one.  This protects the
+        # CoupledPathfinder from running unbounded just because the CLI's
+        # --diffpair-per-pair-timeout is unset.  The derivation matches
+        # the rationale in the issue: at most 30 % of the overall
+        # routing budget per pair, capped at 60 s (the per-pair search
+        # tail rarely needs more), and floored at 5 s (so the budget
+        # cannot collapse to a trivially short value that aborts every
+        # pair unnecessarily when --timeout is tiny).
+        derived_per_pair_timeout: float | None = None
+        if (
+            timeout is not None
+            and timeout > 0
+            and diffpair_config is not None
+            and diffpair_config.enabled
+            and diffpair_config.per_pair_timeout is None
+        ):
+            derived_per_pair_timeout = max(5.0, min(float(timeout) * 0.3, 60.0))
+            # AUTOFIX_SKIPPED-style structured signal (PR #3247 pattern):
+            # surface the auto-derivation so log readers can distinguish
+            # explicit configuration from default fallback when triaging
+            # diff-pair routing behaviour.
+            logger.info(
+                "DIFFPAIR_PER_PAIR_TIMEOUT_AUTODERIVED: --timeout=%.1fs but "
+                "--diffpair-per-pair-timeout unset; deriving per-pair budget "
+                "of %.1fs to bound CoupledPathfinder (issue #3321)",
+                float(timeout),
+                derived_per_pair_timeout,
+            )
+
         result = self._diffpair.route_all_with_diffpairs(
             diffpair_config,
             net_order,
             non_diffpair_strategy=non_diffpair_strategy,
             coupled_only=coupled_only,
+            per_pair_timeout=derived_per_pair_timeout,
         )
 
         # Issue #3040 Phase B: rip-up and retry any pairs whose coupled

--- a/tests/test_router_core_diffpair_timeout.py
+++ b/tests/test_router_core_diffpair_timeout.py
@@ -1,0 +1,305 @@
+"""Tests for Issue #3321: ``Autorouter.route_all_with_diffpairs`` honours
+``--timeout`` and auto-derives a per-pair budget for the CoupledPathfinder.
+
+Background: prior to #3321 the top-level
+``Autorouter.route_all_with_diffpairs`` had no ``timeout`` parameter, so
+the CLI's ``--timeout`` flag never reached the diff-pair pre-pass even
+when the recipe set it.  On board 07 (matchgroup-test) this caused
+``CoupledPathfinder`` to peg CPU at 99.7 % for >40 minutes when
+``--differential-pairs --timeout 600`` was supplied: the per-pair
+coupled A* never self-aborted because ``per_pair_timeout`` was ``None``
+and there was no upstream budget.
+
+Issue #3275 (board 07 differential-pairs re-enable) is blocked on this
+infrastructure -- the wager can only be evaluated once the pre-pass is
+bounded.
+
+The contract this test suite pins:
+
+1. ``timeout`` is accepted as a kwarg on
+   ``Autorouter.route_all_with_diffpairs`` with default ``None`` so
+   back-compat is preserved (the legacy CoupledPathfinder behaviour is
+   unbounded when neither ``--timeout`` nor
+   ``--diffpair-per-pair-timeout`` is supplied).
+2. When ``timeout`` is set AND ``diffpair_config.per_pair_timeout`` is
+   ``None``, the inner ``DiffPairRouter.route_all_with_diffpairs`` is
+   invoked with a derived ``per_pair_timeout`` equal to
+   ``max(5.0, min(timeout * 0.3, 60.0))``.
+3. When ``timeout`` is set AND ``diffpair_config.per_pair_timeout`` is
+   ALSO set, the explicit config wins (no override; the user's
+   ``--diffpair-per-pair-timeout`` takes precedence).
+4. When ``timeout`` is ``None`` (legacy CLI invocation), the inner
+   router is invoked with ``per_pair_timeout=None`` -- back-compat.
+5. The CLI ``route`` command actually passes ``_budgeted_timeout(args)``
+   to the top-level method at every diff-pair callsite (regression
+   guard against future refactors that drop the kwarg).
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import MagicMock, patch
+
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.diffpair import DifferentialPairConfig
+
+
+# ---------------------------------------------------------------------------
+# Signature surface
+# ---------------------------------------------------------------------------
+
+
+def test_autorouter_route_all_with_diffpairs_accepts_timeout_kwarg():
+    """The top-level entry point exposes a ``timeout`` parameter."""
+    sig = inspect.signature(Autorouter.route_all_with_diffpairs)
+    assert "timeout" in sig.parameters, (
+        "Autorouter.route_all_with_diffpairs must accept a 'timeout' "
+        "kwarg so the CLI's --timeout reaches the CoupledPathfinder "
+        "(issue #3321)."
+    )
+
+
+def test_autorouter_route_all_with_diffpairs_timeout_default_is_none():
+    """Back-compat: the default must be ``None`` so existing callers
+    that do not pass ``timeout`` see unchanged behaviour."""
+    sig = inspect.signature(Autorouter.route_all_with_diffpairs)
+    assert sig.parameters["timeout"].default is None
+
+
+# ---------------------------------------------------------------------------
+# Forwarding semantics: how the timeout reaches the inner router
+# ---------------------------------------------------------------------------
+
+
+def _make_autorouter_stub() -> Autorouter:
+    """Build a minimal ``Autorouter`` instance for unit-testing the
+    diff-pair forwarding logic without running the real router.
+
+    We bypass ``__init__`` because instantiating ``Autorouter`` requires
+    a full board state; the methods under test only touch ``_diffpair``
+    and ``_diffpair_router``, both of which we stub.
+    """
+    router = Autorouter.__new__(Autorouter)
+    router._diffpair_router = None
+    # ``self._diffpair`` is a @property that lazy-inits the router.
+    # We stub the inner router directly so the property never fires.
+    inner = MagicMock()
+    inner.route_all_with_diffpairs = MagicMock(return_value=([], []))
+    inner.intra_clearance_violations = MagicMock(return_value=[])
+    inner.repair_intra_clearance_violations = MagicMock()
+    router._diffpair_router = inner
+
+    # ``_finalize_routing`` runs after the inner call; stub it.
+    router._finalize_routing = MagicMock()
+    return router
+
+
+def test_timeout_derives_per_pair_budget_when_config_is_unset():
+    """When ``timeout=600`` and ``per_pair_timeout`` is unset, the inner
+    router must receive a derived budget of ``min(600*0.3, 60) = 60.0``."""
+    router = _make_autorouter_stub()
+    cfg = DifferentialPairConfig(enabled=True)
+    assert cfg.per_pair_timeout is None  # precondition
+
+    router.route_all_with_diffpairs(cfg, timeout=600.0)
+
+    inner = router._diffpair_router
+    inner.route_all_with_diffpairs.assert_called_once()
+    kwargs = inner.route_all_with_diffpairs.call_args.kwargs
+    assert "per_pair_timeout" in kwargs
+    # 600 * 0.3 = 180, capped at 60.
+    assert kwargs["per_pair_timeout"] == 60.0
+
+
+def test_timeout_derived_budget_floored_at_5s_for_tiny_timeout():
+    """For very small ``--timeout`` values (e.g. 10 s) the derived
+    per-pair budget must not collapse below 5 s, otherwise every pair
+    would abort before A* gets a chance to converge."""
+    router = _make_autorouter_stub()
+    cfg = DifferentialPairConfig(enabled=True)
+
+    router.route_all_with_diffpairs(cfg, timeout=10.0)
+
+    kwargs = router._diffpair_router.route_all_with_diffpairs.call_args.kwargs
+    # 10 * 0.3 = 3, floored at 5.
+    assert kwargs["per_pair_timeout"] == 5.0
+
+
+def test_timeout_derived_budget_uses_30_percent_when_in_range():
+    """For mid-range ``--timeout`` values the derived budget is
+    ``timeout * 0.3``: 100 s -> 30 s (below the 60 s cap, above the 5 s
+    floor)."""
+    router = _make_autorouter_stub()
+    cfg = DifferentialPairConfig(enabled=True)
+
+    router.route_all_with_diffpairs(cfg, timeout=100.0)
+
+    kwargs = router._diffpair_router.route_all_with_diffpairs.call_args.kwargs
+    assert kwargs["per_pair_timeout"] == 30.0
+
+
+def test_explicit_per_pair_timeout_takes_precedence_over_derived():
+    """If the user explicitly set ``--diffpair-per-pair-timeout`` via
+    ``DifferentialPairConfig.per_pair_timeout``, the auto-derivation
+    must NOT fire (the user's explicit budget wins)."""
+    router = _make_autorouter_stub()
+    cfg = DifferentialPairConfig(enabled=True, per_pair_timeout=15.0)
+
+    router.route_all_with_diffpairs(cfg, timeout=600.0)
+
+    kwargs = router._diffpair_router.route_all_with_diffpairs.call_args.kwargs
+    # The kwarg must be None so the inner router falls back to the
+    # config value (15.0) per its own precedence rule.
+    assert kwargs["per_pair_timeout"] is None
+
+
+def test_timeout_none_preserves_legacy_unbounded_behaviour():
+    """No ``timeout`` -> no derived budget -> back-compat preserved.
+
+    This is the critical back-compat test: existing tests and callers
+    that never passed ``timeout`` must continue to invoke the inner
+    router with ``per_pair_timeout=None``.
+    """
+    router = _make_autorouter_stub()
+    cfg = DifferentialPairConfig(enabled=True)
+
+    router.route_all_with_diffpairs(cfg)  # no timeout
+
+    kwargs = router._diffpair_router.route_all_with_diffpairs.call_args.kwargs
+    assert kwargs["per_pair_timeout"] is None
+
+
+def test_timeout_zero_or_negative_does_not_derive_budget():
+    """Defensive: a ``timeout <= 0`` is treated the same as ``None``
+    (no derivation, no forwarding).  This protects against odd CLI
+    states where ``--timeout 0`` slipped through validation."""
+    router = _make_autorouter_stub()
+    cfg = DifferentialPairConfig(enabled=True)
+
+    router.route_all_with_diffpairs(cfg, timeout=0.0)
+
+    kwargs = router._diffpair_router.route_all_with_diffpairs.call_args.kwargs
+    assert kwargs["per_pair_timeout"] is None
+
+
+def test_timeout_does_not_derive_when_diffpair_disabled():
+    """When ``diffpair_config.enabled`` is False, the derivation is
+    skipped entirely (the inner router short-circuits to ``route_all``
+    so the per-pair budget would never be consulted anyway)."""
+    router = _make_autorouter_stub()
+    cfg = DifferentialPairConfig(enabled=False)
+
+    router.route_all_with_diffpairs(cfg, timeout=600.0)
+
+    kwargs = router._diffpair_router.route_all_with_diffpairs.call_args.kwargs
+    assert kwargs["per_pair_timeout"] is None
+
+
+def test_timeout_does_not_derive_when_config_is_none():
+    """When ``diffpair_config`` itself is ``None`` (the truly-legacy
+    invocation path) the derivation is skipped."""
+    router = _make_autorouter_stub()
+
+    router.route_all_with_diffpairs(None, timeout=600.0)
+
+    kwargs = router._diffpair_router.route_all_with_diffpairs.call_args.kwargs
+    assert kwargs["per_pair_timeout"] is None
+
+
+# ---------------------------------------------------------------------------
+# Structured-log signal
+# ---------------------------------------------------------------------------
+
+
+def test_autoderive_emits_structured_log_signal(caplog):
+    """When auto-derivation fires, an INFO-level
+    ``DIFFPAIR_PER_PAIR_TIMEOUT_AUTODERIVED`` log line is emitted so log
+    parsers / CI gates can distinguish explicit configuration from the
+    safety-net fallback (similar to the AUTOFIX_SKIPPED pattern from
+    PR #3247)."""
+    import logging
+
+    router = _make_autorouter_stub()
+    cfg = DifferentialPairConfig(enabled=True)
+
+    with caplog.at_level(logging.INFO, logger="kicad_tools.router.core"):
+        router.route_all_with_diffpairs(cfg, timeout=100.0)
+
+    autoderive_records = [
+        r for r in caplog.records
+        if "DIFFPAIR_PER_PAIR_TIMEOUT_AUTODERIVED" in r.getMessage()
+    ]
+    assert autoderive_records, (
+        "Auto-derived per-pair timeout must emit a structured log signal "
+        "so triagers can tell whether the budget came from the CLI flag "
+        "or from the --timeout fallback (issue #3321)."
+    )
+
+
+def test_autoderive_does_not_log_when_user_set_explicit_budget(caplog):
+    """When the user already set ``--diffpair-per-pair-timeout`` we
+    should NOT emit the auto-derived signal (the signal is reserved for
+    the fallback path)."""
+    import logging
+
+    router = _make_autorouter_stub()
+    cfg = DifferentialPairConfig(enabled=True, per_pair_timeout=20.0)
+
+    with caplog.at_level(logging.INFO, logger="kicad_tools.router.core"):
+        router.route_all_with_diffpairs(cfg, timeout=100.0)
+
+    autoderive_records = [
+        r for r in caplog.records
+        if "DIFFPAIR_PER_PAIR_TIMEOUT_AUTODERIVED" in r.getMessage()
+    ]
+    assert not autoderive_records, (
+        "Explicit --diffpair-per-pair-timeout must not trigger the "
+        "auto-derived log signal."
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI plumbing: regression guard
+# ---------------------------------------------------------------------------
+
+
+def test_cli_route_cmd_forwards_timeout_to_diffpair_callsite():
+    """The CLI's diff-pair callsite must pass ``timeout=`` so the
+    pre-pass actually receives the budget.  Without this, the
+    auto-derivation in ``Autorouter.route_all_with_diffpairs`` cannot
+    fire because no caller ever supplies the kwarg.
+
+    Source-level regression guard: count the diff-pair callsites in
+    ``route_cmd.py`` and ensure each one has a ``timeout=`` kwarg.
+    """
+    import pathlib
+
+    src = (
+        pathlib.Path(__file__).parent.parent
+        / "src/kicad_tools/cli/route_cmd.py"
+    ).read_text()
+
+    # Locate every ``router.route_all_with_diffpairs(`` call and inspect
+    # the next few lines for a ``timeout=`` kwarg.
+    lines = src.splitlines()
+    callsites = []
+    for idx, line in enumerate(lines):
+        if "router.route_all_with_diffpairs(" in line:
+            # Capture the call expression up to its closing paren.
+            # Crude but sufficient: take up to the next 10 lines.
+            chunk = "\n".join(lines[idx : idx + 10])
+            callsites.append(chunk)
+
+    assert callsites, (
+        "Expected at least one ``router.route_all_with_diffpairs(`` "
+        "callsite in route_cmd.py; refactor may have moved it."
+    )
+
+    for site in callsites:
+        assert "timeout=" in site, (
+            "Every CLI ``router.route_all_with_diffpairs(`` callsite "
+            "must forward ``timeout=`` so the CoupledPathfinder is "
+            "bounded by --timeout (issue #3321).  Found a callsite "
+            "without timeout forwarding:\n"
+            f"{site}"
+        )


### PR DESCRIPTION
## Summary

Closes #3321.

The CLI's ``--timeout`` flag was never reaching the diff-pair pre-pass: ``Autorouter.route_all_with_diffpairs`` had no ``timeout`` parameter, so ``CoupledPathfinder`` ran unbounded.  On board 07 (matchgroup-test) this caused a CPU peg at 99.7 % for >40 minutes when ``--differential-pairs --timeout 600`` was supplied, blocking #3275 (board 07 differential-pairs re-enable).

This PR is **infrastructure** that unblocks #3275 — the wager itself stays deferred pending #3320.

## Changes

- ``Autorouter.route_all_with_diffpairs`` now accepts ``timeout: float | None = None``.
- When ``timeout`` is set AND ``diffpair_config.per_pair_timeout`` is ``None``, a per-pair budget is auto-derived as ``max(5.0, min(timeout * 0.3, 60.0))`` and forwarded into the inner ``DiffPairRouter``.
- All three CLI diff-pair callsites in ``route_cmd.py`` now pass ``timeout=_budgeted_timeout(args)``.
- Emits an ``DIFFPAIR_PER_PAIR_TIMEOUT_AUTODERIVED`` INFO log line (PR #3247 ``AUTOFIX_SKIPPED`` pattern) so triagers can distinguish explicit configuration from the safety-net fallback.

## Timeout enforcement strategy

Per-pair budget = ``max(5.0, min(timeout * 0.3, 60.0))``:
- **30 % per pair** — generous enough to converge on the typical pair, never more than a third of the total budget so the remaining pairs and the negotiated phase still have headroom.
- **Capped at 60 s** — the per-pair search tail rarely needs more; longer budgets just delay the inevitable fallback to single-ended routing.
- **Floored at 5 s** — protects against pathological cases where a tiny ``--timeout`` (e.g. 10 s) would collapse the budget to ~3 s and abort every pair unnecessarily.

Precedence: explicit ``--diffpair-per-pair-timeout`` wins over the derivation; legacy callers passing no ``timeout`` see exactly the old unbounded behaviour (full back-compat).

## Back-compat

- ``timeout=None`` (default) -> inner router invoked with ``per_pair_timeout=None`` exactly as before.
- Pairs that exceed the derived budget fall through to the negotiated single-ended router via the existing ``budget_exit_diff_nets`` path in ``diffpair_routing.py`` — the user still gets a routed PCB.

## Test plan

- [x] 13 new unit tests in ``tests/test_router_core_diffpair_timeout.py`` pin the signature, derivation arithmetic, precedence rule, back-compat ``None`` default, structured-log signal, and a source-level regression guard against future refactors that drop the kwarg forwarding.
- [x] All 11 existing tests in ``tests/test_diffpair_per_pair_timeout.py`` still pass.
- [x] ``tests/test_diffpair_phase_b.py`` (intra-clearance repair) still passes — 23/23.
- [x] ``tests/test_diffpair_routing_integration.py`` and ``tests/test_diffpair_engagement.py`` still pass — 26/26.
- [x] ``tests/test_board_06_diffpair_test.py`` still passes — 35/35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)