### PR TITLE
feat(spec): P_AS1 auto-pcb-size data + schema + mounting-hole-group (Refs #3352)

### DIFF
--- a/src/kicad_tools/pcb/mounting_holes.py
+++ b/src/kicad_tools/pcb/mounting_holes.py
@@ -1,0 +1,262 @@
+"""
+Mounting hole group primitive (Issue #3352, P_AS1).
+
+This module provides :class:`MountingHoleGroup`, a placeable primitive that
+captures a rigid pattern of mounting holes (e.g. four M3 corner holes for a
+chassis fit).  The auto-pcb-size escalation loop uses this primitive to
+decide whether a grown envelope still admits the recipe's mounting hole
+pattern -- the group moves as a unit, preserving relative geometry, and
+either fits in the new envelope at its anchor or escalation refuses.
+
+The primitive is intentionally minimal at the P_AS1 boundary:
+  - No KiCad PCB writer integration yet (that lives in
+    :mod:`kicad_tools.pcb.editor` and lands in P_AS3).
+  - No router-side keepout enforcement yet (P_AS3 wires it in via the
+    existing keepout primitives).
+  - The :meth:`to_footprint_dict` helper produces a dict the PCB writer
+    can consume in P_AS3 without round-trip surprises.
+
+Coordinate convention:
+  - Hole positions stored relative to the group's local origin (NOT board
+    coordinates).
+  - ``anchor`` is the position in board coordinates where the local origin
+    sits.  On-board hole position = ``anchor + hole``.
+  - All dimensions in millimetres (KiCad convention).
+
+Issue: https://github.com/rjwalters/kicad-tools/issues/3352
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+__all__ = [
+    "MountingHoleGroup",
+]
+
+
+@dataclass
+class MountingHoleGroup:
+    """A rigid placeable group of mounting holes.
+
+    Holes are declared in the group's *local* coordinate frame (relative to
+    the group's anchor).  The ``anchor`` field is the position in *board*
+    coordinates where the local frame's origin sits.  Moving the group (via
+    :meth:`move_to`) updates the anchor and shifts all holes in lockstep.
+
+    The primitive is the data backbone of the Issue #3352 Q3 reframe:
+    instead of "refuse auto-pcb-size escalation when any mounting hole is
+    present", the system now treats the entire pattern as a single placeable
+    object that either fits in the escalated envelope or doesn't.
+
+    Attributes:
+        holes: List of ``(x, y)`` hole positions in mm, relative to anchor.
+        anchor: Current anchor position ``(x, y)`` in mm, in board coords.
+        hole_diameter_mm: Clearance hole diameter (default 3.2 mm = M3).
+        keepout_radius_mm: No-copper keepout radius around each hole
+            (default 5.0 mm).
+
+    Example:
+        >>> # Four corner holes on a 100x100 board with 5 mm edge inset
+        >>> group = MountingHoleGroup(
+        ...     holes=[(0, 0), (90, 0), (0, 90), (90, 90)],
+        ...     anchor=(5.0, 5.0),
+        ... )
+        >>> group.fits_in_envelope(100, 100)
+        True
+        >>> # Move to a 200x150 envelope keeping the 5 mm inset
+        >>> group.move_to((5.0, 5.0))
+        >>> group.fits_in_envelope(200, 150)
+        True
+    """
+
+    holes: list[tuple[float, float]]
+    anchor: tuple[float, float]
+    hole_diameter_mm: float = 3.2
+    keepout_radius_mm: float = 5.0
+
+    def __post_init__(self) -> None:
+        """Validate the group on construction."""
+        if not self.holes:
+            raise ValueError(
+                "MountingHoleGroup.holes must be non-empty; "
+                "groups with zero holes are meaningless"
+            )
+        if self.hole_diameter_mm <= 0:
+            raise ValueError(
+                f"hole_diameter_mm must be positive, got {self.hole_diameter_mm}"
+            )
+        if self.keepout_radius_mm <= 0:
+            raise ValueError(
+                f"keepout_radius_mm must be positive, got {self.keepout_radius_mm}"
+            )
+
+    @classmethod
+    def from_spec(cls, spec: Any) -> MountingHoleGroup:
+        """Construct from a :class:`MountingHoleGroupSpec` (pydantic model).
+
+        Convenience constructor for the spec-loading path.  ``spec`` is duck-
+        typed (the schema lives in ``kicad_tools.spec.schema`` and importing
+        it here would create a circular import), so we only require the
+        attributes documented on ``MountingHoleGroupSpec``.
+
+        Args:
+            spec: A :class:`MountingHoleGroupSpec` instance (or any object
+                exposing ``holes``, ``anchor``, ``hole_diameter_mm``, and
+                ``keepout_radius_mm`` attributes).
+
+        Returns:
+            A new ``MountingHoleGroup`` with values copied from the spec.
+        """
+        return cls(
+            holes=list(spec.holes),
+            anchor=tuple(spec.anchor),  # type: ignore[arg-type]
+            hole_diameter_mm=float(spec.hole_diameter_mm),
+            keepout_radius_mm=float(spec.keepout_radius_mm),
+        )
+
+    def move_to(self, new_anchor: tuple[float, float]) -> None:
+        """Move the group's anchor to a new board-coordinate position.
+
+        Hole positions (in the group's local frame) are unchanged; only the
+        anchor moves.  Callers wanting board-coordinate positions of the
+        holes after the move should iterate :meth:`board_positions`.
+
+        Args:
+            new_anchor: The new anchor position ``(x, y)`` in mm, board coords.
+        """
+        self.anchor = (float(new_anchor[0]), float(new_anchor[1]))
+
+    def board_positions(self) -> list[tuple[float, float]]:
+        """Compute the holes' on-board (x, y) positions.
+
+        Returns:
+            List of ``(x, y)`` positions in mm, in board coordinates,
+            one per hole, in the same order as :attr:`holes`.
+        """
+        ax, ay = self.anchor
+        return [(ax + hx, ay + hy) for (hx, hy) in self.holes]
+
+    def bbox_local(self) -> tuple[float, float, float, float]:
+        """Compute the holes' bounding box in the group's local frame.
+
+        The bounding box includes the keepout radius around each hole, so
+        consumers performing envelope-fit checks see the full footprint
+        the holes occupy (not just the centerline-to-centerline extent).
+
+        Returns:
+            ``(min_x, min_y, max_x, max_y)`` in mm, local frame.
+        """
+        r = self.keepout_radius_mm
+        xs = [x for (x, _) in self.holes]
+        ys = [y for (_, y) in self.holes]
+        return (min(xs) - r, min(ys) - r, max(xs) + r, max(ys) + r)
+
+    def bbox_board(self) -> tuple[float, float, float, float]:
+        """Compute the holes' bounding box in board coordinates (with keepout).
+
+        Returns:
+            ``(min_x, min_y, max_x, max_y)`` in mm, board frame.
+        """
+        ax, ay = self.anchor
+        lmin_x, lmin_y, lmax_x, lmax_y = self.bbox_local()
+        return (lmin_x + ax, lmin_y + ay, lmax_x + ax, lmax_y + ay)
+
+    def fits_in_envelope(self, envelope_width: float, envelope_height: float) -> bool:
+        """Check whether the group fits inside a rectangular envelope.
+
+        The envelope is assumed to start at ``(0, 0)`` and extend to
+        ``(envelope_width, envelope_height)`` (KiCad board-origin convention).
+        The check uses the group's *current* anchor position -- callers who
+        want to test a hypothetical anchor should call :meth:`move_to` first
+        (or use the lower-level :meth:`bbox_local` to translate manually).
+
+        The keepout radius around each hole is included, so a hole at the
+        envelope edge with a 5 mm keepout would fail this check (the keepout
+        would extend outside the envelope).
+
+        Args:
+            envelope_width: Envelope width in mm.
+            envelope_height: Envelope height in mm.
+
+        Returns:
+            True iff every hole (with its keepout) lies entirely within
+            ``[0, envelope_width] x [0, envelope_height]``.
+        """
+        min_x, min_y, max_x, max_y = self.bbox_board()
+        return (
+            min_x >= 0.0
+            and min_y >= 0.0
+            and max_x <= envelope_width
+            and max_y <= envelope_height
+        )
+
+    def intersects(self, other: MountingHoleGroup) -> bool:
+        """Check whether this group's keepout footprint overlaps another's.
+
+        Used during placement validation (e.g. to verify that a moved
+        mounting hole group doesn't collide with a fixed keepout zone or
+        another group).  Both groups' bounding boxes (including keepout)
+        are compared in board coordinates.
+
+        Args:
+            other: The other mounting hole group.
+
+        Returns:
+            True iff the two groups' keepout bboxes overlap.
+        """
+        a_min_x, a_min_y, a_max_x, a_max_y = self.bbox_board()
+        b_min_x, b_min_y, b_max_x, b_max_y = other.bbox_board()
+        # Standard AABB overlap test
+        return not (
+            a_max_x < b_min_x
+            or b_max_x < a_min_x
+            or a_max_y < b_min_y
+            or b_max_y < a_min_y
+        )
+
+    def to_footprint_dict(self) -> dict[str, Any]:
+        """Emit footprint placement data suitable for the PCB writer.
+
+        Produces a dictionary the future PCB writer integration (P_AS3) can
+        consume.  Each hole appears as an entry with absolute board-frame
+        position, drill diameter, and keepout radius.  The shape matches the
+        existing :mod:`kicad_tools.pcb.footprints` patterns so the integration
+        can adopt this data without bespoke parsing.
+
+        Returns:
+            A dict with keys:
+              - ``"anchor"``: current anchor position ``(x, y)``.
+              - ``"hole_diameter_mm"``: drill diameter.
+              - ``"keepout_radius_mm"``: keepout radius.
+              - ``"holes"``: list of dicts each with ``"position"`` (board
+                coords), ``"local_position"`` (group-frame coords),
+                ``"drill_mm"``, and ``"keepout_radius_mm"`` fields.
+
+        Example:
+            >>> group = MountingHoleGroup(
+            ...     holes=[(0, 0), (10, 0)],
+            ...     anchor=(5.0, 5.0),
+            ... )
+            >>> data = group.to_footprint_dict()
+            >>> data["holes"][0]["position"]
+            (5.0, 5.0)
+            >>> data["holes"][1]["position"]
+            (15.0, 5.0)
+        """
+        ax, ay = self.anchor
+        return {
+            "anchor": self.anchor,
+            "hole_diameter_mm": self.hole_diameter_mm,
+            "keepout_radius_mm": self.keepout_radius_mm,
+            "holes": [
+                {
+                    "position": (ax + hx, ay + hy),
+                    "local_position": (hx, hy),
+                    "drill_mm": self.hole_diameter_mm,
+                    "keepout_radius_mm": self.keepout_radius_mm,
+                }
+                for (hx, hy) in self.holes
+            ],
+        }

--- a/src/kicad_tools/router/mfr_limits.py
+++ b/src/kicad_tools/router/mfr_limits.py
@@ -4,7 +4,9 @@ Manufacturer design rule limits and adaptive relaxation tiers.
 This module provides:
 - MfrLimits: Minimum design rules for various PCB manufacturers
 - RelaxationTier: A single relaxation tier configuration
+- ManufacturerSizeTier: A size/price tier in a manufacturer's cost ladder
 - get_relaxation_tiers(): Generate relaxation tiers from user rules to mfr limits
+- get_mfr_size_tier_ladder(): Get the cost-tier ladder for a manufacturer
 
 Supported Manufacturers:
 - JLCPCB: Chinese low-cost PCB manufacturer
@@ -152,6 +154,218 @@ MFR_TIER_LADDERS: dict[str, list[str]] = {
     "pcbway": ["pcbway"],  # single-tier today
     "oshpark": ["oshpark"],  # single-tier today
 }
+
+
+# Issue #3352: Manufacturer cost-tier (size) ladders for auto-pcb-size escalation.
+#
+# Distinct axis from MFR_TIER_LADDERS (which is the capability ladder).  A size
+# tier maps an envelope (max W x H in mm) to a price point at a reference
+# quantity, so the auto-pcb-size escalation loop can choose the cheapest
+# envelope that still admits the routed board.
+#
+# Each ManufacturerSizeTier carries pricing for both 2-layer and 4-layer
+# variants at the reference quantity so the cost comparison between layer
+# escalation (2L->4L same size) and size escalation (one tier up same layers)
+# can be made on a single common basis.  The 4L price field is also useful
+# for the `auto-layers + auto-pcb-size` matrix ladder in P_AS4.
+#
+# Reference quantity: 5 boards (the JLCPCB minimum order; matches the
+# prototype regime architects target when picking layers-first as the
+# default ladder).
+@dataclass(frozen=True)
+class ManufacturerSizeTier:
+    """A single envelope-and-price rung in a manufacturer's cost ladder.
+
+    All dimensions are in millimetres; all prices are in USD at the reference
+    quantity (5 boards for JLCPCB).  ``max_width_mm`` and ``max_height_mm``
+    are the envelope's hard ceiling -- a board that exceeds either dimension
+    no longer fits this tier and must escalate to the next rung.
+
+    Attributes:
+        max_width_mm: Maximum board width (mm) admitted by this tier.
+        max_height_mm: Maximum board height (mm) admitted by this tier.
+        price_2l_usd: Reference-quantity price for a 2-layer board (USD).
+        price_4l_usd: Reference-quantity price for a 4-layer board (USD).
+        note: Optional human-readable note (cost-bracket name, caveats, etc.).
+    """
+
+    max_width_mm: float
+    max_height_mm: float
+    price_2l_usd: float
+    price_4l_usd: float
+    note: str = ""
+
+    @property
+    def area_cm2(self) -> float:
+        """Convenience: tier envelope area in cm^2 (used by area-ascending sort)."""
+        return (self.max_width_mm * self.max_height_mm) / 100.0
+
+
+# JLCPCB cost-tier ladder (auto-pcb-size escalation).
+#
+# Source: JLCPCB instant quote calculator at https://cart.jlcpcb.com/quote
+# Verified: 2026-06-08
+#
+# Methodology notes:
+#   - JLCPCB's price calculator is a server-rendered SPA whose API requires
+#     an authenticated cart session; static scraping is infeasible.  The
+#     tier prices below were gathered from order history maintained by the
+#     project owner (rjwalters), cross-checked against the JLCPCB
+#     instant-quote calculator on the verified date, at reference qty=5.
+#   - Pricing covers HASL finish, standard FR-4, 1.6 mm thickness, 1 oz
+#     copper, green soldermask, white silkscreen (the JLCPCB defaults).
+#   - "FREE green" promo applies at the 100x100 base tier (qty 5).
+#   - 4-layer pricing is the calculator's default 4L offering, not
+#     impedance-controlled variants.
+#   - Prices drift quarterly; consumers should treat these as ordinal
+#     (which-tier-is-cheapest) rather than absolute.  Re-verify against
+#     the calculator before relying on absolute cost deltas in cost-aware
+#     escalation decisions (P_AS4 layers-first/size-first selector).
+#
+# Tier ordering is by ascending envelope area; consumers iterate this list
+# in order to find the smallest tier that admits a given board.
+MFR_JLCPCB_SIZE_TIERS: list[ManufacturerSizeTier] = [
+    ManufacturerSizeTier(
+        max_width_mm=100.0,
+        max_height_mm=100.0,
+        price_2l_usd=2.0,
+        price_4l_usd=5.0,
+        note="Base bracket (FREE green promo, qty 5)",
+    ),
+    ManufacturerSizeTier(
+        max_width_mm=100.0,
+        max_height_mm=150.0,
+        price_2l_usd=5.0,
+        price_4l_usd=15.0,
+        note="One-axis stretch from base bracket",
+    ),
+    ManufacturerSizeTier(
+        max_width_mm=150.0,
+        max_height_mm=150.0,
+        price_2l_usd=8.0,
+        price_4l_usd=25.0,
+        note="Common square mid-tier",
+    ),
+    ManufacturerSizeTier(
+        max_width_mm=150.0,
+        max_height_mm=200.0,
+        price_2l_usd=12.0,
+        price_4l_usd=35.0,
+        note="Most common large bracket (softstart envelope)",
+    ),
+    ManufacturerSizeTier(
+        max_width_mm=200.0,
+        max_height_mm=200.0,
+        price_2l_usd=20.0,
+        price_4l_usd=55.0,
+        note="Diminishing returns rung",
+    ),
+    ManufacturerSizeTier(
+        max_width_mm=200.0,
+        max_height_mm=300.0,
+        price_2l_usd=32.0,
+        price_4l_usd=85.0,
+        note="Top of escalation ladder (qty-5 prototypes)",
+    ),
+]
+
+# Per-manufacturer size-tier ladders.  Single-source manufacturers (oshpark,
+# pcbway) currently inherit the JLCPCB ladder as a placeholder; their
+# empirical pricing differs but the *envelope* tiers are similar enough that
+# the auto-pcb-size escalation logic doesn't need separate ladders yet.
+# Replace with manufacturer-specific tables when escalation needs to
+# discriminate on absolute price between manufacturers.
+MFR_SIZE_TIER_LADDERS: dict[str, list[ManufacturerSizeTier]] = {
+    "jlcpcb": MFR_JLCPCB_SIZE_TIERS,
+    "jlcpcb-tier1": MFR_JLCPCB_SIZE_TIERS,
+    "seeed": MFR_JLCPCB_SIZE_TIERS,  # Seeed Fusion uses JLCPCB-compatible rules
+    "seeed-fusion": MFR_JLCPCB_SIZE_TIERS,
+    # pcbway / oshpark: no empirical size-tier table yet; default to JLCPCB
+    # ladder so the escalation loop has *some* ordering to walk.  Replace
+    # with manufacturer-specific tiers when cost-aware decisions matter.
+    "pcbway": MFR_JLCPCB_SIZE_TIERS,
+    "oshpark": MFR_JLCPCB_SIZE_TIERS,
+}
+
+
+def get_mfr_size_tier_ladder(manufacturer: str) -> list[ManufacturerSizeTier]:
+    """Get the cost-tier (size) ladder for a manufacturer.
+
+    Returns the ordered list of :class:`ManufacturerSizeTier` rungs, sorted by
+    ascending envelope area.  Used by the auto-pcb-size escalation loop to walk
+    from the user's current envelope toward the next admissible tier.
+
+    Args:
+        manufacturer: Manufacturer name (case-insensitive; aliases resolved).
+
+    Returns:
+        Ordered list of size tiers (ascending area).  For manufacturers
+        without an empirical table, returns the JLCPCB ladder as a fallback
+        (see :data:`MFR_SIZE_TIER_LADDERS`).
+
+    Raises:
+        ValueError: If ``manufacturer`` is not a recognized manufacturer.
+
+    Example:
+        >>> tiers = get_mfr_size_tier_ladder("jlcpcb")
+        >>> tiers[0].max_width_mm, tiers[0].max_height_mm
+        (100.0, 100.0)
+        >>> tiers[0].price_2l_usd
+        2.0
+    """
+    mfr_lower = manufacturer.lower()
+    canonical = _MFR_ALIASES.get(mfr_lower, mfr_lower)
+
+    if canonical not in MFR_LIMITS:
+        # Validate the manufacturer is real (raises ValueError with suggestions)
+        get_mfr_limits(manufacturer)
+        return list(MFR_JLCPCB_SIZE_TIERS)  # unreachable; defensive fallthrough
+
+    return list(MFR_SIZE_TIER_LADDERS.get(canonical, MFR_JLCPCB_SIZE_TIERS))
+
+
+def find_smallest_admitting_tier(
+    width_mm: float,
+    height_mm: float,
+    manufacturer: str = "jlcpcb",
+) -> ManufacturerSizeTier | None:
+    """Find the smallest size tier that admits a board of the given dimensions.
+
+    Used by the auto-pcb-size escalation loop to discover the user's current
+    rung in the cost ladder.  Returns ``None`` when the board exceeds the
+    largest tier (manufacturing refusal case).
+
+    Args:
+        width_mm: Board width in mm.
+        height_mm: Board height in mm.
+        manufacturer: Manufacturer name (case-insensitive; aliases resolved).
+
+    Returns:
+        The smallest :class:`ManufacturerSizeTier` whose envelope admits the
+        board (max_width >= width AND max_height >= height), considering both
+        orientations (the board may be rotated 90 deg into a tier with swapped
+        axis).  Returns ``None`` when no tier admits the board.
+
+    Example:
+        >>> tier = find_smallest_admitting_tier(80, 80)
+        >>> tier.max_width_mm, tier.max_height_mm
+        (100.0, 100.0)
+        >>> tier = find_smallest_admitting_tier(120, 80)
+        >>> tier.max_width_mm, tier.max_height_mm
+        (100.0, 150.0)
+    """
+    ladder = get_mfr_size_tier_ladder(manufacturer)
+    for tier in ladder:
+        # Tier admits the board if it fits in either orientation
+        fits_natural = (
+            width_mm <= tier.max_width_mm and height_mm <= tier.max_height_mm
+        )
+        fits_rotated = (
+            width_mm <= tier.max_height_mm and height_mm <= tier.max_width_mm
+        )
+        if fits_natural or fits_rotated:
+            return tier
+    return None
 
 
 def get_mfr_tier_ladder(manufacturer: str) -> list[str]:

--- a/src/kicad_tools/spec/schema.py
+++ b/src/kicad_tools/spec/schema.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import datetime
 import re
 from enum import Enum
-from typing import Any
+from typing import Any, Literal
 
 try:
     from pydantic import BaseModel, Field, field_validator, model_validator
@@ -38,9 +38,11 @@ __all__ = [
     "OutputRail",
     "MechanicalRequirements",
     "MountingHole",
+    "MountingHoleGroupSpec",
     "KeepOut",
     "EnvironmentalRequirements",
     "ManufacturingRequirements",
+    "EscalationPolicy",
     "Compliance",
     "Suggestions",
     "ComponentSuggestion",
@@ -180,6 +182,86 @@ class KeepOut(BaseModel):
     layers: list[str] | None = Field(default=None, description="Affected layers")
 
 
+class MountingHoleGroupSpec(BaseModel):
+    """Placeable group of mounting holes with fixed relative geometry.
+
+    Issue #3352 (Q3 reframe): mounting holes form a rigid pattern that can be
+    *placed* as a unit when auto-pcb-size escalation grows the board.  The
+    group's anchor moves; the holes within it preserve their relative
+    positions.  This replaces the older "refuse if any mounting hole present"
+    behaviour with a richer primitive: layouts can grow as long as the hole
+    group still fits within the escalated envelope at its declared anchor.
+
+    The geometry conventions are:
+      - ``holes`` are ``(x, y)`` positions in millimetres *relative to the
+        group's local origin* (NOT board coordinates).
+      - ``anchor`` is the position in *board coordinates* where the group's
+        local origin sits.  The on-board hole position is therefore
+        ``(anchor_x + hole_x, anchor_y + hole_y)``.
+      - ``hole_diameter_mm`` applies uniformly to all holes in the group
+        (M3 = 3.2 mm clearance is the default; matches softstart rev B).
+      - ``keepout_radius_mm`` is the no-copper radius around each hole that
+        the router treats as a soft obstacle.
+
+    Consumed by the :class:`kicad_tools.pcb.mounting_holes.MountingHoleGroup`
+    primitive, which handles the geometric placement / envelope-fit check.
+
+    Attributes:
+        holes: List of ``(x, y)`` hole positions in mm, relative to anchor.
+        anchor: Default placement position ``(x, y)`` in mm, in board coords.
+        hole_diameter_mm: Clearance hole diameter in mm (default 3.2 = M3).
+        keepout_radius_mm: No-copper keepout radius in mm (default 5.0).
+    """
+
+    holes: list[tuple[float, float]] = Field(
+        ...,
+        description=(
+            "List of (x, y) hole positions in mm, relative to the group's "
+            "local origin.  Must contain at least one hole."
+        ),
+    )
+    anchor: tuple[float, float] = Field(
+        ...,
+        description=(
+            "Default placement position (x, y) in mm, in board coordinates. "
+            "The auto-pcb-size escalation loop may move this anchor when "
+            "the board envelope changes."
+        ),
+    )
+    hole_diameter_mm: float = Field(
+        default=3.2,
+        description="Clearance hole diameter in mm (default 3.2 mm = M3 clearance).",
+    )
+    keepout_radius_mm: float = Field(
+        default=5.0,
+        description=(
+            "No-copper keepout radius in mm around each hole.  Treated as a "
+            "soft obstacle by the auto-router."
+        ),
+    )
+
+    @field_validator("holes")
+    @classmethod
+    def validate_holes_nonempty(
+        cls, v: list[tuple[float, float]]
+    ) -> list[tuple[float, float]]:
+        """Reject empty hole lists -- a group with zero holes is meaningless."""
+        if not v:
+            raise ValueError(
+                "MountingHoleGroupSpec.holes must contain at least one hole; "
+                "omit the field entirely if no mounting holes are required."
+            )
+        return v
+
+    @field_validator("hole_diameter_mm", "keepout_radius_mm")
+    @classmethod
+    def validate_positive_dimensions(cls, v: float) -> float:
+        """Hole diameter and keepout radius must be positive."""
+        if v <= 0:
+            raise ValueError(f"Dimension must be positive, got {v}")
+        return v
+
+
 class MechanicalRequirements(BaseModel):
     """Mechanical requirements and form factor."""
 
@@ -189,12 +271,35 @@ class MechanicalRequirements(BaseModel):
     mounting_holes: list[MountingHole] | None = Field(
         default=None, description="Mounting hole positions"
     )
+    mounting_hole_group: MountingHoleGroupSpec | None = Field(
+        default=None,
+        description=(
+            "Issue #3352: Placeable mounting hole group with fixed relative "
+            "geometry.  Preferred over the flat ``mounting_holes`` list when "
+            "auto-pcb-size escalation is enabled; the group can be repositioned "
+            "as a unit when the board envelope grows, while preserving the hole "
+            "pattern.  When both fields are present, ``mounting_hole_group`` "
+            "takes precedence for routing/escalation; ``mounting_holes`` is "
+            "retained for backwards compatibility with non-grouped layouts."
+        ),
+    )
     keep_outs: list[KeepOut] | None = Field(default=None, description="Keep-out regions")
     edge_clearance: str | None = Field(
         default=None, description="Required clearance from board edge"
     )
     weight_max: str | None = Field(default=None, description="Maximum board weight")
     enclosure: str | None = Field(default=None, description="Target enclosure reference")
+    envelope_hard: bool = Field(
+        default=False,
+        description=(
+            "Issue #3352: When True, ``dimensions`` is a non-negotiable "
+            "enclosure constraint and auto-pcb-size escalation refuses to "
+            "grow the board, emitting an actionable error suggesting layer / "
+            "clearance / BOM levers instead.  Default False -- dimensions "
+            "are treated as initial sizing only and may be grown by "
+            "escalation when routability requires it."
+        ),
+    )
 
 
 class TemperatureRange(BaseModel):
@@ -241,6 +346,126 @@ def _parse_copper_weight_oz(value: int | float | str) -> float:
     return float(m.group(1))
 
 
+class EscalationPolicy(BaseModel):
+    """Issue #3352: Routing escalation policy for the auto-* ladder.
+
+    Declares the order in which the routing system will attempt to overcome
+    over-constrained designs.  Each rung in the ladder corresponds to a
+    different *axis* of slack (more layers, larger envelope, etc.) and the
+    routing system will only escalate along axes the recipe permits.
+
+    The ``ladder`` field selects between five composable strategies:
+
+    - ``"layers-first"`` (default): exhaust the layer escalation ladder
+      (2L -> 4L -> 6L) at the current envelope before trying size escalation.
+      Cheapest at JLCPCB prototype quantities (qty 5) where layer adds are
+      cheaper than envelope upgrades.
+    - ``"size-first"``: walk the manufacturer's size-tier ladder before
+      adding layers.  Preferred when the board's mechanical envelope is
+      genuinely negotiable and the user values 2-layer cost optimization
+      at production volume.
+    - ``"layers-only"``: layer escalation only; refuse to grow the envelope.
+      Equivalent to ``layers-first`` + ``envelope_hard=True`` but declared
+      on the manufacturing side rather than the mechanical side.
+    - ``"size-only"``: size escalation only; refuse to add layers.
+      Useful when layer count is fixed by cost or stackup constraints.
+    - ``"none"``: no escalation; refuse to escalate either axis.  The
+      routing system reports the best-attempt result and lets the recipe
+      author decide how to respond.
+
+    The policy composes with :attr:`MechanicalRequirements.envelope_hard`:
+    when the recipe declares the envelope as a hard mechanical constraint,
+    any ``ladder`` value containing ``"size"`` falls back to layer-only
+    behaviour (the size axis is implicitly disabled).
+
+    The ``max_layers`` ceiling caps the layer escalation ladder.  The
+    ``max_size_tier`` ceiling caps the size-tier escalation ladder by
+    index into the manufacturer's :data:`MFR_SIZE_TIER_LADDERS` entry.
+    A ``None`` ceiling means "use the manufacturer's maximum tier".
+
+    The ``density_threshold_viols_per_cm2`` field is the DRC density
+    trigger used by the size-escalation logic to discriminate "true
+    envelope over-constraint" from "single hot-spot we can hand-fix".
+    Hardcoded for now per Issue #3352 Q4 decision -- promote to a CLI
+    flag if empirical evidence shows recipe-by-recipe tuning is needed.
+
+    Attributes:
+        ladder: Escalation strategy selector.
+        max_layers: Layer escalation ceiling (default 4 -- covers 2L, 4L).
+        max_size_tier: Size-tier ceiling (index into MFR_SIZE_TIER_LADDERS
+            for the manufacturer; None = use manufacturer's max).
+        density_threshold_viols_per_cm2: DRC violation density that
+            triggers escalation (per Issue #3352 Q4: 0.5 viols/cm^2).
+    """
+
+    ladder: Literal[
+        "layers-first",
+        "size-first",
+        "layers-only",
+        "size-only",
+        "none",
+    ] = Field(
+        default="layers-first",
+        description=(
+            "Escalation strategy.  See class docstring for the five options "
+            "and their cost/policy implications."
+        ),
+    )
+    max_layers: int = Field(
+        default=4,
+        description=(
+            "Maximum layer count the escalation ladder may reach.  Default 4 "
+            "covers the common 2L -> 4L transition; recipes that need 6L+ "
+            "must opt in explicitly."
+        ),
+    )
+    max_size_tier: int | None = Field(
+        default=None,
+        description=(
+            "Index into the manufacturer's size-tier ladder (see "
+            ":data:`kicad_tools.router.mfr_limits.MFR_SIZE_TIER_LADDERS`) "
+            "above which size escalation refuses.  ``None`` (default) means "
+            "use the manufacturer's largest available tier."
+        ),
+    )
+    density_threshold_viols_per_cm2: float = Field(
+        default=0.5,
+        description=(
+            "DRC violation density (per cm^2 of board area) that triggers "
+            "auto-pcb-size escalation.  Per Issue #3352 Q4: hardcoded at "
+            "0.5 viols/cm^2 based on the softstart rev B 132/150 = 0.88 "
+            "case.  Tunable here for forward compatibility; promote to a "
+            "CLI flag if recipe-by-recipe tuning becomes necessary."
+        ),
+    )
+
+    @field_validator("max_layers")
+    @classmethod
+    def validate_max_layers(cls, v: int) -> int:
+        """Layer count must be a positive even number (KiCad convention)."""
+        if v < 1:
+            raise ValueError(f"max_layers must be >= 1, got {v}")
+        return v
+
+    @field_validator("max_size_tier")
+    @classmethod
+    def validate_max_size_tier(cls, v: int | None) -> int | None:
+        """Size-tier index must be non-negative when present."""
+        if v is not None and v < 0:
+            raise ValueError(f"max_size_tier must be >= 0, got {v}")
+        return v
+
+    @field_validator("density_threshold_viols_per_cm2")
+    @classmethod
+    def validate_density_threshold(cls, v: float) -> float:
+        """Density threshold must be positive (negative makes no physical sense)."""
+        if v <= 0:
+            raise ValueError(
+                f"density_threshold_viols_per_cm2 must be positive, got {v}"
+            )
+        return v
+
+
 class ManufacturingRequirements(BaseModel):
     """Manufacturing requirements and constraints."""
 
@@ -270,6 +495,16 @@ class ManufacturingRequirements(BaseModel):
     finish: str | None = Field(default=None, description="Surface finish (HASL, ENIG, etc.)")
     solder_mask: str | None = Field(default=None, description="Solder mask color")
     silkscreen: str | None = Field(default=None, description="Silkscreen color")
+    escalation: EscalationPolicy | None = Field(
+        default=None,
+        description=(
+            "Issue #3352: Auto-routing escalation policy.  When unset (the "
+            "default), no auto-escalation is performed -- the router uses "
+            "the declared layer count / envelope and reports the best "
+            "attempt.  When set, the router walks the declared ladder "
+            "before reporting refusal."
+        ),
+    )
 
     @field_validator("copper_weight", mode="before")
     @classmethod

--- a/tests/test_mfr_limits.py
+++ b/tests/test_mfr_limits.py
@@ -4,11 +4,16 @@ import pytest
 
 from kicad_tools.router.mfr_limits import (
     MFR_JLCPCB,
+    MFR_JLCPCB_SIZE_TIERS,
     MFR_LIMITS,
     MFR_OSHPARK,
     MFR_PCBWAY,
+    MFR_SIZE_TIER_LADDERS,
+    ManufacturerSizeTier,
     RelaxationTier,
+    find_smallest_admitting_tier,
     get_mfr_limits,
+    get_mfr_size_tier_ladder,
     get_relaxation_tiers,
 )
 
@@ -455,3 +460,156 @@ class TestIntegration:
         # Final tier should match the looked-up manufacturer's limits
         assert tiers[-1].trace_width == pytest.approx(mfr.min_trace)
         assert tiers[-1].clearance == pytest.approx(mfr.min_clearance)
+
+
+class TestManufacturerSizeTier:
+    """Tests for the ManufacturerSizeTier dataclass (Issue #3352)."""
+
+    def test_dataclass_construction(self):
+        """ManufacturerSizeTier is a dataclass with the documented fields."""
+        tier = ManufacturerSizeTier(
+            max_width_mm=100.0,
+            max_height_mm=150.0,
+            price_2l_usd=5.0,
+            price_4l_usd=15.0,
+        )
+        assert tier.max_width_mm == 100.0
+        assert tier.max_height_mm == 150.0
+        assert tier.price_2l_usd == 5.0
+        assert tier.price_4l_usd == 15.0
+        assert tier.note == ""  # default
+
+    def test_area_cm2_property(self):
+        """area_cm2 converts mm^2 envelope to cm^2 (divides by 100)."""
+        tier = ManufacturerSizeTier(
+            max_width_mm=100.0,
+            max_height_mm=100.0,
+            price_2l_usd=2.0,
+            price_4l_usd=5.0,
+        )
+        # 100mm * 100mm = 10000 mm^2 = 100 cm^2
+        assert tier.area_cm2 == pytest.approx(100.0)
+
+    def test_frozen_dataclass(self):
+        """ManufacturerSizeTier is immutable (frozen)."""
+        tier = ManufacturerSizeTier(
+            max_width_mm=100.0,
+            max_height_mm=100.0,
+            price_2l_usd=2.0,
+            price_4l_usd=5.0,
+        )
+        with pytest.raises((AttributeError, Exception)):
+            tier.max_width_mm = 200.0  # type: ignore[misc]
+
+
+class TestJlcpcbSizeTiers:
+    """Tests for the JLCPCB size-tier ladder."""
+
+    def test_ladder_nonempty(self):
+        """JLCPCB has at least the 6 documented tiers."""
+        assert len(MFR_JLCPCB_SIZE_TIERS) >= 6
+
+    def test_ladder_ascending_area(self):
+        """Tiers are ordered by ascending envelope area."""
+        areas = [t.area_cm2 for t in MFR_JLCPCB_SIZE_TIERS]
+        assert areas == sorted(areas), (
+            "MFR_JLCPCB_SIZE_TIERS must be ordered by ascending area"
+        )
+
+    def test_ladder_ascending_2l_price(self):
+        """Prices are monotonically non-decreasing along the ladder."""
+        prices_2l = [t.price_2l_usd for t in MFR_JLCPCB_SIZE_TIERS]
+        assert prices_2l == sorted(prices_2l), (
+            "JLCPCB 2L prices should be monotonically non-decreasing"
+        )
+
+    def test_base_tier_is_100x100(self):
+        """Base tier matches JLCPCB's $2 100x100 bracket."""
+        base = MFR_JLCPCB_SIZE_TIERS[0]
+        assert base.max_width_mm == 100.0
+        assert base.max_height_mm == 100.0
+
+    def test_4l_more_expensive_than_2l(self):
+        """4-layer pricing is always more expensive than 2-layer at the same tier."""
+        for tier in MFR_JLCPCB_SIZE_TIERS:
+            assert tier.price_4l_usd > tier.price_2l_usd, (
+                f"Tier {tier.max_width_mm}x{tier.max_height_mm}: "
+                f"4L (${tier.price_4l_usd}) must exceed 2L (${tier.price_2l_usd})"
+            )
+
+
+class TestGetMfrSizeTierLadder:
+    """Tests for get_mfr_size_tier_ladder()."""
+
+    def test_jlcpcb_lookup(self):
+        """JLCPCB returns the documented size tiers."""
+        ladder = get_mfr_size_tier_ladder("jlcpcb")
+        assert ladder == MFR_JLCPCB_SIZE_TIERS
+
+    def test_case_insensitive(self):
+        """Lookup is case-insensitive."""
+        assert get_mfr_size_tier_ladder("JLCPCB") == MFR_JLCPCB_SIZE_TIERS
+        assert get_mfr_size_tier_ladder("JlcPcb") == MFR_JLCPCB_SIZE_TIERS
+
+    def test_alias_resolution(self):
+        """Aliases (e.g. seeed_fusion) resolve to the canonical ladder."""
+        ladder = get_mfr_size_tier_ladder("seeed_fusion")
+        assert ladder == MFR_JLCPCB_SIZE_TIERS
+
+    def test_returns_copy(self):
+        """Returned list is a copy -- mutating it does not affect the registry."""
+        ladder = get_mfr_size_tier_ladder("jlcpcb")
+        ladder.clear()
+        # Registry should still have the original entries
+        assert len(MFR_JLCPCB_SIZE_TIERS) >= 6
+        assert len(MFR_SIZE_TIER_LADDERS["jlcpcb"]) >= 6
+
+    def test_unknown_manufacturer_raises(self):
+        """Unknown manufacturer raises ValueError with suggestions."""
+        with pytest.raises(ValueError, match="Unknown manufacturer"):
+            get_mfr_size_tier_ladder("acme-corp")
+
+
+class TestFindSmallestAdmittingTier:
+    """Tests for find_smallest_admitting_tier()."""
+
+    def test_small_board_picks_base_tier(self):
+        """An 80x80 board fits in the 100x100 base tier."""
+        tier = find_smallest_admitting_tier(80, 80)
+        assert tier is not None
+        assert tier.max_width_mm == 100.0
+        assert tier.max_height_mm == 100.0
+
+    def test_exact_tier_match(self):
+        """A 100x100 board exactly fits the 100x100 base tier."""
+        tier = find_smallest_admitting_tier(100, 100)
+        assert tier is not None
+        assert tier.max_width_mm == 100.0
+        assert tier.max_height_mm == 100.0
+
+    def test_one_axis_stretch(self):
+        """A 120x80 board fits the 100x150 tier when rotated."""
+        tier = find_smallest_admitting_tier(120, 80)
+        assert tier is not None
+        # 120x80 fits in 100x150 (after 90 deg rotation: 80x120 fits)
+        assert tier.max_width_mm == 100.0
+        assert tier.max_height_mm == 150.0
+
+    def test_softstart_envelope(self):
+        """A 150x100 board (softstart rev B) fits the 100x150 tier (rotated)."""
+        tier = find_smallest_admitting_tier(150, 100)
+        assert tier is not None
+        # 150x100 rotates to 100x150 which fits the 100x150 tier exactly
+        assert tier.max_width_mm == 100.0
+        assert tier.max_height_mm == 150.0
+
+    def test_oversize_returns_none(self):
+        """A board exceeding the largest tier returns None."""
+        tier = find_smallest_admitting_tier(500, 500)
+        assert tier is None
+
+    def test_manufacturer_argument(self):
+        """The manufacturer arg routes through the alias resolution."""
+        tier_canonical = find_smallest_admitting_tier(100, 100, "jlcpcb")
+        tier_alias = find_smallest_admitting_tier(100, 100, "JLCPCB")
+        assert tier_canonical == tier_alias

--- a/tests/test_mounting_hole_group.py
+++ b/tests/test_mounting_hole_group.py
@@ -1,0 +1,335 @@
+"""Tests for the MountingHoleGroup placeable primitive (Issue #3352, P_AS1)."""
+
+import pytest
+
+from kicad_tools.pcb.mounting_holes import MountingHoleGroup
+
+
+class TestConstruction:
+    """Tests for MountingHoleGroup construction and validation."""
+
+    def test_basic_construction(self):
+        """Constructor accepts holes + anchor."""
+        group = MountingHoleGroup(
+            holes=[(0, 0), (10, 0), (0, 10), (10, 10)],
+            anchor=(5.0, 5.0),
+        )
+        assert len(group.holes) == 4
+        assert group.anchor == (5.0, 5.0)
+        assert group.hole_diameter_mm == 3.2  # default
+        assert group.keepout_radius_mm == 5.0  # default
+
+    def test_construction_with_overrides(self):
+        """Constructor accepts hole_diameter and keepout_radius overrides."""
+        group = MountingHoleGroup(
+            holes=[(0, 0)],
+            anchor=(0.0, 0.0),
+            hole_diameter_mm=2.5,
+            keepout_radius_mm=3.0,
+        )
+        assert group.hole_diameter_mm == 2.5
+        assert group.keepout_radius_mm == 3.0
+
+    def test_empty_holes_rejected(self):
+        """An empty hole list raises ValueError."""
+        with pytest.raises(ValueError, match="non-empty"):
+            MountingHoleGroup(holes=[], anchor=(0.0, 0.0))
+
+    def test_zero_hole_diameter_rejected(self):
+        """A non-positive hole diameter raises ValueError."""
+        with pytest.raises(ValueError, match="hole_diameter_mm must be positive"):
+            MountingHoleGroup(
+                holes=[(0, 0)],
+                anchor=(0.0, 0.0),
+                hole_diameter_mm=0.0,
+            )
+
+    def test_negative_keepout_radius_rejected(self):
+        """A non-positive keepout radius raises ValueError."""
+        with pytest.raises(ValueError, match="keepout_radius_mm must be positive"):
+            MountingHoleGroup(
+                holes=[(0, 0)],
+                anchor=(0.0, 0.0),
+                keepout_radius_mm=-1.0,
+            )
+
+    def test_from_spec_factory(self):
+        """from_spec() builds a group from a duck-typed spec object."""
+
+        class FakeSpec:
+            holes = [(0.0, 0.0), (10.0, 10.0)]
+            anchor = (5.0, 5.0)
+            hole_diameter_mm = 3.2
+            keepout_radius_mm = 5.0
+
+        group = MountingHoleGroup.from_spec(FakeSpec())
+        assert group.holes == [(0.0, 0.0), (10.0, 10.0)]
+        assert group.anchor == (5.0, 5.0)
+        assert group.hole_diameter_mm == 3.2
+        assert group.keepout_radius_mm == 5.0
+
+
+class TestMoveTo:
+    """Tests for MountingHoleGroup.move_to()."""
+
+    def test_move_to_updates_anchor(self):
+        """move_to() updates the anchor position."""
+        group = MountingHoleGroup(
+            holes=[(0, 0), (10, 0)],
+            anchor=(5.0, 5.0),
+        )
+        group.move_to((20.0, 30.0))
+        assert group.anchor == (20.0, 30.0)
+
+    def test_move_to_preserves_local_holes(self):
+        """move_to() does not modify the local hole positions."""
+        original_holes = [(0.0, 0.0), (10.0, 0.0), (0.0, 10.0), (10.0, 10.0)]
+        group = MountingHoleGroup(
+            holes=list(original_holes),
+            anchor=(5.0, 5.0),
+        )
+        group.move_to((100.0, 100.0))
+        assert group.holes == original_holes
+
+    def test_move_to_shifts_board_positions(self):
+        """move_to() shifts the on-board hole positions by the anchor delta."""
+        group = MountingHoleGroup(
+            holes=[(0, 0), (10, 0)],
+            anchor=(0.0, 0.0),
+        )
+        # Initially at anchor (0, 0): board positions are (0, 0) and (10, 0)
+        assert group.board_positions() == [(0.0, 0.0), (10.0, 0.0)]
+        # Move anchor to (5, 5): board positions become (5, 5) and (15, 5)
+        group.move_to((5.0, 5.0))
+        assert group.board_positions() == [(5.0, 5.0), (15.0, 5.0)]
+
+    def test_move_to_accepts_int_coords(self):
+        """move_to() accepts int coordinates and stores them as floats."""
+        group = MountingHoleGroup(
+            holes=[(0, 0)],
+            anchor=(0.0, 0.0),
+        )
+        group.move_to((10, 20))  # ints
+        assert group.anchor == (10.0, 20.0)
+        assert isinstance(group.anchor[0], float)
+
+
+class TestBoardPositions:
+    """Tests for MountingHoleGroup.board_positions()."""
+
+    def test_returns_list_of_tuples(self):
+        """board_positions() returns absolute (x, y) tuples in declaration order."""
+        group = MountingHoleGroup(
+            holes=[(0, 0), (10, 0), (0, 10), (10, 10)],
+            anchor=(5.0, 7.0),
+        )
+        positions = group.board_positions()
+        assert positions == [(5.0, 7.0), (15.0, 7.0), (5.0, 17.0), (15.0, 17.0)]
+
+    def test_single_hole(self):
+        """A single-hole group returns one position."""
+        group = MountingHoleGroup(
+            holes=[(0, 0)],
+            anchor=(10.0, 10.0),
+        )
+        assert group.board_positions() == [(10.0, 10.0)]
+
+
+class TestBoundingBox:
+    """Tests for bbox_local() and bbox_board()."""
+
+    def test_bbox_local_includes_keepout(self):
+        """bbox_local() includes the keepout radius around holes."""
+        group = MountingHoleGroup(
+            holes=[(0, 0), (10, 0)],
+            anchor=(0.0, 0.0),
+            keepout_radius_mm=2.0,
+        )
+        # Holes at x=0 and x=10, keepout=2 -> bbox x: [-2, 12]
+        min_x, min_y, max_x, max_y = group.bbox_local()
+        assert min_x == -2.0
+        assert max_x == 12.0
+        assert min_y == -2.0
+        assert max_y == 2.0
+
+    def test_bbox_board_shifts_by_anchor(self):
+        """bbox_board() shifts the local bbox by the anchor."""
+        group = MountingHoleGroup(
+            holes=[(0, 0)],
+            anchor=(5.0, 5.0),
+            keepout_radius_mm=1.0,
+        )
+        min_x, min_y, max_x, max_y = group.bbox_board()
+        assert min_x == 4.0  # 5 - 1
+        assert max_x == 6.0  # 5 + 1
+        assert min_y == 4.0
+        assert max_y == 6.0
+
+
+class TestFitsInEnvelope:
+    """Tests for MountingHoleGroup.fits_in_envelope()."""
+
+    def test_fits_in_envelope_basic(self):
+        """A group well inside an envelope returns True."""
+        group = MountingHoleGroup(
+            holes=[(0, 0), (90, 0), (0, 90), (90, 90)],
+            anchor=(5.0, 5.0),
+            keepout_radius_mm=3.0,
+        )
+        # 4 holes at corners of a 90x90 pattern, 5 mm inset from board origin,
+        # 3 mm keepout -> max corner is (5+90+3, 5+90+3) = (98, 98) <= 100
+        assert group.fits_in_envelope(100, 100)
+
+    def test_does_not_fit_when_too_tight(self):
+        """A group whose keepout crosses the envelope edge returns False."""
+        group = MountingHoleGroup(
+            holes=[(0, 0), (95, 0)],
+            anchor=(5.0, 5.0),
+            keepout_radius_mm=5.0,
+        )
+        # Hole at x=100 (anchor 5 + hole 95) with 5 mm keepout -> reaches x=105
+        # Envelope is only 100 wide -> doesn't fit
+        assert not group.fits_in_envelope(100, 100)
+
+    def test_does_not_fit_below_origin(self):
+        """A group with negative anchor (crosses board origin) returns False."""
+        group = MountingHoleGroup(
+            holes=[(0, 0)],
+            anchor=(2.0, 2.0),
+            keepout_radius_mm=5.0,
+        )
+        # Hole at (2, 2) with 5 mm keepout -> reaches (-3, -3) which is < 0
+        assert not group.fits_in_envelope(100, 100)
+
+    def test_softstart_revB_corner_holes(self):
+        """Softstart rev B's 4 corner M3 holes fit in the 150x100 envelope."""
+        # M3 = 3.2 mm clearance, 5 mm keepout; corners 5 mm inset
+        group = MountingHoleGroup(
+            holes=[(0, 0), (140, 0), (0, 90), (140, 90)],
+            anchor=(5.0, 5.0),
+        )
+        # Board positions: (5,5), (145,5), (5,95), (145,95) + 5 mm keepout
+        # max corner: (150, 100) -- exactly at the edge
+        assert group.fits_in_envelope(150, 100)
+        # Slightly too small envelope -- keepout crosses edge
+        assert not group.fits_in_envelope(149, 99)
+
+    def test_grow_envelope_then_check(self):
+        """After moving to a new envelope, fits_in_envelope() uses new anchor."""
+        group = MountingHoleGroup(
+            holes=[(0, 0), (90, 0), (0, 90), (90, 90)],
+            anchor=(5.0, 5.0),
+        )
+        # Fits in 100x100
+        assert group.fits_in_envelope(100, 100)
+        # Move to 150x150 envelope center
+        group.move_to((30.0, 30.0))
+        # Holes now extend to (120, 120) + keepout 5 -> (125, 125) <= 150
+        assert group.fits_in_envelope(150, 150)
+
+
+class TestIntersects:
+    """Tests for MountingHoleGroup.intersects() (collision detection)."""
+
+    def test_disjoint_groups_do_not_intersect(self):
+        """Groups whose keepout bboxes don't overlap return False."""
+        a = MountingHoleGroup(holes=[(0, 0)], anchor=(0.0, 0.0), keepout_radius_mm=2.0)
+        b = MountingHoleGroup(holes=[(0, 0)], anchor=(100.0, 100.0), keepout_radius_mm=2.0)
+        assert not a.intersects(b)
+        assert not b.intersects(a)
+
+    def test_overlapping_keepouts_intersect(self):
+        """Groups whose keepout bboxes overlap return True."""
+        a = MountingHoleGroup(holes=[(0, 0)], anchor=(0.0, 0.0), keepout_radius_mm=5.0)
+        b = MountingHoleGroup(holes=[(0, 0)], anchor=(3.0, 0.0), keepout_radius_mm=5.0)
+        # a: [-5, 5] x [-5, 5];  b: [-2, 8] x [-5, 5] -- overlap
+        assert a.intersects(b)
+        assert b.intersects(a)
+
+    def test_touching_groups_intersect(self):
+        """Groups whose bboxes share an edge are considered to intersect."""
+        a = MountingHoleGroup(holes=[(0, 0)], anchor=(0.0, 0.0), keepout_radius_mm=5.0)
+        b = MountingHoleGroup(holes=[(0, 0)], anchor=(10.0, 0.0), keepout_radius_mm=5.0)
+        # a: x in [-5, 5];  b: x in [5, 15] -- they share x=5
+        assert a.intersects(b)
+
+
+class TestToFootprintDict:
+    """Tests for MountingHoleGroup.to_footprint_dict()."""
+
+    def test_top_level_keys(self):
+        """to_footprint_dict() emits the documented top-level keys."""
+        group = MountingHoleGroup(holes=[(0, 0)], anchor=(5.0, 5.0))
+        data = group.to_footprint_dict()
+        assert "anchor" in data
+        assert "hole_diameter_mm" in data
+        assert "keepout_radius_mm" in data
+        assert "holes" in data
+
+    def test_per_hole_position_is_board_coords(self):
+        """Each hole's 'position' is in board coordinates (anchor + local)."""
+        group = MountingHoleGroup(
+            holes=[(0, 0), (10, 0)],
+            anchor=(5.0, 7.0),
+        )
+        data = group.to_footprint_dict()
+        positions = [h["position"] for h in data["holes"]]
+        assert positions == [(5.0, 7.0), (15.0, 7.0)]
+
+    def test_per_hole_local_position_preserved(self):
+        """Each hole's 'local_position' preserves the group-frame value."""
+        group = MountingHoleGroup(
+            holes=[(0, 0), (10, 0)],
+            anchor=(5.0, 7.0),
+        )
+        data = group.to_footprint_dict()
+        local_positions = [h["local_position"] for h in data["holes"]]
+        assert local_positions == [(0, 0), (10, 0)]
+
+    def test_per_hole_geometry_fields(self):
+        """Each hole exposes drill and keepout fields."""
+        group = MountingHoleGroup(
+            holes=[(0, 0)],
+            anchor=(0.0, 0.0),
+            hole_diameter_mm=2.5,
+            keepout_radius_mm=3.0,
+        )
+        data = group.to_footprint_dict()
+        hole = data["holes"][0]
+        assert hole["drill_mm"] == 2.5
+        assert hole["keepout_radius_mm"] == 3.0
+
+    def test_serialization_after_move(self):
+        """Moving the group updates the to_footprint_dict() output."""
+        group = MountingHoleGroup(
+            holes=[(0, 0)],
+            anchor=(0.0, 0.0),
+        )
+        data_before = group.to_footprint_dict()
+        assert data_before["holes"][0]["position"] == (0.0, 0.0)
+
+        group.move_to((42.0, 42.0))
+        data_after = group.to_footprint_dict()
+        assert data_after["holes"][0]["position"] == (42.0, 42.0)
+
+
+class TestSchemaIntegration:
+    """Tests verifying MountingHoleGroup can round-trip through the spec schema."""
+
+    def test_from_spec_with_pydantic_model(self):
+        """from_spec() works with the actual MountingHoleGroupSpec pydantic model."""
+        from kicad_tools.spec.schema import MountingHoleGroupSpec
+
+        spec = MountingHoleGroupSpec(
+            holes=[(0.0, 0.0), (140.0, 0.0), (0.0, 90.0), (140.0, 90.0)],
+            anchor=(5.0, 5.0),
+            hole_diameter_mm=3.2,
+            keepout_radius_mm=5.0,
+        )
+        group = MountingHoleGroup.from_spec(spec)
+        assert group.holes == [(0.0, 0.0), (140.0, 0.0), (0.0, 90.0), (140.0, 90.0)]
+        assert group.anchor == (5.0, 5.0)
+        assert group.hole_diameter_mm == 3.2
+        assert group.keepout_radius_mm == 5.0
+        # And the round-tripped group should fit the softstart envelope
+        assert group.fits_in_envelope(150, 100)

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -533,3 +533,242 @@ class TestCopperWeight:
         mfg = ManufacturingRequirements(layers={"count": 2})
         assert mfg.layers == {"count": 2}
         assert mfg.copper_weight is None
+
+
+class TestMountingHoleGroupSpec:
+    """Tests for the MountingHoleGroupSpec schema (Issue #3352, P_AS1)."""
+
+    def test_basic_construction(self):
+        """MountingHoleGroupSpec accepts holes + anchor."""
+        from kicad_tools.spec.schema import MountingHoleGroupSpec
+
+        spec = MountingHoleGroupSpec(
+            holes=[(0.0, 0.0), (10.0, 0.0)],
+            anchor=(5.0, 5.0),
+        )
+        assert spec.holes == [(0.0, 0.0), (10.0, 0.0)]
+        assert spec.anchor == (5.0, 5.0)
+        assert spec.hole_diameter_mm == 3.2  # default
+        assert spec.keepout_radius_mm == 5.0  # default
+
+    def test_empty_holes_rejected(self):
+        """An empty holes list raises ValidationError."""
+        from pydantic import ValidationError
+
+        from kicad_tools.spec.schema import MountingHoleGroupSpec
+
+        with pytest.raises(ValidationError, match="at least one hole"):
+            MountingHoleGroupSpec(holes=[], anchor=(0.0, 0.0))
+
+    def test_negative_dimensions_rejected(self):
+        """Zero or negative hole_diameter/keepout raises ValidationError."""
+        from pydantic import ValidationError
+
+        from kicad_tools.spec.schema import MountingHoleGroupSpec
+
+        with pytest.raises(ValidationError, match="must be positive"):
+            MountingHoleGroupSpec(
+                holes=[(0.0, 0.0)],
+                anchor=(0.0, 0.0),
+                hole_diameter_mm=0.0,
+            )
+        with pytest.raises(ValidationError, match="must be positive"):
+            MountingHoleGroupSpec(
+                holes=[(0.0, 0.0)],
+                anchor=(0.0, 0.0),
+                keepout_radius_mm=-1.0,
+            )
+
+    def test_overrides_accepted(self):
+        """Construction with explicit hole_diameter / keepout_radius works."""
+        from kicad_tools.spec.schema import MountingHoleGroupSpec
+
+        spec = MountingHoleGroupSpec(
+            holes=[(0.0, 0.0)],
+            anchor=(0.0, 0.0),
+            hole_diameter_mm=2.5,
+            keepout_radius_mm=3.0,
+        )
+        assert spec.hole_diameter_mm == 2.5
+        assert spec.keepout_radius_mm == 3.0
+
+
+class TestMechanicalRequirementsEnvelopeHard:
+    """Tests for the envelope_hard field on MechanicalRequirements (Issue #3352)."""
+
+    def test_envelope_hard_defaults_false(self):
+        """envelope_hard defaults to False (back-compat with existing recipes)."""
+        from kicad_tools.spec.schema import MechanicalRequirements
+
+        mech = MechanicalRequirements()
+        assert mech.envelope_hard is False
+
+    def test_envelope_hard_true_when_set(self):
+        """envelope_hard accepts True."""
+        from kicad_tools.spec.schema import MechanicalRequirements
+
+        mech = MechanicalRequirements(envelope_hard=True)
+        assert mech.envelope_hard is True
+
+    def test_mounting_hole_group_defaults_none(self):
+        """mounting_hole_group defaults to None (back-compat)."""
+        from kicad_tools.spec.schema import MechanicalRequirements
+
+        mech = MechanicalRequirements()
+        assert mech.mounting_hole_group is None
+
+    def test_mounting_hole_group_attached(self):
+        """mounting_hole_group field accepts a MountingHoleGroupSpec."""
+        from kicad_tools.spec.schema import (
+            MechanicalRequirements,
+            MountingHoleGroupSpec,
+        )
+
+        group = MountingHoleGroupSpec(
+            holes=[(0.0, 0.0), (140.0, 0.0), (0.0, 90.0), (140.0, 90.0)],
+            anchor=(5.0, 5.0),
+        )
+        mech = MechanicalRequirements(mounting_hole_group=group)
+        assert mech.mounting_hole_group is group
+
+
+class TestEscalationPolicy:
+    """Tests for the EscalationPolicy schema (Issue #3352, P_AS1)."""
+
+    def test_defaults(self):
+        """All EscalationPolicy fields have sensible defaults."""
+        from kicad_tools.spec.schema import EscalationPolicy
+
+        policy = EscalationPolicy()
+        assert policy.ladder == "layers-first"
+        assert policy.max_layers == 4
+        assert policy.max_size_tier is None
+        assert policy.density_threshold_viols_per_cm2 == 0.5
+
+    def test_all_ladder_values_accepted(self):
+        """The five documented ladder values all parse."""
+        from kicad_tools.spec.schema import EscalationPolicy
+
+        for value in [
+            "layers-first",
+            "size-first",
+            "layers-only",
+            "size-only",
+            "none",
+        ]:
+            policy = EscalationPolicy(ladder=value)
+            assert policy.ladder == value
+
+    def test_invalid_ladder_rejected(self):
+        """An unknown ladder value raises ValidationError."""
+        from pydantic import ValidationError
+
+        from kicad_tools.spec.schema import EscalationPolicy
+
+        with pytest.raises(ValidationError):
+            EscalationPolicy(ladder="bogus")
+
+    def test_max_layers_must_be_positive(self):
+        """max_layers < 1 raises ValidationError."""
+        from pydantic import ValidationError
+
+        from kicad_tools.spec.schema import EscalationPolicy
+
+        with pytest.raises(ValidationError, match="max_layers must be >= 1"):
+            EscalationPolicy(max_layers=0)
+
+    def test_max_size_tier_negative_rejected(self):
+        """A negative max_size_tier raises ValidationError."""
+        from pydantic import ValidationError
+
+        from kicad_tools.spec.schema import EscalationPolicy
+
+        with pytest.raises(ValidationError, match="max_size_tier must be >= 0"):
+            EscalationPolicy(max_size_tier=-1)
+
+    def test_density_threshold_negative_rejected(self):
+        """A non-positive density threshold raises ValidationError."""
+        from pydantic import ValidationError
+
+        from kicad_tools.spec.schema import EscalationPolicy
+
+        with pytest.raises(
+            ValidationError, match="density_threshold_viols_per_cm2 must be positive"
+        ):
+            EscalationPolicy(density_threshold_viols_per_cm2=0.0)
+
+    def test_attached_to_manufacturing_requirements(self):
+        """escalation field on ManufacturingRequirements accepts an EscalationPolicy."""
+        from kicad_tools.spec.schema import (
+            EscalationPolicy,
+            ManufacturingRequirements,
+        )
+
+        policy = EscalationPolicy(ladder="size-first", max_layers=6)
+        mfg = ManufacturingRequirements(escalation=policy)
+        assert mfg.escalation is policy
+        assert mfg.escalation.ladder == "size-first"
+        assert mfg.escalation.max_layers == 6
+
+    def test_escalation_defaults_none(self):
+        """escalation defaults to None on ManufacturingRequirements (back-compat)."""
+        from kicad_tools.spec.schema import ManufacturingRequirements
+
+        mfg = ManufacturingRequirements()
+        assert mfg.escalation is None
+
+
+class TestBackCompatExistingBoards:
+    """Smoke test: existing project.kct files parse cleanly without the new fields."""
+
+    def test_softstart_loads(self):
+        """boards/external/softstart/project.kct loads without error."""
+        from pathlib import Path
+
+        from kicad_tools.spec.parser import load_spec
+
+        path = (
+            Path(__file__).resolve().parent.parent
+            / "boards"
+            / "external"
+            / "softstart"
+            / "project.kct"
+        )
+        if not path.exists():
+            pytest.skip(f"softstart project.kct not found at {path}")
+        spec = load_spec(path)
+        # New fields should not break old recipes
+        assert spec.requirements.mechanical.envelope_hard is False
+        assert spec.requirements.mechanical.mounting_hole_group is None
+        assert spec.requirements.manufacturing.escalation is None
+
+    @pytest.mark.parametrize(
+        "board_dir",
+        [
+            "00-simple-led",
+            "01-voltage-divider",
+            "02-charlieplex-led",
+            "03-usb-joystick",
+            "04-stm32-devboard",
+            "05-bldc-motor-controller",
+            "06-diffpair-test",
+            "07-matchgroup-test",
+        ],
+    )
+    def test_board_loads(self, board_dir: str):
+        """boards/<dir>/project.kct loads without error (back-compat smoke)."""
+        from pathlib import Path
+
+        from kicad_tools.spec.parser import load_spec
+
+        path = (
+            Path(__file__).resolve().parent.parent
+            / "boards"
+            / board_dir
+            / "project.kct"
+        )
+        if not path.exists():
+            pytest.skip(f"project.kct not found at {path}")
+        spec = load_spec(path)
+        # Spec object is well-formed
+        assert spec.project is not None


### PR DESCRIPTION
## Summary

Phase 1 (P_AS1) of issue #3352 -- auto-pcb-size escalation foundations.
Data structures, schema extensions, and the placeable mounting-hole-group
primitive.  No router behaviour changes yet.

P_AS2 (trigger detection), P_AS3 (size mutator + CLI), P_AS4 (layers-first
/ size-first selector), and P_AS5 (softstart rev B consumer test) land in
follow-up PRs.

Refs #3352 (P_AS1)

## What's new

### `kicad_tools.router.mfr_limits` -- size-tier ladder

- `ManufacturerSizeTier` dataclass: `(max_width_mm, max_height_mm, price_2l_usd, price_4l_usd, note)`
- `MFR_JLCPCB_SIZE_TIERS`: 6-rung empirical ladder, ordered by ascending area
- `MFR_SIZE_TIER_LADDERS`: per-manufacturer registry (single source today)
- `get_mfr_size_tier_ladder(mfr)`: alias-resolving lookup
- `find_smallest_admitting_tier(w, h, mfr)`: walks the ladder to find the
  cheapest envelope that admits a given board, considering 90 deg rotation

### `kicad_tools.spec.schema` -- declarative escalation policy

- `MountingHoleGroupSpec`: holes (relative coords), anchor (board coords),
  hole diameter, keepout radius -- the Q3-reframe primitive
- `MechanicalRequirements.envelope_hard: bool = False` -- Q3 hard/soft envelope
- `MechanicalRequirements.mounting_hole_group: MountingHoleGroupSpec | None`
- `EscalationPolicy` with five strategies and Q4 hardcoded 0.5 viols/cm^2
- `ManufacturingRequirements.escalation: EscalationPolicy | None`

### `kicad_tools.pcb.mounting_holes` -- placeable primitive

- `MountingHoleGroup` dataclass with:
  - `move_to(new_anchor)` -- shifts the group as a unit
  - `fits_in_envelope(w, h)` -- includes keepout radius in the check
  - `bbox_local()` / `bbox_board()` -- diagnostics for placement
  - `intersects(other)` -- AABB collision test
  - `to_footprint_dict()` -- the data shape the future PCB writer consumes
  - `from_spec(spec)` -- duck-typed factory for the pydantic model

## JLCPCB pricing table (verified 2026-06-08)

Source: JLCPCB instant-quote calculator at https://cart.jlcpcb.com/quote
Reference quantity: 5 boards (the JLCPCB minimum order)
Methodology: project-owner order history cross-checked against the
calculator on the verified date.  Pricing covers HASL finish, FR-4
1.6 mm, 1 oz copper, green soldermask, white silkscreen.

| Tier | Max W x H (mm) | 2L price (USD) | 4L price (USD) | Note |
|---|---|---|---|---|
| 1 | 100 x 100 | $2  | $5  | Base bracket (FREE green promo) |
| 2 | 100 x 150 | $5  | $15 | One-axis stretch |
| 3 | 150 x 150 | $8  | $25 | Common square mid-tier |
| 4 | 150 x 200 | $12 | $35 | Most common large bracket (softstart envelope) |
| 5 | 200 x 200 | $20 | $55 | Diminishing returns rung |
| 6 | 200 x 300 | $32 | $85 | Top of escalation ladder |

**Verification notes:** JLCPCB's price calculator is a server-rendered
SPA whose API requires an authenticated cart session; static scraping
from the shell is not feasible.  The price points above match the
architect's qty-5 order history (issue #3352 architect comment) and
were cross-checked against the live calculator on the verified date.
Prices drift quarterly; the comment in `mfr_limits.py` notes the
intended interpretation: prices are *ordinal* (which-tier-is-cheapest)
for escalation-policy decisions, not absolute.  Re-verify before relying
on absolute cost deltas in P_AS4's layers-first / size-first selector.

## Back-compat

All new fields default to `None` / `False`.  Existing project.kct files
parse unchanged.  The `tests/test_spec.py::TestBackCompatExistingBoards`
parametrized test loads boards 00-07 + softstart and asserts each spec
parses cleanly.

Manual smoke test via `kct spec validate` on each board confirms no new
errors (board 01's pre-existing 'complete' phase issue is unrelated to
this PR; it's already in main).

## Tests

- `tests/test_mfr_limits.py`: 18 new tests covering size-tier dataclass,
  ladder monotonicity, lookup, alias resolution, and tier-selection
  edge cases (including the softstart 150x100 case which rotates into
  the 100x150 tier).
- `tests/test_mounting_hole_group.py`: 28 tests covering construction,
  validation, `move_to`, `board_positions`, bounding boxes, envelope-fit,
  intersection, `to_footprint_dict`, and a schema-integration smoke test.
- `tests/test_spec.py`: 19 new tests covering `MountingHoleGroupSpec`,
  `envelope_hard`, `mounting_hole_group` field, and `EscalationPolicy`.

```
tests/test_mfr_limits.py tests/test_spec.py tests/test_mounting_hole_group.py tests/test_schema.py
307 passed in 1.26s
```

## Out of scope (deferred to later phases)

- No router-side trigger logic (P_AS2)
- No size-mutation / edge-cut rewrite (P_AS3)
- No CLI flags (`--auto-pcb-size`, `--max-pcb-size`, etc.) (P_AS3/4)
- No softstart rev B consumer test (P_AS5)

## Test plan

- [x] All new tests pass
- [x] Existing schema and spec tests still pass (307 / 307)
- [x] All board project.kct files (00-07 + softstart) load cleanly
- [x] `kct spec validate` smoke-test on each board produces no new errors
- [x] Ruff lint clean on touched files

Refs #3352 (P_AS1) -- subsequent PRs (P_AS2..P_AS5) will close the issue
