### PR TITLE
fix(pcb): make_valid + keep-largest for invalid board outlines (#3614)

### DIFF
--- a/src/kicad_tools/pcb/board_geometry.py
+++ b/src/kicad_tools/pcb/board_geometry.py
@@ -21,9 +21,12 @@ Usage::
 
 from __future__ import annotations
 
+import logging
 import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from kicad_tools.schema.pcb import PCB
@@ -156,6 +159,77 @@ def _linearize_bezier(
             ]
         points.append(work[0])
     return points
+
+
+# ---------------------------------------------------------------------------
+# Outline repair
+# ---------------------------------------------------------------------------
+
+
+def _repair_outline_polygon(poly: Any) -> Any:
+    """Repair an invalid board-outline polygon, keeping the largest piece.
+
+    Self-intersecting outlines (bowties) split into multiple lobes when
+    repaired.  ``buffer(0)`` silently drops the negatively-wound lobe,
+    which *shrinks* the keep-in area -- a conservative failure (routing
+    refuses space that exists) but an invisible one (Issue #3614).
+    ``shapely.make_valid`` keeps every lobe, so we can make a deliberate
+    choice: ``BoardGeometry`` is single-Polygon by design (its Edge.Cuts
+    path also keeps only the largest piece), so keep the largest lobe
+    and log a WARNING naming the area that was discarded.
+
+    ``make_valid`` may return a GeometryCollection when part of the
+    outline collapses to zero-area linework; only polygonal components
+    contribute board area, so extract those (mirrors
+    ``_repair_fill_polygon`` in ``validate/rules/clearance.py``,
+    PR #3613).
+
+    Raises:
+        ValueError: If no polygonal area survives the repair (fully
+            degenerate outline).
+    """
+    from shapely import make_valid
+    from shapely.geometry import GeometryCollection
+    from shapely.geometry import MultiPolygon as ShapelyMultiPolygon
+
+    repaired = make_valid(poly)
+
+    pieces: list[Any] = []
+    if isinstance(repaired, ShapelyPolygon):
+        pieces = [repaired]
+    elif isinstance(repaired, ShapelyMultiPolygon):
+        pieces = list(repaired.geoms)
+    elif isinstance(repaired, GeometryCollection):
+        for geom in repaired.geoms:
+            if isinstance(geom, ShapelyPolygon):
+                pieces.append(geom)
+            elif isinstance(geom, ShapelyMultiPolygon):
+                pieces.extend(geom.geoms)
+
+    pieces = [p for p in pieces if not p.is_empty]
+    if not pieces:
+        raise ValueError(
+            "Board outline is degenerate: repairing the invalid polygon "
+            "produced no polygonal area."
+        )
+
+    if len(pieces) == 1:
+        return pieces[0]
+
+    pieces.sort(key=lambda p: p.area, reverse=True)
+    largest = pieces[0]
+    dropped_area = sum(p.area for p in pieces[1:])
+    logger.warning(
+        "Invalid board outline split into %d pieces after repair; "
+        "keeping the largest (%.4f mm^2) and dropping %d piece(s) "
+        "totalling %.4f mm^2.  The keep-in area shrank -- check the "
+        "outline for self-intersections.",
+        len(pieces),
+        largest.area,
+        len(pieces) - 1,
+        dropped_area,
+    )
+    return largest
 
 
 # ---------------------------------------------------------------------------
@@ -302,9 +376,16 @@ class BoardGeometry:
 
         Useful for testing or when outline points are already extracted.
 
+        Invalid (self-intersecting) outlines are repaired via
+        ``shapely.make_valid``; if the repair splits the outline into
+        multiple pieces, the largest is kept and a WARNING is logged
+        naming the dropped area (see :func:`_repair_outline_polygon`).
+
         Raises:
             ImportError: If Shapely is not installed.
-            ValueError: If fewer than 3 points are provided.
+            ValueError: If fewer than 3 points are provided, or the
+                outline is fully degenerate (no polygonal area survives
+                repair).
         """
         if not _SHAPELY_AVAILABLE:
             raise ImportError(
@@ -317,8 +398,9 @@ class BoardGeometry:
 
         poly = ShapelyPolygon(points)
         if not poly.is_valid:
-            # Attempt to fix via buffer(0) -- common Shapely trick
-            poly = poly.buffer(0)
+            # make_valid + keep-largest (NOT buffer(0), which silently
+            # drops bowtie lobes and shrinks the keep-in -- Issue #3614).
+            poly = _repair_outline_polygon(poly)
         return cls(polygon=poly, origin=origin)
 
     @classmethod

--- a/tests/test_board_geometry.py
+++ b/tests/test_board_geometry.py
@@ -87,6 +87,57 @@ class TestConstruction:
         with pytest.raises(ValueError, match="at least 3"):
             BoardGeometry.from_outline_points([(0, 0), (1, 1)])
 
+    def test_valid_outline_is_identity_and_silent(self, caplog):
+        """A valid outline passes through unchanged, with no warning."""
+        from shapely.geometry import Polygon as ShapelyPolygon
+
+        points = [(0.0, 0.0), (50.0, 0.0), (50.0, 30.0), (0.0, 30.0)]
+        with caplog.at_level(
+            "WARNING", logger="kicad_tools.pcb.board_geometry"
+        ):
+            geom = BoardGeometry.from_outline_points(points)
+        assert geom.polygon.equals(ShapelyPolygon(points))
+        assert geom.area == pytest.approx(50.0 * 30.0)
+        assert caplog.records == []
+
+    def test_bowtie_outline_keeps_largest_lobe_and_warns(self, caplog):
+        """A self-intersecting bowtie keeps the largest lobe and warns.
+
+        Pins the Issue #3614 behavior: make_valid splits the bowtie into
+        two lobes; the larger one becomes the board outline and a
+        WARNING names the dropped area (buffer(0) used to do this
+        silently).
+        """
+        # Ring (0,0)->(10,0)->(0,3)->(4,3)->close self-intersects at
+        # (20/7, 15/7), splitting into:
+        #   - large lobe: triangle (0,0),(10,0),X  -> area 75/7
+        #   - small lobe: triangle X,(0,3),(4,3)   -> area 12/7
+        points = [(0.0, 0.0), (10.0, 0.0), (0.0, 3.0), (4.0, 3.0)]
+        with caplog.at_level(
+            "WARNING", logger="kicad_tools.pcb.board_geometry"
+        ):
+            geom = BoardGeometry.from_outline_points(points)
+
+        # Largest lobe kept, smaller lobe dropped
+        assert geom.polygon.geom_type == "Polygon"
+        assert geom.polygon.is_valid
+        assert geom.area == pytest.approx(75.0 / 7.0)
+
+        # Exactly one WARNING naming the kept and dropped areas
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1
+        msg = warnings[0].getMessage()
+        assert "keeping the largest" in msg
+        assert f"{75.0 / 7.0:.4f}" in msg  # kept area
+        assert f"{12.0 / 7.0:.4f}" in msg  # dropped area
+
+    def test_degenerate_outline_raises(self):
+        """Collinear points yield no polygonal area -> ValueError."""
+        with pytest.raises(ValueError, match="degenerate"):
+            BoardGeometry.from_outline_points(
+                [(0.0, 0.0), (1.0, 1.0), (2.0, 2.0)]
+            )
+
     def test_exterior_coords(self):
         geom = _rect_geometry(0, 0, 10, 10)
         coords = geom.exterior_coords


### PR DESCRIPTION
Closes #3614

## Summary
- `BoardGeometry.from_outline_points` no longer repairs invalid (self-intersecting) outlines with `buffer(0)`, which silently dropped bowtie lobes and shrank the keep-in area conservatively but invisibly.
- New `_repair_outline_polygon` helper uses `shapely.make_valid`, extracts polygonal pieces (handling Polygon / MultiPolygon / GeometryCollection output, mirroring `_repair_fill_polygon` from PR #3613), keeps the largest piece (preserving BoardGeometry's single-Polygon semantics, matching the Edge.Cuts path), and logs a WARNING naming both the kept area and the total dropped area.
- Valid outlines are an identity pass-through with no warning; fully degenerate outlines (no polygonal area survives repair) now raise `ValueError` instead of returning an empty geometry.

## Tests
- `test_bowtie_outline_keeps_largest_lobe_and_warns`: bowtie ring splitting into 75/7 mm^2 and 12/7 mm^2 lobes — asserts the largest lobe is kept, result is a valid single Polygon, and exactly one WARNING names both areas.
- `test_valid_outline_is_identity_and_silent`: valid rectangle passes through geometrically unchanged with zero warning records.
- `test_degenerate_outline_raises`: collinear points raise `ValueError`.
- Full `tests/test_board_geometry.py`: 39 passed.

## Notes
- No production consumers of `from_outline_points` outside tests; `from_pcb` is unaffected (it never used `buffer(0)`).
- Pre-existing (on clean main) `ruff check`/`ruff format` complaints on both touched files (`F401` unused `MultiPolygon` import guard, `I001` import sort, format drift) were left as-is to avoid unrelated churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)