### PR TITLE
fix(fleet): align routing verdict with ADVISORY_RULE_IDS via DRC sidecar (closes #3363)

### DIFF
--- a/boards/04-stm32-devboard/output/drc_report.json
+++ b/boards/04-stm32-devboard/output/drc_report.json
@@ -1,0 +1,55 @@
+{
+  "file": "boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb",
+  "manufacturer": "jlcpcb-tier1",
+  "layers": 2,
+  "summary": {
+    "errors": 2,
+    "warnings": 0,
+    "infos": 0,
+    "rules_checked": 27,
+    "rules_checked_by_rule": {
+      "connectivity": 1
+    },
+    "passed": false
+  },
+  "violations": [
+    {
+      "rule_id": "connectivity",
+      "type": "connectivity",
+      "severity": "error",
+      "message": "Net 'GND' is partially routed: 2 of 18 pads stranded (connected island has 16 pads)",
+      "location": [
+        35.1625,
+        19.75
+      ],
+      "layer": null,
+      "actual_value": null,
+      "required_value": null,
+      "items": [
+        "U2.35"
+      ],
+      "nets": [
+        "GND"
+      ]
+    },
+    {
+      "rule_id": "connectivity",
+      "type": "connectivity",
+      "severity": "error",
+      "message": "Net 'NRST' is partially routed: 1 of 2 pads stranded (connected island has 1 pads)",
+      "location": [
+        26.8375,
+        22.25
+      ],
+      "layer": null,
+      "actual_value": null,
+      "required_value": null,
+      "items": [
+        "U2.7"
+      ],
+      "nets": [
+        "NRST"
+      ]
+    }
+  ]
+}

--- a/src/kicad_tools/cli/fleet_cmd.py
+++ b/src/kicad_tools/cli/fleet_cmd.py
@@ -203,6 +203,23 @@ class DRCStatus:
     does not exceed ``tolerance``. When ``report_exists`` is False the
     DRC step has not yet run for this board, so it must NOT block
     ship-ready (issue #2932 backwards-compat rule).
+
+    Issue #3363: ``blocking_errors`` and ``advisory_errors_by_rule``
+    split the raw ``errors`` count by ``DRCChecker.ADVISORY_RULE_IDS``
+    so the fleet command can align its routing-completion verdict with
+    the CI strict gate (``scripts/ci/check_routed_drc.py``). The CI gate
+    treats ``connectivity`` rule violations -- which include both
+    plane/pour stitching residuals AND signal nets the router refused
+    (e.g. board 04's NRST after the post-#3286 clearance kernel closed
+    the marginal U2.7/U2.8 corridor) -- as advisory. Without this split
+    the fleet command would still emit a misleading ``incomplete
+    routing (1/N nets)`` blocker for boards the CI gate considers
+    ship-ready.
+
+    When ``report_exists`` is False both new fields are 0 / empty;
+    callers MUST treat the absence of a report as "unknown" rather than
+    "advisory-only" so the pre-fix behaviour is preserved on boards
+    that have not yet had ``kct check`` run.
     """
 
     report_exists: bool = False
@@ -212,19 +229,65 @@ class DRCStatus:
     # repo-relative path used to look up the tolerance. Surfaced so
     # JSON consumers can correlate.
     tolerance_key: str | None = None
+    # Issue #3363: split of ``errors`` by ``DRCChecker.ADVISORY_RULE_IDS``.
+    # ``blocking_errors`` is what the CI strict gate compares to tolerance;
+    # ``advisory_errors_by_rule`` maps each advisory rule_id to its error
+    # count (currently only ``connectivity``). Both default to 0/empty when
+    # the violations array is missing (legacy report format) or when no
+    # report exists.
+    blocking_errors: int = 0
+    advisory_errors_by_rule: dict[str, int] = field(default_factory=dict)
 
     @property
     def over_tolerance(self) -> bool:
-        """True iff a real DRC report exists AND it exceeds tolerance."""
-        return self.report_exists and self.errors > self.tolerance
+        """True iff a real DRC report exists AND it exceeds tolerance.
+
+        Issue #3363: uses ``blocking_errors`` (advisory-filtered) instead
+        of the raw ``errors`` count so the fleet verdict matches the CI
+        gate. Reports older than the violations-array format fall back
+        to ``errors`` because ``blocking_errors == 0`` and the gate
+        cannot distinguish blocking vs advisory without the per-rule
+        breakdown (defensive: treat as blocking).
+        """
+        if not self.report_exists:
+            return False
+        # If we parsed per-rule splits, gate on the blocking subset only.
+        # Otherwise (legacy / summary-only report) fall back to the raw
+        # ``errors`` count so the gate stays strict.
+        if self.blocking_errors > 0 or self.advisory_errors_by_rule:
+            return self.blocking_errors > self.tolerance
+        return self.errors > self.tolerance
+
+    @property
+    def advisory_only(self) -> bool:
+        """True iff a real DRC report exists AND every error is advisory.
+
+        Used by :func:`_compute_blockers` (issue #3363) to suppress the
+        ``incomplete routing`` blocker when the only DRC findings are
+        advisory ``connectivity``. ``errors == 0`` (clean report) is NOT
+        treated as ``advisory_only`` because there is nothing to be
+        advisory about -- callers should keep their incomplete-routing
+        verdict from the structural net analysis in that case.
+        """
+        if not self.report_exists:
+            return False
+        # Require at least one advisory error AND zero blocking errors;
+        # the latter ensures we don't suppress a legitimate signal-net
+        # blocker when some advisory violations happen to ride along.
+        if self.blocking_errors > 0:
+            return False
+        return sum(self.advisory_errors_by_rule.values()) > 0
 
     def to_dict(self) -> dict:
         return {
             "report_exists": self.report_exists,
             "errors": self.errors,
+            "blocking_errors": self.blocking_errors,
+            "advisory_errors_by_rule": dict(self.advisory_errors_by_rule),
             "tolerance": self.tolerance,
             "tolerance_key": self.tolerance_key,
             "over_tolerance": self.over_tolerance,
+            "advisory_only": self.advisory_only,
         }
 
 
@@ -476,7 +539,20 @@ def _detect_drc(
     blocker computation must then NOT treat the board as failing DRC,
     so boards that have not yet been DRC'd retain their pre-fix
     classification.
+
+    Issue #3363: when the report includes a ``violations`` array (the
+    current ``kct check --output`` format), split the error-severity
+    count by ``DRCChecker.ADVISORY_RULE_IDS`` so the fleet command's
+    ``incomplete routing`` blocker can be suppressed for boards whose
+    only routing-incompleteness findings are advisory ``connectivity``
+    (matching ``scripts/ci/check_routed_drc.py:_count_blocking_errors``).
+    Reports lacking the array (legacy summary-only format) keep
+    ``blocking_errors == 0`` and ``advisory_errors_by_rule == {}``; the
+    ``over_tolerance`` property then falls back to the raw ``errors``
+    count so the gate stays strict on older reports.
     """
+    from kicad_tools.validate.checker import DRCChecker
+
     drc = DRCStatus()
     report_path = routed_pcb.parent / "drc_report.json"
     tolerance, matched_key = _drc_tolerance_for(routed_pcb, tolerances)
@@ -497,6 +573,29 @@ def _detect_drc(
         errors = summary.get("errors", 0)
         if isinstance(errors, int) and not isinstance(errors, bool):
             drc.errors = errors
+    # Split errors by advisory rule classification when the violations
+    # array is present (issue #3363). Mirrors
+    # ``scripts/ci/check_routed_drc.py:_count_blocking_errors`` so the
+    # fleet command's gate semantics align with the CI strict gate.
+    violations = report.get("violations") if isinstance(report, dict) else None
+    if isinstance(violations, list):
+        blocking = 0
+        advisory: dict[str, int] = {}
+        for v in violations:
+            if not isinstance(v, dict):
+                continue
+            severity = v.get("severity", "error")
+            if severity != "error":
+                continue
+            rule_id = v.get("rule_id", "")
+            if not isinstance(rule_id, str):
+                continue
+            if DRCChecker.is_advisory_rule(rule_id):
+                advisory[rule_id] = advisory.get(rule_id, 0) + 1
+            else:
+                blocking += 1
+        drc.blocking_errors = blocking
+        drc.advisory_errors_by_rule = advisory
     drc.report_exists = True
     return drc
 
@@ -776,6 +875,19 @@ def _compute_blockers(
     routing/manufacturing-artifact blockers so the first-failure reason
     in the table stays consistent with prior behavior; DRC surfaces
     when those upstream gates already pass.
+
+    Incomplete-routing handling (issue #3363, post-#3215 follow-up):
+    when a ``drc_report.json`` exists AND classifies every error as
+    advisory ``connectivity`` (per ``DRCChecker.ADVISORY_RULE_IDS``,
+    via :attr:`DRCStatus.advisory_only`), the ``incomplete routing``
+    blocker is suppressed. This aligns the fleet command's verdict
+    with ``scripts/ci/check_routed_drc.py`` for the case where the
+    router correctly refused a signal net at clearance (board 04's
+    NRST after PR #3286) -- the CI gate treats the residual as
+    advisory so the board ships, and the fleet command must agree to
+    avoid a misleading ``incomplete routing (1/12 nets)`` blocker.
+    Without a DRC report on disk the pre-fix behaviour is preserved
+    (mirrors the issue-#2932 backwards-compat rule for ``_detect_drc``).
     """
     blockers: list[str] = []
     if routed_pcb is None:
@@ -799,11 +911,23 @@ def _compute_blockers(
         else:
             blockers.append("routed PCB stale (schematic drift)")
     elif not routing.routing_complete:
-        # Use the advisory-filtered count so the blocker message agrees
-        # with the verdict (plane/pour stitching residuals do not show
-        # up here even though `incomplete_nets` may be non-zero).
-        incomplete = routing.blocking_incomplete_nets + routing.unrouted_nets
-        blockers.append(f"incomplete routing ({incomplete}/{routing.total_nets} nets)")
+        # Issue #3363: align with the CI strict gate. When a DRC report
+        # exists and shows ONLY advisory ``connectivity`` errors (zero
+        # blocking errors), the CI gate treats the board as ship-ready
+        # and the fleet command must agree. Suppress the
+        # ``incomplete routing`` blocker in that case so the verdict
+        # matches ``scripts/ci/check_routed_drc.py``.
+        if drc is not None and drc.advisory_only:
+            # Advisory-only routing residuals are not a blocker; the
+            # diagnostic count is still preserved in the routing JSON
+            # for human triage.
+            pass
+        else:
+            # Use the advisory-filtered count so the blocker message agrees
+            # with the verdict (plane/pour stitching residuals do not show
+            # up here even though `incomplete_nets` may be non-zero).
+            incomplete = routing.blocking_incomplete_nets + routing.unrouted_nets
+            blockers.append(f"incomplete routing ({incomplete}/{routing.total_nets} nets)")
     if not mfg.dir_exists:
         blockers.append("no manufacturing/ dir")
         return blockers

--- a/tests/test_fleet_status.py
+++ b/tests/test_fleet_status.py
@@ -854,6 +854,314 @@ class TestFleetStatusAdvisoryFilter:
         assert "incomplete_nets" in data["boards"][0]["routing"]
 
 
+class TestFleetStatusAdvisoryDRCFilter:
+    """Issue #3363 -- extend advisory filter to clearance-refused signal nets.
+
+    PR #3215 aligned ``RoutingStatus.routing_complete`` with
+    ``DRCChecker.ADVISORY_RULE_IDS`` for plane/pour stitching residuals.
+    Issue #3363 closes the second category surfaced by PR #3286: signal
+    nets the router correctly refused at clearance (e.g. board 04's NRST
+    after the post-#3225/#3227/#3232/#3248/#3250 clearance kernel closed
+    the marginal U2.7/U2.8 corridor).
+
+    Concrete case: board 04's NRST is a signal net with both pads NOT
+    on a copper zone, so ``NetStatus.is_advisory_incomplete`` is False
+    (correctly -- it's not a plane/pour residual). But the CI strict
+    gate (``scripts/ci/check_routed_drc.py``) classifies the
+    ``connectivity`` rule violation as advisory, so the gate passes.
+    Without this fix the fleet command would still emit a misleading
+    ``incomplete routing (1/12 nets)`` blocker for boards the CI gate
+    considers ship-ready.
+
+    Implementation (Option A from the issue body): when a sidecar
+    ``drc_report.json`` exists AND classifies every error as advisory
+    ``connectivity``, the ``incomplete routing`` blocker is suppressed.
+    Without a sidecar the pre-fix behaviour persists (mirrors the
+    issue-#2932 backwards-compat rule for ``_detect_drc``).
+    """
+
+    @staticmethod
+    def _write_drc_report(
+        routed_pcb: Path,
+        *,
+        connectivity_errors: int = 0,
+        blocking_errors: int = 0,
+        include_violations: bool = True,
+    ) -> None:
+        """Drop a synthetic ``drc_report.json`` next to ``routed_pcb``.
+
+        ``connectivity_errors`` are emitted with ``rule_id="connectivity"``
+        (advisory per ``ADVISORY_RULE_IDS``). ``blocking_errors`` use
+        ``rule_id="clearance"`` so they count as non-advisory blocking
+        violations. When ``include_violations`` is False the ``violations``
+        array is omitted, forcing the fall-back to ``summary.errors``
+        (legacy report format).
+        """
+        violations: list[dict] = []
+        for i in range(connectivity_errors):
+            violations.append(
+                {
+                    "rule_id": "connectivity",
+                    "severity": "error",
+                    "message": f"Net 'X{i}' is partially routed: 1 of 2 pads stranded",
+                }
+            )
+        for i in range(blocking_errors):
+            violations.append(
+                {
+                    "rule_id": "clearance",
+                    "severity": "error",
+                    "message": f"Clearance violation #{i}",
+                }
+            )
+        report: dict = {
+            "file": str(routed_pcb),
+            "manufacturer": "jlcpcb",
+            "summary": {
+                "errors": connectivity_errors + blocking_errors,
+                "warnings": 0,
+                "infos": 0,
+                "passed": (connectivity_errors + blocking_errors) == 0,
+            },
+        }
+        if include_violations:
+            report["violations"] = violations
+        (routed_pcb.parent / "drc_report.json").write_text(json.dumps(report))
+
+    def test_advisory_only_drc_suppresses_incomplete_blocker(
+        self, tmp_path: Path, capsys
+    ):
+        """Issue #3363 acceptance: signal-net incomplete + advisory DRC -> YES.
+
+        Mirrors board 04's post-#3286 state: NRST is a signal net the
+        router refused, but the only DRC error is the advisory
+        ``connectivity`` finding. The board must ship-ready.
+        """
+        boards = tmp_path / "boards"
+        # Use BLOCKING_SIGNAL_PCB which has a signal-net (SIG1) gap that
+        # would normally drive `incomplete routing` in the fleet status.
+        routed_pcb = make_fake_board(
+            boards,
+            "nrst-style",
+            pcb_text=BLOCKING_SIGNAL_PCB,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        # The CI gate sees the same SIG1 net as an advisory connectivity
+        # finding. Drop a matching DRC report.
+        self._write_drc_report(routed_pcb, connectivity_errors=1, blocking_errors=0)
+
+        result = main(["status", "--boards-dir", str(boards), "--format", "json"])
+        assert result == 0  # All ship-ready.
+
+        data = json.loads(capsys.readouterr().out)
+        b = data["boards"][0]
+        # Raw view still reflects the signal-net gap for human triage.
+        assert b["routing"]["blocking_incomplete_nets"] == 1
+        # But the verdict is YES because the CI strict gate would pass.
+        assert b["ship_ready"] is True
+        assert b["blockers"] == []
+        # DRC split surfaces the advisory category to JSON consumers.
+        assert b["drc"]["blocking_errors"] == 0
+        assert b["drc"]["advisory_errors_by_rule"] == {"connectivity": 1}
+        assert b["drc"]["advisory_only"] is True
+        assert b["drc"]["over_tolerance"] is False
+
+    def test_no_drc_report_preserves_incomplete_blocker(
+        self, tmp_path: Path, capsys
+    ):
+        """Without a ``drc_report.json`` the pre-fix behaviour persists.
+
+        Mirrors the issue-#2932 backwards-compat rule for ``_detect_drc``:
+        boards that have not yet had ``kct check`` run must keep their
+        pre-fix classification. A signal-net gap without a DRC report on
+        disk continues to drive ``incomplete routing``.
+        """
+        boards = tmp_path / "boards"
+        make_fake_board(
+            boards,
+            "no-drc-report",
+            pcb_text=BLOCKING_SIGNAL_PCB,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        # NO drc_report.json written.
+
+        result = main(["status", "--boards-dir", str(boards), "--format", "json"])
+        assert result == 2  # Not ship-ready.
+
+        data = json.loads(capsys.readouterr().out)
+        b = data["boards"][0]
+        assert b["ship_ready"] is False
+        assert any("incomplete routing" in blocker for blocker in b["blockers"]), b[
+            "blockers"
+        ]
+        # No DRC report -> advisory_only stays False.
+        assert b["drc"]["report_exists"] is False
+        assert b["drc"]["advisory_only"] is False
+
+    def test_blocking_drc_keeps_incomplete_blocker(self, tmp_path: Path, capsys):
+        """Mixed DRC (advisory + blocking) does NOT suppress the blocker.
+
+        When the CI strict gate would itself report blocking errors
+        (e.g. board 06's ``creepage`` violations), the fleet command
+        must NOT suppress the incomplete-routing blocker -- the board
+        is not ship-ready and both reasons should remain visible.
+        """
+        boards = tmp_path / "boards"
+        routed_pcb = make_fake_board(
+            boards,
+            "mixed-drc",
+            pcb_text=BLOCKING_SIGNAL_PCB,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        # Mix: 1 advisory connectivity + 1 blocking clearance.
+        self._write_drc_report(routed_pcb, connectivity_errors=1, blocking_errors=1)
+
+        result = main(["status", "--boards-dir", str(boards), "--format", "json"])
+        assert result == 2  # Not ship-ready.
+
+        data = json.loads(capsys.readouterr().out)
+        b = data["boards"][0]
+        assert b["ship_ready"] is False
+        # Both the incomplete-routing AND the DRC blocker should be present.
+        assert any(
+            "incomplete routing" in blocker for blocker in b["blockers"]
+        ), b["blockers"]
+        assert any("DRC errors" in blocker for blocker in b["blockers"]), b["blockers"]
+        # advisory_only is False because there's a blocking error.
+        assert b["drc"]["advisory_only"] is False
+        assert b["drc"]["blocking_errors"] == 1
+
+    def test_legacy_summary_only_report_keeps_strict_gate(
+        self, tmp_path: Path, capsys
+    ):
+        """Older reports without a ``violations`` array stay strict.
+
+        Pre-#3363 ``drc_report.json`` files only carried ``summary.errors``.
+        Without per-rule breakdown the gate cannot distinguish blocking
+        from advisory errors, so the safer default is to treat the raw
+        count as blocking (preserves the pre-fix verdict).
+        """
+        boards = tmp_path / "boards"
+        routed_pcb = make_fake_board(
+            boards,
+            "legacy-drc",
+            pcb_text=BLOCKING_SIGNAL_PCB,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        # Legacy: summary.errors=1, no violations array.
+        self._write_drc_report(
+            routed_pcb,
+            connectivity_errors=1,
+            blocking_errors=0,
+            include_violations=False,
+        )
+
+        # Without a violations array we cannot prove all errors are
+        # advisory, so the incomplete-routing blocker stays AND the DRC
+        # blocker fires on the raw error count (strict fall-back).
+        main(["status", "--boards-dir", str(boards), "--format", "json"])
+        data = json.loads(capsys.readouterr().out)
+        b = data["boards"][0]
+        assert b["ship_ready"] is False
+        # Raw error count is 1, tolerance is 0 -> over_tolerance.
+        assert b["drc"]["report_exists"] is True
+        assert b["drc"]["over_tolerance"] is True
+        # advisory_only is False because the violations array is missing.
+        assert b["drc"]["advisory_only"] is False
+
+    def test_clean_drc_report_does_not_flip_incomplete_to_ship(
+        self, tmp_path: Path, capsys
+    ):
+        """A 0-error DRC report does NOT suppress incomplete-routing.
+
+        Defensive: ``advisory_only`` requires at least one advisory
+        error to fire. A clean DRC report with zero errors should NOT
+        suppress an incomplete-routing blocker -- the absence of DRC
+        errors says nothing about routing completeness on its own.
+        """
+        boards = tmp_path / "boards"
+        routed_pcb = make_fake_board(
+            boards,
+            "clean-drc-incomplete-routing",
+            pcb_text=BLOCKING_SIGNAL_PCB,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        # 0 errors total -> not advisory_only.
+        self._write_drc_report(routed_pcb, connectivity_errors=0, blocking_errors=0)
+
+        result = main(["status", "--boards-dir", str(boards), "--format", "json"])
+        # Without an advisory-rule signal the incomplete-routing blocker
+        # stays, so this is NOT ship-ready.
+        assert result == 2
+        data = json.loads(capsys.readouterr().out)
+        b = data["boards"][0]
+        assert any(
+            "incomplete routing" in blocker for blocker in b["blockers"]
+        ), b["blockers"]
+        assert b["drc"]["advisory_only"] is False
+
+    def test_drc_status_to_dict_exposes_new_fields(self, tmp_path: Path):
+        """``DRCStatus.to_dict()`` exposes the new advisory split fields."""
+        from kicad_tools.cli.fleet_cmd import DRCStatus
+
+        drc = DRCStatus(
+            report_exists=True,
+            errors=2,
+            blocking_errors=0,
+            advisory_errors_by_rule={"connectivity": 2},
+        )
+        d = drc.to_dict()
+        assert d["blocking_errors"] == 0
+        assert d["advisory_errors_by_rule"] == {"connectivity": 2}
+        assert d["advisory_only"] is True
+        # over_tolerance uses blocking_errors when present.
+        assert d["over_tolerance"] is False
+
+    def test_drc_status_over_tolerance_uses_blocking_count(self):
+        """``over_tolerance`` ignores advisory errors per CI gate semantics.
+
+        Mirrors ``scripts/ci/check_routed_drc.py``: 5 advisory connectivity
+        errors with 0 blocking errors and tolerance 0 still passes the
+        strict gate, because the gate only counts non-advisory rules.
+        """
+        from kicad_tools.cli.fleet_cmd import DRCStatus
+
+        drc = DRCStatus(
+            report_exists=True,
+            errors=5,
+            tolerance=0,
+            blocking_errors=0,
+            advisory_errors_by_rule={"connectivity": 5},
+        )
+        # Raw errors > tolerance, but blocking_errors == 0 -> not over.
+        assert drc.over_tolerance is False
+
+        # Mixed: 2 blocking + 3 advisory, tolerance 1 -> over (2 > 1).
+        drc2 = DRCStatus(
+            report_exists=True,
+            errors=5,
+            tolerance=1,
+            blocking_errors=2,
+            advisory_errors_by_rule={"connectivity": 3},
+        )
+        assert drc2.over_tolerance is True
+
+
 # ---------------------------------------------------------------------------
 # Issue #3280: schematic-vs-PCB drift detection
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Extends the PR #3215 advisory filter (plane/pour residuals) to cover **clearance-refused signal nets**, the second category surfaced by PR #3286. Closes #3363.

Before this fix, ``kct fleet status`` reported board 04 as ``NO  (incomplete routing (1/12 nets))`` while the CI strict gate (``scripts/ci/check_routed_drc.py``) reported ``OK -- 0 errors (strict gate, --mfr jlcpcb-tier1). [advisory (excluded from gate): connectivity=2]``. Two gates disagreed on the same artifact: board 04's NRST is a signal net (so ``NetStatus.is_advisory_incomplete`` is False -- it's not a plane/pour residual), but the CI gate treats the ``connectivity`` rule violation as advisory and passes.

## Implementation (Option A from the issue body)

- ``DRCStatus`` gains ``blocking_errors``, ``advisory_errors_by_rule``, and an ``advisory_only`` property mirroring ``scripts/ci/check_routed_drc.py:_count_blocking_errors``.
- ``_detect_drc`` parses the ``violations`` array and splits errors via ``DRCChecker.is_advisory_rule``.
- ``_compute_blockers`` suppresses the ``incomplete routing`` blocker when ``drc.advisory_only`` is True (DRC report exists, zero blocking errors, at least one advisory error).
- ``over_tolerance`` now uses ``blocking_errors`` when the violations array is present; falls back to the raw ``errors`` count for legacy summary-only reports (strict fallback).
- Without a sidecar the pre-fix behaviour is preserved (mirrors the issue-#2932 backwards-compat rule).

A fresh ``boards/04-stm32-devboard/output/drc_report.json`` (jlcpcb-tier1, 2 advisory connectivity errors, 0 blocking) is committed so the fix is visible on ``kct fleet status`` immediately.

## Before / after

**Before:**
```
04-stm32-devboard              52/55   95% B/C/G/M  STALE      - NO  (incomplete routing (1/12 nets))
```

**After:**
```
04-stm32-devboard              52/55   95% B/C/G/M  fresh      2 YES
```

Other boards' verdicts are unchanged:
- 02-charlieplex-led: YES (unchanged)
- 03-usb-joystick: NO (schematic drift, unchanged)
- 05-bldc-motor-controller: NO (schematic drift, unchanged)
- 06-diffpair-test: NO (incomplete routing 3/26 nets, unchanged -- no DRC sidecar)
- 07-matchgroup-test: NO (incomplete routing 4/34 nets, unchanged -- no DRC sidecar)

## Test plan

- [x] ``uv run pytest tests/test_fleet*`` -- 68 tests pass (7 new cases in ``TestFleetStatusAdvisoryDRCFilter``)
- [x] ``uv run pytest tests/ -k 'net_status or check_routed_drc'`` -- 133 pass (no regression)
- [x] ``uv run python scripts/ci/check_routed_drc.py boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb`` -- still OK (CI gate semantics unchanged)
- [x] ``uv run ruff check src/kicad_tools/cli/fleet_cmd.py tests/test_fleet_status.py`` -- clean
- [x] ``uv run mypy src/kicad_tools/cli/fleet_cmd.py`` -- no new errors in fleet_cmd.py

New test coverage:
- ``test_advisory_only_drc_suppresses_incomplete_blocker`` -- the board-04 fix path.
- ``test_no_drc_report_preserves_incomplete_blocker`` -- backwards-compat rule.
- ``test_blocking_drc_keeps_incomplete_blocker`` -- mixed advisory+blocking does NOT mask real errors.
- ``test_legacy_summary_only_report_keeps_strict_gate`` -- old report format stays strict.
- ``test_clean_drc_report_does_not_flip_incomplete_to_ship`` -- defensive: ``advisory_only`` requires at least one advisory error.
- ``test_drc_status_to_dict_exposes_new_fields`` -- JSON contract.
- ``test_drc_status_over_tolerance_uses_blocking_count`` -- CI gate semantics.

## Out of scope

- NRST routing recovery (closed by #3286 as correct router behavior; rides with #2834).
- Tightening ``DRCChecker.ADVISORY_RULE_IDS`` itself (Option B's side effect of moving DRC into the hot path).
- Generating DRC sidecars for boards 06/07 (separate scope; their blockers reflect genuine routing gaps).
- Board 04 manifest mtime checkout race (pre-existing, documented in PR #3364).

Closes #3363