### PR TITLE
fix(connectivity): union pour pads across all fill islands of one zone

### DIFF
--- a/src/kicad_tools/validate/connectivity.py
+++ b/src/kicad_tools/validate/connectivity.py
@@ -984,7 +984,7 @@ class ConnectivityValidator:
         """Union pads bonded to the same poured copper island (label-free).
 
         For every ``filled_polygon`` of every zone, build the hole-aware
-        solid region (:meth:`_fill_solid_region`) and union all pads whose
+        solid region (:meth:`_fill_solid_region`) and collect all pads whose
         *copper geometry* overlaps that region on a matching copper layer.  No
         pad/zone ``net_name`` is consulted — pads are tied solely by shared
         metal, so a pad moated out of a pour is left isolated and a
@@ -995,6 +995,19 @@ class ConnectivityValidator:
         sits in the antipad hole, but its copper edge reaches the thermal
         spokes / solid pour, so the box intersects the solid region while the
         center alone would (wrongly) read as moated-out.
+
+        Bonded pads are accumulated **per ``zone`` object across all of its
+        ``filled_polygon`` indices**, then unioned once per zone — not per
+        fill index.  KiCad stores a single poured zone as multiple
+        ``filled_polygon`` entries when thermal reliefs / clearance moats
+        fragment the copper (e.g. board 03's GND F.Cu zone is one main pour
+        plus a dozen tiny per-pad fragments).  All fragments of one ``zone``
+        are the same net by KiCad's data model — DRC guarantees retained
+        fragments are electrically bonded — so unioning across a zone's fill
+        islands cannot fuse two different nets (those are different ``zone``
+        objects).  Without this, a pad alone in its own thermal-relief
+        fragment would land in a singleton component and be reported as a
+        false ``open``.
         """
         # Board-frame pad copper polygons, keyed by pad id.  Built once here
         # so each fill island can be tested against every candidate pad.
@@ -1012,12 +1025,17 @@ class ConnectivityValidator:
         for zone in self.pcb.zones:
             if not zone.filled_polygons:
                 continue
+            # Accumulate the bonded-pad set across ALL fill islands of this
+            # zone (see method docstring): the zone is one net, and KiCad may
+            # fragment its pour into many ``filled_polygon`` entries.  Order is
+            # preserved and duplicates are dropped before unioning so a pad
+            # bonded to several fragments is unioned exactly once.
+            zone_bonded: list[str] = []
             for i, fill_pts in enumerate(zone.filled_polygons):
                 region = self._fill_solid_region(fill_pts)
                 if region is None:
                     continue
                 fill_layer = zone.filled_polygon_layer(i)
-                bonded: list[str] = []
                 for pad_id in pad_positions:
                     if not self._pad_layer_matches_zone(pad_layers.get(pad_id, []), fill_layer):
                         continue
@@ -1037,10 +1055,19 @@ class ConnectivityValidator:
                     # removes all spurious multi-net bridges while preserving
                     # board 00's genuine thermal-relief ties.
                     if region.intersects(pad_geom):
-                        bonded.append(pad_id)
-                for a, p in enumerate(bonded):
-                    for other in bonded[a + 1 :]:
-                        connect(p, other)
+                        zone_bonded.append(pad_id)
+            # De-duplicate preserving first-seen order, then union the whole
+            # zone's bonded set so pads on disjoint fill fragments of one zone
+            # share a single component.
+            seen: set[str] = set()
+            bonded: list[str] = []
+            for pad_id in zone_bonded:
+                if pad_id not in seen:
+                    seen.add(pad_id)
+                    bonded.append(pad_id)
+            for a, p in enumerate(bonded):
+                for other in bonded[a + 1 :]:
+                    connect(p, other)
 
     def _connect_pour_pads_by_declared_net(
         self,

--- a/tests/test_copper_lvs.py
+++ b/tests/test_copper_lvs.py
@@ -713,6 +713,97 @@ def test_pour_extraction_ignores_zone_and_pad_net_labels(tmp_path: Path) -> None
     assert any("R2.1" in c for c in partition)
 
 
+def _pcb_pour_two_disjoint_islands() -> str:
+    """One GND zone whose fill is two DISJOINT same-net islands, one pad each.
+
+    Distilled from board 03: KiCad stores a single poured zone as many
+    ``filled_polygon`` entries when thermal reliefs / clearance moats fragment
+    the copper.  Here the GND F.Cu zone is filled as two separate solid squares
+    that do not touch (a 4 mm gap between them):
+
+    * island A: solid copper 0..4 in x, bonding ``C1`` pad "2" at board (2, 2)
+    * island B: solid copper 8..12 in x, bonding ``C2`` pad "2" at board (10, 2)
+
+    Both pads are declared GND and both sit squarely in solid copper, so the
+    bonding *test* (``region.intersects`` of the eroded pad box) succeeds for
+    each — there is no moat involved.  The ONLY thing under test is whether the
+    extractor unions pads across the zone's two disjoint fill islands.
+
+    * Per-fill (the #3769 bug): C1.2 bonds only within island A, C2.2 only
+      within island B -> two singleton components -> a false GND open.
+    * Per-zone (the fix): both pads are accumulated for the one ``zone`` object
+      and unioned together -> a single GND component -> clean.
+    """
+    return """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "Capacitor_SMD:C_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000b1")
+    (at 2 2)
+    (property "Reference" "C1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "fp-b1-ref"))
+    (property "Value" "100n" (at 0 1.5 0) (layer "F.Fab") (uuid "fp-b1-val"))
+    (pad "2" smd roundrect (at 0 0) (size 1.5 1.5) (layers "F.Cu" "F.Paste" "F.Mask")
+      (roundrect_rratio 0.25) (net 1 "GND"))
+  )
+  (footprint "Capacitor_SMD:C_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000b2")
+    (at 10 2)
+    (property "Reference" "C2" (at 0 -1.5 0) (layer "F.SilkS") (uuid "fp-b2-ref"))
+    (property "Value" "100n" (at 0 1.5 0) (layer "F.Fab") (uuid "fp-b2-val"))
+    (pad "2" smd roundrect (at 0 0) (size 1.5 1.5) (layers "F.Cu" "F.Paste" "F.Mask")
+      (roundrect_rratio 0.25) (net 1 "GND"))
+  )
+  (zone
+    (net 1 "GND")
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000z2")
+    (hatch edge 0.5)
+    (connect_pads (clearance 0.2))
+    (min_thickness 0.2)
+    (fill yes (thermal_gap 0.2) (thermal_bridge_width 0.3))
+    (polygon (pts (xy 0 0) (xy 12 0) (xy 12 4) (xy 0 4)))
+    (filled_polygon (layer "F.Cu") (pts (xy 0 0) (xy 4 0) (xy 4 4) (xy 0 4)))
+    (filled_polygon (layer "F.Cu") (pts (xy 8 0) (xy 12 0) (xy 12 4) (xy 8 4)))
+  )
+)
+"""
+
+
+@requires_shapely
+def test_pour_extraction_unions_pads_across_disjoint_fill_islands_of_one_zone(
+    tmp_path: Path,
+) -> None:
+    """Regression (#3772): one zone, two disjoint fill islands -> one component.
+
+    KiCad fragments a single poured zone into multiple ``filled_polygon``
+    entries (board 03's GND F.Cu zone is one main pour plus a dozen tiny
+    per-pad fragments).  The pre-fix extractor unioned bonded pads only WITHIN
+    a single fill index, so a pad alone in its own fragment landed in a
+    singleton component and copper-LVS reported it as a false ``open``.
+
+    This fixture is that failure shape distilled: two GND pads, each bonded to
+    a *different* disjoint fill island of the SAME ``zone`` object.  Both must
+    land in one connected component.  FAILS on origin/main (per-fill unioning
+    splits them); PASSES after the per-zone unioning fix.
+    """
+    pcb_path = _write(tmp_path, "two_islands.kicad_pcb", _pcb_pour_two_disjoint_islands())
+    partition = ConnectivityValidator(pcb_path).extract_pad_partition()
+    component = next(c for c in partition if "C1.2" in c)
+    assert {"C1.2", "C2.2"} <= component, (
+        "pads bonded to disjoint fill islands of the same zone must share one "
+        f"component (no false open); partition={partition}"
+    )
+
+
 @requires_shapely
 def test_compare_copper_netlist_on_pour_heavy_board07_artifacts() -> None:
     """End-to-end: the label-free pour model stays clean on a pour-heavy board.


### PR DESCRIPTION
## Summary

Pour-served power pads (GND/VCC/VBUS) were being reported as false copper-LVS `open`s on boards whose power pours KiCad fragments into multiple `filled_polygon` entries. The label-free pour extractor from #3769 unioned bonded pads only *within* a single fill index, so a pad alone in its own thermal-relief fragment landed in a singleton connected component and read as `open`.

Root cause (confirmed by the curator on origin/main): board 03's GND F.Cu zone is stored as 13 separate `filled_polygon` entries — one main pour plus 12 tiny per-pad fragments. A `zone` is one net by KiCad's data model, but the extractor never unioned the fill islands of a single zone.

## Changes

- `src/kicad_tools/validate/connectivity.py` — `_connect_pour_pads_label_free()`: accumulate the bonded-pad set **per `zone` object across all of its `filled_polygon` indices**, de-duplicate preserving order, then union once per zone (instead of per fill index). The bonding *test* (eroded pad box vs hole-aware solid region from #3769) is unchanged, so the anti-false-short property is preserved. Docstring updated to state that fill islands of one zone are one electrical net.
- `tests/test_copper_lvs.py` — new `@requires_shapely` regression: one GND zone with two **disjoint** same-net fill islands, each bonding a distinct GND power pad; asserts both pads share one component. Fails on origin/main (per-fill unioning splits them), passes with the fix.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Board 03 opens drop 15 → 2 | ✅ | `compare_copper_netlist` on board 03: opens 2, shorts 0 |
| 2 residual opens are J1 USB-C (out of scope) | ✅ | Only J1.A12 / J1.B1 remain (F.Cu-only pads over B.Cu pour, no via) |
| Zero new shorts on any board | ✅ | 00: 0, 03: 0, 04: 1, 05: 18 — all unchanged from baseline |
| Board 00 stays clean | ✅ | opens 0 / shorts 0 / clean=True |
| Board 05 opens improve 87 → 78 | ✅ | `compare_copper_netlist` on board 05: opens 78, shorts 18 |
| Four #3769 adversarial pour tests still pass | ✅ | GND/SIG short + moated-out GND open still flagged |
| New regression pins two-disjoint-islands-one-zone case | ✅ | Fails pre-fix, passes post-fix (verified by git stash) |
| Fix is purely geometric/per-zone (label-free preserved) | ✅ | No pad/zone `net_name` consulted in bonding; shapely-absent fallback untouched |

## Test Plan

- `uv run pytest tests/test_copper_lvs.py` — 25 passed (24 existing + new regression).
- `uv run pytest tests/test_copper_lvs.py tests/test_connectivity.py tests/test_lvs.py tests/test_board_00_lvs.py` — 113 passed.
- New test verified to FAIL on origin/main connectivity (stashed the source change) and PASS with the fix.
- Board-level `compare_copper_netlist` run for 00/03/04/05 (see table above).
- `uv run ruff check .` clean; `ruff format --check` clean; `mypy` introduces no new errors (the 12 remaining are pre-existing on main, lines 629–705, unrelated to this change).

Closes #3772