### PR TITLE
test: redraw net-extraction fixtures to CCW-positive pin convention

### DIFF
--- a/tests/test_cli_netlist.py
+++ b/tests/test_cli_netlist.py
@@ -869,15 +869,16 @@ class TestBuildNetlistFromSchematic:
         with pytest.raises(FileNotFoundError, match="Schematic not found"):
             build_netlist_from_schematic(sch_file)
 
-    @pytest.mark.xfail(
-        reason="fixture wires drawn at pre-#738 rotation pin positions -- see issue #3518",
-        strict=False,
-    )
     def test_build_netlist_extracts_connectivity(self, tmp_path):
         """Test that connectivity is extracted correctly."""
         from kicad_tools.operations.netlist import build_netlist_from_schematic
 
-        # Create a schematic with two resistors connected by a labeled wire
+        # Create a schematic with two resistors connected by a labeled wire.
+        # Pin positions follow the CCW-positive rotate-then-negate-Y
+        # convention (#738/#2129): both resistors are rotated 180 degrees,
+        # so R1 pin 1 (library (0, 3.81)) lands at (100, 53.81) and R2
+        # pin 2 (library (0, -3.81)) lands at (100, 66.19) -- the two
+        # endpoints of the labeled wire.
         sch_file = tmp_path / "test.kicad_sch"
         sch_file.write_text(
             """(kicad_sch
@@ -892,14 +893,14 @@ class TestBuildNetlistFromSchematic:
                   (symbol "R_1_1"
                     (pin passive line (at 0 3.81 270) (length 1.27) (name "~" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
                     (pin passive line (at 0 -3.81 90) (length 1.27) (name "~" (effects (font (size 1.27 1.27)))) (number "2" (effects (font (size 1.27 1.27))))))))
-              (symbol (lib_id "Device:R") (at 100 50 0) (unit 1)
+              (symbol (lib_id "Device:R") (at 100 50 180) (unit 1)
                 (in_bom yes) (on_board yes)
                 (uuid "00000000-0000-0000-0000-000000000010")
                 (property "Reference" "R1" (at 101.6 48.26 0))
                 (property "Value" "10k" (at 101.6 50.8 0))
                 (pin "1" (uuid "00000000-0000-0000-0000-000000000011"))
                 (pin "2" (uuid "00000000-0000-0000-0000-000000000012")))
-              (symbol (lib_id "Device:R") (at 100 70 0) (unit 1)
+              (symbol (lib_id "Device:R") (at 100 70 180) (unit 1)
                 (in_bom yes) (on_board yes)
                 (uuid "00000000-0000-0000-0000-000000000020")
                 (property "Reference" "R2" (at 101.6 68.26 0))
@@ -924,7 +925,8 @@ class TestBuildNetlistFromSchematic:
         assert "NODE_A" in net_names
 
         # Check the NODE_A net has the correct pins
-        # Note: With the schematic layout, wire connects R1 pin 1 (at y=53.81) to R2 pin 2 (at y=66.19)
+        # Note: With the 180-degree rotations, the wire connects
+        # R1 pin 1 (at y=53.81) to R2 pin 2 (at y=66.19)
         node_a_net = next(n for n in result.nets if n.name == "NODE_A")
         pin_refs = {(node.reference, node.pin) for node in node_a_net.nodes}
         assert ("R1", "1") in pin_refs

--- a/tests/test_netlist_query.py
+++ b/tests/test_netlist_query.py
@@ -7,8 +7,6 @@ Tests the netlist extraction and connectivity query methods:
 - are_connected()
 """
 
-import pytest
-
 from kicad_tools.schematic.models import PinRef, Schematic
 from kicad_tools.schematic.models.elements import Junction, Label, Wire
 from kicad_tools.schematic.models.pin import Pin
@@ -146,16 +144,14 @@ class TestExtractNetlist:
         assert pins[0].symbol_ref == "R1"
         assert pins[0].pin == "2"
 
-    @pytest.mark.xfail(
-        reason="fixture wires drawn at pre-#738 rotation pin positions -- see issue #3518",
-        strict=False,
-    )
     def test_power_net(self):
         """Power symbols create named nets."""
         sch = Schematic("Test")
 
-        # IC with VDD pin
-        ic_def = make_simple_symbol("MCU:Test", [("VDD", "1", 0, -2.54)])
+        # IC with VDD pin.  Pin coordinates are library Y-UP (#738/#2129):
+        # VDD at library (0, +2.54) lands at schematic (100, 47.46) after
+        # the rotate-then-negate-Y transform in SymbolInstance.pin_position.
+        ic_def = make_simple_symbol("MCU:Test", [("VDD", "1", 0, 2.54)])
         ic = SymbolInstance(
             symbol_def=ic_def,
             x=100,
@@ -390,28 +386,28 @@ class TestAreConnected:
 class TestComplexNetlist:
     """Integration tests with more complex schematics."""
 
-    @pytest.mark.xfail(
-        reason="fixture wires drawn at pre-#738 rotation pin positions -- see issue #3518",
-        strict=False,
-    )
     def test_power_distribution(self):
         """Multiple components on a power net."""
         sch = Schematic("Test")
 
-        # IC with multiple power pins
+        # IC with multiple power pins.  Pin coordinates are library Y-UP
+        # (#738/#2129): VDD at library (0, +5.08) is the TOP pin and lands
+        # at schematic (100, 44.92) after the rotate-then-negate-Y
+        # transform; VSS at library (0, -5.08) lands at (100, 55.08).
         ic_def = make_simple_symbol(
             "MCU:Test",
             [
-                ("VDD", "1", 0, -5.08),
-                ("VSS", "2", 0, 5.08),
+                ("VDD", "1", 0, 5.08),
+                ("VSS", "2", 0, -5.08),
                 ("IO", "3", 5.08, 0),
             ],
         )
         ic = SymbolInstance(symbol_def=ic_def, x=100, y=50, rotation=0, reference="U1", value="MCU")
         sch.symbols.append(ic)
 
-        # Decoupling capacitor
-        c_def = make_simple_symbol("Device:C", [("~", "1", 0, -2.54), ("~", "2", 0, 2.54)])
+        # Decoupling capacitor: pin 1 at library (0, +2.54) -> schematic
+        # (90, 47.46); pin 2 at library (0, -2.54) -> schematic (90, 52.54).
+        c_def = make_simple_symbol("Device:C", [("~", "1", 0, 2.54), ("~", "2", 0, -2.54)])
         cap = SymbolInstance(symbol_def=c_def, x=90, y=50, rotation=0, reference="C1", value="100n")
         sch.symbols.append(cap)
 

--- a/tests/test_validate_hierarchical_nets.py
+++ b/tests/test_validate_hierarchical_nets.py
@@ -40,7 +40,10 @@ HIERARCHICAL_ROOT_SCH = Path(__file__).parent / "fixtures" / "hierarchical" / "r
 # chosen to AGREE with what extract_netlist(hierarchical=True) produces
 # for every component (root + every sub-sheet). On the fixtures this is
 # the auto-generated Net-(<ref>-<pin>) form for sub-sheet pins and the
-# power-symbol names ("VCC", "GND") for the root R1 pins.
+# power-symbol names ("VCC", "GND") for the root R1 pins. Under the
+# CCW-positive rotate-then-negate-Y pin convention (#738/#2129), R1
+# pin 1 (library (0, 3.81)) is the TOP pin at (100, 46.19) touching the
+# VCC rail, and pin 2 is the BOTTOM pin at (100, 53.81) touching GND.
 HIERARCHICAL_PCB_MATCHING_NETS = """(kicad_pcb
   (version 20240108)
   (generator "test")
@@ -69,8 +72,8 @@ HIERARCHICAL_PCB_MATCHING_NETS = """(kicad_pcb
     (layer "F.Cu") (uuid "fp-r1") (at 100 100)
     (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "p-r1-ref"))
     (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab") (uuid "p-r1-val"))
-    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 2 "GND"))
-    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "VCC"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "VCC"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 2 "GND"))
   )
   (footprint "Resistor_SMD:R_0402_1005Metric"
     (layer "F.Cu") (uuid "fp-r2") (at 110 100)
@@ -144,8 +147,8 @@ HIERARCHICAL_PCB_BAD_SUBSHEET_NET = """(kicad_pcb
     (layer "F.Cu") (uuid "fp-r1") (at 100 100)
     (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "p-r1-ref"))
     (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab") (uuid "p-r1-val"))
-    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 2 "GND"))
-    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "VCC"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "VCC"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 2 "GND"))
   )
   (footprint "Resistor_SMD:R_0402_1005Metric"
     (layer "F.Cu") (uuid "fp-r2") (at 110 100)
@@ -272,10 +275,6 @@ class TestCheckNetsHierarchical:
     issue #2633.
     """
 
-    @pytest.mark.xfail(
-        reason="fixture wires drawn at pre-#738 rotation pin positions -- see issue #3518",
-        strict=False,
-    )
     def test_in_sync_hierarchical_reports_no_net_issues(
         self, hierarchical_matching_nets_pcb: Path
     ) -> None:
@@ -288,10 +287,6 @@ class TestCheckNetsHierarchical:
             f"{[(i.reference, i.schematic_value, i.pcb_value) for i in net_issues]}"
         )
 
-    @pytest.mark.xfail(
-        reason="fixture wires drawn at pre-#738 rotation pin positions -- see issue #3518",
-        strict=False,
-    )
     def test_subsheet_net_mismatch_is_detected(
         self, hierarchical_bad_subsheet_net_pcb: Path
     ) -> None:


### PR DESCRIPTION
Closes #3518

## Summary

Five connectivity-extraction tests were xfailed by the #3436 burn-down because their hand-drawn schematic fixtures encoded pre-#738 pin positions. `SymbolInstance.pin_position` / `LibrarySymbol.get_pin_position` now rotate in library coordinates (Y-up, CCW-positive) FIRST and negate Y after (#738/#2129) -- production is correct, the fixtures were stale. This PR redraws the fixture geometry so wires/labels/pads coincide with the convention-correct pin positions, keeps the original assertions, and removes all five xfail marks.

## Fixture geometry changes

- **tests/test_cli_netlist.py::test_build_netlist_extracts_connectivity**: both `Device:R` instances rotated `0 -> 180` so the labeled wire endpoints `(100, 53.81)-(100, 66.19)` land exactly on R1 pin 1 and R2 pin 2 as the original assertions expect (this matches the test's own inline comment, which described pin 1 at y=53.81).
- **tests/test_netlist_query.py::test_power_net / test_power_distribution**: in-memory `SymbolDef` pin offsets rewritten in library Y-up convention (VDD at +Y = top pin): `VDD (0,-2.54) -> (0,+2.54)`, `VDD/VSS (0,-5.08)/(0,+5.08) -> (0,+5.08)/(0,-5.08)`, cap pins `(0,-2.54)/(0,+2.54) -> (0,+2.54)/(0,-2.54)`. Pins now land on the existing wires, junctions, and power symbols, which were left untouched.
- **tests/test_validate_hierarchical_nets.py**: the shared `tests/fixtures/hierarchical/root.kicad_sch` already coincides with the corrected pins (R1 pin 1 = top at y=46.19 on the VCC rail; pin 2 = bottom at y=53.81 on GND). The stale part was the two embedded PCB fixtures, whose R1 pad nets encoded the swapped pre-#738 assignment; pad 1 is now `VCC` and pad 2 `GND` in both `HIERARCHICAL_PCB_MATCHING_NETS` and `HIERARCHICAL_PCB_BAD_SUBSHEET_NET`.
- Removed the now-unused `import pytest` from test_netlist_query.py (added by #3436 only for the xfail marks).

All corrected positions were computed with the production transform itself (throwaway script driving `SymbolInstance.pin_position`), not hand-derived.

## Test results

- The five previously-xfailed tests: **5 passed**
- Full affected suites (`test_cli_netlist.py`, `test_netlist_query.py`, `test_validate_hierarchical_nets.py`) plus the suites sharing the hierarchical fixtures (`test_hierarchical_netlist.py`, `test_sch_pin_map.py`): **158 passed, 0 failed**
- `ruff check`: clean. Note: `ruff format --check` flags test_cli_netlist.py on main as well (pre-existing, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)