### PR TITLE
fix(boards/06): MIPI_RST escape + USB2_D+ correction-before-demotion + J1 hotspot (refs #3413)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,7 +377,14 @@ jobs:
     # build + ~9-10 min Python coupled routing exceeds the prior 10-min
     # ceiling.  If the typical run creeps above 5 minutes, move to a
     # nightly schedule per the epic's runtime guidance.
-    timeout-minutes: 15
+    #
+    # Issue #3413 (phase 3): 15 -> 20 min.  The board 06 recipe's
+    # negotiated budget grew 240 -> 360s (so the iteration-3 stagnation
+    # recovery completes instead of being killed mid-surgery) and the
+    # timed-out exit now pays a bounded (<= 90s) post-route correction
+    # pass.  Local M-series wall is ~17 min; the 2-core ubuntu runner
+    # needs the extra headroom.
+    timeout-minutes: 20
     # Board 06 (diffpair-test) status (M-F closure, Issue #3097):
     #
     #   * LATENCY: #3089 landed a per-pair wall-clock budget plumbed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,12 +378,15 @@ jobs:
     # ceiling.  If the typical run creeps above 5 minutes, move to a
     # nightly schedule per the epic's runtime guidance.
     #
-    # Issue #3413 (phase 3): 15 -> 20 min.  The board 06 recipe's
-    # negotiated budget grew 240 -> 360s (so the iteration-3 stagnation
-    # recovery completes instead of being killed mid-surgery) and the
-    # timed-out exit now pays a bounded (<= 90s) post-route correction
-    # pass.  Local M-series wall is ~17 min; the 2-core ubuntu runner
-    # needs the extra headroom.
+    # Issue #3413 (phase 3): 15 -> 20 min.  The board 06 recipe KEEPS
+    # its 240s negotiated budget (a 360s A/B was measured and REJECTED;
+    # see boards/06-diffpair-test/generate_design.py), but the run now
+    # pays for the overflow-silent rescue work inside the loop plus a
+    # bounded (<= 90s) post-route correction pass on the timed-out
+    # exit.  Local M-series wall is ~17 min; the 2-core ubuntu runner
+    # needs the extra headroom.  Also closes #3477 (sub-minute margin
+    # under the prior 15-min ceiling; option 1 -- ceiling bump -- was
+    # its preferred fix).
     timeout-minutes: 20
     # Board 06 (diffpair-test) status (M-F closure, Issue #3097):
     #

--- a/boards/06-diffpair-test/generate_design.py
+++ b/boards/06-diffpair-test/generate_design.py
@@ -589,6 +589,19 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
     # is the strategy ``route_all`` recommends for dense boards and
     # it composes with the diff-pair pre-pass via the
     # ``non_diffpair_strategy`` callable hook (Issue #2464).
+    # Issue #3413 (phase 3): the 240s budget was A/B-measured against
+    # 360s and KEPT.  At 360s the loop reaches iterations 3-4, where it
+    # banks a routed=21/connected=20 snapshot whose extra copper is a
+    # PARTIAL USB3_RX1- route carrying a heavy post-optimizer violation
+    # load (measured: DRC 36 vs the 9-13 band at 240s) -- the lex tuple
+    # prefers the higher routed count when connected ties.  At 240s the
+    # #3413 overflow-silent rescue still fires inside iteration 2
+    # (MIPI_RST rescued at ~110-215s), the stagnation recovery's
+    # no-net-loss restore bounds the mid-surgery timeout, and the
+    # bounded post-timeout correction pass repairs the USB2_D+
+    # crossover -- yielding the stable 20/21 @ 9-13 error trajectory.
+    # USB3_RX1- does not fully connect at either budget (J1 fan-out
+    # geometry; see #3413 phase-3 residual notes).
     def _negotiated_non_diffpair_strategy() -> list:
         return router.route_all_negotiated(
             per_net_timeout=30.0,

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -6638,6 +6638,13 @@ class Autorouter:
         # a diagnostic / emergency escape hatch.
         relief_disabled = bool(os.environ.get("KCT_DISABLE_RELIEF"))
         max_relief_probes_per_net = 0 if relief_disabled else 3
+        # Issue #3413: hard wall-clock deadline for relief rescues.  A
+        # rescue is a composite of stages that are each bounded but whose
+        # product is not (board 06 measurement: one rescue ran 342s past
+        # a 240s loop budget).  Bound every rescue by the loop's own
+        # wall budget; the rescue transaction rolls back verbatim when
+        # the deadline strikes mid-flight.
+        relief_deadline = (start_time + timeout) if timeout is not None else None
         # Issue #2295: Per-net rip-up stall tracking.  For each net that
         # passes through overused cells, count consecutive rip-up iterations
         # where the net's overflow contribution did not improve.  Nets that
@@ -6676,6 +6683,20 @@ class Autorouter:
         cohort_history: list[frozenset[int]] = []
         stagnation_recovery_count = 0
         max_stagnation_recoveries = 2
+        # Issue #3413: per-net consecutive hard-failure counter.  A net
+        # whose A* fails on pin access (start/target corridor sealed by
+        # committed foreign copper) emits NO overflow, so PathFinder
+        # negotiation never rips its blockers.  When unrelated congestion
+        # holds ``overflow > 0`` (board 06: the J1 USB3 cluster), the
+        # ``overflow == 0`` stall gate below never opens and such nets
+        # stay unrouted forever (board 06 MIPI_RST: 0 segments across all
+        # iterations while earlier-routed MIPI_CLK/D0 copper seals the U4
+        # corridor for its wide impedance-resolved trace).  Nets that fail
+        # ``hard_fail_rescue_threshold`` consecutive iterations engage the
+        # overflow-silent rescue block (targeted rip-up + relief rescue)
+        # even while overflow > 0.
+        hard_fail_iterations: dict[int, int] = {}
+        hard_fail_rescue_threshold = 2
         for net in net_order:
             if net in self.nets:
                 pads_for_routing = self.nets[net]
@@ -7742,6 +7763,18 @@ class Autorouter:
                         ripup_targets = [
                             n for n in recovery_cohort if n in net_routes and net_routes[n]
                         ]
+                        # Issue #3413: snapshot the ripped cohort so members
+                        # whose elevated-cost reroute fails are restored
+                        # verbatim.  Measured on board 06 (seed 42): the
+                        # recovery ripped 11 nets, re-landed 7, and left the
+                        # iteration with connected 19 -> 15 -- a strictly
+                        # worse state that also burned the wall budget the
+                        # later iterations needed.  Restoring failures keeps
+                        # the recovery monotone in reach: it can only swap
+                        # geometry, never lose a routed net.
+                        recovery_original_routes: dict[int, list[Route]] = {
+                            n: list(net_routes.get(n, [])) for n in ripup_targets
+                        }
                         if ripup_targets:
                             neg_router.rip_up_nets(ripup_targets, net_routes, self.routes)
                         # Re-route each cohort member fresh with elevated cost
@@ -7762,6 +7795,25 @@ class Autorouter:
                                     self.grid.mark_route_usage(route)
                                     self.routes.append(route)
                                 recovered_count += 1
+                        # Issue #3413: no-net-loss restore for cohort members
+                        # that were ripped but did not re-land (reroute failed
+                        # or the timeout broke the loop mid-cohort).
+                        recovery_restored = 0
+                        for rn in ripup_targets:
+                            if not net_routes.get(rn) and recovery_original_routes.get(rn):
+                                restored = recovery_original_routes[rn]
+                                net_routes[rn] = restored
+                                for route in restored:
+                                    self._mark_route(route)
+                                    self.grid.mark_route_usage(route)
+                                    if route not in self.routes:
+                                        self.routes.append(route)
+                                recovery_restored += 1
+                        if recovery_restored:
+                            flush_print(
+                                f"  Stagnation recovery restored {recovery_restored} "
+                                f"net(s) whose reroute failed (no-net-loss)"
+                            )
                         # Recompute overflow & cohort tracking after recovery
                         current_overflow = self.grid.get_total_overflow()
                         overused = self.grid.find_overused_cells()
@@ -7825,6 +7877,15 @@ class Autorouter:
                     # branch), after the iteration's best state is
                     # already banked.
                     for fn in list(failed_net_ids):
+                        # Issue #3413: per-net wall-clock check.  This
+                        # recovery previously had NO timeout discipline:
+                        # measured on board 06 it ran 380s past a 360s
+                        # budget (21 elevated-cost attempts at up to 30s
+                        # each), and the loop then "discovered" the
+                        # exhausted budget only at the next reroute.
+                        if check_timeout():
+                            timed_out = True
+                            break
                         # Issue #3448: ``net_routes.get(fn)`` (not bare
                         # membership) so a ripped-then-failed net with an
                         # empty-list entry still receives the elevated-cost
@@ -8399,6 +8460,17 @@ class Autorouter:
                             and n not in off_grid_nets
                         )
                     ]
+                    # Issue #3413: update the consecutive hard-failure
+                    # counters (fully unrouted nets only -- partials still
+                    # have copper down and negotiate normally).
+                    for _hf_net in still_failed:
+                        if not net_routes.get(_hf_net):
+                            hard_fail_iterations[_hf_net] = (
+                                hard_fail_iterations.get(_hf_net, 0) + 1
+                            )
+                    for _hf_net in list(hard_fail_iterations):
+                        if net_routes.get(_hf_net):
+                            hard_fail_iterations.pop(_hf_net)
                     if overflow == 0 and still_failed and not timed_out and not hotset_only:
                         flush_print(
                             f"  Stall detected: {len(still_failed)} net(s) unrouted with 0 overflow"
@@ -8609,6 +8681,7 @@ class Autorouter:
                                 per_net_timeout,
                                 flush_print,
                                 elapsed_str,
+                                deadline=relief_deadline,
                             ):
                                 relief_resolved += 1
                         if relief_attempted > 0:
@@ -8618,6 +8691,108 @@ class Autorouter:
                             )
                             overflow = self.grid.get_total_overflow()
                             overused = self.grid.find_overused_cells()
+
+                    # Issue #3413: Overflow-silent hard-failure rescue.
+                    # The targeted-fallback chain above only opens when
+                    # overflow == 0, but a pin-access hard failure emits NO
+                    # overflow signal -- when UNRELATED congestion keeps
+                    # overflow > 0 the failed net's blockers are never in
+                    # the rip-up cohort and the net stays at 0 segments
+                    # forever (board 06 MIPI_RST: sealed U4 escape corridor
+                    # while the J1 USB3 cluster holds overflow at 3).  For
+                    # nets that have been fully unrouted for
+                    # ``hard_fail_rescue_threshold`` consecutive iterations,
+                    # run the same targeted rip-up + relief-rescue sequence
+                    # the overflow==0 chain uses.  Both helpers are
+                    # transactional (verbatim rollback on failure) and
+                    # attempt-capped per net (``ripup_history`` /
+                    # ``relief_probe_attempts``), so hopeless geometry
+                    # cannot burn the wall budget every iteration.
+                    if overflow > 0 and still_failed and not timed_out and not hotset_only:
+                        silent_failed = [
+                            n for n in still_failed
+                            if not net_routes.get(n)
+                            and hard_fail_iterations.get(n, 0) >= hard_fail_rescue_threshold
+                            and len(pads_by_net.get(n, [])) >= 2
+                        ]
+                        if silent_failed:
+                            silent_names = sorted(
+                                self.net_names.get(n, f"Net_{n}") for n in silent_failed
+                            )
+                            flush_print(
+                                f"  Overflow-silent hard failure: {len(silent_failed)} net(s) "
+                                f"unrouted >= {hard_fail_rescue_threshold} iteration(s) with "
+                                f"overflow={overflow} elsewhere - engaging targeted rescue "
+                                f"({elapsed_str()}): {', '.join(silent_names)}"
+                            )
+                            silent_resolved = 0
+                            for failed_net in silent_failed:
+                                if check_timeout():
+                                    timed_out = True
+                                    break
+
+                                # 1) Targeted rip-up of direct-line blockers
+                                # (same Bresenham scan as the overflow==0
+                                # chain; transactional inside targeted_ripup).
+                                pads_for_net = pads_by_net.get(failed_net, [])
+                                blocking_nets: set[int] = set()
+                                for j in range(len(pads_for_net) - 1):
+                                    blockers = neg_router.find_blocking_nets_for_connection(
+                                        pads_for_net[j], pads_for_net[j + 1]
+                                    )
+                                    blocking_nets.update(blockers)
+                                if blocking_nets:
+
+                                    def _mark_route_silent(route: Route) -> None:
+                                        self._mark_route(route)
+
+                                    if neg_router.targeted_ripup(
+                                        failed_net=failed_net,
+                                        blocking_nets=blocking_nets,
+                                        net_routes=net_routes,
+                                        routes_list=self.routes,
+                                        pads_by_net=pads_by_net,
+                                        present_cost_factor=present_factor,
+                                        mark_route_callback=_mark_route_silent,
+                                        ripup_history=ripup_history,
+                                        max_ripups_per_net=max_ripups_per_net,
+                                        per_net_timeout=per_net_timeout,
+                                    ):
+                                        silent_resolved += 1
+                                        continue
+
+                                # 2) Relief rescue (clearance-halo seals the
+                                # Bresenham scan cannot see).
+                                if (
+                                    relief_probe_attempts.get(failed_net, 0)
+                                    >= max_relief_probes_per_net
+                                ):
+                                    continue
+                                relief_probe_attempts[failed_net] = (
+                                    relief_probe_attempts.get(failed_net, 0) + 1
+                                )
+                                if self._relief_rescue(
+                                    failed_net,
+                                    neg_router,
+                                    net_routes,
+                                    pads_by_net,
+                                    present_factor,
+                                    per_net_timeout,
+                                    flush_print,
+                                    elapsed_str,
+                                    deadline=relief_deadline,
+                                ):
+                                    silent_resolved += 1
+                            if silent_resolved > 0:
+                                for n in list(hard_fail_iterations):
+                                    if net_routes.get(n):
+                                        hard_fail_iterations.pop(n)
+                                overflow = self.grid.get_total_overflow()
+                                overused = self.grid.find_overused_cells()
+                            flush_print(
+                                f"  Overflow-silent rescue resolved {silent_resolved}/"
+                                f"{len(silent_failed)} net(s) ({elapsed_str()})"
+                            )
 
                     # Issue #2297: Neighborhood rip-up for standard path when
                     # targeted fallback was insufficient and nets remain stalled.
@@ -8916,12 +9091,40 @@ class Autorouter:
         # rip up both offending nets and reroute them with the current
         # (tightened) blocking radius so they settle into violation-free
         # positions.
-        if not timed_out and successful_nets > 0:
+        #
+        # Issue #3413: also run on the ``timed_out`` path, bounded to a
+        # single pass.  Previously the timeout exit skipped correction
+        # entirely, so the #3433 demotion below was the FIRST thing to
+        # see a repairable overlap and stripped the net instead of
+        # letting the correction pass reroute it (board 06 USB2_D+:
+        # routed every sweep, demoted every sweep).  One bounded pass
+        # (each reroute capped by ``per_net_timeout``) is the repair
+        # opportunity the demotion safety net was always meant to run
+        # after.
+        if successful_nets > 0:
+            # On the timed-out exit the loop's budget is already spent, so
+            # the bounded pass gets a hard wall allowance (90s or 25% of
+            # the loop budget, whichever is smaller) and a clamped per-net
+            # budget.  When the allowance expires mid-pass the pass's
+            # all-or-nothing transaction rolls back verbatim, so a
+            # truncated pass can never leave the board worse.  Without
+            # this cap the softstart `kct route` path (multi-rung layer
+            # escalation, each rung able to time out) paid the full
+            # correction cost per rung and blew CI harness timeouts.
+            correction_deadline = None
+            correction_per_net_timeout = per_net_timeout
+            if timed_out:
+                allowance = 90.0 if timeout is None else min(90.0, 0.25 * timeout)
+                correction_deadline = time.time() + allowance
+                if per_net_timeout is not None:
+                    correction_per_net_timeout = min(10.0, per_net_timeout)
             corrected = self._post_route_clearance_correction(
                 net_routes=net_routes,
                 pads_by_net=pads_by_net,
                 present_factor=present_factor,
-                per_net_timeout=per_net_timeout,
+                per_net_timeout=correction_per_net_timeout,
+                max_correction_passes=1 if timed_out else 3,
+                deadline=correction_deadline,
             )
             if corrected > 0:
                 total_elapsed = time.time() - start_time
@@ -8938,8 +9141,9 @@ class Autorouter:
         # are unmanufacturable hard-gate failures, whereas an unrouted
         # net is an advisory connectivity finding -- the trade is
         # strictly better.  Runs AFTER the correction pass (which gets
-        # first chance to actually fix the geometry) and ALSO on the
-        # ``timed_out`` path that skips the correction pass entirely.
+        # first chance to actually fix the geometry; since issue #3413
+        # the correction pass also runs -- single-pass bounded -- on the
+        # ``timed_out`` exit).
         demoted = self._demote_seg_seg_overlap_nets(net_routes, neg_router)
         if demoted:
             successful_nets = sum(1 for routes in net_routes.values() if routes)
@@ -9156,6 +9360,7 @@ class Autorouter:
         flush_print_fn,
         elapsed_fn,
         depth: int = 0,
+        deadline: float | None = None,
     ) -> bool:
         """Transactional relief rescue for a zero-overflow hard failure.
 
@@ -9172,10 +9377,28 @@ class Autorouter:
         verbatim and ``False`` is returned -- a failed rescue never
         leaves the board worse than it found it.
 
+        Args (selected):
+            deadline: Issue #3413: optional absolute ``time.time()``
+                deadline (typically ``start_time + timeout`` of the
+                calling negotiated loop).  A rescue is a multi-stage
+                composite (probe rounds x victim re-land passes x
+                depth-1 nested rescues), each stage individually
+                bounded by ``per_net_timeout`` -- but their PRODUCT ran
+                to 342s on board 06 (measured during the #3413 work)
+                and blew the loop's whole wall budget on one hopeless
+                rescue.  When the deadline passes mid-rescue the
+                transaction rolls back verbatim and returns False, so
+                the bound costs nothing in correctness.
+
         Returns:
             True when the failed net is now routed and no sibling was
             lost; False after a verbatim rollback.
         """
+        import time as _time
+
+        def _past_deadline() -> bool:
+            return deadline is not None and _time.time() >= deadline
+
         max_rounds = 4
         snapshot_nets: set[int] = {failed_net}
         original_routes: dict[int, list[Route]] = {
@@ -9214,6 +9437,13 @@ class Autorouter:
         probe_timeout = min(10.0, per_net_timeout) if per_net_timeout else 10.0
         committed_routes: list[Route] | None = None
         for round_idx in range(max_rounds):
+            if _past_deadline():
+                flush_print_fn(
+                    f"  Relief rescue: {failed_name} deadline exceeded "
+                    f"(round {round_idx + 1}) -- rolling back ({elapsed_fn()})"
+                )
+                _rollback()
+                return False
             probe_routes, victims = self._relief_probe(
                 failed_net, present_factor, per_net_timeout=probe_timeout
             )
@@ -9317,6 +9547,9 @@ class Autorouter:
             still_pending: list[int] = []
             progress = False
             for rn in pending:
+                if _past_deadline():
+                    still_pending.append(rn)
+                    continue
                 rn_routes = self._route_net_negotiated(
                     rn, present_factor, per_net_timeout=restart_timeout
                 )
@@ -9343,6 +9576,9 @@ class Autorouter:
         if pending and depth == 0:
             still_pending = []
             for rn in pending:
+                if _past_deadline():
+                    still_pending.append(rn)
+                    continue
                 if self._relief_rescue(
                     rn,
                     neg_router,
@@ -9353,6 +9589,7 @@ class Autorouter:
                     flush_print_fn,
                     elapsed_fn,
                     depth=depth + 1,
+                    deadline=deadline,
                 ):
                     relanded += 1
                 else:
@@ -9521,6 +9758,7 @@ class Autorouter:
         present_factor: float = 0.5,
         per_net_timeout: float | None = None,
         max_correction_passes: int = 3,
+        deadline: float | None = None,
     ) -> int:
         """Rip-up and reroute nets involved in seg-seg clearance violations.
 
@@ -9542,10 +9780,20 @@ class Autorouter:
             present_factor: Congestion cost factor for rerouting.
             per_net_timeout: Optional per-net A* timeout.
             max_correction_passes: Maximum correction iterations (default 3).
+            deadline: Issue #3413: optional absolute ``time.time()``
+                deadline.  Checked before each per-net reroute; when it
+                strikes mid-pass the remaining nets count as
+                failed-to-re-land, which triggers the pass's
+                all-or-nothing rollback (pre-pass state restored
+                verbatim).  Used by the ``timed_out`` exit of
+                ``route_all_negotiated`` so a budget-exhausted run pays
+                a bounded, contained surcharge for the repair attempt.
 
         Returns:
             Total number of nets that were rerouted across all passes.
         """
+        import time as _time
+
         from .io import validate_routes
 
         total_corrected = 0
@@ -9602,12 +9850,34 @@ class Autorouter:
 
             # Rip up all violating nets
             nets_to_reroute = [n for n in violating_nets if n in net_routes]
+            # Issue #3413: snapshot original routes so a net whose
+            # reroute FAILS can be restored verbatim.  Measured on
+            # board 06: the pass ripped USB2_D+/USB2_D-, re-landed
+            # USB2_D+ in a better position, then USB2_D-'s A* failed
+            # inside ``per_net_timeout`` -- and the pass silently
+            # dropped the net (19/21 where the loop had committed
+            # 20/21).  A restored original may still hold its
+            # clearance violation, but a violation is repairable by
+            # the later passes (or strippable by the #3433 demotion)
+            # whereas a silently-lost net is strictly worse.
+            original_correction_routes: dict[int, list[Route]] = {
+                n: list(net_routes.get(n, [])) for n in nets_to_reroute
+            }
             neg_router.rip_up_nets(nets_to_reroute, net_routes, self.routes)
 
             # Reroute them one at a time, re-validating after each net to
             # catch violations introduced by sequential placement (Issue #1783).
             rerouted_count = 0
             for net_idx, net in enumerate(nets_to_reroute):
+                # Issue #3413: bounded-surcharge deadline.  Unprocessed
+                # nets stay unrouted here and are swept into the
+                # all-or-nothing rollback below.
+                if deadline is not None and _time.time() >= deadline:
+                    flush_print(
+                        f"  Correction pass deadline reached at net "
+                        f"{net_idx}/{len(nets_to_reroute)}"
+                    )
+                    break
                 # Issue #1798: Use a higher present_factor for nets that had
                 # inner-layer violations, encouraging wider spacing.
                 net_pf = present_factor * 2.0 if net in inner_violating_nets else present_factor
@@ -9654,6 +9924,54 @@ class Autorouter:
                                 for route in retry_routes:
                                     self.grid.mark_route(route)
                                     self.routes.append(route)
+
+            # Issue #3413: ALL-OR-NOTHING transaction.  If any ripped net
+            # failed to re-land, roll the ENTIRE pass back to the
+            # pre-pass state.  Two measured failure shapes motivated
+            # this (board 06 USB2_D+/USB2_D- X-crossover):
+            #
+            #   * no restore at all: the pass silently DROPPED the
+            #     failed net (19/21 where the loop committed 20/21);
+            #   * partial restore (keep the successful reroutes, restore
+            #     only the failures): the restored original geometry
+            #     physically OVERLAPPED its partner's NEW position, and
+            #     the #3433 demotion then stripped the partner -- same
+            #     net loss, plus extra DRC noise.
+            #
+            # The pre-pass state is only ever a positive-clearance
+            # near-miss (overlaps never reach this pass on the loop's
+            # best snapshot), which the DRC nudge pass can still repair
+            # -- strictly better than either failure shape.
+            failed_to_reland = [
+                n for n in nets_to_reroute if not net_routes.get(n)
+            ]
+            if failed_to_reland:
+                for net in nets_to_reroute:
+                    # Unwind any copper this pass placed (committed via
+                    # ``mark_route`` above).
+                    for route in list(net_routes.get(net, [])):
+                        self.grid.unmark_route(route)
+                        self.grid.unmark_route_usage(route)
+                        if route in self.routes:
+                            self.routes.remove(route)
+                    net_routes[net] = []
+                for net in nets_to_reroute:
+                    restored = list(original_correction_routes.get(net, []))
+                    net_routes[net] = restored
+                    for route in restored:
+                        self.grid.mark_route(route)
+                        self.grid.mark_route_usage(route)
+                        if route not in self.routes:
+                            self.routes.append(route)
+                failed_names = sorted(
+                    self.net_names.get(n, f"Net_{n}") for n in failed_to_reland
+                )
+                flush_print(
+                    f"  Correction pass rolled back: {len(failed_to_reland)} "
+                    f"net(s) failed to re-land ({', '.join(failed_names)}) "
+                    f"-- pre-pass state restored verbatim (no-net-loss)"
+                )
+                break
 
             total_corrected += rerouted_count
             flush_print(

--- a/src/kicad_tools/router/path.py
+++ b/src/kicad_tools/router/path.py
@@ -406,7 +406,24 @@ def create_intra_ic_routes(
             direct = [(pad1.x, pad1.y), (pad2.x, pad2.y)]
             path: list[tuple[float, float]] | None = None
             kind = "route"
-            if not _path_violates(direct, trace_width, layer, clearance, same_pkg_foreign):
+            # Issue #3413: validate the DIRECT path against previously
+            # routed copper of other nets too, not only same-package
+            # foreign pads.  The USB-C reversible pinout makes this
+            # concrete (board 06 J1): USB2_D- ties B7->A7 first, then
+            # USB2_D+'s direct A6->B6 tie crosses that committed copper
+            # at the row midpoint -- a physical same-layer overlap that
+            # the #3433 safety net later demotes to unrouted.  With the
+            # obstacle check the crossing tie falls through to the
+            # perimeter wrap, and failing that defers to the main A*
+            # (which can resolve the crossover with a layer swap).
+            if not _path_violates(
+                direct,
+                trace_width,
+                layer,
+                clearance,
+                same_pkg_foreign,
+                obstacle_segments=obstacle_segments,
+            ):
                 path = direct
             else:
                 # Issue #3480: direct path violates same-package pad
@@ -428,9 +445,27 @@ def create_intra_ic_routes(
                     and p.y + p.height / 2.0 >= wminy - margin
                     and p.y - p.height / 2.0 <= wmaxy + margin
                 ]
+                # Issue #3413: cap the acceptable wrap detour.  The wrap
+                # primitive was built for small packages (SOT-23 scale)
+                # where the perimeter detour is 2-3x the direct distance.
+                # On a large pad field (board 06 J1 USB-C) the shortest
+                # legal wrap measured 21.8mm for a 2.24mm tie (9.7x) --
+                # electrically a long stub and, worse, it consumed the
+                # connector's fan-out fabric and collapsed neighbouring
+                # nets.  Past 4x the main A* (layer swap via a via pair)
+                # is strictly better, so defer instead.
+                max_wrap_length = 4.0 * dist
                 for candidate in _perimeter_wrap_candidates(
                     pad1, pad2, component_pads, trace_width, clearance
                 ):
+                    candidate_length = sum(
+                        math.hypot(b[0] - a[0], b[1] - a[1])
+                        for a, b in zip(candidate, candidate[1:], strict=False)
+                    )
+                    if candidate_length > max_wrap_length:
+                        # Candidates are sorted shortest-first: nothing
+                        # acceptable remains.
+                        break
                     if not _path_violates(
                         candidate,
                         trace_width,

--- a/tests/router/test_seg_seg_quality_tuple.py
+++ b/tests/router/test_seg_seg_quality_tuple.py
@@ -436,3 +436,143 @@ class TestDemoteSegSegOverlapNets:
 
         assert ar._demote_seg_seg_overlap_nets(net_routes, neg) == []
         assert net_routes[1] == [r1] and net_routes[2] == [r2]
+
+
+# ---------------------------------------------------------------------------
+# Issue #3413: correction pass must run BEFORE demotion on the timeout exit
+# ---------------------------------------------------------------------------
+
+
+class TestCorrectionBeforeDemotionOnTimeout:
+    """``route_all_negotiated``'s timeout exit must give the post-route
+    clearance-correction pass a (bounded) chance to repair geometry
+    BEFORE the #3433 overlap demotion strips nets.
+
+    Board 06's USB2_D+ made the gap concrete: the negotiated loop exits
+    via timeout, the old ``not timed_out`` gate skipped
+    ``_post_route_clearance_correction`` entirely, and the demotion
+    safety net was the FIRST consumer of a repairable overlap -- so the
+    net was stripped every sweep instead of rerouted.
+    """
+
+    def _make_autorouter(self) -> Autorouter:
+        ar = Autorouter(
+            width=20.0,
+            height=20.0,
+            origin_x=0.0,
+            origin_y=0.0,
+            rules=_make_rules(),
+            layer_stack=LayerStack.two_layer(),
+        )
+        pads1 = [
+            {"number": "1", "x": 2.0, "y": 5.0, "net": 1, "net_name": "NET1"},
+            {"number": "2", "x": 12.0, "y": 5.0, "net": 1, "net_name": "NET1"},
+        ]
+        pads2 = [
+            {"number": "1", "x": 2.0, "y": 10.0, "net": 2, "net_name": "NET2"},
+            {"number": "2", "x": 12.0, "y": 10.0, "net": 2, "net_name": "NET2"},
+        ]
+        ar.add_component("R1", pads1)
+        ar.add_component("R2", pads2)
+        return ar
+
+    @staticmethod
+    def _instrument(monkeypatch, calls):
+        """Replace the correction + demotion passes with order recorders."""
+
+        def _fake_correction(self, **kwargs):
+            calls.append(("correction", kwargs.get("max_correction_passes")))
+            return 0
+
+        def _fake_demotion(self, net_routes, neg_router):
+            calls.append(("demotion", None))
+            return []
+
+        monkeypatch.setattr(
+            Autorouter, "_post_route_clearance_correction", _fake_correction
+        )
+        monkeypatch.setattr(
+            Autorouter, "_demote_seg_seg_overlap_nets", _fake_demotion
+        )
+
+    def test_correction_runs_bounded_before_demotion_on_timeout(self, monkeypatch):
+        ar = self._make_autorouter()
+
+        # Fake clock: every _route_net_negotiated call costs 10 fake
+        # seconds, so with timeout=10 the iteration-0 loop trips the
+        # wall-clock check after the first net (elapsed 10 >= 10) and
+        # exits via the ``timed_out`` path with successful_nets >= 1.
+        # ``route_all_negotiated`` imports ``time`` function-locally, so
+        # patch the global ``time.time``; monkeypatch restores it on
+        # teardown and nothing in this test depends on real wall-clock.
+        class _FakeClock:
+            t = 1000.0
+
+        import time as _time_mod
+
+        monkeypatch.setattr(_time_mod, "time", lambda: _FakeClock.t)
+
+        real_route = Autorouter._route_net_negotiated
+
+        def _slow_route(self, net, present_factor, per_net_timeout=None):
+            _FakeClock.t += 10.0
+            return real_route(
+                self, net, present_factor, per_net_timeout=per_net_timeout
+            )
+
+        monkeypatch.setattr(Autorouter, "_route_net_negotiated", _slow_route)
+
+        calls: list[tuple[str, object]] = []
+        self._instrument(monkeypatch, calls)
+
+        ar.route_all_negotiated(timeout=10.0, per_net_timeout=5.0)
+
+        names = [name for name, _ in calls]
+        assert "correction" in names, (
+            "Timeout exit must still run the bounded correction pass "
+            "(successful_nets > 0)"
+        )
+        assert "demotion" in names, "The #3433 safety net must always run"
+        assert names.index("correction") < names.index("demotion"), (
+            "Correction must get first chance at the geometry before demotion"
+        )
+        correction_passes = dict(calls)["correction"]
+        assert correction_passes == 1, (
+            f"Timed-out exit must bound the correction to a single pass, "
+            f"got max_correction_passes={correction_passes}"
+        )
+
+    def test_correction_unbounded_on_clean_exit(self, monkeypatch):
+        """Non-timeout exits keep the historical 3-pass budget.
+
+        The iteration loop must actually run (the zero-overflow
+        early-return after iteration 0 skips the tail entirely), so
+        force a phantom overflow reading: the loop spins without a
+        cohort, exits without ``timed_out``, and the tail must call the
+        correction pass with the historical 3-pass budget.
+        """
+        ar = self._make_autorouter()
+
+        real_overflow = type(ar.grid).get_total_overflow
+        overflow_calls = {"n": 0}
+
+        def _phantom_overflow(self):
+            overflow_calls["n"] += 1
+            # First reading (post-iteration-0) reports phantom overflow so
+            # the early "No conflicts" return is skipped; later readings
+            # are truthful so the loop winds down naturally.
+            if overflow_calls["n"] == 1:
+                return 1
+            return real_overflow(self)
+
+        monkeypatch.setattr(type(ar.grid), "get_total_overflow", _phantom_overflow)
+
+        calls: list[tuple[str, object]] = []
+        self._instrument(monkeypatch, calls)
+
+        ar.route_all_negotiated(timeout=600.0, per_net_timeout=5.0)
+
+        assert calls, "Clean exit with routed nets must run the correction pass"
+        assert calls[0] == ("correction", 3)
+        names = [name for name, _ in calls]
+        assert names.index("correction") < names.index("demotion")

--- a/tests/test_router_core.py
+++ b/tests/test_router_core.py
@@ -1542,6 +1542,95 @@ class TestIntraICClearanceValidation:
             )
             assert dist - seg.width / 2 - blocker.width / 2 >= self.CLEARANCE - 1e-6
 
+    def test_direct_route_rejects_crossing_routed_copper(self):
+        """Issue #3413: the DIRECT tie must also validate against copper.
+
+        Models board 06's USB-C X-crossover at J1: USB2_D- ties B7->A7
+        first; USB2_D+'s direct A6->B6 tie then crosses that committed
+        copper at the row midpoint.  Before the fix only perimeter-wrap
+        candidates checked ``obstacle_segments``, so the direct tie was
+        emitted as a physical same-layer overlap (later demoted to
+        unrouted by the #3433 safety net).  With the blocker spanning
+        the full wrap envelope no legal wrap exists either, so the pair
+        must defer to the main A* router.
+        """
+        from kicad_tools.router.path import create_intra_ic_routes
+        from kicad_tools.router.primitives import Layer, Segment
+        from kicad_tools.router.rules import DesignRules
+
+        lookup = {
+            ("J1", "A6"): self._mk_pad(
+                "J1", "A6", 10.0, 10.0, 6, "USB2_D+", width=0.3, height=0.3
+            ),
+            ("J1", "B6"): self._mk_pad(
+                "J1", "B6", 10.0, 12.0, 6, "USB2_D+", width=0.3, height=0.3
+            ),
+        }
+        rules = DesignRules(trace_width=0.2, trace_clearance=self.CLEARANCE)
+
+        # Committed USB2_D- copper crossing the direct A6->B6 centerline,
+        # wide enough to also intercept every perimeter-wrap candidate.
+        blocker = Segment(
+            x1=5.0,
+            y1=11.0,
+            x2=15.0,
+            y2=11.0,
+            width=0.2,
+            layer=Layer.F_CU,
+            net=5,
+            net_name="USB2_D-",
+        )
+        routes, connected = create_intra_ic_routes(
+            6,
+            [("J1", "A6"), ("J1", "B6")],
+            lookup,
+            rules,
+            obstacle_segments=[blocker],
+        )
+
+        assert routes == [], (
+            "Direct tie crosses committed foreign copper and no legal wrap "
+            "exists: nothing may be emitted (defer to the main A* router)"
+        )
+        assert connected == set(), "Deferred pads must stay in the A* pad list"
+
+    def test_direct_route_kept_when_routed_copper_clear(self):
+        """Obstacle copper far from the direct tie must not disturb it."""
+        from kicad_tools.router.path import create_intra_ic_routes
+        from kicad_tools.router.primitives import Layer, Segment
+        from kicad_tools.router.rules import DesignRules
+
+        lookup = {
+            ("J1", "A6"): self._mk_pad(
+                "J1", "A6", 10.0, 10.0, 6, "USB2_D+", width=0.3, height=0.3
+            ),
+            ("J1", "B6"): self._mk_pad(
+                "J1", "B6", 10.0, 12.0, 6, "USB2_D+", width=0.3, height=0.3
+            ),
+        }
+        rules = DesignRules(trace_width=0.2, trace_clearance=self.CLEARANCE)
+        far_blocker = Segment(
+            x1=20.0,
+            y1=5.0,
+            x2=20.0,
+            y2=15.0,
+            width=0.2,
+            layer=Layer.F_CU,
+            net=5,
+            net_name="USB2_D-",
+        )
+        routes, connected = create_intra_ic_routes(
+            6,
+            [("J1", "A6"), ("J1", "B6")],
+            lookup,
+            rules,
+            obstacle_segments=[far_blocker],
+        )
+
+        assert connected == {0, 1}
+        assert len(routes) == 1
+        assert len(routes[0].segments) == 1, "Clear direct path must stay direct"
+
 
 class TestAutorouterRouteAll:
     """Tests for route_all methods."""


### PR DESCRIPTION
## Summary

Phases 1-3 of #3413 (board 06 diffpair-test reach). **Refs #3413 — do NOT auto-close** (phases 4-6 remain for a separate builder).

CI-recipe reach (`check_diffpair_coverage.py boards/06-diffpair-test --seed 42`, `PYTHONHASHSEED=42`, local M-series):

| Stage | Reach | Bare gate errors | Demotion |
|---|---|---|---|
| Baseline (main @ 05541c7d) | 18/21 | 9 | USB2_D+ stripped every sweep |
| Phase 1 (overflow-silent rescue) | 19/21 | 18 (transient) | still fires |
| Phases 1+2+3 (final) | **20/21** | **13** | **none** |

Gate verdict: green (13 <= allowlist 21); all 3 diff-pair rule families exercised.

### Phase 1 — MIPI_RST (0 segments ever -> routed every run)
Root cause was NOT static geometry (routes fine on an empty board in 5.6s): the 0.375mm impedance-resolved sideband trace gets sealed at U4 by earlier-routed MIPI pair copper, and its pin-access failure emits **no overflow** — so the negotiated loop's entire targeted-fallback/relief chain (gated `overflow == 0`) never opened while the J1 USB3 cluster held overflow at 2-3. New **overflow-silent hard-failure rescue**: nets fully unrouted >= 2 consecutive iterations engage targeted rip-up + relief rescue even while overflow > 0 (both transactional, attempt-capped). Relief rescues additionally get a hard wall deadline (measured 342s composite overrun on a 240s budget).

### Phase 2 — USB2_D+ (routed every sweep, demoted every sweep)
Two structural fixes plus the ordering fix the architect specified:
- `create_intra_ic_routes` validated the **direct** tie only against same-package pads, never committed copper — the USB-C reversible-pinout X-crossover (D- ties B7->A7, then D+ ties A6->B6 straight across it) emitted physically overlapping copper that #3433 then demoted. Direct ties now check `obstacle_segments`; perimeter wraps are capped at 4x direct distance (the legal J1 wrap measured **21.8mm for a 2.24mm tie** and consumed the J1 fan-out fabric — measured reach regression); past the cap the tie defers to the main A*, which resolves the crossover.
- `_post_route_clearance_correction` now also runs on the `timed_out` exit (single pass, <=90s hard deadline, clamped per-net budget) so demotion is never the first consumer of a repairable overlap — and the pass is now **all-or-nothing** (measured: keep-successes-restore-failures recreated an overlap that demotion then punished; no restore at all silently dropped USB2_D-).
- `diffpair_clearance_intra` structural residual: 1 -> 0 on the re-routed artifact (sidecar-counted).

### Phase 3 — J1 hotspot (USB3_RX1- residual) + timeout discipline
- Stagnation recovery: **no-net-loss restore** (measured 19 -> 15 connected collapse when elevated-cost re-lands failed mid-recovery).
- Zero-overflow elevated-cost recovery: per-net `check_timeout()` (measured 380s overrun past the loop budget).
- Budget A/B (240s vs 360s): 360s REJECTED with evidence — it reaches iterations 3-4 where the lex tuple banks a routed=21/connected=20 snapshot whose extra copper is a *partial* USB3_RX1- route carrying a heavy post-optimizer violation load (DRC 36 vs the 9-13 band at 240s). Recipe stays at 240s with the rationale documented in-line.
- #3488 relief verified ENGAGED on the `route_all_negotiated` path via the new rescue block. #3203 pad-channel budgets verified **cannot** engage on this recipe path: `set_pad_channel_budgets` is only invoked from `route_with_escape`, and this recipe path never generates escape routes/overrides to derive budgets from (no `Escape routes:` lines in any run log).
- Diff-pair CI job ceiling 15 -> 20 min (bounded correction surcharge on the 2-core runner).

### Residual diagnosis — USB3_RX1- (phase-3 AC 21/21 NOT met; honest report)
Relief rescue rips up to 8 J1-area blockers across 3 rounds and the min-conflict probe still finds **no path** — the remaining seal is hard obstacles (foreign pads / statics) at the J1 fan-out, not rippable copper. Per-net A* (30s), elevated-cost recovery, and stagnation recovery all fail it identically. The historical 5-error USB3_RX1+/USB_CC1 clearance cluster shrank to 2 (-0.425mm overlap pair remains). This needs J1 fan-out/escape work (likely with the phase 4-6 builder), not more budget.

### Committed artifact intentionally NOT refreshed
The 20/21 re-routed artifact scores **30 blocking** on the strict committed-artifact gate (sidecar-counted) vs the committed baseline's 17 against floor 21: the 8 length-skew + 8 continuity errors are carried over from the committed baseline's calibration, plus 3 `impedance` errors that are **inherent to routing MIPI_RST** (its neck-down taper segments at J4/U4 — 0.78/0.71/0.32mm at 0.10-0.19mm width — are flagged because `validate/rules/impedance.py` has no neck-down exemption), plus 11 clearance near-misses from rescue re-lands (9 are 0.01-0.095mm pad-segment grazes the nudge pass only partially repairs). Refreshing the artifact lands with phases 4-5 alongside an impedance-rule neck-down exemption; until then both CI gates stay green (committed artifact unchanged at 17 <= 21; re-route gate improved to 20/21 @ 13 <= 21).

Allowlist NOT reduced: bare-gate counts vary 9-13 locally with load-dependent wall-clock classifiers (CI historically runs +2 over local); no reliable drop to lock in yet.

### Cross-board checks
- `tests/test_router_core.py` + `tests/router/test_relief_rescue.py` + `tests/router/test_seg_seg_quality_tuple.py`: 218 passed; 2 failures are pre-existing on main (verified identical at 05541c7d): `test_route_to_pad_adjacent_to_net0_pad` (open #3490) and `test_add_component_rotation`.
- Softstart slow baseline (`KICAD_RUN_SLOW_SOFTSTART_REACH=1`): fails with the **identical** pre-existing assertion signature as main ("Partial routes: 3/30"; red on main too) — and completes in 274s vs main's 451s (the bounded correction pass is faster than main's unbounded tail; no harness timeout).
- Board 06 fast tests + determinism CLI-shape tests: 41 passed.
- Board 07 matchgroup re-route gate runs in CI — flagging it as the cross-board check to watch (negotiated-loop changes apply there).

## New tests
- `TestIntraICClearanceValidation::test_direct_route_rejects_crossing_routed_copper` / `test_direct_route_kept_when_routed_copper_clear` (X-crossover regression).
- `TestCorrectionBeforeDemotionOnTimeout` (2 tests): correction runs bounded (1 pass) before demotion on the timeout exit; 3-pass budget preserved on clean exits.

## Test plan
- [x] Seed-42 gate: 20/21 reach, 13 errors, exit 0 (was 18/21, 9, with structural demotion)
- [x] MIPI_RST routes on every measured run (phase-1 AC: reach >= 19/21)
- [x] USB2_D+ routed with no demotion; intra structural residual 0 (phase-2 AC: reach >= 20/21)
- [ ] 21/21 + 0 clearance (phase-3 AC) — USB3_RX1- residual diagnosed above, J1 fan-out geometry
- [x] No new lint errors (23/23 and 3/3 pre-existing parity on touched files)
- [x] CI: watch diffpair re-route job + board 07 matchgroup job

🤖 Generated with [Claude Code](https://claude.com/claude-code)