### PR TITLE
docs(router): record P_FP6 dispatcher-gap regression finding (Issue #3395)

### DIFF
--- a/tests/router/test_softstart_revb_fine_pitch_escape.py
+++ b/tests/router/test_softstart_revb_fine_pitch_escape.py
@@ -253,6 +253,18 @@ def test_softstart_revb_reach_floor(tmp_path: Path) -> None:
 
     Closing this gap is tracked separately and out of scope for #3390.
 
+    Issue #3395 update (Jun 2026):  investigated raising the
+    dispatcher gate (broadening the dual-row fine-pitch cap in
+    ``is_dense_package`` from 0.75 mm to 1.5 mm so UCC27211 SOIC-8
+    qualifies).  Empirical measurement: reach REGRESSES 18/30 ->
+    8/30 because the P_FP6 in-pad vias collide with the GATE/UCC
+    bus routing downstream.  See
+    ``test_softstart_revb_dispatcher_gap_documents_p_fp6_unreached``
+    for the detailed measurement table.  The dispatcher gap is
+    INTENTIONAL until #3398 (the rescue ↔ main-router interaction
+    fix) lands.  This floor stays at 18 to prevent quiet acceptance
+    of the regression.
+
     Issue #3390: drives routing in-process with a strict 240 s
     budget.  Replaces the previous ``subprocess.run(kct route)``
     invocation that timed out at 660 s.

--- a/tests/router/test_softstart_revb_p_fp6_dispatcher.py
+++ b/tests/router/test_softstart_revb_p_fp6_dispatcher.py
@@ -17,15 +17,22 @@ end-to-end ``route_with_escape`` pipeline and directly verifies:
      ``route_with_escape`` dispatcher were to call it).
 
 Critically, this test also documents the **dispatcher gap** found
-during #3390 verification: the SOIC-8 1.27 mm-pitch packages do not
-pass :func:`kicad_tools.router.escape.is_dense_package` at the recipe
+during #3390 verification and re-confirmed by #3395 measurement:
+the SOIC-8 1.27 mm-pitch packages do not pass
+:func:`kicad_tools.router.escape.is_dense_package` at the recipe
 parameters above (dynamic threshold = 2 * (0.30 + 0.20) = 1.0 mm <
 1.27 mm pitch), so ``Autorouter.detect_dense_packages`` excludes
 them from the escape pre-pass.  P_FP6 wires the rescue path
-correctly but the dispatcher never invokes it on this fixture; the
-+3 UCC27211 net reach lift estimated by the architect (#3381 comment)
-is therefore unrealised in the empirical end-to-end run.  Closing
-this gap is tracked separately (out of scope for #3390).
+correctly but the dispatcher never invokes it on this fixture.
+
+Issue #3395 investigated raising the dispatcher gate and found
+that **opening the gate REGRESSES softstart rev B reach 18 -> 8**
+at L=2 single-attempt (the SOP rescue's in-pad vias collide with
+GATE/UCC bus routing downstream).  The dispatcher gap is therefore
+INTENTIONAL today, pending the P_FP6 rescue ↔ main-router
+interaction fix tracked in #3398.  See
+``test_softstart_revb_dispatcher_gap_documents_p_fp6_unreached``
+below for the empirical detail.
 
 Runtime: <10 s.  Not gated on ``KICAD_RUN_SLOW_SOFTSTART_REACH=1``.
 
@@ -217,7 +224,7 @@ def test_softstart_revb_p_fp6_dispatcher_emits_in_pad_vias(
 def test_softstart_revb_dispatcher_gap_documents_p_fp6_unreached(
     tmp_path: Path,
 ) -> None:
-    """Documents the P_FP6 dispatcher-gap finding from #3390 verification.
+    """Documents the P_FP6 dispatcher-gap finding from #3390 / #3395.
 
     UCC27211 SOIC-8 at 1.27 mm pitch + 0.30 mm trace + 0.20 mm
     clearance does *not* pass
@@ -231,12 +238,35 @@ def test_softstart_revb_dispatcher_gap_documents_p_fp6_unreached(
     ``test_softstart_revb_p_fp6_dispatcher_emits_in_pad_vias`` above);
     only the dispatcher gate prevents the rescue from firing.
 
-    This test is the negative control: if a future change updates the
-    is_dense_package heuristic to include SOIC-8 at fine-pitch, this
-    assertion will fail and the P_FP6 rescue will start contributing
-    to the end-to-end reach number.  At that point this test should
-    be updated to assert the new expected dense-package set, and
-    ``test_softstart_revb_reach_floor`` should be tightened.
+    **Why the dispatcher gap is intentional today (Issue #3395
+    investigation, Jun 9 2026):**  the gate is NOT a bug; it is
+    intentionally closed pending the P_FP6 rescue ↔ main-router
+    interaction work.  PR #XXXX investigated the architect's
+    proposed fix (raise the dual-row fine-pitch cap from 0.75 mm to
+    1.5 mm so UCC27211 SOIC-8 qualifies for the dense pre-pass) and
+    measured softstart rev B reach end-to-end:
+
+    +------------------------------+----------------+--------+
+    | Configuration                | Dense packages | Reach  |
+    +==============================+================+========+
+    | main (status quo)            | 3 packages     | 18/30  |
+    +------------------------------+----------------+--------+
+    | Threshold raised to 1.5 mm   | 6 packages     | 8/30   |
+    +------------------------------+----------------+--------+
+
+    Reach REGRESSES by 10 nets when UCC27211 SOIC-8 enters the
+    dense list.  The SOP rescue places 16 in-pad vias on U5/U6
+    signal pins (+3 on U7) as designed; the downstream detailed
+    router then cannot route GATE_POS/GATE_NEG/UCC_HO/UCC_LO/VGATE
+    because the in-pad via field collides with the tight bus +
+    snubber routing around the FET pairs.  See Issue #3398 for the
+    follow-up interaction-fix work.
+
+    When #3398 lands and the rescue no longer regresses end-to-end
+    reach, the dispatcher gate should be re-opened (re-implement the
+    threshold raise) and this test should flip from negative-control
+    to positive-assertion.  Until then, the negative assertion below
+    is the empirical record of the trade-off.
     """
     from kicad_tools.router.escape import is_dense_package
 
@@ -251,15 +281,18 @@ def test_softstart_revb_dispatcher_gap_documents_p_fp6_unreached(
             trace_width=router.rules.trace_width,
             clearance=router.rules.trace_clearance,
         )
-        # The gap finding: NONE of the UCC27211 SOIC-8 packages are
-        # classified as dense under the current recipe.  When the
-        # heuristic is updated to fix this, this assertion flips.
+        # Issue #3395: NONE of the UCC27211 SOIC-8 packages are
+        # classified as dense under the current recipe BY DESIGN --
+        # opening the gate without the P_FP6 interaction fix (#3398)
+        # regresses end-to-end reach 18 -> 8 on this fixture.
         assert not dense, (
-            f"{ref} is now classified as dense at trace=0.30, clearance=0.20; "
-            "this is a positive change -- the P_FP6 SOP rescue should now "
-            "contribute to end-to-end reach.  Update the dispatcher-gap "
-            "documentation in test_softstart_revb_reach_floor and tighten "
-            "the reach floor accordingly."
+            f"{ref} is now classified as dense at trace=0.30, clearance=0.20.  "
+            "If this was intentional, the test needs updating AND the "
+            "softstart rev B reach floor "
+            "(`test_softstart_revb_reach_floor`) must be re-measured to "
+            "confirm the P_FP6 rescue ↔ main-router interaction (Issue "
+            "#3398) has been addressed.  See the docstring above for the "
+            "Jun 2026 reach-regression measurement details."
         )
 
 


### PR DESCRIPTION
## Summary

Investigated raising `is_dense_package`'s fine-pitch dual-row cap from 0.75 mm to 1.5 mm so UCC27211 SOIC-8 (1.27 mm pitch) qualifies for `detect_dense_packages` and the P_FP6 SOP staggered rescue fires during end-to-end `route_with_escape` on softstart rev B.  **Empirical result: reach REGRESSES** 18/30 -> 8/30 at L=2 single-attempt + 240 s budget.

This PR ships **documentation only** — production code unchanged.  The test docstrings and module preambles record the empirical measurement so future investigators do not repeat the dead-end.  The dispatcher gap is intentional today, pending Issue #3398 (the rescue ↔ main-router interaction fix).

## Empirical measurement

| Configuration                  | Dense packages              | Reach (L=2, 240 s) |
| ------------------------------ | --------------------------- | ------------------ |
| main (status quo)              | U1, U3, U8 (3)              | 18/30              |
| `is_dense` raised to 1.5 mm    | U1, U3, **U5, U6, U7**, U8 (6) | **8/30**           |

The SOP rescue placed 16 in-pad vias on U5/U6 signal pins + 3 on U7 (as designed).  Downstream detailed router failed to route `GATE_POS_*`, `GATE_NEG_*`, `UCC_HO_*`, `UCC_LO_*`, `VGATE` with `blocked_path` errors because the in-pad via field collides with the tight FET bus + snubber routing.

## What changed

* `tests/router/test_softstart_revb_p_fp6_dispatcher.py`: expanded module docstring + the `test_softstart_revb_dispatcher_gap_documents_p_fp6_unreached` test docstring to record the empirical reach table and reference Issue #3398.  Test assertions unchanged (still negative-control on UCC27211 not being dense).
* `tests/router/test_softstart_revb_fine_pitch_escape.py`: added a paragraph to `test_softstart_revb_reach_floor`'s docstring explaining the #3395 measurement and the intentional gap.  Floor unchanged at 18/30 to prevent quiet acceptance of the regression.

## What did NOT change

* `src/kicad_tools/router/escape.py:is_dense_package` — production code unchanged.
* No test assertions updated (only docstrings + comments).
* No other test files touched.

## Geometric heuristic considered

The fix attempted was:

```python
if (
    min_pitch <= FINE_PITCH_THRESHOLD_MM  # 1.5 mm
    and len(pads) >= 8                    # exclude SOT-23-5 / SOT-23-6
    and _is_dual_row(pads)
):
    return True
```

The `len(pads) >= 8` guard was important because the naive 1.5 mm cap sweeps SOT-23-5 (5 pads, 2-column layout, 0.95 mm vertical pitch) into the dual-row class.  With the guard the change is purely additive: only SOIC-8 / SOIC-16 / SSOP-N at 1.27-1.5 mm pitch newly qualify.

The fix was structurally correct per the issue's geometric reasoning (at jlcpcb-tier1: min_via_OD 0.60 + 2 × min_clearance 0.127 + trace_width 0.30 = 1.054 mm < 1.27 mm UCC27211 pitch).  But the downstream router cannot recover from the resulting in-pad via density on softstart's high-current bus.

## Reach delta (architect's prior estimate vs. empirical)

* Architect's estimate (Issue #3381 comment): 24-27/30 at L=2.
* Empirical with the proposed fix: **8/30** at L=2.
* Delta: **-10 nets** versus baseline (18/30), **-16 to -19** versus estimate.

## Caveats

* Tested at L=2 single-attempt only (the consumer-test budget).  L=4 escalation might recover some nets but the L=2 result is what gates the `test_softstart_revb_reach_floor` test.
* SOIC-16 at 1.27 mm pitch is also affected by the theoretical fix but is not present on softstart rev B; the regression measurement only covers SOIC-8.
* The unit tests for `is_dense_package` in `tests/test_escape.py` still assert SOIC-16 at 1.27 mm is NOT dense (no change from main).

## Follow-up

Issue #3398 tracks the P_FP6 rescue ↔ main-router interaction fix.  When it lands, this PR's docstring guidance ("dispatcher gap is intentional") should be revisited and the dispatcher gate re-opened (the threshold raise re-implemented).

## Test plan

- [x] `uv run pytest tests/router/test_softstart_revb_p_fp6_dispatcher.py -v --no-cov` (4 passed)
- [x] `uv run pytest tests/test_escape.py --no-cov` (114 passed)
- [x] `KICAD_RUN_SLOW_SOFTSTART_REACH=1 uv run pytest tests/router/test_softstart_revb_fine_pitch_escape.py::test_softstart_revb_reach_floor -v --no-cov` on main (passes 18/30)
- [x] `KICAD_RUN_SLOW_SOFTSTART_REACH=1 uv run pytest tests/router/test_softstart_revb_fine_pitch_escape.py::test_softstart_revb_reach_floor -v --no-cov` with proposed `is_dense_package` change (fails 8/30) -- this is the regression measurement that motivated reverting.

Closes #3395