### PR TITLE
fix(export): LF line endings for BOM/CPL CSVs + manifest integrity CI guard

### DIFF
--- a/boards/01-voltage-divider/output/manufacturing/manifest.json
+++ b/boards/01-voltage-divider/output/manufacturing/manifest.json
@@ -5,12 +5,12 @@
   "manufacturer": "jlcpcb",
   "files": {
     "bom_jlcpcb.csv": {
-      "sha256": "33431e77ecddbaf7352ed70285f26b66b7291f7f0db81939015592582a4da356",
-      "size": 240
+      "sha256": "9fc349b85c12d2c631884a4f31ab151fc142f678d912eca49be97462d9e8802a",
+      "size": 236
     },
     "cpl_jlcpcb.csv": {
-      "sha256": "52266c589d3ef382c2a672dd4fcae912513c0a57a818ab0e3b3ba484f48fe17a",
-      "size": 372
+      "sha256": "dd868b13c6307261c680c0b7a6921cd8823cb4dcedf0f7ceca8b5cf8ac8126cc",
+      "size": 367
     },
     "gerbers.zip": {
       "sha256": "dea4c79f6ef04960f3c2af71e6bf41e70b2d6454feea781ad06a307dd60de301",

--- a/boards/06-diffpair-test/output/manufacturing/manifest.json
+++ b/boards/06-diffpair-test/output/manufacturing/manifest.json
@@ -5,12 +5,12 @@
   "manufacturer": "jlcpcb",
   "files": {
     "bom_jlcpcb.csv": {
-      "sha256": "91cf0f8a65ec320dbe527d5d0de524ee8f5f91853e86570ec924a509f83b411f",
-      "size": 444
+      "sha256": "45599b2cf1e021bcef64ff637cffe71d2e41c1fa57a3d69ed196edcc085acc7c",
+      "size": 436
     },
     "cpl_jlcpcb.csv": {
-      "sha256": "8b4ae1783abf6ee95ae060c1ba5b46fb314d05c9dc7d09777a17616fd95e6cdc",
-      "size": 591
+      "sha256": "a2c7cbc91bb50ed15e8d65a99c1d788aad4b7c2c728db661d314b0e3eddacda6",
+      "size": 583
     },
     "gerbers.zip": {
       "sha256": "d80a9387cb957af983fd3e1c92e9f4bd9356846eb822f2a5984a69bda5475985",

--- a/boards/07-matchgroup-test/output/manufacturing/manifest.json
+++ b/boards/07-matchgroup-test/output/manufacturing/manifest.json
@@ -5,12 +5,12 @@
   "manufacturer": "jlcpcb",
   "files": {
     "bom_jlcpcb.csv": {
-      "sha256": "73616c721f54f53f170914f02d3270212c7b9243ad92caf3006a45311e025952",
-      "size": 542
+      "sha256": "50f8099e0a50276067a08f7e9e2342750b592983881da79f16c1d252dbaf66e1",
+      "size": 533
     },
     "cpl_jlcpcb.csv": {
-      "sha256": "e6674686799dbff54ddcc1ffe6a9032b85a317ca13f2ce57d48a2337f4f24e6f",
-      "size": 711
+      "sha256": "0a3a84fccd4e77e6b0cbe1521c2a0235713079d067b5a42efdc02cfd676745c6",
+      "size": 702
     },
     "gerbers.zip": {
       "sha256": "9d3666c4726fd685e217b8512439a4213a24908f5bec0a45489686e0035fda5e",

--- a/boards/external/softstart/output/manufacturing/manifest.json
+++ b/boards/external/softstart/output/manufacturing/manifest.json
@@ -5,12 +5,12 @@
   "manufacturer": "jlcpcb-tier1",
   "files": {
     "bom_jlcpcb.csv": {
-      "sha256": "ee97cedb8c151ff78d8507d720d2066e8142ae81f78d95498a604904f251f0d5",
-      "size": 1935
+      "sha256": "15d0f1dcafad8ac7d8e7b6c355aed21e16408683378f3d57cc23e7adf9dbbcc0",
+      "size": 1900
     },
     "cpl_jlcpcb.csv": {
-      "sha256": "012ae7530431aa72aa096bdf9e8bf0ad664a52c1e3ed0bd9bd876b51a14cda03",
-      "size": 3907
+      "sha256": "1b58a014335748b4f7bb3a7080b2f2af5c273a4789a9fdf959d6991cf2bb8adf",
+      "size": 3850
     },
     "gerbers.zip": {
       "sha256": "a11930353a35e46d209dfa21820f04b6a7365e484f0e77d3ddf1986de71ae42a",

--- a/src/kicad_tools/export/__init__.py
+++ b/src/kicad_tools/export/__init__.py
@@ -77,6 +77,7 @@ from .manufacturing import (
     ManufacturingConfig,
     ManufacturingPackage,
     ManufacturingResult,
+    verify_manifest,
 )
 from .pnp import (
     PNP_FORMATTERS,
@@ -118,6 +119,7 @@ __all__ = [
     "ManufacturingPackage",
     "ManufacturingConfig",
     "ManufacturingResult",
+    "verify_manifest",
     # Pre-flight validation
     "PreflightChecker",
     "PreflightConfig",

--- a/src/kicad_tools/export/assembly.py
+++ b/src/kicad_tools/export/assembly.py
@@ -442,7 +442,10 @@ class AssemblyPackage:
         # Write to file
         filename = self.config.bom_filename.format(manufacturer=self.fab_family)
         bom_path = output_dir / filename
-        bom_path.write_text(bom_csv)
+        # newline="\n" keeps the on-disk file byte-identical to the
+        # formatted string on every platform, so manifest.json checksums
+        # match the committed (git-normalized, LF) content (issue #3529).
+        bom_path.write_text(bom_csv, newline="\n")
 
         logger.info(f"Generated BOM: {bom_path}")
         return bom_path
@@ -474,7 +477,8 @@ class AssemblyPackage:
         # Write to file
         filename = self.config.pnp_filename.format(manufacturer=self.fab_family)
         pnp_path = output_dir / filename
-        pnp_path.write_text(pnp_csv)
+        # newline="\n": see _generate_bom — keep disk == git == manifest.
+        pnp_path.write_text(pnp_csv, newline="\n")
 
         logger.info(f"Generated CPL: {pnp_path}")
         return pnp_path

--- a/src/kicad_tools/export/bom_formats.py
+++ b/src/kicad_tools/export/bom_formats.py
@@ -102,7 +102,7 @@ class JLCPCBBOMFormatter(BOMFormatter):
             }
 
         output = io.StringIO()
-        writer = csv.writer(output)
+        writer = csv.writer(output, lineterminator="\n")
         writer.writerow(self.get_headers())
 
         for key, group_items in sorted(grouped.items()):
@@ -163,7 +163,7 @@ class PCBWayBOMFormatter(BOMFormatter):
             grouped = {(item.value, item.footprint): [item] for item in filtered}
 
         output = io.StringIO()
-        writer = csv.writer(output)
+        writer = csv.writer(output, lineterminator="\n")
         writer.writerow(self.get_headers())
 
         for idx, (key, group_items) in enumerate(sorted(grouped.items()), 1):
@@ -214,7 +214,7 @@ class SeeedBOMFormatter(BOMFormatter):
             grouped = {item.reference: [item] for item in filtered}
 
         output = io.StringIO()
-        writer = csv.writer(output)
+        writer = csv.writer(output, lineterminator="\n")
         writer.writerow(self.get_headers())
 
         for _key, group_items in sorted(grouped.items()):
@@ -263,7 +263,7 @@ class GenericBOMFormatter(BOMFormatter):
             grouped = {item.reference: [item] for item in filtered}
 
         output = io.StringIO()
-        writer = csv.writer(output)
+        writer = csv.writer(output, lineterminator="\n")
         writer.writerow(self.get_headers())
 
         for key, group_items in sorted(grouped.items()):

--- a/src/kicad_tools/export/manufacturing.py
+++ b/src/kicad_tools/export/manufacturing.py
@@ -152,6 +152,66 @@ def _sha256_file(path: Path) -> str:
     return h.hexdigest()
 
 
+def verify_manifest(manifest_path: str | Path) -> list[str]:
+    """Verify a manufacturing bundle's manifest.json against files on disk.
+
+    Recomputes the SHA256 checksum and size of every file listed in the
+    manifest and compares them to the recorded values.  Files are looked
+    up first in the manifest's own directory; entries that aren't found
+    there are searched recursively, because the manifest records bare
+    filenames even for artifacts that live in subdirectories (e.g.
+    ``gerbers.zip`` under ``gerbers/``).
+
+    The manifest itself is excluded from verification (its hash can't
+    contain itself).
+
+    Args:
+        manifest_path: Path to a ``manifest.json`` file.
+
+    Returns:
+        A list of human-readable mismatch descriptions.  Empty list
+        means every listed file exists and matches its recorded
+        checksum and size.
+
+    This is the integrity check behind issue #3529: ``kct export`` used
+    to write BOM/CPL CSVs with CRLF line endings and hash that content,
+    while git normalization stored LF -- so a fresh checkout failed
+    ``sha256sum`` verification against the manifest.
+    """
+    manifest_path = Path(manifest_path)
+    bundle_dir = manifest_path.parent
+    manifest = json.loads(manifest_path.read_text())
+
+    problems: list[str] = []
+    for name, info in manifest.get("files", {}).items():
+        if name == manifest_path.name:
+            continue
+        fpath = bundle_dir / name
+        if not fpath.exists():
+            # Manifest stores bare filenames; some artifacts live in
+            # subdirectories of the bundle (e.g. gerbers/gerbers.zip).
+            candidates = sorted(bundle_dir.rglob(name))
+            if not candidates:
+                problems.append(f"{name}: listed in manifest but not found on disk")
+                continue
+            fpath = candidates[0]
+
+        actual_sha = _sha256_file(fpath)
+        actual_size = fpath.stat().st_size
+        expected_sha = info.get("sha256")
+        expected_size = info.get("size")
+        if expected_sha is not None and actual_sha != expected_sha:
+            problems.append(
+                f"{name}: sha256 mismatch (manifest {expected_sha}, disk {actual_sha})"
+            )
+        if expected_size is not None and actual_size != expected_size:
+            problems.append(
+                f"{name}: size mismatch (manifest {expected_size}, disk {actual_size})"
+            )
+
+    return problems
+
+
 def _create_project_zip(
     pcb_path: Path,
     output_dir: Path,

--- a/src/kicad_tools/export/pnp.py
+++ b/src/kicad_tools/export/pnp.py
@@ -166,7 +166,7 @@ class JLCPCBPnPFormatter(PnPFormatter):
         filtered = self.filter_placements(placements)
 
         output = io.StringIO()
-        writer = csv.writer(output)
+        writer = csv.writer(output, lineterminator="\n")
         writer.writerow(self.get_headers())
 
         for placement in sorted(filtered, key=lambda p: p.reference):
@@ -218,7 +218,7 @@ class PCBWayPnPFormatter(PnPFormatter):
         filtered = self.filter_placements(placements)
 
         output = io.StringIO()
-        writer = csv.writer(output)
+        writer = csv.writer(output, lineterminator="\n")
         writer.writerow(self.get_headers())
 
         for placement in sorted(filtered, key=lambda p: p.reference):
@@ -263,7 +263,7 @@ class SeeedPnPFormatter(PnPFormatter):
         filtered = self.filter_placements(placements)
 
         output = io.StringIO()
-        writer = csv.writer(output)
+        writer = csv.writer(output, lineterminator="\n")
         writer.writerow(self.get_headers())
 
         for placement in sorted(filtered, key=lambda p: p.reference):
@@ -299,7 +299,7 @@ class GenericPnPFormatter(PnPFormatter):
         filtered = self.filter_placements(placements)
 
         output = io.StringIO()
-        writer = csv.writer(output)
+        writer = csv.writer(output, lineterminator="\n")
         writer.writerow(self.get_headers())
 
         for placement in sorted(filtered, key=lambda p: p.reference):

--- a/tests/test_manifest_integrity.py
+++ b/tests/test_manifest_integrity.py
@@ -1,0 +1,162 @@
+"""Bundle-integrity guards for manufacturing manifests (issue #3529).
+
+``kct export`` used to write ``bom_jlcpcb.csv`` / ``cpl_jlcpcb.csv`` with
+CRLF line endings (csv.writer's default) and hash THAT content into
+``manifest.json``.  Git text normalization stores LF, so ``sha256sum`` on
+a fresh checkout mismatched the manifest for those two files -- found
+while shipping softstart rev B (softstart#5).
+
+Two layers of defense:
+
+1. Formatter-level: all CSV exporters must emit LF-only content so that
+   disk == git == manifest on every platform.
+2. Bundle-level: every committed ``output/**/manifest.json`` under
+   ``boards/`` must verify against the files actually on disk.  This is
+   the check that would have caught both the CRLF mismatch and the
+   stale-manifest-entry class (issue #3529 scope addition from the
+   PR #3536 judge).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.export import verify_manifest
+from kicad_tools.export.bom_formats import BOMExportConfig, JLCPCBBOMFormatter
+from kicad_tools.export.pnp import JLCPCBPnPFormatter, PlacementData, PnPExportConfig
+from kicad_tools.schema.bom import BOMItem
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# All committed manufacturing bundles: boards/*/output and
+# boards/external/*/output (softstart etc.).
+COMMITTED_MANIFESTS = sorted(REPO_ROOT.glob("boards/**/output/**/manifest.json"))
+
+
+def _manifest_id(path: Path) -> str:
+    return str(path.relative_to(REPO_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: CSV exporters must emit LF-only content
+# ---------------------------------------------------------------------------
+
+
+class TestCSVLineEndings:
+    def test_jlcpcb_bom_has_no_crlf(self):
+        items = [
+            BOMItem(
+                reference="R1",
+                value="10k",
+                footprint="R_0603_1608Metric",
+                lib_id="Device:R",
+                lcsc="C25804",
+            ),
+            BOMItem(
+                reference="C1",
+                value="100nF",
+                footprint="C_0603_1608Metric",
+                lib_id="Device:C",
+                lcsc="C14663",
+            ),
+        ]
+        csv_text = JLCPCBBOMFormatter(BOMExportConfig()).format(items)
+        assert "\r" not in csv_text, "BOM CSV must use LF line endings (issue #3529)"
+        assert csv_text.endswith("\n")
+        assert len(csv_text.splitlines()) == 3  # header + 2 rows
+
+    def test_jlcpcb_cpl_has_no_crlf(self):
+        placements = [
+            PlacementData(
+                reference="R1",
+                value="10k",
+                footprint="R_0603_1608Metric",
+                x=10.0,
+                y=20.0,
+                rotation=90.0,
+                layer="F.Cu",
+            ),
+        ]
+        csv_text = JLCPCBPnPFormatter(PnPExportConfig()).format(placements)
+        assert "\r" not in csv_text, "CPL CSV must use LF line endings (issue #3529)"
+        assert csv_text.endswith("\n")
+
+
+# ---------------------------------------------------------------------------
+# Layer 2a: verify_manifest unit behaviour
+# ---------------------------------------------------------------------------
+
+
+def _write_bundle(tmp_path: Path) -> Path:
+    """Create a minimal bundle with a correct manifest; return its path."""
+    bom = tmp_path / "bom_jlcpcb.csv"
+    bom.write_text("Comment,Designator,Footprint,LCSC Part #\n10k,R1,R_0603,C25804\n")
+    gerber_dir = tmp_path / "gerbers"
+    gerber_dir.mkdir()
+    zip_file = gerber_dir / "gerbers.zip"
+    zip_file.write_bytes(b"PK\x05\x06" + b"\x00" * 18)  # empty zip
+
+    files = {}
+    for p in (bom, zip_file):
+        files[p.name] = {
+            "sha256": hashlib.sha256(p.read_bytes()).hexdigest(),
+            "size": p.stat().st_size,
+        }
+    manifest_path = tmp_path / "manifest.json"
+    files[manifest_path.name] = {"sha256": "self", "size": 0}  # must be skipped
+    manifest_path.write_text(json.dumps({"version": "1.0", "files": files}, indent=2))
+    return manifest_path
+
+
+class TestVerifyManifest:
+    def test_clean_bundle_passes(self, tmp_path):
+        manifest_path = _write_bundle(tmp_path)
+        assert verify_manifest(manifest_path) == []
+
+    def test_resolves_files_in_subdirectories(self, tmp_path):
+        # gerbers.zip lives in gerbers/ but the manifest stores the bare
+        # name; verification must still find and check it.
+        manifest_path = _write_bundle(tmp_path)
+        problems = verify_manifest(manifest_path)
+        assert not any("gerbers.zip" in p for p in problems)
+
+    def test_detects_modified_content(self, tmp_path):
+        manifest_path = _write_bundle(tmp_path)
+        # Simulate the CRLF normalization mismatch: same logical content,
+        # different bytes on disk.
+        bom = tmp_path / "bom_jlcpcb.csv"
+        bom.write_bytes(bom.read_bytes().replace(b"\n", b"\r\n"))
+        problems = verify_manifest(manifest_path)
+        assert any("bom_jlcpcb.csv" in p and "sha256 mismatch" in p for p in problems)
+        assert any("bom_jlcpcb.csv" in p and "size mismatch" in p for p in problems)
+
+    def test_detects_missing_file(self, tmp_path):
+        manifest_path = _write_bundle(tmp_path)
+        (tmp_path / "bom_jlcpcb.csv").unlink()
+        problems = verify_manifest(manifest_path)
+        assert any("bom_jlcpcb.csv" in p and "not found" in p for p in problems)
+
+
+# ---------------------------------------------------------------------------
+# Layer 2b: every committed bundle must verify (would have caught #3529)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("manifest_path", COMMITTED_MANIFESTS, ids=_manifest_id)
+def test_committed_bundle_manifest_verifies(manifest_path: Path):
+    problems = verify_manifest(manifest_path)
+    assert problems == [], (
+        f"{_manifest_id(manifest_path)} is stale relative to the files on disk. "
+        "Regenerate the bundle (kct export) or recompute the listed hashes. "
+        f"Mismatches: {problems}"
+    )
+
+
+def test_committed_bundles_discovered():
+    """Guard the glob itself -- if bundle layout moves, fail loudly instead
+    of silently parametrizing over nothing."""
+    assert COMMITTED_MANIFESTS, "expected committed manifest.json bundles under boards/"


### PR DESCRIPTION
Closes #3529

## Summary

`kct export` wrote `bom_jlcpcb.csv` / `cpl_jlcpcb.csv` with CRLF line endings (csv.writer's default) and hashed that content into `manifest.json` — but git text normalization stores LF, so `sha256sum` on a fresh checkout mismatched the manifest for those two files. Found shipping softstart rev B (softstart#5).

**Approach: LF at the writer** (option preferred by the issue), making disk == git == manifest on every platform.

### Changes

- **`src/kicad_tools/export/bom_formats.py` / `pnp.py`**: all CSV formatters (JLCPCB, PCBWay, Seeed, Generic) now pass `lineterminator="\n"` to `csv.writer`.
- **`src/kicad_tools/export/assembly.py`**: BOM/CPL files written with `write_text(..., newline="\n")` so no platform newline translation can reintroduce CRLF (e.g. on Windows).
- **`src/kicad_tools/export/manufacturing.py`**: new public `verify_manifest(manifest_path)` helper — recomputes sha256 + size for every manifest entry, resolving bare filenames that live in subdirectories (`gerbers/gerbers.zip`), skipping the manifest's self-entry. Exported from `kicad_tools.export`.
- **`tests/test_manifest_integrity.py`** (new, runs in CI's normal pytest job):
  - formatter-level: JLCPCB BOM/CPL output contains no `\r`
  - unit coverage of `verify_manifest` (clean pass, subdir resolution, CRLF-tamper detection, missing file)
  - **bundle-level guard**: parametrized over every committed `boards/**/output/**/manifest.json` (demo boards 01–07 + `boards/external/softstart`) and fails on any hash/size drift — would have caught both the CRLF mismatch and the stale `cpl_jlcpcb.csv` entry flagged by the PR #3536 judge (issue scope addition).

### Manifests regenerated (hash recompute only — no pipeline re-run, no routing changes)

Stale CSV entries (sha256 + size) recomputed in:
- `boards/01-voltage-divider/output/manufacturing/manifest.json`
- `boards/06-diffpair-test/output/manufacturing/manifest.json`
- `boards/07-matchgroup-test/output/manufacturing/manifest.json`
- `boards/external/softstart/output/manufacturing/manifest.json`

Boards 02–05 verified clean already. The on-disk CSVs are already LF (git-normalized), so only the manifest entries needed updating. `boards/external/softstart/project.kct` symlink untouched.

## Test plan

- [x] `tests/test_manifest_integrity.py` — 15/15 pass (includes all 8 committed bundles verifying)
- [x] Export-related suites: `test_manufacturing_package`, `test_export*`, `test_assembly_validation`, `test_pcb_manufacturing_export`, `test_mcp_export` — 304 pass
- [x] BOM/CSV-adjacent suites: `test_mcp_bom`, `test_mcp_assembly`, `test_preflight`, `test_bom_lcsc_merge`, `test_fleet_status`, `test_board_01_ship_ready`, `test_dsn_export`, etc. — 274 pass (one initial failure was a missing `shapely` in a bare `uv sync` venv; passes with `--extra dev` as CI uses)
- [x] `ruff check` / `ruff format --check` clean on the new test file; the 16 pre-existing errors in `src/kicad_tools/export/` are identical on main (CI lint is continue-on-error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)