### PR TITLE
fix(build-native): auto-rebuild when C++ source is newer than installed .so

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,4 +24,16 @@ new git worktrees (`.loom/worktrees/issue-N/`) need this step explicitly.
 The C++ backend gives a 10-100x speedup for the A* loop, so a missing
 extension is the most likely cause of multi-minute-per-net routing.
 
+### Rebuilding after editing C++ sources
+
+`kct build-native` now detects staleness automatically: it compares the
+newest mtime of `src/kicad_tools/router/cpp/**` (`.cpp`/`.hpp` and
+`CMakeLists.txt`) against the installed `.so` and **rebuilds when the
+source is newer**, even without a `BUILD_VERSION` bump. When the `.so` is
+already up to date it prints `SKIPPED rebuild` instead of the old
+misleading `installed successfully!`.
+
+`--force` always recompiles regardless of mtimes — reach for it if you
+suspect the auto-detection missed something (e.g. a touched build flag).
+
 See `README.md` "Fresh worktree checklist" for the full setup sequence.

--- a/src/kicad_tools/cli/build_native_cmd.py
+++ b/src/kicad_tools/cli/build_native_cmd.py
@@ -30,6 +30,7 @@ class BuildResult:
     error_message: str | None = None
     steps_completed: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
+    skipped: bool = False
 
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON output."""
@@ -40,6 +41,7 @@ class BuildResult:
             "error_message": self.error_message,
             "steps_completed": self.steps_completed,
             "warnings": self.warnings,
+            "skipped": self.skipped,
         }
 
 
@@ -92,6 +94,64 @@ def _get_cpp_source_dir() -> Path | None:
     if cpp_dir.exists():
         return cpp_dir
     return None
+
+
+def _find_installed_so(router_dir: Path) -> Path | None:
+    """Return the installed router_cpp extension (.so/.pyd), if any."""
+    for pattern in ("router_cpp.*.so", "router_cpp.*.pyd"):
+        for so_file in router_dir.glob(pattern):
+            return so_file
+    return None
+
+
+def _newest_cpp_source_mtime(cpp_dir: Path) -> float | None:
+    """Return the newest mtime among C++ source/header files under ``cpp_dir``.
+
+    Scans recursively for ``*.cpp`` and ``*.hpp`` (plus the common ``*.cc``,
+    ``*.h``, ``*.hxx`` variants and ``CMakeLists.txt``) so that any edit to the
+    build inputs is detected.  Returns ``None`` when no source files are found.
+    """
+    newest: float | None = None
+    patterns = ("*.cpp", "*.cc", "*.cxx", "*.hpp", "*.hxx", "*.h", "CMakeLists.txt")
+    for pattern in patterns:
+        for source in cpp_dir.rglob(pattern):
+            try:
+                mtime = source.stat().st_mtime
+            except OSError:
+                continue
+            if newest is None or mtime > newest:
+                newest = mtime
+    return newest
+
+
+def _is_so_stale(router_dir: Path) -> bool:
+    """Decide whether the installed .so is older than its C++ sources.
+
+    Returns ``True`` (rebuild needed) when the newest C++ source mtime is
+    strictly greater than the installed extension's mtime.  Returns ``False``
+    when the .so is up to date, when there is no .so to compare against, or
+    when the source tree cannot be located (e.g. a pip-installed wheel without
+    bundled sources) -- in those cases we defer to the existing
+    version-matching guard rather than forcing a rebuild we cannot perform.
+    """
+    so_file = _find_installed_so(router_dir)
+    if so_file is None:
+        return False
+
+    cpp_dir = _get_cpp_source_dir()
+    if cpp_dir is None:
+        return False
+
+    newest_source = _newest_cpp_source_mtime(cpp_dir)
+    if newest_source is None:
+        return False
+
+    try:
+        so_mtime = so_file.stat().st_mtime
+    except OSError:
+        return False
+
+    return newest_source > so_mtime
 
 
 def _get_project_root() -> Path | None:
@@ -190,20 +250,35 @@ def build_native(
     result = BuildResult(success=False)
     router_dir = _get_package_root() / "router"
 
-    # Check if already installed (unless force)
+    # Check if already installed (unless force).
+    #
+    # Issue #3621: a matching-version .so short-circuits the build, but the
+    # version guard offers no protection during development when the C++
+    # source changes WITHOUT a version bump -- the most common iteration loop.
+    # Compare the newest source mtime against the installed extension and fall
+    # through to a real rebuild when the source is newer.  Only short-circuit
+    # (and clearly report SKIPPED) when the .so is genuinely up to date.
     if not force:
         try:
             from kicad_tools.router.cpp_backend import is_cpp_available
 
             if is_cpp_available():
-                result.success = True
-                result.backend_installed = True
-                result.steps_completed.append("C++ backend already installed")
-                # Find the .so file
-                for so_file in router_dir.glob("router_cpp.*.so"):
-                    result.so_path = so_file
-                    break
-                return result
+                if _is_so_stale(router_dir):
+                    if verbose:
+                        print("C++ source is newer than the installed extension -- rebuilding.")
+                    result.steps_completed.append(
+                        "C++ source newer than installed .so -- rebuilding"
+                    )
+                else:
+                    result.success = True
+                    result.backend_installed = True
+                    result.skipped = True
+                    result.steps_completed.append(
+                        "C++ backend already installed (up to date) -- skipped rebuild"
+                    )
+                    # Find the .so file
+                    result.so_path = _find_installed_so(router_dir)
+                    return result
         except ImportError:
             pass
 
@@ -394,7 +469,16 @@ def format_result_text(result: BuildResult) -> str:
     lines = []
 
     if result.success:
-        if result.backend_installed:
+        if result.skipped:
+            lines.append(
+                "C++ backend already installed -- SKIPPED rebuild (use --force to recompile)"
+            )
+            lines.append("")
+            if result.so_path:
+                lines.append(f"  Extension: {result.so_path.name}")
+            lines.append("")
+            lines.append("Run `kct route --backend cpp` to use the C++ backend.")
+        elif result.backend_installed:
             lines.append("C++ backend installed successfully!")
             lines.append("")
             if result.so_path:

--- a/tests/test_build_native_staleness.py
+++ b/tests/test_build_native_staleness.py
@@ -1,0 +1,175 @@
+"""Tests for ``kct build-native`` staleness detection (Issue #3621).
+
+``build_native`` used to short-circuit whenever a matching-version
+``router_cpp.*.so`` was installed, printing ``C++ backend installed
+successfully!`` while compiling nothing.  This caused dev cycles to validate
+against a stale binary when the C++ source was edited without a version bump.
+
+These tests pin the mtime-based auto-rebuild behavior:
+
+* When the C++ source is newer than the installed ``.so`` the command must
+  fall through to a real rebuild (default behavior, no ``--force`` needed).
+* When the ``.so`` is up to date the command skips and reports ``SKIPPED``
+  (no longer the misleading ``installed successfully!``).
+
+They exercise the pure decision helpers and the short-circuit branch of
+``build_native`` with mocks -- no cmake / compiler is invoked.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest import mock
+
+import kicad_tools.cli.build_native_cmd as bnc
+
+
+def _make_so(router_dir: Path, mtime: float) -> Path:
+    """Create a fake installed router_cpp .so with a fixed mtime."""
+    so_file = router_dir / "router_cpp.cpython-311-fake.so"
+    so_file.write_bytes(b"\x00")
+    os.utime(so_file, (mtime, mtime))
+    return so_file
+
+
+def _make_cpp_source(cpp_dir: Path, name: str, mtime: float) -> Path:
+    """Create a fake C++ source/header file with a fixed mtime."""
+    src_dir = cpp_dir / "src"
+    src_dir.mkdir(parents=True, exist_ok=True)
+    source = src_dir / name
+    source.write_text("// fake\n")
+    os.utime(source, (mtime, mtime))
+    return source
+
+
+class TestNewestCppSourceMtime:
+    def test_returns_none_when_no_sources(self, tmp_path: Path) -> None:
+        assert bnc._newest_cpp_source_mtime(tmp_path) is None
+
+    def test_returns_newest_across_extensions(self, tmp_path: Path) -> None:
+        _make_cpp_source(tmp_path, "pathfinder.cpp", 100.0)
+        (tmp_path / "include").mkdir()
+        hpp = tmp_path / "include" / "grid.hpp"
+        hpp.write_text("// header\n")
+        os.utime(hpp, (300.0, 300.0))
+        # CMakeLists.txt is also a build input
+        cmake = tmp_path / "CMakeLists.txt"
+        cmake.write_text("cmake\n")
+        os.utime(cmake, (200.0, 200.0))
+
+        assert bnc._newest_cpp_source_mtime(tmp_path) == 300.0
+
+
+class TestIsSoStale:
+    def test_false_when_no_so(self, tmp_path: Path, monkeypatch) -> None:
+        cpp_dir = tmp_path / "cpp"
+        _make_cpp_source(cpp_dir, "pathfinder.cpp", 100.0)
+        monkeypatch.setattr(bnc, "_get_cpp_source_dir", lambda: cpp_dir)
+        # router_dir has no .so
+        assert bnc._is_so_stale(tmp_path) is False
+
+    def test_false_when_so_newer(self, tmp_path: Path, monkeypatch) -> None:
+        router_dir = tmp_path / "router"
+        router_dir.mkdir()
+        cpp_dir = router_dir / "cpp"
+        _make_cpp_source(cpp_dir, "pathfinder.cpp", 100.0)
+        _make_so(router_dir, 200.0)  # so newer than source
+        monkeypatch.setattr(bnc, "_get_cpp_source_dir", lambda: cpp_dir)
+
+        assert bnc._is_so_stale(router_dir) is False
+
+    def test_true_when_source_newer(self, tmp_path: Path, monkeypatch) -> None:
+        router_dir = tmp_path / "router"
+        router_dir.mkdir()
+        cpp_dir = router_dir / "cpp"
+        _make_so(router_dir, 100.0)
+        _make_cpp_source(cpp_dir, "pathfinder.cpp", 200.0)  # source newer
+        monkeypatch.setattr(bnc, "_get_cpp_source_dir", lambda: cpp_dir)
+
+        assert bnc._is_so_stale(router_dir) is True
+
+    def test_false_when_no_cpp_dir(self, tmp_path: Path, monkeypatch) -> None:
+        router_dir = tmp_path / "router"
+        router_dir.mkdir()
+        _make_so(router_dir, 100.0)
+        # No source tree (pip wheel without bundled sources)
+        monkeypatch.setattr(bnc, "_get_cpp_source_dir", lambda: None)
+
+        assert bnc._is_so_stale(router_dir) is False
+
+
+def _patch_available(monkeypatch, available: bool) -> None:
+    """Make the lazy ``is_cpp_available`` import resolve to a stub."""
+    import kicad_tools.router.cpp_backend as cpp_backend
+
+    monkeypatch.setattr(cpp_backend, "is_cpp_available", lambda: available)
+
+
+class TestBuildNativeShortCircuit:
+    def test_skips_and_marks_skipped_when_up_to_date(self, monkeypatch) -> None:
+        _patch_available(monkeypatch, True)
+        monkeypatch.setattr(bnc, "_is_so_stale", lambda _router_dir: False)
+        fake_so = Path("/fake/router/router_cpp.cpython-311.so")
+        monkeypatch.setattr(bnc, "_find_installed_so", lambda _router_dir: fake_so)
+
+        result = bnc.build_native(force=False)
+
+        assert result.success is True
+        assert result.backend_installed is True
+        assert result.skipped is True
+        assert result.so_path == fake_so
+
+        text = bnc.format_result_text(result)
+        assert "SKIPPED rebuild" in text
+        assert "installed successfully" not in text
+
+    def test_rebuilds_when_source_is_stale(self, monkeypatch) -> None:
+        _patch_available(monkeypatch, True)
+        monkeypatch.setattr(bnc, "_is_so_stale", lambda _router_dir: True)
+
+        # Stub out the heavy build steps so the test stays fast: make the
+        # prerequisite check fail immediately *after* the short-circuit, which
+        # proves we fell through instead of skipping.
+        sentinel = mock.MagicMock(return_value=(False, "cmake stub: reached build path"))
+        monkeypatch.setattr(bnc, "_check_cmake", sentinel)
+
+        result = bnc.build_native(force=False)
+
+        # Did NOT short-circuit: it reached the prerequisite checks.
+        assert sentinel.call_count == 1
+        assert result.skipped is False
+        assert result.success is False
+        assert result.error_message == "cmake stub: reached build path"
+
+    def test_force_bypasses_short_circuit_entirely(self, monkeypatch) -> None:
+        _patch_available(monkeypatch, True)
+        # _is_so_stale must NOT be consulted when force=True.
+        stale_spy = mock.MagicMock(return_value=False)
+        monkeypatch.setattr(bnc, "_is_so_stale", stale_spy)
+        sentinel = mock.MagicMock(return_value=(False, "cmake stub"))
+        monkeypatch.setattr(bnc, "_check_cmake", sentinel)
+
+        result = bnc.build_native(force=True)
+
+        assert stale_spy.call_count == 0
+        assert sentinel.call_count == 1
+        assert result.skipped is False
+
+
+class TestFormatResultText:
+    def test_skipped_message_distinct_from_installed(self) -> None:
+        skipped = bnc.BuildResult(success=True, backend_installed=True, skipped=True)
+        installed = bnc.BuildResult(success=True, backend_installed=True, skipped=False)
+
+        skipped_text = bnc.format_result_text(skipped)
+        installed_text = bnc.format_result_text(installed)
+
+        assert "SKIPPED rebuild" in skipped_text
+        assert "installed successfully" not in skipped_text
+        assert "installed successfully" in installed_text
+
+
+def test_build_result_to_dict_includes_skipped() -> None:
+    result = bnc.BuildResult(success=True, skipped=True)
+    assert result.to_dict()["skipped"] is True


### PR DESCRIPTION
## Summary

`kct build-native` short-circuited whenever a matching-version `router_cpp.*.so` was installed: it compiled nothing but still printed `C++ backend installed successfully!`. During development the source is frequently edited without a `BUILD_VERSION` bump, so the version guard offered zero protection — devs validated hypotheses against a stale binary (e.g. the wasted bisect rounds in #3456).

This adds mtime-based staleness detection so the default behavior rebuilds when the C++ source is newer than the installed extension, and makes a genuine skip clearly visible.

## Changes

- Add `_find_installed_so`, `_newest_cpp_source_mtime`, and `_is_so_stale` helpers in `build_native_cmd.py`. `_newest_cpp_source_mtime` scans `router/cpp/**` recursively for `*.cpp`/`*.hpp` (and `.cc/.cxx/.hxx/.h`) plus `CMakeLists.txt`.
- In the `build_native` short-circuit (not `--force`): if `is_cpp_available()` but the source is newer than the `.so`, fall through to a real rebuild. Only skip when the `.so` is up to date.
- Add a `skipped` field to `BuildResult` (also surfaced in `to_dict`). When skipped, `format_result_text` now prints `C++ backend already installed -- SKIPPED rebuild (use --force to recompile)` instead of `installed successfully!`.
- `--force` still bypasses the staleness check entirely.
- Document the new auto-rebuild behavior in `CLAUDE.md`.
- New test module `tests/test_build_native_staleness.py`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| (1) Compare newest cpp/hpp source mtime vs installed .so; rebuild when source newer, by default | Done | `_is_so_stale` + short-circuit fall-through; `test_rebuilds_when_source_is_stale` proves it reaches the build path without `--force` |
| (2) Skip message is visible, not misleading | Done | `format_result_text` emits `SKIPPED rebuild (use --force to recompile)`; `test_skips_and_marks_skipped_when_up_to_date` and `test_skipped_message_distinct_from_installed` assert `"installed successfully"` is absent |
| (3) CLAUDE.md note on default staleness detection + `--force` | Done | "Rebuilding after editing C++ sources" section added |
| `--force` always recompiles | Done | `test_force_bypasses_short_circuit_entirely` asserts `_is_so_stale` is never consulted and the build path is entered |
| Tests added for staleness detection | Done | `tests/test_build_native_staleness.py` (11 tests) |

## Test Plan

- `uv run pytest tests/test_build_native_staleness.py` — 11 passed.
- `uv run pytest tests/test_router_cpp_auto_build.py` — existing auto-build suite still green (24 passed, 1 env-skip).
- `uv run ruff check` / `ruff format --check` on the changed files — clean.

Note: the issue's live repro (`touch pathfinder.cpp && uv run kct build-native`) assumes a pre-built `.so`; this fresh worktree has none (`build-native --check` reports "not installed"), so the staleness branches are covered via the unit tests above rather than a full cmake build.

Closes #3621