### PR TITLE
fix(drc): make audit gate fail-loud when geometric DRC did not run

### DIFF
--- a/src/kicad_tools/audit/auditor.py
+++ b/src/kicad_tools/audit/auditor.py
@@ -53,7 +53,18 @@ class ERCStatus:
 
 @dataclass
 class DRCStatus:
-    """DRC check results."""
+    """DRC check results.
+
+    ``geometric_drc_ran`` records whether the native ``kicad-cli pcb drc``
+    engine actually executed and produced a report (issue #3817).  It is
+    *distinct* from ``passed``: a board can be ``passed=True`` per the
+    internal ``--mfr`` rule engine while the geometric engine did not run
+    (kicad-cli absent / timed out / crashed), in which case the verdict is
+    **not authoritative** -- the internal engine is structurally blind to
+    several KiCad violation classes (shorts, ``copper_edge_clearance``,
+    ``solder_mask_bridge``, ``silk_*`` overlaps).  Defaults to ``False`` so
+    an un-reconciled status is never silently treated as authoritative.
+    """
 
     error_count: int = 0
     warning_count: int = 0
@@ -62,6 +73,12 @@ class DRCStatus:
     details: str = ""
     report_path: Path | None = None
     violations_by_type: dict[str, int] = field(default_factory=dict)
+    # True only when kicad-cli geometric DRC actually ran and produced a
+    # report.  When False, a ``passed=True`` verdict is NOT authoritative.
+    geometric_drc_ran: bool = False
+    # Human-readable note describing why geometric DRC did not run (skip
+    # path) -- mirrors GeometricDRCResult.note.  None when it ran cleanly.
+    geometric_drc_note: str | None = None
 
     def to_dict(self) -> dict:
         result = {
@@ -70,6 +87,8 @@ class DRCStatus:
             "blocking_count": self.blocking_count,
             "passed": self.passed,
             "details": self.details,
+            "geometric_drc_ran": self.geometric_drc_ran,
+            "geometric_drc_note": self.geometric_drc_note,
         }
         if self.violations_by_type:
             result["violations_by_type"] = dict(self.violations_by_type)
@@ -790,10 +809,28 @@ class ManufacturingAudit:
                 top_rules = sorted(error_rules.items(), key=lambda x: -x[1])[:3]
                 status.details = ", ".join(f"{r[0]} ({r[1]})" for r in top_rules)
 
+        except ImportError as e:
+            # An optional geometry backend (e.g. shapely) is not installed,
+            # so the internal rule engine could not run.  This is the same
+            # class of "could not verify" as kicad-cli being absent: per
+            # issue #3817 we must NOT report it as a hard FAIL (that would
+            # regress backend-less CI), but it is equally NOT an
+            # authoritative clean PASS.  Leave status.passed untouched and
+            # let _merge_geometric_drc / audit_cmd render the verdict as
+            # non-authoritative (geometric_drc_ran stays False).
+            logger.warning(f"DRC check could not run (optional backend absent): {e}")
+            note = f"internal DRC engine could not run: {e}"
+            status.details = f"{status.details}; {note}" if status.details else note
+
         except Exception as e:
+            # A genuine internal DRC checker crash must NOT be reported as a
+            # clean PASS (issue #3817).  Surface it as a could-not-verify
+            # failure so the verdict is fail-loud rather than a false green.
             logger.warning(f"DRC check failed: {e}")
-            status.details = str(e)
-            status.passed = True  # Don't fail on check errors
+            status.details = f"DRC check could not run: {e}"
+            status.passed = False
+            status.error_count = max(status.error_count, 1)
+            status.blocking_count = max(status.blocking_count, 1)
 
         # Merge KiCad's geometric DRC (kicad-cli pcb drc) into the same
         # status.  The two engines catch different real defects: the --mfr
@@ -838,15 +875,23 @@ class ManufacturingAudit:
         result = run_geometric_drc(self.pcb_path)
 
         if not result.ran:
-            # kicad-cli absent / timed out / no report / crashed: append the
-            # helper's explanatory note and leave the --mfr count standing.
+            # kicad-cli absent / timed out / no report / crashed: the
+            # geometric engine did NOT run, so a passing --mfr verdict is
+            # not authoritative (issue #3817).  Record that fact distinctly
+            # from passed -- do NOT flip status.passed here -- and surface
+            # the note so audit_cmd.py can render a third verdict state.
+            status.geometric_drc_ran = False
             note = result.note
+            status.geometric_drc_note = note
             if note == "kicad-cli not found; geometric DRC skipped":
                 # Preserve the audit-specific suffix for backward-compat.
                 note = "kicad-cli not found; geometric DRC skipped (--mfr count only)"
             if note:
                 status.details = f"{status.details}; {note}" if status.details else note
             return
+
+        # The geometric engine ran -- the verdict is now authoritative.
+        status.geometric_drc_ran = True
 
         if result.error_count > 0:
             status.error_count += result.error_count

--- a/src/kicad_tools/cli/audit_cmd.py
+++ b/src/kicad_tools/cli/audit_cmd.py
@@ -211,8 +211,23 @@ def output_table(result: AuditResult, verbose: bool = False) -> None:
 
     # DRC
     drc = result.drc
-    drc_status = "PASS" if drc.passed else "FAIL"
-    drc_icon = "OK" if drc.passed else "X"
+    # Three verdict states (issue #3817):
+    #   FAIL                       -> internal/geometric engine found errors
+    #   PASS                       -> clean AND geometric engine actually ran
+    #   PASS (NOT AUTHORITATIVE)   -> clean per --mfr engine but kicad-cli
+    #                                 geometric DRC did not run; the internal
+    #                                 engine is structurally blind to several
+    #                                 KiCad violation classes, so this PASS
+    #                                 cannot be trusted as a clean verdict.
+    if not drc.passed:
+        drc_status = "FAIL"
+        drc_icon = "X"
+    elif not drc.geometric_drc_ran:
+        drc_status = "PASS (NOT AUTHORITATIVE -- geometric DRC did not run)"
+        drc_icon = "!!"
+    else:
+        drc_status = "PASS"
+        drc_icon = "OK"
     print(f"\n[{drc_icon}] DRC (Design Rules Check): {drc_status}")
     if drc.error_count > 0 or drc.warning_count > 0:
         print(f"    Errors: {drc.error_count}, Warnings: {drc.warning_count}")
@@ -220,6 +235,14 @@ def output_table(result: AuditResult, verbose: bool = False) -> None:
             print(f"    Blocking: {drc.blocking_count} (must fix)")
         if drc.details:
             print(f"    Details: {drc.details}")
+    elif drc.passed and not drc.geometric_drc_ran:
+        # Clean board but geometric engine skipped: always surface the
+        # qualification (previously gated behind error_count > 0 so it was
+        # never shown on a clean board -- the core false-green defect).
+        note = drc.geometric_drc_note or "native kicad-cli geometric DRC was not run"
+        print(f"    Note: {note}")
+        print("    Verdict is NOT authoritative -- geometric defects (shorts,")
+        print("    edge clearance, mask bridges) could not be checked.")
 
     # Sync drift (schematic <-> PCB)
     sync = result.sync

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -192,6 +192,8 @@ class TestMergeGeometricDrc:
         assert status.blocking_count == 0
         assert status.passed is True
         assert status.violations_by_type == {}
+        # Geometric engine actually ran -> verdict is authoritative.
+        assert status.geometric_drc_ran is True
 
     def test_graceful_fallback_when_kicad_cli_absent(self, tmp_path, monkeypatch):
         """Missing kicad-cli leaves --mfr count intact and adds a note."""
@@ -211,6 +213,10 @@ class TestMergeGeometricDrc:
         assert status.blocking_count == 4
         assert status.violations_by_type == {"clearance_pad_zone": 4}
         assert "kicad-cli not found" in status.details
+        # Geometric engine did NOT run -> verdict is not authoritative.
+        assert status.geometric_drc_ran is False
+        assert status.geometric_drc_note is not None
+        assert "kicad-cli not found" in status.geometric_drc_note
 
     def test_cli_warnings_do_not_count(self, tmp_path, monkeypatch):
         """Non-error kicad-cli violations are ignored (severity-error guard)."""
@@ -228,6 +234,175 @@ class TestMergeGeometricDrc:
 
         assert status.error_count == 1
         assert status.violations_by_type == {"kicad-cli:starved_thermal": 1}
+
+
+class TestDRCStatusGeometricRan:
+    """Tests for the geometric_drc_ran authoritative signal (issue #3817)."""
+
+    def test_default_geometric_drc_ran_is_false(self):
+        """A fresh DRCStatus is never silently authoritative."""
+        status = DRCStatus()
+        assert status.geometric_drc_ran is False
+        assert status.geometric_drc_note is None
+
+    def test_to_dict_includes_geometric_drc_fields(self):
+        """to_dict() serializes the authoritative signal + note."""
+        status = DRCStatus(geometric_drc_ran=True)
+        d = status.to_dict()
+        assert d["geometric_drc_ran"] is True
+        assert "geometric_drc_note" in d
+
+    def test_to_dict_geometric_drc_ran_default(self):
+        """to_dict() reports geometric_drc_ran=False by default."""
+        d = DRCStatus().to_dict()
+        assert d["geometric_drc_ran"] is False
+        assert d["geometric_drc_note"] is None
+
+
+class TestMergeGeometricDrcAuthoritative:
+    """Issue #3817: ran=False must not read as an authoritative PASS."""
+
+    def _make_audit(self, tmp_path):
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+        return ManufacturingAudit(pcb, manufacturer="jlcpcb")
+
+    def test_clean_board_with_cli_absent_is_not_authoritative(self, tmp_path, monkeypatch):
+        """Clean --mfr board + kicad-cli absent -> passed but NOT authoritative."""
+        import kicad_tools.drc as drc_mod
+        from kicad_tools.drc import GeometricDRCResult
+
+        audit = self._make_audit(tmp_path)
+        status = DRCStatus(error_count=0, blocking_count=0, passed=True)
+
+        # _merge_geometric_drc does `from kicad_tools.drc import
+        # run_geometric_drc` at call time, so patch the package attribute.
+        monkeypatch.setattr(
+            drc_mod,
+            "run_geometric_drc",
+            lambda *a, **k: GeometricDRCResult(
+                ran=False, note="kicad-cli not found; geometric DRC skipped"
+            ),
+        )
+
+        audit._merge_geometric_drc(status)
+
+        # passed is untouched (still True per --mfr) but the geometric engine
+        # did not run, so downstream rendering must qualify the verdict.
+        assert status.passed is True
+        assert status.geometric_drc_ran is False
+        assert status.geometric_drc_note is not None
+
+    def test_clean_board_with_cli_present_is_authoritative(self, tmp_path, monkeypatch):
+        """Clean --mfr board + kicad-cli ran clean -> authoritative PASS."""
+        import kicad_tools.drc as drc_mod
+        from kicad_tools.drc import GeometricDRCResult
+
+        audit = self._make_audit(tmp_path)
+        status = DRCStatus(error_count=0, blocking_count=0, passed=True)
+
+        monkeypatch.setattr(
+            drc_mod,
+            "run_geometric_drc",
+            lambda *a, **k: GeometricDRCResult(ran=True, error_count=0),
+        )
+
+        audit._merge_geometric_drc(status)
+
+        assert status.passed is True
+        assert status.geometric_drc_ran is True
+
+
+class TestCheckDrcCrashNotGreen:
+    """Issue #3817: a crashed internal DRC checker must NOT report PASS."""
+
+    def test_checker_crash_does_not_pass(self, tmp_path, monkeypatch):
+        """An exception inside DRCChecker.check_all yields passed=False."""
+        import kicad_tools.drc as drc_mod
+        import kicad_tools.validate as validate_mod
+        from kicad_tools.drc import GeometricDRCResult
+
+        pcb_path = tmp_path / "board.kicad_pcb"
+        pcb_path.write_text("(kicad_pcb)")
+        audit = ManufacturingAudit(pcb_path, manufacturer="jlcpcb")
+
+        # Make the internal checker explode; isolate from kicad-cli so the
+        # crash path is what drives the verdict.
+        class _BoomChecker:
+            def __init__(self, *a, **k):
+                pass
+
+            def check_all(self, *a, **k):
+                raise RuntimeError("checker exploded")
+
+        monkeypatch.setattr(validate_mod, "DRCChecker", _BoomChecker)
+        monkeypatch.setattr(
+            drc_mod,
+            "run_geometric_drc",
+            lambda *a, **k: GeometricDRCResult(ran=False, note="skipped"),
+        )
+
+        status = audit._check_drc(_DummyPcb())
+
+        # A crashed checker must NOT be reported as a clean PASS.
+        assert status.passed is False
+        assert status.blocking_count >= 1
+        assert "could not run" in status.details
+
+
+class _DummyPcb:
+    """Minimal PCB stand-in -- DRCChecker is mocked so it is never used."""
+
+
+class TestAuditTableDrcVerdictRendering:
+    """Issue #3817: output_table renders three distinct DRC verdict states."""
+
+    def test_clean_but_not_authoritative_is_not_bare_pass(self, capsys):
+        """Clean board with geometric DRC skipped -> qualified verdict."""
+        from kicad_tools.cli.audit_cmd import output_table
+
+        result = AuditResult()
+        result.drc.passed = True
+        result.drc.geometric_drc_ran = False
+        result.drc.geometric_drc_note = "kicad-cli not found; geometric DRC skipped"
+
+        output_table(result)
+        out = capsys.readouterr().out
+
+        # The DRC line must NOT read as a bare authoritative PASS.
+        assert "NOT AUTHORITATIVE" in out
+        # And the skip note must be surfaced even on a clean board.
+        assert "kicad-cli not found" in out
+
+    def test_authoritative_clean_pass_unchanged(self, capsys):
+        """Clean board with geometric DRC run clean -> plain PASS."""
+        from kicad_tools.cli.audit_cmd import output_table
+
+        result = AuditResult()
+        result.drc.passed = True
+        result.drc.geometric_drc_ran = True
+
+        output_table(result)
+        out = capsys.readouterr().out
+
+        assert "DRC (Design Rules Check): PASS" in out
+        assert "NOT AUTHORITATIVE" not in out
+
+    def test_drc_fail_renders_fail(self, capsys):
+        """A failing DRC still renders FAIL regardless of authoritative flag."""
+        from kicad_tools.cli.audit_cmd import output_table
+
+        result = AuditResult()
+        result.drc.passed = False
+        result.drc.error_count = 3
+        result.drc.blocking_count = 3
+        result.drc.geometric_drc_ran = True
+
+        output_table(result)
+        out = capsys.readouterr().out
+
+        assert "DRC (Design Rules Check): FAIL" in out
+        assert "NOT AUTHORITATIVE" not in out
 
 
 class TestAuditResult:


### PR DESCRIPTION
## Summary

Closes #3817.

The `kct audit` gate could print a bare, unqualified `PASS` on a clean `--mfr` board even when native kicad-cli geometric DRC never ran — masking geometric defects (shorts, `copper_edge_clearance`, `solder_mask_bridge`, `silk_*` overlaps) the internal engine is structurally blind to. The route gate was already fixed (#3815); this brings the audit gate to parity using the **fail-loud, not hard-dep** approach the curator recommended (kicad-cli is a KiCad install, not a pip dep, and KiCad-less CI must still produce a qualified verdict).

## Changes

- **`DRCStatus`** (`auditor.py`): add `geometric_drc_ran: bool = False` (default False so an un-reconciled status is never silently authoritative) and `geometric_drc_note: str | None`; serialize both in `to_dict()`.
- **`_merge_geometric_drc`**: set `geometric_drc_ran` from `result.ran` and record the skip note on the `ran=False` path. Never flips `status.passed`.
- **`_check_drc` exception handling**: a genuine checker crash no longer coerces `status.passed = True` (now fail-loud: `passed=False`, `blocking_count>=1`). An optional-backend absence (`ImportError`, e.g. shapely) is treated as could-not-verify / non-authoritative rather than a hard FAIL, so backend-less CI keeps producing a qualified verdict instead of regressing to red.
- **`audit_cmd.output_table`**: render a third verdict state `PASS (NOT AUTHORITATIVE -- geometric DRC did not run)` and always surface the skip note on clean boards (previously gated behind `error_count > 0`, so it was never displayed).

## Out of scope (unchanged)
- Route gate (`run_post_route_drc`) — already correct (#3815); left untouched, existing tests cover the `ran=False` not-authoritative contract.
- No DRC rules reimplemented; no shapely/`board_geometry.py`/`connectivity.py` changes; no hard pip dep; the sibling `passed = True` anti-patterns in non-DRC checks (connectivity/compat/sync) are a separate follow-up.

## Tests
- Clean board + kicad-cli absent → not a bare PASS (renders NOT AUTHORITATIVE + note).
- Checker crash (`RuntimeError`) → `passed` is not True; details record the error.
- Authoritative clean PASS preserved when kicad-cli ran clean.
- `to_dict()` includes `geometric_drc_ran` / `geometric_drc_note`.
- `uv run pytest tests/test_audit.py tests/test_route_post_drc_geometric.py` → 152 passed.
- ruff clean on touched files; mypy introduces no new errors (2 pre-existing errors unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)