### PR TITLE
fix(router): _remove_conflicting_vias KiCad-8 field-order bug (closes #3447)

### DIFF
--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -3511,25 +3511,33 @@ def _remove_conflicting_vias(pcb_text: str, clearance: float) -> str:
     Returns:
         PCB text with conflicting vias removed.
     """
-    # Parse via positions and net IDs from the text
-    via_pattern = re.compile(
-        r"(\(via\s+"
-        r"\(at\s+([\d.-]+)\s+([\d.-]+)\)\s*"
-        r"\(size\s+[\d.]+\)\s*"
-        r"\(drill\s+[\d.]+\)\s*"
-        r'\(layers\s+"[^"]+"\s+"[^"]+"\)\s*'
-        r"\(net\s+(\d+)\)"
-        r"[^)]*\)[^)]*\))",
-        re.DOTALL,
-    )
+    # Issue #3447: use the same balanced-parentheses walker as
+    # ``parse_vias`` (fixed in #3446) so that fields may appear in any
+    # order.  The previous implementation used a single ordered regex
+    # that required ``(net N)`` to immediately follow ``(layers ...)``.
+    # KiCad 8+ files -- including every PCB written by ``kct route``
+    # itself -- emit ``(uuid "...")`` between ``(layers)`` and
+    # ``(net)``, so the ordered pattern matched ZERO vias on modern
+    # output and conflict detection silently no-opped.  It also missed
+    # ``(via micro ...)`` / ``blind`` / ``buried`` blocks (#3118),
+    # whose type token sits between ``via`` and ``(at ...)``.
+    from .optimizer.pcb import _extract_balanced_blocks
 
-    # Collect all vias with their positions, nets, and match spans
-    vias: list[tuple[float, float, int, re.Match]] = []  # type: ignore[type-arg]
-    for match in via_pattern.finditer(pcb_text):
-        x = float(match.group(2))
-        y = float(match.group(3))
-        net = int(match.group(4))
-        vias.append((x, y, net, match))
+    _re_at = re.compile(r"\(at\s+([\d.eE+-]+)\s+([\d.eE+-]+)\)")
+    _re_net = re.compile(r"\(net\s+(\d+)\)")
+
+    # Collect all vias with their positions, nets, and block spans
+    vias: list[tuple[float, float, int, tuple[int, int]]] = []
+    for start, end, block in _extract_balanced_blocks(pcb_text, "via"):
+        m_at = _re_at.search(block)
+        m_net = _re_net.search(block)
+        # Both core fields are required; skip malformed blocks.
+        if not (m_at and m_net):
+            continue
+        x = float(m_at.group(1))
+        y = float(m_at.group(2))
+        net = int(m_net.group(1))
+        vias.append((x, y, net, (start, end)))
 
     if len(vias) < 2:
         return pcb_text
@@ -3538,19 +3546,18 @@ def _remove_conflicting_vias(pcb_text: str, clearance: float) -> str:
     # Keep the first via encountered at each location; remove later conflicts
     spans_to_remove: list[tuple[int, int]] = []
     for i in range(len(vias)):
-        x_i, y_i, net_i, match_i = vias[i]
+        x_i, y_i, net_i, span_i = vias[i]
         # Skip vias already marked for removal
-        if (match_i.start(), match_i.end()) in spans_to_remove:
+        if span_i in spans_to_remove:
             continue
         for j in range(i + 1, len(vias)):
-            x_j, y_j, net_j, match_j = vias[j]
+            x_j, y_j, net_j, span_j = vias[j]
             if net_i == net_j:
                 continue
             dist = math.sqrt((x_i - x_j) ** 2 + (y_i - y_j) ** 2)
             if dist < clearance:
-                span = (match_j.start(), match_j.end())
-                if span not in spans_to_remove:
-                    spans_to_remove.append(span)
+                if span_j not in spans_to_remove:
+                    spans_to_remove.append(span_j)
                     logger.warning(
                         "Removed conflicting via at (%.4f, %.4f) net %d "
                         "(co-located with net %d, distance %.4fmm)",
@@ -3628,6 +3635,11 @@ def verify_output_connectivity(
     )
 
     # Parse vias: (via (at X Y) ... (net N) ...)
+    # NOTE (#3447 sweep): unlike the ordered regexes fixed in #3446
+    # (parse_vias) and #3447 (_remove_conflicting_vias), this pattern
+    # uses lazy ``.*?`` wildcards between fields, so it tolerates
+    # KiCad-8 field order (uuid before net) and via type tokens
+    # (micro/blind/buried).  Checked and intentionally left as-is.
     via_pattern = re.compile(
         r"\(via\s+"
         r".*?\(at\s+([\d.+-]+)\s+([\d.+-]+)\)"

--- a/tests/test_router_io.py
+++ b/tests/test_router_io.py
@@ -3632,3 +3632,128 @@ class TestMergeRoutesViaConflicts:
         # Without flag, both vias stay (backward compat)
         result = merge_routes_into_pcb(original, new_routes)
         assert result.count("(via") == 2
+
+
+class TestRemoveConflictingViasFieldOrder:
+    """Order-independent via conflict detection (Issue #3447).
+
+    Mirrors the parse_vias regression tests from PR #3446: the old
+    ordered regex required ``(net N)`` to immediately follow
+    ``(layers ...)``, so KiCad-8 output (uuid before net) matched zero
+    vias and conflict detection silently no-opped.  It also missed
+    ``(via micro ...)`` blocks (#3118).
+    """
+
+    # The format kct route itself writes (and KiCad 8+ saves): a
+    # multiline via block with (uuid "...") between (layers) and (net).
+    _ORIGINAL_KICAD8 = """\
+(kicad_pcb
+  (net 0 "")
+  (net 1 "VCC")
+  (net 2 "GND")
+\t(via
+\t\t(at 110.0000 110.0000)
+\t\t(size 0.6)
+\t\t(drill 0.3)
+\t\t(layers "F.Cu" "B.Cu")
+\t\t(uuid "5e6fea07-c453-4f1d-8199-2fdfb31022f0")
+\t\t(net 1)
+\t)
+)"""
+
+    def test_uuid_before_net_kicad8_writer_order(self):
+        """Conflicts must be detected when (uuid ...) precedes (net N)."""
+        new_routes = (
+            "(via (at 110.0000 110.0000) (size 0.6) (drill 0.3) "
+            '(layers "F.Cu" "B.Cu") (uuid "v2") (net 2))'
+        )
+        result = merge_routes_into_pcb(
+            self._ORIGINAL_KICAD8, new_routes, detect_via_conflicts=True, via_clearance=0.2
+        )
+        assert result.count("(via") == 1, (
+            "_remove_conflicting_vias must match via blocks whose "
+            "(uuid ...) precedes (net N) -- the order kct route itself "
+            "writes. Pre-#3447 this matched zero vias and the conflict "
+            "was silently kept."
+        )
+        assert "(net 1)" in result
+        assert '(uuid "v2")' not in result
+        assert _validate_sexp_parentheses(result), (
+            "Removal of conflicting via must not leave orphaned parentheses"
+        )
+
+    def test_mixed_kicad7_and_kicad8_order(self):
+        """Conflict between a legacy-order via and a KiCad-8-order via."""
+        original = """(kicad_pcb
+  (net 0 "")
+  (net 1 "A")
+  (net 2 "B")
+  (via (at 110.0000 110.0000) (size 0.6000) (drill 0.3000) (layers "F.Cu" "B.Cu") (net 1) (uuid "v1"))
+)"""
+        # New via in KiCad-8 order (uuid before net), same position, different net
+        new_routes = (
+            "(via (at 110.0000 110.0000) (size 0.6000) (drill 0.3000) "
+            '(layers "F.Cu" "B.Cu") (uuid "v2") (net 2))'
+        )
+        result = merge_routes_into_pcb(
+            original, new_routes, detect_via_conflicts=True, via_clearance=0.2
+        )
+        assert result.count("(via") == 1
+        assert "(net 1)" in result
+        assert _validate_sexp_parentheses(result)
+
+    def test_micro_via_conflict_detected(self):
+        """(via micro ...) blocks (#3118) participate in conflict detection."""
+        new_routes = (
+            "(via micro (at 110.0000 110.0000) (size 0.3) (drill 0.1) "
+            '(layers "F.Cu" "In1.Cu") (uuid "v2") (net 2))'
+        )
+        result = merge_routes_into_pcb(
+            self._ORIGINAL_KICAD8, new_routes, detect_via_conflicts=True, via_clearance=0.2
+        )
+        assert result.count("(via") == 1, (
+            "#3118 micro token must survive the balanced-block rewrite"
+        )
+        assert "(net 1)" in result
+        assert _validate_sexp_parentheses(result)
+
+    def test_micro_via_same_net_kept(self):
+        """Co-located micro via on the SAME net is not removed."""
+        new_routes = (
+            "(via micro (at 110.0000 110.0000) (size 0.3) (drill 0.1) "
+            '(layers "F.Cu" "In1.Cu") (uuid "v2") (net 1))'
+        )
+        result = merge_routes_into_pcb(
+            self._ORIGINAL_KICAD8, new_routes, detect_via_conflicts=True, via_clearance=0.2
+        )
+        assert result.count("(via") == 2
+
+    def test_malformed_block_skipped(self):
+        """A via block missing (at ...) is skipped, not crashed on."""
+        from kicad_tools.router.io import _remove_conflicting_vias
+
+        txt = """(kicad_pcb
+  (net 1 "A")
+  (net 2 "B")
+  (via (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 1) (uuid "v0"))
+  (via (at 110.0 110.0) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (uuid "v1") (net 1))
+  (via (at 110.0 110.0) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (uuid "v2") (net 2))
+)"""
+        result = _remove_conflicting_vias(txt, 0.2)
+        # Malformed via kept (skipped from analysis); conflicting v2 removed
+        assert '(uuid "v0")' in result
+        assert '(uuid "v1")' in result
+        assert '(uuid "v2")' not in result
+        assert _validate_sexp_parentheses(result)
+
+    def test_via_size_setup_token_not_matched(self):
+        """(via_size ...) / (via_drill ...) in setup must not be treated as vias."""
+        from kicad_tools.router.io import _remove_conflicting_vias
+
+        txt = """(kicad_pcb
+  (net 1 "A")
+  (setup (via_size 0.6) (via_drill 0.3))
+  (via (at 110.0 110.0) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (uuid "v1") (net 1))
+)"""
+        result = _remove_conflicting_vias(txt, 0.2)
+        assert result == txt


### PR DESCRIPTION
## Summary

`_remove_conflicting_vias` in `src/kicad_tools/router/io.py` used the same ordered via regex that PR #3446 fixed in `parse_vias`: it required `(net N)` to immediately follow `(layers ...)`. On KiCad-8 field order (uuid before net) — the order `kct route` itself writes — it matched ZERO vias, so post-merge co-located via conflict detection (`detect_via_conflicts=True` in `merge_routes_into_pcb`) silently no-opped. It also missed `(via micro ...)` blocks (#3118).

## Changes

- Rewrote `_remove_conflicting_vias` on the `_extract_balanced_blocks` walker from `src/kicad_tools/router/optimizer/pcb.py` (imported, not copied — avoids a third implementation), with order-independent `(at ...)` / `(net N)` field extraction and malformed-block skipping
- Added a comment at the `verify_output_connectivity` via regex (io.py ~3631) documenting that its lazy `.*?` wildcards are order-tolerant — checked per the judge sweep and intentionally left as-is
- Added `TestRemoveConflictingViasFieldOrder` (6 tests) in `tests/test_router_io.py` mirroring PR #3446's `TestParseVias`

## Ordered-regex sweep findings

Grepped `src/` for other via-block regexes:

| Location | Verdict |
|---|---|
| `router/io.py:~3515` (`_remove_conflicting_vias`) | **Bug — fixed in this PR** |
| `router/io.py:~3631` (`verify_output_connectivity`) | Order-tolerant lazy `.*?` — unaffected, comment added |
| `router/optimizer/pcb.py:179` (`parse_vias`) | Already fixed by PR #3446 |
| `export/ses.py:198` (`_parse_via`) | Specctra SES grammar (positional `(via "padstack" x y)`), not KiCad field order — unaffected |
| `router/io.py` `via_dia`/`via_drill`/`min_via_annular_width` | Single-field setup-token patterns, no ordering assumption — unaffected |

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Detects conflicts on KiCad-7 field order | PASS | Existing `TestMergeRoutesViaConflicts` (6 tests) still pass unchanged |
| Detects conflicts on KiCad-8 field order (uuid before net) | PASS | `test_uuid_before_net_kicad8_writer_order`, `test_mixed_kicad7_and_kicad8_order` |
| Handles `via micro` blocks | PASS | `test_micro_via_conflict_detected`, `test_micro_via_same_net_kept` |
| Handles malformed blocks | PASS | `test_malformed_block_skipped` (skips, no crash), `test_via_size_setup_token_not_matched` |
| Regression tests mirror PR #3446's parse_vias tests | PASS | Same fixture shape (multiline tab-indented KiCad-8 block) and naming as `TestParseVias` |
| Sweep for other ordered via regexes | PASS | Table above |
| No behavior change for working paths | PASS | Full `tests/test_router_io.py` suite: 179 passed |

## Test Plan

- `uv run pytest tests/test_router_io.py` — 179 passed (was 173; +6 new)
- `uv run pytest tests/test_optimizer_pcb_segments.py` — passed (no regression in #3446's tests)
- `uv run ruff check` / `ruff format --check` — the 9 lint errors and format drift in `io.py`/`test_router_io.py` pre-exist on main (verified via `git stash`); new code is clean

Closes #3447