### PR TITLE
fix(router): net-name-scoped explicit diff-pair gathering

### DIFF
--- a/src/kicad_tools/router/diffpair_detection.py
+++ b/src/kicad_tools/router/diffpair_detection.py
@@ -252,22 +252,47 @@ def _gather_explicit_pairs(
     Supports one-sided declarations: if only one of the two half-pairs
     has the field set, the partner is still found provided it exists
     in ``net_names``.
+
+    Lookup scoping (Issue #3455): ``net_class_routing`` may be keyed by
+    NET NAME (autorouter ``net_class_map`` convention), by CLASS NAME
+    (``validate/match_group_skew`` convention), or by both (the
+    ``synth_routing`` idiom in ``router/core.py``).  A net-name-keyed
+    entry is authoritative for THAT net only.  A class-name-keyed entry
+    fans out to every net of the class, which is a pollution hazard:
+    when a per-net annotation (e.g. ``USB_D+`` with partner ``USB_D-``)
+    is registered under its class name (``HighSpeed``), every other net
+    of that class (``USB_CC1``, ``USB_CC2``, ...) would otherwise
+    inherit the partner declaration.  Class-keyed declarations are
+    therefore honored only when unambiguous -- see
+    :func:`_declared_partner_for_net`.
     """
     if not net_class_routing or not net_to_class:
         return []
 
-    declared: dict[str, str] = {}  # net_name -> partner_name
+    # Class-membership view restricted to nets actually on the board,
+    # used to disambiguate class-name-keyed declarations.
+    class_members: dict[str, list[str]] = {}
     for net_name in net_names.values():
         class_name = net_to_class.get(net_name)
-        if class_name is None:
-            continue
-        nc = net_class_routing.get(class_name)
-        if nc is None or nc.diffpair_partner is None:
-            continue
-        declared[net_name] = nc.diffpair_partner
+        if class_name is not None:
+            members = class_members.setdefault(class_name, [])
+            if net_name not in members:
+                members.append(net_name)
+
+    declared: dict[str, str] = {}  # net_name -> partner_name
+    for net_name in net_names.values():
+        partner_name = _declared_partner_for_net(
+            net_name=net_name,
+            net_class_routing=net_class_routing,
+            net_to_class=net_to_class,
+            class_members=class_members,
+        )
+        if partner_name is not None:
+            declared[net_name] = partner_name
 
     pairs: list[DifferentialPair] = []
     seen: set[frozenset[str]] = set()  # canonical {p, n} pair sets
+    used: set[str] = set()  # nets already consumed by an emitted pair
 
     for net_name, partner_name in declared.items():
         # Canonicalise so we don't emit the same pair twice from a
@@ -279,6 +304,19 @@ def _gather_explicit_pairs(
             logger.warning(
                 "[diffpair] explicit declaration on %s names partner %s "
                 "which is not in the net list; skipping",
+                net_name,
+                partner_name,
+            )
+            continue
+        # A net belongs to AT MOST one pair.  Conflicting declarations
+        # (two nets both claiming the same partner) keep the first and
+        # warn on the rest (Issue #3455: previously USB_CC2 -> USB_D-
+        # was emitted alongside USB_D+ -> USB_D-, and the last writer
+        # clobbered USB_D-'s partner in the autorouter wiring loop).
+        if net_name in used or partner_name in used:
+            logger.warning(
+                "[diffpair] explicit declaration %s <-> %s conflicts with "
+                "an already-emitted pair; skipping",
                 net_name,
                 partner_name,
             )
@@ -297,8 +335,106 @@ def _gather_explicit_pairs(
         )
         if pair is not None:
             pairs.append(pair)
+            used.add(net_name)
+            used.add(partner_name)
 
     return pairs
+
+
+def _declared_partner_for_net(
+    *,
+    net_name: str,
+    net_class_routing: dict[str, NetClassRouting],
+    net_to_class: dict[str, str],
+    class_members: dict[str, list[str]],
+) -> str | None:
+    """Resolve the explicitly-declared partner for ``net_name``, if any.
+
+    Resolution order (Issue #3455 -- net-name-scoped gathering):
+
+    1. **Net-name-keyed entry** (``net_class_routing[net_name]``): the
+       key IS the net name, so a ``diffpair_partner`` here is
+       authoritative for this net.  Arbitrary partner names (including
+       single-ended ones like ``USB_CC2``) remain honored -- this is
+       the documented "designers can still pair CC1/CC2 explicitly"
+       escape hatch.
+    2. **Class-name-keyed entry** (``net_class_routing[class_name]``):
+       the declaration is shared by every net of the class, so it can
+       describe at most ONE pair.  It is honored only when:
+
+       * this net is the ONLY class member besides the partner itself
+         (single-member classes -- the pre-#3455 explicit-declaration
+         shape used by all earlier tests), or
+       * this net is the unique polarity counterpart of the declared
+         partner (matching base name with ``+``/``-``, ``_P``/``_N``,
+         etc. polarity: ``USB_D+`` for partner ``USB_D-``).
+
+       Any other class member (``USB_CC2`` for partner ``USB_D-``) gets
+       NO partner from the class-level declaration.
+    """
+    # 1. Net-name-keyed lookup: authoritative for this net only.
+    nc = net_class_routing.get(net_name)
+    if nc is not None and getattr(nc, "diffpair_partner", None):
+        partner = nc.diffpair_partner
+        return partner if partner != net_name else None
+
+    # 2. Class-name-keyed lookup with fan-out disambiguation.
+    class_name = net_to_class.get(net_name)
+    if class_name is None or class_name == net_name:
+        return None
+    cnc = net_class_routing.get(class_name)
+    if cnc is None or cnc is nc or not getattr(cnc, "diffpair_partner", None):
+        return None
+    partner = cnc.diffpair_partner
+    if partner == net_name:
+        # This net IS the declared partner; the other half of the pair
+        # resolves the declaration from its own side.
+        return None
+
+    candidates = [m for m in class_members.get(class_name, []) if m != partner]
+    if len(candidates) <= 1:
+        # Unambiguous: this net is the only class member that could be
+        # the partner's other half.
+        return partner
+
+    # Multiple class members compete for the declared partner -- only a
+    # true polarity counterpart may claim it.
+    if not _is_polarity_counterpart(net_name, partner):
+        logger.debug(
+            "[diffpair] class %s declares partner %s but member %s is not "
+            "its polarity counterpart; not pairing",
+            class_name,
+            partner,
+            net_name,
+        )
+        return None
+    rivals = [m for m in candidates if m != net_name and _is_polarity_counterpart(m, partner)]
+    if rivals:
+        logger.warning(
+            "[diffpair] class %s declares partner %s but multiple members "
+            "(%s, %s) are polarity counterparts; skipping ambiguous "
+            "declaration",
+            class_name,
+            partner,
+            net_name,
+            ", ".join(rivals),
+        )
+        return None
+    return partner
+
+
+def _is_polarity_counterpart(a: str, b: str) -> bool:
+    """True when ``a`` and ``b`` form a polarity pair: identical base
+    name with opposite polarity suffixes (``USB_D+``/``USB_D-``,
+    ``CLK_P``/``CLK_N``, ...).  Names without a recognisable polarity
+    suffix (``USB_CC2``, ``TX0``) are never counterparts."""
+    from .diffpair import parse_differential_signal
+
+    a_parsed = parse_differential_signal(a)
+    b_parsed = parse_differential_signal(b)
+    if a_parsed is None or b_parsed is None:
+        return False
+    return a_parsed[0] == b_parsed[0] and a_parsed[1] != b_parsed[1]
 
 
 def _order_explicit_pair(a: str, b: str) -> tuple[str, str]:

--- a/tests/test_diffpair_detection.py
+++ b/tests/test_diffpair_detection.py
@@ -269,6 +269,156 @@ class TestExplicitDeclaration:
 
 
 # =============================================================================
+# 5b. Class-name-keyed fan-out pollution (Issue #3455)
+# =============================================================================
+
+
+class TestClassKeyedFanOut:
+    """Issue #3455: a per-net partner annotation registered under its
+    CLASS name must not fan out to every net of the class.
+
+    Board-03 shape: ``USB_D+`` carries ``diffpair_partner='USB_D-'`` on
+    a per-net ``NetClassRouting`` copy.  The autorouter's synth_routing
+    idiom (``router/core.py``) registers that instance under the class
+    name ``HighSpeed`` via ``setdefault``, after which the old
+    class-keyed lookup paired EVERY HighSpeed net (USB_CC1, USB_CC2)
+    with USB_D-.
+    """
+
+    _USB_NETS = {1: "USB_D+", 2: "USB_D-", 3: "USB_CC1", 4: "USB_CC2"}
+
+    def _synth_routing_board03(self):
+        """Mirror core.py's synth_routing idiom: net-name keys for every
+        net plus a class-name key holding the FIRST net's instance
+        (here: the annotated USB_D+ copy -- the worst case)."""
+        plain = NetClassRouting(name="HighSpeed")
+        annotated = NetClassRouting(name="HighSpeed", diffpair_partner="USB_D-")
+        routing = {
+            "USB_D+": annotated,
+            "USB_D-": plain,
+            "USB_CC1": plain,
+            "USB_CC2": plain,
+            "HighSpeed": annotated,  # setdefault winner = first net's instance
+        }
+        net_to_class = dict.fromkeys(self._USB_NETS.values(), "HighSpeed")
+        return routing, net_to_class
+
+    def test_cc_nets_not_polluted_by_class_keyed_annotation(self):
+        routing, net_to_class = self._synth_routing_board03()
+        out = detect_diff_pairs(
+            self._USB_NETS,
+            net_class_routing=routing,
+            net_to_class=net_to_class,
+        )
+        assert len(out) == 1
+        names = {out[0].pair.positive.net_name, out[0].pair.negative.net_name}
+        assert names == {"USB_D+", "USB_D-"}
+        assert out[0].source == DetectionSource.EXPLICIT
+
+    def test_pure_class_keyed_map_selects_polarity_counterpart(self):
+        # validate/match_group_skew convention: ONLY class-name keys.
+        # The declaration can describe at most one pair; only the
+        # polarity counterpart of USB_D- (USB_D+) may claim it.
+        nc = NetClassRouting(name="HighSpeed", diffpair_partner="USB_D-")
+        net_to_class = dict.fromkeys(self._USB_NETS.values(), "HighSpeed")
+        out = detect_diff_pairs(
+            self._USB_NETS,
+            net_class_routing={"HighSpeed": nc},
+            net_to_class=net_to_class,
+        )
+        assert len(out) == 1
+        names = {out[0].pair.positive.net_name, out[0].pair.negative.net_name}
+        assert names == {"USB_D+", "USB_D-"}
+
+    def test_single_member_class_still_pairs_arbitrary_names(self):
+        # Documented escape hatch: designers can pair USB-C CC1/CC2
+        # explicitly.  A class with a single member net keeps working
+        # even though CC2 has no polarity suffix.
+        net_names = {1: "USB_CC1", 2: "USB_CC2"}
+        nc = NetClassRouting(name="USBCC", diffpair_partner="USB_CC2")
+        out = detect_diff_pairs(
+            net_names,
+            net_class_routing={"USBCC": nc},
+            net_to_class={"USB_CC1": "USBCC"},
+        )
+        assert len(out) == 1
+        names = {out[0].pair.positive.net_name, out[0].pair.negative.net_name}
+        assert names == {"USB_CC1", "USB_CC2"}
+
+    def test_multi_member_class_with_non_polarity_partner_refused(self):
+        # Two members compete for a partner that has no polarity suffix
+        # -- ambiguous, so nobody pairs.
+        net_names = {1: "USB_CC1", 2: "SIG_X", 3: "USB_CC2"}
+        nc = NetClassRouting(name="Misc", diffpair_partner="USB_CC2")
+        out = detect_diff_pairs(
+            net_names,
+            net_class_routing={"Misc": nc},
+            net_to_class={"USB_CC1": "Misc", "SIG_X": "Misc", "USB_CC2": "Misc"},
+        )
+        assert out == []
+
+    def test_bus_indices_not_paired_by_class_declaration(self):
+        # TX0/TX1 are bus indices, not polarity halves; a class-level
+        # partner declaration must not couple them.
+        net_names = {1: "TX0", 2: "TX1", 3: "USB_D-"}
+        nc = NetClassRouting(name="HighSpeed", diffpair_partner="USB_D-")
+        out = detect_diff_pairs(
+            net_names,
+            net_class_routing={"HighSpeed": nc},
+            net_to_class={"TX0": "HighSpeed", "TX1": "HighSpeed"},
+        )
+        assert out == []
+
+    def test_net_name_keyed_entry_remains_authoritative(self):
+        # net-name-keyed declarations (autorouter net_class_map style)
+        # are honored verbatim, including arbitrary partner names.
+        net_names = {1: "USB_CC1", 2: "USB_CC2"}
+        nc = NetClassRouting(name="USBCC", diffpair_partner="USB_CC2")
+        out = detect_diff_pairs(
+            net_names,
+            net_class_routing={"USB_CC1": nc},
+            net_to_class={"USB_CC1": "USBCC", "USB_CC2": "USBCC"},
+        )
+        assert len(out) == 1
+        names = {out[0].pair.positive.net_name, out[0].pair.negative.net_name}
+        assert names == {"USB_CC1", "USB_CC2"}
+
+    def test_conflicting_declarations_keep_first_and_warn(self, caplog):
+        # Two nets both name the same partner via net-name-keyed
+        # entries: only one pair is emitted (a net belongs to at most
+        # one pair) and the conflict is logged.
+        net_names = {1: "USB_D+", 2: "USB_D-", 3: "USB_CC2"}
+        nc_dp = NetClassRouting(name="A", diffpair_partner="USB_D-")
+        nc_cc = NetClassRouting(name="B", diffpair_partner="USB_D-")
+        with caplog.at_level(logging.WARNING):
+            out = detect_diff_pairs(
+                net_names,
+                net_class_routing={"USB_D+": nc_dp, "USB_CC2": nc_cc},
+                net_to_class={"USB_D+": "A", "USB_CC2": "B"},
+            )
+        assert len(out) == 1
+        names = {out[0].pair.positive.net_name, out[0].pair.negative.net_name}
+        assert names == {"USB_D+", "USB_D-"}
+        assert any("conflicts" in r.message for r in caplog.records)
+
+    def test_ambiguous_polarity_rivals_warn_and_skip(self, caplog):
+        # Two distinct nets both parse as the polarity counterpart of
+        # the declared partner -- the EXPLICIT declaration is ambiguous
+        # and is skipped with a warning.  Suffix inference may still
+        # pair USB_D+/USB_D- on its own merit afterwards.
+        net_names = {1: "USB_D+", 2: "USB_D_P", 3: "USB_D-"}
+        nc = NetClassRouting(name="HS", diffpair_partner="USB_D-")
+        with caplog.at_level(logging.WARNING):
+            out = detect_diff_pairs(
+                net_names,
+                net_class_routing={"HS": nc},
+                net_to_class={"USB_D+": "HS", "USB_D_P": "HS", "USB_D-": "HS"},
+            )
+        assert all(p.source != DetectionSource.EXPLICIT for p in out)
+        assert any("polarity counterparts" in r.message for r in caplog.records)
+
+
+# =============================================================================
 # 6. KiCad group
 # =============================================================================
 

--- a/tests/test_diffpair_partner_wiring.py
+++ b/tests/test_diffpair_partner_wiring.py
@@ -42,7 +42,6 @@ from kicad_tools.router.rules import (
     NetClassRouting,
 )
 
-
 # =============================================================================
 # Python pathfinder set_net_name_to_id / _resolve_partner_net_id
 # =============================================================================
@@ -259,7 +258,6 @@ class TestAutorouterPrepareRouting:
         """Multiple calls to _prepare_routing leave net_class_map stable."""
         ar = self._build_autorouter_with_usb_pair()
         ar._prepare_routing()
-        first_plus = ar.net_class_map["USB_D+"]
         ar._prepare_routing()
         second_plus = ar.net_class_map["USB_D+"]
         # Either the same dataclass-replaced object is reused OR an
@@ -298,6 +296,35 @@ class TestAutorouterPrepareRouting:
         assert "" not in ar.router._net_name_to_id
         assert ar.router._net_name_to_id == {"REAL_NET": 1}
 
+    def test_prepare_routing_partner_annotation_does_not_pollute_class(self):
+        """Issue #3455 regression: a board-recipe partner annotation on
+        USB_D+ (net-name-keyed, shared class 'HighSpeed') must not fan
+        out to USB_CC1/USB_CC2 through the class-name-keyed synth lookup,
+        and must not clobber USB_D-'s true partner.
+        """
+        ar = Autorouter(width=20.0, height=20.0)
+        for nid, name in enumerate(["USB_D+", "USB_D-", "USB_CC1", "USB_CC2"], start=1):
+            ar.nets[nid] = [("J1", str(nid))]
+            ar.net_names[nid] = name
+            ar.net_class_map[name] = NET_CLASS_HIGH_SPEED
+
+        # Board-03-recipe style annotation: per-net copy for USB_D+.
+        ar.net_class_map["USB_D+"] = dataclasses.replace(
+            NET_CLASS_HIGH_SPEED, diffpair_partner="USB_D-"
+        )
+
+        ar._prepare_routing()
+
+        assert ar.net_class_map["USB_D+"].diffpair_partner == "USB_D-"
+        assert ar.net_class_map["USB_D-"].diffpair_partner == "USB_D+"
+        # CC nets are single-ended configuration channels -- no partner,
+        # and no relaxed intra-pair clearance applied between unrelated
+        # nets.
+        assert ar.net_class_map["USB_CC1"].diffpair_partner is None
+        assert ar.net_class_map["USB_CC2"].diffpair_partner is None
+        # Shared singleton untouched.
+        assert NET_CLASS_HIGH_SPEED.diffpair_partner is None
+
 
 # =============================================================================
 # find_blocking_nets partner exclusion
@@ -312,9 +339,7 @@ class TestFindBlockingNetsPartnerExclusion:
         rules = DesignRules()
         grid = RoutingGrid(10.0, 10.0, rules)
         x_class = NetClassRouting(name="Diff", diffpair_partner="Y")
-        router = Router(
-            grid=grid, rules=rules, net_class_map={"X": x_class}
-        )
+        router = Router(grid=grid, rules=rules, net_class_map={"X": x_class})
         router.set_net_name_to_id({"X": 1, "Y": 2})
         return router, grid
 
@@ -391,9 +416,7 @@ class TestFindBlockingNetsPartnerExclusion:
         end_pad = self._make_pad(9.0, 5.0, net=1, net_name="X")
 
         blocking = router.find_blocking_nets(start_pad, end_pad)
-        assert 2 in blocking, (
-            "without partner declaration, net 2 is a regular blocker"
-        )
+        assert 2 in blocking, "without partner declaration, net 2 is a regular blocker"
 
 
 # =============================================================================


### PR DESCRIPTION
Closes #3455

## Summary

- `_gather_explicit_pairs` previously looked up `diffpair_partner` by CLASS name only, so the `synth_routing.setdefault(net_class.name, ...)` idiom in `router/core.py` (~3610) made the first net's annotated `NetClassRouting` instance fan out to every net of the class. On board 03, USB_D+'s `diffpair_partner='USB_D-'` annotation registered under `HighSpeed` paired USB_CC1/USB_CC2 (and a degenerate USB_D- self-pair) with USB_D-, applying relaxed 0.075 intra-pair clearance between unrelated nets and emitting bogus `diffpair_length_skew`/`diffpair_routing_continuity` advisories.
- New `_declared_partner_for_net` resolution: net-name-keyed entries are authoritative for that net only (preserving the documented arbitrary-name escape hatch, e.g. explicit CC1/CC2 pairing); class-name-keyed declarations are honored only when unambiguous — single candidate class member, or the unique polarity counterpart of the declared partner (`USB_D+` for `USB_D-`; `TX0`/`TX1`/`USB_CC2` never qualify). A net joins at most one pair; conflicting declarations keep the first and warn.
- Complements #3524 / PR #3585 (frozen `DEFAULT_NET_CLASS_MAP`): this fixes the lookup-side pollution rather than shared-instance mutation.

## Repro evidence

Before (main), board-03 synth_routing shape (`{USB_D+: annotated, ..., HighSpeed: annotated}`):

```
USB_D+ <-> USB_D-  EXPLICIT
USB_D- <-> USB_D-  EXPLICIT   (degenerate self-pair)
USB_CC1 <-> USB_D- EXPLICIT
USB_CC2 <-> USB_D- EXPLICIT
```

After (this branch): exactly `USB_D+ <-> USB_D-` (EXPLICIT), CC nets unpaired, `net_class_map['USB_CC2'].diffpair_partner is None`.

## Test plan

- [x] `tests/test_diffpair_detection.py` + `tests/test_diffpair_partner_wiring.py`: 83 passed (incl. new `TestClassKeyedFanOut` near-miss suite: CC1/CC2, TX0/TX1 bus indices, pure class-keyed maps, ambiguous polarity rivals, conflicting declarations; new `_prepare_routing` pollution regression)
- [x] Broader diffpair suite (corridor, coupled-floor, npad, phase-b, shadow, length/tuning, serpentine, swap-via, escape, impedance, validate/CLI checkers, timeouts, routing integration, board 06): 541 passed
- [x] Board-03 + USB fast tests (`test_board_03_regression.py`, `test_usb_interface.py`): 50 passed, 1 skipped
- [x] `ruff check` / `ruff format --check` clean on the three changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)