### PR TITLE
test(router): fix TestEarlyTermination MagicMock > int flake (closes #3407)

### DIFF
--- a/tests/test_layer_escalation.py
+++ b/tests/test_layer_escalation.py
@@ -859,6 +859,14 @@ class TestEarlyTermination:
         router.rules.min_drill_clearance = 0.0
         router.rules.trace_width = 0.2
         router.rules.trace_clearance = 0.15
+        # Issue #3407: router/io.py:2256 compares router._edge_clearance > 0 --
+        # so MagicMock's default sentinel must be replaced with None to avoid
+        # ``TypeError: '>' not supported between instances of 'MagicMock' and
+        # 'int'``.  Same for _edge_segments (truthiness check on the adjacent
+        # line).  Mirrors the pattern in TestStartingLayersEndToEnd (PR #3405)
+        # and TestRegressionEarlyExit.
+        router._edge_clearance = None
+        router._edge_segments = None
         return router
 
     def _make_args(self, **overrides):


### PR DESCRIPTION
## Summary

Closes #3407.

The 12 ``TestEarlyTermination`` tests in ``tests/test_layer_escalation.py``
were failing with ``TypeError: '>' not supported between instances of
'MagicMock' and 'int'`` at ``router/io.py:2256`` because the helper
``_make_mock_router`` did not set ``_edge_clearance`` / ``_edge_segments``
on the mock router. ``router/io.py`` reads those attributes during the
edge-keepout violation emission added in Issue #2743 and compares the
clearance against ``0``; ``MagicMock``'s default auto-attribute sentinel
satisfies ``getattr(..., None) is not None`` and then trips the
type-mismatch comparison.

## Fix

Apply the same defensive pattern that PR #3405 used in
``TestStartingLayersEndToEnd`` (and that ``TestRegressionEarlyExit``
already uses): set both attributes to ``None`` so the early-termination
short-circuit (``edge_clearance is not None and edge_clearance > 0``)
evaluates cleanly and the mock skips that code branch -- which is what
these tests want, since they exercise the escalation-loop heuristics
(zero-overflow short-circuit, stagnation, regression early-exit,
completion floor), not the edge-violation emitter.

Diff is 8 lines: two attribute assignments plus a comment block in
``TestEarlyTermination._make_mock_router``.

## Verification

- ``pytest tests/test_layer_escalation.py::TestEarlyTermination`` -> 12 passed
- Ran 3 consecutive times -> deterministic 12/12 every time
- Full ``tests/test_layer_escalation.py`` -> 91 passed
- Coverage preserved: tests still drive the escalation loop through the
  same ``route_with_layer_escalation`` paths; only the unrelated edge-
  keepout emitter is skipped (as intended by the mock).

## Test plan

- [x] All 8 affected ``TestEarlyTermination`` tests pass (actually 12 in
      the class; 10 hit the mock router, 2 are pure dataclass tests)
- [x] Full ``tests/test_layer_escalation.py`` remains green (91/91)
- [x] Three deterministic runs (no flake)
- [x] Mocks still exercise early-termination paths (zero-overflow,
      stagnation, monte-carlo / basic exemption, completion floor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)