### PR TITLE
fix(deploy): render before board-metrics + add Cloudflare account guard

### DIFF
--- a/scripts/deploy-site.sh
+++ b/scripts/deploy-site.sh
@@ -10,12 +10,16 @@
 # needed (see operator issue #3686).
 #
 # Pipeline (mirrors the old workflow, kept linear so data/render/build are
-# independent of the deploy step):
-#   1. board.json  -- `kct board-metrics --all`           (non-fatal)
-#   2. renders     -- `kct render boards/` per-board PNGs  (3D via xvfb-run)
+# independent of the deploy step).  Renders run BEFORE board-metrics so the
+# freshly generated PNGs are on disk when board-metrics records their paths
+# into board.json — otherwise a fresh deploy (no pre-existing renders) yields
+# board.json without a `renders` field and the site shows placeholders.
+#   1. renders     -- `kct render boards/` per-board PNGs  (3D via xvfb-run)
+#   2. board.json  -- `kct board-metrics --all`           (non-fatal)
 #   3. site build  -- `npm --prefix site ci && run build`  (prebuild stages
 #                     renders + manufacturing files into site/public/)
-#   4. deploy      -- `wrangler pages deploy site/dist`
+#   4. deploy      -- `wrangler pages deploy site/dist` (guarded: asserts the
+#                     authenticated Cloudflare account before uploading)
 #
 # Generated artifacts (board.json, renders, site/public/boards/, site/dist/)
 # are all git-ignored and never committed.
@@ -39,6 +43,14 @@
 #   wrangler  -- required unless --no-deploy (run `wrangler login` once)
 #   kicad-cli -- optional; if absent, renders are skipped and the site serves
 #                placeholder thumbnails (warn-then-continue, not an abort)
+#
+# Cloudflare account guard (deploy path only):
+#   Before deploying, the script asserts the authenticated wrangler account ID
+#   matches EXPECTED_CLOUDFLARE_ACCOUNT_ID (defaults to the personal account
+#   251e6e8626d921603fdc3f0d75576bc6 / r.j.walters@gmail.com).  This prevents a
+#   stray work account left logged in from receiving the deploy.  Override the
+#   expected ID via the EXPECTED_CLOUDFLARE_ACCOUNT_ID env var if needed.  The
+#   guard is skipped entirely under --no-deploy (build-only needs no wrangler).
 
 set -euo pipefail
 
@@ -54,6 +66,75 @@ err()   { printf '\033[0;31m[deploy] ERROR:\033[0m %s\n' "$*" >&2; }
 usage() {
   sed -n '2,/^set -euo pipefail/p' "${BASH_SOURCE[0]}" \
     | sed -e 's/^# \{0,1\}//' -e '/^set -euo pipefail/d'
+}
+
+# --- Cloudflare account guard ----------------------------------------------
+# Expected Cloudflare account ID for kicad-tools deploys.  Defaults to the
+# personal account (r.j.walters@gmail.com / Personal Account); override via the
+# EXPECTED_CLOUDFLARE_ACCOUNT_ID env var.  A deploy recently landed on the WRONG
+# account (a stray work account left logged in), so the guard below refuses to
+# deploy unless the authenticated wrangler account matches.
+EXPECTED_CLOUDFLARE_ACCOUNT_ID="${EXPECTED_CLOUDFLARE_ACCOUNT_ID:-251e6e8626d921603fdc3f0d75576bc6}"
+
+# assert_cloudflare_account WRANGLER_CMD...
+#   Runs `wrangler whoami`, extracts the 32-hex account ID, and aborts (exit 1)
+#   unless it equals EXPECTED_CLOUDFLARE_ACCOUNT_ID.  Also runs `wrangler pages
+#   project list` and WARNs (non-fatal) if the kicad-tools project is absent.
+assert_cloudflare_account() {
+  local whoami_out account_id
+
+  info "Verifying Cloudflare deploy target (wrangler whoami)..."
+  if ! whoami_out="$("$@" whoami 2>&1)"; then
+    err "Could not run 'wrangler whoami' (not logged in?). Output:"
+    printf '%s\n' "${whoami_out}" >&2
+    err "Refusing to deploy. Run 'wrangler logout && wrangler login' to the"
+    err "correct account (r.j.walters@gmail.com), then re-run this script."
+    exit 1
+  fi
+
+  # `wrangler whoami` prints the account ID as a 32-hex token in a table; it is
+  # the only 32-hex value in the output (OAuth tokens are not printed).  Grab
+  # the first such token.
+  account_id="$(printf '%s\n' "${whoami_out}" | grep -oiE '[0-9a-f]{32}' | head -n1 || true)"
+
+  if [ -z "${account_id}" ]; then
+    err "Could not parse a Cloudflare account ID from 'wrangler whoami'."
+    err "Are you logged in? Output was:"
+    printf '%s\n' "${whoami_out}" >&2
+    err "Refusing to deploy. Run 'wrangler logout && wrangler login' to the"
+    err "correct account (r.j.walters@gmail.com), then re-run this script."
+    exit 1
+  fi
+
+  if [ "${account_id}" != "${EXPECTED_CLOUDFLARE_ACCOUNT_ID}" ]; then
+    err "WRONG Cloudflare account! Refusing to deploy."
+    err "  authenticated account ID: ${account_id}"
+    err "  expected account ID:      ${EXPECTED_CLOUDFLARE_ACCOUNT_ID}"
+    err "Wrangler uses whatever account is globally logged in — a stray work"
+    err "account would receive this deploy (or silently create a duplicate"
+    err "project on the wrong account)."
+    err "Fix: run 'wrangler logout && wrangler login' and authenticate to the"
+    err "correct account (r.j.walters@gmail.com / Personal Account), then"
+    err "re-run this script. To intentionally target a different account, set"
+    err "EXPECTED_CLOUDFLARE_ACCOUNT_ID to its ID."
+    exit 1
+  fi
+
+  info "Cloudflare account verified (${account_id})."
+
+  # Non-fatal: confirm the kicad-tools Pages project is reachable.  The very
+  # first deploy may predate project creation, so only WARN if it's missing.
+  local projects
+  if projects="$("$@" pages project list 2>&1)"; then
+    if ! printf '%s\n' "${projects}" | grep -q 'kicad-tools'; then
+      warn "'kicad-tools' Pages project not found in 'wrangler pages project list'."
+      warn "If this is the first deploy, wrangler will create it; otherwise"
+      warn "double-check you're on the right account."
+    fi
+  else
+    warn "Could not list Pages projects ('wrangler pages project list' failed);"
+    warn "continuing — wrangler will report any project issues at deploy time."
+  fi
 }
 
 # --- Parse flags -----------------------------------------------------------
@@ -111,17 +192,15 @@ if ! command -v kicad-cli >/dev/null 2>&1; then
   SKIP_RENDERS=1
 fi
 
-# --- Step 1: board.json metrics (non-fatal) --------------------------------
-info "Step 1/4: generating board metrics (uv run kct board-metrics --all)"
-# A metrics regression must not block the deploy; the site tolerates a board
-# without board.json.
-uv run kct board-metrics --all || warn "board-metrics returned non-zero; continuing (site tolerates missing board.json)."
-
-# --- Step 2: renders -------------------------------------------------------
+# --- Step 1: renders -------------------------------------------------------
+# Renders MUST run before board-metrics: board-metrics records render image
+# paths into board.json based on the PNGs that exist on disk when it runs, so
+# the renders have to be generated first or a fresh deploy produces board.json
+# without a `renders` field (placeholder thumbnails everywhere).
 if [ "${SKIP_RENDERS}" -eq 1 ]; then
-  info "Step 2/4: skipping renders (kicad-cli absent)."
+  info "Step 1/4: skipping renders (kicad-cli absent)."
 else
-  info "Step 2/4: rendering board images (uv run kct render boards/)"
+  info "Step 1/4: rendering board images (uv run kct render boards/)"
   rendered=0
 
   # Prefer 3D (2D + 3D) unless --no-3d.  The 3D pass (kicad-cli pcb render)
@@ -159,6 +238,13 @@ else
   fi
 fi
 
+# --- Step 2: board.json metrics (non-fatal) --------------------------------
+# Runs AFTER renders so board-metrics captures the freshly generated PNG paths
+# into board.json (`renders` field).  A metrics regression must not block the
+# deploy; the site tolerates a board without board.json.
+info "Step 2/4: generating board metrics (uv run kct board-metrics --all)"
+uv run kct board-metrics --all || warn "board-metrics returned non-zero; continuing (site tolerates missing board.json)."
+
 # --- Step 3: build the Astro site ------------------------------------------
 # `prebuild` (site/scripts/copy-renders.mjs) runs automatically before `build`
 # and stages renders + manufacturing files from boards/<id>/output/ into
@@ -181,6 +267,10 @@ if command -v wrangler >/dev/null 2>&1; then
 else
   WRANGLER=(npx wrangler)
 fi
+
+# Guard against deploying to the wrong Cloudflare account (aborts on mismatch
+# or not-logged-in).  Only reached on the deploy path — --no-deploy exits above.
+assert_cloudflare_account "${WRANGLER[@]}"
 
 if [ "${PREVIEW}" -eq 1 ]; then
   info "Step 4/4: deploying PREVIEW to Cloudflare Pages (wrangler auto-names the branch)."


### PR DESCRIPTION
## Summary

Two `scripts/deploy-site.sh`-only fixes for the demo gallery deploy:

1. **Ordering fix** — `kct render` now runs BEFORE `kct board-metrics --all`. `board-metrics` records render image paths into `board.json` based on PNGs present on disk when it runs; running it first on a fresh deploy (no pre-existing renders) produced `board.json` with no `renders` field, so the site served placeholder thumbnails for every board. Renders now generate first, so metrics capture the fresh PNGs.

2. **Cloudflare account guard** — before deploying (skipped under `--no-deploy`), the script asserts the authenticated wrangler account is the expected one, preventing a deploy landing on the wrong account (a work account left logged in). Adopted from the `rjwalters.info` blog-publish Step 1 pattern.

## Changes

- Swap Step 1 (board-metrics) and Step 2 (renders); renders are now Step 1, board-metrics Step 2. Updated the `Step N/4` log strings and header-comment pipeline description.
- Add `EXPECTED_CLOUDFLARE_ACCOUNT_ID` (default `251e6e8626d921603fdc3f0d75576bc6` / r.j.walters@gmail.com Personal Account; env-overridable).
- Add `assert_cloudflare_account()`:
  - Runs `wrangler whoami`, extracts the account ID via `grep -oiE '[0-9a-f]{32}' | head -n1` (the account ID is the only 32-hex token `whoami` prints — OAuth tokens are not shown).
  - Aborts (exit 1) with an actionable error on mismatch, unparseable output, or `whoami` failure — error states the found vs expected account, the wrong-account risk, and the fix (`wrangler logout && wrangler login` to the correct account).
  - Runs `wrangler pages project list` and WARNs (non-fatal) if `kicad-tools` is absent (first deploy may predate project creation).
- Guard is invoked only on the deploy path, after the `--no-deploy` early-exit, so build-only never touches wrangler.
- Preserved: `--no-deploy` build-only path, `SKIP_RENDERS` kicad-cli-absent handling, non-fatal `|| warn` on board-metrics.

## How the guard parses/asserts the account

`wrangler whoami` prints the account ID in a table cell as a 32-hex token. Parsing tested against the installed wrangler 4.46.0: `grep -oiE '[0-9a-f]{32}'` returns exactly one match (the account ID; the OAuth token is not printed, only its scopes). The script compares that to `EXPECTED_CLOUDFLARE_ACCOUNT_ID` and exits non-zero on any mismatch / empty / failure.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Render runs before board-metrics | PASS | Runtime run shows "Step 1/4: rendering" then "Step 2/4: generating board metrics" |
| `--no-deploy` still builds, skips guard | PASS | Ran `--no-deploy` with stubbed tools + a tripwire wrangler: build completed, exit 0, tripwire confirms wrangler NOT invoked |
| `SKIP_RENDERS` (kicad-cli absent) preserved | PASS | Ran `--no-deploy` with kicad-cli absent: warns, skips renders, continues, exit 0 |
| Non-fatal `\|\| warn` on board-metrics preserved | PASS | Block retains `\|\| warn "..."` (now at Step 2) |
| Guard PASSES on correct account here | PASS | Direct function test with live wrangler (account `251e...bc6`): "Cloudflare account verified", exit 0, does NOT abort |
| Guard ABORTS on mismatch | PASS | `EXPECTED_CLOUDFLARE_ACCOUNT_ID=deadbeef...` → "WRONG Cloudflare account! Refusing to deploy", exit 1 |
| Guard ABORTS when not logged in | PASS | Fake wrangler with no account ID / non-zero `whoami` → "Refusing to deploy", exit 1 in both cases |
| `kicad-tools` project absent → WARN non-fatal | PASS | Project not in this account's list → warns, exit 0 (does not abort) |
| Default expected ID hardcoded, env-overridable | PASS | `EXPECTED_CLOUDFLARE_ACCOUNT_ID="${EXPECTED_CLOUDFLARE_ACCOUNT_ID:-251e6e8626d921603fdc3f0d75576bc6}"` |
| `shellcheck` clean | PASS | `shellcheck scripts/deploy-site.sh` → no output, exit 0 |
| `--help` works | PASS | `./scripts/deploy-site.sh --help` prints usage incl. new guard docs |

## Test Plan

- `shellcheck scripts/deploy-site.sh` — clean.
- `bash -n scripts/deploy-site.sh` — syntax OK.
- `./scripts/deploy-site.sh --help` — works, shows updated pipeline + guard docs.
- `--no-deploy` (stubbed uv/npm/kicad-cli, tripwire wrangler): renders→metrics→build, exit 0, wrangler NOT called.
- `--no-deploy` with kicad-cli absent: SKIP_RENDERS warns + continues, exit 0.
- Guard function tested in isolation against live wrangler 4.46.0 (auth as r.j.walters@gmail.com / `251e...bc6`): pass path verified, plus mismatch / no-account-id / whoami-failure abort paths.

Note: the live upload (`wrangler pages deploy`) was not run; the guard logic was exercised directly and via stubs as above.

Scope: `scripts/deploy-site.sh` only. The chorus exclusion / site sections (#3696) are untouched.

Closes #3694