### PR TITLE
test(board-02): re-verify ship-ready on post-Wave-9 main (closes #3334)

### DIFF
--- a/tests/router/test_board02_manufacturable_baseline.py
+++ b/tests/router/test_board02_manufacturable_baseline.py
@@ -22,6 +22,24 @@ Baseline measurement at HEAD (worst-of-3 across seeds 42/43/44 with
   22/155/24/324.66mm output, 8/8 nets, DRC PASS at jlcpcb-tier1.
 - ``kct fleet status`` reports ``ship_ready=YES`` for board 02.
 
+**Re-verified 2026-06-08** on current main (issue #3334) at HEAD 21076e6c:
+- Covers all Wave 9 router PRs landed since the #3292 re-verification:
+  #3300 (escape width), #3322 (power-rail alias + per-segment retry),
+  #3323 (A* flat arrays), #3324 (layer_to_index goal layer fix),
+  #3326 (trace-width-by-impedance), #3328 (board-edge-aware multi-row
+  escape), #3329 (deterministic Segment/Via/Zone UUIDs under seed=N),
+  #3330 (diff-pair centerline overlap rejection), #3332 (BGA-49 /
+  budget-exit diff-pair priority).
+- Board 02 has no impedance net classes (the #3326 trace-width-by-
+  impedance path does not engage), no diff pairs (#3330/#3332 inactive),
+  no multi-row connectors (#3328 inactive), and no escape-width-affected
+  topology -- so most Wave 9 changes are no-ops on this board.
+- All 3 cpp seeds (42/43/44) still produce bit-perfect
+  22/155/24/324.66mm output, 8/8 nets, DRC PASS at jlcpcb-tier1.
+- ``kct fleet status`` reports ``ship_ready=YES`` for board 02, manifest
+  ``fresh`` (no artifact refresh needed -- the routed PCB and manifest
+  from the #3292 verification round remain byte-identical).
+
 Board 02 is the smallest non-trivial routing target in the repo
 (~37mm x ~22mm, 10 nets, 34 pads).  The 4 NODE_x charlieplex matrix
 nets connect to 4-6 LEDs each in an interleaved pattern -- per


### PR DESCRIPTION
## Summary

Re-verifies that ``boards/02-charlieplex-led`` remains JLCPCB ship-ready on current main (HEAD 21076e6c) after the Wave 9 router PRs landed since the prior PR #3301 / issue #3292 verification round.

**Verdict: YES, still manufacturable. No regression. No artifact refresh needed.**

## Measurement results

``tests/router/test_board02_manufacturable_baseline.py`` (the canonical regression guard) was run on HEAD 21076e6c:

| Test | Status | Notes |
|------|--------|-------|
| ``test_all_signal_nets_routed`` | PASSED | 8/8 signal nets routed |
| ``test_drc_clean_at_jlcpcb_tier1`` | PASSED | DRC PASSED (0 errors) |
| ``test_routing_output_deterministic_across_seeds`` | PASSED | seeds 42/43/44 bit-perfect |

```
============================= 3 passed in 68.17s (0:01:08) =============================
```

Pinned baseline ``(22 routes, 155 segments, 24 vias, 324.66mm total length)`` continues to hold across all 3 seeds — board 02 has fully converged and is unaffected by the Wave 9 router changes.

``kct fleet status`` output:

```
Board                           Pads     % Mfr      Stale    DRC Ship?
----------------------------------------------------------------------
02-charlieplex-led             34/34  100% B/C/G/M  fresh      - YES
```

## PRs evaluated for impact on board 02

All Wave 9 router PRs landed since the prior #3292 verification:

| PR | What it changed | Impact on board 02 |
|----|-----------------|---------------------|
| #3300 | Escape width refresh | None (no escape-width-affected topology) |
| #3322 | Power-rail alias + per-segment retry | None (retry path inactive on converged routes) |
| #3323 | A* flat-array g_score / closed-set cache locality | None (perf-only; bit-perfect output preserved) |
| #3324 | C++ A* goal-layer via ``layer_to_index`` | None (2L board uses standard F.Cu/B.Cu mapping) |
| #3326 | Trace-width-by-impedance for board 06 | None (board 02 has no impedance net classes) |
| #3328 | Board-edge-aware multi-row connector escape | None (board 02 has no multi-row connectors) |
| #3329 | Deterministic Segment/Via/Zone UUIDs under seed=N | Compatible (bit-perfect property preserved) |
| #3330 | Diff-pair centerline-overlap rejection | None (board 02 has no diff pairs) |
| #3332 | BGA-49 / budget-exit diff-pair priority | None (board 02 has no BGA / no diff pairs) |

Board 02 (charlieplex 3x3 LED matrix, 2L, ~37mm x 22mm) is small and topologically simple enough that most Wave 9 router work targets paths it doesn't exercise.

## Changes in this PR

Single docstring-only change to ``tests/router/test_board02_manufacturable_baseline.py``:

- Adds a **Re-verified 2026-06-08** block to the module docstring listing the Wave 9 PRs covered and recording the verification results.

**No code changes. No artifact changes.** The routed PCB and ``manufacturing/manifest.json`` from the #3292 verification round (generated 2026-06-07T15:52:37 UTC) remain byte-identical and the fleet-status freshness check still passes.

## Scope discipline

- No router / autorouter / CLI code changes.
- No changes to other boards.
- No manufacturing artifact refresh (none needed — manifest fresh, PCB byte-identical).
- Single-file docstring update; pinned exact-value baseline assertions unchanged.

## Test plan

- [x] ``uv run kct build-native --check`` — C++ backend available (1.0.0)
- [x] ``uv run pytest tests/router/test_board02_manufacturable_baseline.py -v`` — 3 passed in 68s
- [x] ``uv run kct fleet status`` — board 02 = YES (fresh)

Closes #3334

🤖 Generated with [Claude Code](https://claude.com/claude-code)