### PR TITLE
fix(schema): pad-level (locked yes) no longer misread as footprint lock (#3602)

### DIFF
--- a/src/kicad_tools/drc/repair_clearance.py
+++ b/src/kicad_tools/drc/repair_clearance.py
@@ -1897,8 +1897,11 @@ class ClearanceRepairer:
             if fp_ref.upper() != ref_upper:
                 continue
 
-            # Get position
-            at_node = fp_node.find("at")
+            # Get position. Direct child only -- pads, properties and
+            # fp_texts carry their own (at) nodes, and a recursive
+            # find() would misread a descendant's position if the
+            # footprint-level (at) were absent (issue #3602).
+            at_node = fp_node.find_child("at")
             if not at_node:
                 continue
             at_atoms = at_node.get_atoms()
@@ -1916,7 +1919,8 @@ class ClearanceRepairer:
                     locked = True
                     break
             if not locked:
-                attr_node = fp_node.find("attr")
+                # Direct child only, matching the locked lookup above.
+                attr_node = fp_node.find_child("attr")
                 if attr_node:
                     for i in range(len(attr_node.children)):
                         token = attr_node.get_string(i)

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -600,8 +600,12 @@ class Footprint:
         if sexp_node is None:
             return
 
+        # Direct children only for the (at)/(layer) lookups below:
+        # properties, fp_texts and pads carry their own (at)/(layer)
+        # nodes, and a recursive find() would mutate a descendant's
+        # node if the footprint-level one were absent (issue #3602).
         if name == "position":
-            at_node = sexp_node.find("at")
+            at_node = sexp_node.find_child("at")
             if at_node is not None:
                 x, y = value  # type: ignore[unpacking-non-sequence]
                 # ``fp.position`` stores board-relative coordinates but the
@@ -612,7 +616,7 @@ class Footprint:
                 at_node.set_value(1, y + origin[1])
 
         elif name == "rotation":
-            at_node = sexp_node.find("at")
+            at_node = sexp_node.find_child("at")
             if at_node is not None:
                 if len(at_node.children) >= 3:
                     at_node.set_value(2, value)
@@ -620,7 +624,7 @@ class Footprint:
                     at_node.add(value)
 
         elif name == "layer":
-            layer_node = sexp_node.find("layer")
+            layer_node = sexp_node.find_child("layer")
             if layer_node is not None:
                 layer_node.set_value(0, value)
 
@@ -734,12 +738,20 @@ class Footprint:
             graphics=[],
         )
 
+        # NOTE: all footprint-level scalar tokens below use
+        # find_child() (direct children only), NOT the recursive
+        # find(). Descendants legitimately carry same-named tokens --
+        # pads have (at)/(uuid)/(locked), properties and fp_texts have
+        # (at)/(layer)/(uuid) -- and a recursive lookup would misread
+        # a descendant's token as the footprint's own whenever the
+        # footprint-level token is absent (issue #3602).
+
         # Layer
-        if layer := sexp.find("layer"):
+        if layer := sexp.find_child("layer"):
             fp.layer = layer.get_string(0) or "F.Cu"
 
         # Position
-        if at := sexp.find("at"):
+        if at := sexp.find_child("at"):
             x = at.get_float(0) or 0.0
             y = at.get_float(1) or 0.0
             rot = at.get_float(2) or 0.0
@@ -747,13 +759,13 @@ class Footprint:
             fp.rotation = rot
 
         # UUID
-        if uuid := sexp.find("uuid"):
+        if uuid := sexp.find_child("uuid"):
             fp.uuid = uuid.get_string(0) or ""
 
         # Description and tags
-        if descr := sexp.find("descr"):
+        if descr := sexp.find_child("descr"):
             fp.description = descr.get_string(0) or ""
-        if tags := sexp.find("tags"):
+        if tags := sexp.find_child("tags"):
             fp.tags = tags.get_string(0) or ""
 
         # Modern lock form: a top-level ``(locked yes)`` child (KiCad 9/10).
@@ -764,11 +776,17 @@ class Footprint:
         # anchor logic (``getattr(fp, "locked", False)``, issue #2845)
         # would silently stop seeing those footprints as locked
         # (issue #3410).
-        if locked_node := sexp.find("locked"):
+        #
+        # Direct children only: PADS can carry their own ``(locked
+        # yes)``, and the recursive find() previously misread a
+        # pad-level lock as the footprint's, so unlocking a footprint
+        # with locked pads didn't persist across save/reload
+        # (issue #3602).
+        if locked_node := sexp.find_child("locked"):
             if (locked_node.get_string(0) or "yes") in ("yes", "true"):
                 fp.locked = True
 
-        if attr := sexp.find("attr"):
+        if attr := sexp.find_child("attr"):
             # The footprint *type* token (``smd`` / ``through_hole``)
             # is optional in KiCad's emitted form. When KiCad omits the
             # type, the first atom is a flag (e.g. ``(attr
@@ -1944,7 +1962,10 @@ class PCB:
             if child.tag != "footprint":
                 continue
 
-            uuid_node = child.find("uuid")
+            # Direct child only: pads/properties carry their own (uuid)
+            # nodes, and a recursive find() would match a descendant's
+            # uuid when the footprint-level one is absent (issue #3602).
+            uuid_node = child.find_child("uuid")
             child_uuid = uuid_node.get_string(0) if uuid_node else None
 
             fp_idx: int | None = None

--- a/tests/test_footprint_locked_form.py
+++ b/tests/test_footprint_locked_form.py
@@ -56,6 +56,17 @@ def _pcb_text(footprint_extra: str) -> str:
 """
 
 
+def _lock_both_pads(pcb_text: str) -> str:
+    """Add a pad-level ``(locked yes)`` to both pads of the test footprint."""
+    return pcb_text.replace(
+        '(pad "1" smd rect (at -1 0)',
+        '(pad "1" smd rect (locked yes) (at -1 0)',
+    ).replace(
+        '(pad "2" smd rect (at 1 0)',
+        '(pad "2" smd rect (locked yes) (at 1 0)',
+    )
+
+
 def _footprint_node(saved_text: str):
     """Return the (footprint ...) SExp node from saved board text."""
     doc = parse_string(saved_text)
@@ -203,3 +214,98 @@ class TestLegacyFormMigration:
         board.save(path)
 
         _assert_modern_locked_form(path.read_text())
+
+
+class TestPadLockedNotFootprintLocked:
+    """Pad-level (locked yes) must not be misread as the footprint lock.
+
+    ``Footprint.from_sexp`` previously used the RECURSIVE
+    ``sexp.find("locked")`` to read the footprint lock state, so a
+    pad-level ``(locked yes)`` marked an otherwise-unlocked footprint
+    as ``locked=True`` on load -- and unlocking a footprint with
+    locked pads did not persist across save/reload (issue #3602).
+    """
+
+    def test_locked_pads_do_not_lock_unlocked_footprint(self, tmp_path: Path) -> None:
+        """AC1: from_sexp reads only the footprint's direct (locked ...) child."""
+        path = tmp_path / "board.kicad_pcb"
+        path.write_text(_lock_both_pads(_pcb_text("    (attr smd)")))
+
+        fp = PCB.load(path).get_footprint("R1")
+        assert fp.locked is False, (
+            "Pad-level (locked yes) was misread as the footprint lock: "
+            "from_sexp must use a direct-children-only lookup (issue #3602)."
+        )
+
+    def test_locked_pads_plus_locked_footprint_still_parses_locked(self, tmp_path: Path) -> None:
+        """A genuine footprint-level lock still parses when pads are locked too."""
+        path = tmp_path / "board.kicad_pcb"
+        path.write_text(_lock_both_pads(_pcb_text("    (attr smd)\n    (locked yes)")))
+
+        assert PCB.load(path).get_footprint("R1").locked is True
+
+    def test_unlock_with_locked_pads_persists_across_reload(self, tmp_path: Path) -> None:
+        """AC2: unlocked footprint + locked pads survives save -> load -> save."""
+        path = tmp_path / "board.kicad_pcb"
+        path.write_text(_lock_both_pads(_pcb_text("    (attr smd)\n    (locked yes)")))
+
+        # Unlock the footprint (pads stay locked) and save.
+        board = PCB.load(path)
+        fp = board.get_footprint("R1")
+        assert fp.locked is True
+        fp.locked = False
+        board.save(path)
+
+        # Reload: the footprint must STILL be unlocked (the pad-level
+        # locked tokens must not re-lock it), and a second save must
+        # not resurrect the footprint-level (locked yes) node.
+        board2 = PCB.load(path)
+        fp2 = board2.get_footprint("R1")
+        assert fp2.locked is False, (
+            "Footprint unlock did not persist across save/reload: the "
+            "pad-level (locked yes) re-locked the footprint on load "
+            "(issue #3602)."
+        )
+        board2.save(path)
+
+        saved = path.read_text()
+        fp_node = _footprint_node(saved)
+        assert not fp_node.find_children("locked"), (
+            "Second save resurrected the footprint-level (locked yes) node"
+        )
+        # Pad-level locks must survive both round-trips.
+        pad_locked = [pad for pad in fp_node.find_children("pad") if pad.find_children("locked")]
+        assert len(pad_locked) == 2, "Pad-level (locked yes) nodes were lost across the round-trip"
+        assert PCB.load(path).get_footprint("R1").locked is False
+
+    def test_pure_roundtrip_with_locked_pads_does_not_lock(self, tmp_path: Path) -> None:
+        """Load -> save with no modification must not invent a footprint lock."""
+        path = tmp_path / "board.kicad_pcb"
+        path.write_text(_lock_both_pads(_pcb_text("    (attr smd)")))
+
+        board = PCB.load(path)
+        board.save(path)
+
+        saved = path.read_text()
+        fp_node = _footprint_node(saved)
+        assert not fp_node.find_children("locked"), (
+            "Pure load -> save added a spurious footprint-level (locked yes)"
+        )
+        assert PCB.load(path).get_footprint("R1").locked is False
+
+    def test_descendant_uuid_not_misread_as_footprint_uuid(self, tmp_path: Path) -> None:
+        """Same-class audit: a pad's (uuid ...) must not become the footprint uuid."""
+        path = tmp_path / "board.kicad_pcb"
+        # Strip the footprint-level uuid and give a pad its own uuid.
+        text = _pcb_text("    (attr smd)").replace('    (uuid "fp-r1")\n', "")
+        text = text.replace(
+            '(pad "1" smd rect (at -1 0)',
+            '(pad "1" smd rect (at -1 0) (uuid "pad-uuid-1")',
+        )
+        path.write_text(text)
+
+        fp = PCB.load(path).get_footprint("R1")
+        assert fp.uuid == "", (
+            "Footprint without a direct (uuid ...) child inherited a "
+            "descendant's uuid via recursive find() (issue #3602)."
+        )


### PR DESCRIPTION
Closes #3602

## Summary
- `Footprint.from_sexp` used the RECURSIVE `sexp.find("locked")` to read the footprint lock state, so a pad-level `(locked yes)` marked an otherwise-unlocked footprint as `locked=True` on load — footprint unlocks didn't persist across save/reload when pads were locked. Now uses `find_child()` (direct children only), mirroring the discipline PR #3600 established in `_sync_attr_node`.
- Same-class audit of the surrounding parse block: ALL footprint-level scalar token reads in `from_sexp` (`layer`, `at`, `uuid`, `descr`, `tags`, `attr`) had the same recursive-find exposure (pads/properties/fp_texts legitimately carry their own `at`/`layer`/`uuid`); all switched to `find_child()`.
- Same-class fixes outside the parse block:
  - `Footprint.__setattr__` sync path: `find("at")` (x2) and `find("layer")` would mutate a descendant's node if the footprint-level one were absent.
  - `PCB._link_footprint_sexp_nodes`: `child.find("uuid")` could match a pad/property uuid.
  - `drc/repair_clearance.py` `_find_footprint_info`: `find("at")` and `find("attr")` (the `locked` lookup there was already fixed by #3600).
- Not changed (audited, not same-class): `find_all("fp_text"/"property"/"pad"/"fp_*")` in `from_sexp` — those node types cannot nest inside each other in valid KiCad files. `Pad.from_sexp`'s recursive finds are safe: custom-pad `(primitives ...)` children carry none of the read tokens.

## Tests (AC)
- AC1: `test_locked_pads_do_not_lock_unlocked_footprint` — locked pads + unlocked footprint parses `locked=False`; plus `test_locked_pads_plus_locked_footprint_still_parses_locked` confirming a genuine footprint lock still parses.
- AC2: `test_unlock_with_locked_pads_persists_across_reload` — unlock survives save→load→save with no spurious re-lock and pad locks intact; `test_pure_roundtrip_with_locked_pads_does_not_lock`.
- Audit regression: `test_descendant_uuid_not_misread_as_footprint_uuid`.
- AC3: all 8 pre-existing tests in `tests/test_footprint_locked_form.py` pass (13 total now).

## Test results
- `tests/test_footprint_locked_form.py`: 13 passed
- Schema PCB batch (`test_schema.py`, `test_pcb_attr_roundtrip.py`, `test_pcb_lock_footprints.py`, `test_sexp_parser.py`, `test_sexp_roundtrip.py`, `test_pcb_move_footprint.py`): 296 passed, 5 skipped
- `tests/test_kicad_cli_roundtrip.py` (real kicad-cli): 22 passed
- `tests/test_repair_clearance.py` + `tests/test_drc_nudge_pad_clearance.py`: 99 passed

## Pre-existing failures (not introduced here)
- `ruff check` F841 at `repair_clearance.py:975` (unused `required_clearance`) — present on main.
- `ruff format --check` would reformat unrelated regions of `repair_clearance.py` (lines ~131, ~225) — present on main. My hunks are format-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)