### PR TITLE
fix: bound create-pcb grid by board height, emit gr_line outline, pin format version

### DIFF
--- a/src/kicad_tools/cli/create_pcb_cmd.py
+++ b/src/kicad_tools/cli/create_pcb_cmd.py
@@ -154,6 +154,9 @@ def main(argv: list[str] | None = None) -> int:
                 )
             )
 
+            for warning in result.warnings:
+                console.print(f"[yellow]Warning: {warning}[/yellow]")
+
             if result.failed:
                 table = Table(title="Failed Placements")
                 table.add_column("Reference")

--- a/src/kicad_tools/core/version.py
+++ b/src/kicad_tools/core/version.py
@@ -1,0 +1,17 @@
+"""Shared KiCad file-format version constants.
+
+KiCad stamps a numeric format ``version`` (a date code) into ``.kicad_pcb``
+and ``.kicad_mod`` files.  Installed KiCad rejects files stamped with a
+*future* format version it does not recognise, so every writer in this
+package must emit the same, KiCad-compatible value.
+
+Keeping a single constant here prevents the drift that previously had some
+writers emit ``20260206`` (a future code KiCad 10.0.3 rejects) while others
+emitted the correct ``20241229``.
+"""
+
+# KiCad 10.0.x compatible board / footprint file-format version (date code).
+# Used by all writers that emit a ``(version ...)`` node so they cannot drift.
+KICAD_BOARD_FORMAT_VERSION = 20241229
+
+__all__ = ["KICAD_BOARD_FORMAT_VERSION"]

--- a/src/kicad_tools/footprints/__init__.py
+++ b/src/kicad_tools/footprints/__init__.py
@@ -8,6 +8,7 @@ including common package types (0402, 0603, SOT-23, QFN, etc.).
 from enum import Enum
 
 from kicad_tools.core.types import Layer
+from kicad_tools.core.version import KICAD_BOARD_FORMAT_VERSION
 from kicad_tools.sexp import SExp
 from kicad_tools.sexp.builders import fmt
 
@@ -187,7 +188,7 @@ class Footprint:
         Example output::
 
             (footprint "C_0402_1005Metric"
-                (version 20260206)
+                (version 20241229)
                 (generator "kicad-tools")
                 (layer "F.Cu")
                 (descr "Capacitor SMD 0402")
@@ -206,7 +207,7 @@ class Footprint:
         footprint = SExp.list("footprint", self.name)
 
         # Version and generator
-        footprint.append(SExp.list("version", 20260206))
+        footprint.append(SExp.list("version", KICAD_BOARD_FORMAT_VERSION))
         footprint.append(SExp.list("generator", "kicad-tools"))
 
         # Layer

--- a/src/kicad_tools/library/footprint.py
+++ b/src/kicad_tools/library/footprint.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
+from kicad_tools.core.version import KICAD_BOARD_FORMAT_VERSION
 from kicad_tools.utils import ensure_parent_dir
 
 
@@ -318,7 +319,7 @@ class Footprint:
     def to_sexp(self) -> str:
         """Convert footprint to KiCad S-expression format."""
         lines = [f'(footprint "{self.name}"']
-        lines.append("\t(version 20241229)")
+        lines.append(f"\t(version {KICAD_BOARD_FORMAT_VERSION})")
         lines.append('\t(generator "kicad_tools")')
         lines.append('\t(layer "F.Cu")')
 

--- a/src/kicad_tools/pcb/exporter.py
+++ b/src/kicad_tools/pcb/exporter.py
@@ -10,6 +10,7 @@ import re
 import uuid
 from pathlib import Path
 
+from ..core.version import KICAD_BOARD_FORMAT_VERSION
 from .layout import PCBLayout
 
 
@@ -54,7 +55,7 @@ class KiCadPCBExporter:
     def _generate_header(self, title: str = "PCB Layout") -> str:
         """Generate PCB file header."""
         return f'''(kicad_pcb
-	(version 20241229)
+	(version {KICAD_BOARD_FORMAT_VERSION})
 	(generator "kicad_pcb_blocks.py")
 	(generator_version "1.0")
 	(general

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -1651,8 +1651,9 @@ class PadPosition:
 def extract_board_dimensions(pcb_path_or_text: str | Path) -> tuple[float, float] | None:
     """Extract board width and height from a KiCad PCB file.
 
-    Parses the Edge.Cuts gr_rect to determine board dimensions. This is a
-    lightweight extraction that avoids full PCB parsing.
+    Parses the Edge.Cuts outline (``gr_rect`` or four ``gr_line`` segments)
+    to determine board dimensions. This is a lightweight extraction that
+    avoids full PCB parsing.
 
     Args:
         pcb_path_or_text: Path to .kicad_pcb file or PCB file contents
@@ -1682,6 +1683,42 @@ def extract_board_dimensions(pcb_path_or_text: str | Path) -> tuple[float, float
     if edge_match:
         x1, y1, x2, y2 = map(float, edge_match.groups())
         return (abs(x2 - x1), abs(y2 - y1))
+
+    # Fallback: board outlines emitted as four gr_line Edge.Cuts segments
+    # (PCB.create / replace_outline; issue #3805).  Derive the size from the
+    # bounding box of all Edge.Cuts gr_line endpoints.
+    bbox = _edge_cuts_gr_line_bbox(pcb_text)
+    if bbox is not None:
+        min_x, min_y, max_x, max_y = bbox
+        return (max_x - min_x, max_y - min_y)
+    return None
+
+
+def _edge_cuts_gr_line_bbox(pcb_text: str) -> tuple[float, float, float, float] | None:
+    """Bounding box (min_x, min_y, max_x, max_y) of Edge.Cuts gr_line endpoints.
+
+    Lightweight regex scan used by :func:`extract_board_dimensions` and
+    :func:`extract_board_origin` to support board outlines written as four
+    ``gr_line`` segments (issue #3805) rather than a single ``gr_rect``.
+    Returns ``None`` when no Edge.Cuts gr_line geometry is present.
+    """
+    xs: list[float] = []
+    ys: list[float] = []
+    # Split on the gr_line opener; each chunk holds one gr_line's body up to
+    # the next graphic element.  Only consider chunks on the Edge.Cuts layer.
+    chunks = pcb_text.split("(gr_line")
+    for chunk in chunks[1:]:
+        # Bound the chunk at the next graphic opener so a later element's
+        # layer/coords cannot leak in.
+        next_gr = re.search(r"\(gr_", chunk)
+        body = chunk[: next_gr.start()] if next_gr else chunk
+        if "Edge.Cuts" not in body:
+            continue
+        for cx, cy in re.findall(r"\((?:start|end)\s+(-?[\d.]+)\s+(-?[\d.]+)\)", body):
+            xs.append(float(cx))
+            ys.append(float(cy))
+    if xs and ys:
+        return (min(xs), min(ys), max(xs), max(ys))
     return None
 
 
@@ -1719,6 +1756,12 @@ def extract_board_origin(pcb_path_or_text: str | Path) -> tuple[float, float] | 
     if edge_match:
         x1, y1, x2, y2 = map(float, edge_match.groups())
         return (min(x1, x2), min(y1, y2))
+
+    # Fallback: four gr_line Edge.Cuts segments (issue #3805).
+    bbox = _edge_cuts_gr_line_bbox(pcb_text)
+    if bbox is not None:
+        min_x, min_y, _max_x, _max_y = bbox
+        return (min_x, min_y)
     return None
 
 

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -1728,9 +1728,16 @@ class PCB:
             elif tag == "gr_line":
                 line = GraphicLine.from_sexp(child)
                 self._graphic_lines.append(line)
+                # Also surface as a BoardGraphic so the public read path
+                # (``graphics`` / ``graphics_on_layer``) sees gr_line outlines
+                # (e.g. the four-segment Edge.Cuts boundary emitted by
+                # ``PCB.create``).  Without this, gr_line boards would be
+                # invisible to ``graphics_on_layer``.
+                self._graphics.append(BoardGraphic.from_sexp(child, "line"))
             elif tag == "gr_arc":
                 arc = GraphicArc.from_sexp(child)
                 self._graphic_arcs.append(arc)
+                self._graphics.append(BoardGraphic.from_sexp(child, "arc"))
             elif tag == "setup":
                 self._parse_setup(child)
             elif tag == "title_block":
@@ -1738,7 +1745,7 @@ class PCB:
             elif tag == "gr_text":
                 text = GraphicText.from_sexp(child)
                 self._texts.append(text)
-            elif tag in ("gr_line", "gr_rect", "gr_circle", "gr_arc"):
+            elif tag in ("gr_rect", "gr_circle"):
                 graphic_type = tag[3:]  # Remove "gr_" prefix
                 graphic = BoardGraphic.from_sexp(child, graphic_type)
                 self._graphics.append(graphic)
@@ -2670,10 +2677,18 @@ class PCB:
 
         Yields all graphic elements from Edge.Cuts and other layers.
         Used for board outline calculations and layer analysis.
+
+        ``gr_line`` and ``gr_arc`` elements are emitted once, as their richer
+        typed forms (:class:`GraphicLine` / :class:`GraphicArc`).  They are
+        also mirrored into ``_graphics`` as :class:`BoardGraphic` for the
+        ``graphics`` / ``graphics_on_layer`` read path, so those line/arc
+        mirrors are skipped here to avoid double-counting.
         """
         yield from self._graphic_lines
         yield from self._graphic_arcs
-        yield from self._graphics
+        for graphic in self._graphics:
+            if graphic.graphic_type not in ("line", "arc"):
+                yield graphic
 
     def graphics_on_layer(self, layer: str) -> Iterator[BoardGraphic]:
         """Get graphic elements on a specific layer."""
@@ -3007,8 +3022,10 @@ class PCB:
                 tag = child.tag
                 if tag == "gr_line":
                     self._graphic_lines.append(GraphicLine.from_sexp(child))
+                    self._graphics.append(BoardGraphic.from_sexp(child, "line"))
                 elif tag == "gr_arc":
                     self._graphic_arcs.append(GraphicArc.from_sexp(child))
+                    self._graphics.append(BoardGraphic.from_sexp(child, "arc"))
                 elif tag in ("gr_rect", "gr_circle"):
                     graphic_type = tag[3:]
                     self._graphics.append(BoardGraphic.from_sexp(child, graphic_type))
@@ -3062,8 +3079,10 @@ class PCB:
             tag = child.tag
             if tag == "gr_line":
                 self._graphic_lines.append(GraphicLine.from_sexp(child))
+                self._graphics.append(BoardGraphic.from_sexp(child, "line"))
             elif tag == "gr_arc":
                 self._graphic_arcs.append(GraphicArc.from_sexp(child))
+                self._graphics.append(BoardGraphic.from_sexp(child, "arc"))
             elif tag in ("gr_rect", "gr_circle"):
                 graphic_type = tag[3:]
                 self._graphics.append(BoardGraphic.from_sexp(child, graphic_type))

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 from kicad_tools.sexp import SExp
 
 from ..core.sexp_file import load_footprint, load_pcb, save_pcb
+from ..core.version import KICAD_BOARD_FORMAT_VERSION
 from ..footprints.library_path import (
     detect_kicad_library_path,
     guess_standard_library,
@@ -1493,7 +1494,7 @@ class PCB:
         pcb = SExp.list("kicad_pcb")
 
         # Version and generator info
-        pcb.append(SExp.list("version", 20260206))
+        pcb.append(SExp.list("version", KICAD_BOARD_FORMAT_VERSION))
         pcb.append(SExp.list("generator", "kicad_tools"))
         # generator_version is a strict-typed string field in KiCad; emit the
         # value as a quoted atom so kicad-cli accepts the file even though
@@ -1532,8 +1533,9 @@ class PCB:
         # Empty net (required)
         pcb.append(SExp.list("net", 0, ""))
 
-        # Board outline on Edge.Cuts
-        pcb.append(PCB._build_board_outline_sexp(width, height, origin_x, origin_y))
+        # Board outline on Edge.Cuts (four gr_line segments)
+        for line in PCB._build_board_outline_sexp(width, height, origin_x, origin_y):
+            pcb.append(line)
 
         return pcb
 
@@ -1660,17 +1662,45 @@ class PCB:
     @staticmethod
     def _build_board_outline_sexp(
         width: float, height: float, origin_x: float, origin_y: float
-    ) -> SExp:
-        """Build a rectangular board outline on Edge.Cuts layer."""
-        return SExp.list(
-            "gr_rect",
-            SExp.list("start", origin_x, origin_y),
-            SExp.list("end", origin_x + width, origin_y + height),
-            SExp.list("stroke", SExp.list("width", 0.1), SExp.list("type", "default")),
-            SExp.list("fill", "none"),
-            SExp.list("layer", "Edge.Cuts"),
-            SExp.list("uuid", str(uuid.uuid4())),
-        )
+    ) -> list[SExp]:
+        """Build a rectangular board outline on Edge.Cuts layer.
+
+        Emits four ``gr_line`` segments forming a closed rectangle rather than
+        a single ``gr_rect``.  Downstream placement/route tooling (and some of
+        this package's own DSN/routing paths) expect ``gr_line`` boundary
+        segments, and the PCB parser already ingests ``gr_line`` into
+        ``_graphic_lines`` (used by both ``board_size`` and board-origin
+        detection via their gr_line fallbacks).
+
+        Corners are walked clockwise:
+        ``(ox,oy) -> (ox+w,oy) -> (ox+w,oy+h) -> (ox,oy+h) -> (ox,oy)``.
+
+        Returns:
+            A list of four ``gr_line`` S-expressions.
+        """
+        ox, oy = origin_x, origin_y
+        corners = [
+            (ox, oy),
+            (ox + width, oy),
+            (ox + width, oy + height),
+            (ox, oy + height),
+        ]
+
+        lines: list[SExp] = []
+        for i in range(4):
+            start = corners[i]
+            end = corners[(i + 1) % 4]
+            lines.append(
+                SExp.list(
+                    "gr_line",
+                    SExp.list("start", start[0], start[1]),
+                    SExp.list("end", end[0], end[1]),
+                    SExp.list("stroke", SExp.list("width", 0.1), SExp.list("type", "default")),
+                    SExp.list("layer", "Edge.Cuts"),
+                    SExp.list("uuid", str(uuid.uuid4())),
+                )
+            )
+        return lines
 
     def _parse(self):
         """Parse the PCB data structure."""
@@ -2992,11 +3022,12 @@ class PCB:
         width: float,
         height: float,
     ) -> int:
-        """Replace all outline contours with a single rectangle.
+        """Replace all outline contours with a rectangle.
 
         Removes every Edge.Cuts contour whose bounding-box area is above
-        the mounting-hole threshold, then inserts a new ``gr_rect`` at
-        the given origin and size.  Mounting-hole contours are preserved.
+        the mounting-hole threshold, then inserts a new rectangular outline
+        (four ``gr_line`` Edge.Cuts segments) at the given origin and size.
+        Mounting-hole contours are preserved.
 
         Args:
             origin_x: X coordinate of top-left corner (mm).
@@ -3017,9 +3048,9 @@ class PCB:
                     self._sexp.remove(node)
                 removed += 1
 
-        # Insert new rect outline
-        new_rect = PCB._build_board_outline_sexp(width, height, origin_x, origin_y)
-        self._sexp.append(new_rect)
+        # Insert new outline (four gr_line Edge.Cuts segments)
+        for line in PCB._build_board_outline_sexp(width, height, origin_x, origin_y):
+            self._sexp.append(line)
 
         # Rebuild in-memory lists
         self._graphic_lines = []

--- a/src/kicad_tools/workflow/__init__.py
+++ b/src/kicad_tools/workflow/__init__.py
@@ -30,6 +30,7 @@ Example usage:
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -95,6 +96,9 @@ class PlacementResult:
 
     failed: list[tuple[str, str]] = field(default_factory=list)
     """List of (reference, error_message) for components that failed to place"""
+
+    warnings: list[str] = field(default_factory=list)
+    """Non-fatal placement warnings (e.g. spacing was auto-shrunk to fit)."""
 
     @property
     def success_count(self) -> int:
@@ -307,6 +311,29 @@ class PCBFromSchematic:
         """
         return self.add_component(reference, x, y, rotation, layer)
 
+    @staticmethod
+    def _shrink_spacing_to_fit(
+        n: int, usable_width: float, usable_height: float, columns: int
+    ) -> float | None:
+        """Largest spacing (mm) at which ``n`` parts fit in ``columns`` columns.
+
+        Used when the requested spacing would overflow the board.  Returns the
+        biggest spacing such that ``columns`` columns fit within
+        ``usable_width`` and ``ceil(n / columns)`` rows fit within
+        ``usable_height``, or ``None`` if even an infinitesimal spacing cannot
+        fit (i.e. the usable area is non-positive).
+        """
+        if columns <= 0 or usable_width <= 0 or usable_height <= 0 or n <= 0:
+            return None
+
+        rows = math.ceil(n / columns)
+        # Column spacing is bounded by width / columns; row spacing by
+        # height / rows.  Use the tighter of the two so both axes fit.
+        spacing_w = usable_width / columns
+        spacing_h = usable_height / rows
+        spacing = min(spacing_w, spacing_h)
+        return spacing if spacing > 0 else None
+
     def place_all_components(
         self,
         start_x: float | None = None,
@@ -346,13 +373,22 @@ class PCBFromSchematic:
         if self._pcb is None:
             raise ValueError("No PCB created. Call create_pcb() first.")
 
-        board_w, _board_h = self._pcb.board_size
+        board_w, board_h = self._pcb.board_size
 
         # Determine starting position
         sx = start_x if start_x is not None else margin
         sy = start_y if start_y is not None else margin
 
-        # Auto-calculate column count from board width if not specified
+        result = PlacementResult()
+        components = self.get_components()
+
+        # Auto-calculate column count from board width if not specified.  When
+        # auto-sizing, also bound the grid by the board *height*: if the parts
+        # would overflow past the bottom edge at the computed column count,
+        # widen the grid (more columns / fewer rows) until it fits, and if it
+        # still cannot fit at the requested spacing, auto-shrink the spacing.
+        # Callers that pass an explicit ``columns`` keep their grid unchanged.
+        auto_columns = columns is None
         if columns is None:
             if board_w > 0 and spacing > 0:
                 usable_width = board_w - sx - margin
@@ -360,18 +396,58 @@ class PCBFromSchematic:
             else:
                 columns = 10  # fallback when board size is unknown
 
-        result = PlacementResult()
-        components = self.get_components()
+        # Number of components that actually need a grid slot (those with a
+        # footprint assigned); components without a footprint are reported as
+        # failures and never consume a position.
+        placeable = [c for c in components if c.footprint]
+        n = len(placeable)
 
-        for i, comp in enumerate(components):
-            col = i % columns
-            row = i // columns
-            x = sx + col * spacing
-            y = sy + row * spacing
+        if auto_columns and board_w > 0 and board_h > 0 and spacing > 0 and n > 0:
+            usable_width = board_w - sx - margin
+            usable_height = board_h - sy - margin
+            max_cols = max(1, int(usable_width / spacing))
+            max_rows = max(1, int(usable_height / spacing))
+            capacity = max_cols * max_rows
 
+            if n <= capacity:
+                # Fits at the requested spacing: pick the smallest column count
+                # (>= current) whose row count stays within max_rows so parts
+                # stay inside the outline.
+                needed_cols = math.ceil(n / max_rows)
+                columns = max(1, min(max_cols, max(columns, needed_cols)))
+            else:
+                # Cannot fit at the requested spacing.  Shrink spacing so all
+                # parts fit inside the outline, and warn the caller.
+                columns = max_cols
+                fitted = self._shrink_spacing_to_fit(n, usable_width, usable_height, columns)
+                if fitted is not None:
+                    spacing = fitted
+                    result.warnings.append(
+                        f"{n} components do not fit within "
+                        f"{board_w:.1f}x{board_h:.1f} mm at {spacing:.1f} mm "
+                        f"spacing; auto-shrank spacing to {fitted:.2f} mm to fit."
+                    )
+                else:
+                    result.warnings.append(
+                        f"{n} components cannot fit within "
+                        f"{board_w:.1f}x{board_h:.1f} mm even at minimal "
+                        f"spacing; some footprints may overflow the outline."
+                    )
+
+        # Grid slots are consumed only by components that actually get placed,
+        # so components without a footprint do not push the rest of the grid
+        # past the board height.
+        slot = 0
+        for comp in components:
             if not comp.footprint:
                 result.failed.append((comp.reference, "No footprint assigned"))
                 continue
+
+            col = slot % columns
+            row = slot // columns
+            x = sx + col * spacing
+            y = sy + row * spacing
+            slot += 1
 
             try:
                 fp = self.add_component(comp.reference, x, y)

--- a/tests/test_footprints.py
+++ b/tests/test_footprints.py
@@ -254,7 +254,7 @@ class TestFootprint:
 
         assert "(footprint" in sexp
         assert '"test"' in sexp
-        assert "(version 20260206)" in sexp
+        assert "(version 20241229)" in sexp
         assert '(generator "kicad-tools")' in sexp
         assert '(layer "F.Cu")' in sexp
         assert "(attr smd)" in sexp
@@ -636,7 +636,7 @@ class TestFootprintToSexpIntegration:
 
         # Check structure
         assert parsed.name == "footprint"
-        assert parsed["version"].get_first_atom() == 20260206
+        assert parsed["version"].get_first_atom() == 20241229
         assert parsed["generator"].get_first_atom() == "kicad-tools"
         assert parsed["layer"].get_first_atom() == "F.Cu"
         assert parsed["descr"].get_first_atom() == "Test description"

--- a/tests/test_kicad_cli_roundtrip.py
+++ b/tests/test_kicad_cli_roundtrip.py
@@ -149,6 +149,26 @@ class TestPCBSaveRoundtrip:
 
         _assert_kicad_cli_loads(pcb_path, producer="PCB.save (blank)", tmp_path=tmp_path)
 
+    def test_gr_line_outline_and_version_roundtrip(self, tmp_path: Path) -> None:
+        """Issue #3805: gr_line outline + 20241229 version must load in KiCad 10.
+
+        Guards against the future version stamp (20260206) and the gr_rect
+        outline that previously needed manual fixups before opening in KiCad.
+        """
+        pcb = PCB.create(width=65.0, height=56.0, title="issue-3805 roundtrip")
+        pcb_path = tmp_path / "issue3805.kicad_pcb"
+        pcb.save(pcb_path)
+
+        contents = pcb_path.read_text()
+        assert "(version 20241229)" in contents
+        assert "20260206" not in contents
+        assert "gr_rect" not in contents
+        assert contents.count("(gr_line") == 4
+
+        _assert_kicad_cli_loads(
+            pcb_path, producer="PCB.save (issue-3805 outline)", tmp_path=tmp_path
+        )
+
     def test_pcb_with_silkscreen_text_roundtrip(self, tmp_path: Path) -> None:
         """A PCB with ``gr_text`` silkscreen markings must load via kicad-cli.
 

--- a/tests/test_manufacturer_propagation_lint.py
+++ b/tests/test_manufacturer_propagation_lint.py
@@ -74,8 +74,8 @@ _ALLOWLIST: dict[str, dict[int, str]] = {
     # the caller explicitly passes ``rules=None`` (no PCB rules either).
     # The CLI always supplies its own rules with manufacturer wired in.
     "router/io.py": {
-        2825: "route_pcb() fallback when caller passes rules=None",
-        3425: "load_pcb_for_routing() inner fallback when neither rules nor pcb_rules supplied",
+        2868: "route_pcb() fallback when caller passes rules=None",
+        3468: "load_pcb_for_routing() inner fallback when neither rules nor pcb_rules supplied",
     },
     # Benchmark/synthetic fixture generators — no real CLI context.
     "benchmark/runner.py": {

--- a/tests/test_pcb.py
+++ b/tests/test_pcb.py
@@ -20,6 +20,34 @@ requires_kicad_footprint_libs = pytest.mark.skipif(
 )
 
 
+def _edge_cuts_lines(pcb: PCB):
+    """Return all (start, end) gr_line segments on Edge.Cuts from the tree."""
+    segments = []
+    for child in pcb._sexp.iter_children():
+        if child.tag != "gr_line":
+            continue
+        layer = child.find("layer")
+        if layer is None or layer.get_string(0) != "Edge.Cuts":
+            continue
+        start = child.find("start")
+        end = child.find("end")
+        segments.append(
+            (
+                (start.get_float(0), start.get_float(1)),
+                (end.get_float(0), end.get_float(1)),
+            )
+        )
+    return segments
+
+
+def _outline_bbox(pcb: PCB):
+    """Return ((min_x, min_y), (max_x, max_y)) of the Edge.Cuts gr_line outline."""
+    segments = _edge_cuts_lines(pcb)
+    xs = [c for seg in segments for c in (seg[0][0], seg[1][0])]
+    ys = [c for seg in segments for c in (seg[0][1], seg[1][1])]
+    return ((min(xs), min(ys)), (max(xs), max(ys)))
+
+
 def test_load_pcb(minimal_pcb: Path):
     """Load a PCB file."""
     doc = load_pcb(str(minimal_pcb))
@@ -1921,40 +1949,36 @@ class TestPCBCreate:
         # Offset Y: (210 - 120) / 2 = 45mm
         pcb = PCB.create(width=200, height=120)
 
-        # Find the board outline (gr_rect on Edge.Cuts)
-        gr_rect = pcb._sexp.find("gr_rect")
-        assert gr_rect is not None
+        # Board outline is four gr_line segments on Edge.Cuts (issue #3805).
+        assert pcb._sexp.find("gr_rect") is None
+        assert len(_edge_cuts_lines(pcb)) == 4
 
-        start = gr_rect.find("start")
-        end = gr_rect.find("end")
-        assert start is not None
-        assert end is not None
+        (min_x, min_y), (max_x, max_y) = _outline_bbox(pcb)
 
         # Check origin is centered
-        assert start.get_float(0) == pytest.approx(48.5)
-        assert start.get_float(1) == pytest.approx(45.0)
+        assert min_x == pytest.approx(48.5)
+        assert min_y == pytest.approx(45.0)
 
-        # Check end is offset by board dimensions
-        assert end.get_float(0) == pytest.approx(248.5)  # 48.5 + 200
-        assert end.get_float(1) == pytest.approx(165.0)  # 45 + 120
+        # Check far corner is offset by board dimensions
+        assert max_x == pytest.approx(248.5)  # 48.5 + 200
+        assert max_y == pytest.approx(165.0)  # 45 + 120
 
     def test_create_no_centering(self):
         """Test that center=False places board at origin."""
         pcb = PCB.create(width=100, height=80, center=False)
 
-        gr_rect = pcb._sexp.find("gr_rect")
-        assert gr_rect is not None
+        assert pcb._sexp.find("gr_rect") is None
+        assert len(_edge_cuts_lines(pcb)) == 4
 
-        start = gr_rect.find("start")
-        end = gr_rect.find("end")
+        (min_x, min_y), (max_x, max_y) = _outline_bbox(pcb)
 
         # Check origin is at (0, 0)
-        assert start.get_float(0) == pytest.approx(0.0)
-        assert start.get_float(1) == pytest.approx(0.0)
+        assert min_x == pytest.approx(0.0)
+        assert min_y == pytest.approx(0.0)
 
-        # Check end is at (width, height)
-        assert end.get_float(0) == pytest.approx(100.0)
-        assert end.get_float(1) == pytest.approx(80.0)
+        # Check far corner is at (width, height)
+        assert max_x == pytest.approx(100.0)
+        assert max_y == pytest.approx(80.0)
 
     def test_create_with_a3_paper(self):
         """Test centering on A3 paper."""
@@ -1969,14 +1993,12 @@ class TestPCBCreate:
         assert paper is not None
         assert paper.get_string(0) == "A3"
 
-        gr_rect = pcb._sexp.find("gr_rect")
-        start = gr_rect.find("start")
-        end = gr_rect.find("end")
+        (min_x, min_y), (max_x, max_y) = _outline_bbox(pcb)
 
-        assert start.get_float(0) == pytest.approx(110.0)
-        assert start.get_float(1) == pytest.approx(73.5)
-        assert end.get_float(0) == pytest.approx(310.0)  # 110 + 200
-        assert end.get_float(1) == pytest.approx(223.5)  # 73.5 + 150
+        assert min_x == pytest.approx(110.0)
+        assert min_y == pytest.approx(73.5)
+        assert max_x == pytest.approx(310.0)  # 110 + 200
+        assert max_y == pytest.approx(223.5)  # 73.5 + 150
 
     def test_create_with_us_letter_paper(self):
         """Test centering on US Letter (A) paper."""
@@ -1989,11 +2011,10 @@ class TestPCBCreate:
         paper = pcb._sexp.find("paper")
         assert paper.get_string(0) == "A"
 
-        gr_rect = pcb._sexp.find("gr_rect")
-        start = gr_rect.find("start")
+        (min_x, min_y), _ = _outline_bbox(pcb)
 
-        assert start.get_float(0) == pytest.approx(89.7)
-        assert start.get_float(1) == pytest.approx(57.95)
+        assert min_x == pytest.approx(89.7)
+        assert min_y == pytest.approx(57.95)
 
     def test_create_invalid_paper_raises_error(self):
         """Test that invalid paper size raises ValueError."""
@@ -2011,11 +2032,10 @@ class TestPCBCreate:
         # Offset Y: (210 - 300) / 2 = -45mm
         pcb = PCB.create(width=400, height=300, paper="A4")
 
-        gr_rect = pcb._sexp.find("gr_rect")
-        start = gr_rect.find("start")
+        (min_x, min_y), _ = _outline_bbox(pcb)
 
-        assert start.get_float(0) == pytest.approx(-51.5)
-        assert start.get_float(1) == pytest.approx(-45.0)
+        assert min_x == pytest.approx(-51.5)
+        assert min_y == pytest.approx(-45.0)
 
     def test_create_preserves_all_parameters(self):
         """Test that all create() parameters still work with centering."""
@@ -2216,6 +2236,57 @@ class TestPCBCreate:
         else:
             pytest.fail("Footprint R1 not found")
 
+    def test_create_outline_is_four_gr_lines(self):
+        """Issue #3805: board outline must be four gr_line Edge.Cuts segments."""
+        pcb = PCB.create(width=65, height=56, center=False)
+
+        # No gr_rect outline anymore.
+        assert pcb._sexp.find("gr_rect") is None
+
+        segments = _edge_cuts_lines(pcb)
+        assert len(segments) == 4
+
+        # Segments form a closed rectangle: each corner appears as both a
+        # start and an end exactly once.
+        corners = {(0.0, 0.0), (65.0, 0.0), (65.0, 56.0), (0.0, 56.0)}
+        starts = {(round(s[0], 6), round(s[1], 6)) for s, _e in segments}
+        ends = {(round(e[0], 6), round(e[1], 6)) for _s, e in segments}
+        assert starts == corners
+        assert ends == corners
+
+    def test_create_board_size_from_gr_line_outline(self):
+        """board_size resolves correctly from the gr_line outline (#3805)."""
+        pcb = PCB.create(width=65, height=56)
+        w, h = pcb.board_size
+        assert w == pytest.approx(65.0)
+        assert h == pytest.approx(56.0)
+
+    def test_create_board_origin_from_gr_line_outline(self):
+        """Board-origin detection works with the gr_line outline (#3805)."""
+        # Centered on A4: origin = ((297-65)/2, (210-56)/2) = (116, 77).
+        pcb = PCB.create(width=65, height=56)
+        ox, oy = pcb.board_origin
+        assert ox == pytest.approx(116.0)
+        assert oy == pytest.approx(77.0)
+
+    def test_create_stamps_kicad10_format_version(self):
+        """Generated board stamps the KiCad-10 format version 20241229 (#3805)."""
+        from kicad_tools.core.version import KICAD_BOARD_FORMAT_VERSION
+
+        assert KICAD_BOARD_FORMAT_VERSION == 20241229
+
+        pcb = PCB.create(width=65, height=56)
+        version = pcb._sexp.find("version")
+        assert version is not None
+        assert version.get_int(0) == 20241229
+
+    def test_create_4layer_outline_is_gr_line(self):
+        """4-layer boards also emit a gr_line outline (#3805)."""
+        pcb = PCB.create(width=65, height=56, layers=4, center=False)
+        assert pcb._sexp.find("gr_rect") is None
+        assert len(_edge_cuts_lines(pcb)) == 4
+        assert pcb.board_size == pytest.approx((65.0, 56.0))
+
 
 class TestBoardOriginCoordinateConversion:
     """Tests for board origin coordinate conversion.
@@ -2406,20 +2477,18 @@ class TestPCBPageFit:
         margin = 7.5
         new_w, new_h = pcb.page_fit(margin=margin)
 
-        gr_rect = pcb._sexp.find("gr_rect")
-        start = gr_rect.find("start")
-        end = gr_rect.find("end")
+        (min_x, min_y), (max_x, max_y) = _outline_bbox(pcb)
 
         # Board outline min corner moved to (margin, margin).
-        assert start.get_float(0) == pytest.approx(margin)
-        assert start.get_float(1) == pytest.approx(margin)
+        assert min_x == pytest.approx(margin)
+        assert min_y == pytest.approx(margin)
         # Max corner = margin + board size.
-        assert end.get_float(0) == pytest.approx(margin + 200)
-        assert end.get_float(1) == pytest.approx(margin + 120)
+        assert max_x == pytest.approx(margin + 200)
+        assert max_y == pytest.approx(margin + 120)
 
         # Board center == page center.
-        board_cx = (start.get_float(0) + end.get_float(0)) / 2
-        board_cy = (start.get_float(1) + end.get_float(1)) / 2
+        board_cx = (min_x + max_x) / 2
+        board_cy = (min_y + max_y) / 2
         assert board_cx == pytest.approx(new_w / 2)
         assert board_cy == pytest.approx(new_h / 2)
 
@@ -2478,17 +2547,11 @@ class TestPCBPageFit:
     def test_page_fit_preserves_relative_geometry(self):
         """Relative spacing between items is unchanged (DRC-preserving)."""
         pcb = PCB.create(width=80, height=60)
-        gr_rect = pcb._sexp.find("gr_rect")
-        before = (
-            gr_rect.find("end").get_float(0) - gr_rect.find("start").get_float(0),
-            gr_rect.find("end").get_float(1) - gr_rect.find("start").get_float(1),
-        )
+        (bmin, bmax) = _outline_bbox(pcb)
+        before = (bmax[0] - bmin[0], bmax[1] - bmin[1])
         pcb.page_fit(margin=10.0)
-        gr_rect = pcb._sexp.find("gr_rect")
-        after = (
-            gr_rect.find("end").get_float(0) - gr_rect.find("start").get_float(0),
-            gr_rect.find("end").get_float(1) - gr_rect.find("start").get_float(1),
-        )
+        (amin, amax) = _outline_bbox(pcb)
+        after = (amax[0] - amin[0], amax[1] - amin[1])
         assert after[0] == pytest.approx(before[0])
         assert after[1] == pytest.approx(before[1])
 

--- a/tests/test_router_io.py
+++ b/tests/test_router_io.py
@@ -3839,3 +3839,43 @@ class TestRemoveConflictingViasFieldOrder:
 )"""
         result = _remove_conflicting_vias(txt, 0.2)
         assert result == txt
+
+
+class TestExtractBoardDimensionsGrLine:
+    """Issue #3805: board dimensions/origin from gr_line Edge.Cuts outline."""
+
+    _PCB_GR_LINE = """(kicad_pcb
+  (version 20241229)
+  (gr_line (start 116 77) (end 181 77) (stroke (width 0.1) (type default)) (layer "Edge.Cuts") (uuid "a"))
+  (gr_line (start 181 77) (end 181 133) (stroke (width 0.1) (type default)) (layer "Edge.Cuts") (uuid "b"))
+  (gr_line (start 181 133) (end 116 133) (stroke (width 0.1) (type default)) (layer "Edge.Cuts") (uuid "c"))
+  (gr_line (start 116 133) (end 116 77) (stroke (width 0.1) (type default)) (layer "Edge.Cuts") (uuid "d"))
+)"""
+
+    def test_dimensions_from_gr_line_outline(self):
+        from kicad_tools.router.io import extract_board_dimensions
+
+        dims = extract_board_dimensions(self._PCB_GR_LINE)
+        assert dims is not None
+        assert dims[0] == pytest.approx(65.0)
+        assert dims[1] == pytest.approx(56.0)
+
+    def test_origin_from_gr_line_outline(self):
+        from kicad_tools.router.io import extract_board_origin
+
+        origin = extract_board_origin(self._PCB_GR_LINE)
+        assert origin is not None
+        assert origin[0] == pytest.approx(116.0)
+        assert origin[1] == pytest.approx(77.0)
+
+    def test_dimensions_ignore_non_edge_gr_line(self):
+        """Silkscreen gr_lines must not contribute to board dimensions."""
+        from kicad_tools.router.io import extract_board_dimensions
+
+        extra = '  (gr_line (start 0 0) (end 500 500) (layer "F.SilkS") (uuid "z"))\n'
+        # Insert the silkscreen line just before the final closing paren.
+        pcb = self._PCB_GR_LINE[:-1] + extra + ")"
+        dims = extract_board_dimensions(pcb)
+        assert dims is not None
+        assert dims[0] == pytest.approx(65.0)
+        assert dims[1] == pytest.approx(56.0)

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -523,6 +523,112 @@ class TestPlaceAllComponentsBoardAware:
         assert calls[6][1] == pytest.approx(5.0)  # x wraps back
         assert calls[6][2] == pytest.approx(5.0 + 15.0)  # y increments
 
+    def _make_workflow_n(self, tmp_path: Path, board_w, board_h, n: int):
+        """Helper to create a workflow with ``n`` resistor components."""
+        sch_path = tmp_path / "test.kicad_sch"
+        sch_path.write_text("(kicad_sch (version 20231120))")
+
+        mock_netlist = MagicMock(spec=Netlist)
+        mock_netlist.components = [
+            NetlistComponent(
+                reference=f"R{i}",
+                value="10k",
+                footprint="Resistor_SMD:R_0805_2012Metric",
+                lib_id="Device:R",
+            )
+            for i in range(1, n + 1)
+        ]
+        mock_netlist.nets = []
+        mock_netlist.get_component = lambda ref: next(
+            (c for c in mock_netlist.components if c.reference == ref), None
+        )
+
+        workflow = PCBFromSchematic.__new__(PCBFromSchematic)
+        workflow.schematic_path = sch_path
+        workflow._netlist_path = tmp_path / "test.kicad_net"
+        workflow._netlist = mock_netlist
+        workflow._pcb = None
+        workflow._components = None
+
+        workflow.create_pcb(width=board_w, height=board_h)
+        return workflow
+
+    def test_grid_stays_within_board_height(self, tmp_path: Path):
+        """Regression for #3805: parts must not overflow past board height.
+
+        63 parts on a 65x56 board at the default 15mm spacing previously
+        reached y ~= 303mm (5x the board height) because rows were unbounded.
+        """
+        workflow = self._make_workflow_n(tmp_path, board_w=65, board_h=56, n=63)
+
+        calls: list[tuple[str, float, float]] = []
+        original_add = workflow.add_component
+
+        def capture_add(ref, x, y, **kwargs):
+            calls.append((ref, x, y))
+            return original_add(ref, x, y, **kwargs)
+
+        with patch.object(PCB, "add_footprint", return_value=MagicMock()):
+            with patch.object(workflow, "add_component", side_effect=capture_add):
+                result = workflow.place_all_components(spacing=15.0)
+
+        assert result.success_count == 63
+        # Every placed footprint origin must stay inside the board outline.
+        for ref, x, y in calls:
+            assert 0 <= x <= 65, f"{ref} x={x} outside board width 65"
+            assert 0 <= y <= 56, f"{ref} y={y} outside board height 56"
+
+    def test_overcrowded_board_warns_and_shrinks(self, tmp_path: Path):
+        """When parts cannot fit at the requested spacing, a warning is recorded."""
+        workflow = self._make_workflow_n(tmp_path, board_w=65, board_h=56, n=63)
+
+        with patch.object(PCB, "add_footprint", return_value=MagicMock()):
+            result = workflow.place_all_components(spacing=15.0)
+
+        # 63 parts at 15mm cannot fit in 65x56 -> spacing auto-shrunk + warned.
+        assert result.warnings, "expected a placement warning for overcrowded board"
+        assert any("spacing" in w for w in result.warnings)
+
+    def test_explicit_columns_not_height_bounded(self, tmp_path: Path):
+        """Explicit columns preserves prior (unbounded) behavior for callers."""
+        workflow = self._make_workflow_n(tmp_path, board_w=65, board_h=56, n=20)
+
+        calls: list[tuple[str, float, float]] = []
+        original_add = workflow.add_component
+
+        def capture_add(ref, x, y, **kwargs):
+            calls.append((ref, x, y))
+            return original_add(ref, x, y, **kwargs)
+
+        with patch.object(PCB, "add_footprint", return_value=MagicMock()):
+            with patch.object(workflow, "add_component", side_effect=capture_add):
+                result = workflow.place_all_components(spacing=15.0, columns=2)
+
+        assert result.success_count == 20
+        # With 2 explicit columns, 20 parts make 10 rows: y is NOT clamped,
+        # confirming explicit-columns behavior is unchanged.
+        max_y = max(y for _ref, _x, y in calls)
+        assert max_y == pytest.approx(3.0 + 9 * 15.0)
+
+    def test_single_part_fits(self, tmp_path: Path):
+        """A single part is placed at the start margin."""
+        workflow = self._make_workflow_n(tmp_path, board_w=65, board_h=56, n=1)
+
+        calls: list[tuple[str, float, float]] = []
+        original_add = workflow.add_component
+
+        def capture_add(ref, x, y, **kwargs):
+            calls.append((ref, x, y))
+            return original_add(ref, x, y, **kwargs)
+
+        with patch.object(PCB, "add_footprint", return_value=MagicMock()):
+            with patch.object(workflow, "add_component", side_effect=capture_add):
+                result = workflow.place_all_components(spacing=15.0)
+
+        assert result.success_count == 1
+        assert calls[0][1] == pytest.approx(3.0)
+        assert calls[0][2] == pytest.approx(3.0)
+
 
 class TestWorkflowExports:
     """Tests for workflow module exports."""


### PR DESCRIPTION
## Summary

`kct create-pcb` previously produced a `.kicad_pcb` that needed manual repair before opening in KiCad 10.0.3 and before downstream placement/route tooling could use it. This fixes the three defects confirmed by the Curator: grid placement overflowing small boards, a `gr_rect` board outline, and a future format-version stamp.

## Changes

- **Grid placement bounded by board height** (`workflow/__init__.py`): `place_all_components` now uses `board_h` in addition to `board_w`. When auto-sizing the grid it widens the column count so rows stay inside the outline, and when parts cannot fit at the requested spacing it auto-shrinks the spacing and records a warning (instead of letting `y` run ~5x past the bottom edge). Grid slots are only consumed by placeable components, so footprint-less components no longer push the grid down. Explicit `columns`/`start_x`/`start_y` preserve prior behavior. A new `PlacementResult.warnings` list surfaces through the CLI.
- **gr_line board outline** (`schema/pcb.py`): `_build_board_outline_sexp` (and `replace_outline`) now emit four `gr_line` Edge.Cuts segments forming a closed rectangle instead of one `gr_rect`. `board_size` and board-origin detection still resolve via their existing gr_line fallbacks.
- **Shared format-version constant** (`core/version.py`): introduced `KICAD_BOARD_FORMAT_VERSION = 20241229` and wired it into all four writer sites (`schema/pcb.py`, `footprints/__init__.py`, `library/footprint.py`, `pcb/exporter.py`), replacing the future `20260206` stamp KiCad 10.0.3 rejected and preventing future drift.
- **gr_line-aware extractors** (`router/io.py`): `extract_board_dimensions` / `extract_board_origin` fall back to the Edge.Cuts gr_line bounding box so the auto-pcb-size loop keeps working after the outline change.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| All footprints inside outline (no Y overflow); warn when parts can't fit | done | New `test_grid_stays_within_board_height` / `test_overcrowded_board_warns_and_shrinks`; manual `kct create-pcb ... --width 65 --height 56` placed all 25 footprints inside the outline (verified board-relative coords) and emitted a spacing warning |
| Outline is four gr_line Edge.Cuts segments, no gr_rect; board_size/origin still correct | done | `test_create_outline_is_four_gr_lines`, `test_create_board_size_from_gr_line_outline`, `test_create_board_origin_from_gr_line_outline`, `test_create_4layer_outline_is_gr_line` |
| Board + generated footprints stamp 20241229; no 20260206 from our writers | done | `test_create_stamps_kicad10_format_version`, updated footprint version tests; board header confirmed `(version 20241229)` (system-library footprints retain their own KiCad-shipped stamp, which is out of scope to rewrite) |
| Output loads in KiCad 10.0.3 / passes kicad-cli parse | done | `test_gr_line_outline_and_version_roundtrip` (kicad-cli load); manual `kicad-cli pcb drc` on create-pcb output exited 0 |

## Test Plan

- `pytest tests/test_workflow.py tests/test_pcb.py tests/test_footprints.py tests/test_footprint_library.py tests/test_kicad_cli_roundtrip.py tests/test_pcb_edit_outline.py` — 338 passed
- `pytest tests/test_router_io.py tests/test_auto_pcb_size_integration.py` — green (regression from the outline change found and fixed)
- ruff check + format and mypy clean on all touched files (pre-existing mypy errors in pcb.py / router/io.py untouched)
- Manual: `kct create-pcb boards/05-bldc-motor-controller/output/bldc_controller.kicad_sch --width 65 --height 56` then `kicad-cli pcb drc` (exit 0)

Closes #3805