### PR TITLE
fix(schema): emit top-level (locked yes), never the legacy in-attr 'locked' token

### DIFF
--- a/src/kicad_tools/drc/repair_clearance.py
+++ b/src/kicad_tools/drc/repair_clearance.py
@@ -1905,15 +1905,24 @@ class ClearanceRepairer:
             fp_x = float(at_atoms[0]) if at_atoms else 0.0
             fp_y = float(at_atoms[1]) if len(at_atoms) > 1 else 0.0
 
-            # Check locked status from attr
+            # Check locked status. Modern form (KiCad 9/10) is a
+            # top-level ``(locked yes)`` child; the legacy KiCad-6 form
+            # is a ``locked`` token inside ``(attr ...)``. Accept both
+            # (issue #3457) -- direct children only, since pads can
+            # carry their own (locked yes).
             locked = False
-            attr_node = fp_node.find("attr")
-            if attr_node:
-                for i in range(len(attr_node.children)):
-                    token = attr_node.get_string(i)
-                    if token == "locked":
-                        locked = True
-                        break
+            for locked_node in fp_node.find_children("locked"):
+                if (locked_node.get_string(0) or "yes") in ("yes", "true"):
+                    locked = True
+                    break
+            if not locked:
+                attr_node = fp_node.find("attr")
+                if attr_node:
+                    for i in range(len(attr_node.children)):
+                        token = attr_node.get_string(i)
+                        if token == "locked":
+                            locked = True
+                            break
 
             # Count pads
             pad_count = len(list(fp_node.find_all("pad")))

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -640,10 +640,19 @@ class Footprint:
         :meth:`__setattr__`. Removes the existing ``(attr ...)`` node
         (if any), then re-emits it from the current values of
         ``attr``, ``exclude_from_pos_files``, ``exclude_from_bom``,
-        ``locked``, ``dnp``, and any ``_attr_unknown_tokens`` captured
-        during parse. If no flags are set and no unknown tokens are
-        present, no ``(attr ...)`` node is emitted (matches KiCad's
-        canonical "no flags" form).
+        ``dnp``, and any ``_attr_unknown_tokens`` captured during
+        parse. If no flags are set and no unknown tokens are present,
+        no ``(attr ...)`` node is emitted (matches KiCad's canonical
+        "no flags" form).
+
+        ``locked`` is emitted as a top-level ``(locked yes)`` child of
+        the footprint, NEVER as an in-attr ``locked`` token: KiCad 10's
+        kicad-cli rejects the legacy KiCad-6 ``(attr smd locked)`` form
+        with "Failed to load board", which silently breaks zone fill,
+        DRC and gerber export for any board re-saved through the schema
+        layer (issue #3457). Parsing still accepts both forms (see
+        :meth:`from_sexp`), so loading a legacy file and saving it
+        migrates the lock to the modern form.
         """
         sexp_node: SExp | None = self.__dict__.get("_sexp_node")
         if sexp_node is None:
@@ -657,39 +666,49 @@ class Footprint:
         for existing in list(sexp_node.find_children("attr")):
             sexp_node.remove(existing)
 
-        unknown = self.__dict__.get("_attr_unknown_tokens", []) or []
+        # Remove any existing top-level (locked ...) so we can re-emit
+        # it from Python state below. Direct children only -- pads can
+        # legitimately carry their own (locked yes), which must not be
+        # stripped here.
+        for existing in list(sexp_node.find_children("locked")):
+            sexp_node.remove(existing)
+
+        # Defensive: 'locked' is a modeled token (parsed into
+        # ``fp.locked``), but if it ever leaks into the unknown-token
+        # list it must not be echoed back into (attr ...) -- KiCad 10
+        # rejects that form.
+        unknown = [
+            token
+            for token in (self.__dict__.get("_attr_unknown_tokens", []) or [])
+            if token != "locked"
+        ]
 
         # Only emit (attr ...) if there is something to say.
-        if not (
-            self.attr
-            or self.locked
-            or self.dnp
-            or self.exclude_from_pos_files
-            or self.exclude_from_bom
-            or unknown
-        ):
-            return
+        if self.attr or self.dnp or self.exclude_from_pos_files or self.exclude_from_bom or unknown:
+            attr_node = SExp.list("attr")
+            # Canonical KiCad order: <type> [board_only]
+            # [exclude_from_pos_files] [exclude_from_bom]
+            # [allow_missing_courtyard] [dnp]. We emit modeled tokens in
+            # a stable order and append unknown tokens at the end --
+            # KiCad accepts any ordering of these atoms, so this is a
+            # safe simplification.
+            if self.attr:
+                attr_node.add(self.attr)  # 'smd' or 'through_hole'
+            if self.exclude_from_pos_files:
+                attr_node.add("exclude_from_pos_files")
+            if self.exclude_from_bom:
+                attr_node.add("exclude_from_bom")
+            if self.dnp:
+                attr_node.add("dnp")
+            for token in unknown:
+                attr_node.add(token)
 
-        attr_node = SExp.list("attr")
-        # Canonical KiCad order: <type> [board_only] [exclude_from_pos_files]
-        # [exclude_from_bom] [allow_missing_courtyard] [dnp], with `locked`
-        # appearing as a peer token. We emit modeled tokens in a stable
-        # order and append unknown tokens at the end -- KiCad accepts
-        # any ordering of these atoms, so this is a safe simplification.
-        if self.attr:
-            attr_node.add(self.attr)  # 'smd' or 'through_hole'
-        if self.exclude_from_pos_files:
-            attr_node.add("exclude_from_pos_files")
-        if self.exclude_from_bom:
-            attr_node.add("exclude_from_bom")
+            sexp_node.append(attr_node)
+
+        # Modern lock form: top-level (locked yes), the only form
+        # KiCad 10's kicad-cli accepts (issue #3410 / #3457).
         if self.locked:
-            attr_node.add("locked")
-        if self.dnp:
-            attr_node.add("dnp")
-        for token in unknown:
-            attr_node.add(token)
-
-        sexp_node.append(attr_node)
+            sexp_node.append(SExp.list("locked", "yes"))
 
     @classmethod
     def from_sexp(cls, sexp: SExp) -> Footprint:
@@ -1940,6 +1959,20 @@ class PCB:
                 # both _sexp_node and _board_origin are in place.
                 object.__setattr__(fp, "_board_origin", self._board_origin)
                 object.__setattr__(fp, "_sexp_node", child)
+
+                # Migrate the legacy KiCad-6 in-attr 'locked' token to
+                # the modern top-level ``(locked yes)`` form. KiCad 10's
+                # kicad-cli rejects the legacy form ("Failed to load
+                # board"), so a load->save round-trip must not echo the
+                # original token back via raw-sexp passthrough (issue
+                # #3457). ``fp.locked`` was already set by from_sexp;
+                # rebuilding the attr block from Python state drops the
+                # in-attr token and emits the top-level node.
+                attr_nodes = child.find_children("attr")
+                if attr_nodes and any(
+                    atom.value == "locked" for atom in attr_nodes[0].children if atom.is_atom
+                ):
+                    fp._sync_attr_node()
 
             order_idx += 1
 

--- a/tests/test_footprint_locked_form.py
+++ b/tests/test_footprint_locked_form.py
@@ -1,0 +1,205 @@
+"""Tests for the footprint ``locked`` save form (issue #3457).
+
+KiCad 10's kicad-cli rejects boards whose footprints carry the legacy
+KiCad-6 in-attr ``locked`` token (``(attr smd locked)``) with "Failed to
+load board" -- which silently breaks zone fill, DRC and gerber export.
+The schema save path must therefore:
+
+1. Emit ``(locked yes)`` as a top-level footprint child and NEVER write
+   the in-attr token (``Footprint._sync_attr_node``).
+2. Keep PARSING both forms so KiCad 6 files still load
+   (``Footprint.from_sexp``).
+3. MIGRATE the legacy form to the modern form on a load -> save
+   round-trip, even when no footprint field is modified
+   (``PCB._link_footprint_sexp_nodes``).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from kicad_tools.schema.pcb import PCB
+from kicad_tools.sexp.parser import parse_string
+
+# Regex for the legacy in-attr 'locked' token: any (attr ...) block whose
+# atom list contains the bare token 'locked'.
+LEGACY_IN_ATTR_LOCKED = re.compile(r"\(attr\s[^()]*\blocked\b")
+
+
+def _pcb_text(footprint_extra: str) -> str:
+    """Minimal loadable PCB with one footprint carrying ``footprint_extra``."""
+    return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (gr_line (start 0 0) (end 10 0) (layer "Edge.Cuts") (width 0.05))
+  (gr_line (start 10 0) (end 10 10) (layer "Edge.Cuts") (width 0.05))
+  (gr_line (start 10 10) (end 0 10) (layer "Edge.Cuts") (width 0.05))
+  (gr_line (start 0 10) (end 0 0) (layer "Edge.Cuts") (width 0.05))
+  (net 0 "")
+  (footprint "Test:R_0805"
+    (layer "F.Cu")
+    (uuid "fp-r1")
+    (at 5 5)
+{footprint_extra}
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd rect (at -1 0) (size 1 1) (layers "F.Cu") (net 0 ""))
+    (pad "2" smd rect (at 1 0) (size 1 1) (layers "F.Cu") (net 0 ""))
+  )
+)
+"""
+
+
+def _footprint_node(saved_text: str):
+    """Return the (footprint ...) SExp node from saved board text."""
+    doc = parse_string(saved_text)
+    fp_node = doc.find("footprint")
+    assert fp_node is not None, "saved board lost its footprint"
+    return fp_node
+
+
+def _assert_modern_locked_form(saved_text: str) -> None:
+    """Assert top-level ``(locked yes)`` present and in-attr token absent."""
+    assert not LEGACY_IN_ATTR_LOCKED.search(saved_text), (
+        "Saved board carries the legacy in-attr 'locked' token "
+        "(e.g. '(attr smd locked)'). KiCad 10's kicad-cli rejects this "
+        "form with 'Failed to load board' (issue #3457). The schema save "
+        "path must emit a top-level (locked yes) instead -- see "
+        "Footprint._sync_attr_node in src/kicad_tools/schema/pcb.py."
+    )
+    fp_node = _footprint_node(saved_text)
+    locked_children = fp_node.find_children("locked")
+    assert locked_children, (
+        "Saved board is missing the top-level (locked yes) child on the "
+        "locked footprint -- the lock state was silently dropped."
+    )
+    assert (locked_children[0].get_string(0) or "") == "yes"
+
+
+class TestLockedSaveForm:
+    """Setting ``fp.locked`` through the schema layer emits the modern form."""
+
+    def test_lock_emits_top_level_locked_yes(self, tmp_path: Path) -> None:
+        path = tmp_path / "board.kicad_pcb"
+        path.write_text(_pcb_text("    (attr smd)"))
+
+        board = PCB.load(path)
+        fp = board.get_footprint("R1")
+        assert fp.locked is False
+        fp.locked = True
+        board.save(path)
+
+        saved = path.read_text()
+        _assert_modern_locked_form(saved)
+
+        # The footprint type token must survive the attr rebuild.
+        assert "(attr smd)" in saved
+
+        # Reload: the lock must still be visible through the schema layer.
+        assert PCB.load(path).get_footprint("R1").locked is True
+
+    def test_unlock_removes_top_level_locked(self, tmp_path: Path) -> None:
+        path = tmp_path / "board.kicad_pcb"
+        path.write_text(_pcb_text("    (attr smd)\n    (locked yes)"))
+
+        board = PCB.load(path)
+        fp = board.get_footprint("R1")
+        assert fp.locked is True
+        fp.locked = False
+        board.save(path)
+
+        saved = path.read_text()
+        fp_node = _footprint_node(saved)
+        assert not fp_node.find_children("locked"), (
+            "Unlocking a footprint must remove the top-level (locked yes) node"
+        )
+        assert not LEGACY_IN_ATTR_LOCKED.search(saved)
+        assert PCB.load(path).get_footprint("R1").locked is False
+
+    def test_pad_locked_nodes_untouched(self, tmp_path: Path) -> None:
+        """Footprint-level lock sync must not strip pad-level (locked yes)."""
+        path = tmp_path / "board.kicad_pcb"
+        path.write_text(
+            _pcb_text("    (attr smd)").replace(
+                '(pad "1" smd rect (at -1 0)',
+                '(pad "1" smd rect (locked yes) (at -1 0)',
+            )
+        )
+
+        board = PCB.load(path)
+        fp = board.get_footprint("R1")
+        fp.locked = True
+        board.save(path)
+
+        saved = path.read_text()
+        _assert_modern_locked_form(saved)
+        fp_node = _footprint_node(saved)
+        pad_locked = [pad for pad in fp_node.find_children("pad") if pad.find_children("locked")]
+        assert pad_locked, "Footprint-level lock sync stripped the pad-level (locked yes) node"
+
+
+class TestLegacyFormParsing:
+    """Both lock forms must still parse (KiCad 6 files load)."""
+
+    def test_parses_legacy_in_attr_form(self, tmp_path: Path) -> None:
+        path = tmp_path / "board.kicad_pcb"
+        path.write_text(_pcb_text("    (attr smd locked)"))
+        assert PCB.load(path).get_footprint("R1").locked is True
+
+    def test_parses_modern_top_level_form(self, tmp_path: Path) -> None:
+        path = tmp_path / "board.kicad_pcb"
+        path.write_text(_pcb_text("    (attr smd)\n    (locked yes)"))
+        assert PCB.load(path).get_footprint("R1").locked is True
+
+
+class TestLegacyFormMigration:
+    """Loading a legacy-form file and saving must migrate to the modern form."""
+
+    def test_load_save_migrates_without_field_changes(self, tmp_path: Path) -> None:
+        """Pure load -> save (no modification) must not echo the legacy token."""
+        path = tmp_path / "board.kicad_pcb"
+        path.write_text(_pcb_text("    (attr smd locked)"))
+
+        board = PCB.load(path)
+        board.save(path)
+
+        saved = path.read_text()
+        _assert_modern_locked_form(saved)
+        assert "(attr smd)" in saved
+        assert PCB.load(path).get_footprint("R1").locked is True
+
+    def test_migration_preserves_other_attr_tokens(self, tmp_path: Path) -> None:
+        """Modeled + unknown attr tokens survive the legacy-lock migration."""
+        path = tmp_path / "board.kicad_pcb"
+        path.write_text(_pcb_text("    (attr smd locked exclude_from_bom allow_missing_courtyard)"))
+
+        board = PCB.load(path)
+        fp = board.get_footprint("R1")
+        assert fp.locked is True
+        assert fp.exclude_from_bom is True
+        board.save(path)
+
+        saved = path.read_text()
+        _assert_modern_locked_form(saved)
+        attr_node = _footprint_node(saved).find_children("attr")[0]
+        tokens = [c.value for c in attr_node.children if c.is_atom]
+        assert "smd" in tokens
+        assert "exclude_from_bom" in tokens
+        assert "allow_missing_courtyard" in tokens
+        assert "locked" not in tokens
+
+    def test_modern_form_round_trips_unchanged(self, tmp_path: Path) -> None:
+        """A modern-form file keeps its lock through load -> save."""
+        path = tmp_path / "board.kicad_pcb"
+        path.write_text(_pcb_text("    (attr smd)\n    (locked yes)"))
+
+        board = PCB.load(path)
+        board.save(path)
+
+        _assert_modern_locked_form(path.read_text())

--- a/tests/test_kicad_cli_roundtrip.py
+++ b/tests/test_kicad_cli_roundtrip.py
@@ -453,6 +453,130 @@ class TestLoadFailureMessage:
 
 
 # ---------------------------------------------------------------------------
+# Locked-footprint save form (issue #3457)
+# ---------------------------------------------------------------------------
+#
+# KiCad 10's kicad-cli rejects boards whose footprints carry the legacy
+# KiCad-6 in-attr ``locked`` token (``(attr smd locked)``) with "Failed to
+# load board" (exit 3). ``Footprint._sync_attr_node`` previously re-emitted
+# that token whenever ``fp.locked`` was set and the board was saved through
+# the schema layer (``kct pcb lock-footprints``, optimize-placement flows),
+# silently breaking zone fill / DRC / gerber export downstream. The save
+# path now emits a top-level ``(locked yes)`` child instead, and a legacy
+# file is migrated on load -> save. These tests gate that contract against
+# the real kicad-cli parser.
+
+
+def _locked_fp_pcb_text(footprint_extra: str) -> str:
+    """Minimal kicad-cli-loadable PCB with one footprint + ``footprint_extra``."""
+    return textwrap.dedent(f"""\
+        (kicad_pcb
+            (version 20240108)
+            (generator "kicad_tools")
+            (generator_version "9.0")
+            (general
+                (thickness 1.6)
+                (legacy_teardrops no)
+            )
+            (paper "A4")
+            (layers
+                (0 "F.Cu" signal)
+                (31 "B.Cu" signal)
+                (44 "Edge.Cuts" user)
+            )
+            (setup)
+            (net 0 "")
+            (footprint "Test:R_0805"
+                (layer "F.Cu")
+                (uuid "fp-uuid-locked-1")
+                (at 30 30)
+        {footprint_extra}
+                (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS"))
+                (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+                (pad "1" smd rect (at -1 0) (size 1 1) (layers "F.Cu") (net 0 ""))
+                (pad "2" smd rect (at 1 0) (size 1 1) (layers "F.Cu") (net 0 ""))
+            )
+        )
+    """)
+
+
+class TestLockedFootprintRoundtrip:
+    """Locked footprints saved through the schema layer must load in kicad-cli."""
+
+    def test_schema_locked_save_loads_in_kicad_cli(self, tmp_path: Path) -> None:
+        """``fp.locked = True`` + ``PCB.save()`` must produce a loadable board."""
+        pcb_path = tmp_path / "locked.kicad_pcb"
+        pcb_path.write_text(_locked_fp_pcb_text("        (attr smd)"))
+
+        board = PCB.load(pcb_path)
+        board.get_footprint("R1").locked = True
+        board.save(pcb_path)
+
+        # Regression guard: the legacy in-attr token must be absent before
+        # we even invoke kicad-cli, so the failure is attributed clearly.
+        contents = pcb_path.read_text()
+        assert "(attr smd locked" not in contents, (
+            "Regression guard: PCB.save() re-emitted the legacy in-attr "
+            "'locked' token. KiCad 10's kicad-cli rejects '(attr smd locked)' "
+            "with 'Failed to load board'. See Footprint._sync_attr_node in "
+            "src/kicad_tools/schema/pcb.py (issue #3457)."
+        )
+        assert "(locked yes)" in contents, (
+            "PCB.save() dropped the lock entirely -- expected a top-level "
+            "(locked yes) child on the footprint."
+        )
+
+        _assert_kicad_cli_loads(pcb_path, producer="PCB.save (locked footprint)", tmp_path=tmp_path)
+
+    def test_legacy_locked_migration_loads_in_kicad_cli(self, tmp_path: Path) -> None:
+        """A KiCad-6 legacy-form board must be migrated by load -> save."""
+        pcb_path = tmp_path / "legacy_migrated.kicad_pcb"
+        pcb_path.write_text(_locked_fp_pcb_text("        (attr smd locked)"))
+
+        board = PCB.load(pcb_path)
+        assert board.get_footprint("R1").locked is True
+        board.save(pcb_path)
+
+        contents = pcb_path.read_text()
+        assert "(attr smd locked" not in contents, (
+            "Load -> save round-trip echoed the legacy in-attr 'locked' token "
+            "back via raw-sexp passthrough instead of migrating it. See "
+            "PCB._link_footprint_sexp_nodes (issue #3457)."
+        )
+        assert "(locked yes)" in contents
+
+        _assert_kicad_cli_loads(
+            pcb_path,
+            producer="PCB.load + PCB.save (legacy locked migration)",
+            tmp_path=tmp_path,
+        )
+
+    def test_legacy_in_attr_locked_reproduces_failure(self, tmp_path: Path) -> None:
+        """The legacy ``(attr smd locked)`` form must trip kicad-cli's loader.
+
+        Canary test: if this ever stops failing, kicad-cli has relaxed its
+        parser and the regression class this module gates against has
+        shifted -- a signal to revisit the locked-form migration logic.
+        """
+        pcb_path = tmp_path / "legacy_raw.kicad_pcb"
+        pcb_path.write_text(_locked_fp_pcb_text("        (attr smd locked)"))
+
+        result = run_drc(
+            pcb_path,
+            output_path=tmp_path / "legacy_raw_drc.rpt",
+            format="report",
+            schematic_parity=False,
+        )
+
+        assert not result.success, (
+            "Canary failed: kicad-cli accepted the legacy in-attr 'locked' "
+            "token ('(attr smd locked)'). The regression class this test "
+            "gates against has shifted; review the locked-form handling in "
+            "src/kicad_tools/schema/pcb.py."
+        )
+
+
+# ---------------------------------------------------------------------------
 # Schematic load gate (issue #3587)
 # ---------------------------------------------------------------------------
 #

--- a/tests/test_pcb_lock_footprints.py
+++ b/tests/test_pcb_lock_footprints.py
@@ -322,25 +322,27 @@ class TestSExpRoundtrip:
     """Verify the (locked) attribute survives KiCad s-expression round-trip."""
 
     def test_locked_attribute_in_sexp(self, tmp_path):
-        """After lock, the .kicad_pcb file contains 'locked' inside (attr ...)."""
+        """After lock, the .kicad_pcb file contains a top-level ``(locked yes)``.
+
+        Issue #3457: the lock must be the MODERN top-level ``(locked yes)``
+        form, NEVER the legacy KiCad-6 in-attr token (``(attr smd locked)``)
+        -- KiCad 10's kicad-cli rejects the legacy form with "Failed to
+        load board", silently breaking zone fill / DRC / gerber export.
+        """
+        import re
+
         from kicad_tools.cli.pcb_lock_footprints import run_lock_footprints
 
         pcb = _write_pcb(tmp_path)
         assert run_lock_footprints(pcb, refs=["J1"]) == 0
 
         text = pcb.read_text()
-        # KiCad emits (attr "locked") or (attr smd locked).  Match either.
-        # The simple assertion is: somewhere in the file, an (attr ...)
-        # block now contains the literal `locked` token.
         assert "locked" in text
-        # Specifically inside an (attr ...) block — sanity check we are
-        # not picking up some unrelated string.
-        # Find J1 footprint block and confirm.
+        # Find J1 footprint block and confirm the lock landed there.
         # (Naive but sufficient for the fixture.)
         j1_start = text.find('"fp-j1"')
         assert j1_start >= 0
         # Search forward until the matching close-paren of J1's footprint.
-        depth = 0
         i = text.rfind("(footprint", 0, j1_start)
         assert i >= 0
         block_start = i
@@ -356,5 +358,9 @@ class TestSExpRoundtrip:
         else:
             block_end = len(text)
         block = text[block_start:block_end]
-        assert "locked" in block
-        assert "(attr" in block
+        assert "(locked yes)" in block
+        # The legacy in-attr token must never be emitted (issue #3457).
+        assert not re.search(r"\(attr\s[^()]*\blocked\b", block), (
+            "lock-footprints emitted the legacy in-attr 'locked' token; "
+            "KiCad 10's kicad-cli rejects '(attr ... locked)'."
+        )


### PR DESCRIPTION
Closes #3457

## Summary

KiCad 10's kicad-cli rejects boards whose footprints carry the legacy KiCad-6 in-attr `locked` token (`(attr smd locked)`) with "Failed to load board" (exit 3) — silently breaking zone fill, DRC and gerber export. `Footprint._sync_attr_node` re-emitted that token whenever `fp.locked` was set and the file was saved through the schema layer (`kct pcb lock-footprints`, optimize-placement flows), making any re-saved board kicad-cli-incompatible again after PR #3453 fixed the board-03 generator.

### Save-path fix (`src/kicad_tools/schema/pcb.py`)
- `Footprint._sync_attr_node` now emits a **top-level `(locked yes)`** footprint child and never writes the in-attr token. Existing top-level `(locked ...)` nodes are removed/re-emitted from Python state (so unlocking also works), using direct-children-only removal so pad-level `(locked yes)` nodes are untouched. Defensive filter prevents `locked` from ever being echoed back through `_attr_unknown_tokens`.
- **Round-trip migration**: `PCB._link_footprint_sexp_nodes` detects a legacy in-attr `locked` token at load time and rebuilds the attr block immediately, so even a pure load → save (no field modification) migrates the file instead of echoing the legacy token via raw-sexp passthrough.
- Parsing still accepts **both** forms (KiCad 6 files load) — unchanged from #3453.

### Other writers/readers audited (issue item 4)
- Writers of `(attr ...)` nodes: `panel/furniture.py`, `panel/cuts.py`, `footprints/__init__.py`, `library/footprint.py` — none emit the in-attr `locked` token. No other writer shares the bug.
- `drc/repair_clearance.py` locked-status **reader** only recognized the legacy in-attr form and would have gone blind after migration; it now accepts both forms (modern top-level form checked first, direct children only).

### Committed-artifact audit (issue item 3d)
`grep` of every `*.kicad_pcb` in the repo: **no committed artifact carries the legacy token**. Only board 03's artifacts contain `locked` at all, and they already use the modern `(attr smd)` + `(locked yes)` form from PR #3453. No artifact repair needed.

## Tests

- `tests/test_footprint_locked_form.py` (new, 8 tests): lock emits top-level `(locked yes)` with no in-attr token; unlock removes the node; pad-level `(locked yes)` preserved; both forms parse; legacy load → save migrates without field changes; migration preserves modeled + unknown attr tokens (`exclude_from_bom`, `allow_missing_courtyard`); modern form round-trips.
- `tests/test_kicad_cli_roundtrip.py` (+3 tests): schema-locked save loads in kicad-cli; legacy-form migration loads in kicad-cli; canary asserting kicad-cli still rejects the raw legacy form. Verified locally against **kicad-cli 10.0.1** (legacy form: exit 3 "Failed to load board"; modern form: loads, DRC report produced).
- `tests/test_pcb_lock_footprints.py::test_locked_attribute_in_sexp` updated: it previously asserted the legacy in-attr behavior this issue outlaws; it now asserts the modern form and forbids the legacy token.

Results: `test_footprint_locked_form.py` 8 passed; `test_kicad_cli_roundtrip.py` 22 passed (incl. 3 new); `test_pcb_lock_footprints.py` + `test_pcb_attr_roundtrip.py` + `test_repair_clearance.py` 125 passed; schema PCB batch (`test_pcb_create.py`, `test_pcb_move_footprint.py`, `test_pcb_modules.py`, `test_pcb_sync_netlist.py`) 238 passed.

Note: pre-existing `ruff` failure at `drc/repair_clearance.py:975` (unused `required_clearance`) and repo-wide format drift are tracked by #3464 and not touched here; the changed files I authored are ruff-clean and formatted.