### PR TITLE
feat(lvs): shared write_lvs_report helper + wire board 01 into copper-LVS gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -985,3 +985,82 @@ jobs:
           set -euo pipefail
           uv run python scripts/ci/check_board_00_e2e.py \
             /tmp/board00-staging/00-simple-led
+
+  board-01-end-to-end:
+    # Issue #3762: same end-to-end gate as ``board-00-end-to-end``, applied
+    # to board 01 ("voltage-divider").  Board 01 is verified clean on both
+    # the copper-extracted and label-based LVS comparators, so its recipe
+    # now runs ``write_lvs_report(..., require_clean=True)`` and emits
+    # ``output/lvs.json``.  This job regenerates the board, asserts
+    # ``kct check`` Overall PASSED, emits board.json, and asserts
+    # lvs.json clean=true + board.json lvs_clean=true via the generalized
+    # ``scripts/ci/check_board_00_e2e.py`` asserter (parametrized with
+    # ``--stem voltage_divider``).  See the board-00 job above for the
+    # full rationale on container choice, the C++ backend build, and the
+    # advisory (non-required-check) status until a repo admin flips the
+    # branch-protection setting.
+    name: Board 01 End-to-End
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    container:
+      image: kicad/kicad:10.0
+      options: --user 0:0
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Ensure container has prerequisites
+        run: |
+          set -euo pipefail
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates curl git cmake build-essential
+          kicad-cli --version
+
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        run: |
+          set -euo pipefail
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install dependencies
+        run: uv sync --extra dev --python 3.12
+
+      - name: Build C++ router backend
+        run: uv run kct build-native
+
+      - name: Regenerate board 01 from recipe (clean tmp directory)
+        # The recipe exits non-zero if ERC/DRC/LVS fail OR write_lvs_report
+        # raises BoardNetlistMismatch -- board 01 hard-gates on both
+        # comparators (require_clean=True).
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/board01-ci
+          mkdir -p /tmp/board01-ci
+          uv run python boards/01-voltage-divider/generate_design.py /tmp/board01-ci
+
+      - name: Assert kct check Overall PASSED on regenerated routed PCB
+        run: |
+          set -euo pipefail
+          uv run kct check /tmp/board01-ci/voltage_divider_routed.kicad_pcb \
+            | tee /tmp/board01-ci/check.out
+          grep -qE '^Overall:[[:space:]]+PASSED' /tmp/board01-ci/check.out
+
+      - name: Emit board.json via kct board-metrics
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/board01-staging
+          mkdir -p /tmp/board01-staging/01-voltage-divider/output
+          cp -r /tmp/board01-ci/. /tmp/board01-staging/01-voltage-divider/output/
+          uv run kct board-metrics /tmp/board01-staging/01-voltage-divider
+
+      - name: Assert artifacts + lvs.json + board.json fields
+        # Reuse the generalized board-00 asserter with --stem so it derives
+        # board 01's artifact names (voltage_divider*.kicad_{sch,pcb}).
+        run: |
+          set -euo pipefail
+          uv run python scripts/ci/check_board_00_e2e.py \
+            --stem voltage_divider \
+            /tmp/board01-staging/01-voltage-divider

--- a/boards/00-simple-led/generate_design.py
+++ b/boards/00-simple-led/generate_design.py
@@ -17,7 +17,6 @@ Usage:
     python generate_design.py [output_dir]
 """
 
-import json
 import subprocess
 import sys
 import uuid
@@ -25,7 +24,7 @@ from pathlib import Path
 
 from kicad_tools.core.project_file import create_minimal_project, save_project
 from kicad_tools.dev import warn_if_stale
-from kicad_tools.lvs import BoardNetlistMismatch, compare_netlists
+from kicad_tools.lvs import write_lvs_report
 from kicad_tools.schematic.models.schematic import Schematic
 
 # Warn if running source scripts with stale pipx install
@@ -887,56 +886,25 @@ def export_manufacturing_bundle(routed_path: Path, output_dir: Path) -> bool:
 def run_lvs(sch_path: Path, routed_pcb_path: Path, output_dir: Path) -> bool:
     """Step 6.5: assert schematic <-> routed-PCB netlist equivalence (#3748).
 
-    Compares each ``(ref, pad)`` pair's net name between the schematic
-    (the design intent) and the routed PCB (what manufacturing receives)
-    and writes the result to ``output/lvs.json`` for downstream tools
-    (``kct fleet status``, the demo site, etc.) following the v1 schema
-    documented in ``docs/board-json-schema.md``.
+    Thin delegate to the shared :func:`kicad_tools.lvs.write_lvs_report`
+    helper (#3762).  Board 00 is verified clean on both the label-based and
+    copper-extracted comparators, so it hard-gates on both: the helper
+    writes ``output/lvs.json`` (v1 schema) and raises
+    :class:`BoardNetlistMismatch` when either comparator is dirty so the
+    caller's exit gate trips -- a silent dirty board would defeat the
+    purpose of wiring LVS into the recipe.
 
-    Returns ``True`` iff the comparison was clean.  Raises
-    :class:`BoardNetlistMismatch` when it is dirty so the caller's exit
-    gate trips -- a silent dirty board would defeat the purpose of
-    wiring LVS into the recipe.
+    Returns ``True`` iff both comparators were clean.
     """
-    print("\n" + "=" * 60)
-    print("Running LVS (schematic <-> PCB netlist match)...")
-    print("=" * 60)
-
-    result = compare_netlists(sch_path, routed_pcb_path)
-
-    output_dir.mkdir(parents=True, exist_ok=True)
-    lvs_path = output_dir / "lvs.json"
-    lvs_path.write_text(
-        json.dumps(
-            {
-                "$schema": "https://kicad-tools.org/schemas/lvs/v1.json",
-                "clean": result.clean,
-                "mismatches": [
-                    {
-                        "ref": m.ref,
-                        "pad": m.pad,
-                        "schematic_net": m.schematic_net,
-                        "pcb_net": m.pcb_net,
-                    }
-                    for m in result.mismatches
-                ],
-            },
-            indent=2,
-        )
-        + "\n"
+    copper_clean, label_clean = write_lvs_report(
+        sch_path,
+        routed_pcb_path,
+        output_dir,
+        require_clean=True,
+        run_copper=True,
+        run_label=True,
     )
-
-    if result.clean:
-        print(f"\n   PASS: {lvs_path.name} clean (0 mismatches)")
-        return True
-
-    # Print up to the first 5 mismatches before raising, so the recipe
-    # log surfaces what went wrong without forcing the user to crack
-    # open lvs.json.
-    print(f"\n   FAIL: {len(result.mismatches)} schematic/PCB mismatch(es):")
-    for m in result.mismatches[:5]:
-        print(f"      - {m.ref}.{m.pad}: schematic={m.schematic_net!r} pcb={m.pcb_net!r}")
-    raise BoardNetlistMismatch(result)
+    return copper_clean and label_clean
 
 
 def main() -> int:

--- a/boards/01-voltage-divider/generate_design.py
+++ b/boards/01-voltage-divider/generate_design.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 from kicad_tools.core.project_file import create_minimal_project, save_project
 from kicad_tools.dev import warn_if_stale
+from kicad_tools.lvs import write_lvs_report
 from kicad_tools.schematic.models.schematic import Schematic
 
 # Warn if running source scripts with stale pipx install
@@ -658,6 +659,15 @@ def run_drc(pcb_path: Path) -> bool:
 
     Uses kct check as a subprocess to ensure the same DRC rules
     are applied as when running kct check manually.
+
+    Issue #3762: pass ``--allow-incomplete`` (mirroring board-00's
+    ``run_drc``) because this DRC pass runs BEFORE
+    ``export_manufacturing_bundle`` writes ``output/manufacturing/
+    manifest.json`` and BEFORE ``write_lvs_report`` writes ``output/
+    lvs.json``.  Without the opt-in the Manifest meta sub-check reports
+    ``NOT RUN`` (-> Overall INCOMPLETE -> exit 2) and the recipe would
+    fail here on a fresh regen even though DRC itself passes.  LVS is
+    run separately by ``write_lvs_report`` further down the recipe.
     """
     print("\n" + "=" * 60)
     print("Running DRC (via kct check)...")
@@ -665,7 +675,14 @@ def run_drc(pcb_path: Path) -> bool:
 
     try:
         result = subprocess.run(
-            [sys.executable, "-m", "kicad_tools.cli", "check", str(pcb_path)],
+            [
+                sys.executable,
+                "-m",
+                "kicad_tools.cli",
+                "check",
+                str(pcb_path),
+                "--allow-incomplete",
+            ],
             capture_output=True,
             text=True,
         )
@@ -764,6 +781,24 @@ def main() -> int:
         # Step 6: Run DRC
         drc_success = run_drc(routed_path)
 
+        # Step 6.5: LVS (#3762) -- assert the routed PCB's nets match the
+        # schematic's design intent via the shared
+        # ``kicad_tools.lvs.write_lvs_report`` helper.  Board 01 is verified
+        # clean on both the copper-extracted and label-based comparators, so
+        # it hard-gates on both (``require_clean=True``): a dirty result
+        # raises ``BoardNetlistMismatch`` and the recipe exits non-zero.
+        # Writes ``output/lvs.json`` so ``kct board-metrics`` surfaces
+        # ``lvs_clean: true`` and the gallery LVS chip turns green.
+        copper_clean, label_clean = write_lvs_report(
+            sch_path,
+            routed_path,
+            output_dir,
+            require_clean=True,
+            run_copper=True,
+            run_label=True,
+        )
+        lvs_success = copper_clean and label_clean
+
         # Step 7: Export manufacturing bundle (#3147) so ``kct fleet
         # status`` reports ``ship_ready=true`` (the bundle's manifest
         # mtime must be newer than the freshly routed PCB).
@@ -783,6 +818,7 @@ def main() -> int:
         print(f"  ERC: {'PASS' if erc_success else 'FAIL'}")
         print(f"  Routing: {'SUCCESS' if route_success else 'PARTIAL'}")
         print(f"  DRC: {'PASS' if drc_success else 'FAIL'}")
+        print(f"  LVS: {'PASS' if lvs_success else 'FAIL'}")
         print(f"  MFG bundle: {'PASS' if mfg_success else 'FAIL'}")
         print("\nDesign summary:")
         print("  - J1: 2-pin input connector (VIN, GND)")
@@ -790,8 +826,10 @@ def main() -> int:
         print("  - J2: 2-pin output connector (VOUT, GND)")
         print("  - 5V input -> 2.5V output")
 
-        # Partial routing is acceptable; success if ERC and DRC pass
-        return 0 if erc_success and drc_success else 1
+        # Partial routing is acceptable; success if ERC, DRC, and LVS pass.
+        # (``write_lvs_report`` raises on a dirty LVS so a False
+        # ``lvs_success`` here would mean LVS short-circuited.)
+        return 0 if erc_success and drc_success and lvs_success else 1
 
     except Exception as e:
         print(f"\nError: {e}", file=sys.stderr)

--- a/scripts/ci/check_board_00_e2e.py
+++ b/scripts/ci/check_board_00_e2e.py
@@ -51,16 +51,36 @@ import sys
 from pathlib import Path
 from typing import Any
 
-# Artifacts required to exist under ``<board_dir>/output/``.  Paths are
-# slash-joined relative to the output directory.
-REQUIRED_ARTIFACTS: tuple[str, ...] = (
-    "simple_led.kicad_sch",
-    "simple_led.kicad_pcb",
-    "simple_led_routed.kicad_pcb",
+# Artifacts always required under ``<board_dir>/output/`` regardless of the
+# board's name.  The board-specific schematic/PCB artifacts are derived from
+# ``--stem`` (defaulting to board 00's ``simple_led``) so this asserter works
+# for any board, not just board 00 (issue #3762).
+BASE_REQUIRED_ARTIFACTS: tuple[str, ...] = (
     "lvs.json",
     "manufacturing/manifest.json",
     "board.json",
 )
+
+# Default board stem (board 00) so the historical board-00 invocation that
+# passes no ``--stem`` keeps asserting the same artifact set.
+DEFAULT_STEM = "simple_led"
+
+
+def required_artifacts(stem: str) -> tuple[str, ...]:
+    """Return the full required-artifact list for a board with this stem.
+
+    ``stem`` is the board's file prefix (e.g. ``simple_led`` for board 00,
+    ``voltage_divider`` for board 01).  The schematic, unrouted PCB and
+    routed PCB names are derived from it; the base artifacts (lvs.json,
+    manifest, board.json) are board-independent.
+    """
+    return (
+        f"{stem}.kicad_sch",
+        f"{stem}.kicad_pcb",
+        f"{stem}_routed.kicad_pcb",
+        *BASE_REQUIRED_ARTIFACTS,
+    )
+
 
 # board.json fields that must match these exact values for the gate to
 # pass.  The values are deliberately hardcoded (not loaded from the file's
@@ -87,13 +107,13 @@ def _err(msg: str, file: str | Path | None = None) -> None:
         print(f"::error::{msg}")
 
 
-def assert_artifacts_exist(output_dir: Path) -> list[str]:
-    """Assert every member of REQUIRED_ARTIFACTS exists under ``output_dir``.
+def assert_artifacts_exist(output_dir: Path, artifacts: tuple[str, ...]) -> list[str]:
+    """Assert every member of ``artifacts`` exists under ``output_dir``.
 
     Returns the list of *missing* relative paths (empty list = all present).
     """
     missing: list[str] = []
-    for rel in REQUIRED_ARTIFACTS:
+    for rel in artifacts:
         if not (output_dir / rel).is_file():
             missing.append(rel)
     return missing
@@ -138,8 +158,9 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="check_board_00_e2e.py",
         description=(
-            "Assert post-recipe artifact correctness for board 00. "
-            "Pass the board-layout directory (the one containing output/)."
+            "Assert post-recipe artifact correctness for a demo board. "
+            "Pass the board-layout directory (the one containing output/). "
+            "Defaults to board 00's artifact names; override with --stem."
         ),
     )
     parser.add_argument(
@@ -148,6 +169,15 @@ def main(argv: list[str] | None = None) -> int:
         help=(
             "Board-layout directory (must contain output/). "
             "Example: /tmp/board00-staging/00-simple-led"
+        ),
+    )
+    parser.add_argument(
+        "--stem",
+        default=DEFAULT_STEM,
+        help=(
+            "Board file stem used to derive the schematic/PCB artifact names "
+            f"(default: {DEFAULT_STEM!r} for board 00; e.g. 'voltage_divider' "
+            "for board 01)."
         ),
     )
     args = parser.parse_args(argv)
@@ -162,16 +192,17 @@ def main(argv: list[str] | None = None) -> int:
         _err(f"output dir does not exist: {output_dir}")
         return 1
 
+    artifacts = required_artifacts(args.stem)
     failed = False
 
     # 1. Artifact presence ----------------------------------------------------
-    missing = assert_artifacts_exist(output_dir)
+    missing = assert_artifacts_exist(output_dir, artifacts)
     if missing:
         for rel in missing:
             _err(f"missing required artifact: {rel}", file=output_dir / rel)
         failed = True
     else:
-        print(f"[ok] all {len(REQUIRED_ARTIFACTS)} required artifacts present")
+        print(f"[ok] all {len(artifacts)} required artifacts present")
 
     # 2. LVS clean ------------------------------------------------------------
     lvs_path = output_dir / "lvs.json"

--- a/src/kicad_tools/lvs/__init__.py
+++ b/src/kicad_tools/lvs/__init__.py
@@ -51,8 +51,10 @@ from kicad_tools.lvs.copper_lvs import (
     compare_copper_netlist,
     compare_partitions,
 )
+from kicad_tools.lvs.recipe import ADVISORY_LVS_BOARDS, write_lvs_report
 
 __all__ = [
+    "ADVISORY_LVS_BOARDS",
     "BoardNetlistMismatch",
     "CopperLVSMismatch",
     "CopperLVSResult",
@@ -62,4 +64,5 @@ __all__ = [
     "compare_copper_netlist",
     "compare_netlists",
     "compare_partitions",
+    "write_lvs_report",
 ]

--- a/src/kicad_tools/lvs/recipe.py
+++ b/src/kicad_tools/lvs/recipe.py
@@ -1,0 +1,222 @@
+"""Shared board-recipe LVS step (issue #3762).
+
+Board 00's ``run_lvs()`` (``boards/00-simple-led/generate_design.py``) was
+the original template: it runs LVS, writes ``output/lvs.json`` (v1 schema),
+and raises :class:`BoardNetlistMismatch` on a dirty board so the recipe's
+exit gate trips.  This module extracts that logic into a single reusable
+entrypoint, :func:`write_lvs_report`, so the copper-LVS manufacturability
+leg can be wired into every demo board without 7x copy-paste drift.
+
+It runs **both** comparators:
+
+* the label-based :func:`compare_netlists` (trusts each pad's ``(net ...)``
+  label), and
+* the copper-extracted :func:`compare_copper_netlist` (#3742; diffs the
+  *physical* copper partition against the schematic, catching shorts/opens
+  a mislabeled router would hide).
+
+The emitted ``lvs.json`` records both comparators' results.  ``clean`` is
+the AND of the *gated* comparators (the ones selected via ``run_copper`` /
+``run_label``); a comparator that is run-but-not-gated is reflected in the
+payload but does not flip ``clean`` or trigger a raise.
+
+Gate policy is per-board (see the curator matrix on #3762):
+
+* Boards verified clean (00, 01, 02) gate on both comparators.
+* Boards 06/07 are copper-clean but label-dirty (PCB-first test fixtures
+  whose floating schematic pins read ``schematic_net=None``); they gate on
+  copper only (``run_label=False``).
+* Boards in :data:`ADVISORY_LVS_BOARDS` (03/04/05) are genuinely dirty
+  today; they still run LVS and emit ``lvs.json`` so the gallery chip and
+  ``board-metrics`` surface the true state, but pass ``require_clean=False``
+  so the recipe logs the mismatch summary without raising.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from kicad_tools.lvs.board_lvs import (
+    BoardNetlistMismatch,
+    LVSResult,
+    compare_netlists,
+)
+from kicad_tools.lvs.copper_lvs import CopperLVSResult, compare_copper_netlist
+
+# Boards that run LVS + emit ``lvs.json`` but are NOT yet copper/label clean.
+# Recipes for these boards must pass ``require_clean=False`` so a dirty
+# comparator logs a summary instead of raising.  CI does NOT assert
+# ``clean=true`` for these boards.  This allowlist is the single auditable
+# place for the exemption -- shrink it as per-board fix follow-ups land
+# (boards 03/04 board-fix issues; board 05 blocked behind #3775/#3766).
+ADVISORY_LVS_BOARDS: frozenset[str] = frozenset(
+    {
+        "03-usb-joystick",
+        "04-stm32-devboard",
+        "05-bldc-motor-controller",
+    }
+)
+
+# JSON Schema URL stamped into every emitted ``lvs.json``.  Kept identical
+# to board-00's historical value so downstream readers (board-metrics
+# ``_parse_lvs``, ``scripts/ci/check_board_00_e2e.py``) are unaffected.
+_LVS_SCHEMA_URL = "https://kicad-tools.org/schemas/lvs/v1.json"
+
+
+def write_lvs_report(
+    sch_path: Path,
+    routed_pcb_path: Path,
+    output_dir: Path,
+    *,
+    require_clean: bool = True,
+    run_copper: bool = True,
+    run_label: bool = True,
+) -> tuple[bool, bool]:
+    """Run copper + label LVS, write ``output/lvs.json``, optionally raise.
+
+    Args:
+        sch_path: Path to the schematic (design intent).
+        routed_pcb_path: Path to the routed PCB (what manufacturing sees).
+        output_dir: Directory to write ``lvs.json`` into (created if absent).
+        require_clean: When ``True`` (hard gate), raise
+            :class:`BoardNetlistMismatch` if any *gated* comparator is dirty.
+            When ``False`` (advisory), log the mismatch summary and return
+            the dirty flags without raising.
+        run_copper: When ``True``, run the copper-extracted comparator and
+            include it in the gated ``clean`` decision.
+        run_label: When ``True``, run the label-based comparator and include
+            it in the gated ``clean`` decision.
+
+    Returns:
+        ``(copper_clean, label_clean)``.  A comparator that was not run is
+        reported as ``True`` (vacuously clean) so callers can treat the
+        return as "nothing gated is dirty".
+
+    Raises:
+        BoardNetlistMismatch: when ``require_clean`` and a gated comparator
+            is dirty.  The report is still written before raising.
+        ValueError: when neither comparator is selected to run.
+    """
+    if not run_copper and not run_label:
+        raise ValueError("write_lvs_report: at least one of run_copper/run_label must be True")
+
+    print("\n" + "=" * 60)
+    print("Running LVS (schematic <-> PCB netlist match)...")
+    print("=" * 60)
+
+    copper_result = compare_copper_netlist(sch_path, routed_pcb_path) if run_copper else None
+    label_result = compare_netlists(sch_path, routed_pcb_path) if run_label else None
+
+    copper_clean = copper_result.clean if copper_result is not None else True
+    label_clean = label_result.clean if label_result is not None else True
+
+    # ``clean`` is the AND of only the *gated* comparators.  A comparator
+    # that was run but not selected does not flip ``clean``.
+    gated_clean = copper_clean and label_clean
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    lvs_path = output_dir / "lvs.json"
+    lvs_path.write_text(
+        json.dumps(
+            _build_payload(copper_result, label_result, clean=gated_clean),
+            indent=2,
+        )
+        + "\n"
+    )
+
+    _print_summary(copper_result, label_result, lvs_path, run_copper, run_label)
+
+    if not gated_clean and require_clean:
+        # Reuse BoardNetlistMismatch (board-00's exit-gate exception).  When
+        # only copper is dirty we synthesize an LVSResult so the exception's
+        # carried ``.result`` still reflects "dirty"; the human-readable
+        # copper detail was already printed by ``_print_summary``.
+        raise BoardNetlistMismatch(_mismatch_result(copper_result, label_result))
+
+    return copper_clean, label_clean
+
+
+def _build_payload(
+    copper_result: CopperLVSResult | None,
+    label_result: LVSResult | None,
+    *,
+    clean: bool,
+) -> dict:
+    """Assemble the v1 ``lvs.json`` payload.
+
+    ``mismatches`` carries the label-based mismatches (unchanged from the
+    historical board-00 schema so ``_parse_lvs`` and the e2e asserter keep
+    working).  ``copper_mismatches`` is an additive field recording the
+    copper-extracted shorts/opens so a copper-dirty board is reflected too.
+    """
+    payload: dict = {
+        "$schema": _LVS_SCHEMA_URL,
+        "clean": clean,
+        "mismatches": [
+            {
+                "ref": lm.ref,
+                "pad": lm.pad,
+                "schematic_net": lm.schematic_net,
+                "pcb_net": lm.pcb_net,
+            }
+            for lm in (label_result.mismatches if label_result is not None else ())
+        ],
+        "copper_mismatches": [
+            {
+                "kind": cm.kind,
+                "net_a": cm.net_a,
+                "net_b": cm.net_b,
+                "pad_a": cm.pad_a,
+                "pad_b": cm.pad_b,
+            }
+            for cm in (copper_result.mismatches if copper_result is not None else ())
+        ],
+    }
+    return payload
+
+
+def _mismatch_result(
+    copper_result: CopperLVSResult | None,
+    label_result: LVSResult | None,
+) -> LVSResult:
+    """Pick the LVSResult to carry on the raised exception.
+
+    Prefer the label result when it is the dirty one (it has the
+    pin-level ``ref/pad`` detail the exception message renders).  When only
+    copper is dirty, fall back to a synthetic dirty ``LVSResult`` (the
+    copper detail was already printed in the summary).
+    """
+    if label_result is not None and not label_result.clean:
+        return label_result
+    return LVSResult(clean=False, mismatches=())
+
+
+def _print_summary(
+    copper_result: CopperLVSResult | None,
+    label_result: LVSResult | None,
+    lvs_path: Path,
+    run_copper: bool,
+    run_label: bool,
+) -> None:
+    """Print a human-readable LVS summary to the recipe log."""
+    if run_label and label_result is not None:
+        if label_result.clean:
+            print(f"\n   label-LVS PASS: 0 mismatches ({lvs_path.name})")
+        else:
+            print(f"\n   label-LVS FAIL: {len(label_result.mismatches)} mismatch(es):")
+            for lm in label_result.mismatches[:5]:
+                print(
+                    f"      - {lm.ref}.{lm.pad}: schematic={lm.schematic_net!r} pcb={lm.pcb_net!r}"
+                )
+
+    if run_copper and copper_result is not None:
+        if copper_result.clean:
+            print("   copper-LVS PASS: 0 shorts / 0 opens")
+        else:
+            print(
+                f"   copper-LVS FAIL: {len(copper_result.shorts)} short(s) / "
+                f"{len(copper_result.opens)} open(s):"
+            )
+            for cm in copper_result.mismatches[:5]:
+                print(f"      - {cm.kind}: {cm.net_a} <-> {cm.net_b} ({cm.pad_a}, {cm.pad_b})")

--- a/tests/test_check_board_e2e.py
+++ b/tests/test_check_board_e2e.py
@@ -1,0 +1,101 @@
+"""Tests for the generalized board end-to-end CI asserter (issue #3762).
+
+``scripts/ci/check_board_00_e2e.py`` was board-00-only (its
+``REQUIRED_ARTIFACTS`` hardcoded ``simple_led*``).  Issue #3762 parametrized
+it with a ``--stem`` flag so it asserts artifact correctness for any board.
+These tests cover:
+
+* the default stem reproduces board 00's required-artifact list;
+* a non-default stem (board 01's ``voltage_divider``) derives the right
+  schematic/PCB names;
+* ``main()`` exits 0 on a synthetic clean staging dir;
+* ``main()`` exits 2 when ``lvs.json`` reports ``clean:false``.
+
+The script is loaded via importlib (it lives under ``scripts/ci/`` outside
+the installed package), mirroring ``tests/test_check_routed_drc_advisory.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HELPER_SCRIPT_PATH = REPO_ROOT / "scripts" / "ci" / "check_board_00_e2e.py"
+
+
+def _load_helper():
+    spec = importlib.util.spec_from_file_location("check_board_00_e2e", HELPER_SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_board_00_e2e"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _stage_clean_board(root: Path, stem: str) -> Path:
+    """Build a synthetic ``<board_dir>/output/`` with all required artifacts."""
+    helper = _load_helper()
+    board_dir = root / "board"
+    output = board_dir / "output"
+    (output / "manufacturing").mkdir(parents=True)
+    for rel in helper.required_artifacts(stem):
+        p = output / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("placeholder")
+    (output / "lvs.json").write_text(json.dumps({"clean": True, "mismatches": []}))
+    (output / "board.json").write_text(
+        json.dumps({"status": "ok", "drc_violations": 0, "lvs_clean": True})
+    )
+    return board_dir
+
+
+def test_required_artifacts_default_stem_matches_board_00() -> None:
+    helper = _load_helper()
+    artifacts = helper.required_artifacts(helper.DEFAULT_STEM)
+    assert "simple_led.kicad_sch" in artifacts
+    assert "simple_led.kicad_pcb" in artifacts
+    assert "simple_led_routed.kicad_pcb" in artifacts
+    assert "lvs.json" in artifacts
+    assert "manufacturing/manifest.json" in artifacts
+    assert "board.json" in artifacts
+
+
+def test_required_artifacts_board_01_stem() -> None:
+    helper = _load_helper()
+    artifacts = helper.required_artifacts("voltage_divider")
+    assert "voltage_divider.kicad_sch" in artifacts
+    assert "voltage_divider_routed.kicad_pcb" in artifacts
+    assert "simple_led.kicad_sch" not in artifacts
+
+
+def test_main_passes_on_clean_staging(tmp_path: Path) -> None:
+    helper = _load_helper()
+    board_dir = _stage_clean_board(tmp_path, "voltage_divider")
+    rc = helper.main([str(board_dir), "--stem", "voltage_divider"])
+    assert rc == 0
+
+
+def test_main_exits_2_on_dirty_lvs(tmp_path: Path) -> None:
+    helper = _load_helper()
+    board_dir = _stage_clean_board(tmp_path, "voltage_divider")
+    (board_dir / "output" / "lvs.json").write_text(
+        json.dumps(
+            {
+                "clean": False,
+                "mismatches": [{"ref": "D1", "pad": "1", "schematic_net": "A", "pcb_net": "B"}],
+            }
+        )
+    )
+    rc = helper.main([str(board_dir), "--stem", "voltage_divider"])
+    assert rc == 2
+
+
+def test_main_default_stem_still_works_for_board_00_shape(tmp_path: Path) -> None:
+    helper = _load_helper()
+    board_dir = _stage_clean_board(tmp_path, helper.DEFAULT_STEM)
+    # No --stem passed: must default to board 00's artifact set and pass.
+    rc = helper.main([str(board_dir)])
+    assert rc == 0

--- a/tests/test_lvs_recipe.py
+++ b/tests/test_lvs_recipe.py
@@ -1,0 +1,236 @@
+"""Tests for the shared recipe LVS step (issue #3762).
+
+``kicad_tools.lvs.write_lvs_report`` is the extracted, parametrized core of
+board-00's ``run_lvs()``.  These tests cover:
+
+* clean board -> writes ``lvs.json`` with ``clean:true``, does not raise;
+* dirty board + ``require_clean=True`` -> raises ``BoardNetlistMismatch``
+  but still writes the report;
+* dirty board + ``require_clean=False`` (advisory) -> writes the report and
+  returns the dirty flags without raising;
+* copper-only gating (``run_label=False``) -> ignores label-only mismatches
+  (the board-06/07 floating-pin case);
+* the ``ADVISORY_LVS_BOARDS`` allowlist constant exists and is auditable.
+
+The gating-logic tests monkeypatch the two comparators so they are fast and
+fixture-free; two integration tests run the real comparators against
+committed board outputs (board 01 clean; board 04 copper-dirty).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import kicad_tools.lvs.recipe as recipe
+from kicad_tools.lvs import (
+    ADVISORY_LVS_BOARDS,
+    BoardNetlistMismatch,
+    write_lvs_report,
+)
+from kicad_tools.lvs.board_lvs import LVSMismatch, LVSResult
+from kicad_tools.lvs.copper_lvs import CopperLVSMismatch, CopperLVSResult
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+# ---------------------------------------------------------------------------
+# Monkeypatch helpers: stub the two comparators with canned results so the
+# gating logic is exercised without parsing real KiCad files.
+# ---------------------------------------------------------------------------
+
+
+def _patch_comparators(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    copper: CopperLVSResult,
+    label: LVSResult,
+) -> None:
+    monkeypatch.setattr(recipe, "compare_copper_netlist", lambda s, p: copper)
+    monkeypatch.setattr(recipe, "compare_netlists", lambda s, p: label)
+
+
+_CLEAN_COPPER = CopperLVSResult(clean=True, mismatches=())
+_CLEAN_LABEL = LVSResult(clean=True, mismatches=())
+_DIRTY_COPPER = CopperLVSResult(
+    clean=False,
+    mismatches=(
+        CopperLVSMismatch(kind="short", net_a="+5V", net_b="GND", pad_a="U1.1", pad_b="U1.2"),
+    ),
+)
+_DIRTY_LABEL = LVSResult(
+    clean=False,
+    mismatches=(LVSMismatch(ref="D1", pad="1", schematic_net="LED_ANODE", pcb_net="GND"),),
+)
+# Label-only floating-pin mismatch (board 06/07 shape): schematic_net=None.
+_FLOATING_LABEL = LVSResult(
+    clean=False,
+    mismatches=(LVSMismatch(ref="J1", pad="1", schematic_net=None, pcb_net="USB_DP"),),
+)
+
+
+def _read(tmp_path: Path) -> dict:
+    return json.loads((tmp_path / "lvs.json").read_text())
+
+
+# ---------------------------------------------------------------------------
+# Clean board
+# ---------------------------------------------------------------------------
+
+
+def test_clean_board_writes_report_and_does_not_raise(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_comparators(monkeypatch, copper=_CLEAN_COPPER, label=_CLEAN_LABEL)
+    copper_clean, label_clean = write_lvs_report(
+        Path("sch"), Path("pcb"), tmp_path, require_clean=True
+    )
+    assert (copper_clean, label_clean) == (True, True)
+    data = _read(tmp_path)
+    assert data["clean"] is True
+    assert data["mismatches"] == []
+    assert data["copper_mismatches"] == []
+    assert data["$schema"] == "https://kicad-tools.org/schemas/lvs/v1.json"
+
+
+# ---------------------------------------------------------------------------
+# Dirty board, hard gate
+# ---------------------------------------------------------------------------
+
+
+def test_dirty_label_hard_gate_raises_but_writes_report(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_comparators(monkeypatch, copper=_CLEAN_COPPER, label=_DIRTY_LABEL)
+    with pytest.raises(BoardNetlistMismatch):
+        write_lvs_report(Path("sch"), Path("pcb"), tmp_path, require_clean=True)
+    # Report is written even though the call raised.
+    data = _read(tmp_path)
+    assert data["clean"] is False
+    assert len(data["mismatches"]) == 1
+
+
+def test_dirty_copper_hard_gate_raises_but_writes_report(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_comparators(monkeypatch, copper=_DIRTY_COPPER, label=_CLEAN_LABEL)
+    with pytest.raises(BoardNetlistMismatch):
+        write_lvs_report(Path("sch"), Path("pcb"), tmp_path, require_clean=True)
+    data = _read(tmp_path)
+    assert data["clean"] is False
+    assert data["copper_mismatches"][0]["kind"] == "short"
+
+
+# ---------------------------------------------------------------------------
+# Advisory (require_clean=False)
+# ---------------------------------------------------------------------------
+
+
+def test_advisory_dirty_board_does_not_raise(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_comparators(monkeypatch, copper=_DIRTY_COPPER, label=_DIRTY_LABEL)
+    copper_clean, label_clean = write_lvs_report(
+        Path("sch"), Path("pcb"), tmp_path, require_clean=False
+    )
+    assert (copper_clean, label_clean) == (False, False)
+    data = _read(tmp_path)
+    assert data["clean"] is False
+    assert len(data["copper_mismatches"]) == 1
+    assert len(data["mismatches"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Copper-only gating (board 06/07 floating-pin case)
+# ---------------------------------------------------------------------------
+
+
+def test_copper_only_gating_ignores_label_mismatches(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Copper clean, label dirty with floating schematic pin -- with
+    # run_label=False the label comparator is never run, so ``clean`` is
+    # driven by copper alone and the call does not raise.
+    called = {"label": False}
+
+    def _label_should_not_run(s: Path, p: Path) -> LVSResult:
+        called["label"] = True
+        return _FLOATING_LABEL
+
+    monkeypatch.setattr(recipe, "compare_copper_netlist", lambda s, p: _CLEAN_COPPER)
+    monkeypatch.setattr(recipe, "compare_netlists", _label_should_not_run)
+
+    copper_clean, label_clean = write_lvs_report(
+        Path("sch"),
+        Path("pcb"),
+        tmp_path,
+        require_clean=True,
+        run_copper=True,
+        run_label=False,
+    )
+    assert called["label"] is False  # label comparator skipped entirely
+    assert (copper_clean, label_clean) == (True, True)
+    data = _read(tmp_path)
+    assert data["clean"] is True
+    assert data["mismatches"] == []  # no label result -> empty
+
+
+def test_no_comparator_selected_raises_value_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_comparators(monkeypatch, copper=_CLEAN_COPPER, label=_CLEAN_LABEL)
+    with pytest.raises(ValueError):
+        write_lvs_report(
+            Path("sch"),
+            Path("pcb"),
+            tmp_path,
+            run_copper=False,
+            run_label=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Advisory allowlist constant
+# ---------------------------------------------------------------------------
+
+
+def test_advisory_allowlist_contains_known_dirty_boards() -> None:
+    assert "03-usb-joystick" in ADVISORY_LVS_BOARDS
+    assert "04-stm32-devboard" in ADVISORY_LVS_BOARDS
+    assert "05-bldc-motor-controller" in ADVISORY_LVS_BOARDS
+    # Clean boards must NOT be exempted.
+    assert "00-simple-led" not in ADVISORY_LVS_BOARDS
+    assert "01-voltage-divider" not in ADVISORY_LVS_BOARDS
+    assert isinstance(ADVISORY_LVS_BOARDS, frozenset)
+
+
+# ---------------------------------------------------------------------------
+# Integration: real committed board outputs
+# ---------------------------------------------------------------------------
+
+
+def test_board_01_real_outputs_are_clean(tmp_path: Path) -> None:
+    """Board 01 is verified clean on both comparators -> no raise, clean:true."""
+    out = REPO_ROOT / "boards" / "01-voltage-divider" / "output"
+    sch = out / "voltage_divider.kicad_sch"
+    pcb = out / "voltage_divider_routed.kicad_pcb"
+    if not (sch.is_file() and pcb.is_file()):
+        pytest.skip("board 01 committed outputs not present")
+    copper_clean, label_clean = write_lvs_report(sch, pcb, tmp_path, require_clean=True)
+    assert (copper_clean, label_clean) == (True, True)
+    assert _read(tmp_path)["clean"] is True
+
+
+def test_board_04_real_outputs_advisory_does_not_raise(tmp_path: Path) -> None:
+    """Board 04 is copper-dirty; advisory mode writes the report w/o raising."""
+    out = REPO_ROOT / "boards" / "04-stm32-devboard" / "output"
+    sch = out / "stm32_devboard.kicad_sch"
+    pcb = out / "stm32_devboard_routed.kicad_pcb"
+    if not (sch.is_file() and pcb.is_file()):
+        pytest.skip("board 04 committed outputs not present")
+    copper_clean, label_clean = write_lvs_report(sch, pcb, tmp_path, require_clean=False)
+    # Board 04 is known dirty -- at least one comparator must be dirty.
+    assert not (copper_clean and label_clean)
+    assert _read(tmp_path)["clean"] is False


### PR DESCRIPTION
## Summary

Bounded first slice of #3762: roll out the copper-LVS manufacturability leg across the demo fleet via a shared helper instead of 7x copy-paste. This slice extracts board-00's `run_lvs()` into a reusable `kicad_tools.lvs.write_lvs_report(...)`, wires board 01 (verified clean) into the gate end-to-end, generalizes the board-00 CI asserter to any board, and lands the `ADVISORY_LVS_BOARDS` allowlist plumbing so later slices add boards as one-liners.

Per the curator's verified per-board state, the fleet is NOT uniformly clean (boards 03/04/05 are genuinely copper-dirty), so this slice deliberately hard-gates only boards 00 and 01 and does NOT touch 02/03/04/05/06/07 -- those are filed as follow-ups (see below).

## Changes

- **New `src/kicad_tools/lvs/recipe.py`**: `write_lvs_report(sch, pcb, out, *, require_clean, run_copper, run_label) -> (copper_clean, label_clean)`. Runs both the label-based and copper-extracted comparators, writes `output/lvs.json` (v1 schema, with an additive `copper_mismatches` field so copper-dirty boards are reflected), and raises `BoardNetlistMismatch` when a *gated* comparator is dirty and `require_clean`. Includes the `ADVISORY_LVS_BOARDS = {03, 04, 05}` allowlist constant. Exported from `kicad_tools.lvs`.
- **Refactor board-00 `run_lvs()`** to a thin delegate to `write_lvs_report(require_clean=True, run_copper=True, run_label=True)`. Behavior preserved (board 00 stays hard-gated on both comparators; still emits `lvs.json`).
- **Wire board 01 end-to-end**: add the `write_lvs_report(require_clean=True)` step to `main()` emitting `output/lvs.json`; also pass `--allow-incomplete` in board-01 `run_drc` (mirroring board 00) so a fresh regen exits 0.
- **Generalize `scripts/ci/check_board_00_e2e.py`** with a `--stem` flag deriving the schematic/PCB artifact names; default stem keeps the board-00 invocation unchanged.
- **Add `board-01-end-to-end` CI job** in `.github/workflows/ci.yml` (clone of the board-00 job) asserting `lvs.json clean=true` + `board.json lvs_clean=true` via the generalized asserter with `--stem voltage_divider`.
- **Tests**: `tests/test_lvs_recipe.py` (clean/dirty hard-gate raise+report, advisory no-raise, copper-only gating skips the label comparator, allowlist constant, real board 01/04 integration) and `tests/test_check_board_e2e.py` (default-stem == board 00, board-01 stem derivation, exit 0 on clean staging, exit 2 on dirty lvs.json).

No change needed to `board_metrics_cmd._parse_lvs` (already reads `lvs_clean` from `output/lvs.json`) or `check_cmd._lvs_subcheck` (already wired) -- confirmed.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Shared `write_lvs_report` helper exists + exported | done | `src/kicad_tools/lvs/recipe.py`; in `kicad_tools.lvs.__all__` |
| Board 00 refactored to delegate, behavior unchanged | done | Fresh regen of board 00 -> exit 0, `lvs.json clean=true`, asserter exit 0 |
| Board 01 emits clean `lvs.json`, hard `require_clean=True` | done | Fresh regen -> exit 0, `lvs.json clean=true`; `kct check` Overall PASSED (LVS label+copper) |
| Board 01 CI-asserted | done | New `board-01-end-to-end` job; staged board-metrics -> `lvs_clean=true`, asserter exit 0 |
| Advisory allowlist mechanism exists + unit-tested | done | `ADVISORY_LVS_BOARDS` + advisory (`require_clean=False`) path; `test_advisory_*` |
| CI asserter generalized | done | `--stem` flag; `test_check_board_e2e.py` covers default + board-01 stems |
| No regression on board-00 gate or other boards | done | Board-00 e2e regen + asserter pass; ruff/format/mypy clean; 84 LVS-suite tests pass |

## Test Plan

- `uv run pytest tests/test_lvs_recipe.py tests/test_check_board_e2e.py tests/test_board_00_lvs.py tests/test_lvs.py tests/test_copper_lvs.py tests/test_board_metrics.py` -> all pass.
- Fresh regen of board 00 and board 01 (C++ backend built, kicad-cli present) -> both exit 0, both `lvs.json clean=true`; `kct board-metrics` -> `lvs_clean=true`; `check_board_00_e2e.py` (default and `--stem voltage_divider`) -> exit 0.
- `kct check` on fully-generated board-01 routed PCB -> `LVS: PASSED (label + copper)`, `Overall: PASSED`.
- `uv run ruff check .`, `ruff format --check`, `mypy src/kicad_tools/lvs/` -> all clean.

## Follow-ups filed (out of this slice)

- #3779 -- wire boards 02 (full gate), 06/07 (copper-only, label advisory).
- #3780 -- advisory-wire boards 03/04, then per-board fix to graduate to a hard gate.
- #3781 -- investigate board-04 genuine copper shorts (`+5V<->GND`, `OSC_IN<->OSC_OUT`): real defect vs extraction artifact.

Closes #3762