### PR TITLE
fix(router): coupled diff-pair shadow machinery, gated opt-in after measurement (refs #3508)

### DIFF
--- a/.github/routed-drc-tolerance.yml
+++ b/.github/routed-drc-tolerance.yml
@@ -875,6 +875,19 @@ tolerances:
   # Floor tightened 33 -> 20.  Exit clause: (a) above retires the 9+9
   # block; the 2 seg-via grazes are general fine-grid quantization
   # targets; after both, the floor tightens toward ~0.
+  #
+  # Issue #3508 status (exit clause (a), 2026-06-11): the coupled
+  # convergence attempt was MEASURED and DECOMPOSED, not retired.  The
+  # geometric shadow constructor nominally converts 6/9 pairs, but its
+  # committed geometry is not artifact-quality (run-4 seed-42
+  # integration measurement: 16/21 reach, strict gate 49 blocking --
+  # stranded shadow tails, shadow-via/partner intersections, corridor
+  # competition stranding MIPI_D0-/USB_CC1).  The constructor ships
+  # OPT-IN (``DifferentialPairConfig.enable_shadow_construction``,
+  # default False; board 06's recipe keeps it off), the committed
+  # artifact and this floor are UNCHANGED at 20, and the quality gaps
+  # are tracked in #3540-#3544 (#3542, coupled upgrade-in-place, is
+  # the reach-safe architecture that re-opens exit clause (a)).
   boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb: 20
 
   # Match-group regression testbench (Epic #2661 Phase 3L, #2724).

--- a/boards/06-diffpair-test/generate_design.py
+++ b/boards/06-diffpair-test/generate_design.py
@@ -1591,10 +1591,24 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
     # needs up to ~45s for the USB3 J1 fan-out (the C++ validation falls
     # back to the Python pathfinder there) and the budget must cover
     # probe + shadow + swapped-probe + bounded fallback searches.
+    # Issue #3508 (decomposition): the geometric shadow constructor is
+    # kept OFF for this recipe.  The 2026-06-11 seed-42 integration
+    # measurement (run-4) showed it converts 6/9 pairs nominally but
+    # the committed geometry is not yet artifact-quality: stranded
+    # shadow tails (USB3_RX1+/RX2+ goal pads), shadow vias physically
+    # intersecting the partner trace at the tightly-coupled gap, and
+    # greedily-claimed pre-phase corridors stranding MIPI_D0-/USB_CC1
+    # (16/21 reach vs the asserted 21/21; strict-gate 49 blocking vs
+    # the committed floor 20).  Flip BOTH this constant and the
+    # optimizer/nudge diff-pair protections below together once the
+    # #3508 follow-up issues land.
+    ENABLE_COUPLED_SHADOW = False
+
     diffpair_config = DifferentialPairConfig(
         enabled=True,
         per_pair_timeout=120.0,
         per_pair_max_iterations=2000,
+        enable_shadow_construction=ENABLE_COUPLED_SHADOW,
     )
 
     # Issue #3089: route the non-diff-pair tail (including any
@@ -1629,6 +1643,14 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
             seed=42,
         )
 
+    # Issue #3508: an A/B run that PRE-ROUTED the two chronically-
+    # stranded singles (USB_CC1, MIPI_D0-) before the coupled pre-phase
+    # was measured and REJECTED: their single-ended A* claims the prime
+    # J1/FFC corridors and coupled convergence collapses 6/9 -> 2/9
+    # (the shadow constructor needs those corridors).  The coupled
+    # phase must claim corridors first; stranded-single residuals are
+    # handled by the stub-edge deferral and the post-routing repair
+    # passes instead.
     router.route_all_with_diffpairs(
         diffpair_config=diffpair_config,
         non_diffpair_strategy=_negotiated_non_diffpair_strategy,
@@ -1656,19 +1678,29 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
     # pass, step 6b's transactional solo re-route repair) see the TRUE
     # copper state instead of the pre-optimization snapshot.
     #
-    # Issue #3508: diff-pair nets are EXCLUDED from optimization.  The
-    # coupled pre-phase's geometry is intentional: length-matching
-    # serpentines are exactly the "zigzags" ``eliminate_zigzags``
-    # removes (measured: PCIE_RX skew 0.097mm post-serpentine ->
-    # 1.652mm in the optimized artifact), and straightening one side
-    # of a coupled pair breaks the constant-gap geometry the
-    # skew/continuity rules measure.
-    diffpair_net_ids = {
-        r.net
-        for r in router.routes
-        if r.net_name and (r.net_name.endswith("+") or r.net_name.endswith("-"))
-    }
-    optimize_routes_grid_synced(router, optimizer, skip_nets=diffpair_net_ids)
+    # Issue #3508: when the coupled shadow constructor is ON, diff-pair
+    # nets are EXCLUDED from optimization.  The coupled pre-phase's
+    # geometry is intentional: length-matching serpentines are exactly
+    # the "zigzags" ``eliminate_zigzags`` removes (measured: PCIE_RX
+    # skew 0.097mm post-serpentine -> 1.652mm in the optimized
+    # artifact), and straightening one side of a coupled pair breaks
+    # the constant-gap geometry the skew/continuity rules measure.
+    # With the shadow OFF (current state, see ENABLE_COUPLED_SHADOW)
+    # all pairs are single-ended fallback routes with no intentional
+    # coupled geometry, so they stay in the optimizer/nudge scope and
+    # the committed artifact is unchanged.
+    diffpair_net_ids: set[int] = (
+        {
+            r.net
+            for r in router.routes
+            if r.net_name and (r.net_name.endswith("+") or r.net_name.endswith("-"))
+        }
+        if ENABLE_COUPLED_SHADOW
+        else set()
+    )
+    optimize_routes_grid_synced(
+        router, optimizer, skip_nets=diffpair_net_ids if diffpair_net_ids else None
+    )
 
     # Issue #2757: Run the DRC verify-and-nudge pass after trace optimisation.
     # The optimiser can produce chamfered diagonals that graze BGA / QFN /
@@ -1682,13 +1714,18 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
     from kicad_tools.router.drc_nudge import drc_verify_and_nudge
 
     print("\n6. DRC verify-and-nudge pass...")
-    # Issue #3508: diff-pair nets are protected from the nudge pass for
-    # the same reason they skip the optimizer above -- the nudge helpers
-    # are not partner-aware, and a 0.2mm displacement at the pairs'
+    # Issue #3508: when the coupled shadow constructor is ON, diff-pair
+    # nets are protected from the nudge pass for the same reason they
+    # skip the optimizer above -- the nudge helpers are not
+    # partner-aware, and a 0.2mm displacement at the pairs'
     # 0.075-0.1mm intra gap lands copper ON the partner (measured:
     # USB3_RX1/RX2 sides physically overlapping post-nudge, forcing the
-    # 6b solo rip which then destroys the coupled geometry).
-    nudge_result = drc_verify_and_nudge(router, skip_nets=diffpair_net_ids)
+    # 6b solo rip which then destroys the coupled geometry).  With the
+    # shadow OFF, ``diffpair_net_ids`` is empty (see above) and the
+    # nudge pass keeps its full scope.
+    nudge_result = drc_verify_and_nudge(
+        router, skip_nets=diffpair_net_ids if diffpair_net_ids else None
+    )
     if nudge_result.initial_violations:
         print(f"   {nudge_result.summary()}")
     else:

--- a/boards/06-diffpair-test/generate_design.py
+++ b/boards/06-diffpair-test/generate_design.py
@@ -1655,7 +1655,20 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
     # collision checking and every downstream grid consumer (the nudge
     # pass, step 6b's transactional solo re-route repair) see the TRUE
     # copper state instead of the pre-optimization snapshot.
-    optimize_routes_grid_synced(router, optimizer)
+    #
+    # Issue #3508: diff-pair nets are EXCLUDED from optimization.  The
+    # coupled pre-phase's geometry is intentional: length-matching
+    # serpentines are exactly the "zigzags" ``eliminate_zigzags``
+    # removes (measured: PCIE_RX skew 0.097mm post-serpentine ->
+    # 1.652mm in the optimized artifact), and straightening one side
+    # of a coupled pair breaks the constant-gap geometry the
+    # skew/continuity rules measure.
+    diffpair_net_ids = {
+        r.net
+        for r in router.routes
+        if r.net_name and (r.net_name.endswith("+") or r.net_name.endswith("-"))
+    }
+    optimize_routes_grid_synced(router, optimizer, skip_nets=diffpair_net_ids)
 
     # Issue #2757: Run the DRC verify-and-nudge pass after trace optimisation.
     # The optimiser can produce chamfered diagonals that graze BGA / QFN /
@@ -1669,7 +1682,13 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
     from kicad_tools.router.drc_nudge import drc_verify_and_nudge
 
     print("\n6. DRC verify-and-nudge pass...")
-    nudge_result = drc_verify_and_nudge(router)
+    # Issue #3508: diff-pair nets are protected from the nudge pass for
+    # the same reason they skip the optimizer above -- the nudge helpers
+    # are not partner-aware, and a 0.2mm displacement at the pairs'
+    # 0.075-0.1mm intra gap lands copper ON the partner (measured:
+    # USB3_RX1/RX2 sides physically overlapping post-nudge, forcing the
+    # 6b solo rip which then destroys the coupled geometry).
+    nudge_result = drc_verify_and_nudge(router, skip_nets=diffpair_net_ids)
     if nudge_result.initial_violations:
         print(f"   {nudge_result.summary()}")
     else:

--- a/boards/06-diffpair-test/generate_design.py
+++ b/boards/06-diffpair-test/generate_design.py
@@ -1580,10 +1580,21 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
     # timing-dependent classification we are eliminating.  When the
     # iteration budget fires (the deterministic path), wall-clock is
     # always well under 60s so this is a safety net only.
+    # Issue #3508: per_pair_timeout 60 -> 120 and per_pair_max_iterations
+    # 4000 -> 2000.  The coupled pre-phase is no longer search-dominated:
+    # the geometric shadow constructor (guide + validated parallel offset,
+    # see diffpair_routing._shadow_route_pair) converges 6-7/9 pairs in
+    # 0.3-75s each, and the joint-state A* is only a last-resort fallback
+    # -- so its iteration budget SHRINKS (it essentially never converges
+    # on this board; 2000+2000 iterations bound the fallback at ~10-30s).
+    # The wall-clock budget GROWS because the corridor/shadow guide probe
+    # needs up to ~45s for the USB3 J1 fan-out (the C++ validation falls
+    # back to the Python pathfinder there) and the budget must cover
+    # probe + shadow + swapped-probe + bounded fallback searches.
     diffpair_config = DifferentialPairConfig(
         enabled=True,
-        per_pair_timeout=60.0,
-        per_pair_max_iterations=4000,
+        per_pair_timeout=120.0,
+        per_pair_max_iterations=2000,
     )
 
     # Issue #3089: route the non-diff-pair tail (including any

--- a/src/kicad_tools/router/diffpair.py
+++ b/src/kicad_tools/router/diffpair.py
@@ -618,6 +618,24 @@ class DifferentialPairConfig:
     per_pair_timeout: float | None = None
     per_pair_max_iterations: int | None = None
     aggregate_timeout: float | None = None
+    # Issue #3508: opt-in gate for the geometric shadow constructor
+    # (``DiffPairRouter._shadow_route_pair``: single-ended guide route
+    # + validated parallel offset, tried before the joint-state
+    # coupled A*).  The constructor converges pairs the joint search
+    # cannot (6/9 nominal on board 06's seed-42 recipe vs 0/9), but
+    # the 2026-06-11 board 06 integration measurement shows its
+    # committed geometry is not yet artifact-quality: shadow tails can
+    # leave goal pads stranded while still claiming the net
+    # (USB3_RX1+/RX2+ "1 of 2 pads stranded"), staggered shadow vias
+    # physically intersect the partner trace at tightly-coupled gaps
+    # (0.3 mm via radius > 0.15 mm edge gap + 0.1125 mm half-width),
+    # and the pre-phase's greedily-claimed corridors strand later
+    # single-ended nets that the negotiated loop cannot rip
+    # (MIPI_D0-, USB_CC1 -> 16/21 reach vs board 06's asserted
+    # 21/21).  Default False keeps recipes on their pre-#3508
+    # budget-exit behaviour; flip on per-board once the #3508
+    # decomposition follow-ups land.
+    enable_shadow_construction: bool = False
 
     def get_rules(self, pair_type: DifferentialPairType) -> DifferentialPairRules:
         """Get rules with any config overrides applied."""

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -11,10 +11,12 @@ Key features:
 
 from __future__ import annotations
 
+import collections
 import heapq
 import itertools
 import logging
 import math
+import os
 import time
 from dataclasses import dataclass, field
 from enum import Enum
@@ -40,6 +42,35 @@ from .path import calculate_route_length
 from .primitives import Pad, Route, Segment, Via
 
 logger = logging.getLogger(__name__)
+
+# Issue #3508: dev-only periodic A* pop trace (KCT_COUPLED_TRACE=1).
+_COUPLED_TRACE = bool(os.environ.get("KCT_COUPLED_TRACE"))
+
+# Issue #3508: weighted-A* factor used by ``route_differential_pair_coupled``
+# when constructing the per-pair :class:`CoupledPathfinder`.  See the
+# ``heuristic_weight`` rationale in ``CoupledPathfinder.__init__``.
+# Env-overridable for experimentation (KCT_COUPLED_HEURISTIC_WEIGHT).
+COUPLED_HEURISTIC_WEIGHT: float = float(
+    os.environ.get("KCT_COUPLED_HEURISTIC_WEIGHT", "1.5")
+)
+
+# Issue #3508: max joint remaining Manhattan distance (grid cells, max
+# over the two heads) at which a budget-exited coupled search qualifies
+# for the near-miss rescue (commit the coupled body, finish each side
+# single-ended).  60 cells = 3 mm on a 0.05 mm grid -- generous against
+# the measured 5-21-cell stalls, small against the 30-50 mm pair routes
+# so the coupled-length fraction stays >> every continuity threshold.
+NEAR_MISS_RESCUE_CELLS: int = int(os.environ.get("KCT_COUPLED_RESCUE_CELLS", "60"))
+
+# Issue #3508: maximum length (mm) the shadow constructor may trim from
+# EACH end of the offset polyline before tail-connecting to the pads.
+# Endpoint zones are always contested by neighbour-pad clearance halos
+# (connector pin rows, QFN/QFP rings), so some trim is expected; a trim
+# beyond this bound means a mid-route obstacle wall and the shadow is
+# declined for that side.  5 mm against board 06's 18-45 mm pair runs
+# keeps the coupled-length fraction comfortably above the 0.7-0.9
+# continuity thresholds.
+_SHADOW_MAX_TRIM_MM: float = float(os.environ.get("KCT_SHADOW_MAX_TRIM_MM", "5.0"))
 
 
 # ---------------------------------------------------------------------------
@@ -442,6 +473,7 @@ class CoupledPathfinder:
         min_spacing_cells: int = 0,
         heuristic_mode: Literal["manhattan_sum", "partner_aware"] = "partner_aware",
         spacing_penalty_factor: float = 0.25,
+        heuristic_weight: float = 1.0,
     ):
         """Initialize coupled pathfinder.
 
@@ -524,6 +556,21 @@ class CoupledPathfinder:
             )
         self.heuristic_mode: Literal["manhattan_sum", "partner_aware"] = heuristic_mode
         self.spacing_penalty_factor = max(0.0, min(1.0, float(spacing_penalty_factor)))
+
+        # Issue #3508: weighted-A* factor applied to the heuristic when
+        # computing ``f = g + weight * h``.  ``1.0`` is classic optimal
+        # A*.  Values > 1 trade path-cost optimality for search effort:
+        # the coupled joint-state space has DEEP f-plateaus (a single
+        # ``cost_turn`` = 5 shell can hold ~90k states on board 06's
+        # 0.05 mm grid -- measured: MIPI_CLK needed ~95k iterations to
+        # flood ONE such basin before escaping, then cruised 350 cells
+        # in <17k).  Weighting the heuristic makes goal-ward gradient
+        # dominate shell-flooding so converging pairs land within a
+        # CI-affordable iteration budget.  Slightly longer paths are an
+        # acceptable trade: pair length-matching is enforced post-route
+        # (serpentine / Phase 3I tuner), and the corridor mask already
+        # bounds how far from the guide path the route can wander.
+        self.heuristic_weight = max(1.0, float(heuristic_weight))
         # Issue #3089: set when the most-recent ``route_coupled`` call
         # exited early due to ``timeout_seconds`` being exceeded.
         # Callers (``route_differential_pair_coupled``) read this to
@@ -543,6 +590,24 @@ class CoupledPathfinder:
         # 4000+4000 on board 06, doubling the diff-pair phase).
         self.last_iterations: int = 0
 
+        # Issue #3508: progress diagnostics for the most recent
+        # ``route_coupled`` call (smallest joint remaining Manhattan
+        # distance any popped state achieved, and the state/node
+        # achieving it).  Lets budget-exit handlers distinguish
+        # "almost converged" from "structurally stuck", and gives the
+        # near-miss rescue (``_rescue_near_miss_coupled``) a parent
+        # chain to reconstruct the partial coupled route from.
+        self.last_best_progress: float = float("inf")
+        self.last_best_state: CoupledState | None = None
+        self.last_best_node: CoupledNode | None = None
+
+        # Issue #3508: per-search move-rejection counters keyed by
+        # rejection reason (sym/asym x blocked/spacing/floor/trail,
+        # plus corridor pruning).  Reset by ``route_coupled``;
+        # surfaced by the caller's budget-exit diagnostics so a
+        # stalled search reports WHAT is pruning its frontier.
+        self.last_rejections: dict[str, int] = collections.defaultdict(int)
+
         # Pre-calculate trace clearance radius
         self._trace_half_width_cells = max(
             1,
@@ -559,6 +624,20 @@ class CoupledPathfinder:
             ),
         )
 
+        # Issue #3508: extra radial slack a via needs BEYOND the trace
+        # envelope the grid cells already encode (see _is_via_blocked).
+        self._via_extra_cells = max(
+            1,
+            math.ceil(
+                max(
+                    0.0,
+                    (self.rules.via_diameter / 2 + self.rules.via_clearance)
+                    - (self.rules.trace_width / 2 + self.rules.trace_clearance),
+                )
+                / self.grid.resolution
+            ),
+        )
+
         # Orthogonal moves only for differential pairs (diagonal moves
         # would complicate spacing maintenance)
         self.directions = [
@@ -569,31 +648,75 @@ class CoupledPathfinder:
         ]
 
     def _is_cell_blocked(self, gx: int, gy: int, layer: int, net: int) -> bool:
-        """Check if a cell is blocked for this net."""
+        """Check if a cell is blocked for this net.
+
+        Issue #3508: own-net cells are passable, matching the per-net
+        pathfinder's ``different_net = cell.net != routing_net``
+        convention.  The previous implementation additionally rejected
+        any ``is_obstacle`` cell -- but ``RoutingGrid._add_pad_unsafe``
+        sets ``is_obstacle = True`` on a pad's OWN clearance-halo and
+        metal cells (it exists to defeat the negotiated-mode
+        ``static_blocks`` release loophole, #2915/#2940, with own-net
+        passability explicitly preserved via the ``cell.net`` check in
+        the main pathfinder).  ORing ``is_obstacle`` here made every
+        pad unreachable for its own coupled route: the joint search
+        stalled at exactly the halo boundary (5-7 cells out) on all 9
+        board 06 pairs, which is why coupled convergence was 0/9 at
+        ANY budget.  True obstacles (board edge, keepouts,
+        ``add_obstacle`` regions) carry ``cell.net == 0`` and remain
+        blocked for every signal net.
+        """
         if not (0 <= gx < self.grid.cols and 0 <= gy < self.grid.rows):
             return True
         if layer < 0 or layer >= self.grid.num_layers:
             return True
 
         cell = self.grid.grid[layer][gy][gx]
-        if cell.blocked:
-            if cell.is_obstacle or cell.net != net:
-                return True
+        if cell.blocked and cell.net != net:
+            return True
         return False
 
     def _is_trace_blocked(self, gx: int, gy: int, layer: int, net: int) -> bool:
-        """Check if placing a trace at this position would conflict."""
-        for dy in range(-self._trace_half_width_cells, self._trace_half_width_cells + 1):
-            for dx in range(-self._trace_half_width_cells, self._trace_half_width_cells + 1):
-                if self._is_cell_blocked(gx + dx, gy + dy, layer, net):
-                    return True
-        return False
+        """Check if placing a trace centerline at this cell would conflict.
+
+        Issue #3508: this checks ONLY the head cell, matching the per-net
+        pathfinder's convention.  The grid already encodes the full
+        centerline clearance envelope at obstacle-marking time: pads are
+        dilated by ``trace_clearance + trace_width / 2``
+        (``RoutingGrid._clearance_for_pin_pitch``) and committed routes
+        by the equivalent trace halo, so a cell is unblocked exactly
+        when a trace centerline there satisfies clearance.  The previous
+        implementation swept an ADDITIONAL ``(2 * half_width + 1)^2``
+        square (+/- ``ceil((trace_width/2 + clearance)/resolution)`` =
+        5 cells on board 06) around the head -- double-counting the
+        clearance envelope to an effective ~0.45 mm.  In open field that
+        was merely conservative; entering any fine-pitch pad
+        neighbourhood (QFN-32/QFN-24/BGA-49/USB-C/FFC -- BOTH endpoints
+        of every board 06 pair) it formed an impassable wall ~1-2.5 mm
+        short of the pads, which is why every coupled search stalled at
+        an identical frontier regardless of iteration budget or
+        tie-break order (best_progress 34-49 on PCIE/USB2 across
+        FIFO/LIFO and 10k/90k-iteration runs).
+        """
+        return self._is_cell_blocked(gx, gy, layer, net)
 
     def _is_via_blocked(self, gx: int, gy: int, net: int) -> bool:
-        """Check if placing a via at this position would conflict on any layer."""
+        """Check if placing a via at this position would conflict on any layer.
+
+        Issue #3508: the swept radius is now the DIFFERENCE between the
+        via envelope and the trace envelope the grid cells already
+        carry (see ``_is_trace_blocked``), not the full via envelope.
+        A grid cell is unblocked when a TRACE centerline is legal
+        there; a via additionally needs
+        ``(via_diameter/2 + via_clearance) - (trace_width/2 +
+        trace_clearance)`` of extra radial slack, which is what
+        ``_via_extra_cells`` captures.  The previous full-envelope
+        sweep (+/-8 cells on every layer on board 06) double-counted
+        the marked halo exactly like the trace check did.
+        """
         for layer in range(self.grid.num_layers):
-            for dy in range(-self._via_half_cells, self._via_half_cells + 1):
-                for dx in range(-self._via_half_cells, self._via_half_cells + 1):
+            for dy in range(-self._via_extra_cells, self._via_extra_cells + 1):
+                for dx in range(-self._via_extra_cells, self._via_extra_cells + 1):
                     if self._is_cell_blocked(gx + dx, gy + dy, layer, net):
                         return True
         return False
@@ -615,8 +738,11 @@ class CoupledPathfinder:
         n_start: GridPos | None = None,
         target_spacing_cells: int | None = None,
         approach_radius_override: int | None = None,
+        departure_radius_override: int | None = None,
         p_visited: frozenset[tuple[int, int, int]] | None = None,
         n_visited: frozenset[tuple[int, int, int]] | None = None,
+        p_trail_buckets: dict[tuple[int, int], list[tuple[int, int, int]]] | None = None,
+        n_trail_buckets: dict[tuple[int, int], list[tuple[int, int, int]]] | None = None,
     ) -> list[tuple[CoupledState, float, bool]]:
         """Generate valid coupled moves maintaining spacing.
 
@@ -644,6 +770,15 @@ class CoupledPathfinder:
                 differ so the search has room to converge from the
                 wider start spacing to the narrower goal spacing
                 (USB-C vs MCU).
+            departure_radius_override: Issue #3508: mirror of
+                ``approach_radius_override`` for the START side.
+                Within this Manhattan radius of the start pads the
+                spacing tolerance is widened the same way, so the
+                pair can transition from the physical start pad
+                pitch to the configured coupled spacing (the
+                mid-route target no longer inherits the start
+                pitch).  When ``None``, falls back to
+                ``max(target_spacing_cells, 6)``.
             p_visited: Issue #3078: optional set of grid cells the
                 positive trace has already occupied along the current
                 A* parent chain.  Cells are encoded as
@@ -672,6 +807,42 @@ class CoupledPathfinder:
         p_visited_set = p_visited if p_visited else frozenset()
         n_visited_set = n_visited if n_visited else frozenset()
 
+        # Issue #3508: trail PROXIMITY guard.  The exact-cell guard
+        # below only rejects landing ON the partner's trail; a landing
+        # ONE cell away from it (0.05 mm centerline distance on board
+        # 06) is copper overlap that the #3320 gate later rejects
+        # wholesale (measured: MIPI_CLK converged but committed copper
+        # had P passing 1-2 cells from N's earlier fan-out trail --
+        # worst -0.175 mm with 5802 offending segment pairs).  The
+        # spacing floor cannot catch this because it constrains the
+        # SIMULTANEOUS head positions, not head-vs-historical-trail
+        # distance.  Reject any advancing landing within
+        # ``min_spacing_cells`` (Euclidean, same layer) of the
+        # PARTNER's accumulated trail, using the spatial buckets the
+        # caller built during its parent-chain walk.
+        prox_r = self.min_spacing_cells
+        prox_bucket = max(1, prox_r)
+        prox_r_sq = float(prox_r * prox_r)
+
+        def _too_close_to_trail(
+            cell: tuple[int, int, int],
+            buckets: dict[tuple[int, int], list[tuple[int, int, int]]] | None,
+        ) -> bool:
+            if not buckets or prox_r <= 1:
+                return False
+            cx, cy, clayer = cell
+            bx, by = cx // prox_bucket, cy // prox_bucket
+            for dbx in (-1, 0, 1):
+                for dby in (-1, 0, 1):
+                    for tx, ty, tlayer in buckets.get((bx + dbx, by + dby), ()):
+                        if tlayer != clayer:
+                            continue
+                        dx = tx - cx
+                        dy = ty - cy
+                        if float(dx * dx + dy * dy) < prox_r_sq - 1e-9:
+                            return True
+            return False
+
         def _self_intersects(
             new_p_pos: GridPos,
             new_n_pos: GridPos,
@@ -699,6 +870,15 @@ class CoupledPathfinder:
             if p_advances and not p_is_endpoint_cell and p_key in n_visited_set:
                 return True
             if n_advances and not n_is_endpoint_cell and n_key in p_visited_set:
+                return True
+            # Issue #3508: proximity variant of the cross-trail check.
+            if p_advances and not p_is_endpoint_cell and _too_close_to_trail(
+                p_key, n_trail_buckets
+            ):
+                return True
+            if n_advances and not n_is_endpoint_cell and _too_close_to_trail(
+                n_key, p_trail_buckets
+            ):
                 return True
             # Self-loop: the advancing trace re-enters a cell it has
             # already occupied on its own trail.  This is the
@@ -739,6 +919,41 @@ class CoupledPathfinder:
             if p_dist_to_goal <= approach_radius and n_dist_to_goal <= approach_radius:
                 approach_relaxed = True
 
+        # Issue #3508: departure-phase relaxation -- the mirror of the
+        # approach phase, anchored on the START pads.  The mid-route
+        # spacing target is now the configured coupled spacing (it no
+        # longer inherits the start pad pitch), so a pair leaving
+        # wide-pitch connector pads needs the same widened tolerance
+        # near the start that the approach phase grants near the goal,
+        # or the very first symmetric step away from the pads would be
+        # rejected for |pitch - target| > 1.
+        departure_relaxed = False
+        if p_start is not None and n_start is not None:
+            p_dist_from_start = abs(state.p_pos.x - p_start.x) + abs(state.p_pos.y - p_start.y)
+            n_dist_from_start = abs(state.n_pos.x - n_start.x) + abs(state.n_pos.y - n_start.y)
+            if departure_radius_override is not None:
+                departure_radius = departure_radius_override
+            else:
+                departure_radius = max(target_spacing_cells, 6)
+            if p_dist_from_start <= departure_radius and n_dist_from_start <= departure_radius:
+                departure_relaxed = True
+
+        spacing_relaxed = approach_relaxed or departure_relaxed
+
+        # Issue #3508: the relaxed tolerance must cover the FULL pitch
+        # transition of whichever phase is active.  The legacy
+        # ``max(1, target)`` only worked because the target itself had
+        # been widened to the start pitch; with the configured coupled
+        # target restored, a 20-cell USB-C pitch against a 7-cell
+        # target needs tolerance >= 13 inside the endpoint zones.  The
+        # phase radii are already sized as ``delta * 2 + 4`` so they
+        # dominate the pitch delta by construction.
+        relaxed_tolerance = max(1, target_spacing_cells)
+        if approach_relaxed:
+            relaxed_tolerance = max(relaxed_tolerance, approach_radius)
+        if departure_relaxed:
+            relaxed_tolerance = max(relaxed_tolerance, departure_radius)
+
         # Try moving both traces in the same direction
         for dx, dy in self.directions:
             new_p = GridPos(
@@ -761,8 +976,10 @@ class CoupledPathfinder:
             p_is_endpoint = self._is_at_goal(new_p, p_goal) or self._is_at_goal(new_p, p_start)
             n_is_endpoint = self._is_at_goal(new_n, n_goal) or self._is_at_goal(new_n, n_start)
             if not p_is_endpoint and self._is_trace_blocked(new_p.x, new_p.y, new_p.layer, p_net):
+                self.last_rejections["sym_blocked_p"] += 1
                 continue
             if not n_is_endpoint and self._is_trace_blocked(new_n.x, new_n.y, new_n.layer, n_net):
+                self.last_rejections["sym_blocked_n"] += 1
                 continue
 
             # Calculate spacing between new positions
@@ -772,10 +989,13 @@ class CoupledPathfinder:
 
             # Only accept moves that maintain target spacing (within tolerance).
             # Issue #2473: When the search is in the "approach" phase
-            # near the goal pads, allow wider spacing variation so
-            # mismatched source/sink pad pitches can converge.
-            tolerance = 1 if not approach_relaxed else max(1, target_spacing_cells)
+            # near the goal pads (or, issue #3508, the "departure"
+            # phase near the start pads), allow wider spacing variation
+            # so mismatched pad pitches can converge to / diverge from
+            # the coupled target.
+            tolerance = relaxed_tolerance if spacing_relaxed else 1
             if abs(new_spacing - target_spacing_cells) > tolerance:
+                self.last_rejections["sym_spacing"] += 1
                 continue
 
             # Issue #3012: Hard floor on within-pair spacing.  Independent
@@ -791,6 +1011,7 @@ class CoupledPathfinder:
                 # Use a small epsilon so a Euclidean spacing of exactly
                 # min_spacing_cells (axis-aligned) is accepted.
                 if new_spacing + 1e-9 < self.min_spacing_cells:
+                    self.last_rejections["sym_floor"] += 1
                     continue
 
             # Issue #3078: path-history self-intersection guard.  Both
@@ -803,6 +1024,7 @@ class CoupledPathfinder:
                 p_is_endpoint_cell=p_is_endpoint,
                 n_is_endpoint_cell=n_is_endpoint,
             ):
+                self.last_rejections["sym_trail"] += 1
                 continue
 
             # Calculate cost
@@ -816,18 +1038,39 @@ class CoupledPathfinder:
             new_state = CoupledState(new_p, new_n, new_direction)
             neighbors.append((new_state, cost, False))
 
-        # Issue #2490: Asymmetric "converge" moves during approach
-        # phase only.  When start and goal pad pitches differ
-        # (e.g., USB device-side: MCU 0.8mm pitch -> USB-C 0.5mm
-        # pitch), the symmetric step moves above preserve spacing
-        # exactly, so the search can never land both traces on
-        # endpoint cells whose pitch is narrower than the start
-        # pitch.  Within the approach radius, allow one trace to
-        # advance toward its goal while the other holds, which
-        # closes the spacing one cell at a time.  Restricted to
-        # the approach phase so the bulk of the run still
-        # maintains constant spacing.
-        if approach_relaxed and p_goal is not None and n_goal is not None:
+        # Issue #2490: Asymmetric "converge" moves.  When start and
+        # goal pad pitches differ (e.g., USB device-side: MCU 0.8mm
+        # pitch -> USB-C 0.5mm pitch), the symmetric step moves above
+        # preserve spacing exactly, so the search can never land both
+        # traces on endpoint cells whose pitch is narrower than the
+        # start pitch.  Allowing one trace to advance while the other
+        # holds closes the spacing one cell at a time.
+        #
+        # Issue #3508: asymmetric moves are now allowed MID-ROUTE too
+        # (originally #2490 restricted them to the approach phase).
+        # Symmetric moves translate both heads by the same vector, so
+        # the P->N offset vector is FROZEN for the whole mid-route --
+        # the pair physically cannot turn a corner whose leg runs
+        # parallel to that offset: the trailing trace must ride the
+        # leading trace's trail and the #3078 path-history guard
+        # (correctly) rejects it.  On board 06 this made 9/9 pairs
+        # structurally infeasible for the coupled search (MIPI_CLK
+        # burned 90k corridor-bounded iterations without converging;
+        # the L-shaped FFC->IC route needs a leg parallel to the pad
+        # offset).  Concentric corners need the offset vector to
+        # ROTATE, which only asymmetric moves can do (the outer trace
+        # walks a discrete arc around the holding inner trace).
+        #
+        # The #2490 restriction predates the guards that make
+        # mid-route asymmetry safe: the ``min_spacing_cells`` hard
+        # floor (#3012) prevents the spacing collapse, the
+        # path-history guard (#3078) prevents the loop-around
+        # pathology, and the mid-route tolerance here stays TIGHT
+        # (+/-1 cell, same as the symmetric branch) -- the wide
+        # ``max(1, target)`` tolerance still applies only inside the
+        # approach radius.
+        if p_goal is not None and n_goal is not None:
+            asym_tolerance = relaxed_tolerance if spacing_relaxed else 1
             for dx, dy in self.directions:
                 # P advances, N holds.
                 cand_p = GridPos(state.p_pos.x + dx, state.p_pos.y + dy, state.p_pos.layer)
@@ -835,14 +1078,17 @@ class CoupledPathfinder:
                 p_is_endpoint = self._is_at_goal(cand_p, p_goal) or self._is_at_goal(
                     cand_p, p_start
                 )
-                if p_is_endpoint or not self._is_trace_blocked(
+                if not (p_is_endpoint or not self._is_trace_blocked(
                     cand_p.x, cand_p.y, cand_p.layer, p_net
-                ):
+                )):
+                    self.last_rejections["asym_blocked_p"] += 1
+                else:
                     spacing_dx = cand_p.x - cand_n.x
                     spacing_dy = cand_p.y - cand_n.y
                     new_spacing = math.sqrt(spacing_dx * spacing_dx + spacing_dy * spacing_dy)
-                    tolerance = max(1, target_spacing_cells)
-                    if abs(new_spacing - target_spacing_cells) <= tolerance:
+                    if abs(new_spacing - target_spacing_cells) > asym_tolerance:
+                        self.last_rejections["asym_spacing_p"] += 1
+                    else:
                         # Issue #3012: enforce the within-pair spacing
                         # floor in the asymmetric P-advance move.  The
                         # asymmetric moves only fire in the approach
@@ -861,7 +1107,7 @@ class CoupledPathfinder:
                             and not bypass_floor
                             and new_spacing + 1e-9 < self.min_spacing_cells
                         ):
-                            pass  # reject this candidate
+                            self.last_rejections["asym_floor_p"] += 1
                         elif _self_intersects(
                             cand_p,
                             cand_n,
@@ -878,7 +1124,7 @@ class CoupledPathfinder:
                             # producing the centerline-coincident
                             # routes that DRC reports as -0.2mm
                             # intra-pair clearance.
-                            pass  # reject this candidate
+                            self.last_rejections["asym_trail_p"] += 1
                         else:
                             # Direction tracking only reflects P's motion;
                             # tag with the new direction so the cost-of-turn
@@ -898,12 +1144,13 @@ class CoupledPathfinder:
                 if not n_is_endpoint and self._is_trace_blocked(
                     cand_n2.x, cand_n2.y, cand_n2.layer, n_net
                 ):
+                    self.last_rejections["asym_blocked_n"] += 1
                     continue
                 spacing_dx = cand_p2.x - cand_n2.x
                 spacing_dy = cand_p2.y - cand_n2.y
                 new_spacing = math.sqrt(spacing_dx * spacing_dx + spacing_dy * spacing_dy)
-                tolerance = max(1, target_spacing_cells)
-                if abs(new_spacing - target_spacing_cells) > tolerance:
+                if abs(new_spacing - target_spacing_cells) > asym_tolerance:
+                    self.last_rejections["asym_spacing_n"] += 1
                     continue
                 # Issue #3012: same within-pair spacing floor as the
                 # P-advance branch.  P holds at its current position
@@ -919,6 +1166,7 @@ class CoupledPathfinder:
                     and not bypass_floor
                     and new_spacing + 1e-9 < self.min_spacing_cells
                 ):
+                    self.last_rejections["asym_floor_n"] += 1
                     continue
                 # Issue #3078: N-advance must not land on P's
                 # accumulated trail or on its own accumulated trail.
@@ -933,6 +1181,7 @@ class CoupledPathfinder:
                     p_is_endpoint_cell=p_is_endpoint_held,
                     n_is_endpoint_cell=n_is_endpoint,
                 ):
+                    self.last_rejections["asym_trail_n"] += 1
                     continue
                 cost = self.rules.cost_straight
                 if state.direction != (0, 0) and state.direction != (dx, dy):
@@ -1171,6 +1420,16 @@ class CoupledPathfinder:
         self.last_timeout_exceeded = False
         # Issue #3473: reset the iteration counter for this call.
         self.last_iterations = 0
+        # Issue #3508: best progress-toward-goal (joint Manhattan
+        # remaining distance, max over the two heads) any popped state
+        # achieved, plus the state that achieved it.  Consumed by the
+        # caller's budget-exit diagnostics to distinguish "almost
+        # converged, budget-starved" from "structurally stuck".
+        self.last_best_progress: float = float("inf")
+        self.last_best_state: CoupledState | None = None
+        self.last_best_node: CoupledNode | None = None
+        # Issue #3508: reset the per-search rejection counters.
+        self.last_rejections = collections.defaultdict(int)
 
         # Convert to grid coordinates
         p_start_gx, p_start_gy = self.grid.world_to_grid(p_start.x, p_start.y)
@@ -1208,23 +1467,44 @@ class CoupledPathfinder:
             (p_start_gx - n_start_gx) ** 2 + (p_start_gy - n_start_gy) ** 2
         )
         actual_end_spacing = math.sqrt((p_end_gx - n_end_gx) ** 2 + (p_end_gy - n_end_gy) ** 2)
+
+        # Issue #3508: the mid-route spacing target is the CONFIGURED
+        # coupled spacing, NOT the start pad pitch.  The legacy code
+        # (#2473) widened ``effective_target_spacing`` to the start-pad
+        # distance, which forced the pair to fly the ENTIRE route at
+        # connector pitch (0.75-1.0 mm on board 06's FFC / USB-C
+        # sources -- not electrically coupled at all) and then made the
+        # endgame infeasible: a 16-20-cell-wide pair cannot thread the
+        # dense pad field around the destination IC, and the
+        # ``_heuristic`` spacing penalty (which uses the configured
+        # ``self.target_spacing_cells``) actively fought the move
+        # filter the whole way.  Instead, keep the configured target
+        # and let the DEPARTURE phase below absorb the start-pitch
+        # mismatch, exactly mirroring how the approach phase absorbs
+        # the goal-pitch mismatch.
         effective_target_spacing = self.target_spacing_cells
-        if actual_start_spacing > effective_target_spacing:
-            effective_target_spacing = int(round(actual_start_spacing))
 
         # Issue #2490: Size the approach radius to accommodate the
-        # full pitch transition between start and goal pads.  When
-        # start and end pad pitches differ (USB device-side: MCU
-        # 0.8mm pitch vs USB-C 0.5mm pitch), the legacy
-        # ``max(target, 6)`` radius can be smaller than the
-        # number of single-cell spacing reductions required to
-        # converge, leaving the search no room to relax spacing
-        # without exceeding the per-step tolerance.  Scale the
+        # full pitch transition between the coupled target and the
+        # goal pads.  The legacy ``max(target, 6)`` radius can be
+        # smaller than the number of single-cell spacing reductions
+        # required to converge, leaving the search no room to relax
+        # spacing without exceeding the per-step tolerance.  Scale the
         # radius with the absolute spacing difference plus a small
-        # buffer so each cell of the approach can drop spacing by
+        # buffer so each cell of the approach can change spacing by
         # at most one cell.
-        spacing_delta = int(round(abs(actual_start_spacing - actual_end_spacing)))
-        effective_approach_radius = max(effective_target_spacing, 6, spacing_delta * 2 + 4)
+        end_spacing_delta = int(round(abs(actual_end_spacing - effective_target_spacing)))
+        effective_approach_radius = max(effective_target_spacing, 6, end_spacing_delta * 2 + 4)
+
+        # Issue #3508: departure radius -- the mirror of the approach
+        # radius, sized by the start-pitch transition.  Within this
+        # radius of the start pads the spacing tolerance is widened so
+        # the pair can converge from the physical pad pitch down to
+        # the coupled target one cell per step.
+        start_spacing_delta = int(round(abs(actual_start_spacing - effective_target_spacing)))
+        effective_departure_radius = max(
+            effective_target_spacing, 6, start_spacing_delta * 2 + 4
+        )
 
         start_state = CoupledState(p_start_pos, n_start_pos, (0, 0))
 
@@ -1253,8 +1533,25 @@ class CoupledPathfinder:
         # ``CoupledNode`` constructor reads ``next(seq_counter)`` once.
         seq_counter = itertools.count()
 
-        start_h = self._heuristic(start_state, p_goal_pos, n_goal_pos)
-        start_node = CoupledNode(start_h, 0.0, start_state, seq=next(seq_counter))
+        start_h = self.heuristic_weight * self._heuristic(start_state, p_goal_pos, n_goal_pos)
+        # Issue #3508: LIFO tie-break (note the NEGATED counter).  The
+        # #3144 fix introduced the monotonic counter for determinism
+        # with FIFO semantics (oldest equal-f node pops first).  FIFO
+        # explores f-score plateaus breadth-first: on a corridor-
+        # bounded coupled search the plateau is the whole tube
+        # cross-section x direction-history product, so the frontier
+        # saturates laterally and the search burns its entire
+        # iteration budget mid-tube (board 06: every pair, including
+        # 90k-iteration corridor runs, exhausted budgets without
+        # converging).  Popping the NEWEST equal-f node instead dives
+        # depth-first along the most recently extended path -- on a
+        # plateau this beelines toward the goal and only falls back
+        # to sibling states when the dive hits an obstacle.  Equally
+        # deterministic (the counter is still search-local and
+        # monotonic); A* optimality is unaffected (tie-break order
+        # among equal-f nodes never changes the returned path cost
+        # with an admissible heuristic).
+        start_node = CoupledNode(start_h, 0.0, start_state, seq=-next(seq_counter))
         heapq.heappush(open_set, start_node)
         g_scores[(p_start_pos, n_start_pos)] = 0.0
 
@@ -1333,6 +1630,16 @@ class CoupledPathfinder:
                 continue
             closed_set.add(current_key)
 
+            if _COUPLED_TRACE and iterations % 1000 == 0:
+                print(
+                    f"      [trace] it={iterations} f={current.f_score:.1f} "
+                    f"g={current.g_score:.1f} open={len(open_set)} "
+                    f"closed={len(closed_set)} p=({current.state.p_pos.x},"
+                    f"{current.state.p_pos.y},{current.state.p_pos.layer}) "
+                    f"n=({current.state.n_pos.x},{current.state.n_pos.y},"
+                    f"{current.state.n_pos.layer})"
+                )
+
             # Goal check - both traces must reach their goals
             p_at_goal = (
                 current.state.p_pos.x == p_goal_pos.x and current.state.p_pos.y == p_goal_pos.y
@@ -1344,6 +1651,24 @@ class CoupledPathfinder:
             if p_at_goal and n_at_goal:
                 return self._reconstruct_coupled_routes(current, p_start, p_end, n_start, n_end)
 
+            # Issue #3508: progress tracking for budget-exit diagnostics.
+            # ``last_best_progress`` is the smallest joint remaining
+            # distance any popped state achieved; a budget exit at high
+            # remaining distance means the search is structurally stuck
+            # (pinch point / frozen-offset corner), while a near-zero
+            # value means it almost converged and a budget bump would
+            # likely land it.
+            _progress = max(
+                abs(current.state.p_pos.x - p_goal_pos.x)
+                + abs(current.state.p_pos.y - p_goal_pos.y),
+                abs(current.state.n_pos.x - n_goal_pos.x)
+                + abs(current.state.n_pos.y - n_goal_pos.y),
+            )
+            if _progress < self.last_best_progress:
+                self.last_best_progress = _progress
+                self.last_best_state = current.state
+                self.last_best_node = current
+
             # Issue #3078: build path-history sets for the current
             # node by walking its parent chain.  These let
             # ``_get_coupled_neighbors`` reject moves that would put
@@ -1353,14 +1678,28 @@ class CoupledPathfinder:
             # moves let one trace loop around its partner.
             p_visited_cells: set[tuple[int, int, int]] = set()
             n_visited_cells: set[tuple[int, int, int]] = set()
+            # Issue #3508: spatial buckets over the SAME trail cells for
+            # the proximity guard (see ``_too_close_to_trail``).  Bucket
+            # size = the proximity radius so any cell within the radius
+            # of a candidate lives in one of the 3x3 neighbouring
+            # buckets.
+            prox_radius = self.min_spacing_cells
+            p_trail_buckets: dict[tuple[int, int], list[tuple[int, int, int]]] = {}
+            n_trail_buckets: dict[tuple[int, int], list[tuple[int, int, int]]] = {}
+            bucket = max(1, prox_radius)
             walker: CoupledNode | None = current
             while walker is not None:
-                p_visited_cells.add(
-                    (walker.state.p_pos.x, walker.state.p_pos.y, walker.state.p_pos.layer)
-                )
-                n_visited_cells.add(
-                    (walker.state.n_pos.x, walker.state.n_pos.y, walker.state.n_pos.layer)
-                )
+                p_cell = (walker.state.p_pos.x, walker.state.p_pos.y, walker.state.p_pos.layer)
+                n_cell = (walker.state.n_pos.x, walker.state.n_pos.y, walker.state.n_pos.layer)
+                p_visited_cells.add(p_cell)
+                n_visited_cells.add(n_cell)
+                if prox_radius > 1:
+                    p_trail_buckets.setdefault(
+                        (p_cell[0] // bucket, p_cell[1] // bucket), []
+                    ).append(p_cell)
+                    n_trail_buckets.setdefault(
+                        (n_cell[0] // bucket, n_cell[1] // bucket), []
+                    ).append(n_cell)
                 walker = walker.parent
             # Endpoint pads are legitimate landing cells regardless of
             # history -- strip them so the check doesn't disqualify a
@@ -1392,8 +1731,11 @@ class CoupledPathfinder:
                 n_start_pos,
                 target_spacing_cells=effective_target_spacing,
                 approach_radius_override=effective_approach_radius,
+                departure_radius_override=effective_departure_radius,
                 p_visited=p_visited_frozen,
                 n_visited=n_visited_frozen,
+                p_trail_buckets=p_trail_buckets,
+                n_trail_buckets=n_trail_buckets,
             ):
                 # Issue #3439: corridor-bounded search.  Prune any
                 # state whose P or N head leaves the corridor mask
@@ -1406,6 +1748,7 @@ class CoupledPathfinder:
                     if (p_xy not in corridor and p_xy not in corridor_exempt) or (
                         n_xy not in corridor and n_xy not in corridor_exempt
                     ):
+                        self.last_rejections["corridor"] += 1
                         continue
 
                 neighbor_key = (new_state.p_pos, new_state.n_pos)
@@ -1417,10 +1760,13 @@ class CoupledPathfinder:
                 if neighbor_key not in g_scores or new_g < g_scores[neighbor_key]:
                     g_scores[neighbor_key] = new_g
                     h = self._heuristic(new_state, p_goal_pos, n_goal_pos)
-                    f = new_g + h
+                    # Issue #3508: weighted A* (see ``heuristic_weight``).
+                    f = new_g + self.heuristic_weight * h
 
+                    # Issue #3508: negated counter = LIFO tie-break on
+                    # equal f -- see the start-node comment.
                     neighbor_node = CoupledNode(
-                        f, new_g, new_state, current, is_via, seq=next(seq_counter)
+                        f, new_g, new_state, current, is_via, seq=-next(seq_counter)
                     )
                     heapq.heappush(open_set, neighbor_node)
 
@@ -1639,13 +1985,33 @@ def create_serpentine(
     if best_segment is None:
         return False
 
-    # Calculate serpentine parameters
-    # Serpentine adds length = 2 * num_bends * amplitude
-    # We want to add length_to_add, so:
-    # amplitude = length_to_add / (2 * num_bends)
-    # Use 4 bends as default
-    num_bends = 4
-    amplitude = max(min_amplitude, length_to_add / (2 * num_bends))
+    # Calculate serpentine parameters.
+    #
+    # Issue #3508: the bulges this function emits are TRIANGULAR (two
+    # diagonal segments out to the bulge apex and back), so the length
+    # a bend ADDS over the straight step it replaces is
+    #
+    #     added_per_bend = 2 * hypot(step/2, amplitude) - step
+    #
+    # The legacy ``amplitude = length_to_add / (2 * num_bends)``
+    # assumed SQUARE bulges (added = 2 * amplitude per bend) and
+    # under-delivered by up to an order of magnitude on long steps
+    # (e.g. step 4 mm, amplitude 0.5 mm adds 0.124 mm/bend, not
+    # 1.0 mm/bend) -- the shim then "succeeded" while leaving the pair
+    # skewed.  Invert the triangular formula instead, and scale the
+    # bend count with the available segment so amplitudes stay small.
+    seg_len_initial = math.hypot(
+        best_segment.x2 - best_segment.x1, best_segment.y2 - best_segment.y1
+    )
+    num_bends = max(2, min(12, int(seg_len_initial / 1.0)))
+    step_est = seg_len_initial / (num_bends + 1)
+    added_per_bend = length_to_add / num_bends
+    amplitude = max(
+        min_amplitude,
+        math.sqrt(
+            max(0.0, ((added_per_bend + step_est) / 2.0) ** 2 - (step_est / 2.0) ** 2)
+        ),
+    )
 
     # Determine serpentine direction (perpendicular to segment)
     seg_dx = best_segment.x2 - best_segment.x1
@@ -1727,7 +2093,18 @@ def create_serpentine(
                 )
             )
 
-            current_side *= -1  # Flip side for next bend
+            # Issue #3508: keep ALL bulges on the outward side when a
+            # partner constraint is in play.  The legacy alternating
+            # serpentine sends every other bulge TOWARD the partner;
+            # for a coupled pair at the intentionally-tight intra gap
+            # (0.075-0.1 mm edge-to-edge) any inward bulge violates the
+            # clearance self-check below, so the shim always failed on
+            # exactly the pairs that need it most (board 06 shadow
+            # pairs, 2.5-4.5 mm trim/tail skew).  A one-sided comb adds
+            # the same length per bend without ever approaching the
+            # partner.
+            if partner_route is None or intra_pair_clearance_mm is None:
+                current_side *= -1  # Flip side for next bend
         else:
             # Final segment to end point
             new_segments.append(
@@ -2301,6 +2678,859 @@ class DiffPairRouter:
             results.append(route)
         return results
 
+    def _virtual_pad_at(
+        self, template: Pad, wx: float, wy: float, layer_idx: int
+    ) -> Pad:
+        """Virtual pad at an arbitrary board position (issue #3508).
+
+        Used as the start/end anchor for synthesized tail routes and as
+        the reconstruction end pad (so ``_build_route_from_path`` does
+        not force a straight final jump onto the real pad).
+        """
+        grid = self.autorouter.grid
+        return Pad(
+            x=wx,
+            y=wy,
+            width=template.width,
+            height=template.height,
+            net=template.net,
+            net_name=template.net_name,
+            layer=Layer(grid.index_to_layer(layer_idx)),
+            ref=template.ref,
+            pin=template.pin,
+        )
+
+    def _segment_cells_clear(
+        self,
+        pathfinder: CoupledPathfinder,
+        x1: float,
+        y1: float,
+        x2: float,
+        y2: float,
+        layer_idx: int,
+        net: int,
+    ) -> bool:
+        """True when every grid cell under the segment is legal for ``net``.
+
+        Issue #3508: the grid encodes the full centerline clearance
+        envelope at obstacle-marking time (see ``_is_trace_blocked``),
+        so a clear rasterisation implies a clearance-clear segment.
+        """
+        grid = self.autorouter.grid
+        gx1, gy1 = grid.world_to_grid(x1, y1)
+        gx2, gy2 = grid.world_to_grid(x2, y2)
+        steps = max(abs(gx2 - gx1), abs(gy2 - gy1))
+        for i in range(steps + 1):
+            t = i / steps if steps else 0.0
+            gx = int(round(gx1 + (gx2 - gx1) * t))
+            gy = int(round(gy1 + (gy2 - gy1) * t))
+            if pathfinder._is_cell_blocked(gx, gy, layer_idx, net):
+                return False
+        return True
+
+    def _synthesize_tail(
+        self, pathfinder: CoupledPathfinder, head: Pad, goal: Pad, layer_idx: int
+    ) -> Route | None:
+        """Geometric head->pad tail on the head's layer (issue #3508).
+
+        The per-net ``route()`` machinery declines sub-millimetre hops
+        whose endpoints sit inside pad clearance halos (measured: every
+        board 06 rescue tail it was offered), so we draw the tail
+        directly -- a straight segment, or an axis-aligned dogleg --
+        and validate every covered grid cell with
+        :meth:`_segment_cells_clear`.
+        """
+        grid = self.autorouter.grid
+        goal_layer_idx = grid.layer_to_index(goal.layer.value)
+        if goal_layer_idx != layer_idx:
+            return None  # layer mismatch: leave to the A* fallback
+        width = pathfinder._get_trace_width_for_net(head.net_name)
+        layer = Layer(grid.index_to_layer(layer_idx))
+
+        candidates: list[list[tuple[float, float, float, float]]] = [
+            [(head.x, head.y, goal.x, goal.y)],  # direct
+            [  # dogleg via (goal.x, head.y)
+                (head.x, head.y, goal.x, head.y),
+                (goal.x, head.y, goal.x, goal.y),
+            ],
+            [  # dogleg via (head.x, goal.y)
+                (head.x, head.y, head.x, goal.y),
+                (head.x, goal.y, goal.x, goal.y),
+            ],
+        ]
+        # Issue #3508: U-shaped detours.  Neighbour-pad halos often
+        # block both straight doglegs (e.g. a partner pad sitting
+        # between the shadow head and its goal pad on a connector pin
+        # row); a small perpendicular excursion around the blocker is
+        # routinely legal.
+        for off in (0.4, -0.4, 0.8, -0.8, 1.2, -1.2, 1.6, -1.6):
+            wy = head.y + off
+            candidates.append(
+                [
+                    (head.x, head.y, head.x, wy),
+                    (head.x, wy, goal.x, wy),
+                    (goal.x, wy, goal.x, goal.y),
+                ]
+            )
+            wx = head.x + off
+            candidates.append(
+                [
+                    (head.x, head.y, wx, head.y),
+                    (wx, head.y, wx, goal.y),
+                    (wx, goal.y, goal.x, goal.y),
+                ]
+            )
+        for segs in candidates:
+            if all(
+                self._segment_cells_clear(pathfinder, x1, y1, x2, y2, layer_idx, head.net)
+                for x1, y1, x2, y2 in segs
+            ):
+                route = Route(net=head.net, net_name=head.net_name)
+                for x1, y1, x2, y2 in segs:
+                    if abs(x2 - x1) < 0.01 and abs(y2 - y1) < 0.01:
+                        continue
+                    route.segments.append(
+                        Segment(
+                            x1=x1,
+                            y1=y1,
+                            x2=x2,
+                            y2=y2,
+                            width=width,
+                            layer=layer,
+                            net=head.net,
+                            net_name=head.net_name,
+                        )
+                    )
+                if route.segments:
+                    return route
+        return None
+
+    def _pair_seg_clearance(self, pathfinder: CoupledPathfinder, net_name: str) -> float:
+        """Centerline distance bound between pair partners (issue #3508).
+
+        Same-layer P/N copper must keep ``width/2 + intra_pair_clearance
+        + width/2`` of centerline separation -- the intra-pair bound the
+        diffpair DRC family checks, NOT the inter-net manufacturer
+        clearance (using the latter rejects legitimately-coupled
+        geometry: the coupled gap is intentionally tighter).
+        """
+        net_class_map = getattr(self.autorouter, "net_class_map", None) or {}
+        nc = net_class_map.get(net_name)
+        intra = (
+            nc.effective_intra_pair_clearance()
+            if nc is not None
+            else self.autorouter.rules.trace_clearance
+        )
+        width = pathfinder._get_trace_width_for_net(net_name)
+        return width + float(intra)
+
+    @staticmethod
+    def _point_segment_distance(
+        px: float, py: float, seg: Segment
+    ) -> float:
+        """Euclidean distance from a point to a segment's centerline."""
+        vx = seg.x2 - seg.x1
+        vy = seg.y2 - seg.y1
+        wx = px - seg.x1
+        wy = py - seg.y1
+        denom = vx * vx + vy * vy
+        if denom < 1e-12:
+            return math.hypot(wx, wy)
+        t = max(0.0, min(1.0, (wx * vx + wy * vy) / denom))
+        return math.hypot(px - (seg.x1 + t * vx), py - (seg.y1 + t * vy))
+
+    def _min_distance_to_partner(
+        self,
+        x1: float,
+        y1: float,
+        x2: float,
+        y2: float,
+        partner_segments: list[Segment],
+        layer: Layer | None,
+        sample_step: float = 0.05,
+    ) -> float:
+        """Min centerline distance from a segment to partner copper.
+
+        ``layer`` of ``None`` compares against ALL partner segments
+        (used for via barrels, which span every layer); otherwise only
+        same-layer partner segments are considered.
+        """
+        best = float("inf")
+        seg_len = math.hypot(x2 - x1, y2 - y1)
+        n_steps = max(1, int(math.ceil(seg_len / sample_step)))
+        for ps in partner_segments:
+            if layer is not None and ps.layer != layer:
+                continue
+            for i in range(n_steps + 1):
+                t = i / n_steps
+                d = self._point_segment_distance(
+                    x1 + (x2 - x1) * t, y1 + (y2 - y1) * t, ps
+                )
+                if d < best:
+                    best = d
+        return best
+
+    def _synthesize_crossing_tail(
+        self,
+        pathfinder: CoupledPathfinder,
+        head: Pad,
+        goal: Pad,
+        layer_idx: int,
+        partner_segments: list[Segment],
+    ) -> Route | None:
+        """Two-via layer-change tail that may cross the partner guide.
+
+        Issue #3508: polarity-swap pairs (and in-line connector exits)
+        require the tail to cross the partner's path.  A same-layer
+        crossing is a short, so the crossing portion dives to another
+        routable layer between two vias.  Each candidate is validated
+        cell-by-cell per layer, via positions are checked with the
+        pathfinder's via predicate, and -- because the partner guide is
+        NOT in the grid -- explicit geometric clearance against the
+        partner segments is enforced: same-layer segment portions and
+        via barrels keep ``via_diameter/2 + trace_clearance +
+        partner_width/2`` of centerline distance.
+        """
+        grid = self.autorouter.grid
+        rules = self.autorouter.rules
+        goal_layer_idx = grid.layer_to_index(goal.layer.value)
+        if goal_layer_idx != layer_idx:
+            return None
+        width = pathfinder._get_trace_width_for_net(head.net_name)
+        partner_width = max((ps.width for ps in partner_segments), default=width)
+        # Via barrel vs partner trace clearance bound (vias are not
+        # pair members; the standard manufacturer clearance applies).
+        via_clear = (
+            rules.via_diameter / 2 + rules.trace_clearance + partner_width / 2
+        )
+        # Same-layer trace vs partner trace: the intra-pair bound.
+        seg_clear = self._pair_seg_clearance(pathfinder, head.net_name)
+
+        surface = Layer(grid.index_to_layer(layer_idx))
+        routable = [
+            li for li in grid.get_routable_indices() if li != layer_idx
+        ]
+        if not routable:
+            return None
+
+        dx = goal.x - head.x
+        dy = goal.y - head.y
+        run = math.hypot(dx, dy)
+        if run < 1e-9:
+            return None
+        ux, uy = dx / run, dy / run
+        nxp, nyp = -uy, ux  # unit normal
+
+        # Candidate via sites around each endpoint.  Tails are short
+        # (sub-2 mm), so the two vias generally cannot sit ON the
+        # head->goal line; lateral offsets give the crossover room.
+        def _via_candidates(cx: float, cy: float, toward: float) -> list[tuple[float, float]]:
+            out = []
+            for a in (0.0, 0.5, 1.0):
+                for b in (0.0, 0.6, -0.6, 1.2, -1.2):
+                    out.append(
+                        (cx + toward * ux * a + nxp * b, cy + toward * uy * a + nyp * b)
+                    )
+            return out
+
+        for v1 in _via_candidates(head.x, head.y, 1.0):
+            for v2 in _via_candidates(goal.x, goal.y, -1.0):
+                if math.hypot(v2[0] - v1[0], v2[1] - v1[1]) < 0.6:
+                    continue  # via-to-via clearance
+                g1 = grid.world_to_grid(*v1)
+                g2 = grid.world_to_grid(*v2)
+                if pathfinder._is_via_blocked(g1[0], g1[1], head.net):
+                    continue
+                if pathfinder._is_via_blocked(g2[0], g2[1], head.net):
+                    continue
+                # Via barrels: distance to partner copper on ANY layer.
+                if (
+                    self._min_distance_to_partner(
+                        v1[0], v1[1], v1[0], v1[1], partner_segments, None
+                    )
+                    < via_clear
+                ):
+                    continue
+                if (
+                    self._min_distance_to_partner(
+                        v2[0], v2[1], v2[0], v2[1], partner_segments, None
+                    )
+                    < via_clear
+                ):
+                    continue
+                # Surface stubs must stay clear of same-layer partner copper.
+                if (
+                    self._min_distance_to_partner(
+                        head.x, head.y, v1[0], v1[1], partner_segments, surface
+                    )
+                    < seg_clear
+                ):
+                    continue
+                if (
+                    self._min_distance_to_partner(
+                        v2[0], v2[1], goal.x, goal.y, partner_segments, surface
+                    )
+                    < seg_clear
+                ):
+                    continue
+                if not self._segment_cells_clear(
+                    pathfinder, head.x, head.y, v1[0], v1[1], layer_idx, head.net
+                ):
+                    continue
+                if not self._segment_cells_clear(
+                    pathfinder, v2[0], v2[1], goal.x, goal.y, layer_idx, head.net
+                ):
+                    continue
+                for alt in routable:
+                    if not self._segment_cells_clear(
+                        pathfinder, v1[0], v1[1], v2[0], v2[1], alt, head.net
+                    ):
+                        continue
+                    alt_layer = Layer(grid.index_to_layer(alt))
+                    route = Route(net=head.net, net_name=head.net_name)
+                    if math.hypot(v1[0] - head.x, v1[1] - head.y) > 0.01:
+                        route.segments.append(
+                            Segment(
+                                x1=head.x, y1=head.y, x2=v1[0], y2=v1[1],
+                                width=width, layer=surface,
+                                net=head.net, net_name=head.net_name,
+                            )
+                        )
+                    route.vias.append(
+                        Via(
+                            x=v1[0], y=v1[1],
+                            drill=rules.via_drill, diameter=rules.via_diameter,
+                            layers=(surface, alt_layer),
+                            net=head.net, net_name=head.net_name,
+                        )
+                    )
+                    route.segments.append(
+                        Segment(
+                            x1=v1[0], y1=v1[1], x2=v2[0], y2=v2[1],
+                            width=width, layer=alt_layer,
+                            net=head.net, net_name=head.net_name,
+                        )
+                    )
+                    route.vias.append(
+                        Via(
+                            x=v2[0], y=v2[1],
+                            drill=rules.via_drill, diameter=rules.via_diameter,
+                            layers=(alt_layer, surface),
+                            net=head.net, net_name=head.net_name,
+                        )
+                    )
+                    if math.hypot(goal.x - v2[0], goal.y - v2[1]) > 0.01:
+                        route.segments.append(
+                            Segment(
+                                x1=v2[0], y1=v2[1], x2=goal.x, y2=goal.y,
+                                width=width, layer=surface,
+                                net=head.net, net_name=head.net_name,
+                            )
+                        )
+                    return route
+        return None
+
+    def _tail_route(
+        self,
+        pathfinder: CoupledPathfinder,
+        head: Pad,
+        goal: Pad,
+        layer_idx: int,
+        label: str,
+        pair_name: str,
+        partner_segments: list[Segment] | None = None,
+    ) -> Route | None:
+        """Head->pad completion: synthesized tail, then per-net A* fallback.
+
+        Issue #3508: when ``partner_segments`` is provided, planar
+        candidates whose copper would overlap the partner (which is NOT
+        in the grid) are rejected geometrically, and a two-via crossing
+        tail is attempted before giving up -- the polarity-swap pairs'
+        terminal crossover.
+        """
+        tail = self._synthesize_tail(pathfinder, head, goal, layer_idx)
+        if tail is not None and partner_segments:
+            seg_clear = self._pair_seg_clearance(pathfinder, head.net_name)
+            for seg in tail.segments:
+                if (
+                    self._min_distance_to_partner(
+                        seg.x1, seg.y1, seg.x2, seg.y2, partner_segments, seg.layer
+                    )
+                    < seg_clear
+                ):
+                    tail = None
+                    break
+        if tail is None and partner_segments:
+            tail = self._synthesize_crossing_tail(
+                pathfinder, head, goal, layer_idx, partner_segments
+            )
+        if tail is None:
+            tail = self._single_ended_guide_route(head, goal, per_net_timeout=10.0)
+            if tail is not None and not tail.segments:
+                tail = None
+        if tail is None:
+            print(
+                f"    [coupled-rescue] {label} tail unroutable for {pair_name} "
+                f"(head {head.x:.2f},{head.y:.2f} -> pad {goal.x:.2f},{goal.y:.2f})"
+            )
+        return tail
+
+    def _shadow_route_pair(
+        self,
+        pair: DifferentialPair,
+        spec: CoupledSegmentSpec,
+        pathfinder: CoupledPathfinder,
+        guide: Route,
+        spacing_cells: int,
+        swap_roles: bool = False,
+    ) -> tuple[Route, Route] | None:
+        """Construct the pair as guide + validated parallel shadow.
+
+        Issue #3508: the joint-state coupled A* cannot afford board
+        06's geometry even corridor-bounded and weighted (measured: a
+        clearance-clean MIPI_CLK search exceeds 80k iterations without
+        converging; the dirty 2.7k-iteration solution is rejected by
+        the #3320 gate).  This constructor sidesteps the search
+        entirely:
+
+        1. One side is the single-ended guide route (C++-accelerated
+           per-net A*; the P side by default, the N side when
+           ``swap_roles``).
+        2. The partner side is built GEOMETRICALLY: each single-layer
+           SECTION of the guide polyline is offset perpendicular by
+           the coupled center-to-center spacing (both lateral sides
+           tried).  Where the guide changes layers, the shadow places
+           its own via at a laterally-widened, longitudinally-staggered
+           site so both the via-to-via (0.6 mm) and via-to-partner-
+           trace (~0.49 mm) clearance bounds hold by construction.
+           Every shadow segment is rasterised against the grid's
+           clearance envelope; shadow via sites are checked with the
+           pathfinder's via predicate.
+        3. The body is TRIMMED at the two route ends (endpoint zones
+           are always contested by connector/IC neighbour-pad halos)
+           up to ``_SHADOW_MAX_TRIM_MM`` per end, and connects to the
+           real pads via the rescue tail machinery (partner-aware,
+           with a two-via crossing fallback for polarity-swap
+           terminations).
+
+        Returns ``(p_route, n_route)`` -- NOT committed; the caller
+        runs the #3320 severe-overlap gate and the normal commit path.
+        """
+        if not guide.segments:
+            return None
+        grid = self.autorouter.grid
+        rules = self.autorouter.rules
+        if swap_roles:
+            shadow_start, shadow_end = spec.p_start, spec.p_end
+        else:
+            shadow_start, shadow_end = spec.n_start, spec.n_end
+        s_net = shadow_start.net
+        s_net_name = shadow_start.net_name
+        s_width = pathfinder._get_trace_width_for_net(s_net_name)
+        d = spacing_cells * grid.resolution
+        # Shadow via lateral offset: the barrel must clear the guide
+        # trace (via_r + clearance + guide_width/2), independent of the
+        # tighter coupled gap d.
+        guide_width = max((g.width for g in guide.segments), default=s_width)
+        via_lateral = max(
+            d, rules.via_diameter / 2 + rules.trace_clearance + guide_width / 2 + 0.05
+        )
+        # Longitudinal stagger so shadow-via-to-guide-via >= via pitch.
+        via_pitch = rules.via_diameter + rules.via_clearance
+        stagger = max(0.0, math.sqrt(max(0.0, via_pitch**2 - via_lateral**2))) + 0.05
+
+        # ------------------------------------------------------------
+        # Parse the guide into ordered single-layer sections.  Route
+        # segments/vias are emitted in path order by both
+        # ``_build_route_from_path`` and the per-net pathfinder.
+        # ------------------------------------------------------------
+        sections: list[tuple[int, list[Segment]]] = []
+        for seg in guide.segments:
+            li = grid.layer_to_index(seg.layer.value)
+            if not sections or sections[-1][0] != li:
+                sections.append((li, []))
+            sections[-1][1].append(seg)
+        max_trim = _SHADOW_MAX_TRIM_MM
+
+        for side in (1.0, -1.0):
+            elements: list[tuple] = []  # ('seg', x1,y1,x2,y2,layer) | ('via', x,y,l0,l1)
+            ok = True
+            prev_pt: tuple[float, float] | None = None
+            prev_layer: int | None = None
+            prev_dir: tuple[float, float] | None = None
+            for sec_layer, segs in sections:
+                first_in_section = True
+                for seg in segs:
+                    ux = seg.x2 - seg.x1
+                    uy = seg.y2 - seg.y1
+                    length = math.hypot(ux, uy)
+                    if length < 1e-9:
+                        continue
+                    ux /= length
+                    uy /= length
+                    nx = -uy * side
+                    ny = ux * side
+                    a = (seg.x1 + d * nx, seg.y1 + d * ny)
+                    b = (seg.x2 + d * nx, seg.y2 + d * ny)
+                    if prev_pt is not None and prev_layer is not None:
+                        if first_in_section and prev_layer != sec_layer:
+                            # Guide layer change: place the shadow via.
+                            # Site: widen laterally to ``via_lateral``
+                            # and stagger back along the incoming
+                            # direction.
+                            pux, puy = prev_dir if prev_dir else (ux, uy)
+                            pnx, pny = -puy * side, pux * side
+                            gv = (seg.x1, seg.y1)  # guide via position
+                            placed = False
+                            for stag_mult in (1.0, 1.6, -1.0, -1.6):
+                                vx = gv[0] + via_lateral * pnx - stagger * stag_mult * pux
+                                vy = gv[1] + via_lateral * pny - stagger * stag_mult * puy
+                                gvx, gvy = grid.world_to_grid(vx, vy)
+                                if pathfinder._is_via_blocked(gvx, gvy, s_net):
+                                    continue
+                                elements.append(
+                                    ("seg", prev_pt[0], prev_pt[1], vx, vy, prev_layer)
+                                )
+                                elements.append(("via", vx, vy, prev_layer, sec_layer))
+                                elements.append(("seg", vx, vy, a[0], a[1], sec_layer))
+                                prev_pt = a
+                                placed = True
+                                break
+                            if not placed:
+                                ok = False
+                                break
+                        else:
+                            gap = math.hypot(a[0] - prev_pt[0], a[1] - prev_pt[1])
+                            if gap > grid.resolution / 2:
+                                # Issue #3508: MITER the corner join.  A
+                                # straight bevel chord between the two
+                                # offset endpoints passes INSIDE the
+                                # corner (d*cos(45deg) ~ 0.75*d at a 90
+                                # degree turn), shaving the coupled gap
+                                # below the intra-pair clearance -- the
+                                # measured one-mild-violation-per-pair
+                                # Phase B churn.  Extending both offset
+                                # segments to their line intersection
+                                # keeps the full offset everywhere.
+                                mx = None
+                                if elements and elements[-1][0] == "seg":
+                                    pseg = elements[-1]
+                                    d1x, d1y = pseg[3] - pseg[1], pseg[4] - pseg[2]
+                                    d2x, d2y = b[0] - a[0], b[1] - a[1]
+                                    denom = d1x * d2y - d1y * d2x
+                                    if abs(denom) > 1e-9:
+                                        t = (
+                                            (a[0] - pseg[3]) * d2y
+                                            - (a[1] - pseg[4]) * d2x
+                                        ) / denom
+                                        cand = (
+                                            pseg[3] + d1x * t,
+                                            pseg[4] + d1y * t,
+                                        )
+                                        # Bound the miter spike (sharp
+                                        # angles) to ~2 gaps.
+                                        if (
+                                            math.hypot(
+                                                cand[0] - prev_pt[0],
+                                                cand[1] - prev_pt[1],
+                                            )
+                                            <= 2.0 * d + gap
+                                        ):
+                                            mx = cand
+                                if mx is not None:
+                                    pseg = elements[-1]
+                                    elements[-1] = (
+                                        "seg", pseg[1], pseg[2], mx[0], mx[1], pseg[5]
+                                    )
+                                    a = mx
+                                else:
+                                    elements.append(
+                                        ("seg", prev_pt[0], prev_pt[1], a[0], a[1], sec_layer)
+                                    )
+                    elements.append(("seg", a[0], a[1], b[0], b[1], sec_layer))
+                    prev_pt = b
+                    prev_layer = sec_layer
+                    prev_dir = (ux, uy)
+                    first_in_section = False
+                if not ok:
+                    break
+            if not ok or prev_pt is None:
+                print(
+                    f"    [coupled-shadow] side={side:+.0f} no legal shadow-via "
+                    f"site for {pair.name}"
+                )
+                continue
+
+            # ------------------------------------------------------------
+            # Validate + trim.  Blocked cells are tolerated only within
+            # ``max_trim`` of either END of the whole shadow polyline;
+            # any blockage in the interior (including via jogs) fails
+            # this side.
+            # ------------------------------------------------------------
+            arc_total = sum(
+                math.hypot(e[3] - e[1], e[4] - e[2]) for e in elements if e[0] == "seg"
+            )
+            arc = 0.0
+            interior_block = False
+            step = grid.resolution
+            blocked_arcs: list[float] = []
+            for e in elements:
+                if e[0] == "via":
+                    continue
+                _, x1, y1, x2, y2, li = e
+                seg_len = math.hypot(x2 - x1, y2 - y1)
+                if seg_len < 1e-9:
+                    continue
+                n_steps = max(1, int(math.ceil(seg_len / step)))
+                for i in range(n_steps + 1):
+                    t = i / n_steps
+                    gx, gy = grid.world_to_grid(x1 + (x2 - x1) * t, y1 + (y2 - y1) * t)
+                    if pathfinder._is_cell_blocked(gx, gy, li, s_net):
+                        blocked_arcs.append(arc + seg_len * t)
+                arc += seg_len
+            trim_start = 0.0
+            trim_end = 0.0
+            for ba in blocked_arcs:
+                if ba <= max_trim and ba >= trim_start:
+                    if ba <= max_trim:
+                        trim_start = max(trim_start, ba)
+                if ba >= arc_total - max_trim:
+                    trim_end = max(trim_end, arc_total - ba)
+            for ba in blocked_arcs:
+                if ba > trim_start + 1e-9 and ba < arc_total - trim_end - 1e-9:
+                    interior_block = True
+                    print(
+                        f"    [coupled-shadow] side={side:+.0f} mid-route "
+                        f"blockage for {pair.name} at arc {ba:.2f}/"
+                        f"{arc_total:.2f}mm"
+                    )
+                    break
+            if interior_block:
+                continue
+            a0 = trim_start + 2 * step if trim_start > 0 else 0.0
+            a1 = arc_total - trim_end - (2 * step if trim_end > 0 else 0.0)
+            if a1 - a0 < 2.0:
+                print(
+                    f"    [coupled-shadow] side={side:+.0f} clear run too "
+                    f"short for {pair.name} ({a1 - a0:.2f}mm)"
+                )
+                continue
+
+            # Slice elements to [lo, hi] by arc length.  Vias are kept
+            # only if inside the kept interval (vias always are: the
+            # interior is blockage-free and trims are confined to the
+            # ends, which lie in the first/last sections).
+            def _slice_kept(lo_arc: float, hi_arc: float) -> list[tuple]:
+                kept_: list[tuple] = []
+                arc_ = 0.0
+                for e_ in elements:
+                    if e_[0] == "via":
+                        if lo_arc <= arc_ <= hi_arc:
+                            kept_.append(e_)
+                        continue
+                    _, ex1, ey1, ex2, ey2, eli = e_
+                    sl = math.hypot(ex2 - ex1, ey2 - ey1)
+                    if sl < 1e-9:
+                        continue
+                    lo_ = max(lo_arc, arc_)
+                    hi_ = min(hi_arc, arc_ + sl)
+                    if hi_ > lo_:
+                        t_lo = (lo_ - arc_) / sl
+                        t_hi = (hi_ - arc_) / sl
+                        kept_.append(
+                            (
+                                "seg",
+                                ex1 + (ex2 - ex1) * t_lo,
+                                ey1 + (ey2 - ey1) * t_lo,
+                                ex1 + (ex2 - ex1) * t_hi,
+                                ey1 + (ey2 - ey1) * t_hi,
+                                eli,
+                            )
+                        )
+                    arc_ += sl
+                return kept_
+
+            # Issue #3508: anchor-stepping.  When the tail from the
+            # body end to the pad is unroutable (the trimmed body end
+            # can sit flush against a halo wall, leaving the tail no
+            # legal first step), consume more of the body into the
+            # tail and retry from a deeper anchor.
+            partner_segs = list(guide.segments)
+            start_tail = None
+            a0_eff = a0
+            for extra0 in (0.0, 0.7, 1.5, 3.0):
+                if a0 + extra0 >= a1 - 2.0:
+                    break
+                kept_probe = _slice_kept(a0 + extra0, a1)
+                seg_probe = [e for e in kept_probe if e[0] == "seg"]
+                if not seg_probe:
+                    break
+                bh = (seg_probe[0][1], seg_probe[0][2], seg_probe[0][5])
+                anchor = self._virtual_pad_at(shadow_start, bh[0], bh[1], bh[2])
+                start_tail = self._tail_route(
+                    pathfinder, anchor, shadow_start, bh[2],
+                    "shadow-start", pair.name,
+                    partner_segments=partner_segs,
+                )
+                if start_tail is not None:
+                    a0_eff = a0 + extra0
+                    break
+            if start_tail is None:
+                continue
+            end_tail = None
+            a1_eff = a1
+            for extra1 in (0.0, 0.7, 1.5, 3.0):
+                if a0_eff >= a1 - extra1 - 2.0:
+                    break
+                kept_probe = _slice_kept(a0_eff, a1 - extra1)
+                seg_probe = [e for e in kept_probe if e[0] == "seg"]
+                if not seg_probe:
+                    break
+                bt = (seg_probe[-1][3], seg_probe[-1][4], seg_probe[-1][5])
+                anchor = self._virtual_pad_at(shadow_end, bt[0], bt[1], bt[2])
+                end_tail = self._tail_route(
+                    pathfinder, anchor, shadow_end, bt[2],
+                    "shadow-end", pair.name,
+                    partner_segments=partner_segs,
+                )
+                if end_tail is not None:
+                    a1_eff = a1 - extra1
+                    break
+            if end_tail is None:
+                continue
+            kept = _slice_kept(a0_eff, a1_eff)
+            seg_elements = [e for e in kept if e[0] == "seg"]
+            if not seg_elements:
+                continue
+
+            shadow_route = Route(net=s_net, net_name=s_net_name)
+            shadow_route.segments.extend(
+                Segment(
+                    x1=s.x2, y1=s.y2, x2=s.x1, y2=s.y1,
+                    width=s.width, layer=s.layer, net=s.net, net_name=s.net_name,
+                )
+                for s in reversed(start_tail.segments)
+            )
+            shadow_route.vias.extend(start_tail.vias)
+            for e in kept:
+                if e[0] == "via":
+                    _, vx, vy, l0, l1 = e
+                    shadow_route.vias.append(
+                        Via(
+                            x=vx, y=vy,
+                            drill=rules.via_drill, diameter=rules.via_diameter,
+                            layers=(
+                                Layer(grid.index_to_layer(l0)),
+                                Layer(grid.index_to_layer(l1)),
+                            ),
+                            net=s_net, net_name=s_net_name,
+                        )
+                    )
+                    continue
+                _, x1, y1, x2, y2, li = e
+                if math.hypot(x2 - x1, y2 - y1) < 1e-6:
+                    continue
+                shadow_route.segments.append(
+                    Segment(
+                        x1=x1, y1=y1, x2=x2, y2=y2,
+                        width=s_width, layer=Layer(grid.index_to_layer(li)),
+                        net=s_net, net_name=s_net_name,
+                    )
+                )
+            shadow_route.segments.extend(end_tail.segments)
+            shadow_route.vias.extend(end_tail.vias)
+
+            guide_net_pad = spec.n_start if swap_roles else spec.p_start
+            guide_route_obj = Route(net=guide_net_pad.net, net_name=guide_net_pad.net_name)
+            guide_route_obj.segments.extend(guide.segments)
+            guide_route_obj.vias.extend(guide.vias)
+
+            if swap_roles:
+                p_route, n_route = shadow_route, guide_route_obj
+            else:
+                p_route, n_route = guide_route_obj, shadow_route
+
+            # Issue #3508: in-loop severity self-check (the same metric
+            # as the caller's #3320 gate).  Tails are routed without
+            # partner awareness, so a wrong-side body forces the tail
+            # to cross the guide; instead of letting the caller's gate
+            # reject the whole pair, fail THIS side over to the other.
+            net_class_map = getattr(self.autorouter, "net_class_map", None) or {}
+            nc = net_class_map.get(spec.p_start.net_name)
+            threshold = (
+                nc.effective_intra_pair_clearance()
+                if nc is not None
+                else self.autorouter.rules.trace_clearance
+            )
+            violation = find_intra_pair_clearance_violations(
+                p_route, n_route, threshold_mm=threshold, pair_name=pair.name
+            )
+            if violation is not None and violation.actual_clearance_mm < 0.0:
+                print(
+                    f"    [coupled-shadow] side={side:+.0f} self-check overlap "
+                    f"for {pair.name} "
+                    f"(worst={violation.actual_clearance_mm:+.3f}mm); trying "
+                    f"other side"
+                )
+                continue
+            return p_route, n_route
+
+        return None
+
+    def _rescue_near_miss_coupled(
+        self,
+        pair: DifferentialPair,
+        spec: CoupledSegmentSpec,
+        pathfinder: CoupledPathfinder,
+    ) -> tuple[Route, Route] | None:
+        """Complete a budget-exited coupled search that stalled near goal.
+
+        Issue #3508: reconstructs the partial coupled route up to the
+        search's best state (``pathfinder.last_best_node``) and routes
+        the two remaining head->pad tails with the single-ended per-net
+        router.  Returns ``(p_route, n_route)`` with the tails merged
+        in, or ``None`` when either tail cannot be routed (callers then
+        fall through to the legacy budget-exit handling).
+
+        Nothing is committed to the grid here -- the caller runs the
+        returned routes through the same #3320 severe-overlap gate and
+        commit path as a normally-converged coupled result, so a rescue
+        that produced crossing tails is rejected transactionally.
+        """
+        best = pathfinder.last_best_node
+        if best is None:
+            return None
+
+        grid = self.autorouter.grid
+        p_pos = best.state.p_pos
+        n_pos = best.state.n_pos
+        p_wx, p_wy = grid.grid_to_world(p_pos.x, p_pos.y)
+        n_wx, n_wy = grid.grid_to_world(n_pos.x, n_pos.y)
+
+        p_head = self._virtual_pad_at(spec.p_end, p_wx, p_wy, p_pos.layer)
+        n_head = self._virtual_pad_at(spec.n_end, n_wx, n_wy, n_pos.layer)
+
+        try:
+            p_route, n_route = pathfinder._reconstruct_coupled_routes(
+                best, spec.p_start, p_head, spec.n_start, n_head
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            print(f"    [coupled-rescue] reconstruction failed for {pair.name}: {exc}")
+            return None
+
+        p_tail = self._tail_route(pathfinder, p_head, spec.p_end, p_pos.layer, "P", pair.name)
+        if p_tail is None:
+            return None
+        n_tail = self._tail_route(pathfinder, n_head, spec.n_end, n_pos.layer, "N", pair.name)
+        if n_tail is None:
+            return None
+
+        p_route.segments.extend(p_tail.segments)
+        p_route.vias.extend(p_tail.vias)
+        n_route.segments.extend(n_tail.segments)
+        n_route.vias.extend(n_tail.vias)
+        return p_route, n_route
+
     def _single_ended_guide_route(
         self,
         start_pad: Pad,
@@ -2515,16 +3745,40 @@ class DiffPairRouter:
             spacing_cells += extra_spacing_cells
 
         # If any segment requires polarity-swap, enable swap-via moves.
+        #
+        # Issue #3508: swap-via moves are DISABLED.  The swap move
+        # exchanges the two heads' exact grid positions onto one shared
+        # new layer, so reconstruction emits the SAME A->B segment for
+        # both nets (P: A->B, N: B->A) -- coincident copper, i.e. a
+        # short.  Every swap-containing result was therefore rejected
+        # by the #3320 severe-overlap gate at exactly
+        # ``-trace_width`` (board 06 PCIE/USB3, board 07 DQS -- the
+        # "swap-overlap gate" rejection documented in #3473).  With
+        # mid-route asymmetric moves now enabled (this issue), a
+        # polarity swap is achievable WITHOUT vias: the advancing
+        # trace walks a discrete arc around its holding partner
+        # (offset-vector rotation through 180 degrees), which the
+        # trail-proximity guard keeps clearance-legal.  Re-enable only
+        # after the swap reconstruction emits a genuine two-layer
+        # crossover (staggered vias, partner segments on different
+        # layers).
         any_polarity_swap = any(s.polarity_swap for s in coupled_specs)
+        del any_polarity_swap  # documented above; swap moves disabled
 
-        # Create coupled pathfinder
+        # Create coupled pathfinder.
+        # Issue #3508: heuristic_weight > 1 (weighted A*) -- without it
+        # the joint-state search floods cost_turn-deep f-plateaus
+        # (~90k iterations for ONE 5-point shell on board 06) and no
+        # CI-affordable iteration budget converges.  See the
+        # ``heuristic_weight`` rationale in ``CoupledPathfinder``.
         pathfinder = CoupledPathfinder(
             self.autorouter.grid,
             self.autorouter.rules,
             spacing_cells,
             net_class_map=self.autorouter.net_class_map,
-            allow_swap_via=any_polarity_swap,
+            allow_swap_via=False,  # Issue #3508: see rationale above
             min_spacing_cells=min_spacing_cells,
+            heuristic_weight=COUPLED_HEURISTIC_WEIGHT,
         )
 
         routes: list[Route] = []
@@ -2568,13 +3822,72 @@ class DiffPairRouter:
             # skip the corridor and hand the budget to the legacy
             # open search instead of burning it before either coupled
             # attempt runs.
+            # Issue #3508: floor the probe budget at 45s (clamped to half
+            # the per-pair budget).  The #3473 eighth-of-budget bound
+            # starved board 06's USB3 probes: their single-ended guide
+            # routes need 30-37s (the C++ validation falls back to the
+            # Python pathfinder on the J1 fan-out geometry), so at the
+            # 60s per-pair budget the probe deadline (7.5s) always
+            # fired, no corridor existed, and the USB3 pairs ran the
+            # intractable open search only.
             probe_timeout = (
-                per_pair_timeout * 0.125 if per_pair_timeout is not None else None
+                min(max(per_pair_timeout * 0.125, 45.0), per_pair_timeout * 0.5)
+                if per_pair_timeout is not None
+                else None
             )
+            probe_t0 = time.monotonic()
             guide_route = self._single_ended_guide_route(
                 spec.p_start, spec.p_end, per_net_timeout=probe_timeout
             )
+            print(
+                f"    [corridor-probe] guide_route="
+                f"{'ok' if guide_route is not None and guide_route.segments else 'FAILED'} "
+                f"elapsed={time.monotonic() - probe_t0:.2f}s "
+                f"segments={len(guide_route.segments) if guide_route is not None else 0}"
+            )
+            # Issue #3508: geometric shadow construction FIRST.  When
+            # the guide exists, building N as a validated parallel
+            # offset of the guide is deterministic, takes milliseconds,
+            # and produces coupled geometry by construction -- the
+            # joint-state search below is the fallback for guides the
+            # shadow cannot legally parallel (e.g., via-bearing guides
+            # or one-sided obstacle walls).
             if guide_route is not None and guide_route.segments:
+                shadow = self._shadow_route_pair(
+                    pair, spec, pathfinder, guide_route, spacing_cells
+                )
+                if shadow is not None:
+                    result = shadow
+                    coupled_phase = "shadow"
+                    print("    [coupled-shadow] pair constructed as guide + parallel shadow")
+
+            if result is None and guide_route is not None and guide_route.segments:
+                # Issue #3508: role-swapped shadow retry.  P's guide may
+                # carry vias or hug a one-sided obstacle wall; the N
+                # side's single-ended route can be shadowable when P's
+                # is not (board 06 MIPI_D0 / USB2_D: the P guide takes a
+                # 2-via detour while the N guide is planar).  Gated on
+                # the P probe having SUCCEEDED: when the P side cannot
+                # be single-ended-routed within the probe budget at all,
+                # the N side (same endpoints geometry) will not be
+                # either, and the retry would just burn a second probe
+                # budget per deferred pair.
+                n_guide = self._single_ended_guide_route(
+                    spec.n_start, spec.n_end, per_net_timeout=probe_timeout
+                )
+                if n_guide is not None and n_guide.segments:
+                    shadow = self._shadow_route_pair(
+                        pair, spec, pathfinder, n_guide, spacing_cells, swap_roles=True
+                    )
+                    if shadow is not None:
+                        result = shadow
+                        coupled_phase = "shadow-swapped"
+                        print(
+                            "    [coupled-shadow] pair constructed as N guide "
+                            "+ parallel P shadow"
+                        )
+
+            if result is None and guide_route is not None and guide_route.segments:
                 grid = self.autorouter.grid
                 resolution = grid.resolution
                 start_spacing_cells = (
@@ -2676,6 +3989,53 @@ class DiffPairRouter:
                 spec_elapsed,
                 result is not None,
             )
+            # Issue #3508: stdout visibility for the per-pair outcome.
+            # The board recipes are print-based (INFO logging is not
+            # configured), so without this line the only stdout signal
+            # for a failing pair is the budget-exceeded warning -- the
+            # corridor/open phase split and the iteration cost (the two
+            # knobs recipe authors tune) were invisible in CI logs.
+            best_state = pathfinder.last_best_state
+            print(
+                f"    [coupled-timing] phase={coupled_phase} "
+                f"elapsed={spec_elapsed:.2f}s "
+                f"corridor_iters={corridor_iterations_used} "
+                f"last_iters={pathfinder.last_iterations} "
+                f"best_progress={pathfinder.last_best_progress} "
+                f"best_state={best_state} "
+                f"rejections={dict(pathfinder.last_rejections)} "
+                f"success={result is not None}"
+            )
+
+            # Issue #3508: near-miss rescue.  The weighted corridor-
+            # bounded coupled search reliably traverses the route body
+            # but stalls in the final pad-landing needle-eye: the heads
+            # arrive within a few-hundred-micron Manhattan distance of
+            # the goal pads, where interleaved foreign-pad clearance
+            # halos leave only one runway per pad, the pair must
+            # asymmetrically spread from the coupled spacing back to
+            # the goal pad pitch inside that lattice, and the #3078
+            # path-history guard turns every runway probe into a
+            # dead-end (backing out retraces the head's own trail).
+            # Measured on board 06: 8/9 pairs stall at best_progress
+            # 5-21 cells after covering 95%+ of the route.  Rather
+            # than make the joint search solve the landing, commit the
+            # coupled body to the best state and finish each side with
+            # the single-ended per-net router, which lands on pads
+            # routinely.  The resulting tail (<= ~2 mm of a 30-50 mm
+            # route) keeps the coupled-length fraction far above every
+            # ``coupled_continuity_threshold`` in use (0.7-0.9).
+            if result is None and pathfinder.last_best_node is not None:
+                if pathfinder.last_best_progress <= NEAR_MISS_RESCUE_CELLS:
+                    rescue = self._rescue_near_miss_coupled(pair, spec, pathfinder)
+                    if rescue is not None:
+                        result = rescue
+                        coupled_phase += "+rescue"
+                        print(
+                            f"    [coupled-rescue] completed pair via "
+                            f"near-miss rescue (progress="
+                            f"{pathfinder.last_best_progress} cells)"
+                        )
 
             if result is None:
                 # Issue #3089: ``None`` may indicate (a) no path found,
@@ -2775,6 +4135,16 @@ class DiffPairRouter:
                     violation.expected_clearance_mm,
                     len(violation.segment_violations),
                 )
+                if _COUPLED_TRACE:
+                    print(
+                        f"      [overlap-debug] layer={violation.layer} "
+                        f"p_seg=({violation.p_segment.x1:.2f},"
+                        f"{violation.p_segment.y1:.2f})->"
+                        f"({violation.p_segment.x2:.2f},{violation.p_segment.y2:.2f}) "
+                        f"n_seg=({violation.n_segment.x1:.2f},"
+                        f"{violation.n_segment.y1:.2f})->"
+                        f"({violation.n_segment.x2:.2f},{violation.n_segment.y2:.2f})"
+                    )
                 # Do NOT commit p_route/n_route to grid or
                 # ``autorouter.routes``.  Fall back to independent
                 # routing for the whole pair (single source of truth
@@ -3373,6 +4743,29 @@ class DiffPairRouter:
 
             p_id, n_id = pair.get_net_ids()
             n_net_name = pair_violations[0].negative_net_name
+
+            # Issue #3508: defensive pair-identity check.  The lookup
+            # above re-runs pair DETECTION, which can disagree with the
+            # pairing the violation was recorded against (observed on
+            # board 06: a violation recorded for USB3_RX1+/USB3_RX1-
+            # resolved to a DifferentialPair object whose negative side
+            # was USB3_TX1-).  Re-routing such a cross-pair would rip
+            # up and re-couple nets from two DIFFERENT pairs.  Skip and
+            # leave the violation for the validate_routes() safety net.
+            if {pair.positive.net_name, pair.negative.net_name} != {
+                p_net_name,
+                n_net_name,
+            }:
+                logger.warning(
+                    "Phase B repair: detection re-paired %r with %r but the "
+                    "violation was recorded against %r/%r; skipping repair "
+                    "for this pair.",
+                    pair.positive.net_name,
+                    pair.negative.net_name,
+                    p_net_name,
+                    n_net_name,
+                )
+                continue
 
             # Snapshot current routes for this pair so we can either
             # rip them up cleanly or restore them on failure.

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -4057,18 +4057,29 @@ class DiffPairRouter:
             # open search instead of burning it before either coupled
             # attempt runs.
             # Issue #3508: floor the probe budget at 45s (clamped to half
-            # the per-pair budget).  The #3473 eighth-of-budget bound
+            # the per-pair budget) -- but ONLY when the shadow
+            # constructor is enabled.  The #3473 eighth-of-budget bound
             # starved board 06's USB3 probes: their single-ended guide
             # routes need 30-37s (the C++ validation falls back to the
             # Python pathfinder on the J1 fan-out geometry), so at the
             # 60s per-pair budget the probe deadline (7.5s) always
             # fired, no corridor existed, and the USB3 pairs ran the
-            # intractable open search only.
-            probe_timeout = (
-                min(max(per_pair_timeout * 0.125, 45.0), per_pair_timeout * 0.5)
-                if per_pair_timeout is not None
-                else None
-            )
+            # intractable open search only.  The expensive probe exists
+            # to feed the shadow guide; with the shadow gated off
+            # (default -- see ``enable_shadow_construction``) keep the
+            # legacy eighth-of-budget bound so deferring pairs exit
+            # quickly and the per-pair wall-clock matches the
+            # pre-#3508 budget-exit behaviour (matters on slow 2-core
+            # CI runners: 9 pairs x 45s probes is most of the re-route
+            # gate's wall-clock budget).
+            if per_pair_timeout is None:
+                probe_timeout = None
+            elif self.enable_shadow_construction:
+                probe_timeout = min(
+                    max(per_pair_timeout * 0.125, 45.0), per_pair_timeout * 0.5
+                )
+            else:
+                probe_timeout = per_pair_timeout * 0.125
             probe_t0 = time.monotonic()
             guide_route = self._single_ended_guide_route(
                 spec.p_start, spec.p_end, per_net_timeout=probe_timeout

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -713,11 +713,33 @@ class CoupledPathfinder:
         ``_via_extra_cells`` captures.  The previous full-envelope
         sweep (+/-8 cells on every layer on board 06) double-counted
         the marked halo exactly like the trace check did.
+
+        Issue #3508 (second pass): a via must additionally never land
+        on PAD METAL -- even its OWN net's pad.  Own-net passability
+        (see ``_is_cell_blocked``) made pad cells legal for the via
+        predicate too, and the crossing-tail synthesizer promptly
+        placed vias exactly on its own goal pads (measured: 2
+        ``via_in_pad`` errors at J3-9 / J4-2 on the first #3508
+        re-route; the jlcpcb standard tier does not support
+        via-in-pad).  ``cell.pad_blocked`` marks cells whose extent
+        overlaps continuous pad metal (#3233), so reject the via when
+        any cell under its DRILL footprint is pad metal on any layer.
         """
+        drill_cells = max(
+            0, int(math.ceil((self.rules.via_drill / 2) / self.grid.resolution))
+        )
         for layer in range(self.grid.num_layers):
             for dy in range(-self._via_extra_cells, self._via_extra_cells + 1):
                 for dx in range(-self._via_extra_cells, self._via_extra_cells + 1):
                     if self._is_cell_blocked(gx + dx, gy + dy, layer, net):
+                        return True
+            # Issue #3508: no via-in-pad regardless of net ownership.
+            for dy in range(-drill_cells, drill_cells + 1):
+                for dx in range(-drill_cells, drill_cells + 1):
+                    cgx, cgy = gx + dx, gy + dy
+                    if not (0 <= cgx < self.grid.cols and 0 <= cgy < self.grid.rows):
+                        return True
+                    if self.grid.grid[layer][cgy][cgx].pad_blocked:
                         return True
         return False
 
@@ -1924,6 +1946,7 @@ def create_serpentine(
     min_segment_length: float = 1.0,
     partner_route: Route | None = None,
     intra_pair_clearance_mm: float | None = None,
+    grid: RoutingGrid | None = None,
 ) -> bool:
     """Add serpentine meander to a route to increase its length.
 
@@ -1951,6 +1974,17 @@ def create_serpentine(
         intra_pair_clearance_mm: Optional edge-to-edge clearance floor
             in mm.  Required for the clearance-aware path; ignored when
             ``partner_route`` is ``None``.
+        grid: Issue #3508: optional routing grid.  When provided, every
+            proposed serpentine segment is rasterised against the grid's
+            clearance envelope and the serpentine is REJECTED if any
+            covered cell is blocked for a foreign net.  The partner
+            self-check below only protects against the partner's
+            SEGMENTS; the grid check additionally protects against the
+            partner's vias, other nets' committed copper, and pad
+            clearance halos -- the measured failure mode on board 06 was
+            one-sided serpentine combs landing on the partner's shadow
+            vias (8 ``clearance_segment_via`` at -0.038 mm) and grazing
+            neighbour pads (Issue #3508 first re-route attempt).
 
     Returns:
         True if serpentine was added, False if no suitable segment
@@ -2152,6 +2186,31 @@ def create_serpentine(
                 if clearance + 1e-9 < intra_pair_clearance_mm:
                     return False
 
+    # Issue #3508: grid self-check.  Rasterise every proposed segment
+    # against the grid's clearance envelope (the same convention as
+    # ``CoupledPathfinder._is_trace_blocked``: the grid already encodes
+    # the full centerline clearance envelope at marking time, so a cell
+    # is legal exactly when a trace centerline there satisfies
+    # clearance).  Own-net cells are passable; anything else (partner
+    # copper INCLUDING vias, other nets, pad halos, keepouts) rejects
+    # the serpentine -- leaving the pair with a length-mismatch warning
+    # is strictly better than committing clearance violations.
+    if grid is not None:
+        for new_seg in new_segments:
+            li = grid.layer_to_index(new_seg.layer.value)
+            sgx1, sgy1 = grid.world_to_grid(new_seg.x1, new_seg.y1)
+            sgx2, sgy2 = grid.world_to_grid(new_seg.x2, new_seg.y2)
+            steps = max(abs(sgx2 - sgx1), abs(sgy2 - sgy1))
+            for i in range(steps + 1):
+                t = i / steps if steps else 0.0
+                gx = int(round(sgx1 + (sgx2 - sgx1) * t))
+                gy = int(round(sgy1 + (sgy2 - sgy1) * t))
+                if not (0 <= gx < grid.cols and 0 <= gy < grid.rows):
+                    return False
+                cell = grid.grid[li][gy][gx]
+                if cell.blocked and cell.net != route.net:
+                    return False
+
     # Replace the original segment with serpentine segments
     route.segments = (
         route.segments[:best_segment_idx] + new_segments + route.segments[best_segment_idx + 1 :]
@@ -2166,6 +2225,7 @@ def match_pair_lengths(
     max_delta: float,
     add_serpentines: bool = True,
     intra_pair_clearance_mm: float | None = None,
+    grid: RoutingGrid | None = None,
 ) -> bool:
     """Match lengths of differential pair traces.
 
@@ -2211,6 +2271,7 @@ def match_pair_lengths(
             length_to_add,
             partner_route=n_route if intra_pair_clearance_mm is not None else None,
             intra_pair_clearance_mm=intra_pair_clearance_mm,
+            grid=grid,
         )
     else:
         return create_serpentine(
@@ -2218,6 +2279,7 @@ def match_pair_lengths(
             length_to_add,
             partner_route=p_route if intra_pair_clearance_mm is not None else None,
             intra_pair_clearance_mm=intra_pair_clearance_mm,
+            grid=grid,
         )
 
 
@@ -2664,6 +2726,44 @@ class DiffPairRouter:
                 route = None
 
             if route is None:
+                # Issue #3508: synthesized-tail fallback.  The per-net
+                # ``route()`` machinery declines sub-millimetre hops
+                # whose endpoints sit inside pad clearance halos (e.g.
+                # USB-C A6 -> B6 within a coupled pair's net) -- but
+                # when the pre-phase claims the net as routed, the
+                # negotiated main strategy SKIPS it (#2464) and the
+                # stub is never completed (measured: USB2_D+ incomplete
+                # at 18/21 reach on the first #3508 re-route).  The
+                # geometric tail constructor validates straight /
+                # dogleg / U-shaped candidates cell-by-cell against the
+                # grid, which handles exactly this pad-halo geometry.
+                try:
+                    grid = self.autorouter.grid
+                    pf = CoupledPathfinder(grid, self.autorouter.rules, 1)
+                    layer_idx = grid.layer_to_index(stub.start.layer.value)
+                    route = self._synthesize_tail(pf, stub.start, stub.end, layer_idx)
+                    if route is None:
+                        # Planar candidates exhausted (USB-C A6 -> B6 is
+                        # fully fenced by the neighbouring pin halos on
+                        # the surface layer): try the two-via
+                        # layer-change tail.  ``partner_segments=[]``
+                        # because a stub has no coupled partner to keep
+                        # clear of -- the grid validation still applies.
+                        route = self._synthesize_crossing_tail(
+                            pf, stub.start, stub.end, layer_idx, []
+                        )
+                except Exception as exc:  # pragma: no cover — defensive
+                    print(f"    WARNING: stub tail synthesis raised: {exc}")
+                    route = None
+                if route is not None:
+                    print(
+                        f"    Stub edge {stub.start.net_name} "
+                        f"{stub.start.ref}.{stub.start.pin} -> "
+                        f"{stub.end.ref}.{stub.end.pin} completed via "
+                        f"synthesized tail (issue #3508)"
+                    )
+
+            if route is None:
                 print(
                     f"    WARNING: stub edge {stub.start.net_name} "
                     f"{stub.start.ref}.{stub.start.pin} -> "
@@ -2677,6 +2777,33 @@ class DiffPairRouter:
             self.autorouter.routes.append(route)
             results.append(route)
         return results
+
+    def _remark_route_cells(self, route: Route) -> None:
+        """Re-mark an ALREADY-COMMITTED route's cell envelope (issue #3508).
+
+        Used after an in-place geometry mutation (the inline serpentine
+        shim) on a route that ``autorouter._mark_route`` has already
+        committed.  Cell marking is idempotent, so re-rasterising every
+        segment simply adds the NEW copper's envelope; the
+        non-idempotent bookkeeping (``grid.routes`` append, R-tree
+        insertion) is intentionally NOT repeated because the route
+        object is already registered.  The replaced straight chord's
+        cells stay marked -- conservative (own-net) and harmless.
+
+        Note the R-tree keeps the pre-mutation segment set; the grid
+        CELLS are the collision source of truth for the negotiated
+        router and ``GridCollisionChecker``, which is what the
+        downstream passes use.
+        """
+        grid = self.autorouter.grid
+        for seg in route.segments:
+            total_clearance = seg.width / 2 + grid.rules.trace_clearance
+            clearance_cells = int(total_clearance / grid.resolution) + 1
+            # Mirror the #1666 grid-quantization safety margin used by
+            # ``RoutingGrid.mark_route``.
+            clearance_cells += 1
+            grid._mark_segment(seg, clearance_cells=clearance_cells)
+        self.autorouter._mark_route_on_cpp_grid(route)
 
     def _virtual_pad_at(
         self, template: Pad, wx: float, wy: float, layer_idx: int
@@ -2763,7 +2890,11 @@ class DiffPairRouter:
         # between the shadow head and its goal pad on a connector pin
         # row); a small perpendicular excursion around the blocker is
         # routinely legal.
-        for off in (0.4, -0.4, 0.8, -0.8, 1.2, -1.2, 1.6, -1.6):
+        # Issue #3508 (second pass): offsets extended to +/-3.2 mm so
+        # intra-connector stubs (USB-C A6 -> B6) can wrap around the
+        # full pin-row halo band; every candidate is still validated
+        # cell-by-cell so larger detours are safe.
+        for off in (0.4, -0.4, 0.8, -0.8, 1.2, -1.2, 1.6, -1.6, 2.4, -2.4, 3.2, -3.2):
             wy = head.y + off
             candidates.append(
                 [
@@ -4282,9 +4413,26 @@ class DiffPairRouter:
                         pair.rules.max_length_delta,
                         add_serpentines=True,
                         intra_pair_clearance_mm=intra_clearance,
+                        # Issue #3508: grid-validate the bulges (foreign
+                        # copper, partner vias, pad halos) -- see
+                        # ``create_serpentine``.
+                        grid=self.autorouter.grid,
                     )
 
                     if matched:
+                        # Issue #3508: the serpentine mutated a route
+                        # AFTER it was marked on the grid (the commit at
+                        # the top of this method), so the grid does not
+                        # know about the bulge copper -- the negotiated
+                        # main strategy then routes other nets straight
+                        # through it (measured: 106 seg-seg violations
+                        # across 10 nets on the first #3508 re-route).
+                        # Re-mark the cells (idempotent; bookkeeping
+                        # like ``grid.routes``/R-tree insertion is NOT
+                        # repeated -- the route object is already
+                        # registered, only its cell envelope changed).
+                        self._remark_route_cells(p_routes[0])
+                        self._remark_route_cells(n_routes[0])
                         # Recalculate lengths
                         p_length = calculate_route_length(p_routes)
                         n_length = calculate_route_length(n_routes)

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -2313,6 +2313,14 @@ class DiffPairRouter:
         # strategy) from a genuine no-path-found exit (where the
         # caller's existing handling is unchanged).
         self._last_pair_budget_exit: bool = False
+        # Issue #3508: opt-in gate for the geometric shadow
+        # constructor (see
+        # ``DifferentialPairConfig.enable_shadow_construction`` for
+        # the full rationale and the board 06 run-4 integration
+        # measurements that keep this defaulted OFF).  Set from the
+        # config by ``route_all_with_diffpairs``; tests may set it
+        # directly.
+        self.enable_shadow_construction: bool = False
 
     def _resolve_detection_inputs(
         self,
@@ -2422,6 +2430,15 @@ class DiffPairRouter:
         Returns:
             ``(engaged, reason)`` from :func:`should_engage_coupled`.
         """
+        # Issue #3508: refuse coupled routing when either net already
+        # carries committed copper (e.g. the recipe pre-routed a
+        # chronically-stranded single before the pre-phase).  Coupled
+        # routing would lay a SECOND copy of the pre-routed side; the
+        # main strategy is the right tool for whatever remains.
+        p_id, n_id = pair.get_net_ids()
+        existing_nets = {r.net for r in self.autorouter.routes}
+        if p_id in existing_nets or n_id in existing_nets:
+            return False, "pre-routed copper present on a pair net"
         net_class_routing, net_to_class, _ = self._resolve_detection_inputs()
         return should_engage_coupled(pair, net_class_routing, net_to_class)
 
@@ -3001,6 +3018,47 @@ class DiffPairRouter:
                     best = d
         return best
 
+    def _pair_has_physical_overlap(self, p_route: Route, n_route: Route) -> bool:
+        """True when P/N copper PHYSICALLY intersects (issue #3508).
+
+        Mirrors the recipe-side shapely detector
+        (``_repair_pair_overlap_solo``'s ``_sides_overlap``) that rips
+        pairs in board 06's 6b repair: same-layer seg/seg overlap,
+        via-barrel vs any-layer segments, and via-vs-via.  The #3320
+        gate only sees same-layer SEGMENT pairs, so a crossing tail or
+        shadow via overlapping the partner sailed through it and was
+        ripped (de-coupled) downstream.  Running the full check at
+        construction time keeps the committed pre-phase output
+        rip-proof.
+        """
+        for a, b in ((p_route, n_route), (n_route, p_route)):
+            for via in a.vias:
+                bound_any = via.diameter / 2
+                for seg in b.segments:
+                    if (
+                        self._point_segment_distance(via.x, via.y, seg)
+                        < bound_any + seg.width / 2
+                    ):
+                        return True
+                for w in b.vias:
+                    if (
+                        math.hypot(via.x - w.x, via.y - w.y)
+                        < bound_any + w.diameter / 2
+                    ):
+                        return True
+        for ps in p_route.segments:
+            for ns in n_route.segments:
+                if ps.layer != ns.layer:
+                    continue
+                if (
+                    self._min_distance_to_partner(
+                        ps.x1, ps.y1, ps.x2, ps.y2, [ns], ps.layer
+                    )
+                    < (ps.width + ns.width) / 2
+                ):
+                    return True
+        return False
+
     def _synthesize_crossing_tail(
         self,
         pathfinder: CoupledPathfinder,
@@ -3118,6 +3176,21 @@ class DiffPairRouter:
                     ):
                         continue
                     alt_layer = Layer(grid.index_to_layer(alt))
+                    # Issue #3508 (second pass): the partner guide is
+                    # NOT in the grid, so the alt-layer crossover must
+                    # also be checked geometrically against partner
+                    # copper ON THAT LAYER -- a via-bearing partner
+                    # guide has inner-layer segments the cell check
+                    # cannot see (measured: USB3_RX1/RX2 "physically
+                    # overlapping copper" rips in the recipe's 6b
+                    # repair even with nudge protection).
+                    if (
+                        self._min_distance_to_partner(
+                            v1[0], v1[1], v2[0], v2[1], partner_segments, alt_layer
+                        )
+                        < seg_clear
+                    ):
+                        continue
                     route = Route(net=head.net, net_name=head.net_name)
                     if math.hypot(v1[0] - head.x, v1[1] - head.y) > 0.01:
                         route.segments.append(
@@ -3313,20 +3386,39 @@ class DiffPairRouter:
                             pnx, pny = -puy * side, pux * side
                             gv = (seg.x1, seg.y1)  # guide via position
                             placed = False
-                            for stag_mult in (1.0, 1.6, -1.0, -1.6):
-                                vx = gv[0] + via_lateral * pnx - stagger * stag_mult * pux
-                                vy = gv[1] + via_lateral * pny - stagger * stag_mult * puy
-                                gvx, gvy = grid.world_to_grid(vx, vy)
-                                if pathfinder._is_via_blocked(gvx, gvy, s_net):
-                                    continue
-                                elements.append(
-                                    ("seg", prev_pt[0], prev_pt[1], vx, vy, prev_layer)
-                                )
-                                elements.append(("via", vx, vy, prev_layer, sec_layer))
-                                elements.append(("seg", vx, vy, a[0], a[1], sec_layer))
-                                prev_pt = a
-                                placed = True
-                                break
+                            # Issue #3508 (second pass): widened site
+                            # lattice -- lateral multipliers beyond 1.0
+                            # rescue guide-via neighbourhoods where every
+                            # minimum-lateral site is inside a pad halo
+                            # (the FFC/J1 "no legal shadow-via site"
+                            # failures).  Sites are still validated by
+                            # the via predicate, and larger laterals only
+                            # ADD clearance to the guide copper.
+                            for lat_mult in (1.0, 1.5, 2.2):
+                                for stag_mult in (1.0, 1.6, -1.0, -1.6, 2.4, -2.4):
+                                    vx = (
+                                        gv[0]
+                                        + via_lateral * lat_mult * pnx
+                                        - stagger * stag_mult * pux
+                                    )
+                                    vy = (
+                                        gv[1]
+                                        + via_lateral * lat_mult * pny
+                                        - stagger * stag_mult * puy
+                                    )
+                                    gvx, gvy = grid.world_to_grid(vx, vy)
+                                    if pathfinder._is_via_blocked(gvx, gvy, s_net):
+                                        continue
+                                    elements.append(
+                                        ("seg", prev_pt[0], prev_pt[1], vx, vy, prev_layer)
+                                    )
+                                    elements.append(("via", vx, vy, prev_layer, sec_layer))
+                                    elements.append(("seg", vx, vy, a[0], a[1], sec_layer))
+                                    prev_pt = a
+                                    placed = True
+                                    break
+                                if placed:
+                                    break
                             if not placed:
                                 ok = False
                                 break
@@ -3601,6 +3693,17 @@ class DiffPairRouter:
                     f"    [coupled-shadow] side={side:+.0f} self-check overlap "
                     f"for {pair.name} "
                     f"(worst={violation.actual_clearance_mm:+.3f}mm); trying "
+                    f"other side"
+                )
+                continue
+            # Issue #3508 (second pass): full physical-overlap check
+            # (via-vs-seg / via-vs-via / seg-vs-seg) mirroring the
+            # recipe's 6b rip detector -- the segments-only check above
+            # cannot see a crossing-tail via overlapping the partner.
+            if self._pair_has_physical_overlap(p_route, n_route):
+                print(
+                    f"    [coupled-shadow] side={side:+.0f} physical "
+                    f"P/N overlap (via-aware) for {pair.name}; trying "
                     f"other side"
                 )
                 continue
@@ -3983,7 +4086,19 @@ class DiffPairRouter:
             # joint-state search below is the fallback for guides the
             # shadow cannot legally parallel (e.g., via-bearing guides
             # or one-sided obstacle walls).
-            if guide_route is not None and guide_route.segments:
+            #
+            # OPT-IN (``self.enable_shadow_construction``, default
+            # False): the constructor's committed geometry is not yet
+            # artifact-quality -- see the field rationale on
+            # ``DifferentialPairConfig.enable_shadow_construction``
+            # for the board 06 run-4 measurements (stranded shadow
+            # tails, via-on-partner intersections, corridor
+            # competition stranding later single-ended nets).
+            if (
+                self.enable_shadow_construction
+                and guide_route is not None
+                and guide_route.segments
+            ):
                 shadow = self._shadow_route_pair(
                     pair, spec, pathfinder, guide_route, spacing_cells
                 )
@@ -3992,7 +4107,12 @@ class DiffPairRouter:
                     coupled_phase = "shadow"
                     print("    [coupled-shadow] pair constructed as guide + parallel shadow")
 
-            if result is None and guide_route is not None and guide_route.segments:
+            if (
+                result is None
+                and self.enable_shadow_construction
+                and guide_route is not None
+                and guide_route.segments
+            ):
                 # Issue #3508: role-swapped shadow retry.  P's guide may
                 # carry vias or hug a one-sided obstacle wall; the N
                 # side's single-ended route can be shadowable when P's
@@ -4247,26 +4367,50 @@ class DiffPairRouter:
                 violation is not None
                 and violation.actual_clearance_mm < 0.0
             )
+            # Issue #3508 (second pass): the segments-only check above
+            # cannot see via-vs-segment / via-vs-via physical overlap
+            # (e.g. a crossing-tail via on the partner's inner-layer
+            # copper).  Treat those as severe too -- the recipe's 6b
+            # repair would otherwise rip one side and de-couple the
+            # pair downstream.
+            if not severe_violation and self._pair_has_physical_overlap(
+                p_route, n_route
+            ):
+                print(
+                    "    WARNING: Coupled route has via-aware physical "
+                    "P/N overlap; rejecting coupled route."
+                )
+                severe_violation = True
+                if violation is None:
+                    # Synthesize nothing -- the handler below only needs
+                    # the flag; guard its violation-specific logging.
+                    pass
             if severe_violation:
-                assert violation is not None  # for type-checkers
+                # Issue #3508: ``violation`` may be ``None`` when the
+                # rejection came from the via-aware physical-overlap
+                # check (no same-layer segment pair under threshold).
+                worst = (
+                    violation.actual_clearance_mm if violation is not None else float("nan")
+                )
                 print(
                     f"    WARNING: Coupled route produced centerline overlap "
-                    f"(worst={violation.actual_clearance_mm:+.3f}mm < 0); "
+                    f"(worst={worst:+.3f}mm < 0); "
                     "rejecting coupled route and falling back to independent "
                     "routing."
                 )
-                logger.warning(
-                    "diffpair coupled-route REJECTED due to centerline overlap: "
-                    "pair=%r p_net=%r n_net=%r worst_clearance=%.4fmm "
-                    "threshold=%.4fmm offending_segments=%d",
-                    violation.pair_name,
-                    violation.positive_net_name,
-                    violation.negative_net_name,
-                    violation.actual_clearance_mm,
-                    violation.expected_clearance_mm,
-                    len(violation.segment_violations),
-                )
-                if _COUPLED_TRACE:
+                if violation is not None:
+                    logger.warning(
+                        "diffpair coupled-route REJECTED due to centerline overlap: "
+                        "pair=%r p_net=%r n_net=%r worst_clearance=%.4fmm "
+                        "threshold=%.4fmm offending_segments=%d",
+                        violation.pair_name,
+                        violation.positive_net_name,
+                        violation.negative_net_name,
+                        violation.actual_clearance_mm,
+                        violation.expected_clearance_mm,
+                        len(violation.segment_violations),
+                    )
+                if _COUPLED_TRACE and violation is not None:
                     print(
                         f"      [overlap-debug] layer={violation.layer} "
                         f"p_seg=({violation.p_segment.x1:.2f},"
@@ -4347,8 +4491,25 @@ class DiffPairRouter:
         # cluster, e.g., USB-C A6 -> B6) using the independent router.
         # These are short, no coupling required, and the autorouter has
         # better access to obstacle-aware A* than the coupled pathfinder.
+        #
+        # Issue #3508: failed stub edges are recorded in
+        # ``self._last_stub_failed_nets`` so the pre-pass aggregator can
+        # leave the affected NET in the main strategy's routable set.
+        # Previously the "deferred to main strategy" warning was a lie:
+        # the net was still claimed as coupled-routed (#2464 reserve),
+        # the negotiated loop skipped it, and the stub hop was never
+        # routed (measured: USB2_D+ incomplete -> 18/21 reach; the
+        # committed-artifact solution for A6->B6 is a ~12mm
+        # under-connector wrap on In1.Cu that only the main strategy's
+        # full A* can produce).
+        self._last_stub_failed_nets: set[int] = set()
         if stub_specs:
             stub_routes = self._route_stub_edges(stub_specs)
+            expected_per_net = collections.Counter(s.start.net for s in stub_specs)
+            routed_per_net = collections.Counter(r.net for r in stub_routes)
+            for stub_net, expected_count in expected_per_net.items():
+                if routed_per_net.get(stub_net, 0) < expected_count:
+                    self._last_stub_failed_nets.add(stub_net)
             for r in stub_routes:
                 if r.net == pair.positive.net_id:
                     p_routes.append(r)
@@ -5263,6 +5424,13 @@ class DiffPairRouter:
                 if routed_for_net.get(p_id, 0) > 0 and routed_for_net.get(n_id, 0) > 0:
                     routed_net_ids.add(p_id)
                     routed_net_ids.add(n_id)
+                    # Issue #3508: see route_all_with_diffpairs -- a net
+                    # with a failed stub edge stays routable for the
+                    # main strategy.
+                    for incomplete in (
+                        getattr(self, "_last_stub_failed_nets", set()) & {p_id, n_id}
+                    ):
+                        routed_net_ids.discard(incomplete)
 
             all_routes.extend(pair_routes)
             if warning:
@@ -5357,6 +5525,13 @@ class DiffPairRouter:
         effective_aggregate_timeout = aggregate_timeout
         if effective_aggregate_timeout is None and diffpair_config is not None:
             effective_aggregate_timeout = getattr(diffpair_config, "aggregate_timeout", None)
+        # Issue #3508: thread the shadow-constructor opt-in through to
+        # ``route_differential_pair_coupled`` (instance attribute --
+        # the coupled entry point has no config handle).
+        if diffpair_config is not None:
+            self.enable_shadow_construction = bool(
+                getattr(diffpair_config, "enable_shadow_construction", False)
+            )
         if diffpair_config is None or not diffpair_config.enabled:
             return self.autorouter.route_all(net_order), []
 
@@ -5483,6 +5658,19 @@ class DiffPairRouter:
                 if routed_for_net.get(p_id, 0) > 0 and routed_for_net.get(n_id, 0) > 0:
                     coupled_routed_nets.add(p_id)
                     coupled_routed_nets.add(n_id)
+                    # Issue #3508: a net whose intra-cluster stub edge
+                    # failed is INCOMPLETE -- leave it routable so the
+                    # main strategy can finish it (its committed coupled
+                    # copper stays on the grid; the negotiated router
+                    # connects the remaining pad through/around it).
+                    stub_failed = getattr(self, "_last_stub_failed_nets", set())
+                    for incomplete in stub_failed & {p_id, n_id}:
+                        coupled_routed_nets.discard(incomplete)
+                        print(
+                            f"    [diffpair-stub] net {incomplete} has an "
+                            f"unrouted stub edge; returning it to the main "
+                            f"strategy (issue #3508)"
+                        )
             all_routes.extend(pair_routes)
             if warning:
                 warnings.append(warning)

--- a/src/kicad_tools/router/drc_nudge.py
+++ b/src/kicad_tools/router/drc_nudge.py
@@ -1515,6 +1515,7 @@ def drc_verify_and_nudge(
     *,
     max_displacement: float = 0.2,
     max_passes: int = 3,
+    skip_nets: set[int] | None = None,
 ) -> DRCNudgeResult:
     """Run post-optimization DRC verification and repair.
 
@@ -1528,6 +1529,15 @@ def drc_verify_and_nudge(
             recommended by the existing ClearanceRepairer precedent).
         max_passes: Maximum iterative passes. Stops early when no
             violations remain or no progress is made.
+        skip_nets: Issue #3508: optional set of net IDs whose violations
+            are never nudged.  Coupled diff-pair copper runs at an
+            intentional intra-pair gap far below ``max_displacement``
+            (0.075-0.1 mm edge-to-edge vs the 0.2 mm budget), and the
+            nudge helpers are not partner-aware -- a nudge that fixes a
+            pad graze on one side routinely lands ON the partner trace
+            (measured on board 06: shadow-routed USB3_RX1/RX2 sides
+            physically overlapping after the nudge pass, forcing the
+            recipe's 6b solo re-route rip).
 
     Returns:
         :class:`DRCNudgeResult` with statistics.
@@ -1551,7 +1561,10 @@ def drc_verify_and_nudge(
     )
     try:
         return _drc_verify_and_nudge_impl(
-            router, max_displacement=max_displacement, max_passes=max_passes
+            router,
+            max_displacement=max_displacement,
+            max_passes=max_passes,
+            skip_nets=skip_nets,
         )
     finally:
         if _grid is not None:
@@ -1563,6 +1576,7 @@ def _drc_verify_and_nudge_impl(
     *,
     max_displacement: float,
     max_passes: int,
+    skip_nets: set[int] | None = None,
 ) -> DRCNudgeResult:
     """Body of :func:`drc_verify_and_nudge` (wrapped for the #3507 grid resync)."""
     result = DRCNudgeResult()
@@ -1583,6 +1597,14 @@ def _drc_verify_and_nudge_impl(
     violations = validate_routes(router)
     # Only consider actionable (non-component-inherent) violations.
     actionable = [v for v in violations if not v.component_inherent]
+    # Issue #3508: never nudge protected (diff-pair) nets -- see the
+    # ``skip_nets`` rationale in :func:`drc_verify_and_nudge`.
+    if skip_nets:
+        protected = [v for v in actionable if v.net in skip_nets]
+        if protected:
+            for _ in protected:
+                result._bump_skipped("diffpair_protected_net")
+            actionable = [v for v in actionable if v.net not in skip_nets]
     result.initial_violations = len(actionable)
 
     if not actionable:
@@ -1642,6 +1664,9 @@ def _drc_verify_and_nudge_impl(
         # Re-validate after nudges.
         violations = validate_routes(router)
         actionable = [v for v in violations if not v.component_inherent]
+        # Issue #3508: re-apply the protected-net filter on re-detection.
+        if skip_nets:
+            actionable = [v for v in actionable if v.net not in skip_nets]
         current_count = len(actionable)
 
         if current_count == 0:

--- a/src/kicad_tools/router/optimizer/trace.py
+++ b/src/kicad_tools/router/optimizer/trace.py
@@ -36,7 +36,9 @@ from .pcb import optimize_pcb, parse_net_names, parse_segments, replace_segments
 from .via_optimizer import ViaOptimizationConfig, ViaOptimizer
 
 
-def optimize_routes_grid_synced(router, optimizer: TraceOptimizer) -> list[Route]:
+def optimize_routes_grid_synced(
+    router, optimizer: TraceOptimizer, skip_nets: set[int] | None = None
+) -> list[Route]:
     """Optimize every route on ``router`` keeping the grid in sync.
 
     Issue #3507: the historical call-site pattern::
@@ -63,6 +65,14 @@ def optimize_routes_grid_synced(router, optimizer: TraceOptimizer) -> list[Route
         router: ``Autorouter`` whose ``routes`` will be optimized and
             replaced in place.
         optimizer: Configured :class:`TraceOptimizer`.
+        skip_nets: Issue #3508: optional set of net IDs whose routes are
+            passed through UNTOUCHED.  Coupled diff-pair routes carry
+            intentional geometry the optimizer's simplification passes
+            destroy: length-matching serpentines are exactly the
+            "zigzags" ``eliminate_zigzags`` removes (measured on board
+            06: PCIE_RX skew 0.097 mm after serpentine -> 1.652 mm in
+            the final artifact), and straightening one side of a
+            coupled pair breaks the constant-gap geometry.
 
     Returns:
         The new ``router.routes`` list (also assigned on the router).
@@ -70,6 +80,9 @@ def optimize_routes_grid_synced(router, optimizer: TraceOptimizer) -> list[Route
     grid = router.grid
     optimized_routes: list[Route] = []
     for route in router.routes:
+        if skip_nets is not None and route.net in skip_nets:
+            optimized_routes.append(route)
+            continue
         optimized = optimizer.optimize_route(route)
         if optimized is not route and (
             optimized.segments == route.segments and optimized.vias == route.vias

--- a/tests/router/test_grid_resync_3507.py
+++ b/tests/router/test_grid_resync_3507.py
@@ -338,3 +338,74 @@ class TestNudgePassGridConsistency:
         _assert_marked(router.grid, a)
         _assert_marked(router.grid, b)
         assert len(router.grid.routes) == 2
+
+
+class TestSkipNetsProtection:
+    """Issue #3508: diff-pair nets are excluded from the mutating
+    post-route passes (optimizer + nudge) because their geometry is
+    intentional -- length-matching serpentines are exactly the
+    "zigzags" the optimizer removes, and the nudge helpers are not
+    partner-aware at the pairs' sub-displacement intra gap."""
+
+    def test_optimizer_skip_nets_passes_route_through_untouched(self):
+        router = _make_router()
+        # Serpentine-ish zigzag the optimizer WOULD simplify.
+        protected = _make_route(
+            7,
+            "USB_D+",
+            [(5.0, 10.0), (10.0, 10.0), (10.0, 12.0), (15.0, 12.0), (15.0, 10.0), (20.0, 10.0)],
+        )
+        plain = _make_route(8, "SIG", [(5.0, 30.0), (12.0, 30.0), (20.0, 30.0)])
+        _commit(router, protected)
+        _commit(router, plain)
+        protected_geometry = [
+            (s.x1, s.y1, s.x2, s.y2) for s in protected.segments
+        ]
+
+        optimizer = TraceOptimizer(
+            config=OptimizationConfig(merge_collinear=True, eliminate_zigzags=True)
+        )
+        optimize_routes_grid_synced(router, optimizer, skip_nets={7})
+
+        by_net = {r.net: r for r in router.routes}
+        # The protected route is the SAME object with unchanged geometry.
+        assert by_net[7] is protected
+        assert [
+            (s.x1, s.y1, s.x2, s.y2) for s in by_net[7].segments
+        ] == protected_geometry
+        # The unprotected collinear pair was still merged.
+        assert len(by_net[8].segments) == 1
+        _assert_marked(router.grid, protected)
+
+    def test_nudge_skip_nets_filters_protected_violations(self):
+        """Violations on protected nets are recorded as skips, not nudged."""
+        from kicad_tools.router.drc_nudge import _drc_verify_and_nudge_impl
+
+        router = _make_router()
+        # Two parallel same-layer traces well inside clearance of each
+        # other -> seg-seg violations in both directions.
+        a = _make_route(1, "USB_D+", [(5.0, 10.0), (20.0, 10.0)])
+        b = _make_route(2, "USB_D-", [(5.0, 10.2), (20.0, 10.2)])
+        _commit(router, a)
+        _commit(router, b)
+        a_geo = a.copy_geometry()
+        b_geo = b.copy_geometry()
+
+        result = _drc_verify_and_nudge_impl(
+            router,
+            max_displacement=0.2,
+            max_passes=1,
+            skip_nets={1, 2},
+        )
+
+        # Both nets protected: nothing actionable, nothing nudged, and
+        # the geometry is bit-identical.
+        assert result.initial_violations == 0
+        assert result.segments_nudged == 0
+        assert [
+            (s.x1, s.y1, s.x2, s.y2) for s in router.routes[0].segments
+        ] == [(s.x1, s.y1, s.x2, s.y2) for s in a_geo.segments]
+        assert [
+            (s.x1, s.y1, s.x2, s.y2) for s in router.routes[1].segments
+        ] == [(s.x1, s.y1, s.x2, s.y2) for s in b_geo.segments]
+        assert result.skipped.get("diffpair_protected_net", 0) >= 1

--- a/tests/test_diffpair_corridor.py
+++ b/tests/test_diffpair_corridor.py
@@ -28,7 +28,6 @@ to a near-1D tube, which the pure-Python search completes in seconds.
 from __future__ import annotations
 
 import logging
-import time
 
 from kicad_tools.router.core import Autorouter
 from kicad_tools.router.diffpair import DifferentialPairConfig

--- a/tests/test_diffpair_corridor.py
+++ b/tests/test_diffpair_corridor.py
@@ -492,14 +492,31 @@ def test_guide_route_probe_receives_deadline(monkeypatch):
     )
 
     assert probe_timeouts, "guide-route probe was never invoked"
-    # Issue #3508: the probe budget is now
-    # ``min(max(per_pair_timeout * 0.125, 45.0), per_pair_timeout * 0.5)``
-    # -- the #3473 eighth-of-budget bound starved board 06's USB3
-    # probes (30-37s single-ended guide routes) at the 60s per-pair
-    # budget, so the floor was raised with a half-budget clamp.
+    # Issue #3508 (decomposition): with the shadow constructor OFF
+    # (default), the probe keeps the legacy #3473 eighth-of-budget
+    # bound -- the expensive 45s probe floor exists to feed the shadow
+    # guide and would otherwise burn most of a 2-core CI runner's
+    # re-route wall-clock before a deterministic budget-exit defer.
+    assert probe_timeouts[0] == 60.0 * 0.125, (
+        "with shadow construction off the probe must get the legacy "
+        f"eighth-of-budget deadline, got {probe_timeouts[0]}"
+    )
+
+    # With the shadow constructor ON, the budget is floored at 45s and
+    # clamped to half the per-pair budget -- the eighth-of-budget bound
+    # starved board 06's USB3 probes (30-37s single-ended guide routes)
+    # at the 60s per-pair budget.
+    probe_timeouts.clear()
+    router._diffpair.enable_shadow_construction = True
+    router._diffpair.route_differential_pair_coupled(
+        pairs[0],
+        coupled_only=True,
+        per_pair_timeout=60.0,
+    )
+    assert probe_timeouts, "guide-route probe was never invoked (shadow on)"
     assert probe_timeouts[0] == min(max(60.0 * 0.125, 45.0), 60.0 * 0.5), (
-        "probe must get the floored-and-clamped probe budget as its "
-        f"deadline, got {probe_timeouts[0]}"
+        "with shadow construction on the probe must get the "
+        f"floored-and-clamped budget, got {probe_timeouts[0]}"
     )
 
 

--- a/tests/test_diffpair_corridor.py
+++ b/tests/test_diffpair_corridor.py
@@ -192,12 +192,29 @@ def test_route_coupled_corridor_prunes_outside_states():
             for dy in range(-2, 3):
                 start_only.add((cx + dx, cy + dy))
 
-    t0 = time.monotonic()
-    result = pf.route_coupled(p_start, p_end, n_start, n_end, corridor=frozenset(start_only))
-    elapsed = time.monotonic() - t0
+    # Issue #3508: the fail-fast assertion is iteration-based, not
+    # wall-clock.  Mid-route asymmetric moves enlarge the joint state
+    # space inside the corridor (positions x direction tags), so FULL
+    # frontier exhaustion under coverage instrumentation can exceed a
+    # small wall-clock bound while still being a tiny fraction of an
+    # open-grid search.  Production callers always pass an iteration
+    # budget; mirror that here and assert the search failed by corridor
+    # pruning (frontier exhausted) rather than by burning the budget.
+    budget = 200_000
+    result = pf.route_coupled(
+        p_start,
+        p_end,
+        n_start,
+        n_end,
+        corridor=frozenset(start_only),
+        max_iterations_budget=budget,
+    )
 
     assert result is None, "search must fail when the corridor has no path to the goal"
-    assert elapsed < 10.0, f"pruned search must exit fast; took {elapsed:.2f}s"
+    assert pf.last_iterations < budget, (
+        "pruned search must exhaust the corridor-bounded frontier instead of "
+        f"burning the full budget; used {pf.last_iterations} iterations"
+    )
 
 
 def test_route_coupled_corridor_none_preserves_legacy_behaviour():

--- a/tests/test_diffpair_corridor.py
+++ b/tests/test_diffpair_corridor.py
@@ -34,6 +34,7 @@ from kicad_tools.router.core import Autorouter
 from kicad_tools.router.diffpair import DifferentialPairConfig
 from kicad_tools.router.diffpair_routing import (
     CoupledPathfinder,
+    DiffPairRouter,
     build_corridor_mask,
 )
 from kicad_tools.router.grid import RoutingGrid
@@ -282,12 +283,21 @@ def _two_pad_diffpair_router(diffpair_spacing: float = 0.8) -> Autorouter:
     return router
 
 
-def test_coupled_routing_uses_corridor_phase(caplog):
+def test_coupled_routing_uses_corridor_phase(caplog, monkeypatch):
     """On a clean fixture the corridor attempt should succeed (the
     structured timing log reports ``phase=corridor``) and the pair
-    should be fully routed."""
+    should be fully routed.
+
+    Issue #3508: the geometric shadow constructor now runs FIRST and
+    satisfies this clean fixture, so the corridor mechanism is
+    exercised here by disabling the shadow (it has its own coverage in
+    ``tests/test_diffpair_shadow.py``).
+    """
     router = _two_pad_diffpair_router()
     config = DifferentialPairConfig(enabled=True, spacing=0.8)
+    monkeypatch.setattr(
+        DiffPairRouter, "_shadow_route_pair", lambda self, *a, **k: None
+    )
 
     with caplog.at_level(logging.INFO, logger="kicad_tools.router.diffpair_routing"):
         routes, warnings, routed_net_ids = router.route_diffpair_prepass(config)
@@ -336,6 +346,14 @@ def test_iteration_budget_is_split_between_corridor_and_fallback(monkeypatch):
     The corridor attempt gets at most half; the open fallback gets the
     remainder of the SHARED budget.
     """
+    # Issue #3508: bypass the shadow constructor so the corridor/
+    # fallback budget split is what this test exercises.
+    monkeypatch.setattr(
+        DiffPairRouter, "_shadow_route_pair", lambda self, *a, **k: None
+    )
+    monkeypatch.setattr(
+        DiffPairRouter, "_rescue_near_miss_coupled", lambda self, *a, **k: None
+    )
     router = _two_pad_diffpair_router()
     pairs = router._diffpair.detect_differential_pairs()
     assert len(pairs) == 1
@@ -385,6 +403,14 @@ def test_fallback_gets_full_remainder_when_corridor_exits_early(monkeypatch):
     """If the corridor attempt fails after only a few iterations, the
     open fallback inherits nearly the whole shared budget (mirrors the
     wall-clock remaining-budget arithmetic)."""
+    # Issue #3508: bypass the shadow constructor so the corridor/
+    # fallback budget split is what this test exercises.
+    monkeypatch.setattr(
+        DiffPairRouter, "_shadow_route_pair", lambda self, *a, **k: None
+    )
+    monkeypatch.setattr(
+        DiffPairRouter, "_rescue_near_miss_coupled", lambda self, *a, **k: None
+    )
     router = _two_pad_diffpair_router()
     pairs = router._diffpair.detect_differential_pairs()
 
@@ -450,9 +476,14 @@ def test_guide_route_probe_receives_deadline(monkeypatch):
     )
 
     assert probe_timeouts, "guide-route probe was never invoked"
-    assert probe_timeouts[0] == 60.0 * 0.125, (
-        "probe must get an eighth of the per-pair budget as its deadline, "
-        f"got {probe_timeouts[0]}"
+    # Issue #3508: the probe budget is now
+    # ``min(max(per_pair_timeout * 0.125, 45.0), per_pair_timeout * 0.5)``
+    # -- the #3473 eighth-of-budget bound starved board 06's USB3
+    # probes (30-37s single-ended guide routes) at the 60s per-pair
+    # budget, so the floor was raised with a half-budget clamp.
+    assert probe_timeouts[0] == min(max(60.0 * 0.125, 45.0), 60.0 * 0.5), (
+        "probe must get the floored-and-clamped probe budget as its "
+        f"deadline, got {probe_timeouts[0]}"
     )
 
 

--- a/tests/test_diffpair_shadow.py
+++ b/tests/test_diffpair_shadow.py
@@ -1,0 +1,338 @@
+"""Tests for issue #3508: board 06 coupled-convergence machinery.
+
+Covers the units this issue added or changed in
+``kicad_tools.router.diffpair_routing``:
+
+1. ``CoupledPathfinder._is_cell_blocked`` -- own-net passability.  Pad
+   metal and clearance-halo cells carry ``is_obstacle = True`` on the
+   grid (the #2915/#2940 negotiated-mode loophole guard); the coupled
+   pathfinder must NOT treat that as a block for the pad's own net,
+   matching the per-net pathfinder's ``cell.net != routing_net``
+   convention.  Before the fix every pad was unreachable for its own
+   coupled route and convergence was 0/9 at ANY budget.
+
+2. ``CoupledPathfinder`` weighted A* (``heuristic_weight``) -- stored,
+   clamped, and applied to ``f = g + w * h``.
+
+3. ``create_serpentine`` partner-aware mode -- one-sided bulges (never
+   toward the partner) and the triangular length arithmetic actually
+   delivering the requested extra length.
+
+4. ``DiffPairRouter`` geometry helpers -- ``_point_segment_distance``
+   and ``_min_distance_to_partner``.
+
+5. Mid-route asymmetric moves (issue #3508 relaxation of the #2490
+   approach-phase-only restriction): asymmetric P-advance/N-advance
+   moves are generated OUTSIDE the approach radius with a tight
+   tolerance.
+
+6. The trail PROXIMITY guard: an advancing trace may not land within
+   ``min_spacing_cells`` (Euclidean, same layer) of the partner's
+   accumulated trail -- the exact-cell guard alone admitted 1-cell
+   passes (0.05 mm centerline distance = copper overlap).
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from kicad_tools.router.diffpair_routing import (
+    CoupledPathfinder,
+    CoupledState,
+    GridPos,
+    create_serpentine,
+)
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.primitives import Route, Segment
+from kicad_tools.router.rules import DesignRules
+
+
+def _make_pathfinder(**kwargs) -> CoupledPathfinder:
+    rules = DesignRules()
+    grid = RoutingGrid(width=12.7, height=12.7, rules=rules)
+    defaults = {"grid": grid, "rules": rules, "target_spacing_cells": 4}
+    defaults.update(kwargs)
+    return CoupledPathfinder(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# 1. own-net passability
+# ---------------------------------------------------------------------------
+
+
+def test_own_net_obstacle_cell_is_passable():
+    """A blocked cell carrying the routing net is passable (pad metal/halo)."""
+    pf = _make_pathfinder()
+    cell = pf.grid.grid[0][10][10]
+    cell.blocked = True
+    cell.is_obstacle = True
+    cell.net = 42
+    assert pf._is_cell_blocked(10, 10, 0, 42) is False
+
+
+def test_foreign_net_blocked_cell_is_blocked():
+    pf = _make_pathfinder()
+    cell = pf.grid.grid[0][10][10]
+    cell.blocked = True
+    cell.net = 7
+    assert pf._is_cell_blocked(10, 10, 0, 42) is True
+
+
+def test_net_zero_obstacle_blocked_for_signal_nets():
+    """True obstacles (keepouts, board edge) carry net 0 and stay blocked."""
+    pf = _make_pathfinder()
+    cell = pf.grid.grid[0][10][10]
+    cell.blocked = True
+    cell.is_obstacle = True
+    # cell.net stays 0
+    assert pf._is_cell_blocked(10, 10, 0, 42) is True
+
+
+# ---------------------------------------------------------------------------
+# 2. weighted A*
+# ---------------------------------------------------------------------------
+
+
+def test_heuristic_weight_default_is_classic():
+    pf = _make_pathfinder()
+    assert pf.heuristic_weight == 1.0
+
+
+def test_heuristic_weight_stored():
+    pf = _make_pathfinder(heuristic_weight=1.5)
+    assert pf.heuristic_weight == 1.5
+
+
+def test_heuristic_weight_clamped_to_at_least_one():
+    """Sub-1 weights would break A* termination guarantees -- clamped."""
+    pf = _make_pathfinder(heuristic_weight=0.25)
+    assert pf.heuristic_weight == 1.0
+
+
+# ---------------------------------------------------------------------------
+# 3. partner-aware serpentine
+# ---------------------------------------------------------------------------
+
+
+def _straight_route(net: int, name: str, y: float, length: float = 10.0) -> Route:
+    r = Route(net=net, net_name=name)
+    r.segments.append(
+        Segment(
+            x1=1.0,
+            y1=y,
+            x2=1.0 + length,
+            y2=y,
+            width=0.2,
+            layer=Layer.F_CU,
+            net=net,
+            net_name=name,
+        )
+    )
+    return r
+
+
+def _route_length(route: Route) -> float:
+    return sum(
+        math.hypot(s.x2 - s.x1, s.y2 - s.y1) for s in route.segments
+    )
+
+
+def test_partner_aware_serpentine_is_one_sided():
+    """With a partner constraint, no bulge may cross toward the partner.
+
+    Partner runs at y=10.35 above the target trace at y=10.0; every
+    serpentine point must therefore stay at y <= 10.0 (bulge downward,
+    away from the partner).
+    """
+    target = _straight_route(1, "P", 10.0)
+    partner = _straight_route(2, "N", 10.35)
+    ok = create_serpentine(
+        target,
+        length_to_add=2.0,
+        partner_route=partner,
+        intra_pair_clearance_mm=0.1,
+    )
+    assert ok, "partner-aware serpentine must succeed on an open straight run"
+    for seg in target.segments:
+        assert seg.y1 <= 10.0 + 1e-9 and seg.y2 <= 10.0 + 1e-9, (
+            f"bulge crossed toward the partner: ({seg.x1},{seg.y1})->"
+            f"({seg.x2},{seg.y2})"
+        )
+
+
+def test_partner_aware_serpentine_adds_requested_length():
+    """The triangular-bulge arithmetic must deliver ~length_to_add.
+
+    The legacy square-bulge formula under-delivered by up to 10x
+    (issue #3508); assert at least 70% of the request is realised.
+    """
+    target = _straight_route(1, "P", 10.0)
+    partner = _straight_route(2, "N", 10.35)
+    before = _route_length(target)
+    requested = 2.5
+    ok = create_serpentine(
+        target,
+        length_to_add=requested,
+        partner_route=partner,
+        intra_pair_clearance_mm=0.1,
+    )
+    assert ok
+    added = _route_length(target) - before
+    assert added >= 0.7 * requested, (
+        f"serpentine added only {added:.3f}mm of the requested "
+        f"{requested:.3f}mm"
+    )
+
+
+def test_legacy_serpentine_still_alternates():
+    """Without a partner constraint the legacy alternating wave persists."""
+    target = _straight_route(1, "P", 10.0)
+    ok = create_serpentine(target, length_to_add=2.0)
+    assert ok
+    above = any(s.y1 > 10.0 + 1e-9 or s.y2 > 10.0 + 1e-9 for s in target.segments)
+    below = any(s.y1 < 10.0 - 1e-9 or s.y2 < 10.0 - 1e-9 for s in target.segments)
+    assert above and below, "legacy serpentine should alternate sides"
+
+
+# ---------------------------------------------------------------------------
+# 4. geometry helpers
+# ---------------------------------------------------------------------------
+
+
+def _seg(x1, y1, x2, y2, layer=Layer.F_CU) -> Segment:
+    return Segment(
+        x1=x1, y1=y1, x2=x2, y2=y2, width=0.2, layer=layer, net=1, net_name="P"
+    )
+
+
+def test_point_segment_distance_perpendicular():
+    from kicad_tools.router.diffpair_routing import DiffPairRouter
+
+    d = DiffPairRouter._point_segment_distance(5.0, 1.0, _seg(0, 0, 10, 0))
+    assert d == pytest.approx(1.0)
+
+
+def test_point_segment_distance_beyond_endpoint():
+    from kicad_tools.router.diffpair_routing import DiffPairRouter
+
+    d = DiffPairRouter._point_segment_distance(12.0, 0.0, _seg(0, 0, 10, 0))
+    assert d == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# 5. mid-route asymmetric moves
+# ---------------------------------------------------------------------------
+
+
+def test_asymmetric_moves_generated_mid_route():
+    """Asymmetric advance moves fire OUTSIDE the approach radius.
+
+    Issue #3508: symmetric moves freeze the P->N offset vector, so a
+    pair cannot turn a corner whose leg parallels the offset; the
+    offset can only rotate via asymmetric moves, which #2490 had
+    restricted to the approach phase.  Verify a state far from both
+    start and goal produces at least one move where exactly one head
+    advanced.
+    """
+    pf = _make_pathfinder(target_spacing_cells=4)
+    state = CoupledState(GridPos(100, 100, 0), GridPos(100, 104, 0), (1, 0))
+    neighbors = pf._get_coupled_neighbors(
+        state,
+        1,
+        2,
+        p_goal=GridPos(200, 100, 0),
+        n_goal=GridPos(200, 104, 0),
+        p_start=GridPos(10, 100, 0),
+        n_start=GridPos(10, 104, 0),
+    )
+    asym = [
+        (ns, c, v)
+        for ns, c, v in neighbors
+        if (ns.p_pos != state.p_pos) != (ns.n_pos != state.n_pos)
+    ]
+    assert asym, "expected asymmetric single-head moves mid-route"
+    # Mid-route tolerance stays tight: every generated state keeps
+    # spacing within +/-1 cell of the target.
+    for ns, _c, is_via in neighbors:
+        if is_via:
+            continue
+        spacing = math.hypot(
+            ns.p_pos.x - ns.n_pos.x, ns.p_pos.y - ns.n_pos.y
+        )
+        assert abs(spacing - 4) <= 1 + 1e-9
+
+
+# ---------------------------------------------------------------------------
+# 6. trail proximity guard
+# ---------------------------------------------------------------------------
+
+
+def test_proximity_guard_rejects_near_partner_trail():
+    """Landing 1 cell from the partner's trail is rejected.
+
+    Exact-cell guards alone admitted 0.05 mm centerline passes (the
+    measured MIPI_CLK -0.175 mm overlap).  With min_spacing_cells=4,
+    a candidate 1 cell from a partner trail cell must be pruned.
+    """
+    pf = _make_pathfinder(target_spacing_cells=4, min_spacing_cells=4)
+    state = CoupledState(GridPos(100, 100, 0), GridPos(100, 104, 0), (1, 0))
+    # Partner (N) trail passes right next to where P wants to go.
+    n_trail_cell = (101, 101, 0)
+    buckets = {(n_trail_cell[0] // 4, n_trail_cell[1] // 4): [n_trail_cell]}
+    neighbors = pf._get_coupled_neighbors(
+        state,
+        1,
+        2,
+        p_goal=GridPos(200, 100, 0),
+        n_goal=GridPos(200, 104, 0),
+        p_start=GridPos(10, 100, 0),
+        n_start=GridPos(10, 104, 0),
+        p_visited=frozenset({(100, 100, 0)}),
+        n_visited=frozenset({n_trail_cell}),
+        n_trail_buckets=buckets,
+        p_trail_buckets={},
+    )
+    for ns, _c, is_via in neighbors:
+        if is_via:
+            continue
+        if ns.p_pos != state.p_pos:  # P advanced
+            d = math.hypot(ns.p_pos.x - 101, ns.p_pos.y - 101)
+            assert d >= 4 - 1e-9, (
+                f"P landed {d:.2f} cells from the partner trail "
+                f"(< min_spacing_cells=4): {ns.p_pos}"
+            )
+
+
+def test_proximity_guard_allows_exact_min_spacing():
+    """Distance exactly == min_spacing_cells is NOT a violation."""
+    pf = _make_pathfinder(target_spacing_cells=4, min_spacing_cells=4)
+    state = CoupledState(GridPos(100, 100, 0), GridPos(100, 104, 0), (1, 0))
+    # Partner trail directly above P's forward landing cell at exactly
+    # 4 cells.
+    n_trail_cell = (101, 96, 0)
+    buckets = {(n_trail_cell[0] // 4, n_trail_cell[1] // 4): [n_trail_cell]}
+    neighbors = pf._get_coupled_neighbors(
+        state,
+        1,
+        2,
+        p_goal=GridPos(200, 100, 0),
+        n_goal=GridPos(200, 104, 0),
+        p_start=GridPos(10, 100, 0),
+        n_start=GridPos(10, 104, 0),
+        p_visited=frozenset({(100, 100, 0)}),
+        n_visited=frozenset({n_trail_cell}),
+        n_trail_buckets=buckets,
+        p_trail_buckets={},
+    )
+    forward = [
+        ns
+        for ns, _c, is_via in neighbors
+        if not is_via and ns.p_pos == GridPos(101, 100, 0)
+    ]
+    assert forward, (
+        "P's forward symmetric step at exactly min_spacing distance from "
+        "the partner trail must be admitted"
+    )

--- a/tests/test_diffpair_shadow.py
+++ b/tests/test_diffpair_shadow.py
@@ -336,3 +336,48 @@ def test_proximity_guard_allows_exact_min_spacing():
         "P's forward symmetric step at exactly min_spacing distance from "
         "the partner trail must be admitted"
     )
+
+
+# ---------------------------------------------------------------------------
+# 7. Issue #3508 decomposition: shadow-constructor opt-in gate
+# ---------------------------------------------------------------------------
+
+
+def test_shadow_construction_flag_defaults_off():
+    """The geometric shadow constructor is opt-in (default False).
+
+    The 2026-06-11 board 06 seed-42 integration run showed the
+    constructor's committed geometry is not yet artifact-quality
+    (stranded shadow tails, shadow-via/partner intersections, corridor
+    competition stranding single-ended nets -> 16/21 reach).  Recipes
+    must explicitly opt in once the follow-up issues land.
+    """
+    from kicad_tools.router.diffpair import DifferentialPairConfig
+
+    assert DifferentialPairConfig().enable_shadow_construction is False
+    assert DifferentialPairConfig(enabled=True).enable_shadow_construction is False
+
+
+def test_shadow_construction_flag_plumbed_from_config():
+    """``route_all_with_diffpairs`` copies the config flag onto the router."""
+    from kicad_tools.router.core import Autorouter
+    from kicad_tools.router.diffpair import DifferentialPairConfig
+
+    rules = DesignRules()
+    router = Autorouter(width=12.7, height=12.7, rules=rules)
+    dpr = router._diffpair
+    assert dpr.enable_shadow_construction is False
+
+    # No pairs detected -> the call returns immediately, but the flag
+    # must already have been copied from the config.
+    router.route_all_with_diffpairs(
+        diffpair_config=DifferentialPairConfig(
+            enabled=True, enable_shadow_construction=True
+        )
+    )
+    assert dpr.enable_shadow_construction is True
+
+    router.route_all_with_diffpairs(
+        diffpair_config=DifferentialPairConfig(enabled=True)
+    )
+    assert dpr.enable_shadow_construction is False


### PR DESCRIPTION
## Summary

Third builder session on #3508 (coupled diff-pair convergence 0/9 on board 06). This PR lands the inherited convergence machinery (~2,300 lines across two prior sessions plus this one), **measures it end-to-end on the seed-42 CI recipe, and ships it as a gated opt-in with the quality gaps decomposed** — it does NOT retire the 9+9 skew/continuity block, because the measurement shows the machinery is not artifact-quality yet.

### What landed

- **Convergence machinery** (commits 1-2, inherited + finished): own-net passability in `CoupledPathfinder` (pads were unreachable for their own coupled route — the root cause of 0/9 at any budget), weighted A* + LIFO tie-break, mid-route asymmetric moves, trail-proximity guard, the geometric shadow constructor (guide + validated parallel offset, mitred corners, staggered shadow vias, partner-aware/two-via tails), via-in-pad rejection, grid-validated serpentines + post-mutation cell re-marking, synthesized-tail stub fallback, `skip_nets` protection params for `optimize_routes_grid_synced` / `drc_verify_and_nudge`.
- **Opt-in gate** (commits 4-6): `DifferentialPairConfig.enable_shadow_construction` (default **False**, plumbed by `route_all_with_diffpairs`); the 45s probe-budget floor applies only when the shadow is on (legacy eighth-of-budget otherwise — matters for 2-core CI re-route wall-clock); board 06's recipe keeps the constructor off and conditions its optimizer/nudge protections on the same constant.
- **Committed artifact, floor (20), and strict-gate pins: UNCHANGED.** Tolerance file gains a status note for exit clause (a).

### Why gated instead of enabled (run-4 seed-42 integration measurement, 2026-06-11)

With the shadow enabled, 6/9 pairs nominally converge coupled — but the artifact regresses hard:

| metric | committed (floor 20) | shadow enabled (run 4) |
|---|---|---|
| signal reach | 21/21 (hard-asserted by CI) | **16/21** |
| strict gate blocking | 20 | **49** |
| pour audit | PASS | **FAIL** (GND U2.F1 stranded) |

Failure modes, each now a triaged sub-issue:
- #3540 shadow tails leave goal pads stranded while claiming the net (USB3_RX1+/RX2+, USB2_D+ A6->B6)
- #3541 staggered shadow vias physically intersect the partner trace at tightly-coupled gaps (6b rips on USB2_D/RX1/RX2/PCIE_TX)
- #3542 greedy pre-phase corridors strand later singles the negotiated loop cannot rip (MIPI_D0-, USB_CC1) — includes the reach-safe "coupled upgrade-in-place" architecture proposal
- #3543 serpentine legal-space gaps (RX1/RX2 4.5mm skew) + exact-tolerance rounding (PCIE_RX 0.501 vs 0.500)
- #3544 58 post-route seg-seg violations across 10 nets (pre-phase copper invisible to the negotiated loop)

### Verification (run-8, seed 42, PYTHONHASHSEED=42, this branch)

- all 9 pairs defer deterministically (iteration budgets; 9 budget-exit diagnostics)
- `SUCCESS: all 21 signal nets routed`; `POUR CONNECTIVITY: PASS`
- strict-gate sidecar composition of the re-routed artifact: 9 `diffpair_length_skew` + 9 `diffpair_routing_continuity` + 2 `clearance_segment_via` = **20 blocking** + 2 advisory `connectivity` — identical to the committed floor-20 composition
- `tests/test_board_06_diffpair_test.py`: 39 passed; diff-pair battery: 252 passed, 1 xfailed

## Why #3508 stays open (intentionally not auto-closed)

The issue's AC is >= 6/9 *committed* coupled pairs with the skew/continuity block retired and 21/21 reach. The measurement shows nominal convergence without commit-quality geometry; per the builder decomposition protocol the remaining work is tracked in #3540-#3544 (#3542 is the architectural prerequisite). Refs #3508.

## Test plan

- [x] `tests/test_board_06_diffpair_test.py` (39) — committed artifact unchanged, pins hold
- [x] diff-pair battery (corridor/shadow/npad/phase-b/swap-via/timeout/aggregate/serpentine/length/engagement/grid-resync): 252 passed
- [x] seed-42 re-route on this branch: 21/21 reach, pour PASS, 20 blocking (floor band)
- [x] ruff: no new lint errors (pre-existing main errors untouched)
- [ ] CI `routed-pcb-drc-check` + diff-pair coverage gate (now genuinely gating per #3525)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
