### PR TITLE
feat(export): enumerate the THT hand-solder set excluded from the SMT CPL

### DIFF
--- a/src/kicad_tools/export/__init__.py
+++ b/src/kicad_tools/export/__init__.py
@@ -90,8 +90,10 @@ from .pnp import (
     PnPFormatter,
     export_pnp,
     extract_placements,
+    extract_tht_exclusions,
     get_aux_origin,
     get_pnp_formatter,
+    group_tht_exclusions,
 )
 from .preflight import (
     PreflightChecker,
@@ -153,6 +155,8 @@ __all__ = [
     "PNP_FORMATTERS",
     "export_pnp",
     "extract_placements",
+    "extract_tht_exclusions",
     "get_aux_origin",
     "get_pnp_formatter",
+    "group_tht_exclusions",
 ]

--- a/src/kicad_tools/export/assembly.py
+++ b/src/kicad_tools/export/assembly.py
@@ -21,7 +21,13 @@ from .bom_formats import (
 )
 from .bom_spec_overlay import SpecOverlayReport, apply_spec_overlay, find_spec_file
 from .gerber import MANUFACTURER_PRESETS, GerberConfig, GerberExporter
-from .pnp import PnPExportConfig, export_pnp
+from .pnp import (
+    PlacementData,
+    PnPExportConfig,
+    export_pnp,
+    extract_tht_exclusions,
+    get_pnp_formatter,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +84,12 @@ class AssemblyPackageResult:
     gerber_path: Path | None = None
     spec_overlay: SpecOverlayReport | None = None
     lcsc_enrichment: EnrichmentReport | None = None
+    tht_excluded: list[PlacementData] = field(default_factory=list)
+    """Through-hole components excluded from the CPL by the THT filter
+    (issue #3539).  These are on the board and in the BOM but absent
+    from the SMT pick-and-place file, so the assembler must hand-solder
+    them.  Empty when the effective PnP config has ``exclude_tht=False``
+    or the board has no THT parts."""
     errors: list[str] = field(default_factory=list)
 
     @property
@@ -270,7 +282,7 @@ class AssemblyPackage:
         # Generate CPL
         if self.config.include_pnp:
             try:
-                result.pnp_path = self._generate_pnp(out_dir)
+                result.pnp_path = self._generate_pnp(out_dir, result)
             except Exception as e:
                 result.errors.append(f"CPL generation failed: {e}")
                 logger.error(f"CPL generation failed: {e}")
@@ -458,8 +470,14 @@ class AssemblyPackage:
         logger.info(f"Generated BOM: {bom_path}")
         return bom_path
 
-    def _generate_pnp(self, output_dir: Path) -> Path:
-        """Generate pick-and-place file."""
+    def _generate_pnp(self, output_dir: Path, result: AssemblyPackageResult | None = None) -> Path:
+        """Generate pick-and-place file.
+
+        When *result* is provided, the through-hole components excluded
+        from the CPL by the effective THT filter are recorded on
+        ``result.tht_excluded`` so downstream consumers (manufacturing
+        report / README) can enumerate the hand-solder set (issue #3539).
+        """
         # Import here to avoid circular imports
         from ..schema.pcb import PCB
 
@@ -481,6 +499,20 @@ class AssemblyPackage:
             self.config.pnp_config,
             rotation_corrections=rotation_corrections,
         )
+
+        # Record the THT hand-solder set excluded from the CPL.  Use the
+        # formatter's *effective* config so manufacturer defaults
+        # (JLCPCB: exclude_tht=True) are honoured when no explicit
+        # pnp_config was supplied.
+        if result is not None:
+            effective_config = get_pnp_formatter(self.fab_family, self.config.pnp_config).config
+            result.tht_excluded = extract_tht_exclusions(footprints, effective_config)
+            if result.tht_excluded:
+                logger.info(
+                    "CPL excludes %d through-hole component(s) (hand-solder): %s",
+                    len(result.tht_excluded),
+                    ", ".join(p.reference for p in result.tht_excluded),
+                )
 
         # Write to file
         filename = self.config.pnp_filename.format(manufacturer=self.fab_family)

--- a/src/kicad_tools/export/manufacturing.py
+++ b/src/kicad_tools/export/manufacturing.py
@@ -554,6 +554,12 @@ class ManufacturingPackage:
             if figures_data:
                 data_kwargs.update(figures_data)
 
+            # Hand-solder (THT) set excluded from the SMT CPL (issue #3539):
+            # surface the exact refs the assembler must hand-place.
+            tht_components = self._tht_component_groups(result)
+            if tht_components:
+                data_kwargs["tht_components"] = tht_components
+
             project_name = self.pcb_path.stem
             data = ReportData(
                 project_name=project_name,
@@ -937,6 +943,22 @@ class ManufacturingPackage:
 
         logger.info(f"Promoted {len(pngs)} report image(s) to {images_dir}")
 
+    @staticmethod
+    def _tht_component_groups(result: ManufacturingResult) -> list[dict]:
+        """Group the CPL's excluded THT components for the report.
+
+        Returns BOM-style rows ``[{value, footprint, qty, refs}]`` built
+        from ``assembly_result.tht_excluded`` (issue #3539), or an empty
+        list when no THT parts were excluded (SMD-only board, or
+        ``exclude_tht=False``).
+        """
+        if result.assembly_result is None or not result.assembly_result.tht_excluded:
+            return []
+
+        from .pnp import group_tht_exclusions
+
+        return group_tht_exclusions(result.assembly_result.tht_excluded)
+
     def _generate_readme(self, out_dir: Path, result: ManufacturingResult) -> None:
         """Generate a README.txt describing the manufacturing package contents."""
         lines = [
@@ -983,6 +1005,14 @@ class ManufacturingPackage:
                 desc = file_descriptions["pnp"]
                 lines.append(f"  {result.assembly_result.pnp_path.name}")
                 lines.append(f"    {desc[0]}: {desc[1]}")
+                tht_excluded = result.assembly_result.tht_excluded
+                if tht_excluded:
+                    refs = ", ".join(p.reference for p in tht_excluded)
+                    lines.append(
+                        f"    Note: {len(tht_excluded)} through-hole component(s) are"
+                        " excluded from this file and must be hand-soldered"
+                        f" after SMT assembly: {refs}"
+                    )
                 lines.append("")
             if result.assembly_result.gerber_path:
                 desc = file_descriptions["gerber"]

--- a/src/kicad_tools/export/pnp.py
+++ b/src/kicad_tools/export/pnp.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import csv
 import io
+import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
@@ -403,6 +404,99 @@ def extract_placements(
         )
 
     return placements
+
+
+def _ref_sort_key(reference: str) -> tuple[str, int, str]:
+    """Natural sort key for reference designators (R6 before R20)."""
+    match = re.match(r"([A-Za-z_]*)(\d*)(.*)", reference)
+    if match is None:  # pragma: no cover - regex always matches
+        return (reference, -1, "")
+    prefix, digits, rest = match.groups()
+    return (prefix, int(digits) if digits else -1, rest)
+
+
+def extract_tht_exclusions(
+    footprints: list[Footprint],
+    config: PnPExportConfig | None = None,
+) -> list[PlacementData]:
+    """Return the through-hole placements the CPL's THT filter drops.
+
+    These are the components an SMT-only assembler must hand-solder
+    (or wave/selective-solder): they are present on the board and in
+    the BOM, but :func:`extract_placements` omits them from the
+    pick-and-place file when ``config.exclude_tht`` is enabled.
+
+    The same pre-filters as :func:`extract_placements` apply
+    (``exclude_from_pos_files``, DNP), so the returned set is exactly
+    the difference between the unfiltered and THT-filtered CPLs.
+
+    Args:
+        footprints: List of Footprint objects from PCB
+        config: Effective export config.  When ``exclude_tht`` is
+            False (or config is None), no parts are excluded from the
+            CPL, so this returns an empty list.
+
+    Returns:
+        PlacementData for each excluded THT component, in natural
+        reference order (R6 before R20).
+    """
+    config = config or PnPExportConfig()
+    if not config.exclude_tht:
+        return []
+
+    excluded = []
+    for fp in footprints:
+        if getattr(fp, "exclude_from_pos_files", False):
+            continue
+        if not config.include_dnp and getattr(fp, "dnp", False):
+            continue
+        if getattr(fp, "attr", "") != "through_hole":
+            continue
+
+        x, y = fp.position
+        excluded.append(
+            PlacementData(
+                reference=fp.reference,
+                value=fp.value,
+                footprint=fp.name,
+                x=x,
+                y=y,
+                rotation=fp.rotation,
+                layer=fp.layer,
+            )
+        )
+
+    return sorted(excluded, key=lambda p: _ref_sort_key(p.reference))
+
+
+def group_tht_exclusions(placements: list[PlacementData]) -> list[dict]:
+    """Group excluded THT placements for report/README presentation.
+
+    Groups by (value, footprint) and returns BOM-style rows::
+
+        [{"value": ..., "footprint": ..., "qty": N, "refs": "D1, D2"}]
+
+    Rows are ordered by the natural sort key of each group's first
+    reference, and references within a row are naturally sorted.
+    """
+    groups: dict[tuple[str, str], list[str]] = {}
+    for p in placements:
+        groups.setdefault((p.value, p.footprint), []).append(p.reference)
+
+    rows = []
+    for (value, footprint), refs in groups.items():
+        refs_sorted = sorted(refs, key=_ref_sort_key)
+        rows.append(
+            {
+                "value": value,
+                "footprint": footprint,
+                "qty": len(refs_sorted),
+                "refs": ", ".join(refs_sorted),
+            }
+        )
+
+    rows.sort(key=lambda row: _ref_sort_key(row["refs"].split(", ")[0]))
+    return rows
 
 
 def get_aux_origin(pcb_path: str | Path) -> tuple[float, float]:

--- a/src/kicad_tools/report/generator.py
+++ b/src/kicad_tools/report/generator.py
@@ -170,6 +170,7 @@ class ReportGenerator:
             "interfaces": data.interfaces,
             "power_architecture": data.power_architecture,
             "assembly_notes": data.assembly_notes,
+            "tht_components": data.tht_components,
             "stackup": data.stackup,
             "off_board": data.off_board,
             "notes": data.notes,

--- a/src/kicad_tools/report/models.py
+++ b/src/kicad_tools/report/models.py
@@ -88,6 +88,12 @@ class ReportData:
     """Assembly guidance: {fine_pitch_count, thermal_pad_count,
     polarized_count, summary}."""
 
+    tht_components: list[dict] | None = None
+    """Hand-solder THT components excluded from the SMT CPL (issue #3539):
+    [{value, footprint, qty, refs}] where ``refs`` is a comma-joined
+    reference designator string.  ``None``/empty for SMD-only boards or
+    when the CPL includes THT parts (exclude_tht=False)."""
+
     stackup: list[dict] | None = None
     """Layer stackup: [{name, type, thickness_mm, material}].
     Filtered to copper, dielectric, and mask layers."""

--- a/src/kicad_tools/report/templates/design_report.md.j2
+++ b/src/kicad_tools/report/templates/design_report.md.j2
@@ -111,6 +111,19 @@ header-includes:
 {% endif %}
 
 {% endif %}
+{% if tht_components %}
+## Hand-Solder (THT) Components
+
+{% set tht_total = tht_components | sum(attribute='qty') %}
+The following {{ tht_total }} through-hole component{{ 's are' if tht_total != 1 else ' is' }} **excluded from the SMT pick-and-place file** and must be hand-soldered (or wave/selective-soldered) after SMT assembly. {{ 'They appear' if tht_total != 1 else 'It appears' }} in the BOM for sourcing.
+
+| Value | Package | Qty | References |
+|-------|---------|-----|------------|
+{% for item in tht_components %}
+| {{ item.value | default("", true) }} | {{ item.footprint | default("", true) | short_footprint }} | {{ item.qty | default("", true) }} | {{ item.refs | default("", true) }} |
+{% endfor %}
+
+{% endif %}
 {% if off_board and off_board.assemblies %}
 ## Off-board Assemblies
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -26,8 +26,10 @@ from kicad_tools.export.pnp import (
     PnPExportConfig,
     export_pnp,
     extract_placements,
+    extract_tht_exclusions,
     get_aux_origin,
     get_pnp_formatter,
+    group_tht_exclusions,
 )
 
 
@@ -796,3 +798,221 @@ class TestAssemblyPackageJLCPCBTHTIntegration:
         assert "C1" in cpl_content
         # THT connector must be excluded
         assert "J1" not in cpl_content
+
+
+class TestExtractTHTExclusions:
+    """Tests for extract_tht_exclusions (issue #3539)."""
+
+    @pytest.fixture
+    def mixed_footprints(self) -> list[MockFootprint]:
+        return [
+            MockFootprint("R1", "10k", "0402", (10.0, 20.0), 0.0, "F.Cu", attr="smd"),
+            MockFootprint("R20", "1k", "THT_Axial", (12.0, 20.0), 0.0, "F.Cu", attr="through_hole"),
+            MockFootprint("R6", "1k", "THT_Axial", (14.0, 20.0), 0.0, "F.Cu", attr="through_hole"),
+            MockFootprint(
+                "J1", "Conn_01x04", "PinHeader_1x04", (50.0, 10.0), 0.0, "F.Cu", attr="through_hole"
+            ),
+            MockFootprint("U1", "STM32", "LQFP48", (30.0, 30.0), 45.0, "F.Cu", attr="smd"),
+        ]
+
+    def test_lists_exactly_the_excluded_tht_set(self, mixed_footprints):
+        """Exclusions must be exactly the THT parts the CPL filter drops."""
+        config = PnPExportConfig(exclude_tht=True)
+        included = {p.reference for p in extract_placements(mixed_footprints, config)}
+        excluded = extract_tht_exclusions(mixed_footprints, config)
+        excluded_refs = {p.reference for p in excluded}
+
+        assert excluded_refs == {"R6", "R20", "J1"}
+        assert excluded_refs.isdisjoint(included)
+        all_refs = {fp.reference for fp in mixed_footprints}
+        assert included | excluded_refs == all_refs
+
+    def test_natural_reference_ordering(self, mixed_footprints):
+        """R6 must sort before R20 (natural, not lexicographic, order)."""
+        config = PnPExportConfig(exclude_tht=True)
+        refs = [p.reference for p in extract_tht_exclusions(mixed_footprints, config)]
+        assert refs == ["J1", "R6", "R20"]
+
+    def test_exclude_tht_false_returns_empty(self, mixed_footprints):
+        """When the CPL includes THT, nothing is hand-solder-excluded."""
+        config = PnPExportConfig(exclude_tht=False)
+        assert extract_tht_exclusions(mixed_footprints, config) == []
+
+    def test_no_config_returns_empty(self, mixed_footprints):
+        """Default config has exclude_tht=False -> empty exclusion set."""
+        assert extract_tht_exclusions(mixed_footprints) == []
+
+    def test_smd_only_board_returns_empty(self):
+        """SMD-only board has no hand-solder set even with exclude_tht."""
+        footprints = [
+            MockFootprint("R1", "10k", "0402", (10.0, 20.0), 0.0, "F.Cu", attr="smd"),
+            MockFootprint("C1", "100nF", "0402", (15.0, 25.0), 0.0, "F.Cu", attr="smd"),
+        ]
+        config = PnPExportConfig(exclude_tht=True)
+        assert extract_tht_exclusions(footprints, config) == []
+
+    def test_dnp_tht_not_listed(self):
+        """DNP THT parts are not placed at all -> not in the hand-solder set."""
+        footprints = [
+            MockFootprint(
+                "J1", "Conn", "PinHeader", (10.0, 10.0), 0.0, "F.Cu", attr="through_hole"
+            ),
+            MockFootprint(
+                "J2", "Conn", "PinHeader", (20.0, 10.0), 0.0, "F.Cu", attr="through_hole", dnp=True
+            ),
+        ]
+        config = PnPExportConfig(exclude_tht=True)
+        refs = [p.reference for p in extract_tht_exclusions(footprints, config)]
+        assert refs == ["J1"]
+
+    def test_exclude_from_pos_files_not_listed(self):
+        """Footprints excluded from position files are never CPL candidates."""
+        footprints = [
+            MockFootprint(
+                "J1", "Conn", "PinHeader", (10.0, 10.0), 0.0, "F.Cu", attr="through_hole"
+            ),
+            MockFootprint(
+                "H1",
+                "MountingHole",
+                "MountingHole_3.2mm",
+                (20.0, 10.0),
+                0.0,
+                "F.Cu",
+                attr="through_hole",
+                exclude_from_pos_files=True,
+            ),
+        ]
+        config = PnPExportConfig(exclude_tht=True)
+        refs = [p.reference for p in extract_tht_exclusions(footprints, config)]
+        assert refs == ["J1"]
+
+
+class TestGroupTHTExclusions:
+    """Tests for group_tht_exclusions presentation grouping (issue #3539)."""
+
+    def test_groups_by_value_and_footprint(self):
+        placements = [
+            PlacementData("R20", "1k", "THT_Axial", 0, 0, 0, "F.Cu"),
+            PlacementData("R6", "1k", "THT_Axial", 0, 0, 0, "F.Cu"),
+            PlacementData("J1", "Conn_01x04", "PinHeader_1x04", 0, 0, 0, "F.Cu"),
+        ]
+        rows = group_tht_exclusions(placements)
+
+        assert rows == [
+            {"value": "Conn_01x04", "footprint": "PinHeader_1x04", "qty": 1, "refs": "J1"},
+            {"value": "1k", "footprint": "THT_Axial", "qty": 2, "refs": "R6, R20"},
+        ]
+
+    def test_same_value_different_footprint_not_merged(self):
+        placements = [
+            PlacementData("R1", "1k", "THT_Axial_Small", 0, 0, 0, "F.Cu"),
+            PlacementData("R2", "1k", "THT_Axial_Large", 0, 0, 0, "F.Cu"),
+        ]
+        rows = group_tht_exclusions(placements)
+        assert len(rows) == 2
+
+    def test_empty_input(self):
+        assert group_tht_exclusions([]) == []
+
+
+class TestAssemblyPackageTHTExcludedSurfacing:
+    """AssemblyPackageResult.tht_excluded records the CPL hand-solder set."""
+
+    def _make_package(self, tmp_path, manufacturer="jlcpcb", pnp_config=None):
+        from kicad_tools.export.assembly import AssemblyConfig, AssemblyPackage
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text("(kicad_pcb (version 20221018))")
+
+        config = AssemblyConfig(
+            include_bom=False,
+            include_gerbers=False,
+            include_pnp=True,
+            pnp_config=pnp_config,
+        )
+        return AssemblyPackage(
+            pcb_path=pcb_file,
+            schematic_path=None,
+            manufacturer=manufacturer,
+            config=config,
+        )
+
+    def _export_with_footprints(self, pkg, tmp_path, footprints):
+        from unittest.mock import MagicMock, patch
+
+        mock_pcb = MagicMock()
+        mock_pcb.footprints = footprints
+        with patch("kicad_tools.schema.pcb.PCB") as MockPCB:
+            MockPCB.load.return_value = mock_pcb
+            return pkg.export(output_dir=tmp_path / "out")
+
+    def test_jlcpcb_records_tht_excluded(self, tmp_path):
+        """JLCPCB default (exclude_tht=True) surfaces the excluded refs."""
+        pkg = self._make_package(tmp_path)
+        result = self._export_with_footprints(
+            pkg,
+            tmp_path,
+            [
+                MockFootprint("R1", "10k", "0402", (10.0, 20.0), 0.0, "F.Cu", attr="smd"),
+                MockFootprint(
+                    "J1",
+                    "Conn_01x04",
+                    "PinHeader_1x04",
+                    (50.0, 10.0),
+                    0.0,
+                    "F.Cu",
+                    attr="through_hole",
+                ),
+                MockFootprint(
+                    "SW1", "SW_Push", "SW_PUSH_6mm", (60.0, 10.0), 0.0, "F.Cu", attr="through_hole"
+                ),
+            ],
+        )
+
+        assert [p.reference for p in result.tht_excluded] == ["J1", "SW1"]
+        # Sanity: the same refs are absent from the CPL on disk
+        cpl_content = result.pnp_path.read_text()
+        assert "J1" not in cpl_content
+        assert "SW1" not in cpl_content
+        assert "R1" in cpl_content
+
+    def test_smd_only_board_has_empty_tht_excluded(self, tmp_path):
+        pkg = self._make_package(tmp_path)
+        result = self._export_with_footprints(
+            pkg,
+            tmp_path,
+            [
+                MockFootprint("R1", "10k", "0402", (10.0, 20.0), 0.0, "F.Cu", attr="smd"),
+                MockFootprint("C1", "100nF", "0402", (15.0, 25.0), 0.0, "F.Cu", attr="smd"),
+            ],
+        )
+        assert result.tht_excluded == []
+
+    def test_explicit_include_tht_has_empty_tht_excluded(self, tmp_path):
+        """exclude_tht=False means the CPL includes THT -> nothing to document."""
+        pkg = self._make_package(tmp_path, pnp_config=PnPExportConfig(exclude_tht=False))
+        result = self._export_with_footprints(
+            pkg,
+            tmp_path,
+            [
+                MockFootprint(
+                    "J1", "Conn", "PinHeader", (10.0, 10.0), 0.0, "F.Cu", attr="through_hole"
+                ),
+            ],
+        )
+        assert result.tht_excluded == []
+        assert "J1" in result.pnp_path.read_text()
+
+    def test_generic_manufacturer_has_empty_tht_excluded(self, tmp_path):
+        """Generic formatter includes THT by default -> no hand-solder set."""
+        pkg = self._make_package(tmp_path, manufacturer="generic")
+        result = self._export_with_footprints(
+            pkg,
+            tmp_path,
+            [
+                MockFootprint(
+                    "J1", "Conn", "PinHeader", (10.0, 10.0), 0.0, "F.Cu", attr="through_hole"
+                ),
+            ],
+        )
+        assert result.tht_excluded == []

--- a/tests/test_manufacturing_package.py
+++ b/tests/test_manufacturing_package.py
@@ -1184,3 +1184,113 @@ class TestReadmeGeneration:
         """include_readme defaults to True."""
         config = ManufacturingConfig()
         assert config.include_readme is True
+
+
+class TestTHTHandSolderDocumentation:
+    """README/report documentation of the CPL's hand-solder THT set (issue #3539)."""
+
+    @staticmethod
+    def _tht_placements(refs_values_footprints):
+        from kicad_tools.export.pnp import PlacementData
+
+        return [
+            PlacementData(ref, value, footprint, 0.0, 0.0, 0.0, "F.Cu")
+            for ref, value, footprint in refs_values_footprints
+        ]
+
+    def _export(self, tmp_path, monkeypatch, tht_excluded):
+        """Run a ManufacturingPackage export with a faked assembly stage."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        pcb = project_dir / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+        (project_dir / "board.kicad_sch").write_text("(kicad_sch)")
+
+        from kicad_tools.export import assembly
+
+        def fake_assembly_export(self, output_dir=None):
+            od = Path(output_dir) if output_dir else self.config.output_dir
+            od.mkdir(parents=True, exist_ok=True)
+            bom_path = od / "bom_jlcpcb.csv"
+            bom_path.write_text("Comment,Designator\n")
+            pnp_path = od / "cpl_jlcpcb.csv"
+            pnp_path.write_text("Designator,Val\n")
+            return assembly.AssemblyPackageResult(
+                output_dir=od,
+                bom_path=bom_path,
+                pnp_path=pnp_path,
+                tht_excluded=tht_excluded,
+            )
+
+        monkeypatch.setattr(assembly.AssemblyPackage, "export", fake_assembly_export)
+
+        config = ManufacturingConfig(
+            include_report=False,
+            preflight=PreflightConfig(skip_all=True),
+        )
+        pkg = ManufacturingPackage(pcb_path=pcb, manufacturer="jlcpcb", config=config)
+        return pkg.export(tmp_path / "output")
+
+    def test_readme_lists_hand_solder_refs(self, tmp_path, monkeypatch):
+        """README.txt's CPL entry must enumerate the excluded THT refs."""
+        tht = self._tht_placements(
+            [
+                ("J1", "Conn_01x04", "PinHeader_1x04"),
+                ("R6", "1k", "R_Axial"),
+                ("SW1", "SW_Push", "SW_PUSH_6mm"),
+            ]
+        )
+        result = self._export(tmp_path, monkeypatch, tht)
+
+        assert result.readme_path is not None
+        content = result.readme_path.read_text()
+        assert "cpl_jlcpcb.csv" in content
+        assert "3 through-hole component(s)" in content
+        assert "hand-soldered" in content
+        assert "J1, R6, SW1" in content
+
+    def test_readme_no_note_for_smd_only_board(self, tmp_path, monkeypatch):
+        """SMD-only boards must not get a spurious hand-solder note."""
+        result = self._export(tmp_path, monkeypatch, [])
+
+        content = result.readme_path.read_text()
+        assert "cpl_jlcpcb.csv" in content
+        assert "hand-soldered" not in content
+        assert "through-hole" not in content
+
+    def test_tht_component_groups_from_assembly_result(self, tmp_path):
+        """_tht_component_groups produces BOM-style rows for the report."""
+        from kicad_tools.export.assembly import AssemblyPackageResult
+
+        result = ManufacturingResult(
+            output_dir=tmp_path,
+            assembly_result=AssemblyPackageResult(
+                output_dir=tmp_path,
+                tht_excluded=self._tht_placements(
+                    [
+                        ("R20", "1k", "R_Axial"),
+                        ("R6", "1k", "R_Axial"),
+                        ("J1", "Conn_01x04", "PinHeader_1x04"),
+                    ]
+                ),
+            ),
+        )
+
+        rows = ManufacturingPackage._tht_component_groups(result)
+        assert rows == [
+            {"value": "Conn_01x04", "footprint": "PinHeader_1x04", "qty": 1, "refs": "J1"},
+            {"value": "1k", "footprint": "R_Axial", "qty": 2, "refs": "R6, R20"},
+        ]
+
+    def test_tht_component_groups_empty_cases(self, tmp_path):
+        """No assembly result or empty exclusion set -> no rows."""
+        from kicad_tools.export.assembly import AssemblyPackageResult
+
+        no_assembly = ManufacturingResult(output_dir=tmp_path)
+        assert ManufacturingPackage._tht_component_groups(no_assembly) == []
+
+        empty = ManufacturingResult(
+            output_dir=tmp_path,
+            assembly_result=AssemblyPackageResult(output_dir=tmp_path),
+        )
+        assert ManufacturingPackage._tht_component_groups(empty) == []

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -2336,3 +2336,69 @@ class TestDesignNarrative:
         assert "### Functional Blocks" not in content
         assert "### Communication Interfaces" not in content
         assert "### Power Architecture" not in content
+
+
+class TestHandSolderTHTSection:
+    """Hand-Solder (THT) Components section rendering (issue #3539)."""
+
+    _THT_ROWS = [
+        {
+            "value": "Conn_01x04",
+            "footprint": "Connector_PinHeader_2.54mm:PinHeader_1x04_P2.54mm_Vertical",
+            "qty": 1,
+            "refs": "J1",
+        },
+        {"value": "1k", "footprint": "Resistor_THT:R_Axial", "qty": 3, "refs": "R6, R20, R21"},
+    ]
+
+    def test_section_rendered_with_tht_components(self, tmp_path: Path) -> None:
+        data = _full_data(tht_components=self._THT_ROWS)
+        gen = ReportGenerator()
+        report_path = gen.generate(data, tmp_path)
+        content = report_path.read_text(encoding="utf-8")
+
+        assert "## Hand-Solder (THT) Components" in content
+        # Total quantity and intent statement
+        assert "4 through-hole components are" in content
+        assert "excluded from the SMT pick-and-place file" in content
+        # Every excluded ref must be listed (assembler needs the full set)
+        assert "J1" in content
+        assert "R6, R20, R21" in content
+        # short_footprint filter strips the library prefix
+        assert "R_Axial" in content
+
+    def test_section_omitted_when_none(self, tmp_path: Path) -> None:
+        data = _full_data(tht_components=None)
+        gen = ReportGenerator()
+        report_path = gen.generate(data, tmp_path)
+        content = report_path.read_text(encoding="utf-8")
+
+        assert "## Hand-Solder (THT) Components" not in content
+        assert "hand-soldered" not in content
+
+    def test_section_omitted_when_empty_list(self, tmp_path: Path) -> None:
+        """SMD-only boards (empty exclusion set) must not get a spurious section."""
+        data = _full_data(tht_components=[])
+        gen = ReportGenerator()
+        report_path = gen.generate(data, tmp_path)
+        content = report_path.read_text(encoding="utf-8")
+
+        assert "## Hand-Solder (THT) Components" not in content
+
+    def test_singular_phrasing_for_one_component(self, tmp_path: Path) -> None:
+        data = _full_data(
+            tht_components=[
+                {
+                    "value": "SW_Push",
+                    "footprint": "Button_Switch_THT:SW_PUSH_6mm",
+                    "qty": 1,
+                    "refs": "SW1",
+                }
+            ]
+        )
+        gen = ReportGenerator()
+        report_path = gen.generate(data, tmp_path)
+        content = report_path.read_text(encoding="utf-8")
+
+        assert "1 through-hole component is" in content
+        assert "It appears" in content


### PR DESCRIPTION
Closes #3539

## Summary

The JLCPCB CPL formatter (correctly) excludes through-hole parts from the SMT pick-and-place file, but nothing in the bundle documented which refs the assembler must hand-place. This PR surfaces the excluded set in both assembler-facing documents:

- **`report.md`**: new "Hand-Solder (THT) Components" section (rendered right after Assembly Notes) with a Value / Package / Qty / References table. The full ref list is never truncated — the assembler needs every ref. Singular/plural phrasing handled; SMD-only boards and `exclude_tht=False` exports omit the section cleanly.
- **`README.txt`**: the CPL entry gains a note, e.g. `Note: 18 through-hole component(s) are excluded from this file and must be hand-soldered after SMT assembly: D1, F1, ...`

## Design

- `pnp.py: extract_tht_exclusions(footprints, config)` returns **exactly** the placements the CPL's THT filter drops (same `exclude_from_pos_files`/DNP pre-filters as `extract_placements`, then `attr == "through_hole"`), in natural ref order (R6 before R20). Returns `[]` when `exclude_tht` is off.
- `pnp.py: group_tht_exclusions(placements)` groups them into BOM-style rows `{value, footprint, qty, refs}`.
- `assembly.py`: `AssemblyPackageResult.tht_excluded` is populated by `_generate_pnp` using the formatter's **effective** config, so JLCPCB's `exclude_tht=True` default is captured when no explicit `pnp_config` is supplied (generic/PCBWay default to including THT, so they record nothing).
- `manufacturing.py`: `_tht_component_groups()` feeds the new `ReportData.tht_components` field; `_generate_readme()` appends the CPL note. Template/model/generator wired through `design_report.md.j2`.

## Not in this PR

- **Committed bundles are NOT regenerated** (per #3580 artifact discipline). The next `kct export` regen of softstart/fleet bundles picks up the new section automatically; the softstart bundle will then list its 18 on-board THT refs (D1, F1, J1-J5, Q1A/B, Q2A/B, R6, R20, R21, RV1, SW1, U2, U9).

## Test plan

- [x] `tests/test_export.py`: exclusion set is exactly the THT parts dropped from the CPL (mixed SMD/THT), natural ordering, DNP/`exclude_from_pos_files` not listed, SMD-only and `exclude_tht=False` return empty; AssemblyPackage integration tests (JLCPCB records refs + CPL lacks them; generic/explicit-include record nothing)
- [x] `tests/test_report_generator.py`: section renders with full refs, omitted for `None`/empty, singular phrasing
- [x] `tests/test_manufacturing_package.py`: README lists refs; SMD-only board gets no spurious note; `_tht_component_groups` row shape + empty cases
- [x] All tests write to tmp dirs only — `tests/test_manifest_integrity.py` stays green (248 passed)
- [x] Wider suites: export/report/mcp/assembly/softstart-quality — 350 passed
- [x] `ruff check`/`ruff format --check` on touched files: no new findings (remaining flags are pre-existing rot tracked by #3464)

🤖 Generated with [Claude Code](https://claude.com/claude-code)