### PR TITLE
feat(site): add shared Header/Footer chrome to gallery pages

### DIFF
--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -1,0 +1,103 @@
+---
+/**
+ * Footer — shared site chrome for the kicad-tools demo gallery (issue #3699).
+ *
+ * Rendered at the bottom of every page (index + each board detail). Carries
+ * provenance + attribution: the build-time short git commit hash (linked to
+ * the commit on GitHub), a copyright line, the KiCad trademark/unaffiliated
+ * disclaimer, and a link to kicad.org. Styling reuses the global CSS custom
+ * properties (`--muted`, `--border`, `--accent`) so it stays small + muted.
+ */
+import { execSync } from "node:child_process";
+
+// Capture the short SHA at build time (this frontmatter runs in Node during
+// `astro build`, not in the browser). Fallback chain so `npm run build` NEVER
+// fails outside a git checkout:
+//   1. `git rev-parse --short HEAD` — local builds + deploys from the repo.
+//   2. `GITHUB_SHA` env var (40-char on GitHub Actions) sliced to 7 chars —
+//      CI where git history may be a shallow/unavailable clone.
+//   3. "unknown" — terminal fallback; the footer still renders correctly.
+let sha = "unknown";
+try {
+  sha = execSync("git rev-parse --short HEAD", { encoding: "utf8" }).trim();
+} catch {
+  const envSha = process.env.GITHUB_SHA;
+  if (envSha) sha = envSha.slice(0, 7);
+}
+
+const commitUrl =
+  sha !== "unknown"
+    ? `https://github.com/rjwalters/kicad-tools/commit/${sha}`
+    : "https://github.com/rjwalters/kicad-tools";
+
+// Copyright year is captured at build time; edit the holder name below freely.
+const year = new Date().getFullYear();
+---
+
+<footer class="site-footer">
+  <p class="line">
+    Build:
+    <a href={commitUrl} target="_blank" rel="noopener noreferrer">
+      <code>{sha}</code>
+    </a>
+  </p>
+  <p class="line">© {year} Robb Walters / kicad-tools contributors</p>
+  <p class="line disclaimer">
+    KiCad is a registered trademark of its respective owners; this is an
+    independent community project, not affiliated with or endorsed by the
+    KiCad project.
+  </p>
+  <p class="line">
+    <a href="https://www.kicad.org" target="_blank" rel="noopener noreferrer">
+      kicad.org
+    </a>
+    <span class="sep" aria-hidden="true">·</span>
+    <a
+      href="https://www.kicad.org/community/"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      KiCad community
+    </a>
+  </p>
+</footer>
+
+<style>
+  .site-footer {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 1.5rem 1.25rem 2rem;
+    border-top: 1px solid var(--border);
+    color: var(--muted);
+    font-size: 0.78rem;
+    line-height: 1.6;
+  }
+
+  .line {
+    margin: 0.25rem 0;
+  }
+
+  .disclaimer {
+    max-width: 70ch;
+  }
+
+  .site-footer a {
+    color: var(--accent);
+    text-decoration: none;
+  }
+
+  .site-footer a:hover,
+  .site-footer a:focus-visible {
+    text-decoration: underline;
+    outline: none;
+  }
+
+  .site-footer code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+
+  .sep {
+    margin: 0 0.4rem;
+    color: var(--border);
+  }
+</style>

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -1,0 +1,59 @@
+---
+/**
+ * Header — shared site chrome for the kicad-tools demo gallery (issue #3699).
+ *
+ * Rendered at the top of every page (index + each board detail) by importing
+ * this component into `index.astro` and `[slug].astro`. Carries a "View on
+ * GitHub" link back to the project repo. Styling reuses the global CSS custom
+ * properties (`--accent`, `--border`, `--muted`) declared on `:root` by each
+ * page's `<style is:global>` block, so it inherits the dark theme.
+ */
+const REPO = "https://github.com/rjwalters/kicad-tools";
+---
+
+<header class="site-header">
+  <a class="site-title" href="/">kicad-tools</a>
+  <a
+    class="repo-link"
+    href={REPO}
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    View on GitHub
+  </a>
+</header>
+
+<style>
+  .site-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0.75rem 1.25rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .site-title {
+    color: var(--text);
+    font-weight: 600;
+    font-size: 0.95rem;
+    letter-spacing: 0.01em;
+    text-decoration: none;
+  }
+
+  .repo-link {
+    color: var(--accent);
+    font-size: 0.85rem;
+    text-decoration: none;
+  }
+
+  .repo-link:hover,
+  .repo-link:focus-visible,
+  .site-title:hover,
+  .site-title:focus-visible {
+    text-decoration: underline;
+    outline: none;
+  }
+</style>

--- a/site/src/pages/[slug].astro
+++ b/site/src/pages/[slug].astro
@@ -19,6 +19,8 @@ import { existsSync } from "node:fs";
 import { loadBoards, boardsDir, discoverBoardDirs } from "../data/loadBoards.ts";
 import type { Board } from "../data/types.ts";
 import RenderGallery from "../components/RenderGallery.astro";
+import SiteHeader from "../components/Header.astro";
+import SiteFooter from "../components/Footer.astro";
 
 /**
  * The primary manufacturing download. It is also referenced by
@@ -183,6 +185,7 @@ if (board.manifest_generated_at !== undefined) {
     }
   </head>
   <body>
+    <SiteHeader />
     <main>
       <p class="back-top">
         <a href="/">← Back to gallery</a>
@@ -365,6 +368,7 @@ if (board.manifest_generated_at !== undefined) {
         <a href="/">← Back to gallery</a>
       </footer>
     </main>
+    <SiteFooter />
   </body>
 </html>
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -9,6 +9,8 @@ import { join, resolve } from "node:path";
 import { existsSync } from "node:fs";
 import { loadBoards } from "../data/loadBoards.ts";
 import BoardCard from "../components/BoardCard.astro";
+import SiteHeader from "../components/Header.astro";
+import SiteFooter from "../components/Footer.astro";
 
 const boards = loadBoards();
 const withData = boards.filter((b) => b.status !== "no_artifacts").length;
@@ -42,6 +44,7 @@ const hasPcbFor = (slug: string): boolean =>
     />
   </head>
   <body>
+    <SiteHeader />
     <main>
       <header class="page-header">
         <h1>kicad-tools demo gallery</h1>
@@ -94,6 +97,7 @@ const hasPcbFor = (slug: string): boolean =>
         </section>
       )}
     </main>
+    <SiteFooter />
   </body>
 </html>
 


### PR DESCRIPTION
## Summary
Adds shared site chrome to the Astro gallery so every page links back to the project and carries provenance/attribution. Two new components (`Header.astro`, `Footer.astro`) are adopted by both the index and the per-board detail pages, eliminating duplicated chrome markup.

## Changes
- **`site/src/components/Header.astro`** (new): site title + "View on GitHub" link to `https://github.com/rjwalters/kicad-tools`, near the site title. Uses `--accent`/`--border`/`--text`.
- **`site/src/components/Footer.astro`** (new): build-time short git commit hash linked to `.../commit/<sha>`; copyright line (`© <year> Robb Walters / kicad-tools contributors`, easily editable); KiCad trademark/unaffiliated disclaimer; links to `kicad.org` and the official KiCad community page (`kicad.org/community/`). Small/muted styling via `--muted`/`--border`/`--accent`.
  - SHA captured in Node frontmatter: `execSync("git rev-parse --short HEAD")` → `process.env.GITHUB_SHA?.slice(0,7)` → `"unknown"`, wrapped in try/catch so `npm run build` never fails outside a git checkout.
- **`site/src/pages/index.astro`**: import + `<SiteHeader />` / `<SiteFooter />` inside `<body>`.
- **`site/src/pages/[slug].astro`**: import + `<SiteHeader />` / `<SiteFooter />` inside `<body>` only — no changes to the viewer/KiCanvas markup or render gallery (scope guard for sibling PRs #3700/#3702).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Every page shows a header link to the GitHub repo | ✅ | `grep "View on GitHub"` present in built `dist/index.html` and `dist/00-simple-led/index.html` |
| Footer shows build-time short commit hash linked to the commit | ✅ | Built HTML contains `commit/60d159b0` on both index and detail pages |
| Footer shows copyright + KiCad trademark disclaimer + kicad.org link | ✅ | `grep "registered trademark"` and `www.kicad.org/community/` present in built HTML |
| `npm --prefix site run build` succeeds incl. non-git fallback | ✅ | Build succeeded (10 pages). Non-git build in a `/tmp` copy (no `.git`, no `GITHUB_SHA`) also succeeded; footer commit link fell back to repo root (the `"unknown"` branch) |
| `npm --prefix site test` stays green | ✅ | 15/15 tests pass |
| `npm --prefix site run check` clean | ✅ | 0 errors, 0 warnings (98 pre-existing hints, all in vendored kicanvas.js / unrelated inline script) |
| No duplicated header/footer markup; no generated artifacts committed | ✅ | Single shared component pair; only 4 source files staged, `dist/` and `node_modules/` gitignored |

## Test Plan
- `npm --prefix site run build` — succeeds, 10 pages, footer shows real short SHA `60d159b0`.
- Fallback chain verified in isolation (non-git dir): no env → `"unknown"`; `GITHUB_SHA=<40-char>` → first 7 chars (`abcdef0`); git checkout → real short SHA.
- Full `npm run build` in a non-git copy with no `GITHUB_SHA` → build completes, footer renders without throwing.
- `npm --prefix site test` → 15/15 green.
- `npm --prefix site run check` → 0 errors / 0 warnings.

Closes #3699