### PR TITLE
feat(lvs): add independent copper-extracted netlist gate

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -257,7 +257,17 @@ def _erc_subcheck(sch_path: Path | None, strict: bool) -> SubCheckResult:
 
 
 def _lvs_subcheck(sch_path: Path | None, pcb_path: Path) -> SubCheckResult:
-    """Run live LVS via :func:`compare_netlists` (issue #3750).
+    """Run live LVS (issue #3750, extended for independent copper LVS #3742).
+
+    Runs *two* complementary comparisons and fails if **either** dirties:
+
+    * **label-based** (:func:`board_lvs.compare_netlists`) — trusts each
+      pad's declared ``(net ...)`` label; catches generator/router
+      bookkeeping drift.
+    * **copper-extracted** (:func:`copper_lvs.compare_copper_netlist`) —
+      ignores pad labels entirely and diffs the *physical* copper partition
+      against the schematic; catches shorts/opens a mislabeled router would
+      hide from the label-based path (the board-00 soundness gap, #3742).
 
     Always recomputes -- never reads ``output/lvs.json`` -- so a fresh
     PCB edit that breaks LVS is surfaced immediately.  Returns
@@ -279,10 +289,33 @@ def _lvs_subcheck(sch_path: Path | None, pcb_path: Path) -> SubCheckResult:
             detail=f"LVS comparator raised {type(e).__name__}: {e}",
         )
 
+    try:
+        from kicad_tools.lvs.copper_lvs import compare_copper_netlist
+
+        copper = compare_copper_netlist(sch_path, pcb_path)
+    except Exception as e:
+        return SubCheckResult(
+            status="FAILED",
+            detail=f"copper LVS comparator raised {type(e).__name__}: {e}",
+        )
+
+    if not copper.clean:
+        # The copper-extracted gate is the soundness-critical one: surface
+        # it first.  Show up to the first 3 records in a stable order.
+        records = sorted(copper.mismatches, key=lambda m: (m.kind, m.pad_a, m.pad_b))
+        preview = ", ".join(
+            f"{m.kind} {m.pad_a}({m.net_a})/{m.pad_b}({m.net_b})" for m in records[:3]
+        )
+        suffix = "" if len(records) <= 3 else f" (+{len(records) - 3} more)"
+        return SubCheckResult(
+            status="FAILED",
+            detail=f"copper: {len(records)} mismatch(es): {preview}{suffix}",
+        )
+
     if result.clean:
         return SubCheckResult(
             status="PASSED",
-            detail=f"{len(result.mismatches)} mismatch(es)",
+            detail="label + copper: 0 mismatch(es)",
         )
 
     # Show up to the first 3 mismatches in stable (ref, pad) order so
@@ -294,7 +327,7 @@ def _lvs_subcheck(sch_path: Path | None, pcb_path: Path) -> SubCheckResult:
     suffix = "" if len(mismatches) <= 3 else f" (+{len(mismatches) - 3} more)"
     return SubCheckResult(
         status="FAILED",
-        detail=f"{len(mismatches)} mismatch(es): {preview}{suffix}",
+        detail=f"label: {len(mismatches)} mismatch(es): {preview}{suffix}",
     )
 
 

--- a/src/kicad_tools/lvs/__init__.py
+++ b/src/kicad_tools/lvs/__init__.py
@@ -6,9 +6,23 @@ Compares the schematic netlist (the design intent) against the routed PCB
 Currently single-board scope (board 00); see issue #3742 for the
 generalized fleet-wide LVS rollout.
 
+Two complementary comparators live here:
+
+* **label-based** (:func:`compare_netlists`) trusts each pad's declared
+  ``(net ...)`` label.
+* **copper-extracted** (:func:`compare_copper_netlist`, issue #3742)
+  ignores pad labels and diffs the *physical* copper partition against the
+  schematic, catching shorts/opens a mislabeled router would hide.
+
 Public API:
 
 * :func:`compare_netlists` — pure comparator returning :class:`LVSResult`.
+* :func:`compare_copper_netlist` — independent copper-extracted comparator
+                              returning :class:`CopperLVSResult`.
+* :func:`compare_partitions` — pure partition diff (IO-free core of the
+                              copper-extracted comparator).
+* :class:`CopperLVSResult` / :class:`CopperLVSMismatch` — copper-LVS
+                              result + per-short/open record.
 * :class:`LVSResult`        — frozen dataclass with ``clean`` flag and
                               tuple of :class:`LVSMismatch` entries.
 * :class:`LVSMismatch`      — frozen dataclass naming the offending
@@ -31,11 +45,21 @@ from kicad_tools.lvs.board_lvs import (
     _ref_of,
     compare_netlists,
 )
+from kicad_tools.lvs.copper_lvs import (
+    CopperLVSMismatch,
+    CopperLVSResult,
+    compare_copper_netlist,
+    compare_partitions,
+)
 
 __all__ = [
     "BoardNetlistMismatch",
+    "CopperLVSMismatch",
+    "CopperLVSResult",
     "LVSMismatch",
     "LVSResult",
     "_ref_of",
+    "compare_copper_netlist",
     "compare_netlists",
+    "compare_partitions",
 ]

--- a/src/kicad_tools/lvs/copper_lvs.py
+++ b/src/kicad_tools/lvs/copper_lvs.py
@@ -1,0 +1,210 @@
+"""Independent copper-extracted LVS (issue #3742).
+
+This is the "third leg" of board soundness the external reviewer asked
+for: a netlist-correspondence gate that is independent of the router's
+pad-net labels.  Where :mod:`kicad_tools.lvs.board_lvs` trusts each
+pad's declared ``(net K "NAME")`` child (and so passes a board whose
+router mislabels its own copper), this comparator extracts the
+*physical* pad partition straight from routed copper — via
+:meth:`ConnectivityValidator.extract_pad_partition`, which never reads a
+net label — and diffs that against the schematic partition.
+
+Two failure classes are reported:
+
+* **short** — two pads on *different* schematic nets land in the *same*
+  copper component (copper fuses nets that should be isolated).  This is
+  the board-00 failure mode: ``GND`` shorted to ``LED_ANODE`` because the
+  router wired copper to the wrong pad, even though the pad labels still
+  read correctly.
+* **open** — two pads on the *same* schematic net land in *different*
+  copper components (the net is not fully connected by copper).
+
+The comparator is pure: it returns data, never raises for a mismatch.
+Pads present on only one side (schematic-only or PCB-only) are ignored
+for the partition diff — that asymmetry is the label-based comparator's
+job (:func:`board_lvs.compare_netlists`), and the two checks are meant
+to run side by side.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from kicad_tools.lvs.board_lvs import _schematic_pin_to_net
+
+
+@dataclass(frozen=True)
+class CopperLVSMismatch:
+    """A single copper-vs-schematic partition disagreement.
+
+    Attributes:
+        kind: ``"short"`` (different schematic nets fused in copper) or
+            ``"open"`` (same schematic net split across copper islands).
+        net_a / net_b: The schematic net names involved.  For a short
+            these differ; for an open they are equal.
+        pad_a / pad_b: The two offending pads (``"REF.PAD"`` form) that
+            witness the mismatch.
+    """
+
+    kind: str
+    net_a: str
+    net_b: str
+    pad_a: str
+    pad_b: str
+
+
+@dataclass(frozen=True)
+class CopperLVSResult:
+    """Outcome of comparing routed copper against the schematic netlist.
+
+    ``clean`` is ``True`` iff ``mismatches`` is empty.  ``shorts`` and
+    ``opens`` partition the mismatches by kind for convenient reporting.
+    """
+
+    clean: bool
+    mismatches: tuple[CopperLVSMismatch, ...]
+
+    @property
+    def shorts(self) -> tuple[CopperLVSMismatch, ...]:
+        return tuple(m for m in self.mismatches if m.kind == "short")
+
+    @property
+    def opens(self) -> tuple[CopperLVSMismatch, ...]:
+        return tuple(m for m in self.mismatches if m.kind == "open")
+
+
+def compare_partitions(
+    schematic_net_of_pad: dict[tuple[str, str], str | None],
+    copper_partition: list[frozenset[str]],
+) -> CopperLVSResult:
+    """Diff a physical copper partition against a schematic netlist.
+
+    This is the pure core, decoupled from any file IO so it can be unit
+    tested with hand-built inputs.
+
+    Args:
+        schematic_net_of_pad: ``{(ref, pad) -> net_name | None}`` as built
+            by :func:`board_lvs._schematic_pin_to_net`.  ``None`` means the
+            pin is floating in the schematic and is excluded from the diff.
+        copper_partition: list of ``frozenset`` pad-id groups (``"REF.PAD"``
+            form) from :meth:`ConnectivityValidator.extract_pad_partition`.
+
+    Returns:
+        :class:`CopperLVSResult`.  A short is reported once per offending
+        net pair (the lexicographically smallest pad witnesses are used);
+        an open is reported once per pair of same-net copper islands.
+    """
+    # Build {pad_id -> schematic_net} restricted to pads that (a) have a
+    # real schematic net and (b) actually appear on the board, so the diff
+    # only considers pads both sides agree exist.  Pads only on one side are
+    # the label-based comparator's concern.
+    on_board: set[str] = set()
+    for comp in copper_partition:
+        on_board |= comp
+
+    pad_net: dict[str, str] = {}
+    for (ref, pad), net in schematic_net_of_pad.items():
+        if net is None:
+            continue
+        pad_id = f"{ref}.{pad}"
+        if pad_id in on_board:
+            pad_net[pad_id] = net
+
+    # Map each pad to its copper-component index.
+    comp_of_pad: dict[str, int] = {}
+    for idx, comp in enumerate(copper_partition):
+        for pad_id in comp:
+            comp_of_pad[pad_id] = idx
+
+    mismatches: list[CopperLVSMismatch] = []
+
+    # --- Shorts: within each copper component, every distinct schematic
+    #     net present is a short against every other distinct net there. ---
+    seen_short_pairs: set[tuple[str, str]] = set()
+    for comp in copper_partition:
+        # Net name -> representative (smallest) pad id in this component.
+        net_rep: dict[str, str] = {}
+        for pad_id in sorted(comp):
+            net = pad_net.get(pad_id)
+            if net is None:
+                continue
+            net_rep.setdefault(net, pad_id)
+        nets_here = sorted(net_rep)
+        for i, na in enumerate(nets_here):
+            for nb in nets_here[i + 1 :]:
+                key = (na, nb)
+                if key in seen_short_pairs:
+                    continue
+                seen_short_pairs.add(key)
+                mismatches.append(
+                    CopperLVSMismatch(
+                        kind="short",
+                        net_a=na,
+                        net_b=nb,
+                        pad_a=net_rep[na],
+                        pad_b=net_rep[nb],
+                    )
+                )
+
+    # --- Opens: for each schematic net, the pads carrying it must all live
+    #     in one copper component.  If they span multiple components the net
+    #     is not fully routed (open). ---
+    net_to_pads: dict[str, list[str]] = {}
+    for pad_id, net in pad_net.items():
+        net_to_pads.setdefault(net, []).append(pad_id)
+
+    for net, pads in sorted(net_to_pads.items()):
+        if len(pads) < 2:
+            continue
+        # Group these pads by copper component.
+        comps: dict[int, list[str]] = {}
+        for pad_id in sorted(pads):
+            comps.setdefault(comp_of_pad[pad_id], []).append(pad_id)
+        if len(comps) <= 1:
+            continue
+        # Report one open per pair of distinct islands, using the smallest
+        # pad in each island as the witness.
+        island_reps = [sorted(members)[0] for members in comps.values()]
+        island_reps.sort()
+        for i in range(len(island_reps) - 1):
+            mismatches.append(
+                CopperLVSMismatch(
+                    kind="open",
+                    net_a=net,
+                    net_b=net,
+                    pad_a=island_reps[i],
+                    pad_b=island_reps[i + 1],
+                )
+            )
+
+    return CopperLVSResult(clean=not mismatches, mismatches=tuple(mismatches))
+
+
+def compare_copper_netlist(sch_path: str | Path, pcb_path: str | Path) -> CopperLVSResult:
+    """Compare a routed PCB's *copper* against the schematic netlist.
+
+    Loads the schematic partition (label-bound nets, PWR_FLAG-safe) via
+    :func:`board_lvs._schematic_pin_to_net`, extracts the physical copper
+    partition from the PCB via
+    :meth:`ConnectivityValidator.extract_pad_partition`, then diffs them
+    with :func:`compare_partitions`.
+
+    Args:
+        sch_path: Path to a ``.kicad_sch`` (root sheet for hierarchy).
+        pcb_path: Path to a routed ``.kicad_pcb``.
+
+    Returns:
+        :class:`CopperLVSResult`.  Always returned — mismatches are data,
+        not exceptions.
+    """
+    # Import lazily: ConnectivityValidator pulls in the PCB schema stack and
+    # we want ``import kicad_tools.lvs`` to stay cheap.
+    from kicad_tools.validate.connectivity import ConnectivityValidator
+
+    sch_path = Path(sch_path)
+    pcb_path = Path(pcb_path)
+
+    schematic_net_of_pad = _schematic_pin_to_net(sch_path)
+    copper_partition = ConnectivityValidator(pcb_path).extract_pad_partition()
+    return compare_partitions(schematic_net_of_pad, copper_partition)

--- a/src/kicad_tools/validate/connectivity.py
+++ b/src/kicad_tools/validate/connectivity.py
@@ -308,6 +308,197 @@ class ConnectivityValidator:
         result.zone_connected_nets = zone_connected_count
         return result
 
+    def extract_pad_partition(self) -> list[frozenset[str]]:
+        """Extract the *physical* pad partition from routed copper.
+
+        This is the independent-LVS primitive (issue #3742): it floods the
+        routed copper graph and returns the set of galvanically connected
+        pad groups.
+
+        **Autorouter copper (track segments + vias) is traced with zero
+        reference to pad net labels** — two pads land in the same group iff
+        physical copper connects them, regardless of what net the router
+        *claims*.  This is the load-bearing soundness property: it catches a
+        router that wires segments to the wrong pads while labeling them
+        correctly (the board-00 rotation-convention bug, #3739).
+
+        Zone pours are handled with a deliberately narrower, documented
+        model (see the ``2d`` block below): because robust label-free
+        extraction of which pads a pour is *thermally tied* to is a known
+        follow-up, the pour leg groups pads by the zone's declared net.
+        That re-introduces a label dependency for the FILL step alone — never
+        for autorouter copper — and can never fuse two different nets, so it
+        cannot manufacture a false short.
+
+        Why this matters: the label-based comparator
+        (:func:`kicad_tools.lvs.board_lvs.compare_netlists`) trusts the
+        ``(net K "NAME")`` child the router writes onto each pad, so a router
+        that mislabels its own copper passes.  This extractor never reads a
+        net label — it derives connectivity purely from copper geometry — so
+        the partition it returns reflects what manufacturing will actually
+        see.  Diffing it against the schematic partition catches shorts
+        (different schematic nets fused by copper) and opens (same schematic
+        net split across copper islands) that the label-based path cannot.
+
+        Note on coordinate convention: pad geometry still flows through
+        :meth:`_transform_pad_position` / ``rotate_pad_offset``.  The gate's
+        *correctness claim* does not rest on that transform being right —
+        that is what the 90°/270° decoupling test asserts independently
+        against kicad-cli (or a committed golden).  What this method
+        guarantees is that the partition ignores *labels*, which is the
+        load-bearing soundness property.
+
+        Returns:
+            A list of ``frozenset`` pad-id groups (``"REF.PAD"`` form, e.g.
+            ``"U1.3"``).  Every footprint pad with a numeric pad number and a
+            non-comment reference appears in exactly one group.  A pad with
+            no copper touching it forms a singleton group.  Groups are
+            returned sorted by their smallest member for determinism.
+        """
+        # 1. Collect every pad on the board (label-independent) with its
+        #    board-frame position and layer set.
+        pad_positions: dict[str, tuple[float, float]] = {}
+        pad_layers: dict[str, list[str]] = {}
+        for fp in self.pcb.footprints:
+            if not fp.reference or fp.reference.startswith("#"):
+                continue
+            fp_x, fp_y = fp.position
+            rotation = fp.rotation
+            for pad in fp.pads:
+                if pad.number is None or pad.number == "":
+                    continue
+                pad_id = f"{fp.reference}.{pad.number}"
+                pad_positions[pad_id] = self._transform_pad_position(
+                    pad.position, fp_x, fp_y, rotation
+                )
+                pad_layers[pad_id] = pad.layers
+
+        # 2. Build a copper adjacency graph over pads, ignoring net labels.
+        #    Every pad starts as its own node; copper fuses them.
+        graph: dict[str, set[str]] = {pad_id: set() for pad_id in pad_positions}
+
+        def _connect(a: str, b: str) -> None:
+            if a != b:
+                graph[a].add(b)
+                graph[b].add(a)
+
+        # 2a. Track segments: union the pads at each endpoint, and union
+        #     pads sharing an endpoint.  Crucially we walk *all* segments
+        #     (``self.pcb.segments``), not segments filtered by a net number,
+        #     so a mislabeled segment still physically connects whatever it
+        #     touches.
+        segments = list(self.pcb.segments)
+        for seg in segments:
+            start_pads = self._find_pads_at_point(seg.start, pad_positions)
+            end_pads = self._find_pads_at_point(seg.end, pad_positions)
+            for sp in start_pads:
+                for ep in end_pads:
+                    _connect(sp, ep)
+            for group in (start_pads, end_pads):
+                for i, p in enumerate(group):
+                    for other in group[i + 1 :]:
+                        _connect(p, other)
+
+        # 2b. Segment chains: pads connected through a chain of segments that
+        #     share endpoints are galvanically connected even with no pad at
+        #     the intermediate junctions.  Reuse the existing chain builder,
+        #     which is itself label-agnostic (it only looks at endpoints).
+        graph = self._build_segment_chains(segments, pad_positions, graph)
+
+        # 2c. Vias: pads coincident with a via are connected (layer bridge).
+        for via in self.pcb.vias:
+            via_pads = self._find_pads_at_point(via.position, pad_positions)
+            for i, p in enumerate(via_pads):
+                for other in via_pads[i + 1 :]:
+                    _connect(p, other)
+
+        # 2d. Filled zones (copper pours).
+        #
+        #     SCOPE NOTE (issue #3742, bounded first slice): the
+        #     load-bearing soundness property of this extractor is that
+        #     *autorouter copper* — track segments and vias — is traced
+        #     fully independently of pad net labels.  That is exactly where
+        #     the board-00 rotation-convention bug manifested: the router
+        #     wired SEGMENTS to the wrong pads while labeling them
+        #     correctly, and steps 2a–2c above will catch that regardless of
+        #     any shared coordinate convention.
+        #
+        #     Zone pours are different in kind.  A copper pour connects only
+        #     the pads it is *electrically tied* to (via thermal spokes);
+        #     pads of other nets sit inside the pour's outline but are carved
+        #     out by clearance moats.  Recovering that tie purely from the
+        #     flattened ``filled_polygons`` geometry is not reliable — the
+        #     outer hull and inner thermal/clearance cutout loops are
+        #     concatenated into one point list, which breaks naive
+        #     point-in-polygon, and pad-center-to-fill distance does not
+        #     separate tied pads from neighbouring foreign-net pads (verified
+        #     on board 00).  Robust pour extraction (spoke tracing /
+        #     kicad-cli cross-check) is an explicit #3742 follow-up.
+        #
+        #     So for the pour leg ONLY we group pads by the zone's *declared
+        #     net*: a pad enclosed by a pour's boundary on a matching layer
+        #     is treated as tied to that pour iff the pad's own declared net
+        #     equals the zone's.  This re-introduces a label dependency for
+        #     the FILL step alone (a deterministic, label-driven generator
+        #     step — not the autorouter), while keeping segment/via tracing
+        #     100% label-independent.  Crucially it can never fuse two
+        #     different nets, so it cannot manufacture a false short.
+        pad_declared_net: dict[str, str] = {}
+        for fp in self.pcb.footprints:
+            if not fp.reference or fp.reference.startswith("#"):
+                continue
+            for pad in fp.pads:
+                if pad.number is None or pad.number == "":
+                    continue
+                pad_declared_net[f"{fp.reference}.{pad.number}"] = pad.net_name
+
+        for zone in self.pcb.zones:
+            if not zone.filled_polygons:
+                continue
+            if not zone.polygon or len(zone.polygon) < 3:
+                continue
+            if not zone.net_name:
+                continue
+            pads_in_zone: list[str] = []
+            for pad_id, pad_pos in pad_positions.items():
+                if pad_declared_net.get(pad_id) != zone.net_name:
+                    continue
+                if not self._pad_layer_matches_zone(pad_layers.get(pad_id, []), zone.layer):
+                    continue
+                if self._point_in_polygon(pad_pos, zone.polygon):
+                    pads_in_zone.append(pad_id)
+            for i, p in enumerate(pads_in_zone):
+                for other in pads_in_zone[i + 1 :]:
+                    _connect(p, other)
+
+        # 2e. Coincident pads with no intervening copper still share metal
+        #     if they occupy the same point (e.g. stacked pads).
+        pad_ids = list(pad_positions)
+        for i, p in enumerate(pad_ids):
+            for other in pad_ids[i + 1 :]:
+                if self._points_close(pad_positions[p], pad_positions[other]):
+                    _connect(p, other)
+
+        # 3. Flood-fill connected components of the pad graph.
+        visited: set[str] = set()
+        partition: list[frozenset[str]] = []
+        for pad_id in pad_positions:
+            if pad_id in visited:
+                continue
+            component: set[str] = set()
+            queue = [pad_id]
+            while queue:
+                current = queue.pop()
+                if current in visited:
+                    continue
+                visited.add(current)
+                component.add(current)
+                queue.extend(graph[current] - visited)
+            partition.append(frozenset(component))
+
+        partition.sort(key=lambda comp: min(comp))
+        return partition
+
     def _get_net_pads(self, net_number: int) -> list[str]:
         """Get all pads on a specific net.
 

--- a/tests/test_copper_lvs.py
+++ b/tests/test_copper_lvs.py
@@ -1,0 +1,465 @@
+"""Tests for the independent copper-extracted LVS gate (issue #3742).
+
+This gate is the "third leg" of board soundness: unlike the label-based
+:func:`kicad_tools.lvs.board_lvs.compare_netlists`, it ignores every pad's
+declared ``(net ...)`` label and diffs the *physical* copper partition
+against the schematic.  The crux test is the 90°/270° regression fixture:
+adversarial copper that shorts two nets must FAIL, while corrected copper
+that connects same-net pads must PASS — proving "passes DRC" now implies
+"electrically correct" independent of the shared pad-rotation convention.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.core.geometry import rotate_pad_offset
+from kicad_tools.lvs import (
+    CopperLVSResult,
+    compare_copper_netlist,
+    compare_partitions,
+)
+from kicad_tools.validate.connectivity import ConnectivityValidator
+
+# ---------------------------------------------------------------------------
+# Pure partition-diff unit tests (compare_partitions)
+# ---------------------------------------------------------------------------
+
+
+def test_clean_board_no_mismatches() -> None:
+    """Same-net pads together, different-net pads apart -> clean."""
+    sch = {
+        ("R1", "1"): "VCC",
+        ("R1", "2"): "LED_ANODE",
+        ("D1", "1"): "LED_ANODE",
+        ("D1", "2"): "GND",
+    }
+    # Copper joins R1.2<->D1.1 (LED_ANODE) and leaves VCC / GND isolated.
+    partition = [
+        frozenset({"R1.1"}),
+        frozenset({"R1.2", "D1.1"}),
+        frozenset({"D1.2"}),
+    ]
+    result = compare_partitions(sch, partition)
+    assert result.clean
+    assert result.mismatches == ()
+
+
+def test_short_detected_when_two_nets_share_a_copper_island() -> None:
+    """Different schematic nets fused in one copper component -> short."""
+    sch = {
+        ("R1", "1"): "VCC",
+        ("R1", "2"): "LED_ANODE",
+        ("D1", "1"): "GND",
+    }
+    # Copper fuses LED_ANODE (R1.2) with GND (D1.1) — the board-00 bug.
+    partition = [
+        frozenset({"R1.1"}),
+        frozenset({"R1.2", "D1.1"}),
+    ]
+    result = compare_partitions(sch, partition)
+    assert not result.clean
+    assert len(result.shorts) == 1
+    assert result.opens == ()
+    short = result.shorts[0]
+    assert {short.net_a, short.net_b} == {"GND", "LED_ANODE"}
+    assert {short.pad_a, short.pad_b} == {"R1.2", "D1.1"}
+
+
+def test_open_detected_when_same_net_splits_across_islands() -> None:
+    """Same schematic net split across copper components -> open."""
+    sch = {
+        ("R1", "1"): "NET1",
+        ("R2", "1"): "NET1",
+    }
+    # The two NET1 pads land in different copper islands (unrouted).
+    partition = [
+        frozenset({"R1.1"}),
+        frozenset({"R2.1"}),
+    ]
+    result = compare_partitions(sch, partition)
+    assert not result.clean
+    assert len(result.opens) == 1
+    assert result.shorts == ()
+    open_rec = result.opens[0]
+    assert open_rec.net_a == open_rec.net_b == "NET1"
+    assert {open_rec.pad_a, open_rec.pad_b} == {"R1.1", "R2.1"}
+
+
+def test_floating_schematic_pin_excluded_from_diff() -> None:
+    """A pin with no schematic net (None) is ignored, not flagged."""
+    sch = {
+        ("R1", "1"): "VCC",
+        ("R1", "2"): None,  # floating in schematic
+    }
+    partition = [frozenset({"R1.1", "R1.2"})]
+    # R1.2 is floating, so the shared copper island is not a short.
+    result = compare_partitions(sch, partition)
+    assert result.clean
+
+
+def test_pcb_only_pad_does_not_crash_or_flag() -> None:
+    """A pad on the PCB but absent from the schematic is ignored here."""
+    sch = {("R1", "1"): "VCC"}
+    partition = [frozenset({"R1.1", "TP1.1"})]  # TP1 not in schematic
+    result = compare_partitions(sch, partition)
+    assert result.clean
+
+
+def test_schematic_only_pad_does_not_crash() -> None:
+    """A schematic pin with no PCB pad is ignored (label path's concern)."""
+    sch = {
+        ("R1", "1"): "VCC",
+        ("R9", "1"): "VCC",  # not on the board
+    }
+    partition = [frozenset({"R1.1"})]
+    result = compare_partitions(sch, partition)
+    # Only one VCC pad is on the board, so no open is reported.
+    assert result.clean
+
+
+def test_multi_pad_power_net_one_island_is_clean() -> None:
+    """A power net spanning many pads in one copper island is clean."""
+    sch = {
+        ("C1", "1"): "GND",
+        ("C2", "1"): "GND",
+        ("U1", "5"): "GND",
+    }
+    partition = [frozenset({"C1.1", "C2.1", "U1.5"})]
+    result = compare_partitions(sch, partition)
+    assert result.clean
+
+
+def test_short_reported_once_per_net_pair() -> None:
+    """Three pads of three nets in one island -> 3 unique short pairs."""
+    sch = {
+        ("A", "1"): "N1",
+        ("B", "1"): "N2",
+        ("C", "1"): "N3",
+    }
+    partition = [frozenset({"A.1", "B.1", "C.1"})]
+    result = compare_partitions(sch, partition)
+    pairs = {frozenset({m.net_a, m.net_b}) for m in result.shorts}
+    assert pairs == {
+        frozenset({"N1", "N2"}),
+        frozenset({"N1", "N3"}),
+        frozenset({"N2", "N3"}),
+    }
+
+
+# ---------------------------------------------------------------------------
+# 90°/270° regression fixture — the crux test (issue #3742)
+# ---------------------------------------------------------------------------
+#
+# A two-pad footprint at 90°.  Pad "1" sits at local (-1, 0), pad "2" at
+# local (+1, 0).  Under the CORRECT (current, #3739-fixed) transform a 90°
+# footprint maps local x -> board -y: pad "1" -> (origin_x, origin_y+1),
+# pad "2" -> (origin_x, origin_y-1).  Under the OLD standard-CCW transform
+# the signs flip (local x -> board +y), mirroring pad 1 and pad 2.
+#
+# We place TWO 90° footprints and route copper between specific *physical*
+# board points.  The same copper connects different *pads* depending on
+# which transform is used — exactly the convention coupling the gate must
+# expose.
+
+# The schematic side is exercised end-to-end by the committed board-00
+# artifacts (tests/test_board_00_lvs.py).  Here we drive the partition diff
+# with an explicit schematic mapping so the regression isolates the *copper
+# extraction* under the 90° transform — the part the gate adds — without
+# depending on synthetic schematic-wire geometry resolution.
+SCHEMATIC_90_NETS: dict[tuple[str, str], str | None] = {
+    ("R1", "1"): "SIG",
+    ("R1", "2"): "OUT1",
+    ("R2", "1"): "SIG",
+    ("R2", "2"): "OUT2",
+}
+
+
+def _pcb_90(seg_start: tuple[float, float], seg_end: tuple[float, float]) -> str:
+    """Build a PCB with two 90° footprints and a single routed segment.
+
+    Both footprints use local pad offsets ``"1"`` at (-1, 0) and ``"2"`` at
+    (+1, 0), placed at 90°.  The single copper segment runs between the two
+    given board points.  Pad labels are deliberately written *correctly*
+    (the router claims the right nets) so that only a copper-extracted gate
+    — not the label-based one — can catch a physical mis-route.
+    """
+    (sx, sy), (ex, ey) = seg_start, seg_end
+    return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "SIG")
+  (net 2 "OUT1")
+  (net 3 "OUT2")
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000b1")
+    (at 100 100 90)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "fp-r1-ref"))
+    (property "Value" "1k" (at 0 1.5 0) (layer "F.Fab") (uuid "fp-r1-val"))
+    (pad "1" smd roundrect (at -1 0) (size 0.6 0.6) (layers "F.Cu" "F.Paste" "F.Mask")
+      (roundrect_rratio 0.25) (net 1 "SIG"))
+    (pad "2" smd roundrect (at 1 0) (size 0.6 0.6) (layers "F.Cu" "F.Paste" "F.Mask")
+      (roundrect_rratio 0.25) (net 2 "OUT1"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000b2")
+    (at 120 100 90)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "F.SilkS") (uuid "fp-r2-ref"))
+    (property "Value" "1k" (at 0 1.5 0) (layer "F.Fab") (uuid "fp-r2-val"))
+    (pad "1" smd roundrect (at -1 0) (size 0.6 0.6) (layers "F.Cu" "F.Paste" "F.Mask")
+      (roundrect_rratio 0.25) (net 1 "SIG"))
+    (pad "2" smd roundrect (at 1 0) (size 0.6 0.6) (layers "F.Cu" "F.Paste" "F.Mask")
+      (roundrect_rratio 0.25) (net 3 "OUT2"))
+  )
+  (segment (start {sx} {sy}) (end {ex} {ey}) (width 0.25) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-0000000000c1"))
+)
+"""
+
+
+def _board_positions() -> dict[str, tuple[float, float]]:
+    """Compute the board-frame pad positions under the *current* transform."""
+    pos: dict[str, tuple[float, float]] = {}
+    for ref, (ox, oy) in (("R1", (100.0, 100.0)), ("R2", (120.0, 100.0))):
+        for pad, local in (("1", (-1.0, 0.0)), ("2", (1.0, 0.0))):
+            rx, ry = rotate_pad_offset(local[0], local[1], 90.0)
+            pos[f"{ref}.{pad}"] = (ox + rx, oy + ry)
+    return pos
+
+
+def _write(tmp_path: Path, name: str, content: str) -> Path:
+    p = tmp_path / name
+    p.write_text(content)
+    return p
+
+
+def _old_ccw_mirror(ref_origin: tuple[float, float]) -> tuple[float, float]:
+    """Board point the OLD (pre-#3739) CCW transform gave pad "1" at 90°.
+
+    The pre-fix standard-CCW form mapped local x -> board +y (mirror of the
+    #3739-fixed -y).  For pad "1" at local (-1, 0) on a 90° footprint this
+    lands on the *opposite* side from the corrected position.
+    """
+    a = math.radians(90.0)
+    rx = -1.0 * math.cos(a) - 0.0 * math.sin(a)
+    ry = -1.0 * math.sin(a) + 0.0 * math.cos(a)
+    return (ref_origin[0] + rx, ref_origin[1] + ry)
+
+
+def test_90deg_corrected_copper_passes(tmp_path: Path) -> None:
+    """Copper routed between the true SIG pads (R1.1, R2.1) -> clean.
+
+    Under the current (#3739-fixed) transform, pad "1" at local (-1, 0) on a
+    90° footprint maps to board +y of its origin: R1.1 = (100, 101),
+    R2.1 = (120, 101).  A segment between those two physical points connects
+    the two SIG pads, matching the schematic, so the copper-extracted gate
+    must pass.
+    """
+    pos = _board_positions()
+    pcb_path = _write(tmp_path, "b.kicad_pcb", _pcb_90(pos["R1.1"], pos["R2.1"]))
+
+    partition = ConnectivityValidator(pcb_path).extract_pad_partition()
+    result = compare_partitions(SCHEMATIC_90_NETS, partition)
+    assert result.clean, f"expected clean, got {result.mismatches}"
+
+
+def test_90deg_adversarial_copper_fails(tmp_path: Path) -> None:
+    """Copper routed to the *mirrored* pads shorts/opens the SIG net.
+
+    The adversarial segment runs between the board points the OLD
+    (pre-#3739) CCW transform would have computed for the SIG pads.  Under
+    the correct transform those points physically coincide with the *other*
+    (OUT) pads R1.2 / R2.2, so the copper connects the wrong pads.  The
+    copper-extracted gate must FAIL — SIG is left open (its true pads not
+    joined) and/or OUT1<->OUT2 are wrongly fused — even though the pad
+    labels were written correctly (a label-based check stays blind).
+    """
+    seg_start = _old_ccw_mirror((100.0, 100.0))  # where OLD transform put R1.1
+    seg_end = _old_ccw_mirror((120.0, 100.0))  # where OLD transform put R2.1
+    pcb_path = _write(tmp_path, "b.kicad_pcb", _pcb_90(seg_start, seg_end))
+
+    partition = ConnectivityValidator(pcb_path).extract_pad_partition()
+    result = compare_partitions(SCHEMATIC_90_NETS, partition)
+    assert not result.clean, (
+        "adversarial copper routed to mirrored pads must be flagged, "
+        f"but the partition diff was clean; partition={partition}"
+    )
+    # The mirrored segment physically lands on R1.2/R2.2 (OUT1/OUT2), so it
+    # shorts OUT1<->OUT2 and leaves SIG (R1.1/R2.1) open.
+    short_pairs = {frozenset({m.net_a, m.net_b}) for m in result.shorts}
+    assert frozenset({"OUT1", "OUT2"}) in short_pairs
+    assert any(m.net_a == "SIG" for m in result.opens)
+
+
+def test_90deg_label_based_lvs_is_blind_to_the_misroute(tmp_path: Path) -> None:
+    """The label-based comparator passes adversarial copper (motivation).
+
+    Documents *why* the copper-extracted gate is needed: the pad labels are
+    written correctly, so ``_pcb_pin_to_net`` reads SIG/OUT exactly as the
+    schematic expects regardless of where the copper physically runs.
+    """
+    from kicad_tools.lvs.board_lvs import _pcb_pin_to_net
+
+    pcb_path = _write(
+        tmp_path,
+        "b.kicad_pcb",
+        _pcb_90(_old_ccw_mirror((100.0, 100.0)), _old_ccw_mirror((120.0, 100.0))),
+    )
+
+    # Label-based view: pads report their declared nets, which match the
+    # schematic — the very blind spot #3742 closes.
+    pcb_labels = _pcb_pin_to_net(pcb_path)
+    assert pcb_labels[("R1", "1")] == "SIG"
+    assert pcb_labels[("R2", "1")] == "SIG"
+    assert pcb_labels[("R1", "2")] == "OUT1"
+    assert pcb_labels[("R2", "2")] == "OUT2"
+
+
+# ---------------------------------------------------------------------------
+# Independent geometry reference: 90° pad geometry vs golden (decoupling)
+# ---------------------------------------------------------------------------
+#
+# The gate's *correctness* must not silently rely on rotate_pad_offset being
+# right.  This asserts the extractor's 90°/270° pad geometry against an
+# independent hand-computed golden (the values pcbnew 10.0.1 reports, per
+# rotate_pad_offset's own docstring table).  A live kicad-cli cross-check is
+# a documented follow-up; the golden keeps the decoupling assertion running
+# in CI without a KiCad install.
+
+# Footprint at (100, 100), pad local offset (2, 0), per the pcbnew-verified
+# table in core.geometry.rotate_pad_offset:
+#   0   -> (102, 100)
+#   90  -> (100,  98)
+#   180 -> ( 98, 100)
+#   270 -> (100, 102)
+GOLDEN_PAD_GEOMETRY = {
+    0.0: (102.0, 100.0),
+    90.0: (100.0, 98.0),
+    180.0: (98.0, 100.0),
+    270.0: (100.0, 102.0),
+}
+
+
+@pytest.mark.parametrize("rotation", [0.0, 90.0, 180.0, 270.0])
+def test_transform_pad_position_matches_golden(rotation: float) -> None:
+    """_transform_pad_position must match the pcbnew-verified golden.
+
+    This is the decoupling guard (issue #3742): if a future refactor
+    reintroduces a coordinate-convention bug in the shared transform, the
+    90°/270° rows of this golden break, flagging that the copper-LVS gate's
+    pad geometry has drifted from KiCad's ground truth.
+    """
+    # ConnectivityValidator needs a PCB; build a trivial one in-memory.
+    validator = object.__new__(ConnectivityValidator)
+    bx, by = validator._transform_pad_position((2.0, 0.0), 100.0, 100.0, rotation)
+    gx, gy = GOLDEN_PAD_GEOMETRY[rotation]
+    assert bx == pytest.approx(gx, abs=1e-6)
+    assert by == pytest.approx(gy, abs=1e-6)
+
+
+def test_extract_pad_partition_ignores_pad_labels(tmp_path: Path) -> None:
+    """The extractor must not consult (net ...) labels at all.
+
+    Two pads physically joined by copper land in one component even when
+    their declared labels differ; two pads with the *same* label but no
+    copper between them stay in separate components.
+    """
+    pcb = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "A")
+  (net 2 "B")
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000d1")
+    (at 100 100)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "fp-d1-ref"))
+    (property "Value" "1k" (at 0 1.5 0) (layer "F.Fab") (uuid "fp-d1-val"))
+    (pad "1" smd roundrect (at 0 0) (size 0.6 0.6) (layers "F.Cu" "F.Paste" "F.Mask")
+      (roundrect_rratio 0.25) (net 1 "A"))
+    (pad "2" smd roundrect (at 2 0) (size 0.6 0.6) (layers "F.Cu" "F.Paste" "F.Mask")
+      (roundrect_rratio 0.25) (net 2 "B"))
+  )
+  (segment (start 100 100) (end 102 100) (width 0.25) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-0000000000d2"))
+)
+"""
+    pcb_path = _write(tmp_path, "b.kicad_pcb", pcb)
+    partition = ConnectivityValidator(pcb_path).extract_pad_partition()
+    # R1.1 (label A) and R1.2 (label B) are joined by copper despite the
+    # differing labels -> one component.
+    assert frozenset({"R1.1", "R1.2"}) in partition
+    assert len(partition) == 1
+
+
+def test_extract_pad_partition_unconnected_pad_is_singleton(tmp_path: Path) -> None:
+    """A pad with no copper touching it forms its own component."""
+    pcb = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000e1")
+    (at 100 100)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "fp-e1-ref"))
+    (property "Value" "1k" (at 0 1.5 0) (layer "F.Fab") (uuid "fp-e1-val"))
+    (pad "1" smd roundrect (at 0 0) (size 0.6 0.6) (layers "F.Cu" "F.Paste" "F.Mask")
+      (roundrect_rratio 0.25))
+    (pad "2" smd roundrect (at 2 0) (size 0.6 0.6) (layers "F.Cu" "F.Paste" "F.Mask")
+      (roundrect_rratio 0.25))
+  )
+)
+"""
+    pcb_path = _write(tmp_path, "b.kicad_pcb", pcb)
+    partition = ConnectivityValidator(pcb_path).extract_pad_partition()
+    assert frozenset({"R1.1"}) in partition
+    assert frozenset({"R1.2"}) in partition
+    assert len(partition) == 2
+
+
+def test_compare_partitions_returns_result_type() -> None:
+    """Smoke: the pure partition diff returns a CopperLVSResult."""
+    result = compare_partitions({("R1", "1"): "VCC"}, [frozenset({"R1.1"})])
+    assert isinstance(result, CopperLVSResult)
+
+
+def test_compare_copper_netlist_on_board00_artifacts() -> None:
+    """End-to-end: the file-level entry point runs clean on board 00.
+
+    Exercises the real schematic-side resolution (``_schematic_pin_to_net``)
+    plus copper extraction against the committed board-00 artifacts, so the
+    full ``compare_copper_netlist`` path is covered end-to-end.  Skips when
+    the generated artifacts are absent (same policy as test_board_00_lvs).
+    """
+    repo_root = Path(__file__).resolve().parent.parent
+    board_out = repo_root / "boards" / "00-simple-led" / "output"
+    sch = board_out / "simple_led.kicad_sch"
+    pcb = board_out / "simple_led_routed.kicad_pcb"
+    if not (sch.exists() and pcb.exists()):
+        pytest.skip("board 00 artifacts not present; run generate_design.py")
+    result = compare_copper_netlist(sch, pcb)
+    assert isinstance(result, CopperLVSResult)
+    assert result.clean, f"board 00 copper LVS unexpectedly dirty: {result.mismatches}"


### PR DESCRIPTION
## Summary

`kct check` could report a board clean while the routed PCB netlist did
not match the schematic: both the label-based LVS and the geometric
connectivity validator trusted pad `(net ...)` labels and/or shared the
router's pad-rotation transform, so a coordinate-convention bug
self-cancelled (the board-00 failure the external reviewer raised). This
adds the "third leg" of soundness: an **independent copper-extracted
netlist gate** that ignores pad labels and diffs the *physical* copper
partition against the schematic.

This is the curated bounded first slice of #3742; the deferred fleet-wide
rollout, power-net normalization, and per-board kicad-cli cross-check on
every run are explicitly out of scope.

## Changes

- `validate/connectivity.py`: new `ConnectivityValidator.extract_pad_partition()`
  floods the routed copper graph from **track segments + vias with zero
  reference to pad `(net ...)` labels** and returns galvanically-connected
  pad groups. This is the load-bearing property: it catches a router that
  wires copper to the wrong pads while labeling them correctly. Zone pours
  use a documented narrower model (grouped by declared net, against the
  zone boundary) so a pour can never fabricate a false short across nets;
  robust label-free pour/thermal-spoke extraction is a tracked #3742
  follow-up. Fully independent for autorouter copper, which is where the
  #3739 rotation bug actually manifested.
- `lvs/copper_lvs.py` (NEW): `compare_partitions()` (pure, IO-free) diffs
  the copper partition against the schematic partition, classifying
  **shorts** (different schematic nets fused in one copper island) and
  **opens** (one net split across islands). `compare_copper_netlist()`
  is the file-level entry point, reusing `board_lvs._schematic_pin_to_net`
  for the schematic side. New `CopperLVSResult` / `CopperLVSMismatch`.
- `lvs/__init__.py`: re-export the new comparator + result types.
- `cli/check_cmd.py`: `_lvs_subcheck` now runs the copper-extracted
  comparison alongside the existing label-based `compare_netlists`; either
  dirtying fails LVS (copper surfaced first as soundness-critical). The
  label-based path is unchanged.
- `tests/test_copper_lvs.py` (NEW): partition-diff unit tests, the 90°
  regression fixture, the decoupling golden, and a board-00 end-to-end.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Independent copper-extracted partition gate that ignores pad net labels | ✅ | `extract_pad_partition()` traces segments/vias without reading any `(net ...)` label; `test_extract_pad_partition_ignores_pad_labels` proves two differently-labeled pads joined by copper land in one component |
| Reports open/short by diffing physical copper islands vs schematic partition | ✅ | `compare_partitions` emits short/open records; `test_short_detected_*`, `test_open_detected_*` |
| Decoupling guard: 90°/270° pad geometry vs independent reference | ✅ | `test_transform_pad_position_matches_golden` asserts 0/90/180/270° against the pcbnew-verified golden; kicad-cli live cross-check documented as follow-up |
| 90°/270° regression fixture FAILS on adversarial copper, PASSES on corrected copper | ✅ | `test_90deg_adversarial_copper_fails` (mirrored copper → OUT1/OUT2 short + SIG open) and `test_90deg_corrected_copper_passes` |
| Composes with existing label-based LVS (kept alongside) | ✅ | `_lvs_subcheck` runs both; `test_meta_check_*` in `test_cli_check.py` still pass; `compare_netlists` untouched |
| Board-00 still passes | ✅ | `test_compare_copper_netlist_on_board00_artifacts` + full `test_board_00_lvs.py` green |

## Test Plan

- `pytest tests/test_copper_lvs.py` — 19 passed (partition diff, 90° regression, golden, board-00 e2e).
- `pytest tests/test_cli_check.py` — 43 passed (meta-check + LVS-mismatch rows).
- `pytest tests/test_lvs.py tests/test_board_00_lvs.py tests/test_connectivity.py tests/test_output_connectivity.py tests/test_pcb_nets_connectivity.py tests/test_routing_connectivity.py tests/test_connectivity_rule.py` — all passed (label-based path + connectivity unchanged).
- `ruff check` / `ruff format --check` clean on all changed files.
- `mypy` on the new `copper_lvs.py` and `extract_pad_partition` adds no new errors (the 12 reported in `connectivity.py` pre-exist on `origin/main` in the untouched `_build_connectivity_graph`).

Closes #3742