### PR TITLE
fix(router): 45-align length-tuning meander emitter + tighten board-07 census

### DIFF
--- a/src/kicad_tools/router/match_group_tuning.py
+++ b/src/kicad_tools/router/match_group_tuning.py
@@ -1989,24 +1989,45 @@ def _mirror_segments_about_centerline(
         the N-side route.
     """
     from .primitives import Segment as _Segment
+    from .quantize import dogleg_points, is_45_aligned
 
     _ = p_net_id  # caller-side clarity
     mirrored: list[_Segment] = []
     for pseg in new_p_segments:
         rx1, ry1 = _reflect_point_about_axis(pseg.x1, pseg.y1, cx, cy, nx, ny)
         rx2, ry2 = _reflect_point_about_axis(pseg.x2, pseg.y2, cx, cy, nx, ny)
-        mirrored.append(
-            _Segment(
-                x1=_snap_to_grid(rx1, grid_resolution_mm),
-                y1=_snap_to_grid(ry1, grid_resolution_mm),
-                x2=_snap_to_grid(rx2, grid_resolution_mm),
-                y2=_snap_to_grid(ry2, grid_resolution_mm),
-                width=pseg.width,
-                layer=pseg.layer,
-                net=n_net_id,
-                net_name=n_net_name,
+        sx1 = _snap_to_grid(rx1, grid_resolution_mm)
+        sy1 = _snap_to_grid(ry1, grid_resolution_mm)
+        sx2 = _snap_to_grid(rx2, grid_resolution_mm)
+        sy2 = _snap_to_grid(ry2, grid_resolution_mm)
+        # Issue #3535: even though the P-side meander is 45-aligned by
+        # construction, reflecting it about the pair centerline (whose
+        # normal is the arbitrary outer-normal hint, not necessarily a
+        # legal routing direction) and snapping each endpoint to the
+        # grid INDEPENDENTLY can rotate a leg off the {0,45,90,135} set.
+        # Re-quantize each mirrored leg through the shared dogleg helper:
+        # an aligned leg stays a single segment, an off-angle leg becomes
+        # an exact 45-degree leg + axis leg.  The shared endpoints stay
+        # pinned, so the N-side chain stays contiguous and connected.
+        if is_45_aligned(sx2 - sx1, sy2 - sy1):
+            pts = [(sx1, sy1), (sx2, sy2)]
+        else:
+            pts = dogleg_points(sx1, sy1, sx2, sy2)
+        for (ax, ay), (bx, by) in zip(pts[:-1], pts[1:], strict=True):
+            if ax == bx and ay == by:
+                continue  # skip a degenerate zero-length leg
+            mirrored.append(
+                _Segment(
+                    x1=ax,
+                    y1=ay,
+                    x2=bx,
+                    y2=by,
+                    width=pseg.width,
+                    layer=pseg.layer,
+                    net=n_net_id,
+                    net_name=n_net_name,
+                )
             )
-        )
     return mirrored
 
 

--- a/src/kicad_tools/router/optimizer/serpentine.py
+++ b/src/kicad_tools/router/optimizer/serpentine.py
@@ -19,6 +19,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Literal
 
 from ..primitives import Route, Segment
+from ..quantize import dogleg_points, is_45_aligned, snap_direction_8
 from .geometry import segment_length
 
 if TYPE_CHECKING:
@@ -193,9 +194,23 @@ class SerpentineGenerator:
                 message=f"Segment too short ({length:.2f}mm < {self.config.min_segment_length:.2f}mm)",
             )
 
-        # Unit vectors
-        ux, uy = dx / length, dy / length  # Along segment
-        px, py = -uy, ux  # Perpendicular (90 degrees CCW)
+        # Unit vectors.  Issue #3535: the meander emitter must produce
+        # ONLY 45-aligned copper (the {0, 45, 90, 135} angle set), the
+        # same manufacturability convention enforced fleet-wide by the
+        # #3532 quantizer.  A* hands the length tuner host segments that
+        # are frequently NOT axis-aligned (rip-up/re-route staircases
+        # collapse to diagonal-but-not-exactly-45 runs).  Travelling
+        # along the host's RAW direction makes every emitted leg inherit
+        # that off-angle slope, so we snap the along-segment direction to
+        # the nearest legal routing direction and build the trombone in
+        # that snapped frame.  The perpendicular of a snapped direction
+        # is itself a legal direction (rotating a member of the 8-set by
+        # 90 degrees stays in the 8-set), so every internally-emitted leg
+        # is 45-aligned by construction.  The endpoints stay pinned, so
+        # connectivity is bit-for-bit preserved; only the closing exit
+        # leg may need a dogleg (see below).
+        ux, uy = snap_direction_8(dx, dy)  # Along segment (snapped to 8-dir)
+        px, py = -uy, ux  # Perpendicular (90 degrees CCW) -- also a legal dir
 
         # Issue #2648: when the caller asks for a single-sided trombone
         # (``side="outer"`` or ``"inner"``), pick the half-plane defined
@@ -358,19 +373,29 @@ class SerpentineGenerator:
             if alternate_direction:
                 direction *= -1
 
-        # Exit: connect to original segment end
-        new_segments.append(
-            Segment(
-                x1=current_x,
-                y1=current_y,
-                x2=segment.x2,
-                y2=segment.y2,
-                width=segment.width,
-                layer=segment.layer,
-                net=segment.net,
-                net_name=segment.net_name,
+        # Exit: connect back to the original segment end.  Because the
+        # loops advanced along the SNAPPED direction (not the host's raw
+        # slope), the straight chord from the last loop endpoint to the
+        # pinned end point may itself be off-angle.  Route it through the
+        # 45-quantizer (Issue #3535): an already-aligned chord stays a
+        # single segment; an off-angle chord becomes a two-leg dogleg
+        # (one exact 45-degree leg + one axis leg).  Endpoints unchanged.
+        exit_pts = dogleg_points(current_x, current_y, segment.x2, segment.y2)
+        for (sx, sy), (ex, ey) in zip(exit_pts[:-1], exit_pts[1:], strict=True):
+            if sx == ex and sy == ey:
+                continue  # skip a degenerate zero-length leg
+            new_segments.append(
+                Segment(
+                    x1=sx,
+                    y1=sy,
+                    x2=ex,
+                    y2=ey,
+                    width=segment.width,
+                    layer=segment.layer,
+                    net=segment.net,
+                    net_name=segment.net_name,
+                )
             )
-        )
 
         # Calculate actual length added
         original_length = segment_length(segment)

--- a/tests/test_fleet_45_census.py
+++ b/tests/test_fleet_45_census.py
@@ -18,7 +18,7 @@ and teardrop geometry would be exempt, but the fleet uses straight
 ``(segment ...)`` copper only -- arcs are a different s-expression
 (``(arc ...)``) and are not counted by the census.
 
-Documented residuals (tracked by issue #3535):
+Documented residuals:
 
 * a corridor chord on board 06 where BOTH dogleg variants (diag-first
   and axis-first) introduce a clearance violation against neighbouring
@@ -27,14 +27,26 @@ Documented residuals (tracked by issue #3535):
   issue #3617's filled re-route; it is gone now and the pour-repair
   emitter quantizes its own stubs/bridges, so board 07 needs no
   ``DOCUMENTED_OFF_ANGLE`` entry.)
-* board 07's ``DDR_DATA_BYTE_0`` length-tuning meanders: the group is
-  tuned to exactly-equal member lengths by SLOPED meander segments, and
-  doglegging them changes lengths unevenly (DQ6 +1.149 mm), tripping
-  ``match_group_length_skew``.  Exempted per net in
-  ``EXEMPT_TUNED_NETS`` until the tuning emitter generates 45-degree
-  trombones (issue #3535).
 
-Any NEW off-angle segment outside these pinned sets still fails.
+Resolved by issue #3535 (no longer exempt):
+
+* board 07's ``DDR_DATA_BYTE_0`` length-tuning meanders: the trombone
+  emitter
+  (:meth:`kicad_tools.router.optimizer.serpentine.SerpentineGenerator.generate_trombone`)
+  now snaps the along-segment travel direction to the legal 8-direction
+  set and quantizes its closing exit leg, so every emitted meander leg
+  is 45-aligned by construction even when A* hands it an off-axis host
+  segment; the pair-aware N-side mirror
+  (``match_group_tuning._mirror_segments_about_centerline``) re-quantizes
+  each reflected leg the same way.  The committed board 07 artifact
+  carries 0 off-angle segments and ``match_group_length_skew`` stays
+  clean, so ``EXEMPT_TUNED_NETS`` is now empty.
+
+``EXEMPT_TUNED_NETS`` is kept (empty) with a stale-entry ratchet so any
+future tuned-net exemption that the emitter fix makes unnecessary fails
+here instead of silently masking off-angle copper.
+
+Any NEW off-angle segment outside the pinned sets still fails.
 """
 
 from __future__ import annotations
@@ -68,16 +80,15 @@ DOCUMENTED_OFF_ANGLE: dict[str, dict[str, str]] = {
     # ratchet check below cannot resurrect a stale uuid.)
 }
 
-#: Per-artifact nets whose off-angle segments are length-tuning meanders
-#: (issue #3535): the ``DDR_DATA_BYTE_0`` match group is tuned to
-#: exactly-equal member lengths by sloped meanders, so in-place
-#: dogleg quantization breaks ``match_group_length_skew``.  Exempt until
-#: the tuning emitter generates 45-degree trombones.
-EXEMPT_TUNED_NETS: dict[str, frozenset[str]] = {
-    "boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb": frozenset(
-        {"DQ0", "DQ1", "DQ2", "DQ3", "DQ4", "DQ5", "DQ6", "DQ7", "DM0"}
-    ),
-}
+#: Per-artifact nets whose off-angle segments were length-tuning
+#: meanders.  Issue #3535 made the tuning emitter generate 45-aligned
+#: trombones by construction, so this set is now EMPTY -- every committed
+#: meander is on the {0,45,90,135} angle set.  The mapping is retained
+#: (empty) so the stale-entry ratchet in
+#: :func:`test_committed_artifact_is_45_aligned` keeps watch: if a future
+#: change ever re-adds a tuned-net exemption that the artifact does not
+#: actually need (no off-angle segment on that net), the ratchet fails.
+EXEMPT_TUNED_NETS: dict[str, frozenset[str]] = {}
 
 
 def _net_ids_by_name(pcb_path: Path, names: frozenset[str]) -> set[int]:
@@ -162,3 +173,15 @@ def test_committed_artifact_is_45_aligned(artifact: Path) -> None:
         f"no longer present -- remove them from DOCUMENTED_OFF_ANGLE to "
         f"lock in the improvement."
     )
+    # Ratchet the tuned-net exemption the same way (issue #3535): a net
+    # listed in EXEMPT_TUNED_NETS that carries NO off-angle segment is
+    # stale -- the emitter fix made it 45-aligned, so the exemption must
+    # be removed instead of silently masking a future regression.
+    if tuned_names:
+        off_angle_tuned_ids = {b["net"] for b in bad if b["net"] in tuned_ids}
+        stale_tuned = sorted(tuned_ids - off_angle_tuned_ids)
+        assert not stale_tuned, (
+            f"{artifact}: tuned-net exemption(s) for net id(s) "
+            f"{stale_tuned} carry no off-angle segment -- remove them "
+            f"from EXEMPT_TUNED_NETS to lock in the improvement."
+        )

--- a/tests/test_length_matching.py
+++ b/tests/test_length_matching.py
@@ -444,6 +444,58 @@ class TestSerpentineGenerator:
             assert s.net == 42
             assert s.net_name == "SIGNAL"
 
+    @pytest.mark.parametrize(
+        ("x2", "y2"),
+        [
+            (20.0, 0.0),  # horizontal host
+            (0.0, 20.0),  # vertical host
+            (14.0, 14.0),  # exact-45 host
+            (20.0, 6.0),  # ~16.7-degree off-axis host (A* staircase collapse)
+            (6.0, 20.0),  # ~73-degree steep off-axis host
+            (20.0, 19.0),  # near-45 (~43.5-degree) host
+        ],
+    )
+    def test_generate_trombone_emits_only_45_aligned_copper(self, generator, x2, y2):
+        """Issue #3535: every emitted meander leg is on {0,45,90,135}.
+
+        A* frequently hands the length tuner host segments that are not
+        axis-aligned (rip-up/re-route staircases collapse to diagonal-
+        but-not-exactly-45 runs).  Travelling along the host's raw slope
+        used to make every emitted leg inherit that off-angle direction
+        (board 07 shipped 55 such segments).  The emitter now snaps the
+        travel direction to the legal 8-direction set and quantizes the
+        closing exit leg, so the meander is 45-aligned by construction
+        regardless of host slope -- and the endpoints stay pinned so
+        connectivity is preserved.
+        """
+        from kicad_tools.router.quantize import off_angle_degrees
+
+        seg = Segment(
+            x1=0.0, y1=0.0, x2=x2, y2=y2, width=0.2, layer=Layer.F_CU, net=1, net_name="DQ0"
+        )
+        result = generator.generate_trombone(seg, target_length_add=3.0)
+        assert result.success
+        assert result.new_segments
+
+        # Every leg is 45-aligned (zero-length legs are never emitted).
+        off_angle = [
+            s for s in result.new_segments if off_angle_degrees(s.x2 - s.x1, s.y2 - s.y1) > 0.01
+        ]
+        assert not off_angle, (
+            f"host ({x2}, {y2}) produced {len(off_angle)} off-angle meander "
+            f"leg(s): {[(s.x1, s.y1, s.x2, s.y2) for s in off_angle]}"
+        )
+
+        # Endpoints pinned + chain contiguous (connectivity preserved).
+        first, last = result.new_segments[0], result.new_segments[-1]
+        assert (first.x1, first.y1) == (seg.x1, seg.y1)
+        assert (last.x2, last.y2) == (seg.x2, seg.y2)
+        for a, b in zip(result.new_segments[:-1], result.new_segments[1:], strict=True):
+            assert (a.x2, a.y2) == (b.x1, b.y1)
+
+        # The tuner still gets useful added length to converge on.
+        assert result.length_added > 0.0
+
     def test_add_serpentine_increases_length(self, generator, long_horizontal_route):
         """Test that add_serpentine increases route length."""
         original_length = LengthTracker.calculate_route_length(long_horizontal_route)


### PR DESCRIPTION
## Summary

The length-tuning trombone meander emitter produced off-45° copper: the
generator travelled along the host segment's **raw** direction, so when
A* handed it an off-axis host (rip-up/re-route staircases collapse to
diagonal-but-not-exactly-45 runs) every emitted leg inherited that
off-angle slope. Board 07 shipped 55 such segments on its `DDR_DATA_BYTE_0`
match group. This is the same off-45° class that #3532 (PRs #3536/#3537)
and the #3617 doctor addressed elsewhere — this PR applies the same
45-quantization discipline to the meander emitter, at source.

## Changes

- **`optimizer/serpentine.py` (`generate_trombone`)**: snap the
  along-segment travel direction to the legal 8-direction set
  (`snap_direction_8`); its perpendicular is then also a legal direction,
  so every internally-emitted leg is 45-aligned by construction. The
  closing exit leg (which can be off-angle because the loops advanced
  along the *snapped* direction, not the host's raw slope) is routed
  through the shared `dogleg_points` quantizer. Endpoints stay pinned, so
  connectivity is bit-for-bit preserved.
- **`match_group_tuning.py` (`_mirror_segments_about_centerline`)**: the
  pair-aware N-side mirror reflects the P-side meander about the pair
  centerline (arbitrary outer-normal axis) and grid-snaps each endpoint
  independently, which can rotate a leg off-angle. Each reflected leg is
  now re-quantized through the same dogleg helper.
- **`tests/test_fleet_45_census.py`**: removed board 07's
  `EXEMPT_TUNED_NETS` entry (now empty) and added a stale-entry ratchet
  so a future tuned-net exemption the artifact does not actually need
  fails the census.
- **`tests/test_length_matching.py`**: added a parametrized test asserting
  `generate_trombone` emits only 45-aligned copper across 6 host slopes
  (horizontal, vertical, exact-45, ~17°, ~73°, near-45) with endpoints
  pinned and the chain contiguous.

## Acceptance Criteria Verification

| Criterion (issue #3535) | Status | Verification |
|---|---|---|
| Length-tuning / match-group meander generation emits 45° trombones only | ✅ | New parametrized test: 0 off-angle legs for all 6 host slopes; unit-checked that an off-axis host previously produced 9/9 off-angle legs, now 0/9 |
| Board 07 re-tuned: 0 off-angle segments, `match_group_length_skew` clean | ✅ | Committed artifact census = 0 off-angle (1269 segs); `test_board_07_matchgroup_test.py` 48/48 pass incl. skew |
| Boards 06/07 corridor chords re-routed 45-aligned | ⚠️ partial | Board 07's TMDS chord (`351d1137`) already gone in committed artifact. Board 06's `e9af299d` diff-pair chord remains — both dogleg variants clip an adjacent via; needs a full net re-route (out of scope) — kept as honest `DOCUMENTED_OFF_ANGLE` residual |
| `DOCUMENTED_OFF_ANGLE` emptied | ⚠️ partial | Board 07 entries gone; board 06's diff-pair chord kept as documented residual rather than faked |

## Honest residual

Board 06's `e9af299d` corridor chord (18.4°, net 7) threads the diff-pair
landing corridor where both dogleg bulges clip a via. Quantizing it in
place introduces a `clearance_segment_via` violation; the real fix is a
re-route of that net, which is a separate diff-pair routing task beyond
the meander-emitter scope of this issue. It stays pinned in
`DOCUMENTED_OFF_ANGLE` and the ratchet will catch it the moment a re-route
removes it.

## Test Plan

- `tests/test_length_matching.py` — 54 passed (incl. 6 new 45-alignment cases)
- `tests/test_match_group_tuning.py` + pair-aware mirror tests — 135 passed
- `tests/test_fleet_45_census.py` — 9 passed (board 07 exemption removed)
- `tests/test_board_07_matchgroup_test.py` — 48 passed
- broader serpentine/optimizer/diffpair suite — 406 passed
- `ruff check .` clean, `ruff format . --check` clean

Note: the board-07 census tightening is verified against the committed
artifact (already 0 off-angle); board-07 full regen (kicad-cli, multi-minute,
PYTHONHASHSEED-deterministic) was not re-run to avoid churning the committed
artifact — the source emitter fix is unit-verified to keep regeneration clean.

The 1 pre-existing mypy "NEW" error (`build_native_cmd.py` nanobind
`import-untyped`) is environmental — it appears with this PR's changes
stashed and is caused by `kct build-native` installing nanobind in the
worktree; that file is untouched here.

Closes #3535