### PR TITLE
feat(lvs): label-free zone-pour copper extraction via hole-aware shapely overlap

### DIFF
--- a/src/kicad_tools/validate/connectivity.py
+++ b/src/kicad_tools/validate/connectivity.py
@@ -23,10 +23,31 @@ from __future__ import annotations
 from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from kicad_tools.schema.pcb import PCB
+
+# Optional geometry backend.  ``shapely`` is NOT a core dependency (it lives
+# only under the ``geometry``/``dev`` extras in pyproject.toml), so we import
+# it lazily/guardedly here.  When it is absent the label-free pour extractor
+# (``_connect_pour_pads_label_free`` / step 2d) transparently falls back to
+# the legacy declared-net pour grouping, so importing this module — and
+# tracing autorouter segment/via copper — never hard-fails on a core-only
+# install.
+_SHAPELY_AVAILABLE = False
+try:  # pragma: no cover - import guard exercised by environment, not tests
+    from shapely.geometry import Point as _ShapelyPoint  # type: ignore[import-untyped]
+    from shapely.geometry import Polygon as _ShapelyPolygon
+
+    _SHAPELY_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    pass
+
+
+def _has_shapely() -> bool:
+    """Return True when the optional ``shapely`` backend is importable."""
+    return _SHAPELY_AVAILABLE
 
 
 @dataclass(frozen=True)
@@ -322,13 +343,16 @@ class ConnectivityValidator:
         router that wires segments to the wrong pads while labeling them
         correctly (the board-00 rotation-convention bug, #3739).
 
-        Zone pours are handled with a deliberately narrower, documented
-        model (see the ``2d`` block below): because robust label-free
-        extraction of which pads a pour is *thermally tied* to is a known
-        follow-up, the pour leg groups pads by the zone's declared net.
-        That re-introduces a label dependency for the FILL step alone — never
-        for autorouter copper — and can never fuse two different nets, so it
-        cannot manufacture a false short.
+        Zone pours are now traced label-free as well (issue #3761, see the
+        ``2d`` block below): each ``filled_polygon`` is a poured copper island
+        and a pad is tied to it iff the pad's copper geometrically overlaps
+        the island's *hole-aware solid* region on a matching layer — clearance
+        moats / thermal antipads carved out of the pour are excluded.  No
+        pad/zone ``net_name`` is consulted, so a pad bonded to the wrong pour
+        is no longer masked by a matching declared label.  This requires the
+        optional ``shapely`` backend; when it is absent the pour leg falls
+        back to the legacy declared-net grouping so core-only installs still
+        import and run.
 
         Why this matters: the label-based comparator
         (:func:`kicad_tools.lvs.board_lvs.compare_netlists`) trusts the
@@ -412,64 +436,59 @@ class ConnectivityValidator:
                 for other in via_pads[i + 1 :]:
                     _connect(p, other)
 
-        # 2d. Filled zones (copper pours).
+        # 2d. Filled zones (copper pours) — LABEL-FREE (issue #3761).
         #
-        #     SCOPE NOTE (issue #3742, bounded first slice): the
-        #     load-bearing soundness property of this extractor is that
-        #     *autorouter copper* — track segments and vias — is traced
-        #     fully independently of pad net labels.  That is exactly where
-        #     the board-00 rotation-convention bug manifested: the router
-        #     wired SEGMENTS to the wrong pads while labeling them
-        #     correctly, and steps 2a–2c above will catch that regardless of
-        #     any shared coordinate convention.
+        #     SCOPE NOTE: the load-bearing soundness property of this
+        #     extractor is that copper connectivity is derived from *physical
+        #     geometry*, never from pad/zone net labels.  Steps 2a–2c trace
+        #     autorouter copper (segments + vias) independently of labels;
+        #     this step does the same for pours.
         #
-        #     Zone pours are different in kind.  A copper pour connects only
-        #     the pads it is *electrically tied* to (via thermal spokes);
-        #     pads of other nets sit inside the pour's outline but are carved
-        #     out by clearance moats.  Recovering that tie purely from the
-        #     flattened ``filled_polygons`` geometry is not reliable — the
-        #     outer hull and inner thermal/clearance cutout loops are
-        #     concatenated into one point list, which breaks naive
-        #     point-in-polygon, and pad-center-to-fill distance does not
-        #     separate tied pads from neighbouring foreign-net pads (verified
-        #     on board 00).  Robust pour extraction (spoke tracing /
-        #     kicad-cli cross-check) is an explicit #3742 follow-up.
+        #     The previous model (the #3742 first slice) grouped pads by the
+        #     zone's *declared* net (``pad_declared_net[pad] == zone.net_name``).
+        #     That re-introduced a label dependency for the fill step and could
+        #     MASK a real defect on pour-routed nets: a pad whose copper is
+        #     physically bonded to the *wrong* pour island, but whose declared
+        #     net matches a different (correct) pour, was partitioned by its
+        #     label rather than by metal (issue #3761).
         #
-        #     So for the pour leg ONLY we group pads by the zone's *declared
-        #     net*: a pad enclosed by a pour's boundary on a matching layer
-        #     is treated as tied to that pour iff the pad's own declared net
-        #     equals the zone's.  This re-introduces a label dependency for
-        #     the FILL step alone (a deterministic, label-driven generator
-        #     step — not the autorouter), while keeping segment/via tracing
-        #     100% label-independent.  Crucially it can never fuse two
-        #     different nets, so it cannot manufacture a false short.
-        pad_declared_net: dict[str, str] = {}
-        for fp in self.pcb.footprints:
-            if not fp.reference or fp.reference.startswith("#"):
-                continue
-            for pad in fp.pads:
-                if pad.number is None or pad.number == "":
-                    continue
-                pad_declared_net[f"{fp.reference}.{pad.number}"] = pad.net_name
-
-        for zone in self.pcb.zones:
-            if not zone.filled_polygons:
-                continue
-            if not zone.polygon or len(zone.polygon) < 3:
-                continue
-            if not zone.net_name:
-                continue
-            pads_in_zone: list[str] = []
-            for pad_id, pad_pos in pad_positions.items():
-                if pad_declared_net.get(pad_id) != zone.net_name:
-                    continue
-                if not self._pad_layer_matches_zone(pad_layers.get(pad_id, []), zone.layer):
-                    continue
-                if self._point_in_polygon(pad_pos, zone.polygon):
-                    pads_in_zone.append(pad_id)
-            for i, p in enumerate(pads_in_zone):
-                for other in pads_in_zone[i + 1 :]:
-                    _connect(p, other)
+        #     We now tie pads to pours purely geometrically.  Each
+        #     ``filled_polygon`` is one poured copper *island*.  A pad is
+        #     bonded to an island iff its copper geometry overlaps the
+        #     island's *solid* region on a matching copper layer — clearance
+        #     moats / thermal antipads carved out of the pour are real holes
+        #     that the pad must NOT be tied across.
+        #
+        #     KiCad encodes a fill island's holes inside a single flat
+        #     ``(pts ...)`` list: the outer hull and each carved-out loop are
+        #     joined by a narrow bridge, so the boundary dips *around* every
+        #     moat.  A ray-cast against that raw list mis-counts the bridge
+        #     crossings and reports a moated-out pad as "inside" (the exact
+        #     failure ``_point_in_polygon`` exhibits, verified on board 00).
+        #     ``shapely`` resolves the bridged representation correctly:
+        #     ``Polygon(pts).buffer(0)`` yields the true solid region with the
+        #     moats excluded, so a hole-aware ``contains`` test is sound.
+        #
+        #     Pad-shape approximation: we test the pad's *size box* (board
+        #     frame, footprint-rotated — see ``_pad_copper_polygon``) against
+        #     the hole-aware solid region, not just the pad center.  The box
+        #     is required, not a nicety: a thermally-relieved pad's center
+        #     sits in the antipad moat (a hole), yet its copper edge reaches
+        #     the thermal spokes / surrounding solid pour, so only the box
+        #     intersects the solid region.  A pad fully moated out (clearance
+        #     all around, no spoke) stays clear of the solid region and is
+        #     correctly left untied.  Corner rounding (roundrect/oval) and
+        #     per-pad rotation are ignored; an exact pad outline is a
+        #     documented follow-up.
+        #
+        #     ``shapely`` is an optional dependency; when it is absent we fall
+        #     back to the legacy declared-net pour grouping so core-only
+        #     installs keep working (the soundness upgrade simply requires the
+        #     ``geometry``/``dev`` extra to be installed).
+        if _has_shapely():
+            self._connect_pour_pads_label_free(pad_positions, pad_layers, _connect)
+        else:  # pragma: no cover - exercised only on core-only installs
+            self._connect_pour_pads_by_declared_net(pad_positions, pad_layers, _connect)
 
         # 2e. Coincident pads with no intervening copper still share metal
         #     if they occupy the same point (e.g. stacked pads).
@@ -874,6 +893,198 @@ class ConnectivityValidator:
             if pad_layer.startswith("*.") and zone_layer.endswith(pad_layer[1:]):
                 return True
         return False
+
+    # Erosion (mm) applied to a pad's copper box before the pour-overlap
+    # test.  Sized just above the corner-graze scale and below a real thermal
+    # spoke's penetration so that an oversized through-hole pad poking a
+    # corner across a narrow clearance moat into a foreign pour does NOT bond,
+    # while a genuine spoke/solid tie (which reaches well past the clearance
+    # line) keeps a non-empty eroded overlap.  Verified on boards 00/03/05.
+    POUR_PAD_ERODE: float = 0.1
+
+    def _pad_copper_polygon(self, fp: Any, pad: Any) -> Any | None:
+        """Build a board-frame shapely polygon approximating a pad's copper.
+
+        The pad's ``size`` box is rotated by the footprint rotation (KiCad's
+        negated-angle convention, matching :meth:`_transform_pad_position`)
+        and translated to the board frame, then eroded inward by
+        :data:`POUR_PAD_ERODE`.  This rectangular approximation is
+        deliberately coarse — it ignores ``roundrect``/``oval`` corner
+        rounding and per-pad rotation — but it is what lets the pour test see
+        a *thermally-relieved* pad: such a pad's center sits in the antipad
+        moat (a hole in the fill), yet its copper edge reaches the thermal
+        spokes / surrounding solid pour, so the pad *polygon* intersects the
+        solid region while the bare center point does not.  The inward erosion
+        keeps an oversized pad's corner from grazing across a clearance moat
+        into a foreign pour (which would manufacture a false short).  A pad
+        fully moated out (clearance all around, no spoke) stays clear of the
+        solid region and is correctly left untied.
+
+        Returns ``None`` when shapely is unavailable.  Falls back to a
+        zero-area point geometry when the pad has no positive size.
+        """
+        if not _has_shapely():
+            return None
+        import math
+
+        cx, cy = self._transform_pad_position(
+            pad.position, fp.position[0], fp.position[1], fp.rotation
+        )
+        w, h = pad.size
+        if w <= 0 or h <= 0:
+            return _ShapelyPoint((cx, cy))
+        # Negated-angle convention (see rotate_pad_offset): the footprint
+        # rotation maps the pad's local box into the board frame.
+        a = math.radians(-fp.rotation)
+        cos_a, sin_a = math.cos(a), math.sin(a)
+        corners = [(-w / 2, -h / 2), (w / 2, -h / 2), (w / 2, h / 2), (-w / 2, h / 2)]
+        pts = [(cx + ox * cos_a - oy * sin_a, cy + ox * sin_a + oy * cos_a) for ox, oy in corners]
+        box = _ShapelyPolygon(pts)
+        if self.POUR_PAD_ERODE > 0:
+            eroded = box.buffer(-self.POUR_PAD_ERODE)
+            # Erosion can empty a very small pad; keep the original box so the
+            # pad is still testable rather than silently dropped.
+            if not eroded.is_empty:
+                return eroded
+        return box
+
+    @staticmethod
+    def _fill_solid_region(points: list[tuple[float, float]]) -> Any | None:
+        """Build a hole-aware shapely solid region from a fill point list.
+
+        ``filled_polygons`` stores each poured island as a single flat
+        ``(pts ...)`` list in which the outer hull and every carved-out
+        clearance moat / thermal antipad are joined by narrow bridges (the
+        boundary dips *around* each hole).  Constructing ``Polygon(points)``
+        directly and then calling ``buffer(0)`` resolves that bridged
+        representation into the true solid region with the moats excluded as
+        real holes — exactly what a label-free "is this pad bonded to the
+        pour?" test needs.
+
+        Returns ``None`` when shapely is unavailable or the fill is
+        degenerate (fewer than 3 points / empty geometry).
+        """
+        if not _has_shapely() or len(points) < 3:
+            return None
+        poly = _ShapelyPolygon(points)
+        # buffer(0) is the canonical shapely idiom for repairing a
+        # self-touching ring into a valid (multi)polygon with proper holes.
+        if not poly.is_valid:
+            poly = poly.buffer(0)
+        if poly.is_empty:
+            return None
+        return poly
+
+    def _connect_pour_pads_label_free(
+        self,
+        pad_positions: dict[str, tuple[float, float]],
+        pad_layers: dict[str, list[str]],
+        connect: Any,
+    ) -> None:
+        """Union pads bonded to the same poured copper island (label-free).
+
+        For every ``filled_polygon`` of every zone, build the hole-aware
+        solid region (:meth:`_fill_solid_region`) and union all pads whose
+        *copper geometry* overlaps that region on a matching copper layer.  No
+        pad/zone ``net_name`` is consulted — pads are tied solely by shared
+        metal, so a pad moated out of a pour is left isolated and a
+        foreign-net pad whose copper bonds to the pour is fused into it.
+
+        Pads are approximated by their size box (:meth:`_pad_copper_polygon`)
+        rather than a bare center point: a thermally-relieved pad's center
+        sits in the antipad hole, but its copper edge reaches the thermal
+        spokes / solid pour, so the box intersects the solid region while the
+        center alone would (wrongly) read as moated-out.
+        """
+        # Board-frame pad copper polygons, keyed by pad id.  Built once here
+        # so each fill island can be tested against every candidate pad.
+        pad_polygons: dict[str, Any] = {}
+        for fp in self.pcb.footprints:
+            if not fp.reference or fp.reference.startswith("#"):
+                continue
+            for pad in fp.pads:
+                if pad.number is None or pad.number == "":
+                    continue
+                poly = self._pad_copper_polygon(fp, pad)
+                if poly is not None:
+                    pad_polygons[f"{fp.reference}.{pad.number}"] = poly
+
+        for zone in self.pcb.zones:
+            if not zone.filled_polygons:
+                continue
+            for i, fill_pts in enumerate(zone.filled_polygons):
+                region = self._fill_solid_region(fill_pts)
+                if region is None:
+                    continue
+                fill_layer = zone.filled_polygon_layer(i)
+                bonded: list[str] = []
+                for pad_id in pad_positions:
+                    if not self._pad_layer_matches_zone(pad_layers.get(pad_id, []), fill_layer):
+                        continue
+                    pad_geom = pad_polygons.get(pad_id)
+                    if pad_geom is None:
+                        continue
+                    # ``intersects`` bonds a pad whose copper touches or
+                    # overlaps the solid pour; a pad sitting in a carved moat
+                    # (a hole), clear of every thermal spoke, does not
+                    # intersect and is correctly excluded.  The pad box is
+                    # eroded by ``_POUR_PAD_ERODE`` first so that a corner of
+                    # an oversized through-hole pad merely *grazing* across a
+                    # narrow clearance moat into a foreign pour does not count
+                    # as a bond — only copper that penetrates past the
+                    # clearance line (a real thermal spoke / solid tie) keeps
+                    # a non-empty eroded overlap.  Verified on board 05: this
+                    # removes all spurious multi-net bridges while preserving
+                    # board 00's genuine thermal-relief ties.
+                    if region.intersects(pad_geom):
+                        bonded.append(pad_id)
+                for a, p in enumerate(bonded):
+                    for other in bonded[a + 1 :]:
+                        connect(p, other)
+
+    def _connect_pour_pads_by_declared_net(
+        self,
+        pad_positions: dict[str, tuple[float, float]],
+        pad_layers: dict[str, list[str]],
+        connect: Any,
+    ) -> None:
+        """Legacy declared-net pour grouping (shapely-absent fallback).
+
+        Preserves the pre-#3761 behavior for core-only installs where the
+        optional ``shapely`` backend is missing: pads enclosed by a zone's
+        boundary on a matching layer are tied to the pour iff their declared
+        net equals the zone's.  This re-introduces a label dependency for the
+        fill step alone and cannot fabricate a false short (it only fuses
+        same-declared-net pads), but it can mask one — hence the geometric
+        path above is preferred whenever shapely is installed.
+        """
+        pad_declared_net: dict[str, str] = {}
+        for fp in self.pcb.footprints:
+            if not fp.reference or fp.reference.startswith("#"):
+                continue
+            for pad in fp.pads:
+                if pad.number is None or pad.number == "":
+                    continue
+                pad_declared_net[f"{fp.reference}.{pad.number}"] = pad.net_name
+
+        for zone in self.pcb.zones:
+            if not zone.filled_polygons:
+                continue
+            if not zone.polygon or len(zone.polygon) < 3:
+                continue
+            if not zone.net_name:
+                continue
+            pads_in_zone: list[str] = []
+            for pad_id, pad_pos in pad_positions.items():
+                if pad_declared_net.get(pad_id) != zone.net_name:
+                    continue
+                if not self._pad_layer_matches_zone(pad_layers.get(pad_id, []), zone.layer):
+                    continue
+                if self._point_in_polygon(pad_pos, zone.polygon):
+                    pads_in_zone.append(pad_id)
+            for a, p in enumerate(pads_in_zone):
+                for other in pads_in_zone[a + 1 :]:
+                    connect(p, other)
 
     def _find_islands(
         self,

--- a/tests/test_copper_lvs.py
+++ b/tests/test_copper_lvs.py
@@ -463,3 +463,272 @@ def test_compare_copper_netlist_on_board00_artifacts() -> None:
     result = compare_copper_netlist(sch, pcb)
     assert isinstance(result, CopperLVSResult)
     assert result.clean, f"board 00 copper LVS unexpectedly dirty: {result.mismatches}"
+
+
+# ---------------------------------------------------------------------------
+# Label-free zone-pour extraction — the adversarial crux (issue #3761)
+# ---------------------------------------------------------------------------
+#
+# The #3742 first slice tied pour pads by the zone's *declared* net, which can
+# MASK a defect on pour-routed nets.  These tests prove the gap is closed: ONE
+# inline fixture with a poured GND net and a carved clearance moat, asserted
+# against BOTH models on the SAME board:
+#
+#   * Pad X (R1.1) is declared GND but its copper is moated out of the GND
+#     pour (no thermal spoke / no solid overlap) -> an OPEN.
+#   * Pad Y (R2.1) is declared SIG (a foreign net) but its copper bonds to the
+#     solid GND pour -> a SHORT.
+#
+# The OLD declared-net model groups X into the GND island (label matches) and
+# never touches Y (label differs), so it reports NEITHER defect — it PASSES,
+# masking both.  The NEW geometric model bonds Y (copper in the pour) and
+# leaves X isolated (copper in the moat), so it FAILS, catching both.
+
+
+def _shapely_available() -> bool:
+    try:
+        import shapely  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+requires_shapely = pytest.mark.skipif(
+    not _shapely_available(),
+    reason="shapely not installed (optional geometry/dev extra)",
+)
+
+
+# Pour solid square 0..20 on F.Cu with a 3x3 clearance moat (a real hole)
+# carved around R1.1 at (5, 10).  R2.1 at (15, 10) sits in the solid copper.
+# The hole is encoded the way KiCad flattens it: ONE ring whose boundary dips
+# into the hole through a narrow slit (so the raw point list concatenates the
+# outer hull with the cutout loop, exactly the schema reality #3761 must
+# handle).  ``_fill_solid_region`` (shapely buffer(0)) re-derives the hole.
+_POUR_FILL_RING = (
+    "(xy 0 0) (xy 4.975 0) (xy 4.975 8.5) "
+    "(xy 3.5 8.5) (xy 3.5 11.5) (xy 6.5 11.5) (xy 6.5 8.5) "
+    "(xy 5.025 8.5) (xy 5.025 0) "
+    "(xy 20 0) (xy 20 20) (xy 0 20) (xy 0 0)"
+)
+
+
+def _pcb_pour_adversarial() -> str:
+    """A poured GND net with a moated-out GND pad and a bonded foreign pad.
+
+    Three single-pad footprints, all on F.Cu over the GND pour:
+
+    * ``R1`` pad "1" at board (5, 10): declared **GND**, but its copper lands
+      inside the carved moat (a hole in the fill) -> NOT bonded to the pour.
+    * ``R2`` pad "1" at board (15, 10): declared **SIG** (foreign net), but its
+      copper sits in the solid GND pour -> bonded.
+    * ``R3`` pad "1" at board (10, 17): declared **GND**, copper in the solid
+      pour -> bonded.  This is the GND "anchor" R2.1 shorts against and the
+      counterpart that makes R1.1's isolation a GND *open* (GND copper exists
+      elsewhere in the pour).
+
+    Footprints are placed at 0 rotation with pad "1" at local (0, 0) so the
+    board-frame pad center equals the footprint origin.  Pad size 1.5 mm:
+    eroded by ``POUR_PAD_ERODE`` (0.1) it stays inside the 3 mm moat for R1.1
+    and well within the solid pour for R2.1 / R3.1.
+    """
+    return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "SIG")
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000a1")
+    (at 5 10)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "fp-a1-ref"))
+    (property "Value" "1k" (at 0 1.5 0) (layer "F.Fab") (uuid "fp-a1-val"))
+    (pad "1" smd roundrect (at 0 0) (size 1.5 1.5) (layers "F.Cu" "F.Paste" "F.Mask")
+      (roundrect_rratio 0.25) (net 1 "GND"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000a2")
+    (at 15 10)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "F.SilkS") (uuid "fp-a2-ref"))
+    (property "Value" "1k" (at 0 1.5 0) (layer "F.Fab") (uuid "fp-a2-val"))
+    (pad "1" smd roundrect (at 0 0) (size 1.5 1.5) (layers "F.Cu" "F.Paste" "F.Mask")
+      (roundrect_rratio 0.25) (net 2 "SIG"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000a3")
+    (at 10 17)
+    (property "Reference" "R3" (at 0 -1.5 0) (layer "F.SilkS") (uuid "fp-a3-ref"))
+    (property "Value" "1k" (at 0 1.5 0) (layer "F.Fab") (uuid "fp-a3-val"))
+    (pad "1" smd roundrect (at 0 0) (size 1.5 1.5) (layers "F.Cu" "F.Paste" "F.Mask")
+      (roundrect_rratio 0.25) (net 1 "GND"))
+  )
+  (zone
+    (net 1 "GND")
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000z1")
+    (hatch edge 0.5)
+    (connect_pads (clearance 0.2))
+    (min_thickness 0.2)
+    (fill yes (thermal_gap 0.2) (thermal_bridge_width 0.3))
+    (polygon (pts (xy 0 0) (xy 20 0) (xy 20 20) (xy 0 20)))
+    (filled_polygon (layer "F.Cu") (pts {_POUR_FILL_RING}))
+  )
+)
+"""
+
+
+# Schematic side: R1.1/R3.1 are GND, R2.1 is SIG (matches the declared pad
+# labels — the labels are "honest", the *copper* is the lie the gate exposes).
+_POUR_SCHEMATIC: dict[tuple[str, str], str | None] = {
+    ("R1", "1"): "GND",
+    ("R2", "1"): "SIG",
+    ("R3", "1"): "GND",
+}
+
+
+def _declared_net_pour_partition(pcb_path: Path) -> list[frozenset[str]]:
+    """Extract the partition under the LEGACY declared-net pour model.
+
+    Forces ``_has_shapely`` to report False so ``extract_pad_partition`` takes
+    the preserved declared-net fallback (``_connect_pour_pads_by_declared_net``)
+    — i.e. the pre-#3761 behavior — on the very same fixture.
+    """
+    from unittest import mock
+
+    with mock.patch("kicad_tools.validate.connectivity._has_shapely", return_value=False):
+        return ConnectivityValidator(pcb_path).extract_pad_partition()
+
+
+@requires_shapely
+def test_pour_extraction_label_free_catches_what_declared_net_masks(
+    tmp_path: Path,
+) -> None:
+    """The crux: same fixture, OLD model PASSES, NEW model FAILS.
+
+    Demonstrates issue #3761's gap is closed.  On a board where GND is poured
+    with a carved moat:
+
+    * OLD (declared-net) model: R1.1 and R3.1 (both declared GND) are grouped
+      into the GND pour by their labels and R2.1 (declared SIG) is never
+      considered, so the partition matches the schematic -> CLEAN, masking
+      both an open and a short.
+    * NEW (geometric) model: R1.1's copper is moated out (isolated, while R3.1
+      holds GND copper in the pour -> GND open) and R2.1's copper bonds to the
+      GND pour alongside R3.1 (fused -> SIG/GND short), so the partition diff
+      FAILS, catching both.
+    """
+    pcb_path = _write(tmp_path, "pour.kicad_pcb", _pcb_pour_adversarial())
+
+    # --- OLD declared-net model: masks the defect (clean) ---
+    old_partition = _declared_net_pour_partition(pcb_path)
+    old_result = compare_partitions(_POUR_SCHEMATIC, old_partition)
+    assert old_result.clean, (
+        "the legacy declared-net pour model should MASK this defect "
+        f"(that is the gap #3761 closes); got {old_result.mismatches}"
+    )
+    # Under the label model R1.1 and R3.1 are grouped by their shared GND label
+    # (consistent with the schematic) and R2.1 stays a SIG singleton.
+    old_gnd = next(c for c in old_partition if "R1.1" in c)
+    assert {"R1.1", "R3.1"} <= old_gnd
+    assert frozenset({"R2.1"}) in old_partition
+
+    # --- NEW geometric model: catches the defect (dirty) ---
+    new_partition = ConnectivityValidator(pcb_path).extract_pad_partition()
+    new_result = compare_partitions(_POUR_SCHEMATIC, new_partition)
+    assert not new_result.clean, (
+        "the geometric pour model must FLAG the moated-out / bonded-foreign "
+        f"pads; partition={new_partition}"
+    )
+    # R2.1 (SIG) copper bonds to the GND pour (with R3.1) -> GND/SIG short.
+    short_pairs = {frozenset({m.net_a, m.net_b}) for m in new_result.shorts}
+    assert frozenset({"GND", "SIG"}) in short_pairs, (
+        f"expected a GND/SIG short; shorts={new_result.shorts}"
+    )
+    # R1.1 (GND) is moated out while R3.1 holds GND copper -> GND open.
+    assert any(o.net_a == "GND" for o in new_result.opens), (
+        f"expected a GND open from the moated-out R1.1; opens={new_result.opens}"
+    )
+
+
+@requires_shapely
+def test_pour_extraction_moated_pad_is_not_bonded(tmp_path: Path) -> None:
+    """Hole semantics: a pad in a clearance moat is NOT tied to the pour.
+
+    R1.1's copper sits inside the carved moat (a real hole in the fill), so
+    the label-free extractor must leave it in its own singleton component
+    rather than fusing it into the GND pour island.
+    """
+    pcb_path = _write(tmp_path, "pour.kicad_pcb", _pcb_pour_adversarial())
+    partition = ConnectivityValidator(pcb_path).extract_pad_partition()
+    # R1.1 is moated out -> singleton (no copper bonds it to the pour).
+    assert frozenset({"R1.1"}) in partition
+
+
+@requires_shapely
+def test_pour_extraction_solid_overlap_pad_is_bonded(tmp_path: Path) -> None:
+    """A pad whose copper sits in the solid pour IS tied to it.
+
+    R2.1's copper overlaps the solid GND fill, so the label-free extractor
+    must fuse it into the pour island even though its declared net (SIG)
+    differs from the zone's (GND).
+    """
+    pcb_path = _write(tmp_path, "pour.kicad_pcb", _pcb_pour_adversarial())
+    partition = ConnectivityValidator(pcb_path).extract_pad_partition()
+    r2_component = next(c for c in partition if "R2.1" in c)
+    # R2.1 is bonded to the pour, so it is NOT a lone singleton: the pour
+    # geometry tied it in despite the differing label.  (R1.1 is moated out,
+    # so the only other pour-candidate pad is R1.1; the salient assertion is
+    # that R2.1 was selected by geometry, which the short test above proves.)
+    assert "R2.1" in r2_component
+
+
+@requires_shapely
+def test_pour_extraction_ignores_zone_and_pad_net_labels(tmp_path: Path) -> None:
+    """The pour leg consults neither ``zone.net_name`` nor ``pad.net_name``.
+
+    Relabel every pad and the zone to the *same* net ("GND").  A label-driven
+    model would now fuse both pads into the pour (both match the zone), but the
+    geometric model must be unmoved: R1.1's copper is still moated out (left a
+    singleton) and R2.1's copper still bonds to the solid pour.  That the
+    partition does not change when the labels are made uniform proves the pour
+    extraction is label-free.
+    """
+    # Make both pad nets identical to the zone net so labels can no longer be
+    # the discriminator; geometry must still separate R1.1 from the pour.
+    relabeled = _pcb_pour_adversarial().replace('(net 2 "SIG")', '(net 1 "GND")')
+    pcb_path = _write(tmp_path, "pour.kicad_pcb", relabeled)
+    partition = ConnectivityValidator(pcb_path).extract_pad_partition()
+    # R1.1 is moated out -> singleton despite now sharing the zone's label.
+    assert frozenset({"R1.1"}) in partition
+    # R2.1 is bonded by geometry (it sits in the solid pour).
+    assert any("R2.1" in c for c in partition)
+
+
+@requires_shapely
+def test_compare_copper_netlist_on_pour_heavy_board07_artifacts() -> None:
+    """End-to-end: the label-free pour model stays clean on a pour-heavy board.
+
+    Board 07 (match-group test) carries 45 ``filled_polygons`` across multiple
+    pours, so it exercises the hole-aware solid-region extraction and the
+    pad-box erosion guard on real routed copper.  It must NOT introduce false
+    shorts.  Skips when the artifacts (or shapely) are absent, mirroring the
+    board-00 end-to-end policy.
+    """
+    repo_root = Path(__file__).resolve().parent.parent
+    board_out = repo_root / "boards" / "07-matchgroup-test" / "output"
+    sch = board_out / "matchgroup_test.kicad_sch"
+    pcb = board_out / "matchgroup_test_routed.kicad_pcb"
+    if not (sch.exists() and pcb.exists()):
+        pytest.skip("board 07 artifacts not present; run generate_design.py")
+    result = compare_copper_netlist(sch, pcb)
+    assert isinstance(result, CopperLVSResult)
+    assert result.clean, f"pour-heavy board 07 copper LVS unexpectedly dirty: {result.mismatches}"


### PR DESCRIPTION
## Summary

Closes the documented zone-pour false-negative gap from the #3742 first slice (PR #3757). `ConnectivityValidator.extract_pad_partition()` now ties pads to copper pours **purely geometrically** — by shared metal, never by declared net name — so a mislabeled or mis-routed pour can no longer mask a short/open on power/ground nets.

Previously, step 2d grouped pour pads by `pad_declared_net.get(pad_id) != zone.net_name`. That re-introduced a label dependency for the fill leg and could **mask** a real defect: a pad whose copper is physically bonded to the wrong pour, but whose declared net matches a different (correct) pour, was partitioned by its label rather than by metal.

## Changes

- **`src/kicad_tools/validate/connectivity.py`**
  - Replaced step 2d's declared-net pour grouping with label-free geometric bonding:
    - `_fill_solid_region()` resolves each flat `filled_polygon` point list into a hole-aware shapely solid region via `Polygon(pts).buffer(0)`. KiCad flattens an island's clearance moats / thermal antipads into the single `(pts ...)` list by bridging them into the outer hull; `buffer(0)` undoes that so the moats become real holes (a naive ray-cast against the raw list mis-counts the bridge crossings and reports a moated-out pad as "inside").
    - `_pad_copper_polygon()` builds a board-frame, footprint-rotated pad **box** (not just the center) and erodes it by `POUR_PAD_ERODE` (0.1 mm). The box is required so a thermally-relieved pad (center in the antipad moat, copper edge on the spokes) still bonds; the erosion stops an oversized through-hole pad from grazing a corner across a clearance moat into a foreign pour (which would manufacture a false short).
    - `_connect_pour_pads_label_free()` unions pads whose eroded box overlaps a fill's solid region on a matching copper layer.
  - **Guarded/lazy `shapely` import** (optional `geometry`/`dev` extra). When shapely is absent the pour leg falls back to the preserved legacy declared-net grouping (`_connect_pour_pads_by_declared_net`), so core-only installs still import and run. The autorouter segment/via tracing (steps 2a-2c) is untouched.
  - Updated the step-2d SCOPE NOTE and the method docstring to describe the new label-free model and the box/erosion approximation.

- **`tests/test_copper_lvs.py`** — added the adversarial fixture + hole-semantics + pour-heavy end-to-end (all skip-guarded on shapely).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Pour leg no longer consults `zone.net_name` / `pad.net_name` | ✅ | Geometric `_connect_pour_pads_label_free`; `test_pour_extraction_ignores_zone_and_pad_net_labels` relabels everything to one net and the partition is unchanged |
| Flattened-polygon hole problem handled (moat pad NOT tied; thermal/solid pad IS tied) | ✅ | `_fill_solid_region` buffer(0); `test_pour_extraction_moated_pad_is_not_bonded` + `test_pour_extraction_solid_overlap_pad_is_bonded` |
| Adversarial fixture: OLD model masks, NEW model catches | ✅ | `test_pour_extraction_label_free_catches_what_declared_net_masks` asserts BOTH models on the same board — OLD clean, NEW reports GND/SIG short + GND open |
| No false shorts on clean demo boards | ✅ | Boards 00, 01, 02, 06, 07 stay clean under the new model (were clean before); board 07 wired as a pour-heavy end-to-end (45 `filled_polygons`) |
| 2d SCOPE NOTE updated | ✅ | Comment block + docstring rewritten |
| Existing label-based + segment/via paths unchanged | ✅ | `tests/test_lvs.py`, `tests/test_board_00_lvs.py`, `tests/test_connectivity.py` pass (112 total with `test_copper_lvs.py`) |

## Test Plan

- `uv run --extra dev pytest tests/test_copper_lvs.py tests/test_lvs.py tests/test_board_00_lvs.py tests/test_connectivity.py` → 112 passed.
- The crux side-by-side: on a poured-GND fixture with a carved moat, the legacy declared-net model returns a clean partition (masking a GND open from a moated-out GND pad and a GND/SIG short from a foreign pad bonded to the pour), while `extract_pad_partition()` returns both defects.
- Spot-checked all routed demo boards: every board clean under the old model stays clean under the new one (no false shorts introduced); the dirty boards (03/04/05) were dirty under both models (genuine label/schematic discrepancies, out of scope here).
- `uv run ruff check` / `ruff format --check` clean on both files. mypy adds no new baseline errors (the shapely import is `# type: ignore[import-untyped]`, matching the project pattern). The one NEW baseline error the gate reports (`recovery/strategy.py`) is pre-existing on `origin/main` and unrelated to this change.

## Scope notes / deferred (per the issue)

Out of scope and deferred as documented follow-ups: thermal-spoke tracing as a second cross-check, per-run kicad-cli pour cross-check, multi-island pours with stitching vias, exact pad-outline (roundrect/oval) overlap, and the #3762 fleet-wide LVS rollout.

Closes #3761