### PR TITLE
feat(export): emit sibling .kicad_pro DRC constraints from manufacturer profile

### DIFF
--- a/src/kicad_tools/audit/net_audit.py
+++ b/src/kicad_tools/audit/net_audit.py
@@ -120,7 +120,7 @@ def find_stale_nets(pcb: PCB) -> list[StaleNetGroup]:
 
         # Sort by total routing (segments + vias), descending. The one with
         # the most routing is "active".
-        scored.sort(key=lambda x: (x[0] + x[1]), reverse=True)
+        scored.sort(key=lambda x: x[0] + x[1], reverse=True)
 
         active_segs, active_vias, active_num, active_name = scored[0]
 

--- a/src/kicad_tools/export/manufacturing.py
+++ b/src/kicad_tools/export/manufacturing.py
@@ -71,6 +71,12 @@ class ManufacturingConfig(AssemblyConfig):
     # When True (default), generate a README.txt explaining the output files.
     include_readme: bool = True
 
+    # When True (default), emit a sibling ``<board>.kicad_pro`` (and
+    # ``.kicad_dru``) next to the source PCB populated from the target
+    # manufacturer profile, so ``kicad-cli pcb drc`` loads the fab's
+    # relaxed built-in minimums instead of KiCad's stricter defaults.
+    emit_drc_constraints: bool = True
+
 
 @dataclass
 class ManufacturingResult:
@@ -84,6 +90,9 @@ class ManufacturingResult:
     manifest_path: Path | None = None
     readme_path: Path | None = None
     image_paths: list[Path] = field(default_factory=list)
+    # Sibling DRC-constraint sources (.kicad_pro / .kicad_dru) written next
+    # to the source board so kicad-cli loads the manufacturer profile.
+    drc_constraint_paths: list[Path] = field(default_factory=list)
     preflight_results: list[PreflightResult] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
@@ -349,6 +358,15 @@ class ManufacturingPackage:
             logger.error(f"Assembly generation failed: {e}")
             return result
 
+        # Step 0a: Emit DRC-constraint sources next to the source board so
+        # that kicad-cli pcb drc (run here in preflight, in CI, or by the
+        # gallery render pipeline) loads the manufacturer profile's relaxed
+        # built-in minimums instead of KiCad's stricter hard-coded defaults.
+        # Written before preflight so the constraints exist even when a
+        # strict-preflight failure aborts the rest of the pipeline.
+        if self.config.emit_drc_constraints:
+            self._write_drc_constraints(result)
+
         # Step 0: Pre-flight validation
         preflight_cfg = self.config.preflight
         if preflight_cfg is None or not preflight_cfg.skip_all:
@@ -449,6 +467,71 @@ class ManufacturingPackage:
             bom_source=self.config.bom_source,
         )
         return checker.run_all()
+
+    def _detect_layer_config(self) -> tuple[int, float]:
+        """Determine (copper-layer count, copper weight) for the board.
+
+        The layer count is read from the PCB so the DRC rules selected
+        from the manufacturer profile match the board (a 4-layer board
+        uses finer via/drill minimums than a 2-layer board).  Copper
+        weight is not encoded in the board file, so it defaults to 1oz.
+
+        Returns:
+            ``(layers, copper_oz)`` -- falls back to ``(2, 1.0)`` when the
+            board cannot be parsed.
+        """
+        try:
+            from ..schema.pcb import PCB
+
+            pcb = PCB.load(str(self.pcb_path))
+            layers = len(pcb.copper_layers)
+            if layers < 1:
+                layers = 2
+        except Exception as e:
+            logger.debug("Could not detect layer count from %s: %s", self.pcb_path, e)
+            layers = 2
+        return layers, 1.0
+
+    def _write_drc_constraints(self, result: ManufacturingResult) -> None:
+        """Emit sibling .kicad_pro / .kicad_dru from the manufacturer profile.
+
+        Populates the project file's ``board.design_settings.rules`` block
+        (and a companion .kicad_dru) from the target manufacturer profile
+        so that ``kicad-cli pcb drc`` checks the board against the fab's
+        actual capabilities rather than KiCad's stricter built-in defaults.
+        """
+        try:
+            from ..manufacturers import get_profile, write_drc_constraints
+
+            profile = get_profile(self.manufacturer)
+        except Exception as e:
+            logger.warning(
+                "Skipping DRC-constraint emission (profile '%s' unavailable): %s",
+                self.manufacturer,
+                e,
+            )
+            result.warnings.append(
+                f"Could not emit DRC constraints for manufacturer '{self.manufacturer}': {e}"
+            )
+            return
+
+        layers, copper_oz = self._detect_layer_config()
+        rules = profile.get_design_rules(layers=layers, copper_oz=copper_oz)
+
+        try:
+            written = write_drc_constraints(
+                self.pcb_path,
+                rules,
+                manufacturer_id=profile.id,
+                layers=layers,
+                copper_oz=copper_oz,
+            )
+        except OSError as e:
+            logger.warning("Could not write DRC-constraint files: %s", e)
+            result.warnings.append(f"Could not write DRC constraints: {e}")
+            return
+
+        result.drc_constraint_paths = written
 
     def _dry_run(self, out_dir: Path, result: ManufacturingResult) -> ManufacturingResult:
         """Populate result with what *would* be generated."""

--- a/src/kicad_tools/manufacturers/__init__.py
+++ b/src/kicad_tools/manufacturers/__init__.py
@@ -35,17 +35,17 @@ from .base import (
     match_rotation_correction,
 )
 from .dru_generator import generate_dru
+from .flashpcb import FLASHPCB_PROFILE
+from .jlcpcb import JLCPCB_PROFILE
+from .jlcpcb_tier1 import JLCPCB_TIER1_PROFILE
+from .oshpark import OSHPARK_PROFILE
+from .pcbway import PCBWAY_PROFILE
 from .project_generator import (
     build_default_netclass,
     build_project_data,
     build_project_rules,
     write_drc_constraints,
 )
-from .flashpcb import FLASHPCB_PROFILE
-from .jlcpcb import JLCPCB_PROFILE
-from .jlcpcb_tier1 import JLCPCB_TIER1_PROFILE
-from .oshpark import OSHPARK_PROFILE
-from .pcbway import PCBWAY_PROFILE
 from .seeed import SEEED_PROFILE
 
 __all__ = [

--- a/src/kicad_tools/manufacturers/__init__.py
+++ b/src/kicad_tools/manufacturers/__init__.py
@@ -35,6 +35,12 @@ from .base import (
     match_rotation_correction,
 )
 from .dru_generator import generate_dru
+from .project_generator import (
+    build_default_netclass,
+    build_project_data,
+    build_project_rules,
+    write_drc_constraints,
+)
 from .flashpcb import FLASHPCB_PROFILE
 from .jlcpcb import JLCPCB_PROFILE
 from .jlcpcb_tier1 import JLCPCB_TIER1_PROFILE
@@ -59,6 +65,10 @@ __all__ = [
     "load_rotation_corrections",
     "match_rotation_correction",
     "generate_dru",
+    "build_default_netclass",
+    "build_project_data",
+    "build_project_rules",
+    "write_drc_constraints",
     # Profiles (for direct access)
     "FLASHPCB_PROFILE",
     "JLCPCB_PROFILE",

--- a/src/kicad_tools/manufacturers/project_generator.py
+++ b/src/kicad_tools/manufacturers/project_generator.py
@@ -1,0 +1,293 @@
+"""
+KiCad project file (.kicad_pro) DRC-constraint generator.
+
+``kicad-cli pcb drc`` auto-loads ``<board>.kicad_pro`` (same basename and
+directory as the ``.kicad_pcb``) and reads its
+``board.design_settings.rules`` block for the *built-in* minimum
+constraints (min track width, min via diameter, min through-hole drill,
+min clearance, ...).  When no project file is present next to the board,
+kicad-cli falls back to KiCad's hard-coded defaults (min track 0.20mm,
+min via Ø0.50mm, min through-hole 0.30mm, min clearance 0.20mm) -- which
+are *stricter* than the capabilities modern fabs (e.g. jlcpcb-tier1)
+actually offer.  The result is hundreds of false ``track_width`` /
+``via_diameter`` / ``drill_out_of_range`` / ``clearance`` errors on boards
+that are genuinely manufacturable.
+
+This module builds the ``design_settings.rules`` block from a
+:class:`~kicad_tools.manufacturers.base.DesignRules` instance so the
+emitted project file relaxes the built-in minimums to the target
+manufacturer profile.  A ``.kicad_dru`` (generated separately by
+:func:`~kicad_tools.manufacturers.dru_generator.generate_dru`) is *not*
+sufficient on its own: KiCad applies the *most restrictive* of built-in +
+custom rules, so a custom ``track_width min 0.15`` will not relax the
+built-in 0.20 default -- the built-in minimum lives in
+``design_settings.rules`` and must be set there.
+
+Usage::
+
+    from kicad_tools.manufacturers import get_profile
+    from kicad_tools.manufacturers.project_generator import (
+        build_project_rules,
+        write_drc_constraints,
+    )
+
+    profile = get_profile("jlcpcb-tier1")
+    rules = profile.get_design_rules(layers=4, copper_oz=1.0)
+    pro_dict = build_project_rules(rules)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .base import DesignRules
+
+# Severities for DRC rule categories that are *not* manufacturability
+# blockers.  ``lib_footprint_mismatch`` is a library-sync artifact (the
+# board's embedded footprint differs from the on-disk library copy) and
+# ``isolated_copper`` is a cosmetic zone-island warning -- neither stops a
+# fab from building the board, so they must not read as blocking errors.
+_NON_BLOCKING_SEVERITIES: dict[str, str] = {
+    "lib_footprint_mismatch": "ignore",
+    "isolated_copper": "warning",
+}
+
+
+def build_default_netclass(rules: DesignRules) -> dict:
+    """Build the ``Default`` netclass entry for ``net_settings.classes``.
+
+    KiCad's ``clearance`` DRC test uses the *applied* netclass clearance
+    (not ``design_settings.rules.min_clearance``, which only bounds the
+    minimum a netclass may declare).  When the board carries no netclass
+    of its own, kicad-cli falls back to the project's ``Default`` netclass
+    -- whose stock clearance is 0.20mm.  Setting it from the profile here
+    is what actually silences the false ``clearance`` errors on boards
+    routed to tighter fab capabilities.
+
+    Args:
+        rules: Manufacturer design rules to translate.
+
+    Returns:
+        A KiCad ``Default`` netclass definition dict.
+    """
+    return {
+        "bus_width": 12,
+        "clearance": rules.min_clearance_mm,
+        "diff_pair_gap": 0.25,
+        "diff_pair_via_gap": 0.25,
+        "diff_pair_width": rules.min_trace_width_mm,
+        "line_style": 0,
+        "microvia_diameter": rules.min_via_diameter_mm,
+        "microvia_drill": rules.min_via_drill_mm,
+        "name": "Default",
+        "pcb_color": "rgba(0, 0, 0, 0.000)",
+        "schematic_color": "rgba(0, 0, 0, 0.000)",
+        "track_width": rules.min_trace_width_mm,
+        "via_diameter": rules.min_via_diameter_mm,
+        "via_drill": rules.min_via_drill_mm,
+        "wire_width": 6,
+    }
+
+
+def build_project_rules(rules: DesignRules) -> dict[str, float]:
+    """Build the ``board.design_settings.rules`` mapping from a profile.
+
+    Maps :class:`DesignRules` fields onto the KiCad project schema keys
+    that ``kicad-cli pcb drc`` reads as built-in minimum constraints.
+
+    Args:
+        rules: Manufacturer design rules to translate.
+
+    Returns:
+        Dict suitable for ``project["board"]["design_settings"]["rules"]``.
+    """
+    return {
+        "min_clearance": rules.min_clearance_mm,
+        "min_track_width": rules.min_trace_width_mm,
+        "min_via_diameter": rules.min_via_diameter_mm,
+        "min_via_annular_width": rules.min_annular_ring_mm,
+        "min_through_hole_diameter": rules.min_hole_diameter_mm,
+        "min_via_hole": rules.min_via_drill_mm,
+        "min_hole_to_hole": rules.min_hole_to_edge_mm,
+        "min_copper_edge_clearance": rules.min_copper_to_edge_mm,
+        "min_silk_clearance": rules.min_solder_mask_clearance_mm,
+        "min_text_thickness": rules.min_silkscreen_width_mm,
+        "min_text_height": rules.min_silkscreen_height_mm,
+    }
+
+
+def build_project_data(
+    rules: DesignRules,
+    project_name: str,
+    manufacturer_id: str = "",
+    layers: int | None = None,
+    copper_oz: float | None = None,
+) -> dict:
+    """Build a complete minimal ``.kicad_pro`` dict with DRC constraints.
+
+    The returned project carries the ``board.design_settings.rules`` block
+    (relaxing KiCad's built-in minimums to the profile) plus
+    ``rule_severities`` that downgrade non-manufacturability noise.
+
+    Args:
+        rules: Manufacturer design rules to translate.
+        project_name: Base name (without extension) recorded in ``meta``.
+        manufacturer_id: Optional manufacturer id stored in ``meta``.
+        layers: Optional copper-layer count stored in ``meta``.
+        copper_oz: Optional copper weight stored in ``meta``.
+
+    Returns:
+        Project data dict ready to be JSON-serialized to ``.kicad_pro``.
+    """
+    meta: dict = {"filename": f"{project_name}.kicad_pro", "version": 1}
+    if manufacturer_id:
+        meta["manufacturer"] = manufacturer_id
+    if layers is not None:
+        meta["layers"] = layers
+    if copper_oz is not None:
+        meta["copper_oz"] = copper_oz
+
+    return {
+        "meta": meta,
+        "board": {
+            "design_settings": {
+                "rules": build_project_rules(rules),
+                "rule_severities": dict(_NON_BLOCKING_SEVERITIES),
+                "defaults": {
+                    "track_min_width": rules.min_trace_width_mm,
+                    "clearance_min": rules.min_clearance_mm,
+                    "via_min_diameter": rules.min_via_diameter_mm,
+                    "via_min_drill": rules.min_via_drill_mm,
+                },
+            }
+        },
+        "net_settings": {
+            "classes": [build_default_netclass(rules)],
+            "meta": {"version": 3},
+        },
+        "schematic": {"meta": {"version": 1}},
+        "sheets": [],
+        "text_variables": {},
+    }
+
+
+def merge_project_rules(
+    project_data: dict,
+    rules: DesignRules,
+) -> dict:
+    """Apply DRC constraints + severities onto an existing project dict.
+
+    Preserves any unrelated keys already present in the project file and
+    only overwrites the constraint/severity entries this module owns.
+
+    Args:
+        project_data: Parsed ``.kicad_pro`` data (mutated in place).
+        rules: Manufacturer design rules to apply.
+
+    Returns:
+        The same ``project_data`` dict, mutated.
+    """
+    board = project_data.setdefault("board", {})
+    settings = board.setdefault("design_settings", {})
+
+    settings.setdefault("rules", {}).update(build_project_rules(rules))
+
+    severities = settings.setdefault("rule_severities", {})
+    severities.update(_NON_BLOCKING_SEVERITIES)
+
+    defaults = settings.setdefault("defaults", {})
+    defaults["track_min_width"] = rules.min_trace_width_mm
+    defaults["clearance_min"] = rules.min_clearance_mm
+    defaults["via_min_diameter"] = rules.min_via_diameter_mm
+    defaults["via_min_drill"] = rules.min_via_drill_mm
+
+    # Relax the applied Default-netclass clearance/track/via to the profile
+    # so the kicad-cli ``clearance`` test (which reads the applied netclass
+    # clearance, not min_clearance) does not flag the stock 0.20mm default.
+    net_settings = project_data.setdefault("net_settings", {})
+    classes = net_settings.setdefault("classes", [])
+    default_cls = next((c for c in classes if c.get("name") == "Default"), None)
+    if default_cls is None:
+        classes.insert(0, build_default_netclass(rules))
+    else:
+        default_cls["clearance"] = rules.min_clearance_mm
+        default_cls["track_width"] = rules.min_trace_width_mm
+        default_cls["via_diameter"] = rules.min_via_diameter_mm
+        default_cls["via_drill"] = rules.min_via_drill_mm
+
+    return project_data
+
+
+def write_drc_constraints(
+    pcb_path: str | Path,
+    rules: DesignRules,
+    *,
+    manufacturer_id: str = "",
+    layers: int | None = None,
+    copper_oz: float | None = None,
+    write_dru: bool = True,
+) -> list[Path]:
+    """Emit DRC-constraint sources next to a routed ``.kicad_pcb``.
+
+    Writes (or updates) ``<board>.kicad_pro`` so ``kicad-cli pcb drc``
+    auto-loads the relaxed built-in minimums, and -- by default -- a
+    companion ``<board>.kicad_dru`` for the rule families the project
+    schema can't express.  An existing ``.kicad_pro`` is preserved and
+    only the constraint/severity entries are overwritten.
+
+    Args:
+        pcb_path: Path to the routed board.
+        rules: Manufacturer design rules to translate.
+        manufacturer_id: Optional manufacturer id (for ``.kicad_pro`` meta
+            and ``.kicad_dru`` labels).
+        layers: Optional copper-layer count (stored in ``meta``).
+        copper_oz: Optional copper weight (stored in ``meta``).
+        write_dru: When True (default), also emit the ``.kicad_dru``.
+
+    Returns:
+        List of paths written.
+    """
+    pcb_path = Path(pcb_path)
+    project_name = pcb_path.stem
+    pro_path = pcb_path.with_suffix(".kicad_pro")
+    written: list[Path] = []
+
+    if pro_path.exists():
+        try:
+            project_data = json.loads(pro_path.read_text(encoding="utf-8"))
+            merge_project_rules(project_data, rules)
+            if manufacturer_id:
+                project_data.setdefault("meta", {})["manufacturer"] = manufacturer_id
+        except (json.JSONDecodeError, OSError):
+            # Corrupt/unreadable existing project -- overwrite cleanly.
+            project_data = build_project_data(
+                rules,
+                project_name,
+                manufacturer_id=manufacturer_id,
+                layers=layers,
+                copper_oz=copper_oz,
+            )
+    else:
+        project_data = build_project_data(
+            rules,
+            project_name,
+            manufacturer_id=manufacturer_id,
+            layers=layers,
+            copper_oz=copper_oz,
+        )
+
+    pro_path.write_text(json.dumps(project_data, indent=2), encoding="utf-8")
+    written.append(pro_path)
+
+    if write_dru:
+        from .dru_generator import generate_dru
+
+        dru_path = pcb_path.with_suffix(".kicad_dru")
+        dru_path.write_text(
+            generate_dru(rules, manufacturer_name=manufacturer_id),
+            encoding="utf-8",
+        )
+        written.append(dru_path)
+
+    return written

--- a/src/kicad_tools/router/algorithms/mst.py
+++ b/src/kicad_tools/router/algorithms/mst.py
@@ -160,8 +160,10 @@ class MSTRouter:
                 # Build and sort MST edges by length
                 edges = self.build_mst(pad_objs)
                 edges.sort(
-                    key=lambda e: abs(pad_objs[e[0]].x - pad_objs[e[1]].x)
-                    + abs(pad_objs[e[0]].y - pad_objs[e[1]].y)
+                    key=lambda e: (
+                        abs(pad_objs[e[0]].x - pad_objs[e[1]].x)
+                        + abs(pad_objs[e[0]].y - pad_objs[e[1]].y)
+                    )
                 )
 
             # Issue #3485: cumulative per-net deadline.  ``per_net_timeout``

--- a/tests/router/test_initial_pass_grace.py
+++ b/tests/router/test_initial_pass_grace.py
@@ -87,7 +87,7 @@ class TestRunInitialPassGraceHelper:
         committed: dict[int, list] = {}
         routed, attempted, skipped = run_initial_pass_grace(
             [1, 2, 3],
-            route_fn=lambda net, cap: (calls.append((net, cap)) or [f"r{net}"]),
+            route_fn=lambda net, cap: calls.append((net, cap)) or [f"r{net}"],
             commit_fn=lambda net, routes: committed.__setitem__(net, routes),
             per_net_timeout=30.0,
         )
@@ -121,7 +121,7 @@ class TestRunInitialPassGraceHelper:
         seen_caps: set[float] = set()
         run_initial_pass_grace(
             [1],
-            route_fn=lambda net, cap: (seen_caps.add(cap) or []),
+            route_fn=lambda net, cap: seen_caps.add(cap) or [],
             commit_fn=lambda net, routes: None,
             per_net_timeout=0.1,
         )

--- a/tests/test_drc_constraints_export.py
+++ b/tests/test_drc_constraints_export.py
@@ -1,0 +1,244 @@
+"""
+Tests for DRC-constraint emission on manufacturing export (issue #3719).
+
+``kct export`` must write a sibling ``<board>.kicad_pro`` (and
+``.kicad_dru``) next to the source board, populated from the target
+manufacturer profile, so that ``kicad-cli pcb drc`` checks the board
+against the fab's actual capabilities instead of KiCad's stricter
+built-in defaults.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.manufacturers import (
+    build_default_netclass,
+    build_project_data,
+    build_project_rules,
+    get_profile,
+    write_drc_constraints,
+)
+from kicad_tools.manufacturers.project_generator import (
+    _NON_BLOCKING_SEVERITIES,
+    merge_project_rules,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BOARD_03 = REPO_ROOT / "boards/03-usb-joystick/output/usb_joystick_routed.kicad_pcb"
+
+
+# ---------------------------------------------------------------------------
+# build_project_rules: values come from the profile, not hardcoded
+# ---------------------------------------------------------------------------
+
+
+def test_project_rules_match_profile_minimums():
+    profile = get_profile("jlcpcb-tier1")
+    rules = profile.get_design_rules(layers=4, copper_oz=1.0)
+
+    pro_rules = build_project_rules(rules)
+
+    assert pro_rules["min_track_width"] == rules.min_trace_width_mm
+    assert pro_rules["min_clearance"] == rules.min_clearance_mm
+    assert pro_rules["min_via_diameter"] == rules.min_via_diameter_mm
+    assert pro_rules["min_via_hole"] == rules.min_via_drill_mm
+    assert pro_rules["min_through_hole_diameter"] == rules.min_hole_diameter_mm
+    assert pro_rules["min_via_annular_width"] == rules.min_annular_ring_mm
+    assert pro_rules["min_copper_edge_clearance"] == rules.min_copper_to_edge_mm
+    assert pro_rules["min_hole_to_hole"] == rules.min_hole_to_edge_mm
+
+
+def test_project_rules_change_with_layer_config():
+    """A 4-layer profile selects finer via/drill minimums than 2-layer."""
+    profile = get_profile("jlcpcb-tier1")
+    rules_2l = profile.get_design_rules(layers=2, copper_oz=1.0)
+    rules_4l = profile.get_design_rules(layers=4, copper_oz=1.0)
+
+    pro_2l = build_project_rules(rules_2l)
+    pro_4l = build_project_rules(rules_4l)
+
+    # 4-layer JLCPCB allows smaller vias/holes than 2-layer
+    assert pro_4l["min_via_diameter"] < pro_2l["min_via_diameter"]
+    assert pro_4l["min_via_hole"] < pro_2l["min_via_hole"]
+
+
+def test_project_rules_differ_by_manufacturer():
+    """Changing --mfr changes the emitted rules (not hardcoded)."""
+    jlc = get_profile("jlcpcb").get_design_rules(layers=2)
+    osh = get_profile("oshpark").get_design_rules(layers=2)
+
+    jlc_rules = build_project_rules(jlc)
+    osh_rules = build_project_rules(osh)
+
+    # The two fabs have different capabilities; at least one constraint
+    # must differ between the emitted rule sets.
+    assert jlc_rules != osh_rules
+
+
+# ---------------------------------------------------------------------------
+# Default netclass clearance (the load-bearing fix for false clearance errors)
+# ---------------------------------------------------------------------------
+
+
+def test_default_netclass_clearance_from_profile():
+    profile = get_profile("jlcpcb-tier1")
+    rules = profile.get_design_rules(layers=4, copper_oz=1.0)
+
+    nc = build_default_netclass(rules)
+
+    assert nc["name"] == "Default"
+    # The applied netclass clearance must reflect the profile, not KiCad's
+    # stock 0.20mm default.
+    assert nc["clearance"] == rules.min_clearance_mm
+    assert nc["track_width"] == rules.min_trace_width_mm
+    assert nc["via_diameter"] == rules.min_via_diameter_mm
+
+
+def test_build_project_data_structure():
+    profile = get_profile("jlcpcb-tier1")
+    rules = profile.get_design_rules(layers=4, copper_oz=1.0)
+
+    data = build_project_data(
+        rules, "myboard", manufacturer_id="jlcpcb-tier1", layers=4, copper_oz=1.0
+    )
+
+    ds = data["board"]["design_settings"]
+    assert ds["rules"]["min_clearance"] == rules.min_clearance_mm
+    assert ds["rule_severities"] == _NON_BLOCKING_SEVERITIES
+    assert data["net_settings"]["classes"][0]["clearance"] == rules.min_clearance_mm
+    assert data["meta"]["manufacturer"] == "jlcpcb-tier1"
+
+
+# ---------------------------------------------------------------------------
+# rule_severities downgrade non-blocking categories
+# ---------------------------------------------------------------------------
+
+
+def test_non_blocking_severities_downgraded():
+    profile = get_profile("jlcpcb-tier1")
+    rules = profile.get_design_rules(layers=2)
+    data = build_project_data(rules, "b")
+
+    sev = data["board"]["design_settings"]["rule_severities"]
+    assert sev["lib_footprint_mismatch"] == "ignore"
+    assert sev["isolated_copper"] == "warning"
+
+
+# ---------------------------------------------------------------------------
+# merge preserves an existing project's unrelated keys
+# ---------------------------------------------------------------------------
+
+
+def test_merge_preserves_existing_keys_and_relaxes_default_clearance():
+    profile = get_profile("jlcpcb-tier1")
+    rules = profile.get_design_rules(layers=4)
+
+    existing = {
+        "meta": {"filename": "b.kicad_pro"},
+        "board": {
+            "design_settings": {
+                "rules": {"some_other_rule": 1.23},
+                "defaults": {},
+            }
+        },
+        "net_settings": {
+            "classes": [
+                {"name": "Default", "clearance": 0.20, "track_width": 0.25},
+                {"name": "HV", "clearance": 0.5},
+            ]
+        },
+        "custom_top_level": {"keep": True},
+    }
+
+    merge_project_rules(existing, rules)
+
+    ds = existing["board"]["design_settings"]
+    # Unrelated rule preserved
+    assert ds["rules"]["some_other_rule"] == 1.23
+    # Profile rule applied
+    assert ds["rules"]["min_clearance"] == rules.min_clearance_mm
+    # Default netclass clearance relaxed to the profile
+    default_cls = next(c for c in existing["net_settings"]["classes"] if c["name"] == "Default")
+    assert default_cls["clearance"] == rules.min_clearance_mm
+    # Other netclass untouched
+    hv = next(c for c in existing["net_settings"]["classes"] if c["name"] == "HV")
+    assert hv["clearance"] == 0.5
+    # Unrelated top-level key preserved
+    assert existing["custom_top_level"] == {"keep": True}
+
+
+# ---------------------------------------------------------------------------
+# write_drc_constraints writes siblings next to the board
+# ---------------------------------------------------------------------------
+
+
+def test_write_drc_constraints_emits_siblings(tmp_path: Path):
+    board = tmp_path / "demo.kicad_pcb"
+    board.write_text("(kicad_pcb)")  # content irrelevant for this helper
+
+    profile = get_profile("jlcpcb-tier1")
+    rules = profile.get_design_rules(layers=4)
+
+    written = write_drc_constraints(board, rules, manufacturer_id="jlcpcb-tier1", layers=4)
+
+    pro = board.with_suffix(".kicad_pro")
+    dru = board.with_suffix(".kicad_dru")
+    assert pro in written and pro.exists()
+    assert dru in written and dru.exists()
+
+    data = json.loads(pro.read_text())
+    assert data["board"]["design_settings"]["rules"]["min_clearance"] == rules.min_clearance_mm
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: kct export emits a sibling .kicad_pro reflecting the profile
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not BOARD_03.exists(), reason="board 03 routed PCB not available")
+def test_export_emits_sibling_kicad_pro(tmp_path: Path):
+    from kicad_tools.export.manufacturing import (
+        ManufacturingConfig,
+        ManufacturingPackage,
+    )
+    from kicad_tools.export.preflight import PreflightConfig
+
+    board = tmp_path / "usb_joystick_routed.kicad_pcb"
+    shutil.copy(BOARD_03, board)
+
+    config = ManufacturingConfig(
+        output_dir=tmp_path / "manufacturing",
+        include_bom=False,
+        include_pnp=False,
+        include_gerbers=False,
+        include_report=False,
+        include_project_zip=False,
+        include_readme=False,
+        include_manifest=False,
+        preflight=PreflightConfig(skip_drc=True, skip_erc=True),
+    )
+
+    pkg = ManufacturingPackage(
+        pcb_path=board,
+        manufacturer="jlcpcb-tier1",
+        config=config,
+    )
+    result = pkg.export(config.output_dir)
+
+    pro = board.with_suffix(".kicad_pro")
+    assert pro.exists(), "export must write a sibling .kicad_pro next to the board"
+    assert pro in result.drc_constraint_paths
+
+    data = json.loads(pro.read_text())
+    rules = get_profile("jlcpcb-tier1").get_design_rules(layers=2, copper_oz=1.0)
+    pro_rules = data["board"]["design_settings"]["rules"]
+    # Board 03 is 2-layer -> 2-layer profile minimums.
+    assert pro_rules["min_track_width"] == rules.min_trace_width_mm
+    assert pro_rules["min_clearance"] == rules.min_clearance_mm
+    assert pro_rules["min_via_diameter"] == rules.min_via_diameter_mm
+    assert data["net_settings"]["classes"][0]["clearance"] == rules.min_clearance_mm


### PR DESCRIPTION
## Summary

Generated/exported boards shipped no `.kicad_pro` and no `.kicad_dru` next to the routed `.kicad_pcb`, so `kicad-cli pcb drc` fell back to KiCad's stricter built-in defaults (min track 0.20mm, via Ø0.50mm, through-hole 0.30mm, clearance 0.20mm) and emitted hundreds of false `track_width` / `via_diameter` / `drill_out_of_range` / `clearance` errors on boards that are genuinely manufacturable at the target fab's capabilities (e.g. jlcpcb-tier1).

`kct export` now emits a sibling `<board>.kicad_pro` (plus `.kicad_dru`) next to the source board, populated **from the `--mfr` profile**, so kicad-cli loads the fab's relaxed built-in minimums.

## Changes

- New `src/kicad_tools/manufacturers/project_generator.py`:
  - `build_project_rules()` maps `DesignRules` fields onto the `board.design_settings.rules` keys (`min_track_width`, `min_clearance`, `min_via_diameter`, `min_via_hole`, `min_through_hole_diameter`, `min_hole_to_hole`, `min_copper_edge_clearance`, ...).
  - `build_default_netclass()` sets the **applied** Default-netclass clearance from the profile — this is the load-bearing fix for the false `clearance` errors, since kicad-cli's clearance test reads the netclass clearance (stock 0.20mm), not `min_clearance`.
  - `rule_severities` downgrades `lib_footprint_mismatch` (ignore) and `isolated_copper` (warning) so they don't read as blocking errors.
  - `write_drc_constraints()` writes the siblings, merging into an existing `.kicad_pro` without clobbering unrelated keys.
- `export/manufacturing.py`: new `_write_drc_constraints` / `_detect_layer_config` step (default-on via `emit_drc_constraints`) runs before preflight; design rules are selected by the board's **actual copper-layer count** (a 4-layer board gets finer via/drill minimums than 2-layer).
- New test file `tests/test_drc_constraints_export.py`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Routed board has sibling `.kicad_pro` reflecting `--mfr` profile | done | `kct export ... --mfr jlcpcb-tier1` writes `<board>.kicad_pro` + `.kicad_dru`; rules match profile minimums |
| kicad-cli no longer reports default-rule-mismatch track/via/drill/clearance errors | done | See before/after table below |
| Boards 01 & 02 stay at 0 kicad-cli errors | done | 0 -> 0 on both |
| Values come from the profile (changing `--mfr` changes rules) | done | `--mfr oshpark` -> via Ø0.508; `--mfr jlcpcb-tier1` -> via Ø0.45 |
| `lib_footprint_mismatch` / `isolated_copper` downgraded | done | `rule_severities` block in generated `.kicad_pro` |
| Test asserts exported `.kicad_pro` rules match profile minimums | done | `test_export_emits_sibling_kicad_pro` + unit tests |

## Before / After (kicad-cli 10.0.1 `pcb drc --severity-error`)

| Board | Before | After | Eliminated (false) | Remaining (genuine) |
|---|---|---|---|---|
| 01-voltage-divider | 0 | 0 | — | — |
| 02-charlieplex-led | 0 | 0 | — | — |
| 03-usb-joystick | 68 | 10 | track_width 58 | starved_thermal 10 |
| 06-diffpair-test | 360 | 6 | drill 172, via 135, track 36, clearance 11 | clearance 4 (real shorts/zone), track_width 2 (real 0.100mm < 0.1016) |
| 07-matchgroup-test | 688 | 71 | track 199, drill 184, via 184 | shorts, mask-bridges, crossing tracks |
| softstart | 229 | 10 | track 107, drill 49, via 49 | shorts, mask-bridges, starved_thermal |

## Test Plan

- `pytest tests/test_drc_constraints_export.py` — 9 passed
- `pytest tests/test_pcb_manufacturing_export.py tests/test_init_cmd.py tests/test_mfr.py tests/test_export_extended.py` — 182 passed, 2 skipped
- Manual: exported boards 01/02/03/06/07/softstart to /tmp and ran kicad-cli DRC (table above)

Closes #3719