### PR TITLE
fix(ci): raise board-05 blocking gate to 11 to stop 9-vs-10 flakiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1431,21 +1431,29 @@ jobs:
     # fewer nets than the Linux CI router).  Because of that divergence there
     # was no validation path for board-05 routing work (#3775, #3766) -- this
     # job provides one by regenerating + re-routing board 05 INSIDE the CI
-    # container and hard-asserting blocking_incomplete_count <= 9.
+    # container and hard-asserting blocking_incomplete_count <= 11.
     #
-    # REPRODUCIBLE CI FLOOR IS 9, NOT 7.  The committed on-disk artifact is 7
-    # blocking, but that 7-blocking board is NOT reproducible from the current
-    # recipe: a fresh full re-route inside CI (timeout raised to 90 min so it
-    # runs to completion) MEASURES blocking_incomplete_count = 9 (blocking
-    # nets: ISENSE_A+, ISENSE_A-, ISENSE_B+, ISENSE_B-, ISENSE_C-, PHASE_A,
-    # PHASE_B, PHASE_C, PWM_BH).  The 7 -> 9 gap between the committed artifact
-    # and a fresh CI re-route is the board-05 routing reproducibility
-    # regression tracked in #3775 / #3766.  This gate is therefore calibrated
-    # to the MEASURED, REPRODUCIBLE floor of 9 -- NOT the aspirational,
-    # non-reproducible committed value of 7.  This is calibration to reality,
-    # not gate-weakening: the gate stays a hard assertion (no
-    # continue-on-error) and guards against regressions BEYOND 9.  Tighten
-    # --max-blocking back toward 7 (then 0) as #3775 / #3766 land.
+    # CI RE-ROUTE IS NONDETERMINISTIC (9-10); THRESHOLD IS A TEMPORARY LOOSE
+    # BOUND OF 11 (issue #3836).  The committed on-disk artifact is 7 blocking,
+    # but that 7-blocking board is NOT reproducible from the current recipe AND
+    # a fresh full re-route inside CI (timeout raised to 90 min so it runs to
+    # completion) is itself nondeterministic at its floor: it MEASURES
+    # blocking_incomplete_count = 9 OR 10 depending on the run (observed:
+    # main=9, PR #3835 branch=10 on two consecutive runs with IDENTICAL router
+    # code; blocking nets hover around ISENSE_A+/-, ISENSE_B+/-, ISENSE_C-,
+    # PHASE_A/B/C, PWM_BH, +HALL_A intermittently).  The 7 -> 9/10 gap between
+    # the committed artifact and a fresh CI re-route is the board-05 routing
+    # reproducibility regression tracked in #3775 / #3766 / #3829.  The
+    # previous default of 9 sat EXACTLY on the nondeterministic 9-vs-10 floor,
+    # so a coin-flip re-route intermittently red-lighted PRs that never touched
+    # the router (#3836, observed on PR #3835).  --max-blocking is therefore
+    # set to 11, a safe margin above the observed CI ceiling of 10, so the gate
+    # stops flaking.  This is a TEMPORARY loose bound, not the end state: the
+    # gate stays a hard assertion (no continue-on-error) and still catches
+    # GROSS regressions (> 11).  The proper fix is a DETERMINISTIC re-route
+    # (pin seed / iteration order), after which --max-blocking should be
+    # tightened back toward 7 (the committed artifact) then 0 -- tracked in
+    # #3775 / #3766 / #3829.
     #
     # Unlike boards 00-03/06/07, board 05 has NO committed output/lvs.json on
     # origin/main, so the --lvs-only e2e asserter is not reusable.  The
@@ -1454,10 +1462,11 @@ jobs:
     # NetStatusAnalyzer.blocking_incomplete_count (which mirrors the
     # check_routed_drc advisory/plane-residual filtering).
     #
-    # The --max-blocking threshold defaults to 9 (the measured reproducible CI
-    # floor) and is a CLI arg so #3775/#3766 can tighten it back toward 7/0 as
-    # routing improves.  <= 9 catches regressions beyond the current floor
-    # without requiring full parity (0 blocking).
+    # The --max-blocking threshold defaults to 11 (a TEMPORARY loose bound
+    # above the observed nondeterministic CI ceiling of 10) and is a CLI arg so
+    # #3775/#3766/#3829 can tighten it back toward 7/0 once the re-route is
+    # deterministic.  <= 11 catches GROSS regressions without flaking on the
+    # 9-vs-10 nondeterminism.
     #
     # The ``Build C++ router backend`` step is REQUIRED: the recipe re-routes
     # during regen, and per CLAUDE.md a missing native extension makes routing
@@ -1468,7 +1477,7 @@ jobs:
     # be the assertion.
     #
     # CI-VALIDATED ONLY: do NOT expect this job to pass on the macOS host
-    # (host routes board 05 to ~11 blocking, a fresh CI re-route to 9).
+    # (host routes board 05 to ~11 blocking, a fresh CI re-route to 9-10).
     # Advisory until a repo admin adds it to branch protection (same as the
     # board 00/01/02/03/06/07 e2e jobs).
     #
@@ -1481,11 +1490,12 @@ jobs:
     # verdict.  The run was on track for ~45-55 min wall-clock, so the budget
     # is set generously to 90 min to let the full route + rescue loop + gate
     # run to completion and emit a REAL blocking-net count.  With the timeout
-    # raised, the run completed and MEASURED 9 blocking nets, so the gate is
-    # calibrated to <= 9 (green at 9) -- see the floor note above.  This is
+    # raised, the run completed and MEASURED 9-10 blocking nets (nondeter-
+    # ministic), so the gate is set to <= 11 to clear the ceiling without
+    # flaking (#3836) -- see the floor note above.  This is
     # intentionally higher than every other job (next-highest is the 45-min
     # Test job) because no other job runs the board-05 rescue loop from clean.
-    name: Board 05 Routing Regression (blocking <= 9)
+    name: Board 05 Routing Regression (blocking <= 11)
     runs-on: ubuntu-latest
     timeout-minutes: 90
     container:
@@ -1533,19 +1543,22 @@ jobs:
             /tmp/board05-ci || true
           test -f /tmp/board05-ci/bldc_controller_routed.kicad_pcb
 
-      - name: Assert blocking-net baseline (<= 9, the measured CI floor)
-        # Hard gate: fails the job (exit 2) if blocking_incomplete_count > 9.
-        # The committed on-disk artifact is 7 blocking, but a fresh CI re-route
-        # currently reaches 9 (blocking nets: ISENSE_A+/-, ISENSE_B+/-,
-        # ISENSE_C-, PHASE_A/B/C, PWM_BH).  The 7 -> 9 gap is the board-05
-        # reproducibility regression tracked in #3775/#3766; this gate guards
-        # against regressions BEYOND the current reproducible floor of 9.
-        # Tighten --max-blocking back toward 7/0 as #3775/#3766 land.  A LOCAL
-        # macOS run would report ~11 -- the documented host-vs-CI divergence
-        # (#3822), not a job defect.  No continue-on-error: this stays a hard
-        # gate and now goes GREEN at <= 9.
+      - name: Assert blocking-net baseline (<= 11, a temporary loose bound)
+        # Hard gate: fails the job (exit 2) if blocking_incomplete_count > 11.
+        # 11 is a TEMPORARY loose bound (issue #3836): board-05's CI re-route is
+        # NONDETERMINISTIC (9-10 blocking; observed main=9, PR #3835 branch=10
+        # twice with identical router code) and diverges from the committed
+        # artifact (7 blocking).  The previous default of 9 sat exactly on the
+        # 9-vs-10 boundary and intermittently red-lighted unrelated PRs, so the
+        # threshold is set a safe margin above the observed ceiling of 10.  The
+        # gate still catches GROSS regressions (> 11).  The 7 -> 9/10 gap is the
+        # board-05 reproducibility regression tracked in #3775/#3766/#3829; the
+        # proper fix is a DETERMINISTIC re-route, then tightening --max-blocking
+        # back toward 7/0.  A LOCAL macOS run would report ~11 -- the documented
+        # host-vs-CI divergence (#3822), not a job defect.  No
+        # continue-on-error: this stays a hard gate and now reliably goes GREEN.
         run: |
           set -euo pipefail
           uv run python scripts/ci/check_board_05_blocking.py \
-            --max-blocking 9 \
+            --max-blocking 11 \
             /tmp/board05-ci/bldc_controller_routed.kicad_pcb

--- a/scripts/ci/check_board_05_blocking.py
+++ b/scripts/ci/check_board_05_blocking.py
@@ -9,45 +9,55 @@ macOS host router reaches fewer nets than the Linux CI router on the
 identical recipe). See the recipe note in
 ``boards/05-bldc-motor-controller/design.py`` (~lines 2870-2871).
 
-Reproducible CI floor is 9, not 7
----------------------------------
+CI re-route is NONDETERMINISTIC (9-10 blocking); threshold is a TEMPORARY loose bound of 11
+-------------------------------------------------------------------------------------------
 The committed on-disk artifact is 7 blocking, but that 7-blocking board is
 NOT reproducible from the current recipe -- a fresh full re-route INSIDE
 CI (kicad/kicad:10.0, timeout raised to 90 min so it runs to completion)
-measures **blocking_incomplete_count = 9** (blocking nets: ISENSE_A+,
-ISENSE_A-, ISENSE_B+, ISENSE_B-, ISENSE_C-, PHASE_A, PHASE_B, PHASE_C,
-PWM_BH). The 7 -> 9 gap between the committed artifact and a fresh CI
-re-route is the board-05 routing reproducibility regression tracked in
-**#3775 / #3766**.
+is ALSO nondeterministic at its floor: it measures
+**blocking_incomplete_count = 9 OR 10 depending on the run** (observed:
+main re-routes to 9, the PR #3835 branch -- whose router code is identical
+to main -- re-routed to 10 on two consecutive CI runs). The blocking nets
+hover around: ISENSE_A+, ISENSE_A-, ISENSE_B+, ISENSE_B-, ISENSE_C-,
+PHASE_A, PHASE_B, PHASE_C, PWM_BH (+ HALL_A intermittently). The 7 -> 9/10
+gap between the committed artifact and a fresh CI re-route is the board-05
+routing reproducibility regression tracked in **#3775 / #3766 / #3829**.
 
-This gate is therefore calibrated to the MEASURED, REPRODUCIBLE CI floor
-of **9** (the default ``--max-blocking``), not to the aspirational,
-non-reproducible committed value of 7. This is calibration to reality, not
-gate-weakening: the gate is a hard assertion (no ``continue-on-error``) and
-guards against regressions BEYOND the current reproducible floor of 9. As
-#3775 / #3766 land routing improvements, tighten ``--max-blocking`` back
-toward 7 (the committed artifact) and ultimately 0, locking in each gain.
+``--max-blocking`` therefore defaults to **11** -- a TEMPORARY loose bound
+chosen to stop CI flakiness. The previous default of 9 sat EXACTLY on the
+nondeterministic 9-vs-10 boundary, so a coin-flip re-route red-lighted PRs
+that never touched the router (issue #3836, observed on PR #3835). 11 is a
+safe margin above the observed CI ceiling of 10, so the gate stops flaking
+while remaining a hard assertion (no ``continue-on-error``) that still
+catches GROSS regressions (anything > 11 blocking).
+
+This is a deliberately LOOSE, temporary bound -- not the end state. The
+proper fix is to make the board-05 re-route DETERMINISTIC (pin seed /
+iteration order) and then tighten ``--max-blocking`` back toward 7 (the
+committed artifact) and ultimately 0, locking in each gain. That work is
+tracked in **#3775 / #3766 / #3829**.
 
 Validation path for board-05 routing changes
 ---------------------------------------------
 Regenerate board-05 **in the CI environment** (the ``kicad/kicad:10.0``
 container) and let the board-05 CI job assert
-``blocking_incomplete_count <= 9`` via this gate. A LOCAL run of this gate
-after a full host regen will report ~11 and exit 2 -- that is the
-documented host-vs-CI reach divergence (#3822), NOT a defect in this
-script or the job. The authoritative verdict is the PR's own CI run.
+``blocking_incomplete_count <= 11`` via this gate. A LOCAL run of this gate
+after a full host regen reports ~11 -- that is the documented host-vs-CI
+reach divergence (#3822), NOT a defect in this script or the job. The
+authoritative verdict is the PR's own CI run.
 
 This gate loads the routed board-05 PCB and asserts that the number of
-blocking incomplete nets does not exceed ``--max-blocking`` (default 9).
+blocking incomplete nets does not exceed ``--max-blocking`` (default 11).
 It reuses :class:`kicad_tools.analysis.net_status.NetStatusAnalyzer` --
 whose ``blocking_incomplete_count`` "Mirrors
 ``scripts/ci/check_routed_drc.py:_count_blocking_errors``", i.e. it applies
 the same advisory/plane-residual filtering the DRC gate uses -- rather than
 re-deriving the metric.
 
-The ``--max-blocking`` threshold is a CLI argument (default 9, the measured
-reproducible CI floor) so future PRs (#3775 PHASE relayout, #3766 complete
-the blocking nets) can tighten it to 8, 7, ... 0 as they land routing
+The ``--max-blocking`` threshold is a CLI argument (default 11, a temporary
+loose bound above the observed nondeterministic CI ceiling of 10) so future
+PRs (#3775 PHASE relayout, #3766 complete the blocking nets, #3829 make the
+re-route deterministic) can tighten it to 7, ... 0 as they land routing
 improvements, locking in each gain.
 
 Exit codes (mirrors ``scripts/ci/check_routed_drc.py``):
@@ -65,12 +75,18 @@ import argparse
 import sys
 from pathlib import Path
 
-# Measured, reproducible CI floor for a fresh full re-route of board-05
-# (kicad/kicad:10.0, 90-min timeout): 9 blocking nets. The committed on-disk
-# artifact is 7, but that 7-blocking board is NOT reproducible from the
-# current recipe -- the 7 -> 9 gap is the reproducibility regression tracked
-# in #3775 / #3766. Tighten this back toward 7/0 as those land.
-DEFAULT_MAX_BLOCKING = 9
+# TEMPORARY loose bound (issue #3836). A fresh full re-route of board-05
+# (kicad/kicad:10.0, 90-min timeout) is NONDETERMINISTIC at its floor: it
+# reaches 9 OR 10 blocking nets depending on the run (observed: main=9,
+# PR #3835 branch=10 twice, with identical router code). The committed
+# on-disk artifact is 7, which is itself not reproducible from the current
+# recipe. The previous default of 9 sat exactly on the 9-vs-10 boundary and
+# intermittently red-lighted unrelated PRs. 11 is a safe margin above the
+# observed CI ceiling of 10, so the gate stops flaking while still catching
+# gross regressions (> 11). The proper fix is a DETERMINISTIC re-route, after
+# which this should be tightened back toward 7 then 0 -- tracked in
+# #3775 / #3766 / #3829.
+DEFAULT_MAX_BLOCKING = 11
 
 
 def annotate_error(file: str, message: str) -> None:
@@ -152,14 +168,17 @@ def check_pcb(pcb_path: Path, max_blocking: int) -> tuple[int, str]:
     return (
         2,
         f"Board-05 blocking-net regression: {count} blocking incomplete net(s) "
-        f"exceeds the measured reproducible CI floor of {max_blocking} "
-        f"(--max-blocking). The committed on-disk artifact is 7 blocking, but a "
-        f"fresh CI re-route reaches 9 (the 7 -> 9 reproducibility gap is tracked "
-        f"in #3775/#3766); this gate guards against regressions BEYOND that "
-        f"floor. Either fix the routing or, if the floor truly moved, adjust "
-        f"--max-blocking in the CI job with reviewer sign-off. NOTE: a LOCAL "
-        f"macOS run routes board-05 to ~11 blocking nets; this gate is "
-        f"CI-validated only (#3822).{names_suffix}",
+        f"exceeds --max-blocking={max_blocking}. This threshold is a TEMPORARY "
+        f"loose bound (issue #3836): board-05's CI re-route is NONDETERMINISTIC "
+        f"(9-10 blocking) and diverges from the committed artifact (7), so the "
+        f"default of 11 sits a safe margin above the observed CI ceiling of 10 "
+        f"to stop flakiness. The gate still catches GROSS regressions (> 11). "
+        f"The proper fix is a DETERMINISTIC re-route, then tightening this back "
+        f"toward 7 then 0 -- tracked in #3775/#3766/#3829. Either fix the "
+        f"routing or, if the floor truly moved, adjust --max-blocking in the CI "
+        f"job with reviewer sign-off. NOTE: a LOCAL macOS run routes board-05 to "
+        f"~11 blocking nets; this gate is CI-validated only (#3822)."
+        f"{names_suffix}",
     )
 
 
@@ -179,10 +198,11 @@ def main(argv: list[str] | None = None) -> int:
         default=DEFAULT_MAX_BLOCKING,
         help=(
             "Maximum allowed blocking_incomplete_count before the gate fails "
-            f"(default: {DEFAULT_MAX_BLOCKING}, the measured reproducible CI "
-            "floor; the committed artifact is 7 but a fresh CI re-route reaches "
-            "9 -- the 7->9 gap is tracked in #3775/#3766). Tighten this back "
-            "toward 7/0 in #3775/#3766 as routing improves."
+            f"(default: {DEFAULT_MAX_BLOCKING}, a TEMPORARY loose bound above "
+            "the observed nondeterministic CI ceiling of 10; board-05's CI "
+            "re-route is nondeterministic at 9-10 and diverges from the "
+            "committed artifact of 7 -- issue #3836). Tighten this back toward "
+            "7/0 once the re-route is made deterministic (#3775/#3766/#3829)."
         ),
     )
     args = parser.parse_args(argv)

--- a/tests/test_check_board_05_blocking.py
+++ b/tests/test_check_board_05_blocking.py
@@ -1,9 +1,11 @@
 """Tests for the board-05 blocking-net CI gate (issue #3822).
 
 ``scripts/ci/check_board_05_blocking.py`` regenerates + routes board 05 in
-CI and asserts ``blocking_incomplete_count <= --max-blocking`` (default 9,
-the measured reproducible CI floor; the committed artifact is 7 but a fresh
-CI re-route reaches 9 -- the 7->9 gap is tracked in #3775/#3766).
+CI and asserts ``blocking_incomplete_count <= --max-blocking`` (default 11,
+a TEMPORARY loose bound above the observed nondeterministic CI ceiling of
+10; board-05's CI re-route is nondeterministic at 9-10 and diverges from the
+committed artifact of 7 -- the gap is tracked in #3775/#3766/#3829, and the
+flaky-gate consequence in #3836).
 
 The pass/fail VERDICT against a real route is CI-only (the macOS host routes
 board 05 to ~11 blocking nets, not 7 -- the documented host-vs-CI reach
@@ -38,13 +40,48 @@ def _load_helper():
     return module
 
 
-def test_default_threshold_is_measured_ci_floor() -> None:
+def test_default_threshold_is_temporary_loose_bound() -> None:
     helper = _load_helper()
-    assert helper.DEFAULT_MAX_BLOCKING == 9
+    assert helper.DEFAULT_MAX_BLOCKING == 11
 
 
-def test_check_pcb_passes_at_ci_floor(tmp_path, monkeypatch) -> None:
-    """9 blocking nets with --max-blocking 9 -> exit 0 (the measured CI floor)."""
+def test_default_clears_nondeterministic_ci_floor(tmp_path, monkeypatch) -> None:
+    """Rationale for the default of 11 (issue #3836): board-05's CI re-route is
+    nondeterministic at 9-10 blocking, so the gate must pass at BOTH 9 and 10
+    and only fail above the observed ceiling.
+
+    This documents WHY 11 was chosen: 9 (main) and 10 (PR #3835 branch, twice,
+    identical router code) must both be green so the gate stops flaking, while
+    12 (a gross regression beyond the ceiling) must still red.
+    """
+    helper = _load_helper()
+    pcb = tmp_path / "bldc_controller_routed.kicad_pcb"
+    pcb.write_text("(kicad_pcb)")
+
+    def route_to(count: int):
+        monkeypatch.setattr(
+            helper,
+            "count_blocking",
+            lambda _p: (count, [f"NET{i}" for i in range(count)]),
+        )
+
+    # 9 and 10 -- the observed nondeterministic CI floor/ceiling -- both pass.
+    route_to(9)
+    assert helper.check_pcb(pcb, max_blocking=helper.DEFAULT_MAX_BLOCKING)[0] == 0
+    route_to(10)
+    assert helper.check_pcb(pcb, max_blocking=helper.DEFAULT_MAX_BLOCKING)[0] == 0
+
+    # 11 (the exact bound) still passes; 12 (gross regression) fails.
+    route_to(11)
+    assert helper.check_pcb(pcb, max_blocking=helper.DEFAULT_MAX_BLOCKING)[0] == 0
+    route_to(12)
+    exit_code, message = helper.check_pcb(pcb, max_blocking=helper.DEFAULT_MAX_BLOCKING)
+    assert exit_code == 2
+    assert "regression" in message.lower()
+
+
+def test_check_pcb_passes_at_ci_ceiling(tmp_path, monkeypatch) -> None:
+    """10 blocking nets (observed CI ceiling) with --max-blocking 11 -> exit 0."""
     helper = _load_helper()
     pcb = tmp_path / "bldc_controller_routed.kicad_pcb"
     pcb.write_text("(kicad_pcb)")
@@ -52,28 +89,28 @@ def test_check_pcb_passes_at_ci_floor(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(
         helper,
         "count_blocking",
-        lambda _p: (9, [f"NET{i}" for i in range(9)]),
+        lambda _p: (10, [f"NET{i}" for i in range(10)]),
     )
 
-    exit_code, message = helper.check_pcb(pcb, max_blocking=9)
+    exit_code, message = helper.check_pcb(pcb, max_blocking=11)
     assert exit_code == 0
-    assert "9 blocking incomplete net(s)" in message
+    assert "10 blocking incomplete net(s)" in message
 
 
 def test_check_pcb_passes_when_below_threshold(tmp_path, monkeypatch) -> None:
-    """A future improvement (5 blocking) still passes the <= 9 gate."""
+    """A future improvement (5 blocking) still passes the <= 11 gate."""
     helper = _load_helper()
     pcb = tmp_path / "bldc_controller_routed.kicad_pcb"
     pcb.write_text("(kicad_pcb)")
 
     monkeypatch.setattr(helper, "count_blocking", lambda _p: (5, ["A", "B", "C", "D", "E"]))
 
-    exit_code, _ = helper.check_pcb(pcb, max_blocking=9)
+    exit_code, _ = helper.check_pcb(pcb, max_blocking=11)
     assert exit_code == 0
 
 
-def test_check_pcb_fails_on_regression(tmp_path, monkeypatch) -> None:
-    """11 blocking nets (the host divergence) with default threshold -> exit 2."""
+def test_check_pcb_fails_on_gross_regression(tmp_path, monkeypatch) -> None:
+    """12 blocking nets (beyond the observed ceiling) with default -> exit 2."""
     helper = _load_helper()
     pcb = tmp_path / "bldc_controller_routed.kicad_pcb"
     pcb.write_text("(kicad_pcb)")
@@ -81,22 +118,22 @@ def test_check_pcb_fails_on_regression(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(
         helper,
         "count_blocking",
-        lambda _p: (11, [f"NET{i}" for i in range(11)]),
+        lambda _p: (12, [f"NET{i}" for i in range(12)]),
     )
 
-    exit_code, message = helper.check_pcb(pcb, max_blocking=9)
+    exit_code, message = helper.check_pcb(pcb, max_blocking=11)
     assert exit_code == 2
     assert "regression" in message.lower()
-    assert "11 blocking incomplete net(s)" in message
+    assert "12 blocking incomplete net(s)" in message
 
 
 def test_check_pcb_fails_when_threshold_below_actual(tmp_path, monkeypatch) -> None:
-    """--max-blocking 0 against the measured 9 -> exit 2 (test-plan check)."""
+    """--max-blocking 0 against the measured 10 -> exit 2 (test-plan check)."""
     helper = _load_helper()
     pcb = tmp_path / "bldc_controller_routed.kicad_pcb"
     pcb.write_text("(kicad_pcb)")
 
-    monkeypatch.setattr(helper, "count_blocking", lambda _p: (9, [f"NET{i}" for i in range(9)]))
+    monkeypatch.setattr(helper, "count_blocking", lambda _p: (10, [f"NET{i}" for i in range(10)]))
 
     exit_code, _ = helper.check_pcb(pcb, max_blocking=0)
     assert exit_code == 2
@@ -104,8 +141,9 @@ def test_check_pcb_fails_when_threshold_below_actual(tmp_path, monkeypatch) -> N
 
 def test_check_pcb_fails_when_tightened_toward_committed(tmp_path, monkeypatch) -> None:
     """Tightening --max-blocking to 7 (the committed artifact) fails at the
-    current measured floor of 9 -- this is the lever #3775/#3766 will pull as
-    routing improves and the floor drops back to 7."""
+    current nondeterministic floor of 9-10 -- this is the lever
+    #3775/#3766/#3829 will pull once the re-route is deterministic and the
+    floor drops back to 7."""
     helper = _load_helper()
     pcb = tmp_path / "bldc_controller_routed.kicad_pcb"
     pcb.write_text("(kicad_pcb)")
@@ -142,8 +180,8 @@ def test_main_prints_measured_count_on_regression(tmp_path, monkeypatch, capsys)
     """The measured blocking count is surfaced on stdout EVEN when the gate fails.
 
     Requirement from issue #3822 follow-up: CI must be able to read the real
-    count from the log even on the failing (> threshold) path so a >7 result
-    is observable rather than papered over.
+    count from the log even on the failing (> threshold) path so a result above
+    the threshold is observable rather than papered over.
     """
     helper = _load_helper()
     pcb = tmp_path / "bldc_controller_routed.kicad_pcb"
@@ -152,12 +190,12 @@ def test_main_prints_measured_count_on_regression(tmp_path, monkeypatch, capsys)
     monkeypatch.setattr(
         helper,
         "count_blocking",
-        lambda _p: (11, [f"NET{i}" for i in range(11)]),
+        lambda _p: (12, [f"NET{i}" for i in range(12)]),
     )
 
     assert helper.main([str(pcb)]) == 2
     out = capsys.readouterr().out
-    assert "MEASURED blocking_incomplete_count = 11" in out
+    assert "MEASURED blocking_incomplete_count = 12" in out
 
 
 def test_main_parses_max_blocking_arg(tmp_path, monkeypatch) -> None:
@@ -166,11 +204,11 @@ def test_main_parses_max_blocking_arg(tmp_path, monkeypatch) -> None:
     pcb = tmp_path / "bldc_controller_routed.kicad_pcb"
     pcb.write_text("(kicad_pcb)")
 
-    monkeypatch.setattr(helper, "count_blocking", lambda _p: (8, ["A", "B"]))
+    monkeypatch.setattr(helper, "count_blocking", lambda _p: (10, ["A", "B"]))
 
-    # default 9 -> 8 passes
+    # default 11 -> 10 passes
     assert helper.main([str(pcb)]) == 0
-    # tightened to 7 -> 8 fails
+    # tightened to 7 -> 10 fails
     assert helper.main([str(pcb), "--max-blocking", "7"]) == 2
 
 


### PR DESCRIPTION
## Summary

The `Board 05 Routing Regression` CI gate (`scripts/ci/check_board_05_blocking.py`, added in #3823) was nondeterministic at its floor: a fresh CI re-route of board-05 produces 9 OR 10 blocking nets depending on the run (observed: `main`=9, PR #3835 branch=10 on two consecutive runs with identical router code). The previous `--max-blocking 9` default sat exactly on that boundary, so a coin-flip re-route intermittently red-lighted PRs that don't touch the router at all — the same flaky-red problem we fixed for board-07.

This raises the threshold to 11 (a safe margin above the observed CI ceiling of 10) so the gate stops flaking, while documenting clearly that 11 is a TEMPORARY loose bound and the proper fix is a deterministic re-route. The gate stays a hard assertion (no `continue-on-error`) and now reliably passes.

## Changes

- `scripts/ci/check_board_05_blocking.py`: `DEFAULT_MAX_BLOCKING` 9 -> 11; rewrote module docstring, `--max-blocking` help text, and the regression error message to explain the 9-10 nondeterminism, the divergence from the committed artifact (7), the temporary nature of the bound, and the path to tightening it back toward 7/0 (#3775/#3766/#3829).
- `.github/workflows/ci.yml`: `--max-blocking 9` -> `11`; job name `(blocking <= 9)` -> `(blocking <= 11)`; updated the job/step comment blocks to document the nondeterminism rationale.
- `tests/test_check_board_05_blocking.py`: updated for default 11, added `test_default_clears_nondeterministic_ci_floor` documenting that 9 and 10 both pass while 12 fails; renamed/retargeted the regression tests to the new ceiling.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Default `--max-blocking` is 11 in script | done | `--help` shows `default: 11`; `DEFAULT_MAX_BLOCKING == 11` test passes |
| CI job passes `--max-blocking 11` | done | grep of ci.yml run step |
| Job name updated to `(blocking <= 11)` | done | grep of ci.yml `name:` field |
| Docstring/CI note/error message document temporary bound + #3775/#3766/#3829 + gross-regression coverage | done | rewrote all three |
| Hard gate retained (no continue-on-error) | done | no `continue-on-error` added |
| Tests document 9 and 10 pass, 12 fails | done | `test_default_clears_nondeterministic_ci_floor` |

## Test Plan

Locally verified (full re-route cannot be validated on host, which routes to ~11):
- YAML valid: `python3 -c "import yaml; yaml.safe_load(...)"` -> `YAML valid`
- `--help` shows `default: 11`
- Gate prints the measured count and passes against the committed routed PCB: `MEASURED blocking_incomplete_count = 7 (threshold <= 11)` -> exit 0
- Unit tests: 13 passed
- `ruff check` + `ruff format --check`: clean

Closes #3836