### PR TITLE
feat(board-json,site): surface LVS status in gallery chip (closes #3749)

### DIFF
--- a/docs/board-json-schema.md
+++ b/docs/board-json-schema.md
@@ -24,6 +24,8 @@ directory — `kct board-metrics` never recomputes anything from KiCad.
 | `renders`               | `output/renders/*.png` (from `kct render`, #3675) | only existing files |
 | `manufacturing_package` | `output/manufacturing/kicad_project.zip` | omitted if absent |
 | `manifest_generated_at` | `manifest.json` → `generated_at`      | ISO-8601 string |
+| `lvs_clean`             | `output/lvs.json` → `clean`           | omitted when `lvs.json` is absent (#3748, #3749) |
+| `lvs_mismatches`        | `output/lvs.json` → `len(mismatches)` | omitted when `lvs.json` is absent (#3748, #3749) |
 
 ## Example
 
@@ -49,6 +51,8 @@ directory — `kct board-metrics` never recomputes anything from KiCad.
   },
   "manufacturing_package": "manufacturing/kicad_project.zip",
   "manifest_generated_at": "2026-06-12T05:03:41.535120+00:00",
+  "lvs_clean": true,
+  "lvs_mismatches": 0,
   "status": "ok"
 }
 ```
@@ -73,6 +77,8 @@ directory — `kct board-metrics` never recomputes anything from KiCad.
 | `renders`               | object  | no       | Map of render id → path relative to `board.json` |
 | `manufacturing_package` | string  | no       | Path to downloadable `kicad_project.zip` |
 | `manifest_generated_at` | string  | no       | Manifest build timestamp (ISO-8601) |
+| `lvs_clean`             | boolean | no       | `true` iff `output/lvs.json` reports `clean: true`. Omitted when `lvs.json` is absent (board has not run LVS yet). |
+| `lvs_mismatches`        | integer | no       | Count of mismatches recorded in `output/lvs.json`. Omitted when `lvs.json` is absent. |
 
 ### Paths are relative to `board.json`
 
@@ -84,9 +90,14 @@ resolves to `boards/<id>/output/renders/pcb-front.png`.
 
 | Value          | Meaning |
 |----------------|---------|
-| `ok`           | `output/manufacturing/` exists and `report.md` parsed successfully |
-| `partial`      | `output/manufacturing/` exists but `report.md` is absent/unparseable; only identity and recoverable fields are present |
+| `ok`           | `output/manufacturing/` exists, `report.md` parsed successfully, `drc_violations == 0`, and (when `lvs.json` is present) `lvs_clean == true` |
+| `partial`      | `output/manufacturing/` exists but `report.md` is absent/unparseable (only identity and recoverable fields are present), OR `drc_violations > 0`, OR an explicit `lvs_clean == false` |
 | `no_artifacts` | the board has no `output/manufacturing/` directory at all |
+
+Note: a *missing* `lvs.json` does **not** downgrade `status` at the producer
+layer — boards without an LVS step yet keep their existing status. The site
+gallery enforces a stricter gate ("Ready" requires `lvs_clean === true`) by
+rendering a neutral "LVS not run" chip when the field is absent (#3749).
 
 ## Optional fields are omitted, never `null`
 

--- a/site/src/components/BoardCard.astro
+++ b/site/src/components/BoardCard.astro
@@ -207,6 +207,22 @@ const statusLabel = displayStatusLabel(board);
     color: #1a1300;
   }
 
+  /* LVS-mismatch chip (#3749): the schematic and PCB disagree, so the board
+     will not function as designed even though it may be DRC-clean. We use a
+     warmer orange to distinguish it from amber "Partial" and red "DRC". */
+  .chip-lvs {
+    background: rgba(214, 130, 50, 0.92);
+    color: #1a0d00;
+  }
+
+  /* LVS-not-run chip (#3749): neutral gray for "unknown" — visually similar
+     to no_artifacts so the message is "we have not verified" rather than "we
+     verified and it is a problem". Never reads as Ready. */
+  .chip-unverified {
+    background: rgba(120, 134, 148, 0.85);
+    color: #0c1116;
+  }
+
   .chip-no_artifacts {
     background: rgba(120, 134, 148, 0.85);
     color: #0c1116;

--- a/site/src/data/boardStatus.test.ts
+++ b/site/src/data/boardStatus.test.ts
@@ -1,15 +1,20 @@
 /**
- * Unit tests for the display-status helper (issue #3717).
+ * Unit tests for the display-status helper (issues #3717, #3749).
  *
- * The displayed gallery badge must read "Ready" ONLY when a board has zero DRC
- * violations. A board with `drc_violations > 0` must never show "Ready" — even
- * if its raw `status` field is a stale/over-optimistic "ok".
+ * The displayed gallery badge must read "Ready" ONLY when a board has zero
+ * DRC violations AND an explicit `lvs_clean === true`. A board with
+ * `drc_violations > 0` must never show "Ready". A board with an LVS mismatch
+ * (`lvs_clean === false`) must never show "Ready". A board that has not run
+ * LVS at all (`lvs_clean === undefined`) must never show "Ready" — the chip
+ * reads "LVS not run" instead.
  */
 import { describe, expect, it } from "vitest";
 import { displayStatus, displayStatusLabel } from "./boardStatus.ts";
 import type { Board } from "./types.ts";
 
 function makeBoard(overrides: Partial<Board> = {}): Board {
+  // Default fixture is "Ready" — explicitly LVS-clean. Tests for the
+  // unverified path opt OUT via `lvs_clean: undefined`.
   return {
     $schema: "https://kicad-tools.org/schemas/board/v1.json",
     schema_version: 1,
@@ -17,13 +22,14 @@ function makeBoard(overrides: Partial<Board> = {}): Board {
     slug: "demo",
     status: "ok",
     category: "demo",
+    lvs_clean: true,
     ...overrides,
   };
 }
 
 describe("displayStatus", () => {
-  it("returns 'ready' for status ok with zero DRC violations", () => {
-    const b = makeBoard({ status: "ok", drc_violations: 0 });
+  it("returns 'ready' for status ok with zero DRC violations and lvs_clean true", () => {
+    const b = makeBoard({ status: "ok", drc_violations: 0, lvs_clean: true });
     expect(displayStatus(b)).toBe("ready");
     expect(displayStatusLabel(b)).toBe("Ready");
   });
@@ -57,5 +63,59 @@ describe("displayStatus", () => {
     const b = makeBoard({ status: "no_artifacts" });
     expect(displayStatus(b)).toBe("no_artifacts");
     expect(displayStatusLabel(b)).toBe("No artifacts");
+  });
+
+  // ── LVS gates (#3749) ───────────────────────────────────────────────────
+
+  it("returns 'lvs' for lvs_clean false even when status is ok", () => {
+    const b = makeBoard({ status: "ok", drc_violations: 0, lvs_clean: false });
+    expect(displayStatus(b)).toBe("lvs");
+    expect(displayStatusLabel(b)).toBe("LVS mismatch");
+  });
+
+  it("includes the LVS mismatch count when lvs_mismatches > 0 (plural)", () => {
+    const b = makeBoard({ lvs_clean: false, lvs_mismatches: 3 });
+    expect(displayStatus(b)).toBe("lvs");
+    expect(displayStatusLabel(b)).toBe("LVS: 3 mismatches");
+  });
+
+  it("singularizes the LVS mismatch label for one mismatch", () => {
+    const b = makeBoard({ lvs_clean: false, lvs_mismatches: 1 });
+    expect(displayStatus(b)).toBe("lvs");
+    expect(displayStatusLabel(b)).toBe("LVS: 1 mismatch");
+  });
+
+  it("falls back to 'LVS mismatch' when lvs_mismatches is absent or zero", () => {
+    const b = makeBoard({ lvs_clean: false, lvs_mismatches: 0 });
+    expect(displayStatusLabel(b)).toBe("LVS mismatch");
+  });
+
+  it("returns 'unverified' when lvs_clean is absent, even for status ok (regression #3749)", () => {
+    // This is the bug board 00 reproduced today: status="ok" + DRC=0 but no
+    // LVS verification → chip MUST NOT read "Ready".
+    const b = makeBoard({ status: "ok", drc_violations: 0, lvs_clean: undefined });
+    expect(displayStatus(b)).toBe("unverified");
+    expect(displayStatusLabel(b)).toBe("LVS not run");
+    expect(displayStatusLabel(b)).not.toBe("Ready");
+  });
+
+  it("DRC takes priority over LVS when both fail (DRC is the fabrication blocker)", () => {
+    const b = makeBoard({
+      status: "ok",
+      drc_violations: 5,
+      lvs_clean: false,
+      lvs_mismatches: 2,
+    });
+    expect(displayStatus(b)).toBe("drc");
+    expect(displayStatusLabel(b)).toBe("5 DRC violations");
+  });
+
+  it("DRC takes priority over 'unverified' when LVS is missing but DRC > 0", () => {
+    const b = makeBoard({
+      status: "ok",
+      drc_violations: 1,
+      lvs_clean: undefined,
+    });
+    expect(displayStatus(b)).toBe("drc");
   });
 });

--- a/site/src/data/boardStatus.ts
+++ b/site/src/data/boardStatus.ts
@@ -1,33 +1,47 @@
 /**
- * Display-status helper for the gallery status badge (issue #3717).
+ * Display-status helper for the gallery status badge (issues #3717, #3749).
  *
  * The raw `board.status` field ("ok"/"partial"/"no_artifacts") comes from
  * `kct board-metrics`. The gallery renders `status === "ok"` as a green
- * "Ready" badge — but "Ready" must mean *manufacturable*, and a board with
- * `drc_violations > 0` is not manufacturable.
+ * "Ready" badge — but "Ready" must mean *manufacturable + electrically
+ * verified*, so we add two additional gates here:
  *
- * This module derives the *displayed* badge from BOTH `status` and
- * `drc_violations` so a stale or over-optimistic `status` can never surface
- * "Ready" over a violating board. It is defense-in-depth: `board-metrics`
- * already downgrades `status` away from "ok" when DRC > 0, but the site never
- * trusts that alone.
+ *   - `drc_violations > 0`     → "drc"        (board cannot be fabricated)
+ *   - `lvs_clean === false`    → "lvs"        (board will not function)
+ *   - `lvs_clean === undefined`→ "unverified" (LVS has not run; unknown)
+ *
+ * Defense-in-depth: `board-metrics` already downgrades `status` away from
+ * "ok" when DRC > 0 or when LVS records an explicit mismatch, but the site
+ * never trusts that alone. The "unverified" case is purely a site-layer
+ * stricter gate — a missing `lvs.json` does NOT downgrade `status` at the
+ * producer layer (boards without an LVS step yet keep their existing status).
  */
 import type { Board } from "./types.ts";
 
 /** The display variants the status chip / row can take. */
-export type DisplayStatus = "ready" | "drc" | "partial" | "no_artifacts";
+export type DisplayStatus =
+  | "ready"
+  | "drc"
+  | "lvs"
+  | "unverified"
+  | "partial"
+  | "no_artifacts";
 
 /**
  * Compute the *displayed* status variant for a board.
  *
- * Rules:
- *   - `drc_violations > 0`  → "drc"   (warn-styled, never "Ready")
- *   - `status === "ok"`     → "ready" (only reachable when DRC is 0/absent)
- *   - `status === "partial"`→ "partial"
- *   - else                  → "no_artifacts"
+ * Display-priority order (load-bearing): DRC > LVS > unverified > status.
+ *
+ * Rationale: a DRC violation is the strongest negative signal — the board
+ * cannot be manufactured. An LVS mismatch is next — the board can be made
+ * but will not function as designed. "Unverified" is a neutral unknown that
+ * must never display as Ready. Only when all three gates pass does the raw
+ * `status` field decide.
  */
 export function displayStatus(board: Board): DisplayStatus {
   if ((board.drc_violations ?? 0) > 0) return "drc";
+  if (board.lvs_clean === false) return "lvs";
+  if (board.lvs_clean === undefined) return "unverified";
   if (board.status === "ok") return "ready";
   if (board.status === "partial") return "partial";
   return "no_artifacts";
@@ -43,6 +57,15 @@ export function displayStatusLabel(board: Board): string {
       const n = board.drc_violations ?? 0;
       return `${n} DRC violation${n === 1 ? "" : "s"}`;
     }
+    case "lvs": {
+      const n = board.lvs_mismatches ?? 0;
+      if (n > 0) {
+        return `LVS: ${n} mismatch${n === 1 ? "" : "es"}`;
+      }
+      return "LVS mismatch";
+    }
+    case "unverified":
+      return "LVS not run";
     case "partial":
       return "Partial";
     case "no_artifacts":

--- a/site/src/data/types.ts
+++ b/site/src/data/types.ts
@@ -64,4 +64,17 @@ export interface Board {
   renders?: Record<string, string>;
   manufacturing_package?: string;
   manifest_generated_at?: string;
+  /**
+   * LVS (Layout-vs-Schematic) verification result (#3748, #3749). Sourced from
+   * `output/lvs.json` → `clean`. Omitted when the board has not run LVS yet
+   * (e.g. boards 01-05 in v1 — the fleet rollout is tracked by #3742). A
+   * missing `lvs_clean` is treated as "unverified" and must NOT display as
+   * "Ready" by the gallery chip.
+   */
+  lvs_clean?: boolean;
+  /**
+   * Number of schematic-vs-PCB mismatches recorded in `output/lvs.json`
+   * (#3748, #3749). Omitted when the board has not run LVS yet.
+   */
+  lvs_mismatches?: number;
 }

--- a/src/kicad_tools/cli/board_metrics_cmd.py
+++ b/src/kicad_tools/cli/board_metrics_cmd.py
@@ -13,6 +13,9 @@ artifacts that already exist under a board's ``output/manufacturing/`` directory
 * ``bom_jlcpcb.csv`` -> fallback part count (row count minus header).
 * ``kicad_project.zip`` -> downloadable manufacturing package path.
 * ``../renders/*.png`` -> render image paths (written by ``kct render``, #3675).
+* ``../lvs.json``    -> Layout-vs-Schematic verification (#3748, #3749);
+                        sourced from ``output/lvs.json`` (NOT under
+                        ``manufacturing/``).
 
 Output is written to ``boards/<id>/output/board.json``.
 
@@ -46,17 +49,21 @@ absent or unparseable.
       },
       "manufacturing_package": "manufacturing/kicad_project.zip",
       "manifest_generated_at": "2026-06-12T05:03:41.535120+00:00",
+      "lvs_clean": true,
+      "lvs_mismatches": 0,
       "status": "ok"
     }
 
 ``status`` is one of:
 
 * ``"ok"``           — ``output/manufacturing/`` exists, ``report.md`` parsed,
-                        and ``drc_violations == 0`` (manufacturable).
+                        ``drc_violations == 0`` (manufacturable), and (when
+                        ``lvs.json`` is present) ``lvs_clean == True``.
 * ``"partial"``      — ``output/manufacturing/`` exists but ``report.md`` is
                         absent/unparseable (only identity + whatever fields we
                         could recover), OR ``report.md`` parsed but the board
-                        still has ``drc_violations > 0`` (not manufacturable).
+                        still has ``drc_violations > 0`` (not manufacturable),
+                        OR an explicit ``lvs_clean == False`` LVS mismatch.
 * ``"no_artifacts"`` — no ``output/manufacturing/`` directory at all.
 
 Schema versioning policy: this schema is the Phase 2 (Astro site) data contract.
@@ -206,6 +213,27 @@ def _parse_cost(text: str) -> dict | None:
     return cost or None
 
 
+def _parse_lvs(lvs_path: Path, slug: str) -> dict:
+    """Source LVS fields from ``output/lvs.json`` (#3748, #3749).
+
+    Returns ``{"lvs_clean": bool, "lvs_mismatches": int}`` when the file is
+    present and readable; returns ``{}`` when the file is absent or unparseable
+    so the keys are *omitted* from the emitted ``board.json`` rather than set
+    to ``null`` (the board.json contract: missing artifact → field omitted).
+    """
+    if not lvs_path.is_file():
+        return {}
+    try:
+        data = json.loads(lvs_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("board %s: could not read lvs.json (%s)", slug, exc)
+        return {}
+    return {
+        "lvs_clean": bool(data.get("clean", False)),
+        "lvs_mismatches": len(data.get("mismatches") or []),
+    }
+
+
 def _parse_manifest(manifest_path: Path, slug: str) -> dict:
     """Parse identity fields from ``manifest.json`` (board name + timestamp)."""
     out: dict = {}
@@ -291,6 +319,11 @@ def extract_board_metrics(board_dir: Path) -> dict:
     if manifest_path.is_file():
         metrics.update(_parse_manifest(manifest_path, slug))
 
+    # lvs.json lives at output/lvs.json (NOT under output/manufacturing/) per
+    # the #3748 producer. When absent the LVS fields are *omitted* — the site
+    # renders a neutral "LVS not run" chip in that case rather than "Ready".
+    metrics.update(_parse_lvs(output_dir / "lvs.json", slug))
+
     # Fall back to BOM row count when report.md did not yield a part_count.
     if "part_count" not in metrics:
         bom_path = mfg_dir / "bom_jlcpcb.csv"
@@ -310,7 +343,15 @@ def extract_board_metrics(board_dir: Path) -> dict:
     # zero DRC violations. A board that routed (report parsed) but still has
     # DRC errors is downgraded to "partial" — the gallery treats "ok" as the
     # "Ready" badge, which must never appear over a violating board (#3717).
-    if not report_parsed or metrics.get("drc_violations", 0) > 0:
+    #
+    # An *explicit* LVS mismatch (`lvs_clean == False`) is also a downgrade:
+    # the schematic and PCB disagree, so the board will not function as
+    # designed even if it DRC-cleans (#3749). A *missing* lvs.json does NOT
+    # downgrade — boards without an LVS step yet keep their existing status,
+    # and the site layer enforces the stricter "Ready requires lvs_clean ===
+    # true" gate via the "LVS not run" (`unverified`) display variant.
+    lvs_dirty = metrics.get("lvs_clean") is False
+    if not report_parsed or metrics.get("drc_violations", 0) > 0 or lvs_dirty:
         metrics["status"] = "partial"
     else:
         metrics["status"] = "ok"

--- a/tests/test_board_metrics.py
+++ b/tests/test_board_metrics.py
@@ -93,8 +93,16 @@ def _make_board(
     package: bool = False,
     renders: list[str] | None = None,
     make_mfg: bool = True,
+    lvs: dict | None = None,
+    lvs_raw: str | None = None,
 ) -> Path:
-    """Build a synthetic board directory tree and return it."""
+    """Build a synthetic board directory tree and return it.
+
+    ``lvs``: if provided, writes ``output/lvs.json`` with this dict content.
+    ``lvs_raw``: if provided, writes raw text to ``output/lvs.json`` (used to
+    inject malformed JSON for error-handling tests). Mutually exclusive with
+    ``lvs``.
+    """
     board_dir = tmp_path / slug
     output_dir = board_dir / "output"
     output_dir.mkdir(parents=True)
@@ -116,6 +124,13 @@ def _make_board(
         renders_dir.mkdir()
         for name in renders:
             (renders_dir / name).write_bytes(b"\x89PNG")
+
+    if lvs is not None and lvs_raw is not None:
+        raise ValueError("lvs and lvs_raw are mutually exclusive")
+    if lvs is not None:
+        (output_dir / "lvs.json").write_text(json.dumps(lvs))
+    elif lvs_raw is not None:
+        (output_dir / "lvs.json").write_text(lvs_raw)
 
     return board_dir
 
@@ -361,3 +376,64 @@ def test_main_missing_board_dir_errors(tmp_path: Path):
 def test_main_requires_board_or_all(capsys):
     with pytest.raises(SystemExit):
         main([])
+
+
+# ── LVS sourcing (#3749) ───────────────────────────────────────────────────
+
+
+def test_lvs_clean_when_lvs_json_present_and_clean(tmp_path: Path):
+    # An LVS-clean board: lvs_clean=True, lvs_mismatches=0, status stays ok.
+    board = _make_board(
+        tmp_path,
+        lvs={
+            "$schema": "https://kicad-tools.org/schemas/lvs/v1.json",
+            "clean": True,
+            "mismatches": [],
+        },
+    )
+    m = extract_board_metrics(board)
+    assert m["lvs_clean"] is True
+    assert m["lvs_mismatches"] == 0
+    assert m["status"] == "ok"
+
+
+def test_lvs_dirty_downgrades_status_to_partial(tmp_path: Path):
+    # An LVS-dirty board: lvs_clean=False, status downgrades to partial even
+    # when DRC is clean and report.md parses.
+    board = _make_board(
+        tmp_path,
+        lvs={
+            "$schema": "https://kicad-tools.org/schemas/lvs/v1.json",
+            "clean": False,
+            "mismatches": [
+                {"ref": "D1", "pad": "1", "schematic_net": "LED_ANODE", "pcb_net": "GND"},
+                {"ref": "D1", "pad": "2", "schematic_net": "GND", "pcb_net": "LED_ANODE"},
+            ],
+        },
+    )
+    m = extract_board_metrics(board)
+    assert m["lvs_clean"] is False
+    assert m["lvs_mismatches"] == 2
+    # An explicit LVS mismatch downgrades status, mirroring DRC-violation logic.
+    assert m["status"] == "partial"
+
+
+def test_lvs_fields_omitted_when_lvs_json_absent(tmp_path: Path):
+    # No lvs.json on disk -> both LVS fields are OMITTED (never null), and
+    # status follows the existing DRC-only logic (does NOT downgrade).
+    board = _make_board(tmp_path)
+    m = extract_board_metrics(board)
+    assert "lvs_clean" not in m
+    assert "lvs_mismatches" not in m
+    # status stays "ok" — a missing lvs.json must not downgrade boards that
+    # have not run LVS yet. The site layer renders "LVS not run" instead.
+    assert m["status"] == "ok"
+
+
+def test_lvs_fields_omitted_when_lvs_json_malformed(tmp_path: Path):
+    # Malformed JSON in lvs.json -> warning logged, fields omitted, no crash.
+    board = _make_board(tmp_path, lvs_raw="{not json")
+    m = extract_board_metrics(board)
+    assert "lvs_clean" not in m
+    assert "lvs_mismatches" not in m
+    assert m["status"] == "ok"


### PR DESCRIPTION
## Summary

Fixes #3749 — board 00 reads "Ready" in the demo gallery today even though its schematic-vs-PCB netlists are not actually compared by the loader. This PR routes the existing `output/lvs.json` (#3748) through `board.json` and adds two new gallery chip variants so:

- A board with an explicit LVS mismatch (`lvs_clean === false`) reads **"LVS mismatch"** (orange).
- A board that has not run LVS at all (`lvs_clean` absent) reads **"LVS not run"** (gray).
- Only `lvs_clean === true` + `status === "ok"` + zero DRC can read **"Ready"**.

## Changes

**Producer** — `src/kicad_tools/cli/board_metrics_cmd.py`
- New `_parse_lvs()` reads `output/lvs.json` and emits `lvs_clean` / `lvs_mismatches`. Both fields are omitted when `lvs.json` is absent (omit-when-absent contract).
- Status downgrade now also triggers on explicit `lvs_clean == False`. A missing `lvs.json` does NOT downgrade — that is purely a site-layer presentation concern.

**Site** — `site/src/data/types.ts`, `site/src/data/boardStatus.ts`, `site/src/components/BoardCard.astro`
- Extended `Board` interface with `lvs_clean?: boolean` / `lvs_mismatches?: number`.
- Two new `DisplayStatus` variants: `lvs` and `unverified`, with `displayStatusLabel` returning `"LVS: N mismatch(es)"` / `"LVS mismatch"` / `"LVS not run"`.
- Display-priority order (load-bearing): **DRC > LVS > unverified > status**. DRC always wins so a board with both a DRC violation and an LVS mismatch surfaces the DRC chip first (DRC is the fabrication blocker).
- Two new chip CSS classes: `.chip-lvs` (warm orange — distinct from amber `chip-partial` and red `chip-drc`) and `.chip-unverified` (neutral gray).

**Docs** — `docs/board-json-schema.md`
- Documents `lvs_clean?: boolean` and `lvs_mismatches?: number` plus the asymmetric status-gate semantics.

**Tests**
- `tests/test_board_metrics.py`: 4 new cases for present-clean, present-dirty (asserts status downgrade), absent (asserts both fields omitted AND status stays `ok`), and malformed-JSON resilience.
- `site/src/data/boardStatus.test.ts`: 5 new cases including the explicit regression case (no `lvs_clean` field → never "Ready") and DRC > LVS priority.

## Test plan

- [x] `uv run pytest tests/test_board_metrics.py -v` — 24 passed including 4 new LVS cases
- [x] `cd site && npm test` — 28 passed including 5 new LVS cases
- [x] `cd site && npm run check` — 0 errors, 0 warnings (pre-existing hints only)
- [x] `uv run ruff format` + `uv run ruff check` — clean
- [x] Regenerated `boards/00-simple-led/output/board.json` shows `"lvs_clean": true, "lvs_mismatches": 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)