### PR TITLE
feat(boards): route boards 02/03/04 under deterministic iteration budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1087,6 +1087,14 @@ jobs:
     defaults:
       run:
         shell: bash
+    env:
+      # Issue #3799: pin PYTHONHASHSEED so the board-02 regen is
+      # reproducible across runner environments (mirrors board-03/06/07).
+      # The recipe ALSO pins it on the route subprocess, but pinning it at
+      # the job level covers the whole regen pipeline (schematic + zone +
+      # LVS) for belt-and-suspenders determinism.
+      PYTHONHASHSEED: "42"
+      PYTHONUNBUFFERED: "1"
     steps:
       - name: Ensure container has prerequisites
         run: |

--- a/boards/02-charlieplex-led/generate_design.py
+++ b/boards/02-charlieplex-led/generate_design.py
@@ -19,6 +19,7 @@ Usage:
 If no output directory is specified, files are written to ./output/
 """
 
+import os
 import subprocess
 import sys
 import uuid
@@ -580,8 +581,17 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
         "negotiated",
         "--iterations",
         "30",
-        "--per-net-timeout",
-        "30",
+        # Issue #3799: route under an ITERATION budget instead of the
+        # per-net WALL-CLOCK cutoff.  --seed only seeds Python's global
+        # random; it does NOT control the per-net A* deadline checked in
+        # the C++ loop.  On a loaded machine that wall-clock budget fires
+        # mid-search and the net lands less copper -- same seed, different
+        # copper.  --deterministic-budget (#3538) disables the per-net
+        # wall-clock cutoff and pins a fixed node-expansion backstop, so
+        # the seed-42 re-route is byte-identical (UUID-normalized) across
+        # machines.  --timeout 240 below is retained only as a SAFETY
+        # backstop (the normalizer warns if it would bind).
+        "--deterministic-budget",
         "--timeout",
         "240",
         "--seed",
@@ -598,13 +608,22 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
         "jlcpcb",
     ]
 
+    # Issue #3799: pin PYTHONHASHSEED for the route subprocess so any
+    # string-keyed dict/set iteration in the negotiated router is
+    # reproducible across runner environments (CPython randomizes string
+    # hashing per-process otherwise).  Combined with --seed 42 +
+    # --deterministic-budget this makes the full pipeline deterministic,
+    # not just the A* loop.  Mirrors board-07's convention.
+    env = os.environ.copy()
+    env["PYTHONHASHSEED"] = "42"
+
     print(f"\n1. Input: {input_path}")
     print(f"   Output: {output_path}")
     print(f"   Skipping nets: {skip_nets}")
-    print(f"   Command: {' '.join(cmd)}")
+    print(f"   Command: PYTHONHASHSEED={env['PYTHONHASHSEED']} {' '.join(cmd)}")
     print("\n2. Routing...")
 
-    result = subprocess.run(cmd, capture_output=False, text=True)
+    result = subprocess.run(cmd, capture_output=False, text=True, env=env)
 
     # ``kct route`` returns 0 on full success and a non-zero code on
     # partial / failed routing.  Either way it writes a routed PCB to

--- a/boards/02-charlieplex-led/route_demo.py
+++ b/boards/02-charlieplex-led/route_demo.py
@@ -29,6 +29,7 @@ Example:
 """
 
 import contextlib
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -194,8 +195,19 @@ def main():
         "negotiated",
         "--iterations",
         "30",
-        "--per-net-timeout",
-        "30",
+        # Issue #3799: route under an ITERATION budget instead of the
+        # per-net WALL-CLOCK cutoff so the seed-42 route is byte-identical
+        # (UUID-normalized) across machines.  --seed only seeds Python's
+        # global random; it does NOT control the per-net A* deadline checked
+        # in the C++ loop.  On a loaded machine that wall-clock budget fires
+        # mid-search and the net lands less copper -- same seed, different
+        # copper.  --deterministic-budget (#3538) disables the per-net
+        # wall-clock cutoff and pins a fixed node-expansion backstop.
+        # --timeout 240 below is retained only as a SAFETY backstop.
+        # This MUST stay in sync with generate_design.py:route_pcb()
+        # (Issue #3207 no-drift guard,
+        # tests/test_board02_route_demo_recipe.py).
+        "--deterministic-budget",
         "--timeout",
         "240",
         "--seed",
@@ -219,7 +231,15 @@ def main():
     # It returns 0 on full success and a non-zero code on partial routing
     # (in which case it still writes the partially-routed PCB).  We capture
     # stdout for net-count parsing by tee-ing through subprocess.PIPE.
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    # Issue #3799: pin PYTHONHASHSEED for the route subprocess so any
+    # string-keyed dict/set iteration in the negotiated router is
+    # reproducible across runner environments (CPython randomizes string
+    # hashing per-process otherwise).  Combined with --seed 42 +
+    # --deterministic-budget this makes the full pipeline deterministic,
+    # mirroring generate_design.py:route_pcb().
+    env = os.environ.copy()
+    env["PYTHONHASHSEED"] = "42"
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env)
     # Echo subprocess output so users can see routing progress, errors, etc.
     if result.stdout:
         print(result.stdout)

--- a/boards/03-usb-joystick/generate_design.py
+++ b/boards/03-usb-joystick/generate_design.py
@@ -23,6 +23,7 @@ Usage:
 If no output directory is specified, files are written to ./output/
 """
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -533,6 +534,17 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
         "jlcpcb-tier1",
         "--backend",
         "cpp",
+        # Issue #3799: route under an ITERATION budget instead of the
+        # per-net WALL-CLOCK cutoff.  --seed only seeds Python's global
+        # random; it does NOT control the per-net A* deadline checked in
+        # the C++ loop, so on a loaded machine the wall-clock budget fires
+        # mid-search and the net lands less copper -- same seed, different
+        # copper.  --deterministic-budget (#3538) disables the per-net
+        # wall-clock cutoff and pins a fixed node-expansion backstop, so
+        # the seed-42 re-route is byte-identical (UUID-normalized) across
+        # machines.  --timeout 600 below is then a SAFETY backstop only.
+        # KEEP IN SYNC with tests/router/test_board03_routing_baseline.py.
+        "--deterministic-budget",
         "--timeout",
         "600",
         # Issues #3507/#3454: ``--raw`` (skip TraceOptimizer) was
@@ -549,7 +561,21 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
         # the sidecar-aware ``kct check``).
     ]
     print(f"   $ {' '.join(cmd[1:])}")
-    proc = _sp.run(cmd, capture_output=True, text=True, timeout=1800, check=False)
+    # Issue #3799: pin PYTHONHASHSEED for the route subprocess so any
+    # string-keyed dict/set iteration in the negotiated router is
+    # reproducible across runner environments.  Combined with --seed 42 +
+    # --deterministic-budget this makes the full pipeline deterministic,
+    # not just the A* loop.  Mirrors board-07's convention.
+    _route_env = os.environ.copy()
+    _route_env["PYTHONHASHSEED"] = "42"
+    proc = _sp.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=1800,
+        check=False,
+        env=_route_env,
+    )
     # Echo the route output so reach parsers (and humans) see the full log.
     print(proc.stdout)
     if proc.returncode in (1, 5):

--- a/boards/04-stm32-devboard/generate_design.py
+++ b/boards/04-stm32-devboard/generate_design.py
@@ -23,6 +23,7 @@ Usage:
 If no output directory is specified, files are written to ./output/
 """
 
+import os
 import subprocess
 import sys
 import uuid
@@ -1239,12 +1240,32 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
         # across runs and PR #3063 measurements are reproducible.
         "--seed",
         "42",
+        # Issue #3799: route under an ITERATION budget instead of the
+        # per-net WALL-CLOCK cutoff.  --seed only seeds Python's global
+        # random; it does NOT control the per-net A* deadline checked in
+        # the C++ loop.  On a loaded machine that wall-clock budget fires
+        # mid-search and the net lands less copper -- same seed, different
+        # copper (the observed 153/145/145-segment divergence).
+        # --deterministic-budget (#3538) disables the per-net wall-clock
+        # cutoff and pins a fixed node-expansion backstop, so the seed-42
+        # re-route is byte-identical (UUID-normalized) regardless of
+        # machine speed/load.  --timeout 600 below is then a SAFETY
+        # backstop only (the normalizer warns if it would bind).
+        "--deterministic-budget",
         "--timeout",
         "600",
     ]
     print(f"\n   Command: {' '.join(cmd)}")
 
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    # Issue #3799: pin PYTHONHASHSEED for the route subprocess so any
+    # string-keyed dict/set iteration in the negotiated router is
+    # reproducible across runner environments.  Combined with --seed 42 +
+    # --deterministic-budget this makes the full pipeline deterministic,
+    # not just the A* loop.  Mirrors board-07's convention.
+    env = os.environ.copy()
+    env["PYTHONHASHSEED"] = "42"
+
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env)
     if result.stdout:
         # Echo router output (last ~80 lines is plenty for the summary)
         for line in result.stdout.strip().split("\n"):

--- a/scripts/ci/board_route_determinism_smoke.sh
+++ b/scripts/ci/board_route_determinism_smoke.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Routed-copper determinism smoke for a board's UNROUTED PCB (Issue #3799).
+#
+# Routes a board's committed unrouted ``output/<stem>.kicad_pcb`` N times
+# (default N=2) with the board's production ``kct route`` flags -- which
+# now include ``--deterministic-budget`` + ``--seed 42`` + a pinned
+# ``PYTHONHASHSEED=42`` -- and asserts that the UUID-normalized routed
+# COPPER (the ``(segment ...)`` / ``(via ...)`` / ``(arc ...)`` set) is
+# byte-identical across every run.
+#
+# WHY this exists (Issue #3799 root cause):
+#   ``--seed`` only seeds Python's global ``random``.  It does NOT control
+#   the per-net A* WALL-CLOCK cutoff (``--per-net-timeout``, default 30 s)
+#   checked inside the C++ A* loop.  On a loaded machine that budget fires
+#   mid-search and the net lands less copper -- SAME seed, DIFFERENT copper.
+#   ``--deterministic-budget`` (#3538) swaps the wall-clock cutoff for a
+#   fixed node-expansion ITERATION budget, so the abort point is
+#   machine-independent and the seed-42 route is reproducible.  This smoke
+#   is the regression gate proving boards 02/03/04 stay reproducible.
+#
+# Usage:
+#   ./scripts/ci/board_route_determinism_smoke.sh <board-number> [runs]
+#
+# Examples:
+#   ./scripts/ci/board_route_determinism_smoke.sh 02        # 2 runs
+#   ./scripts/ci/board_route_determinism_smoke.sh 04 3      # 3 runs
+#
+# Supported boards: 02 (charlieplex-led), 03 (usb-joystick),
+# 04 (stm32-devboard).  Each board's flag set mirrors the ``kct route``
+# argv in its ``boards/<dir>/generate_design.py:route_pcb()``.  KEEP THE
+# FLAG LISTS BELOW IN SYNC with the recipes.
+
+set -euo pipefail
+
+BOARD="${1:-}"
+N="${2:-2}"
+
+if [[ -z "${BOARD}" ]]; then
+  echo "ERROR: board number required (02, 03, or 04)" >&2
+  echo "Usage: $0 <board-number> [runs]" >&2
+  exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Per-board configuration: directory, unrouted-PCB stem, and the exact
+# ``kct route`` flag list from generate_design.py:route_pcb().  These flag
+# lists are the load-bearing part of the test -- they MUST mirror the
+# recipe so the smoke routes the SAME copper the production recipe emits.
+case "${BOARD}" in
+  02)
+    BOARD_DIR="boards/02-charlieplex-led"
+    STEM="charlieplex_3x3"
+    ROUTE_FLAGS=(
+      --strategy negotiated
+      --iterations 30
+      --deterministic-budget
+      --timeout 240
+      --seed 42
+      --skip-nets GND
+      --manufacturer jlcpcb
+    )
+    ;;
+  03)
+    BOARD_DIR="boards/03-usb-joystick"
+    STEM="usb_joystick"
+    ROUTE_FLAGS=(
+      --seed 42
+      --manufacturer jlcpcb-tier1
+      --backend cpp
+      --deterministic-budget
+      --timeout 600
+    )
+    ;;
+  04)
+    BOARD_DIR="boards/04-stm32-devboard"
+    STEM="stm32_devboard"
+    ROUTE_FLAGS=(
+      --mfr jlcpcb-tier1
+      --auto-fix
+      --auto-layers
+      --auto-mfr-tier
+      --placement-feedback
+      --micro-via-in-pad-fallback
+      --seed 42
+      --deterministic-budget
+      --timeout 600
+    )
+    ;;
+  *)
+    echo "ERROR: unsupported board '${BOARD}' (supported: 02, 03, 04)" >&2
+    exit 1
+    ;;
+esac
+
+INPUT="${REPO_ROOT}/${BOARD_DIR}/output/${STEM}.kicad_pcb"
+OUT_DIR="${BOARD_ROUTE_DETERMINISM_OUT:-/tmp/board-route-determinism-${BOARD}}"
+
+if [[ ! -f "${INPUT}" ]]; then
+  echo "ERROR: unrouted PCB not found at ${INPUT}" >&2
+  echo "       Run the board recipe once to generate it." >&2
+  exit 1
+fi
+
+mkdir -p "${OUT_DIR}"
+rm -f "${OUT_DIR}"/run-*.kicad_pcb "${OUT_DIR}"/run-*.norm "${OUT_DIR}"/run-*.log
+
+# Pin PYTHONHASHSEED for the child route processes -- mirrors the recipe's
+# own pinning (#3799) so dict/set string-iteration entropy can never
+# re-enter, matching board-07's convention.
+export PYTHONHASHSEED="${PYTHONHASHSEED:-42}"
+
+echo "==> Board ${BOARD} routed-copper determinism smoke (Issue #3799)"
+echo "    Input:          ${INPUT}"
+echo "    Runs:           ${N}"
+echo "    Flags:          ${ROUTE_FLAGS[*]}"
+echo "    PYTHONHASHSEED: ${PYTHONHASHSEED}"
+echo "    Output dir:     ${OUT_DIR}"
+echo
+
+# Normalize routed copper: keep only (segment|via|arc) lines, strip the
+# per-element UUID / tstamp tokens (which are deterministic per-seed but
+# stripped defensively), and sort so element ORDER in the file does not
+# matter -- only the SET of copper geometry.
+normalize_copper() {
+  sed -E 's/\(uuid "[^"]*"\)/(uuid "X")/g; s/\(tstamp [^)]*\)/(tstamp X)/g' "$1" \
+    | grep -E '^[[:space:]]*\((segment|via|arc)' \
+    | sort
+}
+
+prev_norm=""
+for ((i = 1; i <= N; i++)); do
+  pcb="${OUT_DIR}/run-${i}.kicad_pcb"
+  log="${OUT_DIR}/run-${i}.log"
+  norm="${OUT_DIR}/run-${i}.norm"
+
+  echo "==> Run ${i}/${N}..."
+  start_s=$(date +%s)
+  # ``kct route`` exits non-zero on partial routing (codes 2/3); the routed
+  # PCB is still written, so we tolerate a non-zero exit and let the copper
+  # comparison be the gate.  Fatal codes (1 crash / 5 SIGINT) surface as an
+  # empty / missing output, which the existence check below catches.
+  PYTHONHASHSEED="${PYTHONHASHSEED}" uv run kct route "${INPUT}" \
+    --output "${pcb}" "${ROUTE_FLAGS[@]}" >"${log}" 2>&1 || true
+  end_s=$(date +%s)
+
+  if [[ ! -s "${pcb}" ]]; then
+    echo "FAIL: run ${i} produced no routed PCB (see ${log})" >&2
+    tail -20 "${log}" >&2 || true
+    exit 2
+  fi
+
+  normalize_copper "${pcb}" >"${norm}"
+  echo "  Elapsed:     $((end_s - start_s))s"
+  echo "  Copper lines: $(wc -l <"${norm}")"
+
+  if [[ -n "${prev_norm}" ]]; then
+    if ! diff -q "${prev_norm}" "${norm}" >/dev/null; then
+      echo
+      echo "FAIL: run ${i} routed copper differs from the prior run."
+      echo "      Same board + --seed 42 + --deterministic-budget +"
+      echo "      PYTHONHASHSEED=42 produced DIFFERENT copper -- the"
+      echo "      determinism guarantee regressed (Issue #3799)."
+      echo "      Normalized copper diff (first 40 lines):"
+      diff "${prev_norm}" "${norm}" | head -40
+      echo "      PCBs preserved in ${OUT_DIR} for post-mortem."
+      exit 3
+    fi
+  fi
+  prev_norm="${norm}"
+done
+
+echo
+echo "PASS: board ${BOARD} routed byte-identical copper across ${N} runs."

--- a/tests/router/test_board03_routing_baseline.py
+++ b/tests/router/test_board03_routing_baseline.py
@@ -176,6 +176,7 @@ References:
 
 from __future__ import annotations
 
+import os
 import re
 import shutil
 import subprocess
@@ -397,6 +398,12 @@ def _run_kct_route(unrouted: Path, seed: int) -> str:
             "jlcpcb-tier1",
             "--backend",
             "cpp",
+            # Issue #3799: kept in lock-step with the production recipe in
+            # ``generate_design.py:route_pcb()`` -- --deterministic-budget
+            # (#3538) routes under a fixed iteration backstop instead of the
+            # per-net wall-clock cutoff, so the seed-42 re-route is
+            # byte-identical (UUID-normalized) across machines.
+            "--deterministic-budget",
             "--timeout",
             "600",
             # Issues #3507/#3454: ``--raw`` removed in lock-step with the
@@ -405,12 +412,17 @@ def _run_kct_route(unrouted: Path, seed: int) -> str:
             # deterministic clearance_segment_via merge violation that
             # made it load-bearing.  Keep these flag lists in sync.
         ]
+        # Issue #3799: pin PYTHONHASHSEED to match the production recipe so
+        # the baseline measured here is the SAME copper the recipe emits.
+        _route_env = os.environ.copy()
+        _route_env["PYTHONHASHSEED"] = "42"
         proc = subprocess.run(
             cmd,
             capture_output=True,
             text=True,
             timeout=900,
             check=False,
+            env=_route_env,
         )
         # Exit codes from cli/route_cmd.py:
         #   0 = full route + DRC clean

--- a/tests/router/test_board_route_determinism.py
+++ b/tests/router/test_board_route_determinism.py
@@ -1,0 +1,247 @@
+"""Routed-copper determinism regression for boards 02 / 04 (Issue #3799).
+
+Background
+---------
+``--seed 42`` only seeds Python's global ``random``; it does NOT control
+the per-net A* WALL-CLOCK cutoff (``--per-net-timeout``, default 30 s)
+checked inside the C++ A* loop (``cpp_backend.py``).  On a loaded machine
+that budget fires mid-search and the net lands less copper -- SAME seed,
+DIFFERENT copper (the observed board-04 153 / 145 / 145-segment
+divergence).
+
+``--deterministic-budget`` (Issue #3538) swaps that wall-clock cutoff for
+a fixed node-expansion ITERATION budget, so the abort point is
+machine-independent and the seed-42 route is byte-identical across
+machines.  Boards 02 / 03 / 04 opt into it in their
+``generate_design.py:route_pcb()`` recipe (this issue), combined with a
+pinned ``PYTHONHASHSEED=42``.
+
+These tests re-route a board's committed UNROUTED PCB twice with the
+production route flags and assert the UUID-normalized routed COPPER (the
+``(segment ...)`` / ``(via ...)`` / ``(arc ...)`` set) is byte-identical.
+
+* ``board 02`` routes in ~20-30 s, so its test runs UNCONDITIONALLY (PR
+  CI included) -- it is the fast regression backstop.
+* ``board 04`` takes longer (a fuller route + auto-fix passes); its test
+  is gated behind ``KICAD_RUN_SLOW_BOARD04_DETERMINISM=1`` so ``pnpm
+  check:ci`` stays fast, mirroring the ``KICAD_RUN_SLOW_BOARD06_DETERMINISM``
+  convention in ``test_board06_determinism.py``.
+
+Negative control (NOT asserted here): WITHOUT ``--deterministic-budget``,
+a tight ``--per-net-timeout 0.05`` makes the wall-clock cutoff bind and
+the copper diverges under load.  That divergence is load-dependent (it is
+the whole point of the bug), so asserting it would be FLAKY on an unloaded
+CI runner -- it is documented as the failure mode the positive test
+guards against, not encoded as a hard assertion.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class _BoardRoute(NamedTuple):
+    """A board's unrouted-PCB location and production ``kct route`` flags."""
+
+    directory: str
+    stem: str
+    flags: list[str]
+
+
+# Per-board production route flags -- MUST mirror the ``kct route`` argv in
+# each board's ``generate_design.py:route_pcb()``.  Keep in sync.
+_BOARD_CONFIG: dict[str, _BoardRoute] = {
+    "02": _BoardRoute(
+        directory="boards/02-charlieplex-led",
+        stem="charlieplex_3x3",
+        flags=[
+            "--strategy",
+            "negotiated",
+            "--iterations",
+            "30",
+            "--deterministic-budget",
+            "--timeout",
+            "240",
+            "--seed",
+            "42",
+            "--skip-nets",
+            "GND",
+            "--manufacturer",
+            "jlcpcb",
+        ],
+    ),
+    "04": _BoardRoute(
+        directory="boards/04-stm32-devboard",
+        stem="stm32_devboard",
+        flags=[
+            "--mfr",
+            "jlcpcb-tier1",
+            "--auto-fix",
+            "--auto-layers",
+            "--auto-mfr-tier",
+            "--placement-feedback",
+            "--micro-via-in-pad-fallback",
+            "--seed",
+            "42",
+            "--deterministic-budget",
+            "--timeout",
+            "600",
+        ],
+    ),
+}
+
+_COPPER_LINE_RE = re.compile(r"^\s*\((segment|via|arc)\b")
+_UUID_RE = re.compile(r'\(uuid "[^"]*"\)')
+_TSTAMP_RE = re.compile(r"\(tstamp [^)]*\)")
+
+
+def _normalize_copper(pcb_text: str) -> list[str]:
+    """Return the sorted, UUID/tstamp-stripped routed-copper line set.
+
+    Keeps only ``(segment|via|arc)`` lines, strips the per-element UUID /
+    tstamp tokens (deterministic per-seed, but stripped defensively so a
+    UUID-toggle regression surfaces as a CONTENT mismatch rather than
+    masking a real routing-path divergence), and sorts so the ORDER of
+    elements in the file does not matter -- only the SET of copper geometry.
+    """
+    lines: list[str] = []
+    for line in pcb_text.splitlines():
+        if not _COPPER_LINE_RE.match(line):
+            continue
+        line = _UUID_RE.sub('(uuid "X")', line)
+        line = _TSTAMP_RE.sub("(tstamp X)", line)
+        lines.append(line)
+    lines.sort()
+    return lines
+
+
+def _route_once(board: str, out_pcb: Path, log: Path) -> None:
+    """Route a board's unrouted PCB once with the production flags.
+
+    Pins ``PYTHONHASHSEED=42`` on the subprocess (mirrors the recipe) so
+    dict/set string-iteration entropy cannot re-enter.  Tolerates the
+    non-zero exit codes ``kct route`` returns on partial routing (2/3) --
+    the routed PCB is still written; a missing/empty output (fatal crash)
+    fails the existence check in the caller.
+    """
+    config = _BOARD_CONFIG[board]
+    board_dir = REPO_ROOT / config.directory
+    input_pcb = board_dir / "output" / f"{config.stem}.kicad_pcb"
+    assert input_pcb.exists(), (
+        f"Unrouted PCB not found: {input_pcb}.  Run the board recipe once to generate it."
+    )
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "kicad_tools.cli",
+        "route",
+        str(input_pcb),
+        "--output",
+        str(out_pcb),
+        *config.flags,
+    ]
+    env = os.environ.copy()
+    env["PYTHONHASHSEED"] = "42"
+    with log.open("w") as log_fh:
+        subprocess.run(
+            cmd,
+            cwd=REPO_ROOT,
+            env=env,
+            stdout=log_fh,
+            stderr=subprocess.STDOUT,
+            timeout=1800,
+            check=False,
+        )
+
+
+def _assert_route_reproducible(board: str, tmp_path: Path) -> None:
+    """Route ``board`` twice and assert byte-identical normalized copper."""
+    norms: list[list[str]] = []
+    for i in (1, 2):
+        out_pcb = tmp_path / f"run-{i}.kicad_pcb"
+        log = tmp_path / f"run-{i}.log"
+        _route_once(board, out_pcb, log)
+        assert out_pcb.exists() and out_pcb.stat().st_size > 0, (
+            f"Run {i} produced no routed PCB.  Log tail:\n"
+            f"{log.read_text()[-2000:] if log.exists() else '(no log)'}"
+        )
+        norms.append(_normalize_copper(out_pcb.read_text()))
+
+    # Both runs must land at least some copper (guards against a silent
+    # all-failed route passing the equality check trivially).
+    assert norms[0], f"Board {board} run 1 produced no routed copper at all."
+
+    if norms[0] != norms[1]:
+        # Build a compact diff for the failure message.
+        only_1 = sorted(set(norms[0]) - set(norms[1]))[:10]
+        only_2 = sorted(set(norms[1]) - set(norms[0]))[:10]
+        pytest.fail(
+            f"Board {board} routed copper diverged across two seed-42 + "
+            f"--deterministic-budget + PYTHONHASHSEED=42 routes (Issue "
+            f"#3799 regression).\n"
+            f"  run1 copper lines: {len(norms[0])}\n"
+            f"  run2 copper lines: {len(norms[1])}\n"
+            f"  only in run1 (up to 10): {only_1}\n"
+            f"  only in run2 (up to 10): {only_2}\n"
+            f"  PCBs preserved at {tmp_path}"
+        )
+
+
+def test_normalize_copper_strips_uuid_and_sorts() -> None:
+    """``_normalize_copper`` keeps copper, strips UUIDs, and is order-free."""
+    pcb_a = (
+        '  (segment (start 1 2) (end 3 4) (uuid "aaaa"))\n'
+        '  (via (at 5 6) (uuid "bbbb"))\n'
+        "  (gr_line (start 0 0) (end 1 1))\n"  # non-copper, dropped
+    )
+    pcb_b = (
+        '  (via (at 5 6) (uuid "different"))\n'  # reordered + different UUID
+        '  (segment (start 1 2) (end 3 4) (uuid "cccc"))\n'
+    )
+    norm_a = _normalize_copper(pcb_a)
+    norm_b = _normalize_copper(pcb_b)
+    # Non-copper line dropped, UUIDs stripped, sort makes order irrelevant.
+    assert norm_a == norm_b
+    assert all('uuid "X"' in line for line in norm_a)
+    assert not any("gr_line" in line for line in norm_a)
+
+
+def test_board02_route_is_reproducible(tmp_path: Path) -> None:
+    """Board 02 routes byte-identical copper twice at seed 42 (Issue #3799).
+
+    Runs unconditionally (board 02 routes in ~20-30 s): the fast
+    determinism regression backstop for the ``--deterministic-budget``
+    opt-in.  If this fails, a board-02 route flag regressed (most likely
+    ``--deterministic-budget`` was dropped, re-introducing the per-net
+    wall-clock cutoff).
+    """
+    _assert_route_reproducible("02", tmp_path)
+
+
+@pytest.mark.skipif(
+    os.environ.get("KICAD_RUN_SLOW_BOARD04_DETERMINISM") != "1",
+    reason=(
+        "Slow board-04 determinism test (two full routes + auto-fix passes). "
+        "Set KICAD_RUN_SLOW_BOARD04_DETERMINISM=1 to enable."
+    ),
+)
+def test_board04_route_is_reproducible(tmp_path: Path) -> None:
+    """Board 04 routes byte-identical copper twice at seed 42 (Issue #3799).
+
+    Gated behind ``KICAD_RUN_SLOW_BOARD04_DETERMINISM=1`` (mirrors the
+    board-06 slow gate) so ``pnpm check:ci`` stays fast.  Board 04 is the
+    board where the wall-clock-budget divergence was first observed
+    (153 / 145 / 145 segments); this proves ``--deterministic-budget``
+    makes its seed-42 route reproducible.
+    """
+    _assert_route_reproducible("04", tmp_path)

--- a/tests/router/test_board_route_determinism.py
+++ b/tests/router/test_board_route_determinism.py
@@ -216,14 +216,26 @@ def test_normalize_copper_strips_uuid_and_sorts() -> None:
     assert not any("gr_line" in line for line in norm_a)
 
 
+@pytest.mark.timeout(600)
 def test_board02_route_is_reproducible(tmp_path: Path) -> None:
     """Board 02 routes byte-identical copper twice at seed 42 (Issue #3799).
 
-    Runs unconditionally (board 02 routes in ~20-30 s): the fast
-    determinism regression backstop for the ``--deterministic-budget``
-    opt-in.  If this fails, a board-02 route flag regressed (most likely
+    Runs UNCONDITIONALLY (PR CI included): the fast determinism
+    regression backstop for the ``--deterministic-budget`` opt-in.  If
+    this fails, a board-02 route flag regressed (most likely
     ``--deterministic-budget`` was dropped, re-introducing the per-net
     wall-clock cutoff).
+
+    Timeout (Issue #3799 CI fix): a single board-02 route takes ~20-30 s
+    locally and this test routes TWICE, so ~40-60 s of wall-clock.  CI's
+    suite-wide default ``--timeout=60`` (see ``.github/workflows/ci.yml``
+    Test job) killed the two-route run spuriously on the slower hosted
+    runner.  The explicit ``@pytest.mark.timeout(600)`` marker OVERRIDES
+    that default with a host-speed- and xdist-contention-tolerant budget
+    while still catching a genuine router hang.  It does NOT slow the
+    happy path (the marker only changes the reaper deadline).  This keeps
+    the determinism regression running in the main Test job rather than
+    deferring it to the nightly slow-tests workflow.
     """
     _assert_route_reproducible("02", tmp_path)
 

--- a/tests/test_board02_route_demo_recipe.py
+++ b/tests/test_board02_route_demo_recipe.py
@@ -189,10 +189,15 @@ def test_route_demo_recipe_mirrors_generate_design() -> None:
     # The flag/value pairs both scripts MUST send to ``kct route``.
     # Keeping these in sync is the whole point of Issue #3207's "no
     # drift" acceptance criterion.
+    #
+    # Issue #3799: ``--per-net-timeout 30`` was REPLACED by the boolean
+    # ``--deterministic-budget`` flag (asserted separately below) so the
+    # seed-42 route is byte-identical across machines.  Both recipes
+    # changed together, so ``--per-net-timeout`` is intentionally no
+    # longer in the expected set.
     required_flag_value_pairs = [
         ("--strategy", "negotiated"),
         ("--iterations", "30"),
-        ("--per-net-timeout", "30"),
         ("--timeout", "240"),
         ("--seed", "42"),
         ("--manufacturer", "jlcpcb"),
@@ -215,6 +220,32 @@ def test_route_demo_recipe_mirrors_generate_design() -> None:
         # this is a coarse co-occurrence check.
         assert value in demo_src, f"route_demo.py is missing value {value!r} for {flag!r}."
         assert value in design_src, f"generate_design.py is missing value {value!r} for {flag!r}."
+
+    # Issue #3799: both recipes must opt into the deterministic ITERATION
+    # budget (boolean flag, no value) so the seed-42 route is
+    # byte-identical across machines.  This is the load-bearing flag the
+    # determinism regression in tests/router/test_board_route_determinism.py
+    # depends on; if it drifts out of either recipe the route reverts to
+    # the per-net wall-clock cutoff and diverges under load.
+    for src_name, src in (("route_demo.py", demo_src), ("generate_design.py", design_src)):
+        assert "--deterministic-budget" in src, (
+            f"{src_name} is missing flag '--deterministic-budget' (Issue "
+            f"#3799).  Both board-02 recipes must route under the iteration "
+            f"budget so the seed-42 route is reproducible.  If this changed "
+            f"intentionally, update the other recipe to match and update "
+            f"this test."
+        )
+
+    # Issue #3799: the per-net WALL-CLOCK cutoff was intentionally removed
+    # from both recipes (it is what caused same-seed/different-copper
+    # divergence under load).  Guard against it silently creeping back.
+    for src_name, src in (("route_demo.py", demo_src), ("generate_design.py", design_src)):
+        assert "--per-net-timeout" not in src, (
+            f"{src_name} re-introduced '--per-net-timeout' (Issue #3799 "
+            f"regression).  The per-net wall-clock cutoff makes the seed-42 "
+            f"route diverge under load; use '--deterministic-budget' "
+            f"instead."
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The autorouter produced different routed copper on repeated runs of the same board with the same `--seed 42`. Root cause (curator-verified): `--seed` only seeds Python's global `random`; it does NOT control the per-net A* **wall-clock** cutoff (`--per-net-timeout`, default 30 s) checked inside the C++ A* loop. On a loaded machine that budget fires mid-search and the net lands less copper — same seed, different copper (the observed board-04 153/145/145-segment divergence).

The fix already exists in-tree (`--deterministic-budget`, #3538, already used by board-07). This PR opts boards 02/03/04 into it (keeping `--seed 42`), which disables the per-net wall-clock cutoff and pins a fixed node-expansion **iteration** backstop, making the abort point machine-independent. It also pins `PYTHONHASHSEED=42` on each route subprocess (and the board-02 e2e CI job) so dict/set string-iteration entropy cannot re-enter. No router-engine change.

## Changes

- `boards/02-charlieplex-led/generate_design.py` — add `--deterministic-budget`; pin `PYTHONHASHSEED=42` on the route subprocess.
- `boards/03-usb-joystick/generate_design.py` — same; `_sp.run` now passes the pinned env.
- `boards/04-stm32-devboard/generate_design.py` — same.
- `tests/router/test_board03_routing_baseline.py` — kept in lock-step with the board-03 recipe (adds `--deterministic-budget` + pinned `PYTHONHASHSEED`).
- `.github/workflows/ci.yml` — add `PYTHONHASHSEED: "42"` to the board-02 e2e job (board-03/06/07 already had it).
- `scripts/ci/board_route_determinism_smoke.sh` — NEW. Parameterized per-board (02/03/04) routed-copper determinism smoke modeled on `board06_determinism_smoke.sh`.
- `tests/router/test_board_route_determinism.py` — NEW. Routes a board's unrouted PCB twice and asserts byte-identical UUID-normalized copper. Board-02 always-on (PR CI); board-04 behind `KICAD_RUN_SLOW_BOARD04_DETERMINISM=1` (mirrors the board-06 slow gate).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Boards 02/03/04 route reproducibly (byte-identical UUID-normalized copper twice) | ✅ | board-02 421 lines x2; board-03 585 lines x2; board-04 full-recipe 173 lines x2 — all IDENTICAL via the smoke script + the pytest |
| Routing quality preserved (02/03 copper-LVS clean; 04 no worse) | ✅ | board-02 DRC clean; board-03 recipe exits 0 with `lvs clean: True` and passes its reach floor; board-04 keeps 9/9 nets and **0 blocking DRC errors** against jlcpcb-tier1 (`check_routed_drc.py` OK — same as committed) |
| No net-completion regression | ✅ | board-03 13/13; board-04 9/9; board-02 all signal nets |
| Determinism regression test added + passing | ✅ | `tests/router/test_board_route_determinism.py` — board-02 PASSED, board-04 PASSED with the slow gate enabled |
| Existing e2e gates (00/01/02/03/06/07) still pass | ✅ | recipe flag change only; committed PCBs unchanged so their gate tests still pass; board-02 e2e regenerates fresh under the new deterministic recipe |
| No C++ router engine change; board-05 untouched | ✅ | only recipe/CI/test files changed |

## Test Plan

- C++ backend built and verified: `kct build-native --check` → `available (version 1.0.0)`; `shapely` present (`--extra dev`).
- `scripts/ci/board_route_determinism_smoke.sh 02|03|04 2` → PASS (byte-identical copper) for all three boards.
- `uv run pytest tests/router/test_board_route_determinism.py` → board-02 reproducibility PASS, helper unit test PASS; board-04 PASS under `KICAD_RUN_SLOW_BOARD04_DETERMINISM=1`.
- Full board-03 recipe regen: exit 0, `lvs clean: True`; board-03 slow reach-floor baseline test PASS with the new flags.
- Full board-04 recipe regen x2: byte-identical; `check_routed_drc.py` reports 0 blocking errors (same as committed).
- `ruff check .` clean; `ruff format --check` clean on changed files; `mypy` clean on the new test (board recipe mypy errors are pre-existing, outside edited lines).
- `shellcheck` clean on the new smoke script.

Note on committed PCBs: deliberately NOT regenerated/committed here. The recipe change alone makes regens reproducible; the committed PCBs still pass every gate, and changing board copper/DRC counts is explicitly out of scope (owned by #3797 / #3775 / #3766 per the curator scope guard).

Note on the negative control: WITHOUT `--deterministic-budget`, a tight `--per-net-timeout 0.05` diverges only **under load** (the bug is load-dependent), so it would be a flaky CI assertion. It is documented as the failure mode the positive test guards against, not encoded as a hard assertion.

Closes #3799