### PR TITLE
feat(ci): add board 00 end-to-end regeneration gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -828,3 +828,160 @@ jobs:
             "${{ matrix.board }}" \
             --seed 42
 
+  board-00-end-to-end:
+    # Issue #3751: regenerate board 00 ("simple-led", the canonical
+    # "Hello World" fixture) from its recipe (boards/00-simple-led/
+    # generate_design.py) on every PR and assert that the resulting
+    # artifacts cross the manufacturability bar.  This is the PR-time
+    # complement to ``tests/test_board_00_simple_led.py::TestBoard00SimpleLed``
+    # (which is @pytest.mark.slow and only runs nightly via
+    # ``slow-tests.yml``) and the recipe-side regression gate that
+    # ``routed-pcb-drc-check`` cannot provide -- the diff-driven DRC
+    # gate only fires when a PR touches the committed *_routed.kicad_pcb,
+    # so a recipe bug that produces a wrong-but-still-DRC-clean PCB (the
+    # exact failure mode of #3747's D1 polarity bug) goes undetected.
+    #
+    # What the gate does:
+    #   1. Re-run ``generate_design.py`` against a clean tmp directory.
+    #   2. Run ``kct check`` on the routed PCB; require ``Overall: PASSED``
+    #      (DRC + ERC + LVS + Manifest sub-checks all PASSED -- the meta
+    #      contract from #3750).
+    #   3. Re-emit board.json via ``kct board-metrics`` against the regen
+    #      output and assert ``status: ok``, ``drc_violations: 0``,
+    #      ``lvs_clean: true`` -- the public contract the demo gallery
+    #      (#3749) consumes.
+    #
+    # The gate intentionally does NOT diff the regenerated artifacts
+    # against the committed ``output/`` tree (the original AC's step 7):
+    # copper UUIDs, segment ordering, and generator timestamps are
+    # nondeterministic, so a naive byte-diff would false-positive on
+    # every PR.  Netlist equivalence is already covered by LVS; component
+    # placement and routing topology need a semantic comparator that is
+    # out of scope for this issue.
+    #
+    # Runner setup mirrors the ``test`` job: official kicad/kicad:10.0
+    # container so kicad-cli is present (the recipe's ``run_erc()`` and
+    # the meta ``ERC`` sub-check both shell out to kicad-cli; on a bare
+    # ubuntu-latest runner the ERC step is silently skipped and the gate
+    # defeats itself).  The C++ backend build is required per CLAUDE.md
+    # ("Routing performance: build the C++ backend first") -- without it
+    # the router falls back to pure Python (10-100x slower) and risks
+    # missing the 15-minute ceiling.
+    #
+    # IMPORTANT (branch-protection note): adding this job to the list of
+    # *required* status checks on ``main`` is a separate repo-admin
+    # action.  The PR landing this job calls that out explicitly so the
+    # human approver can flip the GitHub setting after merge.  Until then
+    # the job runs on every PR but is advisory -- its failure does not
+    # block the merge button.  Same pattern as
+    # ``diffpair-routing-regression`` and ``matchgroup-routing-regression``.
+    name: Board 00 End-to-End
+    runs-on: ubuntu-latest
+    # The recipe is ~30 seconds locally (1 signal net + 2 pour nets),
+    # the C++ backend build is ~2 min, ``kct export`` + ``kct check`` +
+    # ``kct board-metrics`` add ~30s total, and the gate-side asserter
+    # is sub-second.  15 min leaves >2x headroom on a slow 2-core
+    # ubuntu runner without masking a hang.
+    timeout-minutes: 15
+    container:
+      image: kicad/kicad:10.0
+      # Run as root so installs write system locations and actions/checkout
+      # can write $GITHUB_WORKSPACE (mirrors the test + smoke jobs).
+      options: --user 0:0
+    defaults:
+      run:
+        # The image's /bin/sh is dash; force bash (mirrors the test job).
+        shell: bash
+    steps:
+      - name: Ensure container has prerequisites
+        # ca-certificates/curl/git for checkout + uv bootstrap; cmake and
+        # build-essential for the C++ router backend build below.  The
+        # ``kicad-cli --version`` probe makes a missing/broken kicad-cli
+        # fail THIS step with an attributable error instead of surfacing
+        # later as a silently-skipped ERC sub-check.
+        run: |
+          set -euo pipefail
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates curl git cmake build-essential
+          kicad-cli --version
+
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        # Official one-liner instead of setup-uv@v4: avoids action-host
+        # coupling inside the container (mirrors the test + smoke jobs).
+        run: |
+          set -euo pipefail
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install dependencies
+        # Pin the interpreter via uv (parity with the sibling jobs that
+        # use actions/setup-python with python-version: "3.12"); the
+        # container image's own Python version is irrelevant.  ``--extra
+        # dev`` is required because ``kct check`` imports ``shapely`` for
+        # the geometry-based DRC rules (see the [project.optional-dependencies]
+        # dev block in pyproject.toml for the ``shapely>=2.0`` pin).
+        run: uv sync --extra dev --python 3.12
+
+      - name: Build C++ router backend
+        # ``uv sync`` does NOT build the native extension (see repo
+        # CLAUDE.md "Routing performance: build the C++ backend first").
+        # Without this step the recipe's routing step falls back to pure
+        # Python which is 10-100x slower.
+        run: uv run kct build-native
+
+      - name: Regenerate board 00 from recipe (clean tmp directory)
+        # The recipe's main() accepts an optional output directory as
+        # argv[1] (boards/00-simple-led/generate_design.py:944-947); we
+        # point it at a tmp directory so the gate never touches the
+        # committed boards/00-simple-led/output/ tree.  Exits non-zero
+        # if any of ERC/DRC/LVS/MFG fail OR run_lvs() raises
+        # BoardNetlistMismatch -- the polarity-class regression the gate
+        # is designed to catch.
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/board00-ci
+          mkdir -p /tmp/board00-ci
+          uv run python boards/00-simple-led/generate_design.py /tmp/board00-ci
+
+      - name: Assert kct check Overall PASSED on regenerated routed PCB
+        # The meta sub-check pattern from #3750: DRC + ERC + LVS +
+        # Manifest must ALL be PASSED for ``Overall: PASSED`` and exit
+        # 0.  No ``--allow-incomplete`` -- the recipe just wrote
+        # manufacturing/manifest.json, so Manifest is fresh.  ``tee``
+        # surfaces the full output in the log AND lets the grep gate
+        # the build on the exact "Overall: PASSED" line (defence in
+        # depth against future verdict-string renames).
+        run: |
+          set -euo pipefail
+          uv run kct check /tmp/board00-ci/simple_led_routed.kicad_pcb \
+            | tee /tmp/board00-ci/check.out
+          grep -qE '^Overall:[[:space:]]+PASSED' /tmp/board00-ci/check.out
+
+      - name: Emit board.json via kct board-metrics
+        # board.json is NOT written by the recipe -- it's the public
+        # data contract emitted by the ``kct board-metrics`` aggregator
+        # (src/kicad_tools/cli/board_metrics_cmd.py) that the demo
+        # gallery (#3749) consumes.  The command expects a board-layout
+        # directory in the standard ``<board_dir>/output/`` shape, so
+        # we mirror the tmp regen into that shape and point the command
+        # at it.  This validates the same contract a downstream demo-
+        # site build would.
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/board00-staging
+          mkdir -p /tmp/board00-staging/00-simple-led/output
+          cp -r /tmp/board00-ci/. /tmp/board00-staging/00-simple-led/output/
+          uv run kct board-metrics /tmp/board00-staging/00-simple-led
+
+      - name: Assert artifacts + lvs.json + board.json fields
+        # The gate-side asserter: presence of every required artifact,
+        # lvs.json clean=true, and board.json status=ok / drc_violations=0
+        # / lvs_clean=true.  Sibling of scripts/ci/check_routed_drc.py;
+        # see its docstring for the GitHub-Actions annotation contract.
+        run: |
+          set -euo pipefail
+          uv run python scripts/ci/check_board_00_e2e.py \
+            /tmp/board00-staging/00-simple-led

--- a/scripts/ci/check_board_00_e2e.py
+++ b/scripts/ci/check_board_00_e2e.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Board 00 end-to-end CI gate (issue #3751).
+
+Asserts post-recipe artifact correctness for ``boards/00-simple-led/`` after
+the CI workflow has:
+
+1. Run ``boards/00-simple-led/generate_design.py <output_dir>`` against a
+   clean output directory.
+2. Run ``kct check <routed.kicad_pcb>`` and verified ``Overall: PASSED``.
+3. Re-emitted ``board.json`` via ``kct board-metrics <board_dir>`` against
+   that output directory in its expected ``<board_dir>/output/`` shape.
+
+This script is the *parser/asserter* side of the gate.  Given the staging
+board directory it:
+
+- asserts every expected artifact exists (sch, pcb, routed pcb, lvs.json,
+  manufacturing/manifest.json);
+- asserts ``output/lvs.json`` has ``clean: true``;
+- asserts ``output/board.json`` reports ``status: ok``, ``drc_violations: 0``,
+  ``lvs_clean: true``;
+
+and exits non-zero with a ``::error::``-annotated message on any mismatch
+so the failure surfaces inline on the GitHub PR Files-changed view.
+
+Sibling of ``scripts/ci/check_routed_drc.py`` -- same exit-code convention,
+same annotation pattern, deliberately small so the gate's contract stays
+auditable.
+
+Why this lives in a script (vs. inline ``run:`` blocks in ci.yml):
+
+- Each assertion gets a stable, attributable ``::error::`` annotation
+  including the file path and the failing field.  Inline shell+python
+  heredocs in ci.yml lose that affordance (no file: target) and are harder
+  to unit-test.
+- The script is invokable locally (``uv run python scripts/ci/check_board_00_e2e.py
+  /tmp/board00-staging/00-simple-led``) so contributors can reproduce the CI
+  gate exactly without pushing.
+
+Exit codes:
+    0 -- All assertions passed.
+    1 -- Tool/usage error (missing arg, board_dir doesn't exist, JSON parse
+         failure, etc.) -- distinct from "the gate caught a real regression".
+    2 -- One or more assertions failed (the gate caught a regression).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Artifacts required to exist under ``<board_dir>/output/``.  Paths are
+# slash-joined relative to the output directory.
+REQUIRED_ARTIFACTS: tuple[str, ...] = (
+    "simple_led.kicad_sch",
+    "simple_led.kicad_pcb",
+    "simple_led_routed.kicad_pcb",
+    "lvs.json",
+    "manufacturing/manifest.json",
+    "board.json",
+)
+
+# board.json fields that must match these exact values for the gate to
+# pass.  The values are deliberately hardcoded (not loaded from the file's
+# own contents) so a regression that silently switches ``status`` from
+# ``"ok"`` to ``"partial"`` is caught here.
+REQUIRED_BOARD_JSON_FIELDS: dict[str, Any] = {
+    "status": "ok",
+    "drc_violations": 0,
+    "lvs_clean": True,
+}
+
+
+def _err(msg: str, file: str | Path | None = None) -> None:
+    """Emit a GitHub Actions ``::error::`` annotation to stdout.
+
+    The ``file=`` parameter surfaces the failure inline on the PR
+    Files-changed view when the path is tracked by git; for tmp paths
+    (the staging directory under ``/tmp/``) the annotation still shows
+    in the job log with the field name surfaced for triage.
+    """
+    if file is not None:
+        print(f"::error file={file}::{msg}")
+    else:
+        print(f"::error::{msg}")
+
+
+def assert_artifacts_exist(output_dir: Path) -> list[str]:
+    """Assert every member of REQUIRED_ARTIFACTS exists under ``output_dir``.
+
+    Returns the list of *missing* relative paths (empty list = all present).
+    """
+    missing: list[str] = []
+    for rel in REQUIRED_ARTIFACTS:
+        if not (output_dir / rel).is_file():
+            missing.append(rel)
+    return missing
+
+
+def assert_lvs_clean(lvs_path: Path) -> str | None:
+    """Assert ``lvs.json`` reports ``clean: true``.
+
+    Returns ``None`` on pass, or a human-readable error message on fail.
+    """
+    try:
+        data = json.loads(lvs_path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        return f"could not read/parse {lvs_path}: {e}"
+    if not data.get("clean"):
+        mismatches = data.get("mismatches", [])
+        return (
+            f"lvs.json reports clean=False with {len(mismatches)} mismatch(es); "
+            f"first: {mismatches[0] if mismatches else '<none>'}"
+        )
+    return None
+
+
+def assert_board_json_fields(board_json_path: Path) -> list[str]:
+    """Assert ``board.json`` has the required field values.
+
+    Returns the list of error messages (empty list = all OK).
+    """
+    errors: list[str] = []
+    try:
+        data = json.loads(board_json_path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        return [f"could not read/parse {board_json_path}: {e}"]
+    for key, want in REQUIRED_BOARD_JSON_FIELDS.items():
+        got = data.get(key)
+        if got != want:
+            errors.append(f"board.json[{key!r}]={got!r}, expected {want!r}")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="check_board_00_e2e.py",
+        description=(
+            "Assert post-recipe artifact correctness for board 00. "
+            "Pass the board-layout directory (the one containing output/)."
+        ),
+    )
+    parser.add_argument(
+        "board_dir",
+        type=Path,
+        help=(
+            "Board-layout directory (must contain output/). "
+            "Example: /tmp/board00-staging/00-simple-led"
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    board_dir: Path = args.board_dir
+    if not board_dir.is_dir():
+        _err(f"board_dir does not exist or is not a directory: {board_dir}")
+        return 1
+
+    output_dir = board_dir / "output"
+    if not output_dir.is_dir():
+        _err(f"output dir does not exist: {output_dir}")
+        return 1
+
+    failed = False
+
+    # 1. Artifact presence ----------------------------------------------------
+    missing = assert_artifacts_exist(output_dir)
+    if missing:
+        for rel in missing:
+            _err(f"missing required artifact: {rel}", file=output_dir / rel)
+        failed = True
+    else:
+        print(f"[ok] all {len(REQUIRED_ARTIFACTS)} required artifacts present")
+
+    # 2. LVS clean ------------------------------------------------------------
+    lvs_path = output_dir / "lvs.json"
+    if lvs_path.is_file():
+        lvs_err = assert_lvs_clean(lvs_path)
+        if lvs_err is not None:
+            _err(lvs_err, file=lvs_path)
+            failed = True
+        else:
+            print("[ok] lvs.json clean")
+    # (missing lvs.json was already reported above)
+
+    # 3. board.json fields ----------------------------------------------------
+    board_json_path = output_dir / "board.json"
+    if board_json_path.is_file():
+        field_errors = assert_board_json_fields(board_json_path)
+        if field_errors:
+            for msg in field_errors:
+                _err(msg, file=board_json_path)
+            failed = True
+        else:
+            print(
+                "[ok] board.json fields: "
+                + ", ".join(f"{k}={v!r}" for k, v in REQUIRED_BOARD_JSON_FIELDS.items())
+            )
+
+    return 2 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a new PR-time CI job (`Board 00 End-to-End`) to `.github/workflows/ci.yml` that regenerates board 00 from `boards/00-simple-led/generate_design.py` on every PR and asserts full end-to-end manufacturability. This closes the gate gap that let the #3747 D1 polarity bug sit latent on `main`.

This is the missing PR-time complement to the nightly `tests/test_board_00_simple_led.py::TestBoard00SimpleLed` (`@pytest.mark.slow`) and the diff-driven `routed-pcb-drc-check` job (which can't fire on a recipe bug that produces a wrong-but-still-DRC-clean PCB).

## Changes

- **`.github/workflows/ci.yml`** -- new `board-00-end-to-end` job (after `matchgroup-routing-regression`). Mirrors the `test` job's `kicad/kicad:10.0` + uv + C++ backend pattern. Job steps:
  1. Regenerate board 00 from the recipe into `/tmp/board00-ci/`.
  2. Assert every required artifact (`*.kicad_sch`, `*.kicad_pcb`, `*_routed.kicad_pcb`, `lvs.json`, `manufacturing/manifest.json`) exists (via the sidecar script).
  3. Run `kct check <routed.kicad_pcb>` and require `Overall: PASSED` (DRC + ERC + LVS + Manifest meta sub-checks all PASSED -- the meta contract from #3750).
  4. Re-emit `board.json` via `kct board-metrics` against the regen output mirrored into `<board_dir>/output/` shape.
  5. Run `scripts/ci/check_board_00_e2e.py` to assert artifact presence, `lvs.json` clean, and `board.json` `status: ok` / `drc_violations: 0` / `lvs_clean: true`.
- **`scripts/ci/check_board_00_e2e.py`** -- new sidecar gate-side asserter (mirrors the `scripts/ci/check_routed_drc.py` pattern: emits GitHub-Actions `::error::` annotations, distinct exit codes for tool error vs. caught regression).
- **No `pyproject.toml` changes** -- no new dependencies introduced.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| On a fresh PR that introduces a polarity bug in board 00's recipe, CI fails | Verified | Negative-control test: temporarily swapped the D1 wire endpoints in `create_led_schematic` back to the pre-#3752 form, ran the recipe locally. Result: `kct check` reports `LVS: FAILED (2 mismatch(es): D1.1 sch='LED_ANODE' pcb='GND', D1.2 sch='GND' pcb='LED_ANODE')` -> `Overall: FAILED`; recipe `run_lvs()` raises `BoardNetlistMismatch` -> exit 1 -> the workflow's `Regenerate board 00` step fails under `set -euo pipefail`. Reverted before commit. |
| On a clean PR, CI runs in under ~3 minutes | Partially -- 15 min ceiling | Local end-to-end (recipe + check + board-metrics + asserter) is ~30s on an M-series; the CI 15-minute ceiling has wide headroom given the ~2-min C++ build dominates. The original AC's "<3 min" target is aspirational with the C++ rebuild; without backend cache it's structurally bounded by the build step. Acceptable per the curator's wall-clock budget. |
| The job is wired into required-status-checks for `main` | Deferred (operator action) | Branch-protection updates require repo-admin permissions and cannot be done via PR. Same advisory-then-required pattern as `diffpair-routing-regression` and `matchgroup-routing-regression`. Called out in the workflow comment and below. |
| Artifacts (sch, pcb, routed, lvs.json, manifest.json) asserted to exist | Verified | `scripts/ci/check_board_00_e2e.py` `REQUIRED_ARTIFACTS` enumerates each; manual run against the staging dir reports `[ok] all 6 required artifacts present`. |
| `lvs.json` clean=true assertion | Verified | Manual run reports `[ok] lvs.json clean`. Tested negative case (deleted `lvs.json`): script emits `::error file=...::missing required artifact: lvs.json`, exit 2. |
| `board.json` status=ok / drc_violations=0 / lvs_clean=true | Verified | Manual run reports `[ok] board.json fields: status='ok', drc_violations=0, lvs_clean=True`. Tested negative case (mutated `status` and `drc_violations`): script emits two `::error::` annotations, exit 2. |
| Step 7 (diff against committed `output/`) | Deferred | Copper UUIDs/timestamps are nondeterministic; naive byte-diff would false-positive on every PR. Netlist equivalence is already covered by LVS. Documented in the workflow comment + the curator's plan. |

## Test Plan

- [x] Locally run `uv run python boards/00-simple-led/generate_design.py /tmp/test` followed by `uv run kct check /tmp/test/simple_led_routed.kicad_pcb` -- `Overall: PASSED` (DRC + ERC + LVS + Manifest all PASSED).
- [x] Locally run the full workflow recipe end-to-end (recipe -> check -> staging mirror -> board-metrics -> asserter) -- all four stages green.
- [x] Negative-control: re-introduce #3747 polarity bug, verify the gate trips at the recipe-regenerate step (`run_lvs()` raises -> exit 1 under `set -euo pipefail`). Reverted before commit.
- [x] Negative-control: remove `lvs.json` from staging dir, verify the asserter emits `::error::` and exits 2.
- [x] Negative-control: mutate `board.json` fields (`status='partial'`, `drc_violations=5`), verify the asserter emits per-field `::error::` annotations and exits 2.
- [x] `uv run ruff check scripts/ci/check_board_00_e2e.py` -- clean.
- [x] `uv run ruff format scripts/ci/check_board_00_e2e.py --check` -- clean.
- [x] `uv run mypy scripts/ci/check_board_00_e2e.py --ignore-missing-imports` -- clean.
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` -- parses.
- [ ] **Required (CI-side)**: the `Board 00 End-to-End` job runs and passes on this PR (`main` is post-#3752 so the recipe is polarity-correct and the gate should land green).

## Operator Follow-Up (after merge)

Add `Board 00 End-to-End` to the required-status-checks list on `main` (Settings -> Rules -> Rulesets -> the `main` ruleset). This is a repo-admin action; cannot be done via PR. Until then the job runs on every PR but is advisory (its failure does not block the merge button). Same pattern as `diffpair-routing-regression` and `matchgroup-routing-regression`.

Closes #3751