### PR TITLE
fix(deps): make shapely a core dependency and fail loud when absent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,14 @@ dependencies = [
     "pyyaml>=6.0",
     "numpy>=1.24",
     "pydantic>=2.0",
+    # shapely is load-bearing for the correctness-critical copper paths
+    # (zone-fill clearance carving and the zone-vs-copper clearance DRC
+    # rules), so it is a CORE dependency rather than an optional extra
+    # (issue #3824).  shapely 2.x ships prebuilt manylinux/macOS/Windows
+    # wheels (vendored GEOS), so this imposes no system-library build
+    # burden on typical installs.  The ``geometry`` extra remains as a
+    # back-compat alias.
+    "shapely>=2.0",
 ]
 
 [project.urls]
@@ -85,7 +93,9 @@ kicad-fab-rules = "kicad_tools.cli.fab_rules_cmd:main"
 kicad-project-clean = "kicad_tools.cli.clean_cmd:main"
 
 [project.optional-dependencies]
-# Shapely-based board geometry engine
+# Shapely-based board geometry engine.  shapely is now a CORE dependency
+# (see ``[project] dependencies``); this extra is retained as a
+# back-compat alias so ``pip install kicad-tools[geometry]`` keeps working.
 geometry = [
     "shapely>=2.0",
 ]
@@ -189,6 +199,8 @@ all = [
     "jinja2>=3.1",
     "markdown>=3.5",
     "weasyprint>=60.0",
+    # shapely is a core dependency; listed here too for explicitness.
+    "shapely>=2.0",
 ]
 # Development dependencies
 dev = [
@@ -211,10 +223,8 @@ dev = [
     "jinja2>=3.1",
     "markdown>=3.5",
     "weasyprint>=60.0",
-    # Issue #3413 phase 4: the board 06 recipe's copper-union pour audit
-    # (and its committed-artifact regression test) require shapely.  The
-    # diffpair CI job and the test jobs install via --extra dev.
-    "shapely>=2.0",
+    # shapely is now a CORE dependency (issue #3824) so it no longer needs
+    # an explicit entry here; it is always installed with the package.
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/kicad_tools/_shapely.py
+++ b/src/kicad_tools/_shapely.py
@@ -1,0 +1,85 @@
+"""Shared guard for the optional/core ``shapely`` geometry backend.
+
+``shapely`` is a **core** dependency of kicad-tools (declared in
+``[project] dependencies`` in ``pyproject.toml``) because the project's
+correctness-critical copper paths — zone-fill clearance carving and the
+zone-vs-copper clearance DRC rules — cannot produce correct results
+without it.
+
+Historically ``shapely`` lived only under the optional ``geometry`` /
+``dev`` extras, which produced two divergent and both-wrong conventions
+across the codebase:
+
+* **Degrade silently** — return ``0`` / no-op when ``shapely`` is
+  missing.  This is *dangerous* on a correctness path because the caller
+  cannot tell "nothing needed doing" from "we couldn't do anything", so
+  a board with real shorts is reported as a clean fill.
+* **Crash** — bare ``import shapely`` raising ``ModuleNotFoundError`` deep
+  inside a DRC rule, so ``kct check`` / ``kct audit`` die with an opaque
+  traceback instead of an actionable message.
+
+This module is the single, honest convention every geometry-dependent
+module should use:
+
+* :func:`has_shapely` — cheap boolean probe (for fallback paths that have
+  a legitimate pure-Python alternative, e.g. axis-aligned rect inset).
+* :func:`require_shapely` — fail **loud** with an actionable install
+  message when ``shapely`` is genuinely unavailable.  Use this on any
+  path where there is no correct fallback, so a partial/broken
+  environment never silently yields a non-clearance-correct result.
+
+Even though ``shapely`` is now a core dependency, a broken or partial
+install can still leave it unimportable, so these guards remain the
+defense-in-depth layer that keeps a correctness path from ever *silently*
+claiming success.
+"""
+
+from __future__ import annotations
+
+# Friendly, actionable install hint reused everywhere a shapely-dependent
+# feature is requested without shapely available.  shapely is a core
+# dependency, so a missing import almost always means a broken/partial
+# environment; reinstalling the package (or the geometry extra) repairs it.
+SHAPELY_INSTALL_HINT = (
+    "shapely is required for this geometry operation but is not importable. "
+    "shapely is a core dependency of kicad-tools; reinstall it with: "
+    "pip install 'kicad-tools[geometry]' (or 'pip install shapely>=2.0')."
+)
+
+
+_SHAPELY_AVAILABLE: bool | None = None
+
+
+def has_shapely() -> bool:
+    """Return ``True`` when the ``shapely`` backend is importable.
+
+    The result is cached after the first probe.  Use this only for paths
+    that have a *correct* pure-Python fallback; correctness-critical paths
+    must use :func:`require_shapely` instead so a missing backend fails
+    loud rather than silently degrading.
+    """
+    global _SHAPELY_AVAILABLE
+    if _SHAPELY_AVAILABLE is None:
+        try:
+            import shapely  # type: ignore[import-untyped] # noqa: F401
+
+            _SHAPELY_AVAILABLE = True
+        except ImportError:
+            _SHAPELY_AVAILABLE = False
+    return _SHAPELY_AVAILABLE
+
+
+def require_shapely(feature: str) -> None:
+    """Raise :class:`ModuleNotFoundError` with an actionable hint if shapely is absent.
+
+    Call this at the top of any function that cannot produce a correct
+    result without ``shapely``.  ``feature`` names the operation so the
+    error explains *what* could not run, e.g.::
+
+        require_shapely("foreign-net pad clearance carving")
+
+    Raising (rather than a silent ``return 0``) guarantees a correctness
+    path never masquerades a skipped step as success.
+    """
+    if not has_shapely():
+        raise ModuleNotFoundError(f"{feature}: {SHAPELY_INSTALL_HINT}")

--- a/src/kicad_tools/cli/runner.py
+++ b/src/kicad_tools/cli/runner.py
@@ -533,6 +533,11 @@ def _remediate_starved_thermal(
         # refill + carve so the shipped copper reflects both.
         if _run_drc(refill=True) is not None:
             _settle()
+    except ModuleNotFoundError:
+        # shapely unavailable -> the carve/remediation is not clearance-
+        # correct (issue #3824).  Propagate loud rather than shipping a
+        # fill that silently omitted foreign-net clearances.
+        raise
     except Exception:
         # Never let remediation abort a successful fill.
         return
@@ -595,20 +600,30 @@ def _apply_foreign_pad_clearance(pcb_path: Path) -> None:
 
     Loads the filled PCB, applies the pure-Python clearance correction,
     and rewrites the file only when at least one filled_polygon changed.
-    Any failure (e.g. shapely missing) is swallowed — the fill is then
-    left exactly as kicad-cli produced it.
-    """
-    try:
-        from kicad_tools.core.sexp_file import save_pcb
-        from kicad_tools.sexp import parse_file
-        from kicad_tools.zones.fill_clearance import apply_foreign_pad_clearance
 
+    A missing/broken ``shapely`` is propagated **loud** (it is a core
+    dependency — issue #3824): silently leaving the fill as kicad-cli
+    produced it would ship a board with uncarved foreign-net antipads and
+    real ``clearance_pad_zone`` shorts while reporting a clean fill.  Only
+    non-import geometry edge cases are swallowed so a degenerate ring never
+    aborts an otherwise successful fill.
+    """
+    from kicad_tools.core.sexp_file import save_pcb
+    from kicad_tools.sexp import parse_file
+    from kicad_tools.zones.fill_clearance import apply_foreign_pad_clearance
+
+    try:
         doc = parse_file(pcb_path)
         modified = apply_foreign_pad_clearance(doc)
         if modified:
             save_pcb(doc, pcb_path)
+    except ModuleNotFoundError:
+        # shapely unavailable -> the fill is NOT clearance-correct.  Never
+        # swallow this: surface it so the caller cannot mistake an uncarved
+        # fill for a clean one.
+        raise
     except Exception:
-        # Never let the correction abort a successful fill.
+        # Non-import geometry edge case: never let it abort a successful fill.
         return
 
 

--- a/src/kicad_tools/cli/stitch_cmd.py
+++ b/src/kicad_tools/cli/stitch_cmd.py
@@ -4347,16 +4347,26 @@ def _carve_foreign_copper_after_stitch(pcb_path: Path) -> None:
     ``filled_polygon`` (the segment branch added in issue #3773), so it
     cleanly removes the new GND copper from the rail pour.  It edits the
     parsed S-expression directly (no kicad-cli refill, so the post-route
-    carve is preserved) and is a no-op when shapely is unavailable.
+    carve is preserved).  shapely is a core dependency (issue #3824); if it
+    is ever unavailable the carve cannot run and we warn **loud** that the
+    fill is NOT clearance-correct rather than implying the carve was merely
+    an optional skip.
     """
-    try:
-        from kicad_tools.core.sexp_file import load_pcb, save_pcb
-        from kicad_tools.zones.fill_clearance import apply_foreign_pad_clearance
-    except ImportError:
-        return
+    from kicad_tools.core.sexp_file import load_pcb, save_pcb
+    from kicad_tools.zones.fill_clearance import apply_foreign_pad_clearance
+
     try:
         doc = load_pcb(pcb_path)
         modified = apply_foreign_pad_clearance(doc)
+    except ModuleNotFoundError as exc:
+        print(
+            "\nWARNING: post-stitch zone-fill clearance carve could NOT run "
+            f"({exc}). The zone fill is NOT clearance-correct and may contain "
+            "foreign-net pad/via shorts -- do not treat it as fab-ready until "
+            "shapely is installed and the fill is re-carved.",
+            file=sys.stderr,
+        )
+        return
     except Exception as exc:  # pragma: no cover - defensive guard
         print(
             f"\nWarning: post-stitch zone-fill clearance carve skipped ({exc}).",

--- a/src/kicad_tools/validate/connectivity.py
+++ b/src/kicad_tools/validate/connectivity.py
@@ -28,26 +28,18 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from kicad_tools.schema.pcb import PCB
 
-# Optional geometry backend.  ``shapely`` is NOT a core dependency (it lives
-# only under the ``geometry``/``dev`` extras in pyproject.toml), so we import
-# it lazily/guardedly here.  When it is absent the label-free pour extractor
+# Geometry backend.  ``shapely`` is a core dependency (issue #3824), but
+# this module keeps a graceful fallback: when shapely is unavailable (a
+# broken/partial install) the label-free pour extractor
 # (``_connect_pour_pads_label_free`` / step 2d) transparently falls back to
 # the legacy declared-net pour grouping, so importing this module — and
-# tracing autorouter segment/via copper — never hard-fails on a core-only
-# install.
-_SHAPELY_AVAILABLE = False
-try:  # pragma: no cover - import guard exercised by environment, not tests
+# tracing autorouter segment/via copper — never hard-fails.  The boolean
+# probe is delegated to the shared guard in :mod:`kicad_tools._shapely`.
+from kicad_tools._shapely import has_shapely as _has_shapely
+
+if _has_shapely():  # pragma: no cover - import guard exercised by environment
     from shapely.geometry import Point as _ShapelyPoint  # type: ignore[import-untyped]
     from shapely.geometry import Polygon as _ShapelyPolygon
-
-    _SHAPELY_AVAILABLE = True
-except ImportError:  # pragma: no cover
-    pass
-
-
-def _has_shapely() -> bool:
-    """Return True when the optional ``shapely`` backend is importable."""
-    return _SHAPELY_AVAILABLE
 
 
 # Sentinel layer-set meaning "every copper layer".  Used to model a ``*.Cu``

--- a/src/kicad_tools/validate/rules/clearance.py
+++ b/src/kicad_tools/validate/rules/clearance.py
@@ -10,6 +10,7 @@ import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from kicad_tools._shapely import require_shapely
 from kicad_tools.core.geometry import (
     point_to_segment_distance as _point_to_segment_distance,
 )
@@ -1107,6 +1108,13 @@ class SegmentZoneClearanceRule(DRCRule):
             DRCResults containing segment-vs-zone-fill shorts and
             clearance violations
         """
+        # shapely is a core dependency (issue #3824).  Guard up front so a
+        # broken/partial install fails with an actionable install hint
+        # instead of a raw ``ModuleNotFoundError`` deep inside the geometry
+        # query -- this rule is the one that catches the very shorts a
+        # missing shapely would otherwise let through silently.
+        require_shapely("zone-vs-segment clearance DRC")
+
         results = DRCResults()
         results.rules_checked = 1
 
@@ -1290,6 +1298,12 @@ class ViaZoneClearanceRule(DRCRule):
             DRCResults containing via/pad-vs-zone-fill shorts and
             clearance violations.
         """
+        # shapely is a core dependency (issue #3824).  Guard up front so a
+        # broken/partial install fails with an actionable install hint
+        # instead of a raw ``ModuleNotFoundError`` deep inside the geometry
+        # query.
+        require_shapely("zone-vs-via/pad clearance DRC")
+
         results = DRCResults()
         results.rules_checked = 1
 

--- a/src/kicad_tools/zones/fill_clearance.py
+++ b/src/kicad_tools/zones/fill_clearance.py
@@ -21,9 +21,11 @@ foreign-net copper.  Same-net pads/vias are never subtracted, so thermal
 relief / solid connections to the zone's own net are preserved.
 
 The correction operates directly on the parsed S-expression document so it
-needs neither kicad-cli nor the C++ router — only optional ``shapely`` for
-the polygon difference.  When ``shapely`` is unavailable the correction is
-skipped (the caller logs a hint) rather than producing a wrong fill.
+needs neither kicad-cli nor the C++ router — only ``shapely`` for the
+polygon difference.  ``shapely`` is a core dependency (issue #3824); if it
+is ever unavailable (a broken/partial install) the correctness-critical
+entry points fail **loud** via :func:`kicad_tools._shapely.require_shapely`
+rather than silently returning a non-clearance-correct fill.
 """
 
 from __future__ import annotations
@@ -32,6 +34,7 @@ import math
 from dataclasses import dataclass
 from typing import Any, Protocol
 
+from kicad_tools._shapely import require_shapely
 from kicad_tools.core.layers import via_spans_layer
 from kicad_tools.sexp import SExp
 
@@ -725,16 +728,16 @@ def force_solid_on_isolated_island_pads(doc: SExp, zone_uuids: set[str]) -> int:
     refill.  Larger fill lobes are never touched, so substantial copper is
     safe.  Returns the number of pads that received a new solid override.
 
-    A no-op (returns 0) when shapely is unavailable, since the island
-    geometry cannot be reasoned about without it.
+    Raises :class:`ModuleNotFoundError` with an actionable install hint
+    when ``shapely`` is unavailable: the island geometry cannot be
+    reasoned about without it, and silently returning ``0`` would let the
+    caller treat an unremediated fill as clean (issue #3824).
     """
     if not zone_uuids:
         return 0
-    try:
-        import shapely
-        from shapely.geometry import Polygon
-    except ImportError:
-        return 0
+    require_shapely("isolated-copper island remediation")
+    import shapely
+    from shapely.geometry import Polygon
 
     name_map = _build_net_name_map(doc)
     obstacles = _collect_obstacles(doc, shapely, name_map)
@@ -913,15 +916,18 @@ def apply_foreign_pad_clearance(
     The document is mutated in place.  Returns the number of
     ``filled_polygon`` nodes that were modified.
 
-    When ``shapely`` is not importable the function is a no-op and returns
-    ``0`` (the fill is left as kicad-cli produced it).
+    Raises :class:`ModuleNotFoundError` with an actionable install hint
+    when ``shapely`` is not importable.  This path is correctness-critical:
+    silently returning ``0`` (the old behavior) leaves foreign-net pad
+    clearances uncarved while reporting a clean fill, so a fab-ready board
+    would ship with real ``clearance_pad_zone`` shorts.  Failing loud
+    guarantees the caller never mistakes "shapely absent" for "nothing to
+    carve" (issue #3824).
     """
-    try:
-        import shapely
-        from shapely import make_valid
-        from shapely.geometry import Polygon
-    except ImportError:
-        return 0
+    require_shapely("foreign-net pad clearance carving")
+    import shapely
+    from shapely import make_valid
+    from shapely.geometry import Polygon
 
     name_map = _build_net_name_map(doc)
     obstacles = _collect_obstacles(doc, shapely, name_map)

--- a/tests/test_shapely_core_dependency.py
+++ b/tests/test_shapely_core_dependency.py
@@ -1,0 +1,226 @@
+"""Guards for shapely being a load-bearing core dependency (issue #3824).
+
+shapely backs the two correctness-critical copper paths -- zone-fill
+clearance carving and the zone-vs-copper clearance DRC rules.  Historically
+it was only an optional extra, which produced two dangerous failure modes
+when absent:
+
+1. SILENT BAD FILLS -- ``apply_foreign_pad_clearance`` /
+   ``force_solid_on_isolated_island_pads`` returned ``0`` (a no-op) when
+   shapely was missing, so the pipeline reported a clean fill while real
+   ``clearance_pad_zone`` shorts remained in the copper.
+2. UNGUARDED CRASH -- the clearance DRC rules imported shapely with bare
+   ``from shapely import ...`` and died with a raw ``ModuleNotFoundError``.
+
+These tests assert the hardened behavior: a shapely-absent environment now
+fails **loud** with an actionable install message rather than silently
+returning a non-clearance-correct fill, and the DRC rule raises the same
+actionable error instead of a raw ``ModuleNotFoundError``.  They also pin
+the packaging contract (shapely is a core dependency).
+"""
+
+from __future__ import annotations
+
+import builtins
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from kicad_tools import _shapely as shapely_guard
+from kicad_tools.sexp import parse_string
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - Python < 3.11
+    import tomli as tomllib  # type: ignore[import-not-found]
+
+
+# Minimal board with a VCC fill overlapping a foreign-net (GND) pad -- the
+# exact shape that requires carving.  Reused from the fill-clearance suite.
+_BOARD = """
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (net 0 "")
+  (net 1 "VCC")
+  (net 3 "GND")
+  (footprint "lib:foreign"
+    (layer "F.Cu")
+    (at 5 5)
+    (pad "1" thru_hole rect (at 0 0) (size 1.7 1.7) (drill 1.0) (layers "*.Cu" "*.Mask") (net 3 "GND"))
+  )
+  (zone
+    (net "VCC")
+    (layer "F.Cu")
+    (uuid "test-zone")
+    (hatch edge 0.5)
+    (connect_pads (clearance 0.3))
+    (min_thickness 0.25)
+    (fill yes (thermal_gap 0.3) (thermal_bridge_width 0.4))
+    (polygon (pts (xy 0 0) (xy 20 0) (xy 20 20) (xy 0 20)))
+    (filled_polygon
+      (layer "F.Cu")
+      (pts (xy 0 0) (xy 20 0) (xy 20 20) (xy 0 20))
+    )
+  )
+)
+"""
+
+
+@pytest.fixture
+def shapely_absent(monkeypatch: pytest.MonkeyPatch):
+    """Simulate a broken/partial install where shapely cannot be imported.
+
+    Blocks ``import shapely`` (and submodules) and resets the cached probe
+    in :mod:`kicad_tools._shapely` so the guard re-evaluates as unavailable.
+    """
+    # Drop any already-imported shapely modules so a fresh import is forced.
+    for name in list(sys.modules):
+        if name == "shapely" or name.startswith("shapely."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    real_import = builtins.__import__
+
+    def _blocked_import(name, *args, **kwargs):
+        if name == "shapely" or name.startswith("shapely."):
+            raise ModuleNotFoundError("No module named 'shapely'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _blocked_import)
+    # Reset the cached availability so has_shapely() re-probes under the block.
+    monkeypatch.setattr(shapely_guard, "_SHAPELY_AVAILABLE", None, raising=False)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Shared guard helper
+# ---------------------------------------------------------------------------
+
+
+def test_require_shapely_raises_actionable_when_absent(shapely_absent):
+    """``require_shapely`` raises with the friendly install hint, not bare error."""
+    with pytest.raises(ModuleNotFoundError) as excinfo:
+        shapely_guard.require_shapely("unit-test feature")
+    msg = str(excinfo.value)
+    assert "unit-test feature" in msg
+    assert "kicad-tools[geometry]" in msg
+    # Sanity: this is NOT the opaque "No module named 'shapely'" message.
+    assert msg != "No module named 'shapely'"
+
+
+def test_has_shapely_true_when_present():
+    pytest.importorskip("shapely")
+    # Force a clean re-probe (cache may be poisoned by another test).
+    shapely_guard._SHAPELY_AVAILABLE = None
+    assert shapely_guard.has_shapely() is True
+
+
+# ---------------------------------------------------------------------------
+# Silent-bad-fill path: must fail LOUD, never silently return 0
+# ---------------------------------------------------------------------------
+
+
+def test_apply_foreign_pad_clearance_fails_loud_without_shapely(shapely_absent):
+    """The carving path must raise (not silently return 0) when shapely absent."""
+    from kicad_tools.zones.fill_clearance import apply_foreign_pad_clearance
+
+    doc = parse_string(_BOARD)
+    with pytest.raises(ModuleNotFoundError) as excinfo:
+        apply_foreign_pad_clearance(doc)
+    assert "kicad-tools[geometry]" in str(excinfo.value)
+
+
+def test_force_solid_isolated_islands_fails_loud_without_shapely(shapely_absent):
+    """Island remediation must raise (not silently return 0) when shapely absent."""
+    from kicad_tools.zones.fill_clearance import force_solid_on_isolated_island_pads
+
+    doc = parse_string(_BOARD)
+    with pytest.raises(ModuleNotFoundError) as excinfo:
+        force_solid_on_isolated_island_pads(doc, {"test-zone"})
+    assert "kicad-tools[geometry]" in str(excinfo.value)
+
+
+def test_force_solid_empty_zoneset_is_still_noop(shapely_absent):
+    """An empty zone set short-circuits before the guard (genuinely nothing to do)."""
+    from kicad_tools.zones.fill_clearance import force_solid_on_isolated_island_pads
+
+    doc = parse_string(_BOARD)
+    # No zones requested -> legitimately 0, never touches shapely.
+    assert force_solid_on_isolated_island_pads(doc, set()) == 0
+
+
+# ---------------------------------------------------------------------------
+# DRC clearance rules: degrade with actionable message, not raw ModuleNotFound
+# ---------------------------------------------------------------------------
+
+
+def test_segment_zone_clearance_rule_actionable_without_shapely(shapely_absent):
+    """The DRC rule degrades with the actionable hint, not a raw ModuleNotFoundError.
+
+    ``require_shapely`` fires at the very top of ``check()`` before any PCB
+    geometry is touched, so a bare MagicMock PCB is sufficient -- the point
+    is that the rule never reaches a bare ``import shapely`` that would
+    surface the opaque "No module named 'shapely'" message.
+    """
+    from unittest.mock import MagicMock
+
+    from kicad_tools.validate.rules.clearance import SegmentZoneClearanceRule
+
+    rules = MagicMock()
+    rules.min_clearance_mm = 0.127
+    with pytest.raises(ModuleNotFoundError) as excinfo:
+        SegmentZoneClearanceRule().check(MagicMock(), rules)
+    msg = str(excinfo.value)
+    assert "kicad-tools[geometry]" in msg
+    assert msg != "No module named 'shapely'"
+
+
+def test_via_zone_clearance_rule_actionable_without_shapely(shapely_absent):
+    from unittest.mock import MagicMock
+
+    from kicad_tools.validate.rules.clearance import ViaZoneClearanceRule
+
+    rules = MagicMock()
+    rules.min_clearance_mm = 0.127
+    with pytest.raises(ModuleNotFoundError) as excinfo:
+        ViaZoneClearanceRule().check(MagicMock(), rules)
+    msg = str(excinfo.value)
+    assert "kicad-tools[geometry]" in msg
+    assert msg != "No module named 'shapely'"
+
+
+# ---------------------------------------------------------------------------
+# Packaging contract: shapely is a CORE dependency (Option A)
+# ---------------------------------------------------------------------------
+
+
+def _load_pyproject() -> dict[str, Any]:
+    root = Path(__file__).resolve().parents[1]
+    with open(root / "pyproject.toml", "rb") as fh:
+        data: dict[str, Any] = tomllib.load(fh)
+    return data
+
+
+def test_shapely_is_core_dependency():
+    """shapely>=2.0 must be in [project] dependencies (Option A)."""
+    data = _load_pyproject()
+    core = data["project"]["dependencies"]
+    shapely_pins = [d for d in core if d.replace(" ", "").lower().startswith("shapely")]
+    assert shapely_pins, f"shapely missing from core dependencies: {core}"
+    assert any(">=2.0" in pin for pin in shapely_pins), shapely_pins
+
+
+def test_shapely_present_in_all_extra():
+    """shapely is also listed explicitly in the [all] extra."""
+    data = _load_pyproject()
+    all_extra = data["project"]["optional-dependencies"]["all"]
+    assert any(d.lower().startswith("shapely") for d in all_extra), all_extra
+
+
+def test_shapely_not_duplicated_in_dev_extra():
+    """[dev] no longer pins shapely (it is core now); no contradictory pins."""
+    data = _load_pyproject()
+    dev_extra = data["project"]["optional-dependencies"]["dev"]
+    assert not any(d.lower().startswith("shapely") for d in dev_extra), dev_extra

--- a/tests/test_zones_fill_clearance.py
+++ b/tests/test_zones_fill_clearance.py
@@ -243,9 +243,18 @@ class TestForeignSegmentCarved:
         net0_seg = _segment_copper(0, 12, 20, 12, 0.25)
         assert fill.intersection(net0_seg).area > 0.0
 
-    def test_no_shapely_is_noop(self, monkeypatch):
-        """With shapely unavailable the carve is a no-op, not a crash."""
+    def test_no_shapely_fails_loud(self, monkeypatch):
+        """With shapely unavailable the carve must FAIL LOUD, never silently no-op.
+
+        Previously this path returned 0 when shapely was missing, which the
+        caller could not distinguish from "nothing needed carving" -- so a
+        board with real ``clearance_pad_zone`` shorts was reported as a
+        clean fill (issue #3824).  The hardened behavior raises a
+        ``ModuleNotFoundError`` with an actionable install hint instead.
+        """
         import builtins
+
+        from kicad_tools import _shapely as shapely_guard
 
         real_import = builtins.__import__
 
@@ -255,9 +264,12 @@ class TestForeignSegmentCarved:
             return real_import(name, *args, **kwargs)
 
         monkeypatch.setattr(builtins, "__import__", _fake_import)
+        # Reset the cached availability so the guard re-probes under the block.
+        monkeypatch.setattr(shapely_guard, "_SHAPELY_AVAILABLE", None, raising=False)
         doc = _parse(_SEGMENT_BOARD)
-        modified = apply_foreign_pad_clearance(doc)
-        assert modified == 0
+        with pytest.raises(ModuleNotFoundError) as excinfo:
+            apply_foreign_pad_clearance(doc)
+        assert "kicad-tools[geometry]" in str(excinfo.value)
 
     def test_drc_reports_zero_segment_and_via_zone_errors(self, tmp_path):
         """End-to-end through the real DRC rules the CI gate runs."""

--- a/uv.lock
+++ b/uv.lock
@@ -1774,6 +1774,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "rich" },
+    { name = "shapely" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 
@@ -1800,6 +1801,7 @@ all = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "rtree" },
+    { name = "shapely" },
     { name = "weasyprint" },
 ]
 bayesian = [
@@ -1836,7 +1838,6 @@ dev = [
     { name = "responses" },
     { name = "rtree" },
     { name = "ruff" },
-    { name = "shapely" },
     { name = "weasyprint" },
 ]
 drc = [
@@ -1965,7 +1966,8 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "scikit-build-core", marker = "extra == 'native'", specifier = ">=0.8" },
     { name = "scikit-learn", marker = "extra == 'research'", specifier = ">=1.7.2" },
-    { name = "shapely", marker = "extra == 'dev'", specifier = ">=2.0" },
+    { name = "shapely", specifier = ">=2.0" },
+    { name = "shapely", marker = "extra == 'all'", specifier = ">=2.0" },
     { name = "shapely", marker = "extra == 'geometry'", specifier = ">=2.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
     { name = "weasyprint", marker = "extra == 'all'", specifier = ">=60.0" },


### PR DESCRIPTION
## Summary

`shapely` is the geometry backend for the project's two correctness-critical copper paths -- zone-fill clearance carving and the zone-vs-copper clearance DRC rules -- yet it was declared only under the optional `geometry`/`dev` extras. That produced three failure modes (issue #3824):

1. **Silent bad fills (HIGH):** the carve functions returned `0` when shapely was missing, indistinguishable from "nothing to carve", so a board with real `clearance_pad_zone` shorts was reported as a clean fill.
2. **Unguarded crash (HIGH):** the zone-clearance DRC rules imported shapely with bare `from shapely import ...` and died with a raw `ModuleNotFoundError` in `kct check`/`kct audit`.
3. **Packaging gap (MED):** shapely was missing from `[all]`.

This implements the curator's recommended **Option A (shapely as a core dependency)** plus defense-in-depth fail-loud guards.

## Changes

- **Packaging:** promote `shapely>=2.0` into `[project] dependencies`; add it explicitly to the `[all]` extra; drop the now-redundant `[dev]` pin; keep `[geometry]` as a back-compat alias. Regenerated `uv.lock`.
- **New shared guard** `src/kicad_tools/_shapely.py`: `has_shapely()` (cached boolean probe) and `require_shapely(feature)` (raises with a single actionable `install kicad-tools[geometry]` message).
- **Silent-bad-fill path hardened:** `apply_foreign_pad_clearance()` and `force_solid_on_isolated_island_pads()` now `require_shapely()` and raise loud instead of `return 0`.
- **CLI callers no longer swallow the failure:** `runner._apply_foreign_pad_clearance`, the zone-remediation loop, and `stitch_cmd` now propagate `ModuleNotFoundError` loud / warn that the fill is NOT clearance-correct (previously a blanket `except Exception: return` masked it).
- **DRC rules guarded:** `SegmentZoneClearanceRule.check` and `ViaZoneClearanceRule.check` call `require_shapely()` up front, degrading with the actionable message instead of a raw `ModuleNotFoundError`.
- **Convention unified:** `connectivity.py` now consumes the shared `has_shapely()`. `board_geometry.py` already fails loud with a friendly message; `generator.py` already has friendly fallbacks/messages -- left as-is.
- **Tests:** `tests/test_shapely_core_dependency.py` (shapely-absent monkeypatch proving the fill path and both DRC rules fail loud with the actionable hint, plus pyproject packaging assertions); updated `test_zones_fill_clearance.py::test_no_shapely_fails_loud` to assert the new invariant.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Default/[all] install runs `kct check` without `ModuleNotFoundError` | ✅ | shapely is now a core dep (and in `[all]`); guards raise actionable errors only on broken installs |
| Zone fill never silently omits pad clearance | ✅ | carve functions `require_shapely()` and raise; CLI callers propagate/warn loud instead of swallowing |
| No bare shapely import in reachable DRC/fill paths leaks a raw crash | ✅ | both DRC `check()` bodies and both carve entry points guard before any shapely touch |
| shapely>=2.0 in `[project] dependencies`; `[dev]`/`[geometry]` reconciled | ✅ | `test_shapely_is_core_dependency`, `test_shapely_present_in_all_extra`, `test_shapely_not_duplicated_in_dev_extra` |
| shapely-present fill still carves (no regression) | ✅ | existing `test_zones_fill_clearance.py` carve + zero-violation tests pass |

## Test Plan

- `uv run pytest tests/test_shapely_core_dependency.py` -- 10 passed.
- `uv run pytest -k 'clearance or zone or connectivity or shapely or fill or stitch'` -- 2399 passed, 4 skipped.
- `ruff check` / `ruff format --check` clean on touched files.
- `mypy` clean on new files; remaining errors in `connectivity.py`/`stitch_cmd.py`/`clearance.py` are pre-existing on `main` (unrelated lines).

Closes #3824