### PR TITLE
feat(boards): wire boards 03/04 into advisory copper-LVS

### DIFF
--- a/boards/03-usb-joystick/generate_design.py
+++ b/boards/03-usb-joystick/generate_design.py
@@ -29,6 +29,7 @@ from pathlib import Path
 
 from kicad_tools.core.project_file import create_minimal_project, save_project
 from kicad_tools.dev import warn_if_stale
+from kicad_tools.lvs import write_lvs_report
 
 # Warn if running source scripts with stale pipx install
 warn_if_stale()
@@ -542,6 +543,26 @@ def main() -> int:
 
         # Step 6: Run DRC
         drc_success = run_drc(routed_path)
+
+        # Step 6.5: LVS (advisory, #3780) -- board 03 is in
+        # ``ADVISORY_LVS_BOARDS`` and is genuinely copper-dirty today (the
+        # J1 USB-C connector's F.Cu-only pads sit over the B.Cu pour with no
+        # stitching via, leaving residual opens), so ``require_clean=False``:
+        # ``write_lvs_report`` logs the mismatch summary and writes
+        # ``output/lvs.json`` but does NOT raise.  This surfaces
+        # ``lvs_clean=false`` (with ``copper_mismatches`` detail) in
+        # board.json / the gallery LVS chip without gating CI.  ``run_label``
+        # is off because the board is label-dirty too and the copper
+        # comparator is the meaningful leg.  Graduation to a hard gate is
+        # deferred (see #3785 + the board-03 residual-opens follow-up).
+        write_lvs_report(
+            sch_path,
+            routed_path,
+            output_dir,
+            require_clean=False,
+            run_copper=True,
+            run_label=False,
+        )
 
         # Step 7: Export manufacturing bundle (gerbers, BOM, CPL,
         # report).  Required by AC of #3095 so ``kct fleet status``

--- a/boards/04-stm32-devboard/generate_design.py
+++ b/boards/04-stm32-devboard/generate_design.py
@@ -30,6 +30,7 @@ from pathlib import Path
 
 from kicad_tools.core.project_file import create_minimal_project, save_project
 from kicad_tools.dev import warn_if_stale
+from kicad_tools.lvs import write_lvs_report
 from kicad_tools.schematic.blocks import (
     DebugHeader,
     create_crystal_with_loads,
@@ -1504,6 +1505,26 @@ def main() -> int:
 
         # Step 7: Run DRC
         drc_success = run_drc(routed_path)
+
+        # Step 7.5: LVS (advisory, #3780) -- board 04 is in
+        # ``ADVISORY_LVS_BOARDS`` and is genuinely copper-dirty today
+        # (notably the real ``OSC_IN<->OSC_OUT`` B.Cu escape-stub short
+        # bridging the HSE crystal pins, tracked in #3785), so
+        # ``require_clean=False``: ``write_lvs_report`` logs the mismatch
+        # summary and writes ``output/lvs.json`` but does NOT raise.  This
+        # surfaces ``lvs_clean=false`` (with ``copper_mismatches`` detail) in
+        # board.json / the gallery LVS chip without gating CI.  ``run_label``
+        # is off because the board is label-dirty too and the copper
+        # comparator is the meaningful leg.  Graduation to a hard gate is
+        # deferred (blocked on #3785).
+        write_lvs_report(
+            sch_path,
+            routed_path,
+            output_dir,
+            require_clean=False,
+            run_copper=True,
+            run_label=False,
+        )
 
         # Step 8: Generate manufacturing artifacts (Gerbers, BOM, CPL)
         mfr_success = generate_manufacturing(routed_path, output_dir)


### PR DESCRIPTION
## Summary

Part 1 of #3780: wire board 03 (usb-joystick) and board 04 (stm32-devboard) into the copper-LVS leg as **advisory**. Each `generate_design.py` `main()` now runs `write_lvs_report(..., require_clean=False, run_copper=True, run_label=False)` after `run_drc` and before the manufacturing-bundle export, mirroring board 02's Step 6.5.

Both boards are in `ADVISORY_LVS_BOARDS` and are genuinely copper-dirty today, so the step writes `output/lvs.json` and logs the mismatch summary but does NOT raise. This surfaces `lvs_clean: false` (with `copper_mismatches` detail) in `board.json` and the gallery LVS chip **without gating CI**.

**Part 2 (graduation to a hard gate) is explicitly out of scope** and deferred — blocked on #3785 (board-04 `OSC_IN<->OSC_OUT` real short) and the newly-filed #3787 (board-03 J1 USB-C residual GND opens).

## Changes

- `boards/03-usb-joystick/generate_design.py` — add `from kicad_tools.lvs import write_lvs_report`; insert advisory LVS step (Step 6.5) after `run_drc`, before `export_manufacturing_bundle`.
- `boards/04-stm32-devboard/generate_design.py` — add the same import; insert advisory LVS step (Step 7.5) after `run_drc`, before `generate_manufacturing`.
- `run_drc` left untouched on both boards (they already use `kct check --drc-only` per #3764/#3765, which sidesteps the meta sub-check — no `--allow-incomplete` needed, unlike board 02).
- No new CI assert job; boards stay in `ADVISORY_LVS_BOARDS`. `output/lvs.json` is a generated artifact, not committed (matching board 02).
- Filed #3787 (`loom:architect`) to track the board-03 residual-opens defect so Part 2's board-03 dependency is tracked alongside #3785.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Board 03 recipe: import + advisory LVS step after `run_drc`, before mfg export | ✅ | Step 6.5 added; `run_drc` untouched |
| Board 04 recipe: import + advisory LVS step after `run_drc`, before mfg export | ✅ | Step 7.5 added; `run_drc` untouched |
| `require_clean=False`, `run_copper=True`, `run_label=False` | ✅ | matches curator template |
| Boards 03/04 emit `output/lvs.json` with `clean: false`, real mismatch detail, no raise | ✅ | Ran `write_lvs_report` on committed artifacts: board 03 → 0 shorts / 2 GND opens at J1 USB-C; board 04 → 1 short (`OSC_IN<->OSC_OUT`, #3785) / 20 opens. Neither raised. |
| `board-metrics` shows `lvs_clean: false` (no longer omitted) | ✅ | `kct board-metrics` → both report `lvs_clean: false` |
| No CI hard-fail / no new assert job for 03/04 | ✅ | `.github/workflows/ci.yml` unchanged; only end-to-end jobs are 00/01/02/06/07 |
| Boards 00/01/02/06/07 gates unaffected | ✅ | Diff is the two recipe files only (+42 lines); no `src/`, CI, or allowlist changes |
| `run_drc` NOT given `--allow-incomplete` | ✅ | confirmed untouched on both boards |
| Board-03 residual-opens follow-up filed | ✅ | #3787 |

## Test Plan

- `uv run ruff check boards/` → all checks passed; `ruff format --check` → already formatted.
- `uv run mypy src/kicad_tools/lvs/recipe.py` → no issues.
- `uv run pytest tests/test_lvs_recipe.py tests/test_board_metrics.py tests/test_copper_lvs.py tests/test_lvs.py tests/test_board_00_lvs.py` → 106 passed.
- Verified advisory `write_lvs_report` on the committed (pinned) routed PCBs for both boards: emits `lvs.json` (`clean: false`) without raising; routed PCBs not re-routed/modified.

Closes #3780