### PR TITLE
test(router): fix fine-pitch clearance local-vs-CI divergence (closes #3427)

### DIFF
--- a/tests/test_fine_pitch_clearance.py
+++ b/tests/test_fine_pitch_clearance.py
@@ -134,12 +134,44 @@ class TestFinePitchClearanceReduction:
             grid_resolution=0.05,
         )
 
-    def test_fine_pitch_pads_use_reduced_clearance(self, fine_pitch_rules):
-        """0.65mm pitch SSOP pads should use reduced clearance envelope."""
+    def test_fine_pitch_pads_use_reduced_clearance(self):
+        """0.65mm pitch SSOP pads should use reduced clearance envelope.
+
+        Updated for Issue #2865 / PR #2866 (narrow-channel guard): the
+        shrink to ``min_trace_width / 2`` is now applied only when the
+        resulting inter-pad channel can host a trace at full clearance:
+
+            effective_channel = pitch - 2 * (min_trace_width/2) - trace_width
+            required_channel  = 2 * trace_clearance + trace_width
+
+        The original rules here (trace_width=0.2, trace_clearance=0.15)
+        give effective=0.323 < required=0.5, so the guard correctly
+        declines the shrink and blocks the channel -- that behavior is
+        covered by tests/test_grid_narrow_channel_guard.py.  This test
+        now uses relaxed-but-realistic rules where the channel IS
+        feasible, preserving the original Issue #1778 intent: verify the
+        shrink opens the channel when it is geometrically sound.
+        """
+        rules = DesignRules(
+            trace_width=0.15,
+            trace_clearance=0.1,
+            via_drill=0.3,
+            via_diameter=0.6,
+            grid_resolution=0.05,
+            # Fine-pitch settings
+            fine_pitch_clearance=0.127,
+            fine_pitch_threshold=0.8,
+            min_trace_width=0.127,
+            neck_down_threshold=0.8,
+        )
+        # Guard feasibility for these rules at 0.65mm pitch:
+        #   effective_channel = 0.65 - 2*0.0635 - 0.15 = 0.373
+        #   required_channel  = 2*0.1 + 0.15 = 0.35
+        #   0.373 >= 0.35 -> shrink permitted
         grid = RoutingGrid(
             width=10.0,
             height=4.0,
-            rules=fine_pitch_rules,
+            rules=rules,
             origin_x=-5.0,
             origin_y=-2.0,
         )
@@ -283,10 +315,22 @@ class TestFinePitchGridAccess:
     """Tests that A* can find paths between adjacent fine-pitch pads."""
 
     def test_ssop_row_has_passable_cells_between_pads(self):
-        """A row of 0.65mm SSOP pads should have passable cells between them."""
+        """A row of 0.65mm SSOP pads should have passable cells between them.
+
+        Updated for Issue #2865 / PR #2866 (narrow-channel guard): the
+        original rules (trace_width=0.2, trace_clearance=0.15) make the
+        0.65mm inter-pad channel geometrically infeasible (effective
+        0.323 < required 0.5), so the guard now correctly declines the
+        shrink and blocks every gap; that behavior is covered by
+        tests/test_grid_narrow_channel_guard.py.  This test uses
+        relaxed-but-realistic rules where the channel is feasible
+        (effective 0.373 >= required 0.35), preserving the Issue #1778
+        intent: A* must be able to thread between fine-pitch pads when
+        the shrink is geometrically sound.
+        """
         rules = DesignRules(
-            trace_width=0.2,
-            trace_clearance=0.15,
+            trace_width=0.15,
+            trace_clearance=0.1,
             via_drill=0.3,
             via_diameter=0.6,
             grid_resolution=0.05,


### PR DESCRIPTION
## Summary

Fixes the two pre-existing failures in `tests/test_fine_pitch_clearance.py` flagged by the #3426 judge.

### Divergence mechanism (identified)

**There is no local-vs-CI divergence — CI fails these exact tests too.** The `Test` job in `.github/workflows/ci.yml` runs the test step with `continue-on-error: true` (line 71), so the job reports green despite failures. Verified in CI run 27235563106 on main: both tests FAILED there with the identical assertion message, alongside **160 other failures + 30 errors** (`162 failed, 18675 passed`), all masked. Not a platform, marker, hash-seed, or C++-backend difference (reproduced locally with and without the native extension — identical failure).

Closing the mechanism fully means removing `continue-on-error: true`, which requires first fixing/triaging the other 160 failures — far out of scope here. Filed as a follow-up issue (linked below in comments).

### Stale-vs-defect classification (per test)

Both tests: **stale expectations, not a router defect.**

- `test_fine_pitch_pads_use_reduced_clearance` — written for Issue #1778 (PR #1781). PR #2866 (2026-05-13, Issue #2865) added the narrow-channel guard: the `min_trace_width/2` shrink applies only when `pitch - 2*(min_trace_width/2) - trace_width >= 2*trace_clearance + trace_width`. With the test's rules (trace_width=0.2, trace_clearance=0.15): effective 0.323 < required 0.5 → the guard intentionally declines the shrink and blocks the channel (a trace threaded there would fail DRC). The test was never updated for #2866.
- `test_ssop_row_has_passable_cells_between_pads` — identical mechanism, same rules.

### Fix

Updated both tests to relaxed-but-realistic rules (trace_width=0.15, trace_clearance=0.1) where the channel IS guard-feasible (effective 0.373 >= required 0.35), preserving the original #1778 intent: verify the shrink opens the inter-pad channel when geometrically sound. The infeasible-rules blocking behavior is already covered by `tests/test_grid_narrow_channel_guard.py` (added by PR #2866). Justification documented in each test docstring.

## Test plan

- [x] `pytest tests/test_fine_pitch_clearance.py tests/test_grid_narrow_channel_guard.py` — 24 passed (Python backend)
- [x] Same suite with C++ backend built (`kct build-native`) — 24 passed
- [x] `ruff check` clean; `ruff format` diff on the file is pre-existing (whole file uses compact Pad style, already flagged on main), new code is format-clean

Closes #3427

🤖 Generated with [Claude Code](https://claude.com/claude-code)