### PR TITLE
feat(boards): audit starting_layers per board against 100% routability (closes #3402)

### DIFF
--- a/boards/05-bldc-motor-controller/project.kct
+++ b/boards/05-bldc-motor-controller/project.kct
@@ -84,13 +84,26 @@ requirements:
 
   manufacturing:
     layers:
-      preferred: 2
+      preferred: 4
+      # Issue #3402: bumped from 2 to 4 — the empirical routing audit
+      # showed 2L tops out at 46% reach while 4L reaches 60%+.  See the
+      # ``escalation.starting_layers`` note below for the manufacturable-
+      # bar rationale (100% LVS + 0 DRC).
     min_trace: "0.2mm"
     min_space: "0.2mm"
     min_drill: "0.3mm"
     copper_weight: "2oz"
     unit: "mm"
     notes: "2oz copper recommended for motor phase traces"
+    # Issue #3402: DRV8301 gate driver + STM32G431 MCU + 3-phase power
+    # routing combine high pin density with high-current motor phase
+    # traces.  Empirical routing audit (#3402) shows 2L tops out at 46%
+    # reach while 4L reaches 60% — a clear "more layers materially
+    # helps" signal.  Set starting_layers=4 to skip the 2L probe.
+    # Residual reach gap at 4L tracked separately as a follow-on issue
+    # (gh:#3412).
+    escalation:
+      starting_layers: 4
 
 suggestions:
   components:

--- a/boards/06-diffpair-test/project.kct
+++ b/boards/06-diffpair-test/project.kct
@@ -128,13 +128,16 @@ requirements:
     min_space: "0.15mm"
     min_via: "0.3mm"
     assembly: smt
-    # Issue #3402: this board is purpose-built for diff-pair routing on a
-    # 4-layer JLCPCB tier-1 stackup; impedance formulas (Phase 3K) assume
-    # an inner GND plane.  Probing 2L is unproductive — opt out via
-    # starting_layers=4 so the escalation ladder skips the 2L rung.
-    # Residual reach gap at 4L (41%) tracked as gh:#3413.
-    escalation:
-      starting_layers: 4
+    # Issue #3402: this board's spec describes a 4-layer JLCPCB tier-1
+    # stackup with inner GND/PWR planes, but the routing-orchestrator's
+    # auto-layer escalation (#2916) already detects this from the
+    # ``layers.preferred: 4`` hint above.  An earlier attempt to set
+    # ``escalation.starting_layers: 4`` was reverted on this board
+    # specifically: the field is NOT a no-op here — it skips the 2L
+    # probe, lands the negotiator in a different basin (4L
+    # SIG-GND-PWR-SIG), and pushed routed DRC from 21 -> 32 violations
+    # (CI failure on the Diff-Pair Routing Regression gate).  Tracked
+    # under #3413 for a real fix.
 
   compliance:
     standards:

--- a/boards/06-diffpair-test/project.kct
+++ b/boards/06-diffpair-test/project.kct
@@ -128,6 +128,13 @@ requirements:
     min_space: "0.15mm"
     min_via: "0.3mm"
     assembly: smt
+    # Issue #3402: this board is purpose-built for diff-pair routing on a
+    # 4-layer JLCPCB tier-1 stackup; impedance formulas (Phase 3K) assume
+    # an inner GND plane.  Probing 2L is unproductive — opt out via
+    # starting_layers=4 so the escalation ladder skips the 2L rung.
+    # Residual reach gap at 4L (41%) tracked as gh:#3413.
+    escalation:
+      starting_layers: 4
 
   compliance:
     standards:

--- a/boards/07-matchgroup-test/project.kct
+++ b/boards/07-matchgroup-test/project.kct
@@ -149,6 +149,13 @@ requirements:
     min_space: "0.15mm"
     min_via: "0.3mm"
     assembly: smt
+    # Issue #3402: match-group regression testbench mirrors board 06's
+    # 4-layer JLCPCB tier-1 stackup; impedance formulas (Phase 3K) assume
+    # an inner GND plane.  Probing 2L is unproductive — opt out via
+    # starting_layers=4 so the escalation ladder skips the 2L rung.
+    # Residual reach gap at 4L (84%) tracked as gh:#3414.
+    escalation:
+      starting_layers: 4
 
   compliance:
     standards:

--- a/tests/test_demo_boards_starting_layers.py
+++ b/tests/test_demo_boards_starting_layers.py
@@ -1,0 +1,120 @@
+"""Per-board ``starting_layers`` audit (Issue #3402).
+
+PR #3405 (Issue #3400) added ``EscalationPolicy.starting_layers`` so a
+board can opt out of the 2L probe when 2L cannot meet the
+"manufacturable = 100% LVS + 0 DRC" bar (user direction 2026-06-09).
+
+Issue #3402 audited every demo board (``boards/00`` ... ``boards/07``)
+against that bar and set ``starting_layers`` per board:
+
+  - Boards 00, 01, 02 stay at the default (2L probe enabled): they
+    route 100% with 0 DRC on 2L in production.
+  - Boards 03 and 04 also stay at the default: their 2L reach gap is
+    a *placement / topology* gap, not a layer-count gap (4L doesn't
+    improve completion).  Residual gaps tracked as separate issues.
+  - Boards 05, 06, 07 set ``starting_layers: 4``: 06 and 07 are
+    inherent 4-layer PCBs (inner GND / PWR planes), and 05 (DRV8301 +
+    STM32G431 + 3-phase power) shows a material reach gap at 2L vs
+    4L (46% vs 60%+) — probing 2L is a waste of routing budget.
+
+This regression test pins the audit decisions so a future spec edit
+that silently flips a board's starting layer (e.g., dropping ``05``
+back to the default 2L probe) is caught loudly.
+
+The test loads each board's ``project.kct`` through the spec parser
+and asserts the resolved ``EscalationPolicy.starting_layers`` value
+matches the audit table.  It does NOT re-route — that's covered by
+the per-board routing tests already in place.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.spec.parser import load_spec
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BOARDS_DIR = REPO_ROOT / "boards"
+
+
+# Audit table from Issue #3402 (2026-06-09).  ``None`` means no
+# ``escalation`` block (default 2L probe), an int means an explicit
+# ``starting_layers`` value in the spec.
+AUDIT_TABLE: dict[str, int | None] = {
+    "00-simple-led": None,
+    "01-voltage-divider": None,
+    "02-charlieplex-led": None,
+    "03-usb-joystick": None,
+    "04-stm32-devboard": None,
+    "05-bldc-motor-controller": 4,
+    "06-diffpair-test": 4,
+    "07-matchgroup-test": 4,
+}
+
+
+@pytest.mark.parametrize("board,expected", sorted(AUDIT_TABLE.items()))
+def test_starting_layers_matches_audit(board: str, expected: int | None) -> None:
+    """``EscalationPolicy.starting_layers`` matches the Issue #3402 audit.
+
+    For boards in the "stays at default" group the test asserts the
+    ``escalation`` block is absent (or its ``starting_layers`` field
+    is the schema default ``2``).  For the 4L-opt-in group it asserts
+    the explicit value is present.
+    """
+    spec_path = BOARDS_DIR / board / "project.kct"
+    assert spec_path.is_file(), f"Missing project.kct for {board}: {spec_path}"
+
+    spec = load_spec(spec_path)
+    requirements = getattr(spec, "requirements", None)
+    manufacturing = (
+        getattr(requirements, "manufacturing", None) if requirements else None
+    )
+    escalation = (
+        getattr(manufacturing, "escalation", None) if manufacturing else None
+    )
+
+    if expected is None:
+        # Default group: either no escalation block, or escalation
+        # present but starting_layers at the schema default (2).
+        if escalation is None:
+            return
+        assert escalation.starting_layers == 2, (
+            f"{board}: per Issue #3402 audit this board should keep the "
+            f"default 2L probe, but its project.kct now sets "
+            f"starting_layers={escalation.starting_layers}.  If the audit "
+            f"decision changed, update AUDIT_TABLE in this test."
+        )
+    else:
+        assert escalation is not None, (
+            f"{board}: per Issue #3402 audit this board should declare "
+            f"starting_layers={expected}, but project.kct has no "
+            f"requirements.manufacturing.escalation block."
+        )
+        assert escalation.starting_layers == expected, (
+            f"{board}: per Issue #3402 audit starting_layers should be "
+            f"{expected}, got {escalation.starting_layers}.  If the audit "
+            f"decision changed, update AUDIT_TABLE in this test."
+        )
+
+
+def test_all_demo_boards_present() -> None:
+    """Sanity: every demo board directory is covered by the audit.
+
+    Guards against a new ``boards/0N-...`` being added without the
+    Issue #3402 audit decision being recorded here.
+    """
+    on_disk = sorted(
+        p.name
+        for p in BOARDS_DIR.iterdir()
+        if p.is_dir() and p.name[:2].isdigit() and (p / "project.kct").is_file()
+    )
+    audited = sorted(AUDIT_TABLE.keys())
+    assert on_disk == audited, (
+        "Demo boards on disk diverge from the Issue #3402 audit table.\n"
+        f"  On disk:  {on_disk}\n"
+        f"  Audited:  {audited}\n"
+        "Add the new board to AUDIT_TABLE in this test (and pick a "
+        "starting_layers value per the methodology in Issue #3402)."
+    )

--- a/tests/test_demo_boards_starting_layers.py
+++ b/tests/test_demo_boards_starting_layers.py
@@ -12,10 +12,17 @@ against that bar and set ``starting_layers`` per board:
   - Boards 03 and 04 also stay at the default: their 2L reach gap is
     a *placement / topology* gap, not a layer-count gap (4L doesn't
     improve completion).  Residual gaps tracked as separate issues.
-  - Boards 05, 06, 07 set ``starting_layers: 4``: 06 and 07 are
-    inherent 4-layer PCBs (inner GND / PWR planes), and 05 (DRV8301 +
+  - Boards 05 and 07 set ``starting_layers: 4``: 07 is an inherent
+    4-layer PCB (inner GND / PWR planes), and 05 (DRV8301 +
     STM32G431 + 3-phase power) shows a material reach gap at 2L vs
     4L (46% vs 60%+) — probing 2L is a waste of routing budget.
+  - Board 06 was initially in the 4L-opt-in group but reverted after
+    Judge feedback on PR #3415: the field unexpectedly altered the
+    negotiator trajectory (skipped 2L probe, started 4L
+    SIG-GND-PWR-SIG, hit stagnation+timeout, DRC 21 -> 32, CI
+    failure on the diff-pair regression gate).  Tracked under
+    #3413 — whatever closes #3413 should re-evaluate whether
+    explicit ``starting_layers`` makes sense on this board.
 
 This regression test pins the audit decisions so a future spec edit
 that silently flips a board's starting layer (e.g., dropping ``05``
@@ -49,7 +56,8 @@ AUDIT_TABLE: dict[str, int | None] = {
     "03-usb-joystick": None,
     "04-stm32-devboard": None,
     "05-bldc-motor-controller": 4,
-    "06-diffpair-test": 4,
+    # 06-diffpair-test reverted to default — see module docstring + PR #3415.
+    "06-diffpair-test": None,
     "07-matchgroup-test": 4,
 }
 


### PR DESCRIPTION
## Summary

Audits demo boards 00-07 against the 100% LVS + 0 DRC manufacturability bar (user direction 2026-06-09) and sets ``EscalationPolicy.starting_layers`` per board in ``project.kct`` where 2L can't meet the bar.

Closes #3402

## Audit table (production routing, ``--auto-layers --max-layers 4``)

| Board                     | Routed layer | Spec field set | Reach | DRC |
|---------------------------|--------------|----------------|-------|-----|
| 00-simple-led             | 2L           | (default)      | 100%  | 0   |
| 01-voltage-divider        | 2L           | (default)      | 100%  | 27* |
| 02-charlieplex-led        | 2L           | (default)      | 100%  | 0   |
| 03-usb-joystick           | 2L (= 4L)    | (default)      | 77%   | 33  |
| 04-stm32-devboard         | 2L (= 4L)    | (default)      | 67%   | -   |
| 05-bldc-motor-controller  | 4L           | ``starting_layers: 4`` | 60%   | -   |
| 06-diffpair-test          | 4L           | (default)†     | 41%   | 33  |
| 07-matchgroup-test        | 4L           | ``starting_layers: 4`` | 84%   | 30  |

\* Board 01: existing routed artifact passes DRC; fresh negotiated pass has 27 clearance violations (router-quality issue, not a 2L manufacturability gap).  Left at the default.

† Board 06: initially set ``starting_layers: 4`` in this PR, then **reverted** after Judge feedback found the field materially changed the negotiator trajectory on this board.  See "Doctor cycle revert" below.

## Decisions

- **Boards 00, 01, 02:** 2L hits 100% routing in production; keep the default (no escalation block).
- **Boards 03, 04:** 2L AND 4L cap at the same reach (BLOCKED_PATH, USB-C escape geometry).  The gap is placement, not layer count — ``starting_layers: 4`` would not help.  Left at the default.
- **Board 05:** 2L = 46% reach, 4L = 60%+ reach.  Clear "more layers materially helps" signal.  Set ``starting_layers: 4``.  Also bumped ``layers.preferred`` from 2 to 4 to match the new escalation floor.
- **Board 06:** Originally classified with 07 as an inherent 4-layer stackup, so the PR set ``starting_layers: 4``.  Judge rerouted from scratch and found this was NOT a no-op on board 06's negotiator: setting it skipped the 2L probe, started directly at 4L SIG-GND-PWR-SIG, hit stagnation recovery + timeout, and landed at a worse local optimum (DRC 21 → 32, blowing the Diff-Pair Routing Regression CI gate's 21-error allowlist).  Reverted on board 06 only.  Field is documented in-spec as NOT a no-op here.  Tracked under #3413.
- **Board 07:** Inherent 4-layer stackup (inner GND/PWR planes).  ``starting_layers: 4`` is verified safe here (no DRC regression from the field on this board's negotiator); keeps the per-board intent explicit in the spec.

## Doctor cycle revert (board 06)

Judge feedback on the first builder pass: ``starting_layers: 4`` on board 06's project.kct was claimed to be a no-op because the router already auto-detects the 4-layer stackup (#2916).  That claim was wrong for board 06's negotiator — the field alters the routing trajectory, skips the 2L probe, hits stagnation recovery + timeout, and lands at a worse local optimum.  Fresh re-route showed 32 DRC errors vs the 21 allowlist (Diff-Pair Routing Regression CI gate FAILED).

Fix in this doctor cycle:

- Reverted ``starting_layers: 4`` on board 06.
- Replaced the spec comment with an explicit note that the field is NOT a no-op on this board and was reverted (cross-references #3413).
- Updated ``tests/test_demo_boards_starting_layers.py`` AUDIT_TABLE: ``06-diffpair-test`` now expects ``None`` (default).  9/9 still pass.
- Verified the diff-pair coverage re-route is back in the historical ~21-25 DRC band (vs the 32-error regime with the field set).  The committed routed PCB on disk (already at 21) is unchanged.

Board 05 and 07 ``starting_layers: 4`` settings are unchanged — those measurements were sound and the negotiator behavior on those boards is unaffected by the field.

## Residual-gap follow-on issues filed

Per the methodology, boards that don't hit 100% at L=4 get a per-board follow-on rather than being fixed in this PR:

- #3410 board 03 (usb-joystick): 77% reach, USB diff-pair placement gap
- #3411 board 04 (stm32-devboard): 67% reach, OSC_OUT BLOCKED_PATH
- #3412 board 05 (bldc-motor-controller): 60% reach at 4L, congestion-limited around DRV8301/STM32 fan-out
- #3413 board 06 (diffpair-test): 41% reach at 4L, diff-pair escape gap (also tracks the ``starting_layers`` re-evaluation surfaced by this PR's revert)
- #3414 board 07 (matchgroup-test): 84% reach at 4L, length-match groups CLI not yet wired (depends on #2723)

## Test plan

- [x] Spec parser test (``tests/test_demo_boards_starting_layers.py``): asserts the per-board ``EscalationPolicy.starting_layers`` value matches the audit table; sanity check that new boards must add an audit entry.  9/9 pass (with board 06 reverted to ``None``).
- [x] ``_resolve_starting_layers`` integration: verified each board's PCB resolves to the expected value (00-04, 06 → 2; 05, 07 → 4).
- [x] Existing tests still pass: ``tests/test_spec.py`` (70 passed).
- [x] Board 06 fresh re-route confirmed back in the historical ~21-25 DRC range (vs 32 with ``starting_layers: 4``).

## Out of scope

- Softstart spec (#3401 is parallel).
- Deep router fixes for any board that doesn't hit 100% at 4L (per-board follow-on issues filed above; not fixed here).
- Changing the CLI default for ``--starting-layers``.
- Lowering the 100% manufacturable bar (user direction fixed).
- Re-evaluating whether explicit ``starting_layers`` should ever be set on board 06 (added to #3413's scope as a comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
