### PR TITLE
router: budget-exit diff-pair priority promotion + BGA-49 drift-prevention tests (Refs #3270)

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -873,6 +873,21 @@ class Autorouter:
         # preserves the original (non-deterministic-trigger-timing) behaviour.
         self._perturbation_seed: int | None = None
 
+        # Issue #3270: Net IDs whose coupled-pathfinder pre-pass exhausted
+        # the per-pair budget and deferred to the main strategy.  These
+        # nets carry heavy escape-geometry constraints (typically inner-ring
+        # BGA-49 USB3 pairs whose paired escape segments + corridor
+        # reservation still require dense F.Cu/inner-layer routing to
+        # reach the partner package).  When non-empty, ``_get_net_priority``
+        # promotes them to complexity_tier 0 (route ahead of other nets in
+        # the same priority class) so they get first pick of grid resources
+        # before the negotiated congestion main strategy fills the inner-
+        # layer corridor with single-ended traffic.
+        # Populated by ``route_all_with_diffpairs`` after budget-exit
+        # detection (see ``diffpair_routing.py`` ``budget_exit_diff_nets``)
+        # and cleared at the end of the main strategy.
+        self._budget_exit_diff_nets: set[int] = set()
+
         # Routing failure tracking (Issue #688)
         self.routing_failures: list[RoutingFailure] = []
 
@@ -4147,6 +4162,22 @@ class Autorouter:
         complexity_tier = 0 if (pad_count == 2 and distance < SIMPLE_NET_THRESHOLD_MM) else 1
         if complexity_tier == 1 and self._net_has_off_grid_pads(net_id):
             complexity_tier = 0
+
+        # Issue #3270: Promote diff-pair nets whose coupled pre-pass
+        # exhausted the per-pair budget to complexity_tier -1 so they
+        # route ahead of every other net in the same priority class.
+        # Rationale: on board 06's BGA-49 USB3 escapes the inner-ring
+        # pair (B2/B3 USB3_TX1) must traverse a corridor that gets
+        # colonised by single-ended USB3 traffic (B5/B6 USB3_RX1,
+        # F2/F3 USB3_TX2, F5/F6 USB3_RX2) when those route first.
+        # Routing the budget-exit pair FIRST inside the main strategy
+        # gives it first pick of the inner-layer corridor reserved by
+        # ``_reserve_pair_continuation_corridor`` (Issue #2677) before
+        # any siblings can fill it.  Without this nudge the budget-exit
+        # pair lands last and either bursts the per-net-timeout (60s
+        # observed on board 06 seed=42) or times out the run.
+        if net_id in self._budget_exit_diff_nets:
+            complexity_tier = -1
 
         # Issue #2278: Pre-route RUDY congestion score (negated so higher = route first)
         estimator = self._ensure_congestion_estimator()

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -3594,6 +3594,17 @@ class DiffPairRouter:
                 )
                 diff_net_ids = diff_net_ids - budget_exit_diff_nets
 
+        # Issue #3270: Surface budget-exit diff-pair nets to the
+        # Autorouter so ``_get_net_priority`` can promote them to the
+        # head of the non-diff main strategy's net order.  Without this
+        # the budget-exit pair lands last and routes against a heavily
+        # colonised grid; on board 06 seed=42 USB3_TX1+/U2.B2 then
+        # bursts the per-net timeout (60s observed vs 30s budget) and
+        # exhausts the strategy wall-clock before reaching MIPI_RST.
+        # The set is cleared after the strategy returns to keep the
+        # promotion local to this invocation.
+        self.autorouter._budget_exit_diff_nets = set(budget_exit_diff_nets)
+
         non_diff_nets = [n for n in self.autorouter.nets if n not in diff_net_ids and n != 0]
         if non_diff_nets:
             print(f"\n--- Routing {len(non_diff_nets)} non-differential nets ---")
@@ -3603,7 +3614,14 @@ class DiffPairRouter:
                 # responsible for routing every net in self.autorouter.nets;
                 # diff-pair nets are filtered by the caller's net selection
                 # since their pads are already marked as routed on the grid.
-                strategy_routes = non_diffpair_strategy()
+                try:
+                    strategy_routes = non_diffpair_strategy()
+                finally:
+                    # Issue #3270: Clear the budget-exit promotion set so
+                    # subsequent ``route_all`` / ``route_all_negotiated``
+                    # invocations on the same autorouter inherit the
+                    # default priority ordering (no leak across calls).
+                    self.autorouter._budget_exit_diff_nets = set()
                 # Filter out any routes for diff-pair nets that the strategy
                 # may have re-routed (shouldn't happen if grid marking is
                 # correct, but defend against it).
@@ -3618,14 +3636,20 @@ class DiffPairRouter:
                         non_diff_nets, key=lambda n: self.autorouter._get_net_priority(n)
                     )
 
-                for net in non_diff_order:
-                    routes = self.autorouter.route_net(net)
-                    all_routes.extend(routes)
-                    if routes:
-                        print(
-                            f"  Net {net}: {len(routes)} routes, "
-                            f"{sum(len(r.segments) for r in routes)} segments"
-                        )
+                try:
+                    for net in non_diff_order:
+                        routes = self.autorouter.route_net(net)
+                        all_routes.extend(routes)
+                        if routes:
+                            print(
+                                f"  Net {net}: {len(routes)} routes, "
+                                f"{sum(len(r.segments) for r in routes)} segments"
+                            )
+                finally:
+                    # Issue #3270: clear the promotion set on the
+                    # legacy per-net path too -- the priority lift
+                    # is meaningful only for this strategy invocation.
+                    self.autorouter._budget_exit_diff_nets = set()
 
         print("\n=== Differential Pair Routing Complete ===")
         print(f"  Total routes: {len(all_routes)}")

--- a/tests/test_budget_exit_diff_priority.py
+++ b/tests/test_budget_exit_diff_priority.py
@@ -1,0 +1,164 @@
+"""Tests for Issue #3270 budget-exit diff-pair priority promotion.
+
+When the CoupledPathfinder pre-pass exhausts the per-pair iteration or
+wall-clock budget on a diff pair, the pair's nets are deferred to the
+main strategy.  This file pins the contract that those deferred nets
+get a complexity-tier promotion (`tier=-1`) inside `_get_net_priority`,
+so they route ahead of other nets in the same priority class when the
+main strategy schedules its work.
+
+Rationale: on board 06 the budget-exit USB3 pairs end up routing AFTER
+heavy single-ended nets have colonised the inner-layer continuation
+corridor reserved by `_reserve_pair_continuation_corridor` (Issue
+#2677).  Routing them earlier inside the main strategy gives them first
+pick of the still-clean corridor.  See PR comments on #3270 for the
+full reach-by-iteration analysis.
+
+The tests intentionally stub the routing internals and exercise only
+the priority-tuple mechanic so they run fast and are robust against
+unrelated routing changes.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.rules import NET_CLASS_HIGH_SPEED, NetClassRouting
+
+
+def _build_minimal_autorouter() -> Autorouter:
+    """Minimal Autorouter populated with three priority-2 nets.
+
+    Each net is identical aside from net id so the priority tuple
+    reduces to (priority, complexity_tier, -constraint, pad_count,
+    distance, -congestion).  In this setup all three nets land at the
+    same priority class (2), same pad count (2), same distance (small
+    constant), so the tiebreaker is governed by ``complexity_tier``
+    alone -- which is exactly what we want to probe.
+    """
+    ar = Autorouter(width=20.0, height=20.0)
+    ar.nets[10] = [("J1", "1"), ("U1", "1")]
+    ar.nets[11] = [("J1", "2"), ("U1", "2")]
+    ar.nets[12] = [("J1", "3"), ("U1", "3")]
+    ar.net_names = {10: "USB3_TX1+", 11: "USB3_TX1-", 12: "USB3_RX1+"}
+    for name in ("USB3_TX1+", "USB3_TX1-", "USB3_RX1+"):
+        ar.net_class_map[name] = NET_CLASS_HIGH_SPEED
+    # Pads with sane geometry so the bounding-box diagonal is well-defined.
+    from kicad_tools.router.primitives import Pad
+    from kicad_tools.router.layers import Layer
+
+    ar.pads[("J1", "1")] = Pad(
+        x=0.0, y=0.0, width=0.3, height=0.3,
+        net=10, net_name="USB3_TX1+", layer=Layer.F_CU, ref="J1",
+    )
+    ar.pads[("U1", "1")] = Pad(
+        x=2.0, y=0.0, width=0.3, height=0.3,
+        net=10, net_name="USB3_TX1+", layer=Layer.F_CU, ref="U1",
+    )
+    ar.pads[("J1", "2")] = Pad(
+        x=0.0, y=1.0, width=0.3, height=0.3,
+        net=11, net_name="USB3_TX1-", layer=Layer.F_CU, ref="J1",
+    )
+    ar.pads[("U1", "2")] = Pad(
+        x=2.0, y=1.0, width=0.3, height=0.3,
+        net=11, net_name="USB3_TX1-", layer=Layer.F_CU, ref="U1",
+    )
+    ar.pads[("J1", "3")] = Pad(
+        x=0.0, y=2.0, width=0.3, height=0.3,
+        net=12, net_name="USB3_RX1+", layer=Layer.F_CU, ref="J1",
+    )
+    ar.pads[("U1", "3")] = Pad(
+        x=2.0, y=2.0, width=0.3, height=0.3,
+        net=12, net_name="USB3_RX1+", layer=Layer.F_CU, ref="U1",
+    )
+    return ar
+
+
+def test_budget_exit_nets_field_initialized_empty():
+    """`_budget_exit_diff_nets` is initialized as an empty set."""
+    ar = Autorouter(width=10.0, height=10.0)
+    assert ar._budget_exit_diff_nets == set()
+
+
+def test_budget_exit_net_gets_complexity_tier_minus_1():
+    """A budget-exit diff net's priority tuple has complexity_tier == -1."""
+    ar = _build_minimal_autorouter()
+
+    # Baseline: all three nets have tier 0 (2-pin, short net).
+    for nid in (10, 11, 12):
+        prio = ar._get_net_priority(nid)
+        # priority class, complexity_tier are tuple[0] and tuple[1]
+        assert prio[1] == 0, (
+            f"Baseline priority for net {nid}: expected tier 0, got {prio}"
+        )
+
+    # Promote net 10 (USB3_TX1+) to budget-exit.
+    ar._budget_exit_diff_nets = {10}
+    prio_promoted = ar._get_net_priority(10)
+    prio_other = ar._get_net_priority(11)
+    assert prio_promoted[1] == -1, (
+        f"Budget-exit net 10 must get complexity_tier -1, got {prio_promoted}"
+    )
+    assert prio_other[1] == 0, (
+        f"Non-promoted net 11 must keep its baseline tier 0, got {prio_other}"
+    )
+    # The promoted net sorts BEFORE the non-promoted one.
+    assert prio_promoted < prio_other, (
+        f"Budget-exit net must sort earlier than non-promoted siblings "
+        f"in the same priority class.  promoted={prio_promoted} "
+        f"other={prio_other}"
+    )
+
+
+def test_budget_exit_net_promotion_preserves_priority_class():
+    """The priority CLASS (tuple[0]) is unchanged by the tier promotion.
+
+    The promotion only affects the COMPLEXITY tier (tuple[1]); the
+    priority class itself remains the net-class priority (here 2 for
+    NET_CLASS_HIGH_SPEED).  This preserves the existing class-based
+    ordering invariants (e.g. class-2 always before class-4).
+    """
+    ar = _build_minimal_autorouter()
+    expected_class = NET_CLASS_HIGH_SPEED.priority
+
+    ar._budget_exit_diff_nets = {10}
+    prio = ar._get_net_priority(10)
+    assert prio[0] == expected_class, (
+        f"Priority class must remain {expected_class} after tier "
+        f"promotion, got {prio[0]}"
+    )
+
+
+def test_clearing_budget_exit_set_restores_baseline_priority():
+    """Clearing `_budget_exit_diff_nets` reverts to the baseline priority.
+
+    The diff-pair routing layer is contractually obliged to clear the
+    set after the strategy callback returns (see `diffpair_routing.py`
+    `route_all_with_diffpairs`); this test confirms the public API
+    actually responds to that clear.
+    """
+    ar = _build_minimal_autorouter()
+    ar._budget_exit_diff_nets = {10}
+    promoted = ar._get_net_priority(10)
+    ar._budget_exit_diff_nets = set()
+    reverted = ar._get_net_priority(10)
+
+    assert promoted[1] == -1
+    assert reverted[1] == 0, (
+        "After clearing _budget_exit_diff_nets, priority must revert "
+        f"to baseline (tier 0), got {reverted}"
+    )
+
+
+def test_non_diff_net_not_affected_by_budget_exit_set():
+    """A net id NOT in the set is never promoted.
+
+    Defends against an off-by-one or set-membership bug that
+    accidentally lifts a sibling's tier when only its partner is in
+    the set.
+    """
+    ar = _build_minimal_autorouter()
+    ar._budget_exit_diff_nets = {10}  # only TX1+
+    prio_tx1_neg = ar._get_net_priority(11)  # TX1-
+    prio_rx1_pos = ar._get_net_priority(12)  # RX1+
+    assert prio_tx1_neg[1] == 0, prio_tx1_neg
+    assert prio_rx1_pos[1] == 0, prio_rx1_pos

--- a/tests/test_escape_diffpair.py
+++ b/tests/test_escape_diffpair.py
@@ -1254,3 +1254,211 @@ class TestCorridorAttractor:
             diff_pair_map={"TX_P": "TX_N", "TX_N": "TX_P"},
         )
         return er, info
+
+
+# =============================================================================
+# Issue #3270: BGA-49 inner-ring single-pad drift-prevention fixture
+# =============================================================================
+# Codifies the "B2/B3 inner-ring USB3 pair on a 7x7 BGA-49" geometry from
+# board 06 so future budget/heuristic changes that regress the corridor
+# reservation behaviour for inner-ring paired pads land a test failure
+# instead of a silent reach regression on the integration board.
+#
+# Mirrors curator AC #6 from Issue #3270: "Drift-prevention regression:
+# synthetic BGA-49 fixture (the one from #2677 AC, plus one isolating
+# just the U2.B2-class inner-ring single-pad case) holds in the test
+# suite so future budget/heuristic changes cannot regress."
+
+
+def make_bga49_with_inner_ring_pair(
+    p_net: str = "USB3_TX1+",
+    n_net: str = "USB3_TX1-",
+) -> list[Pad]:
+    """Build a 7x7 BGA-49 with the diff pair at B2/B3 (inner-ring).
+
+    Mirrors ``boards/06-diffpair-test/generate_pcb.py:generate_bga49_usb3_sink``
+    exactly so the synthetic fixture exercises the same launch direction
+    (SOUTH from B-row, see ``_get_quadrant_direction``) and same lateral
+    geometry the integration board hits.
+
+    Layout (1.27 mm pitch, 0.45 mm pads, F.Cu only):
+
+    * Row A and G + col 1 and 7: perimeter ring, all GND (net 5)
+    * Inner power: C2/C6/E2/E6 = +3V3 (net 4); rest of inner 3x5 = +1V2
+      (net 6)
+    * **B2 = p_net, B3 = n_net** (the inner-ring USB3 pair under test)
+    * B5, B6, F2, F3, F5, F6: other USB3 lanes (unique nets)
+
+    Total: 49 pads with 8 unique signal nets (USB3 lanes), GND, +3V3,
+    +1V2.
+    """
+    pitch = 1.27
+    pad_size = 0.45
+    pads: list[Pad] = []
+
+    pin_nets: dict[str, tuple[str, int]] = {}
+    for row_letter in "ABCDEFG":
+        for col in range(1, 8):
+            pin_nets[f"{row_letter}{col}"] = ("GND", 5)
+    for row in "CDE":
+        for col in range(2, 7):
+            pin_nets[f"{row}{col}"] = ("+1V2", 6)
+    pin_nets["C2"] = ("+3V3", 4)
+    pin_nets["C6"] = ("+3V3", 4)
+    pin_nets["E2"] = ("+3V3", 4)
+    pin_nets["E6"] = ("+3V3", 4)
+
+    # The pair under test: B2 / B3 (inner-ring, second row from outer
+    # perimeter, second / third column from the west edge).  Net IDs 1
+    # and 2 match the existing TestCorridorReservation convention so the
+    # owner-set assertion (`{1, 2}` for the paired pair) carries over.
+    pin_nets["B2"] = (p_net, 1)
+    pin_nets["B3"] = (n_net, 2)
+    # Other USB3 lanes (unique nets so the diff-pair pre-pass does NOT
+    # pair them and only B2/B3 enters the corridor reservation path).
+    pin_nets["B5"] = ("USB3_RX1+", 10)
+    pin_nets["B6"] = ("USB3_RX1-", 11)
+    pin_nets["F2"] = ("USB3_TX2+", 12)
+    pin_nets["F3"] = ("USB3_TX2-", 13)
+    pin_nets["F5"] = ("USB3_RX2+", 14)
+    pin_nets["F6"] = ("USB3_RX2-", 15)
+
+    for row_idx, row_letter in enumerate("ABCDEFG"):
+        for col in range(1, 8):
+            px = (col - 4) * pitch
+            py = (row_idx - 3) * pitch
+            net_name, net_id = pin_nets[f"{row_letter}{col}"]
+            pads.append(
+                Pad(
+                    x=px, y=py,
+                    width=pad_size, height=pad_size,
+                    net=net_id, net_name=net_name,
+                    layer=Layer.F_CU, ref="U2",
+                    through_hole=False,
+                    pin=f"{row_letter}{col}",
+                )
+            )
+    return pads
+
+
+class TestBGA49InnerRingCorridorDriftPrevention:
+    """Drift-prevention: B2/B3 inner-ring pair gets a corridor reservation.
+
+    Curator AC #6 from Issue #3270.  Synthetic BGA-49 fixture replicates
+    board 06's USB3_TX1+/- launch geometry exactly so any future
+    refactor that breaks inner-ring corridor reservation (e.g. a
+    well-intentioned ring-aware short-circuit that skips inner pads)
+    will fail this gate instead of stranding U2.B2 on the integration
+    board.
+    """
+
+    def test_inner_ring_pair_reserves_corridor(self, grid_4layer, rules):
+        """The B2/B3 inner-ring pair MUST produce a corridor reservation.
+
+        Counterpart to ``TestCorridorReservation.test_gate_a`` but on the
+        exact 7x7 BGA-49 footprint board 06 uses, with the diff pair on
+        the **inner** ring (B-row) -- not the original 4x4 fixture's
+        B-row pair which is functionally on the outer of two rings.
+        """
+        pads = make_bga49_with_inner_ring_pair()
+        info = make_package_info(pads, PackageType.BGA, "U2")
+        diff_pair_map = {"USB3_TX1+": "USB3_TX1-", "USB3_TX1-": "USB3_TX1+"}
+        ncm = {n: NET_CLASS_HIGH_SPEED for n in diff_pair_map}
+
+        er = EscapeRouter(
+            grid_4layer, rules,
+            net_class_map=ncm, diff_pair_map=diff_pair_map,
+        )
+
+        assert er.pair_corridor_reservations == 0
+        er.generate_escapes(info)
+
+        assert er.diff_pair_segment_calls == 1, (
+            "Inner-ring paired escape must run exactly once for the "
+            "single B2/B3 USB3 pair"
+        )
+        assert er.pair_corridor_reservations == 1, (
+            "Inner-ring B2/B3 pair must reserve exactly one corridor; "
+            "future refactors that limit corridor reservation to "
+            "outer-ring pairs will fail this gate"
+        )
+        assert er.pair_corridor_reserved_cells >= 1
+        assert grid_4layer.reserved_cell_count() == er.pair_corridor_reserved_cells
+
+    def test_inner_ring_pair_launches_south(self, grid_4layer, rules):
+        """B2/B3 pair launch direction must be SOUTH (outward from BGA).
+
+        The pair sits 1 pitch south of BGA center (row B = row 1, center
+        is row D = row 3).  ``_get_quadrant_direction`` returns SOUTH
+        when ``|dy| > |dx|`` and ``dy < 0``: B2/B3 mid_y = -2.54 < 0,
+        mid_x = -1.905 -> |dy| > |dx| -> SOUTH.
+
+        Locking in the launch direction prevents a refactor that
+        accidentally classifies the inner-ring pair as 'inward' or
+        'diagonal' (which would defeat the corridor reservation, since
+        the corridor extrudes along the launch direction).
+        """
+        from kicad_tools.router.escape import EscapeDirection
+
+        pads = make_bga49_with_inner_ring_pair()
+        info = make_package_info(pads, PackageType.BGA, "U2")
+        diff_pair_map = {"USB3_TX1+": "USB3_TX1-", "USB3_TX1-": "USB3_TX1+"}
+        ncm = {n: NET_CLASS_HIGH_SPEED for n in diff_pair_map}
+
+        er = EscapeRouter(
+            grid_4layer, rules,
+            net_class_map=ncm, diff_pair_map=diff_pair_map,
+        )
+        escapes = er.generate_escapes(info)
+
+        pair_escapes = [
+            e for e in escapes
+            if e.pad.net_name in ("USB3_TX1+", "USB3_TX1-")
+        ]
+        assert len(pair_escapes) == 2, (
+            "Expected exactly 2 paired escapes for B2/B3 inner-ring pair"
+        )
+        for e in pair_escapes:
+            assert e.direction == EscapeDirection.SOUTH, (
+                f"Inner-ring B-row pair must launch SOUTH (outward), "
+                f"got {e.direction.name} for {e.pad.pin}"
+            )
+            # And the F.Cu paired escape carries no via-drop (the pair
+            # is committed to surface routing until the main pathfinder
+            # decides where to drop).  The corridor reservation is the
+            # mechanism that protects the inner-layer continuation.
+            assert e.via is None
+            assert e.escape_layer == Layer.F_CU
+
+    def test_inner_ring_pair_corridor_owner_set_is_pair_only(
+        self, grid_4layer, rules,
+    ):
+        """The B2/B3 corridor is owned by the B2/B3 pair, not other USB3 lanes.
+
+        Other lanes (USB3_RX1, USB3_TX2, USB3_RX2) on the same BGA share
+        the package but their nets are NOT paired in the diff_pair_map
+        passed to this test, so they MUST NOT appear in the B2/B3
+        corridor's owner set.  This is the regression guard against a
+        future change that accidentally bundles all USB3 lanes into a
+        single shared owner set (which would let RX1's traces colonise
+        the TX1 corridor).
+        """
+        pads = make_bga49_with_inner_ring_pair()
+        info = make_package_info(pads, PackageType.BGA, "U2")
+        diff_pair_map = {"USB3_TX1+": "USB3_TX1-", "USB3_TX1-": "USB3_TX1+"}
+        ncm = {n: NET_CLASS_HIGH_SPEED for n in diff_pair_map}
+
+        er = EscapeRouter(
+            grid_4layer, rules,
+            net_class_map=ncm, diff_pair_map=diff_pair_map,
+        )
+        er.generate_escapes(info)
+
+        # All reservations should be owned by exactly the pair {1, 2}.
+        reserved_items = list(grid_4layer._reserved_for_nets.items())
+        assert reserved_items, "Expected non-empty reservation map"
+        unique_owner_sets = {frozenset(o) for _, o in reserved_items}
+        assert unique_owner_sets == {frozenset({1, 2})}, (
+            f"All B2/B3 corridor cells must be owned by the pair {{1, 2}}; "
+            f"found unexpected owner sets {unique_owner_sets - {{frozenset({{1, 2}})}}}"
+        )


### PR DESCRIPTION
## Summary

Adds infrastructure for the diff-pair-to-main-strategy hand-off so nets whose CoupledPathfinder pre-pass exhausts the per-pair budget can be promoted to the head of their priority class in the negotiated/per-net main strategy.  Also lands the AC #6 drift-prevention tests pinning the Issue #2677 corridor reservation behaviour for the BGA-49 **inner-ring** case the integration board hits.

**Scope honesty:** this PR does NOT close #3270.  See *Reach measurement* below — the seed=42 reach is unchanged at 18/21 because all 9 declared pairs end up in the budget-exit cohort on the current baseline, so the tier-promotion is a uniform lift inside the cohort and does not differentiate the dense BGA-49 inner-ring pair from its siblings.  The infrastructure is sound and will become differential once a follow-up shrinks the budget-exit cohort (e.g. by raising `per_pair_max_iterations` for non-dense pairs, or by landing the Option B BGA inner-ring escape-geometry fix).

## Reach measurement (board 06 `--seed 42`)

| | Before (main `facbe2e7`) | After (this PR) |
|-:|-:|-:|
| Routed signal nets | **18 / 21** (85.7 %) | **18 / 21** (85.7 %) |
| Unrouted nets | USB3_TX1+/U2.B2, USB3_TX1-/U2.B3, MIPI_RST/U4.5 | identical |
| Iteration-0 wall-clock | 145.8 s | 145.8 s |
| Strategy total wall-clock | 279.8 s (timed out in rip-up) | 279.8 s (timed out in rip-up) |
| `kct check --mfr jlcpcb` blocking errors | 17 | 17 |
| `kct check` advisory connectivity errors | 4 | 4 |
| Allowlist headroom | 17 ≤ 21 (slack=4) | unchanged |

All 9 USB3/USB2/MIPI/PCIE diff pairs hit the CoupledPathfinder iteration budget on this baseline.  The budget-exit cohort therefore comprises every diff-pair net the main strategy receives, and the tier-promotion ranks them all to `-1` simultaneously — the relative order inside the cohort is unchanged.  Reach gain requires either:

* shrinking the budget-exit cohort (so promotion creates a differential), OR
* Option B from the issue body (improve BGA-49 inner-ring escape geometry so 4000 iterations suffices for the dense pairs)

Both are out of scope for this PR.

## Implementation

### `src/kicad_tools/router/core.py`

- New instance field `Autorouter._budget_exit_diff_nets: set[int]`, default empty.
- `_get_net_priority(net_id)` consults the set: if the net is a member, complexity_tier becomes **-1** (sorts before the existing tier-0 simple-2-pin promotion and tier-1 default).  Priority class itself is unchanged so class-2 nets stay class-2 (preserves the `_interleave_match_groups` invariants from #2914).

### `src/kicad_tools/router/diffpair_routing.py`

- `route_all_with_diffpairs` populates `autorouter._budget_exit_diff_nets = set(budget_exit_diff_nets)` BEFORE invoking the `non_diffpair_strategy` callback (or the legacy per-net loop).
- `try`/`finally` guarantees the set is cleared after the strategy returns even if the callback raises, so the priority lift is local to that invocation and does not leak across `route_all` / `route_all_negotiated` calls.

### `tests/test_budget_exit_diff_priority.py` (new)

5 focused tests pinning the mechanic:
1. field initialises empty,
2. promotion yields `complexity_tier == -1`,
3. priority CLASS is preserved (only tier flips),
4. clearing the set reverts to baseline tier,
5. non-members are not affected when one sibling is promoted.

### `tests/test_escape_diffpair.py` — `TestBGA49InnerRingCorridorDriftPrevention` (new)

Curator AC #6 fixture: synthetic 7x7 BGA-49 mirroring `boards/06-diffpair-test/generate_pcb.py:generate_bga49_usb3_sink` exactly (1.27 mm pitch, 0.45 mm pads, GND perimeter ring, +3V3/+1V2 inner power, USB3 pairs on row B and F at columns 2/3 and 5/6).  Three gates:

1. **Inner-ring pair MUST produce a corridor reservation** — guards against a refactor that limits the reservation to outer-ring pairs.
2. **Inner-ring pair launch direction MUST be SOUTH** (outward from BGA center) — locks in the launch-direction classifier that the corridor extrusion depends on.
3. **Corridor owner set is the B2/B3 pair only** — no accidental bundling of unrelated USB3 lanes.

## Verification

- [x] `uv run pytest tests/test_budget_exit_diff_priority.py tests/test_escape_diffpair.py tests/test_board_06_diffpair_test.py tests/test_diffpair_routing_integration.py tests/test_corridor_integration.py` — 99 passed
- [x] `uv run pytest tests/router/ -k "not board02_manufacturable_baseline and not board03_routing_baseline and not board07"` — 227 passed, 5 skipped, 8 deselected
- [x] `uv run pytest tests/test_diffpair_routing_integration.py tests/test_diffpair_engagement.py tests/test_diffpair_phase_b.py tests/test_diffpair_per_pair_timeout.py tests/test_diffpair_coupled_floor.py tests/test_router_core_diffpair_timeout.py` — 81 passed
- [x] `uv run python scripts/ci/check_routed_drc.py boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb` — OK, 17 blocking (allowlist max 21)
- [x] `PYTHONHASHSEED=42 uv run python boards/06-diffpair-test/generate_design.py --step route --seed 42` — completes; reach 18/21 unchanged

## Pre-existing test failures (NOT caused by this PR)

- `tests/test_router_core.py::TestPadBlockedByAdjacentNetZero::test_route_to_pad_adjacent_to_net0_pad` — fails on `main` HEAD `facbe2e7`.
- `tests/test_router_core.py::TestAdaptiveAutorouterComponentTransform::test_add_component_rotation` — fails on `main` HEAD `facbe2e7`.

Both verified pre-existing via `git stash` baseline comparison.

## Pieces of the issue this PR does NOT do

- **Option B (root-cause BGA inner-ring escape geometry)** — out of scope; the corridor reservation IS firing for inner-ring pairs (verified by the new drift-prevention test plus a one-shot synthetic-fixture probe that reported `pair_corridor_reservations=4` and `pair_corridor_reserved_cells=792` for the 4 USB3 BGA-49 pairs).  The reach gap is not a corridor-reservation absence but a downstream A* search problem.
- **Iteration / wall-clock budget bumps (Option A)** — explicitly rejected by the curator due to the #3146/#3193 CI determinism contract.
- **Reach lift to 21/21 with seed stability across 3+ seeds (curator AC #1-#4)** — deferred.

## Test plan

- [x] All new tests pass: `uv run pytest tests/test_budget_exit_diff_priority.py tests/test_escape_diffpair.py::TestBGA49InnerRingCorridorDriftPrevention`
- [x] Board 06 routed PCB sidecar gate passes (17 blocking errors ≤ allowlist 21)
- [x] No reach regression: 18/21 baseline preserved
- [x] `route_all_with_diffpairs` test coverage unchanged (existing 81 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)