### PR TITLE
feat(site): PCB viewer loading/error states, mobile CSS, gallery affordance

### DIFF
--- a/site/src/components/BoardCard.astro
+++ b/site/src/components/BoardCard.astro
@@ -15,9 +15,17 @@ import type { Board } from "../data/types.ts";
 
 interface Props {
   board: Board;
+  /**
+   * Whether this board has a staged `.kicad_pcb` and therefore an interactive
+   * KiCanvas viewer on its detail page (#3691). Computed at build time by
+   * `index.astro` (same `existsSync` probe `[slug].astro` uses); defaults to
+   * false so boards without a PCB omit the affordance. Kept out of the `Board`
+   * schema intentionally — it is a presentation signal, not board data.
+   */
+  hasPcb?: boolean;
 }
 
-const { board } = Astro.props;
+const { board, hasPcb = false } = Astro.props;
 
 /**
  * Resolve the thumbnail URL via the fallback chain. `board.renders` values are
@@ -67,6 +75,21 @@ const statusLabel = STATUS_LABEL[board.status];
     {board.description && <p class="desc">{board.description}</p>}
 
     <ul class="badges">
+      {
+        /*
+         * Interactive-view affordance (#3691): a subtle pill signalling that the
+         * board's detail page has a live KiCanvas PCB viewer. Rendered only when
+         * `hasPcb` is true; boards without a staged `.kicad_pcb` omit it. The
+         * whole card already links to `/<slug>`, so the badge is informational —
+         * no extra link wrapping needed.
+         */
+        hasPcb && (
+          <li class="badge badge-interactive">
+            <span class="badge-icon" aria-hidden="true">▦</span>
+            <span class="badge-value">Interactive view</span>
+          </li>
+        )
+      }
       {
         board.nets_routed_pct !== undefined && (
           <li class="badge">
@@ -231,6 +254,24 @@ const statusLabel = STATUS_LABEL[board.status];
   .badge-warn {
     border-color: rgba(224, 168, 0, 0.6);
     background: rgba(224, 168, 0, 0.12);
+  }
+
+  /* Interactive-view affordance pill (#3691): tinted with the accent so it reads
+     as an action cue distinct from the neutral metric badges. */
+  .badge-interactive {
+    align-items: center;
+    border-color: rgba(63, 174, 122, 0.6);
+    background: rgba(63, 174, 122, 0.12);
+    color: var(--accent, #3fae7a);
+  }
+
+  .badge-icon {
+    font-size: 0.8rem;
+    line-height: 1;
+  }
+
+  .badge-interactive .badge-value {
+    color: var(--accent, #3fae7a);
   }
 
   .badge-label {

--- a/site/src/pages/[slug].astro
+++ b/site/src/pages/[slug].astro
@@ -225,7 +225,27 @@ if (board.manifest_generated_at !== undefined) {
         <div id="pcb-viewer-placeholder">
           {
             hasPcb ? (
-              <kicanvas-embed src={pcbHref} controls="full" class="pcb-viewer" />
+              <Fragment>
+                <kicanvas-embed src={pcbHref} controls="full" class="pcb-viewer" />
+                {/*
+                  Phase 4 polish (#3691): loading + error overlay.
+
+                  KiCanvas reflects boolean `loading`/`loaded` attributes on the
+                  <kicanvas-embed> host and dispatches a native CustomEvent("load")
+                  once the PCB renders. It dispatches NO error event, so the inline
+                  script below uses an ~8s timeout: if `loaded` never appears (slow
+                  fetch, parse failure, blocked/failed script), the overlay swaps to
+                  an error message that points users to the static renders above.
+
+                  The overlay starts visible and is removed on the "load" event;
+                  the static <RenderGallery> stays on the page the whole time, so a
+                  failed viewer never leaves a blank box.
+                */}
+                <div class="viewer-loading" data-viewer-overlay role="status" aria-live="polite">
+                  <span class="viewer-spinner" aria-hidden="true" />
+                  <span class="viewer-loading-text">Loading interactive view…</span>
+                </div>
+              </Fragment>
             ) : (
               <p class="viewer-unavailable">
                 Interactive view unavailable — no PCB file for this board. The
@@ -235,6 +255,66 @@ if (board.manifest_generated_at !== undefined) {
           }
         </div>
       </section>
+
+      {
+        /*
+         * Drive the loading → ready / error transition for the KiCanvas embed.
+         * Astro bundles + dedupes this <script>; it runs after the DOM is parsed.
+         * Emitted only when a PCB is present so no-artifact boards stay JS-free.
+         */
+        hasPcb && (
+          <script is:inline>
+            {`(() => {
+  var placeholder = document.getElementById("pcb-viewer-placeholder");
+  if (!placeholder) return;
+  var embed = placeholder.querySelector("kicanvas-embed");
+  var overlay = placeholder.querySelector("[data-viewer-overlay]");
+  if (!embed || !overlay) return;
+
+  var settled = false;
+  var removeOverlay = function () {
+    if (settled) return;
+    settled = true;
+    overlay.remove();
+  };
+  var showError = function () {
+    if (settled) return;
+    settled = true;
+    overlay.classList.add("viewer-error");
+    overlay.innerHTML =
+      '<span class="viewer-loading-text">Interactive view could not load \\u2014 ' +
+      'the static renders above show the board layout.</span>';
+  };
+
+  // Already loaded (fast cache / earlier script run)?
+  if (embed.hasAttribute("loaded")) {
+    removeOverlay();
+    return;
+  }
+
+  // Success path: native CustomEvent("load") on the element.
+  embed.addEventListener("load", removeOverlay, { once: true });
+
+  // Belt-and-suspenders: observe the reflected "loaded" attribute too, in case
+  // the "load" event fired before this listener attached.
+  var observer = new MutationObserver(function () {
+    if (embed.hasAttribute("loaded")) {
+      observer.disconnect();
+      removeOverlay();
+    }
+  });
+  observer.observe(embed, { attributes: true, attributeFilter: ["loaded"] });
+
+  // Error path: KiCanvas dispatches no error event, so fall back to an ~8s
+  // timeout. If "loaded" never appears, degrade to the static renders.
+  window.setTimeout(function () {
+    observer.disconnect();
+    if (!embed.hasAttribute("loaded")) showError();
+  }, 8000);
+})();`}
+          </script>
+        )
+      }
 
       <section class="metrics" aria-label="Board metrics">
         <h2>Metrics</h2>
@@ -422,20 +502,77 @@ if (board.manifest_generated_at !== undefined) {
     font-size: 1.2rem;
   }
 
-  /* Phase 4 (#3690) interactive viewer container. */
+  /* Phase 4 (#3690) interactive viewer container. `position: relative` anchors
+     the absolutely-positioned loading/error overlay added in #3691. */
   .viewer-section #pcb-viewer-placeholder {
+    position: relative;
     border: 1px solid var(--border);
     border-radius: 10px;
     overflow: hidden;
     background: var(--card-bg);
   }
 
-  /* KiCanvas <kicanvas-embed> is a block custom element; give it an explicit
-     height so the canvas has room to render (it sizes to its container). */
+  /* KiCanvas <kicanvas-embed> is a block custom element; give it a responsive
+     height so the canvas has room to render (it sizes to its container).
+     `touch-action: none` lets KiCanvas own all touch gestures (pan/zoom) on the
+     viewer surface without the browser hijacking them — and, paired with the
+     responsive height, keeps page scroll usable around the viewer on mobile. */
   .pcb-viewer {
     display: block;
     width: 100%;
-    height: 560px;
+    height: clamp(300px, 45vw, 560px);
+    touch-action: none;
+  }
+
+  @media (max-width: 480px) {
+    .pcb-viewer {
+      /* Cap height on narrow viewports so the canvas never dominates the page. */
+      height: 320px;
+    }
+  }
+
+  /* Loading / error overlay (#3691). Starts visible over the embed and is
+     removed by the inline script on the "load" event, or swapped to an error
+     message after the timeout. Sits above the canvas via z-index. */
+  .viewer-loading {
+    position: absolute;
+    inset: 0;
+    z-index: 2;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    padding: 1rem;
+    text-align: center;
+    background: var(--card-bg);
+    color: var(--muted);
+    font-size: 0.9rem;
+  }
+
+  .viewer-loading.viewer-error {
+    color: var(--muted);
+  }
+
+  .viewer-spinner {
+    width: 28px;
+    height: 28px;
+    border: 3px solid var(--border);
+    border-top-color: var(--accent);
+    border-radius: 50%;
+    animation: viewer-spin 0.8s linear infinite;
+  }
+
+  @keyframes viewer-spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .viewer-spinner {
+      animation-duration: 2s;
+    }
   }
 
   /* Fallback note for boards with no staged `.kicad_pcb`. Mirrors the subtle

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -5,11 +5,24 @@
 // the per-board detail route `/<slug>` (issue #3681; a 404 there is expected
 // until that page lands). Thumbnails, status chips, and metric badges all
 // degrade gracefully when board.json / renders are absent.
+import { join, resolve } from "node:path";
+import { existsSync } from "node:fs";
 import { loadBoards } from "../data/loadBoards.ts";
 import BoardCard from "../components/BoardCard.astro";
 
 const boards = loadBoards();
 const withData = boards.filter((b) => b.status !== "no_artifacts").length;
+
+// Build-time interactive-viewer signal for the gallery affordance (#3691).
+// The prebuild `copy-renders` step stages each board's `.kicad_pcb` (routed
+// preferred) at `site/public/boards/<slug>/board.kicad_pcb`. We probe that same
+// staged path here so the card's "Interactive view" badge matches exactly which
+// boards `[slug].astro` embeds KiCanvas for — using the identical `existsSync`
+// check and `resolve(process.cwd(), "public", "boards")` root resolution. Runs
+// in Node at build time (cwd = `site/`), so `existsSync` is available.
+const stagedBoardsRoot = resolve(process.cwd(), "public", "boards");
+const hasPcbFor = (slug: string): boolean =>
+  existsSync(join(stagedBoardsRoot, slug, "board.kicad_pcb"));
 ---
 
 <!doctype html>
@@ -46,7 +59,7 @@ const withData = boards.filter((b) => b.status !== "no_artifacts").length;
           <ul class="grid" role="list">
             {boards.map((board) => (
               <li>
-                <BoardCard board={board} />
+                <BoardCard board={board} hasPcb={hasPcbFor(board.slug)} />
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary

Final Phase 4 polish for the kicad-tools.org demo gallery (Epic #3674) on top of the merged KiCanvas embed (#3690). Adds loading + error/timeout handling, mobile responsiveness, and a gallery-index affordance. The viewer embed itself, `copy-renders` PCB staging, and the build-time `hasPcb` detection are unchanged.

## Changes

- **Loading state** (`[slug].astro`): the `<kicanvas-embed>` is wrapped in an absolutely-positioned overlay (spinner + "Loading interactive view…"). An `is:inline` script clears it on the element's native `CustomEvent("load")` and also via a `MutationObserver` on the reflected `loaded` attribute (belt-and-suspenders if the event fired before the listener attached).
- **Error/timeout fallback** (`[slug].astro`): KiCanvas dispatches no error event, so an ~8s timeout swaps the overlay to an error message pointing users to the static renders. The `<RenderGallery>` stays on the page throughout, so a failed/blocked viewer never leaves a blank box and no uncaught errors surface.
- **Mobile CSS** (`[slug].astro`): replaced the fixed `height: 560px` with `clamp(300px, 45vw, 560px)` (capped at `320px` under 480px), added `touch-action: none` on `.pcb-viewer` so KiCanvas owns pan/zoom without trapping page scroll, and made the placeholder `position: relative` to anchor the overlay. Spinner respects `prefers-reduced-motion`.
- **Gallery affordance** (`BoardCard.astro` + `index.astro`): new optional `hasPcb?: boolean` card prop (defaults false) drives a subtle accent-tinted "Interactive view" pill; `index.astro` computes it per board with the **same** `existsSync(join(resolve(process.cwd(), "public", "boards"), slug, "board.kicad_pcb"))` probe `[slug].astro` uses. `types.ts` is intentionally untouched (Curator's Option A).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Loading indicator while viewer initializes; static render stays visible | ✅ | Overlay markup (`data-viewer-overlay`, "Loading interactive view…") emitted for PCB boards; uses `load` event + `loaded` attribute observer |
| ~8s timeout error fallback, no blank box / uncaught errors | ✅ | Inline script with `setTimeout(...,8000)` → `showError()` emitted; `<RenderGallery>` always present; script guards on missing nodes |
| Mobile: responsive height + `touch-action: none` | ✅ | Built CSS contains `clamp(300px,45vw,560px)`, `@media(max-width:480px){height:320px}`, `touch-action:none` |
| Gallery affordance only for boards with a PCB | ✅ | `dist/index.html` has exactly 8 "Interactive view" badges = 8 boards with staged PCB; `00-simple-led` (no PCB) omits it |
| No `types.ts` / embed / loader changes; vendored js kept | ✅ | `git diff --stat` = 3 files (`BoardCard.astro`, `[slug].astro`, `index.astro`) only |

## Test Plan

- `npm --prefix site run build` → exit 0, all 10 pages built.
- `npm --prefix site test` → 10/10 pass.
- `npm --prefix site run check` → 0 errors, 0 warnings (98 pre-existing hints, incl. the unchanged `kicanvas.js` script-tag hint).
- Verified emitted output: PCB board pages contain the overlay + inline timeout script; the no-PCB board page contains neither (0 `kicanvas-embed`/`setTimeout`); viewer CSS (`touch-action:none`, `clamp`, 480px media query) present in the slug CSS bundle; affordance pill + accent CSS present only on PCB cards in the index.

**Not testable headlessly** (no live WASM/touch): the actual loading→ready transition, real touch pan/zoom, and a live `.kicad_pcb` fetch failure. These need a browser with throttling/network-disable as listed in the issue's manual test plan. Verification here is limited to build success + emitted HTML/CSS + conditional logic.

Closes #3691