### PR TITLE
fix(schematic): validator skips pins from non-placed units of multi-unit symbols (#3349)

### DIFF
--- a/src/kicad_tools/schematic/models/pin.py
+++ b/src/kicad_tools/schematic/models/pin.py
@@ -31,7 +31,14 @@ class Pin:
     angle: float  # Direction pin extends INTO symbol (0=right, 90=up, 180=left, 270=down)
     length: float
     pin_type: str = "passive"
-    unit: int = 1  # Unit number for multi-unit symbols (1-indexed; default 1)
+    # Unit number this pin belongs to. KiCad multi-unit symbols use child symbols
+    # named ``Name_<unit>_<style>`` (e.g. ``LM393_2_1``) — each unit owns the pins
+    # declared inside its child symbol. Unit ``0`` is a special "common" unit
+    # whose pins are shared by every unit (e.g. shared package power pins). The
+    # default of ``0`` keeps single-unit symbols and legacy parsers unaffected:
+    # they look like "one common unit", so they continue to match SymbolInstance
+    # placements regardless of the instance's ``unit`` field.
+    unit: int = 0
 
     def connection_point(self) -> tuple[float, float]:
         """Get the wire connection point in symbol-local (library Y-up) coords.

--- a/src/kicad_tools/schematic/models/symbol.py
+++ b/src/kicad_tools/schematic/models/symbol.py
@@ -80,7 +80,7 @@ class SymbolDef:
                         angle=p.angle,
                         length=p.length,
                         pin_type=p.pin_type,
-                        unit=getattr(p, "unit", 1),
+                        unit=getattr(p, "unit", 0),
                     )
                     for p in cached.pins
                 ],
@@ -181,8 +181,14 @@ class SymbolDef:
         highest unit number observed across the parsed pins.  Used by the
         block library (and any caller that needs to place every unit) to
         size loops correctly without re-parsing the underlying library.
+
+        Note: ``Pin.unit`` uses ``0`` as a "common to all units" sentinel
+        (e.g. shared package power pins), so the unit count is the
+        maximum of the non-zero unit numbers — with a floor of 1 so
+        single-unit symbols (whose pins are all tagged ``unit=0``) still
+        report a meaningful count.
         """
-        return max((p.unit for p in self.pins), default=1)
+        return max((p.unit for p in self.pins if p.unit > 0), default=1)
 
     def get_pin_unit(self, pin_number: str) -> int:
         """Return the unit number that owns ``pin_number`` (default 1).
@@ -193,34 +199,35 @@ class SymbolDef:
         use this to route ``pin_position(pin_number)`` to the correct
         instance.  Unknown pin numbers fall back to ``1`` so callers do
         not need defensive existence checks.
+
+        Note: pins tagged with the ``0`` "common to all units" sentinel
+        (shared package power pins) report as unit ``1`` here because
+        callers using this helper want a concrete unit to place against;
+        common pins can be reached through any unit instance.
         """
         for p in self.pins:
             if p.number == pin_number:
-                return p.unit
+                return p.unit if p.unit > 0 else 1
         return 1
 
     @classmethod
     def _parse_pins_sexp(cls, sym_node: SExp) -> list[Pin]:
         """Parse pin definitions from symbol SExp node.
 
-        KiCad multi-unit symbols nest their pins inside ``(symbol "Name_N_1" ...)``
-        sub-blocks where ``N`` is the 1-indexed unit number (``_0_1`` is the
-        graphical body, no pins).  We carry the unit number from the enclosing
-        sub-symbol down to each :class:`Pin` so that callers (and the block
-        library) can locate the correct ``SymbolInstance`` for each pin number.
-        Pins outside any unit sub-symbol default to ``unit=1``.
+        Multi-unit KiCad symbols nest their pins inside child symbol nodes
+        named ``<Name>_<unit>_<style>`` (e.g. ``LM393_2_1``).  Each pin is
+        tagged with the unit number extracted from that wrapper name so
+        downstream validation can filter by which units are actually
+        placed.  Pins declared at the top level (or inside a unit-0
+        wrapper like ``LM393_0_1``) keep ``unit=0`` to indicate they are
+        common to every unit instance (shared package power pins, etc.).
         """
         pins = []
 
-        def _extract_unit(unit_name: str) -> int | None:
-            """Return the unit number for a sub-symbol like ``Name_3_1``."""
-            m = re.match(r".+_(\d+)_\d+$", unit_name)
-            if not m:
-                return None
-            return int(m.group(1))
+        unit_pattern = re.compile(r".+_(\d+)_\d+$")
 
-        def find_pins(node: SExp, current_unit: int = 1):
-            """Recursively find all pin nodes, tagging with enclosing unit."""
+        def find_pins(node: SExp, current_unit: int):
+            """Recursively find all pin nodes, tracking the wrapping unit."""
             for child in node.children:
                 if child.name == "pin":
                     pin = Pin.from_sexp(child)
@@ -228,21 +235,21 @@ class SymbolDef:
                         pin.unit = current_unit
                         pins.append(pin)
                 elif child.is_list:
-                    # If this child is a unit sub-symbol, propagate its number
-                    # down to nested pin nodes.  The graphical body sub-symbol
-                    # (``Name_0_1``) has no pins; treat it as ``unit=1`` for
-                    # safety -- single-unit symbols typically pack everything
-                    # in ``Name_1_1`` anyway.
-                    child_unit = current_unit
+                    # If this is a unit wrapper (Name_<unit>_<style>), update
+                    # the unit context for its descendants.  The graphical
+                    # body sub-symbol (``Name_0_1``) carries no pins; its
+                    # ``unit=0`` tag also doubles as the "common to all
+                    # units" sentinel for shared package pins.
+                    next_unit = current_unit
                     if child.name == "symbol" and child.children:
                         first = child.children[0]
                         if first.is_atom:
-                            extracted = _extract_unit(str(first.value))
-                            if extracted is not None and extracted > 0:
-                                child_unit = extracted
-                    find_pins(child, child_unit)
+                            m = unit_pattern.match(str(first.value))
+                            if m:
+                                next_unit = int(m.group(1))
+                    find_pins(child, next_unit)
 
-        find_pins(sym_node)
+        find_pins(sym_node, 0)
         return pins
 
     def _add_prefix_to_node(self, node: SExp, lib_name: str, skip_extends: bool = False) -> SExp:
@@ -599,11 +606,21 @@ class SymbolInstance:
         # position, but asking unit 1 for pin "4" (V-, on unit 3) would
         # silently return a phantom position derived from unit 1's
         # outline (issue #3346).
+        #
+        # ``Pin.unit`` uses ``0`` as the "common to all units" sentinel
+        # (shared package power pins, single-unit symbols whose pins are
+        # all tagged ``unit=0``).  Treat those as matching any instance
+        # unit so callers asking unit 2 for a shared GND pin still get
+        # the right position.
+        def _pin_matches_unit(pin: Pin) -> bool:
+            pin_unit = getattr(pin, "unit", 0)
+            return pin_unit == 0 or pin_unit == self.unit
+
         pin = None
         for p in self.symbol_def.pins:
-            if (p.name == pin_name_or_number or p.number == pin_name_or_number) and (
-                getattr(p, "unit", 1) == self.unit
-            ):
+            if (
+                p.name == pin_name_or_number or p.number == pin_name_or_number
+            ) and _pin_matches_unit(p):
                 pin = p
                 break
 
@@ -622,7 +639,7 @@ class SymbolInstance:
             for p in self.symbol_def.pins:
                 if (
                     p.name.lower() == target_lower or p.number.lower() == target_lower
-                ) and getattr(p, "unit", 1) == self.unit:
+                ) and _pin_matches_unit(p):
                     pin = p
                     break
         if pin is None:

--- a/src/kicad_tools/schematic/models/validation_mixin.py
+++ b/src/kicad_tools/schematic/models/validation_mixin.py
@@ -60,20 +60,44 @@ class SchematicValidationMixin:
         """
         issues = []
 
-        # Check for duplicate references
-        refs = {}
+        # Check for duplicate references.
+        #
+        # Multi-unit symbols (LM393, MCP6001 dual op-amp, hex inverters, …)
+        # are placed as multiple ``SymbolInstance`` rows that share the same
+        # reference designator on purpose — KiCad's own ERC treats them as
+        # one logical part.  A genuine duplicate is therefore a pair where
+        # either:
+        #   * the lib_ids differ (two different parts numbered the same), or
+        #   * the unit numbers collide (two copies of the same unit, e.g.
+        #     two ``unit=1`` symbols claiming to be channel A of the dual
+        #     comparator).
+        # The previous implementation flagged every second-or-later
+        # ``SymbolInstance`` regardless of unit, generating false positives
+        # like the 13 errors on softstart rev B reported in #3349.
+        refs: dict[str, list] = {}
         for sym in self.symbols:
-            if sym.reference in refs:
-                issues.append(
-                    {
-                        "severity": "error",
-                        "type": "duplicate_reference",
-                        "message": f"Duplicate reference '{sym.reference}' at ({sym.x}, {sym.y})",
-                        "location": (sym.x, sym.y),
-                        "fix_applied": False,
-                    }
-                )
-            refs[sym.reference] = sym
+            refs.setdefault(sym.reference, []).append(sym)
+
+        for ref, instances in refs.items():
+            if len(instances) < 2:
+                continue
+            seen_units: dict[tuple[str, int], object] = {}
+            for sym in instances:
+                key = (sym.symbol_def.lib_id, getattr(sym, "unit", 1))
+                if key in seen_units:
+                    issues.append(
+                        {
+                            "severity": "error",
+                            "type": "duplicate_reference",
+                            "message": (
+                                f"Duplicate reference '{ref}' at ({sym.x}, {sym.y})"
+                            ),
+                            "location": (sym.x, sym.y),
+                            "fix_applied": False,
+                        }
+                    )
+                else:
+                    seen_units[key] = sym
 
         # Check for off-grid symbols
         for sym in self.symbols:
@@ -275,6 +299,23 @@ class SchematicValidationMixin:
             p2 = (round(wire.x2, 2), round(wire.y2, 2))
             wire_segments.append((p1, p2))
 
+        # Multi-unit symbols (e.g. LM393 dual comparator) share a
+        # ``reference`` across multiple :class:`SymbolInstance` rows.
+        # ``symbol_def.pins`` always lists *every* pin from *every* unit,
+        # so without filtering each placed instance would re-check the
+        # entire pin list — producing duplicate "pin not connected"
+        # errors for pins that belong to a different unit (issue #3349).
+        # Pins carry the unit number they were declared under
+        # (``pin.unit``); ``0`` means "common to all units" (typically
+        # shared package power pins).  Each instance only owns the pins
+        # whose unit matches its own ``unit`` field, plus any unit-0
+        # commons — but the common pins should be reported only by the
+        # *first* placed instance of that reference so we do not flag
+        # the same physical pin twice.
+        first_instance_for_ref: dict[str, object] = {}
+        for sym in self.symbols:
+            first_instance_for_ref.setdefault(sym.reference, sym)
+
         for sym in self.symbols:
             # Skip simple 2-pin passive components (resistors, capacitors, etc.)
             # These often have one pin floating during design
@@ -282,7 +323,22 @@ class SchematicValidationMixin:
                 p.pin_type == "passive" for p in sym.symbol_def.pins
             )
 
+            sym_unit = getattr(sym, "unit", 1)
+            owns_common_pins = first_instance_for_ref.get(sym.reference) is sym
+
             for pin in sym.symbol_def.pins:
+                pin_unit = getattr(pin, "unit", 0)
+
+                # Skip pins that belong to a different unit than the one
+                # currently placed.  Unit 0 = "common to all units" and is
+                # reported only by the first placed instance for this ref
+                # so the same physical pin is not double-counted.
+                if pin_unit == 0:
+                    if not owns_common_pins:
+                        continue
+                elif pin_unit != sym_unit:
+                    continue
+
                 # Skip passive pins on simple 2-pin devices
                 if is_simple_passive and pin.pin_type == "passive":
                     continue

--- a/src/kicad_tools/schematic/registry.py
+++ b/src/kicad_tools/schematic/registry.py
@@ -67,7 +67,9 @@ class Pin:
     length: float
     pin_type: str = "passive"
     electrical_type: str = ""
-    unit: int = 1  # Unit number for multi-unit symbols (1-indexed; default 1)
+    # Unit number this pin belongs to (0 = common to all units).  Set from
+    # the wrapping ``Name_<unit>_<style>`` symbol when present.
+    unit: int = 0
 
     def connection_point(self) -> tuple[float, float]:
         """Get the wire connection point (end of pin)."""
@@ -359,23 +361,46 @@ class SymbolRegistry:
     def _parse_pins(self, sexp: str) -> list[Pin]:
         """Parse pin definitions from symbol S-expression.
 
-        Builds a ``pin_number → unit`` map by first scanning for unit
-        sub-symbol declarations (``(symbol "Name_N_1" ...``) and the pin
-        numbers that appear inside each.  Pins whose number cannot be
-        attributed to a specific unit default to ``unit=1``.  This is
-        what lets multi-unit symbols (e.g. LM393's pins 4 & 8 living on
-        unit 3) round-trip through :class:`SymbolInstance.pin_position`
-        without returning a phantom unit-1 position for an off-unit pin
-        (issue #3346).
+        Multi-unit symbols in KiCad nest pins inside child ``symbol``
+        nodes named ``<Name>_<unit>_<style>`` (e.g. ``LM393_2_1``).  This
+        parser walks the raw text and remembers which unit wrapper the
+        most recent pin section appeared under so each :class:`Pin` is
+        tagged with the correct unit number.  Unit ``0`` is reserved for
+        shared/common pins (e.g. package-wide power pins declared at the
+        top level or in a ``Name_0_<style>`` wrapper).  This is what lets
+        multi-unit symbols (e.g. LM393's pins 4 & 8 living on unit 3)
+        round-trip through :class:`SymbolInstance.pin_position` without
+        returning a phantom unit-1 position for an off-unit pin (issue
+        #3346) while preserving the validator's ability to filter pins
+        by which units are actually placed (issue #3349).
         """
-        pin_unit_map = self._build_pin_unit_map(sexp)
-
         pins = []
 
-        # Split on "(pin " to get individual pin sections
+        # Walk text positions of unit-symbol wrappers so we can map each
+        # pin section's offset back to the unit that owns it.  This is a
+        # lightweight alternative to a full SExp parse and stays
+        # consistent with the existing regex-based approach used here.
+        unit_marker = re.compile(r'\(symbol\s+"[^"]+_(\d+)_\d+"')
+        unit_positions: list[tuple[int, int]] = [
+            (m.start(), int(m.group(1))) for m in unit_marker.finditer(sexp)
+        ]
+
+        def _unit_for(pos: int) -> int:
+            current = 0
+            for start, unit in unit_positions:
+                if start < pos:
+                    current = unit
+                else:
+                    break
+            return current
+
+        # Use the same anchor pattern for both splitting and offset
+        # tracking so the two stay aligned.  ``pin_names`` properties
+        # do not start with a newline so they're correctly excluded.
+        section_starts = [m.start() for m in re.finditer(r"\n\s*\(pin\s+", sexp)]
         pin_sections = re.split(r"\n\s*\(pin\s+", sexp)[1:]
 
-        for section in pin_sections:
+        for section, offset in zip(pin_sections, section_starts):
             # Extract pin type and style from start
             type_match = re.match(r"(\w+)\s+(\w+)", section)
             if not type_match:
@@ -410,55 +435,11 @@ class SymbolRegistry:
                         angle=float(at_match.group(3)),
                         length=length,
                         pin_type=pin_type,
-                        unit=pin_unit_map.get(number, 1),
+                        unit=_unit_for(offset),
                     )
                 )
 
         return pins
-
-    @staticmethod
-    def _build_pin_unit_map(sexp: str) -> dict[str, int]:
-        """Map each pin number to its enclosing unit's number.
-
-        Scans the raw S-expression text for ``(symbol "<NAME>_<UNIT>_<VARIANT>"
-        ...)`` blocks.  Inside each block, every ``(number "<N>" ...)`` is
-        attributed to that unit.  Uses parenthesis depth counting to avoid
-        consuming nested blocks past the unit boundary.
-        """
-        result: dict[str, int] = {}
-        # Find every unit sub-symbol header: `(symbol "NAME_N_V"`
-        for unit_match in re.finditer(r'\(symbol\s+"([^"]+_(\d+)_\d+)"', sexp):
-            unit_num = int(unit_match.group(2))
-            if unit_num <= 0:
-                # ``_0_1`` is the graphical body sub-symbol -- ignore
-                continue
-            # Find the slice of text covered by this unit sub-symbol.
-            start = unit_match.end()
-            depth = 1
-            i = start
-            in_string = False
-            escape = False
-            while i < len(sexp):
-                ch = sexp[i]
-                if escape:
-                    escape = False
-                elif ch == "\\":
-                    escape = True
-                elif ch == '"' and not escape:
-                    in_string = not in_string
-                elif not in_string:
-                    if ch == "(":
-                        depth += 1
-                    elif ch == ")":
-                        depth -= 1
-                        if depth == 0:
-                            break
-                i += 1
-            unit_slice = sexp[start:i]
-            # Attribute every pin number inside the slice to this unit.
-            for num_match in re.finditer(r'\(number\s+"([^"]+)"', unit_slice):
-                result.setdefault(num_match.group(1), unit_num)
-        return result
 
     def get(self, lib_id: str) -> SymbolDef:
         """

--- a/tests/test_schematic_models.py
+++ b/tests/test_schematic_models.py
@@ -2256,6 +2256,187 @@ class TestSchematicValidationAdvanced:
         unconnected = [i for i in issues if "unconnected" in i["type"]]
         assert len(unconnected) == 0
 
+    def _build_lm393_symdef(self):
+        """Build a SymbolDef mimicking a 3-unit LM393 comparator.
+
+        Mirrors how the SExp library parser tags pins with their wrapping
+        unit number (``LM393_<unit>_<style>`` symbols):
+
+        - Unit 1 pins (channel A inputs and output): IN+ (pin 3), IN-
+          (pin 2), OUT (pin 1).
+        - Unit 2 pins (channel B inputs and output): IN+ (pin 5), IN-
+          (pin 6), OUT (pin 7).
+        - Unit 3 pins (package power): V+ (pin 8), V- (pin 4).
+
+        All pins are positioned at the symbol origin to simplify wire
+        attachment.  The validator only cares about per-instance pin
+        positions, not the relative geometry between units, so colocated
+        pins are sufficient for this test.
+        """
+        return SymbolDef(
+            lib_id="Comparator:LM393",
+            name="LM393",
+            raw_sexp="",
+            pins=[
+                # Unit 1 (channel A)
+                Pin(name="-", number="2", x=0, y=0, angle=0, length=0,
+                    pin_type="input", unit=1),
+                Pin(name="+", number="3", x=0, y=0, angle=0, length=0,
+                    pin_type="input", unit=1),
+                Pin(name="OUT_A", number="1", x=0, y=0, angle=0, length=0,
+                    pin_type="open_collector", unit=1),
+                # Unit 2 (channel B)
+                Pin(name="-", number="6", x=0, y=0, angle=0, length=0,
+                    pin_type="input", unit=2),
+                Pin(name="+", number="5", x=0, y=0, angle=0, length=0,
+                    pin_type="input", unit=2),
+                Pin(name="OUT_B", number="7", x=0, y=0, angle=0, length=0,
+                    pin_type="open_collector", unit=2),
+                # Unit 3 (package power)
+                Pin(name="V+", number="8", x=0, y=0, angle=0, length=0,
+                    pin_type="power_in", unit=3),
+                Pin(name="V-", number="4", x=0, y=0, angle=0, length=0,
+                    pin_type="power_in", unit=3),
+            ],
+        )
+
+    def test_check_unconnected_pins_multi_unit_only_placed_unit(self):
+        """Multi-unit symbol: validator only flags pins on placed units (#3349).
+
+        Place only unit 1 of a 3-unit LM393.  The other units' pins
+        (which include the V+/V- power pins in unit 3) belong to a
+        different ``SymbolInstance`` that hasn't been added, so they
+        must NOT be flagged as unconnected on the placed instance.
+        Otherwise builders that wire each unit at its own location see
+        spurious "Pin V- (power_in) on U7 ... not connected" errors
+        like the ones reported in issue #3349 on softstart rev B.
+        """
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sym_def = self._build_lm393_symdef()
+
+        # Place ONLY unit 1 (channel A) at the origin.  Add wires for
+        # this unit's three pins so they're connected.
+        inst1 = SymbolInstance(
+            symbol_def=sym_def, x=100.0, y=100.0, rotation=0,
+            reference="U7", value="LM393", unit=1,
+        )
+        sch.symbols.append(inst1)
+        # All unit-1 pins are colocated at (100, 100) per the test
+        # symbol; one wire there connects them.
+        sch.add_wire((100, 100), (100, 50), snap=False)
+
+        issues = sch._check_unconnected_pins()
+        # The validator must not report unit-2 or unit-3 pins (V+, V-,
+        # channel B inputs/outputs) on this instance — those belong to
+        # placements that haven't been added yet.
+        u7_unconnected = [
+            i for i in issues
+            if "unconnected" in i["type"] and "U7" in i["message"]
+        ]
+        assert u7_unconnected == [], (
+            "Validator flagged pins from non-placed units of multi-unit "
+            f"symbol U7: {[i['message'] for i in u7_unconnected]}"
+        )
+
+    def test_check_unconnected_pins_multi_unit_all_placed_connected(self):
+        """Multi-unit symbol: all units placed and connected → 0 errors.
+
+        Mirrors the acceptance criterion from issue #3349: an LM393
+        with all 3 units placed and every pin wired should produce
+        zero ``unconnected_pin`` issues for that reference.
+        """
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sym_def = self._build_lm393_symdef()
+
+        for unit in (1, 2, 3):
+            sch.symbols.append(
+                SymbolInstance(
+                    symbol_def=sym_def,
+                    x=100.0 + unit * 10,
+                    y=100.0,
+                    rotation=0,
+                    reference="U7",
+                    value="LM393",
+                    unit=unit,
+                )
+            )
+            # Wire at the placement point to connect that unit's pins.
+            sch.add_wire((100.0 + unit * 10, 100), (100.0 + unit * 10, 50),
+                         snap=False)
+
+        issues = sch._check_unconnected_pins()
+        u7_unconnected = [
+            i for i in issues
+            if "unconnected" in i["type"] and "U7" in i["message"]
+        ]
+        assert u7_unconnected == [], (
+            "All units of multi-unit symbol U7 are connected; expected 0 "
+            f"unconnected pin issues, got: {[i['message'] for i in u7_unconnected]}"
+        )
+
+    def test_validate_multi_unit_no_duplicate_reference(self):
+        """Multi-unit instances sharing a reference are not duplicates (#3349).
+
+        The validator's duplicate-reference check used to flag every
+        second-and-later ``SymbolInstance`` regardless of unit, which
+        produced false positives for normal multi-unit placements
+        (KiCad ERC accepts them).  Distinct ``unit`` numbers under the
+        same ``lib_id`` must not be reported as duplicates.
+        """
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sym_def = self._build_lm393_symdef()
+
+        for unit in (1, 2, 3):
+            sch.symbols.append(
+                SymbolInstance(
+                    symbol_def=sym_def,
+                    x=100.0 + unit * 10,
+                    y=100.0,
+                    rotation=0,
+                    reference="U7",
+                    value="LM393",
+                    unit=unit,
+                )
+            )
+
+        issues = sch.validate()
+        dup = [i for i in issues if i["type"] == "duplicate_reference"]
+        assert dup == [], (
+            "Multi-unit placements with distinct unit numbers must not be "
+            f"flagged as duplicate references; got: {[i['message'] for i in dup]}"
+        )
+
+    def test_validate_same_unit_twice_still_flagged(self):
+        """Genuine duplicates (same ref + same unit) must still error.
+
+        Defends against over-correction: if two ``SymbolInstance`` rows
+        claim to be the same unit of the same lib_id, that's a real
+        configuration bug and the validator should still flag it.
+        """
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sym_def = self._build_lm393_symdef()
+
+        # Two copies of unit 1 — both claim to be channel A of U7.
+        for x_offset in (10, 20):
+            sch.symbols.append(
+                SymbolInstance(
+                    symbol_def=sym_def,
+                    x=100.0 + x_offset,
+                    y=100.0,
+                    rotation=0,
+                    reference="U7",
+                    value="LM393",
+                    unit=1,
+                )
+            )
+
+        issues = sch.validate()
+        dup = [i for i in issues if i["type"] == "duplicate_reference"]
+        assert len(dup) == 1, (
+            "Expected exactly one duplicate_reference error for two "
+            f"copies of U7 unit 1, got: {[i['message'] for i in dup]}"
+        )
+
     def test_check_disconnected_labels_connected(self):
         """Labels at wire endpoints don't generate errors."""
         from kicad_tools.schematic.models.elements import Label


### PR DESCRIPTION
## Summary

Fix schematic-validator false positives that flagged duplicate references and unconnected pins on every unit of a multi-unit symbol (LM393, MCP6001 dual op-amp, hex inverters, ...). The validator now mirrors KiCad ERC behavior: pins are only checked on the unit that's actually placed.

- Tag each `Pin` with the unit number extracted from the wrapping `<Name>_<unit>_<style>` library symbol (both SExp model parser and regex-based registry parser). Unit `0` = "common to all units".
- `_check_unconnected_pins` now filters by `pin.unit == sym.unit`; unit-0 commons are reported only by the first placed instance of each reference so the same physical pin is never double-counted.
- The duplicate-reference check treats two `SymbolInstance` rows as duplicates only when they share both `lib_id` and `unit` — different units of the same multi-unit part are legitimate.

## Before / after on softstart rev B

Output of `uv run python boards/external/softstart/generate_design.py /tmp/softstart_revb_judge` (the reproduction case from the issue):

| Metric                                      | Before | After |
|---------------------------------------------|-------:|------:|
| `Found N errors:`                           |     13 |     3 |
| `Found N warnings`                          |      3 |     1 |
| `duplicate_reference` errors on U7          |      2 |     0 |
| `unconnected_pin` / `unconnected_power_pin` errors on U7 | 8 | 0 |
| `unconnected_pin` warnings on U7 (open_collector) | 2 | 0 |
| `disconnected_label` errors (pre-existing, unrelated) | 3 | 3 |

The remaining 3 errors and 1 warning after the fix are legitimate findings unrelated to multi-unit symbols (3 disconnected labels off the BUS_LINE / SRC_POS / SRC_NEG rail and 1 pre-existing wire-collision warning).

## Acceptance criteria from #3349

- [x] Multi-unit symbols (LM393 etc.) no longer trigger duplicate-reference warnings when units share a reference
- [x] Unconnected-pin check aggregates pin connectivity across all `SymbolInstance` rows of the same reference
- [x] Unit test covers an LM393 placement with all 3 units present and connected (`test_check_unconnected_pins_multi_unit_all_placed_connected`)
- [x] `boards/external/softstart/generate_design.py` regenerates with 0 spurious U7 warnings

## What this does NOT change

- The set of checks (still flags genuine power/IO unconnected pins, still flags duplicate refs when units collide or lib_ids differ).
- Legitimate "pin not connected" detection on single-unit symbols. The `unit=0` default for unparsed `Pin` instances keeps `unit=1` `SymbolInstance` rows matching shared pins, preserving the old behavior for the entire validation suite.

## Test plan

- [x] `uv run pytest tests/test_schematic_models.py` — 209 passed (4 new multi-unit tests + 205 existing).
- [x] `uv run pytest tests/test_sch_validate_duplicate_refs.py tests/test_sch_validate_pin_audit.py tests/test_sch_validate_unconnected_components.py tests/test_sch_validate_items.py tests/test_validate.py tests/test_power_net_validation.py` — 209 passed, 5 skipped.
- [x] `uv run pytest tests/ -k validation ...` — 377 validation tests pass.
- [x] LM393 library parsing tagged with correct unit numbers: pin 1/2/3 = unit 1 (channel A), pin 5/6/7 = unit 2 (channel B), pin 4/8 = unit 3 (power); single-unit `Device:R` pins 1/2 = unit 1.
- [x] Two pre-existing test failures in `test_cli_netlist.py` and `test_report_cmd.py` confirmed unrelated (reproduce on `main` without these changes).

Closes #3349

🤖 Generated with [Claude Code](https://claude.com/claude-code)