### PR TITLE
feat(board-00): add schematic <-> routed-PCB LVS guard to recipe

### DIFF
--- a/boards/00-simple-led/generate_design.py
+++ b/boards/00-simple-led/generate_design.py
@@ -17,6 +17,7 @@ Usage:
     python generate_design.py [output_dir]
 """
 
+import json
 import subprocess
 import sys
 import uuid
@@ -24,6 +25,7 @@ from pathlib import Path
 
 from kicad_tools.core.project_file import create_minimal_project, save_project
 from kicad_tools.dev import warn_if_stale
+from kicad_tools.lvs import BoardNetlistMismatch, compare_netlists
 from kicad_tools.schematic.models.schematic import Schematic
 
 # Warn if running source scripts with stale pipx install
@@ -868,6 +870,61 @@ def export_manufacturing_bundle(routed_path: Path, output_dir: Path) -> bool:
     return False
 
 
+def run_lvs(sch_path: Path, routed_pcb_path: Path, output_dir: Path) -> bool:
+    """Step 6.5: assert schematic <-> routed-PCB netlist equivalence (#3748).
+
+    Compares each ``(ref, pad)`` pair's net name between the schematic
+    (the design intent) and the routed PCB (what manufacturing receives)
+    and writes the result to ``output/lvs.json`` for downstream tools
+    (``kct fleet status``, the demo site, etc.) following the v1 schema
+    documented in ``docs/board-json-schema.md``.
+
+    Returns ``True`` iff the comparison was clean.  Raises
+    :class:`BoardNetlistMismatch` when it is dirty so the caller's exit
+    gate trips -- a silent dirty board would defeat the purpose of
+    wiring LVS into the recipe.
+    """
+    print("\n" + "=" * 60)
+    print("Running LVS (schematic <-> PCB netlist match)...")
+    print("=" * 60)
+
+    result = compare_netlists(sch_path, routed_pcb_path)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    lvs_path = output_dir / "lvs.json"
+    lvs_path.write_text(
+        json.dumps(
+            {
+                "$schema": "https://kicad-tools.org/schemas/lvs/v1.json",
+                "clean": result.clean,
+                "mismatches": [
+                    {
+                        "ref": m.ref,
+                        "pad": m.pad,
+                        "schematic_net": m.schematic_net,
+                        "pcb_net": m.pcb_net,
+                    }
+                    for m in result.mismatches
+                ],
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+
+    if result.clean:
+        print(f"\n   PASS: {lvs_path.name} clean (0 mismatches)")
+        return True
+
+    # Print up to the first 5 mismatches before raising, so the recipe
+    # log surfaces what went wrong without forcing the user to crack
+    # open lvs.json.
+    print(f"\n   FAIL: {len(result.mismatches)} schematic/PCB mismatch(es):")
+    for m in result.mismatches[:5]:
+        print(f"      - {m.ref}.{m.pad}: schematic={m.schematic_net!r} pcb={m.pcb_net!r}")
+    raise BoardNetlistMismatch(result)
+
+
 def main() -> int:
     """Main entry point."""
     if len(sys.argv) > 1:
@@ -895,6 +952,13 @@ def main() -> int:
         # Step 6: Run DRC
         drc_success = run_drc(routed_path)
 
+        # Step 6.5: LVS (#3748) -- assert the routed PCB's nets match the
+        # schematic's design intent.  This is the post-route guard that
+        # caught #3747 (D1 polarity flipped on the schematic side); it
+        # raises ``BoardNetlistMismatch`` on disagreement so the recipe
+        # exits non-zero instead of silently shipping a bad board.
+        lvs_success = run_lvs(sch_path, routed_path, output_dir)
+
         # Step 7: Export manufacturing bundle (#3147).  Run unconditionally
         # so the manifest mtime stays newer than the routed PCB even when
         # routing is incomplete (board 00 routing is tracked by #3148);
@@ -916,6 +980,7 @@ def main() -> int:
         print(f"  ERC: {'PASS' if erc_success else 'FAIL'}")
         print(f"  Routing: {'SUCCESS' if route_success else 'PARTIAL'}")
         print(f"  DRC: {'PASS' if drc_success else 'FAIL'}")
+        print(f"  LVS: {'PASS' if lvs_success else 'FAIL'}")
         print(f"  MFG bundle: {'PASS' if mfg_success else 'FAIL'}")
         print("\nCircuit description:")
         print("  - J1: 2-pin power input (VCC, GND)")
@@ -923,8 +988,10 @@ def main() -> int:
         print("  - D1: LED indicator")
         print("  - 5V input -> ~10mA LED current")
 
-        # Partial routing is acceptable; success if ERC and DRC pass
-        return 0 if erc_success and drc_success else 1
+        # Partial routing is acceptable; success if ERC, DRC, and LVS pass.
+        # (``run_lvs`` raises on a dirty LVS so a False ``lvs_success`` here
+        # would mean LVS itself short-circuited -- belt-and-braces guard.)
+        return 0 if erc_success and drc_success and lvs_success else 1
 
     except Exception as e:
         print(f"\nError: {e}", file=sys.stderr)

--- a/boards/00-simple-led/output/lvs.json
+++ b/boards/00-simple-led/output/lvs.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://kicad-tools.org/schemas/lvs/v1.json",
+  "clean": true,
+  "mismatches": []
+}

--- a/docs/board-json-schema.md
+++ b/docs/board-json-schema.md
@@ -108,3 +108,80 @@ This file is the data contract for the Phase 2 Astro site, so stability matters:
 
 Consumers should read `schema_version` and reject documents whose major version
 they do not understand.
+
+## `lvs.json` Schema (v1)
+
+`lvs.json` is the per-board LVS (Layout-vs-Schematic) verification report
+produced by the board recipe's LVS step (issue #3748; board 00 only in v1, with
+the fleet-wide rollout tracked by issue #3742). It is emitted next to
+`board.json` at `boards/<id>/output/lvs.json` and records whether every
+schematic pin's net name matches the corresponding PCB pad's net name.
+
+### Source artifacts
+
+| `lvs.json` field | Source artifact | Notes |
+|------------------|-----------------|-------|
+| `clean`          | comparison result | `true` iff `mismatches == []` |
+| `mismatches[*].ref`            | schematic / PCB reference designator | e.g. `"D1"` |
+| `mismatches[*].pad`            | pin or pad number                   | e.g. `"1"` |
+| `mismatches[*].schematic_net`  | `Schematic.get_net_for_pin(ref, pad)` | `null` for floating |
+| `mismatches[*].pcb_net`        | `(pad N ... (net K "NAME"))` in `.kicad_pcb` | `null` for unconnected |
+
+### Example (clean)
+
+```json
+{
+  "$schema": "https://kicad-tools.org/schemas/lvs/v1.json",
+  "clean": true,
+  "mismatches": []
+}
+```
+
+### Example (dirty — D1 polarity flipped)
+
+```json
+{
+  "$schema": "https://kicad-tools.org/schemas/lvs/v1.json",
+  "clean": false,
+  "mismatches": [
+    {
+      "ref": "D1",
+      "pad": "1",
+      "schematic_net": "LED_ANODE",
+      "pcb_net": "GND"
+    },
+    {
+      "ref": "D1",
+      "pad": "2",
+      "schematic_net": "GND",
+      "pcb_net": "LED_ANODE"
+    }
+  ]
+}
+```
+
+### Field reference
+
+| Field                          | Type    | Required | Description |
+|--------------------------------|---------|----------|-------------|
+| `$schema`                      | string  | yes      | Schema URL identifier |
+| `clean`                        | boolean | yes      | `true` iff `mismatches` is empty |
+| `mismatches`                   | array   | yes      | Always present; empty when clean (never omitted, never `null`) |
+| `mismatches[*].ref`            | string  | yes      | Reference designator (e.g. `"R1"`) |
+| `mismatches[*].pad`            | string  | yes      | Pin/pad number as a string (e.g. `"1"`) |
+| `mismatches[*].schematic_net`  | string &#124; null | yes | Net the pin sits on in the schematic, or `null` for floating |
+| `mismatches[*].pcb_net`        | string &#124; null | yes | Net the pad sits on in the PCB, or `null` for unconnected |
+
+### `mismatches` is always present
+
+Unlike `board.json`, where optional fields are *omitted*, `lvs.json` always
+emits `mismatches` (as `[]` when clean). This keeps the type contract simple
+for downstream consumers — they can always `len(report["mismatches"])` without
+a presence check.
+
+### Schema versioning policy
+
+Same rules as `board.json`: additive changes are allowed within v1; renames,
+type changes, or removed fields require bumping the version in the `$schema`
+URL. Consumers should reject documents whose `$schema` references a major
+version they do not understand.

--- a/src/kicad_tools/lvs/__init__.py
+++ b/src/kicad_tools/lvs/__init__.py
@@ -1,0 +1,41 @@
+"""LVS (Layout-vs-Schematic) verification for kicad-tools boards.
+
+Compares the schematic netlist (the design intent) against the routed PCB
+(what manufacturing will see) and reports any per-pin net mismatches.
+
+Currently single-board scope (board 00); see issue #3742 for the
+generalized fleet-wide LVS rollout.
+
+Public API:
+
+* :func:`compare_netlists` — pure comparator returning :class:`LVSResult`.
+* :class:`LVSResult`        — frozen dataclass with ``clean`` flag and
+                              tuple of :class:`LVSMismatch` entries.
+* :class:`LVSMismatch`      — frozen dataclass naming the offending
+                              ``(ref, pad)`` and both nets.
+* :class:`BoardNetlistMismatch` — exception carrying the LVSResult;
+                                  raised by board recipes, never by the
+                                  comparator itself.
+* :func:`_ref_of`           — helper that resolves a footprint's
+                              reference designator across both KiCad
+                              serializer dialects (kept underscored
+                              because it is implementation detail that
+                              board recipes also call directly while
+                              the #3742 deduplication is pending).
+"""
+
+from kicad_tools.lvs.board_lvs import (
+    BoardNetlistMismatch,
+    LVSMismatch,
+    LVSResult,
+    _ref_of,
+    compare_netlists,
+)
+
+__all__ = [
+    "BoardNetlistMismatch",
+    "LVSMismatch",
+    "LVSResult",
+    "_ref_of",
+    "compare_netlists",
+]

--- a/src/kicad_tools/lvs/board_lvs.py
+++ b/src/kicad_tools/lvs/board_lvs.py
@@ -1,0 +1,230 @@
+"""Board-level LVS (Layout-vs-Schematic) comparator.
+
+For each ``(ref, pad)`` pair present on either side, build a
+``dict[(ref, pad), net_name | None]`` from the schematic and another from
+the routed PCB, then diff them.  v1 compares as plain strings -- no
+rename heuristics, no power-net normalization.  Those belong in the
+fleet-wide rollout (issue #3742).
+
+Inputs:
+
+* ``.kicad_sch`` — walked via :class:`Schematic` +
+  :meth:`Schematic.get_net_for_pin` so each pin resolves to the
+  label-bound net name (``VCC``, ``GND``, ``LED_ANODE``, ...) rather
+  than the post-merge ``PWR_FLAG`` blob.
+* ``.kicad_pcb`` — walked via :func:`kicad_tools.sexp.parse_file` and the
+  ``(footprint ... (pad N ... (net K "NAME")))`` shape.  Pads with no
+  ``(net ...)`` child are treated as unconnected (``None``).
+
+The comparator is pure: no logging, no side-effects, no exceptions for
+mismatches.  The board recipe is the one that decides whether a dirty
+result should fail the build (it raises
+:class:`BoardNetlistMismatch`).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from kicad_tools.sexp import SExp, parse_file
+
+
+@dataclass(frozen=True)
+class LVSMismatch:
+    """A single per-pin schematic↔PCB disagreement.
+
+    ``schematic_net`` is ``None`` when the pin is absent from the
+    schematic netlist (e.g. a PCB-only pad), and ``pcb_net`` is ``None``
+    when the pad is present on the board but has no ``(net ...)`` entry
+    (an unconnected pad).
+    """
+
+    ref: str
+    pad: str
+    schematic_net: str | None
+    pcb_net: str | None
+
+
+@dataclass(frozen=True)
+class LVSResult:
+    """Outcome of comparing a schematic against a routed PCB.
+
+    ``clean`` is ``True`` iff ``mismatches`` is empty.  Construct via
+    :func:`compare_netlists`; callers should treat this as read-only.
+    """
+
+    clean: bool
+    mismatches: tuple[LVSMismatch, ...]
+
+
+class BoardNetlistMismatch(Exception):
+    """Raised by board recipes when LVS reports a mismatch.
+
+    Carries the underlying :class:`LVSResult` on the ``.result``
+    attribute so callers (tests, CLI wrappers) can inspect the full
+    mismatch list without re-running the comparator.
+    """
+
+    def __init__(self, result: LVSResult) -> None:
+        self.result = result
+        super().__init__(self._format_message(result))
+
+    @staticmethod
+    def _format_message(result: LVSResult) -> str:
+        if not result.mismatches:
+            return "schematic/PCB netlist mismatch (no details)"
+        lines = [f"schematic/PCB netlist mismatch ({len(result.mismatches)} pin(s)):"]
+        for m in result.mismatches:
+            lines.append(f"  {m.ref}.{m.pad}: schematic={m.schematic_net!r} pcb={m.pcb_net!r}")
+        return "\n".join(lines)
+
+
+def _ref_of(fp: SExp) -> str | None:
+    """Resolve a footprint's reference designator across serializer dialects.
+
+    The kicad-tools PCB generator emits ``(fp_text reference "R1" ...)``
+    while a round-trip through ``kicad-cli`` rewrites the same field as
+    ``(property "Reference" "R1" ...)``.  Either form may appear in a
+    PCB this code reads, so probe both and return whichever is present.
+
+    Returns ``None`` if neither form is found (which should not happen
+    on a well-formed PCB; the caller decides whether to treat that as
+    an error).
+    """
+    for ft in fp.find_all("fp_text"):
+        if ft.get_string(0) == "reference":
+            ref = ft.get_string(1)
+            if ref:
+                return ref
+    for p in fp.find_all("property"):
+        if p.get_string(0) == "Reference":
+            ref = p.get_string(1)
+            if ref:
+                return ref
+    return None
+
+
+def _schematic_pin_to_net(sch_path: Path) -> dict[tuple[str, str], str | None]:
+    """Build ``{(ref, pad) -> net_name | None}`` for every pin in the schematic.
+
+    Uses :meth:`Schematic.get_net_for_pin` per pin: it correctly resolves
+    each pin to the *label-bound* net name (``VCC``, ``GND``,
+    ``LED_ANODE``, ...) rather than collapsing power rails through a
+    ``PWR_FLAG`` symbol.  ``build_netlist_from_schematic`` merges every
+    pin touching the same ``PWR_FLAG`` symbol into one net called
+    ``PWR_FLAG``, which loses the VCC/GND distinction and makes LVS
+    spuriously fail on every board that uses PWR_FLAG.
+
+    ``None`` indicates a floating pin (not connected to anything in the
+    schematic), matching the convention used for unconnected PCB pads.
+    """
+    # Import lazily — ``Schematic`` pulls in a substantial chunk of the
+    # schematic stack and we want ``import kicad_tools.lvs`` cheap.
+    from kicad_tools.schematic.models.schematic import Schematic
+
+    sch = Schematic.load(sch_path)
+    out: dict[tuple[str, str], str | None] = {}
+    for sym in sch.symbols:
+        ref = sym.reference
+        if not ref:
+            continue
+        # ``symbol_def.pins`` is the canonical pin list for this symbol;
+        # iterate by pin number so the mapping aligns with the PCB pads
+        # (which are also keyed by pin/pad number).
+        for pin in sym.symbol_def.pins:
+            number = pin.number
+            if not number:
+                continue
+            out[(ref, number)] = sch.get_net_for_pin(ref, number)
+    return out
+
+
+def _pcb_pin_to_net(pcb_path: Path) -> dict[tuple[str, str], str | None]:
+    """Build ``{(ref, pad) -> net_name | None}`` from a routed PCB.
+
+    ``None`` means the pad exists on the board but has no ``(net ...)``
+    binding (unconnected).  Pads without a numeric label and footprints
+    without a resolvable reference are skipped silently — they cannot
+    take part in an LVS comparison.
+    """
+    doc = parse_file(pcb_path)
+    out: dict[tuple[str, str], str | None] = {}
+    for fp in doc.find_all("footprint"):
+        ref = _ref_of(fp)
+        if ref is None:
+            continue
+        for pad in fp.find_all("pad"):
+            pad_num = pad.get_string(0)
+            if pad_num is None:
+                continue
+            net = pad.find("net")
+            net_name: str | None
+            if net is None:
+                net_name = None
+            else:
+                # ``(net K "NAME")`` — index 0 is the net number, index 1
+                # the human-readable name.
+                net_name = net.get_string(1)
+            out[(ref, pad_num)] = net_name
+    return out
+
+
+def compare_netlists(sch_path: str | Path, pcb_path: str | Path) -> LVSResult:
+    """Compare schematic and routed PCB netlists per-pin.
+
+    The comparison is the simplest possible: for every ``(ref, pad)``
+    key that appears in either dict, both sides must agree on the net
+    name (string equality, no normalization).  Mismatches include:
+
+    * Pin present in schematic, absent from PCB (``pcb_net=None``).
+    * Pin present in PCB, absent from schematic (``schematic_net=None``).
+    * Pin present on both sides but with different net names.
+
+    The PCB's net-0 default ("no net") is treated as ``None`` on the PCB
+    side -- it's the "no connection" sentinel, not a real net name.
+
+    Args:
+        sch_path: Path to a ``.kicad_sch`` (root sheet for hierarchy).
+        pcb_path: Path to a ``.kicad_pcb`` (routed or unrouted; routing
+            does not affect the netlist).
+
+    Returns:
+        :class:`LVSResult`.  Always returned -- mismatches are data, not
+        exceptions.  Callers (recipes) raise
+        :class:`BoardNetlistMismatch` themselves when they want to fail.
+    """
+    sch_path = Path(sch_path)
+    pcb_path = Path(pcb_path)
+
+    sch_map = _schematic_pin_to_net(sch_path)
+    pcb_map = _pcb_pin_to_net(pcb_path)
+
+    # The PCB's net 0 — encoded as an empty-string ``(net 0 "")`` net
+    # name — is the "no connection" placeholder, not a real net.
+    # Collapse it to ``None`` so unconnected pads compare equal to
+    # schematic pins that genuinely lack a net (floating pin).
+    def _norm_pcb(name: str | None) -> str | None:
+        if name is None or name == "":
+            return None
+        return name
+
+    mismatches: list[LVSMismatch] = []
+    # Stable iteration order: union of keys, sorted by (ref, pad) so the
+    # output is deterministic for golden-file tests.
+    all_keys = sorted(set(sch_map) | set(pcb_map))
+    for key in all_keys:
+        ref, pad = key
+        sch_net = sch_map.get(key)
+        pcb_net = _norm_pcb(pcb_map.get(key))
+        if sch_net != pcb_net:
+            mismatches.append(
+                LVSMismatch(
+                    ref=ref,
+                    pad=pad,
+                    schematic_net=sch_net,
+                    pcb_net=pcb_net,
+                )
+            )
+
+    return LVSResult(clean=not mismatches, mismatches=tuple(mismatches))

--- a/tests/test_board_00_lvs.py
+++ b/tests/test_board_00_lvs.py
@@ -1,0 +1,205 @@
+"""LVS coverage for board 00 (issue #3748).
+
+These tests exercise the new :mod:`kicad_tools.lvs` comparator against
+the committed board 00 artifacts and a deliberately mutated copy.  They
+are fast (sub-second) and hermetic -- they read files only, never spawn
+``kicad-cli``, and never invoke the router.
+
+Why three tests:
+
+1. **Clean positive** -- guards against a regression that breaks LVS for
+   the canonical hello-world board.
+2. **Dirty negative** -- swaps two pad-to-net bindings on the PCB so the
+   comparator's output is provably non-trivial; also exercises the
+   :class:`BoardNetlistMismatch` exception path that the recipe relies
+   on to exit non-zero.
+3. **``_ref_of`` polymorphism** -- locks down the two reference dialects
+   the codebase already has to handle.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.lvs import (
+    BoardNetlistMismatch,
+    LVSResult,
+    _ref_of,
+    compare_netlists,
+)
+from kicad_tools.sexp import SExp, parse_file, parse_string
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BOARD_DIR = REPO_ROOT / "boards" / "00-simple-led"
+BOARD_OUTPUT = BOARD_DIR / "output"
+BOARD_SCH = BOARD_OUTPUT / "simple_led.kicad_sch"
+BOARD_PCB = BOARD_OUTPUT / "simple_led_routed.kicad_pcb"
+
+
+@pytest.fixture(scope="module")
+def board00_artifacts() -> tuple[Path, Path]:
+    """The committed board 00 schematic + routed PCB.
+
+    These are checked in under ``boards/00-simple-led/output/`` after the
+    #3747 D1 polarity fix landed, so the comparator should report clean.
+    The fixture skips if either artifact is missing -- it's possible (if
+    unusual) for a contributor to wipe the output directory locally.
+    """
+    if not BOARD_SCH.exists() or not BOARD_PCB.exists():
+        pytest.skip(
+            f"board 00 artifacts not present "
+            f"(sch={BOARD_SCH.exists()}, pcb={BOARD_PCB.exists()}); "
+            "run boards/00-simple-led/generate_design.py to regenerate."
+        )
+    return BOARD_SCH, BOARD_PCB
+
+
+class TestCompareNetlistsCleanOnBoard00:
+    """Board 00's committed artifacts must compare clean (#3748 happy path)."""
+
+    def test_clean_result(self, board00_artifacts: tuple[Path, Path]) -> None:
+        sch, pcb = board00_artifacts
+        result = compare_netlists(sch, pcb)
+        assert isinstance(result, LVSResult)
+        assert result.clean is True, (
+            f"LVS unexpectedly dirty on the committed board 00 artifacts: {result.mismatches}"
+        )
+        assert result.mismatches == ()
+
+
+def _swap_d1_pad_nets(pcb_path: Path, tmp_dest: Path) -> Path:
+    """Copy ``pcb_path`` to ``tmp_dest`` with D1's pads 1/2 net names swapped.
+
+    Produces a deliberately mismatched PCB so the LVS comparator must
+    report two mismatches (D1.1 and D1.2 with their nets crossed).  Done
+    via :func:`kicad_tools.sexp.parse_file` so we don't depend on the
+    physical text layout of the source file.
+    """
+    doc = parse_file(pcb_path)
+    for fp in doc.find_all("footprint"):
+        if _ref_of(fp) != "D1":
+            continue
+        # Find the (pad "1" ...) and (pad "2" ...) children and swap
+        # their (net N "NAME") child nodes wholesale.  Using full-node
+        # replacement keeps both the net number and the name in sync.
+        pad1 = None
+        pad2 = None
+        for pad in fp.find_all("pad"):
+            num = pad.get_string(0)
+            if num == "1":
+                pad1 = pad
+            elif num == "2":
+                pad2 = pad
+        assert pad1 is not None and pad2 is not None, (
+            "D1 footprint must have pads 1 and 2; PCB structure changed."
+        )
+        net1 = pad1.find("net")
+        net2 = pad2.find("net")
+        assert net1 is not None and net2 is not None, (
+            "D1 pads must have (net ...) entries; otherwise nothing to swap."
+        )
+        # Replace pad1's (net ...) with pad2's, and vice versa.  We
+        # build replacements rather than mutating shared nodes to avoid
+        # accidentally aliasing children across pads.
+        new_net_for_1 = SExp.list("net", net2.get_int(0), net2.get_string(1) or "")
+        new_net_for_2 = SExp.list("net", net1.get_int(0), net1.get_string(1) or "")
+        # Splice in: replace the old net node at its original child index.
+        for pad, old_net, new_net in (
+            (pad1, net1, new_net_for_1),
+            (pad2, net2, new_net_for_2),
+        ):
+            for i, child in enumerate(pad.children):
+                if child is old_net:
+                    pad.children[i] = new_net
+                    break
+        break
+    tmp_dest.write_text(doc.to_string() + "\n")
+    return tmp_dest
+
+
+class TestCompareNetlistsDetectsReversedLed:
+    """Swapping D1.1↔D1.2 nets on the PCB must produce a dirty LVS result."""
+
+    @pytest.fixture
+    def mismatched_pcb(
+        self,
+        board00_artifacts: tuple[Path, Path],
+        tmp_path: Path,
+    ) -> tuple[Path, Path]:
+        sch, pcb = board00_artifacts
+        bad_pcb = _swap_d1_pad_nets(pcb, tmp_path / "simple_led_bad.kicad_pcb")
+        return sch, bad_pcb
+
+    def test_reports_two_d1_mismatches(self, mismatched_pcb: tuple[Path, Path]) -> None:
+        sch, bad_pcb = mismatched_pcb
+        result = compare_netlists(sch, bad_pcb)
+        assert result.clean is False
+        # Pull just the D1 mismatches; the comparator emits both
+        # (ref, pad) keys involved in the swap.
+        d1_mismatches = {(m.ref, m.pad): m for m in result.mismatches if m.ref == "D1"}
+        assert set(d1_mismatches.keys()) == {("D1", "1"), ("D1", "2")}, (
+            f"Expected D1.1 and D1.2 in the mismatch list; got "
+            f"{[(m.ref, m.pad) for m in result.mismatches]}"
+        )
+        # And the nets must be crossed (schematic still says cathode/anode
+        # on the original pads; PCB now binds them the other way around).
+        m1 = d1_mismatches[("D1", "1")]
+        m2 = d1_mismatches[("D1", "2")]
+        assert m1.schematic_net == "GND" and m1.pcb_net == "LED_ANODE", (
+            f"D1.1 mismatch wrong: schematic={m1.schematic_net!r} pcb={m1.pcb_net!r}"
+        )
+        assert m2.schematic_net == "LED_ANODE" and m2.pcb_net == "GND", (
+            f"D1.2 mismatch wrong: schematic={m2.schematic_net!r} pcb={m2.pcb_net!r}"
+        )
+
+    def test_board_netlist_mismatch_message_names_pads(
+        self, mismatched_pcb: tuple[Path, Path]
+    ) -> None:
+        """The recipe-facing exception must surface both ref.pad keys.
+
+        Regression for the #3747-style bug: a developer triaging a
+        failed recipe should see the exact pin pair without having to
+        open ``lvs.json`` first.
+        """
+        sch, bad_pcb = mismatched_pcb
+        result = compare_netlists(sch, bad_pcb)
+        exc = BoardNetlistMismatch(result)
+        msg = str(exc)
+        assert "D1.1" in msg, f"BoardNetlistMismatch message missing D1.1: {msg!r}"
+        assert "D1.2" in msg, f"BoardNetlistMismatch message missing D1.2: {msg!r}"
+        # And the exception keeps the structured result for callers that
+        # want to inspect it programmatically (tests, CLI wrappers).
+        assert exc.result is result
+
+
+class TestRefOfHandlesBothReferenceForms:
+    """``_ref_of`` must resolve both the generator and KiCad-CLI dialects."""
+
+    def test_fp_text_reference_form(self) -> None:
+        """Pre-round-trip form: ``(fp_text reference "R1" ...)``."""
+        fp = parse_string(
+            '(footprint "Resistor_SMD:R_0805_2012Metric" '
+            '(layer "F.Cu") '
+            '(fp_text reference "R1" (at 0 -1.5) (layer "F.SilkS")) '
+            '(fp_text value "330" (at 0 1.5) (layer "F.Fab")))'
+        )
+        assert _ref_of(fp) == "R1"
+
+    def test_property_reference_form(self) -> None:
+        """Post-round-trip form: ``(property "Reference" "U2" ...)``."""
+        fp = parse_string(
+            '(footprint "Package_QFP:LQFP-48" '
+            '(layer "F.Cu") '
+            '(property "Reference" "U2" (at 0 -5 0) (layer "F.SilkS")) '
+            '(property "Value" "STM32F0" (at 0 5 0) (layer "F.Fab")))'
+        )
+        assert _ref_of(fp) == "U2"
+
+    def test_missing_reference_returns_none(self) -> None:
+        """A footprint with no reference field must yield ``None`` (not raise)."""
+        fp = parse_string(
+            '(footprint "Misc:NoRef" (layer "F.Cu") (fp_text value "X" (at 0 0) (layer "F.Fab")))'
+        )
+        assert _ref_of(fp) is None


### PR DESCRIPTION
## Summary

- Add a new ``kicad_tools.lvs`` submodule with a pure ``compare_netlists`` comparator (``LVSResult`` / ``LVSMismatch`` / ``BoardNetlistMismatch``) that builds a ``{(ref, pad) -> net_name}`` dict from both the schematic and the routed ``.kicad_pcb`` and diffs them.
- Wire ``run_lvs`` into board 00's ``generate_design.py`` between Step 6 (DRC) and Step 7 (manufacturing bundle); it writes ``output/lvs.json`` per the new v1 schema and raises ``BoardNetlistMismatch`` on disagreement so the recipe **hard-fails** instead of silently shipping a mis-wired board (regression guard for #3747).
- Document the v1 ``lvs.json`` schema in ``docs/board-json-schema.md`` and add three hermetic tests (clean board 00, deliberately-swapped D1.1/D1.2 mismatch case, ``_ref_of`` reference-form polymorphism).

Schematic-side resolution uses ``Schematic.get_net_for_pin`` (label-bound names: VCC, GND, LED_ANODE, ...) rather than ``build_netlist_from_schematic``, which would collapse every PWR_FLAG-touched pin into one "PWR_FLAG" net and make LVS spuriously fail on every board.

Scope is board 00 only; the fleet-wide rollout (rename heuristics, other boards, ``kct check`` integration) is tracked by #3742. The recipe's existing local ``_ref_of`` helper is **not** removed in this PR -- the new module exports it alongside so #3742 can dedupe it cleanly.

Closes #3748.

## Test plan

- [x] ``uv run pytest tests/test_board_00_lvs.py -v`` — 6 passed (clean board 00 / mismatched D1 / exception message / both ``_ref_of`` forms / missing reference)
- [x] ``uv run pytest tests/test_board_00_simple_led.py -v`` — 6 passed (existing board 00 polarity + #3148 regression tests still green)
- [x] ``uv run python boards/00-simple-led/generate_design.py`` — exits 0 with ``LVS: PASS`` and writes ``output/lvs.json`` containing ``{"clean": true, "mismatches": []}``
- [x] ``uv run ruff check`` and ``uv run ruff format`` clean on all changed files
- [ ] Manual sanity: temporarily swap one of the schematic's labels and confirm the recipe exits non-zero with the new ``BoardNetlistMismatch`` message naming the offending ``(ref, pad)`` pairs

🤖 Generated with [Claude Code](https://claude.com/claude-code)