### PR TITLE
fix(router): BGA odd-grid detection + paired-escape coordination (refs #3413, closes #3419)

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -10961,6 +10961,14 @@ class Autorouter:
     def _escape(self) -> EscapeRouter:
         """Lazy-initialize escape router."""
         if self._escape_router is None:
+            # Issue #3419: board-wide net -> pad positions map so the
+            # paired-escape pre-pass can aim the launch direction toward
+            # the partner connector (off-package endpoints) instead of
+            # blindly outward from the package center.
+            net_pad_positions: dict[str, list[tuple[float, float]]] = {}
+            for pad in self.pads.values():
+                if pad.net_name:
+                    net_pad_positions.setdefault(pad.net_name, []).append((pad.x, pad.y))
             self._escape_router = EscapeRouter(
                 self.grid, self.rules, net_class_map=self.net_class_map,
                 edge_clearance=self._edge_clearance,
@@ -10972,6 +10980,7 @@ class Autorouter:
                 # ``get_diff_pair_map`` returns {} when no pairs are
                 # detected, which preserves pre-#2639 behavior bit-for-bit.
                 diff_pair_map=self.get_diff_pair_map(),
+                net_pad_positions=net_pad_positions,
             )
         return self._escape_router
 

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -781,6 +781,20 @@ class Autorouter:
         self._escape_router: EscapeRouter | None = None
         self._subgrid_router: SubGridRouter | None = None
 
+        # Issue #3419: gate for the diff-pair paired-escape pre-pass.
+        # The pre-pass emits two tightly-coupled escape endpoints (at the
+        # intra-pair clearance) that are only routable by a COUPLED
+        # consumer (``route_all_with_diffpairs`` -> CoupledPathfinder).
+        # When the board is routed per-net (plain ``route_all`` /
+        # ``route_all_negotiated`` without --differential-pairs), each
+        # half's A* start point sits inside the partner trace's clearance
+        # envelope and the search strands (30s/net timeouts -- the 41% ->
+        # 27% reach regression on board 06 documented in #3419).  The
+        # flag is flipped on by ``route_all_with_diffpairs`` before the
+        # escape phase; ``_escape`` consults it to decide whether to
+        # thread the diff_pair_map into the EscapeRouter.
+        self.paired_escape_coupling: bool = False
+
         # Issue #2838 (closes #2761 gap): Lazy-initialized via conflict
         # manager.  Wired into the single-ended PIN_ACCESS retry path in
         # ``route_net`` so vias from already-routed nets that sit within
@@ -10600,6 +10614,25 @@ class Autorouter:
                 ``diffpair_routing.py``).  When ``None`` (default) the
                 legacy unbounded behaviour is preserved for back-compat.
         """
+        # Issue #3419: enable the paired-escape pre-pass for this run.
+        # ``route_all_with_diffpairs`` routes pairs through the
+        # CoupledPathfinder which is the intended consumer of the
+        # tightly-coupled escape endpoints the pre-pass emits.  The flag
+        # must be set BEFORE the escape phase runs (escapes are generated
+        # lazily inside the delegated strategies).  If the escape router
+        # was already created by an earlier per-net phase (flag off), its
+        # map is refreshed in place so this run still gets paired escapes.
+        # ``getattr`` guards: some unit tests construct partially
+        # initialised Autorouter doubles (``__new__`` without
+        # ``__init__``); the flag flip must not crash on them.
+        self.paired_escape_coupling = bool(
+            diffpair_config is not None and diffpair_config.enabled
+        )
+        if getattr(self, "_escape_router", None) is not None:
+            self._escape_router.diff_pair_map = (
+                self.get_diff_pair_map() if self.paired_escape_coupling else {}
+            )
+
         # Issue #3321: derive a per-pair budget from --timeout when the
         # caller has not explicitly configured one.  This protects the
         # CoupledPathfinder from running unbounded just because the CLI's
@@ -10979,7 +11012,17 @@ class Autorouter:
                 # dense packages get coupled-at-launch escape routes.
                 # ``get_diff_pair_map`` returns {} when no pairs are
                 # detected, which preserves pre-#2639 behavior bit-for-bit.
-                diff_pair_map=self.get_diff_pair_map(),
+                #
+                # Issue #3419: only thread the map when a coupled consumer
+                # exists (``route_all_with_diffpairs`` flips
+                # ``paired_escape_coupling`` on before the escape phase).
+                # Paired escape endpoints sit at the intra-pair clearance
+                # and are unroutable by the plain per-net A* -- threading
+                # the map unconditionally regressed board 06 from 41% to
+                # 27% reach once the BGA-49 detection fix landed.
+                diff_pair_map=(
+                    self.get_diff_pair_map() if self.paired_escape_coupling else {}
+                ),
                 net_pad_positions=net_pad_positions,
             )
         return self._escape_router

--- a/src/kicad_tools/router/escape.py
+++ b/src/kicad_tools/router/escape.py
@@ -718,10 +718,50 @@ def _is_grid_pattern(pads: list[Pad], center_x: float, center_y: float) -> bool:
     if len(interior_pads) < len(pads) * 0.1:
         return False
 
-    # Count pads in each quadrant relative to center
-    quadrants = [0, 0, 0, 0]
+    # Count pads in each quadrant relative to center.
+    #
+    # Issue #3419: odd-dimension grids (7x7 BGA-49, etc.) have a full row
+    # AND a full column lying exactly ON the center axes.  The previous
+    # strict ``if/elif/else`` cascade lumped every axis pad into the last
+    # quadrant, producing a 9/9/9/22 distribution for a perfectly
+    # symmetric 7x7 grid and failing the balance check below (avg=12.25,
+    # upper bound 20.8 < 22).  Distribute axis pads fractionally across
+    # the adjacent quadrants instead:
+    #   - pad on a single axis: 0.5 to each of the two adjacent quadrants
+    #   - pad at the exact center (both axes): 0.25 to all four
+    #   - strictly in-quadrant pads: 1.0 as before
+    # Even grids have no axis pads, so their counts are unchanged
+    # (all-integer weights, identical to the pre-fix behaviour).
+    # Use a small epsilon so float jitter in pad coordinates does not
+    # spuriously classify near-axis pads as off-axis.
+    eps = 1e-6
+    quadrants = [0.0, 0.0, 0.0, 0.0]
     for p in pads:
-        if p.x > center_x and p.y > center_y:
+        on_x_axis = abs(p.y - center_y) <= eps  # lies on horizontal axis
+        on_y_axis = abs(p.x - center_x) <= eps  # lies on vertical axis
+        if on_x_axis and on_y_axis:
+            # Exact center pad: shared equally by all four quadrants.
+            for i in range(4):
+                quadrants[i] += 0.25
+        elif on_y_axis:
+            # On the vertical axis: split between the upper pair (q0/q1)
+            # or the lower pair (q2/q3) depending on the y side.
+            if p.y > center_y:
+                quadrants[0] += 0.5
+                quadrants[1] += 0.5
+            else:
+                quadrants[2] += 0.5
+                quadrants[3] += 0.5
+        elif on_x_axis:
+            # On the horizontal axis: split between the right pair
+            # (q0/q3) or the left pair (q1/q2) depending on the x side.
+            if p.x > center_x:
+                quadrants[0] += 0.5
+                quadrants[3] += 0.5
+            else:
+                quadrants[1] += 0.5
+                quadrants[2] += 0.5
+        elif p.x > center_x and p.y > center_y:
             quadrants[0] += 1
         elif p.x < center_x and p.y > center_y:
             quadrants[1] += 1
@@ -853,6 +893,7 @@ class EscapeRouter:
         board_bounds: tuple[float, float, float, float] | None = None,
         manufacturer: str | None = None,
         diff_pair_map: dict[str, str] | None = None,
+        net_pad_positions: dict[str, list[tuple[float, float]]] | None = None,
     ):
         """Initialize the escape router.
 
@@ -881,6 +922,16 @@ class EscapeRouter:
                 Pads whose partner is on a different package fall through to
                 the standard per-package escape pattern.  Defaults to ``None``
                 which preserves pre-#2639 single-ended behaviour exactly.
+            net_pad_positions: Optional board-wide map of net name to ALL pad
+                positions on that net (Issue #3419).  When provided, the
+                paired-escape pre-pass (``_escape_diff_pair_segment``) uses
+                the off-package endpoints of the pair's nets to pick a
+                launch direction TOWARD the partner connector instead of
+                blindly outward from the package center.  This keeps the
+                tightly-coupled escape endpoints facing the destination so
+                the main per-net A* does not have to fight its way around
+                the package from a tight launch.  Defaults to ``None``
+                which preserves the center-outward quadrant heuristic.
         """
         self.grid = grid
         self.rules = rules
@@ -896,6 +947,11 @@ class EscapeRouter:
         # ``_escape_diff_pair_segment`` instead of the per-package
         # dispatcher.  An empty / None map disables the feature.
         self.diff_pair_map: dict[str, str] = diff_pair_map or {}
+        # Issue #3419: board-wide net -> pad-position map for partner-
+        # connector-aware paired-escape launch direction.  Empty map
+        # disables the heuristic (falls back to center-outward quadrant
+        # direction).
+        self.net_pad_positions: dict[str, list[tuple[float, float]]] = net_pad_positions or {}
         # Instrumentation counter (Gate 3/4 of the #2587-style verification
         # chain): bumped every time ``_escape_diff_pair_segment`` is
         # invoked.  Tests assert this is non-zero on board 03 and zero
@@ -1531,6 +1587,101 @@ class EscapeRouter:
 
         return paired_escapes, paired_pad_keys
 
+    def _select_pair_launch_direction(
+        self,
+        pad_p: Pad,
+        pad_n: Pad,
+        mid_x: float,
+        mid_y: float,
+        package: PackageInfo,
+    ) -> EscapeDirection:
+        """Pick the launch direction for a paired diff-pair escape.
+
+        Issue #3419: the original heuristic launched the pair outward
+        from the package center (quadrant rule).  On board 06's BGA-49
+        that strands the tightly-coupled escape endpoints on whatever
+        side of the package the pads happen to sit -- when the partner
+        connector is elsewhere, the per-net A* has to drag the coupled
+        pair around the package perimeter from a 0.1 mm-lateral launch
+        and times out.  This helper instead aims the launch TOWARD the
+        pair's off-package endpoints (the partner connector), consulting
+        ``self.net_pad_positions`` (board-wide net -> pad positions map).
+
+        Falls back to the center-outward quadrant direction when:
+          - ``net_pad_positions`` was not provided (default behaviour),
+          - neither net has an off-package endpoint,
+          - the target direction is degenerate (zero-length vector).
+
+        Directions that would launch INTO the package interior (negative
+        dot product with the outward vector from package center to the
+        pair midpoint) are excluded so the escape never crosses the
+        package's own pad field on the surface layer.
+
+        Args:
+            pad_p: Positive-half pad
+            pad_n: Negative-half pad
+            mid_x: X of the pair midpoint
+            mid_y: Y of the pair midpoint
+            package: Package info for center and pad field
+
+        Returns:
+            Cardinal EscapeDirection for the paired launch.
+        """
+        center_x, center_y = package.center
+        fallback = self._get_quadrant_direction(mid_x, mid_y, center_x, center_y)
+        if not self.net_pad_positions:
+            return fallback
+
+        # Collect off-package endpoints for both halves of the pair.
+        # Position-keyed exclusion (not identity) because the board-wide
+        # map stores plain coordinate tuples, not Pad objects.
+        on_package = {(round(p.x, 3), round(p.y, 3)) for p in package.pads}
+        targets: list[tuple[float, float]] = []
+        for net_name in (pad_p.net_name, pad_n.net_name):
+            if not net_name:
+                continue
+            for x, y in self.net_pad_positions.get(net_name, ()):
+                if (round(x, 3), round(y, 3)) in on_package:
+                    continue
+                targets.append((x, y))
+        if not targets:
+            return fallback
+
+        tx = sum(t[0] for t in targets) / len(targets)
+        ty = sum(t[1] for t in targets) / len(targets)
+        vx = tx - mid_x
+        vy = ty - mid_y
+        norm = math.hypot(vx, vy)
+        if norm < 1e-6:
+            return fallback
+        vx /= norm
+        vy /= norm
+
+        # Outward vector (pair midpoint relative to package center):
+        # used to veto launch directions that would cross the package
+        # interior.
+        ox = mid_x - center_x
+        oy = mid_y - center_y
+
+        best_dir = fallback
+        best_score = -math.inf
+        for cand in (
+            EscapeDirection.NORTH,
+            EscapeDirection.SOUTH,
+            EscapeDirection.EAST,
+            EscapeDirection.WEST,
+        ):
+            cdx, cdy = self._direction_to_vector(cand)
+            if (cdx * ox + cdy * oy) < -1e-9:
+                # Points back through the package interior -- never
+                # launch a surface-layer pair into the pad field.
+                continue
+            score = cdx * vx + cdy * vy
+            if score > best_score:
+                best_score = score
+                best_dir = cand
+        return best_dir
+
     def _escape_diff_pair_segment(
         self,
         pad_p: Pad,
@@ -1573,9 +1724,11 @@ class EscapeRouter:
         # so both escapes leave together.
         mid_x = (pad_p.x + pad_n.x) / 2.0
         mid_y = (pad_p.y + pad_n.y) / 2.0
-        center_x, center_y = package.center
 
-        direction = self._get_quadrant_direction(mid_x, mid_y, center_x, center_y)
+        # Issue #3419: pick the launch direction toward the partner
+        # connector when board-wide net endpoints are available; fall
+        # back to the original center-outward quadrant heuristic.
+        direction = self._select_pair_launch_direction(pad_p, pad_n, mid_x, mid_y, package)
         dx, dy = self._direction_to_vector(direction)
 
         # Trace widths come from per-net config.  Use the wider of the
@@ -2109,8 +2262,15 @@ class EscapeRouter:
         escapes: list[EscapeRoute] = []
         center_x, center_y = package.center
 
+        # Issue #3419: Skip pads that belong to skipped/plane nets (net=0).
+        # Plane nets (GND, VCC, etc.) are stitched via planes, not routed
+        # via escapes.  Generating escapes for them wastes the BGA perimeter
+        # channel that the signal nets need -- mirrors the equivalent filter
+        # in ``_escape_qfp_alternating`` (Issue #2513).
+        routable_pads = [p for p in package.pads if p.net != 0]
+
         # Group pads by ring (distance from center)
-        rings = self._group_pads_by_ring(package.pads, center_x, center_y)
+        rings = self._group_pads_by_ring(routable_pads, center_x, center_y)
 
         for ring_idx, ring_pads in enumerate(rings):
             # Alternate layers: even rings on F.Cu, odd on B.Cu

--- a/tests/test_escape.py
+++ b/tests/test_escape.py
@@ -512,58 +512,18 @@ class TestUSBCBGAMisclassification:
         assert len(pads) == 22
         assert detect_package_type(pads) != PackageType.BGA
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Issue #3413: odd-dimension BGA grids (e.g. 7x7 BGA-49) have a "
-            "full row AND a full column directly on the package center "
-            "axes. ``_is_grid_pattern``'s strict ``if/elif/else`` quadrant "
-            "cascade lumps every axis pad into the ``else`` branch, "
-            "producing a 9/9/9/22 distribution for a perfectly symmetric "
-            "7x7 grid and failing the [0.3, 1.7] x avg balance check. "
-            "That misclassifies board 06's USB3 SS BGA-49 sink as "
-            "``PackageType.UNKNOWN`` and routes it through the radial-"
-            "escape fallback. A naive fix (distribute axis pads across "
-            "the two adjacent quadrants) makes detection pass AND fires "
-            "the diff-pair-aware paired escape pre-pass on this BGA, but "
-            "the resulting paired-escape geometry (tight 0.10mm intra-"
-            "pair lateral offset at the BGA edge, escape direction "
-            "perpendicular to the pair axis) drops the per-net A* "
-            "routing reach on board 06 from 41% (the documented baseline) "
-            "to ~27% because the per-net A* times out (30s default) "
-            "trying to leave the tight escape endpoints. The detection "
-            "fix needs to land alongside an escape-strategy refinement "
-            "for sparse-signal BGAs (paired escape direction toward the "
-            "partner connector, not outward from package center). "
-            "Tracked under #3419 (follow-up to #3413)."
-        ),
-    )
     def test_odd_dimension_7x7_bga_detected(self):
-        """7x7 BGA (49 pads, odd grid) should be detected as BGA (Issue #3413).
-
-        REGRESSION TEST DOCUMENTING THE BUG.  See the ``xfail`` reason
-        above for the full root-cause analysis and why a naive
-        ``_is_grid_pattern`` fix is not safe to land on its own.
+        """7x7 BGA (49 pads, odd grid) is detected as BGA (Issues #3413/#3419).
 
         Board 06's BGA-49 USB3 SuperSpeed sink is a 7x7 grid at 1.27 mm
-        pitch.  The router currently misclassifies it as
-        ``PackageType.UNKNOWN`` and dispatches the 8 USB3 SS signal pads
-        through ``_escape_radial`` -- a simple per-pin surface escape
-        that happens to produce the 41% reach this issue captures.  When
-        the BGA detector is corrected in isolation, the paired-escape
-        pre-pass (gated on ``PackageType.BGA``) fires on the USB3 pairs,
-        produces tightly-coupled escape endpoints at the BGA edge, and
-        the per-net A* main router times out searching from those
-        endpoints.  Reach drops to ~27%.
-
-        Two-phase fix needed (tracked separately):
-          1. ``_is_grid_pattern``: distribute axis pads across the two
-             adjacent quadrants when checking the balance heuristic.
-          2. ``_escape_diff_pair_segment`` / ``_generate_paired_escapes``:
-             choose the launch direction based on partner-connector
-             proximity (e.g., consult ``net_class_map`` / the diff-pair
-             partner's package location) rather than outward from
-             package center.
+        pitch.  Odd-dimension grids have a full row AND a full column
+        directly on the package center axes; the pre-#3419
+        ``_is_grid_pattern`` quadrant cascade lumped every axis pad into
+        the last quadrant (9/9/9/22 for a symmetric 7x7 grid), failing
+        the [0.3, 1.7] x avg balance check and misclassifying the
+        package as ``PackageType.UNKNOWN``.  The #3419 fix distributes
+        axis pads fractionally across adjacent quadrants (12.25 each for
+        7x7), so symmetric odd grids classify as BGA.
         """
         pads = create_bga_pads(7, 7, pitch=1.27)
         assert len(pads) == 49
@@ -705,6 +665,35 @@ class TestEscapeRouter:
 
         # Should have escape for each pad
         assert len(escapes) == 16
+
+    def test_bga_rings_skip_plane_net_pads(self, grid_and_rules):
+        """BGA ring escape skips net=0 (plane/skipped) pads (Issue #3419).
+
+        Plane nets (GND, VCC, ...) are stitched via planes, not routed
+        through escapes; generating escapes for them wastes the BGA
+        perimeter channel the signal nets need.  Mirrors the equivalent
+        filter in ``_escape_qfp_alternating`` (Issue #2513).
+        """
+        from dataclasses import replace
+
+        grid, rules = grid_and_rules
+        router = EscapeRouter(grid, rules)
+
+        pads = create_bga_pads(4, 4, pitch=0.8)
+        # Mark 5 of the 16 balls as plane-net pads (net=0).
+        plane_positions = set()
+        for i in (0, 3, 5, 10, 15):
+            pads[i] = replace(pads[i], net=0, net_name="GND")
+            plane_positions.add((pads[i].x, pads[i].y))
+
+        info = router.analyze_package(pads)
+        assert info.package_type == PackageType.BGA
+        escapes = router.generate_escapes(info)
+
+        # No escape may be generated for a plane-net pad, and all 11
+        # signal pads still escape.
+        assert all(e.pad.net != 0 for e in escapes)
+        assert len(escapes) == 11
 
         # Check escape structure
         for escape in escapes:

--- a/tests/test_escape_diffpair.py
+++ b/tests/test_escape_diffpair.py
@@ -333,6 +333,7 @@ class TestGate2EscapeRouterCtorReceivesMap:
         and refreshes an already-created escape router's map in place
         (Issue #3419).
         """
+        import contextlib
         from unittest.mock import MagicMock
 
         from kicad_tools.router.diffpair import DifferentialPairConfig
@@ -348,13 +349,11 @@ class TestGate2EscapeRouterCtorReceivesMap:
         ar._diffpair_router = MagicMock()
         ar._diffpair_router.route_all_with_diffpairs = MagicMock(return_value=([], []))
         ar._diffpair_router.intra_clearance_violations = MagicMock(return_value=[])
-        try:
+        # The mocked inner router may not satisfy the full post-route
+        # pipeline; the flag flip happens FIRST so it is still
+        # observable either way.
+        with contextlib.suppress(Exception):
             ar.route_all_with_diffpairs(DifferentialPairConfig(enabled=True))
-        except Exception:
-            # The mocked inner router may not satisfy the full post-route
-            # pipeline; the flag flip happens FIRST so it is still
-            # observable either way.
-            pass
         assert ar.paired_escape_coupling is True
         assert escape.diff_pair_map == {"USB_D+": "USB_D-", "USB_D-": "USB_D+"}
 

--- a/tests/test_escape_diffpair.py
+++ b/tests/test_escape_diffpair.py
@@ -301,10 +301,61 @@ class TestGate2EscapeRouterCtorReceivesMap:
         return ar
 
     def test_autorouter_escape_property_passes_map(self):
-        """core.py:7271 _escape property threads the map."""
+        """core.py _escape property threads the map when coupling is active.
+
+        Issue #3419: the map is now gated on ``paired_escape_coupling``
+        (flipped on by ``route_all_with_diffpairs``).  Without a coupled
+        consumer, the tightly-coupled paired escape endpoints strand the
+        plain per-net A* (board 06: 41% -> 27% reach regression).
+        """
         ar = self._build_ar_with_pair()
+        ar.paired_escape_coupling = True
         escape = ar._escape
         assert isinstance(escape, EscapeRouter)
+        assert escape.diff_pair_map == {"USB_D+": "USB_D-", "USB_D-": "USB_D+"}
+
+    def test_autorouter_escape_property_empty_map_without_coupling(self):
+        """Issue #3419: per-net routing (no coupled consumer) -> empty map.
+
+        The paired-escape pre-pass emits endpoints at the intra-pair
+        clearance; only the CoupledPathfinder can route from them.  When
+        ``paired_escape_coupling`` is False (default; plain
+        ``route_all`` / ``route_all_negotiated``), the map must NOT be
+        threaded even though pairs are detected.
+        """
+        ar = self._build_ar_with_pair()
+        assert ar.paired_escape_coupling is False
+        escape = ar._escape
+        assert escape.diff_pair_map == {}
+
+    def test_route_all_with_diffpairs_flips_coupling_flag(self):
+        """``route_all_with_diffpairs`` enables the pre-pass before routing
+        and refreshes an already-created escape router's map in place
+        (Issue #3419).
+        """
+        from unittest.mock import MagicMock
+
+        from kicad_tools.router.diffpair import DifferentialPairConfig
+
+        ar = self._build_ar_with_pair()
+        # Simulate an earlier phase having created the escape router with
+        # the gate off.
+        escape = ar._escape
+        assert escape.diff_pair_map == {}
+
+        # ``Autorouter._diffpair`` is a lazy property over
+        # ``_diffpair_router`` -- mock the underlying attribute.
+        ar._diffpair_router = MagicMock()
+        ar._diffpair_router.route_all_with_diffpairs = MagicMock(return_value=([], []))
+        ar._diffpair_router.intra_clearance_violations = MagicMock(return_value=[])
+        try:
+            ar.route_all_with_diffpairs(DifferentialPairConfig(enabled=True))
+        except Exception:
+            # The mocked inner router may not satisfy the full post-route
+            # pipeline; the flag flip happens FIRST so it is still
+            # observable either way.
+            pass
+        assert ar.paired_escape_coupling is True
         assert escape.diff_pair_map == {"USB_D+": "USB_D-", "USB_D-": "USB_D+"}
 
     def test_autorouter_escape_property_empty_map_for_no_pairs(self):

--- a/tests/test_escape_diffpair.py
+++ b/tests/test_escape_diffpair.py
@@ -1462,3 +1462,143 @@ class TestBGA49InnerRingCorridorDriftPrevention:
             f"All B2/B3 corridor cells must be owned by the pair {{1, 2}}; "
             f"found unexpected owner sets {unique_owner_sets - {{frozenset({{1, 2}})}}}"
         )
+
+
+# =============================================================================
+# Issue #3419: partner-connector-aware paired-escape launch direction
+# =============================================================================
+
+
+class TestPairLaunchDirectionHeuristic:
+    """Issue #3419: paired escapes launch TOWARD the partner connector.
+
+    The original heuristic launched the pair outward from the package
+    center (quadrant rule).  On board 06's BGA-49 that strands the
+    tightly-coupled escape endpoints facing away from the USB-C source
+    and the per-net A* times out dragging the pair around the package.
+    ``_select_pair_launch_direction`` aims the launch at the centroid of
+    the pair's off-package endpoints when ``net_pad_positions`` is
+    provided, and falls back to the quadrant rule otherwise.
+    """
+
+    @staticmethod
+    def _pair_and_mid(pads):
+        pad_p = next(p for p in pads if p.net_name == "TX_P")
+        pad_n = next(p for p in pads if p.net_name == "TX_N")
+        mid_x = (pad_p.x + pad_n.x) / 2.0
+        mid_y = (pad_p.y + pad_n.y) / 2.0
+        return pad_p, pad_n, mid_x, mid_y
+
+    def test_fallback_without_positions(self, grid, rules):
+        """No net_pad_positions -> exact pre-#3419 quadrant behaviour."""
+        pads = make_bga_with_pair()
+        info = make_package_info(pads, PackageType.BGA, "U1")
+        er = EscapeRouter(grid, rules, diff_pair_map={"TX_P": "TX_N", "TX_N": "TX_P"})
+        pad_p, pad_n, mid_x, mid_y = self._pair_and_mid(pads)
+        d = er._select_pair_launch_direction(pad_p, pad_n, mid_x, mid_y, info)
+        assert d == er._get_quadrant_direction(mid_x, mid_y, *info.center)
+
+    def test_fallback_when_all_endpoints_on_package(self, grid, rules):
+        """Positions map containing ONLY the on-package pads -> fallback."""
+        pads = make_bga_with_pair()
+        info = make_package_info(pads, PackageType.BGA, "U1")
+        pad_p, pad_n, mid_x, mid_y = self._pair_and_mid(pads)
+        positions = {
+            "TX_P": [(pad_p.x, pad_p.y)],
+            "TX_N": [(pad_n.x, pad_n.y)],
+        }
+        er = EscapeRouter(
+            grid, rules,
+            diff_pair_map={"TX_P": "TX_N", "TX_N": "TX_P"},
+            net_pad_positions=positions,
+        )
+        d = er._select_pair_launch_direction(pad_p, pad_n, mid_x, mid_y, info)
+        assert d == er._get_quadrant_direction(mid_x, mid_y, *info.center)
+
+    def test_direction_points_toward_partner_connector(self, grid, rules):
+        """Connector due EAST -> launch EAST even though quadrant says SOUTH.
+
+        The B2/B3 pair of ``make_bga_with_pair`` sits on the south side
+        of the package (midpoint (0, -0.4) vs center (0, 0)), so the
+        quadrant rule launches SOUTH.  With the partner connector's pads
+        far to the east, the #3419 heuristic must launch EAST.
+        """
+        from kicad_tools.router.escape import EscapeDirection
+
+        pads = make_bga_with_pair()
+        info = make_package_info(pads, PackageType.BGA, "U1")
+        pad_p, pad_n, mid_x, mid_y = self._pair_and_mid(pads)
+        positions = {
+            "TX_P": [(pad_p.x, pad_p.y), (30.0, mid_y)],
+            "TX_N": [(pad_n.x, pad_n.y), (30.0, mid_y - 0.2)],
+        }
+        er = EscapeRouter(
+            grid, rules,
+            diff_pair_map={"TX_P": "TX_N", "TX_N": "TX_P"},
+            net_pad_positions=positions,
+        )
+        d = er._select_pair_launch_direction(pad_p, pad_n, mid_x, mid_y, info)
+        assert d == EscapeDirection.EAST
+
+    def test_never_launches_into_package_interior(self, grid, rules):
+        """Connector on the FAR side -> heuristic must not launch inward.
+
+        The pair sits on the south side; a connector due north would
+        naively suggest NORTH, but that crosses the BGA pad field on the
+        surface layer.  The interior veto must exclude NORTH.
+        """
+        from kicad_tools.router.escape import EscapeDirection
+
+        pads = make_bga_with_pair()
+        info = make_package_info(pads, PackageType.BGA, "U1")
+        pad_p, pad_n, mid_x, mid_y = self._pair_and_mid(pads)
+        positions = {
+            "TX_P": [(pad_p.x, pad_p.y), (0.0, 30.0)],
+            "TX_N": [(pad_n.x, pad_n.y), (0.2, 30.0)],
+        }
+        er = EscapeRouter(
+            grid, rules,
+            diff_pair_map={"TX_P": "TX_N", "TX_N": "TX_P"},
+            net_pad_positions=positions,
+        )
+        d = er._select_pair_launch_direction(pad_p, pad_n, mid_x, mid_y, info)
+        assert d != EscapeDirection.NORTH
+
+    def test_generate_escapes_threads_heuristic(self, grid, rules):
+        """End-to-end: paired escape endpoints move toward the connector."""
+        pads = make_bga_with_pair()
+        info = make_package_info(pads, PackageType.BGA, "U1")
+        pad_p, pad_n, mid_x, mid_y = self._pair_and_mid(pads)
+        positions = {
+            "TX_P": [(pad_p.x, pad_p.y), (30.0, mid_y)],
+            "TX_N": [(pad_n.x, pad_n.y), (30.0, mid_y - 0.2)],
+        }
+        er = EscapeRouter(
+            grid, rules,
+            diff_pair_map={"TX_P": "TX_N", "TX_N": "TX_P"},
+            net_pad_positions=positions,
+        )
+        escapes = er.generate_escapes(info)
+        paired = [e for e in escapes if e.pad.net_name in ("TX_P", "TX_N")]
+        assert len(paired) == 2
+        for e in paired:
+            assert e.escape_point[0] > e.pad.x, (
+                f"{e.pad.net_name}: expected eastward launch toward the "
+                f"connector, got escape point {e.escape_point} from pad "
+                f"({e.pad.x}, {e.pad.y})"
+            )
+
+    def test_autorouter_threads_net_pad_positions(self):
+        """The Autorouter ``_escape`` property builds and threads the map."""
+        ar = Autorouter(width=20.0, height=20.0)
+        ar.net_class_map["SIG_A"] = NetClassRouting(name="Plain")
+        ar.add_component(
+            "J1",
+            [{"number": "1", "x": 5.0, "y": 6.0, "net": 1, "net_name": "SIG_A"}],
+        )
+        escape = ar._escape
+        assert escape.net_pad_positions.get("SIG_A") == [(5.0, 6.0)]
+
+    def test_default_positions_map_is_empty(self, grid, rules):
+        er = EscapeRouter(grid, rules)
+        assert er.net_pad_positions == {}


### PR DESCRIPTION
## Summary

Three-part fix for board 06's BGA-49 misclassification (the #3413 reach investigation), landing the detection fix WITHOUT the 41% -> 27% reach regression that blocked it from shipping standalone.

**Part 1 — `_is_grid_pattern` odd-grid quadrant fix (needed).** Odd-dimension grids (7x7 BGA-49) have a full row AND column exactly on the package center axes; the strict `if/elif/else` cascade lumped all axis pads into `quadrants[3]` (9/9/9/22, balance check fails, package -> UNKNOWN). Axis pads are now distributed fractionally across adjacent quadrants (0.5/0.5; center pad 0.25 x 4). Even grids have no axis pads, so their counts are bit-for-bit unchanged. The strict `xfail` marker from PR #3420 is removed; `test_odd_dimension_7x7_bga_detected` passes, and the 9x9 boundary test still passes.

**Part 2 — paired-escape coordination (needed; two mechanisms).**
- *Partner-connector-aware launch direction* (`_select_pair_launch_direction`): paired escapes now launch toward the centroid of the pair's off-package endpoints (new board-wide `net_pad_positions` map threaded from `Autorouter._escape`), with an interior veto so the pair never launches across the package pad field. Falls back to the original quadrant rule when no positions are available. **Measured alone this was NOT sufficient** — reach still dropped to 27% (6/22) because the per-net A* cannot expand from endpoints inside the partner trace's clearance envelope.
- *Coupled-consumer gate* (`Autorouter.paired_escape_coupling`, default False): the paired pre-pass emits endpoints at the intra-pair clearance that only the CoupledPathfinder can route from. The map is now threaded into the EscapeRouter only when `route_all_with_diffpairs` will consume the escapes (flag flipped at its entry; an already-created escape router is refreshed in place). Plain per-net routing (`kct route` without `--differential-pairs`) gets single-ended escapes — this is what restores (and lifts) reach.

**Part 3 — `_escape_bga_rings` plane-pad filter (needed).** Skips `net == 0` pads, mirroring the #2513 `_escape_qfp_alternating` filter. On board 06 the BGA-49 now escapes exactly its 8 USB3 signal pads instead of all 49 balls, freeing the perimeter channel.

## Measurements

| Metric | Current main | This PR | Delta |
|---|---|---|---|
| Board 06 reach (`kct route ... --auto-layers --max-layers 4`) | 9/22 (41%) | **10/22 (45%)** | **+1 net** |
| Board 06 re-route DRC (`check_diffpair_coverage.py --seed 42`, local) | 31 errors | **31 errors** | **0** |
| U2 (BGA-49) classification | UNKNOWN (radial escape, 49 escapes) | **BGA** (ring escape, 8 signal escapes) | fixed |

- Reach baseline measured on this machine immediately before the fix (same command, same contention conditions). Naive detection fix alone reproduced the predicted regression (27%, 6/22); with the full 3-part fix reach is 45%.
- The re-route DRC gate (`diffpair-routing-regression`) measures 31 locally on BOTH current main and this branch (CI sees 32 on main — the 31-vs-21-allowlist regression is #3421's lane, being bisected in parallel; this PR's delta against current main is exactly 0, and `.github/routed-drc-tolerance.yml` is untouched). The generate_design flow does not run the dense-package escape pre-pass, so this PR is inert there — confirmed by identical logs (27 budget-exceeded events each).

## Tests

- xfail marker removed from `test_odd_dimension_7x7_bga_detected` (now passing); 9x9 boundary test unchanged and passing.
- New: `TestPairLaunchDirectionHeuristic` (7 tests: fallback behavior, connector-aimed launch, interior veto, end-to-end threading, Autorouter map threading), `test_bga_rings_skip_plane_net_pads`, Gate-2 coupling-gate tests (`empty_map_without_coupling`, `flips_coupling_flag`).
- Full escape/diffpair sweep (`-k "escape or diffpair or diff_pair"`): 1054 passed on this branch; the 3 remaining failures (2x `test_subgrid_integration`, 1x `test_diffpair_length_tuning` order-dependent flake) fail identically on current main (verified with the same sweep command).
- ruff/mypy: zero new findings vs main on all touched files.

## Which of the 3 parts were needed

All three. Part 1 is the core fix; Part 2's direction heuristic alone did not prevent the regression — the coupled-consumer gate is the binding mechanism; Part 3 frees the BGA perimeter (8 escapes instead of 49) and contributes to the reach lift.

Refs #3413 (stays open — board 06 still 45% vs 100% bar).

Closes #3419

🤖 Generated with [Claude Code](https://claude.com/claude-code)