### PR TITLE
fix(router): target-aware in-pad stub direction — board 04 NRST unblock (refs #3411, closes #3428)

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -11024,8 +11024,37 @@ class Autorouter:
                     self.get_diff_pair_map() if self.paired_escape_coupling else {}
                 ),
                 net_pad_positions=net_pad_positions,
+                # Issue #3428: board-wide net-id -> pad-position map so the
+                # fine-pitch QFP in-pad rescue can aim its inner stub at
+                # the net's actual routing target instead of the parity-
+                # derived along-edge direction (board 04 OSC_OUT stub
+                # blocking NRST's via slot, Issue #3411).
+                net_target_positions=self._build_net_target_positions(),
             )
         return self._escape_router
+
+    def _build_net_target_positions(self) -> dict[int, list[tuple[float, float, str]]]:
+        """Build the board-wide net-id -> [(x, y, ref), ...] pad map.
+
+        Issue #3428: consumed by ``EscapeRouter._compute_target_direction``
+        to make the in-pad rescue's inner-stub direction target-aware.
+        Plane/unassigned pads (net 0) are skipped -- they connect via
+        zone fill / stitching, never via escape stubs.  Iteration over
+        sorted ``(ref, pin)`` keys keeps the per-net position lists
+        deterministic regardless of pad-insertion order (required for
+        ``--seed`` byte-identical reproducibility).
+
+        Distinct from the str-keyed ``net_pad_positions`` map built inline
+        in ``_escape`` (Issue #3419), which feeds the diff-pair launch
+        heuristic.
+        """
+        net_target_positions: dict[int, list[tuple[float, float, str]]] = {}
+        for key in sorted(self.pads):
+            pad = self.pads[key]
+            if pad.net == 0:
+                continue
+            net_target_positions.setdefault(pad.net, []).append((pad.x, pad.y, pad.ref))
+        return net_target_positions
 
     def detect_dense_packages(self) -> list[PackageInfo]:
         """Detect dense packages that need escape routing.

--- a/src/kicad_tools/router/escape.py
+++ b/src/kicad_tools/router/escape.py
@@ -894,6 +894,7 @@ class EscapeRouter:
         manufacturer: str | None = None,
         diff_pair_map: dict[str, str] | None = None,
         net_pad_positions: dict[str, list[tuple[float, float]]] | None = None,
+        net_target_positions: dict[int, list[tuple[float, float, str]]] | None = None,
     ):
         """Initialize the escape router.
 
@@ -932,6 +933,20 @@ class EscapeRouter:
                 the main per-net A* does not have to fight its way around
                 the package from a tight launch.  Defaults to ``None``
                 which preserves the center-outward quadrant heuristic.
+            net_target_positions: Optional board-wide net-to-pad-position map
+                (Issue #3428): ``{net_id: [(x, y, ref), ...]}`` covering
+                every pad on every net (plane nets / net 0 may be
+                omitted).  When supplied, the fine-pitch QFP in-pad
+                rescue (``_escape_qfp_alternating`` ->
+                ``_try_in_pad_escape``) points the inner-layer escape
+                stub toward the net's nearest OFF-package pad instead of
+                the parity-derived along-edge direction, so the stub no
+                longer blocks the adjacent pin's own via slot (board 04
+                LQFP-48 OSC_OUT stub vs NRST, Issue #3411).  Defaults to
+                ``None`` which preserves legacy parity-based stub
+                directions exactly.  Distinct from ``net_pad_positions``
+                (Issue #3419), which is keyed by net NAME and consumed by
+                the diff-pair launch heuristic.
         """
         self.grid = grid
         self.rules = rules
@@ -952,6 +967,14 @@ class EscapeRouter:
         # disables the heuristic (falls back to center-outward quadrant
         # direction).
         self.net_pad_positions: dict[str, list[tuple[float, float]]] = net_pad_positions or {}
+        # Issue #3428: board-wide net-id -> [(x, y, ref), ...] pad-position
+        # map used by ``_compute_target_direction`` to make the QFP in-pad
+        # rescue's inner stub target-aware.  Empty map disables the
+        # feature (every call site falls back to the legacy
+        # parity-derived direction).
+        self.net_target_positions: dict[int, list[tuple[float, float, str]]] = (
+            net_target_positions or {}
+        )
         # Instrumentation counter (Gate 3/4 of the #2587-style verification
         # chain): bumped every time ``_escape_diff_pair_segment`` is
         # invoked.  Tests assert this is non-zero on board 03 and zero
@@ -2663,13 +2686,75 @@ class EscapeRouter:
                         # that were filtered out of ``pads`` above.
                         extra_pads=self._other_footprint_pads(package, pads),
                     )
-                    if violation or pin_boxed:
+
+                    # Issue #3428 (POCKET-ESCAPE rescue): a clean surface
+                    # escape is not always a USEFUL surface escape.  On
+                    # board 04, U2.7 NRST's perpendicular WEST escape is
+                    # geometrically clean -- but its routing target
+                    # (J1.5) lies EAST across the package, and the only
+                    # west-side exit corridor is already consumed by
+                    # OSC_IN's escape via after U2.6 OSC_OUT claimed its
+                    # in-pad via.  The result is a dead-end pocket and a
+                    # stranded net no amount of rip-up can recover.
+                    #
+                    # Trigger conditions (ALL must hold; deliberately
+                    # narrow so every other board keeps byte-identical
+                    # escapes):
+                    #   1. The standard rescue triggers (violation /
+                    #      pin_boxed) did NOT fire,
+                    #   2. the net is not a pour net (plane nets connect
+                    #      via zone fill, never via escape stubs),
+                    #   3. an immediately adjacent same-package pin
+                    #      already claimed an in-pad via in this pass
+                    #      (the contested-channel signal),
+                    #   4. the net's snapped target direction points
+                    #      AWAY from the parity-derived escape direction
+                    #      (negative dot product -- the escape would
+                    #      walk away from the target into the pocket).
+                    # When they hold, rescue this pin too with an in-pad
+                    # via whose inner stub points AT the target --
+                    # under-package inner-layer space is open for SMD
+                    # packages, so ``allow_into_package=True``.
+                    pocket_target: EscapeDirection | None = None
+                    if not violation and not pin_boxed and pad.net != 0:
+                        nc = self.net_class_map.get(pad.net_name)
+                        is_pour = nc is not None and getattr(nc, "is_pour_net", False)
+                        if not is_pour:
+                            raw_target = self._compute_target_direction(
+                                pad=pad,
+                                package=package,
+                                primary_dir=primary_dir,
+                                allow_into_package=True,
+                            )
+                            if raw_target is not None:
+                                tvx, tvy = self._direction_to_vector(raw_target)
+                                dvx, dvy = self._direction_to_vector(direction)
+                                if tvx * dvx + tvy * dvy < 0 and self._neighbour_claimed_in_pad_via(
+                                    pad,
+                                    package,
+                                    escapes,
+                                ):
+                                    pocket_target = raw_target
+
+                    if violation or pin_boxed or pocket_target is not None:
                         # Issue #3033 / #3062: forward the EscapeRouter-level
                         # strict flag so the dispatcher inherits the "defer
                         # rather than commit a violating via" policy.
                         # Defaults to False on the EscapeRouter constructor,
                         # preserving legacy behaviour exactly for every
                         # existing caller.
+                        #
+                        # Issue #3428: point the rescue's inner stub at the
+                        # net's actual routing target (nearest off-package
+                        # same-net pad, snapped to a cardinal) instead of
+                        # the parity-derived along-edge direction.  On
+                        # board 04 the parity direction for U2.6 OSC_OUT
+                        # was NORTH (+y, toward U2.7 NRST); the 0.5mm
+                        # stub then blocked NRST's only escape-via slot.
+                        # Returns None (-> legacy direction) when no
+                        # net-position map was wired in, the net has no
+                        # off-package pads, or the target points into the
+                        # package body.
                         in_pad_route = self._try_in_pad_escape(
                             pad=pad,
                             direction=direction,
@@ -2677,8 +2762,30 @@ class EscapeRouter:
                             escape_width=escape_width,
                             package=package,
                             skip_on_clearance_violation=self.strict_in_pad_clearance,
+                            target_direction=(
+                                pocket_target
+                                if pocket_target is not None
+                                else self._compute_target_direction(
+                                    pad=pad,
+                                    package=package,
+                                    primary_dir=primary_dir,
+                                )
+                            ),
                         )
                         if in_pad_route is not None:
+                            if pocket_target is not None:
+                                logger.info(
+                                    "POCKET-ESCAPE in-pad rescue for %s pin %s "
+                                    "(net %s): clean surface escape pointed "
+                                    "AWAY from the net target while an "
+                                    "adjacent pin holds an in-pad via; "
+                                    "rescued with target-aware stub dir=%s "
+                                    "(Issue #3428).",
+                                    package.ref,
+                                    pad.pin,
+                                    pad.net_name,
+                                    pocket_target.name,
+                                )
                             if pin_boxed and not violation:
                                 logger.info(
                                     "In-pad rescue forced for %s pin %s "
@@ -2725,16 +2832,26 @@ class EscapeRouter:
                         # the strict-mode path was already using -- still
                         # falls back to "defer to main router" when it
                         # returns None.
-                        lateral_route = self._try_lateral_via_escape(
-                            pad=pad,
-                            direction=primary_dir,
-                            effective_clearance=effective_clearance,
-                            escape_width=escape_width,
-                            package=package,
-                        )
-                        if lateral_route is not None:
-                            escapes.append(lateral_route)
-                            continue
+                        #
+                        # Issue #3428: the lateral attempt is gated to the
+                        # LEGACY triggers (violation / pin_boxed).  When
+                        # only the pocket-escape trigger fired and the
+                        # in-pad rescue could not place a via, the pin's
+                        # surface escape is geometrically clean -- fall
+                        # through to it unchanged rather than introducing
+                        # an off-pad via that the pre-#3428 code would
+                        # never have placed.
+                        if violation or pin_boxed:
+                            lateral_route = self._try_lateral_via_escape(
+                                pad=pad,
+                                direction=primary_dir,
+                                effective_clearance=effective_clearance,
+                                escape_width=escape_width,
+                                package=package,
+                            )
+                            if lateral_route is not None:
+                                escapes.append(lateral_route)
+                                continue
 
                 # Issue #2881: Missed-rescue detection.  When the package is
                 # fine-pitch enough to need via-in-pad rescue but the
@@ -5774,6 +5891,163 @@ class EscapeRouter:
         # last-resort behavior).
         return via_x, via_y, False
 
+    def _compute_target_direction(
+        self,
+        pad: Pad,
+        package: PackageInfo,
+        primary_dir: EscapeDirection,
+        allow_into_package: bool = False,
+    ) -> EscapeDirection | None:
+        """Snap the direction toward the net's nearest off-package pad.
+
+        Issue #3428 (follow-on to #3411): the QFP-alternating dispatcher
+        chooses the in-pad rescue's inner-stub direction purely from the
+        pin's index parity in the sorted same-edge pad list.  On board 04
+        that emitted U2.6 OSC_OUT's B.Cu stub TOWARD U2.7 (NRST), whose
+        candidate escape via then failed clearance against the stub --
+        stranding NRST.  This helper consults the board-wide
+        ``net_target_positions`` map and returns the cardinal direction
+        pointing at the net's actual routing target so the stub leaves
+        the contested channel instead of blocking it.
+
+        Selection rules (all deterministic, required for the ``--seed``
+        byte-identical reproducibility AC):
+
+        1. Candidate targets are the net's pads NOT on ``package``
+           (matched by ref).  No candidates / no map entry -> ``None``
+           (caller keeps the legacy parity direction).
+        2. The nearest candidate wins; exact distance ties break by
+           ``(x, y)`` ascending.
+        3. The delta to the winner snaps to the axis with the larger
+           ``|component|``.  On an exact ``|dx| == |dy|`` tie the fixed
+           precedence ``NORTH > EAST > SOUTH > WEST`` picks between the
+           two candidate cardinals.
+        4. Into-package guard: when the snapped direction points INTO
+           the package body (negative dot product with ``primary_dir``,
+           the outward perpendicular for this edge), return ``None`` --
+           an inner stub under the package would collide with the other
+           edges' escapes.  Along-edge results (zero dot product) are
+           allowed; redirecting the stub along the edge AWAY from a
+           needy neighbour is precisely the board-04 fix.  Callers that
+           EXPLICITLY want an under-package inner stub (the
+           pocket-escape rescue, see ``_escape_qfp_alternating``) pass
+           ``allow_into_package=True`` to skip this guard -- on the
+           inner escape layer the area under an SMD package body is
+           open routing space, and a net whose target lies across the
+           package must traverse it anyway.
+
+        Args:
+            pad: The pad being rescued.
+            package: The package the pad belongs to (its ref filters
+                same-package pads out of the candidate target set).
+            primary_dir: Outward perpendicular escape direction for the
+                pad's package edge (used for the into-package guard).
+            allow_into_package: When True, skip the into-package guard
+                (step 4) and return the snapped target direction even
+                when it points across the package body.  Default False
+                preserves the conservative behaviour for the standard
+                violation-triggered rescue path.
+
+        Returns:
+            The snapped cardinal ``EscapeDirection``, or ``None`` when no
+            target information is available or the target points into
+            the package body (caller falls back to legacy behaviour).
+        """
+        positions = self.net_target_positions.get(pad.net)
+        if not positions:
+            return None
+        candidates = [(x, y) for x, y, ref in positions if ref != package.ref]
+        if not candidates:
+            return None
+
+        # Deterministic nearest-candidate selection: squared distance,
+        # then (x, y) ascending on exact ties.
+        tx, ty = min(
+            candidates,
+            key=lambda p: ((p[0] - pad.x) ** 2 + (p[1] - pad.y) ** 2, p[0], p[1]),
+        )
+        dx = tx - pad.x
+        dy = ty - pad.y
+        if abs(dx) < 1e-9 and abs(dy) < 1e-9:
+            return None
+
+        # NOTE: EscapeDirection.NORTH maps to (0, +1) in this module
+        # (see ``_direction_to_vector``), i.e. toward LARGER y in the
+        # KiCad y-down world frame.  We stay consistent with that
+        # convention here rather than the schematic-intuitive one.
+        horizontal = EscapeDirection.EAST if dx > 0 else EscapeDirection.WEST
+        vertical = EscapeDirection.NORTH if dy > 0 else EscapeDirection.SOUTH
+        if abs(dx) > abs(dy) + 1e-9:
+            target = horizontal
+        elif abs(dy) > abs(dx) + 1e-9:
+            target = vertical
+        else:
+            # Exact |dx| == |dy| tie: documented fixed precedence
+            # NORTH > EAST > SOUTH > WEST between the two candidates.
+            precedence = {
+                EscapeDirection.NORTH: 0,
+                EscapeDirection.EAST: 1,
+                EscapeDirection.SOUTH: 2,
+                EscapeDirection.WEST: 3,
+            }
+            target = min((vertical, horizontal), key=lambda d: precedence[d])
+
+        # Into-package fallback guard: reject directions whose dot
+        # product with the outward perpendicular is negative.
+        if not allow_into_package:
+            pvx, pvy = self._direction_to_vector(primary_dir)
+            tvx, tvy = self._direction_to_vector(target)
+            if pvx * tvx + pvy * tvy < 0:
+                return None
+        return target
+
+    def _neighbour_claimed_in_pad_via(
+        self,
+        pad: Pad,
+        package: PackageInfo,
+        escapes: list[EscapeRoute],
+    ) -> bool:
+        """Check whether an adjacent same-package pin claimed an in-pad via.
+
+        Issue #3428 (pocket-escape rescue trigger): when a fine-pitch
+        pin's immediate neighbour was just rescued with an in-pad via,
+        the inter-pin surface channel is contested -- the neighbour's
+        via plus its inner stub consume the clearance budget that this
+        pin's own escape via would need.  Combined with a routing target
+        on the FAR side of the package (see the caller's dot-product
+        check), the standard perpendicular surface escape leads into a
+        dead-end pocket (board 04: U2.7 NRST escaping WEST into the
+        crystal-cluster pocket while its target J1.5 lies EAST).
+
+        Adjacency is physical, not list-index based: a neighbour
+        qualifies when its pad centre lies within ``1.25 x pin_pitch``
+        (Chebyshev) of this pad.  The 1.25 factor tolerates sub-grid
+        coordinate noise while excluding next-but-one pins (2.0 x
+        pitch away).
+
+        Args:
+            pad: The pad being considered for a pocket-escape rescue.
+            package: Package context (supplies ``pin_pitch``).
+            escapes: Escape routes accumulated so far in this dispatch
+                pass (earlier-indexed pins on this and previous edges).
+
+        Returns:
+            True when at least one already-rescued in-pad via belongs to
+            an immediately adjacent pin on the same component.
+        """
+        pitch = package.pin_pitch
+        if not pitch or pitch <= 0:
+            return False
+        limit = pitch * 1.25
+        for er in escapes:
+            if er.via is None or not getattr(er.via, "in_pad", False):
+                continue
+            if er.pad is pad or er.pad.ref != pad.ref:
+                continue
+            if abs(er.pad.x - pad.x) <= limit and abs(er.pad.y - pad.y) <= limit:
+                return True
+        return False
+
     def _try_in_pad_escape(
         self,
         pad: Pad,
@@ -5782,6 +6056,7 @@ class EscapeRouter:
         escape_width: float,
         package: PackageInfo | None = None,
         skip_on_clearance_violation: bool = False,
+        target_direction: EscapeDirection | None = None,
     ) -> EscapeRoute | None:
         """Attempt an in-pad via escape for a fine-pitch SSOP/TSSOP pad.
 
@@ -5860,6 +6135,14 @@ class EscapeRouter:
                 that prefer surfacing the deferral as an explicit gap
                 over committing a DRC violation that cascades into
                 adjacent-pin routing failures.  Issue #3033 / #3062.
+            target_direction: Optional target-aware override for the
+                inner-layer stub direction (Issue #3428).  When supplied
+                (typically from ``_compute_target_direction``), the
+                inner-layer escape segment and ``escape_point`` use this
+                direction instead of ``direction``.  Via placement is
+                unaffected -- it is direction-independent.  ``None``
+                (default) preserves legacy behaviour byte-for-byte for
+                every existing call site.
 
         Returns:
             An ``EscapeRoute`` with the in-pad via and inner-layer segment,
@@ -6050,7 +6333,16 @@ class EscapeRouter:
         # Inner-layer escape point: continue inward toward the package
         # body (same direction the deferred surface escape would have
         # used) so the main router can pick up from there.
-        dx, dy = self._direction_to_vector(direction)
+        #
+        # Issue #3428: when the caller supplied a target-aware
+        # ``target_direction`` (net's actual routing target, computed by
+        # ``_compute_target_direction``), the stub vector uses it instead
+        # of the parity-derived ``direction`` so the stub does not block
+        # an adjacent fine-pitch pin's via slot.  ONLY the stub vector
+        # (and hence ``escape_point``) changes -- via placement above is
+        # direction-independent.
+        effective_direction = target_direction if target_direction is not None else direction
+        dx, dy = self._direction_to_vector(effective_direction)
         # Use a modest offset -- one via radius plus clearance plus a
         # trace width buffer is enough room for the main router to
         # connect onto the inner-layer endpoint without colliding with
@@ -6079,19 +6371,35 @@ class EscapeRouter:
             is_micro=is_micro_via_used,
         )
 
+        # Issue #3428: neck the TARGET-AWARE stub down to the manufacturer
+        # minimum trace width.  At 0.5 mm pitch the dispatcher-supplied
+        # ``escape_width`` can be the full net trace width (0.5 mm on
+        # power-derived defaults); two adjacent redirected stubs at that
+        # width touch edge-to-edge (0.000 mm clearance) no matter which
+        # directions they point.  Necking mirrors the PR #3079 lateral-
+        # stub precedent (``_try_lateral_via_escape``).  The legacy
+        # ``target_direction is None`` path keeps the dispatcher width
+        # byte-for-byte.
+        stub_width = escape_width
+        if target_direction is not None and self._mfr_limits is not None:
+            mfr_min_trace = self._mfr_limits.min_trace
+            if mfr_min_trace is not None and mfr_min_trace < stub_width:
+                stub_width = mfr_min_trace
+
         inner_seg = Segment(
             x1=via_x,
             y1=via_y,
             x2=escape_x,
             y2=escape_y,
-            width=escape_width,
+            width=stub_width,
             layer=escape_layer,
             net=pad.net,
             net_name=pad.net_name,
         )
 
         logger.info(
-            "In-pad escape generated for pad %s (%s ref=%s pin=%s): via at (%.3f, %.3f) -> %s",
+            "In-pad escape generated for pad %s (%s ref=%s pin=%s): "
+            "via at (%.3f, %.3f) -> %s, stub dir=%s%s",
             pad.net_name,
             pad.layer.kicad_name,
             pad.ref,
@@ -6099,11 +6407,13 @@ class EscapeRouter:
             via_x,
             via_y,
             escape_layer.kicad_name,
+            effective_direction.name,
+            " (target-aware, Issue #3428)" if target_direction is not None else "",
         )
 
         return EscapeRoute(
             pad=pad,
-            direction=direction,
+            direction=effective_direction,
             escape_point=(escape_x, escape_y),
             escape_layer=escape_layer,
             via_pos=(via_x, via_y),

--- a/src/kicad_tools/router/orchestrator.py
+++ b/src/kicad_tools/router/orchestrator.py
@@ -218,6 +218,73 @@ class RoutingOrchestrator:
                 out[n] = p
         return out
 
+    def _build_net_target_positions(self) -> dict[int, list[tuple[float, float, str]]] | None:
+        """Build the board-wide net-id -> [(x, y, ref), ...] pad map.
+
+        Issue #3428: feeds the EscapeRouter's ``net_target_positions``
+        parameter so the fine-pitch QFP in-pad rescue can aim its inner
+        stub at the net's actual routing target (see
+        ``EscapeRouter._compute_target_direction``).  This mirrors the
+        ``Autorouter._build_net_target_positions`` wiring on the ``kct
+        route`` path -- the orchestrator (``kct route-auto``) is an
+        independent code path and fixing only one is a known foot-gun.
+
+        Two PCB-like shapes are supported, both defensively:
+
+        1. Autorouter-style ``self.pcb.pads`` dict keyed by
+           ``(ref, pin)`` with router ``Pad`` values.
+        2. Document-model ``self.pcb.footprints`` with relative pad
+           positions (rotated into world coordinates with the standard
+           CCW-positive convention, mirroring
+           ``kicad_tools.mcp.tools.routing._build_pads_for_net``).
+
+        Returns ``None`` when neither shape is usable (e.g. mock PCBs in
+        unit tests) so the EscapeRouter falls back to legacy
+        parity-derived stub directions.  Iteration is over sorted keys /
+        document order to keep the per-net lists deterministic.
+        """
+        result: dict[int, list[tuple[float, float, str]]] = {}
+        try:
+            pads_attr = getattr(self.pcb, "pads", None)
+            if isinstance(pads_attr, dict) and pads_attr:
+                for key in sorted(pads_attr):
+                    pad = pads_attr[key]
+                    net = getattr(pad, "net", 0)
+                    if not isinstance(net, int) or net == 0:
+                        continue
+                    result.setdefault(net, []).append(
+                        (pad.x, pad.y, getattr(pad, "ref", "") or "")
+                    )
+                return result or None
+
+            footprints = getattr(self.pcb, "footprints", None)
+            if footprints:
+                for fp in footprints:
+                    ref = getattr(fp, "reference", "") or ""
+                    if not ref or ref.startswith("#"):
+                        continue
+                    fp_x, fp_y = fp.position
+                    # KiCad rotation is CCW-positive; standard 2D
+                    # rotation matrix applies directly.
+                    rot_rad = math.radians(getattr(fp, "rotation", 0.0) or 0.0)
+                    cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
+                    for pad in fp.pads:
+                        net = getattr(pad, "net_number", 0)
+                        if not isinstance(net, int) or net == 0:
+                            continue
+                        px, py = pad.position
+                        result.setdefault(net, []).append(
+                            (
+                                fp_x + px * cos_r - py * sin_r,
+                                fp_y + px * sin_r + py * cos_r,
+                                ref,
+                            )
+                        )
+                return result or None
+        except Exception:  # pragma: no cover - defensive against mock PCBs
+            return None
+        return None
+
     def route_net(
         self,
         net: str | int,
@@ -698,6 +765,12 @@ class RoutingOrchestrator:
                     # returns {} when no pairs are detected, preserving
                     # pre-#2639 single-ended behavior.
                     diff_pair_map=self._get_diff_pair_map(),
+                    # Issue #3428: net -> pad-position map for target-aware
+                    # in-pad rescue stub directions.  Same wiring as the
+                    # Autorouter (``kct route``) path -- the orchestrator
+                    # (``kct route-auto``) is an independent code path and
+                    # fixing only one is a known foot-gun in this codebase.
+                    net_target_positions=self._build_net_target_positions(),
                 )
 
         if self._escape is not None:
@@ -1347,6 +1420,9 @@ class RoutingOrchestrator:
                     # Issue #2639 / Epic #2556 Phase 2F: same threading
                     # as the escape_then_global ctor site above.
                     diff_pair_map=self._get_diff_pair_map(),
+                    # Issue #3428: same target-aware in-pad stub wiring
+                    # as the escape_then_global ctor site above.
+                    net_target_positions=self._build_net_target_positions(),
                 )
         return self._escape
 

--- a/tests/router/test_escape_target_direction.py
+++ b/tests/router/test_escape_target_direction.py
@@ -1,0 +1,643 @@
+"""Issue #3428: target-aware in-pad inner segment direction for fine-pitch
+QFP escapes.
+
+Board 04 (STM32 LQFP-48) background: when U2.6 OSC_OUT claims an in-pad
+via rescue, the legacy dispatcher emitted the inner-layer stub in the
+parity-derived ``alt_dir_cw`` direction (NORTH = +y = toward U2.7 NRST),
+blocking the adjacent pin's escape-via slot.  PR for #3428 makes the stub
+direction target-aware:
+
+* ``EscapeRouter._compute_target_direction`` snaps the vector from the
+  rescued pad to the net's nearest OFF-package pad onto a cardinal
+  ``EscapeDirection`` (deterministic tie-breaks, into-package guard).
+* ``EscapeRouter._try_in_pad_escape`` accepts ``target_direction`` which
+  redirects ONLY the inner stub (via placement is direction-independent).
+  ``target_direction=None`` preserves legacy behaviour byte-for-byte.
+* The QFP-alternating dispatcher additionally performs a POCKET-ESCAPE
+  rescue: a pin whose clean surface escape points AWAY from its net
+  target while an adjacent pin already holds an in-pad via is rescued
+  with its own in-pad via + target-aware stub (board 04 NRST).
+
+Test plan (from the curator-sharpened issue):
+1. Snap-to-cardinal selection for targets in each quadrant + exact-tie
+   cases (deterministic result).
+2. ``target_direction=None`` produces an identical ``EscapeRoute`` (stub
+   vector, escape_point, width) to pre-change behaviour.
+3. Target pointing into the package body falls back to legacy direction
+   (returns None) unless ``allow_into_package=True``.
+4. Board-04-like fixture: adjacent 0.5mm-pitch pins where pin N claims
+   an in-pad via and pin N+1's target lies across the package -- the
+   pocket-escape rescue fires and the stub points at the target.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.router.escape import (
+    EscapeDirection,
+    EscapeRoute,
+    EscapeRouter,
+    PackageInfo,
+    PackageType,
+)
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.primitives import Pad, Via
+from kicad_tools.router.rules import DesignRules
+
+# ----------------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------------
+
+ANCHOR_X = 0.0
+ANCHOR_Y = 0.0
+
+
+def _make_rules(manufacturer: str | None = "jlcpcb-tier1") -> DesignRules:
+    # trace_width 0.2: narrow enough that the perpendicular (even-index)
+    # surface escapes in the dispatcher fixture stay clearance-clean at
+    # 0.5 mm pitch (a 0.5 mm-wide escape would violate against the
+    # NEIGHBOUR pads even perpendicular, short-circuiting every pin into
+    # the violation-triggered rescue and hiding the pocket trigger).
+    # The necking unit test passes escape_width=0.5 explicitly, so it is
+    # unaffected by this value.
+    return DesignRules(
+        trace_width=0.2,
+        trace_clearance=0.127,
+        via_drill=0.3,
+        via_diameter=0.6,
+        grid_resolution=0.05,
+        manufacturer=manufacturer,
+    )
+
+
+def _make_grid(rules: DesignRules) -> RoutingGrid:
+    return RoutingGrid(
+        width=30.0,
+        height=30.0,
+        rules=rules,
+        origin_x=-15.0,
+        origin_y=-15.0,
+        layer_stack=LayerStack.two_layer(),
+    )
+
+
+def _make_router(
+    net_target_positions: dict[int, list[tuple[float, float, str]]] | None = None,
+    manufacturer: str | None = "jlcpcb-tier1",
+) -> EscapeRouter:
+    rules = _make_rules(manufacturer=manufacturer)
+    grid = _make_grid(rules)
+    return EscapeRouter(grid, rules, net_target_positions=net_target_positions)
+
+
+def _west_edge_pad(net: int = 7, x: float = ANCHOR_X, y: float = ANCHOR_Y) -> Pad:
+    """A fine-pitch west-edge pad (long axis horizontal)."""
+    return Pad(
+        x=x,
+        y=y,
+        width=1.5,
+        height=0.3,
+        net=net,
+        net_name=f"NET{net}",
+        ref="U2",
+        pin="7",
+        layer=Layer.F_CU,
+    )
+
+
+def _make_package(pads: list[Pad], ref: str = "U2") -> PackageInfo:
+    xs = [p.x for p in pads]
+    ys = [p.y for p in pads]
+    return PackageInfo(
+        ref=ref,
+        package_type=PackageType.QFP,
+        center=(sum(xs) / len(xs), sum(ys) / len(ys)),
+        pads=pads,
+        pin_count=len(pads),
+        pin_pitch=0.5,
+        bounding_box=(min(xs), min(ys), max(xs), max(ys)),
+        is_dense=True,
+    )
+
+
+def _make_lqfp_west_signal_row(
+    pads_per_edge: int = 12,
+    pitch: float = 0.5,
+    pad_short: float = 0.30,
+    pad_long: float = 1.50,
+) -> list[Pad]:
+    """Four-edge LQFP-48-like fixture, all signal nets, unique per pin.
+
+    West-edge pads are emitted bottom-to-top so the dispatcher's
+    y-ascending filtered list index equals the emission index j
+    (west net id = ``100 + j``).
+    """
+    span = (pads_per_edge - 1) * pitch
+    body_size = span + 3.0 * pitch + 2.0 * pad_long
+    half_body = body_size / 2
+    pad_stick_out = 0.85
+    pad_center_offset = half_body + pad_stick_out / 2
+    half_span = span / 2
+
+    pads: list[Pad] = []
+    pin_no = 1
+    # WEST edge, bottom -> top (ascending y) so filtered index == j.
+    for j in range(pads_per_edge):
+        pads.append(
+            Pad(
+                x=-pad_center_offset,
+                y=-half_span + j * pitch,
+                width=pad_long,
+                height=pad_short,
+                net=100 + j,
+                net_name=f"NET{100 + j}",
+                ref="U2",
+                pin=str(pin_no),
+                layer=Layer.F_CU,
+            )
+        )
+        pin_no += 1
+    # SOUTH edge
+    for j in range(pads_per_edge):
+        pads.append(
+            Pad(
+                x=-half_span + j * pitch,
+                y=-pad_center_offset,
+                width=pad_short,
+                height=pad_long,
+                net=300 + j,
+                net_name=f"NET{300 + j}",
+                ref="U2",
+                pin=str(pin_no),
+                layer=Layer.F_CU,
+            )
+        )
+        pin_no += 1
+    # EAST edge
+    for j in range(pads_per_edge):
+        pads.append(
+            Pad(
+                x=pad_center_offset,
+                y=-half_span + j * pitch,
+                width=pad_long,
+                height=pad_short,
+                net=400 + j,
+                net_name=f"NET{400 + j}",
+                ref="U2",
+                pin=str(pin_no),
+                layer=Layer.F_CU,
+            )
+        )
+        pin_no += 1
+    # NORTH edge
+    for j in range(pads_per_edge):
+        pads.append(
+            Pad(
+                x=-half_span + j * pitch,
+                y=pad_center_offset,
+                width=pad_short,
+                height=pad_long,
+                net=500 + j,
+                net_name=f"NET{500 + j}",
+                ref="U2",
+                pin=str(pin_no),
+                layer=Layer.F_CU,
+            )
+        )
+        pin_no += 1
+    return pads
+
+
+# ----------------------------------------------------------------------------
+# 1. Snap-to-cardinal selection
+# ----------------------------------------------------------------------------
+
+
+class TestComputeTargetDirection:
+    """Deterministic snap-to-cardinal of the nearest off-package pad."""
+
+    def _direction_for_target(
+        self,
+        tx: float,
+        ty: float,
+        primary: EscapeDirection = EscapeDirection.WEST,
+        allow_into_package: bool = False,
+    ) -> EscapeDirection | None:
+        pad = _west_edge_pad(net=7)
+        router = _make_router(net_target_positions={7: [(tx, ty, "Y1")]})
+        package = _make_package([pad])
+        return router._compute_target_direction(
+            pad=pad,
+            package=package,
+            primary_dir=primary,
+            allow_into_package=allow_into_package,
+        )
+
+    # NOTE: EscapeDirection.NORTH == (0, +1) in this module (y-down world
+    # frame: toward LARGER y).  The assertions below follow that vector
+    # convention, not the schematic-intuitive one.
+
+    def test_dominant_negative_x_snaps_west(self):
+        assert self._direction_for_target(-5.0, 1.0) == EscapeDirection.WEST
+
+    def test_dominant_positive_y_snaps_north(self):
+        # NORTH is along-edge for a west-edge pad (dot == 0): allowed.
+        assert self._direction_for_target(-1.0, 5.0) == EscapeDirection.NORTH
+
+    def test_dominant_negative_y_snaps_south(self):
+        assert self._direction_for_target(-1.0, -5.0) == EscapeDirection.SOUTH
+
+    def test_dominant_positive_x_is_into_package_for_west_edge(self):
+        # EAST points into the package body for a west-edge pad; the
+        # guard returns None so the caller keeps the legacy direction.
+        assert self._direction_for_target(5.0, 1.0) is None
+
+    def test_dominant_positive_x_allowed_with_into_package_flag(self):
+        assert (
+            self._direction_for_target(5.0, 1.0, allow_into_package=True)
+            == EscapeDirection.EAST
+        )
+
+    def test_exact_tie_precedence_north_beats_east(self):
+        # |dx| == |dy|, dx > 0, dy > 0: candidates {NORTH, EAST}; the
+        # documented N > E > S > W precedence picks NORTH (along-edge,
+        # passes the guard for a west-edge pad).
+        assert self._direction_for_target(3.0, 3.0) == EscapeDirection.NORTH
+
+    def test_exact_tie_precedence_east_beats_south(self):
+        # dx > 0, dy < 0: candidates {SOUTH, EAST} -> EAST.  EAST is
+        # into-package for the west edge, so assert via the unguarded
+        # variant.
+        assert (
+            self._direction_for_target(3.0, -3.0, allow_into_package=True)
+            == EscapeDirection.EAST
+        )
+        # With the guard active EAST is rejected -> None (NOT silently
+        # SOUTH: the tie-break picks first, the guard then rejects).
+        assert self._direction_for_target(3.0, -3.0) is None
+
+    def test_exact_tie_precedence_south_beats_west(self):
+        # dx < 0, dy < 0: candidates {SOUTH, WEST} -> SOUTH.
+        assert self._direction_for_target(-3.0, -3.0) == EscapeDirection.SOUTH
+
+    def test_exact_tie_precedence_north_beats_west(self):
+        # dx < 0, dy > 0: candidates {NORTH, WEST} -> NORTH.
+        assert self._direction_for_target(-3.0, 3.0) == EscapeDirection.NORTH
+
+    def test_no_map_returns_none(self):
+        pad = _west_edge_pad(net=7)
+        router = _make_router(net_target_positions=None)
+        package = _make_package([pad])
+        assert (
+            router._compute_target_direction(
+                pad=pad, package=package, primary_dir=EscapeDirection.WEST
+            )
+            is None
+        )
+
+    def test_only_same_package_pads_returns_none(self):
+        pad = _west_edge_pad(net=7)
+        router = _make_router(net_target_positions={7: [(-5.0, 0.0, "U2")]})
+        package = _make_package([pad])
+        assert (
+            router._compute_target_direction(
+                pad=pad, package=package, primary_dir=EscapeDirection.WEST
+            )
+            is None
+        )
+
+    def test_nearest_candidate_wins(self):
+        pad = _west_edge_pad(net=7)
+        # Far candidate to the south, near candidate to the west.
+        router = _make_router(
+            net_target_positions={7: [(0.0, -10.0, "C1"), (-2.0, 0.0, "Y1")]}
+        )
+        package = _make_package([pad])
+        assert (
+            router._compute_target_direction(
+                pad=pad, package=package, primary_dir=EscapeDirection.WEST
+            )
+            == EscapeDirection.WEST
+        )
+
+    def test_equidistant_candidates_break_by_xy_ascending(self):
+        pad = _west_edge_pad(net=7)
+        # Two candidates at identical distance: (-3, 0) and (3, 0).
+        # (x, y) ascending picks (-3, 0) -> WEST, deterministically.
+        router = _make_router(
+            net_target_positions={7: [(3.0, 0.0, "B"), (-3.0, 0.0, "A")]}
+        )
+        package = _make_package([pad])
+        assert (
+            router._compute_target_direction(
+                pad=pad, package=package, primary_dir=EscapeDirection.WEST
+            )
+            == EscapeDirection.WEST
+        )
+
+
+# ----------------------------------------------------------------------------
+# 2 + 3. _try_in_pad_escape: legacy equivalence and target-aware stub
+# ----------------------------------------------------------------------------
+
+
+class TestTryInPadEscapeTargetDirection:
+    """``target_direction`` redirects ONLY the inner stub."""
+
+    def _rescue(
+        self, target_direction: EscapeDirection | None
+    ) -> EscapeRoute | None:
+        router = _make_router()
+        pad = _west_edge_pad(net=7)
+        package = _make_package([pad])
+        return router._try_in_pad_escape(
+            pad=pad,
+            direction=EscapeDirection.NORTH,
+            effective_clearance=0.127,
+            escape_width=0.5,
+            package=package,
+            target_direction=target_direction,
+        )
+
+    def test_legacy_none_path_unchanged(self):
+        """``target_direction=None`` reproduces the pre-#3428 geometry:
+        stub along ``direction`` (NORTH = +y), dispatcher-supplied
+        width, route.direction == direction."""
+        route = self._rescue(None)
+        assert route is not None
+        assert route.via is not None and route.via.in_pad
+        via_x, via_y = route.via_pos
+        ex, ey = route.escape_point
+        # Stub points NORTH (+y): same x, larger y.
+        assert ex == pytest.approx(via_x, abs=1e-9)
+        assert ey > via_y
+        assert route.direction == EscapeDirection.NORTH
+        # No necking on the legacy path.
+        assert route.segments[0].width == pytest.approx(0.5)
+
+    def test_target_direction_redirects_stub_only(self):
+        legacy = self._rescue(None)
+        redirected = self._rescue(EscapeDirection.SOUTH)
+        assert legacy is not None and redirected is not None
+        # Via placement is direction-independent: identical position.
+        assert redirected.via_pos == legacy.via_pos
+        via_x, via_y = redirected.via_pos
+        ex, ey = redirected.escape_point
+        # Stub now points SOUTH (-y).
+        assert ex == pytest.approx(via_x, abs=1e-9)
+        assert ey < via_y
+        assert redirected.direction == EscapeDirection.SOUTH
+        # Stub length magnitude matches the legacy offset.
+        legacy_len = abs(legacy.escape_point[1] - legacy.via_pos[1])
+        new_len = abs(ey - via_y)
+        assert new_len == pytest.approx(legacy_len, abs=1e-9)
+
+    def test_target_aware_stub_is_necked_to_mfr_min_trace(self):
+        """Two adjacent redirected stubs at the full 0.5 mm dispatcher
+        width would touch edge-to-edge at 0.5 mm pitch; the target-aware
+        stub necks to the manufacturer minimum trace (PR #3079
+        precedent for lateral stubs)."""
+        redirected = self._rescue(EscapeDirection.SOUTH)
+        assert redirected is not None
+        # jlcpcb-tier1 min_trace is 0.127 mm.
+        assert redirected.segments[0].width == pytest.approx(0.127)
+
+
+# ----------------------------------------------------------------------------
+# Adjacent in-pad via detection (pocket-escape trigger input)
+# ----------------------------------------------------------------------------
+
+
+class TestNeighbourClaimedInPadVia:
+    def _escape_with_in_pad_via(self, pad: Pad) -> EscapeRoute:
+        via = Via(
+            x=pad.x,
+            y=pad.y,
+            drill=0.15,
+            diameter=0.3,
+            layers=(Layer.F_CU, Layer.B_CU),
+            net=pad.net,
+            net_name=pad.net_name,
+            in_pad=True,
+        )
+        return EscapeRoute(
+            pad=pad,
+            direction=EscapeDirection.WEST,
+            escape_point=(pad.x - 0.5, pad.y),
+            escape_layer=Layer.B_CU,
+            via_pos=(pad.x, pad.y),
+            via=via,
+        )
+
+    def test_adjacent_in_pad_via_detected(self):
+        router = _make_router()
+        pad = _west_edge_pad(net=7, y=0.0)
+        neighbour = _west_edge_pad(net=6, y=-0.5)
+        package = _make_package([pad, neighbour])
+        escapes = [self._escape_with_in_pad_via(neighbour)]
+        assert router._neighbour_claimed_in_pad_via(pad, package, escapes)
+
+    def test_next_but_one_pin_not_adjacent(self):
+        router = _make_router()
+        pad = _west_edge_pad(net=7, y=0.0)
+        far = _west_edge_pad(net=5, y=-1.0)  # 2 x pitch away
+        package = _make_package([pad, far])
+        escapes = [self._escape_with_in_pad_via(far)]
+        assert not router._neighbour_claimed_in_pad_via(pad, package, escapes)
+
+    def test_surface_escape_neighbour_ignored(self):
+        router = _make_router()
+        pad = _west_edge_pad(net=7, y=0.0)
+        neighbour = _west_edge_pad(net=6, y=-0.5)
+        package = _make_package([pad, neighbour])
+        surface = EscapeRoute(
+            pad=neighbour,
+            direction=EscapeDirection.WEST,
+            escape_point=(neighbour.x - 0.7, neighbour.y),
+            escape_layer=Layer.F_CU,
+        )
+        assert not router._neighbour_claimed_in_pad_via(pad, package, [surface])
+
+    def test_other_component_ignored(self):
+        router = _make_router()
+        pad = _west_edge_pad(net=7, y=0.0)
+        other = Pad(
+            x=pad.x,
+            y=pad.y - 0.5,
+            width=1.5,
+            height=0.3,
+            net=6,
+            net_name="NET6",
+            ref="U9",
+            pin="1",
+            layer=Layer.F_CU,
+        )
+        package = _make_package([pad])
+        escapes = [self._escape_with_in_pad_via(other)]
+        assert not router._neighbour_claimed_in_pad_via(pad, package, escapes)
+
+
+# ----------------------------------------------------------------------------
+# 4. Dispatcher integration: pocket-escape rescue (board-04 NRST pattern)
+# ----------------------------------------------------------------------------
+
+
+class TestPocketEscapeRescue:
+    """Board-04-like scenario on a synthetic LQFP: pin j=1 (odd index,
+    along-edge escape) violates neighbour clearance and claims an in-pad
+    via; pin j=2 (even index, clean perpendicular WEST escape) has its
+    net target far EAST across the package.  Legacy behaviour strands
+    such a pin in the west pocket; the pocket-escape rescue gives it an
+    in-pad via with an EAST-pointing inner stub."""
+
+    PITCH = 0.5
+
+    def _net_positions(
+        self, pads: list[Pad], target_for_net102: tuple[float, float] | None
+    ) -> dict[int, list[tuple[float, float, str]]]:
+        positions: dict[int, list[tuple[float, float, str]]] = {}
+        for p in pads:
+            positions.setdefault(p.net, []).append((p.x, p.y, p.ref))
+        # Net 101 (pin j=1): off-package target to the WEST (outward).
+        positions.setdefault(101, []).append((-20.0, 0.0, "C1"))
+        # Net 102 (pin j=2): optional off-package target EAST.
+        if target_for_net102 is not None:
+            tx, ty = target_for_net102
+            positions.setdefault(102, []).append((tx, ty, "J1"))
+        return positions
+
+    def _run_dispatch(
+        self, with_east_target: bool
+    ) -> tuple[list[EscapeRoute], list[Pad]]:
+        pads = _make_lqfp_west_signal_row()
+        net_target_positions = self._net_positions(
+            pads, (20.0, 0.0) if with_east_target else None
+        )
+        router = _make_router(net_target_positions=net_target_positions)
+        package = router.analyze_package(pads)
+        assert package.package_type in (
+            PackageType.QFP,
+            PackageType.TQFP,
+            PackageType.QFN,
+        )
+        escapes = router._escape_qfp_alternating(package)
+        return escapes, pads
+
+    def test_pocket_pin_rescued_with_east_stub(self):
+        escapes, pads = self._run_dispatch(with_east_target=True)
+        # Pin j=1 (net 101, odd index) must hold an in-pad via -- this is
+        # the standard violation-triggered rescue and the pocket trigger's
+        # adjacency prerequisite.
+        rescue_101 = next((e for e in escapes if e.pad.net == 101), None)
+        assert rescue_101 is not None and rescue_101.via is not None
+        assert getattr(rescue_101.via, "in_pad", False)
+
+        # Pin j=2 (net 102, even index): pocket-escape rescue fires.
+        rescue_102 = next((e for e in escapes if e.pad.net == 102), None)
+        assert rescue_102 is not None, "pocket pin must still produce an escape"
+        assert rescue_102.via is not None and getattr(
+            rescue_102.via, "in_pad", False
+        ), "pocket pin must be rescued with an in-pad via"
+        pad_102 = next(p for p in pads if p.net == 102)
+        ex, _ey = rescue_102.escape_point
+        assert ex > pad_102.x, (
+            "pocket rescue stub must point EAST (toward the net target "
+            f"across the package); escape_point={rescue_102.escape_point}, "
+            f"pad=({pad_102.x}, {pad_102.y})"
+        )
+        assert rescue_102.direction == EscapeDirection.EAST
+
+    def test_without_target_map_pocket_pin_keeps_surface_escape(self):
+        """Legacy-equivalence guard at dispatcher level: without an EAST
+        target entry, pin j=2's escape is the plain perpendicular WEST
+        surface escape (no via)."""
+        escapes, pads = self._run_dispatch(with_east_target=False)
+        rescue_102 = next((e for e in escapes if e.pad.net == 102), None)
+        assert rescue_102 is not None
+        assert rescue_102.via is None, (
+            "without target knowledge the pocket trigger must not fire; "
+            "pin keeps its legacy surface escape"
+        )
+        pad_102 = next(p for p in pads if p.net == 102)
+        assert rescue_102.escape_point[0] < pad_102.x  # WEST
+
+    def test_target_aligned_with_escape_does_not_trigger(self):
+        """A pin whose target lies WEST (same side as its escape) is not
+        pocket-rescued even when its neighbour holds an in-pad via."""
+        pads = _make_lqfp_west_signal_row()
+        positions = self._net_positions(pads, None)
+        # Net 102 target WEST: dot(target, escape) > 0 -> no trigger.
+        positions.setdefault(102, []).append((-20.0, 0.0, "J1"))
+        router = _make_router(net_target_positions=positions)
+        package = router.analyze_package(pads)
+        escapes = router._escape_qfp_alternating(package)
+        rescue_102 = next((e for e in escapes if e.pad.net == 102), None)
+        assert rescue_102 is not None
+        assert rescue_102.via is None
+
+
+# ----------------------------------------------------------------------------
+# Construction-site plumbing (Autorouter + RoutingOrchestrator)
+# ----------------------------------------------------------------------------
+
+
+class TestNetPadPositionPlumbing:
+    """Both router code paths (``kct route`` Autorouter and ``kct
+    route-auto`` RoutingOrchestrator) must supply ``net_target_positions``
+    to the EscapeRouter -- fixing only one is a known foot-gun."""
+
+    def test_orchestrator_builds_map_from_autorouter_style_pads(self):
+        from kicad_tools.router.orchestrator import RoutingOrchestrator
+
+        class _PcbLike:
+            pads = {
+                ("U1", "1"): Pad(
+                    x=1.0, y=2.0, width=0.3, height=1.5, net=5,
+                    net_name="A", ref="U1", pin="1",
+                ),
+                ("C1", "1"): Pad(
+                    x=4.0, y=2.0, width=0.5, height=0.5, net=5,
+                    net_name="A", ref="C1", pin="1",
+                ),
+                ("U1", "2"): Pad(
+                    x=1.0, y=3.0, width=0.3, height=1.5, net=0,
+                    net_name="", ref="U1", pin="2",
+                ),
+            }
+
+        rules = _make_rules()
+        orch = RoutingOrchestrator(pcb=_PcbLike(), rules=rules)
+        result = orch._build_net_target_positions()
+        assert result == {5: [(4.0, 2.0, "C1"), (1.0, 2.0, "U1")]}
+
+    def test_orchestrator_returns_none_for_opaque_pcb(self):
+        from kicad_tools.router.orchestrator import RoutingOrchestrator
+
+        class _Opaque:
+            pass
+
+        rules = _make_rules()
+        orch = RoutingOrchestrator(pcb=_Opaque(), rules=rules)
+        assert orch._build_net_target_positions() is None
+
+    def test_autorouter_map_skips_net_zero_and_sorts(self):
+        from kicad_tools.router.core import Autorouter
+
+        rules = _make_rules(manufacturer=None)
+        router = Autorouter(width=20.0, height=20.0, rules=rules)
+        router.pads[("R1", "2")] = Pad(
+            x=3.0, y=1.0, width=0.5, height=0.5, net=9,
+            net_name="N9", ref="R1", pin="2",
+        )
+        router.pads[("R1", "1")] = Pad(
+            x=1.0, y=1.0, width=0.5, height=0.5, net=9,
+            net_name="N9", ref="R1", pin="1",
+        )
+        router.pads[("J1", "1")] = Pad(
+            x=5.0, y=5.0, width=0.5, height=0.5, net=0,
+            net_name="", ref="J1", pin="1",
+        )
+        result = router._build_net_target_positions()
+        assert result == {9: [(1.0, 1.0, "R1"), (3.0, 1.0, "R1")]}


### PR DESCRIPTION
Closes #3428
Refs #3411 (parent stays open until a fleet pass measures board 04 at 100%)

## Summary

Board 04 (LQFP-48 0.5mm) was stuck at 8/9 with NRST stranded. Two mechanisms, both in the QFP escape path, now deliver **9/9 (100%)** under the production recipe:

1. **Target-aware in-pad stub direction** (the issue as filed). `_try_in_pad_escape` accepts `target_direction`; when supplied, only the inner-layer stub + `escape_point` change — via placement is untouched. The QFP-alternating dispatcher computes it via the new `EscapeRouter._compute_target_direction` (nearest off-package same-net pad, snapped to a cardinal; deterministic tie-breaks: nearest by (dist², x, y), larger-|delta| axis, exact-tie precedence N>E>S>W; into-package guard). Redirected stubs are necked to the manufacturer-minimum trace width (PR #3079 precedent) because at 0.5mm pitch two adjacent full-width (0.5mm) stubs touch edge-to-edge regardless of direction. `target_direction=None` is byte-identical legacy behaviour for all five call sites.
2. **Pocket-escape rescue** (required by the empirical trace; subsumes a narrow slice of sibling #3429). Redirecting OSC_OUT's stub alone did NOT free NRST — verified by forcing NORTH/SOUTH/WEST stubs: all 8/9. NRST's real failure is that its parity-WEST surface escape walks AWAY from its target (J1.5, east) into a dead-end pocket whose only via slot OSC_IN already owns. New trigger (all conditions must hold, so other boards keep byte-identical escapes): standard rescue did NOT fire + non-pour net + immediately adjacent same-package pin already claimed an in-pad via + snapped target direction has negative dot with the parity escape direction. The pin then gets its own in-pad (micro-)via with the stub pointed at the target (`allow_into_package=True`: under-package inner-layer space is open for SMD packages).

Plumbing: `net_pad_positions` (net id -> [(x, y, ref)]) wired at **both** construction sites — `Autorouter._escape` (core.py, `kct route`) and `RoutingOrchestrator` (both ctor sites, `kct route-auto`) — per the known router code-path split.

## Curator call-site question answered

The firing call site for U2.6 is `_escape_qfp_alternating:2513` via `Autorouter.generate_escape_routes` (core.py:11053), with `direction=NORTH` — OSC_OUT sits at odd index **i=1** in the *filtered* west-pad list (plane pads removed), resolving the #3411 index discrepancy (the i=2 reconstruction included pads the dispatcher filters out).

## Verification

- **Board 04 production recipe** (`--mfr jlcpcb-tier1 --auto-fix --auto-layers --auto-mfr-tier --placement-feedback --micro-via-in-pad-fallback --seed 42`): **9/9 (100%)** on 2 layers; NRST routed U2.7 -> in-pad micro-via -> B.Cu east under U2 -> J1.5. Log: `In-pad escape generated for pad NRST (F.Cu ref=U2 pin=7): via at (126.838, 122.250) -> B.Cu, stub dir=EAST (target-aware, Issue #3428)` + `POCKET-ESCAPE in-pad rescue for U2 pin 7`.
- **DRC**: blocking-error set of the routed output is identical to the pre-change baseline (4 seg-seg + 1 seg-via, all SWCLK/SWO, pre-existing on main — filed **#3433**); NRST's connectivity error is GONE. No new violations from the redirected/necked stubs. NOTE: the committed `stm32_devboard_routed.kicad_pcb` is NOT regenerated here — today's main commits the #3433 overlaps, which would trip the CI floor of 0 for unrelated reasons.
- **Baselines**: board 02 manufacturable PASS; board 06 determinism PASS; softstart reach-regression PASS. Board 03 baseline and 2 softstart manufacturable tests fail **identically on unmodified main** (board 03: 10/13 on both main and this branch — pre-existing drift, evidence posted to #3433). Escape suite: 69 passed. Orchestrator suite: 113 passed, 1 pre-existing failure (also fails on main).
- **Determinism**: two seed-42 runs produce identical segment/via geometry sets (368/368 segments equal). Byte-identical files are not achievable on main either: uuids are regenerated per run and segment emission order varies identically on unmodified main (1446 vs 1470 reorder lines) — the board-06 determinism gate measures DRC-count stability, which passes.
- **New tests** (`tests/router/test_escape_target_direction.py`, 26 tests): snap-to-cardinal quadrants + exact ties, into-package guard + allow_into_package, nearest/equidistant tie-breaks, legacy-None byte-equivalence of `_try_in_pad_escape`, stub-only redirect (via position invariant), necking, `_neighbour_claimed_in_pad_via` adjacency, dispatcher-level pocket rescue (fires with east target; does NOT fire without target map or with aligned target), and construction-site plumbing for both router paths.

## Sibling-issue note (per curator request)

#3429/#3430 scenarios after this fix: the pocket-escape trigger implemented here IS a narrow, target-gated form of #3429's adjacent-pin conflict detection — it was empirically required for 9/9 (stub redirect alone left NRST at 8/9 in all three directions). The broader #3429 (conflict detection when the target ALSO points at a needy neighbour) and #3430 (lateral-via fallback) scenarios were not observed on board 04 after this change; they remain optional hardening.

## Test plan

- [x] Board 04 production recipe reaches 9/9, NRST routed, capture U2.6/U2.7 escape logs
- [x] No new DRC violations vs pre-change baseline (pre-existing #3433 set unchanged, NRST connectivity error removed)
- [x] Boards 02/06 + softstart-reach baselines green; board 03 + softstart-manufacturable failures reproduced on unmodified main (pre-existing, #3433)
- [x] Seed-42 geometry determinism (identical segment sets); file-order/uuid variance shown pre-existing on main
- [x] Unit tests for direction choice, legacy equivalence, pocket trigger, plumbing (26 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)