### PR TITLE
feat(drc): clearance_segment_zone — traces vs foreign zone fills (closes #3527)

### DIFF
--- a/.github/routed-drc-tolerance.yml
+++ b/.github/routed-drc-tolerance.yml
@@ -496,7 +496,14 @@ tolerances:
   # TraceOptimizer otherwise re-introduces one ``clearance_segment_via``
   # at the XTAL cluster).  The committed routed PCB is now 13/13 routed
   # with ZERO blocking DRC errors at jlcpcb-tier1 -- tightened 5 -> 0.
-  boards/03-usb-joystick/output/usb_joystick_routed.kicad_pcb: 0
+  # Issue #3527 grandfather (June 11 2026): the new ``clearance_segment_zone``
+  # DRC rule (segments vs foreign-net zone *fill* copper -- stale-fill
+  # shorts that were previously invisible to every gate) fired 4
+  # finding(s) on this committed artifact.  All 4 are shorts (BTN3 vs GND B.Cu fill).
+  # Artifact fix tracked in #3551; remove/reduce this entry in the PR
+  # that re-routes the offenders or refreshes the fills.  Do NOT weaken
+  # the rule.
+  boards/03-usb-joystick/output/usb_joystick_routed.kicad_pcb: 4
 
   # Held at 31 by issue #2781's rect-pad fix.  Board 06 carries 3
   # legitimate ``clearance_pad_segment`` violations (diff-pair partner
@@ -888,7 +895,14 @@ tolerances:
   # artifact and this floor are UNCHANGED at 20, and the quality gaps
   # are tracked in #3540-#3544 (#3542, coupled upgrade-in-place, is
   # the reach-safe architecture that re-opens exit clause (a)).
-  boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb: 20
+  # Issue #3527 grandfather (June 11 2026): the new ``clearance_segment_zone``
+  # DRC rule (segments vs foreign-net zone *fill* copper -- stale-fill
+  # shorts that were previously invisible to every gate) fired 2
+  # finding(s) on this committed artifact.  Both are sub-minimum gaps (USB_CC1 vs GND In1.Cu fill); the 20 pre-existing errors are unchanged.
+  # Artifact fix tracked in #3554; remove/reduce this entry in the PR
+  # that re-routes the offenders or refreshes the fills.  Do NOT weaken
+  # the rule.
+  boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb: 22
 
   # Match-group regression testbench (Epic #2661 Phase 3L, #2724).
   # Held at 70 by issue #2781's rect-pad fix.  Two CI jobs measure
@@ -1507,7 +1521,50 @@ tolerances:
   # LQFP-48 corner cluster of #3267; U2.23 is newly blocked by the
   # recovered NRST B.Cu track, a deliberate signal-over-stitch
   # trade).  Floor stays 0.
-  boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb: 0
+  # Issue #3527 grandfather (June 11 2026): the new ``clearance_segment_zone``
+  # DRC rule (segments vs foreign-net zone *fill* copper -- stale-fill
+  # shorts that were previously invisible to every gate) fired 28
+  # finding(s) on this committed artifact.  24 shorts + 4 grazes vs the +3.3V F.Cu fill (OSC_IN/OSC_OUT/LED_K/GND stitch traces).
+  # Artifact fix tracked in #3552; remove/reduce this entry in the PR
+  # that re-routes the offenders or refreshes the fills.  Do NOT weaken
+  # the rule.
+  boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb: 28
+
+  # Issue #3527 grandfather (June 11 2026): the new ``clearance_segment_zone``
+  # DRC rule (segments vs foreign-net zone *fill* copper -- stale-fill
+  # shorts that were previously invisible to every gate) fired 4
+  # finding(s) on this committed artifact.  All 4 are shorts (VIN/VOUT vs GND F.Cu fill).
+  # Artifact fix tracked in #3549; remove/reduce this entry in the PR
+  # that re-routes the offenders or refreshes the fills.  Do NOT weaken
+  # the rule.
+  boards/01-voltage-divider/output/voltage_divider_routed.kicad_pcb: 4
+
+  # Issue #3527 grandfather (June 11 2026): the new ``clearance_segment_zone``
+  # DRC rule (segments vs foreign-net zone *fill* copper -- stale-fill
+  # shorts that were previously invisible to every gate) fired 11
+  # finding(s) on this committed artifact.  Shorts + grazes (NODE_B/NODE_C/LINE_A vs VCC F.Cu and GND B.Cu fills).
+  # Artifact fix tracked in #3550; remove/reduce this entry in the PR
+  # that re-routes the offenders or refreshes the fills.  Do NOT weaken
+  # the rule.
+  boards/02-charlieplex-led/output/charlieplex_3x3_routed.kicad_pcb: 11
+
+  # Issue #3527 grandfather (June 11 2026): the new ``clearance_segment_zone``
+  # DRC rule (segments vs foreign-net zone *fill* copper -- stale-fill
+  # shorts that were previously invisible to every gate) fired 10
+  # finding(s) on this committed artifact.  6 shorts + 4 grazes (SW_OUT/PWM_AL/PWM_BH/GATE_CL/SWDIO vs +24V/+3V3/GND fills).  The #3526 PWR_LED-vs-+3V3 short is FIXED and does not appear.
+  # Artifact fix tracked in #3553; remove/reduce this entry in the PR
+  # that re-routes the offenders or refreshes the fills.  Do NOT weaken
+  # the rule.
+  boards/05-bldc-motor-controller/output/bldc_controller_routed.kicad_pcb: 10
+
+  # Issue #3527 grandfather (June 11 2026): the new ``clearance_segment_zone``
+  # DRC rule (segments vs foreign-net zone *fill* copper -- stale-fill
+  # shorts that were previously invisible to every gate) fired 36
+  # finding(s) on this committed artifact.  29 shorts + 7 grazes (AC_NEUTRAL/V_AC_SENSE and others vs FUSED_LINE/VGATE fills).
+  # Artifact fix tracked in #3555; remove/reduce this entry in the PR
+  # that re-routes the offenders or refreshes the fills.  Do NOT weaken
+  # the rule.
+  boards/external/softstart/output/softstart_routed.kicad_pcb: 36
 
 # Per-board manufacturer overrides for the CI gate (optional).
 #

--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -134,6 +134,7 @@ def run_netlist_sync_gate(
 CHECK_CATEGORIES = [
     "clearance",
     "connectivity",
+    "segment_zone",
     "diffpair_clearance_intra",
     "diffpair_length_skew",
     "diffpair_routing_continuity",
@@ -525,6 +526,7 @@ def run_selected_checks(
     check_methods = {
         "clearance": checker.check_clearances,
         "connectivity": checker.check_connectivity,
+        "segment_zone": checker.check_segment_zone_clearances,
         "diffpair_clearance_intra": checker.check_diffpair_clearance_intra,
         "diffpair_length_skew": checker.check_diffpair_length_skew,
         "diffpair_routing_continuity": checker.check_diffpair_routing_continuity,

--- a/src/kicad_tools/drc/violation.py
+++ b/src/kicad_tools/drc/violation.py
@@ -44,6 +44,10 @@ def _init_type_category_map() -> None:
             ViolationType.CLEARANCE_PAD_SEGMENT: ViolationCategory.ROUTING,
             ViolationType.CLEARANCE_PAD_VIA: ViolationCategory.ROUTING,
             ViolationType.CLEARANCE_SEGMENT_SEGMENT: ViolationCategory.ROUTING,
+            # Segment vs foreign zone fill (Issue #3527): fixable by
+            # rerouting the trace (or refilling the stale zone) -- same
+            # routing-domain remediation as the other clearance subtypes.
+            ViolationType.CLEARANCE_SEGMENT_ZONE: ViolationCategory.ROUTING,
             ViolationType.CLEARANCE_VIA_VIA: ViolationCategory.ROUTING,
             # Differential-pair within-pair clearance (Issue #2560, Epic #2556 Phase 1D).
             # Same category as other clearance subtypes -- fixable by rerouting.
@@ -132,6 +136,10 @@ class ViolationType(Enum):
     CLEARANCE_PAD_VIA = "clearance_pad_via"
     CLEARANCE_PAD_PAD = "clearance_pad_pad"
     CLEARANCE_SEGMENT_SEGMENT = "clearance_segment_segment"
+    # Segment copper vs foreign-net zone *fill* copper (Issue #3527).
+    # Covers both hard shorts (overlap, negative actual_value) and
+    # sub-minimum gaps to committed filled_polygon geometry.
+    CLEARANCE_SEGMENT_ZONE = "clearance_segment_zone"
     CLEARANCE_VIA_VIA = "clearance_via_via"
     # Differential-pair within-pair clearance (Issue #2560, Epic #2556 Phase 1D).
     # Distinct from the generic CLEARANCE family because it validates the

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -1004,6 +1004,14 @@ class Zone:
     polygon: list[tuple[float, float]] = field(default_factory=list)
     # Filled polygon regions after DRC (may differ from boundary due to clearances)
     filled_polygons: list[list[tuple[float, float]]] = field(default_factory=list)
+    # Layer of each filled polygon, parallel to ``filled_polygons``.
+    # KiCad writes ``(filled_polygon (layer "F.Cu") (pts ...))`` per fill;
+    # multi-layer zones emit one filled_polygon per layer, so the zone-level
+    # ``layer`` field alone cannot locate fill copper.  Entries may be
+    # missing/empty for programmatically constructed zones -- use
+    # :meth:`filled_polygon_layer`, which falls back to the zone-level
+    # ``layer``.  See Issue #3527.
+    filled_polygon_layers: list[str] = field(default_factory=list)
     # Zone fill priority (higher priority fills later, on top of lower priority)
     priority: int = 0
     # Minimum copper thickness in mm
@@ -1109,8 +1117,24 @@ class Zone:
             points = cls._parse_polygon_pts(filled_poly)
             if points:
                 zone.filled_polygons.append(points)
+                fp_layer = ""
+                if fp_layer_node := filled_poly.find("layer"):
+                    fp_layer = fp_layer_node.get_string(0) or ""
+                zone.filled_polygon_layers.append(fp_layer or zone.layer)
 
         return zone
+
+    def filled_polygon_layer(self, index: int) -> str:
+        """Return the copper layer of ``filled_polygons[index]``.
+
+        Uses the per-fill ``(layer ...)`` value when it was parsed from the
+        S-expression and falls back to the zone-level ``layer`` for zones
+        constructed programmatically (whose ``filled_polygon_layers`` list
+        may be shorter than ``filled_polygons`` or contain empty strings).
+        """
+        if index < len(self.filled_polygon_layers) and self.filled_polygon_layers[index]:
+            return self.filled_polygon_layers[index]
+        return self.layer
 
     @staticmethod
     def _parse_polygon_pts(polygon_sexp: SExp) -> list[tuple[float, float]]:

--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 from kicad_tools.manufacturers import DesignRules, get_profile
 
-from .rules.clearance import ClearanceRule
+from .rules.clearance import ClearanceRule, SegmentZoneClearanceRule
 from .rules.connectivity import ConnectivityRule
 from .rules.diffpair_clearance_intra import DiffPairClearanceIntraRule
 from .rules.diffpair_length_skew import DiffPairLengthSkewRule
@@ -113,6 +113,7 @@ class DRCChecker:
     CHECK_ALL_METHODS: tuple[str, ...] = (
         "check_clearances",
         "check_connectivity",
+        "check_segment_zone_clearances",
         "check_diffpair_clearance_intra",
         "check_diffpair_length_skew",
         "check_diffpair_routing_continuity",
@@ -218,6 +219,26 @@ class DRCChecker:
             DRCResults containing clearance violations
         """
         rule = ClearanceRule()
+        return rule.check(self.pcb, self.design_rules)
+
+    def check_segment_zone_clearances(self) -> DRCResults:
+        """Check track segments against foreign-net zone fill copper.
+
+        Validates each segment against the committed ``filled_polygon``
+        geometry of zones on a *different* net and the same layer,
+        flagging both copper overlap (a hard short) and sub-clearance
+        gaps.  Closes the Issue #3527 gap: a trace routed straight
+        through a stale foreign fill was invisible to every other rule
+        (segment-vs-segment / segment-vs-pad / segment-vs-via spacing
+        never consult zone fills), so ``kct check`` certified boards
+        whose committed copper shorts two nets together (found by PR
+        #3526's judge on board 05: PWR_LED through +3V3 fill).
+
+        Returns:
+            DRCResults containing ``clearance_segment_zone`` violations
+            (severity error, blocking).
+        """
+        rule = SegmentZoneClearanceRule()
         return rule.check(self.pcb, self.design_rules)
 
     def check_connectivity(self) -> DRCResults:

--- a/src/kicad_tools/validate/rules/__init__.py
+++ b/src/kicad_tools/validate/rules/__init__.py
@@ -5,7 +5,7 @@ implementations for the pure Python DRC checker.
 """
 
 from .base import DRC_TOLERANCE, DRCRule
-from .clearance import ClearanceRule
+from .clearance import ClearanceRule, SegmentZoneClearanceRule
 from .diffpair_clearance_intra import DiffPairClearanceIntraRule
 from .diffpair_length_skew import DiffPairLengthSkewRule
 from .diffpair_routing_continuity import DiffPairRoutingContinuityRule
@@ -28,6 +28,7 @@ __all__ = [
     "DRC_TOLERANCE",
     "DRCRule",
     "ClearanceRule",
+    "SegmentZoneClearanceRule",
     "DiffPairClearanceIntraRule",
     "DiffPairLengthSkewRule",
     "DiffPairRoutingContinuityRule",

--- a/src/kicad_tools/validate/rules/clearance.py
+++ b/src/kicad_tools/validate/rules/clearance.py
@@ -738,3 +738,229 @@ class ClearanceRule(DRCRule):
             items=(elem1.reference, elem2.reference),
             nets=(elem1.net_name, elem2.net_name),
         )
+
+
+@dataclass
+class _ZoneFill:
+    """One filled polygon of a zone, resolved to a net and a layer."""
+
+    net_number: int
+    net_name: str
+    layer: str
+    polygon: object  # shapely (Multi)Polygon
+
+
+class SegmentZoneClearanceRule(DRCRule):
+    """Check track segments against foreign-net zone fill copper.
+
+    This repo's convention (issues #3482/#3523) treats committed
+    ``filled_polygon`` data as the copper source of truth for
+    connectivity analysis, so it must also be the source of truth for
+    clearance/short checks.  Before this rule, ``kct check`` validated
+    segment-vs-segment, segment-vs-pad, and segment-vs-via spacing but
+    never compared a segment to the *fill* copper of another net's zone
+    -- a trace routed straight through a stale foreign fill (a hard
+    manufacturing short) sailed through every gate.  PR #3526's judge
+    found exactly that on board 05: a PWR_LED segment crossing ~3.1 mm
+    of +3V3 fill with zero blocking violations reported.  See Issue
+    #3527.
+
+    Two violation flavours, both ``rule_id="clearance_segment_zone"``
+    and severity ``error`` (blocking):
+
+    - **Short**: the segment's copper overlaps the fill polygon
+      (edge-to-edge clearance < 0).  ``actual_value`` is the negative
+      overlap depth.
+    - **Clearance**: the copper gap is positive but below the
+      manufacturer's ``min_clearance_mm``.
+
+    Same-net segment/fill pairs are skipped (a trace inside its own
+    pour is legal and common).  Segments and zones on net 0 are
+    skipped, matching :class:`ClearanceRule` (no net identity -> no
+    foreign-net determination).
+
+    Performance: fill polygons are loaded into one shapely ``STRtree``
+    per layer; each segment only visits fills whose bounding box
+    intersects its inflated bbox, and all distance math is exact
+    shapely C geometry (no centerline sampling), so the rule is safe
+    to run inside CI gates on large boards.
+    """
+
+    rule_id = "clearance_segment_zone"
+    name = "Segment to Zone Fill Clearance"
+    description = "Validates track segments against foreign-net zone fill copper"
+
+    def check(
+        self,
+        pcb: PCB,
+        design_rules: DesignRules,
+    ) -> DRCResults:
+        """Check all segments against foreign-net zone fills.
+
+        Args:
+            pcb: The PCB to check
+            design_rules: Design rules from the manufacturer profile
+
+        Returns:
+            DRCResults containing segment-vs-zone-fill shorts and
+            clearance violations
+        """
+        results = DRCResults()
+        results.rules_checked = 1
+
+        fills_by_layer = self._collect_fills(pcb)
+        if not fills_by_layer:
+            return results
+
+        import shapely
+        from shapely import STRtree
+        from shapely.geometry import LineString
+
+        min_clearance = design_rules.min_clearance_mm
+
+        for layer, fills in fills_by_layer.items():
+            tree = STRtree([f.polygon for f in fills])
+            for seg in pcb.segments_on_layer(layer):
+                if seg.net_number == 0:
+                    continue
+                half_w = seg.width / 2.0
+                line = LineString([seg.start, seg.end])
+                # Inflate the segment bbox by everything that could
+                # matter: its own half-width plus the required gap.
+                margin = half_w + min_clearance
+                minx, miny, maxx, maxy = line.bounds
+                query_box = shapely.box(minx - margin, miny - margin, maxx + margin, maxy + margin)
+                for idx in tree.query(query_box):
+                    fill = fills[int(idx)]
+                    if fill.net_number == seg.net_number:
+                        continue
+                    violation = self._check_pair(seg, line, half_w, fill, min_clearance, layer)
+                    if violation is not None:
+                        results.add(violation)
+
+        return results
+
+    def _collect_fills(self, pcb: PCB) -> dict[str, list[_ZoneFill]]:
+        """Group zone fill polygons by copper layer, resolving zone nets.
+
+        Zones whose net cannot be resolved to a nonzero net number are
+        skipped (keepout/rule areas have no fills anyway; a zone with
+        no net has no foreign-net relationship to enforce).
+        """
+        from shapely.geometry import Polygon
+
+        name_to_number = {net.name: net.number for net in pcb.nets.values() if net.name}
+        number_to_name = {net.number: net.name for net in pcb.nets.values()}
+
+        fills_by_layer: dict[str, list[_ZoneFill]] = {}
+        for zone in pcb.zones:
+            net_number = zone.net_number
+            if net_number == 0 and zone.net_name:
+                # KiCad 9 name-only ``(net "X")`` format -- resolve by name.
+                net_number = name_to_number.get(zone.net_name, 0)
+            if net_number == 0:
+                continue
+            net_name = zone.net_name or number_to_name.get(net_number, "")
+            for i, points in enumerate(zone.filled_polygons):
+                if len(points) < 3:
+                    continue
+                poly = Polygon(points)
+                if not poly.is_valid:
+                    # Stale fills can carry self-touching outlines
+                    # (KiCad traces knockout holes through the exterior
+                    # ring).  buffer(0) re-nodes to equivalent copper.
+                    poly = poly.buffer(0)
+                if poly.is_empty:
+                    continue
+                layer = zone.filled_polygon_layer(i)
+                if not layer:
+                    continue
+                fills_by_layer.setdefault(layer, []).append(
+                    _ZoneFill(
+                        net_number=net_number,
+                        net_name=net_name,
+                        layer=layer,
+                        polygon=poly,
+                    )
+                )
+        return fills_by_layer
+
+    def _check_pair(
+        self,
+        seg: Segment,
+        line: object,
+        half_w: float,
+        fill: _ZoneFill,
+        min_clearance: float,
+        layer: str,
+    ) -> DRCViolation | None:
+        """Check one segment against one foreign fill polygon."""
+        from shapely.ops import nearest_points
+
+        poly = fill.polygon
+        centerline_dist = line.distance(poly)  # type: ignore[attr-defined]
+        seg_net = seg.net_name if seg.net_number != 0 else ""
+        seg_ref = f"Trace-{seg.uuid[:8]}" if seg.uuid else "Trace"
+        zone_ref = f"ZoneFill-{fill.net_name}" if fill.net_name else "ZoneFill"
+
+        if centerline_dist == 0.0:
+            # Centerline touches or enters the fill copper: hard short.
+            # Depth = how far inside the fill the overlap's representative
+            # point sits, plus the trace half-width.
+            intersection = line.intersection(poly)  # type: ignore[attr-defined]
+            if intersection.is_empty:
+                # Grazing contact with no overlap length -- still a
+                # zero-clearance touch.
+                rep = nearest_points(line, poly)[0]
+                depth = 0.0
+            else:
+                rep = intersection.representative_point()
+                depth = poly.boundary.distance(rep)  # type: ignore[attr-defined]
+            clearance = -(depth + half_w)
+            return DRCViolation(
+                rule_id=self.rule_id,
+                severity="error",
+                message=(
+                    f"Short: segment on net '{seg_net}' overlaps zone fill of net "
+                    f"'{fill.net_name}' on {layer} (overlap depth "
+                    f"{depth + half_w:.3f}mm)"
+                ),
+                location=(round(rep.x, 3), round(rep.y, 3)),
+                layer=layer,
+                actual_value=round(clearance, 4),
+                required_value=min_clearance,
+                items=(seg_ref, zone_ref),
+                nets=(seg_net, fill.net_name),
+            )
+
+        clearance = centerline_dist - half_w
+        if clearance + DRC_TOLERANCE >= min_clearance:
+            return None
+
+        p_line, p_poly = nearest_points(line, poly)
+        loc_x = (p_line.x + p_poly.x) / 2.0
+        loc_y = (p_line.y + p_poly.y) / 2.0
+        if clearance < 0:
+            # Centerline outside the fill but the trace copper (width)
+            # overlaps the fill edge: still a short.
+            message = (
+                f"Short: segment on net '{seg_net}' copper overlaps zone fill of "
+                f"net '{fill.net_name}' on {layer} by {-clearance:.3f}mm"
+            )
+        else:
+            message = (
+                f"Segment to zone fill clearance {clearance:.3f}mm < minimum "
+                f"{min_clearance:.3f}mm (net '{seg_net}' vs zone net "
+                f"'{fill.net_name}')"
+            )
+        return DRCViolation(
+            rule_id=self.rule_id,
+            severity="error",
+            message=message,
+            location=(round(loc_x, 3), round(loc_y, 3)),
+            layer=layer,
+            actual_value=round(clearance, 4),
+            required_value=min_clearance,
+            items=(seg_ref, zone_ref),
+            nets=(seg_net, fill.net_name),
+        )

--- a/tests/router/test_board03_routing_baseline.py
+++ b/tests/router/test_board03_routing_baseline.py
@@ -240,9 +240,19 @@ EXPECTED_TOTAL_NETS = 13
 # The only BY-RULE entries are silkscreen_text_height WARNINGS (0402
 # value text on the demo passives); the breakdown parser below sees
 # warnings too, so the rule allowlist names it explicitly.
-MAX_COMMITTED_DRC_ERRORS = 0
+# Issue #3527 (June 11 2026): the new ``clearance_segment_zone`` rule
+# (segments vs foreign-net zone *fill* copper) surfaced 4 pre-existing
+# stale-fill shorts in the committed artifact (BTN3 vs the GND B.Cu
+# fill).  These were always in the copper -- the gate simply could not
+# see them before the rule existed.  Artifact fix tracked in Issue
+# #3551; when it lands, restore the ceiling to 0 and drop the rule from
+# the allowlist set below.  The ceiling is EXACT-count grandfathering
+# (mirrors .github/routed-drc-tolerance.yml) so any further regression
+# still trips.
+MAX_COMMITTED_DRC_ERRORS = 4
 EXPECTED_COMMITTED_DRC_RULES = {
     "silkscreen_text_height",
+    "clearance_segment_zone",
 }
 
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1292,8 +1292,12 @@ class TestZoneConnectedNets:
     (pad "2" smd roundrect (at 0.5 0) (size 0.6 0.6)
       (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 2 "+3V3"))
   )
-  (segment (start 30.5 50) (end 70.5 50) (width 0.25) (layer "F.Cu") (net 2)
+  (segment (start 30.5 50) (end 30.5 40) (width 0.25) (layer "F.Cu") (net 2)
     (uuid "seg1"))
+  (segment (start 30.5 40) (end 70.5 40) (width 0.25) (layer "F.Cu") (net 2)
+    (uuid "seg1b"))
+  (segment (start 70.5 40) (end 70.5 50) (width 0.25) (layer "F.Cu") (net 2)
+    (uuid "seg1c"))
   (zone (net 1) (net_name "GND") (layer "F.Cu")
     (uuid "zone1")
     (connect_pads (clearance 0.5))
@@ -1303,11 +1307,22 @@ class TestZoneConnectedNets:
       (xy 0 0) (xy 100 0) (xy 100 100) (xy 0 100)
     ))
     (filled_polygon (layer "F.Cu") (pts
-      (xy 1 1) (xy 99 1) (xy 99 99) (xy 1 99)
+      (xy 1 55) (xy 29.2 55) (xy 29.2 49.7) (xy 29.8 49.7) (xy 29.8 55)
+      (xy 69.2 55) (xy 69.2 49.7) (xy 69.8 49.7) (xy 69.8 55) (xy 99 55)
+      (xy 99 99) (xy 1 99)
     ))
   )
 )
 """
+    # NOTE on PCB_WITH_ZONE copper: the GND filled_polygon is a bottom
+    # slab with two fingers reaching the GND pads (R1.1 / R2.1) and the
+    # +3V3 trace doglegs through y=40 to stay clear of the fill.  The
+    # original whole-board fill put the foreign +3V3 trace inside GND
+    # fill copper, which the ``clearance_segment_zone`` rule (Issue
+    # #3527) correctly reports as a blocking short -- escalating the
+    # zone-fill advisory this fixture pins to priority 1.  The fixture's
+    # purpose is the zone-connectivity advisory, so the copper must be
+    # short-free.
 
     # PCB with both zone-connected and truly-incomplete nets.
     # GND (net 1) has a zone, SIG (net 3) has no zone and no trace.
@@ -1374,11 +1389,23 @@ class TestZoneConnectedNets:
       (xy 0 0) (xy 100 0) (xy 100 100) (xy 0 100)
     ))
     (filled_polygon (layer "F.Cu") (pts
-      (xy 1 1) (xy 99 1) (xy 99 99) (xy 1 99)
+      (xy 1 55) (xy 29.2 55) (xy 29.2 49.7) (xy 29.8 49.7) (xy 29.8 55)
+      (xy 69.2 55) (xy 69.2 49.7) (xy 69.8 49.7) (xy 69.8 55) (xy 99 55)
+      (xy 99 99) (xy 1 99)
     ))
   )
 )
 """
+    # NOTE on the filled_polygon shape above: it is a bottom slab with two
+    # fingers reaching up to the GND pads (R1.1 at (29.5, 50), R2.1 at
+    # (69.5, 50)) so the zone still classifies both pads as
+    # zone-connected.  It deliberately AVOIDS the +3V3 trace seg1
+    # ((30.5, 50) -> (49.5, 30)): the original whole-board fill put that
+    # foreign-net trace inside the GND fill copper, which the
+    # ``clearance_segment_zone`` rule (Issue #3527) correctly reports as
+    # a blocking short -- flipping the audit verdict this fixture pins to
+    # NOT_READY for an unrelated reason.  The fixture's purpose is the
+    # zone-connectivity advisory, so the copper must be short-free.
 
     # PCB with no zones — incomplete signal nets should still be flagged normally.
     #

--- a/tests/test_board_01_ship_ready.py
+++ b/tests/test_board_01_ship_ready.py
@@ -62,9 +62,7 @@ def test_board_01_schematic_pcb_net_sets_match() -> None:
     )
 
     # Lock in the expected canonical names so future renames are visible.
-    assert sch_nets == {"VIN", "VOUT", "GND"}, (
-        f"Unexpected schematic net set: {sorted(sch_nets)}"
-    )
+    assert sch_nets == {"VIN", "VOUT", "GND"}, f"Unexpected schematic net set: {sorted(sch_nets)}"
 
 
 def test_board_01_bom_excludes_synthesized_power_symbol() -> None:
@@ -77,14 +75,10 @@ def test_board_01_bom_excludes_synthesized_power_symbol() -> None:
 
     designators = [r.get("Designator", "") for r in rows]
     flat = ",".join(designators)
-    assert "#PWR" not in flat, (
-        f"Power symbol leaked into BOM CSV: designators={designators}"
-    )
+    assert "#PWR" not in flat, f"Power symbol leaked into BOM CSV: designators={designators}"
     # Must have exactly the four real components (R1+R2 grouped).
     refs = sorted(d.strip() for r in designators for d in r.split(","))
-    assert refs == ["J1", "J2", "R1", "R2"], (
-        f"Unexpected BOM designators: {refs}"
-    )
+    assert refs == ["J1", "J2", "R1", "R2"], f"Unexpected BOM designators: {refs}"
 
 
 def test_board_01_bom_formatter_skips_virtual_items() -> None:
@@ -115,9 +109,7 @@ def test_board_01_bom_formatter_skips_virtual_items() -> None:
     kept = formatter.filter_items([real, stock_power, synth_power])
     kept_refs = {item.reference for item in kept}
 
-    assert kept_refs == {"R1"}, (
-        f"Expected only R1 to survive filter, got {kept_refs}"
-    )
+    assert kept_refs == {"R1"}, f"Expected only R1 to survive filter, got {kept_refs}"
 
 
 def test_board_01_drc_clean_with_jlcpcb_rules() -> None:
@@ -141,17 +133,31 @@ def test_board_01_drc_clean_with_jlcpcb_rules() -> None:
         only_set=None,
         skip_set=set(),
     )
-    error_count = sum(1 for v in results.violations if v.is_error)
+    # Issue #3527 (June 11 2026): the new ``clearance_segment_zone``
+    # rule surfaced 4 pre-existing stale-fill shorts in the committed
+    # artifact (VIN/VOUT vs the GND F.Cu fill).  They were always in the
+    # copper; the artifact fix is tracked in Issue #3549 and the same
+    # count is grandfathered in .github/routed-drc-tolerance.yml.  This
+    # test pins the grandfathered findings EXACTLY (rule + count) so any
+    # other error class -- or a 5th segment-zone finding -- still fails.
+    grandfathered = [
+        v for v in results.violations if v.is_error and v.rule_id == "clearance_segment_zone"
+    ]
+    assert len(grandfathered) == 4, (
+        f"Expected exactly 4 grandfathered clearance_segment_zone errors "
+        f"(Issue #3549), got {len(grandfathered)}: "
+        f"{[v.message for v in grandfathered][:6]}"
+    )
+
+    error_count = sum(
+        1 for v in results.violations if v.is_error and v.rule_id != "clearance_segment_zone"
+    )
     warn_count = sum(1 for v in results.violations if v.is_warning)
 
     sample = [
         f"{v.rule_id}: {v.message}"
         for v in results.violations
-        if v.is_error or v.is_warning
+        if (v.is_error and v.rule_id != "clearance_segment_zone") or v.is_warning
     ][:5]
-    assert error_count == 0, (
-        f"Expected 0 DRC errors, got {error_count}; sample={sample}"
-    )
-    assert warn_count == 0, (
-        f"Expected 0 DRC warnings, got {warn_count}; sample={sample}"
-    )
+    assert error_count == 0, f"Expected 0 DRC errors, got {error_count}; sample={sample}"
+    assert warn_count == 0, f"Expected 0 DRC warnings, got {warn_count}; sample={sample}"

--- a/tests/test_board_05_drc_allowlist.py
+++ b/tests/test_board_05_drc_allowlist.py
@@ -73,9 +73,23 @@ def routed_pcb_path() -> Path:
     return ROUTED_PCB
 
 
+# Issue #3527 (2026-06-11): the new ``clearance_segment_zone`` DRC rule
+# (segments vs foreign-net zone *fill* copper) revealed 10 pre-existing
+# stale-fill defects in board 05's committed artifact (6 shorts + 4
+# sub-clearance grazes: SW_OUT/PWM_AL/PWM_BH/GATE_CL/SWDIO vs the
+# +24V/+3V3/GND fills).  These are NOT a routing regression introduced by
+# a code change -- they were always in the copper; the gate simply could
+# not see them before the rule existed.  The artifact fix (re-route /
+# refill) is tracked in Issue #3553; the allowlist entry was re-added at
+# exactly this value so any FURTHER regression still trips the gate.
+# When #3553 lands, remove the entry (restoring the #3470 strict-0 gate)
+# and set this constant back to ``None``.
+BOARD_05_EXPECTED_TOLERANCE: int | None = 10
+
+
 @pytest.fixture(scope="module")
 def board_05_allowlist_value() -> int:
-    """Resolve board 05's effective allowlist value (Issue #3470: 0).
+    """Resolve board 05's effective allowlist value.
 
     Issue #3470 (2026-06-10) removed the board-05 ``tolerances:`` entry
     from ``.github/routed-drc-tolerance.yml`` -- per the file's policy
@@ -85,10 +99,13 @@ def board_05_allowlist_value() -> int:
     conflict-aware in-pad escape stub direction (escape.py) plus the
     transactional rip-up rollback (negotiated.py ``targeted_ripup``).
 
-    This fixture now asserts the entry STAYS removed: re-adding a
-    board-05 tolerance is a loosening regression that requires explicit
-    reviewer sign-off per the allowlist policy, and this test makes it
-    loud.
+    Issue #3527 (2026-06-11) re-added a tolerance of 10 because the new
+    ``clearance_segment_zone`` rule surfaced 10 pre-existing stale-fill
+    defects in the committed artifact (tracked in Issue #3553 -- see
+    ``BOARD_05_EXPECTED_TOLERANCE`` above).  This fixture pins the entry
+    to EXACTLY that value: any other value (loosening beyond 10, or a
+    stale entry after #3553 fixes the artifact) fails loudly and requires
+    an explicit update to this test with reviewer sign-off.
     """
     if not ALLOWLIST_PATH.exists():
         pytest.skip(f"Allowlist file not found at {ALLOWLIST_PATH!s}")
@@ -101,19 +118,20 @@ def board_05_allowlist_value() -> int:
         )
 
     tolerances = data["tolerances"]
-    if BOARD_05_ALLOWLIST_KEY in tolerances:
+    actual = tolerances.get(BOARD_05_ALLOWLIST_KEY)
+    if actual != BOARD_05_EXPECTED_TOLERANCE:
         pytest.fail(
-            f"Board 05 entry {BOARD_05_ALLOWLIST_KEY!r} reappeared in "
-            f"allowlist {ALLOWLIST_PATH!s} with value "
-            f"{tolerances[BOARD_05_ALLOWLIST_KEY]!r}.  Issue #3470 removed "
-            f"the entry (strict 0-blocking gate) after fixing the ISENSE "
-            f"stub-overlap at the source; re-adding a tolerance is a "
-            f"loosening regression that needs reviewer sign-off AND an "
-            f"update to this test."
+            f"Board 05 allowlist entry {BOARD_05_ALLOWLIST_KEY!r} is "
+            f"{actual!r} but this test pins "
+            f"{BOARD_05_EXPECTED_TOLERANCE!r} (None = entry absent).  "
+            f"Changing the board-05 tolerance requires reviewer sign-off "
+            f"AND an update to ``BOARD_05_EXPECTED_TOLERANCE`` in this "
+            f"test with a tracking-issue link (see Issues #3470/#3527/"
+            f"#3553 for the history)."
         )
 
     # Absence of the entry = strict 0-blocking-error gate.
-    return 0
+    return 0 if actual is None else actual
 
 
 def _run_kct_check(pcb_path: Path) -> int:

--- a/tests/test_board_06_diffpair_test.py
+++ b/tests/test_board_06_diffpair_test.py
@@ -748,9 +748,15 @@ class TestBoard06StrictGateGuard:
     state and never introduce the overlap (the recipe's 6b solo
     re-route repair reports "No physically-overlapping pair sides
     detected").  33 -> 20.
+
+    Issue #3527 (2026-06-11): +2 ``clearance_segment_zone`` (the new
+    segment-vs-foreign-zone-fill rule surfaced two pre-existing USB_CC1
+    grazes against the GND In1.Cu fill at (14.397, 12.083) -- stale-fill
+    defects that were always in the committed copper, newly visible).
+    Artifact fix tracked in Issue #3554.  20 -> 22.
     """
 
-    EXPECTED_STRICT_GATE_ERRORS = 20
+    EXPECTED_STRICT_GATE_ERRORS = 22
     EXPECTED_ADVISORY_CONNECTIVITY = 2
 
     @pytest.fixture(scope="class")

--- a/tests/test_ci_routed_drc_workflow.py
+++ b/tests/test_ci_routed_drc_workflow.py
@@ -177,10 +177,15 @@ class TestAllowlist:
     def test_allowlist_paths_match_routed_pattern(self, allowlist_data: dict) -> None:
         """Every key in the allowlist must be a repo-relative path to a
         routed PCB. Catches typos like a stray space, a wrong board number,
-        or accidentally listing the unrouted PCB."""
+        or accidentally listing the unrouted PCB.
+
+        The board directory may be nested (e.g.
+        ``boards/external/softstart/output/softstart_routed.kicad_pcb``,
+        grandfathered by Issue #3527), so the pattern allows one or more
+        path components between ``boards/`` and ``output/``."""
         import re
 
-        pattern = re.compile(r"^boards/[^/]+/output/[^/]+_routed\.kicad_pcb$")
+        pattern = re.compile(r"^boards/(?:[^/]+/)+output/[^/]+_routed\.kicad_pcb$")
         for key in allowlist_data["tolerances"]:
             assert pattern.match(key), (
                 f"Allowlist key {key!r} does not match the expected pattern "

--- a/tests/test_validate_segment_zone_clearance.py
+++ b/tests/test_validate_segment_zone_clearance.py
@@ -1,0 +1,314 @@
+"""Tests for the segment-vs-foreign-zone-fill DRC rule (Issue #3527).
+
+A trace routed through another net's committed ``filled_polygon`` copper
+is a hard manufacturing short, but before ``SegmentZoneClearanceRule``
+no rule in ``kct check`` compared segments to zone fill geometry (PR
+#3526's judge found a PWR_LED trace crossing ~3.1 mm of +3V3 fill on
+board 05 with zero blocking violations reported).
+
+Covers the four acceptance scenarios from the issue:
+
+1. Synthetic short (trace centerline inside a foreign fill)
+2. Clearance graze (positive gap below the manufacturer minimum)
+3. Same-net pass-through (legal -- a trace inside its own pour)
+4. Knocked-out fill (legal -- the fill has a corridor with adequate gap)
+
+plus schema-level tests for the new per-fill layer tracking on
+:class:`~kicad_tools.schema.pcb.Zone`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from unittest.mock import MagicMock
+
+from kicad_tools.schema.pcb import Zone
+from kicad_tools.sexp import parse_string
+from kicad_tools.validate.rules.clearance import SegmentZoneClearanceRule
+
+# ---------------------------------------------------------------------------
+# Minimal stubs mirroring the fields the rule reads
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeNet:
+    number: int
+    name: str
+
+
+@dataclass
+class _FakeSegment:
+    start: tuple[float, float]
+    end: tuple[float, float]
+    width: float = 0.2
+    layer: str = "F.Cu"
+    net_number: int = 1
+    net_name: str = "SIG"
+    uuid: str = "deadbeef-0000"
+
+
+@dataclass
+class _FakeZone:
+    net_number: int = 2
+    net_name: str = "+3V3"
+    layer: str = "F.Cu"
+    filled_polygons: list[list[tuple[float, float]]] = field(default_factory=list)
+    filled_polygon_layers: list[str] = field(default_factory=list)
+
+    def filled_polygon_layer(self, index: int) -> str:
+        if index < len(self.filled_polygon_layers) and self.filled_polygon_layers[index]:
+            return self.filled_polygon_layers[index]
+        return self.layer
+
+
+def _make_pcb(zones, segments, nets):
+    pcb = MagicMock()
+    pcb.zones = zones
+    pcb.nets = {n.number: n for n in nets}
+    pcb.segments_on_layer = lambda layer: iter([s for s in segments if s.layer == layer])
+    return pcb
+
+
+def _make_design_rules(min_clearance: float = 0.127):
+    rules = MagicMock()
+    rules.min_clearance_mm = min_clearance
+    return rules
+
+
+# A 10x10 mm square fill on net 2 (+3V3) at (100,100)..(110,110)
+_SQUARE_FILL = [(100.0, 100.0), (110.0, 100.0), (110.0, 110.0), (100.0, 110.0)]
+
+_NETS = [_FakeNet(1, "SIG"), _FakeNet(2, "+3V3")]
+
+
+def _run(zones, segments, min_clearance=0.127):
+    pcb = _make_pcb(zones, segments, _NETS)
+    rule = SegmentZoneClearanceRule()
+    return rule.check(pcb, _make_design_rules(min_clearance))
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1: hard short -- trace centerline inside a foreign fill
+# ---------------------------------------------------------------------------
+
+
+class TestShortDetection:
+    def test_trace_through_foreign_fill_is_short(self):
+        zone = _FakeZone(filled_polygons=[_SQUARE_FILL])
+        seg = _FakeSegment(start=(95.0, 105.0), end=(115.0, 105.0))
+        results = _run([zone], [seg])
+
+        shorts = [v for v in results.violations if v.rule_id == "clearance_segment_zone"]
+        assert len(shorts) == 1
+        v = shorts[0]
+        assert v.severity == "error"
+        assert "Short" in v.message
+        # Negative actual value = overlap depth (centerline runs through
+        # the middle of the fill, so depth is substantial).
+        assert v.actual_value is not None and v.actual_value < 0
+        assert v.nets == ("SIG", "+3V3")
+        assert v.layer == "F.Cu"
+
+    def test_trace_fully_inside_foreign_fill_is_short(self):
+        """Board 05 regression shape: segment entirely within the fill."""
+        zone = _FakeZone(filled_polygons=[_SQUARE_FILL])
+        seg = _FakeSegment(start=(102.0, 105.0), end=(108.0, 105.0))
+        results = _run([zone], [seg])
+
+        assert len(results.violations) == 1
+        v = results.violations[0]
+        assert "Short" in v.message
+        # Depth >= distance to nearest edge (2mm) -- definitely < -1.
+        assert v.actual_value < -1.0
+
+    def test_copper_edge_overlap_without_centerline_inside_is_short(self):
+        """Centerline outside the fill but trace width overlaps the edge."""
+        # Centerline 0.05mm left of the fill edge; half-width 0.1mm.
+        zone = _FakeZone(filled_polygons=[_SQUARE_FILL])
+        seg = _FakeSegment(start=(99.95, 102.0), end=(99.95, 108.0), width=0.2)
+        results = _run([zone], [seg])
+
+        assert len(results.violations) == 1
+        v = results.violations[0]
+        assert "Short" in v.message
+        assert v.actual_value < 0
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2: clearance graze (gap > 0 but < minimum)
+# ---------------------------------------------------------------------------
+
+
+class TestClearanceGraze:
+    def test_sub_minimum_gap_is_flagged(self):
+        zone = _FakeZone(filled_polygons=[_SQUARE_FILL])
+        # Centerline 0.15mm left of the fill edge; half-width 0.1mm
+        # -> copper gap 0.05mm < 0.127mm minimum.
+        seg = _FakeSegment(start=(99.85, 102.0), end=(99.85, 108.0), width=0.2)
+        results = _run([zone], [seg])
+
+        assert len(results.violations) == 1
+        v = results.violations[0]
+        assert v.severity == "error"
+        assert "Short" not in v.message
+        assert abs(v.actual_value - 0.05) < 1e-6
+        assert v.required_value == 0.127
+
+    def test_adequate_gap_passes(self):
+        zone = _FakeZone(filled_polygons=[_SQUARE_FILL])
+        # Centerline 0.30mm left of the fill edge -> copper gap 0.20mm.
+        seg = _FakeSegment(start=(99.70, 102.0), end=(99.70, 108.0), width=0.2)
+        results = _run([zone], [seg])
+        assert results.violations == []
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3: same-net pass-through is legal
+# ---------------------------------------------------------------------------
+
+
+class TestSameNet:
+    def test_trace_through_own_pour_passes(self):
+        zone = _FakeZone(net_number=1, net_name="SIG", filled_polygons=[_SQUARE_FILL])
+        seg = _FakeSegment(start=(95.0, 105.0), end=(115.0, 105.0))
+        results = _run([zone], [seg])
+        assert results.violations == []
+
+    def test_net0_segment_skipped(self):
+        zone = _FakeZone(filled_polygons=[_SQUARE_FILL])
+        seg = _FakeSegment(start=(95.0, 105.0), end=(115.0, 105.0), net_number=0)
+        results = _run([zone], [seg])
+        assert results.violations == []
+
+    def test_net0_unnamed_zone_skipped(self):
+        zone = _FakeZone(net_number=0, net_name="", filled_polygons=[_SQUARE_FILL])
+        seg = _FakeSegment(start=(95.0, 105.0), end=(115.0, 105.0))
+        results = _run([zone], [seg])
+        assert results.violations == []
+
+    def test_name_only_zone_net_resolved(self):
+        """KiCad 9 name-only zone net resolves through the net table."""
+        zone = _FakeZone(net_number=0, net_name="SIG", filled_polygons=[_SQUARE_FILL])
+        seg = _FakeSegment(start=(95.0, 105.0), end=(115.0, 105.0))
+        # Same net after resolution -> legal.
+        results = _run([zone], [seg])
+        assert results.violations == []
+
+
+# ---------------------------------------------------------------------------
+# Scenario 4: knocked-out fill (corridor with adequate gap) is legal
+# ---------------------------------------------------------------------------
+
+
+class TestKnockedOutFill:
+    def test_fill_with_corridor_around_trace_passes(self):
+        """A properly refilled zone leaves a knockout around the trace.
+
+        The fill outline traces a 0.6mm-wide corridor around a vertical
+        trace at x=105 (0.2mm wide trace + 0.2mm gap each side), the way
+        KiCad's filler knocks out foreign copper through the exterior
+        ring.
+        """
+        corridor_fill = [
+            (100.0, 100.0),
+            (110.0, 100.0),
+            (110.0, 110.0),
+            (105.3, 110.0),
+            (105.3, 100.5),  # corridor right wall (trace edge + 0.2 gap)
+            (104.7, 100.5),  # corridor left wall
+            (104.7, 110.0),
+            (100.0, 110.0),
+        ]
+        zone = _FakeZone(filled_polygons=[corridor_fill])
+        # Vertical trace down the corridor, 0.2mm wide -> copper edges at
+        # x = 104.9 / 105.1; gap to fill walls = 0.2mm >= 0.127mm.
+        seg = _FakeSegment(start=(105.0, 101.0), end=(105.0, 109.0), width=0.2)
+        results = _run([zone], [seg])
+        assert results.violations == []
+
+    def test_fill_with_too_tight_corridor_flagged(self):
+        """Same corridor shape but only 0.05mm of gap -> violation."""
+        corridor_fill = [
+            (100.0, 100.0),
+            (110.0, 100.0),
+            (110.0, 110.0),
+            (105.15, 110.0),
+            (105.15, 100.5),
+            (104.85, 100.5),
+            (104.85, 110.0),
+            (100.0, 110.0),
+        ]
+        zone = _FakeZone(filled_polygons=[corridor_fill])
+        seg = _FakeSegment(start=(105.0, 101.0), end=(105.0, 109.0), width=0.2)
+        results = _run([zone], [seg])
+        assert len(results.violations) == 1
+        v = results.violations[0]
+        assert "Short" not in v.message
+        assert 0 < v.actual_value < 0.127
+
+
+# ---------------------------------------------------------------------------
+# Layer discipline
+# ---------------------------------------------------------------------------
+
+
+class TestLayers:
+    def test_fill_on_other_layer_ignored(self):
+        zone = _FakeZone(
+            filled_polygons=[_SQUARE_FILL],
+            filled_polygon_layers=["B.Cu"],
+        )
+        seg = _FakeSegment(start=(95.0, 105.0), end=(115.0, 105.0), layer="F.Cu")
+        results = _run([zone], [seg])
+        assert results.violations == []
+
+    def test_multilayer_zone_uses_per_fill_layer(self):
+        """Multi-layer zone: only the B.Cu fill collides with a B.Cu trace."""
+        zone = _FakeZone(
+            layer="",  # multi-layer zones have no single zone-level layer
+            filled_polygons=[_SQUARE_FILL, _SQUARE_FILL],
+            filled_polygon_layers=["F.Cu", "B.Cu"],
+        )
+        seg = _FakeSegment(start=(95.0, 105.0), end=(115.0, 105.0), layer="B.Cu")
+        results = _run([zone], [seg])
+        assert len(results.violations) == 1
+        assert results.violations[0].layer == "B.Cu"
+
+
+# ---------------------------------------------------------------------------
+# Zone schema: per-fill layer parsing (Issue #3527 schema change)
+# ---------------------------------------------------------------------------
+
+
+_ZONE_SEXP = """
+(zone
+  (net 2)
+  (net_name "+3V3")
+  (layer "F.Cu")
+  (uuid "11111111-2222-3333-4444-555555555555")
+  (fill yes)
+  (polygon (pts (xy 100 100) (xy 110 100) (xy 110 110) (xy 100 110)))
+  (filled_polygon
+    (layer "F.Cu")
+    (pts (xy 100 100) (xy 110 100) (xy 110 110) (xy 100 110)))
+  (filled_polygon
+    (layer "B.Cu")
+    (pts (xy 100 100) (xy 110 100) (xy 110 110) (xy 100 110)))
+)
+"""
+
+
+class TestZoneSchemaFillLayers:
+    def test_filled_polygon_layers_parsed(self):
+        zone = Zone.from_sexp(parse_string(_ZONE_SEXP))
+        assert len(zone.filled_polygons) == 2
+        assert zone.filled_polygon_layers == ["F.Cu", "B.Cu"]
+        assert zone.filled_polygon_layer(0) == "F.Cu"
+        assert zone.filled_polygon_layer(1) == "B.Cu"
+
+    def test_fallback_to_zone_layer_for_programmatic_zones(self):
+        zone = Zone(net_number=1, net_name="GND", layer="In1.Cu")
+        zone.filled_polygons.append(_SQUARE_FILL)
+        # No filled_polygon_layers entry -> falls back to zone.layer
+        assert zone.filled_polygon_layer(0) == "In1.Cu"


### PR DESCRIPTION
Closes #3527

## Summary

- **New blocking DRC rule `clearance_segment_zone`** (`SegmentZoneClearanceRule` in `src/kicad_tools/validate/rules/clearance.py`): every track segment is checked against the committed `filled_polygon` copper of zones on a **different net** and the same layer. Reports hard shorts (copper overlap, negative `actual_value` = overlap depth) and sub-minimum clearance grazes (positive gap < profile `min_clearance_mm`). This closes the gap PR #3526's judge found: a PWR_LED trace running ~3.1mm through +3V3 fill copper with every gate green.
- **Exact geometry, CI-gate-safe performance**: shapely `STRtree` per layer + `LineString.distance` / `intersection` (no centerline sampling, unlike the reference script). Invalid stale-fill rings are re-noded via `buffer(0)`. Measured **~200ms** on the largest committed board (softstart: 4,723 segments, 69 fills); 2–30ms on boards 01–07.
- **Schema**: `Zone.filled_polygon_layers` (parallel to `filled_polygons`, parsed from each `(filled_polygon (layer ...))`) + `Zone.filled_polygon_layer(i)` accessor with fallback to `zone.layer` — multi-layer zones place fills on several layers, so the zone-level layer alone cannot locate fill copper.
- **Wiring**: `DRCChecker.check_segment_zone_clearances` + `CHECK_ALL_METHODS`, CLI category `segment_zone` (`CHECK_CATEGORIES` + dispatcher dict, per the #3046 invariant), `ViolationType.CLEARANCE_SEGMENT_ZONE` (ROUTING category), rules `__init__` export. Severity is blocking (NOT in `ADVISORY_RULE_IDS`).

## Fleet scan (the #3487 protocol — run before pushing)

Cross-validated against the independent sampling script `scripts/check_trace_vs_zone_fills.py` (identical findings on board 04). All new blocking errors fleet-wide are `clearance_segment_zone`; baselines are otherwise unchanged.

| Board | Gate profile | Shorts | Grazes | New blocking | Rule time | Artifact-fix issue |
|---|---|---|---|---|---|---|
| 01-voltage-divider | jlcpcb | 4 | 0 | 4 | 2ms | #3549 |
| 02-charlieplex-led | jlcpcb | 5 | 4+ | 11 | 6ms | #3550 |
| 03-usb-joystick | jlcpcb-tier1 | 4 | 0 | 4 | 16ms | #3551 |
| 04-stm32-devboard | jlcpcb-tier1 | 24 | 4 | 28 | 8ms | #3552 |
| 05-bldc-motor-controller | jlcpcb-tier1 | 6 | 4 | 10 | 22ms | #3553 |
| 06-diffpair-test | jlcpcb | 0 | 2 | 2 (20→22) | 8ms | #3554 |
| 07-matchgroup-test | jlcpcb | 0 | 0 | 0 (clean) | 28ms | — |
| external/softstart | jlcpcb-tier1 | 29 | 7 | 36 | 110–200ms | #3555 |

- **Board 05 verification**: the #3526 PWR_LED-vs-+3V3 short does **not** appear — fix confirmed. The 10 remaining findings are different nets (SW_OUT/PWM_AL/PWM_BH vs +24V/GND fills, GATE_CL/SWDIO grazes).
- These are **pre-existing stale-fill defects in committed copper** (the rule made them visible; no code change introduced them). Per the allowlist policy, exact counts are grandfathered in `.github/routed-drc-tolerance.yml` with tracking-issue links (#3549–#3555) so any further regression still trips the gate. The per-board guard tests (`test_board_05_drc_allowlist` pin-to-exactly-10, `test_board_06_diffpair_test` 20→22, `test_board_01_ship_ready` exact-4 grandfather, board-03 baseline ceiling 0→4) were updated per their own documented update-with-justification procedures. The rule itself was NOT weakened.
- `tests/test_audit.py` zone fixtures were reshaped (slab + fingers fill, dogleg trace) because their whole-board GND fill legitimately contained the foreign +3V3 test trace — the new rule was correctly flagging the synthetic short and flipping the verdicts those tests pin for unrelated reasons.

## Unit tests

`tests/test_validate_segment_zone_clearance.py` (15 tests): synthetic short (through-fill, fully-inside, width-overlap-only), clearance graze + adequate-gap pass, same-net pass-through, net-0 skips, KiCad-9 name-only zone-net resolution, knocked-out-corridor fill (legal) + too-tight corridor (flagged), per-fill layer discipline (B.Cu fill ignored for F.Cu trace; multi-layer zone), and Zone schema per-fill layer parsing/fallback.

## Test plan

- [x] `tests/test_validate_segment_zone_clearance.py` — 15 passed
- [x] `scripts/ci/check_routed_drc.py` on all 8 committed routed artifacts — gate green against updated allowlist
- [x] Broad sweep (`-k "audit or check or drc or fleet or board_0 or softstart or ship or zone or clearance"`, not slow) — 3,703 passed
- [x] `tests/router/test_board03_routing_baseline.py` — 9 passed (incl. re-route)
- [x] ruff check + format on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)