### PR TITLE
fix(drc): clearance_segment_via checks all layers the barrel spans (closes #3487)

### DIFF
--- a/src/kicad_tools/analysis/net_status.py
+++ b/src/kicad_tools/analysis/net_status.py
@@ -23,6 +23,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from kicad_tools.core.layers import COPPER_LAYER_ORDER, via_spans_layer
+
 if TYPE_CHECKING:
     from kicad_tools.schema.pcb import PCB
 
@@ -901,41 +903,10 @@ class NetStatusAnalyzer:
         return (dx * dx + dy * dy) < (self.POSITION_TOLERANCE * self.POSITION_TOLERANCE)
 
     # Canonical copper layer ordering from top to bottom.
-    # Used to determine whether a through-via spans a given inner layer.
-    _COPPER_LAYER_ORDER: list[str] = [
-        "F.Cu",
-        "In1.Cu",
-        "In2.Cu",
-        "In3.Cu",
-        "In4.Cu",
-        "In5.Cu",
-        "In6.Cu",
-        "In7.Cu",
-        "In8.Cu",
-        "In9.Cu",
-        "In10.Cu",
-        "In11.Cu",
-        "In12.Cu",
-        "In13.Cu",
-        "In14.Cu",
-        "In15.Cu",
-        "In16.Cu",
-        "In17.Cu",
-        "In18.Cu",
-        "In19.Cu",
-        "In20.Cu",
-        "In21.Cu",
-        "In22.Cu",
-        "In23.Cu",
-        "In24.Cu",
-        "In25.Cu",
-        "In26.Cu",
-        "In27.Cu",
-        "In28.Cu",
-        "In29.Cu",
-        "In30.Cu",
-        "B.Cu",
-    ]
+    # Promoted to ``kicad_tools.core.layers`` in Issue #3487 so the DRC
+    # clearance rule shares the same via-span semantics; kept here as a
+    # class attribute for backwards compatibility with existing tests.
+    _COPPER_LAYER_ORDER: list[str] = list(COPPER_LAYER_ORDER)
 
     def _via_spans_layer(self, via_layers: list[str], target_layer: str) -> bool:
         """Check if a via spans (connects to) a target copper layer.
@@ -945,6 +916,10 @@ class NetStatusAnalyzer:
         just the two listed layers.  A blind/buried via ["F.Cu", "In1.Cu"]
         connects F.Cu and In1.Cu only (no intermediates beyond those two).
 
+        Delegates to :func:`kicad_tools.core.layers.via_spans_layer`
+        (single source of truth shared with the DRC clearance rule;
+        Issue #3487).
+
         Args:
             via_layers: List of layer names from the via (e.g., ["F.Cu", "B.Cu"])
             target_layer: Layer name to check (e.g., "In1.Cu")
@@ -952,30 +927,7 @@ class NetStatusAnalyzer:
         Returns:
             True if the via electrically connects the target layer
         """
-        # Direct match -- layer explicitly listed on the via
-        if target_layer in via_layers:
-            return True
-
-        # Determine the span of the via in the copper stack
-        indices = []
-        for layer in via_layers:
-            try:
-                indices.append(self._COPPER_LAYER_ORDER.index(layer))
-            except ValueError:
-                # Unknown layer name -- skip (non-copper or custom)
-                continue
-
-        if len(indices) < 2:
-            return False
-
-        # Target must also be a recognised copper layer
-        try:
-            target_idx = self._COPPER_LAYER_ORDER.index(target_layer)
-        except ValueError:
-            return False
-
-        # Via spans from min to max index; any layer in between is connected
-        return min(indices) <= target_idx <= max(indices)
+        return via_spans_layer(via_layers, target_layer)
 
     def _pad_layer_matches_zone(
         self,

--- a/src/kicad_tools/core/__init__.py
+++ b/src/kicad_tools/core/__init__.py
@@ -2,6 +2,7 @@
 
 from kicad_tools.sexp import SExp, parse_file, parse_string, serialize_sexp
 
+from .layers import COPPER_LAYER_ORDER, via_spans_layer
 from .severity import SeverityMixin
 from .sexp_file import (
     load_pcb,
@@ -39,4 +40,7 @@ __all__ = [
     "Layer",
     "CopperLayer",
     "LayoutStyle",
+    # Stackup helpers
+    "COPPER_LAYER_ORDER",
+    "via_spans_layer",
 ]

--- a/src/kicad_tools/core/layers.py
+++ b/src/kicad_tools/core/layers.py
@@ -1,0 +1,63 @@
+"""Copper-layer stackup helpers shared across analysis and DRC code.
+
+KiCad's layer *numbering* is not the physical stackup order (KiCad 9
+numbers F.Cu=0, B.Cu=2, inner layers 4, 6, 8, ...), so code that needs
+"which layers does this via barrel pass through?" must consult the
+canonical front-to-back name ordering instead of layer indices.
+
+The canonical ordering and the :func:`via_spans_layer` predicate were
+originally private to ``analysis/net_status.py``; Issue #3487 promoted
+them here so the DRC clearance rule can reuse the same semantics (a
+through-via barrel is physical copper on EVERY layer it spans, not just
+the two endpoint layers KiCad lists in ``(layers "F.Cu" "B.Cu")``).
+"""
+
+from __future__ import annotations
+
+# Canonical copper layer ordering from top (front) to bottom (back).
+# KiCad supports up to 30 inner layers named In1.Cu .. In30.Cu.
+COPPER_LAYER_ORDER: tuple[str, ...] = (
+    "F.Cu",
+    *(f"In{i}.Cu" for i in range(1, 31)),
+    "B.Cu",
+)
+
+_COPPER_LAYER_INDEX: dict[str, int] = {name: idx for idx, name in enumerate(COPPER_LAYER_ORDER)}
+
+
+def via_spans_layer(via_layers: list[str] | tuple[str, ...], target_layer: str) -> bool:
+    """Check whether a via barrel passes through a target copper layer.
+
+    In KiCad, a via with layers ``["F.Cu", "B.Cu"]`` is a through-via
+    whose barrel is physical copper on ALL intermediate copper layers
+    (In1.Cu, In2.Cu, ...), not just the two listed endpoint layers.  A
+    blind/buried/micro via such as ``["F.Cu", "In1.Cu"]`` spans only the
+    layers between (and including) its declared endpoints.
+
+    Args:
+        via_layers: Layer names declared on the via
+            (e.g., ``["F.Cu", "B.Cu"]``).
+        target_layer: Copper layer name to test (e.g., ``"In1.Cu"``).
+
+    Returns:
+        True if the via barrel exists on (electrically connects to)
+        the target layer.
+    """
+    # Direct match -- layer explicitly listed on the via.
+    if target_layer in via_layers:
+        return True
+
+    # Determine the span of the via in the copper stack.
+    indices = [
+        _COPPER_LAYER_INDEX[layer] for layer in via_layers if layer in _COPPER_LAYER_INDEX
+    ]
+    if len(indices) < 2:
+        return False
+
+    # Target must also be a recognised copper layer.
+    target_idx = _COPPER_LAYER_INDEX.get(target_layer)
+    if target_idx is None:
+        return False
+
+    # Via spans from min to max index; any layer in between is connected.
+    return min(indices) <= target_idx <= max(indices)

--- a/src/kicad_tools/core/layers.py
+++ b/src/kicad_tools/core/layers.py
@@ -48,9 +48,7 @@ def via_spans_layer(via_layers: list[str] | tuple[str, ...], target_layer: str) 
         return True
 
     # Determine the span of the via in the copper stack.
-    indices = [
-        _COPPER_LAYER_INDEX[layer] for layer in via_layers if layer in _COPPER_LAYER_INDEX
-    ]
+    indices = [_COPPER_LAYER_INDEX[layer] for layer in via_layers if layer in _COPPER_LAYER_INDEX]
     if len(indices) < 2:
         return False
 

--- a/src/kicad_tools/validate/rules/clearance.py
+++ b/src/kicad_tools/validate/rules/clearance.py
@@ -19,6 +19,7 @@ from kicad_tools.core.geometry import (
 from kicad_tools.core.geometry import (
     segments_intersect as _segments_intersect,
 )
+from kicad_tools.core.layers import via_spans_layer as _via_spans_layer
 
 from ..violations import DRCResults, DRCViolation
 from .base import DRC_TOLERANCE, DRCRule
@@ -64,6 +65,14 @@ class CopperElement:
     reference: str
     # Net name for violation output (empty string for unconnected/net 0)
     net_name: str = ""
+    # For vias: the layer names explicitly declared on the via (the
+    # endpoint pair, e.g. ("F.Cu", "B.Cu")).  A through-via barrel is
+    # physical copper on every layer it SPANS, so the element is
+    # collected on inner layers too (issue #3487) -- but via-via and
+    # pad-via pairs are only evaluated on explicitly-declared layers to
+    # avoid re-reporting the same geometric pair on every spanned layer
+    # (the endpoint-layer scan already covers them).
+    explicit_layers: tuple[str, ...] = ()
 
     @classmethod
     def from_segment(cls, seg: Segment) -> CopperElement:
@@ -103,6 +112,7 @@ class CopperElement:
             geometry=(via.position[0], via.position[1], via.size, via.size),
             reference=f"Via-{via.uuid[:8]}" if via.uuid else "Via",
             net_name=via.net_name if via.net_number != 0 else "",
+            explicit_layers=tuple(via.layers),
         )
 
     def on_layer(self, layer: str) -> bool:
@@ -636,6 +646,26 @@ class ClearanceRule(DRCRule):
                 if elem1.net_number == 0 or elem2.net_number == 0:
                     continue
 
+                # Vias are collected on every copper layer their barrel
+                # spans (issue #3487) so SEGMENT-via conflicts on inner
+                # layers are caught.  Pairs of layer-spanning elements
+                # (via-via, pad-via) have layer-independent geometry and
+                # are already evaluated on the via's explicitly-declared
+                # endpoint layers -- re-running them on each spanned
+                # inner layer would only duplicate the same report, so
+                # restrict non-segment pairs to declared layers.
+                if elem1.element_type != "segment" and elem2.element_type != "segment":
+                    if (
+                        elem1.element_type == "via"
+                        and elem1.explicit_layers
+                        and layer_name not in elem1.explicit_layers
+                    ) or (
+                        elem2.element_type == "via"
+                        and elem2.explicit_layers
+                        and layer_name not in elem2.explicit_layers
+                    ):
+                        continue
+
                 # Skip same-pair segment-to-segment edges -- they are
                 # validated by DiffPairClearanceIntraRule against a
                 # tighter per-class threshold.  Pad/via combinations
@@ -702,9 +732,16 @@ class ClearanceRule(DRCRule):
                 if layer_name in pad.layers or "*.Cu" in pad.layers:
                     elements.append(CopperElement.from_pad(pad, fp))
 
-        # Add vias (they span layers, so include if layer is in via's layer list)
+        # Add vias whose barrel passes through this layer.  KiCad
+        # declares only the endpoint pair on the via (a through-via on a
+        # 4-layer board reads ``(layers "F.Cu" "B.Cu")``), but the barrel
+        # is physical copper on EVERY layer it spans -- including inner
+        # layers that never appear in ``via.layers``.  The previous
+        # ``layer_name in via.layers`` test silently skipped barrel-vs-
+        # inner-layer-segment conflicts (issue #3487: three real shorts
+        # on the softstart board were invisible to ``kct check``).
         for via in pcb.vias:
-            if layer_name in via.layers:
+            if _via_spans_layer(via.layers, layer_name):
                 elements.append(CopperElement.from_via(via))
 
         return elements

--- a/tests/test_board_06_diffpair_test.py
+++ b/tests/test_board_06_diffpair_test.py
@@ -122,9 +122,9 @@ class TestRoutedPcbArtifact:
         are valid KiCad 10.
         """
         for layer_name in ("F.Cu", "In1.Cu", "In2.Cu", "B.Cu"):
-            assert re.search(
-                rf'\(\d+ "{re.escape(layer_name)}" signal\)', routed_pcb_text
-            ), f"Copper layer {layer_name} missing from the routed PCB stackup"
+            assert re.search(rf'\(\d+ "{re.escape(layer_name)}" signal\)', routed_pcb_text), (
+                f"Copper layer {layer_name} missing from the routed PCB stackup"
+            )
 
     @pytest.mark.parametrize(
         "net_name",
@@ -648,6 +648,7 @@ class TestManufacturabilityFloor:
 
         # Convert to floats and count.
         from collections import Counter
+
         width_counts = Counter(float(w) for w in seg_widths)
         if not width_counts:
             pytest.fail(
@@ -827,8 +828,7 @@ class TestBoard06StrictGateGuard:
                 timeout=180,
             )
             assert proc.returncode in (0, 2), (
-                f"kct check exited {proc.returncode} on {routed_pcb}.\n"
-                f"stderr:\n{proc.stderr}"
+                f"kct check exited {proc.returncode} on {routed_pcb}.\nstderr:\n{proc.stderr}"
             )
             return json.loads(proc.stdout)
 
@@ -936,9 +936,7 @@ class TestBoard06StrictGateGuard:
         """
         violations = strict_gate_result.get("violations", [])
         connectivity = sum(
-            1
-            for v in violations
-            if isinstance(v, dict) and v.get("rule_id") == "connectivity"
+            1 for v in violations if isinstance(v, dict) and v.get("rule_id") == "connectivity"
         )
         assert connectivity == self.EXPECTED_ADVISORY_CONNECTIVITY, (
             f"Advisory connectivity count on the committed routed PCB is "
@@ -980,9 +978,7 @@ class TestPourCopperUnionAudit:
         for net in pour_nets:
             info = audit[net]
             if not info["connected"]:
-                stranded = [
-                    [p for p, _ in group] for group in info["pad_groups"][1:]
-                ]
+                stranded = [[p for p, _ in group] for group in info["pad_groups"][1:]]
                 failures.append(
                     f"{net}: {len(info['pad_groups'])} disjoint copper "
                     f"components; stranded pads: {stranded}"

--- a/tests/test_clearance_via_barrel_layers.py
+++ b/tests/test_clearance_via_barrel_layers.py
@@ -64,13 +64,13 @@ def _pcb_via_vs_segment(layer: str, seg_x: float, via_sexp: str | None = None) -
     100.3 gives -0.1 mm (hard overlap), seg_x = 101 gives +0.6 mm (clean).
     """
     via = via_sexp or (
-        '(via (at 100 100) (size 0.6) (drill 0.3)'
+        "(via (at 100 100) (size 0.6) (drill 0.3)"
         ' (layers "F.Cu" "B.Cu") (net 1 "SIG1") (uuid "via-1"))'
     )
     return (
         _HEADER_4L
         + f"  {via}\n"
-        + f'  (segment (start {seg_x} 99) (end {seg_x} 101) (width 0.2)'
+        + f"  (segment (start {seg_x} 99) (end {seg_x} 101) (width 0.2)"
         + f' (layer "{layer}") (net 2 "SIG2") (uuid "seg-1"))\n'
         + ")\n"
     )
@@ -157,7 +157,7 @@ class TestViaSpansLayerHelper:
         """The NetStatusAnalyzer class attribute mirrors the shared order."""
         from kicad_tools.analysis.net_status import NetStatusAnalyzer
 
-        assert NetStatusAnalyzer._COPPER_LAYER_ORDER == list(COPPER_LAYER_ORDER)
+        assert list(COPPER_LAYER_ORDER) == NetStatusAnalyzer._COPPER_LAYER_ORDER
 
 
 # ---------------------------------------------------------------------------
@@ -207,10 +207,9 @@ class TestThroughViaInnerLayerSegments:
     def test_same_net_inner_segment_not_flagged(self, tmp_path: Path):
         """Same-net copper may touch -- including on inner layers."""
         pcb = (
-            _HEADER_4L
-            + '  (via (at 100 100) (size 0.6) (drill 0.3)'
+            _HEADER_4L + "  (via (at 100 100) (size 0.6) (drill 0.3)"
             ' (layers "F.Cu" "B.Cu") (net 1 "SIG1") (uuid "via-1"))\n'
-            '  (segment (start 100.3 99) (end 100.3 101) (width 0.2)'
+            "  (segment (start 100.3 99) (end 100.3 101) (width 0.2)"
             ' (layer "In1.Cu") (net 1 "SIG1") (uuid "seg-1"))\n'
             ")\n"
         )
@@ -225,10 +224,9 @@ class TestThroughViaInnerLayerSegments:
         suppression must keep working now that inner layers are scanned.
         """
         pcb = (
-            _HEADER_4L
-            + '  (via (at 100 100) (size 0.6) (drill 0.3)'
+            _HEADER_4L + "  (via (at 100 100) (size 0.6) (drill 0.3)"
             ' (layers "F.Cu" "B.Cu") (net 1 "SIG1") (uuid "via-1"))\n'
-            '  (segment (start 100 100) (end 101 100) (width 0.2)'
+            "  (segment (start 100 100) (end 101 100) (width 0.2)"
             ' (layer "In1.Cu") (net 2 "SIG2") (uuid "seg-1"))\n'
             ")\n"
         )
@@ -246,12 +244,10 @@ class TestPartialSpanVias:
 
     def test_micro_via_does_not_reach_in2(self, tmp_path: Path):
         via = (
-            '(via micro (at 100 100) (size 0.6) (drill 0.3)'
+            "(via micro (at 100 100) (size 0.6) (drill 0.3)"
             ' (layers "F.Cu" "In1.Cu") (net 1 "SIG1") (uuid "via-1"))'
         )
-        results = _check_clearances(
-            _pcb_via_vs_segment("In2.Cu", 100.3, via_sexp=via), tmp_path
-        )
+        results = _check_clearances(_pcb_via_vs_segment("In2.Cu", 100.3, via_sexp=via), tmp_path)
         assert len(_segment_via_violations(results)) == 0, (
             "A micro via F.Cu->In1.Cu has no barrel copper on In2.Cu; "
             "flagging it would be a false positive."
@@ -259,43 +255,35 @@ class TestPartialSpanVias:
 
     def test_micro_via_does_not_reach_bottom(self, tmp_path: Path):
         via = (
-            '(via micro (at 100 100) (size 0.6) (drill 0.3)'
+            "(via micro (at 100 100) (size 0.6) (drill 0.3)"
             ' (layers "F.Cu" "In1.Cu") (net 1 "SIG1") (uuid "via-1"))'
         )
-        results = _check_clearances(
-            _pcb_via_vs_segment("B.Cu", 100.3, via_sexp=via), tmp_path
-        )
+        results = _check_clearances(_pcb_via_vs_segment("B.Cu", 100.3, via_sexp=via), tmp_path)
         assert len(_segment_via_violations(results)) == 0
 
     def test_micro_via_fires_inside_span(self, tmp_path: Path):
         via = (
-            '(via micro (at 100 100) (size 0.6) (drill 0.3)'
+            "(via micro (at 100 100) (size 0.6) (drill 0.3)"
             ' (layers "F.Cu" "In1.Cu") (net 1 "SIG1") (uuid "via-1"))'
         )
-        results = _check_clearances(
-            _pcb_via_vs_segment("In1.Cu", 100.3, via_sexp=via), tmp_path
-        )
+        results = _check_clearances(_pcb_via_vs_segment("In1.Cu", 100.3, via_sexp=via), tmp_path)
         assert len(_segment_via_violations(results)) == 1
 
     def test_buried_via_fires_on_intermediate_layer(self, tmp_path: Path):
         """A buried In1->B.Cu via spans In2.Cu even though not listed."""
         via = (
-            '(via buried (at 100 100) (size 0.6) (drill 0.3)'
+            "(via buried (at 100 100) (size 0.6) (drill 0.3)"
             ' (layers "In1.Cu" "B.Cu") (net 1 "SIG1") (uuid "via-1"))'
         )
-        results = _check_clearances(
-            _pcb_via_vs_segment("In2.Cu", 100.3, via_sexp=via), tmp_path
-        )
+        results = _check_clearances(_pcb_via_vs_segment("In2.Cu", 100.3, via_sexp=via), tmp_path)
         assert len(_segment_via_violations(results)) == 1
 
     def test_buried_via_does_not_reach_front(self, tmp_path: Path):
         via = (
-            '(via buried (at 100 100) (size 0.6) (drill 0.3)'
+            "(via buried (at 100 100) (size 0.6) (drill 0.3)"
             ' (layers "In1.Cu" "B.Cu") (net 1 "SIG1") (uuid "via-1"))'
         )
-        results = _check_clearances(
-            _pcb_via_vs_segment("F.Cu", 100.3, via_sexp=via), tmp_path
-        )
+        results = _check_clearances(_pcb_via_vs_segment("F.Cu", 100.3, via_sexp=via), tmp_path)
         assert len(_segment_via_violations(results)) == 0
 
 
@@ -316,10 +304,9 @@ class TestNonSegmentPairCountsUnchanged:
 
     def test_via_via_overlap_reported_twice_not_four_times(self, tmp_path: Path):
         pcb = (
-            _HEADER_4L
-            + '  (via (at 100 100) (size 0.6) (drill 0.3)'
+            _HEADER_4L + "  (via (at 100 100) (size 0.6) (drill 0.3)"
             ' (layers "F.Cu" "B.Cu") (net 1 "SIG1") (uuid "via-1"))\n'
-            '  (via (at 100.5 100) (size 0.6) (drill 0.3)'
+            "  (via (at 100.5 100) (size 0.6) (drill 0.3)"
             ' (layers "F.Cu" "B.Cu") (net 2 "SIG2") (uuid "via-2"))\n'
             ")\n"
         )

--- a/tests/test_clearance_via_barrel_layers.py
+++ b/tests/test_clearance_via_barrel_layers.py
@@ -1,0 +1,333 @@
+"""Regression tests for via-barrel clearance on every spanned copper layer.
+
+Issue #3487: ``clearance_segment_via`` only compared vias against
+segments on layers explicitly listed in the via's ``(layers ...)``
+node.  KiCad declares only the endpoint pair (a through-via on a
+4-layer board reads ``(layers "F.Cu" "B.Cu")``), so barrel-vs-segment
+conflicts on inner layers were silently skipped -- the softstart rev B
+board shipped 3 real cross-net barrel shorts that ``kct check`` could
+not see (found by PR #3481's step-10d geometric sweep).
+
+These tests verify:
+
+1.  **Through-via vs inner-layer segment**: violations now fire on
+    In1.Cu / In2.Cu (the primary bug case).
+2.  **Endpoint layers unchanged**: F.Cu / B.Cu behavior is identical
+    to before (regression guard).
+3.  **Blind/micro vias**: the barrel only spans its declared range --
+    a segment on a layer OUTSIDE the range must not be flagged.
+4.  **Same-net and far-away segments**: no over-reporting.
+5.  **Non-segment pairs**: via-via / pad-via pair counts are unchanged
+    (no duplicate reports on spanned inner layers).
+6.  **Co-location skip (#2706)**: still applies on inner layers.
+7.  **`via_spans_layer` helper**: unit coverage of the shared
+    predicate in ``kicad_tools.core.layers``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kicad_tools.core.layers import COPPER_LAYER_ORDER, via_spans_layer
+
+# ---------------------------------------------------------------------------
+# Synthetic 4-layer PCB fixtures
+# ---------------------------------------------------------------------------
+
+_HEADER_4L = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (4 "In1.Cu" signal)
+    (6 "In2.Cu" signal)
+    (2 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "SIG1")
+  (net 2 "SIG2")
+"""
+
+
+def _pcb_via_vs_segment(layer: str, seg_x: float, via_sexp: str | None = None) -> str:
+    """4-layer board: one net-1 via at (100, 100), one net-2 vertical segment.
+
+    The segment runs x=``seg_x``, y=99..101 on ``layer``.  With via size
+    0.6 (radius 0.3) and trace width 0.2 (half-width 0.1), the
+    edge-to-edge clearance is ``|seg_x - 100| - 0.4`` -- e.g. seg_x =
+    100.3 gives -0.1 mm (hard overlap), seg_x = 101 gives +0.6 mm (clean).
+    """
+    via = via_sexp or (
+        '(via (at 100 100) (size 0.6) (drill 0.3)'
+        ' (layers "F.Cu" "B.Cu") (net 1 "SIG1") (uuid "via-1"))'
+    )
+    return (
+        _HEADER_4L
+        + f"  {via}\n"
+        + f'  (segment (start {seg_x} 99) (end {seg_x} 101) (width 0.2)'
+        + f' (layer "{layer}") (net 2 "SIG2") (uuid "seg-1"))\n'
+        + ")\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _check_clearances(pcb_content: str, tmp_path: Path):
+    """Write a PCB fixture and return the clearance check results."""
+    from kicad_tools.schema.pcb import PCB
+    from kicad_tools.validate import DRCChecker
+
+    pcb_path = tmp_path / "test.kicad_pcb"
+    pcb_path.write_text(pcb_content)
+    pcb = PCB.load(pcb_path)
+
+    checker = DRCChecker(pcb, manufacturer="jlcpcb", layers=4, copper_oz=1.0)
+    return checker.check_clearances()
+
+
+def _segment_via_violations(results) -> list:
+    return [v for v in results.violations if v.rule_id == "clearance_segment_via"]
+
+
+def _via_via_violations(results) -> list:
+    return [v for v in results.violations if v.rule_id == "clearance_via_via"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: the shared via_spans_layer predicate
+# ---------------------------------------------------------------------------
+
+
+class TestViaSpansLayerHelper:
+    """Unit coverage for kicad_tools.core.layers.via_spans_layer."""
+
+    def test_through_via_spans_inner_layers(self):
+        layers = ["F.Cu", "B.Cu"]
+        assert via_spans_layer(layers, "F.Cu")
+        assert via_spans_layer(layers, "In1.Cu")
+        assert via_spans_layer(layers, "In2.Cu")
+        assert via_spans_layer(layers, "In30.Cu")
+        assert via_spans_layer(layers, "B.Cu")
+
+    def test_blind_via_spans_only_declared_range(self):
+        layers = ["F.Cu", "In1.Cu"]
+        assert via_spans_layer(layers, "F.Cu")
+        assert via_spans_layer(layers, "In1.Cu")
+        assert not via_spans_layer(layers, "In2.Cu")
+        assert not via_spans_layer(layers, "B.Cu")
+
+    def test_buried_via_spans_inner_range(self):
+        layers = ["In1.Cu", "In3.Cu"]
+        assert not via_spans_layer(layers, "F.Cu")
+        assert via_spans_layer(layers, "In1.Cu")
+        assert via_spans_layer(layers, "In2.Cu")
+        assert via_spans_layer(layers, "In3.Cu")
+        assert not via_spans_layer(layers, "In4.Cu")
+        assert not via_spans_layer(layers, "B.Cu")
+
+    def test_layer_order_is_reversal_agnostic(self):
+        """Span is min..max regardless of declaration order."""
+        assert via_spans_layer(["B.Cu", "F.Cu"], "In2.Cu")
+
+    def test_unknown_layers_are_rejected(self):
+        assert not via_spans_layer(["F.Cu", "B.Cu"], "Edge.Cuts")
+        assert not via_spans_layer(["Edge.Cuts"], "In1.Cu")
+        assert not via_spans_layer([], "F.Cu")
+
+    def test_explicit_listing_always_matches(self):
+        # Single-entry layer lists still match the listed layer.
+        assert via_spans_layer(["In1.Cu"], "In1.Cu")
+        assert not via_spans_layer(["In1.Cu"], "In2.Cu")
+
+    def test_canonical_order_shape(self):
+        assert COPPER_LAYER_ORDER[0] == "F.Cu"
+        assert COPPER_LAYER_ORDER[-1] == "B.Cu"
+        assert len(COPPER_LAYER_ORDER) == 32  # F.Cu + In1..In30 + B.Cu
+
+    def test_net_status_delegates_to_shared_helper(self):
+        """The NetStatusAnalyzer class attribute mirrors the shared order."""
+        from kicad_tools.analysis.net_status import NetStatusAnalyzer
+
+        assert NetStatusAnalyzer._COPPER_LAYER_ORDER == list(COPPER_LAYER_ORDER)
+
+
+# ---------------------------------------------------------------------------
+# Tests: through-via barrel vs inner-layer segments (the #3487 bug)
+# ---------------------------------------------------------------------------
+
+
+class TestThroughViaInnerLayerSegments:
+    """Through-via barrels must be checked against inner-layer segments."""
+
+    def test_in1_overlap_fires(self, tmp_path: Path):
+        """Barrel-on-trace on In1.Cu (the softstart hard-short case)."""
+        results = _check_clearances(_pcb_via_vs_segment("In1.Cu", 100.3), tmp_path)
+        viols = _segment_via_violations(results)
+        assert len(viols) == 1, (
+            "Through-via barrel overlapping a cross-net In1.Cu segment "
+            "must produce a clearance_segment_via violation (Issue #3487 "
+            "blind spot)."
+        )
+        assert viols[0].actual_value < 0  # hard overlap
+        assert viols[0].layer == "In1.Cu"
+
+    def test_in2_near_miss_fires(self, tmp_path: Path):
+        """Sub-minimum (but positive) clearance on In2.Cu fires too."""
+        # seg_x = 100.45 -> edge clearance 0.05 mm < 0.127 mm minimum.
+        results = _check_clearances(_pcb_via_vs_segment("In2.Cu", 100.45), tmp_path)
+        viols = _segment_via_violations(results)
+        assert len(viols) == 1
+        assert 0 < viols[0].actual_value < 0.127
+        assert viols[0].layer == "In2.Cu"
+
+    def test_bottom_layer_still_fires(self, tmp_path: Path):
+        """Regression: B.Cu (explicitly listed) behavior unchanged."""
+        results = _check_clearances(_pcb_via_vs_segment("B.Cu", 100.3), tmp_path)
+        assert len(_segment_via_violations(results)) == 1
+
+    def test_front_layer_still_fires(self, tmp_path: Path):
+        """Regression: F.Cu (explicitly listed) behavior unchanged."""
+        results = _check_clearances(_pcb_via_vs_segment("F.Cu", 100.3), tmp_path)
+        assert len(_segment_via_violations(results)) == 1
+
+    def test_inner_segment_with_clean_clearance_passes(self, tmp_path: Path):
+        """An inner-layer segment well clear of the barrel is not flagged."""
+        results = _check_clearances(_pcb_via_vs_segment("In1.Cu", 101.0), tmp_path)
+        assert len(_segment_via_violations(results)) == 0
+
+    def test_same_net_inner_segment_not_flagged(self, tmp_path: Path):
+        """Same-net copper may touch -- including on inner layers."""
+        pcb = (
+            _HEADER_4L
+            + '  (via (at 100 100) (size 0.6) (drill 0.3)'
+            ' (layers "F.Cu" "B.Cu") (net 1 "SIG1") (uuid "via-1"))\n'
+            '  (segment (start 100.3 99) (end 100.3 101) (width 0.2)'
+            ' (layer "In1.Cu") (net 1 "SIG1") (uuid "seg-1"))\n'
+            ")\n"
+        )
+        results = _check_clearances(pcb, tmp_path)
+        assert len(_segment_via_violations(results)) == 0
+
+    def test_colocation_skip_applies_on_inner_layers(self, tmp_path: Path):
+        """The #2706 endpoint-at-via-center skip also applies on In1.Cu.
+
+        The router's in-pad escape invariant places inner-layer stub
+        endpoints exactly at via centers; the cross-net co-location
+        suppression must keep working now that inner layers are scanned.
+        """
+        pcb = (
+            _HEADER_4L
+            + '  (via (at 100 100) (size 0.6) (drill 0.3)'
+            ' (layers "F.Cu" "B.Cu") (net 1 "SIG1") (uuid "via-1"))\n'
+            '  (segment (start 100 100) (end 101 100) (width 0.2)'
+            ' (layer "In1.Cu") (net 2 "SIG2") (uuid "seg-1"))\n'
+            ")\n"
+        )
+        results = _check_clearances(pcb, tmp_path)
+        assert len(_segment_via_violations(results)) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: blind / micro vias only span their declared range
+# ---------------------------------------------------------------------------
+
+
+class TestPartialSpanVias:
+    """Blind/micro vias must NOT be flagged against layers outside the span."""
+
+    def test_micro_via_does_not_reach_in2(self, tmp_path: Path):
+        via = (
+            '(via micro (at 100 100) (size 0.6) (drill 0.3)'
+            ' (layers "F.Cu" "In1.Cu") (net 1 "SIG1") (uuid "via-1"))'
+        )
+        results = _check_clearances(
+            _pcb_via_vs_segment("In2.Cu", 100.3, via_sexp=via), tmp_path
+        )
+        assert len(_segment_via_violations(results)) == 0, (
+            "A micro via F.Cu->In1.Cu has no barrel copper on In2.Cu; "
+            "flagging it would be a false positive."
+        )
+
+    def test_micro_via_does_not_reach_bottom(self, tmp_path: Path):
+        via = (
+            '(via micro (at 100 100) (size 0.6) (drill 0.3)'
+            ' (layers "F.Cu" "In1.Cu") (net 1 "SIG1") (uuid "via-1"))'
+        )
+        results = _check_clearances(
+            _pcb_via_vs_segment("B.Cu", 100.3, via_sexp=via), tmp_path
+        )
+        assert len(_segment_via_violations(results)) == 0
+
+    def test_micro_via_fires_inside_span(self, tmp_path: Path):
+        via = (
+            '(via micro (at 100 100) (size 0.6) (drill 0.3)'
+            ' (layers "F.Cu" "In1.Cu") (net 1 "SIG1") (uuid "via-1"))'
+        )
+        results = _check_clearances(
+            _pcb_via_vs_segment("In1.Cu", 100.3, via_sexp=via), tmp_path
+        )
+        assert len(_segment_via_violations(results)) == 1
+
+    def test_buried_via_fires_on_intermediate_layer(self, tmp_path: Path):
+        """A buried In1->B.Cu via spans In2.Cu even though not listed."""
+        via = (
+            '(via buried (at 100 100) (size 0.6) (drill 0.3)'
+            ' (layers "In1.Cu" "B.Cu") (net 1 "SIG1") (uuid "via-1"))'
+        )
+        results = _check_clearances(
+            _pcb_via_vs_segment("In2.Cu", 100.3, via_sexp=via), tmp_path
+        )
+        assert len(_segment_via_violations(results)) == 1
+
+    def test_buried_via_does_not_reach_front(self, tmp_path: Path):
+        via = (
+            '(via buried (at 100 100) (size 0.6) (drill 0.3)'
+            ' (layers "In1.Cu" "B.Cu") (net 1 "SIG1") (uuid "via-1"))'
+        )
+        results = _check_clearances(
+            _pcb_via_vs_segment("F.Cu", 100.3, via_sexp=via), tmp_path
+        )
+        assert len(_segment_via_violations(results)) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: non-segment pair counts are unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestNonSegmentPairCountsUnchanged:
+    """Via-via (and pad-via) pairs must not be duplicated on inner layers.
+
+    Two overlapping cross-net through-vias on a 4-layer board were
+    historically reported once per explicitly-declared layer (F.Cu +
+    B.Cu = 2 reports).  Collecting barrels on spanned inner layers must
+    NOT inflate that to 4 -- the pair's geometry is layer-independent
+    and the endpoint-layer scans already cover it.
+    """
+
+    def test_via_via_overlap_reported_twice_not_four_times(self, tmp_path: Path):
+        pcb = (
+            _HEADER_4L
+            + '  (via (at 100 100) (size 0.6) (drill 0.3)'
+            ' (layers "F.Cu" "B.Cu") (net 1 "SIG1") (uuid "via-1"))\n'
+            '  (via (at 100.5 100) (size 0.6) (drill 0.3)'
+            ' (layers "F.Cu" "B.Cu") (net 2 "SIG2") (uuid "via-2"))\n'
+            ")\n"
+        )
+        results = _check_clearances(pcb, tmp_path)
+        viols = _via_via_violations(results)
+        assert len(viols) == 2, (
+            f"Expected the pre-#3487 count of 2 via_via reports (one per "
+            f"declared endpoint layer), got {len(viols)}: "
+            f"{[v.layer for v in viols]}"
+        )
+        assert sorted(v.layer for v in viols) == ["B.Cu", "F.Cu"]


### PR DESCRIPTION
Closes #3487

## Summary

- `clearance_segment_via` now collects vias on **every copper layer their barrel spans**, not just the endpoint pair KiCad declares (`(layers "F.Cu" "B.Cu")` on a through-via). Barrel-vs-segment conflicts on inner layers — including the 3 real cross-net shorts on the softstart board that `kct check` could not see — are now reported.
- The via-span predicate is promoted from `analysis/net_status.py` to a shared `kicad_tools.core.layers.via_spans_layer` (single source of truth); `NetStatusAnalyzer` delegates to it.
- Non-segment pairs (via-via, pad-via) are restricted to the via's explicitly-declared layers so their layer-independent geometry is not re-reported on every spanned inner layer (counts unchanged vs pre-fix).
- 21 new unit tests (`tests/test_clearance_via_barrel_layers.py`): through/blind/buried/micro spans, endpoint-layer regression guards, #2706 co-location skip on inner layers, via-via duplication guard, helper coverage.

## Full-fleet artifact scan (fixed rule vs pre-fix baseline, committed routed artifacts)

| Board | mfr | baseline `clearance_segment_via` | fixed | new | verdict |
|---|---|---|---|---|---|
| 01 voltage-divider | jlcpcb | 0 | 0 | 0 | unchanged (0 errors) |
| 02 charlieplex | jlcpcb | 0 | 0 | 0 | unchanged (0 errors) |
| 03 usb-joystick | jlcpcb-tier1 | 0 | 0 | 0 | unchanged (0 errors) |
| 04 stm32-devboard | jlcpcb-tier1 | 0 | 0 | 0 | unchanged (1 advisory connectivity) |
| 05 bldc-controller | jlcpcb-tier1 | 0 | 0 | 0 | unchanged (8 advisory connectivity) |
| 06 diffpair-test | jlcpcb | 2 | 2 | 0 | unchanged post-#3548 (strict gate stays 20) — see below |
| 07 matchgroup-test | jlcpcb | 1 | 1 | 0 | unchanged (gate 14 / floor 28) |
| **softstart (external)** | jlcpcb-tier1 | 0 | **1** | **+1** | **was expected 0/0** — see below |

(Board 00 has no committed PCB artifact.)

### Board 06 — real short found, then RESOLVED by PR #3548 (Issue #3515)

When first scanned, the fixed rule surfaced two USB_CC1 segments vs the USB2_D- **through-via barrel on In1.Cu** at PCB-local (13.8, 17.9), actual **-0.0033 mm** (a real cross-net short always present in the committed artifact; the old rule compared the via only on its declared F.Cu/B.Cu layers). This PR originally grandfathered it with a 20 -> 22 floor/`EXPECTED_STRICT_GATE_ERRORS` bump tracked by #3515. **PR #3548 has since merged and repaired the artifact** (USB_CC1 corridor moved clear of the barrel + GND fill regenerated), so on rebase the bump was DROPPED: board 06 keeps main's floor of 20, and the post-#3548 artifact shows **0 new findings** under the all-layer barrel rule (the only 2 `clearance_segment_via` remaining are the pre-existing USB_CC2 vs USB2_D+ F.Cu quantization grazes already in main's 20-count).

### Softstart — NEW real short (Issue #3516); step-10d verification

The three barrel conflicts #3487 originally documented (GATE_POS_B / SRC_POS / SRC_NEG vs VGATE vias) **are repaired** in the committed artifact (verified: none reported). One residual remains: a **diagonal** I_SENSE_OUT segment (191.8,163.8)->(196.9,158.7) on In2.Cu vs the GND through-via at (196, 160), actual **-0.042 mm** — exactly the axis-aligned-only gap #3487 called out in `_repair_segment_via_clearance`. Tracked in #3516. Softstart is outside the `routed-pcb-drc-check` gate's `boards/[^/]+/output/` path regex, so no tolerance entry exists to update; the defect is tracked solely by the issue.

## Test plan

- [x] `tests/test_clearance_via_barrel_layers.py` — 21 passed
- [x] `tests/test_board_06_diffpair_test.py` — 39 passed (gate pin stays at main's 20 post-rebase)
- [x] validate/clearance/drc suite subset (~3,000 tests): all pass except 9 failures **pre-existing on main** (6 `test_drc_tolerance.py::TestClearanceRuleTolerance` MockPCB AttributeError, 2 `test_validate_hierarchical_nets.py`, 1 `test_cli_parser_drift.py`) — verified failing on the main checkout without this change; masked-CI tracking is #3436
- [x] `scripts/ci/check_routed_drc.py` on all 7 in-repo routed artifacts: exit 0
- [x] `ruff check` + `ruff format --check` clean on all touched files (two `B905` in `net_status.py` pre-exist on main, untouched lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
