### PR TITLE
ci: drop push trigger and validate guard from label-external-issues

### DIFF
--- a/.github/workflows/label-external-issues.yml
+++ b/.github/workflows/label-external-issues.yml
@@ -3,25 +3,12 @@ name: Label external issues
 on:
   issues:
     types: [opened]
-  push:
-    paths:
-      - '.github/workflows/label-external-issues.yml'
 
 permissions:
   issues: write
   contents: read
 
 jobs:
-  # Guard job to prevent workflow failure on push events
-  # GitHub Actions marks runs as failed when no jobs execute, so this ensures
-  # at least one job runs. Using explicit true condition for clarity.
-  validate:
-    if: ${{ true }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Workflow syntax valid
-        run: echo "Workflow file validated successfully"
-
   label_external:
     if: ${{ github.event_name == 'issues' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

`.github/workflows/label-external-issues.yml` reported a red/failed run on essentially every push to `main`. The workflow triggered on both `issues: opened` and a self-referential `push.paths` filter restricting pushes to changes to the workflow file itself. On any push that does **not** touch the workflow file, GitHub still records a run for the workflow but the path filter strips every job → a 0-job run, which GitHub marks as `failure`. The `validate` guard job (added to dodge the no-jobs-fails quirk) could not help because the path filter removes all jobs before any can run.

This removes the `push:` trigger and the now-pointless `validate` guard job, leaving the workflow to trigger only on `issues: opened` — its actual function.

## Changes

- Removed the `push:` block (and its `paths:` child) from `on:`, leaving only `issues: { types: [opened] }`.
- Removed the `validate` guard job and its explanatory comment.
- Left `permissions:` and the entire `label_external` job (collaborator check, `external` label, welcome comment, and the `if: ${{ github.event_name == 'issues' }}` gate) byte-for-byte unchanged.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| No longer triggers on `push` (no `push:` key under `on:`) | ✅ | `on:` now has the single key `issues`; verified via diff and structural grep |
| Pushing an unrelated commit produces no failed run | ✅ | Workflow no longer triggers on `push` at all, so no run is created (manual verification in Actions tab after merge) |
| External-issue labeling on `issues: opened` preserved | ✅ | `diff` of the `label_external` job vs `main` is empty (byte-for-byte identical) |
| No new failing/empty runs introduced | ✅ | Only trigger remaining is `issues: opened`, which runs the real job |

## Test Plan

- Confirmed the diff is exactly the two intended deletions and nothing else (`git diff`: 13 deletions, 0 additions).
- Confirmed the `label_external` job is identical to `main` via `diff`.
- `uv run ruff check .` and `uv run ruff format . --check` pass (no Python touched).
- Manual post-merge: push an unrelated commit and confirm no new `Label external issues` run appears; open a test issue from a non-collaborator and confirm the `external` label + welcome comment still apply.

Closes #3759