### PR TITLE
fix(drc): repair invalid fill rings with make_valid, not buffer(0)

### DIFF
--- a/src/kicad_tools/validate/rules/clearance.py
+++ b/src/kicad_tools/validate/rules/clearance.py
@@ -787,6 +787,45 @@ class _ZoneFill:
     polygon: object  # shapely (Multi)Polygon
 
 
+def _repair_fill_polygon(poly):  # type: ignore[no-untyped-def]
+    """Repair an invalid fill ring, preserving every copper lobe.
+
+    Stale fills can carry self-touching outlines (KiCad traces knockout
+    holes through the exterior ring) or, in the worst case, genuinely
+    self-intersecting bowtie rings.  ``buffer(0)`` re-nodes the former
+    losslessly but silently *drops* the negatively-wound lobe of a
+    bowtie -- and dropped copper is exactly the copper this rule exists
+    to check, so a real short under that lobe would be masked (Issue
+    #3560).  ``shapely.make_valid`` instead keeps all lobes as a
+    MultiPolygon.
+
+    ``make_valid`` may return a GeometryCollection when part of the
+    outline collapses to zero-area linework; only the polygonal
+    components are copper, so extract those (an empty Polygon is
+    returned if nothing polygonal survives, which callers skip via
+    ``is_empty``).
+    """
+    from shapely import make_valid
+    from shapely.geometry import GeometryCollection, MultiPolygon, Polygon
+
+    repaired = make_valid(poly)
+    if isinstance(repaired, (Polygon, MultiPolygon)):
+        return repaired
+    polys: list[Polygon] = []
+    if isinstance(repaired, GeometryCollection):
+        for geom in repaired.geoms:
+            if isinstance(geom, Polygon):
+                polys.append(geom)
+            elif isinstance(geom, MultiPolygon):
+                polys.extend(geom.geoms)
+    # Pure linework / points (fully degenerate outline) -> no copper.
+    if not polys:
+        return Polygon()
+    if len(polys) == 1:
+        return polys[0]
+    return MultiPolygon(polys)
+
+
 class SegmentZoneClearanceRule(DRCRule):
     """Check track segments against foreign-net zone fill copper.
 
@@ -903,10 +942,9 @@ class SegmentZoneClearanceRule(DRCRule):
                     continue
                 poly = Polygon(points)
                 if not poly.is_valid:
-                    # Stale fills can carry self-touching outlines
-                    # (KiCad traces knockout holes through the exterior
-                    # ring).  buffer(0) re-nodes to equivalent copper.
-                    poly = poly.buffer(0)
+                    # make_valid keeps every copper lobe (buffer(0)
+                    # drops bowtie lobes -- see _repair_fill_polygon).
+                    poly = _repair_fill_polygon(poly)
                 if poly.is_empty:
                     continue
                 layer = zone.filled_polygon_layer(i)

--- a/tests/test_validate_segment_zone_clearance.py
+++ b/tests/test_validate_segment_zone_clearance.py
@@ -277,6 +277,97 @@ class TestLayers:
 
 
 # ---------------------------------------------------------------------------
+# Invalid fill repair: make_valid must keep every lobe (Issue #3560)
+# ---------------------------------------------------------------------------
+
+# Bowtie ring: two 5x5-mm triangular lobes meeting at (105, 105).  The
+# lower lobe spans y 100..105, the upper lobe y 105..110.  buffer(0)
+# silently drops the negatively-wound lower lobe (keeps only y>=105);
+# make_valid keeps both as a MultiPolygon.
+_BOWTIE_FILL = [(100.0, 100.0), (110.0, 100.0), (100.0, 110.0), (110.0, 110.0)]
+
+
+class TestInvalidFillRepair:
+    def test_bowtie_fixture_buffer0_actually_loses_copper(self):
+        """Sanity-check the fixture exhibits the hazard being hardened.
+
+        If shapely ever changes buffer(0) to be loss-free for bowties,
+        this documents that the other tests in this class no longer
+        discriminate (they would still pass).
+        """
+        from shapely import make_valid
+        from shapely.geometry import Polygon
+
+        bowtie = Polygon(_BOWTIE_FILL)
+        assert not bowtie.is_valid
+        assert make_valid(bowtie).area > bowtie.buffer(0).area
+
+    def test_repair_helper_preserves_all_lobes(self):
+        from shapely.geometry import Polygon
+
+        from kicad_tools.validate.rules.clearance import _repair_fill_polygon
+
+        repaired = _repair_fill_polygon(Polygon(_BOWTIE_FILL))
+        assert repaired.is_valid
+        # Both 12.5 mm^2 lobes survive (buffer(0) keeps only 25.0).
+        assert abs(repaired.area - 50.0) < 1e-9
+        # Full original extent retained, including the dropped lobe's y range.
+        assert repaired.bounds == (100.0, 100.0, 110.0, 110.0)
+
+    def test_repair_helper_extracts_polygons_from_geometrycollection(self):
+        """Zero-area spikes make make_valid return a GeometryCollection."""
+        from shapely.geometry import Polygon
+
+        from kicad_tools.validate.rules.clearance import _repair_fill_polygon
+
+        spike = Polygon([(0, 0), (2, 0), (2, 2), (4, 2), (2, 2), (0, 2)])
+        repaired = _repair_fill_polygon(spike)
+        assert repaired.is_valid
+        assert repaired.geom_type in ("Polygon", "MultiPolygon")
+        assert abs(repaired.area - 4.0) < 1e-9
+
+    def test_repair_helper_fully_degenerate_outline_is_empty(self):
+        """A ring that collapses entirely to linework yields no copper."""
+        from shapely.geometry import Polygon
+
+        from kicad_tools.validate.rules.clearance import _repair_fill_polygon
+
+        line_only = Polygon([(0, 0), (2, 0), (0, 0)])
+        repaired = _repair_fill_polygon(line_only)
+        assert repaired.is_empty
+
+    def test_trace_under_dropped_bowtie_lobe_is_flagged(self):
+        """The hardening payoff: a short under the lobe buffer(0) drops.
+
+        buffer(0) keeps only the upper lobe (y >= 105) of the bowtie,
+        so pre-#3560 a trace crossing the *lower* lobe sailed through.
+        make_valid retains it and the short is reported.
+        """
+        zone = _FakeZone(filled_polygons=[_BOWTIE_FILL])
+        # Horizontal trace through the lower lobe at y=102: the lower
+        # triangle (apexes (100,100), (110,100), (105,105)) spans
+        # x 102..108 there, so the centerline runs straight through it.
+        seg = _FakeSegment(start=(95.0, 102.0), end=(115.0, 102.0))
+        results = _run([zone], [seg])
+
+        assert len(results.violations) == 1
+        v = results.violations[0]
+        assert "Short" in v.message
+        assert v.actual_value < 0
+        assert v.nets == ("SIG", "+3V3")
+
+    def test_traces_under_both_bowtie_lobes_both_flagged(self):
+        """One trace per lobe -> two shorts (buffer(0) would report one)."""
+        zone = _FakeZone(filled_polygons=[_BOWTIE_FILL])
+        lower = _FakeSegment(start=(95.0, 102.0), end=(115.0, 102.0), uuid="aaaa0000-0000")
+        upper = _FakeSegment(start=(95.0, 108.0), end=(115.0, 108.0), uuid="bbbb0000-0000")
+        results = _run([zone], [lower, upper])
+
+        shorts = [v for v in results.violations if "Short" in v.message]
+        assert len(shorts) == 2
+
+
+# ---------------------------------------------------------------------------
 # Zone schema: per-fill layer parsing (Issue #3527 schema change)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #3560

## Summary

`SegmentZoneClearanceRule._collect_fills` repaired invalid fill rings with `poly.buffer(0)`, which silently drops the negatively-wound lobe of a bowtie/self-intersecting ring — shrinking the copper the rule checks and masking any short under the dropped lobe. This replaces it with `shapely.make_valid` via a new `_repair_fill_polygon` helper that preserves every lobe.

## make_valid handling

- `pyproject.toml` floors shapely at `>=2.0`, so the top-level `shapely.make_valid` import is guaranteed (no `shapely.validation` fallback needed).
- Output types handled:
  - `Polygon` / `MultiPolygon` -> returned as-is (the common cases; bowties come back as MultiPolygon with all lobes).
  - `GeometryCollection` (occurs when part of the outline collapses to zero-area linework) -> polygonal components extracted, nested MultiPolygons flattened; linework/points discarded (zero-area = no copper).
  - Nothing polygonal survives -> empty `Polygon`, which the existing `is_empty` skip in `_collect_fills` handles.

Verified on shapely 2.1.2: bowtie fixture gives area 25.0 via `buffer(0)` (lower lobe dropped) vs 50.0 via `make_valid` (both lobes kept).

## Other buffer(0) repair sites

Full grep of `src/` and `tests/`: the only other site is `src/kicad_tools/pcb/board_geometry.py:321` (`BoardGeometry.from_outline_points`). That repairs the **board outline**, not copper fills, and `BoardGeometry` is single-Polygon by design (its other constructor path already keeps only the largest polygon) — switching it to `make_valid` could return a MultiPolygon and change class semantics, so it is left as a follow-up rather than a same-class fix. No repair idioms exist anywhere else in `validate/` or `analysis/`; other `filled_polygon` consumers there do not construct shapely polygons with validity repair.

## Tests

New `TestInvalidFillRepair` class in `tests/test_validate_segment_zone_clearance.py`:
- Fixture sanity: `make_valid(bowtie).area > bowtie.buffer(0).area` (proves the fixture exhibits the hazard).
- Helper preserves all lobes (area 50.0, full original bounds).
- GeometryCollection extraction (zero-area spike outline).
- Fully degenerate outline -> empty (no copper, no crash).
- **Payoff test**: a trace under the lobe `buffer(0)` drops IS flagged as a short post-fix.
- Two traces, one per lobe -> two shorts (`buffer(0)` would report one).

## Test results

- `tests/test_validate_segment_zone_clearance.py`: 21 passed (15 existing + 6 new)
- `tests/test_drc_regression.py` + `tests/test_board_01_ship_ready.py` + `tests/test_board_05_drc_allowlist.py` + `tests/test_board_06_diffpair_test.py`: 50 passed — fleet committed-artifact DRC verdicts/counts unchanged (expected: the issue measured 0.000000 mm² worst-case area delta across all 42 invalid fills in committed artifacts)
- `tests/test_audit.py`: passed
- `tests/router/test_board03_routing_baseline.py`: 5 passed serially (`-p no:randomly`). An initial interleaved run with `test_audit.py` under pytest-randomly reproduced the known order-dependence flake from #3450 (reach floor / per-net USB); passes cleanly in the suite's documented serial configuration and is unrelated to this DRC-only change.
- `ruff check` + `ruff format`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)