### PR TITLE
fix(geometry): negate footprint angle in forward pad transforms to match pcbnew

### DIFF
--- a/src/kicad_tools/analysis/complexity.py
+++ b/src/kicad_tools/analysis/complexity.py
@@ -261,7 +261,9 @@ class ComplexityAnalyzer:
 
         for footprint in board.footprints:
             fx, fy = footprint.position
-            rotation = math.radians(footprint.rotation or 0)
+            # KiCad applies the footprint orientation as a NEGATED angle vs
+            # standard CCW math (verified vs pcbnew, issue #3739).
+            rotation = math.radians(-(footprint.rotation or 0))
 
             for pad in footprint.pads:
                 # Transform pad position to board coordinates

--- a/src/kicad_tools/analysis/net_status.py
+++ b/src/kicad_tools/analysis/net_status.py
@@ -567,7 +567,9 @@ class NetStatusAnalyzer:
         Returns:
             Pad position in board coordinates
         """
-        angle = math.radians(rotation)
+        # KiCad applies the footprint orientation as a NEGATED angle vs
+        # standard CCW math (verified vs pcbnew, issue #3739).
+        angle = math.radians(-rotation)
         px, py = pad_local
         cos_a = math.cos(angle)
         sin_a = math.sin(angle)

--- a/src/kicad_tools/cli/placement_cmd.py
+++ b/src/kicad_tools/cli/placement_cmd.py
@@ -940,10 +940,10 @@ def _estimate_routability(pcb_path: Path, quiet: bool = False) -> tuple[float, i
                 ref = fp.reference
                 cx, cy = fp.position
                 rotation = fp.rotation
-                # NOTE: positive sign matches PCB.get_pad_position (the
-                # canonical local->world transform used throughout the
-                # codebase).  KiCad rotation is positive counter-clockwise.
-                rot_rad = math.radians(rotation)
+                # KiCad applies the footprint orientation as a NEGATED angle vs
+                # standard CCW math (verified vs pcbnew 10.0.1, issue #3739);
+                # matches PCB.get_pad_position / core.geometry.rotate_pad_offset.
+                rot_rad = math.radians(-rotation)
                 cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
 
                 pads = []

--- a/src/kicad_tools/cli/stitch_cmd.py
+++ b/src/kicad_tools/cli/stitch_cmd.py
@@ -685,8 +685,10 @@ def find_pads_on_nets(sexp: SExp, net_names: set[str]) -> list[PadInfo]:
             pad_rel_x = pad_at.get_float(0) or 0.0
             pad_rel_y = pad_at.get_float(1) or 0.0
 
-            # Transform pad position to board coordinates
-            rad = math.radians(fp_rotation)
+            # Transform pad position to board coordinates.
+            # KiCad applies the footprint orientation as a NEGATED angle vs
+            # standard CCW math (verified vs pcbnew, issue #3739).
+            rad = math.radians(-fp_rotation)
             cos_r = math.cos(rad)
             sin_r = math.sin(rad)
             pad_x = fp_x + pad_rel_x * cos_r - pad_rel_y * sin_r
@@ -757,7 +759,9 @@ def find_smd_pad_bboxes_on_nets(
         fp_x = at_node.get_float(0) or 0.0
         fp_y = at_node.get_float(1) or 0.0
         fp_rotation_deg = at_node.get_float(2) or 0.0
-        rad = math.radians(fp_rotation_deg)
+        # KiCad applies the footprint orientation as a NEGATED angle vs
+        # standard CCW math (verified vs pcbnew, issue #3739).
+        rad = math.radians(-fp_rotation_deg)
         cos_r = math.cos(rad)
         sin_r = math.sin(rad)
 
@@ -862,7 +866,9 @@ def find_all_pad_bboxes(
         fp_x = at_node.get_float(0) or 0.0
         fp_y = at_node.get_float(1) or 0.0
         fp_rotation_deg = at_node.get_float(2) or 0.0
-        rad = math.radians(fp_rotation_deg)
+        # KiCad applies the footprint orientation as a NEGATED angle vs
+        # standard CCW math (verified vs pcbnew, issue #3739).
+        rad = math.radians(-fp_rotation_deg)
         cos_r = math.cos(rad)
         sin_r = math.sin(rad)
 
@@ -1145,7 +1151,9 @@ def find_all_pads(
             continue
         fp_x = at_node.get_float(0) or 0.0
         fp_y = at_node.get_float(1) or 0.0
-        fp_rot = math.radians(at_node.get_float(2) or 0.0)
+        # KiCad applies the footprint orientation as a NEGATED angle vs
+        # standard CCW math (verified vs pcbnew, issue #3739).
+        fp_rot = math.radians(-(at_node.get_float(2) or 0.0))
 
         cos_rot = math.cos(fp_rot)
         sin_rot = math.sin(fp_rot)
@@ -3129,7 +3137,9 @@ def find_thermal_pad_candidates(
         fp_match = _matches_footprint_pattern(footprint_name, footprint_patterns)
         ref_match = _matches_reference_prefix(reference, reference_prefixes)
 
-        rad = math.radians(fp_rotation)
+        # KiCad applies the footprint orientation as a NEGATED angle vs
+        # standard CCW math (verified vs pcbnew, issue #3739).
+        rad = math.radians(-fp_rotation)
         cos_r = math.cos(rad)
         sin_r = math.sin(rad)
 

--- a/src/kicad_tools/core/geometry.py
+++ b/src/kicad_tools/core/geometry.py
@@ -198,3 +198,61 @@ def segment_clearance(
     """
     center_dist = segment_to_segment_distance(ax1, ay1, ax2, ay2, bx1, by1, bx2, by2)
     return center_dist - width_a / 2 - width_b / 2
+
+
+# ---------------------------------------------------------------------------
+# Footprint pad rotation (KiCad convention)
+# ---------------------------------------------------------------------------
+
+
+def rotate_pad_offset(
+    local_x: float,
+    local_y: float,
+    rotation_deg: float,
+) -> tuple[float, float]:
+    """Rotate a pad's footprint-local offset into board-frame offset.
+
+    This is the canonical forward local->world rotation for pad/footprint
+    geometry. It MUST match KiCad's own ``pcbnew`` transform.
+
+    KiCad applies the footprint orientation as a **negated** angle relative
+    to the standard counter-clockwise math convention (verified directly
+    against pcbnew 10.0.1, issue #3739)::
+
+        rotated_x =  lx*cos(theta) + ly*sin(theta)
+        rotated_y = -lx*sin(theta) + ly*cos(theta)
+
+    which is equivalent to evaluating the standard CCW matrix at
+    ``-rotation_deg``. For a footprint at (100,100) with a pad at local
+    offset (2,0), this yields the pcbnew-verified world positions:
+
+        ===  ====================
+        deg  world (mm)
+        ===  ====================
+          0  (102, 100)
+         90  (100,  98)
+        180  ( 98, 100)
+        270  (100, 102)
+        ===  ====================
+
+    The earlier standard-CCW form (PR #738) produced the mirror-image
+    positions at 90/270 degrees (0/180 agree under both signs -- the
+    "test trap" that hid the bug). To recover a board-frame offset back to
+    footprint-local coordinates (the *inverse* transform), call this with
+    ``-rotation_deg``.
+
+    Args:
+        local_x: Pad x offset in footprint-local frame.
+        local_y: Pad y offset in footprint-local frame.
+        rotation_deg: Footprint orientation in degrees.
+
+    Returns:
+        Tuple ``(rotated_x, rotated_y)`` board-frame offset (not yet
+        translated by the footprint origin).
+    """
+    angle_rad = math.radians(-rotation_deg)
+    cos_a = math.cos(angle_rad)
+    sin_a = math.sin(angle_rad)
+    rotated_x = local_x * cos_a - local_y * sin_a
+    rotated_y = local_x * sin_a + local_y * cos_a
+    return rotated_x, rotated_y

--- a/src/kicad_tools/design/strategies.py
+++ b/src/kicad_tools/design/strategies.py
@@ -355,12 +355,12 @@ class MCUCoreStrategy(PlacementStrategy):
             return None
 
         # Rotate pad-local offsets into the world frame using the
-        # footprint's rotation. KiCad rotation is positive CCW; the
-        # standard 2D rotation matrix applies directly (no negation).
-        # This matches PCB.get_pad_position and the router's
-        # adaptive._add_component_to_router transform.
+        # footprint's rotation. KiCad applies the orientation as a NEGATED
+        # angle vs standard CCW math (verified vs pcbnew 10.0.1, #3739).
+        # This matches PCB.get_pad_position / core.geometry.rotate_pad_offset
+        # and the router's adaptive._add_component_to_router transform.
         rotation_deg = float(getattr(mcu_fp, "rotation", 0.0) or 0.0)
-        rot_rad = math.radians(rotation_deg)
+        rot_rad = math.radians(-rotation_deg)
         cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
 
         sum_x = 0.0

--- a/src/kicad_tools/drc/cpp_backend.py
+++ b/src/kicad_tools/drc/cpp_backend.py
@@ -152,8 +152,12 @@ def check_pair_clearance_cpp(
         return None
 
     pos1 = fp1_position if fp1_position is not None else fp1.position
-    rot1_rad = math.radians(fp1.rotation)
-    rot2_rad = math.radians(fp2.rotation)
+    # The C++ kernel applies the standard CCW rotation matrix to the angle it
+    # receives; KiCad uses the NEGATED footprint orientation (verified vs
+    # pcbnew, issue #3739), so we pass -rotation here. This keeps the convention
+    # in one place (Python) without recompiling the native extension.
+    rot1_rad = math.radians(-fp1.rotation)
+    rot2_rad = math.radians(-fp2.rotation)
 
     result = drc_cpp.check_pair_clearance(
         lx1,

--- a/src/kicad_tools/drc/incremental.py
+++ b/src/kicad_tools/drc/incremental.py
@@ -582,8 +582,10 @@ class IncrementalDRC:
         max_x = float("-inf")
         max_y = float("-inf")
 
-        cos_a = math.cos(math.radians(fp.rotation))
-        sin_a = math.sin(math.radians(fp.rotation))
+        # KiCad applies the footprint orientation as a NEGATED angle vs
+        # standard CCW math (verified vs pcbnew, issue #3739).
+        cos_a = math.cos(math.radians(-fp.rotation))
+        sin_a = math.sin(math.radians(-fp.rotation))
 
         for pad in fp.pads:
             # Transform pad position to board coordinates
@@ -739,10 +741,12 @@ class IncrementalDRC:
 
         pos1 = fp1_position if fp1_position is not None else fp1.position
 
-        cos1 = math.cos(math.radians(fp1.rotation))
-        sin1 = math.sin(math.radians(fp1.rotation))
-        cos2 = math.cos(math.radians(fp2.rotation))
-        sin2 = math.sin(math.radians(fp2.rotation))
+        # KiCad applies the footprint orientation as a NEGATED angle vs
+        # standard CCW math (verified vs pcbnew, issue #3739).
+        cos1 = math.cos(math.radians(-fp1.rotation))
+        sin1 = math.sin(math.radians(-fp1.rotation))
+        cos2 = math.cos(math.radians(-fp2.rotation))
+        sin2 = math.sin(math.radians(-fp2.rotation))
 
         for pad1 in fp1.pads:
             # Transform pad1 to board coordinates

--- a/src/kicad_tools/drc/repair_clearance.py
+++ b/src/kicad_tools/drc/repair_clearance.py
@@ -1260,7 +1260,9 @@ class ClearanceRepairer:
             fp_y = float(fp_atoms[1]) if len(fp_atoms) > 1 else 0.0
             fp_rot = float(fp_atoms[2]) if len(fp_atoms) > 2 else 0.0
 
-            angle_rad = math.radians(fp_rot)
+            # KiCad applies the footprint orientation as a NEGATED angle vs
+            # standard CCW math (verified vs pcbnew, issue #3739).
+            angle_rad = math.radians(-fp_rot)
             cos_a = math.cos(angle_rad)
             sin_a = math.sin(angle_rad)
 
@@ -2007,8 +2009,10 @@ class ClearanceRepairer:
         new_x = round(old_x + dx, 4)
         new_y = round(old_y + dy, 4)
 
-        # Compute absolute pad positions before the move
-        angle_rad = math.radians(fp_rot)
+        # Compute absolute pad positions before the move.
+        # KiCad applies the footprint orientation as a NEGATED angle vs
+        # standard CCW math (verified vs pcbnew, issue #3739).
+        angle_rad = math.radians(-fp_rot)
         cos_a = math.cos(angle_rad)
         sin_a = math.sin(angle_rad)
 

--- a/src/kicad_tools/mcp/tools/analysis.py
+++ b/src/kicad_tools/mcp/tools/analysis.py
@@ -1016,14 +1016,15 @@ class _CopperElement:
 
 
 def _transform_pad_position(pad: Pad, footprint: Footprint) -> tuple[float, float]:
-    """Transform pad position from footprint-local to board coordinates."""
-    angle_rad = math.radians(footprint.rotation)
-    cos_a = math.cos(angle_rad)
-    sin_a = math.sin(angle_rad)
+    """Transform pad position from footprint-local to board coordinates.
+
+    Uses KiCad's negated-angle pad rotation convention (see
+    :func:`kicad_tools.core.geometry.rotate_pad_offset`).
+    """
+    from kicad_tools.core.geometry import rotate_pad_offset
 
     local_x, local_y = pad.position
-    rotated_x = local_x * cos_a - local_y * sin_a
-    rotated_y = local_x * sin_a + local_y * cos_a
+    rotated_x, rotated_y = rotate_pad_offset(local_x, local_y, footprint.rotation)
 
     abs_x = footprint.position[0] + rotated_x
     abs_y = footprint.position[1] + rotated_y

--- a/src/kicad_tools/mcp/tools/routing.py
+++ b/src/kicad_tools/mcp/tools/routing.py
@@ -271,11 +271,10 @@ def route_net(
 
         fp_x, fp_y = fp.position
         rotation = fp.rotation
-        # NOTE: positive sign matches PCB.get_pad_position (the canonical
-        # local->world transform used throughout the codebase).  KiCad
-        # stores rotation in degrees, positive = counter-clockwise, and
-        # the standard 2D rotation matrix applies directly (no negation).
-        rot_rad = math.radians(rotation)
+        # KiCad applies the footprint orientation as a NEGATED angle vs standard
+        # CCW math (verified vs pcbnew 10.0.1, issue #3739); matches
+        # PCB.get_pad_position / core.geometry.rotate_pad_offset.
+        rot_rad = math.radians(-rotation)
         cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
 
         for pad in fp.pads:
@@ -684,11 +683,10 @@ def _build_pad_positions(pcb: PCB) -> dict[int, list[tuple[float, float]]]:
 
         fp_x, fp_y = fp.position
         rotation = fp.rotation
-        # NOTE: positive sign matches PCB.get_pad_position (the canonical
-        # local->world transform used throughout the codebase).  KiCad
-        # stores rotation in degrees, positive = counter-clockwise, and
-        # the standard 2D rotation matrix applies directly (no negation).
-        rot_rad = math.radians(rotation)
+        # KiCad applies the footprint orientation as a NEGATED angle vs standard
+        # CCW math (verified vs pcbnew 10.0.1, issue #3739); matches
+        # PCB.get_pad_position / core.geometry.rotate_pad_offset.
+        rot_rad = math.radians(-rotation)
         cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
 
         for pad in fp.pads:
@@ -725,8 +723,9 @@ def _build_pads_for_net(pcb: PCB, net_number: int, net_name: str) -> list:
             continue
 
         fp_x, fp_y = fp.position
-        # KiCad rotation is CCW-positive; standard 2D rotation matrix applies directly
-        rot_rad = math.radians(fp.rotation)
+        # KiCad applies the footprint orientation as a NEGATED angle vs standard
+        # CCW math (verified vs pcbnew 10.0.1, issue #3739).
+        rot_rad = math.radians(-fp.rotation)
         cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
 
         for pad in fp.pads:

--- a/src/kicad_tools/optim/fom_features.py
+++ b/src/kicad_tools/optim/fom_features.py
@@ -132,12 +132,13 @@ def _pad_absolute_position(fp: Footprint, pad: Pad) -> tuple[float, float]:
     """Compute the pad's absolute (board-relative) position.
 
     Footprint pad coords are relative to the footprint origin and rotated by
-    the footprint's rotation (CCW in KiCad's coord convention).  This helper
+    the footprint's rotation. KiCad applies the orientation as a NEGATED angle
+    vs standard CCW math (verified vs pcbnew, issue #3739).  This helper
     converts to board-relative coords.
     """
     px, py = pad.position
     if fp.rotation:
-        theta = math.radians(fp.rotation)
+        theta = math.radians(-fp.rotation)
         cos_t = math.cos(theta)
         sin_t = math.sin(theta)
         rx = px * cos_t - py * sin_t

--- a/src/kicad_tools/optim/keepout.py
+++ b/src/kicad_tools/optim/keepout.py
@@ -240,9 +240,11 @@ def create_keepout_from_component(
             min_y = min(min_y, py - ph / 2)
             max_y = max(max_y, py + ph / 2)
 
-        # Transform to absolute coordinates
+        # Transform to absolute coordinates.
+        # KiCad applies the footprint orientation as a NEGATED angle vs
+        # standard CCW math (verified vs pcbnew, issue #3739).
         fx, fy = footprint.position
-        rot = math.radians(footprint.rotation)
+        rot = math.radians(-footprint.rotation)
         cos_r, sin_r = math.cos(rot), math.sin(rot)
 
         # Compute corners in component-local space

--- a/src/kicad_tools/optim/place_route.py
+++ b/src/kicad_tools/optim/place_route.py
@@ -299,10 +299,10 @@ class PlaceRouteOptimizer:
             cx, cy = fp.position
             rotation = fp.rotation
 
-            # Transform pad positions.  KiCad rotation is positive
-            # counter-clockwise; the standard 2D rotation matrix applies
-            # directly (no negation).  Matches PCB.get_pad_position.
-            rot_rad = math.radians(rotation)
+            # Transform pad positions.  KiCad applies the footprint orientation
+            # as a NEGATED angle vs standard CCW math (verified vs pcbnew 10.0.1,
+            # #3739).  Matches PCB.get_pad_position / core.geometry.rotate_pad_offset.
+            rot_rad = math.radians(-rotation)
             cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
 
             pads = []

--- a/src/kicad_tools/optim/router_factory.py
+++ b/src/kicad_tools/optim/router_factory.py
@@ -180,7 +180,10 @@ class PlacementRouterFactory:
             new_x, new_y = positions.get(off.ref, (comp_ref.base_x, comp_ref.base_y))
             new_rot = rotations.get(off.ref, comp_ref.base_rotation)
 
-            delta_rot = math.radians(new_rot - off.base_rotation)
+            # base offsets are real board-frame pad positions; a footprint
+            # re-rotation rotates them by the NEGATED delta to match KiCad's
+            # pad world positions (verified vs pcbnew 10.0.1, issue #3739).
+            delta_rot = math.radians(-(new_rot - off.base_rotation))
             cos_t = math.cos(delta_rot)
             sin_t = math.sin(delta_rot)
             rx = off.local_dx * cos_t - off.local_dy * sin_t

--- a/src/kicad_tools/pcb/placement.py
+++ b/src/kicad_tools/pcb/placement.py
@@ -43,8 +43,11 @@ class ComponentPlacement:
         # Start with pad position relative to component
         p = self.pads[pad_name]
 
-        # Rotate by component rotation
-        p = p.rotate(self.rotation)
+        # Rotate by component rotation. KiCad applies the footprint orientation
+        # as a NEGATED angle vs standard CCW math (verified vs pcbnew, #3739),
+        # so we rotate the pad offset by -rotation to match KiCad pad world
+        # positions. (Point.rotate itself stays standard-CCW for generic use.)
+        p = p.rotate(-self.rotation)
 
         # Translate to component position (relative to block)
         p = p + self.position

--- a/src/kicad_tools/placement/analyzer.py
+++ b/src/kicad_tools/placement/analyzer.py
@@ -253,9 +253,12 @@ class PlacementAnalyzer:
         holes: list[HoleInfo] = []
 
         for pad in fp.pads:
-            # Calculate absolute pad position (considering rotation)
+            # Calculate absolute pad position (considering rotation).
+            # KiCad applies the footprint orientation as a NEGATED angle vs
+            # standard CCW math (verified vs pcbnew, issue #3739); _rotate_point
+            # is standard-CCW, so pass -rotation to match KiCad pad positions.
             rel_x, rel_y = pad.position
-            abs_pos = self._rotate_point(Point(rel_x, rel_y), fp.rotation, position)
+            abs_pos = self._rotate_point(Point(rel_x, rel_y), -fp.rotation, position)
 
             pad_info = PadInfo(
                 name=pad.number,

--- a/src/kicad_tools/reasoning/state.py
+++ b/src/kicad_tools/reasoning/state.py
@@ -433,11 +433,10 @@ class PCBState:
         pads: list[PadState] = []
         import math
 
-        # NOTE: positive sign matches PCB.get_pad_position (the canonical
-        # local->world transform used throughout the codebase).  KiCad
-        # stores rotation in degrees, positive = counter-clockwise; the
-        # standard 2D rotation matrix applies directly (no negation).
-        rot_rad = math.radians(rotation)
+        # KiCad applies the footprint orientation as a NEGATED angle vs standard
+        # CCW math (verified vs pcbnew 10.0.1, issue #3739); matches
+        # PCB.get_pad_position / core.geometry.rotate_pad_offset.
+        rot_rad = math.radians(-rotation)
         cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
 
         for pad_node in fp_node.find_all("pad"):

--- a/src/kicad_tools/router/adaptive.py
+++ b/src/kicad_tools/router/adaptive.py
@@ -151,10 +151,10 @@ class AdaptiveAutorouter:
         cx, cy = comp["x"], comp["y"]
         rotation = comp.get("rotation", 0)
 
-        # Transform pad positions.  KiCad rotation is positive
-        # counter-clockwise; the standard 2D rotation matrix applies
-        # directly (no negation).  Matches PCB.get_pad_position.
-        rot_rad = math.radians(rotation)
+        # Transform pad positions.  KiCad applies the footprint orientation as a
+        # NEGATED angle vs standard CCW math (verified vs pcbnew 10.0.1, #3739).
+        # Matches PCB.get_pad_position / core.geometry.rotate_pad_offset.
+        rot_rad = math.radians(-rotation)
         cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
 
         pads: list[dict] = []

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -1765,8 +1765,9 @@ def extract_pad_positions(pcb_path_or_text: str | Path) -> list[PadPosition]:
         fp_y = float(at_match.group(2))
         fp_rot = float(at_match.group(3)) if at_match.group(3) else 0
 
-        # Precompute rotation values
-        rot_rad = math.radians(fp_rot)
+        # Precompute rotation values. KiCad applies the footprint orientation
+        # as a NEGATED angle vs standard CCW math (verified vs pcbnew, #3739).
+        rot_rad = math.radians(-fp_rot)
         cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
 
         # Find all pad blocks
@@ -1839,8 +1840,9 @@ def load_pads_for_analysis(pcb_path_or_text: str | Path) -> list[Pad]:
         fp_y = float(at_match.group(2))
         fp_rot = float(at_match.group(3)) if at_match.group(3) else 0
 
-        # Precompute rotation values
-        rot_rad = math.radians(fp_rot)
+        # Precompute rotation values. KiCad applies the footprint orientation
+        # as a NEGATED angle vs standard CCW math (verified vs pcbnew, #3739).
+        rot_rad = math.radians(-fp_rot)
         cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
 
         # Find all pad blocks
@@ -2839,11 +2841,11 @@ def route_pcb(
         rotation = comp.get("rotation", 0)
 
         # Transform pad positions based on component placement.
-        # KiCad stores rotation in degrees, positive = counter-clockwise;
-        # the standard 2D rotation matrix applies directly (no negation).
-        # See PCB.get_pad_position (schema/pcb.py) and the canonical
-        # implementation later in this file (~line 2661) for reference.
-        rot_rad = math.radians(rotation)
+        # KiCad applies the footprint orientation as a NEGATED angle relative
+        # to standard CCW math (verified vs pcbnew 10.0.1, issue #3739), so we
+        # evaluate the rotation matrix at -rotation. See
+        # core.geometry.rotate_pad_offset for the canonical implementation.
+        rot_rad = math.radians(-rotation)
         cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
 
         pads: list[dict] = []
@@ -3367,10 +3369,11 @@ def load_pcb_for_routing(
             if net_name in skip_nets:
                 net_num = 0  # Treat as obstacle, not a routable net
 
-            # Transform pad position by footprint rotation
-            # KiCad stores rotation in degrees, positive = counter-clockwise
-            # Standard 2D rotation matrix applies directly (no negation needed)
-            rot_rad = math.radians(fp_rot)
+            # Transform pad position by footprint rotation.
+            # KiCad applies the footprint orientation as a NEGATED angle vs
+            # standard CCW math (verified vs pcbnew 10.0.1, issue #3739), so we
+            # evaluate the rotation matrix at -fp_rot.
+            rot_rad = math.radians(-fp_rot)
             cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
             abs_x = fp_x + pad_x * cos_r - pad_y * sin_r
             abs_y = fp_y + pad_x * sin_r + pad_y * cos_r

--- a/src/kicad_tools/router/orchestrator.py
+++ b/src/kicad_tools/router/orchestrator.py
@@ -253,8 +253,9 @@ class RoutingOrchestrator:
         1. Autorouter-style ``self.pcb.pads`` dict keyed by
            ``(ref, pin)`` with router ``Pad`` values.
         2. Document-model ``self.pcb.footprints`` with relative pad
-           positions (rotated into world coordinates with the standard
-           CCW-positive convention, mirroring
+           positions (rotated into world coordinates with KiCad's
+           negated-angle convention -- see core.geometry.rotate_pad_offset,
+           #3739 -- mirroring
            ``kicad_tools.mcp.tools.routing._build_pads_for_net``).
 
         Returns ``None`` when neither shape is usable (e.g. mock PCBs in
@@ -281,9 +282,9 @@ class RoutingOrchestrator:
                     if not ref or ref.startswith("#"):
                         continue
                     fp_x, fp_y = fp.position
-                    # KiCad rotation is CCW-positive; standard 2D
-                    # rotation matrix applies directly.
-                    rot_rad = math.radians(getattr(fp, "rotation", 0.0) or 0.0)
+                    # KiCad applies the footprint orientation as a NEGATED angle
+                    # vs standard CCW math (verified vs pcbnew 10.0.1, #3739).
+                    rot_rad = math.radians(-(getattr(fp, "rotation", 0.0) or 0.0))
                     cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
                     for pad in fp.pads:
                         net = getattr(pad, "net_number", 0)

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -4182,17 +4182,14 @@ class PCB:
         if not fp:
             return None
 
+        from kicad_tools.core.geometry import rotate_pad_offset
+
         for pad in fp.pads:
             if pad.number == pad_number:
-                # Apply rotation to pad offset
-                rot_rad = math.radians(fp.rotation)
-                cos_r = math.cos(rot_rad)
-                sin_r = math.sin(rot_rad)
-
-                # Rotate pad position around footprint center
+                # Rotate pad offset around footprint origin using KiCad's
+                # negated-angle convention (see core.geometry.rotate_pad_offset).
                 pad_x, pad_y = pad.position
-                rotated_x = pad_x * cos_r - pad_y * sin_r
-                rotated_y = pad_x * sin_r + pad_y * cos_r
+                rotated_x, rotated_y = rotate_pad_offset(pad_x, pad_y, fp.rotation)
 
                 # Add footprint position
                 abs_x = fp.position[0] + rotated_x

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -4176,7 +4176,6 @@ class PCB:
             >>> pos = pcb.get_pad_position("U1", "1")
             >>> print(f"Pad at ({pos[0]:.2f}, {pos[1]:.2f})")
         """
-        import math
 
         fp = self.get_footprint(reference)
         if not fp:

--- a/src/kicad_tools/validate/connectivity.py
+++ b/src/kicad_tools/validate/connectivity.py
@@ -581,19 +581,12 @@ class ConnectivityValidator:
         Returns:
             Pad position in board coordinates
         """
-        import math
+        from kicad_tools.core.geometry import rotate_pad_offset
 
-        # Convert rotation to radians
-        # KiCad uses counter-clockwise positive rotation (standard math convention)
-        angle = math.radians(rotation)
-
-        # Rotate pad position
+        # Rotate pad position using KiCad's negated-angle convention
+        # (see kicad_tools.core.geometry.rotate_pad_offset).
         px, py = pad_local
-        cos_a = math.cos(angle)
-        sin_a = math.sin(angle)
-
-        rotated_x = px * cos_a - py * sin_a
-        rotated_y = px * sin_a + py * cos_a
+        rotated_x, rotated_y = rotate_pad_offset(px, py, rotation)
 
         # Translate to board coordinates
         board_x = fp_x + rotated_x

--- a/src/kicad_tools/validate/rules/clearance.py
+++ b/src/kicad_tools/validate/rules/clearance.py
@@ -14,6 +14,9 @@ from kicad_tools.core.geometry import (
     point_to_segment_distance as _point_to_segment_distance,
 )
 from kicad_tools.core.geometry import (
+    rotate_pad_offset as _rotate_pad_offset,
+)
+from kicad_tools.core.geometry import (
     segment_to_segment_distance as _segment_to_segment_distance,
 )
 from kicad_tools.core.geometry import (
@@ -125,17 +128,12 @@ class CopperElement:
 def _transform_pad_position(pad: Pad, footprint: Footprint) -> tuple[float, float]:
     """Transform pad position from footprint-local to board coordinates.
 
-    KiCad uses counter-clockwise positive rotation (standard math convention).
+    Uses KiCad's negated-angle pad rotation convention (see
+    :func:`kicad_tools.core.geometry.rotate_pad_offset`).
     """
-    # Apply rotation using standard 2D rotation matrix
-    angle_rad = math.radians(footprint.rotation)
-    cos_a = math.cos(angle_rad)
-    sin_a = math.sin(angle_rad)
-
-    # Rotate pad position around footprint origin
+    # Rotate pad position around footprint origin (KiCad convention)
     local_x, local_y = pad.position
-    rotated_x = local_x * cos_a - local_y * sin_a
-    rotated_y = local_x * sin_a + local_y * cos_a
+    rotated_x, rotated_y = _rotate_pad_offset(local_x, local_y, footprint.rotation)
 
     # Translate to board coordinates
     abs_x = footprint.position[0] + rotated_x

--- a/src/kicad_tools/validate/rules/edge.py
+++ b/src/kicad_tools/validate/rules/edge.py
@@ -192,8 +192,10 @@ class EdgeClearanceRule(DRCRule):
 
         for footprint in pcb.footprints:
             fp_x, fp_y = footprint.position
-            # KiCad rotation is CCW-positive; standard 2D rotation matrix applies directly
-            fp_rotation = math.radians(footprint.rotation)
+            # KiCad applies the footprint orientation as a NEGATED angle relative
+            # to standard CCW math (verified vs pcbnew, issue #3739). Use -rotation
+            # so the 2D rotation matrix below matches KiCad's pad world positions.
+            fp_rotation = math.radians(-footprint.rotation)
             cos_rot = math.cos(fp_rotation)
             sin_rot = math.sin(fp_rotation)
 

--- a/src/kicad_tools/validate/rules/netlist.py
+++ b/src/kicad_tools/validate/rules/netlist.py
@@ -8,7 +8,6 @@ is referencing an undeclared net.
 
 from __future__ import annotations
 
-import math
 from typing import TYPE_CHECKING
 
 from ..violations import DRCResults, DRCViolation

--- a/src/kicad_tools/validate/rules/netlist.py
+++ b/src/kicad_tools/validate/rules/netlist.py
@@ -102,12 +102,14 @@ def _absolute_pad_position(fp, pad) -> tuple[float, float]:
     Returns:
         (x, y) tuple in board coordinates.
     """
+    from kicad_tools.core.geometry import rotate_pad_offset
+
     fx, fy = fp.position
     px, py = pad.position
-    rot_rad = math.radians(fp.rotation)
 
-    # Rotate pad offset by footprint rotation
-    abs_x = fx + px * math.cos(rot_rad) - py * math.sin(rot_rad)
-    abs_y = fy + px * math.sin(rot_rad) + py * math.cos(rot_rad)
+    # Rotate pad offset by footprint rotation (KiCad negated-angle convention)
+    rotated_x, rotated_y = rotate_pad_offset(px, py, fp.rotation)
+    abs_x = fx + rotated_x
+    abs_y = fy + rotated_y
 
     return (abs_x, abs_y)

--- a/src/kicad_tools/validate/rules/via_in_pad.py
+++ b/src/kicad_tools/validate/rules/via_in_pad.py
@@ -61,13 +61,16 @@ def _pad_absolute_bbox(
     Returns:
         (min_x, min_y, max_x, max_y) tuple in mm.
     """
+    from kicad_tools.core.geometry import rotate_pad_offset
+
+    # cos/sin magnitudes for the (orientation-independent) AABB below; the
+    # signed center rotation goes through the shared KiCad-convention helper.
     angle_rad = math.radians(footprint.rotation)
     cos_a = math.cos(angle_rad)
     sin_a = math.sin(angle_rad)
 
     local_x, local_y = pad.position
-    rotated_x = local_x * cos_a - local_y * sin_a
-    rotated_y = local_x * sin_a + local_y * cos_a
+    rotated_x, rotated_y = rotate_pad_offset(local_x, local_y, footprint.rotation)
     abs_x = footprint.position[0] + rotated_x
     abs_y = footprint.position[1] + rotated_y
 

--- a/src/kicad_tools/zones/fill_clearance.py
+++ b/src/kicad_tools/zones/fill_clearance.py
@@ -143,7 +143,9 @@ def _collect_obstacles(
         fp_x = fp_at.get_float(0) or 0.0
         fp_y = fp_at.get_float(1) or 0.0
         fp_rot = fp_at.get_float(2) or 0.0
-        rot_rad = math.radians(fp_rot)
+        # KiCad applies the footprint orientation as a NEGATED angle vs
+        # standard CCW math (verified vs pcbnew, issue #3739).
+        rot_rad = math.radians(-fp_rot)
         cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
 
         for pad in fp.find_all("pad"):
@@ -168,7 +170,7 @@ def _collect_obstacles(
             if w <= 0 or h <= 0:
                 continue
 
-            # Footprint-local -> sheet-absolute (CCW-positive convention,
+            # Footprint-local -> sheet-absolute (KiCad negated-angle convention,
             # matching PCB.get_pad_position used throughout the codebase).
             abs_x = fp_x + (local_x * cos_r - local_y * sin_r)
             abs_y = fp_y + (local_x * sin_r + local_y * cos_r)

--- a/src/kicad_tools/zones/generator.py
+++ b/src/kicad_tools/zones/generator.py
@@ -1114,10 +1114,11 @@ def _net_pad_positions_absolute(
             continue
 
         fp_x, fp_y = fp.position
-        # NOTE: positive sign matches PCB.get_pad_position (the canonical
-        # local->world transform used throughout the codebase).  See #2778
-        # for the previous drift bug where a negative sign was used here.
-        rot_rad = math.radians(fp.rotation)
+        # KiCad applies the footprint orientation as a NEGATED angle vs standard
+        # CCW math (verified vs pcbnew 10.0.1, issue #3739); this matches
+        # PCB.get_pad_position / core.geometry.rotate_pad_offset, the canonical
+        # local->world transform used throughout the codebase.
+        rot_rad = math.radians(-fp.rotation)
         cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
 
         for pad in fp.pads:

--- a/tests/test_analysis_net_status.py
+++ b/tests/test_analysis_net_status.py
@@ -663,11 +663,12 @@ class TestAnalyzerHelperMethods:
         """Test pad position transform with 90 degree rotation."""
         analyzer = NetStatusAnalyzer(fully_routed_pcb)
 
-        # 90 degree rotation: (1, 0) should become (0, 1)
+        # KiCad pcbnew negated-angle convention: a +90 deg footprint
+        # rotation maps local pad (1, 0) to (0, -1) (verified against pcbnew).
         result = analyzer._transform_pad_position((1.0, 0.0), 0.0, 0.0, 90.0)
 
         assert result[0] == pytest.approx(0.0, abs=0.001)
-        assert result[1] == pytest.approx(1.0, abs=0.001)
+        assert result[1] == pytest.approx(-1.0, abs=0.001)
 
     def test_via_spans_layer_direct_match(self, fully_routed_pcb: Path):
         """Test _via_spans_layer with direct layer match."""

--- a/tests/test_build_zones_step.py
+++ b/tests/test_build_zones_step.py
@@ -1164,13 +1164,12 @@ class TestAutoPourGeometricOutlines:
 
 
 class TestNetPadPositionsRotationConvention:
-    """Regression guard for #2778.
+    """Regression guard for #3739 (which overturned #2778/#738).
 
     ``_net_pad_positions_absolute`` must use the same rotation-sign
-    convention as the canonical :meth:`PCB.get_pad_position` (positive
-    ``math.radians(fp.rotation)``).  A previous implementation used the
-    negative sign, which silently produced mirrored pad positions for
-    rotated footprints.  Existing fixtures in
+    convention as the canonical :meth:`PCB.get_pad_position`, which is
+    KiCad's negated-angle form ``math.radians(-fp.rotation)`` (verified
+    vs pcbnew 10.0.1).  Existing fixtures in
     :class:`TestAutoPourGeometricOutlines` all use ``rotation=0`` and
     therefore did not catch the drift.
 
@@ -1243,7 +1242,7 @@ class TestNetPadPositionsRotationConvention:
 
         Must include at least one rotation in {45, 90, 270}.  Pure 0/180
         cases are sign-symmetric and would pass even with the buggy
-        ``math.radians(-fp.rotation)`` implementation.
+        un-negated ``math.radians(fp.rotation)`` implementation (PR #738).
         """
         import math
 
@@ -1294,13 +1293,13 @@ class TestNetPadPositionsRotationConvention:
         canonical = pcb.get_pad_position("U1", "1")
         assert canonical is not None
 
-        # Manually compute what the pre-fix code (negative sign) would have
-        # produced for the single rotated pad.
+        # Manually compute what the pre-#3739 code (un-negated standard CCW,
+        # PR #738) would have produced for the single rotated pad.
         fp = pcb.get_footprint("U1")
         assert fp is not None
         fp_x, fp_y = fp.position
         ox, oy = pcb.board_origin
-        rot_rad_buggy = math.radians(-fp.rotation)
+        rot_rad_buggy = math.radians(fp.rotation)
         cos_b, sin_b = math.cos(rot_rad_buggy), math.sin(rot_rad_buggy)
         pad = fp.pads[0]
         px, py = pad.position

--- a/tests/test_edge_clearance_epsilon.py
+++ b/tests/test_edge_clearance_epsilon.py
@@ -392,19 +392,19 @@ class TestCheckZonesEpsilon:
 
 
 class TestCheckPadsRotationSignConvention:
-    """Verify that _check_pads applies the canonical CCW-positive rotation.
+    """Verify that _check_pads applies KiCad's negated-angle pad rotation.
 
-    Regression coverage for issue #2788: prior code computed
-    ``math.radians(-footprint.rotation)`` which mirrored the pad across the
-    footprint origin for 90°/270° rotations and reflected it about the
-    diagonal for 45°.  Pure 0°/180° tests pass under BOTH sign conventions
-    because cos is even and sin*y_local terms vanish when y_local==0,
-    so the parametrization MUST include {45°, 90°, 270°} to catch the bug.
+    Regression coverage for issue #3739 (which OVERTURNED #2788/#738):
+    KiCad's ``pcbnew`` 10.0.1 applies the footprint orientation as the
+    NEGATED angle (``math.radians(-footprint.rotation)``) relative to
+    standard CCW math.  Pure 0°/180° tests pass under BOTH sign
+    conventions, so the parametrization MUST include {45°, 90°, 270°} to
+    catch a divergence.
 
     The fixture uses ``board_origin = (0, 0)`` to isolate rotation from
     any origin-offset asymmetries, and the footprint is placed in the
-    interior of the board with a pad offset chosen so the correct and
-    buggy positions differ.
+    interior of the board with a pad offset chosen so the two sign
+    conventions land the pad on opposite sides of the edge threshold.
     """
 
     @staticmethod
@@ -434,10 +434,10 @@ class TestCheckPadsRotationSignConvention:
         rotation_deg: float,
         pad_local: tuple[float, float],
     ) -> tuple[float, float]:
-        """Canonical forward transform (CCW-positive, matches schema/pcb.py)."""
+        """KiCad forward transform (negated angle, matches schema/pcb.py)."""
         import math
 
-        rot_rad = math.radians(rotation_deg)
+        rot_rad = math.radians(-rotation_deg)
         cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
         px, py = pad_local
         return (
@@ -456,13 +456,13 @@ class TestCheckPadsRotationSignConvention:
         fp_pos = (10.0, 15.0)
 
         for rot in (45.0, 90.0, 270.0):
-            rot_rad = math.radians(rot)
+            rot_rad = math.radians(-rot)  # KiCad negated-angle convention
             cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
             correct = (
                 fp_pos[0] + pad_local[0] * cos_r - pad_local[1] * sin_r,
                 fp_pos[1] + pad_local[0] * sin_r + pad_local[1] * cos_r,
             )
-            # Buggy (negated angle) → cos same, sin flipped sign
+            # Buggy (un-negated standard CCW, PR #738) → sin flipped sign
             buggy = (
                 fp_pos[0] + pad_local[0] * cos_r + pad_local[1] * sin_r,
                 fp_pos[1] - pad_local[0] * sin_r + pad_local[1] * cos_r,
@@ -477,30 +477,30 @@ class TestCheckPadsRotationSignConvention:
             )
 
     # Per-rotation fixtures: footprint x-position chosen so that, under
-    # the CANONICAL CCW-positive transform, the pad lands close enough
-    # to the left board edge (x=0) to violate (or not violate) the
-    # 0.3mm copper-to-edge minimum, while under the BUGGY negated
-    # rotation the pad lands somewhere else with the OPPOSITE violation
-    # status.  This makes the violation *count* a clean discriminator
-    # between the two sign conventions.
+    # the CANONICAL KiCad (negated-angle) transform, the pad lands close
+    # enough to the left board edge (x=0) to violate (or not violate) the
+    # 0.3mm copper-to-edge minimum, while under the OLD un-negated CCW
+    # rotation (PR #738) the pad lands with the OPPOSITE violation status.
+    # This makes the violation *count* a clean discriminator between the
+    # two sign conventions.
     #
     # pad_local = (3.0, 1.0) — nonzero, distinct x/y so 0°/180°
-    # symmetries do not paper over the bug.
+    # symmetries do not paper over the divergence.
     #
-    # Pre-computed pad positions (see negative-control test below for
-    # proof that canonical and buggy diverge at these rotations):
-    #   rot=45°,  fp_x=-1.9: canonical pad_x ~ -0.486 (violates),
-    #                        buggy     pad_x ~  0.928 (clears)
-    #   rot=90°,  fp_x= 0.6: canonical pad_x = -0.4   (violates),
-    #                        buggy     pad_x =  1.6   (clears)
-    #   rot=270°, fp_x= 0.6: canonical pad_x =  1.6   (clears),
-    #                        buggy     pad_x = -0.4   (violates)
+    # Pre-computed pad positions under the KiCad (negated) oracle
+    # (the negative-control test proves the two conventions diverge):
+    #   rot=45°,  fp_x=-1.9: kicad pad_x ~  0.928 (clears),
+    #                        old-ccw   pad_x ~ -0.486 (violates)
+    #   rot=90°,  fp_x= 0.6: kicad pad_x =  1.6   (clears),
+    #                        old-ccw   pad_x = -0.4   (violates)
+    #   rot=270°, fp_x= 0.6: kicad pad_x = -0.4   (violates),
+    #                        old-ccw   pad_x =  1.6   (clears)
     @pytest.mark.parametrize(
         "rotation, fp_x, expect_canonical_violation",
         [
-            (45.0, -1.9, True),
-            (90.0, 0.6, True),
-            (270.0, 0.6, False),
+            (45.0, -1.9, False),
+            (90.0, 0.6, False),
+            (270.0, 0.6, True),
         ],
     )
     def test_violation_count_matches_canonical_convention(

--- a/tests/test_footprint_rotation.py
+++ b/tests/test_footprint_rotation.py
@@ -20,16 +20,16 @@ class TestPadPositionRotation:
         fp_rot = 90  # degrees
         pad_x, pad_y = -1.0, 0  # local pad position
 
-        # Apply rotation (fixed: no negation)
-        rot_rad = math.radians(fp_rot)
+        # KiCad applies the footprint orientation as a NEGATED angle (#3739).
+        rot_rad = math.radians(-fp_rot)
         cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
         abs_x = fp_x + pad_x * cos_r - pad_y * sin_r
         abs_y = fp_y + pad_x * sin_r + pad_y * cos_r
 
-        # Expected: pad at (-1, 0) rotated 90° CCW becomes (0, -1)
-        # So absolute position should be (112.5, 109.0)
+        # KiCad: pad at (-1, 0) under a +90° footprint lands at local->world
+        # offset (0, +1), so absolute position is (112.5, 111.0).
         assert abs_x == pytest.approx(112.5, abs=0.001)
-        assert abs_y == pytest.approx(109.0, abs=0.001)
+        assert abs_y == pytest.approx(111.0, abs=0.001)
 
     def test_router_io_pad_rotation_180_degrees(self):
         """Test pad position with 180° rotation."""
@@ -37,12 +37,13 @@ class TestPadPositionRotation:
         fp_rot = 180
         pad_x, pad_y = 1.0, 0.5
 
-        rot_rad = math.radians(fp_rot)
+        rot_rad = math.radians(-fp_rot)
         cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
         abs_x = fp_x + pad_x * cos_r - pad_y * sin_r
         abs_y = fp_y + pad_x * sin_r + pad_y * cos_r
 
-        # Pad at (1, 0.5) rotated 180° becomes (-1, -0.5)
+        # Pad at (1, 0.5) rotated 180° becomes (-1, -0.5) under both
+        # conventions (180° is sign-blind).
         assert abs_x == pytest.approx(99.0, abs=0.001)
         assert abs_y == pytest.approx(99.5, abs=0.001)
 
@@ -52,14 +53,15 @@ class TestPadPositionRotation:
         fp_rot = 270
         pad_x, pad_y = 1.0, 0
 
-        rot_rad = math.radians(fp_rot)
+        rot_rad = math.radians(-fp_rot)
         cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
         abs_x = fp_x + pad_x * cos_r - pad_y * sin_r
         abs_y = fp_y + pad_x * sin_r + pad_y * cos_r
 
-        # Pad at (1, 0) rotated 270° CCW (or 90° CW) becomes (0, 1)
+        # KiCad: pad at (1, 0) under a +270° footprint lands at offset (0, +1),
+        # so absolute position is (100.0, 101.0).
         assert abs_x == pytest.approx(100.0, abs=0.001)
-        assert abs_y == pytest.approx(99.0, abs=0.001)
+        assert abs_y == pytest.approx(101.0, abs=0.001)
 
     def test_router_io_pad_rotation_0_degrees(self):
         """Test pad position with no rotation."""
@@ -67,7 +69,7 @@ class TestPadPositionRotation:
         fp_rot = 0
         pad_x, pad_y = 2.0, 1.0
 
-        rot_rad = math.radians(fp_rot)
+        rot_rad = math.radians(-fp_rot)
         cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
         abs_x = fp_x + pad_x * cos_r - pad_y * sin_r
         abs_y = fp_y + pad_x * sin_r + pad_y * cos_r
@@ -82,15 +84,16 @@ class TestPadPositionRotation:
         fp_rot = 45
         pad_x, pad_y = 1.0, 0
 
-        rot_rad = math.radians(fp_rot)
+        rot_rad = math.radians(-fp_rot)
         cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
         abs_x = fp_x + pad_x * cos_r - pad_y * sin_r
         abs_y = fp_y + pad_x * sin_r + pad_y * cos_r
 
-        # Pad at (1, 0) rotated 45° becomes (cos45, sin45) ≈ (0.707, 0.707)
+        # KiCad (negated angle): pad at (1, 0) under +45° lands at
+        # (cos(-45), sin(-45)) ≈ (0.707, -0.707).
         sqrt2_2 = math.sqrt(2) / 2
         assert abs_x == pytest.approx(100.0 + sqrt2_2, abs=0.001)
-        assert abs_y == pytest.approx(100.0 + sqrt2_2, abs=0.001)
+        assert abs_y == pytest.approx(100.0 - sqrt2_2, abs=0.001)
 
 
 class TestConnectivityValidationRotation:
@@ -109,9 +112,9 @@ class TestConnectivityValidationRotation:
 
         board_x, board_y = validator._transform_pad_position(pad_local, fp_x, fp_y, rotation)
 
-        # Expected: (112.5, 109.0)
+        # KiCad negated-angle convention (#3739): (112.5, 111.0)
         assert board_x == pytest.approx(112.5, abs=0.001)
-        assert board_y == pytest.approx(109.0, abs=0.001)
+        assert board_y == pytest.approx(111.0, abs=0.001)
 
 
 class TestClearanceValidationRotation:
@@ -137,9 +140,9 @@ class TestClearanceValidationRotation:
 
         abs_x, abs_y = _transform_pad_position(pad, footprint)
 
-        # Expected: (112.5, 109.0)
+        # KiCad negated-angle convention (#3739): (112.5, 111.0)
         assert abs_x == pytest.approx(112.5, abs=0.001)
-        assert abs_y == pytest.approx(109.0, abs=0.001)
+        assert abs_y == pytest.approx(111.0, abs=0.001)
 
 
 def _make_pcb_text(fp_rotation: float, pad_rotation: float | None = None) -> str:

--- a/tests/test_grid_auto_selection.py
+++ b/tests/test_grid_auto_selection.py
@@ -898,11 +898,15 @@ class TestExtractPadPositions:
 
         positions = extract_pad_positions(pcb_file)
         assert len(positions) == 1
-        # With 90 degree rotation, pad at (1, 0) relative becomes (0, 1) relative
-        # Absolute: (100 + 0, 100 + 1) = (100, 101)
+        # KiCad pcbnew uses a negated-angle (clockwise) pad transform for a
+        # positive footprint orientation, so a 90 degree rotation maps the
+        # local pad at (1, 0) to relative (0, -1).
+        # Absolute: (100 + 0, 100 - 1) = (100, 99)
+        # Verified against pcbnew: footprint@(100,100,90), pad local (1,0)
+        # -> world (100.0, 99.0).
         pos = positions[0]
         assert abs(pos.x - 100.0) < 0.01
-        assert abs(pos.y - 101.0) < 0.01
+        assert abs(pos.y - 99.0) < 0.01
 
 
 class TestRecommendGridForBoardSize:

--- a/tests/test_manufacturer_propagation_lint.py
+++ b/tests/test_manufacturer_propagation_lint.py
@@ -74,8 +74,8 @@ _ALLOWLIST: dict[str, dict[int, str]] = {
     # the caller explicitly passes ``rules=None`` (no PCB rules either).
     # The CLI always supplies its own rules with manufacturer wired in.
     "router/io.py": {
-        2823: "route_pcb() fallback when caller passes rules=None",
-        3422: "load_pcb_for_routing() inner fallback when neither rules nor pcb_rules supplied",
+        2825: "route_pcb() fallback when caller passes rules=None",
+        3425: "load_pcb_for_routing() inner fallback when neither rules nor pcb_rules supplied",
     },
     # Benchmark/synthetic fixture generators — no real CLI context.
     "benchmark/runner.py": {

--- a/tests/test_mcp_routing.py
+++ b/tests/test_mcp_routing.py
@@ -789,19 +789,17 @@ def _rotated_pcb_text(rotation_deg: float) -> str:
 
 
 class TestBuildPadsForNetRotationSignConvention:
-    """Verify that _build_pads_for_net applies the canonical CCW-positive
-    rotation when projecting pad-local offsets into world coordinates.
+    """Verify that _build_pads_for_net agrees with ``PCB.get_pad_position``
+    when projecting pad-local offsets into world coordinates.
 
-    Regression coverage for issue #2788: prior code computed
-    ``math.radians(-fp.rotation)`` which mirrored pad world positions for
-    rotated footprints, feeding the autorouter wrong anchors and causing
-    unroutable nets / off-pad escape attempts.
+    Both use KiCad's negated-angle convention (verified vs pcbnew 10.0.1,
+    issue #3739, which overturned the standard-CCW form of #2788/#738).
+    This test asserts the two implementations agree with each other to
+    within 1e-9 mm; the dedicated pcbnew-oracle check lives in
+    ``tests/test_rotation_convention.py``.
 
-    Pure 0°/180° rotations pass under BOTH sign conventions (cos is even
-    and sin*y_local terms cancel when chosen symmetrically), so the
-    parametrization MUST include {45°, 90°, 270°} to catch the bug.
-    Agreement is asserted against the canonical reference implementation
-    in ``PCB.get_pad_position`` to within 1e-9 mm.
+    Pure 0°/180° rotations pass under BOTH sign conventions, so the
+    parametrization MUST include {45°, 90°, 270°} to catch a divergence.
     """
 
     @pytest.mark.parametrize("rotation", [45.0, 90.0, 270.0])
@@ -816,8 +814,8 @@ class TestBuildPadsForNetRotationSignConvention:
 
         pcb = PCB.load(str(pcb_file))
 
-        # Canonical reference: PCB.get_pad_position uses the correct,
-        # un-negated forward rotation (schema/pcb.py:3628).
+        # Canonical reference: PCB.get_pad_position uses KiCad's negated-angle
+        # forward rotation (core.geometry.rotate_pad_offset, #3739).
         expected = pcb.get_pad_position("U1", "1")
         assert expected is not None, (
             f"Reference get_pad_position returned None for rotation={rotation}°"

--- a/tests/test_optim_fom_features.py
+++ b/tests/test_optim_fom_features.py
@@ -156,9 +156,10 @@ def test_pad_absolute_position_with_rotation_90():
     fp = _make_fp(position=(0.0, 0.0), rotation=90.0)
     pad = Pad(number="1", type="smd", shape="rect", position=(1.0, 0.0), size=(0.5, 0.5), layers=[])
     x, y = _pad_absolute_position(fp, pad)
-    # 90 deg CCW rotation of (1, 0) -> (0, 1).
+    # KiCad negated-angle convention (#3739): a +90° footprint maps the pad
+    # offset (1, 0) -> (0, -1), not (0, +1).
     assert x == pytest.approx(0.0, abs=1e-9)
-    assert y == pytest.approx(1.0, abs=1e-9)
+    assert y == pytest.approx(-1.0, abs=1e-9)
 
 
 # --------------------------------------------------------------------

--- a/tests/test_pad_grid_preflight.py
+++ b/tests/test_pad_grid_preflight.py
@@ -237,8 +237,9 @@ class TestRotatedFootprint:
     listed in the issue)."""
 
     def test_rotated_footprint_off_grid(self, tmp_path: Path) -> None:
-        # Local pad at (0.0333, 0.0) with footprint rotated 90 deg CCW:
-        # absolute offset becomes (0.0, 0.0333), still off the 0.1 mm
+        # Local pad at (0.0333, 0.0) with footprint rotated 90 deg.
+        # KiCad applies the orientation as a NEGATED angle (#3739), so the
+        # absolute offset becomes (0.0, -0.0333), still off the 0.1 mm
         # grid.  Use a strict threshold (the 0.05 mm default would clear
         # this offset, but the test is about rotation handling).
         text = _pcb_with_pads(
@@ -259,8 +260,8 @@ class TestRotatedFootprint:
         violation = report.off_grid_pads[0]
         # X should be near 100.0 (was rotated to that axis)
         assert violation.x == pytest.approx(100.0, abs=1e-3)
-        # Y should be ~100.0333 -> off-grid
-        assert violation.y == pytest.approx(100.0333, abs=1e-3)
+        # Y should be ~99.9667 -> off-grid (negated-angle convention)
+        assert violation.y == pytest.approx(99.9667, abs=1e-3)
 
 
 class TestThreshold:

--- a/tests/test_pcb_modules.py
+++ b/tests/test_pcb_modules.py
@@ -229,10 +229,11 @@ class TestComponentPlacement:
             ref="U1", footprint="Test", position=Point(10, 20), rotation=90, pads={"1": Point(5, 0)}
         )
         pad_pos = comp.pad_position("1")
-        # 90 degree rotation of (5, 0) around origin = (0, 5)
-        # Then add component position (10, 20)
+        # KiCad pcbnew negated-angle convention: a +90 deg rotation maps
+        # local (5, 0) to (0, -5) (verified against pcbnew).
+        # Then add component position (10, 20) -> (10, 15).
         assert pad_pos.x == pytest.approx(10.0, abs=0.01)
-        assert pad_pos.y == pytest.approx(25.0, abs=0.01)
+        assert pad_pos.y == pytest.approx(15.0, abs=0.01)
 
     def test_component_pad_position_not_found(self):
         """Test pad position with invalid pad name."""

--- a/tests/test_repair_clearance.py
+++ b/tests/test_repair_clearance.py
@@ -1945,14 +1945,15 @@ class TestPadClearanceRepair:
 
         repairer = ClearanceRepairer(pcb_file)
 
-        # Footprint at (105, 100) rotated 90deg, pad local (0.5, 0)
-        # After rotation: abs = (105, 100.5)
-        pads = repairer._find_pads_near(105.0, 100.5, 0.5, "F.Cu", ["GND"])
+        # Footprint at (105, 100) rotated 90deg, pad local (0.5, 0).
+        # KiCad pcbnew negated-angle convention: +90 deg maps (0.5, 0) to
+        # (0, -0.5), so abs = (105, 99.5) (verified against pcbnew).
+        pads = repairer._find_pads_near(105.0, 99.5, 0.5, "F.Cu", ["GND"])
         assert len(pads) >= 1
         pad_info = pads[0]
         assert pad_info[1] == "pad"
         assert abs(pad_info[2] - 105.0) < 0.01
-        assert abs(pad_info[3] - 100.5) < 0.01
+        assert abs(pad_info[3] - 99.5) < 0.01
 
     def test_choose_target_never_moves_pad(self, tmp_path: Path):
         """_choose_target should always return the non-pad object."""

--- a/tests/test_rotation_convention.py
+++ b/tests/test_rotation_convention.py
@@ -1,0 +1,170 @@
+"""Pcbnew-oracle regression test for the pad rotation convention (#3739).
+
+KiCad's own ``pcbnew`` 10.0.1 was probed directly to establish the
+authoritative forward local->world pad transform.  For a footprint at
+(100, 100) mm with a pad at footprint-local offset (2, 0):
+
+    ===  ====================
+    deg  pcbnew GetPosition()
+    ===  ====================
+      0  (102.0, 100.0)
+     90  (100.0,  98.0)
+    180  ( 98.0, 100.0)
+    270  (100.0, 102.0)
+    ===  ====================
+
+These four values are the regression oracle.  They were captured with::
+
+    KPY=/Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/\
+Versions/3.9/bin/python3
+    # board, FOOTPRINT at (100,100), PAD whose world pos at deg0 is (102,100),
+    # then fp.SetOrientationDegrees(deg); pcbnew.ToMM(pad.GetPosition())
+
+KiCad applies the footprint orientation as the *negated* angle relative
+to standard CCW math.  PR #738 used the un-negated (standard CCW) form,
+which produced the mirror-image positions at 90°/270° (0°/180° agree
+under both signs — the long-known "test trap").
+
+This test runs WITHOUT pcbnew by asserting against the hardcoded oracle
+constants above.  When pcbnew *is* importable (e.g. on a developer's
+machine with KiCad installed) an extra test re-derives the oracle live
+and asserts kicad-tools matches it exactly.
+
+MUST exercise 90° and 270° — a 0°/180°-only test cannot detect the bug.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from kicad_tools.core.geometry import rotate_pad_offset
+
+# Footprint origin and the pad's footprint-local offset used by the oracle.
+FP_POS = (100.0, 100.0)
+PAD_LOCAL = (2.0, 0.0)
+
+# pcbnew 10.0.1-verified world positions (mm) for PAD_LOCAL at each angle.
+PCBNEW_ORACLE: dict[float, tuple[float, float]] = {
+    0.0: (102.0, 100.0),
+    90.0: (100.0, 98.0),
+    180.0: (98.0, 100.0),
+    270.0: (100.0, 102.0),
+}
+
+EPS = 1e-9
+
+
+def _world_via_helper(rotation_deg: float) -> tuple[float, float]:
+    """kicad-tools world position via the shared rotate_pad_offset helper."""
+    rx, ry = rotate_pad_offset(PAD_LOCAL[0], PAD_LOCAL[1], rotation_deg)
+    return (FP_POS[0] + rx, FP_POS[1] + ry)
+
+
+class TestRotatePadOffsetMatchesPcbnewOracle:
+    """``core.geometry.rotate_pad_offset`` must match pcbnew at all cardinals."""
+
+    @pytest.mark.parametrize("rotation", sorted(PCBNEW_ORACLE))
+    def test_matches_oracle(self, rotation: float) -> None:
+        expected = PCBNEW_ORACLE[rotation]
+        actual = _world_via_helper(rotation)
+        assert actual[0] == pytest.approx(expected[0], abs=1e-6), (
+            f"deg{rotation}: x={actual[0]} != pcbnew {expected[0]}"
+        )
+        assert actual[1] == pytest.approx(expected[1], abs=1e-6), (
+            f"deg{rotation}: y={actual[1]} != pcbnew {expected[1]}"
+        )
+
+    def test_90_and_270_differ_from_standard_ccw(self) -> None:
+        """Negative control: the standard-CCW form (PR #738) would FAIL here.
+
+        A 0°/180°-only test is a blind spot; this asserts that 90° and
+        270° genuinely discriminate KiCad's negated convention from the
+        un-negated one that this fix overturned.
+        """
+        for rotation in (90.0, 270.0):
+            px, py = PAD_LOCAL
+            rad = math.radians(rotation)  # un-negated (the old, wrong form)
+            ccw = (
+                FP_POS[0] + px * math.cos(rad) - py * math.sin(rad),
+                FP_POS[1] + px * math.sin(rad) + py * math.cos(rad),
+            )
+            oracle = PCBNEW_ORACLE[rotation]
+            assert ccw != pytest.approx(oracle, abs=0.5), (
+                f"deg{rotation}: standard-CCW {ccw} unexpectedly matches "
+                f"pcbnew {oracle} — fixture no longer discriminates the bug."
+            )
+
+
+class TestGetPadPositionMatchesPcbnewOracle:
+    """``PCB.get_pad_position`` (the public API) must match pcbnew too."""
+
+    @pytest.mark.parametrize("rotation", sorted(PCBNEW_ORACLE))
+    def test_get_pad_position_matches_oracle(self, tmp_path, rotation: float) -> None:
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_text = f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 1 "SIG1")
+  (footprint "Oracle"
+    (layer "F.Cu")
+    (at {FP_POS[0]} {FP_POS[1]} {rotation})
+    (attr smd)
+    (property "Reference" "U1")
+    (pad "1" smd rect (at {PAD_LOCAL[0]} {PAD_LOCAL[1]}) (size 0.6 0.6) (layers "F.Cu") (net 1 "SIG1"))
+  )
+)
+"""
+        pcb_file = tmp_path / "oracle.kicad_pcb"
+        pcb_file.write_text(pcb_text)
+        pcb = PCB.load(str(pcb_file))
+
+        pos = pcb.get_pad_position("U1", "1")
+        assert pos is not None
+        expected = PCBNEW_ORACLE[rotation]
+        assert pos[0] == pytest.approx(expected[0], abs=1e-6)
+        assert pos[1] == pytest.approx(expected[1], abs=1e-6)
+
+
+class TestLivePcbnewOracle:
+    """Re-derive the oracle from a live pcbnew if it is importable."""
+
+    def test_helper_matches_live_pcbnew(self) -> None:
+        pcbnew = pytest.importorskip(
+            "pcbnew", reason="pcbnew not importable in this environment"
+        )
+
+        board = pcbnew.BOARD()
+        fp = pcbnew.FOOTPRINT(board)
+        fp.SetPosition(
+            pcbnew.VECTOR2I(pcbnew.FromMM(FP_POS[0]), pcbnew.FromMM(FP_POS[1]))
+        )
+        board.Add(fp)
+
+        pad = pcbnew.PAD(fp)
+        fp.Add(pad)
+        # Define the pad's local offset by setting its world pos at deg 0.
+        fp.SetOrientationDegrees(0)
+        pad.SetPosition(
+            pcbnew.VECTOR2I(
+                pcbnew.FromMM(FP_POS[0] + PAD_LOCAL[0]),
+                pcbnew.FromMM(FP_POS[1] + PAD_LOCAL[1]),
+            )
+        )
+
+        for rotation in (0.0, 90.0, 180.0, 270.0):
+            fp.SetOrientationDegrees(rotation)
+            p = pad.GetPosition()
+            live = (pcbnew.ToMM(p.x), pcbnew.ToMM(p.y))
+            ours = _world_via_helper(rotation)
+            assert ours[0] == pytest.approx(live[0], abs=1e-4), (
+                f"deg{rotation}: kicad-tools x={ours[0]} != live pcbnew {live[0]}"
+            )
+            assert ours[1] == pytest.approx(live[1], abs=1e-4), (
+                f"deg{rotation}: kicad-tools y={ours[1]} != live pcbnew {live[1]}"
+            )
+            # And the hardcoded oracle must equal live pcbnew too.
+            assert PCBNEW_ORACLE[rotation] == pytest.approx(live, abs=1e-4)

--- a/tests/test_rotation_convention.py
+++ b/tests/test_rotation_convention.py
@@ -133,15 +133,11 @@ class TestLivePcbnewOracle:
     """Re-derive the oracle from a live pcbnew if it is importable."""
 
     def test_helper_matches_live_pcbnew(self) -> None:
-        pcbnew = pytest.importorskip(
-            "pcbnew", reason="pcbnew not importable in this environment"
-        )
+        pcbnew = pytest.importorskip("pcbnew", reason="pcbnew not importable in this environment")
 
         board = pcbnew.BOARD()
         fp = pcbnew.FOOTPRINT(board)
-        fp.SetPosition(
-            pcbnew.VECTOR2I(pcbnew.FromMM(FP_POS[0]), pcbnew.FromMM(FP_POS[1]))
-        )
+        fp.SetPosition(pcbnew.VECTOR2I(pcbnew.FromMM(FP_POS[0]), pcbnew.FromMM(FP_POS[1])))
         board.Add(fp)
 
         pad = pcbnew.PAD(fp)

--- a/tests/test_rotation_convention_audit.py
+++ b/tests/test_rotation_convention_audit.py
@@ -1,27 +1,26 @@
 """Cross-subsystem audit tests for the local->world rotation sign convention.
 
-Regression coverage for issue #2789 (follow-up to #2778 and #2788).
+Regression coverage for issue #3739 (which OVERTURNED #2789/#2778/#2788/#738).
 
-Seven distinct call sites across the codebase computed the forward
-local->world pad transform with a *negated* angle:
+KiCad's ``pcbnew`` 10.0.1 was probed directly (the authoritative engine)
+and its forward local->world pad transform uses the *negated* footprint
+angle relative to standard CCW math::
 
     rot_rad = math.radians(-fp.rotation)
     rx = px * cos(rot_rad) - py * sin(rot_rad)
     ry = px * sin(rot_rad) + py * cos(rot_rad)
 
-The canonical KiCad convention (documented at ``src/kicad_tools/router/io.py``
-lines 2661-2667 and implemented at ``src/kicad_tools/schema/pcb.py:3628``)
-is that rotation is positive counter-clockwise and the standard 2D
-rotation matrix applies *directly* with no negation.  Using the negated
-angle mirrors the pad about the footprint y-axis, which under 90° and
-270° rotations sends pads to the wrong half of the board.
+For a footprint at (100,100) with a pad at local (2,0), pcbnew places the
+pad at: deg0 (102,100), deg90 (100,98), deg180 (98,100), deg270 (100,102).
+The earlier standard-CCW form (PR #738 / this module's pre-#3739 oracle)
+produced the *mirror-image* world positions at 90°/270°, which sent pads
+to the wrong half of the board and let ``kct check`` pass copper shorts
+that ``kicad-cli`` flagged.
 
-Pure 0°/180° rotations pass under BOTH sign conventions (cos is even,
-and the sin*y_local terms cancel symmetrically), so these tests MUST
-exercise {45°, 90°, 270°} to discriminate the bug from a correct fix.
-Each test includes a negative-control assertion that the chosen fixture
-coordinates actually differ between the two conventions at those
-rotations — otherwise the test would silently pass against buggy code.
+This module's canonical oracle is therefore KiCad's negated-angle
+transform (``core.geometry.rotate_pad_offset`` / ``PCB.get_pad_position``).
+The negative control still asserts the two sign conventions differ at
+{45°, 90°, 270°}; 0°/180° agree under both (the long-known "test trap").
 
 Affected sites covered by this module (one test class each):
 
@@ -63,13 +62,13 @@ def _canonical_world(
     rotation_deg: float,
     pad_local: tuple[float, float],
 ) -> tuple[float, float]:
-    """Canonical CCW-positive forward transform.
+    """Canonical KiCad forward transform (negated footprint angle).
 
-    This is the reference oracle.  It is mathematically identical to
-    ``PCB.get_pad_position`` (``schema/pcb.py:3628``) and the inline
-    transform at ``router/io.py:2661-2667``.
+    This is the reference oracle, verified against pcbnew 10.0.1 (#3739).
+    It is mathematically identical to ``PCB.get_pad_position`` and the
+    shared helper ``core.geometry.rotate_pad_offset``.
     """
-    rot_rad = math.radians(rotation_deg)
+    rot_rad = math.radians(-rotation_deg)
     cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
     px, py = pad_local
     return (
@@ -83,8 +82,8 @@ def _buggy_world(
     rotation_deg: float,
     pad_local: tuple[float, float],
 ) -> tuple[float, float]:
-    """The (incorrect) negated-angle transform that the bug used."""
-    rot_rad = math.radians(-rotation_deg)
+    """The (incorrect) standard-CCW transform that PR #738 used."""
+    rot_rad = math.radians(rotation_deg)
     cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
     px, py = pad_local
     return (

--- a/tests/test_router_core.py
+++ b/tests/test_router_core.py
@@ -1268,17 +1268,16 @@ class TestAdaptiveAutorouterComponentTransform:
         stack = LayerStack.two_layer()
         router = adaptive._create_autorouter(stack)
 
-        # Rotation is CCW-positive standard math applied directly to
-        # file coordinates with NO y negation (repo-wide convention since
-        # PR #738; cleanups #2778/#2788/#2789): (1, 0) rotated 90 deg
-        # becomes (0, +1), i.e. pad.y = 20 + 1 = 21
-        # (stale-test update, issue #3436 burn-down).
+        # KiCad applies the footprint orientation as a NEGATED angle vs
+        # standard CCW math (verified vs pcbnew 10.0.1, issue #3739, which
+        # overturned PR #738/#2778/#2788/#2789): (1, 0) under a +90°
+        # footprint becomes (0, -1), i.e. pad.y = 20 - 1 = 19.
         pad = router.pads.get(("R1", "1"))
         assert pad is not None
         # x should be close to 25.0 (component center)
         assert abs(pad.x - 25.0) < 0.01
-        # y should be offset by approximately +1.0 from center
-        assert abs(pad.y - 21.0) < 0.01
+        # y should be offset by approximately -1.0 from center
+        assert abs(pad.y - 19.0) < 0.01
 
 
 class TestAutorouterIntraICRoutes:

--- a/tests/test_router_factory.py
+++ b/tests/test_router_factory.py
@@ -144,17 +144,22 @@ class TestFactoryCall:
         assert new_router.pads[("U2", "1")].y == pytest.approx(0.0)
 
     def test_rotation_rotates_pad_offset(self):
-        """A 90° rotation should rotate pad offsets accordingly."""
+        """A 90° rotation should rotate pad offsets per KiCad's convention.
+
+        KiCad applies the footprint orientation as a NEGATED angle vs standard
+        CCW math (verified vs pcbnew 10.0.1, issue #3739), so a +90° rotation
+        of offset (+1, 0) lands at (0, -1), not (0, +1).
+        """
         # Two-pin component with pin 2 at +x offset.
         router = _two_pin_component_router()
         factory = _build_factory_from_router(router, component_positions=None)
-        # Place U1 at origin and rotate 90°: pin 2 (offset +1, 0) becomes (0, +1).
+        # Place U1 at origin and rotate 90°: pin 2 (offset +1, 0) becomes (0, -1).
         new_router = factory({"U1": (0.0, 0.0)}, {"U1": 90.0})
         assert new_router.pads[("U1", "2")].x == pytest.approx(0.0, abs=1e-9)
-        assert new_router.pads[("U1", "2")].y == pytest.approx(1.0)
-        # Pin 1 (offset -1, 0) becomes (0, -1).
+        assert new_router.pads[("U1", "2")].y == pytest.approx(-1.0)
+        # Pin 1 (offset -1, 0) becomes (0, +1).
         assert new_router.pads[("U1", "1")].x == pytest.approx(0.0, abs=1e-9)
-        assert new_router.pads[("U1", "1")].y == pytest.approx(-1.0)
+        assert new_router.pads[("U1", "1")].y == pytest.approx(1.0)
 
     def test_translation_after_rotation(self):
         """Combined: move centroid to (10, 20) and rotate 180°."""

--- a/tests/test_stitch_cmd.py
+++ b/tests/test_stitch_cmd.py
@@ -2378,16 +2378,16 @@ class TestFindAllPads:
     def test_handles_rotated_footprints(self, stitch_rotated_pad_pcb: Path):
         """Pad positions should be correctly transformed for rotated footprints."""
         sexp = load_pcb(stitch_rotated_pad_pcb)
-        # Find pad from rotated U2 (at 10, 20, rotated 90 degrees)
-        # Pad at relative (1, 0) -> after 90-degree rotation:
-        # board_x = 10 + 1*cos(90) - 0*sin(90) = 10 + 0 = 10
-        # board_y = 20 + 1*sin(90) + 0*cos(90) = 20 + 1 = 21
+        # Find pad from rotated U2 (at 10, 20, rotated 90 degrees).
+        # KiCad applies the orientation as a NEGATED angle (#3739):
+        # board_x = 10 + 1*cos(-90) - 0*sin(-90) = 10 + 0 = 10
+        # board_y = 20 + 1*sin(-90) + 0*cos(-90) = 20 - 1 = 19
         pads = find_all_pads(sexp, exclude_nets={1})  # Exclude GND
 
         assert len(pads) == 1  # Only U2.1 (SIG, net 2)
         px, py, radius, net = pads[0]
         assert abs(px - 10.0) < 0.01
-        assert abs(py - 21.0) < 0.01
+        assert abs(py - 19.0) < 0.01
         assert net == 2
 
     def test_pad_radius_from_size(self, stitch_pad_clearance_pcb: Path):

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -141,25 +141,29 @@ class TestXTALEdgeAngleDetection:
     @pytest.mark.parametrize(
         "xtal_edge,rotation,expected_angle",
         [
-            # North XTAL pads (-y locally) rotated 90 deg CCW =>
-            # rotated to +x (east). Confirms rotation-awareness.
-            ("N", 90.0, 0.0),
-            # West XTAL pads (-x locally) rotated 90 deg CCW => -y (north).
-            ("W", 90.0, 270.0),
-            # West rotated 180 deg => east.
+            # KiCad pcbnew applies a footprint's positive orientation as a
+            # NEGATED (clockwise) rotation of the local pad frame (verified
+            # vs pcbnew, #3739). Expected world-frame edges below are
+            # cross-checked against the pcbnew oracle.
+            # North XTAL pads (-y locally) @ +90 deg => world -x (west).
+            ("N", 90.0, 180.0),
+            # West XTAL pads (-x locally) @ +90 deg => world +y (south).
+            ("W", 90.0, 90.0),
+            # West rotated 180 deg => east (convention-invariant).
             ("W", 180.0, 0.0),
-            # East rotated 270 deg => north (-y).
-            ("E", 270.0, 270.0),
-            # West rotated 90 deg CW (= -90 / 270 deg CCW) => south (+y).
-            ("W", 270.0, 90.0),
+            # East XTAL pads (+x locally) @ +270 deg => world +y (south).
+            ("E", 270.0, 90.0),
+            # West XTAL pads (-x locally) @ +270 deg => world -y (north).
+            ("W", 270.0, 270.0),
         ],
     )
     def test_xtal_edge_with_rotation(self, xtal_edge: str, rotation: float, expected_angle: float):
         """Footprint rotation moves XTAL pads to a different world-frame edge.
 
-        TQFP-32 packages have XTAL on the west edge. If the MCU is
-        rotated 90 deg CCW, the XTAL pads end up on the south edge in the
-        world frame. The placer must follow.
+        TQFP-32 packages have XTAL on the west edge. Under KiCad's
+        negated-angle convention, a +90 deg footprint rotation sends the
+        west-edge XTAL pads to the south edge in the world frame. The
+        placer must follow.
         """
         mcu = _make_tqfp32_mcu(xtal_edge=xtal_edge, rotation=rotation)
         pcb = _make_pcb_with_mcu(mcu)
@@ -308,13 +312,14 @@ class TestMCUCoreStrategyCrystalPlacement:
         assert math.isclose(crystal.y - anchor_pos[1], expected_dy, abs_tol=1e-6)
 
     def test_crystal_follows_mcu_rotation(self):
-        """Rotating the MCU 90 deg CCW moves XTAL pads from west to north.
+        """Rotating the MCU 90 deg moves XTAL pads from west to south.
 
-        TQFP-32 XTAL pads are natively on the west edge (local -x). The
-        standard 2D rotation matrix R(theta) with theta = +90 deg maps
-        the vector (-1, 0) to (0, -1). In screen-Y conventions that's
-        "north" (angle 270 deg in our 0=east, 90=south, 180=west,
-        270=north scheme). The crystal must follow.
+        TQFP-32 XTAL pads are natively on the west edge (local -x). KiCad
+        pcbnew applies a +90 deg footprint orientation as a NEGATED
+        (clockwise) rotation of the local frame (verified vs pcbnew,
+        #3739), mapping the vector (-1, 0) to (0, +1). In screen-Y
+        conventions that's "south" (angle 90 deg in our 0=east, 90=south,
+        180=west, 270=north scheme). The crystal must follow.
         """
         mcu = _make_tqfp32_mcu(xtal_edge="W", rotation=90.0)
         pcb = _make_pcb_with_mcu(mcu)
@@ -333,10 +338,10 @@ class TestMCUCoreStrategyCrystalPlacement:
         dy = crystal.y - anchor_pos[1]
         # Distance is 5.0 mm and the crystal lies on a cardinal axis.
         assert math.isclose(math.hypot(dx, dy), 5.0, abs_tol=1e-6)
-        # West edge rotated 90 deg CCW => north edge (angle 270 deg).
-        # Position vector = 5 * (cos(270), sin(270)) = (0, -5).
+        # West edge @ +90 deg (negated-angle) => south edge (angle 90 deg).
+        # Position vector = 5 * (cos(90), sin(90)) = (0, +5).
         assert math.isclose(dx, 0.0, abs_tol=1e-6)
-        assert math.isclose(dy, -5.0, abs_tol=1e-6)
+        assert math.isclose(dy, 5.0, abs_tol=1e-6)
 
     def test_crystal_fallback_when_no_xtal_pads(self):
         """When MCU has no XTAL pads, fall back to 270 deg (legacy behaviour).

--- a/tests/test_validate_netlist.py
+++ b/tests/test_validate_netlist.py
@@ -192,9 +192,10 @@ class TestNetlistRule:
         pad = _StubPad(number="1", position=(1.0, 0.0))
 
         x, y = _absolute_pad_position(fp, pad)
-        # 90-degree rotation: (1,0) -> (0,1) relative, so absolute = (100, 51)
+        # KiCad negated-angle convention (#3739): a +90° footprint maps
+        # (1, 0) -> (0, -1) relative, so absolute = (100, 49).
         assert x == pytest.approx(100.0, abs=1e-6)
-        assert y == pytest.approx(51.0, abs=1e-6)
+        assert y == pytest.approx(49.0, abs=1e-6)
 
     def test_declared_net_with_nonzero_number_not_flagged(self):
         """A pad whose net_number > 0 with a declared name is fine."""


### PR DESCRIPTION
## Summary

KiCad's `pcbnew` applies the footprint orientation as the **NEGATED** angle relative to standard CCW math (verified directly against pcbnew 10.0.1, the authoritative engine). The codebase used the un-negated standard-CCW form introduced by PR #738, which mirrored pad world positions at 90/270 degrees while agreeing at 0/180 (the long-known "test trap"). Because the autorouter AND `kct check` shared the same wrong sign, they agreed with each other but disagreed with kicad-cli — which is exactly how board 00 shipped a copper short that `kct check` passed (#3737/#3742).

This PR restores `math.radians(-rotation)` at **every forward local→world pad/footprint-geometry transform**, overturning #738/#2778/#2788/#2789.

### pcbnew oracle (footprint @ (100,100), pad local (2,0))

| deg | pcbnew | pre-#3739 (CCW) | this PR |
|----|----|----|----|
| 0 | (102,100) | (102,100) | (102,100) |
| 90 | **(100,98)** | (100,102) | **(100,98)** |
| 180 | (98,100) | (98,100) | (98,100) |
| 270 | **(100,102)** | (100,98) | **(100,102)** |

Re-verified live against `pcbnew` 10.0.1 at the start of this work.

## Changes

- **New shared helper** `core.geometry.rotate_pad_offset(local_x, local_y, rotation_deg)` implementing KiCad's negated-angle convention; canonical transforms (`PCB.get_pad_position`, validate clearance/connectivity/netlist, mcp analysis) route through it.
- **Forward transforms flipped to `-rotation`** (negate the angle):
  - validate: `rules/clearance.py`, `connectivity.py`, `rules/netlist.py`, `rules/via_in_pad.py`, `rules/edge.py`
  - schema: `pcb.py` `get_pad_position`
  - router: `io.py` (4 sites), `adaptive.py`, `orchestrator.py`
  - zones: `fill_clearance.py`, `generator.py`
  - drc: `cpp_backend.py` (feeds `-rotation` to the C++ kernel — no native rebuild needed), `incremental.py` (2 sites), `repair_clearance.py` (2 sites)
  - analysis: `net_status.py`, `complexity.py`
  - optim: `keepout.py`, `fom_features.py`, `place_route.py`, `router_factory.py` (delta-rotation), `pcb/placement.py`
  - mcp: `tools/analysis.py`, `tools/routing.py` (3 sites)
  - cli: `stitch_cmd.py` (5 sites), `placement_cmd.py`
  - reasoning: `state.py`; placement: `analyzer.py`; design: `strategies.py`
- **Left alone (documented reasoning):**
  - `optim/components.py` & `optim/evolutionary.py` physics pin-offset compute/reconstruct pairs — internally self-consistent, used for relative GA scoring, never emit real KiCad pad world positions.
  - `schematic/models/symbol.py` Y-flip — separate, correct schematic convention.
  - Generic math helpers (`pcb/geometry.py` `Point.rotate`, `optim/geometry.py` `Vector2D.rotated`, `placement/analyzer._rotate_point`), circle/search generators (`recovery/strategy.py`, `schema/pcb.py` collision search, `router/zones.py` thermal spokes), angular-velocity scalars — not pad transforms.
  - `cli/pcb_lock_footprints.py` perimeter bbox — placement heuristic, not on the DRC/routing path.
- **Regression test** `tests/test_rotation_convention.py`: asserts `rotate_pad_offset` and `PCB.get_pad_position` match the pcbnew oracle at 0/90/180/270 degrees (hardcoded constants so it runs without pcbnew; live-pcbnew cross-check when importable). Includes a 90/270 negative control.
- **Updated stale tests** that encoded the proven-wrong CCW convention at 90/270: `test_rotation_convention_audit.py`, `test_footprint_rotation.py`, `test_router_core.py`, `test_router_factory.py`, `test_mcp_routing.py`, `test_edge_clearance_epsilon.py`, `test_optim_fom_features.py`, `test_stitch_cmd.py`, `test_validate_netlist.py`, `test_pad_grid_preflight.py`, `test_build_zones_step.py`. Each value was re-derived from the pcbnew oracle; 0/180 cases (sign-blind) were left unchanged.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Pad world-positions match pcbnew for 0/90/180/270 | ✅ | `test_rotation_convention.py` passes (886 convention tests green); re-verified live pcbnew 10.0.1 |
| All 7 manufacturable boards stay 0 DRC (no regression) | ✅ | `kct check` byte-identical to main: 00/01/02/03/softstart = 0 errors, 04 = 1 connectivity (advisory), 06 = 2 connectivity (advisory); kicad-cli board 00 = 0 violations. All counts unchanged from baseline. |
| Forward transforms negated, inverse opposite, schematic Y-flip untouched | ✅ | Per-site audit above |
| Test suite green with justified expectation updates | ✅ | All convention tests pass; only stale CCW assertions corrected against the oracle |

## Test Plan

- [x] `pytest tests/test_rotation_convention.py` + audit/footprint/router/validate/drc/zones/stitch suites — 886 passed, 1 skipped (live pcbnew unavailable in CI venv)
- [x] Re-derived pcbnew oracle live (deg90 → (100,98), deg270 → (100,102))
- [x] DRC safety net on 7 boards under `kct check` (correct profiles: tier1 for 03/04/softstart) + kicad-cli — no regression vs main
- Pre-existing failures unrelated to this change: `cmaes`/`matplotlib` optional deps missing in the worktree venv (verified failing identically without these changes)

Closes #3739