### PR TITLE
fix(analysis): NetStatusAnalyzer requires filled copper for zone connectivity (closes #3482)

### DIFF
--- a/src/kicad_tools/analysis/net_status.py
+++ b/src/kicad_tools/analysis/net_status.py
@@ -603,25 +603,36 @@ class NetStatusAnalyzer:
         # We track both filled_polygons (actual copper) AND boundary polygon (zone outline)
         # because vias at pad positions may be in thermal clearance cutouts of filled
         # polygons but still within the zone boundary (and thus connected to the zone).
+        #
+        # IMPORTANT (Issue #3482): the boundary polygon only implies connectivity
+        # when the zone actually produced filled copper. A zone with fill enabled
+        # but zero filled polygons (e.g. fully shadowed by a higher-priority zone,
+        # or carved away entirely by clearances) contributes NO copper, so its
+        # boundary must not mark pads/vias as connected. The boundary heuristic
+        # (Issue #479) exists solely for thermal-relief cutouts INSIDE filled
+        # copper, which presupposes the zone has at least one filled polygon.
         net_zones: list[tuple[str, list[list[tuple[float, float]]]]] = []
         zone_boundaries: list[tuple[str, list[tuple[float, float]]]] = []
         for zone in self.pcb.zones:
             if zone.net_number == net_number:
+                # Zero-fill zones provide no electrical connectivity at all
+                # (Issue #3482): skip both boundary and copper collection.
+                if not zone.filled_polygons:
+                    continue
                 # Collect boundary polygon (zone outline) for via-in-zone checking.
                 # If no boundary polygon exists, use the convex hull of filled
                 # polygons as a fallback boundary so that pad-in-zone checks
                 # still work when kicad-cli omits the outline for filled zones.
                 if zone.polygon:
                     zone_boundaries.append((zone.layer, zone.polygon))
-                elif zone.filled_polygons:
+                else:
                     # Use the bounding box of all filled polygon vertices as a
                     # conservative fallback boundary.
                     fallback = self._bounding_box_polygon(zone.filled_polygons)
                     if fallback:
                         zone_boundaries.append((zone.layer, fallback))
                 # Collect filled polygons for copper overlap checks
-                if zone.filled_polygons:
-                    net_zones.append((zone.layer, zone.filled_polygons))
+                net_zones.append((zone.layer, zone.filled_polygons))
 
         # Build segment components for reuse
         segment_components = self._build_segment_components(segments)

--- a/tests/test_analysis_net_status.py
+++ b/tests/test_analysis_net_status.py
@@ -1579,3 +1579,198 @@ class TestNonZeroBoardOriginRegression:
         assert status["signal_complete_count"] == 1
         assert status["signal_completion_percent"] == pytest.approx(100.0)
         assert status["incomplete_count"] == 0
+
+
+# ---- PCB fixtures for zero-fill zone connectivity tests (Issue #3482) ----
+
+# Shared body: two GND pads inside the zone outline, no traces, no vias.
+# The zone definition is parameterized so each case differs only in its
+# fill / filled_polygon content.
+_ZONE_FILL_PCB_TEMPLATE = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "GND")
+
+  (footprint "C_0402"
+    (layer "F.Cu")
+    (at 15 15)
+    (property "Reference" "C1")
+    (pad "1" smd rect (at 0 -0.25) (size 0.4 0.4) (layers "F.Cu") (net 0 ""))
+    (pad "2" smd rect (at 0 0.25) (size 0.4 0.4) (layers "F.Cu") (net 1 "GND"))
+  )
+
+  (footprint "C_0402"
+    (layer "F.Cu")
+    (at 25 15)
+    (property "Reference" "C2")
+    (pad "1" smd rect (at 0 -0.25) (size 0.4 0.4) (layers "F.Cu") (net 0 ""))
+    (pad "2" smd rect (at 0 0.25) (size 0.4 0.4) (layers "F.Cu") (net 1 "GND"))
+  )
+
+  (zone
+    (net 1)
+    (net_name "GND")
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000001")
+    (hatch edge 0.5)
+    (connect_pads (clearance 0.2))
+    (min_thickness 0.15)
+    (filled_areas_thickness no)
+    {fill_clause}
+    (polygon
+      (pts
+        (xy 10 10)
+        (xy 30 10)
+        (xy 30 20)
+        (xy 10 20)
+      )
+    )
+{filled_polygons}  )
+)
+"""
+
+# Zone with fill ENABLED but zero filled polygons (e.g. fully shadowed by a
+# higher-priority overlapping zone or carved away entirely by clearances).
+# This is the exact softstart AC_NEUTRAL/ISENSE_POS failure mode from
+# Issue #3482: both pads sit inside the zone BOUNDARY but there is no copper.
+ZERO_FILL_ZONE_PCB = _ZONE_FILL_PCB_TEMPLATE.format(
+    fill_clause="(fill yes (thermal_gap 0.2) (thermal_bridge_width 0.2))",
+    filled_polygons="",
+)
+
+# Zone with fill DISABLED (boundary-only zone, board 06 style).
+BOUNDARY_ONLY_ZONE_PCB = _ZONE_FILL_PCB_TEMPLATE.format(
+    fill_clause="(fill (thermal_gap 0.2) (thermal_bridge_width 0.2))",
+    filled_polygons="",
+)
+
+# Zone whose fill produced copper over only PART of the outline: filled
+# polygon covers x in [10, 22] while the boundary extends to x = 30.
+# C1 (15, 15) lands inside filled copper; C2 (25, 15) is inside the
+# boundary only.  The Issue #479 thermal-relief heuristic applies because
+# the zone genuinely has filled copper.
+PARTIAL_FILL_ZONE_PCB = _ZONE_FILL_PCB_TEMPLATE.format(
+    fill_clause="(fill yes (thermal_gap 0.2) (thermal_bridge_width 0.2))",
+    filled_polygons="""    (filled_polygon
+      (layer "F.Cu")
+      (pts
+        (xy 10 10)
+        (xy 22 10)
+        (xy 22 20)
+        (xy 10 20)
+      )
+    )
+""",
+)
+
+
+class TestZeroFillZoneConnectivity:
+    """Regression tests for Issue #3482.
+
+    A zone with zero filled polygons produces NO copper on the manufactured
+    board, so its boundary polygon must not mark pads or vias as connected.
+    Before the fix, the Issue #479 boundary heuristic (intended only for
+    thermal-relief cutouts INSIDE filled copper) marked every pad inside a
+    zero-fill zone outline as zone-connected, reporting electrically open
+    pour nets (softstart AC_NEUTRAL / ISENSE_POS) as ``complete``.
+    """
+
+    @pytest.fixture
+    def zero_fill_pcb(self, tmp_path: Path) -> Path:
+        pcb_file = tmp_path / "zero_fill.kicad_pcb"
+        pcb_file.write_text(ZERO_FILL_ZONE_PCB)
+        return pcb_file
+
+    @pytest.fixture
+    def boundary_only_pcb(self, tmp_path: Path) -> Path:
+        pcb_file = tmp_path / "boundary_only.kicad_pcb"
+        pcb_file.write_text(BOUNDARY_ONLY_ZONE_PCB)
+        return pcb_file
+
+    @pytest.fixture
+    def partial_fill_pcb(self, tmp_path: Path) -> Path:
+        pcb_file = tmp_path / "partial_fill.kicad_pcb"
+        pcb_file.write_text(PARTIAL_FILL_ZONE_PCB)
+        return pcb_file
+
+    def test_zero_fill_zone_is_not_connectivity(self, zero_fill_pcb: Path):
+        """Pads inside a zero-fill zone boundary must NOT report complete.
+
+        This is the softstart PR #3481 failure mode: fill enabled, zero
+        filled polygons, no segments, no vias -> open circuit on the
+        manufactured board.
+        """
+        analyzer = NetStatusAnalyzer(zero_fill_pcb)
+        result = analyzer.analyze()
+
+        gnd = result.get_net("GND")
+        assert gnd is not None
+        assert gnd.status != "complete", (
+            f"Zero-fill zone must not provide connectivity; got status={gnd.status}"
+        )
+        # Both pads are electrically isolated; only the trivial largest
+        # island (one pad) counts as connected.
+        assert gnd.unconnected_count == 1
+        assert gnd.connected_count == 1
+
+    def test_boundary_only_zone_is_not_connectivity(self, boundary_only_pcb: Path):
+        """A boundary-only zone (no fill) must not provide connectivity."""
+        analyzer = NetStatusAnalyzer(boundary_only_pcb)
+        result = analyzer.analyze()
+
+        gnd = result.get_net("GND")
+        assert gnd is not None
+        assert gnd.status != "complete", (
+            f"Boundary-only zone must not provide connectivity; got status={gnd.status}"
+        )
+        assert gnd.unconnected_count == 1
+
+    def test_zero_fill_zone_still_reported_as_plane_net(self, zero_fill_pcb: Path):
+        """Zero-fill zones still classify the net as a plane net.
+
+        The plane-net metadata drives the 'kct stitch' suggested fix, which
+        is exactly the right remediation for an unfilled pour.
+        """
+        analyzer = NetStatusAnalyzer(zero_fill_pcb)
+        result = analyzer.analyze()
+
+        gnd = result.get_net("GND")
+        assert gnd is not None
+        assert gnd.is_plane_net is True
+        assert gnd.plane_layer == "F.Cu"
+
+    def test_partial_fill_zone_provides_connectivity(self, partial_fill_pcb: Path):
+        """A zone with at least one filled polygon retains the Issue #479
+        boundary heuristic: pads inside the outline (including thermal-relief
+        cutouts) are zone-connected.
+        """
+        analyzer = NetStatusAnalyzer(partial_fill_pcb)
+        result = analyzer.analyze()
+
+        gnd = result.get_net("GND")
+        assert gnd is not None
+        assert gnd.status == "complete", (
+            f"Partially filled zone should connect pads inside its boundary; "
+            f"got status={gnd.status}, "
+            f"unconnected: {[p.full_name for p in gnd.unconnected_pads]}"
+        )
+
+    def test_fully_filled_zone_regression(self, tmp_path: Path):
+        """Fully filled zone behavior (Issue #479) must not regress."""
+        pcb_file = tmp_path / "full_fill.kicad_pcb"
+        pcb_file.write_text(PLANE_NET_PCB)
+
+        analyzer = NetStatusAnalyzer(pcb_file)
+        result = analyzer.analyze()
+
+        gnd = result.get_net("GND")
+        assert gnd is not None
+        assert gnd.status == "complete", (
+            f"Fully filled zone should connect both pads; got {gnd.status}"
+        )


### PR DESCRIPTION
Closes #3482

## Summary

`NetStatusAnalyzer._build_connectivity_graph` marked every pad/via inside a zone's BOUNDARY polygon as zone-connected even when the zone had **zero filled polygons** (fill fully shadowed by a higher-priority zone, or carved away by clearances). The boundary heuristic (Issue #479) exists solely for thermal-relief cutouts INSIDE filled copper — it presupposes the zone produced at least one filled polygon. The false positive reported physically open pour nets as `complete` (softstart AC_NEUTRAL/ISENSE_POS on PR #3481; board 06 boundary-only planes), letting automated manufacturability gates pass open circuits.

**Fix**: zones with no `filled_polygon` entries are skipped entirely — they contribute neither boundary nor copper to connectivity. Zones with >=1 filled polygon keep the #479 boundary heuristic unchanged. `kct check`'s `ConnectivityRule` delegates to `NetStatusAnalyzer`, so it inherits the fix and now raises a connectivity ERROR (not just the `zone_unfilled` WARNING) for these nets.

## New regression tests (`tests/test_analysis_net_status.py`)

| Case | Expectation |
|------|-------------|
| Zero-fill zone (fill yes, 0 filled_polygons) | NOT complete (the #3482 failure mode) |
| Boundary-only zone (fill disabled) | NOT complete |
| Partial fill (pad in boundary, outside copper) | complete (#479 heuristic preserved) |
| Fully filled zone | complete (#479 regression guard) |
| Zero-fill zone plane-net metadata | still `is_plane_net` (keeps `kct stitch` suggested fix) |

## Blast radius: per-board reach delta (committed artifacts, main vs fixed)

| Artifact | main | fixed | delta |
|---|---|---|---|
| 01 voltage_divider (unrouted / routed) | 0/3 / 3/3 | 0/3 / 3/3 | none |
| 02 charlieplex (unrouted / routed) | 1/10 / 10/10 | 1/10 / 10/10 | none |
| 03 usb_joystick unrouted | 3/16 | 0/16 | -3 (honest: pre-route zones have no fill) |
| 03 usb_joystick routed | 16/16 | 16/16 | none |
| 04 stm32 (unrouted / routed) | 0/12 / 11/12 | 0/12 / 11/12 | none |
| 05 bldc unrouted | 13/52 | 8/52 | -5 (honest: unfilled pours) |
| **05 bldc routed** | **44/52** | **43/52** | **-1: PWR_LED** |
| 06 diffpair (unrouted / routed) | 0/26 / 24/26 | 0/26 / 24/26 | none |
| 07 matchgroup (unrouted / routed) | 0/34 / 29/34 | 0/34 / 29/34 | none |
| softstart unrouted | 2/41 | 2/41 | none |
| **softstart routed** | **41/41** | **41/41** | **none** |

The single routed-artifact drop is honest: board 05's PWR_LED zone on F.Cu has `(fill yes)` but **zero filled_polygon entries**, and the net has zero segments/vias — R3.1 is an open circuit on the manufactured board, previously masked by this exact bug. Filed **#3513** to repair the artifact. `tests/test_board_05_zones.py` already tolerates PWR_LED pour absence, so no re-pin was needed.

## Ground-truth agreement (shapely copper-union audits)

- **softstart**: `_audit_pour_nets` on the committed `softstart_routed.kicad_pcb` reports all 10 reinforcement pour nets `connected=True` with `zero_fill_zones=0`; analyzer stays 41/41 — agreement.
- **board 06**: `tests/test_board_06_diffpair_test.py` (39 passed) including `TestPourCopperUnionAudit` and the pinned strict-gate/advisory-connectivity numbers — agreement, no re-pins.

## Test results

- `tests/test_analysis_net_status.py`: **64 passed** (5 new)
- `tests/test_board_06_diffpair_test.py`: **39 passed**
- Targeted blast-radius set (connectivity rule, net-status CLI, fleet/report/pipeline/mcp/route-auto consumers, board 03 baseline, board 05 zone/DRC suites): **730 passed, 6 pre-existing failures** (`test_pipeline_cmd.py` report-step output dirs + `test_report_generator.py` skeleton — fail identically on main, unrelated)
- stitch/zones/sync set: **460 passed, 3 pre-existing failures** (`TestBoard05SyncDriftRegression` — fail identically on main, unrelated)

## Follow-ups filed

- #3513 — board 05 PWR_LED pour is dead copper (open circuit at R3.1) on the committed routed artifact
- #3514 — `ConnectivityValidator` (`kct validate --connectivity`, separate module) has the same zero-fill boundary false positive

🤖 Generated with [Claude Code](https://claude.com/claude-code)