### PR TITLE
fix(router): SOP rescue consumer-aware deferral + target-aware stubs for softstart GATE/UCC nets (closes #3398)

### DIFF
--- a/src/kicad_tools/router/escape.py
+++ b/src/kicad_tools/router/escape.py
@@ -67,6 +67,86 @@ logger = logging.getLogger(__name__)
 # the literal.
 FINE_PITCH_THRESHOLD_MM: float = 1.5
 
+# Issue #3398: locality radius for the consumer-aware SOP rescue deferral.
+#
+# When a rescue-only-band SOP pad's net has its nearest off-package pad
+# within this distance, the P_FP6 in-pad rescue is DEFERRED and the pad
+# emits no escape geometry at all.  Empirical basis (softstart rev B,
+# Jun 2026): the UCC27211 gate-driver pins with local consumers sit
+# 2-12 mm from their targets (bootstrap caps, TVS clamps, gate
+# resistors, Kelvin-source stitches), while the genuinely-far driver
+# input nets are 20-54 mm away (MCU).  Rescuing the local-consumer pads
+# placed 19 in-pad vias whose B.Cu via field blocked the FET bus +
+# snubber routing and DROPPED reach 18 -> 8/30; the short local hops
+# route better with no canned escape at all.  15 mm splits the two
+# observed clusters with margin on both sides.
+SOP_LOCAL_CONSUMER_RADIUS_MM: float = 15.0
+
+# Issue #3398: maximum number of in-pad rescues granted per SOP row on a
+# rescue-only-band package, awarded to the candidate(s) with the FARTHEST
+# off-package consumer.  Override with the
+# ``KICAD_TOOLS_SOP_RESCUE_ROW_CAP`` environment variable (integer) for
+# reach experiments.
+#
+# DEFAULT 0 (= defer every rescue; rescue-only-band packages enter the
+# dense list but emit NO escape geometry, reproducing the pre-#3398
+# not-dense routing bit-for-bit).  This is an EMPIRICAL decision, from
+# four same-machine paired A/B measurements on softstart rev B
+# (Jun 9 2026, PYTHONHASHSEED=0, C++ backend):
+#
+#   | Config                  | L=2 (2400 s)   | L=4 (480 s floor test) |
+#   | ----------------------- | -------------- | ---------------------- |
+#   | main (no rescue)        | 17/30          | 22/30 (all attempted)  |
+#   | cap=1/row + target stub | 15/30          | --                     |
+#   | cap=1/row + perp stub   | 16/30          | 20/30 (timeout @28/30) |
+#
+# Mechanisms observed:
+#
+# - Full-row rescue (pre-cap): the U5/U6 pin 7+8 via pairs walled the
+#   rows' shared back-layer launch corridor; the pin-7 nets that route
+#   in < 3 s from their surface pads went to ``blocked_path`` after
+#   ~45 s of search each (18 -> 8/30 in the #3395 measurement).
+# - cap=1 (pin 8 only): the pin-7 nets recover, but GATE_POS_A -- the
+#   one net the rescue targets -- stays ``blocked_path`` WITH its own
+#   in-pad via, at both L=2 and L=4.  The via field does not unblock
+#   it; the binding constraint is corridor capacity near the MCU, not
+#   the driver-side launch.
+# - Wall-clock: the rescues enlarge the explorable B.Cu space around
+#   the FET pairs, slowing failed searches; at L=4 the 480 s production
+#   budget then truncates 2 nets that unmodified main has time to
+#   route (22/30 -> 20/30 with an identical blocked-set minus SWDIO).
+# - A static back-layer congestion gate cannot discriminate: softstart
+#   is all-SMD, so B.Cu is 0% occupied at escape time everywhere; the
+#   congestion that kills these nets is created dynamically during
+#   routing.
+#
+# Net: until the detailed router can exploit (rather than merely
+# tolerate) a pre-placed in-pad via field on this geometry class, the
+# correct production setting is "admit to dense list, emit nothing".
+# Keeping the band admission + this machinery means the dispatcher
+# plumbing is in place and a one-variable experiment
+# (KICAD_TOOLS_SOP_RESCUE_ROW_CAP=1) re-enables the rescue.
+SOP_RESCUE_MAX_PER_ROW: int = 0
+
+
+def _sop_rescue_row_cap() -> int:
+    """Resolve the per-row rescue cap (env override, Issue #3398)."""
+    import os
+
+    raw = os.environ.get("KICAD_TOOLS_SOP_RESCUE_ROW_CAP")
+    if raw is None:
+        return SOP_RESCUE_MAX_PER_ROW
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        logger.warning(
+            "Ignoring invalid KICAD_TOOLS_SOP_RESCUE_ROW_CAP=%r "
+            "(expected integer); using default %d.",
+            raw,
+            SOP_RESCUE_MAX_PER_ROW,
+        )
+        return SOP_RESCUE_MAX_PER_ROW
+
 
 @dataclass(frozen=True)
 class _SegmentAdapter:
@@ -241,6 +321,36 @@ def is_dense_package(
     # Fine-pitch SSOP/TSSOP check (0.75mm or less is always dense)
     # These packages need escape routing regardless of design rules
     if min_pitch <= 0.75 and _is_dual_row(pads):
+        return True
+
+    # Issue #3398: SOIC-8-class dual-row SMD band ((0.75, 1.5] mm pitch).
+    # UCC27211 / LM393 SOIC-8 at 1.27 mm pitch sit ABOVE the dynamic
+    # threshold at common power recipes (2 * (0.30 + 0.20) = 1.0 mm),
+    # so the escape pre-pass previously skipped them and the P_FP6 SOP
+    # in-pad rescue was unreachable end-to-end (Issue #3395).  The band
+    # matches :data:`FINE_PITCH_THRESHOLD_MM` (the same cap the
+    # fine-pitch classifier and ``_sop_in_pad_rescue_eligible`` use)
+    # and is deliberately narrow:
+    #
+    # - ``len(pads) >= 8``: SOIC-8 and up; SOT-23-5/6 class parts keep
+    #   their pre-#3398 classification (dynamic threshold only).
+    # - all-SMD: dual-row connectors with through-hole anchor tabs
+    #   (e.g. board 07's J1/J2 1.0 mm receptacles) are NOT SOPs and
+    #   must not enter the escape pre-pass -- their TH tabs fail this
+    #   guard.  A real SOP/SOIC body is all-SMD.
+    # - ``_is_dual_row``: quad/grid parts are handled by their own
+    #   rules above.
+    #
+    # The consumer-aware SOP rescue deferral (Issue #3398, see
+    # ``_create_staggered_row_escapes``) ensures entering the dense
+    # list does not regress nets whose consumers are local: those pads
+    # emit NO escape geometry and route exactly as before.
+    if (
+        len(pads) >= 8
+        and min_pitch <= FINE_PITCH_THRESHOLD_MM + 1e-9
+        and not any(getattr(p, "through_hole", False) for p in pads)
+        and _is_dual_row(pads)
+    ):
         return True
 
     # TQFP-32-class quad packages (issue #2513).
@@ -4520,6 +4630,184 @@ class EscapeRouter:
 
         return escapes
 
+    def _rescue_only_band_escapes(
+        self,
+        pads: list[Pad],
+        direction: EscapeDirection,
+        package: PackageInfo,
+        effective_clearance: float,
+        escape_width: float,
+        rescue_eligible: bool,
+    ) -> list[EscapeRoute]:
+        """Consumer-aware in-pad rescues for one rescue-only-band SOP row.
+
+        Issue #3398: P_FP6's naive full-row rescue on UCC27211 SOIC-8
+        placed 19 in-pad vias around the softstart FET pairs and dropped
+        reach 18 -> 8/30 -- the via field blocked the GATE/UCC/VGATE
+        nets whose consumers sit 2-12 mm away (bootstrap caps, TVS
+        clamps, gate resistors).  The rescue's value proposition (free
+        the launch corridor by escaping vertically) only pays off when
+        the net must TRAVERSE the congested neighbourhood to a far
+        consumer; for local hops the via + back-layer stub costs more
+        corridor than it frees.
+
+        Decision ladder (every "defer" emits no escape geometry at all,
+        reproducing the pre-#3398 not-dense behaviour for that pad):
+
+        1. Plane/skipped pads (``net == 0``) -> defer (pours connect
+           them; an escape would burn corridor for nothing).
+        2. Package not rescue-eligible (no fine-pitch region, tier-0
+           manufacturer, pitch/headroom fail) -> defer all.
+        3. No off-package consumer information in
+           ``net_target_positions`` -> defer (cannot prove the rescue
+           helps; the conservative choice is the pre-#3398 behaviour).
+        4. Nearest off-package consumer within
+           :data:`SOP_LOCAL_CONSUMER_RADIUS_MM` -> defer (local hop).
+        5. Row cap (:data:`SOP_RESCUE_MAX_PER_ROW`, env-overridable via
+           ``KICAD_TOOLS_SOP_RESCUE_ROW_CAP``): among the surviving
+           far-consumer candidates, only the pad(s) with the FARTHEST
+           consumer get the rescue; the rest defer.  The DEFAULT cap is
+           0 -- defer everything -- because four same-machine paired
+           A/B measurements on softstart rev B showed every
+           rescue-firing configuration is net-negative under production
+           budgets (see the :data:`SOP_RESCUE_MAX_PER_ROW` comment for
+           the measurement table and mechanisms).
+        6. Winner -> attempt :meth:`_try_in_pad_escape`.  The stub
+           direction comes from :meth:`_compute_target_direction`
+           (Issue #3428 machinery) but is only honoured when it agrees
+           with the row's outward perpendicular -- a stub running ALONG
+           the row axis sweeps the row's shared back-layer launch
+           corridor (the Jun 9 A/B failure geometry), so perpendicular
+           targets fall back to the legacy outward stub.  ``None`` from
+           the rescue -> that pad emits nothing and the next-farthest
+           candidate is tried (the cap counts SUCCESSFUL rescues).
+
+        Args:
+            pads: Row of pads sorted by position.
+            direction: Outward perpendicular escape direction for this
+                row (legacy stub direction when the target map has no
+                opinion).
+            package: Package context.
+            effective_clearance: Launch clearance from the caller (per-
+                ref fine-pitch value when a region matched).
+            escape_width: Stub trace width from the caller.
+            rescue_eligible: Package-level
+                :meth:`_sop_in_pad_rescue_eligible` result.
+
+        Returns:
+            At most :data:`SOP_RESCUE_MAX_PER_ROW` in-pad
+            ``EscapeRoute`` objects for the row (possibly empty).
+        """
+        row_cap = _sop_rescue_row_cap()
+        if not rescue_eligible or row_cap <= 0:
+            # Default (row_cap == 0, Issue #3398): every pad defers and
+            # the package routes exactly as it did before entering the
+            # dense list.  See :data:`SOP_RESCUE_MAX_PER_ROW` for the
+            # empirical A/B basis of the defer-all default.
+            return []
+
+        # Steps 1-4: collect far-consumer candidates.
+        candidates: list[tuple[float, int, Pad]] = []
+        for i, pad in enumerate(pads):
+            if pad.net == 0:
+                continue
+            positions = self.net_target_positions.get(pad.net) or []
+            off_package = [(x, y) for x, y, ref in positions if ref != package.ref]
+            if not off_package:
+                continue
+            nearest = min(math.hypot(x - pad.x, y - pad.y) for x, y in off_package)
+            if nearest <= SOP_LOCAL_CONSUMER_RADIUS_MM:
+                logger.debug(
+                    "SOP rescue deferred for %s pin %s (net %s): nearest "
+                    "off-package consumer %.2f mm <= %.2f mm locality radius "
+                    "(Issue #3398).",
+                    package.ref,
+                    pad.pin,
+                    pad.net_name,
+                    nearest,
+                    SOP_LOCAL_CONSUMER_RADIUS_MM,
+                )
+                continue
+            candidates.append((nearest, i, pad))
+
+        # Step 5: farthest consumer first; row index breaks exact ties
+        # deterministically.
+        candidates.sort(key=lambda c: (-c[0], c[1]))
+
+        routes: list[EscapeRoute] = []
+        for nearest, _i, pad in candidates:
+            if len(routes) >= row_cap:
+                logger.debug(
+                    "SOP rescue deferred for %s pin %s (net %s): row cap "
+                    "of %d rescue(s) already granted (far consumer at "
+                    "%.2f mm; Issue #3398).",
+                    package.ref,
+                    pad.pin,
+                    pad.net_name,
+                    row_cap,
+                    nearest,
+                )
+                continue
+
+            # Step 6: attempt the rescue for the winner.
+            target_dir = self._compute_target_direction(pad, package, direction)
+            # Issue #3398 (Jun 9 A/B measurement): an inner stub running
+            # ALONG the row axis (target perpendicular to the outward
+            # escape direction) sweeps the row's shared back-layer
+            # launch corridor and the sibling pads' B.Cu landing zones
+            # -- on softstart the SOUTH-pointing stubs from U5/U6 pin 8
+            # crossed the pin 5-7 column and degraded the FET-bus
+            # neighbourhood even with the row cap in place.  Only keep
+            # the target-aware override when it agrees with the outward
+            # perpendicular; otherwise fall back to the legacy
+            # perpendicular stub (``target_direction=None``) and let
+            # the main router turn toward the consumer in open space.
+            if target_dir is not None and target_dir != direction:
+                logger.debug(
+                    "SOP rescue stub for %s pin %s (net %s): target "
+                    "direction %s runs along the row axis; using outward "
+                    "perpendicular %s instead (Issue #3398).",
+                    package.ref,
+                    pad.pin,
+                    pad.net_name,
+                    target_dir.name,
+                    direction.name,
+                )
+                target_dir = None
+            in_pad_route = self._try_in_pad_escape(
+                pad=pad,
+                direction=direction,
+                effective_clearance=effective_clearance,
+                escape_width=escape_width,
+                package=package,
+                skip_on_clearance_violation=self.strict_in_pad_clearance,
+                target_direction=target_dir,
+            )
+            if in_pad_route is None:
+                logger.debug(
+                    "SOP rescue infeasible for %s pin %s (net %s): "
+                    "_try_in_pad_escape declined; trying next-farthest "
+                    "candidate (Issue #3398).",
+                    package.ref,
+                    pad.pin,
+                    pad.net_name,
+                )
+                continue
+            logger.info(
+                "SOP in-pad rescue for %s pin %s (net %s): rescue-only "
+                "band, far consumer at %.2f mm, stub direction %s, "
+                "in-pad via at (%.3f, %.3f) (Issue #3398).",
+                package.ref,
+                pad.pin,
+                pad.net_name,
+                nearest,
+                (target_dir or direction).name,
+                in_pad_route.via_pos[0] if in_pad_route.via_pos else 0.0,
+                in_pad_route.via_pos[1] if in_pad_route.via_pos else 0.0,
+            )
+            routes.append(in_pad_route)
+        return routes
+
     def _sop_in_pad_rescue_eligible(
         self,
         package: PackageInfo,
@@ -4694,6 +4982,49 @@ class EscapeRouter:
             if self.rules.min_trace_width is not None
             else self._get_trace_width_for_net(pads[0].net_name if pads else "")
         )
+
+        # Issue #3398: rescue-only band detection.  A dual-row SMD package
+        # whose pitch sits ABOVE both the always-dense 0.75 mm cap and the
+        # dynamic between-pin-trace threshold is NOT geometrically dense --
+        # a trace fits between adjacent pins at the active design rules.
+        # Such packages (UCC27211 / LM393 SOIC-8 at 1.27 mm pitch under
+        # 0.30/0.20 rules) only enter the dense list via the #3398
+        # SOIC-8-class band in :func:`is_dense_package`, and they enter it
+        # for exactly ONE reason: to give the P_FP6 in-pad rescue a chance
+        # to free the launch corridor for far-away consumers.  Emitting the
+        # legacy staggered via geometry for them would CREATE congestion
+        # where none existed (the pre-#3398 router placed no escape
+        # geometry at all and reached 18/30 on softstart; naive full-row
+        # rescue dropped it to 8/30).  Therefore rescue-only-band packages
+        # are "rescue or nothing": each pad either gets a consumer-aware
+        # in-pad rescue (far target only) or NO escape geometry.
+        dynamic_threshold = 2 * (self.rules.trace_width + self.rules.trace_clearance)
+        package_pitch = getattr(package, "pin_pitch", None) or 0.0
+        rescue_only_band = (
+            package_pitch > 0.75 + 1e-9 and package_pitch >= dynamic_threshold - 1e-9
+        )
+
+        # Issue #3398: rescue-only band -- never fall through to the
+        # staggered geometry.  Pads with local consumers, plane pads,
+        # ineligible packages, geometric rescue failures, and row-cap
+        # losers all emit NOTHING, which reproduces the pre-#3398
+        # (not-dense) routing behaviour bit-for-bit for those pads.
+        # At most ``_sop_rescue_row_cap()`` pad(s) per row -- the one(s)
+        # with the farthest off-package consumer -- get an in-pad
+        # rescue; the production default cap is 0 (defer all; see the
+        # :data:`SOP_RESCUE_MAX_PER_ROW` measurement table).
+        if rescue_only_band:
+            escapes.extend(
+                self._rescue_only_band_escapes(
+                    pads=pads,
+                    direction=direction,
+                    package=package,
+                    effective_clearance=effective_escape_clearance,
+                    escape_width=rescue_escape_width,
+                    rescue_eligible=in_pad_rescue_eligible,
+                )
+            )
+            return escapes
 
         # Calculate base escape distance and stagger offset
         base_escape_dist = effective_escape_clearance + self.rules.trace_width

--- a/tests/router/test_softstart_revb_p_fp6_dispatcher.py
+++ b/tests/router/test_softstart_revb_p_fp6_dispatcher.py
@@ -46,8 +46,10 @@ Issue: https://github.com/rjwalters/kicad-tools/issues/3390
 from __future__ import annotations
 
 import logging
+import os
 import sys
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -165,108 +167,139 @@ def test_softstart_revb_p_fp6_dispatcher_eligible(tmp_path: Path) -> None:
 def test_softstart_revb_p_fp6_dispatcher_emits_in_pad_vias(
     tmp_path: Path, caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Direct dispatch of the SOP escape generates in-pad vias on UCC27211.
+    """Dispatch is defer-all by default; env cap=1 rescues pin 8 only.
 
-    Issue #3390 AC #4 sub-check: when ``generate_escapes`` is called
-    directly on the UCC27211 SOIC-8 package (bypassing the
-    ``detect_dense_packages`` gate that excludes it from the
-    end-to-end ``route_with_escape`` pipeline), the SOP staggered
-    dispatcher produces an :class:`~kicad_tools.router.escape.EscapeRoute`
-    with a via for every pin on every signal net.  This is the
-    positive evidence that the P_FP6 wiring is correct -- the rescue
-    fires, places in-pad vias, and logs the
-    ``SOP in-pad rescue for ... (Issue #3381 / P_FP6)`` line.
+    Issue #3390 AC #4 sub-check, REVISED by Issue #3398: the UCC27211
+    SOIC-8 at 1.27 mm pitch sits in the rescue-only band (pitch above
+    the 1.0 mm dynamic threshold), so the SOP staggered dispatcher is
+    "rescue or nothing" and the rescue is consumer-aware:
+
+    - PRODUCTION DEFAULT (``KICAD_TOOLS_SOP_RESCUE_ROW_CAP`` unset =
+      cap 0): every pad defers and the packages emit NO escape
+      geometry at all -- the Jun 9 2026 same-machine A/B measurements
+      showed every rescue-firing configuration is net-negative on
+      softstart under production budgets (L=2: 17/30 main vs
+      15-16/30; L=4 floor test: 22/30 main vs 20/30).
+    - With ``KICAD_TOOLS_SOP_RESCUE_ROW_CAP=1`` (experiment mode):
+      pads whose net's nearest off-package consumer is LOCAL
+      (<= 15 mm: bootstrap caps, TVS clamps, gate resistors) defer;
+      among the FAR-consumer pads of a row (U5/U6 pins 7-8:
+      GATE_*_A/B driver inputs, 20-54 mm from the MCU) only the
+      FARTHEST one (pin 8: GATE_*_A) wins the row's single rescue.
+      Rescuing pins 7+8 together walled the row's B.Cu launch
+      corridor and turned the pin-7 nets into ``blocked_path``
+      failures (the original 18 -> 8/30 regression of #3395).
+    - U7 (LM393) has only local consumers (2-12 mm) -> zero rescues
+      at any cap.
     """
     from kicad_tools.router.escape import EscapeRouter
 
     pcb_path = _regenerate_softstart_pcb(tmp_path / "softstart_p_fp6_emit")
     router = _load_router(pcb_path)
 
-    er = EscapeRouter(router.grid, router.rules)
+    er = EscapeRouter(
+        router.grid,
+        router.rules,
+        net_target_positions=router._build_net_target_positions(),
+    )
     caplog.set_level(logging.INFO, logger="kicad_tools.router.escape")
 
-    total_vias = 0
-    total_pins = 0
-    for ref in UCC_REFS:
-        pads = [p for p in router.pads.values() if p.ref == ref]
-        package_info = er.analyze_package(pads)
-        routes = er.generate_escapes(package_info)
-        vias = sum(1 for r in routes if r.via is not None)
-        total_vias += vias
-        total_pins += len(pads)
-        # Each UCC27211 SOIC-8 has 8 pads -- but pads on net 0 (plane
-        # net) are skipped by the rescue gate.  At minimum every
-        # signal-net pad gets a via.
-        signal_pins = sum(1 for p in pads if p.net != 0)
-        assert vias >= signal_pins, (
-            f"{ref}: expected at least {signal_pins} in-pad vias "
-            f"(one per signal-net pin), got {vias}"
-        )
+    # --- Phase 1: production default (cap 0) -> NO geometry at all. ---
+    clean_env = {
+        k: v for k, v in os.environ.items()
+        if k != "KICAD_TOOLS_SOP_RESCUE_ROW_CAP"
+    }
+    with mock.patch.dict(os.environ, clean_env, clear=True):
+        for ref in UCC_REFS:
+            pads = [p for p in router.pads.values() if p.ref == ref]
+            package_info = er.analyze_package(pads)
+            routes = er.generate_escapes(package_info)
+            assert routes == [], (
+                f"{ref}: production default (row cap 0) must emit NO "
+                f"escape geometry on the rescue-only band; got "
+                f"{len(routes)} routes"
+            )
 
-    # Sanity check on log output -- at least one rescue line per ref
-    # confirms the P_FP6 path emitted the diagnostic.
+    # --- Phase 2: experiment mode (cap 1) -> pin 8 per row only. ---
+    # Expected far-consumer rescue pins per ref (Issue #3398 diag +
+    # per-row cap: pin 8's consumer is farther than pin 7's, so pin 8
+    # wins each row's single rescue).
+    expected_rescued = {
+        "U5": {"8"},   # GATE_POS_A -> MCU, 53.8 mm (beats pin 7 @ 52.5)
+        "U6": {"8"},   # GATE_NEG_A -> MCU, 21.8 mm (beats pin 7 @ 20.5)
+        "U7": set(),   # all consumers local (2-12 mm)
+    }
+
+    with mock.patch.dict(
+        os.environ, {"KICAD_TOOLS_SOP_RESCUE_ROW_CAP": "1"},
+    ):
+        for ref in UCC_REFS:
+            pads = [p for p in router.pads.values() if p.ref == ref]
+            package_info = er.analyze_package(pads)
+            routes = er.generate_escapes(package_info)
+            in_pad_pins = {
+                r.pad.pin
+                for r in routes
+                if r.via is not None and getattr(r.via, "in_pad", False)
+            }
+            assert in_pad_pins == expected_rescued[ref], (
+                f"{ref}: expected in-pad rescues exactly on far-consumer "
+                f"pins {sorted(expected_rescued[ref])}, got "
+                f"{sorted(in_pad_pins)}"
+            )
+            # Rescue-only band: no staggered fallback geometry may appear.
+            staggered = [
+                r for r in routes
+                if r.via is not None and not getattr(r.via, "in_pad", False)
+            ]
+            assert not staggered, (
+                f"{ref}: rescue-only-band package emitted "
+                f"{len(staggered)} legacy staggered escapes (Issue #3398 "
+                "requires rescue-or-nothing)"
+            )
+
+    # Sanity check on log output -- the far-consumer rescues log the
+    # ``SOP in-pad rescue`` diagnostic; U5 and U6 must each appear
+    # exactly once (cap=1 phase only; the cap-0 phase logs nothing).
     rescue_lines = [
         rec.getMessage() for rec in caplog.records
         if "SOP in-pad rescue" in rec.getMessage()
     ]
-    assert len(rescue_lines) > 0, (
-        "Expected SOP in-pad rescue log lines from the P_FP6 path"
+    assert len(rescue_lines) == 2, (
+        f"Expected exactly 2 rescue log lines (U5 pin 8 + U6 pin 8), "
+        f"got {len(rescue_lines)}: {rescue_lines}"
     )
-    # Each of U5/U6/U7 should have at least one rescue line.
-    for ref in UCC_REFS:
+    for ref in ("U5", "U6"):
         matching = [l for l in rescue_lines if f" {ref} " in l]
-        assert matching, (
-            f"Expected at least one SOP in-pad rescue log for {ref}; "
-            f"all rescue lines: {rescue_lines[:5]}"
+        assert len(matching) == 1, (
+            f"Expected 1 SOP in-pad rescue log for {ref} (per-row cap); "
+            f"all rescue lines: {rescue_lines}"
         )
 
 
-def test_softstart_revb_dispatcher_gap_documents_p_fp6_unreached(
+def test_softstart_revb_dispatcher_gate_open_for_soic8(
     tmp_path: Path,
 ) -> None:
-    """Documents the P_FP6 dispatcher-gap finding from #3390 / #3395.
+    """The #3398 SOIC-8 band classifies UCC27211/LM393 as dense.
 
-    UCC27211 SOIC-8 at 1.27 mm pitch + 0.30 mm trace + 0.20 mm
-    clearance does *not* pass
-    :func:`kicad_tools.router.escape.is_dense_package` -- the dynamic
-    threshold is ``2 * (0.30 + 0.20) = 1.0 mm`` which is below 1.27 mm.
-    Therefore ``Autorouter.detect_dense_packages`` excludes UCC27211
-    from the escape pre-pass and the P_FP6 SOP rescue path is
-    unreachable on this fixture during the actual end-to-end route.
+    History: #3390/#3395 documented the original dispatcher GAP
+    (UCC27211 at 1.27 mm pitch > dynamic threshold 1.0 mm -> not
+    dense -> P_FP6 unreachable end-to-end).  Naively opening the gate
+    regressed softstart rev B reach 18 -> 8/30 at L=2 because the
+    full-row rescue's 19-via field blocked the
+    GATE_POS/GATE_NEG/UCC_HO/UCC_LO/VGATE bus + snubber routing
+    around the FET pairs.
 
-    The wiring is correct (verified by
-    ``test_softstart_revb_p_fp6_dispatcher_emits_in_pad_vias`` above);
-    only the dispatcher gate prevents the rescue from firing.
-
-    **Why the dispatcher gap is intentional today (Issue #3395
-    investigation, Jun 9 2026):**  the gate is NOT a bug; it is
-    intentionally closed pending the P_FP6 rescue ↔ main-router
-    interaction work.  PR #XXXX investigated the architect's
-    proposed fix (raise the dual-row fine-pitch cap from 0.75 mm to
-    1.5 mm so UCC27211 SOIC-8 qualifies for the dense pre-pass) and
-    measured softstart rev B reach end-to-end:
-
-    +------------------------------+----------------+--------+
-    | Configuration                | Dense packages | Reach  |
-    +==============================+================+========+
-    | main (status quo)            | 3 packages     | 18/30  |
-    +------------------------------+----------------+--------+
-    | Threshold raised to 1.5 mm   | 6 packages     | 8/30   |
-    +------------------------------+----------------+--------+
-
-    Reach REGRESSES by 10 nets when UCC27211 SOIC-8 enters the
-    dense list.  The SOP rescue places 16 in-pad vias on U5/U6
-    signal pins (+3 on U7) as designed; the downstream detailed
-    router then cannot route GATE_POS/GATE_NEG/UCC_HO/UCC_LO/VGATE
-    because the in-pad via field collides with the tight bus +
-    snubber routing around the FET pairs.  See Issue #3398 for the
-    follow-up interaction-fix work.
-
-    When #3398 lands and the rescue no longer regresses end-to-end
-    reach, the dispatcher gate should be re-opened (re-implement the
-    threshold raise) and this test should flip from negative-control
-    to positive-assertion.  Until then, the negative assertion below
-    is the empirical record of the trade-off.
+    Issue #3398 closed the gap properly: the SOIC-8-class band in
+    :func:`kicad_tools.router.escape.is_dense_package` admits these
+    packages to the escape pre-pass, and the rescue-only-band
+    consumer-aware deferral in ``_create_staggered_row_escapes``
+    ensures they emit escape geometry ONLY for each row's single
+    farthest-consumer pad (see
+    ``test_softstart_revb_p_fp6_dispatcher_emits_in_pad_vias``).
+    This test is the flipped positive-assertion the original
+    negative-control (``..._dispatcher_gap_documents_p_fp6_unreached``)
+    promised once #3398 landed.
     """
     from kicad_tools.router.escape import is_dense_package
 
@@ -281,18 +314,15 @@ def test_softstart_revb_dispatcher_gap_documents_p_fp6_unreached(
             trace_width=router.rules.trace_width,
             clearance=router.rules.trace_clearance,
         )
-        # Issue #3395: NONE of the UCC27211 SOIC-8 packages are
-        # classified as dense under the current recipe BY DESIGN --
-        # opening the gate without the P_FP6 interaction fix (#3398)
-        # regresses end-to-end reach 18 -> 8 on this fixture.
-        assert not dense, (
-            f"{ref} is now classified as dense at trace=0.30, clearance=0.20.  "
-            "If this was intentional, the test needs updating AND the "
-            "softstart rev B reach floor "
-            "(`test_softstart_revb_reach_floor`) must be re-measured to "
-            "confirm the P_FP6 rescue ↔ main-router interaction (Issue "
-            "#3398) has been addressed.  See the docstring above for the "
-            "Jun 2026 reach-regression measurement details."
+        # Issue #3398: the SOIC-8 band (all-SMD dual-row, >= 8 pads,
+        # pitch in (0.75, 1.5] mm) now admits UCC27211/LM393 so the
+        # consumer-aware P_FP6 rescue can fire end-to-end.
+        assert dense, (
+            f"{ref} is no longer classified as dense at trace=0.30, "
+            "clearance=0.20.  The #3398 SOIC-8-class band in "
+            "is_dense_package appears to have regressed; without it "
+            "the P_FP6 SOP rescue is unreachable end-to-end and the "
+            "GATE_*_A/B reach contribution on softstart rev B is lost."
         )
 
 

--- a/tests/test_escape.py
+++ b/tests/test_escape.py
@@ -312,9 +312,25 @@ class TestIsDensePackage:
         assert len(pads) == 32
         assert is_dense_package(pads) is True
 
-    def test_sop_16_not_dense(self):
-        """SOP-16 with standard pitch is not dense."""
+    def test_sop_16_at_soic_pitch_dense_via_soic8_band(self):
+        """SOIC-16 at 1.27 mm pitch is dense via the #3398 SOIC-8-class band.
+
+        Issue #3398: all-SMD dual-row packages with >= 8 pads at
+        (0.75, 1.5] mm pitch enter the escape pre-pass so the
+        consumer-aware P_FP6 in-pad rescue can fire end-to-end.  The
+        SOP staggered dispatcher treats this band as "rescue or
+        nothing" (see ``_create_staggered_row_escapes``), so the
+        classification change emits NO escape geometry unless a
+        fine-pitch region + via-in-pad manufacturer + far consumer
+        all line up.
+        """
         pads = create_sop_pads(16, pitch=1.27)
+        assert len(pads) == 16
+        assert is_dense_package(pads) is True
+
+    def test_sop_16_wide_pitch_not_dense(self):
+        """SOP-16 at 2.54 mm pitch stays non-dense (above the SOIC band)."""
+        pads = create_sop_pads(16, pitch=2.54)
         assert len(pads) == 16
         assert is_dense_package(pads) is False
 
@@ -357,11 +373,17 @@ class TestIsDensePackage:
         assert is_dense_package(pads, trace_width=0.2, clearance=0.2) is True
 
     def test_wide_pitch_not_dense_with_clearance(self):
-        """Package with wide pitch is not dense even with clearance requirements."""
-        pads = create_sop_pads(16, pitch=1.27)  # Standard SOP
+        """Package with wide pitch is not dense even with clearance requirements.
+
+        Issue #3398: 1.27 mm now falls inside the SOIC-8-class band
+        (always dense for >= 8-pad all-SMD dual-row), so the wide-pitch
+        control uses 2.54 mm -- above both the band cap (1.5 mm) and any
+        reasonable dynamic threshold.
+        """
+        pads = create_sop_pads(16, pitch=2.54)  # Wide-pitch SOP
         assert len(pads) == 16
 
-        # 1.27mm pitch > 2 * (0.2 + 0.2) = 0.8mm threshold, so not dense
+        # 2.54mm pitch > 2 * (0.2 + 0.2) = 0.8mm threshold, so not dense
         assert is_dense_package(pads, trace_width=0.2, clearance=0.2) is False
 
     def test_dynamic_threshold_tight_clearance(self):
@@ -447,16 +469,27 @@ class TestTQFP32DenseRule:
         assert is_dense_package(pads, trace_width=0.2, clearance=0.15) is False
 
     def test_sop16_at_1_27mm_not_caught_by_tqfp32_rule(self):
-        """SOIC-16 (dual-row, 1.27mm pitch) is correctly NOT dense.
+        """SOIC-16 (dual-row, 1.27mm pitch) never reaches the TQFP-32 rule.
 
-        Confirms the TQFP-32 rule doesn't fire for non-quad layouts.
-        SOIC has fewer than 20 pins so it doesn't trigger the existing
-        multi-row dense path either.
+        Confirms the TQFP-32 rule doesn't fire for non-quad layouts:
+        a 16-pad dual-row arrangement fails both the >= 32-pin count
+        and the quad-layout check.  Issue #3398: the package IS now
+        dense, but via the SOIC-8-class band (>= 8-pad all-SMD
+        dual-row at (0.75, 1.5] mm pitch), which evaluates BEFORE the
+        TQFP-32 rule -- the wide-pitch control below proves the
+        TQFP-32 rule still does not fire once the band is out of
+        range.
         """
         pads = create_sop_pads(16, pitch=1.27)
         assert len(pads) == 16
-        assert is_dense_package(pads) is False
-        assert is_dense_package(pads, trace_width=0.2, clearance=0.15) is False
+        # Dense via the #3398 SOIC-8-class band (not the TQFP-32 rule).
+        assert is_dense_package(pads) is True
+        assert is_dense_package(pads, trace_width=0.2, clearance=0.15) is True
+        # Control: above the band cap nothing else fires for a 16-pad
+        # dual-row layout (TQFP-32 rule requires >= 32 pads + quad).
+        wide = create_sop_pads(16, pitch=2.54)
+        assert is_dense_package(wide) is False
+        assert is_dense_package(wide, trace_width=0.2, clearance=0.15) is False
 
     def test_qfn32_at_0_5mm_pitch_dense_via_fine_pitch(self):
         """QFN-32 at 0.5mm pitch is dense (fine-pitch path), not via the new rule.
@@ -1137,8 +1170,11 @@ class TestAutorouterEscapeIntegration:
                 ],
             )
 
-        # Add a non-dense package
-        sop_pads = create_sop_pads(8, pitch=1.27, ref="U2")
+        # Add a non-dense package.  Issue #3398: SOIC-pitch (1.27 mm)
+        # dual-row SMD packages with >= 8 pads are now dense via the
+        # SOIC-8-class band, so the non-dense control uses a 2.54 mm
+        # wide-pitch SOP instead.
+        sop_pads = create_sop_pads(8, pitch=2.54, ref="U2")
         for i, pad in enumerate(sop_pads):
             router.add_component(
                 "U2",
@@ -1219,9 +1255,13 @@ class TestSOPStaggeredEscape:
         grid, rules = grid_and_rules
         router = EscapeRouter(grid, rules)
 
-        # Create SOP-16 pads with 1.0mm pitch (standard SOP pitch)
-        # Note: 0.65mm pitch is now classified as SSOP with different routing
-        pads = create_sop_pads(16, pitch=1.0)
+        # Create SOP-16 pads with 0.75mm pitch (legacy dense dual-row band)
+        # Note: 0.65mm pitch is now classified as SSOP with different routing.
+        # Issue #3398: pitch 0.75mm keeps the package in the legacy always-
+        # dense dual-row band; 1.0mm would fall into the rescue-only SOIC
+        # band at these rules (dynamic threshold 0.8mm) and emit no
+        # staggered geometry at all.
+        pads = create_sop_pads(16, pitch=0.75)
         info = router.analyze_package(pads)
 
         assert info.package_type == PackageType.SOP
@@ -1236,9 +1276,13 @@ class TestSOPStaggeredEscape:
         grid, rules = grid_and_rules
         router = EscapeRouter(grid, rules)
 
-        # Create SOP pads with 1.0mm pitch (standard SOP)
-        # Note: 0.65mm pitch is now classified as SSOP with different routing
-        pads = create_sop_pads(16, pitch=1.0)
+        # Create SOP pads with 0.75mm pitch (legacy dense dual-row band)
+        # Note: 0.65mm pitch is now classified as SSOP with different routing.
+        # Issue #3398: pitch 0.75mm keeps the package in the legacy always-
+        # dense dual-row band; 1.0mm would fall into the rescue-only SOIC
+        # band at these rules (dynamic threshold 0.8mm) and emit no
+        # staggered geometry at all.
+        pads = create_sop_pads(16, pitch=0.75)
         info = router.analyze_package(pads)
         escapes = router.generate_escapes(info)
 
@@ -1252,9 +1296,13 @@ class TestSOPStaggeredEscape:
         grid, rules = grid_and_rules
         router = EscapeRouter(grid, rules)
 
-        # Create horizontal SOP (rows at different Y positions) with 1.0mm pitch
-        # Note: 0.65mm pitch is now classified as SSOP with different routing
-        pads = create_sop_pads(8, pitch=1.0)
+        # Create horizontal SOP (rows at different Y positions) with 0.75mm pitch
+        # Note: 0.65mm pitch is now classified as SSOP with different routing.
+        # Issue #3398: pitch 0.75mm keeps the package in the legacy always-
+        # dense dual-row band; 1.0mm would fall into the rescue-only SOIC
+        # band at these rules (dynamic threshold 0.8mm) and emit no
+        # staggered geometry at all.
+        pads = create_sop_pads(8, pitch=0.75)
         info = router.analyze_package(pads)
         escapes = router.generate_escapes(info)
 

--- a/tests/test_fine_pitch_p_fp6.py
+++ b/tests/test_fine_pitch_p_fp6.py
@@ -231,36 +231,61 @@ class TestStaggeredRowRescueWiring:
     """
 
     def test_eligible_geometry_triggers_in_pad_rescue(self):
-        """1.27 mm SOIC + region + tier-1 -> rescue fires on every pad."""
+        """1.27 mm SOIC + region + tier-1 + far consumers -> rescue fires.
+
+        Issue #3398: a 1.27 mm SOIC at the 0.30/0.20 recipe sits in the
+        rescue-only band (pitch >= dynamic threshold 1.0 mm), so the
+        rescue additionally requires the pad's net to have a FAR
+        off-package consumer in ``net_target_positions`` AND the row
+        grants at most ``KICAD_TOOLS_SOP_RESCUE_ROW_CAP`` rescues (here
+        pinned to 1; the production default is 0 = defer all), awarded
+        to the farthest-consumer candidate.  This test supplies one
+        consumer exactly 50 mm away for every net; the exact tie is
+        broken deterministically by row index, so pad 1 (index 0) wins
+        the row's single rescue.
+        """
         rules = _make_rules()
         router = _make_router(rules)
         pads = _ucc27211_row()
         _install_u5_region(router, pads)
         package = _FakePackage(pads, pin_pitch=1.27)
+        # Far consumers (50 mm north, different ref) for every net.
+        router.net_target_positions = {
+            p.net: [(p.x, p.y + 50.0, "J1")] for p in pads
+        }
 
-        escapes = router._create_staggered_row_escapes(
-            pads=pads, direction=EscapeDirection.NORTH, package=package,
+        with mock.patch.dict(
+            os.environ, {"KICAD_TOOLS_SOP_RESCUE_ROW_CAP": "1"},
+        ):
+            escapes = router._create_staggered_row_escapes(
+                pads=pads, direction=EscapeDirection.NORTH, package=package,
+            )
+
+        # Row cap (Issue #3398): exactly ONE rescue for the row, granted
+        # to the farthest-consumer candidate (exact 50.0 mm tie -> row
+        # index 0 -> pin "1").  In-pad rescue places the via dead-centre
+        # on the pad.
+        assert len(escapes) == 1, (
+            f"Expected exactly 1 rescue (SOP_RESCUE_MAX_PER_ROW); "
+            f"got {len(escapes)}"
         )
-
-        # Every pad has a non-zero net, so every pad should be rescued.
-        # In-pad rescue places the via dead-centre on the pad (offset 0
-        # from the pad in the launch direction).  Without P_FP6 the via
-        # would sit at pad.y + 0.44 mm (i=0, even) or pad.y + 0.84 mm
-        # (i=1, odd with stagger).
-        assert len(escapes) == 4
-        for esc in escapes:
-            assert esc.via_pos is not None
-            assert esc.via is not None
-            assert esc.via.in_pad is True, (
-                f"Expected in-pad via for pad {esc.pad.pin}; got in_pad=False"
-            )
-            via_y_offset = esc.via_pos[1] - esc.pad.y
-            # Long-axis nudge can shift the via up to a few hundred microns
-            # along the long axis; the dead-centre case yields 0.
-            assert abs(via_y_offset) < 0.50, (
-                f"Expected dead-centre in-pad via for pad {esc.pad.pin}; "
-                f"got via_y_offset={via_y_offset:.3f}mm"
-            )
+        esc = escapes[0]
+        assert esc.pad.pin == "1", (
+            f"Expected the exact-tie to resolve to row index 0 (pin 1); "
+            f"got pin {esc.pad.pin}"
+        )
+        assert esc.via_pos is not None
+        assert esc.via is not None
+        assert esc.via.in_pad is True, (
+            f"Expected in-pad via for pad {esc.pad.pin}; got in_pad=False"
+        )
+        via_y_offset = esc.via_pos[1] - esc.pad.y
+        # Long-axis nudge can shift the via up to a few hundred microns
+        # along the long axis; the dead-centre case yields 0.
+        assert abs(via_y_offset) < 0.50, (
+            f"Expected dead-centre in-pad via for pad {esc.pad.pin}; "
+            f"got via_y_offset={via_y_offset:.3f}mm"
+        )
 
     def test_ineligible_package_preserves_legacy_staggered_path(self):
         """Bare ``_FakePackage`` (no pin_pitch) -> rescue does not fire.
@@ -303,6 +328,206 @@ class TestStaggeredRowRescueWiring:
 
 
 # ============================================================================
+# 2b. Issue #3398 -- consumer-aware deferral on the rescue-only band
+# ============================================================================
+
+
+class TestRescueOnlyBandConsumerDeferral:
+    """Pin the Issue #3398 contract for rescue-only-band SOP packages.
+
+    A dual-row SMD package whose pitch exceeds both the 0.75 mm
+    always-dense cap and the dynamic between-pin-trace threshold
+    (UCC27211 SOIC-8 at 1.27 mm under 0.30/0.20 rules) is "rescue or
+    nothing": at most ``SOP_RESCUE_MAX_PER_ROW`` (= 1) pad per row --
+    the one with the farthest off-package consumer -- receives a
+    consumer-aware in-pad rescue; every other pad emits NO escape
+    geometry.  The
+    legacy staggered geometry must never be emitted for these packages
+    -- on softstart rev B it (and the unconditional full-row rescue)
+    dropped reach 18 -> 8/30 by walling the FET-bus corridor with vias.
+    """
+
+    def test_local_consumer_defers_with_no_geometry(self):
+        """Targets inside the locality radius -> pad emits nothing."""
+        rules = _make_rules()
+        router = _make_router(rules)
+        pads = _ucc27211_row()
+        _install_u5_region(router, pads)
+        package = _FakePackage(pads, pin_pitch=1.27)
+        # Local consumers 5 mm away (softstart: bootstrap caps, TVS
+        # clamps, gate resistors sit 2-12 mm from the driver pins).
+        router.net_target_positions = {
+            p.net: [(p.x, p.y + 5.0, "C21")] for p in pads
+        }
+
+        # Row cap pinned to 1 so the deferral below is attributable to
+        # the LOCALITY gate, not the default cap of 0.
+        with mock.patch.dict(
+            os.environ, {"KICAD_TOOLS_SOP_RESCUE_ROW_CAP": "1"},
+        ):
+            escapes = router._create_staggered_row_escapes(
+                pads=pads, direction=EscapeDirection.NORTH, package=package,
+            )
+        assert escapes == [], (
+            "Local-consumer pads on a rescue-only-band SOP must emit NO "
+            f"escape geometry (Issue #3398); got {len(escapes)} routes"
+        )
+
+    def test_missing_target_map_defers_with_no_geometry(self):
+        """No ``net_target_positions`` info -> conservative deferral."""
+        rules = _make_rules()
+        router = _make_router(rules)
+        pads = _ucc27211_row()
+        _install_u5_region(router, pads)
+        package = _FakePackage(pads, pin_pitch=1.27)
+        # router.net_target_positions left empty (legacy/direct callers).
+
+        with mock.patch.dict(
+            os.environ, {"KICAD_TOOLS_SOP_RESCUE_ROW_CAP": "1"},
+        ):
+            escapes = router._create_staggered_row_escapes(
+                pads=pads, direction=EscapeDirection.NORTH, package=package,
+            )
+        assert escapes == [], (
+            "Without consumer information the rescue-only band must "
+            "defer (pre-#3398 not-dense behaviour); got "
+            f"{len(escapes)} routes"
+        )
+
+    def test_plane_pads_defer_with_no_geometry(self):
+        """net == 0 pads on a rescue-only-band SOP emit nothing.
+
+        Pre-#3398 these packages were not dense, so their plane/skipped
+        pads had no staggered geometry either (softstart U7 pins 4-8).
+        """
+        rules = _make_rules()
+        router = _make_router(rules)
+        pads = _ucc27211_row()
+        for p in pads:
+            p.net = 0
+        _install_u5_region(router, pads)
+        package = _FakePackage(pads, pin_pitch=1.27)
+
+        with mock.patch.dict(
+            os.environ, {"KICAD_TOOLS_SOP_RESCUE_ROW_CAP": "1"},
+        ):
+            escapes = router._create_staggered_row_escapes(
+                pads=pads, direction=EscapeDirection.NORTH, package=package,
+            )
+        assert escapes == [], (
+            "Plane-net pads on a rescue-only-band SOP must emit NO "
+            f"escape geometry (Issue #3398); got {len(escapes)} routes"
+        )
+
+    def test_mixed_row_rescues_only_farthest_consumer_pad(self):
+        """Row cap: only the farthest-consumer pad rescues; rest defer.
+
+        Issue #3398 (row cap, Jun 9 measurement): rescuing every far-
+        consumer pad of a row walls the row's shared back-layer launch
+        corridor -- on softstart, rescuing U5/U6 pins 7+8 turned the
+        pin-7 nets (which route in < 3 s from their surface pads on
+        main) into ~45 s ``blocked_path`` failures.  With
+        ``KICAD_TOOLS_SOP_RESCUE_ROW_CAP=1`` the row grants one rescue
+        to the candidate with the farthest off-package consumer;
+        local-consumer pads and the row-cap losers emit nothing.
+        """
+        rules = _make_rules()
+        router = _make_router(rules)
+        pads = _ucc27211_row()
+        _install_u5_region(router, pads)
+        package = _FakePackage(pads, pin_pitch=1.27)
+        # Pads 1-2: local consumers; pads 3-4: far consumers (mirrors
+        # softstart U5 where only GATE_POS_A/B reach the distant MCU).
+        # Pad 4's consumer (sqrt(30^2 + 30^2) = 42.4 mm) is farther
+        # than pad 3's (40.0 mm), so pad 4 wins the row's rescue.
+        router.net_target_positions = {
+            pads[0].net: [(pads[0].x, pads[0].y + 4.0, "C21")],
+            pads[1].net: [(pads[1].x, pads[1].y + 6.0, "D_TVS1")],
+            pads[2].net: [(pads[2].x, pads[2].y + 40.0, "U1")],
+            pads[3].net: [(pads[3].x + 30.0, pads[3].y + 30.0, "U1")],
+        }
+
+        with mock.patch.dict(
+            os.environ, {"KICAD_TOOLS_SOP_RESCUE_ROW_CAP": "1"},
+        ):
+            escapes = router._create_staggered_row_escapes(
+                pads=pads, direction=EscapeDirection.NORTH, package=package,
+            )
+
+        rescued_pins = sorted(esc.pad.pin for esc in escapes)
+        assert rescued_pins == ["4"], (
+            "Expected only the farthest-consumer pad (pin 4, 42.4 mm) "
+            f"to win the row's single rescue; got pins {rescued_pins}"
+        )
+        for esc in escapes:
+            assert esc.via is not None and esc.via.in_pad is True, (
+                f"Far-consumer pad {esc.pad.pin} must use an in-pad via, "
+                "never the staggered geometry, on the rescue-only band"
+            )
+
+    def test_default_row_cap_zero_defers_everything(self):
+        """Production default (no env override) -> NO rescue ever fires.
+
+        Issue #3398 empirical decision: four same-machine paired A/B
+        measurements on softstart rev B showed every rescue-firing
+        configuration is net-negative under production budgets (L=2:
+        17/30 main vs 15-16/30 with rescues; L=4 floor test: 22/30
+        main vs 20/30 with rescues, the deficit being two
+        budget-truncated nets).  The default row cap is therefore 0:
+        rescue-only-band packages enter the dense list but emit no
+        escape geometry at all, reproducing the pre-#3398 routing
+        bit-for-bit.  ``KICAD_TOOLS_SOP_RESCUE_ROW_CAP=1`` re-enables
+        the rescue for experiments.
+        """
+        rules = _make_rules()
+        router = _make_router(rules)
+        pads = _ucc27211_row()
+        _install_u5_region(router, pads)
+        package = _FakePackage(pads, pin_pitch=1.27)
+        # Far consumers for every net -- the rescue WOULD fire if the
+        # cap allowed it (see test_eligible_geometry_triggers_in_pad_rescue).
+        router.net_target_positions = {
+            p.net: [(p.x, p.y + 50.0, "J1")] for p in pads
+        }
+
+        env = dict(os.environ)
+        env.pop("KICAD_TOOLS_SOP_RESCUE_ROW_CAP", None)
+        with mock.patch.dict(os.environ, env, clear=True):
+            escapes = router._create_staggered_row_escapes(
+                pads=pads, direction=EscapeDirection.NORTH, package=package,
+            )
+        assert escapes == [], (
+            "Default row cap (0) must defer every rescue on the "
+            f"rescue-only band; got {len(escapes)} routes"
+        )
+
+    def test_legacy_band_keeps_unconditional_first_try_rescue(self):
+        """Pitch below the dynamic threshold -> pre-#3398 behaviour.
+
+        A 0.95 mm-pitch SOP at 0.30/0.20 rules is genuinely dense
+        (0.95 < dynamic threshold 1.0), so the original P_FP6 contract
+        applies: the rescue is attempted first for every signal pad
+        with NO consumer-awareness, and the staggered geometry remains
+        the fallback.  No ``net_target_positions`` map is installed --
+        the legacy band must not consult it.
+        """
+        rules = _make_rules()
+        router = _make_router(rules)
+        pads = _ucc27211_row()
+        _install_u5_region(router, pads, pitch=0.95)
+        package = _FakePackage(pads, pin_pitch=0.95)
+
+        escapes = router._create_staggered_row_escapes(
+            pads=pads, direction=EscapeDirection.NORTH, package=package,
+        )
+
+        assert len(escapes) == len(pads), (
+            "Legacy-band SOP must emit one escape per pad "
+            f"(rescue or staggered fallback); got {len(escapes)}"
+        )
+
+
+# ============================================================================
 # 3. Regression-prevention -- micro-via fallback monotonicity on SOP path
 # ============================================================================
 
@@ -334,23 +559,38 @@ class TestSopRescueFallbackMonotonic:
 
     def test_fallback_does_not_regress_on_loose_geometry(self):
         """Toggling the flag on the no-clip geometry is a no-op."""
-        # Off baseline.
+        # Off baseline.  Issue #3398: 1.27 mm at 0.30/0.20 is the
+        # rescue-only band, so a far-consumer target map is required
+        # for the rescue (and therefore this comparison) to be
+        # non-vacuous.
         router_off = self._make_router_with_env(enabled=False)
         pads_off = _ucc27211_row()
         _install_u5_region(router_off, pads_off)
         pkg_off = _FakePackage(pads_off, pin_pitch=1.27)
-        esc_off = router_off._create_staggered_row_escapes(
-            pads=pads_off, direction=EscapeDirection.NORTH, package=pkg_off,
-        )
+        router_off.net_target_positions = {
+            p.net: [(p.x, p.y + 50.0, "J1")] for p in pads_off
+        }
+        with mock.patch.dict(
+            os.environ, {"KICAD_TOOLS_SOP_RESCUE_ROW_CAP": "1"},
+        ):
+            esc_off = router_off._create_staggered_row_escapes(
+                pads=pads_off, direction=EscapeDirection.NORTH, package=pkg_off,
+            )
 
         # On.
         router_on = self._make_router_with_env(enabled=True)
         pads_on = _ucc27211_row()
         _install_u5_region(router_on, pads_on)
         pkg_on = _FakePackage(pads_on, pin_pitch=1.27)
-        esc_on = router_on._create_staggered_row_escapes(
-            pads=pads_on, direction=EscapeDirection.NORTH, package=pkg_on,
-        )
+        router_on.net_target_positions = {
+            p.net: [(p.x, p.y + 50.0, "J1")] for p in pads_on
+        }
+        with mock.patch.dict(
+            os.environ, {"KICAD_TOOLS_SOP_RESCUE_ROW_CAP": "1"},
+        ):
+            esc_on = router_on._create_staggered_row_escapes(
+                pads=pads_on, direction=EscapeDirection.NORTH, package=pkg_on,
+            )
 
         # On the no-clip geometry the rescue must not fire either way,
         # so the routes are identical (same count, same via offsets).


### PR DESCRIPTION
Closes #3398

## Summary

Opens the P_FP6 dispatcher gate for UCC27211/LM393 SOIC-8 (the #3395 blocker) **without** the 18 -> 8/30 softstart reach regression, and answers the issue's "should the rescue defer?" question with same-machine paired A/B data: **yes, defer by default — every rescue-firing configuration measured net-negative under production budgets.**

- **`is_dense_package` SOIC-8-class band**: all-SMD dual-row, >= 8 pads, pitch in (0.75, 1.5] mm — admits UCC27211/LM393 to the escape pre-pass (TH-tab connectors and quad packages excluded by construction).
- **Rescue-only band** in `_create_staggered_row_escapes`: packages whose pitch also clears the dynamic between-pin-trace threshold never emit legacy staggered geometry — each pad either gets a consumer-aware in-pad rescue or NOTHING (pre-#3398 behaviour bit-for-bit).
- **`_rescue_only_band_escapes` decision ladder** (uses the #3434 `net_target_positions` machinery): plane pads, missing target info, local consumers (<= 15 mm: bootstrap caps, TVS clamps, gate resistors), and row-cap losers all defer; the per-row cap is awarded to the farthest-consumer pad; the target-aware stub direction is honoured only when it agrees with the outward perpendicular (along-row stubs walled the row's shared B.Cu launch corridor).
- **Production default row cap = 0 (defer all)**, env-overridable via `KICAD_TOOLS_SOP_RESCUE_ROW_CAP=1` for experiments. With cap 0 the band is provably inert: zero escape geometry is emitted, so routing inputs are identical to main.

## Measurements (same machine, PYTHONHASHSEED=0, C++ backend)

L=2, non-truncating 2400 s budget (`tests/router/measure_softstart_revb_p_fp6_reach.py`):

| Config | Reach | Blocked nets |
|---|---|---|
| main (UCC27211 not dense) | 17/30 | ISENSE_NEG, NRST, STATUS_LED, GATE_POS_A, UCC_LO_POS, SRC_POS, PRECHARGE_NEG, V_AC_SENSE_RAW |
| cap=1/row, target-aware stub | 15/30 | ISENSE_NEG, NRST, GATE_POS_A, SRC_POS, V_AC_SENSE_RAW |
| cap=1/row, perpendicular stub | 16/30 | + UCC_LO_POS |
| **cap=0 (this PR's default)** | 15/30 and 18/30 (440 s run) | superset/subset of main's — within the observed ±3-net same-config spread |

L=4 production (official `test_softstart_revb_reach_floor`, 480 s, plane-aware stack):

| Config | Reach | Notes |
|---|---|---|
| main | 22/30 | all 30 nets attempted in budget |
| cap=1/row | 20/30 (floor passes) | budget-truncated at net 28/30; blocked set SMALLER than main (SWDIO recovered) but 2 nets never attempted |
| **cap=0 (this PR's default)** | **22/30 (floor passes)** | identical to main |

Key mechanisms found (full detail in the `SOP_RESCUE_MAX_PER_ROW` comment):
1. Naive full-row rescue (the #3395 config): U5/U6 pin 7+8 via pairs wall the rows' B.Cu launch corridor; the pin-7 nets that route in < 3 s from their surface pads go `blocked_path` after ~45 s each (18 -> 8/30).
2. cap=1 (pin 8 only): pin-7 nets recover, but **GATE_POS_A — the net the rescue targets — stays `blocked_path` WITH its own in-pad via at both L=2 and L=4**; the binding constraint is corridor capacity near the MCU, not the driver-side launch.
3. Wall-clock: rescues enlarge the explorable B.Cu space around the FET pairs, slowing failed searches; under the fixed 480 s L=4 budget this truncates 2 nets main has time to route.
4. A static back-layer congestion gate (the issue's proposed extra eligibility check) cannot discriminate: softstart is all-SMD, measured 0% B.Cu occupancy at escape time around every driver pad — the killing congestion is created dynamically during routing.

## Residual gap (L=4 production, 22/30): per failure mode

- `blocked_path` (corridor capacity near MCU / sense divider): GATE_POS_A, ISENSE_NEG, V_AC_SENSE_RAW, SRC_POS, NRST, SWDIO (varies run to run with UCC_LO_POS/STATUS_LED/PRECHARGE_NEG at L=2)
- Partial connectivity (multi-pin nets, rip-up budget): ~2-3 nets/run
- Same-config run spread is ±2-3 nets (wall-clock-coupled decisions); reach deltas inside that band are not attributable.

## Acceptance criteria

- [x] UCC27211 SOIC-8 enters the dense list without reach regression (cap-0 emits zero geometry; L=4 22/30 == main; L=2 within same-config spread of main)
- [x] Softstart L=4 production >= 20/30 (measured 22/30; floor test passes)
- [x] Boards baselines: board02 manufacturable PASS, board04 routing regression PASS, softstart unaided reach PASS, softstart L=4 floor PASS
- [x] Residual-gap net list per failure mode (above)
- [x] 134 unit tests pass on the changed files; no new lint findings (5 escape.py + 5 test_escape.py findings pre-exist on HEAD)

Pre-existing failure (NOT from this PR): `test_board06_determinism.py::test_drc_counts_identical_across_five_runs` fails **identically on unmodified main** — the test invokes `check_routed_drc.py --pcb <file>` but the script's CLI now takes positional files (`error: unrecognized arguments: --pcb`). Board06 also has zero dual-row packages, so the new band structurally cannot fire there. Filing a separate issue.

## Test plan

- [x] L=2 A/B: main vs cap=1 (x2 stub variants) vs cap=0 at 2400 s; cap=0 also at default budget
- [x] L=4 A/B: main (22/30) vs cap=1 (20/30) vs cap=0 (22/30) via the official floor test
- [x] Unit: rescue-only band classification (SOIC/wide-pitch/TH/quad controls), decision ladder (local/missing/plane/row-cap/default-zero), legacy-band preservation, env override, dispatcher emit test (default-off + cap=1 phases)
- [x] Baselines: board02, board04, board06 (pre-existing CLI-drift failure reproduced on main), softstart unaided reach

🤖 Generated with [Claude Code](https://claude.com/claude-code)