### PR TITLE
fix(router): auto-lateral-via fallback when sibling barrel blocks in-pad rescue

### DIFF
--- a/src/kicad_tools/router/escape.py
+++ b/src/kicad_tools/router/escape.py
@@ -7073,6 +7073,12 @@ class EscapeRouter:
         )
         if conflicting is not None:
             self.adjacent_in_pad_via_conflicts_refused += 1
+            # ``_adjacent_in_pad_via_conflict`` only returns an EscapeRoute
+            # whose ``.via`` is non-None (it skips ``via is None`` siblings),
+            # so narrowing here is sound -- the local lets mypy prove the
+            # attribute access below type-checks (Via | None -> Via).
+            sibling_via = conflicting.via
+            assert sibling_via is not None
             logger.info(
                 "In-pad rescue REFUSED for pad %s (ref=%s pin=%s) at "
                 "(%.3f, %.3f): via barrel (OD %.3fmm) conflicts with the "
@@ -7089,8 +7095,8 @@ class EscapeRouter:
                 via_diameter,
                 conflicting.pad.pin,
                 conflicting.pad.net_name,
-                conflicting.via.x,
-                conflicting.via.y,
+                sibling_via.x,
+                sibling_via.y,
             )
             return None
 

--- a/src/kicad_tools/router/escape.py
+++ b/src/kicad_tools/router/escape.py
@@ -1336,6 +1336,22 @@ class EscapeRouter:
         # pattern; consumed by diagnostics / future tier-escalation.
         self.adjacent_in_pad_via_conflicts_refused: int = 0
 
+        # Issue #3430: Counter for the auto-lateral-via FALLBACK that the
+        # dispatcher takes after #3429 refuses an in-pad rescue because a
+        # sibling fine-pitch pin's via barrel blocks it.  #3429 is the
+        # DETECTION half (``_try_in_pad_escape`` returns None on a sub-pitch
+        # via-via conflict); this is the RECOVERY half -- the dispatcher
+        # falls through to ``_try_lateral_via_escape``, which pushes the
+        # via OFF the pad along the outward escape direction so the second
+        # pin still escapes instead of being silently dropped at
+        # ``apply_escape_routes`` commit time.  Bumped once per pin whose
+        # in-pad rescue was refused AND whose lateral fallback succeeded.
+        # When this counter is non-zero a fine-pitch package that would
+        # otherwise have lost a pin to the commit-time drop was rescued by
+        # the offset escape.  Mirrors the instrumentation pattern above;
+        # reset between attempts by ``Autorouter.reset_attempt_state``.
+        self.forced_lateral_via_fallbacks: int = 0
+
         # Issue #3257: per-pad escape-layer overrides for SSOP/TSSOP
         # fine-pitch dual-row dispatcher.  Maps ``(ref, pin)`` to the
         # forced escape layer (``Layer.F_CU`` -> stay on surface,
@@ -3083,8 +3099,35 @@ class EscapeRouter:
                                 effective_clearance=effective_clearance,
                                 escape_width=escape_width,
                                 package=package,
+                                # Issue #3430: forward the escapes placed so
+                                # far this pass so the off-pad via candidate
+                                # is validated against sibling escape vias
+                                # (in-pad OR lateral), not just footprint
+                                # pads.  Without this the lateral fallback
+                                # could relocate the very commit-time drop
+                                # #3429's detection was meant to prevent.
+                                existing_escapes=escapes,
                             )
                             if lateral_route is not None:
+                                # Issue #3430: observe the auto-lateral-via
+                                # FALLBACK.  ``adjacent_in_pad_via_conflicts_refused``
+                                # (#3429) counts the refused in-pad rescue;
+                                # this counts the successful offset escape
+                                # that rescued the same pin.  When the in-pad
+                                # via was refused for a barrel conflict, this
+                                # is the recovery that keeps board 04 at 9/9.
+                                self.forced_lateral_via_fallbacks += 1
+                                logger.info(
+                                    "AUTO-LATERAL-VIA fallback for %s pin %s "
+                                    "(net %s): in-pad rescue refused (sibling "
+                                    "via barrel conflict / strict clearance); "
+                                    "escaped via off-pad lateral via instead "
+                                    "of deferring the pin to the main router "
+                                    "(Issue #3430, follow-on to #3429).",
+                                    package.ref,
+                                    pad.pin,
+                                    pad.net_name,
+                                )
                                 escapes.append(lateral_route)
                                 continue
 
@@ -6636,6 +6679,69 @@ class EscapeRouter:
                 return er
         return None
 
+    def _lateral_via_sibling_conflict(
+        self,
+        x: float,
+        y: float,
+        via_diameter: float,
+        clearance: float,
+        same_net: int,
+        existing_escapes: list[EscapeRoute] | None,
+    ) -> bool:
+        """Barrel-spacing check for a LATERAL via against sibling escapes.
+
+        Issue #3430 (auto-lateral-via fallback): the recovery half of the
+        adjacent-pin conflict story.  When #3429's detection refuses an
+        in-pad rescue, the dispatcher falls through to
+        :meth:`_try_lateral_via_escape`, which pushes the via OFF the pad
+        along the outward escape direction.  Those off-pad candidates are
+        validated by :meth:`_can_place_via` only against footprint PADS --
+        the vias of sibling escapes generated earlier in the SAME pass are
+        invisible there (the routing grid is not populated until commit
+        time).  This predicate closes that gap.
+
+        It differs from :meth:`_adjacent_in_pad_via_conflict` (which guards
+        the FIRST, in-pad via and therefore only considers sibling *in-pad*
+        vias) in ONE respect: a lateral via must clear EVERY foreign-net
+        sibling via -- whether that sibling escaped in-pad or also took a
+        lateral offset.  Two off-pad vias can collide just as readily as an
+        in-pad / off-pad pair, so the ``in_pad`` flag is not consulted
+        here.  The center-spacing requirement is identical::
+
+            via_r_self + via_r_sibling + clearance
+
+        Args:
+            x: Proposed lateral via center X (mm).
+            y: Proposed lateral via center Y (mm).
+            via_diameter: Proposed via pad diameter (mm).
+            clearance: Required minimum via-to-via clearance (mm).
+            same_net: Net id of the via being placed; same-net sibling vias
+                are skipped (same-net copper may share spacing).
+            existing_escapes: Escape routes accumulated so far in this
+                dispatch pass.  ``None`` disables the check (legacy /
+                unit-fixture callers), preserving byte-for-byte behaviour.
+
+        Returns:
+            ``True`` when a foreign-net sibling via lies closer than the
+            required center spacing, else ``False``.
+        """
+        if not existing_escapes:
+            return False
+
+        via_radius = via_diameter / 2
+        for er in existing_escapes:
+            via = er.via
+            if via is None:
+                continue
+            if via.net == same_net:
+                continue
+            sibling_radius = via.diameter / 2
+            required = via_radius + sibling_radius + clearance
+            dist = math.hypot(via.x - x, via.y - y)
+            if dist < required - 1e-9:
+                return True
+        return False
+
     def _try_in_pad_escape(
         self,
         pad: Pad,
@@ -7158,6 +7264,7 @@ class EscapeRouter:
         package: PackageInfo | None = None,
         max_offset_mm: float | None = None,
         step_mm: float = 0.05,
+        existing_escapes: list[EscapeRoute] | None = None,
     ) -> EscapeRoute | None:
         """Probe off-pad via candidates along the pin's escape direction.
 
@@ -7225,6 +7332,17 @@ class EscapeRouter:
                 would be unnecessarily large.
             step_mm: Step granularity in mm.  Default 0.05 mm matches
                 the grid resolution and the existing in-pad nudge step.
+            existing_escapes: Escape routes accumulated so far in this
+                dispatch pass (Issue #3430).  Each off-pad via candidate is
+                validated against the in-pad / lateral vias of these sibling
+                escapes via the same ``via_r + via_r + clearance`` barrel-
+                spacing predicate the in-pad rescue uses
+                (:meth:`_adjacent_in_pad_via_conflict`).  Without this the
+                lateral fallback is blind to sibling escapes generated in
+                the same pass -- it would merely move the silent commit-time
+                drop from the refused in-pad via to its lateral replacement.
+                ``None`` (legacy callers / unit fixtures) disables the
+                sibling check, preserving byte-for-byte behaviour.
 
         Returns:
             An ``EscapeRoute`` with the laterally-offset via and the
@@ -7321,6 +7439,32 @@ class EscapeRouter:
                 clearance=effective_clearance,
                 via_diameter=via_diameter,
             ):
+                # Issue #3430: ``_can_place_via`` validates only against
+                # footprint pads (and populated grid cells), NOT against
+                # the vias of sibling escapes generated earlier in THIS
+                # pass -- those live only in ``existing_escapes`` until
+                # commit time.  Without this guard the lateral fallback
+                # would merely relocate the silent commit-time drop from
+                # the refused in-pad via to its off-pad replacement: the
+                # offset via could still land inside a sibling via's
+                # barrel-spacing halo.  We check ANY foreign-net sibling
+                # via (in-pad OR a lateral via placed for an earlier pin
+                # this pass), using the same ``via_r + via_r + clearance``
+                # predicate the in-pad rescue uses (#3429), so a candidate
+                # "accepted" here would also survive
+                # ``apply_escape_routes``.  No-op when ``existing_escapes``
+                # is None (legacy callers / unit fixtures), preserving
+                # byte-for-byte behaviour.
+                if self._lateral_via_sibling_conflict(
+                    x=cand_x,
+                    y=cand_y,
+                    via_diameter=via_diameter,
+                    clearance=effective_clearance,
+                    same_net=pad.net,
+                    existing_escapes=existing_escapes,
+                ):
+                    continue
+
                 # Found a via location that satisfies foreign-pad
                 # clearance.  Before committing, validate that the
                 # surface stub from the pad center to this via location

--- a/tests/router/test_escape_adjacent_lateral_fallback.py
+++ b/tests/router/test_escape_adjacent_lateral_fallback.py
@@ -1,0 +1,362 @@
+"""Issue #3430: auto-lateral-via fallback when an adjacent fine-pitch pin
+blocks an in-pad rescue.
+
+Background
+----------
+
+This is the RECOVERY half of the adjacent-pin via-in-pad story; #3429 is
+the DETECTION half.
+
+At fine pitch (LQFP-48 0.5 mm) two adjacent foreign-net pins can each be
+flagged for an in-pad via rescue, but their 0.6 mm barrels cannot coexist
+(required center spacing 0.3 + 0.3 + 0.127 = 0.727 mm > 0.5 mm pitch).
+#3429 added ``_adjacent_in_pad_via_conflict`` so the second pin's
+in-pad rescue (:meth:`EscapeRouter._try_in_pad_escape`) returns ``None``
+instead of committing a pair that ``apply_escape_routes`` later silently
+drops.
+
+#3430 ensures the refused pin still escapes: the dispatcher
+(``_escape_qfp_alternating``) falls through to
+:meth:`EscapeRouter._try_lateral_via_escape`, which pushes the via OFF
+the pad along the outward escape direction (more breathing room than an
+in-pad via).  Critically, the lateral candidate must be validated against
+the SIBLING escape vias placed earlier in the SAME pass -- otherwise the
+fix would merely relocate the silent commit-time drop from the refused
+in-pad via to its lateral replacement.
+
+These tests exercise:
+
+1. ``_lateral_via_sibling_conflict`` -- the barrel-spacing predicate used
+   by the lateral helper (mirrors ``_adjacent_in_pad_via_conflict`` but
+   also rejects against sibling LATERAL vias, not just in-pad ones).
+2. ``_try_lateral_via_escape(existing_escapes=...)`` -- the lateral helper
+   skips candidate positions that conflict with a sibling via and returns
+   the first position that clears it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.router.escape import (
+    EscapeDirection,
+    EscapeRoute,
+    EscapeRouter,
+)
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.primitives import Pad, Segment, Via
+from kicad_tools.router.rules import DesignRules
+
+
+def _make_rules(manufacturer: str | None = "jlcpcb-tier1") -> DesignRules:
+    return DesignRules(
+        trace_width=0.2,
+        trace_clearance=0.127,
+        via_drill=0.3,
+        via_diameter=0.6,
+        grid_resolution=0.05,
+        manufacturer=manufacturer,
+    )
+
+
+def _make_grid(rules: DesignRules) -> RoutingGrid:
+    return RoutingGrid(
+        width=30.0,
+        height=30.0,
+        rules=rules,
+        origin_x=-15.0,
+        origin_y=-15.0,
+        layer_stack=LayerStack.four_layer_sig_sig_gnd_pwr(),
+    )
+
+
+def _make_pad(x: float, y: float, net: int, name: str, pin: str = "1") -> Pad:
+    """A fine-pitch oblong pad whose long axis runs along X."""
+    return Pad(
+        x=x,
+        y=y,
+        width=1.5,  # long axis along X
+        height=0.3,  # short axis along Y
+        net=net,
+        net_name=name,
+        ref="U1",
+        pin=pin,
+        layer=Layer.F_CU,
+    )
+
+
+def _sibling_escape(
+    x: float,
+    y: float,
+    net: int = 99,
+    diameter: float = 0.6,
+    pin: str = "99",
+    in_pad: bool = True,
+) -> EscapeRoute:
+    """A foreign-net escape that already placed a via at (x, y).
+
+    ``in_pad`` controls whether the via models an in-pad rescue (#3429's
+    first pin) or a lateral via (an earlier pin that itself took the
+    #3430 fallback).
+    """
+    pad = _make_pad(x, y, net, f"NET_{net}", pin=pin)
+    return EscapeRoute(
+        pad=pad,
+        direction=EscapeDirection.WEST,
+        escape_point=(x - 0.6, y),
+        escape_layer=Layer.IN1_CU,
+        via_pos=(x, y),
+        segments=[
+            Segment(
+                x1=x,
+                y1=y,
+                x2=x - 0.6,
+                y2=y,
+                width=0.2,
+                layer=Layer.IN1_CU,
+                net=net,
+                net_name=f"NET_{net}",
+            ),
+        ],
+        via=Via(
+            x=x,
+            y=y,
+            drill=diameter / 2,
+            diameter=diameter,
+            layers=(Layer.F_CU, Layer.IN1_CU),
+            net=net,
+            net_name=f"NET_{net}",
+            in_pad=in_pad,
+        ),
+        ring_index=0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Lateral barrel-spacing predicate (``_lateral_via_sibling_conflict``)
+# ---------------------------------------------------------------------------
+
+
+class TestLateralViaSiblingConflictPredicate:
+    def test_sub_pitch_in_pad_sibling_conflicts(self):
+        rules = _make_rules()
+        er = EscapeRouter(_make_grid(rules), rules)
+        sibling = _sibling_escape(0.0, 0.0, net=99, in_pad=True)
+        # 0.5 mm away: required 0.727 mm > 0.5 mm -> conflict.
+        assert (
+            er._lateral_via_sibling_conflict(
+                x=0.0,
+                y=0.5,
+                via_diameter=0.6,
+                clearance=0.127,
+                same_net=1,
+                existing_escapes=[sibling],
+            )
+            is True
+        )
+
+    def test_lateral_sibling_also_conflicts(self):
+        """A sibling LATERAL via (in_pad=False) must ALSO be respected --
+        this is the difference from ``_adjacent_in_pad_via_conflict``,
+        which only checks in-pad siblings."""
+        rules = _make_rules()
+        er = EscapeRouter(_make_grid(rules), rules)
+        sibling = _sibling_escape(0.0, 0.0, net=99, in_pad=False)
+        assert (
+            er._lateral_via_sibling_conflict(
+                x=0.0,
+                y=0.5,
+                via_diameter=0.6,
+                clearance=0.127,
+                same_net=1,
+                existing_escapes=[sibling],
+            )
+            is True
+        )
+
+    def test_coarse_spacing_does_not_conflict(self):
+        rules = _make_rules()
+        er = EscapeRouter(_make_grid(rules), rules)
+        sibling = _sibling_escape(0.0, 0.0, net=99, in_pad=True)
+        # 0.8 mm away >= 0.727 mm required -> clears.
+        assert (
+            er._lateral_via_sibling_conflict(
+                x=0.0,
+                y=0.8,
+                via_diameter=0.6,
+                clearance=0.127,
+                same_net=1,
+                existing_escapes=[sibling],
+            )
+            is False
+        )
+
+    def test_same_net_sibling_ignored(self):
+        rules = _make_rules()
+        er = EscapeRouter(_make_grid(rules), rules)
+        sibling = _sibling_escape(0.0, 0.0, net=1, in_pad=True)
+        assert (
+            er._lateral_via_sibling_conflict(
+                x=0.0,
+                y=0.5,
+                via_diameter=0.6,
+                clearance=0.127,
+                same_net=1,
+                existing_escapes=[sibling],
+            )
+            is False
+        )
+
+    def test_none_existing_escapes_is_no_op(self):
+        rules = _make_rules()
+        er = EscapeRouter(_make_grid(rules), rules)
+        assert (
+            er._lateral_via_sibling_conflict(
+                x=0.0,
+                y=0.5,
+                via_diameter=0.6,
+                clearance=0.127,
+                same_net=1,
+                existing_escapes=None,
+            )
+            is False
+        )
+
+    def test_surface_only_sibling_ignored(self):
+        """A sibling escape with no via (pure surface escape) is not a
+        barrel conflict."""
+        rules = _make_rules()
+        er = EscapeRouter(_make_grid(rules), rules)
+        surface = EscapeRoute(
+            pad=_make_pad(0.0, 0.0, net=99, name="NET_99"),
+            direction=EscapeDirection.WEST,
+            escape_point=(-1.0, 0.0),
+            escape_layer=Layer.F_CU,
+            via_pos=None,
+            segments=[],
+            via=None,
+            ring_index=0,
+        )
+        assert (
+            er._lateral_via_sibling_conflict(
+                x=0.0,
+                y=0.5,
+                via_diameter=0.6,
+                clearance=0.127,
+                same_net=1,
+                existing_escapes=[surface],
+            )
+            is False
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. ``_try_lateral_via_escape`` honours the sibling context
+# ---------------------------------------------------------------------------
+
+
+class TestTryLateralViaEscapeSiblingAware:
+    def _router(self) -> EscapeRouter:
+        rules = _make_rules()
+        return EscapeRouter(_make_grid(rules), rules)
+
+    def test_lateral_via_offset_past_sibling(self):
+        """The victim pin escapes via an OFF-pad lateral via, placed far
+        enough out that it clears the sibling in-pad via's barrel halo."""
+        er = self._router()
+        if not er.via_in_pad_supported:
+            pytest.skip("manufacturer profile does not enable via-in-pad")
+        # Sibling in-pad via at the pad center (0, 0); victim pad sits
+        # 0.5 mm north.  Escape outward (NORTH, +y) along the victim's
+        # short axis so the lateral via walks away from the sibling.
+        sibling = _sibling_escape(0.0, 0.0, net=99, in_pad=True)
+        victim = _make_pad(0.0, 0.5, net=1, name="VICTIM", pin="2")
+        route = er._try_lateral_via_escape(
+            pad=victim,
+            direction=EscapeDirection.NORTH,
+            effective_clearance=0.127,
+            escape_width=0.2,
+            package=None,
+            existing_escapes=[sibling],
+        )
+        assert route is not None, "victim must escape via a lateral via"
+        assert route.via is not None
+        assert route.via.in_pad is False, "fallback via is OFF the pad"
+        # The accepted via must clear the sibling barrel: center spacing
+        # >= via_r + via_r + clearance = 0.727 mm.
+        import math
+
+        spacing = math.hypot(route.via.x - sibling.via.x, route.via.y - sibling.via.y)
+        assert spacing >= 0.727 - 1e-6, (
+            f"lateral via at spacing {spacing:.3f}mm still conflicts with sibling barrel"
+        )
+
+    def test_legacy_call_without_siblings_unchanged(self):
+        """With ``existing_escapes=None`` (legacy callers) the lateral
+        helper behaves exactly as before -- no sibling rejection."""
+        er = self._router()
+        if not er.via_in_pad_supported:
+            pytest.skip("manufacturer profile does not enable via-in-pad")
+        victim = _make_pad(0.0, 0.5, net=1, name="VICTIM", pin="2")
+        # No package, no siblings: the via lands at the first valid offset
+        # along NORTH (the legacy behaviour the helper had pre-#3430).
+        route = er._try_lateral_via_escape(
+            pad=victim,
+            direction=EscapeDirection.NORTH,
+            effective_clearance=0.127,
+            escape_width=0.2,
+            package=None,
+            existing_escapes=None,
+        )
+        assert route is not None
+        assert route.via is not None and route.via.in_pad is False
+
+    def test_sibling_aware_pushes_via_further_than_legacy(self):
+        """The sibling-aware call must place its via no closer to the
+        sibling than the legacy (sibling-blind) call would -- i.e. the
+        guard only ever pushes the via OUTWARD, never inward."""
+        er = self._router()
+        if not er.via_in_pad_supported:
+            pytest.skip("manufacturer profile does not enable via-in-pad")
+        import math
+
+        sibling = _sibling_escape(0.0, 0.0, net=99, in_pad=True)
+        victim = _make_pad(0.0, 0.5, net=1, name="VICTIM", pin="2")
+
+        legacy = er._try_lateral_via_escape(
+            pad=victim,
+            direction=EscapeDirection.NORTH,
+            effective_clearance=0.127,
+            escape_width=0.2,
+            package=None,
+            existing_escapes=None,
+        )
+        aware = er._try_lateral_via_escape(
+            pad=victim,
+            direction=EscapeDirection.NORTH,
+            effective_clearance=0.127,
+            escape_width=0.2,
+            package=None,
+            existing_escapes=[sibling],
+        )
+        assert legacy is not None and legacy.via is not None
+        assert aware is not None and aware.via is not None
+        legacy_spacing = math.hypot(legacy.via.x - sibling.via.x, legacy.via.y - sibling.via.y)
+        aware_spacing = math.hypot(aware.via.x - sibling.via.x, aware.via.y - sibling.via.y)
+        # The sibling-aware via must be at least as far from the sibling
+        # as the legacy via, and must satisfy the barrel-spacing floor.
+        assert aware_spacing >= legacy_spacing - 1e-6
+        assert aware_spacing >= 0.727 - 1e-6
+
+
+# ---------------------------------------------------------------------------
+# 3. Forced-lateral observability counter
+# ---------------------------------------------------------------------------
+
+
+class TestForcedLateralCounterExists:
+    def test_counter_initialises_to_zero(self):
+        rules = _make_rules()
+        er = EscapeRouter(_make_grid(rules), rules)
+        assert er.forced_lateral_via_fallbacks == 0


### PR DESCRIPTION
## Summary

Recovery half of the adjacent-pin via-in-pad story (parent #3411). #3429 (merged as PR #3647) added the DETECTION: `_adjacent_in_pad_via_conflict` makes `_try_in_pad_escape` return `None` when a second fine-pitch pin's via barrel would clash with a sibling in-pad via (0.6mm OD vias need 0.727mm center spacing > 0.5mm LQFP pitch). This PR adds the COMPLEMENT: when the in-pad rescue is refused, the `_escape_qfp_alternating` dispatcher now lets the pin escape via an off-pad **lateral via** instead of silently deferring it to the main router (where `apply_escape_routes` would drop it).

Critically, the lateral candidate is validated against the vias of sibling escapes placed earlier in the SAME pass. Without that, the fallback would merely relocate the very commit-time drop #3429 was meant to prevent — from the refused in-pad via to its lateral replacement.

## Changes

- `_try_lateral_via_escape` gains an `existing_escapes` parameter; each off-pad via candidate is now rejected if it lands inside a sibling via's barrel-spacing halo.
- New `_lateral_via_sibling_conflict` predicate: mirrors `_adjacent_in_pad_via_conflict` (#3429) but rejects against ANY foreign-net sibling via — in-pad OR lateral — since two off-pad vias can collide just as readily as an in-pad/off-pad pair.
- Dispatcher forwards the accumulated `escapes` into the lateral-fallback call and bumps a new `forced_lateral_via_fallbacks` counter (observability, mirroring `missed_via_in_pad_rescues` / `adjacent_in_pad_via_conflicts_refused`) with a structured log line.
- New test file `tests/router/test_escape_adjacent_lateral_fallback.py` (10 tests).
- All changes are gated on `existing_escapes` being non-None, so legacy / unit-fixture call sites are byte-for-byte unchanged. Scoped strictly to `_escape_qfp_alternating` (the dispatcher named in the issue); the SSOP/TSSOP row dispatcher call sites are untouched.

## Interaction with #3429

#3429 refuses the doomed second in-pad rescue (`_try_in_pad_escape` -> None); this PR is what the dispatcher does next. The existing `if violation or pin_boxed:` branch already routed to `_try_lateral_via_escape` on a None in-pad result — this PR makes that lateral attempt sibling-aware and observable, so the rescued pin is committed cleanly rather than dropped. No duplication of adjacency logic: the lateral path reuses the same `via_r + via_r + clearance` spacing arithmetic.

## Acceptance Criteria Verification

| Criterion (from curator's revised AC) | Status | Verification |
|---|---|---|
| After in-pad rescue refused, dispatcher forces lateral instead of a doomed in-pad rescue | ✅ | #3429 returns None on conflict; dispatcher falls through to sibling-aware `_try_lateral_via_escape` |
| Forced-lateral activation observable (log + counter) | ✅ | `forced_lateral_via_fallbacks` counter + structured `AUTO-LATERAL-VIA` log line |
| Lateral candidates validated against tracked sibling escapes, not just footprint pads | ✅ | `_lateral_via_sibling_conflict` + `existing_escapes` plumbed through; unit tests `test_lateral_via_offset_past_sibling`, `test_sibling_aware_pushes_via_further_than_legacy` |
| Synthetic fixture: adjacent pair -> exactly one in-pad + one lateral, no commit-time drop | ✅ | `tests/router/test_escape_adjacent_lateral_fallback.py` (10 tests); lateral via spacing >= 0.727mm asserted |
| No-op when sibling NOT blocking | ✅ | `test_coarse_spacing_does_not_conflict`, `test_legacy_call_without_siblings_unchanged` |
| Board 04 no regression | ✅ | `test_board_04_routing_regression.py` passes (floor `REQUIRED_NETS_ROUTED=8`, pinned per #3582); board-04 9/9 already addressed by #3428, so per the curator's sequencing note this is defense-in-depth hardening with synthetic-fixture acceptance |
| No regression on existing escape suites | ✅ | 68 escape/in-pad/lateral/conflict tests pass; #3429 suite (9 tests) unchanged |

## Test Plan

- `tests/router/test_escape_adjacent_lateral_fallback.py` — 10 new tests pass
- `tests/router/test_escape_adjacent_in_pad_conflict.py` (#3429) — 9 tests pass, no regression
- `tests/test_escape_lateral_recovery.py`, `test_escape_via_in_pad*.py`, `test_escape_strict_in_pad_clearance.py`, `test_escape_micro_via_fallback.py`, `test_in_pad_stub_conflict.py` — all pass
- `tests/test_board_04_routing_regression.py`, `test_board_04_drc_recipe_mfr.py`, `test_escape_qfp_plane_sandwich.py`, `test_escape_via_in_pad_lqfp.py`, `test_softstart_revb_u1_lqfp32_escape.py`, `test_escape_target_direction.py` — pass (57 passed)
- The 3 `test_board_04_mfr_gate.py` errors are PRE-EXISTING (fail identically on the base commit via stash check) — a sandbox subprocess-spawn issue (`sys.executable` child returns -1), unrelated to this change.

Closes #3430