### PR TITLE
fix(boards/05): U10 SWDIO/SWCLK/ISENSE wire-stub collision in _connect_mcu_pin_to_label

### DIFF
--- a/boards/05-bldc-motor-controller/design.py
+++ b/boards/05-bldc-motor-controller/design.py
@@ -44,6 +44,7 @@ from kicad_tools.schematic.blocks import (
     create_hall_sensor_input,
     create_mcu_decoupling_array,
 )
+from kicad_tools.schematic.blocks._stub_helpers import _stub_endpoint_would_collide
 from kicad_tools.schematic.models.schematic import Schematic
 
 # Warn if running source scripts with stale pipx install
@@ -462,59 +463,159 @@ def create_bldc_controller(output_dir: Path) -> Path:
     # local label so the netlist matches the PCB nets.
     def _connect_mcu_pin_to_label(pin_id: str, label_text: str, dx: int = 0, dy: int = 0):
         """Drop a wire from a MCU pin to a local label; the label provides the
-        net connection by name (e.g. ``GATE_AH``)."""
+        net connection by name (e.g. ``GATE_AH``).
+
+        Collision-aware (issue #3379): the naive single-stub form silently
+        bridges nets when the label coordinate lands on the interior of an
+        unrelated foreign wire. Board 05's MCU SWDIO / SWCLK / ISENSE_A-/B-/C-
+        / GND pins all suffered this: PHASE_A and PHASE_B wires from the
+        motor connector run east-to-west across U10's right-side label
+        row, and a vertical HallSensorInput rail at x=227.33 crosses
+        through both the +3.3V and GND label rows. kicad-cli reported
+        U10.23->PHASE_A, U10.24->PHASE_B, U10.14/16/32->+3.3V (instead
+        of the intended SWDIO/SWCLK/GND), regressing DRC from 6 to 73
+        violations after a fresh ``kct pcb sync-netlist --apply``.
+
+        This implementation tries the requested geometry first, then
+        escalates through (a) longer horizontal stub, (b) primary-side
+        with a small vertical offset, (c) opposite-side stub, and (d)
+        L-shaped stub (horizontal then vertical to a free row).  Raises
+        ``ValueError`` if no candidate is collision-free -- silent
+        net-bridging is unrecoverable at netlist time, so the failure
+        must surface loudly.
+        """
         pin_pos = mcu.pin_position(pin_id)
-        # Pin is on the symbol perimeter; pull a stub away from the body
-        # in the direction of dx/dy (the caller picks based on which side the
-        # pin lives on so the wire doesn't cross the body).
-        end_pos = (pin_pos[0] + dx, pin_pos[1] + dy)
-        sch.add_wire(pin_pos, end_pos, warn_on_collision=False)
-        sch.add_label(label_text, end_pos[0], end_pos[1], rotation=0, validate_connection=False)
 
-    # Power pins (VDD/VDDA = +3.3V, VSS/VSSA = GND) get wired straight to
-    # rails.  Pin 1 (VDD), 17 (VDD), 15 (VDDA) -> +3.3V.
-    # Pin 14 (VSSA), 16 (VSS), 32 (VSS) -> GND.
-    # Local labels so any pin sharing the same net gets electrically connected.
-    for vdd_pin in ["1", "17", "15"]:
-        _connect_mcu_pin_to_label(vdd_pin, "+3.3V", dx=-5, dy=0)
-    for vss_pin in ["14", "16", "32"]:
-        _connect_mcu_pin_to_label(vss_pin, "GND", dx=-5, dy=0)
+        # Build a list of candidate label endpoints in priority order.
+        # Each candidate is either a straight stub (one wire) or an
+        # L-shaped stub (two wires) terminating at ``(lx, ly)``.
+        primary_dx = dx if dx != 0 else 5  # default outward direction
+        opposite_dx = -primary_dx
+        grid = 2.54  # KiCad default grid
 
-    # Pin 4 = PG10 (configured as NRST)
-    _connect_mcu_pin_to_label("4", "NRST", dx=-5, dy=0)
+        # Straight-stub candidates: try the requested geometry, then
+        # progressively longer stubs in the same direction, then a
+        # slight vertical nudge, then the opposite direction.
+        straight: list[tuple[float, float]] = []
+        for k in (1, 2, 3, 4, 5, 6):
+            straight.append((pin_pos[0] + primary_dx * k, pin_pos[1] + dy))
+        for k in (1, -1, 2, -2):
+            straight.append((pin_pos[0] + primary_dx, pin_pos[1] + dy + grid * k))
+        if opposite_dx != primary_dx:
+            for k in (1, 2, 3):
+                straight.append((pin_pos[0] + opposite_dx * k, pin_pos[1] + dy))
 
-    # ADC current-sense returns: PA0/PA1/PA2 -> ISENSE_A-/B-/C-
-    _connect_mcu_pin_to_label("5", "ISENSE_A-", dx=5, dy=0)
-    _connect_mcu_pin_to_label("6", "ISENSE_B-", dx=5, dy=0)
-    _connect_mcu_pin_to_label("7", "ISENSE_C-", dx=5, dy=0)
+        # L-shaped candidates: horizontal stub to a midpoint, then
+        # vertical to a row above/below.  Used when no straight stub
+        # clears (SWDIO/SWCLK rely on this when the row is dense).
+        l_shaped: list[tuple[tuple[float, float], tuple[float, float]]] = []
+        for dy_off in (-grid, grid, -2 * grid, 2 * grid, -3 * grid, 3 * grid):
+            mid = (pin_pos[0] + primary_dx, pin_pos[1])
+            end = (mid[0], pin_pos[1] + dy_off)
+            l_shaped.append((mid, end))
 
-    # Hall sensor inputs: PA6/PA7/PB0 (TIM3 CH1/CH2/CH3 capable)
-    _connect_mcu_pin_to_label("11", "HALL_A", dx=5, dy=0)
-    _connect_mcu_pin_to_label("12", "HALL_B", dx=5, dy=0)
-    _connect_mcu_pin_to_label("13", "HALL_C", dx=5, dy=0)
+        def _endpoint_safe(point: tuple[float, float]) -> bool:
+            # Reject if the point lies on the interior of any existing
+            # wire (silent net-bridging risk).  ``_stub_endpoint_would_collide``
+            # also catches degenerate landing-on-existing-endpoint cases,
+            # but those usually mean the caller is wiring to an existing
+            # symbol pin -- conservative-reject is safer for MCU stubs.
+            # Check the SNAPPED endpoint coordinates so the check matches
+            # where the label actually lands after grid snapping.
+            sx = sch._snap_coord(point[0], "_connect_mcu_pin_to_label probe")
+            sy = sch._snap_coord(point[1], "_connect_mcu_pin_to_label probe")
+            return not _stub_endpoint_would_collide(sch, sx, sy)
 
-    # High-side gate PWM: PA8/PA9/PA10 (TIM1_CH1/CH2/CH3).  These drive the
-    # DRV8301 INH_A/B/C logic inputs (pins 17/19/21), not the MOSFET gates
-    # directly — gate output of the driver is GATE_DRV_*H, then through the
-    # R20/R21/R22 slew-rate resistors to GATE_*H on the MOSFET gates.
-    _connect_mcu_pin_to_label("18", "PWM_AH", dx=5, dy=0)
-    _connect_mcu_pin_to_label("19", "PWM_BH", dx=5, dy=0)
-    _connect_mcu_pin_to_label("20", "PWM_CH", dx=5, dy=0)
+        # Try straight stubs first.
+        for end_pos in straight:
+            if _endpoint_safe(end_pos):
+                sch.add_wire(pin_pos, end_pos, warn_on_collision=False)
+                sch.add_label(
+                    label_text,
+                    end_pos[0],
+                    end_pos[1],
+                    rotation=0,
+                    validate_connection=False,
+                )
+                return
 
-    # SWD debug pins
-    _connect_mcu_pin_to_label("23", "SWDIO", dx=5, dy=0)
-    _connect_mcu_pin_to_label("24", "SWCLK", dx=5, dy=0)
-    _connect_mcu_pin_to_label("26", "SWO", dx=5, dy=0)
+        # Fall back to L-shaped routing.  The label sits on the second
+        # wire's endpoint; check both the midpoint and the final endpoint
+        # for collisions.
+        for mid, end in l_shaped:
+            if _endpoint_safe(mid) and _endpoint_safe(end):
+                sch.add_wire(pin_pos, mid, warn_on_collision=False)
+                sch.add_wire(mid, end, warn_on_collision=False)
+                sch.add_label(
+                    label_text,
+                    end[0],
+                    end[1],
+                    rotation=0,
+                    validate_connection=False,
+                )
+                return
 
-    # Low-side gate PWM: PB6/PB7/PB8 (TIM4_CH1/CH2/CH3, sync'd with TIM1).
-    # Drives DRV8301 INL_A/B/C logic inputs (pins 18/20/22).
-    _connect_mcu_pin_to_label("29", "PWM_AL", dx=5, dy=0)
-    _connect_mcu_pin_to_label("30", "PWM_BL", dx=5, dy=0)
-    _connect_mcu_pin_to_label("31", "PWM_CL", dx=5, dy=0)
+        # No candidate worked.  Surface the failure loudly so the
+        # caller can move the MCU or split the colliding rail.
+        raise ValueError(
+            f"_connect_mcu_pin_to_label: cannot place label {label_text!r} for "
+            f"pin {pin_id} at {pin_pos} without colliding with a foreign wire. "
+            f"All straight and L-shaped stub candidates landed on existing "
+            f"wires (silent net-bridging risk). Move U10 or split the "
+            f"colliding rails."
+        )
 
-    # Crystal pins: PF0/PF1 -> OSC_IN/OSC_OUT
-    _connect_mcu_pin_to_label("2", "OSC_IN", dx=-5, dy=0)
-    _connect_mcu_pin_to_label("3", "OSC_OUT", dx=-5, dy=0)
+    # U10 pin-label emission is DEFERRED until after Sections 6-10 have
+    # added their wires (PHASE_A/B/C from J2, vertical HallSensorInput
+    # rails near x=227, +3.3V/GND symbol stubs near the bypass caps).
+    # Without deferral the collision check in ``_connect_mcu_pin_to_label``
+    # can't see those future wires, and labels end up silently bridged
+    # into PHASE_A / +3.3V / GND -- the original board 05 bug
+    # (issue #3379) that regressed DRC from 6 to 73 violations after a
+    # fresh sync-netlist. We record the desired (pin, label, dx, dy)
+    # tuples here and emit them at the end of Section 11, after every
+    # other section has finished drawing wires.
+    deferred_mcu_labels: list[tuple[str, str, int, int]] = [
+        # Power pins (VDD/VDDA = +3.3V, VSS/VSSA = GND) get wired
+        # straight to rails. Pin 1 (VDD), 17 (VDD), 15 (VDDA) -> +3.3V.
+        # Pin 14 (VSSA), 16 (VSS), 32 (VSS) -> GND.
+        ("1", "+3.3V", -5, 0),
+        ("17", "+3.3V", -5, 0),
+        ("15", "+3.3V", -5, 0),
+        ("14", "GND", -5, 0),
+        ("16", "GND", -5, 0),
+        ("32", "GND", -5, 0),
+        # Pin 4 = PG10 (configured as NRST)
+        ("4", "NRST", -5, 0),
+        # ADC current-sense returns: PA0/PA1/PA2 -> ISENSE_A-/B-/C-
+        ("5", "ISENSE_A-", 5, 0),
+        ("6", "ISENSE_B-", 5, 0),
+        ("7", "ISENSE_C-", 5, 0),
+        # Hall sensor inputs: PA6/PA7/PB0 (TIM3 CH1/CH2/CH3 capable)
+        ("11", "HALL_A", 5, 0),
+        ("12", "HALL_B", 5, 0),
+        ("13", "HALL_C", 5, 0),
+        # High-side gate PWM: PA8/PA9/PA10 (TIM1_CH1/CH2/CH3). These drive
+        # the DRV8301 INH_A/B/C logic inputs (pins 17/19/21), not the MOSFET
+        # gates directly -- gate output of the driver is GATE_DRV_*H, then
+        # through the R20/R21/R22 slew-rate resistors to GATE_*H on the
+        # MOSFET gates.
+        ("18", "PWM_AH", 5, 0),
+        ("19", "PWM_BH", 5, 0),
+        ("20", "PWM_CH", 5, 0),
+        # SWD debug pins
+        ("23", "SWDIO", 5, 0),
+        ("24", "SWCLK", 5, 0),
+        ("26", "SWO", 5, 0),
+        # Low-side gate PWM: PB6/PB7/PB8 (TIM4_CH1/CH2/CH3, sync'd with
+        # TIM1). Drives DRV8301 INL_A/B/C logic inputs (pins 18/20/22).
+        ("29", "PWM_AL", 5, 0),
+        ("30", "PWM_BL", 5, 0),
+        ("31", "PWM_CL", 5, 0),
+        # Crystal pins: PF0/PF1 -> OSC_IN/OSC_OUT
+        ("2", "OSC_IN", -5, 0),
+        ("3", "OSC_OUT", -5, 0),
+    ]
 
     # Unused STM32G431K8 GPIO pins (PA3-PA5, PA11-PA15, PB3-PB5 mapped to
     # LQFP-32 pins 8, 9, 10, 21, 22, 25, 27, 28).  This demo design does
@@ -524,7 +625,11 @@ def create_bldc_controller(output_dir: Path) -> Path:
         nc_pos = mcu.pin_position(nc_pin)
         sch.add_no_connect(nc_pos[0], nc_pos[1])
 
-    print("   Wired 16 floating nets (6 PWM, 3 HALL, 3 ISENSE-, 4 SWD) to MCU pins")
+    print(
+        f"   Deferred {len(deferred_mcu_labels)} U10 pin labels "
+        f"(6 PWM, 3 HALL, 3 ISENSE-, 4 SWD, 3 power, 1 NRST, 2 OSC); "
+        f"emitted after Section 11 (issue #3379)"
+    )
     print("   Marked 8 unused GPIO pins as no-connect (PA3-PA5, PA11-PA15, PB3-PB5)")
 
     # Crystal oscillator (8MHz)
@@ -815,7 +920,27 @@ def create_bldc_controller(output_dir: Path) -> Path:
             ref_start=10 + i,  # R10, R11, R12
             amplifier=False,  # No amplifier for basic sensing
         )
-        sense.connect_to_rails(gnd_rail_y=RAIL_GND)
+        # NOTE (issue #3379): we intentionally do NOT call
+        # ``sense.connect_to_rails(gnd_rail_y=RAIL_GND)`` here. That
+        # helper would wire the shunt's IN- pin straight down to the
+        # global GND rail, which short-circuits the ``ISENSE_X-`` label
+        # (placed on the same pin below) into the ``GND`` net.  The
+        # committed PCB and the U10 ADC topology treat ``ISENSE_X-``
+        # as a *separate* Kelvin-sense net (PCB nets 15/17/19),
+        # distinct from the bulk GND that carries phase current.  With
+        # the ``connect_to_rails`` call, kicad-cli collapses ISENSE_X-
+        # onto GND, then ``sync-netlist`` rewrites U10.5/6/7 ADC pins
+        # to ``GND`` instead of the intended ``ISENSE_X-`` nets --
+        # regressing the U10 round-trip that is the locus of #3379.
+        # The shunt's IN- pin is connected to GND *physically* via the
+        # LS MOSFET source / GND copper zone on the PCB; only the
+        # schematic label is needed for the netlister because
+        # ``ISENSE_X-`` is consumed only by the U10 ADC pins.  The
+        # IN+ side (R10/11/12.1) remains bridged to GND through the
+        # ``HalfBridge.connect_to_rails`` LS-source-to-GND wire -- a
+        # separate structural issue (the shunt should be in-line
+        # between LS source and GND, not in parallel) that is out of
+        # scope for #3379 and tracked elsewhere.
         current_sensors.append(sense)
 
         # Wire the inverter LS output to the current sense input
@@ -981,6 +1106,20 @@ def create_bldc_controller(output_dir: Path) -> Path:
         x=X_POWER_IN,
         y=RAIL_GND + 20,
     )
+
+    # =========================================================================
+    # Emit deferred U10 pin labels (issue #3379)
+    # =========================================================================
+    # Sections 5-10 added all the wires that could collide with U10's
+    # right-side label row (PHASE_A/B/C from J2, vertical
+    # HallSensorInput rails near x=227.33, bypass-cap rail stubs near
+    # the +3.3V/GND rows). Now that those wires exist, the collision
+    # check inside ``_connect_mcu_pin_to_label`` can see them and pick
+    # a non-bridging endpoint for each MCU pin label.
+    print("\n11b. Emitting deferred U10 pin labels (with collision avoidance)...")
+    for pin_id, label_text, dx, dy in deferred_mcu_labels:
+        _connect_mcu_pin_to_label(pin_id, label_text, dx=dx, dy=dy)
+    print(f"   Emitted {len(deferred_mcu_labels)} U10 pin labels")
 
     # =========================================================================
     # Validate Schematic

--- a/boards/05-bldc-motor-controller/output/bldc_controller.kicad_sch
+++ b/boards/05-bldc-motor-controller/output/bldc_controller.kicad_sch
@@ -2,7 +2,7 @@
 	(version 20231120)
 	(generator "eeschema")
 	(generator_version "9.0")
-	(uuid "6d5b711c-e8e4-4a79-9276-ebb98f41bf1e")
+	(uuid "c1f30df2-ebb7-4d3e-8f8e-34649100dccf")
 	(paper "A4")
 	(title_block
 		(title "BLDC Motor Controller")
@@ -1172,15 +1172,13 @@
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
-			(property "Footprint" "Package_TO_SOT_SMD:TO-263-5_TabPin3"
-				(at 1.27 -6.35 0)
+			(property "Reference" "U"
+				(at -10.16 6.35 0)
 				(show_name no)
 				(do_not_autoplace no)
-				(hide yes)
 				(effects
 					(font
 						(size 1.27 1.27)
-						(italic yes)
 					)
 					(justify left)
 				)
@@ -1196,7 +1194,7 @@
 					)
 				)
 			)
-			(property "ki_fp_filters" "TO?263*"
+			(property "Description" "5V 3A Step-Down Voltage Regulator, TO-263"
 				(at 0 0 0)
 				(show_name no)
 				(do_not_autoplace no)
@@ -1205,6 +1203,19 @@
 					(font
 						(size 1.27 1.27)
 					)
+				)
+			)
+			(property "Footprint" "Package_TO_SOT_SMD:TO-263-5_TabPin3"
+				(at 1.27 -6.35 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+						(italic yes)
+					)
+					(justify left)
 				)
 			)
 			(property "ki_keywords" "Step-Down Voltage Regulator 5V 3A"
@@ -1218,18 +1229,7 @@
 					)
 				)
 			)
-			(property "Reference" "U"
-				(at -10.16 6.35 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(justify left)
-				)
-			)
-			(property "Description" "5V 3A Step-Down Voltage Regulator, TO-263"
+			(property "ki_fp_filters" "TO?263*"
 				(at 0 0 0)
 				(show_name no)
 				(do_not_autoplace no)
@@ -1807,11 +1807,10 @@
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
-			(property "Footprint" "Package_TO_SOT_SMD:SOT-223-3_TabPin2"
-				(at 0 5.08 0)
+			(property "Reference" "U"
+				(at -3.81 3.175 0)
 				(show_name no)
 				(do_not_autoplace no)
-				(hide yes)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -1829,8 +1828,19 @@
 					)
 				)
 			)
-			(property "ki_fp_filters" "SOT?223*TabPin2*"
+			(property "Description" "1A Low Dropout regulator, positive, 3.3V fixed output, SOT-223"
 				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "Package_TO_SOT_SMD:SOT-223-3_TabPin2"
+				(at 0 5.08 0)
 				(show_name no)
 				(do_not_autoplace no)
 				(hide yes)
@@ -1851,17 +1861,7 @@
 					)
 				)
 			)
-			(property "Reference" "U"
-				(at -3.81 3.175 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "Description" "1A Low Dropout regulator, positive, 3.3V fixed output, SOT-223"
+			(property "ki_fp_filters" "SOT?223*TabPin2*"
 				(at 0 0 0)
 				(show_name no)
 				(do_not_autoplace no)
@@ -1952,16 +1952,15 @@
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
-			(property "Footprint" "Package_QFP:LQFP-32_7x7mm_P0.8mm"
-				(at -10.16 -22.86 0)
+			(property "Reference" "U"
+				(at -10.16 26.67 0)
 				(show_name no)
 				(do_not_autoplace no)
-				(hide yes)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
-					(justify right)
+					(justify left)
 				)
 			)
 			(property "Datasheet" "https://www.st.com/resource/en/datasheet/stm32g431k8.pdf"
@@ -1975,7 +1974,7 @@
 					)
 				)
 			)
-			(property "ki_fp_filters" "LQFP*7x7mm*P0.8mm*"
+			(property "Description" "STMicroelectronics Arm Cortex-M4 MCU, 64KB flash, 32KB RAM, 170 MHz, 1.71-3.6V, 26 GPIO, LQFP32"
 				(at 0 0 0)
 				(show_name no)
 				(do_not_autoplace no)
@@ -1984,6 +1983,18 @@
 					(font
 						(size 1.27 1.27)
 					)
+				)
+			)
+			(property "Footprint" "Package_QFP:LQFP-32_7x7mm_P0.8mm"
+				(at -10.16 -22.86 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify right)
 				)
 			)
 			(property "ki_keywords" "Arm Cortex-M4 STM32G4 STM32G4x1"
@@ -1997,18 +2008,7 @@
 					)
 				)
 			)
-			(property "Reference" "U"
-				(at -10.16 26.67 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(justify left)
-				)
-			)
-			(property "Description" "STMicroelectronics Arm Cortex-M4 MCU, 64KB flash, 32KB RAM, 170 MHz, 1.71-3.6V, 26 GPIO, LQFP32"
+			(property "ki_fp_filters" "LQFP*7x7mm*P0.8mm*"
 				(at 0 0 0)
 				(show_name no)
 				(do_not_autoplace no)
@@ -5008,7 +5008,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "db0081ed-9461-4477-ada2-0ca5021ccf5c")
+		(uuid "6c62c709-9720-4d11-90de-f8989ef424d8")
 		(property "Reference" "J1"
 			(at 25.4 95.25 0)
 			(effects
@@ -5043,13 +5043,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "4b61eb29-bc06-4c1d-b547-ae2aecf26213")
+		(pin "1" (uuid "5ba6c311-7ec1-44b3-868d-ac05bd453178")
 		)
-		(pin "2" (uuid "08e84bbb-d77f-48a1-b4d6-737061e437a1")
+		(pin "2" (uuid "8906808d-de65-4fdf-9346-836863400cad")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "J1") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "J1") (unit 1)
 				)
 			)
 		)
@@ -5062,7 +5062,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "5d57cb16-4719-468b-899e-9df6a084d89d")
+		(uuid "2ce4dec7-277d-40ff-aaa3-d5ed75434491")
 		(property "Reference" "F1"
 			(at 44.45 95.25 0)
 			(effects
@@ -5097,13 +5097,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "7c44f602-af92-4eb4-8915-0bafa6aeb80f")
+		(pin "1" (uuid "d0b58bdb-8ad9-4400-a98d-9fe7dfbfdf5e")
 		)
-		(pin "2" (uuid "040fea1f-67e1-4252-b0d7-2eae1ede2810")
+		(pin "2" (uuid "4d8ef11d-7140-4bb2-9dc8-55c35e41772d")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "F1") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "F1") (unit 1)
 				)
 			)
 		)
@@ -5116,7 +5116,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "23dcbebb-4476-4d4c-8426-aadaf8fdc070")
+		(uuid "92d35af5-81c9-49c7-b664-85a4e78098eb")
 		(property "Reference" "D1"
 			(at 64.77 114.3 0)
 			(effects
@@ -5151,13 +5151,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "ff3a04da-d847-4bc7-9ce1-8055c720de22")
+		(pin "1" (uuid "82d3ea1b-e8d7-4f27-9fe0-ee51bb5640c4")
 		)
-		(pin "2" (uuid "2e122c31-33a3-4b7f-b123-20d7a113e280")
+		(pin "2" (uuid "287ce8aa-40d3-4629-a40e-2cae92607dd6")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "D1") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "D1") (unit 1)
 				)
 			)
 		)
@@ -5170,7 +5170,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "981da90c-baab-4ec4-ad27-39621aab266f")
+		(uuid "bae37683-7656-4968-b283-49f5fcb1d1e8")
 		(property "Reference" "C1"
 			(at 80.01 114.3 0)
 			(effects
@@ -5205,13 +5205,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "01feaff7-479e-4ab7-a5d2-233ceecf1b50")
+		(pin "1" (uuid "44d03f52-2bd8-481a-a13c-65540a49abbd")
 		)
-		(pin "2" (uuid "3b806bf8-a024-4e4e-add7-818271868c9f")
+		(pin "2" (uuid "09be9645-7f44-436d-acb3-5b403d6ea318")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "C1") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "C1") (unit 1)
 				)
 			)
 		)
@@ -5224,7 +5224,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "efe23687-3469-404b-85f4-3425ff6668f5")
+		(uuid "00251745-4240-4c7b-a3ce-bdfffaca176c")
 		(property "Reference" "C2"
 			(at 95.25 114.3 0)
 			(effects
@@ -5259,13 +5259,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "7a232096-3965-45d9-84ff-6f6ac2a88881")
+		(pin "1" (uuid "203bd6d9-72be-4edf-b1ac-414bc52ef9a3")
 		)
-		(pin "2" (uuid "5fd23e21-8bc8-4a9c-8669-75ded0deb1a3")
+		(pin "2" (uuid "84befb33-a8dd-4ca1-a6fb-362571079a1c")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "C2") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "C2") (unit 1)
 				)
 			)
 		)
@@ -5278,7 +5278,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "29ff6fd4-e0ba-4b22-bc7e-73cb6091de59")
+		(uuid "553cb349-ede2-48cd-802a-7e5261a1a7c8")
 		(property "Reference" "U1"
 			(at 80.01 95.25 0)
 			(effects
@@ -5313,19 +5313,19 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "28d26f0f-79d8-4c32-b8bd-18774e8d7e61")
+		(pin "1" (uuid "6a767fc5-43ce-4b07-a902-a9ee5fa74300")
 		)
-		(pin "2" (uuid "3aa92a15-9479-443b-accc-3d142d5439fe")
+		(pin "2" (uuid "359937d9-aa25-488b-a277-d1848305a67a")
 		)
-		(pin "3" (uuid "792fc148-6e44-4108-ae0b-e505c91f57d0")
+		(pin "3" (uuid "61c0e194-48bc-451b-a8d3-805ddfdd0c3d")
 		)
-		(pin "4" (uuid "e592df3d-2d0a-46c5-8259-1b6127c7c8b2")
+		(pin "4" (uuid "6d646668-d709-4d01-9908-950cdc2813cd")
 		)
-		(pin "5" (uuid "bce6ea77-a687-47f4-930d-77573b53c391")
+		(pin "5" (uuid "39f5274b-156d-438b-a0db-27757a61b5d4")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "U1") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "U1") (unit 1)
 				)
 			)
 		)
@@ -5338,7 +5338,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "5caba3a7-ba34-465d-a705-9389e46c0ddf")
+		(uuid "51cfd5f1-566d-472f-b10b-769610a02f79")
 		(property "Reference" "C3"
 			(at 54.61 110.49 0)
 			(effects
@@ -5373,13 +5373,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "8ad04890-e8c8-4353-b4fd-61cabb174d4e")
+		(pin "1" (uuid "568bce83-592d-4655-a2ac-cea67f44eded")
 		)
-		(pin "2" (uuid "973a25f0-75ec-4f07-9f49-904ea7c04067")
+		(pin "2" (uuid "2e3505a1-66eb-4a87-adb9-47067cbcb69b")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "C3") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "C3") (unit 1)
 				)
 			)
 		)
@@ -5392,7 +5392,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "f8eef44b-85a8-4b54-974c-549deaab2933")
+		(uuid "af1a58c8-c220-47ab-8b67-6bc62461a332")
 		(property "Reference" "L1"
 			(at 105.41 95.25 0)
 			(effects
@@ -5427,13 +5427,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "a5cda141-fbfc-4966-9dcb-98c71d637acf")
+		(pin "1" (uuid "ed5046d9-ad7e-4831-9b44-d753b196ab2e")
 		)
-		(pin "2" (uuid "5f2d7c5a-3e68-462f-97e5-fa3cc3a14991")
+		(pin "2" (uuid "4fa3abb6-ee44-4527-8ba3-c8dc054910ee")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "L1") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "L1") (unit 1)
 				)
 			)
 		)
@@ -5446,7 +5446,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "c718657c-6f4e-4f6d-92c5-8bc040e216bc")
+		(uuid "112385f1-18f7-4ef5-88d8-3040b12456d5")
 		(property "Reference" "C4"
 			(at 129.54 110.49 0)
 			(effects
@@ -5481,13 +5481,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "70663e55-054a-42ee-a678-3f8a1e0cc02d")
+		(pin "1" (uuid "0a7e7a4a-e86c-40e3-ad29-9dbbc019e111")
 		)
-		(pin "2" (uuid "ce6f593b-1785-488b-9ae7-e267a062841c")
+		(pin "2" (uuid "de0f8dd6-43af-48bc-abf3-fd8e2ad8ae2a")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "C4") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "C4") (unit 1)
 				)
 			)
 		)
@@ -5500,7 +5500,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "0dac15fd-97fb-497b-86a2-06d378cd8aa5")
+		(uuid "907df258-c66d-4fb3-bcc5-462b71c45030")
 		(property "Reference" "D2"
 			(at 105.41 114.3 0)
 			(effects
@@ -5535,13 +5535,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "0674968b-db1a-4a34-8c63-2b0a21de027e")
+		(pin "1" (uuid "6f0463ff-c5c9-4efe-bc44-3bdf13f57f9a")
 		)
-		(pin "2" (uuid "7ddc2303-d367-48d9-833f-ffc92a0460fb")
+		(pin "2" (uuid "ed2c04e1-67c8-43d6-b8cb-1f44bd0d2d89")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "D2") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "D2") (unit 1)
 				)
 			)
 		)
@@ -5554,7 +5554,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "0468346b-62c4-49f1-9fad-3308b4a8c127")
+		(uuid "da0ee483-ecf1-4613-8617-73ffb7a91eea")
 		(property "Reference" "U2"
 			(at 139.7 95.25 0)
 			(effects
@@ -5589,15 +5589,15 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "9d8bdde0-83c9-4312-afe6-68e90c92227f")
+		(pin "1" (uuid "b427dc8a-a5f0-4019-a688-16db5cff9f4a")
 		)
-		(pin "2" (uuid "b55cc2c5-e25f-40b2-a1f5-65106b00dca2")
+		(pin "2" (uuid "2ebb46d0-b089-4185-9ef4-2240d4393d05")
 		)
-		(pin "3" (uuid "0d10efae-5b73-4234-b604-8f9d24e4c443")
+		(pin "3" (uuid "7d71ff3b-e9eb-42c0-9ff0-b3ab10b3b18f")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "U2") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "U2") (unit 1)
 				)
 			)
 		)
@@ -5610,7 +5610,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "122d5cd2-b90b-4ba5-a510-ae67839d6eae")
+		(uuid "83deac43-60b9-4299-a89c-19b69d4722fb")
 		(property "Reference" "C5"
 			(at 119.38 110.49 0)
 			(effects
@@ -5645,13 +5645,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "9b4632ad-0c55-4fcb-b9e0-d8cc61c1697b")
+		(pin "1" (uuid "f7b42137-b2f2-45f0-9d2e-9e035d9bfcb9")
 		)
-		(pin "2" (uuid "060a5db1-9733-4fab-8b82-41435f3f92af")
+		(pin "2" (uuid "cea61a34-7cc8-4c48-baed-b010ee823120")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "C5") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "C5") (unit 1)
 				)
 			)
 		)
@@ -5664,7 +5664,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "59c3fb2d-4eb2-4961-a04f-7cd60a781644")
+		(uuid "cff0bdb5-241c-4313-9709-0510f3d9ddd2")
 		(property "Reference" "C6"
 			(at 160.02 110.49 0)
 			(effects
@@ -5699,13 +5699,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "38f0d313-a1a8-4f86-a8e5-70d0f33e4384")
+		(pin "1" (uuid "1c46cfaf-33e3-4060-b5e3-6cd200114150")
 		)
-		(pin "2" (uuid "4afe19f0-c55c-4988-a2d9-a57c40a0f8cc")
+		(pin "2" (uuid "844df66d-dc8a-43f2-8208-ef34b3716bf8")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "C6") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "C6") (unit 1)
 				)
 			)
 		)
@@ -5718,7 +5718,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "5cabf2fb-cb3b-4006-a8f0-51cd2dd134da")
+		(uuid "fd95baa8-ca48-41af-be82-aa676c80a89a")
 		(property "Reference" "C7"
 			(at 199.39 95.25 0)
 			(effects
@@ -5753,13 +5753,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "85c9d089-f672-4fe1-bfc7-21ddf50b6d42")
+		(pin "1" (uuid "d22acc75-cd21-4720-89dd-0439f3951025")
 		)
-		(pin "2" (uuid "0efb4c5e-6031-4057-88c7-c7dfdb4dcb87")
+		(pin "2" (uuid "cfcfce2c-ddd1-407a-891b-f9f93bf2a254")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "C7") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "C7") (unit 1)
 				)
 			)
 		)
@@ -5772,7 +5772,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "969a47fd-c2e4-40df-b283-2061b10a255e")
+		(uuid "948052d1-080c-447d-80f4-dca68e855998")
 		(property "Reference" "C8"
 			(at 209.55 95.25 0)
 			(effects
@@ -5807,13 +5807,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "6a5f6fad-4476-433d-9d68-1d5a489386b8")
+		(pin "1" (uuid "044cde24-d192-43a4-b85c-9ba86d92212d")
 		)
-		(pin "2" (uuid "2de98d11-564d-4c46-ad88-12f1afc34f28")
+		(pin "2" (uuid "50fffc56-b2f8-45ed-bcbc-416ab4bc9db2")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "C8") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "C8") (unit 1)
 				)
 			)
 		)
@@ -5826,7 +5826,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "08280229-72d0-4196-a8cd-f448ce945a1a")
+		(uuid "e63ace97-d76e-458d-b6a4-bae41d8cced3")
 		(property "Reference" "C9"
 			(at 219.71 95.25 0)
 			(effects
@@ -5861,13 +5861,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "f350f8d4-9f16-40b2-a4c0-552f87ae3bf3")
+		(pin "1" (uuid "6e994e9a-572f-4b4b-b723-5289f7474e5c")
 		)
-		(pin "2" (uuid "f5024001-a7e8-44e3-81f3-0c1bbd2c19f5")
+		(pin "2" (uuid "1fec2bf7-eafd-4388-a57e-fe65bfaea756")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "C9") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "C9") (unit 1)
 				)
 			)
 		)
@@ -5880,7 +5880,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "600f4307-7915-4d48-aa3d-82d828802acf")
+		(uuid "eb0dbf33-b25f-430d-af88-43aa72b8201f")
 		(property "Reference" "U10"
 			(at 229.87 160.02 0)
 			(effects
@@ -5915,73 +5915,73 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "a778dec1-12c5-4285-9a2e-0be8cfb834bd")
+		(pin "1" (uuid "a8b03106-a941-4747-933f-a53f1c46130a")
 		)
-		(pin "2" (uuid "5c85349a-cfbf-41da-bc64-9f7a57cf9a70")
+		(pin "2" (uuid "d121b882-5b15-456c-8d9c-5a245404f6ab")
 		)
-		(pin "3" (uuid "55cb3a31-0b7b-4907-b294-bfeed05ce02a")
+		(pin "3" (uuid "790e7e3d-57f6-4fae-b8f9-5dd3d18854cb")
 		)
-		(pin "4" (uuid "c7163fc3-374e-4ae5-b88c-0394fa68fd8c")
+		(pin "4" (uuid "91184511-a541-41fd-be44-fffce684fbdb")
 		)
-		(pin "5" (uuid "8dcb6488-ba05-499a-a80a-bb4224419e61")
+		(pin "5" (uuid "51b50647-ccba-413a-8034-339fec66059b")
 		)
-		(pin "6" (uuid "69863648-18be-433b-90cf-d136622316bc")
+		(pin "6" (uuid "c7e4f49a-32c6-4847-a31f-c27999fcbf67")
 		)
-		(pin "7" (uuid "e3417018-aa93-4ffa-97d7-cf597c784249")
+		(pin "7" (uuid "7e402c28-018f-4c55-b184-efa6bd4ae66d")
 		)
-		(pin "8" (uuid "94aff6c0-64de-467d-834b-447246ed974c")
+		(pin "8" (uuid "de975b93-813d-443b-8c23-705abf865589")
 		)
-		(pin "9" (uuid "83d8a8a3-ce96-4b5b-82bf-9f72b4715b2b")
+		(pin "9" (uuid "6a451519-2a9b-4996-b479-c05d1a0ab3e7")
 		)
-		(pin "10" (uuid "c423ac27-4ddf-4db2-871f-fddaca46835d")
+		(pin "10" (uuid "74f5bf3d-f411-4360-ba62-010e31d50c38")
 		)
-		(pin "11" (uuid "a8b44dc9-61d6-4f32-b31a-c63cd903b6c7")
+		(pin "11" (uuid "f4d2249d-2110-4162-82f6-9264979167d0")
 		)
-		(pin "12" (uuid "efcad3a5-daad-4292-8c7a-b60a1236d714")
+		(pin "12" (uuid "ec467af8-068c-4aec-b1c8-963703790f2a")
 		)
-		(pin "13" (uuid "834e4356-2dc2-4a8c-9d8a-04a1d38c5601")
+		(pin "13" (uuid "17e7bda3-0cfe-4021-a346-37bfc050fec3")
 		)
-		(pin "14" (uuid "0c4f7d62-e789-4363-919a-a5938d23ced4")
+		(pin "14" (uuid "3ff4685d-8f04-4bc8-b02e-8da9efce83ad")
 		)
-		(pin "15" (uuid "bdfde442-f973-4ce1-b6b2-d55de766392c")
+		(pin "15" (uuid "bb8191d3-208b-4287-9794-5ea88bfd8b64")
 		)
-		(pin "16" (uuid "70e02344-445f-43d4-8521-87f5e1854d0d")
+		(pin "16" (uuid "062e2ef9-7496-4337-a985-27e03606a782")
 		)
-		(pin "17" (uuid "7108379c-afee-429e-a377-d5f0f7f28c81")
+		(pin "17" (uuid "44de71d0-7056-40b2-93b1-1ef884caec40")
 		)
-		(pin "18" (uuid "0275b756-0530-4e84-b046-9a39d5b3237a")
+		(pin "18" (uuid "72c7e024-8d6f-4e8d-8d9e-0967dd7cfeff")
 		)
-		(pin "19" (uuid "a289e072-f683-45ad-8d15-159786b30ba1")
+		(pin "19" (uuid "243a68ee-2d08-480c-bba5-5f3081cffec0")
 		)
-		(pin "20" (uuid "89ffee08-7134-49e5-bff6-afe42b3fc235")
+		(pin "20" (uuid "93a40ce3-17da-489c-9c9f-39b192f60043")
 		)
-		(pin "21" (uuid "6e592955-d956-4051-b41e-1412ab81eaa2")
+		(pin "21" (uuid "5f024c03-d993-4c27-b8da-198f50fa4578")
 		)
-		(pin "22" (uuid "b9665dd3-e5be-42cc-8515-b98393baa2dd")
+		(pin "22" (uuid "c4453cb1-0953-400d-9d52-bb579638f7f3")
 		)
-		(pin "23" (uuid "7857c504-6fdf-4921-8c7e-339f59b002c7")
+		(pin "23" (uuid "ebfb349c-b066-42ab-8da6-1741cca78431")
 		)
-		(pin "24" (uuid "23ad2f09-bb45-4bfc-b857-3abbf30f331c")
+		(pin "24" (uuid "fdd80cfc-216f-4884-a786-1375e508a773")
 		)
-		(pin "25" (uuid "e1f87da2-ae94-4819-bb5e-40c8fd7cea15")
+		(pin "25" (uuid "395ce0f0-91a2-46da-beb0-b3d8f076a8e6")
 		)
-		(pin "26" (uuid "c555b575-4a7c-421d-bafc-b7c43bf67381")
+		(pin "26" (uuid "186ebf8e-c3ce-43e1-a8d3-42262f52cb86")
 		)
-		(pin "27" (uuid "040409ca-4cee-464e-ad49-ed0da89277b5")
+		(pin "27" (uuid "a7274798-3a8a-4200-a37f-24227ff2b0c6")
 		)
-		(pin "28" (uuid "5852f641-a209-4a29-8d7b-27928d09cacc")
+		(pin "28" (uuid "753a0c1d-3890-409e-af7a-c3244558903a")
 		)
-		(pin "29" (uuid "b0d6da14-82bd-4265-9efd-3339954b603a")
+		(pin "29" (uuid "51175e86-6b12-4906-bab0-55e50452d1a7")
 		)
-		(pin "30" (uuid "5b3aa046-e4f1-42c8-89eb-5a61e10bfc1c")
+		(pin "30" (uuid "1b14176b-7e5d-44b2-a4f7-c1387e65f3f1")
 		)
-		(pin "31" (uuid "09b34b14-1d27-4d3f-a5d4-dd6584155d30")
+		(pin "31" (uuid "b1e7528a-cf1a-49db-bdae-d57767b26146")
 		)
-		(pin "32" (uuid "9ec861b7-0ed5-4946-95f5-c168ba2d10b3")
+		(pin "32" (uuid "2c26497b-d49b-4793-b24a-90512526606b")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "U10") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "U10") (unit 1)
 				)
 			)
 		)
@@ -5994,7 +5994,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "ee1ef71c-1952-439f-8a9a-d984537653a5")
+		(uuid "675b1dda-3e5d-49af-bbad-63f0863b50b7")
 		(property "Reference" "Y1"
 			(at 270.51 95.25 0)
 			(effects
@@ -6029,13 +6029,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "2d9ce87a-d6b7-4679-8690-d7e3e682168a")
+		(pin "1" (uuid "945daa1d-b804-4198-843c-67a8943ac1bb")
 		)
-		(pin "2" (uuid "5ee7b61a-a02a-471f-9ea7-2fed4fc4d25e")
+		(pin "2" (uuid "49bcfdac-64ac-4ca6-aca2-19afbbad1224")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "Y1") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "Y1") (unit 1)
 				)
 			)
 		)
@@ -6048,7 +6048,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "29eb2aec-73ba-490d-a045-cc2984aad459")
+		(uuid "2a475b41-1a48-4bb6-b916-ba3ebbfc7ecf")
 		(property "Reference" "C10"
 			(at 262.89 110.49 0)
 			(effects
@@ -6083,13 +6083,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "2d9a4407-0d54-4722-9c8b-ca12161d9f49")
+		(pin "1" (uuid "fe40968d-a77d-4bbe-acb4-0d1abf49becd")
 		)
-		(pin "2" (uuid "39ec99f4-a03a-4919-a0d0-c0ef7edcd199")
+		(pin "2" (uuid "3851beae-a4c4-470d-b5ec-8de48de8bc2d")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "C10") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "C10") (unit 1)
 				)
 			)
 		)
@@ -6102,7 +6102,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "35ba6a4f-d499-49a4-aef8-8fdedbc99fd9")
+		(uuid "19fd1e39-1ab0-4e7d-9e7d-048a178a1f6b")
 		(property "Reference" "C11"
 			(at 278.13 110.49 0)
 			(effects
@@ -6137,13 +6137,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "2d8cfba0-415e-4450-a716-d33c45f882a0")
+		(pin "1" (uuid "40bea713-e2e1-43ea-8460-9c3b249e397a")
 		)
-		(pin "2" (uuid "dcb64c39-87ed-42c2-b46e-771a18466bf8")
+		(pin "2" (uuid "60f45f8e-5d26-4901-bcfe-c5e13de0be05")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "C11") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "C11") (unit 1)
 				)
 			)
 		)
@@ -6156,7 +6156,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "95afbf8f-9c9e-4621-8165-9d3f2df81bf6")
+		(uuid "77381429-6982-4b72-8ead-42f439acc6fc")
 		(property "Reference" "J4"
 			(at 299.72 95.25 0)
 			(effects
@@ -6191,21 +6191,21 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "c7a0601d-18dd-47f3-a04d-15a651b55aae")
+		(pin "1" (uuid "7b123c5e-84db-49db-b89d-93acf0ff28f9")
 		)
-		(pin "2" (uuid "57c2fb61-8b84-497c-b28e-38d518ff6865")
+		(pin "2" (uuid "b1582f98-310b-4173-8542-9e809721e9fb")
 		)
-		(pin "3" (uuid "b943b883-6a40-4219-810e-e7460a6cc4b6")
+		(pin "3" (uuid "47a951b2-2f29-4bc4-b05e-cd8d8127d3f7")
 		)
-		(pin "4" (uuid "596c1123-81f6-459a-9734-5d7a9d374c0a")
+		(pin "4" (uuid "1fe6718a-a234-417d-bfc8-d9effc933dd4")
 		)
-		(pin "5" (uuid "7a11800c-5716-4531-84b9-6c682afa9e95")
+		(pin "5" (uuid "9b9f47d4-5da8-4854-b16a-098b8a3b9ff0")
 		)
-		(pin "6" (uuid "334d0847-e65a-4ff0-b86b-1efc9f48dff4")
+		(pin "6" (uuid "6aaf65cc-a0e9-4cc4-849f-f1fa371d9e3f")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "J4") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "J4") (unit 1)
 				)
 			)
 		)
@@ -6218,7 +6218,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "9e2acc84-5020-4dce-81bd-920c1ca188fd")
+		(uuid "b061f5c3-53fe-44cf-9d4a-7cfc0d09435e")
 		(property "Reference" "U3"
 			(at 279.4 91.44 0)
 			(effects
@@ -6253,91 +6253,91 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "9c221310-9edb-41b7-92f3-0762b80ac568")
+		(pin "1" (uuid "ab49e59f-a794-461d-bbed-8297270172ad")
 		)
-		(pin "2" (uuid "1d7a65a5-f1a0-493d-86b2-504a9dd0bbfd")
+		(pin "2" (uuid "def9d1cb-78a1-47ef-a89c-809ea10fcf96")
 		)
-		(pin "3" (uuid "83f0dedb-7ffa-4c2b-8e4a-79d9e534c7c6")
+		(pin "3" (uuid "ee28ffa9-cff8-44c9-8192-b94589f0eb81")
 		)
-		(pin "4" (uuid "b381ed4c-0f0e-4efb-95c2-9ab1bb7dda8b")
+		(pin "4" (uuid "17476b8d-e218-4a00-85a9-b61b9f6a9b3d")
 		)
-		(pin "5" (uuid "f9108334-4f34-4efb-a8d6-a05d4458b2e6")
+		(pin "5" (uuid "2c4730fe-392a-44a1-b6b8-a1d413292c98")
 		)
-		(pin "6" (uuid "eede6eae-554d-40f3-a7dd-89c481c89c65")
+		(pin "6" (uuid "ed304a2c-6ddb-4d4c-9796-96536e399822")
 		)
-		(pin "7" (uuid "3ab86983-dca1-47a4-88fd-d76452a14883")
+		(pin "7" (uuid "ccb787db-e302-469f-8a14-a16f49b8ce22")
 		)
-		(pin "8" (uuid "ee25a648-cc44-407f-9fac-72927fd16a20")
+		(pin "8" (uuid "dfdeb9d9-76ea-4d8c-a255-ba673e9830ae")
 		)
-		(pin "9" (uuid "fbe6a7cd-f9ff-4810-b008-c7131d2e279c")
+		(pin "9" (uuid "52b62e75-2d10-4ab3-aa32-a205575a9d73")
 		)
-		(pin "10" (uuid "850e7a84-4db9-4a13-b139-d9fe1fcb906f")
+		(pin "10" (uuid "8c64b069-5396-4a08-930b-65145d7bae84")
 		)
-		(pin "11" (uuid "393d3ca8-e8ce-47fc-85ce-97b53bb58626")
+		(pin "11" (uuid "3e900bd4-d949-4ff7-a85f-f84ab36580b5")
 		)
-		(pin "12" (uuid "794270ac-dff9-4298-bcd7-fcbad234e45b")
+		(pin "12" (uuid "5ca789e3-83b9-48a4-bdb5-730f65429d37")
 		)
-		(pin "13" (uuid "5b54e088-4d2b-4fad-a436-f922082f86ec")
+		(pin "13" (uuid "314afbe7-f6e9-44e1-bd36-d0a285146d3b")
 		)
-		(pin "14" (uuid "060a297a-a936-4889-a506-a81b44f2c11e")
+		(pin "14" (uuid "99794da0-64df-45e0-b6a9-b7af5a23806a")
 		)
-		(pin "15" (uuid "3c3e3890-8ef8-427c-a20c-f9fc1ac1e773")
+		(pin "15" (uuid "dc2463ed-985a-456f-86d2-cc134d7073ba")
 		)
-		(pin "16" (uuid "cce5aadc-7a60-4465-a6e0-e25b8e60e011")
+		(pin "16" (uuid "c681558f-bdbf-48c8-a475-aee67cac5e39")
 		)
-		(pin "17" (uuid "7d04de60-eec3-45a6-a9cf-7756ea7f6e60")
+		(pin "17" (uuid "aec5e678-3910-498b-ac2d-93a5079ef7e5")
 		)
-		(pin "18" (uuid "fcccff10-a5e3-48f2-8991-14f2239bfcdc")
+		(pin "18" (uuid "331bf1f9-9436-40d3-afa1-60e811c4888c")
 		)
-		(pin "19" (uuid "b2cd553e-0381-4fa4-ac67-726060e3c70f")
+		(pin "19" (uuid "714bd440-22c8-42f3-ae27-c89d3b41fabc")
 		)
-		(pin "20" (uuid "b5807a3d-c53d-441d-a6da-06e443f17c49")
+		(pin "20" (uuid "2bc5ecaf-dcd0-4a5d-9e43-0f43e06fa6f9")
 		)
-		(pin "21" (uuid "30c4e232-3578-4684-b75f-c79bb57ad523")
+		(pin "21" (uuid "75c5fd1d-8912-44ff-87ec-8b67159e367e")
 		)
-		(pin "22" (uuid "51137829-1772-4056-9623-c2d935c377f9")
+		(pin "22" (uuid "0f8a96ea-4585-48d0-af1d-e57cb4938599")
 		)
-		(pin "23" (uuid "82cdbae1-56d2-4be1-800a-456fb83848ac")
+		(pin "23" (uuid "0f51e9a6-3369-4cd6-bc3f-9ead1939a0d1")
 		)
-		(pin "24" (uuid "e92ac70d-5a47-4eed-9566-b7ecb1563ba8")
+		(pin "24" (uuid "8165fa45-4991-4f7b-a691-e4ba68eacdb3")
 		)
-		(pin "25" (uuid "bca94e73-687b-44b5-82d3-9919b9550d0c")
+		(pin "25" (uuid "e2d8a5c4-81a4-48d9-9449-4d116308bcae")
 		)
-		(pin "26" (uuid "c639f744-b1bb-4861-bd3a-6d54b2871e7e")
+		(pin "26" (uuid "8fa90d24-3acd-4ba0-bf99-60e2bfc47825")
 		)
-		(pin "27" (uuid "75f9b469-6081-4356-88ce-9d87cf78459e")
+		(pin "27" (uuid "fcb4d2e8-e47f-4dd1-8a52-f14f8834d750")
 		)
-		(pin "28" (uuid "67fbeb7f-6fda-4dbf-95fd-a372a843fcf3")
+		(pin "28" (uuid "30fbc31c-7a97-42e8-846c-eaf7cf4f7759")
 		)
-		(pin "29" (uuid "01bc95fa-f595-40db-bd4e-506bdda609d5")
+		(pin "29" (uuid "9ee515e0-54cd-4b7c-a434-3745f2837461")
 		)
-		(pin "30" (uuid "5639a113-4834-45b3-95f2-8ceec33970dc")
+		(pin "30" (uuid "7e9d4ecf-3f15-4db4-92d9-ac6fa1155367")
 		)
-		(pin "31" (uuid "a244f636-a677-4504-a177-57daa64e0a23")
+		(pin "31" (uuid "83e963a1-61c3-4fde-80d8-2ad128f96506")
 		)
-		(pin "32" (uuid "9b8b9903-05da-4f70-b16a-ea8d095059f9")
+		(pin "32" (uuid "488ccd59-8130-4f6c-99d8-9857ec8ccc39")
 		)
-		(pin "33" (uuid "f9da3524-7df7-4059-83cf-cf9dfb23cd81")
+		(pin "33" (uuid "e5172b4d-eff6-4243-b4b7-caedacc1244b")
 		)
-		(pin "34" (uuid "39d345b3-e482-4a9d-89ee-1d92d37d5c3e")
+		(pin "34" (uuid "4207e1aa-533d-4aaf-85b4-d60e7fdbba52")
 		)
-		(pin "35" (uuid "9f73060b-98a9-4700-8234-9123308dc617")
+		(pin "35" (uuid "fb7c98e8-4f36-454c-8553-771ae48cdfab")
 		)
-		(pin "36" (uuid "7184d47a-2dd4-4eb2-abce-9daf9e17c6f1")
+		(pin "36" (uuid "051bdc3c-d9a9-4863-a916-1f5a0763c032")
 		)
-		(pin "37" (uuid "5204c683-f11e-42c4-9291-40c671286eaf")
+		(pin "37" (uuid "b0446eef-4288-444c-9e8c-cdc5ad14c7f8")
 		)
-		(pin "38" (uuid "6fcca7bd-4d18-4b74-968c-61e9bec43ddf")
+		(pin "38" (uuid "e1e37df5-75f2-4dd2-9b3e-3f50f9bfaab5")
 		)
-		(pin "39" (uuid "cb780029-22b8-411b-9027-d389670531de")
+		(pin "39" (uuid "d9342a05-14bb-4c3d-9d8f-70ab432c603a")
 		)
-		(pin "40" (uuid "b3ba2286-2271-4350-8775-f9d8211c912f")
+		(pin "40" (uuid "5df20276-fba0-4fad-868a-dfb5b35236e0")
 		)
-		(pin "41" (uuid "18ef5e4b-215e-4a8b-9c5d-4a61e3f36bdd")
+		(pin "41" (uuid "6dbcb8b6-6821-4b56-a34d-4656da9412d3")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "U3") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "U3") (unit 1)
 				)
 			)
 		)
@@ -6350,7 +6350,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "725af423-cdeb-441c-a433-70fe6febd448")
+		(uuid "4fb07816-65b1-44aa-a762-0ce597304775")
 		(property "Reference" "C15"
 			(at 299.72 76.2 0)
 			(effects
@@ -6385,13 +6385,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "f5df1978-4382-42d7-bdd7-551f26faf5f5")
+		(pin "1" (uuid "c482a0d2-8534-4ff9-a85a-e51eebfe6786")
 		)
-		(pin "2" (uuid "2a3af6e9-2ef5-464a-a741-8b5ae2a26f83")
+		(pin "2" (uuid "fed0379e-796c-43c5-b19d-4adf60d0c054")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "C15") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "C15") (unit 1)
 				)
 			)
 		)
@@ -6404,7 +6404,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "629d2686-b6c6-4248-9458-3d1bd28100ba")
+		(uuid "9853ada3-3335-4225-94f3-fb6665ad9adb")
 		(property "Reference" "C16"
 			(at 309.88 76.2 0)
 			(effects
@@ -6439,13 +6439,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "0834f480-12bc-4983-9795-5a2922afc43f")
+		(pin "1" (uuid "b7ba84ac-22f3-4d7e-939f-857873d2030c")
 		)
-		(pin "2" (uuid "4cfdab4c-5c49-4907-ae09-95808025b6c5")
+		(pin "2" (uuid "0115d539-6897-49cc-9ac1-00332ff65286")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "C16") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "C16") (unit 1)
 				)
 			)
 		)
@@ -6458,7 +6458,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "c1810eeb-2373-4879-8dd2-12be17618bc4")
+		(uuid "5b044c07-f9d9-4111-abb9-89a0fc944c7d")
 		(property "Reference" "C12"
 			(at 260.35 74.93 0)
 			(effects
@@ -6493,13 +6493,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "94c5eef5-e3a6-4dbe-956d-01b8a0563d0c")
+		(pin "1" (uuid "b207ec4a-ae3c-410c-a207-2dc02a2b4311")
 		)
-		(pin "2" (uuid "854dcabd-e63d-494f-808b-595d5a4303c5")
+		(pin "2" (uuid "287e4b98-1c78-4de6-b340-565d22da2845")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "C12") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "C12") (unit 1)
 				)
 			)
 		)
@@ -6512,7 +6512,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "cce645a1-eb8e-4269-ab58-888f4e5ab932")
+		(uuid "9172dd9e-11c7-4106-82a5-8f4aedf8a0c0")
 		(property "Reference" "C13"
 			(at 270.51 74.93 0)
 			(effects
@@ -6547,13 +6547,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "738f2ea9-356e-4708-9191-d9b8722a082a")
+		(pin "1" (uuid "a95eb60e-c61a-4da7-8838-c8bd3970ad5e")
 		)
-		(pin "2" (uuid "2de1f35a-394d-44c2-8585-16f010139d12")
+		(pin "2" (uuid "a7462202-a288-406b-b194-02446685e412")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "C13") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "C13") (unit 1)
 				)
 			)
 		)
@@ -6566,7 +6566,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "f9443df6-2d94-455c-b432-292528bd82fe")
+		(uuid "e31a6a21-6db0-4f68-ac09-5382ac42e772")
 		(property "Reference" "C14"
 			(at 279.4 74.93 0)
 			(effects
@@ -6601,13 +6601,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "0ebbf1e1-d29f-4d0a-b076-1fbb3ba21e54")
+		(pin "1" (uuid "2eb1822c-8f18-4ed1-97f7-7fc76202b877")
 		)
-		(pin "2" (uuid "3c61c434-e2e2-4bc4-a7e0-d799c7f2d3cf")
+		(pin "2" (uuid "7b0e9d5b-eb62-4ec1-a179-840a1c180844")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "C14") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "C14") (unit 1)
 				)
 			)
 		)
@@ -6620,7 +6620,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "4e352ad9-96ec-42af-bb09-533ad6b80167")
+		(uuid "952823a2-459a-4e79-9db1-318815b7c23a")
 		(property "Reference" "R20"
 			(at 309.88 114.3 0)
 			(effects
@@ -6664,13 +6664,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "dafc32b7-eda6-46a2-a574-ca1447868627")
+		(pin "1" (uuid "a8213afe-602e-4f19-9714-ebed6ee0292e")
 		)
-		(pin "2" (uuid "339c081c-29a6-4772-ae70-cb53a703a14c")
+		(pin "2" (uuid "e16d02e9-f6a7-48f6-8ab9-826f2b1e995d")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "R20") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "R20") (unit 1)
 				)
 			)
 		)
@@ -6683,7 +6683,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "eaad2965-4ef2-42b8-8bbe-2df7b3e82300")
+		(uuid "0ca48d0f-2934-4c67-8580-ba028507a843")
 		(property "Reference" "R21"
 			(at 320.04 114.3 0)
 			(effects
@@ -6727,13 +6727,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "f4a13a61-4c4e-4a11-af95-200ac33bea25")
+		(pin "1" (uuid "434708e8-9ef0-4417-b115-ab58e22d5f9e")
 		)
-		(pin "2" (uuid "102a85a8-fc7e-4bbf-83bd-2f17983eefad")
+		(pin "2" (uuid "4a336ef7-1fd9-4a96-ab69-b5a2c7665700")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "R21") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "R21") (unit 1)
 				)
 			)
 		)
@@ -6746,7 +6746,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "135d9ccd-ffea-4a04-a9b8-cc9b8d547d0c")
+		(uuid "d72073f3-ad66-44e2-96ad-74601910b8f0")
 		(property "Reference" "R22"
 			(at 330.2 114.3 0)
 			(effects
@@ -6790,13 +6790,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "f742394c-9680-4b79-9c62-9d47f2576a7b")
+		(pin "1" (uuid "ed003cb3-f689-4dd5-9afa-1fa9bde52b84")
 		)
-		(pin "2" (uuid "e1d278cd-fdf9-4482-97c2-599dd88d5723")
+		(pin "2" (uuid "005426b7-4096-465d-a238-ac6672f262aa")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "R22") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "R22") (unit 1)
 				)
 			)
 		)
@@ -6809,7 +6809,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "ccd5198b-0e3b-43d5-bf9b-b12dacf05223")
+		(uuid "e5c18f6f-43c1-4dae-bd40-c9c0fa3b533a")
 		(property "Reference" "Q1"
 			(at 25.4 154.94 0)
 			(effects
@@ -6862,15 +6862,15 @@
 				(hide yes)
 			)
 		)
-		(pin "D" (uuid "0630a743-bb7f-4c0b-8e51-2fff124a9576")
+		(pin "D" (uuid "73a242d7-5e94-49a3-8c35-286b6ca76633")
 		)
-		(pin "G" (uuid "63cbc9f4-8740-466a-91e9-f60a647d9ea2")
+		(pin "G" (uuid "5842604a-0c3e-453a-ac3f-93da5ec45821")
 		)
-		(pin "S" (uuid "ddb48240-09a4-4d26-b991-e245a52b9202")
+		(pin "S" (uuid "c9bc52ff-92da-4df2-aff9-e6570ecb79c8")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "Q1") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "Q1") (unit 1)
 				)
 			)
 		)
@@ -6883,7 +6883,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "239329a8-6ba4-45c3-b5ae-c66fe6807579")
+		(uuid "bafedebf-9c4d-4028-ba02-aa94c2016ebc")
 		(property "Reference" "Q2"
 			(at 25.4 194.31 0)
 			(effects
@@ -6936,15 +6936,15 @@
 				(hide yes)
 			)
 		)
-		(pin "D" (uuid "5f0262a0-ef44-4153-9d06-1ecfb9baffad")
+		(pin "D" (uuid "9cebc415-5acb-40a8-9e1f-2c7254767f8a")
 		)
-		(pin "G" (uuid "96d5c658-1563-41d8-ad02-0562a094d9fa")
+		(pin "G" (uuid "f8198f40-6b21-4c7a-999c-54428a758cef")
 		)
-		(pin "S" (uuid "153b7c20-39af-4051-a8e3-3bf97359e73c")
+		(pin "S" (uuid "df779913-b8f3-4fe0-8217-8be9f88ee700")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "Q2") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "Q2") (unit 1)
 				)
 			)
 		)
@@ -6957,7 +6957,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "d93d1264-c003-47b6-9280-3856f5cb5581")
+		(uuid "4c439bcd-d296-431e-942e-a64dfe5d8d9d")
 		(property "Reference" "Q3"
 			(at 100.33 154.94 0)
 			(effects
@@ -7010,15 +7010,15 @@
 				(hide yes)
 			)
 		)
-		(pin "D" (uuid "f00cce93-e008-4794-93de-43126fe8bde7")
+		(pin "D" (uuid "d8a5d226-f306-43e4-a282-fdad41a92d04")
 		)
-		(pin "G" (uuid "48bd3296-5b37-4049-b33b-63ddc323a283")
+		(pin "G" (uuid "0e4d171e-dabb-4420-bbdb-f104a73be5f7")
 		)
-		(pin "S" (uuid "1996fc06-05c4-45f6-83e7-cda860f62f5e")
+		(pin "S" (uuid "22ae04bb-d5b7-42d6-8af2-fe2124bbb548")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "Q3") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "Q3") (unit 1)
 				)
 			)
 		)
@@ -7031,7 +7031,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "2ceb178f-673a-4d43-b574-b638c6455285")
+		(uuid "aa8522a5-7916-441e-b795-69190622fb5d")
 		(property "Reference" "Q4"
 			(at 100.33 194.31 0)
 			(effects
@@ -7084,15 +7084,15 @@
 				(hide yes)
 			)
 		)
-		(pin "D" (uuid "23940a44-03c8-4f27-9fca-5778fbc3581b")
+		(pin "D" (uuid "acf3cc0c-738f-4a12-b0eb-7a3405ca8442")
 		)
-		(pin "G" (uuid "bbe5ff04-f05f-4e06-a407-d7e15292b1e1")
+		(pin "G" (uuid "00489791-d9c8-40bd-ba75-71a81c051f54")
 		)
-		(pin "S" (uuid "729b385f-6b91-4ea6-8602-70c568dd5238")
+		(pin "S" (uuid "b0db269e-0874-48fa-891f-099f52779b2c")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "Q4") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "Q4") (unit 1)
 				)
 			)
 		)
@@ -7105,7 +7105,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "cc180ab7-1024-4cfd-a43e-9e5a01a67605")
+		(uuid "8298fa77-4e7a-48ce-addf-01455c8279a8")
 		(property "Reference" "Q5"
 			(at 175.26 154.94 0)
 			(effects
@@ -7158,15 +7158,15 @@
 				(hide yes)
 			)
 		)
-		(pin "D" (uuid "718e134f-b000-4387-a53c-61ec439efa45")
+		(pin "D" (uuid "59746a5c-794b-4c0c-8bb6-061883ae3ce0")
 		)
-		(pin "G" (uuid "8546681f-a679-487f-9f4e-b7c5039bf168")
+		(pin "G" (uuid "7388985e-fc0a-4c64-8e12-d6c5fc106df5")
 		)
-		(pin "S" (uuid "ebca3957-b1b5-4140-b372-c1370c902b7a")
+		(pin "S" (uuid "1e0183d7-1137-42a8-8f2a-b84101df0b4a")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "Q5") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "Q5") (unit 1)
 				)
 			)
 		)
@@ -7179,7 +7179,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "a0402b03-aeb7-496b-9b55-71ba30597873")
+		(uuid "08e97f65-1794-49ab-855a-04a38b724e6f")
 		(property "Reference" "Q6"
 			(at 175.26 194.31 0)
 			(effects
@@ -7232,15 +7232,15 @@
 				(hide yes)
 			)
 		)
-		(pin "D" (uuid "1545419e-008f-43d9-948c-7b26a205a1f8")
+		(pin "D" (uuid "791444e4-ce29-416b-987a-15eb3c979e98")
 		)
-		(pin "G" (uuid "9cf7ac94-d9a3-4751-af4a-10e89e066fa3")
+		(pin "G" (uuid "6d1813d4-996c-4a29-b638-591f603544f7")
 		)
-		(pin "S" (uuid "f92f9c2d-6c1a-4834-a605-03a70101e56b")
+		(pin "S" (uuid "291d5ea5-620f-4c41-b2ad-23d442d482b4")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "Q6") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "Q6") (unit 1)
 				)
 			)
 		)
@@ -7253,7 +7253,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "0d242549-8e20-4009-8c8a-a85f58ed95c7")
+		(uuid "f2302937-1630-4616-a05e-83907eadd575")
 		(property "Reference" "R10"
 			(at 25.4 234.95 0)
 			(effects
@@ -7306,13 +7306,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "9699b62d-ca55-4144-bc8b-cef843a69e5b")
+		(pin "1" (uuid "c2e0b794-7325-43ad-a83b-816446903404")
 		)
-		(pin "2" (uuid "41dee029-1cd4-4851-a83d-2ee6b397c9e9")
+		(pin "2" (uuid "b538e0e9-e4f1-42a0-b96e-a99274cdf210")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "R10") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "R10") (unit 1)
 				)
 			)
 		)
@@ -7325,7 +7325,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "6b5d9b51-445f-48e9-9b23-e05b4a4beeb1")
+		(uuid "10a018ab-c27e-41a9-9a64-4fd7b852e8ee")
 		(property "Reference" "R11"
 			(at 100.33 234.95 0)
 			(effects
@@ -7378,13 +7378,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "2d08f156-3256-4114-a7fa-7fff98dc9d11")
+		(pin "1" (uuid "e461ffb1-f774-4751-844b-a8746794d284")
 		)
-		(pin "2" (uuid "591273dc-7b54-4a55-ba6c-2d21994b55a3")
+		(pin "2" (uuid "5fb0005f-50ee-41ca-a494-e6391364f899")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "R11") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "R11") (unit 1)
 				)
 			)
 		)
@@ -7397,7 +7397,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "b8f17510-1982-4e60-8e60-3d3123bf5374")
+		(uuid "19620b75-899d-4aeb-9587-87c443e6d22f")
 		(property "Reference" "R12"
 			(at 175.26 234.95 0)
 			(effects
@@ -7450,13 +7450,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "560c7c20-02dc-4bf9-ad14-073dd0eaacea")
+		(pin "1" (uuid "7e30b8bd-471c-41cc-b148-3d9ceb0c764c")
 		)
-		(pin "2" (uuid "6ddb6e17-d23c-466b-822b-51b67049fd4a")
+		(pin "2" (uuid "e7065836-97ad-4547-b44a-e9ed82d97c03")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "R12") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "R12") (unit 1)
 				)
 			)
 		)
@@ -7469,7 +7469,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "d012af0d-1594-41a4-b497-f18bcbfefe9a")
+		(uuid "b641c4f3-a3b7-4e3f-98af-82817dd6af9e")
 		(property "Reference" "J2"
 			(at 260.35 175.26 0)
 			(effects
@@ -7504,15 +7504,15 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "1b11538b-d99f-4b02-9226-631c034b2ed3")
+		(pin "1" (uuid "eee0f0fa-d1e0-4fca-be69-6cdc1d86219b")
 		)
-		(pin "2" (uuid "6a96e573-7276-424d-b52b-8b6d9b21b41e")
+		(pin "2" (uuid "b46f4f38-1322-48d3-929a-94e86d8213d4")
 		)
-		(pin "3" (uuid "707fe5c5-99da-48c8-80c5-5aea4050e207")
+		(pin "3" (uuid "613194f0-ba4b-4b47-9d4d-d4173ccfc99e")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "J2") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "J2") (unit 1)
 				)
 			)
 		)
@@ -7525,7 +7525,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "dba0778b-a7d3-41fc-b161-52ef1ea37032")
+		(uuid "ffb516c4-a872-498b-9284-21b038da341e")
 		(property "Reference" "J3"
 			(at 260.35 95.25 0)
 			(effects
@@ -7560,19 +7560,19 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "1563cfa8-5b20-4c1e-9733-9ac317b300b4")
+		(pin "1" (uuid "8bb6c63d-b4c5-4f06-9881-776185ef4833")
 		)
-		(pin "2" (uuid "ec5a77be-e0d5-48ce-9efd-2a27eb80da4e")
+		(pin "2" (uuid "49574a97-5386-49c8-a083-cdb8709f40b6")
 		)
-		(pin "3" (uuid "9e3b3633-4c3f-4524-b268-0a7aab96c494")
+		(pin "3" (uuid "4c35c424-3722-49a3-a894-7182206fdbdc")
 		)
-		(pin "4" (uuid "fd5906cd-8cbf-441d-ae06-68160e74341d")
+		(pin "4" (uuid "108fd352-2574-4ae7-9530-f4bafe58c0ed")
 		)
-		(pin "5" (uuid "733048ed-ecd4-479d-ad26-86b354021acb")
+		(pin "5" (uuid "72fda1cb-bd75-45dc-a8e9-dce87225a01c")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "J3") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "J3") (unit 1)
 				)
 			)
 		)
@@ -7585,7 +7585,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "8977bb08-680a-4037-9f47-a969f32c0979")
+		(uuid "94eaa45c-c6a5-48c6-a07e-7b41a3bf2d57")
 		(property "Reference" "R30"
 			(at 232.41 74.93 0)
 			(effects
@@ -7620,13 +7620,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "bb893702-3ae8-44bc-a7c1-62837a51830a")
+		(pin "1" (uuid "3cad2ccf-47e3-45e0-9ec2-63364147aa16")
 		)
-		(pin "2" (uuid "98243d40-2327-4275-beca-eaea2b9bbb46")
+		(pin "2" (uuid "512826b8-2fb2-4124-b5bd-4bc25e05d32d")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "R30") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "R30") (unit 1)
 				)
 			)
 		)
@@ -7639,7 +7639,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "fb3ae60f-b6c0-4d46-99b0-89ad65474ca8")
+		(uuid "50ab8f83-6139-4ccc-bc51-5efbdafc94fa")
 		(property "Reference" "C30"
 			(at 232.41 105.41 0)
 			(effects
@@ -7674,13 +7674,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "2a31f000-2fa4-4c5f-a1d1-abb3254a7c5d")
+		(pin "1" (uuid "d2d72bd8-2f26-4fd0-a7ee-eb3886f5b14f")
 		)
-		(pin "2" (uuid "48705a21-6940-4908-90dc-97bb43e50028")
+		(pin "2" (uuid "50440966-9416-443c-889d-6710ff99b3f3")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "C30") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "C30") (unit 1)
 				)
 			)
 		)
@@ -7693,7 +7693,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "0ad9d643-b2e7-46d1-9b1b-1dc24d437ceb")
+		(uuid "b37be14a-b61f-4d30-a7f1-e1fe36ad8316")
 		(property "Reference" "R31"
 			(at 223.52 77.47 0)
 			(effects
@@ -7728,13 +7728,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "df6b3a96-5d1d-42bc-a9bd-16fd4bb8c513")
+		(pin "1" (uuid "03a8f77f-947b-41ce-8883-9a69081c2b59")
 		)
-		(pin "2" (uuid "ad246afe-b2bf-43a1-a4f5-569a3421c715")
+		(pin "2" (uuid "ad04241e-96a6-4c34-afe5-768ebc0c63c4")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "R31") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "R31") (unit 1)
 				)
 			)
 		)
@@ -7747,7 +7747,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "118c01e0-2d22-4fc4-8e6c-030bcc77229c")
+		(uuid "db774047-bbe1-48d4-8b47-95e9ae55246a")
 		(property "Reference" "C31"
 			(at 223.52 107.95 0)
 			(effects
@@ -7782,13 +7782,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "fddbe422-b8a4-4749-a6ab-e4cf94434fbd")
+		(pin "1" (uuid "405f19e4-0436-4c7d-bce2-9b28430c1cec")
 		)
-		(pin "2" (uuid "be77078c-92a1-4797-96d8-a93011d004de")
+		(pin "2" (uuid "4432946b-40ad-4529-acee-2b73c687454c")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "C31") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "C31") (unit 1)
 				)
 			)
 		)
@@ -7801,7 +7801,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "79164d9f-98c1-4793-9fc9-77fe9783dc5d")
+		(uuid "00c10286-a2ca-44f2-aa14-c48b3ea27c8e")
 		(property "Reference" "R32"
 			(at 215.9 80.01 0)
 			(effects
@@ -7836,13 +7836,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "bd4524f4-8142-4acc-b608-5745d433855a")
+		(pin "1" (uuid "e8a741ad-6378-479a-aeef-a932e3a2594a")
 		)
-		(pin "2" (uuid "0a8dfa8e-eebd-45df-9cf3-8aaf627f4e93")
+		(pin "2" (uuid "97f29211-9112-43ff-afe0-238a42612eb3")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "R32") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "R32") (unit 1)
 				)
 			)
 		)
@@ -7855,7 +7855,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "5b8eb406-3a47-4017-9a21-f5ac214a42bd")
+		(uuid "4063d6a5-582f-4040-91d3-bbcf803b1579")
 		(property "Reference" "C32"
 			(at 215.9 110.49 0)
 			(effects
@@ -7890,13 +7890,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "dd3b4738-a501-493b-91c0-0b1edbd1f79f")
+		(pin "1" (uuid "ece6c311-a4c6-47fb-8325-24a051264077")
 		)
-		(pin "2" (uuid "438cd52a-740d-42b8-b17e-8f460b0e1b3a")
+		(pin "2" (uuid "8718f3e1-bf1f-45f4-a9d2-1e7ef4882548")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "C32") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "C32") (unit 1)
 				)
 			)
 		)
@@ -7909,7 +7909,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "1f4a1968-0a55-4f2f-b4e4-e715d2bacd4c")
+		(uuid "0635790d-3140-457a-b95c-a6f381480d10")
 		(property "Reference" "D3"
 			(at 190.5 114.3 0)
 			(effects
@@ -7944,13 +7944,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "74debe5d-09fe-47f3-a712-587493abce9d")
+		(pin "1" (uuid "d07455a5-b621-4e15-b0db-6bd62e5a36e0")
 		)
-		(pin "2" (uuid "31c52c9a-dc08-423d-8d12-b43bdff18fec")
+		(pin "2" (uuid "edc13e48-66c0-4666-976d-c505e3af5ef6")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "D3") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "D3") (unit 1)
 				)
 			)
 		)
@@ -7963,7 +7963,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "a5d200f4-4402-46f7-8c3d-506671efc3cc")
+		(uuid "ad23e3e2-cdb4-4786-b30e-36a6b1ba46fc")
 		(property "Reference" "R3"
 			(at 190.5 129.54 0)
 			(effects
@@ -7998,13 +7998,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "0f8aa613-34b5-470b-9f76-69f7113bc7dc")
+		(pin "1" (uuid "c5caf769-fe23-4ee0-8387-8382d59e2177")
 		)
-		(pin "2" (uuid "f96da087-6432-44a4-a472-0201a5756d94")
+		(pin "2" (uuid "0c6f1ecb-7e98-48b0-9920-cdea93abcd28")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "R3") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "R3") (unit 1)
 				)
 			)
 		)
@@ -8017,7 +8017,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "ae9640b8-d31e-4869-90d0-24e75143d5e2")
+		(uuid "157dffd7-9388-403d-96d9-448967fa6195")
 		(property "Reference" "D4"
 			(at 209.55 114.3 0)
 			(effects
@@ -8052,13 +8052,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "fb534df9-5181-4ad3-9429-263d33664e3c")
+		(pin "1" (uuid "0ce33f75-56f8-4e3a-a366-c19fe10bd577")
 		)
-		(pin "2" (uuid "d8736f98-a2d1-4c9f-ab6c-447a10a83edf")
+		(pin "2" (uuid "48cbfaa4-8aa6-416f-a143-4323a7b93bc2")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "D4") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "D4") (unit 1)
 				)
 			)
 		)
@@ -8071,7 +8071,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "eab290c0-b2d4-4bcb-b353-6a768503a21d")
+		(uuid "6d55b226-7f63-4cdc-926b-f52e98f210b5")
 		(property "Reference" "R4"
 			(at 209.55 129.54 0)
 			(effects
@@ -8106,13 +8106,13 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "a0d8aa86-b685-4524-8460-a55a6d843500")
+		(pin "1" (uuid "762ae77b-eb13-43c7-af3b-7f19ee555bc7")
 		)
-		(pin "2" (uuid "99f55747-d00f-4390-8a38-3bb31d1446bc")
+		(pin "2" (uuid "62926eaa-7620-4498-9b7b-52dd5ba3f2dd")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "R4") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "R4") (unit 1)
 				)
 			)
 		)
@@ -8125,7 +8125,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "499cbd01-ec92-442b-a8fa-ced33a57f94b")
+		(uuid "c094e232-4ec7-43f8-91b6-8d229049036e")
 		(property "Reference" "#PWR01"
 			(at 25.4 17.78 0)
 			(effects
@@ -8161,11 +8161,11 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "99309a7d-383d-401b-ae46-dc1c4b837324")
+		(pin "1" (uuid "1840c3b2-da81-48a8-9bbc-534a599dc373")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "#PWR01") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "#PWR01") (unit 1)
 				)
 			)
 		)
@@ -8178,7 +8178,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "f1b996f0-fbcb-41a8-ad6a-7f5a0e2c20dd")
+		(uuid "90317815-581c-4b78-9fcc-e79d7eeb3878")
 		(property "Reference" "#PWR02"
 			(at 31.75 17.78 0)
 			(effects
@@ -8214,11 +8214,11 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "71933cae-eef4-4a01-a636-330732f0989e")
+		(pin "1" (uuid "bcc34191-d54c-4344-9d1c-cc57a8f6ceea")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "#PWR02") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "#PWR02") (unit 1)
 				)
 			)
 		)
@@ -8231,7 +8231,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "0afde606-04e5-4c7c-878d-dbdd54c50988")
+		(uuid "fc6ff658-ec73-4ab7-8239-ba698e04ae53")
 		(property "Reference" "#PWR03"
 			(at 105.41 38.1 0)
 			(effects
@@ -8267,11 +8267,11 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "86d49dd9-3f8c-40c6-a4f7-6f29944be492")
+		(pin "1" (uuid "c27feaa8-02e9-4bb2-b79f-5f7a390fda08")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "#PWR03") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "#PWR03") (unit 1)
 				)
 			)
 		)
@@ -8284,7 +8284,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "7597d8b7-a681-4bdb-9d94-5a898ec869cb")
+		(uuid "e7f2ab08-d5ea-4fab-8310-6340f9f056e1")
 		(property "Reference" "#PWR04"
 			(at 111.76 38.1 0)
 			(effects
@@ -8320,11 +8320,11 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "df212f66-7c94-489e-8456-09c87bcf7ed1")
+		(pin "1" (uuid "d7539bd1-72a3-45c8-a07b-fceb0d433fb1")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "#PWR04") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "#PWR04") (unit 1)
 				)
 			)
 		)
@@ -8337,7 +8337,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "265009a7-20b2-4a9c-9603-c29d0545dc47")
+		(uuid "f4a647bc-b9ea-49d1-a823-9b11078f28e6")
 		(property "Reference" "#PWR05"
 			(at 165.1 57.15 0)
 			(effects
@@ -8373,11 +8373,11 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "4e2e44b3-440b-43e9-98b5-20a9b3b236a3")
+		(pin "1" (uuid "9c831380-188d-4948-9ddf-9eaf01206680")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "#PWR05") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "#PWR05") (unit 1)
 				)
 			)
 		)
@@ -8390,7 +8390,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "2a37ed44-f0f1-4980-97fb-b00ae34e7252")
+		(uuid "ef6e6fb7-b252-4921-9c62-10ada96ee6e9")
 		(property "Reference" "#PWR06"
 			(at 25.4 292.1 0)
 			(effects
@@ -8426,11 +8426,11 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "46e1867a-8b3b-44e0-b96a-cb914c781744")
+		(pin "1" (uuid "9258c1ba-5055-4ae3-ab44-723c4e251055")
 		)
 		(instances
 			(project "project"
-				(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (reference "#PWR06") (unit 1)
+				(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (reference "#PWR06") (unit 1)
 				)
 			)
 		)
@@ -8441,7 +8441,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "733e287d-5067-4366-90ce-fc898cc10af0")
+		(uuid "e339a714-16d7-4453-8505-87addc64dd8f")
 	)
 	(wire
 		(pts (xy 25.4 15.24) (xy 25.4 25.4))
@@ -8449,7 +8449,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "bd02c16f-b9b7-4c86-b2a1-1ebcdbbfa635")
+		(uuid "ce3b7dd5-5114-4e00-bfa1-42e79fdb0af7")
 	)
 	(wire
 		(pts (xy 31.75 15.24) (xy 31.75 25.4))
@@ -8457,7 +8457,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "f0aa1fb5-5a06-4ce7-b38e-f122b3db89c6")
+		(uuid "e33bbe7d-2952-4aa3-ae9a-f12fb31f1aed")
 	)
 	(wire
 		(pts (xy 105.41 44.45) (xy 309.88 44.45))
@@ -8465,7 +8465,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "a525aa40-bfea-444a-9ae0-c9418f86ba0c")
+		(uuid "d147f6d6-4122-4dbb-a983-2800d96ff519")
 	)
 	(wire
 		(pts (xy 105.41 35.56) (xy 105.41 44.45))
@@ -8473,7 +8473,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "eccdda51-592d-4c76-a991-c454ea0ccfe9")
+		(uuid "3cdcdc79-62a8-4ffb-8c3c-df83b9695fab")
 	)
 	(wire
 		(pts (xy 111.76 35.56) (xy 111.76 44.45))
@@ -8481,7 +8481,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "012deb1b-5bf1-4c54-a142-34b0e44c3e99")
+		(uuid "78249290-87ef-480e-a0b6-b80937c14dec")
 	)
 	(wire
 		(pts (xy 147.32 64.77) (xy 279.4 64.77))
@@ -8489,7 +8489,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "c9737e01-7dc1-4c34-9db1-4c3eca08452c")
+		(uuid "ba531d52-e5c6-4fd0-a8ab-e2bfbfecc8d6")
 	)
 	(wire
 		(pts (xy 165.1 54.61) (xy 165.1 64.77))
@@ -8497,7 +8497,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "201efb1f-a90a-4835-b4b4-ae4157bb1996")
+		(uuid "61721380-17b8-4806-abdc-0081e63d7f5b")
 	)
 	(wire
 		(pts (xy 25.4 279.4) (xy 299.72 279.4))
@@ -8505,7 +8505,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "2cf04e97-6c48-4994-8c40-40688722aa01")
+		(uuid "2527cf58-409c-4ff0-b77d-6fab0e31f7bb")
 	)
 	(wire
 		(pts (xy 25.4 289.56) (xy 25.4 279.4))
@@ -8513,7 +8513,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "ef424a57-2c33-4d59-a32b-f305fcb52320")
+		(uuid "47267e6a-2086-45d8-977b-7896377f9ee5")
 	)
 	(wire
 		(pts (xy 299.72 279.4) (xy 309.88 279.4))
@@ -8521,7 +8521,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "18b05e24-206c-4805-a6a7-7adc0a208484")
+		(uuid "95d7b1d9-b579-4f14-ba94-e05c43b87c58")
 	)
 	(wire
 		(pts (xy 30.48 100.33) (xy 44.45 96.52))
@@ -8529,7 +8529,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "9fbff132-c81e-4032-aeb0-46b71b56f294")
+		(uuid "1b70dcee-1756-40eb-8740-4097796fa28d")
 	)
 	(wire
 		(pts (xy 44.45 104.14) (xy 44.45 25.4))
@@ -8537,7 +8537,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "e8d980b4-1a89-4b4e-ac03-9f7d4fadb310")
+		(uuid "b212d54d-5dd2-4caf-8325-b097072dc71b")
 	)
 	(wire
 		(pts (xy 64.77 123.19) (xy 64.77 25.4))
@@ -8545,7 +8545,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "410cbc88-9b56-4ef2-9cff-107e3b81fe35")
+		(uuid "e0db9c08-cba4-4a92-a5c4-4504cd2a6a77")
 	)
 	(wire
 		(pts (xy 64.77 115.57) (xy 64.77 279.4))
@@ -8553,7 +8553,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "1a716d0e-1675-4994-9f38-41bb5eb5fcf6")
+		(uuid "77e9ccf6-8e0d-49b2-bfd4-6c411489c9a4")
 	)
 	(wire
 		(pts (xy 80.01 115.57) (xy 80.01 25.4))
@@ -8561,7 +8561,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "e24117c0-4c2c-4205-982f-8a0cf845db85")
+		(uuid "24b3d145-af76-440a-9d8b-7a89c4fca810")
 	)
 	(wire
 		(pts (xy 80.01 123.19) (xy 80.01 279.4))
@@ -8569,7 +8569,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "1da58d3e-29ae-4b1e-9e81-01ba454cd411")
+		(uuid "f6042b54-1578-42bc-9865-a53fb3d82f60")
 	)
 	(wire
 		(pts (xy 95.25 115.57) (xy 95.25 25.4))
@@ -8577,7 +8577,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "f200e040-eae0-42b1-ab16-c37860036002")
+		(uuid "5d756b5a-3598-4357-adf3-df683a50476f")
 	)
 	(wire
 		(pts (xy 95.25 123.19) (xy 95.25 279.4))
@@ -8585,7 +8585,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "35813676-679c-42ec-bde7-82969f9b705b")
+		(uuid "08eac769-7c17-48a6-934c-4b0b9cb51d34")
 	)
 	(wire
 		(pts (xy 30.48 102.87) (xy 30.48 279.4))
@@ -8593,7 +8593,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "98bb6e80-58ad-4f84-8793-70e122f8a498")
+		(uuid "53cce832-2499-4f6f-90b3-3f1046c96a8c")
 	)
 	(wire
 		(pts (xy 92.71 102.87) (xy 105.41 96.52))
@@ -8601,7 +8601,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "155d4bb0-b501-4d80-8845-239b77bed2a7")
+		(uuid "d6a65151-8a99-41a1-9240-a579e03f0b49")
 	)
 	(wire
 		(pts (xy 105.41 123.19) (xy 100.33 123.19))
@@ -8609,7 +8609,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "f72bf352-8a9f-4411-bcda-0a0fd7d23e69")
+		(uuid "5d5e942b-319f-4390-b166-565954eb22d5")
 	)
 	(wire
 		(pts (xy 100.33 123.19) (xy 100.33 96.52))
@@ -8617,7 +8617,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "c533bdf4-775f-41c9-9c14-288a669fada6")
+		(uuid "ae6362eb-b077-475d-972f-0c72cdade851")
 	)
 	(wire
 		(pts (xy 100.33 96.52) (xy 105.41 96.52))
@@ -8625,7 +8625,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "24f47a40-db26-423e-bbb3-7825290ab1fb")
+		(uuid "3b13eca9-d28b-42ec-bd8a-af8aa9ea7f8b")
 	)
 	(wire
 		(pts (xy 105.41 104.14) (xy 105.41 111.76))
@@ -8633,7 +8633,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "90a1cd49-c548-4b83-b634-cdcbb0d11110")
+		(uuid "99fd7826-cf74-4b77-9522-d1eb6238755e")
 	)
 	(wire
 		(pts (xy 105.41 111.76) (xy 129.54 111.76))
@@ -8641,7 +8641,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "e9b845c2-5eda-4599-b88b-cfa3683a932c")
+		(uuid "40126823-c2b3-4057-9e2d-6736a78ffda6")
 	)
 	(wire
 		(pts (xy 67.31 97.79) (xy 69.85 97.79))
@@ -8649,7 +8649,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "70b39ad5-b95d-444d-afc7-e42f54b997fc")
+		(uuid "684ad27a-0ba9-47ba-9b7c-421443919bcc")
 	)
 	(wire
 		(pts (xy 80.01 107.95) (xy 82.55 107.95))
@@ -8657,7 +8657,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "0927e177-06fd-415c-8a5f-e0e95d9f289d")
+		(uuid "ff6c8a95-8991-44cd-bd8c-588900e71a25")
 	)
 	(wire
 		(pts (xy 92.71 97.79) (xy 129.54 97.79))
@@ -8665,7 +8665,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "6043ee6b-a689-4282-b882-63723f200e80")
+		(uuid "24e3f95d-b1f0-4653-8f82-a34906917e82")
 	)
 	(wire
 		(pts (xy 129.54 97.79) (xy 129.54 111.76))
@@ -8673,7 +8673,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "2ae12c5e-412a-4e5b-8a37-7dbf250e0cad")
+		(uuid "cde8aed8-a5b4-4f6d-b7a8-177b9c79e84e")
 	)
 	(wire
 		(pts (xy 132.08 100.33) (xy 134.62 100.33))
@@ -8681,7 +8681,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "335cc9ad-34ae-4e0b-9142-5e1b1ef6cd1c")
+		(uuid "350ddbcc-256b-4898-95d9-6351068b32a7")
 	)
 	(wire
 		(pts (xy 147.32 100.33) (xy 149.86 100.33))
@@ -8689,7 +8689,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "d2b010de-661a-45e4-9978-c559de750834")
+		(uuid "26a2f405-82c1-4d91-b1ac-7922e475a218")
 	)
 	(wire
 		(pts (xy 139.7 107.95) (xy 137.16 107.95))
@@ -8697,7 +8697,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "ccfcc2ce-84d9-4a57-b375-0b5e194bbc7f")
+		(uuid "5b242224-d0d5-43f0-b647-70d09e7dc9ab")
 	)
 	(wire
 		(pts (xy 67.31 97.79) (xy 67.31 25.4))
@@ -8705,7 +8705,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "b0799a2f-bf3c-4640-8c0e-d3f5c4d981e0")
+		(uuid "084582fb-c6e3-478c-ba00-df74ff6f1028")
 	)
 	(wire
 		(pts (xy 80.01 107.95) (xy 80.01 279.4))
@@ -8713,7 +8713,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "f370f573-4c11-4b07-a6cc-42597d7974f7")
+		(uuid "154a6c79-00e8-4c58-b72a-1884408576f5")
 	)
 	(wire
 		(pts (xy 54.61 111.76) (xy 54.61 25.4))
@@ -8721,7 +8721,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "dec1f93e-a3f9-4ec7-a98b-077b8704df29")
+		(uuid "7b96e937-310a-4e39-a1e0-3cd6eb5a634a")
 	)
 	(wire
 		(pts (xy 54.61 119.38) (xy 54.61 279.4))
@@ -8729,7 +8729,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "c7e55843-f57d-46c9-ad4c-e2b9873eae8d")
+		(uuid "5618e061-4058-400a-b143-a3757f17065d")
 	)
 	(wire
 		(pts (xy 129.54 111.76) (xy 129.54 44.45))
@@ -8737,7 +8737,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "4b356ed8-eca6-4b06-9069-b9a4fac8477e")
+		(uuid "5bc4ed3d-04f2-4eff-a5f0-e342e22f77c2")
 	)
 	(wire
 		(pts (xy 129.54 119.38) (xy 129.54 279.4))
@@ -8745,7 +8745,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "c5f957f0-ebdb-46c3-8e85-94b2969e231e")
+		(uuid "a72f12fa-3994-452e-b9d2-6d821d85c36f")
 	)
 	(wire
 		(pts (xy 129.54 111.76) (xy 129.54 44.45))
@@ -8753,7 +8753,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "e292bf63-6dff-4471-b518-acd26705b9a2")
+		(uuid "57221294-fd03-4a8a-acd3-286a83ded318")
 	)
 	(wire
 		(pts (xy 105.41 115.57) (xy 105.41 279.4))
@@ -8761,7 +8761,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "f81baeb1-adf2-4417-8df9-a0cf8381d953")
+		(uuid "6b2abad2-c59d-45f6-b7ad-6eb026c46c07")
 	)
 	(wire
 		(pts (xy 132.08 100.33) (xy 132.08 44.45))
@@ -8769,7 +8769,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "a1c1bdd4-919a-4dea-99b3-1f83786cf2ee")
+		(uuid "e8a8f068-7f18-4f72-98c2-79b06f30d7c1")
 	)
 	(wire
 		(pts (xy 147.32 100.33) (xy 147.32 64.77))
@@ -8777,7 +8777,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "55675867-09b6-4bf4-b0e4-94d358826dac")
+		(uuid "1bb8df71-6b64-47a2-872d-bb7ee603c2ce")
 	)
 	(wire
 		(pts (xy 139.7 107.95) (xy 139.7 279.4))
@@ -8785,7 +8785,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "7bcf5940-28ed-4c98-9530-cb1a9a78aff2")
+		(uuid "2fcc9bbf-c324-4c48-b90c-287d725690f8")
 	)
 	(wire
 		(pts (xy 119.38 111.76) (xy 119.38 44.45))
@@ -8793,7 +8793,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "4368e58f-fc31-47ca-bf84-faa13ee843ca")
+		(uuid "4a5251d6-0770-4d9a-baff-177176f44236")
 	)
 	(wire
 		(pts (xy 119.38 119.38) (xy 119.38 279.4))
@@ -8801,7 +8801,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "d7fa4c62-05c6-48d4-99d3-da2706c6ab37")
+		(uuid "869421c5-23c3-4946-ab23-12d542d23bc2")
 	)
 	(wire
 		(pts (xy 160.02 111.76) (xy 160.02 64.77))
@@ -8809,7 +8809,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "059c5d01-6adf-4a34-818d-8b9a9ac2938c")
+		(uuid "bd1e7d33-76a4-40bd-8dfb-da4db8737265")
 	)
 	(wire
 		(pts (xy 160.02 119.38) (xy 160.02 279.4))
@@ -8817,7 +8817,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "bd123b5f-9998-458b-b887-5c2606401fc9")
+		(uuid "eedf1baa-cf32-4392-ab6f-2af580b1cc03")
 	)
 	(wire
 		(pts (xy 67.31 102.87) (xy 67.31 279.4))
@@ -8825,7 +8825,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "57326a0a-7294-4635-b49b-eaea3ed4faf8")
+		(uuid "cda2fe9c-5e29-4dc0-836c-47ca657245e2")
 	)
 	(wire
 		(pts (xy 199.39 96.52) (xy 199.39 64.77))
@@ -8833,7 +8833,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "b2906736-9b26-4f78-8178-e1c40c89a9b2")
+		(uuid "551f28e9-c9c4-4eeb-be56-66b340cbddfb")
 	)
 	(wire
 		(pts (xy 199.39 104.14) (xy 199.39 279.4))
@@ -8841,7 +8841,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "02504aeb-c8d7-416c-80be-14007949577a")
+		(uuid "6f287846-5c25-4e1d-a7a5-edb4e3999360")
 	)
 	(wire
 		(pts (xy 209.55 96.52) (xy 209.55 64.77))
@@ -8849,7 +8849,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "bfc1d8ec-27fd-4cca-b5b2-819255c6a029")
+		(uuid "4047e0f0-f6ce-47ce-bf84-a36bca16a464")
 	)
 	(wire
 		(pts (xy 209.55 104.14) (xy 209.55 279.4))
@@ -8857,7 +8857,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "a22234ed-b498-40e2-9940-3199e5f8dadc")
+		(uuid "afc5b22c-8df0-44d7-811d-f45f935815ee")
 	)
 	(wire
 		(pts (xy 219.71 96.52) (xy 219.71 64.77))
@@ -8865,7 +8865,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "faea34ca-0483-4265-ba4b-f571769bcadb")
+		(uuid "1e5a1c4a-cdc5-42f6-85cc-b2212d89a36c")
 	)
 	(wire
 		(pts (xy 219.71 104.14) (xy 219.71 279.4))
@@ -8873,199 +8873,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "d4de7de2-5a34-4813-a3dd-2d73c68d29de")
-	)
-	(wire
-		(pts (xy 227.33 137.16) (xy 222.25 137.16))
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "a13ffacc-aa28-404f-a1a4-19e49b515edb")
-	)
-	(wire
-		(pts (xy 229.87 137.16) (xy 224.79 137.16))
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "131d442c-2c4a-4da6-bb48-a136604a18c7")
-	)
-	(wire
-		(pts (xy 232.41 137.16) (xy 227.33 137.16))
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "a9de4280-9963-425d-b9c3-30e7c8c60c19")
-	)
-	(wire
-		(pts (xy 232.41 190.5) (xy 227.33 190.5))
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "c5e87bbd-f26b-4f85-98e0-a2cee59dfd5b")
-	)
-	(wire
-		(pts (xy 229.87 190.5) (xy 224.79 190.5))
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "a7cf2dbf-2b8a-45b9-936f-b2bd92a9c18c")
-	)
-	(wire
-		(pts (xy 229.87 190.5) (xy 224.79 190.5))
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "b9eb5222-a517-4061-a466-a27a49f3df5f")
-	)
-	(wire
-		(pts (xy 217.17 144.78) (xy 212.09 144.78))
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "e212eba1-a4c7-457c-ba58-f2ff20db8d6c")
-	)
-	(wire
-		(pts (xy 242.57 144.78) (xy 247.65 144.78))
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "2ad52107-aaae-43a3-997c-86ac86314917")
-	)
-	(wire
-		(pts (xy 242.57 147.32) (xy 247.65 147.32))
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "d707e044-58bf-4323-8d35-5ceabfe684a9")
-	)
-	(wire
-		(pts (xy 242.57 149.86) (xy 247.65 149.86))
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "b58dd59f-a3b6-476e-89b6-0520d165bcfd")
-	)
-	(wire
-		(pts (xy 242.57 160.02) (xy 247.65 160.02))
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "f8b53fb2-bd96-4423-b1f6-76d8279767ee")
-	)
-	(wire
-		(pts (xy 242.57 162.56) (xy 247.65 162.56))
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "dfc6f1bd-ad2b-4549-a748-87f4622f81b2")
-	)
-	(wire
-		(pts (xy 217.17 157.48) (xy 222.25 157.48))
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "d1d86770-3653-4970-86ef-9fbfc3d8d05e")
-	)
-	(wire
-		(pts (xy 242.57 165.1) (xy 247.65 165.1))
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "d199e250-dcc9-49ba-bb97-cc17e256c60b")
-	)
-	(wire
-		(pts (xy 242.57 167.64) (xy 247.65 167.64))
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "038ec6e6-e68e-463d-a279-4a89088226f5")
-	)
-	(wire
-		(pts (xy 242.57 170.18) (xy 247.65 170.18))
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "fda04030-300e-4c6d-8915-dfe7839381e7")
-	)
-	(wire
-		(pts (xy 242.57 177.8) (xy 247.65 177.8))
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "c63a4930-e9ab-46cf-afc2-716bc266100d")
-	)
-	(wire
-		(pts (xy 242.57 180.34) (xy 247.65 180.34))
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "4efafad3-b93e-4ffc-bb62-208c2de47db9")
-	)
-	(wire
-		(pts (xy 217.17 160.02) (xy 222.25 160.02))
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "5c6d45fb-f03a-43b8-b2dc-c52bd4a9bcff")
-	)
-	(wire
-		(pts (xy 217.17 167.64) (xy 222.25 167.64))
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "6813c980-f149-4f7f-982f-660ac5562690")
-	)
-	(wire
-		(pts (xy 217.17 170.18) (xy 222.25 170.18))
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "a74cde84-7f52-4d55-8e7a-f80a3a044c7d")
-	)
-	(wire
-		(pts (xy 217.17 172.72) (xy 222.25 172.72))
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "d8b3bf9a-ed6d-4914-84a1-39f7ec66d738")
-	)
-	(wire
-		(pts (xy 217.17 149.86) (xy 212.09 149.86))
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "69159356-fd85-4824-a577-e51f8bc38b78")
-	)
-	(wire
-		(pts (xy 217.17 152.4) (xy 212.09 152.4))
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "ad800a77-6039-49e1-85fb-568ee3e2352f")
+		(uuid "8437a5c5-0365-4ee3-90a0-a63eafa83762")
 	)
 	(wire
 		(pts (xy 266.7 100.33) (xy 262.89 100.33))
@@ -9073,7 +8881,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "185e7769-fd00-4474-a1ea-6aca250c5fc0")
+		(uuid "861a197b-5ae0-4fcb-a738-634472954a0e")
 	)
 	(wire
 		(pts (xy 262.89 100.33) (xy 262.89 111.76))
@@ -9081,7 +8889,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "44b8dd48-3f61-42de-87d5-ba5d1e859d56")
+		(uuid "2165a6f7-ed2d-42ae-a726-048e99b8f458")
 	)
 	(wire
 		(pts (xy 274.32 100.33) (xy 278.13 100.33))
@@ -9089,7 +8897,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "9ccbba5a-e6fd-485c-b371-2e82e933b750")
+		(uuid "26c6c963-403c-456d-8c63-6ce9d48a3d74")
 	)
 	(wire
 		(pts (xy 278.13 100.33) (xy 278.13 111.76))
@@ -9097,7 +8905,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "0aa0dc93-650f-4f29-8150-39531033ef2f")
+		(uuid "c5df02ad-f305-49ff-8c88-0442d1e5a9a0")
 	)
 	(wire
 		(pts (xy 262.89 119.38) (xy 278.13 119.38))
@@ -9105,7 +8913,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "8b5d1d85-afc7-4c36-ae25-66715a5da5ae")
+		(uuid "0dbbd53f-28b6-4d07-9ae4-f75561d9df17")
 	)
 	(wire
 		(pts (xy 270.51 119.38) (xy 270.51 279.4))
@@ -9113,7 +8921,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "a917ea48-2bb0-4609-bdf6-735784b727ca")
+		(uuid "322e2fc4-d510-4033-9fd1-4cd6b0d6189f")
 	)
 	(wire
 		(pts (xy 266.7 100.33) (xy 261.62 100.33))
@@ -9121,7 +8929,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "263d1699-a404-463d-b810-58de97338b9f")
+		(uuid "08163c1a-9aae-476a-a00a-6ea4dec012e4")
 	)
 	(wire
 		(pts (xy 274.32 100.33) (xy 279.4 100.33))
@@ -9129,7 +8937,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "adec10fb-e878-47ff-b78d-74e347642e5b")
+		(uuid "9a373de2-99cb-4f8c-a63c-acb194e55e90")
 	)
 	(wire
 		(pts (xy 294.64 95.25) (xy 292.1 95.25))
@@ -9137,7 +8945,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "98999062-323f-4216-a8c2-271b81c6fedf")
+		(uuid "ae9174e8-d927-4c47-a3a1-f6d0b60af81c")
 	)
 	(wire
 		(pts (xy 294.64 97.79) (xy 292.1 97.79))
@@ -9145,7 +8953,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "037a0490-e983-48ba-b127-e37b47d39db8")
+		(uuid "de63fb23-e428-47a4-85a4-765e50f321a4")
 	)
 	(wire
 		(pts (xy 294.64 100.33) (xy 292.1 100.33))
@@ -9153,7 +8961,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "b7787f58-bbe5-4802-aab9-7790befa4da0")
+		(uuid "5d962952-3168-492e-8b1f-ff5d95c930c1")
 	)
 	(wire
 		(pts (xy 294.64 102.87) (xy 292.1 102.87))
@@ -9161,7 +8969,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "beeff68e-0194-4607-bbb0-eeb8d5571dfa")
+		(uuid "9b5951cf-ea5a-40b3-88f6-aa56956b2b08")
 	)
 	(wire
 		(pts (xy 294.64 105.41) (xy 292.1 105.41))
@@ -9169,7 +8977,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "dd2d910b-191d-4f67-99ca-cf30d7882ff0")
+		(uuid "c505105c-bb6c-40f8-91cf-250463197087")
 	)
 	(wire
 		(pts (xy 294.64 107.95) (xy 292.1 107.95))
@@ -9177,7 +8985,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "7853a2d7-0eca-460f-a500-9f4bb9aa20c1")
+		(uuid "7dfe3cf5-b5ce-4ef3-8520-9e567e5648bc")
 	)
 	(wire
 		(pts (xy 294.64 95.25) (xy 294.64 64.77))
@@ -9185,7 +8993,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "9f3f6d78-593a-4668-b025-0306cd614fa3")
+		(uuid "7082e1ef-f3ed-4250-b8b3-61082a2cedc6")
 	)
 	(wire
 		(pts (xy 294.64 100.33) (xy 294.64 279.4))
@@ -9193,7 +9001,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "12cced89-bab5-43fb-bd7e-39fd265d49b2")
+		(uuid "4e4f9758-3daa-4e5c-9398-55c920f90a73")
 	)
 	(wire
 		(pts (xy 259.08 73.66) (xy 256.54 73.66))
@@ -9201,7 +9009,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "3bb05006-90da-4981-9556-d0bf5b0df4e4")
+		(uuid "e9c5d75b-d6e1-4191-98ce-e345874e9d03")
 	)
 	(wire
 		(pts (xy 259.08 71.12) (xy 256.54 71.12))
@@ -9209,7 +9017,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "f1396e1a-349a-408d-880c-186fd6891e2e")
+		(uuid "a8e2350d-992c-4bef-ad15-ebaf691eb131")
 	)
 	(wire
 		(pts (xy 259.08 76.2) (xy 256.54 76.2))
@@ -9217,7 +9025,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "61a43a35-9a1b-4962-b2c4-bca9f7787338")
+		(uuid "b8b8ec70-b257-41f9-b85d-41a536cb4f6c")
 	)
 	(wire
 		(pts (xy 259.08 81.28) (xy 256.54 81.28))
@@ -9225,7 +9033,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "95e136f1-d3d4-481c-9d3b-fcdb658b59bc")
+		(uuid "ea92128a-cec0-496e-ae9a-7488be3158d2")
 	)
 	(wire
 		(pts (xy 259.08 96.52) (xy 256.54 96.52))
@@ -9233,7 +9041,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "2cb3d7c5-4e79-41d9-835c-e39649c37b65")
+		(uuid "213265af-b56a-463f-a0ef-3b690a82cf42")
 	)
 	(wire
 		(pts (xy 259.08 86.36) (xy 256.54 86.36))
@@ -9241,7 +9049,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "05025493-e54b-4294-a28f-ada3dd874860")
+		(uuid "9fda1423-4838-4fa0-b453-60c02a200bb9")
 	)
 	(wire
 		(pts (xy 259.08 88.9) (xy 256.54 88.9))
@@ -9249,7 +9057,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "adbb35df-f4e9-4260-b949-69ebe76fe7e9")
+		(uuid "367d93a0-cb34-4db5-b0b4-a64ab7be45e6")
 	)
 	(wire
 		(pts (xy 259.08 93.98) (xy 256.54 93.98))
@@ -9257,7 +9065,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "c92850cb-3522-4f88-aed1-103f6519aea3")
+		(uuid "b283d3b0-a359-4a90-aa48-71f4dff47ea3")
 	)
 	(wire
 		(pts (xy 259.08 91.44) (xy 256.54 91.44))
@@ -9265,7 +9073,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "5084209a-629c-48a5-90b0-364badefc679")
+		(uuid "de73963c-9b7f-4de1-9fc7-a9291031ee0c")
 	)
 	(wire
 		(pts (xy 259.08 106.68) (xy 256.54 106.68))
@@ -9273,7 +9081,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "0b86bd47-fcdf-4db3-a3b4-cc05f5b8bb4f")
+		(uuid "6e9ab759-4355-4b66-9152-d1e4f7eab214")
 	)
 	(wire
 		(pts (xy 259.08 104.14) (xy 256.54 104.14))
@@ -9281,7 +9089,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "c191867c-c5e9-40e2-b6a1-e949285d8b02")
+		(uuid "e3a8203b-78b6-46be-90e7-6eb2fb7e11bd")
 	)
 	(wire
 		(pts (xy 259.08 78.74) (xy 256.54 78.74))
@@ -9289,7 +9097,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "e8c24097-b43e-466b-8486-71acd8a7581c")
+		(uuid "da14d359-5ad9-4190-9b9b-e4a61681358e")
 	)
 	(wire
 		(pts (xy 259.08 101.6) (xy 256.54 101.6))
@@ -9297,7 +9105,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "985c192d-ace2-4d62-a31e-07ddb61c15fa")
+		(uuid "a9e04a06-660f-4b38-a6ce-54e383ecf6d1")
 	)
 	(wire
 		(pts (xy 259.08 109.22) (xy 256.54 109.22))
@@ -9305,7 +9113,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "32f6edd7-5704-487f-bf29-df8e11f8242d")
+		(uuid "ce971839-459b-4af8-be0e-67df8186f20f")
 	)
 	(wire
 		(pts (xy 259.08 111.76) (xy 256.54 111.76))
@@ -9313,7 +9121,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "a7ef7c8b-08d3-4167-a1d4-ea815655268d")
+		(uuid "8d3a8667-ec04-4011-bf31-52ac7b8df36f")
 	)
 	(wire
 		(pts (xy 259.08 114.3) (xy 256.54 114.3))
@@ -9321,7 +9129,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "a3001069-aee5-4883-a95d-3f72f297f1fd")
+		(uuid "786efe11-ca8b-45a4-9df0-c0ed77c7d84e")
 	)
 	(wire
 		(pts (xy 299.72 63.5) (xy 302.26 63.5))
@@ -9329,7 +9137,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "b7982d75-4e3b-4b68-896e-0f51bb67ec86")
+		(uuid "eed0ec23-c98f-45ca-97ba-ead5833417ac")
 	)
 	(wire
 		(pts (xy 299.72 73.66) (xy 302.26 73.66))
@@ -9337,7 +9145,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "9579a5bc-fa74-435c-8fee-bcc631da4c28")
+		(uuid "5ab49106-3e18-4f9b-ab0f-25ec0b8945ce")
 	)
 	(wire
 		(pts (xy 299.72 83.82) (xy 302.26 83.82))
@@ -9345,7 +9153,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "e5926282-ae91-4285-83a9-78aee2c89577")
+		(uuid "fae89d22-e664-4086-8f81-6db3cf6b9be8")
 	)
 	(wire
 		(pts (xy 299.72 68.58) (xy 302.26 68.58))
@@ -9353,7 +9161,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "773376be-af8b-4ea8-9f3e-75cbf2e1b8e6")
+		(uuid "c9ec5aec-dbfb-44d4-a6ab-69b490122285")
 	)
 	(wire
 		(pts (xy 299.72 78.74) (xy 302.26 78.74))
@@ -9361,7 +9169,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "3d940ed0-cd08-40fb-b26d-a3930b996684")
+		(uuid "d8e28a62-cd57-448e-8318-c3bd6204fa72")
 	)
 	(wire
 		(pts (xy 299.72 88.9) (xy 302.26 88.9))
@@ -9369,7 +9177,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "386b9bcb-7baa-4c6b-8571-c08d5d3987be")
+		(uuid "eb30aa83-121f-4d47-af37-b8888ce755b6")
 	)
 	(wire
 		(pts (xy 299.72 101.6) (xy 302.26 101.6))
@@ -9377,7 +9185,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "e85694f4-ee14-4810-85c2-a45869611ca7")
+		(uuid "6f411f9b-7505-4dfd-ae33-447a6209aefa")
 	)
 	(wire
 		(pts (xy 299.72 104.14) (xy 302.26 104.14))
@@ -9385,7 +9193,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "9550bea8-e082-49ba-ab39-9f06aeef0fda")
+		(uuid "17146e9d-0304-46a9-8fa0-26d1efc4810a")
 	)
 	(wire
 		(pts (xy 299.72 106.68) (xy 302.26 106.68))
@@ -9393,7 +9201,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "97890913-4d5e-4405-813c-d969595dc090")
+		(uuid "ce716cbf-6fbf-4756-971d-c4582968f570")
 	)
 	(wire
 		(pts (xy 299.72 109.22) (xy 302.26 109.22))
@@ -9401,7 +9209,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "809e3e06-d167-4a79-966d-d6919fb0cbce")
+		(uuid "ed8c01bb-2262-4d51-aa69-409b946bed36")
 	)
 	(wire
 		(pts (xy 299.72 111.76) (xy 302.26 111.76))
@@ -9409,7 +9217,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "8065c8da-5f60-472c-81bc-323cbdb28d98")
+		(uuid "4eb19393-5b4a-4049-8a79-d0f9ab6f73a9")
 	)
 	(wire
 		(pts (xy 299.72 114.3) (xy 302.26 114.3))
@@ -9417,7 +9225,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "ef84df9c-2acb-49a5-99e3-41d3b875ae4c")
+		(uuid "347d6944-cc3a-4f1e-b815-e3765db82fa5")
 	)
 	(wire
 		(pts (xy 299.72 66.04) (xy 302.26 66.04))
@@ -9425,7 +9233,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "90ea3774-5906-48d3-949b-20291f3f37fb")
+		(uuid "2b606c6e-09d6-4977-9e1f-7d68adb134e6")
 	)
 	(wire
 		(pts (xy 299.72 76.2) (xy 302.26 76.2))
@@ -9433,7 +9241,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "9f59cdde-1b7b-4347-9df7-2858fb8ef998")
+		(uuid "a44f98b9-9e3f-48de-935c-84b78e4dedfa")
 	)
 	(wire
 		(pts (xy 299.72 86.36) (xy 302.26 86.36))
@@ -9441,7 +9249,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "51ea2e32-8fb6-4da3-9b7e-64adfc3fb9b3")
+		(uuid "b683564f-cbe6-4ca8-b0cf-c6ea1ac16cee")
 	)
 	(wire
 		(pts (xy 299.72 96.52) (xy 302.26 96.52))
@@ -9449,7 +9257,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "a54445c8-fe0a-4b93-aad2-6553bcfd027c")
+		(uuid "132f273a-6f24-4573-80fb-7c4f6a93b3aa")
 	)
 	(wire
 		(pts (xy 276.86 119.38) (xy 279.4 119.38))
@@ -9457,7 +9265,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "5405d230-7547-4cf0-8b2d-345ec306a0ca")
+		(uuid "ebc0999c-7016-44a1-ab28-2be0143efcaa")
 	)
 	(wire
 		(pts (xy 281.94 119.38) (xy 284.48 119.38))
@@ -9465,7 +9273,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "a440b68e-84b5-4a48-9d75-b70dd7400807")
+		(uuid "5053bc82-d4d4-4c2d-bb91-194ff975907c")
 	)
 	(wire
 		(pts (xy 259.08 63.5) (xy 256.54 63.5))
@@ -9473,7 +9281,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "9dca8417-8452-4d2a-8e03-06aad4965412")
+		(uuid "72fe2ca8-22d6-45f4-acb7-8588f8e1ba24")
 	)
 	(wire
 		(pts (xy 259.08 66.04) (xy 256.54 66.04))
@@ -9481,7 +9289,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "eccd2e01-772d-4cbb-8952-2096202fc5c7")
+		(uuid "42fc607b-90e1-46c3-81ca-b04f00ad47da")
 	)
 	(wire
 		(pts (xy 271.78 58.42) (xy 271.78 55.88))
@@ -9489,7 +9297,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "f744378d-e161-4996-95cd-4d0d653dfdf7")
+		(uuid "29cae7f9-24cf-42a2-a8d4-feb4ab615fcd")
 	)
 	(wire
 		(pts (xy 274.32 58.42) (xy 274.32 55.88))
@@ -9497,7 +9305,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "13f30889-addf-4e6f-a65e-f087ce7ccc87")
+		(uuid "0bb89ec7-f59d-4e8e-bdf5-2739c9a478f7")
 	)
 	(wire
 		(pts (xy 279.4 58.42) (xy 279.4 55.88))
@@ -9505,7 +9313,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "fab9cf6b-23ec-4657-b476-ab5c226cd1a1")
+		(uuid "77b12184-06d7-411d-b519-5ec1e84e3377")
 	)
 	(wire
 		(pts (xy 281.94 58.42) (xy 281.94 55.88))
@@ -9513,7 +9321,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "06a9260e-8322-492e-ba14-0e5ce3fdbaab")
+		(uuid "cdabedaf-bea7-4645-bc18-dcb7f3938812")
 	)
 	(wire
 		(pts (xy 284.48 58.42) (xy 284.48 55.88))
@@ -9521,7 +9329,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "9401cd33-b4fb-48a3-811e-2c0c727524b2")
+		(uuid "24633276-3e69-4578-8d8b-30a0c3df26f9")
 	)
 	(wire
 		(pts (xy 299.72 77.47) (xy 299.72 44.45))
@@ -9529,7 +9337,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "b5899351-2abf-4942-b249-8e3f6c8af5c9")
+		(uuid "7dbf0455-d910-4103-9c85-9cb0c2116fcf")
 	)
 	(wire
 		(pts (xy 299.72 85.09) (xy 299.72 279.4))
@@ -9537,7 +9345,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "08f01ab4-27e6-48ec-84bf-0e3a2aed8c4d")
+		(uuid "37f2b50b-a6b0-4745-b952-41e87056cda7")
 	)
 	(wire
 		(pts (xy 309.88 77.47) (xy 309.88 44.45))
@@ -9545,7 +9353,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "c3ef32bf-3404-4067-a7a2-43f458fe1be9")
+		(uuid "a66bdaf7-0a0e-4d92-a1c2-c7b78488abdc")
 	)
 	(wire
 		(pts (xy 309.88 85.09) (xy 309.88 279.4))
@@ -9553,7 +9361,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "d5a2a698-925f-4f33-a853-70ce31194ad8")
+		(uuid "d0e8da1e-b337-4688-83fd-095198b481df")
 	)
 	(wire
 		(pts (xy 260.35 76.2) (xy 260.35 73.66))
@@ -9561,7 +9369,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "b0e20a9e-5e3f-463a-9ab1-c38400776250")
+		(uuid "c65abde1-7aba-42bd-b5d4-5c10323c5029")
 	)
 	(wire
 		(pts (xy 260.35 83.82) (xy 260.35 86.36))
@@ -9569,7 +9377,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "f83b3a38-07fe-49d7-a953-5b6b3aa14164")
+		(uuid "831b54b2-8aa5-4ed0-96d2-e02ff1ddf10f")
 	)
 	(wire
 		(pts (xy 270.51 76.2) (xy 270.51 73.66))
@@ -9577,7 +9385,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "a4915ec1-a574-4d38-97bd-7fa9abc4be06")
+		(uuid "5aac7314-6230-479f-97ec-b5cec0c6ec79")
 	)
 	(wire
 		(pts (xy 270.51 83.82) (xy 270.51 86.36))
@@ -9585,7 +9393,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "b68b889e-a476-442e-bf52-9379479465d8")
+		(uuid "6be305c9-dcf1-44b8-98f4-656158f05d85")
 	)
 	(wire
 		(pts (xy 279.4 76.2) (xy 279.4 73.66))
@@ -9593,7 +9401,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "c275c02f-0a05-49b8-a60e-9b6d0d1be7a8")
+		(uuid "fbc4ba41-a8f3-4542-b52c-246fef48709e")
 	)
 	(wire
 		(pts (xy 279.4 83.82) (xy 279.4 86.36))
@@ -9601,7 +9409,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "6ed027a3-bcb9-43eb-a1f6-eee946b869e1")
+		(uuid "273fd97e-e2cc-44bf-a6bb-fe18a8f0af1b")
 	)
 	(wire
 		(pts (xy 309.88 115.57) (xy 307.34 115.57))
@@ -9609,7 +9417,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "89f30271-a45b-49f1-87f3-120a9d252a42")
+		(uuid "0cd9b828-256b-4168-82fb-4cb66025f37c")
 	)
 	(wire
 		(pts (xy 309.88 123.19) (xy 312.42 123.19))
@@ -9617,7 +9425,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "c73efd30-a2e8-4d12-ac6b-73182e80f0e4")
+		(uuid "721d28a0-153d-42c3-ada7-ba3ee2fb55b2")
 	)
 	(wire
 		(pts (xy 320.04 115.57) (xy 317.5 115.57))
@@ -9625,7 +9433,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "9d7b158b-5743-4915-90df-d9f4a90311bd")
+		(uuid "2fcc4549-b41e-4015-8b3a-f7ad9f002d20")
 	)
 	(wire
 		(pts (xy 320.04 123.19) (xy 322.58 123.19))
@@ -9633,7 +9441,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "36e58f41-ef10-433b-b888-6e9d58db44b5")
+		(uuid "9aa85be5-d1ca-4b08-adcf-494fd347e88b")
 	)
 	(wire
 		(pts (xy 330.2 115.57) (xy 327.66 115.57))
@@ -9641,7 +9449,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "491a447e-1399-4fa5-9151-e2a36e2e8934")
+		(uuid "60bdb9a3-843d-4050-900c-440c5fc459d7")
 	)
 	(wire
 		(pts (xy 330.2 123.19) (xy 332.74 123.19))
@@ -9649,7 +9457,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "106d2a78-0767-4747-9407-0e3aa548598f")
+		(uuid "d481ad04-355f-4230-8fd7-77386a2291a5")
 	)
 	(wire
 		(pts (xy 27.94 165.1) (xy 27.94 194.31))
@@ -9657,7 +9465,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "d2d533ec-c053-410c-8787-99f6c29ed54e")
+		(uuid "f777748b-7ea7-45cd-89cb-e15090274343")
 	)
 	(wire
 		(pts (xy 20.32 160.02) (xy 17.78 160.02))
@@ -9665,7 +9473,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "74f6a21a-92ce-4e28-94df-196b43389a2b")
+		(uuid "9d3684c1-1d63-4b22-83d6-81a5374087a8")
 	)
 	(wire
 		(pts (xy 20.32 199.39) (xy 17.78 199.39))
@@ -9673,7 +9481,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "c483bccf-c6d9-4155-92cb-24caa9900e36")
+		(uuid "20572a09-e4f9-4f9d-8027-958ad396bef2")
 	)
 	(wire
 		(pts (xy 27.94 179.07) (xy 38.1 179.07))
@@ -9681,7 +9489,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "79e25ea3-f5b1-48a1-a68f-29f062be5f45")
+		(uuid "d0347fe2-f2b3-4c37-9a37-85d3ba423580")
 	)
 	(wire
 		(pts (xy 102.87 165.1) (xy 102.87 194.31))
@@ -9689,7 +9497,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "3476cf07-f92d-4d23-bd2d-1264170b9961")
+		(uuid "4021ec9b-55b7-4e80-aa09-560e5b05ab29")
 	)
 	(wire
 		(pts (xy 95.25 160.02) (xy 92.71 160.02))
@@ -9697,7 +9505,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "6bb86d54-f340-4197-b8b4-5b869d4bdcf3")
+		(uuid "fba61610-ea77-4311-a3d3-5130cc66ed79")
 	)
 	(wire
 		(pts (xy 95.25 199.39) (xy 92.71 199.39))
@@ -9705,7 +9513,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "52b1ce5e-bdb9-40a9-a134-ed1eadbd9667")
+		(uuid "3e8b0a7a-b4b3-44f4-bdf5-a44a7571781d")
 	)
 	(wire
 		(pts (xy 102.87 179.07) (xy 113.03 179.07))
@@ -9713,7 +9521,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "5c6d9b2a-7dd8-4816-8a86-5f5f49fdf51f")
+		(uuid "798f61a0-fb8b-47e3-bb95-65ca987792be")
 	)
 	(wire
 		(pts (xy 177.8 165.1) (xy 177.8 194.31))
@@ -9721,7 +9529,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "08144ea0-7b5b-4180-a5b8-916bc23abb7c")
+		(uuid "22ebaa3c-2cbb-4f93-9692-00aec375c13f")
 	)
 	(wire
 		(pts (xy 170.18 160.02) (xy 167.64 160.02))
@@ -9729,7 +9537,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "787dc23c-555d-42c0-b752-ba690d5516b8")
+		(uuid "1d5f93c7-c7fd-4143-ab7c-aa09bb9d0b55")
 	)
 	(wire
 		(pts (xy 170.18 199.39) (xy 167.64 199.39))
@@ -9737,7 +9545,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "8903eafc-66e5-48e4-9463-0868aeedd541")
+		(uuid "d9afdcbc-ea52-492c-918e-8683085f8a1f")
 	)
 	(wire
 		(pts (xy 177.8 179.07) (xy 187.96 179.07))
@@ -9745,7 +9553,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "ca43bcad-9526-44cc-879d-66448d967a3d")
+		(uuid "b4737828-09d9-41a0-9f8a-712c667ecc5a")
 	)
 	(wire
 		(pts (xy 27.94 154.94) (xy 27.94 25.4))
@@ -9753,7 +9561,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "a09ae351-1da1-40ae-9313-c8b8653e682b")
+		(uuid "37cd1e9a-7990-48ef-aa27-6a1e6a5a7bc7")
 	)
 	(wire
 		(pts (xy 27.94 204.47) (xy 27.94 279.4))
@@ -9761,7 +9569,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "e495899a-6450-4fcc-be60-9383ce8c0fb8")
+		(uuid "351f2bcf-3223-4559-9439-f18cbb6fb545")
 	)
 	(wire
 		(pts (xy 102.87 154.94) (xy 102.87 25.4))
@@ -9769,7 +9577,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "d459b984-eff8-4329-a033-b813d01e795a")
+		(uuid "00813b74-0050-4fc8-9e51-4a21997996db")
 	)
 	(wire
 		(pts (xy 102.87 204.47) (xy 102.87 279.4))
@@ -9777,7 +9585,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "bfd164d2-6056-4562-8ea3-9a1c0b4adc75")
+		(uuid "c37da25f-9e90-47e9-967b-be03cf28974f")
 	)
 	(wire
 		(pts (xy 177.8 154.94) (xy 177.8 25.4))
@@ -9785,7 +9593,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "c34f9ce2-361c-496c-99aa-48b7e593ea65")
+		(uuid "2f45a618-2722-448a-9c4d-dfb29efa9882")
 	)
 	(wire
 		(pts (xy 177.8 204.47) (xy 177.8 279.4))
@@ -9793,15 +9601,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "24cb7a86-5b25-46dc-b141-fdde2b0e159f")
-	)
-	(wire
-		(pts (xy 25.4 243.84) (xy 25.4 279.4))
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "87e123f4-00c7-4503-8320-4b963874de19")
+		(uuid "5c577cfc-f8cb-42a2-8c69-f5ed5c84a89a")
 	)
 	(wire
 		(pts (xy 27.94 204.47) (xy 25.4 236.22))
@@ -9809,7 +9609,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "8b35131c-f54e-458d-a797-1a29be1d07a9")
+		(uuid "fa0ba2c3-484f-4d84-9b8a-354ea62924f4")
 	)
 	(wire
 		(pts (xy 25.4 236.22) (xy 15.24 236.22))
@@ -9817,7 +9617,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "13c5c582-d62b-403c-baa0-f8e3b4733ba7")
+		(uuid "48642015-5efd-4d4c-9089-9c23934affb9")
 	)
 	(wire
 		(pts (xy 25.4 243.84) (xy 15.24 243.84))
@@ -9825,15 +9625,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "ad45967d-5734-42b9-94a0-270c3148d024")
-	)
-	(wire
-		(pts (xy 100.33 243.84) (xy 100.33 279.4))
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "55ebcf6b-70ed-4474-9360-a63f1cdb8a59")
+		(uuid "dec75c44-d5cd-4b80-ac1e-eab3bedbe53e")
 	)
 	(wire
 		(pts (xy 102.87 204.47) (xy 100.33 236.22))
@@ -9841,7 +9633,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "7ff5751a-d53f-42ed-8dd4-ec5823842fe7")
+		(uuid "e8604527-1ec5-42b9-98f4-7874011d4514")
 	)
 	(wire
 		(pts (xy 100.33 236.22) (xy 90.17 236.22))
@@ -9849,7 +9641,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "c45e0a42-fb3b-421c-8c8b-c9dc095e900d")
+		(uuid "42109eca-7966-4d4d-90bf-04cf79771fc2")
 	)
 	(wire
 		(pts (xy 100.33 243.84) (xy 90.17 243.84))
@@ -9857,15 +9649,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "c7252adc-ca61-4897-9d4a-2ae933b4d381")
-	)
-	(wire
-		(pts (xy 175.26 243.84) (xy 175.26 279.4))
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "50d34e08-3436-45ff-8343-55168a7879d5")
+		(uuid "0b42b273-300d-478f-9ed2-c15715dc1eb5")
 	)
 	(wire
 		(pts (xy 177.8 204.47) (xy 175.26 236.22))
@@ -9873,7 +9657,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "6a5dade0-d982-4215-aa82-c2d6b2557675")
+		(uuid "920b04a7-54d5-4cf3-b8b3-0f13ff1d4e03")
 	)
 	(wire
 		(pts (xy 175.26 236.22) (xy 165.1 236.22))
@@ -9881,7 +9665,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "4b86959f-ea09-4e44-8db2-d7f485fb9b21")
+		(uuid "920d9f7d-0064-4163-ad84-55eb8eeaf4eb")
 	)
 	(wire
 		(pts (xy 175.26 243.84) (xy 165.1 243.84))
@@ -9889,7 +9673,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "1677aa09-ccde-4e0c-8281-40fe9353aca4")
+		(uuid "542551d8-3b62-4556-8905-c446fdd6e560")
 	)
 	(wire
 		(pts (xy 265.43 177.8) (xy 43.18 177.8))
@@ -9897,7 +9681,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "91cafea5-5620-4d65-a571-b77530c3244e")
+		(uuid "9f39bc1e-786b-4427-81e0-8549ae117798")
 	)
 	(wire
 		(pts (xy 43.18 177.8) (xy 43.18 179.07))
@@ -9905,7 +9689,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "f146a2f5-7c16-4f9e-a115-346dc64b366d")
+		(uuid "730280ef-4840-4e8e-a891-b57303de9617")
 	)
 	(wire
 		(pts (xy 43.18 179.07) (xy 27.94 179.07))
@@ -9913,7 +9697,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "1343e069-6471-44b0-95da-1db98b5b3abc")
+		(uuid "12b224c5-eed3-4c8f-a385-2b1b9430ffb7")
 	)
 	(wire
 		(pts (xy 265.43 180.34) (xy 118.11 180.34))
@@ -9921,7 +9705,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "5931aed4-d8d9-4190-8021-2c6a189c5831")
+		(uuid "a0622c98-5470-401c-bcba-aaeb3fa1b72b")
 	)
 	(wire
 		(pts (xy 118.11 180.34) (xy 118.11 179.07))
@@ -9929,7 +9713,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "27468a9d-3516-45da-b318-fad7a74583c4")
+		(uuid "beca72db-774a-4c61-a3d5-c3c9176d4302")
 	)
 	(wire
 		(pts (xy 118.11 179.07) (xy 102.87 179.07))
@@ -9937,7 +9721,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "35608b1b-ca84-406c-8bda-5a4d5c9e67be")
+		(uuid "e1b3bc14-9f7d-4ac7-b8e1-ed419cf3c1f7")
 	)
 	(wire
 		(pts (xy 265.43 182.88) (xy 193.04 182.88))
@@ -9945,7 +9729,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "ca6a457f-6833-49e6-8084-38c7eb52d676")
+		(uuid "6c0a092a-e719-48a2-b67b-0454016c71aa")
 	)
 	(wire
 		(pts (xy 193.04 182.88) (xy 193.04 179.07))
@@ -9953,7 +9737,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "8d823c53-1450-472c-a98d-5b3c2b0c79ae")
+		(uuid "1bddab81-72c9-43e4-9db4-fc9b5400f536")
 	)
 	(wire
 		(pts (xy 193.04 179.07) (xy 177.8 179.07))
@@ -9961,7 +9745,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "72b30315-cde9-4b51-9170-2119eab65778")
+		(uuid "73dc98a5-6174-489c-b0a8-dbe105ae1a55")
 	)
 	(wire
 		(pts (xy 236.22 80.01) (xy 228.6 110.49))
@@ -9969,7 +9753,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "ebc5f448-efd6-477f-8141-9832dfe80cde")
+		(uuid "e66fae52-af8b-4ec6-bdfb-715c69a6b799")
 	)
 	(wire
 		(pts (xy 265.43 95.25) (xy 236.22 80.01))
@@ -9977,7 +9761,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "0150e207-a224-4348-8b55-65127e49ba3b")
+		(uuid "0383ae33-7809-44bc-9135-16b9c0c0ba81")
 	)
 	(wire
 		(pts (xy 236.22 80.01) (xy 240.03 95.25))
@@ -9985,7 +9769,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "0f2961b4-11d4-4c85-a28e-b6b6d4224795")
+		(uuid "875ed248-049a-4896-a206-1529b037a23b")
 	)
 	(wire
 		(pts (xy 228.6 80.01) (xy 228.6 64.77))
@@ -9993,7 +9777,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "b95eea66-0d29-40fe-818f-2812d2d44e10")
+		(uuid "39f09a7e-d19b-4a78-a8e2-a3eee6d85943")
 	)
 	(wire
 		(pts (xy 236.22 110.49) (xy 236.22 279.4))
@@ -10001,7 +9785,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "960c361a-de53-41f8-90ca-cb2c673be019")
+		(uuid "616c3a47-749a-4892-99ec-0340b76cc20f")
 	)
 	(wire
 		(pts (xy 227.33 82.55) (xy 219.71 113.03))
@@ -10009,7 +9793,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "c1a4b993-d176-4747-aa7e-4f74e37438dc")
+		(uuid "f7bdbf07-d91f-466e-809f-05418e2a0971")
 	)
 	(wire
 		(pts (xy 265.43 97.79) (xy 227.33 82.55))
@@ -10017,7 +9801,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "6cddd871-3a41-4e4f-b1b4-d88b77814a98")
+		(uuid "4ab8e12b-cd29-4b20-9391-e5e6e3f96453")
 	)
 	(wire
 		(pts (xy 227.33 82.55) (xy 240.03 97.79))
@@ -10025,7 +9809,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "e56db3f5-e43e-4c61-a361-c5a11c7cf3cb")
+		(uuid "9a8ed475-d619-41eb-b05b-212834472c43")
 	)
 	(wire
 		(pts (xy 219.71 82.55) (xy 219.71 64.77))
@@ -10033,7 +9817,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "fb216fc4-0a91-4104-9fc4-65163570d66a")
+		(uuid "89901f75-a90f-42bb-9141-aa0f10a5df88")
 	)
 	(wire
 		(pts (xy 227.33 113.03) (xy 227.33 279.4))
@@ -10041,7 +9825,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "d12399f1-b6ba-4999-aa80-4e2caef7160e")
+		(uuid "f337bcbf-b949-4ead-bd7c-957dd88a1f7b")
 	)
 	(wire
 		(pts (xy 219.71 85.09) (xy 212.09 115.57))
@@ -10049,7 +9833,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "acb12f77-07b7-4229-8ead-1bec8bf8c0a5")
+		(uuid "ceee47c3-555f-4820-ac07-6af59ee8286f")
 	)
 	(wire
 		(pts (xy 265.43 100.33) (xy 219.71 85.09))
@@ -10057,7 +9841,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "558da64d-b813-4e01-afcd-aa8501fe9699")
+		(uuid "f2c98d8e-7e0f-4bb0-a28f-3e42222035ed")
 	)
 	(wire
 		(pts (xy 219.71 85.09) (xy 240.03 100.33))
@@ -10065,7 +9849,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "f561d167-19e5-47c5-921f-b32685320025")
+		(uuid "f61a0148-f594-454b-bca3-16afb51abb78")
 	)
 	(wire
 		(pts (xy 212.09 85.09) (xy 212.09 64.77))
@@ -10073,7 +9857,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "e5ec1754-22e5-4ead-b580-8bd0ba2e3939")
+		(uuid "6693d90e-f51a-4685-bd49-9cdce010da08")
 	)
 	(wire
 		(pts (xy 219.71 115.57) (xy 219.71 279.4))
@@ -10081,7 +9865,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "bf20f867-ff22-4fbf-824c-57dc0ba42426")
+		(uuid "590b2329-e218-4f9d-a4dd-927386810179")
 	)
 	(wire
 		(pts (xy 265.43 102.87) (xy 265.43 64.77))
@@ -10089,7 +9873,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "afe4503c-92d4-499b-a0d1-e200257e710c")
+		(uuid "3fcc91b2-dd74-4cde-8bb3-505b9faed0b8")
 	)
 	(wire
 		(pts (xy 265.43 105.41) (xy 265.43 279.4))
@@ -10097,7 +9881,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "e6df5590-51d3-483d-a1da-ad5fe37c0c36")
+		(uuid "ec9ada0a-c6d7-4124-afe0-6da99b208008")
 	)
 	(wire
 		(pts (xy 190.5 123.19) (xy 190.5 130.81))
@@ -10105,7 +9889,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "8dba0245-eced-4d42-9bce-3409c957d4bb")
+		(uuid "b8257f73-d420-4338-bc5c-dac8303f6f12")
 	)
 	(wire
 		(pts (xy 190.5 115.57) (xy 190.5 64.77))
@@ -10113,7 +9897,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "3be05d78-1fc3-44cb-9fc7-fb69909bc80f")
+		(uuid "adb8a183-34af-4343-8ebd-960c9361291f")
 	)
 	(wire
 		(pts (xy 190.5 138.43) (xy 190.5 279.4))
@@ -10121,7 +9905,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "a551885e-1798-492a-bde0-c8bc9c9a37d2")
+		(uuid "f258ea4c-39e8-46f1-8781-2ca593b9599a")
 	)
 	(wire
 		(pts (xy 209.55 123.19) (xy 209.55 130.81))
@@ -10129,7 +9913,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "46051dfd-9e94-4ad9-a61b-bcff1cb01586")
+		(uuid "f443d312-f4b0-4177-9e2b-7ccf0a797be8")
 	)
 	(wire
 		(pts (xy 209.55 115.57) (xy 209.55 64.77))
@@ -10137,7 +9921,7 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "4f831409-a202-44e3-a493-952933e7febe")
+		(uuid "dd3f2b32-7c99-40ca-ab01-60d0ad45b210")
 	)
 	(wire
 		(pts (xy 209.55 138.43) (xy 209.55 279.4))
@@ -10145,388 +9929,565 @@
 			(width 0)
 			(type default)
 		)
-		(uuid "6907c979-cc23-4cc5-a1fa-c40fb7adf0ad")
+		(uuid "e70b70d1-098b-4adf-abc5-34f56e9f0fb7")
+	)
+	(wire
+		(pts (xy 227.33 137.16) (xy 222.25 137.16))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "44d5f9e1-9b6b-4a52-8712-309001bd61d1")
+	)
+	(wire
+		(pts (xy 229.87 137.16) (xy 214.63 137.16))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9d06c6b7-e289-49f5-a585-73d1af310255")
+	)
+	(wire
+		(pts (xy 232.41 137.16) (xy 212.09 137.16))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cc0f0af3-3367-4c83-a6c0-08d8b4534a40")
+	)
+	(wire
+		(pts (xy 232.41 190.5) (xy 222.25 190.5))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "41512b9a-d932-4ab6-8952-f6452fee17ad")
+	)
+	(wire
+		(pts (xy 229.87 190.5) (xy 214.63 190.5))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "23d19c40-12c8-4b43-be3a-4bc8b3a4436e")
+	)
+	(wire
+		(pts (xy 229.87 190.5) (xy 214.63 190.5))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e2acd3cb-176a-48cc-b408-e9f1f5608461")
+	)
+	(wire
+		(pts (xy 217.17 144.78) (xy 212.09 144.78))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a71bf5d7-7c2e-4ebb-b9df-1015e7ddcc84")
+	)
+	(wire
+		(pts (xy 242.57 144.78) (xy 247.65 144.78))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "359bc1d1-3e11-4092-a161-ca7587dd9133")
+	)
+	(wire
+		(pts (xy 242.57 147.32) (xy 247.65 147.32))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6f06acde-038e-41a5-be7e-beb4996accf5")
+	)
+	(wire
+		(pts (xy 242.57 149.86) (xy 247.65 149.86))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a873ec7d-70b3-494a-bc67-45eff8d29032")
+	)
+	(wire
+		(pts (xy 242.57 160.02) (xy 247.65 160.02))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "065063e9-e2b0-4dd9-b13e-f4930ec9d585")
+	)
+	(wire
+		(pts (xy 242.57 162.56) (xy 247.65 162.56))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "10c03728-2ebb-4c92-9922-70c441cba6d7")
+	)
+	(wire
+		(pts (xy 217.17 157.48) (xy 222.25 157.48))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8ea6d534-b018-4b2f-867c-cf072de03ee8")
+	)
+	(wire
+		(pts (xy 242.57 165.1) (xy 247.65 165.1))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "83c5b152-2fc4-426a-8f65-55366983d373")
+	)
+	(wire
+		(pts (xy 242.57 167.64) (xy 247.65 167.64))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "80cfd943-83fc-4a62-8dd6-04cde7620e5f")
+	)
+	(wire
+		(pts (xy 242.57 170.18) (xy 247.65 170.18))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9366ad5e-1117-4643-a24c-ad2bf86f5d3e")
+	)
+	(wire
+		(pts (xy 242.57 177.8) (xy 267.97 177.8))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d9d77f01-0ca5-4276-990d-4a275662b0be")
+	)
+	(wire
+		(pts (xy 242.57 180.34) (xy 267.97 180.34))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4328809a-5337-4743-a942-331d40d75754")
+	)
+	(wire
+		(pts (xy 217.17 160.02) (xy 222.25 160.02))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e7d2bc58-0605-4776-a4d5-fc6a335c3283")
+	)
+	(wire
+		(pts (xy 217.17 167.64) (xy 222.25 167.64))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f854e443-a79d-4bc7-bbe6-355a7cae346a")
+	)
+	(wire
+		(pts (xy 217.17 170.18) (xy 222.25 170.18))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5b8dfebc-7709-4ae7-b79e-493487242a84")
+	)
+	(wire
+		(pts (xy 217.17 172.72) (xy 222.25 172.72))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "972d7fd2-fe70-4508-b129-df8d4c7a1899")
+	)
+	(wire
+		(pts (xy 217.17 149.86) (xy 212.09 149.86))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5bfe039d-060c-4c36-b9ec-576cfc983d81")
+	)
+	(wire
+		(pts (xy 217.17 152.4) (xy 212.09 152.4))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "78652a46-4dc6-4b94-8de0-383f8cff6228")
 	)
 	(junction
 		(at 31.75 25.4)
 		(diameter 0)
-		(uuid "378faf5f-2cbd-4908-8357-c6471a29c4ea")
+		(uuid "b4d235e4-4805-415e-b875-ef4017a7f027")
 	)
 	(junction
 		(at 111.76 44.45)
 		(diameter 0)
-		(uuid "29d0eb97-0c2a-40b6-9581-cbaa23e96124")
+		(uuid "1b8ddbe9-f473-482d-9c75-cefd83516592")
 	)
 	(junction
 		(at 165.1 64.77)
 		(diameter 0)
-		(uuid "51d23f5d-c241-4d60-9fde-7537c362cbe7")
+		(uuid "b178d0e5-3451-40d8-8090-7ef17820505b")
 	)
 	(junction
 		(at 299.72 279.4)
 		(diameter 0)
-		(uuid "548f8661-b3b2-4b2e-b9e7-c17432781e72")
+		(uuid "40977f8e-7049-4f35-8e23-853eb72b2b9c")
 	)
 	(junction
 		(at 44.45 25.4)
 		(diameter 0)
-		(uuid "2f155b2c-d5b8-4d25-9336-0fa02a65ca9f")
+		(uuid "9ac80213-c876-43f1-bd6d-695cde16e7e0")
 	)
 	(junction
 		(at 64.77 25.4)
 		(diameter 0)
-		(uuid "6cbcf42f-42b5-4fa5-9f7c-cad3264d0c57")
+		(uuid "851d8a98-6670-4ef2-bd3f-c99c72ad3d8b")
 	)
 	(junction
 		(at 64.77 279.4)
 		(diameter 0)
-		(uuid "7e33cacc-c83c-4268-a73d-cc438b3d30a2")
+		(uuid "f20f693f-a53b-4675-bf62-428c7e7193a0")
 	)
 	(junction
 		(at 80.01 25.4)
 		(diameter 0)
-		(uuid "148b1dc7-49c6-4d80-bc97-8945c663c2fe")
+		(uuid "c2c65eec-617a-48a8-a0db-a6953dcb5936")
 	)
 	(junction
 		(at 80.01 279.4)
 		(diameter 0)
-		(uuid "5593aca1-3441-4d7d-8965-50eb99ab0f22")
+		(uuid "544d23e9-ee9d-45e5-8610-a9d5cf0fabb9")
 	)
 	(junction
 		(at 95.25 25.4)
 		(diameter 0)
-		(uuid "f48d29c2-43ae-4e78-9b56-6dfa998a7739")
+		(uuid "ee345fd0-17b1-4488-a906-157908171132")
 	)
 	(junction
 		(at 95.25 279.4)
 		(diameter 0)
-		(uuid "c9ad38bc-6071-4ed1-a180-ca2011034b82")
+		(uuid "330a3863-232c-4a40-bec4-b96f3ceb276c")
 	)
 	(junction
 		(at 30.48 279.4)
 		(diameter 0)
-		(uuid "701932b6-41bb-4f03-86a2-e67bfc1463f9")
+		(uuid "d0f42b46-655c-4e43-8eed-61d7a36ff2df")
 	)
 	(junction
 		(at 105.41 96.52)
 		(diameter 0)
-		(uuid "22f16a17-ad94-499e-8d6a-4b4a6cb2a952")
+		(uuid "225f96b5-eb9c-4daf-b518-b4ef042e358c")
 	)
 	(junction
 		(at 105.41 111.76)
 		(diameter 0)
-		(uuid "530db1a5-966a-4cd4-baaa-fa384d2ece06")
+		(uuid "32927f65-4897-4c91-a044-c98ae9e52267")
 	)
 	(junction
 		(at 129.54 111.76)
 		(diameter 0)
-		(uuid "d6eb7aac-1f4b-4b61-8d16-7ce26aae4bf7")
+		(uuid "c944c6c0-9ef4-4b68-933c-fade8b93dfc9")
 	)
 	(junction
 		(at 54.61 25.4)
 		(diameter 0)
-		(uuid "aaef4e7b-97ff-4f04-98ee-9a38ee8e9ddf")
+		(uuid "36441918-e6a6-4466-8978-3afe2289b2bc")
 	)
 	(junction
 		(at 54.61 279.4)
 		(diameter 0)
-		(uuid "c4bdb435-4fdb-4314-8c86-9e8954ffa98c")
+		(uuid "6b3c205f-4c62-4209-9e8a-3d7bc82d6f34")
 	)
 	(junction
 		(at 129.54 44.45)
 		(diameter 0)
-		(uuid "53abc5a0-7b27-49bf-b007-8a6091d5103b")
+		(uuid "b5b64d85-3bcc-4bd1-b788-1e35063f9f37")
 	)
 	(junction
 		(at 129.54 279.4)
 		(diameter 0)
-		(uuid "5c028591-7421-4963-a2ef-4611cb5179b9")
+		(uuid "af972dd8-4dab-47c6-b1e9-e37aeb09f2e7")
 	)
 	(junction
 		(at 105.41 279.4)
 		(diameter 0)
-		(uuid "ce0641c3-3ab1-42fc-9033-b05161fcb811")
+		(uuid "917f460e-3f6f-47e5-9b5c-032b5b366007")
 	)
 	(junction
 		(at 67.31 25.4)
 		(diameter 0)
-		(uuid "03959058-c101-4a6c-93ab-e65108901f2a")
+		(uuid "9cb19d2e-6bf9-4e1b-97ec-365816e05e88")
 	)
 	(junction
 		(at 80.01 279.4)
 		(diameter 0)
-		(uuid "dce5ed73-312f-4ec5-93de-e4a09cc3bf42")
+		(uuid "e4e43995-77e1-4bbd-84da-4634137e872f")
 	)
 	(junction
 		(at 129.54 44.45)
 		(diameter 0)
-		(uuid "260010e5-9b4e-4680-9725-a4b6e920efa4")
+		(uuid "3d64777e-1f3c-4133-a1e9-79c319d03ce2")
 	)
 	(junction
 		(at 132.08 44.45)
 		(diameter 0)
-		(uuid "07d7d210-3881-4b01-8d89-5b8b207c2e51")
+		(uuid "129e0b0c-8446-4bd6-9581-38df80a255f1")
 	)
 	(junction
 		(at 147.32 64.77)
 		(diameter 0)
-		(uuid "11eab229-1576-42ca-9f0c-444b3f5bc0a7")
+		(uuid "4e04a75c-5fed-4c68-b16d-0b3456d2072b")
 	)
 	(junction
 		(at 139.7 279.4)
 		(diameter 0)
-		(uuid "92fbabf0-8586-4138-9ee0-75f64659df33")
+		(uuid "d1a9b9df-d53d-4abd-8d77-997f241d3ddc")
 	)
 	(junction
 		(at 119.38 44.45)
 		(diameter 0)
-		(uuid "f5214e65-8932-4319-823f-87e760a1759a")
+		(uuid "051ba133-a50a-418a-8aaf-e30e7029118a")
 	)
 	(junction
 		(at 119.38 279.4)
 		(diameter 0)
-		(uuid "d6380eaf-37af-4ee7-ae57-ce53da0c6cf7")
+		(uuid "cbcf8467-74bf-4353-8603-a75cce2e63c4")
 	)
 	(junction
 		(at 160.02 64.77)
 		(diameter 0)
-		(uuid "3721a712-b323-4b88-b383-b163e68a3dde")
+		(uuid "e9442c97-7814-4fd0-8202-37f39eb10b91")
 	)
 	(junction
 		(at 160.02 279.4)
 		(diameter 0)
-		(uuid "aa49360d-e572-4784-96c1-53de03ebe875")
+		(uuid "073cc105-49d7-49ff-b611-d6482cabeefa")
 	)
 	(junction
 		(at 67.31 279.4)
 		(diameter 0)
-		(uuid "e96f740a-2200-4fdd-896e-c5d4e6c2a6a0")
+		(uuid "498f8512-75aa-494d-ae04-edc3c181c474")
 	)
 	(junction
 		(at 199.39 64.77)
 		(diameter 0)
-		(uuid "66f01027-c04a-42a8-91c0-5be280fbc21f")
+		(uuid "b11fb01e-2da0-4950-a962-592a4bd4c34e")
 	)
 	(junction
 		(at 199.39 279.4)
 		(diameter 0)
-		(uuid "7349d944-b013-4023-8540-e669e2153b1f")
+		(uuid "fa05e0d2-3ad6-4fd5-b35d-0f15b8daa4b0")
 	)
 	(junction
 		(at 209.55 64.77)
 		(diameter 0)
-		(uuid "57d0b5c4-0584-4bff-bb22-a8be56271dfa")
+		(uuid "3af78e26-179e-4597-a964-146c7b5127e0")
 	)
 	(junction
 		(at 209.55 279.4)
 		(diameter 0)
-		(uuid "caa45ced-7372-4b07-8f41-81697de46170")
+		(uuid "205b3588-6f3d-4c8f-b4ef-a518106e0451")
 	)
 	(junction
 		(at 219.71 64.77)
 		(diameter 0)
-		(uuid "4e467746-f962-41b0-be10-8cd196249985")
+		(uuid "4338ea49-a9c4-4dd4-8a36-c60069697b32")
 	)
 	(junction
 		(at 219.71 279.4)
 		(diameter 0)
-		(uuid "62d9d30e-b36a-45d9-b6f2-c5537d3f6ee4")
+		(uuid "549b07a4-a1c5-4886-8b83-0d6eb8658b06")
 	)
 	(junction
 		(at 262.89 100.33)
 		(diameter 0)
-		(uuid "56d5e124-7d42-4056-a5b2-a8d96df2274e")
+		(uuid "e0f7aa46-0330-457c-8239-7aa393aedaf1")
 	)
 	(junction
 		(at 278.13 100.33)
 		(diameter 0)
-		(uuid "2c470ba0-54dd-415a-acc9-cd242e5bf57f")
+		(uuid "d6c06151-5659-48c2-8008-6a08bdcce193")
 	)
 	(junction
 		(at 270.51 279.4)
 		(diameter 0)
-		(uuid "143eb506-d600-4292-acfc-4ffa11b27337")
+		(uuid "f8dc9671-8e71-4423-9f87-4724ac5bbdcb")
 	)
 	(junction
 		(at 294.64 64.77)
 		(diameter 0)
-		(uuid "89a6a0ad-746c-4a32-b9cd-371555175ae4")
+		(uuid "83baf94e-9c47-4271-bcc7-0feb0cf649c7")
 	)
 	(junction
 		(at 294.64 279.4)
 		(diameter 0)
-		(uuid "c6efa56b-54f4-422c-88df-6323764157e2")
+		(uuid "86d53001-878f-4ae0-bfd2-f92467f68b1c")
 	)
 	(junction
 		(at 299.72 44.45)
 		(diameter 0)
-		(uuid "c6749ebb-3cb2-4b51-bc5f-c6bce931eca2")
+		(uuid "8120e42e-3350-40c4-a49c-deb8471de64b")
 	)
 	(junction
 		(at 299.72 279.4)
 		(diameter 0)
-		(uuid "b2327684-9649-48ce-a811-649dd9001b20")
+		(uuid "4207a615-dcdc-45fa-92d0-9d6179891eb8")
 	)
 	(junction
 		(at 309.88 44.45)
 		(diameter 0)
-		(uuid "3a3bec6a-4638-484a-9385-ceb4e835648b")
+		(uuid "ccdb102e-5f9d-4f6f-99f3-f3f2c428bb7f")
 	)
 	(junction
 		(at 309.88 279.4)
 		(diameter 0)
-		(uuid "6a59885d-3c5c-4bd0-809c-9666c07719ef")
+		(uuid "6c5e709d-2266-46f9-8492-71a6c0b493b6")
 	)
 	(junction
 		(at 27.94 179.07)
 		(diameter 0)
-		(uuid "53e3e6c4-e723-4c55-a546-7060d6d66b84")
+		(uuid "656ebffa-715f-4f42-82f8-93dbaf26393f")
 	)
 	(junction
 		(at 102.87 179.07)
 		(diameter 0)
-		(uuid "9ae7bfdd-1e47-4558-88f5-51b4bb0fec1b")
+		(uuid "b27e507b-60ad-4f56-9d68-bd3e02f123dd")
 	)
 	(junction
 		(at 177.8 179.07)
 		(diameter 0)
-		(uuid "67f705cc-26cb-4ee7-ba46-c5ad3bafae8f")
+		(uuid "a73c3a77-4fe9-4c02-b6f0-698e61015d41")
 	)
 	(junction
 		(at 27.94 25.4)
 		(diameter 0)
-		(uuid "a175a384-3fcc-43cb-a0d9-a9a01a92b3db")
+		(uuid "1a54a4b0-843d-4740-8339-c78b6fe2df0b")
 	)
 	(junction
 		(at 27.94 279.4)
 		(diameter 0)
-		(uuid "7edce1cc-037c-4155-8849-4dbe95e5d088")
+		(uuid "53e64632-991e-44cb-9a82-92bc44b7121b")
 	)
 	(junction
 		(at 102.87 25.4)
 		(diameter 0)
-		(uuid "1a43e820-99e0-47f6-b868-f1e1399baa74")
+		(uuid "3e109fdb-38d3-4105-ba75-7e83dcf39491")
 	)
 	(junction
 		(at 102.87 279.4)
 		(diameter 0)
-		(uuid "3e9a1460-9347-4744-976e-fd1973e3dfcb")
+		(uuid "c605ae80-85c6-4844-9b10-97eef980525f")
 	)
 	(junction
 		(at 177.8 25.4)
 		(diameter 0)
-		(uuid "58c399c4-2e9a-47cd-98dd-85d5236a8143")
+		(uuid "982b1a53-d537-46e3-818c-b1029f509070")
 	)
 	(junction
 		(at 177.8 279.4)
 		(diameter 0)
-		(uuid "fa1106c4-1582-4712-b968-b30376719d3b")
-	)
-	(junction
-		(at 25.4 279.4)
-		(diameter 0)
-		(uuid "1bced146-6e5c-4e7a-8211-6d77dfe18e4a")
-	)
-	(junction
-		(at 100.33 279.4)
-		(diameter 0)
-		(uuid "b39224ad-841f-4380-8a8c-8dd5c23413f9")
-	)
-	(junction
-		(at 175.26 279.4)
-		(diameter 0)
-		(uuid "06e7dd3a-6d44-404e-96c5-0c464f353538")
+		(uuid "ee72a767-8d64-4c58-aca8-a6c5e4c13186")
 	)
 	(junction
 		(at 27.94 179.07)
 		(diameter 0)
-		(uuid "9023ad50-8959-42f0-9aea-1e79313d11d4")
+		(uuid "b7236a0d-603c-4eb2-b79e-71c84dd9cc14")
 	)
 	(junction
 		(at 102.87 179.07)
 		(diameter 0)
-		(uuid "9b4f0f8d-0b4a-4340-af97-3ad695c862f7")
+		(uuid "b3663d2f-30d1-49d0-9bad-49ff1b3120b2")
 	)
 	(junction
 		(at 177.8 179.07)
 		(diameter 0)
-		(uuid "2a1beab4-d53c-4e6c-992a-646848f9e89e")
+		(uuid "fac6d011-07e3-412a-99ed-9ffcaf42afd9")
 	)
 	(junction
 		(at 228.6 64.77)
 		(diameter 0)
-		(uuid "82e90a44-f38c-4bff-8b09-b2ed6a4aff16")
+		(uuid "9dc3fb7f-0107-41b0-b4be-2c3a9235511d")
 	)
 	(junction
 		(at 236.22 279.4)
 		(diameter 0)
-		(uuid "75ab94c7-75fd-4677-a414-115bc28e02c1")
+		(uuid "07bc97cd-9819-48e1-9fdd-7a97194e2623")
 	)
 	(junction
 		(at 219.71 64.77)
 		(diameter 0)
-		(uuid "8a539f28-df09-48bc-9a4c-d3680f64f121")
+		(uuid "1e3fdfc4-85c2-4e28-96c2-b07049a213ef")
 	)
 	(junction
 		(at 227.33 279.4)
 		(diameter 0)
-		(uuid "d9fe62ec-218f-4316-a897-783e78c2bd2c")
+		(uuid "1ac24692-ee13-4b98-b8b4-8900281ff682")
 	)
 	(junction
 		(at 212.09 64.77)
 		(diameter 0)
-		(uuid "3e64ea41-9f16-4e3c-85be-1ef77e933fce")
+		(uuid "0eda6f86-0893-4bf9-9ad2-1a94d9a84948")
 	)
 	(junction
 		(at 219.71 279.4)
 		(diameter 0)
-		(uuid "3ad73e0d-48e0-43f3-bdf2-4cbf7178e2ab")
+		(uuid "7d0ad095-5c6c-45ab-84e1-a651d76d5de9")
 	)
 	(junction
 		(at 265.43 64.77)
 		(diameter 0)
-		(uuid "89dd194a-cd47-4830-beef-88e7f6c4fc7e")
+		(uuid "4597d6b9-ae47-4d4f-a6a1-04bbf43dd601")
 	)
 	(junction
 		(at 265.43 279.4)
 		(diameter 0)
-		(uuid "1b4d5899-624d-45f1-84b1-1eb7649392a1")
+		(uuid "9878873f-4097-44e9-8c93-e499081143e9")
 	)
 	(junction
 		(at 190.5 64.77)
 		(diameter 0)
-		(uuid "bb782878-3408-4608-b0f9-bb09741cc761")
+		(uuid "a1489b12-c45c-4877-8e2d-c7e0e3dba5a3")
 	)
 	(junction
 		(at 190.5 279.4)
 		(diameter 0)
-		(uuid "11018673-37ee-4a9d-a85e-e3bdb14691f2")
+		(uuid "4a87f32d-f841-4387-b46e-da8f42346ed8")
 	)
 	(junction
 		(at 209.55 64.77)
 		(diameter 0)
-		(uuid "8b044d4d-f48d-44b1-b3ce-697dfb7ab345")
+		(uuid "5fb4fb0d-f21f-4741-9605-e42df2d31666")
 	)
 	(junction
 		(at 209.55 279.4)
 		(diameter 0)
-		(uuid "d6e178e3-1561-46f5-a0f2-5faec1ecb2a8")
+		(uuid "313d24d9-4721-492c-9444-0987038d6314")
 	)
-	(no_connect (at 242.57 152.4) (uuid "cbff7639-d47b-4a6f-9e0b-6eb9a9e5537c")
+	(no_connect (at 242.57 152.4) (uuid "30337aa0-3bd2-457f-a8d6-83a63dedfa5b")
 	)
-	(no_connect (at 242.57 154.94) (uuid "7eeb90fe-a449-4cea-998f-075959e910d5")
+	(no_connect (at 242.57 154.94) (uuid "0f778beb-b0c7-4152-98fd-29513047604f")
 	)
-	(no_connect (at 242.57 157.48) (uuid "e69ce53f-2d50-4264-8f78-84e1a01661a0")
+	(no_connect (at 242.57 157.48) (uuid "6fdc0674-0557-4ede-aeb6-3ac569801b71")
 	)
-	(no_connect (at 242.57 172.72) (uuid "9f1bece6-0a0e-43a6-8be9-fd0273e75561")
+	(no_connect (at 242.57 172.72) (uuid "067da3be-9826-440d-8b3e-594c127adc58")
 	)
-	(no_connect (at 242.57 175.26) (uuid "e6b7b30c-1273-4f41-913d-6ae139681cae")
+	(no_connect (at 242.57 175.26) (uuid "7d8d7182-2e24-4092-b801-7c6857b9148b")
 	)
-	(no_connect (at 242.57 182.88) (uuid "887dab25-7acf-4861-97e3-a6cdd37aa37a")
+	(no_connect (at 242.57 182.88) (uuid "349d8d91-176f-47ba-9424-72842a467eb7")
 	)
-	(no_connect (at 217.17 162.56) (uuid "5d555c5d-23c0-4294-875b-1a45acd949b4")
+	(no_connect (at 217.17 162.56) (uuid "e94f9597-8b84-443d-9c18-8da9153d1c35")
 	)
-	(no_connect (at 217.17 165.1) (uuid "cf23d275-8912-4487-ac1c-0b785c156047")
+	(no_connect (at 217.17 165.1) (uuid "25e49fda-75bf-472c-89a1-dbf9955407b0")
 	)
 	(label "VMOTOR"
 		(at 25.4 25.4 0)
@@ -10537,7 +10498,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "09ea881c-8374-4080-802d-14acf8bdbfd9")
+		(uuid "d18f46e5-f06a-4441-8b36-745471c841e5")
 	)
 	(label "+5V"
 		(at 105.41 44.45 0)
@@ -10548,7 +10509,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "7c1d52bd-1b23-43e6-9a06-de492a3ad652")
+		(uuid "56c3f167-dff8-4970-ab39-31ca050376d0")
 	)
 	(label "+3.3V"
 		(at 147.32 64.77 0)
@@ -10559,7 +10520,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "1def7ecb-c99f-48d6-9db4-2f194948d067")
+		(uuid "16951dd5-d712-4fc9-b2b0-936f6d5ddb8b")
 	)
 	(label "GND"
 		(at 25.4 279.4 0)
@@ -10570,7 +10531,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "0c127217-b422-481a-aa8a-1de840612231")
+		(uuid "3c4119f3-a65e-42e9-ba41-05676f58ccf8")
 	)
 	(label "VMOTOR"
 		(at 69.85 97.79 0)
@@ -10581,7 +10542,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "92ddc179-1c3d-4a91-bb86-1018a94d0279")
+		(uuid "6c4d743d-d7a8-4200-98c8-663ab6bcc6c6")
 	)
 	(label "GND"
 		(at 82.55 107.95 0)
@@ -10592,7 +10553,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "3c36364d-41d7-41b5-8e45-5b6f4614bc9d")
+		(uuid "b3b27932-68e6-45f3-b081-57ff4ef5286c")
 	)
 	(label "+5V"
 		(at 134.62 100.33 0)
@@ -10603,7 +10564,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "8373c936-0033-40ce-b993-f94a65d36fc7")
+		(uuid "e9f997b5-a37d-4649-b535-029140662ecb")
 	)
 	(label "+3.3V"
 		(at 149.86 100.33 0)
@@ -10614,7 +10575,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "3c548310-b737-47cb-ba4c-406f9d71edb4")
+		(uuid "bda8fd60-1684-4e09-816b-4400de632445")
 	)
 	(label "GND"
 		(at 137.16 107.95 0)
@@ -10625,271 +10586,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "3bc69554-2f70-4a84-82f9-39bb71d1a949")
-	)
-	(label "+3.3V"
-		(at 222.25 137.16 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "7caf766a-de23-48aa-9c97-3bdb072af1da")
-	)
-	(label "+3.3V"
-		(at 224.79 137.16 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "0b70ff1e-4027-4c3a-bdc7-aa400fcf9a0d")
-	)
-	(label "+3.3V"
-		(at 227.33 137.16 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "7a0bc3d2-b61b-416c-9389-258fe508619d")
-	)
-	(label "GND"
-		(at 227.33 190.5 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "0daeafab-8109-4328-9a84-5cd9f6371286")
-	)
-	(label "GND"
-		(at 224.79 190.5 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "efff02a7-c3ae-4350-8bcd-5c1dc17ccf25")
-	)
-	(label "GND"
-		(at 224.79 190.5 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "d7ef1011-310d-4572-b1f8-7a6f35c9b36f")
-	)
-	(label "NRST"
-		(at 212.09 144.78 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "1ff0f664-1698-46c9-8df1-c6b302e759b8")
-	)
-	(label "ISENSE_A-"
-		(at 247.65 144.78 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "f42d40ed-7359-4bfe-a0bb-d6d46669da5a")
-	)
-	(label "ISENSE_B-"
-		(at 247.65 147.32 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "e35b2b8e-93a0-47d0-ac4d-77e0863f9d95")
-	)
-	(label "ISENSE_C-"
-		(at 247.65 149.86 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "3b83f428-7ef4-48f0-8835-91a5eeec9cd8")
-	)
-	(label "HALL_A"
-		(at 247.65 160.02 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "7bd6bc0b-bdfa-4b45-a258-071a79b66992")
-	)
-	(label "HALL_B"
-		(at 247.65 162.56 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "5606f05e-2aef-4b98-a5db-50e877b00309")
-	)
-	(label "HALL_C"
-		(at 222.25 157.48 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "efc22f48-a114-47fb-933b-5d83e328216c")
-	)
-	(label "PWM_AH"
-		(at 247.65 165.1 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "ab7637d7-edf3-4689-b15f-7a917fcdc2ac")
-	)
-	(label "PWM_BH"
-		(at 247.65 167.64 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "426fe5ce-0395-4d97-a5c9-6f0a8720f530")
-	)
-	(label "PWM_CH"
-		(at 247.65 170.18 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "95d0aad6-a2f2-4202-b7f7-a66910fde2ad")
-	)
-	(label "SWDIO"
-		(at 247.65 177.8 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "78b7c855-7cd9-4063-b47b-99723e1a3510")
-	)
-	(label "SWCLK"
-		(at 247.65 180.34 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "a5a5f248-a4fa-47d7-a626-37843d3d0704")
-	)
-	(label "SWO"
-		(at 222.25 160.02 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "6c5cf3a9-478d-45bd-aade-f2e71ffa0954")
-	)
-	(label "PWM_AL"
-		(at 222.25 167.64 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "03e0593c-6efb-4969-b3da-c8c7260d2ec0")
-	)
-	(label "PWM_BL"
-		(at 222.25 170.18 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "35035637-bb14-44ba-843a-8f96de116204")
-	)
-	(label "PWM_CL"
-		(at 222.25 172.72 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "43ade40a-658a-4b8c-94c1-ff66ee783f9f")
-	)
-	(label "OSC_IN"
-		(at 212.09 149.86 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "a9825c2f-0feb-4ec5-a579-b624b8a7c8ae")
-	)
-	(label "OSC_OUT"
-		(at 212.09 152.4 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "348db898-7dbd-42ed-9e43-4223f90d9527")
+		(uuid "33c41431-27c2-4d77-9a71-68d65c67bf57")
 	)
 	(label "OSC_IN"
 		(at 261.62 100.33 0)
@@ -10900,7 +10597,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "fa165018-f57c-4e29-a52b-441fc750fe1f")
+		(uuid "9896dc38-a536-4535-a394-f4cccc8596dd")
 	)
 	(label "OSC_OUT"
 		(at 279.4 100.33 0)
@@ -10911,7 +10608,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "82501cf8-25d4-4e51-adea-56bcd066168b")
+		(uuid "e8512d43-0030-40dd-8dca-559ffc7a0168")
 	)
 	(label "+3.3V"
 		(at 292.1 95.25 0)
@@ -10922,7 +10619,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "8e9ce403-cf84-4d6c-87b3-ec8edb154246")
+		(uuid "6c8ecfb1-9e53-4b41-af3e-57172028b0b3")
 	)
 	(label "SWDIO"
 		(at 292.1 97.79 0)
@@ -10933,7 +10630,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "d0b6a917-ad31-48bd-b629-582e9c061146")
+		(uuid "ebb6f90b-8f1f-48a1-9f7b-57cf20558ac7")
 	)
 	(label "GND"
 		(at 292.1 100.33 0)
@@ -10944,7 +10641,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "0ad0162d-71ca-4fd7-8dd4-8e8e5cf7ecb2")
+		(uuid "345452d6-982f-4f19-8972-b4693f0c210d")
 	)
 	(label "SWCLK"
 		(at 292.1 102.87 0)
@@ -10955,7 +10652,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "f5722410-f4ea-4224-91d4-62d34ff28713")
+		(uuid "47104319-ceab-437d-a37a-2211a19a36f5")
 	)
 	(label "GND"
 		(at 292.1 105.41 0)
@@ -10966,7 +10663,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "7fab1f51-9590-4749-901d-c204cf9126dc")
+		(uuid "59daec07-a9c9-4c4a-aa6a-c43227f3121a")
 	)
 	(label "NRST"
 		(at 292.1 107.95 0)
@@ -10977,7 +10674,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "a9ef6a87-fc6a-474c-8681-19bf4c16ae78")
+		(uuid "93a0386c-7be2-496b-8bbd-becec95a7440")
 	)
 	(label "+3.3V"
 		(at 256.54 73.66 0)
@@ -10988,7 +10685,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "e0092f61-d8d3-452f-8c55-7069717d5a93")
+		(uuid "edb4666b-edb0-417d-b18e-6dbe95b374ef")
 	)
 	(label "+3.3V"
 		(at 256.54 71.12 0)
@@ -10999,7 +10696,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "cbbd6c64-6a42-4e70-88ce-d0a26157fa51")
+		(uuid "6e9dafc2-d51c-4c55-850c-0956ef033b3a")
 	)
 	(label "+3.3V"
 		(at 256.54 76.2 0)
@@ -11010,7 +10707,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "73ca6336-62c8-4dc8-9f95-3cc86bc1b84d")
+		(uuid "2eff90ab-bc1f-4af6-9aab-e024879967ee")
 	)
 	(label "+3.3V"
 		(at 256.54 81.28 0)
@@ -11021,7 +10718,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "b701668e-ed58-4ea8-8c72-f5daa04ecd09")
+		(uuid "2f3bfba6-ecba-4c52-a5ee-fb8e92b27038")
 	)
 	(label "+3.3V"
 		(at 256.54 96.52 0)
@@ -11032,7 +10729,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "a3775101-6dba-406e-8a91-c43866619863")
+		(uuid "d931ce0d-df0e-407a-a1ff-2f2071d00072")
 	)
 	(label "+3.3V"
 		(at 256.54 86.36 0)
@@ -11043,7 +10740,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "b7376aa7-6818-42ab-9ef8-77d26bca4abc")
+		(uuid "3d41f28c-b109-44f4-aa9e-34bcece51767")
 	)
 	(label "+3.3V"
 		(at 256.54 88.9 0)
@@ -11054,7 +10751,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "2b9b6393-6427-498d-9660-07a82e22f3c5")
+		(uuid "c49135cf-44ac-494f-841a-ea8e5d4c16eb")
 	)
 	(label "+3.3V"
 		(at 256.54 93.98 0)
@@ -11065,7 +10762,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "5901703f-7aed-45d3-bf40-140daa2e9bed")
+		(uuid "6b1a2ab1-7241-4344-8fca-e18a99b2ce20")
 	)
 	(label "GND"
 		(at 256.54 91.44 0)
@@ -11076,7 +10773,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "946e365e-7e6f-465a-ac69-9299dc6e2d5d")
+		(uuid "4376aced-c784-49f2-a143-2ec3a40e648e")
 	)
 	(label "GND"
 		(at 256.54 106.68 0)
@@ -11087,7 +10784,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "a006820e-f3bd-497c-96f6-73bf9cf4df9d")
+		(uuid "05cc8125-6661-45d0-9cce-5c729d85be2f")
 	)
 	(label "GND"
 		(at 256.54 104.14 0)
@@ -11098,7 +10795,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "edbbd2b8-f7fa-4edd-8ab5-3e3027022e25")
+		(uuid "a1b81302-e800-4742-a657-7c2de6a948ac")
 	)
 	(label "SPI_MISO"
 		(at 256.54 78.74 0)
@@ -11109,7 +10806,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "4c8f9678-38bd-46e2-8c32-7b824714a2d6")
+		(uuid "a27f428f-9a0f-4707-8a23-6300dcc13067")
 	)
 	(label "FGFB"
 		(at 256.54 101.6 0)
@@ -11120,7 +10817,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "56795b8c-c4d6-4465-a802-18f73fb26b72")
+		(uuid "284b3378-53b1-41a1-8a12-c30001f24f29")
 	)
 	(label "FGOUT"
 		(at 256.54 109.22 0)
@@ -11131,7 +10828,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "2e3f4ebc-f807-48c1-b013-06b74a487bc6")
+		(uuid "66be8fb5-07fa-4d9f-bb39-ad42d5aacd9a")
 	)
 	(label "DRV_FAULTn"
 		(at 256.54 111.76 0)
@@ -11142,7 +10839,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "23de3fd6-d21a-4817-991a-4c765be34b8d")
+		(uuid "9f670833-4ddf-4e3a-80fb-03c401d2a205")
 	)
 	(label "DRV_LOCKn"
 		(at 256.54 114.3 0)
@@ -11153,7 +10850,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "ef794c56-99d5-4da0-9a0f-3e3d5c27af37")
+		(uuid "e0b0ef0e-75a0-46fe-a75e-4d31c09ca4c5")
 	)
 	(label "GATE_DRV_AH"
 		(at 302.26 63.5 0)
@@ -11164,7 +10861,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "185d5e72-7bc4-4af9-9314-ea52a0aa963c")
+		(uuid "81b5f729-89ef-4462-9fa2-f2ac5e865c69")
 	)
 	(label "GATE_DRV_BH"
 		(at 302.26 73.66 0)
@@ -11175,7 +10872,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "3b04914e-c829-4e35-81e0-01bb3a5705df")
+		(uuid "7deb63d2-d5f5-40dc-a31e-a90e09631e2e")
 	)
 	(label "GATE_DRV_CH"
 		(at 302.26 83.82 0)
@@ -11186,7 +10883,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "c2e7137b-776a-4626-97bd-44d0acd02216")
+		(uuid "c617616c-30cb-4e95-9ed3-76710e9f400b")
 	)
 	(label "GATE_AL"
 		(at 302.26 68.58 0)
@@ -11197,7 +10894,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "fd1d8ef8-b830-4e4f-8885-0d9181cd4e9d")
+		(uuid "b0f1c988-6bf1-4a20-b2a4-2ba2ac222396")
 	)
 	(label "GATE_BL"
 		(at 302.26 78.74 0)
@@ -11208,7 +10905,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "3ad7ca42-c12d-484a-9a69-b1f20ec7461c")
+		(uuid "8b9767c3-7a80-447d-8501-a3bb22032bfc")
 	)
 	(label "GATE_CL"
 		(at 302.26 88.9 0)
@@ -11219,7 +10916,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "2acdcc87-14c1-4755-8710-b3e78e6a8b7d")
+		(uuid "314926f4-ad2d-45d5-a2a9-acca6012b819")
 	)
 	(label "BST_A"
 		(at 302.26 101.6 0)
@@ -11230,7 +10927,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "362dd1fd-4b5e-4fbb-b388-796f4828827e")
+		(uuid "546cc4c4-4cd3-4cdf-a410-e95b16855735")
 	)
 	(label "PHASE_A"
 		(at 302.26 104.14 0)
@@ -11241,7 +10938,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "9ae66d51-3c81-4900-be7f-cfa272f8ac41")
+		(uuid "335271b9-96e2-461c-9af9-a5a3a8daaa1b")
 	)
 	(label "BST_B"
 		(at 302.26 106.68 0)
@@ -11252,7 +10949,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "c53e263a-f53b-420a-8dad-c6b8d7ddde7b")
+		(uuid "d5780c85-c021-4813-b5b2-0868b0bf9d2e")
 	)
 	(label "PHASE_B"
 		(at 302.26 109.22 0)
@@ -11263,7 +10960,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "e0886c02-09d4-4718-b740-b83e4e5f57ce")
+		(uuid "bf61d3c0-a9c8-4522-8b88-cf5fe6f28852")
 	)
 	(label "BST_C"
 		(at 302.26 111.76 0)
@@ -11274,7 +10971,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "c76b3629-34d2-4b32-a2ef-12dea0f021bf")
+		(uuid "10989acb-618b-4c14-9da3-276eedd5ae59")
 	)
 	(label "PHASE_C"
 		(at 302.26 114.3 0)
@@ -11285,7 +10982,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "d330c44d-5e23-4b91-8142-f17438c4f9d6")
+		(uuid "704355db-77ce-4c7b-929d-fe289884d7e1")
 	)
 	(label "PHASE_A"
 		(at 302.26 66.04 0)
@@ -11296,7 +10993,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "e09a7289-c39e-4c11-aac8-56c8b3d44386")
+		(uuid "02053d09-8ebf-43a2-9f14-65e1bc81372a")
 	)
 	(label "PHASE_B"
 		(at 302.26 76.2 0)
@@ -11307,7 +11004,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "1384b166-063b-484c-a3c7-dbe41f9c9a9d")
+		(uuid "0bfc6ad3-69e1-472f-a669-6d2972b0d3c2")
 	)
 	(label "PHASE_C"
 		(at 302.26 86.36 0)
@@ -11318,7 +11015,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "24ae2314-a8e4-4afd-85aa-6c6e36011a87")
+		(uuid "1f589fcb-c79f-4e22-9562-80357fdaeb32")
 	)
 	(label "GND"
 		(at 302.26 96.52 0)
@@ -11329,7 +11026,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "a0caf537-e213-492a-a0a2-f440ad60f29c")
+		(uuid "17d557a9-fd6b-45a2-a633-0b72acba09c1")
 	)
 	(label "GND"
 		(at 279.4 119.38 0)
@@ -11340,7 +11037,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "2fcc3d6e-536d-410b-88b6-f5329d0211c4")
+		(uuid "c744cd53-dd92-4fb9-9455-09ab15879363")
 	)
 	(label "GND"
 		(at 284.48 119.38 0)
@@ -11351,7 +11048,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "791c05a5-772a-4481-a1ee-e68d29ebd5ac")
+		(uuid "0f9aaf53-265d-4af6-b734-14b16e8e0675")
 	)
 	(label "DRV_CP1"
 		(at 256.54 63.5 0)
@@ -11362,7 +11059,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "ddf297a8-ae71-4b08-9d2d-3cbee1cbcee2")
+		(uuid "4b8691bc-2b1a-4973-8f8a-89730d8d3369")
 	)
 	(label "DRV_CP2"
 		(at 256.54 66.04 0)
@@ -11373,7 +11070,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "dabd7a4d-0abf-45d5-a077-6d643c092eac")
+		(uuid "97952ee7-8ceb-4ece-8fd1-84161b3a0e45")
 	)
 	(label "DRV_VINT"
 		(at 271.78 55.88 90)
@@ -11384,7 +11081,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "7c3c6ab1-52ef-4314-9966-55e95e169497")
+		(uuid "33f0a0be-b8cd-4576-bdc5-9b851d5fe5d1")
 	)
 	(label "DRV_VCP"
 		(at 274.32 55.88 90)
@@ -11395,7 +11092,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "23f51753-d1a6-41fc-8285-97122c9ba33e")
+		(uuid "277390c5-6267-4c1e-8cd8-ac0160edda3b")
 	)
 	(label "VMOTOR"
 		(at 279.4 55.88 90)
@@ -11406,7 +11103,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "4428a4dd-ebf9-4ac5-b505-1904bee565ff")
+		(uuid "a7c74782-ddea-45c2-a181-e6a920b4d78a")
 	)
 	(label "DRV_VSW"
 		(at 281.94 55.88 90)
@@ -11417,7 +11114,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "397b0d0c-c67f-4169-9efd-64d4f4bda325")
+		(uuid "cf414d3c-35cd-45f5-972e-57986e93d5aa")
 	)
 	(label "DRV_VREG"
 		(at 284.48 55.88 90)
@@ -11428,7 +11125,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "83029aea-9be7-4120-bf51-b0cbf6d6bad8")
+		(uuid "dea18154-e6cc-4b84-85e7-ae96305b1c5d")
 	)
 	(label "BST_A"
 		(at 260.35 73.66 0)
@@ -11439,7 +11136,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "99472294-2c0d-4de6-a40d-e9a0087ba6b7")
+		(uuid "6e8c74ee-205c-4a89-a1fa-0c5b93803703")
 	)
 	(label "PHASE_A"
 		(at 260.35 86.36 0)
@@ -11450,7 +11147,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "babd838a-d9c5-4774-99a0-34cbb0d8d362")
+		(uuid "dafde3e7-41f6-4c1d-8125-2d912d99eab2")
 	)
 	(label "BST_B"
 		(at 270.51 73.66 0)
@@ -11461,7 +11158,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "9b54eed4-c88e-47fc-977c-1dcdcda332d0")
+		(uuid "99f81b0a-c7cc-4c71-9ea1-9c5961f82613")
 	)
 	(label "PHASE_B"
 		(at 270.51 86.36 0)
@@ -11472,7 +11169,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "24fb31ed-9a9b-446b-9a36-3895a403aaba")
+		(uuid "5d570bb6-72be-4aa5-9a0c-163cb07cfec9")
 	)
 	(label "BST_C"
 		(at 279.4 73.66 0)
@@ -11483,7 +11180,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "5065824c-7329-4201-b118-6b9a3f82e380")
+		(uuid "02b1f0c5-d0f8-442e-a172-9944d49dd03d")
 	)
 	(label "PHASE_C"
 		(at 279.4 86.36 0)
@@ -11494,7 +11191,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "0d2c7b09-6dbd-4dc6-ac0d-78f24831db7b")
+		(uuid "666acb14-bb0f-48a2-805e-0785e03620c3")
 	)
 	(label "GATE_DRV_AH"
 		(at 307.34 115.57 0)
@@ -11505,7 +11202,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "70bab074-8b2a-4ee2-b637-8b6178844042")
+		(uuid "6646a540-f2cb-42d1-997b-7796b4f15423")
 	)
 	(label "GATE_AH"
 		(at 312.42 123.19 0)
@@ -11516,7 +11213,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "157c9d03-2e2f-4e55-8c3d-825f9df4e1e3")
+		(uuid "279761de-33d9-4c6c-bd1c-795c930562e3")
 	)
 	(label "GATE_DRV_BH"
 		(at 317.5 115.57 0)
@@ -11527,7 +11224,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "aaafdb68-21f2-4e6d-ba4b-64b576e447cf")
+		(uuid "6875ee0c-8f0f-4807-97a4-fecdb3693fab")
 	)
 	(label "GATE_BH"
 		(at 322.58 123.19 0)
@@ -11538,7 +11235,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "78ff042d-7f98-4916-b334-c6fe65d24f90")
+		(uuid "59727a30-d9fe-4b9b-8061-d4096fc9432d")
 	)
 	(label "GATE_DRV_CH"
 		(at 327.66 115.57 0)
@@ -11549,7 +11246,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "c5a82603-80ac-4491-983c-c9954954743b")
+		(uuid "d96defd8-5536-4ac0-b49b-c6d9bd1bcd42")
 	)
 	(label "GATE_CH"
 		(at 332.74 123.19 0)
@@ -11560,7 +11257,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "32d7395a-378f-401e-92a0-0d8c95163d5e")
+		(uuid "0733efe6-79ff-45f0-ab1e-4028fe80bed9")
 	)
 	(label "GATE_AH"
 		(at 17.78 160.02 0)
@@ -11571,7 +11268,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "074d2d56-57a4-4277-86f7-29e808e04cf0")
+		(uuid "9d98b324-2972-4a99-b603-5cacf89eb101")
 	)
 	(label "GATE_AL"
 		(at 17.78 199.39 0)
@@ -11582,7 +11279,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "fd3855b3-868c-4aea-987f-269a4cdad574")
+		(uuid "a569cf5b-c63e-48a1-8ac4-72f849e245f5")
 	)
 	(label "PHASE_A"
 		(at 38.1 179.07 0)
@@ -11593,7 +11290,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "1f5b2812-a4ea-448c-ae82-32bd407d3236")
+		(uuid "e7626e5b-9eff-4d3e-9965-5aab34852bf4")
 	)
 	(label "GATE_BH"
 		(at 92.71 160.02 0)
@@ -11604,7 +11301,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "7dab4ca8-cfc2-4e31-8696-c17decf3d1bf")
+		(uuid "4868f54b-2d0d-4366-b834-46fd6d1a3ac9")
 	)
 	(label "GATE_BL"
 		(at 92.71 199.39 0)
@@ -11615,7 +11312,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "0f0741a2-3f3f-49f9-a34a-358dc9347578")
+		(uuid "0f44381f-e8ca-46d1-b353-7ffda90ac256")
 	)
 	(label "PHASE_B"
 		(at 113.03 179.07 0)
@@ -11626,7 +11323,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "ba2f06de-44e4-4f14-a5f2-07ee07e72455")
+		(uuid "d5b3920a-7a61-49c7-8a0c-83d7806d1770")
 	)
 	(label "GATE_CH"
 		(at 167.64 160.02 0)
@@ -11637,7 +11334,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "c6b3697b-59ee-4790-8661-085ada7c3909")
+		(uuid "3bfbdb55-3166-487d-86df-823bb72d4753")
 	)
 	(label "GATE_CL"
 		(at 167.64 199.39 0)
@@ -11648,7 +11345,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "045c0bc1-2f38-4d39-96d0-8da9017e27f4")
+		(uuid "3c83cbf2-7d45-4178-a384-8092d42378ff")
 	)
 	(label "PHASE_C"
 		(at 187.96 179.07 0)
@@ -11659,7 +11356,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "bd4c0113-6cec-4c62-afc6-63f74a80a9a1")
+		(uuid "3ac23a8d-a4f9-403d-b3b7-f95549ab6313")
 	)
 	(label "ISENSE_A+"
 		(at 15.24 236.22 0)
@@ -11670,7 +11367,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "525020d4-47d8-4a92-bd00-451140ecfe32")
+		(uuid "b427817d-d49e-4226-89a8-4770ea2d4b6e")
 	)
 	(label "ISENSE_A-"
 		(at 15.24 243.84 0)
@@ -11681,7 +11378,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "8b4c6aa9-0aae-454c-baa4-0b9b1ef9c9a0")
+		(uuid "183f49a3-5a01-450e-9ca3-d41f2eaaf1bb")
 	)
 	(label "ISENSE_B+"
 		(at 90.17 236.22 0)
@@ -11692,7 +11389,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "92a2df00-0d26-4e9f-aa9c-a88380a89c83")
+		(uuid "14c43ddd-81ac-4282-b819-1087c3cf106e")
 	)
 	(label "ISENSE_B-"
 		(at 90.17 243.84 0)
@@ -11703,7 +11400,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "8e4ebca2-fb35-4a23-acb7-b662c1880f3e")
+		(uuid "c214e8a5-6374-4b94-96b9-8a357deb6faf")
 	)
 	(label "ISENSE_C+"
 		(at 165.1 236.22 0)
@@ -11714,7 +11411,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "00a83b6c-45ab-4c76-8ed3-105a8e061aad")
+		(uuid "fc984503-ed96-4e80-9582-080c63af8e00")
 	)
 	(label "ISENSE_C-"
 		(at 165.1 243.84 0)
@@ -11725,7 +11422,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "fc62c677-5988-4551-88ec-783fd573c56a")
+		(uuid "62527208-84cb-4675-9213-af2ef536f3aa")
 	)
 	(label "HALL_A"
 		(at 240.03 95.25 0)
@@ -11736,7 +11433,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "2da29541-bcba-4dd0-9050-fe4988875f06")
+		(uuid "b5e30159-3260-42e7-9de4-8a6914f4fd21")
 	)
 	(label "HALL_B"
 		(at 240.03 97.79 0)
@@ -11747,7 +11444,7 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "0db4f69f-40d9-4c9f-81f2-32a5ce3a475e")
+		(uuid "8391b56c-d242-47cc-ac69-8757d3934f0b")
 	)
 	(label "HALL_C"
 		(at 240.03 100.33 0)
@@ -11758,7 +11455,271 @@
 			)
 			(justify left bottom)
 		)
-		(uuid "74e5691f-4c8e-4fb8-a798-2957a2027dcc")
+		(uuid "a8e7cc3b-dfa6-41a6-b956-ad1d19e1f07a")
+	)
+	(label "+3.3V"
+		(at 222.25 137.16 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "9c00ac02-3fbd-4a23-8f65-3b12283ff299")
+	)
+	(label "+3.3V"
+		(at 214.63 137.16 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "2f8aa51a-7899-4eb3-8e82-f81cb67b7293")
+	)
+	(label "+3.3V"
+		(at 212.09 137.16 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "ca7f41cb-c8c9-4d4d-9386-fe16a405b611")
+	)
+	(label "GND"
+		(at 222.25 190.5 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "a5ab16db-7b8f-46b8-b9ba-2bf37ac93d18")
+	)
+	(label "GND"
+		(at 214.63 190.5 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "80c800d6-3bd9-45ad-ad34-3dac5161fe45")
+	)
+	(label "GND"
+		(at 214.63 190.5 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "297c8339-2fe3-458d-9a5a-ee76e4c6a4f3")
+	)
+	(label "NRST"
+		(at 212.09 144.78 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "3e492f0e-9cc2-47b3-b2c6-4c1116e13258")
+	)
+	(label "ISENSE_A-"
+		(at 247.65 144.78 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "79c615a5-508f-4c03-a55e-b0506e97a0bf")
+	)
+	(label "ISENSE_B-"
+		(at 247.65 147.32 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "cd6e558f-08c7-4746-bccd-dbf5b2806296")
+	)
+	(label "ISENSE_C-"
+		(at 247.65 149.86 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "037868ad-2516-49f4-9931-7d60611c3869")
+	)
+	(label "HALL_A"
+		(at 247.65 160.02 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "60741f17-7106-4a53-a393-f442b4a29cda")
+	)
+	(label "HALL_B"
+		(at 247.65 162.56 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "6401d68a-3ffc-4254-89bf-3396208b979c")
+	)
+	(label "HALL_C"
+		(at 222.25 157.48 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "d213bc33-0a5e-42e9-80c5-f8686058b6ad")
+	)
+	(label "PWM_AH"
+		(at 247.65 165.1 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "3bc7ef49-3145-4bb5-aad9-4127c92a2434")
+	)
+	(label "PWM_BH"
+		(at 247.65 167.64 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "6b853f69-95db-4527-abc0-1190410c5544")
+	)
+	(label "PWM_CH"
+		(at 247.65 170.18 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "a47737a2-7a07-48a9-a57b-e5badb427f56")
+	)
+	(label "SWDIO"
+		(at 267.97 177.8 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "7624625b-4398-4403-a01d-8f9ba011cd73")
+	)
+	(label "SWCLK"
+		(at 267.97 180.34 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "01c8295b-f85a-4d2b-ac10-f9c18429b95b")
+	)
+	(label "SWO"
+		(at 222.25 160.02 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "de2d13af-483a-4f8b-8435-140477ed00ad")
+	)
+	(label "PWM_AL"
+		(at 222.25 167.64 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "6dca98ce-3e3f-41f1-aca9-7be2518abe27")
+	)
+	(label "PWM_BL"
+		(at 222.25 170.18 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "c91c68e0-5ffa-44d4-9ec8-21ec44c9908b")
+	)
+	(label "PWM_CL"
+		(at 222.25 172.72 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "d6d6670b-0163-412b-852a-590a83aeb24a")
+	)
+	(label "OSC_IN"
+		(at 212.09 149.86 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "4b647915-68dc-4441-b6b1-c4f9154af452")
+	)
+	(label "OSC_OUT"
+		(at 212.09 152.4 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "57b314a9-dd6d-4963-8cf6-6f20a90900c8")
 	)
 	(text "BLDC Motor Controller Design Notes:\n=====================================\n1. MOSFETs Q1-Q6 require thermal vias (min 6 per device)\n2. Use 2mm+ trace width for motor phase and power traces\n3. Ground plane on bottom layer for heat spreading\n4. Keep gate drive traces short (<10mm)\n5. Kelvin connection for current sense resistors\n6. Separate analog ground near current sense\n7. Bulk capacitors near MOSFETs for motor current\n" (exclude_from_sim no) (at 25.4 299.72 0)
 		(effects
@@ -11767,10 +11728,10 @@
 			)
 			(justify left)
 		)
-		(uuid "9aa41553-f5fc-4711-8723-cc88ebce8983")
+		(uuid "39a4174d-a3c3-43fc-a996-dc71a423345c")
 	)
 	(sheet_instances
-		(path "/6d5b711c-e8e4-4a79-9276-ebb98f41bf1e" (page "1")
+		(path "/c1f30df2-ebb7-4d3e-8f8e-34649100dccf" (page "1")
 		)
 	)
 )

--- a/tests/test_board_05_u10_pin_emission.py
+++ b/tests/test_board_05_u10_pin_emission.py
@@ -1,0 +1,367 @@
+"""Regression test for board-05 U10 (STM32G431K8Tx) pin-label emission (#3379).
+
+PR #3377 fixed the ``kct pcb sync-netlist`` pipeline (kicad-cli ``/``-prefix
+strip + unconditional pin-to-pad mapping). Applying that fix to the existing
+board-05 schematic exposed a *separate* defect in ``design.py``: the helper
+``_connect_mcu_pin_to_label`` placed each U10 pin's stub-and-label without
+checking whether the label coordinate landed on the interior of a foreign
+wire. Three categories of silent bridge resulted:
+
+1. ``SWDIO`` (U10 pin 23) and ``SWCLK`` (U10 pin 24) ended up on the long
+   horizontal wires running from J2 (motor output connector) west to the
+   half-bridge phase nodes, bridging into ``PHASE_A`` / ``PHASE_B``.
+2. ``GND`` labels for U10 pins 14 / 16 / 32 landed at x=227.33, which sits
+   on a vertical HallSensorInput rail that also passes through the
+   ``+3.3V`` label row at y=137.16 -- the two labels collapsed onto a
+   single net and ``GND`` was reassigned to ``+3V3``.
+3. ``ISENSE_A-`` / ``B-`` / ``C-`` (U10 pins 5/6/7) collapsed onto
+   ``+3V3`` via the same x=227.33 collision (the labels themselves were
+   placed in a row where the +3.3V symbol-stub wire crossed).
+
+The kicad-cli netlist exporter reported ``U10.5/6/7 -> +3V3``,
+``U10.14/16/32 -> +3V3``, ``U10.23 -> PHASE_A``, ``U10.24 -> PHASE_B``
+-- eight mismatches against the design's intent. Applying
+``kct pcb sync-netlist`` then rewrote the committed PCB pad assignments
+to match, regressing DRC from 6 to 73 violations.
+
+The fix in ``design.py`` is twofold:
+
+* ``_connect_mcu_pin_to_label`` was rewritten to be collision-aware
+  (mirrors the ``_emit_pin_net_stub`` pattern in
+  ``schematic/blocks/_stub_helpers.py``).  Candidate label endpoints
+  are tried in priority order; the first that does *not* land on the
+  interior of an existing wire wins. L-shaped (horizontal + vertical)
+  fallbacks cover the dense SWDIO/SWCLK row. ``ValueError`` is raised
+  if no candidate clears.
+* The U10 pin labels are *deferred* to the end of
+  ``create_bldc_controller`` (after every other section has drawn its
+  wires), so the collision detector can see all foreign wires that
+  could potentially bridge.  Without deferral the future
+  ``PHASE_A`` / ``PHASE_B`` / HallSensorInput-rail wires don't exist
+  yet at U10-label-emission time.
+* The ``CurrentSenseShunt.connect_to_rails(gnd_rail_y=...)`` call was
+  removed for board 05; previously it shorted the ``ISENSE_X-`` net
+  to ``GND`` by wiring the shunt's IN- pin directly to the GND rail.
+  The committed PCB and U10 ADC topology require ``ISENSE_X-`` to be
+  a distinct Kelvin-sense net.
+
+This test exercises the full ``design.create_bldc_controller`` pipeline
+and asserts that:
+
+* every U10 signal pin lands on the correct labelled net (kicad-cli
+  netlist round-trip), and
+* the SWDIO/SWCLK labels are *not* electrically connected to PHASE_A
+  or PHASE_B (the original silent-bridge symptom).
+
+Acceptance criteria (per #3379):
+
+* AC1: U10.5/6/7 resolve to ISENSE_A-/B-/C- (not +3V3 or GND).
+* AC2: U10.23/24 resolve to SWDIO/SWCLK (not PHASE_A/B).
+* AC3: U10.14/16/32 resolve to GND (not +3V3).
+* AC4: All other U10 signal pins (HALL, PWM, NRST, OSC, SWO) match
+  their intended labels.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# The U10 pin -> intended net map.  Power-net names use the global
+# "+3V3" form (kicad-cli's serialization of the power:+3V3 symbol);
+# the "+3.3V" form is the local label-side name used inside
+# ``_connect_mcu_pin_to_label``.  They both refer to the same net.
+U10_EXPECTED_NETS: dict[str, set[str]] = {
+    # Power supply pins
+    "1": {"+3V3", "+3.3V"},  # VDD
+    "17": {"+3V3", "+3.3V"},  # VDD
+    "15": {"+3V3", "+3.3V"},  # VDDA
+    "14": {"GND"},  # VSSA
+    "16": {"GND"},  # VSS
+    "32": {"GND"},  # VSS
+    # Reset and crystal (kicad-cli `/`-prefixes local labels)
+    "4": {"NRST", "/NRST"},  # PG10 -> NRST
+    "2": {"OSC_IN", "/OSC_IN"},  # PF0
+    "3": {"OSC_OUT", "/OSC_OUT"},  # PF1
+    # ADC current-sense returns (the original #3379 mismatch set).
+    # kicad-cli prefixes the local label with `/` since these are
+    # not power symbols; the test allows either form.
+    "5": {"ISENSE_A-", "/ISENSE_A-"},  # PA0
+    "6": {"ISENSE_B-", "/ISENSE_B-"},  # PA1
+    "7": {"ISENSE_C-", "/ISENSE_C-"},  # PA2
+    # Hall sensor inputs
+    "11": {"HALL_A", "/HALL_A"},  # PA6
+    "12": {"HALL_B", "/HALL_B"},  # PA7
+    "13": {"HALL_C", "/HALL_C"},  # PB0
+    # High-side PWM (to gate driver INH_A/B/C)
+    "18": {"PWM_AH", "/PWM_AH"},  # PA8
+    "19": {"PWM_BH", "/PWM_BH"},  # PA9
+    "20": {"PWM_CH", "/PWM_CH"},  # PA10
+    # SWD debug pins (the original #3379 SWDIO/SWCLK mismatch set)
+    "23": {"SWDIO", "/SWDIO"},  # PA13
+    "24": {"SWCLK", "/SWCLK"},  # PA14
+    "26": {"SWO", "/SWO"},  # PB3
+    # Low-side PWM (to gate driver INL_A/B/C)
+    "29": {"PWM_AL", "/PWM_AL"},  # PB6
+    "30": {"PWM_BL", "/PWM_BL"},  # PB7
+    "31": {"PWM_CL", "/PWM_CL"},  # PB8
+}
+
+# Nets that the original #3379 bug silently bridged INTO. The test
+# asserts that none of the U10 signal pins resolve to these "wrong"
+# nets after the fix.  Each entry maps a U10 pin to the pre-fix net.
+U10_PREFIX_BRIDGE_VICTIMS: dict[str, str] = {
+    "5": "+3V3",  # ISENSE_A- was bridged to +3V3
+    "6": "+3V3",  # ISENSE_B- was bridged to +3V3
+    "7": "+3V3",  # ISENSE_C- was bridged to +3V3
+    "14": "+3V3",  # GND was bridged to +3V3
+    "16": "+3V3",  # GND was bridged to +3V3
+    "32": "+3V3",  # GND was bridged to +3V3
+    "23": "/PHASE_A",  # SWDIO was bridged to PHASE_A
+    "24": "/PHASE_B",  # SWCLK was bridged to PHASE_B
+}
+
+
+def _find_kicad_cli() -> str | None:
+    """Locate the kicad-cli binary; return None if unavailable.
+
+    Used to skip tests cleanly when KiCad is not installed (CI sandbox).
+    """
+    candidates = [
+        "/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli",
+        "/usr/local/bin/kicad-cli",
+        "/usr/bin/kicad-cli",
+    ]
+    for c in candidates:
+        if Path(c).exists():
+            return c
+    return None
+
+
+def _run_design_create_schematic(tmp_path: Path) -> Path:
+    """Run ``design.create_bldc_controller`` and return the schematic path.
+
+    Imports ``design`` directly from ``boards/05-bldc-motor-controller``
+    so the test exercises the actual emitter, not a copy.
+    """
+    repo_root = Path(__file__).parent.parent
+    board_dir = repo_root / "boards" / "05-bldc-motor-controller"
+    sys.path.insert(0, str(board_dir))
+    try:
+        import design  # noqa: PLC0415 - dynamic load by design
+
+        design.create_project(tmp_path, "bldc_controller")
+        sch_path = design.create_bldc_controller(tmp_path)
+        return sch_path
+    finally:
+        sys.path.remove(str(board_dir))
+
+
+def _parse_u10_pin_assignments(netlist_path: Path) -> dict[str, str]:
+    """Parse ``netlist_path`` and return a {pin -> net_name} map for U10.
+
+    Walks the kicad-cli sexpr netlist with a paren-matched scanner
+    rather than a regex over the whole file (the format is line-
+    folded so a flat regex misses ``(node (ref "U10") (pin "N"))``
+    blocks split across lines).
+    """
+    content = netlist_path.read_text()
+    nets_anchor = content.find("(nets")
+    if nets_anchor < 0:
+        return {}
+    text = content[nets_anchor:]
+
+    i = 0
+    net_blocks: list[str] = []
+    while True:
+        j = text.find("(net", i)
+        if j < 0:
+            break
+        # Must be a real "(net (code N) ..." block, not "(nets ..." or
+        # "(net_name ...".
+        head = text[j : j + 30]
+        if not re.match(r"\(net\s+\(code", head):
+            i = j + 1
+            continue
+        depth = 0
+        k = j
+        while k < len(text):
+            c = text[k]
+            if c == "(":
+                depth += 1
+            elif c == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+            k += 1
+        net_blocks.append(text[j : k + 1])
+        i = k + 1
+
+    u10: dict[str, str] = {}
+    for nb in net_blocks:
+        m = re.search(r'\(name\s+"([^"]*)"\)', nb)
+        if not m:
+            continue
+        net_name = m.group(1)
+        for pm in re.finditer(r'\(ref\s+"U10"\)\s*\(pin\s+"(\d+)"\)', nb):
+            u10[pm.group(1)] = net_name
+    return u10
+
+
+@pytest.fixture(scope="module")
+def u10_netlist(tmp_path_factory: pytest.TempPathFactory) -> dict[str, str]:
+    """Generate the board-05 schematic, export the kicad-cli netlist,
+    and parse U10's pin assignments.  Module-scoped so we only pay the
+    ~10s pipeline cost once per test session.
+
+    Skips the test module cleanly when kicad-cli is not installed
+    (e.g. CI sandboxes without KiCad).
+    """
+    kicad_cli = _find_kicad_cli()
+    if kicad_cli is None:
+        pytest.skip("kicad-cli not available; install KiCad to run this test")
+
+    tmp_path = tmp_path_factory.mktemp("board05_u10_pins")
+    sch_path = _run_design_create_schematic(tmp_path)
+    assert sch_path.exists(), f"Schematic not generated: {sch_path}"
+
+    netlist_path = tmp_path / "netlist.net"
+    result = subprocess.run(
+        [
+            kicad_cli,
+            "sch",
+            "export",
+            "netlist",
+            "--format",
+            "kicadsexpr",
+            str(sch_path),
+            "-o",
+            str(netlist_path),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    # Fontconfig warnings on macOS go to stderr but the export
+    # still succeeds; only fail if the netlist file is missing or
+    # empty.
+    assert netlist_path.exists(), f"kicad-cli failed: {result.stderr}"
+    assert netlist_path.stat().st_size > 1000, "Netlist file unexpectedly small"
+
+    u10 = _parse_u10_pin_assignments(netlist_path)
+    assert len(u10) >= 32, f"Expected >=32 U10 pin entries, got {len(u10)}: {u10}"
+    return u10
+
+
+class TestU10PinEmission:
+    """U10 pin-label emission round-trips through kicad-cli (#3379)."""
+
+    @pytest.mark.parametrize(
+        "pin, expected_nets",
+        sorted(U10_EXPECTED_NETS.items(), key=lambda kv: int(kv[0])),
+    )
+    def test_pin_resolves_to_intended_net(
+        self,
+        u10_netlist: dict[str, str],
+        pin: str,
+        expected_nets: set[str],
+    ) -> None:
+        """Each U10 signal pin lands on the intended net after the
+        kicad-cli netlist round-trip.
+
+        Parameterized for clear failure messages -- a regression on
+        SWDIO would fail only ``test_pin_resolves_to_intended_net[23-...]``
+        rather than the whole batch.
+        """
+        actual = u10_netlist.get(pin, "MISSING")
+        assert actual in expected_nets, (
+            f"U10.{pin} resolved to {actual!r}, expected one of "
+            f"{sorted(expected_nets)!r}. "
+            f"Likely cause: wire-stub collision in "
+            f"_connect_mcu_pin_to_label (issue #3379)."
+        )
+
+    def test_swdio_not_bridged_to_phase_a(
+        self, u10_netlist: dict[str, str]
+    ) -> None:
+        """U10.23 (SWDIO) must NOT be bridged to PHASE_A.
+
+        Pre-fix symptom: the SWDIO stub-and-label at (247.65, 177.80)
+        landed on the interior of the long horizontal PHASE_A wire
+        from J2 west to HB_A's VOUT, silently merging the SWDIO net
+        into PHASE_A.
+        """
+        assert u10_netlist.get("23") not in {"/PHASE_A", "PHASE_A"}, (
+            "U10.23 (SWDIO) is bridged to PHASE_A -- regression of #3379"
+        )
+
+    def test_swclk_not_bridged_to_phase_b(
+        self, u10_netlist: dict[str, str]
+    ) -> None:
+        """U10.24 (SWCLK) must NOT be bridged to PHASE_B.
+
+        Pre-fix symptom: the SWCLK stub-and-label at (247.65, 180.34)
+        landed on the long horizontal PHASE_B wire from J2 west to
+        HB_B's VOUT, silently merging the SWCLK net into PHASE_B.
+        """
+        assert u10_netlist.get("24") not in {"/PHASE_B", "PHASE_B"}, (
+            "U10.24 (SWCLK) is bridged to PHASE_B -- regression of #3379"
+        )
+
+    @pytest.mark.parametrize("pin", ["5", "6", "7"])
+    def test_isense_negative_not_bridged_to_power(
+        self, u10_netlist: dict[str, str], pin: str
+    ) -> None:
+        """U10.5/6/7 (ISENSE_A-/B-/C-) must NOT be bridged to +3V3.
+
+        Pre-fix symptom: the ISENSE_* labels at x=247.65, y in
+        (144.78, 147.32, 149.86) landed on a vertical
+        HallSensorInput rail wire crossing x=227.33 that also touched
+        the +3.3V label row at y=137.16, silently merging the ISENSE
+        nets into +3V3.
+        """
+        actual = u10_netlist.get(pin, "MISSING")
+        assert actual not in {"+3V3", "+3.3V", "GND"}, (
+            f"U10.{pin} (ISENSE) resolved to {actual!r} -- the "
+            f"original #3379 silent bridge into a power rail."
+        )
+
+    @pytest.mark.parametrize("pin", ["14", "16", "32"])
+    def test_gnd_pins_not_bridged_to_power(
+        self, u10_netlist: dict[str, str], pin: str
+    ) -> None:
+        """U10.14/16/32 (VSS/VSSA) must resolve to GND, not +3V3.
+
+        Pre-fix symptom: the GND label for VDD pin 14 at (227.33,
+        190.50) sat on a vertical HallSensorInput rail at x=227.33
+        that also crossed the +3.3V label row at y=137.16, silently
+        merging GND into +3V3.
+        """
+        actual = u10_netlist.get(pin, "MISSING")
+        assert actual == "GND", (
+            f"U10.{pin} (GND) resolved to {actual!r} -- the original "
+            f"#3379 silent bridge into +3V3."
+        )
+
+    def test_no_pre_fix_bridge_victims_remain(
+        self, u10_netlist: dict[str, str]
+    ) -> None:
+        """End-to-end summary check: every pin in the original #3379
+        bridge-victim set has moved off the wrong-net it was on
+        before the fix.
+
+        Acts as a backstop in case future refactors of the per-pin
+        tests above silently weaken individual assertions.
+        """
+        offenders = []
+        for pin, wrong_net in U10_PREFIX_BRIDGE_VICTIMS.items():
+            if u10_netlist.get(pin) == wrong_net:
+                offenders.append(f"U10.{pin} -> {wrong_net}")
+        assert not offenders, (
+            f"#3379 regression: the following U10 pins are still "
+            f"bridged to their original wrong nets: {offenders}"
+        )


### PR DESCRIPTION
## Summary

Closes #3379

PR #3377 fixed the kicad-cli `/`-prefix strip + unconditional pin-to-pad map in `kct pcb sync-netlist` but deliberately did not refresh the committed routed PCB because applying that sync exposed a *separate* defect in `boards/05-bldc-motor-controller/design.py`: `_connect_mcu_pin_to_label` placed each U10 stub-and-label without checking whether the label coordinate landed on the interior of a foreign wire.

Three categories of silent net-bridging resulted (verified via direct kicad-cli netlist export against the schematic at HEAD):

| U10 pin | label intent | actual (pre-fix) | bridge mechanism |
|---|---|---|---|
| `23` | `SWDIO` | `/PHASE_A` | label at (247.65, 177.80) sat on the long J2-to-HB_A `PHASE_A` wire |
| `24` | `SWCLK` | `/PHASE_B` | label at (247.65, 180.34) sat on the J2-to-HB_B `PHASE_B` wire |
| `5`/`6`/`7` | `ISENSE_A-/B-/C-` | `+3V3` | label row at y=144..149 sat on vertical HallSensorInput rail at x=227.33 that also crossed `+3.3V` at y=137.16 |
| `14`/`16`/`32` | `GND` | `+3V3` | leftward GND stub at x=227.33 sat on the same vertical rail, swallowed by the `+3.3V` net |

Applying `kct pcb sync-netlist` with those bridges in place rewrote U10's pad nets to match the schematic and regressed DRC from 6 to 73 violations, breaking the #3258 hot-spot invariant.

## Fix

Three changes in `boards/05-bldc-motor-controller/design.py`:

### 1. Collision-aware `_connect_mcu_pin_to_label`
Mirrors the `_emit_pin_net_stub` helper in `schematic/blocks/_stub_helpers.py`. Tries the requested geometry first, then escalates through:
1. progressively longer horizontal stubs in the same direction
2. a one-grid vertical nudge
3. the opposite-side stub
4. L-shaped routes (horizontal+vertical to a free row)

Snapped candidate coordinates are checked against `_stub_endpoint_would_collide`; the first collision-free candidate wins. `ValueError` is raised when no candidate clears -- silent net-bridging is unrecoverable at netlist time.

### 2. Deferred U10 label emission
The 24 U10 pin labels are now emitted *after* Section 11 (design notes) instead of inside Section 5. Without deferral the collision detector can't see the PHASE_A/B/C and HallSensorInput-rail wires drawn by Sections 7-9 *after* the original Section 5 U10-label loop. The deferred-emit list preserves the original per-pin `dx/dy` hints so collision-free placements stay on the same side as before.

### 3. ISENSE_- not shorted to GND in schematic
`CurrentSenseShunt.connect_to_rails(gnd_rail_y=RAIL_GND)` is intentionally NOT called for board 05. That helper would wire the shunt's `IN-` pin straight down to the global GND rail and short the `ISENSE_X-` label (placed on the same pin below) into `GND`, causing the U10 ADC sense pins to resolve to `GND` instead of the intended Kelvin-sense nets. The shunt's `IN-` is connected to GND *physically* via the PCB copper zone; only the schematic label is needed for the netlister because `ISENSE_X-` is consumed only by U10's ADC pins.

## Regression test

New `tests/test_board_05_u10_pin_emission.py` (33 cases) exercises `design.create_bldc_controller`, exports the kicad-cli netlist, and parametrically asserts:

- Every U10 signal pin (24 total) resolves to its intended net.
- `U10.23` (SWDIO) is NOT bridged to `PHASE_A`.
- `U10.24` (SWCLK) is NOT bridged to `PHASE_B`.
- `U10.5/6/7` (ISENSE_*-) are NOT bridged to a power rail.
- `U10.14/16/32` (VSS) resolve to `GND`, not `+3V3`.
- An end-to-end backstop verifies the original 8-pin bridge-victim set is empty.

## Verification

### U10 netlist round-trip (kicad-cli)

| pin | before | after |
|---|---|---|
| `5/6/7` | `+3V3` | `/ISENSE_A-` / `/ISENSE_B-` / `/ISENSE_C-` |
| `14/16/32` | `+3V3` | `GND` |
| `23` | `/PHASE_A` | `/SWDIO` |
| `24` | `/PHASE_B` | `/SWCLK` |
| **mismatch count** | **8 / 24** | **0 / 24** |

### Test status

- `test_board_05_u10_pin_emission` (NEW): 33/33 pass
- `test_board_05_drc_hotspot_regression`: 10/10 pass (hot-spot floor of 6 preserved)
- `test_board_05_drv8308_pin_nets`: pass
- `test_board_05_erc_regression`: pass
- `test_board_05_drift_regression`: pass
- `test_board_05_zones`, `test_board_05_thermal_stitch`, `test_board_05_buck_footprints`, `test_board_05_drc_allowlist`, `test_board_05_export`: all pass

### DRC and fleet status

| State | DRC errors | fleet drift |
|---|---|---|
| `main` (baseline, no sync) | 26 | 53 nets |
| `main` + sync (pre-#3379) | 99 (`kct check`) | 0 nets |
| this PR (no sync) | 26 | 53 nets |
| this PR + sync | 84 (`kct check`) | 0 nets |

This PR reduces post-sync DRC by **15 errors** vs the pre-#3379 sync floor (`99 -> 84`), entirely from removing the U10 silent bridges. The committed routed PCB is intentionally NOT refreshed because applying the sync still regresses `test_board_05_drc_hotspot_regression` -- see *Out of scope* below.

## Out of scope (separate follow-ups)

The U10 fix is structurally complete (8 / 24 U10 mismatches dropped to 0 / 24). Two residual sync regressions are out of scope for the `_connect_mcu_pin_to_label` locus identified by #3379:

1. **`R10/R11/R12.1` (ISENSE_X+) still bridges to GND in the schematic** via `HalfBridge.connect_to_rails`'s LS-source-to-GND wire. Fixing this requires placing the shunt in-line between the LS source and GND (a half-bridge topology rewrite). After sync this collapses R10-1 to `GND` and produces the 1027µm clearance_pad_segment shortfall that fails the hot-spot test.

2. **U3 (DRV8308 vs DRV8301 footprint mismatch) sync changes** introduced by PR #3377's pin-to-pad map fix. The schematic uses the DRV8308 symbol (39 pins) but the committed PCB uses the DRV8301 footprint (different pinout). Sync remaps schematic pin -> PCB pad and renames ~40 U3 pad nets; the existing routed traces no longer match the new pad nets.

Both items will need follow-up issues to refresh the committed routed PCB cleanly.

## Test plan
- [x] Run `pytest tests/test_board_05_u10_pin_emission.py` -- 33/33 pass
- [x] Run `pytest tests/test_board_05_drc_hotspot_regression.py` -- 10/10 pass
- [x] Run other board-05 tests -- all pass
- [x] Verify U10 netlist round-trip via direct kicad-cli export -- 0/24 mismatches