### PR TITLE
fix(export): gerber layer set derives from stackup — inner layers were missing (closes #3559)

### DIFF
--- a/src/kicad_tools/export/gerber.py
+++ b/src/kicad_tools/export/gerber.py
@@ -7,6 +7,7 @@ Wraps kicad-cli for generating Gerber files with manufacturer presets.
 from __future__ import annotations
 
 import logging
+import re
 import subprocess
 import tempfile
 import zipfile
@@ -17,12 +18,12 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from kicad_tools.progress import ProgressCallback
 
+from kicad_tools.cli.runner import find_kicad_cli
 from kicad_tools.exceptions import (
     ConfigurationError,
     ExportError,
 )
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
-from kicad_tools.cli.runner import find_kicad_cli
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +51,69 @@ def _pcb_has_unfilled_zones(pcb_path: Path) -> bool:
     # If we have zones but no filled_polygon, the zones are unfilled and
     # the resulting Gerbers would lack G36..G37 polygon-fill regions.
     return "filled_polygon" not in text
+
+
+# Board-level copper layer definitions inside the top-level ``(layers ...)``
+# table look like ``(0 "F.Cu" signal)`` / ``(4 "In1.Cu" signal)`` -- an
+# integer ordinal, a quoted layer name, then a layer type token.  The integer
+# ordinal distinguishes these from per-pad/per-via ``(layers "F.Cu" ...)``
+# lists, and the type token guards against ``(net 4 "...")`` entries.
+_COPPER_LAYER_DEF_RE = re.compile(
+    r'\(\s*\d+\s+"((?:F|B|In\d+)\.Cu)"\s+(?:signal|power|mixed|jumper)\b'
+)
+
+
+def _inner_copper_index(name: str) -> int:
+    """Return the ``N`` from ``InN.Cu`` (e.g. 1 for ``In1.Cu``)."""
+    return int(name[2:].split(".")[0])
+
+
+def _pcb_copper_layers(pcb_path: Path) -> list[str]:
+    """Return the copper layers declared by the PCB's stackup, in plot order.
+
+    Parses the board-level ``(layers ...)`` table with a cheap text scan
+    (same approach as :func:`_pcb_has_unfilled_zones`) and returns the
+    copper layers ordered front-to-back: ``F.Cu``, ``In1.Cu`` .. ``InN.Cu``,
+    ``B.Cu``.  Ordering is derived from the layer *names* rather than the
+    file's numeric ordinals because KiCad changed copper-layer numbering
+    between versions (legacy: F.Cu=0 .. B.Cu=31; KiCad 9+: F.Cu=0, B.Cu=2,
+    In1.Cu=4, ...) while the canonical names are stable.
+
+    Falls back to ``["F.Cu", "B.Cu"]`` if the file cannot be read or no
+    copper layer definitions are found, preserving the previous 2-layer
+    behaviour (issue #3559: the old hardcode silently dropped inner copper
+    on 4-layer boards).
+    """
+    fallback = ["F.Cu", "B.Cu"]
+    try:
+        text = pcb_path.read_text()
+    except OSError:
+        logger.warning(
+            "Could not read %s to detect copper layers; assuming 2-layer (F.Cu, B.Cu)",
+            pcb_path,
+        )
+        return fallback
+
+    found = set(_COPPER_LAYER_DEF_RE.findall(text))
+    if not found:
+        logger.warning(
+            "No copper layer definitions found in %s; assuming 2-layer (F.Cu, B.Cu)",
+            pcb_path,
+        )
+        return fallback
+
+    inner = sorted(
+        (name for name in found if name.startswith("In")),
+        key=_inner_copper_index,
+    )
+
+    layers: list[str] = []
+    if "F.Cu" in found:
+        layers.append("F.Cu")
+    layers.extend(inner)
+    if "B.Cu" in found:
+        layers.append("B.Cu")
+    return layers
 
 
 @dataclass
@@ -108,6 +172,8 @@ JLCPCB_PRESET = GerberManufacturerPreset(
     layer_rename={
         # JLCPCB preferred naming
         "F.Cu": "F_Cu",
+        "In1.Cu": "In1_Cu",
+        "In2.Cu": "In2_Cu",
         "B.Cu": "B_Cu",
         "F.SilkS": "F_Silkscreen",
         "B.SilkS": "B_Silkscreen",
@@ -171,7 +237,6 @@ MANUFACTURER_PRESETS: dict[str, GerberManufacturerPreset] = {
     "oshpark": OSHPARK_PRESET,
     "seeed": SEEED_PRESET,
 }
-
 
 
 def get_kicad_cli_version(kicad_cli: Path) -> str | None:
@@ -534,11 +599,13 @@ class GerberExporter:
             )
 
     def _get_default_layers(self, config: GerberConfig) -> list[str]:
-        """Get default layers to export based on config."""
-        layers = ["F.Cu", "B.Cu"]  # Always include copper
+        """Get default layers to export based on config.
 
-        # Add inner copper layers if present (detected from PCB)
-        # For now, assume 2-layer. Could parse PCB to detect actual layers.
+        Copper layers are derived from the PCB's actual stackup (issue
+        #3559): a 4-layer board yields F.Cu, In1.Cu, In2.Cu, B.Cu so the
+        inner plane copper is never silently dropped from the Gerbers.
+        """
+        layers = _pcb_copper_layers(self.pcb_path)
 
         if config.include_silkscreen:
             layers.extend(["F.SilkS", "B.SilkS"])

--- a/tests/test_gerber_layer_detection.py
+++ b/tests/test_gerber_layer_detection.py
@@ -1,0 +1,295 @@
+"""Tests for stackup-derived copper layer selection in Gerber export (issue #3559).
+
+``GerberExporter._get_default_layers`` previously hardcoded ``["F.Cu", "B.Cu"]``
+so any 4-layer board exported through ``kct export`` shipped Gerbers with no
+inner plane copper (softstart's In1.Cu GND and In2.Cu +3.3V planes were absent
+from gerbers.zip while the .gbrjob declared LayerNumber 4).
+
+The fix derives the copper layer set from the PCB's actual ``(layers ...)``
+table via :func:`kicad_tools.export.gerber._pcb_copper_layers`.
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kicad_tools.export.gerber import (
+    GerberConfig,
+    GerberExporter,
+    _pcb_copper_layers,
+)
+
+# ---------------------------------------------------------------------------
+# Synthetic PCB layer tables
+# ---------------------------------------------------------------------------
+
+# KiCad 9+ numbering: F.Cu=0, B.Cu=2, inner layers at even ordinals 4, 6, ...
+FOUR_LAYER_KICAD9 = """(kicad_pcb
+\t(version 20241229)
+\t(layers
+\t\t(0 "F.Cu" signal)
+\t\t(4 "In1.Cu" signal)
+\t\t(6 "In2.Cu" signal)
+\t\t(2 "B.Cu" signal)
+\t\t(1 "F.Mask" user)
+\t\t(3 "B.Mask" user)
+\t\t(25 "Edge.Cuts" user)
+\t)
+\t(net 0 "")
+)
+"""
+
+# Legacy numbering: F.Cu=0, inner layers 1..30, B.Cu=31.
+FOUR_LAYER_LEGACY = """(kicad_pcb
+  (version 20240108)
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (2 "In2.Cu" power)
+    (31 "B.Cu" signal)
+    (39 "F.Mask" user)
+    (44 "Edge.Cuts" user)
+  )
+)
+"""
+
+TWO_LAYER = """(kicad_pcb
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+)
+"""
+
+
+class TestPcbCopperLayers:
+    """Unit tests for the stackup text-scan."""
+
+    def test_two_layer_board(self, tmp_path):
+        pcb = tmp_path / "two.kicad_pcb"
+        pcb.write_text(TWO_LAYER)
+        assert _pcb_copper_layers(pcb) == ["F.Cu", "B.Cu"]
+
+    def test_four_layer_kicad9_numbering(self, tmp_path):
+        """KiCad 9+ files number B.Cu=2 and inner layers 4, 6, ...
+
+        Plot order must still be front-to-back by *name*, not by ordinal.
+        """
+        pcb = tmp_path / "four9.kicad_pcb"
+        pcb.write_text(FOUR_LAYER_KICAD9)
+        assert _pcb_copper_layers(pcb) == ["F.Cu", "In1.Cu", "In2.Cu", "B.Cu"]
+
+    def test_four_layer_legacy_numbering(self, tmp_path):
+        pcb = tmp_path / "four_legacy.kicad_pcb"
+        pcb.write_text(FOUR_LAYER_LEGACY)
+        assert _pcb_copper_layers(pcb) == ["F.Cu", "In1.Cu", "In2.Cu", "B.Cu"]
+
+    def test_inner_layers_sort_numerically(self, tmp_path):
+        """In10.Cu must sort after In2.Cu (numeric, not lexicographic)."""
+        pcb = tmp_path / "many.kicad_pcb"
+        pcb.write_text(
+            "(kicad_pcb (layers\n"
+            '  (0 "F.Cu" signal)\n'
+            '  (4 "In1.Cu" signal)\n'
+            '  (24 "In10.Cu" signal)\n'
+            '  (6 "In2.Cu" signal)\n'
+            '  (2 "B.Cu" signal)\n'
+            "))\n"
+        )
+        assert _pcb_copper_layers(pcb) == [
+            "F.Cu",
+            "In1.Cu",
+            "In2.Cu",
+            "In10.Cu",
+            "B.Cu",
+        ]
+
+    def test_pad_layer_lists_are_ignored(self, tmp_path):
+        """Per-pad ``(layers "F.Cu" ...)`` lists must not pollute the result."""
+        pcb = tmp_path / "pads.kicad_pcb"
+        pcb.write_text(
+            TWO_LAYER.rstrip()[:-1]  # strip trailing close paren
+            + '\n  (footprint "R_0402"\n'
+            '    (pad "1" smd rect (layers "F.Cu" "F.Paste" "F.Mask"))\n'
+            '    (pad "2" thru_hole circle (layers "In7.Cu"))\n'
+            "  )\n"
+            ")\n"
+        )
+        assert _pcb_copper_layers(pcb) == ["F.Cu", "B.Cu"]
+
+    def test_missing_file_falls_back_to_two_layer(self, tmp_path):
+        assert _pcb_copper_layers(tmp_path / "missing.kicad_pcb") == ["F.Cu", "B.Cu"]
+
+    def test_no_layer_table_falls_back_to_two_layer(self, tmp_path):
+        pcb = tmp_path / "empty.kicad_pcb"
+        pcb.write_text('(kicad_pcb (version 20240108) (net 0 ""))\n')
+        assert _pcb_copper_layers(pcb) == ["F.Cu", "B.Cu"]
+
+    def test_power_and_mixed_layer_types_detected(self, tmp_path):
+        """Inner planes are often declared as ``power`` rather than ``signal``."""
+        pcb = tmp_path / "power.kicad_pcb"
+        pcb.write_text(
+            "(kicad_pcb (layers\n"
+            '  (0 "F.Cu" signal)\n'
+            '  (4 "In1.Cu" power)\n'
+            '  (6 "In2.Cu" mixed)\n'
+            '  (2 "B.Cu" signal)\n'
+            "))\n"
+        )
+        assert _pcb_copper_layers(pcb) == ["F.Cu", "In1.Cu", "In2.Cu", "B.Cu"]
+
+    def test_generated_pcb_create_four_layer(self, tmp_path):
+        """A board produced by our own ``PCB.create(layers=4)`` is detected."""
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_path = tmp_path / "generated.kicad_pcb"
+        PCB.create(width=20, height=20, layers=4, title="t").save(pcb_path)
+        assert _pcb_copper_layers(pcb_path) == ["F.Cu", "In1.Cu", "In2.Cu", "B.Cu"]
+
+
+# ---------------------------------------------------------------------------
+# _get_default_layers integration
+# ---------------------------------------------------------------------------
+
+
+def _make_exporter(pcb_path: Path) -> GerberExporter:
+    with patch.object(GerberExporter, "__init__", lambda self, path: None):
+        exporter = GerberExporter.__new__(GerberExporter)
+        exporter.pcb_path = pcb_path
+        exporter.kicad_cli = Path("/usr/bin/kicad-cli")
+        return exporter
+
+
+class TestGetDefaultLayers:
+    def test_four_layer_board_includes_inner_copper(self, tmp_path):
+        pcb = tmp_path / "four.kicad_pcb"
+        pcb.write_text(FOUR_LAYER_KICAD9)
+        exporter = _make_exporter(pcb)
+
+        layers = exporter._get_default_layers(GerberConfig())
+
+        # Copper layers first, in front-to-back order.
+        assert layers[:4] == ["F.Cu", "In1.Cu", "In2.Cu", "B.Cu"]
+        # Non-copper defaults still present.
+        assert "F.SilkS" in layers
+        assert "F.Mask" in layers
+        assert "Edge.Cuts" in layers
+
+    def test_two_layer_board_unchanged(self, tmp_path):
+        pcb = tmp_path / "two.kicad_pcb"
+        pcb.write_text(TWO_LAYER)
+        exporter = _make_exporter(pcb)
+
+        layers = exporter._get_default_layers(GerberConfig())
+
+        assert layers[:2] == ["F.Cu", "B.Cu"]
+        assert not any(layer.startswith("In") for layer in layers)
+
+    def test_explicit_config_layers_take_precedence(self, tmp_path):
+        """config.layers overrides stackup detection (existing contract)."""
+        pcb = tmp_path / "four.kicad_pcb"
+        pcb.write_text(FOUR_LAYER_KICAD9)
+        exporter = _make_exporter(pcb)
+
+        captured: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            idx = cmd.index("--layers")
+            captured.append(cmd[idx + 1].split(","))
+
+            class R:
+                stdout = ""
+
+            return R()
+
+        config = GerberConfig(layers=["F.Cu", "Edge.Cuts"])
+        with patch("kicad_tools.export.gerber.subprocess.run", side_effect=fake_run):
+            exporter._export_gerbers_impl(config, tmp_path, pcb)
+
+        assert captured == [["F.Cu", "Edge.Cuts"]]
+
+    def test_export_impl_passes_inner_layers_to_kicad_cli(self, tmp_path):
+        """The --layers argument handed to kicad-cli must include inner copper."""
+        pcb = tmp_path / "four.kicad_pcb"
+        pcb.write_text(FOUR_LAYER_KICAD9)
+        exporter = _make_exporter(pcb)
+
+        captured: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            idx = cmd.index("--layers")
+            captured.append(cmd[idx + 1].split(","))
+
+            class R:
+                stdout = ""
+
+            return R()
+
+        with patch("kicad_tools.export.gerber.subprocess.run", side_effect=fake_run):
+            exporter._export_gerbers_impl(GerberConfig(), tmp_path, pcb)
+
+        assert len(captured) == 1
+        assert captured[0][:4] == ["F.Cu", "In1.Cu", "In2.Cu", "B.Cu"]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: real kicad-cli export of a synthetic 4-layer board
+# ---------------------------------------------------------------------------
+
+
+def _kicad_cli_available() -> bool:
+    from kicad_tools.cli.runner import find_kicad_cli
+
+    return find_kicad_cli() is not None
+
+
+@pytest.mark.skipif(not _kicad_cli_available(), reason="kicad-cli not installed")
+class TestFourLayerExportEndToEnd:
+    """Export a synthetic 4-layer board and verify the shipped artifacts."""
+
+    @pytest.fixture(scope="class")
+    def exported_zip(self, tmp_path_factory) -> Path:
+        from kicad_tools.schema.pcb import PCB
+
+        tmp = tmp_path_factory.mktemp("gerber_4layer")
+        pcb_path = tmp / "four_layer.kicad_pcb"
+        PCB.create(width=20, height=20, layers=4, title="4L test").save(pcb_path)
+
+        exporter = GerberExporter(pcb_path)
+        return exporter.export_for_manufacturer("jlcpcb", tmp / "out")
+
+    def test_zip_contains_all_copper_layers(self, exported_zip):
+        with zipfile.ZipFile(exported_zip) as zf:
+            names = zf.namelist()
+
+        for fragment in ("F_Cu", "In1_Cu", "In2_Cu", "B_Cu"):
+            assert any(fragment in n for n in names), (
+                f"copper layer {fragment} missing from {sorted(names)}"
+            )
+
+    def test_gbrjob_layer_count_matches_copper_files(self, exported_zip):
+        """The .gbrjob LayerNumber must match the copper files actually shipped."""
+        with zipfile.ZipFile(exported_zip) as zf:
+            job_names = [n for n in zf.namelist() if n.endswith(".gbrjob")]
+            assert len(job_names) == 1, f"expected one .gbrjob, got {job_names}"
+            job = json.loads(zf.read(job_names[0]))
+
+            declared = job["GeneralSpecs"]["LayerNumber"]
+            copper_files = [
+                f for f in job["FilesAttributes"] if f.get("FileFunction", "").startswith("Copper")
+            ]
+            # Every copper file the job declares must actually be in the zip.
+            names = set(zf.namelist())
+            missing = [f["Path"] for f in copper_files if f["Path"] not in names]
+
+        assert declared == 4
+        assert len(copper_files) == 4, (
+            f"gbrjob declares {declared} layers but lists {len(copper_files)} copper files"
+        )
+        assert missing == [], f"gbrjob references copper files absent from zip: {missing}"


### PR DESCRIPTION
Closes #3559

## Summary

`GerberExporter._get_default_layers()` hardcoded `["F.Cu", "B.Cu"]` (the "could parse PCB to detect actual layers" TODO was never finished), so every 4-layer board exported through `kct export` shipped gerbers with **no inner plane copper** while the `.gbrjob` declared `LayerNumber: 4` — an unbuildable board a fab may still accept.

- New module-level `_pcb_copper_layers(pcb_path)` parses the board-level `(layers ...)` table with a cheap text scan (same pattern as the existing `_pcb_has_unfilled_zones`). Board layer definitions are uniquely `(<ordinal> "<name>.Cu" signal|power|mixed|jumper)` — the integer ordinal + type token excludes per-pad `(layers "F.Cu" ...)` lists and `(net N "...")` entries.
- Ordering is derived from layer **names** (F.Cu, In1..InN numerically, B.Cu), not file ordinals, since KiCad changed copper numbering between versions (legacy `0..31` vs KiCad 9+ even ordinals `0/2/4/6`); both forms are tested.
- Fallback to `["F.Cu", "B.Cu"]` on unreadable file / missing layer table (previous behavior), with a warning.
- kicad-cli inner-layer naming verified against a real export: `--layers F.Cu,In1.Cu,In2.Cu,B.Cu` produces `*-In1_Cu.g1` / `*-In2_Cu.g2`. Added matching `In1_Cu`/`In2_Cu` entries to the JLCPCB rename map.
- Fixed a pre-existing import-sort (I001) lint error in the touched file.

## Proof artifact (softstart, exported on a COPY — see sequencing below)

Before (committed bundle): 9 files, copper = `F_Cu.gtl` + `B_Cu.gbl` only.
After (this branch, copy of `softstart_routed.kicad_pcb`):

```
   686275  softstart_routed-F_Cu.gtl
   291790  softstart_routed-In1_Cu.g1   <- GND plane, has G36/G37 fill regions
   308047  softstart_routed-In2_Cu.g2   <- +3.3V plane, has G36/G37 fill regions
   316411  softstart_routed-B_Cu.gbl
```

`.gbrjob` now lists all 4 copper files (`Copper,L1,Top` / `Copper,L2,Inr` / `Copper,L3,Inr` / `Copper,L4,Bot`) consistent with `LayerNumber: 4`.

## Affected committed bundles (fleet check)

| Bundle | gbrjob layers | Inner copper files in zip | Status |
|---|---|---|---|
| `boards/external/softstart/.../gerbers.zip` | 4 | 0 | **affected** — regen deferred to #3555 (see below) |
| `boards/05-bldc-motor-controller/.../gerbers.zip` | 4 | 0 | **affected** — follow-up issue |
| `boards/06-diffpair-test/.../gerbers.zip` | 4 | 0 | **affected** — follow-up issue |
| `boards/07-matchgroup-test/.../gerbers.zip` | 4 | 0 | **affected** — follow-up issue |
| boards 01–04 | 2 | n/a | not affected (2-layer) |

## Sequencing vs #3555 (softstart stale fills)

The sibling #3555 builder is concurrently fixing softstart's stale zone fills and will regenerate the same committed bundle. To avoid racing on binary artifacts, **this PR does not commit a regenerated softstart bundle**: the layer fix was verified on a copy (above). The committed bundle must be regenerated by #3555's final regen **after this PR merges** — if #3555's regen runs against pre-fix export code, its bundle will again lack inner layers. A coordination comment has been left on #3555.

## Tests

`tests/test_gerber_layer_detection.py` (26 pass total with existing gerber suite):
- `_pcb_copper_layers` units: 2-layer, 4-layer in both numbering schemes, numeric In-layer sort (In10 after In2), pad-layer-list exclusion, power/mixed types, fallbacks, and a `PCB.create(layers=4)` round-trip
- `_get_default_layers` + `--layers` CLI argument assembly (inner copper included; explicit `config.layers` still wins)
- End-to-end (skipped when kicad-cli absent): synthetic 4-layer board exported via real kicad-cli; asserts all four copper layers in the zip and `.gbrjob` consistency (LayerNumber == copper file count, every referenced copper path present in the zip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)