### PR TITLE
feat(router): add read-only stuck-net classifier with net-status --why

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 3842
-# Branch: feature/issue-3842
+# Issue: 3863
+# Branch: feature/issue-3863
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -415,6 +415,8 @@ def _dispatch_command(args) -> int:
             sub_argv.append("--by-class")
         if hasattr(args, "net_status_verbose") and args.net_status_verbose:
             sub_argv.append("--verbose")
+        if hasattr(args, "net_status_why") and args.net_status_why:
+            sub_argv.append("--why")
         return net_status_cmd(sub_argv)
 
     elif args.command == "clean":

--- a/src/kicad_tools/cli/net_status_cmd.py
+++ b/src/kicad_tools/cli/net_status_cmd.py
@@ -60,6 +60,15 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Show all pads with coordinates",
     )
+    parser.add_argument(
+        "--why",
+        action="store_true",
+        help=(
+            "Classify each incomplete signal net by WHY it is stuck "
+            "(ESCAPE_BLOCKED / CONGESTION_SATURATED / PLACEMENT_BOUND) with "
+            "supporting evidence. Read-only diagnostic (issue #3863)."
+        ),
+    )
 
     args = parser.parse_args(argv)
 
@@ -76,6 +85,12 @@ def main(argv: list[str] | None = None) -> int:
     except Exception as e:
         print(f"Error during analysis: {e}", file=sys.stderr)
         return 1
+
+    # --why: stuck-net classifier (issue #3863). Read-only diagnostic that
+    # labels each incomplete signal net by WHY it is stuck. Handled before the
+    # normal filter/output path because it has its own output shape.
+    if args.why:
+        return output_why(pcb_path, args.format)
 
     # Filter results if needed
     if args.net:
@@ -264,6 +279,50 @@ def output_json(
         data["nets"] = [n.to_dict() for n in result.nets]
 
     print(json.dumps(data, indent=2))
+
+
+def output_why(pcb_path: Path, fmt: str) -> int:
+    """Classify incomplete signal nets by why they are stuck and print them.
+
+    Returns 2 if any stuck nets were found (matching the rest of net-status'
+    exit-code convention), 0 if the board has no stuck signal nets.
+    """
+    from kicad_tools.router.stuck_classifier import classify_stuck_nets
+
+    result = classify_stuck_nets(pcb_path)
+
+    if fmt == "json":
+        data = {"pcb": str(pcb_path), **result.to_dict()}
+        print(json.dumps(data, indent=2))
+        return 2 if result.diagnoses else 0
+
+    print(f"Stuck-net classification: {pcb_path.name}")
+    print("=" * 70)
+    print()
+    counts = result.counts
+    print(f"Stuck signal nets: {len(result.diagnoses)}")
+    print(f"  ESCAPE_BLOCKED:       {counts['escape_blocked']}")
+    print(f"  CONGESTION_SATURATED: {counts['congestion_saturated']}")
+    print(f"  PLACEMENT_BOUND:      {counts['placement_bound']}")
+    print()
+
+    if not result.diagnoses:
+        print("No stuck signal nets -- board is fully routed (or only advisory")
+        print("plane/pour residuals remain).")
+        return 0
+
+    # Group for readability, escape-blocked first (most upstream).
+    order = {"escape_blocked": 0, "congestion_saturated": 1, "placement_bound": 2}
+    for diag in sorted(result.diagnoses, key=lambda d: order[d.classification_value]):
+        pads = ", ".join(diag.unconnected_pads) or "(none)"
+        print(f"[{diag.classification.value.upper()}] {diag.net_name}")
+        print(f"  unconnected pads: {pads}")
+        if diag.blocking_nets:
+            print(f"  blocking nets:    {', '.join(diag.blocking_nets)}")
+        print(f"  evidence:         {diag.evidence}")
+        print()
+
+    return 2
 
 
 if __name__ == "__main__":

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -5000,6 +5000,16 @@ def _add_net_status_parser(subparsers) -> None:
         action="store_true",
         help="Show all pads with coordinates",
     )
+    net_status_parser.add_argument(
+        "--why",
+        dest="net_status_why",
+        action="store_true",
+        help=(
+            "Classify each incomplete signal net by WHY it is stuck "
+            "(ESCAPE_BLOCKED / CONGESTION_SATURATED / PLACEMENT_BOUND) with "
+            "supporting evidence. Read-only diagnostic (issue #3863)."
+        ),
+    )
 
 
 def _add_board_metrics_parser(subparsers) -> None:

--- a/src/kicad_tools/router/stuck_classifier.py
+++ b/src/kicad_tools/router/stuck_classifier.py
@@ -1,0 +1,719 @@
+"""Stuck-net classifier (Milestone 1 of architect roadmap #3862, issue #3863).
+
+READ-ONLY diagnostic that labels every unfinished signal net by *why* it is
+stuck so downstream fixes (M2 region re-solve, M3 placement nudge, M4 escape
+upgrade) and humans can target the right remedy.
+
+The three architecturally-distinct failure modes (per #3862):
+
+* ``ESCAPE_BLOCKED`` -- a stranded pad cannot leave its own footprint: foreign
+  copper and foreign pads crowd every direction around the pad so there is no
+  open sector wide enough for a trace to escape (the chorus J2 "0/8 escaped, no
+  grid point reachable" class).
+
+* ``CONGESTION_SATURATED`` -- the stranded pad *can* escape, and committed
+  *strict* (fully-connected) signal-net copper sits adjacent to it.  Completing
+  the net would require ripping that copper, which strands the blocker net (the
+  1:1-trade local minimum confirmed on chorus #3861).  This is the M2 region
+  re-solve target.
+
+* ``PLACEMENT_BOUND`` -- the stranded pad can escape, but there is no nearby
+  committed strict copper to rip (ripping blockers cannot help) AND the local
+  neighbourhood is densely packed with foreign nets between the stranded pad
+  and its partner island.  No routing order closes it; a part must move (the
+  chorus AUDIO_R / U5 analog cluster class).  This is the M3 placement-nudge
+  target.
+
+Design notes
+------------
+This is a *pure-geometry* analysis built entirely on
+:class:`kicad_tools.schema.pcb.PCB`, which resolves pad positions and committed
+copper into the SAME board-coordinate frame.  The frame-correct blocker
+geometry (``_find_blocking_strict_nets_from_pcb`` / ``_point_to_segment_distance``,
+below) is the load-bearing piece carried over from the #3861 controlled-rip-up
+work: it reads BOTH the stranded pad positions AND the committed copper through
+:class:`PCB` so they share the board frame.  Parsing the raw ``.kicad_pcb`` text
+directly would mix page-space copper coordinates with board-space pad
+coordinates (off by the page origin) and find no blockers -- the #3861
+frame-mismatch defect.  These helpers are vendored here (rather than imported
+from ``partial_rescue``) so the classifier is self-contained and carries no
+dependency on routing-mutation code.
+
+No routing grid is built and no routing is mutated, so the classifier is
+zero-regression by construction and cheap enough to run on any board as a
+routing-report feature.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from kicad_tools.router.failure_analysis import FailureCause
+
+if TYPE_CHECKING:
+    from kicad_tools.schema.pcb import PCB
+
+
+__all__ = [
+    "StuckClass",
+    "StuckNetDiagnosis",
+    "StuckClassifierResult",
+    "classify_stuck_nets",
+    "classify_stuck_nets_from_pcb",
+]
+
+
+# --- tunable geometry thresholds (mm) ---------------------------------------
+#
+# These defaults are tuned against the chorus stress fixture (31/51 strict, 20
+# partial).  They are exposed as parameters so a caller can sweep them, but the
+# defaults are what the CLI and the snapshot tests use.
+
+# Radius around a stranded pad scanned for "blocking" strict-net copper.  Reuses
+# the #3861 controlled-rip-up default so the classifier agrees with what that
+# stage would actually try to rip.
+DEFAULT_BLOCKER_RADIUS_MM = 2.0
+
+# A trace needs roughly this much open width to escape a pad.  A foreign
+# obstruction closer than this in an angular sector "blocks" that sector.
+DEFAULT_ESCAPE_CLEARANCE_MM = 0.25
+
+# How far around a pad to scan for foreign obstructions when testing escape.
+# Kept tight so only obstructions in the immediate escape ring count (a
+# neighbour at fine pitch ~0.5mm is seen; a part 1.5mm away is not a wall).
+DEFAULT_NEIGHBORHOOD_RADIUS_MM = 1.0
+
+# Wider radius used only for the local-congestion *count* that separates
+# placement-bound analog clusters (dense) from copper-boxed nets.
+DEFAULT_CONGESTION_RADIUS_MM = 2.0
+
+# Number of angular sectors the escape ring is divided into.  A pad escapes if a
+# contiguous open arc of at least ``ESCAPE_MIN_OPEN_SECTORS`` sectors exists.
+ESCAPE_SECTORS = 16
+
+# A pad is ESCAPE_BLOCKED when its widest contiguous open arc is narrower than
+# this many sectors (i.e. no routing lane wide enough to leave the pad).  With
+# 16 sectors (22.5 deg each), 2 sectors == a 45-degree lane.
+ESCAPE_MIN_OPEN_SECTORS = 2
+
+# Local congestion (foreign obstruction count within the congestion radius) at
+# or above this is "dense" -- used to separate PLACEMENT_BOUND (dense) from a
+# merely sparse stranded pad with no rippable copper.
+DEFAULT_CONGESTION_THRESHOLD = 6
+
+# Congestion at or above this is "analog-cluster dense" (e.g. chorus U5 QFN /
+# AUDIO_R): even ripping the few adjacent strict nets cannot clear the wall of
+# surrounding non-strict copper, so such a net is PLACEMENT_BOUND even when a
+# strict blocker is technically adjacent.  The chorus codec cluster sits at
+# 29-118 obstructions while the genuinely copper-boxed (M2-tractable) nets sit
+# at 2-15, so 20 lands in the natural gap between the two populations.
+DEFAULT_DENSE_CLUSTER_THRESHOLD = 20
+
+
+class StuckClass(Enum):
+    """Why an unfinished signal net is stuck.
+
+    The ``failure_cause`` property maps each class onto the pre-existing
+    :class:`~kicad_tools.router.failure_analysis.FailureCause` enum so the
+    classifier integrates with the rest of the failure-analysis machinery.
+    """
+
+    ESCAPE_BLOCKED = "escape_blocked"
+    CONGESTION_SATURATED = "congestion_saturated"
+    PLACEMENT_BOUND = "placement_bound"
+
+    @property
+    def description(self) -> str:
+        return {
+            "escape_blocked": (
+                "Pad cannot escape its footprint -- no open lane through "
+                "surrounding copper/pads (fine-pitch/connector). Fix: escape "
+                "upgrade (M4)."
+            ),
+            "congestion_saturated": (
+                "Pad reachable but boxed in by committed strict-net copper; "
+                "completing it would strand the blocker (1:1 trade). Fix: "
+                "region rip-up-and-reroute (M2)."
+            ),
+            "placement_bound": (
+                "Pad reachable with no rippable copper nearby and dense local "
+                "congestion -- no routing order closes it. Fix: placement "
+                "nudge (M3)."
+            ),
+        }[self.value]
+
+    @property
+    def failure_cause(self) -> FailureCause:
+        """Map onto the shared :class:`FailureCause` enum."""
+        return {
+            "escape_blocked": FailureCause.PIN_ACCESS,
+            "congestion_saturated": FailureCause.CONGESTION,
+            "placement_bound": FailureCause.ROUTING_ORDER,
+        }[self.value]
+
+
+@dataclass
+class StuckNetDiagnosis:
+    """Per-net classification result with supporting evidence."""
+
+    net_name: str
+    net_number: int
+    classification: StuckClass
+    unconnected_pads: list[str]
+    blocking_nets: list[str] = field(default_factory=list)
+    evidence: str = ""
+    # Diagnostics that fed the decision (handy for tuning / JSON consumers).
+    escape_lane_deg: float = 0.0
+    local_congestion: int = 0
+    nearest_blocker_mm: float | None = None
+
+    @property
+    def classification_value(self) -> str:
+        return self.classification.value
+
+    def to_dict(self) -> dict:
+        return {
+            "net_name": self.net_name,
+            "net_number": self.net_number,
+            "classification": self.classification.value,
+            "failure_cause": self.classification.failure_cause.value,
+            "unconnected_pads": list(self.unconnected_pads),
+            "blocking_nets": list(self.blocking_nets),
+            "evidence": self.evidence,
+            "escape_lane_deg": round(self.escape_lane_deg, 2),
+            "local_congestion": self.local_congestion,
+            "nearest_blocker_mm": (
+                round(self.nearest_blocker_mm, 4) if self.nearest_blocker_mm is not None else None
+            ),
+        }
+
+    def one_line(self) -> str:
+        pads = ", ".join(self.unconnected_pads) or "(none)"
+        blockers = f" blockers=[{', '.join(self.blocking_nets)}]" if self.blocking_nets else ""
+        return (
+            f"{self.net_name}: {self.classification.value.upper()} "
+            f"({len(self.unconnected_pads)} pad(s): {pads}){blockers} -- {self.evidence}"
+        )
+
+
+@dataclass
+class StuckClassifierResult:
+    """Aggregate classification over all unfinished signal nets."""
+
+    diagnoses: list[StuckNetDiagnosis]
+
+    @property
+    def counts(self) -> dict[str, int]:
+        out = {c.value: 0 for c in StuckClass}
+        for d in self.diagnoses:
+            out[d.classification.value] += 1
+        return out
+
+    def to_dict(self) -> dict:
+        return {
+            "summary": {
+                "stuck_nets": len(self.diagnoses),
+                "counts": self.counts,
+            },
+            "nets": [d.to_dict() for d in self.diagnoses],
+        }
+
+
+# --- internal geometry helpers ----------------------------------------------
+#
+# The two functions below are the frame-correct blocker geometry carried over
+# from the #3861 controlled-rip-up work.  They are vendored here so the
+# classifier is self-contained and carries no dependency on routing-mutation
+# code.  Both read the stranded pad positions AND the committed copper through
+# :class:`PCB` so they share the SAME board-coordinate frame -- the load-bearing
+# page-space-vs-board-space fix from #3861.
+
+
+def _point_to_segment_distance(
+    px: float,
+    py: float,
+    ax: float,
+    ay: float,
+    bx: float,
+    by: float,
+) -> float:
+    """Euclidean distance from point ``(px, py)`` to segment ``a->b``.
+
+    Distance is measured pad-to-segment (point-to-line-segment), not
+    pad-to-endpoint, so copper that *passes near* a pad without terminating
+    there is still recognised as a blocker (#3861).
+    """
+    dx = bx - ax
+    dy = by - ay
+    if dx == 0.0 and dy == 0.0:
+        return math.hypot(px - ax, py - ay)
+    t = ((px - ax) * dx + (py - ay) * dy) / (dx * dx + dy * dy)
+    t = max(0.0, min(1.0, t))
+    cx = ax + t * dx
+    cy = ay + t * dy
+    return math.hypot(px - cx, py - cy)
+
+
+def _find_blocking_strict_nets_from_pcb(
+    pcb: PCB,
+    target_net: str,
+    strict_nets: list[str],
+    *,
+    radius_mm: float = 2.0,
+    max_blockers: int = 3,
+) -> list[str]:
+    """Strict signal nets whose committed copper boxes in *target_net*'s pads.
+
+    A near-complete partial net is stuck because committed strict-net copper
+    sits between its connected island and its last unreached pad(s).  We
+    approximate "blocking" geometrically: a strict net is a candidate blocker
+    when any of its committed segments/vias lie within *radius_mm* of any of
+    *target_net*'s unconnected pads.  Candidates are ranked by proximity
+    (closest first) and capped at *max_blockers*.
+
+    Returns an ordered list of strict net names.  Empty when no committed copper
+    is near the stranded pad(s) (the pad is placement-bound, not copper-boxed).
+
+    Vendored from #3861 (``partial_rescue._find_blocking_strict_nets_from_pcb``)
+    -- the frame-correct geometry is load-bearing; see module docstring.
+    """
+    from kicad_tools.analysis.net_status import NetStatusAnalyzer
+
+    analysis = NetStatusAnalyzer(pcb).analyze()
+    status = analysis.get_net(target_net)
+    if status is None or not status.unconnected_pads:
+        return []
+    pad_positions = [p.position for p in status.unconnected_pads]
+
+    name_by_id = {nid: net.name for nid, net in pcb.nets.items() if net.name}
+    strict_set = set(strict_nets)
+    best_dist: dict[str, float] = {}
+
+    def _update(net_name: str, d: float) -> None:
+        if net_name not in best_dist or d < best_dist[net_name]:
+            best_dist[net_name] = d
+
+    for seg in pcb.segments:
+        name = name_by_id.get(seg.net_number)
+        if name not in strict_set:
+            continue
+        ax, ay = seg.start
+        bx, by = seg.end
+        for tx, ty in pad_positions:
+            _update(name, _point_to_segment_distance(tx, ty, ax, ay, bx, by))
+
+    for via in pcb.vias:
+        name = name_by_id.get(via.net_number)
+        if name not in strict_set:
+            continue
+        vx, vy = via.position
+        for tx, ty in pad_positions:
+            _update(name, math.hypot(vx - tx, vy - ty))
+
+    candidates = sorted(
+        (name for name, d in best_dist.items() if d <= radius_mm),
+        key=lambda n: best_dist[n],
+    )
+    return candidates[:max_blockers]
+
+
+def _iter_board_pads(pcb: PCB):
+    """Yield ``(net_number, (x, y), (w, h))`` for every real pad in board frame.
+
+    Mirrors the footprint->board transform used by
+    :class:`kicad_tools.analysis.net_status.NetStatusAnalyzer` (KiCad negates
+    the footprint orientation vs standard CCW math, issue #3739).
+    """
+    for fp in pcb.footprints:
+        if not fp.reference or fp.reference.startswith("#"):
+            continue
+        fp_x, fp_y = fp.position
+        angle = math.radians(-fp.rotation)
+        cos_a = math.cos(angle)
+        sin_a = math.sin(angle)
+        for pad in fp.pads:
+            px, py = pad.position
+            bx = fp_x + (px * cos_a - py * sin_a)
+            by = fp_y + (px * sin_a + py * cos_a)
+            yield pad.net_number, (bx, by), pad.size
+
+
+def _foreign_obstructions(
+    pcb: PCB,
+    target_net: int,
+    point: tuple[float, float],
+    radius_mm: float,
+) -> list[tuple[float, float, float]]:
+    """Foreign obstructions within *radius_mm* of *point*.
+
+    Returns a list of ``(x, y, dist)`` for foreign-net pad centres and foreign
+    copper segment closest-points near *point*.  Used both for escape-sector
+    analysis and for the local-congestion count.  "Foreign" == any net other
+    than *target_net* (net 0 / unassigned copper counts as an obstruction too,
+    since it still occupies the lane).
+    """
+    px, py = point
+    obstructions: list[tuple[float, float, float]] = []
+
+    for net_number, (bx, by), _size in _iter_board_pads(pcb):
+        if net_number == target_net:
+            continue
+        d = math.hypot(bx - px, by - py)
+        if d <= radius_mm:
+            obstructions.append((bx, by, d))
+
+    for seg in pcb.segments:
+        if seg.net_number == target_net:
+            continue
+        ax, ay = seg.start
+        ex, ey = seg.end
+        d = _point_to_segment_distance(px, py, ax, ay, ex, ey)
+        if d <= radius_mm:
+            # Use the segment midpoint direction for sector bucketing; distance
+            # is the true point-to-segment distance.
+            mx = (ax + ex) / 2.0
+            my = (ay + ey) / 2.0
+            obstructions.append((mx, my, d))
+
+    for via in pcb.vias:
+        if via.net_number == target_net:
+            continue
+        vx, vy = via.position
+        d = math.hypot(vx - px, vy - py)
+        if d <= radius_mm:
+            obstructions.append((vx, vy, d))
+
+    return obstructions
+
+
+def _widest_open_arc(
+    obstructions: list[tuple[float, float, float]],
+    point: tuple[float, float],
+    sectors: int,
+    escape_clearance_mm: float,
+) -> int:
+    """Width (in sectors) of the widest contiguous *open* escape arc.
+
+    Divides the directions around *point* into *sectors* angular buckets.  A
+    sector is "blocked" when a foreign obstruction sits within
+    *escape_clearance_mm* of the pad in that direction, "open" otherwise.  The
+    return value is the number of sectors in the widest contiguous run of open
+    sectors (wrapping around the full circle).  A small value means the pad is
+    walled in on (almost) all sides -> ESCAPE_BLOCKED; a large value means a
+    routing lane exists.
+    """
+    px, py = point
+    blocked = [False] * sectors
+    for ox, oy, d in obstructions:
+        if d > escape_clearance_mm:
+            continue
+        ang = math.atan2(oy - py, ox - px)
+        idx = int((ang + math.pi) / (2 * math.pi) * sectors) % sectors
+        blocked[idx] = True
+
+    if not any(blocked):
+        return sectors
+    if all(blocked):
+        return 0
+
+    # Widest run of False (open) sectors over the circular array.  Doubling the
+    # array handles the wrap-around in one linear pass.
+    best = run = 0
+    for is_blocked in blocked + blocked:
+        if is_blocked:
+            run = 0
+        else:
+            run += 1
+            best = max(best, run)
+    return min(best, sectors)
+
+
+def classify_stuck_nets_from_pcb(
+    pcb: PCB,
+    *,
+    blocker_radius_mm: float = DEFAULT_BLOCKER_RADIUS_MM,
+    escape_clearance_mm: float = DEFAULT_ESCAPE_CLEARANCE_MM,
+    neighborhood_radius_mm: float = DEFAULT_NEIGHBORHOOD_RADIUS_MM,
+    congestion_radius_mm: float = DEFAULT_CONGESTION_RADIUS_MM,
+    congestion_threshold: int = DEFAULT_CONGESTION_THRESHOLD,
+    dense_cluster_threshold: int = DEFAULT_DENSE_CLUSTER_THRESHOLD,
+    max_blockers: int = 3,
+    excluded_nets: frozenset[str] = frozenset(),
+) -> StuckClassifierResult:
+    """Classify every unfinished signal net on *pcb* (already-loaded PCB).
+
+    Split out from :func:`classify_stuck_nets` so it can be unit-tested with a
+    small synthetic board without round-tripping through a file.
+    """
+    from kicad_tools.analysis.net_status import NetStatusAnalyzer
+
+    analysis = NetStatusAnalyzer(pcb).analyze()
+
+    # Strict signal nets = fully-connected multi-pad signal nets.  This is the
+    # rip-up pool the M2 stage would draw from, and the set #3861's blocker
+    # finder ranks against.
+    strict_nets = [
+        n.net_name
+        for n in analysis.nets
+        if n.net_name not in excluded_nets
+        and n.net_type == "signal"
+        and n.total_pads >= 2
+        and n.status == "complete"
+    ]
+
+    # Map net name -> net number for richer output.
+    number_by_name = {net.name: nid for nid, net in pcb.nets.items() if net.name}
+
+    diagnoses: list[StuckNetDiagnosis] = []
+    for net in analysis.nets:
+        if net.net_name in excluded_nets:
+            continue
+        if net.net_type != "signal":
+            continue
+        if net.status != "incomplete":
+            continue
+        # Skip advisory (plane/pour) residuals -- not genuine signal gaps.
+        if net.is_advisory_incomplete:
+            continue
+
+        net_number = number_by_name.get(net.net_name, net.net_number)
+        pad_names = [p.full_name for p in net.unconnected_pads]
+        pad_points = [p.position for p in net.unconnected_pads]
+
+        # 1) Escape test: the NARROWEST widest-open-arc across the stranded
+        #    pads.  A pad walled in on all sides has a tiny open arc; a pad with
+        #    a routing lane has a wide one.
+        worst_open_arc = ESCAPE_SECTORS
+        for pt in pad_points:
+            obstr = _foreign_obstructions(pcb, net_number, pt, neighborhood_radius_mm)
+            arc = _widest_open_arc(obstr, pt, ESCAPE_SECTORS, escape_clearance_mm)
+            worst_open_arc = min(worst_open_arc, arc)
+
+        # 2) Blocking strict copper near the stranded pad(s) (#3861 geometry).
+        blockers = _find_blocking_strict_nets_from_pcb(
+            pcb,
+            net.net_name,
+            strict_nets,
+            radius_mm=blocker_radius_mm,
+            max_blockers=max_blockers,
+        )
+
+        # 3) Local congestion = densest foreign-obstruction count over the
+        #    stranded pads (wider radius than the escape ring).
+        local_congestion = 0
+        for pt in pad_points:
+            obstr = _foreign_obstructions(pcb, net_number, pt, congestion_radius_mm)
+            local_congestion = max(local_congestion, len(obstr))
+
+        # nearest blocker distance for evidence
+        nearest_blocker_mm = _nearest_blocker_distance(
+            pcb, net_number, pad_points, strict_nets, blocker_radius_mm
+        )
+
+        diag = _decide(
+            net_name=net.net_name,
+            net_number=net_number,
+            pad_names=pad_names,
+            blockers=blockers,
+            worst_open_arc=worst_open_arc,
+            local_congestion=local_congestion,
+            nearest_blocker_mm=nearest_blocker_mm,
+            congestion_threshold=congestion_threshold,
+            dense_cluster_threshold=dense_cluster_threshold,
+        )
+        diagnoses.append(diag)
+
+    return StuckClassifierResult(diagnoses=diagnoses)
+
+
+def _nearest_blocker_distance(
+    pcb: PCB,
+    target_net: int,
+    pad_points: list[tuple[float, float]],
+    strict_nets: list[str],
+    radius_mm: float,
+) -> float | None:
+    """Distance to the closest strict-net copper near any stranded pad.
+
+    Scans a slightly larger window than *radius_mm* (so PLACEMENT_BOUND can
+    report "blocker exists but too far to be the cause") and returns ``None``
+    when no strict copper is found in that window at all.
+    """
+    name_by_id = {nid: net.name for nid, net in pcb.nets.items() if net.name}
+    strict_set = set(strict_nets)
+    window = max(radius_mm * 3.0, 6.0)
+    best = math.inf
+    for seg in pcb.segments:
+        if name_by_id.get(seg.net_number) not in strict_set:
+            continue
+        ax, ay = seg.start
+        ex, ey = seg.end
+        for px, py in pad_points:
+            d = _point_to_segment_distance(px, py, ax, ay, ex, ey)
+            if d <= window and d < best:
+                best = d
+    return None if best is math.inf else best
+
+
+def _decide(
+    *,
+    net_name: str,
+    net_number: int,
+    pad_names: list[str],
+    blockers: list[str],
+    worst_open_arc: int,
+    local_congestion: int,
+    nearest_blocker_mm: float | None,
+    congestion_threshold: int,
+    dense_cluster_threshold: int,
+) -> StuckNetDiagnosis:
+    """Apply the decision tree to one net's diagnostics.
+
+    Decision order (each branch is mutually exclusive):
+
+    1. ESCAPE_BLOCKED -- the widest open arc around a stranded pad is narrower
+       than a trace can use (``worst_open_arc < ESCAPE_MIN_OPEN_SECTORS``).  The
+       pad cannot leave its footprint, so neither ripping copper (M2) nor moving
+       a *distant* part (M3) helps until the escape itself is upgraded (M4).
+       Checked first because an escape-blocked pad is upstream of everything.
+
+    2. PLACEMENT_BOUND (dense analog cluster) -- the pad escapes but the local
+       neighbourhood is *cluster-dense* (e.g. chorus U5 QFN / AUDIO_R): even
+       ripping the few adjacent strict nets cannot clear the wall of
+       surrounding non-strict copper, so a part must move.  Checked before the
+       blocker branch because such a net usually has a nominal strict blocker
+       too, yet ripping it cannot help.
+
+    3. CONGESTION_SATURATED -- the pad escapes AND committed strict copper is
+       adjacent (a blocker the M2 rip-up could try) AND the neighbourhood is not
+       cluster-dense.  This is the 1:1-trade class.
+
+    4. PLACEMENT_BOUND (no rippable copper) -- the pad escapes and there is no
+       adjacent rippable strict copper.  Nothing to rip, so only a placement
+       change can help.
+    """
+    open_deg = worst_open_arc * (360.0 / ESCAPE_SECTORS)
+
+    if worst_open_arc < ESCAPE_MIN_OPEN_SECTORS:
+        evidence = (
+            f"no escape lane: widest open arc only {open_deg:.0f} deg "
+            f"(pad walled in by foreign copper/pads on all sides)"
+        )
+        return StuckNetDiagnosis(
+            net_name=net_name,
+            net_number=net_number,
+            classification=StuckClass.ESCAPE_BLOCKED,
+            unconnected_pads=pad_names,
+            blocking_nets=blockers,
+            evidence=evidence,
+            escape_lane_deg=open_deg,
+            local_congestion=local_congestion,
+            nearest_blocker_mm=nearest_blocker_mm,
+        )
+
+    if local_congestion >= dense_cluster_threshold:
+        nb = (
+            f"nearest strict blocker {nearest_blocker_mm:.3f}mm"
+            if nearest_blocker_mm is not None
+            else "no strict copper nearby"
+        )
+        evidence = (
+            f"pad reachable ({open_deg:.0f} deg lane) but in a dense cluster "
+            f"({local_congestion} foreign obstructions, {nb}); ripping the few "
+            f"strict blockers cannot clear the surrounding copper -- a part "
+            f"must move (analog/codec cluster)"
+        )
+        return StuckNetDiagnosis(
+            net_name=net_name,
+            net_number=net_number,
+            classification=StuckClass.PLACEMENT_BOUND,
+            unconnected_pads=pad_names,
+            blocking_nets=blockers,
+            evidence=evidence,
+            escape_lane_deg=open_deg,
+            local_congestion=local_congestion,
+            nearest_blocker_mm=nearest_blocker_mm,
+        )
+
+    if blockers:
+        nb = f"{nearest_blocker_mm:.3f}mm" if nearest_blocker_mm is not None else "n/a"
+        evidence = (
+            f"pad reachable ({open_deg:.0f} deg lane) but boxed in by committed "
+            f"strict copper (nearest blocker {nb}); ripping it would strand "
+            f"{', '.join(blockers)} (1:1 trade)"
+        )
+        return StuckNetDiagnosis(
+            net_name=net_name,
+            net_number=net_number,
+            classification=StuckClass.CONGESTION_SATURATED,
+            unconnected_pads=pad_names,
+            blocking_nets=blockers,
+            evidence=evidence,
+            escape_lane_deg=open_deg,
+            local_congestion=local_congestion,
+            nearest_blocker_mm=nearest_blocker_mm,
+        )
+
+    nb = (
+        f"nearest strict copper {nearest_blocker_mm:.3f}mm away"
+        if nearest_blocker_mm is not None
+        else "no strict copper nearby"
+    )
+    dense = local_congestion >= congestion_threshold
+    density_note = (
+        f"dense local congestion ({local_congestion} foreign obstructions)"
+        if dense
+        else f"sparse neighbourhood ({local_congestion} foreign obstructions)"
+    )
+    evidence = (
+        f"pad reachable ({open_deg:.0f} deg lane), no adjacent rippable strict "
+        f"copper ({nb}); {density_note} -- ripping cannot help, a part must move"
+    )
+    return StuckNetDiagnosis(
+        net_name=net_name,
+        net_number=net_number,
+        classification=StuckClass.PLACEMENT_BOUND,
+        unconnected_pads=pad_names,
+        blocking_nets=[],
+        evidence=evidence,
+        escape_lane_deg=open_deg,
+        local_congestion=local_congestion,
+        nearest_blocker_mm=nearest_blocker_mm,
+    )
+
+
+def classify_stuck_nets(
+    pcb_path: str | Path,
+    *,
+    blocker_radius_mm: float = DEFAULT_BLOCKER_RADIUS_MM,
+    escape_clearance_mm: float = DEFAULT_ESCAPE_CLEARANCE_MM,
+    neighborhood_radius_mm: float = DEFAULT_NEIGHBORHOOD_RADIUS_MM,
+    congestion_radius_mm: float = DEFAULT_CONGESTION_RADIUS_MM,
+    congestion_threshold: int = DEFAULT_CONGESTION_THRESHOLD,
+    dense_cluster_threshold: int = DEFAULT_DENSE_CLUSTER_THRESHOLD,
+    max_blockers: int = 3,
+    excluded_nets: frozenset[str] = frozenset(),
+) -> StuckClassifierResult:
+    """Classify every unfinished signal net on the PCB at *pcb_path*.
+
+    READ-ONLY: loads the board, analyses connectivity + geometry, and returns
+    the per-net classification.  Never mutates the board.
+    """
+    from kicad_tools.schema.pcb import PCB
+
+    pcb = PCB.load(str(pcb_path))
+    return classify_stuck_nets_from_pcb(
+        pcb,
+        blocker_radius_mm=blocker_radius_mm,
+        escape_clearance_mm=escape_clearance_mm,
+        neighborhood_radius_mm=neighborhood_radius_mm,
+        congestion_radius_mm=congestion_radius_mm,
+        congestion_threshold=congestion_threshold,
+        dense_cluster_threshold=dense_cluster_threshold,
+        max_blockers=max_blockers,
+        excluded_nets=excluded_nets,
+    )

--- a/tests/router/test_stuck_classifier.py
+++ b/tests/router/test_stuck_classifier.py
@@ -1,0 +1,269 @@
+"""Unit tests for the stuck-net classifier (issue #3863, M1 of #3862).
+
+Each test builds a small synthetic ``.kicad_pcb`` that isolates ONE failure
+mode and asserts the classifier labels it correctly:
+
+* ESCAPE_BLOCKED      -- a stranded pad walled in by foreign copper on all sides
+* CONGESTION_SATURATED -- a reachable pad boxed in by committed strict-net copper
+* PLACEMENT_BOUND     -- a reachable pad with no rippable copper nearby
+
+The classifier is pure geometry, so these synthetic boards exercise the real
+decision tree without needing the router.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.router.stuck_classifier import (
+    StuckClass,
+    classify_stuck_nets,
+)
+
+# ---------------------------------------------------------------------------
+# Synthetic boards
+# ---------------------------------------------------------------------------
+
+_HEADER = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+"""
+
+
+def _ring_pads(cx: float, cy: float, radius: float, net: int, name: str) -> str:
+    """16 foreign pads in a tight ring around (cx, cy) -- a wall with no lane."""
+    import math
+
+    out = []
+    for i in range(16):
+        ang = 2 * math.pi * i / 16
+        px = cx + radius * math.cos(ang)
+        py = cy + radius * math.sin(ang)
+        out.append(
+            f'  (footprint "wall{i}" (layer "F.Cu") (at {px:.4f} {py:.4f})\n'
+            f'    (property "Reference" "W{i}")\n'
+            f'    (pad "1" smd circle (at 0 0) (size 0.1 0.1) '
+            f'(layers "F.Cu") (net {net} "{name}"))\n'
+            f"  )\n"
+        )
+    return "".join(out)
+
+
+# --- ESCAPE_BLOCKED ---------------------------------------------------------
+# Net TGT has a connected island (R1.1 <-> R1.2 routed) plus a STRANDED pad
+# (U1.1) at (50, 50) that is surrounded on all sides by a tight ring of foreign
+# pads (net WALL) at 0.15mm -- no open escape lane.
+
+
+def _escape_blocked_board() -> str:
+    body = (
+        _HEADER
+        + (
+            '  (net 0 "")\n'
+            '  (net 1 "TGT")\n'
+            '  (net 2 "WALL")\n'
+            # connected island for TGT so the net is "incomplete", not "unrouted"
+            '  (footprint "R_0402" (layer "F.Cu") (at 10 10)\n'
+            '    (property "Reference" "R1")\n'
+            '    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "TGT"))\n'
+            '    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "TGT"))\n'
+            "  )\n"
+            # the stranded TGT pad, far from the island and walled in
+            '  (footprint "U_QFN" (layer "F.Cu") (at 50 50)\n'
+            '    (property "Reference" "U1")\n'
+            '    (pad "1" smd circle (at 0 0) (size 0.1 0.1) (layers "F.Cu") (net 1 "TGT"))\n'
+            "  )\n"
+            + _ring_pads(50, 50, 0.15, 2, "WALL")
+            # route the island so R1.1-R1.2 are connected (=> 1 stranded pad U1.1)
+            + '  (segment (start 9.5 10) (end 10.5 10) (width 0.25) (layer "F.Cu") (net 1))\n'
+            ")\n"
+        )
+    )
+    return body
+
+
+# --- CONGESTION_SATURATED ---------------------------------------------------
+# Net TGT has a connected island and one stranded pad (U1.1) with an OPEN escape
+# lane (no surrounding wall), but a fully-connected STRICT net (BLK) runs its
+# committed copper ~0.2mm from the stranded pad -- a rippable blocker.
+
+
+def _congestion_saturated_board() -> str:
+    body = (
+        _HEADER
+        + (
+            '  (net 0 "")\n'
+            '  (net 1 "TGT")\n'
+            '  (net 2 "BLK")\n'
+            # TGT island
+            '  (footprint "R_0402" (layer "F.Cu") (at 10 10)\n'
+            '    (property "Reference" "R1")\n'
+            '    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "TGT"))\n'
+            '    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "TGT"))\n'
+            "  )\n"
+            # stranded TGT pad with an open lane (nothing within escape clearance)
+            '  (footprint "U_SOT" (layer "F.Cu") (at 50 50)\n'
+            '    (property "Reference" "U1")\n'
+            '    (pad "1" smd circle (at 0 0) (size 0.2 0.2) (layers "F.Cu") (net 1 "TGT"))\n'
+            "  )\n"
+            # BLK is a complete 2-pad signal net (strict) whose copper passes 0.2mm
+            # from the stranded TGT pad at (50,50): segment y=50.2.
+            '  (footprint "R_0402" (layer "F.Cu") (at 48 50.2)\n'
+            '    (property "Reference" "R2")\n'
+            '    (pad "1" smd rect (at 0 0) (size 0.3 0.3) (layers "F.Cu") (net 2 "BLK"))\n'
+            "  )\n"
+            '  (footprint "R_0402" (layer "F.Cu") (at 52 50.2)\n'
+            '    (property "Reference" "R3")\n'
+            '    (pad "1" smd rect (at 0 0) (size 0.3 0.3) (layers "F.Cu") (net 2 "BLK"))\n'
+            "  )\n"
+            # route TGT island and the full BLK net
+            + '  (segment (start 9.5 10) (end 10.5 10) (width 0.25) (layer "F.Cu") (net 1))\n'
+            + '  (segment (start 48 50.2) (end 52 50.2) (width 0.25) (layer "F.Cu") (net 2))\n'
+            ")\n"
+        )
+    )
+    return body
+
+
+# --- PLACEMENT_BOUND --------------------------------------------------------
+# Net TGT has a connected island and one stranded pad (U1.1) far out in open
+# space: open escape lane, NO strict copper anywhere near, sparse neighbourhood.
+
+
+def _placement_bound_board() -> str:
+    body = _HEADER + (
+        '  (net 0 "")\n'
+        '  (net 1 "TGT")\n'
+        # TGT island
+        '  (footprint "R_0402" (layer "F.Cu") (at 10 10)\n'
+        '    (property "Reference" "R1")\n'
+        '    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "TGT"))\n'
+        '    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "TGT"))\n'
+        "  )\n"
+        # stranded TGT pad alone in open space
+        '  (footprint "U_SOT" (layer "F.Cu") (at 80 80)\n'
+        '    (property "Reference" "U1")\n'
+        '    (pad "1" smd circle (at 0 0) (size 0.2 0.2) (layers "F.Cu") (net 1 "TGT"))\n'
+        "  )\n" + '  (segment (start 9.5 10) (end 10.5 10) (width 0.25) (layer "F.Cu") (net 1))\n'
+        ")\n"
+    )
+    return body
+
+
+@pytest.fixture
+def escape_blocked_pcb(tmp_path: Path) -> Path:
+    p = tmp_path / "escape.kicad_pcb"
+    p.write_text(_escape_blocked_board())
+    return p
+
+
+@pytest.fixture
+def congestion_pcb(tmp_path: Path) -> Path:
+    p = tmp_path / "congestion.kicad_pcb"
+    p.write_text(_congestion_saturated_board())
+    return p
+
+
+@pytest.fixture
+def placement_pcb(tmp_path: Path) -> Path:
+    p = tmp_path / "placement.kicad_pcb"
+    p.write_text(_placement_bound_board())
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestEscapeBlocked:
+    def test_stranded_pad_walled_in_is_escape_blocked(self, escape_blocked_pcb: Path):
+        result = classify_stuck_nets(escape_blocked_pcb)
+        tgt = [d for d in result.diagnoses if d.net_name == "TGT"]
+        assert len(tgt) == 1
+        d = tgt[0]
+        assert d.classification is StuckClass.ESCAPE_BLOCKED
+        assert "U1.1" in d.unconnected_pads
+        # the open arc must be below the escape threshold
+        assert d.escape_lane_deg < 45.0
+        assert "no escape lane" in d.evidence
+
+
+class TestCongestionSaturated:
+    def test_reachable_pad_boxed_by_strict_copper(self, congestion_pcb: Path):
+        result = classify_stuck_nets(congestion_pcb)
+        tgt = [d for d in result.diagnoses if d.net_name == "TGT"]
+        assert len(tgt) == 1
+        d = tgt[0]
+        assert d.classification is StuckClass.CONGESTION_SATURATED
+        assert "BLK" in d.blocking_nets
+        assert d.nearest_blocker_mm is not None
+        assert d.nearest_blocker_mm < 0.5
+        assert "1:1 trade" in d.evidence
+
+
+class TestPlacementBound:
+    def test_reachable_pad_no_rippable_copper(self, placement_pcb: Path):
+        result = classify_stuck_nets(placement_pcb)
+        tgt = [d for d in result.diagnoses if d.net_name == "TGT"]
+        assert len(tgt) == 1
+        d = tgt[0]
+        assert d.classification is StuckClass.PLACEMENT_BOUND
+        assert d.blocking_nets == []
+        assert "a part must move" in d.evidence
+
+
+class TestClassifierAggregate:
+    def test_counts_and_to_dict(self, congestion_pcb: Path):
+        result = classify_stuck_nets(congestion_pcb)
+        counts = result.counts
+        assert set(counts) == {
+            "escape_blocked",
+            "congestion_saturated",
+            "placement_bound",
+        }
+        assert counts["congestion_saturated"] == 1
+        data = result.to_dict()
+        assert data["summary"]["stuck_nets"] == 1
+        net = data["nets"][0]
+        assert net["classification"] == "congestion_saturated"
+        # failure_cause maps onto the shared FailureCause enum
+        assert net["failure_cause"] == "congestion"
+
+    def test_no_stuck_nets_on_complete_board(self, tmp_path: Path):
+        # A fully-routed 2-pad net -> no incomplete signal nets.
+        pcb = tmp_path / "done.kicad_pcb"
+        pcb.write_text(
+            _HEADER
+            + (
+                '  (net 0 "")\n'
+                '  (net 1 "DONE")\n'
+                '  (footprint "R_0402" (layer "F.Cu") (at 10 10)\n'
+                '    (property "Reference" "R1")\n'
+                '    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "DONE"))\n'
+                "  )\n"
+                '  (footprint "R_0402" (layer "F.Cu") (at 20 10)\n'
+                '    (property "Reference" "R2")\n'
+                '    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "DONE"))\n'
+                "  )\n"
+                + '  (segment (start 9.5 10) (end 19.5 10) (width 0.25) (layer "F.Cu") (net 1))\n'
+                ")\n"
+            )
+        )
+        result = classify_stuck_nets(pcb)
+        assert result.diagnoses == []
+
+
+class TestReadOnly:
+    def test_classifier_does_not_mutate_board(self, congestion_pcb: Path):
+        before = congestion_pcb.read_bytes()
+        classify_stuck_nets(congestion_pcb)
+        after = congestion_pcb.read_bytes()
+        assert before == after


### PR DESCRIPTION
## Summary

Milestone 1 of the architect roadmap (#3862): a **read-only** diagnostic
that labels every unfinished signal net by *why* it is stuck, turning the
manual hours-long analysis into a tool and providing the targeting
substrate for the (routing-mutating) milestones M2-M4.

Three architecturally-distinct failure modes are classified:

- **ESCAPE_BLOCKED** -- a stranded pad has no open escape lane (foreign
  copper/pads wall it in on all sides). Fix: escape upgrade (M4).
- **CONGESTION_SATURATED** -- a reachable pad boxed in by committed
  *strict* (fully-connected) signal-net copper; completing it strands the
  blocker (the 1:1-trade local minimum confirmed on chorus #3861). Fix:
  region rip-up-and-reroute (M2).
- **PLACEMENT_BOUND** -- a reachable pad with no rippable strict copper
  nearby, or sitting in a dense analog/codec cluster where ripping the few
  adjacent strict nets cannot clear the surrounding copper. Fix: placement
  nudge (M3).

It is pure geometry over the PCB schema -- **no routing grid is built and
no routing is mutated**, so it is zero-regression by construction and cheap
enough to run on any board as a routing-report feature.

## Changes

- `src/kicad_tools/router/stuck_classifier.py` (new): `classify_stuck_nets`
  / `classify_stuck_nets_from_pcb`, `StuckClass` (mapped onto the existing
  `FailureCause` enum), `StuckNetDiagnosis`, `StuckClassifierResult`.
  Vendors the frame-correct blocker geometry from #3861
  (`_find_blocking_strict_nets_from_pcb` / `_point_to_segment_distance`) so
  the classifier is self-contained and carries no dependency on
  routing-mutation code. The page-space-vs-board-space frame fix is
  load-bearing: both pad positions and committed copper are read through
  `PCB` so they share the board frame.
- `kct net-status --why` flag (`cli/parser.py`, `cli/__init__.py`,
  `cli/net_status_cmd.py`): prints per-incomplete-net classification +
  evidence, in text or `--format json`.
- `tests/router/test_stuck_classifier.py` (new): one synthetic board per
  class (clearly escape-blocked, congestion-boxed, placement-bound), plus
  aggregate/JSON, no-stuck-nets, and read-only (board-unchanged) tests.

## Chorus validation (20 partials)

Run on the routed chorus board (`/tmp/chorus/chorus_routed.kicad_pcb`,
31/51 strict, 20 partial):

| Classification | Count | Nets |
|---|---|---|
| CONGESTION_SATURATED | 5 | SWCLK, Net-(U5-VNEG), BOOT0, SYNC_R, NRST |
| PLACEMENT_BOUND (dense codec/analog cluster) | 9 | SDA, SCL, Net-(U5-VCOM/DEMP), Net-(LED4-A), DAC_FLT, I2S_DIN, **AUDIO_R**, I2S_LRCLK, Net-(LED3-A) |
| PLACEMENT_BOUND (no rippable copper / connector) | 6 | LATCH, SPI_MISO, SPI_MOSI, SPI_SCK, UART_TX, Net-(LED4-K) |
| ESCAPE_BLOCKED | 0 | -- |

This matches the **decisive evidence** in #3862: AUDIO_R / U5 codec
cluster -> PLACEMENT_BOUND, and LATCH / SPI_MOSI / UART -> PLACEMENT_BOUND.
The congestion counts split cleanly into two populations (codec cluster at
29-118 foreign obstructions vs. genuinely copper-boxed nets at 2-15), so the
dense-cluster threshold lands in the natural gap.

Note on ESCAPE_BLOCKED=0: on *this* routed output the J2 connector is a
2.54mm-pitch header whose stuck nets already have their escape stubs routed
(0 foreign obstructions around the J2 pads) -- they are genuinely
placement-bound (their J4 partner is far), not escape-blocked. The
escape-blocked detector is exercised by a dedicated synthetic fine-pitch
unit test.

## Acceptance Criteria Verification

| Criterion (from #3863 / #3862) | Status | Verification |
|---|---|---|
| Classify each unfinished net ESCAPE_BLOCKED / CONGESTION_SATURATED / PLACEMENT_BOUND | done | `classify_stuck_nets`; 3 synthetic unit tests pass |
| Reuse FailureCause enum | done | `StuckClass.failure_cause` maps onto `FailureCause` (PIN_ACCESS / CONGESTION / ROUTING_ORDER) |
| Reuse #3861 frame-correct blocker geometry | done | vendored `_find_blocking_strict_nets_from_pcb` / `_point_to_segment_distance`, board-frame reads |
| Read-only, zero regression | done | no grid/no mutation; `TestReadOnly` asserts board bytes unchanged |
| Expose via `kct net-status --why` | done | text + JSON output; manual run on chorus |
| Validate chorus 20 partials classify sensibly | done | table above; AUDIO_R/U5/SPI/UART placement-bound per #3862 evidence |
| Unit tests per classification | done | `tests/router/test_stuck_classifier.py` (6 tests, all pass) |

## Test Plan

- `uv run pytest tests/router/test_stuck_classifier.py tests/test_net_status_cmd.py` -> 24 passed
- `uv run ruff check .` -> all checks passed; `ruff format --check` clean on touched files (ruff 0.14.10)
- `uv run python -m mypy src/kicad_tools/router/stuck_classifier.py` -> Success, no issues
- `uv run kct net-status /tmp/chorus/chorus_routed.kicad_pcb --why` (and `--format json`) -> table above

Closes #3863