### PR TITLE
fix(router): certify global-min clearance in R-tree segment query

### DIFF
--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -3022,35 +3022,19 @@ class RoutingGrid:
         )
 
         if use_rtree:
-            # Issue #2335: R-tree envelopes are already inflated by
-            # _rtree_clearance_inflation (= max_clearance).  The query
-            # envelope only needs the query segment's own half-width plus a
-            # small margin for accurate min_actual_clearance reporting on
-            # nearby (non-violating) segments.  Segments whose inflated
-            # envelopes do not intersect this query region are guaranteed to
-            # have edge-to-edge clearance >= max_clearance and can be safely
-            # skipped.  The extra ``min_clearance`` term ensures that all
-            # potential violators are captured even when the query segment's
-            # required clearance differs from the index inflation.
-            search_margin = seg_half_width + min_clearance
-            query_envelope = (
-                min(seg.x1, seg.x2) - search_margin,
-                min(seg.y1, seg.y2) - search_margin,
-                max(seg.x1, seg.x2) + search_margin,
-                max(seg.y1, seg.y2) + search_margin,
-            )
-            candidate_ids = list(self._seg_rtree[seg_layer_idx].intersection(query_envelope))
+            rtree_idx = self._seg_rtree[seg_layer_idx]
             layer_items = self._seg_rtree_items.get(seg_layer_idx, {})
+            seg_min_x = min(seg.x1, seg.x2)
+            seg_min_y = min(seg.y1, seg.y2)
+            seg_max_x = max(seg.x1, seg.x2)
+            seg_max_y = max(seg.y1, seg.y2)
 
-            for cand_id in candidate_ids:
-                other_seg = layer_items.get(cand_id)
-                if other_seg is None:
-                    continue
-                # Skip same-net segments
-                if other_seg.net == exclude_net:
-                    continue
+            def _exact_clearance(other_seg: Segment) -> float:
+                """Edge-to-edge clearance between ``seg`` and ``other_seg``.
 
-                # Exact segment-to-segment distance
+                Uses the exact same arithmetic as the brute-force branch so
+                the two paths produce bit-identical results (Issue #3522).
+                """
                 dist = self._segment_to_segment_distance(
                     seg.x1,
                     seg.y1,
@@ -3061,26 +3045,108 @@ class RoutingGrid:
                     other_seg.x2,
                     other_seg.y2,
                 )
+                return dist - seg_half_width - other_seg.width / 2
 
-                # Edge-to-edge clearance (both segment half-widths)
-                clearance = dist - seg_half_width - other_seg.width / 2
+            def _scan_candidates(
+                margin: float,
+            ) -> tuple[float, bool, tuple[float, float] | None]:
+                """Exact-distance scan of R-tree candidates within ``margin``.
 
-                # Issue #2559 / Phase 1C: tighter clearance for the diff-pair
-                # partner only.
-                effective_clearance = (
-                    partner_clearance
-                    if partner_active and other_seg.net == partner_net
-                    else min_clearance
+                Returns (best_clearance, found_violation, violation_loc) over
+                all foreign-net candidates whose inflated envelopes intersect
+                the query envelope expanded by ``margin``.
+                """
+                envelope = (
+                    seg_min_x - margin,
+                    seg_min_y - margin,
+                    seg_max_x + margin,
+                    seg_max_y + margin,
                 )
+                best = float("inf")
+                found = False
+                loc: tuple[float, float] | None = None
+                for cand_id in rtree_idx.intersection(envelope):
+                    other_seg = layer_items.get(cand_id)
+                    if other_seg is None:
+                        continue
+                    # Skip same-net segments
+                    if other_seg.net == exclude_net:
+                        continue
 
-                if clearance < min_actual_clearance:
-                    min_actual_clearance = clearance
-                if clearance < effective_clearance:
-                    has_violation = True
-                    violation_loc = (
-                        (seg.x1 + seg.x2 + other_seg.x1 + other_seg.x2) / 4,
-                        (seg.y1 + seg.y2 + other_seg.y1 + other_seg.y2) / 4,
+                    # Edge-to-edge clearance (both segment half-widths)
+                    clearance = _exact_clearance(other_seg)
+
+                    # Issue #2559 / Phase 1C: tighter clearance for the
+                    # diff-pair partner only.
+                    effective_clearance = (
+                        partner_clearance
+                        if partner_active and other_seg.net == partner_net
+                        else min_clearance
                     )
+
+                    if clearance < best:
+                        best = clearance
+                    if clearance < effective_clearance:
+                        found = True
+                        loc = (
+                            (seg.x1 + seg.x2 + other_seg.x1 + other_seg.x2) / 4,
+                            (seg.y1 + seg.y2 + other_seg.y1 + other_seg.y2) / 4,
+                        )
+                return best, found, loc
+
+            # Pass 1 (Issue #2335): R-tree envelopes are already inflated by
+            # _rtree_clearance_inflation (= max_clearance) plus the stored
+            # segment's half-width, so a query envelope expanded by
+            # ``seg_half_width + min_clearance`` is guaranteed to capture
+            # every segment whose edge-to-edge clearance is below
+            # ``min_clearance`` -- all potential violators.  Violation
+            # detection (``is_valid``) is therefore certified by this pass
+            # alone.
+            search_margin = seg_half_width + min_clearance
+            best_clearance, seg_violation, seg_violation_loc = _scan_candidates(search_margin)
+
+            # Pass 2 (Issue #3522): the bounded pass-1 query only certifies
+            # the reported *minimum* when it lies within ``min_clearance``.
+            # The brute-force branch reports the global minimum clearance
+            # over all foreign-net same-layer segments with no distance
+            # bound, so callers relying on ``actual_clearance`` got a false
+            # ``inf`` (or a finite but non-minimal value from a
+            # bbox-overlapping far candidate, e.g. a long diagonal) whenever
+            # the true nearest segment fell outside the pass-1 envelope.
+            # Certify the true minimum by re-querying with the best-known
+            # clearance as the margin: a segment with edge-to-edge clearance
+            # ``c`` has a bbox gap of at most
+            # ``c + seg_half_width + other_half_width`` per axis, and the
+            # stored envelopes already include ``other_half_width``, so a
+            # query margin of ``seg_half_width + c_bound`` captures every
+            # segment with clearance <= ``c_bound``.
+            if best_clearance > min_clearance:
+                if best_clearance == float("inf") and layer_items:
+                    # No foreign-net candidate intersected the pass-1
+                    # envelope.  Seed an upper bound from the nearest stored
+                    # envelopes (ordered by inflated-bbox distance; the first
+                    # foreign-net hit gives a finite -- though not
+                    # necessarily minimal -- clearance bound for the
+                    # certification pass below).
+                    query_bbox = (seg_min_x, seg_min_y, seg_max_x, seg_max_y)
+                    for cand_id in rtree_idx.nearest(query_bbox, num_results=len(layer_items)):
+                        other_seg = layer_items.get(cand_id)
+                        if other_seg is None or other_seg.net == exclude_net:
+                            continue
+                        best_clearance = _exact_clearance(other_seg)
+                        break
+                if best_clearance < float("inf"):
+                    certify_margin = seg_half_width + best_clearance
+                    if certify_margin > search_margin:
+                        best_clearance, seg_violation, seg_violation_loc = _scan_candidates(
+                            certify_margin
+                        )
+
+            if best_clearance < min_actual_clearance:
+                min_actual_clearance = best_clearance
+            if seg_violation:
+                has_violation = True
+                violation_loc = seg_violation_loc
         else:
             # Brute-force path: iterate all routes and segments.
             for route in self.routes:

--- a/tests/test_rtree_segment_index.py
+++ b/tests/test_rtree_segment_index.py
@@ -172,10 +172,6 @@ class TestRtreeBruteForceEquivalence:
         return result_normal, result_brute
 
     @pytest.mark.skipif(not RTREE_AVAILABLE, reason="rtree not installed")
-    @pytest.mark.xfail(
-        reason="RtreeSegmentIndex returns clearance=inf where brute force finds a neighbor -- see issue #3522",
-        strict=False,
-    )
     def test_parity_above_threshold(self, grid):
         """With 200+ segments the R-tree path matches brute-force exactly."""
         self._populate_grid(grid, n_routes=40, n_segs_per_route=6)
@@ -233,6 +229,128 @@ class TestRtreeBruteForceEquivalence:
         # Just verify it returns a valid tuple (no crash)
         assert isinstance(is_valid, bool)
         assert isinstance(clearance, float)
+
+
+# ---------------------------------------------------------------------------
+# Issue #3522: global-minimum clearance parity (pin tests)
+# ---------------------------------------------------------------------------
+
+
+class TestRtreeGlobalMinParity:
+    """Pin tests for issue #3522.
+
+    The R-tree path used a single bounded range query (margin =
+    ``seg_half_width + min_clearance``), so when the true nearest foreign-net
+    segment fell outside that envelope the reported ``actual_clearance`` was
+    either ``inf`` (no candidate at all) or a finite but non-minimal value
+    (a far candidate whose bbox happened to overlap, e.g. a long diagonal).
+    The brute-force reference reports the unbounded global minimum.
+    """
+
+    def _query_both_paths(self, grid, query_seg, exclude_net, min_clearance=0.127):
+        """Run the same query via the R-tree path and the brute-force path."""
+        result_rtree = grid.validate_segment_clearance(
+            query_seg, exclude_net=exclude_net, min_clearance=min_clearance
+        )
+        saved_count = grid._seg_rtree_count
+        grid._seg_rtree_count = 0
+        result_brute = grid.validate_segment_clearance(
+            query_seg, exclude_net=exclude_net, min_clearance=min_clearance
+        )
+        grid._seg_rtree_count = saved_count
+        return result_rtree, result_brute
+
+    @pytest.mark.skipif(not RTREE_AVAILABLE, reason="rtree not installed")
+    def test_far_neighbor_clearance_not_infinite(self, grid):
+        """A neighbor beyond the violation envelope must still be reported.
+
+        33 vertical foreign-net segments sit 4.5mm+ away from the query --
+        far outside the pass-1 envelope (~0.227mm margin) -- so the old code
+        found zero candidates and returned clearance=inf while brute force
+        found 4.3mm.
+        """
+        for i in range(33):
+            s = _make_segment(10.0 + i * 1.0, 20.0, 10.0 + i * 1.0, 30.0, net=i + 1)
+            grid.mark_route(_make_route([s], net=i + 1))
+        assert grid._seg_rtree_count >= RTREE_SEGMENT_THRESHOLD
+
+        query = _make_segment(5.0, 25.0, 5.5, 25.0, net=999)
+        result_rt, result_bf = self._query_both_paths(grid, query, exclude_net=999)
+
+        # Nearest stored segment is at x=10.0: centerline distance 4.5mm,
+        # minus both half-widths (0.1 + 0.1) = 4.3mm edge-to-edge.
+        assert result_bf[1] == pytest.approx(4.3, abs=1e-12)
+        assert result_rt[1] != float("inf"), (
+            "R-tree path dropped the nearest neighbor (issue #3522 regression)"
+        )
+        assert result_rt[0] == result_bf[0]
+        assert abs(result_rt[1] - result_bf[1]) < 1e-9
+
+    @pytest.mark.skipif(not RTREE_AVAILABLE, reason="rtree not installed")
+    def test_bbox_overlap_does_not_mask_true_minimum(self, grid):
+        """A far diagonal candidate must not mask a nearer off-envelope segment.
+
+        The long diagonal's bounding box overlaps the query envelope, so the
+        old single-pass code returned its (large) clearance even though a
+        vertical segment outside the pass-1 envelope was geometrically much
+        closer.  This is the finite-but-non-minimal variant of #3522.
+        """
+        # Long diagonal: bbox covers the query region, but the actual
+        # centerline is ~11mm away from the query segment.
+        diag = _make_segment(0.0, 0.0, 20.0, 20.0, net=1)
+        grid.mark_route(_make_route([diag], net=1))
+
+        # True nearest neighbor: vertical segment 3.5mm right of the query,
+        # well outside the pass-1 envelope (~0.227mm margin).
+        near = _make_segment(6.0, 10.0, 6.0, 26.0, net=2)
+        grid.mark_route(_make_route([near], net=2))
+
+        # Filler segments far away so the R-tree path engages.
+        for i in range(32):
+            s = _make_segment(35.0 + i * 0.4, 35.0, 35.0 + i * 0.4, 45.0, net=100 + i)
+            grid.mark_route(_make_route([s], net=100 + i))
+        assert grid._seg_rtree_count >= RTREE_SEGMENT_THRESHOLD
+
+        query = _make_segment(2.0, 18.0, 2.5, 18.0, net=999)
+        result_rt, result_bf = self._query_both_paths(grid, query, exclude_net=999)
+
+        # Nearest is the vertical segment at x=6.0: centerline distance 3.5mm
+        # minus both half-widths = 3.3mm edge-to-edge.
+        assert result_bf[1] == pytest.approx(3.3, abs=1e-12)
+        assert result_rt[0] == result_bf[0]
+        assert abs(result_rt[1] - result_bf[1]) < 1e-9
+
+    @pytest.mark.skipif(not RTREE_AVAILABLE, reason="rtree not installed")
+    def test_issue_3522_exact_geometry(self, grid):
+        """Pin the exact failing query from the issue #3522 report.
+
+        Reproduces the deterministic geometry from
+        ``test_parity_above_threshold`` (populate seed 42, query seed 99,
+        second query) where the R-tree path returned clearance=inf and brute
+        force found 3.325339152448819mm.
+        """
+        TestRtreeBruteForceEquivalence()._populate_grid(grid, n_routes=40, n_segs_per_route=6)
+        assert grid._seg_rtree_count >= RTREE_SEGMENT_THRESHOLD
+
+        rng = random.Random(99)
+        query = None
+        exclude_net = None
+        for _ in range(2):  # second draw is the historically failing query q1
+            x1 = rng.uniform(2.0, 48.0)
+            y1 = rng.uniform(2.0, 48.0)
+            x2 = x1 + rng.uniform(-5.0, 5.0)
+            y2 = y1 + rng.uniform(-5.0, 5.0)
+            exclude_net = rng.randint(1, 40)
+            query = _make_segment(x1, y1, x2, y2, net=exclude_net)
+
+        result_rt, result_bf = self._query_both_paths(grid, query, exclude_net)
+
+        assert result_bf[1] == pytest.approx(3.325339152448819, abs=1e-9)
+        assert result_rt[1] != float("inf"), (
+            "R-tree path returned clearance=inf for the issue #3522 geometry"
+        )
+        assert result_rt[0] == result_bf[0]
+        assert abs(result_rt[1] - result_bf[1]) < 1e-9
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`tests/test_rtree_segment_index.py::TestRtreeBruteForceEquivalence::test_parity_above_threshold` failed deterministically: the R-tree path of `RoutingGrid.validate_segment_clearance` returned `clearance=inf` where the brute-force reference found 3.325mm. A false-infinite clearance means index-backed callers can miss real proximity — a production correctness bug in the spatial index query, not a stale test.

**Root cause**: the R-tree branch issued a single bounded range query with margin `seg_half_width + min_clearance` (~0.327mm). That bound is sound for *violation detection* (Issue #2335's inflated envelopes guarantee every violator is captured), but the brute-force branch reports the **global minimum** clearance over all foreign-net same-layer segments with no distance bound. Whenever the true nearest segment fell outside the pass-1 envelope, the index reported either:
- `inf` — no candidate intersected the envelope at all (12 of the 20 seeded parity queries), or
- a **finite but non-minimal** value — a far candidate whose bbox happened to overlap (e.g. a long diagonal) masked the true nearest segment (seeded query q13: rtree=2.464 vs brute=2.236).

**Fix** (geometry, no magic constants): keep pass 1 unchanged, then certify the minimum. If pass 1's best clearance exceeds `min_clearance` it is not certified minimal:
1. If no candidate was found, seed a finite upper bound from `Index.nearest()` (first foreign-net hit, exact distance).
2. Re-query with margin `seg_half_width + best_clearance`. Stored envelopes already include the other segment's half-width, so any segment with edge-to-edge clearance `c` has per-axis bbox gap ≤ `c + seg_half_width + other_half_width`; the certify margin therefore provably captures every segment with `c <= best_clearance`, making the recomputed minimum the exact global minimum. Both paths use the same `_segment_to_segment_distance` arithmetic, so results are bit-identical.

Other query-path call sites were audited for the same latent bug: `optimizer/collision.py::path_is_clear`, `failure_analysis.py` cell classification, and `drc/incremental.py` are bounded boolean predicates (capture guarantee is sufficient); `validate_via_clearance` / `validate_via_to_via_clearance` are brute-force only. The bug was unique to the min-clearance reporting in `validate_segment_clearance`.

## Changes

- `src/kicad_tools/router/grid.py`: two-pass certified R-tree query in `validate_segment_clearance` (`_scan_candidates` closure + `nearest()`-seeded certification pass); shared `_exact_clearance` helper keeps the arithmetic identical to the brute-force branch.
- `tests/test_rtree_segment_index.py`:
  - removed the `xfail(strict=False)` mark from `test_parity_above_threshold`
  - new `TestRtreeGlobalMinParity` pin tests: far-neighbor-returns-inf mode, bbox-overlap-masks-true-minimum mode, and the exact seed-derived geometry from the issue report (brute=3.325339152448819mm)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Parity test passes un-xfailed | ✅ | `test_parity_above_threshold` passes; xfail mark removed; all 20 seeded queries match within 1e-9 |
| Targeted pin test for the failing geometry | ✅ | `TestRtreeGlobalMinParity::test_issue_3522_exact_geometry` asserts brute=3.325339152448819 and rtree == brute; plus two hand-constructed pin tests for both failure modes |
| No rtree/DRC regressions | ✅ | `tests/test_rtree_segment_index.py` 22 passed (incl. perf test); consumer suites green (see Test Plan) |
| Other query-path call sites audited | ✅ | collision.py / failure_analysis.py / incremental.py are bounded boolean predicates — sound; via validators are brute-force only |

## Test Plan

All run with `-p no:randomly` (C++ extension built via `kct build-native`):

- `tests/test_rtree_segment_index.py` — **22 passed** (19 existing incl. un-xfailed parity + perf test, 3 new pin tests)
- `tests/test_router_grid.py`, `tests/test_component_clearance.py`, `tests/test_router_collision.py`, `tests/test_via_conflict.py`, `tests/test_router_via_rtree_perf.py`, `tests/router/test_validate_route_clearance_rect.py`, `tests/router/test_grid_resync_3507.py`, `tests/test_static_halo_ripup_3545.py` — **324 passed, 1 skipped**
- `tests/test_subgrid.py`, `tests/test_cpp_validation_parity.py`, `tests/test_cpp_clearance_enforcement.py` — **131 passed, 3 skipped**
- `tests/test_incremental_drc.py`, `tests/test_predictive_drc.py`, `tests/test_drc_cpp_backend.py`, `tests/test_router_core.py` — **245 passed, 6 skipped, 1 xfailed**
- `tests/test_failure_analysis.py`, `tests/test_failure_analysis_blocking_ref.py`, `tests/test_collision_detection.py`, `tests/test_trace_optimizer.py` — **182 passed**
- `ruff check` on changed files: no new findings (grid.py's 27 findings are identical on main); new test code is lint-clean and format-clean

Closes #3522