### PR TITLE
fix(gallery): never show "Ready" badge for boards with DRC violations

### DIFF
--- a/site/src/components/BoardCard.astro
+++ b/site/src/components/BoardCard.astro
@@ -12,6 +12,7 @@
  * issue #3681. Until that page exists the link 404s, which is expected.
  */
 import type { Board } from "../data/types.ts";
+import { displayStatus, displayStatusLabel } from "../data/boardStatus.ts";
 
 interface Props {
   board: Board;
@@ -48,15 +49,14 @@ const thumb = thumbnailFor(board);
 const displayName = board.name ?? board.slug;
 const href = `/${board.slug}`;
 
-const STATUS_LABEL: Record<Board["status"], string> = {
-  ok: "Ready",
-  partial: "Partial",
-  no_artifacts: "No artifacts",
-};
-const statusLabel = STATUS_LABEL[board.status];
+// The displayed badge is derived from BOTH status and drc_violations so a
+// board with DRC violations never reads "Ready", regardless of a stale
+// `status` field (#3717).
+const statusVariant = displayStatus(board);
+const statusLabel = displayStatusLabel(board);
 ---
 
-<a class="card" href={href} data-status={board.status}>
+<a class="card" href={href} data-status={statusVariant}>
   <div class="thumb">
     <img
       src={thumb.src}
@@ -67,7 +67,7 @@ const statusLabel = STATUS_LABEL[board.status];
       decoding="async"
       class:list={["thumb-img", { "is-placeholder": thumb.isPlaceholder }]}
     />
-    <span class:list={["chip", `chip-${board.status}`]}>{statusLabel}</span>
+    <span class:list={["chip", `chip-${statusVariant}`]}>{statusLabel}</span>
   </div>
 
   <div class="body">
@@ -190,9 +190,16 @@ const statusLabel = STATUS_LABEL[board.status];
     backdrop-filter: blur(4px);
   }
 
-  .chip-ok {
+  .chip-ready {
     background: rgba(63, 174, 122, 0.9);
     color: #04150d;
+  }
+
+  /* DRC-violation chip (#3717): a distinct red warn tone so a violating board
+     is never confused with the amber "Partial" or green "Ready" states. */
+  .chip-drc {
+    background: rgba(214, 84, 79, 0.92);
+    color: #1c0605;
   }
 
   .chip-partial {

--- a/site/src/data/boardStatus.test.ts
+++ b/site/src/data/boardStatus.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit tests for the display-status helper (issue #3717).
+ *
+ * The displayed gallery badge must read "Ready" ONLY when a board has zero DRC
+ * violations. A board with `drc_violations > 0` must never show "Ready" — even
+ * if its raw `status` field is a stale/over-optimistic "ok".
+ */
+import { describe, expect, it } from "vitest";
+import { displayStatus, displayStatusLabel } from "./boardStatus.ts";
+import type { Board } from "./types.ts";
+
+function makeBoard(overrides: Partial<Board> = {}): Board {
+  return {
+    $schema: "https://kicad-tools.org/schemas/board/v1.json",
+    schema_version: 1,
+    generated_at: "2026-06-15T00:00:00+00:00",
+    slug: "demo",
+    status: "ok",
+    category: "demo",
+    ...overrides,
+  };
+}
+
+describe("displayStatus", () => {
+  it("returns 'ready' for status ok with zero DRC violations", () => {
+    const b = makeBoard({ status: "ok", drc_violations: 0 });
+    expect(displayStatus(b)).toBe("ready");
+    expect(displayStatusLabel(b)).toBe("Ready");
+  });
+
+  it("returns 'ready' for status ok when drc_violations is absent", () => {
+    const b = makeBoard({ status: "ok" });
+    expect(displayStatus(b)).toBe("ready");
+    expect(displayStatusLabel(b)).toBe("Ready");
+  });
+
+  it("never returns 'ready' when drc_violations > 0, even for status ok", () => {
+    const b = makeBoard({ status: "ok", drc_violations: 3 });
+    expect(displayStatus(b)).toBe("drc");
+    expect(displayStatusLabel(b)).not.toBe("Ready");
+    expect(displayStatusLabel(b)).toBe("3 DRC violations");
+  });
+
+  it("singularizes the DRC label for one violation", () => {
+    const b = makeBoard({ status: "partial", drc_violations: 1 });
+    expect(displayStatus(b)).toBe("drc");
+    expect(displayStatusLabel(b)).toBe("1 DRC violation");
+  });
+
+  it("returns 'partial' for status partial with zero DRC violations", () => {
+    const b = makeBoard({ status: "partial", drc_violations: 0 });
+    expect(displayStatus(b)).toBe("partial");
+    expect(displayStatusLabel(b)).toBe("Partial");
+  });
+
+  it("returns 'no_artifacts' for a stub board", () => {
+    const b = makeBoard({ status: "no_artifacts" });
+    expect(displayStatus(b)).toBe("no_artifacts");
+    expect(displayStatusLabel(b)).toBe("No artifacts");
+  });
+});

--- a/site/src/data/boardStatus.ts
+++ b/site/src/data/boardStatus.ts
@@ -1,0 +1,51 @@
+/**
+ * Display-status helper for the gallery status badge (issue #3717).
+ *
+ * The raw `board.status` field ("ok"/"partial"/"no_artifacts") comes from
+ * `kct board-metrics`. The gallery renders `status === "ok"` as a green
+ * "Ready" badge — but "Ready" must mean *manufacturable*, and a board with
+ * `drc_violations > 0` is not manufacturable.
+ *
+ * This module derives the *displayed* badge from BOTH `status` and
+ * `drc_violations` so a stale or over-optimistic `status` can never surface
+ * "Ready" over a violating board. It is defense-in-depth: `board-metrics`
+ * already downgrades `status` away from "ok" when DRC > 0, but the site never
+ * trusts that alone.
+ */
+import type { Board } from "./types.ts";
+
+/** The display variants the status chip / row can take. */
+export type DisplayStatus = "ready" | "drc" | "partial" | "no_artifacts";
+
+/**
+ * Compute the *displayed* status variant for a board.
+ *
+ * Rules:
+ *   - `drc_violations > 0`  → "drc"   (warn-styled, never "Ready")
+ *   - `status === "ok"`     → "ready" (only reachable when DRC is 0/absent)
+ *   - `status === "partial"`→ "partial"
+ *   - else                  → "no_artifacts"
+ */
+export function displayStatus(board: Board): DisplayStatus {
+  if ((board.drc_violations ?? 0) > 0) return "drc";
+  if (board.status === "ok") return "ready";
+  if (board.status === "partial") return "partial";
+  return "no_artifacts";
+}
+
+/** Human-readable label for a display-status variant. */
+export function displayStatusLabel(board: Board): string {
+  const variant = displayStatus(board);
+  switch (variant) {
+    case "ready":
+      return "Ready";
+    case "drc": {
+      const n = board.drc_violations ?? 0;
+      return `${n} DRC violation${n === 1 ? "" : "s"}`;
+    }
+    case "partial":
+      return "Partial";
+    case "no_artifacts":
+      return "No artifacts";
+  }
+}

--- a/site/src/pages/[slug].astro
+++ b/site/src/pages/[slug].astro
@@ -17,6 +17,7 @@
 import { join, resolve } from "node:path";
 import { existsSync } from "node:fs";
 import { loadBoards, boardsDir, discoverBoardDirs } from "../data/loadBoards.ts";
+import { displayStatus, displayStatusLabel } from "../data/boardStatus.ts";
 import type { Board } from "../data/types.ts";
 import RenderGallery from "../components/RenderGallery.astro";
 import SiteHeader from "../components/Header.astro";
@@ -109,11 +110,10 @@ const pcbHref = `/boards/${board.slug}/board.kicad_pcb`;
 const displayName = board.name ?? board.slug;
 const isBuilt = board.status !== "no_artifacts";
 
-const STATUS_LABEL: Record<Board["status"], string> = {
-  ok: "Ready",
-  partial: "Partial",
-  no_artifacts: "No artifacts",
-};
+// Displayed badge derived from BOTH status and drc_violations so a board with
+// DRC violations never reads "Ready", regardless of a stale `status` (#3717).
+const statusVariant = displayStatus(board);
+const statusLabel = displayStatusLabel(board);
 
 const mfgBase = `/boards/${board.slug}/manufacturing`;
 const hasDownloads = hasPrimary || extras.length > 0;
@@ -125,7 +125,7 @@ const hasDownloads = hasPrimary || extras.length > 0;
  */
 type Row = { label: string; value: string; warn?: boolean };
 const rows: Row[] = [];
-rows.push({ label: "Build Status", value: STATUS_LABEL[board.status] });
+rows.push({ label: "Build Status", value: statusLabel, warn: statusVariant === "drc" });
 if (board.nets_routed_pct !== undefined) {
   rows.push({ label: "Nets Routed", value: `${board.nets_routed_pct.toFixed(1)}%` });
 }
@@ -193,8 +193,8 @@ if (board.manifest_generated_at !== undefined) {
 
       <header class="detail-header">
         <h1>{displayName}</h1>
-        <span class:list={["chip", `chip-${board.status}`]}>
-          {STATUS_LABEL[board.status]}
+        <span class:list={["chip", `chip-${statusVariant}`]}>
+          {statusLabel}
         </span>
         {board.description && <p class="desc">{board.description}</p>}
         {board.slug !== displayName && <p class="slug">{board.slug}</p>}
@@ -513,9 +513,16 @@ if (board.manifest_generated_at !== undefined) {
     letter-spacing: 0.02em;
   }
 
-  .chip-ok {
+  .chip-ready {
     background: rgba(63, 174, 122, 0.9);
     color: #04150d;
+  }
+
+  /* DRC-violation chip (#3717): a distinct red warn tone so a violating board
+     is never confused with the amber "Partial" or green "Ready" states. */
+  .chip-drc {
+    background: rgba(214, 84, 79, 0.92);
+    color: #1c0605;
   }
 
   .chip-partial {

--- a/src/kicad_tools/cli/board_metrics_cmd.py
+++ b/src/kicad_tools/cli/board_metrics_cmd.py
@@ -310,9 +310,7 @@ def extract_board_metrics(board_dir: Path) -> dict:
     # zero DRC violations. A board that routed (report parsed) but still has
     # DRC errors is downgraded to "partial" — the gallery treats "ok" as the
     # "Ready" badge, which must never appear over a violating board (#3717).
-    if not report_parsed:
-        metrics["status"] = "partial"
-    elif metrics.get("drc_violations", 0) > 0:
+    if not report_parsed or metrics.get("drc_violations", 0) > 0:
         metrics["status"] = "partial"
     else:
         metrics["status"] = "ok"

--- a/src/kicad_tools/cli/board_metrics_cmd.py
+++ b/src/kicad_tools/cli/board_metrics_cmd.py
@@ -51,10 +51,12 @@ absent or unparseable.
 
 ``status`` is one of:
 
-* ``"ok"``           — ``output/manufacturing/`` exists and ``report.md`` parsed.
+* ``"ok"``           — ``output/manufacturing/`` exists, ``report.md`` parsed,
+                        and ``drc_violations == 0`` (manufacturable).
 * ``"partial"``      — ``output/manufacturing/`` exists but ``report.md`` is
                         absent/unparseable (only identity + whatever fields we
-                        could recover).
+                        could recover), OR ``report.md`` parsed but the board
+                        still has ``drc_violations > 0`` (not manufacturable).
 * ``"no_artifacts"`` — no ``output/manufacturing/`` directory at all.
 
 Schema versioning policy: this schema is the Phase 2 (Astro site) data contract.
@@ -304,7 +306,16 @@ def extract_board_metrics(board_dir: Path) -> dict:
 
     _attach_render_paths(metrics, output_dir)
 
-    metrics["status"] = "ok" if report_parsed else "partial"
+    # `status == "ok"` asserts the board is manufacturable, so it MUST require
+    # zero DRC violations. A board that routed (report parsed) but still has
+    # DRC errors is downgraded to "partial" — the gallery treats "ok" as the
+    # "Ready" badge, which must never appear over a violating board (#3717).
+    if not report_parsed:
+        metrics["status"] = "partial"
+    elif metrics.get("drc_violations", 0) > 0:
+        metrics["status"] = "partial"
+    else:
+        metrics["status"] = "ok"
     return metrics
 
 

--- a/tests/test_board_metrics.py
+++ b/tests/test_board_metrics.py
@@ -54,7 +54,7 @@ author: "kicad-tools 0.13.0"
 
 | Metric | Count |
 |--------|-------|
-| Errors | 14 |
+| Errors | 0 |
 | Warnings | 0 |
 
 ## Routing Status
@@ -132,7 +132,7 @@ def test_extract_full_metrics(tmp_path: Path):
     assert m["board_size_mm"] == {"width": 80.0, "height": 100.0}
     assert m["part_count"] == 55
     assert m["nets_routed_pct"] == 82.1
-    assert m["drc_violations"] == 14
+    assert m["drc_violations"] == 0
     assert m["cost"] == {
         "per_board_usd": 9.16,
         "batch_qty": 5,
@@ -198,6 +198,30 @@ title: "sparse_board"
         assert omitted not in m
     # No DRC Status section -> drc_violations omitted.
     assert "drc_violations" not in m
+
+
+def test_status_downgraded_to_partial_when_drc_violations(tmp_path: Path):
+    # A board whose report parses fine but still has DRC errors is NOT
+    # manufacturable, so status must NOT be "ok" — it downgrades to "partial".
+    # The gallery renders status=="ok" as the "Ready" badge (#3717).
+    drc_report = SAMPLE_REPORT_MD.replace(
+        "| Errors | 0 |",
+        "| Errors | 14 |",
+    )
+    board = _make_board(tmp_path, report=drc_report)
+    m = extract_board_metrics(board)
+
+    assert m["drc_violations"] == 14
+    assert m["status"] == "partial"
+
+
+def test_status_ok_requires_zero_drc(tmp_path: Path):
+    # The mirror case: report parses and drc_violations == 0 -> status "ok".
+    board = _make_board(tmp_path)
+    m = extract_board_metrics(board)
+
+    assert m["drc_violations"] == 0
+    assert m["status"] == "ok"
 
 
 def test_bom_fallback_for_part_count(tmp_path: Path):


### PR DESCRIPTION
## Summary

The demo gallery rendered a green "Ready" badge for any board whose
`board.json` `status == "ok"` — even when the same record reported
`drc_violations > 0`. A board with DRC violations is not manufacturable, so
"Ready" was misleading. This fixes it in two layers (defense-in-depth).

## Changes

- **`kct board-metrics`** (`src/kicad_tools/cli/board_metrics_cmd.py`):
  `status == "ok"` now requires `drc_violations == 0`. A parsed `report.md`
  that still has DRC errors downgrades to `"partial"`. `no_artifacts` is
  unchanged. Updated the module docstring.
- **Website**: new `site/src/data/boardStatus.ts` helper (`displayStatus` /
  `displayStatusLabel`) derives the displayed badge from BOTH `status` and
  `drc_violations`, so a stale/over-optimistic `status` can never surface
  "Ready" over a violating board.
  - `BoardCard.astro` gallery chip and `[slug].astro` detail-page chip + the
    "Build Status" metrics row now use the helper.
  - Added a warn-styled red `chip-drc` variant (distinct from amber "Partial"
    and green "Ready"); the chip reads `"{n} DRC violation(s)"`.
- **Tests**: Python `test_board_metrics.py` gets two new cases
  (`test_status_downgraded_to_partial_when_drc_violations`,
  `test_status_ok_requires_zero_drc`); the shared fixture now reports 0 DRC
  errors so existing "ok" assertions remain valid. New vitest suite
  `boardStatus.test.ts` covers the display-status logic.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `drc_violations > 0` never shows "Ready" (card or detail) and is warn-styled | done | `displayStatus` returns `"drc"` whenever `drc_violations > 0`; both `.astro` files render `chip-drc` (red) and the warn `Build Status` row. Covered by `boardStatus.test.ts`. |
| `drc_violations === 0` + `status: ok` still shows "Ready" | done | `displayStatus` returns `"ready"` only for `status==ok` with 0 DRC. Test: `returns 'ready' for status ok with zero DRC violations`. |
| `board-metrics` sets `status: "ok"` only with 0 DRC violations | done | `test_status_downgraded_to_partial_when_drc_violations` + `test_status_ok_requires_zero_drc`. |
| `npm --prefix site run build` + tests green | done | `astro build` built all 10 pages; `vitest run` 21 passed; `astro check` 0 errors/0 warnings; `uv run pytest tests/test_board_metrics.py` 20 passed. |

## Test Plan

- `uv run pytest tests/test_board_metrics.py` — 20 passed
- `npm --prefix site test` — 21 passed
- `npm --prefix site run build` — 10 pages built
- `npm --prefix site run check` — 0 errors, 0 warnings

Closes #3717