### PR TITLE
feat(audit): count kicad-cli geometric DRC in manufacturing report

### DIFF
--- a/src/kicad_tools/audit/auditor.py
+++ b/src/kicad_tools/audit/auditor.py
@@ -895,9 +895,7 @@ class ManufacturingAudit:
 
                 top = sorted(cli_summary.items(), key=lambda x: -x[1])[:3]
                 cli_detail = "kicad-cli: " + ", ".join(f"{t} ({c})" for t, c in top)
-                status.details = (
-                    f"{status.details}; {cli_detail}" if status.details else cli_detail
-                )
+                status.details = f"{status.details}; {cli_detail}" if status.details else cli_detail
         except subprocess.TimeoutExpired:
             note = "kicad-cli DRC timed out (geometric DRC skipped)"
             status.details = f"{status.details}; {note}" if status.details else note

--- a/src/kicad_tools/audit/auditor.py
+++ b/src/kicad_tools/audit/auditor.py
@@ -795,7 +795,119 @@ class ManufacturingAudit:
             status.details = str(e)
             status.passed = True  # Don't fail on check errors
 
+        # Merge KiCad's geometric DRC (kicad-cli pcb drc) into the same
+        # status.  The two engines catch different real defects: the --mfr
+        # rule engine above catches manufacturer-capability violations
+        # (e.g. clearance_pad_zone), while kicad-cli catches geometric
+        # defects (starved_thermal, shorts, sub-spec traces, zones_intersect)
+        # that the rule engine does not.  A board is manufacturable only
+        # when BOTH report zero errors (issue #3721).
+        self._merge_geometric_drc(status)
+
         return status
+
+    def _merge_geometric_drc(self, status: DRCStatus) -> None:
+        """Run ``kicad-cli pcb drc`` and fold its errors into ``status``.
+
+        kicad-cli loads the sibling ``<board>.kicad_pro`` emitted by
+        ``kct export`` (issue #3720), so a ``--severity-error`` run checks
+        against the manufacturer's fab-accurate rules with
+        ``lib_footprint_mismatch`` / ``isolated_copper`` already downgraded
+        below error severity (they will not appear and so are not counted
+        as blocking).
+
+        Counts are *additive* on top of the ``--mfr`` engine's tally:
+        ``error_count`` / ``blocking_count`` grow by the kicad-cli error
+        count, and each kicad-cli violation type is recorded in
+        ``violations_by_type`` under a ``kicad-cli:`` namespace so it is
+        clearly attributed to the geometric engine and never collides with
+        a ``--mfr`` rule_id.
+
+        Graceful fallback: if kicad-cli is not on PATH (e.g. CI without
+        KiCad), the report still generates -- a note is appended to
+        ``status.details`` and only the ``--mfr`` count stands.  The
+        ``status`` is mutated in place; this method never raises.
+        """
+        import tempfile
+
+        from kicad_tools.cli.runner import find_kicad_cli
+
+        kicad_cli = find_kicad_cli()
+        if kicad_cli is None:
+            note = "kicad-cli not found; geometric DRC skipped (--mfr count only)"
+            status.details = f"{status.details}; {note}" if status.details else note
+            return
+
+        report_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+                report_path = Path(f.name)
+
+            # kicad-cli loads the sibling .kicad_pro automatically from the
+            # board's directory/stem, so the fab-accurate rules apply.
+            # --severity-error restricts the report to error-severity
+            # violations, which (per the emitted .kicad_pro rule_severities)
+            # already excludes lib_footprint_mismatch / isolated_copper.
+            cmd = [
+                str(kicad_cli),
+                "pcb",
+                "drc",
+                "--format",
+                "json",
+                "--severity-error",
+                "--units",
+                "mm",
+                "--output",
+                str(report_path),
+                str(self.pcb_path),
+            ]
+            subprocess.run(cmd, capture_output=True, timeout=120, check=False)
+
+            if report_path is None or not report_path.exists():
+                note = "kicad-cli produced no DRC report (geometric DRC skipped)"
+                status.details = f"{status.details}; {note}" if status.details else note
+                return
+
+            from kicad_tools.drc import DRCReport
+
+            report = DRCReport.load(report_path)
+
+            # --severity-error already filters to errors, but guard defensively
+            # in case a future kicad-cli emits mixed severities.
+            cli_errors = [v for v in report.violations if v.is_error]
+            cli_error_count = len(cli_errors)
+
+            if cli_error_count > 0:
+                status.error_count += cli_error_count
+                status.blocking_count += cli_error_count
+                status.passed = status.blocking_count == 0
+
+                # Record per-type counts under a kicad-cli namespace so the
+                # report's by-type table makes the engine explicit and the
+                # geometric types never collide with --mfr rule_ids.
+                by_type = status.violations_by_type
+                cli_summary: dict[str, int] = {}
+                for v in cli_errors:
+                    key = f"kicad-cli:{v.type_str}"
+                    by_type[key] = by_type.get(key, 0) + 1
+                    cli_summary[v.type_str] = cli_summary.get(v.type_str, 0) + 1
+                status.violations_by_type = by_type
+
+                top = sorted(cli_summary.items(), key=lambda x: -x[1])[:3]
+                cli_detail = "kicad-cli: " + ", ".join(f"{t} ({c})" for t, c in top)
+                status.details = (
+                    f"{status.details}; {cli_detail}" if status.details else cli_detail
+                )
+        except subprocess.TimeoutExpired:
+            note = "kicad-cli DRC timed out (geometric DRC skipped)"
+            status.details = f"{status.details}; {note}" if status.details else note
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning("Geometric DRC (kicad-cli) failed: %s", e)
+            note = f"geometric DRC failed: {e}"
+            status.details = f"{status.details}; {note}" if status.details else note
+        finally:
+            if report_path is not None:
+                report_path.unlink(missing_ok=True)
 
     def _check_connectivity(self, pcb: PCB) -> ConnectivityStatus:
         """Check net connectivity.

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -68,6 +68,167 @@ class TestDRCStatusViolationsByType:
         assert "violations_by_type" not in d
 
 
+class _FakeCliViolation:
+    """Minimal stand-in for a kicad-cli DRCViolation (error severity)."""
+
+    def __init__(self, type_str: str, is_error: bool = True):
+        self.type_str = type_str
+        self.is_error = is_error
+
+
+class _FakeCliReport:
+    """Minimal stand-in for drc.DRCReport with only ``violations``."""
+
+    def __init__(self, violations):
+        self.violations = violations
+
+
+class TestMergeGeometricDrc:
+    """Tests for ManufacturingAudit._merge_geometric_drc (issue #3721).
+
+    The combined-count logic is exercised by mocking both engines' outputs
+    so the test never requires kicad-cli to be installed.
+    """
+
+    def _make_audit(self, tmp_path):
+        """Build an audit instance without running anything."""
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+        return ManufacturingAudit(pcb, manufacturer="jlcpcb")
+
+    def _patch_cli(self, monkeypatch, *, cli_violations, found=True):
+        """Patch kicad-cli discovery, subprocess, and report parsing.
+
+        When ``found`` is False, simulates kicad-cli missing from PATH.
+        Otherwise ``cli_violations`` is returned from DRCReport.load.
+        """
+        from kicad_tools import drc as drc_mod
+        from kicad_tools.audit import auditor as auditor_mod
+        from kicad_tools.cli import runner as runner_mod
+
+        # _merge_geometric_drc imports find_kicad_cli from cli.runner at call
+        # time, so patch the source module.
+        monkeypatch.setattr(
+            runner_mod,
+            "find_kicad_cli",
+            lambda: (Path("/fake/kicad-cli") if found else None),
+        )
+
+        def _fake_run(cmd, *args, **kwargs):
+            # Materialise the --output path so the method proceeds to parse.
+            out_idx = cmd.index("--output") + 1
+            Path(cmd[out_idx]).write_text("{}")
+
+            class _R:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            return _R()
+
+        monkeypatch.setattr(auditor_mod.subprocess, "run", _fake_run)
+        monkeypatch.setattr(
+            drc_mod.DRCReport,
+            "load",
+            classmethod(lambda cls, path: _FakeCliReport(cli_violations)),
+        )
+
+    def test_combined_count_sums_both_engines(self, tmp_path, monkeypatch):
+        """Errors = --mfr errors + kicad-cli errors; both types in table."""
+        audit = self._make_audit(tmp_path)
+        # Pre-populate a --mfr engine result (e.g. 4 clearance_pad_zone).
+        status = DRCStatus(
+            error_count=4,
+            warning_count=0,
+            blocking_count=4,
+            passed=False,
+            violations_by_type={"clearance_pad_zone": 4},
+        )
+        self._patch_cli(
+            monkeypatch,
+            cli_violations=[
+                _FakeCliViolation("starved_thermal"),
+                _FakeCliViolation("starved_thermal"),
+                _FakeCliViolation("track_width"),
+            ],
+        )
+
+        audit._merge_geometric_drc(status)
+
+        assert status.error_count == 7  # 4 + 3
+        assert status.blocking_count == 7
+        assert status.passed is False
+        # Both engines represented in the by-type table.
+        assert status.violations_by_type["clearance_pad_zone"] == 4
+        assert status.violations_by_type["kicad-cli:starved_thermal"] == 2
+        assert status.violations_by_type["kicad-cli:track_width"] == 1
+
+    def test_zero_mfr_but_cli_errors_reports_them(self, tmp_path, monkeypatch):
+        """A board clean by --mfr but dirty by kicad-cli is NOT passing."""
+        audit = self._make_audit(tmp_path)
+        status = DRCStatus(error_count=0, blocking_count=0, passed=True)
+        self._patch_cli(
+            monkeypatch,
+            cli_violations=[_FakeCliViolation("starved_thermal")] * 10,
+        )
+
+        audit._merge_geometric_drc(status)
+
+        assert status.error_count == 10
+        assert status.blocking_count == 10
+        assert status.passed is False
+        assert status.violations_by_type["kicad-cli:starved_thermal"] == 10
+
+    def test_clean_by_both_reports_zero(self, tmp_path, monkeypatch):
+        """0 --mfr + 0 kicad-cli stays at 0 and passing."""
+        audit = self._make_audit(tmp_path)
+        status = DRCStatus(error_count=0, blocking_count=0, passed=True)
+        self._patch_cli(monkeypatch, cli_violations=[])
+
+        audit._merge_geometric_drc(status)
+
+        assert status.error_count == 0
+        assert status.blocking_count == 0
+        assert status.passed is True
+        assert status.violations_by_type == {}
+
+    def test_graceful_fallback_when_kicad_cli_absent(self, tmp_path, monkeypatch):
+        """Missing kicad-cli leaves --mfr count intact and adds a note."""
+        audit = self._make_audit(tmp_path)
+        status = DRCStatus(
+            error_count=4,
+            blocking_count=4,
+            passed=False,
+            violations_by_type={"clearance_pad_zone": 4},
+        )
+        self._patch_cli(monkeypatch, cli_violations=[], found=False)
+
+        audit._merge_geometric_drc(status)
+
+        # --mfr count unchanged; no crash; note recorded.
+        assert status.error_count == 4
+        assert status.blocking_count == 4
+        assert status.violations_by_type == {"clearance_pad_zone": 4}
+        assert "kicad-cli not found" in status.details
+
+    def test_cli_warnings_do_not_count(self, tmp_path, monkeypatch):
+        """Non-error kicad-cli violations are ignored (severity-error guard)."""
+        audit = self._make_audit(tmp_path)
+        status = DRCStatus(error_count=0, blocking_count=0, passed=True)
+        self._patch_cli(
+            monkeypatch,
+            cli_violations=[
+                _FakeCliViolation("silk_over_copper", is_error=False),
+                _FakeCliViolation("starved_thermal", is_error=True),
+            ],
+        )
+
+        audit._merge_geometric_drc(status)
+
+        assert status.error_count == 1
+        assert status.violations_by_type == {"kicad-cli:starved_thermal": 1}
+
+
 class TestAuditResult:
     """Tests for AuditResult class."""
 
@@ -1246,6 +1407,22 @@ class TestCorruptionGuard:
 
 class TestZoneConnectedNets:
     """Tests for zone-connected net reclassification in connectivity check."""
+
+    @pytest.fixture(autouse=True)
+    def _disable_geometric_drc(self, monkeypatch):
+        """Isolate the connectivity-verdict assertions from kicad-cli DRC.
+
+        These tests assert on the *connectivity* advisory verdict using
+        minimal synthetic boards.  Since issue #3721 the audit also folds in
+        KiCad's geometric DRC (kicad-cli pcb drc), which finds unrelated
+        geometric defects on these hand-written boards and would flip the
+        verdict to NOT_READY.  Simulate the documented "kicad-cli absent"
+        graceful-fallback path so the geometric engine does not perturb the
+        connectivity subject under test.
+        """
+        from kicad_tools.cli import runner as runner_mod
+
+        monkeypatch.setattr(runner_mod, "find_kicad_cli", lambda: None)
 
     # PCB where GND net has a zone definition but no filled_polygons.
     # Two footprints with pads on GND (net 1) and +3V3 (net 2).


### PR DESCRIPTION
## Summary

The manufacturing `report.md` "## DRC Status" section (parsed by `kct board-metrics` into `board.json` `drc_violations`, which the demo gallery reads for its Ready/DRC badge) was populated **only** by the `kct check --mfr` rule engine. It did not include KiCad's geometric DRC (`kicad-cli pcb drc`), so a board with real geometric defects (e.g. `starved_thermal`, shorts, sub-spec traces) could read "0 DRC / Ready". This makes the DRC count the **union** of both engines: a board is manufacturable only when both report 0 errors.

## Changes

- `audit/auditor.py`: `_check_drc` now calls a new `_merge_geometric_drc` helper that runs `kicad-cli pcb drc --format json --severity-error` against the board. kicad-cli loads the sibling `<board>.kicad_pro` emitted by `kct export` (#3720), so the run uses fab-accurate rules with `lib_footprint_mismatch` / `isolated_copper` already downgraded below error severity.
- Error-severity kicad-cli violations are folded **additively** into the same `DRCStatus`: `error_count` / `blocking_count` become the combined total, and `passed` is True only when the combined count is 0.
- kicad-cli violation types are recorded under a `kicad-cli:` namespace in `violations_by_type` so the report's by-type table makes the engine explicit and they never collide with `--mfr` rule_ids.
- Graceful fallback: when `kicad-cli` is not on PATH, the report still generates with a note appended to the DRC details and the `--mfr` count alone -- never crashes.
- `kct board-metrics` needs no change: its `_DRC_ERRORS_RE` reads the `| Errors |` row, which is now the combined count.
- Tests: new `TestMergeGeometricDrc` mocks both engines' outputs (no kicad-cli required). An autouse fixture on `TestZoneConnectedNets` isolates its connectivity-verdict assertions from the new geometric engine.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `Errors` = kicad-cli error count + --mfr error count, both engines' types in by-type table | ✅ | Board 03 report.md: Errors=24 (14 `clearance_pad_zone` + 10 `kicad-cli:starved_thermal`); unit test `test_combined_count_sums_both_engines` |
| 0 --mfr but >0 kicad-cli reports them (not "Ready") | ✅ | Board 03 went 14→24, Status FAIL; unit test `test_zero_mfr_but_cli_errors_reports_them` |
| Clean by both reports 0 | ✅ | Board 01 report.md: Errors=0, Status PASS; unit test `test_clean_by_both_reports_zero` |
| kicad-cli invoked with emitted `.kicad_pro` (fab-accurate) | ✅ | Command runs against the board path; sibling `.kicad_pro` from #3720 is loaded by kicad-cli |
| `lib_footprint_mismatch` / `isolated_copper` not blocking | ✅ | `--severity-error` + `.kicad_pro` rule_severities exclude them; board 03 surfaces only `starved_thermal`, none appear |
| Graceful fallback when kicad-cli absent | ✅ | Note appended, --mfr count stands; unit test `test_graceful_fallback_when_kicad_cli_absent` |
| Test coverage for combined-count logic (mock both engines) | ✅ | `TestMergeGeometricDrc` (5 tests, no kicad-cli required) |

## Test Plan

- `uv run pytest tests/test_audit.py` -> 137 passed
- `uv run pytest tests/test_report_collector.py tests/test_report_mfr_profile_and_images.py tests/test_check_routed_drc_advisory.py` -> 105 passed
- Runtime verification via `uv run --with shapely kct export <routed.kicad_pcb> --mfr jlcpcb-tier1 --sch <sch> -o <out>/manufacturing` then inspecting `report.md` DRC Status:
  - Board 02 (charlieplex): Errors **4 → 4** (4 `clearance_pad_zone`, 0 kicad-cli)
  - Board 03 (usb-joystick): Errors **14 → 24** (10 `kicad-cli:starved_thermal` now surface)
  - Board 01 (voltage-divider): Errors **0 → 0**, Status PASS

Note: the pre-existing `tests/test_board_05_drc_allowlist.py` failure (`ModuleNotFoundError: No module named 'shapely'` in a `kct check` subprocess) reproduces on unmodified `main` and is unrelated to this change.

Closes #3721