### PR TITLE
fix(fleet): tolerate checkout mtime jitter in manufacturing-staleness check

### DIFF
--- a/src/kicad_tools/cli/fleet_cmd.py
+++ b/src/kicad_tools/cli/fleet_cmd.py
@@ -74,6 +74,31 @@ _DRIFT_ADDED_ONLY_TOLERANCE = 2
 # grandfathered non-zero error count; boards NOT listed must report 0.
 _DRC_TOLERANCE_PATH = Path(".github/routed-drc-tolerance.yml")
 
+# Issue #3767: the manufacturing-staleness check compares the routed PCB's
+# mtime against the manifest.json mtime ("the manufacturing bundle was
+# exported BEFORE the last route, so it may be out of date"). The trap is
+# that **git does not preserve mtimes** -- on a fresh ``git clone`` /
+# ``git checkout`` every file is stamped with the checkout time, and the
+# relative ordering of two committed siblings is decided purely by the
+# order git happens to write them (effectively alphabetical within a
+# directory tree), NOT by their content.
+#
+# Empirically (boards 00/01/07 vs 02/06 at #3767), this produced
+# sub-10-millisecond mtime deltas that flipped boards between STALE and
+# fresh based solely on whether the ``*_routed.kicad_pcb`` filename sorts
+# before or after the ``manufacturing/`` subdirectory -- a pure filename
+# artifact with zero manufacturability signal. Regenerating the artifacts
+# does NOT fix this: any subsequent clone re-derives the same ordering.
+#
+# The fix: only treat the bundle as stale when the routed PCB is newer by
+# more than this tolerance. A genuine staleness gap (route re-run minutes,
+# hours, or days after the last manufacturing export) clears the window
+# easily, while checkout-ordering jitter (well under a second, even on slow
+# filesystems with large gerber/render trees) does not. 120s sits far above
+# any plausible single-checkout write spread and far below a real
+# regenerate-the-route-but-forget-to-re-export gap.
+_STALE_MTIME_TOLERANCE_S = 120.0
+
 
 # ---------------------------------------------------------------------------
 # Data classes
@@ -1104,10 +1129,16 @@ def _survey_board(
         routing.drift_added = added
         routing.drift_removed = removed
         mfg = _detect_manufacturing(board_dir)
+        # Issue #3767: require the routed PCB to be newer than the manifest
+        # by more than _STALE_MTIME_TOLERANCE_S before flagging STALE. This
+        # absorbs git's non-preservation of mtimes (a fresh checkout stamps
+        # all files with the checkout time and orders siblings by filename,
+        # not content), which otherwise false-flags at-parity boards whose
+        # routed-PCB filename happens to sort after ``manufacturing/``.
         if (
             routed_mtime is not None
             and mfg.manifest_mtime is not None
-            and routed_mtime > mfg.manifest_mtime
+            and routed_mtime - mfg.manifest_mtime > _STALE_MTIME_TOLERANCE_S
         ):
             mfg.stale = True
         drc = _detect_drc(routed_pcb, drc_tolerances or {})

--- a/tests/test_fleet_status.py
+++ b/tests/test_fleet_status.py
@@ -596,6 +596,40 @@ class TestFleetStatusBasics:
         assert b["manufacturing"]["stale"] is True
         assert "artifacts stale" in b["blockers"]
 
+    def test_fleet_status_checkout_jitter_not_stale(self, tmp_path: Path, capsys):
+        """Issue #3767: a routed PCB only a few ms/s newer than the manifest
+        (the signature of git-checkout write-ordering, which does NOT
+        preserve mtimes) must NOT be flagged STALE.
+
+        Boards 00/01/07 were false-flagged because their
+        ``*_routed.kicad_pcb`` filename sorts after ``manufacturing/``, so a
+        fresh checkout wrote the PCB a few milliseconds later. The
+        staleness check tolerates sub-``_STALE_MTIME_TOLERANCE_S`` deltas so
+        content-correct boards stay shippable across checkouts.
+        """
+        boards = tmp_path / "boards"
+        routed_pcb = make_fake_board(
+            boards,
+            "jitter-board",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        # Manifest is 3 seconds OLDER than the routed PCB -- comfortably
+        # within checkout-jitter range and far below the 120s tolerance.
+        manifest_path = boards / "jitter-board" / "output" / "manufacturing" / "manifest.json"
+        routed_mtime = routed_pcb.stat().st_mtime
+        os.utime(manifest_path, (routed_mtime - 3.0, routed_mtime - 3.0))
+
+        main(["status", "--boards-dir", str(boards), "--format", "json"])
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        b = data["boards"][0]
+        assert b["manufacturing"]["stale"] is False
+        assert not any("artifacts stale" in blocker for blocker in b["blockers"]), b["blockers"]
+
     def test_fleet_status_pattern_override(self, tmp_path: Path, capsys):
         """--pattern '*.kicad_pcb' picks up unrouted PCBs too."""
         boards = tmp_path / "boards"


### PR DESCRIPTION
## Summary

Boards 00/01/07 (and 04) were reporting `FAIL (artifacts stale)` from `kct fleet ship-ready` despite being content-correct. The root cause is **not** stale artifacts — it is the staleness *detection logic*, which compares mtimes that git does not preserve.

While implementing the issue's prescribed fix (regenerate each board's recipe end-to-end so the manifest lands last), I discovered the regen does **not** robustly fix the FAIL — exactly the reproducibility caveat the issue flagged. So I fixed the detection logic in `fleet_cmd.py` instead, which is the durable fix.

### Why regenerating artifacts does not work

`_compute_board_status` (`fleet_cmd.py` ~L1107) flags STALE when `routed_pcb.stat().st_mtime > manifest.json.st_mtime`. **Git does not store mtimes** — a fresh `clone`/`checkout` stamps every file with the checkout time and writes committed siblings in (effectively) alphabetical order within a directory. Empirically at HEAD, after a clean checkout:

| Board | routed-PCB filename | sorts vs `manufacturing/` | mtime delta | verdict |
|---|---|---|---|---|
| 00-simple-led | `simple_led_routed…` | after | +4.8 ms | STALE (false) |
| 01-voltage-divider | `voltage_divider_routed…` | after | +3.9 ms | STALE (false) |
| 07-matchgroup-test | `matchgroup_test_routed…` | after | +11.6 ms | STALE (false) |
| 02-charlieplex-led | `charlieplex_3x3_routed…` | before | −6.0 ms | fresh |
| 06-diffpair-test | `diffpair_test_routed…` | before | −10.3 ms | fresh |

The STALE flag is decided entirely by whether the routed-PCB filename alphabetically sorts before/after the string `manufacturing` — a **sub-10ms, content-independent, non-reproducible** artifact. Regenerating bundles cannot fix it: the next clone re-derives the same ordering. The correct fix is to the mtime comparison.

### Why not just regenerate anyway?

I tried. Boards 00 and 01 regenerated cleanly, but **board 07's full re-route did not reproduce the committed `238/244` routing_complete state** in this environment — it landed at `237/244` with `routing_complete: false` and 7 blocking incomplete nets (the board-07 recipe routes via Python A* fallbacks on the hard DDR/MIPI nets; the macOS arm64 + Python 3.14 worktree diverges from the CI `kicad/kicad:10.0` + Python 3.12 gate that defines the committed PCB). Per the issue's explicit guard ("if your regen CHANGES the routing result, STOP and report rather than committing a regression"), I reset board 07 and committed **no artifact changes**.

## Changes

- `src/kicad_tools/cli/fleet_cmd.py`:
  - New `_STALE_MTIME_TOLERANCE_S = 120.0` constant with a detailed rationale comment.
  - Staleness check now flags STALE only when `routed_mtime - manifest_mtime > _STALE_MTIME_TOLERANCE_S`, absorbing git-checkout write-ordering jitter while still catching a genuine "route re-run long after the last manufacturing export" gap.
- `tests/test_fleet_status.py`: new `test_fleet_status_checkout_jitter_not_stale` regression — a routed PCB 3 s newer than the manifest must **not** be flagged STALE. The existing 3600 s genuine-staleness test still asserts STALE.
- **No board artifacts modified** (all `boards/**/output/**` left at the committed baseline).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| 00/01/07 no longer `FAIL (artifacts stale)` | ✅ | `ship-ready --format table`: all three now `fresh` + `PASS` |
| 00/01/07 `manufacturing.stale == false` (JSON) | ✅ | `ship-ready --format json` confirms `false` for each |
| Boards 02 & 06 stay PASS | ✅ | both `fresh` + `PASS` |
| 03 keeps non-staleness FAIL | ✅ | `FAIL (routed PCB stale (schematic drift: 14 vs 16 nets))` — unchanged |
| 05 keeps non-staleness FAIL | ✅ | `FAIL (incomplete routing (7/52 nets))` — unchanged |
| Board 00 keeps clean drc/erc/lvs | ✅ | `drc_report.json` errors=0 passed=true; `lvs.json` clean=true (artifacts untouched) |
| Board 07 stays `routing_complete: true` (238/244) | ✅ | committed PCB untouched; ship-ready shows 238/244 |
| ruff check / format | ✅ | both pass on changed files |
| relevant tests | ✅ | `tests/test_fleet_status.py`, `tests/test_fleet_ship_ready.py`, `tests/test_net_audit.py` → 80 passed |

> Note on board 04 (#3765): its only ship-ready blocker was the same false "artifacts stale" signal (DRC errors are advisory-only, routing complete), so the logic fix also clears its FALSE failure. Its genuine connectivity work (2 advisory `connectivity` violations) is unaffected and remains tracked in #3765. Boards 03 and 05 retain their genuine non-staleness FAILs.

## Test Plan

- `uv run pytest tests/test_fleet_status.py tests/test_fleet_ship_ready.py tests/test_net_audit.py` → 80 passed (incl. new regression + existing 3600 s stale test).
- `uv run ruff check` / `ruff format --check` on both changed files → clean.
- `uv run kct fleet ship-ready --boards-dir boards` (table + JSON) → 00/01/07 `fresh`/PASS; 02/06 PASS; 03/05 keep non-staleness FAILs.

### Follow-up (slice 2, not implemented here per curator)

A `manufacturing.stale`-asserting CI freshness gate remains a separate design decision (mtimes are not reproducible across checkouts — this PR is precisely why). Left as an open follow-up note, not bundled here.

Closes #3767