### PR TITLE
fix(router): spread shadow via off the partner trace at coupled gaps

### DIFF
--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -3371,9 +3371,20 @@ class DiffPairRouter:
         # trace (via_r + clearance + guide_width/2), independent of the
         # tighter coupled gap d.
         guide_width = max((g.width for g in guide.segments), default=s_width)
-        via_lateral = max(
-            d, rules.via_diameter / 2 + rules.trace_clearance + guide_width / 2 + 0.05
-        )
+        # Issue #3541: the perpendicular distance from the shadow via to
+        # the partner (guide) copper must keep this bound everywhere, not
+        # just at the projected guide-via point ``gv``.  The guide BENDS
+        # at the layer change, so a nominal ``via_lateral`` offset taken
+        # against the incoming leg's normal can still let the barrel
+        # intersect the outgoing leg (measured: ~0.04 mm intersection at
+        # board 06's 0.075-0.15 mm coupled gaps).  ``via_clear`` is the
+        # same via-barrel-vs-partner bound the crossing-tail synthesizer
+        # enforces (see ``_synthesize_crossing_tail``); we validate each
+        # candidate site against the guide polyline with it and widen the
+        # perpendicular spread (the ``lat_mult`` lattice) until it holds.
+        via_clear = rules.via_diameter / 2 + rules.trace_clearance + guide_width / 2
+        via_lateral = max(d, via_clear + 0.05)
+        guide_segs = list(guide.segments)
         # Longitudinal stagger so shadow-via-to-guide-via >= via pitch.
         via_pitch = rules.via_diameter + rules.via_clearance
         stagger = max(0.0, math.sqrt(max(0.0, via_pitch**2 - via_lateral**2))) + 0.05
@@ -3443,6 +3454,32 @@ class DiffPairRouter:
                                     )
                                     gvx, gvy = grid.world_to_grid(vx, vy)
                                     if pathfinder._is_via_blocked(gvx, gvy, s_net):
+                                        continue
+                                    # Issue #3541: the guide is NOT in the
+                                    # grid, so ``_is_via_blocked`` cannot
+                                    # see a barrel grazing the partner.
+                                    # The barrel offset is taken against
+                                    # the INCOMING leg's normal, but the
+                                    # guide BENDS at the via -- so a site
+                                    # that clears the incoming leg can
+                                    # still intersect the OUTGOING leg
+                                    # when the guide turns toward the
+                                    # shadow side (measured: ~0.04 mm
+                                    # overlap at board 06's 0.075-0.15 mm
+                                    # gaps).  Reject any candidate whose
+                                    # barrel violates the via-vs-partner
+                                    # clearance against the WHOLE guide
+                                    # polyline (any layer -- the barrel
+                                    # spans all layers); the lattice then
+                                    # widens the perpendicular spread
+                                    # (larger ``lat_mult``) until a site
+                                    # clears every guide segment.
+                                    if (
+                                        self._min_distance_to_partner(
+                                            vx, vy, vx, vy, guide_segs, None
+                                        )
+                                        < via_clear
+                                    ):
                                         continue
                                     elements.append(
                                         ("seg", prev_pt[0], prev_pt[1], vx, vy, prev_layer)

--- a/tests/test_diffpair_shadow.py
+++ b/tests/test_diffpair_shadow.py
@@ -882,6 +882,19 @@ def _stub_tail_route(self, _pf, head, goal, _layer, _label, _name, partner_segme
     return r
 
 
+# The #3541 load-bearing geometry: an out-going B_CU leg bending up-and-LEFT
+# (``bend_end`` below x=12.0) that sweeps the guide back through the side=+1.0
+# minimum-lateral (lat_mult=1.0) shadow-via neighbourhood.  At this geometry
+# the un-spread via barrel lands 0.354 mm from the guide -- a SHORT against the
+# ~0.65 mm ``via_clear`` bound -- and the guide's own seg-vs-seg self-check
+# (``find_intra_pair_clearance_violations``) does NOT see it (it is a
+# via-vs-trace overlap, not seg-vs-seg), so WITHOUT the guard the constructor
+# COMMITS the shorting via.  WITH the guard the lattice widens to lat_mult>1.0
+# and the via clears at 0.700 mm.  (Verified by deleting the guard: the
+# committed via min-dist drops 0.700 -> 0.354 mm.)
+_SHADOW_VIA_GUARD_BEND_END = (11.0, 7.7)
+
+
 def test_shadow_via_clears_partner_at_tight_gap(monkeypatch):
     """End-to-end: the constructed shadow via clears the partner copper.
 
@@ -891,11 +904,18 @@ def test_shadow_via_clears_partner_at_tight_gap(monkeypatch):
     ``via_diameter/2 + trace_clearance + guide_width/2`` -- the geometric
     guarantee the perpendicular spread provides (issue #3541 acceptance:
     "via_edge -> partner_copper >= trace_clearance, validated cell-by-cell").
+
+    Uses the load-bearing geometry (:data:`_SHADOW_VIA_GUARD_BEND_END`) at
+    which the un-spread minimum-lateral via shorts the guide, so the assertion
+    is only satisfiable because the guard widened the lattice -- see
+    ``test_shadow_via_guard_is_load_bearing`` for the matching negative control.
     """
     from kicad_tools.router.diffpair_routing import DiffPairRouter
 
     spacing_cells = 4
-    dpr, pair, spec, pathfinder, guide = _shadow_setup(spacing_cells, bend_end=(18.0, 7.0))
+    dpr, pair, spec, pathfinder, guide = _shadow_setup(
+        spacing_cells, bend_end=_SHADOW_VIA_GUARD_BEND_END
+    )
 
     monkeypatch.setattr(DiffPairRouter, "_tail_route", _stub_tail_route, raising=True)
     # Defeat the belt-and-braces overlap gate so we observe the via the
@@ -921,72 +941,94 @@ def test_shadow_via_clears_partner_at_tight_gap(monkeypatch):
             )
 
 
-def test_shadow_via_guard_rejects_grazing_site_and_keeps_spread_site():
-    """Load-bearing: the guard rejects the pre-#3541 (un-spread) via site.
+def test_shadow_via_guard_is_load_bearing(monkeypatch):
+    """Negative control: deleting the guard makes ``_shadow_route_pair`` short.
 
-    Uses a guide whose out-going B_CU leg sweeps back through the side=+1.0
-    minimum-lateral via neighbourhood, so the pre-#3541 placement -- the
-    barrel offset only against the INCOMING +x leg's normal -- lands ON the
-    out-going leg.  Asserts:
+    This is the integration-level proof the #3541 guard is load-bearing -- it
+    drives ``_shadow_route_pair`` END TO END (asserting on the route it
+    RETURNS, not on the geometry helper) and contrasts two runs on the same
+    load-bearing geometry (:data:`_SHADOW_VIA_GUARD_BEND_END`):
 
-      1. that naive site DOES violate the clearance bound (the scenario
-         actually exercises the #3541 bug -- otherwise the guard would pass
-         vacuously), and
-      2. the guard predicate the fix added (barrel-vs-whole-guide distance
-         < ``via_clear``) flags exactly that site, while a wider-spread
-         candidate from the same lattice clears -- i.e. the perpendicular
-         spread is what restores clearance.
+      * **Guard present** (production): the minimum-lateral (lat_mult=1.0) via
+        site grazes the out-going guide leg, so the guard rejects it and the
+        lattice widens; the committed via clears the guide by >= ``via_clear``.
+      * **Guard absent** (the guard predicate stubbed out via
+        ``_min_distance_to_partner`` -> +inf, the ONLY call site of that helper
+        inside ``_shadow_route_pair``): the constructor COMMITS the grazing
+        lat_mult=1.0 via, whose barrel sits < ``via_clear`` from the guide -- a
+        short.  The seg-vs-seg self-check (``find_intra_pair_clearance_violations``)
+        does NOT catch it because the overlap is via-vs-trace, not seg-vs-seg.
+
+    The downstream ``_pair_has_physical_overlap`` belt-and-braces gate IS the
+    backstop that would otherwise defer this short in production, so it is
+    stubbed off in BOTH runs to isolate the guard's contribution -- exactly the
+    PCIE_TX 0.0%-continuity short #3541 locks down (a future refactor that
+    silently drops the guard re-exposes it, and this test then fails).
     """
-    import math
-
     from kicad_tools.router.diffpair_routing import DiffPairRouter
 
     spacing_cells = 4
-    # Out-going leg bends acutely up-and-LEFT, sweeping back under the
-    # side=+1.0 shadow-via region (~(11.4, 5.5)).
-    dpr, _pair, _spec, pathfinder, guide = _shadow_setup(spacing_cells, bend_end=(10.0, 6.0))
-    rules = dpr.autorouter.rules
-    via_clear = _via_clearance_bound(rules, guide)
 
-    via_lateral = max(spacing_cells * pathfinder.grid.resolution, via_clear + 0.05)
-    via_pitch = rules.via_diameter + rules.via_clearance
-    stagger = max(0.0, math.sqrt(max(0.0, via_pitch**2 - via_lateral**2))) + 0.05
-    pux, puy = 1.0, 0.0  # incoming unit dir
-    pnx, pny = -puy, pux  # side=+1.0 normal
-
-    def _site(lat_mult: float, stag_mult: float) -> tuple[float, float]:
-        return (
-            12.0 + via_lateral * lat_mult * pnx - stagger * stag_mult * pux,
-            4.8 + via_lateral * lat_mult * pny - stagger * stag_mult * puy,
+    def _committed_shadow_via(disable_guard: bool):
+        # A fresh patch context per run: the guard is patched out ONLY for the
+        # unguarded run, then reverted, so the guarded run sees the real guard.
+        with monkeypatch.context() as mp:
+            dpr, pair, spec, pathfinder, guide = _shadow_setup(
+                spacing_cells, bend_end=_SHADOW_VIA_GUARD_BEND_END
+            )
+            mp.setattr(DiffPairRouter, "_tail_route", _stub_tail_route, raising=True)
+            # Stub OFF the belt-and-braces overlap gate in both runs: it is the
+            # production backstop, but here we are isolating the GUARD's effect,
+            # so what the constructor COMMITS (clean vs short) must be the
+            # guard's doing, not the gate's.
+            mp.setattr(
+                DiffPairRouter, "_pair_has_physical_overlap", lambda self, p, n: False, raising=True
+            )
+            if disable_guard:
+                # ``_min_distance_to_partner`` is called in exactly one place
+                # inside ``_shadow_route_pair`` -- the #3541 via-vs-guide guard.
+                # Forcing it to +inf makes every candidate pass the guard, i.e.
+                # deletes the guard.
+                mp.setattr(
+                    DiffPairRouter,
+                    "_min_distance_to_partner",
+                    lambda self, *a, **k: float("inf"),
+                    raising=True,
+                )
+            result = dpr._shadow_route_pair(pair, spec, pathfinder, guide, spacing_cells)
+        assert result is not None, "shadow constructor should commit a route at this geometry"
+        _p_route, n_route = result
+        assert n_route.vias, "the shadow must carry its own layer-change via"
+        via_clear = _via_clearance_bound(dpr.autorouter.rules, guide)
+        min_dist = min(
+            DiffPairRouter._point_segment_distance(via.x, via.y, seg)
+            for via in n_route.vias
+            for seg in guide.segments
         )
+        return min_dist, via_clear
 
-    def _barrel_clearance(site: tuple[float, float]) -> float:
-        # The exact guard the fix evaluates: barrel vs the whole guide
-        # polyline on ANY layer (a via spans every layer).
-        return dpr._min_distance_to_partner(
-            site[0], site[1], site[0], site[1], list(guide.segments), None
-        )
-
-    naive = _site(1.0, 1.0)  # the pre-#3541 minimum-lateral placement
-    naive_clear = _barrel_clearance(naive)
-    assert naive_clear < via_clear, (
-        "scenario sanity: the un-spread via must intersect the partner "
-        f"(barrel clearance {naive_clear:.4f} mm should be < bound "
-        f"{via_clear:.4f} mm) for this test to exercise the #3541 fix"
+    # Guard ABSENT: the constructor commits the grazing lat_mult=1.0 via -- a
+    # short.  This is the assertion that FAILS if the guard is restored, and
+    # (equivalently) PASSES only because deleting the guard re-introduces the
+    # #3541 short -- proving the guard is what prevents it.
+    unguarded_dist, via_clear = _committed_shadow_via(disable_guard=True)
+    assert unguarded_dist < via_clear, (
+        "negative control failed: with the #3541 guard deleted, "
+        "_shadow_route_pair must COMMIT a shorting via (barrel-to-guide "
+        f"{unguarded_dist:.4f} mm < required {via_clear:.4f} mm).  If this "
+        "passes, the geometry no longer exercises the guard and the positive "
+        "case below is vacuous."
     )
 
-    # The guard the fix added rejects exactly that grazing candidate ...
-    assert _barrel_clearance(naive) < via_clear
-
-    # ... and the lattice's wider perpendicular spread restores clearance:
-    # at least one larger-lat candidate clears the bound.
-    spread_clearances = [
-        _barrel_clearance(_site(lat, stag))
-        for lat in (1.5, 2.2)
-        for stag in (1.0, 1.6, -1.0, -1.6, 2.4, -2.4)
-    ]
-    assert any(c >= via_clear for c in spread_clearances), (
-        "the perpendicular-spread lattice must offer at least one via site "
-        f"clearing the partner by >= {via_clear:.4f} mm (max offered "
-        f"{max(spread_clearances):.4f} mm)"
+    # Guard PRESENT (production): the same geometry now clears, because the
+    # guard rejected the grazing site and the lattice widened.
+    guarded_dist, _via_clear = _committed_shadow_via(disable_guard=False)
+    assert guarded_dist >= via_clear - 1e-9, (
+        "with the #3541 guard active the committed shadow via must clear the "
+        f"guide (barrel-to-guide {guarded_dist:.4f} mm >= {via_clear:.4f} mm)"
+    )
+    # And the guard's effect is the difference between the two runs.
+    assert guarded_dist > unguarded_dist, (
+        "the guard must change the committed geometry: clearing via "
+        f"({guarded_dist:.4f} mm) vs grazing via ({unguarded_dist:.4f} mm)"
     )

--- a/tests/test_diffpair_shadow.py
+++ b/tests/test_diffpair_shadow.py
@@ -46,7 +46,7 @@ from kicad_tools.router.diffpair_routing import (
 )
 from kicad_tools.router.grid import RoutingGrid
 from kicad_tools.router.layers import Layer
-from kicad_tools.router.primitives import Route, Segment
+from kicad_tools.router.primitives import Route, Segment, Via
 from kicad_tools.router.rules import DesignRules
 
 
@@ -754,3 +754,239 @@ def test_shadow_claim_commits_when_all_pads_reached(monkeypatch):
     )
     assert any(r.net == pair.positive.net_id for r in router.routes)
     assert any(r.net == pair.negative.net_id for r in router.routes)
+
+
+# ---------------------------------------------------------------------------
+# 10. Issue #3541: shadow via must not intersect the partner trace
+#
+# When the geometric shadow constructor places its own via before a guide
+# layer change, the barrel sits at a perpendicular offset taken against the
+# INCOMING guide leg's normal.  The guide BENDS at the via, so an offset
+# that clears the incoming leg can still let the barrel intersect the
+# OUTGOING leg when the guide turns back toward the shadow side.  At board
+# 06's tightly-coupled gaps (0.075-0.15 mm) this produced a ~0.04 mm
+# physical overlap between the shadow via and the partner copper -- a short
+# that the recipe's 6b audit ripped (USB2_D / USB3_RX1 / USB3_RX2 / PCIE_TX
+# de-coupled).
+#
+# The fix validates each candidate via site against the WHOLE guide
+# polyline (barrel vs any-layer copper) with the same
+# ``via_diameter/2 + trace_clearance + guide_width/2`` bound the crossing-
+# tail synthesizer uses, and widens the perpendicular spread (the
+# ``lat_mult`` lattice) until a site clears every guide segment.
+# ---------------------------------------------------------------------------
+
+
+def _via_clearance_bound(rules, guide) -> float:
+    """The #3541 via-barrel-vs-partner bound the constructor enforces."""
+    guide_width = max((g.width for g in guide.segments), default=rules.trace_width)
+    return rules.via_diameter / 2 + rules.trace_clearance + guide_width / 2
+
+
+def _layer_change_guide(p_start_pad, bend_end: tuple[float, float]) -> Route:
+    """F_CU leg -> via at (12.0, 4.8) -> B_CU leg toward ``bend_end``.
+
+    The pre-via leg approaches the layer change along +x; the post-via leg
+    heads toward ``bend_end``.  Choosing a ``bend_end`` that sweeps the
+    out-going leg back through the shadow-via neighbourhood is what made the
+    pre-#3541 minimum-lateral via intersect the partner.
+    """
+    net, name = p_start_pad.net, p_start_pad.net_name
+    guide = Route(net=net, net_name=name)
+    guide.segments.append(
+        Segment(
+            x1=5.0,
+            y1=4.8,
+            x2=12.0,
+            y2=4.8,
+            width=0.2,
+            layer=Layer.F_CU,
+            net=net,
+            net_name=name,
+        )
+    )
+    guide.segments.append(
+        Segment(
+            x1=12.0,
+            y1=4.8,
+            x2=bend_end[0],
+            y2=bend_end[1],
+            width=0.2,
+            layer=Layer.B_CU,
+            net=net,
+            net_name=name,
+        )
+    )
+    guide.vias.append(
+        Via(
+            x=12.0,
+            y=4.8,
+            drill=0.35,
+            diameter=0.7,
+            layers=(Layer.F_CU, Layer.B_CU),
+            net=net,
+            net_name=name,
+        )
+    )
+    return guide
+
+
+def _shadow_setup(spacing_cells: int, bend_end: tuple[float, float]):
+    """Build (dpr, pair, spec, pathfinder, guide) for the via-geometry test.
+
+    Open 2-pad fixture (no obstacles), a tight coupled spacing, and a
+    layer-changing guide bending toward ``bend_end``.
+    """
+    from kicad_tools.router.diffpair_routing import CoupledPathfinder, CoupledSegmentSpec
+
+    router, pair = _two_pad_coupled_router_and_pair()
+    dpr = router._diffpair
+    dpr.enable_shadow_construction = True
+    spec = CoupledSegmentSpec(
+        p_start=router.pads[("U1", "1")],
+        p_end=router.pads[("J1", "1")],
+        n_start=router.pads[("U1", "2")],
+        n_end=router.pads[("J1", "2")],
+    )
+    pathfinder = CoupledPathfinder(
+        grid=router.grid,
+        rules=router.rules,
+        target_spacing_cells=spacing_cells,
+        net_class_map=getattr(router, "net_class_map", None),
+    )
+    guide = _layer_change_guide(router.pads[("U1", "1")], bend_end)
+    return dpr, pair, spec, pathfinder, guide
+
+
+def _stub_tail_route(self, _pf, head, goal, _layer, _label, _name, partner_segments=None):
+    """Degenerate body-anchor tail (isolates the via geometry under test).
+
+    Routing the real pad-reaching tail would have a straight fake tail
+    cross the guide and trip the constructor's separate intra-pair / overlap
+    self-checks -- artifacts unrelated to the #3541 via geometry.  A
+    near-zero stub at the body anchor leaves the body's via intact.
+    """
+    r = Route(net=goal.net, net_name=goal.net_name)
+    r.segments.append(
+        Segment(
+            x1=head.x,
+            y1=head.y,
+            x2=head.x + 0.001,
+            y2=head.y,
+            width=0.2,
+            layer=head.layer,
+            net=goal.net,
+            net_name=goal.net_name,
+        )
+    )
+    return r
+
+
+def test_shadow_via_clears_partner_at_tight_gap(monkeypatch):
+    """End-to-end: the constructed shadow via clears the partner copper.
+
+    Drives ``_shadow_route_pair`` with a layer-changing guide and a tightly-
+    coupled spacing (4 cells = 0.4 mm, well below the ~0.65 mm via bound).
+    Every via the shadow places must clear EVERY guide segment by at least
+    ``via_diameter/2 + trace_clearance + guide_width/2`` -- the geometric
+    guarantee the perpendicular spread provides (issue #3541 acceptance:
+    "via_edge -> partner_copper >= trace_clearance, validated cell-by-cell").
+    """
+    from kicad_tools.router.diffpair_routing import DiffPairRouter
+
+    spacing_cells = 4
+    dpr, pair, spec, pathfinder, guide = _shadow_setup(spacing_cells, bend_end=(18.0, 7.0))
+
+    monkeypatch.setattr(DiffPairRouter, "_tail_route", _stub_tail_route, raising=True)
+    # Defeat the belt-and-braces overlap gate so we observe the via the
+    # constructor PRODUCES (the fix must clear the guide by construction,
+    # not merely fail the side over to a reject-everything None).
+    monkeypatch.setattr(
+        DiffPairRouter, "_pair_has_physical_overlap", lambda self, p, n: False, raising=True
+    )
+
+    result = dpr._shadow_route_pair(pair, spec, pathfinder, guide, spacing_cells)
+    assert result is not None, "shadow constructor should place a clearing via, not give up"
+    _p_route, n_route = result  # P is the guide; N is the geometric shadow.
+
+    via_clear = _via_clearance_bound(dpr.autorouter.rules, guide)
+    assert n_route.vias, "the shadow must carry its own layer-change via"
+    for via in n_route.vias:
+        for seg in guide.segments:
+            dist = DiffPairRouter._point_segment_distance(via.x, via.y, seg)
+            assert dist >= via_clear - 1e-9, (
+                f"shadow via at ({via.x:.3f},{via.y:.3f}) intersects partner "
+                f"copper: centerline distance {dist:.4f} mm < required "
+                f"{via_clear:.4f} mm (barrel overlaps the guide trace)"
+            )
+
+
+def test_shadow_via_guard_rejects_grazing_site_and_keeps_spread_site():
+    """Load-bearing: the guard rejects the pre-#3541 (un-spread) via site.
+
+    Uses a guide whose out-going B_CU leg sweeps back through the side=+1.0
+    minimum-lateral via neighbourhood, so the pre-#3541 placement -- the
+    barrel offset only against the INCOMING +x leg's normal -- lands ON the
+    out-going leg.  Asserts:
+
+      1. that naive site DOES violate the clearance bound (the scenario
+         actually exercises the #3541 bug -- otherwise the guard would pass
+         vacuously), and
+      2. the guard predicate the fix added (barrel-vs-whole-guide distance
+         < ``via_clear``) flags exactly that site, while a wider-spread
+         candidate from the same lattice clears -- i.e. the perpendicular
+         spread is what restores clearance.
+    """
+    import math
+
+    from kicad_tools.router.diffpair_routing import DiffPairRouter
+
+    spacing_cells = 4
+    # Out-going leg bends acutely up-and-LEFT, sweeping back under the
+    # side=+1.0 shadow-via region (~(11.4, 5.5)).
+    dpr, _pair, _spec, pathfinder, guide = _shadow_setup(spacing_cells, bend_end=(10.0, 6.0))
+    rules = dpr.autorouter.rules
+    via_clear = _via_clearance_bound(rules, guide)
+
+    via_lateral = max(spacing_cells * pathfinder.grid.resolution, via_clear + 0.05)
+    via_pitch = rules.via_diameter + rules.via_clearance
+    stagger = max(0.0, math.sqrt(max(0.0, via_pitch**2 - via_lateral**2))) + 0.05
+    pux, puy = 1.0, 0.0  # incoming unit dir
+    pnx, pny = -puy, pux  # side=+1.0 normal
+
+    def _site(lat_mult: float, stag_mult: float) -> tuple[float, float]:
+        return (
+            12.0 + via_lateral * lat_mult * pnx - stagger * stag_mult * pux,
+            4.8 + via_lateral * lat_mult * pny - stagger * stag_mult * puy,
+        )
+
+    def _barrel_clearance(site: tuple[float, float]) -> float:
+        # The exact guard the fix evaluates: barrel vs the whole guide
+        # polyline on ANY layer (a via spans every layer).
+        return dpr._min_distance_to_partner(
+            site[0], site[1], site[0], site[1], list(guide.segments), None
+        )
+
+    naive = _site(1.0, 1.0)  # the pre-#3541 minimum-lateral placement
+    naive_clear = _barrel_clearance(naive)
+    assert naive_clear < via_clear, (
+        "scenario sanity: the un-spread via must intersect the partner "
+        f"(barrel clearance {naive_clear:.4f} mm should be < bound "
+        f"{via_clear:.4f} mm) for this test to exercise the #3541 fix"
+    )
+
+    # The guard the fix added rejects exactly that grazing candidate ...
+    assert _barrel_clearance(naive) < via_clear
+
+    # ... and the lattice's wider perpendicular spread restores clearance:
+    # at least one larger-lat candidate clears the bound.
+    spread_clearances = [
+        _barrel_clearance(_site(lat, stag))
+        for lat in (1.5, 2.2)
+        for stag in (1.0, 1.6, -1.0, -1.6, 2.4, -2.4)
+    ]
+    assert any(c >= via_clear for c in spread_clearances), (
+        "the perpendicular-spread lattice must offer at least one via site "
+        f"clearing the partner by >= {via_clear:.4f} mm (max offered "
+        f"{max(spread_clearances):.4f} mm)"
+    )


### PR DESCRIPTION
## Summary

The geometric diff-pair shadow constructor (`DiffPairRouter._shadow_route_pair`, opt-in behind `enable_shadow_construction`) placed its layer-change via at a perpendicular offset taken against the **incoming** guide leg's normal. The guide bends at the via, so a site that cleared the incoming leg could still let the via barrel intersect the **outgoing** leg when the guide turned back toward the shadow side — a physical short.

At board 06's tightly-coupled geometry (0.075-0.15 mm edge gaps) the via radius (0.3 mm) exceeded `edge_gap + partner_half_width`, producing the historical ~0.04 mm `clearance_segment_via` intersection. Step 6b's shapely overlap audit flagged USB2_D / USB3_RX1 / USB3_RX2 / PCIE_TX and the solo re-route repair destroyed the coupled geometry.

This is the bounded geometry fix from parent #3508 — perpendicular-spread the via pair before the layer change. It is **not** the larger #3542 convergence rewrite.

## Changes

- `src/kicad_tools/router/diffpair_routing.py`: In the shadow via-site lattice, validate each candidate barrel against the **whole guide polyline** (any layer — a through-via spans every layer) with the bound `via_diameter/2 + trace_clearance + guide_width/2` (the same `via_clear` the crossing-tail synthesizer already enforces). Candidates that graze the partner are rejected, so the existing `lat_mult` widening (1.0 → 1.5 → 2.2) provides the perpendicular spread until a site clears every guide segment. The guide is not in the routing grid, so `_is_via_blocked` alone could not see the grazing barrel.
- `tests/test_diffpair_shadow.py`: two tests (section 10).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Shadow via placement guarantees `via_edge -> partner_copper >= trace_clearance`, validated cell-by-cell | ✅ | Guard added at the via-site selection point; every accepted site satisfies `_min_distance_to_partner(via, guide, any-layer) >= via_clear` by construction |
| Unit test: layer-changing shadow pair at a tight gap places vias without partner intersection | ✅ | `test_shadow_via_clears_partner_at_tight_gap` drives `_shadow_route_pair` end-to-end at 0.4 mm spacing and asserts every produced shadow via clears every guide segment by ≥ `via_clear` |
| Board 06 seed-42: 6b reports no physically-overlapping shadow-claimed pairs | ⚠️ | Not run here (full board route is the #3508 integration milestone); the unit/geometry guard is the bounded slice this issue scopes |

`test_shadow_via_guard_rejects_grazing_site_and_keeps_spread_site` proves the fix is load-bearing: it builds a guide whose outgoing leg sweeps back through the pre-#3541 minimum-lateral via neighbourhood, asserts that naive site **violates** `via_clear`, and asserts the widened-spread lattice offers a clearing site.

## Test Plan

- `pytest tests/test_diffpair_shadow.py` — 24 passed (22 pre-existing + 2 new)
- `pytest tests/test_diffpair_{corridor,phase_b,intra_clearance_detection,routing_integration,self_intersection,serpentine_clearance,swap_via_reject,engagement}.py` — all green (no regressions)
- `ruff check .` ✅ / `ruff format . --check` ✅
- `check_mypy_baseline.py`: the only flagged error (`nanobind` import-untyped in `cli/build_native_cmd.py`) is pre-existing and environmental — it appears with my changes stashed and is triggered by the locally-built native extension; my diff introduces zero new type errors.

Closes #3541