### PR TITLE
fix(motor): HalfBridge.connect_to_rails supports in-line shunt topology (closes #3383)

### DIFF
--- a/boards/05-bldc-motor-controller/design.py
+++ b/boards/05-bldc-motor-controller/design.py
@@ -900,11 +900,16 @@ def create_bldc_controller(output_dir: Path) -> Path:
         gate_hs_nets=["GATE_AH", "GATE_BH", "GATE_CH"],
         gate_ls_nets=["GATE_AL", "GATE_BL", "GATE_CL"],
     )
-    inverter.connect_to_rails(vin_rail_y=RAIL_VMOTOR, gnd_rail_y=RAIL_GND)
     print("   Three-phase inverter: Q1-Q6 (ThreePhaseInverter block)")
 
     # Add current sense shunts for each phase (R10-R12)
-    # Using CurrentSenseShunt blocks for proper current sensing
+    # Using CurrentSenseShunt blocks for proper current sensing.
+    # NOTE: Build the shunts BEFORE wiring the inverter to the rails so
+    # that ``inverter.connect_to_rails`` can be told (via ``inline_shunts``)
+    # to skip its default LS-source-to-GND wire on every phase.  Without
+    # this ordering, the half-bridge helper would emit a direct LS-source
+    # to GND wire that shorts the shunt (the LS source belongs on the
+    # shunt's IN+ side, not on GND).  See issue #3383.
     phases = ["A", "B", "C"]
     current_sensors = []
     for i, phase in enumerate(phases):
@@ -935,16 +940,14 @@ def create_bldc_controller(output_dir: Path) -> Path:
         # The shunt's IN- pin is connected to GND *physically* via the
         # LS MOSFET source / GND copper zone on the PCB; only the
         # schematic label is needed for the netlister because
-        # ``ISENSE_X-`` is consumed only by the U10 ADC pins.  The
-        # IN+ side (R10/11/12.1) remains bridged to GND through the
-        # ``HalfBridge.connect_to_rails`` LS-source-to-GND wire -- a
-        # separate structural issue (the shunt should be in-line
-        # between LS source and GND, not in parallel) that is out of
-        # scope for #3379 and tracked elsewhere.
+        # ``ISENSE_X-`` is consumed only by the U10 ADC pins.
         current_sensors.append(sense)
 
-        # Wire the inverter LS output to the current sense input
-        # Get the phase output from inverter and wire to shunt
+        # Wire the inverter LS output to the current sense input.
+        # Get the phase LS-source position and wire to shunt IN+.  This
+        # replaces the suppressed LS-source-to-GND wire from
+        # ``ThreePhaseInverter.connect_to_rails(..., inline_shunts=...)``
+        # so the LS source sits on ISENSE_X+ instead of GND.
         phase_gnd = inverter.half_bridges[i].port("GND")
         sense_in = sense.port("IN_POS")
         sense_gnd = sense.port("GND")
@@ -960,6 +963,16 @@ def create_bldc_controller(output_dir: Path) -> Path:
         sch.add_label(f"ISENSE_{phase}-", label_x, sense_gnd[1], rotation=0)
 
         print(f"   Phase {phase}: Current sense R{10 + i} (CurrentSenseShunt block)")
+
+    # Now wire the inverter to its power rails -- but pass the per-phase
+    # in-line shunts so each half-bridge skips its default LS-source-to-
+    # GND wire (which would short the shunt; issue #3383).  VIN/VMOTOR
+    # wires + junctions are still emitted as usual.
+    inverter.connect_to_rails(
+        vin_rail_y=RAIL_VMOTOR,
+        gnd_rail_y=RAIL_GND,
+        inline_shunts=current_sensors,
+    )
 
     # =========================================================================
     # Section 8: Motor Output Connector

--- a/src/kicad_tools/schematic/blocks/motor.py
+++ b/src/kicad_tools/schematic/blocks/motor.py
@@ -256,6 +256,7 @@ class HalfBridge(CircuitBlock):
         vin_rail_y: float,
         gnd_rail_y: float,
         add_junctions: bool = True,
+        inline_shunt: "CurrentSenseShunt | None" = None,
     ) -> None:
         """
         Connect half-bridge to power rails.
@@ -264,6 +265,18 @@ class HalfBridge(CircuitBlock):
             vin_rail_y: Y coordinate of VIN (motor voltage) rail
             gnd_rail_y: Y coordinate of ground rail
             add_junctions: Whether to add junction markers
+            inline_shunt: Optional :class:`CurrentSenseShunt` placed in
+                series between the low-side MOSFET source and GND.  When
+                provided, the LS-source-to-GND wire that this helper
+                normally emits is suppressed, because that wire would
+                short-circuit the shunt (the LS source belongs on the
+                shunt's IN+ side, not directly on GND).  The caller is
+                responsible for wiring the LS source to the shunt's
+                ``IN_POS`` port and for routing the shunt to GND (either
+                via ``CurrentSenseShunt.connect_to_rails`` or a Kelvin-
+                sense label).  When ``None`` (the default), behavior is
+                unchanged: a direct LS-source-to-GND wire is emitted.
+                See issue #3383 (board 05 ISENSE_X+ shunt-bridge).
         """
         sch = self.schematic
 
@@ -271,13 +284,20 @@ class HalfBridge(CircuitBlock):
         vin_pos = self._vin_pos
         sch.add_wire(vin_pos, (vin_pos[0], vin_rail_y), warn_on_collision=False)
 
-        # Connect LS source to GND rail
+        # Connect LS source to GND rail -- unless an in-line shunt sits
+        # between the LS source and GND, in which case this wire would
+        # short the shunt (issue #3383).  When ``inline_shunt`` is
+        # provided, we skip the LS-source-to-GND wire and let the caller
+        # wire LS source to the shunt's IN+ side and the shunt's IN-
+        # side to GND.
         gnd_pos = self._gnd_pos
-        sch.add_wire(gnd_pos, (gnd_pos[0], gnd_rail_y), warn_on_collision=False)
+        if inline_shunt is None:
+            sch.add_wire(gnd_pos, (gnd_pos[0], gnd_rail_y), warn_on_collision=False)
 
         if add_junctions:
             sch.add_junction(vin_pos[0], vin_rail_y)
-            sch.add_junction(gnd_pos[0], gnd_rail_y)
+            if inline_shunt is None:
+                sch.add_junction(gnd_pos[0], gnd_rail_y)
 
         # Connect bootstrap diode anode to VIN rail
         if self.has_bootstrap:
@@ -443,6 +463,7 @@ class ThreePhaseInverter(CircuitBlock):
         vin_rail_y: float,
         gnd_rail_y: float,
         add_junctions: bool = True,
+        inline_shunts: "list[CurrentSenseShunt | None] | None" = None,
     ) -> None:
         """
         Connect all half-bridges to power rails.
@@ -451,9 +472,34 @@ class ThreePhaseInverter(CircuitBlock):
             vin_rail_y: Y coordinate of VIN (motor voltage) rail
             gnd_rail_y: Y coordinate of ground rail
             add_junctions: Whether to add junction markers
+            inline_shunts: Optional per-phase :class:`CurrentSenseShunt`
+                instances (one per phase, in ``phase_labels`` order; use
+                ``None`` for phases without an in-line shunt).  When the
+                entry for a given phase is non-``None``, the
+                corresponding half-bridge's LS-source-to-GND wire is
+                suppressed -- see ``HalfBridge.connect_to_rails`` for
+                details and rationale (issue #3383).  Length must equal
+                the number of phases (``len(self.half_bridges)``).  When
+                ``None`` (the default), every half-bridge emits its
+                direct LS-source-to-GND wire as before.
+
+        Raises:
+            ValueError: If ``inline_shunts`` is provided and its length
+                does not match the number of phases.
         """
-        for hb in self.half_bridges:
-            hb.connect_to_rails(vin_rail_y, gnd_rail_y, add_junctions)
+        if inline_shunts is not None and len(inline_shunts) != len(self.half_bridges):
+            raise ValueError(
+                f"inline_shunts length ({len(inline_shunts)}) must equal "
+                f"number of phases ({len(self.half_bridges)})"
+            )
+        for i, hb in enumerate(self.half_bridges):
+            shunt = inline_shunts[i] if inline_shunts is not None else None
+            hb.connect_to_rails(
+                vin_rail_y,
+                gnd_rail_y,
+                add_junctions,
+                inline_shunt=shunt,
+            )
 
 
 class CurrentSenseShunt(CircuitBlock):

--- a/tests/test_blocks_half_bridge_inline_shunt.py
+++ b/tests/test_blocks_half_bridge_inline_shunt.py
@@ -1,0 +1,271 @@
+"""Tests for ``HalfBridge.connect_to_rails`` in-line shunt topology.
+
+Issue #3383: ``HalfBridge.connect_to_rails`` historically always emitted
+an LS-source-to-GND wire.  When a board wires a current-sense shunt in
+series between the LS source and GND (the canonical low-side-sense
+topology used on board 05's BLDC stage), that wire short-circuits the
+shunt -- the LS source ends up tied directly to GND and the shunt's IN+
+side is bridged to its IN- side via the schematic.  After ``sync-netlist``
+this manifests as R10/R11/R12.1 (ISENSE_X+) appearing on the GND net.
+
+The fix is the new optional ``inline_shunt`` parameter (``HalfBridge``)
+and the corresponding ``inline_shunts`` list parameter (``ThreePhaseInverter``).
+When provided, the LS-source-to-GND wire (and its rail-side junction) is
+suppressed -- the caller is responsible for wiring LS source to the
+shunt's IN+ side and routing the shunt to GND.
+
+The tests below use a mocked schematic so they exercise wire emission
+without producing real KiCad output (shape mirrors
+``tests/test_blocks_half_bridge.py``).
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from kicad_tools.schematic.blocks import (
+    CurrentSenseShunt,
+    HalfBridge,
+    ThreePhaseInverter,
+)
+
+
+@pytest.fixture
+def mock_schematic():
+    """Mock Schematic returning mock symbols with deterministic pin positions.
+
+    MOSFET pins follow ``Device:Q_NMOS`` convention; shunt resistor pins
+    follow ``Device:R`` convention (pin 1 above, pin 2 below).
+    """
+    sch = Mock()
+
+    def create_mock_component(symbol, x, y, ref, *args, **kwargs):
+        comp = Mock()
+        comp.reference = ref
+        comp.symbol = symbol
+        comp.pin_position.side_effect = lambda name, _x=x, _y=y: {
+            "D": (_x, _y - 10),
+            "G": (_x - 10, _y),
+            "S": (_x, _y + 10),
+            "A": (_x - 5, _y),
+            "K": (_x + 5, _y),
+            "IN+": (_x - 5, _y - 5),
+            "IN-": (_x - 5, _y + 5),
+            "OUT": (_x + 5, _y),
+            "VS": (_x, _y - 10),
+            "GND": (_x, _y + 10),
+            "1": (_x, _y - 5),
+            "2": (_x, _y + 5),
+        }.get(name, (_x, _y))
+        return comp
+
+    sch.add_symbol = Mock(side_effect=create_mock_component)
+    sch.add_wire = Mock()
+    sch.add_junction = Mock()
+    sch.add_label = Mock()
+    sch.wire_decoupling_cap = Mock()
+    return sch
+
+
+class TestHalfBridgeConnectToRailsDefault:
+    """Baseline: default behavior emits LS-source-to-GND wire.
+
+    AC4 (no regression for callers that don't opt in to the new
+    parameter).
+    """
+
+    def test_default_emits_ls_source_to_gnd_wire(self, mock_schematic):
+        """The default code path must still emit a LS-source-to-GND wire.
+
+        This is the historical behavior every existing consumer relies on.
+        """
+        hb = HalfBridge(mock_schematic, x=100, y=100)
+        ls_source = hb.ports["GND"]
+
+        mock_schematic.add_wire.reset_mock()
+        mock_schematic.add_junction.reset_mock()
+
+        hb.connect_to_rails(vin_rail_y=30, gnd_rail_y=200)
+
+        # The LS-source-to-GND wire must appear among emitted wires.
+        wire_calls = [call.args for call in mock_schematic.add_wire.call_args_list]
+        expected_gnd_wire = (ls_source, (ls_source[0], 200))
+        assert expected_gnd_wire in wire_calls, (
+            f"expected LS-source-to-GND wire {expected_gnd_wire} not found among "
+            f"emitted wires {wire_calls}"
+        )
+
+        # And the GND-side junction must be added.
+        junction_calls = [call.args for call in mock_schematic.add_junction.call_args_list]
+        assert (ls_source[0], 200) in junction_calls
+
+    def test_default_emits_vin_wire_and_junction(self, mock_schematic):
+        """VIN-side wire + junction are unchanged by the new parameter."""
+        hb = HalfBridge(mock_schematic, x=100, y=100)
+        hs_drain = hb.ports["VIN"]
+
+        mock_schematic.add_wire.reset_mock()
+        mock_schematic.add_junction.reset_mock()
+
+        hb.connect_to_rails(vin_rail_y=30, gnd_rail_y=200)
+
+        wire_calls = [call.args for call in mock_schematic.add_wire.call_args_list]
+        assert (hs_drain, (hs_drain[0], 30)) in wire_calls
+
+        junction_calls = [call.args for call in mock_schematic.add_junction.call_args_list]
+        assert (hs_drain[0], 30) in junction_calls
+
+
+class TestHalfBridgeConnectToRailsInlineShunt:
+    """In-line shunt topology: LS-source-to-GND wire is suppressed."""
+
+    def test_inline_shunt_suppresses_ls_gnd_wire(self, mock_schematic):
+        """When ``inline_shunt`` is provided, the LS-source-to-GND wire is omitted.
+
+        This is the core AC for #3383: the wire that bridges the shunt
+        must not be emitted.
+        """
+        hb = HalfBridge(mock_schematic, x=100, y=100)
+        ls_source = hb.ports["GND"]
+
+        shunt = CurrentSenseShunt(
+            mock_schematic, x=120, y=180, shunt_value="5mR", ref_start=10
+        )
+
+        mock_schematic.add_wire.reset_mock()
+        mock_schematic.add_junction.reset_mock()
+
+        hb.connect_to_rails(vin_rail_y=30, gnd_rail_y=200, inline_shunt=shunt)
+
+        # The LS-source-to-GND wire must NOT appear among emitted wires.
+        wire_calls = [call.args for call in mock_schematic.add_wire.call_args_list]
+        forbidden_gnd_wire = (ls_source, (ls_source[0], 200))
+        assert forbidden_gnd_wire not in wire_calls, (
+            f"LS-source-to-GND wire {forbidden_gnd_wire} was emitted despite "
+            f"inline_shunt being provided (regression of #3383); emitted wires: "
+            f"{wire_calls}"
+        )
+
+        # And the GND-side junction must also be suppressed (otherwise a
+        # bare junction sits on the GND rail with nothing connected to it
+        # from the half-bridge side).
+        junction_calls = [call.args for call in mock_schematic.add_junction.call_args_list]
+        assert (ls_source[0], 200) not in junction_calls
+
+    def test_inline_shunt_still_emits_vin_wire(self, mock_schematic):
+        """The VIN-side wire is independent of the LS-side suppression."""
+        hb = HalfBridge(mock_schematic, x=100, y=100)
+        hs_drain = hb.ports["VIN"]
+
+        shunt = CurrentSenseShunt(
+            mock_schematic, x=120, y=180, shunt_value="5mR", ref_start=10
+        )
+
+        mock_schematic.add_wire.reset_mock()
+        mock_schematic.add_junction.reset_mock()
+
+        hb.connect_to_rails(vin_rail_y=30, gnd_rail_y=200, inline_shunt=shunt)
+
+        wire_calls = [call.args for call in mock_schematic.add_wire.call_args_list]
+        assert (hs_drain, (hs_drain[0], 30)) in wire_calls
+
+        junction_calls = [call.args for call in mock_schematic.add_junction.call_args_list]
+        assert (hs_drain[0], 30) in junction_calls
+
+    def test_inline_shunt_none_is_default_behavior(self, mock_schematic):
+        """Explicitly passing ``inline_shunt=None`` matches the default behavior."""
+        hb = HalfBridge(mock_schematic, x=100, y=100)
+        ls_source = hb.ports["GND"]
+
+        mock_schematic.add_wire.reset_mock()
+        mock_schematic.add_junction.reset_mock()
+
+        hb.connect_to_rails(vin_rail_y=30, gnd_rail_y=200, inline_shunt=None)
+
+        # LS-source-to-GND wire still present.
+        wire_calls = [call.args for call in mock_schematic.add_wire.call_args_list]
+        assert (ls_source, (ls_source[0], 200)) in wire_calls
+
+
+class TestThreePhaseInverterConnectToRailsInlineShunts:
+    """Pass-through tests for ``ThreePhaseInverter.connect_to_rails``."""
+
+    def test_default_emits_three_ls_gnd_wires(self, mock_schematic):
+        """Without ``inline_shunts``, each phase emits its LS-source-to-GND wire."""
+        inv = ThreePhaseInverter(mock_schematic, x=100, y=100)
+        ls_positions = [hb.ports["GND"] for hb in inv.half_bridges]
+
+        mock_schematic.add_wire.reset_mock()
+        inv.connect_to_rails(vin_rail_y=30, gnd_rail_y=200)
+
+        wire_calls = [call.args for call in mock_schematic.add_wire.call_args_list]
+        for ls in ls_positions:
+            assert (ls, (ls[0], 200)) in wire_calls
+
+    def test_inline_shunts_suppresses_all_three_ls_gnd_wires(self, mock_schematic):
+        """When every phase has an in-line shunt, no LS-source-to-GND wires are emitted."""
+        inv = ThreePhaseInverter(mock_schematic, x=100, y=100)
+        ls_positions = [hb.ports["GND"] for hb in inv.half_bridges]
+
+        # Build one shunt per phase.
+        shunts = [
+            CurrentSenseShunt(
+                mock_schematic,
+                x=100 + i * 75,
+                y=180,
+                shunt_value="5mR",
+                ref_start=10 + i,
+            )
+            for i in range(3)
+        ]
+
+        mock_schematic.add_wire.reset_mock()
+        inv.connect_to_rails(vin_rail_y=30, gnd_rail_y=200, inline_shunts=shunts)
+
+        wire_calls = [call.args for call in mock_schematic.add_wire.call_args_list]
+        for ls in ls_positions:
+            assert (ls, (ls[0], 200)) not in wire_calls, (
+                f"LS-source-to-GND wire at {ls} was emitted despite an in-line "
+                f"shunt being provided for that phase"
+            )
+
+    def test_inline_shunts_mixed_some_phases_inline_some_not(self, mock_schematic):
+        """Per-phase opt-in: only phases with non-None shunts skip the GND wire."""
+        inv = ThreePhaseInverter(mock_schematic, x=100, y=100)
+        ls_positions = [hb.ports["GND"] for hb in inv.half_bridges]
+
+        # Phase A and C get in-line shunts; phase B does not.
+        shunt_a = CurrentSenseShunt(
+            mock_schematic, x=100, y=180, shunt_value="5mR", ref_start=10
+        )
+        shunt_c = CurrentSenseShunt(
+            mock_schematic, x=250, y=180, shunt_value="5mR", ref_start=12
+        )
+
+        mock_schematic.add_wire.reset_mock()
+        inv.connect_to_rails(
+            vin_rail_y=30,
+            gnd_rail_y=200,
+            inline_shunts=[shunt_a, None, shunt_c],
+        )
+
+        wire_calls = [call.args for call in mock_schematic.add_wire.call_args_list]
+        # A and C: no GND wire.
+        assert (ls_positions[0], (ls_positions[0][0], 200)) not in wire_calls
+        assert (ls_positions[2], (ls_positions[2][0], 200)) not in wire_calls
+        # B: GND wire still emitted.
+        assert (ls_positions[1], (ls_positions[1][0], 200)) in wire_calls
+
+    def test_inline_shunts_wrong_length_raises(self, mock_schematic):
+        """Length mismatch with phase count must raise ``ValueError``."""
+        inv = ThreePhaseInverter(mock_schematic, x=100, y=100)
+        shunt = CurrentSenseShunt(
+            mock_schematic, x=100, y=180, shunt_value="5mR", ref_start=10
+        )
+
+        with pytest.raises(ValueError, match="inline_shunts length"):
+            inv.connect_to_rails(
+                vin_rail_y=30,
+                gnd_rail_y=200,
+                inline_shunts=[shunt, shunt],  # 2 entries vs 3 phases
+            )


### PR DESCRIPTION
## Summary

- Add optional `inline_shunt: CurrentSenseShunt | None` parameter to `HalfBridge.connect_to_rails` (and `inline_shunts: list[...] | None` to `ThreePhaseInverter.connect_to_rails`) that suppresses the historical LS-source-to-GND wire. When omitted, behavior is unchanged so no existing consumer regresses.
- Wire board 05's `design.py` to build the per-phase shunts first, then call `inverter.connect_to_rails(..., inline_shunts=current_sensors)` so each half-bridge skips the GND wire that previously bridged ISENSE_X+ to GND through the shunt.
- The committed board 05 PCB is intentionally NOT refreshed here because the U3 footprint mismatch (#3384) still blocks a clean PCB refresh.

## Why

`HalfBridge.connect_to_rails` historically emitted a LS-source-to-GND wire on every call. When a board wires a current-sense shunt in series between the LS source and GND (board 05's BLDC stage), that wire short-circuits the shunt -- the LS source ends up tied directly to GND. After `sync-netlist`, the shunt's IN+ pad (R10/R11/R12 pin 1) appears on the GND net rather than the intended ISENSE_X+ net. Issue #3383 spun this out of PR #3382 review.

## Sync mismatch delta (board 05, freshly regenerated)

| | Total mismatches | R10/R11/R12 ISENSE_X+ -> GND |
|---|---|---|
| baseline (`main`) | 97 | 3 (R10.1, R11.1, R12.1) |
| after this PR | 94 | 0 |

`diff` of sync-netlist output shows exactly these three lines removed -- no other mismatches change. Remaining ISENSE_* mismatches are on U3 pins and are the separate U3 pin/footprint issue tracked in #3384.

## Half-bridge consumers verified

- `boards/05-bldc-motor-controller/design.py` -- updated and verified by sync delta above.
- `boards/02-charlieplex-led/design.py`, `boards/04-stm32-devboard/design.py` -- inspected via `grep "HalfBridge|ThreePhaseInverter"`; neither uses these blocks, so neither can regress.
- `boards/external/` -- no consumers.
- 430-test block suite (`test_blocks_half_bridge.py`, `test_blocks_three_phase_inverter.py`, `test_blocks_gate_driver_block.py`, `test_blocks_back_to_back_fet_pair.py`, `test_blocks_ucc27211_gate_driver.py`, etc.) all pass.
- `test_board_04_erc_regression.py` (38 cases) all pass.

## Test plan

- [x] New `tests/test_blocks_half_bridge_inline_shunt.py` (9 cases) covers: default emits LS-source-to-GND wire + junction; `inline_shunt=<shunt>` suppresses both while leaving VIN-side wiring untouched; explicit `inline_shunt=None` matches default; `ThreePhaseInverter` mirrors the semantics with per-phase opt-in; length mismatch raises `ValueError`.
- [x] Pre-existing half-bridge / three-phase-inverter tests pass unchanged.
- [x] Pre-existing board 04 / 05 regression tests pass.
- [x] Board 05 `design.py` regenerates schematic + PCB successfully (manufacturing bundle PASS).
- [x] `sync-netlist` on freshly regenerated board 05: R10/R11/R12 disappear from the mismatch list (3 mismatches removed, 0 added).

Closes #3383