### PR TITLE
feat(zones): add --bbox/--region island-pour flags to `zones add`

### DIFF
--- a/src/kicad_tools/cli/zones_cmd.py
+++ b/src/kicad_tools/cli/zones_cmd.py
@@ -13,6 +13,91 @@ import sys
 from pathlib import Path
 
 
+def parse_bbox(spec: str) -> list[tuple[float, float]]:
+    """Parse a ``MINX,MINY,MAXX,MAXY`` bbox string into a polygon.
+
+    Returns the four corner points of the rectangle in counter-clockwise
+    order, in sheet-absolute millimetres.
+
+    Args:
+        spec: Bounding-box specification, e.g. ``"10,10,40,30"``.
+
+    Returns:
+        List of four ``(x, y)`` corner tuples.
+
+    Raises:
+        ValueError: If the format is malformed (wrong arity, non-numeric,
+            or ``min >= max`` on either axis).
+    """
+    parts = [p.strip() for p in spec.split(",")]
+    if len(parts) != 4:
+        raise ValueError(
+            f"Invalid --bbox '{spec}': expected 4 comma-separated numbers "
+            "'MINX,MINY,MAXX,MAXY' (e.g. '10,10,40,30')"
+        )
+    try:
+        min_x, min_y, max_x, max_y = (float(p) for p in parts)
+    except ValueError as exc:
+        raise ValueError(
+            f"Invalid --bbox '{spec}': all values must be numeric (e.g. '10,10,40,30')"
+        ) from exc
+
+    if min_x >= max_x:
+        raise ValueError(
+            f"Invalid --bbox '{spec}': MINX ({min_x}) must be less than MAXX ({max_x})"
+        )
+    if min_y >= max_y:
+        raise ValueError(
+            f"Invalid --bbox '{spec}': MINY ({min_y}) must be less than MAXY ({max_y})"
+        )
+
+    return [
+        (min_x, min_y),
+        (max_x, min_y),
+        (max_x, max_y),
+        (min_x, max_y),
+    ]
+
+
+def parse_region(spec: str) -> list[tuple[float, float]]:
+    """Parse a ``X1,Y1;X2,Y2;...`` polygon string into a list of points.
+
+    Args:
+        spec: Polygon specification, e.g. ``"10,10;40,10;40,30;10,30"``.
+
+    Returns:
+        List of ``(x, y)`` tuples in sheet-absolute millimetres.
+
+    Raises:
+        ValueError: If the format is malformed (fewer than 3 points, wrong
+            arity per point, or non-numeric values).
+    """
+    points: list[tuple[float, float]] = []
+    items = [p.strip() for p in spec.split(";") if p.strip()]
+    for item in items:
+        coords = [c.strip() for c in item.split(",")]
+        if len(coords) != 2:
+            raise ValueError(
+                f"Invalid --region point '{item}': expected 'X,Y' (e.g. '10,10;40,10;40,30;10,30')"
+            )
+        try:
+            x, y = (float(c) for c in coords)
+        except ValueError as exc:
+            raise ValueError(
+                f"Invalid --region point '{item}': X and Y must be numeric "
+                "(e.g. '10,10;40,10;40,30;10,30')"
+            ) from exc
+        points.append((x, y))
+
+    if len(points) < 3:
+        raise ValueError(
+            f"Invalid --region '{spec}': a polygon needs at least 3 points "
+            "(e.g. '10,10;40,10;40,30;10,30')"
+        )
+
+    return points
+
+
 def main(argv: list[str] | None = None) -> int:
     """Main entry point for zones command."""
     parser = argparse.ArgumentParser(
@@ -69,6 +154,28 @@ def main(argv: list[str] | None = None) -> int:
         type=float,
         default=0.25,
         help="Minimum copper thickness in mm (default: 0.25)",
+    )
+    region_group = add_parser.add_mutually_exclusive_group()
+    region_group.add_argument(
+        "--bbox",
+        metavar="MINX,MINY,MAXX,MAXY",
+        help=(
+            "Restrict the pour to a rectangular region (island pour) instead "
+            "of the full board outline. Coordinates are sheet-absolute "
+            "millimetres (same frame as `zones list` output). "
+            "Example: --bbox 10,10,40,30"
+        ),
+    )
+    region_group.add_argument(
+        "--region",
+        metavar="X1,Y1;X2,Y2;...",
+        help=(
+            "Restrict the pour to an explicit polygon region (island pour) "
+            "instead of the full board outline. At least 3 points, each "
+            "'X,Y' separated by ';'. Coordinates are sheet-absolute "
+            "millimetres (same frame as `zones list` output). "
+            "Example: --region 10,10;40,10;40,30;10,30"
+        ),
     )
     add_parser.add_argument(
         "-v",
@@ -200,6 +307,17 @@ def _run_add(args) -> int:
 
     quiet = args.quiet
 
+    # Parse optional region/island boundary (mutually exclusive in argparse).
+    boundary = None
+    try:
+        if args.bbox:
+            boundary = parse_bbox(args.bbox)
+        elif args.region:
+            boundary = parse_region(args.region)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
     if not quiet:
         print(f"Loading PCB: {pcb_path}")
 
@@ -219,6 +337,7 @@ def _run_add(args) -> int:
             thermal_gap=args.thermal_gap,
             thermal_bridge_width=args.thermal_bridge,
             min_thickness=args.min_thickness,
+            boundary=boundary,
         )
     except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/tests/test_zones_cmd.py
+++ b/tests/test_zones_cmd.py
@@ -1378,3 +1378,250 @@ class TestFillIntegration:
         assert out.exists()
         content = out.read_text()
         assert "filled_polygon" in content
+
+
+# ---------------------------------------------------------------------------
+# Test: region/island boundary parsing helpers (Slice 1 of #3807)
+# ---------------------------------------------------------------------------
+
+
+class TestParseBbox:
+    """Unit tests for the --bbox parse helper."""
+
+    def test_valid_bbox_returns_corner_polygon(self):
+        from kicad_tools.cli.zones_cmd import parse_bbox
+
+        assert parse_bbox("10,10,40,30") == [
+            (10.0, 10.0),
+            (40.0, 10.0),
+            (40.0, 30.0),
+            (10.0, 30.0),
+        ]
+
+    def test_bbox_tolerates_whitespace(self):
+        from kicad_tools.cli.zones_cmd import parse_bbox
+
+        assert parse_bbox(" 10 , 10 , 40 , 30 ") == [
+            (10.0, 10.0),
+            (40.0, 10.0),
+            (40.0, 30.0),
+            (10.0, 30.0),
+        ]
+
+    def test_bbox_wrong_arity_raises(self):
+        from kicad_tools.cli.zones_cmd import parse_bbox
+
+        with pytest.raises(ValueError, match="expected 4"):
+            parse_bbox("10,10,40")
+
+    def test_bbox_non_numeric_raises(self):
+        from kicad_tools.cli.zones_cmd import parse_bbox
+
+        with pytest.raises(ValueError, match="numeric"):
+            parse_bbox("a,b,c,d")
+
+    def test_bbox_min_ge_max_x_raises(self):
+        from kicad_tools.cli.zones_cmd import parse_bbox
+
+        with pytest.raises(ValueError, match="MINX"):
+            parse_bbox("40,10,10,30")
+
+    def test_bbox_min_ge_max_y_raises(self):
+        from kicad_tools.cli.zones_cmd import parse_bbox
+
+        with pytest.raises(ValueError, match="MINY"):
+            parse_bbox("10,30,40,30")
+
+
+class TestParseRegion:
+    """Unit tests for the --region parse helper."""
+
+    def test_valid_region_round_trips(self):
+        from kicad_tools.cli.zones_cmd import parse_region
+
+        assert parse_region("10,10;40,10;40,30;10,30") == [
+            (10.0, 10.0),
+            (40.0, 10.0),
+            (40.0, 30.0),
+            (10.0, 30.0),
+        ]
+
+    def test_region_too_few_points_raises(self):
+        from kicad_tools.cli.zones_cmd import parse_region
+
+        with pytest.raises(ValueError, match="at least 3"):
+            parse_region("10,10;40,10")
+
+    def test_region_bad_point_arity_raises(self):
+        from kicad_tools.cli.zones_cmd import parse_region
+
+        with pytest.raises(ValueError, match="X,Y"):
+            parse_region("10,10;40;40,30")
+
+    def test_region_non_numeric_raises(self):
+        from kicad_tools.cli.zones_cmd import parse_region
+
+        with pytest.raises(ValueError, match="numeric"):
+            parse_region("10,10;a,b;40,30")
+
+
+# ---------------------------------------------------------------------------
+# Test: --bbox / --region flow through `zones add` to the zone polygon
+# ---------------------------------------------------------------------------
+
+
+class TestAddRegionBoundary:
+    """Verify region flags produce a zone with the requested polygon."""
+
+    def test_bbox_dry_run_emits_requested_rectangle(self, tmp_pcb, capsys):
+        """--bbox produces a polygon matching the requested rectangle."""
+        ret = main(
+            [
+                "add",
+                str(tmp_pcb),
+                "--net",
+                "GND",
+                "--layer",
+                "F.Cu",
+                "--bbox",
+                "10,10,40,30",
+                "--dry-run",
+            ]
+        )
+        assert ret == 0
+        out = capsys.readouterr().out
+        # The four rectangle corners appear in the generated polygon, and the
+        # zone reports a 4-point boundary (not the full board outline).
+        assert "(xy 10 10)" in out
+        assert "(xy 40 10)" in out
+        assert "(xy 40 30)" in out
+        assert "(xy 10 30)" in out
+        assert "Boundary:    4 points" in out
+
+    def test_region_dry_run_round_trips_polygon(self, tmp_pcb, capsys):
+        """--region produces a polygon matching the requested points."""
+        ret = main(
+            [
+                "add",
+                str(tmp_pcb),
+                "--net",
+                "GND",
+                "--layer",
+                "F.Cu",
+                "--region",
+                "5,5;45,5;45,35;25,35;5,35",
+                "--dry-run",
+            ]
+        )
+        assert ret == 0
+        out = capsys.readouterr().out
+        assert "(xy 5 5)" in out
+        assert "(xy 45 5)" in out
+        assert "(xy 25 35)" in out
+        assert "Boundary:    5 points" in out
+
+    def test_bbox_on_inner_layer(self, tmp_pcb, capsys):
+        """--bbox works on an inner copper layer."""
+        ret = main(
+            [
+                "add",
+                str(tmp_pcb),
+                "--net",
+                "GND",
+                "--layer",
+                "In1.Cu",
+                "--bbox",
+                "12,12,20,20",
+                "--dry-run",
+            ]
+        )
+        assert ret == 0
+        out = capsys.readouterr().out
+        assert "(xy 12 12)" in out
+        assert "Boundary:    4 points" in out
+
+    def test_no_region_flag_uses_board_outline(self, tmp_pcb, capsys):
+        """Omitting region flags preserves full-board-outline behavior."""
+        ret = main(
+            [
+                "add",
+                str(tmp_pcb),
+                "--net",
+                "GND",
+                "--layer",
+                "F.Cu",
+                "--dry-run",
+            ]
+        )
+        assert ret == 0
+        out = capsys.readouterr().out
+        # Board outline produces a polygon; it should not be the tiny island
+        # rectangle and should have a boundary point count.
+        assert "Boundary:" in out
+        assert "(polygon" in out
+
+    def test_invalid_bbox_returns_1_without_traceback(self, tmp_pcb, capsys):
+        """Malformed --bbox returns non-zero with a clear error message."""
+        ret = main(
+            [
+                "add",
+                str(tmp_pcb),
+                "--net",
+                "GND",
+                "--layer",
+                "F.Cu",
+                "--bbox",
+                "10,10,40",
+                "--dry-run",
+            ]
+        )
+        assert ret == 1
+        err = capsys.readouterr().err
+        assert "Error:" in err
+        assert "expected 4" in err
+
+    def test_invalid_bbox_min_ge_max_returns_1(self, tmp_pcb, capsys):
+        """--bbox with min>=max returns non-zero with a clear message."""
+        ret = main(
+            [
+                "add",
+                str(tmp_pcb),
+                "--net",
+                "GND",
+                "--layer",
+                "F.Cu",
+                "--bbox",
+                "40,10,10,30",
+                "--dry-run",
+            ]
+        )
+        assert ret == 1
+        err = capsys.readouterr().err
+        assert "MINX" in err
+
+    def test_bbox_and_region_mutually_exclusive(self, tmp_pcb):
+        """argparse rejects supplying both --bbox and --region."""
+        with pytest.raises(SystemExit):
+            main(
+                [
+                    "add",
+                    str(tmp_pcb),
+                    "--net",
+                    "GND",
+                    "--layer",
+                    "F.Cu",
+                    "--bbox",
+                    "10,10,40,30",
+                    "--region",
+                    "10,10;40,10;40,30",
+                    "--dry-run",
+                ]
+            )
+
+    def test_bbox_documented_in_add_help(self, capsys):
+        """--bbox flag and its coordinate frame are documented in help."""
+        with pytest.raises(SystemExit):
+            main(["add", "--help"])
+        out = capsys.readouterr().out
+        assert "--bbox" in out
+        assert "sheet-absolute" in out


### PR DESCRIPTION
## Summary

Plumbs an optional region boundary through the `zones add` CLI so users can create island pours (e.g. an analog-ground GNDA island under a DAC) directly from the command line. Previously every CLI-created pour defaulted to the full board outline; the underlying `ZoneGenerator.add_zone(boundary=...)` API and the `zone_node` serializer already supported arbitrary polygons end-to-end, so this is a thin CLI-plumbing change.

This implements **Slice 1 only** of the Curator's sequenced scoping for #3807. Slices 2 (CLI keepout subcommand) and 3 (named fill-divergence remediation) are intentionally deferred per the Curator — they are distinct surfaces and the latter requires a reproducible failing board + `kct check` violation list before it can be bounded. Full byte-parity with pcbnew's filler remains explicitly out of scope.

## Changes

- Add a mutually-exclusive `--bbox MINX,MINY,MAXX,MAXY` / `--region X1,Y1;X2,Y2;...` group to the `zones add` subparser (`src/kicad_tools/cli/zones_cmd.py`).
- Add `parse_bbox` / `parse_region` helpers (mirroring `parse_power_nets` style) that return sheet-absolute `list[tuple[float, float]]` polygons and raise `ValueError` on malformed input.
- Pass the parsed polygon as `boundary=` to the existing `gen.add_zone(...)` call in `_run_add`. Omitting both flags preserves the full-board-outline default.
- Help text documents the new flags and their coordinate frame (sheet-absolute mm, same frame as `zones list` output).
- Add tests in `tests/test_zones_cmd.py` for parsing, custom-polygon dry-run output, inner-layer support, backward compatibility, and invalid-input error handling.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `--bbox` creates a pour matching the requested rectangle (not board outline) | done | `test_bbox_dry_run_emits_requested_rectangle`; manual dry-run shows `(polygon (pts (xy 10 10) (xy 40 10) (xy 40 30) (xy 10 30)))` |
| No region flag = unchanged full-board behavior | done | `test_no_region_flag_uses_board_outline` |
| Invalid region input → clear non-zero error, no traceback | done | `test_invalid_bbox_returns_1_without_traceback`, `test_invalid_bbox_min_ge_max_returns_1`, parse-helper unit tests |
| Region passed to `add_zone(boundary=...)`; overlap logic still runs | done | `boundary=` wired in `_run_add`; `_check_overlap` runs on `actual_boundary` in `add_zone` |
| `--dry-run` prints generated S-expression with custom polygon | done | dry-run tests assert polygon points in stdout |
| Help text documents flag + coordinate frame | done | `test_bbox_documented_in_add_help` asserts `--bbox` and `sheet-absolute` |

## Test Plan

- `uv run pytest tests/test_zones_cmd.py -k "Region or Bbox or ParseBbox or ParseRegion"` — 18 passed.
- `uv run ruff check` and `uv run ruff format --check` on touched files — clean.
- `uv run mypy src/kicad_tools/cli/zones_cmd.py` — no issues.
- Manual: `kct zones add <board> --net GND --layer F.Cu --bbox 10,10,40,30 --dry-run` prints the requested rectangle.

Closes #3807