### PR TITLE
test(board-06): strict-gate guard pins blocking-error count at 17 (Closes #3338)

### DIFF
--- a/tests/test_board_06_diffpair_test.py
+++ b/tests/test_board_06_diffpair_test.py
@@ -679,3 +679,234 @@ class TestManufacturabilityFloor:
             f"the impedance pipeline is wired all the way through to the "
             f"emitted geometry.  Width distribution: {dict(width_counts)}"
         )
+
+
+# =============================================================================
+# Issue #3338: strict-gate guard for the committed routed PCB
+# =============================================================================
+
+
+class TestBoard06StrictGateGuard:
+    """Issue #3338 -- pin the strict CI gate's blocking-error count on the
+    committed routed PCB so a future artifact refresh that drifts on the
+    impedance sidecar (the PR #3273 trap) trips this fast unit test before
+    the CI ``routed-pcb-drc-check`` job catches it.
+
+    The strict gate (``scripts/ci/check_routed_drc.py``) runs ``kct check``
+    with ``--net-class-map`` auto-resolved by
+    ``scripts/ci/net_class_map_resolver.py`` (in-process derivation for
+    board 06 because no committed ``net_class_map.json`` sidecar lives
+    next to the routed PCB).  Without the sidecar the impedance /
+    diff-pair-skew / diff-pair-continuity / match-group-skew rule families
+    short-circuit to a no-op (see #3151), so a naive ``kct check`` would
+    report a count that hides ~hundreds of impedance violations whenever
+    the trace widths drift off the 50 / 90 / 100 Ω impedance-resolved
+    targets.  PR #3273 fell into this trap; PR #3315 codified the
+    impedance modal-width tripwire (see ``test_impedance_sidecar_trap_lifted``
+    above) and this test pins the strict-gate count itself so a refresh
+    PR is caught by an exact-count assertion rather than only the modal-
+    width invariant.
+
+    Mirrors ``tests/test_board_05_drc_allowlist.py`` in shape (per-board
+    strict-gate guard) but routes through the sidecar resolver so the
+    impedance / diff-pair rule families are actually counted.
+
+    The expected count is sourced from the live measurement on the
+    committed PCB at the time this test was written (Issue #3338,
+    HEAD = 21076e6c):
+
+    *   strict gate WITH sidecar = ``17`` blocking errors
+    *   advisory ``connectivity`` = ``4`` (3 unrouted blocking nets
+        ``USB3_TX1+``, ``USB3_TX1-``, ``MIPI_RST`` plus partial GND plane)
+
+    Both counts are excluded-from-gate per the audit pipeline's classifier;
+    only the 17 blocking value gates CI.  The allowlist at
+    ``.github/routed-drc-tolerance.yml:767`` is currently ``21`` (post-#3326
+    tightening), leaving 4-error headroom for seed-dependent variance in
+    the negotiated rip-up cohort -- this test pins the *current* floor
+    (17) so a regression is caught even within the 21 headroom.
+    """
+
+    EXPECTED_STRICT_GATE_ERRORS = 17
+    EXPECTED_ADVISORY_CONNECTIVITY = 4
+
+    @pytest.fixture(scope="class")
+    def routed_pcb(self) -> Path:
+        routed = OUTPUT_DIR / "diffpair_test_routed.kicad_pcb"
+        if not routed.exists():
+            pytest.skip(
+                f"Routed PCB artifact missing: {routed}.  Re-run "
+                "`python boards/06-diffpair-test/generate_design.py --step route "
+                "--seed 42` to regenerate."
+            )
+        return routed
+
+    @pytest.fixture(scope="class")
+    def strict_gate_result(self, routed_pcb: Path) -> dict:
+        """Invoke ``kct check`` with the auto-resolved impedance sidecar.
+
+        Mirrors the exact invocation used by
+        ``scripts/ci/check_routed_drc.py`` so this fast unit test produces
+        the same number CI gates on.
+        """
+        import json
+        import subprocess
+
+        # Import the resolver the same way the strict gate script does.
+        ci_dir = REPO_ROOT / "scripts" / "ci"
+        sys.path.insert(0, str(ci_dir))
+        try:
+            from net_class_map_resolver import resolve_net_class_map_sidecar  # type: ignore
+        finally:
+            sys.path.pop(0)
+
+        with resolve_net_class_map_sidecar(routed_pcb) as sidecar:
+            assert sidecar is not None, (
+                "Board 06 net-class-map sidecar resolution returned None; the "
+                "in-process derivation from "
+                "``boards/06-diffpair-test/generate_design.py::build_net_class_map`` "
+                "failed.  Without the sidecar the impedance / diff-pair / "
+                "match-group rule families short-circuit to a no-op and the "
+                "PR #3273 trap re-opens."
+            )
+
+            cmd = [
+                "uv",
+                "run",
+                "kct",
+                "check",
+                str(routed_pcb),
+                "--mfr",
+                "jlcpcb",
+                "--errors-only",
+                "--format",
+                "json",
+                "--net-class-map",
+                str(sidecar),
+            ]
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=False,
+                cwd=REPO_ROOT,
+                timeout=180,
+            )
+            assert proc.returncode in (0, 2), (
+                f"kct check exited {proc.returncode} on {routed_pcb}.\n"
+                f"stderr:\n{proc.stderr}"
+            )
+            return json.loads(proc.stdout)
+
+    def test_strict_gate_blocking_count_pinned(self, strict_gate_result: dict) -> None:
+        """Blocking-error count under the impedance sidecar matches the floor.
+
+        The CI gate's ``_count_blocking_errors`` filters advisory rules
+        (``connectivity``) out of the count it compares against the
+        allowlist.  We apply the same filter here so the pinned value
+        matches what the CI gate sees.
+
+        A FAILURE here means one of:
+
+        * A real routing regression that introduced new DRC violations
+          (e.g., a refresh PR drifted on impedance widths and triggered
+          ~hundreds of impedance violations -- the PR #3273 trap).
+        * A router improvement that DROPPED the count below 17 -- in that
+          case tighten ``EXPECTED_STRICT_GATE_ERRORS`` in the SAME PR
+          and tighten the allowlist in ``.github/routed-drc-tolerance.yml``
+          (currently 21; the strict gate's drift warning will be your
+          guide).  This is the OUT-OF-SCOPE follow-up from issue #3338.
+        """
+        from kicad_tools.validate.checker import DRCChecker
+
+        violations = strict_gate_result.get("violations", [])
+        blocking = 0
+        for v in violations:
+            if not isinstance(v, dict):
+                continue
+            if v.get("severity", "error") != "error":
+                continue
+            rule_id = v.get("rule_id", "")
+            if not isinstance(rule_id, str):
+                continue
+            if DRCChecker.is_advisory_rule(rule_id):
+                continue
+            blocking += 1
+
+        assert blocking == self.EXPECTED_STRICT_GATE_ERRORS, (
+            f"Strict-gate blocking-error count on the committed routed PCB "
+            f"is {blocking}; expected {self.EXPECTED_STRICT_GATE_ERRORS} "
+            f"(pinned by Issue #3338).  If a refresh PR INCREASED this, "
+            f"the impedance sidecar likely drifted -- re-run "
+            f"``scripts/ci/check_routed_drc.py "
+            f"boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb`` "
+            f"to confirm and either revert the refresh or accept the new "
+            f"floor.  If a router improvement DECREASED this, tighten "
+            f"``EXPECTED_STRICT_GATE_ERRORS`` AND "
+            f"``.github/routed-drc-tolerance.yml:767`` in the same PR."
+        )
+
+    def test_strict_gate_within_allowlist(self, strict_gate_result: dict) -> None:
+        """Belt-and-braces: also verify the blocking count is within the
+        committed allowlist (the CI gate's actual comparison)."""
+        import yaml
+
+        from kicad_tools.validate.checker import DRCChecker
+
+        allowlist_path = REPO_ROOT / ".github" / "routed-drc-tolerance.yml"
+        if not allowlist_path.exists():
+            pytest.skip(f"Allowlist file not found at {allowlist_path}")
+
+        data = yaml.safe_load(allowlist_path.read_text())
+        tolerances = data.get("tolerances", {})
+        key = "boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb"
+        assert key in tolerances, (
+            f"Board 06 entry {key!r} missing from allowlist {allowlist_path}.  "
+            f"Issue #3326 tightened the floor from 39 to 21; if board 06 "
+            f"now reaches 0 the entry should be removed entirely (per the "
+            f"file's policy header) and this test updated."
+        )
+        allowed = tolerances[key]
+
+        violations = strict_gate_result.get("violations", [])
+        blocking = sum(
+            1
+            for v in violations
+            if isinstance(v, dict)
+            and v.get("severity", "error") == "error"
+            and isinstance(v.get("rule_id", ""), str)
+            and not DRCChecker.is_advisory_rule(v.get("rule_id", ""))
+        )
+        assert blocking <= allowed, (
+            f"Board 06 routed PCB strict-gate blocking-error count "
+            f"({blocking}) exceeds allowlist value ({allowed}) from "
+            f"{allowlist_path.relative_to(REPO_ROOT)}.  This is a routing "
+            f"regression -- revert the offending change or raise the "
+            f"allowlist with reviewer sign-off and a tracking-issue link."
+        )
+
+    def test_advisory_connectivity_pinned(self, strict_gate_result: dict) -> None:
+        """Advisory ``connectivity`` count pinned at 4 (3 blocking-incomplete
+        signal nets + 1 partial GND plane).
+
+        The 3 blocking incompletes are ``USB3_TX1+`` / ``USB3_TX1-`` (the
+        BGA-49 inner-ring residual tracked under closed #3270) and
+        ``MIPI_RST`` (FFC connector single-ended trace).  A drift in this
+        count usually signals the router has either gained OR lost a net
+        in the residual cohort -- both deserve scrutiny because the
+        cohort is the "Wave 9 unfinished business" set.
+        """
+        violations = strict_gate_result.get("violations", [])
+        connectivity = sum(
+            1
+            for v in violations
+            if isinstance(v, dict) and v.get("rule_id") == "connectivity"
+        )
+        assert connectivity == self.EXPECTED_ADVISORY_CONNECTIVITY, (
+            f"Advisory connectivity count on the committed routed PCB is "
+            f"{connectivity}; expected {self.EXPECTED_ADVISORY_CONNECTIVITY} "
+            f"(3 blocking-incomplete signal nets USB3_TX1+/USB3_TX1-/MIPI_RST "
+            f"+ 1 partial GND plane).  A change here indicates the router "
+            f"gained or lost a net in the residual cohort -- investigate "
+            f"before updating the pin."
+        )


### PR DESCRIPTION
## Summary

Issue #3338 asked for a board-06 artifact refresh post-Wave-9 (#3326 impedance + #3328 multi-row escape + #3332 BGA-49 priority promotion). Verification on current main shows the **committed routed PCB is already at the post-Wave-9 floor** -- a fresh re-route produces a structurally identical PCB (same 351 segments, 106 vias, same byte size, same strict-gate result; only deterministic-UUID drift). Per the #3338 brief ("if refresh equal or worse: don't commit; ship test-only verification"), this PR preserves the committed artifact and adds a strict-gate guard test class that codifies the verification.

## CRITICAL: impedance-sidecar trap (PR #3273 lesson) - HEEDED

The strict CI gate `scripts/ci/check_routed_drc.py` was run **WITH** the `--net-class-map` sidecar (auto-resolved by `scripts/ci/net_class_map_resolver.py` from `boards/06-diffpair-test/generate_design.py::build_net_class_map`). Without the sidecar the impedance / diff-pair / match-group rule families short-circuit to a no-op (graceful-degradation contract for external-router boards) and the trap re-opens.

**Strict gate result WITH sidecar**:
```
OK: boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb -- 17 errors
(--mfr jlcpcb, allowlist max 21; reduce the allowlist value ... if this count drops further).
[advisory (excluded from gate): connectivity=4]
```

By rule family the 17 blocking errors break down as:
- `diffpair_length_skew` = 8
- `diffpair_routing_continuity` = 8
- `diffpair_clearance_intra` = 1

(Plus 4 advisory `connectivity` excluded from the gate -- 3 blocking-incomplete signal nets USB3_TX1+/USB3_TX1-/MIPI_RST + 1 partial GND plane.)

## Acceptance criteria status

- [x] Run `generate_design.py --step route --seed 42` on current main (HEAD 5b85ab33; refresh produced structurally identical PCB -- only UUID drift)
- [x] **Strict DRC gate WITH `--net-class-map`** -- 17 errors, well within 21-allowlist
- [x] Routes >= 18/21 signal nets (18/21; USB3_TX1+/- + MIPI_RST residual)
- [x] `test_impedance_sidecar_trap_lifted` passes (modal width 0.375mm matches impedance-resolved 50 Ω SE)
- [x] `TestManufacturabilityFloor` passes (`test_at_least_14_signal_nets_have_segments`, `test_each_diffpair_has_at_least_one_side_routed`)
- [x] PR #3332's drift-prevention tests pass (all 5 in `test_budget_exit_diff_priority`)
- [x] Determinism preserved (refresh = byte-identical structure modulo random UUIDs)
- [ ] `kct fleet status` no longer reports "incomplete routing (3/26 nets)" -- **NOT MET**; those 3 nets are the persistent USB3_TX1+/- + MIPI_RST residual (USB3_TX1+ explicitly out-of-scope per #3270 closed; the other two require further router work). The committed PCB and a fresh refresh both report identical 3/26.

## What this PR ships (test-only verification)

A new `TestBoard06StrictGateGuard` class in `tests/test_board_06_diffpair_test.py` with three guard tests:

1. **`test_strict_gate_blocking_count_pinned`** -- the strict gate's blocking count is exactly 17 (pinning the current floor). Any drift trips this fast unit test before the slow CI `routed-pcb-drc-check` job catches it. Mirrors the exact `scripts/ci/check_routed_drc.py` invocation (auto-resolves the impedance sidecar via `net_class_map_resolver.py`) so the impedance / diff-pair / match-group rule families are actually counted (PR #3151 fix).

2. **`test_strict_gate_within_allowlist`** -- belt-and-braces guard against the YAML allowlist value (currently 21); auto-tightens when a follow-up PR lowers the allowlist.

3. **`test_advisory_connectivity_pinned`** -- pins the 4-connectivity-advisory cohort (3 blocking-incomplete signal nets + partial GND) so a router change that gains OR loses a net in the residual cohort surfaces immediately.

The PR #3273 trap (impedance sidecar drift hidden by naive `kct check`) now has a third tripwire in addition to the existing impedance modal-width assertion in `test_impedance_sidecar_trap_lifted` (PR #3315) and the CI strict gate job.

## Why no PCB refresh

A fresh `--step route --seed 42` produced:
- Same 351 segments
- Same 106 vias
- Same 101,193 bytes
- Same strict-gate result (17 errors with sidecar)
- Same incomplete cohort (USB3_TX1+, USB3_TX1-, MIPI_RST)
- Different MD5 (random-shuffle UUID drift only)

Per the #3338 instruction "if refresh equal or worse: don't commit; ship test-only verification", committing the refresh would only churn UUIDs without any routing/DRC improvement. Avoiding the churn keeps git blame clean.

## Out of scope (separate follow-ups)

- Tightening the 21-allowlist to 17 (CI script's drift warning already surfaces this as a one-line YAML change)
- USB3_TX1+ U2.B2 BGA-49 escape (closed #3270, expected residual)
- USB2_D+/USB2_D- pre-existing violation (orthogonal mechanism)
- Bringing `kct fleet status` to 0/26 unrouted (requires further router work on USB3_TX1- + MIPI_RST)

## Test plan

- [x] `uv run python -m pytest tests/test_board_06_diffpair_test.py --no-cov -v` (38 passed)
- [x] `uv run python -m pytest tests/test_budget_exit_diff_priority.py -v` (5 passed)
- [x] `uv run python scripts/ci/check_routed_drc.py boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb` (17 errors, OK)
- [x] `uv run kct fleet status` -- unchanged delta (still reports 3/26 incomplete)
- [x] `uv run kct build-native --check` -- C++ backend available 1.0.0
- [x] `--seed 42` refresh produces structurally identical PCB (verified by diff -- only UUID lines differ)

Closes #3338