### PR TITLE
docs: add kicad-tools.org live demo gallery link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 **Tools for AI agents to work with KiCad projects.**
 
+🌐 **Live demo gallery: [kicad-tools.org](https://kicad-tools.org)** — explore example boards built end-to-end by these tools, with 2D/3D renders, routing & manufacturing metrics, downloadable fabrication packages, and an interactive in-browser PCB viewer.
+
 This project provides standalone Python tools that enable AI agents (LLMs, autonomous coding assistants, etc.) to parse, analyze, and manipulate KiCad schematic and PCB files programmatically. All tools output machine-readable JSON and require no running KiCad instance.
 
 ## Why Agent-Focused?


### PR DESCRIPTION
## Summary

Adds a prominent **Live demo gallery: [kicad-tools.org](https://kicad-tools.org)** callout near the top of the README, just under the tagline.

The gallery showcases example boards built end-to-end by these tools — 2D/3D renders, routing & manufacturing metrics, downloadable fabrication packages, and an interactive in-browser PCB viewer (KiCanvas).

One-line addition; no code changes.