### PR TITLE
fix(pcb): quote numeric footprint property values on embed

### DIFF
--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -3936,25 +3936,33 @@ class PCB:
         for prop in fp_sexp.find_all("property"):
             prop_name = prop.get_string(0)
             if prop_name == "Reference":
-                prop.set_value(1, reference)
+                # Use quoted_atom so values that look numeric (e.g. a
+                # reference "1") still serialize quoted. A bare numeric
+                # property value makes the board unloadable in kicad-cli.
+                prop.children[1] = SExp.quoted_atom(reference)
                 ref_updated = True
             elif prop_name == "Value":
-                prop.set_value(1, value)
+                # Use quoted_atom so unit-less numeric values (e.g. "470",
+                # "0", "100") serialize as (property "Value" "470") rather
+                # than the bare token (property "Value" 470), which
+                # kicad-cli rejects with "Failed to load board".
+                prop.children[1] = SExp.quoted_atom(value)
                 val_updated = True
 
         # Fall back to KiCad 7 fp_text format
         for fp_text in fp_sexp.find_all("fp_text"):
             text_type = fp_text.get_string(0)
             if text_type == "reference" and not ref_updated:
-                fp_text.set_value(1, reference)
+                fp_text.children[1] = SExp.quoted_atom(reference)
                 ref_updated = True
             elif text_type == "value" and not val_updated:
-                fp_text.set_value(1, value)
+                fp_text.children[1] = SExp.quoted_atom(value)
                 val_updated = True
 
         # If reference/value weren't found, add them as KiCad 8+ properties
         if not ref_updated:
-            ref_prop = SExp.list("property", "Reference", reference)
+            # Quote the value so a numeric reference doesn't serialize bare.
+            ref_prop = SExp.list("property", "Reference", SExp.quoted_atom(reference))
             ref_prop.append(SExp.list("at", 0.0, -1.5))
             ref_prop.append(SExp.list("layer", layer.replace(".Cu", ".SilkS")))
             ref_prop.append(SExp.list("uuid", str(uuid.uuid4())))
@@ -3967,7 +3975,8 @@ class PCB:
             fp_sexp.append(ref_prop)
 
         if not val_updated:
-            val_prop = SExp.list("property", "Value", value)
+            # Quote the value so a unit-less numeric value doesn't serialize bare.
+            val_prop = SExp.list("property", "Value", SExp.quoted_atom(value))
             val_prop.append(SExp.list("at", 0.0, 1.5))
             val_prop.append(SExp.list("layer", layer.replace(".Cu", ".Fab")))
             val_prop.append(SExp.list("uuid", str(uuid.uuid4())))

--- a/tests/test_kicad_cli_roundtrip.py
+++ b/tests/test_kicad_cli_roundtrip.py
@@ -719,3 +719,83 @@ class TestSheetInstancesPageQuoting:
         node = sheet_instances("/00000000-0000-0000-0000-000000000001", "1")
         text = node.to_string()
         assert '(page "1")' in text, f"sheet_instances builder emitted: {text}"
+
+
+# ---------------------------------------------------------------------------
+# Numeric footprint property quoting (issue #3802)
+# ---------------------------------------------------------------------------
+#
+# create-pcb / PCBFromSchematic embed Reference/Value via
+# PCB.add_footprint_from_file(). When a value parses as a float (e.g. a
+# unit-less resistor value "470"), the serializer's textual heuristic used to
+# emit the bare token (property "Value" 470) -- which kicad-cli rejects with
+# "Failed to load board" (exit 3), silently breaking the entire schematic ->
+# PCB -> manufacturing path. The fix forces Reference/Value (and the
+# synthesized-property fallback) through SExp.quoted_atom() so they always
+# serialize quoted. These tests gate the load contract against the real
+# kicad-cli parser; the kicad-cli-free unit assertions live in
+# tests/test_pcb.py:TestAddFootprintNumericPropertyQuoting.
+
+_FIXTURE_FP = (
+    REPO_ROOT / "tests" / "fixtures" / "Test_Library.pretty" / "C_0402_1005Metric.kicad_mod"
+)
+
+
+class TestNumericPropertyValueRoundtrip:
+    """A board with a unit-less numeric footprint Value must load in kicad-cli."""
+
+    @pytest.mark.parametrize("value", ["470", "0", "100"])
+    def test_numeric_value_loads_in_kicad_cli(self, value: str, tmp_path: Path) -> None:
+        """add_footprint_from_file with a numeric Value -> loadable board."""
+        pcb = PCB.create(width=50.0, height=50.0, title="numeric value roundtrip")
+        pcb.add_footprint_from_file(
+            kicad_mod_path=_FIXTURE_FP,
+            reference="R1",
+            x=25.0,
+            y=25.0,
+            value=value,
+        )
+        pcb_path = tmp_path / f"numeric_{value}.kicad_pcb"
+        pcb.save(pcb_path)
+
+        # Regression guard: the value must be quoted before kicad-cli is even
+        # invoked, so the failure is attributed clearly on runners where
+        # kicad-cli's stderr is unhelpful.
+        contents = pcb_path.read_text()
+        assert f'(property "Value" "{value}"' in contents, (
+            f"Regression guard: a numeric Value {value!r} must serialize as "
+            f'(property "Value" "{value}") -- quoted. The bare numeric form is '
+            "rejected by kicad-cli with 'Failed to load board' (exit 3). See "
+            "PCB.add_footprint_from_file in src/kicad_tools/schema/pcb.py "
+            "(issue #3802)."
+        )
+        assert f'(property "Value" {value}' not in contents
+
+        _assert_kicad_cli_loads(
+            pcb_path,
+            producer="PCB.add_footprint_from_file (numeric Value)",
+            tmp_path=tmp_path,
+        )
+
+    def test_numeric_reference_loads_in_kicad_cli(self, tmp_path: Path) -> None:
+        """A numeric-looking Reference designator must not break the load."""
+        pcb = PCB.create(width=50.0, height=50.0, title="numeric reference roundtrip")
+        pcb.add_footprint_from_file(
+            kicad_mod_path=_FIXTURE_FP,
+            reference="1",
+            x=25.0,
+            y=25.0,
+            value="10k",
+        )
+        pcb_path = tmp_path / "numeric_ref.kicad_pcb"
+        pcb.save(pcb_path)
+
+        contents = pcb_path.read_text()
+        assert '(property "Reference" "1"' in contents
+        assert '(property "Reference" 1' not in contents
+
+        _assert_kicad_cli_loads(
+            pcb_path,
+            producer="PCB.add_footprint_from_file (numeric Reference)",
+            tmp_path=tmp_path,
+        )

--- a/tests/test_pcb.py
+++ b/tests/test_pcb.py
@@ -3450,3 +3450,118 @@ class TestPCBConstructorGuard:
         pcb = PCB.load(fixture_path)
         assert len(pcb.layers) > 0
         assert len(pcb.nets) >= 0
+
+
+class TestAddFootprintNumericPropertyQuoting:
+    """Numeric Reference/Value properties must serialize quoted (issue #3802).
+
+    ``add_footprint_from_file`` embeds Reference/Value into the board's
+    S-expression tree. When the value parses as a float (e.g. a unit-less
+    resistor value ``470``), the serializer's textual heuristic would emit a
+    bare token ``(property "Value" 470)``. KiCad/kicad-cli reject that with
+    "Failed to load board" (exit 3), making the whole board unloadable.
+
+    These assertions run without kicad-cli so the regression is caught on any
+    runner; ``tests/test_kicad_cli_roundtrip.py`` adds the load-level gate.
+    """
+
+    FIXTURES_DIR = Path(__file__).parent / "fixtures"
+    TEST_PRETTY_DIR = FIXTURES_DIR / "Test_Library.pretty"
+
+    # Footprint that already carries Reference/Value property nodes, to
+    # exercise the existing-property write branch (the fixture footprint
+    # below has none, exercising the synthesized-property fallback).
+    _FP_WITH_PROPERTIES = """\
+(footprint "Test:R_Numeric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-00000000aaaa")
+    (property "Reference" "REF**" (at 0 -1.5 0) (layer "F.SilkS")
+        (effects (font (size 1 1) (thickness 0.15)))
+    )
+    (property "Value" "Test:R_Numeric" (at 0 1.5 0) (layer "F.Fab")
+        (effects (font (size 1 1) (thickness 0.15)))
+    )
+    (pad "1" smd rect (at -1 0) (size 1 1) (layers "F.Cu"))
+    (pad "2" smd rect (at 1 0) (size 1 1) (layers "F.Cu"))
+)
+"""
+
+    @pytest.mark.parametrize("value", ["470", "0", "100", "-5", "3.3"])
+    def test_synthesized_value_property_is_quoted(self, minimal_pcb, tmp_path, value):
+        """A numeric Value emits ``(property "Value" "<n>")`` (synthesized branch)."""
+        doc = load_pcb(str(minimal_pcb))
+        pcb = PCB(doc)
+        pcb.add_footprint_from_file(
+            kicad_mod_path=self.TEST_PRETTY_DIR / "C_0402_1005Metric.kicad_mod",
+            reference="R1",
+            x=50.0,
+            y=30.0,
+            value=value,
+        )
+        out = tmp_path / "synth.kicad_pcb"
+        pcb.save(out)
+        contents = out.read_text()
+        assert f'(property "Value" "{value}"' in contents, (
+            f"Numeric Value {value!r} must serialize quoted; bare numeric "
+            "makes the board unloadable in kicad-cli. Got:\n"
+            + "\n".join(line for line in contents.splitlines() if "Value" in line)
+        )
+        # The bug emitted the value as a bare numeric token (no quotes).
+        assert f'(property "Value" {value}' not in contents
+
+    @pytest.mark.parametrize("value", ["470", "0", "100"])
+    def test_existing_value_property_is_quoted(self, minimal_pcb, tmp_path, value):
+        """A numeric Value emits quoted when the footprint already has the prop."""
+        fp_path = tmp_path / "R_Numeric.kicad_mod"
+        fp_path.write_text(self._FP_WITH_PROPERTIES)
+
+        doc = load_pcb(str(minimal_pcb))
+        pcb = PCB(doc)
+        pcb.add_footprint_from_file(
+            kicad_mod_path=fp_path,
+            reference="R1",
+            x=50.0,
+            y=30.0,
+            value=value,
+        )
+        out = tmp_path / "existing.kicad_pcb"
+        pcb.save(out)
+        contents = out.read_text()
+        assert f'(property "Value" "{value}"' in contents
+        assert f'(property "Value" {value} ' not in contents
+
+    def test_numeric_reference_is_quoted(self, minimal_pcb, tmp_path):
+        """A numeric-looking Reference designator serializes quoted."""
+        doc = load_pcb(str(minimal_pcb))
+        pcb = PCB(doc)
+        pcb.add_footprint_from_file(
+            kicad_mod_path=self.TEST_PRETTY_DIR / "C_0402_1005Metric.kicad_mod",
+            reference="1",
+            x=50.0,
+            y=30.0,
+            value="10k",
+        )
+        out = tmp_path / "ref.kicad_pcb"
+        pcb.save(out)
+        contents = out.read_text()
+        assert '(property "Reference" "1"' in contents
+        assert '(property "Reference" 1' not in contents
+
+    def test_structural_numeric_tokens_stay_unquoted(self, minimal_pcb, tmp_path):
+        """The fix must not over-quote structural numerics (at/size/layer idx)."""
+        doc = load_pcb(str(minimal_pcb))
+        pcb = PCB(doc)
+        pcb.add_footprint_from_file(
+            kicad_mod_path=self.TEST_PRETTY_DIR / "C_0402_1005Metric.kicad_mod",
+            reference="C1",
+            x=50.0,
+            y=30.0,
+            value="470",
+        )
+        out = tmp_path / "structural.kicad_pcb"
+        pcb.save(out)
+        contents = out.read_text()
+        # Pad/geometry coordinates and sizes must remain bare numerics.
+        assert "(size 1 1)" in contents or "(size " in contents
+        assert '(size "1" "1")' not in contents
+        assert '(thickness "0.15")' not in contents


### PR DESCRIPTION
## Summary
`kct create-pcb` / `PCBFromSchematic` embedded footprint Reference/Value
properties via `SExp.set_value()`, which produces an atom with
`_originally_quoted=False`. The serializer's textual heuristic
(`_needs_quoting`) does **not** quote strings that parse as a float, so a
unit-less numeric value like `470` serialized as the bare token
`(property "Value" 470)`. KiCad/kicad-cli reject that with "Failed to load
board" (exit 3), silently breaking the entire schematic -> PCB ->
manufacturing path for common designs (any resistor with a bare numeric value).

## Changes
- `src/kicad_tools/schema/pcb.py` — `add_footprint_from_file()` now routes
  Reference/Value through the existing `SExp.quoted_atom()` helper in all
  three write paths: the existing-`property` branch, the KiCad-7 `fp_text`
  fallback, and the synthesized-`property` fallback (when the footprint lacks a
  Reference/Value node). `add_footprint()` delegates here, so both public
  entry points and the create-pcb workflow are covered.
- `tests/test_pcb.py` — `TestAddFootprintNumericPropertyQuoting`: kicad-cli-free
  unit assertions on the serialized string (parametrized over `470/0/100/-5/3.3`),
  covering both the synthesized and existing-property branches, a numeric
  Reference, and a no-over-quoting check for structural tokens.
- `tests/test_kicad_cli_roundtrip.py` — `TestNumericPropertyValueRoundtrip`:
  loads a board built via `add_footprint_from_file` with a numeric Value/Reference
  through `kicad-cli pcb drc` and asserts it loads (exit 0).

Scope kept narrow per the curated guidance: no change to the global
`_needs_quoting()` heuristic; structural numeric tokens (`at`, `size`, layer
indices, net numbers) remain bare.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Numeric Value (470/0/100) emits `(property "Value" "470")` quoted | done | `test_synthesized_value_property_is_quoted`, `test_existing_value_property_is_quoted` |
| Numeric Reference / custom values quoted | done | `test_numeric_reference_is_quoted`, `test_numeric_reference_loads_in_kicad_cli` |
| Synthesized-property fallback emits quoted | done | fixture footprint has no Reference/Value -> exercises fallback in `test_synthesized_*` |
| Board with numeric value loads under kicad-cli (exit 0) | done | `TestNumericPropertyValueRoundtrip` (4 passed with kicad-cli present) |
| Structural numerics (at/size) stay unquoted | done | `test_structural_numeric_tokens_stay_unquoted` |

## Test Plan
- `uv run pytest tests/test_pcb.py tests/test_kicad_cli_roundtrip.py` — 209 passed
  (kicad-cli present locally, so the roundtrip load gate runs).
- `uv run ruff check .` — passed; `uv run ruff format . --check` — passed after
  formatting the two touched test files.
- mypy on `src/kicad_tools/schema/pcb.py` reports only pre-existing errors
  (lines 610-1848, 5122); none on the touched lines (~3936-3982).

Closes #3802