### PR TITLE
fix(router): batched resync re-marks same-net sibling cells after optimize loop

### DIFF
--- a/src/kicad_tools/router/optimizer/trace.py
+++ b/src/kicad_tools/router/optimizer/trace.py
@@ -61,6 +61,20 @@ def optimize_routes_grid_synced(
     optimized geometry is unchanged are skipped (the incremental
     unmark-old/mark-new perf shape).
 
+    Issue #3511: the incremental per-route unmark is net-guarded but
+    geometry-scoped -- ``grid.unmark_route(route)`` clears every cell the
+    OLD envelope owned, including cells that a same-net SIBLING route
+    (left geometry-unchanged by the optimizer) still occupies where the
+    two envelopes overlapped.  The per-route ``mark_route`` only re-marks
+    the mutated route's NEW geometry, so the sibling's cells inside the
+    old overlap region stay cleared and the grid under-blocks real
+    own-net copper.  To close that asymmetry we collect the
+    ``(old, new)`` pair for every mutated route and issue ONE batched
+    :meth:`RoutingGrid.resync_route_occupancy` after the loop: its step-4
+    affected-net re-mark restores the sibling cells, and its single
+    wholesale R-tree rebuild keeps the pass O(n) (calling resync per
+    route would re-rebuild the R-trees n times -- the O(n^2) trap).
+
     Args:
         router: ``Autorouter`` whose ``routes`` will be optimized and
             replaced in place.
@@ -79,6 +93,10 @@ def optimize_routes_grid_synced(
     """
     grid = router.grid
     optimized_routes: list[Route] = []
+    # Issue #3511: (old, new) pairs for every MUTATED route, replayed
+    # through a single batched resync after the loop so same-net sibling
+    # cells cleared by an incremental unmark are re-marked.
+    mutated_pairs: list[tuple[Route, Route]] = []
     for route in router.routes:
         if skip_nets is not None and route.net in skip_nets:
             optimized_routes.append(route)
@@ -97,11 +115,26 @@ def optimize_routes_grid_synced(
             continue
         # Incremental grid transaction: rip the old copper (cells +
         # R-trees + grid.routes + C++ mirror + stored-route snapshot
-        # invalidation), then commit the new copper on both grids.
+        # invalidation), then commit the new copper on both grids.  Route
+        # ``i`` must collision-check against the POST-opt copper of routes
+        # ``0..i-1``, so this stays incremental -- the batched resync
+        # below only repairs same-net sibling under-marking, it does not
+        # replace the per-route transaction.
         grid.unmark_route(route)
         grid.mark_route(optimized)
         grid._mark_route_on_cpp_cells(optimized)
+        mutated_pairs.append((route, optimized))
     router.routes = optimized_routes
+    # Issue #3511: ONE batched repair after the loop.  The incremental
+    # per-route ``unmark_route`` above clears every cell the old envelope
+    # owned, which can blank cells still occupied by a geometry-unchanged
+    # same-net sibling route where the envelopes overlapped; the per-route
+    # ``mark_route`` only re-marks the mutated route's new geometry.
+    # ``resync_route_occupancy``'s affected-net re-mark (its step 4)
+    # restores those sibling cells, and its single wholesale R-tree
+    # rebuild keeps the pass O(n) -- do NOT call it per route.
+    if mutated_pairs:
+        grid.resync_route_occupancy(mutated_pairs)
     return optimized_routes
 
 

--- a/tests/router/test_grid_resync_3507.py
+++ b/tests/router/test_grid_resync_3507.py
@@ -209,6 +209,52 @@ class TestResyncRouteOccupancy:
         _assert_marked(router.grid, mutated)
         _assert_unmarked(router.grid, snapshot.segments[0])
 
+    def test_resync_defers_cpp_unmark_inside_window(self):
+        """Issue #3511 secondary: with a corridor-reservation window open
+        (``begin_cpp_unmark_deferral``), ``resync_route_occupancy`` must
+        QUEUE the stale C++ unmark into ``_deferred_cpp_unmarks`` rather
+        than applying it immediately, and the flush must apply it -- the
+        same defer-don't-apply contract ``unmark_route`` honors.  This
+        branch (grid.py step 1) is otherwise unexercised because the
+        post-route passes run after the negotiated loop closes its
+        windows; the test pins it so a future in-window caller is
+        protected."""
+        router = _make_router()
+        grid = router.grid
+        live = _make_route(9, "I", [(5.0, 10.0), (20.0, 10.0)])
+        _commit(router, live)
+
+        snapshot = live.copy_geometry()
+        live.segments[0].y1 = 25.0
+        live.segments[0].y2 = 25.0
+
+        applied: list[Route] = []
+        with patch.object(
+            grid,
+            "_unmark_route_on_cpp_cells",
+            side_effect=lambda route, **_kw: applied.append(route),
+        ):
+            grid.begin_cpp_unmark_deferral()
+            changed = grid.resync_route_occupancy([(snapshot, live)])
+
+            assert changed == 1
+            # The stale C++ unmark is QUEUED, not applied, while the
+            # window is open.
+            assert applied == []
+            queued = [r for r, _mtw in grid._deferred_cpp_unmarks]
+            assert snapshot in queued
+
+            # Flushing the window applies exactly the queued stale unmark.
+            flushed = grid.flush_cpp_unmark_deferral()
+
+        assert snapshot in flushed
+        assert snapshot in applied
+        assert grid._deferred_cpp_unmarks == []
+        assert grid._cpp_unmark_deferred is False
+        # The Python grid is unaffected by deferral (unmarked immediately).
+        _assert_unmarked(grid, snapshot.segments[0])
+        _assert_marked(grid, live)
+
     def test_segment_rtree_rebuilt_from_current_geometry(self):
         router = _make_router()
         grid = router.grid
@@ -262,6 +308,58 @@ class TestOptimizeRoutesGridSynced:
         # same object (no stale twin for later resyncs to re-mark).
         assert router.routes[0] is route
         assert router.grid.routes[0] is route
+
+    def test_same_net_sibling_cells_survive_optimize_loop(self):
+        """Issue #3511: the incremental per-route unmark clears every cell
+        the OLD envelope owned, including cells a geometry-unchanged
+        same-net SIBLING route still occupies where the envelopes
+        overlapped.  The per-route ``mark_route`` only re-marks the
+        mutated route's NEW geometry, so without the batched
+        post-loop resync the sibling's cells in the old overlap region
+        stay blank.  The trailing ``resync_route_occupancy`` must
+        re-mark them."""
+        router = _make_router()
+        # A vertical sibling the optimizer cannot simplify (single
+        # segment) crossing a horizontal mutated route at (10, 10).
+        sibling = _make_route(5, "E", [(10.0, 5.0), (10.0, 15.0)])
+        # Collinear 3-point horizontal route through the crossing point:
+        # merge_collinear collapses it to one segment from (5,10)-(20,10),
+        # so the route is MUTATED (new object) and its old envelope
+        # overlapped the sibling at (10, 10).
+        mutated = _make_route(5, "E", [(5.0, 10.0), (12.0, 10.0), (20.0, 10.0)])
+        _commit(router, sibling)
+        _commit(router, mutated)
+
+        optimizer = TraceOptimizer(config=OptimizationConfig(merge_collinear=True))
+        optimize_routes_grid_synced(router, optimizer)
+
+        by_net_segments = {len(r.segments) for r in router.routes}
+        # The mutated route really did collapse (3 points -> 1 segment).
+        assert 1 in by_net_segments
+        # The unchanged sibling's copper -- including the crossing cell at
+        # (10, 10) the mutated route's old envelope also owned -- must
+        # still be marked after the loop's batched resync.
+        _assert_marked(router.grid, sibling)
+        for r in router.routes:
+            _assert_marked(router.grid, r)
+        # Grid bookkeeping still mirrors router.routes (no stale twins).
+        assert _grid_route_geometries(router.grid) == _router_route_geometries(router)
+
+    def test_no_resync_when_nothing_mutated(self):
+        """Issue #3511: when no route changes geometry the loop must not
+        invoke the (R-tree-rebuilding) resync at all."""
+        router = _make_router()
+        route = _make_route(2, "B", [(5.0, 10.0), (20.0, 10.0)])
+        _commit(router, route)
+
+        optimizer = TraceOptimizer(config=OptimizationConfig(merge_collinear=True))
+        with patch.object(
+            router.grid,
+            "resync_route_occupancy",
+            wraps=router.grid.resync_route_occupancy,
+        ) as spy:
+            optimize_routes_grid_synced(router, optimizer)
+        spy.assert_not_called()
 
 
 class TestNudgePassGridConsistency:


### PR DESCRIPTION
## Summary

`optimize_routes_grid_synced` (router/optimizer/trace.py) rips and re-marks copper incrementally per route so route *i* collision-checks against the post-opt copper of routes 0..*i*-1. But `grid.unmark_route(route)` is net-guarded yet geometry-scoped: it clears every cell the OLD envelope owned, including cells still occupied by a geometry-unchanged same-net SIBLING route where the two envelopes overlapped. The per-route `mark_route` only re-marks the mutated route's NEW geometry, so the sibling's cells in the old overlap region stayed blank — the grid under-blocked real own-net copper (a downstream foreign-net consumer could path through the sibling's clearance envelope).

`RoutingGrid.resync_route_occupancy` already solves the identical asymmetry with its step-4 affected-net re-mark, but the optimize loop had no equivalent. This PR closes the gap with ONE batched resync after the loop.

## Changes

- `src/kicad_tools/router/optimizer/trace.py`: collect the `(old, new)` pair for every mutated route and call `grid.resync_route_occupancy(pairs)` once after the loop. The incremental per-route unmark/mark is preserved (route *i* still checks against 0..*i*-1 post-opt copper); the batched resync only repairs same-net sibling under-marking. Single call keeps the pass O(n) — per-route resync would re-rebuild the R-trees n times (the O(n^2) trap called out in the issue).
- `tests/router/test_grid_resync_3507.py`: three regression tests (details below).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Batched `resync_route_occupancy` (or equivalent) after the optimize loop re-marks same-net sibling cells | done | `test_same_net_sibling_cells_survive_optimize_loop`: a single-segment vertical sibling crossing a collinear-mergeable horizontal route at the same net; after the loop the sibling's crossing-cell copper is still marked |
| Single batched resync (not per-route) to avoid O(n^2) R-tree rebuild | done | One `grid.resync_route_occupancy(mutated_pairs)` call after the loop; `test_no_resync_when_nothing_mutated` confirms it is skipped entirely when no route mutates |
| Resync deferral-window regression test | done | `test_resync_defers_cpp_unmark_inside_window`: with `begin_cpp_unmark_deferral` open, the stale C++ unmark is queued (not applied) into `_deferred_cpp_unmarks`, the flush applies it, and the Python grid is updated immediately |
| Incremental per-route check semantics preserved | done | Per-route unmark/mark loop unchanged; existing `test_grid_consistent_after_optimize`, `test_unchanged_route_keeps_identity`, skip-nets tests still pass |

## Test Plan

- `pytest tests/router/test_grid_resync_3507.py` — 20 passed (17 prior + 3 new).
- `pytest tests/router/ -k "optimiz or resync or grid_synced or trace"` — 25 passed.
- Board 03 routing baseline: 4 routing-dependent tests pass. The 1 unrelated failure (`test_committed_pcb_drc_state`, "Could not parse error count from 'kct check' output") reproduces identically on clean `main` in 1.04s with no routing — a pre-existing CLI-output-parse mismatch, out of scope.

Closes #3511