### PR TITLE
fix(drc): model pads as true roundrect/oval geometry, not bounding boxes

### DIFF
--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -165,6 +165,13 @@ class Pad:
     drill: float = 0.0
     solder_mask_margin: float | None = None
     uuid: str = ""
+    # Per-pad rotation in degrees (the optional third token of ``(at x y angle)``),
+    # relative to the parent footprint. The pad's absolute rotation is
+    # ``footprint.rotation + pad.rotation``. Defaults to 0.
+    rotation: float = 0.0
+    # Corner-radius ratio for ``roundrect`` pads: radius = rratio * min(w, h).
+    # KiCad's default is 0.25 when ``(roundrect_rratio ...)`` is absent.
+    roundrect_rratio: float = 0.25
 
     @property
     def net(self) -> int:
@@ -183,17 +190,24 @@ class Pad:
             layers=[],
         )
 
-        # Position
+        # Position (and optional per-pad rotation as the third token)
         if at := sexp.find("at"):
             x = at.get_float(0) or 0.0
             y = at.get_float(1) or 0.0
             pad.position = (x, y)
+            pad.rotation = at.get_float(2) or 0.0
 
         # Size
         if size := sexp.find("size"):
             w = size.get_float(0) or 0.0
             h = size.get_float(1) or w
             pad.size = (w, h)
+
+        # Corner radius ratio for roundrect pads (default 0.25 when absent)
+        if rratio := sexp.find("roundrect_rratio"):
+            value = rratio.get_float(0)
+            if value is not None:
+                pad.roundrect_rratio = value
 
         # Layers
         if layers := sexp.find("layers"):

--- a/src/kicad_tools/validate/rules/clearance.py
+++ b/src/kicad_tools/validate/rules/clearance.py
@@ -77,6 +77,14 @@ class CopperElement:
     # avoid re-reporting the same geometric pair on every spanned layer
     # (the endpoint-layer scan already covers them).
     explicit_layers: tuple[str, ...] = ()
+    # For pads: a precomputed shapely polygon of the TRUE copper outline
+    # (roundrect/oval honored) in board coordinates.  When two elements
+    # both carry a polygon -- or one polygon plus one circular via -- the
+    # clearance is computed via exact shapely geometry instead of the
+    # analytic axis-aligned-rectangle formulas, which over-approximate
+    # rounded corners and produce phantom sub-10um shorts (issue #3826).
+    # ``None`` for segments and vias (which use the analytic disc path).
+    polygon: object | None = None
 
     @classmethod
     def from_segment(cls, seg: Segment) -> CopperElement:
@@ -95,8 +103,13 @@ class CopperElement:
         """Create from a PCB pad with footprint context."""
         # Transform pad position from footprint-local to board coordinates
         abs_x, abs_y = _transform_pad_position(pad, footprint)
-        # Transform pad dimensions to axis-aligned bounding box
+        # Transform pad dimensions to axis-aligned bounding box (retained
+        # for the AABB-bounds fast path / location reporting).
         width, height = _transform_pad_dimensions(pad, footprint)
+        # Build the TRUE copper outline (roundrect/oval honored) so the
+        # pad-pad clearance path can use exact geometry instead of the
+        # over-approximating analytic AABB formulas (issue #3826).
+        polygon = _pad_polygon(pad, footprint)
         return cls(
             element_type="pad",
             layer="*",  # Pads can span multiple layers
@@ -104,6 +117,7 @@ class CopperElement:
             geometry=(abs_x, abs_y, width, height),
             reference=f"{footprint.reference}-{pad.number}",
             net_name=pad.net_name if pad.net_number != 0 else "",
+            polygon=polygon,
         )
 
     @classmethod
@@ -186,6 +200,74 @@ def _transform_pad_dimensions(pad: Pad, footprint: Footprint) -> tuple[float, fl
     new_height = width * sin_a + height * cos_a
 
     return new_width, new_height
+
+
+def _pad_polygon(pad: Pad, footprint: Footprint):
+    """Return a shapely polygon of a pad's copper in board coordinates.
+
+    Unlike :func:`_transform_pad_dimensions` (which returns only an
+    axis-aligned bounding box and therefore over-approximates rounded
+    corners), this builds the *true* copper outline honoring
+    ``pad.shape``:
+
+    * ``circle`` (and ``oval``/``obround`` with ``w == h``) -> exact disc.
+    * ``oval`` / ``obround`` -> stadium / capsule (rectangle core with
+      semicircular caps on the minor axis).
+    * ``roundrect`` -> rectangle with rounded corners of radius
+      ``roundrect_rratio * min(w, h)`` (KiCad default ratio 0.25).
+    * ``rect`` (and any unknown shape) -> exact rectangle, with no
+      over-approximation.
+
+    The polygon is built around the origin from the pad's *local* size,
+    rotated by the total rotation (``footprint.rotation + pad.rotation``)
+    and translated to the pad's absolute board position.  Modeling the
+    rounded geometry instead of an AABB removes the sub-10-micron phantom
+    corner overlaps that KiCad's true geometry never sees (issue #3826).
+
+    Returns ``None`` for degenerate (non-positive) sizes so callers can
+    skip them.
+    """
+    require_shapely("pad clearance geometry")
+    import shapely
+    from shapely.affinity import rotate, translate  # type: ignore[import-untyped]
+    from shapely.geometry import Point
+
+    cx, cy = _transform_pad_position(pad, footprint)
+    w, h = pad.size  # LOCAL size -- the rotation below orients the polygon
+    if w <= 0 or h <= 0:
+        return None
+
+    total_rot = footprint.rotation + getattr(pad, "rotation", 0.0)
+    shape = pad.shape
+
+    if shape == "circle" or (shape in ("oval", "obround") and abs(w - h) < 1e-6):
+        # Symmetric disc -- rotation and the (origin) translate are no-ops
+        # on a circle, so build it directly at the board position.
+        return Point(cx, cy).buffer(min(w, h) / 2.0)
+
+    if shape in ("oval", "obround"):
+        # Stadium / capsule: a core rectangle shrunk by the minor
+        # half-axis on the long dimension, buffered by that radius so the
+        # short ends become true semicircles.
+        r = min(w, h) / 2.0
+        if w >= h:
+            core = shapely.box(-(w / 2.0 - r), 0.0, (w / 2.0 - r), 0.0)
+        else:
+            core = shapely.box(0.0, -(h / 2.0 - r), 0.0, (h / 2.0 - r))
+        poly = core.buffer(r)
+    elif shape == "roundrect":
+        rr = getattr(pad, "roundrect_rratio", 0.25)
+        r = rr * min(w, h)
+        if r <= 0:
+            poly = shapely.box(-w / 2.0, -h / 2.0, w / 2.0, h / 2.0)
+        else:
+            inner = shapely.box(-(w / 2.0 - r), -(h / 2.0 - r), (w / 2.0 - r), (h / 2.0 - r))
+            poly = inner.buffer(r, join_style=1)  # round joins -> rounded corners
+    else:  # "rect" and any unknown shape -> exact rectangle (no over-approx)
+        poly = shapely.box(-w / 2.0, -h / 2.0, w / 2.0, h / 2.0)
+
+    poly = rotate(poly, total_rot, origin=(0, 0), use_radians=False)
+    return translate(poly, cx, cy)
 
 
 # _point_to_segment_distance and _segment_to_segment_distance are imported
@@ -433,8 +515,76 @@ def _rect_segment_centerline_distance(
     return min(candidates)
 
 
+def _element_to_shapely_geom(elem: CopperElement):
+    """Return a shapely geometry for a pad/via copper element.
+
+    Pads carry a precomputed ``polygon`` (true outline).  Vias (and any
+    element without a polygon) are represented as a circle buffered around
+    their center using the AABB diameter.  Returns ``None`` if no geometry
+    can be built.
+    """
+    if elem.polygon is not None:
+        return elem.polygon
+    from shapely.geometry import Point
+
+    x, y, w, h = elem.geometry
+    radius = max(w, h) / 2.0
+    if radius <= 0:
+        return None
+    return Point(x, y).buffer(radius)
+
+
+def _polygon_pair_clearance(
+    c1: CopperElement, c2: CopperElement
+) -> tuple[float, float, float] | None:
+    """Exact shapely clearance between two pad/via copper shapes.
+
+    Used when at least one element carries a true pad polygon.  Returns
+    ``(clearance_mm, loc_x, loc_y)`` with the standard sign convention
+    (negative when the shapes overlap), or ``None`` if a geometry could
+    not be built (caller falls back to the analytic path).
+    """
+    require_shapely("pad-pad clearance geometry")
+    g1 = _element_to_shapely_geom(c1)
+    g2 = _element_to_shapely_geom(c2)
+    if g1 is None or g2 is None:
+        return None
+
+    inter = g1.intersection(g2)
+    if not inter.is_empty and inter.area > 0:
+        # Real area overlap: most-negative clearance.  Approximate the
+        # penetration depth by the largest dimension of the
+        # intersection's bounding box -- monotonic in overlap and always
+        # < 0, which is all the DRC gate needs (a real short).
+        minx, miny, maxx, maxy = inter.bounds
+        depth = max(maxx - minx, maxy - miny)
+        clearance = -depth
+        loc_x = (minx + maxx) / 2.0
+        loc_y = (miny + maxy) / 2.0
+        return clearance, loc_x, loc_y
+
+    # Disjoint, or merely touching at a point/edge (zero-area
+    # intersection).  ``distance`` is 0 for a touch, which is the correct
+    # edge-to-edge clearance.
+    dist = g1.distance(g2)
+    from shapely.ops import nearest_points
+
+    p1, p2 = nearest_points(g1, g2)
+    loc_x = (p1.x + p2.x) / 2.0
+    loc_y = (p1.y + p2.y) / 2.0
+    return dist, loc_x, loc_y
+
+
 def _circle_circle_clearance(c1: CopperElement, c2: CopperElement) -> tuple[float, float, float]:
     """Calculate clearance between two pads/vias.
+
+    When either element carries a precomputed pad polygon (roundrect /
+    oval / rect pads), the clearance is computed with exact shapely
+    geometry so rounded corners are not over-approximated as a bounding
+    box (which produced phantom sub-10um pad-pad shorts -- issue #3826).
+    The analytic disc/AABB path below is retained for the common via-via
+    case (pure circles), where it is exact and avoids per-pair shapely
+    overhead.
 
     For vias (circular), uses circle-to-circle distance.
     For rectangular pads, uses axis-aligned rectangle-to-rectangle distance.
@@ -442,6 +592,15 @@ def _circle_circle_clearance(c1: CopperElement, c2: CopperElement) -> tuple[floa
     """
     x1, y1, w1, h1 = c1.geometry
     x2, y2, w2, h2 = c2.geometry
+
+    # Exact-geometry path: when at least one element is a pad with a true
+    # copper polygon, use shapely so rounded corners are modeled
+    # faithfully.  A circular via (no polygon) is represented as a
+    # buffered point; this keeps pad-via and pad-pad pairs exact.
+    if c1.polygon is not None or c2.polygon is not None:
+        result = _polygon_pair_clearance(c1, c2)
+        if result is not None:
+            return result
 
     # Check if elements are circular (vias or square pads)
     is_circular_1 = c1.element_type == "via" or abs(w1 - h1) < 0.001
@@ -954,7 +1113,7 @@ class _ZoneFill:
     polygon: object  # shapely (Multi)Polygon
 
 
-def _repair_fill_polygon(poly):  # type: ignore[no-untyped-def]
+def _repair_fill_polygon(poly):
     """Repair an invalid fill ring, preserving every copper lobe.
 
     Stale fills can carry self-touching outlines (KiCad traces knockout
@@ -1352,16 +1511,13 @@ class ViaZoneClearanceRule(DRCRule):
                         continue
                     if not _pad_on_layer(pad, layer):
                         continue
-                    abs_x, abs_y = _transform_pad_position(pad, fp)
-                    width, height = _transform_pad_dimensions(pad, fp)
-                    if width <= 0 or height <= 0:
+                    # Build the TRUE pad copper outline (roundrect/oval
+                    # honored) rather than an axis-aligned bounding box so
+                    # rounded corners do not produce phantom sub-10um
+                    # shorts against foreign-net fills (issue #3826).
+                    shape = _pad_polygon(pad, fp)
+                    if shape is None:
                         continue
-                    shape = shapely.box(
-                        abs_x - width / 2.0,
-                        abs_y - height / 2.0,
-                        abs_x + width / 2.0,
-                        abs_y + height / 2.0,
-                    )
                     ref = f"{fp.reference}-{pad.number}"
                     self._query_and_check(
                         tree,

--- a/tests/test_pad_polygon_geometry.py
+++ b/tests/test_pad_polygon_geometry.py
@@ -1,0 +1,155 @@
+"""Unit tests for true-geometry pad polygons and pad-pad clearance (Issue #3826).
+
+``src/kicad_tools/validate/rules/clearance.py`` previously modeled every
+pad as an axis-aligned bounding box, over-approximating the rounded
+corners of ``roundrect``/``oval`` pads.  When such a corner sat next to a
+foreign-net zone fill (or another pad) at the design minimum clearance,
+the phantom corner triangle produced a sub-10-micron "overlap" that
+KiCad's true rounded geometry never sees -- a false-positive
+``clearance_pad_zone`` / ``clearance_pad_pad`` short.
+
+These tests cover the shared ``_pad_polygon`` helper (exact outline per
+shape + rotation) and the pad-pad clearance path that now consumes it.
+"""
+
+from __future__ import annotations
+
+import math
+
+from kicad_tools.schema.pcb import Footprint, Pad
+from kicad_tools.validate.rules.clearance import (
+    CopperElement,
+    _calculate_clearance,
+    _pad_polygon,
+)
+
+
+def _fp(position=(0.0, 0.0), rotation=0.0) -> Footprint:
+    return Footprint(
+        name="fp",
+        reference="U1",
+        value="",
+        position=position,
+        rotation=rotation,
+        layer="F.Cu",
+    )
+
+
+def _pad(shape, size, position=(0.0, 0.0), rotation=0.0, rratio=0.25) -> Pad:
+    return Pad(
+        number="1",
+        type="smd",
+        shape=shape,
+        position=position,
+        size=size,
+        layers=["F.Cu"],
+        net_number=1,
+        net_name="SIG",
+        rotation=rotation,
+        roundrect_rratio=rratio,
+    )
+
+
+class TestPadPolygonShapes:
+    def test_rect_pad_equals_exact_box(self):
+        poly = _pad_polygon(_pad("rect", (1.0, 2.0)), _fp())
+        assert abs(poly.area - 2.0) < 1e-9
+
+    def test_roundrect_area_strictly_below_aabb(self):
+        poly = _pad_polygon(_pad("roundrect", (1.0, 2.0)), _fp())
+        aabb = 1.0 * 2.0
+        # Corner triangles are removed -> area must be less than the AABB.
+        assert poly.area < aabb
+        # ...but not radically smaller (only the four rounded corners).
+        assert poly.area > aabb * 0.9
+
+    def test_circle_pad_matches_disc(self):
+        poly = _pad_polygon(_pad("circle", (2.0, 2.0)), _fp())
+        assert abs(poly.area - math.pi * 1.0**2) < 0.01
+
+    def test_oval_pad_is_stadium_between_circle_and_box(self):
+        poly = _pad_polygon(_pad("oval", (3.0, 1.0)), _fp())
+        # Stadium = core rect (w-2r) x h + circle of radius r ; r = 0.5
+        expected = (3.0 - 1.0) * 1.0 + math.pi * 0.5**2
+        assert abs(poly.area - expected) < 0.01
+        # Bounded by inscribed circle (area) and bounding rectangle.
+        assert math.pi * 0.5**2 < poly.area < 3.0 * 1.0
+
+    def test_oval_with_equal_axes_degenerates_to_circle(self):
+        poly = _pad_polygon(_pad("oval", (2.0, 2.0)), _fp())
+        assert abs(poly.area - math.pi) < 0.01
+
+    def test_default_rratio_used_when_unset(self):
+        # A bare roundrect Pad (rratio default 0.25) rounds its corners.
+        pad = Pad(
+            number="1",
+            type="smd",
+            shape="roundrect",
+            position=(0.0, 0.0),
+            size=(2.0, 2.0),
+            layers=["F.Cu"],
+        )
+        assert pad.roundrect_rratio == 0.25
+        assert _pad_polygon(pad, _fp()).area < 4.0
+
+    def test_zero_size_returns_none(self):
+        assert _pad_polygon(_pad("rect", (0.0, 1.0)), _fp()) is None
+
+
+class TestPadPolygonRotation:
+    def test_footprint_rotation_90_swaps_extents(self):
+        poly = _pad_polygon(_pad("rect", (4.0, 1.0)), _fp(rotation=90.0))
+        minx, miny, maxx, maxy = poly.bounds
+        assert abs((maxy - miny) - 4.0) < 1e-6
+        assert abs((maxx - minx) - 1.0) < 1e-6
+
+    def test_per_pad_rotation_adds_to_footprint_rotation(self):
+        # footprint 45deg + pad 45deg = 90deg total -> extents swap.
+        poly = _pad_polygon(_pad("rect", (4.0, 1.0), rotation=45.0), _fp(rotation=45.0))
+        minx, miny, maxx, maxy = poly.bounds
+        assert abs((maxy - miny) - 4.0) < 1e-5
+        assert abs((maxx - minx) - 1.0) < 1e-5
+
+    def test_translation_to_board_position(self):
+        poly = _pad_polygon(_pad("rect", (1.0, 1.0)), _fp(position=(10.0, 20.0)))
+        assert abs(poly.centroid.x - 10.0) < 1e-9
+        assert abs(poly.centroid.y - 20.0) < 1e-9
+
+
+class TestPadPadClearance:
+    """Pad-vs-pad clearance now uses true polygons (Issue #3826)."""
+
+    def _elem(self, shape, size, position):
+        fp = _fp(position=position)
+        return CopperElement.from_pad(_pad(shape, size), fp)
+
+    def test_roundrect_corner_clears_no_false_overlap(self):
+        # Two 1x1 roundrect pads whose AABB corners just touch diagonally.
+        # Sharp-corner AABBs would touch (clearance ~0); the rounded
+        # corners leave a real positive gap, so clearance must be > 0.
+        a = self._elem("roundrect", (1.0, 1.0), (0.0, 0.0))
+        b = self._elem("roundrect", (1.0, 1.0), (1.0, 1.0))
+        clearance, _, _ = _calculate_clearance(a, b)
+        assert clearance > 0.0, "rounded corners must leave a positive gap"
+
+    def test_rect_corner_touch_is_zero_clearance(self):
+        # Control: sharp rect corners diagonally adjacent -> ~0 clearance.
+        a = self._elem("rect", (1.0, 1.0), (0.0, 0.0))
+        b = self._elem("rect", (1.0, 1.0), (1.0, 1.0))
+        clearance, _, _ = _calculate_clearance(a, b)
+        assert abs(clearance) < 1e-6
+
+    def test_real_body_overlap_still_negative(self):
+        # Two pads that genuinely overlap in the body must report a
+        # negative (overlapping) clearance.
+        a = self._elem("roundrect", (2.0, 2.0), (0.0, 0.0))
+        b = self._elem("roundrect", (2.0, 2.0), (1.0, 0.0))
+        clearance, _, _ = _calculate_clearance(a, b)
+        assert clearance < 0.0, "real body overlap must remain a short"
+
+    def test_separated_pads_positive_clearance(self):
+        a = self._elem("roundrect", (1.0, 1.0), (0.0, 0.0))
+        b = self._elem("roundrect", (1.0, 1.0), (5.0, 0.0))
+        clearance, _, _ = _calculate_clearance(a, b)
+        # Edge-to-edge: centers 5mm apart, half-widths 0.5 each -> ~4.0mm.
+        assert abs(clearance - 4.0) < 1e-3

--- a/tests/test_validate_via_zone_clearance.py
+++ b/tests/test_validate_via_zone_clearance.py
@@ -57,6 +57,8 @@ class _FakePad:
     net_name: str = "SIG"
     number: str = "1"
     rotation: float = 0.0
+    shape: str = "rect"
+    roundrect_rratio: float = 0.25
 
 
 @dataclass
@@ -334,6 +336,67 @@ class TestPadZone:
         fp = _FakeFootprint(pads=[pad])
         results = _run([zone], footprints=[fp])
         assert results.violations == []
+
+
+# ---------------------------------------------------------------------------
+# Rounded-pad geometry regression (Issue #3826)
+#
+# The fill occupies x,y in [100,110].  Its bottom-left corner is at
+# (100, 100).  We place a 1x1 mm pad in the third quadrant relative to
+# that corner so ONLY the pad's top-right corner is near the fill.  For a
+# roundrect/oval pad the rounded corner clears the fill, while the
+# square AABB used by the old code pokes into it -> phantom short.
+# ---------------------------------------------------------------------------
+
+
+class TestRoundedPadCornerNoPhantomShort:
+    # min_clearance well below the AABB poke-in so we isolate the
+    # short/overlap behavior, not a clearance graze.
+    _MIN_CLEARANCE = 0.001
+
+    def _pad_corner_overlap_setup(self, shape, rratio=0.25):
+        zone = _FakeZone(filled_polygons=[_SQUARE_FILL])
+        # AABB corner of the pad pokes ~0.06mm diagonally into the fill
+        # corner: place pad center so its top-right AABB corner is at
+        # (100.04, 100.04) -- inside the fill -- but the rounded corner
+        # (radius 0.25mm) is pulled back inboard and clears (100,100).
+        cx = 100.04 - 0.5
+        cy = 100.04 - 0.5
+        pad = _FakePad(position=(cx, cy), size=(1.0, 1.0), shape=shape, roundrect_rratio=rratio)
+        fp = _FakeFootprint(pads=[pad], reference="U3")
+        return zone, fp
+
+    def test_rect_pad_aabb_corner_overlaps_is_short(self):
+        # Control: a plain rect pad's sharp corner genuinely overlaps the
+        # fill corner, so a violation MUST be reported.
+        zone, fp = self._pad_corner_overlap_setup("rect")
+        results = _run([zone], footprints=[fp], min_clearance=self._MIN_CLEARANCE)
+        shorts = [v for v in results.violations if v.rule_id == "clearance_pad_zone"]
+        assert len(shorts) == 1, "rect pad with overlapping corner must short"
+
+    def test_roundrect_pad_corner_clears_no_phantom_short(self):
+        # The bug: the roundrect's rounded corner clears the fill, so the
+        # NEW true-geometry code must report NO short (old AABB code did).
+        zone, fp = self._pad_corner_overlap_setup("roundrect")
+        results = _run([zone], footprints=[fp], min_clearance=self._MIN_CLEARANCE)
+        shorts = [v for v in results.violations if v.rule_id == "clearance_pad_zone"]
+        assert shorts == [], "roundrect rounded corner must not phantom-short"
+
+    def test_oval_pad_corner_clears_no_phantom_short(self):
+        zone, fp = self._pad_corner_overlap_setup("oval")
+        results = _run([zone], footprints=[fp], min_clearance=self._MIN_CLEARANCE)
+        shorts = [v for v in results.violations if v.rule_id == "clearance_pad_zone"]
+        assert shorts == [], "oval (circular) corner must not phantom-short"
+
+    def test_roundrect_genuine_body_overlap_still_shorts(self):
+        # Guard: a roundrect pad whose BODY (not just the phantom corner)
+        # overlaps the fill must still be flagged.
+        zone = _FakeZone(filled_polygons=[_SQUARE_FILL])
+        pad = _FakePad(position=(100.4, 105.0), size=(1.0, 1.0), shape="roundrect")
+        fp = _FakeFootprint(pads=[pad], reference="U4")
+        results = _run([zone], footprints=[fp], min_clearance=self._MIN_CLEARANCE)
+        shorts = [v for v in results.violations if v.rule_id == "clearance_pad_zone"]
+        assert len(shorts) == 1, "deep roundrect body overlap must still short"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`kct check` over-reported copper shorts relative to the authoritative `kicad-cli pcb drc`. The clearance DRC modeled every pad as an axis-aligned bounding box (AABB), so `roundrect` / `oval` pad corners poked past the true copper by up to ~(1 - cos45)*corner_radius. When such a phantom corner sat next to a foreign-net zone fill (or another pad) at the design minimum clearance, it produced sub-10-micron false-positive `clearance_pad_zone` / `clearance_pad_pad` shorts that KiCad's true rounded geometry never sees — stalling the clean-rebuild gate on boards with rounded pads (board-02: 26 roundrect + 4 oval pads).

This fixes BOTH independent AABB sites (the curator confirmed there were two) with a single shared true-geometry helper so they can never drift again.

## Changes

- `src/kicad_tools/schema/pcb.py` — `Pad` now parses the two fields the fix needs and that were previously dropped:
  - `roundrect_rratio` (corner-radius ratio; KiCad default `0.25`)
  - per-pad `rotation` (the optional third token of `(at x y angle)`)
- `src/kicad_tools/validate/rules/clearance.py`
  - New shared `_pad_polygon()` helper builds the true shapely outline per shape: roundrect (rounded corners), oval/obround (stadium/capsule), circle (disc), exact rect — including `footprint.rotation + pad.rotation`.
  - **Pad-vs-zone** (`ViaZoneClearanceRule`): replaced the `shapely.box` pad construction with `_pad_polygon`.
  - **Pad-vs-pad** (`ClearanceRule`): `CopperElement` now carries a precomputed pad polygon; the pad path routes through exact shapely distance/intersection (`_polygon_pair_clearance`) instead of the analytic AABB formulas. Via-via stays on the fast analytic disc path (no perf regression on dense boards).
  - Uses `require_shapely(...)` (no silent degrade) since there is no correct pure-Python fallback for rounded pads.
- Tests — new `tests/test_pad_polygon_geometry.py` (helper geometry + rotation + pad-pad) and added a `TestRoundedPadCornerNoPhantomShort` class to `tests/test_validate_via_zone_clearance.py`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Roundrect/oval pad near a zone that false-positived now PASSES | ✅ | `TestRoundedPadCornerNoPhantomShort::test_roundrect/oval_pad_corner_clears_no_phantom_short` |
| Roundrect/oval pad near another pad that false-positived now PASSES | ✅ | `TestPadPadClearance::test_roundrect_corner_clears_no_false_overlap` |
| Genuine overlap still FAILS (zone + pad) | ✅ | `test_roundrect_genuine_body_overlap_still_shorts`, `test_real_body_overlap_still_negative` |
| `_pad_polygon` exact outlines (roundrect < AABB, oval stadium, circle disc, rect exact, rotation) | ✅ | `TestPadPolygonShapes`, `TestPadPolygonRotation` |
| Pad model parses `roundrect_rratio` + per-pad rotation | ✅ | Boards 02/04 load 30/79 rounded pads with `rratio=0.25` parsed |
| kct agrees with kicad-cli on board 02 | ✅ | Both report 0 copper shorts (`kct check` 0 violations; `kicad-cli pcb drc` "Found 0 violations") |
| Genuine detections preserved on board 04 | ✅ | Baseline vs new code report identical real-violation counts at tightened clearances |
| Perf sanity (no via-via shapely) | ✅ | Via-via remains on analytic path; STRtree pre-filter retained |

## Test Plan

- `uv run pytest tests/test_pad_polygon_geometry.py tests/test_validate_via_zone_clearance.py tests/test_validate_clearance_rect_pad.py tests/test_drc_pad_clearance_epsilon.py tests/test_validate_segment_zone_clearance.py tests/test_same_component_clearance.py` → 132 passed
- `uv run pytest tests/test_schema.py` → 162 passed (Pad model changes are backward-compatible)
- `uv run ruff check` / `ruff format --check` on touched files → clean
- mypy baseline gate: zero new errors from this PR (the one remaining `recovery/strategy.py` finding pre-exists on clean `origin/main` and is unrelated)
- e2e: `kct check` on boards 02/04 + `kicad-cli pcb drc` parity confirmed

Closes #3826