### PR TITLE
fix(sync): /-prefix strip + unconditional pin-to-pad map (Closes #3370)

### DIFF
--- a/src/kicad_tools/cli/fleet_cmd.py
+++ b/src/kicad_tools/cli/fleet_cmd.py
@@ -586,7 +586,12 @@ def _detect_erc(board_dir: Path) -> ERCStatus:
 
 
 _SCH_LABEL_RE = re.compile(r'\(\s*(?:label|global_label|hierarchical_label)\s+"([^"]+)"')
-_PCB_NET_RE = re.compile(r'\(net\s+\d+\s+"([^"]+)"\)')
+_SCH_POWER_SYMBOL_RE = re.compile(r'\(\s*lib_id\s+"power:([^"]+)"')
+# Match ``(net NUMBER "NAME")`` -- shared between top-level
+# declarations and pad-nested references.  Pad context is
+# distinguished by the streaming parser in
+# ``_extract_pcb_pad_net_numbers``.
+_PCB_NET_NUMBERED_RE = re.compile(r'\(net\s+(\d+)\s+"([^"]+)"')
 
 
 def _extract_schematic_nets(sch_path: Path) -> set[str] | None:
@@ -594,9 +599,19 @@ def _extract_schematic_nets(sch_path: Path) -> set[str] | None:
 
     The detection is intentionally lightweight: we only collect text from
     ``label`` / ``global_label`` / ``hierarchical_label`` s-expression
-    leaves. Auto-generated ``Net-(...)`` placeholders (KiCad's default
-    unconnected names) are skipped because they cannot be reliably
-    mapped to a PCB net name without a full netlister pass.
+    leaves, plus implicit globals published by ``power:`` symbol
+    instances (e.g. ``power:+24V`` -> ``+24V``).  Auto-generated
+    ``Net-(...)`` placeholders (KiCad's default unconnected names) are
+    skipped because they cannot be reliably mapped to a PCB net name
+    without a full netlister pass.
+
+    Power-symbol detection (issue #3370): KiCad's ``power:`` library
+    publishes a single global label per symbol instance equal to the
+    symbol's name (the part after the ``:``).  These globals never
+    appear as ``(label "...")`` leaves in the schematic file even
+    though they are first-class nets.  Picking them up here keeps the
+    drift comparison symmetric with ``_extract_pcb_named_nets``,
+    which sees the same globals as bare ``(net N "name")`` entries.
 
     Returns ``None`` if the file cannot be read so callers can treat
     that as "unknown source state" and skip drift gating.
@@ -613,24 +628,131 @@ def _extract_schematic_nets(sch_path: Path) -> set[str] | None:
         if name.startswith("Net-("):
             continue
         labels.add(name)
+    # Power symbols (``power:+24V``, ``power:GND``, ``power:+3V3``, ...)
+    # publish an implicit global label whose name is the part after
+    # the colon.  Include them so the drift comparison treats power
+    # rails consistently with the PCB-side ``(net N "+24V")`` entries.
+    #
+    # ``PWR_FLAG`` is a KiCad ERC convention symbol -- it marks an
+    # existing net as actively driven so the connectivity checker
+    # doesn't flag it as floating -- and does NOT publish a net of
+    # its own.  Excluding it keeps boards that use it (e.g. board 02)
+    # from showing a spurious one-net drift after this change.
+    for m in _SCH_POWER_SYMBOL_RE.finditer(text):
+        name = m.group(1)
+        if name and name != "PWR_FLAG":
+            labels.add(name)
     return labels
 
 
-def _extract_pcb_named_nets(pcb_path: Path) -> set[str] | None:
-    """Return the set of non-empty named nets declared in a KiCad PCB.
+def _extract_pcb_pad_net_numbers(pcb_text: str) -> set[int]:
+    """Return the set of net numbers actually referenced by pads.
 
-    Only top-level ``(net N "name")`` declarations are matched; the
-    empty net 0 is dropped. Returns ``None`` on read failure.
+    Pads in KiCad PCB files appear as ``(pad "NUM" TYPE SHAPE ...
+    (net N "NAME") ...)`` blocks nested inside ``(footprint ...)``.
+    Top-level ``(net N "NAME")`` declarations exist for *every* known
+    net even when no pad references the net -- routing-only artifacts
+    (segments / vias / zones left over from older sync rounds) keep
+    their declarations after their pads have been reassigned.
+
+    Returning the *number* set rather than the *name* set lets the
+    caller cross-reference with top-level declarations to determine
+    which named nets are pad-referenced and which are routing-only.
+
+    Uses a depth-tracked streaming scan rather than a single regex
+    because pad bodies can span many lines and contain nested forms.
+    """
+    pad_net_numbers: set[int] = set()
+    i = 0
+    n = len(pcb_text)
+    while True:
+        idx = pcb_text.find("(pad ", i)
+        if idx < 0:
+            idx = pcb_text.find("(pad\t", i)
+        if idx < 0:
+            idx = pcb_text.find("(pad\n", i)
+        if idx < 0:
+            break
+        # Find the end of this pad's s-expression by tracking depth.
+        depth = 0
+        j = idx
+        body_start = idx
+        body_end = idx
+        while j < n:
+            c = pcb_text[j]
+            if c == '(':
+                depth += 1
+            elif c == ')':
+                depth -= 1
+                if depth == 0:
+                    body_end = j + 1
+                    break
+            j += 1
+        if body_end <= body_start:
+            i = idx + 5
+            continue
+        body = pcb_text[body_start:body_end]
+        # Match (net N "name") inside the pad body
+        m = _PCB_NET_NUMBERED_RE.search(body)
+        if m:
+            try:
+                pad_net_numbers.add(int(m.group(1)))
+            except ValueError:
+                pass
+        i = body_end
+    return pad_net_numbers
+
+
+def _extract_pcb_named_nets(pcb_path: Path) -> set[str] | None:
+    """Return the set of non-empty PCB nets that have at least one pad.
+
+    The drift detector compares this set against the schematic's
+    label / power-symbol set.  To keep the comparison meaningful, we
+    return only nets that are actually attached to pads -- i.e. the
+    nets the synchronisation layer is responsible for.  Top-level
+    ``(net N "name")`` declarations that exist *only* because a
+    segment / via / zone still references the name (a routing-only
+    leftover from an older sync round) are dropped.
+
+    Two additional name-pattern filters keep the comparison
+    symmetric with :func:`_extract_schematic_nets` (which already
+    skips ``Net-(...)`` placeholders):
+
+      * ``Net-(REF-Pad/PinN)`` -- the netlist exporter's default name
+        for un-labeled local nets.  These appear on the PCB after
+        ``sync-netlist`` runs against a schematic whose nets carry no
+        explicit ``label`` element, so they cannot represent genuine
+        schematic-vs-PCB drift -- only sync state.
+      * ``unconnected-(REF-PinName-PadN)`` -- KiCad's marker for
+        explicitly unconnected pins.  These are not nets the schematic
+        author labeled, so they are pure sync artifacts as well.
+
+    Issue #3370: without the pad-attachment filter, board 05's stale
+    ``PWR_LED`` / ``STATUS_LED`` / ``SW_OUT`` segment leftovers from
+    an earlier sync round would surface as drift even though they
+    have no pads.
+
+    Returns ``None`` on read failure.
     """
     try:
         text = pcb_path.read_text()
     except OSError:
         return None
+    pad_net_numbers = _extract_pcb_pad_net_numbers(text)
     nets: set[str] = set()
-    for m in _PCB_NET_RE.finditer(text):
-        name = m.group(1)
-        if name:
-            nets.add(name)
+    for m in _PCB_NET_NUMBERED_RE.finditer(text):
+        try:
+            num = int(m.group(1))
+        except ValueError:
+            continue
+        if num not in pad_net_numbers:
+            continue
+        name = m.group(2)
+        if not name:
+            continue
+        if name.startswith("Net-(") or name.startswith("unconnected-("):
+            continue
+        nets.add(name)
     return nets
 
 

--- a/src/kicad_tools/cli/pcb_sync_netlist.py
+++ b/src/kicad_tools/cli/pcb_sync_netlist.py
@@ -391,6 +391,42 @@ def _get_pad_net_snapshot(pcb) -> dict[tuple[str, str], str]:
     return snapshot
 
 
+def _normalize_kicad_cli_net_names(netlist) -> None:
+    """Strip leading ``/`` from hierarchical-label net names in-place.
+
+    The ``kicad-cli sch export netlist`` exporter prefixes hierarchical
+    local labels with the sheet path (e.g. ``/BST_A``, ``/DRV_CP1``)
+    while global power-symbol labels come through unprefixed
+    (e.g. ``+3V3``, ``GND``).  PCB net tables conventionally store bare
+    names, so adding the prefixed form creates ghost nets that get
+    dropped by orphan-net cleanup and prevents pads from being assigned
+    to the intended net.
+
+    This normalization mirrors what ``_extract_schematic_nets`` in
+    :mod:`kicad_tools.cli.fleet_cmd` does -- it consumes label-leaf
+    names that are already bare, so the drift detector and the sync
+    writer agree on the same naming convention.
+
+    Only a single leading ``/`` is stripped, and only from names that
+    do not begin with another ``/`` after the strip (defensive against
+    deeper hierarchical paths such as ``/sheetA/SIGNAL`` -- those keep
+    a leading ``/`` only if the parser was confused; we still strip
+    one and leave the rest as a sub-path token, which then becomes a
+    valid bare net name).
+
+    Power-rail aliases (``+3V3``, ``GND``, ``+5V``, ...) are left
+    unchanged because they don't carry the ``/`` prefix in the
+    exported netlist.
+
+    Args:
+        netlist: A :class:`Netlist` whose ``nets`` list will be
+            mutated in place.
+    """
+    for net in netlist.nets:
+        if net.name and net.name.startswith("/"):
+            net.name = net.name[1:]
+
+
 def _assign_nets_from_schematic(
     pcb, schematic_path: Path
 ) -> tuple[list[SyncAction], list[str]]:
@@ -419,19 +455,31 @@ def _assign_nets_from_schematic(
         errors.append(f"Failed to export netlist for net assignment: {exc}")
         return actions, errors
 
-    # Build pin-to-pad mapping when using the Python fallback path.
-    # The Python fallback produces NetNode.pin values that are schematic
-    # symbol pin numbers, which may differ from footprint pad numbers.
-    # The kicad-cli path already resolves this mapping internally, so
-    # the map is only needed for the fallback.
+    # Normalize ``/``-prefixed hierarchical net names from kicad-cli.
+    # The Python fallback already emits bare names, so this is a no-op
+    # for that path; running it unconditionally keeps the downstream
+    # invariant simple (``net.name`` is always the bare PCB-side name).
+    _normalize_kicad_cli_net_names(netlist)
+
+    # Build pin-to-pad mapping for all netlist sources.
+    #
+    # Both the Python fallback and the kicad-cli exporter emit
+    # ``NetNode.pin`` values that are *schematic* symbol pin numbers.
+    # These may differ from footprint pad numbers when a symbol uses
+    # name-based pads (BGA-style ``A1``/``B2``) or when the symbol's
+    # pin numbering follows a different package family than the
+    # footprint's pad numbering.  ``build_pin_to_pad_map`` resolves the
+    # translation by walking ``lib_symbols`` and the PCB footprint pad
+    # lists; the map is identity for the common case (pin number ==
+    # pad number) and only diverges for genuine mismatches, so building
+    # it unconditionally is safe.
     pin_to_pad_map = None
-    if netlist.tool and "Python fallback" in netlist.tool:
-        try:
-            pin_to_pad_map = build_pin_to_pad_map(schematic_path, pcb)
-        except Exception as exc:
-            errors.append(
-                f"Failed to build pin-to-pad map (proceeding without): {exc}"
-            )
+    try:
+        pin_to_pad_map = build_pin_to_pad_map(schematic_path, pcb)
+    except Exception as exc:
+        errors.append(
+            f"Failed to build pin-to-pad map (proceeding without): {exc}"
+        )
 
     # Snapshot before assignment
     before = _get_pad_net_snapshot(pcb)

--- a/tests/test_fleet_status.py
+++ b/tests/test_fleet_status.py
@@ -1399,3 +1399,160 @@ class TestFleetStatusDriftFalsePositiveFixes:
         assert canonicalize_power_net("LED_K") == "LED_K"
         assert canonicalize_power_net("USB_CC1") == "USB_CC1"
         assert canonicalize_power_net("") == ""
+
+
+# ---------------------------------------------------------------------------
+# Drift detector extraction primitives -- issue #3370
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSchematicNets:
+    """Unit-level checks on :func:`_extract_schematic_nets`.
+
+    Issue #3370: the drift detector must surface implicit globals
+    published by ``power:`` symbol instances (e.g. ``+24V`` on board
+    05's input power section), but must NOT surface ``PWR_FLAG`` -- a
+    KiCad ERC convention symbol that doesn't represent its own net.
+    """
+
+    def _write_sch(self, tmp_path: Path, text: str) -> Path:
+        sch = tmp_path / "test.kicad_sch"
+        sch.write_text(text)
+        return sch
+
+    def test_label_extraction(self, tmp_path):
+        from kicad_tools.cli.fleet_cmd import _extract_schematic_nets
+
+        sch = self._write_sch(tmp_path, """(kicad_sch
+          (label "SIG1" (at 10 10 0))
+          (label "SIG2" (at 10 20 0))
+          (global_label "GLOBAL_SIG" (at 10 30 0))
+          (hierarchical_label "HIER_SIG" (at 10 40 0))
+        )""")
+        names = _extract_schematic_nets(sch)
+        assert names == {"SIG1", "SIG2", "GLOBAL_SIG", "HIER_SIG"}
+
+    def test_power_symbol_globals(self, tmp_path):
+        """``power:+24V`` -> ``+24V`` implicit global."""
+        from kicad_tools.cli.fleet_cmd import _extract_schematic_nets
+
+        sch = self._write_sch(tmp_path, """(kicad_sch
+          (symbol (lib_id "power:+24V") (at 10 10 0))
+          (symbol (lib_id "power:GND") (at 10 20 0))
+          (symbol (lib_id "power:+3V3") (at 10 30 0))
+          (label "SIG1" (at 10 40 0))
+        )""")
+        names = _extract_schematic_nets(sch)
+        assert names == {"+24V", "GND", "+3V3", "SIG1"}
+
+    def test_pwr_flag_excluded(self, tmp_path):
+        """``power:PWR_FLAG`` is an ERC marker, not a net publisher."""
+        from kicad_tools.cli.fleet_cmd import _extract_schematic_nets
+
+        sch = self._write_sch(tmp_path, """(kicad_sch
+          (symbol (lib_id "power:PWR_FLAG") (at 10 10 0))
+          (symbol (lib_id "power:VCC") (at 10 20 0))
+          (label "SIG1" (at 10 30 0))
+        )""")
+        names = _extract_schematic_nets(sch)
+        assert "PWR_FLAG" not in names
+        assert names == {"VCC", "SIG1"}
+
+    def test_net_placeholder_skipped(self, tmp_path):
+        """``Net-(...)`` label placeholders are dropped."""
+        from kicad_tools.cli.fleet_cmd import _extract_schematic_nets
+
+        sch = self._write_sch(tmp_path, """(kicad_sch
+          (label "Net-(R1-Pad2)" (at 10 10 0))
+          (label "SIG1" (at 10 20 0))
+        )""")
+        names = _extract_schematic_nets(sch)
+        assert names == {"SIG1"}
+
+    def test_unreadable_returns_none(self, tmp_path):
+        """Missing file yields ``None`` so the detector skips the gate."""
+        from kicad_tools.cli.fleet_cmd import _extract_schematic_nets
+
+        result = _extract_schematic_nets(tmp_path / "nonexistent.kicad_sch")
+        assert result is None
+
+
+class TestExtractPcbNamedNets:
+    """Unit-level checks on :func:`_extract_pcb_named_nets`.
+
+    Issue #3370: the function must drop PCB nets that exist only in
+    routing artifacts (segments / vias / zones) with no pad
+    attachment.  Those are routing leftovers from earlier sync rounds
+    and don't represent meaningful schematic-vs-PCB drift.
+    """
+
+    def _write_pcb(self, tmp_path: Path, text: str) -> Path:
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(text)
+        return pcb
+
+    def test_pad_attached_nets_kept(self, tmp_path):
+        from kicad_tools.cli.fleet_cmd import _extract_pcb_named_nets
+
+        pcb = self._write_pcb(tmp_path, """(kicad_pcb
+          (net 0 "")
+          (net 1 "VCC")
+          (net 2 "GND")
+          (footprint "R_0402"
+            (pad "1" smd rect (at 0 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "VCC"))
+            (pad "2" smd rect (at 1 0) (size 0.5 0.5) (layers "F.Cu") (net 2 "GND"))
+          )
+        )""")
+        names = _extract_pcb_named_nets(pcb)
+        assert names == {"VCC", "GND"}
+
+    def test_pad_orphan_nets_dropped(self, tmp_path):
+        """Top-level ``(net N "X")`` with no pad reference is dropped.
+
+        Mirrors board 05's ``PWR_LED`` / ``STATUS_LED`` leftover from
+        an older sync round: the segments still reference the net but
+        no pad does.  Without this filter, those names would surface
+        as drift even though they only describe stale routing state.
+        """
+        from kicad_tools.cli.fleet_cmd import _extract_pcb_named_nets
+
+        pcb = self._write_pcb(tmp_path, """(kicad_pcb
+          (net 0 "")
+          (net 1 "VCC")
+          (net 2 "GND")
+          (net 3 "STALE_SEG_NET")
+          (footprint "R_0402"
+            (pad "1" smd rect (at 0 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "VCC"))
+            (pad "2" smd rect (at 1 0) (size 0.5 0.5) (layers "F.Cu") (net 2 "GND"))
+          )
+          (segment (start 0 0) (end 1 1) (width 0.25) (layer "F.Cu") (net 3))
+        )""")
+        names = _extract_pcb_named_nets(pcb)
+        assert "STALE_SEG_NET" not in names
+        assert names == {"VCC", "GND"}
+
+    def test_auto_generated_names_dropped(self, tmp_path):
+        """``Net-(...)`` and ``unconnected-(...)`` names are dropped."""
+        from kicad_tools.cli.fleet_cmd import _extract_pcb_named_nets
+
+        pcb = self._write_pcb(tmp_path, """(kicad_pcb
+          (net 0 "")
+          (net 1 "VCC")
+          (net 2 "Net-(R1-Pad2)")
+          (net 3 "unconnected-(U1-NC-Pad5)")
+          (footprint "R_0402"
+            (pad "1" smd rect (at 0 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "VCC"))
+            (pad "2" smd rect (at 1 0) (size 0.5 0.5) (layers "F.Cu") (net 2 "Net-(R1-Pad2)"))
+          )
+          (footprint "QFN-32"
+            (pad "5" smd rect (at 0 0) (size 0.5 0.5) (layers "F.Cu") (net 3 "unconnected-(U1-NC-Pad5)"))
+          )
+        )""")
+        names = _extract_pcb_named_nets(pcb)
+        assert names == {"VCC"}
+
+    def test_unreadable_returns_none(self, tmp_path):
+        from kicad_tools.cli.fleet_cmd import _extract_pcb_named_nets
+
+        result = _extract_pcb_named_nets(tmp_path / "nonexistent.kicad_pcb")
+        assert result is None

--- a/tests/test_pcb_sync_netlist.py
+++ b/tests/test_pcb_sync_netlist.py
@@ -2440,3 +2440,243 @@ class TestRemoveOrphanNets:
 
         rc = _run_sync_netlist_command(Args(), pcb)
         assert rc == 0
+
+
+class TestNormalizeKicadCliNetNames:
+    """Tests for the ``/``-prefix normalisation of kicad-cli net names.
+
+    Issue #3370: ``kicad-cli sch export netlist`` writes hierarchical
+    local labels with a leading sheet-path slash (``/BST_A``) while
+    power-symbol globals (``+3V3``, ``GND``) come through unprefixed.
+    PCB net tables conventionally store bare names; mixing the two
+    conventions causes the ``/``-prefixed adds to land in the PCB as
+    ghost nets that get dropped by orphan cleanup, leaving the intended
+    pads on stale net values.
+    """
+
+    def _make_net(self, code: int, name: str):
+        """Construct a minimal NetlistNet with the given code and name."""
+        from kicad_tools.operations.netlist import NetlistNet
+
+        return NetlistNet(code=code, name=name, nodes=[])
+
+    def _make_netlist(self, nets):
+        """Construct a minimal Netlist with the given nets."""
+        from kicad_tools.operations.netlist import Netlist
+
+        return Netlist(
+            source_file="test.kicad_sch",
+            tool="Eeschema 10.0.1",
+            components=[],
+            nets=list(nets),
+        )
+
+    def test_single_slash_stripped(self):
+        """A single leading ``/`` is stripped from hierarchical labels."""
+        from kicad_tools.cli.pcb_sync_netlist import _normalize_kicad_cli_net_names
+
+        netlist = self._make_netlist([
+            self._make_net(1, "/BST_A"),
+            self._make_net(2, "/DRV_CP1"),
+            self._make_net(3, "/SPI_MISO"),
+        ])
+        _normalize_kicad_cli_net_names(netlist)
+        names = [n.name for n in netlist.nets]
+        assert names == ["BST_A", "DRV_CP1", "SPI_MISO"]
+
+    def test_power_symbol_names_unchanged(self):
+        """Power-symbol names (``+3V3``, ``GND``, ``+5V``) are untouched."""
+        from kicad_tools.cli.pcb_sync_netlist import _normalize_kicad_cli_net_names
+
+        netlist = self._make_netlist([
+            self._make_net(1, "+3V3"),
+            self._make_net(2, "GND"),
+            self._make_net(3, "+5V"),
+            self._make_net(4, "+3.3V"),
+            self._make_net(5, "-12V"),
+        ])
+        _normalize_kicad_cli_net_names(netlist)
+        names = [n.name for n in netlist.nets]
+        assert names == ["+3V3", "GND", "+5V", "+3.3V", "-12V"]
+
+    def test_bare_names_unchanged(self):
+        """Already-bare names from the Python fallback are untouched."""
+        from kicad_tools.cli.pcb_sync_netlist import _normalize_kicad_cli_net_names
+
+        netlist = self._make_netlist([
+            self._make_net(1, "BST_A"),
+            self._make_net(2, "PHASE_A"),
+            self._make_net(3, "Net-(R1-Pad2)"),
+        ])
+        _normalize_kicad_cli_net_names(netlist)
+        names = [n.name for n in netlist.nets]
+        assert names == ["BST_A", "PHASE_A", "Net-(R1-Pad2)"]
+
+    def test_empty_name_unchanged(self):
+        """The empty net (code 0) has no name; normalisation is a no-op."""
+        from kicad_tools.cli.pcb_sync_netlist import _normalize_kicad_cli_net_names
+
+        netlist = self._make_netlist([self._make_net(0, "")])
+        _normalize_kicad_cli_net_names(netlist)
+        assert netlist.nets[0].name == ""
+
+    def test_only_leading_slash_stripped(self):
+        """Only the first ``/`` is stripped; deeper paths keep their tail."""
+        from kicad_tools.cli.pcb_sync_netlist import _normalize_kicad_cli_net_names
+
+        # Defensive: a sub-sheet hierarchical path comes through as
+        # /sheetA/SIGNAL.  We strip ONE leading slash so the surviving
+        # form (sheetA/SIGNAL) is a unique-but-bare name that will
+        # round-trip to the same canonical key on every sync invocation.
+        netlist = self._make_netlist([self._make_net(1, "/sheetA/SIGNAL")])
+        _normalize_kicad_cli_net_names(netlist)
+        assert netlist.nets[0].name == "sheetA/SIGNAL"
+
+    def test_mixed_names_partial_normalisation(self):
+        """Mixed power+hierarchical netlist: only ``/``-prefixed names change."""
+        from kicad_tools.cli.pcb_sync_netlist import _normalize_kicad_cli_net_names
+
+        netlist = self._make_netlist([
+            self._make_net(1, "/BST_A"),
+            self._make_net(2, "+3V3"),
+            self._make_net(3, "/DRV_CP1"),
+            self._make_net(4, "GND"),
+            self._make_net(5, "PWM_AH"),
+        ])
+        _normalize_kicad_cli_net_names(netlist)
+        names = [n.name for n in netlist.nets]
+        assert names == ["BST_A", "+3V3", "DRV_CP1", "GND", "PWM_AH"]
+
+    def test_normalisation_is_idempotent(self):
+        """Running the normaliser twice produces the same result."""
+        from kicad_tools.cli.pcb_sync_netlist import _normalize_kicad_cli_net_names
+
+        netlist = self._make_netlist([
+            self._make_net(1, "/BST_A"),
+            self._make_net(2, "+3V3"),
+        ])
+        _normalize_kicad_cli_net_names(netlist)
+        first = [n.name for n in netlist.nets]
+        _normalize_kicad_cli_net_names(netlist)
+        second = [n.name for n in netlist.nets]
+        assert first == second == ["BST_A", "+3V3"]
+
+
+# ---------------------------------------------------------------------------
+# Board 05 round-trip / drift regression (issue #3370)
+# ---------------------------------------------------------------------------
+
+_BOARD_05_DIR = Path("boards/05-bldc-motor-controller/output")
+_BOARD_05_SCH = _BOARD_05_DIR / "bldc_controller.kicad_sch"
+_BOARD_05_PCB = _BOARD_05_DIR / "bldc_controller_routed.kicad_pcb"
+
+# The 14 hierarchical-local nets that were dropped before the
+# ``/``-prefix fix.  ``+3.3V`` is intentionally excluded -- it is a
+# power-symbol alias handled by ``canonicalize_power_nets``.
+_BOARD_05_DRIFT_NETS = frozenset({
+    "BST_A", "BST_B", "BST_C",
+    "DRV_CP1", "DRV_CP2",
+    "DRV_FAULTn", "DRV_LOCKn",
+    "DRV_VCP", "DRV_VINT", "DRV_VREG", "DRV_VSW",
+    "FGFB", "FGOUT",
+    "SPI_MISO",
+})
+
+# After the fix, the PCB must carry at least this many named nets
+# (40 pre-fix + 13 recovered drift nets = 53; ``+3.3V`` already
+# present pre-fix as an alias).
+_BOARD_05_MIN_NET_COUNT = 53
+
+
+@pytest.mark.skipif(
+    not _BOARD_05_SCH.exists() or not _BOARD_05_PCB.exists(),
+    reason="Board 05 schematic/PCB artifacts not present in this checkout",
+)
+class TestBoard05SyncDriftRegression:
+    """Round-trip + invariants for board 05 schematic-PCB drift (#3370).
+
+    These tests load the on-disk board-05 artifacts (schematic +
+    committed routed PCB), apply :func:`sync_netlist` to a copy of
+    the PCB, and assert:
+
+      1. All 14 drift nets land in the synced PCB.
+      2. The synced PCB exposes >= 53 named nets (was 40 pre-fix).
+      3. No ``/``-prefixed net names appear in the synced PCB.
+      4. U3 pad assignments match the schematic's intended nets.
+    """
+
+    @pytest.fixture
+    def synced_pcb(self, tmp_path):
+        """Run sync_netlist against a copy of the board-05 PCB."""
+        import shutil
+
+        from kicad_tools.cli.pcb_sync_netlist import sync_netlist
+        from kicad_tools.schema.pcb import PCB
+
+        dst_pcb = tmp_path / "bldc_controller_synced.kicad_pcb"
+        shutil.copy(_BOARD_05_PCB, dst_pcb)
+
+        result = sync_netlist(
+            schematic_path=_BOARD_05_SCH,
+            pcb_path=dst_pcb,
+            dry_run=False,
+            remove_orphan_nets=True,
+        )
+        assert not result.errors, f"sync_netlist errors: {result.errors}"
+        return PCB.load(dst_pcb), result
+
+    def test_drift_nets_present(self, synced_pcb):
+        """All 14 drift nets land in the synced PCB."""
+        pcb, _ = synced_pcb
+        named = {n.name for n in pcb.nets.values() if n.name}
+        missing = _BOARD_05_DRIFT_NETS - named
+        assert not missing, (
+            f"Drift nets still missing after sync: {sorted(missing)}"
+        )
+
+    def test_net_count_above_floor(self, synced_pcb):
+        """The synced PCB carries >= 53 named nets (was 40 pre-fix)."""
+        pcb, _ = synced_pcb
+        named = {n.name for n in pcb.nets.values() if n.name}
+        assert len(named) >= _BOARD_05_MIN_NET_COUNT, (
+            f"Synced PCB has only {len(named)} named nets, expected "
+            f">= {_BOARD_05_MIN_NET_COUNT}.  Drift recovery regressed."
+        )
+
+    def test_no_slash_prefixed_names(self, synced_pcb):
+        """No ``/``-prefixed net names appear in the synced PCB."""
+        pcb, _ = synced_pcb
+        named = {n.name for n in pcb.nets.values() if n.name}
+        prefixed = {n for n in named if n.startswith("/")}
+        assert not prefixed, (
+            f"Found /-prefixed net names in synced PCB: {sorted(prefixed)}"
+        )
+
+    def test_u3_drift_pads_assigned_correctly(self, synced_pcb):
+        """U3 pads land on the schematic-intended drift nets, not stale rails.
+
+        Pre-fix, U3.1 / U3.3 / U3.5 / U3.15 / U3.17 / U3.29 / U3.30
+        were stuck on ``GND`` / ``+5V`` / ``+3.3V`` / ``PWM_AH`` from
+        the original bottom-up footprint generator's DRV8301_PINS
+        table.  After the fix, sync rewrites them to the schematic's
+        BST_A / BST_B / BST_C / SPI_MISO / DRV_FAULTn / DRV_CP2 /
+        DRV_CP1 assignments.
+        """
+        pcb, _ = synced_pcb
+        u3 = pcb.get_footprint("U3")
+        assert u3 is not None, "U3 footprint not found"
+        pad_nets = {p.number: p.net_name for p in u3.pads}
+        expected = {
+            "1": "BST_A",
+            "3": "BST_B",
+            "5": "BST_C",
+            "15": "SPI_MISO",
+            "17": "DRV_FAULTn",
+            "29": "DRV_CP2",
+            "30": "DRV_CP1",
+        }
+        for pad_num, want_net in expected.items():
+            got = pad_nets.get(pad_num)
+            assert got == want_net, (
+                f"U3.{pad_num}: expected net {want_net!r}, got {got!r}"
+            )


### PR DESCRIPTION
## Summary

Two coupled fixes to `kct pcb sync-netlist` so the kicad-cli netlist exporter produces PCB nets that round-trip cleanly through pad assignment, plus drift-detector symmetry improvements that surface the same set of "real" nets from both sides.

### Fix 1 — strip leading `/` from kicad-cli net names
`kicad-cli sch export netlist --format kicadsexpr` prefixes hierarchical local labels with the sheet path (`/BST_A`, `/DRV_CP1`, ...), while global power-symbol labels come through unprefixed (`+3V3`, `GND`). `_assign_nets_from_schematic` was passing names verbatim to `pcb.add_net()`, producing ghost `/`-form nets that `_remove_unused_nets` then dropped. Board 05 lost its 14 DRV8301 internal nets (`BST_A` / `DRV_CP*` / `FGFB` / `SPI_MISO` etc) this way. A new `_normalize_kicad_cli_net_names` helper strips a single leading `/` in-place; the Python fallback path is unaffected.

### Fix 2 — build pin-to-pad map for the kicad-cli path too
`build_pin_to_pad_map` was previously called only when the netlist came from the "Python fallback" path, on the assumption that kicad-cli resolves pin-vs-pad numbering internally. Empirically it does not — it emits schematic *symbol* pin numbers, identical to the fallback. We now build the map unconditionally; the result is identity (no-op) for the common case and diverges only for genuine name-based-pad footprints.

### Drift detector symmetry
`_extract_schematic_nets` and `_extract_pcb_named_nets` in `fleet_cmd` now agree on what counts as a "real" net:

- **Schematic side** now picks up implicit globals published by `power:` symbol instances (e.g. `power:+24V` → `+24V`) — these never appear as `(label ...)` leaves but are first-class nets. `PWR_FLAG` is excluded (it's a KiCad ERC convention marker, not a net publisher).
- **PCB side** now returns only nets actually attached to at least one pad. Top-level `(net N "X")` declarations that survive only because a segment / via / zone references the name (routing-only leftover from an older sync round) are dropped. Auto-generated `Net-(REF-PadN)` and `unconnected-(...)` names are also dropped on both sides for symmetry.

## Round-trip verification

Board 05 (in-memory; the committed routed PCB is intentionally preserved):

| Metric | Before fix | After fix |
|---|---|---|
| Total named nets on synced PCB | 40 | 69 |
| Drift nets recovered | 0 / 14 | 14 / 14 |
| `/`-prefixed net names | 14 ghost | 0 |
| `U3.1` assignment | `GND` (stale) | `BST_A` (sch-correct) |
| `U3.5` assignment | `+3.3V` (stale) | `BST_C` (sch-correct) |
| `U3.15` assignment | `+5V` (stale) | `SPI_MISO` (sch-correct) |
| `U3.17` assignment | `PWM_AH` (stale) | `DRV_FAULTn` (sch-correct) |

Boards 01–04, 06–07: sync runs cleanly with zero errors and zero `/`-prefixed net names on every board.

## Why the committed routed PCB is not updated

Applying sync to `boards/05-bldc-motor-controller/output/bldc_controller_routed.kicad_pcb` regresses U10 (STM32G431K8) pad assignments because of a *separate* schematic-emission bug in `design.py`: the SWDIO / SWCLK / ISENSE_B- / ISENSE_C- labels for U10.23 / U10.24 / U10.6 / U10.7 don't wire through the kicad-cli netlister (the wire stubs from `_connect_mcu_pin_to_label` collide with adjacent power rails, silently bridging the net before the label can take effect — visible in board-05 fresh-build warnings).

Updating the synced PCB would push the routed-PCB DRC error count from 6 (allowlist max) to 73, breaking `tests/test_board_05_drc_allowlist.py`. The acceptance criterion "Existing PR #3258 hot-spot regression test still passes (committed PCB invariant)" takes precedence over "fleet status no longer reports drift". The fleet status drift on board 05 will resolve once the schematic-emission bug is fixed in a follow-up.

## Tests

- 7 unit tests for `_normalize_kicad_cli_net_names` (single, power-rail, bare, empty, deeper-path, mixed, idempotency)
- 4 board-05 round-trip regression tests (drift nets present, net count ≥ 53, no `/`-prefixed names, U3 pad assignments)
- 9 unit tests for the drift-detector primitives (label / power symbol / `PWR_FLAG` / placeholder / pad-attached / pad-orphan / auto-generated / unreadable)

All 40 `tests/test_fleet_status.py` pass; all 254 `tests/test_pcb_sync*` and related sync tests pass; all 19 `tests/test_board_05_*` non-export/buck/thermal tests pass.

## Test plan

- [x] `_normalize_kicad_cli_net_names` unit tests (7/7)
- [x] Board-05 round-trip regression (4/4)
- [x] Drift detector primitives (9/9)
- [x] `tests/test_fleet_status.py` (40/40)
- [x] `tests/test_pcb_sync_netlist.py`, `test_netlist_sync.py`, `test_sync_*` (397/397)
- [x] `tests/test_board_05_*` (DRC allowlist, hotspot, drift regression, drv8308 pin nets, routing regression, zones) — 19/19
- [x] Sync sweep on boards 01-04, 06-07 (all clean, 0 errors, 0 `/`-prefixed names)

Closes #3370

🤖 Generated with [Claude Code](https://claude.com/claude-code)