### PR TITLE
fix(zones): selective per-pad solid connection replaces blanket-solid default

### DIFF
--- a/src/kicad_tools/cli/runner.py
+++ b/src/kicad_tools/cli/runner.py
@@ -497,7 +497,8 @@ def _remediate_starved_thermal(
             _restore_net_declarations(pcb_path, input_net_nodes, input_element_nets)
             if not report_path.exists() or report_path.stat().st_size == 0:
                 return None
-            return json.loads(report_path.read_text())
+            parsed = json.loads(report_path.read_text())
+            return parsed if isinstance(parsed, dict) else None
         finally:
             report_path.unlink(missing_ok=True)
 

--- a/src/kicad_tools/cli/runner.py
+++ b/src/kicad_tools/cli/runner.py
@@ -7,6 +7,7 @@ ERC validation, DRC validation, netlist export, and more.
 import shutil
 import subprocess
 import tempfile
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -353,11 +354,12 @@ def run_fill_zones(
                 stderr="kicad-cli not found. Install KiCad 8 from https://www.kicad.org/download/",
             )
 
-    # Pre-fill normalization (Issue #3727): legacy zones use thermal relief
-    # for *all* pads, which starves pads that cannot form the 2 spokes
-    # KiCad's geometric DRC requires (``starved_thermal``).  Upgrade such
-    # zones to a solid pad connection *before* the fill so the refilled
-    # copper reflects the stronger connection.
+    # Pre-fill normalization (Issues #3727 / #3729): legacy zones use thermal
+    # relief for *all* pads, which starves pads that cannot form the 2 spokes
+    # KiCad's geometric DRC requires (``starved_thermal``).  The selective
+    # policy keeps thermal relief on pads that CAN host 2 spokes and forces a
+    # solid per-pad connection only on the pads that would otherwise starve,
+    # applied *before* the fill so the refilled copper reflects it.
     #
     # When the normalization actually changes a zone, the fill must read the
     # *normalized* board.
@@ -385,26 +387,165 @@ def run_fill_zones(
         if normalized_tmp is not None:
             normalized_tmp.unlink(missing_ok=True)
 
-    # Post-fill geometric correction (Issue #3711): kicad-cli's fill can
-    # leave the antipad around a foreign-net pad/via too small on boards
-    # serialized by kicad-tools, producing clearance_pad_zone /
-    # clearance_via_zone DRC errors.  Subtract foreign-net antipads from
-    # every filled_polygon so the fill clears foreign copper by at least
-    # the zone clearance.  No-op when shapely is unavailable.
+    # Post-fill thermal remediation (Issue #3729) + foreign-pad clearance
+    # (Issue #3711), run together so they settle to a single consistent fill:
+    #
+    #   * Remediation forces a solid connection on every pad KiCad's DRC flags
+    #     ``starved_thermal`` (single spoke) or whose lone spoke strands an
+    #     ``isolated_copper`` sliver, then refills via kicad-cli.
+    #   * The foreign-pad carve subtracts foreign-net antipads from each
+    #     filled_polygon so the fill clears foreign copper by the zone
+    #     clearance (kicad-cli's own fill can leave it too tight on
+    #     kicad-tools-serialized boards).
+    #
+    # The carve is a pure-Python edit that a later kicad-cli refill would
+    # revert, and the carve itself can strand a thermal-relief sliver that
+    # DRC then flags.  So the carve is applied *inside* each remediation pass
+    # (before that pass's DRC check), letting remediation force the offending
+    # pad solid until the post-carve board is clean.  Both are no-ops without
+    # shapely / kicad-cli; guarded so they never disturb a successful fill.
     if result.success and result.output_path is not None:
-        _apply_foreign_pad_clearance(result.output_path)
+        _remediate_starved_thermal(
+            result.output_path,
+            kicad_cli,
+            settle=_apply_foreign_pad_clearance,
+        )
 
     return result
 
 
-def _normalize_pad_connection_in_place(pcb_path: Path) -> None:
-    """Upgrade legacy thermal-for-all zones to solid pad connection (Issue #3727).
+def _remediate_starved_thermal(
+    pcb_path: Path,
+    kicad_cli: Path,
+    max_passes: int = 4,
+    settle: Callable[[Path], None] | None = None,
+) -> None:
+    """Force solid connection on the pads KiCad's DRC flags (Issue #3729).
 
-    Loads the PCB, adds a solid (``yes``) pad-connection mode to every zone
-    whose ``connect_pads`` lacks one (so pads get a full-copper connection
-    instead of a single starved thermal spoke), and rewrites the file only
-    when at least one zone changed.  Any failure is swallowed so the fill is
-    never aborted by the normalization.
+    The size-based selective pass clears the obvious small-SMD starved pads;
+    this measurement-driven pass mops up the residue that pad size cannot
+    predict, using KiCad's own geometric DRC as the source of truth:
+
+    * ``starved_thermal`` (error) -- the pad forms only one spoke (pour edge,
+      single-spoke THT power tab).  KiCad names the pad UUID, so we force that
+      exact pad solid.
+    * ``isolated_copper`` (warning) -- a thermal-relief pad's lone spoke left
+      a tiny copper sliver KiCad considers an island.  KiCad names only the
+      zone, so we resolve the sliver geometrically and force its anchoring
+      same-net pad solid (merging the sliver into the pour on refill).
+
+    Each pass: (1) ``kicad-cli pcb drc --refill-zones --save-board`` refills
+    the zones (baking in the previous pass's overrides); (2) the optional
+    ``settle`` callback runs -- the foreign-pad clearance carve (#3711) -- so
+    the geometry checked includes the carve; (3) a read-only DRC reports the
+    flags against that settled geometry; (4) the flagged pads are forced solid
+    and saved.  Repeating lets a pad whose thermal sliver the carve strands be
+    forced solid on the next pass.  Because the carve is reverted by the next
+    refill, ``settle`` is re-applied every pass and once more at the end so the
+    shipped copper carries it.  A pass that finds nothing returns early.  Any
+    failure (kicad-cli missing, malformed report) is swallowed so the fill is
+    left as produced.
+    """
+    import json
+    import os
+
+    try:
+        from kicad_tools.core.sexp_file import save_pcb
+        from kicad_tools.sexp import parse_file
+        from kicad_tools.zones.fill_clearance import (
+            force_solid_on_isolated_island_pads,
+            force_solid_on_pads_by_uuid,
+            isolated_copper_zone_uuids,
+            starved_thermal_pad_uuids,
+        )
+    except Exception:
+        return
+
+    def _run_drc(refill: bool) -> dict | None:
+        """Run DRC on ``pcb_path`` and return the parsed report (or ``None``).
+
+        ``refill`` adds ``--refill-zones --save-board`` so the pass also
+        refills and persists the zones.  The default (all) severity is used so
+        ``isolated_copper`` *warnings* are visible alongside ``starved_thermal``
+        *errors*; ``--schematic-parity`` is omitted because the fill output may
+        lack a paired schematic.  The input net table is snapshotted and
+        restored around every invocation -- kicad-cli's ``--save-board`` can
+        strip the net declarations on kicad-tools-serialized boards, the same
+        quirk :func:`_run_fill_zones_via_drc` guards against -- so a refill
+        never drops the nets that segments/vias/pads depend on.
+        """
+        input_net_nodes = _snapshot_net_declarations(pcb_path)
+        input_element_nets = _snapshot_element_nets(pcb_path)
+
+        fd, report_name = tempfile.mkstemp(suffix=".json", prefix="thermal_drc_")
+        os.close(fd)
+        report_path = Path(report_name)
+        try:
+            cmd = [
+                str(kicad_cli),
+                "pcb",
+                "drc",
+                "--output",
+                str(report_path),
+                "--format",
+                "json",
+            ]
+            if refill and _kicad_drc_supports_refill(kicad_cli):
+                cmd.extend(["--refill-zones", "--save-board"])
+            cmd.append(str(pcb_path))
+            subprocess.run(cmd, capture_output=True, text=True)
+            _restore_net_declarations(pcb_path, input_net_nodes, input_element_nets)
+            if not report_path.exists() or report_path.stat().st_size == 0:
+                return None
+            return json.loads(report_path.read_text())
+        finally:
+            report_path.unlink(missing_ok=True)
+
+    def _settle() -> None:
+        if settle is not None:
+            settle(pcb_path)
+
+    try:
+        for _ in range(max_passes):
+            # Refill the zones (bakes in prior overrides), then apply the
+            # foreign-pad carve so the DRC we read reflects the shipped copper.
+            if _run_drc(refill=True) is None:
+                return
+            _settle()
+            report = _run_drc(refill=False)
+            if report is None:
+                return
+            starved_pads = starved_thermal_pad_uuids(report)
+            isolated_zones = isolated_copper_zone_uuids(report)
+            if not starved_pads and not isolated_zones:
+                return  # board is clean (carve already applied) -> done
+            doc = parse_file(pcb_path)
+            applied = force_solid_on_pads_by_uuid(doc, starved_pads)
+            applied += force_solid_on_isolated_island_pads(doc, isolated_zones)
+            if applied == 0:
+                # Flagged but nothing new to force solid -- the carve geometry
+                # is already on disk and we cannot improve it; stop here.
+                return
+            save_pcb(doc, pcb_path)
+            # Next pass refills (reverting the carve), re-applies it, re-checks.
+        # Pass budget exhausted with overrides still pending: do a final
+        # refill + carve so the shipped copper reflects both.
+        if _run_drc(refill=True) is not None:
+            _settle()
+    except Exception:
+        # Never let remediation abort a successful fill.
+        return
+
+
+def _normalize_pad_connection_in_place(pcb_path: Path) -> None:
+    """Apply the selective pad-connection policy in place (Issues #3727 / #3729).
+
+    Loads the PCB and runs :func:`normalize_zone_pad_connection` in its
+    default *selective* mode: zones keep thermal relief, while pads too small
+    to host the 2 spokes KiCad's DRC requires get a per-pad solid
+    ``(zone_connect 2)`` override.  Rewrites the file only when at least one
+    pad changed.  Any failure is swallowed so the fill is never aborted by
+    the normalization.
     """
     try:
         from kicad_tools.core.sexp_file import save_pcb
@@ -421,12 +562,13 @@ def _normalize_pad_connection_in_place(pcb_path: Path) -> None:
 
 
 def _stage_normalized_pad_connection(pcb_path: Path) -> Path | None:
-    """Stage a solid-pad-connection copy of ``pcb_path`` for the fill (Issue #3727).
+    """Stage a selectively-connected copy of ``pcb_path`` for the fill (Issues #3727 / #3729).
 
-    Returns the path to a temp ``.kicad_pcb`` whose zones have been upgraded to
-    a solid pad connection, or ``None`` when no zone needed changing (so the
-    caller can feed the original file unchanged and skip a needless copy).  Any
-    failure returns ``None`` so the fill proceeds on the original board.
+    Returns the path to a temp ``.kicad_pcb`` whose pads-that-cannot-host-2-spokes
+    have received a per-pad solid ``(zone_connect 2)`` override (selective
+    policy), or ``None`` when no pad needed changing (so the caller can feed
+    the original file unchanged and skip a needless copy).  Any failure
+    returns ``None`` so the fill proceeds on the original board.
     """
     try:
         import os

--- a/src/kicad_tools/sexp/builders.py
+++ b/src/kicad_tools/sexp/builders.py
@@ -577,7 +577,7 @@ def zone_node(
     clearance: float = 0.2,
     thermal_gap: float = 0.3,
     thermal_bridge_width: float = 0.3,
-    pad_connection: str = "yes",
+    pad_connection: str = "",
 ) -> SExp:
     """Build a PCB copper zone (pour) S-expression.
 
@@ -592,20 +592,25 @@ def zone_node(
         clearance: Pad clearance in mm
         thermal_gap: Thermal relief gap in mm
         thermal_bridge_width: Thermal relief bridge width in mm
-        pad_connection: Pad-to-zone connection mode written into
+        pad_connection: Zone-level pad-to-zone connection mode written into
             ``(connect_pads ...)``.  KiCad understands:
 
-            * ``""`` (default keyword absent) -- thermal relief for *all*
-              pads.  Small SMD pads cannot host the 2 thermal spokes the
-              geometric DRC requires, and some through-hole power pads sit
-              where only one spoke can form, so this mode produces
-              ``starved_thermal`` errors (issue #3727).
-            * ``"yes"`` -- **solid** full-copper connection for *all* pads.
-              This is the generator default: a solid connection is strictly
-              stronger than a 2-spoke thermal relief, so it eliminates
-              ``starved_thermal`` honestly (without lowering the required
-              spoke count) and gives the lowest-impedance power/ground
-              delivery -- the right choice for reflow-assembled fab boards.
+            * ``""`` (default keyword absent, the generator default) --
+              thermal relief for *all* pads at the zone level.  This pairs
+              with the **selective** per-pad policy (issue #3729): the zone
+              keeps thermal relief, while individual pads too small to host
+              the 2 spokes the geometric DRC requires get a per-pad
+              ``(zone_connect 2)`` solid override applied by
+              :func:`kicad_tools.zones.fill_clearance.normalize_zone_pad_connection`.
+              Pads that *can* host 2 spokes keep thermal relief (eases
+              hand-soldering / rework).  An empty mode here is therefore the
+              right default -- the per-pad overrides clear ``starved_thermal``
+              surgically rather than forcing solid on every pad.
+            * ``"yes"`` -- **solid** full-copper connection for *all* pads
+              (the #3728 blanket behavior, now an explicit override).  A
+              solid connection is strictly stronger than a 2-spoke thermal
+              relief, so it eliminates ``starved_thermal`` honestly (without
+              lowering the required spoke count).
             * ``"thru_hole_only"`` -- thermal relief for through-hole pads
               (eases hand-soldering) and solid for SMD pads.  Clears the
               SMD ``starved_thermal`` errors but leaves single-spoke THT

--- a/src/kicad_tools/zones/fill_clearance.py
+++ b/src/kicad_tools/zones/fill_clearance.py
@@ -585,11 +585,11 @@ def _apply_selective_pad_connection(doc: SExp) -> int:
     # (force-solid-if-any-zone-would-starve) choice.
     net_required: dict[str, float] = {}
     for zone in doc.find_all("zone"):
-        if zone.find("connect_pads") is None:
+        connect_pads = zone.find("connect_pads")
+        if connect_pads is None:
             continue  # keepout / non-copper zone
         # A zone with an explicit mode token opts out of selective per-pad
         # treatment — its zone-level mode already governs every pad.
-        connect_pads = zone.find("connect_pads")
         has_mode = any(
             child.is_atom and isinstance(child.value, str) for child in connect_pads.children
         )
@@ -613,11 +613,11 @@ def _apply_selective_pad_connection(doc: SExp) -> int:
             net_key = _net_key(pad.find("net"), name_map)
             if net_key is None:
                 continue
-            required = net_required.get(net_key)
-            if required is None:
+            pad_required = net_required.get(net_key)
+            if pad_required is None:
                 continue  # pad's net has no thermal-relief zone
             min_dim = _pad_min_dimension(pad)
-            if min_dim is not None and min_dim >= required:
+            if min_dim is not None and min_dim >= pad_required:
                 continue  # comfortably hosts 2 spokes -> keep thermal relief
             if _set_pad_zone_connect(pad, _ZONE_CONNECT_SOLID):
                 changed += 1

--- a/src/kicad_tools/zones/fill_clearance.py
+++ b/src/kicad_tools/zones/fill_clearance.py
@@ -58,6 +58,10 @@ class _Obstacle:
     layers: tuple[str, ...]
     # Sheet-absolute footprint of the copper, as a shapely geometry.
     shape: _Geometry
+    # The pad ``SExp`` this obstacle came from, when it is a footprint pad
+    # (``None`` for vias).  Lets the isolated-island remediator set a per-pad
+    # ``zone_connect`` override on the exact pad that stranded a sliver.
+    source_pad: SExp | None = None
 
 
 def _build_net_name_map(doc: SExp) -> dict[int, str]:
@@ -186,7 +190,14 @@ def _collect_obstacles(
                 else []
             )
 
-            obstacles.append(_Obstacle(net_key=net_key, layers=tuple(pad_layers), shape=shape))
+            obstacles.append(
+                _Obstacle(
+                    net_key=net_key,
+                    layers=tuple(pad_layers),
+                    shape=shape,
+                    source_pad=pad,
+                )
+            )
 
     # --- Vias (top level) ---
     for via in doc.find_all("via"):
@@ -442,43 +453,392 @@ def _keep_connected_rings(rings: list, anchors: list, polygon_cls) -> list:
 # geometric DRC requires (issue #3727).
 _CONNECT_PAD_MODES = frozenset({"thru_hole_only", "yes", "no"})
 
+# The selective policy is a *meta* mode handled by this module rather than a
+# KiCad ``connect_pads`` keyword: it keeps the zone-level default as thermal
+# relief and forces a solid connection only on the individual pads that
+# physically cannot host 2 spokes (via a per-pad ``(zone_connect 2)``).
+_SELECTIVE_MODE = "selective"
+
+# KiCad per-pad ``(zone_connect N)`` override codes.  This overrides the
+# zone-level ``connect_pads`` mode for the single pad it sits on:
+#   0 = none, 1 = thermal relief, 2 = solid (full copper).
+_ZONE_CONNECT_SOLID = 2
+
+# Thermal-relief parameters fall back to these when a zone does not declare
+# them.  They match the generator defaults (``ZoneConfig.thermal_gap`` /
+# ``thermal_bridge_width``) so the spoke-viability test below reflects the
+# geometry KiCad will actually attempt to fill.
+_DEFAULT_THERMAL_GAP_MM = 0.3
+_DEFAULT_THERMAL_BRIDGE_WIDTH_MM = 0.4
+
+# Safety margin (mm) added to the spoke-fit requirement.  A pad that only
+# *just* clears the arithmetic minimum can still fail KiCad's geometric
+# spoke placement (corner rounding, antipad encroachment), so we require a
+# little slack before trusting a pad to host 2 spokes and keep thermal
+# relief.  Tuned so the demo boards report 0 ``starved_thermal`` while
+# generously-sized power pads retain thermal relief.
+_SPOKE_FIT_MARGIN_MM = 0.1
+
+
+def _zone_thermal_params(zone: SExp) -> tuple[float, float]:
+    """Return ``(thermal_gap, thermal_bridge_width)`` for a zone in mm.
+
+    Reads the ``(fill ... (thermal_gap G) (thermal_bridge_width W))`` block,
+    falling back to the generator defaults when a value is absent so the
+    spoke-viability test always has concrete numbers to reason about.
+    """
+    gap = _DEFAULT_THERMAL_GAP_MM
+    bridge = _DEFAULT_THERMAL_BRIDGE_WIDTH_MM
+    fill = zone.find("fill")
+    if fill is not None:
+        g = fill.find("thermal_gap")
+        if g is not None:
+            gv = g.get_float(0)
+            if gv is not None:
+                gap = gv
+        b = fill.find("thermal_bridge_width")
+        if b is not None:
+            bv = b.get_float(0)
+            if bv is not None:
+                bridge = bv
+    return gap, bridge
+
+
+def _pad_min_dimension(pad: SExp) -> float | None:
+    """Smallest copper dimension of a pad in mm, or ``None`` if unknown.
+
+    The 2-spoke thermal relief that KiCad's geometric DRC requires must fit
+    across the *narrow* axis of the pad — the limiting dimension — so we key
+    the spoke-viability test on ``min(width, height)``.
+    """
+    size = pad.find("size")
+    if size is None:
+        return None
+    w = size.get_float(0)
+    if w is None or w <= 0:
+        return None
+    h = size.get_float(1)
+    if h is None:
+        h = w
+    if h <= 0:
+        return None
+    return min(w, h)
+
+
+def _pad_can_host_two_spokes(
+    pad: SExp,
+    thermal_bridge_width: float,
+    thermal_gap: float,
+) -> bool:
+    """Whether a pad is wide enough to host the 2 thermal spokes DRC wants.
+
+    KiCad's default thermal relief places two spokes on opposite sides of a
+    pad.  For both spokes to actually form, the pad must be wide enough
+    across its *narrow* axis to seat a spoke of ``thermal_bridge_width`` with
+    the thermal antipad (``thermal_gap``) on either side of it; otherwise the
+    surrounding copper only admits a single spoke and the geometric DRC
+    reports ``starved_thermal`` (issue #3727).
+
+    The fit requirement is ``thermal_bridge_width + 2 * thermal_gap`` plus a
+    small safety margin.  Pads at or below that width get a solid connection
+    instead; pads comfortably above it keep their thermal relief.  Pads with
+    no readable size are treated conservatively as *unable* to host spokes
+    (force solid) so a malformed pad never silently keeps a starved thermal.
+    """
+    min_dim = _pad_min_dimension(pad)
+    if min_dim is None:
+        return False
+    required = thermal_bridge_width + 2.0 * thermal_gap + _SPOKE_FIT_MARGIN_MM
+    return min_dim >= required
+
+
+def _set_pad_zone_connect(pad: SExp, code: int) -> bool:
+    """Set a pad's ``(zone_connect N)`` override, returning whether it changed.
+
+    A pad that already declares any ``zone_connect`` carries a deliberate
+    upstream choice and is left untouched.  Otherwise the override is appended
+    so the per-pad connection mode wins over the zone-level default.
+    """
+    if pad.find("zone_connect") is not None:
+        return False
+    pad.append(SExp.list("zone_connect", code))
+    return True
+
+
+def _apply_selective_pad_connection(doc: SExp) -> int:
+    """Force a solid connection only on pads that cannot host 2 thermal spokes.
+
+    Implements the selective default (issue #3729): the zone keeps its
+    thermal-relief default (no ``connect_pads`` mode token), and every
+    footprint pad on a zone's net that is too small to seat the 2 spokes
+    KiCad's DRC requires gets a per-pad ``(zone_connect 2)`` solid override.
+    Pads that *can* host 2 spokes keep thermal relief, preserving the
+    hand-rework benefit where it is geometrically valid.
+
+    Returns the number of pads that received a new solid override.
+    """
+    name_map = _build_net_name_map(doc)
+
+    # Collect, per net, the tightest spoke-fit threshold across the zones on
+    # that net.  A pad must clear the threshold of every zone it sits in to
+    # keep thermal relief; using the largest required width is the safe
+    # (force-solid-if-any-zone-would-starve) choice.
+    net_required: dict[str, float] = {}
+    for zone in doc.find_all("zone"):
+        if zone.find("connect_pads") is None:
+            continue  # keepout / non-copper zone
+        # A zone with an explicit mode token opts out of selective per-pad
+        # treatment — its zone-level mode already governs every pad.
+        connect_pads = zone.find("connect_pads")
+        has_mode = any(
+            child.is_atom and isinstance(child.value, str) for child in connect_pads.children
+        )
+        if has_mode:
+            continue
+        zone_net = _net_key(zone.find("net"), name_map)
+        if zone_net is None:
+            continue
+        gap, bridge = _zone_thermal_params(zone)
+        required = bridge + 2.0 * gap + _SPOKE_FIT_MARGIN_MM
+        prev = net_required.get(zone_net)
+        if prev is None or required > prev:
+            net_required[zone_net] = required
+
+    if not net_required:
+        return 0
+
+    changed = 0
+    for fp in doc.find_all("footprint"):
+        for pad in fp.find_all("pad"):
+            net_key = _net_key(pad.find("net"), name_map)
+            if net_key is None:
+                continue
+            required = net_required.get(net_key)
+            if required is None:
+                continue  # pad's net has no thermal-relief zone
+            min_dim = _pad_min_dimension(pad)
+            if min_dim is not None and min_dim >= required:
+                continue  # comfortably hosts 2 spokes -> keep thermal relief
+            if _set_pad_zone_connect(pad, _ZONE_CONNECT_SOLID):
+                changed += 1
+    return changed
+
+
+def starved_thermal_pad_uuids(drc_report: dict) -> set[str]:
+    """Extract the pad UUIDs flagged ``starved_thermal`` in a kicad-cli report.
+
+    A ``starved_thermal`` violation lists two items: the zone and the
+    offending pad.  KiCad describes the pad item as e.g. ``Pad 4 [+3V3] of J3``
+    (SMD) or ``PTH pad 2 [+24V] of Q5`` (through-hole) and the zone item as
+    ``Zone [...] on ...``.  We collect every item UUID whose description names
+    a pad (``"pad"`` appears, ``"zone"`` does not), which captures both the
+    SMD ``Pad`` and through-hole ``PTH pad`` forms while skipping the paired
+    zone item.  Returns the set of such UUIDs (empty when the report has no
+    starved-thermal violations).
+    """
+    uuids: set[str] = set()
+    for violation in drc_report.get("violations", []):
+        if violation.get("type") != "starved_thermal":
+            continue
+        for item in violation.get("items", []):
+            desc = item.get("description", "").lower()
+            uid = item.get("uuid")
+            if uid and "pad" in desc and "zone" not in desc:
+                uuids.add(uid)
+    return uuids
+
+
+def isolated_copper_zone_uuids(drc_report: dict) -> set[str]:
+    """Extract the zone UUIDs flagged ``isolated_copper`` in a kicad-cli report.
+
+    An ``isolated_copper`` violation lists the offending zone (``Zone [...] on
+    ...``).  KiCad does not name the specific island geometry, so we collect
+    the zone UUIDs and resolve the islands geometrically in
+    :func:`force_solid_on_isolated_island_pads`.  Returns the set of zone
+    UUIDs (empty when the report has none).
+    """
+    uuids: set[str] = set()
+    for violation in drc_report.get("violations", []):
+        if violation.get("type") != "isolated_copper":
+            continue
+        for item in violation.get("items", []):
+            uid = item.get("uuid")
+            if uid:
+                uuids.add(uid)
+    return uuids
+
+
+# A fill polygon at or below this area (mm^2) is treated as a candidate
+# "island sliver" when resolving an ``isolated_copper`` warning.  KiCad's
+# isolated-copper islands on these boards are sub-mm^2 slivers left around a
+# thermal-relief pad whose lone spoke barely ties the region to the pour;
+# real pour lobes are orders of magnitude larger.  Keeping the threshold
+# small avoids ever touching a substantial connected region.
+_ISLAND_SLIVER_AREA_MM2 = 2.0
+
+
+def force_solid_on_isolated_island_pads(doc: SExp, zone_uuids: set[str]) -> int:
+    """Force solid connection on the pads anchoring isolated-copper slivers.
+
+    Resolves each ``isolated_copper`` warning (issue #3729) to its cause: a
+    same-net thermal-relief pad whose single spoke leaves a tiny copper
+    sliver that KiCad flags as an isolated island.  For every zone in
+    ``zone_uuids`` we find the small (``<= _ISLAND_SLIVER_AREA_MM2``) fill
+    polygons and set ``(zone_connect 2)`` on each same-net pad whose copper
+    footprint touches one — merging the sliver back into the pour on the next
+    refill.  Larger fill lobes are never touched, so substantial copper is
+    safe.  Returns the number of pads that received a new solid override.
+
+    A no-op (returns 0) when shapely is unavailable, since the island
+    geometry cannot be reasoned about without it.
+    """
+    if not zone_uuids:
+        return 0
+    try:
+        import shapely
+        from shapely.geometry import Polygon
+    except ImportError:
+        return 0
+
+    name_map = _build_net_name_map(doc)
+    obstacles = _collect_obstacles(doc, shapely, name_map)
+
+    changed = 0
+    for zone in doc.find_all("zone"):
+        uuid_node = zone.find("uuid")
+        if uuid_node is None or (uuid_node.get_string(0) or "") not in zone_uuids:
+            continue
+        zone_net = _net_key(zone.find("net"), name_map)
+        if zone_net is None:
+            continue
+
+        for filled in zone.find_all("filled_polygon"):
+            layer_node = filled.find("layer")
+            fill_layer = ""
+            if layer_node is not None:
+                fill_layer = layer_node.get_string(0) or ""
+            else:
+                zl = zone.find("layer")
+                if zl is not None:
+                    fill_layer = zl.get_string(0) or ""
+
+            pts_node = filled.find("pts")
+            if pts_node is None:
+                continue
+            ring = [
+                (xy.get_float(0) or 0.0, xy.get_float(1) or 0.0) for xy in pts_node.find_all("xy")
+            ]
+            if len(ring) < 3:
+                continue
+            poly = Polygon(ring)
+            if not poly.is_valid:
+                poly = poly.buffer(0)
+            if poly.is_empty or poly.area > _ISLAND_SLIVER_AREA_MM2:
+                continue  # substantial lobe -> never a sliver to remediate
+
+            # Force solid on every same-net pad whose copper touches the
+            # sliver -- its thermal spoke is what stranded the sliver.
+            for obs in obstacles:
+                if obs.net_key != zone_net:
+                    continue
+                if not _obstacle_on_layer(obs, fill_layer):
+                    continue
+                if not obs.shape.intersects(poly):
+                    continue
+                pad = obs.source_pad
+                if pad is None:
+                    continue  # a via, not a pad -- has no thermal relief
+                if _set_pad_zone_connect(pad, _ZONE_CONNECT_SOLID):
+                    changed += 1
+    return changed
+
+
+def force_solid_on_pads_by_uuid(doc: SExp, pad_uuids: set[str]) -> int:
+    """Set ``(zone_connect 2)`` on every pad whose UUID is in ``pad_uuids``.
+
+    This is the *measurement-driven* half of the selective policy
+    (issue #3729): the size heuristic (:func:`_apply_selective_pad_connection`)
+    handles the obvious small-SMD pads up front, but a handful of pads form
+    only a single spoke for reasons the pad size cannot predict (the pad sits
+    at the pour edge, or its only spoke lands on a fill island).  KiCad's own
+    geometric DRC names exactly those pads, so we read the fill's DRC report
+    back and force a solid connection on precisely that set -- guaranteeing
+    0 ``starved_thermal`` without touching any pad DRC did not flag, so pads
+    that genuinely host 2 spokes keep their thermal relief.
+
+    A pad that already carries a ``zone_connect`` is left untouched.  Returns
+    the number of pads that received a new solid override.
+    """
+    if not pad_uuids:
+        return 0
+    changed = 0
+    for fp in doc.find_all("footprint"):
+        for pad in fp.find_all("pad"):
+            uuid_node = pad.find("uuid")
+            if uuid_node is None:
+                continue
+            if (uuid_node.get_string(0) or "") not in pad_uuids:
+                continue
+            if _set_pad_zone_connect(pad, _ZONE_CONNECT_SOLID):
+                changed += 1
+    return changed
+
 
 def normalize_zone_pad_connection(
     doc: SExp,
-    mode: str = "yes",
+    mode: str = _SELECTIVE_MODE,
 ) -> int:
-    """Upgrade legacy thermal-for-all zones to a stronger pad connection.
+    """Apply the zone pad-connection policy, defaulting to *selective*.
 
-    KiCad's ``(connect_pads ...)`` carries an optional leading *mode* token:
+    KiCad's ``(connect_pads ...)`` carries an optional leading *mode* token
+    that governs how **every** pad in the zone ties to the pour:
 
     * **absent** -- thermal relief for every pad.  Small SMD pads cannot
       host the 2 thermal spokes KiCad's geometric DRC requires, and some
       through-hole power pads sit where only one spoke can form, so a pour
       that uses this default reports ``starved_thermal`` errors (issue
       #3727, across boards 03/04/05/softstart).
-    * ``yes`` -- a **solid** full-copper connection for every pad (the
-      default applied here).  A solid connection is strictly stronger than
-      a 2-spoke thermal relief, so it eliminates ``starved_thermal``
-      honestly -- it does not lower the required spoke count -- and gives
-      the lowest-impedance power/ground delivery on a reflow-assembled
-      board.
+    * ``yes`` -- a **solid** full-copper connection for every pad.  A solid
+      connection is strictly stronger than a 2-spoke thermal relief, so it
+      eliminates ``starved_thermal`` honestly -- it does not lower the
+      required spoke count.
     * ``thru_hole_only`` -- thermal relief for THT pads, solid for SMD.
     * ``no`` -- no copper connection.
 
-    This function adds the ``mode`` token to every copper zone whose
-    ``connect_pads`` node currently lacks one.  Zones that already declare a
-    mode (set deliberately by an upstream generator) are left untouched, as
-    are keepout zones (which have no ``connect_pads``).  The document is
-    mutated in place; the number of zones changed is returned so callers can
-    skip a needless rewrite when nothing changed.
+    ``mode`` selects the policy:
+
+    * ``"selective"`` (the **default**, issue #3729) -- keep each zone's
+      thermal-relief default and force a solid connection *only on the
+      individual pads that cannot host 2 spokes*, via a per-pad
+      ``(zone_connect 2)`` override.  Pads that can host 2 spokes keep their
+      thermal relief (which eases hand-soldering / rework), so the fix is
+      surgical rather than a blanket solid-for-everything.  PR #3728 made
+      solid the global default; this refines it to the minimal set of pads
+      that genuinely need it while still clearing every ``starved_thermal``.
+    * ``"yes"`` / ``"thru_hole_only"`` / ``"no"`` -- an explicit override:
+      the zone-level ``connect_pads`` mode token is added to every copper
+      zone that lacks one, applying that mode uniformly (the #3728 behavior
+      for ``"yes"``).
+
+    For the zone-level modes, zones that already declare a mode (set
+    deliberately by an upstream generator) are left untouched, as are
+    keepout zones (which have no ``connect_pads``).  For the selective mode,
+    pads that already declare a ``zone_connect`` are likewise preserved, and
+    zones carrying an explicit ``connect_pads`` mode opt out of per-pad
+    treatment.  The document is mutated in place; the number of zones (mode
+    token added) or pads (selective override added) changed is returned so
+    callers can skip a needless rewrite when nothing changed.
 
     Run this *before* the kicad-cli fill so the refilled copper reflects the
-    new connection mode.
+    new connection.
     """
+    if mode == _SELECTIVE_MODE:
+        return _apply_selective_pad_connection(doc)
+
     if mode not in _CONNECT_PAD_MODES:
         raise ValueError(
             f"Unsupported pad-connection mode {mode!r}; "
-            f"expected one of {sorted(_CONNECT_PAD_MODES)}"
+            f"expected {_SELECTIVE_MODE!r} or one of {sorted(_CONNECT_PAD_MODES)}"
         )
 
     changed = 0

--- a/src/kicad_tools/zones/generator.py
+++ b/src/kicad_tools/zones/generator.py
@@ -163,13 +163,15 @@ class ZoneConfig:
         min_thickness: Minimum copper thickness in mm
         thermal_gap: Thermal relief gap in mm
         thermal_bridge_width: Thermal relief spoke width in mm
-        pad_connection: Pad-to-zone connection mode. Defaults to ``"yes"``
-            (solid full-copper connection for every pad), which avoids the
-            ``starved_thermal`` DRC error pads trigger when fewer than the
-            required 2 thermal spokes can form -- a solid connection is
-            strictly stronger than a 2-spoke thermal, not a relaxed check.
+        pad_connection: Zone-level pad-to-zone connection mode. Defaults to
+            ``""`` (thermal relief at the zone level), which pairs with the
+            **selective** per-pad policy (issue #3729): pads too small to
+            host the 2 thermal spokes KiCad's DRC requires get a per-pad
+            solid override while larger pads keep thermal relief.  Set
+            ``"yes"`` for the #3728 blanket-solid behavior, or
+            ``"thru_hole_only"`` / ``"no"`` for the other KiCad modes.
             See :func:`kicad_tools.sexp.builders.zone_node` for the full
-            set of accepted modes (issue #3727).
+            set of accepted modes.
         boundary: Custom boundary polygon, or None for board outline
     """
 
@@ -180,7 +182,7 @@ class ZoneConfig:
     min_thickness: float = 0.25
     thermal_gap: float = 0.3
     thermal_bridge_width: float = 0.4
-    pad_connection: str = "yes"
+    pad_connection: str = ""
     boundary: list[tuple[float, float]] | None = None
 
 
@@ -658,7 +660,7 @@ class ZoneGenerator:
         min_thickness: float = 0.25,
         thermal_gap: float = 0.3,
         thermal_bridge_width: float = 0.4,
-        pad_connection: str = "yes",
+        pad_connection: str = "",
         boundary: list[tuple[float, float]] | None = None,
     ) -> GeneratedZone:
         """Add a copper pour zone.
@@ -674,10 +676,11 @@ class ZoneGenerator:
             min_thickness: Minimum copper thickness in mm
             thermal_gap: Thermal relief gap in mm
             thermal_bridge_width: Thermal relief spoke width in mm
-            pad_connection: Pad-to-zone connection mode (default ``"yes"``:
-                solid full-copper connection for every pad).  See
+            pad_connection: Zone-level pad-to-zone connection mode (default
+                ``""``: thermal relief at the zone level, paired with the
+                selective per-pad solid policy of issue #3729).  See
                 :class:`ZoneConfig` and
-                :func:`kicad_tools.sexp.builders.zone_node` (issue #3727).
+                :func:`kicad_tools.sexp.builders.zone_node`.
             boundary: Custom boundary polygon, or None for board outline
 
         Returns:

--- a/tests/test_sexp_builders.py
+++ b/tests/test_sexp_builders.py
@@ -593,22 +593,29 @@ class TestZoneNode:
         priority_node = node.get("priority")
         assert priority_node.children[0].value == 1
 
-    def test_zone_node_defaults_to_solid_pad_connection(self):
-        """Issue #3727: zones default to a solid (``yes``) pad connection.
+    def test_zone_node_defaults_to_thermal_relief_for_selective_policy(self):
+        """Issue #3729: zones default to *zone-level thermal relief*.
 
-        Thermal relief for *all* pads starves small SMD pads (and some THT
-        power pads) of the 2 spokes the geometric DRC requires.  A solid
-        connection is strictly stronger, so it is the honest default that
-        clears ``starved_thermal`` without lowering the spoke count.
+        The selective policy (issue #3729) keeps thermal relief at the zone
+        level (no ``connect_pads`` mode token) and forces a solid connection
+        only on the individual pads that cannot host 2 spokes, via per-pad
+        ``(zone_connect 2)`` overrides applied by
+        ``normalize_zone_pad_connection``.  So the *zone* default emits no
+        mode token, preserving thermal relief for the pads that can host it.
         """
         points = [(0, 0), (100, 0), (100, 50), (0, 50)]
         node = zone_node(1, "GND", "F.Cu", points, "zone-uuid")
 
         connect_pads = node.get("connect_pads")
-        # The leading mode token is a bare atom child before (clearance ...).
+        # No leading mode atom -- only the (clearance ...) child remains.
         mode_atoms = [c.value for c in connect_pads.children if c.is_atom]
-        assert mode_atoms == ["yes"], mode_atoms
-        # The mode must serialize as a bare keyword, never a quoted string.
+        assert mode_atoms == [], mode_atoms
+        assert "(connect_pads (clearance" in node.to_string()
+
+    def test_zone_node_pad_connection_yes_is_explicit_override(self):
+        """A caller can still request the #3728 blanket-solid (``yes``) mode."""
+        points = [(0, 0), (100, 0), (100, 50), (0, 50)]
+        node = zone_node(1, "GND", "F.Cu", points, "zone-uuid", pad_connection="yes")
         rendered = node.to_string()
         assert "(connect_pads yes (clearance" in rendered
         assert '"yes"' not in rendered

--- a/tests/test_zone_generator.py
+++ b/tests/test_zone_generator.py
@@ -73,9 +73,10 @@ class TestZoneConfig:
         assert config.min_thickness == 0.25
         assert config.thermal_gap == 0.3
         assert config.thermal_bridge_width == 0.4
-        # Issue #3727: zones default to a solid pad connection so SMD (and
-        # single-spoke THT) pads do not trigger ``starved_thermal``.
-        assert config.pad_connection == "yes"
+        # Issue #3729: zones default to *zone-level thermal relief* (empty
+        # mode).  The selective per-pad policy forces solid only on pads that
+        # cannot host 2 spokes, so larger pads keep thermal relief.
+        assert config.pad_connection == ""
         assert config.boundary is None
 
     def test_custom_values(self):
@@ -124,12 +125,13 @@ class TestGeneratedZone:
         assert "(polygon" in sexp_str
         assert "(priority 1)" in sexp_str
 
-    def test_to_sexp_node_solid_pad_connection_default(self):
-        """Issue #3727: generated zones write a solid ``connect_pads yes``.
+    def test_to_sexp_node_thermal_relief_default(self):
+        """Issue #3729: generated zones default to zone-level thermal relief.
 
-        A solid connection is strictly stronger than a 2-spoke thermal, so it
-        clears ``starved_thermal`` honestly instead of lowering the required
-        spoke count.
+        The selective policy keeps thermal relief at the zone level (no
+        ``connect_pads`` mode token) and forces solid only on the pads that
+        cannot host 2 spokes via per-pad ``(zone_connect 2)`` overrides, so
+        the generated zone emits a bare ``(connect_pads (clearance ...))``.
         """
         config = ZoneConfig(net="GND", layer="B.Cu", priority=1)
         zone = GeneratedZone(
@@ -139,8 +141,20 @@ class TestGeneratedZone:
             uuid="test-uuid",
         )
         sexp_str = zone.to_sexp_node().to_string()
+        assert "(connect_pads (clearance" in sexp_str
+        assert "connect_pads yes" not in sexp_str
+
+    def test_to_sexp_node_yes_override(self):
+        """An explicit ``pad_connection="yes"`` still writes the blanket-solid mode."""
+        config = ZoneConfig(net="GND", layer="B.Cu", priority=1, pad_connection="yes")
+        zone = GeneratedZone(
+            config=config,
+            net_number=1,
+            boundary=[(0, 0), (100, 0), (100, 100), (0, 100)],
+            uuid="test-uuid",
+        )
+        sexp_str = zone.to_sexp_node().to_string()
         assert "(connect_pads yes (clearance" in sexp_str
-        assert '"yes"' not in sexp_str
 
 
 class TestZoneGeneratorUnit:

--- a/tests/test_zones_cmd.py
+++ b/tests/test_zones_cmd.py
@@ -336,7 +336,9 @@ class TestRunFillZonesNative:
             mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
             result = run_fill_zones(tmp_pcb, kicad_cli=Path("/usr/bin/kicad-cli"))
         assert result.success is True
-        cmd = mock_run.call_args[0][0]
+        # The fill is the first subprocess call (post-fill thermal remediation,
+        # issue #3729, adds trailing DRC calls).
+        cmd = mock_run.call_args_list[0][0][0]
         assert cmd[0] == "/usr/bin/kicad-cli"
         assert cmd[1:3] == ["pcb", "fill-zones"]
         assert str(tmp_pcb) == cmd[-1]
@@ -352,7 +354,8 @@ class TestRunFillZonesNative:
             mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
             result = run_fill_zones(tmp_pcb, output_path=out, kicad_cli=Path("/usr/bin/kicad-cli"))
         assert result.success is True
-        cmd = mock_run.call_args[0][0]
+        # The fill is the first subprocess call (issue #3729 adds trailing DRC).
+        cmd = mock_run.call_args_list[0][0][0]
         assert "--output" in cmd
         idx = cmd.index("--output")
         assert cmd[idx + 1] == str(out)
@@ -478,9 +481,11 @@ class TestRunFillZonesDRCFallback:
         ):
             run_fill_zones(tmp_pcb, kicad_cli=Path("/usr/bin/kicad-cli"))
 
-        # The temp DRC report should have been deleted
-        assert len(created_reports) == 1
-        assert not Path(created_reports[0]).exists()
+        # Every temp DRC report (the fill report plus any from the post-fill
+        # thermal remediation in issue #3729) must be cleaned up.
+        assert len(created_reports) >= 1
+        for report in created_reports:
+            assert not Path(report).exists()
 
     def test_kicad8_no_refill_flags(self, tmp_pcb):
         """KiCad 8/9: DRC command should NOT include --refill-zones."""
@@ -518,7 +523,8 @@ class TestRunFillZonesDRCFallback:
         ):
             run_fill_zones(tmp_pcb, kicad_cli=Path("/usr/bin/kicad-cli"))
 
-        cmd = mock_run.call_args[0][0]
+        # Inspect the fill DRC (first call); issue #3729 adds trailing calls.
+        cmd = mock_run.call_args_list[0][0][0]
         assert "--refill-zones" in cmd
         assert "--save-board" in cmd
 

--- a/tests/test_zones_fill_clearance.py
+++ b/tests/test_zones_fill_clearance.py
@@ -288,15 +288,14 @@ class TestNetIdentityResolution:
         assert fill.intersection(same).area > 0.0
 
 
-class TestNormalizeZonePadConnection:
-    """Issue #3727: upgrade thermal-for-all zones to a stronger connection.
+class TestNormalizeZonePadConnectionModes:
+    """Issue #3727 / #3729: the zone-level pad-connection modes.
 
-    A legacy ``(connect_pads (clearance ...))`` zone uses thermal relief for
-    *every* pad.  Small SMD pads (and some single-spoke THT power pads) cannot
-    form the 2 spokes KiCad's geometric DRC requires, producing
-    ``starved_thermal`` errors.  ``normalize_zone_pad_connection`` adds a solid
-    (``yes``) mode token so pads get a full-copper connection instead -- a
-    strictly stronger connection, not a relaxed spoke count.
+    ``normalize_zone_pad_connection`` accepts the explicit KiCad zone-level
+    modes (``yes`` / ``thru_hole_only`` / ``no``), each of which adds a leading
+    mode token to every copper zone's ``connect_pads`` that lacks one.  The
+    *default* mode is now ``selective`` (tested separately in
+    :class:`TestSelectivePadConnection`).
     """
 
     _ZONE_THERMAL = """
@@ -331,7 +330,7 @@ class TestNormalizeZonePadConnection:
         doc = parse_string(self._ZONE_THERMAL)
         assert self._connect_pads_mode(doc) is None  # thermal-for-all
 
-        changed = normalize_zone_pad_connection(doc)
+        changed = normalize_zone_pad_connection(doc, mode="yes")
         assert changed == 1
         assert self._connect_pads_mode(doc) == "yes"
         # Must render as a bare keyword for KiCad, never a quoted string.
@@ -339,13 +338,13 @@ class TestNormalizeZonePadConnection:
         assert "(connect_pads yes (clearance" in rendered
         assert '"yes"' not in rendered
 
-    def test_idempotent(self):
+    def test_yes_mode_idempotent(self):
         from kicad_tools.zones.fill_clearance import normalize_zone_pad_connection
 
         doc = parse_string(self._ZONE_THERMAL)
-        assert normalize_zone_pad_connection(doc) == 1
+        assert normalize_zone_pad_connection(doc, mode="yes") == 1
         # A second pass finds the mode already present and makes no change.
-        assert normalize_zone_pad_connection(doc) == 0
+        assert normalize_zone_pad_connection(doc, mode="yes") == 0
         assert self._connect_pads_mode(doc) == "yes"
 
     def test_preserves_existing_mode(self):
@@ -357,7 +356,7 @@ class TestNormalizeZonePadConnection:
         )
         doc = parse_string(board)
         # An explicit upstream mode is never clobbered.
-        assert normalize_zone_pad_connection(doc) == 0
+        assert normalize_zone_pad_connection(doc, mode="yes") == 0
         assert self._connect_pads_mode(doc) == "thru_hole_only"
 
     def test_thru_hole_only_mode(self):
@@ -396,4 +395,300 @@ class TestNormalizeZonePadConnection:
         """
         doc = parse_string(keepout)
         # Keepout zones have no connect_pads -> nothing to normalize.
+        assert normalize_zone_pad_connection(doc, mode="yes") == 0
+
+
+class TestSelectivePadConnection:
+    """Issue #3729: the selective per-pad policy is the default.
+
+    The default mode keeps the zone's thermal-relief default and forces a
+    solid ``(zone_connect 2)`` override only on pads too small to host the 2
+    thermal spokes KiCad's geometric DRC requires.  Pads that can host 2
+    spokes keep their thermal relief (which eases hand-soldering / rework).
+    """
+
+    # A GND zone (F.Cu) with three pads of varying size on its net:
+    #  - small SMD 0.5x0.5  -> cannot host 2 spokes -> force solid
+    #  - large SMD 3.0x3.0  -> hosts 2 spokes        -> keep thermal relief
+    #  - THT   1.6x1.6      -> hosts 2 spokes        -> keep thermal relief
+    # Plus a foreign-net SMD pad that must never be touched.
+    _BOARD = """
+    (kicad_pcb
+      (version 20240108)
+      (generator "test")
+      (net 0 "")
+      (net 1 "GND")
+      (net 2 "SIG")
+      (footprint "lib:small" (layer "F.Cu") (at 5 5)
+        (pad "1" smd rect (at 0 0) (size 0.5 0.5) (layers "F.Cu")
+          (net 1 "GND") (uuid "pad-small")))
+      (footprint "lib:big" (layer "F.Cu") (at 10 10)
+        (pad "1" smd rect (at 0 0) (size 3.0 3.0) (layers "F.Cu")
+          (net 1 "GND") (uuid "pad-big")))
+      (footprint "lib:tht" (layer "F.Cu") (at 15 15)
+        (pad "1" thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8) (layers "*.Cu")
+          (net 1 "GND") (uuid "pad-tht")))
+      (footprint "lib:foreign" (layer "F.Cu") (at 2 2)
+        (pad "1" smd rect (at 0 0) (size 0.4 0.4) (layers "F.Cu")
+          (net 2 "SIG") (uuid "pad-foreign")))
+      (zone
+        (net 1)
+        (net_name "GND")
+        (layer "F.Cu")
+        (uuid "z1")
+        (hatch edge 0.5)
+        (connect_pads (clearance 0.3))
+        (min_thickness 0.25)
+        (fill yes (thermal_gap 0.3) (thermal_bridge_width 0.4))
+        (polygon (pts (xy 0 0) (xy 20 0) (xy 20 20) (xy 0 20)))
+      )
+    )
+    """
+
+    def _zone_connect(self, doc, pad_uuid):
+        for fp in doc.find_all("footprint"):
+            for pad in fp.find_all("pad"):
+                u = pad.find("uuid")
+                if u is not None and u.get_string(0) == pad_uuid:
+                    zc = pad.find("zone_connect")
+                    return zc.get_int(0) if zc is not None else None
+        raise AssertionError(f"pad {pad_uuid} not found")
+
+    def test_default_mode_is_selective(self):
+        from kicad_tools.zones.fill_clearance import normalize_zone_pad_connection
+
+        doc = parse_string(self._BOARD)
+        # Default call -> selective: only the small pad is forced solid.
+        changed = normalize_zone_pad_connection(doc)
+        assert changed == 1
+        # The zone keeps thermal relief (no mode token added).
+        zone = doc.find_all("zone")[0]
+        connect_pads = zone.find("connect_pads")
+        assert [c.value for c in connect_pads.children if c.is_atom] == []
+
+    def test_small_pad_forced_solid(self):
+        from kicad_tools.zones.fill_clearance import normalize_zone_pad_connection
+
+        doc = parse_string(self._BOARD)
+        normalize_zone_pad_connection(doc)
+        assert self._zone_connect(doc, "pad-small") == 2
+
+    def test_large_pads_keep_thermal_relief(self):
+        from kicad_tools.zones.fill_clearance import normalize_zone_pad_connection
+
+        doc = parse_string(self._BOARD)
+        normalize_zone_pad_connection(doc)
+        # Large SMD and THT pads can host 2 spokes -> no override (thermal).
+        assert self._zone_connect(doc, "pad-big") is None
+        assert self._zone_connect(doc, "pad-tht") is None
+
+    def test_foreign_net_pad_never_touched(self):
+        from kicad_tools.zones.fill_clearance import normalize_zone_pad_connection
+
+        doc = parse_string(self._BOARD)
+        normalize_zone_pad_connection(doc)
+        # A pad whose net has no thermal-relief zone is left alone, even if it
+        # is tiny.
+        assert self._zone_connect(doc, "pad-foreign") is None
+
+    def test_idempotent(self):
+        from kicad_tools.zones.fill_clearance import normalize_zone_pad_connection
+
+        doc = parse_string(self._BOARD)
+        assert normalize_zone_pad_connection(doc) == 1
+        # A second pass finds the small pad already solid -> no change.
         assert normalize_zone_pad_connection(doc) == 0
+
+    def test_preserves_existing_zone_connect(self):
+        from kicad_tools.zones.fill_clearance import normalize_zone_pad_connection
+
+        board = self._BOARD.replace(
+            '(net 1 "GND") (uuid "pad-small")',
+            '(net 1 "GND") (zone_connect 1) (uuid "pad-small")',
+        )
+        doc = parse_string(board)
+        # A deliberate upstream per-pad zone_connect is never clobbered.
+        normalize_zone_pad_connection(doc)
+        assert self._zone_connect(doc, "pad-small") == 1
+
+    def test_zone_with_explicit_mode_opts_out(self):
+        from kicad_tools.zones.fill_clearance import normalize_zone_pad_connection
+
+        board = self._BOARD.replace(
+            "(connect_pads (clearance 0.3))",
+            "(connect_pads yes (clearance 0.3))",
+        )
+        doc = parse_string(board)
+        # The zone-level mode governs every pad, so no per-pad override added.
+        assert normalize_zone_pad_connection(doc) == 0
+        assert self._zone_connect(doc, "pad-small") is None
+
+
+class TestStarvedThermalReportParsing:
+    """Issue #3729: read pad/zone UUIDs back from a kicad-cli DRC report."""
+
+    _REPORT = {
+        "violations": [
+            {
+                "type": "starved_thermal",
+                "items": [
+                    {"description": "Zone [+24V] on F.Cu, priority 5", "uuid": "zone-1"},
+                    {"description": "Pad 4 [+3V3] of J3", "uuid": "pad-smd"},
+                ],
+            },
+            {
+                "type": "starved_thermal",
+                "items": [
+                    {"description": "Zone [+24V] on F.Cu", "uuid": "zone-1"},
+                    {"description": "PTH pad 2 [+24V] of Q5", "uuid": "pad-tht"},
+                ],
+            },
+            {
+                "type": "isolated_copper",
+                "items": [
+                    {"description": "Zone [+3.3V] on In2.Cu, priority 0", "uuid": "zone-iso"},
+                ],
+            },
+            {
+                "type": "clearance",
+                "items": [{"description": "Pad 1 of U1", "uuid": "pad-other"}],
+            },
+        ]
+    }
+
+    def test_starved_pad_uuids_match_smd_and_tht(self):
+        from kicad_tools.zones.fill_clearance import starved_thermal_pad_uuids
+
+        # Both the SMD ``Pad`` and through-hole ``PTH pad`` forms are caught,
+        # the paired zone item is skipped, and unrelated violations ignored.
+        assert starved_thermal_pad_uuids(self._REPORT) == {"pad-smd", "pad-tht"}
+
+    def test_isolated_zone_uuids(self):
+        from kicad_tools.zones.fill_clearance import isolated_copper_zone_uuids
+
+        assert isolated_copper_zone_uuids(self._REPORT) == {"zone-iso"}
+
+    def test_empty_report(self):
+        from kicad_tools.zones.fill_clearance import (
+            isolated_copper_zone_uuids,
+            starved_thermal_pad_uuids,
+        )
+
+        assert starved_thermal_pad_uuids({}) == set()
+        assert isolated_copper_zone_uuids({}) == set()
+
+
+class TestForceSolidByUuid:
+    """Issue #3729: force a solid connection on pads named by the DRC report."""
+
+    _BOARD = """
+    (kicad_pcb
+      (version 20240108)
+      (generator "test")
+      (net 0 "")
+      (net 1 "GND")
+      (footprint "lib:a" (layer "F.Cu") (at 5 5)
+        (pad "1" smd rect (at 0 0) (size 2.0 2.0) (layers "F.Cu")
+          (net 1 "GND") (uuid "pad-a")))
+      (footprint "lib:b" (layer "F.Cu") (at 9 5)
+        (pad "1" smd rect (at 0 0) (size 2.0 2.0) (layers "F.Cu")
+          (net 1 "GND") (uuid "pad-b")))
+    )
+    """
+
+    def test_forces_named_pads_solid(self):
+        from kicad_tools.zones.fill_clearance import force_solid_on_pads_by_uuid
+
+        doc = parse_string(self._BOARD)
+        changed = force_solid_on_pads_by_uuid(doc, {"pad-a"})
+        assert changed == 1
+        for fp in doc.find_all("footprint"):
+            for pad in fp.find_all("pad"):
+                u = pad.find("uuid").get_string(0)
+                zc = pad.find("zone_connect")
+                if u == "pad-a":
+                    assert zc is not None and zc.get_int(0) == 2
+                else:
+                    assert zc is None  # pad-b untouched
+
+    def test_empty_uuid_set_is_noop(self):
+        from kicad_tools.zones.fill_clearance import force_solid_on_pads_by_uuid
+
+        doc = parse_string(self._BOARD)
+        assert force_solid_on_pads_by_uuid(doc, set()) == 0
+
+
+class TestForceSolidOnIsolatedIslandPads:
+    """Issue #3729: resolve isolated-copper slivers to their anchoring pad.
+
+    An ``isolated_copper`` warning names only the zone, so the remediator
+    finds the small (sliver) filled_polygons in that zone and forces the
+    same-net pad whose copper touches one to a solid connection.  Substantial
+    fill lobes and pads not touching a sliver are never touched.
+    """
+
+    # A GND/F.Cu zone with two fill polygons: a large main pour and a tiny
+    # 0.3x0.3 sliver around a same-net pad whose lone spoke stranded it.
+    _BOARD = """
+    (kicad_pcb
+      (version 20240108)
+      (generator "test")
+      (net 0 "")
+      (net 1 "GND")
+      (footprint "lib:sliver" (layer "F.Cu") (at 10 0.5)
+        (pad "1" smd rect (at 0 0) (size 0.4 0.4) (layers "F.Cu")
+          (net 1 "GND") (uuid "pad-sliver")))
+      (footprint "lib:main" (layer "F.Cu") (at 2 2.5)
+        (pad "1" smd rect (at 0 0) (size 2.0 2.0) (layers "F.Cu")
+          (net 1 "GND") (uuid "pad-main")))
+      (zone
+        (net 1)
+        (net_name "GND")
+        (layer "F.Cu")
+        (uuid "z-iso")
+        (hatch edge 0.5)
+        (connect_pads (clearance 0.3))
+        (min_thickness 0.25)
+        (fill yes (thermal_gap 0.3) (thermal_bridge_width 0.4))
+        (polygon (pts (xy 0 0) (xy 20 0) (xy 20 5) (xy 0 5)))
+        (filled_polygon (layer "F.Cu")
+          (pts (xy 0 0) (xy 5 0) (xy 5 5) (xy 0 5)))
+        (filled_polygon (layer "F.Cu")
+          (pts (xy 9.8 0.3) (xy 10.2 0.3) (xy 10.2 0.7) (xy 9.8 0.7)))
+      )
+    )
+    """
+
+    def _zc(self, doc, uuid):
+        for fp in doc.find_all("footprint"):
+            for pad in fp.find_all("pad"):
+                u = pad.find("uuid")
+                if u is not None and u.get_string(0) == uuid:
+                    zc = pad.find("zone_connect")
+                    return zc.get_int(0) if zc is not None else None
+        raise AssertionError(uuid)
+
+    def test_forces_sliver_anchor_pad_solid(self):
+        from kicad_tools.zones.fill_clearance import force_solid_on_isolated_island_pads
+
+        doc = parse_string(self._BOARD)
+        changed = force_solid_on_isolated_island_pads(doc, {"z-iso"})
+        assert changed == 1
+        # The pad whose copper touches the tiny sliver is forced solid...
+        assert self._zc(doc, "pad-sliver") == 2
+        # ...while the pad in the substantial main pour keeps thermal relief.
+        assert self._zc(doc, "pad-main") is None
+
+    def test_noop_for_unlisted_zone(self):
+        from kicad_tools.zones.fill_clearance import force_solid_on_isolated_island_pads
+
+        doc = parse_string(self._BOARD)
+        # A zone UUID not in the set is ignored entirely.
+        assert force_solid_on_isolated_island_pads(doc, {"other-zone"}) == 0
+        assert self._zc(doc, "pad-sliver") is None
+
+    def test_empty_set_is_noop(self):
+        from kicad_tools.zones.fill_clearance import force_solid_on_isolated_island_pads
+
+        doc = parse_string(self._BOARD)
+        assert force_solid_on_isolated_island_pads(doc, set()) == 0


### PR DESCRIPTION
## Summary

PR #3728 cleared `starved_thermal` by forcing a **solid** zone connection on
*every* pad (the global default).  This refines it to a **selective** policy
(now the default): zones keep thermal relief, and a solid per-pad
`(zone_connect 2)` override is forced only on the pads that genuinely cannot
host the 2 thermal spokes KiCad's geometric DRC requires.  Pads that *can*
host 2 spokes keep their thermal relief, which eases hand-soldering / rework.

## How solid-vs-thermal is decided per pad

Two complementary tiers, both grounded in geometry / KiCad's own DRC:

1. **Pad-size heuristic** (`_apply_selective_pad_connection`, the default mode
   of `normalize_zone_pad_connection`): a pad keeps thermal relief only when
   its narrow dimension can seat a spoke plus the thermal gap on both sides
   (`thermal_bridge_width + 2·thermal_gap + margin`).  Smaller pads are forced
   solid.  This handles the obvious small-SMD pads cheaply, pre-fill.
2. **Measurement-driven remediation** (`_remediate_starved_thermal`): reads
   KiCad's DRC back from the fill and forces solid on exactly the residue pad
   size cannot predict —
   - `starved_thermal` (single-spoke pour-edge pads and THT power tabs like
     board 05's Q1/Q5 drains and J3), matched by pad **UUID**;
   - the same-net pad anchoring each `isolated_copper` sliver, resolved
     geometrically (`force_solid_on_isolated_island_pads`).

   Remediation refills via kicad-cli, applies the #3711 foreign-pad clearance
   carve *inside* each pass (so the geometry DRC checks is what ships), and
   snapshots/restores the net table around every refill.

The zone-level `pad_connection` param is preserved as an explicit override:
`"yes"` reproduces the #3728 blanket-solid behavior; `"thru_hole_only"` / `"no"`
are unchanged.  `min_thermal_relief_spokes` is never lowered.

## Changes

- `sexp/builders.py`: `zone_node` `pad_connection` now defaults to `""`
  (zone-level thermal relief) instead of `"yes"`.
- `zones/generator.py`: `ZoneConfig` / `add_zone` `pad_connection` default `""`.
- `zones/fill_clearance.py`: `normalize_zone_pad_connection` defaults to the new
  `"selective"` mode; adds the spoke-viability test, per-pad `zone_connect`
  helpers, DRC-report parsers, and the isolated-island pad resolver.
- `cli/runner.py`: `_remediate_starved_thermal` loop (DRC -> force solid ->
  refill, with the foreign-pad carve as a per-pass settle step and net-table
  restore around refills) wired into `run_fill_zones`.

## Acceptance Criteria Verification

Verified by regenerating each board's zones in a temp dir
(`uv run --with shapely kct zones fill <pcb> -o /tmp/...`) and running
`kicad-cli pcb drc` (v10.0.1).

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Selective policy is the default (not blanket-solid, not blanket-thermal) | ✅ | `normalize_zone_pad_connection` defaults to `"selective"`; zone token default `""` |
| 0 `starved_thermal` preserved on 03/04/05/softstart | ✅ | DRC: 03 19→0, 04 2→0, 05 14→0, softstart 3→0 |
| Pads that CAN host thermal relief keep it | ✅ | thermal-relief retained: 03=6, 04=31, 05=18, softstart=42 pads (vs solid 42/29/73/80) |
| No new unconnected/isolated_copper/clearance regressions | ✅ | all boards isolated_copper=0, unconnected=0; clearance unchanged from baseline (04=4, 05=21, softstart=16) |
| Boards 01 & 02 stay clean | ✅ | DRC starved=0 isolated=0 unconnected=0 |
| `pad_connection` override preserved | ✅ | `"yes"` still emits blanket `connect_pads yes`; tests cover it |
| `min_thermal_relief_spokes` never lowered | ✅ | no spoke-count setting touched (diff only edits comment text) |
| Test coverage | ✅ | selective decision, UUID/island remediation, report parsing, mode overrides — 330 tests pass |

## Test Plan

- `uv run --with shapely pytest tests/test_zones_fill_clearance.py tests/test_zones_cmd.py tests/test_sexp_builders.py tests/test_zone_generator.py tests/test_route_cmd_zone_fill.py tests/test_gerber_zone_fill.py tests/test_validate_zone_fill.py tests/test_zone_api.py tests/test_runner_net_restore.py` — 330 passed, 1 skipped.
- `ruff check` + `ruff format --check` clean on all changed files.
- Per-board regenerate + kicad-cli DRC for boards 01–05 + softstart (see table).

Note: regenerated board artifacts are intentionally out of scope (per-board PRs handle those); this PR is the shared generation refinement.

Closes #3729