### PR TITLE
docs(router): repoint stale escape.py comment to live rev B harness

### DIFF
--- a/src/kicad_tools/router/escape.py
+++ b/src/kicad_tools/router/escape.py
@@ -1363,8 +1363,8 @@ class EscapeRouter:
         # post-escape layer (e.g. softstart U1 east column where pin 17
         # SWDIO odd-via to B.Cu and pin 15 STATUS_LED odd-via to B.Cu
         # produce overlapping B.Cu routes near the U1 east-side cluster
-        # -- the documented 4-violation residual the
-        # ``test_softstart_manufacturable_baseline`` test pinned).
+        # -- the kind of fine-pitch escape regression now guarded by the
+        # rev B harness ``test_softstart_revb_fine_pitch_escape``).
         #
         # Env-var encoding (preferred for both CLI and Python callers):
         #


### PR DESCRIPTION
## Summary
A prose comment in `src/kicad_tools/router/escape.py` referenced the test `test_softstart_manufacturable_baseline`, which was deleted in PR #3640 (issue #3492). This repoints the dangling reference to the live rev B escape harness and drops the now-obsolete "4-violation residual" claim. Comment-only change; no code logic altered.

## Changes
- In the `escape_pad_layer_overrides` doc comment (was escape.py:1366-1367), replaced the dangling reference to the deleted `test_softstart_manufacturable_baseline` with a pointer to the live `tests/router/test_softstart_revb_fine_pitch_escape.py` harness, and removed the stale 4-violation-residual wording (the post-#3287/#3297 floor is 0 seg-seg violations).

Before:
```
# -- the documented 4-violation residual the
# ``test_softstart_manufacturable_baseline`` test pinned).
```
After:
```
# -- the kind of fine-pitch escape regression now guarded by the
# rev B harness ``test_softstart_revb_fine_pitch_escape``).
```

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Stale `test_softstart_manufacturable_baseline` reference removed from source | done | `grep -rn test_softstart_manufacturable_baseline src/` returns no matches |
| Comment points to live harness (or drops dangling ref) | done | Now references `test_softstart_revb_fine_pitch_escape`; file confirmed present at `tests/router/test_softstart_revb_fine_pitch_escape.py` |
| No code logic changed | done | `git diff` shows only the 2-line comment edit |

## Test Plan
- `git diff` confirms the change is comment-only (2 lines, lines 1366-1367 region).
- `grep -rn test_softstart_manufacturable_baseline src/` -> no matches.
- Confirmed `tests/router/test_softstart_revb_fine_pitch_escape.py` exists.
- Note: `check_mypy_baseline.py` and `ruff check escape.py` report pre-existing, tree-wide failures (stale mypy baseline; ruff findings at lines 1387 and 3401-3408) that are unrelated to and untouched by this comment edit.

Closes #3641