### PR TITLE
fix(router): bank serpentine length-match headroom + epsilon skew-DRC at tolerance

### DIFF
--- a/src/kicad_tools/router/diffpair_length_tuning.py
+++ b/src/kicad_tools/router/diffpair_length_tuning.py
@@ -132,6 +132,17 @@ class DiffPairTuneResult:
 # targets (very large skew on a congested board).
 MAX_INSERTS_PER_PAIR: int = 3
 
+# Fraction of the skew tolerance to deliberately leave un-closed when
+# sizing the trombone (issue #3543).  Closing 100% of the gap aims the
+# serpentine at the partner's exact length; because loop length is
+# quantized (45deg doglegs, integer loop counts) the artifact routinely
+# *overshoots* by a fraction of a loop, landing the measured skew just
+# *over* tolerance (the observed 0.501 mm against a 0.500 mm budget).
+# Under-targeting by 0.9x tolerance banks ~0.45 mm of headroom (at the
+# 0.5 mm default) so a quantization overshoot stays comfortably in-bounds,
+# while the residual ~0.45 mm skew is itself still within tolerance.
+SERPENTINE_TARGET_HEADROOM_FRACTION: float = 0.9
+
 
 def tune_diff_pair_skew(
     pair: DetectedPair,
@@ -256,6 +267,18 @@ def tune_diff_pair_skew(
         shorter_id, shorter_route, longer_id, longer_route = n_id, n_route, p_id, p_route
         longer_is_p = True
     target_length = max(l_p, l_n)
+    # Under-target by a fraction of the tolerance so quantized loop sizing
+    # does not overshoot the partner length and push the measured skew just
+    # *over* tolerance (issue #3543).  ``serpentine_target`` is what the
+    # trombone generator aims for; ``target_length`` remains the partner's
+    # true length and is used for skew measurement / early-stop below.  The
+    # headroom is clamped so it never reaches/inverts the gap on a pair
+    # whose skew is smaller than the headroom itself.
+    target_headroom = min(
+        SERPENTINE_TARGET_HEADROOM_FRACTION * tolerance_mm,
+        skew,
+    )
+    serpentine_target = target_length - target_headroom
     original_longer_segments = longer_route.segments  # for rollback assertion
 
     # Snapshot the original shorter route -- we may need to roll back.
@@ -307,7 +330,7 @@ def tune_diff_pair_skew(
         attempt_generator = SerpentineGenerator(attempt_config)
 
         candidate_route, serp_result = attempt_generator.add_serpentine(
-            current_shorter, target_length
+            current_shorter, serpentine_target
         )
         result.serpentine_results.append(serp_result)
 
@@ -601,6 +624,7 @@ def _empty_route(net_id: int, net_name: str) -> Route:
 # Re-export for ``from kicad_tools.router.diffpair_length_tuning import *``.
 __all__ = [
     "MAX_INSERTS_PER_PAIR",
+    "SERPENTINE_TARGET_HEADROOM_FRACTION",
     "DiffPairTuneResult",
     "tune_diff_pair_skew",
 ]

--- a/src/kicad_tools/validate/rules/diffpair_length_skew.py
+++ b/src/kicad_tools/validate/rules/diffpair_length_skew.py
@@ -98,6 +98,16 @@ if TYPE_CHECKING:
 # DDR5) MUST set ``NetClassRouting.skew_tolerance_mm`` explicitly.
 DEFAULT_SKEW_TOLERANCE_MM = 0.5
 
+# Float-comparison slack for the skew-vs-tolerance test.  A pair routed to
+# *exactly* the tolerance (e.g. skew 0.500 mm against a 0.500 mm budget)
+# can measure as 0.5000000001 mm after summing many segment lengths in
+# floating point, which would spuriously fire ``skew_mm > tolerance_mm``.
+# We treat any skew within this epsilon of the tolerance as in-bounds
+# (issue #3543: "exact-tolerance rounding 0.501 vs 0.500").  1 micron is
+# far below fab resolution (typical min trace/space ~0.1 mm) so this never
+# masks a real, manufacturable over-skew.
+SKEW_TOLERANCE_EPSILON_MM = 1e-6
+
 
 def _normalize_name_pair(a: str, b: str) -> tuple[str, str]:
     """Return the lexicographically-sorted (low, high) name tuple."""
@@ -266,7 +276,7 @@ class DiffPairLengthSkewRule(DRCRule):
             )
 
             tolerance_mm = self._threshold_map.get(key, self._default_tolerance_mm)
-            if skew_mm > tolerance_mm:
+            if skew_mm > tolerance_mm + SKEW_TOLERANCE_EPSILON_MM:
                 results.add(
                     self._make_violation(
                         name_a=name_a,

--- a/tests/test_diffpair_length_tuning.py
+++ b/tests/test_diffpair_length_tuning.py
@@ -37,6 +37,7 @@ from kicad_tools.router.diffpair import (
 from kicad_tools.router.diffpair_detection import DetectedPair, DetectionSource
 from kicad_tools.router.diffpair_length_tuning import (
     MAX_INSERTS_PER_PAIR,
+    SERPENTINE_TARGET_HEADROOM_FRACTION,
     DiffPairTuneResult,
     tune_diff_pair_skew,
 )
@@ -599,3 +600,109 @@ class TestModuleInvariants:
         assert r.attempts == 0
         assert r.inserts_applied == 0
         assert r.serpentine_results == []
+
+    def test_serpentine_target_headroom_fraction_is_point_nine(self):
+        # Issue #3543 AC: "Serpentine targets <= 0.9 * max_length_delta".
+        assert SERPENTINE_TARGET_HEADROOM_FRACTION == 0.9
+
+
+# =============================================================================
+# 11. Exact-tolerance target headroom (issue #3543)
+# =============================================================================
+
+
+class TestTargetHeadroom:
+    """The trombone under-targets so a quantization overshoot stays in-bounds.
+
+    Issue #3543: closing 100% of the gap aimed the serpentine at the
+    partner's exact length; quantized loop sizing then overshot, landing
+    the measured skew at 0.501 mm against a 0.500 mm budget.  The tuner now
+    deliberately leaves ``0.9 * tolerance`` of residual delta so the
+    artifact cannot cross tolerance.
+    """
+
+    def _length(self, route: Route) -> float:
+        from kicad_tools.router.length import LengthTracker
+
+        return LengthTracker.calculate_route_length(route)
+
+    def test_tuned_skew_stays_under_tolerance(self):
+        # PCIE_RX-style geometry: a pair that is just out of tolerance.
+        # P is shorter (20.0 mm); N is the partner/target (20.55 mm) so the
+        # entry skew is 0.55 mm > 0.5 mm tolerance and the tuner engages.
+        pair = _make_pair(p_id=1, n_id=2)
+        p = Route(
+            net=1,
+            net_name="USB_D+",
+            segments=[Segment(0.0, 0.0, 20.0, 0.0, 0.2, Layer.F_CU, net=1, net_name="USB_D+")],
+        )
+        n = Route(
+            net=2,
+            net_name="USB_D-",
+            segments=[Segment(0.0, 2.0, 20.55, 2.0, 0.2, Layer.F_CU, net=2, net_name="USB_D-")],
+        )
+        routes = {1: p, 2: n}
+        target_length = self._length(n)
+
+        p_out, n_out, result = tune_diff_pair_skew(
+            pair,
+            routes,
+            tolerance_mm=0.5,
+            intra_pair_clearance_mm=0.1,
+            config=SerpentineConfig(amplitude=0.5, min_spacing=0.2, gap_factor=2.0),
+        )
+
+        # The longer half is never mutated.
+        assert n_out is n
+        # The tuner must have actually engaged (skew was > tolerance).
+        assert result.inserts_applied >= 1
+        # The *measured* artifact skew must be within tolerance -- the
+        # overshoot that produced 0.501 mm pre-fix is now banked as headroom.
+        measured_skew = abs(target_length - self._length(p_out))
+        assert measured_skew <= 0.5 + 1e-9, (
+            f"Tuned artifact skew {measured_skew:.4f} mm exceeds 0.5 mm tolerance"
+        )
+        assert result.skew_after_mm <= 0.5 + 1e-9
+
+    def test_under_targets_below_partner_length(self):
+        # The serpentine target passed to add_serpentine must be the partner
+        # length MINUS the headroom (not the full partner length), so the
+        # shorter route is grown to *less than* the partner -- leaving the
+        # residual delta as headroom rather than risking an overshoot past it.
+        pair = _make_pair(p_id=1, n_id=2)
+        p = Route(
+            net=1,
+            net_name="USB_D+",
+            segments=[Segment(0.0, 0.0, 20.0, 0.0, 0.2, Layer.F_CU, net=1, net_name="USB_D+")],
+        )
+        n = Route(
+            net=2,
+            net_name="USB_D-",
+            segments=[Segment(0.0, 2.0, 24.0, 2.0, 0.2, Layer.F_CU, net=2, net_name="USB_D-")],
+        )
+        routes = {1: p, 2: n}
+        target_length = self._length(n)
+
+        captured_targets: list[float] = []
+        orig_add = SerpentineGenerator.add_serpentine
+
+        def spy(self, route, target_length_arg, grid=None):
+            captured_targets.append(target_length_arg)
+            return orig_add(self, route, target_length_arg, grid)
+
+        with patch.object(SerpentineGenerator, "add_serpentine", spy):
+            tune_diff_pair_skew(
+                pair,
+                routes,
+                tolerance_mm=0.5,
+                intra_pair_clearance_mm=0.1,
+                config=SerpentineConfig(amplitude=0.5, min_spacing=0.2, gap_factor=2.0),
+            )
+
+        assert captured_targets, "add_serpentine was never called"
+        expected_headroom = SERPENTINE_TARGET_HEADROOM_FRACTION * 0.5  # 0.45 mm
+        for tgt in captured_targets:
+            # Aim is partner length minus the banked headroom, never the full
+            # partner length (which is what overshot pre-fix).
+            assert tgt == pytest.approx(target_length - expected_headroom, abs=1e-9)
+            assert tgt < target_length

--- a/tests/test_validate_diffpair_length_skew.py
+++ b/tests/test_validate_diffpair_length_skew.py
@@ -167,6 +167,43 @@ class TestDiffPairLengthSkewRule:
         results = rule.check(pcb, _design_rules())
         assert len(results.violations) == 0
 
+    def test_float_noise_at_tolerance_does_not_fire(self):
+        """skew measured as tolerance + float epsilon -> no violation (issue #3543).
+
+        A pair routed to *exactly* the tolerance can sum to a value a few
+        ULPs over (e.g. 0.5 + 1e-12) after accumulating many segment
+        lengths.  Without the epsilon slack the bare ``>`` comparison would
+        spuriously fire on a manufacturable, at-tolerance pair.
+        """
+        pcb = _make_pair_pcb()
+        # 0.5 + tiny float noise, well inside SKEW_TOLERANCE_EPSILON_MM (1e-6).
+        noisy = 0.5 + 1e-12
+        assert noisy > 0.5  # genuinely greater as a raw float
+        rule = DiffPairLengthSkewRule(
+            skew_data={("USB_D+", "USB_D-"): noisy},
+            engaged_pairs={(4, 5)},
+        )
+        results = rule.check(pcb, _design_rules())
+        assert len(results.violations) == 0
+        # The pair was still *checked* (engaged + measured); just no fire.
+        assert results.rules_checked == 1
+
+    def test_overshoot_beyond_epsilon_still_fires(self):
+        """skew = 0.501 (1 micron over) is a real over-skew -> still fires.
+
+        The epsilon slack is only 1e-6 mm; a 0.001 mm (1 micron) overshoot
+        is three orders of magnitude larger and must NOT be masked.  This
+        guards against the epsilon being widened into a real-tolerance hole.
+        """
+        pcb = _make_pair_pcb()
+        rule = DiffPairLengthSkewRule(
+            skew_data={("USB_D+", "USB_D-"): 0.501},
+            engaged_pairs={(4, 5)},
+        )
+        results = rule.check(pcb, _design_rules())
+        assert len(results.violations) == 1
+        assert results.violations[0].actual_value == pytest.approx(0.501, abs=1e-9)
+
     def test_above_default_tolerance_fires(self):
         """Asymmetric pair: skew=2.0 > default 0.5 -> fires with correct values."""
         pcb = _make_pair_pcb()


### PR DESCRIPTION
## Summary

Addresses the **bounded** half of issue #3543: the exact-tolerance rounding defect (`0.501` vs `0.500`) on length-matched diff pairs. Two complementary root causes:

1. **Tuner over-targets (the source of the 0.501 mm artifact).** `tune_diff_pair_skew` aimed the trombone at the partner's *exact* length (100% gap closure). Because loop length is quantized (45deg doglegs, integer loop counts), the artifact routinely overshot the partner by a fraction of a loop, landing the measured skew at 0.501 mm against a 0.500 mm budget. The tuner now deliberately under-targets by `0.9 * tolerance` (`SERPENTINE_TARGET_HEADROOM_FRACTION`), banking ~0.45 mm of headroom (at the 0.5 mm default) so a quantization overshoot stays comfortably in-bounds while the residual ~0.45 mm skew is itself still within tolerance. This is the issue's "Target ~90% of `max_length_delta` instead of 100%" guidance.

2. **DRC comparison had no float slack.** `diffpair_length_skew`'s bare `skew_mm > tolerance_mm` could spuriously fire on a pair routed to *exactly* the tolerance, because summing many segment lengths in floating point can land a few ULPs over (0.5 -> 0.5000000001). Added a `1e-6` mm epsilon (`SKEW_TOLERANCE_EPSILON_MM`) -- three orders of magnitude below the observed 0.001 mm overshoot and far below fab resolution -- so an at-tolerance pair passes while a genuine over-skew still fires.

## Changes

- `diffpair_length_tuning.py`: under-target the serpentine by `0.9 * tolerance_mm` (clamped to the entry skew). `target_length` still drives skew measurement / early-stop; only the value passed to `add_serpentine` is reduced. New `SERPENTINE_TARGET_HEADROOM_FRACTION = 0.9` constant (exported in `__all__`).
- `validate/rules/diffpair_length_skew.py`: compare against `tolerance_mm + SKEW_TOLERANCE_EPSILON_MM` (1e-6 mm) instead of the raw tolerance.
- Tests for both fixes (see below).

## Acceptance Criteria Verification

| Criterion (issue #3543) | Status | Verification |
|-------------------------|--------|--------------|
| Serpentine targets <= 0.9 * max_length_delta (PCIE_RX-style geometry) | done | `TestTargetHeadroom` asserts `add_serpentine` is aimed at `partner_length - 0.9*tol` (never the full partner length) and the tuned artifact skew stays <= tolerance |
| Exact-tolerance rounding (0.500 / 0.501) handled | done | `test_float_noise_at_tolerance_does_not_fire` (0.5 + float noise -> no fire) and `test_overshoot_beyond_epsilon_still_fires` (0.501 -> still fires); existing `test_at_tolerance_does_not_fire` (0.500 == 0.500) still green |
| Serpentine falls back to alternative segments / smaller amplitude on grid-reject | deferred | See "Out of scope" below -- this is the genuine routing-capacity half (#3508 family) |
| Board 06 seed-42 re-route with shadow enabled | deferred | Integration AC bound to the fallback above; shadow machinery is flag-gated behind `enable_shadow_construction` (#3508) |

## Out of scope (remains for #3508 / #3542)

The other half of #3543 -- **no legal serpentine space on the dense USB3 BGA-49 escapes** -- is *not* a bounded fix. It requires the grid-validated `create_serpentine` to try alternative route segments / reduced amplitude (or length-absorbing detours during shadow construction itself), which is part of the #3508 coupled-convergence family and gated behind `enable_shadow_construction`. I'm using **Refs** (not Closes) so #3543 stays open for that work.

## Test Plan

- `pytest tests/test_validate_diffpair_length_skew.py tests/test_validate_match_group_length_skew.py tests/test_diffpair_length_tuning.py tests/test_diffpair_serpentine_clearance.py tests/test_cli_check_diffpair_length_skew.py` -> 93 passed.
- `ruff check .` clean; `ruff format . --check` clean (1456 files already formatted).
- C++ backend built (`kct build-native`).

> Note on the mypy gate: building the native extension installs `nanobind`, which flips the pre-existing baseline entry for `src/kicad_tools/cli/build_native_cmd.py` from `import-not-found` to `import-untyped` (and clears 14 other baseline errors). This is a build-environment artifact in a file this PR does not touch -- none of the four changed files introduce a mypy error (verified by running mypy directly on the two edited source modules). The baseline was intentionally left unmodified.

Refs #3543