### PR TITLE
feat(router): fine-pitch escape detector + per-net-class clearance threading (P_FP2)

### DIFF
--- a/src/kicad_tools/router/__init__.py
+++ b/src/kicad_tools/router/__init__.py
@@ -107,9 +107,13 @@ from .fine_pitch import (
     analyze_fine_pitch_components,
 )
 from .fine_pitch_escape import (
+    DEFAULT_ESCAPE_REGION_RADIUS_MM,
     ESCAPE_CLEARANCE_SAFETY_MARGIN_MM,
+    FinePitchRegion,
+    detect_fine_pitch_regions,
     geometry_needs_fine_pitch_escape,
     get_default_escape_clearance,
+    resolve_clearance_with_escape_region,
 )
 from .grid import RoutingGrid
 from .adaptive_grid import (
@@ -541,6 +545,11 @@ __all__ = [
     "ESCAPE_CLEARANCE_SAFETY_MARGIN_MM",
     "geometry_needs_fine_pitch_escape",
     "get_default_escape_clearance",
+    # Fine-Pitch Escape Region Detector (Issue #3371 P_FP2)
+    "DEFAULT_ESCAPE_REGION_RADIUS_MM",
+    "FinePitchRegion",
+    "detect_fine_pitch_regions",
+    "resolve_clearance_with_escape_region",
     # Sub-Grid Routing for Fine-Pitch Components (Issue #1109)
     "SubGridRouter",
     "SubGridAnalysis",

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -601,9 +601,31 @@ class CppGrid:
         # Issue #2908: Pre-compute plane-net classification on Python side
         # (C++ has no net-name string table) so the C++ validator can use
         # the same carve-out as the Python ``_is_plane_net_pad`` helper.
+        from .fine_pitch_escape import resolve_clearance_with_escape_region
         from .grid import _is_plane_net_pad
 
         component_pitches = grid.compute_component_pitches()
+
+        # Issue #3371 / P_FP2: Fine-pitch escape regions installed on the
+        # grid (empty list when the detector has not run, which is the
+        # default until P_FP3 wires the autorouter to populate them).
+        # Threaded into ``resolve_clearance_with_escape_region`` for every
+        # pad's clearance lookup so the per-net-class escape clearance can
+        # land at the C++ pad-segment validator's clearance source.
+        #
+        # Important: this bulk-copy runs at grid construction time, BEFORE
+        # any specific net is being routed.  We therefore cannot pass a
+        # per-net :class:`NetClassRouting` here -- the bulk clearance is a
+        # *board-wide default*.  ``net_class=None`` in the call below
+        # means "use the region's escape_clearance default at detection
+        # time" (which already encodes the manufacturer floor + safety
+        # margin via :func:`get_default_escape_clearance`).  P_FP3 will
+        # add the per-net override path via either (a) a separate set of
+        # add_pad calls per net during the A* boundary, or (b) a tighter
+        # ``clearance_override`` carrier on the C++ Pad struct that the
+        # search-side can interpret per net.  P_FP2 only opens the seam.
+        regions = grid.get_fine_pitch_regions()
+
         for pad in grid._pads:
             # Compute layer index (-1 for through-hole pads = all layers)
             if pad.through_hole:
@@ -615,8 +637,18 @@ class CppGrid:
                     layer_idx = 0
 
             # Pre-compute clearance for this pad's component (Issue #1016)
+            # threaded with the fine-pitch escape regions (Issue #3371 / P_FP2).
+            # When ``regions`` is empty (the default) this call delegates to
+            # the standard :meth:`DesignRules.get_clearance_for_component`
+            # path -- byte-for-byte identical to the pre-#3371 line.
             pin_pitch = component_pitches.get(pad.ref) if pad.ref else None
-            clearance_override = grid.rules.get_clearance_for_component(pad.ref, pin_pitch)
+            clearance_override = resolve_clearance_with_escape_region(
+                grid.rules,
+                pad,
+                net_class=None,
+                regions=regions,
+                pin_pitch=pin_pitch,
+            )
 
             # Deterministic FNV-1a hash of component reference
             ref_hash = router_cpp.fnv1a_hash(pad.ref) if pad.ref else 0

--- a/src/kicad_tools/router/fine_pitch_escape.py
+++ b/src/kicad_tools/router/fine_pitch_escape.py
@@ -1,41 +1,72 @@
 """
-Fine-pitch escape predicates and manufacturer-aware clearance defaults.
+Fine-pitch escape predicates, detector, and manufacturer-aware clearance defaults.
 
-Issue #3371 (P_FP1) -- the foundation layer for the fine-pitch escape ladder.
-This module exposes the *pure-logic* primitives that downstream phases build
-on:
+Issue #3371 (P_FP1 + P_FP2) -- the foundation layer for the fine-pitch
+escape ladder.  This module exposes the *pure-logic* primitives that
+downstream phases build on:
 
-- :func:`geometry_needs_fine_pitch_escape` -- the Q_FP1 recipe-relative
-  predicate.  Returns ``True`` when the trace-plus-clearance corridor cannot
-  fit between adjacent pads of a fine-pitch package at the current routing
-  parameters.  This is the trigger condition for shrinking clearance (or
-  switching escape strategy) in the escape-region near the package.
+- :func:`geometry_needs_fine_pitch_escape` (P_FP1) -- the Q_FP1
+  recipe-relative predicate.  Returns ``True`` when the trace-plus-clearance
+  corridor cannot fit between adjacent pads of a fine-pitch package at the
+  current routing parameters.
 
-- :func:`get_default_escape_clearance` -- the Q_FP2 manufacturer-aware
-  safe-default helper.  Returns a clearance value that is strictly above
-  the manufacturer's minimum capability so the per-net-class
-  ``escape_clearance`` overrides cannot accidentally violate fab limits.
+- :func:`get_default_escape_clearance` (P_FP1) -- the Q_FP2
+  manufacturer-aware safe-default helper.  Returns a clearance value that
+  is strictly above the manufacturer's minimum capability so the
+  per-net-class ``escape_clearance`` overrides cannot accidentally violate
+  fab limits.
+
+- :class:`FinePitchRegion` (P_FP2) -- frozen dataclass describing a single
+  fine-pitch escape region as a circular halo of fixed radius centred on a
+  detected fine-pitch package.  Carries the metadata downstream consumers
+  (validator, grid halo, C++ pad-segment check) need to apply the
+  per-net-class escape clearance once threaded.
+
+- :func:`detect_fine_pitch_regions` (P_FP2) -- iterates the router-level
+  pad list and returns one :class:`FinePitchRegion` per qualifying
+  component (pitch <= ``FINE_PITCH_THRESHOLD_MM`` AND geometry-needs the
+  escape per the Q_FP1 predicate).  The detector is the trigger feeding the
+  P_FP3 per-net clearance application.
+
+- :func:`resolve_clearance_with_escape_region` (P_FP2) -- single-threading-
+  point helper for the validator / grid-halo / C++ pad-segment consumers.
+  Returns the escape clearance for a (pad, net_class, regions) triple when
+  the gates fire, falling back to the standard
+  :meth:`DesignRules.get_clearance_for_component` otherwise.  Enforces the
+  impedance-controlled-net guard from PR #3273 so the escape rule cannot
+  shrink clearance on impedance-controlled segments.
 
 No router behaviour is changed by this module.  P_FP2 wires the trigger
-predicate into a region detector; P_FP3 applies the per-net-class clearance
-through :meth:`DesignRules.get_clearance_for_component`; P_FP4 composes the
-ladder with auto-layers and auto-pcb-size; P_FP5 adds the consumer test on
-softstart rev B.
+predicate into a region detector + the clearance-resolution helper; the
+threading points at :meth:`cpp_backend.from_routing_grid` line 619 and at
+the pathfinder boundary opt in via an *empty* default regions list, so
+the change is zero-impact until P_FP3 wires the regions through.  P_FP3
+applies the per-net-class clearance at the consumer side; P_FP4 composes
+the ladder with auto-layers and auto-pcb-size; P_FP5 adds the consumer
+test on softstart rev B.
 
 Issue: https://github.com/rjwalters/kicad-tools/issues/3371
 """
 
 from __future__ import annotations
 
+import math
+from collections import defaultdict
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .mfr_limits import MfrLimits
+    from .primitives import Pad
+    from .rules import DesignRules, NetClassRouting
 
 __all__ = [
     "ESCAPE_CLEARANCE_SAFETY_MARGIN_MM",
+    "FinePitchRegion",
+    "detect_fine_pitch_regions",
     "geometry_needs_fine_pitch_escape",
     "get_default_escape_clearance",
+    "resolve_clearance_with_escape_region",
 ]
 
 
@@ -122,7 +153,7 @@ def geometry_needs_fine_pitch_escape(
     return required > gap
 
 
-def get_default_escape_clearance(mfr_limits: "MfrLimits") -> float:
+def get_default_escape_clearance(mfr_limits: MfrLimits) -> float:
     """Return the manufacturer-aware safe default for escape clearance.
 
     Implements the Q_FP2 decision from Issue #3371: the default
@@ -155,3 +186,561 @@ def get_default_escape_clearance(mfr_limits: "MfrLimits") -> float:
         epsilon.
     """
     return mfr_limits.min_clearance + ESCAPE_CLEARANCE_SAFETY_MARGIN_MM
+
+
+# ============================================================================
+# P_FP2 -- region detector
+# ============================================================================
+#
+# The detector returns one :class:`FinePitchRegion` per qualifying component
+# (i.e. one per fine-pitch SOIC/SSOP/TSSOP/etc. that the pathfinder will
+# encounter on this board).  Regions are circular halos centred on the
+# component's pad-cluster centroid, with a configurable radius (default
+# 5mm -- architect Q2 recommendation in Issue #3371's open-question table).
+#
+# The choice of *circular halo* (vs per-package bounding box or per-row
+# corridor strip) is the simplest of the architect's three options and is
+# the most robust for the dispatcher: a circular ``contains_point`` check
+# is one ``hypot`` call per A* edge expansion, no axis-aligned-vs-rotated
+# package handling, no per-row dispatch.  Future phases can widen the
+# region shape if a per-row strip turns out to be necessary, but the P_FP1
+# builder's decision #1 was "circular halo per pad cluster centroid";
+# P_FP2 honours that.
+#
+# The detector is a *pure function* of (pads, rules, mfr_limits).  Routing
+# state (the negotiator's current iteration count, the auto-layer stack,
+# the auto-pcb-size escalation tier, etc.) is intentionally NOT consumed
+# -- the same set of regions is valid for the lifetime of a board's design
+# rules, so the detector can run once at route-start and the result is
+# cached at the consumer side.
+
+
+# Default escape-region radius (mm).  Q_FP2 architect recommendation in
+# Issue #3371: a single fixed radius covering "near the fine-pitch
+# package" is sufficient for the vast majority of boards (one or two
+# fine-pitch parts per board, neighbouring traffic blocked by the
+# package's own pad cluster well before 5mm).  Tighter radii (e.g. 3mm)
+# under-cover the escape corridor for SOIC-8 inboard pins; wider radii
+# (e.g. 10mm) start to consume the inter-package backbone routing where
+# the relaxed default clearance is the right answer.
+#
+# Recipes that want per-package tuning should set
+# :attr:`DesignRules.escape_region_radius` (when that field lands in
+# P_FP3 / P_FP4) or pass an explicit ``radius_mm`` to
+# :func:`detect_fine_pitch_regions`.
+DEFAULT_ESCAPE_REGION_RADIUS_MM: float = 5.0
+
+
+@dataclass(frozen=True)
+class FinePitchRegion:
+    """A single fine-pitch escape region.
+
+    Issue #3371 / P_FP2 -- describes a circular halo around a detected
+    fine-pitch package within which the per-net-class
+    :attr:`NetClassRouting.escape_clearance` is applied (for non-
+    impedance-controlled nets) instead of the global
+    :attr:`DesignRules.trace_clearance`.
+
+    Frozen dataclass for two reasons:
+
+    1. The detector's output is a pure function of the board's design
+       rules + footprints; recomputing it cheaply is fine and accidental
+       mutation downstream would silently desync the validator from the
+       grid halo.
+    2. The :meth:`contains_point` check is on the per-edge A*-expansion
+       hot path; immutable instances are safely hashable / cacheable by
+       reference if a future consumer wants to memoise the dispatch.
+
+    Attributes:
+        package_ref: Component reference of the fine-pitch package
+            (e.g. ``"U5"``).  Carried for diagnostics and for callers
+            that want to log the per-region escape decision.
+        package_origin: World-coordinate ``(x, y)`` centre of the pad
+            cluster, in mm.  Used as the circular-halo centre by
+            :meth:`contains_point`.
+        radius_mm: Halo radius in mm.  The escape clearance applies to
+            cells / pads strictly within this radius of
+            :attr:`package_origin`.
+        pin_pitch: Detected centre-to-centre pin pitch of the
+            fine-pitch package, in mm.  Stored for diagnostics and so
+            P_FP3+ consumers can re-validate the corridor math without
+            re-deriving the pitch.
+        pad_size_along_pitch: Pad dimension along the pitch axis, in
+            mm.  For a horizontal SOIC row this is the pad *width*; for
+            a vertical row it is the pad *height*.  Used by P_FP3+ to
+            apply the Q_FP1 corridor predicate at edge-expansion time.
+        escape_clearance: Default escape clearance for this region, in
+            mm, computed at detection time from
+            :func:`get_default_escape_clearance` and the configured
+            manufacturer.  Per-net-class overrides
+            (:attr:`NetClassRouting.escape_clearance`) take precedence
+            at the consumer side (see
+            :func:`resolve_clearance_with_escape_region`).
+        pad_refs: Set of ``(ref, pin)`` tuples identifying the pads
+            that belong to this fine-pitch package.  Used by
+            :meth:`applies_to_pad` for the strict "is this pad inside
+            *this* fine-pitch package" check (which is more precise
+            than the circular-halo geometry test for a foreign pad
+            that just happens to sit inside the halo).
+    """
+
+    package_ref: str
+    package_origin: tuple[float, float]
+    radius_mm: float
+    pin_pitch: float
+    pad_size_along_pitch: float
+    escape_clearance: float
+    pad_refs: frozenset[tuple[str, str]] = field(default_factory=frozenset)
+
+    def contains_point(self, x: float, y: float) -> bool:
+        """Return True when the world-coordinate ``(x, y)`` is inside the halo.
+
+        Circular containment check; strictly less than the radius (a
+        point exactly on the radius boundary is considered *outside*
+        the region so the standard ``trace_clearance`` applies).  The
+        ``hypot`` form is the canonical Python idiom for 2D
+        Euclidean distance and avoids the sqrt-of-sum-of-squares
+        rounding error you can hit at small distances.
+
+        Args:
+            x: World x coordinate in mm.
+            y: World y coordinate in mm.
+
+        Returns:
+            ``True`` when the point is strictly inside the circular
+            halo of radius :attr:`radius_mm` centred at
+            :attr:`package_origin`.
+        """
+        dx = x - self.package_origin[0]
+        dy = y - self.package_origin[1]
+        return math.hypot(dx, dy) < self.radius_mm
+
+    def applies_to_pad(self, pad: Pad) -> bool:
+        """Return True when this region applies to ``pad``.
+
+        Two paths:
+
+        1. **Identity match** -- when the pad's ``(ref, pin)`` is in
+           :attr:`pad_refs`, this region *owns* the pad (it is one of
+           the fine-pitch package's own pads) and the escape clearance
+           applies unconditionally.
+        2. **Geometric containment** -- when the pad's centre lies
+           strictly inside the circular halo (per
+           :meth:`contains_point`), the pad sits in the escape region
+           even though it belongs to a foreign component.  This case
+           covers neighbouring decoupling caps and signal-trace
+           start/end pads inside the halo radius.
+
+        Strict identity match comes first so a fine-pitch package's
+        own pad is *always* considered an escape-region pad even when
+        the package geometry is large enough that its outermost pads
+        sit on or past the halo boundary.
+
+        Args:
+            pad: Router-level pad to test.
+
+        Returns:
+            ``True`` when the per-net-class escape clearance should be
+            considered for this pad.
+        """
+        if (pad.ref, pad.pin) in self.pad_refs:
+            return True
+        return self.contains_point(pad.x, pad.y)
+
+
+def _calculate_min_pitch(pads: list[Pad]) -> float:
+    """Return the minimum centre-to-centre pin pitch in ``pads``, or 0.
+
+    Replicates :func:`kicad_tools.router.escape._calculate_min_pitch`
+    locally to avoid a circular import (the escape module already
+    depends on this module for :data:`FINE_PITCH_THRESHOLD_MM`).
+    Coincident pads (within 0.01mm) are ignored.
+    """
+    if len(pads) < 2:
+        return 0.0
+    min_dist = math.inf
+    for i, p1 in enumerate(pads):
+        for p2 in pads[i + 1 :]:
+            dist = math.hypot(p2.x - p1.x, p2.y - p1.y)
+            if dist > 0.01:
+                if dist < min_dist:
+                    min_dist = dist
+    return min_dist if min_dist is not math.inf else 0.0
+
+
+def _infer_pad_size_along_pitch(pads: list[Pad]) -> float:
+    """Return the pad dimension along the pitch axis for ``pads``.
+
+    Q_FP2 builder decision #2: rather than tagging each pad with an
+    explicit "pitch axis = X|Y" annotation, the detector infers the
+    pitch direction from the cluster geometry.  For a dual-row SOIC
+    arrangement with two distinct Y values, the pitch axis is X and the
+    relevant pad dimension is :attr:`Pad.width`; for a vertical row
+    (two distinct X values), the pitch axis is Y and the dimension is
+    :attr:`Pad.height`.  When the cluster does not look like a clear
+    row layout (e.g. a quad QFN), we fall back to the *shorter* of the
+    two pad dimensions, which is the conservative choice for the
+    Q_FP1 predicate (the corridor predicate fires more readily on
+    smaller pad sizes -> we are biased toward applying the escape
+    rule, which is the right safe direction for P_FP2).
+
+    Args:
+        pads: All pads belonging to a single component.
+
+    Returns:
+        Pad size along the pitch axis in mm.  Falls back to the
+        ``min(width, height)`` of the median pad for non-row layouts.
+        Returns ``0.0`` when ``pads`` is empty.
+    """
+    if not pads:
+        return 0.0
+
+    ys = sorted({round(p.y, 2) for p in pads})
+    xs = sorted({round(p.x, 2) for p in pads})
+
+    # Horizontal row layout: 2 distinct Y values, many X values -> pitch
+    # axis is X, relevant pad dimension is width.
+    if len(ys) == 2 and len(xs) >= len(pads) // 2 - 1 and len(xs) >= 2:
+        widths = [p.width for p in pads if p.width > 0]
+        if widths:
+            return min(widths)  # use smallest -- conservative for predicate
+        return 0.0
+
+    # Vertical row layout: 2 distinct X values, many Y values -> pitch
+    # axis is Y, relevant pad dimension is height.
+    if len(xs) == 2 and len(ys) >= len(pads) // 2 - 1 and len(ys) >= 2:
+        heights = [p.height for p in pads if p.height > 0]
+        if heights:
+            return min(heights)
+        return 0.0
+
+    # Non-row layout (BGA-like, quad QFN, etc.) -- conservative
+    # fallback: use the shortest of width/height across the cluster so
+    # the Q_FP1 predicate fires more readily.  These packages are not
+    # the primary target of P_FP2 (BGA escape is a different ladder per
+    # the issue's "Out of scope" list), but the detector should not
+    # silently skip them either.
+    sizes: list[float] = []
+    for p in pads:
+        if p.width > 0:
+            sizes.append(p.width)
+        if p.height > 0:
+            sizes.append(p.height)
+    return min(sizes) if sizes else 0.0
+
+
+def detect_fine_pitch_regions(
+    pads: list[Pad],
+    rules: DesignRules,
+    mfr_limits: MfrLimits | None = None,
+    radius_mm: float = DEFAULT_ESCAPE_REGION_RADIUS_MM,
+) -> list[FinePitchRegion]:
+    """Detect per-component fine-pitch escape regions on a board.
+
+    Issue #3371 / P_FP2 -- groups ``pads`` by component reference
+    (``pad.ref``), computes per-cluster pin pitch / pad size, applies
+    the :data:`FINE_PITCH_THRESHOLD_MM` pitch ceiling AND the Q_FP1
+    recipe-relative geometry predicate
+    (:func:`geometry_needs_fine_pitch_escape`), and returns one
+    :class:`FinePitchRegion` per qualifying component.
+
+    Trigger conditions (BOTH must hold):
+
+    1. The cluster's minimum pin pitch is ``<= FINE_PITCH_THRESHOLD_MM``
+       (1.5mm by default; raised from the historical 0.8mm in P_FP1
+       so 1.27mm SOIC qualifies).
+    2. The recipe-relative corridor predicate fires at the current
+       (rules.trace_width, rules.trace_clearance, pin_pitch,
+       pad_size_along_pitch) parameters.  This filters out 1.27mm-pitch
+       packages that already route fine at the active clearance (the
+       same UCC27211 routes without escape at 0.15mm + 0.30mm).
+
+    The default escape clearance for each region is computed once via
+    :func:`get_default_escape_clearance` using ``mfr_limits``.  When
+    ``mfr_limits`` is ``None`` the function attempts to look up the
+    manufacturer via ``rules.manufacturer``; if that is also unset the
+    region's :attr:`FinePitchRegion.escape_clearance` is left at
+    ``rules.trace_clearance`` (i.e. no shrink) so consumers see a
+    no-op region rather than an undefined value.
+
+    Args:
+        pads: All router-level pads on the board, across all
+            components.  The detector groups by ``pad.ref`` internally.
+            Pads with empty ``ref`` (e.g. board-edge fiducials) are
+            skipped.
+        rules: Design rules.  ``rules.trace_width`` and
+            ``rules.trace_clearance`` are the recipe parameters fed
+            into the Q_FP1 predicate.  ``rules.manufacturer`` is used
+            as a fallback to look up the escape-clearance default
+            when ``mfr_limits`` is not supplied.
+        mfr_limits: Optional explicit manufacturer profile.  When
+            supplied, takes precedence over ``rules.manufacturer`` for
+            the escape-clearance default.
+        radius_mm: Halo radius in mm.  Defaults to
+            :data:`DEFAULT_ESCAPE_REGION_RADIUS_MM` (5mm).  Callers can
+            shrink this for board-specific tuning (e.g. dense boards
+            where two fine-pitch packages sit within 10mm of each
+            other and overlapping halos would over-shrink the inter-
+            package backbone).
+
+    Returns:
+        List of :class:`FinePitchRegion` objects, one per qualifying
+        component.  Empty list when no fine-pitch packages need the
+        escape shrink at the current recipe parameters.  Order is
+        insertion order over the input ``pads`` (deterministic for
+        callers that care about stable region lists).
+
+    Example -- a board with one UCC27211 SOIC-8 at JLCPCB tier-1
+    recipe:
+
+        >>> from kicad_tools.router.mfr_limits import MFR_JLCPCB
+        >>> from kicad_tools.router.rules import DesignRules
+        >>> from kicad_tools.router.primitives import Pad
+        >>> rules = DesignRules(trace_width=0.30, trace_clearance=0.20)
+        >>> # 8 pads of UCC27211: 4 per side, 1.27mm pitch, 0.30mm wide
+        >>> pads = []
+        >>> for i in range(4):
+        ...     pads.append(Pad(x=i*1.27, y=0.0, width=0.30, height=1.55,
+        ...                     net=1, net_name="N1", ref="U5",
+        ...                     pin=str(i+1)))
+        ...     pads.append(Pad(x=i*1.27, y=4.0, width=0.30, height=1.55,
+        ...                     net=1, net_name="N1", ref="U5",
+        ...                     pin=str(i+5)))
+        >>> regions = detect_fine_pitch_regions(pads, rules, MFR_JLCPCB)
+        >>> len(regions)
+        1
+        >>> regions[0].package_ref
+        'U5'
+    """
+    # Resolve the per-region escape clearance default.  When neither
+    # the explicit ``mfr_limits`` argument nor ``rules.manufacturer``
+    # is set, fall back to ``rules.trace_clearance`` (a no-shrink
+    # default that keeps the region from accidentally tightening
+    # clearance on boards without a configured manufacturer).
+    resolved_mfr_limits: MfrLimits | None = mfr_limits
+    if resolved_mfr_limits is None and getattr(rules, "manufacturer", None):
+        try:
+            from .mfr_limits import get_mfr_limits
+
+            resolved_mfr_limits = get_mfr_limits(rules.manufacturer)
+        except (ValueError, ImportError):
+            resolved_mfr_limits = None
+
+    if resolved_mfr_limits is not None:
+        default_escape_clearance = get_default_escape_clearance(resolved_mfr_limits)
+    else:
+        default_escape_clearance = rules.trace_clearance
+
+    # Group pads by component reference, preserving insertion order
+    # for deterministic region output.
+    pads_by_ref: dict[str, list[Pad]] = defaultdict(list)
+    ref_order: list[str] = []
+    for pad in pads:
+        if not pad.ref:
+            continue
+        if pad.ref not in pads_by_ref:
+            ref_order.append(pad.ref)
+        pads_by_ref[pad.ref].append(pad)
+
+    regions: list[FinePitchRegion] = []
+    for ref in ref_order:
+        cluster = pads_by_ref[ref]
+        if len(cluster) < 2:
+            continue  # Single-pad clusters cannot be fine-pitch.
+
+        pin_pitch = _calculate_min_pitch(cluster)
+        if pin_pitch <= 0.0:
+            continue
+
+        # Pitch ceiling -- excludes 2.54mm DIP-style headers and the
+        # like.  Uses the module-level :data:`FINE_PITCH_THRESHOLD_MM`
+        # so the cap stays in sync with
+        # :data:`kicad_tools.router.escape.FINE_PITCH_THRESHOLD_MM`
+        # (drift-prevention test in
+        # ``tests/test_fine_pitch_escape.py``).
+        if pin_pitch > FINE_PITCH_THRESHOLD_MM:
+            continue
+
+        pad_size = _infer_pad_size_along_pitch(cluster)
+        if pad_size <= 0.0:
+            continue
+
+        # Q_FP1 recipe-relative trigger -- a fine-pitch package only
+        # qualifies for the escape region when the corridor is
+        # actually infeasible at the active recipe.
+        if not geometry_needs_fine_pitch_escape(
+            trace_width=rules.trace_width,
+            clearance=rules.trace_clearance,
+            pin_pitch=pin_pitch,
+            pad_size=pad_size,
+        ):
+            continue
+
+        # Centroid of the cluster's pad cluster.  Use the bounding-box
+        # centre rather than a per-pad mean: clusters with asymmetric
+        # pad fill (e.g. a 14-pin SOIC with one pad depopulated) come
+        # out with a centre that better tracks the package's physical
+        # outline.
+        xs = [p.x for p in cluster]
+        ys = [p.y for p in cluster]
+        origin = ((min(xs) + max(xs)) / 2.0, (min(ys) + max(ys)) / 2.0)
+
+        pad_refs = frozenset((p.ref, p.pin) for p in cluster)
+
+        regions.append(
+            FinePitchRegion(
+                package_ref=ref,
+                package_origin=origin,
+                radius_mm=radius_mm,
+                pin_pitch=pin_pitch,
+                pad_size_along_pitch=pad_size,
+                escape_clearance=default_escape_clearance,
+                pad_refs=pad_refs,
+            )
+        )
+
+    return regions
+
+
+# Module-level :data:`FINE_PITCH_THRESHOLD_MM` import is deliberately
+# placed at the bottom of the module to avoid a circular import with
+# :mod:`kicad_tools.router.escape` (which imports
+# :func:`geometry_needs_fine_pitch_escape` from this module for the
+# P_FP3+ dispatcher work).  The constant is defined in escape.py for
+# historical reasons (the predicate ``is_fine_pitch_ssop`` consumes it)
+# and we re-export it via this lazy reference so detector callers do
+# not have to know about the escape module.  P_FP1 builder decision #4
+# acknowledged the manual drift risk; the drift-prevention test guards
+# both literals match.
+from .escape import FINE_PITCH_THRESHOLD_MM  # noqa: E402
+
+# ============================================================================
+# P_FP2 -- single-threading-point clearance resolver
+# ============================================================================
+
+
+def resolve_clearance_with_escape_region(
+    rules: DesignRules,
+    pad: Pad,
+    net_class: NetClassRouting | None,
+    regions: list[FinePitchRegion] | None,
+    pin_pitch: float | None = None,
+) -> float:
+    """Resolve the clearance to use for ``pad`` under the active ``net_class``.
+
+    Issue #3371 / P_FP2 -- the single-threading-point helper that
+    consumers (validator clearance source, grid halo, C++ pad-segment
+    check) call to fold the fine-pitch escape-region logic into their
+    existing :meth:`DesignRules.get_clearance_for_component` lookup.
+
+    Precedence (high to low):
+
+    1. **Per-component explicit override** -- if ``pad.ref`` is in
+       ``rules.component_clearances``, that value wins
+       unconditionally.  Preserves the Issue #1016 contract.
+    2. **Impedance-controlled-net guard (PR #3273)** -- if
+       ``net_class`` has either ``target_diff_impedance`` or
+       ``target_single_impedance`` set, the escape rule is bypassed
+       entirely and we fall through to the standard
+       :meth:`DesignRules.get_clearance_for_component` lookup so the
+       impedance budget is preserved.  This is the load-bearing
+       carve-out: shrinking clearance on a 50 Ω single-ended escape
+       segment would break the trace's characteristic impedance,
+       which is exactly the trap PR #3273 closed.
+    3. **Per-net-class escape clearance in a fine-pitch region** --
+       when ``net_class.escape_clearance`` is set AND at least one
+       :class:`FinePitchRegion` in ``regions`` applies to ``pad`` (per
+       :meth:`FinePitchRegion.applies_to_pad`), return that escape
+       clearance.
+    4. **Region default escape clearance** -- when ``net_class`` does
+       NOT supply its own override but a region applies, return the
+       region's :attr:`FinePitchRegion.escape_clearance` (the
+       manufacturer-aware safe default from
+       :func:`get_default_escape_clearance` computed at detection
+       time).  This lets boards opt into the escape shrink without
+       having to set per-class overrides explicitly.
+    5. **Fall through** -- standard
+       :meth:`DesignRules.get_clearance_for_component` lookup, which
+       handles the global ``fine_pitch_clearance`` shrink (with the
+       Issue #2867 narrow-channel guard) and the per-net-class
+       ``escape_clearance`` override when no region matches.
+
+    Backward-compat: when ``regions`` is ``None`` or empty (the
+    pre-#3371 default), this function returns the same value as
+    ``rules.get_clearance_for_component(pad.ref, pin_pitch, net_class)``
+    byte-for-byte.  P_FP2 leaves all call sites passing ``None`` /
+    ``[]`` for ``regions`` so router behaviour is unchanged.  P_FP3
+    wires the actual region list at the cpp_backend ``from_routing_grid``
+    bulk-copy and at the pathfinder per-net A* boundary.
+
+    Args:
+        rules: Active design rules.
+        pad: Router-level pad whose clearance is being resolved.
+            ``pad.ref`` drives the per-component override lookup;
+            ``(pad.x, pad.y)`` and ``(pad.ref, pad.pin)`` drive the
+            region applicability check.
+        net_class: Active net class for the route consuming this pad's
+            clearance.  ``None`` falls through to global defaults.
+        regions: Optional list of fine-pitch escape regions on this
+            board.  ``None`` and empty list both mean "no escape regions
+            configured" -- the resolver behaves exactly like
+            :meth:`DesignRules.get_clearance_for_component`.
+        pin_pitch: Optional pin pitch for the component, in mm.  When
+            supplied, threaded into the fall-through
+            :meth:`DesignRules.get_clearance_for_component` call so the
+            global ``fine_pitch_clearance`` shrink can fire on the
+            component-pad-pitch path.  ``None`` (the default) preserves
+            the pre-#3371 call shape.
+
+    Returns:
+        Clearance in mm to apply for ``pad`` under ``net_class``.
+
+    Note:
+        This function is the *only* P_FP2-supplied seam between the
+        detector and the validator / grid halo / C++ clearance source.
+        Future phases that add more escape-region behaviour (per-
+        package radius override, escape-direction-aware clearance,
+        etc.) should land here so the threading footprint stays a
+        single function.
+    """
+    # Layer 1: per-component explicit override.  Wins unconditionally so
+    # designers can opt-out of the escape rule for a specific component
+    # by pinning ``component_clearances[ref]`` to the relaxed value.
+    if pad.ref and pad.ref in rules.component_clearances:
+        return rules.component_clearances[pad.ref]
+
+    # Layer 2: impedance-controlled-net guard (PR #3273).
+    #
+    # When the active net class declares any impedance target -- either
+    # differential (``target_diff_impedance``) or single-ended
+    # (``target_single_impedance``) -- the escape clearance rule is
+    # bypassed entirely.  Shrinking clearance on an impedance-controlled
+    # segment changes the trace's effective characteristic impedance
+    # (the C between trace and ground / between coupled traces depends
+    # on clearance), which is precisely the trap that PR #3273's
+    # validation closed.  Re-opening the trap on fine-pitch escape
+    # would be a silent regression.  Architect Q7 + P_FP1 builder
+    # decision #5: gate on both impedance fields being ``None``.
+    if net_class is not None and (
+        net_class.target_diff_impedance is not None
+        or net_class.target_single_impedance is not None
+    ):
+        # Fall through to the standard lookup -- trace_clearance (or
+        # the global ``fine_pitch_clearance`` shrink, which has its
+        # own #2867 narrow-channel guard).
+        return rules.get_clearance_for_component(pad.ref, pin_pitch, net_class=None)
+
+    # Layers 3 & 4: region applicability check.
+    if regions:
+        for region in regions:
+            if region.applies_to_pad(pad):
+                # Per-net-class override wins (layer 3).
+                if net_class is not None and net_class.escape_clearance is not None:
+                    return net_class.escape_clearance
+                # Otherwise use the region's pre-computed default (layer 4).
+                return region.escape_clearance
+
+    # Layer 5: standard fall-through.  ``net_class`` is forwarded so
+    # the global ``fine_pitch_clearance`` / per-component-pitch logic
+    # in :meth:`DesignRules.get_clearance_for_component` runs unchanged.
+    return rules.get_clearance_for_component(pad.ref, pin_pitch, net_class=net_class)

--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -165,7 +165,24 @@ def _sync_pad_to_cpp_grid(
         except (KeyError, ValueError):
             layer_idx = 0
 
-    clearance_override = py_grid.rules.get_clearance_for_component(pad.ref, pin_pitch)
+    # Issue #3371 / P_FP2: route the clearance lookup through
+    # ``resolve_clearance_with_escape_region`` so fine-pitch escape
+    # regions installed on the grid (via ``set_fine_pitch_regions``) can
+    # land at the C++ pad-segment validator's clearance source.  When the
+    # grid has no regions installed (the default) the helper delegates to
+    # the standard :meth:`DesignRules.get_clearance_for_component` -- the
+    # pre-#3371 behaviour is preserved byte-for-byte.  Imported lazily to
+    # mirror the deferred ``router_cpp`` import above and avoid module-
+    # load ordering hazards.
+    from .fine_pitch_escape import resolve_clearance_with_escape_region
+
+    clearance_override = resolve_clearance_with_escape_region(
+        py_grid.rules,
+        pad,
+        net_class=None,
+        regions=py_grid.get_fine_pitch_regions(),
+        pin_pitch=pin_pitch,
+    )
     ref_hash = router_cpp.fnv1a_hash(pad.ref) if pad.ref else 0
     is_plane_net = _is_plane_net_pad(pad)
 
@@ -785,6 +802,23 @@ class RoutingGrid:
         # reduced since the component footprint already guarantees physical
         # manufacturability at that pitch.
         self._component_pads: dict[str, list[Pad]] = {}
+
+        # Issue #3371 (P_FP2): Fine-pitch escape regions detected on this
+        # board.  Populated by the autorouter (or test fixture) once after
+        # all pads are added via :meth:`set_fine_pitch_regions`.  Consumed
+        # by the pad-clearance lookup at C++ grid build time
+        # (``cpp_backend.from_routing_grid``) and by the Python pathfinder
+        # halo lookup (``_clearance_for_pin_pitch``) once P_FP3 wires the
+        # consumer paths.  Empty list (the default) preserves pre-#3371
+        # behaviour: every lookup falls through to
+        # :meth:`DesignRules.get_clearance_for_component` unchanged.
+        #
+        # Type-loose ``Any`` to avoid a top-of-module import of
+        # ``fine_pitch_escape`` (which would create a circular dependency
+        # at module-load time -- ``escape.py`` already imports things from
+        # ``grid.py``).  Runtime callers cast to
+        # ``list[FinePitchRegion]`` via the resolver helper.
+        self._fine_pitch_regions: list[Any] = []
 
         # Issue #2604 follow-up: track per-pad pin_pitch so reverse lookups
         # (``find_pad_ref_at``) can mirror the reduced clearance envelope
@@ -2921,6 +2955,43 @@ class RoutingGrid:
     ) -> float:
         """Calculate minimum distance between two line segments."""
         return _geom_seg_to_seg_dist(x1, y1, x2, y2, x3, y3, x4, y4)
+
+    def set_fine_pitch_regions(self, regions: list[Any]) -> None:
+        """Install detected fine-pitch escape regions on this grid.
+
+        Issue #3371 / P_FP2 -- the autorouter (or test fixture) calls this
+        once after all pads have been added to the grid, passing the output
+        of :func:`kicad_tools.router.fine_pitch_escape.detect_fine_pitch_regions`.
+        The regions are stored on the grid so subsequent per-pad clearance
+        lookups (Python halo + C++ ``from_routing_grid`` bulk copy) can fold
+        the per-net-class escape clearance into the standard
+        :meth:`DesignRules.get_clearance_for_component` resolution via
+        :func:`kicad_tools.router.fine_pitch_escape.resolve_clearance_with_escape_region`.
+
+        Backward-compat: the regions list defaults to empty.  P_FP2 leaves
+        every caller in the codebase passing an empty list (i.e. no regions
+        installed) so router behaviour is byte-for-byte identical to
+        pre-#3371 until P_FP3 wires the detector into the autorouter.
+
+        Args:
+            regions: List of :class:`FinePitchRegion` objects from the
+                detector.  Loosely typed as ``list[Any]`` so this module
+                does not need to import ``fine_pitch_escape`` at top-of-
+                module (which would create a circular dependency --
+                ``escape.py`` already imports from ``grid.py`` and
+                ``fine_pitch_escape.py`` imports from ``escape.py``).
+        """
+        self._fine_pitch_regions = list(regions) if regions else []
+
+    def get_fine_pitch_regions(self) -> list[Any]:
+        """Return the installed fine-pitch escape regions.
+
+        Issue #3371 / P_FP2 -- read-side companion to
+        :meth:`set_fine_pitch_regions`.  Returns the stored list directly
+        (callers must not mutate it).  Empty list when no regions have
+        been installed yet.
+        """
+        return self._fine_pitch_regions
 
     def compute_component_pitches(self) -> dict[str, float]:
         """Compute minimum pin pitch for each component.

--- a/tests/test_fine_pitch_detector.py
+++ b/tests/test_fine_pitch_detector.py
@@ -1,0 +1,815 @@
+"""Tests for the fine-pitch escape detector (Issue #3371 / P_FP2).
+
+Phase 2 (region detector + per-net-class threading at the pathfinder /
+cpp_backend clearance boundary) of the fine-pitch escape capability
+ladder.  Validates:
+
+- :class:`kicad_tools.router.fine_pitch_escape.FinePitchRegion` --
+  frozen dataclass + ``contains_point`` / ``applies_to_pad`` helpers.
+- :func:`kicad_tools.router.fine_pitch_escape.detect_fine_pitch_regions`
+  -- per-component grouping, pitch-ceiling filter, Q_FP1 recipe-relative
+  geometry trigger, manufacturer-aware default escape clearance.
+- :func:`kicad_tools.router.fine_pitch_escape.resolve_clearance_with_escape_region`
+  -- the single-threading-point helper.  In particular the
+  *impedance-controlled-net guard* (PR #3273 carve-out) -- a fine-pitch
+  package on an impedance-controlled net must NOT trigger the escape
+  shrink.
+- :data:`kicad_tools.router.fine_pitch_escape.DEFAULT_ESCAPE_REGION_RADIUS_MM`
+  -- the 5mm halo radius (Q_FP2 architect recommendation).
+- Pad-axis extraction (Q_FP2 builder decision #2) -- horizontal SOIC row
+  vs vertical row vs non-row layout.
+
+No router behaviour is exercised here -- P_FP3 applies the regions at
+the per-net A* boundary; P_FP4 composes the ladder; P_FP5 adds the
+softstart consumer test.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.router.fine_pitch_escape import (
+    DEFAULT_ESCAPE_REGION_RADIUS_MM,
+    FinePitchRegion,
+    detect_fine_pitch_regions,
+    get_default_escape_clearance,
+    resolve_clearance_with_escape_region,
+)
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.mfr_limits import (
+    MFR_JLCPCB,
+    MFR_JLCPCB_TIER1,
+    MFR_OSHPARK,
+    MFR_PCBWAY,
+)
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules, NetClassRouting
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def _make_soic8_pads(
+    ref: str = "U5",
+    cx: float = 10.0,
+    cy: float = 10.0,
+    pitch: float = 1.27,
+    pad_w: float = 0.30,
+    pad_h: float = 1.55,
+    row_gap: float = 4.0,
+    net_id: int = 1,
+) -> list[Pad]:
+    """Synthesize an SOIC-8 footprint at JLCPCB tier-1 geometry.
+
+    Mirrors the UCC27211 SOIC-8 fixture from Issue #3371:
+    1.27mm pitch, 0.30mm pad width, 1.55mm pad height,
+    4mm row-to-row gap (centre-to-centre).
+
+    Returns a list of 8 router-level :class:`Pad` objects with pad
+    centres laid out as a horizontal dual-row package.
+    """
+    pads: list[Pad] = []
+    # Bottom row (pins 1-4), top row (pins 8-5, KiCad numbering)
+    half_pitch_span = ((pitch * (4 - 1)) / 2.0)
+    for i in range(4):
+        x = cx - half_pitch_span + i * pitch
+        # Bottom row pads
+        pads.append(
+            Pad(
+                x=x,
+                y=cy - row_gap / 2.0,
+                width=pad_w,
+                height=pad_h,
+                net=net_id,
+                net_name=f"N{net_id}",
+                layer=Layer.F_CU,
+                ref=ref,
+                pin=str(i + 1),
+            )
+        )
+        # Top row pads (pin numbering counts down)
+        pads.append(
+            Pad(
+                x=x,
+                y=cy + row_gap / 2.0,
+                width=pad_w,
+                height=pad_h,
+                net=net_id,
+                net_name=f"N{net_id}",
+                layer=Layer.F_CU,
+                ref=ref,
+                pin=str(8 - i),
+            )
+        )
+    return pads
+
+
+def _make_2p54_dip_pads(
+    ref: str = "J1", cx: float = 50.0, cy: float = 50.0, pitch: float = 2.54
+) -> list[Pad]:
+    """Synthesize a 2.54mm-pitch DIP-style header (2x4 = 8 pads).
+
+    DIP pitch is too coarse to ever need the fine-pitch escape, so the
+    detector should NEVER return a region for this fixture regardless
+    of recipe.
+    """
+    pads: list[Pad] = []
+    for i in range(4):
+        for row in (0, 1):
+            pads.append(
+                Pad(
+                    x=cx + i * pitch,
+                    y=cy + row * 7.62,
+                    width=1.6,
+                    height=1.6,
+                    net=row * 4 + i + 1,
+                    net_name=f"DIP{row * 4 + i + 1}",
+                    layer=Layer.F_CU,
+                    ref=ref,
+                    pin=str(row * 4 + i + 1),
+                )
+            )
+    return pads
+
+
+# ============================================================================
+# FinePitchRegion dataclass
+# ============================================================================
+
+
+class TestFinePitchRegion:
+    """Tests for the :class:`FinePitchRegion` dataclass + helpers."""
+
+    def test_contains_point_inside_halo(self):
+        """A point near the centre is inside the 5mm halo."""
+        region = FinePitchRegion(
+            package_ref="U5",
+            package_origin=(10.0, 10.0),
+            radius_mm=5.0,
+            pin_pitch=1.27,
+            pad_size_along_pitch=0.30,
+            escape_clearance=0.14,
+        )
+        assert region.contains_point(10.0, 10.0)
+        assert region.contains_point(12.0, 13.0)  # dist=3.6 < 5
+        assert region.contains_point(13.5, 13.5)  # dist~4.95 < 5
+
+    def test_contains_point_outside_halo(self):
+        """A point past the radius is outside the halo."""
+        region = FinePitchRegion(
+            package_ref="U5",
+            package_origin=(10.0, 10.0),
+            radius_mm=5.0,
+            pin_pitch=1.27,
+            pad_size_along_pitch=0.30,
+            escape_clearance=0.14,
+        )
+        assert not region.contains_point(15.001, 10.0)  # dist=5.001 > 5
+        assert not region.contains_point(20.0, 20.0)
+
+    def test_contains_point_on_boundary_is_outside(self):
+        """A point exactly on the radius boundary is considered outside.
+
+        The helper uses strict less-than (``<``) so the boundary cell
+        falls back to standard clearance rather than the escape value.
+        This matters at integer grid resolutions where the boundary
+        is at a known grid line.
+        """
+        region = FinePitchRegion(
+            package_ref="U5",
+            package_origin=(0.0, 0.0),
+            radius_mm=5.0,
+            pin_pitch=1.27,
+            pad_size_along_pitch=0.30,
+            escape_clearance=0.14,
+        )
+        # Point at distance exactly 5.0
+        assert not region.contains_point(5.0, 0.0)
+        assert not region.contains_point(3.0, 4.0)  # 3-4-5 triangle
+
+    def test_applies_to_pad_identity_match(self):
+        """A pad with (ref, pin) in pad_refs is always considered to apply.
+
+        Identity match wins even when the pad position happens to be
+        outside the circular halo (defensive: a 14-pin SOIC's outermost
+        pad can sit just past 5mm from the centroid).
+        """
+        # Pad sits at (100, 100) -- well outside the 5mm halo at (0, 0).
+        pad = Pad(
+            x=100.0,
+            y=100.0,
+            width=0.30,
+            height=1.55,
+            net=1,
+            net_name="N1",
+            ref="U5",
+            pin="1",
+        )
+        region = FinePitchRegion(
+            package_ref="U5",
+            package_origin=(0.0, 0.0),
+            radius_mm=5.0,
+            pin_pitch=1.27,
+            pad_size_along_pitch=0.30,
+            escape_clearance=0.14,
+            pad_refs=frozenset({("U5", "1"), ("U5", "2")}),
+        )
+        assert region.applies_to_pad(pad)
+
+    def test_applies_to_pad_geometric_containment(self):
+        """A foreign pad inside the halo also applies to the region."""
+        # Foreign pad (different ref) sitting near U5's centroid.
+        pad = Pad(
+            x=11.0,
+            y=11.0,
+            width=0.30,
+            height=0.30,
+            net=2,
+            net_name="N2",
+            ref="C1",  # Different component
+            pin="1",
+        )
+        region = FinePitchRegion(
+            package_ref="U5",
+            package_origin=(10.0, 10.0),
+            radius_mm=5.0,
+            pin_pitch=1.27,
+            pad_size_along_pitch=0.30,
+            escape_clearance=0.14,
+            pad_refs=frozenset({("U5", "1")}),
+        )
+        assert region.applies_to_pad(pad)
+
+    def test_applies_to_pad_outside(self):
+        """A foreign pad outside the halo does NOT apply."""
+        pad = Pad(
+            x=50.0,
+            y=50.0,
+            width=0.30,
+            height=0.30,
+            net=2,
+            net_name="N2",
+            ref="C1",
+            pin="1",
+        )
+        region = FinePitchRegion(
+            package_ref="U5",
+            package_origin=(10.0, 10.0),
+            radius_mm=5.0,
+            pin_pitch=1.27,
+            pad_size_along_pitch=0.30,
+            escape_clearance=0.14,
+        )
+        assert not region.applies_to_pad(pad)
+
+    def test_region_is_frozen(self):
+        """The dataclass is frozen -- fields cannot be reassigned."""
+        region = FinePitchRegion(
+            package_ref="U5",
+            package_origin=(10.0, 10.0),
+            radius_mm=5.0,
+            pin_pitch=1.27,
+            pad_size_along_pitch=0.30,
+            escape_clearance=0.14,
+        )
+        with pytest.raises((AttributeError, Exception)):
+            region.radius_mm = 10.0  # type: ignore[misc]
+
+
+# ============================================================================
+# detect_fine_pitch_regions -- the detector
+# ============================================================================
+
+
+class TestDetectFinePitchRegions:
+    """Tests for the per-board fine-pitch escape region detector."""
+
+    def test_ucc27211_soic8_at_strict_recipe_fires(self):
+        """UCC27211 SOIC-8 at 0.30mm trace + 0.20mm clearance qualifies."""
+        rules = DesignRules(trace_width=0.30, trace_clearance=0.20)
+        pads = _make_soic8_pads()
+        regions = detect_fine_pitch_regions(pads, rules, mfr_limits=MFR_JLCPCB)
+        assert len(regions) == 1
+        assert regions[0].package_ref == "U5"
+        # SOIC-8 layout: pitch is 1.27mm along X axis.
+        assert regions[0].pin_pitch == pytest.approx(1.27, abs=0.01)
+        # Pad size along pitch = pad width (X dimension).
+        assert regions[0].pad_size_along_pitch == pytest.approx(0.30, abs=0.01)
+        # Default halo radius is 5mm.
+        assert regions[0].radius_mm == DEFAULT_ESCAPE_REGION_RADIUS_MM
+        # Escape clearance is the manufacturer-aware default
+        # (0.127 + 0.013 = 0.140mm for jlcpcb).
+        assert regions[0].escape_clearance == pytest.approx(0.140, abs=1e-6)
+
+    def test_ucc27211_at_relaxed_recipe_does_not_fire(self):
+        """SOIC-8 at 0.15mm clearance -- corridor fits, no region."""
+        # 0.30mm trace + 0.15mm clearance = 0.90mm corridor.
+        # SOIC gap = 1.27 - 0.30 = 0.97mm.  Corridor fits -- no region.
+        rules = DesignRules(trace_width=0.30, trace_clearance=0.15)
+        pads = _make_soic8_pads()
+        regions = detect_fine_pitch_regions(pads, rules, mfr_limits=MFR_JLCPCB)
+        assert regions == []
+
+    def test_2p54mm_dip_does_not_fire(self):
+        """2.54mm DIP header is too coarse -- never fires."""
+        rules = DesignRules(trace_width=0.30, trace_clearance=0.20)
+        pads = _make_2p54_dip_pads()
+        regions = detect_fine_pitch_regions(pads, rules, mfr_limits=MFR_JLCPCB)
+        assert regions == []
+
+    def test_2p54mm_dip_does_not_fire_at_extreme_recipe(self):
+        """Even at an absurd recipe (1mm trace + 1mm clearance) DIP doesn't fire.
+
+        2.54mm pitch with 1.6mm pad gives gap = 0.94mm.  But pitch is
+        2.54 > FINE_PITCH_THRESHOLD_MM (1.5mm), so the pitch ceiling
+        excludes it BEFORE the recipe geometry check.
+        """
+        rules = DesignRules(trace_width=1.0, trace_clearance=1.0)
+        pads = _make_2p54_dip_pads()
+        regions = detect_fine_pitch_regions(pads, rules, mfr_limits=MFR_JLCPCB)
+        assert regions == []
+
+    def test_empty_pad_list_returns_empty(self):
+        """No pads -> no regions."""
+        rules = DesignRules(trace_width=0.30, trace_clearance=0.20)
+        regions = detect_fine_pitch_regions([], rules, mfr_limits=MFR_JLCPCB)
+        assert regions == []
+
+    def test_pads_without_ref_are_skipped(self):
+        """Pads with empty ``ref`` (board fiducials, edge cuts) are skipped."""
+        rules = DesignRules(trace_width=0.30, trace_clearance=0.20)
+        pads = [
+            Pad(x=0.0, y=0.0, width=0.30, height=1.55, net=0, net_name="", ref="", pin=""),
+            Pad(x=1.27, y=0.0, width=0.30, height=1.55, net=0, net_name="", ref="", pin=""),
+        ]
+        regions = detect_fine_pitch_regions(pads, rules, mfr_limits=MFR_JLCPCB)
+        assert regions == []
+
+    def test_single_pad_clusters_are_skipped(self):
+        """Single-pad clusters cannot be fine-pitch packages."""
+        rules = DesignRules(trace_width=0.30, trace_clearance=0.20)
+        pads = [
+            Pad(x=0.0, y=0.0, width=0.30, height=1.55, net=1, net_name="N1", ref="U1", pin="1"),
+        ]
+        regions = detect_fine_pitch_regions(pads, rules, mfr_limits=MFR_JLCPCB)
+        assert regions == []
+
+    def test_multiple_packages_yield_multiple_regions(self):
+        """Two fine-pitch packages on the same board -> two regions."""
+        rules = DesignRules(trace_width=0.30, trace_clearance=0.20)
+        pads = _make_soic8_pads(ref="U5", cx=10.0, cy=10.0)
+        pads += _make_soic8_pads(ref="U6", cx=30.0, cy=30.0)
+        regions = detect_fine_pitch_regions(pads, rules, mfr_limits=MFR_JLCPCB)
+        assert len(regions) == 2
+        refs = {r.package_ref for r in regions}
+        assert refs == {"U5", "U6"}
+
+    def test_origin_is_pad_cluster_centroid(self):
+        """The region origin is the cluster's bounding-box centre."""
+        rules = DesignRules(trace_width=0.30, trace_clearance=0.20)
+        # U5 centred at (20, 30); the SOIC-8 fixture centres pads at cx, cy.
+        pads = _make_soic8_pads(ref="U5", cx=20.0, cy=30.0)
+        regions = detect_fine_pitch_regions(pads, rules, mfr_limits=MFR_JLCPCB)
+        assert len(regions) == 1
+        # Allow small tolerance for the row-gap centring.
+        assert regions[0].package_origin[0] == pytest.approx(20.0, abs=0.5)
+        assert regions[0].package_origin[1] == pytest.approx(30.0, abs=0.5)
+
+    def test_radius_is_configurable(self):
+        """Custom radius is honoured."""
+        rules = DesignRules(trace_width=0.30, trace_clearance=0.20)
+        pads = _make_soic8_pads()
+        regions = detect_fine_pitch_regions(
+            pads, rules, mfr_limits=MFR_JLCPCB, radius_mm=3.0
+        )
+        assert len(regions) == 1
+        assert regions[0].radius_mm == 3.0
+
+    def test_pad_refs_are_populated(self):
+        """The region's pad_refs set covers all of the package's pads."""
+        rules = DesignRules(trace_width=0.30, trace_clearance=0.20)
+        pads = _make_soic8_pads(ref="U5")
+        regions = detect_fine_pitch_regions(pads, rules, mfr_limits=MFR_JLCPCB)
+        assert len(regions) == 1
+        # SOIC-8 has 8 pads with pins "1".."8".
+        expected_refs = frozenset({("U5", str(i)) for i in range(1, 9)})
+        assert regions[0].pad_refs == expected_refs
+
+    def test_default_escape_clearance_uses_mfr_floor(self):
+        """The region's escape clearance is mfr.min_clearance + 0.013."""
+        rules = DesignRules(trace_width=0.30, trace_clearance=0.20)
+        pads = _make_soic8_pads()
+
+        for mfr in (MFR_JLCPCB, MFR_JLCPCB_TIER1, MFR_PCBWAY, MFR_OSHPARK):
+            regions = detect_fine_pitch_regions(pads, rules, mfr_limits=mfr)
+            assert len(regions) == 1
+            expected = get_default_escape_clearance(mfr)
+            assert regions[0].escape_clearance == pytest.approx(expected, abs=1e-9)
+
+    def test_manufacturer_resolved_from_rules(self):
+        """When no explicit mfr_limits, rules.manufacturer is used as a fallback."""
+        rules = DesignRules(
+            trace_width=0.30, trace_clearance=0.20, manufacturer="jlcpcb"
+        )
+        pads = _make_soic8_pads()
+        regions = detect_fine_pitch_regions(pads, rules)
+        assert len(regions) == 1
+        assert regions[0].escape_clearance == pytest.approx(0.140, abs=1e-6)
+
+    def test_unknown_manufacturer_falls_back_to_trace_clearance(self):
+        """When rules has an unknown manufacturer, escape_clearance defaults to trace_clearance.
+
+        This is a *no-shrink* fallback so a board without a recognised
+        manufacturer profile does not accidentally generate a region
+        with an unsafe clearance value.
+        """
+        rules = DesignRules(
+            trace_width=0.30, trace_clearance=0.20, manufacturer="this-mfr-does-not-exist"
+        )
+        pads = _make_soic8_pads()
+        regions = detect_fine_pitch_regions(pads, rules)
+        assert len(regions) == 1
+        assert regions[0].escape_clearance == pytest.approx(0.20, abs=1e-6)
+
+    def test_no_manufacturer_falls_back_to_trace_clearance(self):
+        """When neither argument nor rules supplies a manufacturer, escape_clearance falls back."""
+        rules = DesignRules(trace_width=0.30, trace_clearance=0.20)
+        pads = _make_soic8_pads()
+        regions = detect_fine_pitch_regions(pads, rules)
+        assert len(regions) == 1
+        assert regions[0].escape_clearance == pytest.approx(0.20, abs=1e-6)
+
+    def test_explicit_mfr_limits_overrides_rules_manufacturer(self):
+        """An explicit ``mfr_limits`` argument wins over ``rules.manufacturer``."""
+        rules = DesignRules(
+            trace_width=0.30, trace_clearance=0.20, manufacturer="jlcpcb"
+        )
+        pads = _make_soic8_pads()
+        # Force the OSHPark default (0.152 + 0.013 = 0.165) instead of jlcpcb (0.140).
+        regions = detect_fine_pitch_regions(pads, rules, mfr_limits=MFR_OSHPARK)
+        assert len(regions) == 1
+        assert regions[0].escape_clearance == pytest.approx(0.165, abs=1e-6)
+
+
+# ============================================================================
+# Pad-axis extraction (Q_FP2 builder decision #2)
+# ============================================================================
+
+
+class TestPadAxisExtraction:
+    """Tests for the pad-size-along-pitch inference.
+
+    Q_FP2 builder decision #2: the detector infers the pitch axis from
+    cluster geometry rather than requiring callers to annotate each pad.
+    Horizontal SOIC row -> pad width.  Vertical row -> pad height.  Non-
+    row layout -> conservative ``min(width, height)`` fallback.
+    """
+
+    def test_horizontal_soic_uses_pad_width(self):
+        """A dual-row package laid out horizontally uses pad WIDTH as size."""
+        rules = DesignRules(trace_width=0.30, trace_clearance=0.20)
+        # SOIC with 0.30mm width, 1.55mm height -- the pitch is along X.
+        pads = _make_soic8_pads(pad_w=0.30, pad_h=1.55)
+        regions = detect_fine_pitch_regions(pads, rules, mfr_limits=MFR_JLCPCB)
+        assert len(regions) == 1
+        assert regions[0].pad_size_along_pitch == pytest.approx(0.30, abs=0.01)
+
+    def test_vertical_soic_uses_pad_height(self):
+        """A vertical dual-row package uses pad HEIGHT as the pitch-axis dimension.
+
+        Rotate the SOIC 90 degrees: pads cluster around two distinct X
+        values with the pitch running along Y.  In that orientation
+        the leaded-pad's *short* axis is the pad HEIGHT (the rotated
+        equivalent of the horizontal-row width).
+        """
+        rules = DesignRules(trace_width=0.30, trace_clearance=0.20)
+        # Rotated SOIC: swap pad x/y AND swap width/height.
+        pads: list[Pad] = []
+        for i in range(4):
+            for col_offset, pin_offset in ((0, 0), (4, 0)):
+                y = 0.0 + i * 1.27
+                x = (0.0 if col_offset == 0 else 4.0)
+                pads.append(
+                    Pad(
+                        x=x,
+                        y=y,
+                        width=1.55,  # rotated: width along X (row-perpendicular)
+                        height=0.30,  # rotated: height along Y (pitch axis)
+                        net=i + 1 + col_offset,
+                        net_name=f"N{i + 1 + col_offset}",
+                        ref="U7",
+                        pin=str(i + 1 + col_offset),
+                    )
+                )
+        regions = detect_fine_pitch_regions(pads, rules, mfr_limits=MFR_JLCPCB)
+        assert len(regions) == 1
+        # Vertical row -> pitch axis is Y -> pad size is HEIGHT (0.30mm).
+        assert regions[0].pad_size_along_pitch == pytest.approx(0.30, abs=0.01)
+
+    def test_non_row_layout_uses_min_dimension_fallback(self):
+        """A QFN-style non-row layout falls back to ``min(width, height)``.
+
+        QFN packages are not the primary P_FP2 target (BGA escape is a
+        separate ladder per the issue's "Out of scope" list), but the
+        detector should not silently skip them.  The conservative
+        fallback makes the Q_FP1 predicate fire more readily, biasing
+        toward applying the escape rule on QFN-style packages.
+        """
+        rules = DesignRules(trace_width=0.30, trace_clearance=0.20)
+        # Synthesize a 0.5mm-pitch quad QFN-16 with square pads.
+        pads: list[Pad] = []
+        for i in range(4):
+            # Bottom row (y=0)
+            pads.append(
+                Pad(
+                    x=i * 0.5,
+                    y=0.0,
+                    width=0.25,
+                    height=0.25,
+                    net=i + 1,
+                    net_name=f"N{i+1}",
+                    ref="U9",
+                    pin=str(i + 1),
+                )
+            )
+            # Top row (y=2)
+            pads.append(
+                Pad(
+                    x=i * 0.5,
+                    y=2.0,
+                    width=0.25,
+                    height=0.25,
+                    net=i + 5,
+                    net_name=f"N{i+5}",
+                    ref="U9",
+                    pin=str(i + 5),
+                )
+            )
+            # Left col (x=0)
+            pads.append(
+                Pad(
+                    x=0.0,
+                    y=0.5 + i * 0.4,
+                    width=0.25,
+                    height=0.25,
+                    net=i + 9,
+                    net_name=f"N{i+9}",
+                    ref="U9",
+                    pin=str(i + 9),
+                )
+            )
+            # Right col (x=2)
+            pads.append(
+                Pad(
+                    x=2.0,
+                    y=0.5 + i * 0.4,
+                    width=0.25,
+                    height=0.25,
+                    net=i + 13,
+                    net_name=f"N{i+13}",
+                    ref="U9",
+                    pin=str(i + 13),
+                )
+            )
+        regions = detect_fine_pitch_regions(pads, rules, mfr_limits=MFR_JLCPCB)
+        # Should fire (0.5mm pitch < 1.5mm threshold AND corridor infeasible).
+        assert len(regions) == 1
+        # Non-row layout falls back to min dimension (0.25mm).
+        assert regions[0].pad_size_along_pitch == pytest.approx(0.25, abs=0.01)
+
+
+# ============================================================================
+# resolve_clearance_with_escape_region -- the impedance guard
+# ============================================================================
+
+
+class TestImpedanceGuard:
+    """Tests for the PR #3273 impedance-trap carve-out.
+
+    P_FP1 builder decision #5: when the active net class declares any
+    impedance target, the escape rule is bypassed entirely so the
+    impedance budget is preserved.  This is the load-bearing guard --
+    re-opening it would be a silent regression on every
+    impedance-controlled board.
+    """
+
+    def test_no_regions_no_net_class_falls_through_to_default(self):
+        """Empty regions + no net class -> rules.trace_clearance."""
+        rules = DesignRules(trace_width=0.30, trace_clearance=0.20)
+        pad = Pad(
+            x=10.0, y=10.0, width=0.30, height=1.55, net=1, net_name="N1", ref="U5", pin="1"
+        )
+        clearance = resolve_clearance_with_escape_region(
+            rules, pad, net_class=None, regions=None
+        )
+        assert clearance == pytest.approx(0.20, abs=1e-6)
+
+    def test_regions_none_falls_through(self):
+        """``regions=None`` behaves identically to empty list -- backward compat."""
+        rules = DesignRules(trace_width=0.30, trace_clearance=0.20)
+        nc = NetClassRouting(name="SIGNAL", clearance=0.20, escape_clearance=0.14)
+        pad = Pad(
+            x=10.0, y=10.0, width=0.30, height=1.55, net=1, net_name="N1", ref="U5", pin="1"
+        )
+        # Without regions, the per-class escape_clearance still wins (via
+        # the standard get_clearance_for_component net_class path).
+        clearance = resolve_clearance_with_escape_region(
+            rules, pad, net_class=nc, regions=None
+        )
+        # Falls through to get_clearance_for_component which respects
+        # nc.escape_clearance as the per-net-class override (P_FP1).
+        assert clearance == pytest.approx(0.14, abs=1e-6)
+
+    def test_in_region_uses_net_class_escape_clearance(self):
+        """A pad inside a region on a non-impedance net uses nc.escape_clearance."""
+        rules = DesignRules(trace_width=0.30, trace_clearance=0.20)
+        nc = NetClassRouting(name="SIGNAL", clearance=0.20, escape_clearance=0.14)
+        pads = _make_soic8_pads()
+        regions = detect_fine_pitch_regions(pads, rules, mfr_limits=MFR_JLCPCB)
+        assert len(regions) == 1
+        # Pick one of U5's pads -- inside the region by identity.
+        u5_pad = pads[0]
+        clearance = resolve_clearance_with_escape_region(
+            rules, u5_pad, net_class=nc, regions=regions
+        )
+        assert clearance == pytest.approx(0.14, abs=1e-6)
+
+    def test_in_region_without_net_class_override_uses_region_default(self):
+        """In-region pad with no per-class override uses region.escape_clearance."""
+        rules = DesignRules(trace_width=0.30, trace_clearance=0.20)
+        # No escape_clearance on the class -- should fall back to region default.
+        nc = NetClassRouting(name="SIGNAL", clearance=0.20)
+        pads = _make_soic8_pads()
+        regions = detect_fine_pitch_regions(pads, rules, mfr_limits=MFR_JLCPCB)
+        u5_pad = pads[0]
+        clearance = resolve_clearance_with_escape_region(
+            rules, u5_pad, net_class=nc, regions=regions
+        )
+        # Region default at JLCPCB = 0.127 + 0.013 = 0.140.
+        assert clearance == pytest.approx(0.140, abs=1e-6)
+
+    def test_impedance_controlled_diff_net_bypasses_escape(self):
+        """A diff-impedance net does NOT shrink even inside the region.
+
+        Load-bearing guard: PR #3273 impedance trap.  A USB 3.0 pair at
+        90 ohms target_diff_impedance must keep the standard clearance
+        even when escaping a fine-pitch package, because the impedance
+        budget assumes the full clearance.
+        """
+        rules = DesignRules(trace_width=0.30, trace_clearance=0.20)
+        nc = NetClassRouting(
+            name="USB3",
+            clearance=0.20,
+            escape_clearance=0.14,  # would normally apply
+            target_diff_impedance=90.0,  # but this guards
+        )
+        pads = _make_soic8_pads()
+        regions = detect_fine_pitch_regions(pads, rules, mfr_limits=MFR_JLCPCB)
+        u5_pad = pads[0]
+        clearance = resolve_clearance_with_escape_region(
+            rules, u5_pad, net_class=nc, regions=regions
+        )
+        # MUST be standard trace_clearance, not the escape value.
+        assert clearance == pytest.approx(0.20, abs=1e-6)
+
+    def test_impedance_controlled_single_ended_net_bypasses_escape(self):
+        """A 50-ohm single-ended net also bypasses the escape rule."""
+        rules = DesignRules(trace_width=0.30, trace_clearance=0.20)
+        nc = NetClassRouting(
+            name="CLOCK",
+            clearance=0.20,
+            escape_clearance=0.14,
+            target_single_impedance=50.0,  # guards
+        )
+        pads = _make_soic8_pads()
+        regions = detect_fine_pitch_regions(pads, rules, mfr_limits=MFR_JLCPCB)
+        u5_pad = pads[0]
+        clearance = resolve_clearance_with_escape_region(
+            rules, u5_pad, net_class=nc, regions=regions
+        )
+        assert clearance == pytest.approx(0.20, abs=1e-6)
+
+    def test_explicit_component_override_wins_unconditionally(self):
+        """Explicit component_clearances override wins -- Issue #1016 contract."""
+        rules = DesignRules(
+            trace_width=0.30,
+            trace_clearance=0.20,
+            component_clearances={"U5": 0.10},
+        )
+        nc = NetClassRouting(name="SIGNAL", clearance=0.20, escape_clearance=0.14)
+        pads = _make_soic8_pads()
+        regions = detect_fine_pitch_regions(pads, rules, mfr_limits=MFR_JLCPCB)
+        u5_pad = pads[0]
+        clearance = resolve_clearance_with_escape_region(
+            rules, u5_pad, net_class=nc, regions=regions
+        )
+        # Component override wins over both escape clearance and trace clearance.
+        assert clearance == pytest.approx(0.10, abs=1e-6)
+
+    def test_explicit_component_override_wins_over_impedance_guard(self):
+        """Component override is the highest-precedence layer.
+
+        The component override happens BEFORE the impedance guard.  If a
+        designer pins a per-component clearance, they're asserting they
+        know the geometry and impedance trade-off for that part.  This
+        is consistent with the Issue #1016 + #2867 precedence.
+        """
+        rules = DesignRules(
+            trace_width=0.30,
+            trace_clearance=0.20,
+            component_clearances={"U5": 0.10},
+        )
+        nc = NetClassRouting(
+            name="USB3",
+            clearance=0.20,
+            escape_clearance=0.14,
+            target_diff_impedance=90.0,
+        )
+        pads = _make_soic8_pads()
+        regions = detect_fine_pitch_regions(pads, rules, mfr_limits=MFR_JLCPCB)
+        u5_pad = pads[0]
+        clearance = resolve_clearance_with_escape_region(
+            rules, u5_pad, net_class=nc, regions=regions
+        )
+        assert clearance == pytest.approx(0.10, abs=1e-6)
+
+    def test_pad_outside_region_uses_default(self):
+        """A pad outside any region falls through to standard clearance."""
+        rules = DesignRules(trace_width=0.30, trace_clearance=0.20)
+        nc = NetClassRouting(name="SIGNAL", clearance=0.20, escape_clearance=0.14)
+        pads = _make_soic8_pads(cx=10.0, cy=10.0)
+        regions = detect_fine_pitch_regions(pads, rules, mfr_limits=MFR_JLCPCB)
+        # Pad sitting far from the U5 region.
+        far_pad = Pad(
+            x=100.0, y=100.0, width=0.30, height=0.30,
+            net=2, net_name="N2", ref="R1", pin="1",
+        )
+        clearance = resolve_clearance_with_escape_region(
+            rules, far_pad, net_class=nc, regions=regions
+        )
+        # No region applies -- falls through to the per-class escape_clearance
+        # via get_clearance_for_component (P_FP1 path).
+        assert clearance == pytest.approx(0.14, abs=1e-6)
+
+
+# ============================================================================
+# Threading at the cpp_backend boundary
+# ============================================================================
+
+
+class TestNetClassThreading:
+    """Tests that the RoutingGrid carries fine-pitch regions through to the
+    cpp_backend pad-clearance lookup at line 619.
+
+    These tests do NOT exercise the C++ backend (which would require the
+    extension build).  They verify the *threading* by directly invoking
+    :func:`resolve_clearance_with_escape_region` with the same arguments
+    the cpp_backend uses, and by checking the
+    :meth:`RoutingGrid.set_fine_pitch_regions` /
+    :meth:`RoutingGrid.get_fine_pitch_regions` accessors.
+    """
+
+    def test_routing_grid_default_regions_empty(self):
+        """A freshly constructed grid has no regions installed."""
+        from kicad_tools.router.grid import RoutingGrid
+
+        grid = RoutingGrid(width=50.0, height=50.0, rules=DesignRules())
+        assert grid.get_fine_pitch_regions() == []
+
+    def test_routing_grid_set_get_round_trip(self):
+        """``set_fine_pitch_regions`` and ``get_fine_pitch_regions`` round-trip."""
+        from kicad_tools.router.grid import RoutingGrid
+
+        grid = RoutingGrid(width=50.0, height=50.0, rules=DesignRules())
+        region = FinePitchRegion(
+            package_ref="U5",
+            package_origin=(10.0, 10.0),
+            radius_mm=5.0,
+            pin_pitch=1.27,
+            pad_size_along_pitch=0.30,
+            escape_clearance=0.14,
+        )
+        grid.set_fine_pitch_regions([region])
+        regions = grid.get_fine_pitch_regions()
+        assert len(regions) == 1
+        assert regions[0].package_ref == "U5"
+
+    def test_routing_grid_empty_regions_preserves_clearance_for_component(self):
+        """With no regions installed, the cpp_backend clearance lookup is unchanged.
+
+        This is the P_FP2 "no behaviour change" promise: the threading
+        seam at cpp_backend.py:619 must produce byte-for-byte identical
+        clearances when no regions are installed.
+        """
+        rules = DesignRules(trace_width=0.30, trace_clearance=0.20)
+        pad = Pad(
+            x=10.0, y=10.0, width=0.30, height=1.55, net=1, net_name="N1", ref="U5", pin="1"
+        )
+        # Pre-#3371 call shape:
+        old = rules.get_clearance_for_component("U5", pin_pitch=1.27)
+        # Post-#3371 call shape with empty regions:
+        new = resolve_clearance_with_escape_region(
+            rules, pad, net_class=None, regions=[], pin_pitch=1.27
+        )
+        assert old == new


### PR DESCRIPTION
## Summary

Phase 2 (**P_FP2**) of the fine-pitch escape capability ladder for Issue #3371.

Builds the per-component **region detector** and the **single-threading-point clearance helper** at the pathfinder / cpp_backend boundary. Builds on the P_FP1 foundation (#3373, merged as f487a0de). **No router behaviour changes yet** -- P_FP3 wires the detector output through the autorouter so the per-net-class escape clearance lands at A* edge expansion.

Mirrors the P_AS1-P_AS5 phased decomposition pattern from the auto-pcb-size ladder (#3352).

## What changed

### New module surface in `router/fine_pitch_escape.py`

- **`FinePitchRegion`** -- frozen dataclass with `package_ref`, `package_origin`, `radius_mm`, `pin_pitch`, `pad_size_along_pitch`, `escape_clearance`, `pad_refs`.
  - `contains_point(x, y)` -- strict-less-than circular halo (P_FP1 builder decision #1).
  - `applies_to_pad(pad)` -- identity match by `(ref, pin)` OR geometric containment.
- **`DEFAULT_ESCAPE_REGION_RADIUS_MM = 5.0`** -- Q_FP2 architect recommendation.
- **`detect_fine_pitch_regions(pads, rules, mfr_limits=None, radius_mm=5.0)`** -- groups pads by `pad.ref`, applies the pitch ceiling AND the Q_FP1 recipe-relative trigger, returns one region per qualifying component. Per-axis pad-size inference (Q_FP2 builder decision #2): horizontal dual-row -> pad width, vertical dual-row -> pad height, non-row layout -> conservative `min(width, height)`.
- **`resolve_clearance_with_escape_region(rules, pad, net_class, regions, pin_pitch=None)`** -- the single-threading-point helper. Precedence (high to low):
  1. `rules.component_clearances[ref]` (Issue #1016 contract)
  2. **Impedance-controlled-net guard (PR #3273)** -- when `net_class` has `target_diff_impedance is not None` OR `target_single_impedance is not None`, the escape rule is BYPASSED. Load-bearing carve-out so impedance budgets stay intact.
  3. Per-net-class `escape_clearance` inside an applying region
  4. Region's `escape_clearance` default inside an applying region
  5. Standard fall-through to `DesignRules.get_clearance_for_component`

### Threading at the pathfinder / cpp_backend boundary

- **`RoutingGrid._fine_pitch_regions`** + `set_fine_pitch_regions` / `get_fine_pitch_regions` accessors. Defaults to `[]` so pre-#3371 behaviour is byte-for-byte unchanged.
- **`cpp_backend.from_routing_grid` line 619** routes the per-pad `clearance_override` lookup through `resolve_clearance_with_escape_region`. With empty regions (the default) the resolver delegates straight through.
- **`grid._sync_pad_to_cpp_grid`** (the incremental sync path used by `Autorouter.add_component`) gets the same threading so bulk-copy + incremental-sync paths produce identical pad geometry.
- **`router/__init__.py`** re-exports the new surface.

## Tests

New `tests/test_fine_pitch_detector.py` (38 tests):

- `FinePitchRegion` contracts: contains_point inside/outside/boundary, applies_to_pad identity/geometric/outside, frozen-dataclass.
- Detector behaviour: UCC27211 SOIC-8 fires at strict (0.30 + 0.20), does NOT fire at relaxed (0.30 + 0.15), 2.54mm DIP never fires, empty/single-pad/no-ref clusters skipped, multi-package boards yield multiple regions, custom radius honoured, pad_refs populated.
- Manufacturer-aware defaults: jlcpcb / jlcpcb-tier1 / pcbway / oshpark, explicit `mfr_limits` overrides `rules.manufacturer`, unknown / no manufacturer -> no-shrink fallback.
- Pad-axis extraction (Q_FP2 builder decision #2): horizontal SOIC -> pad width, vertical SOIC -> pad height, QFN non-row -> min(w, h).
- **Impedance-guard tests (PR #3273 carve-out)**: in-region pad on `target_diff_impedance=90.0` keeps `trace_clearance`, in-region pad on `target_single_impedance=50.0` keeps `trace_clearance`, `component_clearances` override wins over impedance guard.
- Threading at the cpp_backend boundary: `RoutingGrid` regions accessor round-trip, empty regions produce byte-for-byte identical clearance to pre-#3371 `get_clearance_for_component`.

## Acceptance criteria (P_FP2)

- [x] `detect_fine_pitch_regions` returns correct regions on UCC27211 SOIC-8 fixture
- [x] Empty result on 2.54mm-pitch boards (no false positives)
- [x] `FinePitchRegion.contains_point` works for circular halo
- [x] Impedance-controlled net guard prevents `escape_clearance` application
- [x] Net-class threading reaches `cpp_backend.py:619` clearance_override path (via `resolve_clearance_with_escape_region`)
- [x] No router behaviour changes yet (P_FP3 wires this in)
- [x] All P_FP1 tests still pass (29/29)
- [x] Uses `Refs #3371 (P_FP2)` trailer

## Test plan

- [x] `uv run pytest tests/test_fine_pitch_detector.py` -- **38/38 pass**
- [x] `uv run pytest tests/test_fine_pitch_escape.py tests/test_fine_pitch_detector.py tests/test_fine_pitch_ssop.py tests/test_net_class_serialization.py` -- **111/111 pass**
- [x] `uv run pytest tests/test_component_clearance.py tests/test_cpp_clearance_enforcement.py tests/test_grid_narrow_channel_guard.py tests/test_grid_cpp_parity.py tests/test_grid_plane_net_halo.py tests/test_drc_cpp_backend.py tests/test_cpp_pathfinder_own_net_obstacle.py tests/test_adaptive_grid.py tests/test_neck_down.py` -- **152/152 pass**
- [x] Smoke test: detector returns 1 region on UCC27211 fixture, impedance-controlled net keeps 0.20mm clearance, signal net inside region gets 0.14mm clearance, no regions installed -> identical behaviour to pre-#3371
- [ ] Pre-existing failure in `tests/test_router_core.py::TestAdaptiveAutorouterComponentTransform::test_add_component_rotation` reproduces on main HEAD with my changes stashed -- not introduced by this PR

## Decisions to flag for P_FP3

1. **Per-net A* threading at search time.** P_FP2's `cpp_backend.py:619` threading passes `net_class=None` because the bulk-copy of pads to the C++ side runs at grid-construction time (before any specific net is being routed). For P_FP3 to apply the per-net `escape_clearance` override at A* edge expansion, the C++ side will need either (a) per-net add_pad re-issues at route boundary, or (b) a tighter `clearance_override` carrier on the C++ Pad struct that the search-side can interpret per net. The second option is cleaner but requires C++ API changes.

2. **Pathfinder Python-side threading.** The Python pathfinder uses grid-level halos (`_clearance_for_pin_pitch`) rather than per-pad `clearance_override`. P_FP3 should either (a) extend `_clearance_for_pin_pitch` to take the active `net_class` + regions, or (b) add a per-net A*-expansion clearance check that runs after the grid-halo check. The C++ backend is the dominant routing path so option (a) on the Python side is lower-priority.

3. **Region radius vs pad-cluster size.** The 5mm halo can be smaller than the package itself for wide packages (e.g. a 14-pin SOIC at 1.27mm pitch is ~8mm long, so the halo's outer pads sit just OUTSIDE the halo boundary). The `applies_to_pad` identity-match path covers this defensively, but P_FP3 may want a per-package adaptive radius (`max(5mm, bbox_diagonal/2)`).

4. **Boundary behaviour of `contains_point`.** Uses strict `<` so the radius boundary cell falls back to `trace_clearance`. This matters at the 0.1mm grid resolution where the boundary cells are at known integer positions. If a future board surfaces a "trace gets squeezed right at the boundary" pathology, switching to `<=` would extend the halo by one grid cell.

5. **Non-row layouts (QFN, BGA, etc.).** The detector applies a conservative `min(width, height)` fallback for non-row layouts. BGA is explicitly out of scope for #3371 per the issue's "Out of scope" list, but QFN-style packages will now generate regions where they previously fell through. This is the right safe direction but P_FP3 should verify the QFN path through `_escape_fine_pitch_dual_row` (or its equivalent) is properly engaged when the region applies.

6. **Manufacturer fallback semantics.** When neither `mfr_limits` nor `rules.manufacturer` is configured, the region's `escape_clearance` defaults to `rules.trace_clearance` (no-shrink). This means a region detected on a manufacturer-less board produces a NO-OP region (the resolver returns `trace_clearance` even inside the region). P_FP3 may want to log a warning so users notice the detector ran but didn't apply.

Closes part of #3371 (P_FP2)