### PR TITLE
fix(zones): carve foreign-net track segments out of zone fills

### DIFF
--- a/src/kicad_tools/cli/stitch_cmd.py
+++ b/src/kicad_tools/cli/stitch_cmd.py
@@ -4333,6 +4333,44 @@ def run_stitch(
     return result
 
 
+def _carve_foreign_copper_after_stitch(pcb_path: Path) -> None:
+    """Re-carve foreign-net copper out of zone fills after stitching.
+
+    Issue #3773: ``kct stitch`` adds GND vias and pad-to-via trace segments
+    that cross the existing rail pours (e.g. ``+3.3V`` / ``+5V`` F.Cu), but
+    it does not refill the zones.  The freshly added GND copper is therefore
+    left embedded in the rail fill, producing ``clearance_via_zone`` and
+    ``clearance_segment_zone`` shorts on a fresh board regen.
+
+    :func:`apply_foreign_pad_clearance` subtracts an antipad around every
+    foreign-net pad, via, **and** track segment from each committed
+    ``filled_polygon`` (the segment branch added in issue #3773), so it
+    cleanly removes the new GND copper from the rail pour.  It edits the
+    parsed S-expression directly (no kicad-cli refill, so the post-route
+    carve is preserved) and is a no-op when shapely is unavailable.
+    """
+    try:
+        from kicad_tools.core.sexp_file import load_pcb, save_pcb
+        from kicad_tools.zones.fill_clearance import apply_foreign_pad_clearance
+    except ImportError:
+        return
+    try:
+        doc = load_pcb(pcb_path)
+        modified = apply_foreign_pad_clearance(doc)
+    except Exception as exc:  # pragma: no cover - defensive guard
+        print(
+            f"\nWarning: post-stitch zone-fill clearance carve skipped ({exc}).",
+            file=sys.stderr,
+        )
+        return
+    if modified:
+        save_pcb(doc, pcb_path)
+        print(
+            f"  ~ Carved foreign-net copper out of {modified} zone fill(s) "
+            "(post-stitch clearance correction)"
+        )
+
+
 def run_post_stitch_drc(pcb_path: Path) -> int:
     """Run DRC on the PCB after stitching and display summary.
 
@@ -4879,6 +4917,19 @@ def main(argv: list[str] | None = None) -> int:
             )
 
         output_result(result, dry_run=args.dry_run, run_drc=args.drc, edited_path=pcb_path)
+
+        # Issue #3773: stitching adds new foreign-net copper (GND vias and
+        # pad-to-via trace segments) *across* the existing rail pours, but
+        # does not refill the zones (a refill would revert the post-route
+        # foreign-pad clearance carve).  Without re-carving, those new GND
+        # vias/segments stay embedded in the +3.3V/+5V fill, producing
+        # ``clearance_via_zone`` / ``clearance_segment_zone`` shorts on a
+        # fresh regen.  Re-apply the pure-Python carve here so the existing
+        # fill clears the freshly added GND copper too.  It operates only on
+        # the committed ``filled_polygon`` geometry (no kicad-cli refill, so
+        # route's carve is preserved) and is a no-op when shapely is absent.
+        if not args.dry_run and result.vias_added:
+            _carve_foreign_copper_after_stitch(pcb_path)
 
         # Run DRC if requested (and not dry run, and vias were actually added)
         if args.drc and not args.dry_run and result.vias_added:

--- a/src/kicad_tools/zones/fill_clearance.py
+++ b/src/kicad_tools/zones/fill_clearance.py
@@ -131,7 +131,10 @@ def _collect_obstacles(
     are modelled by their circular barrel.  Net-0 (unassigned) copper is
     skipped — it does not participate in clearance checks.
     """
-    from shapely.geometry import Point  # type: ignore[import-untyped]
+    from shapely.geometry import (  # type: ignore[import-untyped]
+        LineString,
+        Point,
+    )
 
     obstacles: list[_Obstacle] = []
 
@@ -227,6 +230,37 @@ def _collect_obstacles(
         )
         shape = Point(cx, cy).buffer(diameter / 2.0)
         obstacles.append(_Obstacle(net_key=net_key, layers=tuple(via_layers), shape=shape))
+
+    # --- Track segments (top level) ---
+    # A foreign-net trace routed across a pour is copper the fill must clear,
+    # exactly like a foreign pad or via.  We model the segment by its buffered
+    # centreline (a half-width-radius capsule) on its single copper layer,
+    # mirroring the same-net anchor geometry in ``_collect_same_net_anchors``.
+    # Without this branch a GND trace crossing a +3.3V/+5V pour stays embedded
+    # in the rail copper and ``SegmentZoneClearanceRule`` reports a short
+    # (issue #3773).
+    for seg in doc.find_all("segment"):
+        net_key = _net_key(seg.find("net"), name_map)
+        if net_key is None:
+            continue
+        layer_node = seg.find("layer")
+        layer = layer_node.get_string(0) if layer_node is not None else None
+        if not layer:
+            continue
+        start = seg.find("start")
+        end = seg.find("end")
+        if start is None or end is None:
+            continue
+        sx = start.get_float(0) or 0.0
+        sy = start.get_float(1) or 0.0
+        ex = end.get_float(0) or 0.0
+        ey = end.get_float(1) or 0.0
+        width_node = seg.find("width")
+        width = (width_node.get_float(0) if width_node is not None else None) or 0.0
+        if width <= 0:
+            continue
+        shape = LineString([(sx, sy), (ex, ey)]).buffer(width / 2.0)
+        obstacles.append(_Obstacle(net_key=net_key, layers=(layer,), shape=shape))
 
     return obstacles
 

--- a/tests/test_stitch_cmd.py
+++ b/tests/test_stitch_cmd.py
@@ -1,5 +1,6 @@
 """Tests for the kicad-pcb-stitch CLI command."""
 
+import importlib.util
 import math
 from pathlib import Path
 
@@ -13,6 +14,7 @@ from kicad_tools.cli.stitch_cmd import (
     TrackSegment,
     ViaPlacement,
     ZonePolygon,
+    _carve_foreign_copper_after_stitch,
     _is_ground_net,
     _should_use_stackup_fallback,
     calculate_dogleg_via_position,
@@ -6085,3 +6087,108 @@ class TestCrossNetTraceCoCheck:
                     f"NETB via at ({vb.via_x}, {vb.via_y}) violates NETA stitch "
                     f"trace clearance: {dist:.4f} < {required:.4f}"
                 )
+
+
+class TestPostStitchForeignCopperCarve:
+    """Issue #3773: re-carve foreign-net copper out of zone fills after stitch.
+
+    ``kct stitch`` adds GND vias and pad-to-via trace segments across the
+    existing rail pours but does not refill the zones, leaving the new GND
+    copper embedded in the +3.3V/+5V fill (clearance_via_zone /
+    clearance_segment_zone shorts on a fresh regen).
+    ``_carve_foreign_copper_after_stitch`` re-applies the pure-Python
+    foreign-pad clearance carve so the existing fill clears the new copper.
+    """
+
+    _BOARD = """
+    (kicad_pcb
+      (version 20240108)
+      (generator "test")
+      (net 0 "")
+      (net 1 "+3.3V")
+      (net 3 "GND")
+      (footprint "lib:rail"
+        (layer "F.Cu")
+        (at 1 10)
+        (pad "1" thru_hole rect (at 0 0) (size 1.7 1.7) (drill 1.0) (layers "*.Cu" "*.Mask") (net 1 "+3.3V"))
+      )
+      (segment (start 0 5) (end 20 5) (width 0.25) (layer "F.Cu") (net 3))
+      (via (at 10 5) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 3))
+      (zone
+        (net "+3.3V")
+        (layer "F.Cu")
+        (uuid "rail-zone")
+        (hatch edge 0.5)
+        (connect_pads (clearance 0.3))
+        (min_thickness 0.25)
+        (fill yes (thermal_gap 0.3) (thermal_bridge_width 0.4))
+        (polygon (pts (xy 0 0) (xy 20 0) (xy 20 20) (xy 0 20)))
+        (filled_polygon
+          (layer "F.Cu")
+          (pts (xy 0 0) (xy 20 0) (xy 20 20) (xy 0 20))
+        )
+      )
+    )
+    """
+
+    def _zone_shorts(self, pcb_path: Path):
+        from collections import Counter
+
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate.rules.clearance import (
+            SegmentZoneClearanceRule,
+            ViaZoneClearanceRule,
+        )
+
+        class _Rules:
+            min_clearance_mm = 0.127
+
+        pcb = PCB.load(str(pcb_path))
+        v = SegmentZoneClearanceRule().check(pcb, _Rules()).violations
+        v += ViaZoneClearanceRule().check(pcb, _Rules()).violations
+        return Counter(x.rule_id for x in v)
+
+    @pytest.mark.skipif(
+        importlib.util.find_spec("shapely") is None,
+        reason="shapely required for the foreign-pad clearance carve",
+    )
+    def test_carve_removes_foreign_via_and_segment_shorts(self, tmp_path):
+        from kicad_tools.core.sexp_file import save_pcb
+        from kicad_tools.sexp import parse_string
+
+        pcb_path = tmp_path / "board.kicad_pcb"
+        doc = parse_string(self._BOARD)
+        save_pcb(doc, pcb_path)
+
+        before = self._zone_shorts(pcb_path)
+        assert before.get("clearance_segment_zone", 0) >= 1
+        assert before.get("clearance_via_zone", 0) >= 1
+
+        _carve_foreign_copper_after_stitch(pcb_path)
+
+        after = self._zone_shorts(pcb_path)
+        assert after.get("clearance_segment_zone", 0) == 0
+        assert after.get("clearance_via_zone", 0) == 0
+
+    def test_carve_is_noop_without_shapely(self, tmp_path, monkeypatch):
+        import builtins
+
+        from kicad_tools.core.sexp_file import save_pcb
+        from kicad_tools.sexp import parse_string
+
+        pcb_path = tmp_path / "board.kicad_pcb"
+        doc = parse_string(self._BOARD)
+        save_pcb(doc, pcb_path)
+        original = pcb_path.read_text()
+
+        real_import = builtins.__import__
+
+        def _fake_import(name, *args, **kwargs):
+            if name == "shapely" or name.startswith("shapely."):
+                raise ImportError("shapely disabled for test")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _fake_import)
+        # Must not raise and must not modify the board.
+        _carve_foreign_copper_after_stitch(pcb_path)
+        assert pcb_path.read_text() == original

--- a/tests/test_zones_fill_clearance.py
+++ b/tests/test_zones_fill_clearance.py
@@ -136,6 +136,166 @@ class TestForeignPadCarved:
         assert fill.area > 380.0
 
 
+# A +3.3V F.Cu pour crossed by a foreign-net (GND) track segment and sitting
+# next to a foreign-net GND via.  A same-net (+3.3V) segment also runs through
+# the pour and must be preserved.  Regression fixture for issue #3773: the
+# foreign-net carve previously subtracted only pads and vias, leaving GND
+# traces embedded in the rail copper -> clearance_segment_zone shorts.
+_SEGMENT_BOARD = """
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 1 "+3.3V")
+  (net 3 "GND")
+  (footprint "lib:rail"
+    (layer "F.Cu")
+    (at 1 10)
+    (pad "1" thru_hole rect (at 0 0) (size 1.7 1.7) (drill 1.0) (layers "*.Cu" "*.Mask") (net 1 "+3.3V"))
+  )
+  (footprint "lib:gnd"
+    (layer "F.Cu")
+    (at 19 10)
+    (pad "1" thru_hole rect (at 0 0) (size 1.7 1.7) (drill 1.0) (layers "*.Cu" "*.Mask") (net 3 "GND"))
+  )
+  (segment (start 0 5) (end 20 5) (width 0.25) (layer "F.Cu") (net 3))
+  (segment (start 0 15) (end 20 15) (width 0.25) (layer "F.Cu") (net 1))
+  (segment (start 0 8) (end 20 8) (width 0.25) (layer "B.Cu") (net 3))
+  (segment (start 0 12) (end 20 12) (width 0.25) (layer "F.Cu") (net 0))
+  (via (at 10 5) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 3))
+  (zone
+    (net "+3.3V")
+    (layer "F.Cu")
+    (uuid "rail-zone")
+    (hatch edge 0.5)
+    (connect_pads (clearance 0.3))
+    (min_thickness 0.25)
+    (fill yes (thermal_gap 0.3) (thermal_bridge_width 0.4))
+    (polygon (pts (xy 0 0) (xy 20 0) (xy 20 20) (xy 0 20)))
+    (filled_polygon
+      (layer "F.Cu")
+      (pts (xy 0 0) (xy 20 0) (xy 20 20) (xy 0 20))
+    )
+  )
+)
+"""
+
+
+def _segment_copper(sx, sy, ex, ey, width):
+    from shapely.geometry import LineString
+
+    return LineString([(sx, sy), (ex, ey)]).buffer(width / 2.0)
+
+
+class TestForeignSegmentCarved:
+    """Issue #3773: foreign-net track segments must be carved from pours.
+
+    A GND trace routed across a +3.3V pour was previously left embedded in
+    the rail copper because ``_collect_obstacles`` only modelled pads and
+    vias, never ``segment`` primitives.
+    """
+
+    def test_foreign_segment_is_excluded_with_clearance(self):
+        doc = _parse(_SEGMENT_BOARD)
+        modified = apply_foreign_pad_clearance(doc)
+        assert modified >= 1
+
+        fill = _fill_polygon(doc)
+        # Foreign GND F.Cu segment at y=5, full width, 0.25mm trace.
+        gnd_seg = _segment_copper(0, 5, 20, 5, 0.25)
+        assert fill.intersection(gnd_seg).area == pytest.approx(0.0, abs=1e-9)
+        # Cleared by at least the zone clearance (0.3mm).
+        assert fill.distance(gnd_seg) >= 0.3 - 1e-6
+
+    def test_foreign_via_still_excluded(self):
+        doc = _parse(_SEGMENT_BOARD)
+        apply_foreign_pad_clearance(doc)
+        fill = _fill_polygon(doc)
+        via = shapely.geometry.Point(10.0, 5.0).buffer(0.3)
+        assert fill.intersection(via).area == pytest.approx(0.0, abs=1e-9)
+        assert fill.distance(via) >= 0.3 - 1e-6
+
+    def test_same_net_segment_preserved(self):
+        """A +3.3V trace inside the pour must NOT be carved out."""
+        doc = _parse(_SEGMENT_BOARD)
+        apply_foreign_pad_clearance(doc)
+        fill = _fill_polygon(doc)
+        # Same-net +3.3V F.Cu segment at y=15 must remain inside the fill.
+        same_seg = _segment_copper(0, 15, 20, 15, 0.25)
+        assert fill.intersection(same_seg).area > 0.0
+
+    def test_wrong_layer_segment_not_carved(self):
+        """A GND segment on B.Cu must not carve the F.Cu fill."""
+        doc = _parse(_SEGMENT_BOARD)
+        apply_foreign_pad_clearance(doc)
+        fill = _fill_polygon(doc)
+        # GND B.Cu segment at y=8 -- its footprint must remain covered by the
+        # F.Cu fill (only the F.Cu GND segment/via carve copper here).
+        bcu_seg = _segment_copper(0, 8, 20, 8, 0.25)
+        assert fill.intersection(bcu_seg).area > 0.0
+
+    def test_net0_segment_ignored(self):
+        """An unassigned (net 0) segment is not a clearance obstacle."""
+        doc = _parse(_SEGMENT_BOARD)
+        apply_foreign_pad_clearance(doc)
+        fill = _fill_polygon(doc)
+        # net-0 F.Cu segment at y=12 must remain covered (not carved).
+        net0_seg = _segment_copper(0, 12, 20, 12, 0.25)
+        assert fill.intersection(net0_seg).area > 0.0
+
+    def test_no_shapely_is_noop(self, monkeypatch):
+        """With shapely unavailable the carve is a no-op, not a crash."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _fake_import(name, *args, **kwargs):
+            if name == "shapely" or name.startswith("shapely."):
+                raise ImportError("shapely disabled for test")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _fake_import)
+        doc = _parse(_SEGMENT_BOARD)
+        modified = apply_foreign_pad_clearance(doc)
+        assert modified == 0
+
+    def test_drc_reports_zero_segment_and_via_zone_errors(self, tmp_path):
+        """End-to-end through the real DRC rules the CI gate runs."""
+        from kicad_tools.core.sexp_file import save_pcb
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate.rules.clearance import (
+            SegmentZoneClearanceRule,
+            ViaZoneClearanceRule,
+        )
+
+        class _Rules:
+            min_clearance_mm = 0.127
+
+        doc = _parse(_SEGMENT_BOARD)
+        out = tmp_path / "board.kicad_pcb"
+        save_pcb(doc, out)
+        pcb_before = PCB.load(str(out))
+        seg_rule = SegmentZoneClearanceRule()
+        via_rule = ViaZoneClearanceRule()
+
+        before = seg_rule.check(pcb_before, _Rules()).violations
+        before += via_rule.check(pcb_before, _Rules()).violations
+        # Sanity: pre-carve, the GND segment and via overlap the +3.3V fill.
+        assert any(v.rule_id in ("clearance_segment_zone", "clearance_via_zone") for v in before), (
+            "fixture should produce zone shorts before the carve"
+        )
+
+        apply_foreign_pad_clearance(doc)
+        save_pcb(doc, out)
+        pcb_after = PCB.load(str(out))
+        after = seg_rule.check(pcb_after, _Rules()).violations
+        after += via_rule.check(pcb_after, _Rules()).violations
+        zone_shorts = [
+            v for v in after if v.rule_id in ("clearance_segment_zone", "clearance_via_zone")
+        ]
+        assert zone_shorts == [], f"expected no segment/via-zone errors, got: {zone_shorts}"
+
+
 class TestNoForeignCopper:
     def test_no_modification_when_all_same_net(self):
         """A fill with only same-net pads is left untouched."""


### PR DESCRIPTION
## Summary

A foreign-net track segment routed across a copper pour (e.g. a `GND`
trace crossing a `+3.3V`/`+5V` F.Cu rail fill) was left embedded in the
rail copper because the post-fill foreign-net clearance carve only
modelled footprint **pads** and top-level **vias** — never `segment`
primitives. `SegmentZoneClearanceRule` then reported the overlap as a
`clearance_segment_zone` short (with related `clearance_via_zone`).

This was the exact in-file asymmetry the curator localized:
`_collect_same_net_anchors` already walks `find_all("segment")` to
preserve same-net fill rings, but `_collect_obstacles` did not iterate
segments to carve foreign track copper out.

## Changes

- **`src/kicad_tools/zones/fill_clearance.py`** — Add a foreign-net
  track-segment branch to `_collect_obstacles`: for each net-assigned,
  non-zero-width `segment`, build a `LineString([(sx,sy),(ex,ey)]).buffer(width/2)`
  obstacle on the segment's single copper layer (reusing the geometry the
  same-net anchor collector already builds). Net-0 and zero-width segments
  are skipped; the branch sits inside the existing shapely guard.
  `apply_foreign_pad_clearance`'s buffering / hole-venting / island-removal
  / safety gates flow through unchanged.
- **`src/kicad_tools/cli/stitch_cmd.py`** — `kct stitch` adds new GND vias
  and pad-to-via trace segments across the existing rail pours but does not
  refill the zones, so the freshly added GND copper was left embedded in the
  fill on a board regen. Re-apply the pure-Python carve after stitching
  (`_carve_foreign_copper_after_stitch`) — no kicad-cli refill, so the
  post-route carve is preserved; no-op without shapely.
- **`tests/test_zones_fill_clearance.py`** — `TestForeignSegmentCarved`:
  foreign GND segment + via overlapping a `+3.3V` pour, asserting 0
  `clearance_segment_zone` / `clearance_via_zone` after the carve (fails
  pre-fix), plus same-net-preserved / wrong-layer / net-0 / no-shapely
  edge cases, and an end-to-end DRC round-trip.
- **`tests/test_stitch_cmd.py`** — `TestPostStitchForeignCopperCarve`:
  the post-stitch re-carve removes the new GND via/segment shorts; no-op
  without shapely.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Fresh board-04 regen (cpp, seed 42, shapely): 0 `clearance_segment_zone` + 0 `clearance_via_zone` | ✅ | Full `generate_design.py` regen: zone shorts 20+10 → **0**; only the advisory `connectivity` finding remains (excluded from gate) |
| `_collect_obstacles` carves foreign-net track segments with ≥ zone clearance | ✅ | New regression test asserts 0 overlap + ≥0.3mm clearance |
| Regression test passes post-fix, fails pre-fix | ✅ | Reverting only the source change makes `test_foreign_segment_is_excluded_with_clearance` + `test_drc_reports_zero_segment_and_via_zone_errors` fail (GND short surfaces); restored → pass |
| No new DRC violations on other boards' pours | ✅ | Applied carve to boards 00–03, 05–07 committed PCBs: **no new zone shorts**; boards 05/07 pre-existing `clearance_pad_zone`/`clearance_via_zone` actually cleared |
| Board-04 full-regen path re-enabled or pinning documented | ✅ | Documented below — routed PCB stays pinned for an unrelated advisory-connectivity reason |

## Board-04 regen result

| | committed (pinned) | fresh regen (this PR) |
|---|---|---|
| `clearance_segment_zone` | 0 | **0** (was 20) |
| `clearance_via_zone` | 0 | **0** (was 10) |
| blocking errors | 0 | **0** |
| advisory `connectivity` | 1 (GND U2.23) | 4 stranded GND pads (U2.8/U2.23/U2.35) |

The 30 zone-fill shorts are fully resolved. The routed artifact is **kept
pinned** (not re-committed): a fresh regen strands 4 GND corner pads vs the
committed artifact's 1, driven by the pre-existing #3266/#3267 NRST/SWO
routing interaction (advisory `connectivity`, excluded from the CI gate),
**not** by this zone-fill bug. Committing the regen would worsen the
advisory count, so per the issue guidance ("do NOT commit a regression")
the committed-good PCB stays in place.

## Test Plan

- `pytest tests/test_zones_fill_clearance.py tests/test_stitch_cmd.py tests/test_board_04_mfr_gate.py tests/test_board_05_drc_allowlist.py` → 294 passed
- Pre-fix verification: reverting the `fill_clearance.py` change makes the new segment/DRC assertions fail
- End-to-end: `uv run python boards/04-stm32-devboard/generate_design.py` (cpp backend, seed 42) → 0 blocking `clearance_*_zone` errors
- `ruff check .` clean; `ruff format --check` clean on changed files; mypy introduces no new errors (17 pre-existing in `stitch_cmd.py` unchanged)

Closes #3773