### PR TITLE
fix(router): gate RoutingOrchestrator diff_pair_map threading (closes #3432)

### DIFF
--- a/src/kicad_tools/router/orchestrator.py
+++ b/src/kicad_tools/router/orchestrator.py
@@ -129,6 +129,25 @@ class RoutingOrchestrator:
         self.net_class_map: dict[str, NetClassRouting] = net_class_map or {}
         self.max_strategy_retries = max_strategy_retries
 
+        # Issue #3432 (mirrors ``Autorouter.paired_escape_coupling`` from
+        # #3419/#3431): gate for the diff-pair paired-escape pre-pass.
+        # The pre-pass emits two tightly-coupled escape endpoints (at the
+        # intra-pair clearance) that are only routable by a COUPLED
+        # consumer (CoupledPathfinder).  The orchestrator's escape
+        # consumer is the per-net GlobalRouter (Phase 2 of
+        # ``_route_escape_then_global``) and its diff-pair strategy
+        # delegates to the per-net AdaptiveAutorouter -- there is no
+        # coupled consumer on the ``kct route-auto`` path today, so this
+        # flag defaults to False and is never flipped.  Both EscapeRouter
+        # construction sites consult it before threading
+        # ``_get_diff_pair_map()``; with the flag off they pass an empty
+        # map, matching the Autorouter's default-off behaviour and
+        # avoiding the per-net A* stranding documented in #3419 (board
+        # 06: 41% -> 27% reach).  If a coupled consumer is ever added to
+        # the route-auto path, flip this flag on BEFORE the escape phase
+        # (escapes are generated lazily).
+        self.paired_escape_coupling: bool = False
+
         # Lazy-initialized routers (created on first use)
         self._global_router: GlobalRouter | None = None
         self._hierarchical: AdaptiveAutorouter | None = None
@@ -761,10 +780,18 @@ class RoutingOrchestrator:
                     manufacturer=getattr(self.rules, "manufacturer", None),
                     # Issue #2639 / Epic #2556 Phase 2F: thread the
                     # diff-pair partner map into the escape router for
-                    # coupled-at-launch escape routes.  ``_get_diff_pair_map``
-                    # returns {} when no pairs are detected, preserving
-                    # pre-#2639 single-ended behavior.
-                    diff_pair_map=self._get_diff_pair_map(),
+                    # coupled-at-launch escape routes.
+                    #
+                    # Issue #3432: gated on ``paired_escape_coupling``
+                    # (mirrors core.py's ``_escape`` property, #3419).
+                    # Phase 2 of this strategy is the per-net
+                    # GlobalRouter -- no CoupledPathfinder exists on the
+                    # route-auto path, so threading the map would emit
+                    # tightly-coupled paired escape endpoints that
+                    # strand the per-net search.
+                    diff_pair_map=(
+                        self._get_diff_pair_map() if self.paired_escape_coupling else {}
+                    ),
                     # Issue #3428: net -> pad-position map for target-aware
                     # in-pad rescue stub directions.  Same wiring as the
                     # Autorouter (``kct route``) path -- the orchestrator
@@ -1419,7 +1446,12 @@ class RoutingOrchestrator:
                     manufacturer=getattr(self.rules, "manufacturer", None),
                     # Issue #2639 / Epic #2556 Phase 2F: same threading
                     # as the escape_then_global ctor site above.
-                    diff_pair_map=self._get_diff_pair_map(),
+                    #
+                    # Issue #3432: same ``paired_escape_coupling`` gate
+                    # as the escape_then_global ctor site above.
+                    diff_pair_map=(
+                        self._get_diff_pair_map() if self.paired_escape_coupling else {}
+                    ),
                     # Issue #3428: same target-aware in-pad stub wiring
                     # as the escape_then_global ctor site above.
                     net_target_positions=self._build_net_target_positions(),

--- a/tests/test_escape_diffpair.py
+++ b/tests/test_escape_diffpair.py
@@ -369,10 +369,13 @@ class TestGate2EscapeRouterCtorReceivesMap:
         assert escape.diff_pair_map == {}
 
     def test_orchestrator_ctor_sites_thread_map(self):
-        """Both orchestrator EscapeRouter construction sites pass the map.
+        """The orchestrator's ``_get_diff_pair_map`` resolves the map.
 
         Tested via a lightweight PCB-like shim that exposes the same
-        ``get_diff_pair_map`` hook the orchestrator looks up.
+        ``get_diff_pair_map`` hook the orchestrator looks up.  Note
+        (Issue #3432): the EscapeRouter ctor sites now gate the map on
+        ``paired_escape_coupling`` -- see
+        ``TestOrchestratorPairedEscapeGate`` for the threading tests.
         """
         from kicad_tools.router.orchestrator import RoutingOrchestrator
 
@@ -396,6 +399,107 @@ class TestGate2EscapeRouterCtorReceivesMap:
             "USB_D+": "USB_D-",
             "USB_D-": "USB_D+",
         }
+
+
+# =============================================================================
+# Issue #3432: RoutingOrchestrator paired-escape coupling gate
+# =============================================================================
+
+
+class TestOrchestratorPairedEscapeGate:
+    """RoutingOrchestrator gates diff_pair_map on ``paired_escape_coupling``.
+
+    Issue #3432 (mirrors the Autorouter gate from #3419/#3431): both
+    orchestrator EscapeRouter construction sites
+    (``_route_escape_then_global`` and the ``escape_router`` property)
+    must NOT thread the diff-pair map unless a coupled consumer exists
+    on the route-auto path.  The route-auto escape consumer is the
+    per-net GlobalRouter, which cannot route from the tightly-coupled
+    paired escape endpoints the pre-pass emits -- threading the map
+    unconditionally is the same stranding mechanism that regressed
+    board 06 from 41% to 27% reach on the Autorouter path.
+    """
+
+    PAIR_MAP = {"USB_D+": "USB_D-", "USB_D-": "USB_D+"}
+
+    def _build_orchestrator(self, grid, rules):
+        from kicad_tools.router.orchestrator import RoutingOrchestrator
+
+        pair_map = self.PAIR_MAP
+
+        class _ShimPcb:
+            """PCB-like shim with a real grid so the EscapeRouter ctor
+            sites actually construct (unlike the grid=None shim above)."""
+
+            def __init__(self):
+                self.grid = grid
+                self.net_names = {1: "USB_D+", 2: "USB_D-"}
+                self._edge_clearance = None
+                self._board_bbox = None
+
+            def get_diff_pair_map(self):
+                return dict(pair_map)
+
+        return RoutingOrchestrator(pcb=_ShimPcb(), rules=rules)
+
+    def test_orchestrator_escape_property_empty_map_without_coupling(self, grid, rules):
+        """Mirror of ``test_autorouter_escape_property_empty_map_without_coupling``.
+
+        ``paired_escape_coupling`` defaults to False (route-auto has no
+        CoupledPathfinder), so the ``escape_router`` property ctor site
+        must pass an empty map even though pairs ARE detected.
+        """
+        orch = self._build_orchestrator(grid, rules)
+        assert orch.paired_escape_coupling is False
+        # Pairs are detectable...
+        assert orch._get_diff_pair_map() == self.PAIR_MAP
+        # ...but the EscapeRouter must not receive them.
+        escape = orch.escape_router
+        assert isinstance(escape, EscapeRouter)
+        assert escape.diff_pair_map == {}
+
+    def test_orchestrator_escape_property_passes_map_with_coupling(self, grid, rules):
+        """If a coupled consumer is ever added to route-auto, flipping
+        the flag on before the escape phase threads the map (same
+        contract as ``Autorouter.paired_escape_coupling``)."""
+        orch = self._build_orchestrator(grid, rules)
+        orch.paired_escape_coupling = True
+        escape = orch.escape_router
+        assert escape.diff_pair_map == self.PAIR_MAP
+
+    def test_orchestrator_escape_then_global_site_empty_map_without_coupling(self, grid, rules):
+        """The ``_route_escape_then_global`` ctor site is gated too.
+
+        Phase 2 (GlobalRouter) is stubbed out so the test exercises only
+        the Phase 1 EscapeRouter construction.
+        """
+        from kicad_tools.router.strategies import RoutingResult, RoutingStrategy
+
+        orch = self._build_orchestrator(grid, rules)
+        assert orch.paired_escape_coupling is False
+        # Short-circuit Phase 2: the per-net global router is not under
+        # test here and needs board geometry the shim does not provide.
+        orch._route_global = lambda net, pads: RoutingResult(  # type: ignore[method-assign]
+            success=True,
+            net=net,
+            strategy_used=RoutingStrategy.GLOBAL_WITH_REPAIR,
+        )
+        pads = [
+            Pad(
+                x=1.0, y=1.0, width=0.4, height=0.4,
+                net=1, net_name="USB_D+",
+                layer=Layer.F_CU, ref="U1", through_hole=False,
+            ),
+            Pad(
+                x=5.0, y=5.0, width=0.4, height=0.4,
+                net=1, net_name="USB_D+",
+                layer=Layer.F_CU, ref="J1", through_hole=False,
+            ),
+        ]
+        result = orch._route_escape_then_global("USB_D+", pads)
+        assert result.success is True
+        assert orch._escape is not None
+        assert orch._escape.diff_pair_map == {}
 
 
 # =============================================================================


### PR DESCRIPTION
Closes #3432

## Summary

- Adds `RoutingOrchestrator.paired_escape_coupling` (default `False`), mirroring the `Autorouter.paired_escape_coupling` gate PR #3431 added on the `kct route` path (Issue #3419).
- Gates `diff_pair_map` threading at BOTH orchestrator EscapeRouter construction sites (`_route_escape_then_global` and the `escape_router` property): with the flag off they pass `{}` instead of `_get_diff_pair_map()`.
- Rationale: route-auto's escape consumer is the per-net GlobalRouter (Phase 2 of `_route_escape_then_global`) and `HIERARCHICAL_DIFF_PAIR` delegates to the per-net AdaptiveAutorouter — there is no CoupledPathfinder on this path, so the paired-escape pre-pass would emit tightly-coupled endpoints (at intra-pair clearance) that strand the per-net A* (the board 06 41% -> 27% mechanism from #3419). Risk was enlarged after #3431's shared odd-grid BGA detection fix made 7x7 BGA-49 packages classify as BGA on this path too.
- If a coupled consumer is ever added to route-auto, flip the flag on before the escape phase — same contract as the Autorouter gate (`escape_router` is lazy).

## Tests

New `TestOrchestratorPairedEscapeGate` in `tests/test_escape_diffpair.py`, mirroring `test_autorouter_escape_property_empty_map_without_coupling`:

- `test_orchestrator_escape_property_empty_map_without_coupling` — pairs detected, flag off (default) -> `escape_router.diff_pair_map == {}`
- `test_orchestrator_escape_property_passes_map_with_coupling` — flag on -> map threaded (future coupled consumer contract)
- `test_orchestrator_escape_then_global_site_empty_map_without_coupling` — exercises the `_route_escape_then_global` ctor site with Phase 2 stubbed

Also updated the now-stale docstring of `test_orchestrator_ctor_sites_thread_map` (it only asserts `_get_diff_pair_map` resolution).

```
tests/test_escape_diffpair.py: 49 passed
tests/test_routing_orchestrator.py + test_route_auto_fix.py + test_route_auto_persistence.py: 92 passed, 1 failed
```

The 1 failure (`test_route_hierarchical_with_intent`, `AttributeError: 'Autorouter' object has no attribute 'use_waypoint_injection'` in core.py) is pre-existing on main — fails identically with this change stashed.

## route-auto regression check (AC3)

Board 06 (`boards/06-diffpair-test`, 7x7 BGA-49 odd-grid + diff pairs), `kct route-auto --strategy escape` on U2 diff-pair nets `USB3_TX1+` and `USB3_RX2-`:

| | main (ungated) | this PR (gated) |
|---|---|---|
| USB3_TX1+ | success, 51.90mm, 6 segs | success, 51.90mm, 6 segs |
| USB3_RX2- | success, 56.11mm, 6 segs | success, 56.11mm, 6 segs |

Output `.kicad_pcb` files differ only in randomly generated segment UUIDs — routing geometry is byte-identical. No regression; no Autorouter-path changes (`core.py` untouched).

## Pre-existing lint note

`ruff check` reports 4 findings in the touched files (F401 `AdaptiveGridRouter` import in orchestrator.py, 3x C420 in test_escape_diffpair.py) — all pre-existing on main in lines this PR does not touch; left out of scope.