### PR TITLE
fix(router): keep same-component net=0 pad overlap routable in validator

### DIFF
--- a/src/kicad_tools/router/cpp/include/types.hpp
+++ b/src/kicad_tools/router/cpp/include/types.hpp
@@ -83,7 +83,14 @@ namespace router {
 // through J1-1's halo at 0.127mm actual vs 0.200mm required).
 // ``mark_blocked`` also began recording ``original_net`` for ALL static
 // cells (previously pad-metal only) so the restore has the owner net.
-constexpr int ROUTER_CPP_BUILD_VERSION = 11;
+//
+// Bump to 12 (Issue #3490): the same-component validator carve-out in
+// ``validate_route`` now silences NEGATIVE pad clearance for net=0
+// (unconnected / NC) same-component pads, restoring routability to a
+// signal pad whose metal overlaps an adjacent net=0 pad (the #1764
+// reachability guarantee). Foreign signal pads keep the strict >= 0
+// guard (#2933).
+constexpr int ROUTER_CPP_BUILD_VERSION = 12;
 
 // Grid cell state
 struct GridCell {

--- a/src/kicad_tools/router/cpp/src/grid.cpp
+++ b/src/kicad_tools/router/cpp/src/grid.cpp
@@ -509,7 +509,20 @@ ValidationResult Grid3D::validate_route(
             // trace clears the neighbour pad's metal (clearance >= 0).
             // Negative clearance means the trace overlaps pad copper -- a
             // true defect that no carve-out should silence.
-            if (same_component_signal_carveout && clearance >= 0.0f) {
+            //
+            // Issue #3490: EXCEPTION -- a same-component pad on net 0
+            // (an unconnected / NC pad) carries no electrical net, so a
+            // trace endpoint that geometrically overlaps its metal is not
+            // a real short.  When such a pad sits within metal-overlap
+            // distance of the signal pad being routed (an LED whose
+            // net=0 pin is 0.2mm from its signal pin -- the #1764
+            // scenario), reaching the signal pad's center is impossible
+            // without entering the net=0 pad's rectangle.  The footprint
+            // guarantees the geometry, so silence the violation for
+            // negative clearance too -- but ONLY for net=0 pads.  Foreign
+            // SIGNAL pads (net != 0) keep the strict >= 0 guard so the
+            // trace-through-pad-copper pathology (#2933) stays caught.
+            if (same_component_signal_carveout && (clearance >= 0.0f || pad.net == 0)) {
                 continue;
             }
 

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -47,7 +47,7 @@ logger = logging.getLogger(__name__)
 # ``AttributeError`` deep in the routing code (e.g. ``router_cpp.PadBounds``
 # missing).  The guard below catches that at import time and falls back to the
 # pure-Python router with an actionable ``kct build-native`` hint.
-_REQUIRED_CPP_BUILD_VERSION = 11
+_REQUIRED_CPP_BUILD_VERSION = 12
 
 # Try to import C++ module with detailed error tracking
 _CPP_IMPORT_ERROR: str | None = None

--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -2799,7 +2799,10 @@ class RoutingGrid:
                 )
                 clearance = center_dist - seg_half_width
 
-            if same_component_signal_carveout and clearance >= 0:
+            # Issue #3490: same-component net=0 (NC/unconnected) pads
+            # carry no net, so overlap is not a real short -- silence the
+            # deficit for negative clearance too (mirrors the validator).
+            if same_component_signal_carveout and (clearance >= 0 or pad.net == 0):
                 continue
 
             deficit = required_clearance - clearance
@@ -3095,7 +3098,20 @@ class RoutingGrid:
             # trace clears the neighbour pad's metal (clearance >= 0).
             # Negative clearance means the trace overlaps pad copper -- a
             # true defect that no carve-out should silence.
-            if same_component_signal_carveout and clearance >= 0:
+            #
+            # Issue #3490: EXCEPTION -- a same-component pad on net 0
+            # (an unconnected / NC pad) carries no electrical net, so a
+            # trace endpoint that geometrically overlaps its metal is not
+            # a real short.  When such a pad sits within metal-overlap
+            # distance of the signal pad being routed (e.g. an LED whose
+            # net=0 pin is 0.2mm from its signal pin -- the exact #1764
+            # scenario), reaching the signal pad's center is impossible
+            # without entering the net=0 pad's rectangle.  The footprint
+            # guarantees the physical geometry, so silence the violation
+            # for negative clearance too -- but ONLY for net=0 pads.
+            # Foreign SIGNAL pads (net != 0) keep the strict >= 0 guard so
+            # the trace-through-pad-copper pathology (#2933) stays caught.
+            if same_component_signal_carveout and (clearance >= 0 or pad.net == 0):
                 continue
 
             if clearance < min_actual_clearance:

--- a/tests/test_router_core.py
+++ b/tests/test_router_core.py
@@ -187,10 +187,6 @@ class TestPadBlockedByAdjacentNetZero:
     area regardless of blocked/net state.
     """
 
-    @pytest.mark.xfail(
-        reason="pad blocked by adjacent net=0 pad on main -- see issue #3490",
-        strict=False,
-    )
     def test_route_to_pad_adjacent_to_net0_pad(self):
         """Route to a signal pad whose metal area overlaps with a net=0 pad's cells.
 


### PR DESCRIPTION
## Summary

`test_route_to_pad_adjacent_to_net0_pad` failed on main: a routable signal pad could not be reached because an adjacent same-component net=0 (NC/unconnected) pad whose metal overlapped it caused the clearance validator to reject every route to the pad's center. `route_net(1)` returned no routes.

## Root cause

The regression is the `clearance >= 0` guard added by **#2933** ("same-component carve-out rejects trace-through-pad-metal") and carried forward by **#3545** (net-aware validator skip) — not #3483/#3488 as the triage suspected.

The same-component carve-out (the #1764 reachability fix) only silenced a neighbour-pad clearance complaint when the trace cleared the pad metal (`clearance >= 0`). #2933 added that guard to catch traces passing *through* an opposite signal pad's copper on standard-pitch passives. But when a signal pad's metal overlaps an adjacent same-component net=0 pad (LED1: net=1 pin at x=10.0, net=0 pin at x=10.2, 0.6mm pads → metal overlap), the trace endpoint reaching the signal pad's center necessarily lies inside the net=0 pad's rectangle. Measured clearance was **-0.2mm** → carve-out skipped → route rejected → no path.

A net=0 pad carries no electrical net, so geometric overlap is not a real short and the footprint guarantees the physical geometry.

## Changes

- `validate_segment_clearance` and `worst_segment_pad_deficit` (grid.py): silence negative clearance for **net=0** same-component pads only; foreign signal pads (net != 0) keep the strict `>= 0` guard so the #2933 trace-through-copper pathology stays caught.
- C++ `validate_route` predicate (grid.cpp): same change for backend parity.
- Bumped `ROUTER_CPP_BUILD_VERSION` 11 → 12 (both `types.hpp` and `cpp_backend.py`).
- Removed the `xfail` marker from `test_route_to_pad_adjacent_to_net0_pad`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Bisect the regression | done | Root cause is the #2933 `clearance >= 0` guard (not #3483/#3488); verified by direct `validate_segment_clearance` call returning clearance=-0.2 → reject |
| Pad adjacent to net=0 pad is reachable | done | `route_net(1)` now returns 1 route (was 0); test passes |
| net=0 pads on OTHER components still block | done | `test_net0_pad_on_different_component_still_blocks` still passes (change is gated on `exclude_refs` same-component) |
| Python/C++ parity | done | Both backends updated; `test_cpp_validation_parity.py` 34 passed; build version bumped |

## Test Plan

- `TestPadBlockedByAdjacentNetZero` (both tests): PASS (0.42s — the 9-12 min figure in the issue was stale; the failure is a fast empty-route return, not a retry/rip-up exhaustion)
- `test_cpp_validation_parity.py`: 34 passed, 3 skipped
- `test_same_component_clearance.py`, `test_validate_clearance_rect_pad.py`, `test_static_halo_ripup_3545.py`, `test_static_halo_via_gate_3566.py`, `test_grid_obstacle_respect.py`: 65 passed
- `test_router_core.py` + `test_drc_regression.py`: 185 passed (protects #2933 board-02 / #3545 regressions)

Closes #3490