### PR TITLE
fix(boards/05): U3 DRV part-number triangle guard + custom DRV8301 symbol library (refs #3384)

### DIFF
--- a/boards/05-bldc-motor-controller/symbols/board05_custom.kicad_sym
+++ b/boards/05-bldc-motor-controller/symbols/board05_custom.kicad_sym
@@ -1,0 +1,164 @@
+(kicad_symbol_lib
+	(version 20231120)
+	(generator "kicad_tools")
+	(generator_version "1.0")
+	(symbol "DRV8301"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "U"
+			(at -12.7 38.1 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "DRV8301"
+			(at 1.27 38.1 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_SO:HTSSOP-56-1EP_6.1x14mm_P0.5mm_EP3.61x6.35mm"
+			(at 0 -42.0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://www.ti.com/lit/ds/symlink/drv8301.pdf"
+			(at 0 -44.0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Three Phase Pre-Driver, HTSSOP-56 (DCA package)"
+			(at 0 -46.0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "MFR" "Texas Instruments"
+			(at 0 -48.0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "MPN" "DRV8301"
+			(at 0 -50.0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "DRV8301 gate driver three-phase BLDC motor PMSM"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_fp_filters" "HTSSOP*56*"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "DRV8301_0_1"
+			(rectangle
+				(start -12.7 36.83)
+				(end 12.7 -36.83)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+		)
+		(symbol "DRV8301_1_1"
+			(pin passive line (at -15.24 35.56 0) (length 2.54) (name "RT_CLK" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at -15.24 34.29 0) (length 2.54) (name "COMP" (effects (font (size 1.27 1.27)))) (number "2" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at -15.24 33.02 0) (length 2.54) (name "VSENSE" (effects (font (size 1.27 1.27)))) (number "3" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at -15.24 31.75 0) (length 2.54) (name "PWRGD" (effects (font (size 1.27 1.27)))) (number "4" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at -15.24 30.48 0) (length 2.54) (name "nOCTW" (effects (font (size 1.27 1.27)))) (number "5" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at -15.24 29.21 0) (length 2.54) (name "nFAULT" (effects (font (size 1.27 1.27)))) (number "6" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at -15.24 27.94 0) (length 2.54) (name "DTC" (effects (font (size 1.27 1.27)))) (number "7" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at -15.24 26.67 0) (length 2.54) (name "nSCS" (effects (font (size 1.27 1.27)))) (number "8" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at -15.24 25.4 0) (length 2.54) (name "SDI" (effects (font (size 1.27 1.27)))) (number "9" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at -15.24 24.13 0) (length 2.54) (name "SDO" (effects (font (size 1.27 1.27)))) (number "10" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at -15.24 22.86 0) (length 2.54) (name "SCLK" (effects (font (size 1.27 1.27)))) (number "11" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at -15.24 21.59 0) (length 2.54) (name "DC_CAL" (effects (font (size 1.27 1.27)))) (number "12" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at -15.24 20.32 0) (length 2.54) (name "GVDD" (effects (font (size 1.27 1.27)))) (number "13" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at -15.24 19.05 0) (length 2.54) (name "CP1" (effects (font (size 1.27 1.27)))) (number "14" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at -15.24 17.78 0) (length 2.54) (name "CP2" (effects (font (size 1.27 1.27)))) (number "15" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at -15.24 16.51 0) (length 2.54) (name "EN_GATE" (effects (font (size 1.27 1.27)))) (number "16" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at -15.24 15.24 0) (length 2.54) (name "INH_A" (effects (font (size 1.27 1.27)))) (number "17" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at -15.24 13.97 0) (length 2.54) (name "INL_A" (effects (font (size 1.27 1.27)))) (number "18" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at -15.24 12.7 0) (length 2.54) (name "INH_B" (effects (font (size 1.27 1.27)))) (number "19" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at -15.24 11.43 0) (length 2.54) (name "INL_B" (effects (font (size 1.27 1.27)))) (number "20" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at -15.24 10.16 0) (length 2.54) (name "INH_C" (effects (font (size 1.27 1.27)))) (number "21" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at -15.24 8.89 0) (length 2.54) (name "INL_C" (effects (font (size 1.27 1.27)))) (number "22" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at -15.24 7.62 0) (length 2.54) (name "DVDD" (effects (font (size 1.27 1.27)))) (number "23" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at -15.24 6.35 0) (length 2.54) (name "REF" (effects (font (size 1.27 1.27)))) (number "24" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at -15.24 5.08 0) (length 2.54) (name "SO1" (effects (font (size 1.27 1.27)))) (number "25" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at -15.24 3.81 0) (length 2.54) (name "SO2" (effects (font (size 1.27 1.27)))) (number "26" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at -15.24 2.54 0) (length 2.54) (name "AVDD" (effects (font (size 1.27 1.27)))) (number "27" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at -15.24 1.27 0) (length 2.54) (name "AGND" (effects (font (size 1.27 1.27)))) (number "28" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 35.56 180) (length 2.54) (name "PVDD1" (effects (font (size 1.27 1.27)))) (number "29" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 34.29 180) (length 2.54) (name "SP2" (effects (font (size 1.27 1.27)))) (number "30" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 33.02 180) (length 2.54) (name "SN2" (effects (font (size 1.27 1.27)))) (number "31" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 31.75 180) (length 2.54) (name "SP1" (effects (font (size 1.27 1.27)))) (number "32" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 30.48 180) (length 2.54) (name "SN1" (effects (font (size 1.27 1.27)))) (number "33" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 29.21 180) (length 2.54) (name "SL_C" (effects (font (size 1.27 1.27)))) (number "34" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 27.94 180) (length 2.54) (name "GL_C" (effects (font (size 1.27 1.27)))) (number "35" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 26.67 180) (length 2.54) (name "SH_C" (effects (font (size 1.27 1.27)))) (number "36" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 25.4 180) (length 2.54) (name "GH_C" (effects (font (size 1.27 1.27)))) (number "37" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 24.13 180) (length 2.54) (name "BST_C" (effects (font (size 1.27 1.27)))) (number "38" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 22.86 180) (length 2.54) (name "SL_B" (effects (font (size 1.27 1.27)))) (number "39" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 21.59 180) (length 2.54) (name "GL_B" (effects (font (size 1.27 1.27)))) (number "40" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 20.32 180) (length 2.54) (name "SH_B" (effects (font (size 1.27 1.27)))) (number "41" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 19.05 180) (length 2.54) (name "GH_B" (effects (font (size 1.27 1.27)))) (number "42" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 17.78 180) (length 2.54) (name "BST_B" (effects (font (size 1.27 1.27)))) (number "43" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 16.51 180) (length 2.54) (name "SL_A" (effects (font (size 1.27 1.27)))) (number "44" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 15.24 180) (length 2.54) (name "GL_A" (effects (font (size 1.27 1.27)))) (number "45" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 13.97 180) (length 2.54) (name "SH_A" (effects (font (size 1.27 1.27)))) (number "46" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 12.7 180) (length 2.54) (name "GH_A" (effects (font (size 1.27 1.27)))) (number "47" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 11.43 180) (length 2.54) (name "BST_A" (effects (font (size 1.27 1.27)))) (number "48" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 10.16 180) (length 2.54) (name "VDD_SPI" (effects (font (size 1.27 1.27)))) (number "49" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 8.89 180) (length 2.54) (name "PH1" (effects (font (size 1.27 1.27)))) (number "50" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 7.62 180) (length 2.54) (name "PH2" (effects (font (size 1.27 1.27)))) (number "51" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 6.35 180) (length 2.54) (name "BST_BK" (effects (font (size 1.27 1.27)))) (number "52" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 5.08 180) (length 2.54) (name "PVDD2_1" (effects (font (size 1.27 1.27)))) (number "53" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 3.81 180) (length 2.54) (name "PVDD2_2" (effects (font (size 1.27 1.27)))) (number "54" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 2.54 180) (length 2.54) (name "EN_BUCK" (effects (font (size 1.27 1.27)))) (number "55" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 15.24 1.27 180) (length 2.54) (name "SS_TR" (effects (font (size 1.27 1.27)))) (number "56" (effects (font (size 1.27 1.27)))))
+			(pin passive line (at 0 -39.37 90) (length 2.54) (name "PowerPAD" (effects (font (size 1.27 1.27)))) (number "57" (effects (font (size 1.27 1.27)))))
+		)
+	)
+)

--- a/tests/test_board_05_u3_drv_part_consistency.py
+++ b/tests/test_board_05_u3_drv_part_consistency.py
@@ -1,0 +1,275 @@
+"""Regression guard: board-05 U3 (gate driver) BOM/PCB/schematic part number must agree.
+
+Issue #3384: ``kct pcb sync-netlist`` reports ~40 U3 pad mismatches against
+the committed ``bldc_controller_routed.kicad_pcb`` because the schematic
+emits its gate-driver symbol using KiCad's stock ``Driver_Motor:DRV8308``
+(a 39-pin part with a completely different pinout than the DRV8301), while
+the BOM ships ``DRV8301`` (HTSSOP-56, LCSC C129292) and the PCB carries
+the matching ``Package_SO:HTSSOP-56-1EP_6.1x14mm_P0.5mm_EP3.61x6.35mm``
+footprint with 57 pads.  See PR description for the full investigation.
+
+This test pins down the **BOM/PCB/schematic-value** invariants that are
+load-bearing for physical manufacturing:
+
+* The BOM lists ``DRV8301`` with the HTSSOP-56 footprint.  This is what
+  physically ships -- whatever it says is the truth.
+* The PCB footprint is ``Package_SO:HTSSOP-56-1EP_*`` (DRV8301's DCA
+  package).  Matches the BOM.
+* The schematic's U3 ``Value`` field is ``DRV8301`` -- matches BOM.
+
+The schematic's ``lib_id`` (``Driver_Motor:DRV8308``) is **intentionally
+not asserted here** because the stock KiCad library doesn't ship a
+DRV8301 symbol and replacing the symbol requires a project-local symbol
+library plus a non-trivial schematic re-layout (the existing
+MCU-to-U3 routing infrastructure in ``deferred_mcu_labels`` /
+``_connect_mcu_pin_to_label`` is wired against the DRV8308 pin layout).
+See the spun-off follow-on issue (linked from #3384) for the symbol-side
+fix.  Filing that under a separate issue keeps this regression test
+focused on the BOM<->PCB<->schematic-value triangle that any future
+gate-driver replacement (e.g. swap to a real DRV8301 symbol) must
+preserve.
+
+If any of the three assertions below regress -- e.g. a Builder changes the
+``generate_htssop56`` call value, edits the BOM template, or renames the
+``GateDriverBlock`` value kwarg -- this test fails loudly with a pointer
+to the asymmetric edit.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BOARD_DIR = REPO_ROOT / "boards" / "05-bldc-motor-controller"
+DESIGN_PY = BOARD_DIR / "design.py"
+
+# Expected DRV8301 invariants -- the BOM is the ground truth (it
+# determines what TI part actually ships on the board).
+EXPECTED_PART_NUMBER = "DRV8301"
+EXPECTED_PCB_FOOTPRINT_PREFIX = "Package_SO:HTSSOP-56-1EP"
+EXPECTED_LCSC = "C129292"  # JLCPCB / LCSC part number for DRV8301
+
+
+def _load_design_module():
+    """Import the board-05 ``design.py`` as a fresh module."""
+    if not DESIGN_PY.exists():
+        pytest.skip(f"Board 05 design.py not found at {DESIGN_PY!s}")
+
+    spec = importlib.util.spec_from_file_location("board_05_design", DESIGN_PY)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        pytest.skip(f"Could not load spec for {DESIGN_PY!s}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["board_05_design"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_bom_lists_drv8301_with_htssop56() -> None:
+    """The committed JLCPCB BOM must list U3 as DRV8301, HTSSOP-56.
+
+    The BOM is the authoritative source for what TI part ships on the
+    fabricated board.  ``kct pcb sync-netlist`` checks pad nets against
+    the schematic netlist export; the schematic symbol must match the
+    pin/pad numbering of the physical part, which is determined by the
+    BOM row for U3.
+    """
+    bom_path = BOARD_DIR / "output" / "manufacturing" / "bom_jlcpcb.csv"
+    if not bom_path.exists():
+        pytest.skip(
+            f"BOM file not found at {bom_path!s} -- run "
+            "boards/05-bldc-motor-controller/design.py first"
+        )
+
+    with bom_path.open(newline="") as fh:
+        rows = list(csv.DictReader(fh))
+
+    u3_rows = [row for row in rows if "U3" in (row.get("Designator", "") or "")]
+    assert u3_rows, (
+        f"BOM at {bom_path!s} does not reference U3.  Expected the gate "
+        f"driver row to designate U3 as {EXPECTED_PART_NUMBER}."
+    )
+    # The Designator field may aggregate multiple refs (e.g. "U1,U2"), so
+    # narrow to rows where U3 is one of the comma-separated tokens.
+    u3_rows = [
+        row for row in u3_rows
+        if "U3" in [token.strip() for token in row["Designator"].split(",")]
+    ]
+    assert len(u3_rows) == 1, (
+        f"Expected exactly one BOM row referencing U3, got {len(u3_rows)}: "
+        f"{u3_rows}"
+    )
+
+    row = u3_rows[0]
+    comment = row.get("Comment", "") or ""
+    footprint = row.get("Footprint", "") or ""
+    lcsc = (row.get("LCSC Part #", "") or "").strip()
+
+    assert comment == EXPECTED_PART_NUMBER, (
+        f"BOM U3 Comment is {comment!r}, expected {EXPECTED_PART_NUMBER!r}. "
+        f"The Comment field drives the JLCPCB part lookup and must match "
+        f"what TI catalogues (DRV8301 ships only in the HTSSOP-56 / DCA "
+        f"package per datasheet SLOS719F)."
+    )
+    assert footprint.startswith(EXPECTED_PCB_FOOTPRINT_PREFIX), (
+        f"BOM U3 Footprint is {footprint!r}, expected to start with "
+        f"{EXPECTED_PCB_FOOTPRINT_PREFIX!r} (the DRV8301 DCA package).  "
+        f"If U3 is genuinely a different part, update the schematic and "
+        f"PCB to match -- this test guards the BOM<->PCB consistency."
+    )
+    # LCSC C129292 is JLCPCB's catalogue entry for DRV8301PHPR -- pin
+    # this to make a silent part substitution surface loudly here.
+    assert lcsc == EXPECTED_LCSC, (
+        f"BOM U3 LCSC part number is {lcsc!r}, expected {EXPECTED_LCSC!r} "
+        f"(DRV8301 on JLCPCB).  A different LCSC code likely means the "
+        f"footprint or part number drifted -- reconcile before shipping."
+    )
+
+
+def test_committed_pcb_u3_footprint_matches_bom() -> None:
+    """The committed routed PCB's U3 footprint must be HTSSOP-56.
+
+    Sync-netlist resolves PCB pads against schematic pins; a footprint
+    swap (e.g. to LQFP-48 for DRV8308) would invalidate the pad numbering
+    and silently bridge nets.  This test catches a regression of the
+    committed PCB to a non-DRV8301 footprint.
+    """
+    pcb_path = BOARD_DIR / "output" / "bldc_controller_routed.kicad_pcb"
+    if not pcb_path.exists():
+        pytest.skip(
+            f"Committed routed PCB not found at {pcb_path!s} -- run "
+            "boards/05-bldc-motor-controller/design.py first"
+        )
+
+    text = pcb_path.read_text()
+
+    # Locate U3's footprint declaration.  S-expr blocks are bracket-
+    # balanced; we use a relaxed regex to grab the footprint string that
+    # precedes the ``"U3"`` Reference property.
+    # Pattern: ``(footprint "<fp_string>" ... (property "Reference" "U3"``
+    pattern = re.compile(
+        r'\(footprint\s+"([^"]+)".*?\(property\s+"Reference"\s+"U3"',
+        re.DOTALL,
+    )
+    matches = pattern.findall(text)
+    assert matches, (
+        f"Could not find U3's footprint declaration in {pcb_path!s}.  The "
+        f"committed PCB must include a U3 footprint with a "
+        f"{EXPECTED_PCB_FOOTPRINT_PREFIX!r}-prefixed library reference."
+    )
+
+    # Match the LAST occurrence -- regex is greedy in DOTALL mode and may
+    # capture a footprint string from an earlier component; the closest
+    # ``(footprint ...`` block before ``"U3"`` is the relevant one.
+    # Re-scan for the closest match by walking backwards from each
+    # ``(property "Reference" "U3"`` position.
+    fp_string: str | None = None
+    for u3_ref_match in re.finditer(r'\(property\s+"Reference"\s+"U3"', text):
+        # Walk backwards to the nearest preceding ``(footprint "..."``.
+        upto = text[: u3_ref_match.start()]
+        fp_match = list(re.finditer(r'\(footprint\s+"([^"]+)"', upto))
+        if fp_match:
+            fp_string = fp_match[-1].group(1)
+            break
+
+    assert fp_string is not None, (
+        f"Could not resolve U3's library footprint in {pcb_path!s}.  "
+        f"Expected a {EXPECTED_PCB_FOOTPRINT_PREFIX!r}-prefixed lib_id."
+    )
+    assert fp_string.startswith(EXPECTED_PCB_FOOTPRINT_PREFIX), (
+        f"Committed PCB U3 footprint is {fp_string!r}, expected to start "
+        f"with {EXPECTED_PCB_FOOTPRINT_PREFIX!r}.  A footprint swap "
+        f"requires re-routing -- file a follow-on issue, do not ship."
+    )
+
+
+def test_design_py_emits_u3_value_drv8301(tmp_path: Path) -> None:
+    """Fresh design.py build must emit U3 with Value=DRV8301 on both sides.
+
+    The schematic-side ``Value`` field and the PCB-side footprint Value
+    text both flow into the BOM.  This regression test rebuilds the
+    schematic + unrouted PCB from ``design.py`` and confirms both sides
+    emit ``"DRV8301"`` as U3's value (matching the BOM expectation).
+
+    Note: this test does NOT assert the schematic's ``lib_id`` -- the
+    stock KiCad library only ships ``Driver_Motor:DRV8308``, so the
+    current schematic uses that symbol with a ``value="DRV8301"``
+    override.  The full symbol-side fix (custom DRV8301 library +
+    DRV8301-pin-numbered emission) is tracked in a follow-on issue
+    linked from #3384.
+    """
+    module = _load_design_module()
+
+    sch_path = module.create_bldc_controller(tmp_path)
+    pcb_path = module.create_bldc_pcb(tmp_path)
+
+    assert sch_path.exists(), f"design.py did not write schematic to {sch_path!s}"
+    assert pcb_path.exists(), f"design.py did not write PCB to {pcb_path!s}"
+
+    # Schematic side: locate U3's Value property.
+    sch_text = sch_path.read_text()
+    # The symbol block has a ``Reference`` property of "U3" and a
+    # ``Value`` property with the part number.  We scan forward from the
+    # first occurrence of ``"U3"`` as a Reference value to the next
+    # Value property.
+    sch_u3_ref = re.search(
+        r'\(property\s+"Reference"\s+"U3"', sch_text
+    )
+    assert sch_u3_ref is not None, (
+        f"Could not locate U3 Reference property in schematic at {sch_path!s}"
+    )
+    sch_after = sch_text[sch_u3_ref.end():]
+    sch_value = re.search(r'\(property\s+"Value"\s+"([^"]+)"', sch_after)
+    assert sch_value is not None, (
+        f"Could not locate U3 Value property in schematic at {sch_path!s}"
+    )
+    assert sch_value.group(1) == EXPECTED_PART_NUMBER, (
+        f"Schematic U3 Value is {sch_value.group(1)!r}, expected "
+        f"{EXPECTED_PART_NUMBER!r}.  The schematic Value field drives "
+        f"the BOM Comment column -- a mismatch would ship the wrong TI "
+        f"part number to JLCPCB."
+    )
+
+    # PCB side: locate U3's footprint block.  The PCB uses
+    # ``(fp_text reference "U3")`` (KiCad ``.kicad_pcb`` text format) and
+    # ``(fp_text value "DRV8301")``, NOT the schematic's ``(property
+    # "Reference" "U3")`` form.
+    pcb_text = pcb_path.read_text()
+    pcb_u3_ref = re.search(
+        r'\(fp_text\s+reference\s+"U3"', pcb_text
+    )
+    assert pcb_u3_ref is not None, (
+        f"Could not locate U3 fp_text reference in PCB at {pcb_path!s}"
+    )
+    # Walk back to the enclosing ``(footprint ...)`` block and forward
+    # to its ``(fp_text value "...")`` to read U3's value text.
+    upto = pcb_text[: pcb_u3_ref.start()]
+    fp_match_list = list(re.finditer(r'\(footprint\s+"[^"]+"', upto))
+    assert fp_match_list, (
+        f"Could not locate enclosing footprint block for U3 in {pcb_path!s}"
+    )
+    fp_start = fp_match_list[-1].start()
+    # Search for the next fp_text value within this block, before the
+    # next footprint block starts.
+    next_fp = re.search(r'\(footprint\s+"[^"]+"', pcb_text[pcb_u3_ref.end():])
+    block_end = (
+        pcb_u3_ref.end() + next_fp.start() if next_fp else len(pcb_text)
+    )
+    fp_block = pcb_text[fp_start:block_end]
+    fp_value = re.search(r'\(fp_text\s+value\s+"([^"]+)"', fp_block)
+    if fp_value is not None:
+        # If the PCB stamps a Value, it must agree with the schematic
+        # and BOM.  ``generate_htssop56`` writes "DRV8301" via the value
+        # kwarg passed at the call site -- a typo there would surface
+        # here.
+        assert fp_value.group(1) == EXPECTED_PART_NUMBER, (
+            f"PCB U3 fp_text value is {fp_value.group(1)!r}, expected "
+            f"{EXPECTED_PART_NUMBER!r}.  A mismatch indicates "
+            f"``generate_htssop56(\"U3\", ..., value=...)`` was edited "
+            f"to a different string -- reconcile with the schematic."
+        )


### PR DESCRIPTION
## Summary

After PR #3382 (U10 wire-stub fix) landed, ``kct pcb sync-netlist`` reported ~40 U3 pad mismatches against the committed ``bldc_controller_routed.kicad_pcb``.  Investigation surfaced the root cause: the schematic emits its gate-driver symbol using KiCad's stock ``Driver_Motor:DRV8308`` (a 39-pin sensorless-BLDC controller) while the BOM ships **DRV8301** (HTSSOP-56, LCSC C129292) and the PCB carries the matching HTSSOP-56 footprint with 57 pads.

- **BOM** (authoritative): ``DRV8301``, ``Package_SO:HTSSOP-56-1EP_6.1x14mm_P0.5mm_EP3.61x6.35mm``, ``C129292``
- **PCB** committed routed: 57-pad HTSSOP-56 ✓ matches BOM
- **Schematic value field**: ``DRV8301`` ✓ matches BOM
- **Schematic lib_id**: ``Driver_Motor:DRV8308`` ✗ wrong symbol (39 pins, different pinout)

The schematic is the wrong side.  This PR ships the **BOM/PCB/schematic-value consistency guard** and defers the full symbol-side replacement to #3387 (filed as a follow-on, because the symbol swap requires a non-trivial schematic re-layout — see #3387 for the structural blocker analysis).

## What this PR changes

- **``boards/05-bldc-motor-controller/symbols/board05_custom.kicad_sym``** — new project-local KiCad symbol library defining a full 57-pin ``DRV8301`` symbol whose pin numbers match the HTSSOP-56 footprint pad numbers per TI datasheet SLOS719F.  Sits on disk as a ready-to-use starting point for #3387; not consumed by ``design.py`` in this PR.
- **``tests/test_board_05_u3_drv_part_consistency.py``** — three pinned invariants asserting the BOM, PCB, and schematic all agree on the DRV8301 part number / HTSSOP-56 footprint / LCSC C129292 row.  Catches future drift on the part-number triangle.

## What this PR does NOT change

- No edits to ``boards/05-bldc-motor-controller/design.py`` — the schematic continues to emit U3 via ``GateDriverBlock`` + DRV8308 symbol with ``value="DRV8301"``.  The committed PCB stays exactly as it is (no re-route needed).
- No retirement of ``tests/test_board_05_drv8308_pin_nets.py`` — the underlying ``GateDriverBlock`` library code that test exercises is unchanged.  When #3387 lands and U3 stops using ``GateDriverBlock``, that test can be retired or reshaped at the same time.

## Why defer the symbol swap to #3387

An initial attempt at the symbol swap (using the new ``board05_custom:DRV8301`` symbol) revealed a structural blocker:

- The MCU-to-U3 routing in ``deferred_mcu_labels`` + ``_connect_mcu_pin_to_label`` was designed against the DRV8308 pin layout.
- A vertical wire from the +3.3V rail (y=64.77) drops to y=102.87 at x=265.43 — part of the gate-driver column.
- The new 57-pin DRV8301 symbol's left-edge pin lines extend from x=264.16 (pin connection) to x=266.7 (body edge); pin lines pass through (265.43, y) for every left-edge pin.
- This silently bridges every left-edge pin to the column wire (+3V3 or GND, depending on y) — and because one of my left-edge pin labels chains through a GND-and-+3V3-touching path, ERC reports ``Both +3V3 and GND are attached to the same items`` — a catastrophic short.

Fixing this means rerouting the MCU-to-U3 infrastructure to terminate cleanly at the new DRV8301 pin coordinates AND ensuring the U3 placement doesn't conflict with the column wires.  That's the scope of #3387.  Shipping the BOM/PCB/schematic-value guard now means the part-number triangle is locked in regardless of the symbol-side timing.

## Investigation deliverables

- Which side was wrong: **schematic** (BOM and PCB agreed on DRV8301; schematic symbol was DRV8308).
- Pad-change-count delta on current main: **41 U3 pad changes** (matches the ~40 the issue described).
- Whether committed PCB needs refresh: **no** — the committed PCB matches the BOM.  Refresh will be possible once #3387 lands and the schematic netlist agrees pad-for-pad with the PCB.

## Test plan

- [x] ``uv run pytest tests/test_board_05_u3_drv_part_consistency.py`` — all 3 tests pass
- [x] ``uv run pytest tests/test_board_05_drv8308_pin_nets.py`` — existing tests still pass (no regression)
- [ ] Judge to re-verify the regression test against a fresh ``design.py`` build
- [ ] Judge to confirm ``test_board_05_drv8308_pin_nets.py`` still serves a purpose (library-level invariant) or should be retired in #3387

## Related

- refs #3384
- Follow-on: #3387 (full schematic-symbol replacement requires layout refactor)
- Discovered during: PR #3382 (#3379 U10 SWDIO/SWCLK/ISENSE wire-stub fix)
- Sister issue from the same investigation: #3383 (HalfBridge GND-bridge)
- Sync drift umbrella: #3370 (closed)

refs #3384
