### PR TITLE
ci: add independent out-of-process copper-LVS + DRC re-checks to board-03/06/07 --lvs-only jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1225,6 +1225,42 @@ jobs:
           uv run python boards/03-usb-joystick/generate_design.py \
             /tmp/board03-ci
           test -f /tmp/board03-ci/lvs.json
+          test -f /tmp/board03-ci/usb_joystick.kicad_sch
+          test -f /tmp/board03-ci/usb_joystick_routed.kicad_pcb
+
+      - name: Independent copper-LVS re-check (out-of-process, issue #3840)
+        # Re-run compare_copper_netlist in a process the CI job controls (NOT
+        # the recipe) on the REGENERATED schematic + routed PCB, and assert
+        # clean.  This does NOT read lvs.json, so it catches a copper short/
+        # open even if a future recipe change mis-wrote lvs.json or skipped
+        # the fresh check.  The subprocess entrypoint (python -m
+        # kicad_tools.lvs.copper_lvs) was added in #3838; the asserter
+        # (check_copper_lvs.py) maps clean->0, dirty->2, malformed->1.
+        run: |
+          set -euo pipefail
+          uv run python -m kicad_tools.lvs.copper_lvs \
+            /tmp/board03-ci/usb_joystick.kicad_sch \
+            /tmp/board03-ci/usb_joystick_routed.kicad_pcb \
+            > /tmp/board03-copper.json
+          uv run python scripts/ci/check_copper_lvs.py /tmp/board03-copper.json
+
+      - name: Independent DRC re-check within allowlist (out-of-process, issue #3840)
+        # Validate the REGENERATED routed PCB's DRC out-of-process against the
+        # per-board allowlist (.github/routed-drc-tolerance.yml).  Board 03 has
+        # NO tolerance entry (strict 0-blocking gate) but DOES carry a
+        # jlcpcb-tier1 manufacturers: override; check_routed_drc.py keys both
+        # off the repo-relative path, so the fresh PCB MUST be staged over the
+        # committed path for the override + strict-0 gate to resolve.  This is
+        # the SAME tolerance mechanism the board-04 job and the
+        # routed-pcb-drc-check job use, so it never double-fails on
+        # already-grandfathered errors.  No git restore is needed: the CI
+        # checkout is a throwaway workspace (mirrors the board-04 job).
+        run: |
+          set -euo pipefail
+          cp /tmp/board03-ci/usb_joystick_routed.kicad_pcb \
+            boards/03-usb-joystick/output/usb_joystick_routed.kicad_pcb
+          uv run python scripts/ci/check_routed_drc.py \
+            boards/03-usb-joystick/output/usb_joystick_routed.kicad_pcb
 
       - name: Emit board.json via kct board-metrics
         run: |
@@ -1324,6 +1360,41 @@ jobs:
           uv run python boards/06-diffpair-test/generate_design.py \
             /tmp/board06-ci --step all --seed 42 || true
           test -f /tmp/board06-ci/lvs.json
+          test -f /tmp/board06-ci/diffpair_test.kicad_sch
+          test -f /tmp/board06-ci/diffpair_test_routed.kicad_pcb
+
+      - name: Independent copper-LVS re-check (out-of-process, issue #3840)
+        # Re-run compare_copper_netlist in a process the CI job controls (NOT
+        # the recipe) on the REGENERATED schematic + routed PCB, and assert
+        # clean.  Does NOT read lvs.json, so it catches a copper short/open
+        # even if the recipe mis-wrote lvs.json.  Board 06 routes PARTIAL by
+        # design (recipe exits non-zero, tolerated above), but the persisted
+        # *_routed.kicad_pcb exists regardless, so this re-check still runs and
+        # gates.  Entrypoint from #3838; asserter maps clean->0, dirty->2.
+        run: |
+          set -euo pipefail
+          uv run python -m kicad_tools.lvs.copper_lvs \
+            /tmp/board06-ci/diffpair_test.kicad_sch \
+            /tmp/board06-ci/diffpair_test_routed.kicad_pcb \
+            > /tmp/board06-copper.json
+          uv run python scripts/ci/check_copper_lvs.py /tmp/board06-copper.json
+
+      - name: Independent DRC re-check within allowlist (out-of-process, issue #3840)
+        # Validate the REGENERATED routed PCB's DRC out-of-process against the
+        # per-board allowlist (.github/routed-drc-tolerance.yml: 33 for board
+        # 06's diff-pair + drill residuals).  This is the SAME tolerance
+        # mechanism the routed-pcb-drc-check + matchgroup/diffpair regression
+        # jobs use, so it does NOT double-fail on the already-grandfathered
+        # errors -- it only catches a NEW DRC regression above the allowlist.
+        # check_routed_drc.py keys tolerance off the repo-relative path, so
+        # stage the fresh PCB over the committed path (throwaway CI checkout;
+        # mirrors the board-04 job).
+        run: |
+          set -euo pipefail
+          cp /tmp/board06-ci/diffpair_test_routed.kicad_pcb \
+            boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb
+          uv run python scripts/ci/check_routed_drc.py \
+            boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb
 
       - name: Emit board.json via kct board-metrics
         run: |
@@ -1405,6 +1476,40 @@ jobs:
           uv run python boards/07-matchgroup-test/generate_design.py \
             /tmp/board07-ci --step all --seed 42 || true
           test -f /tmp/board07-ci/lvs.json
+          test -f /tmp/board07-ci/matchgroup_test.kicad_sch
+          test -f /tmp/board07-ci/matchgroup_test_routed.kicad_pcb
+
+      - name: Independent copper-LVS re-check (out-of-process, issue #3840)
+        # Re-run compare_copper_netlist in a process the CI job controls (NOT
+        # the recipe) on the REGENERATED schematic + routed PCB, and assert
+        # clean.  Does NOT read lvs.json, so it catches a copper short/open
+        # even if the recipe mis-wrote lvs.json.  Board 07 routes PARTIAL by
+        # design (recipe exits non-zero, tolerated above), but the persisted
+        # *_routed.kicad_pcb exists regardless, so this re-check still runs and
+        # gates.  Entrypoint from #3838; asserter maps clean->0, dirty->2.
+        run: |
+          set -euo pipefail
+          uv run python -m kicad_tools.lvs.copper_lvs \
+            /tmp/board07-ci/matchgroup_test.kicad_sch \
+            /tmp/board07-ci/matchgroup_test_routed.kicad_pcb \
+            > /tmp/board07-copper.json
+          uv run python scripts/ci/check_copper_lvs.py /tmp/board07-copper.json
+
+      - name: Independent DRC re-check within allowlist (out-of-process, issue #3840)
+        # Validate the REGENERATED routed PCB's DRC out-of-process against the
+        # per-board allowlist (.github/routed-drc-tolerance.yml: 120 for board
+        # 07's matchgroup baseline).  This is the SAME tolerance mechanism the
+        # routed-pcb-drc-check + matchgroup regression jobs use, so it does NOT
+        # double-fail on the already-grandfathered errors -- it only catches a
+        # NEW DRC regression above the allowlist.  check_routed_drc.py keys
+        # tolerance off the repo-relative path, so stage the fresh PCB over the
+        # committed path (throwaway CI checkout; mirrors the board-04 job).
+        run: |
+          set -euo pipefail
+          cp /tmp/board07-ci/matchgroup_test_routed.kicad_pcb \
+            boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb
+          uv run python scripts/ci/check_routed_drc.py \
+            boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb
 
       - name: Emit board.json via kct board-metrics
         run: |

--- a/scripts/ci/check_copper_lvs.py
+++ b/scripts/ci/check_copper_lvs.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Independent copper-LVS re-check asserter for CI (issue #3840).
+
+This is the *parser/asserter* side of an out-of-process copper-LVS gate.
+The CI job first emits a fresh copper-LVS verdict for a regenerated board
+by running the subprocess entrypoint added in #3838::
+
+    uv run python -m kicad_tools.lvs.copper_lvs <schematic> <routed_pcb> > out.json
+
+That entrypoint loads both files in a clean interpreter (no in-process
+recipe state), runs :func:`compare_copper_netlist`, and prints a single
+JSON object of the shape produced by
+:func:`kicad_tools.lvs.copper_lvs.result_to_json`::
+
+    {"clean": true, "mismatches": []}
+
+This script reads that JSON and asserts ``clean == true``, emitting a
+GitHub-Actions ``::error::`` annotation and exiting 2 on any mismatch.
+
+Why this exists (defense-in-depth, issue #3840):
+
+The board-03/06/07 ``--lvs-only`` jobs gate on ``output/lvs.json``, which
+is written by the same ``generate_design.py`` recipe process that routed
+the board.  Since #3838 the recipe's ``lvs.json`` copper verdict is already
+authoritative against the on-disk bytes (``write_lvs_report`` re-derives it
+in a fresh subprocess and fails closed on divergence).  But the CI gate
+still *trusts the recipe to have run that fresh check* -- a future recipe
+change that drops ``fresh_copper_check=True`` / ``require_clean=True`` or
+overwrites ``lvs.json`` would silently pass.  Running
+``python -m kicad_tools.lvs.copper_lvs`` from a process the CI job *itself*
+controls, on the regenerated ``*_routed.kicad_pcb``, and asserting the
+result here removes that single point of trust: this asserter never reads
+``lvs.json``.
+
+Sibling of ``scripts/ci/check_board_00_e2e.py`` and
+``scripts/ci/check_routed_drc.py`` -- same exit-code convention, same
+``::error::`` annotation pattern, deliberately small so the gate's contract
+stays auditable and unit-testable.
+
+Exit codes:
+    0 -- The copper-LVS result is clean (no shorts / no opens).
+    1 -- Tool/usage error (missing arg, file unreadable, JSON parse
+         failure, missing ``clean`` key) -- distinct from "the gate caught
+         a real regression".
+    2 -- The copper-LVS result reports ``clean: false`` (the gate caught a
+         short or open).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _err(msg: str, file: str | Path | None = None) -> None:
+    """Emit a GitHub Actions ``::error::`` annotation to stdout.
+
+    The ``file=`` parameter surfaces the failure inline on the PR
+    Files-changed view when the path is tracked by git; for tmp paths
+    the annotation still shows in the job log with the field surfaced
+    for triage.
+    """
+    if file is not None:
+        print(f"::error file={file}::{msg}")
+    else:
+        print(f"::error::{msg}")
+
+
+def _summarize_mismatches(mismatches: list[dict[str, Any]]) -> str:
+    """Render a short human-readable summary of copper-LVS mismatches.
+
+    Mirrors the field names produced by
+    :func:`kicad_tools.lvs.copper_lvs.result_to_json`
+    (``kind``/``net_a``/``net_b``/``pad_a``/``pad_b``).
+    """
+    shorts = sum(1 for m in mismatches if m.get("kind") == "short")
+    opens = sum(1 for m in mismatches if m.get("kind") == "open")
+    first = mismatches[0] if mismatches else None
+    first_desc = ""
+    if isinstance(first, dict):
+        kind = first.get("kind", "?")
+        net_a = first.get("net_a", "?")
+        net_b = first.get("net_b", "?")
+        pad_a = first.get("pad_a", "?")
+        pad_b = first.get("pad_b", "?")
+        first_desc = f"; first: {kind} {net_a}({pad_a}) <-> {net_b}({pad_b})"
+    return f"{len(mismatches)} mismatch(es) ({shorts} short, {opens} open){first_desc}"
+
+
+def assert_clean(payload: dict[str, Any]) -> str | None:
+    """Assert a copper-LVS JSON payload reports ``clean: true``.
+
+    Args:
+        payload: Parsed JSON object as emitted by
+            ``python -m kicad_tools.lvs.copper_lvs``.  Must contain a
+            ``clean`` boolean; ``mismatches`` (a list) is optional.
+
+    Returns:
+        ``None`` on pass (clean).  A human-readable error message on a
+        dirty result (caller maps to exit 2).
+
+    Raises:
+        KeyError: If ``clean`` is absent (caller maps to exit 1 -- a
+            malformed payload, not a caught regression).
+    """
+    clean = payload["clean"]
+    if clean:
+        return None
+    mismatches = payload.get("mismatches", [])
+    if not isinstance(mismatches, list):
+        mismatches = []
+    return f"copper-LVS reports clean=false with {_summarize_mismatches(mismatches)}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="check_copper_lvs.py",
+        description=(
+            "Assert a fresh out-of-process copper-LVS result is clean. "
+            "Reads the JSON emitted by "
+            "'python -m kicad_tools.lvs.copper_lvs <sch> <routed_pcb>'. "
+            "Use '/dev/stdin' (or '-') to read the result from a pipe."
+        ),
+    )
+    parser.add_argument(
+        "result_json",
+        help=(
+            "Path to the JSON file emitted by python -m kicad_tools.lvs.copper_lvs "
+            "(use '-' or '/dev/stdin' to read from stdin)."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    raw_path = args.result_json
+    try:
+        if raw_path in ("-", "/dev/stdin"):
+            text = sys.stdin.read()
+            display = "<stdin>"
+        else:
+            path = Path(raw_path)
+            if not path.is_file():
+                _err(f"result JSON does not exist or is not a file: {path}")
+                return 1
+            text = path.read_text()
+            display = str(path)
+    except OSError as e:
+        _err(f"could not read result JSON {raw_path}: {e}")
+        return 1
+
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as e:
+        _err(f"could not parse copper-LVS JSON from {display}: {e}")
+        return 1
+
+    if not isinstance(payload, dict):
+        _err(f"copper-LVS JSON from {display} is not a JSON object: {type(payload).__name__}")
+        return 1
+
+    try:
+        dirty_msg = assert_clean(payload)
+    except KeyError:
+        _err(f"copper-LVS JSON from {display} missing required 'clean' key: {payload!r}")
+        return 1
+
+    if dirty_msg is not None:
+        _err(dirty_msg, file=display)
+        print(
+            "\nIndependent copper-LVS re-check FAILED (exit 2). This re-check is run "
+            "by the CI job itself (not the recipe) on the regenerated routed PCB, so "
+            "it catches a copper short/open even if the recipe mis-wrote lvs.json.",
+            flush=True,
+        )
+        return 2
+
+    print("[ok] copper-LVS clean (independent out-of-process re-check)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_ci_check_copper_lvs.py
+++ b/tests/test_ci_check_copper_lvs.py
@@ -1,0 +1,188 @@
+"""Tests for the independent copper-LVS re-check asserter (issue #3840).
+
+``scripts/ci/check_copper_lvs.py`` is the parser/asserter side of the
+out-of-process copper-LVS gate added to the board-03/06/07 ``--lvs-only``
+CI jobs.  It reads the JSON emitted by
+``python -m kicad_tools.lvs.copper_lvs <sch> <routed_pcb>`` and asserts the
+result is clean, mirroring the exit-code + ``::error::`` annotation
+convention of the sibling asserters (``check_board_00_e2e.py``,
+``check_routed_drc.py``).
+
+These tests exercise the asserter in isolation against synthetic JSON
+payloads matching the shape produced by
+:func:`kicad_tools.lvs.copper_lvs.result_to_json` -- no KiCad data or
+subprocess needed.
+
+Exit-code contract under test:
+    0 -- clean result (clean: true).
+    1 -- usage/parse error (missing file, bad JSON, missing 'clean' key).
+    2 -- dirty result (clean: false) -- the gate caught a regression.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HELPER_SCRIPT_PATH = REPO_ROOT / "scripts" / "ci" / "check_copper_lvs.py"
+
+
+def _load_helper_module():
+    """Import ``scripts/ci/check_copper_lvs.py`` as a module."""
+    spec = importlib.util.spec_from_file_location("check_copper_lvs", HELPER_SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_copper_lvs"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+check_copper_lvs = _load_helper_module()
+
+
+def _write_json(tmp_path: Path, payload: object) -> Path:
+    p = tmp_path / "copper.json"
+    p.write_text(json.dumps(payload))
+    return p
+
+
+# --- clean result -> exit 0 ------------------------------------------------
+
+
+def test_clean_result_exits_0(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    p = _write_json(tmp_path, {"clean": True, "mismatches": []})
+    rc = check_copper_lvs.main([str(p)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "[ok] copper-LVS clean" in out
+
+
+def test_clean_result_no_mismatches_key_exits_0(tmp_path: Path) -> None:
+    # ``mismatches`` is optional when clean.
+    p = _write_json(tmp_path, {"clean": True})
+    assert check_copper_lvs.main([str(p)]) == 0
+
+
+# --- dirty result -> exit 2 ------------------------------------------------
+
+
+def test_dirty_short_exits_2(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    p = _write_json(
+        tmp_path,
+        {
+            "clean": False,
+            "mismatches": [
+                {
+                    "kind": "short",
+                    "net_a": "GND",
+                    "net_b": "LED_ANODE",
+                    "pad_a": "D1.1",
+                    "pad_b": "R1.2",
+                }
+            ],
+        },
+    )
+    rc = check_copper_lvs.main([str(p)])
+    assert rc == 2
+    out = capsys.readouterr().out
+    assert "::error" in out
+    assert "clean=false" in out
+    assert "1 short" in out
+
+
+def test_dirty_open_exits_2(tmp_path: Path) -> None:
+    p = _write_json(
+        tmp_path,
+        {
+            "clean": False,
+            "mismatches": [
+                {
+                    "kind": "open",
+                    "net_a": "VCC",
+                    "net_b": "VCC",
+                    "pad_a": "U1.7",
+                    "pad_b": "C1.1",
+                }
+            ],
+        },
+    )
+    assert check_copper_lvs.main([str(p)]) == 2
+
+
+def test_dirty_empty_mismatches_still_exits_2(tmp_path: Path) -> None:
+    # ``clean: false`` is authoritative even if mismatches list is empty
+    # (the gate must not pass a self-contradictory dirty payload).
+    p = _write_json(tmp_path, {"clean": False, "mismatches": []})
+    assert check_copper_lvs.main([str(p)]) == 2
+
+
+# --- malformed / usage -> exit 1 -------------------------------------------
+
+
+def test_missing_clean_key_exits_1(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    p = _write_json(tmp_path, {"mismatches": []})
+    rc = check_copper_lvs.main([str(p)])
+    assert rc == 1
+    assert "missing required 'clean' key" in capsys.readouterr().out
+
+
+def test_malformed_json_exits_1(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    p = tmp_path / "copper.json"
+    p.write_text("{not valid json")
+    rc = check_copper_lvs.main([str(p)])
+    assert rc == 1
+    assert "could not parse" in capsys.readouterr().out
+
+
+def test_missing_file_exits_1(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    rc = check_copper_lvs.main([str(tmp_path / "does-not-exist.json")])
+    assert rc == 1
+    assert "does not exist" in capsys.readouterr().out
+
+
+def test_non_object_json_exits_1(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    p = _write_json(tmp_path, ["clean", True])
+    rc = check_copper_lvs.main([str(p)])
+    assert rc == 1
+    assert "not a JSON object" in capsys.readouterr().out
+
+
+# --- stdin support ---------------------------------------------------------
+
+
+def test_reads_from_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
+    import io
+
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps({"clean": True, "mismatches": []})))
+    assert check_copper_lvs.main(["-"]) == 0
+
+
+def test_reads_dirty_from_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
+    import io
+
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(
+            json.dumps(
+                {
+                    "clean": False,
+                    "mismatches": [
+                        {
+                            "kind": "short",
+                            "net_a": "A",
+                            "net_b": "B",
+                            "pad_a": "U1.1",
+                            "pad_b": "U1.2",
+                        }
+                    ],
+                }
+            )
+        ),
+    )
+    assert check_copper_lvs.main(["/dev/stdin"]) == 2


### PR DESCRIPTION
## Summary

The board-03/06/07 `--lvs-only` CI jobs gated only on `output/lvs.json` (the recipe's own self-report) and never independently re-validated DRC. Since #3838 the recipe's copper verdict is authoritative against the on-disk bytes, but the gate still *trusts the recipe to have run the fresh check*, and DRC was not validated at all in these jobs. This PR adds two CI-owned, out-of-process re-checks (defense-in-depth) to each of the three jobs.

## Changes

- **New `scripts/ci/check_copper_lvs.py`** — small asserter that reads the JSON emitted by `python -m kicad_tools.lvs.copper_lvs` (the subprocess entrypoint added in #3838) and asserts `clean: true`. Follows the sibling asserters' convention: clean -> exit 0, malformed/usage -> exit 1, dirty -> exit 2, with `::error::` annotations. Never reads `lvs.json`.
- **`.github/workflows/ci.yml`** — added two steps to each of `board-03/06/07-end-to-end`:
  1. *Independent copper-LVS re-check*: runs `python -m kicad_tools.lvs.copper_lvs <regen_sch> <regen_routed_pcb>` (a process the CI job controls, not the recipe) and asserts clean via the new asserter. Runs even when the recipe exits non-zero on PARTIAL routes (boards 06/07) since it operates on the persisted `*_routed.kicad_pcb`.
  2. *Allowlist-aware DRC re-check*: stages the regenerated routed PCB over the committed repo-relative path and runs `scripts/ci/check_routed_drc.py`, which keys per-board tolerance + manufacturer off that path. Uses the **same** `.github/routed-drc-tolerance.yml` mechanism as the existing routing-regression jobs, so it does not double-fail on board-06/07's grandfathered errors (board-06: 33; board-07: 120; board-03: strict-0 + jlcpcb-tier1 override).
- **New `tests/test_ci_check_copper_lvs.py`** — unit tests for the asserter (clean -> 0, dirty short/open -> 2, malformed/missing-key/missing-file -> 1, stdin support).

Reuses the board-04 (#3854) job's staging pattern. Boards 00/01/02 (full e2e) and board-05 (metric re-route) are unchanged.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| board-03/06/07 run an independent out-of-process copper-LVS re-check on the regenerated routed PCB, assert clean | OK | New steps run `python -m kicad_tools.lvs.copper_lvs` + `check_copper_lvs.py`; verified end-to-end on committed board-03 (rc=0) |
| board-03/06/07 run an allowlist-aware DRC re-check on the regenerated routed PCB | OK | New steps stage fresh PCB over committed path + run `check_routed_drc.py`; verified board-03 (strict-0, tier1, rc=0), board-06 (24<=33), board-07 (28<=120) |
| A board whose recipe self-report is wrong is caught even if lvs.json is mis-written | OK | Asserter does not read lvs.json; `test_dirty_*` + dirty-injection rc=2 |
| No gate passes solely on the recipe's in-process verdict | OK | Both copper-LVS and DRC re-checks are run by the CI job, independent of lvs.json |
| Copper re-check runs even when recipe exited non-zero | OK | Operates on the persisted `*_routed.kicad_pcb`; board-06/07 regen keeps `\|\| true` |
| Boards 00/01/02 and board-05 jobs unchanged | OK | No edits to those jobs |
| Asserter follows ::error:: + exit-code convention (0/1/2) | OK | 11 unit tests cover all paths |

## Test Plan

- `uv run pytest tests/test_ci_check_copper_lvs.py` — 11 passed.
- `uv run pytest tests/test_check_routed_drc_advisory.py tests/test_ci_routed_drc_workflow.py` — passed (76 total with the new file).
- `uv run ruff check` + `ruff format --check` on new files — clean.
- YAML validated via `yaml.safe_load(ci.yml)`.
- Manual end-to-end: `python -m kicad_tools.lvs.copper_lvs ... | check_copper_lvs.py -` on committed board-03 -> rc=0; dirty JSON injection -> rc=2.
- Manual DRC: `check_routed_drc.py` on committed board-03 (rc=0, tier1, strict-0), board-06 (rc=0, 24<=33), board-07 (rc=0, 28<=120) — confirms jobs stay GREEN and no double-fail on grandfathered errors.

Closes #3840