### PR TITLE
fix(router): missed via-in-pad rescues override dominant-cause veto in --auto-mfr-tier

### DIFF
--- a/src/kicad_tools/cli/mfr_tier_budget.py
+++ b/src/kicad_tools/cli/mfr_tier_budget.py
@@ -1,0 +1,149 @@
+"""Per-tier wall-clock budget slicing for ``--auto-mfr-tier`` escalation.
+
+Issue #3463: the manufacturer-tier escalation ladder
+(``route_with_mfr_tier_escalation`` in :mod:`kicad_tools.cli.route_cmd`)
+walks a sequence of tiers (e.g. ``jlcpcb -> jlcpcb-tier1``).  For each
+tier it re-enters the layer-escalation path, which divides the *remaining
+routing budget* across its own layer attempts via
+``_per_attempt_budgeted_timeout``.
+
+The bug: that inner helper sees the **full** remaining routing budget at
+base-tier time, so the base tier's layer escalation expands to fill the
+entire routing deadline.  When control returns to the outer ladder, the
+routing deadline is already exhausted, ``_deadline_expired(args)`` is
+``True`` at the top of the next tier iteration, and the loop breaks
+*before* attempting ``jlcpcb-tier1`` -- exactly the symptom reported in
+#3463 (per-tier banner only ever shows ``['jlcpcb']``, escalation aborts
+on the base-tier escape-infeasibility diagnosis instead of advancing to
+the via-in-pad-capable tier).
+
+The fix lives here, deliberately out of
+:meth:`kicad_tools.router.core.Autorouter.route_all_negotiated` (a sibling
+PR touches that method).  We expose a small context manager that
+temporarily narrows ``args._routing_deadline`` to a fair per-tier slice of
+the *remaining* routing budget, so each tier -- including the final one --
+gets a real chance to run.  The original deadline is restored on exit so
+auto-fix and any subsequent CLI reuse of ``args`` see the unmodified
+total.
+
+Design notes:
+
+* The slice rolls forward naturally: a fast-finishing tier leaves more
+  budget for the next, because the slice is recomputed from the *current*
+  remaining budget divided by the *current* number of outstanding tiers.
+* When no wall-clock deadline is configured (legacy unbounded runs, or
+  ``--timeout`` unset) the context manager is a no-op and the inner path
+  keeps its existing unbounded behaviour.
+* The narrowing is intentionally a *floor-guarded* slice: we never narrow
+  the per-tier deadline below a small floor, so a ladder with many tiers
+  and a tight ``--timeout`` does not collapse the final tier to zero
+  budget.  The floor matches the per-attempt floor philosophy used by the
+  layer-escalation budget helper.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import time
+from collections.abc import Iterator
+
+# Minimum per-tier routing budget (seconds).  Mirrors the spirit of the
+# auto-fix reserve floor: a tier given less than this much time cannot
+# make meaningful progress, so we never slice below it.  If the total
+# remaining budget is itself below the floor, the slice collapses to the
+# remaining budget (the tier gets whatever is left).
+_PER_TIER_FLOOR_SEC = 30.0
+
+
+def per_tier_routing_deadline(
+    args,
+    *,
+    tier_index: int,
+    tier_count: int,
+    now: float | None = None,
+) -> float | None:
+    """Compute a fair per-tier routing deadline (monotonic clock value).
+
+    Divides the *remaining* routing budget evenly across the *remaining*
+    tiers (including the current one) and returns the monotonic deadline
+    for the current tier: ``now + slice``.
+
+    Args:
+        args: Parsed CLI namespace.  Must carry ``_routing_deadline`` (set
+            by ``_set_wall_clock_deadline``); when that is ``None`` this
+            returns ``None`` (legacy unbounded behaviour).
+        tier_index: 0-based index of the current tier in the ladder.
+        tier_count: Total number of tiers the ladder intends to attempt.
+        now: Override for the current monotonic time (testing seam).
+            Defaults to ``time.monotonic()``.
+
+    Returns:
+        A monotonic deadline (float) for the current tier, or ``None`` when
+        no routing deadline is configured.  When the current tier is the
+        last outstanding one, the returned deadline equals the original
+        routing deadline (no point reserving budget for a tier that does
+        not exist).
+    """
+    routing_deadline = getattr(args, "_routing_deadline", None)
+    if routing_deadline is None:
+        return None
+
+    if now is None:
+        now = time.monotonic()
+
+    remaining = routing_deadline - now
+    if remaining <= 0.0:
+        # Routing deadline already passed -- return the original so the
+        # caller's existing ``_deadline_expired`` check fires as before.
+        return routing_deadline
+
+    # Outstanding tiers including the current one.
+    outstanding = max(1, tier_count - tier_index)
+    if outstanding <= 1:
+        # Last tier: hand it the whole remaining budget.
+        return routing_deadline
+
+    per_tier_slice = remaining / outstanding
+    # Floor-guard: never collapse a tier below the floor unless the total
+    # remaining budget is itself below the floor (in which case the tier
+    # simply gets whatever is left).
+    per_tier_slice = max(per_tier_slice, min(_PER_TIER_FLOOR_SEC, remaining))
+    # Never exceed the original routing deadline.
+    return min(routing_deadline, now + per_tier_slice)
+
+
+@contextlib.contextmanager
+def per_tier_routing_budget(
+    args,
+    *,
+    tier_index: int,
+    tier_count: int,
+) -> Iterator[None]:
+    """Temporarily narrow ``args._routing_deadline`` to a per-tier slice.
+
+    On ``__enter__`` the routing deadline is replaced with the value from
+    :func:`per_tier_routing_deadline` (when a deadline is configured); on
+    ``__exit__`` the original is restored unconditionally so auto-fix and
+    any subsequent reuse of ``args`` see the unmodified total.
+
+    This is the mechanism that lets the manufacturer-tier escalation ladder
+    reserve budget for later tiers instead of letting the first tier's
+    layer-escalation loop consume the entire routing deadline (Issue #3463).
+
+    No-op (yields immediately, restores nothing meaningful) when no routing
+    deadline is configured.
+    """
+    original = getattr(args, "_routing_deadline", None)
+    narrowed = per_tier_routing_deadline(
+        args,
+        tier_index=tier_index,
+        tier_count=tier_count,
+    )
+    if narrowed is not None:
+        args._routing_deadline = narrowed
+    try:
+        yield
+    finally:
+        # Restore unconditionally.  ``original`` may be ``None`` (unbounded
+        # run) -- restoring ``None`` is correct in that case.
+        args._routing_deadline = original

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -4505,6 +4505,7 @@ def route_with_mfr_tier_escalation(
     Returns:
         Exit code (0 = success, 1 = failure, 2 = partial)
     """
+    from kicad_tools.cli.mfr_tier_budget import per_tier_routing_budget
     from kicad_tools.cli.progress import flush_print
     from kicad_tools.router.failure_analysis import (
         MFR_TIER_ESCALATION_TRIGGERS,
@@ -4634,17 +4635,38 @@ def route_with_mfr_tier_escalation(
 
             should_escalate = False
             reason = ""
-            if trigger_table_vetoes:
+            # Issue #3463: the canonical ``missed_via_in_pad_rescues``
+            # signal takes precedence over the dominant-cause trigger-table
+            # veto.  A non-zero missed-rescue counter is *direct,
+            # instrumented* evidence that one or more fine-pitch pins would
+            # be rescued by an in-pad via on the next tier -- strictly
+            # stronger than a statistical tally of per-net failure causes.
+            #
+            # On board-04 the dominant cause across the (few) failing nets
+            # is classified as BLOCKED_PATH (a single keepout-blocked net),
+            # which the trigger table marks not-manufacturer-fixable.  But
+            # the EscapeRouter separately recorded a non-zero
+            # ``missed_via_in_pad_rescues`` for the LQFP-48 inner pins --
+            # exactly what ``jlcpcb-tier1`` fixes.  Letting the BLOCKED_PATH
+            # tally veto escalation here aborts the ladder before the
+            # capable tier ever runs (the #3463 regression).  So we check
+            # the missed-rescue signal *first*: when it fires and the next
+            # tier gains via-in-pad capability, escalate regardless of the
+            # dominant-cause tally.  The trigger-table veto still applies
+            # when there is *no* instrumented missed-rescue signal (the
+            # legacy placement-class suppression for #2883).
+            if gains_capability and triggered_by_missed_in_pad:
+                should_escalate = True
+                reason = "missed via-in-pad rescues detected on previous tier"
+            elif trigger_table_vetoes:
                 # Trigger table says this failure category is not
-                # manufacturer-fixable.  Suppress escalation even if
+                # manufacturer-fixable and there is no missed-rescue
+                # signal to override it.  Suppress escalation even if
                 # capability / scalar gain exists.
                 reason = (
                     f"dominant failure cause ({dominant_cause.value}) is not "
                     "manufacturer-fixable (trigger table veto)"
                 )
-            elif gains_capability and triggered_by_missed_in_pad:
-                should_escalate = True
-                reason = "missed via-in-pad rescues detected on previous tier"
             elif gains_capability:
                 # No instrumented missed-rescue signal, but capability gain
                 # exists -- escalate defensively (the user asked for it).
@@ -4697,20 +4719,26 @@ def route_with_mfr_tier_escalation(
             # Dispatch to the layer-escalation path.  When args.auto_layers
             # is False we fall through to single-layer routing.  When True,
             # full 2D escalation (layers x mfr-tier) occurs.
-            if getattr(args, "auto_layers", True):
-                inner_rc = route_with_layer_escalation(
-                    pcb_path=pcb_path,
-                    output_path=output_path,
-                    args=args,
-                    quiet=quiet,
-                )
-            else:
-                # Single-layer routing path -- recurse via main() with
-                # auto_layers/auto_mfr_tier turned off would be cleaner, but
-                # to keep this PR focused we just call the layer-escalation
-                # path with --max-layers=args.layers honored via the inner
-                # filter.  When the user explicitly disabled auto-layers,
-                # they should explicitly invoke the appropriate path.
+            #
+            # Issue #3463: wrap the inner call in a per-tier routing-budget
+            # window so the base tier's layer-escalation loop cannot consume
+            # the entire routing deadline.  Without this, the inner
+            # ``_per_attempt_budgeted_timeout`` sees the full remaining
+            # budget at base-tier time, the base tier expands to fill it,
+            # and ``_deadline_expired(args)`` is True at the top of the next
+            # tier iteration -- so the ladder aborts before ever attempting
+            # ``jlcpcb-tier1`` (the via-in-pad-capable tier).  The context
+            # manager narrows ``args._routing_deadline`` to a fair per-tier
+            # slice and restores the original deadline on exit (so auto-fix
+            # still sees its reserved budget).
+            with per_tier_routing_budget(
+                args,
+                tier_index=tier_idx,
+                tier_count=len(tiers_to_try),
+            ):
+                # Both branches dispatch identically today; when the user
+                # explicitly disabled --auto-layers the layer-escalation
+                # path honours --max-layers via its inner filter.
                 inner_rc = route_with_layer_escalation(
                     pcb_path=pcb_path,
                     output_path=output_path,

--- a/tests/test_mfr_tier_budget.py
+++ b/tests/test_mfr_tier_budget.py
@@ -1,0 +1,136 @@
+"""Fast unit tests for ``kicad_tools.cli.mfr_tier_budget`` (Issue #3463).
+
+These pin the per-tier wall-clock budget slicing that lets the
+``--auto-mfr-tier`` escalation ladder reserve routing budget for later
+tiers instead of letting the base tier consume the entire routing
+deadline (the regression that aborted escalation before ``jlcpcb-tier1``).
+
+No routing is performed here -- the slow end-to-end chain lives in
+``test_route_auto_mfr_tier_integration.py``.  This module exercises the
+budget arithmetic and the context-manager restore semantics directly.
+"""
+
+from __future__ import annotations
+
+import time
+import types
+
+from kicad_tools.cli.mfr_tier_budget import (
+    _PER_TIER_FLOOR_SEC,
+    per_tier_routing_budget,
+    per_tier_routing_deadline,
+)
+
+
+def _args(routing_deadline: float | None) -> types.SimpleNamespace:
+    return types.SimpleNamespace(_routing_deadline=routing_deadline)
+
+
+class TestPerTierRoutingDeadline:
+    def test_none_when_no_deadline_configured(self) -> None:
+        """Unbounded runs (no --timeout) return None -- legacy behaviour."""
+        assert per_tier_routing_deadline(_args(None), tier_index=0, tier_count=2) is None
+
+    def test_first_of_two_tiers_gets_half(self) -> None:
+        """The base tier of a two-tier ladder must NOT get the whole budget.
+
+        This is the core #3463 fix: with two tiers and 600s remaining the
+        base tier is sliced to ~300s, leaving ~300s for jlcpcb-tier1.
+        """
+        now = 1000.0
+        remaining = 600.0
+        args = _args(now + remaining)
+        deadline = per_tier_routing_deadline(args, tier_index=0, tier_count=2, now=now)
+        assert deadline is not None
+        slice_seconds = deadline - now
+        assert slice_seconds == 300.0
+
+    def test_last_tier_gets_whole_remaining_budget(self) -> None:
+        """The final outstanding tier is handed the full remaining budget."""
+        now = 1000.0
+        original = now + 600.0
+        args = _args(original)
+        deadline = per_tier_routing_deadline(args, tier_index=1, tier_count=2, now=now)
+        assert deadline == original
+
+    def test_single_tier_ladder_is_passthrough(self) -> None:
+        """A one-tier ladder gets the full deadline (no reservation)."""
+        now = 1000.0
+        original = now + 600.0
+        args = _args(original)
+        deadline = per_tier_routing_deadline(args, tier_index=0, tier_count=1, now=now)
+        assert deadline == original
+
+    def test_slice_rolls_forward_when_earlier_tier_finishes_fast(self) -> None:
+        """A fast base tier enlarges the slice available to the next tier.
+
+        The slice is recomputed from the *current* remaining budget over
+        the *current* outstanding-tier count, so unused budget rolls
+        forward automatically.
+        """
+        # Three-tier ladder, 900s total.  Base tier sliced to 300s but
+        # finishes in 60s, so the second tier (with 840s remaining over 2
+        # outstanding tiers) is sliced to 420s -- more than its naive
+        # 1/3 share of the original budget.
+        now0 = 0.0
+        args = _args(now0 + 900.0)
+        first = per_tier_routing_deadline(args, tier_index=0, tier_count=3, now=now0)
+        assert first - now0 == 300.0
+        # Simulate the base tier consuming only 60s of wall clock.
+        now1 = 60.0
+        second = per_tier_routing_deadline(args, tier_index=1, tier_count=3, now=now1)
+        # Remaining = 840s over 2 outstanding tiers -> 420s slice.
+        assert second - now1 == 420.0
+
+    def test_floor_guard_prevents_zero_budget_tier(self) -> None:
+        """Many tiers + tight budget: a tier is never sliced below the floor
+        (unless the total remaining is itself below the floor)."""
+        now = 0.0
+        # 5 tiers, only 100s remaining -> naive slice would be 20s, below
+        # the 30s floor; the floor wins.
+        args = _args(now + 100.0)
+        deadline = per_tier_routing_deadline(args, tier_index=0, tier_count=5, now=now)
+        assert deadline is not None
+        assert deadline - now == _PER_TIER_FLOOR_SEC
+
+    def test_already_expired_returns_original(self) -> None:
+        """When the routing deadline has already passed, return it unchanged
+        so the caller's existing ``_deadline_expired`` check fires."""
+        now = 1000.0
+        original = now - 5.0  # already in the past
+        args = _args(original)
+        deadline = per_tier_routing_deadline(args, tier_index=0, tier_count=2, now=now)
+        assert deadline == original
+
+
+class TestPerTierRoutingBudgetContextManager:
+    def test_narrows_then_restores(self) -> None:
+        """Inside the window the deadline is narrowed; on exit it is
+        restored to the original total."""
+        now = time.monotonic()
+        original = now + 600.0
+        args = _args(original)
+        with per_tier_routing_budget(args, tier_index=0, tier_count=2):
+            # Narrowed to roughly half (allowing for monotonic drift).
+            assert args._routing_deadline < original
+            assert args._routing_deadline <= now + 320.0
+        # Restored exactly.
+        assert args._routing_deadline == original
+
+    def test_restores_even_on_exception(self) -> None:
+        """The original deadline is restored even if the body raises."""
+        original = time.monotonic() + 600.0
+        args = _args(original)
+        try:
+            with per_tier_routing_budget(args, tier_index=0, tier_count=2):
+                raise RuntimeError("boom")
+        except RuntimeError:
+            pass
+        assert args._routing_deadline == original
+
+    def test_noop_when_unbounded(self) -> None:
+        """No deadline configured -> context manager leaves args untouched."""
+        args = _args(None)
+        with per_tier_routing_budget(args, tier_index=0, tier_count=2):
+            assert args._routing_deadline is None
+        assert args._routing_deadline is None

--- a/tests/test_route_auto_mfr_tier.py
+++ b/tests/test_route_auto_mfr_tier.py
@@ -45,7 +45,13 @@ class TestArgparseFlagPlumbing:
         """--mfr-tier-ladder accepts a comma-separated value."""
         parser = self._get_route_parser()
         args = parser.parse_args(
-            ["route", "test.kicad_pcb", "--auto-mfr-tier", "--mfr-tier-ladder", "jlcpcb,jlcpcb-tier1"]
+            [
+                "route",
+                "test.kicad_pcb",
+                "--auto-mfr-tier",
+                "--mfr-tier-ladder",
+                "jlcpcb,jlcpcb-tier1",
+            ]
         )
         assert args.mfr_tier_ladder == "jlcpcb,jlcpcb-tier1"
 
@@ -508,9 +514,7 @@ class TestLadderExhaustionDiagnostic:
         # Named line precedes the generic Options list.
         assert out.index("Diagnosis") < out.index("Options:")
 
-    def test_exhaustion_with_multiple_affected_components_reports_count(
-        self, capsys
-    ):
+    def test_exhaustion_with_multiple_affected_components_reports_count(self, capsys):
         """When more than one component shares the unfixable constraint,
         the diagnostic mentions the extra-affected count so the user knows
         the scope of the problem."""
@@ -550,9 +554,7 @@ class TestLadderExhaustionDiagnostic:
         # 2 other components affected.
         assert "2 other component" in out
 
-    def test_exhaustion_without_missed_rescues_suppresses_named_line(
-        self, capsys
-    ):
+    def test_exhaustion_without_missed_rescues_suppresses_named_line(self, capsys):
         """When the EscapeRouter has no missed-rescue signal we don't have
         a confident named constraint to surface; the Diagnosis section is
         suppressed but the generic Options list still prints."""
@@ -594,9 +596,7 @@ class TestLadderExhaustionDiagnostic:
             _name_dominant_unfixable_constraint,
         )
 
-        assert _name_dominant_unfixable_constraint(
-            last_router=None, manufacturer="jlcpcb"
-        ) is None
+        assert _name_dominant_unfixable_constraint(last_router=None, manufacturer="jlcpcb") is None
 
     def test_named_constraint_helper_handles_missing_escape_router(self):
         """The diagnostic helper degrades gracefully when the Autorouter
@@ -609,9 +609,11 @@ class TestLadderExhaustionDiagnostic:
         # We need to explicitly stub _escape_router to None.
         broken_router = MagicMock()
         broken_router._escape_router = None
-        assert _name_dominant_unfixable_constraint(
-            last_router=broken_router, manufacturer="jlcpcb"
-        ) is None
+        assert (
+            _name_dominant_unfixable_constraint(last_router=broken_router, manufacturer="jlcpcb")
+            is None
+        )
+
 
 class TestTriggerTableWiring:
     """Issue #2883: trigger table is wired into the outer escalation loop.
@@ -698,6 +700,13 @@ class TestTriggerTableWiring:
         via-in-pad capability gain (which would otherwise escalate
         defensively), the trigger table marks BLOCKED_PATH as
         non-manufacturer-fixable and vetoes the walk-forward.
+
+        Issue #3463: the veto only applies when there is *no* instrumented
+        ``missed_via_in_pad_rescues`` signal.  A non-zero missed-rescue
+        counter is direct evidence that via-in-pad would help and takes
+        precedence over the dominant-cause tally (see
+        ``test_missed_via_in_pad_overrides_blocked_path_veto`` below).  So
+        this pure-veto case sets the missed-rescue counter to 0.
         """
         from kicad_tools.cli.route_cmd import route_with_mfr_tier_escalation
         from kicad_tools.router.failure_analysis import FailureCause
@@ -709,10 +718,10 @@ class TestTriggerTableWiring:
             seen_tiers.append(args.manufacturer)
             mock_router = MagicMock()
             mock_router._escape_router = MagicMock()
-            # Even with non-zero missed_via_in_pad_rescues (so the
-            # legacy heuristic would escalate), the trigger table must
-            # override and suppress.
-            mock_router._escape_router.missed_via_in_pad_rescues = 5
+            # No missed-rescue signal: the only evidence is the
+            # BLOCKED_PATH tally, which the trigger table marks
+            # non-manufacturer-fixable -> veto.
+            mock_router._escape_router.missed_via_in_pad_rescues = 0
             mock_router.routing_failures = [
                 self._make_failure(FailureCause.BLOCKED_PATH),
                 self._make_failure(FailureCause.BLOCKED_PATH),
@@ -737,8 +746,20 @@ class TestTriggerTableWiring:
         # Only the starting tier ran; trigger table vetoed escalation.
         assert seen_tiers == ["jlcpcb"]
 
-    def test_congestion_dominant_cause_suppresses_escalation(self):
-        """CONGESTION (a layer-budget issue) should not trigger escalation."""
+    def test_missed_via_in_pad_overrides_blocked_path_veto(self):
+        """Issue #3463: a non-zero ``missed_via_in_pad_rescues`` counter
+        overrides a BLOCKED_PATH dominant-cause veto.
+
+        This is the board-04 regression shape: a single keepout-blocked
+        net makes BLOCKED_PATH the *most-common* per-net failure cause, so
+        ``_classify_dominant_failure_cause`` returns BLOCKED_PATH and the
+        #2883 trigger table would veto escalation.  But the EscapeRouter
+        separately recorded a non-zero ``missed_via_in_pad_rescues`` for
+        the fine-pitch LQFP-48 inner pins -- direct, instrumented evidence
+        that the next (via-in-pad-capable) tier is exactly the fix.  The
+        ladder must walk forward to ``jlcpcb-tier1`` rather than aborting
+        on the coincidental BLOCKED_PATH tally.
+        """
         from kicad_tools.cli.route_cmd import route_with_mfr_tier_escalation
         from kicad_tools.router.failure_analysis import FailureCause
 
@@ -749,7 +770,59 @@ class TestTriggerTableWiring:
             seen_tiers.append(args.manufacturer)
             mock_router = MagicMock()
             mock_router._escape_router = MagicMock()
-            mock_router._escape_router.missed_via_in_pad_rescues = 1
+            # Non-zero missed-rescue signal: via-in-pad would directly
+            # rescue the fine-pitch pins, even though the dominant tally
+            # is BLOCKED_PATH (an unrelated keepout-blocked net).
+            mock_router._escape_router.missed_via_in_pad_rescues = 3
+            mock_router._escape_router.missed_via_in_pad_components = {"U2"}
+            mock_router.routing_failures = [
+                self._make_failure(FailureCause.BLOCKED_PATH),
+                self._make_failure(FailureCause.BLOCKED_PATH),
+                self._make_failure(FailureCause.PIN_ACCESS),
+            ]
+            args._last_router = mock_router
+            if args.manufacturer == "jlcpcb-tier1":
+                return 0  # success on the via-in-pad-capable tier
+            return 2
+
+        with patch(
+            "kicad_tools.cli.route_cmd.route_with_layer_escalation",
+            side_effect=fake_inner,
+        ):
+            from pathlib import Path
+
+            rc = route_with_mfr_tier_escalation(
+                pcb_path=Path("test.kicad_pcb"),
+                output_path=Path("out.kicad_pcb"),
+                args=args,
+                quiet=True,
+            )
+
+        # Escalation engaged despite the BLOCKED_PATH dominant tally:
+        # the missed-rescue signal took precedence.
+        assert seen_tiers == ["jlcpcb", "jlcpcb-tier1"]
+        assert rc == 0
+
+    def test_congestion_dominant_cause_suppresses_escalation(self):
+        """CONGESTION (a layer-budget issue) should not trigger escalation.
+
+        Issue #3463: the trigger-table veto only applies absent an
+        instrumented ``missed_via_in_pad_rescues`` signal, so this
+        pure-veto case sets the missed-rescue counter to 0 (CONGESTION is
+        a layer-budget problem handled by --auto-layers, not a via-in-pad
+        deficiency).
+        """
+        from kicad_tools.cli.route_cmd import route_with_mfr_tier_escalation
+        from kicad_tools.router.failure_analysis import FailureCause
+
+        args = self._make_args()
+        seen_tiers: list[str] = []
+
+        def fake_inner(*, pcb_path, output_path, args, quiet):
+            seen_tiers.append(args.manufacturer)
+            mock_router = MagicMock()
+            mock_router._escape_router = MagicMock()
+            mock_router._escape_router.missed_via_in_pad_rescues = 0
             mock_router.routing_failures = [
                 self._make_failure(FailureCause.CONGESTION),
                 self._make_failure(FailureCause.CONGESTION),

--- a/tests/test_route_auto_mfr_tier_integration.py
+++ b/tests/test_route_auto_mfr_tier_integration.py
@@ -220,14 +220,6 @@ class TestAutoMfrTierIntegration:
     # AC #1: Tier-1 escalation produces measurable progress over jlcpcb.
     # ------------------------------------------------------------------
 
-    @pytest.mark.xfail(
-        reason=(
-            "Issue #3463: --auto-mfr-tier aborts on the jlcpcb escape "
-            "infeasibility (U2 via-in-pad) instead of escalating to "
-            "jlcpcb-tier1; remove this xfail when #3463 is fixed."
-        ),
-        strict=False,
-    )
     def test_tier1_routes_more_nets_than_jlcpcb(
         self,
         auto_mfr_tier_result: subprocess.CompletedProcess[str],
@@ -294,14 +286,6 @@ class TestAutoMfrTierIntegration:
     # AC #2: CLI advances to jlcpcb-tier1
     # ------------------------------------------------------------------
 
-    @pytest.mark.xfail(
-        reason=(
-            "Issue #3463: --auto-mfr-tier aborts on the jlcpcb escape "
-            "infeasibility (U2 via-in-pad) instead of escalating to "
-            "jlcpcb-tier1; remove this xfail when #3463 is fixed."
-        ),
-        strict=False,
-    )
     def test_escalation_advances_to_tier1(
         self,
         auto_mfr_tier_result: subprocess.CompletedProcess[str],
@@ -331,14 +315,6 @@ class TestAutoMfrTierIntegration:
     # AC #3: Escalation trigger reason is the canonical missed-rescue signal.
     # ------------------------------------------------------------------
 
-    @pytest.mark.xfail(
-        reason=(
-            "Issue #3463: --auto-mfr-tier aborts on the jlcpcb escape "
-            "infeasibility (U2 via-in-pad) instead of escalating to "
-            "jlcpcb-tier1; remove this xfail when #3463 is fixed."
-        ),
-        strict=False,
-    )
     def test_escalation_triggered_by_missed_via_in_pad(
         self, auto_mfr_tier_result: subprocess.CompletedProcess[str]
     ) -> None:


### PR DESCRIPTION
## Summary

`kct route --auto-mfr-tier` aborted its escalation ladder on board 04 before ever attempting `jlcpcb-tier1`, so the via-in-pad-capable tier that fixes the LQFP-48 inner-pin escapes never ran. Three slow integration tests (`test_route_auto_mfr_tier_integration.py`) were xfail'd to land the slow-tests gate (#3458); this PR fixes the root cause and removes the xfails.

There were two compounding bugs, both fixed without touching `core.py::route_all_negotiated` (a sibling PR owns that method):

1. **Budget starvation.** The mfr-tier loop checks `_deadline_expired` at the top of each tier, but the inner `route_with_layer_escalation` divides the *full* remaining routing budget across its own layer attempts. The base tier therefore expanded to fill the entire routing deadline, and the loop broke before tier 1.

2. **Trigger-table veto precedence.** On board 04 a single keepout-blocked net makes `BLOCKED_PATH` the most-common per-net failure, so `_classify_dominant_failure_cause` returns `BLOCKED_PATH` and the #2883 trigger table vetoes escalation -- even though the `EscapeRouter` separately recorded a non-zero `missed_via_in_pad_rescues` for the fine-pitch pins, which is exactly what `jlcpcb-tier1` fixes.

## Changes

- New module `src/kicad_tools/cli/mfr_tier_budget.py`: `per_tier_routing_budget` context manager + `per_tier_routing_deadline` helper that narrow `args._routing_deadline` to a fair per-tier slice (floor-guarded, rolls unused budget forward) and restore the original deadline on exit so auto-fix keeps its reserve.
- `route_with_mfr_tier_escalation` (`cli/route_cmd.py`): wrap the inner layer-escalation call in the per-tier budget window; reorder the convergence guard so a non-zero `missed_via_in_pad_rescues` + via-in-pad capability gain escalates *before* the dominant-cause veto is consulted. The veto still suppresses escalation when there is no instrumented missed-rescue signal (legacy #2883 placement-class behavior preserved).
- Removed the 3 xfail markers in `test_route_auto_mfr_tier_integration.py`.
- Updated the `BLOCKED_PATH` / `CONGESTION` veto unit tests to set `missed_via_in_pad_rescues = 0` (the pure-veto case) and added `test_missed_via_in_pad_overrides_blocked_path_veto` pinning the new precedence.
- New fast unit suite `tests/test_mfr_tier_budget.py` (10 tests) for the budget arithmetic and restore semantics.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Escalation attempts `jlcpcb-tier1` on board 04 | done | `test_escalation_advances_to_tier1` passes: `Tier N/M: jlcpcb-tier1` banner now appears |
| tier1 routes more nets than jlcpcb in the same run | done | `test_tier1_routes_more_nets_than_jlcpcb` passes |
| Escalation triggered by canonical missed-via-in-pad signal | done | `test_escalation_triggered_by_missed_via_in_pad` passes |
| 3 xfail markers removed | done | markers deleted; tests run as normal slow tests |
| escalation ladder fix outside `core.py::route_all_negotiated` | done | only `cli/route_cmd.py` + new `cli/mfr_tier_budget.py` changed |

## Test Plan

- `pytest tests/test_route_auto_mfr_tier_integration.py -m slow --no-cov` -> **3 passed in 457.65s** (was 3 failed). These are `@pytest.mark.slow`, excluded from PR-time CI and picked up by the nightly slow-tests workflow.
- `pytest tests/test_route_auto_mfr_tier.py tests/test_mfr_tier_ladder.py tests/test_auto_mfr_tier_log_suppression.py tests/test_mfr_tier_budget.py --no-cov` -> 83 passed (fast).
- `ruff check` + `ruff format --check` clean on all changed files.
- C++ backend built (`uv run kct build-native`) before running the slow chain.

Closes #3463