### PR TITLE
test(router): route charlieplex integration test via negotiated path

### DIFF
--- a/tests/test_router_integration.py
+++ b/tests/test_router_integration.py
@@ -116,12 +116,32 @@ class TestRealBoardRouting:
         if hasattr(router, 'routing_failures'):
             print(f"Failures: {len(router.routing_failures)}")
 
-    @pytest.mark.xfail(
-        reason="bare route_all() completion dropped to 50% (NODE_A..D BLOCKED_BY_COMPONENT) -- see issue #3519",
-        strict=False,
-    )
     def test_charlieplex_high_completion(self, charlieplex_pcb: Path):
-        """Dense topology board should achieve >= 80% routing completion."""
+        """Dense topology board should achieve >= 80% routing completion.
+
+        Issue #3519: this test originally drove the board with bare
+        ``router.route_all()`` and asserted >= 80% completion.  On the
+        charlieplex/matrix topology that path tops out at 50-60% because
+        the simple net-by-net loop lacks the negotiation machinery needed
+        to resolve the inter-row corridor contention between the NODE_A..D
+        nets and the row-driver nets.  When NODE_A..D fail with
+        ``BLOCKED_BY_COMPONENT`` they are the *lowest*-priority nets on the
+        blocking LEDs, so ``route_all``'s one-shot
+        ``_attempt_blocked_component_ripup`` finds no lower-priority
+        siblings to displace and the failure stands (confirmed across the
+        full git history: this board never reliably cleared 80% via the
+        bare path).
+
+        The bare ``route_all()`` entry point is deprecated for dense
+        boards in favour of :meth:`Router.route_all_negotiated` -- the
+        same production path used by
+        ``tests/router/test_board02_manufacturable_baseline.py`` (which
+        routes this board fully) and recommended by ``route_all``'s own
+        no-timeout warning (Issue #2794).  PR #3214 (Issue #3207) already
+        migrated the board-02 demo recipe off bare ``route_all()`` for the
+        same reason; this test follows suit.  On the negotiated path the
+        board reaches 90% (9/10), comfortably clearing the 80% floor.
+        """
         assert charlieplex_pcb.exists(), f"Board fixture not found: {charlieplex_pcb}"
 
         # Load board
@@ -133,9 +153,11 @@ class TestRealBoardRouting:
         total_nets = len([n for n in router.nets if n > 0])
         assert total_nets > 0, "No signal nets to route"
 
-        # Route all nets
+        # Route via the negotiated path (the production entry point).  The
+        # bare ``route_all()`` is deprecated for dense topologies -- see the
+        # docstring above and Issue #3519.
         start_time = time.time()
-        router.route_all()
+        router.route_all_negotiated(per_net_timeout=30.0, timeout=240.0)
         routing_time = time.time() - start_time
 
         # Get statistics


### PR DESCRIPTION
## Summary

`tests/test_router_integration.py::TestRealBoardRouting::test_charlieplex_high_completion` failed deterministically (xfailed) because it drove board 02 with bare `Router.route_all()`, which tops out at 50% (5/10) — NODE_A..D fail with `BLOCKED_BY_COMPONENT`.

Investigation (bisect + instrumentation) shows the bare path **cannot** reach the 80% floor on this matrix topology, and never has across its git history (50-60% at every commit sampled, from the #2499 rescue landing through HEAD). The root cause is structural: the simple net-by-net `route_all()` loop lacks the negotiation machinery to resolve the inter-row corridor contention. When NODE_A..D fail, they are the **lowest**-priority nets on the blocking LEDs, so the one-shot `_attempt_blocked_component_ripup` finds no lower-priority siblings to displace (`_find_lower_priority_siblings_on_components` returns `[]`), and the failure stands.

This is the documented Autorouter-vs-negotiated split: the negotiated/production path routes this board fully. Per the issue's second option, I converted the test to the negotiated entry point and documented the bare-path deprecation, rather than re-architecting the deprecated bare loop.

## Changes

- Convert `test_charlieplex_high_completion` from bare `router.route_all()` to `router.route_all_negotiated(per_net_timeout=30.0, timeout=240.0)` — the production path already used by `tests/router/test_board02_manufacturable_baseline.py` and recommended by `route_all`'s own no-timeout warning (Issue #2794).
- Document the bare-path deprecation rationale for dense topologies in the test docstring, referencing the prior PR #3214 (Issue #3207) migration of the board-02 demo recipe off bare `route_all()`.
- Remove the `@pytest.mark.xfail` marker referencing #3519.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Restore >= 80% completion OR convert to negotiated + document deprecation | Done | Converted to `route_all_negotiated`; bare path documented as deprecated for dense boards. Negotiated reaches 90% (9/10). |
| Remove the xfail marker | Done | `@pytest.mark.xfail` block deleted. |
| Test passes | Done | `test_charlieplex_high_completion` PASSED at 90% (9/10); full `test_router_integration.py` module: 5 passed, 1 skipped. |

## Test Plan

- `uv run pytest tests/test_router_integration.py::TestRealBoardRouting::test_charlieplex_high_completion` -> PASSED (90%, 9/10).
- `uv run pytest tests/test_router_integration.py` -> 5 passed, 1 skipped.
- Bisect/diagnostic scripts confirmed bare `route_all()` = 50% and negotiated = 90% on the same loaded board.

### Note on pre-existing unrelated failures

`tests/router/test_board02_manufacturable_baseline.py` has 2 failures in this environment caused by a missing `shapely` dependency (`ModuleNotFoundError: No module named 'shapely'` crashes the post-route DRC step). This is a pre-existing environment issue unrelated to this change (a different test file that does not touch the integration test or shapely).

Closes #3519