### PR TITLE
fix(router): freeze DEFAULT_NET_CLASS_MAP + shrink polarity-swap fixture (closes #3524)

### DIFF
--- a/src/kicad_tools/router/block_router.py
+++ b/src/kicad_tools/router/block_router.py
@@ -85,7 +85,9 @@ class BlockRouter:
 
         self.block = block
         self.rules = rules
-        self.net_class_map = net_class_map or DEFAULT_NET_CLASS_MAP
+        # Issue #3524: copy the default map instead of aliasing the
+        # module-level singleton -- in-place writes must stay local.
+        self.net_class_map = net_class_map or dict(DEFAULT_NET_CLASS_MAP)
         self.layer_stack = layer_stack or LayerStack.two_layer()
         self.margin = margin
         self._force_python = force_python

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -761,7 +761,12 @@ class Autorouter:
                 the ``--max-search-iterations`` CLI flag.
         """
         self.rules = rules or DesignRules()
-        self.net_class_map = net_class_map or DEFAULT_NET_CLASS_MAP
+        # Issue #3524: copy the default map instead of aliasing it.  The
+        # autorouter writes per-net overrides into ``self.net_class_map``
+        # (impedance synthesis, diff-pair partner wiring, matrix layer
+        # preferences); aliasing the module-level singleton leaked those
+        # writes into every later Autorouter in the same process.
+        self.net_class_map = net_class_map or dict(DEFAULT_NET_CLASS_MAP)
         self.layer_stack = layer_stack
         self._force_python = force_python
         # Issue #2610: stored so _create_grid_and_routers can pass it to

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -183,7 +183,9 @@ class Router:
         """
         self.grid = grid
         self.rules = rules
-        self.net_class_map = net_class_map or DEFAULT_NET_CLASS_MAP
+        # Issue #3524: copy the default map instead of aliasing the
+        # module-level singleton -- in-place writes must stay local.
+        self.net_class_map = net_class_map or dict(DEFAULT_NET_CLASS_MAP)
         self.heuristic = heuristic or DEFAULT_HEURISTIC
         self.diagonal_routing = diagonal_routing
 

--- a/src/kicad_tools/router/rules.py
+++ b/src/kicad_tools/router/rules.py
@@ -7,7 +7,9 @@ This module provides:
 - Predefined net classes for common use cases
 """
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
+from types import MappingProxyType
 from typing import Literal
 
 from .layers import Layer
@@ -1427,10 +1429,24 @@ def net_class_map_from_dict(
 # short connections first access to routing channels.
 SIMPLE_NET_THRESHOLD_MM: float = 10.0
 
-# Default net class map with common net names
-DEFAULT_NET_CLASS_MAP: dict[str, NetClassRouting] = create_net_class_map(
-    power_nets=["+5V", "+3.3V", "+3.3VA", "+1.8V", "VCC", "VDD", "GND", "GNDA", "PGND"],
-    clock_nets=["CLK", "MCLK", "BCLK", "LRCLK", "SCK"],
-    audio_nets=["AUDIO_L", "AUDIO_R", "I2S_DIN", "I2S_DOUT"],
-    debug_nets=["SWDIO", "SWCLK", "NRST", "TDI", "TDO", "TCK", "TMS"],
+# Default net class map with common net names.
+#
+# Issue #3524: this is a module-level singleton shared by reference across
+# every Autorouter/Pathfinder/BlockRouter constructed without an explicit
+# ``net_class_map``.  It used to be a plain dict, and any consumer that
+# wrote into its aliased ``self.net_class_map`` (impedance synthesis,
+# diff-pair partner wiring, matrix layer preferences, test setup code)
+# silently polluted the defaults for every later caller in the same
+# process -- which surfaced as order-dependent failures under pytest-xdist.
+# It is now wrapped in a read-only ``MappingProxyType`` so any in-place
+# mutation raises ``TypeError`` immediately; consumers that need a mutable
+# map must take a copy (``dict(DEFAULT_NET_CLASS_MAP)``), which the router
+# constructors now do.
+DEFAULT_NET_CLASS_MAP: Mapping[str, NetClassRouting] = MappingProxyType(
+    create_net_class_map(
+        power_nets=["+5V", "+3.3V", "+3.3VA", "+1.8V", "VCC", "VDD", "GND", "GNDA", "PGND"],
+        clock_nets=["CLK", "MCLK", "BCLK", "LRCLK", "SCK"],
+        audio_nets=["AUDIO_L", "AUDIO_R", "I2S_DIN", "I2S_DOUT"],
+        debug_nets=["SWDIO", "SWCLK", "NRST", "TDI", "TDO", "TCK", "TMS"],
+    )
 )

--- a/tests/test_diffpair_length_tuning.py
+++ b/tests/test_diffpair_length_tuning.py
@@ -532,10 +532,6 @@ class TestTripleGate:
     the pipeline invokes the tuner for each detected pair.
     """
 
-    @pytest.mark.xfail(
-        reason="net-class length_critical state polluted by sibling xdist-worker tests -- see issue #3524",
-        strict=False,
-    )
     def test_autorouter_invokes_tuner_for_each_pair(self):
         from kicad_tools.router import diffpair_length_tuning as dlt_module
         from kicad_tools.router.core import Autorouter

--- a/tests/test_diffpair_npad.py
+++ b/tests/test_diffpair_npad.py
@@ -199,21 +199,33 @@ def test_three_pad_no_swap_routes_all_pads():
 def _polarity_swap_router() -> Autorouter:
     """USB-C-shaped fixture with mirrored polarity at source vs sink.
 
-    Source: P at (10, 10), N at (12, 10)  — P-left, N-right
-    Sink (cluster A): P at (28, 9.75), N at (30, 9.75)  — P-left, N-right
-    Sink (cluster B, same net pads): P at (30, 11.25), N at (28, 11.25)
+    Source: P at (4, 4), N at (6, 4)  — P-left, N-right
+    Sink (cluster A): P at (10, 3.75), N at (12, 3.75)  — P-left, N-right
+    Sink (cluster B, same net pads): P at (12, 5.25), N at (10, 5.25)
                                      — P-RIGHT, N-LEFT (polarity inverted)
+
+    Issue #3524: this fixture was originally a 40x20mm board with 16mm
+    between the MCU and connector clusters, which drove the pure-Python
+    coupled A* (plus coverage tracing) to ~60s serially and past the
+    300s module budget under full-suite xdist CPU contention.  The
+    geometry is scaled down to a 16x8mm board with 4mm between clusters
+    -- the polarity-swap shape (mirrored P/N orientation on connector
+    row B, single connector cluster, stub absorption) and the exercised
+    code path (coupled attempt -> independent fallback; the coupled
+    open phase failed on the original geometry too) are preserved
+    exactly, but the route completes in well under a second of router
+    time serially.
     """
     rules = DesignRules(trace_width=0.2, trace_clearance=0.2, grid_resolution=0.1)
-    router = Autorouter(width=40.0, height=20.0, rules=rules)
+    router = Autorouter(width=16.0, height=8.0, rules=rules)
 
     # MCU side
     router.add_component(
         "U1",
         [
-            {"number": "29", "x": 10.0, "y": 10.0, "width": 0.4, "height": 0.4,
+            {"number": "29", "x": 4.0, "y": 4.0, "width": 0.4, "height": 0.4,
              "net": 1, "net_name": "USB_D+"},
-            {"number": "28", "x": 12.0, "y": 10.0, "width": 0.4, "height": 0.4,
+            {"number": "28", "x": 6.0, "y": 4.0, "width": 0.4, "height": 0.4,
              "net": 2, "net_name": "USB_D-"},
         ],
     )
@@ -222,13 +234,13 @@ def _polarity_swap_router() -> Autorouter:
     router.add_component(
         "J1",
         [
-            {"number": "A6", "x": 28.0, "y": 9.75, "width": 0.25, "height": 0.35,
+            {"number": "A6", "x": 10.0, "y": 3.75, "width": 0.25, "height": 0.35,
              "net": 1, "net_name": "USB_D+"},
-            {"number": "A7", "x": 30.0, "y": 9.75, "width": 0.25, "height": 0.35,
+            {"number": "A7", "x": 12.0, "y": 3.75, "width": 0.25, "height": 0.35,
              "net": 2, "net_name": "USB_D-"},
-            {"number": "B6", "x": 30.0, "y": 11.25, "width": 0.25, "height": 0.35,
+            {"number": "B6", "x": 12.0, "y": 5.25, "width": 0.25, "height": 0.35,
              "net": 1, "net_name": "USB_D+"},
-            {"number": "B7", "x": 28.0, "y": 11.25, "width": 0.25, "height": 0.35,
+            {"number": "B7", "x": 10.0, "y": 5.25, "width": 0.25, "height": 0.35,
              "net": 2, "net_name": "USB_D-"},
         ],
     )
@@ -257,10 +269,6 @@ def test_polarity_swap_detected_in_pair_up():
     )
 
 
-@pytest.mark.xfail(
-    reason="pure-Python coupled A* exceeds 300s under full-suite xdist contention -- see issue #3524",
-    strict=False,
-)
 def test_polarity_swap_routes_all_nets():
     """The coupled router still produces routes for both nets when polarity swaps."""
     router = _polarity_swap_router()


### PR DESCRIPTION
Closes #3524

## Summary

Two diffpair tests passed serially but failed in the full `-n auto` suite. Both root causes are fixed and the `xfail(strict=False)` marks from the #3436 burn-down are removed.

### 1. Net-class state pollution (`test_autorouter_invokes_tuner_for_each_pair`)

`Autorouter`, `Router` (pathfinder), and `BlockRouter` all aliased the module-level `DEFAULT_NET_CLASS_MAP` singleton when constructed without an explicit `net_class_map`. The autorouter writes per-net overrides into `self.net_class_map`:

- `core.py:3431` — impedance synthesis (`new_nc`)
- `core.py:3740/3746` — diff-pair partner wiring (`dataclasses.replace(..., diffpair_partner=...)`) — this is the `length_critical`-class pollution site
- `core.py:4216` — matrix layer-preference overrides

Through the alias those writes leaked into the shared default map for every later router in the same xdist worker process, flipping the engagement gate's `length_critical` read for sibling tests.

Fix (defense in depth):
- `rules.py`: `DEFAULT_NET_CLASS_MAP` is now wrapped in `types.MappingProxyType` — any future in-place write raises `TypeError` immediately instead of silently polluting cross-test state.
- `core.py`, `pathfinder.py`, `block_router.py`: constructors take a `dict(DEFAULT_NET_CLASS_MAP)` copy so their per-instance writes stay local.

No code mutates `NetClassRouting` instances in place (all overrides use `dataclasses.replace` or assign fresh instances), so the dict-level copy is sufficient; `io.py:3371` already copied.

### 2. Pure-Python coupled A* timeout (`test_polarity_swap_routes_all_nets`)

The 40x20mm fixture (16mm between MCU and connector clusters) drove the pure-Python `CoupledPathfinder` past the 300s module budget under full-suite CPU contention. The fixture is scaled to 16x8mm (4mm between clusters), preserving the mirrored-polarity geometry (P/N swapped on connector row B), single connector cluster with stub absorption, and the exercised coupled-attempt -> independent-fallback code path. The test now completes in ~0.3s serially (was ~60s serially / >300s under contention).

## Validation

- Each test serially: both pass (`test_polarity_swap_routes_all_nets` call time 0.28s without coverage)
- Both files under `-n auto`: 24 passed; polarity test 11.2s under worker contention with coverage tracing
- Broad slice (`tests/router/` + `test_diffpair*` + `test_router*` + `test_main_router*`) under `-n auto`: 1964 passed, 16 skipped, 3 xfailed (other tests) in 10:48
- Full suite `-n auto` running locally; PR CI runs the same full-suite gate
- `ruff check`/`ruff format --check`: changed files clean except 24 lint findings and 3 format diffs that are byte-identical pre-existing on main (verified by running ruff against the main versions)

Refs #3436.