### PR TITLE
fix(lint): burn down ruff backlog baselined by #3464; enforce 9 rules

### DIFF
--- a/boards/external/softstart/generate_design.py
+++ b/boards/external/softstart/generate_design.py
@@ -307,7 +307,6 @@ def create_softstart_schematic(output_dir: Path) -> Path:
     # =========================================================================
     RAIL_3V3 = 30  # 3.3V logic supply
     RAIL_VRECT = 50  # Rectified DC (~12V from bridge rectifier)
-    RAIL_12V = 70  # 12V VGATE rail (LM7812 output) for UCC27211 supply
     RAIL_GND = 280  # Ground
 
     # Schematic section X positions
@@ -938,8 +937,8 @@ def create_softstart_schematic(output_dir: Path) -> Path:
     # nets explicitly so they bind to the driver outputs.
     qa_gate = pair_pos.port("GATE_A")
     qb_gate = pair_pos.port("GATE_B")
-    qa_pos_source = pair_pos.port("SOURCE")
-    qb_pos_source = pair_pos.port("SOURCE")
+    pair_pos.port("SOURCE")
+    pair_pos.port("SOURCE")
     # Gate labels for the back-to-back pair pins so they bond to driver outputs
     sch.add_wire(qa_gate, (qa_gate[0] - 5, qa_gate[1]))
     sch.add_label("UCC_HO_POS", qa_gate[0] - 5, qa_gate[1])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,20 +249,12 @@ ignore = [
     "B023",   # function doesn't bind loop variable - requires refactoring
     "UP035",  # deprecated typing imports - requires Python 3.9+ for generics
     # ---------------------------------------------------------------------
-    # Residual backlog baselined when the CI Lint & Format gate was turned
-    # on (#3464). These rules carry behavioral risk (unsafe --fix can delete
-    # side-effecting calls) or need per-site judgement, so they were parked
-    # rather than bulk-fixed. Burn-down tracked by #3663 -- remove each entry
-    # as its sites are individually reviewed and fixed.
-    "F841",   # unused-variable - unsafe fix can drop side-effecting calls
-    "SIM105", # suppressible-exception (try/except/pass)
-    "F401",   # unused-import - residual __init__.py re-export positions
-    "F601",   # multi-value-repeated-key-literal
-    "SIM115", # open-file-with-context-handler
-    "F811",   # redefined-while-unused (router/__init__.py RoutingResult)
-    "SIM101", # duplicate-isinstance-call
-    "SIM116", # if-else-block-instead-of-dict-lookup
-    "UP007",  # non-pep604-annotation-union
+    # The residual backlog baselined when the CI Lint & Format gate was
+    # turned on (#3464) has been fully burned down by #3663: F841, SIM105,
+    # F401, F601, SIM115, F811, SIM101, SIM116, and UP007 are all enforced
+    # again. Two latent defects were fixed in the process -- duplicate dict
+    # keys in erc/violation.py (F601) and a shadowed duplicate test class in
+    # test_pcb_sync_netlist.py (F811).
 ]
 
 [tool.ruff.format]

--- a/src/kicad_tools/acceleration/backend.py
+++ b/src/kicad_tools/acceleration/backend.py
@@ -502,7 +502,7 @@ class ArrayBackend:
         if self._backend_type == BackendType.METAL:
             # MLX doesn't have fill_diagonal, use indexing
             n = min(arr.shape[0], arr.shape[1])
-            indices = self._xp.arange(n)
+            self._xp.arange(n)
             # MLX arrays are immutable, need to create new array
             result = self._xp.array(arr)
             # Use scatter for diagonal assignment

--- a/src/kicad_tools/acceleration/kernels/evolutionary.py
+++ b/src/kicad_tools/acceleration/kernels/evolutionary.py
@@ -67,7 +67,7 @@ def evaluate_population_gpu(
     Returns:
         Fitness values with shape (pop_size,). Higher is better.
     """
-    pop_size = positions.shape[0]
+    positions.shape[0]
 
     # Transfer data to GPU
     pos_gpu = backend.array(positions)
@@ -122,7 +122,6 @@ def _compute_wire_lengths_batch(
     Returns:
         Wire lengths (pop_size,)
     """
-    xp = backend.xp
     pop_size = positions.shape[0]
     n_springs = springs.shape[0]
 
@@ -182,7 +181,6 @@ def _compute_overlaps_batch(
     Returns:
         Overlap counts (pop_size,)
     """
-    xp = backend.xp
     pop_size = positions.shape[0]
     n_comp = positions.shape[1]
 
@@ -206,7 +204,7 @@ def _compute_overlaps_batch(
 
     idx_i = backend.array(idx_i, dtype=backend.int32)
     idx_j = backend.array(idx_j, dtype=backend.int32)
-    n_pairs = len(idx_i) if hasattr(idx_i, "__len__") else idx_i.shape[0]
+    len(idx_i) if hasattr(idx_i, "__len__") else idx_i.shape[0]
 
     # Get positions for all pairs
     # positions[:, idx_i, :] gives (pop_size, n_pairs, 2)
@@ -254,7 +252,6 @@ def _compute_boundary_violations_batch(
     Returns:
         Violation counts (pop_size,)
     """
-    xp = backend.xp
     pop_size = positions.shape[0]
     n_comp = positions.shape[1]
     n_verts = board_vertices.shape[0]
@@ -326,7 +323,6 @@ def _compute_routability_batch(
     Returns:
         Routability scores (pop_size,) in range [0, 100]
     """
-    xp = backend.xp
     pop_size = positions.shape[0]
     n_comp = positions.shape[1]
 
@@ -378,7 +374,6 @@ def _compute_pin_alignment_batch(
     Returns:
         Alignment scores (pop_size,) in range [0, 100]
     """
-    xp = backend.xp
     pop_size = positions.shape[0]
     n_springs = springs.shape[0]
 
@@ -445,7 +440,7 @@ def prepare_evaluation_data(
     """
     n_components = len(components)
     n_springs = len(springs)
-    n_verts = len(board_vertices)
+    len(board_vertices)
 
     # Build component sizes array
     component_sizes = np.zeros((n_components, 2), dtype=np.float32)

--- a/src/kicad_tools/acceleration/kernels/placement.py
+++ b/src/kicad_tools/acceleration/kernels/placement.py
@@ -162,11 +162,11 @@ def compute_pairwise_repulsion_gpu(
 
         # Get chunk of source edges (edges receiving forces)
         src_starts = starts[chunk_start:chunk_end]  # (chunk, 2)
-        src_ends = ends[chunk_start:chunk_end]
+        ends[chunk_start:chunk_end]
         src_vecs = edge_vecs[chunk_start:chunk_end]
         src_lens = edge_lens[chunk_start:chunk_end]
         src_comp = comp_idx[chunk_start:chunk_end]
-        chunk_size = chunk_end - chunk_start
+        chunk_end - chunk_start
 
         # Generate sample points along source edges
         # t values: (num_samples,)

--- a/src/kicad_tools/acceleration/kernels/routing.py
+++ b/src/kicad_tools/acceleration/kernels/routing.py
@@ -560,11 +560,11 @@ class BatchPathfinder:
             net_ids[i] = req.net_id
 
         # Move to GPU
-        source_gx_gpu = self.backend.array(source_gx)
-        source_gy_gpu = self.backend.array(source_gy)
-        target_gx_gpu = self.backend.array(target_gx)
-        target_gy_gpu = self.backend.array(target_gy)
-        net_ids_gpu = self.backend.array(net_ids)
+        self.backend.array(source_gx)
+        self.backend.array(source_gy)
+        self.backend.array(target_gx)
+        self.backend.array(target_gy)
+        self.backend.array(net_ids)
 
         # Run parallel A* with shared frontier expansion
         # For now, fall back to sequential with GPU-accelerated cost computation
@@ -1040,8 +1040,8 @@ def compute_batch_costs_gpu(
     off_gpu = backend.array(neighbor_offsets)
 
     # Compute neighbor positions
-    pos_expanded = backend.reshape(pos_gpu, (n_positions, 1, 3))
-    off_expanded = backend.reshape(off_gpu, (1, n_neighbors, 3))
+    backend.reshape(pos_gpu, (n_positions, 1, 3))
+    backend.reshape(off_gpu, (1, n_neighbors, 3))
 
     # This would need custom kernel for proper broadcasting
     # For now, return placeholder
@@ -1073,8 +1073,8 @@ def batch_heuristic_gpu(
     Returns:
         (N,) array of minimum heuristic values to any goal
     """
-    n = current_positions.shape[0]
-    m = goal_positions.shape[0]
+    current_positions.shape[0]
+    goal_positions.shape[0]
 
     # Move to GPU
     curr_gpu = backend.array(current_positions)

--- a/src/kicad_tools/cli/fleet_cmd.py
+++ b/src/kicad_tools/cli/fleet_cmd.py
@@ -37,6 +37,7 @@ decision 2026-05-21):
 from __future__ import annotations
 
 import argparse
+import contextlib
 import datetime as _dt
 import json
 import re
@@ -794,10 +795,8 @@ def _extract_pcb_pad_net_numbers(pcb_text: str) -> set[int]:
         # Match (net N "name") inside the pad body
         m = _PCB_NET_NUMBERED_RE.search(body)
         if m:
-            try:
+            with contextlib.suppress(ValueError):
                 pad_net_numbers.add(int(m.group(1)))
-            except ValueError:
-                pass
         i = body_end
     return pad_net_numbers
 

--- a/src/kicad_tools/cli/modify_schematic.py
+++ b/src/kicad_tools/cli/modify_schematic.py
@@ -24,6 +24,7 @@ Usage:
 """
 
 import argparse
+import contextlib
 import re
 import shutil
 import sys
@@ -89,10 +90,8 @@ def find_symbol_text_range(text: str, reference: str) -> tuple[int, int, dict] |
     lib_symbols_end = 0
     lib_sym_match = re.search(r"\(lib_symbols\b", text)
     if lib_sym_match:
-        try:
+        with contextlib.suppress(ValueError):
             lib_symbols_end = _find_matching_close_paren(text, lib_sym_match.start()) + 1
-        except ValueError:
-            pass
 
     # Find each top-level (symbol ...) block after lib_symbols using paren balancing
     symbol_start_pattern = re.compile(r"\n(\s+)\(symbol\n")

--- a/src/kicad_tools/cli/optimize_placement_cmd.py
+++ b/src/kicad_tools/cli/optimize_placement_cmd.py
@@ -13,6 +13,7 @@ Usage:
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import signal
@@ -133,10 +134,8 @@ def _write_placements_to_pcb_atomic(
         Path(tmp_path).replace(out)
     except BaseException:
         # Clean up the temp file on failure
-        try:
+        with contextlib.suppress(OSError):
             Path(tmp_path).unlink(missing_ok=True)
-        except OSError:
-            pass
         raise
 
 

--- a/src/kicad_tools/cli/sch_add_pull_resistor.py
+++ b/src/kicad_tools/cli/sch_add_pull_resistor.py
@@ -503,7 +503,7 @@ def run_add_pull_resistor(args) -> int:
         if clear_x is not None:
             rerouted = True
             # Shift the resistor and power symbol to the new column
-            x_shift = clear_x - res_x
+            clear_x - res_x
             res_x = clear_x
             res_position = (res_x, res_y)
 

--- a/src/kicad_tools/cli/sch_insert_inline.py
+++ b/src/kicad_tools/cli/sch_insert_inline.py
@@ -383,7 +383,7 @@ def run_insert_inline(args) -> int:
     else:
         effective_end = wire_end
 
-    effective_len = _wire_length(effective_start, effective_end)
+    _wire_length(effective_start, effective_end)
 
     # Component placement at midpoint
     mid_x = _snap((effective_start[0] + effective_end[0]) / 2)

--- a/src/kicad_tools/cli/sch_repair_instances.py
+++ b/src/kicad_tools/cli/sch_repair_instances.py
@@ -187,7 +187,7 @@ def _extract_symbols_with_instance_info(text: str, project_name: str) -> list[di
     )
 
     for start_match in start_pattern.finditer(text):
-        indent = start_match.group(1)
+        start_match.group(1)
         lib_id = start_match.group(2)
         block_start = start_match.start()
 
@@ -257,8 +257,8 @@ def _extract_symbols_with_instance_info(text: str, project_name: str) -> list[di
             # Check if this uuid is inside a (pin ...) block
             preceding = block[: uuid_m.start()]
             # Count unmatched (pin openings
-            pin_opens = len(re.findall(r"\(pin\b", preceding))
-            pin_closes = preceding.count(")")  # rough estimate
+            len(re.findall(r"\(pin\b", preceding))
+            preceding.count(")")  # rough estimate
             # Better approach: check if (pin appears after the last )
             # before our uuid position
             last_paren_close = preceding.rfind(")")

--- a/src/kicad_tools/cli/sch_validate.py
+++ b/src/kicad_tools/cli/sch_validate.py
@@ -113,7 +113,7 @@ def run_erc(schematic_path: str) -> list[ValidationIssue]:
             output_file = f.name
 
         try:
-            result = subprocess.run(
+            subprocess.run(
                 [
                     kicad_cli,
                     "sch",

--- a/src/kicad_tools/drc/repair_clearance.py
+++ b/src/kicad_tools/drc/repair_clearance.py
@@ -980,7 +980,6 @@ class ClearanceRepairer:
 
         # Get actual clearance values for reporting
         actual_clearance = violation.actual_value_mm or 0.0
-        required_clearance = violation.required_value_mm or 0.0
 
         nudge_result = NudgeResult(
             object_type=obj_type,

--- a/src/kicad_tools/erc/violation.py
+++ b/src/kicad_tools/erc/violation.py
@@ -119,12 +119,6 @@ ERC_TYPE_DESCRIPTIONS = {
     "unspecified": "Unspecified error",
     "wire_dangling": "Wire not connected at both ends",
     "unconnected_wire_endpoint": "Unconnected wire endpoint",
-    # Library/footprint checks (non-electrical)
-    "lib_symbol_mismatch": "Library symbol does not match schematic symbol",
-    "footprint_link_issues": "Footprint link issues",
-    "single_global_label": "Only one global label for a net",
-    "isolated_pin_label": "Pin connected only by label (no wire)",
-    "pin_to_pin": "Pin-to-pin connection issue",
     # Unknown
     "unknown": "Unknown violation type",
 }

--- a/src/kicad_tools/optim/place_route.py
+++ b/src/kicad_tools/optim/place_route.py
@@ -19,6 +19,7 @@ Example:
 
 from __future__ import annotations
 
+import contextlib
 import os
 import shutil
 import tempfile
@@ -511,10 +512,8 @@ class PlaceRouteOptimizer:
             if self.verbose:
                 print(f"  Warning: checkpoint save failed: {e}")
             # Clean up temp file if it exists
-            try:
+            with contextlib.suppress(OSError, UnboundLocalError):
                 Path(tmp_path).unlink(missing_ok=True)
-            except (OSError, UnboundLocalError):
-                pass
 
     def _run_placement_phase(self) -> list[Conflict]:
         """Run placement conflict detection.

--- a/src/kicad_tools/placement/vector.py
+++ b/src/kicad_tools/placement/vector.py
@@ -463,14 +463,13 @@ def bounds(
 def _rotate_offset(dx: float, dy: float, rot_deg: float) -> tuple[float, float]:
     """Rotate an offset vector by *rot_deg* degrees counter-clockwise."""
     rot_idx = int(round(rot_deg / 90.0)) % 4
-    if rot_idx == 0:
-        return dx, dy
-    elif rot_idx == 1:
-        return -dy, dx
-    elif rot_idx == 2:
-        return -dx, -dy
-    else:
-        return dy, -dx
+    rotations = {
+        0: (dx, dy),
+        1: (-dy, dx),
+        2: (-dx, -dy),
+        3: (dy, -dx),
+    }
+    return rotations[rot_idx]
 
 
 def _block_member_refs(block_groups: Sequence[BlockGroupDef]) -> frozenset[str]:
@@ -611,7 +610,7 @@ def decode_with_blocks(
     Raises:
         ValueError: If vector length does not match expected dimensionality.
     """
-    blocked_refs = _block_member_refs(block_groups)
+    _block_member_refs(block_groups)
     free_indices, ref_to_idx = _split_free_and_block(components, block_groups)
     n_free = len(free_indices)
     n_blocks = len(block_groups)
@@ -702,7 +701,7 @@ def bounds_with_blocks(
     Returns:
         :class:`PlacementBounds` for the reduced-dimensionality vector.
     """
-    blocked_refs = _block_member_refs(block_groups)
+    _block_member_refs(block_groups)
     free_indices, ref_to_idx = _split_free_and_block(components, block_groups)
     n_free = len(free_indices)
     n_blocks = len(block_groups)

--- a/src/kicad_tools/report/collector.py
+++ b/src/kicad_tools/report/collector.py
@@ -544,9 +544,7 @@ class ReportDataCollector:
         # Classify nets by type for richer reporting.
         # Zone-connected: plane nets that the trace-level analyzer may mark
         # incomplete but are actually connected via copper zones.
-        zone_connected_nets = sorted(
-            n.net_name for n in result.nets if n.is_plane_net and n.status != "complete"
-        )
+        sorted(n.net_name for n in result.nets if n.is_plane_net and n.status != "complete")
         # Also include plane nets that *are* complete (they are still zone-connected).
         all_zone_nets = sorted(n.net_name for n in result.nets if n.is_plane_net)
 

--- a/src/kicad_tools/router/__init__.py
+++ b/src/kicad_tools/router/__init__.py
@@ -64,7 +64,7 @@ from .cache import (
     transform_routes,
 )
 from .congestion_estimator import CongestionEstimator, NetBBox, TileGrid
-from .core import AdaptiveAutorouter, Autorouter, RoutingFailure, RoutingResult
+from .core import AdaptiveAutorouter, Autorouter, RoutingFailure
 from .cpp_backend import (
     CppGrid,
     CppPathfinder,
@@ -305,7 +305,6 @@ __all__ = [
     "Autorouter",
     "AdaptiveAutorouter",
     "RoutingFailure",
-    "RoutingResult",
     # C++ backend
     "is_cpp_available",
     "ensure_cpp_backend_available",
@@ -567,8 +566,16 @@ __all__ = [
     "CacheKey",
     "CachedRoutingResult",
     "CachedNetRoute",
+    "CachedSubProblem",
+    "SubProblemSignature",
     "compute_pad_positions_hash",
     "get_default_cache_path",
+    "normalize_routes_to_origin",
+    "transform_routes",
+    # Congestion estimation
+    "CongestionEstimator",
+    "NetBBox",
+    "TileGrid",
     # Preflight checks (Issue #2497)
     "OffGridReport",
     "PreflightOffGridPad",

--- a/src/kicad_tools/router/algorithms/negotiated.py
+++ b/src/kicad_tools/router/algorithms/negotiated.py
@@ -12,6 +12,7 @@ Adaptive parameter tuning (Issue #633) improves convergence by:
 
 from __future__ import annotations
 
+import contextlib
 import random
 import time
 from typing import TYPE_CHECKING, Callable
@@ -2404,7 +2405,8 @@ class NegotiatedRouter:
                 resolved_name = net_names.get(net_id, f"Net_{net_id}")
             else:
                 resolved_name = f"Net_{net_id}"
-            try:
+            # Never let a buggy progress callback abort the rip-up.
+            with contextlib.suppress(Exception):
                 progress_callback(
                     "ripup_phase",
                     {
@@ -2416,9 +2418,6 @@ class NegotiatedRouter:
                         "elapsed": time.time() - start_time,
                     },
                 )
-            except Exception:
-                # Never let a buggy progress callback abort the rip-up.
-                pass
 
         # Re-route the failed net first (it now has priority with cleared
         # path).  Issue #3470: track per-edge failures via the failure

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -27,6 +27,8 @@ from kicad_tools.cli.progress import flush_print
 
 logger = logging.getLogger(__name__)
 
+import contextlib
+
 from . import via_conflict as _via_conflict_module
 from .adaptive import AdaptiveAutorouter, RoutingResult
 from .adaptive_grid import AdaptiveGridRouter
@@ -3798,10 +3800,8 @@ class Autorouter:
         if hasattr(self.router, "_net_class_map"):
             self.router._net_class_map = self.net_class_map
         if hasattr(self.router, "net_class_map"):
-            try:
+            with contextlib.suppress(AttributeError):
                 self.router.net_class_map = self.net_class_map
-            except AttributeError:
-                pass
 
     # ------------------------------------------------------------------
     # Post-route skew bookkeeping
@@ -6526,7 +6526,7 @@ class Autorouter:
         self._prepare_routing()
 
         # Issue #1603: Sub-grid escape pre-pass for off-grid pads
-        escape_routes = self._run_subgrid_prepass()
+        self._run_subgrid_prepass()
 
         flush_print("\n=== Negotiated Congestion Routing ===")
         flush_print(f"  Max iterations: {max_iterations}")
@@ -11582,8 +11582,8 @@ class Autorouter:
         removed_oob_segs: dict[int, list[Segment]] = {}  # noqa: F821  # Segment imported func-locally
         removed_oob_vias: dict[int, list[Via]] = {}  # noqa: F821  # Via imported func-locally
         for idx, route in enumerate(self.routes):
-            orig_seg_count = len(route.segments)
-            orig_via_count = len(route.vias)
+            len(route.segments)
+            len(route.vias)
 
             # Keep segment if at least one endpoint is inside bounds
             # (bridges the board edge -- preserve to avoid breaking
@@ -11675,13 +11675,11 @@ class Autorouter:
         # restored vias.  Rebuild from the post-cleanup ``self.routes``
         # so the optimizer's ``VectorCollisionChecker.path_is_clear``
         # queries see the same set of vias the validator does.
-        try:
+        # Grids constructed by older test fixtures may not provide
+        # ``rebuild_via_index``; suppress AttributeError so cleanup remains
+        # backwards compatible (treats the missing method as a no-op).
+        with contextlib.suppress(AttributeError):
             self.grid.rebuild_via_index()
-        except AttributeError:
-            # Grids constructed by older test fixtures may not provide
-            # ``rebuild_via_index``; treat as a no-op so cleanup remains
-            # backwards compatible.
-            pass
 
         # Store stats for retrieval by output module
         self._cleanup_stats = stats

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
     from .grid import RoutingGrid
     from .rules import DesignRules, NetClassRouting
 
+import contextlib
+
 from .diffpair import (
     DifferentialPair,
     DifferentialPairConfig,
@@ -4579,10 +4581,8 @@ class DiffPairRouter:
                 # will see the pair as unrouted and the negotiated
                 # strategy picks it up on the main pass.
                 for prev_route in routes:
-                    try:
+                    with contextlib.suppress(Exception):
                         self.autorouter.grid.unmark_route(prev_route)
-                    except Exception:
-                        pass
                     if prev_route in self.autorouter.routes:
                         self.autorouter.routes.remove(prev_route)
                 if coupled_only:
@@ -4725,10 +4725,8 @@ class DiffPairRouter:
                 # net is claimed because we return without the pair's
                 # routes.
                 for committed in routes:
-                    try:
+                    with contextlib.suppress(Exception):
                         self.autorouter.grid.unmark_route(committed)
-                    except Exception:
-                        pass
                     if committed in self.autorouter.routes:
                         self.autorouter.routes.remove(committed)
                 if coupled_only:
@@ -5337,7 +5335,7 @@ class DiffPairRouter:
 
             # Snapshot the violation count BEFORE the retry so we can
             # detect new violations introduced by this attempt.
-            pre_retry_count = len(self._intra_clearance_violations)
+            len(self._intra_clearance_violations)
 
             for attempt in range(1, max_retries_per_pair + 1):
                 # Clear violations from prior retry on this pair so the

--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 import logging
 import math
 import threading
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from typing import TYPE_CHECKING, Any, Iterator
 
 import numpy as np
@@ -3477,10 +3477,8 @@ class RoutingGrid:
         # Determine which layer indices the via spans
         via_layer_indices: set[int] = set()
         for layer in via.layers:
-            try:
+            with suppress(KeyError, ValueError):
                 via_layer_indices.add(self.layer_to_index(layer.value))
-            except (KeyError, ValueError):
-                pass
 
         # Check against segments from existing routes
         for route in self.routes:

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -283,7 +283,7 @@ def parse_pcb_design_rules(pcb_text: str) -> PCBDesignRules:
         # Parse min_via_annular_width if present
         via_ann_match = re.search(r"\(min_via_annular_width\s+([\d.]+)\)", setup_text)
         if via_ann_match:
-            ann_width = float(via_ann_match.group(1))
+            float(via_ann_match.group(1))
             # Via diameter = drill + 2 * annular width
             # We'll use this to calculate minimum via diameter
             pass
@@ -296,7 +296,7 @@ def parse_pcb_design_rules(pcb_text: str) -> PCBDesignRules:
 
     # Find all net_class blocks using bracket matching
     for nc_match in re.finditer(r'\(net_class\s+"([^"]+)"', pcb_text):
-        class_name = nc_match.group(1)
+        nc_match.group(1)
         start_pos = nc_match.start()
 
         # Find the matching closing paren for this net_class block
@@ -1380,10 +1380,8 @@ def compute_multi_resolution_plan(
     # Convert to appropriate format
     if isinstance(pads, dict):
         pad_list: list = list(pads.values())
-        pad_dict = pads
     else:
         pad_list = list(pads)
-        pad_dict = None
 
     if not pad_list:
         return None
@@ -3534,10 +3532,8 @@ def load_pcb_for_routing(
             from kicad_tools.schema.pcb import PCB as SchemaPCB
 
             _schema_pcb = SchemaPCB.load(pcb_path)
-            try:
+            with contextlib.suppress(ValueError, Exception):
                 router._board_geometry = BoardGeometry.from_pcb(_schema_pcb)
-            except (ValueError, Exception):
-                pass
     except ImportError:
         pass
 

--- a/src/kicad_tools/router/optimizer/serpentine.py
+++ b/src/kicad_tools/router/optimizer/serpentine.py
@@ -19,7 +19,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Literal
 
 from ..primitives import Route, Segment
-from ..quantize import dogleg_points, is_45_aligned, snap_direction_8
+from ..quantize import dogleg_points, snap_direction_8
 from .geometry import segment_length
 
 if TYPE_CHECKING:

--- a/src/kicad_tools/sync/reconciler.py
+++ b/src/kicad_tools/sync/reconciler.py
@@ -322,7 +322,7 @@ class Reconciler:
         from kicad_tools.validate.consistency import SchematicPCBChecker
 
         checker = SchematicPCBChecker(self._schematic_path, self._pcb_path)
-        result = checker.check()
+        checker.check()
 
         analysis = SyncAnalysis()
 

--- a/src/kicad_tools/validate/filters.py
+++ b/src/kicad_tools/validate/filters.py
@@ -31,14 +31,14 @@ from __future__ import annotations
 import copy
 import re
 from dataclasses import dataclass, field
-from typing import Any, Union
+from typing import Any
 
 from kicad_tools.drc.violation import DRCViolation as DRCReportViolation
 from kicad_tools.erc.violation import ERCViolation
 from kicad_tools.validate.violations import DRCViolation as ValidateViolation
 
 # Union type for all supported violation types
-AnyViolation = Union[DRCReportViolation, ERCViolation, ValidateViolation]
+AnyViolation = DRCReportViolation | ERCViolation | ValidateViolation
 
 # Valid actions for filter rules
 VALID_ACTIONS = frozenset({"ignore", "warning", "error"})

--- a/tests/test_best_state_tracking.py
+++ b/tests/test_best_state_tracking.py
@@ -522,7 +522,7 @@ class TestEarlyStopOverflowRegression:
             "kicad_tools.router.algorithms.NegotiatedRouter",
             FakeNegotiatedRouter,
         ):
-            routes = two_phase._detailed_negotiated(
+            two_phase._detailed_negotiated(
                 net_order=[1],
                 corridor_penalty=5.0,
                 max_iterations=10,

--- a/tests/test_block_router.py
+++ b/tests/test_block_router.py
@@ -1407,7 +1407,7 @@ class TestCorridorCostsInterBlockRouting:
             return original_set(corridor, net, penalty)
 
         with patch.object(router.grid, "set_corridor_preference", side_effect=tracking_set):
-            routes = router.route_all_block_aware()
+            router.route_all_block_aware()
 
         # No inter-block nets means no corridor assignments
         assert len(calls) == 0, (

--- a/tests/test_board_05_erc_regression.py
+++ b/tests/test_board_05_erc_regression.py
@@ -43,6 +43,7 @@ adjustment (rare — bump the constant with a referenced commit/issue).
 
 from __future__ import annotations
 
+import contextlib
 import json
 from pathlib import Path
 
@@ -100,10 +101,8 @@ def _run_erc_count_errors(sch_path: Path) -> tuple[int, list[dict]]:
 
     with open(result.output_path) as f:
         data = json.load(f)
-    try:
+    with contextlib.suppress(Exception):
         result.output_path.unlink(missing_ok=True)
-    except Exception:
-        pass
 
     errors: list[dict] = []
     for sheet in data.get("sheets", []):

--- a/tests/test_board_outline.py
+++ b/tests/test_board_outline.py
@@ -160,7 +160,7 @@ class TestPCBEditorBoardOutline:
         pcb_file.write_text(MINIMAL_PCB)
         editor = PCBEditor(str(pcb_file))
 
-        nodes = editor.add_board_outline(150.0, 100.0, origin_x=100.0, origin_y=100.0)
+        editor.add_board_outline(150.0, 100.0, origin_x=100.0, origin_y=100.0)
         editor.save()
 
         # Re-read and verify the outline matches spec dimensions

--- a/tests/test_cli_placement_routing_aware.py
+++ b/tests/test_cli_placement_routing_aware.py
@@ -212,7 +212,7 @@ class TestRoutingAwareExecution:
 
         from kicad_tools.cli.placement_cmd import main
 
-        result = main(
+        main(
             [
                 "optimize",
                 str(minimal_pcb),

--- a/tests/test_collision_detection.py
+++ b/tests/test_collision_detection.py
@@ -530,7 +530,7 @@ class TestIntegrationWorkflow:
 
         if success:
             # Final DRC should pass
-            drc_result = pcb.run_drc()
+            pcb.run_drc()
             # Note: DRC may still find issues if placement is tight
             # but at least we avoided direct collision
             assert final_pos is not None

--- a/tests/test_component_clearance.py
+++ b/tests/test_component_clearance.py
@@ -556,7 +556,7 @@ class TestAutorouterComponentClearance:
         router.add_component("U1", pads)
 
         # Should detect fine-pitch and use tighter clearance
-        routes = router.route_all([1])
+        router.route_all([1])
 
         # Check that component pitches are computed
         pitches = router.grid.compute_component_pitches()

--- a/tests/test_congestion.py
+++ b/tests/test_congestion.py
@@ -376,7 +376,7 @@ class TestCongestionCLI:
         from kicad_tools.cli.analyze_cmd import main
 
         # Run with critical filter - should filter out lower severity
-        result = main(
+        main(
             [
                 "congestion",
                 str(congested_pcb),
@@ -421,7 +421,7 @@ class TestCongestionCLI:
         result = main(["congestion", str(simple_pcb), "--quiet"])
         assert result == 0
 
-        captured = capsys.readouterr()
+        capsys.readouterr()
         # In quiet mode with no issues, output should be minimal
         # (no header, no "No congestion issues found" message)
 

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -347,7 +347,7 @@ class TestManufacturingCostEstimator:
             quantity=10,
         )
         # Should identify layer count and finish as cost drivers
-        drivers_text = " ".join(estimate.cost_drivers)
+        " ".join(estimate.cost_drivers)
         # At least one cost driver should be identified
         assert len(estimate.cost_drivers) > 0
 

--- a/tests/test_diffpair_routing_integration.py
+++ b/tests/test_diffpair_routing_integration.py
@@ -364,7 +364,7 @@ def test_diffpair_prepass_then_negotiated_routes_connector_sibling():
     )
 
     # Now run the negotiated loop.  USB_CC1 must connect.
-    routes = router.route_all_negotiated(max_iterations=10, timeout=60.0)
+    router.route_all_negotiated(max_iterations=10, timeout=60.0)
 
     # Look for at least one segment per net.
     nets_with_routes = {r.net for r in router.routes}

--- a/tests/test_dsn_export.py
+++ b/tests/test_dsn_export.py
@@ -217,7 +217,7 @@ class TestDSNRoundTrip:
         exporter = KiCadToDSNExporter(str(VOLTAGE_DIVIDER_PCB))
 
         # Count nets in DSN (exclude net 0 which is the unconnected net)
-        dsn_nets = re.findall(r'\(net "?[^")\s]+', dsn_content)
+        re.findall(r'\(net "?[^")\s]+', dsn_content)
         # Count non-empty net names from source
         source_nets = {n for n, v in exporter.nets.items() if v and n != 0}
 

--- a/tests/test_erc_explain.py
+++ b/tests/test_erc_explain.py
@@ -260,7 +260,7 @@ class TestERCExplainCommand:
 
     def test_main_with_json_format(self, sample_erc_report: Path, capsys):
         """Test JSON output format."""
-        result = main([str(sample_erc_report), "--format", "json"])
+        main([str(sample_erc_report), "--format", "json"])
 
         captured = capsys.readouterr()
         # Should be valid JSON
@@ -272,7 +272,7 @@ class TestERCExplainCommand:
 
     def test_main_errors_only(self, sample_erc_report: Path, capsys):
         """Test --errors-only filter."""
-        result = main([str(sample_erc_report), "--errors-only", "--format", "json"])
+        main([str(sample_erc_report), "--errors-only", "--format", "json"])
 
         captured = capsys.readouterr()
         data = json.loads(captured.out)
@@ -283,7 +283,7 @@ class TestERCExplainCommand:
 
     def test_main_filter_by_type(self, sample_erc_report: Path, capsys):
         """Test --type filter."""
-        result = main([str(sample_erc_report), "--type", "label", "--format", "json"])
+        main([str(sample_erc_report), "--type", "label", "--format", "json"])
 
         captured = capsys.readouterr()
         data = json.loads(captured.out)

--- a/tests/test_escape.py
+++ b/tests/test_escape.py
@@ -1798,7 +1798,7 @@ class TestInwardViaStrategy:
         escape_logger = logging.getLogger("kicad_tools.router.escape")
         escape_logger.addHandler(handler)
         try:
-            escapes = router.generate_escapes(info)
+            router.generate_escapes(info)
             handler.flush()
             warnings = [
                 r
@@ -2012,7 +2012,7 @@ class TestConnectorEscapeRouting:
         )
 
         # Adjacent vias in the inner row should be staggered along the row axis
-        min_stagger = router.via_spacing / 2
+        router.via_spacing / 2
         for i in range(len(via_escapes) - 1):
             vp1 = via_escapes[i].via_pos
             vp2 = via_escapes[i + 1].via_pos
@@ -2624,7 +2624,7 @@ class TestSegmentToPadClearance:
         escape_logger = logging.getLogger("kicad_tools.router.escape")
         escape_logger.addHandler(handler)
         try:
-            escapes = router.generate_escapes(info)
+            router.generate_escapes(info)
             handler.flush()
             warnings = [
                 r
@@ -2745,7 +2745,7 @@ class TestSegmentToPadClearance:
                 row_pads,
             )
             handler.flush()
-            pad_warnings = [
+            [
                 r
                 for r in handler.buffer
                 if r.levelno >= logging.WARNING and "segment-to-pad" in r.getMessage().lower()
@@ -2814,7 +2814,7 @@ class TestSegmentToPadClearance:
 
         rules = DesignRules()
         grid = RoutingGrid(10, 10, rules, origin_x=0, origin_y=0)
-        router = EscapeRouter(grid, rules)
+        EscapeRouter(grid, rules)
 
         # Pad centered at (0, 1.0) with height=0.42mm
         pad = Pad(

--- a/tests/test_escape_endpoint_routing.py
+++ b/tests/test_escape_endpoint_routing.py
@@ -120,7 +120,7 @@ class TestEscapePadOverrides:
         if not dense:
             pytest.skip("Package not detected as dense -- test data may need adjustment")
 
-        escape_routes = router.generate_escape_routes(dense)
+        router.generate_escape_routes(dense)
 
         # Verify that overrides were built
         assert len(router._escape_pad_overrides) > 0, (
@@ -158,9 +158,9 @@ class TestRSMTUsesEscapeEndpoints:
         from kicad_tools.router.algorithms.steiner import build_rsmt
 
         # Original pad positions
-        pad1 = _make_pad(0.0, 0.0, net=1, ref="U1", pin="1")
-        pad2 = _make_pad(10.0, 0.0, net=1, ref="U1", pin="2")
-        pad3 = _make_pad(5.0, 10.0, net=1, ref="U1", pin="3")
+        _make_pad(0.0, 0.0, net=1, ref="U1", pin="1")
+        _make_pad(10.0, 0.0, net=1, ref="U1", pin="2")
+        _make_pad(5.0, 10.0, net=1, ref="U1", pin="3")
 
         # Virtual pads at escape endpoints (shifted)
         vpad1 = _make_pad(1.0, 1.0, net=1, ref="U1", pin="1")

--- a/tests/test_escape_lateral_recovery.py
+++ b/tests/test_escape_lateral_recovery.py
@@ -32,6 +32,7 @@ gate the lateral rescue success/failure.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 
 import pytest
@@ -710,12 +711,10 @@ class TestQfpDispatcherWiring:
         # Run the QFP dispatcher; with strict mode + forced in-pad
         # deferral, any clearance violation should funnel through the
         # lateral helper.
-        try:
+        # Minimal fixtures may trip downstream assertions; the
+        # spy is what matters here.
+        with contextlib.suppress(Exception):
             router._escape_qfp_alternating(package)
-        except Exception:  # noqa: BLE001
-            # Minimal fixtures may trip downstream assertions; the
-            # spy is what matters here.
-            pass
 
         assert calls, (
             "Strict-mode dispatcher must invoke _try_lateral_via_escape "
@@ -762,10 +761,8 @@ class TestQfpDispatcherWiring:
         for pad in package.pads:
             router.grid.add_pad(pad)
 
-        try:
+        with contextlib.suppress(Exception):
             router._escape_qfp_alternating(package)
-        except Exception:  # noqa: BLE001
-            pass
 
         assert calls, (
             "Issue #3080: non-strict mode MUST invoke the lateral helper "

--- a/tests/test_find_kicad_cli.py
+++ b/tests/test_find_kicad_cli.py
@@ -23,7 +23,6 @@ class TestFindKicadCliUserApplications:
         user_app_path = str(Path.home() / "Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli")
 
         # Patch Path.exists so only the user-local path "exists"
-        original_exists = Path.exists
 
         def fake_exists(self):
             if str(self) == user_app_path:
@@ -43,7 +42,6 @@ class TestFindKicadCliUserApplications:
         won't be expanded and the file will never be found."""
         # Capture all paths that find_kicad_cli checks by patching Path.exists
         checked_paths: list[str] = []
-        original_exists = Path.exists
 
         def tracking_exists(self):
             checked_paths.append(str(self))

--- a/tests/test_global_router.py
+++ b/tests/test_global_router.py
@@ -1403,7 +1403,6 @@ class TestNegotiatedGlobalRouting:
         """History cost increases on overflowed edges after update."""
         edge = RegionEdge(source=0, target=1, capacity=2, utilization=3)
         assert edge.overflow == 1
-        cost_before = edge.congestion_cost
 
         graph = RegionGraph(
             board_width=10.0,
@@ -1837,7 +1836,7 @@ class TestEscapeRouteRipupEligibility:
 
         # Directly test _detailed_negotiated with initial_routes
         # Use a very short timeout to prevent it from running too long
-        routes = tp_router._detailed_negotiated(
+        tp_router._detailed_negotiated(
             net_order=[1],
             initial_routes=[escape_route],
             timeout=0.001,

--- a/tests/test_hierarchical_netlist.py
+++ b/tests/test_hierarchical_netlist.py
@@ -94,7 +94,7 @@ class TestBuildNetlistHierarchical:
     def test_global_labels_merged_across_sheets(self):
         """Global label DATA_BUS appears in root, sub_a, and sub_b -- should merge."""
         netlist = build_netlist_from_schematic(FIXTURES / "root.kicad_sch")
-        net_names = {n.name for n in netlist.nets}
+        {n.name for n in netlist.nets}
         # DATA_BUS is a global label present on root, sub_a, and sub_b
         # It won't have pin connections (no symbols connected by wire to it)
         # but should still appear as a net if the extract_netlist picks it up

--- a/tests/test_hierarchy_validation.py
+++ b/tests/test_hierarchy_validation.py
@@ -87,7 +87,7 @@ class TestFindSimilarName:
     def test_threshold(self):
         """Threshold should be respected."""
         # With default 0.8 threshold, "VCC" and "VDD" might not match
-        result = _find_similar_name("VCC", ["VDD"])
+        _find_similar_name("VCC", ["VDD"])
         # This depends on the similarity ratio
 
 

--- a/tests/test_layer_balancing.py
+++ b/tests/test_layer_balancing.py
@@ -59,7 +59,7 @@ class TestLayerFillRatios:
     def test_blocked_cells_excluded(self, grid_4layer):
         """Blocked cells should be excluded from the denominator."""
         rows, cols = grid_4layer.rows, grid_4layer.cols
-        total_cells = rows * cols
+        rows * cols
 
         # Block half the cells on layer 1
         for y in range(rows):

--- a/tests/test_layer_escalation.py
+++ b/tests/test_layer_escalation.py
@@ -4,6 +4,7 @@ Verifies that the --auto-layers flag correctly escalates layer count
 when routing fails to achieve the minimum completion threshold.
 """
 
+import contextlib
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -1017,7 +1018,7 @@ class TestEarlyTermination:
             with patch("kicad_tools.router.is_cpp_available", return_value=False):
                 with patch("kicad_tools.router.show_routing_summary"):
                     with patch("kicad_tools.cli.route_cmd.run_post_route_drc", return_value=False):
-                        result = route_with_layer_escalation(pcb, out, args, quiet=True)
+                        route_with_layer_escalation(pcb, out, args, quiet=True)
 
         assert call_count == 1, f"Expected 1 attempt (success on first try), got {call_count}"
 
@@ -1838,7 +1839,8 @@ class TestPristineStatePerAttempt:
             # --no-auto-layers should NOT call route_with_layer_escalation.
             # It will fail on PCB loading since we don't mock that, but the
             # key assertion is that escalation was never invoked.
-            try:
+            # Expected -- PCB file doesn't exist.
+            with contextlib.suppress(SystemExit, FileNotFoundError, Exception):
                 route_main(
                     [
                         "test.kicad_pcb",
@@ -1846,8 +1848,6 @@ class TestPristineStatePerAttempt:
                         "--quiet",
                     ]
                 )
-            except (SystemExit, FileNotFoundError, Exception):
-                pass  # Expected -- PCB file doesn't exist
 
             assert mock_escalation.call_count == 0, (
                 "route_with_layer_escalation should not be called with --no-auto-layers"

--- a/tests/test_manufacturer_propagation_lint.py
+++ b/tests/test_manufacturer_propagation_lint.py
@@ -57,14 +57,14 @@ _SRC_ROOT = _REPO_ROOT / "src" / "kicad_tools"
 
 # Format: {relative_path: {line_number: reason}}
 _ALLOWLIST: dict[str, dict[int, str]] = {
-    # Router core: default-constructed router (line ~398 is the
-    # ``rules_dict``-spread default in _route_with_seed; line ~807 is
+    # Router core: default-constructed router (line ~400 is the
+    # ``rules_dict``-spread default in _route_with_seed; line ~809 is
     # the constructor default).  Reaching either means the caller did
-    # not pass rules.  (Line numbers refreshed for issue #3464 — the
-    # repo-wide ruff format reflowed both router/core.py sites.)
+    # not pass rules.  (Line numbers refreshed for issue #3464 and again
+    # for the #3663 ruff lint burn-down, which shifted both sites +2.)
     "router/core.py": {
-        398: "worker-process rules_dict-spread default (both calls on this line)",
-        807: "Autorouter.__init__ rules-arg default fallback",
+        400: "worker-process rules_dict-spread default (both calls on this line)",
+        809: "Autorouter.__init__ rules-arg default fallback",
     },
     # AdaptiveRouter default fallback — same pattern as Autorouter.
     "router/adaptive.py": {
@@ -74,8 +74,8 @@ _ALLOWLIST: dict[str, dict[int, str]] = {
     # the caller explicitly passes ``rules=None`` (no PCB rules either).
     # The CLI always supplies its own rules with manufacturer wired in.
     "router/io.py": {
-        2825: "route_pcb() fallback when caller passes rules=None",
-        3424: "load_pcb_for_routing() inner fallback when neither rules nor pcb_rules supplied",
+        2823: "route_pcb() fallback when caller passes rules=None",
+        3422: "load_pcb_for_routing() inner fallback when neither rules nor pcb_rules supplied",
     },
     # Benchmark/synthetic fixture generators — no real CLI context.
     "benchmark/runner.py": {

--- a/tests/test_manufacturing_package.py
+++ b/tests/test_manufacturing_package.py
@@ -723,7 +723,7 @@ class TestLatestReportOnly:
             preflight=PreflightConfig(skip_all=True),
         )
         pkg = ManufacturingPackage(pcb_path=pcb, manufacturer="jlcpcb", config=config)
-        result = pkg.export(out_dir)
+        pkg.export(out_dir)
 
         # Version directories should remain
         assert (out_dir / "v1").exists()
@@ -789,7 +789,7 @@ class TestLatestReportOnly:
             preflight=PreflightConfig(skip_all=True),
         )
         pkg = ManufacturingPackage(pcb_path=pcb, manufacturer="jlcpcb", config=config)
-        result = pkg.export(out_dir)
+        pkg.export(out_dir)
 
         # report.md should be promoted to root with v1 content
         assert (out_dir / "report.md").exists()
@@ -967,7 +967,7 @@ class TestLatestReportOnly:
             preflight=PreflightConfig(skip_all=True),
         )
         pkg = ManufacturingPackage(pcb_path=pcb, manufacturer="jlcpcb", config=config)
-        result = pkg.export(out_dir)
+        pkg.export(out_dir)
 
         # vN/ directories preserved
         assert (out_dir / "v1").exists()
@@ -1006,7 +1006,7 @@ class TestLatestReportOnly:
             preflight=PreflightConfig(skip_all=True),
         )
         pkg = ManufacturingPackage(pcb_path=pcb, manufacturer="jlcpcb", config=config)
-        result = pkg.export(out_dir)
+        pkg.export(out_dir)
 
         # Parse manifest
         import json

--- a/tests/test_neighborhood_ripup.py
+++ b/tests/test_neighborhood_ripup.py
@@ -357,8 +357,6 @@ class TestNeighborhoodRipup:
 
         neg.find_blocking_nets_relaxed = MagicMock(return_value={100: 1})
 
-        call_count = [0]
-
         def mock_rip_up(nets, net_routes, routes_list):
             for n in nets:
                 net_routes[n] = []

--- a/tests/test_net_status_cmd.py
+++ b/tests/test_net_status_cmd.py
@@ -188,7 +188,7 @@ class TestNetStatusCLI:
 
     def test_basic_text_output(self, connected_pcb: Path, capsys):
         """Test basic text output format."""
-        result = main([str(connected_pcb)])
+        main([str(connected_pcb)])
 
         captured = capsys.readouterr()
         assert "Net Status:" in captured.out
@@ -197,7 +197,7 @@ class TestNetStatusCLI:
 
     def test_json_output(self, connected_pcb: Path, capsys):
         """Test JSON output format."""
-        result = main([str(connected_pcb), "--format", "json"])
+        main([str(connected_pcb), "--format", "json"])
 
         captured = capsys.readouterr()
         data = json.loads(captured.out)
@@ -232,7 +232,7 @@ class TestNetStatusCLI:
 
     def test_incomplete_filter(self, incomplete_pcb: Path, capsys):
         """Test --incomplete filter shows only incomplete nets."""
-        result = main([str(incomplete_pcb), "--incomplete"])
+        main([str(incomplete_pcb), "--incomplete"])
 
         captured = capsys.readouterr()
         # Should show incomplete/unrouted nets
@@ -295,7 +295,7 @@ class TestNetStatusCLI:
 
     def test_by_class_option(self, incomplete_pcb: Path, capsys):
         """Test --by-class grouping option."""
-        result = main([str(incomplete_pcb), "--by-class"])
+        main([str(incomplete_pcb), "--by-class"])
 
         captured = capsys.readouterr()
         # Should show net class grouping
@@ -307,7 +307,7 @@ class TestNetStatusCLI:
 
     def test_verbose_option(self, incomplete_pcb: Path, capsys):
         """Test --verbose option shows more details."""
-        result = main([str(incomplete_pcb), "--verbose"])
+        main([str(incomplete_pcb), "--verbose"])
 
         captured = capsys.readouterr()
         # Verbose should show coordinates
@@ -316,7 +316,7 @@ class TestNetStatusCLI:
 
     def test_json_by_class(self, incomplete_pcb: Path, capsys):
         """Test JSON output with --by-class option."""
-        result = main([str(incomplete_pcb), "--format", "json", "--by-class"])
+        main([str(incomplete_pcb), "--format", "json", "--by-class"])
 
         captured = capsys.readouterr()
         data = json.loads(captured.out)
@@ -326,7 +326,7 @@ class TestNetStatusCLI:
 
     def test_json_nets_list(self, incomplete_pcb: Path, capsys):
         """Test JSON output contains nets list."""
-        result = main([str(incomplete_pcb), "--format", "json"])
+        main([str(incomplete_pcb), "--format", "json"])
 
         captured = capsys.readouterr()
         data = json.loads(captured.out)

--- a/tests/test_netclass.py
+++ b/tests/test_netclass.py
@@ -166,7 +166,7 @@ class TestAddNetclass:
     def test_add_netclass_pattern(self):
         """Test adding a netclass pattern."""
         data = {}
-        pattern = add_netclass_pattern(data, "Power", "VCC*")
+        add_netclass_pattern(data, "Power", "VCC*")
 
         patterns = get_netclass_patterns(data)
         assert len(patterns) == 1

--- a/tests/test_optimize_placement_cmd.py
+++ b/tests/test_optimize_placement_cmd.py
@@ -862,7 +862,7 @@ class TestBoardOriginCoordinates:
         # R1 at board-relative (10, 10) should be written as
         # sheet-absolute (10 + 116, 10 + 76.75) = (126, 86.75)
         at_pattern = re.compile(r"\(at\s+([\d.]+)\s+([\d.]+)")
-        at_matches = at_pattern.findall(content)
+        at_pattern.findall(content)
 
         # Collect footprint (at ...) values — should be sheet-absolute
         # The file has two footprints; collect their (at ...) from the output.

--- a/tests/test_pad_grid_auto_derive.py
+++ b/tests/test_pad_grid_auto_derive.py
@@ -407,7 +407,7 @@ class TestCLIDefaults:
         from kicad_tools.cli import check_cmd
         from kicad_tools.cli.check_cmd import main as _main  # noqa: F401
 
-        parser = argparse.ArgumentParser()
+        argparse.ArgumentParser()
         # Just verify the symbols exist in the module
         assert hasattr(check_cmd, "run_selected_checks")
         # Sanity check: run_selected_checks accepts the two new kwargs.

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -1153,7 +1153,7 @@ class TestLCSCClientAdditional:
             cache = PartsCache(db_path=tmp_path / "cache.db")
             client = LCSCClient(cache=cache)
 
-            results = client.search("test")
+            client.search("test")
 
             # Part from search should be cached
             assert cache.contains("C123")

--- a/tests/test_pcb_manufacturing_export.py
+++ b/tests/test_pcb_manufacturing_export.py
@@ -441,7 +441,7 @@ class TestRenderReportPdf:
             with patch(
                 "kicad_tools.export.manufacturing.ManufacturingPackage._render_report_pdf",
                 wraps=None,
-            ) as mock_render:
+            ):
                 # Let _generate_report run normally to produce the .md,
                 # then manually call the rendering logic with mocks.
                 pkg._generate_report(out_dir, result)

--- a/tests/test_pcb_sync_netlist.py
+++ b/tests/test_pcb_sync_netlist.py
@@ -1704,7 +1704,7 @@ class TestNetTieSync:
         assert not result.orphaned
 
 
-class TestGetBoardEdgePosition:
+class TestGetBoardEdgePositionCoordinates:
     """Tests for _get_board_edge_position coordinate handling."""
 
     def test_nonzero_origin_no_double_subtraction(self):
@@ -2380,9 +2380,7 @@ class TestNetAssignmentErrorSurfacing:
 
         # Mock export_netlist to raise
 
-        original_import = (
-            __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__
-        )
+        (__builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__)
 
         def mock_export_netlist(path):
             raise RuntimeError("kicad-cli not found")

--- a/tests/test_placement_gpu.py
+++ b/tests/test_placement_gpu.py
@@ -343,10 +343,8 @@ class TestPlacementOptimizerGPUIntegration:
         assert iterations >= 1, "Should run at least one iteration"
 
         # Verify components moved (positions changed)
-        positions_changed = False
         for comp in optimizer.components:
             if comp.vx != 0 or comp.vy != 0:
-                positions_changed = True
                 break
 
         # Note: Energy may not decrease in all cases due to GPU implementation differences

--- a/tests/test_placement_iterative_fix.py
+++ b/tests/test_placement_iterative_fix.py
@@ -319,7 +319,7 @@ class TestIterativeFixDenseCluster:
         result = fixer.iterative_fix(dense_pcb, output_path=output)
 
         # If there are stalled passes, at least one should have escalation > 1.0
-        stalled_passes = [pr for pr in result.pass_results if pr.escalation_factor > 1.0]
+        [pr for pr in result.pass_results if pr.escalation_factor > 1.0]
         # We may or may not have stalled passes depending on geometry,
         # but the total_passes should be > 1 for a dense cluster
         assert result.total_passes >= 1
@@ -400,7 +400,7 @@ class TestIterativeFixCLI:
         from kicad_tools.cli.placement_cmd import main
 
         output = tmp_path / "cli_fixed.kicad_pcb"
-        result = main(
+        main(
             [
                 "fix",
                 str(simple_overlap_pcb),

--- a/tests/test_placement_nudge.py
+++ b/tests/test_placement_nudge.py
@@ -265,7 +265,7 @@ class TestNudgePadClearance:
 
         if result.fixes_applied > 0:
             # Read the output and check that R2 moved further right (or R1 further left)
-            content = output_path.read_text()
+            output_path.read_text()
             # The fix should maintain directional relationship
             assert output_path.exists()
 

--- a/tests/test_placement_zones.py
+++ b/tests/test_placement_zones.py
@@ -265,7 +265,7 @@ class TestPlacementOptimizerZoneMethods:
             "supercaps",
             pattern=r"C1[0-6][0-9]",
         )
-        control_assigned = self.optimizer.assign_to_zone(
+        self.optimizer.assign_to_zone(
             "control",
             references=["C100", "C101"],  # Some overlap for control logic
         )

--- a/tests/test_predictive_drc.py
+++ b/tests/test_predictive_drc.py
@@ -191,7 +191,7 @@ class TestPredictiveAnalyzer:
     def test_analyze_move_performance(self, analyzer) -> None:
         """Test that analysis completes within performance target (<10ms)."""
         # Run analysis
-        warnings = analyzer.analyze_move("R1", (150.0, 150.0))
+        analyzer.analyze_move("R1", (150.0, 150.0))
 
         # Check analysis time (stored in analyzer)
         assert hasattr(analyzer, "_last_analysis_time_ms")

--- a/tests/test_reasoning_agent.py
+++ b/tests/test_reasoning_agent.py
@@ -407,7 +407,7 @@ class TestPCBReasoningAgentInit:
         mock_state = create_mock_pcb_state()
         mock_from_pcb.return_value = mock_state
 
-        agent = PCBReasoningAgent(pcb_path="/test/board.kicad_pcb")
+        PCBReasoningAgent(pcb_path="/test/board.kicad_pcb")
 
         mock_from_pcb.assert_called_once()
 
@@ -1027,7 +1027,7 @@ class TestPCBReasoningAgentFromPCB:
         mock_state = create_mock_pcb_state()
         mock_from_pcb.return_value = mock_state
 
-        agent = PCBReasoningAgent.from_pcb("/test/board.kicad_pcb")
+        PCBReasoningAgent.from_pcb("/test/board.kicad_pcb")
 
         mock_from_pcb.assert_called_once()
         mock_drc_load.assert_not_called()
@@ -1044,7 +1044,7 @@ class TestPCBReasoningAgentFromPCB:
         mock_drc = MagicMock()
         mock_drc_load.return_value = mock_drc
 
-        agent = PCBReasoningAgent.from_pcb(
+        PCBReasoningAgent.from_pcb(
             "/test/board.kicad_pcb",
             drc_path="/test/board.rpt",
         )

--- a/tests/test_reasoning_diagnosis.py
+++ b/tests/test_reasoning_diagnosis.py
@@ -692,7 +692,7 @@ class TestDiagnosisEngine:
 
         # Target near the edge of U1's bounds (40-60, 40-60)
         # so some +5mm offsets will find clear positions
-        diag = engine.diagnose_placement(
+        engine.diagnose_placement(
             result=result,
             ref="C1",
             target=(65.0, 65.0),  # Just at the edge of U1

--- a/tests/test_router_cleanup.py
+++ b/tests/test_router_cleanup.py
@@ -597,7 +597,7 @@ class TestConnectivityAwareRestoration:
                 ],
             ),
         ]
-        stats = router.cleanup_artifacts()
+        router.cleanup_artifacts()
         # Segment 3 (99,79)-(95,75) has both endpoints OOB.
         # Removing it fragments the net into two components
         # (the first two segments connect to each other, but
@@ -698,7 +698,7 @@ class TestConnectivityAwareRestoration:
                 ],
             ),
         ]
-        stats = router.cleanup_artifacts()
+        router.cleanup_artifacts()
         # Net 3's bridge restored
         assert len(router.routes[0].segments) == 3
         # Net 7's orphan removed

--- a/tests/test_router_core.py
+++ b/tests/test_router_core.py
@@ -1904,7 +1904,7 @@ class TestAutorouterAdvanced:
         """Test resetting router for new trial."""
         # Route first
         router_with_nets.route_all()
-        original_routes = len(router_with_nets.routes)
+        len(router_with_nets.routes)
 
         # Reset
         router_with_nets._reset_for_new_trial()

--- a/tests/test_router_cpp_backend.py
+++ b/tests/test_router_cpp_backend.py
@@ -820,7 +820,7 @@ class TestResumableRouting:
         reject_gx, reject_gy = grid._impl.world_to_grid(last_seg.x2, last_seg.y2)
 
         # Resume with the goal cell rejected
-        result2 = pf.resume(reject_gx, reject_gy, 0)
+        pf.resume(reject_gx, reject_gy, 0)
 
         # The resume should find an alternative path (different goal cell
         # in the end pad metal area) or exhaust the search

--- a/tests/test_router_cpp_per_pad_channel_budget.py
+++ b/tests/test_router_cpp_per_pad_channel_budget.py
@@ -476,7 +476,6 @@ class TestSoftstartRealisticCluster:
         # (0.5mm east of the package edge -- matches softstart's escape
         # stub length).
         pad_y_list = [4.0, 4.65, 5.3, 5.95]
-        pkg_edge_x = 6.0
         escape_x = 6.5
 
         # Targets: each net wants to reach a peer pad's row but on the

--- a/tests/test_same_component_clearance.py
+++ b/tests/test_same_component_clearance.py
@@ -127,7 +127,7 @@ class TestSameComponentClearanceRelaxation:
         """Cells within trace_width/2 of pad metal must remain blocked."""
         grid = crystal_grid
         layer_idx = grid.layer_to_index(Layer.F_CU.value)
-        reduced = grid.rules.trace_width / 2  # 0.1mm
+        grid.rules.trace_width / 2  # 0.1mm
 
         # Check that cells immediately adjacent to pad metal (within 0.1mm)
         # are still blocked.  Pad1 metal right edge is at x=4.5.
@@ -224,7 +224,7 @@ class TestSameComponentClearanceRelaxation:
         # Count blocked cells at midpoint before second pad
         layer_idx = grid.layer_to_index(Layer.F_CU.value)
         mid_gx, mid_gy = grid.world_to_grid(5.0, 5.0)
-        blocked_before = bool(grid._blocked[layer_idx, mid_gy, mid_gx])
+        bool(grid._blocked[layer_idx, mid_gy, mid_gx])
 
         grid.add_pad(pad2)
 
@@ -273,7 +273,7 @@ class TestSameComponentClearanceRelaxation:
         grid.add_pad(pad2)
 
         # Should not crash and should not relax (net=0 pad is skipped)
-        layer_idx = grid.layer_to_index(Layer.F_CU.value)
+        grid.layer_to_index(Layer.F_CU.value)
         mid_gx, mid_gy = grid.world_to_grid(5.0, 5.0)
         # No assertion on blocked state -- just verify no exception
 

--- a/tests/test_sch_add_component.py
+++ b/tests/test_sch_add_component.py
@@ -756,7 +756,7 @@ class TestInstancesBlock:
         )
         assert result == 0
 
-        content = sch_path.read_text()
+        sch_path.read_text()
         # Power symbols should not have instances blocks
         # The symbol section should not contain (instances ...)
         # (The only (instances ...) would be in sheet_instances which is different)

--- a/tests/test_sch_re_annotate.py
+++ b/tests/test_sch_re_annotate.py
@@ -2053,7 +2053,7 @@ class TestIncludePower:
     def test_unannotated_only_without_include_power_skips_power(self, tmp_path):
         """--unannotated-only without --include-power skips #PWR? symbols."""
         sch = _write_sch(tmp_path, POWER_UNANNOTATED_SCHEMATIC)
-        original = sch.read_text()
+        sch.read_text()
         ret = run_re_annotate(
             schematic_path=sch,
             dry_run=False,

--- a/tests/test_sch_validate_items.py
+++ b/tests/test_sch_validate_items.py
@@ -7,6 +7,7 @@ ERC JSON and populates both ``ValidationIssue.items`` and an enriched
 
 from __future__ import annotations
 
+import contextlib
 import json
 from unittest.mock import MagicMock, patch
 
@@ -49,12 +50,12 @@ def _run_erc_with_violations(violations: list[dict]) -> list[ValidationIssue]:
     erc_json = _make_erc_json(violations)
 
     # Write ERC JSON to a real temp file so run_erc can read it back.
-    tmp = _tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w")
-    tmp.write(erc_json)
-    tmp.close()
+    with _tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as tmp:
+        tmp.write(erc_json)
+    tmp_name = tmp.name
 
     class _FakeTmp:
-        name = tmp.name
+        name = tmp_name
 
         def __enter__(self):
             return self
@@ -74,8 +75,8 @@ def _run_erc_with_violations(violations: list[dict]) -> list[ValidationIssue]:
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
         issues = run_erc("test.kicad_sch")
 
-    if os.path.exists(tmp.name):
-        os.unlink(tmp.name)
+    if os.path.exists(tmp_name):
+        os.unlink(tmp_name)
     return issues
 
 
@@ -307,10 +308,8 @@ class TestJSONOutput:
         with patch("kicad_tools.cli.sch_validate.validate_schematic", return_value=result):
             with patch("kicad_tools.cli.sch_validate.Path") as mock_path:
                 mock_path.return_value.exists.return_value = True
-                try:
+                with contextlib.suppress(SystemExit):
                     main(["test.kicad_sch", "--format", "json"])
-                except SystemExit:
-                    pass
 
         output = capsys.readouterr().out
         data = json.loads(output)

--- a/tests/test_sch_validate_wire_dangling.py
+++ b/tests/test_sch_validate_wire_dangling.py
@@ -321,12 +321,12 @@ class TestRunERCWireDanglingIntegration:
         """Run ``run_erc`` with mocked subprocess and custom sheet data."""
         erc_json = _make_erc_json(sheets)
 
-        tmp = _tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w")
-        tmp.write(erc_json)
-        tmp.close()
+        with _tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as tmp:
+            tmp.write(erc_json)
+        tmp_name = tmp.name
 
         class _FakeTmp:
-            name = tmp.name
+            name = tmp_name
 
             def __enter__(self):
                 return self
@@ -361,8 +361,8 @@ class TestRunERCWireDanglingIntegration:
             mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
             issues = run_erc("test.kicad_sch")
 
-        if os.path.exists(tmp.name):
-            os.unlink(tmp.name)
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
         return issues
 
     def test_wire_dangling_location_from_sheet_path(self):
@@ -380,12 +380,12 @@ class TestRunERCWireDanglingIntegration:
         """Verify that reattribute_wire_dangling_violations is called."""
         erc_json = _make_erc_json([_make_sheet("/", [_wire_dangling(100.0, 50.0)])])
 
-        tmp = _tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w")
-        tmp.write(erc_json)
-        tmp.close()
+        with _tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as tmp:
+            tmp.write(erc_json)
+        tmp_name = tmp.name
 
         class _FakeTmp:
-            name = tmp.name
+            name = tmp_name
 
             def __enter__(self):
                 return self
@@ -421,8 +421,8 @@ class TestRunERCWireDanglingIntegration:
         args = mock_reattr.call_args[0]
         assert args[1] == "test.kicad_sch"
 
-        if os.path.exists(tmp.name):
-            os.unlink(tmp.name)
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
 
     def test_multiple_sheets_wire_dangling_preserved(self):
         """Multiple sheets with wire_dangling keep their own sheet paths."""
@@ -1119,12 +1119,12 @@ class TestRunERCPhantomFilterIntegration:
         """Verify that filter_phantom_wire_violations is invoked during run_erc."""
         erc_json = _make_erc_json([_make_sheet("/", [_wire_dangling(100.0, 50.0)])])
 
-        tmp = _tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w")
-        tmp.write(erc_json)
-        tmp.close()
+        with _tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as tmp:
+            tmp.write(erc_json)
+        tmp_name = tmp.name
 
         class _FakeTmp:
-            name = tmp.name
+            name = tmp_name
 
             def __enter__(self):
                 return self
@@ -1163,5 +1163,5 @@ class TestRunERCPhantomFilterIntegration:
         args = mock_phantom.call_args[0]
         assert args[1] == "test.kicad_sch"
 
-        if os.path.exists(tmp.name):
-            os.unlink(tmp.name)
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)

--- a/tests/test_schematic_blocks.py
+++ b/tests/test_schematic_blocks.py
@@ -2837,7 +2837,7 @@ class TestResetButtonMocked:
         # Find the jog wires (the pair for cap bottom)
         # The jog_x should be 110 - 2.54 = 107.46
         jog_x = 110 - 2.54
-        jog_wire_starts = [c[0][0] for c in rail_calls]  # p1 of each call
+        [c[0][0] for c in rail_calls]  # p1 of each call
         # One wire should go horizontal from (115, ...) to (jog_x, ...)
         has_horizontal_jog = any(
             c[0][0][0] != c[0][1][0] and abs(c[0][1][0] - jog_x) < 0.01 for c in rail_calls

--- a/tests/test_schematic_models.py
+++ b/tests/test_schematic_models.py
@@ -1073,7 +1073,7 @@ class TestSchematicConstruction:
     def test_add_rail(self):
         """Add power rail wire."""
         sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
-        wire = sch.add_rail(y=100, x_start=10, x_end=50, net_label="VCC", snap=False)
+        sch.add_rail(y=100, x_start=10, x_end=50, net_label="VCC", snap=False)
         assert len(sch.wires) == 1
         assert len(sch.labels) == 1
         assert sch.labels[0].text == "VCC"
@@ -1081,7 +1081,7 @@ class TestSchematicConstruction:
     def test_add_rail_with_end_power_symbols(self):
         """add_rail() places power symbols at endpoints when requested."""
         sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
-        wire = sch.add_rail(
+        sch.add_rail(
             y=100,
             x_start=10,
             x_end=50,
@@ -1104,7 +1104,7 @@ class TestSchematicConstruction:
     def test_add_rail_with_gnd_power_symbol(self):
         """add_rail() places GND power symbols below the rail."""
         sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
-        wire = sch.add_rail(
+        sch.add_rail(
             y=280,
             x_start=25,
             x_end=600,
@@ -2154,7 +2154,7 @@ class TestSchematicValidationAdvanced:
         issues = sch._check_wire_connectivity()
         # One end of vertical wire connects to horizontal at (50, 100) - should detect missing junction
         # Other end at (50, 50) is floating
-        t_junctions = [i for i in issues if i["type"] == "missing_junction"]
+        [i for i in issues if i["type"] == "missing_junction"]
         # Note: May or may not detect depending on implementation
 
     def test_check_unconnected_pins_power_connected(self):

--- a/tests/test_ses_import.py
+++ b/tests/test_ses_import.py
@@ -193,7 +193,7 @@ class TestSESMerge:
 
         output = tmp_path / "merged.kicad_pcb"
         importer = SESToKiCadImporter(str(ses_file))
-        result = importer.merge_into(str(VOLTAGE_DIVIDER_PCB), str(output))
+        importer.merge_into(str(VOLTAGE_DIVIDER_PCB), str(output))
 
         assert output.exists()
         content = output.read_text()

--- a/tests/test_sexp.py
+++ b/tests/test_sexp.py
@@ -364,7 +364,7 @@ class TestSExpSerialization:
 
     def test_needs_quoting_nan_inf(self):
         """Strings like 'nan' and 'inf' are valid floats but should not be unquoted."""
-        sexp = SExp("test")
+        SExp("test")
         # 'nan' and 'inf' parse as float but are not valid KiCad numeric literals.
         # However, _needs_quoting uses float() which accepts them.  Since KiCad
         # would never emit these, and they are not identifiers, leaving them

--- a/tests/test_stitch_cmd.py
+++ b/tests/test_stitch_cmd.py
@@ -2811,7 +2811,7 @@ class TestDoglegRouting:
         assert len(result.vias_added) > 0, "Should place at least some vias"
 
         # Check if any dog-leg traces were used
-        dogleg_traces = [t for t in result.traces_added if t.is_dogleg]
+        [t for t in result.traces_added if t.is_dogleg]
         # We expect some dog-leg routing due to the dense pin arrangement
         # Note: The exact count depends on the algorithm finding clearance
 
@@ -2834,21 +2834,11 @@ class TestDoglegRouting:
                 assert trace.intermediate_x is not None
                 assert trace.intermediate_y is not None
 
-                # Verify the path is actually L-shaped (not colinear)
-                # The intermediate point should not be on the direct line from pad to via
-                pad_to_via_dx = trace.via_x - trace.pad.x
-                pad_to_via_dy = trace.via_y - trace.pad.y
-                pad_to_int_dx = trace.intermediate_x - trace.pad.x
-                pad_to_int_dy = trace.intermediate_y - trace.pad.y
-
-                # If the path were straight, these ratios would be equal
-                # For an L-shape, they should differ
-                if abs(pad_to_via_dx) > 0.01 and abs(pad_to_int_dx) > 0.01:
-                    ratio_dx = pad_to_int_dy / (pad_to_int_dx + 0.001)
-                    ratio_via = pad_to_via_dy / (pad_to_via_dx + 0.001)
-                    # L-shape: ratios should differ significantly (not colinear)
-                    is_colinear = abs(ratio_dx - ratio_via) < 0.1
-                    # Note: An L-shape doesn't need to fail this check; it's informational
+                # The intermediate point should not be on the direct line from
+                # pad to via. Comparing the pad->via vs pad->intermediate slope
+                # ratios would confirm the L-shape, but that check is purely
+                # informational here (an L-shape need not fail any assertion),
+                # so we only assert the intermediate point exists, above.
 
     def test_dogleg_no_clearance_violations(self, fine_pitch_pcb: Path):
         """All placed vias (straight or dog-leg) should respect clearance."""
@@ -2894,7 +2884,7 @@ class TestDoglegRouting:
         # GND pads in the SSOP-20: pins 3, 8, 13, 18 (4 pads total)
         total_gnd_pads = 4
         placed_count = len(result.vias_added)
-        skipped_count = len(result.pads_skipped)
+        len(result.pads_skipped)
 
         # With dog-leg routing, we should achieve at least 50% success rate
         # on fine-pitch packages (better than 0% without dog-leg)
@@ -3794,8 +3784,8 @@ class TestExtendedEscapeRouting:
         # Each waypoint should be a tuple of (x, y)
         for wp in waypoints:
             assert len(wp) == 2
-            assert isinstance(wp[0], float) or isinstance(wp[0], int)
-            assert isinstance(wp[1], float) or isinstance(wp[1], int)
+            assert isinstance(wp[0], (float, int))
+            assert isinstance(wp[1], (float, int))
 
     def test_extended_escape_respects_clearance(self):
         """Extended escape via and trace path should respect clearance."""

--- a/tests/test_subgrid.py
+++ b/tests/test_subgrid.py
@@ -1545,7 +1545,7 @@ class TestFineGridClearanceZoneUnblocking:
         was_blocked = center_cell.blocked
 
         # Run escape routing
-        result = subgrid.route_with_subgrid([pad, other_pad])
+        subgrid.route_with_subgrid([pad, other_pad])
 
         # After escape routing, the other pad's copper must still be blocked
         center_cell_after = grid.grid[layer_idx][ogy][ogx]
@@ -2668,7 +2668,7 @@ class TestSubGridEscapeFailureLogging:
         analysis = subgrid.analyze_pads(pads)
 
         with caplog.at_level(logging.WARNING, logger="kicad_tools.router.subgrid"):
-            result = subgrid.generate_escape_segments(analysis)
+            subgrid.generate_escape_segments(analysis)
 
         warning_msgs = [r.message for r in caplog.records if r.levelno == logging.WARNING]
         assert not warning_msgs, f"Expected no WARNING on success but got: {warning_msgs}"

--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -82,7 +82,7 @@ class TestSyncCLIAnalyzeMode:
         )
         MockReconciler.return_value = self._mock_reconciler(analysis)
 
-        result = sync_main(["--analyze", "--format", "json", "project.kicad_pro"])
+        sync_main(["--analyze", "--format", "json", "project.kicad_pro"])
         captured = capsys.readouterr()
         data = json.loads(captured.out)
         assert "matches" in data


### PR DESCRIPTION
## Summary

Burns down the residual ruff lint backlog that PR #3464 baselined in
`[tool.ruff.lint] ignore` (refs #3663). All nine parked rules are fixed at
every site and removed from the ignore list, so they are enforced going
forward. Two latent defects flagged in the #3464 review were fixed as part
of the burn-down.

## Changes

- **pyproject.toml**: removed `F841, SIM105, F401, F601, SIM115, F811,
  SIM101, SIM116, UP007` from the `ignore` list; updated the comment to note
  the backlog is fully cleared.
- **F601 (real defect)** — `src/kicad_tools/erc/violation.py`: removed five
  duplicate dict keys (`lib_symbol_mismatch`, `footprint_link_issues`,
  `single_global_label`, `isolated_pin_label`, `pin_to_pin`) whose vaguer
  second descriptions silently overrode the richer earlier ones. Kept the
  accurate earlier definitions.
- **F811 (real defect)** — `tests/test_pcb_sync_netlist.py`: the file
  defined `class TestGetBoardEdgePosition` twice (lines 377 and 1707), so
  the first class's two tests never collected. Renamed the second class to
  `TestGetBoardEdgePositionCoordinates`; all four tests now run and pass.
- **F811** — `src/kicad_tools/router/__init__.py`: `RoutingResult` was
  imported from both `.core` (adaptive) and `.strategies` (orchestrator) —
  two distinct classes. Resolved to the orchestrator's
  `strategies.RoutingResult` (current runtime behavior; no external consumer
  imports the bare name), dropped the shadowed `.core` import, and removed
  the duplicate `__all__` entry.
- **F401** — `router/__init__.py` re-exports added to `__all__`
  (`CachedSubProblem`, `SubProblemSignature`, `normalize_routes_to_origin`,
  `transform_routes`, `CongestionEstimator`, `NetBBox`, `TileGrid`); removed
  a genuinely-unused import in `optimizer/serpentine.py`.
- **F841** (123 sites): removed unused assignments while preserving any
  side-effecting RHS call (e.g. `subprocess.run`, `checker.check`,
  `_run_subgrid_prepass`, and `main(...)`/`pkg.export(...)` in tests keep the
  call and drop only the binding).
- **SIM105** (16 sites): `try/except/pass` → `contextlib.suppress`, with
  explanatory comments relocated above the `with` and `contextlib` imported
  where needed.
- **SIM115** (4 sites): bare `NamedTemporaryFile` rewritten with a `with`
  block, preserving `delete=False` cleanup semantics.
- **SIM116 / SIM101 / UP007**: dict-lookup rotation table in
  `placement/vector.py`; merged `isinstance` tuple in a test; `Union[...]` →
  PEP 604 `X | Y` in `validate/filters.py`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Each baselined rule removed from `ignore` | ✅ | All 9 entries deleted from `pyproject.toml` |
| All sites for each rule fixed | ✅ | `uv run ruff check .` → All checks passed! |
| `ruff check .` exits 0 with rules re-enabled | ✅ | Passes after ignore entries removed |
| `ruff format . --check` exits 0 | ✅ | 1456 files already formatted |
| mypy baseline check exits 0 | ✅ | 1498 errors, all within baseline; no new type errors |
| No behavioral changes (F841 side effects, F811 RoutingResult choice) | ✅ | Side-effecting RHS calls preserved; public `RoutingResult` unchanged (strategies) |
| Un-shadowed `TestGetBoardEdgePosition` tests pass | ✅ | 4/4 pass after rename |
| `pytest -m "not slow"` (affected files) passes | ✅ | 2215 + 807 + 521 + 259 passing across all touched modules, 0 failures |

## Test Plan

- `uv run pytest --collect-only` → 20213 tests collected, no import errors
  (confirms F401/F811/contextlib edits don't break imports).
- Ran every affected test file plus erc/validate/placement/acceleration
  suites: all pass (0 failures, 5 skipped).
- Verified `ERC_TYPE_DESCRIPTIONS` now resolves the five formerly-duplicated
  keys to the richer descriptions.

Closes #3663