### PR TITLE
fix(router): refuse adjacent-pin via-in-pad pairs that violate barrel spacing

### DIFF
--- a/src/kicad_tools/router/escape.py
+++ b/src/kicad_tools/router/escape.py
@@ -1319,6 +1319,23 @@ class EscapeRouter:
         # for the named-constraint diagnostic line.
         self.missed_via_in_pad_components: set[str] = set()
 
+        # Issue #3429: Counter for adjacent-pin via-in-pad CONFLICTS that
+        # the dispatcher refused before committing a second in-pad via.
+        # Two adjacent fine-pitch QFP pins can each be flagged for an
+        # in-pad rescue, but at sub-pitch spacing their two via barrels +
+        # annular rings cannot both fit (center spacing < via_r_A +
+        # via_r_B + clearance).  ``_try_in_pad_escape`` validates the
+        # candidate via against PADS only -- sibling escapes' vias from
+        # the same pass are invisible there -- so without this guard the
+        # losing escape was silently dropped at the ``apply_escape_routes``
+        # commit-time cross-validation with no retry.  When the guard
+        # fires, the second in-pad rescue is refused (returns None) so the
+        # dispatcher falls through to the lateral / surface escape path
+        # instead of emitting a pair that the commit step later drops.
+        # Mirrors the ``missed_via_in_pad_rescues`` instrumentation
+        # pattern; consumed by diagnostics / future tier-escalation.
+        self.adjacent_in_pad_via_conflicts_refused: int = 0
+
         # Issue #3257: per-pad escape-layer overrides for SSOP/TSSOP
         # fine-pitch dual-row dispatcher.  Maps ``(ref, pin)`` to the
         # forced escape layer (``Layer.F_CU`` -> stay on surface,
@@ -2980,6 +2997,15 @@ class EscapeRouter:
                             # avoid copper conflicts with the escapes
                             # generated earlier in this pass.
                             existing_escapes=escapes,
+                            # Issue #3429: enforce via-barrel spacing
+                            # against sibling in-pad vias for the LEGACY
+                            # violation / pin_boxed rescues (which have a
+                            # lateral / surface fallback when refused).
+                            # The #3428 pocket-escape rescue is exempt --
+                            # its divergent target-aware stubs are designed
+                            # to let two adjacent in-pad vias coexist, and
+                            # it has no lateral fallback.
+                            enforce_adjacent_via_spacing=(pocket_target is None),
                         )
                         if in_pad_route is not None:
                             if pocket_target is not None:
@@ -6539,6 +6565,77 @@ class EscapeRouter:
                 return True
         return False
 
+    def _adjacent_in_pad_via_conflict(
+        self,
+        x: float,
+        y: float,
+        via_diameter: float,
+        clearance: float,
+        same_net: int,
+        existing_escapes: list[EscapeRoute] | None,
+    ) -> EscapeRoute | None:
+        """Detect a via-via spacing conflict with a sibling in-pad via.
+
+        Issue #3429 (adjacent-pin via-in-pad conflict detection): the
+        per-pad in-pad rescue (:meth:`_try_in_pad_escape`) validates a
+        candidate via only against the footprint's PADS
+        (:meth:`_via_clears_other_pads`) -- sibling escapes' vias placed
+        earlier in the SAME dispatch pass are invisible to that check
+        because the routing grid is not yet populated.  At fine pitch
+        (e.g. LQFP-48 0.5 mm) two adjacent foreign-net pins can each be
+        flagged for an in-pad rescue, but their two via barrels + annular
+        rings physically cannot coexist: the required center-to-center
+        spacing is::
+
+            via_r_A + via_r_B + clearance
+
+        which on jlcpcb-tier1 (0.6 mm OD, 0.127 mm clearance) is
+        0.3 + 0.3 + 0.127 = 0.727 mm -- already wider than the 0.5 mm
+        pitch.  Before this guard the conflict surfaced only at the
+        :meth:`apply_escape_routes` commit-time cross-validation, where
+        the losing escape was dropped with no retry (a silent gap).
+
+        This helper performs the cheap pairwise check BEFORE the second
+        via is committed so the dispatcher can refuse it and fall through
+        to the lateral / surface escape path.  Distinct from #3470's
+        :meth:`_in_pad_stub_conflicts`, which guards the inner-layer STUB
+        copper; this guards the VIA-BARREL spacing, which the stub-flip
+        retry cannot fix (flipping the stub does not move the via).
+
+        Args:
+            x: Proposed via center X (mm).
+            y: Proposed via center Y (mm).
+            via_diameter: Proposed via pad diameter (mm).
+            clearance: Required minimum via-to-via clearance (mm).
+            same_net: Net id of the via being placed; sibling vias on the
+                same net are skipped (same-net copper may share spacing).
+            existing_escapes: Escape routes accumulated so far in this
+                dispatch pass.  ``None`` (legacy call sites) disables the
+                check entirely, preserving byte-for-byte behaviour.
+
+        Returns:
+            The conflicting sibling :class:`EscapeRoute` when a foreign-net
+            in-pad via lies closer than the required center spacing, else
+            ``None``.
+        """
+        if not existing_escapes:
+            return None
+
+        via_radius = via_diameter / 2
+        for er in existing_escapes:
+            via = er.via
+            if via is None or not getattr(via, "in_pad", False):
+                continue
+            # Same-net vias do not need foreign-clearance spacing.
+            if via.net == same_net:
+                continue
+            sibling_radius = via.diameter / 2
+            required = via_radius + sibling_radius + clearance
+            dist = math.hypot(via.x - x, via.y - y)
+            if dist < required - 1e-9:
+                return er
+        return None
+
     def _try_in_pad_escape(
         self,
         pad: Pad,
@@ -6549,6 +6646,7 @@ class EscapeRouter:
         skip_on_clearance_violation: bool = False,
         target_direction: EscapeDirection | None = None,
         existing_escapes: list[EscapeRoute] | None = None,
+        enforce_adjacent_via_spacing: bool = False,
     ) -> EscapeRoute | None:
         """Attempt an in-pad via escape for a fine-pitch SSOP/TSSOP pad.
 
@@ -6646,6 +6744,20 @@ class EscapeRouter:
                 mutually block their nets' escape endpoints (board-05
                 U3 pin31/pin33 ISENSE_B-/ISENSE_A-).  ``None`` (default)
                 preserves legacy behaviour byte-for-byte.
+            enforce_adjacent_via_spacing: When True (Issue #3429), refuse
+                the rescue (return ``None``) if the candidate via barrel
+                would land closer than ``via_r + sibling_via_r +
+                clearance`` to a FOREIGN-net in-pad via already present in
+                ``existing_escapes``.  This is the via-VS-via spacing
+                guard the #3470 stub-flip cannot fix (flipping the stub
+                does not move the barrel).  It is gated to the LEGACY
+                violation / pin_boxed rescue paths, where the dispatcher
+                has a lateral / surface fallback to take when the rescue
+                is refused; it is intentionally left ``False`` for the
+                #3428 pocket-escape path, whose divergent target-aware
+                stubs are designed to let two adjacent in-pad vias
+                coexist.  ``False`` (default) preserves legacy behaviour
+                byte-for-byte for every existing call site.
 
         Returns:
             An ``EscapeRoute`` with the in-pad via and inner-layer segment,
@@ -6829,6 +6941,52 @@ class EscapeRouter:
                         via_y,
                         pad.ref,
                     )
+
+        # Issue #3429: adjacent-pin via-in-pad conflict detection.  The
+        # pad-clearance check above only validates the candidate via
+        # against the footprint's PADS; a sibling fine-pitch pin that
+        # already claimed an in-pad via in THIS pass is invisible there
+        # (the routing grid is not populated until commit time).  At
+        # sub-pitch spacing the two via barrels cannot coexist -- refuse
+        # the second rescue here so the dispatcher falls through to the
+        # lateral / surface escape path, instead of emitting a pair that
+        # ``apply_escape_routes`` later silently drops one of.  The check
+        # is a no-op when ``existing_escapes`` is None (legacy callers),
+        # preserving byte-for-byte behaviour.
+        conflicting = (
+            self._adjacent_in_pad_via_conflict(
+                x=via_x,
+                y=via_y,
+                via_diameter=via_diameter,
+                clearance=effective_clearance,
+                same_net=pad.net,
+                existing_escapes=existing_escapes,
+            )
+            if enforce_adjacent_via_spacing
+            else None
+        )
+        if conflicting is not None:
+            self.adjacent_in_pad_via_conflicts_refused += 1
+            logger.info(
+                "In-pad rescue REFUSED for pad %s (ref=%s pin=%s) at "
+                "(%.3f, %.3f): via barrel (OD %.3fmm) conflicts with the "
+                "in-pad via already claimed by sibling pin %s (net %s) at "
+                "(%.3f, %.3f) -- center spacing below via_r+via_r+clearance "
+                "at this pitch.  Returning None so the dispatcher takes the "
+                "lateral / surface escape path rather than committing a pair "
+                "that apply_escape_routes would later drop (Issue #3429).",
+                pad.net_name,
+                pad.ref,
+                pad.pin,
+                via_x,
+                via_y,
+                via_diameter,
+                conflicting.pad.pin,
+                conflicting.pad.net_name,
+                conflicting.via.x,
+                conflicting.via.y,
+            )
+            return None
 
         # Select inner escape layer (In1.Cu on 4-layer, B.Cu on 2-layer).
         escape_layer = self._select_inner_escape_layer(pad.layer)

--- a/tests/router/test_escape_adjacent_in_pad_conflict.py
+++ b/tests/router/test_escape_adjacent_in_pad_conflict.py
@@ -1,0 +1,316 @@
+"""Issue #3429: adjacent-pin via-in-pad conflict detection.
+
+Background
+----------
+
+The QFP-alternating dispatcher's per-pad in-pad rescue
+(``EscapeRouter._try_in_pad_escape``) validates a candidate via only
+against the footprint's PADS (``_via_clears_other_pads``).  Sibling
+escapes' vias placed earlier in the SAME dispatch pass are invisible to
+that check because the routing grid is not populated until commit time.
+At fine pitch (LQFP-48 0.5 mm) two adjacent foreign-net pins can each be
+flagged for an in-pad rescue, but their via barrels + annular rings
+cannot coexist: the required center-to-center spacing is
+``via_r_A + via_r_B + clearance`` (0.727 mm on jlcpcb-tier1 with 0.6 mm
+OD vias + 0.127 mm clearance) -- already wider than the 0.5 mm pitch.
+
+Before #3429 this conflict surfaced only at the ``apply_escape_routes``
+commit-time cross-validation, where the losing escape was dropped with
+no retry (a silent gap).  #3429 adds a cheap pairwise pre-check BEFORE
+the second via is committed so the dispatcher refuses it (returns None)
+and falls through to the lateral / surface escape path.
+
+Distinct from #3470 (``_in_pad_stub_conflicts``), which guards the
+inner-layer STUB copper: #3429 guards the VIA-BARREL spacing, which the
+stub-flip retry cannot fix (flipping the stub does not move the barrel).
+
+The guard is gated to the LEGACY violation / pin_boxed rescues (which
+have a lateral / surface fallback when refused).  The #3428 pocket-escape
+rescue is exempt -- its divergent target-aware stubs are designed to let
+two adjacent in-pad vias coexist.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.router.escape import (
+    EscapeDirection,
+    EscapeRoute,
+    EscapeRouter,
+)
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.primitives import Pad, Segment, Via
+from kicad_tools.router.rules import DesignRules
+
+
+def _make_rules(manufacturer: str | None = "jlcpcb-tier1") -> DesignRules:
+    return DesignRules(
+        trace_width=0.2,
+        trace_clearance=0.127,
+        via_drill=0.3,
+        via_diameter=0.6,
+        grid_resolution=0.05,
+        manufacturer=manufacturer,
+    )
+
+
+def _make_grid(rules: DesignRules) -> RoutingGrid:
+    return RoutingGrid(
+        width=30.0,
+        height=30.0,
+        rules=rules,
+        origin_x=-15.0,
+        origin_y=-15.0,
+        layer_stack=LayerStack.four_layer_sig_sig_gnd_pwr(),
+    )
+
+
+def _make_pad(x: float, y: float, net: int, name: str, pin: str = "1") -> Pad:
+    """A fine-pitch oblong pad large enough to host an in-pad via."""
+    return Pad(
+        x=x,
+        y=y,
+        width=1.5,  # long axis along X
+        height=0.3,  # short axis along Y
+        net=net,
+        net_name=name,
+        ref="U1",
+        pin=pin,
+        layer=Layer.F_CU,
+    )
+
+
+def _sibling_in_pad_escape(
+    x: float,
+    y: float,
+    net: int = 99,
+    diameter: float = 0.6,
+    pin: str = "99",
+) -> EscapeRoute:
+    """A foreign-net escape that already placed an in-pad via at (x, y)."""
+    pad = _make_pad(x, y, net, f"NET_{net}", pin=pin)
+    return EscapeRoute(
+        pad=pad,
+        direction=EscapeDirection.WEST,
+        escape_point=(x - 0.6, y),
+        escape_layer=Layer.IN1_CU,
+        via_pos=(x, y),
+        segments=[
+            Segment(
+                x1=x,
+                y1=y,
+                x2=x - 0.6,
+                y2=y,
+                width=0.2,
+                layer=Layer.IN1_CU,
+                net=net,
+                net_name=f"NET_{net}",
+            ),
+        ],
+        via=Via(
+            x=x,
+            y=y,
+            drill=diameter / 2,
+            diameter=diameter,
+            layers=(Layer.F_CU, Layer.IN1_CU),
+            net=net,
+            net_name=f"NET_{net}",
+            in_pad=True,
+        ),
+        ring_index=0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Pairwise spacing predicate (``_adjacent_in_pad_via_conflict``)
+# ---------------------------------------------------------------------------
+
+
+class TestAdjacentInPadViaConflictPredicate:
+    def test_sub_pitch_pair_conflicts(self):
+        rules = _make_rules()
+        er = EscapeRouter(_make_grid(rules), rules)
+        # Sibling 0.6 mm via 0.5 mm away: required spacing
+        # 0.3 + 0.3 + 0.127 = 0.727 mm > 0.5 mm -> conflict.
+        sibling = _sibling_in_pad_escape(0.0, 0.0, net=99)
+        conflict = er._adjacent_in_pad_via_conflict(
+            x=0.0,
+            y=0.5,
+            via_diameter=0.6,
+            clearance=0.127,
+            same_net=1,
+            existing_escapes=[sibling],
+        )
+        assert conflict is sibling
+
+    def test_coarse_pitch_pair_does_not_conflict(self):
+        rules = _make_rules()
+        er = EscapeRouter(_make_grid(rules), rules)
+        # 0.8 mm apart >= 0.727 mm required -> no conflict (the guard
+        # must NOT fire for coarse-pitch packages).
+        sibling = _sibling_in_pad_escape(0.0, 0.0, net=99)
+        assert (
+            er._adjacent_in_pad_via_conflict(
+                x=0.0,
+                y=0.8,
+                via_diameter=0.6,
+                clearance=0.127,
+                same_net=1,
+                existing_escapes=[sibling],
+            )
+            is None
+        )
+
+    def test_same_net_sibling_is_not_a_conflict(self):
+        rules = _make_rules()
+        er = EscapeRouter(_make_grid(rules), rules)
+        sibling = _sibling_in_pad_escape(0.0, 0.0, net=1)
+        assert (
+            er._adjacent_in_pad_via_conflict(
+                x=0.0,
+                y=0.5,
+                via_diameter=0.6,
+                clearance=0.127,
+                same_net=1,
+                existing_escapes=[sibling],
+            )
+            is None
+        )
+
+    def test_surface_escape_sibling_ignored(self):
+        """A sibling escape with no in-pad via is not a barrel conflict."""
+        rules = _make_rules()
+        er = EscapeRouter(_make_grid(rules), rules)
+        surface = EscapeRoute(
+            pad=_make_pad(0.0, 0.0, net=99, name="NET_99"),
+            direction=EscapeDirection.WEST,
+            escape_point=(-1.0, 0.0),
+            escape_layer=Layer.F_CU,
+            via_pos=None,
+            segments=[],
+            via=None,
+            ring_index=0,
+        )
+        assert (
+            er._adjacent_in_pad_via_conflict(
+                x=0.0,
+                y=0.5,
+                via_diameter=0.6,
+                clearance=0.127,
+                same_net=1,
+                existing_escapes=[surface],
+            )
+            is None
+        )
+
+    def test_none_existing_escapes_is_no_op(self):
+        rules = _make_rules()
+        er = EscapeRouter(_make_grid(rules), rules)
+        assert (
+            er._adjacent_in_pad_via_conflict(
+                x=0.0,
+                y=0.5,
+                via_diameter=0.6,
+                clearance=0.127,
+                same_net=1,
+                existing_escapes=None,
+            )
+            is None
+        )
+
+    def test_micro_via_pair_at_half_mm_does_not_conflict(self):
+        """0.3 mm OD micro-vias at 0.5 mm pitch: required spacing
+        0.15 + 0.15 + 0.127 = 0.427 mm < 0.5 mm -> no conflict.  This is
+        why the board-04 production recipe (``--micro-via-in-pad-fallback``)
+        can fit two adjacent in-pad vias where the standard 0.6 mm pair
+        cannot."""
+        rules = _make_rules()
+        er = EscapeRouter(_make_grid(rules), rules)
+        sibling = _sibling_in_pad_escape(0.0, 0.0, net=99, diameter=0.3)
+        assert (
+            er._adjacent_in_pad_via_conflict(
+                x=0.0,
+                y=0.5,
+                via_diameter=0.3,
+                clearance=0.127,
+                same_net=1,
+                existing_escapes=[sibling],
+            )
+            is None
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. ``_try_in_pad_escape`` refuses the conflicting second rescue
+# ---------------------------------------------------------------------------
+
+
+class TestTryInPadEscapeRefusal:
+    def _router(self) -> EscapeRouter:
+        rules = _make_rules()
+        return EscapeRouter(_make_grid(rules), rules)
+
+    def test_second_rescue_refused_when_sibling_via_conflicts(self):
+        er = self._router()
+        if not er.via_in_pad_supported:
+            import pytest
+
+            pytest.skip("manufacturer profile does not enable via-in-pad")
+        # A sibling in-pad via 0.5 mm away (sub-pitch conflict).
+        sibling = _sibling_in_pad_escape(0.0, 0.0, net=99)
+        pad = _make_pad(0.0, 0.5, net=1, name="VICTIM")
+        before = er.adjacent_in_pad_via_conflicts_refused
+        route = er._try_in_pad_escape(
+            pad=pad,
+            direction=EscapeDirection.WEST,
+            effective_clearance=0.127,
+            escape_width=0.2,
+            package=None,
+            existing_escapes=[sibling],
+            enforce_adjacent_via_spacing=True,
+        )
+        assert route is None, "conflicting second in-pad via must be refused"
+        assert er.adjacent_in_pad_via_conflicts_refused == before + 1
+
+    def test_no_refusal_when_spacing_is_adequate(self):
+        er = self._router()
+        if not er.via_in_pad_supported:
+            import pytest
+
+            pytest.skip("manufacturer profile does not enable via-in-pad")
+        sibling = _sibling_in_pad_escape(0.0, 0.0, net=99)
+        pad = _make_pad(0.0, 1.0, net=1, name="OK")  # 1.0 mm away, clears
+        route = er._try_in_pad_escape(
+            pad=pad,
+            direction=EscapeDirection.WEST,
+            effective_clearance=0.127,
+            escape_width=0.2,
+            package=None,
+            existing_escapes=[sibling],
+            enforce_adjacent_via_spacing=True,
+        )
+        assert route is not None
+        assert route.via is not None and route.via.in_pad
+        assert er.adjacent_in_pad_via_conflicts_refused == 0
+
+    def test_guard_disabled_by_default_preserves_legacy(self):
+        """``enforce_adjacent_via_spacing`` defaults to False -- the same
+        conflicting geometry produces a via, exactly as before #3429."""
+        er = self._router()
+        if not er.via_in_pad_supported:
+            import pytest
+
+            pytest.skip("manufacturer profile does not enable via-in-pad")
+        sibling = _sibling_in_pad_escape(0.0, 0.0, net=99)
+        pad = _make_pad(0.0, 0.5, net=1, name="VICTIM")
+        route = er._try_in_pad_escape(
+            pad=pad,
+            direction=EscapeDirection.WEST,
+            effective_clearance=0.127,
+            escape_width=0.2,
+            package=None,
+            existing_escapes=[sibling],
+            # enforce_adjacent_via_spacing omitted -> default False
+        )
+        assert route is not None and route.via is not None
+        assert er.adjacent_in_pad_via_conflicts_refused == 0


### PR DESCRIPTION
## Summary

Defense-in-depth for the board-04 fine-pitch QFP escape path (parent #3411).
Adds adjacent-pin via-in-pad **barrel-spacing** conflict detection to the
`_escape_qfp_alternating` dispatcher so two adjacent fine-pitch pins can no
longer both commit an in-pad via that physically cannot coexist.

Per the curator's sequencing note, #3428 (target-aware inner direction) was
the DIRECT fix and has already merged; board 04 already reaches 9/9. This PR
implements the remaining hardening: refuse geometrically-impossible rescue
pairs *before* the second via is generated, instead of having
`apply_escape_routes` silently drop one at commit time.

## Changes

- `_adjacent_in_pad_via_conflict(...)` — pairwise predicate: returns the
  conflicting sibling `EscapeRoute` when a foreign-net in-pad via lies closer
  than `via_r_A + via_r_B + clearance` (0.727mm for 0.6mm vias + 0.127mm
  clearance on jlcpcb-tier1; > the 0.5mm LQFP-48 pitch).
- `_try_in_pad_escape(..., enforce_adjacent_via_spacing=False)` — when True,
  refuses the rescue (returns `None`) on a barrel conflict, increments the
  new `adjacent_in_pad_via_conflicts_refused` counter, and emits a structured
  `logger.info` line (mirrors the `missed_via_in_pad_rescues` pattern).
- Dispatcher passes `enforce_adjacent_via_spacing=(pocket_target is None)` so
  the guard is active on the LEGACY violation/pin_boxed rescues (which have a
  lateral/surface fallback when refused) and **exempt** for the #3428
  pocket-escape rescue (whose divergent target-aware stubs are designed to let
  two adjacent in-pad vias coexist).
- New unit suite `tests/router/test_escape_adjacent_in_pad_conflict.py`.

The guard is distinct from #3470's `_in_pad_stub_conflicts`: that flips the
inner-layer STUB direction, which cannot resolve a VIA-BARREL conflict
(flipping the stub does not move the barrel). Default `False` keeps every
existing call site byte-for-byte unchanged.

## Acceptance Criteria Verification

| Criterion (curator-revised AC) | Status | Verification |
|---|---|---|
| Pre-scan detects adjacent same-edge in-pad rescue pairs below required via-via spacing before the 2nd via is committed | ✅ | `_adjacent_in_pad_via_conflict` runs inside `_try_in_pad_escape` before the `Via(...)` is built |
| On detection, refuse the 2nd in-pad rescue (no pair that `apply_escape_routes` later drops) | ✅ | returns `None`; dispatcher falls to lateral/surface path |
| Refusal is observable: structured log + counter | ✅ | `adjacent_in_pad_via_conflicts_refused` counter + `logger.info` |
| Synthetic-fixture test: pair conflict refused, coarse pitch does not fire, legacy preserved | ✅ | 9 tests in the new file (sub-pitch conflicts, 0.8mm coarse OK, micro-via 0.3mm OK, same-net skip, surface-escape skip, default-off legacy) |
| Board-04 (conditional after #3428) | ✅ | production recipe routes **9/9 (100%)** |
| No regression on boards 03/05/07 escape patterns | ✅ | full escape/router suites green (see Test Plan) |

## Test Plan

- New: `tests/router/test_escape_adjacent_in_pad_conflict.py` — 9 passed.
- #3428 regression: `tests/router/test_escape_target_direction.py` — pocket-escape rescue still fires (exempt from the guard); all pass.
- Escape suites (boards 03/05/07 patterns + LQFP/strict/lateral/stub-conflict/missed-rescue/extended-pitch): 214+ passed.
- Integration: `kct route boards/04-stm32-devboard/output/stm32_devboard.kicad_pcb --mfr jlcpcb-tier1 --auto-fix --auto-layers --max-layers 4 --auto-mfr-tier --placement-feedback --micro-via-in-pad-fallback --seed 42` → **Nets routed: 9/9**.

Closes #3429