### PR TITLE
feat(router): escalate two-phase stall fast-fails to relief rescue (closes #3494)

### DIFF
--- a/src/kicad_tools/router/algorithms/two_phase.py
+++ b/src/kicad_tools/router/algorithms/two_phase.py
@@ -11,6 +11,7 @@ GlobalRouter supporting per-layer capacity and negotiated congestion.
 from __future__ import annotations
 
 import copy
+import os
 import time
 from typing import TYPE_CHECKING, Any, Callable
 
@@ -63,6 +64,7 @@ class TwoPhaseRouter:
         interleave_match_groups: Callable[[list[int]], list[int]] | None = None,
         apply_byte_lane_inner_priority: Callable[[list[int]], list[int]] | None = None,
         stall_ripup_budget: int | None = None,
+        relief_rescue: Callable[..., bool] | None = None,
     ):
         self.grid = grid
         self.router = router
@@ -107,6 +109,20 @@ class TwoPhaseRouter:
         # initial-pass stall recovery in ``_detailed_negotiated``.  None
         # preserves the historical hardcoded default of 3 (Issue #2527).
         self._stall_ripup_budget = stall_ripup_budget
+        # Issue #3471: Optional hook to ``Autorouter._relief_rescue``
+        # (#3438 machinery).  The initial-pass stall path's
+        # BLOCKED_BY_COMPONENT rip-up fast-fails ("geometric blocker")
+        # when the failed net cannot route even with its destination-
+        # component siblings ripped -- on board 05's ISENSE cluster the
+        # actual blockage is non-rippable foreign ESCAPE copper in the
+        # U3 sense band, which sibling rip-up by construction cannot
+        # clear.  The relief rescue makes that copper passable at a
+        # penalty, displaces the crossed owner nets, and commits only
+        # when every victim re-lands (strict transaction), so it is the
+        # correct escalation for exactly the nets the rip-up returns
+        # False for.  ``None`` (e.g. unit tests constructing
+        # TwoPhaseRouter directly) preserves legacy behaviour.
+        self._relief_rescue = relief_rescue
 
         # Issue #2597: Communicates the reason the negotiated outer loop in
         # ``_detailed_negotiated()`` exited.  Read by the progress-callback
@@ -633,6 +649,8 @@ class TwoPhaseRouter:
                     if self._stall_ripup_budget is not None
                     else 3
                 )
+                relief_attempted = 0
+                relief_resolved = 0
                 for failed_net in list(stall_failed):
                     if check_timeout():
                         timed_out = True
@@ -647,8 +665,49 @@ class TwoPhaseRouter:
                         max_ripups_per_net=stall_budget,
                         per_net_timeout=per_net_timeout,
                     )
+                    # Issue #3471: escalate a rip-up "geometric blocker"
+                    # fast-fail to the #3438 relief rescue IMMEDIATELY
+                    # (interleaved, not in a deferred second pass).
+                    # These nets failed to route even with their
+                    # destination-component siblings ripped, which means
+                    # the blockage is NON-RIPPABLE copper (escape-phase
+                    # stubs / halos in the board-05 U3 sense band) that
+                    # only the relief probe can negotiate through.
+                    # Strictly transactional (commits only when the net
+                    # routes AND every displaced victim re-lands), one
+                    # attempt per net, honours the ``KCT_DISABLE_RELIEF=1``
+                    # escape hatch.  Interleaving matters: a single
+                    # sibling rip-up can burn 200+ s re-routing its
+                    # 24-net cohort before failing (board 05 ISENSE_A-),
+                    # so a deferred relief pass routinely found the
+                    # phase budget already exhausted.
+                    if (
+                        not rescued
+                        and self._relief_rescue is not None
+                        and not os.environ.get("KCT_DISABLE_RELIEF")
+                        and not check_timeout()
+                    ):
+                        relief_attempted += 1
+                        rescued = self._relief_rescue(
+                            failed_net,
+                            neg_router,
+                            net_routes,
+                            pads_by_net_local,
+                            present_factor,
+                            per_net_timeout,
+                            flush_print,
+                            elapsed_str,
+                        )
+                        if rescued:
+                            relief_resolved += 1
                     if rescued:
                         rescued_count += 1
+                if relief_attempted > 0:
+                    flush_print(
+                        f"  Stall relief rescue resolved "
+                        f"{relief_resolved}/{relief_attempted} net(s) "
+                        f"({elapsed_str()})"
+                    )
                 if rescued_count > 0:
                     flush_print(
                         f"  BLOCKED_BY_COMPONENT rip-up resolved "

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -9728,6 +9728,13 @@ class Autorouter:
             # (``--max-ripups-per-net``).  None preserves the historical
             # default of 3.
             stall_ripup_budget=self.stall_ripup_budget,
+            # Issue #3471: share the #3438 relief rescue with the
+            # two-phase initial-pass stall recovery so nets the
+            # BLOCKED_BY_COMPONENT rip-up fast-fails on ("geometric
+            # blocker": non-rippable foreign escape copper, the board-05
+            # ISENSE-cluster mechanism) get the same last-resort
+            # transactional escalation ``route_all_negotiated`` has.
+            relief_rescue=self._relief_rescue,
         )
 
     def route_all_two_phase(

--- a/tests/test_two_phase_stall_recovery.py
+++ b/tests/test_two_phase_stall_recovery.py
@@ -315,3 +315,87 @@ class TestTwoPhaseStallRecoveryInvocation:
         # thrash on charlieplex-style boards.
         for call in tp_router._attempt_blocked_component_ripup.call_args_list:
             assert call.kwargs["max_ripups_per_net"] >= 3
+
+
+class TestTwoPhaseStallReliefRescue:
+    """Issue #3471: the stall path escalates rip-up fast-fails to the
+    #3438 relief rescue.
+
+    Board 05's ISENSE cluster fails the BLOCKED_BY_COMPONENT rip-up at
+    0.0s even with all 24 destination-component siblings displaced: the
+    actual blockage is NON-RIPPABLE foreign escape copper in the U3
+    sense band, which sibling rip-up by construction cannot clear.  The
+    relief rescue (strictly transactional, foreign copper passable at a
+    penalty) is the correct escalation for exactly the nets the rip-up
+    returns False for.
+    """
+
+    def _make_tp_router(self, ar, ripup_result: bool, relief_result: bool = False):
+        tp_router = ar._create_two_phase_router()
+        tp_router._attempt_blocked_component_ripup = MagicMock(return_value=ripup_result)
+        tp_router._relief_rescue = MagicMock(return_value=relief_result)
+        # Force every net to fail the initial pass.
+        tp_router._route_net_with_corridor = MagicMock(return_value=[])
+        tp_router.grid.get_total_overflow = MagicMock(return_value=0)
+        return tp_router
+
+    def _run_detailed(self, tp_router):
+        from unittest.mock import patch as _patch
+
+        with _patch("kicad_tools.router.algorithms.NegotiatedRouter") as _NegMock:
+            _NegMock.return_value.find_nets_through_overused_cells = MagicMock(return_value=[])
+            _NegMock.return_value.rip_up_nets = MagicMock()
+            tp_router._detailed_negotiated(
+                net_order=[1, 2],
+                corridor_penalty=0.0,
+                corridors={},
+                progress_callback=None,
+                timeout=None,
+                start_time=0.0,
+                per_net_timeout=None,
+                initial_routes=None,
+                max_iterations=1,
+                patience=2,
+            )
+
+    def test_create_two_phase_router_threads_relief_rescue(self, autorouter_with_two_phase):
+        """``_create_two_phase_router`` must thread ``_relief_rescue``."""
+        ar = autorouter_with_two_phase
+        tp_router = ar._create_two_phase_router()
+        assert tp_router._relief_rescue is not None
+        assert tp_router._relief_rescue.__func__ is type(ar)._relief_rescue
+
+    def test_relief_invoked_for_ripup_fast_fails(self, autorouter_with_two_phase):
+        """Nets the rip-up could not rescue must each get one relief
+        rescue attempt."""
+        ar = autorouter_with_two_phase
+        tp_router = self._make_tp_router(ar, ripup_result=False)
+        self._run_detailed(tp_router)
+        # Both nets unrescued by the rip-up -> two relief attempts.
+        assert tp_router._relief_rescue.call_count == 2
+        attempted_nets = {c.args[0] for c in tp_router._relief_rescue.call_args_list}
+        assert attempted_nets == {1, 2}
+
+    def test_relief_not_invoked_when_ripup_rescues(self, autorouter_with_two_phase):
+        """A net the rip-up successfully rescued must NOT be escalated."""
+        ar = autorouter_with_two_phase
+        tp_router = self._make_tp_router(ar, ripup_result=True)
+        self._run_detailed(tp_router)
+        assert tp_router._relief_rescue.call_count == 0
+
+    def test_relief_honours_disable_env(self, autorouter_with_two_phase, monkeypatch):
+        """``KCT_DISABLE_RELIEF=1`` must keep the escalation off (the
+        #3438 emergency escape hatch covers this call site too)."""
+        monkeypatch.setenv("KCT_DISABLE_RELIEF", "1")
+        ar = autorouter_with_two_phase
+        tp_router = self._make_tp_router(ar, ripup_result=False)
+        self._run_detailed(tp_router)
+        assert tp_router._relief_rescue.call_count == 0
+
+    def test_relief_none_hook_preserves_legacy(self, autorouter_with_two_phase):
+        """A TwoPhaseRouter constructed without the hook (unit-test
+        construction path) must not raise in the stall path."""
+        ar = autorouter_with_two_phase
+        tp_router = self._make_tp_router(ar, ripup_result=False)
+        tp_router._relief_rescue = None
+        self._run_detailed(tp_router)  # must not raise


### PR DESCRIPTION
## Summary

Wires the #3488 relief rescue (`Autorouter._relief_rescue`: foreign non-obstacle copper passable at a penalty, strictly transactional commit/rollback) into the two-phase initial-pass stall recovery, so nets the BLOCKED_BY_COMPONENT sibling rip-up fast-fails on ("geometric blocker": the net cannot route even with all destination-component siblings displaced) get the same last-resort escalation `route_all_negotiated` already has. This is the stall path the production `kct route` entry point (`route_with_escape` -> `route_all_two_phase`) actually uses.

Integrates the ready-made implementation from `feature/two-phase-stall-relief` (a0a38cca, built and measured during the #3471 retry) onto current main — clean cherry-pick, no conflicts with the #3491 Steiner/cpp_backend/path fixes or #3493 (neither touched `two_phase.py`, and the `_relief_rescue` signature is unchanged).

### Design points

- **Interleaved, not deferred**: the rescue is invoked immediately after each rip-up fast-fail. A single sibling rip-up can burn 200+ s re-routing its 24-net cohort before failing (board 05 `ISENSE_A-`), so a deferred post-loop relief pass routinely found the phase budget already exhausted.
- **Strictly transactional**: commits only when the failed net routes in normal mode AND every displaced victim re-lands; otherwise verbatim rollback (#3488 semantics, unchanged).
- **`KCT_DISABLE_RELIEF=1`** escape hatch covers this call site too; a `None` hook (direct `TwoPhaseRouter` constructions, e.g. unit tests) preserves legacy behaviour.
- **`max_rounds=4` left unchanged**: the board-05 victim trend (10/4/2/1) was still converging at the cap, but a cap bump must be A/B'd on board 07 (the #3488 calibration board) — follow-on scope, see issue open question 1.

## Measurements

### Board 05 (production recipe via `boards/05-bldc-motor-controller/design.py`, seed 7, jlcpcb-tier1 + cpp + 4L) — NEUTRAL, exact parity

Fresh run on this branch reproduces the committed #3491 trajectory exactly:

| metric | committed artifact (#3491, no relief wiring) | this branch (fresh run) |
|---|---|---|
| main pass reach | 29/35 | 29/35 |
| step-6b rescues | ISENSE_A+, PWM_CL | ISENSE_A+, PWM_CL |
| final reach | **31/35** | **31/35** |
| `kct check --mfr jlcpcb-tier1` | connectivity 8, clearance 0, blocking 0 | connectivity 8, clearance 0, blocking 0 (byte-identical summary) |

The committed artifact is NOT touched by this PR (no reach/DRC change to commit).

### Relief escalation on the residual ISENSE nets (issue task: confirm the geometric-capacity diagnosis)

The rescue ENGAGES with the exact signature from the issue and rolls back cleanly:

```
Relief rescue: ISENSE_B- round 1 -- ripped 10 blocker(s): BST_A, BST_B, BST_C, GATE_AL, GATE_BH, GATE_BL, GATE_CL, GATE_DRV_BH, GATE_DRV_CH, PWM_BH
Relief rescue: ISENSE_B- round 2 -- ripped 4 blocker(s): GATE_DRV_AH, ISENSE_B+, PWM_BL, SW_OUT
Relief rescue: ISENSE_B- round 3 -- ripped 2 blocker(s): PWM_AH, PWM_CH
Relief rescue: ISENSE_B- round 4 -- ripped 1 blocker(s): NRST
Relief rescue: ISENSE_B- still conflicted after 4 rounds -- rolling back
Stall relief rescue resolved 0/1 net(s)
```

**Honest answer: relief escalation does NOT move the residual ISENSE nets at the current `max_rounds=4`.** The victim trend converges (10/4/2/1) but the transaction hits the round cap and rolls back verbatim — reach unchanged, 0 blocking maintained. `ISENSE_A-`'s relief attempt was correctly skipped by the timeout guard (its sibling rip-up burned 246 s of the phase budget first — the #3485 enforcement gap, separate issue). This confirms #3491's geometric-capacity diagnosis: the right machinery now reaches these nets and they still don't land; next levers are placement-level or a deeper round cap (A/B on board 07 required).

### Cross-board

- **216 passed, 5 skipped, 0 failed** (35:43) across: board02 manufacturable baseline + route demo recipe, board03 baselines + regression, board04 routing regression, board06 determinism + diffpair, board07 matchgroup, softstart manufacturable baseline + reach regression, board-05 allowlist/hotspot/drift, relief-rescue suite, and the committed-artifact gates (`test_ci_routed_drc_workflow`, `test_fleet_status_drc`, `test_fleet_ship_ready`).
- Softstart 0-DRC milestone artifact untouched (test fixtures regenerate `boards/external/softstart/output/` in place; the churn was restored to HEAD — `git status` clean).
- The two env-gated softstart reach tests (`KICAD_RUN_SLOW_SOFTSTART_REACH=1`, excluded from CI) hit their fixture's 480-s subprocess cap on this machine. **Causality ruled out**: the identical run with `KCT_DISABLE_RELIEF=1` (escalation fully off, relief never invoked) times out at exactly the same 480-s cap — the cause is machine contention (two concurrent agent routing jobs at 100 % CPU during the measurement window), not this change.

## Changes

- `src/kicad_tools/router/algorithms/two_phase.py` — `relief_rescue` ctor hook + interleaved escalation in the stall loop + per-pass `Stall relief rescue resolved m/n` log line
- `src/kicad_tools/router/core.py` — `_create_two_phase_router` threads `self._relief_rescue`
- `tests/test_two_phase_stall_recovery.py` — 5 regression tests (`TestTwoPhaseStallReliefRescue`): hook threading, escalation on fast-fail only, no escalation when rip-up rescues, `KCT_DISABLE_RELIEF=1`, `None`-hook legacy path

## Test Plan

- [x] `tests/test_two_phase_stall_recovery.py` — 12 passed (5 new + 7 pre-existing)
- [x] Board 05 production recipe fresh run: 31/35 + 0 blocking, byte-identical DRC summary vs committed artifact
- [x] Cross-board battery (relief suite, board02/03/04/06/07 + softstart baselines, board-05 allowlist/hotspot/drift, fleet/CI artifact gates): 216 passed, 5 skipped, 0 failed
- [x] Env-gated softstart reach tests: timeout reproduced identically with `KCT_DISABLE_RELIEF=1` — machine contention, not this change (see Cross-board section)
- [x] Lint: `ruff check` on changed files at exact failure-parity with main (25 pre-existing, none introduced)

Closes #3494

🤖 Generated with [Claude Code](https://claude.com/claude-code)
