### PR TITLE
fix(render): emit 2D layer plots as SVG for kicad-cli 10

### DIFF
--- a/site/scripts/copy-renders.mjs
+++ b/site/scripts/copy-renders.mjs
@@ -1,6 +1,7 @@
 /**
- * Prebuild step: stage board render PNGs and manufacturing downloads into
- * `site/public/` so the static Astro build can serve them.
+ * Prebuild step: stage board renders (2D `.svg` layer plots + 3D `.png`) and
+ * manufacturing downloads into `site/public/` so the static Astro build can
+ * serve them.
  *
  * Why this exists
  * ---------------
@@ -9,14 +10,14 @@
  * import or bundle assets from outside its project root, so we copy the files
  * into `site/public/boards/<slug>/...` at build time. Anything under `public/`
  * is served verbatim at the site root, so a copied file at
- * `site/public/boards/<slug>/renders/pcb-front.png` is reachable at the URL
- * `/boards/<slug>/renders/pcb-front.png` — which is exactly what
+ * `site/public/boards/<slug>/renders/pcb-front.svg` is reachable at the URL
+ * `/boards/<slug>/renders/pcb-front.svg` — which is exactly what
  * `BoardCard.astro` (gallery thumbnails) and `[slug].astro` (detail gallery +
  * downloads) reference.
  *
  * What gets staged
  * ----------------
- *   - Renders:        `boards/<id>/output/renders/*.png`
+ *   - Renders:        `boards/<id>/output/renders/*.svg` and `*.png`
  *                  →  `site/public/boards/<slug>/renders/<file>`
  *                  →  served at `/boards/<slug>/renders/<file>`
  *   - Manufacturing:  the downloadable files under
@@ -163,13 +164,14 @@ function main() {
     // --- Renders ---
     const srcRenders = join(dir, "output", "renders");
     if (isDir(srcRenders)) {
-      const pngs = readdirSync(srcRenders).filter((f) =>
-        f.toLowerCase().endsWith(".png"),
-      );
-      if (pngs.length > 0) {
+      const renders = readdirSync(srcRenders).filter((f) => {
+        const lower = f.toLowerCase();
+        return lower.endsWith(".png") || lower.endsWith(".svg");
+      });
+      if (renders.length > 0) {
         const destRenders = join(destRoot, slug, "renders");
         mkdirSync(destRenders, { recursive: true });
-        for (const file of pngs) {
+        for (const file of renders) {
           copyFileSync(join(srcRenders, file), join(destRenders, file));
           copied += 1;
         }

--- a/site/src/components/BoardCard.astro
+++ b/site/src/components/BoardCard.astro
@@ -29,7 +29,7 @@ const { board, hasPcb = false } = Astro.props;
 
 /**
  * Resolve the thumbnail URL via the fallback chain. `board.renders` values are
- * paths relative to `board.json` (e.g. `renders/pcb-front.png`); the prebuild
+ * paths relative to `board.json` (e.g. `renders/pcb-front.svg`); the prebuild
  * `copy-renders` step stages them at `site/public/boards/<slug>/renders/<file>`
  * so they are served from `/boards/<slug>/renders/<file>`.
  */

--- a/site/src/components/RenderGallery.astro
+++ b/site/src/components/RenderGallery.astro
@@ -8,7 +8,7 @@
  * layout reads the same whether a board has all, some, or no renders.
  *
  * Render-path resolution mirrors `BoardCard.astro`: `board.renders` values are
- * paths relative to `board.json` (e.g. `renders/pcb-front.png`); the prebuild
+ * paths relative to `board.json` (e.g. `renders/pcb-front.svg`); the prebuild
  * `copy-renders` step stages them at `site/public/boards/<slug>/renders/<file>`
  * so they are served from `/boards/<slug>/renders/<file>`.
  */

--- a/src/kicad_tools/cli/board_metrics_cmd.py
+++ b/src/kicad_tools/cli/board_metrics_cmd.py
@@ -39,8 +39,8 @@ absent or unparseable.
       "drc_violations": 14,
       "cost": {"per_board_usd": 9.16, "batch_qty": 5, "batch_total_usd": 45.78},
       "renders": {
-        "pcb_front": "renders/pcb-front.png",
-        "pcb_back": "renders/pcb-back.png",
+        "pcb_front": "renders/pcb-front.svg",
+        "pcb_back": "renders/pcb-back.svg",
         "3d_front": "renders/3d-front.png",
         "3d_back": "renders/3d-back.png"
       },
@@ -86,8 +86,8 @@ SCHEMA_URL = "https://kicad-tools.org/schemas/board/v1.json"
 # Render images written by `kct render` (#3675), relative to output/.
 # Keys are the board.json field names; values are paths relative to output/.
 RENDER_FILES = {
-    "pcb_front": "renders/pcb-front.png",
-    "pcb_back": "renders/pcb-back.png",
+    "pcb_front": "renders/pcb-front.svg",
+    "pcb_back": "renders/pcb-back.svg",
     "3d_front": "renders/3d-front.png",
     "3d_back": "renders/3d-back.png",
 }

--- a/src/kicad_tools/cli/render_cmd.py
+++ b/src/kicad_tools/cli/render_cmd.py
@@ -5,15 +5,15 @@ Generates per-board visual artifacts for downstream consumers (e.g. the
 kicad-tools.org demo gallery, Epic #3674):
 
 - 2D layer plots (front + back: copper + silkscreen + edge cuts) via
-  ``kicad-cli pcb export png``.
+  ``kicad-cli pcb export svg`` (KiCad 10 removed the raster ``png`` export).
 - 3D ray-traced renders (front + back) via ``kicad-cli pcb render``.
 
 Outputs are written to a fixed, documented path under each board's output
 directory so the site build and CI can consume them without board-specific
 logic:
 
-    boards/<id>/output/renders/pcb-front.png   # 2D front layer plot
-    boards/<id>/output/renders/pcb-back.png    # 2D back layer plot
+    boards/<id>/output/renders/pcb-front.svg   # 2D front layer plot
+    boards/<id>/output/renders/pcb-back.svg    # 2D back layer plot
     boards/<id>/output/renders/3d-front.png    # 3D ray-traced front
     boards/<id>/output/renders/3d-back.png     # 3D ray-traced back
 
@@ -21,7 +21,7 @@ The routed PCB (``*_routed.kicad_pcb``) is preferred; the command falls back
 to the unrouted ``*.kicad_pcb`` when no routed artifact exists.
 
 This command only writes image files — it makes no assumptions about hosting
-or any website. Generated PNGs are git-ignored build artifacts.
+or any website. Generated renders are git-ignored build artifacts.
 
 ``kicad-cli pcb render`` requires KiCad 8.0.4 or newer and a display (use a
 virtual framebuffer such as ``xvfb-run`` on headless CI).
@@ -44,7 +44,7 @@ from kicad_tools.cli.export_cmd import _find_pcb_for_export
 from kicad_tools.cli.runner import (
     find_kicad_cli,
     get_kicad_version,
-    run_pcb_export_png,
+    run_pcb_export_svg,
     run_pcb_render,
 )
 
@@ -58,8 +58,8 @@ BACK_LAYERS = ["B.Cu", "B.Silkscreen", "Edge.Cuts"]
 
 # Output file names (fixed contract for downstream consumers).
 RENDER_OUTPUTS = {
-    "pcb-front": "pcb-front.png",
-    "pcb-back": "pcb-back.png",
+    "pcb-front": "pcb-front.svg",
+    "pcb-back": "pcb-back.svg",
     "3d-front": "3d-front.png",
     "3d-back": "3d-back.png",
 }
@@ -167,7 +167,7 @@ def _render_board(
     ]
     for key, layers in plots:
         out = renders_dir / RENDER_OUTPUTS[key]
-        res = run_pcb_export_png(pcb_path, out, layers, kicad_cli=kicad_cli)
+        res = run_pcb_export_svg(pcb_path, out, layers, kicad_cli=kicad_cli)
         if res.success:
             written[key] = str(out)
         else:

--- a/src/kicad_tools/cli/runner.py
+++ b/src/kicad_tools/cli/runner.py
@@ -1260,7 +1260,7 @@ def _run_fill_zones_via_drc(
         drc_report.unlink(missing_ok=True)
 
 
-def run_pcb_export_png(
+def run_pcb_export_svg(
     pcb_path: Path,
     output_path: Path,
     layers: list[str],
@@ -1269,11 +1269,18 @@ def run_pcb_export_png(
     timeout: int = 120,
     kicad_cli: Path | None = None,
 ) -> KiCadCLIResult:
-    """Export a 2D layer plot of a PCB to a PNG using ``kicad-cli pcb export png``.
+    """Export a 2D layer plot of a PCB to an SVG using ``kicad-cli pcb export svg``.
+
+    KiCad 10 removed the raster ``pcb export png`` subcommand entirely, so the
+    2D layer plots are produced as scalable SVGs instead (a better web format
+    for ``<img src>`` anyway). ``--mode-single`` writes the full output path as a
+    single file (avoiding the KiCad-9 deprecation warning that flips the default
+    to directory output); ``--page-size-mode 2`` and ``--fit-page-to-board`` keep
+    the plot trimmed to the board content.
 
     Args:
         pcb_path: Path to the ``.kicad_pcb`` file to plot.
-        output_path: Where to write the PNG.
+        output_path: Where to write the SVG.
         layers: Layer names to render (e.g. ``["F.Cu", "F.Silkscreen", "Edge.Cuts"]``).
         black_and_white: Render in black & white instead of color.
         theme: Optional KiCad color theme name.
@@ -1295,13 +1302,15 @@ def run_pcb_export_png(
         str(kicad_cli),
         "pcb",
         "export",
-        "png",
+        "svg",
+        "--mode-single",
         "--output",
         str(output_path),
         "--layers",
         ",".join(layers),
         "--page-size-mode",
         "2",  # fit page to board content
+        "--fit-page-to-board",
     ]
 
     if black_and_white:
@@ -1324,15 +1333,15 @@ def run_pcb_export_png(
             )
         return KiCadCLIResult(
             success=False,
-            stderr=result.stderr or "PNG export produced no output",
+            stderr=result.stderr or "SVG export produced no output",
             return_code=result.returncode,
         )
     except FileNotFoundError as e:
         return KiCadCLIResult(success=False, stderr=f"kicad-cli not found: {e}")
     except subprocess.TimeoutExpired:
-        return KiCadCLIResult(success=False, stderr=f"PNG export timed out after {timeout} seconds")
+        return KiCadCLIResult(success=False, stderr=f"SVG export timed out after {timeout} seconds")
     except subprocess.SubprocessError as e:
-        return KiCadCLIResult(success=False, stderr=f"Failed to export PNG: {e}")
+        return KiCadCLIResult(success=False, stderr=f"Failed to export SVG: {e}")
 
 
 def run_pcb_render(

--- a/tests/test_board_metrics.py
+++ b/tests/test_board_metrics.py
@@ -222,13 +222,13 @@ title: "fallback_board"
 def test_render_paths_attached_when_present(tmp_path: Path):
     board = _make_board(
         tmp_path,
-        renders=["pcb-front.png", "pcb-back.png", "3d-front.png", "3d-back.png"],
+        renders=["pcb-front.svg", "pcb-back.svg", "3d-front.png", "3d-back.png"],
     )
     m = extract_board_metrics(board)
 
     assert m["renders"] == {
-        "pcb_front": "renders/pcb-front.png",
-        "pcb_back": "renders/pcb-back.png",
+        "pcb_front": "renders/pcb-front.svg",
+        "pcb_back": "renders/pcb-back.svg",
         "3d_front": "renders/3d-front.png",
         "3d_back": "renders/3d-back.png",
     }
@@ -239,9 +239,9 @@ def test_render_paths_attached_when_present(tmp_path: Path):
 
 def test_render_paths_partial(tmp_path: Path):
     # Only some renders exist -> only those keys appear.
-    board = _make_board(tmp_path, renders=["pcb-front.png"])
+    board = _make_board(tmp_path, renders=["pcb-front.svg"])
     m = extract_board_metrics(board)
-    assert m["renders"] == {"pcb_front": "renders/pcb-front.png"}
+    assert m["renders"] == {"pcb_front": "renders/pcb-front.svg"}
 
 
 def test_renders_omitted_when_absent(tmp_path: Path):

--- a/tests/test_render_cmd.py
+++ b/tests/test_render_cmd.py
@@ -36,9 +36,9 @@ def _make_board(root: Path, name: str, pcb_name: str | None = None) -> Path:
 def fake_kicad(monkeypatch):
     """Make kicad-cli appear available and stub render helpers to write files.
 
-    Each export/render helper creates the requested output PNG (non-empty) and
-    returns a successful KiCadCLIResult, so the command exercises its full path
-    without a live KiCad.
+    The 2D export helper creates the requested SVG and the 3D render helper the
+    requested PNG (both non-empty), returning a successful KiCadCLIResult, so the
+    command exercises its full path without a live KiCad.
     """
     from kicad_tools.cli.runner import KiCadCLIResult
 
@@ -47,11 +47,11 @@ def fake_kicad(monkeypatch):
     monkeypatch.setattr(render_cmd, "find_kicad_cli", lambda: fake_cli)
     monkeypatch.setattr(render_cmd, "get_kicad_version", lambda *a, **k: "8.0.6")
 
-    calls: dict[str, list] = {"png": [], "render": []}
+    calls: dict[str, list] = {"svg": [], "render": []}
 
-    def fake_png(pcb_path, output_path, layers, **kwargs):
-        Path(output_path).write_bytes(b"PNG")
-        calls["png"].append((Path(pcb_path), Path(output_path), list(layers)))
+    def fake_svg(pcb_path, output_path, layers, **kwargs):
+        Path(output_path).write_bytes(b"<svg></svg>")
+        calls["svg"].append((Path(pcb_path), Path(output_path), list(layers)))
         return KiCadCLIResult(success=True, output_path=Path(output_path))
 
     def fake_render(pcb_path, output_path, side="front", **kwargs):
@@ -59,7 +59,7 @@ def fake_kicad(monkeypatch):
         calls["render"].append((Path(pcb_path), Path(output_path), side))
         return KiCadCLIResult(success=True, output_path=Path(output_path))
 
-    monkeypatch.setattr(render_cmd, "run_pcb_export_png", fake_png)
+    monkeypatch.setattr(render_cmd, "run_pcb_export_svg", fake_svg)
     monkeypatch.setattr(render_cmd, "run_pcb_render", fake_render)
 
     return calls
@@ -149,8 +149,8 @@ class TestOutputPathContract:
 
     def test_filenames_are_exactly_the_contract(self):
         assert RENDER_OUTPUTS == {
-            "pcb-front": "pcb-front.png",
-            "pcb-back": "pcb-back.png",
+            "pcb-front": "pcb-front.svg",
+            "pcb-back": "pcb-back.svg",
             "3d-front": "3d-front.png",
             "3d-back": "3d-back.png",
         }
@@ -170,14 +170,14 @@ class TestPcbSelection:
         assert rc == 0
 
         # Every helper should have been called with the routed PCB.
-        used = {call[0].name for call in fake_kicad["png"]}
+        used = {call[0].name for call in fake_kicad["svg"]}
         assert used == {"vd_routed.kicad_pcb"}
 
     def test_falls_back_to_unrouted(self, tmp_path, fake_kicad):
         board = _make_board(tmp_path, "00-led", "led.kicad_pcb")
         rc = render_main([str(board)])
         assert rc == 0
-        used = {call[0].name for call in fake_kicad["png"]}
+        used = {call[0].name for call in fake_kicad["svg"]}
         assert used == {"led.kicad_pcb"}
 
 
@@ -193,8 +193,8 @@ class TestNo3d:
         assert rc == 0
 
         renders = board / "output" / "renders"
-        assert (renders / "pcb-front.png").exists()
-        assert (renders / "pcb-back.png").exists()
+        assert (renders / "pcb-front.svg").exists()
+        assert (renders / "pcb-back.svg").exists()
         assert not (renders / "3d-front.png").exists()
         assert not (renders / "3d-back.png").exists()
         # The 3D render helper was never called.
@@ -244,7 +244,7 @@ class TestEdgeCases:
         def failing(pcb_path, output_path, *a, **k):
             return KiCadCLIResult(success=False, stderr="boom")
 
-        monkeypatch.setattr(render_cmd, "run_pcb_export_png", failing)
+        monkeypatch.setattr(render_cmd, "run_pcb_export_svg", failing)
         monkeypatch.setattr(render_cmd, "run_pcb_render", failing)
 
         rc = render_main([str(board)])

--- a/tests/test_runner_export_svg.py
+++ b/tests/test_runner_export_svg.py
@@ -1,0 +1,103 @@
+"""Regression tests for ``run_pcb_export_svg`` (issue #3695).
+
+KiCad 10 removed the raster ``pcb export png`` subcommand, so the 2D layer
+plots are produced as SVGs via ``pcb export svg --mode-single``. These tests
+mock the subprocess call and assert the command array carries the verified
+KiCad-10 flags.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from kicad_tools.cli.runner import run_pcb_export_svg
+
+_RUNNER = "kicad_tools.cli.runner"
+
+
+def test_export_svg_command_uses_svg_subcommand_and_flags(tmp_path: Path):
+    pcb = tmp_path / "board.kicad_pcb"
+    pcb.write_text("(kicad_pcb)")
+    out = tmp_path / "pcb-front.svg"
+
+    def fake_run(cmd, *args, **kwargs):
+        # Simulate kicad-cli writing a non-empty SVG.
+        out.write_text("<svg></svg>")
+        fake_run.cmd = cmd
+        return MagicMock(returncode=0, stdout="Plotted to ...", stderr="")
+
+    with patch(f"{_RUNNER}.subprocess.run", side_effect=fake_run):
+        res = run_pcb_export_svg(
+            pcb,
+            out,
+            ["F.Cu", "F.Silkscreen", "Edge.Cuts"],
+            kicad_cli=Path("/usr/bin/kicad-cli"),
+        )
+
+    assert res.success
+    assert res.output_path == out
+
+    cmd = fake_run.cmd
+    # Uses the SVG export subcommand, not the removed raster png export.
+    assert "svg" in cmd
+    assert "png" not in cmd
+    assert cmd[cmd.index("svg") - 1] == "export"
+    # Single-file mode + board-fit flags verified on kicad-cli 10.0.1.
+    assert "--mode-single" in cmd
+    assert "--fit-page-to-board" in cmd
+    assert "--page-size-mode" in cmd
+    assert cmd[cmd.index("--page-size-mode") + 1] == "2"
+    # Layers are passed comma-joined.
+    assert "--layers" in cmd
+    assert cmd[cmd.index("--layers") + 1] == "F.Cu,F.Silkscreen,Edge.Cuts"
+    # Output path and PCB are present.
+    assert str(out) in cmd
+    assert str(pcb) in cmd
+
+
+def test_export_svg_passes_black_and_white_and_theme(tmp_path: Path):
+    pcb = tmp_path / "board.kicad_pcb"
+    pcb.write_text("(kicad_pcb)")
+    out = tmp_path / "pcb-back.svg"
+
+    def fake_run(cmd, *args, **kwargs):
+        out.write_text("<svg></svg>")
+        fake_run.cmd = cmd
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch(f"{_RUNNER}.subprocess.run", side_effect=fake_run):
+        res = run_pcb_export_svg(
+            pcb,
+            out,
+            ["B.Cu", "B.Silkscreen", "Edge.Cuts"],
+            black_and_white=True,
+            theme="KiCad Classic",
+            kicad_cli=Path("/usr/bin/kicad-cli"),
+        )
+
+    assert res.success
+    cmd = fake_run.cmd
+    assert "--black-and-white" in cmd
+    assert "--theme" in cmd
+    assert cmd[cmd.index("--theme") + 1] == "KiCad Classic"
+
+
+def test_export_svg_reports_failure_when_no_output(tmp_path: Path):
+    pcb = tmp_path / "board.kicad_pcb"
+    pcb.write_text("(kicad_pcb)")
+    out = tmp_path / "missing.svg"  # never created by the fake
+
+    def fake_run(cmd, *args, **kwargs):
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch(f"{_RUNNER}.subprocess.run", side_effect=fake_run):
+        res = run_pcb_export_svg(
+            pcb,
+            out,
+            ["F.Cu"],
+            kicad_cli=Path("/usr/bin/kicad-cli"),
+        )
+
+    assert not res.success
+    assert "SVG export produced no output" in res.stderr


### PR DESCRIPTION
## Summary

kicad-cli 10.0 removed the raster `pcb export png` subcommand entirely, so `kct render`'s 2D front/back layer plots silently produced no output ("PNG export produced no output") on KiCad 10 — only the 3D `pcb render` PNGs were ever written. This switches the 2D layer plots to `pcb export svg --mode-single --fit-page-to-board` (verified working on kicad-cli 10.0.1). SVG is scalable/crisp and serves natively in `<img src>`. 3D ray-traced renders remain PNG.

## Changes

- `runner.py`: renamed `run_pcb_export_png` -> `run_pcb_export_svg`; switched subcommand to `pcb export svg`, added `--mode-single` and `--fit-page-to-board`, kept `--page-size-mode 2` plus the `--black-and-white`/`--theme` passthrough and the "output exists & non-empty" success check.
- `render_cmd.py`: `RENDER_OUTPUTS` 2D entries -> `pcb-front.svg`/`pcb-back.svg` (3D stays `.png`); updated module docstring; import + call site use `run_pcb_export_svg`.
- `board_metrics_cmd.py`: `RENDER_FILES` 2D entries -> `renders/pcb-front.svg`/`renders/pcb-back.svg`; updated docstring example. `_attach_render_paths` checks on-disk existence so the new paths flow through.
- `site/scripts/copy-renders.mjs`: broadened the render-staging filter from `.png`-only to `.png` || `.svg`; renamed the variable and updated the module docstring.
- `site/src/components/{BoardCard,RenderGallery}.astro`: cosmetic docstring path examples (`.png` -> `.svg`); no logic change — both read paths from `board.json` into `<img src>`, which works for SVG as-is.
- Tests: updated `.png` -> `.svg` assertions for the 2D slots in `test_render_cmd.py`/`test_board_metrics.py` (3D `.png` assertions kept); added `tests/test_runner_export_svg.py` asserting the `pcb export svg --mode-single --fit-page-to-board` invocation.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `kct render <board>` produces non-empty `pcb-front.svg`/`pcb-back.svg` on kicad-cli 10.0.1 | Done | Ran `kct render boards/01-voltage-divider` with KiCad 10.0.1 on PATH; produced `pcb-front.svg` (64 KB) and `pcb-back.svg` (53 KB), both valid SVG headers |
| 3D renders still produce `3d-front.png`/`3d-back.png` | Done | Same run wrote `3d-front.png` / `3d-back.png` (valid PNG, 1568x872) |
| `board.json` references 2D `.svg` paths (3D `.png`) | Done | `kct board-metrics boards/01-voltage-divider --dry-run` emits `pcb_front: renders/pcb-front.svg`, `pcb_back: renders/pcb-back.svg`, 3D `.png` |
| `copy-renders.mjs` stages `.svg`; site shows 2D plots | Done | Filter now matches `.svg`; `node --check` passes; Astro components pass SVG into `<img src>` unchanged |
| Tests updated + green; regression test covers `pcb export svg` invocation | Done | `pytest tests/test_render_cmd.py tests/test_board_metrics.py tests/test_runner_export_svg.py` = 42 passed |

## Test Plan

- `uv run pytest tests/test_render_cmd.py tests/test_board_metrics.py tests/test_runner_export_svg.py` — 42 passed
- `uv run ruff format` + `uv run ruff check` on changed Python — all clean
- `node --check site/scripts/copy-renders.mjs` — OK
- End-to-end on kicad-cli 10.0.1: real SVG (2D) + PNG (3D) produced; board.json renders verified

Closes #3695