### PR TITLE
fix(router): Python-backend static-halo gate for vias/diagonals + via-pad demotion backstop

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -9911,10 +9911,13 @@ class Autorouter:
         grid resolution (beyond ``drc_verify_and_nudge``'s plausible snap
         reach) is demoted to unrouted instead of shipped.
 
-        Uses :meth:`RoutingGrid.worst_segment_pad_deficit` -- rect-aware
+        Uses :meth:`RoutingGrid.worst_segment_pad_deficit` and (Issue
+        #3566) :meth:`RoutingGrid.worst_via_pad_deficit` -- rect-aware
         exact geometry with per-component clearances and the net-aware
         same-component carve-out -- so fine-pitch escapes and relaxed
         same-component corridors (#1764 / #2452) never trigger demotion.
+        The via quadrant guarantees the contract on BOTH backends even
+        though only the pre-#3566 Python fallback could place such vias.
 
         Args:
             net_routes: Mapping of net ID to committed routes (mutated:
@@ -9937,6 +9940,20 @@ class Autorouter:
                 for seg in route.segments:
                     deficit, loc = self.grid.worst_segment_pad_deficit(
                         seg,
+                        exclude_net=net,
+                        component_pitches=pitches,
+                        exclude_refs=own_refs or None,
+                    )
+                    if deficit > worst_deficit:
+                        worst_deficit = deficit
+                        worst_loc = loc
+                # Issue #3566: via quadrant.  The #3545 backstop iterated
+                # segments only, so a sub-clearance via next to a foreign
+                # pad shipped uncaught (the Python fallback backend's
+                # ``_is_via_blocked`` lacked the static-halo gate).
+                for via in route.vias:
+                    deficit, loc = self.grid.worst_via_pad_deficit(
+                        via,
                         exclude_net=net,
                         component_pitches=pitches,
                         exclude_refs=own_refs or None,

--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -2809,6 +2809,102 @@ class RoutingGrid:
 
         return worst_deficit, worst_loc
 
+    def worst_via_pad_deficit(
+        self,
+        via: Via,
+        exclude_net: int,
+        component_pitches: dict[str, float] | None = None,
+        exclude_refs: set[str] | None = None,
+    ) -> tuple[float, tuple[float, float] | None]:
+        """Worst via-vs-FOREIGN-pad clearance deficit for one via.
+
+        Issue #3566 (finalization backstop, via quadrant): sibling of
+        :meth:`worst_segment_pad_deficit` for vias.  The #3545 backstop
+        iterated ``route.segments`` only, so a sub-clearance via next to
+        a foreign pad (placeable pre-#3566 on the Python fallback
+        backend, whose ``_is_via_blocked`` lacked the static-halo gate)
+        shipped uncaught until exact KiCad DRC.  Consumed by
+        ``Autorouter._demote_pad_clearance_violation_nets`` so the
+        finalization contract covers vias on BOTH backends.
+
+        Uses the same per-component clearances and the NET-AWARE
+        same-component carve-out as the segment sibling, so the backstop
+        never fires on legitimate fine-pitch escapes or relaxed
+        same-component corridors.  In-pad escape vias (#2605) sit on
+        their OWN net's pad, which the same-net exclusion already skips.
+
+        Args:
+            via: The committed via to check.
+            exclude_net: The via's net (same-net pads are skipped).
+            component_pitches: Optional ref -> pin pitch map for
+                automatic fine-pitch clearance detection.
+            exclude_refs: Refs of the net's own components (the
+                same-component carve-out is only consulted for these).
+
+        Returns:
+            ``(worst_deficit, worst_location)`` where ``worst_deficit``
+            is ``max(required_clearance - actual_clearance)`` over all
+            checked pads (<= 0 means no violation) and
+            ``worst_location`` is the violating pad center (or ``None``).
+        """
+        min_clearance = self.rules.trace_clearance
+        via_radius = via.diameter / 2
+        worst_deficit = 0.0
+        worst_loc: tuple[float, float] | None = None
+
+        # Layer span of the via (indices, inclusive).  SMD pads on layers
+        # outside this span never interact with the via barrel/annulus.
+        via_idx_a = self.layer_to_index(via.layers[0].value)
+        via_idx_b = self.layer_to_index(via.layers[1].value)
+        via_lo, via_hi = min(via_idx_a, via_idx_b), max(via_idx_a, via_idx_b)
+
+        for pad in self._pads:
+            if pad.net == exclude_net:
+                continue
+
+            if not pad.through_hole:
+                pad_layer_idx = self.layer_to_index(pad.layer.value)
+                if not (via_lo <= pad_layer_idx <= via_hi):
+                    continue
+
+            pad_ref = pad.ref
+            pin_pitch = component_pitches.get(pad_ref) if component_pitches else None
+            required_clearance = self.rules.get_clearance_for_component(pad_ref, pin_pitch)
+
+            # Issue #3545 net-aware carve-out (see validate_segment_clearance)
+            same_component_signal_carveout = (
+                exclude_refs
+                and pad.ref in exclude_refs
+                and not _is_plane_net_pad(pad)
+                and self._same_component_carveout_active(
+                    pad.ref, required_clearance, min_clearance, component_pitches
+                )
+            )
+
+            is_circular_pad = abs(pad.width - pad.height) < 0.001
+            if is_circular_pad:
+                pad_radius = max(pad.width, pad.height) / 2
+                dist = math.hypot(via.x - pad.x, via.y - pad.y)
+                clearance = dist - via_radius - pad_radius
+            else:
+                # Degenerate (point) segment: distance from the pad rect
+                # boundary to the via center.
+                center_dist = _rect_segment_centerline_distance(
+                    pad.x, pad.y, pad.width, pad.height,
+                    via.x, via.y, via.x, via.y,
+                )
+                clearance = center_dist - via_radius
+
+            if same_component_signal_carveout and clearance >= 0:
+                continue
+
+            deficit = required_clearance - clearance
+            if deficit > worst_deficit:
+                worst_deficit = deficit
+                worst_loc = (pad.x, pad.y)
+
+        return worst_deficit, worst_loc
+
     def validate_segment_clearance(
         self,
         seg: Segment,

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -1600,6 +1600,11 @@ class Router:
             (gx + dx, gy),  # C: horizontal neighbor
         ]
 
+        # Issue #3566 (Python parity for #3545): static blockage snapshot
+        # (None until the first ``mark_route``; before that, usage is
+        # uniformly 0 and the legacy usage clause is equivalent).
+        grid_static = getattr(self.grid, "_static_blocked", None)
+
         for cx, cy in adjacent_cells:
             # Check bounds
             if not (0 <= cx < self.grid.cols and 0 <= cy < self.grid.rows):
@@ -1609,6 +1614,23 @@ class Router:
 
             if cell.blocked:
                 if allow_sharing and not cell.is_obstacle:
+                    # Issue #3566 / #3545: statically blocked foreign
+                    # cells (pad clearance halos, keepouts) are
+                    # non-negotiable regardless of usage_count -- a pad
+                    # cannot "negotiate away", so cutting a corner
+                    # through a halo cell only produces unresolvable
+                    # overflow.  Relief probes keep their #3438
+                    # soft-crossing semantics for foreign-net cells.
+                    # Mirrors the ``cell.static_blocked && cell.net !=
+                    # net && !relief_mode_`` gate in
+                    # ``Pathfinder::is_diagonal_blocked``.
+                    if (
+                        grid_static is not None
+                        and grid_static[layer, cy, cx]
+                        and cell.net != net
+                        and not self.relief_mode
+                    ):
+                        return True
                     # In negotiated mode, non-obstacle cells can be shared
                     # No-net pads (cell.net == 0) must always block other nets
                     # See issue #317: routes incorrectly allowed through no-net pads
@@ -1715,6 +1737,16 @@ class Router:
             is_obstacle_arr = self.grid._is_obstacle[layer, blocked_cy, blocked_cx]
             usage_arr = self.grid._usage_count[layer, blocked_cy, blocked_cx]
 
+            # Issue #3566 (Python parity for #3545): consult the static
+            # blockage snapshot so foreign static cells (pad clearance
+            # halos, keepouts) stay non-negotiable even at usage > 0.
+            grid_static = getattr(self.grid, "_static_blocked", None)
+            static_arr = (
+                grid_static[layer, blocked_cy, blocked_cx]
+                if grid_static is not None
+                else None
+            )
+
             for i in range(len(blocked_indices)):
                 cell_net = net_arr[i]
                 is_obstacle = is_obstacle_arr[i]
@@ -1726,6 +1758,22 @@ class Router:
                 # obstacles still hard-reject.
                 if is_obstacle and cell_net != net:
                     return True  # Obstacles always block (foreign net)
+
+                # Issue #3566 / #3545: statically blocked foreign cells
+                # (pad clearance halos, keepouts) are non-negotiable
+                # regardless of usage_count -- a pad cannot "negotiate
+                # away", so sharing a halo cell only produces
+                # unresolvable overflow.  Relief probes keep their #3438
+                # soft-crossing semantics for foreign-net cells.  Mirrors
+                # the ``cell.static_blocked && cell.net != net &&
+                # !relief_mode_`` gate in ``Pathfinder::is_via_blocked``.
+                if (
+                    static_arr is not None
+                    and static_arr[i]
+                    and cell_net != net
+                    and not self.relief_mode
+                ):
+                    return True
 
                 # No-net pads must always block
                 if cell_net == 0:

--- a/tests/test_static_halo_via_gate_3566.py
+++ b/tests/test_static_halo_via_gate_3566.py
@@ -1,0 +1,379 @@
+"""Issue #3566: Python fallback router static-halo gate for vias/diagonals.
+
+PR #3565 (Issue #3545) made statically blocked foreign cells (pad
+clearance halos, keepouts) non-negotiable in the sharing A*: all five
+C++ branches plus the Python ``Router._is_trace_blocked`` /
+``RoutingGrid.compute_expanded_blocked`` paths were gated on the static
+blockage snapshot.  Two Python fallback branches were missed and kept
+the pre-#3545 ``usage_count > 0`` release for foreign static cells:
+
+* ``Router._is_via_blocked``
+* ``Router._is_diagonal_corner_blocked``
+
+Post-#3545, a net's own escape route legitimately crosses its own pad
+halo cells, leaving them at ``usage_count > 0`` while ``cell.net`` stays
+the owner net.  On the Python backend a FOREIGN net could then place a
+via whose envelope intrudes into that halo, or cut a diagonal corner
+through it -- shipping sub-clearance copper caught only by exact KiCad
+DRC (neither ``validate_via_clearance`` nor the #3545 segment-only
+demotion backstop covers vias-vs-pads).
+
+These tests are the Python-backend twin of
+``tests/test_static_halo_ripup_3545.py::TestStaticHaloRipupRestore``:
+they exercise the pure-Python :class:`kicad_tools.router.pathfinder.Router`
+directly (instantiating ``Router`` IS the Python backend -- no
+``router_cpp`` involvement), and pin:
+
+* ``_is_via_blocked`` blocks a foreign via over a static halo cell with
+  ``usage_count > 0`` (the #3566 gate),
+* ``_is_diagonal_corner_blocked`` blocks the corner-cut equivalently,
+* relief probes (#3438) keep their soft-crossing semantics,
+* same-net checks remain passable,
+* the finalization backstop's new via quadrant
+  (``RoutingGrid.worst_via_pad_deficit`` consumed by
+  ``Autorouter._demote_pad_clearance_violation_nets``) demotes nets
+  whose committed vias violate foreign-pad clearance on BOTH backends.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.router import DesignRules, load_pcb_for_routing
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.pathfinder import Router
+from kicad_tools.router.primitives import Pad, Route, Via
+
+FIXTURE = Path(__file__).parent / "fixtures" / "routing-diagnostic.kicad_pcb"
+
+
+@pytest.fixture
+def rules() -> DesignRules:
+    return DesignRules(
+        trace_width=0.2,
+        trace_clearance=0.2,
+        via_drill=0.3,
+        via_diameter=0.6,
+        grid_resolution=0.2,
+    )
+
+
+@pytest.fixture
+def grid(rules: DesignRules) -> RoutingGrid:
+    # 20mm x 20mm board at 0.2mm resolution.
+    return RoutingGrid(100, 100, rules, origin_x=0.0, origin_y=0.0)
+
+
+@pytest.fixture
+def router(grid: RoutingGrid, rules: DesignRules) -> Router:
+    """Pure-Python A* pathfinder (the Python fallback backend)."""
+    return Router(grid, rules)
+
+
+def _tht_pad(x: float, y: float, net: int, net_name: str, ref: str, pin: str) -> Pad:
+    """1.7mm circular THT pad, mirroring J1 on the routing-diagnostic fixture."""
+    return Pad(
+        x=x,
+        y=y,
+        width=1.7,
+        height=1.7,
+        net=net,
+        net_name=net_name,
+        layer=Layer.F_CU,
+        ref=ref,
+        pin=pin,
+        through_hole=True,
+        drill=1.0,
+    )
+
+
+def _make_static_halo_cell(grid: RoutingGrid, gx: int, gy: int, layer: int, net: int) -> None:
+    """Single statically blocked non-obstacle cell (a pad clearance halo
+    cell), captured into the static blockage snapshot.
+
+    Mirrors the C++ parity test's ``Grid3D.mark_blocked(x, y, layer, net,
+    blocked=True, is_obstacle=False)`` setup in
+    ``test_static_halo_ripup_3545.py``.
+    """
+    cell = grid.grid[layer][gy][gx]
+    cell.blocked = True
+    cell.net = net
+    # Snapshot is normally captured by the first ``mark_route``; trigger
+    # the same hook directly so the test does not depend on route-copper
+    # envelopes contaminating the via kernel.
+    grid._ensure_static_blockage_snapshot()
+
+
+class TestPythonViaStaticHaloGate:
+    """``_is_via_blocked`` must not release foreign static halo cells at
+    ``usage_count > 0`` (Issue #3566, C++ parity for #3545)."""
+
+    def test_foreign_via_blocked_on_static_halo_with_usage(
+        self, grid: RoutingGrid, router: Router
+    ) -> None:
+        """The exact #3566 defect: usage > 0 released the halo to vias."""
+        gx, gy, layer = 35, 57, 0
+        _make_static_halo_cell(grid, gx, gy, layer, net=1)
+
+        # Sanity: at usage 0 the legacy clause already blocks.
+        assert router._is_via_blocked(gx, gy, layer, net=3, allow_sharing=True) is True
+
+        # NET1's own escape route crossed its own halo (legal): usage > 0,
+        # net stays the owner.
+        grid.grid[layer][gy][gx].usage_count = 1
+
+        # Pre-#3566 the usage>0 clause released the cell and the foreign
+        # via envelope was allowed to intrude into the pad's clearance
+        # halo.  Post-fix the static gate blocks regardless of usage.
+        assert router._is_via_blocked(gx, gy, layer, net=3, allow_sharing=True) is True, (
+            "foreign via released a static pad-halo cell at usage_count > 0"
+        )
+
+    def test_own_net_via_remains_passable(self, grid: RoutingGrid, router: Router) -> None:
+        """The owner net's own via over its own halo stays legal."""
+        gx, gy, layer = 35, 57, 0
+        _make_static_halo_cell(grid, gx, gy, layer, net=1)
+        grid.grid[layer][gy][gx].usage_count = 1
+
+        assert router._is_via_blocked(gx, gy, layer, net=1, allow_sharing=True) is False
+
+    def test_relief_probe_keeps_soft_crossing(self, grid: RoutingGrid, router: Router) -> None:
+        """#3438 semantics survive: relief probes stay static-visible
+        (passable at a penalty) so conflict attribution works."""
+        gx, gy, layer = 35, 57, 0
+        _make_static_halo_cell(grid, gx, gy, layer, net=1)
+
+        router.set_relief_mode(True)
+        try:
+            # usage 0: relief releases the foreign static cell (soft).
+            assert router._is_via_blocked(gx, gy, layer, net=3, allow_sharing=True) is False
+            # usage > 0: the new static gate must NOT re-block the probe.
+            grid.grid[layer][gy][gx].usage_count = 1
+            assert router._is_via_blocked(gx, gy, layer, net=3, allow_sharing=True) is False
+        finally:
+            router.set_relief_mode(False)
+
+    def test_plane_pad_halo_cell_with_usage_blocks_foreign_via(
+        self, grid: RoutingGrid, router: Router
+    ) -> None:
+        """Realistic geometry: a real plane-net pad's halo at usage > 0.
+
+        Twin of ``TestStaticHaloRipupRestore.test_python_ripup_restores_
+        static_halo`` but for via placement.  Signal-pad halos are fully
+        ``is_obstacle`` since #2940, so the live remaining release path
+        runs through NET-0 statics: plane-net pads (``pad.net == 0``,
+        bonded by ``kct stitch``) keep ``is_obstacle = False`` on every
+        halo/metal cell, and the pre-#3566 ``cell_net == 0`` branch
+        released them to foreign vias as soon as ``usage_count > 0``.
+        The via is centered so its envelope's only blocked cell is the
+        halo edge cell.
+        """
+        pad = Pad(
+            x=8.0,
+            y=12.0,
+            width=1.7,
+            height=1.7,
+            net=0,
+            net_name="",
+            layer=Layer.F_CU,
+            ref="J1",
+            pin="1",
+            through_hole=True,
+            drill=1.0,
+        )
+        grid.add_pad(pad)
+        grid._ensure_static_blockage_snapshot()
+
+        pad_gx, pad_gy = grid.world_to_grid(8.0, 12.0)
+        layer = 0
+
+        # Outermost blocked halo cell scanning west from the pad center.
+        edge_gx = pad_gx
+        while edge_gx > 0 and bool(grid._blocked[layer, pad_gy, edge_gx - 1]):
+            edge_gx -= 1
+        assert bool(grid._blocked[layer, pad_gy, edge_gx]) is True
+        assert not bool(grid._is_obstacle[layer, pad_gy, edge_gx]), (
+            "plane-pad halo cells must be non-obstacle (else this test "
+            "no longer pins the #3566 release path)"
+        )
+        assert int(grid._net[layer, pad_gy, edge_gx]) == 0
+
+        # Via centered so the envelope's rightmost cell IS the halo edge.
+        r_v = router._via_half_cells
+        via_gx, via_gy = edge_gx - r_v, pad_gy
+
+        # Precondition: every blocked cell in the via envelope is a
+        # non-obstacle net-0 halo cell -- give them all usage > 0 so the
+        # pre-#3566 logic would release the entire envelope.
+        blocked_in_envelope = 0
+        for dx, dy in zip(router._via_offset_dx, router._via_offset_dy, strict=True):
+            cx, cy = via_gx + int(dx), via_gy + int(dy)
+            if bool(grid._blocked[layer, cy, cx]):
+                assert not bool(grid._is_obstacle[layer, cy, cx])
+                assert int(grid._net[layer, cy, cx]) == 0
+                grid.grid[layer][cy][cx].usage_count = 1
+                blocked_in_envelope += 1
+        assert blocked_in_envelope >= 1, "via envelope must touch the halo"
+
+        assert router._is_via_blocked(via_gx, via_gy, layer, net=3, allow_sharing=True) is True, (
+            "foreign via intruded into a plane pad's clearance halo at usage > 0"
+        )
+
+
+class TestPythonDiagonalCornerStaticHaloGate:
+    """``_is_diagonal_corner_blocked`` must not release foreign static
+    halo cells at ``usage_count > 0`` (Issue #3566)."""
+
+    def test_foreign_corner_cut_blocked_on_static_halo_with_usage(
+        self, grid: RoutingGrid, router: Router
+    ) -> None:
+        gx, gy, layer = 35, 57, 0
+        _make_static_halo_cell(grid, gx, gy, layer, net=1)
+
+        # Diagonal move from (34, 57) with (dx=1, dy=1) checks adjacent
+        # cells (34, 58) and (35, 57) -- the static halo cell.
+        # Sanity at usage 0 (legacy clause):
+        assert (
+            router._is_diagonal_corner_blocked(34, 57, 1, 1, layer, net=3, allow_sharing=True)
+            is True
+        )
+
+        grid.grid[layer][gy][gx].usage_count = 1
+        assert (
+            router._is_diagonal_corner_blocked(34, 57, 1, 1, layer, net=3, allow_sharing=True)
+            is True
+        ), "foreign diagonal corner-cut released a static halo cell at usage > 0"
+
+    def test_own_net_corner_cut_remains_passable(self, grid: RoutingGrid, router: Router) -> None:
+        gx, gy, layer = 35, 57, 0
+        _make_static_halo_cell(grid, gx, gy, layer, net=1)
+        grid.grid[layer][gy][gx].usage_count = 1
+
+        assert (
+            router._is_diagonal_corner_blocked(34, 57, 1, 1, layer, net=1, allow_sharing=True)
+            is False
+        )
+
+    def test_relief_probe_keeps_soft_crossing(self, grid: RoutingGrid, router: Router) -> None:
+        """The static gate is relief-exempt (matches the C++ gate); the
+        legacy usage clause in this branch never had a relief carve-out
+        and is unchanged by #3566."""
+        gx, gy, layer = 35, 57, 0
+        _make_static_halo_cell(grid, gx, gy, layer, net=1)
+        grid.grid[layer][gy][gx].usage_count = 1
+
+        router.set_relief_mode(True)
+        try:
+            assert (
+                router._is_diagonal_corner_blocked(34, 57, 1, 1, layer, net=3, allow_sharing=True)
+                is False
+            ), "relief probe must not be hard-blocked by the #3566 static gate"
+        finally:
+            router.set_relief_mode(False)
+
+
+class TestViaPadDeficitBackstop:
+    """Finalization backstop via quadrant (Issue #3566): sub-clearance
+    vias next to foreign pads are demoted, never committed."""
+
+    def test_worst_via_pad_deficit_geometry(self, grid: RoutingGrid) -> None:
+        """Exact geometry: via 1.0mm from a 1.7mm pad center."""
+        grid.add_pad(_tht_pad(8.0, 12.0, net=1, net_name="NET1", ref="J1", pin="1"))
+        via = Via(
+            x=7.0,
+            y=12.0,
+            drill=0.3,
+            diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU),
+            net=3,
+            net_name="NET3",
+        )
+        # clearance = 1.0 - 0.3 (via radius) - 0.85 (pad radius) = -0.15mm
+        # deficit = 0.2 - (-0.15) = 0.35mm
+        deficit, loc = grid.worst_via_pad_deficit(via, exclude_net=3)
+        assert deficit == pytest.approx(0.35, abs=0.01)
+        assert loc == (8.0, 12.0)
+
+    def test_clean_via_has_no_deficit(self, grid: RoutingGrid) -> None:
+        grid.add_pad(_tht_pad(8.0, 12.0, net=1, net_name="NET1", ref="J1", pin="1"))
+        via = Via(
+            x=5.0,
+            y=12.0,
+            drill=0.3,
+            diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU),
+            net=3,
+            net_name="NET3",
+        )
+        # clearance = 3.0 - 0.3 - 0.85 = 1.85mm >> 0.2mm required.
+        deficit, loc = grid.worst_via_pad_deficit(via, exclude_net=3)
+        assert deficit == 0.0
+        assert loc is None
+
+    def test_same_net_pad_excluded(self, grid: RoutingGrid) -> None:
+        """A via tight against its OWN net's pad never registers."""
+        grid.add_pad(_tht_pad(8.0, 12.0, net=3, net_name="NET3", ref="J1", pin="1"))
+        via = Via(
+            x=8.0,
+            y=12.0,
+            drill=0.3,
+            diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU),
+            net=3,
+            net_name="NET3",
+        )
+        deficit, _loc = grid.worst_via_pad_deficit(via, exclude_net=3)
+        assert deficit == 0.0
+
+    def test_via_violation_is_demoted(self, rules: DesignRules) -> None:
+        """A committed via inside a foreign pad's halo strips the net."""
+        router, _ = load_pcb_for_routing(str(FIXTURE), rules=rules, validate_drc=False)
+        # NET3 via 0.6mm from J1 pad 1 (NET1, 1.7mm circular at 8.0/12.0):
+        # clearance = 0.6 - 0.3 - 0.85 = -0.55mm => deficit 0.75mm, far
+        # beyond the 0.2mm grid-resolution nudge reach.
+        bad = Route(net=3, net_name="NET3")
+        bad.vias.append(
+            Via(
+                x=7.4,
+                y=12.0,
+                drill=0.3,
+                diameter=0.6,
+                layers=(Layer.F_CU, Layer.B_CU),
+                net=3,
+                net_name="NET3",
+            )
+        )
+        router.routes.append(bad)
+        net_routes = {3: [bad]}
+
+        demoted = router._demote_pad_clearance_violation_nets(net_routes)
+
+        assert demoted == [3]
+        assert net_routes[3] == []
+        assert bad not in router.routes
+
+    def test_clean_via_route_is_not_demoted(self, rules: DesignRules) -> None:
+        router, _ = load_pcb_for_routing(str(FIXTURE), rules=rules, validate_drc=False)
+        good = Route(net=3, net_name="NET3")
+        good.vias.append(
+            Via(
+                x=5.0,
+                y=10.0,
+                drill=0.3,
+                diameter=0.6,
+                layers=(Layer.F_CU, Layer.B_CU),
+                net=3,
+                net_name="NET3",
+            )
+        )
+        router.routes.append(good)
+        net_routes = {3: [good]}
+
+        demoted = router._demote_pad_clearance_violation_nets(net_routes)
+
+        assert demoted == []
+        assert net_routes[3] == [good]
+        assert good in router.routes


### PR DESCRIPTION
Closes #3566

## Summary

PR #3565 (#3545) made statically blocked foreign cells (pad clearance halos, keepouts) non-negotiable in the sharing A* — all five C++ branches plus the Python trace path. Two Python fallback branches were missed and kept the pre-#3545 `usage_count > 0` release, so on the Python backend a foreign net could place a via whose envelope intrudes into a pad's clearance halo, or cut a diagonal corner through it, shipping sub-clearance copper caught only by exact KiCad DRC.

- **Gate `Router._is_via_blocked`** (`pathfinder.py`): consult the `_static_blocked` positional snapshot inside the `allow_sharing` loop — foreign static cell blocks regardless of `usage_count`, except in `relief_mode`. Placed after the foreign-obstacle reject and before the net-0/usage clauses, mirroring the C++ `cell.static_blocked && cell.net != net && !relief_mode_` gate order exactly.
- **Gate `Router._is_diagonal_corner_blocked`**: same gate in the per-cell corner-cut check, mirroring `Pathfinder::is_diagonal_blocked`.
- **Backstop via quadrant**: new `RoutingGrid.worst_via_pad_deficit` — exact-geometry sibling of `worst_segment_pad_deficit` (per-component clearances, net-aware same-component carve-out, via layer-span filter for SMD pads) — consumed by `Autorouter._demote_pad_clearance_violation_nets`, so a sub-clearance via next to a foreign pad demotes the net at finalization on BOTH backends.
- **Parity tests** (`tests/test_static_halo_via_gate_3566.py`, 12 tests): Python-backend twin of `TestStaticHaloRipupRestore`. Covers the synthetic C++-parity setup (single static non-obstacle cell at usage > 0), a realistic plane-net pad halo (signal-pad halos are fully `is_obstacle` since #2940, so the live release path runs through net-0 statics), relief-probe soft-crossing preservation (#3438), same-net passability, and the new backstop quadrant (geometry + demotion + clean-route survival). The three gate tests were verified to FAIL with the pathfinder fix stashed.

## Test plan

- [x] `tests/test_static_halo_via_gate_3566.py` — 12 passed
- [x] `tests/test_static_halo_ripup_3545.py` — passed (no regression to the #3545 pins)
- [x] `tests/test_drc_regression.py` — passed (28 total across the three files)
- [x] `tests/router/test_relief_rescue.py`, `tests/router/test_negotiated_ripup.py`, `tests/router/test_grid_same_component_carveout.py`, `tests/router/test_narrow_channel_halo.py`, `tests/test_negotiated_adaptive.py` — 162 passed
- [x] Discrimination check: gate tests fail with the pathfinder change reverted
- [x] C++ extension built (`kct build-native --check`: available 1.0.0); ruff introduces no new findings (router-file errors pre-exist on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)