### PR TITLE
fix(erc): suppress cross-sheet global-label false positives in kct erc

### DIFF
--- a/src/kicad_tools/cli/erc_cmd.py
+++ b/src/kicad_tools/cli/erc_cmd.py
@@ -13,9 +13,18 @@ Exit Codes:
     0 - No errors (warnings may be present)
     1 - Errors found or command failure
     2 - Warnings found (only with --strict)
+
+Cross-sheet global labels:
+    When run on a schematic, single_global_label / isolated_pin_label
+    false positives for global labels spanning multiple sheets are
+    suppressed automatically (matching `kct sch validate`). When parsing a
+    bare report (.json/.rpt) this suppression is skipped because the
+    schematic hierarchy needed to build the cross-sheet label inventory is
+    not available -- run on the .kicad_sch directly for filtered results.
 """
 
 import argparse
+import contextlib
 import json
 import sys
 from pathlib import Path
@@ -26,6 +35,7 @@ from ..erc import (
     ERCReport,
     ERCViolation,
     check_cross_sheet_duplicates,
+    filter_cross_sheet_global_labels_objs,
 )
 from .runner import find_kicad_cli, run_erc
 
@@ -117,12 +127,19 @@ def main(argv: list[str] | None = None) -> int:
 
     input_path = Path(args.input)
 
+    # Root schematic used to build the cross-sheet global-label inventory.
+    # Only available when ERC is run on a schematic (not when parsing a bare
+    # report), so the false-positive filter is skipped for report-only input.
+    schematic_for_filter: str | None = None
+
     # Determine if input is schematic or report
     if input_path.suffix == ".kicad_sch":
         # Run ERC on schematic
         report = run_erc_on_schematic(input_path, args.output, args.keep_report)
         if report is None:
             return 1
+
+        schematic_for_filter = str(input_path)
 
         # Run cross-sheet duplicate reference check (supplements KiCad ERC)
         try:
@@ -145,6 +162,28 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Error: Unsupported file type: {input_path.suffix}", file=sys.stderr)
         print("Expected .kicad_sch (schematic) or .json/.rpt (report)", file=sys.stderr)
         return 1
+
+    # Suppress cross-sheet global-label false positives.
+    #
+    # KiCad's ERC engine emits single_global_label / isolated_pin_label
+    # per-sheet without aggregating a global label across the full
+    # hierarchy, so a label that legitimately spans >= 2 sheets is wrongly
+    # reported as isolated.  The dict-based filter is already applied on the
+    # `kct sch validate` / preflight path; apply the ERCViolation-aware
+    # variant here so `kct erc` is consistent.
+    #
+    # Building the inventory requires a real `.kicad_sch` hierarchy, so this
+    # is skipped when only a bare report (.json/.rpt) is supplied -- the
+    # hierarchy cannot be reconstructed from the report alone.  Wrapped in
+    # try/except to degrade gracefully (matching check_cross_sheet_duplicates)
+    # so a parsing hiccup never turns a clean ERC into a crash.
+    if schematic_for_filter is not None:
+        # Non-fatal: filtering is supplemental; on any error (e.g. a malformed
+        # or missing hierarchy) the raw violations are kept unchanged.
+        with contextlib.suppress(Exception):
+            report.violations = filter_cross_sheet_global_labels_objs(
+                report.violations, schematic_for_filter
+            )
 
     # Apply violation filters from config file
     filter_ignored_count = 0

--- a/src/kicad_tools/erc/__init__.py
+++ b/src/kicad_tools/erc/__init__.py
@@ -14,6 +14,7 @@ Example:
 from .cross_sheet import (
     check_cross_sheet_duplicates,
     filter_cross_sheet_global_labels,
+    filter_cross_sheet_global_labels_objs,
     filter_cross_sheet_power_violations,
     reattribute_wire_dangling_violations,
 )
@@ -48,6 +49,7 @@ __all__ = [
     # Cross-sheet checks
     "check_cross_sheet_duplicates",
     "filter_cross_sheet_global_labels",
+    "filter_cross_sheet_global_labels_objs",
     "filter_cross_sheet_power_violations",
     "reattribute_wire_dangling_violations",
 ]

--- a/src/kicad_tools/erc/cross_sheet.py
+++ b/src/kicad_tools/erc/cross_sheet.py
@@ -370,6 +370,79 @@ def filter_cross_sheet_global_labels(
     return filtered
 
 
+def filter_cross_sheet_global_labels_objs(
+    violations: list[ERCViolation],
+    root_schematic: str,
+) -> list[ERCViolation]:
+    """``ERCViolation``-aware variant of :func:`filter_cross_sheet_global_labels`.
+
+    Suppresses false-positive ``single_global_label`` / ``isolated_pin_label``
+    violations for global labels that appear on multiple sheets of the
+    hierarchy, operating directly on :class:`ERCViolation` objects rather than
+    raw KiCad JSON dicts.
+
+    This mirrors the suppression logic used by ``kct sch validate`` /
+    ``kct sch preflight`` (which works on dicts via
+    :func:`filter_cross_sheet_global_labels`) so that ``kct erc`` produces a
+    consistent result.  The shared inventory helpers
+    (:func:`build_global_label_inventory`, :func:`build_sheet_label_presence`,
+    :func:`_extract_label_name`) are reused unchanged.
+
+    Per-sheet provenance is read from each violation's ``sheet`` attribute,
+    which :meth:`ERCReport.load` populates from the originating sheet path.
+
+    Args:
+        violations: List of :class:`ERCViolation` objects.
+        root_schematic: Path to the root ``.kicad_sch`` file used to build
+            the global label inventory.  A real hierarchy is required; the
+            caller is responsible for only invoking this when a schematic is
+            available.
+
+    Returns:
+        A new list with false-positive violations removed.  Violations of
+        other types pass through unchanged.
+    """
+    target_types = {"single_global_label", "isolated_pin_label"}
+
+    # Quick check: if no target violations exist, skip the expensive
+    # hierarchy traversal.
+    has_target = any(v.type_str in target_types for v in violations)
+    if not has_target:
+        return violations
+
+    inventory = build_global_label_inventory(root_schematic)
+    sheet_label_presence = build_sheet_label_presence(root_schematic)
+
+    filtered: list[ERCViolation] = []
+    for v in violations:
+        if v.type_str not in target_types:
+            filtered.append(v)
+            continue
+
+        # ERCViolation.items is a list[str]; adapt to the {"description": ...}
+        # shape that _extract_label_name expects for the KiCad 10+ path.
+        item_dicts = [{"description": item} for item in v.items] if v.items else None
+        label_name = _extract_label_name(v.description, item_dicts)
+        if label_name is None:
+            # Could not parse label name.  If the violation's sheet has no
+            # labels at all, this is a phantom detection -- suppress it.
+            sheet_path = v.sheet
+            if sheet_path and sheet_path not in sheet_label_presence:
+                continue
+            # Sheet has labels (or no sheet info available) -- keep to be safe.
+            filtered.append(v)
+            continue
+
+        sheets = inventory.get(label_name, set())
+        if len(sheets) >= 2:
+            # Label appears on multiple sheets -- this is a false positive.
+            continue
+
+        filtered.append(v)
+
+    return filtered
+
+
 # ---------------------------------------------------------------------------
 # Cross-sheet power-pin false-positive filtering
 # ---------------------------------------------------------------------------

--- a/tests/test_erc_cmd_global_labels.py
+++ b/tests/test_erc_cmd_global_labels.py
@@ -1,0 +1,204 @@
+"""Integration tests for cross-sheet global-label filtering in ``kct erc``.
+
+Regression coverage for the bug where ``kct erc`` over-reported
+single-pin / isolated nets for global labels that legitimately span
+multiple hierarchical sheets (issue #3808).  The suppression logic lived in
+``filter_cross_sheet_global_labels`` and was wired into ``kct sch validate``
+but never into the ``kct erc`` path.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli import erc_cmd
+from kicad_tools.core.types import ERCSeverity
+from kicad_tools.erc.report import ERCReport
+from kicad_tools.erc.violation import ERCViolation, ERCViolationType
+
+# Schematic templates: a root that instantiates one child sheet, with global
+# labels placed on both so the shared label spans 2 sheets.
+
+_ROOT_TEMPLATE = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "root-uuid-3808")
+  (paper "A4")
+  (lib_symbols)
+  {global_labels}
+  (sheet
+    (at 130 40) (size 40 30)
+    (uuid "sheet-sub-3808")
+    (property "Sheetname" "Sub" (at 130 39 0) (effects (font (size 1.27 1.27))))
+    (property "Sheetfile" "sub.kicad_sch" (at 130 71 0) (effects (font (size 1.27 1.27))))
+  )
+)
+"""
+
+_SUB_TEMPLATE = """\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "sub-uuid-3808")
+  (paper "A4")
+  (lib_symbols)
+  {global_labels}
+)
+"""
+
+_GLOBAL_LABEL = """\
+  (global_label "{text}"
+    (shape input)
+    (at 100 {y} 0)
+    (effects (font (size 1.27 1.27)) (justify left))
+    (uuid "{uuid}")
+  )
+"""
+
+
+def _gl(text: str, uuid: str, y: int = 100) -> str:
+    return _GLOBAL_LABEL.format(text=text, uuid=uuid, y=y)
+
+
+def _write_two_sheet_design(tmp_path: Path) -> Path:
+    """Root + child sharing ``MCU_CLK``; ``LONELY`` only on root."""
+    root = _ROOT_TEMPLATE.format(
+        global_labels=_gl("MCU_CLK", "gl-root-clk", 100) + _gl("LONELY", "gl-root-lonely", 110)
+    )
+    sub = _SUB_TEMPLATE.format(global_labels=_gl("MCU_CLK", "gl-sub-clk", 100))
+    (tmp_path / "design.kicad_sch").write_text(root)
+    (tmp_path / "sub.kicad_sch").write_text(sub)
+    return tmp_path / "design.kicad_sch"
+
+
+def _isolated_violation(label: str, sheet: str) -> ERCViolation:
+    return ERCViolation(
+        type=ERCViolationType.ISOLATED_PIN_LABEL,
+        type_str="isolated_pin_label",
+        severity=ERCSeverity.ERROR,
+        description="Label connected to only one pin",
+        sheet=sheet,
+        items=[f"Global Label '{label}'"],
+    )
+
+
+def test_kct_erc_suppresses_cross_sheet_false_positive(tmp_path, monkeypatch, capsys):
+    """A global label on >= 2 sheets is not reported, and exit code is 0."""
+    schematic = _write_two_sheet_design(tmp_path)
+
+    report = ERCReport(
+        source_file=str(schematic),
+        violations=[_isolated_violation("MCU_CLK", "/")],
+    )
+
+    monkeypatch.setattr(erc_cmd, "run_erc_on_schematic", lambda *a, **k: report)
+
+    exit_code = erc_cmd.main([str(schematic), "--verbose"])
+    out = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "MCU_CLK" not in out
+    assert "PASSED" in out
+
+
+def test_kct_erc_still_reports_genuine_single_pin(tmp_path, monkeypatch, capsys):
+    """A genuinely isolated single-sheet label is still reported (exit 1)."""
+    schematic = _write_two_sheet_design(tmp_path)
+
+    report = ERCReport(
+        source_file=str(schematic),
+        violations=[_isolated_violation("LONELY", "/")],
+    )
+
+    monkeypatch.setattr(erc_cmd, "run_erc_on_schematic", lambda *a, **k: report)
+
+    # --verbose surfaces the label name from the items array.
+    exit_code = erc_cmd.main([str(schematic), "--verbose"])
+    out = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "LONELY" in out
+    assert "isolated_pin_label" in out or "only one pin" in out
+
+
+def test_kct_erc_mixed_suppresses_only_false_positive(tmp_path, monkeypatch, capsys):
+    """Mixed input: cross-sheet label suppressed, genuine one retained."""
+    schematic = _write_two_sheet_design(tmp_path)
+
+    report = ERCReport(
+        source_file=str(schematic),
+        violations=[
+            _isolated_violation("MCU_CLK", "/"),  # false positive (2 sheets)
+            _isolated_violation("LONELY", "/"),  # genuine (1 sheet)
+        ],
+    )
+
+    monkeypatch.setattr(erc_cmd, "run_erc_on_schematic", lambda *a, **k: report)
+
+    exit_code = erc_cmd.main([str(schematic), "--verbose"])
+    out = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "MCU_CLK" not in out
+    assert "LONELY" in out
+
+
+def test_kct_erc_parse_bare_report_does_not_crash(tmp_path, capsys):
+    """Parsing a bare report (no schematic) skips the filter gracefully."""
+    report_json = tmp_path / "report.json"
+    report_json.write_text(
+        """
+        {
+          "source": "design.kicad_sch",
+          "kicad_version": "8.0",
+          "coordinate_units": "mm",
+          "sheets": [
+            {
+              "path": "/",
+              "violations": [
+                {
+                  "type": "isolated_pin_label",
+                  "severity": "error",
+                  "description": "Label connected to only one pin",
+                  "items": [{"description": "Global Label 'MCU_CLK'"}]
+                }
+              ]
+            }
+          ]
+        }
+        """
+    )
+
+    exit_code = erc_cmd.main([str(report_json)])
+    out = capsys.readouterr().out
+
+    # Filter is skipped for bare reports, so the violation flows through.
+    assert exit_code == 1
+    assert "isolated_pin_label" in out or "only one pin" in out
+
+
+def test_kct_erc_filter_failure_is_non_fatal(tmp_path, monkeypatch, capsys):
+    """A failure building the inventory must not crash a clean ERC run."""
+    schematic = tmp_path / "missing.kicad_sch"  # never written
+
+    report = ERCReport(
+        source_file=str(schematic),
+        violations=[_isolated_violation("MCU_CLK", "/")],
+    )
+
+    monkeypatch.setattr(erc_cmd, "run_erc_on_schematic", lambda *a, **k: report)
+
+    # The filter will attempt to traverse a nonexistent hierarchy; the
+    # try/except in erc_cmd must swallow any error and keep the violation.
+    exit_code = erc_cmd.main([str(schematic), "--verbose"])
+    out = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "MCU_CLK" in out
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_erc_cross_sheet_globals.py
+++ b/tests/test_erc_cross_sheet_globals.py
@@ -2,12 +2,15 @@
 
 from pathlib import Path
 
+from kicad_tools.core.types import ERCSeverity
 from kicad_tools.erc.cross_sheet import (
     _extract_label_name,
     build_global_label_inventory,
     build_sheet_label_presence,
     filter_cross_sheet_global_labels,
+    filter_cross_sheet_global_labels_objs,
 )
+from kicad_tools.erc.violation import ERCViolation, ERCViolationType
 
 # ---------------------------------------------------------------------------
 # Schematic templates with global labels
@@ -736,3 +739,159 @@ class TestBuildSheetLabelPresence:
 
         assert "/" not in presence
         assert "/Sub" in presence
+
+
+# ---------------------------------------------------------------------------
+# Tests: filter_cross_sheet_global_labels_objs (ERCViolation-aware wrapper)
+# ---------------------------------------------------------------------------
+
+
+class TestFilterCrossSheetGlobalLabelsObjs:
+    """Tests for the ERCViolation-aware cross-sheet filter used by ``kct erc``."""
+
+    def _make_violation(
+        self,
+        vtype: str,
+        label_name: str | None = None,
+        *,
+        description: str | None = None,
+        sheet: str = "",
+        items: list[str] | None = None,
+    ) -> ERCViolation:
+        if description is None:
+            description = (
+                f"Label '{label_name}' appears only once in the design"
+                if label_name
+                else "Label connected to only one pin"
+            )
+        return ERCViolation(
+            type=ERCViolationType.from_string(vtype),
+            type_str=vtype,
+            severity=ERCSeverity.WARNING,
+            description=description,
+            sheet=sheet,
+            items=items or [],
+        )
+
+    def _build_two_sheet_design(self, tmp_path: Path, label: str) -> str:
+        """Create a root + child sharing *label*; return the root path."""
+        sub_file = "sub.kicad_sch"
+        root_labels = _make_global_label(label, uuid="gl-root")
+        root_sheets = _make_sheet("Sub", sub_file, uuid="sheet-sub")
+        root_content = _ROOT_WITH_GLOBALS_TEMPLATE.format(
+            global_labels=root_labels, sheets=root_sheets
+        )
+        sub_labels = _make_global_label(label, uuid="gl-sub")
+        sub_content = _SUBSHEET_WITH_GLOBALS_TEMPLATE.format(
+            uuid="sub-uuid", global_labels=sub_labels
+        )
+        (tmp_path / "root.kicad_sch").write_text(root_content)
+        (tmp_path / sub_file).write_text(sub_content)
+        return str(tmp_path / "root.kicad_sch")
+
+    def test_suppresses_multi_sheet_global_label(self, tmp_path: Path):
+        """A global label on 2 sheets is NOT reported as single-pin/isolated."""
+        root = self._build_two_sheet_design(tmp_path, "AUDIO_L")
+        violations = [self._make_violation("single_global_label", "AUDIO_L")]
+
+        result = filter_cross_sheet_global_labels_objs(violations, root)
+
+        assert len(result) == 0
+
+    def test_suppresses_multi_sheet_isolated_pin_label(self, tmp_path: Path):
+        root = self._build_two_sheet_design(tmp_path, "SPI_MOSI")
+        violations = [self._make_violation("isolated_pin_label", "SPI_MOSI")]
+
+        result = filter_cross_sheet_global_labels_objs(violations, root)
+
+        assert len(result) == 0
+
+    def test_preserves_genuine_single_pin_label(self, tmp_path: Path):
+        """A label on exactly one sheet IS still reported."""
+        root_labels = _make_global_label("LONELY_NET", uuid="gl-lonely")
+        root_content = _ROOT_WITH_GLOBALS_TEMPLATE.format(global_labels=root_labels, sheets="")
+        (tmp_path / "root.kicad_sch").write_text(root_content)
+
+        violations = [self._make_violation("single_global_label", "LONELY_NET")]
+        result = filter_cross_sheet_global_labels_objs(violations, str(tmp_path / "root.kicad_sch"))
+
+        assert len(result) == 1
+        assert result[0].type_str == "single_global_label"
+
+    def test_kicad10_label_in_items_filtered(self, tmp_path: Path):
+        """KiCad 10+ puts the label name in items (list[str] on ERCViolation)."""
+        root = self._build_two_sheet_design(tmp_path, "SYNC_R")
+        violations = [
+            self._make_violation(
+                "isolated_pin_label",
+                description="Label connected to only one pin",
+                items=["Global Label 'SYNC_R'"],
+            )
+        ]
+
+        result = filter_cross_sheet_global_labels_objs(violations, root)
+
+        assert len(result) == 0
+
+    def test_mixed_selective_filtering(self, tmp_path: Path):
+        """Only the false positive is removed; genuine + unrelated remain."""
+        sub_file = "sub.kicad_sch"
+        root_labels = _make_global_label("MULTI", uuid="gl-r-m") + _make_global_label(
+            "SINGLE", uuid="gl-r-s"
+        )
+        root_sheets = _make_sheet("Sub", sub_file, uuid="sheet-sub")
+        root_content = _ROOT_WITH_GLOBALS_TEMPLATE.format(
+            global_labels=root_labels, sheets=root_sheets
+        )
+        sub_content = _SUBSHEET_WITH_GLOBALS_TEMPLATE.format(
+            uuid="sub-uuid", global_labels=_make_global_label("MULTI", uuid="gl-s-m")
+        )
+        (tmp_path / "root.kicad_sch").write_text(root_content)
+        (tmp_path / sub_file).write_text(sub_content)
+
+        violations = [
+            self._make_violation("single_global_label", "MULTI"),  # false positive
+            self._make_violation("single_global_label", "SINGLE"),  # genuine
+            self._make_violation("pin_not_connected", description="Pin 1 of R1 is not connected"),
+        ]
+        result = filter_cross_sheet_global_labels_objs(violations, str(tmp_path / "root.kicad_sch"))
+
+        types = sorted(v.type_str for v in result)
+        assert types == ["pin_not_connected", "single_global_label"]
+        sgl = next(v for v in result if v.type_str == "single_global_label")
+        assert "SINGLE" in sgl.description
+
+    def test_no_target_violations_skips_hierarchy(self, tmp_path: Path):
+        """Skip hierarchy traversal when no target types are present."""
+        violations = [
+            self._make_violation("pin_not_connected", description="Pin 1 of R1 is not connected")
+        ]
+        # nonexistent path would raise if traversed
+        result = filter_cross_sheet_global_labels_objs(
+            violations, str(tmp_path / "nonexistent.kicad_sch")
+        )
+        assert len(result) == 1
+
+    def test_phantom_on_label_free_sheet_suppressed(self, tmp_path: Path):
+        """Unparseable violation on a label-free sheet is suppressed."""
+        sub_file = "sub.kicad_sch"
+        root_sheets = _make_sheet("Sub", sub_file, uuid="sheet-sub")
+        root_content = _ROOT_WITH_GLOBALS_TEMPLATE.format(global_labels="", sheets=root_sheets)
+        sub_content = _SUBSHEET_WITH_GLOBALS_TEMPLATE.format(
+            uuid="sub-uuid", global_labels=_make_global_label("SPI", uuid="gl-sub")
+        )
+        (tmp_path / "root.kicad_sch").write_text(root_content)
+        (tmp_path / sub_file).write_text(sub_content)
+
+        violations = [
+            self._make_violation(
+                "isolated_pin_label",
+                description="Pin connected to only other pins or labels on the sheet",
+                sheet="/",
+            )
+        ]
+        result = filter_cross_sheet_global_labels_objs(violations, str(tmp_path / "root.kicad_sch"))
+        assert len(result) == 0
+
+    def test_empty_violations(self, tmp_path: Path):
+        assert filter_cross_sheet_global_labels_objs([], "ignored.kicad_sch") == []


### PR DESCRIPTION
## Summary

`kct erc` over-reported `single_global_label` / `isolated_pin_label`
violations ("Label connected to only one pin" / "Global label appears
only once") for global labels that legitimately connect across
hierarchical sheets (e.g. MCU_CLK, UART). KiCad's ERC engine emits these
per-sheet without aggregating a global label across the full hierarchy.

The suppression logic already existed (`filter_cross_sheet_global_labels`
in `erc/cross_sheet.py`) and was wired into the `kct sch validate` /
preflight path (`sch_validate.py`), but was never invoked from the
`kct erc` path (`erc_cmd.py`), so the raw per-sheet false positives flowed
straight through `kct erc` and `kct erc parse` into the exit code.

This PR wires the filter into `erc_cmd.main()` so `kct erc` is consistent
with `kct sch validate` and native `kicad-cli sch erc`.

## Changes

- `erc/cross_sheet.py`: add `filter_cross_sheet_global_labels_objs()`, an
  `ERCViolation`-aware wrapper (Option A from the issue) that reuses the
  existing inventory helpers (`build_global_label_inventory`,
  `build_sheet_label_presence`, `_extract_label_name`) and reads
  `v.type_str` / `v.description` / `v.items` / `v.sheet` directly. The
  `list[str]` items are adapted to the `{"description": ...}` shape the
  shared parser expects. The dict-based function is left intact for
  `sch_validate`.
- `erc/__init__.py`: export the new wrapper.
- `cli/erc_cmd.py`: invoke the wrapper in `main()` after the report is
  obtained and before violations are filtered/printed. Guarded so it only
  runs when a real schematic is available (skipped for bare `.json`/`.rpt`
  reports, where the hierarchy cannot be reconstructed), and wrapped in
  `contextlib.suppress(Exception)` so a malformed/missing hierarchy never
  turns a clean ERC into a crash. The bare-report limitation is documented
  in `--help`.
- `tests/test_erc_cross_sheet_globals.py`: add `TestFilterCrossSheetGlobalLabelsObjs`
  covering the new wrapper (multi-sheet suppression, genuine single-sheet
  retention, KiCad 10+ items format, phantom label-free sheet, selective
  filtering, no-target fast path).
- `tests/test_erc_cmd_global_labels.py` (new): end-to-end coverage of
  `erc_cmd.main()` — suppresses a cross-sheet false positive (exit 0),
  still reports a genuinely isolated label (exit 1), mixed selective
  filtering, bare-report graceful skip, and non-fatal degradation.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| No `isolated_pin_label`/`single_global_label` for a label on >= 2 sheets | Done | `test_kct_erc_suppresses_cross_sheet_false_positive` |
| Exit code reflects filtered result (clean -> exit 0) | Done | same test asserts `exit_code == 0` + "PASSED" |
| Genuinely isolated single-pin labels STILL reported | Done | `test_kct_erc_still_reports_genuine_single_pin` / `_mixed_` |
| `kct erc parse <report.json>` degrades cleanly (documented) | Done | `test_kct_erc_parse_bare_report_does_not_crash` + `--help` note |
| `kct sch validate` / preflight unchanged | Done | dict-based filter untouched; `test_sch_preflight` + `test_sch_validate_items` green |

## Test Plan

- `pytest tests/test_erc_cmd_global_labels.py tests/test_erc_cross_sheet_globals.py` — 47 passed
- `pytest tests/test_erc.py tests/test_erc_cross_sheet.py tests/test_schematic_run_erc.py tests/test_fix_erc_cmd.py tests/test_erc_violation_classification.py` — 127 passed
- `pytest tests/test_sch_preflight.py tests/test_sch_validate_items.py` — 40 passed (no preflight regression)
- `ruff check` + `ruff format --check` clean on all touched files
- `mypy` on touched files: only two pre-existing errors remain (FilterEngine.apply invariance at erc_cmd.py:199 and ERCReport.load Path|None at :282), both outside the changed region

Closes #3808