### PR TITLE
fix(schematic): honor KICAD_SYMBOL_DIR in symbol library discovery

### DIFF
--- a/src/kicad_tools/cli/lib.py
+++ b/src/kicad_tools/cli/lib.py
@@ -28,7 +28,7 @@ from kicad_tools.footprints.library_path import (
     list_available_libraries as list_footprint_libraries,
 )
 from kicad_tools.schema import SymbolLibrary
-from kicad_tools.schematic.grid import KICAD_SYMBOL_PATHS
+from kicad_tools.schematic.grid import get_symbol_search_paths
 from kicad_tools.schematic.library import list_libraries as list_symbol_libraries
 
 
@@ -48,7 +48,7 @@ def list_kicad_libraries(
     result: dict[str, Any] = {}
 
     if library_type in ("symbols", "all"):
-        symbol_libs = list_symbol_libraries(KICAD_SYMBOL_PATHS)
+        symbol_libs = list_symbol_libraries(get_symbol_search_paths())
         result["symbols"] = {
             "count": len(symbol_libs),
             "libraries": symbol_libs,
@@ -152,7 +152,7 @@ def _find_symbol_library(library: str) -> Path | None:
     lib_name = library if library.endswith(".kicad_sym") else f"{library}.kicad_sym"
 
     # Search in KiCad paths
-    for search_path in KICAD_SYMBOL_PATHS:
+    for search_path in get_symbol_search_paths():
         candidate = search_path / lib_name
         if candidate.exists():
             return candidate

--- a/src/kicad_tools/schematic/grid.py
+++ b/src/kicad_tools/schematic/grid.py
@@ -4,6 +4,7 @@ KiCad Grid Constants and Snapping Utilities
 Provides grid size constants and functions for snapping coordinates to grid points.
 """
 
+import os
 import warnings
 from enum import Enum
 from pathlib import Path
@@ -28,12 +29,43 @@ class GridSize(Enum):
 # Default grid for schematic operations
 DEFAULT_GRID = GridSize.SCH_STANDARD.value  # 1.27mm
 
-# Default KiCad library paths
-KICAD_SYMBOL_PATHS = [
-    Path("/Applications/KiCad/KiCad.app/Contents/SharedSupport/symbols"),
-    Path("/usr/share/kicad/symbols"),
-    Path.home() / ".local/share/kicad/symbols",
-]
+
+def get_symbol_search_paths() -> list[Path]:
+    """Get KiCad symbol library search paths, honoring ``KICAD_SYMBOL_DIR``.
+
+    This is the single source of truth for symbol library discovery,
+    mirroring how ``detect_kicad_library_path()`` resolves footprint
+    paths from ``KICAD_FOOTPRINT_DIR``. The environment variable is read
+    at call time (not import time), so it works regardless of when it is
+    set — important on systems like NixOS where libraries live in
+    non-standard store paths.
+
+    Priority order:
+    1. ``KICAD_SYMBOL_DIR`` environment variable
+    2. Platform default locations (macOS app bundle, Linux system dirs,
+       user-local share)
+
+    Returns:
+        List of existing directories, highest priority first. Paths that
+        do not exist on this machine are filtered out.
+    """
+    paths: list[Path] = []
+
+    # 1. Environment variable override (highest priority)
+    env_dir = os.environ.get("KICAD_SYMBOL_DIR")
+    if env_dir:
+        paths.append(Path(env_dir))
+
+    # 2. Platform defaults
+    # macOS
+    paths.append(Path("/Applications/KiCad/KiCad.app/Contents/SharedSupport/symbols"))
+    # Linux
+    paths.append(Path("/usr/share/kicad/symbols"))
+    paths.append(Path("/usr/local/share/kicad/symbols"))
+    # User local (both platforms)
+    paths.append(Path.home() / ".local/share/kicad/symbols")
+
+    return [p for p in paths if p.exists()]
 
 
 def snap_to_grid(value: float, grid: float = DEFAULT_GRID) -> float:

--- a/src/kicad_tools/schematic/library.py
+++ b/src/kicad_tools/schematic/library.py
@@ -8,7 +8,7 @@ import re
 from pathlib import Path
 
 from .exceptions import LibraryNotFoundError
-from .grid import KICAD_SYMBOL_PATHS
+from .grid import get_symbol_search_paths
 from .helpers import _group_pins_by_type
 from .models.pin import Pin
 from .models.symbol import SymbolInstance
@@ -28,7 +28,7 @@ def list_libraries(lib_paths: list[Path] = None) -> list[str]:
         print(f"Available libraries: {libs[:10]}...")  # First 10
     """
     if lib_paths is None:
-        lib_paths = KICAD_SYMBOL_PATHS
+        lib_paths = get_symbol_search_paths()
 
     libraries = set()
     for search_path in lib_paths:
@@ -54,7 +54,7 @@ def list_symbols(library: str, lib_paths: list[Path] = None) -> list[str]:
         print(f"Audio symbols: {symbols}")
     """
     if lib_paths is None:
-        lib_paths = KICAD_SYMBOL_PATHS
+        lib_paths = get_symbol_search_paths()
 
     lib_file = f"{library}.kicad_sym"
 
@@ -97,7 +97,7 @@ def search_symbols(pattern: str, lib_paths: list[Path] = None) -> list[str]:
     import fnmatch
 
     if lib_paths is None:
-        lib_paths = KICAD_SYMBOL_PATHS
+        lib_paths = get_symbol_search_paths()
 
     results = []
     for lib_name in list_libraries(lib_paths):

--- a/src/kicad_tools/schematic/models/elements_mixin.py
+++ b/src/kicad_tools/schematic/models/elements_mixin.py
@@ -231,7 +231,7 @@ class SchematicElementsMixin:
         1. If the lib_id's library prefix matches a local lib registered
            on ``self.local_symbol_libs``, parse from that file directly.
         2. Otherwise, fall through to ``SymbolDef.from_library()`` which
-           uses the global ``KICAD_SYMBOL_PATHS`` search.
+           uses the global ``get_symbol_search_paths()`` search.
 
         Args:
             lib_id: Library:Symbol format id (e.g., ``"softstart_custom:UCC27211"``).

--- a/src/kicad_tools/schematic/models/schematic.py
+++ b/src/kicad_tools/schematic/models/schematic.py
@@ -196,7 +196,7 @@ class Schematic(
         Searches ``self.local_symbol_libs`` first (project-local libs win
         over stock libs, matching KiCad's project-table precedence).
         Returns ``None`` if no match is found in the local libs — callers
-        should fall through to the global ``KICAD_SYMBOL_PATHS`` search
+        should fall through to the global ``get_symbol_search_paths()`` search
         in that case.
 
         Args:

--- a/src/kicad_tools/schematic/models/symbol.py
+++ b/src/kicad_tools/schematic/models/symbol.py
@@ -22,7 +22,7 @@ from kicad_tools.sexp.builders import (
 from kicad_tools.sexp.builders import fmt as sexp_fmt
 
 from ..exceptions import LibraryNotFoundError, PinNotFoundError, SymbolNotFoundError
-from ..grid import KICAD_SYMBOL_PATHS
+from ..grid import get_symbol_search_paths
 from ..helpers import _expand_pin_aliases, _find_similar, _fmt_coord
 from .pin import Pin
 
@@ -95,7 +95,7 @@ class SymbolDef:
         from kicad_tools.sexp import parse_file
 
         if lib_paths is None:
-            lib_paths = KICAD_SYMBOL_PATHS
+            lib_paths = get_symbol_search_paths()
 
         lib_name, sym_name = lib_id.split(":", 1)
         lib_file = f"{lib_name}.kicad_sym"

--- a/src/kicad_tools/schematic/registry.py
+++ b/src/kicad_tools/schematic/registry.py
@@ -26,33 +26,22 @@ Usage:
     pin = registry.get_pin(symbol, "anode")  # Fuzzy matches to "A"
 """
 
-import os
 import re
 from dataclasses import dataclass, field
 from difflib import get_close_matches
 from pathlib import Path
 
+from .grid import get_symbol_search_paths
 
-# Default KiCad library paths (platform-specific)
+
 def _default_symbol_paths() -> list[Path]:
-    """Get platform-appropriate KiCad symbol paths."""
-    paths = []
+    """Get platform-appropriate KiCad symbol paths.
 
-    # macOS
-    paths.append(Path("/Applications/KiCad/KiCad.app/Contents/SharedSupport/symbols"))
-
-    # Linux
-    paths.append(Path("/usr/share/kicad/symbols"))
-    paths.append(Path("/usr/local/share/kicad/symbols"))
-
-    # User local (both platforms)
-    paths.append(Path.home() / ".local/share/kicad/symbols")
-
-    # Environment variable override
-    if "KICAD_SYMBOL_DIR" in os.environ:
-        paths.insert(0, Path(os.environ["KICAD_SYMBOL_DIR"]))
-
-    return [p for p in paths if p.exists()]
+    Thin delegation to :func:`kicad_tools.schematic.grid.get_symbol_search_paths`,
+    the single source of truth for symbol library discovery (honors
+    ``KICAD_SYMBOL_DIR`` at call time).
+    """
+    return get_symbol_search_paths()
 
 
 @dataclass
@@ -400,7 +389,7 @@ class SymbolRegistry:
         section_starts = [m.start() for m in re.finditer(r"\n\s*\(pin\s+", sexp)]
         pin_sections = re.split(r"\n\s*\(pin\s+", sexp)[1:]
 
-        for section, offset in zip(pin_sections, section_starts):
+        for section, offset in zip(pin_sections, section_starts, strict=False):
             # Extract pin type and style from start
             type_match = re.match(r"(\w+)\s+(\w+)", section)
             if not type_match:

--- a/tests/test_cli_lib.py
+++ b/tests/test_cli_lib.py
@@ -7,9 +7,11 @@ import pytest
 
 def _kicad_installed() -> bool:
     """Check if KiCad standard libraries are available."""
-    from kicad_tools.schematic.grid import KICAD_SYMBOL_PATHS
+    from kicad_tools.schematic.grid import get_symbol_search_paths
 
-    return any(path.exists() and any(path.glob("*.kicad_sym")) for path in KICAD_SYMBOL_PATHS)
+    return any(
+        path.exists() and any(path.glob("*.kicad_sym")) for path in get_symbol_search_paths()
+    )
 
 
 class TestLibListCommand:

--- a/tests/test_symbol_search_paths.py
+++ b/tests/test_symbol_search_paths.py
@@ -1,0 +1,140 @@
+"""Regression tests for KICAD_SYMBOL_DIR symbol library discovery.
+
+Issue #3606: `kicad-tools lib list --symbols` ignored KICAD_SYMBOL_DIR
+because the CLI consumed a hardcoded module constant instead of reading
+the environment variable at call time (the footprint side already read
+KICAD_FOOTPRINT_DIR at call time via detect_kicad_library_path()).
+
+These tests pin the unified resolver, get_symbol_search_paths(), and
+its consumers (lib list, symbol-info library lookup, list_libraries),
+including the reporter's flat-directory-of-.kicad_sym-files layout
+(the standard KiCad/NixOS layout).
+"""
+
+import json
+
+from kicad_tools.schematic.grid import get_symbol_search_paths
+from kicad_tools.schematic.library import list_libraries
+
+MINIMAL_LIB = '(kicad_symbol_lib\n\t(symbol "R0"\n\t\t(property "Reference" "R")\n\t)\n)\n'
+
+
+def _make_symbol_dir(tmp_path, names=("Device", "Audio")):
+    """Create a flat directory of .kicad_sym files (NixOS/KiCad layout)."""
+    sym_dir = tmp_path / "symbols"
+    sym_dir.mkdir()
+    for name in names:
+        (sym_dir / f"{name}.kicad_sym").write_text(MINIMAL_LIB)
+    return sym_dir
+
+
+class TestGetSymbolSearchPaths:
+    """Tests for the unified call-time symbol path resolver."""
+
+    def test_env_var_dir_is_first(self, tmp_path, monkeypatch):
+        """KICAD_SYMBOL_DIR takes priority over platform defaults."""
+        sym_dir = _make_symbol_dir(tmp_path)
+        monkeypatch.setenv("KICAD_SYMBOL_DIR", str(sym_dir))
+
+        paths = get_symbol_search_paths()
+        assert paths, "env-var directory should be discovered"
+        assert paths[0] == sym_dir
+
+    def test_env_var_read_at_call_time(self, tmp_path, monkeypatch):
+        """Setting the env var after import is honored (no import-time constant)."""
+        monkeypatch.delenv("KICAD_SYMBOL_DIR", raising=False)
+        before = get_symbol_search_paths()
+
+        sym_dir = _make_symbol_dir(tmp_path)
+        monkeypatch.setenv("KICAD_SYMBOL_DIR", str(sym_dir))
+        after = get_symbol_search_paths()
+
+        assert sym_dir not in before
+        assert after[0] == sym_dir
+
+    def test_unset_env_var_platform_defaults_only(self, monkeypatch):
+        """Without the env var, only platform defaults are returned (unchanged)."""
+        monkeypatch.delenv("KICAD_SYMBOL_DIR", raising=False)
+        paths = get_symbol_search_paths()
+        # All returned paths exist and none came from the (unset) env var
+        for p in paths:
+            assert p.exists()
+
+    def test_nonexistent_env_dir_filtered(self, tmp_path, monkeypatch):
+        """A KICAD_SYMBOL_DIR pointing at a missing path falls through silently
+        (matching KICAD_FOOTPRINT_DIR behavior)."""
+        missing = tmp_path / "does-not-exist"
+        monkeypatch.setenv("KICAD_SYMBOL_DIR", str(missing))
+        assert missing not in get_symbol_search_paths()
+
+    def test_registry_delegates_to_shared_resolver(self, tmp_path, monkeypatch):
+        """registry._default_symbol_paths is a thin alias of the shared resolver."""
+        from kicad_tools.schematic.registry import _default_symbol_paths
+
+        sym_dir = _make_symbol_dir(tmp_path)
+        monkeypatch.setenv("KICAD_SYMBOL_DIR", str(sym_dir))
+        assert _default_symbol_paths() == get_symbol_search_paths()
+
+
+class TestListLibrariesEnvVar:
+    """list_libraries() honors KICAD_SYMBOL_DIR (flat .kicad_sym layout)."""
+
+    def test_finds_env_var_libraries(self, tmp_path, monkeypatch):
+        sym_dir = _make_symbol_dir(tmp_path, names=("Device", "Audio", "MCU_Module"))
+        monkeypatch.setenv("KICAD_SYMBOL_DIR", str(sym_dir))
+
+        libs = list_libraries()
+        for name in ("Device", "Audio", "MCU_Module"):
+            assert name in libs
+
+    def test_unset_env_var_does_not_find_temp_libs(self, tmp_path, monkeypatch):
+        sym_dir = _make_symbol_dir(tmp_path, names=("Issue3606Sentinel",))
+        monkeypatch.delenv("KICAD_SYMBOL_DIR", raising=False)
+        assert "Issue3606Sentinel" not in list_libraries()
+        # Sanity: setting it makes the sentinel appear
+        monkeypatch.setenv("KICAD_SYMBOL_DIR", str(sym_dir))
+        assert "Issue3606Sentinel" in list_libraries()
+
+
+class TestCliLibListEnvVar:
+    """The reporter's exact case: `kicad-tools lib list --symbols`."""
+
+    def test_lib_list_symbols_honors_env_var(self, tmp_path, monkeypatch, capsys):
+        from kicad_tools.cli import main
+
+        sym_dir = _make_symbol_dir(tmp_path, names=("Issue3606Lib",))
+        monkeypatch.setenv("KICAD_SYMBOL_DIR", str(sym_dir))
+
+        result = main(["lib", "list", "--symbols"])
+        assert result == 0
+
+        captured = capsys.readouterr()
+        assert "Issue3606Lib" in captured.out
+        assert "No symbol libraries found" not in captured.out
+
+    def test_lib_list_symbols_json_count(self, tmp_path, monkeypatch, capsys):
+        from kicad_tools.cli import main
+
+        sym_dir = _make_symbol_dir(tmp_path, names=("A3606", "B3606"))
+        monkeypatch.setenv("KICAD_SYMBOL_DIR", str(sym_dir))
+
+        result = main(["lib", "list", "--symbols", "--format", "json"])
+        assert result == 0
+
+        data = json.loads(capsys.readouterr().out)
+        assert data["symbols"]["count"] >= 2
+        assert "A3606" in data["symbols"]["libraries"]
+        assert "B3606" in data["symbols"]["libraries"]
+
+
+class TestFindSymbolLibraryEnvVar:
+    """`lib symbol-info` library lookup honors KICAD_SYMBOL_DIR."""
+
+    def test_find_symbol_library_in_env_dir(self, tmp_path, monkeypatch):
+        from kicad_tools.cli.lib import _find_symbol_library
+
+        sym_dir = _make_symbol_dir(tmp_path, names=("Issue3606Lib",))
+        monkeypatch.setenv("KICAD_SYMBOL_DIR", str(sym_dir))
+
+        found = _find_symbol_library("Issue3606Lib")
+        assert found == sym_dir / "Issue3606Lib.kicad_sym"


### PR DESCRIPTION
Closes #3606

Fixes an **external user report** (NixOS): `kicad-tools lib list --symbols` found 0 libraries even with `KICAD_SYMBOL_DIR` set, while `--footprints` worked with `KICAD_FOOTPRINT_DIR`.

## Root cause

Two parallel symbol-path mechanisms existed:
- `schematic/grid.py` had a hardcoded module-level `KICAD_SYMBOL_PATHS` constant (macOS app bundle, `/usr/share/kicad/symbols`, `~/.local/share/kicad/symbols`) that never read `KICAD_SYMBOL_DIR` — and a constant evaluated at import time never could. The CLI and `schematic/library.py` used this one.
- `schematic/registry.py:_default_symbol_paths()` honored the env var, but the CLI did not use it.

On NixOS none of the hardcoded paths exist, so the scan returned 0 libraries.

## Fix (unification design)

- **Single source of truth**: new `get_symbol_search_paths()` in `schematic/grid.py`, reading `KICAD_SYMBOL_DIR` **at call time** with priority order mirroring the footprint resolver `detect_kicad_library_path()`: env var first, then platform defaults (adds `/usr/local/share/kicad/symbols`, previously only in registry). Returns existing directories only; a non-existent env path silently falls through, matching the footprint side.
- `registry._default_symbol_paths()` is now a thin delegation to the shared resolver (kept because tests import it; no second implementation remains).
- `KICAD_SYMBOL_PATHS` constant **deleted** — nothing in `src/`, `tests/`, or `docs/` imports it after this change, per repo convention of no backwards-compat shims.

## Call sites updated

- `cli/lib.py` — `lib list --symbols` and `_find_symbol_library` (`symbol-info`)
- `schematic/library.py` — `list_libraries`, `list_symbols`, `search_symbols`
- `schematic/models/symbol.py` — `SymbolDef._parse_library_sexp`
- Docstring references in `models/schematic.py`, `models/elements_mixin.py`; `tests/test_cli_lib.py` helper

## Tests

New `tests/test_symbol_search_paths.py` (10 tests): env dir of flat `.kicad_sym` files is found and searched first (the reporter's layout); env var read at call time, not import time; unset env var leaves platform behavior unchanged; non-existent env dir filtered; registry delegation; CLI `lib list --symbols` (table + JSON) and `symbol-info` lookup honor the env var.

- `tests/test_symbol_search_paths.py tests/test_cli_lib.py tests/test_schematic_registry.py`: 68 passed (includes the existing `_default_symbol_paths` env-var coverage)
- `tests/test_schematic_library.py test_schematic.py test_schematic_models.py test_schematic_editing.py test_library_extends.py test_schematic_helpers.py`: 336 passed
- `ruff check` clean on all changed files; `ruff format` clean except `models/symbol.py` whose drift pre-exists on main (repo-wide lint rot tracked in #3464; the pre-existing SIM110 in `elements_mixin.py` is also part of that backlog — only a docstring was touched there)

## Manual verification (reporter's exact commands)

```
$ KICAD_SYMBOL_DIR=/tmp/issue3606_syms uv run kicad-tools lib list --symbols
Symbol Libraries (224):   # 222 system + 2 temp libs, temp libs listed
$ uv run kicad-tools lib list --symbols
Symbol Libraries (222):   # unchanged without env var
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)