### PR TITLE
test(board05): accept two-phase 'Initial pass' iter-0 line + bypass routing cache

### DIFF
--- a/tests/test_board_05_routing_regression.py
+++ b/tests/test_board_05_routing_regression.py
@@ -95,17 +95,31 @@ def _parse_routed_net_count(stdout: str) -> tuple[int, int] | None:
 def _parse_iter0_route_count(stdout: str) -> int | None:
     """Extract the iteration-0 routed-net count from kct route output.
 
-    Negotiated congestion routing emits a line of the form::
+    The legacy negotiated loop (``core.py::route_all_negotiated``) emits a
+    line of the form::
 
         Routed 23/35 nets, overflow: 14 (178.4s)
 
-    immediately after the initial-routing-with-sharing pass.  We
-    capture the FIRST such line (iteration 0) because subsequent
+    immediately after the initial-routing-with-sharing pass.  The two-phase
+    path (``two_phase.py`` / ``hierarchical.py``, default since #3452/#3499)
+    emits the equivalent tally as::
+
+        Initial pass: 23/39 nets, overflow: 14
+
+    Both report the same measure: the net count after the iteration-0
+    initial pass, before any rip-up-and-reroute iteration.  Note the
+    two-phase line is printed AFTER the bounded grace pass (#3452)
+    commits its routes, so it includes grace-routed starved nets; the
+    grace pass is part of the initial pass by design (one bounded
+    attempt per starved net within a fixed grace budget), so this line
+    remains the honest iteration-0 tally.
+
+    We capture the FIRST such line (iteration 0) because subsequent
     iterations may rip up and re-route a different subset.
 
     Returns the integer count or ``None`` if no such line was found.
     """
-    pattern = re.compile(r"Routed\s+(\d+)/\d+ nets,\s+overflow:\s+\d+")
+    pattern = re.compile(r"(?:Routed|Initial pass:)\s+(\d+)/\d+\s+nets,\s+overflow:\s+\d+")
     match = pattern.search(stdout)
     if match is None:
         return None
@@ -143,6 +157,13 @@ class TestBoard05RoutingThroughput:
             # loop from re-running on 4L/6L stacks (which would multiply
             # the wall-clock cost by 4x); this test only pins 2L throughput,
             # the regression dimension #2681 identified.
+            # ``--no-cache`` (issue #3502): a warm routing cache makes
+            # ``kct route`` skip the routing phase entirely ("Cache HIT ...
+            # Using cached routing result"), so no iteration-0 line is
+            # emitted at all and the completion metric reflects a stale
+            # cached route rather than current router throughput.  Both
+            # tests in this class pin THROUGHPUT, so the route must
+            # actually run.
             cmd = [
                 sys.executable,
                 "-m",
@@ -161,6 +182,7 @@ class TestBoard05RoutingThroughput:
                 "240",
                 "--backend",
                 "python",
+                "--no-cache",
             ]
             proc = subprocess.run(
                 cmd,
@@ -241,11 +263,12 @@ class TestBoard05RoutingThroughput:
         """
         actual_count = _parse_iter0_route_count(route_stdout)
         assert actual_count is not None, (
-            "Could not find 'Routed N/M nets' iteration-0 line in kct "
+            "Could not find the iteration-0 line ('Routed N/M nets, "
+            "overflow: K' or 'Initial pass: N/M nets, overflow: K') in kct "
             f"route output.  Last 2000 chars of stdout:\n{route_stdout[-2000:]}"
         )
         assert actual_count >= 15, (
-            f"Board 05 iteration-0 routed only {actual_count}/35 nets "
+            f"Board 05 iteration-0 routed only {actual_count} nets "
             "in the 240s budget; expected >= 15 (issue #2681 floor).  "
             "Lower counts indicate per-net A* slowdown -- check recent "
             "router changes for added per-call overhead in "


### PR DESCRIPTION
Closes #3502

## Summary

`test_initial_pass_routes_enough_nets` failed on main because `_parse_iter0_route_count` only matched the legacy negotiated-loop line `Routed N/M nets, overflow: K`. Two distinct staleness modes were found and fixed:

- **Pattern staleness (the reported bug):** the two-phase path (#3452/#3499, `two_phase.py:630` / `hierarchical.py:320`) emits `Initial pass: N/M nets, overflow: K` instead. The regex now accepts both forms: `(?:Routed|Initial pass:)\s+(\d+)/\d+\s+nets,\s+overflow:\s+\d+` (first match wins, preserving iteration-0 semantics).
- **Cache staleness (found during verification):** on a machine with a warm routing cache, `kct route` skips routing entirely (`Cache HIT ... Using cached routing result`) and emits **no iteration-0 line in either form** — this was the actual reproduction on this machine (test failed in 6s without routing). Worse, the sibling `test_2l_completion_meets_floor` was silently measuring a stale cached route instead of live throughput. Added `--no-cache` to the fixture so both tests measure what they pin.

## Two-phase semantics check (per issue AC)

The two-phase `Initial pass:` line is printed AFTER the bounded grace pass (#3452) commits its routes into `net_routes`, so it includes grace-routed starved nets. The grace pass is part of the initial pass by design (one bounded attempt per starved net within a fixed `GRACE_PASS_BUDGET_S`), so this line is the honest iteration-0 tally — documented in the helper docstring. Since grace can only add nets, the existing `>= 15` floor remains conservative.

## Threshold check against live (no-cache) output

On the test's exact recipe (`--seed 42 --backend python --timeout 240 --no-cache`), current main takes the legacy `core.py::route_all_negotiated` path and emits:

```
Routed 24/47 nets, overflow: 34 (177.0s)   <- iteration 0; floor 15, 9 nets slack
Nets routed: 15/39 (38%)                   <- final; floor 35%, 3 points slack
```

The 38% vs 35% margin on the completion floor is tighter than the historical ~10-point slack (the cached result reported 43%); re-pinning that floor is out of scope but flagged here for awareness.

## Other consumers of the legacy pattern (per issue AC)

Grepped `tests/` for `Routed N/M nets` consumers:
- `tests/test_board_05_routing_regression.py` — the only consumer of the `, overflow:` iteration-0 form; fixed here.
- `tests/test_board02_route_demo_recipe.py:236` — final-summary parser, tries `Nets routed: N/M` first which still appears; not broken.
- `tests/test_board_03_regression.py:743` — handles `Routed N/M [signal] nets` with optional word; not broken.

## Test plan

- [x] Reproduced failure on unmodified origin/main (`assert None is not None`, test fails in 6s due to cache hit)
- [x] Full class passes with fix: `2 passed in 265.86s`
- [x] Targeted test second run: `1 passed in 262.42s`
- [x] Regex unit-checked against legacy, two-phase, mixed, and no-match inputs
- [x] `ruff check` + `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)