### PR TITLE
fix(copper-lvs): make segment chainer layer-aware to drop phantom crossover shorts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1065,6 +1065,85 @@ jobs:
             --stem voltage_divider \
             /tmp/board01-staging/01-voltage-divider
 
+  board-02-end-to-end:
+    # Issue #3783: same full end-to-end gate as ``board-00-end-to-end`` /
+    # ``board-01-end-to-end``, applied to board 02 ("charlieplex-led").
+    # This job was deferred in #3779 because a fresh regen produced a
+    # spurious copper short (NODE_B<->NODE_C) — a layer-agnostic copper-LVS
+    # extractor false-positive on a legal via-less F.Cu/B.Cu crossover.
+    # With the layer-aware ``_build_segment_chains`` fix (this PR), a fresh
+    # board-02 regen is copper-LVS clean (Overall: PASSED), so the full
+    # e2e gate (regen → ``kct check`` Overall PASSED → board.json status:ok
+    # / drc_violations:0 / lvs_clean:true) is now green and added here.
+    # See the board-00 job above for the full rationale on container choice,
+    # the C++ backend build, and the advisory (non-required-check) status
+    # until a repo admin flips the branch-protection setting.
+    name: Board 02 End-to-End
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    container:
+      image: kicad/kicad:10.0
+      options: --user 0:0
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Ensure container has prerequisites
+        run: |
+          set -euo pipefail
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates curl git cmake build-essential
+          kicad-cli --version
+
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        run: |
+          set -euo pipefail
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install dependencies
+        run: uv sync --extra dev --python 3.12
+
+      - name: Build C++ router backend
+        run: uv run kct build-native
+
+      - name: Regenerate board 02 from recipe (clean tmp directory)
+        # The recipe exits non-zero if ERC/DRC/LVS fail OR write_lvs_report
+        # raises BoardNetlistMismatch -- board 02 hard-gates on both the
+        # copper-extracted and label-based comparators (require_clean=True).
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/board02-ci
+          mkdir -p /tmp/board02-ci
+          uv run python boards/02-charlieplex-led/generate_design.py /tmp/board02-ci
+
+      - name: Assert kct check Overall PASSED on regenerated routed PCB
+        run: |
+          set -euo pipefail
+          uv run kct check /tmp/board02-ci/charlieplex_3x3_routed.kicad_pcb \
+            | tee /tmp/board02-ci/check.out
+          grep -qE '^Overall:[[:space:]]+PASSED' /tmp/board02-ci/check.out
+
+      - name: Emit board.json via kct board-metrics
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/board02-staging
+          mkdir -p /tmp/board02-staging/02-charlieplex-led/output
+          cp -r /tmp/board02-ci/. /tmp/board02-staging/02-charlieplex-led/output/
+          uv run kct board-metrics /tmp/board02-staging/02-charlieplex-led
+
+      - name: Assert artifacts + lvs.json + board.json fields
+        # Reuse the generalized board-00 asserter with --stem so it derives
+        # board 02's artifact names (charlieplex_3x3*.kicad_{sch,pcb}).
+        run: |
+          set -euo pipefail
+          uv run python scripts/ci/check_board_00_e2e.py \
+            --stem charlieplex_3x3 \
+            /tmp/board02-staging/02-charlieplex-led
+
   board-06-end-to-end:
     # Issue #3779: LVS-ONLY end-to-end gate for board 06 ("diffpair-test").
     # Board 06 is a PCB-first routing fixture (USB3 connectors with no

--- a/src/kicad_tools/validate/connectivity.py
+++ b/src/kicad_tools/validate/connectivity.py
@@ -50,6 +50,14 @@ def _has_shapely() -> bool:
     return _SHAPELY_AVAILABLE
 
 
+# Sentinel layer-set meaning "every copper layer".  Used to model a ``*.Cu``
+# through-hole pad as a universal copper bridge in the layer-aware segment
+# chainer (issue #3783): a multi-layer pad joins copper on any layer at its
+# position, so any two copper segments meeting there are fused regardless of
+# their individual layers.
+_ALL_COPPER_LAYERS: frozenset[str] = frozenset({"*.Cu"})
+
+
 @dataclass(frozen=True)
 class ConnectivityIssue:
     """Represents a single net connectivity issue.
@@ -427,7 +435,9 @@ class ConnectivityValidator:
         #     share endpoints are galvanically connected even with no pad at
         #     the intermediate junctions.  Reuse the existing chain builder,
         #     which is itself label-agnostic (it only looks at endpoints).
-        graph = self._build_segment_chains(segments, pad_positions, graph)
+        #     It is layer-aware (issue #3783): cross-layer hops require a via /
+        #     multi-layer pad bridge, so pad_layers is passed through.
+        graph = self._build_segment_chains(segments, pad_positions, graph, pad_layers)
 
         # 2c. Vias: pads coincident with a via are connected (layer bridge).
         for via in self.pcb.vias:
@@ -648,8 +658,10 @@ class ConnectivityValidator:
                         graph[other].add(pad)
 
         # Build full transitive closure through segment chains
-        # Track endpoints can form chains connecting distant pads
-        graph = self._build_segment_chains(segments, pad_positions, graph)
+        # Track endpoints can form chains connecting distant pads.
+        # Layer-aware (issue #3783): cross-layer hops require a via /
+        # multi-layer pad bridge at the shared point.
+        graph = self._build_segment_chains(segments, pad_positions, graph, pad_layers)
 
         # --- Zone boundary polygon containment checks ---
         # For each zone on this net, check if pads fall inside the zone
@@ -709,34 +721,201 @@ class ConnectivityValidator:
 
         return graph
 
+    def _copper_layer_order(self) -> list[str]:
+        """Return the board's copper layers in physical stack order.
+
+        KiCad's canonical copper order is ``F.Cu``, then the inner layers
+        ``In1.Cu, In2.Cu, ...`` (ascending), then ``B.Cu``.  The numeric
+        ``Layer.number`` does NOT encode physical order (B.Cu is index 2 even
+        though it stacks last), so we derive the order by name.  This order
+        lets a through-hole / multi-span via bridge *every* copper layer it
+        physically passes through, not just the two endpoints named in
+        ``via.layers`` (issue #3783): a standard ``["F.Cu","B.Cu"]`` via on a
+        4-layer board electrically joins ``In1.Cu`` and ``In2.Cu`` too.
+        """
+        names = {layer.name for layer in self.pcb.copper_layers}
+        if not names:
+            # Fall back to the two outer layers, which exist on every board.
+            names = {"F.Cu", "B.Cu"}
+
+        def _inner_index(layer_name: str) -> int:
+            digits = layer_name[2:-3]  # strip "In" prefix and ".Cu" suffix
+            try:
+                return int(digits)
+            except ValueError:
+                return 0
+
+        inner = sorted(
+            (name for name in names if name.startswith("In") and name.endswith(".Cu")),
+            key=_inner_index,
+        )
+
+        order: list[str] = []
+        if "F.Cu" in names:
+            order.append("F.Cu")
+        order.extend(inner)
+        if "B.Cu" in names:
+            order.append("B.Cu")
+        return order
+
+    def _via_bridged_layers(self, via_layers: list[str]) -> frozenset[str]:
+        """Expand a via's named layer span into every copper layer it joins.
+
+        ``via.layers`` records only the *endpoints* of the via's span (e.g.
+        ``["F.Cu", "B.Cu"]`` for a through-hole via).  A through-hole / buried
+        via physically connects every copper layer between (and including)
+        those endpoints, so we expand the span across the board's physical
+        copper order (issue #3783).  A degenerate or unrecognised span falls
+        back to the named layers themselves.
+        """
+        copper_span = [layer_str for layer_str in via_layers if layer_str.endswith(".Cu")]
+        order = self._copper_layer_order()
+        indices = [order.index(layer_str) for layer_str in copper_span if layer_str in order]
+        if len(indices) < 2:
+            return frozenset(copper_span)
+        lo, hi = min(indices), max(indices)
+        return frozenset(order[lo : hi + 1])
+
+    def _collect_layer_bridges(
+        self,
+        pad_positions: dict[str, tuple[float, float]] | None = None,
+        pad_layers: dict[str, list[str]] | None = None,
+    ) -> list[tuple[tuple[float, float], frozenset[str]]]:
+        """Collect points where a via (or multi-layer pad) bridges copper layers.
+
+        A via electrically joins the copper layers listed in ``via.layers``
+        (e.g. ``["F.Cu", "B.Cu"]``) at its position.  A through-hole /
+        multi-layer pad (``*.Cu`` or two or more explicit ``.Cu`` layers)
+        bridges all copper layers it spans at its position.
+
+        This index is consulted by :meth:`_build_segment_chains` so that two
+        copper segments meeting at a shared XY point are only fused across
+        *different* copper layers when a real layer bridge exists there.  A
+        via-less F.Cu/B.Cu crossover (two traces that merely cross at the same
+        XY on opposite layers, with nothing joining them) is a legal,
+        DRC-clean layer crossover and must NOT be fused (issue #3783).
+
+        Args:
+            pad_positions: Optional pad-id -> board-frame position mapping.
+            pad_layers: Optional pad-id -> layer-list mapping.  When both pad
+                maps are supplied, multi-layer pads also contribute bridges.
+
+        Returns:
+            A list of ``(point, layer_set)`` tuples.  ``layer_set`` is the
+            frozenset of copper layers the bridge joins at ``point``.
+        """
+        bridges: list[tuple[tuple[float, float], frozenset[str]]] = []
+
+        # Vias: bridge every copper layer the via physically passes through.
+        # ``via.layers`` names only the span endpoints (e.g. ["F.Cu","B.Cu"]),
+        # so expand the span across the stackup — a through-hole via joins the
+        # inner layers too (issue #3783).
+        for via in self.pcb.vias:
+            via_layer_set = self._via_bridged_layers(via.layers)
+            if len(via_layer_set) >= 2:
+                bridges.append((via.position, via_layer_set))
+
+        # Multi-layer pads (through-hole / ``*.Cu``): bridge every copper layer
+        # they span.  ``*.Cu`` is treated as a universal copper bridge so any
+        # two copper segments meeting at the pad are joined (mirroring the
+        # wildcard handling in :meth:`_pad_layer_matches_zone`).
+        if pad_positions is not None and pad_layers is not None:
+            for pad_id, pad_layer_list in pad_layers.items():
+                copper = [layer_str for layer_str in pad_layer_list if layer_str.endswith(".Cu")]
+                if not copper:
+                    continue
+                wildcard = any(layer_str.startswith("*.") for layer_str in copper)
+                if wildcard or len(set(copper)) >= 2:
+                    pos = pad_positions.get(pad_id)
+                    if pos is None:
+                        continue
+                    layer_set = _ALL_COPPER_LAYERS if wildcard else frozenset(copper)
+                    bridges.append((pos, layer_set))
+
+        return bridges
+
+    def _layers_bridged_at(
+        self,
+        point: tuple[float, float],
+        layer_a: str,
+        layer_b: str,
+        bridges: list[tuple[tuple[float, float], frozenset[str]]],
+    ) -> bool:
+        """Return True if a via/multi-layer pad bridges two layers at a point.
+
+        ``layer_a`` and ``layer_b`` are joined at ``point`` when some bridge
+        coincident with ``point`` spans both layers (``_ALL_COPPER_LAYERS``
+        matches any copper layer, modelling a ``*.Cu`` through-hole pad).
+        """
+        for bridge_point, layer_set in bridges:
+            if not self._points_close(point, bridge_point):
+                continue
+            a_ok = layer_set is _ALL_COPPER_LAYERS or layer_a in layer_set
+            b_ok = layer_set is _ALL_COPPER_LAYERS or layer_b in layer_set
+            if a_ok and b_ok:
+                return True
+        return False
+
+    def _segments_chain_at_shared_point(
+        self,
+        seg_a: Any,
+        seg_b: Any,
+        bridges: list[tuple[tuple[float, float], frozenset[str]]],
+    ) -> bool:
+        """Decide whether two segments chain where they share an endpoint.
+
+        Same-layer segments chain whenever they share an XY endpoint (the
+        historic behaviour).  Different-layer segments chain only at a shared
+        XY endpoint that a via / multi-layer pad bridges across their two
+        layers — a bare cross-layer crossover does NOT chain (issue #3783).
+        """
+        same_layer = seg_a.layer == seg_b.layer
+        for pa in (seg_a.start, seg_a.end):
+            for pb in (seg_b.start, seg_b.end):
+                if not self._points_close(pa, pb):
+                    continue
+                if same_layer:
+                    return True
+                # Cross-layer: require an actual layer bridge at the point.
+                if self._layers_bridged_at(pa, seg_a.layer, seg_b.layer, bridges):
+                    return True
+        return False
+
     def _build_segment_chains(
         self,
         segments: list,
         pad_positions: dict[str, tuple[float, float]],
         graph: dict[str, set[str]],
+        pad_layers: dict[str, list[str]] | None = None,
     ) -> dict[str, set[str]]:
         """Build connectivity through chains of connected segments.
 
         Segments that share endpoints form chains. Pads at any point
         in a chain are connected to all other pads in the chain.
+
+        The chain builder is **layer-aware** (issue #3783): two segments on
+        *different* copper layers are only chained where they share an XY
+        endpoint if a via (``via.layers`` spanning both layers) or a
+        multi-layer pad actually bridges the layers at that point.  Two
+        traces that merely cross at the same XY on opposite layers with no
+        via — a legal, DRC-clean layer crossover — are NOT fused.  Same-layer
+        chaining is unchanged.
         """
         if not segments:
             return graph
 
+        # Per-point layer bridges (vias + multi-layer pads) used to gate
+        # cross-layer chain hops.
+        bridges = self._collect_layer_bridges(pad_positions, pad_layers)
+
         # Build segment adjacency graph
         segment_graph: dict[int, set[int]] = defaultdict(set)
         for i, seg_a in enumerate(segments):
-            for j, seg_b in enumerate(segments):
-                if i != j:
-                    # Check if segments share an endpoint
-                    if (
-                        self._points_close(seg_a.start, seg_b.start)
-                        or self._points_close(seg_a.start, seg_b.end)
-                        or self._points_close(seg_a.end, seg_b.start)
-                        or self._points_close(seg_a.end, seg_b.end)
-                    ):
-                        segment_graph[i].add(j)
-                        segment_graph[j].add(i)
+            for j in range(i + 1, len(segments)):
+                seg_b = segments[j]
+                if self._segments_chain_at_shared_point(seg_a, seg_b, bridges):
+                    segment_graph[i].add(j)
+                    segment_graph[j].add(i)
 
         # Find connected components of segments
         visited: set[int] = set()

--- a/tests/test_connectivity.py
+++ b/tests/test_connectivity.py
@@ -1196,3 +1196,182 @@ class TestConnectivityProResolution:
         assert exit_code == 1
         captured = capsys.readouterr()
         assert "PCB file not found" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Layer-aware segment chaining (issue #3783)
+#
+# A via-less F.Cu/B.Cu crossover — two different-net traces that merely cross
+# at the same (x, y) on opposite copper layers with NO via — is a legal,
+# DRC-clean layer crossover and must NOT be fused into one component.  A via
+# (or a multi-layer / through-hole pad) at that point DOES bridge the layers,
+# so a same-net trace that legitimately hops layers through a via must still
+# flood as one component.
+# ---------------------------------------------------------------------------
+
+
+def _crossover_pcb(*, with_via: bool, same_net: bool) -> str:
+    """Build a 2-layer PCB with NODE_B (F.Cu) crossing NODE_C (B.Cu).
+
+    Geometry mirrors the board-02 false-positive (issue #3783): a vertical
+    F.Cu trace from R1.1 and a horizontal B.Cu trace from R2.1 cross at
+    (110, 110).  ``with_via`` drops a through-hole via at the crossing.
+    ``same_net`` labels both traces/pads on the same net (only meaningful
+    together with ``with_via`` to model a real layer hop).
+    """
+    net_b = '(net 1 "NODE_B")'
+    pad2_net = '(net 1 "NODE_B")' if same_net else '(net 2 "NODE_C")'
+    via_block = ""
+    if with_via:
+        via_block = (
+            '  (via (at 110 110) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") '
+            '(net 1) (uuid "00000000-0000-0000-0000-0000000000f9"))\n'
+        )
+    return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "NODE_B")
+  (net 2 "NODE_C")
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000c1")
+    (at 110 105)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "fp-c1-ref"))
+    (property "Value" "1k" (at 0 1.5 0) (layer "F.Fab") (uuid "fp-c1-val"))
+    (pad "1" smd roundrect (at 0 0) (size 0.6 0.6) (layers "F.Cu" "F.Paste" "F.Mask")
+      (roundrect_rratio 0.25) {net_b})
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "B.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000c2")
+    (at 105 110)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "B.SilkS") (uuid "fp-c2-ref"))
+    (property "Value" "1k" (at 0 1.5 0) (layer "B.Fab") (uuid "fp-c2-val"))
+    (pad "1" smd roundrect (at 0 0) (size 0.6 0.6) (layers "B.Cu" "B.Paste" "B.Mask")
+      (roundrect_rratio 0.25) {pad2_net})
+  )
+  (segment (start 110 105) (end 110 110) (width 0.25) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-0000000000c3"))
+  (segment (start 110 110) (end 110 115) (width 0.25) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-0000000000c4"))
+  (segment (start 105 110) (end 110 110) (width 0.25) (layer "B.Cu") (net {1 if same_net else 2})
+    (uuid "00000000-0000-0000-0000-0000000000c5"))
+  (segment (start 110 110) (end 115 110) (width 0.25) (layer "B.Cu") (net {1 if same_net else 2})
+    (uuid "00000000-0000-0000-0000-0000000000c6"))
+{via_block})
+"""
+
+
+def _four_layer_thruvia_pcb() -> str:
+    """4-layer PCB: a through-hole via must bridge an inner-layer hop.
+
+    R1.1 routes on F.Cu to a via at (110, 110); the trace continues on the
+    inner layer In1.Cu to R2.1.  ``via.layers`` only names ["F.Cu","B.Cu"],
+    so the chainer must expand the through-hole span to include In1.Cu —
+    otherwise the same-net hop falsely splits (the board-05 regression in
+    issue #3783).
+    """
+    return """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (2 "In2.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "SIG")
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000d1")
+    (at 110 105)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "fp-d1-ref"))
+    (property "Value" "1k" (at 0 1.5 0) (layer "F.Fab") (uuid "fp-d1-val"))
+    (pad "1" smd roundrect (at 0 0) (size 0.6 0.6) (layers "F.Cu" "F.Paste" "F.Mask")
+      (roundrect_rratio 0.25) (net 1 "SIG"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000d2")
+    (at 115 110)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "F.SilkS") (uuid "fp-d2-ref"))
+    (property "Value" "1k" (at 0 1.5 0) (layer "F.Fab") (uuid "fp-d2-val"))
+    (pad "1" smd roundrect (at 0 0) (size 0.6 0.6) (layers "In1.Cu")
+      (roundrect_rratio 0.25) (net 1 "SIG"))
+  )
+  (segment (start 110 105) (end 110 110) (width 0.25) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-0000000000d3"))
+  (segment (start 110 110) (end 115 110) (width 0.25) (layer "In1.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-0000000000d4"))
+  (via (at 110 110) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-0000000000d5"))
+)
+"""
+
+
+class TestLayerAwareSegmentChaining:
+    """Issue #3783: cross-layer copper only fuses where a via/pad bridges."""
+
+    def test_via_less_crossover_is_two_components(self, tmp_path: Path) -> None:
+        """Different-net F.Cu/B.Cu traces crossing with NO via -> 2 groups."""
+        pcb_file = tmp_path / "crossover.kicad_pcb"
+        pcb_file.write_text(_crossover_pcb(with_via=False, same_net=False))
+        partition = ConnectivityValidator(pcb_file).extract_pad_partition()
+        # R1.1 (NODE_B, F.Cu) and R2.1 (NODE_C, B.Cu) must NOT fuse.
+        assert frozenset({"R1.1"}) in partition
+        assert frozenset({"R2.1"}) in partition
+        assert len(partition) == 2
+
+    def test_via_bridged_crossover_is_one_component(self, tmp_path: Path) -> None:
+        """Same-net F.Cu/B.Cu traces joined by a via -> 1 group."""
+        pcb_file = tmp_path / "via_bridge.kicad_pcb"
+        pcb_file.write_text(_crossover_pcb(with_via=True, same_net=True))
+        partition = ConnectivityValidator(pcb_file).extract_pad_partition()
+        # The via at the crossing bridges F.Cu<->B.Cu, so both pads fuse.
+        assert frozenset({"R1.1", "R2.1"}) in partition
+        assert len(partition) == 1
+
+    def test_via_at_crossover_bridges_different_nets(self, tmp_path: Path) -> None:
+        """A via present at a crossover DOES bridge layers (sanity check).
+
+        With a via at the crossing the two traces become galvanically one
+        component even when labeled as different nets — this is what makes
+        the label-free extractor catch a *real* via-on-crossover short, and
+        confirms the layer-aware gate is not blanket-suppressing vias.
+        """
+        pcb_file = tmp_path / "via_short.kicad_pcb"
+        pcb_file.write_text(_crossover_pcb(with_via=True, same_net=False))
+        partition = ConnectivityValidator(pcb_file).extract_pad_partition()
+        assert frozenset({"R1.1", "R2.1"}) in partition
+        assert len(partition) == 1
+
+    def test_through_via_bridges_inner_layer_hop(self, tmp_path: Path) -> None:
+        """A through-hole via bridges inner layers not named in via.layers."""
+        pcb_file = tmp_path / "thruvia.kicad_pcb"
+        pcb_file.write_text(_four_layer_thruvia_pcb())
+        partition = ConnectivityValidator(pcb_file).extract_pad_partition()
+        # F.Cu -> via -> In1.Cu hop must keep the net as one component even
+        # though via.layers only lists F.Cu/B.Cu.
+        assert frozenset({"R1.1", "R2.1"}) in partition
+        assert len(partition) == 1
+
+    def test_copper_layer_order_expands_thru_via(self, tmp_path: Path) -> None:
+        """The via-span expander includes inner copper layers."""
+        pcb_file = tmp_path / "thruvia.kicad_pcb"
+        pcb_file.write_text(_four_layer_thruvia_pcb())
+        validator = ConnectivityValidator(pcb_file)
+        order = validator._copper_layer_order()
+        assert order == ["F.Cu", "In1.Cu", "In2.Cu", "B.Cu"]
+        bridged = validator._via_bridged_layers(["F.Cu", "B.Cu"])
+        assert bridged == frozenset({"F.Cu", "In1.Cu", "In2.Cu", "B.Cu"})

--- a/tests/test_copper_lvs.py
+++ b/tests/test_copper_lvs.py
@@ -979,3 +979,80 @@ def test_board04_osc_in_out_short_absent() -> None:
         f"({[(seg.start, seg.end, seg.layer) for seg in bridging]}); "
         "the OSC_OUT escape stub must not pass through the OSC_IN pad center."
     )
+
+
+# ---------------------------------------------------------------------------
+# Layer-aware crossover (issue #3783): a via-less F.Cu/B.Cu crossover of two
+# different nets is a legal layer crossover and must NOT be reported as a
+# copper short.  This is the end-to-end gate behaviour behind board-02's
+# false-positive NODE_B<->NODE_C "short".
+# ---------------------------------------------------------------------------
+
+
+def _pcb_crossover_via_less() -> str:
+    """Two different-net traces crossing at the same XY on opposite layers.
+
+    R1.1 (NODE_B) routes vertically on F.Cu through (110, 110); R2.1
+    (NODE_C) routes horizontally on B.Cu through (110, 110).  No via joins
+    them, so the copper-LVS gate must keep them on separate nets.
+    """
+    return """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "NODE_B")
+  (net 2 "NODE_C")
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000fb1")
+    (at 110 105)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "fp-fb1-ref"))
+    (property "Value" "1k" (at 0 1.5 0) (layer "F.Fab") (uuid "fp-fb1-val"))
+    (pad "1" smd roundrect (at 0 0) (size 0.6 0.6) (layers "F.Cu" "F.Paste" "F.Mask")
+      (roundrect_rratio 0.25) (net 1 "NODE_B"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "B.Cu")
+    (uuid "00000000-0000-0000-0000-000000000fb2")
+    (at 105 110)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "B.SilkS") (uuid "fp-fb2-ref"))
+    (property "Value" "1k" (at 0 1.5 0) (layer "B.Fab") (uuid "fp-fb2-val"))
+    (pad "1" smd roundrect (at 0 0) (size 0.6 0.6) (layers "B.Cu" "B.Paste" "B.Mask")
+      (roundrect_rratio 0.25) (net 2 "NODE_C"))
+  )
+  (segment (start 110 105) (end 110 110) (width 0.25) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-000000000fb3"))
+  (segment (start 110 110) (end 110 115) (width 0.25) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-000000000fb4"))
+  (segment (start 105 110) (end 110 110) (width 0.25) (layer "B.Cu") (net 2)
+    (uuid "00000000-0000-0000-0000-000000000fb5"))
+  (segment (start 110 110) (end 115 110) (width 0.25) (layer "B.Cu") (net 2)
+    (uuid "00000000-0000-0000-0000-000000000fb6"))
+)
+"""
+
+
+def test_via_less_crossover_copper_lvs_clean(tmp_path: Path) -> None:
+    """A via-less F.Cu/B.Cu crossover is clean copper-LVS (issue #3783).
+
+    The two traces cross at one XY on opposite layers with no via — a legal,
+    DRC-clean layer crossover.  The copper extractor must keep NODE_B and
+    NODE_C separate, so the partition diff against the schematic is clean
+    (no spurious NODE_B<->NODE_C short).
+    """
+    pcb_path = _write(tmp_path, "crossover.kicad_pcb", _pcb_crossover_via_less())
+    partition = ConnectivityValidator(pcb_path).extract_pad_partition()
+
+    # Each net keeps its own pad — no phantom short.
+    assert frozenset({"R1.1"}) in partition
+    assert frozenset({"R2.1"}) in partition
+
+    sch = {("R1", "1"): "NODE_B", ("R2", "1"): "NODE_C"}
+    result = compare_partitions(sch, partition)
+    assert result.clean
+    assert result.mismatches == ()


### PR DESCRIPTION
## Summary

The copper-LVS connectivity extractor (`ConnectivityValidator._build_segment_chains`) chained two track segments whenever they shared an `(x, y)` endpoint, **ignoring each segment's copper layer**. A legal via-less F.Cu/B.Cu crossover — two different-net traces that merely cross at the same XY on opposite layers with **no via** — was therefore fused into one component and reported as a phantom short.

A fresh `boards/02-charlieplex-led` regen routes NODE_B vertically on F.Cu and NODE_C horizontally on B.Cu; they cross at board-frame `(18.1, 28.0)` with no via, and the layer-agnostic chainer mis-fused them → spurious `short NODE_B<->NODE_C`. On a real 2-layer board this crossover is electrically correct (DRC-clean), so the gate was wrong, not the router.

This is a correctness fix to the shared copper-LVS extractor; the router, the board-02 recipe, and all committed board artifacts are untouched.

## Changes

- **`src/kicad_tools/validate/connectivity.py`**
  - `_build_segment_chains` is now **layer-aware**: same-layer segments chain at a shared XY endpoint (unchanged); different-layer segments chain only where a via or multi-layer/through-hole pad actually bridges the layers at that point.
  - New helpers: `_collect_layer_bridges` (per-point via + multi-layer-pad bridge index), `_layers_bridged_at`, `_segments_chain_at_shared_point`.
  - `_via_bridged_layers` / `_copper_layer_order` expand a via's named span (`["F.Cu","B.Cu"]`) across the board's **physical** copper stack, so a through-hole via also bridges inner layers (`In1.Cu`, `In2.Cu`) it passes through. Without this, real same-net layer hops on 4-layer boards (board-05) would falsely split into opens.
  - Both `_build_segment_chains` call sites (`extract_pad_partition` step 2b and `_build_connectivity_graph`) now pass `pad_layers` through.
- **`tests/test_connectivity.py`** — `TestLayerAwareSegmentChaining`: via-less crossover → 2 groups; via-bridged → 1 group; via-on-crossover bridges different nets; through-hole via bridges an inner-layer hop; `_copper_layer_order` / `_via_bridged_layers` unit checks.
- **`tests/test_copper_lvs.py`** — end-to-end `compare_partitions` test on a via-less F.Cu/B.Cu crossover fixture → `clean == True`.
- **`.github/workflows/ci.yml`** — add the deferred `board-02-end-to-end` full e2e job (clone of `board-00-end-to-end`, `--stem charlieplex_3x3`).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `_build_segment_chains` layer-aware; same-layer unchanged | ✅ | New helpers gate cross-layer hops on a via/pad bridge; same-layer path untouched |
| Real via-bridged nets still flood (no new opens) | ✅ | Fleet copper-LVS mismatch counts identical before/after on boards 00-07 (board-05: 96→96 after via-span fix; the naive version regressed to 104) |
| Fresh board-02 regen copper-LVS clean | ✅ | `generate_design.py` exits 0; `kct check` → `Overall: PASSED`, no NODE_B<->NODE_C short |
| Board-02 DRC-clean + matrix connected | ✅ | `kct check` DRC/ERC/LVS/Manifest all PASSED |
| Regression test: via-less (2 groups) vs via-bridged (1 group) | ✅ | `TestLayerAwareSegmentChaining` + copper-LVS fixture |
| Committed board-02 still clean | ✅ | `kct check` on committed PCB → Overall PASSED (unchanged) |
| No board regressed; no real short masked | ✅ | Adversarial short tests (#3769/#3772/#3777) in `test_copper_lvs.py` still flag same-layer shorts |
| board-02-end-to-end CI job added | ✅ | Added after `board-01-end-to-end`, YAML validated |

## Decision: committed board-02 PCB not regenerated

The committed `charlieplex_3x3_routed.kicad_pcb` is already copper-LVS clean under the new extractor, and a fresh regen is now also clean — so the board is reproducible **without** touching the committed artifact. Per the issue's scope guard ("do NOT modify the committed board-02 PCB"), the committed artifact is left as-is and the change stays bounded to the shared extractor.

## Test Plan

- `pytest tests/test_connectivity.py tests/test_copper_lvs.py` — 77 passed.
- Broad regression: `test_board_00_lvs`, `test_board_03_copper_lvs`, `test_board_03_regression`, `test_board_04_routing_regression`, `test_lvs`, `test_output_connectivity`, `test_pcb_nets_connectivity`, `test_route_pipeline_connectivity`, `test_routing_connectivity` — 189 passed, 1 skipped.
- Fleet `kct check` on committed boards 00-07: copper-LVS counts unchanged vs `origin/main`.
- Fresh `boards/02-charlieplex-led/generate_design.py` → exit 0, `kct check` Overall PASSED.
- `ruff check .` clean, `ruff format --check` clean on changed files, `mypy` on connectivity.py adds no new errors (pre-existing `Pad` variable-reuse errors only).

Closes #3783