### PR TITLE
fix(export): aux-origin branch resolves config through formatter (JLCPCB exclude_tht)

### DIFF
--- a/src/kicad_tools/export/pnp.py
+++ b/src/kicad_tools/export/pnp.py
@@ -10,7 +10,7 @@ import csv
 import io
 import re
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -547,33 +547,26 @@ def export_pnp(
     Returns:
         Formatted CPL as CSV string
     """
+    # Resolve the effective config through the formatter FIRST so
+    # manufacturer defaults (e.g., JLCPCB defaults to exclude_tht=True)
+    # apply regardless of which branch below runs.  The formatter is the
+    # single source of truth for the effective config; synthesizing a
+    # config here would silently drop those defaults (issue #3618).
+    formatter = get_pnp_formatter(manufacturer, config, rotation_corrections)
+    config = formatter.config
+
     # Auto-apply auxiliary origin offset when a PCB path is provided
-    if config is not None and pcb_path is not None and config.use_aux_origin:
+    if pcb_path is not None and config.use_aux_origin:
         aux_x, aux_y = get_aux_origin(pcb_path)
         if aux_x != 0.0 or aux_y != 0.0:
-            config = PnPExportConfig(
+            # dataclasses.replace preserves every other field of the
+            # effective config (exclude_tht, include_dnp, ...).
+            config = replace(
+                config,
                 x_offset=config.x_offset - aux_x,
                 y_offset=config.y_offset - aux_y,
-                mirror_x=config.mirror_x,
-                mirror_y=config.mirror_y,
-                use_aux_origin=config.use_aux_origin,
-                include_dnp=config.include_dnp,
-                exclude_tht=config.exclude_tht,
-                top_only=config.top_only,
-                bottom_only=config.bottom_only,
-                rotation_offset=config.rotation_offset,
             )
-    elif config is None and pcb_path is not None:
-        # Check aux origin with default config settings
-        aux_x, aux_y = get_aux_origin(pcb_path)
-        if aux_x != 0.0 or aux_y != 0.0:
-            config = PnPExportConfig(
-                x_offset=-aux_x,
-                y_offset=-aux_y,
-            )
+            formatter = get_pnp_formatter(manufacturer, config, rotation_corrections)
 
-    # Let the formatter provide its own default config (e.g., JLCPCB
-    # defaults to exclude_tht=True) when the caller did not supply one.
-    formatter = get_pnp_formatter(manufacturer, config, rotation_corrections)
     placements = extract_placements(footprints, formatter.config)
     return formatter.format(placements)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -21,9 +21,9 @@ from kicad_tools.export.pnp import (
     GenericPnPFormatter,
     JLCPCBPnPFormatter,
     PCBWayPnPFormatter,
-    SeeedPnPFormatter,
     PlacementData,
     PnPExportConfig,
+    SeeedPnPFormatter,
     export_pnp,
     extract_placements,
     extract_tht_exclusions,
@@ -524,6 +524,76 @@ class TestExportPnPWithAuxOrigin:
         ]
         output = export_pnp(footprints, "jlcpcb", config=config, pcb_path=fixture)
         # 10 + 5 = 15, 20 + (-3) = 17
+        assert "15.0000mm" in output
+        assert "17.0000mm" in output
+
+    def test_aux_origin_config_none_jlcpcb_excludes_tht(self, tmp_path):
+        """Aux-origin branch + config=None must honor JLCPCB's exclude_tht default.
+
+        Regression test for issue #3618: the aux-origin branch used to
+        synthesize a bare PnPExportConfig when config was None, silently
+        dropping the JLCPCB formatter's exclude_tht=True default.  The CPL
+        would then include THT rows while the hand-solder set (computed from
+        the formatter's effective config) listed the same parts as excluded —
+        a CPL/exclusion divergence.
+        """
+        # Build a PCB with a NONZERO aux origin so the branch actually fires.
+        fixture = Path(__file__).parent / "fixtures" / "projects" / "multilayer_zones.kicad_pcb"
+        pcb_text = fixture.read_text().replace("(aux_axis_origin 0 0)", "(aux_axis_origin 100 50)")
+        assert "(aux_axis_origin 100 50)" in pcb_text
+        pcb_path = tmp_path / "aux_origin.kicad_pcb"
+        pcb_path.write_text(pcb_text)
+        assert get_aux_origin(pcb_path) == (100.0, 50.0)
+
+        footprints = [
+            MockFootprint("R1", "10k", "0402", (110.0, 70.0), 0.0, "F.Cu", attr="smd"),
+            MockFootprint(
+                "J1",
+                "Conn_01x04",
+                "PinHeader_1x04",
+                (150.0, 60.0),
+                0.0,
+                "F.Cu",
+                attr="through_hole",
+            ),
+        ]
+
+        output = export_pnp(footprints, "jlcpcb", config=None, pcb_path=pcb_path)
+
+        # THT component excluded from the CPL (JLCPCB default)...
+        assert "J1" not in output
+        # ...while the SMD part remains, shifted by the aux origin:
+        # 110 - 100 = 10, 70 - 50 = 20.
+        assert "R1" in output
+        assert "10.0000mm" in output
+        assert "20.0000mm" in output
+
+        # The hand-solder set computed from the formatter's effective config
+        # (the assembly.py pattern) must AGREE with the CPL: J1 is listed.
+        effective = get_pnp_formatter("jlcpcb", None).config
+        excluded = extract_tht_exclusions(footprints, effective)
+        assert [p.reference for p in excluded] == ["J1"]
+
+    def test_aux_origin_explicit_config_fields_preserved(self, tmp_path):
+        """dataclasses.replace path keeps all caller-set fields intact."""
+        fixture = Path(__file__).parent / "fixtures" / "projects" / "multilayer_zones.kicad_pcb"
+        pcb_text = fixture.read_text().replace("(aux_axis_origin 0 0)", "(aux_axis_origin 100 50)")
+        pcb_path = tmp_path / "aux_origin.kicad_pcb"
+        pcb_path.write_text(pcb_text)
+
+        config = PnPExportConfig(x_offset=5.0, y_offset=-3.0, exclude_tht=False)
+        footprints = [
+            MockFootprint("R1", "10k", "0402", (110.0, 70.0), 0.0, "F.Cu", attr="smd"),
+            MockFootprint(
+                "J1", "Conn", "PinHeader", (150.0, 60.0), 0.0, "F.Cu", attr="through_hole"
+            ),
+        ]
+        output = export_pnp(footprints, "jlcpcb", config=config, pcb_path=pcb_path)
+
+        # Explicit exclude_tht=False overrides the JLCPCB default: J1 stays.
+        assert "J1" in output
+        # Manual offsets combine with aux origin: 110 + 5 - 100 = 15,
+        # 70 + (-3) - 50 = 17.
         assert "15.0000mm" in output
         assert "17.0000mm" in output
 


### PR DESCRIPTION
Closes #3618

## Summary
- `export_pnp`'s aux-origin branch synthesized a bare `PnPExportConfig` when `config=None`, defeating the JLCPCB formatter's `exclude_tht=True` default (judge-found in PR #3616). A caller hitting that branch would ship THT rows in the CPL while the hand-solder set (`tht_excluded`) listed those same parts — a CPL/exclusion divergence.
- Fix: resolve the effective config through `get_pnp_formatter(manufacturer, config, rotation_corrections)` BEFORE any branching, making the formatter the single source of truth. The aux-origin offset adjustment now uses `dataclasses.replace()`, preserving all other fields (`exclude_tht`, `include_dnp`, `top_only`, ...) instead of hand-copying them, then rebuilds the formatter with the adjusted config.
- Both `config=None` branches collapse into one path; the old `elif config is None` branch (the bug site) is gone entirely.

## Tests
- `test_aux_origin_config_none_jlcpcb_excludes_tht` — the divergence test from the issue: nonzero aux origin + `config=None` + JLCPCB → THT excluded from CPL, SMD coordinates correctly shifted by the aux origin, and `extract_tht_exclusions` with the formatter's effective config lists the same THT part (CPL and hand-solder set agree).
- `test_aux_origin_explicit_config_fields_preserved` — explicit `exclude_tht=False` + manual offsets survive the `replace()` path (offsets combine with aux origin; THT kept).

## Audit of synthesized-config sites (per issue ask)
- `src/kicad_tools/export/pnp.py` — aux-origin branch: FIXED here. `extract_placements`/`extract_tht_exclusions` default to `PnPExportConfig()` only as generic-helper fallbacks; all manufacturer-aware callers pass the formatter's effective config. OK.
- `src/kicad_tools/export/assembly.py` — `_generate_pnp` passes `self.config.pnp_config` (possibly None) straight to `export_pnp` and computes `tht_excluded` from `get_pnp_formatter(...).config`. Already correct (this is the #3616 pattern). No aux-origin path reached from assembly (no `pcb_path` passed).
- `src/kicad_tools/cli/export_cmd.py:261` — `PnPExportConfig(exclude_tht=False)` is intentional (`--include-tht` flag). OK.
- `src/kicad_tools/schema/pcb.py:4943` — `PCB.export_placement()` synthesizes `PnPExportConfig()` and passes it to `export_pnp`, defeating the JLCPCB default the same way (latent, out of scope for this issue's files). Filed as a follow-up issue.

## Test results
- `tests/test_export.py` + `tests/test_manufacturing_package.py`: 129 passed
- `tests/test_report_generator.py`, `tests/test_preflight.py`, `tests/test_export_cmd.py`, `tests/test_pcb_manufacturing_export.py` (#3616-adjacent THT coverage): 228 passed
- `ruff check` clean on changed files; pre-existing `ruff format` drift at pnp.py:99 (unrelated line, present on main) left untouched. A pre-existing import-sort lint error in `tests/test_export.py` (present on main) was autofixed since the file is part of this change.