### PR TITLE
chore(chorus): symlink chorus-test-revA fixture to external repo

### DIFF
--- a/boards/external/chorus-test-revA
+++ b/boards/external/chorus-test-revA
@@ -1,0 +1,1 @@
+../../../chorus/hardware/chorus-test-revA

--- a/tests/test_chorus_reach_floor_3237.py
+++ b/tests/test_chorus_reach_floor_3237.py
@@ -231,13 +231,23 @@ CHORUS_POST_WAVE9_PERNET_SPEEDUP_DAC_CLK = 3.2  # 217s -> 68.6s
 # floor constant retired.
 CHORUS_MAY10_TARGET = 30  # 30/48 = 62.5%
 
-# The external chorus repo path, where the v19_stripped fixture lives.
+# The vendored chorus-test-revA fixture, surfaced via the
+# ``boards/external/chorus-test-revA`` symlink that points at the
+# canonical ``rjwalters/chorus`` repo checkout.  Resolves relative to
+# the repository root (this file is two levels under it), matching the
+# pattern in ``test_chorus_test_placement_feedback.py`` and
+# ``src/kicad_tools/benchmark/cases.py``.
+#
 # When the fixture is missing the slow integration test skips rather than
 # fails, matching the existing pattern in ``test_benchmark_chorus.py``
 # (see ``test_missing_pcb_skips_gracefully``).
-CHORUS_FIXTURE_PATH = Path(
-    "/Users/rwalters/GitHub/chorus/hardware/chorus-test-revA/kicad/"
-    "chorus-test-revA_v19_stripped.kicad_pcb"
+CHORUS_FIXTURE_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "boards"
+    / "external"
+    / "chorus-test-revA"
+    / "kicad"
+    / "chorus-test-revA_v19_stripped.kicad_pcb"
 )
 
 


### PR DESCRIPTION
## Summary

Mirror the softstart pattern from #3341 for the chorus-test-revA fixture: add a symlink at `boards/external/chorus-test-revA` pointing at the canonical `project-shamrock/chorus` checkout (`../chorus/hardware/chorus-test-revA/`).

This consolidates fixture access:
- **Before**: `tests/test_chorus_reach_floor_3237.py` had `/Users/rwalters/GitHub/chorus/...` hardcoded as an absolute path; `test_chorus_test_placement_feedback.py` and `src/kicad_tools/benchmark/cases.py` already expected the symlinked path but it didn't exist yet.
- **After**: all three consumers go through `boards/external/chorus-test-revA/kicad/...`.

## Changes

- ✅ Add symlink `boards/external/chorus-test-revA` → `../../../chorus/hardware/chorus-test-revA`
- ✅ Update `tests/test_chorus_reach_floor_3237.py`: `CHORUS_FIXTURE_PATH` now resolves via the symlink instead of the hardcoded absolute path.

## Verification

```
CHORUS_FIXTURE_PATH:
  → boards/external/chorus-test-revA/kicad/chorus-test-revA_v19_stripped.kicad_pcb
  → resolves to /Users/rwalters/GitHub/chorus/hardware/chorus-test-revA/kicad/chorus-test-revA_v19_stripped.kicad_pcb
  exists: True

placement-feedback v9_grid50 path:
  exists: True

benchmark/cases.py v18 path:
  exists: True

tests/test_chorus_reach_floor_3237.py -m 'not slow': 5 passed
```

## Caveat

Symlink target is relative; assumes `project-shamrock/chorus` is checked out at `../chorus` alongside `kicad-tools`. CI runners without the chorus checkout will see a dangling symlink — same caveat as PR #3341 (softstart). The slow integration tests already skip cleanly when the fixture is missing.

## Follow-up

A separate issue will be filed against `rjwalters/ml-audio-codecs` to retire its duplicated chorus-test-revA copies so there's exactly one source of truth.