### PR TITLE
fix(ci): board 06 pour-connectivity — kicad-cli container + asserted pour audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,6 +431,30 @@ jobs:
     # the merge button.
     name: Diff-Pair Routing Regression
     runs-on: ubuntu-latest
+    # Issue #3509: run inside the official KiCad 10 container (same image
+    # as the test + kicad-cli-smoke jobs).  The board 06 recipe's pour
+    # pipeline (zone fill -> stitch -> pour-connectivity repair -> re-fill
+    # -> copper-union audit) shells out to ``kct zones fill``, which is
+    # backed by kicad-cli.  On the bare ubuntu-latest runner kicad-cli
+    # does not exist, so EVERY fill invocation failed with rc=1
+    # ("kicad-cli not found"), all 5 pour zones stayed zero-fill, and the
+    # repair loop was left trying to do a copper plane's job with discrete
+    # vias/bridges -- the non-converging "FAIL while the gate is green"
+    # trap from PR #3506's run 27343006197.  The container provides
+    # kicad-cli 10 so the fills actually run, matching the local artifact-
+    # refresh environment.  The gate also asserts the pour audit verdict
+    # now (see scripts/ci/check_diffpair_coverage.py + the board recipe's
+    # REQUIRE_POUR_CONNECTIVITY contract), so a future fill regression
+    # fails the job instead of rotting in the log.
+    container:
+      image: kicad/kicad:10.0
+      # Run as root so installs write system locations and actions/checkout
+      # can write $GITHUB_WORKSPACE (mirrors the test + smoke jobs).
+      options: --user 0:0
+    defaults:
+      run:
+        # The image's /bin/sh is dash; force bash (mirrors the test job).
+        shell: bash
     # Issue #2660 acceptance criterion #5: wall-clock <= 5 min on
     # ubuntu-latest.  Originally a 10-minute safety-net ceiling, bumped
     # to 15 minutes per PR #3141 Judge feedback (2026-05-27):
@@ -479,6 +503,14 @@ jobs:
     # budgeted (per-pair 60s, negotiated 360s, repair loop capped at 3
     # rounds), so 30 min gives ~20-30% headroom over the worst expected
     # wall without masking a genuine hang.
+    #
+    # Issue #3509 re-measure note: moving into the kicad/kicad:10.0
+    # container adds ~1-2 min (image pull + apt prerequisites) but the
+    # zone fills now succeed, so the pour-repair loop converges instead
+    # of grinding its full round budget against unfillable zero-fill
+    # zones (the pre-#3509 runs burned ~2.2 min on 3 futile rounds).
+    # Prior green run wall: 20m42s (run 27343006197); ceiling kept at
+    # 30 min.
     timeout-minutes: 30
     # Board 06 (diffpair-test) status (M-F closure, Issue #3097):
     #
@@ -530,18 +562,34 @@ jobs:
         # Future: add boards/03-usb-joystick here once #2589 stabilises
         # its router determinism and #2513 (USB-C blockers) clears.
     steps:
+      - name: Ensure container has prerequisites
+        # ca-certificates/curl/git for checkout + uv bootstrap; cmake and
+        # build-essential for the C++ router backend build below.  The
+        # ``kicad-cli --version`` probe makes a missing/broken kicad-cli
+        # fail THIS step with an attributable error instead of surfacing
+        # later as zero-fill pour zones (Issue #3509).
+        run: |
+          set -euo pipefail
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates curl git cmake build-essential
+          kicad-cli --version
+
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v4
-        with:
-          version: "latest"
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
+      - name: Install uv
+        # Official one-liner instead of setup-uv@v4: avoids action-host
+        # coupling inside the container (mirrors the test + smoke jobs).
+        run: |
+          set -euo pipefail
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        # Pin the interpreter via uv (parity with the sibling jobs that use
+        # actions/setup-python with python-version: "3.12"); the container
+        # image's own Python version is irrelevant.
+        run: uv sync --extra dev --python 3.12
 
       - name: Build C++ router backend
         # `uv sync` does NOT build the native extension (see repo CLAUDE.md

--- a/boards/06-diffpair-test/generate_design.py
+++ b/boards/06-diffpair-test/generate_design.py
@@ -65,6 +65,25 @@ warn_if_stale()
 POUR_NETS: list[str] = ["GND", "VBUS_USB", "+3V3", "+1V8", "+1V2"]
 REQUIRED_SIGNAL_REACH: int = 21
 
+# Issue #3509: pour-connectivity contract.  When True, the CI gate runs
+# this recipe's shapely copper-union audit (``_audit_pour_nets``) against
+# the re-routed artifact and FAILS the job if any pour net is disjoint or
+# any fill-enabled zone has zero filled polygons.  Before this contract
+# the recipe printed "POUR CONNECTIVITY: FAIL" in the CI log while the
+# gate stayed green (PR #3506 run 27343006197) -- a latent artifact-
+# refresh trap.  A board that cannot yet pass must set this to False
+# WITH a tracking-issue comment (the explicit exit clause; mirrors the
+# .github/routed-drc-tolerance.yml grandfathering convention) -- the
+# verdict must never be silently ignored.
+REQUIRE_POUR_CONNECTIVITY: bool = True
+
+# Issue #3509: pour repair <-> re-fill iteration budget.  Was hardcoded
+# at 3, which the CI re-route's convergence trend (GND 79 -> 45 -> 12
+# disjoint groups across rounds) showed is too low when the routed
+# copper differs from the local artifact.  The loop breaks early on
+# audit PASS, so a higher cap only costs wall time in failure scenarios.
+MAX_POUR_REPAIR_ROUNDS: int = 6
+
 
 # =============================================================================
 # Per-Protocol Net Class Declarations
@@ -1852,7 +1871,8 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
         str(output_path),
     ]
     fill_result = subprocess.run(fill_argv, capture_output=True, text=True)
-    if fill_result.returncode == 0:
+    first_fill_ok = fill_result.returncode == 0
+    if first_fill_ok:
         for line in fill_result.stdout.strip().split("\n")[-4:]:
             print(f"   {line}")
     else:
@@ -1924,12 +1944,16 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
     # positive) and places offset vias + F.Cu stubs + island bridges that
     # stay legal at the jlcpcb standard tier (no via-in-pad).
     #
-    # Repair and re-fill ITERATE (max 3 rounds): each re-fill recomputes
-    # the pours with the new copper carved in, which can shift fill
-    # edges away from a previous round's bridge endpoint (measured: a
-    # +1V8 bridge connected against the round-1 fill, then the round-2
-    # fill quantised away from it).  The loop converges when the
-    # copper-union audit reports every pour net in one component.
+    # Repair and re-fill ITERATE (max ``MAX_POUR_REPAIR_ROUNDS``): each
+    # re-fill recomputes the pours with the new copper carved in, which
+    # can shift fill edges away from a previous round's bridge endpoint
+    # (measured: a +1V8 bridge connected against the round-1 fill, then
+    # the round-2 fill quantised away from it).  The loop converges when
+    # the copper-union audit reports every pour net in one component,
+    # and short-circuits when the zone filler is unavailable (Issue
+    # #3509: every fill failing with "kicad-cli not found" means no
+    # round can ever clear the zero-fill-zone audit term, so iterating
+    # just grinds repair geometry against an unfillable board).
     def _run_pour_audit(tag: str) -> bool:
         ok = True
         try:
@@ -1963,7 +1987,7 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
         return ok
 
     pour_ok = False
-    for repair_round in range(1, 4):
+    for repair_round in range(1, MAX_POUR_REPAIR_ROUNDS + 1):
         print(
             f"\n10b. Pour-connectivity repair round {repair_round} "
             f"(offset vias + stubs + island bridges)..."
@@ -1979,7 +2003,8 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
         # clearance around them (and so the exported copper is final).
         print(f"10c. Re-filling zones (round {repair_round})...")
         fill_result = subprocess.run(fill_argv, capture_output=True, text=True)
-        if fill_result.returncode != 0:
+        refill_ok = fill_result.returncode == 0
+        if not refill_ok:
             print(f"   Zone re-fill failed (rc={fill_result.returncode}):")
             if fill_result.stderr:
                 print(f"   stderr: {fill_result.stderr.strip()}")
@@ -1992,6 +2017,19 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
         print(f"11. Copper-union pour-connectivity audit (round {repair_round})...")
         pour_ok = _run_pour_audit(f"[r{repair_round}]")
         if pour_ok:
+            break
+        # Issue #3509: when the filler is structurally unavailable (the
+        # first pass AND this round's re-fill both failed -- e.g.
+        # kicad-cli missing from the environment), every pour zone stays
+        # zero-fill and no number of repair rounds can converge.  Stop
+        # iterating; the FAIL verdict below (and the CI gate's asserted
+        # pour audit) surfaces the environment defect attributably.
+        if not first_fill_ok and not refill_ok:
+            print(
+                "   Zone filler unavailable (every fill invocation failed) -- "
+                "aborting repair loop; pours CANNOT converge without fills "
+                "(Issue #3509)."
+            )
             break
     if not pour_ok:
         print("   POUR CONNECTIVITY: FAIL (see above)")

--- a/scripts/ci/check_diffpair_coverage.py
+++ b/scripts/ci/check_diffpair_coverage.py
@@ -14,6 +14,14 @@ asserting:
      a regression that disables diff-pair detection (e.g., flipping
      ``coupled_routing`` back to ``False``) would silently produce a
      0-error report and hide the defect.
+  3. (Issue #3413 phase 5) Signal-net reach meets the board's
+     ``REQUIRED_SIGNAL_REACH`` contract.
+  4. (Issue #3509) For boards declaring ``REQUIRE_POUR_CONNECTIVITY``,
+     the recipe's copper-union pour audit passes on the re-routed
+     artifact: every pour net is one copper component and no
+     fill-enabled zone has zero filled polygons.  Previously the recipe
+     printed "POUR CONNECTIVITY: FAIL" in the job log while the gate
+     stayed green.
 
 The three rule_ids this script asserts coverage of are:
 
@@ -250,6 +258,71 @@ def measure_signal_reach(
     complete = [n for n in signal if n.status == "complete"]
     incomplete_names = sorted(n.net_name for n in signal if n.status != "complete")
     return len(complete), len(signal), incomplete_names
+
+
+def measure_pour_connectivity(
+    recipe_mod, pcb_path: Path, pour_nets: set[str]
+) -> list[str]:
+    """Run the board recipe's copper-union pour audit on a routed PCB.
+
+    Issue #3509: the board 06 recipe runs a shapely copper-union audit
+    (``_audit_pour_nets``) at the end of its pour pipeline and prints
+    PASS/FAIL -- but until this helper the gate never consumed that
+    verdict, so a re-route whose pours failed the audit still went green
+    (PR #3506 run 27343006197: "POUR CONNECTIVITY: FAIL" in the log,
+    job passed).  Boards opt in by declaring
+    ``REQUIRE_POUR_CONNECTIVITY = True`` next to their ``POUR_NETS``
+    contract; the gate then re-runs the audit against the routed
+    artifact and fails the job on any disjoint pour net or zero-fill
+    zone.
+
+    Args:
+        recipe_mod: The board's imported ``generate_design`` module (must
+            expose ``_audit_pour_nets(pcb_path, net_names)``).
+        pcb_path: Routed PCB to audit.
+        pour_nets: The board's ``POUR_NETS`` set.
+
+    Returns:
+        List of human-readable failure strings; empty means every pour
+        net is one copper component with real fill geometry.
+
+    Raises:
+        RuntimeError: When the audit cannot run at all (missing
+            ``_audit_pour_nets``, shapely unavailable, audit crash).
+            Callers must treat this as a tool failure (exit 1), NOT a
+            pass -- a silent skip is how dead pours shipped in the
+            first place (PR #3481).
+    """
+    audit_fn = getattr(recipe_mod, "_audit_pour_nets", None)
+    if audit_fn is None:
+        raise RuntimeError(
+            "Board declares REQUIRE_POUR_CONNECTIVITY but its "
+            "generate_design module does not expose _audit_pour_nets()."
+        )
+    try:
+        audit = audit_fn(pcb_path, sorted(pour_nets))
+    except Exception as e:
+        raise RuntimeError(f"Pour-connectivity audit crashed: {e}") from e
+
+    failures: list[str] = []
+    for net in sorted(pour_nets):
+        info = audit.get(net)
+        if info is None:
+            failures.append(f"{net}: missing from audit result")
+            continue
+        n_pads = sum(len(g) for g in info["pad_groups"])
+        if not info["connected"]:
+            largest = len(info["pad_groups"][0]) if info["pad_groups"] else 0
+            failures.append(
+                f"{net}: {len(info['pad_groups'])} disjoint pad groups "
+                f"(largest {largest}/{n_pads})"
+            )
+        if info.get("zero_fill_zones"):
+            failures.append(
+                f"{net}: {info['zero_fill_zones']} fill-enabled zone(s) "
+                f"with ZERO filled polygons (dead pour)"
+            )
+    return failures
 
 
 def _measure_skew_data_from_pcb(
@@ -517,11 +590,16 @@ def check_board(
     # boards without it (none today in this gate's matrix) skip it.
     required_reach: int | None = None
     pour_nets: set[str] = set()
+    require_pour_connectivity = False
+    recipe_mod = None
     try:
         recipe_mod = load_board_recipe_module(board_dir)
         if recipe_mod is not None:
             required_reach = getattr(recipe_mod, "REQUIRED_SIGNAL_REACH", None)
             pour_nets = set(getattr(recipe_mod, "POUR_NETS", ()) or ())
+            require_pour_connectivity = bool(
+                getattr(recipe_mod, "REQUIRE_POUR_CONNECTIVITY", False)
+            )
     except Exception as e:
         annotate_error(
             str(board_dir),
@@ -594,6 +672,41 @@ def check_board(
             print(
                 f"[diffpair-coverage] OK: reach {complete}/{signal_total} "
                 f">= {required_reach}."
+            )
+
+    # Issue #3509: pour-connectivity assertion.  The board recipe's
+    # copper-union audit verdict was previously informational only --
+    # the recipe printed "POUR CONNECTIVITY: FAIL" while this gate stayed
+    # green.  Boards opting in via REQUIRE_POUR_CONNECTIVITY get the
+    # audit re-run here against the routed artifact; failures gate.
+    if require_pour_connectivity:
+        try:
+            pour_failures = measure_pour_connectivity(
+                recipe_mod, routed_pcb, pour_nets
+            )
+        except RuntimeError as e:
+            annotate_error(
+                str(routed_pcb),
+                f"Pour-connectivity audit could not run: {e}  (A skipped "
+                "audit must be a tool failure, never a silent pass.)",
+            )
+            return 1
+        if pour_failures:
+            annotate_error(
+                str(routed_pcb),
+                f"Pour-connectivity regression on re-routed {routed_pcb}: "
+                f"{'; '.join(pour_failures)}.  Every pour net must be ONE "
+                "copper component with non-empty zone fills (copper-union "
+                "audit, Issue #3509).  See the recipe's pour pipeline in "
+                f"{board_dir.name}/generate_design.py (steps 9-11); if the "
+                "fill log shows 'kicad-cli not found', the CI environment "
+                "lost its KiCad container.",
+            )
+            failed = True
+        else:
+            print(
+                f"[diffpair-coverage] OK: pour connectivity "
+                f"({len(pour_nets)} pour nets, copper-union audit)."
             )
 
     # AC #4: each of the three diff-pair rules must have been exercised.

--- a/tests/test_check_diffpair_coverage.py
+++ b/tests/test_check_diffpair_coverage.py
@@ -246,11 +246,23 @@ class TestWorkflowJob:
             f"Found: {sorted(workflow['jobs'].keys())}"
         )
 
-    def test_job_runs_on_ubuntu_no_container(self, workflow: dict) -> None:
-        """Pure-Python; don't pay container-pull cost."""
+    def test_job_runs_in_kicad_container(self, workflow: dict) -> None:
+        """Issue #3509: the board 06 recipe's pour pipeline shells out to
+        ``kct zones fill``, which is backed by kicad-cli.  On the bare
+        ubuntu-latest runner every fill failed ("kicad-cli not found"),
+        all pour zones stayed zero-fill, and the pour-repair loop could
+        not converge -- the FAIL-while-green trap from PR #3506.  The
+        job must run inside the official KiCad container (same image as
+        the test + kicad-cli-smoke jobs) so the fills actually run."""
         job = workflow["jobs"][JOB_NAME]
         assert job["runs-on"] == "ubuntu-latest"
-        assert "container" not in job
+        container = job.get("container")
+        assert isinstance(container, dict), (
+            "diffpair-routing-regression must run inside the kicad/kicad "
+            "container -- without kicad-cli the recipe's zone fills fail "
+            "and the pour audit can never pass (Issue #3509)."
+        )
+        assert str(container.get("image", "")).startswith("kicad/kicad:")
 
     def test_job_has_reasonable_timeout(self, workflow: dict) -> None:
         """Issue #2660 AC #5: <= 5 min on ubuntu-latest.  Timeout-minutes
@@ -305,18 +317,18 @@ class TestWorkflowJob:
                     "regressions."
                 )
 
-    def test_no_kicad_cli_dependency(self, workflow: dict) -> None:
-        """Like sibling job: pure Python.  No kicad-cli setup steps."""
+    def test_job_probes_kicad_cli_availability(self, workflow: dict) -> None:
+        """Issue #3509: a missing/broken kicad-cli must fail an early,
+        attributable setup step -- not surface 15 minutes later as
+        zero-fill pour zones.  The prerequisites step probes
+        ``kicad-cli --version``."""
         steps = workflow["jobs"][JOB_NAME]["steps"]
-        for s in steps:
-            if not isinstance(s, dict):
-                continue
-            uses = s.get("uses", "")
-            run = s.get("run", "")
-            assert "kicad" not in uses.lower(), (
-                f"Unexpected kicad-cli setup step: {s}"
-            )
-            assert "apt-get install" not in run or "kicad" not in run.lower()
+        run_blocks = [s.get("run", "") for s in steps if isinstance(s, dict) and "run" in s]
+        assert any("kicad-cli --version" in r for r in run_blocks), (
+            "Expected an early 'kicad-cli --version' probe in "
+            f"{JOB_NAME} so a missing filler backend fails setup "
+            "attributably (Issue #3509)."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -508,3 +520,127 @@ class TestMeasureSignalReach:
         assert mod is not None
         assert mod.REQUIRED_SIGNAL_REACH == 21
         assert set(mod.POUR_NETS) == {"GND", "VBUS_USB", "+3V3", "+1V8", "+1V2"}
+
+
+# ---------------------------------------------------------------------------
+# Issue #3509: pour-connectivity assertion
+# ---------------------------------------------------------------------------
+
+
+def _fake_recipe(audit_result=None, crash=False, omit_audit_fn=False):
+    """Build a stand-in recipe module for measure_pour_connectivity."""
+    import types
+
+    mod = types.SimpleNamespace()
+    if omit_audit_fn:
+        return mod
+
+    def _audit_pour_nets(pcb_path, net_names):
+        if crash:
+            raise ValueError("synthetic audit crash")
+        return audit_result
+
+    mod._audit_pour_nets = _audit_pour_nets
+    return mod
+
+
+def _net_ok(n_pads=4):
+    return {
+        "connected": True,
+        "pad_groups": [[(f"U1.{i}", False) for i in range(n_pads)]],
+        "zero_fill_zones": 0,
+    }
+
+
+class TestMeasurePourConnectivity:
+    """Unit tests for the Issue #3509 pour-connectivity gate term.
+
+    Before this helper the recipe printed "POUR CONNECTIVITY: FAIL" in
+    the CI log while the job stayed green (PR #3506 run 27343006197).
+    """
+
+    def test_all_connected_returns_empty(self, tmp_path):
+        mod = _load_helper_module()
+        recipe = _fake_recipe({"GND": _net_ok(), "+3V3": _net_ok()})
+        failures = mod.measure_pour_connectivity(
+            recipe, tmp_path / "x.kicad_pcb", {"GND", "+3V3"}
+        )
+        assert failures == []
+
+    def test_disjoint_net_reported(self, tmp_path):
+        mod = _load_helper_module()
+        audit = {
+            "GND": {
+                "connected": False,
+                "pad_groups": [
+                    [("U1.1", False), ("U1.2", False)],
+                    [("J1.5", False)],
+                ],
+                "zero_fill_zones": 0,
+            }
+        }
+        failures = mod.measure_pour_connectivity(
+            _fake_recipe(audit), tmp_path / "x.kicad_pcb", {"GND"}
+        )
+        assert len(failures) == 1
+        assert "GND" in failures[0]
+        assert "2 disjoint pad groups" in failures[0]
+        assert "largest 2/3" in failures[0]
+
+    def test_zero_fill_zone_reported(self, tmp_path):
+        """A zero-fill zone fails the audit even when the pads happen to
+        be connected by stitching copper -- a dead pour is the #3482
+        boundary-test illusion this audit exists to catch."""
+        mod = _load_helper_module()
+        audit = {"+1V8": {**_net_ok(), "zero_fill_zones": 1}}
+        failures = mod.measure_pour_connectivity(
+            _fake_recipe(audit), tmp_path / "x.kicad_pcb", {"+1V8"}
+        )
+        assert len(failures) == 1
+        assert "ZERO filled polygons" in failures[0]
+
+    def test_missing_net_in_audit_reported(self, tmp_path):
+        mod = _load_helper_module()
+        failures = mod.measure_pour_connectivity(
+            _fake_recipe({}), tmp_path / "x.kicad_pcb", {"GND"}
+        )
+        assert failures == ["GND: missing from audit result"]
+
+    def test_missing_audit_fn_raises(self, tmp_path):
+        """A recipe that declares the contract but lost its audit function
+        is a tool failure, never a silent pass (the PR #3481 lesson)."""
+        mod = _load_helper_module()
+        with pytest.raises(RuntimeError, match="_audit_pour_nets"):
+            mod.measure_pour_connectivity(
+                _fake_recipe(omit_audit_fn=True), tmp_path / "x.kicad_pcb", {"GND"}
+            )
+
+    def test_audit_crash_raises(self, tmp_path):
+        mod = _load_helper_module()
+        with pytest.raises(RuntimeError, match="crashed"):
+            mod.measure_pour_connectivity(
+                _fake_recipe(crash=True), tmp_path / "x.kicad_pcb", {"GND"}
+            )
+
+    def test_board_06_declares_pour_connectivity_contract(self):
+        """Board 06 must opt in -- the explicit gate, never silent."""
+        import sys as _sys
+        from pathlib import Path as _Path
+
+        repo_root = _Path(__file__).resolve().parent.parent
+        ci_dir = repo_root / "scripts" / "ci"
+        _sys.path.insert(0, str(ci_dir))
+        try:
+            from net_class_map_resolver import load_board_recipe_module
+        finally:
+            _sys.path.pop(0)
+
+        mod = load_board_recipe_module(repo_root / "boards" / "06-diffpair-test")
+        assert mod is not None
+        assert mod.REQUIRE_POUR_CONNECTIVITY is True
+        # The repair loop budget must exceed the historical 3-round cap
+        # that the CI convergence trend (GND 79 -> 45 -> 12 disjoint
+        # groups) showed was too low.
+        assert mod.MAX_POUR_REPAIR_ROUNDS >= 6
+        # The audit function the gate calls must exist.
+        assert callable(mod._audit_pour_nets)


### PR DESCRIPTION
Closes #3509

## Root cause

The `diffpair-routing-regression` job runs on a bare `ubuntu-latest` runner with **no KiCad installed**. The board 06 recipe's pour pipeline (zone fill -> stitch -> repair -> re-fill -> copper-union audit) shells out to `kct zones fill`, which is backed by `kicad-cli`. Ground truth from the green run 27343006197 (job 80784327578):

```
9b. Filling zones (first pass)...
   Zone fill failed (rc=1):
   stderr: Error: kicad-cli not found. Install KiCad 8 from https://www.kicad.org/download/
...same for every 10c re-fill, all 3 rounds...
```

Every fill failed, so **all 5 pour zones stayed zero-fill** and the repair loop was left trying to do a copper plane's job with discrete vias/bridges — that's why GND "converged" 79 -> 45 -> 12 disjoint groups but could never land: the `zero-fill zone(s)` audit term is unfixable without a filler. The round budget was never the primary defect; the environment was. And the gate (`check_diffpair_coverage.py`) never consumed the audit verdict, so the job stayed green while the recipe printed FAIL.

## Fixes

1. **Convergence (environment)**: the job now runs inside the `kicad/kicad:10.0` container (same image + setup pattern as the `test` and `kicad-cli-smoke` jobs), with an early `kicad-cli --version` probe so a lost filler backend fails setup attributably instead of surfacing 15 minutes later as zero-fill pours.
2. **Gate gap closed**: board 06 declares `REQUIRE_POUR_CONNECTIVITY = True` next to its `POUR_NETS` contract; the gate re-runs the recipe's shapely copper-union audit (`_audit_pour_nets`) against the re-routed artifact and fails the job (exit 2) on any disjoint pour net or dead zero-fill zone. An audit that cannot run at all (shapely missing, recipe lost the function) is a tool failure (exit 1) — never a silent pass. The exit clause is explicit: a board that cannot yet pass sets the flag to False with a tracking-issue comment (mirrors the `.github/routed-drc-tolerance.yml` grandfathering convention).
3. **Round budget insurance**: `MAX_POUR_REPAIR_ROUNDS` raised 3 -> 6 (loop still breaks early on PASS), and the loop now short-circuits when the filler is structurally unavailable (first fill AND re-fill both failed) instead of grinding futile rounds (~2.2 min wasted per pre-fix CI run).

## Verification (fresh-route repro, temp dir only — committed artifacts untouched)

Fresh CI-style re-route (`--step route --seed 42`, `PYTHONHASHSEED=42`) into `/tmp` with kicad-cli available:

```
[r1] FAIL GND: 2 disjoint pad groups (largest 115/122)   <- no zero-fill zones at all
[r2] OK   GND: 122 pads in one copper component
[r2] OK   VBUS_USB / +3V3 / +1V8 / +1V2
   POUR CONNECTIVITY: PASS
   SUCCESS: all 21 signal nets routed
```

Gate end-to-end on that fresh artifact: exit 0 (`reach 21/21`, `pour connectivity OK`, all 3 diff-pair rules exercised, 2 DRC errors within the 20 allowlist floor). Gate on a synthesized dead-GND-pour artifact: exit 2 with `GND: 62 disjoint pad groups ... 1 fill-enabled zone(s) with ZERO filled polygons (dead pour)` — the exact trap shape now gates.

Job ceiling: kept at 30 min. Prior green wall was 20m42s; the container adds ~1-2 min (pull + apt) but removes the ~2.2 min of futile repair rounds (re-measure note added inline).

Board 07 (`matchgroup-routing-regression`) does not fill zones, so the sibling job has no parallel gap.

## Test plan

- [x] `tests/test_check_diffpair_coverage.py` (41 passed; container/probe pins inverted, new `TestMeasurePourConnectivity` + board 06 contract test)
- [x] `tests/test_ci_routed_drc_workflow.py` (49 passed)
- [x] `tests/test_check_routed_drc_advisory.py` (16 passed)
- [x] `tests/test_board_06_diffpair_test.py` (39 passed — committed artifact still passes the copper-union audit)
- [x] Full fresh re-route repro + gate run (above)
- [x] `ruff check` clean; `ci.yml` parses
- [ ] First CI run on this PR confirms container wall-clock fits the 30-min ceiling

🤖 Generated with [Claude Code](https://claude.com/claude-code)