### PR TITLE
feat(cli): add --absolute coordinate mode to pcb move-footprint

### DIFF
--- a/src/kicad_tools/cli/commands/pcb.py
+++ b/src/kicad_tools/cli/commands/pcb.py
@@ -691,6 +691,7 @@ def _run_move_footprint_command(args, pcb_path: Path) -> int:
     output_path = Path(output) if output else None
     dry_run = getattr(args, "dry_run", False)
     output_format = getattr(args, "format", "text")
+    absolute = getattr(args, "absolute", False)
 
     # Parse batch map JSON if provided
     batch_map = None
@@ -724,6 +725,7 @@ def _run_move_footprint_command(args, pcb_path: Path) -> int:
         dry_run=dry_run,
         output_path=output_path,
         output_format=output_format,
+        absolute=absolute,
     )
 
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1673,9 +1673,12 @@ def _add_pcb_parser(subparsers) -> None:
     # pcb move-footprint
     pcb_move_fp = pcb_subparsers.add_parser(
         "move-footprint",
-        help="Move a footprint to new board-relative coordinates",
+        help="Move a footprint to new coordinates (board-relative by default)",
         description="Relocate a footprint to a new position (and optionally "
-        "rotation) by reference designator.  Supports batch mode via --map.",
+        "rotation) by reference designator.  Supports batch mode via --map.  "
+        "Coordinates are board-relative by default (measured from the "
+        "Edge.Cuts top-left origin); pass --absolute to use KiCad page "
+        "coordinates instead.",
     )
     pcb_move_fp.add_argument("pcb", help="Path to .kicad_pcb file")
     pcb_move_fp.add_argument(
@@ -1687,7 +1690,10 @@ def _add_pcb_parser(subparsers) -> None:
         nargs=2,
         type=float,
         metavar=("X", "Y"),
-        help="New board-relative position (e.g., --to 132.5 98.25)",
+        help="New position in mm. Board-relative by default (measured from the "
+        "Edge.Cuts top-left origin); the board-origin offset is added "
+        "automatically. Pass --absolute to give KiCad page coordinates "
+        "directly. Example (board-relative): --to 10 10",
     )
     pcb_move_fp.add_argument(
         "--rotation",
@@ -1695,9 +1701,18 @@ def _add_pcb_parser(subparsers) -> None:
         help="New rotation in degrees (optional)",
     )
     pcb_move_fp.add_argument(
+        "--absolute",
+        action="store_true",
+        help="Interpret --to / --map coordinates as absolute KiCad page "
+        "coordinates (the same space as a footprint's raw (at ...) node) "
+        "instead of board-relative. Default: board-relative.",
+    )
+    pcb_move_fp.add_argument(
         "--map",
         dest="batch_map",
-        help='JSON map for batch moves (e.g., \'{"J2": {"x": 132.5, "y": 98.25}}\')',
+        help="JSON map for batch moves; x/y are board-relative by default "
+        "(or absolute page coords with --absolute), "
+        'e.g. \'{"J2": {"x": 10, "y": 10}}\'',
     )
     pcb_move_fp.add_argument(
         "-o",

--- a/src/kicad_tools/cli/pcb_move_footprint.py
+++ b/src/kicad_tools/cli/pcb_move_footprint.py
@@ -1,8 +1,22 @@
 """Move a footprint in a PCB by reference designator.
 
 Provides a standalone command to relocate a specific footprint to new
-board-relative coordinates, optionally setting a new rotation.  Supports
-batch mode via a JSON map for moving multiple footprints atomically.
+coordinates, optionally setting a new rotation.  Supports batch mode via a
+JSON map for moving multiple footprints atomically.
+
+Coordinate convention
+----------------------
+By default the supplied (x, y) values are **board-relative**: they are
+measured from the board origin (the top-left corner of the Edge.Cuts
+outline), and the board-origin offset is added automatically when the
+``(at ...)`` node is written.  This matches the rest of the placement API.
+
+Pass ``absolute=True`` to interpret (x, y) as **absolute KiCad page
+coordinates** (the same space as a footprint's raw ``(at ...)`` node).  In
+that mode the board origin is subtracted before assignment so the setter's
+re-addition nets out and the footprint lands at exactly (x, y) on the sheet.
+On a board with no detectable outline the origin is ``(0, 0)`` and the two
+modes agree.
 """
 
 from __future__ import annotations
@@ -20,18 +34,23 @@ def run_move_footprint(
     dry_run: bool = False,
     output_path: Path | None = None,
     output_format: str = "text",
+    absolute: bool = False,
 ) -> int:
     """Move one or more footprints in a PCB file.
 
     Args:
         pcb_path: Path to .kicad_pcb file.
         reference: Reference designator to move (single mode).
-        to: New (x, y) board-relative position (single mode).
+        to: New (x, y) position (single mode).  Board-relative by default;
+            absolute page coordinates when ``absolute=True``.
         rotation: Optional new rotation in degrees.
         batch_map: JSON-parsed dict for batch mode.
         dry_run: Preview moves without modifying.
         output_path: Alternative output path for modified PCB.
         output_format: "text" or "json".
+        absolute: When True, interpret (x, y) as absolute KiCad page
+            coordinates (subtract the board origin before assignment) rather
+            than board-relative coordinates.
 
     Returns:
         Exit code (0 for success, 1 for errors).
@@ -66,6 +85,18 @@ def run_move_footprint(
         )
         return 1
 
+    coord_space = "absolute" if absolute else "board-relative"
+    ox, oy = pcb.board_origin
+
+    # The position the setter ultimately writes into the (at ...) node:
+    #   - board-relative: setter adds (ox, oy), so assign (x, y) directly.
+    #   - absolute: subtract (ox, oy) first so the setter's re-addition nets
+    #     out, landing the footprint at exactly (x, y) on the sheet.
+    def _assign_coords(x: float, y: float) -> tuple[float, float]:
+        if absolute:
+            return (x - ox, y - oy)
+        return (x, y)
+
     # Validate all references exist before making any changes
     move_details: list[dict] = []
     for ref, x, y, rot in moves:
@@ -73,12 +104,19 @@ def run_move_footprint(
         if not fp:
             _print_error(f"Footprint {ref} not found in PCB", output_format)
             return 1
+        # fp.position is stored board-relative; report old + new in the same
+        # coordinate space the user requested so they are directly comparable.
+        old_x, old_y = fp.position
+        if absolute:
+            old_x, old_y = old_x + ox, old_y + oy
         move_details.append(
             {
                 "reference": ref,
                 "footprint": fp.name,
-                "old_position": list(fp.position),
+                "old_position": [old_x, old_y],
                 "old_rotation": fp.rotation,
+                # new_position is reported in the coordinate space the user
+                # requested (see coordinate_space for which one that is).
                 "new_position": [x, y],
                 "new_rotation": rot if rot is not None else fp.rotation,
             }
@@ -87,6 +125,8 @@ def run_move_footprint(
     result = {
         "pcb": str(pcb_path),
         "dry_run": dry_run,
+        "coordinate_space": coord_space,
+        "board_origin": [ox, oy],
         "moves": move_details,
         "moved": False,
     }
@@ -95,7 +135,7 @@ def run_move_footprint(
         for ref, x, y, rot in moves:
             fp = pcb.get_footprint(ref)
             # fp existence already validated above
-            fp.position = (x, y)  # type: ignore[union-attr]
+            fp.position = _assign_coords(x, y)  # type: ignore[union-attr]
             if rot is not None:
                 fp.rotation = rot  # type: ignore[union-attr]
 
@@ -115,12 +155,16 @@ def run_move_footprint(
         label = "PCB Move Footprint (dry run)" if dry_run else "PCB Move Footprint"
         print(label)
         print(f"  PCB: {pcb_path}")
+        print(f"  Coordinates: {coord_space} (board origin: {ox}, {oy})")
         print()
         for md in move_details:
             old_pos = md["old_position"]
             new_pos = md["new_position"]
             print(f"  {md['reference']} ({md['footprint']}):")
-            print(f"    Position: ({old_pos[0]}, {old_pos[1]}) -> ({new_pos[0]}, {new_pos[1]})")
+            print(
+                f"    Position [{coord_space}]: "
+                f"({old_pos[0]}, {old_pos[1]}) -> ({new_pos[0]}, {new_pos[1]})"
+            )
             if md["old_rotation"] != md["new_rotation"]:
                 print(f"    Rotation: {md['old_rotation']} -> {md['new_rotation']}")
         print()

--- a/tests/test_pcb_move_footprint.py
+++ b/tests/test_pcb_move_footprint.py
@@ -35,6 +35,64 @@ MINIMAL_PCB = """(kicad_pcb
 )
 """
 
+# Board with a non-zero origin: the Edge.Cuts rect starts at (116, 77), so
+# PCB.board_origin == (116, 77).  The footprint's raw (at ...) is at the
+# sheet-absolute coordinate (126, 87) which is board-relative (10, 10).
+NONZERO_ORIGIN_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (gr_rect
+    (start 116 77)
+    (end 181 133)
+    (layer "Edge.Cuts")
+    (width 0.1)
+    (uuid "edge-rect")
+  )
+  (footprint "Connector_JST:JST_XH_B2B"
+    (layer "F.Cu")
+    (uuid "fp-j2")
+    (at 126 87)
+    (property "Reference" "J2" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "Conn_01x02" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" thru_hole roundrect (at -1.25 0) (size 1.7 1.7) (layers "*.Cu") (net 1 "GND"))
+    (pad "2" thru_hole roundrect (at 1.25 0) (size 1.7 1.7) (layers "*.Cu") (net 0 ""))
+  )
+  (footprint "Connector_JST:JST_XH_B3B"
+    (layer "F.Cu")
+    (uuid "fp-j3")
+    (at 140 87 90)
+    (property "Reference" "J3" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "Conn_01x03" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" thru_hole roundrect (at -2.5 0) (size 1.7 1.7) (layers "*.Cu") (net 1 "GND"))
+    (pad "2" thru_hole roundrect (at 0 0) (size 1.7 1.7) (layers "*.Cu") (net 0 ""))
+    (pad "3" thru_hole roundrect (at 2.5 0) (size 1.7 1.7) (layers "*.Cu") (net 0 ""))
+  )
+)
+"""
+
+
+def _at_node_values(pcb_path, uuid):
+    """Return the raw footprint-level (at X Y) written into the S-expression.
+
+    In every fixture here the footprint-level ``(at ...)`` node immediately
+    follows the footprint ``(uuid ...)`` line, so we read the first ``(at ...)``
+    after that uuid.
+    """
+    import re
+
+    text = pcb_path.read_text()
+    idx = text.index(f'(uuid "{uuid}")')
+    after = text[idx:]
+    m = re.search(r"\(at ([-\d.]+) ([-\d.]+)(?: [-\d.]+)?\)", after)
+    assert m is not None, f"no (at ...) found after uuid {uuid}"
+    return float(m.group(1)), float(m.group(2))
+
 
 class TestRunMoveFootprint:
     """Tests for run_move_footprint function."""
@@ -347,3 +405,211 @@ class TestMoveFootprintCLIParser:
 
         rc = _run_move_footprint_command(Args(), pcb)
         assert rc == 0
+
+
+class TestNonZeroBoardOrigin:
+    """Sanity checks on the fixture's board origin."""
+
+    def test_board_origin_is_nonzero(self, tmp_path):
+        """NONZERO_ORIGIN_PCB has board_origin (116, 77)."""
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(NONZERO_ORIGIN_PCB)
+
+        board = PCB.load(pcb)
+        ox, oy = board.board_origin
+        assert ox == pytest.approx(116.0, abs=0.01)
+        assert oy == pytest.approx(77.0, abs=0.01)
+        # J2's (at 126 87) is board-relative (10, 10) after origin detection.
+        j2 = board.get_footprint("J2")
+        assert j2 is not None
+        assert j2.position[0] == pytest.approx(10.0, abs=0.01)
+        assert j2.position[1] == pytest.approx(10.0, abs=0.01)
+
+
+class TestAbsoluteCoordinates:
+    """Tests for the --absolute coordinate mode."""
+
+    def test_default_is_board_relative_nonzero_origin(self, tmp_path):
+        """Default (no flag): --to X Y writes (at X+ox Y+oy)."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(NONZERO_ORIGIN_PCB)
+
+        rc = run_move_footprint(pcb, reference="J2", to=(0.0, 0.0))
+        assert rc == 0
+
+        # board-relative (0, 0) -> sheet-absolute (116, 77)
+        ax, ay = _at_node_values(pcb, "fp-j2")
+        assert ax == pytest.approx(116.0, abs=0.01)
+        assert ay == pytest.approx(77.0, abs=0.01)
+
+    def test_absolute_single_move_nonzero_origin(self, tmp_path):
+        """--absolute --to X Y writes (at X Y) regardless of board origin."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(NONZERO_ORIGIN_PCB)
+
+        rc = run_move_footprint(pcb, reference="J2", to=(116.0, 77.0), absolute=True)
+        assert rc == 0
+
+        # absolute (116, 77) lands exactly at sheet-absolute (116, 77)
+        ax, ay = _at_node_values(pcb, "fp-j2")
+        assert ax == pytest.approx(116.0, abs=0.01)
+        assert ay == pytest.approx(77.0, abs=0.01)
+
+    def test_absolute_and_relative_agree_on_zero_origin(self, tmp_path):
+        """On a board with origin (0,0) both modes write the same (at ...)."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+
+        rel = tmp_path / "rel.kicad_pcb"
+        absf = tmp_path / "abs.kicad_pcb"
+        rel.write_text(MINIMAL_PCB)
+        absf.write_text(MINIMAL_PCB)
+
+        assert run_move_footprint(rel, reference="J2", to=(132.5, 98.25)) == 0
+        assert run_move_footprint(absf, reference="J2", to=(132.5, 98.25), absolute=True) == 0
+
+        assert _at_node_values(rel, "fp-j2") == _at_node_values(absf, "fp-j2")
+
+    def test_absolute_batch_mode_nonzero_origin(self, tmp_path):
+        """--absolute applies to every entry in batch --map mode."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(NONZERO_ORIGIN_PCB)
+
+        batch = {
+            "J2": {"x": 130.0, "y": 90.0},
+            "J3": {"x": 150.0, "y": 95.0},
+        }
+        rc = run_move_footprint(pcb, batch_map=batch, absolute=True)
+        assert rc == 0
+
+        j2x, j2y = _at_node_values(pcb, "fp-j2")
+        j3x, j3y = _at_node_values(pcb, "fp-j3")
+        assert (j2x, j2y) == pytest.approx((130.0, 90.0), abs=0.01)
+        assert (j3x, j3y) == pytest.approx((150.0, 95.0), abs=0.01)
+
+    def test_default_batch_mode_nonzero_origin(self, tmp_path):
+        """Default batch --map mode is board-relative (adds origin)."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(NONZERO_ORIGIN_PCB)
+
+        batch = {"J2": {"x": 0.0, "y": 0.0}}
+        rc = run_move_footprint(pcb, batch_map=batch)
+        assert rc == 0
+
+        ax, ay = _at_node_values(pcb, "fp-j2")
+        assert (ax, ay) == pytest.approx((116.0, 77.0), abs=0.01)
+
+    def test_json_reports_coordinate_space(self, tmp_path, capsys):
+        """JSON output labels the active coordinate space and board origin."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(NONZERO_ORIGIN_PCB)
+
+        rc = run_move_footprint(
+            pcb,
+            reference="J2",
+            to=(120.0, 80.0),
+            absolute=True,
+            output_format="json",
+            dry_run=True,
+        )
+        assert rc == 0
+
+        data = json.loads(capsys.readouterr().out)
+        assert data["coordinate_space"] == "absolute"
+        assert data["board_origin"] == [116.0, 77.0]
+        # new_position reported in requested (absolute) space
+        assert data["moves"][0]["new_position"] == [120.0, 80.0]
+
+    def test_dry_run_text_labels_mode(self, tmp_path, capsys):
+        """Text dry-run output labels the coordinate mode."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(NONZERO_ORIGIN_PCB)
+
+        # absolute mode
+        run_move_footprint(pcb, reference="J2", to=(120.0, 80.0), absolute=True, dry_run=True)
+        out = capsys.readouterr().out
+        assert "absolute" in out
+
+        # board-relative mode
+        run_move_footprint(pcb, reference="J2", to=(5.0, 5.0), dry_run=True)
+        out = capsys.readouterr().out
+        assert "board-relative" in out
+
+
+class TestAbsoluteParserAndDispatch:
+    """Parser + dispatcher coverage for --absolute."""
+
+    def test_parser_absolute_flag(self):
+        """Parser accepts --absolute and stores it on args."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(
+            [
+                "pcb",
+                "move-footprint",
+                "--ref",
+                "J2",
+                "--to",
+                "116",
+                "77",
+                "--absolute",
+                "test.kicad_pcb",
+            ]
+        )
+        assert args.absolute is True
+
+    def test_parser_absolute_defaults_false(self):
+        """--absolute defaults to False when omitted."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(
+            [
+                "pcb",
+                "move-footprint",
+                "--ref",
+                "J2",
+                "--to",
+                "10",
+                "10",
+                "test.kicad_pcb",
+            ]
+        )
+        assert args.absolute is False
+
+    def test_dispatcher_plumbs_absolute(self, tmp_path):
+        """Dispatcher forwards args.absolute into run_move_footprint."""
+        from kicad_tools.cli.commands.pcb import _run_move_footprint_command
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(NONZERO_ORIGIN_PCB)
+
+        class Args:
+            ref = "J2"
+            to = [116.0, 77.0]
+            rotation = None
+            batch_map = None
+            output = None
+            dry_run = False
+            format = "text"
+            absolute = True
+
+        rc = _run_move_footprint_command(Args(), pcb)
+        assert rc == 0
+
+        ax, ay = _at_node_values(pcb, "fp-j2")
+        assert (ax, ay) == pytest.approx((116.0, 77.0), abs=0.01)


### PR DESCRIPTION
## Summary

`kct pcb move-footprint --to X Y` interprets coordinates as **board-relative**: the board-origin offset (Edge.Cuts top-left) is added inside the `Footprint.position` setter when writing the `(at ...)` node. This convention was undocumented and the `--to` help example (`132.5 98.25`) looked like an absolute page coordinate, so passing a footprint's raw KiCad `(at ...)` values back through `--to` silently placed the part offset by the origin — landing it off-board with no warning.

This adds an `--absolute` flag for KiCad page coordinates and fixes the misleading help text. Default behavior is unchanged.

## Changes

- **`src/kicad_tools/cli/pcb_move_footprint.py`**: add `absolute` param. When `absolute=True`, subtract `pcb.board_origin` before assigning `fp.position` so the setter's `+origin` re-addition nets out (single `--ref/--to` and batch `--map` paths). Report `coordinate_space` + `board_origin` in JSON, label the mode in text/dry-run output, and report old/new positions in the requested space. Expanded module docstring.
- **`src/kicad_tools/cli/parser.py`**: add `--absolute` flag (default `False`); rewrite `--to`, `--map`, and subparser help to state the board-relative default and document `--absolute`.
- **`src/kicad_tools/cli/commands/pcb.py`**: plumb `args.absolute` through `_run_move_footprint_command()`.
- **`tests/test_pcb_move_footprint.py`**: new `NONZERO_ORIGIN_PCB` fixture (Edge.Cuts rect at 116,77) plus tests for absolute single/batch, board-relative regression on a non-zero origin board, zero-origin agreement, parser flag presence/default, dispatcher plumbing, and dry-run labeling.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `--help` states default is board-relative and documents `--absolute` | done | Verified via `kct pcb move-footprint --help` |
| `--to`/`--map` help no longer implies absolute page coords | done | Rewrote help strings |
| Default (no flag) unchanged: `--to X Y` writes `(at X+ox Y+oy)` | done | `test_default_is_board_relative_nonzero_origin` |
| `--absolute --to X Y` writes `(at X Y)` regardless of origin | done | `test_absolute_single_move_nonzero_origin` |
| `--absolute` works in batch `--map` mode | done | `test_absolute_batch_mode_nonzero_origin` |
| `--dry-run` makes active mode unambiguous | done | `test_dry_run_text_labels_mode`, `test_json_reports_coordinate_space` |
| Off-board warning (optional) | deferred | Left as a follow-up per the issue's optional/lower-priority note to keep this PR focused on docs + `--absolute` |

## Test Plan

- `uv run pytest tests/test_pcb_move_footprint.py` — 27 passed.
- `uv run ruff check` and `ruff format --check` clean on touched files.
- `mypy` on touched files: no new errors (the 10 errors in `commands/pcb.py` pre-exist on `main`, unrelated lines).
- Manual: `kct pcb move-footprint --help` shows corrected help.

Closes #3806