### PR TITLE
feat(validate): detect net-0 stray-copper bridges between assigned nets

### DIFF
--- a/src/kicad_tools/drc/violation.py
+++ b/src/kicad_tools/drc/violation.py
@@ -141,6 +141,13 @@ class ViolationType(Enum):
     # sub-minimum gaps to committed filled_polygon geometry.
     CLEARANCE_SEGMENT_ZONE = "clearance_segment_zone"
     CLEARANCE_VIA_VIA = "clearance_via_via"
+    # Net-0 stray-copper bridge: a piece of unassigned (net 0) copper that
+    # electrically shorts two distinct assigned nets (Issue #3816).  The
+    # base ClearanceRule pairwise loop skips net 0 (legitimate unconnected
+    # copper is common), so this connectivity-based short is reported under
+    # a distinct rule_id and MUST be aliased explicitly below -- the fuzzy
+    # fallback would otherwise miscategorize it as the generic CLEARANCE.
+    CLEARANCE_NET0_BRIDGE = "clearance_net0_bridge"
     # Differential-pair within-pair clearance (Issue #2560, Epic #2556 Phase 1D).
     # Distinct from the generic CLEARANCE family because it validates the
     # *intra-pair* gap (allowed to be tighter than the manufacturer's inter-pair
@@ -282,6 +289,11 @@ class ViolationType(Enum):
             "clearance_segment_segment": cls.CLEARANCE_SEGMENT_SEGMENT,
             "clearance_segment_via": cls.CLEARANCE_SEGMENT_VIA,
             "clearance_via_via": cls.CLEARANCE_VIA_VIA,
+            # Net-0 stray-copper bridge (Issue #3816).  MUST be aliased
+            # explicitly -- the fuzzy "clearance" fallback below would
+            # otherwise drop through to the generic CLEARANCE type and
+            # mask the new short class from downstream exact-type filters.
+            "clearance_net0_bridge": cls.CLEARANCE_NET0_BRIDGE,
             # clearance subtypes using "trace" (synonym for "segment")
             "clearance_pad_trace": cls.CLEARANCE_PAD_SEGMENT,
             "clearance_trace_trace": cls.CLEARANCE_SEGMENT_SEGMENT,

--- a/src/kicad_tools/validate/rules/clearance.py
+++ b/src/kicad_tools/validate/rules/clearance.py
@@ -602,6 +602,16 @@ class ClearanceRule(DRCRule):
             for v in violations:
                 results.add(v)
 
+            # Net-0 bridge detection (Issue #3816).  The pairwise loop in
+            # ``_check_layer`` deliberately skips net 0 to avoid flooding
+            # false positives on legitimate unconnected copper (e.g.
+            # board 04's 31 net-0 QFP pins).  That skip masks a genuine
+            # short class: a piece of stray net-0 copper that physically
+            # bridges two different ASSIGNED nets.  Detect that explicitly
+            # as a connectivity property of net-0 copper islands.
+            for v in self._check_net0_bridges(pcb, layer_name, min_clearance):
+                results.add(v)
+
         # Count rules checked (one per layer)
         results.rules_checked = len(pcb.copper_layers)
 
@@ -743,6 +753,164 @@ class ClearanceRule(DRCRule):
                 elements.append(CopperElement.from_via(via))
 
         return elements
+
+    def _elements_touch(self, a: CopperElement, b: CopperElement) -> bool:
+        """Return ``True`` when two copper elements are electrically joined.
+
+        "Touch" means the edge-to-edge clearance is at or below the
+        co-location epsilon (overlapping copper, or coincident within
+        manufacturing-irrelevant float noise).  Used both to group net-0
+        copper into islands and to decide whether an island contacts an
+        assigned net.
+
+        The router's in-pad escape places an inner-layer segment endpoint
+        at *exactly* a via center (router invariant), so a net-0 segment
+        endpoint coinciding with a via center is a modeling artifact, not
+        a real copper join -- mirror the suppression in ``_check_layer``
+        (Issue #2706) so it does not fabricate an island/contact edge.
+        """
+        if {a.element_type, b.element_type} == {"segment", "via"}:
+            seg = a if a.element_type == "segment" else b
+            via = b if a.element_type == "segment" else a
+            sx1, sy1, sx2, sy2, _ = seg.geometry
+            vx, vy, _, _ = via.geometry
+            if (
+                math.hypot(sx1 - vx, sy1 - vy) < _COLOCATION_EPSILON_MM
+                or math.hypot(sx2 - vx, sy2 - vy) < _COLOCATION_EPSILON_MM
+            ):
+                return False
+
+        clearance, _, _ = _calculate_clearance(a, b)
+        return clearance <= _COLOCATION_EPSILON_MM
+
+    def _check_net0_bridges(
+        self,
+        pcb: PCB,
+        layer_name: str,
+        min_clearance: float,
+    ) -> list[DRCViolation]:
+        """Flag net-0 copper that electrically bridges two assigned nets.
+
+        A net-0 copper element (stray fill / unassigned router copper) is
+        only a defect when it touches copper of **two or more distinct
+        assigned (nonzero) nets** at once -- that is a short between those
+        nets carried by a piece of copper that itself has no net.  A net-0
+        element touching zero or one assigned net is legitimate
+        unconnected copper (unused pads, NPTH, test points) and must NOT
+        fire; that is exactly why the base pairwise loop skips net 0.
+
+        Algorithm (connectivity, not full DRC):
+
+        1. Split this layer's copper into net-0 elements and assigned-net
+           elements.
+        2. Union-find net-0 elements that touch each other into islands
+           (so a cluster of adjacent net-0 QFP pins is a single island,
+           which is harmless if it contacts < 2 assigned nets).
+        3. For each island, collect the set of distinct assigned net
+           numbers whose copper any island member touches.
+        4. Emit one ``clearance_net0_bridge`` error per island whose set
+           has >= 2 distinct nets, naming the two bridged nets.
+
+        See Issue #3816.
+        """
+        elements = self._collect_elements(pcb, layer_name)
+        net0 = [e for e in elements if e.net_number == 0]
+        assigned = [e for e in elements if e.net_number != 0]
+
+        if not net0 or not assigned:
+            # No net-0 copper, or no assigned copper for it to bridge.
+            return []
+
+        # --- 2. Group net-0 elements into touching islands (union-find). ---
+        parent = list(range(len(net0)))
+
+        def _find(i: int) -> int:
+            while parent[i] != i:
+                parent[i] = parent[parent[i]]
+                i = parent[i]
+            return i
+
+        def _union(i: int, j: int) -> None:
+            ri, rj = _find(i), _find(j)
+            if ri != rj:
+                parent[ri] = rj
+
+        for i in range(len(net0)):
+            for j in range(i + 1, len(net0)):
+                if self._elements_touch(net0[i], net0[j]):
+                    _union(i, j)
+
+        islands: dict[int, list[int]] = {}
+        for i in range(len(net0)):
+            islands.setdefault(_find(i), []).append(i)
+
+        # --- 3/4. For each island, find distinct assigned nets it touches. ---
+        violations: list[DRCViolation] = []
+        for members in islands.values():
+            touched: dict[int, CopperElement] = {}
+            contact_elem: CopperElement | None = None
+            for idx in members:
+                n0 = net0[idx]
+                for a in assigned:
+                    if a.net_number in touched:
+                        continue
+                    if self._elements_touch(n0, a):
+                        touched[a.net_number] = a
+                        if contact_elem is None:
+                            contact_elem = n0
+
+            if len(touched) >= 2:
+                violations.append(
+                    self._create_net0_bridge_violation(
+                        net0[members[0]] if contact_elem is None else contact_elem,
+                        list(touched.values()),
+                        min_clearance,
+                        layer_name,
+                    )
+                )
+
+        return violations
+
+    def _create_net0_bridge_violation(
+        self,
+        net0_elem: CopperElement,
+        bridged: list[CopperElement],
+        required: float,
+        layer: str,
+    ) -> DRCViolation:
+        """Build the ``clearance_net0_bridge`` short violation.
+
+        Names the first two bridged assigned nets (deterministically
+        sorted by net number) and locates the violation at the bridging
+        net-0 element.
+        """
+        bridged_sorted = sorted(bridged, key=lambda e: e.net_number)
+        a, b = bridged_sorted[0], bridged_sorted[1]
+        name_a = a.net_name or f"net{a.net_number}"
+        name_b = b.net_name or f"net{b.net_number}"
+
+        # Locate at the net-0 element's representative point.
+        gx = net0_elem.geometry
+        if net0_elem.element_type == "segment":
+            loc_x = (gx[0] + gx[2]) / 2
+            loc_y = (gx[1] + gx[3]) / 2
+        else:
+            loc_x, loc_y = gx[0], gx[1]
+
+        return DRCViolation(
+            rule_id="clearance_net0_bridge",
+            severity="error",
+            message=(
+                f"Net-0 copper ({net0_elem.reference}) bridges nets "
+                f"{name_a} and {name_b} (stray-copper short)"
+            ),
+            location=(round(loc_x, 3), round(loc_y, 3)),
+            layer=layer,
+            actual_value=0.0,
+            required_value=required,
+            items=(net0_elem.reference, a.reference, b.reference),
+            nets=(name_a, name_b),
+        )
 
     def _create_violation(
         self,

--- a/tests/test_validate_clearance_net0_bridge.py
+++ b/tests/test_validate_clearance_net0_bridge.py
@@ -1,0 +1,220 @@
+"""Tests for net-0 stray-copper bridge detection (Issue #3816).
+
+The base :class:`~kicad_tools.validate.rules.clearance.ClearanceRule`
+pairwise loop deliberately skips net 0 (legitimate unconnected copper --
+unused pads, NPTH, test points -- is common and must not flood
+``clearance_pad_pad`` false positives, e.g. board 04's 31 net-0 QFP
+pins).  That skip masks a genuine short class: a piece of stray net-0
+copper that physically bridges two distinct *assigned* nets.
+
+These tests cover the bounded bridge detector added to ``ClearanceRule``:
+
+* positive -- a net-0 island bridging two assigned nets fires exactly
+  one ``clearance_net0_bridge`` error naming both nets;
+* negative -- a lone net-0 element near zero/one assigned net stays
+  silent;
+* negative -- a cluster of mutually-touching net-0 elements that touches
+  no assigned net stays silent;
+* regression -- the routed boards 01..06 produce zero net-0 bridge
+  violations (the false-positive guard the issue mandates).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.schema.pcb import PCB
+from kicad_tools.validate import DRCChecker
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_HEADER = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "NET_A")
+  (net 2 "NET_B")
+"""
+
+
+def _load(tmp_path: Path, body: str) -> PCB:
+    pcb_path = tmp_path / "test.kicad_pcb"
+    pcb_path.write_text(_HEADER + body + "\n)\n")
+    return PCB.load(pcb_path)
+
+
+def _bridge_violations(pcb: PCB):
+    checker = DRCChecker(pcb, manufacturer="jlcpcb", layers=2, copper_oz=1.0)
+    results = checker.check_clearances()
+    return [v for v in results.violations if v.rule_id == "clearance_net0_bridge"]
+
+
+# ---------------------------------------------------------------------------
+# Positive: net-0 island bridges two assigned nets
+# ---------------------------------------------------------------------------
+
+
+class TestNet0BridgePositive:
+    """A net-0 segment overlapping two assigned-net pads fires one short."""
+
+    def test_net0_segment_bridging_two_nets_fires_once(self, tmp_path: Path):
+        # Two assigned pads, one on NET_A (1) at x=100, one on NET_B (2)
+        # at x=110.  A net-0 segment runs straight from one to the other,
+        # physically connecting both -> a stray-copper short.
+        body = """\
+  (footprint "test:pad" (layer "F.Cu") (at 100 100)
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "NET_A")))
+  (footprint "test:pad2" (layer "F.Cu") (at 110 100)
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 2 "NET_B")))
+  (segment (start 100 100) (end 110 100) (width 0.25) (layer "F.Cu") (net 0) (uuid "seg-stray"))"""
+        pcb = _load(tmp_path, body)
+
+        bridges = _bridge_violations(pcb)
+        assert len(bridges) == 1
+        v = bridges[0]
+        assert v.severity == "error"
+        assert v.rule_id == "clearance_net0_bridge"
+        assert set(v.nets) == {"NET_A", "NET_B"}
+
+    def test_net0_island_of_multiple_segments_fires_once(self, tmp_path: Path):
+        # Two touching net-0 segments form a single island that, together,
+        # reaches both assigned pads.  Exactly one violation (per island),
+        # not one per touching pair.
+        body = """\
+  (footprint "test:pad" (layer "F.Cu") (at 100 100)
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "NET_A")))
+  (footprint "test:pad2" (layer "F.Cu") (at 120 100)
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 2 "NET_B")))
+  (segment (start 100 100) (end 110 100) (width 0.25) (layer "F.Cu") (net 0) (uuid "seg-a"))
+  (segment (start 110 100) (end 120 100) (width 0.25) (layer "F.Cu") (net 0) (uuid "seg-b"))"""
+        pcb = _load(tmp_path, body)
+
+        bridges = _bridge_violations(pcb)
+        assert len(bridges) == 1
+        assert set(bridges[0].nets) == {"NET_A", "NET_B"}
+
+
+# ---------------------------------------------------------------------------
+# Negative: lone net-0 element near zero/one assigned net
+# ---------------------------------------------------------------------------
+
+
+class TestNet0BridgeNegativeLone:
+    """A net-0 element touching < 2 assigned nets is legitimate copper."""
+
+    def test_lone_net0_pad_near_one_net_silent(self, tmp_path: Path):
+        # A single net-0 pad 0.5 mm from a NET_A pad -- touches one
+        # assigned net at most.  No bridge.
+        body = """\
+  (footprint "test:pad" (layer "F.Cu") (at 100 100)
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "NET_A")))
+  (footprint "test:nc" (layer "F.Cu") (at 101.5 100)
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 0)))"""
+        pcb = _load(tmp_path, body)
+        assert _bridge_violations(pcb) == []
+
+    def test_net0_pad_overlapping_one_net_silent(self, tmp_path: Path):
+        # Even when the net-0 pad directly overlaps a single assigned
+        # net, only one net is touched -> not a bridge.
+        body = """\
+  (footprint "test:pad" (layer "F.Cu") (at 100 100)
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "NET_A")))
+  (footprint "test:nc" (layer "F.Cu") (at 100 100)
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 0)))"""
+        pcb = _load(tmp_path, body)
+        assert _bridge_violations(pcb) == []
+
+
+# ---------------------------------------------------------------------------
+# Negative: net-0 cluster touching only itself (board-04 QFP analogue)
+# ---------------------------------------------------------------------------
+
+
+class TestNet0BridgeNegativeCluster:
+    """Adjacent net-0 copper that touches no assigned net stays silent."""
+
+    def test_two_touching_net0_pads_silent(self, tmp_path: Path):
+        body = """\
+  (footprint "test:a" (layer "F.Cu") (at 100 100)
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 0)))
+  (footprint "test:b" (layer "F.Cu") (at 100.5 100)
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 0)))"""
+        pcb = _load(tmp_path, body)
+        assert _bridge_violations(pcb) == []
+
+    def test_qfp_like_net0_cluster_near_one_net_silent(self, tmp_path: Path):
+        # Replicate board-04's geometry: a row of mutually-adjacent net-0
+        # fine-pitch pins, adjacent to at most one assigned net.  This is
+        # the case that would over-fire if net 0 were treated as foreign.
+        pins = []
+        for i in range(6):
+            x = 100 + i * 0.5
+            pins.append(
+                f'  (footprint "test:p{i}" (layer "F.Cu") (at {x} 100)\n'
+                f'    (pad "1" smd rect (at 0 0) (size 0.3 1) (layers "F.Cu") (net 0)))'
+            )
+        # One assigned-net pad adjacent to the cluster on one side.
+        pins.append(
+            '  (footprint "test:assigned" (layer "F.Cu") (at 99 100)\n'
+            '    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "NET_A")))'
+        )
+        body = "\n".join(pins)
+        pcb = _load(tmp_path, body)
+        assert _bridge_violations(pcb) == []
+
+
+# ---------------------------------------------------------------------------
+# Regression: routed boards 01..06 produce no net-0 bridge violations
+# ---------------------------------------------------------------------------
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_ROUTED_BOARDS = {
+    "01-voltage-divider": "voltage_divider_routed.kicad_pcb",
+    "02-charlieplex-led": "charlieplex_3x3_routed.kicad_pcb",
+    "03-usb-joystick": "usb_joystick_routed.kicad_pcb",
+    "04-stm32-devboard": "stm32_devboard_routed.kicad_pcb",
+    "05-bldc-motor-controller": "bldc_controller_routed.kicad_pcb",
+    "06-diffpair-test": "diffpair_test_routed.kicad_pcb",
+}
+
+
+class TestNet0BridgeBoardRegression:
+    """The net-0 bridge detector must not fire on the real routed boards.
+
+    Boards 03/04/05 carry legitimate unconnected net-0 pads (2 / 31 / 4).
+    None of them bridge two assigned nets, so the detector must report
+    zero ``clearance_net0_bridge`` violations -- the false-positive guard
+    the issue mandates.
+    """
+
+    @pytest.mark.parametrize("board_dir,pcb_name", sorted(_ROUTED_BOARDS.items()))
+    def test_routed_board_has_no_net0_bridge(self, board_dir: str, pcb_name: str):
+        pcb_path = _REPO_ROOT / "boards" / board_dir / "output" / pcb_name
+        if not pcb_path.exists():
+            pytest.skip(f"routed board artifact missing: {pcb_path}")
+
+        pcb = PCB.load(pcb_path)
+        # 4-layer profile covers the 4-layer boards; 2-layer boards ignore
+        # the extra copper layers harmlessly.
+        checker = DRCChecker(pcb, manufacturer="jlcpcb", layers=4, copper_oz=1.0)
+        results = checker.check_clearances()
+        bridges = [v for v in results.violations if v.rule_id == "clearance_net0_bridge"]
+        assert bridges == [], (
+            f"{board_dir}: unexpected net-0 bridge violations: {[v.message for v in bridges]}"
+        )


### PR DESCRIPTION
## Summary

`ClearanceRule`'s O(n^2) pairwise loop skips any pair where either element is on net 0. That skip is load-bearing (it prevents flooding `clearance_pad_pad` false positives on legitimate unconnected copper, e.g. board 04's 31 net-0 QFP pins), but it masked a genuine short class: a piece of stray net-0 copper that physically bridges two distinct assigned nets carries the short while having no net of its own, so no element pair ever fired. KiCad's native DRC catches this via connectivity analysis; the internal engine did not.

This adds a bounded, connectivity-based **net-0 bridge** detector inside `ClearanceRule` — not a reimplementation of full DRC.

## Changes

- `src/kicad_tools/validate/rules/clearance.py`:
  - `_check_net0_bridges()` — runs per copper layer from `check()`, alongside the existing pairwise pass. Groups mutually-touching net-0 copper elements into islands via union-find, then for each island collects the distinct assigned (nonzero) nets it touches. Fires **one** `clearance_net0_bridge` error (severity `error`) only when an island bridges **>= 2 distinct assigned nets**, naming both nets in `nets=(...)`.
  - `_elements_touch()` — reuses the existing `_calculate_clearance` distance math and the `_COLOCATION_EPSILON_MM` in-pad segment/via colocation guard (mirroring the pairwise-loop suppression from Issue #2706) so a net-0 segment endpoint coinciding with a via center is not misread as a bridge.
  - `_create_net0_bridge_violation()` — builds the violation, deterministically naming the two lowest-numbered bridged nets.
- `src/kicad_tools/drc/violation.py`: register `CLEARANCE_NET0_BRIDGE` enum member + explicit `from_string` alias so the new rule_id is not silently miscategorized as the generic `CLEARANCE` by the fuzzy fallback.
- `tests/test_validate_clearance_net0_bridge.py` (new): positive, negative, and board-regression coverage.

The net-0 skip in the pairwise loop is intentionally left in place — `clearance_pad_pad` etc. still skip net 0; the new connectivity check is the only path that examines net-0 copper.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Net-0 island bridging two assigned nets flagged by internal `DRCChecker` (no kicad-cli) | ✅ | `test_net0_segment_bridging_two_nets_fires_once` via `check_clearances()` |
| Net-0 element adjacent to 0/1 assigned nets produces no new violation | ✅ | `test_lone_net0_pad_near_one_net_silent`, `test_net0_pad_overlapping_one_net_silent` |
| Adjacent net-0-to-net-0 copper (board-04 QFP analogue) produces no new violation | ✅ | `test_two_touching_net0_pads_silent`, `test_qfp_like_net0_cluster_near_one_net_silent` |
| No new violations on routed boards 01..06 (counts unchanged) | ✅ | All six boards report 0 `clearance_net0_bridge` and total clearance count unchanged; `TestNet0BridgeBoardRegression` parametrized over 01..06 |
| Violation has `severity="error"`, distinct `rule_id`, names both nets | ✅ | Asserted in positive test |
| Regression test with in-memory fixtures (positive + two negatives) | ✅ | 12 tests in new file, all passing |

## Test Plan

- `uv run pytest tests/test_validate_clearance_net0_bridge.py` — 12 passed.
- Manual check: all of boards 01..06 routed PCBs report `net0_bridge=0` and unchanged total clearance counts.
- `uv run ruff check` + `ruff format --check` clean on touched files.
- mypy: no new errors from added code (pre-existing shapely-stub / unused-ignore errors in unrelated zone-fill code remain).

Note: pre-existing failures in `tests/test_validate_segment_zone_clearance.py` exist on the base commit (verified via `git stash`) and are unrelated to this change (shapely zone-fill machinery, untouched here).

Closes #3816