### PR TITLE
feat(router): P_AS2 auto-pcb-size trigger + ladder logic (Refs #3352)

### DIFF
--- a/src/kicad_tools/router/auto_pcb_size.py
+++ b/src/kicad_tools/router/auto_pcb_size.py
@@ -1,0 +1,473 @@
+"""
+Auto-pcb-size escalation: trigger detection and ladder logic (Issue #3352, P_AS2).
+
+This module implements the *pure-logic* core of the auto-pcb-size escalation
+loop:
+
+  - :func:`should_escalate` -- decides whether the current routing attempt
+    indicates the envelope (not the layer count, not the clearance) is the
+    bottleneck.
+  - :func:`select_next_tier` -- walks the manufacturer's size-tier ladder per
+    the :class:`~kicad_tools.spec.schema.EscalationPolicy` strategy.
+  - :func:`can_escalate_with_holes` -- enforces the Q3 reframe: mounting
+    holes move as a placeable group; escalation refuses when growing the
+    board would push them outside the new envelope.
+  - :func:`decide_escalation` -- the single public entry point that composes
+    the three checks and returns an :class:`EscalationDecision`.
+
+No router behaviour is changed here.  P_AS3 will wire these helpers into
+``route_cmd.py`` alongside the existing ``route_with_layer_escalation``
+implementation; P_AS4 will compose them with auto-layers per the
+``EscalationPolicy.ladder`` policy.
+
+The single-shot threshold trigger is intentionally simpler than the
+``route_with_layer_escalation`` cross-attempt monotonic-regression
+detector.  P_AS4 may add a multi-attempt detector if real recipes need
+it; for now, the Q4 hardcoded density threshold + reach floor is the
+agreed-upon trigger.
+
+Coordinate / units convention:
+  - All board dimensions in millimetres.
+  - Board area metrics in cm^2 (matches the EscalationPolicy field).
+  - DRC violation counts are integer net-routability blockers (clearance
+    violations + shorts), NOT including warnings.
+
+Issue: https://github.com/rjwalters/kicad-tools/issues/3352
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from kicad_tools.pcb.mounting_holes import MountingHoleGroup
+from kicad_tools.router.mfr_limits import (
+    ManufacturerSizeTier,
+    get_mfr_size_tier_ladder,
+)
+from kicad_tools.spec.schema import EscalationPolicy
+
+__all__ = [
+    "DEFAULT_REACH_THRESHOLD",
+    "EscalationContext",
+    "EscalationDecision",
+    "RoutingResultMetrics",
+    "can_escalate_with_holes",
+    "decide_escalation",
+    "select_next_tier",
+    "should_escalate",
+]
+
+
+# Per Issue #3352 architect proposal section 2: routing reach is the
+# acceptance threshold for "the current envelope is the bottleneck".  When
+# completion is at or above this floor, no escalation is needed even if
+# DRC density is over the threshold (a few hot-spot violations on an
+# almost-fully-routed PCB are best hand-fixed, not escalated).
+#
+# Hardcoded for now (Q4-style policy: hardcode until empirical evidence
+# argues for tunability).  Promote to an EscalationPolicy field if recipe-
+# by-recipe tuning becomes necessary -- the constant is intentionally
+# named here so the future field has an obvious source.
+DEFAULT_REACH_THRESHOLD: float = 0.95
+
+
+@dataclass(frozen=True)
+class RoutingResultMetrics:
+    """Lightweight routing-attempt summary consumed by escalation logic.
+
+    The full :class:`kicad_tools.router.strategies.RoutingResult` (one per
+    net) is too granular for ladder-level decisions; this structure
+    captures the per-attempt aggregate signals the trigger uses.
+
+    Attributes:
+        signal_nets_routed: Number of signal nets fully connected this attempt.
+            "Signal" means non-pour, non-skipped nets -- the population the
+            routing-reach metric is normalised against.
+        signal_nets_total: Total signal nets the attempt tried to route.
+            ``signal_nets_routed / signal_nets_total`` is the routing reach.
+            When zero, completion is treated as 1.0 (vacuously full reach,
+            since there's nothing to route).
+        drc_violations: Count of DRC blocking violations (clearance
+            violations + shorts).  Excludes warnings.
+        board_area_cm2: Board area in cm^2 (used to normalise drc_violations
+            into a density).  Must be > 0; the trigger asserts this.
+    """
+
+    signal_nets_routed: int
+    signal_nets_total: int
+    drc_violations: int
+    board_area_cm2: float
+
+    @property
+    def completion(self) -> float:
+        """Routing reach as a fraction in ``[0.0, 1.0]``.
+
+        Defaults to ``1.0`` when ``signal_nets_total == 0`` (vacuously full
+        completion -- nothing to route means nothing un-routed).
+        """
+        if self.signal_nets_total <= 0:
+            return 1.0
+        return self.signal_nets_routed / self.signal_nets_total
+
+    @property
+    def drc_density(self) -> float:
+        """DRC violations per cm^2 of board area.
+
+        Always non-negative.  When ``board_area_cm2 <= 0`` returns
+        ``float("inf")`` so the trigger never silently false-negatives on
+        a degenerate board (a zero-area board with any violations should
+        flag immediately).
+        """
+        if self.board_area_cm2 <= 0:
+            return float("inf")
+        return self.drc_violations / self.board_area_cm2
+
+
+class EscalationDecision(Enum):
+    """The five possible outcomes of :func:`decide_escalation`.
+
+    The naming convention is verb-first: ``ESCALATE`` means "grow the board",
+    ``REFUSE_*`` means "the trigger fired but escalation is impossible for
+    the named reason", and ``NO_ESCALATION_NEEDED`` means "the trigger did
+    not fire -- the current attempt is good enough".
+
+    Members:
+        ESCALATE: Grow the board to the next admissible tier.
+        REFUSE_HARD_ENVELOPE: Trigger fired but recipe declares
+            ``envelope_hard=True`` AND a mounting-hole group is present.
+            (Without a hole group, ``envelope_hard=True`` is the only
+            blocker -- but P_AS3 will surface a different actionable
+            error message in that case.)
+        REFUSE_HOLES_DONT_FIT: Trigger fired and envelope is soft, but
+            the mounting-hole group would not fit in the next-tier
+            envelope at its declared anchor.
+        REFUSE_MAX_TIER: Trigger fired but the current tier index is
+            already at the policy's max (or the manufacturer's max),
+            so there's no further size escalation to attempt.
+        NO_ESCALATION_NEEDED: Trigger did not fire.  The current attempt
+            is good enough (reach >= threshold AND DRC density <= threshold).
+    """
+
+    ESCALATE = "escalate"
+    REFUSE_HARD_ENVELOPE = "refuse_hard_envelope"
+    REFUSE_HOLES_DONT_FIT = "refuse_holes_dont_fit"
+    REFUSE_MAX_TIER = "refuse_max_tier"
+    NO_ESCALATION_NEEDED = "no_escalation_needed"
+
+
+@dataclass(frozen=True)
+class EscalationContext:
+    """Per-attempt context for the auto-pcb-size escalation loop.
+
+    Encapsulates the slow-changing state (current rung in the ladder,
+    policy declaration, manufacturer, mounting-hole geometry, hard-envelope
+    declaration) so callers don't have to thread eight positional args
+    through :func:`decide_escalation`.
+
+    Attributes:
+        current_tier_index: Index of the current rung in the manufacturer's
+            size-tier ladder (0-based, matches ``get_mfr_size_tier_ladder``
+            ordering).  ``None`` is not allowed -- callers must determine
+            the starting rung from the board envelope before invoking
+            the escalation logic (typically via
+            :func:`kicad_tools.router.mfr_limits.find_smallest_admitting_tier`).
+        policy: The :class:`EscalationPolicy` from the recipe spec.
+        manufacturer: Manufacturer name (case-insensitive; aliases resolved
+            internally).
+        hole_group: Optional mounting-hole group whose placement governs
+            whether escalation can grow the board.  ``None`` means no
+            mounting holes are pinned -- escalation is free to grow.
+        envelope_hard: Mirrors
+            :attr:`kicad_tools.spec.schema.MechanicalRequirements.envelope_hard`.
+            When ``True``, escalation refuses to grow the board.
+    """
+
+    current_tier_index: int
+    policy: EscalationPolicy
+    manufacturer: str
+    hole_group: MountingHoleGroup | None = None
+    envelope_hard: bool = False
+
+
+def should_escalate(
+    metrics: RoutingResultMetrics,
+    policy: EscalationPolicy,
+    reach_threshold: float = DEFAULT_REACH_THRESHOLD,
+) -> bool:
+    """Decide whether the current routing attempt warrants escalation.
+
+    The trigger fires when **both** conditions hold:
+
+      1. Routing reach (``signal_nets_routed / signal_nets_total``) is
+         strictly below ``reach_threshold``.
+      2. DRC violation density (``drc_violations / board_area_cm2``) is
+         strictly above ``policy.density_threshold_viols_per_cm2``.
+
+    Requiring *both* signals is intentional: a few hot-spot violations on
+    an almost-fully-routed PCB are best hand-fixed (high reach, density
+    over threshold -> no escalate), and a sparse incomplete routing on
+    a board with few violations is more often a router bug than a true
+    envelope problem (low reach, density below threshold -> no escalate).
+    Only the "both signals fire" case is unambiguously an envelope issue.
+
+    Single-shot threshold trigger only (per architect's P_AS2 recommendation
+    in the issue).  Multi-attempt monotonic-regression detection -- mirroring
+    the ``REGRESSION_TOLERANCE`` / ``HARD_DROP_NETS`` pattern in
+    ``route_with_layer_escalation`` -- is a P_AS4 addition if needed.
+
+    Args:
+        metrics: Aggregate metrics for the current routing attempt.
+        policy: The recipe's escalation policy (provides the density
+            threshold).
+        reach_threshold: Minimum reach below which escalation is considered.
+            Defaults to :data:`DEFAULT_REACH_THRESHOLD` (0.95) per the
+            Issue #3352 architect proposal.
+
+    Returns:
+        ``True`` if the routing attempt indicates the envelope is the
+        bottleneck and escalation should be attempted.  ``False``
+        otherwise.
+
+    Example:
+        >>> from kicad_tools.spec.schema import EscalationPolicy
+        >>> policy = EscalationPolicy()  # default 0.5 viols/cm^2
+        >>> # Softstart rev B P4: 132 violations on 150 cm^2, 80% reach
+        >>> metrics = RoutingResultMetrics(
+        ...     signal_nets_routed=80,
+        ...     signal_nets_total=100,
+        ...     drc_violations=132,
+        ...     board_area_cm2=150.0,
+        ... )
+        >>> should_escalate(metrics, policy)
+        True
+    """
+    if metrics.completion >= reach_threshold:
+        return False
+    if metrics.drc_density <= policy.density_threshold_viols_per_cm2:
+        return False
+    return True
+
+
+def select_next_tier(
+    current_tier_index: int,
+    policy: EscalationPolicy,
+    manufacturer: str,
+) -> ManufacturerSizeTier | None:
+    """Pick the next size tier per the escalation policy strategy.
+
+    Returns the next-tier-up (one rung up the manufacturer's size-tier
+    ladder) when the policy permits size escalation; returns ``None``
+    when no further escalation is permitted.
+
+    Ladder strategy semantics (mirroring
+    :class:`~kicad_tools.spec.schema.EscalationPolicy`):
+
+      - ``"layers-first"`` -- this function returns the next size tier
+        up.  P_AS4 will gate the call: layer escalation runs first, and
+        :func:`select_next_tier` is only invoked after layers exhaust.
+      - ``"size-first"`` -- this function returns the next size tier up.
+        P_AS4 will run size escalation before layers.
+      - ``"layers-only"`` -- returns ``None``: size escalation disabled.
+      - ``"size-only"`` -- returns the next size tier up; P_AS4 will skip
+        layer escalation.
+      - ``"none"`` -- returns ``None``: no escalation of any axis.
+
+    Independent of ladder strategy, this function returns ``None`` when:
+
+      - ``current_tier_index >= len(ladder) - 1`` (already at top rung).
+      - ``current_tier_index >= policy.max_size_tier`` (recipe-imposed
+        ceiling reached).  ``policy.max_size_tier=None`` (default) means
+        no recipe ceiling.
+
+    Args:
+        current_tier_index: 0-based index of the current rung in the
+            manufacturer's size-tier ladder.
+        policy: The recipe's escalation policy.
+        manufacturer: Manufacturer name (case-insensitive; aliases resolved).
+
+    Returns:
+        The :class:`ManufacturerSizeTier` for the next rung up, or
+        ``None`` if no further escalation is permitted.
+
+    Raises:
+        ValueError: If ``manufacturer`` is not recognized.
+    """
+    # Strategies that disable size escalation altogether.
+    if policy.ladder in ("layers-only", "none"):
+        return None
+
+    ladder = get_mfr_size_tier_ladder(manufacturer)
+    if not ladder:
+        # Defensive: no ladder registered for this manufacturer (shouldn't
+        # happen given get_mfr_size_tier_ladder's fallback, but guard).
+        return None
+
+    next_index = current_tier_index + 1
+    if next_index >= len(ladder):
+        # Already at the top of the manufacturer's ladder.
+        return None
+
+    if policy.max_size_tier is not None and next_index > policy.max_size_tier:
+        # Recipe-imposed ceiling: refuse to escalate beyond max_size_tier.
+        return None
+
+    return ladder[next_index]
+
+
+def can_escalate_with_holes(
+    hole_group: MountingHoleGroup | None,
+    new_tier: ManufacturerSizeTier,
+    envelope_hard: bool,
+) -> tuple[bool, str]:
+    """Check whether mounting holes permit escalation to ``new_tier``.
+
+    Implements the Issue #3352 Q3 reframe: mounting holes are a placeable
+    group with fixed relative geometry.  When the envelope is *soft*, the
+    group either fits in the new envelope at its declared anchor (escalation
+    proceeds) or it doesn't (escalation refuses with a clear error).  When
+    the envelope is *hard*, the presence of any mounting hole group
+    immediately refuses -- the recipe author has declared the mechanical
+    envelope as a non-negotiable constraint, so growing the board is not
+    permitted at all.
+
+    Note that the *envelope-hard refusal* fires even when ``hole_group`` is
+    ``None``.  P_AS3 will use this signal at the route-cmd level to emit the
+    architect's actionable error enumerating the layer / clearance / BOM
+    levers; this function only returns the structured refusal flag here.
+
+    Args:
+        hole_group: The mounting-hole group, or ``None`` if no group is
+            declared.  When ``None`` and ``envelope_hard=False``, the
+            check passes trivially.
+        new_tier: The proposed next-tier size envelope (max width / height).
+        envelope_hard: The mechanical envelope-hard declaration from
+            :attr:`MechanicalRequirements.envelope_hard`.
+
+    Returns:
+        A ``(can_escalate, reason)`` tuple.
+
+          - ``(True, "")`` when escalation is permitted.
+          - ``(False, "envelope_hard=True")`` when the hard-envelope
+            declaration blocks the grow.
+          - ``(False, "mounting hole group at <anchor> doesn't fit in
+            <new>")`` when the envelope is soft but the group falls outside
+            the new envelope at its current anchor.
+
+    Example:
+        >>> from kicad_tools.pcb.mounting_holes import MountingHoleGroup
+        >>> from kicad_tools.router.mfr_limits import MFR_JLCPCB_SIZE_TIERS
+        >>> group = MountingHoleGroup(
+        ...     holes=[(0, 0), (140, 0), (0, 90), (140, 90)],
+        ...     anchor=(5.0, 5.0),
+        ... )
+        >>> # Next tier: 150x150 mm
+        >>> tier = MFR_JLCPCB_SIZE_TIERS[2]
+        >>> can_escalate_with_holes(group, tier, envelope_hard=False)
+        (True, '')
+        >>> can_escalate_with_holes(group, tier, envelope_hard=True)
+        (False, 'envelope_hard=True')
+    """
+    if envelope_hard:
+        return (False, "envelope_hard=True")
+
+    if hole_group is None:
+        # No mounting-hole geometry to worry about; escalation is unrestricted.
+        return (True, "")
+
+    if hole_group.fits_in_envelope(new_tier.max_width_mm, new_tier.max_height_mm):
+        return (True, "")
+
+    new_label = f"{new_tier.max_width_mm:g}x{new_tier.max_height_mm:g} mm"
+    anchor_label = f"({hole_group.anchor[0]:g}, {hole_group.anchor[1]:g})"
+    reason = f"mounting hole group at {anchor_label} doesn't fit in {new_label}"
+    return (False, reason)
+
+
+def decide_escalation(
+    metrics: RoutingResultMetrics,
+    context: EscalationContext,
+    reach_threshold: float = DEFAULT_REACH_THRESHOLD,
+) -> EscalationDecision:
+    """Compose trigger detection, ladder logic, and hole-fit check.
+
+    The single public entry point for the auto-pcb-size escalation loop.
+    Returns an :class:`EscalationDecision` enum the caller (P_AS3) uses to
+    either grow the board or emit an actionable error.
+
+    Decision precedence (most specific first):
+
+      1. ``NO_ESCALATION_NEEDED`` when the trigger does not fire (reach
+         is already at or above threshold, or density is at or below
+         threshold).
+      2. ``REFUSE_MAX_TIER`` when the trigger fires but the ladder is
+         exhausted (already at policy / manufacturer maximum).
+      3. ``REFUSE_HARD_ENVELOPE`` when the trigger fires, the ladder has
+         room, but ``envelope_hard=True`` blocks the grow.
+      4. ``REFUSE_HOLES_DONT_FIT`` when the trigger fires, the envelope is
+         soft, the ladder has room, but the mounting-hole group falls
+         outside the next-tier envelope.
+      5. ``ESCALATE`` otherwise -- the grow is permitted.
+
+    This ordering ensures the caller gets the most actionable refusal
+    reason possible: "you can't escalate because you're already at the
+    max tier" is more useful than "you can't escalate because your
+    envelope is declared hard" when both happen to be true.
+
+    Args:
+        metrics: Per-attempt routing metrics.
+        context: Slow-changing escalation state.
+        reach_threshold: See :func:`should_escalate`.
+
+    Returns:
+        The escalation decision.
+
+    Example:
+        >>> from kicad_tools.spec.schema import EscalationPolicy
+        >>> # Softstart rev B P4: should trigger
+        >>> metrics = RoutingResultMetrics(
+        ...     signal_nets_routed=80,
+        ...     signal_nets_total=100,
+        ...     drc_violations=132,
+        ...     board_area_cm2=150.0,
+        ... )
+        >>> context = EscalationContext(
+        ...     current_tier_index=3,  # 150x200 in JLCPCB ladder
+        ...     policy=EscalationPolicy(),
+        ...     manufacturer="jlcpcb",
+        ...     envelope_hard=True,
+        ... )
+        >>> decide_escalation(metrics, context)
+        <EscalationDecision.REFUSE_HARD_ENVELOPE: 'refuse_hard_envelope'>
+    """
+    # Step 1: did the trigger fire?  If not, no escalation needed.
+    if not should_escalate(metrics, context.policy, reach_threshold):
+        return EscalationDecision.NO_ESCALATION_NEEDED
+
+    # Step 2: is there a next tier to escalate to?  This check comes
+    # before the envelope-hard check because "max tier" is the more
+    # specific failure mode (no further escalation is possible *at all*
+    # vs. "the recipe forbids growing"); the caller's error message can
+    # be more actionable when we name the correct cause.
+    next_tier = select_next_tier(
+        context.current_tier_index,
+        context.policy,
+        context.manufacturer,
+    )
+    if next_tier is None:
+        return EscalationDecision.REFUSE_MAX_TIER
+
+    # Step 3: does the envelope-hard declaration or hole-group geometry
+    # block the grow?  can_escalate_with_holes returns the structured
+    # refusal flag for either failure mode.
+    permitted, reason = can_escalate_with_holes(
+        context.hole_group,
+        next_tier,
+        context.envelope_hard,
+    )
+    if not permitted:
+        if reason == "envelope_hard=True":
+            return EscalationDecision.REFUSE_HARD_ENVELOPE
+        return EscalationDecision.REFUSE_HOLES_DONT_FIT
+
+    return EscalationDecision.ESCALATE

--- a/tests/test_auto_pcb_size.py
+++ b/tests/test_auto_pcb_size.py
@@ -1,0 +1,612 @@
+"""Tests for the auto-pcb-size escalation trigger + ladder logic (Issue #3352, P_AS2).
+
+Covers the pure-logic core of the auto-pcb-size escalation loop:
+
+  - Trigger detection (under threshold, over threshold, edge cases).
+  - Ladder logic for each of the five EscalationPolicy strategies.
+  - Mounting-hole-group fit check (Q3 reframe consumer).
+  - Max-tier refusal.
+  - No-escalation-needed for fully-routed PCBs.
+  - The composed ``decide_escalation`` entry point.
+
+No router behaviour is exercised here -- this is a unit-test boundary.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.pcb.mounting_holes import MountingHoleGroup
+from kicad_tools.router.auto_pcb_size import (
+    DEFAULT_REACH_THRESHOLD,
+    EscalationContext,
+    EscalationDecision,
+    RoutingResultMetrics,
+    can_escalate_with_holes,
+    decide_escalation,
+    select_next_tier,
+    should_escalate,
+)
+from kicad_tools.router.mfr_limits import (
+    MFR_JLCPCB_SIZE_TIERS,
+    get_mfr_size_tier_ladder,
+)
+from kicad_tools.spec.schema import EscalationPolicy
+
+# ---------------------------------------------------------------------------
+# RoutingResultMetrics: derived-property semantics
+# ---------------------------------------------------------------------------
+
+
+class TestRoutingResultMetrics:
+    """Tests for the lightweight per-attempt metrics container."""
+
+    def test_completion_default_zero_nets(self):
+        """Zero signal nets total -> vacuous full completion (1.0)."""
+        m = RoutingResultMetrics(
+            signal_nets_routed=0,
+            signal_nets_total=0,
+            drc_violations=0,
+            board_area_cm2=100.0,
+        )
+        assert m.completion == 1.0
+
+    def test_completion_partial(self):
+        """80/100 nets -> 0.8 completion."""
+        m = RoutingResultMetrics(
+            signal_nets_routed=80,
+            signal_nets_total=100,
+            drc_violations=0,
+            board_area_cm2=100.0,
+        )
+        assert m.completion == pytest.approx(0.8)
+
+    def test_completion_full(self):
+        """100/100 nets -> 1.0 completion."""
+        m = RoutingResultMetrics(
+            signal_nets_routed=100,
+            signal_nets_total=100,
+            drc_violations=0,
+            board_area_cm2=100.0,
+        )
+        assert m.completion == pytest.approx(1.0)
+
+    def test_drc_density_softstart_revb(self):
+        """Softstart rev B: 132 viols / 150 cm^2 = 0.88 /cm^2."""
+        m = RoutingResultMetrics(
+            signal_nets_routed=80,
+            signal_nets_total=100,
+            drc_violations=132,
+            board_area_cm2=150.0,
+        )
+        assert m.drc_density == pytest.approx(0.88)
+
+    def test_drc_density_zero_area_inf(self):
+        """Degenerate zero-area board -> infinite density (never silently zero)."""
+        m = RoutingResultMetrics(
+            signal_nets_routed=0,
+            signal_nets_total=0,
+            drc_violations=5,
+            board_area_cm2=0.0,
+        )
+        assert m.drc_density == float("inf")
+
+    def test_drc_density_zero_violations(self):
+        """Zero violations -> 0.0 density regardless of board area."""
+        m = RoutingResultMetrics(
+            signal_nets_routed=100,
+            signal_nets_total=100,
+            drc_violations=0,
+            board_area_cm2=100.0,
+        )
+        assert m.drc_density == 0.0
+
+
+# ---------------------------------------------------------------------------
+# should_escalate: the single-shot threshold trigger
+# ---------------------------------------------------------------------------
+
+
+class TestShouldEscalate:
+    """Tests for the trigger-detection helper."""
+
+    def _policy(self, density: float = 0.5) -> EscalationPolicy:
+        return EscalationPolicy(density_threshold_viols_per_cm2=density)
+
+    def test_under_both_thresholds_no_escalate(self):
+        """Reach above threshold AND density at or below threshold -> no escalate."""
+        # 98% reach, 0.1 viols/cm^2 -- both signals say "good enough"
+        m = RoutingResultMetrics(
+            signal_nets_routed=98,
+            signal_nets_total=100,
+            drc_violations=10,
+            board_area_cm2=100.0,
+        )
+        assert should_escalate(m, self._policy()) is False
+
+    def test_over_both_thresholds_escalate(self):
+        """Reach below threshold AND density above threshold -> escalate."""
+        # softstart rev B case: 80% reach, 0.88 viols/cm^2
+        m = RoutingResultMetrics(
+            signal_nets_routed=80,
+            signal_nets_total=100,
+            drc_violations=132,
+            board_area_cm2=150.0,
+        )
+        assert should_escalate(m, self._policy()) is True
+
+    def test_high_reach_high_density_no_escalate(self):
+        """High reach + high density = hot-spot, not envelope problem -> no escalate."""
+        # 99% reach but 1.0 viols/cm^2 -- the few un-routed nets are
+        # hot-spots best fixed manually, not by growing the board.
+        m = RoutingResultMetrics(
+            signal_nets_routed=99,
+            signal_nets_total=100,
+            drc_violations=100,
+            board_area_cm2=100.0,
+        )
+        assert should_escalate(m, self._policy()) is False
+
+    def test_low_reach_low_density_no_escalate(self):
+        """Low reach + low density = router bug, not envelope problem -> no escalate."""
+        # 50% reach but 0.0 viols/cm^2 -- the un-routed nets are
+        # router-confusing, not density-blocked.  Growing won't help.
+        m = RoutingResultMetrics(
+            signal_nets_routed=50,
+            signal_nets_total=100,
+            drc_violations=0,
+            board_area_cm2=100.0,
+        )
+        assert should_escalate(m, self._policy()) is False
+
+    def test_reach_exactly_at_threshold_no_escalate(self):
+        """Reach == threshold is treated as "good enough"."""
+        m = RoutingResultMetrics(
+            signal_nets_routed=95,
+            signal_nets_total=100,  # 0.95 == DEFAULT_REACH_THRESHOLD
+            drc_violations=100,
+            board_area_cm2=100.0,
+        )
+        assert should_escalate(m, self._policy()) is False
+
+    def test_density_exactly_at_threshold_no_escalate(self):
+        """Density == threshold is treated as "good enough"."""
+        # 80% reach, exactly 0.5 viols/cm^2
+        m = RoutingResultMetrics(
+            signal_nets_routed=80,
+            signal_nets_total=100,
+            drc_violations=50,
+            board_area_cm2=100.0,
+        )
+        assert should_escalate(m, self._policy(density=0.5)) is False
+
+    def test_custom_reach_threshold(self):
+        """A custom reach_threshold flips the decision."""
+        m = RoutingResultMetrics(
+            signal_nets_routed=90,
+            signal_nets_total=100,
+            drc_violations=100,
+            board_area_cm2=100.0,
+        )
+        # At 0.95 threshold + density 1.0: escalate (reach 0.90 < 0.95)
+        assert should_escalate(m, self._policy(), reach_threshold=0.95) is True
+        # At 0.85 threshold: no escalate (reach 0.90 >= 0.85)
+        assert should_escalate(m, self._policy(), reach_threshold=0.85) is False
+
+    def test_custom_density_threshold(self):
+        """A custom policy density threshold flips the decision."""
+        m = RoutingResultMetrics(
+            signal_nets_routed=80,
+            signal_nets_total=100,
+            drc_violations=80,
+            board_area_cm2=100.0,
+        )
+        # 0.8 density, threshold 0.5 -> escalate
+        assert should_escalate(m, self._policy(density=0.5)) is True
+        # 0.8 density, threshold 1.0 -> no escalate
+        assert should_escalate(m, self._policy(density=1.0)) is False
+
+    def test_default_reach_threshold_is_95(self):
+        """The default reach threshold matches the architect's proposal."""
+        assert DEFAULT_REACH_THRESHOLD == 0.95
+
+
+# ---------------------------------------------------------------------------
+# select_next_tier: per-strategy ladder logic
+# ---------------------------------------------------------------------------
+
+
+class TestSelectNextTier:
+    """Tests for the size-tier ladder logic."""
+
+    def test_layers_first_returns_next_tier(self):
+        """layers-first strategy still returns the next size tier
+        (P_AS4 will gate the call)."""
+        policy = EscalationPolicy(ladder="layers-first")
+        tier = select_next_tier(0, policy, "jlcpcb")
+        assert tier is not None
+        assert tier == MFR_JLCPCB_SIZE_TIERS[1]
+
+    def test_size_first_returns_next_tier(self):
+        """size-first strategy returns the next size tier."""
+        policy = EscalationPolicy(ladder="size-first")
+        tier = select_next_tier(0, policy, "jlcpcb")
+        assert tier is not None
+        assert tier == MFR_JLCPCB_SIZE_TIERS[1]
+
+    def test_layers_only_returns_none(self):
+        """layers-only strategy disables size escalation."""
+        policy = EscalationPolicy(ladder="layers-only")
+        assert select_next_tier(0, policy, "jlcpcb") is None
+
+    def test_size_only_returns_next_tier(self):
+        """size-only strategy returns the next size tier."""
+        policy = EscalationPolicy(ladder="size-only")
+        tier = select_next_tier(0, policy, "jlcpcb")
+        assert tier is not None
+        assert tier == MFR_JLCPCB_SIZE_TIERS[1]
+
+    def test_none_returns_none(self):
+        """none strategy disables all escalation."""
+        policy = EscalationPolicy(ladder="none")
+        assert select_next_tier(0, policy, "jlcpcb") is None
+
+    def test_at_top_of_ladder_returns_none(self):
+        """current index at top of ladder -> no further escalation."""
+        ladder = get_mfr_size_tier_ladder("jlcpcb")
+        top_index = len(ladder) - 1
+        policy = EscalationPolicy(ladder="size-first")
+        assert select_next_tier(top_index, policy, "jlcpcb") is None
+
+    def test_max_size_tier_ceiling_respected(self):
+        """current index >= policy.max_size_tier -> no escalation."""
+        # max_size_tier=2 means we cannot escalate beyond index 2
+        policy = EscalationPolicy(ladder="size-first", max_size_tier=2)
+        # From index 1, next would be index 2 (allowed)
+        assert select_next_tier(1, policy, "jlcpcb") is not None
+        # From index 2, next would be index 3 (refused by ceiling)
+        assert select_next_tier(2, policy, "jlcpcb") is None
+
+    def test_max_size_tier_zero_blocks_all_escalation(self):
+        """max_size_tier=0 means no escalation is possible from any rung."""
+        policy = EscalationPolicy(ladder="size-first", max_size_tier=0)
+        assert select_next_tier(0, policy, "jlcpcb") is None
+
+    def test_max_size_tier_none_uses_manufacturer_max(self):
+        """max_size_tier=None falls back to manufacturer's top tier."""
+        ladder = get_mfr_size_tier_ladder("jlcpcb")
+        top_index = len(ladder) - 1
+        policy = EscalationPolicy(ladder="size-first", max_size_tier=None)
+        # We can escalate up to top_index (returns the top tier).
+        tier = select_next_tier(top_index - 1, policy, "jlcpcb")
+        assert tier is not None
+        assert tier == ladder[top_index]
+        # And refuses beyond that.
+        assert select_next_tier(top_index, policy, "jlcpcb") is None
+
+    def test_walks_through_all_tiers(self):
+        """Sequential calls walk the ladder one rung at a time."""
+        ladder = get_mfr_size_tier_ladder("jlcpcb")
+        policy = EscalationPolicy(ladder="size-first")
+        for i in range(len(ladder) - 1):
+            tier = select_next_tier(i, policy, "jlcpcb")
+            assert tier == ladder[i + 1], f"mismatch at index {i}"
+
+    def test_unknown_manufacturer_raises(self):
+        """An unrecognized manufacturer raises ValueError from the underlying ladder lookup."""
+        policy = EscalationPolicy(ladder="size-first")
+        with pytest.raises(ValueError):
+            select_next_tier(0, policy, "nosuchmfr")
+
+
+# ---------------------------------------------------------------------------
+# can_escalate_with_holes: Q3 reframe consumer
+# ---------------------------------------------------------------------------
+
+
+class TestCanEscalateWithHoles:
+    """Tests for the mounting-hole-group fit check."""
+
+    def _group(
+        self,
+        holes: list[tuple[float, float]] | None = None,
+        anchor: tuple[float, float] = (5.0, 5.0),
+    ) -> MountingHoleGroup:
+        if holes is None:
+            # Four-corner pattern that fits in a 150x100 inset by 5 mm.
+            holes = [(0, 0), (140, 0), (0, 90), (140, 90)]
+        return MountingHoleGroup(holes=holes, anchor=anchor)
+
+    def test_no_holes_soft_envelope_permits(self):
+        """No hole group + soft envelope -> escalation permitted trivially."""
+        tier = MFR_JLCPCB_SIZE_TIERS[2]  # 150x150
+        ok, reason = can_escalate_with_holes(None, tier, envelope_hard=False)
+        assert ok is True
+        assert reason == ""
+
+    def test_no_holes_hard_envelope_refuses(self):
+        """No hole group BUT hard envelope -> structured envelope_hard refusal."""
+        tier = MFR_JLCPCB_SIZE_TIERS[2]
+        ok, reason = can_escalate_with_holes(None, tier, envelope_hard=True)
+        assert ok is False
+        assert reason == "envelope_hard=True"
+
+    def test_holes_fit_soft_envelope_permits(self):
+        """Group fits in next tier + soft envelope -> permitted."""
+        group = self._group()  # fits in 150x100 with 5mm inset
+        tier = MFR_JLCPCB_SIZE_TIERS[3]  # 150x200 (the softstart envelope)
+        ok, reason = can_escalate_with_holes(group, tier, envelope_hard=False)
+        assert ok is True
+        assert reason == ""
+
+    def test_holes_fit_hard_envelope_refuses(self):
+        """Group fits BUT hard envelope -> envelope_hard refusal wins."""
+        group = self._group()
+        tier = MFR_JLCPCB_SIZE_TIERS[3]
+        ok, reason = can_escalate_with_holes(group, tier, envelope_hard=True)
+        assert ok is False
+        assert reason == "envelope_hard=True"
+
+    def test_holes_dont_fit_soft_envelope_refuses(self):
+        """Group falls outside next tier + soft envelope -> hole-fit refusal."""
+        # Group needs ~150x100 inset by 5; tier 0 is 100x100 (too small).
+        group = self._group()
+        tier = MFR_JLCPCB_SIZE_TIERS[0]  # 100x100
+        ok, reason = can_escalate_with_holes(group, tier, envelope_hard=False)
+        assert ok is False
+        assert "doesn't fit" in reason
+        assert "(5, 5)" in reason  # anchor label
+        assert "100x100" in reason  # new envelope label
+
+    def test_holes_dont_fit_hard_envelope_refuses_with_envelope_hard_reason(self):
+        """Hard envelope wins over the hole-fit failure mode."""
+        group = self._group()
+        tier = MFR_JLCPCB_SIZE_TIERS[0]
+        ok, reason = can_escalate_with_holes(group, tier, envelope_hard=True)
+        assert ok is False
+        # envelope_hard takes precedence over hole-fit failure
+        assert reason == "envelope_hard=True"
+
+
+# ---------------------------------------------------------------------------
+# decide_escalation: composed entry point
+# ---------------------------------------------------------------------------
+
+
+class TestDecideEscalation:
+    """Tests for the composed public entry point."""
+
+    def _metrics_softstart_revb(self) -> RoutingResultMetrics:
+        """Softstart rev B P4 metrics: 80% reach, 0.88 viols/cm^2.
+
+        This is the motivating real-world case for the feature.
+        """
+        return RoutingResultMetrics(
+            signal_nets_routed=80,
+            signal_nets_total=100,
+            drc_violations=132,
+            board_area_cm2=150.0,
+        )
+
+    def _metrics_clean(self) -> RoutingResultMetrics:
+        """Fully-routed PCB metrics: 100% reach, zero violations."""
+        return RoutingResultMetrics(
+            signal_nets_routed=100,
+            signal_nets_total=100,
+            drc_violations=0,
+            board_area_cm2=150.0,
+        )
+
+    def test_clean_route_no_escalation_needed(self):
+        """Fully-routed PCB -> NO_ESCALATION_NEEDED."""
+        context = EscalationContext(
+            current_tier_index=2,
+            policy=EscalationPolicy(),
+            manufacturer="jlcpcb",
+        )
+        assert (
+            decide_escalation(self._metrics_clean(), context)
+            == EscalationDecision.NO_ESCALATION_NEEDED
+        )
+
+    def test_softstart_revb_at_top_tier_refuse_max(self):
+        """Trigger fires at the top of the ladder -> REFUSE_MAX_TIER."""
+        ladder = get_mfr_size_tier_ladder("jlcpcb")
+        context = EscalationContext(
+            current_tier_index=len(ladder) - 1,
+            policy=EscalationPolicy(),
+            manufacturer="jlcpcb",
+        )
+        assert (
+            decide_escalation(self._metrics_softstart_revb(), context)
+            == EscalationDecision.REFUSE_MAX_TIER
+        )
+
+    def test_softstart_revb_hard_envelope_refuse(self):
+        """Trigger fires + envelope_hard=True -> REFUSE_HARD_ENVELOPE."""
+        context = EscalationContext(
+            current_tier_index=3,  # 150x200 in JLCPCB ladder (softstart envelope)
+            policy=EscalationPolicy(),
+            manufacturer="jlcpcb",
+            envelope_hard=True,
+        )
+        assert (
+            decide_escalation(self._metrics_softstart_revb(), context)
+            == EscalationDecision.REFUSE_HARD_ENVELOPE
+        )
+
+    def test_softstart_revb_soft_envelope_escalate(self):
+        """Trigger fires + envelope soft + no holes -> ESCALATE."""
+        context = EscalationContext(
+            current_tier_index=2,  # 150x150
+            policy=EscalationPolicy(),
+            manufacturer="jlcpcb",
+            envelope_hard=False,
+        )
+        assert (
+            decide_escalation(self._metrics_softstart_revb(), context)
+            == EscalationDecision.ESCALATE
+        )
+
+    def test_softstart_revb_holes_dont_fit_refuses(self):
+        """Trigger fires + holes don't fit in next tier -> REFUSE_HOLES_DONT_FIT."""
+        # A group that needs >= 150x150 with 5mm inset; next tier from idx 0
+        # is 100x150 (too narrow at the width axis).
+        group = MountingHoleGroup(
+            holes=[(0, 0), (140, 0), (0, 140), (140, 140)],
+            anchor=(5.0, 5.0),
+        )
+        context = EscalationContext(
+            current_tier_index=0,  # at 100x100; next is 100x150
+            policy=EscalationPolicy(),
+            manufacturer="jlcpcb",
+            hole_group=group,
+            envelope_hard=False,
+        )
+        assert (
+            decide_escalation(self._metrics_softstart_revb(), context)
+            == EscalationDecision.REFUSE_HOLES_DONT_FIT
+        )
+
+    def test_softstart_revb_holes_fit_escalate(self):
+        """Trigger fires + holes fit + soft envelope -> ESCALATE."""
+        # Group fits comfortably in 150x150 (next tier from idx 1).
+        group = MountingHoleGroup(
+            holes=[(0, 0), (90, 0), (0, 90), (90, 90)],
+            anchor=(5.0, 5.0),
+        )
+        context = EscalationContext(
+            current_tier_index=1,  # at 100x150; next is 150x150
+            policy=EscalationPolicy(),
+            manufacturer="jlcpcb",
+            hole_group=group,
+            envelope_hard=False,
+        )
+        assert (
+            decide_escalation(self._metrics_softstart_revb(), context)
+            == EscalationDecision.ESCALATE
+        )
+
+    def test_layers_only_strategy_no_escalation(self):
+        """layers-only strategy never returns ESCALATE."""
+        context = EscalationContext(
+            current_tier_index=0,
+            policy=EscalationPolicy(ladder="layers-only"),
+            manufacturer="jlcpcb",
+        )
+        # Trigger fires but select_next_tier returns None -> REFUSE_MAX_TIER
+        assert (
+            decide_escalation(self._metrics_softstart_revb(), context)
+            == EscalationDecision.REFUSE_MAX_TIER
+        )
+
+    def test_none_strategy_no_escalation(self):
+        """none strategy never returns ESCALATE."""
+        context = EscalationContext(
+            current_tier_index=0,
+            policy=EscalationPolicy(ladder="none"),
+            manufacturer="jlcpcb",
+        )
+        assert (
+            decide_escalation(self._metrics_softstart_revb(), context)
+            == EscalationDecision.REFUSE_MAX_TIER
+        )
+
+    def test_precedence_max_tier_over_envelope_hard(self):
+        """When both max-tier AND envelope-hard apply, REFUSE_MAX_TIER wins.
+
+        The max-tier failure is the more specific one (the ladder is empty);
+        envelope_hard is only meaningful when there's a next rung to refuse.
+        """
+        ladder = get_mfr_size_tier_ladder("jlcpcb")
+        context = EscalationContext(
+            current_tier_index=len(ladder) - 1,
+            policy=EscalationPolicy(),
+            manufacturer="jlcpcb",
+            envelope_hard=True,
+        )
+        assert (
+            decide_escalation(self._metrics_softstart_revb(), context)
+            == EscalationDecision.REFUSE_MAX_TIER
+        )
+
+    def test_precedence_envelope_hard_over_holes_dont_fit(self):
+        """envelope_hard wins over hole-fit failure."""
+        # Holes that wouldn't fit anyway, but envelope_hard refuses first.
+        group = MountingHoleGroup(
+            holes=[(0, 0), (290, 0), (0, 290), (290, 290)],
+            anchor=(5.0, 5.0),
+        )
+        context = EscalationContext(
+            current_tier_index=0,
+            policy=EscalationPolicy(),
+            manufacturer="jlcpcb",
+            hole_group=group,
+            envelope_hard=True,
+        )
+        assert (
+            decide_escalation(self._metrics_softstart_revb(), context)
+            == EscalationDecision.REFUSE_HARD_ENVELOPE
+        )
+
+    def test_decide_with_max_size_tier_policy(self):
+        """policy.max_size_tier ceiling triggers REFUSE_MAX_TIER mid-ladder."""
+        context = EscalationContext(
+            current_tier_index=2,
+            policy=EscalationPolicy(max_size_tier=2),
+            manufacturer="jlcpcb",
+            envelope_hard=False,
+        )
+        # Next index 3 > ceiling 2 -> refuse max tier
+        assert (
+            decide_escalation(self._metrics_softstart_revb(), context)
+            == EscalationDecision.REFUSE_MAX_TIER
+        )
+
+
+# ---------------------------------------------------------------------------
+# EscalationContext: dataclass construction
+# ---------------------------------------------------------------------------
+
+
+class TestEscalationContext:
+    """Tests for the EscalationContext value type."""
+
+    def test_minimal_construction(self):
+        """Only the required fields need to be supplied."""
+        policy = EscalationPolicy()
+        ctx = EscalationContext(
+            current_tier_index=0,
+            policy=policy,
+            manufacturer="jlcpcb",
+        )
+        assert ctx.current_tier_index == 0
+        assert ctx.policy is policy
+        assert ctx.manufacturer == "jlcpcb"
+        assert ctx.hole_group is None
+        assert ctx.envelope_hard is False
+
+    def test_full_construction(self):
+        """All fields explicit."""
+        group = MountingHoleGroup(holes=[(0, 0)], anchor=(5.0, 5.0))
+        policy = EscalationPolicy(ladder="size-only", max_size_tier=2)
+        ctx = EscalationContext(
+            current_tier_index=1,
+            policy=policy,
+            manufacturer="pcbway",
+            hole_group=group,
+            envelope_hard=True,
+        )
+        assert ctx.hole_group is group
+        assert ctx.envelope_hard is True
+        assert ctx.policy.ladder == "size-only"
+
+    def test_immutable_frozen(self):
+        """EscalationContext is frozen -- attributes cannot be reassigned."""
+        ctx = EscalationContext(
+            current_tier_index=0,
+            policy=EscalationPolicy(),
+            manufacturer="jlcpcb",
+        )
+        with pytest.raises((AttributeError, TypeError)):
+            ctx.current_tier_index = 1  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Implements **P_AS2** of the auto-pcb-size escalation roadmap (Issue #3352). Adds the pure-logic core of the escalation loop in a new `kicad_tools.router.auto_pcb_size` module.

Builds on P_AS1 (#3355). No router behaviour changes here — P_AS3 will wire this into `route_cmd.py`.

## What's new

**Public API** (`kicad_tools.router.auto_pcb_size`):

| Symbol | Purpose |
|---|---|
| `RoutingResultMetrics` | Lightweight per-attempt metrics (`signal_nets_routed`, `signal_nets_total`, `drc_violations`, `board_area_cm2`); derived `completion` + `drc_density` properties |
| `EscalationContext` | Frozen dataclass: `current_tier_index`, `policy`, `manufacturer`, `hole_group`, `envelope_hard` |
| `EscalationDecision` | Enum: `ESCALATE` / `REFUSE_HARD_ENVELOPE` / `REFUSE_HOLES_DONT_FIT` / `REFUSE_MAX_TIER` / `NO_ESCALATION_NEEDED` |
| `should_escalate(metrics, policy)` | Single-shot threshold trigger (reach < 95% AND density > policy threshold) |
| `select_next_tier(idx, policy, mfr)` | Walks the manufacturer's size-tier ladder per `policy.ladder` strategy |
| `can_escalate_with_holes(group, tier, envelope_hard)` | Q3-reframe consumer — refuses on hard envelope or when group falls outside next tier |
| `decide_escalation(metrics, context)` | Composed entry point returning an `EscalationDecision` |
| `DEFAULT_REACH_THRESHOLD = 0.95` | Default reach floor (per architect proposal §2) |

## Design decisions

1. **Single-shot threshold**, not cross-attempt monotonic regression. Simpler than the `route_with_layer_escalation` `REGRESSION_TOLERANCE` / `HARD_DROP_NETS` pattern; P_AS4 may add multi-attempt detection if needed (acknowledged in the module docstring).
2. **Both signals must fire**: trigger requires reach < threshold AND density > threshold. Discriminates true envelope over-constraint from single hot-spots (high reach + high density) and router bugs (low reach + low density).
3. **Decision precedence**: `NO_ESCALATION_NEEDED` → `REFUSE_MAX_TIER` → `REFUSE_HARD_ENVELOPE` → `REFUSE_HOLES_DONT_FIT` → `ESCALATE`. Max-tier wins over envelope-hard because "no further rung exists" is the more specific failure mode.
4. **Q3 reframe consumed**: `can_escalate_with_holes` calls `MountingHoleGroup.fits_in_envelope` (the P_AS1 primitive) for the soft-envelope case. When the group falls outside the next tier at its current anchor, the refusal reason includes the anchor coords + new envelope dimensions for the P_AS3 actionable error.
5. **No CLI changes** (P_AS4). No `route_cmd.py` changes (P_AS3). No new dependencies.

## Verification

```
tests/test_auto_pcb_size.py ......... 46 passed (new)
tests/test_mfr_limits.py    .........  6 passed (P_AS1 regression)
tests/test_mounting_hole_group.py .. 28 passed (P_AS1 regression)
tests/test_spec.py          .........  rest passed (P_AS1 regression)
                            191 passed in 0.99s
```

Lint + format clean (`ruff check`, `ruff format --check`).

## What's NOT in this PR (deferred)

- P_AS3: wire `decide_escalation` into `route_cmd.py` alongside `route_with_layer_escalation`. The edge-cut mutation (grow the PCB outline + reposition the mounting-hole group) is the load-bearing piece there.
- P_AS4: `--auto-pcb-size` CLI flag, layers-first/size-first composition with the existing auto-layers ladder, optional multi-attempt regression detector.
- P_AS5: softstart rev B consumer test.

## Decisions to flag for P_AS3

1. **Edge-cut mutator**: P_AS2 doesn't grow the PCB outline — `select_next_tier` only returns the new envelope dimensions. P_AS3 needs an edge-cut rewrite that respects Q2 (corner-anchored grow) and updates the mounting-hole-group anchor accordingly.
2. **Density metric source**: `RoutingResultMetrics.board_area_cm2` is the trigger denominator. P_AS3 needs to compute board area from the current PCB outline (or from the current tier dimensions) before constructing the metrics object.
3. **`drc_violations` definition**: assumed to be clearance violations + shorts (excluding warnings) per the issue body. P_AS3 needs to call the DRC engine consistently — likely `run_drc(...).blocking_violation_count` or equivalent.
4. **Hole-group anchor invariance under grow**: `can_escalate_with_holes` checks fit at the *current* anchor. If the corner-anchored grow strategy from Q2 preserves the bottom-left origin, the anchor doesn't need to move — but P_AS3 should document this assumption explicitly (and the `MountingHoleGroup.move_to` API is there if the strategy changes).
5. **Multi-attempt regression detector**: if P_AS3/P_AS4 want it, the architecture is already amenable — accumulate `RoutingResultMetrics` per attempt and add a `should_escalate_with_history(history)` function. The current single-shot trigger is unchanged.

Closes part of #3352 (P_AS2 phase only).

Refs #3352 (P_AS2)