### PR TITLE
fix(board-04): gate main() on DRC/LVS + add board-04 end-to-end CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1562,3 +1562,141 @@ jobs:
           uv run python scripts/ci/check_board_05_blocking.py \
             --max-blocking 11 \
             /tmp/board05-ci/bldc_controller_routed.kicad_pcb
+
+  board-04-end-to-end:
+    # Issue #3839: end-to-end gate for board 04 ("stm32-devboard").  Two
+    # board-04 gaps shipped regressions undetected: (1) the recipe's main()
+    # success gate omitted the already-computed drc_success / copper-LVS
+    # verdict (fixed in generate_design.py this PR), and (2) board 04 had NO
+    # clean-room regen+validate CI job at all (boards 00/01/02 run the full
+    # asserter, 03/06/07 the --lvs-only asserter, 05 a blocking-net baseline;
+    # 04 was absent).  This job closes (2): it regenerates board 04 inside the
+    # CI container and validates the FRESH artifact OUT-OF-PROCESS against
+    # (a) the DRC allowlist and (b) copper-LVS.
+    #
+    # Board 04 has a committed output/lvs.json (clean: true), so this reuses
+    # the board-03 --lvs-only asserter pattern (NOT the full asserter: board 04
+    # carries 2 grandfathered dimension_drill_clearance drills + 1 advisory
+    # connectivity finding, so board-metrics classifies it status:partial /
+    # drc_violations:2, which the full status:ok / drc_violations:0 assertion
+    # would FAIL).
+    #
+    # DRC is ALLOWLIST-AWARE: the fresh routed PCB is staged over the
+    # repo-relative committed path and checked with scripts/ci/check_routed_drc.py,
+    # which keys tolerance off that path -- so the 2 known sub-0.5mm drills
+    # (.github/routed-drc-tolerance.yml: 2; board-layout fix tracked in #3847)
+    # are tolerated while a 3rd (NEW) blocking error fails the gate.  The
+    # connectivity finding is advisory (DRCChecker.ADVISORY_RULE_IDS), excluded
+    # from the gate count.
+    #
+    # RECIPE EXIT IS NOT GATED (|| true).  Board 04's route is subject to the
+    # same documented host-vs-CI router divergence as board 05 (#3822): a fresh
+    # regen may land a PARTIAL route (route_pcb returns False -> recipe exits 1)
+    # even though the resulting artifact is DRC-within-allowlist and copper-LVS
+    # clean (verified: a fresh host regen with a 9-net partial route still
+    # produces 2 drills + 0 shorts/0 opens).  The OUT-OF-PROCESS DRC + LVS
+    # asserters below are therefore the real gate -- they validate the RESULT,
+    # not the recipe's nondeterministic exit code.  This keeps the job GREEN on
+    # the current board while still catching a real DRC/LVS regression.
+    #
+    # The ``Build C++ router backend`` step is REQUIRED: the recipe re-routes
+    # during regen, and per CLAUDE.md a missing native extension makes routing
+    # multi-minute-per-net.  Board 04's recipe (generate_design.py) takes only
+    # an output-dir positional arg (no --step / --seed).
+    #
+    # Advisory until a repo admin adds it to branch protection (same as the
+    # board 00/01/02/03/05/06/07 e2e jobs).
+    #
+    # TIMEOUT (45 min): board 04 re-routes ~9 signal nets + stitch + tie +
+    # quantize + fill.  Fewer nets than board 05's 36-net rescue loop (which
+    # needs 90 min), so 45 min leaves comfortable headroom over board 03's
+    # 30 min for the LQFP-48 escape work.
+    name: Board 04 End-to-End (LVS-only + DRC allowlist)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    container:
+      image: kicad/kicad:10.0
+      options: --user 0:0
+    defaults:
+      run:
+        shell: bash
+    env:
+      PYTHONHASHSEED: "42"
+      PYTHONUNBUFFERED: "1"
+    steps:
+      - name: Ensure container has prerequisites
+        run: |
+          set -euo pipefail
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates curl git cmake build-essential
+          kicad-cli --version
+
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        run: |
+          set -euo pipefail
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install dependencies
+        run: uv sync --frozen --extra dev --python 3.12
+
+      - name: Build C++ router backend
+        run: uv run kct build-native
+
+      - name: Regenerate board 04 from recipe (clean tmp directory)
+        # Board 04's recipe takes only an output-dir argument.  Its route is
+        # subject to the documented host-vs-CI router divergence (#3822) and may
+        # land a PARTIAL route (recipe exits 1) even though the resulting
+        # artifact is DRC-within-allowlist + copper-LVS clean, so tolerate a
+        # non-zero recipe exit (|| true) -- the out-of-process DRC + LVS
+        # asserters below are the real gate.  write_lvs_report(require_clean=True)
+        # still RAISES on an actual copper short/open, so a genuine LVS
+        # regression aborts the recipe before this step succeeds.
+        run: |
+          set -uo pipefail
+          rm -rf /tmp/board04-ci
+          mkdir -p /tmp/board04-ci
+          uv run python boards/04-stm32-devboard/generate_design.py \
+            /tmp/board04-ci || true
+          test -f /tmp/board04-ci/lvs.json
+          test -f /tmp/board04-ci/stm32_devboard_routed.kicad_pcb
+
+      - name: Assert fresh DRC within allowlist (drill tolerance of 2)
+        # Stage the fresh routed PCB over the repo-relative committed path so
+        # scripts/ci/check_routed_drc.py finds the board-04 tolerance entry
+        # (.github/routed-drc-tolerance.yml: 2) and the jlcpcb-tier1 mfr
+        # override.  The gate tolerates the 2 grandfathered
+        # dimension_drill_clearance drills (#3847) + the advisory connectivity
+        # finding, but fails (exit 2) on a 3rd blocking error or any new rule.
+        run: |
+          set -euo pipefail
+          cp /tmp/board04-ci/stm32_devboard_routed.kicad_pcb \
+            boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb
+          uv run python scripts/ci/check_routed_drc.py \
+            boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb
+          # Restore the committed artifact so the workspace stays clean.
+          git checkout -- \
+            boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb
+
+      - name: Emit board.json via kct board-metrics
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/board04-staging
+          mkdir -p /tmp/board04-staging/04-stm32-devboard/output
+          cp -r /tmp/board04-ci/. /tmp/board04-staging/04-stm32-devboard/output/
+          uv run kct board-metrics /tmp/board04-staging/04-stm32-devboard
+
+      - name: Assert artifacts + lvs.json clean (LVS-only)
+        # --lvs-only: assert artifact presence + lvs.json clean=true +
+        # board.json lvs_clean=true, but NOT status:ok / drc_violations:0
+        # (board 04 carries 2 allowlisted drills + 1 advisory connectivity ->
+        # status='partial').
+        run: |
+          set -euo pipefail
+          uv run python scripts/ci/check_board_00_e2e.py \
+            --stem stm32_devboard \
+            --lvs-only \
+            /tmp/board04-staging/04-stm32-devboard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1673,12 +1673,23 @@ jobs:
         # finding, but fails (exit 2) on a 3rd blocking error or any new rule.
         run: |
           set -euo pipefail
+          # Stage the fresh routed PCB over the repo-relative committed path:
+          # check_routed_drc.py keys the tolerance allowlist + mfr override off
+          # the path's repo-relative form (relative_to(cwd)), so the fresh
+          # artifact MUST live at the committed path for the board-04 entry
+          # (.github/routed-drc-tolerance.yml: 2) and the jlcpcb-tier1 override
+          # to resolve.  No cleanup is needed afterwards: the CI checkout is a
+          # throwaway workspace discarded when the job ends, nothing downstream
+          # reads the committed PCB, and (per #3854 review) the previous
+          # ``git checkout -- ...`` restore aborted the step with exit 128
+          # ("detected dubious ownership") because the kicad/kicad:10.0
+          # container runs as root over a checkout owned by another uid -- which
+          # SKIPPED the board-metrics + --lvs-only asserter steps below under
+          # ``set -euo pipefail``.  Every other board e2e job already avoids any
+          # git usage here; this matches that pattern.
           cp /tmp/board04-ci/stm32_devboard_routed.kicad_pcb \
             boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb
           uv run python scripts/ci/check_routed_drc.py \
-            boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb
-          # Restore the committed artifact so the workspace stays clean.
-          git checkout -- \
             boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb
 
       - name: Emit board.json via kct board-metrics

--- a/boards/04-stm32-devboard/generate_design.py
+++ b/boards/04-stm32-devboard/generate_design.py
@@ -23,6 +23,7 @@ Usage:
 If no output directory is specified, files are written to ./output/
 """
 
+import json
 import os
 import subprocess
 import sys
@@ -1753,6 +1754,27 @@ def generate_manufacturing(routed_path: Path, output_dir: Path) -> bool:
     return True
 
 
+# Issue #3839: board-04's main() success gate must reflect DRC.  The DRC
+# leg is allowlist-aware so it tolerates EXACTLY the same grandfathered
+# violations the CI gate tolerates -- no more.  Today that is:
+#
+#   * advisory ``connectivity`` (1 stranded GND-stitch pad; in
+#     ``DRCChecker.ADVISORY_RULE_IDS``, filtered from every CI gate), and
+#   * up to 2 ``dimension_drill_clearance`` errors -- the 2 true-positive
+#     sub-0.5mm drills (a 0.350mm hole-to-hole pair) surfaced by the
+#     corrected ``min_hole_to_hole_mm`` rule (#3842/#3846).  These are
+#     allowlisted at exactly 2 in ``.github/routed-drc-tolerance.yml``
+#     (board-layout fix tracked in #3847).
+#
+# Any 3rd drill error, OR any OTHER blocking rule, fails the gate so a
+# real DRC regression cannot ship 0.  EXIT CLAUSE: when #3847 re-spaces
+# the drill pair, drop the allowlist entry back to strict-0 and set
+# ``_DRILL_CLEARANCE_ALLOWANCE`` to 0 here in lockstep.
+_ADVISORY_DRC_RULE_IDS: frozenset[str] = frozenset({"connectivity"})
+_DRILL_CLEARANCE_RULE_ID = "dimension_drill_clearance"
+_DRILL_CLEARANCE_ALLOWANCE = 2  # keep in lockstep with .github/routed-drc-tolerance.yml (#3847)
+
+
 def run_drc(pcb_path: Path) -> bool:
     """Run DRC on the routed PCB and write ``drc_report.json`` beside it.
 
@@ -1775,6 +1797,19 @@ def run_drc(pcb_path: Path) -> bool:
     profile this board ships and is CI-gated against (the GND micro-via
     stitching needs the Capability-Plus tier; see the manufacturers:
     override in ``.github/routed-drc-tolerance.yml``).
+
+    Issue #3839: the return value now gates ``main()``'s exit code, so it
+    is **allowlist-aware** rather than a raw ``returncode == 0`` check.
+    ``kct check --drc-only`` exits 2 on the 2 grandfathered
+    ``dimension_drill_clearance`` drills (#3842/#3847) and on the advisory
+    ``connectivity`` finding, neither of which should fail the recipe.
+    Instead of trusting the exit code we parse the emitted JSON and count
+    *blocking* violations the same way the CI gate
+    (``scripts/ci/check_routed_drc.py``) does: advisory rules are excluded,
+    and up to ``_DRILL_CLEARANCE_ALLOWANCE`` (=2) drill-clearance errors are
+    tolerated.  Returns ``True`` iff no other blocking error exists and the
+    drill count is within the allowance -- so a 3rd drill or any new rule
+    flips the recipe to a non-zero exit.
     """
     print("\n" + "=" * 60)
     print("Running DRC (via kct check --drc-only)...")
@@ -1792,6 +1827,9 @@ def run_drc(pcb_path: Path) -> bool:
                 "--mfr",
                 "jlcpcb-tier1",
                 "--drc-only",
+                "--errors-only",
+                "--format",
+                "json",
                 "--output",
                 str(report_path),
             ],
@@ -1799,21 +1837,68 @@ def run_drc(pcb_path: Path) -> bool:
             text=True,
         )
 
-        # Print the output
-        if result.stdout:
-            for line in result.stdout.strip().split("\n"):
-                print(f"   {line}")
-
         if report_path.is_file():
             print(f"\n   DRC report: {report_path}")
 
-        # Check for success
-        if result.returncode == 0:
-            return True
-        else:
+        # The JSON payload is written to ``report_path`` via --output; parse
+        # it (preferred) and fall back to stdout if the file is absent.
+        payload: dict | None = None
+        if report_path.is_file():
+            try:
+                payload = json.loads(report_path.read_text())
+            except (OSError, json.JSONDecodeError):
+                payload = None
+        if payload is None and result.stdout:
+            brace = result.stdout.find("{")
+            if brace >= 0:
+                try:
+                    payload = json.loads(result.stdout[brace:])
+                except json.JSONDecodeError:
+                    payload = None
+
+        if payload is None:
+            # No parseable verdict -> fail closed.
+            print("\n   Error: could not parse DRC JSON output")
             if result.stderr:
-                print(f"\n   Error: {result.stderr}")
+                print(f"   stderr: {result.stderr}")
             return False
+
+        violations = payload.get("violations", [])
+        blocking_other = 0
+        drill_errors = 0
+        advisory = 0
+        for v in violations:
+            if not isinstance(v, dict) or v.get("severity") != "error":
+                continue
+            rule_id = v.get("rule_id", "")
+            if rule_id in _ADVISORY_DRC_RULE_IDS:
+                advisory += 1
+            elif rule_id == _DRILL_CLEARANCE_RULE_ID:
+                drill_errors += 1
+            else:
+                blocking_other += 1
+
+        print(
+            f"\n   DRC errors: {blocking_other} blocking (excl. drill+advisory), "
+            f"{drill_errors} {_DRILL_CLEARANCE_RULE_ID} (allow {_DRILL_CLEARANCE_ALLOWANCE}), "
+            f"{advisory} advisory (excluded)"
+        )
+
+        # PASS iff: no other-rule blocking error AND drill count within the
+        # grandfathered allowance.  Advisory rules never gate (#3074).
+        if blocking_other == 0 and drill_errors <= _DRILL_CLEARANCE_ALLOWANCE:
+            return True
+        print(
+            "\n   DRC FAIL: "
+            + (f"{blocking_other} non-allowlisted blocking error(s); " if blocking_other else "")
+            + (
+                f"{drill_errors} drill-clearance errors exceed allowance "
+                f"of {_DRILL_CLEARANCE_ALLOWANCE}"
+                if drill_errors > _DRILL_CLEARANCE_ALLOWANCE
+                else ""
+            )
+        )
+        return False
 
     except Exception as e:
         print(f"\n   Error running DRC: {e}")
@@ -1916,7 +2001,12 @@ def main() -> int:
         # the copper comparator is the meaningful leg.  Removing board-04 from
         # ``ADVISORY_LVS_BOARDS`` + the CI end-to-end gate is the #3795 Slice 2
         # follow-up (out of scope here).
-        write_lvs_report(
+        # Issue #3839: capture the (copper_clean, label_clean) return so the
+        # exit gate ANDs the copper-LVS verdict explicitly.  require_clean=True
+        # already RAISES on a dirty copper comparator (so a short can't reach
+        # the gate at all), but ANDing copper_clean makes the gate's intent
+        # self-documenting and defends against a future require_clean=False.
+        copper_clean, _label_clean = write_lvs_report(
             sch_path,
             routed_path,
             output_dir,
@@ -2025,6 +2115,18 @@ def main() -> int:
         # from 3 — but it remains in ``ADVISORY_RULE_IDS`` and is filtered from
         # the CI gate; ``blocking_errors`` stays 0.  This unblocks the #3795
         # board-04 copper-LVS hard-gate graduation.
+        #
+        # Per #3839 (2026-06-21): the exit gate previously omitted
+        # ``drc_success`` (computed + printed but never gating) and discarded
+        # the ``write_lvs_report`` return -- so a board with a NEW blocking DRC
+        # error or a copper-LVS short could print SUCCESS and exit 0.  The gate
+        # now ANDs ``drc_success`` (allowlist-aware per ``run_drc``: tolerates
+        # the 2 grandfathered ``dimension_drill_clearance`` drills (#3847) +
+        # advisory ``connectivity`` but fails on a 3rd drill or any new rule)
+        # and ``copper_clean`` (the copper-LVS verdict) so a real DRC/LVS
+        # regression exits non-zero.  The current committed board -- 2
+        # allowlisted drills, 1 advisory connectivity, copper-LVS clean --
+        # still exits 0.
         return (
             0
             if (
@@ -2034,6 +2136,8 @@ def main() -> int:
                 and stitch_success
                 and tie_success
                 and fill_success
+                and drc_success
+                and copper_clean
                 and mfr_success
             )
             else 1

--- a/tests/test_board_04_main_gate.py
+++ b/tests/test_board_04_main_gate.py
@@ -1,0 +1,160 @@
+"""Unit guard: board 04 main() success gate reflects DRC + copper-LVS (#3839).
+
+The board-04 recipe's ``main()`` return gate previously omitted the
+already-computed ``drc_success`` and discarded ``write_lvs_report``'s
+``(copper_clean, label_clean)`` return -- so a board with a NEW blocking DRC
+error or a copper-LVS short printed SUCCESS and exited 0.  Issue #3839 wires
+both into the gate.  ``run_drc`` is now ALLOWLIST-AWARE: it parses the DRC
+JSON and tolerates exactly the grandfathered violations the CI gate tolerates
+(the 2 sub-0.5mm ``dimension_drill_clearance`` drills tracked in #3847 + the
+advisory ``connectivity`` rule), failing on a 3rd drill or any new blocking
+rule.
+
+These tests are hermetic: they monkeypatch ``subprocess.run`` (for
+``run_drc``) and ``write_lvs_report`` (for the LVS leg) so no router /
+kicad-cli invocation is needed.  They exercise the gate's two halves
+directly without re-routing the board.
+
+References:
+- ``boards/04-stm32-devboard/generate_design.py`` -- the gate under test.
+- ``.github/routed-drc-tolerance.yml`` -- the board-04 floor of 2 (#3847).
+- ``tests/test_board_04_mfr_gate.py`` -- the committed-artifact DRC pin.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BOARD_DIR = REPO_ROOT / "boards" / "04-stm32-devboard"
+
+
+def _load_board04_module() -> types.ModuleType:
+    """Import the board-04 ``generate_design.py`` as a module."""
+    gen = BOARD_DIR / "generate_design.py"
+    spec = importlib.util.spec_from_file_location("board04_generate_design", gen)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def board04() -> types.ModuleType:
+    return _load_board04_module()
+
+
+def _drc_payload(rule_ids: list[str]) -> dict:
+    """Build a minimal ``kct check --format json`` payload from rule ids."""
+    violations = [
+        {"rule_id": rid, "type": rid, "severity": "error", "message": f"{rid} sample"}
+        for rid in rule_ids
+    ]
+    return {
+        "summary": {"errors": len(violations), "passed": not violations},
+        "violations": violations,
+    }
+
+
+def _patch_run_drc(
+    board04: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    rule_ids: list[str],
+) -> None:
+    """Make ``run_drc``'s subprocess emit a fabricated DRC report JSON."""
+    payload = _drc_payload(rule_ids)
+
+    def fake_run(cmd, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        # ``run_drc`` writes the report via --output; honour that contract so
+        # the function's file-first parse path is exercised.
+        out_idx = cmd.index("--output")
+        report_path = Path(cmd[out_idx + 1])
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(json.dumps(payload))
+        returncode = 2 if payload["violations"] else 0
+        return subprocess.CompletedProcess(cmd, returncode, stdout=json.dumps(payload), stderr="")
+
+    monkeypatch.setattr(board04.subprocess, "run", fake_run)
+
+
+# --------------------------------------------------------------------------
+# run_drc allowlist-awareness
+# --------------------------------------------------------------------------
+
+
+def test_run_drc_passes_with_two_drills_and_connectivity(
+    board04: types.ModuleType, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The current committed board: 2 drills + 1 advisory connectivity -> PASS."""
+    _patch_run_drc(
+        board04,
+        monkeypatch,
+        tmp_path,
+        ["dimension_drill_clearance", "dimension_drill_clearance", "connectivity"],
+    )
+    pcb = tmp_path / "stm32_devboard_routed.kicad_pcb"
+    pcb.write_text("(kicad_pcb)")
+    assert board04.run_drc(pcb) is True
+
+
+def test_run_drc_fails_on_third_drill(
+    board04: types.ModuleType, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A 3rd drill-clearance error exceeds the allowance of 2 -> FAIL."""
+    _patch_run_drc(
+        board04,
+        monkeypatch,
+        tmp_path,
+        ["dimension_drill_clearance"] * 3,
+    )
+    pcb = tmp_path / "stm32_devboard_routed.kicad_pcb"
+    pcb.write_text("(kicad_pcb)")
+    assert board04.run_drc(pcb) is False
+
+
+def test_run_drc_fails_on_non_drill_blocking_rule(
+    board04: types.ModuleType, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Any non-drill, non-advisory blocking rule -> FAIL even within drill allowance."""
+    _patch_run_drc(
+        board04,
+        monkeypatch,
+        tmp_path,
+        ["dimension_drill_clearance", "clearance_segment_zone"],
+    )
+    pcb = tmp_path / "stm32_devboard_routed.kicad_pcb"
+    pcb.write_text("(kicad_pcb)")
+    assert board04.run_drc(pcb) is False
+
+
+def test_run_drc_passes_clean_board(
+    board04: types.ModuleType, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A fully clean board (0 violations) -> PASS."""
+    _patch_run_drc(board04, monkeypatch, tmp_path, [])
+    pcb = tmp_path / "stm32_devboard_routed.kicad_pcb"
+    pcb.write_text("(kicad_pcb)")
+    assert board04.run_drc(pcb) is True
+
+
+def test_run_drc_drill_allowance_matches_yaml() -> None:
+    """The recipe's drill allowance must equal the CI tolerance floor (#3847)."""
+    import yaml
+
+    board04 = _load_board04_module()
+    tolerance = yaml.safe_load((REPO_ROOT / ".github" / "routed-drc-tolerance.yml").read_text())
+    floor = (tolerance.get("tolerances") or {}).get(
+        "boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb"
+    )
+    assert floor == board04._DRILL_CLEARANCE_ALLOWANCE, (
+        "The board-04 recipe's _DRILL_CLEARANCE_ALLOWANCE must stay in lockstep "
+        "with .github/routed-drc-tolerance.yml.  When #3847 re-spaces the drill "
+        "pair, drop BOTH to 0 in the same PR."
+    )


### PR DESCRIPTION
## Summary

Two independent board-04 gaps let a broken board ship undetected (child of #3829):

1. The recipe's `main()` success gate omitted the already-computed `drc_success` and discarded `write_lvs_report`'s `(copper_clean, label_clean)` return -- so a board with a NEW blocking DRC error or a copper-LVS short printed SUCCESS and exited 0.
2. Board 04 had NO end-to-end CI job (boards 00/01/02 run the full asserter, 03/06/07 `--lvs-only`, 05 a blocking-net baseline; 04 was absent), so a recipe regression shipped undetected at PR time.

This PR fixes both while staying GREEN on the current board (which carries 2 grandfathered `dimension_drill_clearance` drills + 1 advisory `connectivity` finding, copper-LVS clean).

## Changes

- `boards/04-stm32-devboard/generate_design.py`
  - `run_drc` is now **allowlist-aware**: parses the DRC JSON and counts blocking violations the way `scripts/ci/check_routed_drc.py` does -- excludes the advisory `connectivity` rule, tolerates up to `_DRILL_CLEARANCE_ALLOWANCE` (=2) grandfathered `dimension_drill_clearance` drills (#3847), and fails on a 3rd drill or any other blocking rule. Switched its `kct check` call to `--errors-only --format json --output`.
  - Captured `copper_clean` from `write_lvs_report` and ANDed both `drc_success` and `copper_clean` into the `main()` exit gate.
- `.github/workflows/ci.yml` -- new `board-04-end-to-end` job (template: `board-03-end-to-end`). Regenerates board 04 in a `kicad/kicad:10.0` container and validates the FRESH artifact out-of-process: DRC against the allowlist of 2 (fresh routed PCB staged over the repo-relative path so the tolerance entry + `jlcpcb-tier1` mfr override resolve) and copper-LVS via the `--lvs-only` asserter. Uses `uv sync --frozen` (matching #3852). Recipe exit is not gated (`|| true`) because board-04's route is subject to the documented host-vs-CI router divergence (#3822); the out-of-process asserters are the real gate.
- `tests/test_board_04_main_gate.py` -- new hermetic unit tests for the `run_drc` allowlist edge cases + a lockstep guard tying the recipe's drill allowance to the YAML floor.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `main()` gate exits non-zero on a real DRC/LVS failure | ✅ | `run_drc` returns False on a 3rd drill or any non-drill blocking rule (unit tests); `copper_clean` ANDed into gate; `write_lvs_report(require_clean=True)` also raises on a copper short |
| `main()` gate exits 0 on the current board (2 allowlisted drills) | ✅ | `run_drc` returns True on the committed board (verified: "0 blocking, 2 dimension_drill_clearance (allow 2), 1 advisory"); a fresh host regen yields `drc_success=True`, `copper_clean=True` |
| DRC gate is allowlist-aware (tolerates the 2 drills, catches new) | ✅ | Recipe allowance kept in lockstep with `.github/routed-drc-tolerance.yml: 2`; CI job uses `check_routed_drc.py` keyed to the repo-relative path |
| board-04 CI job exists + regenerates + validates the RESULT out-of-process | ✅ | New `board-04-end-to-end` job: regen -> stage fresh PCB -> `check_routed_drc.py` (DRC) + `check_board_00_e2e.py --lvs-only` (LVS) |
| Job is GREEN on the current board | ✅ | All three out-of-process asserters verified locally against a fresh regen (DRC = 2 == allowlist max; lvs.json clean; LVS-only asserter passes) even with a partial host route |
| Tests as appropriate | ✅ | `tests/test_board_04_main_gate.py` (5) + existing `tests/test_board_04_mfr_gate.py` (4) all pass |

## Test Plan

- `uv run pytest tests/test_board_04_main_gate.py tests/test_board_04_mfr_gate.py` -> 9 passed.
- Fresh regen into `/tmp` (`PYTHONHASHSEED=42`): final `run_drc` -> PASS (2 drills tolerated), copper-LVS PASS (0/0), `lvs.json clean: true`.
- `check_routed_drc.py` on the fresh artifact staged at the repo-relative path -> exit 0 (2 errors == allowlist max 2).
- `check_board_00_e2e.py --stem stm32_devboard --lvs-only` on the fresh artifact -> all 6 artifacts present, lvs.json clean, board.json lvs_clean=True.
- `ruff check` + `ruff format` clean on touched files; `mypy` on touched files adds no new errors (the 2 reported -- untyped `yaml`, pre-existing `ERCReport.load` at line 683 -- are pre-existing repo patterns).
- `yaml.safe_load(ci.yml)` parses.

**Note on determinism / baseline:** the recipe routes `--seed 42 --deterministic-budget` aiming for byte-identical regen, but board-04's route is subject to the documented host-vs-CI router divergence (#3822). Rather than gate on the recipe's nondeterministic exit code, the CI job validates the RESULT out-of-process (DRC allowlist-aware + copper-LVS), which is stable: even a partial host regen produces exactly 2 drills + 0 shorts/0 opens.

**Exit clause:** when #3847 re-spaces the sub-0.5mm drill pair, drop both the `.github/routed-drc-tolerance.yml` entry and the recipe's `_DRILL_CLEARANCE_ALLOWANCE` back to 0 in lockstep (a test enforces they match).

Closes #3839