### PR TITLE
fix(lvs): make copper-LVS gate authoritative via fresh out-of-process re-check

### DIFF
--- a/src/kicad_tools/lvs/__init__.py
+++ b/src/kicad_tools/lvs/__init__.py
@@ -51,13 +51,18 @@ from kicad_tools.lvs.copper_lvs import (
     compare_copper_netlist,
     compare_partitions,
 )
-from kicad_tools.lvs.recipe import ADVISORY_LVS_BOARDS, write_lvs_report
+from kicad_tools.lvs.recipe import (
+    ADVISORY_LVS_BOARDS,
+    FreshCopperCheckError,
+    write_lvs_report,
+)
 
 __all__ = [
     "ADVISORY_LVS_BOARDS",
     "BoardNetlistMismatch",
     "CopperLVSMismatch",
     "CopperLVSResult",
+    "FreshCopperCheckError",
     "LVSMismatch",
     "LVSResult",
     "_ref_of",

--- a/src/kicad_tools/lvs/copper_lvs.py
+++ b/src/kicad_tools/lvs/copper_lvs.py
@@ -208,3 +208,77 @@ def compare_copper_netlist(sch_path: str | Path, pcb_path: str | Path) -> Copper
     schematic_net_of_pad = _schematic_pin_to_net(sch_path)
     copper_partition = ConnectivityValidator(pcb_path).extract_pad_partition()
     return compare_partitions(schematic_net_of_pad, copper_partition)
+
+
+def result_to_json(result: CopperLVSResult) -> dict:
+    """Serialize a :class:`CopperLVSResult` to a JSON-safe dict.
+
+    Used by the ``python -m kicad_tools.lvs.copper_lvs`` subprocess
+    entrypoint (see :mod:`kicad_tools.lvs.recipe`'s fail-closed gate) so a
+    *fresh* out-of-process comparison can be marshalled back to the parent
+    recipe process for an authoritative, byte-for-byte agreement check.
+    """
+    return {
+        "clean": result.clean,
+        "mismatches": [
+            {
+                "kind": m.kind,
+                "net_a": m.net_a,
+                "net_b": m.net_b,
+                "pad_a": m.pad_a,
+                "pad_b": m.pad_b,
+            }
+            for m in result.mismatches
+        ],
+    }
+
+
+def result_from_json(payload: dict) -> CopperLVSResult:
+    """Reconstruct a :class:`CopperLVSResult` from :func:`result_to_json`."""
+    mismatches = tuple(
+        CopperLVSMismatch(
+            kind=m["kind"],
+            net_a=m["net_a"],
+            net_b=m["net_b"],
+            pad_a=m["pad_a"],
+            pad_b=m["pad_b"],
+        )
+        for m in payload.get("mismatches", ())
+    )
+    return CopperLVSResult(clean=bool(payload["clean"]), mismatches=mismatches)
+
+
+def _main(argv: list[str] | None = None) -> int:
+    """CLI/subprocess entrypoint: emit a fresh copper-LVS result as JSON.
+
+    Usage::
+
+        python -m kicad_tools.lvs.copper_lvs <schematic> <routed_pcb>
+
+    Loads both files fresh (a clean interpreter, no in-process recipe
+    state), runs :func:`compare_copper_netlist`, and prints the result via
+    :func:`result_to_json` to stdout as a single JSON object.  This is the
+    authoritative on-disk check the recipe gate compares its in-process
+    result against (issue #3838).
+    """
+    import argparse
+    import json
+    import sys
+
+    parser = argparse.ArgumentParser(
+        prog="python -m kicad_tools.lvs.copper_lvs",
+        description="Emit a fresh out-of-process copper-LVS result as JSON.",
+    )
+    parser.add_argument("schematic", help="Path to the .kicad_sch (root sheet).")
+    parser.add_argument("routed_pcb", help="Path to the routed .kicad_pcb.")
+    args = parser.parse_args(argv)
+
+    result = compare_copper_netlist(args.schematic, args.routed_pcb)
+    sys.stdout.write(json.dumps(result_to_json(result)))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via subprocess
+    import sys
+
+    sys.exit(_main())

--- a/src/kicad_tools/lvs/recipe.py
+++ b/src/kicad_tools/lvs/recipe.py
@@ -37,6 +37,8 @@ Gate policy is per-board (see the curator matrix on #3762):
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 from pathlib import Path
 
 from kicad_tools.lvs.board_lvs import (
@@ -44,7 +46,12 @@ from kicad_tools.lvs.board_lvs import (
     LVSResult,
     compare_netlists,
 )
-from kicad_tools.lvs.copper_lvs import CopperLVSResult, compare_copper_netlist
+from kicad_tools.lvs.copper_lvs import (
+    CopperLVSMismatch,
+    CopperLVSResult,
+    compare_copper_netlist,
+    result_from_json,
+)
 
 # Boards that run LVS + emit ``lvs.json`` but are NOT yet copper/label clean.
 # Recipes for these boards must pass ``require_clean=False`` so a dirty
@@ -76,6 +83,118 @@ ADVISORY_LVS_BOARDS: frozenset[str] = frozenset(
 _LVS_SCHEMA_URL = "https://kicad-tools.org/schemas/lvs/v1.json"
 
 
+class FreshCopperCheckError(RuntimeError):
+    """The fresh out-of-process copper-LVS check could not be obtained.
+
+    Raised when the ``python -m kicad_tools.lvs.copper_lvs`` subprocess
+    fails to run or emits output we cannot parse.  The gate treats this as
+    fatal (fail closed) rather than silently trusting the in-process result.
+    """
+
+
+def _copper_mismatch_key(
+    result: CopperLVSResult,
+) -> tuple[bool, frozenset[tuple[str, str, str, str, str]]]:
+    """Canonical, order-independent identity of a copper-LVS result.
+
+    Two results are equal iff they agree on ``clean`` AND carry the same
+    set of mismatches.  Used to detect in-process-vs-fresh divergence on
+    identical bytes (#3838).
+    """
+    mismatches = frozenset((m.kind, m.net_a, m.net_b, m.pad_a, m.pad_b) for m in result.mismatches)
+    return (result.clean, mismatches)
+
+
+def _fresh_copper_compare(sch_path: Path, routed_pcb_path: Path) -> CopperLVSResult:
+    """Run :func:`compare_copper_netlist` in a fresh subprocess.
+
+    Spawns ``python -m kicad_tools.lvs.copper_lvs <sch> <pcb>`` so the
+    comparison loads the persisted ``.kicad_pcb`` bytes from a *clean*
+    interpreter — no in-process recipe fill/zone state, no cached netlist,
+    a fresh shapely-availability resolution.  This is byte-for-byte what
+    CI's fresh re-check (and any downstream consumer) will see.
+
+    Raises:
+        FreshCopperCheckError: when the subprocess exits non-zero or its
+            stdout cannot be parsed as a copper-LVS JSON result.
+    """
+    cmd = [
+        sys.executable,
+        "-m",
+        "kicad_tools.lvs.copper_lvs",
+        str(sch_path),
+        str(routed_pcb_path),
+    ]
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:  # pragma: no cover - environment-dependent
+        raise FreshCopperCheckError(f"failed to spawn fresh copper-LVS check: {exc}") from exc
+
+    if proc.returncode != 0:
+        raise FreshCopperCheckError(
+            "fresh copper-LVS subprocess exited "
+            f"{proc.returncode}:\n--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
+        )
+    try:
+        payload = json.loads(proc.stdout)
+        return result_from_json(payload)
+    except (ValueError, KeyError) as exc:
+        raise FreshCopperCheckError(
+            f"could not parse fresh copper-LVS output: {exc}\nstdout was:\n{proc.stdout}"
+        ) from exc
+
+
+def _authoritative_copper_result(
+    sch_path: Path,
+    routed_pcb_path: Path,
+    *,
+    in_process: CopperLVSResult,
+) -> CopperLVSResult:
+    """Return the gate-authoritative copper-LVS result, failing closed.
+
+    Re-runs the copper comparison in a fresh subprocess (the byte-for-byte
+    on-disk view a CI re-check uses).  Returns the fresh result, but if the
+    fresh and in-process results disagree on ``clean`` or on their mismatch
+    set, the board is treated as DIRTY: a synthetic ``open`` mismatch is
+    appended recording the divergence so the gate trips and the divergence
+    is visible in ``lvs.json`` / the summary (#3838).
+    """
+    fresh = _fresh_copper_compare(sch_path, routed_pcb_path)
+
+    if _copper_mismatch_key(fresh) == _copper_mismatch_key(in_process):
+        return fresh
+
+    # Disagreement on identical bytes -> fail closed.  Surface BOTH legs so
+    # the divergence itself is debuggable, and union their mismatches so no
+    # real defect is hidden by whichever leg happened to look cleaner.
+    print(
+        "   copper-LVS GATE DIVERGENCE (#3838): in-process result disagrees "
+        "with a fresh out-of-process re-check on the same persisted bytes; "
+        "failing closed (treating board as DIRTY)."
+    )
+    print(f"      in-process: clean={in_process.clean} ({len(in_process.mismatches)} mismatch(es))")
+    print(f"      fresh:      clean={fresh.clean} ({len(fresh.mismatches)} mismatch(es))")
+
+    combined = dict.fromkeys(_copper_mismatch_key(in_process)[1] | _copper_mismatch_key(fresh)[1])
+    union = tuple(
+        CopperLVSMismatch(kind=k, net_a=a, net_b=b, pad_a=pa, pad_b=pb)
+        for (k, a, b, pa, pb) in combined
+    )
+    divergence = CopperLVSMismatch(
+        kind="open",
+        net_a="<gate-divergence>",
+        net_b="<gate-divergence>",
+        pad_a=f"in_process.clean={in_process.clean}",
+        pad_b=f"fresh.clean={fresh.clean}",
+    )
+    return CopperLVSResult(clean=False, mismatches=(divergence, *union))
+
+
 def write_lvs_report(
     sch_path: Path,
     routed_pcb_path: Path,
@@ -84,6 +203,7 @@ def write_lvs_report(
     require_clean: bool = True,
     run_copper: bool = True,
     run_label: bool = True,
+    fresh_copper_check: bool = True,
 ) -> tuple[bool, bool]:
     """Run copper + label LVS, write ``output/lvs.json``, optionally raise.
 
@@ -99,6 +219,14 @@ def write_lvs_report(
             include it in the gated ``clean`` decision.
         run_label: When ``True``, run the label-based comparator and include
             it in the gated ``clean`` decision.
+        fresh_copper_check: When ``True`` (default) and ``run_copper`` is
+            set, the copper-LVS result used for the gate is re-derived in a
+            *fresh subprocess* against the persisted ``routed_pcb_path``
+            bytes (issue #3838), so the gated decision equals what a clean
+            out-of-process re-check / CI sees.  If the in-process and fresh
+            results disagree the board is treated as DIRTY (fail closed).
+            Set ``False`` only in unit tests that monkeypatch the
+            in-process comparator and have no real files on disk.
 
     Returns:
         ``(copper_clean, label_clean)``.  A comparator that was not run is
@@ -108,6 +236,8 @@ def write_lvs_report(
     Raises:
         BoardNetlistMismatch: when ``require_clean`` and a gated comparator
             is dirty.  The report is still written before raising.
+        FreshCopperCheckError: when the fresh out-of-process copper check
+            cannot be obtained (subprocess failure / unparseable output).
         ValueError: when neither comparator is selected to run.
     """
     if not run_copper and not run_label:
@@ -119,6 +249,17 @@ def write_lvs_report(
 
     copper_result = compare_copper_netlist(sch_path, routed_pcb_path) if run_copper else None
     label_result = compare_netlists(sch_path, routed_pcb_path) if run_label else None
+
+    # Make the copper leg authoritative against the ON-DISK artifact: the
+    # in-process ``compare_copper_netlist`` above can see a cleaner board
+    # than a fresh process does (Python-post-processed fill that a fresh
+    # kicad-cli refill reverts; shapely-availability skew).  Re-derive the
+    # gated copper result in a fresh subprocess and fail closed if the two
+    # disagree on identical bytes (#3838).
+    if run_copper and fresh_copper_check and copper_result is not None:
+        copper_result = _authoritative_copper_result(
+            sch_path, routed_pcb_path, in_process=copper_result
+        )
 
     copper_clean = copper_result.clean if copper_result is not None else True
     label_clean = label_result.clean if label_result is not None else True

--- a/tests/test_lvs_recipe.py
+++ b/tests/test_lvs_recipe.py
@@ -85,7 +85,7 @@ def test_clean_board_writes_report_and_does_not_raise(
 ) -> None:
     _patch_comparators(monkeypatch, copper=_CLEAN_COPPER, label=_CLEAN_LABEL)
     copper_clean, label_clean = write_lvs_report(
-        Path("sch"), Path("pcb"), tmp_path, require_clean=True
+        Path("sch"), Path("pcb"), tmp_path, require_clean=True, fresh_copper_check=False
     )
     assert (copper_clean, label_clean) == (True, True)
     data = _read(tmp_path)
@@ -105,7 +105,9 @@ def test_dirty_label_hard_gate_raises_but_writes_report(
 ) -> None:
     _patch_comparators(monkeypatch, copper=_CLEAN_COPPER, label=_DIRTY_LABEL)
     with pytest.raises(BoardNetlistMismatch):
-        write_lvs_report(Path("sch"), Path("pcb"), tmp_path, require_clean=True)
+        write_lvs_report(
+            Path("sch"), Path("pcb"), tmp_path, require_clean=True, fresh_copper_check=False
+        )
     # Report is written even though the call raised.
     data = _read(tmp_path)
     assert data["clean"] is False
@@ -117,7 +119,9 @@ def test_dirty_copper_hard_gate_raises_but_writes_report(
 ) -> None:
     _patch_comparators(monkeypatch, copper=_DIRTY_COPPER, label=_CLEAN_LABEL)
     with pytest.raises(BoardNetlistMismatch):
-        write_lvs_report(Path("sch"), Path("pcb"), tmp_path, require_clean=True)
+        write_lvs_report(
+            Path("sch"), Path("pcb"), tmp_path, require_clean=True, fresh_copper_check=False
+        )
     data = _read(tmp_path)
     assert data["clean"] is False
     assert data["copper_mismatches"][0]["kind"] == "short"
@@ -133,7 +137,7 @@ def test_advisory_dirty_board_does_not_raise(
 ) -> None:
     _patch_comparators(monkeypatch, copper=_DIRTY_COPPER, label=_DIRTY_LABEL)
     copper_clean, label_clean = write_lvs_report(
-        Path("sch"), Path("pcb"), tmp_path, require_clean=False
+        Path("sch"), Path("pcb"), tmp_path, require_clean=False, fresh_copper_check=False
     )
     assert (copper_clean, label_clean) == (False, False)
     data = _read(tmp_path)
@@ -169,6 +173,7 @@ def test_copper_only_gating_ignores_label_mismatches(
         require_clean=True,
         run_copper=True,
         run_label=False,
+        fresh_copper_check=False,
     )
     assert called["label"] is False  # label comparator skipped entirely
     assert (copper_clean, label_clean) == (True, True)
@@ -251,3 +256,196 @@ def test_board_04_real_outputs_copper_clean_advisory(tmp_path: Path) -> None:
     assert copper_clean is True
     assert _read(tmp_path)["clean"] is True
     assert _read(tmp_path)["copper_mismatches"] == []
+
+
+# ---------------------------------------------------------------------------
+# On-disk authoritativeness: the gate is re-checked in a FRESH subprocess
+# against the persisted bytes, and fails closed on divergence (issue #3838).
+#
+# These tests exercise the REAL on-disk path (no monkeypatched comparator),
+# so ``fresh_copper_check`` stays at its True default.
+# ---------------------------------------------------------------------------
+
+
+_BOARD_01 = REPO_ROOT / "boards" / "01-voltage-divider" / "output"
+_BOARD_01_SCH = _BOARD_01 / "voltage_divider.kicad_sch"
+_BOARD_01_PCB = _BOARD_01 / "voltage_divider_routed.kicad_pcb"
+
+
+def _board_01_present() -> bool:
+    return _BOARD_01_SCH.is_file() and _BOARD_01_PCB.is_file()
+
+
+def _find_sexp_block_end(text: str, start: int) -> int:
+    """Return the index just past the ``)`` that closes the ``(`` at ``start``."""
+    depth = 0
+    j = start
+    while j < len(text):
+        if text[j] == "(":
+            depth += 1
+        elif text[j] == ")":
+            depth -= 1
+            if depth == 0:
+                return j + 1
+        j += 1
+    return len(text)
+
+
+def _strand_net_in_pcb(pcb_text: str, net_index: int) -> str:
+    """Return ``pcb_text`` with every ``(segment ... (net N) ...)`` removed.
+
+    Dropping all copper tracks carrying net ``N`` splits that net's pads
+    into separate copper islands, i.e. a deterministic copper *open* — a
+    real, persistable "stranded pad" board for the gate to catch.
+    """
+    needle = f"(net {net_index})"
+    pieces: list[str] = []
+    idx = 0
+    while idx < len(pcb_text):
+        seg = pcb_text.find("(segment", idx)
+        if seg == -1:
+            pieces.append(pcb_text[idx:])
+            break
+        pieces.append(pcb_text[idx:seg])
+        end = _find_sexp_block_end(pcb_text, seg)
+        block = pcb_text[seg:end]
+        if needle not in block:
+            pieces.append(block)
+        idx = end
+    return "".join(pieces)
+
+
+@pytest.mark.skipif(not _board_01_present(), reason="board 01 committed outputs not present")
+def test_gate_matches_fresh_out_of_process_on_identical_bytes(tmp_path: Path) -> None:
+    """Core invariant (#3838): in-process and fresh agree on identical bytes.
+
+    For the genuinely-clean committed board-01 PCB, the value the gate uses
+    (re-derived in a fresh subprocess) must equal a fresh out-of-process
+    ``compare_copper_netlist`` on the same file -- clean==clean and the
+    mismatch set is identical.  The gate must NOT raise on a clean board.
+    """
+    from kicad_tools.lvs.copper_lvs import compare_copper_netlist
+    from kicad_tools.lvs.recipe import _copper_mismatch_key, _fresh_copper_compare
+
+    in_process = compare_copper_netlist(_BOARD_01_SCH, _BOARD_01_PCB)
+    fresh = _fresh_copper_compare(_BOARD_01_SCH, _BOARD_01_PCB)
+    assert _copper_mismatch_key(in_process) == _copper_mismatch_key(fresh)
+    assert fresh.clean is True
+
+    # Full gate over the real files (fresh_copper_check defaults to True).
+    copper_clean, label_clean = write_lvs_report(
+        _BOARD_01_SCH,
+        _BOARD_01_PCB,
+        tmp_path,
+        require_clean=True,
+        run_copper=True,
+        run_label=False,
+    )
+    assert (copper_clean, label_clean) == (True, True)
+    assert _read(tmp_path)["clean"] is True
+
+
+@pytest.mark.skipif(not _board_01_present(), reason="board 01 committed outputs not present")
+def test_gate_catches_stranded_pad_board(tmp_path: Path) -> None:
+    """A persisted board with a stranded pad is caught by the hard gate.
+
+    Build a REAL on-disk dirty board (net 1 / VIN copper removed -> J1.1 and
+    R1.1 stranded into separate islands) and confirm ``require_clean=True``
+    now RAISES ``BoardNetlistMismatch`` instead of passing, with the open
+    recorded in ``lvs.json``.  Exercises the on-disk authoritative path, not
+    a monkeypatched comparator.
+    """
+    dirty_pcb = tmp_path / "voltage_divider_dirty.kicad_pcb"
+    dirty_pcb.write_text(_strand_net_in_pcb(_BOARD_01_PCB.read_text(), net_index=1))
+
+    out_dir = tmp_path / "out"
+    with pytest.raises(BoardNetlistMismatch):
+        write_lvs_report(
+            _BOARD_01_SCH,
+            dirty_pcb,
+            out_dir,
+            require_clean=True,
+            run_copper=True,
+            run_label=False,
+        )
+    data = json.loads((out_dir / "lvs.json").read_text())
+    assert data["clean"] is False
+    kinds = {cm["kind"] for cm in data["copper_mismatches"]}
+    assert "open" in kinds
+
+
+@pytest.mark.skipif(not _board_01_present(), reason="board 01 committed outputs not present")
+def test_stranded_pad_board_is_advisory_when_require_clean_false(tmp_path: Path) -> None:
+    """Advisory boards still only log a dirty fresh result, never raise (#3838)."""
+    dirty_pcb = tmp_path / "voltage_divider_dirty.kicad_pcb"
+    dirty_pcb.write_text(_strand_net_in_pcb(_BOARD_01_PCB.read_text(), net_index=1))
+
+    out_dir = tmp_path / "out"
+    copper_clean, _label_clean = write_lvs_report(
+        _BOARD_01_SCH,
+        dirty_pcb,
+        out_dir,
+        require_clean=False,
+        run_copper=True,
+        run_label=False,
+    )
+    assert copper_clean is False  # fresh check saw the open
+    assert json.loads((out_dir / "lvs.json").read_text())["clean"] is False
+
+
+def test_run_copper_false_skips_fresh_check(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``run_copper=False`` short-circuits the copper leg (and its fresh check).
+
+    No subprocess is spawned; the copper leg is vacuously clean.
+    """
+    import kicad_tools.lvs.recipe as recipe_mod
+
+    def _fresh_should_not_run(s: Path, p: Path) -> CopperLVSResult:
+        raise AssertionError("fresh copper check must not run when run_copper=False")
+
+    monkeypatch.setattr(recipe_mod, "_fresh_copper_compare", _fresh_should_not_run)
+    monkeypatch.setattr(recipe, "compare_netlists", lambda s, p: _CLEAN_LABEL)
+
+    copper_clean, label_clean = write_lvs_report(
+        Path("sch"),
+        Path("pcb"),
+        tmp_path,
+        require_clean=True,
+        run_copper=False,
+        run_label=True,
+    )
+    assert (copper_clean, label_clean) == (True, True)
+    assert _read(tmp_path)["clean"] is True
+
+
+def test_gate_fails_closed_on_in_process_vs_fresh_divergence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If in-process disagrees with the fresh check, fail closed (#3838).
+
+    Simulate the exact defect: the in-process comparator reports CLEAN while
+    a fresh out-of-process re-check on the same bytes reports DIRTY.  The
+    gate must treat the board as dirty and raise under ``require_clean``.
+    """
+    import kicad_tools.lvs.recipe as recipe_mod
+
+    monkeypatch.setattr(recipe, "compare_copper_netlist", lambda s, p: _CLEAN_COPPER)
+    monkeypatch.setattr(recipe_mod, "_fresh_copper_compare", lambda s, p: _DIRTY_COPPER)
+
+    out_dir = tmp_path / "out"
+    with pytest.raises(BoardNetlistMismatch):
+        write_lvs_report(
+            Path("sch"),
+            Path("pcb"),
+            out_dir,
+            require_clean=True,
+            run_copper=True,
+            run_label=False,
+            # fresh_copper_check defaults True; _fresh_copper_compare patched.
+        )
+    data = json.loads((out_dir / "lvs.json").read_text())
+    assert data["clean"] is False
+    # The divergence sentinel is recorded so the disagreement is debuggable.
+    assert any(cm["net_a"] == "<gate-divergence>" for cm in data["copper_mismatches"])


### PR DESCRIPTION
## Summary

The recipe copper-LVS gate (`write_lvs_report(..., require_clean=True)`, `src/kicad_tools/lvs/recipe.py`) trusted a single **in-process** `compare_copper_netlist` whose result can diverge from a **fresh out-of-process** check on the *same persisted `.kicad_pcb` bytes*. Because the recipe persists a Python-post-processed fill (a fresh `kicad-cli` refill reverts the carve at `cli/runner.py:407-413`) and resolves shapely availability per-process, the gated comparison could see a cleaner board than a fresh process — so a physically broken board (e.g. board-03 with stranded J1 shield pads / GND opens) passed the hard gate while CI's fresh re-check on the identical file reports dirty.

This makes the gated copper compare authoritative against the on-disk artifact (curator Option A): re-run `compare_copper_netlist` in a **fresh subprocess** on the persisted file and **fail closed** if the in-process and fresh results disagree.

It does NOT mask the real board-03 defect — the gate now CATCHES the stranded-pad board (the via-firing root cause is sibling #3841). Genuinely-clean boards (01/02/03 committed) still pass.

## Changes

- `src/kicad_tools/lvs/copper_lvs.py`: add `result_to_json` / `result_from_json` and a `__main__` / `_main` subprocess entrypoint (`python -m kicad_tools.lvs.copper_lvs <sch> <pcb>`) that loads both files fresh and emits the copper-LVS result as JSON.
- `src/kicad_tools/lvs/recipe.py`: add `_fresh_copper_compare` (spawns the subprocess), `_authoritative_copper_result` (returns the fresh result, fails closed with a recorded divergence sentinel when in-process != fresh), `_copper_mismatch_key`, a `fresh_copper_check` flag (default `True`), and `FreshCopperCheckError`. The gated copper result and `lvs.json` now reflect the authoritative fresh state; advisory boards (`require_clean=False`) still only log, never raise.
- `src/kicad_tools/lvs/__init__.py`: export `FreshCopperCheckError`.
- `tests/test_lvs_recipe.py`: new real on-disk regression tests (no monkeypatched comparator for the authoritativeness path) plus `fresh_copper_check=False` on the existing fixture-free gating-logic tests.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Gated result equals a fresh out-of-process check on identical bytes | ✅ | `test_gate_matches_fresh_out_of_process_on_identical_bytes` (real board-01 files) asserts `_copper_mismatch_key(in_process) == _copper_mismatch_key(fresh)` |
| A stranded-pad board is CAUGHT by the gate (raises, not silenced) | ✅ | `test_gate_catches_stranded_pad_board` builds a real persisted board with net-1 copper removed (J1.1/R1.1 stranded -> open) and asserts `require_clean=True` raises `BoardNetlistMismatch`, `lvs.json` clean=false |
| Clean board still passes | ✅ | `test_gate_matches_fresh_out_of_process_on_identical_bytes` runs the full gate on board-01 with no raise; `test_board_01_real_outputs_are_clean` still green |
| Fail closed on in-process vs fresh disagreement | ✅ | `test_gate_fails_closed_on_in_process_vs_fresh_divergence` (in-process clean, fresh dirty) raises and records a `<gate-divergence>` sentinel |
| Advisory (`require_clean=False`) never raises | ✅ | `test_stranded_pad_board_is_advisory_when_require_clean_false` |
| `run_copper=False` short-circuits (no subprocess) | ✅ | `test_run_copper_false_skips_fresh_check` asserts the fresh check is never invoked |

## Test Plan

- `uv run pytest tests/test_lvs_recipe.py` -> 14 passed.
- `uv run pytest tests/test_copper_lvs.py tests/test_board_03_copper_lvs.py tests/test_board_04_copper_lvs.py` -> all green (no regressions).
- `uv run ruff check` + `ruff format --check` on all touched files -> clean.
- Manual: `python -m kicad_tools.lvs.copper_lvs <board-01 sch/pcb>` emits `{"clean": true, "mismatches": []}`.

Scope guard: this PR only makes the GATE trustworthy. The board-03 stitching-via root cause is #3841 and the CI fresh-regen validation is #3840 — neither is folded in here.

Closes #3838