### PR TITLE
fix(ci): board 06 diff-pair regression gate — bisect + fix (closes #3421)

### DIFF
--- a/src/kicad_tools/router/fine_pitch_escape.py
+++ b/src/kicad_tools/router/fine_pitch_escape.py
@@ -793,14 +793,28 @@ def resolve_clearance_with_escape_region(
                 # ``get_clearance_for_component`` so the validator
                 # rejects through-channel routes the same way the grid
                 # halo does.
-                pitch_for_guard = pin_pitch
-                if pitch_for_guard is None:
-                    pitch_for_guard = region.pin_pitch
-                if pitch_for_guard is not None:
+                #
+                # Guard pitches (Issue #3421): the feasibility check must
+                # hold for BOTH the region's *package* pitch AND the
+                # call-side pad's own component pitch (when known).  The
+                # escape shrink exists to thread the fine-pitch package's
+                # own corridors; when those corridors stay infeasible
+                # even at the candidate clearance, the region cannot
+                # serve its purpose, so loosening clearance on any
+                # in-halo pad (own or foreign) is pure routing
+                # perturbation.  Pre-#3421 the guard consulted only the
+                # call-side pitch, so a foreign pad (e.g. a 0.96mm-pitch
+                # passive inside a BGA's 5mm halo) picked up the 0.14mm
+                # escape clearance even though the BGA corridor it would
+                # serve was infeasible at that clearance (board 06
+                # re-route DRC regression, 13 -> 32 errors).
+                required_channel = 2.0 * candidate + rules.trace_width
+                for pitch_for_guard in (region.pin_pitch, pin_pitch):
+                    if not pitch_for_guard:
+                        continue
                     effective_channel = (
                         pitch_for_guard - 2.0 * candidate - rules.trace_width
                     )
-                    required_channel = 2.0 * candidate + rules.trace_width
                     if effective_channel < required_channel:
                         # Channel too narrow at candidate clearance --
                         # decline the shrink for this in-region pad.

--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -1289,59 +1289,84 @@ class RoutingGrid:
         # the shrunk halo would let A* commit to traces that DRC
         # rejects (the same pathology PR #2866 fixed for the global
         # ``fine_pitch_clearance`` path).  We decline the shrink and
-        # fall through to the standard halo so the pathfinder routes
-        # around the package instead of through-channel.
+        # fall through to the LEGACY fine-pitch shrink logic below (NOT
+        # straight to the standard halo) so pre-#3371 behaviour is
+        # preserved for boards whose recipe already used the
+        # ``min_trace_width`` shrink (Issue #3421: board 06's 0.8mm
+        # BGA/QFN pads carried a 0.05mm legacy halo pre-P_FP3; the
+        # region branch hard-returning ``standard`` inflated those
+        # halos 4.5x and regressed the board's re-route DRC 13 -> 32).
+        #
+        # Guard pitches (Issue #3421): the corridor-feasibility check
+        # must hold for BOTH
+        #   (a) the applying region's *package* pitch -- the escape
+        #       shrink exists to thread the fine-pitch package's own
+        #       corridors; when those corridors stay infeasible even at
+        #       the escape clearance, the region cannot serve its
+        #       purpose and shrinking any pad (own or foreign) only
+        #       perturbs routing; AND
+        #   (b) the call-side pad's own component pitch (when known) --
+        #       a fine-pitch pad inside a *neighbouring* package's halo
+        #       must not have its own inter-pad corridor opened by the
+        #       neighbour's region.
+        # Pre-#3421 the guard only consulted the call-side pitch, so a
+        # foreign pad (e.g. a 0.96mm-pitch passive inside a BGA's 5mm
+        # halo) picked up the escape shrink even though the BGA corridor
+        # the shrink serves was infeasible at the escape clearance.
         if pad is not None and self._fine_pitch_regions:
             region_clearance = self._region_clearance_for_pad(pad)
             if region_clearance is not None:
-                # Compute pin pitch from the region directly (the region
-                # carries the package's pitch).  This is more reliable
-                # than the call-side ``pin_pitch`` argument, which can
-                # be ``None`` for callers that did not look it up.
-                region_pin_pitch = pin_pitch
-                if region_pin_pitch is None:
-                    for region in self._fine_pitch_regions:
-                        if region.applies_to_pad(pad):
-                            region_pin_pitch = region.pin_pitch
-                            break
+                # The applying region's package pitch (the region
+                # carries the package's pitch).  This is the pitch the
+                # escape shrink is FOR; the call-side ``pin_pitch``
+                # describes the pad's own component which may differ
+                # for foreign in-halo pads.
+                region_pin_pitch: float | None = None
+                for region in self._fine_pitch_regions:
+                    if region.applies_to_pad(pad):
+                        region_pin_pitch = region.pin_pitch
+                        break
 
-                if region_pin_pitch is not None:
+                required_channel = 2.0 * region_clearance + self.rules.trace_width
+                channel_ok = True
+                for guard_pitch in (region_pin_pitch, pin_pitch):
+                    if not guard_pitch:
+                        continue
                     effective_channel = (
-                        region_pin_pitch
-                        - 2.0 * region_clearance
-                        - self.rules.trace_width
-                    )
-                    required_channel = (
-                        2.0 * region_clearance + self.rules.trace_width
+                        guard_pitch - 2.0 * region_clearance - self.rules.trace_width
                     )
                     if effective_channel < required_channel:
                         # Channel too narrow for the escape clearance --
-                        # decline the shrink so the pathfinder routes
-                        # around the package via the escape mechanism.
-                        return standard
+                        # decline the shrink.  Fall THROUGH to the legacy
+                        # min_trace_width shrink below (pre-#3371
+                        # behaviour) instead of returning the standard
+                        # halo here.
+                        channel_ok = False
+                        break
 
-                # Halo is region clearance + trace half-width, mirroring
-                # the standard-halo formulation.
-                escape_halo = region_clearance + self.rules.trace_width / 2
+                if channel_ok:
+                    # Halo is region clearance + trace half-width,
+                    # mirroring the standard-halo formulation.
+                    escape_halo = region_clearance + self.rules.trace_width / 2
 
-                # Compose with the existing fine-pitch shrink: when both
-                # apply, take the smaller (more permissive) halo so the
-                # corridor opens up for the pathfinder.  Either halo is
-                # later validated by post-route DRC against the
-                # manufacturer floor.
-                if (
-                    pin_pitch is not None
-                    and pin_pitch < self.rules.fine_pitch_threshold
-                    and self.rules.min_trace_width is not None
-                ):
-                    shrunk = self.rules.min_trace_width / 2
-                    eff_legacy = pin_pitch - 2.0 * shrunk - self.rules.trace_width
-                    req_legacy = (
-                        2.0 * self.rules.trace_clearance + self.rules.trace_width
-                    )
-                    if eff_legacy >= req_legacy:
-                        return min(escape_halo, shrunk)
-                return escape_halo
+                    # Compose with the existing fine-pitch shrink: when
+                    # both apply, take the smaller (more permissive) halo
+                    # so the corridor opens up for the pathfinder.
+                    # Either halo is later validated by post-route DRC
+                    # against the manufacturer floor.
+                    if (
+                        pin_pitch is not None
+                        and pin_pitch < self.rules.fine_pitch_threshold
+                        and self.rules.min_trace_width is not None
+                    ):
+                        shrunk = self.rules.min_trace_width / 2
+                        eff_legacy = pin_pitch - 2.0 * shrunk - self.rules.trace_width
+                        req_legacy = (
+                            2.0 * self.rules.trace_clearance + self.rules.trace_width
+                        )
+                        if eff_legacy >= req_legacy:
+                            return min(escape_halo, shrunk)
+                    return escape_halo
 
         if (
             pin_pitch is not None

--- a/tests/test_fine_pitch_integration.py
+++ b/tests/test_fine_pitch_integration.py
@@ -517,5 +517,138 @@ class TestLoadPcbIntegration:
             )
 
 
+class TestInfeasibleRegionGuard:
+    """Issue #3421 -- regions whose package corridor stays infeasible at the
+    escape clearance must be inert, and the guard's decline must fall through
+    to the legacy ``min_trace_width`` shrink (pre-P_FP3 behaviour).
+
+    Regression context: board 06 (diffpair-test) routes at trace_width=0.15 /
+    trace_clearance=0.15 / min_trace_width=0.10 with five 0.8mm-pitch
+    packages (BGA-49, QFN-32 etc.).  At the jlcpcb escape clearance (0.14)
+    those corridors remain infeasible (0.8 - 2*0.14 - 0.15 = 0.37 < 0.43
+    required), so the regions cannot serve their purpose.  Pre-fix, the
+    P_FP3 region branch (a) hard-returned the STANDARD halo on guard
+    decline, clobbering the 0.05mm legacy halo the packages' own pads had
+    pre-P_FP3 (a 4.5x halo inflation), and (b) evaluated the guard against
+    the foreign pad's own pitch, so in-halo neighbours picked up the 0.14
+    escape clearance the region could never use.  Net effect: the board 06
+    seed-42 re-route regressed from 13 to 32 DRC errors (CI gate failure,
+    Issue #3421).
+    """
+
+    def _board06_like_setup(self) -> tuple[RoutingGrid, FinePitchRegion, DesignRules]:
+        rules = DesignRules(
+            grid_resolution=0.05,
+            trace_width=0.15,
+            trace_clearance=0.15,
+            manufacturer="jlcpcb",
+            min_trace_width=0.10,
+        )
+        grid = RoutingGrid(
+            width=50.0, height=50.0, rules=rules, layer_stack=LayerStack.two_layer()
+        )
+        # QFN/BGA-style region: 0.8mm pitch, escape clearance 0.14.
+        # Corridor at escape clearance: 0.8 - 0.28 - 0.15 = 0.37 < 0.43
+        # required -> guard must decline for EVERY pad this region covers.
+        region = FinePitchRegion(
+            package_ref="U3",
+            package_origin=(25.0, 25.0),
+            radius_mm=7.07,
+            pin_pitch=0.8,
+            pad_size_along_pitch=0.3,
+            escape_clearance=0.14,
+            pad_refs=frozenset([("U3", "1")]),
+        )
+        grid.set_fine_pitch_regions([region])
+        return grid, region, rules
+
+    def test_own_pad_decline_falls_through_to_legacy_shrink(self) -> None:
+        """Guard decline must yield the legacy min_trace_width halo, not the
+        standard halo (the pre-P_FP3 value for board 06's 0.8mm pads)."""
+        grid, _, rules = self._board06_like_setup()
+        own_pad = Pad(
+            x=25.0, y=25.0, width=0.3, height=0.3,
+            net=1, net_name="SIG", layer=Layer.F_CU, ref="U3", pin="1",
+        )
+        halo = grid._clearance_for_pin_pitch(pin_pitch=0.8, pad=own_pad)
+        # Legacy shrink: min_trace_width / 2 = 0.05 (its own #2865 guard
+        # passes: 0.8 - 0.10 - 0.15 = 0.55 >= 0.45 required).
+        assert halo == pytest.approx(0.05), (
+            f"Guard decline must fall through to the legacy shrink (0.05), "
+            f"got {halo} (standard would be 0.225 -- the Issue #3421 bug)"
+        )
+
+    def test_foreign_pad_guard_uses_region_pitch(self) -> None:
+        """A foreign pad in the halo whose OWN pitch passes the guard must
+        still be declined when the region's package pitch is infeasible."""
+        grid, _, rules = self._board06_like_setup()
+        # 0402-style passive 2mm from the package origin; its own pitch
+        # (0.96) would pass the guard (0.96 - 0.28 - 0.15 = 0.53 >= 0.43)
+        # but the region's package pitch (0.8) must dominate.
+        foreign_pad = Pad(
+            x=27.0, y=25.0, width=0.5, height=0.5,
+            net=2, net_name="SIG2", layer=Layer.F_CU, ref="C7", pin="1",
+        )
+        halo = grid._clearance_for_pin_pitch(pin_pitch=0.96, pad=foreign_pad)
+        # Pre-P_FP3 value for this pad: legacy shrink (0.96 pitch passes
+        # the legacy #2865 guard) = 0.05.  The escape halo would be 0.215.
+        assert halo == pytest.approx(0.05), (
+            f"Foreign in-halo pad must not pick up the escape halo when the "
+            f"region's package corridor is infeasible; got {halo}"
+        )
+
+    def test_resolver_declines_for_all_in_region_pads(self) -> None:
+        """The C++ validator clearance source must return the standard
+        clearance for every pad covered by an infeasible region."""
+        grid, region, rules = self._board06_like_setup()
+        own_pad = Pad(
+            x=25.0, y=25.0, width=0.3, height=0.3,
+            net=1, net_name="SIG", layer=Layer.F_CU, ref="U3", pin="1",
+        )
+        foreign_pad = Pad(
+            x=27.0, y=25.0, width=0.5, height=0.5,
+            net=2, net_name="SIG2", layer=Layer.F_CU, ref="C7", pin="1",
+        )
+        for pad, pitch in ((own_pad, 0.8), (foreign_pad, 0.96), (foreign_pad, 2.54)):
+            clearance = resolve_clearance_with_escape_region(
+                rules, pad, net_class=None, regions=[region], pin_pitch=pitch
+            )
+            assert clearance == pytest.approx(rules.trace_clearance), (
+                f"Resolver must decline the 0.14 escape clearance for "
+                f"{pad.ref} (pitch={pitch}); got {clearance}"
+            )
+
+    def test_feasible_region_still_shrinks(self) -> None:
+        """Control: a SOIC-style region whose corridor IS feasible at the
+        escape clearance keeps the escape shrink (softstart behaviour)."""
+        rules = DesignRules(
+            trace_width=0.30, trace_clearance=0.20, manufacturer="jlcpcb-tier1"
+        )
+        grid = RoutingGrid(
+            width=50.0, height=50.0, rules=rules, layer_stack=LayerStack.two_layer()
+        )
+        region = FinePitchRegion(
+            package_ref="U5",
+            package_origin=(25.0, 25.0),
+            radius_mm=5.0,
+            pin_pitch=1.27,
+            pad_size_along_pitch=0.3,
+            escape_clearance=0.14,
+            pad_refs=frozenset([("U5", "1")]),
+        )
+        grid.set_fine_pitch_regions([region])
+        own_pad = Pad(
+            x=25.0, y=25.0, width=0.3, height=1.55,
+            net=1, net_name="N1", layer=Layer.F_CU, ref="U5", pin="1",
+        )
+        # 1.27 - 0.28 - 0.30 = 0.69 >= 0.58 required -> shrink applies.
+        halo = grid._clearance_for_pin_pitch(pin_pitch=1.27, pad=own_pad)
+        assert halo == pytest.approx(0.14 + rules.trace_width / 2)
+        clearance = resolve_clearance_with_escape_region(
+            rules, own_pad, net_class=None, regions=[region], pin_pitch=1.27
+        )
+        assert clearance == pytest.approx(0.14)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "--no-cov"])


### PR DESCRIPTION
## Summary

Fixes the board 06 `Diff-Pair Routing Regression` CI gate that has been red on main itself since 2026-06-09 00:21Z (re-route DRC 32 > allowlist 21), turning every PR's board-06 check red regardless of content.

Closes #3421

### Bisect result

No local bisect was needed — CI run history isolates the regression to a **single commit**:

| run | head SHA | diff-pair job | DRC count |
|---|---|---|---|
| 27165130514 (last green) | `c1a4d549` (P_FP2, #3374) | pass | **13** |
| 27175601138 (first red) | `2999e847` (P_FP3, #3375) | **fail** (only failing job) | **32** |

**Culprit: PR #3375 — `feat(router): fine-pitch escape autorouter integration (P_FP3)` (commit `2999e847`).** This matches the judges' earlier trace. The #3203 / #3193 candidates named in the issue are exonerated (both merged well before the green run at `c1a4d549`).

### Classification: real routing-quality regression (no allowlist change)

P_FP3 wired the fine-pitch escape region detector into `load_pcb_for_routing`. On board 06 it detects 5 regions (J3, J4, U1, U3, U4 — all 0.8mm pitch, escape clearance 0.14mm). At board 06's recipe (0.15 trace / 0.15 clearance) these packages' corridors are **infeasible even at the escape clearance** (0.8 − 2·0.14 − 0.15 = 0.37mm < 0.43mm required), so the regions can never serve their purpose — but they still perturbed routing through two defects:

1. **Guard decline clobbered the legacy shrink** — `RoutingGrid._clearance_for_pin_pitch`'s region branch hard-returned the *standard* halo (0.225mm) when the narrow-channel guard declined, skipping the legacy `min_trace_width` shrink (0.05mm) those pads carried pre-P_FP3. A 4.5x halo inflation on every pad of the five packages. Fixed: decline now **falls through** to the legacy shrink path.

2. **Guard evaluated the wrong pitch for foreign pads** — the feasibility check used the call-side pad's own component pitch, so a 0.96mm-pitch passive inside a BGA's 5mm halo picked up the 0.14 escape clearance even though the BGA corridor it would serve is infeasible. Fixed: the guard (grid halo + `resolve_clearance_with_escape_region`) now requires feasibility for **both** the region's package pitch and the call-side pitch. Strictly more conservative; infeasible regions become fully inert.

The `EscapeRouter` consumer (P_FP4/5/6) already guarded on the region's own pitch — unchanged.

`.github/routed-drc-tolerance.yml` stays at 21 — the new routing profile was a quality regression, not an acceptable trade (no reach change: 19/21 before and after).

### Verification

Local A/B, same hardware, `--seed 42` + `PYTHONHASHSEED=42` (local counts are platform-shifted vs CI's 13/32, so relative comparison is the test):

| tree | local DRC count | gate |
|---|---|---|
| HEAD (main) | 75 | FAIL |
| `c1a4d549` (last green, temp worktree) | 5 | PASS |
| HEAD + this fix | **5** | **PASS** |

The HEAD+fix re-routed PCB is **byte-identical** to the `c1a4d549` re-route after UUID stripping — the fix restores pre-regression routing exactly. Rule coverage also matches the green profile (`diffpair_length_skew: 18` vs the red runs' 17).

### Blast radius

- **Board 07 (matchgroup gate, also re-routes every PR)**: its 4 detected regions (U1/U2/U3/U5, all 0.8mm pitch) are also infeasible → become inert → reverts to pre-#3375 re-route behaviour, which was green.
- **Softstart (P_FP3's target board)**: SOIC regions at 1.27mm pitch are feasible (0.69 ≥ 0.58) → escape shrink preserved (covered by the new control test).
- **Tests**: 4 new regression tests in `tests/test_fine_pitch_integration.py::TestInfeasibleRegionGuard`. All fine-pitch suites pass (`test_fine_pitch_integration/detector/escape/ssop/p_fp4/p_fp5/p_fp6`, `test_grid_narrow_channel_guard`, `test_grid_cpp_parity`, `test_neck_down`, `test_component_clearance`, `test_cpp_clearance_enforcement`, `test_cpp_pathfinder_own_net_obstacle`): 249 passed. Two failures in `test_fine_pitch_clearance.py` are **pre-existing on main** (verified on a clean main checkout).
- **Coordination with #3419** (odd-dim BGA detection in `escape.py`): no file overlap — this PR touches `grid.py` + `fine_pitch_escape.py` clearance resolution; #3419 touches `escape.py` detection/launch. If #3419 changes board 06's escape behaviour the gates re-measure independently.

### Test plan
- [x] Local re-route gate passes (5 ≤ 21) with fix; matches last-green baseline exactly
- [x] New regression tests pass
- [x] Fine-pitch + clearance + parity suites pass (pre-existing failures documented)
- [ ] CI `Diff-Pair Routing Regression (boards/06-diffpair-test)` green on this PR
- [ ] CI `Match-Group Routing Regression (boards/07-matchgroup-test)` green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)