### PR TITLE
fix(export): export_placement resolves config through formatter for JLCPCB exclude_tht

### DIFF
--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -4925,7 +4925,6 @@ class PCB:
             >>> # JLCPCB format
             >>> pcb.export_placement("cpl_jlcpcb.csv", format="jlcpcb")
         """
-        from ..export import PnPExportConfig
         from ..export import export_pnp as _export_pnp
 
         footprints = list(self.footprints)
@@ -4940,8 +4939,11 @@ class PCB:
         if format.lower() in ("jlcpcb", "pcbway"):
             mfr = format.lower()
 
-        config = PnPExportConfig()
-        pnp_csv = _export_pnp(footprints, mfr, config)
+        # Pass config=None so the formatter resolves the effective config —
+        # the single source of truth (issues #3616/#3618).  Synthesizing a
+        # bare PnPExportConfig() here would defeat manufacturer defaults such
+        # as JLCPCB's exclude_tht=True, shipping THT rows in the CPL.
+        pnp_csv = _export_pnp(footprints, mfr, config=None)
 
         # Write to file
         output_path = Path(output)

--- a/tests/test_pcb_manufacturing_export.py
+++ b/tests/test_pcb_manufacturing_export.py
@@ -73,6 +73,50 @@ class TestExportPlacement:
             assert result == output
             assert output.exists()
 
+    def test_export_placement_jlcpcb_excludes_tht(self, test_project_pcb, tmp_path):
+        """export_placement(format="jlcpcb") must honor JLCPCB's exclude_tht default.
+
+        Regression test for issue #3627: export_placement() used to synthesize a
+        bare PnPExportConfig() and pass it to export_pnp(), defeating the JLCPCB
+        formatter's exclude_tht=True default.  The CPL would then ship THT rows,
+        diverging from export_pnp(..., config=None).  Passing config=None lets the
+        formatter resolve the effective config (single source of truth, #3616/#3618).
+        """
+        # Inject a through-hole footprint into the SMD-only fixture so the
+        # JLCPCB exclude_tht default has something to act on.
+        tht_footprint = (
+            '\t(footprint "Connector_PinHeader_2.54mm:PinHeader_1x04"\n'
+            '\t\t(layer "F.Cu")\n'
+            '\t\t(uuid "fp-j1-uuid")\n'
+            "\t\t(at 160 50)\n"
+            "\t\t(attr through_hole)\n"
+            '\t\t(property "Reference" "J1" (at 0 -1.5) (layer "F.SilkS") (uuid "ref-j1"))\n'
+            '\t\t(property "Value" "Conn_01x04" (at 0 1.5) (layer "F.Fab") (uuid "val-j1"))\n'
+            '\t\t(pad "1" thru_hole circle (at 0 0) (size 1.7 1.7) (drill 1.0) '
+            '(layers "*.Cu" "*.Mask") (net 2 "GND"))\n'
+            "\t)\n"
+        )
+        original = Path(test_project_pcb).read_text()
+        # Insert the THT footprint before the final closing paren of the board.
+        patched = original.rstrip()
+        assert patched.endswith(")")
+        patched = patched[:-1] + tht_footprint + ")\n"
+
+        pcb_path = tmp_path / "with_tht.kicad_pcb"
+        pcb_path.write_text(patched)
+
+        pcb = PCB.load(pcb_path)
+
+        output = tmp_path / "cpl_jlcpcb.csv"
+        pcb.export_placement(output, format="jlcpcb")
+        content = output.read_text()
+
+        # THT part excluded from the CPL by JLCPCB's exclude_tht default...
+        assert "J1" not in content
+        # ...while SMD parts remain.
+        assert "R1" in content
+        assert "C1" in content
+
     def test_export_placement_top_only(self, test_project_pcb):
         """Should export only top-side components."""
         pcb = PCB.load(test_project_pcb)


### PR DESCRIPTION
## Summary
`PCB.export_placement()` synthesized a bare `PnPExportConfig()` and passed it to `export_pnp()`, which prevented the JLCPCB formatter from applying its `exclude_tht=True` default. As a result `pcb.export_placement("cpl.csv", format="jlcpcb")` shipped THT rows in the CPL — diverging from `export_pnp(..., config=None)` and from the assembly-package path. This is the same latent bug class fixed in PR #3626 for `export/pnp.py`, applied here to the `schema/pcb.py` caller.

## Changes
- `src/kicad_tools/schema/pcb.py` (`PCB.export_placement`): pass `config=None` to `export_pnp` so the formatter resolves the effective config (single source of truth, #3616/#3618). Dropped the now-unused `PnPExportConfig` import in that method.
- `tests/test_pcb_manufacturing_export.py`: added `test_export_placement_jlcpcb_excludes_tht`, which injects a through-hole footprint into the fixture and asserts the JLCPCB CPL excludes it while keeping SMD parts (R1, C1).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Pass `config=None` so formatter resolves effective config | done | `export_placement` now calls `_export_pnp(footprints, mfr, config=None)` |
| Test: `export_placement(format="jlcpcb")` on a board with a THT footprint excludes it from the CPL | done | New `test_export_placement_jlcpcb_excludes_tht`; asserts `"J1" not in content`, `"R1"`/`"C1"` present |
| Check existing `test_export_placement_jlcpcb` for THT-row assumptions | done | Existing test only asserts file existence, no THT-row assumptions; no update needed |

## Test Plan
- `uv run pytest tests/test_pcb_manufacturing_export.py` — 24 passed.
- Confirmed the new test is a meaningful regression guard: with the `pcb.py` fix stashed, `test_export_placement_jlcpcb_excludes_tht` FAILS (J1 THT row present in CPL); with the fix applied it passes.
- `ruff check`/`ruff format` on changed regions clean. Pre-existing lint errors (`MagicMock` unused at line 5, `mock_render` unused at line 439) and pre-existing format drift (lines 159/321/360) in `test_pcb_manufacturing_export.py` exist on main and are out of scope — left untouched.

Closes #3627