### PR TITLE
fix(optim): contain placement components within the real Edge.Cuts outline

### DIFF
--- a/src/kicad_tools/optim/geometry.py
+++ b/src/kicad_tools/optim/geometry.py
@@ -174,6 +174,35 @@ class Polygon:
             j = i
         return inside
 
+    def nearest_point_on_boundary(self, p: Vector2D) -> Vector2D:
+        """Return the closest point on the polygon boundary to ``p``.
+
+        Projects ``p`` onto each edge segment and returns the nearest
+        projection. Used to pull a component center that has escaped a
+        non-rectangular outline back to the polygon edge.
+        """
+        if not self.vertices:
+            return Vector2D(p.x, p.y)
+        if len(self.vertices) == 1:
+            return Vector2D(self.vertices[0].x, self.vertices[0].y)
+
+        best: Vector2D | None = None
+        best_dist_sq = float("inf")
+        for a, b in self.edges():
+            ab = b - a
+            ab_len_sq = ab.magnitude_squared()
+            if ab_len_sq < 1e-12:
+                proj = a
+            else:
+                t = (p - a).dot(ab) / ab_len_sq
+                t = max(0.0, min(1.0, t))
+                proj = a + ab * t
+            dist_sq = (p - proj).magnitude_squared()
+            if dist_sq < best_dist_sq:
+                best_dist_sq = dist_sq
+                best = proj
+        return best if best is not None else Vector2D(p.x, p.y)
+
     def translate(self, delta: Vector2D) -> Polygon:
         """Return translated polygon."""
         return Polygon(vertices=[v + delta for v in self.vertices])

--- a/src/kicad_tools/optim/placement.py
+++ b/src/kicad_tools/optim/placement.py
@@ -184,6 +184,7 @@ class PlacementOptimizer:
         edge_constraints: list[EdgeConstraint] | None = None,
         record_decisions: bool = False,
         perf_config: PerformanceConfig | None = None,
+        allow_estimated_outline: bool = False,
     ) -> PlacementOptimizer:
         """
         Create optimizer from a loaded PCB.
@@ -199,11 +200,28 @@ class PlacementOptimizer:
             edge_constraints: Manual list of edge constraints to apply
             record_decisions: If True, record placement decisions for later querying
             perf_config: Performance configuration for GPU acceleration
+            allow_estimated_outline: If True, fall back to estimating the board
+                outline from current component positions when the Edge.Cuts
+                outline cannot be parsed. This fallback is unsafe -- if any
+                footprints start off-board it inflates the "board" far beyond
+                the real Edge.Cuts and lets the optimizer scatter components
+                off-board (issue #3804). When False (the default) an
+                unparseable Edge.Cuts raises ``ValueError`` so the failure is
+                visible rather than silently producing a bogus boundary.
+
+        Raises:
+            ValueError: If the board outline cannot be parsed from Edge.Cuts
+                and ``allow_estimated_outline`` is False.
         """
         fixed_refs = set(fixed_refs or [])
 
-        # Try Shapely-based geometry first, fall back to legacy parsing
+        # Try Shapely-based geometry first, fall back to legacy parsing.
+        # Distinguish a genuine geometry parse failure (Edge.Cuts present but
+        # cannot be closed into a polygon -- a ValueError) from Shapely being
+        # unavailable (ImportError), so that a real parse failure is surfaced
+        # rather than silently degrading to an estimated outline (#3804).
         board = None
+        shapely_parse_error: Exception | None = None
         try:
             from kicad_tools.pcb.board_geometry import BoardGeometry, has_shapely
 
@@ -212,8 +230,15 @@ class PlacementOptimizer:
                     board_geom = BoardGeometry.from_pcb(pcb)
                     board = board_geom.to_optim_polygon()
                     logger.debug("Using Shapely-based board geometry engine")
-                except (ValueError, Exception) as exc:
-                    logger.debug("Shapely geometry failed (%s), falling back", exc)
+                except ValueError as exc:
+                    # Edge.Cuts could not be closed into a polygon. Remember
+                    # the real error; we may still succeed via the legacy
+                    # parser below, but if not we re-raise this.
+                    shapely_parse_error = exc
+                    logger.debug("Shapely geometry parse failed (%s), trying legacy parser", exc)
+                except Exception as exc:  # pragma: no cover - defensive
+                    shapely_parse_error = exc
+                    logger.debug("Shapely geometry failed (%s), trying legacy parser", exc)
         except ImportError:
             pass
 
@@ -221,13 +246,30 @@ class PlacementOptimizer:
             board = cls._extract_board_outline(pcb)
 
         if board is None:
-            # Fall back to estimating from component positions.
-            # This typically means Edge.Cuts uses geometry we cannot parse
-            # (e.g. gr_poly, fp_line) -- boundary enforcement will be weaker.
+            # Neither the Shapely engine nor the legacy parser could recover a
+            # closed outline from Edge.Cuts. Estimating a board from component
+            # positions is the mechanism that lets parts spread far off-board
+            # (#3804), so it is now opt-in and otherwise fails loudly.
+            detail = f" ({shapely_parse_error})" if shapely_parse_error else ""
+            if not allow_estimated_outline:
+                raise ValueError(
+                    "Could not extract a closed board outline from Edge.Cuts"
+                    f"{detail}. The placement optimizer requires a valid board "
+                    "boundary to contain components. Add a closed Edge.Cuts "
+                    "outline to the board, or pass allow_estimated_outline=True "
+                    "to fall back to an outline estimated from component "
+                    "positions (which may let components escape the real board)."
+                )
+
+            # Opt-in fallback: estimate from component positions. This is
+            # unsafe when footprints start off-board -- it inflates the
+            # boundary -- so it is gated behind allow_estimated_outline.
             logger.warning(
-                "Could not extract board outline from Edge.Cuts; "
-                "falling back to estimated outline from component positions. "
-                "Boundary enforcement may be degraded."
+                "Could not extract board outline from Edge.Cuts%s; "
+                "falling back to estimated outline from component positions "
+                "(allow_estimated_outline=True). Boundary enforcement may be "
+                "degraded and components may escape the real board.",
+                detail,
             )
             min_x = min_y = float("inf")
             max_x = max_y = float("-inf")
@@ -1922,13 +1964,36 @@ class PlacementOptimizer:
             # footprint stays within the board, not just the center.
             half_w = comp.width / 2 + self.config.boundary_margin
             half_h = comp.height / 2 + self.config.boundary_margin
-            comp.x = max(min_x + half_w, min(max_x - half_w, comp.x))
-            comp.y = max(min_y + half_h, min(max_y - half_h, comp.y))
+            # Guard against an inverted clamp box when the margin (plus half the
+            # component) exceeds half the board: collapse to the box center so
+            # min(...) does not exceed max(...) and flip the bounds (#3804).
+            lo_x, hi_x = min_x + half_w, max_x - half_w
+            lo_y, hi_y = min_y + half_h, max_y - half_h
+            if lo_x > hi_x:
+                lo_x = hi_x = (min_x + max_x) / 2
+            if lo_y > hi_y:
+                lo_y = hi_y = (min_y + max_y) / 2
+            comp.x = max(lo_x, min(hi_x, comp.x))
+            comp.y = max(lo_y, min(hi_y, comp.y))
 
             # If component was clamped, kill its outward velocity
-            if comp.x <= min_x + half_w or comp.x >= max_x - half_w:
+            if comp.x <= lo_x or comp.x >= hi_x:
                 comp.vx = 0.0
-            if comp.y <= min_y + half_h or comp.y >= max_y - half_h:
+            if comp.y <= lo_y or comp.y >= hi_y:
+                comp.vy = 0.0
+
+            # For non-rectangular outlines the AABB clamp above is necessary but
+            # not sufficient: a center can sit inside the bounding box yet
+            # outside a concave/cut-out polygon. Project any such center back to
+            # the nearest point on the outline boundary (#3804). The rectangular
+            # common case is already fully contained by the AABB clamp, so this
+            # only fires on genuinely non-rectangular boards.
+            if len(self.board_outline.vertices) > 4 and not self.board_outline.contains_point(
+                Vector2D(comp.x, comp.y)
+            ):
+                nearest = self.board_outline.nearest_point_on_boundary(Vector2D(comp.x, comp.y))
+                comp.x, comp.y = nearest.x, nearest.y
+                comp.vx = 0.0
                 comp.vy = 0.0
 
             # Update pin positions based on new position and rotation
@@ -2189,6 +2254,62 @@ class PlacementOptimizer:
             total += math.sqrt(dx * dx + dy * dy)
 
         return total
+
+    def out_of_bounds_components(self, margin: float | None = None) -> list[str]:
+        """Return refs of non-fixed components whose center is outside the board.
+
+        A component center is considered out of bounds if it lies outside the
+        board outline's axis-aligned bounding box inset by ``margin`` (or, for
+        non-rectangular outlines with more than four vertices, outside the
+        polygon itself). Fixed components are excluded since they are intended
+        to be pinned by the caller and may legitimately sit on/near the edge.
+
+        This is the end-of-run containment check for issue #3804: a healthy run
+        returns an empty list; a non-empty list signals components escaped the
+        Edge.Cuts outline.
+
+        Args:
+            margin: Boundary margin to apply. Defaults to ``config.boundary_margin``.
+
+        Returns:
+            Sorted list of reference designators that are out of bounds.
+        """
+        if margin is None:
+            margin = self.config.boundary_margin
+
+        verts = self.board_outline.vertices
+        if not verts:
+            return []
+
+        min_x = min(v.x for v in verts)
+        max_x = max(v.x for v in verts)
+        min_y = min(v.y for v in verts)
+        max_y = max(v.y for v in verts)
+
+        # Small epsilon so a component clamped exactly to the inset bound is
+        # not flagged due to floating-point round-off.
+        eps = 1e-6
+        violators: list[str] = []
+        for comp in self.components:
+            if comp.fixed:
+                continue
+            lo_x, hi_x = min_x + margin, max_x - margin
+            lo_y, hi_y = min_y + margin, max_y - margin
+            if lo_x > hi_x:
+                lo_x = hi_x = (min_x + max_x) / 2
+            if lo_y > hi_y:
+                lo_y = hi_y = (min_y + max_y) / 2
+            outside = (
+                comp.x < lo_x - eps
+                or comp.x > hi_x + eps
+                or comp.y < lo_y - eps
+                or comp.y > hi_y + eps
+            )
+            if not outside and len(verts) > 4:
+                outside = not self.board_outline.contains_point(Vector2D(comp.x, comp.y))
+            if outside:
+                violators.append(comp.ref)
+        return sorted(violators)
 
     def report(self) -> str:
         """Generate a text report of current placement."""

--- a/src/kicad_tools/optim/placement.py
+++ b/src/kicad_tools/optim/placement.py
@@ -229,6 +229,21 @@ class PlacementOptimizer:
                 try:
                     board_geom = BoardGeometry.from_pcb(pcb)
                     board = board_geom.to_optim_polygon()
+                    # BoardGeometry.from_pcb subtracts pcb.board_origin from
+                    # every Edge.Cuts vertex, so to_optim_polygon() returns an
+                    # origin-relative outline. The optimizer, however, adds
+                    # components at their raw *absolute* positions (and
+                    # write_to_pcb persists absolute coordinates). Translate the
+                    # outline back into the absolute board frame so the clamp,
+                    # the polygon projection, and out_of_bounds_components() all
+                    # operate in the same coordinate frame the components live
+                    # in. Without this, containment "succeeds" against a board
+                    # at (0,0) while the parts sit ~origin mm away (#3804).
+                    from kicad_tools.optim.geometry import Vector2D
+
+                    ox, oy = pcb.board_origin
+                    if ox or oy:
+                        board = board.translate(Vector2D(ox, oy))
                     logger.debug("Using Shapely-based board geometry engine")
                 except ValueError as exc:
                     # Edge.Cuts could not be closed into a polygon. Remember

--- a/src/kicad_tools/optim/workflow.py
+++ b/src/kicad_tools/optim/workflow.py
@@ -100,6 +100,11 @@ class OptimizationResult:
     output_path: Path | None = None
     message: str = ""
 
+    # Board-containment check (issue #3804). After a physics-based run, lists
+    # the refs of any non-fixed component whose center escaped the Edge.Cuts
+    # outline (minus boundary margin). Empty on a healthy run.
+    out_of_bounds_components: list[str] = field(default_factory=list)
+
     # Routing-specific fields (used by PlaceRouteOptimizer)
     pcb_path: Path | None = None
     routes: list[Route] | None = None
@@ -130,6 +135,8 @@ class OptimizationResult:
             parts.append(f", iterations={self.iterations}")
         if self.routes:
             parts.append(f", routes={len(self.routes)}")
+        if self.out_of_bounds_components:
+            parts.append(f", out_of_bounds={len(self.out_of_bounds_components)}")
         if self.message:
             parts.append(f", message={self.message!r}")
         parts.append(")")
@@ -146,6 +153,8 @@ class OptimizationResult:
             "energy": round(self.energy, 4),
             "components_updated": self.components_updated,
             "constraint_violations": self.constraint_violations,
+            "out_of_bounds_components": self.out_of_bounds_components,
+            "out_of_bounds_count": len(self.out_of_bounds_components),
             "output_path": str(self.output_path) if self.output_path else None,
             "message": self.message,
         }
@@ -345,6 +354,17 @@ class OptimizationWorkflow:
         if self.constraints and hasattr(optimizer, "validate_constraints"):
             violations = optimizer.validate_constraints() or []
 
+        # End-of-run containment check (#3804): flag any non-fixed component
+        # that escaped the board outline.
+        out_of_bounds = optimizer.out_of_bounds_components()
+
+        message = "Optimization completed successfully"
+        if out_of_bounds:
+            message += (
+                f"; WARNING: {len(out_of_bounds)} component(s) outside board "
+                f"outline: {', '.join(out_of_bounds)}"
+            )
+
         return OptimizationResult(
             success=True,
             strategy="force-directed",
@@ -353,7 +373,8 @@ class OptimizationWorkflow:
             wire_length_mm=optimizer.total_wire_length(),
             energy=optimizer.compute_energy(),
             constraint_violations=violations,
-            message="Optimization completed successfully",
+            out_of_bounds_components=out_of_bounds,
+            message=message,
         )
 
     def _build_routing_evaluator(self) -> Any | None:
@@ -528,6 +549,20 @@ class OptimizationWorkflow:
 
         self._optimizer = physics_optimizer
 
+        # End-of-run containment check (#3804). The hybrid strategy reuses the
+        # PlacementOptimizer physics layer for its refinement phase, so the
+        # same check applies.
+        out_of_bounds: list[str] = []
+        if hasattr(physics_optimizer, "out_of_bounds_components"):
+            out_of_bounds = physics_optimizer.out_of_bounds_components()
+
+        message = "Hybrid optimization completed successfully"
+        if out_of_bounds:
+            message += (
+                f"; WARNING: {len(out_of_bounds)} component(s) outside board "
+                f"outline: {', '.join(out_of_bounds)}"
+            )
+
         return OptimizationResult(
             success=True,
             strategy="hybrid",
@@ -535,7 +570,8 @@ class OptimizationWorkflow:
             iterations=self.config.generations + self.config.iterations,
             wire_length_mm=physics_optimizer.total_wire_length(),
             energy=physics_optimizer.compute_energy(),
-            message="Hybrid optimization completed successfully",
+            out_of_bounds_components=out_of_bounds,
+            message=message,
         )
 
     def write_to_pcb(self) -> int:

--- a/tests/test_placement_containment.py
+++ b/tests/test_placement_containment.py
@@ -1,0 +1,353 @@
+"""Regression tests for board-outline containment in placement optimization.
+
+Issue #3804: ``kct placement optimize`` let components escape the Edge.Cuts
+because (1) ``PlacementOptimizer.from_pcb`` silently swallowed the real
+Edge.Cuts parse error and estimated a (wrong) outline from current component
+positions, and (2) the only hard containment was an AABB clamp keyed off that
+(possibly wrong) outline.
+
+These tests build PCBs with *known small* Edge.Cuts outlines, seed footprints
+off-board, run the optimizer, and assert that every non-fixed component center
+ends up inside the real outline (minus boundary margin).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.optim.geometry import Polygon, Vector2D
+from kicad_tools.optim.workflow import OptimizationWorkflow, WorkflowConfig
+from kicad_tools.schema.pcb import PCB
+
+# A 40 x 30 mm board outline anchored at (100, 100). Deliberately small so that
+# components seeded far away (e.g. at ~250, 200) are unambiguously off-board and
+# must be pulled back inside.
+BOARD_MIN_X = 100.0
+BOARD_MIN_Y = 100.0
+BOARD_W = 40.0
+BOARD_H = 30.0
+BOARD_MAX_X = BOARD_MIN_X + BOARD_W
+BOARD_MAX_Y = BOARD_MIN_Y + BOARD_H
+
+
+_HEADER = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (37 "F.SilkS" user "F.Silkscreen")
+    (44 "Edge.Cuts" user)
+    (49 "F.Fab" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+"""
+
+_GR_RECT_OUTLINE = f"""  (gr_rect (start {BOARD_MIN_X} {BOARD_MIN_Y}) (end {BOARD_MAX_X} {BOARD_MAX_Y})
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+"""
+
+# Same rectangle expressed as four chained gr_line segments (the alternate
+# outline representation the reporter also tried).
+_GR_LINE_OUTLINE = f"""  (gr_line (start {BOARD_MIN_X} {BOARD_MIN_Y}) (end {BOARD_MAX_X} {BOARD_MIN_Y})
+    (stroke (width 0.1) (type default)) (layer "Edge.Cuts"))
+  (gr_line (start {BOARD_MAX_X} {BOARD_MIN_Y}) (end {BOARD_MAX_X} {BOARD_MAX_Y})
+    (stroke (width 0.1) (type default)) (layer "Edge.Cuts"))
+  (gr_line (start {BOARD_MAX_X} {BOARD_MAX_Y}) (end {BOARD_MIN_X} {BOARD_MAX_Y})
+    (stroke (width 0.1) (type default)) (layer "Edge.Cuts"))
+  (gr_line (start {BOARD_MIN_X} {BOARD_MAX_Y}) (end {BOARD_MIN_X} {BOARD_MIN_Y})
+    (stroke (width 0.1) (type default)) (layer "Edge.Cuts"))
+"""
+
+
+def _footprint(ref: str, x: float, y: float, net1: int, net2: int, uuid_n: int) -> str:
+    """A small two-pad resistor footprint at (x, y) on two nets."""
+    return f"""  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000{uuid_n:02d}")
+    (at {x} {y})
+    (property "Reference" "{ref}" (at 0 -1.5 0) (layer "F.SilkS")
+      (effects (font (size 1.0 1.0) (thickness 0.15)))
+      (uuid "00000000-0000-0000-0000-0000000001{uuid_n:02d}"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab")
+      (uuid "00000000-0000-0000-0000-0000000002{uuid_n:02d}"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net {net1} "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net {net2} "+3.3V"))
+  )
+"""
+
+
+def _build_pcb_text(outline: str, *, off_board: bool) -> str:
+    """Assemble a .kicad_pcb with the given outline and several footprints.
+
+    When ``off_board`` is True several footprints are seeded well outside the
+    Edge.Cuts to exercise the containment fix (and to ensure the off-board
+    seeds are *not* used to inflate the outline estimate).
+    """
+    if off_board:
+        seeds = [
+            ("R1", 250.0, 200.0),
+            ("R2", 260.0, 210.0),
+            ("R3", 50.0, 50.0),
+            ("R4", 300.0, 105.0),
+            ("R5", 115.0, 115.0),  # one in-board for good measure
+        ]
+    else:
+        seeds = [
+            ("R1", 110.0, 110.0),
+            ("R2", 120.0, 115.0),
+            ("R3", 130.0, 120.0),
+            ("R4", 115.0, 125.0),
+            ("R5", 125.0, 110.0),
+        ]
+    # Alternate the spring nets so the optimizer has connectivity to act on.
+    fps = []
+    for i, (ref, x, y) in enumerate(seeds):
+        net1 = 1 if i % 2 == 0 else 2
+        net2 = 2 if i % 2 == 0 else 1
+        fps.append(_footprint(ref, x, y, net1, net2, uuid_n=10 + i))
+    return _HEADER + outline + "".join(fps) + ")\n"
+
+
+def _write_pcb(tmp_path: Path, text: str, name: str) -> PCB:
+    pcb_file = tmp_path / name
+    pcb_file.write_text(text)
+    return PCB.load(str(pcb_file))
+
+
+def _assert_all_in_bounds(pcb: PCB, margin: float) -> None:
+    """Assert every footprint center is within the real Edge.Cuts (minus margin)."""
+    for fp in pcb.footprints:
+        x, y = fp.position
+        assert BOARD_MIN_X + margin - 1e-6 <= x <= BOARD_MAX_X - margin + 1e-6, (
+            f"{fp.reference} x={x} escaped board [{BOARD_MIN_X + margin}, {BOARD_MAX_X - margin}]"
+        )
+        assert BOARD_MIN_Y + margin - 1e-6 <= y <= BOARD_MAX_Y - margin + 1e-6, (
+            f"{fp.reference} y={y} escaped board [{BOARD_MIN_Y + margin}, {BOARD_MAX_Y - margin}]"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Containment after optimize (the core regression)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "outline", [_GR_RECT_OUTLINE, _GR_LINE_OUTLINE], ids=["gr_rect", "gr_line"]
+)
+def test_force_directed_keeps_components_in_bounds(tmp_path: Path, outline: str) -> None:
+    """Force-directed optimize must keep all centers inside a small outline."""
+    pcb = _write_pcb(tmp_path, _build_pcb_text(outline, off_board=True), "board.kicad_pcb")
+
+    workflow = OptimizationWorkflow(pcb, WorkflowConfig(strategy="force-directed", iterations=400))
+    result = workflow.run()
+    workflow.write_to_pcb()
+
+    assert result.success
+    # End-of-run containment check reports zero escapes.
+    assert result.out_of_bounds_components == []
+    # And the actual written-back positions are inside the real outline.
+    margin = workflow.optimizer.config.boundary_margin
+    _assert_all_in_bounds(pcb, margin)
+
+
+def test_hybrid_keeps_components_in_bounds(tmp_path: Path) -> None:
+    """Hybrid (evolutionary + physics) optimize must also contain components."""
+    pcb = _write_pcb(tmp_path, _build_pcb_text(_GR_RECT_OUTLINE, off_board=True), "board.kicad_pcb")
+
+    workflow = OptimizationWorkflow(
+        pcb,
+        WorkflowConfig(strategy="hybrid", iterations=200, generations=10, population=12),
+    )
+    result = workflow.run()
+    workflow.write_to_pcb()
+
+    assert result.success
+    assert result.out_of_bounds_components == []
+    margin = workflow.optimizer.config.boundary_margin
+    _assert_all_in_bounds(pcb, margin)
+
+
+def test_offboard_seed_does_not_inflate_outline(tmp_path: Path) -> None:
+    """A footprint seeded far off-board is pulled in, not used to grow the board.
+
+    Regression for the smoking-gun fallback: the optimizer must resolve the real
+    Edge.Cuts (40x30) rather than an outline estimated from the off-board seeds
+    (which would span >150mm and "contain" the escapees).
+    """
+    pcb = _write_pcb(tmp_path, _build_pcb_text(_GR_RECT_OUTLINE, off_board=True), "board.kicad_pcb")
+    workflow = OptimizationWorkflow(pcb, WorkflowConfig(strategy="force-directed", iterations=400))
+    workflow.run()
+
+    # The resolved board outline must be the real 40x30 rect, not an inflated
+    # box derived from the off-board seeds.
+    verts = workflow.optimizer.board_outline.vertices
+    width = max(v.x for v in verts) - min(v.x for v in verts)
+    height = max(v.y for v in verts) - min(v.y for v in verts)
+    assert width == pytest.approx(BOARD_W, abs=1e-6)
+    assert height == pytest.approx(BOARD_H, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# --fixed pinning
+# ---------------------------------------------------------------------------
+
+
+def test_fixed_refs_are_pinned(tmp_path: Path) -> None:
+    """Components passed via fixed_refs must not move (within float tolerance)."""
+    pcb = _write_pcb(
+        tmp_path, _build_pcb_text(_GR_RECT_OUTLINE, off_board=False), "board.kicad_pcb"
+    )
+
+    # Record R1's starting position before optimize.
+    r1_before = next(fp.position for fp in pcb.footprints if fp.reference == "R1")
+
+    workflow = OptimizationWorkflow(
+        pcb,
+        WorkflowConfig(strategy="force-directed", iterations=300, fixed_refs=["R1"]),
+    )
+    workflow.run()
+
+    comp = workflow.optimizer._component_map["R1"]
+    assert comp.fixed is True
+    assert comp.x == pytest.approx(r1_before[0], abs=1e-6)
+    assert comp.y == pytest.approx(r1_before[1], abs=1e-6)
+
+
+def test_connector_prefix_autofixed_and_others_contained(tmp_path: Path) -> None:
+    """A ``J``-prefixed ref is auto-fixed; non-fixed parts still contain."""
+    # Build a board with one connector (J1) seeded in-board and resistors
+    # seeded off-board.
+    text = _HEADER + _GR_RECT_OUTLINE
+    text += _footprint("J1", 110.0, 110.0, 1, 2, uuid_n=10)
+    text += _footprint("R2", 250.0, 200.0, 2, 1, uuid_n=11)
+    text += _footprint("R3", 300.0, 150.0, 1, 2, uuid_n=12)
+    text += ")\n"
+    pcb = _write_pcb(tmp_path, text, "board.kicad_pcb")
+
+    j1_before = next(fp.position for fp in pcb.footprints if fp.reference == "J1")
+
+    workflow = OptimizationWorkflow(pcb, WorkflowConfig(strategy="force-directed", iterations=400))
+    result = workflow.run()
+    workflow.write_to_pcb()
+
+    # J1 auto-fixed by the J/H/MH prefix rule -> unchanged.
+    j1 = workflow.optimizer._component_map["J1"]
+    assert j1.fixed is True
+    assert j1.x == pytest.approx(j1_before[0], abs=1e-6)
+    assert j1.y == pytest.approx(j1_before[1], abs=1e-6)
+
+    # Non-fixed resistors contained.
+    assert result.out_of_bounds_components == []
+
+
+# ---------------------------------------------------------------------------
+# Fail-loud outline resolution
+# ---------------------------------------------------------------------------
+
+
+def test_unparseable_outline_raises_by_default(tmp_path: Path) -> None:
+    """When Edge.Cuts cannot be closed, from_pcb raises rather than estimating."""
+    from kicad_tools.optim.placement import PlacementOptimizer
+
+    # An Edge.Cuts board with a single dangling segment cannot form a closed
+    # polygon. The optimizer must refuse to estimate from component positions.
+    text = _HEADER
+    text += """  (gr_line (start 100 100) (end 140 100)
+    (stroke (width 0.1) (type default)) (layer "Edge.Cuts"))
+"""
+    text += _footprint("R1", 250.0, 200.0, 1, 2, uuid_n=10)
+    text += ")\n"
+    pcb = _write_pcb(tmp_path, text, "board.kicad_pcb")
+
+    with pytest.raises(ValueError, match="closed board outline"):
+        PlacementOptimizer.from_pcb(pcb)
+
+
+def test_unparseable_outline_opt_in_estimates_with_warning(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """With allow_estimated_outline=True the fallback is used but warns loudly."""
+    from kicad_tools.optim.placement import PlacementOptimizer
+
+    text = _HEADER
+    text += """  (gr_line (start 100 100) (end 140 100)
+    (stroke (width 0.1) (type default)) (layer "Edge.Cuts"))
+"""
+    text += _footprint("R1", 110.0, 110.0, 1, 2, uuid_n=10)
+    text += ")\n"
+    pcb = _write_pcb(tmp_path, text, "board.kicad_pcb")
+
+    with caplog.at_level(logging.WARNING):
+        opt = PlacementOptimizer.from_pcb(pcb, allow_estimated_outline=True)
+
+    assert opt.board_outline.vertices  # an estimated outline exists
+    assert any("estimated outline" in rec.getMessage() for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Boundary-margin guard (margin larger than half the board)
+# ---------------------------------------------------------------------------
+
+
+def test_oversized_margin_does_not_invert_clamp(tmp_path: Path) -> None:
+    """A boundary margin larger than half the board collapses to center, not NaN."""
+    pcb = _write_pcb(tmp_path, _build_pcb_text(_GR_RECT_OUTLINE, off_board=True), "board.kicad_pcb")
+
+    # Margin 25mm > half of 30mm height -> would invert min/max bounds without
+    # the guard. Components should collapse toward the board center, not fly off
+    # to NaN / inverted positions.
+    workflow = OptimizationWorkflow(
+        pcb,
+        WorkflowConfig(strategy="force-directed", iterations=200, boundary_margin=25.0),
+    )
+    workflow.run()
+
+    cx = (BOARD_MIN_X + BOARD_MAX_X) / 2
+    cy = (BOARD_MIN_Y + BOARD_MAX_Y) / 2
+    for comp in workflow.optimizer.components:
+        if comp.fixed:
+            continue
+        # Center of the (collapsed) clamp box in x; y collapses too since
+        # 25 > 15. Positions must be finite and near the board center.
+        assert abs(comp.x - cx) < 1.0
+        assert abs(comp.y - cy) < 1.0
+
+
+# ---------------------------------------------------------------------------
+# Polygon geometry helper (non-rectangular projection)
+# ---------------------------------------------------------------------------
+
+
+def test_nearest_point_on_boundary_projects_outside_point() -> None:
+    """nearest_point_on_boundary projects an external point onto the edge."""
+    square = Polygon.rectangle(0.0, 0.0, 10.0, 10.0)  # corners at +/-5
+    nearest = square.nearest_point_on_boundary(Vector2D(20.0, 0.0))
+    assert nearest.x == pytest.approx(5.0)
+    assert nearest.y == pytest.approx(0.0)
+
+
+def test_out_of_bounds_components_flags_escapee() -> None:
+    """out_of_bounds_components reports a component placed outside the outline."""
+    from kicad_tools.optim.components import Component
+    from kicad_tools.optim.placement import PlacementOptimizer
+
+    board = Polygon.rectangle(0.0, 0.0, 20.0, 20.0)  # +/-10
+    opt = PlacementOptimizer(board)
+    opt.add_component(Component(ref="R1", x=0.0, y=0.0, width=1.0, height=1.0))
+    opt.add_component(Component(ref="R2", x=100.0, y=100.0, width=1.0, height=1.0))
+    assert opt.out_of_bounds_components(margin=0.0) == ["R2"]


### PR DESCRIPTION
## Summary

`kct placement optimize` let components escape the board Edge.Cuts and spread far off-board. Root cause (per the curator's analysis): `PlacementOptimizer.from_pcb` swallowed the genuine `ValueError` raised when Edge.Cuts could not be closed into a polygon (`except (ValueError, Exception)`), then silently estimated a board outline from current component positions. When footprints started off-board that inflated the "board" far beyond the real Edge.Cuts, and the only hard containment -- an AABB clamp keyed off `board_outline.vertices` -- clamped to the wrong box, letting parts spread ~120mm off-board.

## Changes

- **Fail-loud outline resolution** (`optim/placement.py:from_pcb`): distinguish a real Shapely parse failure from Shapely being unavailable. When neither the Shapely engine nor the legacy parser can recover a closed outline, raise a clear `ValueError` instead of estimating from component positions. The estimate is now opt-in via `allow_estimated_outline=True` and emits a loud warning when used.
- **True-polygon containment + margin guard** (`step()`): guard against an inverted clamp box when `boundary_margin` exceeds half the board (collapse to center, no NaN/flip), and project any center that escapes a non-rectangular outline back onto the polygon boundary.
- **Geometry helper**: add `Polygon.nearest_point_on_boundary` for that projection.
- **End-of-run containment check**: add `PlacementOptimizer.out_of_bounds_components()`; surface the count and refs in `OptimizationResult` (force-directed and hybrid), its `to_dict()` (`out_of_bounds_count`) and `__str__`.
- **Tests**: new `tests/test_placement_containment.py` (11 tests).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| gr_rect rectangular board: all non-fixed centers within margin-inset bounds | done | `test_force_directed_keeps_components_in_bounds[gr_rect]` |
| gr_line (chained-segment) rectangular outline: same | done | `test_force_directed_keeps_components_in_bounds[gr_line]` |
| `--strategy hybrid`: same | done | `test_hybrid_keeps_components_in_bounds` |
| Unparseable Edge.Cuts emits visible error / does not silently estimate | done | `test_unparseable_outline_raises_by_default`; opt-in path warns in `test_unparseable_outline_opt_in_estimates_with_warning` |
| `--fixed` provably pins refs (x,y unchanged) | done | `test_fixed_refs_are_pinned`; auto-fixed `J` prefix in `test_connector_prefix_autofixed_and_others_contained` |
| `OptimizationResult` includes out-of-bounds count (0 on healthy run) | done | `out_of_bounds_components` field + `to_dict` `out_of_bounds_count`; asserted `== []` in containment tests |
| Off-board seed pulled in, not used to inflate outline | done | `test_offboard_seed_does_not_inflate_outline` (resolved outline stays 40x30) |
| Oversized `--boundary-margin` does not invert clamp | done | `test_oversized_margin_does_not_invert_clamp` |

## Test Plan

- `uv run pytest tests/test_placement_containment.py` -> 11 passed.
- Regression: `uv run pytest tests/test_workflow.py tests/test_placement.py tests/test_placement_geometry.py tests/test_board_outline.py tests/test_placement_vector.py tests/test_pcb.py tests/test_placement_suggestions.py tests/test_bottom_up_placement.py tests/test_placement_session.py tests/test_placement_validation.py` -> all passed.
- `uv run ruff check .` clean; `uv run ruff format --check .` clean.
- mypy on the three touched source files: no new errors introduced (23 pre-existing -> 22 with this change).

Note: remaining failures in the broader `-k "placement or optim or workflow"` run are all environment-only (`matplotlib`/`shapely` not installed in this worktree) and unrelated to this change.

Closes #3804