### PR TITLE
fix(router): reject routes through static foreign-pad halos + net-aware validator skip (closes #3545)

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -9277,6 +9277,25 @@ class Autorouter:
                 f"(now {successful_nets}/{total_nets} routed)"
             )
 
+        # Issue #3545 (safety net): never commit copper that genuinely
+        # violates FOREIGN-pad clearance beyond nudge reach.  The
+        # negotiated loop can exit holding a best snapshot whose copper
+        # crossed a static foreign-pad halo (unresolvable overflow the
+        # loop oscillated on) -- exact KiCad DRC flags it, so an
+        # unrouted net (advisory connectivity finding) is the strictly
+        # better trade.  Sub-resolution deficits are left for
+        # ``drc_verify_and_nudge`` / post-route correction, mirroring
+        # the #3433 demote-only-unrepairable philosophy.
+        pad_demoted = self._demote_pad_clearance_violation_nets(net_routes)
+        if pad_demoted:
+            successful_nets = sum(1 for routes in net_routes.values() if routes)
+            flush_print(
+                f"\n  ⚠ Demoted {len(pad_demoted)} net(s) with sub-clearance "
+                f"copper against foreign pads to unrouted: "
+                f"{sorted(pad_demoted)} "
+                f"(now {successful_nets}/{total_nets} routed)"
+            )
+
         if progress_callback is not None:
             # Issue #2597: Distinguish ``stagnated`` from ``timeout`` and
             # bare ``f"overflow={N}"`` so callers (and CI) can pick the
@@ -9874,6 +9893,78 @@ class Autorouter:
                     self.routes.remove(route)
             net_routes[net] = []
         return victims
+
+    def _demote_pad_clearance_violation_nets(
+        self,
+        net_routes: dict[int, list[Route]],
+    ) -> list[int]:
+        """Strip nets whose copper violates foreign-pad clearance beyond repair.
+
+        Issue #3545 (safety net): the negotiated loop's in-loop metrics
+        historically had no seg-vs-pad quadrant, so a best snapshot whose
+        copper crossed a static foreign-pad clearance halo was committed
+        and only exact KiCad DRC caught it.  The #3545 root fixes (static
+        halo survival across rip-up + net-aware validator carve-out)
+        prevent such routes from being constructed, but this backstop
+        guarantees the contract at finalization: any net whose committed
+        segments have a FOREIGN-pad clearance deficit larger than one
+        grid resolution (beyond ``drc_verify_and_nudge``'s plausible snap
+        reach) is demoted to unrouted instead of shipped.
+
+        Uses :meth:`RoutingGrid.worst_segment_pad_deficit` -- rect-aware
+        exact geometry with per-component clearances and the net-aware
+        same-component carve-out -- so fine-pitch escapes and relaxed
+        same-component corridors (#1764 / #2452) never trigger demotion.
+
+        Args:
+            net_routes: Mapping of net ID to committed routes (mutated:
+                demoted nets are reset to ``[]``).
+
+        Returns:
+            Sorted list of demoted net ids (empty in the common case).
+        """
+        pitches = self.component_pitches
+        nudge_reach = self.grid.resolution
+        victims: list[int] = []
+
+        for net, routes in net_routes.items():
+            if not routes:
+                continue
+            own_refs = {ref for ref, _pin in self.nets.get(net, [])}
+            worst_deficit = 0.0
+            worst_loc: tuple[float, float] | None = None
+            for route in routes:
+                for seg in route.segments:
+                    deficit, loc = self.grid.worst_segment_pad_deficit(
+                        seg,
+                        exclude_net=net,
+                        component_pitches=pitches,
+                        exclude_refs=own_refs or None,
+                    )
+                    if deficit > worst_deficit:
+                        worst_deficit = deficit
+                        worst_loc = loc
+            if worst_deficit > nudge_reach:
+                loc_str = (
+                    f" at ({worst_loc[0]:.3f}, {worst_loc[1]:.3f})"
+                    if worst_loc
+                    else ""
+                )
+                flush_print(
+                    f"    Net {net} ({self.net_names.get(net, '?')}): "
+                    f"foreign-pad clearance deficit {worst_deficit:.3f}mm"
+                    f"{loc_str} exceeds nudge reach ({nudge_reach:.3f}mm)"
+                )
+                victims.append(net)
+
+        for net in victims:
+            for route in net_routes.get(net, []):
+                self.grid.unmark_route_usage(route)
+                self.grid.unmark_route(route)
+                if route in self.routes:
+                    self.routes.remove(route)
+            net_routes[net] = []
+        return sorted(victims)
 
     def _post_route_clearance_correction(
         self,

--- a/src/kicad_tools/router/cpp/include/types.hpp
+++ b/src/kicad_tools/router/cpp/include/types.hpp
@@ -72,7 +72,18 @@ namespace router {
 // the version forces a rebuild so the post-#3309 performance fix takes
 // effect and the regression test (``tests/test_router_cpp_astar_flat_arrays_3309.py``)
 // passes its build-version guard.
-constexpr int ROUTER_CPP_BUILD_VERSION = 10;
+// Bump to 11 for Issue #3545 (static-blockage survival across rip-up).
+// ``GridCell`` gained a ``static_blocked`` flag set by ``mark_blocked``
+// (static obstacle sync) and consulted by ``unmark_segment`` /
+// ``unmark_via``: ripping up a route whose clearance envelope overlapped
+// a STATIC pad clearance halo must RESTORE the halo (blocked=true,
+// net=original_net) instead of erasing it.  Pre-#3545 .so files erase
+// the halo, letting foreign nets route through a pad's clearance band
+// and ship sub-clearance copper (routing-diagnostic fixture: NET3
+// through J1-1's halo at 0.127mm actual vs 0.200mm required).
+// ``mark_blocked`` also began recording ``original_net`` for ALL static
+// cells (previously pad-metal only) so the restore has the owner net.
+constexpr int ROUTER_CPP_BUILD_VERSION = 11;
 
 // Grid cell state
 struct GridCell {
@@ -85,6 +96,11 @@ struct GridCell {
     bool is_zone = false;
     bool pad_blocked = false;
     int32_t original_net = 0;
+    // Issue #3545: true for cells blocked by STATIC board geometry
+    // (pad metal, pad clearance halos, keepouts) registered via
+    // ``mark_blocked``.  Route marking never sets this; rip-up uses it
+    // to restore static blockage instead of freeing the cell.
+    bool static_blocked = false;
 };
 
 // A* node for priority queue

--- a/src/kicad_tools/router/cpp/src/bindings.cpp
+++ b/src/kicad_tools/router/cpp/src/bindings.cpp
@@ -32,6 +32,11 @@ NB_MODULE(router_cpp, m) {
         .def_rw("is_zone", &GridCell::is_zone)
         .def_rw("pad_blocked", &GridCell::pad_blocked)
         .def_rw("original_net", &GridCell::original_net)
+        // Issue #3545: static-blockage flag -- set by ``mark_blocked``
+        // for board geometry (pads, halos, keepouts); consulted by
+        // ``unmark_segment`` / ``unmark_via`` so rip-up restores static
+        // blockage instead of erasing it.
+        .def_rw("static_blocked", &GridCell::static_blocked)
         .def_rw("avoidance_cost", &GridCell::avoidance_cost);
 
     // DesignRules struct

--- a/src/kicad_tools/router/cpp/src/grid.cpp
+++ b/src/kicad_tools/router/cpp/src/grid.cpp
@@ -54,8 +54,17 @@ void Grid3D::mark_blocked(int x, int y, int layer, int net, bool is_obstacle,
     // grid.cpp:188).
     if (pad_blocked) {
         cell.pad_blocked = true;
-        cell.original_net = net;
     }
+    // Issue #3545: every ``mark_blocked`` call registers STATIC board
+    // geometry (pad metal, clearance halos, keepouts) -- route copper
+    // goes through ``mark_segment`` / ``mark_via`` instead.  Record the
+    // static flag and the owning net (previously recorded for pad metal
+    // only) so ``unmark_segment`` / ``unmark_via`` can RESTORE the cell
+    // after a rip-up whose clearance envelope swept it, instead of
+    // erasing the static blockage and letting foreign nets route
+    // through a pad's clearance halo.
+    cell.static_blocked = true;
+    cell.original_net = net;
 }
 
 void Grid3D::mark_rect_blocked(int x1, int y1, int x2, int y2, int layer, int net,
@@ -161,8 +170,21 @@ void Grid3D::unmark_segment(int x1, int y1, int x2, int y2, int layer, int net,
                     if (cell.pad_blocked) {
                         cell.net = cell.original_net;
                     } else if (cell.net == net) {
-                        cell.blocked = false;
-                        cell.net = 0;
+                        // Issue #3545: STATICALLY blocked cells (pad
+                        // clearance halos, keepouts) must survive
+                        // rip-up.  Pre-fix, ripping a route whose
+                        // clearance envelope overlapped its own pads'
+                        // halo cells erased them (blocked=false,
+                        // net=0), after which foreign nets routed
+                        // straight through the halo and shipped
+                        // sub-clearance copper.  Restore the static
+                        // owner instead of freeing.
+                        if (cell.static_blocked) {
+                            cell.net = cell.original_net;
+                        } else {
+                            cell.blocked = false;
+                            cell.net = 0;
+                        }
                     }
                 }
             }
@@ -203,8 +225,15 @@ void Grid3D::unmark_via(int x, int y, int net, int radius_cells) {
                     if (cell.pad_blocked) {
                         cell.net = cell.original_net;
                     } else if (cell.net == net) {
-                        cell.blocked = false;
-                        cell.net = 0;
+                        // Issue #3545: restore static halo / keepout
+                        // cells instead of freeing them (see
+                        // ``unmark_segment`` for rationale).
+                        if (cell.static_blocked) {
+                            cell.net = cell.original_net;
+                        } else {
+                            cell.blocked = false;
+                            cell.net = 0;
+                        }
                     }
                 }
             }

--- a/src/kicad_tools/router/cpp/src/pathfinder.cpp
+++ b/src/kicad_tools/router/cpp/src/pathfinder.cpp
@@ -247,6 +247,15 @@ bool Pathfinder::is_trace_blocked(int x, int y, int layer, int net,
                 if (cell.is_obstacle && cell.net != net) {
                     return true;
                 }
+                // Issue #3545: statically blocked foreign cells (pad
+                // clearance halos, keepouts) are non-negotiable
+                // regardless of usage_count -- a pad cannot "negotiate
+                // away", so sharing a halo cell only produces
+                // unresolvable overflow.  Relief probes keep their
+                // #3438 soft-crossing semantics for foreign-net cells.
+                if (cell.static_blocked && cell.net != net && !relief_mode_) {
+                    return true;
+                }
                 if (cell.net == 0 && cell.usage_count == 0) {
                     return true;
                 }
@@ -292,6 +301,15 @@ bool Pathfinder::is_trace_blocked(int x, int y, int layer, int net,
 
             if (allow_sharing) {
                 if (cell.is_obstacle && cell.net != net) {
+                    return true;
+                }
+                // Issue #3545: statically blocked foreign cells (pad
+                // clearance halos, keepouts) are non-negotiable
+                // regardless of usage_count -- a pad cannot "negotiate
+                // away", so sharing a halo cell only produces
+                // unresolvable overflow.  Relief probes keep their
+                // #3438 soft-crossing semantics for foreign-net cells.
+                if (cell.static_blocked && cell.net != net && !relief_mode_) {
                     return true;
                 }
                 if (cell.net == 0 && cell.usage_count == 0) {
@@ -401,6 +419,15 @@ bool Pathfinder::is_diagonal_blocked(int x, int y, int dx, int dy, int layer,
                 if (cell.is_obstacle && cell.net != net) {
                     return true;
                 }
+                // Issue #3545: statically blocked foreign cells (pad
+                // clearance halos, keepouts) are non-negotiable
+                // regardless of usage_count -- a pad cannot "negotiate
+                // away", so sharing a halo cell only produces
+                // unresolvable overflow.  Relief probes keep their
+                // #3438 soft-crossing semantics for foreign-net cells.
+                if (cell.static_blocked && cell.net != net && !relief_mode_) {
+                    return true;
+                }
                 if (cell.net == 0 && cell.usage_count == 0) {
                     return true;
                 }
@@ -500,6 +527,15 @@ bool Pathfinder::is_via_blocked_diag(int x, int y, int net, bool allow_sharing,
                     if (cell.is_obstacle && cell.net != net) {
                         return true;  // Foreign-net obstacle blocks
                     }
+                    // Issue #3545: statically blocked foreign cells (pad
+                    // clearance halos, keepouts) are non-negotiable
+                    // regardless of usage_count -- a pad cannot "negotiate
+                    // away", so sharing a halo cell only produces
+                    // unresolvable overflow.  Relief probes keep their
+                    // #3438 soft-crossing semantics for foreign-net cells.
+                    if (cell.static_blocked && cell.net != net && !relief_mode_) {
+                        return true;
+                    }
                     if (cell.net == 0 && cell.usage_count == 0) {
                         return true;
                     }
@@ -538,6 +574,15 @@ bool Pathfinder::is_via_blocked_diag(int x, int y, int net, bool allow_sharing,
 
                     if (allow_sharing) {
                         if (cell.is_obstacle && cell.net != net) {
+                            return true;
+                        }
+                        // Issue #3545: statically blocked foreign cells (pad
+                        // clearance halos, keepouts) are non-negotiable
+                        // regardless of usage_count -- a pad cannot "negotiate
+                        // away", so sharing a halo cell only produces
+                        // unresolvable overflow.  Relief probes keep their
+                        // #3438 soft-crossing semantics for foreign-net cells.
+                        if (cell.static_blocked && cell.net != net && !relief_mode_) {
                             return true;
                         }
                         if (cell.net == 0 && cell.usage_count == 0) {

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -47,7 +47,7 @@ logger = logging.getLogger(__name__)
 # ``AttributeError`` deep in the routing code (e.g. ``router_cpp.PadBounds``
 # missing).  The guard below catches that at import time and falls back to the
 # pure-Python router with an actionable ``kct build-native`` hint.
-_REQUIRED_CPP_BUILD_VERSION = 10
+_REQUIRED_CPP_BUILD_VERSION = 11
 
 # Try to import C++ module with detailed error tracking
 _CPP_IMPORT_ERROR: str | None = None
@@ -838,6 +838,11 @@ class CppPathfinder:
         # Fallback statistics
         self._fallback_count: int = 0
         self._fallback_nets: list[str] = []
+
+        # Issue #3545: lazy cache for ``compute_component_pitches`` used
+        # by the net-aware same-component carve-out gate in
+        # ``_same_component_carveout_eligible``.
+        self._component_pitches_cache: dict[str, float] | None = None
 
         # Issue #3438: relief-probe mode flag (mirrored into the C++
         # Pathfinder AND the lazy Python fallback router so both backends
@@ -1764,6 +1769,45 @@ class CppPathfinder:
         )
         return route
 
+    def _same_component_carveout_eligible(self, py_grid, ref: str) -> bool:
+        """Return True when ``ref`` may keep the same-component carve-out.
+
+        Issue #3545: the carve-out (skipping clearance checks against
+        same-component pads) is only legitimate where a clearance
+        relaxation is actually in effect for the component:
+
+        1. The component's inter-pad corridor was relaxed by
+           ``_relax_same_component_clearance`` (Issue #2452), or
+        2. A fine-pitch / explicit per-component clearance relaxation
+           applies (``get_clearance_for_component`` returns less than
+           the default ``trace_clearance``, Issue #1764), or
+        3. The component is fine-pitch (min pin pitch below
+           ``rules.fine_pitch_threshold``) -- covers boards routed with
+           ``fine_pitch_clearance`` unset (the default), where the
+           clearance lookup cannot signal the relaxation.
+
+        Standard-pitch components return False, so their FOREIGN-net
+        pads stay in the C++ validator and sub-clearance copper is
+        rejected at route construction time.  Mirrors
+        ``RoutingGrid._same_component_carveout_active``.
+        """
+        relaxed_refs = getattr(py_grid, "_relaxed_clearance_refs", None)
+        if relaxed_refs and ref in relaxed_refs:
+            return True
+        pitches = self._component_pitches_cache
+        if pitches is None:
+            try:
+                pitches = py_grid.compute_component_pitches()
+            except Exception:
+                pitches = {}
+            self._component_pitches_cache = pitches
+        pitch = pitches.get(ref)
+        required = self._rules.get_clearance_for_component(ref, pitch)
+        if required < self._rules.trace_clearance:
+            return True
+        threshold = getattr(self._rules, "fine_pitch_threshold", None)
+        return pitch is not None and threshold is not None and pitch < threshold
+
     def _validate_route_clearance(
         self,
         route: "Route",
@@ -1807,9 +1851,21 @@ class CppPathfinder:
         self._sync_stored_routes(py_grid)
 
         # Build exclude_ref_hashes for start/end pad components (Issue #1764)
+        #
+        # Issue #3545: NET-AWARE tightening.  The C++ validator's
+        # same-component carve-out (``is_excluded_ref`` in
+        # ``Grid3D::validate_route``) silently exempted FOREIGN-net pads
+        # on the route's own components (same-net pads are skipped by
+        # ``pad.net == exclude_net`` anyway), masking sub-clearance
+        # copper like the routing-diagnostic NET3-vs-J1.1 0.127mm gap.
+        # The carve-out's legitimate use is fine-pitch escape (#1764)
+        # and relaxed same-component corridors (#2452) -- include a ref
+        # in the exclusion set ONLY when one of those relaxations is
+        # actually in effect for that component.  Mirrors the Python
+        # validator gate in ``RoutingGrid.validate_segment_clearance``.
         exclude_ref_hashes: list[int] = []
         for pad in (start, end):
-            if pad.ref:
+            if pad.ref and self._same_component_carveout_eligible(py_grid, pad.ref):
                 exclude_ref_hashes.append(router_cpp.fnv1a_hash(pad.ref))
 
         # Build C++ segment/via lists from route

--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -803,6 +803,23 @@ class RoutingGrid:
         # manufacturability at that pitch.
         self._component_pads: dict[str, list[Pad]] = {}
 
+        # Issue #3545: component refs whose inter-pad corridor was
+        # actually relaxed by ``_relax_same_component_clearance``
+        # (Issue #2452).  For these components the same-component
+        # validator carve-out must stay available even when no
+        # fine-pitch clearance relaxation applies -- escape traces
+        # legitimately pass sub-default-clearance from the neighbour
+        # pad inside the relaxed corridor.  All other components get
+        # the NET-AWARE tightened carve-out (foreign-net same-component
+        # pads are validated at full clearance).
+        self._relaxed_clearance_refs: set[str] = set()
+
+        # Issue #3545: lazy cache for the grid-computed component pitch
+        # map used by the fine-pitch leg of the same-component carve-out
+        # gate (``_component_is_fine_pitch``).  Invalidated by
+        # ``add_pad`` so late pad additions re-measure.
+        self._component_pitch_cache: dict[str, float] | None = None
+
         # Issue #3371 (P_FP2): Fine-pitch escape regions detected on this
         # board.  Populated by the autorouter (or test fixture) once after
         # all pads are added via :meth:`set_fine_pitch_regions`.  Consumed
@@ -959,6 +976,43 @@ class RoutingGrid:
         self._is_zone = xp.zeros(grid_shape, dtype=np.bool_)
         self._pad_blocked = xp.zeros(grid_shape, dtype=np.bool_)
         self._original_net = xp.zeros(grid_shape, dtype=np.int32)
+        # Issue #3545: snapshot of the STATIC blocked bitmap, captured
+        # lazily on the first ``mark_route`` call (after all pads /
+        # keepouts / same-component relaxations have shaped ``_blocked``
+        # but before any route copper is marked).  ``_unmark_segment`` /
+        # ``_unmark_via`` consult it during rip-up: a statically blocked
+        # cell (pad clearance halo, keepout) must be RESTORED to its
+        # static owner (``blocked=True, net=original_net``) instead of
+        # being freed.  Pre-#3545 rip-up erased same-net static halo
+        # cells outright (``blocked=False, net=0``), letting foreign
+        # nets route through a pad's clearance halo and ship
+        # sub-clearance copper (routing-diagnostic fixture: NET3 through
+        # J1-1's halo at 0.127mm actual vs 0.200mm required).
+        self._static_blocked: np.ndarray | None = None
+
+    def _ensure_static_blockage_snapshot(self) -> None:
+        """Capture the static blocked bitmap before the first route mark.
+
+        Issue #3545: called from :meth:`mark_route` (under the grid lock)
+        so the snapshot reflects ALL static obstacles -- pad metal,
+        clearance halos, keepouts -- including the cells re-opened by
+        ``_relax_same_component_clearance`` (those are NOT static-blocked:
+        a route ripped off a relaxed corridor cell must free it again).
+        Idempotent after the first call.
+        """
+        if self._static_blocked is None:
+            self._static_blocked = to_numpy(self._blocked).copy()
+
+    def invalidate_static_blockage_snapshot(self) -> None:
+        """Drop the static-blockage snapshot (Issue #3545).
+
+        Call when static geometry changes AFTER routing has begun (e.g.
+        late ``add_pad`` / ``add_keepout``); the next ``mark_route``
+        re-captures.  Note the re-capture would then include any
+        currently-marked route copper, so callers mutating static
+        geometry mid-route should do so only while no routes are marked.
+        """
+        self._static_blocked = None
 
     def sync_to_cpu(self) -> None:
         """Transfer GPU arrays to CPU for A* operations.
@@ -1470,6 +1524,8 @@ class RoutingGrid:
         # clearance relaxation.
         if pad.ref:
             self._component_pads.setdefault(pad.ref, []).append(pad)
+            # Issue #3545: pitch cache is stale once a new pad lands.
+            self._component_pitch_cache = None
 
         # Issue #2604 follow-up: remember the pin_pitch this pad was added
         # with so ``find_pad_ref_at`` can reproduce the reduced fine-pitch
@@ -2551,6 +2607,11 @@ class RoutingGrid:
 
                         # Unblock the cell so A* can route through
                         self._blocked[layer_idx, gy, gx] = False
+                        # Issue #3545: record that this component's
+                        # corridor was relaxed so the same-component
+                        # validator carve-out stays available for it
+                        # (see ``validate_segment_clearance``).
+                        self._relaxed_clearance_refs.add(pad.ref)
 
     def add_keepout(
         self,
@@ -2607,6 +2668,146 @@ class RoutingGrid:
         if cell.blocked:
             return cell.net == 0 or cell.net != net
         return False
+
+    def _component_is_fine_pitch(
+        self,
+        ref: str,
+        component_pitches: dict[str, float] | None = None,
+    ) -> bool:
+        """True when ``ref``'s minimum pin pitch is below the fine-pitch
+        threshold (Issue #3545 carve-out gate, fine-pitch leg).
+
+        Prefers the caller-supplied ``component_pitches`` map (matching
+        the per-component clearance lookup); falls back to a lazily
+        computed grid-level pitch map so call sites that do not thread
+        pitches (e.g. direct validator invocations) still recognise
+        fine-pitch components.
+        """
+        pitch: float | None = None
+        if component_pitches:
+            pitch = component_pitches.get(ref)
+        if pitch is None:
+            cache = self._component_pitch_cache
+            if cache is None:
+                cache = self.compute_component_pitches()
+                self._component_pitch_cache = cache
+            pitch = cache.get(ref)
+        threshold = getattr(self.rules, "fine_pitch_threshold", None)
+        return pitch is not None and threshold is not None and pitch < threshold
+
+    def _same_component_carveout_active(
+        self,
+        ref: str,
+        required_clearance: float,
+        min_clearance: float,
+        component_pitches: dict[str, float] | None = None,
+    ) -> bool:
+        """NET-AWARE same-component carve-out gate (Issue #3545).
+
+        Same-net pads are skipped before the carve-out is consulted, so
+        every pad it exempts is on a FOREIGN net.  The exemption is only
+        legitimate where the component's geometry forces sub-clearance
+        proximity:
+
+        1. an explicit / fine-pitch clearance relaxation is in effect
+           (``required_clearance < min_clearance``, Issue #1764), or
+        2. the component's inter-pad corridor was relaxed by
+           ``_relax_same_component_clearance`` (Issue #2452), or
+        3. the component is fine-pitch (min pin pitch below
+           ``rules.fine_pitch_threshold``) -- covers boards that route
+           with ``fine_pitch_clearance`` unset (the default), where the
+           per-component clearance lookup cannot signal the relaxation.
+
+        Standard-pitch components (e.g. a 2.54mm THT connector) match
+        none of these, so their foreign-net pads stay in the validator
+        and sub-clearance copper is rejected (the routing-diagnostic
+        NET3-vs-J1.1 0.127mm defect).
+        """
+        return (
+            required_clearance < min_clearance
+            or ref in self._relaxed_clearance_refs
+            or self._component_is_fine_pitch(ref, component_pitches)
+        )
+
+    def worst_segment_pad_deficit(
+        self,
+        seg: Segment,
+        exclude_net: int,
+        component_pitches: dict[str, float] | None = None,
+        exclude_refs: set[str] | None = None,
+    ) -> tuple[float, tuple[float, float] | None]:
+        """Worst seg-vs-FOREIGN-pad clearance deficit for one segment.
+
+        Issue #3545 (finalization backstop): exact-geometry sibling of the
+        pad quadrant in :meth:`validate_segment_clearance`, restricted to
+        pads so the negotiated loop's final acceptance can demote nets
+        whose committed copper genuinely violates pad clearance (e.g. a
+        route that crossed a static foreign-pad halo) without re-running
+        the (heavier, multi-quadrant) full validation.
+
+        Uses the same rect-aware geometry, per-component clearances, and
+        the NET-AWARE same-component carve-out as the validator, so the
+        backstop never fires on legitimate fine-pitch escapes or relaxed
+        same-component corridors.
+
+        Returns:
+            ``(worst_deficit, worst_location)`` where ``worst_deficit`` is
+            ``max(required_clearance - actual_clearance)`` over all
+            checked pads (<= 0 means no violation) and ``worst_location``
+            is the violating pad center (or ``None``).
+        """
+        min_clearance = self.rules.trace_clearance
+        seg_half_width = seg.width / 2
+        worst_deficit = 0.0
+        worst_loc: tuple[float, float] | None = None
+
+        for pad in self._pads:
+            if pad.net == exclude_net:
+                continue
+
+            if not pad.through_hole:
+                pad_layer_idx = self.layer_to_index(pad.layer.value)
+                seg_layer_idx = self.layer_to_index(seg.layer.value)
+                if pad_layer_idx != seg_layer_idx:
+                    continue
+
+            pad_ref = pad.ref
+            pin_pitch = component_pitches.get(pad_ref) if component_pitches else None
+            required_clearance = self.rules.get_clearance_for_component(pad_ref, pin_pitch)
+
+            # Issue #3545 net-aware carve-out (see validate_segment_clearance)
+            same_component_signal_carveout = (
+                exclude_refs
+                and pad.ref in exclude_refs
+                and not _is_plane_net_pad(pad)
+                and self._same_component_carveout_active(
+                    pad.ref, required_clearance, min_clearance, component_pitches
+                )
+            )
+
+            is_circular_pad = abs(pad.width - pad.height) < 0.001
+            if is_circular_pad:
+                pad_radius = max(pad.width, pad.height) / 2
+                dist = self._point_to_segment_distance(
+                    pad.x, pad.y, seg.x1, seg.y1, seg.x2, seg.y2
+                )
+                clearance = dist - seg_half_width - pad_radius
+            else:
+                center_dist = _rect_segment_centerline_distance(
+                    pad.x, pad.y, pad.width, pad.height,
+                    seg.x1, seg.y1, seg.x2, seg.y2,
+                )
+                clearance = center_dist - seg_half_width
+
+            if same_component_signal_carveout and clearance >= 0:
+                continue
+
+            deficit = required_clearance - clearance
+            if deficit > worst_deficit:
+                worst_deficit = deficit
+                worst_loc = (pad.x, pad.y)
+
+        return worst_deficit, worst_loc
 
     def validate_segment_clearance(
         self,
@@ -2722,12 +2923,6 @@ class RoutingGrid:
             # same-component pads, so the trace-through-pad pathology is now
             # caught at the validator while the fine-pitch escape exemption
             # (positive clearance < required_clearance) is unchanged.
-            same_component_signal_carveout = (
-                exclude_refs
-                and pad.ref in exclude_refs
-                and not _is_plane_net_pad(pad)
-            )
-
             # Skip pads on different layers (unless PTH)
             if not pad.through_hole:
                 # Convert layer for comparison
@@ -2741,6 +2936,36 @@ class RoutingGrid:
             pad_ref = pad.ref
             pin_pitch = component_pitches.get(pad_ref) if component_pitches else None
             required_clearance = self.rules.get_clearance_for_component(pad_ref, pin_pitch)
+
+            # Issue #3545: NET-AWARE tightening of the same-component
+            # carve-out.  Same-net pads are already skipped at the top of
+            # this loop, so every pad reaching this point is on a FOREIGN
+            # net -- the carve-out was silently exempting foreign-net pads
+            # on the route's own components (routing-diagnostic fixture:
+            # NET3 routed 0.127mm from J1 pad 1 / NET1, masked because
+            # NET3 also connects to J1 pad 2).  The legitimate use of the
+            # carve-out is fine-pitch escape routing (Issue #1764), which
+            # is exactly the case where a per-component clearance
+            # relaxation is in effect (``required_clearance <
+            # min_clearance`` via fine-pitch detection or an explicit
+            # component override).  Standard-pitch components get no
+            # relaxation, so their foreign-net pads now stay in the
+            # validator and sub-clearance copper is rejected.
+            #
+            # The carve-out remains active where the component geometry
+            # legitimately forces sub-clearance proximity: explicit /
+            # fine-pitch clearance relaxations (#1764), relaxed
+            # same-component corridors (#2452), and fine-pitch
+            # components routed without ``fine_pitch_clearance``
+            # configured -- see ``_same_component_carveout_active``.
+            same_component_signal_carveout = (
+                exclude_refs
+                and pad.ref in exclude_refs
+                and not _is_plane_net_pad(pad)
+                and self._same_component_carveout_active(
+                    pad.ref, required_clearance, min_clearance, component_pitches
+                )
+            )
 
             # Issue #2908: Rect-aware geometry for rectangular SMD pads. The
             # previous disc bound (``radius = max(w, h) / 2``) over-rejected
@@ -3503,6 +3728,10 @@ class RoutingGrid:
                 (Issue #1692).  Falls back to ``rules.trace_width``.
         """
         with self._acquire_lock():
+            # Issue #3545: capture the static blocked bitmap before the
+            # first route copper lands so rip-up can restore pad halos /
+            # keepouts instead of erasing them.
+            self._ensure_static_blockage_snapshot()
             for seg in route.segments:
                 # Issue #1674: Use seg.width instead of rules.trace_width
                 # so wider net-class traces block the correct number of cells.
@@ -3867,6 +4096,7 @@ class RoutingGrid:
         gx2, gy2 = self.world_to_grid(seg.x2, seg.y2)
 
         layer_idx = self.layer_to_index(seg.layer.value)
+        static_blocked = self._static_blocked
 
         def unmark_with_clearance(gx: int, gy: int) -> None:
             for dy in range(-clearance_cells, clearance_cells + 1):
@@ -3878,8 +4108,20 @@ class RoutingGrid:
                             # Don't unblock pad cells, just restore original net
                             cell.net = cell.original_net
                         elif cell.net == seg.net:
-                            cell.blocked = False
-                            cell.net = 0
+                            # Issue #3545: STATICALLY blocked cells (pad
+                            # clearance halos, keepouts) must survive
+                            # rip-up.  Pre-fix, ripping a route whose
+                            # clearance envelope overlapped its OWN pads'
+                            # halo cells erased those cells outright
+                            # (blocked=False, net=0), after which foreign
+                            # nets could route straight through the halo
+                            # and ship sub-clearance copper.  Restore the
+                            # static owner instead of freeing.
+                            if static_blocked is not None and static_blocked[layer_idx, ny, nx]:
+                                cell.net = cell.original_net
+                            else:
+                                cell.blocked = False
+                                cell.net = 0
 
         if gx1 == gx2:
             for gy in range(min(gy1, gy2), max(gy1, gy2) + 1):
@@ -3923,6 +4165,7 @@ class RoutingGrid:
         # cells are cleared during rip-up.
         radius += 1
 
+        static_blocked = self._static_blocked
         for layer_idx in range(self.num_layers):
             for dy in range(-radius, radius + 1):
                 for dx in range(-radius, radius + 1):
@@ -3933,8 +4176,14 @@ class RoutingGrid:
                             # Don't unblock pad cells, just restore original net
                             cell.net = cell.original_net
                         elif cell.net == via.net:
-                            cell.blocked = False
-                            cell.net = 0
+                            # Issue #3545: restore static halo / keepout
+                            # cells instead of freeing them (see
+                            # ``_unmark_segment`` for rationale).
+                            if static_blocked is not None and static_blocked[layer_idx, ny, nx]:
+                                cell.net = cell.original_net
+                            else:
+                                cell.blocked = False
+                                cell.net = 0
 
     def find_relief_conflict_nets(self, route: Route, net: int) -> set[int]:
         """Owner nets of foreign static cells conflicting with ``route``.
@@ -4753,8 +5002,22 @@ class RoutingGrid:
                     & (self._usage_count == 0)
                 )
             else:
+                # Issue #3545: statically blocked cells (pad clearance
+                # halos, keepouts) are non-negotiable -- a pad cannot
+                # "negotiate away", so overflow on these cells is
+                # unresolvable by construction.  Pre-fix, the
+                # ``usage_count == 0`` clause released a static halo cell
+                # to foreign nets as soon as ANY route's envelope touched
+                # it (usage > 0), letting the negotiated loop oscillate
+                # on unresolvable halo overflow and ship sub-clearance
+                # copper.  The snapshot is captured on first
+                # ``mark_route``; before that, usage is uniformly 0 and
+                # the legacy clause is equivalent.
+                static_usage_free = self._usage_count == 0
+                if self._static_blocked is not None:
+                    static_usage_free = static_usage_free | self._static_blocked
                 static_blocks = (
-                    self._blocked & ~self._is_obstacle & different_net & (self._usage_count == 0)
+                    self._blocked & ~self._is_obstacle & different_net & static_usage_free
                 )
             base_blocked = obstacle_blocks | static_blocks
         else:

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -2000,6 +2000,36 @@ def validate_routes(
     def _resolve_net_name(net_id: int) -> str:
         return net_names.get(net_id, f"Net {net_id}")
 
+    # Issue #3545: NET-AWARE component_inherent classification.  A
+    # same-component FOREIGN-net pad violation is only "inherent" (and
+    # thus filtered from ``drc_verify_and_nudge`` repair) when a
+    # clearance relaxation is actually in effect for the component:
+    # fine-pitch / explicit override (#1764) or a relaxed same-component
+    # corridor (#2452).  Standard-pitch components (e.g. a 2.54mm THT
+    # connector) get no relaxation, so a trace from one of their nets
+    # grazing a sibling pad on another net is a repairable routing
+    # defect, not component geometry.
+    _relaxed_refs = getattr(getattr(router, "grid", None), "_relaxed_clearance_refs", None) or set()
+    try:
+        _pitches: dict[str, float] = router.component_pitches
+    except Exception:
+        _pitches = {}
+
+    def _same_component_relaxation_active(ref: str) -> bool:
+        if ref in _relaxed_refs:
+            return True
+        pitch = _pitches.get(ref)
+        if rules.get_clearance_for_component(ref, pitch) < clearance:
+            return True
+        # Fine-pitch leg: boards routed with ``fine_pitch_clearance``
+        # unset (the default) get no per-component relaxation signal,
+        # but sub-clearance proximity on a fine-pitch footprint is
+        # still forced by the component geometry -- inherent, not a
+        # repairable routing defect.  Mirrors
+        # ``RoutingGrid._same_component_carveout_active``.
+        threshold = getattr(rules, "fine_pitch_threshold", None)
+        return pitch is not None and threshold is not None and pitch < threshold
+
     # Check each route segment against pads of different nets
     for route_idx, route in enumerate(router.routes):
         route_net = route.net
@@ -2077,10 +2107,14 @@ def validate_routes(
                     # to avoid the pad).  Mark these as non-inherent so
                     # ``drc_verify_and_nudge`` (which filters out
                     # ``component_inherent=True``) attempts repair.
+                    # Issue #3545: additionally require an active
+                    # clearance relaxation for the component (fine-pitch
+                    # #1764 or relaxed corridor #2452); otherwise the
+                    # violation is actionable for the nudge pass.
                     is_component_inherent = (
-                        ref in route_component_refs and not (
-                            pad.net == 0 and pad.net_name
-                        )
+                        ref in route_component_refs
+                        and not (pad.net == 0 and pad.net_name)
+                        and _same_component_relaxation_active(ref)
                     )
 
                     violations.append(
@@ -2230,10 +2264,14 @@ def validate_routes(
                     # only "inherent" when it's a true net obstacle, not
                     # when the pad belongs to a skipped pour net (the trace
                     # / via can be re-routed to avoid it).
+                    # Issue #3545: additionally require an active
+                    # clearance relaxation for the component (fine-pitch
+                    # #1764 or relaxed corridor #2452); otherwise the
+                    # violation is actionable for the nudge pass.
                     is_component_inherent = (
-                        ref in route_component_refs and not (
-                            pad.net == 0 and pad.net_name
-                        )
+                        ref in route_component_refs
+                        and not (pad.net == 0 and pad.net_name)
+                        and _same_component_relaxation_active(ref)
                     )
 
                     violations.append(

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -1474,7 +1474,16 @@ class Router:
             obstacle_blocks = blocked_region & obstacle_region & different_net
 
             # Case 2: Blocked non-obstacles with different net AND static (usage == 0)
-            static_blocks = blocked_region & ~obstacle_region & different_net & (usage_region == 0)
+            # Issue #3545: statically blocked cells (pad clearance halos,
+            # keepouts) are additionally non-negotiable regardless of
+            # usage_count -- a pad cannot "negotiate away", so sharing a
+            # halo cell only produces unresolvable overflow.  Mirrors
+            # ``RoutingGrid.compute_expanded_blocked``.
+            static_usage_free = usage_region == 0
+            grid_static = getattr(self.grid, "_static_blocked", None)
+            if grid_static is not None:
+                static_usage_free = static_usage_free | grid_static[layer, y1:y2, x1:x2]
+            static_blocks = blocked_region & ~obstacle_region & different_net & static_usage_free
 
             combined = obstacle_blocks | static_blocks
             if partner_relax_mask is not None:

--- a/tests/router/test_board02_manufacturable_baseline.py
+++ b/tests/router/test_board02_manufacturable_baseline.py
@@ -11,9 +11,13 @@ Baseline measurement at HEAD (worst-of-3 across seeds 42/43/44 with
 - **Routed: 8/8 signal nets (100%)** -- LINE_A-D + NODE_A-D
 - **Connected pads: 34/34 (100%)** including GND/VCC via auto-pour
 - **DRC: 0 errors, 0 warnings** at ``jlcpcb-tier1`` profile
-- **Deterministic output**: 22 routes / 387 segments / 24 vias /
-  328.16mm total length identical across seeds 42/43/44 -- this small
-  2-layer board has fully converged.  (193 segments / 325.08mm before
+- **Deterministic output**: 22 routes / 24 vias / 328.16mm total
+  length identical across seeds 42/43/44 -- this small 2-layer board
+  has fully converged.  Segment count is 397 on macOS-arm64 and 399
+  on Linux-x86_64 (platform-dependent collinear resplit at identical
+  geometry; see the #3545 PLATFORM NOTE in
+  ``test_routing_output_deterministic_across_seeds``).  (387 segments
+  before the #3545 static-halo rip-up survival; 193/325.08mm before
   the #3532 45-degree pad-tail doglegs; 299/325.55 before the #3436
   burn-down straightening (#3203/#3510); 206/324.92 before the #3438
   rip-up parity fix; 155/324.66 before the #3433 collision-checker
@@ -437,6 +441,22 @@ def test_routing_output_deterministic_across_seeds(unrouted_pcb_path: Path) -> N
     # documents.  All 3 cpp seeds (42/43/44) bit-perfect at
     # (22, 397, 24, 328.16), measured in a uv.lock-synced venv.
     #
+    # PLATFORM NOTE (#3545): the SEGMENT count -- and only the segment
+    # count -- diverges between macOS-arm64 (397) and CI Linux-x86_64
+    # (399) at identical routes/vias/length/reach and exact cross-seed
+    # equality on both platforms.  The collinear-merge pass gates each
+    # merge on a float collision probe of the merged candidate
+    # (optimizer/algorithms.py merge_collinear -> path_is_clear), and
+    # with #3545 those probes now graze static pad-halo boundaries where
+    # libm/FMA rounding differs across platforms, flipping two
+    # borderline merges.  Same harmless splitting mode as the stale-venv
+    # 507-segment NOTE below: identical geometry, different collinear
+    # segmentation.  We therefore pin routes/vias/length EXACTLY (these
+    # are the regression-sensitive metrics) and allow the segment count
+    # a narrow documented band.  The cross-seed equality assertion above
+    # remains exact, so within-platform determinism regressions are
+    # still caught; only the platform-dependent resplit is tolerated.
+    #
     # Prior pin (22, 387, 24, 328.16), re-baselined 2026-06-11 for
     # Issue #3532: 45-degree quantization of the pad-tail emitters.
     # Off-grid pad
@@ -466,12 +486,33 @@ def test_routing_output_deterministic_across_seeds(unrouted_pcb_path: Path) -> N
     # that the cross-seed equality check above would silently allow
     # (e.g. a router cost-function tweak that improves all seeds in
     # lockstep -- still a measurable regression vs the PR #3265 baseline).
-    EXPECTED = (22, 397, 24, 328.16)
-    assert ref == EXPECTED, (
-        f"Board 02 routing baseline drifted: got {ref}, expected "
-        f"{EXPECTED}. This is consistent across seeds (so no determinism "
-        "regression), but a real router-output change.  Investigate the "
-        "router PRs landed since 2026-06-07 (see PR #3265 baseline log) "
-        "and decide whether the change is desired -- if yes, update "
-        "EXPECTED here AND the docstring baseline."
+    EXPECTED_ROUTES = 22
+    EXPECTED_VIAS = 24
+    EXPECTED_LENGTH = 328.16
+    # Measured: 397 on macOS-arm64, 399 on CI Linux-x86_64 (see
+    # PLATFORM NOTE above).  Band is deliberately tight (+/-3 around
+    # the two measured values) so a real collinear-handling regression
+    # still trips it.
+    EXPECTED_SEGMENTS_RANGE = (394, 402)
+    got_routes, got_segments, got_vias, got_length = ref
+    exact = (got_routes, got_vias, got_length)
+    expected_exact = (EXPECTED_ROUTES, EXPECTED_VIAS, EXPECTED_LENGTH)
+    assert exact == expected_exact, (
+        f"Board 02 routing baseline drifted: got "
+        f"(routes, vias, length)={exact}, expected {expected_exact} "
+        f"(full tuple {ref}). This is consistent across seeds (so no "
+        "determinism regression), but a real router-output change.  "
+        "Investigate the router PRs landed since 2026-06-07 (see PR "
+        "#3265 baseline log) and decide whether the change is desired "
+        "-- if yes, update the EXPECTED_* pins here AND the docstring "
+        "baseline."
+    )
+    lo, hi = EXPECTED_SEGMENTS_RANGE
+    assert lo <= got_segments <= hi, (
+        f"Board 02 segment count {got_segments} outside the documented "
+        f"platform band [{lo}, {hi}] (macOS-arm64: 397, Linux-x86_64: "
+        "399; see PLATFORM NOTE above).  Routes/vias/length matched the "
+        "exact pin, so this is a change in collinear segmentation -- "
+        "investigate merge_collinear/path_is_clear behaviour before "
+        "widening the band."
     )

--- a/tests/router/test_board02_manufacturable_baseline.py
+++ b/tests/router/test_board02_manufacturable_baseline.py
@@ -425,8 +425,21 @@ def test_routing_output_deterministic_across_seeds(unrouted_pcb_path: Path) -> N
             "before relaxing the assertion."
         )
 
-    # Exact baseline numbers (re-baselined 2026-06-11 for Issue #3532:
-    # 45-degree quantization of the pad-tail emitters.  Off-grid pad
+    # Exact baseline numbers (re-baselined 2026-06-11 for Issue #3545:
+    # static foreign-pad halo cells now SURVIVE rip-up -- pre-fix the
+    # unmark erased them, letting later iterations route through pad
+    # clearance halos -- and the negotiated A* treats them as
+    # non-negotiable.  Routes, vias, total length and reach are
+    # UNCHANGED (22 routes, 24 vias, 328.16mm, full reach, 0 DRC at
+    # jlcpcb tier-1); the +10 segment delta (387 -> 397) is collinear
+    # re-splitting from the restored halo cells shifting merge
+    # boundaries -- the same harmless mode the stale-venv NOTE below
+    # documents.  All 3 cpp seeds (42/43/44) bit-perfect at
+    # (22, 397, 24, 328.16), measured in a uv.lock-synced venv.
+    #
+    # Prior pin (22, 387, 24, 328.16), re-baselined 2026-06-11 for
+    # Issue #3532: 45-degree quantization of the pad-tail emitters.
+    # Off-grid pad
     # tails are now emitted as exact two-leg doglegs instead of a single
     # skewed segment (+1 segment per off-grid tail), and the pull-tight
     # pass declines moves that would skew chain neighbours off the
@@ -453,7 +466,7 @@ def test_routing_output_deterministic_across_seeds(unrouted_pcb_path: Path) -> N
     # that the cross-seed equality check above would silently allow
     # (e.g. a router cost-function tweak that improves all seeds in
     # lockstep -- still a measurable regression vs the PR #3265 baseline).
-    EXPECTED = (22, 387, 24, 328.16)
+    EXPECTED = (22, 397, 24, 328.16)
     assert ref == EXPECTED, (
         f"Board 02 routing baseline drifted: got {ref}, expected "
         f"{EXPECTED}. This is consistent across seeds (so no determinism "

--- a/tests/router/test_validate_route_clearance_rect.py
+++ b/tests/router/test_validate_route_clearance_rect.py
@@ -617,13 +617,31 @@ class TestIssue2933SameComponentSignalMetalOverlap:
         assert clearance < 0
         assert location is not None
 
-    def test_trace_in_clearance_envelope_outside_pad_metal_is_accepted(self) -> None:
-        """The flip side of the regression: a trace that stays OUTSIDE
-        the same-component pad's metal -- even when below manufacturer
-        clearance -- must still pass under the #1764/#2933 carve-out.
-        This is the regime the carve-out is intended for (escape routing
-        past a neighbour pad with sub-DRC clearance, geometric
-        feasibility guaranteed by the component's designed pitch).
+    def test_trace_in_clearance_envelope_outside_pad_metal_is_rejected_3545(self) -> None:
+        """Issue #3545 NET-AWARE tightening of the #1764/#2933 carve-out.
+
+        Pre-#3545 contract: a trace that stayed OUTSIDE the
+        same-component pad's metal passed even below manufacturer
+        clearance, on the assumption that the component's designed
+        pitch guaranteed geometric feasibility.  That assumption is
+        net-blind: R1.2 here is a FOREIGN net (NODE_A vs the trace's
+        LINE_B), the component is standard pitch (2.0mm, above
+        ``fine_pitch_threshold``), no clearance relaxation is in
+        effect, and full-clearance routing around the pad is
+        geometrically feasible.  Exempting it shipped sub-clearance
+        copper that exact KiCad DRC flags (the routing-diagnostic
+        NET3-vs-J1.1 0.127mm defect).
+
+        Post-#3545 the carve-out only engages where the component
+        geometry forces the proximity: fine-pitch components (pitch
+        below ``rules.fine_pitch_threshold``), explicit / fine-pitch
+        clearance relaxations, or #2452-relaxed corridors.  This 0805
+        at 2.0mm pitch matches none, so the sub-clearance segment is
+        now REJECTED.  (The fine-pitch regime keeping the carve-out is
+        pinned by ``test_signal_net_carve_out_still_applies`` on the
+        0.5mm-pitch LQFP-48 fixture.)  Board 02 -- the #2933 origin --
+        still routes 22/22 with 0 DRC at jlcpcb tier-1 under the new
+        contract (re-measured for the #3545 re-baseline).
         """
         grid = self._make_0805_resistor_grid()
 
@@ -654,9 +672,11 @@ class TestIssue2933SameComponentSignalMetalOverlap:
             exclude_refs={"R1"},
         )
 
-        # Trace stays outside R1.2's metal (clearance >= 0) so the
-        # same-component carve-out applies and the segment passes.
-        assert is_valid is True
+        # Issue #3545: R1.2 is a foreign-net pad on a standard-pitch
+        # component with no relaxation in effect, so the validator now
+        # reports the sub-clearance gap (0.1mm actual vs 0.127mm
+        # required) instead of carving it out.
+        assert is_valid is False
 
 
 def test_validator_does_not_over_reject_non_fine_pitch_geometry() -> None:

--- a/tests/test_drc_regression.py
+++ b/tests/test_drc_regression.py
@@ -130,31 +130,20 @@ def get_routing_violations(report: DRCReport) -> list:
     return [v for v in report.violations if v.type in routing_types]
 
 
-# Issue #3545: the negotiated router can accept a final route through
-# STATICALLY blocked foreign-pad halo cells when overflow never resolves
-# (this fixture oscillates at overflow=2 with NET4 unroutable), and the
-# in-loop validator's same-component-ref skip is net-blind so the metric
-# reports clearance_viol=0 for copper 0.127mm from a foreign-net J1 pad.
-# Where the unresolved overflow lands is a deterministic function of
-# occupancy marking, so any router PR that legitimately perturbs
-# occupancy (e.g. #3532's exact dogleg emission) can re-roll it onto a
-# DRC-visible spot.  Non-strict: passes again whenever the dice land
-# benignly or once #3545's root fix (halo cells non-negotiable +
-# net-aware validator skip) lands.
-_XFAIL_STATIC_HALO_OVERFLOW = pytest.mark.xfail(
-    reason=(
-        "Issue #3545: negotiated router accepts unresolved overflow "
-        "through static foreign-pad halo cells; same-component validator "
-        "skip masks the resulting sub-clearance copper"
-    ),
-    strict=False,
-)
+# Issue #3545 (RESOLVED): the negotiated router used to accept a final
+# route through STATICALLY blocked foreign-pad halo cells -- rip-up
+# erased static halo cells outright instead of restoring them, after
+# which foreign nets routed straight through a pad's clearance band, and
+# the validator's net-blind same-component-ref skip masked the resulting
+# sub-clearance copper (NET3 0.127mm from J1-1 / NET1 on this fixture).
+# The root fix (static-blockage survival across rip-up + net-aware
+# validator carve-out + finalization backstop) landed with #3545; the
+# two tests below were xfail'd against the defect and now run strict.
 
 
 class TestRoutingDRCCompliance:
     """Tests for DRC compliance after routing."""
 
-    @_XFAIL_STATIC_HALO_OVERFLOW
     def test_routing_produces_no_drc_violations(
         self,
         routed_drc_report: tuple,
@@ -206,7 +195,6 @@ class TestRoutingDRCCompliance:
 class TestPadClearancePreservation:
     """Tests for pad clearance validation after rip-up and reroute."""
 
-    @_XFAIL_STATIC_HALO_OVERFLOW
     def test_no_clearance_violations_after_multiple_ripups(
         self,
         routed_drc_report: tuple,

--- a/tests/test_manufacturer_propagation_lint.py
+++ b/tests/test_manufacturer_propagation_lint.py
@@ -73,8 +73,8 @@ _ALLOWLIST: dict[str, dict[int, str]] = {
     # the caller explicitly passes ``rules=None`` (no PCB rules either).
     # The CLI always supplies its own rules with manufacturer wired in.
     "router/io.py": {
-        2691: "route() fallback when caller passes rules=None",
-        3292: "route_pcb() inner fallback when neither rules nor pcb_rules supplied",
+        2729: "route() fallback when caller passes rules=None",
+        3330: "route_pcb() inner fallback when neither rules nor pcb_rules supplied",
     },
     # Benchmark/synthetic fixture generators — no real CLI context.
     "benchmark/runner.py": {

--- a/tests/test_static_halo_ripup_3545.py
+++ b/tests/test_static_halo_ripup_3545.py
@@ -1,0 +1,303 @@
+"""Issue #3545: static foreign-pad halo cells must survive rip-up.
+
+Defect chain (routing-diagnostic fixture, surfaced by PR #3537's
+occupancy re-roll):
+
+1. ``RoutingGrid._unmark_segment`` / ``_unmark_via`` (and the C++
+   ``Grid3D::unmark_segment`` / ``unmark_via``) erased STATICALLY
+   blocked pad clearance-halo cells outright (``blocked=False, net=0``)
+   whenever a ripped-up route's clearance envelope swept them.  After
+   the erasure, foreign nets routed straight through the pad's
+   clearance band.
+2. The validator's same-component-ref carve-out was net-blind, so the
+   resulting sub-clearance copper (NET3 at 0.127mm from foreign-net J1
+   pad 1) was masked in-loop and only exact KiCad DRC caught it.
+3. Final acceptance had no backstop, so the route shipped.
+
+These tests pin the three fixes:
+
+* rip-up restores static halo cells (Python grid + C++ grid parity),
+* the same-component carve-out is net-aware (only active where a
+  fine-pitch or relaxed-corridor clearance relaxation actually applies),
+* ``Autorouter._demote_pad_clearance_violation_nets`` demotes nets whose
+  committed copper genuinely violates foreign-pad clearance beyond
+  nudge reach -- never committing it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.router import DesignRules, load_pcb_for_routing
+from kicad_tools.router.cpp_backend import is_cpp_available
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.primitives import Pad, Route, Segment
+
+FIXTURE = Path(__file__).parent / "fixtures" / "routing-diagnostic.kicad_pcb"
+
+
+@pytest.fixture
+def rules() -> DesignRules:
+    return DesignRules(
+        trace_width=0.2,
+        trace_clearance=0.2,
+        via_drill=0.3,
+        via_diameter=0.6,
+        grid_resolution=0.2,
+    )
+
+
+@pytest.fixture
+def grid(rules: DesignRules) -> RoutingGrid:
+    # 20mm x 20mm board at 0.2mm resolution.
+    return RoutingGrid(100, 100, rules, origin_x=0.0, origin_y=0.0)
+
+
+def _tht_pad(x: float, y: float, net: int, net_name: str, ref: str, pin: str) -> Pad:
+    """1.7mm circular THT pad, mirroring J1 on the routing-diagnostic fixture."""
+    return Pad(
+        x=x,
+        y=y,
+        width=1.7,
+        height=1.7,
+        net=net,
+        net_name=net_name,
+        layer=Layer.F_CU,
+        ref=ref,
+        pin=pin,
+        through_hole=True,
+        drill=1.0,
+    )
+
+
+class TestStaticHaloRipupRestore:
+    """Rip-up must restore static halo cells, not erase them."""
+
+    def test_python_ripup_restores_static_halo(
+        self, grid: RoutingGrid, rules: DesignRules
+    ) -> None:
+        """Mark + unmark a same-net route over a pad halo; halo survives."""
+        pad = _tht_pad(8.0, 12.0, net=1, net_name="NET1", ref="J1", pin="1")
+        grid.add_pad(pad)
+
+        # Halo cell west of the pad (the fixture's violating corridor).
+        gx, gy = grid.world_to_grid(7.0, 11.4)
+        layer = 0
+        assert bool(grid._blocked[layer, gy, gx]) is True
+        assert int(grid._net[layer, gy, gx]) == 1
+
+        # A NET1 route passing through its own pad's halo (legal).
+        route = Route(net=1, net_name="NET1")
+        route.segments.append(
+            Segment(x1=7.0, y1=10.0, x2=7.0, y2=12.0, width=0.2, layer=Layer.F_CU, net=1)
+        )
+        grid.mark_route(route)
+        grid.unmark_route(route)
+
+        # Pre-#3545 the unmark erased the halo (blocked=False, net=0),
+        # opening the corridor to foreign nets.  Post-fix the static
+        # blockage is restored.
+        assert bool(grid._blocked[layer, gy, gx]) is True, (
+            "static pad halo cell was erased by rip-up"
+        )
+        assert int(grid._net[layer, gy, gx]) == 1
+        # Foreign nets must still see the cell as blocked.
+        assert grid.is_blocked_for_net(gx, gy, layer, net=3) is True
+
+    def test_python_ripup_still_frees_route_only_cells(
+        self, grid: RoutingGrid, rules: DesignRules
+    ) -> None:
+        """Cells blocked ONLY by route copper are freed by rip-up."""
+        route = Route(net=5, net_name="NET5")
+        route.segments.append(
+            Segment(x1=4.0, y1=4.0, x2=4.0, y2=8.0, width=0.2, layer=Layer.F_CU, net=5)
+        )
+        grid.mark_route(route)
+        gx, gy = grid.world_to_grid(4.0, 6.0)
+        assert bool(grid._blocked[0, gy, gx]) is True
+        grid.unmark_route(route)
+        assert bool(grid._blocked[0, gy, gx]) is False
+        assert int(grid._net[0, gy, gx]) == 0
+
+    @pytest.mark.skipif(not is_cpp_available(), reason="C++ backend not built")
+    def test_cpp_ripup_restores_static_halo(self) -> None:
+        """C++ Grid3D parity: unmark_segment restores static cells."""
+        from kicad_tools.router import router_cpp  # type: ignore[attr-defined]
+
+        g = router_cpp.Grid3D(100, 100, 2, 0.2, 0.0, 0.0)
+        # Static halo cell (net 1, clearance halo: not pad metal).
+        g.mark_blocked(35, 57, 0, 1, True, False)
+        cell = g.at(35, 57, 0)
+        assert cell.blocked is True
+        assert cell.static_blocked is True
+        assert cell.original_net == 1
+
+        # Mark + rip a same-net route segment sweeping the halo cell.
+        g.mark_segment(35, 50, 35, 60, 0, 1, 2)
+        g.unmark_segment(35, 50, 35, 60, 0, 1, 2)
+
+        cell = g.at(35, 57, 0)
+        assert cell.blocked is True, "C++ rip-up erased a static halo cell"
+        assert cell.net == 1
+
+        # Route-only neighbour cells ARE freed.
+        cell2 = g.at(35, 50, 0)
+        assert cell2.blocked is False
+        assert cell2.net == 0
+
+    @pytest.mark.skipif(not is_cpp_available(), reason="C++ backend not built")
+    def test_cpp_ripup_restores_static_halo_via(self) -> None:
+        """C++ Grid3D parity: unmark_via restores static cells."""
+        from kicad_tools.router import router_cpp  # type: ignore[attr-defined]
+
+        g = router_cpp.Grid3D(100, 100, 2, 0.2, 0.0, 0.0)
+        g.mark_blocked(40, 40, 0, 7, True, False)
+        g.mark_via(40, 41, 7, 3)
+        g.unmark_via(40, 41, 7, 3)
+        cell = g.at(40, 40, 0)
+        assert cell.blocked is True
+        assert cell.net == 7
+
+
+class TestNetAwareSameComponentCarveout:
+    """The validator carve-out must not exempt foreign-net pads on
+    standard-pitch components."""
+
+    def test_foreign_net_same_component_pad_violation_detected(
+        self, grid: RoutingGrid, rules: DesignRules
+    ) -> None:
+        """The fixture geometry: NET3 segment 0.127mm from J1-1 (NET1)."""
+        grid.add_pad(_tht_pad(8.0, 12.0, net=1, net_name="NET1", ref="J1", pin="1"))
+        grid.add_pad(_tht_pad(8.0, 14.54, net=3, net_name="NET3", ref="J1", pin="2"))
+
+        seg = Segment(
+            x1=7.0, y1=11.0, x2=7.0, y2=11.6, width=0.2, layer=Layer.F_CU, net=3
+        )
+
+        # Pre-#3545: exclude_refs={"J1"} silently exempted J1-1 (foreign
+        # net) and the validator reported the segment as clean.
+        is_valid, clearance, _loc = grid.validate_segment_clearance(
+            seg, exclude_net=3, exclude_refs={"J1"}
+        )
+        assert is_valid is False, (
+            "net-blind same-component carve-out masked a foreign-net "
+            f"sub-clearance violation (clearance={clearance:.3f}mm)"
+        )
+        # Geometry: 1.077 center distance - 0.85 pad radius - 0.1 half
+        # trace = 0.127mm < 0.200mm required.
+        assert clearance == pytest.approx(0.127, abs=0.01)
+
+    def test_explicit_component_override_keeps_carveout(
+        self, rules: DesignRules
+    ) -> None:
+        """Fine-pitch-style explicit override keeps the #1764 carve-out."""
+        rules.component_clearances = {"J1": 0.05}
+        grid = RoutingGrid(100, 100, rules, origin_x=0.0, origin_y=0.0)
+        grid.add_pad(_tht_pad(8.0, 12.0, net=1, net_name="NET1", ref="J1", pin="1"))
+        grid.add_pad(_tht_pad(8.0, 14.54, net=3, net_name="NET3", ref="J1", pin="2"))
+
+        seg = Segment(
+            x1=7.0, y1=11.0, x2=7.0, y2=11.6, width=0.2, layer=Layer.F_CU, net=3
+        )
+        # 0.127mm actual >= 0.05mm required AND the relaxation is in
+        # effect, so the carve-out applies and the segment validates.
+        is_valid, _clearance, _loc = grid.validate_segment_clearance(
+            seg, exclude_net=3, exclude_refs={"J1"}
+        )
+        assert is_valid is True
+
+    def test_relaxed_corridor_component_keeps_carveout(
+        self, grid: RoutingGrid, rules: DesignRules
+    ) -> None:
+        """Components relaxed by #2452 keep the carve-out."""
+        grid.add_pad(_tht_pad(8.0, 12.0, net=1, net_name="NET1", ref="J1", pin="1"))
+        grid.add_pad(_tht_pad(8.0, 14.54, net=3, net_name="NET3", ref="J1", pin="2"))
+        # Simulate the #2452 corridor relaxation bookkeeping.
+        grid._relaxed_clearance_refs.add("J1")
+
+        seg = Segment(
+            x1=7.0, y1=11.0, x2=7.0, y2=11.6, width=0.2, layer=Layer.F_CU, net=3
+        )
+        is_valid, _clearance, _loc = grid.validate_segment_clearance(
+            seg, exclude_net=3, exclude_refs={"J1"}
+        )
+        assert is_valid is True
+
+    def test_metal_overlap_never_carved_out(self, grid: RoutingGrid) -> None:
+        """#2933 invariant: negative clearance is flagged regardless."""
+        grid.add_pad(_tht_pad(8.0, 12.0, net=1, net_name="NET1", ref="J1", pin="1"))
+        grid.add_pad(_tht_pad(8.0, 14.54, net=3, net_name="NET3", ref="J1", pin="2"))
+        grid._relaxed_clearance_refs.add("J1")
+
+        # Segment centerline crossing J1-1's pad metal.
+        seg = Segment(
+            x1=7.5, y1=11.0, x2=7.5, y2=13.0, width=0.2, layer=Layer.F_CU, net=3
+        )
+        is_valid, clearance, _loc = grid.validate_segment_clearance(
+            seg, exclude_net=3, exclude_refs={"J1"}
+        )
+        assert is_valid is False
+        assert clearance < 0
+
+
+class TestPadClearanceDemotionBackstop:
+    """Finalization backstop: severe foreign-pad violations are demoted,
+    never committed."""
+
+    def test_forced_route_through_static_halo_is_demoted(
+        self, rules: DesignRules
+    ) -> None:
+        """A route forced across a foreign pad's halo is stripped."""
+        router, _ = load_pcb_for_routing(
+            str(FIXTURE), rules=rules, validate_drc=False
+        )
+        # NET3 copper slicing through J1 pad 1 (NET1, at 8.0/12.0):
+        # clearance = 0.6 - 0.85 - 0.1 = -0.35mm => deficit 0.55mm,
+        # far beyond the 0.2mm grid-resolution nudge reach.
+        bad = Route(net=3, net_name="NET3")
+        bad.segments.append(
+            Segment(x1=7.4, y1=10.0, x2=7.4, y2=13.0, width=0.2, layer=Layer.F_CU, net=3)
+        )
+        router.routes.append(bad)
+        net_routes = {3: [bad]}
+
+        demoted = router._demote_pad_clearance_violation_nets(net_routes)
+
+        assert demoted == [3]
+        assert net_routes[3] == []
+        assert bad not in router.routes
+
+    def test_clean_route_is_not_demoted(self, rules: DesignRules) -> None:
+        """A legally placed route survives the backstop untouched."""
+        router, _ = load_pcb_for_routing(
+            str(FIXTURE), rules=rules, validate_drc=False
+        )
+        # Vertical NET3 run at x=6.0: 2.0mm from J1-1's center, well
+        # clear of every pad at full clearance.
+        good = Route(net=3, net_name="NET3")
+        good.segments.append(
+            Segment(x1=6.0, y1=10.0, x2=6.0, y2=11.0, width=0.2, layer=Layer.F_CU, net=3)
+        )
+        router.routes.append(good)
+        net_routes = {3: [good]}
+
+        demoted = router._demote_pad_clearance_violation_nets(net_routes)
+
+        assert demoted == []
+        assert net_routes[3] == [good]
+        assert good in router.routes
+
+    def test_worst_segment_pad_deficit_geometry(
+        self, grid: RoutingGrid
+    ) -> None:
+        """Exact-geometry deficit matches the fixture's 0.073mm gap."""
+        grid.add_pad(_tht_pad(8.0, 12.0, net=1, net_name="NET1", ref="J1", pin="1"))
+        seg = Segment(
+            x1=7.0, y1=11.0, x2=7.0, y2=11.6, width=0.2, layer=Layer.F_CU, net=3
+        )
+        deficit, loc = grid.worst_segment_pad_deficit(seg, exclude_net=3)
+        assert deficit == pytest.approx(0.2 - 0.127, abs=0.01)
+        assert loc == (8.0, 12.0)


### PR DESCRIPTION
Closes #3545

## Root cause (found by instrumented A* trace)

`RoutingGrid._unmark_segment` / `_unmark_via` (and C++ `Grid3D::unmark_segment` / `unmark_via`) **erased statically blocked pad clearance-halo cells** (`blocked=False, net=0`) whenever a ripped-up route's clearance envelope swept them. On the routing-diagnostic fixture, ripping NET1's route erased J1-1's halo at x=7.0; NET3 then routed straight through the freed corridor, the net-blind same-component carve-out masked the 0.127mm-vs-0.200mm gap in-loop, and the route shipped — the exact DRC failures in the #3545 diagnosis.

## Fixes (defense in depth)

1. **Static-blockage survival across rip-up** — lazy `_static_blocked` snapshot (Python, captured at first `mark_route`) + `GridCell.static_blocked` (C++, set by `mark_blocked`); unmark now restores `blocked=True, net=original_net` for static cells. C++ build version 10 → 11 (forces `kct build-native`).
2. **Static halos non-negotiable in the sharing A\*** — `usage_count > 0` no longer releases static cells to foreign nets (Python `_is_region_blocked` / `compute_expanded_blocked` + all five C++ sharing branches). Relief probes keep #3438 soft-crossing semantics.
3. **Net-aware same-component carve-out** — the exemption only engages where component geometry forces proximity: explicit/fine-pitch clearance relaxations (#1764), #2452-relaxed corridors, or fine-pitch components (`pitch < rules.fine_pitch_threshold`). Applied in Python `validate_segment_clearance`, the C++ `exclude_ref_hashes` gating, and io.py's `component_inherent` classification (so `drc_verify_and_nudge` now repairs what it previously filtered).
4. **Finalization backstop** (#3433/#3442 demote pattern) — `_demote_pad_clearance_violation_nets` strips nets whose committed copper violates foreign-pad clearance beyond one grid resolution (past nudge reach): demoted-to-partial, never committed.

## xfail flips

Both `test_drc_regression.py` xfail markers REMOVED; tests pass strict (verified XPASS first, then markers removed, full module 5/5). Fixture routing wall-clock dropped ~337s → ~37s — the A* was burning effort exploring corrupted-grid space.

## Synthetic tests (new `tests/test_static_halo_ripup_3545.py`, 11 tests)

- rip-up restores static halos (Python + C++ parity, segment + via), route-only cells still freed
- net-aware carve-out: foreign-net same-component pad at standard pitch rejected; explicit-override / relaxed-corridor / metal-overlap (#2933) regimes preserved
- backstop: route forced through a foreign pad halo → demoted, never committed; clean route untouched

## Fleet impact (strict gates on committed artifacts)

| Board | Gate result | Notes |
|---|---|---|
| 01 voltage-divider | 0 violations | clean |
| 02 charlieplex | 0 violations | clean |
| 03 usb-joystick | 4 via_in_pad | pre-existing class, unrelated |
| 04 stm32-devboard | 1 connectivity + 4 via_in_pad | pre-existing (matches fleet status) |
| 05 bldc | 8 connectivity + 14 via_in_pad | pre-existing |
| 06 diffpair | 2 clearance_segment_via + 2 connectivity | pre-existing class |
| 07 matchgroup | 5 connectivity + 1 diffpair_intra | pre-existing |
| softstart | 14 via_in_pad | pre-existing |

**Zero `clearance_pad_segment` violations on any committed artifact** — the #3545 defect class never shipped; no artifact-fix issues needed.

## Reach deltas / re-baselines

- **Board 02**: determinism pin re-baselined (22, 387, 24, 328.16) → (22, 397, 24, 328.16) — same routes/vias/length/reach, +10 collinear re-splits; bit-perfect across seeds 42/43/44; strict gates (22/22 routed, 0 DRC jlcpcb tier-1) pass. The issue explicitly sanctioned this re-baseline.
- **Board 06/07**: coverage-floor suites 87/87 pass.
- **Board 03**: 8 passed/1 skipped/2 setup-errors — byte-identical result on main (pre-existing).
- **Board 04/05**: `test_routes_all_nets_on_2l` (error) and `test_initial_pass_routes_enough_nets` (fail) reproduce identically on main (pre-existing, budget-sensitive).
- Fixture: 3/4 nets (NET4 unroutable by design), unchanged reach, now DRC-clean.
- One #2933-era contract test (`test_trace_in_clearance_envelope_outside_pad_metal_*`) flipped to the new net-aware contract with full rationale (its premise was the exact masking #3545 removes; board 02 evidence attached in the docstring).

## Test summary

- `tests/test_drc_regression.py` 5/5 strict
- `tests/test_static_halo_ripup_3545.py` 11/11
- `tests/router/` 500+ pass (only sanctioned baseline re-pin changed)
- pathfinder/negotiated suites 201 pass; io/clearance/nudge suites 308 pass
- `kct build-native` rebuilt at version 11

🤖 Generated with [Claude Code](https://claude.com/claude-code)