### PR TITLE
feat(lvs): graduate board-03 to hard copper-LVS gate + add board-03 e2e CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1144,6 +1144,100 @@ jobs:
             --stem charlieplex_3x3 \
             /tmp/board02-staging/02-charlieplex-led
 
+  board-03-end-to-end:
+    # Issue #3795 (#3780 Part 2): LVS-ONLY end-to-end gate for board 03
+    # ("usb-joystick"), graduated out of ``ADVISORY_LVS_BOARDS``.  Board 03's
+    # recipe now runs ``write_lvs_report(..., require_clean=True,
+    # run_copper=True, run_label=False)`` -- a HARD copper-LVS gate.  A fresh
+    # clean-room regen routes fully and regenerates copper-clean (0 shorts /
+    # 0 opens, verified 2/2 runs), so this job is GREEN.
+    #
+    # This uses the asserter's ``--lvs-only`` mode (like boards 06/07), NOT
+    # the full e2e asserter (boards 00/01/02).  Board 03 carries 4 advisory
+    # ``via_in_pad`` DRC residuals (the recipe prints ``DRC: PASS``; the
+    # board is not in ``.github/routed-drc-tolerance.yml``), so board-metrics
+    # classifies it ``status: partial`` / ``drc_violations: 4``.  The full
+    # asserter hard-asserts ``status: ok`` / ``drc_violations: 0`` and would
+    # FAIL on those advisories; ``--lvs-only`` asserts only artifact presence
+    # + ``lvs.json clean=true`` (+ ``board.json lvs_clean=true``), which is
+    # the meaningful copper-LVS gate.
+    #
+    # The ``Build C++ router backend`` step is REQUIRED: the recipe re-routes
+    # during regen, and per CLAUDE.md a missing native extension makes routing
+    # multi-minute-per-net.  Board 03's recipe takes only an output-dir arg
+    # (no ``--step`` / ``--seed``); it routes fully and exits 0.
+    #
+    # Advisory until a repo admin adds it to branch protection (same as the
+    # board 00/01/02/06/07 e2e jobs).
+    name: Board 03 End-to-End (LVS-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    container:
+      image: kicad/kicad:10.0
+      options: --user 0:0
+    defaults:
+      run:
+        shell: bash
+    env:
+      PYTHONHASHSEED: "42"
+      PYTHONUNBUFFERED: "1"
+    steps:
+      - name: Ensure container has prerequisites
+        run: |
+          set -euo pipefail
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates curl git cmake build-essential
+          kicad-cli --version
+
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        run: |
+          set -euo pipefail
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install dependencies
+        run: uv sync --extra dev --python 3.12
+
+      - name: Build C++ router backend
+        run: uv run kct build-native
+
+      - name: Regenerate board 03 from recipe (clean tmp directory)
+        # Board 03's recipe takes only an output-dir argument and routes
+        # fully (no --step / --seed).  It regenerates copper-LVS clean and
+        # exits 0.  write_lvs_report(require_clean=True) writes lvs.json and
+        # raises on any copper short/open; the LVS-only asserter below is the
+        # gate.
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/board03-ci
+          mkdir -p /tmp/board03-ci
+          uv run python boards/03-usb-joystick/generate_design.py \
+            /tmp/board03-ci
+          test -f /tmp/board03-ci/lvs.json
+
+      - name: Emit board.json via kct board-metrics
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/board03-staging
+          mkdir -p /tmp/board03-staging/03-usb-joystick/output
+          cp -r /tmp/board03-ci/. /tmp/board03-staging/03-usb-joystick/output/
+          uv run kct board-metrics /tmp/board03-staging/03-usb-joystick
+
+      - name: Assert artifacts + lvs.json clean (LVS-only)
+        # --lvs-only: assert artifact presence + lvs.json clean=true +
+        # board.json lvs_clean=true, but NOT status:ok / drc_violations:0
+        # (board 03 carries 4 advisory via_in_pad DRC residuals ->
+        # status='partial').
+        run: |
+          set -euo pipefail
+          uv run python scripts/ci/check_board_00_e2e.py \
+            --stem usb_joystick \
+            --lvs-only \
+            /tmp/board03-staging/03-usb-joystick
+
   board-06-end-to-end:
     # Issue #3779: LVS-ONLY end-to-end gate for board 06 ("diffpair-test").
     # Board 06 is a PCB-first routing fixture (USB3 connectors with no

--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,0 @@
-# Loom-managed worktree marker
-# Created by .loom/scripts/worktree.sh
-# Issue: 3795
-# Branch: feature/issue-3795
-# Removing this file makes Loom treat the worktree as user-owned and refuse
-# to clean it up automatically.

--- a/.loom-managed
+++ b/.loom-managed
@@ -1,0 +1,6 @@
+# Loom-managed worktree marker
+# Created by .loom/scripts/worktree.sh
+# Issue: 3795
+# Branch: feature/issue-3795
+# Removing this file makes Loom treat the worktree as user-owned and refuse
+# to clean it up automatically.

--- a/boards/03-usb-joystick/generate_design.py
+++ b/boards/03-usb-joystick/generate_design.py
@@ -742,23 +742,25 @@ def main() -> int:
         # Step 6: Run DRC
         drc_success = run_drc(routed_path)
 
-        # Step 6.5: LVS (advisory, #3780) -- board 03 is in
-        # ``ADVISORY_LVS_BOARDS``.  The residual GND copper-opens are now
-        # FIXED (#3787): Step 5.4 stitches the F.Cu/B.Cu GND planes so the
-        # J1 USB-C F.Cu-only shield pads bond into the GND net and the
-        # copper comparator reports 0 shorts / 0 opens.  ``require_clean``
-        # stays ``False`` here on purpose: flipping it to a hard gate (and
-        # removing the board from ``ADVISORY_LVS_BOARDS``) is #3780 Part 2,
-        # tracked separately and explicitly out of scope for #3787.
-        # ``write_lvs_report`` still logs the summary and writes
-        # ``output/lvs.json`` (now ``clean: true``) so board.json / the
-        # gallery LVS chip surface the green status.  ``run_label`` is off
-        # because the copper comparator is the meaningful leg here.
+        # Step 6.5: LVS (HARD copper gate, #3795 / #3780 Part 2) -- board 03
+        # graduated out of ``ADVISORY_LVS_BOARDS``.  The residual GND
+        # copper-opens were FIXED in #3787: Step 5.4 stitches the F.Cu/B.Cu
+        # GND planes so the J1 USB-C F.Cu-only shield pads bond into the GND
+        # net and the copper comparator reports 0 shorts / 0 opens.  A fresh
+        # clean-room ``generate_design.py`` regen regenerates copper-clean,
+        # so ``require_clean=True`` now hard-gates the copper leg: a
+        # copper short/open raises :class:`BoardNetlistMismatch` and trips
+        # the recipe exit gate (and the new ``board-03-end-to-end`` CI job
+        # asserts ``lvs.json clean=true``).  ``write_lvs_report`` still
+        # writes ``output/lvs.json`` so board.json / the gallery LVS chip
+        # surface the green status.  ``run_label`` stays ``False``: the
+        # copper comparator is the meaningful leg, and the USB-C fixture's
+        # ``schematic_net=None`` label noise keeps the label leg advisory.
         write_lvs_report(
             sch_path,
             routed_path,
             output_dir,
-            require_clean=False,
+            require_clean=True,
             run_copper=True,
             run_label=False,
         )

--- a/src/kicad_tools/lvs/recipe.py
+++ b/src/kicad_tools/lvs/recipe.py
@@ -26,10 +26,12 @@ Gate policy is per-board (see the curator matrix on #3762):
 * Boards 06/07 are copper-clean but label-dirty (PCB-first test fixtures
   whose floating schematic pins read ``schematic_net=None``); they gate on
   copper only (``run_label=False``).
-* Boards in :data:`ADVISORY_LVS_BOARDS` (03/04/05) are genuinely dirty
-  today; they still run LVS and emit ``lvs.json`` so the gallery chip and
-  ``board-metrics`` surface the true state, but pass ``require_clean=False``
-  so the recipe logs the mismatch summary without raising.
+* Boards in :data:`ADVISORY_LVS_BOARDS` (04/05) are genuinely dirty on a
+  fresh clean-room regen; they still run LVS and emit ``lvs.json`` so the
+  gallery chip and ``board-metrics`` surface the true state, but pass
+  ``require_clean=False`` so the recipe logs the mismatch summary without
+  raising.  Board 03 graduated to a hard copper-LVS gate in #3795 (its
+  recipe regenerates copper-clean) and is no longer in the allowlist.
 """
 
 from __future__ import annotations
@@ -48,11 +50,21 @@ from kicad_tools.lvs.copper_lvs import CopperLVSResult, compare_copper_netlist
 # Recipes for these boards must pass ``require_clean=False`` so a dirty
 # comparator logs a summary instead of raising.  CI does NOT assert
 # ``clean=true`` for these boards.  This allowlist is the single auditable
-# place for the exemption -- shrink it as per-board fix follow-ups land
-# (boards 03/04 board-fix issues; board 05 blocked behind #3775/#3766).
+# place for the exemption -- shrink it as per-board fix follow-ups land.
+#
+# Graduated (removed): board 03 (#3795) -- its recipe regenerates
+# copper-LVS clean (0/0) on a fresh clean-room route, now hard-gated.
+#
+# Still advisory:
+# * 04-stm32-devboard -- the COMMITTED PCB was hand-fixed (#3785/#3796:
+#   OSC short + power-pad bonding), but a fresh ``generate_design.py``
+#   regen re-introduces the OSC_IN<->OSC_OUT short + 20 same-net power
+#   opens (21 mismatches).  The RECIPE cannot yet produce a clean board
+#   from scratch, so a hard gate would be RED.  Graduation blocked on a
+#   recipe-reproducibility fix (board-04 follow-up).
+# * 05-bldc-motor-controller -- incomplete routing, blocked on #3775/#3766.
 ADVISORY_LVS_BOARDS: frozenset[str] = frozenset(
     {
-        "03-usb-joystick",
         "04-stm32-devboard",
         "05-bldc-motor-controller",
     }

--- a/tests/test_lvs_recipe.py
+++ b/tests/test_lvs_recipe.py
@@ -197,9 +197,12 @@ def test_no_comparator_selected_raises_value_error(
 
 
 def test_advisory_allowlist_contains_known_dirty_boards() -> None:
-    assert "03-usb-joystick" in ADVISORY_LVS_BOARDS
+    # Boards whose fresh clean-room regen is still copper/label dirty.
     assert "04-stm32-devboard" in ADVISORY_LVS_BOARDS
     assert "05-bldc-motor-controller" in ADVISORY_LVS_BOARDS
+    # Graduated boards must NOT be exempted.  Board 03 graduated to a hard
+    # copper-LVS gate in #3795 (its recipe regenerates copper-clean).
+    assert "03-usb-joystick" not in ADVISORY_LVS_BOARDS
     # Clean boards must NOT be exempted.
     assert "00-simple-led" not in ADVISORY_LVS_BOARDS
     assert "01-voltage-divider" not in ADVISORY_LVS_BOARDS


### PR DESCRIPTION
## Summary

Completes the board-03 slice of #3780 Part 2: graduates board 03 (usb-joystick) out of the `ADVISORY_LVS_BOARDS` allowlist and onto a **hard** copper-LVS gate. A fresh clean-room `generate_design.py` regen (C++ backend built) routes board-03 fully and regenerates copper-LVS clean (0 shorts / 0 opens, verified 2/2 runs, recipe exit 0), so "passes CI" now means "copper-LVS clean" for this board too.

Board-04 and board-05 stay advisory. Board-04's graduation is deferred behind a recipe-reproducibility fix (#3797): the **committed** board-04 PCB is hand-fixed (#3785/#3796), but a fresh `generate_design.py` regen re-introduces the `OSC_IN`/`OSC_OUT` short + 20 same-net power opens (21 mismatches), so a `board-04-end-to-end` job would be RED.

## Changes

- **`src/kicad_tools/lvs/recipe.py`** — remove `"03-usb-joystick"` from `ADVISORY_LVS_BOARDS` (04/05 remain); refresh the allowlist comment + module docstring to record board-03's graduation and board-04's still-dirty fresh regen.
- **`boards/03-usb-joystick/generate_design.py`** — flip the `write_lvs_report(...)` call to `require_clean=True` (copper hard gate). `run_copper=True`, `run_label=False` unchanged (USB-C fixture has `schematic_net=None` label noise; label stays advisory). Updated the comment block.
- **`.github/workflows/ci.yml`** — add a `board-03-end-to-end` (LVS-only) job cloned from `board-06-end-to-end`: regenerates board-03 from its recipe, retains the **Build C++ router backend** step (the regen re-routes), emits `board.json` via `kct board-metrics`, and runs `check_board_00_e2e.py --stem usb_joystick --lvs-only`. Uses `--lvs-only` (not the full asserter) because board-03 is `status: partial` (4 advisory `via_in_pad` DRC).
- **`tests/test_lvs_recipe.py`** — update the allowlist membership assertion for board-03's graduation.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `03-usb-joystick` removed from `ADVISORY_LVS_BOARDS`; 04/05 remain | ✅ | `test_advisory_allowlist_contains_known_dirty_boards` passes |
| board-03 recipe `require_clean=True` (copper); `run_copper=True`, `run_label=False` unchanged | ✅ | Edited L757-764 of `generate_design.py` |
| New `board-03-end-to-end` LVS-only job (regen + build-native + board-metrics + `--stem usb_joystick --lvs-only`) | ✅ | YAML parses; job present alongside 00/01/02/06/07 |
| New job is GREEN (board-03 regenerates copper-clean) | ✅ | Local: regen exit 0, `lvs.json clean=true`, asserter exit 0 (2/2 runs) |
| Boards 00/01/02/06/07 e2e gates unaffected | ✅ | No edits to their jobs/recipes; only an additive job inserted |
| Board-04 stays advisory (in allowlist, recipe `require_clean=False`, no e2e job) | ✅ | `04-stm32-devboard` retained; recipe untouched; no `board-04-end-to-end` |
| Board-05 stays advisory | ✅ | `05-bldc-motor-controller` retained; untouched |
| recipe.py allowlist comment updated | ✅ | Documents board-03 graduation + board-04 still-dirty regen |
| Board-04 reproducibility follow-up filed | ✅ | #3797 (`loom:architect`) |

## Test Plan

Verified locally (C++ backend built, `kct build-native --check` = available 1.0.0):
- `rm -rf /tmp/b03 && PYTHONHASHSEED=42 uv run python boards/03-usb-joystick/generate_design.py /tmp/b03` → exit 0, `lvs.json clean=true`, 0 copper mismatches.
- Stage into `/tmp/b03-staging/03-usb-joystick/output/`, `uv run kct board-metrics ...` → `status=partial`, `drc_violations=4`, `lvs_clean=True`.
- `check_board_00_e2e.py --stem usb_joystick --lvs-only ...` → **exit 0**.
- Negative check: full asserter (no `--lvs-only`) → **exit 1** (fails on `drc_violations=4`), confirming `--lvs-only` is required.
- `uv run pytest tests/test_lvs_recipe.py tests/test_board_03_copper_lvs.py tests/test_board_03_regression.py` → 28 passed, 1 skipped.
- `uv run pytest -k "lvs or recipe or board_metrics"` → 147 passed, 1 skipped (after test fix).
- `ruff check`, `ruff format --check`, `mypy src/kicad_tools/lvs/recipe.py` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #3795