### PR TITLE
ci: pin ruff to 0.14.10 and --frozen all uv sync invocations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --frozen --extra dev
 
       # Issue #3464: continue-on-error was removed from both steps below.
       # It made the "Lint & Format" check always green regardless of
@@ -53,7 +53,7 @@ jobs:
           version: "latest"
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --frozen --extra dev
 
       # Issue #3512: the `Run mypy` step used to carry continue-on-error: true,
       # so the Type Check job was green regardless of mypy's exit code and
@@ -119,7 +119,7 @@ jobs:
         # Pin the interpreter via uv (parity with the other jobs that use
         # actions/setup-python with python-version: "3.12"); the container
         # image's own Python version is irrelevant.
-        run: uv sync --extra dev --python 3.12
+        run: uv sync --frozen --extra dev --python 3.12
 
       - name: Build C++ router backend
         # Issue #3436: `uv sync` does NOT build the native extension (see
@@ -175,7 +175,7 @@ jobs:
         # actions/setup-python with python-version: "3.12"). uv will install
         # the requested interpreter into its managed cache and create
         # .venv from it.
-        run: uv sync --extra dev --python 3.12
+        run: uv sync --frozen --extra dev --python 3.12
 
       - name: Install nanobind
         run: uv pip install nanobind
@@ -293,7 +293,7 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --frozen --extra dev
 
       - name: Run kicad-cli round-trip smoke tests
         run: uv run pytest tests/test_kicad_cli_roundtrip.py -v --no-cov
@@ -372,7 +372,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.changed.outputs.files != ''
-        run: uv sync --extra dev
+        run: uv sync --frozen --extra dev
 
       - name: Run kct check on each modified routed PCB
         if: steps.changed.outputs.files != ''
@@ -597,7 +597,7 @@ jobs:
         # Pin the interpreter via uv (parity with the sibling jobs that use
         # actions/setup-python with python-version: "3.12"); the container
         # image's own Python version is irrelevant.
-        run: uv sync --extra dev --python 3.12
+        run: uv sync --frozen --extra dev --python 3.12
 
       - name: Build C++ router backend
         # `uv sync` does NOT build the native extension (see repo CLAUDE.md
@@ -795,7 +795,7 @@ jobs:
         # Pin the interpreter via uv (parity with the sibling jobs that use
         # actions/setup-python with python-version: "3.12"); the container
         # image's own Python version is irrelevant.
-        run: uv sync --extra dev --python 3.12
+        run: uv sync --frozen --extra dev --python 3.12
 
       - name: Build C++ router backend
         # Issue #3146: ``uv sync`` does NOT build the native extension
@@ -923,7 +923,7 @@ jobs:
         # dev`` is required because ``kct check`` imports ``shapely`` for
         # the geometry-based DRC rules (see the [project.optional-dependencies]
         # dev block in pyproject.toml for the ``shapely>=2.0`` pin).
-        run: uv sync --extra dev --python 3.12
+        run: uv sync --frozen --extra dev --python 3.12
 
       - name: Build C++ router backend
         # ``uv sync`` does NOT build the native extension (see repo
@@ -1026,7 +1026,7 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
-        run: uv sync --extra dev --python 3.12
+        run: uv sync --frozen --extra dev --python 3.12
 
       - name: Build C++ router backend
         run: uv run kct build-native
@@ -1113,7 +1113,7 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
-        run: uv sync --extra dev --python 3.12
+        run: uv sync --frozen --extra dev --python 3.12
 
       - name: Build C++ router backend
         run: uv run kct build-native
@@ -1207,7 +1207,7 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
-        run: uv sync --extra dev --python 3.12
+        run: uv sync --frozen --extra dev --python 3.12
 
       - name: Build C++ router backend
         run: uv run kct build-native
@@ -1306,7 +1306,7 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
-        run: uv sync --extra dev --python 3.12
+        run: uv sync --frozen --extra dev --python 3.12
 
       - name: Build C++ router backend
         run: uv run kct build-native
@@ -1390,7 +1390,7 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
-        run: uv sync --extra dev --python 3.12
+        run: uv sync --frozen --extra dev --python 3.12
 
       - name: Build C++ router backend
         run: uv run kct build-native
@@ -1525,7 +1525,7 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
-        run: uv sync --extra dev --python 3.12
+        run: uv sync --frozen --extra dev --python 3.12
 
       - name: Build C++ router backend
         run: uv run kct build-native

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,7 +209,7 @@ dev = [
     "pytest-cov>=4.0",
     "pytest-benchmark>=4.0",
     "pytest-timeout>=2.3",
-    "ruff>=0.1.0",
+    "ruff==0.14.10",
     "mypy>=1.0",
     "rtree>=1.0",
     "numpy>=1.24",

--- a/uv.lock
+++ b/uv.lock
@@ -1963,7 +1963,7 @@ requires-dist = [
     { name = "rtree", marker = "extra == 'all'", specifier = ">=1.0" },
     { name = "rtree", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "rtree", marker = "extra == 'drc'", specifier = ">=1.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.14.10" },
     { name = "scikit-build-core", marker = "extra == 'native'", specifier = ">=0.8" },
     { name = "scikit-learn", marker = "extra == 'research'", specifier = ">=1.7.2" },
     { name = "shapely", specifier = ">=2.0" },


### PR DESCRIPTION
Closes #3850

## Problem

The `Lint & Format` CI gate was non-deterministic. `pyproject.toml` declared an open `ruff>=0.1.0` spec while every `uv sync --extra dev` in `.github/workflows/ci.yml` ran **without** `--frozen`/`--locked`, under `astral-sh/setup-uv@v4` pinned to `version: "latest"`. A newer uv binary re-resolved the open spec to the latest ruff on PyPI (0.15.18) instead of the committed lock (0.14.10). Ruff 0.15.x reformats files that are clean under 0.14.x (e.g. `tests/test_audit.py`), turning the Lint gate red on PRs that touched none of it (cost a full Judge cycle on PR #3849).

Non-deterministic in two dimensions: across *time* (a future ruff release re-triggers it) and across *machines* (local cached ruff 0.14.10 vs CI `latest`).

## Fix (defense in depth)

1. **`pyproject.toml`** — exact-pin `ruff==0.14.10` (was `ruff>=0.1.0`), matching the lock, so a re-resolve can never jump a formatting-affecting minor.
2. **`uv.lock`** — re-locked via `uv lock`; ruff specifier is now `==0.14.10` and `uv lock --check` passes (no re-resolve needed).
3. **`.github/workflows/ci.yml`** — added `--frozen` to all 15 `uv sync --extra dev` invocations so CI installs exactly the locked versions and errors loudly if the lock is ever stale, rather than silently re-resolving.

(The optional `setup-uv` version pin was not applied; #1-#3 close the float vector on their own and it is the lowest-value of the suggested mitigations.)

## Verification (local, ruff 0.14.10)

- `uv run ruff --version` -> `ruff 0.14.10`
- `uv run ruff check .` -> `All checks passed!`
- `uv run ruff format . --check` -> `1493 files already formatted` (no drift; `test_audit.py` is clean under 0.14.10)
- `uv lock --check` -> passes
- `tests/test_audit.py` -> 156 passed; import + CLI smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)