### PR TITLE
fix(report): deterministic protocol detection + exclude diff-pair/high-speed nets from UART rows

### DIFF
--- a/src/kicad_tools/report/collector.py
+++ b/src/kicad_tools/report/collector.py
@@ -890,6 +890,33 @@ class ReportDataCollector:
         "USB": ["D+", "D-", "VBUS", "USB_D"],
     }
 
+    # Protocols whose signals are single-ended.  Differential-pair nets
+    # (polarity-suffixed ``...+``/``...-`` or ``..._P``/``..._N``) and nets
+    # belonging to known high-speed serial interfaces must never be claimed
+    # by these protocols (e.g. ``PCIE_RX+`` is not a UART RX line).
+    _SINGLE_ENDED_PROTOCOLS: frozenset[str] = frozenset({"I2C", "SPI", "I2S", "UART"})
+
+    # Net-name prefixes for high-speed serial interfaces that use TX/RX
+    # (and similar) signal names but are not single-ended protocols.
+    _HIGH_SPEED_PREFIXES: tuple[str, ...] = ("PCIE_", "USB3_", "LVDS_", "MIPI_")
+
+    @classmethod
+    def _is_high_speed_or_differential(cls, label_text: str) -> bool:
+        """Return True for differential-pair or high-speed serial net names.
+
+        Such nets (``PCIE_RX+``, ``USB3_TX2-``, ``LVDS_D0_P`` ...) must be
+        excluded from single-ended protocol detection (UART/SPI/I2C/I2S).
+        ``label_text`` is expected to be upper-cased.
+        """
+        if label_text.startswith(cls._HIGH_SPEED_PREFIXES):
+            return True
+        # Polarity suffix conventions for differential pairs.
+        if label_text.endswith(("+", "-")):
+            return True
+        if label_text.endswith(("_P", "_N")) and len(label_text) > 2:
+            return True
+        return False
+
     def _detect_interfaces(
         self, sch: Any, sch_path: Path
     ) -> list[dict[str, Any]] | None:
@@ -931,14 +958,27 @@ class ReportDataCollector:
                     exc_info=True,
                 )
 
+        # Sort labels so pattern matching (first match wins) is
+        # deterministic across runs: ``all_labels`` is a set, and iterating
+        # it directly is hash-order (PYTHONHASHSEED) dependent, which
+        # caused identical inputs to produce different report rows.
+        sorted_labels = sorted(all_labels)
+
         detected: list[dict[str, Any]] = []
         for protocol, patterns in self._INTERFACE_PATTERNS.items():
+            single_ended = protocol in self._SINGLE_ENDED_PROTOCOLS
             matched = []
             for pattern in patterns:
-                for label_text in all_labels:
-                    if pattern in label_text:
-                        matched.append(label_text)
-                        break  # one match per pattern is enough
+                for label_text in sorted_labels:
+                    if pattern not in label_text:
+                        continue
+                    # Differential-pair / high-speed nets (PCIE_RX+,
+                    # USB3_TX2+, ...) must not satisfy single-ended
+                    # protocol patterns such as UART TX/RX.
+                    if single_ended and self._is_high_speed_or_differential(label_text):
+                        continue
+                    matched.append(label_text)
+                    break  # one match per pattern is enough
             if len(matched) >= 2:
                 detected.append(
                     {"protocol": protocol, "signals": sorted(set(matched))}

--- a/tests/test_report_collector.py
+++ b/tests/test_report_collector.py
@@ -1341,6 +1341,83 @@ class TestCollectNarrative:
 
         assert interfaces is None
 
+    def test_interface_detection_deterministic(self, tmp_path):
+        """Repeated detection over identical labels yields identical rows.
+
+        Regression test for issue #3574: set iteration order made the
+        first-match-per-pattern choice hash-order dependent, so identical
+        inputs produced different report rows across runs.
+        """
+        collector = ReportDataCollector(tmp_path / "dummy.kicad_pcb")
+
+        # Ambiguous names from the board-06 report plus genuine UART nets,
+        # in several insertion orders to perturb set layout.
+        names = [
+            "PCIE_RX+",
+            "PCIE_RX-",
+            "PCIE_TX+",
+            "PCIE_TX-",
+            "USB3_TX2+",
+            "USB3_TX2-",
+            "UART_TX",
+            "UART_RX",
+            "DEBUG_TXD",
+            "DEBUG_RXD",
+        ]
+        results = []
+        for ordering in (names, list(reversed(names)), sorted(names)):
+            mock_sch = _make_mock_schematic_with_labels(ordering)
+            results.append(
+                collector._detect_interfaces(mock_sch, tmp_path / "test.kicad_sch")
+            )
+        # Also re-run on the same ordering.
+        mock_sch = _make_mock_schematic_with_labels(names)
+        results.append(
+            collector._detect_interfaces(mock_sch, tmp_path / "test.kicad_sch")
+        )
+
+        assert all(r == results[0] for r in results[1:])
+
+    def test_interface_detection_uart_excludes_high_speed_diff_pairs(self, tmp_path):
+        """PCIE/USB3 differential nets never satisfy UART TX/RX patterns."""
+        collector = ReportDataCollector(tmp_path / "dummy.kicad_pcb")
+
+        mock_sch = _make_mock_schematic_with_labels(
+            ["PCIE_RX+", "PCIE_RX-", "PCIE_TX+", "PCIE_TX-", "USB3_TX2+", "USB3_TX2-"]
+        )
+        interfaces = collector._detect_interfaces(mock_sch, tmp_path / "test.kicad_sch")
+
+        if interfaces is not None:
+            protocols = [i["protocol"] for i in interfaces]
+            assert "UART" not in protocols
+
+    def test_interface_detection_uart_still_detected_alongside_high_speed(self, tmp_path):
+        """Genuine UART nets are detected; UART row contains only them."""
+        collector = ReportDataCollector(tmp_path / "dummy.kicad_pcb")
+
+        mock_sch = _make_mock_schematic_with_labels(
+            ["PCIE_RX+", "PCIE_RX-", "USB3_TX2+", "USB3_TX2-", "UART_TX", "UART_RX"]
+        )
+        interfaces = collector._detect_interfaces(mock_sch, tmp_path / "test.kicad_sch")
+
+        assert interfaces is not None
+        uart_rows = [i for i in interfaces if i["protocol"] == "UART"]
+        assert len(uart_rows) == 1
+        assert uart_rows[0]["signals"] == ["UART_RX", "UART_TX"]
+
+    def test_interface_detection_excludes_p_n_suffix_diff_pairs(self, tmp_path):
+        """_P/_N polarity-suffixed nets are excluded from single-ended rows."""
+        collector = ReportDataCollector(tmp_path / "dummy.kicad_pcb")
+
+        mock_sch = _make_mock_schematic_with_labels(
+            ["ETH_TX_P", "ETH_TX_N", "ETH_RX_P", "ETH_RX_N"]
+        )
+        interfaces = collector._detect_interfaces(mock_sch, tmp_path / "test.kicad_sch")
+
+        if interfaces is not None:
+            protocols = [i["protocol"] for i in interfaces]
+            assert "UART" not in protocols
+
     def test_power_architecture_finds_rails(self, tmp_path):
         """Power architecture detects power symbols."""
         collector = ReportDataCollector(tmp_path / "dummy.kicad_pcb")


### PR DESCRIPTION
Closes #3574

## Root cause

Two defects in `ReportDataCollector._detect_interfaces` (`src/kicad_tools/report/collector.py`):

1. **Nondeterminism**: labels were collected into a `set[str]` and the matcher iterated it directly (`for label_text in all_labels: ... break` on first match). Set iteration order is hash-order (PYTHONHASHSEED) dependent, so which label "won" each TX/RX pattern varied per process — board 06's UART row flipped between (PCIE_RX+, PCIE_TX-) and (PCIE_RX-, USB3_TX2+) on identical input.
2. **Misclassification**: UART patterns are bare substrings `"TX"`/`"RX"`, so `PCIE_RX+`, `PCIE_TX-`, and `USB3_TX2+` all satisfied them.

## Fix

- Iterate `sorted(all_labels)` so first-match-per-pattern is deterministic; emitted rows are now byte-identical across regens (verified across PYTHONHASHSEED 0/1/42/31337/99999).
- Exclude differential-pair nets (trailing `+`/`-` or `_P`/`_N`) and known high-speed prefixes (`PCIE_`, `USB3_`, `LVDS_`, `MIPI_`) from single-ended protocol rows (UART/SPI/I2C/I2S). USB's `D+`/`D-` patterns are unaffected. Genuine `UART_TX`/`UART_RX` (and `TXD`/`RXD`) names still detect.

## Tests

- `test_interface_detection_deterministic` — runs the classifier over the ambiguous fixture names in 4 insertion orders, asserts identical output.
- `test_interface_detection_uart_excludes_high_speed_diff_pairs` — PCIE/USB3 nets never produce a UART row.
- `test_interface_detection_uart_still_detected_alongside_high_speed` — UART row exists and contains exactly `[UART_RX, UART_TX]` when mixed with PCIE/USB3 nets.
- `test_interface_detection_excludes_p_n_suffix_diff_pairs` — `_P`/`_N` pairs excluded.

`uv run pytest tests/test_report_collector.py` — 64 passed (all pre-existing interface tests still green).

Pre-existing, untouched: 4 ruff findings (1x F841, 3x I001) and format drift in these two files exist on main; this PR introduces no new lint/format issues in its hunks.

## Note on committed bundles

Committed board bundles are intentionally **not** regenerated here (avoids bundle churn). The deterministic/corrected rows take effect on the next regen of each board.