### PR TITLE
fix(router): restore placement atomically with best-routes snapshot

### DIFF
--- a/src/kicad_tools/router/placement_feedback.py
+++ b/src/kicad_tools/router/placement_feedback.py
@@ -341,6 +341,20 @@ class PlacementFeedbackLoop:
         best_routed_count = -1
         best_iteration = -1
 
+        # Issue #3504: the routes snapshot above is only geometrically
+        # meaningful when paired with the component placement it was
+        # computed against.  Placement adjustments are applied to
+        # ``self.pcb`` in-place at the END of each iteration, so if the
+        # best snapshot came from iteration N (or the pre-loop input) and
+        # the loop moved components in iterations N..final, then restoring
+        # only ``self.router.routes`` pairs stale routes with a moved
+        # placement -- the saved artifact can contain opens/DRC at the new
+        # pad positions.  Snapshot the placement ALONGSIDE the routes and
+        # restore them together so the best snapshot is atomic.
+        best_placement_snapshot: dict[str, tuple[tuple[float, float], float]] = (
+            self._snapshot_placement()
+        )
+
         # Issue #3474 (chorus R2): seed the best-known state with the
         # PRE-LOOP routes.  The #2840 snapshot only made the loop
         # monotonic across its own iterations -- iteration 0 still calls
@@ -433,6 +447,13 @@ class PlacementFeedbackLoop:
                 best_routed_count = routed_count
                 best_routes_snapshot = copy.deepcopy(list(self.router.routes))
                 best_iteration = iteration
+                # Issue #3504: capture the placement these routes were
+                # computed against, atomically with the routes themselves.
+                # At this point in the iteration NO move has yet been
+                # applied for the current pass (moves happen at the bottom
+                # of the loop body), so ``self.pcb`` still reflects the
+                # placement that produced ``routes`` above.
+                best_placement_snapshot = self._snapshot_placement()
             else:
                 improved = False
 
@@ -556,6 +577,14 @@ class PlacementFeedbackLoop:
         # solely from ``self.router.routes`` (core.py:8320), so restoring
         # the routes is sufficient to make the reported failed-net count
         # consistent with the restored snapshot.
+        #
+        # Issue #3504: ALSO restore the component placement captured
+        # alongside the routes.  The restored routes were computed against
+        # ``best_placement_snapshot``; if the loop applied moves after that
+        # snapshot was taken, ``self.pcb`` no longer matches.  Restoring
+        # the placement keeps the returned routes geometrically consistent
+        # with the placement (and with ``placement_diff``, which is built
+        # from ``self.pcb`` below).
         current_routed_count = len(self.router.nets) - 1 - len(self.router.get_failed_nets())
         if best_routed_count > current_routed_count:
             if self.verbose:
@@ -573,6 +602,8 @@ class PlacementFeedbackLoop:
             # cannot be mutated through ``self.router.routes`` after
             # this call returns.
             self.router.routes = copy.deepcopy(best_routes_snapshot)
+            # Issue #3504: restore the placement those routes belong to.
+            self._restore_placement(best_placement_snapshot)
 
         # Final failure analysis -- computed AFTER restoration so the
         # result reflects the restored state, not the live last-iteration
@@ -882,6 +913,51 @@ class PlacementFeedbackLoop:
             pos = fp.position
             rotation = float(getattr(fp, "rotation", 0.0))
             self._original_positions[ref] = ((pos[0], pos[1]), rotation)
+
+    def _snapshot_placement(self) -> dict[str, tuple[tuple[float, float], float]]:
+        """Capture every footprint's (x, y) position and rotation.
+
+        Issue #3504: used to take an atomic best snapshot of the
+        component placement alongside the best routes.  Returns a mapping
+        ``ref -> ((x, y), rotation)``.  When no PCB is attached (routing-
+        strategies-only mode) this returns an empty dict, which makes
+        ``_restore_placement`` a no-op.
+        """
+        snapshot: dict[str, tuple[tuple[float, float], float]] = {}
+        if self.pcb is None:
+            return snapshot
+        for fp in getattr(self.pcb, "footprints", []):
+            ref = getattr(fp, "reference", None)
+            if ref is None:
+                continue
+            pos = fp.position
+            rotation = float(getattr(fp, "rotation", 0.0))
+            snapshot[ref] = ((pos[0], pos[1]), rotation)
+        return snapshot
+
+    def _restore_placement(
+        self,
+        snapshot: dict[str, tuple[tuple[float, float], float]],
+    ) -> None:
+        """Restore footprint positions/rotations from a placement snapshot.
+
+        Issue #3504: counterpart to :meth:`_snapshot_placement`.  Writes
+        the captured ``(x, y)`` and rotation back onto each footprint so
+        the live ``self.pcb`` matches the placement the restored routes
+        were computed against.  Refs present in the PCB but absent from the
+        snapshot are left untouched (defensive against footprints added
+        mid-loop, which does not happen in practice).
+        """
+        if self.pcb is None or not snapshot:
+            return
+        for fp in getattr(self.pcb, "footprints", []):
+            ref = getattr(fp, "reference", None)
+            if ref is None or ref not in snapshot:
+                continue
+            (x, y), rotation = snapshot[ref]
+            fp.position = (x, y)
+            if hasattr(fp, "rotation"):
+                fp.rotation = rotation
 
     def _build_placement_diff(self) -> list[PlacementDiffEntry]:
         """Build the placement diff from snapshotted original positions.

--- a/tests/test_placement_feedback.py
+++ b/tests/test_placement_feedback.py
@@ -1676,3 +1676,203 @@ class TestPlacementFeedbackLoopRollback:
         # Iteration 0 (3 routed) beats the seeded input (1 routed).
         assert sorted(r.net for r in result.routes) == [1, 2, 3]
         assert sorted(result.failed_nets) == [4]
+
+
+class TestPlacementFeedbackBestSnapshotAtomicPlacement:
+    """Issue #3504: best-snapshot restore must restore placement too.
+
+    Placement adjustments are applied to ``self.pcb`` in-place at the END
+    of each iteration.  When the loop restores a best-routes snapshot taken
+    BEFORE one or more of those moves, restoring only the routes pairs them
+    with a placement that has since moved -- the returned routes describe
+    pad positions that no longer exist on the PCB.
+
+    These tests drive the loop with an applicator that actually mutates a
+    footprint position, then assert the final PCB placement matches the
+    placement the restored routes were computed under (and that
+    ``placement_diff`` agrees).
+    """
+
+    @staticmethod
+    def _make_moving_loop(loop, *, move_to: tuple[float, float], target_ref: str = "U1"):
+        """Patch the loop so each accepted strategy moves ``target_ref``.
+
+        The strategy generator is bypassed (mirroring the #2840 rollback
+        tests) and the applicator physically relocates ``target_ref`` to
+        ``move_to`` on ``loop.pcb``.  This models the real applicator
+        writing ``fp.position`` in place at the end of each iteration.
+        """
+        dummy_strategy = ResolutionStrategy(
+            type=StrategyType.MOVE_COMPONENT,
+            difficulty=Difficulty.EASY,
+            confidence=0.99,
+            actions=[
+                Action(
+                    type="move",
+                    target=target_ref,
+                    params={"x": move_to[0], "y": move_to[1]},
+                )
+            ],
+        )
+
+        def _dummy_find(_failed, _conf):
+            return dummy_strategy
+
+        pcb = loop.pcb
+
+        class _MovingApplicator:
+            def apply_strategy(self, _pcb, _strategy):
+                for fp in pcb.footprints:
+                    if getattr(fp, "reference", None) == target_ref:
+                        fp.position = (move_to[0], move_to[1])
+                        return ApplicationResult(
+                            success=True,
+                            components_moved=[target_ref],
+                            message=f"moved {target_ref} -> {move_to}",
+                        )
+                return ApplicationResult(
+                    success=False,
+                    components_moved=[],
+                    message="ref not found",
+                )
+
+            def is_safe_to_apply(self, _strategy, _pcb):
+                return True
+
+        loop._find_best_placement_strategy = _dummy_find  # type: ignore[method-assign]
+        loop._strategy_applicator = _MovingApplicator()
+        return loop
+
+    def test_restored_routes_match_restored_placement(self):
+        """Iter 0 is best; iter 1 moves a component and regresses.
+
+        After the loop restores iteration 0's routes, the PCB placement
+        must be restored to iteration 0's (pre-move) positions so the
+        returned routes describe pads that actually exist where the
+        routes say they do.
+        """
+        from kicad_tools.router import PlacementFeedbackLoop
+
+        original_xy = (10.0, 20.0)
+        moved_xy = (40.0, 50.0)
+
+        # iter-0: 3/4 routed (best); iter-1: 1/4 routed (regression).
+        iter0_routes = [_make_test_route(i) for i in (1, 2, 3)]
+        iter1_routes = [_make_test_route(1)]
+        router = _RoutingFakeRouter(
+            total_nets=4,
+            routes_per_call=[iter0_routes, iter1_routes],
+        )
+
+        pcb = MockPCB()
+        u1 = MockFootprint("U1", *original_xy)
+        pcb.footprints.append(u1)
+
+        loop = PlacementFeedbackLoop(
+            router=router,
+            pcb=pcb,
+            verbose=False,
+            stagnation_patience=0,
+            max_movement=None,  # allow the 40mm move
+        )
+        self._make_moving_loop(loop, move_to=moved_xy)
+        result = loop.run(max_adjustments=1)  # 2 iterations
+
+        # Routes restored from iteration 0 (the best).
+        assert sorted(r.net for r in result.routes) == [1, 2, 3], (
+            "Issue #3504: expected iteration-0 routes restored as best"
+        )
+        # Placement restored to iteration-0 (pre-move) positions: the
+        # routes were computed against U1 at original_xy, so U1 must be
+        # back at original_xy -- NOT the moved position.
+        assert u1.position == original_xy, (
+            f"Issue #3504: best-snapshot restore left U1 at the moved "
+            f"position {u1.position}; restored routes were computed "
+            f"against U1 at {original_xy}, so the placement must be "
+            f"restored atomically with the routes"
+        )
+        # The router's live placement-bearing state agrees.
+        assert loop.pcb.footprints[0].position == original_xy
+
+    def test_placement_diff_consistent_with_restored_placement(self):
+        """placement_diff must reflect the restored (reverted) placement.
+
+        With iter-0 as best and the only move reverted on restore, U1 ends
+        back at its original position, so ``placement_diff`` must contain
+        NO entry for U1 (it did not net-move).
+        """
+        from kicad_tools.router import PlacementFeedbackLoop
+
+        original_xy = (10.0, 20.0)
+        moved_xy = (40.0, 50.0)
+
+        iter0_routes = [_make_test_route(i) for i in (1, 2, 3)]
+        iter1_routes = [_make_test_route(1)]
+        router = _RoutingFakeRouter(
+            total_nets=4,
+            routes_per_call=[iter0_routes, iter1_routes],
+        )
+
+        pcb = MockPCB()
+        u1 = MockFootprint("U1", *original_xy)
+        pcb.footprints.append(u1)
+
+        loop = PlacementFeedbackLoop(
+            router=router,
+            pcb=pcb,
+            verbose=False,
+            stagnation_patience=0,
+            max_movement=None,
+        )
+        self._make_moving_loop(loop, move_to=moved_xy)
+        result = loop.run(max_adjustments=1)
+
+        moved_refs = {entry.ref for entry in result.placement_diff}
+        assert "U1" not in moved_refs, (
+            f"Issue #3504: placement_diff reports U1 as moved but the "
+            f"best snapshot reverted the move; diff must be consistent "
+            f"with the restored placement. diff={result.placement_diff}"
+        )
+
+    def test_improving_move_kept_when_later_iteration_is_best(self):
+        """When the move IMPROVES routing, the moved placement is kept.
+
+        iter-0: 1/4 routed; iter-1 moves U1 and reaches 3/4 (best).  No
+        restore is needed, so U1 must remain at the moved position -- the
+        atomic-snapshot logic must not spuriously revert a winning move.
+        """
+        from kicad_tools.router import PlacementFeedbackLoop
+
+        original_xy = (10.0, 20.0)
+        moved_xy = (40.0, 50.0)
+
+        iter0_routes = [_make_test_route(1)]
+        iter1_routes = [_make_test_route(i) for i in (1, 2, 3)]
+        router = _RoutingFakeRouter(
+            total_nets=4,
+            routes_per_call=[iter0_routes, iter1_routes],
+        )
+
+        pcb = MockPCB()
+        u1 = MockFootprint("U1", *original_xy)
+        pcb.footprints.append(u1)
+
+        loop = PlacementFeedbackLoop(
+            router=router,
+            pcb=pcb,
+            verbose=False,
+            stagnation_patience=0,
+            max_movement=None,
+        )
+        self._make_moving_loop(loop, move_to=moved_xy)
+        result = loop.run(max_adjustments=1)
+
+        # iter-1 is best (3 routed), captured AFTER iter-0's move was
+        # applied at the bottom of iteration 0.
+        assert sorted(r.net for r in result.routes) == [1, 2, 3]
+        # The winning move must be retained, not reverted.
+        assert u1.position == moved_xy, (
+            f"Issue #3504: the improving move was reverted ({u1.position}); "
+            f"only restores that roll back to an earlier best should revert "
+            f"placement"
+        )


### PR DESCRIPTION
## Summary

`PlacementFeedbackLoop.run()` restored the best-known **routes** snapshot before returning but never restored the **component placement** those routes were computed against. Placement adjustments are applied to `self.pcb` in-place at the end of each iteration, so when the best snapshot predated one or more applied moves, the loop paired stale routes with a moved placement — the saved artifact could contain opens/DRC at pad positions that no longer matched the geometry the routes describe.

This makes the best snapshot **atomic**: footprint positions/rotations are captured alongside the routes and restored together.

## Changes

- `placement_feedback.py`: added `_snapshot_placement()` / `_restore_placement()` helpers.
- Capture the placement snapshot both for the pre-loop seed (#3474 path) and on every strict routed-count improvement, taken at the point in the iteration *before* that iteration's move is applied — so the captured placement is the one the snapshotted routes were computed under.
- In the best-snapshot restore branch, restore the placement alongside the routes. `placement_diff` is built from `self.pcb` after restoration, so it now reflects the restored (reverted) placement.
- Added a `TestPlacementFeedbackBestSnapshotAtomicPlacement` test class with a moving applicator.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Restoring a best snapshot taken before placement moves also restores the placement those routes were computed under | done | `test_restored_routes_match_restored_placement`: iter-0 best, iter-1 moves U1 + regresses; after restore U1 is back at its pre-move position |
| Unit test: iteration 0 best, iteration 1 applies a move and regresses — final placement matches iteration-0 positions | done | Same test asserts `u1.position == original_xy` |
| `placement_diff` consistent with returned routes/placement | done | `test_placement_diff_consistent_with_restored_placement`: reverted move produces no `placement_diff` entry for U1 |
| Winning moves are not spuriously reverted | done | `test_improving_move_kept_when_later_iteration_is_best`: improving move retained |

## Test Plan

- `pytest tests/test_placement_feedback.py` — 61 passed (3 new)
- `pytest tests/test_route_cmd_placement_feedback.py tests/test_chorus_test_placement_feedback.py` — 56 passed, 1 skipped
- `ruff check` on both changed files — clean

Closes #3504