### PR TITLE
fix(route): reconcile post-route DRC gate against native kicad-cli

### DIFF
--- a/src/kicad_tools/audit/auditor.py
+++ b/src/kicad_tools/audit/auditor.py
@@ -827,85 +827,44 @@ class ManufacturingAudit:
         KiCad), the report still generates -- a note is appended to
         ``status.details`` and only the ``--mfr`` count stands.  The
         ``status`` is mutated in place; this method never raises.
+
+        The kicad-cli invocation/parsing is delegated to the shared
+        :func:`kicad_tools.drc.run_geometric_drc` helper so that this
+        path and the ``kct route`` post-route gate cannot drift (issue
+        #3803).
         """
-        import tempfile
+        from kicad_tools.drc import run_geometric_drc
 
-        from kicad_tools.cli.runner import find_kicad_cli
+        result = run_geometric_drc(self.pcb_path)
 
-        kicad_cli = find_kicad_cli()
-        if kicad_cli is None:
-            note = "kicad-cli not found; geometric DRC skipped (--mfr count only)"
-            status.details = f"{status.details}; {note}" if status.details else note
+        if not result.ran:
+            # kicad-cli absent / timed out / no report / crashed: append the
+            # helper's explanatory note and leave the --mfr count standing.
+            note = result.note
+            if note == "kicad-cli not found; geometric DRC skipped":
+                # Preserve the audit-specific suffix for backward-compat.
+                note = "kicad-cli not found; geometric DRC skipped (--mfr count only)"
+            if note:
+                status.details = f"{status.details}; {note}" if status.details else note
             return
 
-        report_path: Path | None = None
-        try:
-            with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
-                report_path = Path(f.name)
+        if result.error_count > 0:
+            status.error_count += result.error_count
+            status.blocking_count += result.error_count
+            status.passed = status.blocking_count == 0
 
-            # kicad-cli loads the sibling .kicad_pro automatically from the
-            # board's directory/stem, so the fab-accurate rules apply.
-            # --severity-error restricts the report to error-severity
-            # violations, which (per the emitted .kicad_pro rule_severities)
-            # already excludes lib_footprint_mismatch / isolated_copper.
-            cmd = [
-                str(kicad_cli),
-                "pcb",
-                "drc",
-                "--format",
-                "json",
-                "--severity-error",
-                "--units",
-                "mm",
-                "--output",
-                str(report_path),
-                str(self.pcb_path),
-            ]
-            subprocess.run(cmd, capture_output=True, timeout=120, check=False)
+            # Record per-type counts under a kicad-cli namespace so the
+            # report's by-type table makes the engine explicit and the
+            # geometric types never collide with --mfr rule_ids.
+            by_type = status.violations_by_type
+            for type_str, count in result.by_type.items():
+                key = f"kicad-cli:{type_str}"
+                by_type[key] = by_type.get(key, 0) + count
+            status.violations_by_type = by_type
 
-            if report_path is None or not report_path.exists():
-                note = "kicad-cli produced no DRC report (geometric DRC skipped)"
-                status.details = f"{status.details}; {note}" if status.details else note
-                return
-
-            from kicad_tools.drc import DRCReport
-
-            report = DRCReport.load(report_path)
-
-            # --severity-error already filters to errors, but guard defensively
-            # in case a future kicad-cli emits mixed severities.
-            cli_errors = [v for v in report.violations if v.is_error]
-            cli_error_count = len(cli_errors)
-
-            if cli_error_count > 0:
-                status.error_count += cli_error_count
-                status.blocking_count += cli_error_count
-                status.passed = status.blocking_count == 0
-
-                # Record per-type counts under a kicad-cli namespace so the
-                # report's by-type table makes the engine explicit and the
-                # geometric types never collide with --mfr rule_ids.
-                by_type = status.violations_by_type
-                cli_summary: dict[str, int] = {}
-                for v in cli_errors:
-                    key = f"kicad-cli:{v.type_str}"
-                    by_type[key] = by_type.get(key, 0) + 1
-                    cli_summary[v.type_str] = cli_summary.get(v.type_str, 0) + 1
-                status.violations_by_type = by_type
-
-                top = sorted(cli_summary.items(), key=lambda x: -x[1])[:3]
-                cli_detail = "kicad-cli: " + ", ".join(f"{t} ({c})" for t, c in top)
-                status.details = f"{status.details}; {cli_detail}" if status.details else cli_detail
-        except subprocess.TimeoutExpired:
-            note = "kicad-cli DRC timed out (geometric DRC skipped)"
-            status.details = f"{status.details}; {note}" if status.details else note
-        except Exception as e:  # pragma: no cover - defensive
-            logger.warning("Geometric DRC (kicad-cli) failed: %s", e)
-            note = f"geometric DRC failed: {e}"
-            status.details = f"{status.details}; {note}" if status.details else note
-        finally:
-            if report_path is not None:
-                report_path.unlink(missing_ok=True)
+            top = result.top_types(3)
+            cli_detail = "kicad-cli: " + ", ".join(f"{t} ({c})" for t, c in top)
+            status.details = f"{status.details}; {cli_detail}" if status.details else cli_detail
 
     def _check_connectivity(self, pcb: PCB) -> ConnectivityStatus:
         """Check net connectivity.

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -1544,11 +1544,46 @@ def run_post_route_drc(
         error_count = results.error_count
         warning_count = results.warning_count
 
+        # Reconcile against native KiCad geometric DRC (kicad-cli pcb drc).
+        # The internal DRCChecker is structurally blind to several KiCad
+        # violation classes (shorting_items / tracks_crossing on net 0,
+        # copper_edge_clearance without an Edge.Cuts outline,
+        # solder_mask_bridge, silk_* overlaps), so a clean internal verdict
+        # must NOT be reported as an unqualified PASS when kicad-cli finds
+        # geometric defects.  This mirrors DesignAuditor._merge_geometric_drc
+        # via the shared run_geometric_drc helper (issue #3803).
+        from kicad_tools.drc import run_geometric_drc
+
+        geo = run_geometric_drc(output_path)
+
+        if geo.ran and geo.error_count > 0:
+            # Native DRC found blocking geometric violations -- fold them into
+            # the verdict so PASS requires BOTH engines clean.
+            error_count += geo.error_count
+
         if not quiet:
             print("\n--- DRC Validation ---")
             if error_count == 0 and warning_count == 0:
-                print(f"  DRC PASSED ({manufacturer} profile, {layers} layers)")
+                if geo.ran:
+                    print(f"  DRC PASSED ({manufacturer} profile, {layers} layers)")
+                    print("    (internal engine + kicad-cli geometric DRC both clean)")
+                else:
+                    # kicad-cli unavailable / skipped: never overstate cleanliness.
+                    print(f"  DRC PASSED ({manufacturer} profile, {layers} layers)")
+                    note = geo.note or "geometric DRC skipped"
+                    print(f"    NOTE: {note} -> internal-engine-only PASS")
+                    print("    (native kicad-cli DRC was not run; PASS is not authoritative)")
             else:
+                # Loud divergence warning: internal engine clean but native
+                # DRC flagged geometric violations the internal engine missed.
+                if results.error_count == 0 and geo.has_errors:
+                    top = geo.top_types(4)
+                    type_summary = ", ".join(f"{t} ({c})" for t, c in top)
+                    print(
+                        "  WARNING: internal DRC clean but kicad-cli found "
+                        f"{geo.error_count} geometric violation(s): {type_summary}"
+                    )
+                    print("           PASS withheld -- native KiCad DRC is authoritative.")
                 if error_count > 0:
                     print(f"  Errors:   {error_count}")
                 if warning_count > 0:

--- a/src/kicad_tools/drc/__init__.py
+++ b/src/kicad_tools/drc/__init__.py
@@ -23,6 +23,7 @@ from .checker import (
     ManufacturerCheck,
     check_manufacturer_rules,
 )
+from .geometric import GeometricDRCResult, run_geometric_drc
 from .incremental import (
     DRCDelta,
     DRCState,
@@ -88,4 +89,7 @@ __all__ = [
     "DrillRepairResult",
     # Net compatibility
     "resolve_net_atom",
+    # Native (kicad-cli) geometric DRC reconciliation
+    "GeometricDRCResult",
+    "run_geometric_drc",
 ]

--- a/src/kicad_tools/drc/geometric.py
+++ b/src/kicad_tools/drc/geometric.py
@@ -1,0 +1,162 @@
+"""Shared native (kicad-cli) geometric DRC reconciliation.
+
+kct has two internal DRC entry points -- ``kct audit``
+(:class:`kicad_tools.audit.auditor.DesignAuditor`) and the ``kct route``
+post-route gate (:func:`kicad_tools.cli.route_cmd.run_post_route_drc`).
+Both must reconcile their internal verdict against KiCad's own
+``kicad-cli pcb drc`` so that a clean *internal* verdict can never
+overstate cleanliness when KiCad finds geometric defects the internal
+engine is structurally blind to (shorts, ``copper_edge_clearance``,
+``solder_mask_bridge``, ``silk_*`` overlaps, ...).
+
+Previously only ``kct audit`` did this (issue #3721); the route gate did
+not, so ``kct route`` could print ``DRC PASSED`` while ``kicad-cli pcb
+drc`` reported 400+ violations including real shorts (issue #3803).
+
+This module factors that reconciliation into a single shared helper,
+:func:`run_geometric_drc`, so the two entry points cannot drift again.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["GeometricDRCResult", "run_geometric_drc"]
+
+
+@dataclass
+class GeometricDRCResult:
+    """Outcome of a native ``kicad-cli pcb drc`` reconciliation run.
+
+    Attributes:
+        ran: ``True`` when kicad-cli actually executed and produced a
+            report.  ``False`` for every skip path (kicad-cli absent,
+            timeout, no report, crash) -- callers MUST treat a
+            ``ran=False`` result as "geometric DRC not performed" and
+            never as a clean PASS.
+        error_count: Number of error-severity geometric violations found
+            by kicad-cli.  ``0`` when ``ran`` is ``False``.
+        by_type: ``{kicad-cli type_str: count}`` for the error-severity
+            violations (unnamespaced; callers that need a namespace add
+            their own prefix).
+        note: A human-readable note describing the outcome -- always set
+            for skip paths (e.g. the "kicad-cli not found" fallback) and
+            ``None`` on a clean successful run.
+    """
+
+    ran: bool = False
+    error_count: int = 0
+    by_type: dict[str, int] = field(default_factory=dict)
+    note: str | None = None
+
+    @property
+    def has_errors(self) -> bool:
+        """``True`` when kicad-cli ran and found >=1 error-severity violation."""
+        return self.ran and self.error_count > 0
+
+    def top_types(self, n: int = 3) -> list[tuple[str, int]]:
+        """Return the ``n`` most frequent violation types (desc by count)."""
+        return sorted(self.by_type.items(), key=lambda x: -x[1])[:n]
+
+
+# Reuse the exact fallback wording from auditor.py so audit + route stay
+# consistent for KiCad-less environments.
+KICAD_CLI_ABSENT_NOTE = "kicad-cli not found; geometric DRC skipped"
+
+
+def run_geometric_drc(
+    pcb_path: Path | str,
+    *,
+    timeout: int = 120,
+    kicad_cli: Path | None = None,
+) -> GeometricDRCResult:
+    """Run ``kicad-cli pcb drc`` and summarize its error-severity findings.
+
+    kicad-cli loads the sibling ``<board>.kicad_pro`` emitted by ``kct
+    export`` (issue #3720), so a ``--severity-error`` run checks against
+    the manufacturer's fab-accurate rules with ``lib_footprint_mismatch``
+    / ``isolated_copper`` already downgraded below error severity.
+
+    This never raises: every failure mode (kicad-cli absent, timeout, no
+    report, parse error) returns a :class:`GeometricDRCResult` with
+    ``ran=False`` and an explanatory ``note`` so callers can degrade
+    gracefully without ever silently overstating cleanliness.
+
+    Args:
+        pcb_path: Path to the ``.kicad_pcb`` file to check.
+        timeout: Seconds before the kicad-cli invocation is abandoned.
+        kicad_cli: Explicit kicad-cli path (auto-detected when ``None``).
+
+    Returns:
+        A :class:`GeometricDRCResult` summarizing the run.
+    """
+    from kicad_tools.cli.runner import find_kicad_cli
+
+    pcb_path = Path(pcb_path)
+
+    if kicad_cli is None:
+        kicad_cli = find_kicad_cli()
+    if kicad_cli is None:
+        return GeometricDRCResult(ran=False, note=KICAD_CLI_ABSENT_NOTE)
+
+    report_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            report_path = Path(f.name)
+
+        cmd = [
+            str(kicad_cli),
+            "pcb",
+            "drc",
+            "--format",
+            "json",
+            "--severity-error",
+            "--units",
+            "mm",
+            "--output",
+            str(report_path),
+            str(pcb_path),
+        ]
+        subprocess.run(cmd, capture_output=True, timeout=timeout, check=False)
+
+        if report_path is None or not report_path.exists():
+            return GeometricDRCResult(
+                ran=False,
+                note="kicad-cli produced no DRC report (geometric DRC skipped)",
+            )
+
+        from kicad_tools.drc import DRCReport
+
+        report = DRCReport.load(report_path)
+
+        # --severity-error already filters to errors, but guard defensively
+        # in case a future kicad-cli emits mixed severities.
+        cli_errors = [v for v in report.violations if v.is_error]
+
+        by_type: dict[str, int] = {}
+        for v in cli_errors:
+            by_type[v.type_str] = by_type.get(v.type_str, 0) + 1
+
+        return GeometricDRCResult(
+            ran=True,
+            error_count=len(cli_errors),
+            by_type=by_type,
+            note=None,
+        )
+    except subprocess.TimeoutExpired:
+        return GeometricDRCResult(
+            ran=False,
+            note="kicad-cli DRC timed out (geometric DRC skipped)",
+        )
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning("Geometric DRC (kicad-cli) failed: %s", e)
+        return GeometricDRCResult(ran=False, note=f"geometric DRC failed: {e}")
+    finally:
+        if report_path is not None:
+            report_path.unlink(missing_ok=True)

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -103,11 +103,12 @@ class TestMergeGeometricDrc:
         Otherwise ``cli_violations`` is returned from DRCReport.load.
         """
         from kicad_tools import drc as drc_mod
-        from kicad_tools.audit import auditor as auditor_mod
         from kicad_tools.cli import runner as runner_mod
+        from kicad_tools.drc import geometric as geometric_mod
 
-        # _merge_geometric_drc imports find_kicad_cli from cli.runner at call
-        # time, so patch the source module.
+        # _merge_geometric_drc now delegates to the shared run_geometric_drc
+        # helper (issue #3803), which imports find_kicad_cli from cli.runner
+        # at call time, so patch the source module.
         monkeypatch.setattr(
             runner_mod,
             "find_kicad_cli",
@@ -126,7 +127,7 @@ class TestMergeGeometricDrc:
 
             return _R()
 
-        monkeypatch.setattr(auditor_mod.subprocess, "run", _fake_run)
+        monkeypatch.setattr(geometric_mod.subprocess, "run", _fake_run)
         monkeypatch.setattr(
             drc_mod.DRCReport,
             "load",

--- a/tests/test_route_post_drc_geometric.py
+++ b/tests/test_route_post_drc_geometric.py
@@ -1,0 +1,201 @@
+"""Tests for native-DRC reconciliation in the ``kct route`` post-route gate.
+
+Issue #3803: ``run_post_route_drc`` used only the internal ``DRCChecker``
+and printed ``DRC PASSED`` on a clean internal verdict, even though native
+``kicad-cli pcb drc`` could find 400+ violations (including shorts) on the
+identical file.  The route gate now reconciles against the shared
+:func:`kicad_tools.drc.run_geometric_drc` helper so that:
+
+* PASS requires BOTH the internal engine AND native kicad-cli to be clean.
+* A clean-internal / dirty-native divergence emits a loud WARNING and the
+  combined error count makes the gate FAIL.
+* When kicad-cli is absent the gate still completes but prints an explicit
+  "internal-engine-only PASS" note (no silent overstatement).
+
+The reconciliation logic is unit-tested with the geometric helper mocked so
+the suite runs in KiCad-less CI.  An optional end-to-end test that actually
+shells out to kicad-cli is gated behind a skipif.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.cli import route_cmd
+from kicad_tools.cli.runner import find_kicad_cli
+from kicad_tools.drc.geometric import GeometricDRCResult
+
+
+class _FakeViolation:
+    def __init__(self, rule_id="clearance", message="x", location=None):
+        self.rule_id = rule_id
+        self.message = message
+        self.location = location
+
+
+class _FakeResults:
+    """Stand-in for DRCResults exposing the fields run_post_route_drc reads."""
+
+    def __init__(self, errors=None, warnings=None):
+        self.errors = errors or []
+        self.warnings = warnings or []
+
+    @property
+    def error_count(self):
+        return len(self.errors)
+
+    @property
+    def warning_count(self):
+        return len(self.warnings)
+
+
+def _patch_internal(monkeypatch, results: _FakeResults):
+    """Patch PCB.load and DRCChecker so the internal engine returns ``results``."""
+    import kicad_tools.validate as validate_mod
+    from kicad_tools.schema import pcb as pcb_mod
+
+    monkeypatch.setattr(pcb_mod.PCB, "load", classmethod(lambda cls, p: object()))
+
+    class _FakeChecker:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def check_all(self, *args, **kwargs):
+            return results
+
+    # run_post_route_drc does ``from kicad_tools.validate import DRCChecker``
+    # at call time, so patch the name on the package module.
+    monkeypatch.setattr(validate_mod, "DRCChecker", _FakeChecker)
+
+
+def _patch_geometric(monkeypatch, result: GeometricDRCResult):
+    """Patch the shared run_geometric_drc helper at its import site."""
+    import kicad_tools.drc as drc_mod
+
+    monkeypatch.setattr(drc_mod, "run_geometric_drc", lambda *a, **k: result)
+
+
+def test_internal_clean_native_clean_passes(monkeypatch, tmp_path, capsys):
+    """Both engines clean -> PASS, error_count 0."""
+    _patch_internal(monkeypatch, _FakeResults())
+    _patch_geometric(monkeypatch, GeometricDRCResult(ran=True, error_count=0))
+
+    errors, warnings = route_cmd.run_post_route_drc(
+        output_path=tmp_path / "b.kicad_pcb", manufacturer="jlcpcb", layers=2
+    )
+
+    assert errors == 0
+    assert warnings == 0
+    out = capsys.readouterr().out
+    assert "DRC PASSED" in out
+    assert "both clean" in out
+
+
+def test_internal_clean_native_dirty_fails_with_divergence_warning(monkeypatch, tmp_path, capsys):
+    """Internal clean but native finds shorts -> FAIL + loud divergence warning."""
+    _patch_internal(monkeypatch, _FakeResults())
+    _patch_geometric(
+        monkeypatch,
+        GeometricDRCResult(
+            ran=True,
+            error_count=52,
+            by_type={"shorting_items": 39, "tracks_crossing": 13},
+        ),
+    )
+
+    errors, warnings = route_cmd.run_post_route_drc(
+        output_path=tmp_path / "b.kicad_pcb", manufacturer="jlcpcb", layers=4
+    )
+
+    # Native errors folded into the verdict -> gate FAILS.
+    assert errors == 52
+    out = capsys.readouterr().out
+    assert "DRC PASSED" not in out
+    assert "WARNING" in out
+    assert "kicad-cli found 52 geometric violation" in out
+    # Top native violation types are named.
+    assert "shorting_items" in out
+    assert "tracks_crossing" in out
+
+
+def test_kicad_cli_absent_falls_back_to_internal_only_pass(monkeypatch, tmp_path, capsys):
+    """kicad-cli not found -> internal-only PASS with an explicit note."""
+    _patch_internal(monkeypatch, _FakeResults())
+    _patch_geometric(
+        monkeypatch,
+        GeometricDRCResult(ran=False, note="kicad-cli not found; geometric DRC skipped"),
+    )
+
+    errors, warnings = route_cmd.run_post_route_drc(
+        output_path=tmp_path / "b.kicad_pcb", manufacturer="jlcpcb", layers=2
+    )
+
+    assert errors == 0
+    out = capsys.readouterr().out
+    assert "DRC PASSED" in out
+    assert "internal-engine-only PASS" in out
+    assert "kicad-cli not found" in out
+    assert "not authoritative" in out
+
+
+def test_kicad_cli_absent_does_not_overstate_when_internal_dirty(monkeypatch, tmp_path, capsys):
+    """When kicad-cli is absent and internal is dirty, no PASS is printed."""
+    _patch_internal(monkeypatch, _FakeResults(errors=[_FakeViolation()]))
+    _patch_geometric(monkeypatch, GeometricDRCResult(ran=False, note="kicad-cli not found"))
+
+    errors, _ = route_cmd.run_post_route_drc(
+        output_path=tmp_path / "b.kicad_pcb", manufacturer="jlcpcb", layers=2
+    )
+
+    assert errors == 1
+    out = capsys.readouterr().out
+    assert "DRC PASSED" not in out
+    assert "Errors:   1" in out
+
+
+def test_combined_error_count_sums_both_engines(monkeypatch, tmp_path):
+    """Internal errors + native errors are both reflected in the returned count."""
+    _patch_internal(monkeypatch, _FakeResults(errors=[_FakeViolation(), _FakeViolation()]))
+    _patch_geometric(monkeypatch, GeometricDRCResult(ran=True, error_count=3))
+
+    errors, _ = route_cmd.run_post_route_drc(
+        output_path=tmp_path / "b.kicad_pcb", manufacturer="jlcpcb", layers=2, quiet=True
+    )
+
+    assert errors == 5  # 2 internal + 3 native
+
+
+# ---------------------------------------------------------------------------
+# Optional end-to-end test: actually shell out to kicad-cli.  Skipped when
+# kicad-cli is not installed (mirrors tests/test_kicad_cli_roundtrip.py).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(find_kicad_cli() is None, reason="kicad-cli not installed")
+def test_run_geometric_drc_end_to_end_on_committed_board():
+    """run_geometric_drc executes against a real committed routed board.
+
+    This does not assert a specific violation count (boards evolve); it
+    only confirms the shared helper actually runs kicad-cli and returns a
+    populated result (ran=True) without raising in a KiCad environment.
+    """
+    from pathlib import Path
+
+    from kicad_tools.drc import run_geometric_drc
+
+    repo_root = Path(__file__).resolve().parents[1]
+    candidates = [
+        repo_root / "boards/external/softstart/output/softstart_routed.kicad_pcb",
+        repo_root / "boards/external/softstart/output/softstart.kicad_pcb",
+    ]
+    board = next((c for c in candidates if c.exists()), None)
+    if board is None:
+        pytest.skip("no committed routed board fixture available")
+
+    result = run_geometric_drc(board)
+
+    # In a KiCad environment the helper must actually run (ran=True) and
+    # never raise; error_count is board-dependent and not asserted.
+    assert isinstance(result, GeometricDRCResult)
+    assert result.ran is True
+    assert result.error_count >= 0


### PR DESCRIPTION
## Summary

The `kct route` success gate (`run_post_route_drc`) declared **"DRC PASSED"** using only the internal `DRCChecker`, never cross-checking native `kicad-cli pcb drc`. As a result it could report PASS while native KiCad found 400+ violations (incl. real shorts) on the *identical* file. Meanwhile `kct audit` already reconciled against native KiCad via `DesignAuditor._merge_geometric_drc` (#3721). This PR implements the curator's bounded **first slice**: extract that proven reconciliation into a single shared helper and wire it into the route gate so the two entry points cannot drift again.

## Changes

- **New shared helper** `kicad_tools.drc.run_geometric_drc(pcb_path) -> GeometricDRCResult` (`src/kicad_tools/drc/geometric.py`). Runs `kicad-cli pcb drc --severity-error`, summarizes error-severity findings into `{ran, error_count, by_type, note}`, and never raises (every skip path returns `ran=False` + an explanatory note).
- **Refactor `_merge_geometric_drc`** (`src/kicad_tools/audit/auditor.py`) to delegate to the shared helper — behavior-preserving for `kct audit` (the kicad-cli-absent suffix wording is retained).
- **Wire reconciliation into the route gate** (`src/kicad_tools/cli/route_cmd.py:run_post_route_drc`): PASS now requires BOTH the internal engine AND native kicad-cli clean. The native error count is folded into the returned `error_count`, so all four call sites fail the gate automatically.
- **Loud divergence warning** when internal is clean but native finds violations, naming the top native types (e.g. `shorting_items`, `tracks_crossing`).
- **Graceful kicad-cli-absent fallback**: still PASS on a clean internal verdict but print an explicit "internal-engine-only PASS / not authoritative" note so cleanliness is never silently overstated.

## Acceptance Criteria Verification

| Criterion (first slice) | Status | Verification |
|-----------|--------|--------------|
| Board flagged by kicad-cli no longer prints unqualified `DRC PASSED`; verdict reflects native count | ✅ | `test_internal_clean_native_dirty_fails_with_divergence_warning` (errors==52, no "DRC PASSED") |
| Loud divergence WARNING listing top native types + total | ✅ | Same test asserts WARNING + `shorting_items`/`tracks_crossing` named |
| kicad-cli absent → completes with explicit internal-only note | ✅ | `test_kicad_cli_absent_falls_back_to_internal_only_pass` |
| Single shared helper used by both audit and route (no duplicated kicad-cli logic) | ✅ | `run_geometric_drc`; `_merge_geometric_drc` now delegates; audit tests still green |
| No regression; native step skipped/mocked in KiCad-less CI | ✅ | New tests mock the helper; e2e test gated by `skipif(find_kicad_cli() is None)` |

## Test Plan

- `tests/test_route_post_drc_geometric.py` (new): unit tests for both-clean PASS, clean-internal/dirty-native FAIL + divergence warning, kicad-cli-absent fallback note, no-overstatement when internal dirty, combined count, plus a kicad-cli-gated end-to-end test on a committed routed board.
- `tests/test_audit.py`: existing `TestMergeGeometricDrc` updated to patch the new import site; confirms `kct audit` behaves identically (143 passed across audit + new tests).
- `uv run ruff check .` → All checks passed. `uv run ruff format . --check` → all formatted. mypy on touched files adds no new errors (the 2 in `auditor.py` at lines 439/571 are pre-existing on `origin/main`).

## Deferred (per curator's recommended 3-way split)

- **D1** — refine the blanket `net_number == 0` skip in `ClearanceRule` so router-emitted stray copper overlapping a real net is caught without kicad-cli.
- **D2** — `shapely` hard-dep / fail-loud: `auditor.py` sets `status.passed = True` on checker crash (silent green); same swallow risk must not exist on the route path.
- **D3** (backlog) — internal geometry-model fidelity (centerline vs polygonized copper, mask-bridge, silk overlap).

Closes #3803