### PR TITLE
feat: add kct board-metrics command for normalized board.json per board

### DIFF
--- a/docs/board-json-schema.md
+++ b/docs/board-json-schema.md
@@ -1,0 +1,110 @@
+# `board.json` Schema (v1)
+
+`board.json` is the normalized per-board data contract produced by
+`kct board-metrics` (Epic #3674, Phase 1, issue #3676) and consumed by the
+kicad-tools.org demo gallery (Phase 2, Astro site).
+
+It is emitted to `boards/<id>/output/board.json`. Every metric is sourced from
+artifacts that **already exist** under the board's `output/manufacturing/`
+directory — `kct board-metrics` never recomputes anything from KiCad.
+
+## Source artifacts
+
+| `board.json` field      | Source artifact                       | Notes |
+|-------------------------|---------------------------------------|-------|
+| `slug`                  | board directory name                  | always present |
+| `name`                  | `manifest.json` → `board.name`        | omitted if absent |
+| `description`           | `report.md` → `### Theory of Operation` (fallback: front-matter `title`) | omitted if absent |
+| `layer_count`           | `report.md` → `\| Layers \|` row      | integer copper layers |
+| `board_size_mm`         | `report.md` → `\| Board Size \|` row  | `{width, height}` in mm |
+| `part_count`            | `report.md` → `\| Footprints \|` row (fallback: `bom_jlcpcb.csv` rows − 1) | integer |
+| `nets_routed_pct`       | `report.md` → `\| Signal Net Completion \|` row | float percent |
+| `drc_violations`        | `report.md` → `## DRC Status` → `\| Errors \|` row | integer |
+| `cost`                  | `report.md` → `## Cost Estimate` block | omitted if section absent |
+| `renders`               | `output/renders/*.png` (from `kct render`, #3675) | only existing files |
+| `manufacturing_package` | `output/manufacturing/kicad_project.zip` | omitted if absent |
+| `manifest_generated_at` | `manifest.json` → `generated_at`      | ISO-8601 string |
+
+## Example
+
+```json
+{
+  "$schema": "https://kicad-tools.org/schemas/board/v1.json",
+  "schema_version": 1,
+  "generated_at": "2026-06-15T00:00:00+00:00",
+  "slug": "05-bldc-motor-controller",
+  "name": "bldc_controller_routed",
+  "description": "BLDC Motor Controller 3-Phase Brushless DC Motor Driver ...",
+  "layer_count": 4,
+  "board_size_mm": { "width": 80.0, "height": 100.0 },
+  "part_count": 55,
+  "nets_routed_pct": 82.1,
+  "drc_violations": 14,
+  "cost": { "per_board_usd": 9.16, "batch_qty": 5, "batch_total_usd": 45.78 },
+  "renders": {
+    "pcb_front": "renders/pcb-front.png",
+    "pcb_back": "renders/pcb-back.png",
+    "3d_front": "renders/3d-front.png",
+    "3d_back": "renders/3d-back.png"
+  },
+  "manufacturing_package": "manufacturing/kicad_project.zip",
+  "manifest_generated_at": "2026-06-12T05:03:41.535120+00:00",
+  "status": "ok"
+}
+```
+
+## Field reference
+
+| Field                   | Type    | Required | Description |
+|-------------------------|---------|----------|-------------|
+| `$schema`               | string  | yes      | Schema URL identifier |
+| `schema_version`        | integer | yes      | Schema version (currently `1`) |
+| `generated_at`          | string  | yes      | ISO-8601 UTC timestamp of extraction |
+| `slug`                  | string  | yes      | Board directory name |
+| `status`                | string  | yes      | `ok` \| `partial` \| `no_artifacts` |
+| `name`                  | string  | no       | Human board name |
+| `description`           | string  | no       | Theory-of-operation summary |
+| `layer_count`           | integer | no       | Copper layer count |
+| `board_size_mm`         | object  | no       | `{ "width": number, "height": number }` |
+| `part_count`            | integer | no       | Number of footprints / BOM parts |
+| `nets_routed_pct`       | number  | no       | Signal-net routing completion percent |
+| `drc_violations`        | integer | no       | DRC error count |
+| `cost`                  | object  | no       | `{ per_board_usd?, batch_qty?, batch_total_usd? }` |
+| `renders`               | object  | no       | Map of render id → path relative to `board.json` |
+| `manufacturing_package` | string  | no       | Path to downloadable `kicad_project.zip` |
+| `manifest_generated_at` | string  | no       | Manifest build timestamp (ISO-8601) |
+
+### Paths are relative to `board.json`
+
+`renders` values and `manufacturing_package` are relative to the `board.json`
+file location (`boards/<id>/output/`). For example `renders/pcb-front.png`
+resolves to `boards/<id>/output/renders/pcb-front.png`.
+
+### `status` values
+
+| Value          | Meaning |
+|----------------|---------|
+| `ok`           | `output/manufacturing/` exists and `report.md` parsed successfully |
+| `partial`      | `output/manufacturing/` exists but `report.md` is absent/unparseable; only identity and recoverable fields are present |
+| `no_artifacts` | the board has no `output/manufacturing/` directory at all |
+
+## Optional fields are omitted, never `null`
+
+All fields except `$schema`, `schema_version`, `generated_at`, `slug` and
+`status` are optional. When a source artifact is missing or a field cannot be
+parsed, the field is **omitted** from the output rather than emitted as `null`.
+Downstream consumers should treat a missing key as "unknown".
+
+## Schema versioning policy
+
+This file is the data contract for the Phase 2 Astro site, so stability matters:
+
+- **Additive changes only** within `schema_version: 1`. New optional fields may
+  be added without a version bump.
+- **No renames and no type changes** to existing fields without bumping
+  `schema_version`.
+- Breaking changes (renames, type changes, removed fields, changed semantics)
+  require incrementing `schema_version` and updating the `$schema` URL.
+
+Consumers should read `schema_version` and reject documents whose major version
+they do not understand.

--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -49,6 +49,7 @@ from .commands import (
     run_analyze_command,
     run_audit_command,
     run_benchmark_command,
+    run_board_metrics_command,
     run_build_command,
     run_build_native_command,
     run_check_command,
@@ -396,6 +397,9 @@ def _dispatch_command(args) -> int:
 
     elif args.command == "render":
         return _run_render_command(args)
+
+    elif args.command == "board-metrics":
+        return run_board_metrics_command(args)
 
     elif args.command == "net-status":
         from .net_status_cmd import main as net_status_cmd

--- a/src/kicad_tools/cli/board_metrics_cmd.py
+++ b/src/kicad_tools/cli/board_metrics_cmd.py
@@ -1,0 +1,460 @@
+"""Board metrics extractor — emit a normalized ``board.json`` per demo board.
+
+This module aggregates already-computed manufacturing artifacts into a single,
+stable ``board.json`` data contract consumed by the kicad-tools.org demo gallery
+(Epic #3674, Phase 1, issue #3676).
+
+It does **not** recompute anything from KiCad. All metrics are parsed from
+artifacts that already exist under a board's ``output/manufacturing/`` directory:
+
+* ``report.md``      -> routing %, DRC errors, layer count, board size, part
+                        count, description, cost estimate.
+* ``manifest.json``  -> board name and ``generated_at`` timestamp.
+* ``bom_jlcpcb.csv`` -> fallback part count (row count minus header).
+* ``kicad_project.zip`` -> downloadable manufacturing package path.
+* ``../renders/*.png`` -> render image paths (written by ``kct render``, #3675).
+
+Output is written to ``boards/<id>/output/board.json``.
+
+board.json schema (v1)
+----------------------
+
+All fields except ``schema_version``, ``generated_at``, ``slug`` and ``status``
+are OPTIONAL — they are omitted (never ``null``) when the source artifact is
+absent or unparseable.
+
+::
+
+    {
+      "$schema": "https://kicad-tools.org/schemas/board/v1.json",
+      "schema_version": 1,
+      "generated_at": "<ISO-8601 UTC timestamp>",
+      "slug": "05-bldc-motor-controller",
+      "name": "bldc_controller_routed",
+      "description": "3-Phase Brushless DC Motor Driver",
+      "layer_count": 4,
+      "board_size_mm": {"width": 80.0, "height": 100.0},
+      "part_count": 55,
+      "nets_routed_pct": 82.1,
+      "drc_violations": 14,
+      "cost": {"per_board_usd": 9.16, "batch_qty": 5, "batch_total_usd": 45.78},
+      "renders": {
+        "pcb_front": "renders/pcb-front.png",
+        "pcb_back": "renders/pcb-back.png",
+        "3d_front": "renders/3d-front.png",
+        "3d_back": "renders/3d-back.png"
+      },
+      "manufacturing_package": "manufacturing/kicad_project.zip",
+      "manifest_generated_at": "2026-06-12T05:03:41.535120+00:00",
+      "status": "ok"
+    }
+
+``status`` is one of:
+
+* ``"ok"``           — ``output/manufacturing/`` exists and ``report.md`` parsed.
+* ``"partial"``      — ``output/manufacturing/`` exists but ``report.md`` is
+                        absent/unparseable (only identity + whatever fields we
+                        could recover).
+* ``"no_artifacts"`` — no ``output/manufacturing/`` directory at all.
+
+Schema versioning policy: this schema is the Phase 2 (Astro site) data contract.
+Field additions must be additive — no renames, no type changes. Bump
+``schema_version`` only for breaking changes. See ``docs/board-json-schema.md``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import logging
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "extract_board_metrics",
+    "emit_board_json",
+    "main",
+]
+
+SCHEMA_VERSION = 1
+SCHEMA_URL = "https://kicad-tools.org/schemas/board/v1.json"
+
+# Render images written by `kct render` (#3675), relative to output/.
+# Keys are the board.json field names; values are paths relative to output/.
+RENDER_FILES = {
+    "pcb_front": "renders/pcb-front.png",
+    "pcb_back": "renders/pcb-back.png",
+    "3d_front": "renders/3d-front.png",
+    "3d_back": "renders/3d-back.png",
+}
+
+# --- report.md field regexes (machine-generated, stable format) -------------
+_LAYERS_RE = re.compile(r"\|\s*Layers\s*\|\s*(\d+)\s*copper", re.IGNORECASE)
+_BOARD_SIZE_RE = re.compile(r"\|\s*Board Size\s*\|\s*([\d.]+)\s*x\s*([\d.]+)\s*mm", re.IGNORECASE)
+_FOOTPRINTS_RE = re.compile(r"\|\s*Footprints\s*\|\s*(\d+)", re.IGNORECASE)
+_NETS_ROUTED_RE = re.compile(r"\|\s*Signal Net Completion\s*\|\s*([\d.]+)\s*%", re.IGNORECASE)
+_DRC_ERRORS_RE = re.compile(
+    r"##\s*DRC Status.*?\|\s*Errors\s*\|\s*(\d+)", re.IGNORECASE | re.DOTALL
+)
+_COST_TOTAL_RE = re.compile(r"Total \(estimated\)\D*~([\d.]+)\s*USD", re.IGNORECASE)
+_COST_BATCH_QTY_RE = re.compile(r"\|\s*Batch Quantity\s*\|\s*(\d+)", re.IGNORECASE)
+_COST_BATCH_TOTAL_RE = re.compile(r"Batch Total \(estimated\)\D*~([\d.]+)\s*USD", re.IGNORECASE)
+# Front-matter title: lives between the leading `---` fences.
+_TITLE_RE = re.compile(r'^title:\s*"?([^"\n]+)"?\s*$', re.MULTILINE)
+
+
+def _parse_report_md(text: str, slug: str) -> dict:
+    """Parse the machine-generated ``report.md`` into a partial metrics dict.
+
+    Each field is parsed independently; a miss logs a warning (naming the slug
+    and field) and is omitted rather than raising.
+    """
+    out: dict = {}
+
+    m = _LAYERS_RE.search(text)
+    if m:
+        out["layer_count"] = int(m.group(1))
+    else:
+        logger.warning("board %s: could not parse layer_count from report.md", slug)
+
+    m = _BOARD_SIZE_RE.search(text)
+    if m:
+        out["board_size_mm"] = {
+            "width": float(m.group(1)),
+            "height": float(m.group(2)),
+        }
+    else:
+        logger.warning("board %s: could not parse board_size_mm from report.md", slug)
+
+    m = _FOOTPRINTS_RE.search(text)
+    if m:
+        out["part_count"] = int(m.group(1))
+    else:
+        logger.warning("board %s: could not parse part_count from report.md", slug)
+
+    m = _NETS_ROUTED_RE.search(text)
+    if m:
+        out["nets_routed_pct"] = float(m.group(1))
+    else:
+        logger.warning("board %s: could not parse nets_routed_pct from report.md", slug)
+
+    m = _DRC_ERRORS_RE.search(text)
+    if m:
+        out["drc_violations"] = int(m.group(1))
+    else:
+        logger.warning("board %s: could not parse drc_violations from report.md", slug)
+
+    # Description: prefer the Theory of Operation section's first non-empty
+    # paragraph after the heading, falling back to the front-matter title.
+    description = _parse_description(text)
+    if description:
+        out["description"] = description
+
+    # Cost is optional — omit the whole block if the section is absent.
+    cost = _parse_cost(text)
+    if cost:
+        out["cost"] = cost
+
+    return out
+
+
+def _parse_description(text: str) -> str | None:
+    """Extract a human-readable board description from report.md.
+
+    Uses the first non-empty line(s) under ``### Theory of Operation``; falls
+    back to the front-matter ``title``.
+    """
+    theory_idx = text.find("### Theory of Operation")
+    if theory_idx != -1:
+        section = text[theory_idx + len("### Theory of Operation") :]
+        # Stop at the next markdown heading.
+        end = re.search(r"\n#{1,6}\s", section)
+        if end:
+            section = section[: end.start()]
+        lines = [ln.strip() for ln in section.splitlines() if ln.strip()]
+        if lines:
+            # Join the leading description lines (skip the board-name line if a
+            # richer sentence follows) into a single space-joined string.
+            return " ".join(lines)
+
+    m = _TITLE_RE.search(text)
+    if m:
+        return m.group(1).strip()
+    return None
+
+
+def _parse_cost(text: str) -> dict | None:
+    """Parse the ``## Cost Estimate`` block; return None when absent."""
+    if "## Cost Estimate" not in text:
+        return None
+    cost: dict = {}
+    m = _COST_TOTAL_RE.search(text)
+    if m:
+        cost["per_board_usd"] = float(m.group(1))
+    m = _COST_BATCH_QTY_RE.search(text)
+    if m:
+        cost["batch_qty"] = int(m.group(1))
+    m = _COST_BATCH_TOTAL_RE.search(text)
+    if m:
+        cost["batch_total_usd"] = float(m.group(1))
+    return cost or None
+
+
+def _parse_manifest(manifest_path: Path, slug: str) -> dict:
+    """Parse identity fields from ``manifest.json`` (board name + timestamp)."""
+    out: dict = {}
+    try:
+        data = json.loads(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("board %s: could not read manifest.json (%s)", slug, exc)
+        return out
+
+    board = data.get("board") or {}
+    name = board.get("name")
+    if name:
+        out["name"] = name
+
+    generated_at = data.get("generated_at")
+    if generated_at:
+        out["manifest_generated_at"] = generated_at
+
+    return out
+
+
+def _count_bom_parts(bom_path: Path, slug: str) -> int | None:
+    """Count assembly parts as ``bom_jlcpcb.csv`` data rows (minus header)."""
+    try:
+        with bom_path.open(newline="") as fh:
+            rows = list(csv.reader(fh))
+    except OSError as exc:
+        logger.warning("board %s: could not read %s (%s)", slug, bom_path.name, exc)
+        return None
+    # Drop the header row; ignore trailing blank lines.
+    data_rows = [r for r in rows[1:] if any(cell.strip() for cell in r)]
+    return len(data_rows)
+
+
+def extract_board_metrics(board_dir: Path) -> dict:
+    """Read existing artifacts under ``board_dir`` and return a board.json dict.
+
+    Never raises on missing/partial artifacts — fields are omitted and the
+    ``status`` enum reflects how much was recovered.
+
+    Args:
+        board_dir: A board directory, e.g. ``boards/05-bldc-motor-controller``.
+
+    Returns:
+        A schema-conforming ``board.json`` dict.
+    """
+    board_dir = Path(board_dir)
+    slug = board_dir.name
+
+    metrics: dict = {
+        "$schema": SCHEMA_URL,
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "slug": slug,
+    }
+
+    output_dir = board_dir / "output"
+    mfg_dir = output_dir / "manufacturing"
+
+    if not mfg_dir.is_dir():
+        # No manufacturing artifacts at all — identity-only board.json.
+        logger.info("board %s: no output/manufacturing directory; status=no_artifacts", slug)
+        metrics["status"] = "no_artifacts"
+        _attach_render_paths(metrics, output_dir)
+        return metrics
+
+    report_parsed = False
+
+    # report.md is the primary metrics source.
+    report_path = mfg_dir / "report.md"
+    if report_path.is_file():
+        try:
+            text = report_path.read_text()
+            metrics.update(_parse_report_md(text, slug))
+            report_parsed = True
+        except OSError as exc:
+            logger.warning("board %s: could not read report.md (%s)", slug, exc)
+    else:
+        logger.warning("board %s: report.md missing under output/manufacturing", slug)
+
+    # manifest.json supplies board identity (name + timestamp).
+    manifest_path = mfg_dir / "manifest.json"
+    if manifest_path.is_file():
+        metrics.update(_parse_manifest(manifest_path, slug))
+
+    # Fall back to BOM row count when report.md did not yield a part_count.
+    if "part_count" not in metrics:
+        bom_path = mfg_dir / "bom_jlcpcb.csv"
+        if bom_path.is_file():
+            count = _count_bom_parts(bom_path, slug)
+            if count is not None:
+                metrics["part_count"] = count
+
+    # Downloadable manufacturing package (relative to board.json location).
+    package_path = mfg_dir / "kicad_project.zip"
+    if package_path.is_file():
+        metrics["manufacturing_package"] = "manufacturing/kicad_project.zip"
+
+    _attach_render_paths(metrics, output_dir)
+
+    metrics["status"] = "ok" if report_parsed else "partial"
+    return metrics
+
+
+def _attach_render_paths(metrics: dict, output_dir: Path) -> None:
+    """Attach a ``renders`` dict for render images that exist on disk.
+
+    Paths are relative to ``board.json``'s location (``output/``), so they
+    resolve as ``output/<value>``. Missing files are omitted; the ``renders``
+    key is added only when at least one render exists.
+    """
+    renders: dict = {}
+    for field, rel_path in RENDER_FILES.items():
+        if (output_dir / rel_path).is_file():
+            renders[field] = rel_path
+    if renders:
+        metrics["renders"] = renders
+
+
+def emit_board_json(board_dir: Path, output_path: Path | None = None) -> Path:
+    """Extract metrics and write ``board.json``; return the written path.
+
+    Args:
+        board_dir: Board directory (e.g. ``boards/05-bldc-motor-controller``).
+        output_path: Override output path. Defaults to
+            ``<board_dir>/output/board.json``.
+
+    Returns:
+        The path the ``board.json`` was written to.
+    """
+    board_dir = Path(board_dir)
+    metrics = extract_board_metrics(board_dir)
+
+    if output_path is None:
+        output_path = board_dir / "output" / "board.json"
+    output_path = Path(output_path)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(metrics, indent=2) + "\n")
+    return output_path
+
+
+def _iter_board_dirs(boards_dir: Path):
+    """Yield candidate board sub-directories of ``boards_dir`` in sorted order.
+
+    A board dir is any immediate sub-directory that is not hidden. The
+    ``external/`` directory is descended into one level (it groups external
+    boards), mirroring the ``boards/`` layout.
+    """
+    if not boards_dir.is_dir():
+        return
+    for entry in sorted(boards_dir.iterdir()):
+        if not entry.is_dir() or entry.name.startswith(".") or entry.name.startswith("_"):
+            continue
+        if entry.name == "external":
+            for sub in sorted(entry.iterdir()):
+                if sub.is_dir() and not sub.name.startswith("."):
+                    yield sub
+            continue
+        yield entry
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Standalone entry point for ``kct board-metrics``.
+
+    Usage::
+
+        kct board-metrics boards/05-bldc-motor-controller
+        kct board-metrics --all --boards-dir boards/
+        kct board-metrics boards/05-... --output path/board.json
+        kct board-metrics boards/05-... --dry-run
+    """
+    parser = argparse.ArgumentParser(
+        prog="kct board-metrics",
+        description="Emit a normalized board.json per demo board from existing artifacts.",
+    )
+    parser.add_argument(
+        "board",
+        nargs="?",
+        help="Path to a board directory (e.g. boards/05-bldc-motor-controller)",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Process every board under --boards-dir instead of a single board",
+    )
+    parser.add_argument(
+        "--boards-dir",
+        default="boards",
+        help="Root directory containing per-board subdirs (default: boards)",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        default=None,
+        help="Override output path (single-board mode only)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print board.json to stdout without writing any file",
+    )
+    args = parser.parse_args(argv)
+
+    if args.all:
+        return _run_all(Path(args.boards_dir), dry_run=args.dry_run)
+
+    if not args.board:
+        parser.error("a board directory is required (or use --all)")
+
+    board_dir = Path(args.board)
+    if not board_dir.is_dir():
+        print(f"error: board directory not found: {board_dir}")
+        return 1
+
+    if args.dry_run:
+        metrics = extract_board_metrics(board_dir)
+        print(json.dumps(metrics, indent=2))
+        return 0
+
+    output_path = Path(args.output) if args.output else None
+    written = emit_board_json(board_dir, output_path)
+    metrics = json.loads(written.read_text())
+    print(f"{metrics['slug']:30s} {metrics['status']:13s} -> {written}")
+    return 0
+
+
+def _run_all(boards_dir: Path, dry_run: bool) -> int:
+    """Process every board under ``boards_dir`` in sorted order."""
+    if not boards_dir.is_dir():
+        print(f"error: boards directory not found: {boards_dir}")
+        return 1
+
+    any_board = False
+    for board_dir in _iter_board_dirs(boards_dir):
+        any_board = True
+        if dry_run:
+            metrics = extract_board_metrics(board_dir)
+            print(json.dumps(metrics, indent=2))
+            continue
+        written = emit_board_json(board_dir)
+        metrics = json.loads(written.read_text())
+        print(f"{metrics['slug']:30s} {metrics['status']:13s} -> {written}")
+
+    if not any_board:
+        print(f"error: no board subdirectories found under {boards_dir}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())

--- a/src/kicad_tools/cli/commands/__init__.py
+++ b/src/kicad_tools/cli/commands/__init__.py
@@ -17,6 +17,7 @@ This package contains command handler modules organized by domain:
 
 from .analyze import run_analyze_command
 from .benchmark import run_benchmark_command
+from .board_metrics import run_board_metrics_command
 from .build import run_build_command
 from .config import run_config_command, run_interactive_command
 from .create_pcb import run_create_pcb_command
@@ -103,6 +104,8 @@ __all__ = [
     "run_decisions_command",
     # Fleet
     "run_fleet_command",
+    # Board metrics
+    "run_board_metrics_command",
     # Reasoning
     "run_reason_command",
     # Placement

--- a/src/kicad_tools/cli/commands/board_metrics.py
+++ b/src/kicad_tools/cli/commands/board_metrics.py
@@ -1,0 +1,35 @@
+"""Board-metrics command handler (emit normalized board.json per board).
+
+Thin shim that re-serializes the unified-parser args back into an argv list for
+the standalone :mod:`kicad_tools.cli.board_metrics_cmd` module, mirroring the
+pattern used by :func:`run_fleet_command`. This keeps behavior in sync between
+``kct board-metrics`` and ``python -m kicad_tools.cli.board_metrics_cmd``.
+"""
+
+__all__ = ["run_board_metrics_command"]
+
+
+def run_board_metrics_command(args) -> int:
+    """Dispatch to ``board_metrics_cmd.main`` after rebuilding sub-argv."""
+    from ..board_metrics_cmd import main as board_metrics_main
+
+    sub_argv: list[str] = []
+
+    if getattr(args, "board_metrics_board", None):
+        sub_argv.append(args.board_metrics_board)
+
+    if getattr(args, "board_metrics_all", False):
+        sub_argv.append("--all")
+
+    boards_dir = getattr(args, "board_metrics_boards_dir", None)
+    if boards_dir:
+        sub_argv.extend(["--boards-dir", boards_dir])
+
+    output = getattr(args, "board_metrics_output", None)
+    if output:
+        sub_argv.extend(["--output", output])
+
+    if getattr(args, "board_metrics_dry_run", False):
+        sub_argv.append("--dry-run")
+
+    return board_metrics_main(sub_argv)

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -175,6 +175,7 @@ def create_parser() -> argparse.ArgumentParser:
     _add_net_status_parser(subparsers)
     _add_fleet_parser(subparsers)
     _add_render_parser(subparsers)
+    _add_board_metrics_parser(subparsers)
     _add_clean_parser(subparsers)
     _add_impedance_parser(subparsers)
     _add_mcp_parser(subparsers)
@@ -4925,6 +4926,56 @@ def _add_net_status_parser(subparsers) -> None:
         dest="net_status_verbose",
         action="store_true",
         help="Show all pads with coordinates",
+    )
+
+
+def _add_board_metrics_parser(subparsers) -> None:
+    """Add the ``board-metrics`` parser (normalized board.json per board, #3676).
+
+    Emits a stable ``board.json`` data contract per demo board by aggregating
+    artifacts that already exist under ``output/manufacturing/`` (report.md,
+    manifest.json, BOM, kicad_project.zip) plus render images from ``kct render``.
+    """
+    bm_parser = subparsers.add_parser(
+        "board-metrics",
+        help="Emit a normalized board.json per board from existing artifacts",
+        description=(
+            "Aggregate already-computed manufacturing artifacts (report.md, "
+            "manifest.json, BOM, kicad_project.zip) and render images into a "
+            "normalized board.json per board. Sources existing output; never "
+            "recomputes from KiCad. Default output: boards/<id>/output/board.json."
+        ),
+    )
+    bm_parser.add_argument(
+        "board_metrics_board",
+        nargs="?",
+        metavar="board",
+        help="Path to a board directory (e.g. boards/05-bldc-motor-controller)",
+    )
+    bm_parser.add_argument(
+        "--all",
+        dest="board_metrics_all",
+        action="store_true",
+        help="Process every board under --boards-dir instead of a single board",
+    )
+    bm_parser.add_argument(
+        "--boards-dir",
+        dest="board_metrics_boards_dir",
+        default="boards",
+        help="Root directory containing per-board subdirs (default: boards)",
+    )
+    bm_parser.add_argument(
+        "--output",
+        "-o",
+        dest="board_metrics_output",
+        default=None,
+        help="Override output path (single-board mode only)",
+    )
+    bm_parser.add_argument(
+        "--dry-run",
+        dest="board_metrics_dry_run",
+        action="store_true",
+        help="Print board.json to stdout without writing any file",
     )
 
 

--- a/tests/test_board_metrics.py
+++ b/tests/test_board_metrics.py
@@ -1,0 +1,339 @@
+"""Tests for the board-metrics extractor (issue #3676).
+
+Covers:
+* full extraction against a synthetic report.md + manifest.json fixture,
+* graceful handling of missing/unparseable report fields (status=partial),
+* the no-artifacts path (status=no_artifacts),
+* BOM fallback for part_count,
+* render-path attachment and relativity,
+* emit_board_json writing to the default and overridden paths,
+* the CLI main() single-board, --all and --dry-run modes.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.board_metrics_cmd import (
+    SCHEMA_VERSION,
+    emit_board_json,
+    extract_board_metrics,
+    main,
+)
+
+# A trimmed but faithful copy of board 05's report.md structure.
+SAMPLE_REPORT_MD = """---
+title: "bldc_controller_routed"
+subtitle: "Design Report"
+author: "kicad-tools 0.13.0"
+---
+
+## Board Summary
+
+| Property | Value |
+|----------|-------|
+| Layers | 4 copper (F.Cu, In1.Cu, In2.Cu, B.Cu) |
+| Footprints | 55 (40 SMD, 11 THT, 4 other) |
+| Nets | 52 |
+| Board Size | 80.0 x 100.0 mm |
+
+## Design Overview
+
+### Theory of Operation
+
+3-Phase Brushless DC Motor Driver
+
+### Power Architecture
+
+**Power Rails**: +24V
+
+## DRC Status
+
+| Metric | Count |
+|--------|-------|
+| Errors | 14 |
+| Warnings | 0 |
+
+## Routing Status
+
+| Metric | Value |
+|--------|-------|
+| Signal Net Completion | 82.1% (32/39) |
+| Overall Completion | 84.6% |
+
+## Cost Estimate
+
+| Metric | Per Board (estimated) |
+|--------|-------|
+| **Total (estimated)** | **~9.16 USD** |
+| Batch Quantity | 5 |
+| Batch Total (estimated) | ~45.78 USD |
+"""
+
+SAMPLE_MANIFEST = {
+    "version": 1,
+    "generated_at": "2026-06-12T05:03:41.535120+00:00",
+    "board": {
+        "name": "bldc_controller_routed",
+        "pcb_file": "bldc_controller_routed.kicad_pcb",
+    },
+}
+
+
+def _make_board(
+    tmp_path: Path,
+    slug: str = "05-bldc-motor-controller",
+    *,
+    report: str | None = SAMPLE_REPORT_MD,
+    manifest: dict | None = None,
+    bom: str | None = None,
+    package: bool = False,
+    renders: list[str] | None = None,
+    make_mfg: bool = True,
+) -> Path:
+    """Build a synthetic board directory tree and return it."""
+    board_dir = tmp_path / slug
+    output_dir = board_dir / "output"
+    output_dir.mkdir(parents=True)
+
+    if make_mfg:
+        mfg = output_dir / "manufacturing"
+        mfg.mkdir()
+        if report is not None:
+            (mfg / "report.md").write_text(report)
+        if manifest is not None:
+            (mfg / "manifest.json").write_text(json.dumps(manifest))
+        if bom is not None:
+            (mfg / "bom_jlcpcb.csv").write_text(bom)
+        if package:
+            (mfg / "kicad_project.zip").write_bytes(b"PK\x03\x04zip")
+
+    if renders:
+        renders_dir = output_dir / "renders"
+        renders_dir.mkdir()
+        for name in renders:
+            (renders_dir / name).write_bytes(b"\x89PNG")
+
+    return board_dir
+
+
+def test_extract_full_metrics(tmp_path: Path):
+    board = _make_board(tmp_path, manifest=SAMPLE_MANIFEST, package=True)
+    m = extract_board_metrics(board)
+
+    assert m["schema_version"] == SCHEMA_VERSION
+    assert m["slug"] == "05-bldc-motor-controller"
+    assert m["status"] == "ok"
+    assert m["name"] == "bldc_controller_routed"
+    assert m["layer_count"] == 4
+    assert m["board_size_mm"] == {"width": 80.0, "height": 100.0}
+    assert m["part_count"] == 55
+    assert m["nets_routed_pct"] == 82.1
+    assert m["drc_violations"] == 14
+    assert m["cost"] == {
+        "per_board_usd": 9.16,
+        "batch_qty": 5,
+        "batch_total_usd": 45.78,
+    }
+    assert m["manufacturing_package"] == "manufacturing/kicad_project.zip"
+    assert m["manifest_generated_at"] == "2026-06-12T05:03:41.535120+00:00"
+    assert "3-Phase Brushless DC Motor Driver" in m["description"]
+    # generated_at is an ISO-8601 string.
+    assert isinstance(m["generated_at"], str) and "T" in m["generated_at"]
+
+
+def test_no_artifacts_path(tmp_path: Path):
+    # Board with an output dir but no manufacturing subdir.
+    board = _make_board(tmp_path, slug="00-simple-led", make_mfg=False)
+    m = extract_board_metrics(board)
+
+    assert m["status"] == "no_artifacts"
+    assert m["slug"] == "00-simple-led"
+    # Identity fields present; metric fields omitted (not null).
+    for omitted in ("layer_count", "nets_routed_pct", "drc_violations", "name"):
+        assert omitted not in m
+
+
+def test_no_output_dir_at_all(tmp_path: Path):
+    # Board directory exists but has no output/ at all.
+    board = tmp_path / "00-simple-led"
+    board.mkdir()
+    m = extract_board_metrics(board)
+    assert m["status"] == "no_artifacts"
+    assert "renders" not in m
+
+
+def test_partial_when_report_missing(tmp_path: Path):
+    # manufacturing/ exists but report.md is absent -> partial.
+    board = _make_board(tmp_path, report=None, manifest=SAMPLE_MANIFEST)
+    m = extract_board_metrics(board)
+
+    assert m["status"] == "partial"
+    assert m["name"] == "bldc_controller_routed"  # from manifest
+    assert "layer_count" not in m  # no report to parse
+
+
+def test_unparseable_fields_omitted(tmp_path: Path):
+    # report.md present but missing several rows -> those fields omitted,
+    # status still ok (report parsed, just sparse).
+    sparse_report = """---
+title: "sparse_board"
+---
+
+## Board Summary
+
+| Property | Value |
+|----------|-------|
+| Layers | 2 copper (F.Cu, B.Cu) |
+"""
+    board = _make_board(tmp_path, report=sparse_report)
+    m = extract_board_metrics(board)
+
+    assert m["status"] == "ok"
+    assert m["layer_count"] == 2
+    for omitted in ("board_size_mm", "part_count", "nets_routed_pct", "cost"):
+        assert omitted not in m
+    # No DRC Status section -> drc_violations omitted.
+    assert "drc_violations" not in m
+
+
+def test_bom_fallback_for_part_count(tmp_path: Path):
+    # report.md without a Footprints row falls back to BOM data-row count.
+    report_no_footprints = """---
+title: "fallback_board"
+---
+
+## Board Summary
+
+| Property | Value |
+|----------|-------|
+| Layers | 2 copper (F.Cu, B.Cu) |
+"""
+    bom = "Comment,Designator,Footprint,LCSC\n100nF,C1,C_0402,C123\n10k,R1,R_0402,C456\n"
+    board = _make_board(tmp_path, report=report_no_footprints, bom=bom)
+    m = extract_board_metrics(board)
+
+    assert m["part_count"] == 2  # two data rows, header dropped
+
+
+def test_render_paths_attached_when_present(tmp_path: Path):
+    board = _make_board(
+        tmp_path,
+        renders=["pcb-front.png", "pcb-back.png", "3d-front.png", "3d-back.png"],
+    )
+    m = extract_board_metrics(board)
+
+    assert m["renders"] == {
+        "pcb_front": "renders/pcb-front.png",
+        "pcb_back": "renders/pcb-back.png",
+        "3d_front": "renders/3d-front.png",
+        "3d_back": "renders/3d-back.png",
+    }
+    # Paths resolve relative to output/board.json.
+    for rel in m["renders"].values():
+        assert (board / "output" / rel).is_file()
+
+
+def test_render_paths_partial(tmp_path: Path):
+    # Only some renders exist -> only those keys appear.
+    board = _make_board(tmp_path, renders=["pcb-front.png"])
+    m = extract_board_metrics(board)
+    assert m["renders"] == {"pcb_front": "renders/pcb-front.png"}
+
+
+def test_renders_omitted_when_absent(tmp_path: Path):
+    board = _make_board(tmp_path)
+    m = extract_board_metrics(board)
+    assert "renders" not in m
+
+
+def test_corrupt_manifest_does_not_crash(tmp_path: Path):
+    board = _make_board(tmp_path)
+    (board / "output" / "manufacturing" / "manifest.json").write_text("{not json")
+    m = extract_board_metrics(board)
+    # Still ok from report.md; name simply omitted.
+    assert m["status"] == "ok"
+    assert "name" not in m
+
+
+def test_emit_board_json_default_path(tmp_path: Path):
+    board = _make_board(tmp_path, manifest=SAMPLE_MANIFEST)
+    out = emit_board_json(board)
+
+    assert out == board / "output" / "board.json"
+    assert out.is_file()
+    data = json.loads(out.read_text())
+    assert data["slug"] == "05-bldc-motor-controller"
+    assert data["status"] == "ok"
+
+
+def test_emit_board_json_override_path(tmp_path: Path):
+    board = _make_board(tmp_path)
+    target = tmp_path / "custom" / "out.json"
+    out = emit_board_json(board, target)
+
+    assert out == target
+    assert target.is_file()
+
+
+def test_main_single_board(tmp_path: Path, capsys):
+    board = _make_board(tmp_path, manifest=SAMPLE_MANIFEST)
+    rc = main([str(board)])
+    assert rc == 0
+    assert (board / "output" / "board.json").is_file()
+    out = capsys.readouterr().out
+    assert "05-bldc-motor-controller" in out
+    assert "ok" in out
+
+
+def test_main_dry_run_writes_nothing(tmp_path: Path, capsys):
+    board = _make_board(tmp_path)
+    rc = main([str(board), "--dry-run"])
+    assert rc == 0
+    assert not (board / "output" / "board.json").exists()
+    # stdout is valid JSON.
+    data = json.loads(capsys.readouterr().out)
+    assert data["slug"] == "05-bldc-motor-controller"
+
+
+def test_main_all_mode(tmp_path: Path, capsys):
+    boards_dir = tmp_path / "boards"
+    boards_dir.mkdir()
+    # Two boards: one full, one no-artifacts.
+    _make_board(boards_dir, slug="05-bldc-motor-controller", manifest=SAMPLE_MANIFEST)
+    _make_board(boards_dir, slug="00-simple-led", make_mfg=False)
+
+    rc = main(["--all", "--boards-dir", str(boards_dir)])
+    assert rc == 0
+
+    full = json.loads(
+        (boards_dir / "05-bldc-motor-controller" / "output" / "board.json").read_text()
+    )
+    minimal = json.loads((boards_dir / "00-simple-led" / "output" / "board.json").read_text())
+    assert full["status"] == "ok"
+    assert minimal["status"] == "no_artifacts"
+
+
+def test_main_all_descends_external(tmp_path: Path):
+    boards_dir = tmp_path / "boards"
+    boards_dir.mkdir()
+    external = boards_dir / "external"
+    external.mkdir()
+    _make_board(external, slug="softstart", manifest=SAMPLE_MANIFEST)
+
+    rc = main(["--all", "--boards-dir", str(boards_dir)])
+    assert rc == 0
+    assert (external / "softstart" / "output" / "board.json").is_file()
+
+
+def test_main_missing_board_dir_errors(tmp_path: Path):
+    rc = main([str(tmp_path / "does-not-exist")])
+    assert rc == 1
+
+
+def test_main_requires_board_or_all(capsys):
+    with pytest.raises(SystemExit):
+        main([])


### PR DESCRIPTION
## Summary

Adds a new `kct board-metrics` command (Epic #3674, Phase 1) that emits a normalized `board.json` per demo board by aggregating manufacturing artifacts that **already exist** under each board's `output/manufacturing/` directory. It never recomputes anything from KiCad — it parses `report.md`, `manifest.json`, `bom_jlcpcb.csv`, `kicad_project.zip`, and the render images written by `kct render` (#3675).

This `board.json` is the stable data contract for Phase 2 (the Astro demo gallery site).

## Changes

- **New core extractor** `src/kicad_tools/cli/board_metrics_cmd.py`: `extract_board_metrics(board_dir)` and `emit_board_json(board_dir, output_path)`, plus a standalone `main()` with single-board, `--all`, `--output`, and `--dry-run` modes.
- **New command shim** `src/kicad_tools/cli/commands/board_metrics.py` (mirrors the `fleet` shim pattern).
- **Parser registration** in `parser.py` (`_add_board_metrics_parser`) and **dispatch** in `cli/__init__.py` + `commands/__init__.py`.
- **Schema doc** `docs/board-json-schema.md`: full field reference, source-artifact mapping, path-relativity rules, and additive-only versioning policy.
- **Tests** `tests/test_board_metrics.py` (18 tests).

### What it extracts

| field | source |
|-------|--------|
| `nets_routed_pct`, `drc_violations`, `layer_count`, `board_size_mm`, `part_count`, `description`, `cost` | `report.md` |
| `name`, `manifest_generated_at` | `manifest.json` |
| `part_count` (fallback) | `bom_jlcpcb.csv` row count |
| `renders` | `output/renders/{pcb-front,pcb-back,3d-front,3d-back}.png` |
| `manufacturing_package` | `output/manufacturing/kicad_project.zip` |

Output: `boards/<id>/output/board.json`. Missing/partial artifacts are handled via a `status` enum (`ok` / `partial` / `no_artifacts`); absent fields are omitted rather than emitted as `null`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Command emits `board.json` per board from existing artifacts | ✅ | `kct board-metrics --all` writes 9 board.json files, exits 0 |
| Includes routing %, DRC, layers, size, part count, cost | ✅ | Board 05 verified: `layer_count=4`, `board_size_mm={80,100}`, `nets_routed_pct=82.1`, `drc_violations=14`, `cost.per_board_usd=9.16`, `part_count=55` |
| References render image paths + manufacturing package | ✅ | `renders` dict (paths relative to board.json) + `manufacturing_package` populated when files exist; render-path tests included |
| Schema documented and stable | ✅ | `docs/board-json-schema.md` with additive-only versioning policy + `schema_version` |
| Handles missing/partial artifacts gracefully (omit, no crash) | ✅ | `boards/00-simple-led` (no `manufacturing/`) emits `status=no_artifacts`; `partial` path + corrupt-manifest test |
| Tests pass | ✅ | 18/18 pass via `uv run pytest tests/test_board_metrics.py` |

## Test Plan

- `uv run pytest tests/test_board_metrics.py` — 18 passed.
- `uv run kct board-metrics boards/05-bldc-motor-controller --dry-run` — values match `report.md` exactly.
- `uv run kct board-metrics boards/00-simple-led --dry-run` — `status=no_artifacts`, no crash.
- `uv run kct board-metrics --all --boards-dir boards` — processes all 8 boards + external/softstart, exits 0.
- `uv run ruff format . --check` and `uv run ruff check` on changed files — clean.

Note: generated `board.json` files are runtime artifacts and are intentionally not committed.

Closes #3676