### PR TITLE
docs(board05): retire python/2L trace-overlap path (closes #3444)

### DIFF
--- a/.github/routed-drc-tolerance.yml
+++ b/.github/routed-drc-tolerance.yml
@@ -1450,7 +1450,12 @@ tolerances:
   # Board 05 (BLDC motor controller).  Issue #3470 (2026-06-10) removed
   # this board's tolerances entry -- the committed artifact reached a
   # strict 0-blocking-error state at jlcpcb-tier1 (the manufacturers:
-  # override below keeps it on tier-1).
+  # override below keeps it on tier-1).  In particular the hard cross-net
+  # trace-overlap families that Issue #3444 reported on the OLD
+  # ``--backend python --layers 2`` re-route path (which had churned this
+  # entry 6 -> 20) are 0 on the cpp/tier1/4L production snapshot, so #3444
+  # required no python-backend overlap fix -- the recipe moved off that
+  # path (#3425).  The entry below is NOT those overlap families.
   #
   # Issue #3556 grandfather (June 13 2026): the new ``clearance_via_zone`` /
   # ``clearance_pad_zone`` DRC rule (vias and pads vs foreign-net zone

--- a/tests/test_board_05_drc_hotspot_regression.py
+++ b/tests/test_board_05_drc_hotspot_regression.py
@@ -24,11 +24,26 @@ Why a separate test:
   ships with **0 ``clearance_pad_segment`` violations**: the 0.3 mm
   micro-via in-pad rescues fit the DRV8301's 0.3 mm-wide pads without
   clipping neighbours, eliminating the historical U3/U10 escape
-  hot-spots.  The single residual blocking violation is 1
-  ``clearance_segment_segment`` (ISENSE_A- / ISENSE_B- partial-route
-  stub overlap on In1.Cu at (18.75, 53.75)) -- gated by the allowlist
-  (= 1) in ``.github/routed-drc-tolerance.yml`` and tracked in the
-  #3425 follow-on issues.
+  hot-spots.
+* Issue #3444 (2026-06-13) closed: the hard cross-net trace-overlap
+  crossings it reported (``clearance_segment_segment`` actual -0.200mm,
+  ``clearance_segment_via`` -0.274mm, in-pad ``clearance_pad_segment``)
+  were artifacts of the OLD ``--backend python --layers 2`` fresh
+  re-route path, which forced ``.github/routed-drc-tolerance.yml`` to be
+  churned 6 -> 20.  That path is DEAD in board 05's production recipe:
+  ``design.py`` now pins ``--backend cpp --auto-layers --starting-layers 4
+  --max-layers 4 --manufacturer jlcpcb-tier1 --micro-via-in-pad-fallback``
+  (#3425, PR #3472), and the python in-pad stub generator was made
+  conflict-aware (#3470, PR #3478).  Measured on the committed cpp/tier1/4L
+  snapshot at ``--mfr jlcpcb-tier1``: all three #3444 trace-overlap
+  families are 0.  No python-2L fix is needed; the python 2L path was
+  retired in production, not repaired.
+* The board-05 ``.github/routed-drc-tolerance.yml`` entry is NOT removed:
+  it is re-pinned at 30, but those 30 are ALL the unrelated
+  ``clearance_pad_zone`` family added by Issue #3556 (2026-06-13: pads
+  vs stale foreign-net pour-fill copper, a stale-zone-fill artifact
+  tracked with #3549-#3553).  None of the 30 are the trace/segment
+  overlap families this test pins absent.
 
 The test does NOT pin the exact set of violating pins (that would be
 too brittle).  It asserts:
@@ -124,8 +139,24 @@ MAX_SHORTFALL_UM = 130
 # the BLOCKED_BY_COMPONENT rip-up transactional (negotiated.py
 # ``targeted_ripup`` snapshot/rollback), so partial outputs no longer
 # strand overlap copper.  The refreshed committed snapshot measures 0
-# blocking violations at jlcpcb-tier1; the board-05 allowlist entry in
-# .github/routed-drc-tolerance.yml was removed (strict 0 gate).
+# blocking violations of these families at jlcpcb-tier1.
+#
+# Issue #3444 (2026-06-13) closed against this set: the hard cross-net
+# trace-overlap crossings (-0.200mm ``clearance_segment_segment``,
+# -0.274mm ``clearance_segment_via``, in-pad ``clearance_pad_segment``)
+# it reported were a property of the OLD ``--backend python --layers 2``
+# fresh re-route recipe (the path that forced the tolerance churn
+# 6 -> 20).  That recipe is no longer board 05's production path -- it
+# moved to cpp/tier1/4L (#3425) -- so #3444 needed no new python-backend
+# overlap fix; the families are already absent here.  This frozenset is
+# the standing regression guard that keeps them absent.
+#
+# NOTE on the tolerance file: the board-05 entry was NOT permanently
+# removed.  Issue #3556 (2026-06-13) re-added it at 30 for an UNRELATED
+# new rule family (``clearance_pad_zone`` / ``clearance_via_zone``: pads
+# and vias vs stale foreign-net pour-fill copper).  None of those 30 are
+# in this frozenset, so the #3556 grandfather does not loosen the #3444
+# trace-overlap guard.
 ABSENT_RULES_ON_COMMITTED_PCB: frozenset[str] = frozenset(
     {
         "clearance_pad_via",
@@ -306,6 +337,14 @@ class TestBoard05DRCHotspotRegression:
         clipping U3's neighbouring 0.5 mm-pitch pads.  Pinning their
         absence makes that regression loud even while the aggregate
         allowlist would otherwise tolerate a count drift.
+
+        This is also the standing regression guard for Issue #3444 (the
+        ``clearance_segment_segment`` / ``clearance_segment_via`` hard
+        cross-net trace-overlap crossings reported on the OLD python-2L
+        fresh re-route recipe).  Those families are absent here because
+        the production recipe moved to cpp/tier1/4L (#3425) and the
+        python in-pad stub generator was made conflict-aware (#3470);
+        no python-backend overlap fix was required.
 
         Refresh policy: when a recipe/router change legitimately alters
         the committed snapshot's rule mix, re-route AND re-derive

--- a/tests/test_board_05_routing_regression.py
+++ b/tests/test_board_05_routing_regression.py
@@ -17,6 +17,23 @@ change that re-introduces the regression is caught loudly.
 The test is marked ``@pytest.mark.slow`` (4-minute wall clock) so PR-time
 CI excludes it; the nightly slow-tests workflow at
 ``.github/workflows/slow-tests.yml`` (``-m slow``) picks it up.
+
+NON-PRODUCTION RECIPE (read before editing the flags below).  This test
+deliberately runs ``--backend python --no-auto-layers --layers 2`` -- it
+is a *throughput* regression guard (net-completion %, the #2681 per-net
+A* slowdown dimension), pinned on the python backend so it reproduces on
+CI runners where the C++ extension is not built.  It is NOT board 05's
+production recipe: ``boards/05-bldc-motor-controller/design.py`` routes
+with ``--backend cpp --auto-layers --starting-layers 4 --max-layers 4
+--manufacturer jlcpcb-tier1`` (Issue #3425).
+
+The hard cross-net trace-overlap crossings on this python/2L path
+(Issue #3444: ``clearance_segment_segment`` actual -0.200mm etc.) were
+NOT fixed in the python backend -- the production recipe moved off this
+path entirely.  Do not treat this throughput floor as a manufacturability
+or DRC-cleanliness gate for board 05; that is
+``tests/test_board_05_drc_hotspot_regression.py`` against the committed
+cpp/tier1/4L snapshot.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Issue #3444 asked to fix the hard cross-net trace-overlap crossings on board 05's `--backend python --layers 2` fresh re-routes (`clearance_segment_segment` actual -0.200mm, `clearance_segment_via` -0.274mm, an in-pad `clearance_pad_segment`) and tighten the routed-DRC tolerance back down from the churned value of 20.

**Triage outcome: the python 2L path is DEAD in board 05's production recipe.** The issue's own triage note (re: sibling #3425) called this out, and it is now confirmed:

- `boards/05-bldc-motor-controller/design.py` already pins `--backend cpp --auto-layers --starting-layers 4 --max-layers 4 --manufacturer jlcpcb-tier1 --micro-via-in-pad-fallback --seed 7` (#3425, merged PR #3472).
- The python in-pad stub generator was made conflict-aware and rip-up made transactional (#3470, merged PR #3478).

**Measured on the committed cpp/tier1/4L snapshot at `--mfr jlcpcb-tier1`:** all three #3444 trace-overlap families are **0**:

```
clearance_segment_segment   0   (was -0.200mm hard short)
clearance_segment_via       0   (was -0.274mm)
clearance_pad_segment       0   (was the in-pad GATE_DRV_CH 12um intrusion)
```

The 30 blocking errors that remain on the committed artifact are ALL the unrelated `clearance_pad_zone` family added by the new #3556 DRC rule (pads vs stale foreign-net pour-fill copper) plus 9 `connectivity` partial-route advisories — neither is the #3444 trace-overlap concern. No python-backend overlap fix is required; the path was retired in production, not repaired.

This PR therefore closes the **documentation/honesty debt** rather than the already-fixed behavior:

- `tests/test_board_05_drc_hotspot_regression.py`: document the #3444 closure. The existing `test_committed_pcb_absent_rule_families` already pins these families absent (it is the standing #3444 regression guard). Corrected the stale "tolerance removed (strict 0 gate)" claim in the docstring/comment — the entry is actually re-pinned at 30 for the unrelated #3556 pad-zone family.
- `tests/test_board_05_routing_regression.py`: flagged that its `python/2L` recipe is a *throughput* guard (#2681), reproducible on C++-less CI runners — NOT board 05's production recipe, and NOT a DRC-cleanliness gate.
- `.github/routed-drc-tolerance.yml`: clarified the board-05 entry (30) is the #3556 pad-zone family, not the #3444 overlap families.

## Tolerance value

The #3444 overlap families are already at the strict-0 gate (absent, enforced by the hotspot regression test). The numeric tolerance entry (30) is unrelated #3556 grandfather debt tracked separately (#3549-#3553).

## Test plan

- [x] `pytest tests/test_board_05_drc_hotspot_regression.py` (4 passed)
- [x] `pytest tests/test_board_05_drc_allowlist.py` (2 passed)
- [x] `kct check ... --mfr jlcpcb-tier1` confirms 0 of the three #3444 families on the committed PCB
- [x] AST parse of both edited test files

Closes #3444

🤖 Generated with [Claude Code](https://claude.com/claude-code)