### PR TITLE
fix(router): reject coupled diff-pair routes with centerline overlap (#3320)

### DIFF
--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -2399,6 +2399,87 @@ class DiffPairRouter:
 
             p_route, n_route = result
 
+            # Issue #3320: Pre-mark intra-pair clearance audit.  Before
+            # we commit the coupled-route to the grid and the route list,
+            # check whether the reconstructed geometry actually meets the
+            # per-pair clearance threshold.  A SEVERE violation
+            # (centerlines overlap by more than ``trace_width / 2`` --
+            # i.e., the partner trace's centerline lies on or inside our
+            # trace's body) means the coupled search produced an
+            # unrouteable swap-via / crossover geometry that the
+            # ``min_spacing_cells`` floor (PR #3022) could not prevent.
+            # The canonical failure mode is the board-07 DQS_N/DQS_P
+            # pair: the polarity-swap-via at the U1 vias places both
+            # traces with swapped y-coordinates on the same inner layer,
+            # producing a long diagonal that crosses the partner's start
+            # cell with -0.150 mm edge-to-edge clearance (the full trace
+            # width).  When this happens we reject the coupled route,
+            # do NOT commit it to the grid, and fall back to the
+            # independent router which routes P and N as separate
+            # single-ended nets -- a worse outcome for skew but a
+            # routable one that doesn't produce shorting overlaps.
+            violation = find_intra_pair_clearance_violations(
+                p_route,
+                n_route,
+                threshold_mm=pair_intra_clearance,
+                pair_name=pair.name,
+            )
+            # Severity gate: any actual centerline overlap (negative
+            # edge-to-edge clearance) is "severe" -- the partner trace's
+            # body literally intersects ours.  Pure quantization slack
+            # (clearance in ``[0, threshold)``) is logged but kept
+            # because the trace-optimizer / serpentine shim can still
+            # nudge it into compliance.
+            severe_violation = (
+                violation is not None
+                and violation.actual_clearance_mm < 0.0
+            )
+            if severe_violation:
+                assert violation is not None  # for type-checkers
+                print(
+                    f"    WARNING: Coupled route produced centerline overlap "
+                    f"(worst={violation.actual_clearance_mm:+.3f}mm < 0); "
+                    "rejecting coupled route and falling back to independent "
+                    "routing."
+                )
+                logger.warning(
+                    "diffpair coupled-route REJECTED due to centerline overlap: "
+                    "pair=%r p_net=%r n_net=%r worst_clearance=%.4fmm "
+                    "threshold=%.4fmm offending_segments=%d",
+                    violation.pair_name,
+                    violation.positive_net_name,
+                    violation.negative_net_name,
+                    violation.actual_clearance_mm,
+                    violation.expected_clearance_mm,
+                    len(violation.segment_violations),
+                )
+                # Do NOT commit p_route/n_route to grid or
+                # ``autorouter.routes``.  Fall back to independent
+                # routing for the whole pair (single source of truth
+                # for the fallback path).  For the n-pad case where
+                # earlier specs in this loop may already have committed
+                # routes, unmark them and remove from the autorouter's
+                # route list so the independent router starts from a
+                # clean grid state for this pair.  ``coupled_only``
+                # callers short-circuit out without a fallback -- they
+                # will see the pair as unrouted and the negotiated
+                # strategy picks it up on the main pass.
+                for prev_route in routes:
+                    try:
+                        self.autorouter.grid.unmark_route(prev_route)
+                    except Exception:
+                        pass
+                    if prev_route in self.autorouter.routes:
+                        self.autorouter.routes.remove(prev_route)
+                if coupled_only:
+                    print(
+                        "    Skipping diff-pair pre-pass: coupled route "
+                        "rejected (centerline overlap) and ``coupled_only`` "
+                        "is set."
+                    )
+                    return [], None
+                return self.route_differential_pair_independent(pair, spacing)
+
             # Mark routes on grid (use the unified helper that updates
             # both the Python and C++ grids — issue #1250).
             self.autorouter._mark_route(p_route)
@@ -2419,13 +2500,9 @@ class DiffPairRouter:
             # segments against the per-pair threshold and emit a
             # diagnostic so Phase B (fine-grid repair, separate PR) can
             # rip-and-replace just the offenders.  No behavioural change
-            # here -- detection only.
-            violation = find_intra_pair_clearance_violations(
-                p_route,
-                n_route,
-                threshold_mm=pair_intra_clearance,
-                pair_name=pair.name,
-            )
+            # here -- detection only.  Note: severe overlaps that would
+            # have triggered the #3320 rejection above never reach this
+            # diagnostic because they fall back to independent routing.
             if violation is not None:
                 logger.info(
                     "diffpair intra-clearance violation: pair=%r "

--- a/tests/test_diffpair_swap_via_reject.py
+++ b/tests/test_diffpair_swap_via_reject.py
@@ -1,0 +1,297 @@
+"""Regression tests for Issue #3320: CoupledPathfinder swap-via overlap rejection.
+
+PR #3022 added a ``min_spacing_cells`` floor to ``CoupledPathfinder`` to
+prevent the coupled A* from collapsing within-pair spacing to zero during
+the approach phase or asymmetric "converge" moves.  Empirical follow-up
+on board 07's DDR strobe pair (DQS_N/DQS_P) showed that the floor is
+necessary but not sufficient: when the pair has a *polarity-swap* (the P
+and N pad rows are inverted between the two footprints, e.g.
+``U1.30=P-top, U1.31=N-bottom`` vs ``U2.6=P-bottom, U2.7=N-top``), the
+search uses a "swap-via" move at the start pads to invert the spacing
+orientation.
+
+The reconstructed swap-via geometry physically requires both traces to
+cross over each other on the same destination layer.  The
+``min_spacing_cells`` floor only protects coupled segments after the
+swap-via lands; it does NOT prevent the *crossover stub* between the via
+position and the swapped grid position from overlapping the partner
+trace's via location.  On board 07 DQS this produces 5 negative-clearance
+overlaps (worst -0.150 mm = full trace width = traces literally
+coincident).
+
+The fix in ``route_differential_pair_coupled`` runs the post-route
+intra-pair clearance audit BEFORE committing the coupled route to the
+grid, and rejects the route (falling back to independent routing) when
+any segment-pair has actual edge-to-edge clearance below 0.0 mm (i.e.
+centerlines overlap).
+
+This module exercises two related behaviors:
+
+1. ``test_dqs_like_polarity_swap_does_not_produce_negative_clearance``:
+   end-to-end check that running the coupled router on a DQS-like
+   polarity-swap fixture either produces routes whose intra-pair
+   clearance is non-negative, or falls back to independent routing.
+2. ``test_severe_overlap_triggers_independent_fallback`` and
+   ``test_quantization_slack_does_not_trigger_fallback``: gate-only
+   unit tests that verify the severity classifier (``actual_clearance_mm
+   < 0.0``) is the trigger and that quantization-slack violations (in
+   ``[0, threshold)``) do NOT trigger the fallback.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.core.geometry import segment_clearance
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.diffpair import DifferentialPairConfig
+from kicad_tools.router.rules import DesignRules, NetClassRouting
+
+
+# ---------------------------------------------------------------------------
+# DQS-like fine-pitch polarity-swap fixture
+# ---------------------------------------------------------------------------
+
+
+def _dqs_like_class_map() -> dict[str, NetClassRouting]:
+    """Build a per-net class map mirroring board 07's DDR_DQS net class.
+
+    The defining attributes are:
+      * ``trace_width = 0.15`` (board 07 ``DDR_DQS`` class)
+      * ``intra_pair_clearance = 0.1`` (tight, sub-grid-resolution)
+      * ``coupled_routing = True`` (engagement opt-in, per PR #2638 Phase 2E)
+
+    These together demand ``required_center_spacing = 0.15 + 0.1 = 0.25``,
+    which on a 0.127 mm grid converts to ``ceil(0.25 / 0.127) = 2`` cells
+    of center-to-center spacing.  The minimum-spacing floor (PR #3022)
+    enforces this, but the polarity-swap-via at the start pads still
+    produces an overlapping crossover that the floor does not catch.
+    """
+    nc = NetClassRouting(
+        name="DDR_DQS",
+        trace_width=0.15,
+        clearance=0.1,
+        intra_pair_clearance=0.1,
+        coupled_routing=True,
+        length_critical=True,
+    )
+    return {"DQS_P": nc, "DQS_N": nc}
+
+
+def _dqs_polarity_swap_router(grid_resolution: float = 0.127) -> Autorouter:
+    """Two-pad polarity-swap fixture with DQS-like tight clearance.
+
+    At U1: P at (5.0, 5.4), N at (5.0, 4.6) -- P above N
+    At U2: P at (25.0, 4.6), N at (25.0, 5.4) -- P BELOW N (polarity inverted)
+
+    This matches the board 07 DDR_DQS layout (U1.30/31 vs U2.6/7) that
+    triggered the original #3320 negative-clearance bug.
+    """
+    rules = DesignRules(
+        trace_width=0.15,
+        trace_clearance=0.1,
+        grid_resolution=grid_resolution,
+    )
+    router = Autorouter(
+        width=30.0,
+        height=10.0,
+        rules=rules,
+        net_class_map=_dqs_like_class_map(),
+    )
+    # MCU side: P (net 1) above N (net 2)
+    router.add_component(
+        "U1",
+        [
+            {"number": "30", "x": 5.0, "y": 5.4, "width": 0.3, "height": 0.3,
+             "net": 1, "net_name": "DQS_P"},
+            {"number": "31", "x": 5.0, "y": 4.6, "width": 0.3, "height": 0.3,
+             "net": 2, "net_name": "DQS_N"},
+        ],
+    )
+    # DDR side: P (net 1) BELOW N (net 2) -- polarity swap
+    router.add_component(
+        "U2",
+        [
+            {"number": "6", "x": 25.0, "y": 4.6, "width": 0.3, "height": 0.3,
+             "net": 1, "net_name": "DQS_P"},
+            {"number": "7", "x": 25.0, "y": 5.4, "width": 0.3, "height": 0.3,
+             "net": 2, "net_name": "DQS_N"},
+        ],
+    )
+    return router
+
+
+# ---------------------------------------------------------------------------
+# End-to-end behavior: DQS-like polarity swap must not produce overlap
+# ---------------------------------------------------------------------------
+
+
+def _min_intra_pair_clearance(p_route, n_route) -> float:
+    """Return the minimum edge-to-edge clearance between any same-layer P/N seg pair."""
+    if p_route is None or n_route is None:
+        return float("inf")
+    worst = float("inf")
+    for ps in p_route.segments:
+        for ns in n_route.segments:
+            if ps.layer != ns.layer:
+                continue
+            c = segment_clearance(
+                ps.x1, ps.y1, ps.x2, ps.y2, ps.width,
+                ns.x1, ns.y1, ns.x2, ns.y2, ns.width,
+            )
+            if c < worst:
+                worst = c
+    return worst
+
+
+def test_dqs_like_polarity_swap_does_not_produce_negative_clearance():
+    """Coupled routing on a DQS-like polarity-swap fixture must not produce overlap.
+
+    The pre-#3320 behavior on this fixture: the CoupledPathfinder's
+    swap-via at the start pads produces P and N routes whose first
+    inner-layer segment has the polarity-swapped grid position as its
+    endpoint.  The resulting (1-cell-x, 7-cell-y) diagonal segment
+    intersects the partner trace's via cell, producing a worst-case
+    intra-pair clearance of -trace_width (= -0.15 mm).
+
+    Post-#3320 the route_differential_pair_coupled severity gate
+    rejects this coupled route and falls back to independent routing,
+    so the returned routes either:
+      (a) come from the coupled path (no severe overlap), or
+      (b) come from the independent fallback path (single-ended A* for
+          each net -- no within-pair constraint, so worst-case clearance
+          can be anything in ``[generic_clearance, +inf)``).
+
+    Either way, the worst intra-pair edge-to-edge clearance must be
+    >= 0.0 mm (no centerline overlap).  The acceptance criterion in
+    #3320 is "0 negative-clearance violations on DQS_N/DQS_P".
+    """
+    router = _dqs_polarity_swap_router()
+
+    pairs = router._diffpair.detect_differential_pairs()
+    assert len(pairs) == 1, f"expected 1 pair, got {len(pairs)}"
+
+    config = DifferentialPairConfig(enabled=True, spacing=0.25)
+    pair = pairs[0]
+    pair.rules = config.get_rules(pair.pair_type)
+
+    routes, _warning = router._diffpair.route_differential_pair_coupled(
+        pair, spacing=0.25, coupled_only=False
+    )
+    assert routes, "DQS-like fixture must produce routes (coupled or fallback)"
+
+    # Split routes by net.
+    p_routes = [r for r in routes if r.net == 1]
+    n_routes = [r for r in routes if r.net == 2]
+    assert p_routes and n_routes, (
+        f"both nets must route; got p={len(p_routes)} n={len(n_routes)}"
+    )
+
+    # Compute worst-case intra-pair clearance across all (P, N) route
+    # combinations on the same layer.
+    worst = float("inf")
+    for p in p_routes:
+        for n in n_routes:
+            c = _min_intra_pair_clearance(p, n)
+            if c < worst:
+                worst = c
+
+    # The #3320 invariant: no centerline overlap (clearance >= 0).
+    # 1e-6 mm tolerance to account for floating-point quantization.
+    assert worst >= -1e-6, (
+        f"DQS-like polarity-swap pair must not produce centerline overlap; "
+        f"worst intra-pair clearance = {worst:+.4f}mm (expected >= 0)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Severity classifier behavior
+# ---------------------------------------------------------------------------
+
+
+def test_severe_overlap_triggers_independent_fallback():
+    """A coupled route with negative intra-pair clearance is rejected.
+
+    Constructs a synthetic ``IntraPairClearanceViolation`` via
+    ``find_intra_pair_clearance_violations`` on routes we hand-build to
+    overlap, and verifies the severity classifier returns True.  This
+    is the trigger used in ``route_differential_pair_coupled`` to
+    decide between committing the coupled route and falling back to
+    independent routing.
+    """
+    from kicad_tools.router.diffpair_routing import (
+        find_intra_pair_clearance_violations,
+    )
+    from kicad_tools.router.layers import Layer
+    from kicad_tools.router.primitives import Route, Segment
+
+    # Hand-construct two overlapping routes.  P at y=0, N at y=0 (fully
+    # coincident, clearance = -trace_width = -0.15).
+    p_route = Route(net=1, net_name="P", segments=[
+        Segment(
+            x1=0.0, y1=0.0, x2=5.0, y2=0.0,
+            width=0.15, layer=Layer.F_CU, net=1, net_name="P",
+        ),
+    ])
+    n_route = Route(net=2, net_name="N", segments=[
+        Segment(
+            x1=0.0, y1=0.0, x2=5.0, y2=0.0,
+            width=0.15, layer=Layer.F_CU, net=2, net_name="N",
+        ),
+    ])
+    v = find_intra_pair_clearance_violations(
+        p_route, n_route, threshold_mm=0.1, pair_name="P/N"
+    )
+    assert v is not None
+    # The severity classifier in route_differential_pair_coupled is
+    # ``violation.actual_clearance_mm < 0.0``.
+    assert v.actual_clearance_mm < 0.0, (
+        f"hand-built overlap must report negative clearance; "
+        f"got actual={v.actual_clearance_mm}"
+    )
+
+
+def test_quantization_slack_does_not_trigger_fallback():
+    """A coupled route with clearance in [0, threshold) is NOT severe.
+
+    The severity classifier rejects only NEGATIVE clearance.  Pure
+    quantization slack (clearance in ``[0, threshold)``) is logged via
+    the existing Phase A diagnostic but the route is still committed --
+    the trace optimizer / serpentine shim can nudge it into compliance,
+    and falling back to independent routing for a 0.01-0.05 mm overshoot
+    would be unnecessarily destructive of skew matching.
+    """
+    from kicad_tools.router.diffpair_routing import (
+        find_intra_pair_clearance_violations,
+    )
+    from kicad_tools.router.layers import Layer
+    from kicad_tools.router.primitives import Route, Segment
+
+    # Two parallel routes with center-to-center spacing = 0.20 mm,
+    # trace widths 0.15 mm each -> edge-to-edge clearance = 0.05 mm.
+    # Threshold = 0.10 mm so this is a quantization-slack violation
+    # (positive but below threshold).
+    p_route = Route(net=1, net_name="P", segments=[
+        Segment(
+            x1=0.0, y1=0.0, x2=5.0, y2=0.0,
+            width=0.15, layer=Layer.F_CU, net=1, net_name="P",
+        ),
+    ])
+    n_route = Route(net=2, net_name="N", segments=[
+        Segment(
+            x1=0.0, y1=0.20, x2=5.0, y2=0.20,
+            width=0.15, layer=Layer.F_CU, net=2, net_name="N",
+        ),
+    ])
+    v = find_intra_pair_clearance_violations(
+        p_route, n_route, threshold_mm=0.10, pair_name="P/N"
+    )
+    assert v is not None
+    # Clearance is positive (5e-2 mm) -- below threshold but not overlap.
+    assert 0.0 <= v.actual_clearance_mm < 0.10, (
+        f"expected quantization-slack violation (0 <= c < 0.10); "
+        f"got actual={v.actual_clearance_mm}"
+    )
+    # The severity classifier is ``actual_clearance_mm < 0.0`` -- this
+    # must be False so the coupled route is committed (no fallback).
+    assert not (v.actual_clearance_mm < 0.0), (
+        "quantization-slack violation must NOT trigger severe-overlap fallback"
+    )


### PR DESCRIPTION
## Summary

Closes #3320.

PR #3022 added a ``min_spacing_cells`` floor to ``CoupledPathfinder``
to prevent the coupled A* from collapsing within-pair spacing to zero
during the approach phase / asymmetric \"converge\" moves.  The floor
is necessary but not sufficient: when the pair has a polarity-swap
(P and N rows inverted between the two footprints, e.g.
``U1.30=P-top, U1.31=N-bottom`` vs ``U2.6=P-bottom, U2.7=N-top`` -- the
board-07 DDR strobe DQS_N/DQS_P layout), the pathfinder uses a swap-via
move at the start pads to invert the spacing orientation.

The reconstructed P route ends a segment at ``p_old.x/y`` on the old
layer and the next segment starts from the SWAPPED grid position
``(n_old.x, n_old.y)`` on the new layer -- producing a long diagonal
that crosses the partner trace's via cell.  ``min_spacing_cells`` only
governs the Euclidean cell spacing at A* states, not the segment
geometry connecting consecutive states across a swap-via.

## Root cause

Confirmed by instrumented A* path dump on board 07 DQS:

```
=== DEBUG DQS path (DQS_P,DQS_N) ===
  [  0]   P=(124.981,125.451,L0) N=(124.981,124.562,L0)
  [  1] V P=(124.981,124.562,L1) N=(124.981,125.451,L1)  ← swap-via
  [  2]   P=(125.108,124.562,L1) N=(125.108,125.451,L1)
  ...
```

State [0]→[1] swaps both grid positions across the via.  When
``_build_route_from_path`` reconstructs N's route from this path it
emits a segment from ``(24.981, 24.562)`` (N's pre-swap position) to
``(25.108, 25.451)`` (N's post-swap position one cell to the right) --
a (1, 7) jump in grid cells.  This single segment crosses P's via cell
at (24.981, 25.451), producing -0.150 mm edge-to-edge clearance
(= -trace_width, the two traces are literally coincident there).

## Fix

Run the existing ``find_intra_pair_clearance_violations`` audit BEFORE
marking the coupled route on the grid.  If any segment-pair has actual
edge-to-edge clearance ``< 0.0`` mm (centerlines overlap), reject the
coupled route -- unmark any previously-committed routes for the same
pair, then fall back to independent routing for the whole pair.

Quantization-slack violations (clearance in ``[0, threshold)``) are
left to the existing post-mark Phase A diagnostic and the
trace-optimizer / serpentine shim, matching the prior behaviour.

## Empirical result (board 07 DQS_N/DQS_P)

Recipe used (NOT committed):
```bash
cd boards/07-matchgroup-test/output
PYTHONHASHSEED=42 uv run python -m kicad_tools.cli route \\
  matchgroup_test.kicad_pcb --output /tmp/mgt.kicad_pcb \\
  --manufacturer jlcpcb --strategy negotiated --no-auto-layers \\
  --layers 4 --differential-pairs --seed 42 --timeout 600 \\
  --skip-nets GND,+1V2,+1V8 \\
  --net-class-map net_class_map.json
```

|                              | Before fix       | After fix        |
|------------------------------|------------------|------------------|
| ``diffpair_clearance_intra`` | **8 errors**     | **0 errors**     |
| DQS worst clearance          | **-0.150 mm**    | **>= 0.0 mm**    |
| DQS overlap list (mm)        | -0.150, -0.093,  | (none)           |
|                              | -0.036, -0.002,  |                  |
|                              | 0.022, 0.004,    |                  |
|                              | 0.022, 0.037     |                  |
| Routing yield                | 27/31 (87%)      | 26/31 (84%)      |

The 1-net yield delta (DQ3) comes from the fallback to independent
routing leaving the grid in a slightly different state for the
negotiated tail.  This is the documented trade-off in the #3320 AC:
the empirical criterion is \"0 negative-clearance violations on
DQS_N/DQS_P\", which we now meet.

## Recipe / #3275 status

The board-07 recipe still does NOT enable ``--differential-pairs`` --
that change is gated on #3275, which was BLOCKED on this fix.  Once
this PR lands, #3275 can be re-attempted (PR #3318's residual scope).

## Board 06 verification

Board 06 (Diff-Pair Routing CI) re-routed cleanly with this fix.  The
DRC shows the same 1 pre-existing ``USB2_D+/USB2_D-`` violation
(-0.475 mm) that origin/main also has -- this is NOT introduced by
this PR (verified by stashing this PR's changes and re-checking the
committed routed PCB).  Board 06's polarity-swap fixtures
(``_polarity_swap_router`` etc.) all route as expected via the
existing test suite.

## Tests

* 3 new regression tests in ``tests/test_diffpair_swap_via_reject.py``:
  - End-to-end DQS-like polarity-swap fixture asserts non-negative
    worst intra-pair clearance.
  - Severity classifier accepts hand-built overlapping routes.
  - Severity classifier rejects quantization-slack-only violations.
* All 317 tests in ``tests/test_diffpair*.py`` pass (1669 s).
* Existing min_spacing_cells floor tests (``test_diffpair_coupled_floor.py``,
  PR #3022's 9-case suite) pass verbatim.
* Existing polarity-swap routing tests (``test_diffpair_npad.py::
  test_polarity_swap_*``) pass verbatim.

## Test plan

- [x] Run ``pytest tests/test_diffpair*.py`` (317/317 pass)
- [x] Reproduce the bug on board 07 with ``--differential-pairs``
- [x] Verify DQS overlap before/after (see table above)
- [x] Verify board 06 still routes (yield + DRC delta == 0)
- [x] Verify board 06's USB-C polarity-swap fixture still routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)