### PR TITLE
fix(router): CoupledPathfinder budget + aggregate-phase cap (closes #3439)

### DIFF
--- a/boards/07-matchgroup-test/generate_design.py
+++ b/boards/07-matchgroup-test/generate_design.py
@@ -663,6 +663,26 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
     # baseline; the residual gap is tracked in #3438 (reach -- now
     # with minimal 5/10/11-net repros), #3439 (coupled routing perf),
     # #3440 (match-group tuner), #3441 (auto-grid).
+    #
+    # Issue #3439 addendum (2026-06-10): the CoupledPathfinder now has
+    # (a) a corridor-bounded search mode (P side routed single-ended
+    # via the C++ backend, coupled A* restricted to the dilated
+    # corridor) and (b) an aggregate coupled-phase cap auto-derived as
+    # ``max(per_pair, 0.25 * timeout)``.  Empirical re-test with
+    # ``--differential-pairs`` on this recipe (load-contended host):
+    #   - DQS coupled search COMPLETES in ~4s (vs blowing the 60s
+    #     budget at 14k iterations before) but is rejected for the
+    #     #3320 polarity-swap centerline overlap.
+    #   - MIPI pairs still budget-exit: their P sides cannot route
+    #     single-ended at all (the #3438 reach gap), so no corridor
+    #     exists; the open search remains intractable.
+    #   - The aggregate cap fires at 150s and defers the 3 TMDS pairs;
+    #     total coupled phase = 150s vs 420s pre-#3439, and reach no
+    #     longer collapses (26-28/31 vs the 7/31 incident).
+    # ``--differential-pairs`` is now SAFE to enable (bounded, reach-
+    # preserving) but is not yet a quality win: no pair survives to a
+    # committed coupled route until #3438 (MIPI reach) and #3320
+    # (DQS swap overlap) land.  The recipe therefore still omits it.
     cmd = [
         sys.executable,
         "-m",

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -11000,12 +11000,49 @@ class Autorouter:
                 derived_per_pair_timeout,
             )
 
+        # Issue #3439: derive an AGGREGATE coupled-phase budget from
+        # --timeout when the caller has not explicitly configured one.
+        # The per-pair budget alone is insufficient containment: a board
+        # with many pathological pairs burns ``num_pairs * per_pair``
+        # of the outer budget before the single-ended main strategy
+        # runs (board 07: 7 pairs x 60s = 420s of the 600s --timeout,
+        # collapsing final reach to 7/31).  Capping the whole coupled
+        # phase at 25% of --timeout (floored at one full per-pair
+        # budget so a single pair always gets a complete attempt)
+        # guarantees the main strategy retains at least ~75% of its
+        # budget no matter how many pairs fail.
+        derived_aggregate_timeout: float | None = None
+        if (
+            timeout is not None
+            and timeout > 0
+            and diffpair_config is not None
+            and diffpair_config.enabled
+            and getattr(diffpair_config, "aggregate_timeout", None) is None
+        ):
+            per_pair_floor = (
+                diffpair_config.per_pair_timeout
+                if diffpair_config.per_pair_timeout is not None
+                else (derived_per_pair_timeout or 0.0)
+            )
+            derived_aggregate_timeout = max(
+                float(per_pair_floor), float(timeout) * 0.25
+            )
+            logger.info(
+                "DIFFPAIR_AGGREGATE_TIMEOUT_AUTODERIVED: --timeout=%.1fs; "
+                "capping the aggregate coupled diff-pair phase at %.1fs so "
+                "a failed coupled pre-pass cannot starve the single-ended "
+                "main strategy (issue #3439)",
+                float(timeout),
+                derived_aggregate_timeout,
+            )
+
         result = self._diffpair.route_all_with_diffpairs(
             diffpair_config,
             net_order,
             non_diffpair_strategy=non_diffpair_strategy,
             coupled_only=coupled_only,
             per_pair_timeout=derived_per_pair_timeout,
+            aggregate_timeout=derived_aggregate_timeout,
         )
 
         # Issue #3040 Phase B: rip-up and retry any pairs whose coupled

--- a/src/kicad_tools/router/diffpair.py
+++ b/src/kicad_tools/router/diffpair.py
@@ -591,6 +591,23 @@ class DifferentialPairConfig:
             against pathological cases) AND
             ``per_pair_max_iterations`` (as the deterministic
             classifier).  Whichever fires first triggers the exit.
+        aggregate_timeout: Issue #3439: Optional wall-clock budget
+            (seconds) for the ENTIRE coupled diff-pair phase (all
+            pairs combined).  ``per_pair_timeout`` bounds any single
+            ``CoupledPathfinder.route_coupled`` call, but a board with
+            many pathological pairs can still burn
+            ``num_pairs * per_pair_timeout`` of the outer routing
+            budget before the single-ended main strategy ever runs --
+            the board-07 7/31-reach collapse (every one of 7 pairs
+            blew its 60 s budget, consuming 420 s of the 600 s
+            ``--timeout`` before fallback).  When the aggregate budget
+            is exhausted, all remaining pairs are deferred to the main
+            strategy WITHOUT attempting coupled routing, so a failed
+            coupled pre-pass can never reduce the final reach below
+            the ``--differential-pairs``-off baseline.  ``None``
+            (default) preserves the legacy per-pair-only behaviour;
+            ``Autorouter.route_all_with_diffpairs`` auto-derives a
+            value from ``--timeout`` when this is unset.
     """
 
     enabled: bool = False
@@ -600,6 +617,7 @@ class DifferentialPairConfig:
     add_serpentines: bool = True
     per_pair_timeout: float | None = None
     per_pair_max_iterations: int | None = None
+    aggregate_timeout: float | None = None
 
     def get_rules(self, pair_type: DifferentialPairType) -> DifferentialPairRules:
         """Get rules with any config overrides applied."""

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -534,6 +534,15 @@ class CoupledPathfinder:
         # invocation.
         self.last_timeout_exceeded: bool = False
 
+        # Issue #3473 (review of #3439): number of A* iterations the
+        # most recent ``route_coupled`` call consumed.  The two-phase
+        # corridor-then-open caller charges the corridor attempt's
+        # iterations against the shared per-pair iteration budget,
+        # mirroring the wall-clock split -- otherwise a failing pair
+        # receives the FULL ``max_iterations_budget`` twice (observed
+        # 4000+4000 on board 06, doubling the diff-pair phase).
+        self.last_iterations: int = 0
+
         # Pre-calculate trace clearance radius
         self._trace_half_width_cells = max(
             1,
@@ -1160,6 +1169,8 @@ class CoupledPathfinder:
         # this immediately after ``route_coupled`` returns ``None`` to
         # decide whether to attempt an independent-routing fallback.
         self.last_timeout_exceeded = False
+        # Issue #3473: reset the iteration counter for this call.
+        self.last_iterations = 0
 
         # Convert to grid coordinates
         p_start_gx, p_start_gy = self.grid.world_to_grid(p_start.x, p_start.y)
@@ -1269,6 +1280,12 @@ class CoupledPathfinder:
 
         while open_set and iterations < max_iterations:
             iterations += 1
+            # Issue #3473: keep the public counter current on every
+            # iteration so EVERY exit path (budget, timeout, goal,
+            # exhausted open set, exceptions) reports the true cost.
+            # A single attribute store is noise next to the heap and
+            # parent-chain work in this loop body.
+            self.last_iterations = iterations
 
             # Issue #3144: iteration budget classifier check.  Sits
             # adjacent to the wall-clock check so a single ``if`` body
@@ -2284,7 +2301,12 @@ class DiffPairRouter:
             results.append(route)
         return results
 
-    def _single_ended_guide_route(self, start_pad: Pad, end_pad: Pad) -> Route | None:
+    def _single_ended_guide_route(
+        self,
+        start_pad: Pad,
+        end_pad: Pad,
+        per_net_timeout: float | None = None,
+    ) -> Route | None:
         """Route one side of a pair single-ended to seed a corridor mask.
 
         Issue #3439: the corridor-bounded coupled search needs a
@@ -2295,12 +2317,23 @@ class DiffPairRouter:
         or the route list -- it exists only to bound the coupled
         search's state space and is discarded afterwards.
 
-        Returns ``None`` when no single-ended path exists (in which
-        case the caller falls back to the unconstrained coupled
-        search) or when the pathfinder raises.
+        Issue #3473 (review of #3439): the probe is bounded by
+        ``per_net_timeout``.  It is only a guide route -- if the
+        single-ended path cannot be found quickly, the corridor
+        attempt is skipped and the legacy open search gets the budget
+        instead.  Without this, a hard P side (C++ search fails ->
+        unbounded Python fallback) consumed nearly the whole per-pair
+        budget on board 06 BEFORE either coupled attempt ran, leaving
+        the open fallback just the 1.0s floor.
+
+        Returns ``None`` when no single-ended path exists within the
+        deadline (in which case the caller falls back to the
+        unconstrained coupled search) or when the pathfinder raises.
         """
         try:
-            return self.autorouter.router.route(start_pad, end_pad)
+            return self.autorouter.router.route(
+                start_pad, end_pad, per_net_timeout=per_net_timeout
+            )
         except Exception as exc:  # pragma: no cover — defensive
             logger.debug(
                 "corridor guide route raised for %r -> %r: %s",
@@ -2309,6 +2342,16 @@ class DiffPairRouter:
                 exc,
             )
             return None
+        finally:
+            # Issue #3473 (judge note on #3439): the C++ backend's
+            # validation-failure path mutates persistent avoidance
+            # costs (``_boost_avoidance_at``); normally cleared in
+            # ``Autorouter._route_net``, which this probe bypasses.
+            # Clear them here so a failed probe cannot leak
+            # cost-shaping into subsequent searches.
+            router = self.autorouter.router
+            if hasattr(router, "clear_avoidance_costs"):
+                router.clear_avoidance_costs()
 
     def route_differential_pair_coupled(
         self,
@@ -2512,8 +2555,25 @@ class DiffPairRouter:
             spec_t0 = time.monotonic()
             result: tuple[Route, Route] | None = None
             coupled_phase = "open"
+            # Issue #3473: iterations the corridor attempt consumed,
+            # charged against the shared per-pair iteration budget so
+            # the open fallback gets the REMAINDER (not a fresh full
+            # budget -- the 4000+4000 double-spend on board 06).
+            corridor_iterations_used = 0
 
-            guide_route = self._single_ended_guide_route(spec.p_start, spec.p_end)
+            # Issue #3473: bound the probe.  It is only a guide route;
+            # give it a small slice of the corridor half-budget (an
+            # eighth of the per-pair budget, e.g. 7.5s of 60s).  If
+            # the P side cannot be routed single-ended that quickly,
+            # skip the corridor and hand the budget to the legacy
+            # open search instead of burning it before either coupled
+            # attempt runs.
+            probe_timeout = (
+                per_pair_timeout * 0.125 if per_pair_timeout is not None else None
+            )
+            guide_route = self._single_ended_guide_route(
+                spec.p_start, spec.p_end, per_net_timeout=probe_timeout
+            )
             if guide_route is not None and guide_route.segments:
                 grid = self.autorouter.grid
                 resolution = grid.resolution
@@ -2549,22 +2609,37 @@ class DiffPairRouter:
                         grid.world_to_grid(spec.n_end.x, spec.n_end.y),
                     ),
                 )
-                # Half the per-pair budget for the corridor attempt;
-                # the rest is reserved for the open-search fallback so
-                # a corridor pathology can never starve the legacy
-                # path entirely.
-                corridor_budget = (
-                    per_pair_timeout * 0.5 if per_pair_timeout is not None else None
-                )
+                # Half the per-pair budget for probe + corridor
+                # attempt combined; the rest is reserved for the
+                # open-search fallback so a corridor pathology can
+                # never starve the legacy path entirely.  Issue #3473:
+                # the probe's elapsed time is deducted from the
+                # corridor half (it already counts against the pair
+                # via ``spec_t0``), keeping probe+corridor <= ~50% of
+                # the per-pair budget instead of 62.5%.
+                corridor_budget: float | None = None
+                if per_pair_timeout is not None:
+                    corridor_budget = max(
+                        0.5,
+                        per_pair_timeout * 0.5 - (time.monotonic() - spec_t0),
+                    )
+                # Issue #3473: split the ITERATION budget the same way
+                # as the wall-clock budget -- the corridor attempt gets
+                # at most half, so a failing pair cannot spend the full
+                # budget twice (4000 corridor + 4000 open on board 06).
+                corridor_iteration_budget: int | None = None
+                if per_pair_max_iterations is not None and per_pair_max_iterations > 0:
+                    corridor_iteration_budget = max(1, per_pair_max_iterations // 2)
                 result = pathfinder.route_coupled(
                     spec.p_start,
                     spec.p_end,
                     spec.n_start,
                     spec.n_end,
                     timeout_seconds=corridor_budget,
-                    max_iterations_budget=per_pair_max_iterations,
+                    max_iterations_budget=corridor_iteration_budget,
                     corridor=corridor,
                 )
+                corridor_iterations_used = pathfinder.last_iterations
                 if result is not None:
                     coupled_phase = "corridor"
 
@@ -2574,13 +2649,23 @@ class DiffPairRouter:
                     remaining_budget = max(
                         1.0, per_pair_timeout - (time.monotonic() - spec_t0)
                     )
+                # Issue #3473: the open fallback gets the REMAINDER of
+                # the shared iteration budget.  Because the corridor
+                # attempt was capped at half, the fallback always
+                # retains at least ~half -- mirroring the wall-clock
+                # arithmetic above.
+                remaining_iterations = per_pair_max_iterations
+                if per_pair_max_iterations is not None and per_pair_max_iterations > 0:
+                    remaining_iterations = max(
+                        1, per_pair_max_iterations - corridor_iterations_used
+                    )
                 result = pathfinder.route_coupled(
                     spec.p_start,
                     spec.p_end,
                     spec.n_start,
                     spec.n_end,
                     timeout_seconds=remaining_budget,
-                    max_iterations_budget=per_pair_max_iterations,
+                    max_iterations_budget=remaining_iterations,
                 )
 
             spec_elapsed = time.monotonic() - spec_t0
@@ -3888,10 +3973,19 @@ class DiffPairRouter:
                 # the budget-exit nets would be excluded from the
                 # main strategy AND have no coupled routes, leaving
                 # them unrouted in the final PCB.
-                print(
-                    f"  Diff pairs deferred to main strategy due to "
-                    f"per-pair budget: {len(budget_exit_diff_nets) // 2}"
+                # Issue #3473 (cosmetic): aggregate-deferred pairs are
+                # also in ``budget_exit_diff_nets`` but already have
+                # their own "[diffpair-aggregate] deferred N pair(s)"
+                # print above; report only the genuinely per-pair
+                # budget exits under the per-pair label.
+                per_pair_deferred = max(
+                    0, len(budget_exit_diff_nets) // 2 - aggregate_deferred_pairs
                 )
+                if per_pair_deferred:
+                    print(
+                        f"  Diff pairs deferred to main strategy due to "
+                        f"per-pair budget: {per_pair_deferred}"
+                    )
                 diff_net_ids = diff_net_ids - budget_exit_diff_nets
 
         # Issue #3270: Surface budget-exit diff-pair nets to the

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -334,6 +334,87 @@ class CoupledNode:
     seq: int = field(compare=True, default=0)
 
 
+def build_corridor_mask(
+    grid: RoutingGrid,
+    guide_route: Route,
+    radius_cells: int,
+    extra_cells: tuple[tuple[int, int], ...] = (),
+) -> frozenset[tuple[int, int]]:
+    """Build a layer-agnostic corridor mask from a single-ended guide route.
+
+    Issue #3439: the coupled diff-pair A* searches the joint
+    ``(p_pos, n_pos)`` product state space, which is roughly quadratic
+    in the open-grid single-net search and intractable in pure Python
+    on a 4-layer 110x95 mm grid (~14k iterations/min vs the millions
+    needed).  Restricting both traces to a corridor dilated around a
+    known-routable single-ended path (found by the C++-accelerated
+    per-net router) converts the open 2D search into a near-1D one,
+    which the pure-Python coupled search completes in seconds.
+
+    The mask is intentionally layer-agnostic: the coupled search keeps
+    full freedom to choose layers (paired vias) within the spatial
+    tube.  This avoids over-constraining the pair to the guide path's
+    exact layer sequence, which was computed for a single trace and may
+    not have room for two.
+
+    Args:
+        grid: The routing grid (used for world->grid conversion and
+            bounds clamping).
+        guide_route: A single-ended :class:`Route` whose segments trace
+            the spatial path to dilate (typically the P-side of the
+            pair, routed by the standard per-net pathfinder WITHOUT
+            being committed to the grid).
+        radius_cells: Chebyshev dilation radius in grid cells.  Must be
+            at least the pair's center-to-center spacing plus a few
+            cells of maneuvering slack so the N trace fits alongside
+            the guide path and the search can detour around local
+            obstacles.
+        extra_cells: Additional ``(x, y)`` grid cells to include (with
+            the same dilation), e.g. the four pad endpoint cells so the
+            N-side endpoints are always inside the corridor even when
+            the start/end pad pitch exceeds ``radius_cells``.
+
+    Returns:
+        Frozenset of in-bounds ``(x, y)`` grid cells forming the
+        corridor.
+    """
+    base_cells: set[tuple[int, int]] = set(extra_cells)
+
+    for seg in guide_route.segments:
+        gx1, gy1 = grid.world_to_grid(seg.x1, seg.y1)
+        gx2, gy2 = grid.world_to_grid(seg.x2, seg.y2)
+        steps = max(abs(gx2 - gx1), abs(gy2 - gy1))
+        if steps == 0:
+            base_cells.add((gx1, gy1))
+            continue
+        for i in range(steps + 1):
+            t = i / steps
+            base_cells.add(
+                (
+                    int(round(gx1 + (gx2 - gx1) * t)),
+                    int(round(gy1 + (gy2 - gy1) * t)),
+                )
+            )
+
+    for via in guide_route.vias:
+        base_cells.add(grid.world_to_grid(via.x, via.y))
+
+    radius = max(0, int(radius_cells))
+    corridor: set[tuple[int, int]] = set()
+    cols, rows = grid.cols, grid.rows
+    for cx, cy in base_cells:
+        for dx in range(-radius, radius + 1):
+            x = cx + dx
+            if x < 0 or x >= cols:
+                continue
+            for dy in range(-radius, radius + 1):
+                y = cy + dy
+                if 0 <= y < rows:
+                    corridor.add((x, y))
+
+    return frozenset(corridor)
+
+
 class CoupledPathfinder:
     """A* pathfinder for coupled differential pair routing.
 
@@ -1011,6 +1092,7 @@ class CoupledPathfinder:
         n_end: Pad,
         timeout_seconds: float | None = None,
         max_iterations_budget: int | None = None,
+        corridor: frozenset[tuple[int, int]] | None = None,
     ) -> tuple[Route, Route] | None:
         """Route a differential pair with coupled pathfinding.
 
@@ -1053,6 +1135,20 @@ class CoupledPathfinder:
                 memory backstop; ``max_iterations_budget`` is the
                 user-tunable classifier and is expected to fire much
                 earlier than the backstop.
+            corridor: Issue #3439: Optional layer-agnostic corridor
+                mask (set of ``(x, y)`` grid cells, typically built by
+                :func:`build_corridor_mask` from a single-ended guide
+                route).  When set, every generated neighbor state must
+                place BOTH the P and N head positions inside the
+                corridor; states outside are pruned before they reach
+                the open set.  This converts the open joint-state
+                search (quadratic in the single-net state space and
+                intractable in pure Python on large boards) into a
+                corridor-bounded near-1D search that completes in
+                seconds.  Start/goal endpoint cells are exempt so an
+                under-dilated corridor can never disqualify the only
+                landing cells.  ``None`` (default) preserves the
+                unconstrained legacy search.
 
         Returns:
             Tuple of (p_route, n_route) or None if routing failed (no
@@ -1120,6 +1216,19 @@ class CoupledPathfinder:
         effective_approach_radius = max(effective_target_spacing, 6, spacing_delta * 2 + 4)
 
         start_state = CoupledState(p_start_pos, n_start_pos, (0, 0))
+
+        # Issue #3439: endpoint cells are exempt from the corridor
+        # check -- the corridor builder includes them by construction,
+        # but an under-dilated mask must never disqualify the search's
+        # only landing cells.
+        corridor_exempt: frozenset[tuple[int, int]] = frozenset(
+            (
+                (p_start_pos.x, p_start_pos.y),
+                (p_goal_pos.x, p_goal_pos.y),
+                (n_start_pos.x, n_start_pos.y),
+                (n_goal_pos.x, n_goal_pos.y),
+            )
+        )
 
         # A* setup
         open_set: list[CoupledNode] = []
@@ -1269,6 +1378,19 @@ class CoupledPathfinder:
                 p_visited=p_visited_frozen,
                 n_visited=n_visited_frozen,
             ):
+                # Issue #3439: corridor-bounded search.  Prune any
+                # state whose P or N head leaves the corridor mask
+                # (endpoint cells exempt).  Layer is intentionally
+                # ignored -- the corridor constrains the spatial tube,
+                # not the layer choice.
+                if corridor is not None:
+                    p_xy = (new_state.p_pos.x, new_state.p_pos.y)
+                    n_xy = (new_state.n_pos.x, new_state.n_pos.y)
+                    if (p_xy not in corridor and p_xy not in corridor_exempt) or (
+                        n_xy not in corridor and n_xy not in corridor_exempt
+                    ):
+                        continue
+
                 neighbor_key = (new_state.p_pos, new_state.n_pos)
                 if neighbor_key in closed_set:
                     continue
@@ -2162,6 +2284,32 @@ class DiffPairRouter:
             results.append(route)
         return results
 
+    def _single_ended_guide_route(self, start_pad: Pad, end_pad: Pad) -> Route | None:
+        """Route one side of a pair single-ended to seed a corridor mask.
+
+        Issue #3439: the corridor-bounded coupled search needs a
+        known-routable spatial path to dilate.  We use the autorouter's
+        standard per-net pathfinder (C++-accelerated when available,
+        10-100x faster than the pure-Python coupled A*) to find the
+        P-side path.  The returned route is NOT committed to the grid
+        or the route list -- it exists only to bound the coupled
+        search's state space and is discarded afterwards.
+
+        Returns ``None`` when no single-ended path exists (in which
+        case the caller falls back to the unconstrained coupled
+        search) or when the pathfinder raises.
+        """
+        try:
+            return self.autorouter.router.route(start_pad, end_pad)
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.debug(
+                "corridor guide route raised for %r -> %r: %s",
+                start_pad.net_name,
+                end_pad.net_name,
+                exc,
+            )
+            return None
+
     def route_differential_pair_coupled(
         self,
         pair: DifferentialPair,
@@ -2346,13 +2494,102 @@ class DiffPairRouter:
                 f"    Routing {pair.positive.net_name}/{pair.negative.net_name}{polarity_marker}..."
             )
 
-            result = pathfinder.route_coupled(
-                spec.p_start,
-                spec.p_end,
-                spec.n_start,
-                spec.n_end,
-                timeout_seconds=per_pair_timeout,
-                max_iterations_budget=per_pair_max_iterations,
+            # Issue #3439: corridor-bounded attempt first.  The open
+            # joint-state coupled A* is pure Python and intractable on
+            # large boards (~14k iterations/min on board 07's 4-layer
+            # 110x95mm grid -- every pair blew its 60s budget).  Route
+            # the P side single-ended via the (C++-accelerated) per-net
+            # pathfinder, dilate its path into a spatial corridor, and
+            # run the coupled search restricted to that corridor.  This
+            # converts the open 2D product-space search into a near-1D
+            # one that completes in seconds.  The guide route is NEVER
+            # committed to the grid.  When the corridor attempt fails
+            # (no guide path, corridor too tight for two traces, or
+            # corridor budget exceeded) we fall back to the legacy
+            # unconstrained search with the remaining per-pair budget,
+            # preserving behaviour on boards where the open search
+            # already converged (boards 03/06).
+            spec_t0 = time.monotonic()
+            result: tuple[Route, Route] | None = None
+            coupled_phase = "open"
+
+            guide_route = self._single_ended_guide_route(spec.p_start, spec.p_end)
+            if guide_route is not None and guide_route.segments:
+                grid = self.autorouter.grid
+                resolution = grid.resolution
+                start_spacing_cells = (
+                    math.dist(
+                        (spec.p_start.x, spec.p_start.y),
+                        (spec.n_start.x, spec.n_start.y),
+                    )
+                    / resolution
+                )
+                end_spacing_cells = (
+                    math.dist(
+                        (spec.p_end.x, spec.p_end.y),
+                        (spec.n_end.x, spec.n_end.y),
+                    )
+                    / resolution
+                )
+                # The corridor must admit the N trace alongside the
+                # guide path at the WIDEST spacing the run will see
+                # (start/end pad pitch can exceed the target), plus
+                # maneuvering slack for local detours.
+                corridor_radius = int(
+                    math.ceil(max(spacing_cells, start_spacing_cells, end_spacing_cells))
+                ) + max(6, spacing_cells)
+                corridor = build_corridor_mask(
+                    grid,
+                    guide_route,
+                    corridor_radius,
+                    extra_cells=(
+                        grid.world_to_grid(spec.p_start.x, spec.p_start.y),
+                        grid.world_to_grid(spec.p_end.x, spec.p_end.y),
+                        grid.world_to_grid(spec.n_start.x, spec.n_start.y),
+                        grid.world_to_grid(spec.n_end.x, spec.n_end.y),
+                    ),
+                )
+                # Half the per-pair budget for the corridor attempt;
+                # the rest is reserved for the open-search fallback so
+                # a corridor pathology can never starve the legacy
+                # path entirely.
+                corridor_budget = (
+                    per_pair_timeout * 0.5 if per_pair_timeout is not None else None
+                )
+                result = pathfinder.route_coupled(
+                    spec.p_start,
+                    spec.p_end,
+                    spec.n_start,
+                    spec.n_end,
+                    timeout_seconds=corridor_budget,
+                    max_iterations_budget=per_pair_max_iterations,
+                    corridor=corridor,
+                )
+                if result is not None:
+                    coupled_phase = "corridor"
+
+            if result is None:
+                remaining_budget = per_pair_timeout
+                if per_pair_timeout is not None:
+                    remaining_budget = max(
+                        1.0, per_pair_timeout - (time.monotonic() - spec_t0)
+                    )
+                result = pathfinder.route_coupled(
+                    spec.p_start,
+                    spec.p_end,
+                    spec.n_start,
+                    spec.n_end,
+                    timeout_seconds=remaining_budget,
+                    max_iterations_budget=per_pair_max_iterations,
+                )
+
+            spec_elapsed = time.monotonic() - spec_t0
+            logger.info(
+                "diffpair coupled timing: pair=%r phase=%s elapsed=%.2fs success=%s",
+                pair.name,
+                coupled_phase,
+                spec_elapsed,
+                result is not None,
             )
 
             if result is None:
@@ -3428,6 +3665,7 @@ class DiffPairRouter:
         coupled_only: bool = False,
         per_pair_timeout: float | None = None,
         per_pair_max_iterations: int | None = None,
+        aggregate_timeout: float | None = None,
     ) -> tuple[list[Route], list[LengthMismatchWarning]]:
         """Route all nets with differential pair-aware routing.
 
@@ -3462,6 +3700,21 @@ class DiffPairRouter:
                 are supplied; ``None`` defers to the config value, and
                 if that is also ``None`` the legacy unbounded
                 behaviour is preserved.
+            aggregate_timeout: Issue #3439: Optional wall-clock budget
+                (seconds) for the ENTIRE coupled diff-pair phase.  Once
+                exhausted, all remaining pairs are deferred to the main
+                strategy WITHOUT attempting coupled routing (the same
+                budget-exit path as per-pair exits), so a board full of
+                pathological pairs can never burn
+                ``num_pairs * per_pair_timeout`` of the outer routing
+                budget before the single-ended fallback runs -- the
+                board-07 7/31-reach collapse.  Per-pair budgets are
+                additionally clamped to the remaining aggregate budget.
+                Takes precedence over
+                ``DifferentialPairConfig.aggregate_timeout``; ``None``
+                defers to the config value, and if that is also
+                ``None`` the legacy per-pair-only behaviour is
+                preserved.
         """
         # Issue #3089: prefer the explicit kwarg, otherwise fall back to
         # the config field so callers configuring everything via
@@ -3474,6 +3727,10 @@ class DiffPairRouter:
         effective_per_pair_max_iterations = per_pair_max_iterations
         if effective_per_pair_max_iterations is None and diffpair_config is not None:
             effective_per_pair_max_iterations = diffpair_config.per_pair_max_iterations
+        # Issue #3439: same precedence pattern for the aggregate budget.
+        effective_aggregate_timeout = aggregate_timeout
+        if effective_aggregate_timeout is None and diffpair_config is not None:
+            effective_aggregate_timeout = getattr(diffpair_config, "aggregate_timeout", None)
         if diffpair_config is None or not diffpair_config.enabled:
             return self.autorouter.route_all(net_order), []
 
@@ -3514,6 +3771,16 @@ class DiffPairRouter:
         # them up normally (the per-net C++ A* router is the right tool
         # for any single net the coupled search couldn't converge on).
         budget_exit_diff_nets: set[int] = set()
+        # Issue #3439: aggregate coupled-phase deadline.  When set, the
+        # whole pair loop must finish by this time; pairs that would
+        # start after the deadline (or with <0.5s of budget left) are
+        # deferred to the main strategy via the budget-exit path so a
+        # failed coupled pre-pass can never starve the single-ended
+        # fallback of wall-clock budget (the board-07 7/31 collapse).
+        coupled_phase_deadline: float | None = None
+        if effective_aggregate_timeout is not None and effective_aggregate_timeout > 0:
+            coupled_phase_deadline = time.monotonic() + float(effective_aggregate_timeout)
+        aggregate_deferred_pairs = 0
         for pair in diff_pairs:
             p_id, n_id = pair.get_net_ids()
             # Issue #2638, Epic #2556 Phase 2E: engagement gate.  Refuse
@@ -3531,12 +3798,38 @@ class DiffPairRouter:
                 refused_diff_nets.add(p_id)
                 refused_diff_nets.add(n_id)
                 continue
+            # Issue #3439: aggregate budget check + per-pair clamp.
+            pair_timeout = effective_per_pair_timeout
+            if coupled_phase_deadline is not None:
+                aggregate_remaining = coupled_phase_deadline - time.monotonic()
+                if aggregate_remaining <= 0.5:
+                    if aggregate_deferred_pairs == 0:
+                        logger.warning(
+                            "DIFFPAIR_AGGREGATE_BUDGET_EXCEEDED: coupled "
+                            "diff-pair phase consumed its %.1fs aggregate "
+                            "budget; deferring remaining pairs to the main "
+                            "strategy (issue #3439)",
+                            float(effective_aggregate_timeout),
+                        )
+                    print(
+                        f"  [diffpair-aggregate] budget exhausted; deferring "
+                        f"{pair} to main strategy"
+                    )
+                    budget_exit_diff_nets.add(p_id)
+                    budget_exit_diff_nets.add(n_id)
+                    aggregate_deferred_pairs += 1
+                    continue
+                pair_timeout = (
+                    min(pair_timeout, aggregate_remaining)
+                    if pair_timeout is not None
+                    else aggregate_remaining
+                )
             if coupled_only:
                 pair_routes, warning = self.route_differential_pair_coupled(
                     pair,
                     diffpair_config.spacing,
                     coupled_only=True,
-                    per_pair_timeout=effective_per_pair_timeout,
+                    per_pair_timeout=pair_timeout,
                     per_pair_max_iterations=effective_per_pair_max_iterations,
                 )
             else:
@@ -3544,7 +3837,7 @@ class DiffPairRouter:
                     pair,
                     diffpair_config.spacing,
                     use_coupled_routing=True,  # Use coupled routing by default
-                    per_pair_timeout=effective_per_pair_timeout,
+                    per_pair_timeout=pair_timeout,
                     per_pair_max_iterations=effective_per_pair_max_iterations,
                 )
             # Issue #3089: detect budget-exit via the pair's last_budget_exit
@@ -3567,6 +3860,13 @@ class DiffPairRouter:
             all_routes.extend(pair_routes)
             if warning:
                 warnings.append(warning)
+
+        if aggregate_deferred_pairs:
+            print(
+                f"  [diffpair-aggregate] deferred {aggregate_deferred_pairs} "
+                f"pair(s) to main strategy after the aggregate coupled-phase "
+                f"budget ({effective_aggregate_timeout:.1f}s) was exhausted"
+            )
 
         # Issue #2464: When coupled_only=True, only the nets actually
         # routed by the CoupledPathfinder are reserved.  Pairs that fell

--- a/tests/test_diffpair_aggregate_cap.py
+++ b/tests/test_diffpair_aggregate_cap.py
@@ -1,0 +1,281 @@
+"""Tests for the Issue #3439 aggregate coupled-phase budget cap.
+
+Background: ``per_pair_timeout`` (issue #3089/#3321) bounds any single
+``CoupledPathfinder.route_coupled`` call, but a board with many
+pathological pairs still burns ``num_pairs * per_pair_timeout`` of the
+outer ``--timeout`` budget before the single-ended main strategy runs.
+On board 07 (7 declared pairs, every one blowing its 60 s budget) the
+coupled pre-pass consumed 420 s of the 600 s ``--timeout``, starving
+the negotiated strategy and collapsing final reach to 7/31 nets.
+
+Issue #3439 adds an AGGREGATE coupled-phase budget:
+
+1. ``DifferentialPairConfig.aggregate_timeout`` (explicit config).
+2. ``DiffPairRouter.route_all_with_diffpairs(aggregate_timeout=...)``
+   (kwarg, takes precedence over config).
+3. ``Autorouter.route_all_with_diffpairs`` auto-derives
+   ``max(per_pair_budget, timeout * 0.25)`` from ``--timeout`` when the
+   config does not set one.
+
+The load-bearing invariant (pinned below): once the aggregate budget is
+exhausted, remaining pairs are deferred to the main strategy WITHOUT
+attempting coupled routing, so a failed coupled pre-pass can never
+reduce the final reach below the ``--differential-pairs``-off baseline.
+"""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import fields
+from unittest.mock import MagicMock
+
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.diffpair import DifferentialPairConfig
+from kicad_tools.router.diffpair_routing import DiffPairRouter
+from kicad_tools.router.rules import DesignRules, NetClassRouting
+
+# ---------------------------------------------------------------------------
+# Config / signature surface
+# ---------------------------------------------------------------------------
+
+
+def test_diffpair_config_has_aggregate_timeout_field():
+    field_names = {f.name for f in fields(DifferentialPairConfig)}
+    assert "aggregate_timeout" in field_names
+
+
+def test_diffpair_config_aggregate_timeout_default_none():
+    """Back-compat: legacy per-pair-only behaviour by default."""
+    assert DifferentialPairConfig().aggregate_timeout is None
+
+
+def test_route_all_with_diffpairs_signature_accepts_aggregate_timeout():
+    sig = inspect.signature(DiffPairRouter.route_all_with_diffpairs)
+    assert "aggregate_timeout" in sig.parameters
+    assert sig.parameters["aggregate_timeout"].default is None
+
+
+# ---------------------------------------------------------------------------
+# Autorouter derivation from --timeout (mirrors the #3321 test pattern)
+# ---------------------------------------------------------------------------
+
+
+def _make_autorouter_stub() -> Autorouter:
+    router = Autorouter.__new__(Autorouter)
+    inner = MagicMock()
+    inner.route_all_with_diffpairs = MagicMock(return_value=([], []))
+    inner.intra_clearance_violations = MagicMock(return_value=[])
+    inner.repair_intra_clearance_violations = MagicMock()
+    router._diffpair_router = inner
+    router._finalize_routing = MagicMock()
+    return router
+
+
+def test_timeout_derives_aggregate_budget():
+    """``--timeout 600`` -> aggregate cap ``max(60, 600*0.25) = 150``."""
+    router = _make_autorouter_stub()
+    cfg = DifferentialPairConfig(enabled=True)
+
+    router.route_all_with_diffpairs(cfg, timeout=600.0)
+
+    kwargs = router._diffpair_router.route_all_with_diffpairs.call_args.kwargs
+    assert kwargs["aggregate_timeout"] == 150.0
+
+
+def test_aggregate_budget_floored_at_per_pair_budget():
+    """The aggregate cap is never smaller than one full per-pair budget
+    so a single pair always gets a complete attempt.  ``--timeout 100``
+    derives per-pair = 30 and aggregate = max(30, 25) = 30."""
+    router = _make_autorouter_stub()
+    cfg = DifferentialPairConfig(enabled=True)
+
+    router.route_all_with_diffpairs(cfg, timeout=100.0)
+
+    kwargs = router._diffpair_router.route_all_with_diffpairs.call_args.kwargs
+    assert kwargs["per_pair_timeout"] == 30.0
+    assert kwargs["aggregate_timeout"] == 30.0
+
+
+def test_explicit_per_pair_budget_floors_aggregate():
+    """When the user set ``--diffpair-per-pair-timeout``, the aggregate
+    floor uses the explicit value."""
+    router = _make_autorouter_stub()
+    cfg = DifferentialPairConfig(enabled=True, per_pair_timeout=200.0)
+
+    router.route_all_with_diffpairs(cfg, timeout=600.0)
+
+    kwargs = router._diffpair_router.route_all_with_diffpairs.call_args.kwargs
+    # max(200, 150) = 200.
+    assert kwargs["aggregate_timeout"] == 200.0
+
+
+def test_explicit_aggregate_timeout_takes_precedence_over_derived():
+    """An explicit ``DifferentialPairConfig.aggregate_timeout`` disables
+    the auto-derivation (kwarg forwarded as None; the inner router's
+    own precedence rule falls back to the config value)."""
+    router = _make_autorouter_stub()
+    cfg = DifferentialPairConfig(enabled=True, aggregate_timeout=42.0)
+
+    router.route_all_with_diffpairs(cfg, timeout=600.0)
+
+    kwargs = router._diffpair_router.route_all_with_diffpairs.call_args.kwargs
+    assert kwargs["aggregate_timeout"] is None
+
+
+def test_no_timeout_means_no_derived_aggregate_budget():
+    """Back-compat: callers that never pass ``timeout`` see ``None``."""
+    router = _make_autorouter_stub()
+    cfg = DifferentialPairConfig(enabled=True)
+
+    router.route_all_with_diffpairs(cfg)
+
+    kwargs = router._diffpair_router.route_all_with_diffpairs.call_args.kwargs
+    assert kwargs["aggregate_timeout"] is None
+
+
+def test_aggregate_derivation_emits_structured_log_signal(caplog):
+    import logging
+
+    router = _make_autorouter_stub()
+    cfg = DifferentialPairConfig(enabled=True)
+
+    with caplog.at_level(logging.INFO, logger="kicad_tools.router.core"):
+        router.route_all_with_diffpairs(cfg, timeout=600.0)
+
+    assert any("DIFFPAIR_AGGREGATE_TIMEOUT_AUTODERIVED" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Behavioural invariant: exhausted aggregate budget defers pairs to the
+# main strategy and never collapses reach below the diffpairs-off baseline
+# ---------------------------------------------------------------------------
+
+
+def _opt_in_diffpair_class_map(net_names: list[str]) -> dict[str, NetClassRouting]:
+    nc = NetClassRouting(name="HighSpeedOptIn", coupled_routing=True)
+    return dict.fromkeys(net_names, nc)
+
+
+def _two_pad_diffpair_router() -> Autorouter:
+    """30x10mm board with one straight two-pad diff pair plus one plain
+    net, so 'reach' covers both diff and non-diff nets."""
+    rules = DesignRules(trace_width=0.2, trace_clearance=0.15, grid_resolution=0.1)
+    router = Autorouter(
+        width=30.0,
+        height=10.0,
+        rules=rules,
+        net_class_map=_opt_in_diffpair_class_map(["USB_D+", "USB_D-"]),
+    )
+    router.add_component(
+        "U1",
+        [
+            {
+                "number": "1",
+                "x": 5.0,
+                "y": 4.6,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 1,
+                "net_name": "USB_D+",
+            },
+            {
+                "number": "2",
+                "x": 5.0,
+                "y": 5.4,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 2,
+                "net_name": "USB_D-",
+            },
+            {
+                "number": "3",
+                "x": 5.0,
+                "y": 8.0,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 3,
+                "net_name": "GPIO1",
+            },
+        ],
+    )
+    router.add_component(
+        "J1",
+        [
+            {
+                "number": "1",
+                "x": 25.0,
+                "y": 4.6,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 1,
+                "net_name": "USB_D+",
+            },
+            {
+                "number": "2",
+                "x": 25.0,
+                "y": 5.4,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 2,
+                "net_name": "USB_D-",
+            },
+            {
+                "number": "3",
+                "x": 25.0,
+                "y": 8.0,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 3,
+                "net_name": "GPIO1",
+            },
+        ],
+    )
+    return router
+
+
+def test_exhausted_aggregate_budget_skips_coupled_and_preserves_reach(monkeypatch):
+    """The load-bearing #3439 invariant: with a (near-)zero aggregate
+    budget, the coupled pathfinder is never invoked and every net --
+    including the diff-pair members -- is still routed by the fallback
+    per-net path.  Final reach therefore equals the
+    ``--differential-pairs``-off baseline."""
+    router = _two_pad_diffpair_router()
+    config = DifferentialPairConfig(enabled=True, spacing=0.8)
+
+    coupled_calls: list[str] = []
+    original = DiffPairRouter.route_differential_pair_coupled
+
+    def _spy(self, pair, *args, **kwargs):
+        coupled_calls.append(pair.name)
+        return original(self, pair, *args, **kwargs)
+
+    monkeypatch.setattr(DiffPairRouter, "route_differential_pair_coupled", _spy)
+
+    routes, _warnings = router._diffpair.route_all_with_diffpairs(
+        config,
+        aggregate_timeout=0.001,
+    )
+
+    assert coupled_calls == [], (
+        "With an exhausted aggregate budget the coupled pathfinder must "
+        f"never be invoked; saw calls for {coupled_calls}"
+    )
+
+    routed_nets = {r.net for r in routes}
+    assert {1, 2, 3} <= routed_nets, (
+        "Aggregate-budget deferral must leave the diff-pair nets to the "
+        "main per-net strategy so reach never drops below the "
+        f"diffpairs-off baseline; routed nets: {routed_nets}"
+    )
+
+
+def test_aggregate_cap_unset_preserves_coupled_routing():
+    """Control for the invariant test: with no aggregate cap the pair
+    routes through the coupled pathfinder as before."""
+    router = _two_pad_diffpair_router()
+    config = DifferentialPairConfig(enabled=True, spacing=0.8)
+
+    routes, _warnings = router._diffpair.route_all_with_diffpairs(config)
+
+    routed_nets = {r.net for r in routes}
+    assert {1, 2, 3} <= routed_nets

--- a/tests/test_diffpair_corridor.py
+++ b/tests/test_diffpair_corridor.py
@@ -1,0 +1,320 @@
+"""Tests for the Issue #3439 corridor-bounded coupled diff-pair search.
+
+Background: ``CoupledPathfinder.route_coupled`` is a pure-Python A* over
+the joint ``(P-pos, N-pos)`` product state space.  On board 07's
+4-layer 110x95 mm grid every declared pair blew its 60 s per-pair
+budget at ~14k iterations (pure-Python speed), so coupled routing was
+structurally intractable and the recipe had to disable
+``--differential-pairs`` entirely.
+
+Issue #3439 adds a corridor-bounded search mode:
+
+1. ``build_corridor_mask`` dilates a single-ended guide route (found by
+   the C++-accelerated per-net pathfinder) into a layer-agnostic
+   spatial corridor.
+2. ``CoupledPathfinder.route_coupled`` accepts a ``corridor`` kwarg and
+   prunes any neighbor state whose P or N head leaves the corridor
+   (endpoint cells exempt).
+3. ``DiffPairRouter.route_differential_pair_coupled`` routes the P side
+   single-ended (WITHOUT committing it), builds the corridor, attempts
+   the coupled search inside it with half the per-pair budget, and
+   falls back to the legacy unconstrained search when the corridor
+   attempt fails.
+
+The corridor reduces the joint search space from the full grid product
+to a near-1D tube, which the pure-Python search completes in seconds.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.diffpair import DifferentialPairConfig
+from kicad_tools.router.diffpair_routing import (
+    CoupledPathfinder,
+    build_corridor_mask,
+)
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.primitives import Pad, Route, Segment
+from kicad_tools.router.rules import DesignRules, NetClassRouting
+
+# ---------------------------------------------------------------------------
+# build_corridor_mask
+# ---------------------------------------------------------------------------
+
+
+def _make_grid(width: float = 12.7, height: float = 12.7) -> RoutingGrid:
+    rules = DesignRules()
+    return RoutingGrid(width=width, height=height, rules=rules)
+
+
+def _straight_guide_route(grid: RoutingGrid) -> Route:
+    """A single horizontal segment from (2, 5) to (10, 5) mm."""
+    route = Route(net=1, net_name="GUIDE")
+    route.segments.append(
+        Segment(
+            x1=2.0,
+            y1=5.0,
+            x2=10.0,
+            y2=5.0,
+            width=0.2,
+            layer=Layer.F_CU,
+            net=1,
+            net_name="GUIDE",
+        )
+    )
+    return route
+
+
+def test_corridor_mask_covers_guide_path():
+    """Every rasterized guide cell is inside the corridor."""
+    grid = _make_grid()
+    route = _straight_guide_route(grid)
+    corridor = build_corridor_mask(grid, route, radius_cells=2)
+
+    gx1, gy1 = grid.world_to_grid(2.0, 5.0)
+    gx2, gy2 = grid.world_to_grid(10.0, 5.0)
+    for x in range(gx1, gx2 + 1):
+        assert (x, gy1) in corridor, f"guide cell ({x},{gy1}) missing from corridor"
+
+
+def test_corridor_mask_dilates_by_radius():
+    """Cells within ``radius_cells`` (Chebyshev) of the guide are
+    included; cells beyond it are excluded."""
+    grid = _make_grid()
+    route = _straight_guide_route(grid)
+    radius = 3
+    corridor = build_corridor_mask(grid, route, radius_cells=radius)
+
+    gx, gy = grid.world_to_grid(6.0, 5.0)  # mid-path cell
+    assert (gx, gy + radius) in corridor
+    assert (gx, gy - radius) in corridor
+    assert (gx, gy + radius + 1) not in corridor
+    assert (gx, gy - radius - 1) not in corridor
+
+
+def test_corridor_mask_clamps_to_grid_bounds():
+    """Dilation near the board edge never produces out-of-bounds cells."""
+    grid = _make_grid()
+    route = Route(net=1, net_name="EDGE")
+    route.segments.append(
+        Segment(
+            x1=0.1,
+            y1=0.1,
+            x2=1.0,
+            y2=0.1,
+            width=0.2,
+            layer=Layer.F_CU,
+            net=1,
+            net_name="EDGE",
+        )
+    )
+    corridor = build_corridor_mask(grid, route, radius_cells=5)
+    for x, y in corridor:
+        assert 0 <= x < grid.cols
+        assert 0 <= y < grid.rows
+
+
+def test_corridor_mask_includes_extra_cells():
+    """``extra_cells`` (pad endpoints) are dilated into the mask too."""
+    grid = _make_grid()
+    route = _straight_guide_route(grid)
+    far_cell = grid.world_to_grid(11.5, 11.5)
+    corridor = build_corridor_mask(grid, route, radius_cells=1, extra_cells=(far_cell,))
+    assert far_cell in corridor
+
+
+# ---------------------------------------------------------------------------
+# CoupledPathfinder.route_coupled corridor kwarg
+# ---------------------------------------------------------------------------
+
+
+def _make_simple_pair_pads() -> tuple[Pad, Pad, Pad, Pad]:
+    """Two-pad fixture the coupled pathfinder routes in well under 1 s."""
+    p_start = Pad(x=2.0, y=5.0, width=0.2, height=0.2, net=1, net_name="DP+", layer=Layer.F_CU)
+    p_end = Pad(x=10.0, y=5.0, width=0.2, height=0.2, net=1, net_name="DP+", layer=Layer.F_CU)
+    n_start = Pad(x=2.0, y=5.4, width=0.2, height=0.2, net=2, net_name="DP-", layer=Layer.F_CU)
+    n_end = Pad(x=10.0, y=5.4, width=0.2, height=0.2, net=2, net_name="DP-", layer=Layer.F_CU)
+    return p_start, p_end, n_start, n_end
+
+
+def test_route_coupled_signature_accepts_corridor():
+    """The kwarg must be on the method with a None default (legacy)."""
+    import inspect
+
+    sig = inspect.signature(CoupledPathfinder.route_coupled)
+    assert "corridor" in sig.parameters
+    assert sig.parameters["corridor"].default is None
+
+
+def test_route_coupled_succeeds_inside_corridor():
+    """A corridor dilated around the P-side path admits the pair."""
+    rules = DesignRules()
+    grid = _make_grid()
+    pf = CoupledPathfinder(grid=grid, rules=rules, target_spacing_cells=2, min_spacing_cells=2)
+    p_start, p_end, n_start, n_end = _make_simple_pair_pads()
+
+    corridor = build_corridor_mask(
+        grid,
+        _straight_guide_route(grid),
+        radius_cells=8,
+        extra_cells=(
+            grid.world_to_grid(p_start.x, p_start.y),
+            grid.world_to_grid(p_end.x, p_end.y),
+            grid.world_to_grid(n_start.x, n_start.y),
+            grid.world_to_grid(n_end.x, n_end.y),
+        ),
+    )
+    result = pf.route_coupled(p_start, p_end, n_start, n_end, corridor=corridor)
+    assert result is not None, "corridor-bounded search must route the simple pair"
+
+
+def test_route_coupled_corridor_prunes_outside_states():
+    """A corridor that covers only the start cells (no path to the
+    goal) must make the search fail fast instead of exploring the open
+    grid."""
+    rules = DesignRules()
+    grid = _make_grid()
+    pf = CoupledPathfinder(grid=grid, rules=rules, target_spacing_cells=2, min_spacing_cells=2)
+    p_start, p_end, n_start, n_end = _make_simple_pair_pads()
+
+    # Corridor = just the start pad neighborhoods.  Goal cells are
+    # exempt from the check but unreachable because every intermediate
+    # cell is pruned.
+    start_only: set[tuple[int, int]] = set()
+    for pad in (p_start, n_start):
+        cx, cy = grid.world_to_grid(pad.x, pad.y)
+        for dx in range(-2, 3):
+            for dy in range(-2, 3):
+                start_only.add((cx + dx, cy + dy))
+
+    t0 = time.monotonic()
+    result = pf.route_coupled(p_start, p_end, n_start, n_end, corridor=frozenset(start_only))
+    elapsed = time.monotonic() - t0
+
+    assert result is None, "search must fail when the corridor has no path to the goal"
+    assert elapsed < 10.0, f"pruned search must exit fast; took {elapsed:.2f}s"
+
+
+def test_route_coupled_corridor_none_preserves_legacy_behaviour():
+    """``corridor=None`` (default) matches the unconstrained search."""
+    rules = DesignRules()
+    pf = CoupledPathfinder(
+        grid=_make_grid(), rules=rules, target_spacing_cells=2, min_spacing_cells=2
+    )
+    p_start, p_end, n_start, n_end = _make_simple_pair_pads()
+
+    result_default = pf.route_coupled(p_start, p_end, n_start, n_end)
+    assert result_default is not None
+
+
+# ---------------------------------------------------------------------------
+# DiffPairRouter integration: corridor-guided attempt
+# ---------------------------------------------------------------------------
+
+
+def _opt_in_diffpair_class_map(net_names: list[str]) -> dict[str, NetClassRouting]:
+    nc = NetClassRouting(name="HighSpeedOptIn", coupled_routing=True)
+    return dict.fromkeys(net_names, nc)
+
+
+def _two_pad_diffpair_router(diffpair_spacing: float = 0.8) -> Autorouter:
+    """30x10mm board with one straight two-pad diff pair (see
+    ``test_diffpair_routing_integration.py`` for the geometry rationale)."""
+    rules = DesignRules(trace_width=0.2, trace_clearance=0.15, grid_resolution=0.1)
+    router = Autorouter(
+        width=30.0,
+        height=10.0,
+        rules=rules,
+        net_class_map=_opt_in_diffpair_class_map(["USB_D+", "USB_D-"]),
+    )
+    p_y = 5.0 - diffpair_spacing / 2
+    n_y = 5.0 + diffpair_spacing / 2
+    router.add_component(
+        "U1",
+        [
+            {
+                "number": "1",
+                "x": 5.0,
+                "y": p_y,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 1,
+                "net_name": "USB_D+",
+            },
+            {
+                "number": "2",
+                "x": 5.0,
+                "y": n_y,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 2,
+                "net_name": "USB_D-",
+            },
+        ],
+    )
+    router.add_component(
+        "J1",
+        [
+            {
+                "number": "1",
+                "x": 25.0,
+                "y": p_y,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 1,
+                "net_name": "USB_D+",
+            },
+            {
+                "number": "2",
+                "x": 25.0,
+                "y": n_y,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 2,
+                "net_name": "USB_D-",
+            },
+        ],
+    )
+    return router
+
+
+def test_coupled_routing_uses_corridor_phase(caplog):
+    """On a clean fixture the corridor attempt should succeed (the
+    structured timing log reports ``phase=corridor``) and the pair
+    should be fully routed."""
+    router = _two_pad_diffpair_router()
+    config = DifferentialPairConfig(enabled=True, spacing=0.8)
+
+    with caplog.at_level(logging.INFO, logger="kicad_tools.router.diffpair_routing"):
+        routes, warnings, routed_net_ids = router.route_diffpair_prepass(config)
+
+    assert 1 in routed_net_ids and 2 in routed_net_ids, (
+        f"Expected both diff-pair nets to route; got {routed_net_ids}"
+    )
+    timing_records = [r for r in caplog.records if "diffpair coupled timing" in r.getMessage()]
+    assert timing_records, "per-pair timing log must be emitted (issue #3439)"
+    assert any("phase=corridor" in r.getMessage() for r in timing_records), (
+        "corridor-guided attempt should succeed on a clean straight pair; "
+        f"got: {[r.getMessage() for r in timing_records]}"
+    )
+
+
+def test_guide_route_is_not_committed_to_route_list():
+    """The single-ended guide route must never leak into
+    ``autorouter.routes`` -- only the coupled P/N routes are committed."""
+    router = _two_pad_diffpair_router()
+    config = DifferentialPairConfig(enabled=True, spacing=0.8)
+
+    routes, _warnings, routed_net_ids = router.route_diffpair_prepass(config)
+    assert routed_net_ids == {1, 2}
+
+    # Exactly the committed coupled routes appear on the autorouter;
+    # an uncommitted guide route would add a third entry for net 1.
+    net1_routes = [r for r in router.routes if r.net == 1]
+    net2_routes = [r for r in router.routes if r.net == 2]
+    assert len(net1_routes) == 1
+    assert len(net2_routes) == 1

--- a/tests/test_diffpair_corridor.py
+++ b/tests/test_diffpair_corridor.py
@@ -318,3 +318,172 @@ def test_guide_route_is_not_committed_to_route_list():
     net2_routes = [r for r in router.routes if r.net == 2]
     assert len(net1_routes) == 1
     assert len(net2_routes) == 1
+
+
+# ---------------------------------------------------------------------------
+# PR #3473 (review of #3439): shared per-pair budgets across the two
+# coupled attempts + bounded guide-route probe
+# ---------------------------------------------------------------------------
+
+
+def test_iteration_budget_is_split_between_corridor_and_fallback(monkeypatch):
+    """A failing pair must NOT receive the full iteration budget twice.
+
+    PR #3473 review (board 06 forensics): the corridor attempt was
+    passed the un-halved ``per_pair_max_iterations``, so every failing
+    pair burned 4000 corridor + 4000 open iterations, doubling the
+    diff-pair phase and tipping the CI job over its 15-minute ceiling.
+    The corridor attempt gets at most half; the open fallback gets the
+    remainder of the SHARED budget.
+    """
+    router = _two_pad_diffpair_router()
+    pairs = router._diffpair.detect_differential_pairs()
+    assert len(pairs) == 1
+
+    budgets_seen: list[int | None] = []
+
+    def fake_route_coupled(
+        self,
+        p_start,
+        p_end,
+        n_start,
+        n_end,
+        timeout_seconds=None,
+        max_iterations_budget=None,
+        corridor=None,
+    ):
+        budgets_seen.append(max_iterations_budget)
+        self.last_timeout_exceeded = False
+        # Simulate exhausting exactly the budget this attempt received.
+        self.last_iterations = max_iterations_budget or 0
+        return None
+
+    monkeypatch.setattr(CoupledPathfinder, "route_coupled", fake_route_coupled)
+
+    routes, warning = router._diffpair.route_differential_pair_coupled(
+        pairs[0],
+        coupled_only=True,
+        per_pair_timeout=60.0,
+        per_pair_max_iterations=4000,
+    )
+
+    assert routes == [] and warning is None
+    assert len(budgets_seen) == 2, (
+        f"expected corridor attempt + open fallback, got {budgets_seen}"
+    )
+    corridor_budget, fallback_budget = budgets_seen
+    assert corridor_budget == 2000, (
+        f"corridor attempt must get half the iteration budget, got {corridor_budget}"
+    )
+    assert fallback_budget == 2000, (
+        "open fallback must get only the remainder of the shared budget "
+        f"(4000 - 2000), got {fallback_budget}"
+    )
+
+
+def test_fallback_gets_full_remainder_when_corridor_exits_early(monkeypatch):
+    """If the corridor attempt fails after only a few iterations, the
+    open fallback inherits nearly the whole shared budget (mirrors the
+    wall-clock remaining-budget arithmetic)."""
+    router = _two_pad_diffpair_router()
+    pairs = router._diffpair.detect_differential_pairs()
+
+    budgets_seen: list[int | None] = []
+
+    def fake_route_coupled(
+        self,
+        p_start,
+        p_end,
+        n_start,
+        n_end,
+        timeout_seconds=None,
+        max_iterations_budget=None,
+        corridor=None,
+    ):
+        budgets_seen.append(max_iterations_budget)
+        self.last_timeout_exceeded = False
+        self.last_iterations = 100  # cheap corridor failure
+        return None
+
+    monkeypatch.setattr(CoupledPathfinder, "route_coupled", fake_route_coupled)
+
+    router._diffpair.route_differential_pair_coupled(
+        pairs[0],
+        coupled_only=True,
+        per_pair_timeout=60.0,
+        per_pair_max_iterations=4000,
+    )
+
+    assert budgets_seen[0] == 2000
+    assert budgets_seen[1] == 3900, (
+        "fallback budget must be the shared budget minus iterations the "
+        f"corridor attempt actually used, got {budgets_seen[1]}"
+    )
+
+
+def test_guide_route_probe_receives_deadline(monkeypatch):
+    """The single-ended probe must be bounded by a per-net deadline.
+
+    PR #3473 review: the probe was called with no ``per_net_timeout``;
+    on hard P sides (C++ fails -> unbounded Python fallback) it ate
+    nearly the whole per-pair budget before either coupled attempt ran,
+    leaving the open fallback only the 1.0s floor.
+    """
+    router = _two_pad_diffpair_router()
+    pairs = router._diffpair.detect_differential_pairs()
+
+    probe_timeouts: list[float | None] = []
+    original_route = router.router.route
+
+    def spying_route(start, end, *args, per_net_timeout=None, **kwargs):
+        probe_timeouts.append(per_net_timeout)
+        return original_route(
+            start, end, *args, per_net_timeout=per_net_timeout, **kwargs
+        )
+
+    monkeypatch.setattr(router.router, "route", spying_route)
+
+    routes, _warning = router._diffpair.route_differential_pair_coupled(
+        pairs[0],
+        coupled_only=True,
+        per_pair_timeout=60.0,
+    )
+
+    assert probe_timeouts, "guide-route probe was never invoked"
+    assert probe_timeouts[0] == 60.0 * 0.125, (
+        "probe must get an eighth of the per-pair budget as its deadline, "
+        f"got {probe_timeouts[0]}"
+    )
+
+
+def test_failed_probe_clears_avoidance_costs():
+    """A probe that raises must still clear persistent avoidance costs.
+
+    PR #3473 review (non-blocking note): the C++ validation-failure
+    path mutates grid avoidance costs via ``_boost_avoidance_at``;
+    the normal cleanup lives in ``Autorouter._route_net``, which the
+    probe bypasses.
+    """
+    router = _two_pad_diffpair_router()
+
+    class _StubRouter:
+        def __init__(self):
+            self.cleared = 0
+
+        def route(self, start, end, per_net_timeout=None):
+            raise RuntimeError("probe failure")
+
+        def clear_avoidance_costs(self):
+            self.cleared += 1
+
+    stub = _StubRouter()
+    router.router = stub
+
+    pads = [p for p in router.pads.values() if p.net == 1]
+    start, end = pads[0], pads[1]
+
+    result = router._diffpair._single_ended_guide_route(start, end)
+    assert result is None
+    assert stub.cleared == 1, (
+        "clear_avoidance_costs must run even when the probe raises"
+    )


### PR DESCRIPTION
Closes #3439

## Summary

Two composable fixes for the CoupledPathfinder budget blowout (curator options 2 + 3):

1. **Corridor-bounded coupled search** (`diffpair_routing.py`): route the P side single-ended via the C++-accelerated per-net pathfinder (never committed to the grid), dilate the path into a layer-agnostic corridor mask (`build_corridor_mask`), and run the joint-state coupled A* restricted to the corridor with half the per-pair budget. Falls back to the legacy unconstrained search with the remaining budget, so boards where the open search already converged (03/06) are unaffected.
2. **Aggregate coupled-phase cap**: new `DifferentialPairConfig.aggregate_timeout`; `Autorouter.route_all_with_diffpairs` auto-derives `max(per_pair_budget, 0.25 * timeout)` from `--timeout` (structured log `DIFFPAIR_AGGREGATE_TIMEOUT_AUTODERIVED`). Once exhausted, remaining pairs are deferred to the main strategy WITHOUT attempting coupled routing (`DIFFPAIR_AGGREGATE_BUDGET_EXCEEDED`), and the per-pair budget is clamped to the remaining aggregate. A failed coupled pre-pass can no longer burn `num_pairs * 60s` of the outer budget (the 7/31-reach incident: 7 x 60s = 420s of the 600s `--timeout`).

Per-pair timing is logged via `diffpair coupled timing: pair=... phase={corridor|open} elapsed=...s success=...`.

## Board 07 empirical results (`--differential-pairs --timeout 600`, load-contended host)

Per-pair timing before -> after:

| Pair | Before (main) | After |
|---|---|---|
| DQS | 60s budget blowout (~14k iters) | **coupled search completes in ~4s** (corridor); rejected by the pre-existing #3320 swap-overlap gate, falls through cleanly |
| MIPI_CLK / MIPI_DAT0 | 60s blowout each | 60s budget-exit each (their P sides cannot route single-ended at all — the #3438 reach gap — so no corridor exists) |
| MIPI_DAT1 | 60s blowout | 25s (per-pair budget clamped to remaining aggregate) |
| TMDS_D0/D1/D2 | 60s blowout each (180s) | **0s — deferred by the aggregate cap at 150s** |

- Coupled phase total: **150s (capped) vs 420s before**; the negotiated phase retains ~450s of the 600s budget.
- Reach: 26/31 under load (vs 7/31 in the incident; the documented solo baseline is 28/31, and the recipe notes concurrent runs degrade even the baseline to 25-26/31 — another builder's board-04 regression was running on this host).
- DRC delta (routed + pours, `--net-class-map`): baseline committed artifact = 21 errors (5 continuity + 5 skew + 1 intra = **11 diff-pair-attributable**); this run = 15 errors (4 continuity + 3 skew + 0 intra = **7 diff-pair-attributable**). The residual quality errors persist because no pair survives to a committed coupled route yet: MIPI is blocked by #3438 (no single-ended P path) and DQS by #3320 (swap-via centerline overlap). Board 07's recipe keeps `--differential-pairs` off; the empirical addendum is recorded in `generate_design.py`.

## Tests

- `tests/test_diffpair_corridor.py` (10 tests): corridor mask rasterization/dilation/bounds, corridor kwarg pruning + legacy default, corridor-phase integration (timing log asserts `phase=corridor`), guide route never committed.
- `tests/test_diffpair_aggregate_cap.py` (11 tests): config field + signatures, `--timeout` derivation (cap, floor, explicit-config precedence, back-compat), structured log, and the **load-bearing reach invariant**: with an exhausted aggregate budget the coupled pathfinder is never invoked and all nets (incl. diff-pair members) route via the main strategy.
- Regression: 29 tests in the #3089/#3321 timeout suites, 159 board-06/escape/diffpair tests, 136 detection/length/impedance tests, full `tests/test_board_03_regression.py` (10 passed incl. `test_usb_diff_pair_routes_via_coupled_pathfinder`, 26 min). One pre-existing order-dependent flake (`test_autorouter_invokes_tuner_for_each_pair`) fails identically on main.
- Pre-existing ruff findings in `core.py`/`diffpair_routing.py` are unchanged (24 on main, 24 here); new files are clean.

## Test plan
- [ ] CI green
- [ ] Judge review

🤖 Generated with [Claude Code](https://claude.com/claude-code)