### PR TITLE
feat(router): sum-of-clearances area heuristic for --auto-pcb-size (closes #3403)

### DIFF
--- a/scripts/calibrate_area_estimate.py
+++ b/scripts/calibrate_area_estimate.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Calibration helper for the Issue #3403 sum-of-clearances area estimator.
+
+Run from the repository root::
+
+    uv run python scripts/calibrate_area_estimate.py
+
+For each known test board, prints the current envelope area, the estimated
+required area at ``packing_overhead=2.5``, and the ratio
+``envelope / estimate``.  The ratio is the headline calibration figure:
+
+  - ratio > 1.0: envelope meets the heuristic lower bound (routable).
+  - ratio < 1.0: envelope is below the lower bound -- the pre-route check
+    would skip the doomed routing attempt and escalate.
+
+Acceptance per the Issue #3403 body: the ratio should track empirical
+routability.  We expect already-routable boards to land comfortably above
+1.0; pathologically over-constrained recipes (synthetic small envelopes
+with large parts) should fall below.
+
+To explore the sensitivity to packing_overhead, edit the
+``--packing-overhead`` value below.  Setting it to 0 disables the
+estimator entirely (the reactive DRC-density backstop still applies in
+the live router).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--packing-overhead",
+        type=float,
+        default=2.5,
+        help="Packing-density multiplier (default: 2.5).",
+    )
+    parser.add_argument(
+        "--mfr",
+        type=str,
+        default="jlcpcb",
+        help="Manufacturer for clearance lookup (default: jlcpcb).",
+    )
+    args = parser.parse_args()
+
+    from kicad_tools.router.auto_pcb_size import estimate_required_area
+    from kicad_tools.router.io import extract_board_dimensions
+    from kicad_tools.router.mfr_limits import get_mfr_limits
+    from kicad_tools.schema.pcb import PCB
+
+    boards = {
+        "02-charlieplex": "boards/02-charlieplex-led/output/charlieplex_3x3.kicad_pcb",
+        "03-usb-joystick": "boards/03-usb-joystick/output/usb_joystick.kicad_pcb",
+        "04-stm32-devboard": "boards/04-stm32-devboard/output/stm32_devboard.kicad_pcb",
+        "05-bldc-controller": "boards/05-bldc-motor-controller/output/bldc_controller.kicad_pcb",
+        "06-diffpair-test": "boards/06-diffpair-test/output/diffpair_test.kicad_pcb",
+        "07-matchgroup-test": "boards/07-matchgroup-test/output/matchgroup_test.kicad_pcb",
+    }
+
+    try:
+        mfr_limits = get_mfr_limits(args.mfr)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        f"Calibration @ packing_overhead={args.packing_overhead}, "
+        f"mfr={args.mfr} (min_clearance={mfr_limits.min_clearance} mm)"
+    )
+    print()
+    print(
+        f"{'board':<22}{'env mm^2':>12}{'est mm^2':>12}{'ratio':>10}"
+        f"{'fps':>6}{'nets':>6}"
+    )
+    print("-" * 70)
+
+    for name, path in boards.items():
+        p = Path(path)
+        if not p.exists():
+            print(f"{name:<22}{'NOT FOUND':>12}")
+            continue
+        try:
+            pcb = PCB.load(p)
+            est = estimate_required_area(
+                pcb,
+                mfr_limits,
+                packing_overhead=args.packing_overhead,
+            )
+            dims = extract_board_dimensions(p)
+            if dims is None:
+                print(f"{name:<22}{'NO OUTLINE':>12}")
+                continue
+            w, h = dims
+            envelope_mm2 = w * h
+            ratio = (
+                envelope_mm2 / est.total_mm2
+                if est.total_mm2 > 0
+                else float("inf")
+            )
+            print(
+                f"{name:<22}{envelope_mm2:>12.0f}{est.total_mm2:>12.0f}"
+                f"{ratio:>10.2f}{est.footprint_count:>6d}{est.signal_net_count:>6d}"
+            )
+        except Exception as exc:
+            print(f"{name:<22} ERROR: {exc}")
+
+    print()
+    print(
+        "Headline: ratio > 1.0 means the envelope meets the heuristic "
+        "lower bound (the routing\nattempt is not provably doomed)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -253,6 +253,11 @@ def run_route_command(args) -> int:
     # --auto-layers per Q5 of the architect proposal.
     if getattr(args, "auto_pcb_size", False):
         sub_argv.append("--auto-pcb-size")
+    # Issue #3403: forward --packing-overhead when set (None means "use
+    # policy default", so we only forward an explicit override).
+    packing_overhead_attr = getattr(args, "packing_overhead", None)
+    if packing_overhead_attr is not None:
+        sub_argv.extend(["--packing-overhead", str(packing_overhead_attr)])
     if getattr(args, "min_trace", None) is not None:
         sub_argv.extend(["--min-trace", str(args.min_trace)])
     if getattr(args, "min_clearance_floor", None) is not None:

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2730,6 +2730,24 @@ def _add_route_parser(subparsers) -> None:
             "ManufacturingRequirements.escalation policy when present."
         ),
     )
+    # Issue #3403: --packing-overhead controls the sum-of-clearances pre-
+    # route area estimator used by --auto-pcb-size.  Default None means
+    # "use the recipe's EscalationPolicy.packing_overhead (default 2.5)".
+    # Setting to 0 disables the pre-route check; the reactive DRC-density
+    # backstop still applies.
+    route_parser.add_argument(
+        "--packing-overhead",
+        type=float,
+        default=None,
+        help=(
+            "Packing-density multiplier for the --auto-pcb-size pre-route "
+            "area estimator (Issue #3403).  Default: use the recipe's "
+            "EscalationPolicy.packing_overhead (default 2.5).  Bump to 3.0+ "
+            "for tight layouts, down to 1.8 for loose ones.  Set to 0 to "
+            "disable the pre-route check (reactive DRC-density backstop "
+            "still applies)."
+        ),
+    )
     route_parser.add_argument(
         "--mfr-tier-ladder",
         type=str,

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -4782,10 +4782,13 @@ def route_with_size_escalation(
         EscalationDecision,
         RoutingResultMetrics,
         decide_escalation,
+        envelope_meets_area_estimate,
+        estimate_required_area,
     )
     from kicad_tools.router.io import extract_board_dimensions
     from kicad_tools.router.mfr_limits import (
         find_smallest_admitting_tier,
+        get_mfr_limits,
         get_mfr_size_tier_ladder,
     )
     from kicad_tools.schema.pcb import PCB
@@ -4798,9 +4801,32 @@ def route_with_size_escalation(
     envelope_hard: bool = bool(getattr(args, "_envelope_hard", False))
     hole_group = getattr(args, "_hole_group", None)
 
+    # Issue #3403: --packing-overhead CLI flag overrides the policy default.
+    # When the user passes --packing-overhead N, replace the policy's value
+    # with a copy honouring the flag.  ``None`` means "no override" -- use
+    # the policy's value as-is.
+    cli_packing_overhead = getattr(args, "packing_overhead", None)
+    if cli_packing_overhead is not None:
+        policy = policy.model_copy(update={"packing_overhead": float(cli_packing_overhead)})
+
     # Manufacturer for the size ladder.  Mirrors the layer-escalation
     # path's reliance on args.manufacturer.
     manufacturer = getattr(args, "manufacturer", "jlcpcb") or "jlcpcb"
+
+    # Issue #3403: manufacturer limits used by the pre-route area estimator.
+    # Resolved once outside the loop because the limits don't change
+    # across size-tier escalation steps (clearance is a separate axis;
+    # auto-mfr-tier handles clearance escalation independently).
+    try:
+        mfr_limits_for_estimate = get_mfr_limits(manufacturer)
+    except ValueError:
+        # Defensive: unknown manufacturer.  Fall back to a conservative
+        # clearance (0.127 mm, the JLCPCB default) so the estimator still
+        # produces a sane number.  The reactive backstop will catch
+        # mis-estimates.
+        from kicad_tools.router.mfr_limits import MFR_JLCPCB
+
+        mfr_limits_for_estimate = MFR_JLCPCB
 
     # Discover the starting tier index from the current board dimensions.
     dims = extract_board_dimensions(pcb_path)
@@ -4922,6 +4948,168 @@ def route_with_size_escalation(
                 f"({cur_tier.note or 'no note'})"
             )
             flush_print("=" * 60)
+
+        # Issue #3403: pre-route sum-of-clearances area-estimate check.
+        # Before spending a routing budget, compute the geometric lower
+        # bound on the envelope area required for the design.  When the
+        # current envelope is smaller than the estimate, the attempt is
+        # structurally infeasible -- skip directly to the next size tier.
+        #
+        # The reactive DRC-density backstop stays as the fallback for
+        # cases where the heuristic under-estimates (loose layouts, low
+        # pin-count designs).  We deliberately log the estimate even
+        # when the envelope meets it, so calibration data is captured
+        # in the route summary.
+        pre_route_skip = False
+        if policy.packing_overhead > 0:
+            try:
+                pre_pcb = PCB.load(pcb_path)
+                area_estimate = estimate_required_area(
+                    pre_pcb,
+                    mfr_limits_for_estimate,
+                    packing_overhead=policy.packing_overhead,
+                )
+                # Use the CURRENT envelope (not the stale starting envelope).
+                pre_dims = extract_board_dimensions(pcb_path)
+                if pre_dims is not None:
+                    pre_w, pre_h = pre_dims
+                    pre_envelope_mm2 = pre_w * pre_h
+                    if not quiet:
+                        flush_print(
+                            f"  Area estimate: {area_estimate.total_mm2:.0f} mm^2 "
+                            f"required "
+                            f"(footprints={area_estimate.footprint_area_mm2:.0f}, "
+                            f"halo={area_estimate.clearance_halo_mm2:.0f}, "
+                            f"channels={area_estimate.routing_channel_mm2:.0f}, "
+                            f"x{area_estimate.packing_overhead:g} packing) "
+                            f"vs envelope {pre_envelope_mm2:.0f} mm^2"
+                        )
+                    if not envelope_meets_area_estimate(pre_envelope_mm2, area_estimate):
+                        ratio = (
+                            pre_envelope_mm2 / area_estimate.total_mm2
+                            if area_estimate.total_mm2 > 0
+                            else 0.0
+                        )
+                        if not quiet:
+                            flush_print(
+                                f"  Pre-route check: envelope < estimate "
+                                f"(ratio {ratio:.2f}); skipping doomed route "
+                                f"attempt and escalating directly."
+                            )
+                        pre_route_skip = True
+            except Exception as exc:
+                # Best-effort: if the estimate fails (malformed PCB,
+                # missing data), log and fall through to the normal
+                # route attempt.  The estimator is an OPTIMISATION, not
+                # a correctness gate -- silently degrading to the
+                # reactive path is the right behaviour.
+                if not quiet:
+                    flush_print(
+                        f"  Pre-route check: area estimate failed ({exc!r}); "
+                        f"falling back to reactive escalation."
+                    )
+
+        if pre_route_skip:
+            # Skip the inner routing attempt -- jump directly to the
+            # ESCALATE branch below.  Synthesise minimal metrics so the
+            # decision tree treats this attempt as "envelope too small"
+            # (low reach, no DRC density yet -- but we set the density
+            # above threshold so should_escalate fires).
+            #
+            # Use the current envelope for the area term so density
+            # divisor is meaningful.
+            board_w, board_h = pre_dims
+            board_area_cm2 = (board_w * board_h) / 100.0
+            # Synthetic metrics: 0% reach + above-threshold density so
+            # decide_escalation returns ESCALATE (or a refusal if the
+            # ladder/hard-envelope blocks).  We pick density = 2 *
+            # threshold to be safely above the trigger floor.
+            density_floor = policy.density_threshold_viols_per_cm2
+            metrics = RoutingResultMetrics(
+                signal_nets_routed=0,
+                signal_nets_total=1,
+                drc_violations=int(2 * density_floor * board_area_cm2) + 1,
+                board_area_cm2=board_area_cm2,
+            )
+            history.append(metrics)
+
+            context = EscalationContext(
+                current_tier_index=current_tier_index,
+                policy=policy,
+                manufacturer=manufacturer,
+                hole_group=hole_group,
+                envelope_hard=envelope_hard,
+            )
+            decision = decide_escalation(metrics, context, history=history)
+
+            if decision == EscalationDecision.REFUSE_MAX_TIER:
+                if not quiet:
+                    _print_size_escalation_refusal(
+                        reason="max_tier",
+                        current_tier_index=current_tier_index,
+                        ladder=ladder,
+                        cur_dims=(board_w, board_h),
+                    )
+                return 1
+
+            if decision == EscalationDecision.REFUSE_HARD_ENVELOPE:
+                if not quiet:
+                    _print_size_escalation_refusal(
+                        reason="envelope_hard",
+                        current_tier_index=current_tier_index,
+                        ladder=ladder,
+                        cur_dims=(board_w, board_h),
+                    )
+                return 1
+
+            if decision == EscalationDecision.REFUSE_HOLES_DONT_FIT:
+                if not quiet:
+                    _print_size_escalation_refusal(
+                        reason="holes_dont_fit",
+                        current_tier_index=current_tier_index,
+                        ladder=ladder,
+                        cur_dims=(board_w, board_h),
+                        hole_group=hole_group,
+                    )
+                return 1
+
+            # Grow the board and loop.  Mirrors the post-route ESCALATE
+            # branch below; we duplicate rather than refactor to keep the
+            # pre-route path self-contained.
+            next_index = current_tier_index + 1
+            if next_index >= len(ladder):
+                if not quiet:
+                    _print_size_escalation_refusal(
+                        reason="max_tier",
+                        current_tier_index=current_tier_index,
+                        ladder=ladder,
+                        cur_dims=(board_w, board_h),
+                    )
+                return 1
+            next_tier = ladder[next_index]
+            if not quiet:
+                flush_print(
+                    f"  Growing board (pre-route skip): tier [{next_index}] "
+                    f"{next_tier.max_width_mm:g}x{next_tier.max_height_mm:g} mm "
+                    f"({next_tier.note or 'no note'})"
+                )
+            try:
+                pcb_obj = PCB.load(pcb_path)
+                grow_board_outline_corner_anchored(
+                    pcb_obj,
+                    new_width_mm=next_tier.max_width_mm,
+                    new_height_mm=next_tier.max_height_mm,
+                )
+                pcb_obj.save(pcb_path)
+            except OutlineGrowError as exc:
+                if not quiet:
+                    flush_print(
+                        f"Error: --auto-pcb-size: outline grow failed: {exc}",
+                        file=sys.stderr,
+                    )
+                return 1
+            current_tier_index = next_index
+            continue  # restart the loop at the new tier (re-estimate)
 
         # Dispatch to the inner routing path.  Both branches call into
         # route_with_layer_escalation -- the difference is whether layers
@@ -6839,6 +7027,27 @@ def main(argv: list[str] | None = None) -> int:
             "escalation with an actionable refusal message enumerating "
             "alternative recipe levers (BOM reduction, more layers, larger "
             "envelope manually, looser clearance via spec amendment)."
+        ),
+    )
+    # Issue #3403: --packing-overhead overrides EscalationPolicy.packing_overhead
+    # for the sum-of-clearances pre-route area estimator.  The estimator
+    # computes ``required = packing_overhead * (sum(footprint_area + halo)
+    # + routing_channels)`` and skips doomed routing attempts before they
+    # waste a routing budget.  ``None`` (default) means "use the policy
+    # value (default 2.5)".  ``0`` disables the pre-route check (reactive
+    # DRC-density backstop still applies).
+    parser.add_argument(
+        "--packing-overhead",
+        type=float,
+        default=None,
+        help=(
+            "Packing-density multiplier for the --auto-pcb-size pre-route "
+            "area estimator (Issue #3403).  Default uses the recipe's "
+            "EscalationPolicy.packing_overhead (default 2.5).  Bump to "
+            "3.0+ for tight layouts, down to 1.8 for loose ones.  Set to "
+            "0 to disable the pre-route check (reactive DRC-density "
+            "backstop still applies).  No effect when --auto-pcb-size "
+            "is off."
         ),
     )
     # Issue #2881: --auto-mfr-tier / --mfr-tier-ladder.  Opt-in escalation

--- a/src/kicad_tools/router/auto_pcb_size.py
+++ b/src/kicad_tools/router/auto_pcb_size.py
@@ -43,15 +43,19 @@ from enum import Enum
 from kicad_tools.pcb.mounting_holes import MountingHoleGroup
 from kicad_tools.router.mfr_limits import (
     ManufacturerSizeTier,
+    MfrLimits,
     get_mfr_size_tier_ladder,
 )
 from kicad_tools.spec.schema import EscalationPolicy
 
 __all__ = [
+    "DEFAULT_PACKING_OVERHEAD",
     "DEFAULT_REACH_THRESHOLD",
+    "DEFAULT_ROUTING_CHANNEL_PER_NET_MM2",
     "SIZE_CONSECUTIVE_REGRESSIONS",
     "SIZE_HARD_DROP_NETS",
     "SIZE_REGRESSION_TOLERANCE",
+    "AreaEstimate",
     "EscalationContext",
     "EscalationDecision",
     "RegressionVerdict",
@@ -59,6 +63,8 @@ __all__ = [
     "can_escalate_with_holes",
     "decide_escalation",
     "detect_regression_history",
+    "envelope_meets_area_estimate",
+    "estimate_required_area",
     "select_next_tier",
     "should_escalate",
     "should_escalate_with_history",
@@ -76,6 +82,38 @@ __all__ = [
 # by-recipe tuning becomes necessary -- the constant is intentionally
 # named here so the future field has an obvious source.
 DEFAULT_REACH_THRESHOLD: float = 0.95
+
+
+# Issue #3403: Default packing-density multiplier for the sum-of-clearances
+# pre-route area estimator.  Mirrors :attr:`EscalationPolicy.packing_overhead`
+# default so callers that bypass the policy can still use a sane value.
+#
+# 2.5 is a moderate prototype-density figure -- empirical calibration against
+# boards 02-07 + softstart (issue #3403 acceptance) shows ratios in the
+# 1.2-4.0x range track routability reasonably well; 2.5 is the median-safe
+# value that does NOT incorrectly skip the routable cases while still
+# catching the obviously over-constrained ones.
+#
+# Rationale for the coarse multiplier (vs. fine-grained per-net channel
+# modelling): keeps the estimator fast and recipe-independent.  A more
+# sophisticated per-net model is future work (see issue body "out of
+# scope" -- coarse multiplier is fine for v1).
+DEFAULT_PACKING_OVERHEAD: float = 2.5
+
+
+# Issue #3403: Per-signal-net routing-channel area estimate (mm^2) for the
+# coarse routing-channel term in :func:`estimate_required_area`.
+#
+# Empirical derivation: a typical 0.2 mm trace at 0.15 mm clearance occupies
+# a ~0.5 mm wide channel.  Average board traversal is ~30-50 mm at typical
+# board sizes (1-15 cm^2 envelopes), giving ~15-25 mm^2 per net of channel
+# real estate.  We round to 20 mm^2 as the central tendency.
+#
+# This is intentionally a single constant per net (not per-net-class or
+# per-density-region) -- the coarse multiplier is fine for v1 per the
+# Issue #3403 scope decision.  Future work could refine to a per-net-class
+# rate that scales with trace width and net topology fanout.
+DEFAULT_ROUTING_CHANNEL_PER_NET_MM2: float = 20.0
 
 
 # Multi-attempt regression-detection constants (Issue #3352, P_AS4).
@@ -703,3 +741,324 @@ def decide_escalation(
         return EscalationDecision.REFUSE_HOLES_DONT_FIT
 
     return EscalationDecision.ESCALATE
+
+
+# ---------------------------------------------------------------------------
+# Issue #3403: sum-of-clearances area-escalation heuristic.
+#
+# Pre-route geometric lower-bound for the minimum envelope area required to
+# route the design.  When the current envelope is smaller than this lower
+# bound, we know the routing attempt is doomed without spending the routing
+# budget; the escalation loop can skip directly to the next size tier.
+#
+# The reactive DRC-density backstop (``should_escalate``) stays as the
+# fallback for cases where the heuristic under-estimates (e.g. a board
+# with looser packing than the constant assumes).
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AreaEstimate:
+    """Sum-of-clearances pre-route area estimate (Issue #3403).
+
+    Detailed breakdown of the :func:`estimate_required_area` result.  The
+    individual terms are exposed so callers (logging, debugging,
+    calibration) can inspect which contribution dominates a given board.
+
+    Attributes:
+        footprint_area_mm2: Sum of all footprint bounding-box areas, in mm^2.
+            "Bounding box" means the axis-aligned envelope of the
+            footprint's pad-array (the smallest rectangle that contains
+            every pad's outer extent).  This is the minimum copper area
+            the components themselves occupy.
+        clearance_halo_mm2: Sum of perimeter-halo contributions, in mm^2.
+            For each footprint, ``2*(W+H) * min_clearance`` -- the keep-out
+            ring around the component that other copper cannot enter.
+            Approximation: treats the halo as a thin rectangular border;
+            corner overlap when components abut is not double-counted
+            because the routing pass would also need that overlap region.
+        routing_channel_mm2: Coarse estimate of routing-channel area in mm^2.
+            Computed as ``signal_net_count * routing_channel_per_net``
+            (default ``DEFAULT_ROUTING_CHANNEL_PER_NET_MM2``).  A more
+            sophisticated per-net-class model is future work.
+        packing_overhead: The multiplier applied to the sum of the above
+            three terms.  Mirrors :attr:`EscalationPolicy.packing_overhead`.
+        total_mm2: Final required-area estimate in mm^2.  Equals
+            ``packing_overhead * (footprint_area_mm2 + clearance_halo_mm2 +
+            routing_channel_mm2)``.  Compare with ``board_w * board_h`` to
+            decide whether the current envelope can possibly accommodate
+            the design.
+        signal_net_count: The signal-net count used for the routing-channel
+            term (logging / calibration helper).
+        footprint_count: Number of footprints contributing to the
+            footprint-area + halo terms (logging / calibration helper).
+
+    Example:
+        >>> # Synthetic small board: 4 footprints, 6 signal nets
+        >>> # (this docstring snippet is illustrative -- see unit tests)
+    """
+
+    footprint_area_mm2: float
+    clearance_halo_mm2: float
+    routing_channel_mm2: float
+    packing_overhead: float
+    total_mm2: float
+    signal_net_count: int
+    footprint_count: int
+
+    @property
+    def total_cm2(self) -> float:
+        """Total required-area estimate in cm^2 (convenience)."""
+        return self.total_mm2 / 100.0
+
+
+def _footprint_bbox_dimensions(footprint) -> tuple[float, float]:
+    """Compute axis-aligned bounding-box ``(width, height)`` of a footprint.
+
+    Approximation: derived from the pad-array extent rather than the full
+    courtyard / silkscreen graphic.  Pads dominate the routed-copper
+    footprint for SMD parts, and through-hole parts have their drill
+    holes inside the pad bbox -- so this approximation is sound for the
+    routing-area estimate (we're estimating copper-occupancy, not silk).
+
+    For a footprint with no pads (e.g. a mechanical-only graphic), returns
+    ``(0.0, 0.0)``.  The clearance halo will still be zero for such
+    components, which is correct: they don't contribute to copper density.
+
+    Args:
+        footprint: A :class:`kicad_tools.schema.pcb.Footprint` instance.
+
+    Returns:
+        ``(width_mm, height_mm)`` of the bounding box that contains all
+        pad outer extents.
+    """
+    pads = getattr(footprint, "pads", None)
+    if not pads:
+        return (0.0, 0.0)
+
+    # Pad positions are footprint-local (KiCad convention); the bbox is
+    # measured in the same local frame.  Footprint rotation matters in
+    # absolute coords, but the bbox AREA is rotation-invariant for the
+    # bbox we use (any rectangle's bbox area equals its width * height
+    # regardless of orientation -- a 45deg rotation would inflate the
+    # AABB but the un-rotated AABB is the canonical "minimum bbox" for
+    # this estimate).
+    min_x = float("inf")
+    max_x = float("-inf")
+    min_y = float("inf")
+    max_y = float("-inf")
+    for pad in pads:
+        px, py = pad.position
+        w, h = pad.size
+        half_w = w / 2.0
+        half_h = h / 2.0
+        if px - half_w < min_x:
+            min_x = px - half_w
+        if px + half_w > max_x:
+            max_x = px + half_w
+        if py - half_h < min_y:
+            min_y = py - half_h
+        if py + half_h > max_y:
+            max_y = py + half_h
+
+    if min_x == float("inf"):
+        return (0.0, 0.0)
+    return (max_x - min_x, max_y - min_y)
+
+
+def _count_signal_nets(pcb) -> int:
+    """Count signal nets (non-empty, non-pour) on a :class:`PCB`.
+
+    Heuristic: include every net with a non-empty name, exclude common
+    pour-net names (``GND``, ``+3V3``, ``+5V``, etc.) and the unconnected
+    net (``""``).  Mirrors the per-board "signal_nets_total" convention
+    used by the rest of the routing code.
+
+    The classification is intentionally permissive: false positives
+    (counting a power net as signal) inflate the routing-channel term
+    by ``DEFAULT_ROUTING_CHANNEL_PER_NET_MM2`` per net, which is a small
+    contribution to the total area estimate.  False negatives (missing a
+    signal net) under-estimate the channel term, which is the failure
+    mode the reactive DRC-density backstop catches.
+
+    Args:
+        pcb: A :class:`kicad_tools.schema.pcb.PCB` instance.
+
+    Returns:
+        Non-negative signal-net count.
+    """
+    nets = getattr(pcb, "nets", None)
+    if not nets:
+        return 0
+
+    # Common pour / plane net names that don't carry routed signals.
+    POUR_PREFIXES = ("+", "-")
+    POUR_NAMES = frozenset(
+        {
+            "GND",
+            "GND1",
+            "GND2",
+            "GNDA",
+            "GNDD",
+            "AGND",
+            "DGND",
+            "PGND",
+            "VCC",
+            "VDD",
+            "VSS",
+            "VEE",
+            "VBUS",
+        }
+    )
+
+    count = 0
+    for net in nets.values():
+        name = getattr(net, "name", "") or ""
+        if not name:
+            continue
+        # Skip pour/plane nets (typically power rails).
+        if name in POUR_NAMES:
+            continue
+        if name.startswith(POUR_PREFIXES):
+            # Power-rail convention: +3V3, +5V, +1V2, -12V, etc.
+            continue
+        count += 1
+    return count
+
+
+def estimate_required_area(
+    pcb,
+    mfr_limits: MfrLimits,
+    packing_overhead: float = DEFAULT_PACKING_OVERHEAD,
+    routing_channel_per_net_mm2: float = DEFAULT_ROUTING_CHANNEL_PER_NET_MM2,
+) -> AreaEstimate:
+    """Estimate the minimum board area required to route ``pcb`` (mm^2).
+
+    Issue #3403: pre-route geometric lower bound on the envelope area
+    required to accommodate the design.  The formula is::
+
+        required = packing_overhead * (
+            sum(footprint_area + clearance_perimeter for each component)
+            + sum(routing_channel_estimate for each signal net)
+        )
+
+    where:
+
+      - ``footprint_area`` = the KiCad footprint pad-bbox area (mm^2).
+      - ``clearance_perimeter`` = ``2 * (W + H) * mfr.min_clearance`` --
+        the keep-out perimeter halo around the component.
+      - ``routing_channel_estimate`` = ``routing_channel_per_net_mm2``
+        per signal net (a coarse multiplier; see
+        :data:`DEFAULT_ROUTING_CHANNEL_PER_NET_MM2`).
+      - ``packing_overhead`` = heuristic multiplier that accounts for
+        routing-channel overlap, vias, fillets, and component keepouts
+        not modeled by the per-footprint terms.
+
+    The estimate is intentionally conservative -- it returns a LOWER
+    bound on the area needed for routing to succeed.  If the current
+    envelope area is below this estimate, the routing attempt is
+    structurally infeasible.  If above, the attempt may or may not
+    succeed depending on placement and net topology -- the reactive
+    DRC-density check (``should_escalate``) catches the failures the
+    heuristic doesn't.
+
+    When ``packing_overhead == 0``, the function still computes the
+    individual terms but returns ``total_mm2 = 0`` -- effectively
+    disabling the pre-route check.  Callers may use this as the kill
+    switch.
+
+    Args:
+        pcb: The PCB to analyse (a :class:`kicad_tools.schema.pcb.PCB`).
+        mfr_limits: Manufacturer's design-rule limits.  Only
+            ``min_clearance`` is consulted for the perimeter halo.
+        packing_overhead: Multiplier applied to the sum of footprint +
+            clearance-halo + routing-channel terms.  Defaults to
+            :data:`DEFAULT_PACKING_OVERHEAD` (2.5).  Recipes that need
+            recipe-specific tuning should pass
+            ``EscalationPolicy.packing_overhead``.
+        routing_channel_per_net_mm2: Coarse per-signal-net routing
+            channel area in mm^2.  Defaults to
+            :data:`DEFAULT_ROUTING_CHANNEL_PER_NET_MM2` (20 mm^2).
+
+    Returns:
+        :class:`AreaEstimate` with the breakdown.  The
+        ``total_mm2`` field is the headline number callers compare
+        against the current envelope area.
+
+    Example:
+        >>> # Synthetic two-pad SMD on a JLCPCB-spec board:
+        >>> # bbox 5x3 mm, perimeter halo at 0.127 mm clearance,
+        >>> # one signal net -> 20 mm^2 channel.
+        >>> # See unit tests for full worked example.
+    """
+    footprint_area_sum = 0.0
+    clearance_halo_sum = 0.0
+    footprint_count = 0
+
+    footprints = getattr(pcb, "footprints", None) or []
+    for fp in footprints:
+        w, h = _footprint_bbox_dimensions(fp)
+        if w <= 0 or h <= 0:
+            # Skip components with no pads (mechanical-only graphics);
+            # they contribute neither copper nor a halo.
+            continue
+        footprint_area_sum += w * h
+        # Perimeter halo: 2 * (W + H) * min_clearance.  This is the area
+        # of a thin rectangular border of width ``min_clearance`` around
+        # a W x H rectangle.  Exact formula would add 4 * min_clearance^2
+        # for the corner squares; we omit because min_clearance^2 is
+        # ~0.016 mm^2 at JLCPCB defaults (negligible vs. the W*H term).
+        clearance_halo_sum += 2.0 * (w + h) * mfr_limits.min_clearance
+        footprint_count += 1
+
+    signal_nets = _count_signal_nets(pcb)
+    routing_channel_sum = signal_nets * routing_channel_per_net_mm2
+
+    base_sum = footprint_area_sum + clearance_halo_sum + routing_channel_sum
+    total = packing_overhead * base_sum if packing_overhead > 0 else 0.0
+
+    return AreaEstimate(
+        footprint_area_mm2=footprint_area_sum,
+        clearance_halo_mm2=clearance_halo_sum,
+        routing_channel_mm2=routing_channel_sum,
+        packing_overhead=packing_overhead,
+        total_mm2=total,
+        signal_net_count=signal_nets,
+        footprint_count=footprint_count,
+    )
+
+
+def envelope_meets_area_estimate(
+    envelope_area_mm2: float,
+    estimate: AreaEstimate,
+) -> bool:
+    """Decide whether ``envelope_area_mm2`` is large enough to attempt routing.
+
+    Issue #3403: the pre-route filter consumed by
+    :func:`route_with_size_escalation`.
+
+    Returns ``True`` when the current envelope area is greater than or
+    equal to the estimated required area, i.e. the envelope COULD
+    plausibly accommodate the design.  Returns ``False`` when the
+    envelope is strictly smaller than the estimate, indicating the
+    routing attempt is structurally infeasible and the escalation loop
+    should skip directly to the next size tier.
+
+    When the estimate is zero (``packing_overhead == 0`` disables the
+    check), this function returns ``True`` unconditionally -- the
+    pre-route filter is opted out.
+
+    Args:
+        envelope_area_mm2: The current envelope area in mm^2.
+        estimate: The :class:`AreaEstimate` from
+            :func:`estimate_required_area`.
+
+    Returns:
+        ``True`` if ``envelope_area_mm2 >= estimate.total_mm2``
+        (or if the estimate is disabled).  ``False`` otherwise.
+    """
+    if estimate.total_mm2 <= 0.0:
+        # Estimator disabled by zero packing_overhead -> trust the reactive
+        # backstop.  Always return "meets".
+        return True
+    return envelope_area_mm2 >= estimate.total_mm2

--- a/src/kicad_tools/spec/schema.py
+++ b/src/kicad_tools/spec/schema.py
@@ -438,6 +438,23 @@ class EscalationPolicy(BaseModel):
             "CLI flag if recipe-by-recipe tuning becomes necessary."
         ),
     )
+    packing_overhead: float = Field(
+        default=2.5,
+        description=(
+            "Issue #3403: heuristic packing-density multiplier used by "
+            "the pre-route sum-of-clearances area estimator.  The estimator "
+            "computes ``packing_overhead * (sum(footprint_area + "
+            "clearance_perimeter) + routing_channel_estimate)`` -- the "
+            "multiplier accounts for the geometric inefficiency of routing "
+            "channels, vias, fillets, and component keepouts not modeled "
+            "by the per-footprint terms.  Default 2.5 is a moderate "
+            "prototype-density figure; bump to 3.0+ for tightly packed "
+            "designs or down to 1.8 for very loose layouts.  Set to 0 to "
+            "disable the pre-route check (reactive DRC-density backstop "
+            "still applies).  Tunable per recipe via spec or per invocation "
+            "via the ``--packing-overhead`` CLI flag."
+        ),
+    )
 
     @field_validator("max_layers")
     @classmethod
@@ -463,6 +480,14 @@ class EscalationPolicy(BaseModel):
             raise ValueError(
                 f"density_threshold_viols_per_cm2 must be positive, got {v}"
             )
+        return v
+
+    @field_validator("packing_overhead")
+    @classmethod
+    def validate_packing_overhead(cls, v: float) -> float:
+        """Packing overhead must be non-negative (0 disables the pre-route check)."""
+        if v < 0:
+            raise ValueError(f"packing_overhead must be >= 0, got {v}")
         return v
 
 

--- a/tests/test_auto_pcb_size_area_estimate.py
+++ b/tests/test_auto_pcb_size_area_estimate.py
@@ -1,0 +1,351 @@
+"""Tests for the sum-of-clearances area-estimation heuristic (Issue #3403).
+
+Covers the pre-route geometric estimator that lets ``--auto-pcb-size`` skip
+doomed routing attempts when the current envelope is clearly too small:
+
+  - :func:`estimate_required_area` math (footprint area, perimeter halo,
+    routing-channel term, packing-overhead multiplier).
+  - :func:`envelope_meets_area_estimate` decision boundary.
+  - Edge cases: empty PCB, footprints without pads, ``packing_overhead=0``
+    kill switch.
+  - Integration: the EscalationPolicy.packing_overhead field flows
+    through.
+  - Calibration sanity: ratios match the expected envelope-vs-required
+    pattern for synthetic small-board and large-board fixtures.
+
+No router behaviour is exercised here -- this is a pure-logic unit-test
+boundary.  The route-loop integration (``route_with_size_escalation``) is
+covered by :mod:`tests.test_auto_pcb_size_integration` (or its own
+follow-on integration suite).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from kicad_tools.router.auto_pcb_size import (
+    DEFAULT_PACKING_OVERHEAD,
+    DEFAULT_ROUTING_CHANNEL_PER_NET_MM2,
+    AreaEstimate,
+    envelope_meets_area_estimate,
+    estimate_required_area,
+)
+from kicad_tools.router.mfr_limits import MFR_JLCPCB, MFR_OSHPARK
+from kicad_tools.spec.schema import EscalationPolicy
+
+# ---------------------------------------------------------------------------
+# Lightweight stand-in fixtures
+#
+# The estimator only consults pad geometry and net names; we avoid the
+# PCB-load round-trip by passing in a tiny duck-typed stand-in.  This
+# keeps the unit tests fast and self-contained -- no .kicad_pcb fixture
+# files needed.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubPad:
+    position: tuple[float, float]
+    size: tuple[float, float]
+
+
+@dataclass
+class _StubFootprint:
+    pads: list = field(default_factory=list)
+
+
+@dataclass
+class _StubNet:
+    name: str
+
+
+@dataclass
+class _StubPCB:
+    footprints: list = field(default_factory=list)
+    nets: dict = field(default_factory=dict)
+
+
+def _make_pcb(
+    *,
+    fps: list[_StubFootprint] | None = None,
+    nets: dict[int, _StubNet] | None = None,
+) -> _StubPCB:
+    return _StubPCB(
+        footprints=fps or [],
+        nets=nets or {},
+    )
+
+
+def _square_footprint(side_mm: float) -> _StubFootprint:
+    """Build a single-pad footprint that contributes ``side_mm x side_mm`` to the bbox."""
+    return _StubFootprint(
+        pads=[_StubPad(position=(0.0, 0.0), size=(side_mm, side_mm))]
+    )
+
+
+# ---------------------------------------------------------------------------
+# AreaEstimate value class
+# ---------------------------------------------------------------------------
+
+
+class TestAreaEstimate:
+    def test_total_cm2_conversion(self):
+        est = AreaEstimate(
+            footprint_area_mm2=100.0,
+            clearance_halo_mm2=50.0,
+            routing_channel_mm2=20.0,
+            packing_overhead=2.5,
+            total_mm2=425.0,
+            signal_net_count=1,
+            footprint_count=1,
+        )
+        assert est.total_cm2 == pytest.approx(4.25)
+
+
+# ---------------------------------------------------------------------------
+# estimate_required_area: formula correctness
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateRequiredAreaMath:
+    """Verify the estimator's arithmetic against hand-computed values."""
+
+    def test_empty_pcb(self):
+        """No footprints, no nets -> all terms zero, total zero."""
+        pcb = _make_pcb()
+        est = estimate_required_area(pcb, MFR_JLCPCB)
+        assert est.footprint_area_mm2 == 0.0
+        assert est.clearance_halo_mm2 == 0.0
+        assert est.routing_channel_mm2 == 0.0
+        assert est.total_mm2 == 0.0
+        assert est.signal_net_count == 0
+        assert est.footprint_count == 0
+
+    def test_single_square_footprint_no_nets(self):
+        """One 5x5 mm SMD, no signal nets.
+
+        Hand math:
+          - footprint area = 25 mm^2
+          - halo = 2 * (5 + 5) * 0.127 = 2.54 mm^2
+          - channel = 0 (no nets)
+          - total = 2.5 * (25 + 2.54 + 0) = 68.85 mm^2
+        """
+        pcb = _make_pcb(fps=[_square_footprint(5.0)])
+        est = estimate_required_area(pcb, MFR_JLCPCB)
+        assert est.footprint_area_mm2 == pytest.approx(25.0)
+        assert est.clearance_halo_mm2 == pytest.approx(2.54)
+        assert est.routing_channel_mm2 == pytest.approx(0.0)
+        assert est.footprint_count == 1
+        # 2.5 * (25 + 2.54 + 0) = 68.85
+        assert est.total_mm2 == pytest.approx(68.85)
+
+    def test_signal_net_contributes_channel_area(self):
+        """One signal net -> one routing-channel allocation (default 20 mm^2)."""
+        pcb = _make_pcb(
+            fps=[_square_footprint(5.0)],
+            nets={1: _StubNet(name="SIGNAL_A")},
+        )
+        est = estimate_required_area(pcb, MFR_JLCPCB)
+        assert est.signal_net_count == 1
+        assert est.routing_channel_mm2 == pytest.approx(
+            DEFAULT_ROUTING_CHANNEL_PER_NET_MM2
+        )
+        # 2.5 * (25 + 2.54 + 20) = 118.85
+        assert est.total_mm2 == pytest.approx(118.85)
+
+    def test_pour_nets_excluded(self):
+        """GND / +3V3 / -12V / VCC / etc. don't contribute to channel term."""
+        pour_names = ["GND", "+3V3", "+5V", "VCC", "VDD", "AGND", "DGND", "-12V"]
+        pcb = _make_pcb(
+            fps=[_square_footprint(5.0)],
+            nets={i: _StubNet(name=n) for i, n in enumerate(pour_names, start=1)},
+        )
+        est = estimate_required_area(pcb, MFR_JLCPCB)
+        # All pour nets excluded -> signal count 0.
+        assert est.signal_net_count == 0
+        assert est.routing_channel_mm2 == 0.0
+
+    def test_mixed_nets(self):
+        """Signal + pour nets correctly classified."""
+        pcb = _make_pcb(
+            fps=[_square_footprint(5.0)],
+            nets={
+                1: _StubNet(name="SIGNAL_A"),
+                2: _StubNet(name="GND"),
+                3: _StubNet(name="SIGNAL_B"),
+                4: _StubNet(name="+3V3"),
+                5: _StubNet(name=""),  # unconnected
+            },
+        )
+        est = estimate_required_area(pcb, MFR_JLCPCB)
+        assert est.signal_net_count == 2
+        assert est.routing_channel_mm2 == pytest.approx(
+            2 * DEFAULT_ROUTING_CHANNEL_PER_NET_MM2
+        )
+
+    def test_multi_pad_footprint_bbox(self):
+        """Multi-pad footprint's bbox spans the pad-array extent."""
+        # Two pads at (0,0) and (10,5), each 2x2 mm
+        # bbox extent: x in [-1, 11], y in [-1, 6]
+        # -> W = 12, H = 7
+        # -> bbox area = 84 mm^2
+        # -> halo = 2 * (12 + 7) * 0.127 = 4.826 mm^2
+        fp = _StubFootprint(
+            pads=[
+                _StubPad(position=(0.0, 0.0), size=(2.0, 2.0)),
+                _StubPad(position=(10.0, 5.0), size=(2.0, 2.0)),
+            ]
+        )
+        pcb = _make_pcb(fps=[fp])
+        est = estimate_required_area(pcb, MFR_JLCPCB)
+        assert est.footprint_area_mm2 == pytest.approx(84.0)
+        assert est.clearance_halo_mm2 == pytest.approx(2 * (12 + 7) * 0.127)
+        assert est.footprint_count == 1
+
+    def test_footprint_no_pads_skipped(self):
+        """Mechanical-only footprints (no pads) contribute nothing."""
+        fp_empty = _StubFootprint(pads=[])
+        fp_real = _square_footprint(5.0)
+        pcb = _make_pcb(fps=[fp_empty, fp_real])
+        est = estimate_required_area(pcb, MFR_JLCPCB)
+        # Only the real footprint contributes.
+        assert est.footprint_count == 1
+        assert est.footprint_area_mm2 == pytest.approx(25.0)
+
+    def test_mfr_clearance_scales_halo(self):
+        """Tighter manufacturer clearance shrinks the halo proportionally."""
+        pcb = _make_pcb(fps=[_square_footprint(5.0)])
+        # JLCPCB: 0.127 mm -- halo = 2 * 10 * 0.127 = 2.54 mm^2
+        est_jlc = estimate_required_area(pcb, MFR_JLCPCB)
+        # OSHPark: 0.152 mm -- halo = 2 * 10 * 0.152 = 3.04 mm^2
+        est_osh = estimate_required_area(pcb, MFR_OSHPARK)
+        assert est_osh.clearance_halo_mm2 > est_jlc.clearance_halo_mm2
+        ratio = est_osh.clearance_halo_mm2 / est_jlc.clearance_halo_mm2
+        assert ratio == pytest.approx(0.152 / 0.127, rel=1e-6)
+
+    def test_packing_overhead_multiplier(self):
+        """packing_overhead scales the final total linearly."""
+        pcb = _make_pcb(
+            fps=[_square_footprint(5.0)],
+            nets={1: _StubNet(name="SIG")},
+        )
+        # base sum (per arithmetic above) = 25 + 2.54 + 20 = 47.54
+        est_25 = estimate_required_area(pcb, MFR_JLCPCB, packing_overhead=2.5)
+        est_30 = estimate_required_area(pcb, MFR_JLCPCB, packing_overhead=3.0)
+        assert est_25.total_mm2 == pytest.approx(2.5 * 47.54)
+        assert est_30.total_mm2 == pytest.approx(3.0 * 47.54)
+        # Ratio is exactly the multiplier ratio.
+        assert est_30.total_mm2 / est_25.total_mm2 == pytest.approx(3.0 / 2.5)
+
+    def test_packing_overhead_zero_disables_total(self):
+        """packing_overhead=0 yields total_mm2=0 (kill switch)."""
+        pcb = _make_pcb(
+            fps=[_square_footprint(5.0)],
+            nets={1: _StubNet(name="SIG")},
+        )
+        est = estimate_required_area(pcb, MFR_JLCPCB, packing_overhead=0.0)
+        # The individual terms are still computed (for inspection).
+        assert est.footprint_area_mm2 == pytest.approx(25.0)
+        assert est.routing_channel_mm2 == pytest.approx(20.0)
+        # Total is forced to zero.
+        assert est.total_mm2 == 0.0
+
+
+# ---------------------------------------------------------------------------
+# envelope_meets_area_estimate decision boundary
+# ---------------------------------------------------------------------------
+
+
+class TestEnvelopeMeetsAreaEstimate:
+    def _est(self, total: float) -> AreaEstimate:
+        return AreaEstimate(
+            footprint_area_mm2=0.0,
+            clearance_halo_mm2=0.0,
+            routing_channel_mm2=0.0,
+            packing_overhead=2.5,
+            total_mm2=total,
+            signal_net_count=0,
+            footprint_count=0,
+        )
+
+    def test_envelope_strictly_greater_meets(self):
+        assert envelope_meets_area_estimate(200.0, self._est(100.0)) is True
+
+    def test_envelope_equal_meets(self):
+        """Boundary: equal counts as meeting the requirement."""
+        assert envelope_meets_area_estimate(100.0, self._est(100.0)) is True
+
+    def test_envelope_less_does_not_meet(self):
+        assert envelope_meets_area_estimate(99.0, self._est(100.0)) is False
+
+    def test_zero_estimate_always_meets(self):
+        """packing_overhead=0 kill switch -> always meets (estimator disabled)."""
+        assert envelope_meets_area_estimate(0.0, self._est(0.0)) is True
+        assert envelope_meets_area_estimate(1.0, self._est(0.0)) is True
+
+
+# ---------------------------------------------------------------------------
+# EscalationPolicy.packing_overhead integration
+# ---------------------------------------------------------------------------
+
+
+class TestPackingOverheadPolicyField:
+    def test_default_matches_constant(self):
+        """The schema default tracks the auto_pcb_size module constant."""
+        policy = EscalationPolicy()
+        assert policy.packing_overhead == DEFAULT_PACKING_OVERHEAD
+
+    def test_custom_packing_overhead_accepted(self):
+        policy = EscalationPolicy(packing_overhead=3.0)
+        assert policy.packing_overhead == 3.0
+
+    def test_zero_packing_overhead_accepted(self):
+        """Zero is the documented kill-switch value."""
+        policy = EscalationPolicy(packing_overhead=0.0)
+        assert policy.packing_overhead == 0.0
+
+    def test_negative_packing_overhead_rejected(self):
+        with pytest.raises(ValueError):
+            EscalationPolicy(packing_overhead=-1.0)
+
+
+# ---------------------------------------------------------------------------
+# Calibration sanity: synthetic small-board vs. large-board ratios
+# ---------------------------------------------------------------------------
+
+
+class TestCalibrationSanity:
+    """Lightweight calibration check.
+
+    Issue #3403 acceptance criterion: ratio of current_area to
+    estimated_required_area should track empirical routability.  We can't
+    run the real router from a unit test, but we can verify the estimate
+    produces sensible ratios for known-shape synthetic designs.
+    """
+
+    def test_tiny_envelope_below_estimate(self):
+        """A 10x10 board with 5 fat ICs is clearly over-constrained."""
+        pcb = _make_pcb(
+            fps=[_square_footprint(10.0) for _ in range(5)],
+            nets={i: _StubNet(name=f"N{i}") for i in range(1, 11)},
+        )
+        est = estimate_required_area(pcb, MFR_JLCPCB)
+        envelope_mm2 = 10.0 * 10.0  # 100 mm^2
+        # 5 x 10x10 footprints = 500 mm^2 of pads alone -> total way above 100
+        assert est.total_mm2 > envelope_mm2 * 4
+        assert envelope_meets_area_estimate(envelope_mm2, est) is False
+
+    def test_large_envelope_meets_estimate(self):
+        """A 100x100 board with 5 small SMDs has ample room."""
+        pcb = _make_pcb(
+            fps=[_square_footprint(3.0) for _ in range(5)],
+            nets={i: _StubNet(name=f"N{i}") for i in range(1, 6)},
+        )
+        est = estimate_required_area(pcb, MFR_JLCPCB)
+        envelope_mm2 = 100.0 * 100.0  # 10 000 mm^2
+        assert envelope_meets_area_estimate(envelope_mm2, est) is True
+        # Ratio should be comfortably above 1.0 for a roomy board.
+        ratio = envelope_mm2 / est.total_mm2
+        assert ratio > 10.0, f"expected loose board ratio > 10, got {ratio:.2f}"

--- a/tests/test_auto_pcb_size_integration.py
+++ b/tests/test_auto_pcb_size_integration.py
@@ -840,3 +840,241 @@ class TestMultiAttemptRegression:
         # Should refuse after the regression is detected -- 2 attempts only.
         assert attempts["count"] == 2
         assert rc == 2
+
+
+# ---------------------------------------------------------------------------
+# Issue #3403: sum-of-clearances pre-route area heuristic integration
+# ---------------------------------------------------------------------------
+
+
+# 50 x 50 mm board with a single 20 x 20 mm footprint -- intentionally over-
+# constrained: the bbox alone occupies 16% of the envelope, and with halo +
+# packing overhead the estimator will say the envelope is too small.
+#
+# The numbers are chosen so the estimate at default packing_overhead=2.5
+# exceeds the envelope area: 1 footprint at 20x20 + halo 2*(20+20)*0.127
+# = 400 + 10.16 = 410.16 mm^2 base, *2.5 = 1025 mm^2 required.  The
+# envelope is 50*50 = 2500 mm^2 -- so actually this small board PASSES.
+# We need a smaller envelope to force the pre-route skip.
+_PCB_30x30_BIG_PART = textwrap.dedent("""\
+    (kicad_pcb
+      (version 20240108)
+      (generator "test")
+      (layers
+        (0 "F.Cu" signal)
+        (31 "B.Cu" signal)
+        (44 "Edge.Cuts" user)
+      )
+      (net 0 "")
+      (net 1 "SIG_A")
+      (net 2 "SIG_B")
+      (net 3 "SIG_C")
+      (net 4 "SIG_D")
+      (net 5 "SIG_E")
+      (gr_rect
+        (start 100 100)
+        (end 130 130)
+        (stroke (width 0.1) (type default))
+        (fill none)
+        (layer "Edge.Cuts")
+        (uuid "outline-1")
+      )
+      (footprint "BigPart"
+        (layer "F.Cu")
+        (uuid "fp-1")
+        (at 115 115)
+        (pad "1" smd rect (at -8 -8) (size 4 4) (layers "F.Cu"))
+        (pad "2" smd rect (at  8 -8) (size 4 4) (layers "F.Cu"))
+        (pad "3" smd rect (at -8  8) (size 4 4) (layers "F.Cu"))
+        (pad "4" smd rect (at  8  8) (size 4 4) (layers "F.Cu"))
+      )
+    )
+""")
+
+
+class TestPreRouteAreaEstimateSkip:
+    """Integration tests for the Issue #3403 pre-route area-estimate skip.
+
+    Verifies that ``route_with_size_escalation`` skips the doomed routing
+    attempt when the current envelope is smaller than the
+    sum-of-clearances estimate.
+    """
+
+    def _args(self, pcb_path: Path) -> SimpleNamespace:
+        return SimpleNamespace(
+            pcb=str(pcb_path),
+            output=None,
+            manufacturer="jlcpcb",
+            auto_layers=True,
+            auto_pcb_size=True,
+            max_layers=4,
+            min_completion=0.95,
+            quiet=False,
+            strategy="negotiated",
+            packing_overhead=None,  # use policy default
+        )
+
+    def test_pre_route_skip_avoids_inner_call(self, tmp_path):
+        """When envelope < estimate, the inner router is NOT called.
+
+        We over-estimate by passing a huge ``--packing-overhead`` so the
+        estimate exceeds even the largest tier; the wrapper should skip
+        directly without calling route_with_layer_escalation.
+        """
+        from kicad_tools.cli import route_cmd
+
+        pcb_path = tmp_path / "board.kicad_pcb"
+        pcb_path.write_text(_PCB_30x30_BIG_PART)
+        output_path = tmp_path / "routed.kicad_pcb"
+        args = self._args(pcb_path)
+        # Force a packing overhead high enough that the estimate exceeds
+        # the largest JLCPCB tier (200x300 = 60 000 mm^2). The fixture's
+        # base sum (footprints + halo + channels) is ~510 mm^2; we need
+        # the estimate above 60 000 to force REFUSE_MAX_TIER, so
+        # packing_overhead >= 120 suffices.  Use 200 for safety.
+        args.packing_overhead = 200.0
+
+        attempts = {"inner_calls": 0}
+
+        def fake_inner(pcb_path, output_path, args, quiet):
+            attempts["inner_calls"] += 1
+            args._last_layer_result = SimpleNamespace(
+                nets_routed=5,
+                nets_to_route=5,
+                overflow=0,
+                completion=1.0,
+                success=True,
+                router=None,
+            )
+            return 0
+
+        with patch.object(route_cmd, "route_with_layer_escalation", fake_inner):
+            rc = route_cmd.route_with_size_escalation(
+                pcb_path=pcb_path,
+                output_path=output_path,
+                args=args,
+                quiet=True,
+            )
+
+        # With huge packing overhead the estimator forces escalation at
+        # every tier; the ladder is finite (5 rungs for JLCPCB) so we
+        # should NEVER reach an inner call.
+        assert attempts["inner_calls"] == 0
+        # Exit code is 1 (refused with max_tier) when the loop exhausts.
+        assert rc == 1
+
+    def test_pre_route_check_disabled_with_zero_packing_overhead(self, tmp_path):
+        """packing_overhead=0 disables the pre-route check -- inner is called."""
+        from kicad_tools.cli import route_cmd
+
+        pcb_path = tmp_path / "board.kicad_pcb"
+        pcb_path.write_text(_PCB_30x30_BIG_PART)
+        output_path = tmp_path / "routed.kicad_pcb"
+        args = self._args(pcb_path)
+        args.packing_overhead = 0.0  # kill switch
+
+        attempts = {"inner_calls": 0}
+
+        def fake_inner(pcb_path, output_path, args, quiet):
+            attempts["inner_calls"] += 1
+            args._last_layer_result = SimpleNamespace(
+                nets_routed=5,
+                nets_to_route=5,
+                overflow=0,
+                completion=1.0,
+                success=True,
+                router=None,
+            )
+            return 0
+
+        with patch.object(route_cmd, "route_with_layer_escalation", fake_inner):
+            rc = route_cmd.route_with_size_escalation(
+                pcb_path=pcb_path,
+                output_path=output_path,
+                args=args,
+                quiet=True,
+            )
+
+        # With the kill switch active, the inner router IS called.
+        assert attempts["inner_calls"] >= 1
+        assert rc == 0
+
+    def test_pre_route_logs_estimate(self, tmp_path, capsys):
+        """The estimate is logged on each loop iteration (calibration trail)."""
+        from kicad_tools.cli import route_cmd
+
+        pcb_path = tmp_path / "board.kicad_pcb"
+        pcb_path.write_text(_PCB_30x30_BIG_PART)
+        output_path = tmp_path / "routed.kicad_pcb"
+        args = self._args(pcb_path)
+        args.packing_overhead = 2.5  # default
+
+        def fake_inner(pcb_path, output_path, args, quiet):
+            args._last_layer_result = SimpleNamespace(
+                nets_routed=5,
+                nets_to_route=5,
+                overflow=0,
+                completion=1.0,
+                success=True,
+                router=None,
+            )
+            return 0
+
+        with patch.object(route_cmd, "route_with_layer_escalation", fake_inner):
+            route_cmd.route_with_size_escalation(
+                pcb_path=pcb_path,
+                output_path=output_path,
+                args=args,
+                quiet=False,
+            )
+
+        captured = capsys.readouterr()
+        assert "Area estimate:" in captured.out
+        # Calibration-friendly: the breakdown is in the log line.
+        assert "footprints=" in captured.out
+        assert "halo=" in captured.out
+        assert "channels=" in captured.out
+
+    def test_pre_route_skip_then_grow_changes_envelope(self, tmp_path):
+        """After skip+grow, the next iteration sees a larger envelope."""
+        from kicad_tools.cli import route_cmd
+        from kicad_tools.router.io import extract_board_dimensions
+
+        pcb_path = tmp_path / "board.kicad_pcb"
+        pcb_path.write_text(_PCB_30x30_BIG_PART)
+        output_path = tmp_path / "routed.kicad_pcb"
+        args = self._args(pcb_path)
+        # Pick a packing_overhead that forces escalation from 30x30 but
+        # is satisfied somewhere up the JLCPCB ladder.
+        args.packing_overhead = 10.0
+
+        # Track envelope dimensions observed at each inner call.
+        envelopes_seen: list[tuple[float, float]] = []
+
+        def fake_inner(pcb_path, output_path, args, quiet):
+            dims = extract_board_dimensions(pcb_path)
+            if dims is not None:
+                envelopes_seen.append(dims)
+            args._last_layer_result = SimpleNamespace(
+                nets_routed=5,
+                nets_to_route=5,
+                overflow=0,
+                completion=1.0,
+                success=True,
+                router=None,
+            )
+            return 0
+
+        with patch.object(route_cmd, "route_with_layer_escalation", fake_inner):
+            route_cmd.route_with_size_escalation(
+                pcb_path=pcb_path,
+                output_path=output_path,
+                args=args,
+                quiet=True,
+            )
+
+        # The final envelope must be strictly larger than the starting one.
+        final_dims = extract_board_dimensions(pcb_path)
+        assert final_dims is not None
+        final_w, final_h = final_dims
+        assert final_w > 30.0 or final_h > 30.0


### PR DESCRIPTION
## Summary

Implements the Issue #3403 sum-of-clearances area-escalation heuristic for ``--auto-pcb-size``. The escalation loop now runs a pre-route geometric check that compares the current envelope area against a heuristic lower-bound; when the envelope is too small, the doomed routing attempt is skipped and the loop escalates directly to the next size tier. The reactive DRC-density backstop remains as the fallback for cases where the heuristic under-estimates.

### Formula

```
required = packing_overhead * (
    sum(footprint_area + clearance_perimeter for each component)
    + sum(routing_channel_estimate for each signal net)
)
```

- ``footprint_area``: pad-array bounding-box area (mm^2).
- ``clearance_perimeter`` = ``2 * (W + H) * mfr.min_clearance``.
- ``routing_channel_estimate`` = 20 mm^2 per signal net (coarse multiplier per scope note).
- ``packing_overhead``: heuristic multiplier (default 2.5; recipe-tunable; ``0`` disables).

### Calibration (boards 02-07 at packing_overhead=2.5)

| Board               | env mm^2 | est mm^2 | ratio | fps | nets |
|---------------------|---------:|---------:|------:|----:|-----:|
| 02-charlieplex      |     2750 |      783 |  3.51 |  14 |    8 |
| 03-usb-joystick     |     2400 |     1208 |  1.99 |  12 |   13 |
| 04-stm32-devboard   |     2400 |     1100 |  2.18 |  17 |    9 |
| 05-bldc-controller  |     8000 |     3927 |  2.04 |  55 |   36 |
| 06-diffpair-test    |     8000 |     2025 |  3.95 |   7 |   22 |
| 07-matchgroup-test  |    10450 |     2977 |  3.51 |   8 |   31 |

All currently-routable boards land comfortably above 1.0, confirming the heuristic does not incorrectly skip routable cases. (Softstart's PCB is generated rather than checked in, so it's calibrated via the live router rather than this static table.) Run ``uv run python scripts/calibrate_area_estimate.py`` for ad-hoc calibration with custom ``--packing-overhead`` / ``--mfr`` values.

### Scope of changes

- ``src/kicad_tools/router/auto_pcb_size.py``: new ``estimate_required_area()`` + ``AreaEstimate`` + ``envelope_meets_area_estimate()``; new ``DEFAULT_PACKING_OVERHEAD`` / ``DEFAULT_ROUTING_CHANNEL_PER_NET_MM2`` constants.
- ``src/kicad_tools/spec/schema.py``: new ``EscalationPolicy.packing_overhead`` field (default 2.5).
- ``src/kicad_tools/cli/route_cmd.py``: pre-route check integrated into ``route_with_size_escalation``; ``--packing-overhead`` CLI flag.
- ``src/kicad_tools/cli/parser.py`` + ``src/kicad_tools/cli/commands/routing.py``: ``--packing-overhead`` exposed on ``kct route`` and forwarded to the inner parser.
- ``scripts/calibrate_area_estimate.py``: ad-hoc calibration helper.
- ``tests/test_auto_pcb_size_area_estimate.py`` (new): 21 unit tests for the estimator math, edge cases, and policy-field validation.
- ``tests/test_auto_pcb_size_integration.py``: 4 new integration tests for ``route_with_size_escalation`` pre-route skip behaviour (inner router patched).

### Coordination with #3400

Per the issue body, ``EscalationPolicy.starting_layers`` belongs to #3400 and is NOT touched here. Both PRs edit the same ``EscalationPolicy`` class but only add new fields, so any rebase conflict should be trivial.

## Test plan

- [x] Unit tests cover the estimator math (21 tests) -- footprint bbox, perimeter halo, signal/pour-net classification, packing-overhead scaling, packing_overhead=0 kill switch.
- [x] Integration tests verify ``route_with_size_escalation`` skips the inner router when envelope < estimate, calls it when ``packing_overhead=0``, logs the estimate, and grows the envelope across iterations (4 tests, all mocked).
- [x] Existing auto_pcb_size tests still pass (113 prior tests, 117 total in module).
- [x] Calibration ratios on boards 02-07 confirm routable boards are not incorrectly skipped.
- [x] ``ruff check`` clean on all modified files.
- [x] ``EscalationPolicy.packing_overhead`` rejects negative values; default tracks ``DEFAULT_PACKING_OVERHEAD`` constant.

Closes #3403