### PR TITLE
fix(boards/05): emit drc_report.json sidecar; document PHASE placement blocker

### DIFF
--- a/boards/05-bldc-motor-controller/README.md
+++ b/boards/05-bldc-motor-controller/README.md
@@ -12,10 +12,15 @@ uv run python boards/05-bldc-motor-controller/design.py
 > **Status**: Schematic, PCB layout (with STM32G431K8Tx MCU + complete
 > DRV8301 QFN-56 footprint) and autorouting are all implemented.  After
 > regeneration, every net has at least two pads so the autorouter can
-> attempt full connectivity.  The autorouter still leaves a few segment
-> clearance violations on this complex high-density board; those are
-> tracked separately and do not affect the schematic correctness or
-> the BOM/netlist.
+> attempt full connectivity.  The three motor-phase nets (PHASE_A/B/C)
+> are currently SKIPPED from routing and are NOT yet pour-served, so they
+> ship as open circuits -- closing them is placement-bound (see
+> "High-Current Traces" below and issue #3766) and tracked as a follow-up.
+> The residual U3-south current-sense (ISENSE) cluster is congestion-
+> limited (#3471).  The autorouter also leaves a few segment clearance
+> violations on this complex high-density board; those are tracked
+> separately and do not affect the schematic correctness or the
+> BOM/netlist.
 
 ## Overview
 
@@ -76,7 +81,18 @@ This board exercises kicad-tools capabilities that simpler boards don't:
 ### 2. High-Current Traces
 
 - Motor phase traces carry 10A continuous
-- Requires 2mm+ trace width or polygon pours
+- **PHASE_A/B/C connectivity is placement-bound (issue #3766).** They are
+  classified `HIGH_CURRENT_SIGNAL` (`is_pour_net=False`, "phase outputs
+  must NOT be poured"), so a polygon pour is not the right tool -- and the
+  FET->motor phase pads are scattered across the layout, so a bounding-box
+  pour island would span the whole board and short against the rail pours.
+  Routing them as traces *does* connect PHASE_A/B/C, but on the current
+  70x90 mm placement the extra high-current traces consume the U3-south
+  escape channels the ISENSE / PWM / GATE_DRV / BST nets also need: two
+  full seed-7 regens measured 9 blocking signal nets (vs the committed 7),
+  i.e. fixing PHASE breaks ~4 previously-complete nets.  Closing PHASE
+  cleanly therefore needs a targeted U3-south / power-stage relayout
+  (tracked as a follow-up) rather than a recipe change.
 - Power input traces carry 15A
 - Tests net class differentiation
 

--- a/boards/05-bldc-motor-controller/design.py
+++ b/boards/05-bldc-motor-controller/design.py
@@ -2851,6 +2851,24 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
 
     # Skip power and high-current nets (route manually or use copper pour zones)
     # Phase nets carry motor current (10A+) and need wide traces (2mm+)
+    #
+    # Issue #3766 (investigation, NOT yet applied): PHASE_A/B/C are listed
+    # here AND in ``_RESCUE_EXCLUDED_NETS`` on the premise that copper pours
+    # carry them like the rails -- but ``auto_pour_if_missing`` classifies
+    # PHASE_x as a *signal* (HIGH_CURRENT_SIGNAL), never a pour candidate,
+    # so no PHASE zone is ever created and the committed artifact ships them
+    # as permanent open circuits.  Removing them from this skip list does
+    # make the router connect PHASE_A/B/C, BUT on the current 70x90 mm
+    # placement the extra high-current traces consume the U3-south escape
+    # channels the ISENSE / PWM / GATE_DRV / BST nets also need: two full
+    # seed-7 regens measured 130-143/206 pads with 9 blocking signal nets
+    # (vs the committed 143/206 with 7 blocking) -- i.e. fixing PHASE breaks
+    # ~4 previously-complete nets.  Pours are not an alternative: the
+    # FET->motor PHASE pads are scattered across the whole board, so a
+    # bounding-box pour island shorts against the rail pours.  Net: PHASE
+    # connectivity is placement-bound on this board and needs a targeted
+    # U3-south relayout (tracked as a follow-up).  Left skipped here until
+    # that placement work lands so the committed routing does not regress.
     skip_nets = ["+24V", "+5V", "+3V3", "GND", "PHASE_A", "PHASE_B", "PHASE_C"]
 
     cmd = [
@@ -3168,16 +3186,32 @@ def generate_manufacturing(routed_path: Path, output_dir: Path) -> bool:
 
 
 def run_drc(pcb_path: Path) -> bool:
-    """Run DRC on the PCB using kct check for consistent results."""
+    """Run DRC on the routed PCB and write ``drc_report.json`` beside it.
+
+    Issue #3766: previously this ran ``kct check`` for stdout only and
+    never wrote ``output/drc_report.json`` -- the sidecar that
+    ``fleet_cmd._detect_drc`` looks for next to the routed PCB.  Without
+    it, ``kct fleet ship-ready`` showed board-05's DRC leg as ``-``.  This
+    now emits the report via ``--drc-only --output`` so the leg moves from
+    ``n/a`` to a real PASS/FAIL.  Mirrors board-03's #3764 / board-04's
+    #3765 ``run_drc``.
+
+    Uses ``--drc-only`` so the gate reflects geometric DRC (clearance /
+    connectivity / via rules) rather than the copper-LVS sub-check, which
+    reports pour-served power-net pads (GND / rails / PHASE) as "open"
+    because the router deliberately serves those nets via copper pours
+    (the #3772 pour-extraction gap).  LVS is tracked separately by #3762.
+
+    Issue #3425: ``--mfr jlcpcb-tier1`` aligns the summary with the
+    profile this board routes and is CI-gated against (see route_pcb and
+    the manufacturers: override in ``.github/routed-drc-tolerance.yml``).
+    """
     print("\n" + "=" * 60)
-    print("Running DRC (via kct check)...")
+    print("Running DRC (via kct check --drc-only)...")
     print("=" * 60)
 
+    report_path = pcb_path.parent / "drc_report.json"
     try:
-        # Issue #3425: align the local DRC summary with the jlcpcb-tier1
-        # profile this board routes and is CI-gated against (see
-        # route_pcb and the manufacturers: override in
-        # .github/routed-drc-tolerance.yml).  Mirrors board 03 (#3150).
         result = subprocess.run(
             [
                 sys.executable,
@@ -3187,6 +3221,9 @@ def run_drc(pcb_path: Path) -> bool:
                 str(pcb_path),
                 "--mfr",
                 "jlcpcb-tier1",
+                "--drc-only",
+                "--output",
+                str(report_path),
             ],
             capture_output=True,
             text=True,
@@ -3196,6 +3233,9 @@ def run_drc(pcb_path: Path) -> bool:
         if result.stdout:
             for line in result.stdout.strip().split("\n"):
                 print(f"   {line}")
+
+        if report_path.is_file():
+            print(f"\n   DRC report: {report_path}")
 
         # Check for success
         if result.returncode == 0:

--- a/boards/05-bldc-motor-controller/output/drc_report.json
+++ b/boards/05-bldc-motor-controller/output/drc_report.json
@@ -1,0 +1,971 @@
+{
+  "file": "/Users/rwalters/GitHub/kicad-tools/.loom/worktrees/issue-3766/boards/05-bldc-motor-controller/output/bldc_controller_routed.kicad_pcb",
+  "manufacturer": "jlcpcb-tier1",
+  "layers": 4,
+  "summary": {
+    "errors": 39,
+    "warnings": 0,
+    "infos": 8,
+    "rules_checked": 33,
+    "rules_checked_by_rule": {
+      "connectivity": 1,
+      "diffpair_clearance_intra": 3
+    },
+    "passed": false
+  },
+  "violations": [
+    {
+      "rule_id": "connectivity",
+      "type": "connectivity",
+      "severity": "error",
+      "message": "Net '+24V' is partially routed: 7 of 13 pads stranded (connected island has 6 pads)",
+      "location": [
+        29.0,
+        8.0
+      ],
+      "layer": null,
+      "actual_value": null,
+      "required_value": null,
+      "items": [
+        "C1.1"
+      ],
+      "nets": [
+        "+24V"
+      ]
+    },
+    {
+      "rule_id": "connectivity",
+      "type": "connectivity",
+      "severity": "error",
+      "message": "Net 'GND' is partially routed: 33 of 36 pads stranded (connected island has 3 pads)",
+      "location": [
+        31.0,
+        8.0
+      ],
+      "layer": null,
+      "actual_value": null,
+      "required_value": null,
+      "items": [
+        "C1.2"
+      ],
+      "nets": [
+        "GND"
+      ]
+    },
+    {
+      "rule_id": "connectivity",
+      "type": "connectivity",
+      "severity": "error",
+      "message": "Net 'ISENSE_A-' is partially routed: 3 of 4 pads stranded (connected island has 1 pads)",
+      "location": [
+        43.1,
+        84.0
+      ],
+      "layer": null,
+      "actual_value": null,
+      "required_value": null,
+      "items": [
+        "R12.2"
+      ],
+      "nets": [
+        "ISENSE_A-"
+      ]
+    },
+    {
+      "rule_id": "connectivity",
+      "type": "connectivity",
+      "severity": "error",
+      "message": "Net 'ISENSE_B+' is partially routed: 3 of 4 pads stranded (connected island has 1 pads)",
+      "location": [
+        20.9,
+        84.0
+      ],
+      "layer": null,
+      "actual_value": null,
+      "required_value": null,
+      "items": [
+        "R11.1"
+      ],
+      "nets": [
+        "ISENSE_B+"
+      ]
+    },
+    {
+      "rule_id": "connectivity",
+      "type": "connectivity",
+      "severity": "error",
+      "message": "Net 'ISENSE_B-' is partially routed: 3 of 4 pads stranded (connected island has 1 pads)",
+      "location": [
+        32.825,
+        40.7
+      ],
+      "layer": null,
+      "actual_value": null,
+      "required_value": null,
+      "items": [
+        "U10.6"
+      ],
+      "nets": [
+        "ISENSE_B-"
+      ]
+    },
+    {
+      "rule_id": "connectivity",
+      "type": "connectivity",
+      "severity": "error",
+      "message": "Net 'ISENSE_C-' is partially routed: 2 of 3 pads stranded (connected island has 1 pads)",
+      "location": [
+        32.825,
+        41.5
+      ],
+      "layer": null,
+      "actual_value": null,
+      "required_value": null,
+      "items": [
+        "U10.7"
+      ],
+      "nets": [
+        "ISENSE_C-"
+      ]
+    },
+    {
+      "rule_id": "connectivity",
+      "type": "connectivity",
+      "severity": "error",
+      "message": "Net 'PHASE_A' is partially routed: 4 of 5 pads stranded (connected island has 1 pads)",
+      "location": [
+        5.0,
+        59.0
+      ],
+      "layer": null,
+      "actual_value": null,
+      "required_value": null,
+      "items": [
+        "C14.2"
+      ],
+      "nets": [
+        "PHASE_A"
+      ]
+    },
+    {
+      "rule_id": "connectivity",
+      "type": "connectivity",
+      "severity": "error",
+      "message": "Net 'PHASE_B' is partially routed: 4 of 5 pads stranded (connected island has 1 pads)",
+      "location": [
+        5.0,
+        53.0
+      ],
+      "layer": null,
+      "actual_value": null,
+      "required_value": null,
+      "items": [
+        "C13.2"
+      ],
+      "nets": [
+        "PHASE_B"
+      ]
+    },
+    {
+      "rule_id": "connectivity",
+      "type": "connectivity",
+      "severity": "error",
+      "message": "Net 'PHASE_C' is partially routed: 4 of 5 pads stranded (connected island has 1 pads)",
+      "location": [
+        5.0,
+        47.0
+      ],
+      "layer": null,
+      "actual_value": null,
+      "required_value": null,
+      "items": [
+        "C12.2"
+      ],
+      "nets": [
+        "PHASE_C"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net 'SWDIO' overlaps zone fill of net '+3V3' on F.Cu (overlap depth 0.013mm)",
+      "location": [
+        64.168,
+        17.376
+      ],
+      "layer": "F.Cu",
+      "actual_value": -0.0129,
+      "required_value": 0.1016,
+      "items": [
+        "J4-2",
+        "ZoneFill-+3V3"
+      ],
+      "nets": [
+        "SWDIO",
+        "+3V3"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net 'SWO' overlaps zone fill of net '+3V3' on F.Cu (overlap depth 0.013mm)",
+      "location": [
+        64.168,
+        22.456
+      ],
+      "layer": "F.Cu",
+      "actual_value": -0.0129,
+      "required_value": 0.1016,
+      "items": [
+        "J4-4",
+        "ZoneFill-+3V3"
+      ],
+      "nets": [
+        "SWO",
+        "+3V3"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net 'PHASE_B' overlaps zone fill of net '+24V' on F.Cu (overlap depth 0.018mm)",
+      "location": [
+        27.414,
+        67.151
+      ],
+      "layer": "F.Cu",
+      "actual_value": -0.0181,
+      "required_value": 0.1016,
+      "items": [
+        "Q3-3",
+        "ZoneFill-+24V"
+      ],
+      "nets": [
+        "PHASE_B",
+        "+24V"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net 'GND' overlaps zone fill of net '+24V' on F.Cu (overlap depth 0.013mm)",
+      "location": [
+        4.168,
+        10.084
+      ],
+      "layer": "F.Cu",
+      "actual_value": -0.0129,
+      "required_value": 0.1016,
+      "items": [
+        "J1-2",
+        "ZoneFill-+24V"
+      ],
+      "nets": [
+        "GND",
+        "+24V"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net 'HALL_C' overlaps zone fill of net '+3V3' on F.Cu (overlap depth 0.013mm)",
+      "location": [
+        64.168,
+        58.814
+      ],
+      "layer": "F.Cu",
+      "actual_value": -0.0129,
+      "required_value": 0.1016,
+      "items": [
+        "J3-3",
+        "ZoneFill-+3V3"
+      ],
+      "nets": [
+        "HALL_C",
+        "+3V3"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net 'PHASE_C' overlaps zone fill of net '+24V' on F.Cu (overlap depth 0.018mm)",
+      "location": [
+        9.666,
+        68.849
+      ],
+      "layer": "F.Cu",
+      "actual_value": -0.0181,
+      "required_value": 0.1016,
+      "items": [
+        "Q1-3",
+        "ZoneFill-+24V"
+      ],
+      "nets": [
+        "PHASE_C",
+        "+24V"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net 'PHASE_C' overlaps zone fill of net '+24V' on F.Cu (overlap depth 0.018mm)",
+      "location": [
+        11.414,
+        67.151
+      ],
+      "layer": "F.Cu",
+      "actual_value": -0.0181,
+      "required_value": 0.1016,
+      "items": [
+        "Q1-3",
+        "ZoneFill-+24V"
+      ],
+      "nets": [
+        "PHASE_C",
+        "+24V"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net 'SWDIO' overlaps zone fill of net 'GND' on B.Cu (overlap depth 0.013mm)",
+      "location": [
+        65.832,
+        19.004
+      ],
+      "layer": "B.Cu",
+      "actual_value": -0.0129,
+      "required_value": 0.1016,
+      "items": [
+        "J4-2",
+        "ZoneFill-GND"
+      ],
+      "nets": [
+        "SWDIO",
+        "GND"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net 'SWCLK' overlaps zone fill of net 'GND' on B.Cu (overlap depth 0.013mm)",
+      "location": [
+        65.832,
+        21.544
+      ],
+      "layer": "B.Cu",
+      "actual_value": -0.0129,
+      "required_value": 0.1016,
+      "items": [
+        "J4-3",
+        "ZoneFill-GND"
+      ],
+      "nets": [
+        "SWCLK",
+        "GND"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net 'SWO' overlaps zone fill of net 'GND' on B.Cu (overlap depth 0.013mm)",
+      "location": [
+        65.832,
+        24.084
+      ],
+      "layer": "B.Cu",
+      "actual_value": -0.0129,
+      "required_value": 0.1016,
+      "items": [
+        "J4-4",
+        "ZoneFill-GND"
+      ],
+      "nets": [
+        "SWO",
+        "GND"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net 'NRST' overlaps zone fill of net 'GND' on B.Cu (overlap depth 0.013mm)",
+      "location": [
+        65.832,
+        24.996
+      ],
+      "layer": "B.Cu",
+      "actual_value": -0.0129,
+      "required_value": 0.1016,
+      "items": [
+        "J4-5",
+        "ZoneFill-GND"
+      ],
+      "nets": [
+        "NRST",
+        "GND"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net 'PHASE_B' overlaps zone fill of net 'GND' on B.Cu (overlap depth 0.018mm)",
+      "location": [
+        24.874,
+        75.151
+      ],
+      "layer": "B.Cu",
+      "actual_value": -0.0181,
+      "required_value": 0.1016,
+      "items": [
+        "Q4-2",
+        "ZoneFill-GND"
+      ],
+      "nets": [
+        "PHASE_B",
+        "GND"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net 'ISENSE_B+' overlaps zone fill of net 'GND' on B.Cu (overlap depth 0.018mm)",
+      "location": [
+        27.414,
+        75.151
+      ],
+      "layer": "B.Cu",
+      "actual_value": -0.0181,
+      "required_value": 0.1016,
+      "items": [
+        "Q4-3",
+        "ZoneFill-GND"
+      ],
+      "nets": [
+        "ISENSE_B+",
+        "GND"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net 'OSC_IN' overlaps zone fill of net 'GND' on B.Cu (overlap depth 0.003mm)",
+      "location": [
+        50.306,
+        37.743
+      ],
+      "layer": "B.Cu",
+      "actual_value": -0.0025,
+      "required_value": 0.1016,
+      "items": [
+        "Y1-1",
+        "ZoneFill-GND"
+      ],
+      "nets": [
+        "OSC_IN",
+        "GND"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net 'OSC_OUT' overlaps zone fill of net 'GND' on B.Cu (overlap depth 0.003mm)",
+      "location": [
+        55.186,
+        37.743
+      ],
+      "layer": "B.Cu",
+      "actual_value": -0.0025,
+      "required_value": 0.1016,
+      "items": [
+        "Y1-2",
+        "ZoneFill-GND"
+      ],
+      "nets": [
+        "OSC_OUT",
+        "GND"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net 'PHASE_C' overlaps zone fill of net 'GND' on B.Cu (overlap depth 0.018mm)",
+      "location": [
+        7.126,
+        76.849
+      ],
+      "layer": "B.Cu",
+      "actual_value": -0.0181,
+      "required_value": 0.1016,
+      "items": [
+        "Q2-2",
+        "ZoneFill-GND"
+      ],
+      "nets": [
+        "PHASE_C",
+        "GND"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net 'ISENSE_C+' overlaps zone fill of net 'GND' on B.Cu (overlap depth 0.018mm)",
+      "location": [
+        9.666,
+        76.849
+      ],
+      "layer": "B.Cu",
+      "actual_value": -0.0181,
+      "required_value": 0.1016,
+      "items": [
+        "Q2-3",
+        "ZoneFill-GND"
+      ],
+      "nets": [
+        "ISENSE_C+",
+        "GND"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net '+24V' overlaps zone fill of net 'GND' on B.Cu (overlap depth 0.018mm)",
+      "location": [
+        24.874,
+        67.151
+      ],
+      "layer": "B.Cu",
+      "actual_value": -0.0181,
+      "required_value": 0.1016,
+      "items": [
+        "Q3-2",
+        "ZoneFill-GND"
+      ],
+      "nets": [
+        "+24V",
+        "GND"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net 'PHASE_B' overlaps zone fill of net 'GND' on B.Cu (overlap depth 0.018mm)",
+      "location": [
+        27.414,
+        67.151
+      ],
+      "layer": "B.Cu",
+      "actual_value": -0.0181,
+      "required_value": 0.1016,
+      "items": [
+        "Q3-3",
+        "ZoneFill-GND"
+      ],
+      "nets": [
+        "PHASE_B",
+        "GND"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net 'PHASE_A' overlaps zone fill of net 'GND' on B.Cu (overlap depth 0.018mm)",
+      "location": [
+        40.874,
+        75.151
+      ],
+      "layer": "B.Cu",
+      "actual_value": -0.0181,
+      "required_value": 0.1016,
+      "items": [
+        "Q6-2",
+        "ZoneFill-GND"
+      ],
+      "nets": [
+        "PHASE_A",
+        "GND"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net 'ISENSE_A+' overlaps zone fill of net 'GND' on B.Cu (overlap depth 0.018mm)",
+      "location": [
+        41.666,
+        76.849
+      ],
+      "layer": "B.Cu",
+      "actual_value": -0.0181,
+      "required_value": 0.1016,
+      "items": [
+        "Q6-3",
+        "ZoneFill-GND"
+      ],
+      "nets": [
+        "ISENSE_A+",
+        "GND"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net '+24V' overlaps zone fill of net 'GND' on B.Cu (overlap depth 0.018mm)",
+      "location": [
+        40.874,
+        67.151
+      ],
+      "layer": "B.Cu",
+      "actual_value": -0.0181,
+      "required_value": 0.1016,
+      "items": [
+        "Q5-2",
+        "ZoneFill-GND"
+      ],
+      "nets": [
+        "+24V",
+        "GND"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net 'PHASE_A' overlaps zone fill of net 'GND' on B.Cu (overlap depth 0.018mm)",
+      "location": [
+        43.414,
+        67.151
+      ],
+      "layer": "B.Cu",
+      "actual_value": -0.0181,
+      "required_value": 0.1016,
+      "items": [
+        "Q5-3",
+        "ZoneFill-GND"
+      ],
+      "nets": [
+        "PHASE_A",
+        "GND"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net 'HALL_B' overlaps zone fill of net 'GND' on B.Cu (overlap depth 0.013mm)",
+      "location": [
+        65.832,
+        56.274
+      ],
+      "layer": "B.Cu",
+      "actual_value": -0.0129,
+      "required_value": 0.1016,
+      "items": [
+        "J3-2",
+        "ZoneFill-GND"
+      ],
+      "nets": [
+        "HALL_B",
+        "GND"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net 'HALL_C' overlaps zone fill of net 'GND' on B.Cu (overlap depth 0.013mm)",
+      "location": [
+        65.832,
+        57.186
+      ],
+      "layer": "B.Cu",
+      "actual_value": -0.0129,
+      "required_value": 0.1016,
+      "items": [
+        "J3-3",
+        "ZoneFill-GND"
+      ],
+      "nets": [
+        "HALL_C",
+        "GND"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net '+3V3' overlaps zone fill of net 'GND' on B.Cu (overlap depth 0.013mm)",
+      "location": [
+        65.832,
+        59.726
+      ],
+      "layer": "B.Cu",
+      "actual_value": -0.0129,
+      "required_value": 0.1016,
+      "items": [
+        "J3-4",
+        "ZoneFill-GND"
+      ],
+      "nets": [
+        "+3V3",
+        "GND"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net '+24V' overlaps zone fill of net 'GND' on B.Cu (overlap depth 0.018mm)",
+      "location": [
+        7.126,
+        68.849
+      ],
+      "layer": "B.Cu",
+      "actual_value": -0.0181,
+      "required_value": 0.1016,
+      "items": [
+        "Q1-2",
+        "ZoneFill-GND"
+      ],
+      "nets": [
+        "+24V",
+        "GND"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net 'PHASE_C' overlaps zone fill of net 'GND' on B.Cu (overlap depth 0.018mm)",
+      "location": [
+        9.666,
+        68.849
+      ],
+      "layer": "B.Cu",
+      "actual_value": -0.0181,
+      "required_value": 0.1016,
+      "items": [
+        "Q1-3",
+        "ZoneFill-GND"
+      ],
+      "nets": [
+        "PHASE_C",
+        "GND"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net 'PHASE_B' overlaps zone fill of net 'GND' on B.Cu (overlap depth 0.013mm)",
+      "location": [
+        65.832,
+        75.186
+      ],
+      "layer": "B.Cu",
+      "actual_value": -0.0129,
+      "required_value": 0.1016,
+      "items": [
+        "J2-2",
+        "ZoneFill-GND"
+      ],
+      "nets": [
+        "PHASE_B",
+        "GND"
+      ]
+    },
+    {
+      "rule_id": "clearance_pad_zone",
+      "type": "clearance",
+      "severity": "error",
+      "message": "Short: pad on net 'PHASE_A' overlaps zone fill of net 'GND' on B.Cu (overlap depth 0.013mm)",
+      "location": [
+        65.832,
+        77.726
+      ],
+      "layer": "B.Cu",
+      "actual_value": -0.0129,
+      "required_value": 0.1016,
+      "items": [
+        "J2-3",
+        "ZoneFill-GND"
+      ],
+      "nets": [
+        "PHASE_A",
+        "GND"
+      ]
+    },
+    {
+      "rule_id": "single_pad_net",
+      "type": "single_pad_net",
+      "severity": "info",
+      "message": "Net 'unconnected-(U10-PA3-Pad8)' has only 1 pad on U10-8 -- KiCad-emitted explicit no-connect (symbol pin marked NC); no action required",
+      "location": [
+        32.825,
+        42.3
+      ],
+      "layer": null,
+      "actual_value": null,
+      "required_value": null,
+      "items": [
+        "U10-8"
+      ],
+      "nets": [
+        "unconnected-(U10-PA3-Pad8)"
+      ]
+    },
+    {
+      "rule_id": "single_pad_net",
+      "type": "single_pad_net",
+      "severity": "info",
+      "message": "Net 'unconnected-(U10-PA4-Pad9)' has only 1 pad on U10-9 -- KiCad-emitted explicit no-connect (symbol pin marked NC); no action required",
+      "location": [
+        34.2,
+        43.675
+      ],
+      "layer": null,
+      "actual_value": null,
+      "required_value": null,
+      "items": [
+        "U10-9"
+      ],
+      "nets": [
+        "unconnected-(U10-PA4-Pad9)"
+      ]
+    },
+    {
+      "rule_id": "single_pad_net",
+      "type": "single_pad_net",
+      "severity": "info",
+      "message": "Net 'unconnected-(U10-PA5-Pad10)' has only 1 pad on U10-10 -- KiCad-emitted explicit no-connect (symbol pin marked NC); no action required",
+      "location": [
+        35.0,
+        43.675
+      ],
+      "layer": null,
+      "actual_value": null,
+      "required_value": null,
+      "items": [
+        "U10-10"
+      ],
+      "nets": [
+        "unconnected-(U10-PA5-Pad10)"
+      ]
+    },
+    {
+      "rule_id": "single_pad_net",
+      "type": "single_pad_net",
+      "severity": "info",
+      "message": "Net 'unconnected-(U10-PA11-Pad21)' has only 1 pad on U10-21 -- KiCad-emitted explicit no-connect (symbol pin marked NC); no action required",
+      "location": [
+        41.175,
+        39.1
+      ],
+      "layer": null,
+      "actual_value": null,
+      "required_value": null,
+      "items": [
+        "U10-21"
+      ],
+      "nets": [
+        "unconnected-(U10-PA11-Pad21)"
+      ]
+    },
+    {
+      "rule_id": "single_pad_net",
+      "type": "single_pad_net",
+      "severity": "info",
+      "message": "Net 'unconnected-(U10-PA12-Pad22)' has only 1 pad on U10-22 -- KiCad-emitted explicit no-connect (symbol pin marked NC); no action required",
+      "location": [
+        41.175,
+        38.3
+      ],
+      "layer": null,
+      "actual_value": null,
+      "required_value": null,
+      "items": [
+        "U10-22"
+      ],
+      "nets": [
+        "unconnected-(U10-PA12-Pad22)"
+      ]
+    },
+    {
+      "rule_id": "single_pad_net",
+      "type": "single_pad_net",
+      "severity": "info",
+      "message": "Net 'unconnected-(U10-PA15-Pad25)' has only 1 pad on U10-25 -- KiCad-emitted explicit no-connect (symbol pin marked NC); no action required",
+      "location": [
+        39.8,
+        35.325
+      ],
+      "layer": null,
+      "actual_value": null,
+      "required_value": null,
+      "items": [
+        "U10-25"
+      ],
+      "nets": [
+        "unconnected-(U10-PA15-Pad25)"
+      ]
+    },
+    {
+      "rule_id": "single_pad_net",
+      "type": "single_pad_net",
+      "severity": "info",
+      "message": "Net 'unconnected-(U10-PB4-Pad27)' has only 1 pad on U10-27 -- KiCad-emitted explicit no-connect (symbol pin marked NC); no action required",
+      "location": [
+        38.2,
+        35.325
+      ],
+      "layer": null,
+      "actual_value": null,
+      "required_value": null,
+      "items": [
+        "U10-27"
+      ],
+      "nets": [
+        "unconnected-(U10-PB4-Pad27)"
+      ]
+    },
+    {
+      "rule_id": "single_pad_net",
+      "type": "single_pad_net",
+      "severity": "info",
+      "message": "Net 'unconnected-(U10-PB5-Pad28)' has only 1 pad on U10-28 -- KiCad-emitted explicit no-connect (symbol pin marked NC); no action required",
+      "location": [
+        37.4,
+        35.325
+      ],
+      "layer": null,
+      "actual_value": null,
+      "required_value": null,
+      "items": [
+        "U10-28"
+      ],
+      "nets": [
+        "unconnected-(U10-PB5-Pad28)"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Board-05's ship-ready DRC leg showed `-` because `run_drc` in `design.py` only printed `kct check` to stdout and never wrote `output/drc_report.json` (the sidecar `fleet_cmd._detect_drc` looks for). This PR fixes that, and documents a load-bearing investigation result: **PHASE_A/B/C connectivity on board-05 is placement-bound, not a recipe bug**, so the routing half of #3766 is deferred to follow-up #3775 rather than shipped as a regression.

This is a partial delivery of #3766: the DRC sidecar (a curator-required deliverable) is done; the PHASE-connectivity requirement is justify-and-deferred with a measured rationale and a tracked follow-up (#3775), because closing it on the current placement regresses the board.

## Changes

- **`design.py` `run_drc`**: now writes `output/drc_report.json` via `kct check <pcb> --mfr jlcpcb-tier1 --drc-only --output ...`, mirroring boards 03 (#3764) / 04 (#3765). `--drc-only` scopes copper-LVS (#3772) and the LVS leg (#3762) out of the gate.
- **`output/drc_report.json`** (new): measured against the **committed** routed PCB. 39 errors = 30 `clearance_pad_zone` (exactly the `.github/routed-drc-tolerance.yml` allowlist of 30 — all grandfathered #3556 pad-vs-stale-pour-copper) + 9 advisory `connectivity` + 8 `single_pad_net` infos. Deterministic across re-runs.
- **`design.py` / `README.md` comments**: document why PHASE_A/B/C cannot be closed in-scope (see below). No functional routing change — `skip_nets` and `_RESCUE_EXCLUDED_NETS` keep their committed values, so the committed routing artifacts are **unchanged** (no regression).

## Why PHASE is deferred (measured, not assumed)

The curator offered two options: pour PHASE (Option A, preferred) or route as wide traces (Option B). Both fail on this board:

- **Pours don't work.** PHASE_x is classified `HIGH_CURRENT_SIGNAL` with `is_pour_net=False` ("phase outputs must NOT be poured"). And the FET->motor PHASE pads are scattered across the whole 70x90 mm board, so a per-net bounding-box pour island spans the board and **shorts the rail pours** (confirmed: priority-10 PHASE islands zeroed the +24V/+5V/+3V3 F.Cu copper).
- **Routing as traces regresses the board.** Removing PHASE from `skip_nets`/`_RESCUE_EXCLUDED_NETS` does connect PHASE_A/B/C, but the extra high-current traces consume the U3 (DRV8301, 0.5mm-pitch) south escape band that ISENSE/PWM/GATE_DRV/BST also use. **Two full seed-7 regens** (C++ backend, jlcpcb-tier1, 4-layer) both measured **9 blocking signal nets vs the committed 7** — PHASE closes but BST_A/GATE_DRV_CH/NRST/PWM_BH (previously complete) regress, and the ISENSE cluster stays open. The #3471 rescue loop recovered only 3/12 displaced nets.

Net: closing PHASE needs a targeted U3-south relayout, which is explicitly out of scope here. Filed as **#3775** (`loom:architect`).

### Host-vs-CI divergence surfaced (per curator caveat)

A fresh end-to-end regen on this host diverges materially from the committed CI artifact (130-143/206 pads with PHASE routed, and with shapely-absent zone fill it produced 34 `clearance_pad_zone` + 4 `clearance_pad_segment`). Per the curator's instruction, I did **not** silently commit the divergent snapshot — the committed routing is left as-is and the DRC sidecar is measured against it.

## Acceptance Criteria Verification

| Criterion (from #3766) | Status | Verification |
|---|---|---|
| PHASE_A/B/C connected (required) | ⚠️ Deferred | Measured infeasible in-scope (pours short rails; traces regress 4 nets). Justify-and-defer → follow-up #3775. |
| ISENSE: drive fresh regen, land what's feasible / justify-defer rest | ✅ | Two seed-7 regens; ISENSE cluster congestion-bound, deferred with #3775. |
| Fresh `drc_report.json` generated & committed; DRC leg `-` → PASS/FAIL | ✅ | Committed; ship-ready board-05 DRC now `39` (30 blocking = within tolerance) instead of `-`. |
| No regression on the other 7 boards | ✅ | `kct fleet ship-ready` unchanged for boards 00-04, 06, 07 (all PASS). |
| Divergence surfaced not silently committed | ✅ | Committed routing unchanged; divergence documented above. |
| Changes confined to board 05 | ✅ | Only `boards/05-*/` touched. |

## Test Plan

- `uv run kct build-native --check` → C++ backend available (v1.0.0).
- `uv run kct fleet ship-ready --boards-dir boards` → board-05 `143/206  39  FAIL (7/52 nets)`; DRC leg populated; other 7 boards PASS.
- `uv run pytest tests/test_board_05_zones.py tests/test_board_05_drc_hotspot_regression.py tests/test_board_05_drc_allowlist.py` → 13 passed (committed artifact unchanged).
- `uv run ruff check` / `ruff format --check` on `design.py` → clean.
- DRC sidecar verified deterministic (39 errors across two runs).

Refs #3766

> Judge note: changed `Closes #3766` -> `Refs #3766`. The issue's
> **required** deliverable (PHASE_A/B/C connected) is not met by this PR;
> only the DRC sidecar landed. The required routing work is tracked by
> follow-up #3775 (`loom:architect`). #3766 stays open behind it.
