### PR TITLE
fix(router): make shadow-constructed diff-pair claim transactional

### DIFF
--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -38,6 +38,7 @@ from .diffpair_detection import (
     detect_diff_pairs as _layered_detect_diff_pairs,
 )
 from .layers import Layer
+from .observability import validate_net_connectivity
 from .path import calculate_route_length
 from .primitives import Pad, Route, Segment, Via
 
@@ -4625,6 +4626,81 @@ class DiffPairRouter:
                 elif r.net == pair.negative.net_id:
                     n_routes.append(r)
                 routes.append(r)
+
+        # Issue #3540: transactional pad-connectivity claim.  The shadow
+        # constructor (and its rescue-tail / stub-edge machinery) can
+        # commit copper that fails to actually REACH a goal pad -- a
+        # parallel-offset tail that exhausts its anchor-stepping budget,
+        # or a stub edge that the independent router could not land --
+        # while the per-spec commit above has already marked that copper
+        # on the grid.  Left as-is the caller claims the pair's nets
+        # (#2464 reserve), the negotiated main strategy skips them, and
+        # the stranded pads are unreachable for the rest of the pipeline
+        # (measured board 06 run-4: USB3_RX1+/USB3_RX2+ shipped "1 of 2
+        # pads stranded" with no warning).  A pair that claims-but-strands
+        # costs REACH; a pair that defers cleanly costs only QUALITY --
+        # and reach is the asserted contract.  So before returning the
+        # pair's routes (which is what the caller turns into a net claim),
+        # verify every pad of BOTH nets is in a single connected component
+        # of the committed copper.  On any gap, rip the pair's copper off
+        # the grid + route list and defer the WHOLE pair: return
+        # ``([], None)`` (the caller never claims) or fall through to the
+        # single-ended independent router (``coupled_only=False``).
+        #
+        # Gated on ``enable_shadow_construction`` so a flag-off run -- whose
+        # contract is "may only defer, never commit where main would
+        # defer" -- is behaviourally unchanged: with the flag off the
+        # shadow/rescue paths are inert, so the committed routes here are
+        # the coupled body that already passed the #3320 severe-overlap
+        # gate, and re-deferring a clean body would needlessly lose reach.
+        if self.enable_shadow_construction and routes:
+            net_pads_for_check: dict[int, list[Pad]] = {}
+            for net_id in (pair.positive.net_id, pair.negative.net_id):
+                pad_keys = self.autorouter.nets.get(net_id, [])
+                net_pads_for_check[net_id] = [
+                    self.autorouter.pads[k] for k in pad_keys if k in self.autorouter.pads
+                ]
+            conn = validate_net_connectivity(routes, net_pads_for_check)
+            stranded_nets = [
+                net_id for net_id, info in conn.items() if not info.get("connected", False)
+            ]
+            if stranded_nets:
+                for net_id in stranded_nets:
+                    info = conn[net_id]
+                    print(
+                        f"    WARNING: [coupled-shadow] pair {pair.name} net "
+                        f"{net_id} stranded "
+                        f"({info.get('connected_pads', 0)}/"
+                        f"{info.get('total_pads', 0)} pads reached); "
+                        "ripping pair copper and deferring the whole pair."
+                    )
+                    logger.warning(
+                        "diffpair shadow claim NOT transactional -- rolling back: "
+                        "pair=%r net=%r connected_pads=%d total_pads=%d",
+                        pair.name,
+                        net_id,
+                        info.get("connected_pads", 0),
+                        info.get("total_pads", 0),
+                    )
+                # Roll back: unmark every committed route for this pair and
+                # drop it from the autorouter's route list, leaving a clean
+                # grid for whichever fallback handles the pair next.  No
+                # net is claimed because we return without the pair's
+                # routes.
+                for committed in routes:
+                    try:
+                        self.autorouter.grid.unmark_route(committed)
+                    except Exception:
+                        pass
+                    if committed in self.autorouter.routes:
+                        self.autorouter.routes.remove(committed)
+                if coupled_only:
+                    print(
+                        "    Skipping diff-pair pre-pass: shadow-constructed "
+                        "pair stranded goal pads (transactional rollback)."
+                    )
+                    return [], None
+                return self.route_differential_pair_independent(pair, spacing)
 
         # Calculate lengths
         p_length = calculate_route_length(p_routes)

--- a/tests/test_diffpair_shadow.py
+++ b/tests/test_diffpair_shadow.py
@@ -625,3 +625,132 @@ def test_flag_on_invokes_near_miss_rescue(monkeypatch):
     assert calls["n"] == 1, (
         "near-miss rescue must be invoked when enable_shadow_construction is True"
     )
+
+
+# ---------------------------------------------------------------------------
+# 9. Issue #3540: transactional pad-connectivity claim
+#
+# The shadow constructor (and its rescue-tail / stub-edge machinery) can
+# commit copper that fails to actually REACH a goal pad while the per-spec
+# commit has already marked that copper on the grid.  Left as-is the caller
+# claims the pair's nets (#2464 reserve), the negotiated main strategy
+# skips them, and the goal pads are STRANDED for the rest of the pipeline.
+#
+# ``route_differential_pair_coupled`` must make the claim TRANSACTIONAL:
+# after committing the pair's copper (body + tails + stub edges), it
+# verifies every pad of BOTH nets is reached.  On any gap it rips the
+# pair's copper off the grid + route list and defers the whole pair
+# (returns ``([], None)`` under ``coupled_only`` so the caller never
+# claims, or falls through to the single-ended router otherwise).
+# ---------------------------------------------------------------------------
+
+
+def _coupled_routes_for_pair(pair, p_end_x: float, n_end_x: float) -> tuple[Route, Route]:
+    """Build a committable (P, N) result for the 2-pad fixture.
+
+    The U1 pads sit at x=5.0 and the J1 pads at x=25.0 (y=4.8 for P,
+    y=5.2 for N).  Each returned route is a single horizontal segment
+    from the U1 pad to ``*_end_x``; passing 25.0 reaches the J1 goal
+    pad, while a shorter value (e.g. 15.0) STRANDS it -- the exact
+    "claimed-but-unconnected goal pad" failure mode #3540 fixes.
+    """
+    p_route = Route(net=pair.positive.net_id, net_name=pair.positive.net_name)
+    p_route.segments.append(
+        Segment(
+            x1=5.0,
+            y1=4.8,
+            x2=p_end_x,
+            y2=4.8,
+            width=0.2,
+            layer=Layer.F_CU,
+            net=pair.positive.net_id,
+            net_name=pair.positive.net_name,
+        )
+    )
+    n_route = Route(net=pair.negative.net_id, net_name=pair.negative.net_name)
+    n_route.segments.append(
+        Segment(
+            x1=5.0,
+            y1=5.2,
+            x2=n_end_x,
+            y2=5.2,
+            width=0.2,
+            layer=Layer.F_CU,
+            net=pair.negative.net_id,
+            net_name=pair.negative.net_name,
+        )
+    )
+    return p_route, n_route
+
+
+def test_shadow_claim_rolls_back_when_goal_pad_stranded(monkeypatch):
+    """Flag ON + a committed route that strands a goal pad -> full rollback.
+
+    The stub pathfinder converges with a P route that stops at x=15.0 --
+    10 mm short of the J1.1 goal pad at x=25.0 -- so the P net has only
+    1 of its 2 pads reachable from the committed copper.  The
+    transactional claim must:
+
+      * NOT return any routes (so the caller never claims the nets),
+      * leave the autorouter's route list empty (the committed P and N
+        copper is ripped), and
+      * unmark every cell it had marked on the grid (no stranded copper).
+    """
+    router, pair = _two_pad_coupled_router_and_pair()
+    dpr = router._diffpair
+    dpr.enable_shadow_construction = True
+    monkeypatch.setattr(dpr, "_single_ended_guide_route", lambda *a, **k: None)
+    # P strands its J1 goal pad (stops at x=15.0); N reaches its goal.
+    stranded = _coupled_routes_for_pair(pair, p_end_x=15.0, n_end_x=25.0)
+    _patch_pathfinder_capture_weight(monkeypatch, stranded, rescue_eligible=False)
+
+    grid = router.grid
+
+    def _pair_cell_count() -> int:
+        net_arr = grid._net
+        return int(((net_arr == pair.positive.net_id) | (net_arr == pair.negative.net_id)).sum())
+
+    occupied_before = _pair_cell_count()
+
+    routes, warning = dpr.route_differential_pair_coupled(pair, coupled_only=True)
+
+    assert routes == [], (
+        "a shadow pair that strands a goal pad must NOT return routes "
+        "(returning routes is what makes the caller claim the nets)"
+    )
+    assert warning is None
+    # The committed copper was ripped from the autorouter's route list.
+    assert not any(r.net in (pair.positive.net_id, pair.negative.net_id) for r in router.routes), (
+        "stranded pair copper must be removed from autorouter.routes on rollback"
+    )
+    # And every cell it marked on the grid was unmarked (clean rollback).
+    occupied_after = _pair_cell_count()
+    assert occupied_after == occupied_before, (
+        "rollback must unmark the stranded pair's copper from the grid "
+        f"(cells before={occupied_before}, after={occupied_after})"
+    )
+
+
+def test_shadow_claim_commits_when_all_pads_reached(monkeypatch):
+    """Control: a shadow pair that reaches every goal pad IS claimed.
+
+    Same converged-search setup as the rollback test, but both routes run
+    fully from the U1 pads to the J1 pads, so both nets are fully
+    connected.  The transactional check must let the claim stand: routes
+    are returned and the copper stays committed on the autorouter.
+    """
+    router, pair = _two_pad_coupled_router_and_pair()
+    dpr = router._diffpair
+    dpr.enable_shadow_construction = True
+    monkeypatch.setattr(dpr, "_single_ended_guide_route", lambda *a, **k: None)
+    good = _coupled_routes_for_pair(pair, p_end_x=25.0, n_end_x=25.0)
+    _patch_pathfinder_capture_weight(monkeypatch, good, rescue_eligible=False)
+
+    routes, _warning = dpr.route_differential_pair_coupled(pair, coupled_only=True)
+
+    p_nets = {r.net for r in routes}
+    assert pair.positive.net_id in p_nets and pair.negative.net_id in p_nets, (
+        "a fully-connected shadow pair must return both nets' routes so the caller claims them"
+    )
+    assert any(r.net == pair.positive.net_id for r in router.routes)
+    assert any(r.net == pair.negative.net_id for r in router.routes)


### PR DESCRIPTION
## Summary

The coupled diff-pair shadow constructor claimed pad connectivity
NON-transactionally: it commits a pair's copper (shadow body + rescue
tails + intra-net stub edges) to the grid in `route_differential_pair_coupled`,
and then the caller claims the pair's nets (`diff_net_ids` / #2464
reserve). But a rescue tail that exhausts its anchor-stepping budget, or
a stub edge the independent router could not land, leaves a goal pad
unreached — yet the net was still claimed, the negotiated main strategy
skipped it, and the goal pad was STRANDED for the rest of the pipeline
(measured board 06 run-4: `USB3_RX1+` / `USB3_RX2+` shipped "1 of 2 pads
stranded" with no warning).

This PR makes the claim transactional: either the full pad connectivity
genuinely holds, or the pair's copper is rolled back cleanly and the
whole pair is deferred (no stranded/half-claimed pads).

## Changes

- `src/kicad_tools/router/diffpair_routing.py`: after the per-spec and
  stub-edge commits in `route_differential_pair_coupled` (the point at
  which the full pair copper exists), verify every pad of BOTH nets is in
  a single connected component of the committed copper via the existing,
  tested `validate_net_connectivity` union-find helper. On any gap:
  - rip every committed route off the grid (`grid.unmark_route`) and out
    of `autorouter.routes`, and
  - defer the whole pair — return `([], None)` under `coupled_only` (so
    the caller never adds the nets to its routed set), else fall through
    to `route_differential_pair_independent`.
  - A warning + structured log records the stranded net and its
    reached/total pad count (the failure was previously silent).
  - Gated on `enable_shadow_construction` so the flag-off defer-only path
    is behaviourally unchanged (the committed body there already passed
    the #3320 severe-overlap gate; re-deferring it would lose reach).
- `tests/test_diffpair_shadow.py`: two new tests driving
  `route_differential_pair_coupled` against a stubbed pathfinder whose
  converged result strands a goal pad.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Shadow-constructed pairs verify full pad connectivity (all pads, both nets) before claiming | done | `validate_net_connectivity` over the committed routes runs before the routes are returned (the caller's claim input) |
| On verification failure the pair's copper is ripped and the pair deferred (log line with the reason) | done | `grid.unmark_route` + removal from `autorouter.routes`; returns `([], None)` / independent fallback; WARNING + `logger.warning` emitted |
| Unit test: a shadow construction with a synthetic unroutable tail defers instead of claiming | done | `test_shadow_claim_rolls_back_when_goal_pad_stranded` (P route stops 10mm short of its J1 goal pad → asserts no routes returned, route list cleared, grid cells unmarked); `test_shadow_claim_commits_when_all_pads_reached` is the positive control |
| Board 06 seed-42 re-route: no connectivity errors on shadow-claimed nets | n/a (flag-gated) | The shadow constructor is inert by default (#3547); this fix is the correctness prerequisite for the flag-on path. Full board-06 convergence is parent #3508 / keystone #3542 |

## Test Plan

- `uv run pytest tests/test_diffpair_shadow.py` — 24 passed (incl. 2 new)
- `uv run pytest tests/test_diffpair*.py tests/test_coupled_lines.py` — 147 passed, no regressions
- `uv run ruff check .` — passed; `uv run ruff format . --check` — passed
- Pre-existing, unrelated: `scripts/ci/check_mypy_baseline.py` reports a
  `nanobind` import-untyped error in `cli/build_native_cmd.py` that is
  present on a clean tree once the native ext is built locally; it does
  not involve either file in this PR and does not fire in CI (no native
  build there).

Closes #3540