### PR TITLE
fix(router): align C++ standard-mode is_via_blocked with Python (#864 parity)

### DIFF
--- a/src/kicad_tools/router/cpp/include/types.hpp
+++ b/src/kicad_tools/router/cpp/include/types.hpp
@@ -109,7 +109,26 @@ namespace router {
 // own-net-obstacle reject pinned by
 // tests/test_cpp_pathfinder_own_net_obstacle.py (verified NOT needed
 // for the board-03 fallbacks).
-constexpr int ROUTER_CPP_BUILD_VERSION = 13;
+//
+// Version 14 (Issue #3622): complete the standard-mode own-net-obstacle
+// parity family by aligning the THIRD sibling predicate,
+// ``Pathfinder::is_via_blocked`` (both the cached fast path and the
+// per-net-radius slow path), with the Python ``_is_via_blocked``
+// standard branch (Issue #864: "same-net passable, different nets
+// block"; it does NOT consult ``is_obstacle``).  Pre-#3622 the standard
+// arm rejected a via candidate whose Euclidean disc touched the routing
+// net's OWN ``is_obstacle`` pad copper (``cell.is_obstacle ||
+// cell.net != net``); a board that routes a via through its own
+// destination pad in the Python fallback but not in C++ is another
+// silent-fallback seed of the #3456 class.  Both backends now read
+// ``if (cell.net != net) return true;`` for the standard via predicate.
+// The single-layer (``allowed_layers``) invariant is preserved by a
+// Python-side routable-layer guard in
+// ``cpp_backend.py::CppPathfinder._apply_allowed_layers_to_routable``
+// (a via needs >= 2 routable layers), and fine-pitch neck-down survives
+// via the #1018 post-processing #3456/PR #3623 added to
+// ``cpp_backend.py::_convert_result_to_route``.
+constexpr int ROUTER_CPP_BUILD_VERSION = 14;
 
 // Grid cell state
 struct GridCell {

--- a/src/kicad_tools/router/cpp/src/pathfinder.cpp
+++ b/src/kicad_tools/router/cpp/src/pathfinder.cpp
@@ -572,7 +572,19 @@ bool Pathfinder::is_via_blocked_diag(int x, int y, int net, bool allow_sharing,
                     }
                     // Allow with cost for routed cells / own-net obstacle.
                 } else {
-                    if (cell.is_obstacle || cell.net != net) {
+                    // Issue #3622: same-net cells are passable in standard
+                    // mode regardless of the obstacle flag -- parity with the
+                    // Python ``_is_via_blocked`` standard branch (Issue #864:
+                    // "same-net passable, different nets block"; it does NOT
+                    // consult ``is_obstacle``) and with the sibling
+                    // ``is_trace_blocked`` / ``is_diagonal_blocked`` standard
+                    // predicates aligned in #3456.  Pre-fix, ``cell.is_obstacle``
+                    // here rejected a via candidate whose disc touched the
+                    // routing net's OWN ``is_obstacle`` pad copper, so a board
+                    // that routes a via through its own destination pad in the
+                    // Python fallback would FAIL in C++ and silently fall back
+                    // (the exact #3456-class silent-fallback seed).
+                    if (cell.net != net) {
                         return true;
                     }
                 }
@@ -620,7 +632,10 @@ bool Pathfinder::is_via_blocked_diag(int x, int y, int net, bool allow_sharing,
                             return true;
                         }
                     } else {
-                        if (cell.is_obstacle || cell.net != net) {
+                        // Issue #3622: same-net cells passable in standard
+                        // mode (Python #864 parity -- see the cached fast-path
+                        // branch above for the full rationale).
+                        if (cell.net != net) {
                             return true;
                         }
                     }

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -47,7 +47,7 @@ logger = logging.getLogger(__name__)
 # ``AttributeError`` deep in the routing code (e.g. ``router_cpp.PadBounds``
 # missing).  The guard below catches that at import time and falls back to the
 # pure-Python router with an actionable ``kct build-native`` hint.
-_REQUIRED_CPP_BUILD_VERSION = 13
+_REQUIRED_CPP_BUILD_VERSION = 14
 
 # Try to import C++ module with detailed error tracking
 _CPP_IMPORT_ERROR: str | None = None
@@ -833,6 +833,29 @@ class CppPathfinder:
         self._rules = rules
         self._diagonal_routing = diagonal_routing
 
+        # Issue #3622 follow-up: restrict the C++ via-expansion to the layers
+        # actually permitted by ``allowed_layers`` (Issue #715 single-layer
+        # constraint).  The pathfinder defaults ``routable_layers_`` to every
+        # grid layer, so without this the via loop in ``pathfinder.cpp`` will
+        # attempt a layer change even when only one copper layer is routable.
+        #
+        # Pre-#3622 this leaked no vias because the strict standard-mode
+        # ``is_via_blocked`` rejected via candidates whose clearance disc
+        # touched the routing net's OWN ``is_obstacle`` pad copper.  The #864
+        # parity relaxation (own-net obstacle cells now passable for vias)
+        # removes that incidental suppression, so a single-layer route would
+        # begin emitting vias that land back on the only routable layer.
+        # Filtering the routable-layer set here enforces the real single-layer
+        # invariant ("a via requires >= 2 routable layers") WITHOUT touching
+        # the parity predicate -- with a one-element routable set the via
+        # loop's ``new_layer == current.layer`` skip leaves no via target.
+        #
+        # ``_routable_layers`` mirrors the C++ ``routable_layers_`` vector,
+        # defaulting to the grid's routable indices (the pathfinder ctor's
+        # own default) until/unless the allowed-layers filter narrows it.
+        self._routable_layers: list[int] = list(grid.get_routable_indices())
+        self._apply_allowed_layers_to_routable()
+
         # Lazy Python fallback router (constructed on first fallback)
         self._py_router: Router | None = None
         # Fallback statistics
@@ -1104,6 +1127,38 @@ class CppPathfinder:
     def set_routable_layers(self, layers: list[int]) -> None:
         """Set which layers are routable (skip plane layers)."""
         self._impl.set_routable_layers(layers)
+        # Mirror the value pushed to the C++ ``routable_layers_`` vector so
+        # Python callers (and tests) can introspect the active set without a
+        # dedicated C++ getter binding.
+        self._routable_layers = list(layers)
+
+    def _apply_allowed_layers_to_routable(self) -> None:
+        """Restrict the C++ via-expansion to ``allowed_layers`` (Issue #715).
+
+        When ``DesignRules.allowed_layers`` constrains routing to a subset of
+        copper layers (e.g. a single-layer ``["F.Cu"]`` board), the C++
+        pathfinder must not consider a layer change to a disallowed layer.
+        The pathfinder defaults its routable-layer set to every grid layer, so
+        we intersect that default with the ``allowed_layers``-permitted indices
+        and push the result down to the C++ ``routable_layers_`` vector.
+
+        With a single allowed layer the resulting set has one element, and the
+        via loop's ``new_layer == current.layer`` skip leaves no via target --
+        which is exactly the single-layer invariant ("a via requires >= 2
+        routable layers"). This keeps the Issue #3622 / #864 own-net-obstacle
+        via relaxation intact while preventing it from leaking vias onto
+        single-layer routes.
+        """
+        if self._rules.allowed_layers is None:
+            return  # No restriction; keep the pathfinder default (all layers).
+
+        base = self._grid.get_routable_indices()
+        permitted = [idx for idx in base if self._is_layer_allowed(idx)]
+        # Defensive: never push an empty set (would make every route fail);
+        # leave the default in place and let the start/end-layer filter in
+        # the routing path reject impossible routes instead.
+        if permitted and permitted != list(base):
+            self.set_routable_layers(permitted)
 
     def _is_layer_allowed(self, layer_idx: int) -> bool:
         """Check if routing on this layer is allowed by allowed_layers constraint.

--- a/tests/test_cpp_pathfinder_own_net_obstacle.py
+++ b/tests/test_cpp_pathfinder_own_net_obstacle.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import pytest
 
+from kicad_tools.router.core import Autorouter
 from kicad_tools.router.cpp_backend import (
     CppGrid,
     CppPathfinder,
@@ -143,11 +144,21 @@ class TestIsViaBlockedOwnNetObstacle:
             "the via (preserves PR #2928's invariant)."
         )
 
-    def test_own_net_obstacle_rejects_via_standard(self) -> None:
-        """In standard (non-negotiated) mode, obstacle cells reject
-        the via even for the own net -- the standard branch retains
-        the strict pre-negotiation contract.  Only the negotiated
-        branch needed the own-net gate.
+    def test_own_net_obstacle_admits_via_standard(self) -> None:
+        """Issue #3622: In standard (non-negotiated) mode an own-net
+        ``is_obstacle`` cell must NOT reject the via -- parity with the
+        Python ``_is_via_blocked`` standard branch (Issue #864: same-net
+        cells are passable regardless of the obstacle flag) and with the
+        sibling ``is_trace_blocked`` / ``is_diagonal_blocked`` standard
+        predicates aligned in #3456.
+
+        This flips the previously-pinned strict-reject contract.  Its
+        rationale ("A* in standard mode never enters obstacle metal
+        anyway") was shown false during #3456 -- standard-mode
+        ``route_all`` does traverse own-pad copper -- so a board that
+        routes a via through its own destination pad in the Python
+        fallback but not in C++ was a silent-fallback seed of exactly
+        the #3456 class.  Both backends now agree.
         """
         grid, rules = _make_grid_and_rules()
         cpp_grid = CppGrid.from_routing_grid(grid)
@@ -158,12 +169,100 @@ class TestIsViaBlockedOwnNetObstacle:
         gx, gy = cpp_grid._impl.world_to_grid(2.5, 2.5)
         _paint_own_net_obstacle(cpp_grid, gx, gy, pad_net)
 
-        # Standard mode keeps the strict reject -- A* in standard mode
-        # never enters obstacle metal anyway (escape probes use the
-        # negotiated path).
-        assert pathfinder._impl.is_via_blocked(
+        # Standard mode now admits the own-net via, matching the Python
+        # ``_is_via_blocked`` standard branch (same-net passable).
+        assert not pathfinder._impl.is_via_blocked(
             gx, gy, pad_net, False, 0
         ), (
-            "Standard-mode via probe at any obstacle cell stays "
-            "conservative; only negotiated mode admits own-net obstacles."
+            "Issue #3622: standard-mode via probe at an own-net "
+            "is_obstacle cell must be admitted (Python #864 parity); "
+            "foreign-net obstacles still reject."
+        )
+
+    def test_foreign_net_obstacle_rejects_via_standard(self) -> None:
+        """Counterpart to the own-net admit case above: in standard mode
+        a FOREIGN-net cell must still reject the via.  The #3622 fix is a
+        same-net relaxation, not a blanket one -- foreign metal continues
+        to hard-block.
+        """
+        grid, rules = _make_grid_and_rules()
+        cpp_grid = CppGrid.from_routing_grid(grid)
+        pathfinder = CppPathfinder(cpp_grid, rules, diagonal_routing=True)
+        pathfinder.set_routable_layers(cpp_grid.get_routable_indices())
+
+        obstacle_net = 7
+        probe_net = 99
+        gx, gy = cpp_grid._impl.world_to_grid(2.5, 2.5)
+        _paint_own_net_obstacle(cpp_grid, gx, gy, obstacle_net)
+
+        assert pathfinder._impl.is_via_blocked(
+            gx, gy, probe_net, False, 0
+        ), (
+            "Issue #3622: foreign-net cells must still reject the via in "
+            "standard mode (same-net relaxation only)."
+        )
+
+
+@requires_cpp
+class TestSingleLayerOwnNetObstacleNoVias:
+    """Issue #3622 follow-up: the standard-mode own-net-obstacle via admit
+    must NOT introduce vias on a single-layer (``allowed_layers``) route.
+
+    The #864 parity relaxation made own-net ``is_obstacle`` cells passable
+    for vias in standard mode.  That removes an incidental suppression that
+    had been keeping vias off single-layer boards: the C++ pathfinder's
+    via-expansion loop iterates every grid layer, and only the strict
+    obstacle reject (now relaxed) had been blocking the layer change when a
+    candidate via's clearance disc touched the routing net's own pad copper.
+
+    The fix restricts the C++ ``routable_layers_`` set to the
+    ``allowed_layers`` permitted indices (see
+    ``CppPathfinder._apply_allowed_layers_to_routable``), so a single-layer
+    route has no second layer to land a via on.  These tests pin that the
+    own-net admit and the single-layer invariant coexist.
+    """
+
+    def test_single_layer_route_emits_no_vias_with_own_net_obstacle(self) -> None:
+        """A same-net two-pad route constrained to F.Cu must emit zero vias
+        even though the destination pad copper is an own-net ``is_obstacle``
+        that the #864 relaxation now admits for via landing.
+        """
+        rules = DesignRules(allowed_layers=["F.Cu"])
+        router = Autorouter(width=50.0, height=40.0, rules=rules)
+
+        pads = [
+            {"number": "1", "x": 10.0, "y": 20.0, "net": 1, "net_name": "NET1"},
+            {"number": "2", "x": 40.0, "y": 20.0, "net": 1, "net_name": "NET1"},
+        ]
+        router.add_component("R1", pads)
+
+        routes = router.route_net(1)
+
+        assert routes, "Single-layer same-net route should still connect"
+        for route in routes:
+            assert len(route.vias) == 0, (
+                "Issue #3622: own-net-obstacle via admit must not introduce "
+                "vias on a single-layer (allowed_layers=['F.Cu']) route"
+            )
+
+    def test_routable_layers_restricted_to_single_allowed_layer(self) -> None:
+        """White-box check: the C++ pathfinder's routable-layer set is
+        restricted to the single allowed copper index, leaving the via loop
+        with no alternate layer to expand onto.
+        """
+        rules = DesignRules(allowed_layers=["F.Cu"], grid_resolution=0.1)
+        grid = RoutingGrid(
+            width=5.0,
+            height=5.0,
+            rules=rules,
+            layer_stack=LayerStack.four_layer_all_signal(),
+        )
+        cpp_grid = CppGrid.from_routing_grid(grid)
+        pathfinder = CppPathfinder(cpp_grid, rules, diagonal_routing=True)
+
+        f_cu_idx = grid.layer_to_index(0)  # F.Cu is enum value 0
+        assert pathfinder._routable_layers == [f_cu_idx], (
+            "Issue #3622: allowed_layers=['F.Cu'] must restrict the C++ "
+            "routable-layer set to the single F.Cu index so the via loop "
+            "has no second routable layer to land on"
         )


### PR DESCRIPTION
## Summary

Fresh re-attempt of #3622 on current main (the prior PR #3630 was closed as stale because the root causes of its block are now fixed on main).

Aligns the third sibling standard-mode predicate, C++ `Pathfinder::is_via_blocked`, with the Python `_is_via_blocked` standard branch (#864: "same-net passable, different nets block" — it does NOT consult `is_obstacle`). Both standard-mode arms (cached fast path + per-net-radius slow path) change from `if (cell.is_obstacle || cell.net != net)` to `if (cell.net != net)`. Negotiated arms untouched. The sibling `is_trace_blocked` / `is_diagonal_blocked` predicates were already aligned in #3456 / PR #3623; this completes the family.

- `ROUTER_CPP_BUILD_VERSION` bumped 13 -> 14 in `cpp/include/types.hpp`; `_REQUIRED_CPP_BUILD_VERSION` mirror in `cpp_backend.py` matches; compiled `.so` reports `BUILD_VERSION = 14`.
- **Single-layer guard re-implemented** (was correct/necessary in the prior attempt): `CppPathfinder._apply_allowed_layers_to_routable()` intersects the C++ `routable_layers_` set with the `allowed_layers`-permitted indices. With one allowed layer the via loop's `new_layer == current.layer` skip leaves no via target — the real "a via requires >= 2 routable layers" invariant. Pure-Python; does not touch the parity predicate.
- **Neck-down regression does NOT recur**: the prior block (#864 relaxation suppressed fine-pitch taper because the C++ backend lacked neck-down) is fixed on main by #3623, which added #1018 neck-down post-processing to `cpp_backend.py::_convert_result_to_route`. Verified green.
- Pinned test `test_own_net_obstacle_rejects_via_standard` flipped to `test_own_net_obstacle_admits_via_standard`; added `test_foreign_net_obstacle_rejects_via_standard` counterpart; added `TestSingleLayerOwnNetObstacleNoVias` (end-to-end zero-vias + white-box routable-layer guard).

## The two prior block causes — both green

- `tests/test_router_core.py::TestSingleLayerRouting::test_single_layer_no_vias` — **PASS** (F.Cu-only route emits 0 vias).
- `tests/test_neck_down.py` — **26 passed**, `test_routing_fine_pitch_with_neckdown` produces neck-down segments again.

## Test plan

- [x] `tests/test_neck_down.py` — 26 passed
- [x] `tests/test_cpp_pathfinder_own_net_obstacle.py` — 6 passed (flipped + 2 new classes)
- [x] `tests/test_router_core.py` — 214 passed, 3 skipped (incl. single-layer-no-vias)
- [x] `tests/test_cpp_validation_parity.py` — green
- [x] via/pathfinder parity suites (`test_router_cpp_fallback_warning_3456`, `test_router_cpp_via_blocked_failure`, `test_pathfinder_via_foreign_clearance`, `test_router_pathfinder`, `test_static_halo_via_gate_3566`) — 60 passed
- [x] `uv run python scripts/ci/check_mypy_baseline.py` — exit 0 (a pre-existing `build_native_cmd.py` nanobind import-untyped finding is present on clean origin/main too — environment artifact, not introduced here)
- [x] C++ rebuilt with `--force`, `BUILD_VERSION = 14`

Closes #3622

🤖 Generated with [Claude Code](https://claude.com/claude-code)