### PR TITLE
fix(router): initial-pass grace pass eliminates the load-modulated budget cliff misattributed to #3442 (closes #3452)

### DIFF
--- a/src/kicad_tools/router/algorithms/__init__.py
+++ b/src/kicad_tools/router/algorithms/__init__.py
@@ -18,12 +18,16 @@ from .hierarchical import HierarchicalRouter
 from .monte_carlo import MonteCarloRouter
 from .mst import MSTRouter
 from .negotiated import (
+    GRACE_PASS_BUDGET_S,
+    GRACE_PASS_PER_NET_S,
+    GRACE_PASS_TIER_CAPS_S,
     NegotiatedRouter,
     calculate_congestion_tuned_params,
     calculate_history_increment,
     calculate_present_cost,
     detect_oscillation,
     detect_ripup_stagnation,
+    run_initial_pass_grace,
     select_seg_seg_demotion_nets,
     should_terminate_early,
 )
@@ -39,6 +43,11 @@ __all__ = [
     "RoutingChromosome",
     "TwoPhaseRouter",
     "build_rsmt",
+    # Initial-pass grace pass (Issue #3452)
+    "GRACE_PASS_BUDGET_S",
+    "GRACE_PASS_PER_NET_S",
+    "GRACE_PASS_TIER_CAPS_S",
+    "run_initial_pass_grace",
     # Adaptive parameter functions (Issue #633, #2333)
     "calculate_congestion_tuned_params",
     "calculate_history_increment",

--- a/src/kicad_tools/router/algorithms/negotiated.py
+++ b/src/kicad_tools/router/algorithms/negotiated.py
@@ -28,6 +28,100 @@ if TYPE_CHECKING:
 ProgressCallback = Callable[[str, dict], None]
 
 
+# Issue #3452: initial-pass grace-pass bounds, shared by the two
+# sequential initial passes (``core.Autorouter.route_all_negotiated`` and
+# ``two_phase.TwoPhaseRouter._route_detailed_negotiated``).  When the
+# wall-clock budget expires mid-list, the starved tail is swept in
+# escalating tiers: tier 1 gives every net a TINY per-A*-call cap so the
+# cheap majority commits in milliseconds no matter where pathological
+# searches sit in the order; tier 2 re-attempts the tier-1 failures with
+# a bigger cap from whatever budget remains.  The whole pass is bounded
+# by ``GRACE_PASS_BUDGET_S``.
+#
+# The caps are per-A*-CALL budgets, not per-net wall bounds: a failing
+# multi-edge net can legally spend several multiples of the cap
+# (cumulative-deadline RSMT edges x the pathfinder's 3x
+# ``_ESCAPE_HINT_DEADLINE_MULT`` for escape-flanked pads x relaxed-retry
+# calls -- measured ~15x on board 05's ISENSE family, where a single
+# starved ISENSE net consumed 31.2s of a 30s grace budget under a flat
+# 2.0s cap).  Tier 1's 0.3s cap keeps even that worst case to a few
+# seconds, which is why the tiny tier runs FIRST.
+GRACE_PASS_TIER_CAPS_S: tuple[float, ...] = (0.3, 2.0)
+# Total sweep bound.  Sized from the board-05 measurement: a 26-net
+# starved tail with three pathological ISENSE searches costs ~30s for
+# the first 12 tier-1 attempts under load (each failing escape-flanked
+# net legally spends ~15x the per-call cap; see above).  60s lets
+# tier 1 finish the WHOLE tail (the cheap majority) and still leaves
+# tier 2 room for second chances -- and stays small next to the ~140s
+# overrun the post-initial-pass stall-recovery path already tolerates.
+GRACE_PASS_BUDGET_S = 60.0
+# The largest (final-tier) per-call cap, re-exported for callers/tests
+# that reason about the upper bound of any single grace attempt.
+GRACE_PASS_PER_NET_S = GRACE_PASS_TIER_CAPS_S[-1]
+
+
+def run_initial_pass_grace(
+    grace_nets: list[int],
+    route_fn: Callable[[int, float], list],
+    commit_fn: Callable[[int, list], None],
+    per_net_timeout: float | None,
+) -> tuple[int, int, int]:
+    """Bounded best-effort sweep over nets starved by an initial-pass timeout.
+
+    Issue #3452: the sequential initial passes route nets in a
+    difficulty-agnostic order and used to HARD-BREAK on the wall-clock
+    check, silently dropping every net after the break point.  On board
+    05 (4L jlcpcb, seed 42) five pathological ISENSE searches burn ~190s
+    of a 420s budget, after which the remaining 24 nets route in under
+    10 seconds -- whether the budget line lands before or after that
+    window decided 28/32 vs 6/32 at the initial pass (the #3452
+    "12/32 -> 3/32" collapse, load-modulated; the #3442 in-loop pieces
+    never even execute in the collapsing runs because ``timed_out``
+    skips the iteration loop entirely).  This sweep gives each starved
+    net a bounded attempt instead of zero.
+
+    Args:
+        grace_nets: Net ids starved by the timeout, in original order.
+        route_fn: ``(net, per_net_timeout_cap) -> routes`` -- the
+            caller's single-net router.
+        commit_fn: ``(net, routes) -> None`` -- commits successful
+            routes (grid marking + bookkeeping), caller-specific.
+        per_net_timeout: The caller's own per-net budget; tier caps are
+            clamped to it so a grace attempt never receives MORE time
+            per call than the caller's normal pass would grant.
+
+    Returns:
+        ``(routed, attempted, skipped)``: nets successfully routed,
+        distinct nets given at least one attempt, and nets never
+        attempted because the grace budget ran out.
+    """
+    start = time.monotonic()
+    remaining = list(grace_nets)
+    attempted: set[int] = set()
+    routed = 0
+    out_of_budget = False
+    for tier_cap in GRACE_PASS_TIER_CAPS_S:
+        if out_of_budget or not remaining:
+            break
+        cap = min(tier_cap, per_net_timeout) if per_net_timeout else tier_cap
+        still_failing: list[int] = []
+        for idx, net in enumerate(remaining):
+            if time.monotonic() - start > GRACE_PASS_BUDGET_S:
+                out_of_budget = True
+                still_failing.extend(remaining[idx:])
+                break
+            attempted.add(net)
+            routes = route_fn(net, cap)
+            if routes:
+                routed += 1
+                commit_fn(net, routes)
+            else:
+                still_failing.append(net)
+        remaining = still_failing
+    skipped = sum(1 for n in grace_nets if n not in attempted)
+    return routed, len(attempted), skipped
+
+
 def select_seg_seg_demotion_nets(
     overlap_pairs: list[tuple[int, int]],
     demotable: set[int],

--- a/src/kicad_tools/router/algorithms/two_phase.py
+++ b/src/kicad_tools/router/algorithms/two_phase.py
@@ -16,6 +16,8 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from kicad_tools.cli.progress import flush_print
 
+from .negotiated import run_initial_pass_grace
+
 if TYPE_CHECKING:
     from kicad_tools.progress import ProgressCallback
 
@@ -501,12 +503,17 @@ class TwoPhaseRouter:
         timed_out = False
 
         # Initial routing pass
+        # Issue #3452: when the wall-clock budget expires mid-list, record
+        # the starved tail for the bounded grace pass below instead of
+        # silently dropping every remaining net.
+        grace_nets: list[int] = []
         for i, net in enumerate(net_order):
             if check_timeout():
                 flush_print(
                     f"  ⚠ Timeout during detailed routing at net {i}/{total_nets} ({elapsed_str()})"
                 )
                 timed_out = True
+                grace_nets = list(net_order[i:])
                 break
 
             net_name = self.net_names.get(net, f"Net {net}")
@@ -519,6 +526,38 @@ class TwoPhaseRouter:
                 for route in routes:
                     self.grid.mark_route_usage(route)
                     self.routes.append(route)
+
+        # Issue #3452: budget-cliff grace pass.  Net order is
+        # difficulty-agnostic, so a block of pathological searches early
+        # in ``net_order`` can exhaust the wall-clock budget before the
+        # cheap majority gets ANY attempt.  Board 05 (bldc, 4L jlcpcb,
+        # seed 42) is the measured case -- see
+        # :func:`run_initial_pass_grace` for the full rationale and the
+        # tiered-cap design.  The overrun past ``--timeout`` is bounded
+        # by ``GRACE_PASS_BUDGET_S`` (well inside the slack the recipe
+        # already tolerates from the stall-recovery path).
+        if grace_nets:
+            grace_start = time.monotonic()
+
+            def _grace_route(net: int, cap: float) -> list[Route]:
+                return self._route_net_with_corridor(
+                    net, present_factor, per_net_timeout=cap
+                )
+
+            def _grace_commit(net: int, routes: list[Route]) -> None:
+                net_routes[net] = routes
+                for route in routes:
+                    self.grid.mark_route_usage(route)
+                    self.routes.append(route)
+
+            graced, attempted, skipped = run_initial_pass_grace(
+                grace_nets, _grace_route, _grace_commit, per_net_timeout
+            )
+            flush_print(
+                f"  Grace pass: {graced}/{attempted} starved net(s) routed in "
+                f"{time.monotonic() - grace_start:.1f}s "
+                f"({skipped} skipped) (Issue #3452)"
+            )
 
         overflow = self.grid.get_total_overflow()
         flush_print(f"  Initial pass: {len(net_routes)}/{total_nets} nets, overflow: {overflow}")

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -37,6 +37,7 @@ from .algorithms import (
     calculate_history_increment,
     calculate_present_cost,
     detect_oscillation,
+    run_initial_pass_grace,
     select_seg_seg_demotion_nets,
     should_terminate_early,
 )
@@ -6596,10 +6597,15 @@ class Autorouter:
 
         else:
             # Sequential routing (original behavior)
+            # Issue #3452: when the wall-clock budget expires mid-list,
+            # record the starved tail for the bounded grace pass below
+            # instead of silently dropping every remaining net.
+            grace_nets: list[int] = []
             for i, net in enumerate(net_order):
                 if check_timeout():
                     print(f"  ⚠ Timeout reached at net {i}/{total_nets} ({elapsed_str()})")
                     timed_out = True
+                    grace_nets = list(net_order[i:])
                     break
 
                 # Progress output for every net with percentage
@@ -6620,6 +6626,38 @@ class Autorouter:
                     # Issue #2275: Update layer fill ratios after each net
                     if hasattr(self.router, "update_layer_fill_ratios"):
                         self.router.update_layer_fill_ratios()
+
+            # Issue #3452: budget-cliff grace pass.  Net order is
+            # difficulty-agnostic, so a block of pathological searches
+            # early in ``net_order`` can exhaust the wall-clock budget
+            # before the cheap majority gets ANY attempt (board 05: five
+            # ISENSE searches burn ~190s of a 420s budget, after which
+            # the remaining 24 nets route in under 10s -- the #3452
+            # 12/32 -> 3/32 collapse is that cliff, load-modulated).
+            # See :func:`run_initial_pass_grace` for the tiered-cap
+            # design and measured rationale.
+            if grace_nets:
+                grace_start = time.time()
+
+                def _grace_route(net: int, cap: float) -> list[Route]:
+                    return self._route_net_negotiated(
+                        net, present_factor, per_net_timeout=cap
+                    )
+
+                def _grace_commit(net: int, routes: list[Route]) -> None:
+                    net_routes[net] = routes
+                    for route in routes:
+                        self.grid.mark_route_usage(route)
+                        self.routes.append(route)
+
+                graced, attempted, skipped = run_initial_pass_grace(
+                    grace_nets, _grace_route, _grace_commit, per_net_timeout
+                )
+                flush_print(
+                    f"  Grace pass: {graced}/{attempted} starved net(s) routed in "
+                    f"{time.time() - grace_start:.1f}s "
+                    f"({skipped} skipped) (Issue #3452)"
+                )
 
         overflow = self.grid.get_total_overflow()
         overused = self.grid.find_overused_cells()

--- a/tests/router/test_initial_pass_grace.py
+++ b/tests/router/test_initial_pass_grace.py
@@ -1,0 +1,221 @@
+"""Tests for the initial-pass budget-cliff grace pass (Issue #3452).
+
+Structural hazard (board 05, 4L jlcpcb, seed 42 — the #3452 controlled
+A/B): the sequential initial pass routes nets in a difficulty-agnostic
+order and HARD-BREAKS the moment ``check_timeout()`` fires.  A block of
+pathological searches early in ``net_order`` (five ISENSE escapes, ~190s
+of a 420s budget) can therefore exhaust the wall clock before the cheap
+majority gets ANY attempt — on board 05 the 24 nets after the ISENSE
+block route in under 10 seconds, so whether the timeout line lands
+before or after that 10s window decides 28/32 vs 6/32 at the initial
+pass.  The #3452 "12/32 -> 3/32 in-loop regression" is this cliff,
+load-modulated: in the collapsing runs ``timed_out`` skips the rip-up
+iteration loop entirely, so the #3442 in-loop pieces (seg-seg lex tuple,
+rip-up feed) never even execute.
+
+The fix: when the budget expires mid-list, each starved net gets ONE
+A* attempt capped at ``GRACE_PASS_PER_NET_S`` seconds, with the whole
+pass bounded by ``GRACE_PASS_BUDGET_S``.  Cheap nets complete in
+milliseconds; pathological searches fail fast; the overrun past
+``--timeout`` is small and bounded.
+
+Twin implementations:
+- ``Autorouter.route_all_negotiated`` sequential initial pass (core.py)
+- ``TwoPhaseRouter._route_detailed_negotiated`` initial pass (two_phase.py)
+
+These tests drive the core.py path end-to-end (the two_phase twin is
+line-for-line the same policy against the same shared constants).
+"""
+
+from __future__ import annotations
+
+from kicad_tools.router.algorithms import (
+    GRACE_PASS_BUDGET_S,
+    GRACE_PASS_PER_NET_S,
+    GRACE_PASS_TIER_CAPS_S,
+    run_initial_pass_grace,
+)
+from kicad_tools.router.core import Autorouter
+
+
+def _build_trivial_router() -> Autorouter:
+    """Two easy 2-pad nets on an open 20x20 grid (routes in ms each)."""
+    router = Autorouter(width=20.0, height=20.0)
+    router.add_component(
+        "R1",
+        [
+            {"number": "1", "x": 2.0, "y": 10.0, "net": 1, "net_name": "NET1"},
+            {"number": "2", "x": 18.0, "y": 10.0, "net": 1, "net_name": "NET1"},
+        ],
+    )
+    router.add_component(
+        "R2",
+        [
+            {"number": "1", "x": 10.0, "y": 2.0, "net": 2, "net_name": "NET2"},
+            {"number": "2", "x": 10.0, "y": 18.0, "net": 2, "net_name": "NET2"},
+        ],
+    )
+    return router
+
+
+class TestGracePassConstants:
+    """The shared bounds must stay small: the grace pass exists to be a
+    cheap tail sweep, not a second routing budget."""
+
+    def test_per_call_caps_are_small_and_escalating(self):
+        assert all(0 < cap <= 5.0 for cap in GRACE_PASS_TIER_CAPS_S)
+        assert list(GRACE_PASS_TIER_CAPS_S) == sorted(GRACE_PASS_TIER_CAPS_S)
+        assert GRACE_PASS_TIER_CAPS_S[-1] == GRACE_PASS_PER_NET_S
+
+    def test_first_tier_is_tiny(self):
+        """Tier 1 must stay tiny: a failing net's wall time is a large
+        multiple of the per-call cap (RSMT edges x escape-hint deadline
+        x relaxed retries, ~15x measured on board 05's ISENSE family),
+        and tier 1 is what guarantees the cheap majority gets attempts
+        before any pathological net can drain the budget."""
+        assert GRACE_PASS_TIER_CAPS_S[0] <= 0.5
+
+    def test_total_budget_is_bounded(self):
+        assert 0 < GRACE_PASS_BUDGET_S <= 60.0
+
+
+class TestRunInitialPassGraceHelper:
+    """Direct tests of the shared sweep (tier escalation + accounting)."""
+
+    def test_all_cheap_nets_routed_in_tier_one(self):
+        calls: list[tuple[int, float]] = []
+        committed: dict[int, list] = {}
+        routed, attempted, skipped = run_initial_pass_grace(
+            [1, 2, 3],
+            route_fn=lambda net, cap: (calls.append((net, cap)) or [f"r{net}"]),
+            commit_fn=lambda net, routes: committed.__setitem__(net, routes),
+            per_net_timeout=30.0,
+        )
+        assert (routed, attempted, skipped) == (3, 3, 0)
+        assert sorted(committed) == [1, 2, 3]
+        # Every net succeeded on tier 1; tier 2 must not re-run them.
+        assert [c[1] for c in calls] == [GRACE_PASS_TIER_CAPS_S[0]] * 3
+
+    def test_tier_two_retries_only_failures_with_bigger_cap(self):
+        calls: list[tuple[int, float]] = []
+
+        def route_fn(net: int, cap: float) -> list:
+            calls.append((net, cap))
+            if net == 2 and cap < GRACE_PASS_TIER_CAPS_S[-1]:
+                return []  # Net 2 needs the tier-2 cap.
+            return [f"r{net}"]
+
+        routed, attempted, skipped = run_initial_pass_grace(
+            [1, 2, 3],
+            route_fn=route_fn,
+            commit_fn=lambda net, routes: None,
+            per_net_timeout=30.0,
+        )
+        assert (routed, attempted, skipped) == (3, 3, 0)
+        tier2_calls = [c for c in calls if c[1] == GRACE_PASS_TIER_CAPS_S[-1]]
+        assert tier2_calls == [(2, GRACE_PASS_TIER_CAPS_S[-1])]
+
+    def test_caps_clamped_to_caller_per_net_timeout(self):
+        """The grace pass must never grant a net MORE per-call time
+        than the caller's own per-net budget."""
+        seen_caps: set[float] = set()
+        run_initial_pass_grace(
+            [1],
+            route_fn=lambda net, cap: (seen_caps.add(cap) or []),
+            commit_fn=lambda net, routes: None,
+            per_net_timeout=0.1,
+        )
+        assert seen_caps == {0.1}
+
+    def test_budget_exhaustion_skips_remaining_nets(self, monkeypatch):
+        """A single pathological net that blows through the budget (the
+        board-05 ISENSE measurement: 31.2s under a flat 2.0s cap) must
+        not cause an unbounded sweep -- remaining nets are reported as
+        skipped."""
+        import kicad_tools.router.algorithms.negotiated as neg_mod
+
+        clock = {"now": 0.0}
+        monkeypatch.setattr(neg_mod.time, "monotonic", lambda: clock["now"])
+
+        def route_fn(net: int, cap: float) -> list:
+            # First net silently devours the whole budget.
+            clock["now"] += GRACE_PASS_BUDGET_S + 5.0
+            return []
+
+        routed, attempted, skipped = run_initial_pass_grace(
+            [1, 2, 3],
+            route_fn=route_fn,
+            commit_fn=lambda net, routes: None,
+            per_net_timeout=30.0,
+        )
+        assert routed == 0
+        assert attempted == 1
+        assert skipped == 2
+
+
+class TestInitialPassGraceEndToEnd:
+    """An immediately-expired wall clock must no longer zero the board."""
+
+    def test_expired_timeout_still_routes_cheap_nets(self):
+        """timeout so small that ``check_timeout()`` fires at net 0/N:
+        pre-#3452 the initial pass hard-broke and returned ZERO routes;
+        with the grace pass both trivial nets must still be attempted
+        (and on this open grid, routed)."""
+        ar = _build_trivial_router()
+        routes = ar.route_all_negotiated(
+            max_iterations=2,
+            timeout=1e-9,
+            adaptive=False,
+            perturbation=False,
+        )
+        routed_nets = {r.net for r in routes}
+        assert routed_nets == {1, 2}, (
+            f"Grace pass must rescue the starved tail; got routes for "
+            f"{sorted(routed_nets)}"
+        )
+
+    def test_expired_timeout_respects_per_net_timeout_floor(self):
+        """A caller-supplied ``per_net_timeout`` SMALLER than the grace
+        cap must win (the grace pass must never grant a net more time
+        than the caller's own per-net budget)."""
+        ar = _build_trivial_router()
+        routes = ar.route_all_negotiated(
+            max_iterations=2,
+            timeout=1e-9,
+            per_net_timeout=0.5,
+            adaptive=False,
+            perturbation=False,
+        )
+        # Trivial nets route far inside 0.5s; the assertion is that the
+        # combination does not crash and still rescues the tail.
+        routed_nets = {r.net for r in routes}
+        assert routed_nets == {1, 2}
+
+    def test_normal_timeout_unchanged(self):
+        """With a comfortable budget the grace pass must never engage
+        (``grace_nets`` stays empty) and behavior is identical to
+        pre-#3452: both nets route through the normal initial pass."""
+        ar = _build_trivial_router()
+        routes = ar.route_all_negotiated(
+            max_iterations=2,
+            timeout=30.0,
+            adaptive=False,
+            perturbation=False,
+        )
+        routed_nets = {r.net for r in routes}
+        assert routed_nets == {1, 2}
+
+    def test_grace_pass_logs_summary(self, capsys):
+        """The grace pass must announce itself so CI logs show when the
+        budget cliff fired (observability parity with the timeout
+        warning it follows)."""
+        ar = _build_trivial_router()
+        ar.route_all_negotiated(
+            max_iterations=2,
+            timeout=1e-9,
+            adaptive=False,
+            perturbation=False,
+        )
+        out = capsys.readouterr().out
+        assert "Grace pass:" in out
+        assert "Issue #3452" in out


### PR DESCRIPTION
Closes #3452
Refs #3442, #3450, #3449, #3444

## What the bisection found

The issue ranked three #3442 in-loop suspects. A controlled bisection (same rotated board-05 input, same `--auto-layers --max-layers 4 --starting-layers 4 --backend cpp --seed 42 --skip-nets ... --timeout 420 --per-net-timeout 30` recipe, same machine, `PYTHONHASHSEED=0`) exonerates ALL THREE:

| run | conditions | board 05 result |
|---|---|---|
| HEAD unmodified | 2-way CPU load | **3/32** (reproduces the judge's collapse; DRC profile identical: 2 pad_seg + 1 pad_via, 0 seg_seg) |
| HEAD + all 3 in-loop pieces disabled via env toggles | same 2-way load | **3/32** (no change) |
| pre-#3442 parent `10b4d5f1` | idle | **21/32**, 0 seg_seg / 0 seg_via |
| HEAD unmodified | idle | **21/32**, 0 seg_seg / 0 seg_via (same as pre-#3442) |

Decisive structural fact: in every collapsing run the rip-up **iteration loop never executes** — both auto-layer attempts time out during the *initial pass*, and `timed_out` skips the loop entirely. The #3442 lex tuple and rip-up feed literally never run; demote-to-partial never fires (judge-confirmed); the `ignore_overflow` scoping only affects the post-loop optimizer (strictly more conservative, cannot remove reach).

## The actual mechanism: a wall-clock budget cliff

The initial pass routes nets in difficulty-agnostic order and hard-breaks on `check_timeout()`. On board 05, five pathological ISENSE escape searches burn ~190s of the 420s budget — after which the remaining **24 nets route in 9.6 seconds** (measured: 166.7s -> 176.3s). Whether the budget line lands before or after that 10-second window decides 28/32 vs 6/32 at the initial pass. That knife edge is load-modulated, which is why the judge's pre/post A/B split cleanly under their session load and why identical-code CI runs flap (#3450, the board-02/03 evidence in #3452).

## Fix: bounded tiered grace pass (both sequential initial passes)

`run_initial_pass_grace` in `algorithms/negotiated.py`, shared by `core.route_all_negotiated` and the two-phase detailed pass. When the budget expires mid-list, every starved net gets a tier-1 attempt at a tiny 0.3s per-A*-call cap (the cheap majority commits in milliseconds no matter where pathological searches sit in the order), then tier-2 retries failures at 2.0s from what remains of a 60s grace budget. Caps clamp to the caller's `--per-net-timeout`. Tier 1 must be tiny because a failing escape-flanked net legally spends ~15x its per-call cap (RSMT edges x the pathfinder's 3x `_ESCAPE_HINT_DEADLINE_MULT` x relaxed retries — measured: one ISENSE net consumed 31.2s under a flat 2.0s cap).

## Re-verification (issue checklist)

- **Board 05 rotated, full recipe (timeout 420), 2-way load**: unfixed 3/32 twice -> **fixed 21/32 twice** (>= the 12/32 target), outputs overlap-free (0 seg_seg / 0 seg_via; 4 pad_seg + 1 pad_via — the judge's pre-#3442 residual classes)
- **Forced cliff (timeout 200, deterministic trigger)**: pre-#3442 3/32, HEAD 3/32 -> fixed **12/32** (with 30s grace budget) and **19-24/32** (with the final 60s budget); grace line visible in logs; outputs overlap-free
- **Board 04 (non-negotiable)**: production recipe re-route at fixed HEAD -> **9/9 routed, 0 blocking, 1 advisory connectivity** — identical profile to the committed artifact; grace pass never fires there
- **Board 02 re-baseline from #3442**: `tests/router/test_board02_manufacturable_baseline.py` **3/3 passed**
- **#3442 protections intact**: zero behavioral change to the lex tuple, rip-up feed, demote-to-partial, or collision scoping (bisect toggles removed before commit); all **21 synthetic hazard tests pass** (`tests/router/test_seg_seg_quality_tuple.py`)
- **New tests**: `tests/router/test_initial_pass_grace.py` (11 tests — tier escalation, caller-budget clamping, budget-exhaustion accounting, end-to-end rescue on an expired clock, no-engagement on healthy budgets, log observability)
- Lint: exact parity with main (127 pre-existing findings before and after; zero new)

## Pre-existing failures observed (NOT from this PR, verified against pristine main)

- `tests/router/test_board03_routing_baseline.py::test_reach_meets_floor` (10/13 vs 11 floor) — the documented #3450 pristine-main failure
- `tests/test_best_state_tracking.py` / `tests/test_adaptive_early_stop.py` (19 failures) — `FakeNegotiatedRouter` fixtures lack the #3442 `find_nets_with_segment_*` hooks; fails identically on unmodified HEAD

## Test plan
- [x] Bisect the three #3442 in-loop pieces independently on the board-05 A/B fixture
- [x] Board 05 >= 12/32 overlap-free at the issue recipe
- [x] Board 04 stays 9/9 with 0 blocking
- [x] Board 02 baseline still valid
- [x] #3442 synthetic hazard tests pass
- [x] New regression tests for the grace pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)