### PR TITLE
investigation(boards/06): root-cause for 41% reach (refs #3413; fix tracked in #3419)

### DIFF
--- a/tests/test_escape.py
+++ b/tests/test_escape.py
@@ -512,6 +512,84 @@ class TestUSBCBGAMisclassification:
         assert len(pads) == 22
         assert detect_package_type(pads) != PackageType.BGA
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Issue #3413: odd-dimension BGA grids (e.g. 7x7 BGA-49) have a "
+            "full row AND a full column directly on the package center "
+            "axes. ``_is_grid_pattern``'s strict ``if/elif/else`` quadrant "
+            "cascade lumps every axis pad into the ``else`` branch, "
+            "producing a 9/9/9/22 distribution for a perfectly symmetric "
+            "7x7 grid and failing the [0.3, 1.7] x avg balance check. "
+            "That misclassifies board 06's USB3 SS BGA-49 sink as "
+            "``PackageType.UNKNOWN`` and routes it through the radial-"
+            "escape fallback. A naive fix (distribute axis pads across "
+            "the two adjacent quadrants) makes detection pass AND fires "
+            "the diff-pair-aware paired escape pre-pass on this BGA, but "
+            "the resulting paired-escape geometry (tight 0.10mm intra-"
+            "pair lateral offset at the BGA edge, escape direction "
+            "perpendicular to the pair axis) drops the per-net A* "
+            "routing reach on board 06 from 41% (the documented baseline) "
+            "to ~27% because the per-net A* times out (30s default) "
+            "trying to leave the tight escape endpoints. The detection "
+            "fix needs to land alongside an escape-strategy refinement "
+            "for sparse-signal BGAs (paired escape direction toward the "
+            "partner connector, not outward from package center). "
+            "Tracked under #3419 (follow-up to #3413)."
+        ),
+    )
+    def test_odd_dimension_7x7_bga_detected(self):
+        """7x7 BGA (49 pads, odd grid) should be detected as BGA (Issue #3413).
+
+        REGRESSION TEST DOCUMENTING THE BUG.  See the ``xfail`` reason
+        above for the full root-cause analysis and why a naive
+        ``_is_grid_pattern`` fix is not safe to land on its own.
+
+        Board 06's BGA-49 USB3 SuperSpeed sink is a 7x7 grid at 1.27 mm
+        pitch.  The router currently misclassifies it as
+        ``PackageType.UNKNOWN`` and dispatches the 8 USB3 SS signal pads
+        through ``_escape_radial`` -- a simple per-pin surface escape
+        that happens to produce the 41% reach this issue captures.  When
+        the BGA detector is corrected in isolation, the paired-escape
+        pre-pass (gated on ``PackageType.BGA``) fires on the USB3 pairs,
+        produces tightly-coupled escape endpoints at the BGA edge, and
+        the per-net A* main router times out searching from those
+        endpoints.  Reach drops to ~27%.
+
+        Two-phase fix needed (tracked separately):
+          1. ``_is_grid_pattern``: distribute axis pads across the two
+             adjacent quadrants when checking the balance heuristic.
+          2. ``_escape_diff_pair_segment`` / ``_generate_paired_escapes``:
+             choose the launch direction based on partner-connector
+             proximity (e.g., consult ``net_class_map`` / the diff-pair
+             partner's package location) rather than outward from
+             package center.
+        """
+        pads = create_bga_pads(7, 7, pitch=1.27)
+        assert len(pads) == 49
+        assert detect_package_type(pads) == PackageType.BGA
+
+    def test_odd_dimension_9x9_bga_still_detected(self):
+        """9x9 BGA (81 pads, odd grid) IS detected correctly today (Issue #3413).
+
+        Sibling case for Issue #3413: confirms that the
+        ``_is_grid_pattern`` quadrant-balance bug only fires below a
+        critical grid size.  For 9x9 the quadrant counts come out
+        16/16/16/33 against avg 20.25 (range [6.1, 34.4]) so the
+        unbalanced 33 squeaks under the upper threshold and the BGA
+        path is still selected.  For 7x7 the counts are 9/9/9/22
+        against avg 12.25 (range [3.7, 20.8]) and the 22 exceeds the
+        upper threshold, triggering the bug (see the xfail-marked 7x7
+        test above).  The 7x7 case is the odd-dim threshold board 06
+        exercises.
+
+        Once the underlying ``_is_grid_pattern`` fix lands, this test
+        continues to pass -- the fix is upward compatible.
+        """
+        pads = create_bga_pads(9, 9, pitch=0.8)
+        assert len(pads) == 81
+        assert detect_package_type(pads) == PackageType.BGA
+
 
 class TestDetectPackageType:
     """Tests for detect_package_type function."""


### PR DESCRIPTION
## Summary

Investigation under #3413 (board 06 production routing 41 -> 100%) identified the root-cause blocking diff-pair routing on the BGA-49 USB3 SuperSpeed sink, but the full fix requires a paired-escape direction heuristic that exceeds the scope of a single-issue PR.  This PR documents the BGA detection bug as an ``xfail(strict=True)`` regression test, files the full fix as #3419, and surfaces the routing-reach gap status.

**Current state**: board 06 stays at 41% reach (9/22 nets routed) under the existing committed routed PCB.  The DRC allowlist remains at 21 (unchanged).

## Root cause

``detect_package_type`` misclassifies the 7x7 BGA-49 USB3 sink (board 06's ``U2``) as ``PackageType.UNKNOWN``.  ``_is_grid_pattern`` (escape.py:662) uses a strict ``if/elif/else`` quadrant-balance cascade that lumps every pad lying directly on a center axis into the ``else`` branch, producing a 9/9/9/22 distribution for an otherwise perfectly symmetric 7x7 grid.  With avg=12.25 / threshold 20.8 the unbalanced ``quadrants[3]=22`` fails the BGA check.

Down-stream consequence: the BGA is dispatched through ``_escape_radial`` instead of ``_escape_bga_rings``, and -- critically -- the diff-pair-aware paired escape pre-pass (gated on ``PackageType.BGA``, escape.py:1313) does NOT engage on the USB3 SS pairs.  All 4 USB3 lanes (TX1, RX1, TX2, RX2) escape as per-pin radial segments, and the per-net A* main router gets stuck routing them back to J1 with no coupling.

## Why the detection fix is NOT in this PR

A naive ``_is_grid_pattern`` fix (distribute axis pads across the two adjacent quadrants, +0.5 each) does correct the detection -- BUT it regresses board 06's routing reach from 41% to ~27% because the diff-pair-aware paired escape pre-pass then fires and produces tightly-coupled escape endpoints (0.10mm intra-pair lateral offset at the BGA edge) that the per-net A* main router times out (30s default) trying to leave.

Two simultaneous fixes needed (tracked under #3419):

1. ``_is_grid_pattern``: distribute axis pads across the two adjacent quadrants.
2. ``_escape_diff_pair_segment`` / ``_generate_paired_escapes``: choose launch direction based on partner-connector proximity, not outward from package center.  For sparse-signal BGAs (≤8 signal pads), consider skipping the paired-escape pre-pass entirely.
3. ``_escape_bga_rings``: add a ``pad.net == 0`` filter (currently missing) -- mirrors ``_escape_qfp_alternating`` line 2385.  Without this, every GND/+1V2/+3V3 pad gets a wasteful escape segment.

## What this PR lands

- ``tests/test_escape.py::TestUSBCBGAMisclassification::test_odd_dimension_7x7_bga_detected`` — xfail-marked regression test that reproduces board 06's exact BGA-49 geometry (7x7 at 1.27mm pitch) and documents the bug with a full root-cause analysis in the xfail reason.
- ``test_odd_dimension_9x9_bga_still_detected`` — companion case proving the bug only fires below a critical grid size: 9x9 squeaks under the upper threshold (16/16/16/33 vs avg 20.25 / range [6.1, 34.4]) so larger odd grids still route as BGA.

## Investigation artifacts (not committed)

- ``_is_grid_pattern`` fix tried locally: U2 then correctly detects as BGA, paired escape pre-pass engages on the 4 USB3 pairs (8 escapes total), but per-net A* timeouts at 30s/net produce 4L SIG-GND-PWR-SIG attempt 1 = 6/22 (27%) -- worse than the 9/22 (41%) baseline.
- ``_escape_bga_rings`` plane-filter fix tried locally: filters the 40 plane-net pads from ring generation so they don't consume perimeter channels.  Composes cleanly with the detection fix but doesn't lift the per-net-A* timeout regression on its own.

## Allowlist status

The ``.github/routed-drc-tolerance.yml`` entry for board 06 stays at 21 (unchanged).  This PR does NOT lower it -- the 41 -> 100% reach gap is not closed.  Tightening the allowlist further requires the #3419 fix landing first.

## Test plan

- [x] ``tests/test_escape.py`` 114 passed, 1 xfailed (the documented 7x7 detection bug)
- [x] No regression on existing tests
- [x] ``check_diffpair_coverage.py`` re-route still produces the historical reach (no change to committed artifact or allowlist)

## Related

- Parent: #3413 (board 06 production routing reach gap)
- Follow-up: #3419 (BGA detection + paired-escape direction refinement; the actual fix)
- Adjacent: Epic #2556 Phase 2F (paired escape coupling), #2639 (CoupledPathfinder), #2677 (corridor reservation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)