### PR TITLE
feat(site): Demo/Project gallery sections + exclude chorus-test

### DIFF
--- a/site/scripts/copy-renders.mjs
+++ b/site/scripts/copy-renders.mjs
@@ -58,6 +58,7 @@ import {
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { EXCLUDED_SLUGS } from "../src/data/galleryConfig.mjs";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const SITE_DIR = resolve(SCRIPT_DIR, "..");
@@ -117,6 +118,7 @@ function discoverBoards(root) {
   const boards = [];
   for (const entry of readdirSync(root).sort()) {
     if (entry.startsWith(".") || entry.startsWith("_")) continue;
+    if (EXCLUDED_SLUGS.has(entry)) continue;
     const full = join(root, entry);
     if (!isDir(full)) continue;
 
@@ -124,6 +126,7 @@ function discoverBoards(root) {
       // Group directory: descend one level. The slug is the sub-entry name.
       for (const sub of readdirSync(full).sort()) {
         if (sub.startsWith(".")) continue;
+        if (EXCLUDED_SLUGS.has(sub)) continue;
         const subFull = join(full, sub);
         if (isDir(subFull)) boards.push({ slug: sub, dir: subFull });
       }

--- a/site/src/data/galleryConfig.mjs
+++ b/site/src/data/galleryConfig.mjs
@@ -1,0 +1,17 @@
+/**
+ * Shared gallery configuration.
+ *
+ * Imported by BOTH the TypeScript loader (`loadBoards.ts`) and the plain-ESM
+ * staging script (`scripts/copy-renders.mjs`). Kept as `.mjs` (plain JS) so
+ * `node scripts/copy-renders.mjs` can import it directly without TypeScript
+ * transpilation, while Astro/Vitest resolve it from the `.ts` loader too.
+ */
+
+/**
+ * Board slugs that must never be published to the gallery.
+ *
+ * `chorus-test-revA` is a private design symlinked into `boards/external/`;
+ * it must produce no card, route, render, or staged PCB. Honored by both the
+ * loader's discovery and the render-staging script so it is dropped uniformly.
+ */
+export const EXCLUDED_SLUGS = new Set(["chorus-test-revA"]);

--- a/site/src/data/loadBoards.test.ts
+++ b/site/src/data/loadBoards.test.ts
@@ -157,3 +157,52 @@ describe("loadBoards", () => {
     expect(loadBoards(root)).toEqual([]);
   });
 });
+
+describe("excluded slugs (#3696)", () => {
+  it("drops chorus-test-revA from discovery under external/", () => {
+    mkdirSync(join(root, "external", "softstart", "output"), { recursive: true });
+    mkdirSync(join(root, "external", "chorus-test-revA", "output"), { recursive: true });
+
+    const slugs = discoverBoardDirs(root).map((d) =>
+      d.split(/[\\/]/).filter(Boolean).pop(),
+    );
+    expect(slugs).toContain("softstart");
+    expect(slugs).not.toContain("chorus-test-revA");
+  });
+
+  it("emits no Board for an excluded slug", () => {
+    mkdirSync(join(root, "external", "chorus-test-revA", "output"), { recursive: true });
+    writeBoardJson("00-simple-led", validBoard("00-simple-led"));
+
+    const boards = loadBoards(root);
+    expect(boards.map((b) => b.slug)).not.toContain("chorus-test-revA");
+    expect(boards.map((b) => b.slug)).toContain("00-simple-led");
+  });
+});
+
+describe("board category (#3696)", () => {
+  it("tags numbered top-level boards as demo", () => {
+    const board = loadBoard(makeBoardDir("00-simple-led"));
+    expect(board.category).toBe("demo");
+  });
+
+  it("tags boards under external/ as project", () => {
+    mkdirSync(join(root, "external", "softstart", "output"), { recursive: true });
+    const board = loadBoard(join(root, "external", "softstart"));
+    expect(board.category).toBe("project");
+  });
+
+  it("assigns category across a mixed set", () => {
+    writeBoardJson("01-voltage-divider", validBoard("01-voltage-divider"));
+    mkdirSync(join(root, "external", "softstart", "output"), { recursive: true });
+    writeFileSync(
+      join(root, "external", "softstart", "output", "board.json"),
+      JSON.stringify(validBoard("softstart")),
+    );
+
+    const boards = loadBoards(root);
+    const bySlug = Object.fromEntries(boards.map((b) => [b.slug, b.category]));
+    expect(bySlug["01-voltage-divider"]).toBe("demo");
+    expect(bySlug["softstart"]).toBe("project");
+  });
+});

--- a/site/src/data/loadBoards.ts
+++ b/site/src/data/loadBoards.ts
@@ -23,7 +23,13 @@ import { readdirSync, existsSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { SCHEMA_VERSION } from "./types.ts";
-import type { Board, BoardStatus } from "./types.ts";
+import type { Board, BoardCategory, BoardStatus } from "./types.ts";
+import { EXCLUDED_SLUGS } from "./galleryConfig.mjs";
+
+/** True if a discovered board path lives under `boards/external/`. */
+function categoryForPath(boardPath: string): BoardCategory {
+  return /(^|[\\/])external[\\/]/.test(boardPath) ? "project" : "demo";
+}
 
 const VALID_STATUSES: ReadonlySet<string> = new Set<BoardStatus>([
   "ok",
@@ -78,6 +84,7 @@ export function discoverBoardDirs(root: string): string[] {
   const dirs: string[] = [];
   for (const entry of readdirSync(root).sort()) {
     if (entry.startsWith(".") || entry.startsWith("_")) continue;
+    if (EXCLUDED_SLUGS.has(entry)) continue;
     const full = join(root, entry);
     if (!isDir(full)) continue;
 
@@ -85,6 +92,7 @@ export function discoverBoardDirs(root: string): string[] {
       // Group directory: descend one level.
       for (const sub of readdirSync(full).sort()) {
         if (sub.startsWith(".")) continue;
+        if (EXCLUDED_SLUGS.has(sub)) continue;
         const subFull = join(full, sub);
         if (isDir(subFull)) dirs.push(subFull);
       }
@@ -96,13 +104,14 @@ export function discoverBoardDirs(root: string): string[] {
 }
 
 /** Construct a `no_artifacts` stub for a board with no parsable `board.json`. */
-function makeStub(slug: string): Board {
+function makeStub(slug: string, category: BoardCategory): Board {
   return {
     $schema: "https://kicad-tools.org/schemas/board/v1.json",
     schema_version: SCHEMA_VERSION,
     generated_at: new Date(0).toISOString(),
     slug,
     status: "no_artifacts",
+    category,
   };
 }
 
@@ -152,10 +161,11 @@ function validateBoard(data: unknown, slug: string): Board | null {
  */
 export function loadBoard(boardPath: string): Board {
   const slug = boardPath.split(/[\\/]/).filter(Boolean).pop() ?? boardPath;
+  const category = categoryForPath(boardPath);
   const jsonPath = join(boardPath, "output", "board.json");
 
   if (!existsSync(jsonPath)) {
-    return makeStub(slug);
+    return makeStub(slug, category);
   }
 
   let raw: string;
@@ -163,7 +173,7 @@ export function loadBoard(boardPath: string): Board {
     raw = readFileSync(jsonPath, "utf8");
   } catch (err) {
     console.warn(`[loadBoards] ${slug}: failed to read board.json (${String(err)}); using stub`);
-    return makeStub(slug);
+    return makeStub(slug, category);
   }
 
   let parsed: unknown;
@@ -171,11 +181,14 @@ export function loadBoard(boardPath: string): Board {
     parsed = JSON.parse(raw);
   } catch (err) {
     console.warn(`[loadBoards] ${slug}: board.json is not valid JSON (${String(err)}); using stub`);
-    return makeStub(slug);
+    return makeStub(slug, category);
   }
 
   const board = validateBoard(parsed, slug);
-  return board ?? makeStub(slug);
+  if (!board) return makeStub(slug, category);
+  // `category` is loader-assigned (not part of board.json); always set it.
+  board.category = category;
+  return board;
 }
 
 /**

--- a/site/src/data/types.ts
+++ b/site/src/data/types.ts
@@ -17,6 +17,13 @@ export const SCHEMA_VERSION = 1;
 /** Board status enum — see `docs/board-json-schema.md` "status values". */
 export type BoardStatus = "ok" | "partial" | "no_artifacts";
 
+/**
+ * Gallery section a board belongs to. Loader-assigned (NOT part of the
+ * `board.json` contract): `"project"` for boards under `boards/external/`,
+ * `"demo"` for the numbered tutorial boards.
+ */
+export type BoardCategory = "demo" | "project";
+
 /** Physical board dimensions in millimeters. */
 export interface BoardSize {
   width: number;
@@ -43,6 +50,8 @@ export interface Board {
   generated_at: string;
   slug: string;
   status: BoardStatus;
+  /** Gallery section, assigned by the loader (not from `board.json`). */
+  category: BoardCategory;
   name?: string;
   description?: string;
   layer_count?: number;

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -13,6 +13,11 @@ import BoardCard from "../components/BoardCard.astro";
 const boards = loadBoards();
 const withData = boards.filter((b) => b.status !== "no_artifacts").length;
 
+// Two gallery sections (issue #3696): the numbered tutorial boards ("Demo
+// boards") and real designs under boards/external/ ("Project gallery").
+const demoBoards = boards.filter((b) => b.category === "demo");
+const projectBoards = boards.filter((b) => b.category === "project");
+
 // Build-time interactive-viewer signal for the gallery affordance (#3691).
 // The prebuild `copy-renders` step stages each board's `.kicad_pcb` (routed
 // preferred) at `site/public/boards/<slug>/board.kicad_pcb`. We probe that same
@@ -49,22 +54,45 @@ const hasPcbFor = (slug: string): boolean =>
         </p>
       </header>
 
-      {
-        boards.length === 0 ? (
-          <p class="empty">
-            No boards discovered. Add boards under <code>boards/</code> and run
-            <code>uv run kct board-metrics --all</code> to populate data.
+      {boards.length === 0 && (
+        <p class="empty">
+          No boards discovered. Add boards under <code>boards/</code> and run
+          <code>uv run kct board-metrics --all</code> to populate data.
+        </p>
+      )}
+
+      {demoBoards.length > 0 && (
+        <section class="board-section">
+          <h2>Demo boards</h2>
+          <p class="section-copy">
+            Reference designs that exercise the kicad-tools pipeline end-to-end.
           </p>
-        ) : (
           <ul class="grid" role="list">
-            {boards.map((board) => (
+            {demoBoards.map((board) => (
               <li>
                 <BoardCard board={board} hasPcb={hasPcbFor(board.slug)} />
               </li>
             ))}
           </ul>
-        )
-      }
+        </section>
+      )}
+
+      {projectBoards.length > 0 && (
+        <section class="board-section">
+          <h2>Project gallery</h2>
+          <p class="section-copy">
+            Real-world boards built with kicad-tools. More designs — including
+            contributed work from others — will land here over time.
+          </p>
+          <ul class="grid" role="list">
+            {projectBoards.map((board) => (
+              <li>
+                <BoardCard board={board} hasPcb={hasPcbFor(board.slug)} />
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
     </main>
   </body>
 </html>
@@ -132,6 +160,22 @@ const hasPcbFor = (slug: string): boolean =>
     margin: 0.5rem 0 0;
     color: var(--muted);
     font-size: 0.85rem;
+  }
+
+  .board-section {
+    margin-top: 2.5rem;
+  }
+
+  .board-section h2 {
+    margin: 0 0 0.3rem;
+    font-size: 1.3rem;
+  }
+
+  .section-copy {
+    margin: 0 0 1.25rem;
+    color: var(--muted);
+    font-size: 0.9rem;
+    max-width: 60ch;
   }
 
   .grid {


### PR DESCRIPTION
## Summary

Restructures the gallery index into two sections and removes a private design (issue #3696, Epic #3674).

- **Two sections** on the index: **Demo boards** (numbered tutorial boards 00–07) and **Project gallery** (designs under `boards/external/`, currently just `softstart`; section copy notes it will grow to include contributed designs). Empty sections are hidden.
- **`category` field** (`"demo" | "project"`) added to the `Board` type and assigned by the loader (`"project"` iff discovered under `external/`). The index groups by it.
- **chorus-test-revA excluded entirely** via a new shared `site/src/data/galleryConfig.mjs` (`EXCLUDED_SLUGS`) imported by BOTH `loadBoards.ts` (discovery) and `copy-renders.mjs` (staging) — no card, route, render, or staged PCB.

## Verification

- `npm test` → 15/15 (added cases for exclusion + category).
- `npm run check` → 0 errors / 0 warnings.
- `npm run build` → 10 pages (was 11): **no `/chorus-test-revA` route**, no chorus references in `dist/`. Index shows both sections; cards are 00–07 + softstart only.
- No generated artifacts committed (board.json, renders, `public/boards/`, `dist` all git-ignored).

Closes #3696