### PR TITLE
boards/04: remove manual crystal GND-bus junction workaround

### DIFF
--- a/boards/04-stm32-devboard/generate_design.py
+++ b/boards/04-stm32-devboard/generate_design.py
@@ -320,15 +320,10 @@ def create_stm32_schematic(output_dir: Path) -> Path:
     # Connect crystal ground to GND rail.  The block's GND port is the
     # MIDPOINT of the C10/C11 ground-bus horizontal wire, and
     # ``connect_to_rails`` drops a vertical wire from that midpoint down to
-    # the rail.  Because the midpoint lands mid-segment on the ground bus
-    # (not on a wire endpoint) and the block adds a junction only at the
-    # rail end, the vertical wire's TOP endpoint is left as an
-    # ``unconnected_wire_endpoint`` (KiCad needs a junction dot to register
-    # the T-connection).  Add a junction at the GND port to close that
-    # warning.  See issue #3149 (AC #2).
+    # the rail, emitting junctions at both the rail end and the ground-bus
+    # midpoint (the latter added by PR #3467; previously this generator had
+    # to add it manually -- see issues #3149 AC #2 and #3468).
     xtal.connect_to_rails(gnd_rail_y=RAIL_GND)
-    _xtal_gnd = xtal.port("GND")
-    sch.add_junction(_xtal_gnd[0], _xtal_gnd[1])
 
     # Wire crystal IN/OUT to OSC_IN / OSC_OUT labels (on stubs).  Labels at the
     # MCU side are added below when we wire the MCU pins.


### PR DESCRIPTION
Closes #3468

## Summary

- Removed the manual `sch.add_junction(_xtal_gnd[0], _xtal_gnd[1])` workaround in `boards/04-stm32-devboard/generate_design.py` (crystal section). Since PR #3467, `CrystalOscillator.connect_to_rails` emits the T-junction at the ground-bus midpoint itself (`src/kicad_tools/schematic/blocks/timing.py:300`), so the manual call produced a duplicate junction at (139.7, 119.38).
- Rewrote the stale comment block that described the old "junction only at the rail end" behavior.

## Equivalence evidence

Regenerated the schematic into temp dirs before and after the change (workaround present vs removed):

- Junction count: 40 -> 39; the only structural diff (ignoring UUID churn and run-to-run property ordering) is the removed **duplicate** junction at `(at 139.7 119.38)` — one junction remains at that coordinate.
- `kct netlist compare` before vs after: **no component changes, no net changes**.
- `kct erc` output identical before vs after (same single pre-existing label-only-pin warning class, no errors).

## Artifact decision: generator-only, committed schematic untouched

The committed `boards/04-stm32-devboard/output/stm32_devboard.kicad_sch` was generated with the old workaround (pre-#3467) and already carries exactly **one** junction at (139.7, 119.38) and 39 junctions total — structurally identical to what the fixed generator now produces. `kct netlist compare` between the committed schematic and the fresh post-change regen reports no component or net changes. Regenerating would only churn UUIDs against the routed PCB, so the committed artifacts are left untouched (the safer path per the #3580 artifact-integrity class).

## Test results

All green (after `uv sync --extra dev`; plain `uv sync` lacks shapely, which `kct check` needs — pre-existing worktree-setup quirk, not caused by this change):

- `tests/test_board_04_erc_regression.py`
- `tests/test_board_04_drc_recipe_mfr.py`
- `tests/test_board_04_mfr_gate.py`
- `tests/test_manifest_integrity.py`

27 passed. `git status` confirms the only tracked-file change is `generate_design.py` — no committed artifacts modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)