### PR TITLE
fix(mfr): restore kicad-cli standard-via detection via micro-via floor split

### DIFF
--- a/src/kicad_tools/manufacturers/project_generator.py
+++ b/src/kicad_tools/manufacturers/project_generator.py
@@ -53,23 +53,41 @@ _NON_BLOCKING_SEVERITIES: dict[str, str] = {
     "isolated_copper": "warning",
 }
 
-# Built-in via floors that accommodate micro vias (Issue #3734).
+# Built-in via floors and the micro-via split (Issues #3734, #3736).
 #
 # KiCad's built-in ``via_diameter`` / ``annular_width`` / ``hole_size``
-# checks read ``design_settings.rules`` and have NO micro-via exemption --
-# they fire on every via, including the ``(via micro ...)`` structures that
-# the router's ``--micro-via-in-pad-fallback`` emits for fine-pitch escape
-# (e.g. LQFP-48 0.5 mm pitch, where a 0.6 mm via cannot fit between adjacent
-# pads).  Because KiCad applies the *most restrictive* of built-in + custom
-# rules, the ``A.Via_Type != 'Micro'`` exemption in the generated
-# ``.kicad_dru`` cannot relax the built-in minimum; the built-in floor has
-# to be lowered to the micro-via process minimum here.  The standard
-# through-via floor is still enforced -- by the ``.kicad_dru`` "Via Diameter"
-# / "Annular Ring" / "Via Drill" rules, which apply to non-micro vias only.
-# This mirrors the kct-check engine, which flatly exempts ``via_type ==
-# "micro"`` from the standard floors (see validate/rules/dimensions.py) on
-# the basis that jlcpcb-tier1's Capability+ tier supports ~0.1 mm drill /
-# 0.2 mm OD micro vias natively.
+# checks read ``design_settings.rules`` and fire on every via, including the
+# ``(via micro ...)`` structures the router's ``--micro-via-in-pad-fallback``
+# emits for fine-pitch escape (e.g. LQFP-48 0.5 mm pitch, where a 0.6 mm via
+# cannot fit between adjacent pads).  jlcpcb-tier1's Capability+ tier supports
+# these micro vias natively, so the kct-check engine flatly exempts
+# ``via_type == "micro"`` from the standard floors (see
+# validate/rules/dimensions.py) and we mirror that here.
+#
+# #3734 lowered the *built-in* ``min_via_*`` floor to the micro minimum for
+# ALL vias and relied on the ``A.Via_Type != 'Micro'`` guarded ``.kicad_dru``
+# rules as the standard-via backstop.  #3736 (board-04 judge) found that
+# backstop is non-functional under kicad-cli 10.0.1: any custom
+# ``solder_mask_margin`` rule (the unconditional "Solder Mask Clearance" rule
+# this generator always emits) SILENTLY SUPPRESSES ``via_diameter`` /
+# ``annular_width`` reporting from the other custom DRU rules -- a kicad-cli
+# bug, reproduced in tests/test_drc_constraints_export.py.  Net effect: a
+# genuinely sub-spec STANDARD via passed kicad-cli silently.
+#
+# Fix: keep the BUILT-IN ``min_via_diameter`` / ``min_via_hole`` at the
+# manufacturer's STANDARD floor (built-in checks are NOT masked by the
+# solder-mask quirk, so they catch sub-spec standard vias independently) and
+# exempt micro vias from those two checks via KiCad's dedicated
+# ``min_microvia_diameter`` / ``min_microvia_drill`` keys.
+#
+# ``annular_width`` is the one exception: KiCad 10.0.1 has NO micro-via
+# annular key (``min_microvia_annular_width`` is silently ignored), so the
+# built-in ``annular_width`` floor applies to micro vias too.  Holding it at
+# the standard floor would falsely flag board-04's legitimate micro vias, so
+# ``min_via_annular_width`` stays at the micro floor; standard-via annular is
+# enforced by ``kct check --mfr`` (the primary CI gate, with its own
+# micro-via exemption) plus the guarded DRU "Annular Ring" rule.  This is a
+# documented kicad-cli limitation, not a coverage gap in the primary gate.
 _MICRO_VIA_FLOOR_DIAMETER_MM = 0.2
 _MICRO_VIA_FLOOR_ANNULAR_MM = 0.05
 _MICRO_VIA_FLOOR_HOLE_MM = 0.1
@@ -132,15 +150,23 @@ def build_project_rules(rules: DesignRules) -> dict[str, float]:
     return {
         "min_clearance": rules.min_clearance_mm,
         "min_track_width": rules.min_trace_width_mm,
-        # Built-in via floors are set to the micro-via process minimum so
-        # KiCad's exemption-less built-in checks do not flag the router's
-        # fine-pitch micro vias; the standard through-via floor is enforced
-        # by the ``.kicad_dru`` "Via Diameter"/"Annular Ring"/"Via Drill"
-        # rules (non-micro only).  See ``_MICRO_VIA_FLOOR_*`` above.
-        "min_via_diameter": _MICRO_VIA_FLOOR_DIAMETER_MM,
+        # Standard via diameter / hole floors stay at the manufacturer
+        # minimum so KiCad's built-in checks independently catch sub-spec
+        # STANDARD vias (the #3734 DRU backstop is masked by the
+        # solder_mask_margin quirk -- see _MICRO_VIA_FLOOR_* above).  Micro
+        # vias are exempted from these two built-in checks via the dedicated
+        # ``min_microvia_diameter`` / ``min_microvia_drill`` keys.
+        "min_via_diameter": rules.min_via_diameter_mm,
+        "min_microvia_diameter": _MICRO_VIA_FLOOR_DIAMETER_MM,
+        # ``annular_width`` has no micro-via key in KiCad 10.0.1, so this
+        # floor applies to micro vias too -- it must stay at the micro
+        # minimum to avoid false positives on legitimate micro vias.
+        # Standard-via annular is enforced by ``kct check --mfr`` + the
+        # guarded DRU "Annular Ring" rule.
         "min_via_annular_width": _MICRO_VIA_FLOOR_ANNULAR_MM,
         "min_through_hole_diameter": rules.min_hole_diameter_mm,
-        "min_via_hole": _MICRO_VIA_FLOOR_HOLE_MM,
+        "min_via_hole": rules.min_via_drill_mm,
+        "min_microvia_drill": _MICRO_VIA_FLOOR_HOLE_MM,
         "min_hole_to_hole": rules.min_hole_to_edge_mm,
         "min_copper_edge_clearance": rules.min_copper_to_edge_mm,
         "min_silk_clearance": rules.min_solder_mask_clearance_mm,

--- a/tests/test_drc_constraints_export.py
+++ b/tests/test_drc_constraints_export.py
@@ -33,6 +33,7 @@ from kicad_tools.manufacturers.project_generator import (
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 BOARD_03 = REPO_ROOT / "boards/03-usb-joystick/output/usb_joystick_routed.kicad_pcb"
+BOARD_04 = REPO_ROOT / "boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb"
 
 
 # ---------------------------------------------------------------------------
@@ -48,13 +49,18 @@ def test_project_rules_match_profile_minimums():
 
     assert pro_rules["min_track_width"] == rules.min_trace_width_mm
     assert pro_rules["min_clearance"] == rules.min_clearance_mm
-    # The built-in via floors are relaxed to the micro-via process minimum
-    # so KiCad's exemption-less built-in checks do not flag the router's
-    # fine-pitch micro vias (Issue #3734).  The standard through-via floor
-    # is enforced by the .kicad_dru "Via Diameter"/"Annular Ring"/"Via
-    # Drill" rules (A.Via_Type != 'Micro') and the netclass via size.
-    assert pro_rules["min_via_diameter"] == _MICRO_VIA_FLOOR_DIAMETER_MM
-    assert pro_rules["min_via_hole"] == _MICRO_VIA_FLOOR_HOLE_MM
+    # #3736: the built-in via *diameter* and *hole* floors stay at the
+    # manufacturer STANDARD minimum so kicad-cli's built-in checks catch
+    # sub-spec standard vias independently (the #3734 DRU backstop is masked
+    # by the solder_mask_margin quirk).  Micro vias are exempted from those
+    # two built-in checks via the dedicated min_microvia_* keys.
+    assert pro_rules["min_via_diameter"] == rules.min_via_diameter_mm
+    assert pro_rules["min_via_hole"] == rules.min_via_drill_mm
+    assert pro_rules["min_microvia_diameter"] == _MICRO_VIA_FLOOR_DIAMETER_MM
+    assert pro_rules["min_microvia_drill"] == _MICRO_VIA_FLOOR_HOLE_MM
+    # annular_width has no micro-via key in KiCad 10.0.1, so its built-in
+    # floor must stay at the micro minimum to avoid false positives on
+    # legitimate micro vias; standard-via annular is enforced by kct check.
     assert pro_rules["min_via_annular_width"] == _MICRO_VIA_FLOOR_ANNULAR_MM
     assert pro_rules["min_through_hole_diameter"] == rules.min_hole_diameter_mm
     assert pro_rules["min_copper_edge_clearance"] == rules.min_copper_to_edge_mm
@@ -255,8 +261,105 @@ def test_export_emits_sibling_kicad_pro(tmp_path: Path):
     # Board 03 is 2-layer -> 2-layer profile minimums.
     assert pro_rules["min_track_width"] == rules.min_trace_width_mm
     assert pro_rules["min_clearance"] == rules.min_clearance_mm
-    # Built-in via floor is the micro-via process minimum (Issue #3734);
-    # the standard 2-layer via size lives in the Default netclass.
-    assert pro_rules["min_via_diameter"] == _MICRO_VIA_FLOOR_DIAMETER_MM
+    # #3736: built-in via diameter floor stays at the standard 2-layer
+    # minimum; micro vias are exempted via min_microvia_diameter.
+    assert pro_rules["min_via_diameter"] == rules.min_via_diameter_mm
+    assert pro_rules["min_microvia_diameter"] == _MICRO_VIA_FLOOR_DIAMETER_MM
     assert data["net_settings"]["classes"][0]["via_diameter"] == rules.min_via_diameter_mm
     assert data["net_settings"]["classes"][0]["clearance"] == rules.min_clearance_mm
+
+
+# ---------------------------------------------------------------------------
+# Regression (#3736): kicad-cli independently catches sub-spec STANDARD vias
+# ---------------------------------------------------------------------------
+#
+# #3734 lowered the built-in via floors to the micro minimum for ALL vias and
+# relied on the A.Via_Type != 'Micro' guarded .kicad_dru rules to gate
+# standard vias.  The board-04 judge found those DRU rules are silently
+# suppressed by the unconditional solder_mask_margin rule under kicad-cli
+# 10.0.1, so a sub-spec STANDARD via passed kicad-cli silently.  #3736 keeps
+# the built-in min_via_diameter / min_via_hole at the standard floor (built-in
+# checks are NOT masked) while exempting micro vias via min_microvia_*.
+
+
+def _kicad_cli() -> Path | None:
+    from kicad_tools.cli.runner import find_kicad_cli
+
+    return find_kicad_cli()
+
+
+def _run_drc(cli: Path, pcb: Path, report: Path) -> str:
+    import subprocess
+
+    subprocess.run(
+        [
+            str(cli),
+            "pcb",
+            "drc",
+            "--severity-error",
+            str(pcb),
+            "-o",
+            str(report),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return report.read_text()
+
+
+@pytest.mark.skipif(not BOARD_04.exists(), reason="board 04 routed PCB not available")
+@pytest.mark.skipif(_kicad_cli() is None, reason="kicad-cli not installed")
+def test_subspec_standard_via_fires_under_kicad_cli(tmp_path: Path):
+    """A sub-spec STANDARD via must fire via_diameter under kicad-cli on the
+    full emitted ruleset (regression for #3736)."""
+    cli = _kicad_cli()
+    assert cli is not None
+
+    pcb = tmp_path / "board.kicad_pcb"
+    text = BOARD_04.read_text()
+
+    # Shrink one legitimate standard 0.6 mm / 0.3 mm via to a sub-spec
+    # 0.4 mm diameter (0.05 mm annular) -- below the jlcpcb-tier1 standard
+    # 0.6 mm diameter / 0.15 mm annular floors.  This is NOT a micro via, so
+    # it must be caught by the built-in standard-via floor.
+    needle = "(at 32.5 38.15)\n\t\t(size 0.6)\n\t\t(drill 0.3)"
+    replacement = "(at 32.5 38.15)\n\t\t(size 0.4)\n\t\t(drill 0.3)"
+    assert needle in text, "expected standard via at (32.5, 38.15) in board 04"
+    pcb.write_text(text.replace(needle, replacement, 1))
+
+    profile = get_profile("jlcpcb-tier1")
+    rules = profile.get_design_rules(layers=4, copper_oz=1.0)
+    write_drc_constraints(pcb, rules, manufacturer_id="jlcpcb-tier1", layers=4)
+
+    report = _run_drc(cli, pcb, tmp_path / "drc.rpt")
+
+    # The sub-spec standard via must be flagged on the FULL ruleset (which
+    # includes the solder_mask_margin rule that masks the custom DRU via
+    # rules).  Before #3736 this reported 0 via_diameter violations.
+    assert "via_diameter" in report, (
+        "sub-spec STANDARD via was not flagged by kicad-cli on the full "
+        f"ruleset -- #3736 regression. Report:\n{report}"
+    )
+
+
+@pytest.mark.skipif(not BOARD_04.exists(), reason="board 04 routed PCB not available")
+@pytest.mark.skipif(_kicad_cli() is None, reason="kicad-cli not installed")
+def test_board_04_micro_vias_stay_clean_under_kicad_cli(tmp_path: Path):
+    """Board 04's legitimate micro vias must stay exempt: 0 kicad-cli errors
+    on the full emitted ruleset (the micro-via exemption survives #3736)."""
+    cli = _kicad_cli()
+    assert cli is not None
+
+    pcb = tmp_path / "board.kicad_pcb"
+    pcb.write_text(BOARD_04.read_text())
+
+    profile = get_profile("jlcpcb-tier1")
+    rules = profile.get_design_rules(layers=4, copper_oz=1.0)
+    write_drc_constraints(pcb, rules, manufacturer_id="jlcpcb-tier1", layers=4)
+
+    report = _run_drc(cli, pcb, tmp_path / "drc.rpt")
+
+    # Micro vias must not trip via_diameter / annular_width.
+    assert "via_diameter" not in report, f"micro via flagged via_diameter:\n{report}"
+    assert "annular_width" not in report, f"micro via flagged annular_width:\n{report}"


### PR DESCRIPTION
## Summary

PR #3735 (#3734) lowered the built-in `.kicad_pro` via floor to the micro minimum for ALL vias and relied on the `A.Via_Type != 'Micro'` guarded `.kicad_dru` rules to gate standard vias. The board-04 judge (#3736) found those DRU rules are **silently suppressed by the unconditional `solder_mask_margin` rule under kicad-cli 10.0.1** -- so a genuinely sub-spec STANDARD via passed `kicad-cli pcb drc` silently. kicad-cli's independent dimensional coverage regressed (the primary `kct check --mfr` gate still caught it, so this was defense-in-depth, not a release blocker).

## Investigation (reproduced the quirk)

Built a fixture from board 04 with one standard via shrunk to 0.4mm / 0.3mm drill (0.05mm annular -- sub the jlcpcb-tier1 0.6mm / 0.15mm floors) and ran `kicad-cli pcb drc` (v10.0.1) against the full emitted `.kicad_pro`+`.kicad_dru`:

- **Full committed ruleset (micro floors everywhere):** 0 violations -- the sub-spec standard via was NOT flagged (regression confirmed).
- **Remove the `Solder Mask Clearance` rule:** the via fires `via_diameter` + `annular_width` again.
- **Via DRU rules in isolation:** fire correctly. **Add any `solder_mask_margin` rule:** masked. Scoping the solder-mask rule to `A.Type == 'pad'` or reordering does NOT help -- the masking is keyed to the *presence* of a custom `solder_mask_margin` constraint. `physical_hole_clearance` (Solder Mask Dam) does NOT mask. **This is a kicad-cli 10.0.1 bug.**
- **Built-in floors are NOT masked** by the solder-mask quirk -- they fire independently.

## Fix

Split the built-in via floor in `project_generator.py`:

- `min_via_diameter` / `min_via_hole` -> manufacturer **STANDARD** floor (built-in catches sub-spec standard vias, independent of the masked DRU rules).
- `min_microvia_diameter` / `min_microvia_drill` -> **micro** floor (KiCad's dedicated micro-via keys exempt micro vias from those two built-in checks).
- `min_via_annular_width` -> stays at the **micro** floor.

### Documented kicad-cli limitation (annular)

KiCad 10.0.1 has **no micro-via annular key** (`min_microvia_annular_width` is silently ignored), so the built-in `annular_width` check applies one floor to ALL vias. Holding it at the standard floor would falsely flag board-04's legitimate micro vias (0.075mm < 0.15mm). So standard-via *annular* detection cannot be restored to the built-in engine without breaking board 04. Standard-via annular remains enforced by:
- the **primary `kct check --mfr` gate** (its own micro-via exemption -- the airtight CI gate), and
- the guarded DRU `Annular Ring` rule (functional in isolation; masked only when co-resident with the solder-mask rule under kicad-cli).

Net: **`via_diameter` + `via_hole` (drill) standard-via detection restored to kicad-cli; annular is a documented kicad-cli limitation mitigated by the primary gate.**

## Verification

| Check | Result |
|---|---|
| Board 04 (unmodified) under kicad-cli, regenerated sidecars | **0 violations** (micro vias stay exempt) |
| Sub-spec STANDARD via fixture under kicad-cli, full ruleset | **fires `via_diameter`** (regression fixed) |
| Boards 02 / 03 / 04 / 06 / softstart, regenerated sidecars | **all 0** under kicad-cli |
| `tests/test_drc_constraints_export.py` | 11 passed (incl. 2 new kicad-cli regression tests) |
| `test_mfr / test_fab_rules / test_board_04_mfr_gate / test_netclass / test_manufacturer_*` | 424 passed, 2 skipped |

## Tests added

- `test_subspec_standard_via_fires_under_kicad_cli` -- a sub-spec standard via now fires `via_diameter` on the full ruleset.
- `test_board_04_micro_vias_stay_clean_under_kicad_cli` -- board 04's micro vias stay 0.

## Scope

Shared-toolchain fix (`project_generator.py` only). `dru_generator.py` is unchanged, so the static `rules/*.kicad_dru` fixtures need no regeneration. Per-board sidecars are emitted by export and not committed.

**Out of scope (pre-existing):** `cmaes`-extra test collection errors (noted in #3734/#3735).

Closes #3736