### PR TITLE
fix(blocks): OvercurrentComparator multi-unit pin lookup (#3346)

### DIFF
--- a/src/kicad_tools/schematic/blocks/analog.py
+++ b/src/kicad_tools/schematic/blocks/analog.py
@@ -1,11 +1,12 @@
 """Analog circuit blocks: op-amps, ADC input filters, sensor interfaces."""
 
+import contextlib
 from typing import TYPE_CHECKING, Literal
 
 from .base import CircuitBlock
 
 if TYPE_CHECKING:
-    from kicad_sch_helper import Schematic
+    from kicad_sch_helper import Schematic, SymbolInstance  # noqa: F401
 
 
 class ADCInputFilterBlock(CircuitBlock):
@@ -677,7 +678,28 @@ class OvercurrentComparator(CircuitBlock):
         """
         super().__init__(sch, x, y)
 
-        # Place the comparator IC
+        # Place the comparator IC.  LM393 is a multi-unit symbol:
+        #   * unit 1 = comparator channel A (pins 1=OUT, 2=IN-, 3=IN+)
+        #   * unit 2 = comparator channel B (pins 5=IN+, 6=IN-, 7=OUT)
+        #   * unit 3 = power pins (4=V-, 8=V+)
+        # If we only placed unit 1 then ``pin_position("4")`` and
+        # ``pin_position("8")`` would silently return phantom positions
+        # derived from the unit-1 outline (the LM393 library file stores
+        # pin 4 at (-2.54, -7.62) inside its ``_3_1`` sub-symbol -- that
+        # offset is meaningless when applied to a unit-1 placement and
+        # leads to wires terminating in empty space (issue #3346).
+        #
+        # Place all three units; each ``SymbolInstance`` resolves
+        # ``pin_position`` against its own unit's outline.  We then build
+        # an internal pin-number -> instance map so the rest of this
+        # block (and downstream callers) can keep calling
+        # ``pin_position("4")`` and get the correct unit-3 coordinates.
+        # ``SymbolInstance`` is only imported under ``TYPE_CHECKING`` so the
+        # annotation must remain a string at runtime.  ``ruff`` flags this
+        # as ``UP037`` but the suggested fix breaks Python <3.10 evaluation.
+        self._unit_instances: "dict[int, SymbolInstance]" = {}  # noqa: UP037
+
+        primary_unit = 1
         self.comparator = sch.add_symbol(
             comparator_symbol,
             x,
@@ -685,8 +707,55 @@ class OvercurrentComparator(CircuitBlock):
             ref,
             "LM393",
             footprint=comparator_footprint,
+            unit=primary_unit,
         )
+        self._unit_instances[primary_unit] = self.comparator
         self.components = {"U_CMP": self.comparator}
+
+        # Discover the symbol's other units (if any) and place them.
+        # We read this from the parsed ``SymbolDef``; falling back
+        # gracefully when the schematic mock used in unit tests does not
+        # expose a real ``SymbolDef`` (a bare ``Mock().symbol_def`` is
+        # itself a Mock object and ``unit_count()`` returns a Mock too,
+        # so we explicitly type-check the result before iterating).
+        sym_def = getattr(self.comparator, "symbol_def", None)
+        raw_unit_count = sym_def.unit_count() if sym_def is not None else 1
+        unit_count = raw_unit_count if isinstance(raw_unit_count, int) else 1
+
+        # Offsets for power and channel-B placements.  These match the
+        # hand-tuned coordinates that PR #3345 used for softstart rev B
+        # (which is now the canonical placement for an LM393 block):
+        # power above the divider, channel B further right with all
+        # three pins marked NC.
+        unit_offsets = {
+            2: (x + 50, y - 40),  # channel B (NC pins)
+            3: (x + 25, y),       # power (V+, V-)
+        }
+        for u in range(2, unit_count + 1):
+            if u not in unit_offsets:
+                continue
+            ux, uy = unit_offsets[u]
+            inst = sch.add_symbol(
+                comparator_symbol,
+                ux,
+                uy,
+                ref,
+                "LM393",
+                footprint=comparator_footprint,
+                unit=u,
+            )
+            self._unit_instances[u] = inst
+            self.components[f"U_CMP_U{u}"] = inst
+
+        # Channel B (unit 2) pins are unused on this block; mark them as
+        # no-connect to keep ERC quiet.  Only attempt this for instances
+        # that expose ``pin_position`` (real ``SymbolInstance``); mocked
+        # schematics may not implement ``add_no_connect``.
+        if 2 in self._unit_instances and hasattr(sch, "add_no_connect"):
+            for pin_num in ("5", "6", "7"):
+                with contextlib.suppress(Exception):
+                    pos = self._unit_pin_position(pin_num)
+                    sch.add_no_connect(pos[0], pos[1])
 
         # Threshold divider: R_TH_HI from VCC, R_TH_LO to GND, junction = V_THRESHOLD.
         # ratio = vcc/threshold = (R_TH_HI + R_TH_LO) / R_TH_LO
@@ -741,20 +810,23 @@ class OvercurrentComparator(CircuitBlock):
         r_pullup_top = self.r_pullup.pin_position("1")
         r_pullup_bot = self.r_pullup.pin_position("2")
 
-        # Comparator pin layout (LM393 single-pole, generic positions —
-        # actual pin numbers come from the symbol).  We use port-style
-        # access (named pins) where possible; the symbol numbering for
-        # LM393 dual is: 1=OUT1, 2=IN1-, 3=IN1+, 4=VEE/GND, 5=IN2+,
-        # 6=IN2-, 7=OUT2, 8=VCC.  We use channel 1.
+        # Comparator pin layout (LM393 multi-unit): pins 1=OUT_A, 2=IN-_A,
+        # 3=IN+_A live on unit 1; pins 4=V-, 8=V+ live on unit 3; pins
+        # 5-7 live on unit 2 (channel B, unused here).  ``_unit_pin_position``
+        # routes each lookup to the correct ``SymbolInstance`` so that
+        # pin 4 / pin 8 resolve against the unit-3 outline -- the unit-1
+        # fallback positions used by the previous implementation produced
+        # phantom coordinates that landed in empty space (issue #3346).
         try:
-            cmp_out = self.comparator.pin_position("1")
-            cmp_in_neg = self.comparator.pin_position("2")
-            cmp_in_pos = self.comparator.pin_position("3")
-            cmp_gnd = self.comparator.pin_position("4")
-            cmp_vcc = self.comparator.pin_position("8")
+            cmp_out = self._unit_pin_position("1")
+            cmp_in_neg = self._unit_pin_position("2")
+            cmp_in_pos = self._unit_pin_position("3")
+            cmp_gnd = self._unit_pin_position("4")
+            cmp_vcc = self._unit_pin_position("8")
         except Exception:
             # Fall back to symbol-relative positions if the symbol layout
-            # differs (e.g. unit-A subsymbol convention).
+            # differs (e.g. mocked schematic in unit tests that doesn't
+            # mirror the LM393 unit topology).
             cmp_out = (x + 10, y - 5)
             cmp_in_neg = (x - 10, y - 5)
             cmp_in_pos = (x - 10, y + 5)
@@ -795,6 +867,43 @@ class OvercurrentComparator(CircuitBlock):
         self.vcc_voltage = vcc_voltage
         self.shunt_voltage_node = shunt_voltage_node
         self.irq_output_pin = irq_output_pin
+
+    def _unit_pin_position(self, pin_number: str) -> tuple[float, float]:
+        """Return the absolute position of an LM393 pin, picking the right unit.
+
+        Walks the comparator's parsed :class:`SymbolDef` to discover
+        which unit owns ``pin_number``, then delegates to the matching
+        ``SymbolInstance`` placed in :class:`__init__`.  Falls back to
+        the primary (unit 1) instance if the symbol definition is not
+        introspectable (unit-test mock) or the unit was never placed.
+
+        This is what fixes the multi-unit phantom-position bug
+        (issue #3346): asking the primary unit-1 instance for pin 4
+        used to return a position derived from unit 1's outline plus
+        unit 3's library pin offset -- two unrelated coordinate
+        systems -- which landed in empty space.  Now pin 4 is looked
+        up on the unit-3 instance and the returned point sits on a
+        wire-able grid node.
+        """
+        primary = self._unit_instances.get(1) or self.comparator
+        sym_def = getattr(primary, "symbol_def", None)
+        if sym_def is not None and hasattr(sym_def, "get_pin_unit"):
+            unit = sym_def.get_pin_unit(pin_number)
+            inst = self._unit_instances.get(unit, primary)
+        else:
+            inst = primary
+        return inst.pin_position(pin_number)
+
+    def pin_position(self, pin_number: str) -> tuple[float, float]:
+        """Public helper mirroring :meth:`SymbolInstance.pin_position`.
+
+        Exposes the multi-unit-aware lookup so callers that previously
+        held a reference to ``block.comparator`` and called
+        ``comparator.pin_position(num)`` can switch to
+        ``block.pin_position(num)`` and get correct results for pins on
+        any unit (issue #3346).
+        """
+        return self._unit_pin_position(pin_number)
 
     @staticmethod
     def _format_resistance(r_ohms: float) -> str:

--- a/src/kicad_tools/schematic/models/elements_mixin.py
+++ b/src/kicad_tools/schematic/models/elements_mixin.py
@@ -270,6 +270,7 @@ class SchematicElementsMixin:
         auto_layout: bool = False,
         auto_footprint: bool = False,
         properties: dict[str, str] = None,
+        unit: int = 1,
     ) -> SymbolInstance:
         """Add a symbol to the schematic.
 
@@ -287,6 +288,14 @@ class SchematicElementsMixin:
             properties: Optional dict of custom symbol properties (e.g.,
                 {"Thermal_Rth_JC": "0.5", "Power_Dissipation": "5W"}).
                 These are stored as hidden KiCad symbol properties.
+            unit: Symbol unit number for multi-unit symbols (1-indexed,
+                default 1).  KiCad symbols like LM393 contain several
+                logical units in a single library entry; each unit's
+                pins live in a different sub-symbol block.  Passing the
+                correct unit here makes :meth:`SymbolInstance.pin_position`
+                resolve to the unit-local coordinates so that pin 4
+                (LM393 V-, on unit 3) returns the unit-3 position
+                instead of a phantom unit-1 fallback (issue #3346).
 
         Returns:
             SymbolInstance with pin_position() method
@@ -357,6 +366,7 @@ class SchematicElementsMixin:
             value=value or sym_def.name,
             footprint=effective_footprint,
             properties=properties or {},
+            unit=unit,
         )
 
         self.symbols.append(instance)

--- a/src/kicad_tools/schematic/models/pin.py
+++ b/src/kicad_tools/schematic/models/pin.py
@@ -31,6 +31,7 @@ class Pin:
     angle: float  # Direction pin extends INTO symbol (0=right, 90=up, 180=left, 270=down)
     length: float
     pin_type: str = "passive"
+    unit: int = 1  # Unit number for multi-unit symbols (1-indexed; default 1)
 
     def connection_point(self) -> tuple[float, float]:
         """Get the wire connection point in symbol-local (library Y-up) coords.

--- a/src/kicad_tools/schematic/models/symbol.py
+++ b/src/kicad_tools/schematic/models/symbol.py
@@ -80,6 +80,7 @@ class SymbolDef:
                         angle=p.angle,
                         length=p.length,
                         pin_type=p.pin_type,
+                        unit=getattr(p, "unit", 1),
                     )
                     for p in cached.pins
                 ],
@@ -172,20 +173,74 @@ class SymbolDef:
             _parent_node=parent_node,
         )
 
+    def unit_count(self) -> int:
+        """Return the number of distinct units this symbol contains.
+
+        Single-unit symbols return 1.  Multi-unit symbols (e.g. LM393's
+        three units: comparator A, comparator B, power) return the
+        highest unit number observed across the parsed pins.  Used by the
+        block library (and any caller that needs to place every unit) to
+        size loops correctly without re-parsing the underlying library.
+        """
+        return max((p.unit for p in self.pins), default=1)
+
+    def get_pin_unit(self, pin_number: str) -> int:
+        """Return the unit number that owns ``pin_number`` (default 1).
+
+        For multi-unit symbols, the pin number is unique across the whole
+        symbol but its position lives on whichever sub-unit declares it.
+        Blocks that place several ``SymbolInstance``s for a single device
+        use this to route ``pin_position(pin_number)`` to the correct
+        instance.  Unknown pin numbers fall back to ``1`` so callers do
+        not need defensive existence checks.
+        """
+        for p in self.pins:
+            if p.number == pin_number:
+                return p.unit
+        return 1
+
     @classmethod
     def _parse_pins_sexp(cls, sym_node: SExp) -> list[Pin]:
-        """Parse pin definitions from symbol SExp node."""
+        """Parse pin definitions from symbol SExp node.
+
+        KiCad multi-unit symbols nest their pins inside ``(symbol "Name_N_1" ...)``
+        sub-blocks where ``N`` is the 1-indexed unit number (``_0_1`` is the
+        graphical body, no pins).  We carry the unit number from the enclosing
+        sub-symbol down to each :class:`Pin` so that callers (and the block
+        library) can locate the correct ``SymbolInstance`` for each pin number.
+        Pins outside any unit sub-symbol default to ``unit=1``.
+        """
         pins = []
 
-        def find_pins(node: SExp):
-            """Recursively find all pin nodes."""
+        def _extract_unit(unit_name: str) -> int | None:
+            """Return the unit number for a sub-symbol like ``Name_3_1``."""
+            m = re.match(r".+_(\d+)_\d+$", unit_name)
+            if not m:
+                return None
+            return int(m.group(1))
+
+        def find_pins(node: SExp, current_unit: int = 1):
+            """Recursively find all pin nodes, tagging with enclosing unit."""
             for child in node.children:
                 if child.name == "pin":
                     pin = Pin.from_sexp(child)
                     if pin.number:  # Must have a pin number
+                        pin.unit = current_unit
                         pins.append(pin)
                 elif child.is_list:
-                    find_pins(child)
+                    # If this child is a unit sub-symbol, propagate its number
+                    # down to nested pin nodes.  The graphical body sub-symbol
+                    # (``Name_0_1``) has no pins; treat it as ``unit=1`` for
+                    # safety -- single-unit symbols typically pack everything
+                    # in ``Name_1_1`` anyway.
+                    child_unit = current_unit
+                    if child.name == "symbol" and child.children:
+                        first = child.children[0]
+                        if first.is_atom:
+                            extracted = _extract_unit(str(first.value))
+                            if extracted is not None and extracted > 0:
+                                child_unit = extracted
+                    find_pins(child, child_unit)
 
         find_pins(sym_node)
         return pins
@@ -535,14 +590,41 @@ class SymbolInstance:
             PinNotFoundError: If no pin matches the given name/number, with
                 suggestions for similar pin names
         """
-        # Find the pin by exact match on name or number
+        # Find the pin by exact match on name or number.  For multi-unit
+        # symbols (e.g. LM393), the same pin name may appear on multiple
+        # units (pin 3 = "+" on unit 1, pin 5 = "+" on unit 2).  Prefer
+        # pins that belong to *this* instance's unit before falling back
+        # to any matching pin -- otherwise asking unit 3 for pin 8 (V+,
+        # the only pin numbered "8") would still return the correct
+        # position, but asking unit 1 for pin "4" (V-, on unit 3) would
+        # silently return a phantom position derived from unit 1's
+        # outline (issue #3346).
         pin = None
         for p in self.symbol_def.pins:
-            if p.name == pin_name_or_number or p.number == pin_name_or_number:
+            if (p.name == pin_name_or_number or p.number == pin_name_or_number) and (
+                getattr(p, "unit", 1) == self.unit
+            ):
                 pin = p
                 break
 
-        # If not found, try case-insensitive match
+        # If no in-unit match, fall back to any exact match (this is
+        # what preserves single-unit symbol behaviour for callers who
+        # don't pass a unit number to ``add_symbol``).
+        if pin is None:
+            for p in self.symbol_def.pins:
+                if p.name == pin_name_or_number or p.number == pin_name_or_number:
+                    pin = p
+                    break
+
+        # If not found, try case-insensitive match (in-unit preferred)
+        if pin is None:
+            target_lower = pin_name_or_number.lower()
+            for p in self.symbol_def.pins:
+                if (
+                    p.name.lower() == target_lower or p.number.lower() == target_lower
+                ) and getattr(p, "unit", 1) == self.unit:
+                    pin = p
+                    break
         if pin is None:
             target_lower = pin_name_or_number.lower()
             for p in self.symbol_def.pins:

--- a/src/kicad_tools/schematic/registry.py
+++ b/src/kicad_tools/schematic/registry.py
@@ -67,6 +67,7 @@ class Pin:
     length: float
     pin_type: str = "passive"
     electrical_type: str = ""
+    unit: int = 1  # Unit number for multi-unit symbols (1-indexed; default 1)
 
     def connection_point(self) -> tuple[float, float]:
         """Get the wire connection point (end of pin)."""
@@ -356,7 +357,19 @@ class SymbolRegistry:
         )
 
     def _parse_pins(self, sexp: str) -> list[Pin]:
-        """Parse pin definitions from symbol S-expression."""
+        """Parse pin definitions from symbol S-expression.
+
+        Builds a ``pin_number → unit`` map by first scanning for unit
+        sub-symbol declarations (``(symbol "Name_N_1" ...``) and the pin
+        numbers that appear inside each.  Pins whose number cannot be
+        attributed to a specific unit default to ``unit=1``.  This is
+        what lets multi-unit symbols (e.g. LM393's pins 4 & 8 living on
+        unit 3) round-trip through :class:`SymbolInstance.pin_position`
+        without returning a phantom unit-1 position for an off-unit pin
+        (issue #3346).
+        """
+        pin_unit_map = self._build_pin_unit_map(sexp)
+
         pins = []
 
         # Split on "(pin " to get individual pin sections
@@ -397,10 +410,55 @@ class SymbolRegistry:
                         angle=float(at_match.group(3)),
                         length=length,
                         pin_type=pin_type,
+                        unit=pin_unit_map.get(number, 1),
                     )
                 )
 
         return pins
+
+    @staticmethod
+    def _build_pin_unit_map(sexp: str) -> dict[str, int]:
+        """Map each pin number to its enclosing unit's number.
+
+        Scans the raw S-expression text for ``(symbol "<NAME>_<UNIT>_<VARIANT>"
+        ...)`` blocks.  Inside each block, every ``(number "<N>" ...)`` is
+        attributed to that unit.  Uses parenthesis depth counting to avoid
+        consuming nested blocks past the unit boundary.
+        """
+        result: dict[str, int] = {}
+        # Find every unit sub-symbol header: `(symbol "NAME_N_V"`
+        for unit_match in re.finditer(r'\(symbol\s+"([^"]+_(\d+)_\d+)"', sexp):
+            unit_num = int(unit_match.group(2))
+            if unit_num <= 0:
+                # ``_0_1`` is the graphical body sub-symbol -- ignore
+                continue
+            # Find the slice of text covered by this unit sub-symbol.
+            start = unit_match.end()
+            depth = 1
+            i = start
+            in_string = False
+            escape = False
+            while i < len(sexp):
+                ch = sexp[i]
+                if escape:
+                    escape = False
+                elif ch == "\\":
+                    escape = True
+                elif ch == '"' and not escape:
+                    in_string = not in_string
+                elif not in_string:
+                    if ch == "(":
+                        depth += 1
+                    elif ch == ")":
+                        depth -= 1
+                        if depth == 0:
+                            break
+                i += 1
+            unit_slice = sexp[start:i]
+            # Attribute every pin number inside the slice to this unit.
+            for num_match in re.finditer(r'\(number\s+"([^"]+)"', unit_slice):
+                result.setdefault(num_match.group(1), unit_num)
+        return result
 
     def get(self, lib_id: str) -> SymbolDef:
         """

--- a/tests/test_blocks_overcurrent_comparator.py
+++ b/tests/test_blocks_overcurrent_comparator.py
@@ -16,6 +16,7 @@ from unittest.mock import Mock
 import pytest
 
 from kicad_tools.schematic.blocks import OvercurrentComparator
+from kicad_tools.schematic.models.schematic import Schematic
 
 
 @pytest.fixture
@@ -57,7 +58,14 @@ def mock_schematic():
 
 class TestOvercurrentComparator:
     def test_places_comparator_and_three_resistors(self, mock_schematic):
-        """Comparator IC + R_TH_HI + R_TH_LO + R_PULLUP = 4 symbols."""
+        """Comparator IC (1 unit in the mock) + R_TH_HI + R_TH_LO + R_PULLUP.
+
+        The mock schematic returns a bare ``Mock`` from ``add_symbol`` so the
+        block treats the LM393 as single-unit and does not place units 2/3.
+        Real LM393 placement against a live ``Schematic`` produces three
+        unit instances; that's covered by ``TestLM393MultiUnitPlacement``
+        below.
+        """
         OvercurrentComparator(mock_schematic, x=200, y=80, ref="U6")
         assert mock_schematic.add_symbol.call_count == 4
 
@@ -124,3 +132,123 @@ class TestOvercurrentComparator:
         """A junction marker is placed at the threshold-divider tap."""
         OvercurrentComparator(mock_schematic, x=200, y=80)
         assert mock_schematic.add_junction.call_count >= 1
+
+
+class TestLM393MultiUnitPlacement:
+    """Regression tests for the multi-unit LM393 pin-position bug (issue #3346).
+
+    LM393 packs three logical units in one library entry:
+      * unit 1 -- comparator channel A (pins 1=OUT, 2=IN-, 3=IN+)
+      * unit 2 -- comparator channel B (pins 5=IN+, 6=IN-, 7=OUT)
+      * unit 3 -- power               (pins 4=V-, 8=V+)
+
+    The previous ``OvercurrentComparator`` placed only unit 1, then
+    asked the unit-1 ``SymbolInstance`` for pin 4 / pin 8.  Because
+    ``pin_position`` walked every pin in the parsed ``SymbolDef``
+    regardless of unit, it returned a position derived by applying the
+    unit-3 library offset to the unit-1 placement origin -- a phantom
+    point that landed in empty space and broke ERC + caller wires.
+
+    These tests exercise the real ``Schematic`` / KiCad-library code
+    path (no mocks) so they catch any regression of the unit dispatch.
+    """
+
+    def test_pin_unit_metadata_is_propagated_through_symbol_def(self):
+        """Every LM393 pin is tagged with the unit number that owns it."""
+        sch = Schematic(title="test")
+        u = sch.add_symbol("Comparator:LM393", 100, 100, "U1", "LM393")
+        unit_by_pin = {p.number: p.unit for p in u.symbol_def.pins}
+        # Channel A
+        assert unit_by_pin["1"] == 1
+        assert unit_by_pin["2"] == 1
+        assert unit_by_pin["3"] == 1
+        # Channel B
+        assert unit_by_pin["5"] == 2
+        assert unit_by_pin["6"] == 2
+        assert unit_by_pin["7"] == 2
+        # Power
+        assert unit_by_pin["4"] == 3
+        assert unit_by_pin["8"] == 3
+
+    def test_unit_count_reports_three_for_lm393(self):
+        """``SymbolDef.unit_count`` reports the highest unit observed."""
+        sch = Schematic(title="test")
+        u = sch.add_symbol("Comparator:LM393", 100, 100, "U1", "LM393")
+        assert u.symbol_def.unit_count() == 3
+
+    def test_block_places_three_unit_instances_for_lm393(self):
+        """The block emits one ``SymbolInstance`` per LM393 unit."""
+        sch = Schematic(title="test")
+        block = OvercurrentComparator(sch, x=200, y=100, ref="U7")
+        lm_units = sorted(
+            inst.unit
+            for inst in sch.symbols
+            if inst.symbol_def.lib_id == "Comparator:LM393"
+            and inst.reference == "U7"
+        )
+        assert lm_units == [1, 2, 3], (
+            f"Expected channel A + channel B + power units; got {lm_units}"
+        )
+        # The block's _unit_instances map matches.
+        assert set(block._unit_instances.keys()) == {1, 2, 3}
+
+    def test_power_pin_position_is_resolved_against_unit_3(self):
+        """Pin 4 (V-) and pin 8 (V+) resolve via the unit-3 instance.
+
+        Without the fix this used to return ``unit_1.x + unit_3_offset``,
+        a non-grid phantom point.  After the fix it returns the unit-3
+        instance's own placement plus the (-2.54, +/-7.62) library
+        offset -- a real schematic pin on the unit-3 outline.
+        """
+        sch = Schematic(title="test")
+        block = OvercurrentComparator(sch, x=200, y=100, ref="U7")
+        unit3 = block._unit_instances[3]
+        # Pin 8 (V+) is at library offset (-2.54, +7.62) on unit 3.
+        # Library Y is up, schematic Y is down, so the rendered offset
+        # is (-2.54, -7.62) relative to the unit-3 placement origin.
+        expected_vcc = (unit3.x - 2.54, unit3.y - 7.62)
+        expected_gnd = (unit3.x - 2.54, unit3.y + 7.62)
+        assert block.pin_position("8") == expected_vcc
+        assert block.pin_position("4") == expected_gnd
+        # And ports surface the same coordinates.
+        assert block.ports["VCC"] == expected_vcc
+        assert block.ports["GND"] == expected_gnd
+
+    def test_channel_a_pins_resolve_against_unit_1(self):
+        """Pins 1/2/3 still resolve against the unit-1 placement origin."""
+        sch = Schematic(title="test")
+        block = OvercurrentComparator(sch, x=200, y=100, ref="U7")
+        unit1 = block._unit_instances[1]
+        # Library offset for pin 1 (OUT) is (+7.62, 0) on unit 1.
+        expected_out = (unit1.x + 7.62, unit1.y - 0.0)
+        assert block.pin_position("1") == expected_out
+
+    def test_channel_b_pins_marked_no_connect(self):
+        """Unit 2 pins (5/6/7) are auto-tagged ``no_connect`` to satisfy ERC."""
+        sch = Schematic(title="test")
+        OvercurrentComparator(sch, x=200, y=100, ref="U7")
+        # ``Schematic`` stores no-connects in ``self.no_connects``.
+        nc_count = len(getattr(sch, "no_connects", []))
+        # 3 NCs from channel B, plus any others the block may add.
+        assert nc_count >= 3
+
+    def test_pin_position_no_longer_returns_phantom_unit1_for_pin_4(self):
+        """Direct evidence the bug is gone.
+
+        Before the fix: ``unit1_instance.pin_position("4")`` returned a
+        position computed from the unit-1 placement origin plus unit
+        3's library offset -- mathematically valid coordinates, but
+        nowhere near where pin 4 is actually drawn.  We confirm the
+        block-level dispatch returns the unit-3 coordinate instead.
+        """
+        sch = Schematic(title="test")
+        block = OvercurrentComparator(sch, x=200, y=100, ref="U7")
+        unit1 = block._unit_instances[1]
+        unit3 = block._unit_instances[3]
+        # The unit-1 instance and unit-3 instance are placed at
+        # different coordinates by the block, so applying the same
+        # library offset to each gives distinguishable results.
+        assert unit1.x != unit3.x or unit1.y != unit3.y
+        pin4_via_block = block.pin_position("4")
+        pin4_via_unit3 = unit3.pin_position("4")
+        assert pin4_via_block == pin4_via_unit3


### PR DESCRIPTION
## Summary

Fixes the multi-unit `pin_position` bug in `OvercurrentComparator` (issue #3346) by threading the KiCad **unit** through the parser → `SymbolDef` → `SymbolInstance` → block dispatch.

- The LM393 packs three units in one symbol: channel A (pins 1-3, unit 1), channel B (pins 5-7, unit 2), power (pins 4 & 8, unit 3).
- The block used to place only unit 1, then ask the unit-1 instance for pin 4 / pin 8 — which returned a phantom position (unit-3 library offset applied to the unit-1 placement origin).
- Now the block places all three units, owns a `unit -> SymbolInstance` map, and routes every `pin_position(num)` lookup to the instance that actually owns that pin.

Closes #3346.

## Changes

- `Pin` (both `models.pin` and `registry`) gains a `unit` field (default 1).
- Both pin parsers (`SymbolDef._parse_pins_sexp` SExp-based + registry regex-based) detect the enclosing `Name_N_1` unit sub-symbol and tag each pin with its unit number.
- `SymbolDef` adds `unit_count()` and `get_pin_unit(pin_number)` helpers.
- `SymbolInstance.pin_position` prefers in-unit pin matches before falling back to any match (single-unit symbols unaffected).
- `Schematic.add_symbol` gains a `unit=` parameter. `MCUBlock` already passed this kwarg under the assumption it worked; now it does.
- `OvercurrentComparator` places all three LM393 units, owns a unit-instance map, and exposes a `block.pin_position(num)` helper. Channel B pins (5-7) auto-marked NC for ERC quiet.

## Test plan

- [x] `tests/test_blocks_overcurrent_comparator.py` — 9 existing mock tests pass unchanged plus 7 new tests in `TestLM393MultiUnitPlacement` that exercise the real KiCad LM393 library (no mocks) and assert:
  - every pin is tagged with the correct unit (1 → A, 2 → B, 3 → power)
  - `SymbolDef.unit_count()` returns 3 for LM393
  - the block places three `SymbolInstance`s (units 1, 2, 3) with `reference="U7"`
  - `block.pin_position("4")` / `pin_position("8")` resolve via the unit-3 instance (not phantom unit-1 fallback)
  - channel A pins resolve against unit 1's placement origin
  - channel B pins are marked `no_connect`
  - the block-level dispatch returns the same coordinate as querying the unit-3 instance directly
- [x] `tests/test_blocks_*.py` — full block suite (174 tests) passes
- [x] `tests/test_softstart_revb_schematic.py`, `tests/test_library_extends.py`, `tests/test_erc_cross_sheet.py`, `tests/test_board_05_drv8308_pin_nets.py` — all pass
- [x] Ruff clean on all touched files
- [ ] Follow-up: softstart rev B can retire the manual LM393 placement workaround at `boards/external/softstart/generate_design.py:1058-1167` (separate board-side change, out of scope here)

## Out of scope

- `BackToBackFETPair` (`motor.py`) multi-unit fix — issue #3347
- Validator multi-unit handling — issue #3349

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>