### PR TITLE
fix(audit): gate READY verdict on authoritative DRC and fail-loud on checker crashes

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,0 +1,6 @@
+# Loom-managed worktree marker
+# Created by .loom/scripts/worktree.sh
+# Issue: 3825
+# Branch: feature/issue-3825
+# Removing this file makes Loom treat the worktree as user-owned and refuse
+# to clean it up automatically.

--- a/src/kicad_tools/audit/auditor.py
+++ b/src/kicad_tools/audit/auditor.py
@@ -341,6 +341,21 @@ class AuditResult:
         ):
             return AuditVerdict.WARNING
 
+        # Non-authoritative DRC gate (issue #3825): a board may be clean per
+        # the internal --mfr rule engine (drc.passed, blocking_count == 0)
+        # while the geometric engine (kicad-cli pcb drc) never actually ran
+        # -- e.g. shapely ImportError or kicad-cli absent leaves
+        # geometric_drc_ran=False.  #3820 fixed the DRC *line label* but the
+        # overall verdict still returned READY, so kct audit / report.md
+        # shipped "READY FOR MANUFACTURING" for a board whose DRC was never
+        # authoritatively verified.  The internal engine is structurally
+        # blind to several KiCad violation classes (shorts, copper-edge
+        # clearance, mask bridges), so a clean-but-un-run DRC MUST NOT be
+        # READY.  Downgrade to WARNING (not NOT_READY) so backend-less CI
+        # does not regress to red, consistent with the #3820 policy.
+        if self.drc.passed and not self.drc.geometric_drc_ran:
+            return AuditVerdict.WARNING
+
         return AuditVerdict.READY
 
     @property
@@ -714,9 +729,15 @@ class ManufacturingAudit:
                 status.passed = False
 
         except Exception as e:
+            # A genuine ERC checker crash must NOT be coerced into a clean
+            # PASS (issue #3825, sibling of the #3817/#3820 DRC fix).  Surface
+            # it as a fail-loud could-not-verify result so the verdict gate
+            # (which reads blocking_error_count) cannot return a false READY.
             logger.warning(f"ERC check failed: {e}")
-            status.details = str(e)
-            status.passed = True  # Don't fail on check errors
+            status.details = f"ERC check could not run: {e}"
+            status.passed = False
+            status.error_count = max(status.error_count, 1)
+            status.blocking_error_count = max(status.blocking_error_count, 1)
 
         return status
 
@@ -1041,9 +1062,13 @@ class ManufacturingAudit:
                     )
 
         except Exception as e:
+            # A genuine connectivity checker crash must NOT be coerced into a
+            # clean PASS (issue #3825).  Mark it fail-loud as could-not-verify
+            # so the verdict cannot silently return READY when net
+            # connectivity was never actually checked.
             logger.warning(f"Connectivity check failed: {e}")
-            status.details = str(e)
-            status.passed = True  # Don't fail on check errors
+            status.details = f"Connectivity check could not run: {e}"
+            status.passed = False
 
         return status
 
@@ -1102,9 +1127,13 @@ class ManufacturingAudit:
             )
 
         except Exception as e:
+            # A genuine compatibility checker crash must NOT be coerced into a
+            # clean PASS (issue #3825).  compat.passed feeds the verdict gate
+            # directly (NOT_READY when False), so a false PASS here is exactly
+            # the false-READY anti-pattern.  Fail loud as could-not-verify.
             logger.warning(f"Compatibility check failed: {e}")
-            compat.details = str(e)
-            compat.passed = True  # Don't fail on check errors
+            compat.details = f"Compatibility check could not run: {e}"
+            compat.passed = False
 
         return compat
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -411,6 +411,8 @@ class TestAuditResult:
     def test_verdict_ready_when_all_pass(self):
         """Test that verdict is READY when all checks pass."""
         result = AuditResult()
+        # An authoritative clean board: geometric DRC actually ran (#3825).
+        result.drc.geometric_drc_ran = True
         assert result.verdict == AuditVerdict.READY
         assert result.is_ready is True
 
@@ -475,6 +477,7 @@ class TestAuditResult:
             warning_count=0,
             blocking_count=0,
             passed=True,
+            geometric_drc_ran=True,
         )
         result.connectivity = ConnectivityStatus(
             total_nets=10,
@@ -529,9 +532,10 @@ class TestAuditResult:
         result.erc.error_count = 0
         result.erc.warning_count = 0
 
-        # Gate 2: DRC blocking = 0
+        # Gate 2: DRC blocking = 0 (authoritative -- geometric DRC ran, #3825)
         result.drc.blocking_count = 0
         result.drc.warning_count = 0
+        result.drc.geometric_drc_ran = True
 
         # Gate 3: connectivity passed
         result.connectivity.passed = True
@@ -594,7 +598,9 @@ class TestAuditResult:
             passed=False,
             details="ERC timed out",
         )
-        result.drc = DRCStatus(blocking_count=0, warning_count=0, passed=True)
+        result.drc = DRCStatus(
+            blocking_count=0, warning_count=0, passed=True, geometric_drc_ran=True
+        )
         result.connectivity = ConnectivityStatus(passed=True)
         result.compatibility = ManufacturerCompatibility(passed=True)
 
@@ -613,7 +619,9 @@ class TestAuditResult:
             passed=True,
             details="kicad-cli not found (skipped)",
         )
-        result.drc = DRCStatus(blocking_count=0, warning_count=0, passed=True)
+        result.drc = DRCStatus(
+            blocking_count=0, warning_count=0, passed=True, geometric_drc_ran=True
+        )
         result.connectivity = ConnectivityStatus(passed=True)
         result.compatibility = ManufacturerCompatibility(passed=True)
 
@@ -695,7 +703,9 @@ class TestAuditResult:
         """
         result = AuditResult()
         result.erc = ERCStatus(error_count=0, warning_count=0, passed=True)
-        result.drc = DRCStatus(blocking_count=0, warning_count=0, passed=True)
+        result.drc = DRCStatus(
+            blocking_count=0, warning_count=0, passed=True, geometric_drc_ran=True
+        )
         result.connectivity = ConnectivityStatus(
             total_nets=10,
             connected_nets=10,
@@ -1054,7 +1064,8 @@ class TestAuditExitCodes:
         exit code logic in audit_cmd.main returns 0.
         """
         result = AuditResult(project_name="test_ready")
-        # All defaults yield READY
+        # Authoritative clean board (geometric DRC ran) yields READY (#3825).
+        result.drc.geometric_drc_ran = True
         assert result.verdict == AuditVerdict.READY
 
         # Verify the exit code logic directly
@@ -1156,6 +1167,8 @@ class TestAuditExitCodes:
         pcb_file.write_text("(kicad_pcb (version 20221018))")
 
         mock_result = AuditResult()
+        # Authoritative clean board (geometric DRC ran) yields READY (#3825).
+        mock_result.drc.geometric_drc_ran = True
         assert mock_result.verdict == AuditVerdict.READY
 
         mock_audit_instance = MagicMock()
@@ -1180,7 +1193,13 @@ class TestAuditOutputRendering:
         result = AuditResult(project_name="test_ready_board")
         # Explicitly set all checks to passing
         result.erc = ERCStatus(error_count=0, warning_count=0, passed=True)
-        result.drc = DRCStatus(error_count=0, warning_count=0, blocking_count=0, passed=True)
+        result.drc = DRCStatus(
+            error_count=0,
+            warning_count=0,
+            blocking_count=0,
+            passed=True,
+            geometric_drc_ran=True,
+        )
         result.connectivity = ConnectivityStatus(total_nets=5, connected_nets=5, passed=True)
         result.compatibility = ManufacturerCompatibility(manufacturer="JLCPCB", passed=True)
 
@@ -1919,7 +1938,7 @@ class TestZoneConnectedNets:
             passed=True,
         )
         result.erc = ERCStatus(passed=True)
-        result.drc = DRCStatus(passed=True)
+        result.drc = DRCStatus(passed=True, geometric_drc_ran=True)
         result.compatibility = ManufacturerCompatibility(passed=True)
 
         assert result.verdict == AuditVerdict.READY
@@ -2610,7 +2629,8 @@ class TestSyncDriftVerdict:
         from kicad_tools.audit.auditor import AuditResult, AuditVerdict
 
         r = AuditResult()
-        # All zero
+        # All zero, authoritative clean DRC (geometric engine ran, #3825)
+        r.drc.geometric_drc_ran = True
         assert r.verdict == AuditVerdict.READY
 
     def test_schematic_only_overrides_drc_warnings(self):
@@ -3041,7 +3061,7 @@ class TestConnectivityStatusZoneVerification:
         thanks to zone-connected nets."""
         result = AuditResult()
         result.erc = ERCStatus(passed=True)
-        result.drc = DRCStatus(passed=True)
+        result.drc = DRCStatus(passed=True, geometric_drc_ran=True)
         result.connectivity = ConnectivityStatus(
             total_nets=10,
             connected_nets=10,
@@ -3309,3 +3329,176 @@ class TestAnalogNetActionItems:
         items = audit._generate_action_items(AuditResult())
         assert self._net_items(items) == []
         assert self._bridge_items(items) == []
+
+
+class TestVerdictGateNotAuthoritativeDrc:
+    """Issue #3825: a clean board whose DRC did not run must NOT be READY.
+
+    #3820 fixed the DRC *line label* (PASS NOT AUTHORITATIVE) but left the
+    overall verdict gate returning READY when ``drc.passed`` and
+    ``geometric_drc_ran is False`` (shapely ImportError / kicad-cli absent).
+    The verdict must downgrade to WARNING (never READY) so kct audit /
+    report.md cannot ship a false "READY FOR MANUFACTURING".
+    """
+
+    def test_clean_but_drc_not_run_is_not_ready(self):
+        """drc.passed + geometric_drc_ran=False -> WARNING, never READY."""
+        result = AuditResult()
+        result.drc.passed = True
+        result.drc.blocking_count = 0
+        result.drc.geometric_drc_ran = False
+
+        assert result.verdict != AuditVerdict.READY
+        assert result.verdict == AuditVerdict.WARNING
+        assert result.is_ready is False
+        assert result.to_dict()["verdict"] != "ready"
+        assert result.to_dict()["verdict"] == "warning"
+
+    def test_authoritative_clean_board_is_ready(self):
+        """Both engines clean (geometric_drc_ran=True) -> READY (no regression)."""
+        result = AuditResult()
+        result.drc.passed = True
+        result.drc.blocking_count = 0
+        result.drc.geometric_drc_ran = True
+
+        assert result.verdict == AuditVerdict.READY
+        assert result.is_ready is True
+        assert result.to_dict()["verdict"] == "ready"
+
+    def test_drc_blocking_still_not_ready(self):
+        """Real blocking violations still drive NOT_READY regardless of gate."""
+        result = AuditResult()
+        result.drc.passed = False
+        result.drc.blocking_count = 2
+        result.drc.geometric_drc_ran = True
+
+        assert result.verdict == AuditVerdict.NOT_READY
+        assert result.is_ready is False
+
+    def test_not_authoritative_drc_banner_not_ready(self, capsys):
+        """output_table banner does not print READY for a not-run DRC."""
+        from kicad_tools.cli.audit_cmd import output_table
+
+        result = AuditResult()
+        result.drc.passed = True
+        result.drc.geometric_drc_ran = False
+
+        output_table(result)
+        out = capsys.readouterr().out
+
+        assert "READY FOR MANUFACTURING" not in out
+
+    def test_not_authoritative_drc_summary_not_ready(self, capsys):
+        """output_summary one-liner does not report READY for a not-run DRC."""
+        from kicad_tools.cli.audit_cmd import output_summary
+
+        result = AuditResult()
+        result.drc.passed = True
+        result.drc.geometric_drc_ran = False
+
+        output_summary(result)
+        out = capsys.readouterr().out
+
+        first_line = out.splitlines()[0]
+        # Must not report a bare READY one-liner (NOT READY is acceptable).
+        assert not first_line.startswith("READY:")
+        assert "Verdict: WARNING" in out
+
+
+class TestCheckerCrashesFailLoud:
+    """Issue #3825: ERC/connectivity/compat crashes must NOT coerce to PASS.
+
+    These three sibling ``except Exception: passed = True`` sites survived
+    #3817/#3820.  A genuine checker exception must surface as a fail-loud
+    could-not-verify result, never a silent green PASS.
+    """
+
+    def _make_audit_with_schematic(self, tmp_path):
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+        sch = tmp_path / "board.kicad_sch"
+        sch.write_text("(kicad_sch)")
+        return ManufacturingAudit(pcb, manufacturer="jlcpcb")
+
+    def test_erc_crash_does_not_pass(self, tmp_path, monkeypatch):
+        """An exception inside _check_erc yields passed=False + blocking."""
+        audit = self._make_audit_with_schematic(tmp_path)
+
+        # subprocess.run is the first call inside the try block; make it
+        # raise an unexpected (non-FileNotFound, non-Timeout) error.
+        import kicad_tools.audit.auditor as auditor_mod
+
+        def _boom(*a, **k):
+            raise RuntimeError("erc exploded")
+
+        monkeypatch.setattr(auditor_mod.subprocess, "run", _boom)
+
+        status = audit._check_erc()
+
+        assert status.passed is False
+        assert status.blocking_error_count >= 1
+        assert "could not run" in status.details
+
+    def test_connectivity_crash_does_not_pass(self, monkeypatch):
+        """An exception inside _check_connectivity yields passed=False."""
+
+        class _BoomPcb:
+            @property
+            def footprint_count(self):
+                raise RuntimeError("connectivity exploded")
+
+        audit = ManufacturingAudit.__new__(ManufacturingAudit)
+        status = ManufacturingAudit._check_connectivity(audit, _BoomPcb())
+
+        assert status.passed is False
+        assert "could not run" in status.details
+
+    def test_compatibility_crash_does_not_pass(self, tmp_path, monkeypatch):
+        """An exception inside _check_compatibility yields passed=False."""
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+        audit = ManufacturingAudit(pcb, manufacturer="jlcpcb")
+
+        def _boom():
+            raise RuntimeError("profile exploded")
+
+        monkeypatch.setattr(audit, "_get_profile", _boom)
+
+        compat = audit._check_compatibility(_DummyPcb())
+
+        assert compat.passed is False
+        assert "could not run" in compat.details
+
+    def test_compat_crash_drives_not_ready_verdict(self, tmp_path, monkeypatch):
+        """A compat-checker crash makes the overall verdict NOT_READY."""
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+        audit = ManufacturingAudit(pcb, manufacturer="jlcpcb")
+
+        def _boom():
+            raise RuntimeError("profile exploded")
+
+        monkeypatch.setattr(audit, "_get_profile", _boom)
+
+        result = AuditResult()
+        result.compatibility = audit._check_compatibility(_DummyPcb())
+
+        assert result.verdict == AuditVerdict.NOT_READY
+        assert result.is_ready is False
+
+    def test_erc_kicad_cli_absent_stays_non_fatal(self, tmp_path, monkeypatch):
+        """Expected-skip path (kicad-cli missing) stays non-authoritative, not red."""
+        audit = self._make_audit_with_schematic(tmp_path)
+
+        import kicad_tools.audit.auditor as auditor_mod
+
+        def _missing(*a, **k):
+            raise FileNotFoundError("kicad-cli")
+
+        monkeypatch.setattr(auditor_mod.subprocess, "run", _missing)
+
+        status = audit._check_erc()
+
+        # kicad-cli absent is an expected skip, not a hard fail.
+        assert status.passed is True
+        assert status.blocking_error_count == 0

--- a/tests/test_erc_violation_classification.py
+++ b/tests/test_erc_violation_classification.py
@@ -190,6 +190,8 @@ class TestVerdictWithBlockingClassification:
             warning_count=0,  # non-blocking errors not counted as warnings here
             passed=True,
         )
+        # Authoritative clean DRC so the not-run gate (#3825) does not apply.
+        result.drc.geometric_drc_ran = True
         assert result.verdict == AuditVerdict.READY
 
     def test_blocking_erc_error_blocks_ready(self):
@@ -248,4 +250,6 @@ class TestVerdictWithBlockingClassification:
             warning_count=0,
             passed=True,
         )
+        # Authoritative clean DRC so the not-run gate (#3825) does not apply.
+        result.drc.geometric_drc_ran = True
         assert result.verdict == AuditVerdict.READY


### PR DESCRIPTION
## Summary

The manufacturing-audit verdict could ship a false `READY FOR MANUFACTURING` in two ways that survived #3817/#3820:

1. **Verdict-gate hole (primary bug).** `AuditResult.verdict` never consulted `geometric_drc_ran`. A clean `--mfr` board whose geometric DRC engine could-not-run (shapely `ImportError` or `kicad-cli` absent → `geometric_drc_ran=False`) had `passed=True`/`blocking_count=0`, so `verdict` returned `READY`. #3820 fixed only the DRC *line label* (`PASS NOT AUTHORITATIVE`); the verdict, exit code, banner, and shipped `report.md` still said READY.
2. **Sibling `passed=True`-on-exception sites.** `_check_erc`, `_check_connectivity`, and `_check_compatibility` still coerced a genuine checker *crash* into a green PASS. `_check_compatibility` feeds the verdict directly.

## Changes

- `auditor.py` `AuditResult.verdict`: added a gate so a clean-but-non-authoritative DRC (`drc.passed and not drc.geometric_drc_ran`) returns `WARNING`, never `READY`. WARNING (not NOT_READY) keeps backend-less CI green, consistent with the #3820 policy. `is_ready`, exit code, banner, summary one-liner, and `report.md` all inherit the corrected verdict (no change needed in `audit_cmd.py`).
- `auditor.py` `_check_erc`/`_check_connectivity`/`_check_compatibility`: a genuine exception now sets `passed=False` with a `could not run` detail (ERC also bumps `blocking_error_count`/`error_count >= 1`), mirroring `_check_drc`'s #3817/#3820 handler. Expected-skip paths (kicad-cli not installed) remain non-fatal/non-authoritative.
- Tests: added `TestVerdictGateNotAuthoritativeDrc` and `TestCheckerCrashesFailLoud`; updated existing READY-path tests to mark the DRC authoritative (`geometric_drc_ran=True`) per the new contract.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Clean board, DRC did not run → `verdict != READY`, `is_ready False`, `to_dict()["verdict"] != "ready"` | ✅ | `test_clean_but_drc_not_run_is_not_ready` |
| `kct audit` does not print READY / summary not a bare READY for not-run DRC | ✅ | `test_not_authoritative_drc_banner_not_ready`, `test_not_authoritative_drc_summary_not_ready` |
| ERC/connectivity/compat crash → `passed False` (ERC `blocking_error_count >= 1`) | ✅ | `test_erc_crash_does_not_pass`, `test_connectivity_crash_does_not_pass`, `test_compatibility_crash_does_not_pass` |
| Compat crash → `verdict == NOT_READY` | ✅ | `test_compat_crash_drives_not_ready_verdict` |
| Expected-skip (kicad-cli absent) stays non-fatal | ✅ | `test_erc_kicad_cli_absent_stays_non_fatal` |
| Authoritative clean board still READY (no regression) | ✅ | `test_authoritative_clean_board_is_ready` + updated existing READY-path tests |

## Test Plan

`uv run pytest tests/test_audit.py tests/test_erc_violation_classification.py` → 183 passed. `ruff check`/`ruff format --check` clean on all touched files. mypy on touched files introduces no new errors (the 2 reported are pre-existing baseline noise on untouched lines 473/605).

Closes #3825