### PR TITLE
ci(chorus): M2/M3 flag-matrix measurement harness

### DIFF
--- a/.github/workflows/chorus-flag-matrix.yml
+++ b/.github/workflows/chorus-flag-matrix.yml
@@ -1,0 +1,185 @@
+name: Chorus M2/M3 flag matrix (measurement)
+
+# Issue #3873 (MEASUREMENT-INFRASTRUCTURE): measure the chorus-test-revA
+# strict signal-net count under the M2 (joint region re-solve) and M3
+# (placement nudge) flags on CI-parity hardware.
+#
+# This is the measurement HARNESS, not a gate.  The dense-board unblock
+# stack (M2 #3871, M3 #3872) is merged but its END-TO-END chorus
+# strict-count gain is UNMEASURED -- the dev machine that built it was
+# too throttled (load avg ~30; C++ router fell back to Python A*) to
+# produce a stable baseline.  This workflow runs route_chorus.py on
+# adequate Linux runners under four flag variants, in PARALLEL matrix
+# legs so each leg fits the per-job timeout, then collects the four
+# strict counts into a comparison table on the Step Summary.
+#
+# What it does NOT do (deliberately, per #3873 scope):
+#   * It is NOT a required per-PR gate -- a single chorus route is a
+#     long (tens of minutes) job; this runs on demand / on a schedule.
+#   * It does NOT tighten tests/test_chorus_reach_floor_3237.py or change
+#     route_chorus.py defaults -- those are follow-ups that depend on
+#     SEEING these measured numbers first.
+#
+# The four variants (route_chorus.py main pass + completion passes +
+# optional M3 nudge, PYTHONHASHSEED=0, seed 42):
+#   baseline : no flags
+#   m2       : --joint-region-resolve            (KCT_JOINT_REGION_RESOLVE=1)
+#   m3       : --placement-nudge
+#   m2m3     : --joint-region-resolve --placement-nudge
+#
+# Requires the private chorus fixture: set the CHORUS_TEST_GIT_URL /
+# CHORUS_TEST_GIT_REF repo secrets so scripts/ci/fetch_chorus_test.py can
+# clone it.  When unset every leg skips gracefully (no red workflow).
+
+on:
+  workflow_dispatch:
+    inputs:
+      seed:
+        description: "Router seed passed to route_chorus.py (default 42)."
+        required: false
+        default: "42"
+  schedule:
+    # Monthly: 1st of the month, 05:00 UTC.  Four ~tens-of-minutes legs
+    # in parallel is expensive; a manual dispatch is the primary path and
+    # the schedule is just a slow-drip regression tripwire.
+    - cron: "0 5 1 * *"
+
+permissions:
+  contents: read
+
+jobs:
+  measure:
+    name: chorus ${{ matrix.variant }}
+    runs-on: ubuntu-latest
+    # route_chorus does a long main pass (1200s budget) plus up to three
+    # completion passes plus (for m3/m2m3) a placement-nudge re-route, all
+    # gated by the per-net timeout.  150 min leaves generous headroom over
+    # the observed worst case without being unbounded.
+    timeout-minutes: 150
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: baseline
+            flags: ""
+            joint_region_resolve: "0"
+          - variant: m2
+            flags: "--joint-region-resolve"
+            joint_region_resolve: "1"
+          - variant: m3
+            flags: "--placement-nudge"
+            joint_region_resolve: "0"
+          - variant: m2m3
+            flags: "--joint-region-resolve --placement-nudge"
+            joint_region_resolve: "1"
+    env:
+      CHORUS_TEST_GIT_URL: ${{ secrets.CHORUS_TEST_GIT_URL }}
+      CHORUS_TEST_GIT_REF: ${{ secrets.CHORUS_TEST_GIT_REF }}
+      PYTHONHASHSEED: "0"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Build C++ router backend
+        # The native A* backend is 10-100x faster than the Python
+        # fallback.  Without it the chorus route starves and the
+        # measurement is meaningless (the exact failure mode that left
+        # the gain unmeasured on the dev machine -- see #3873).
+        run: |
+          uv run kct build-native
+          uv run kct build-native --check
+
+      - name: Fetch chorus-test-revA fixture
+        run: uv run python scripts/ci/fetch_chorus_test.py
+
+      - name: Confirm fixture availability
+        id: fixture
+        run: |
+          PCB=boards/external/chorus-test-revA/kicad/chorus-test-revA_v21_stripped.kicad_pcb
+          if [ -f "$PCB" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+            echo "pcb=$PCB" >> "$GITHUB_OUTPUT"
+            echo "::notice::chorus fixture present, running ${{ matrix.variant }} leg"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::chorus fixture not available -- skipping ${{ matrix.variant }}.  Configure CHORUS_TEST_GIT_URL/CHORUS_TEST_GIT_REF secrets to enable."
+          fi
+
+      - name: Route chorus (${{ matrix.variant }})
+        if: steps.fixture.outputs.present == 'true'
+        run: |
+          mkdir -p chorus-results
+          set -o pipefail
+          uv run python scripts/route_chorus.py \
+            --pcb "${{ steps.fixture.outputs.pcb }}" \
+            --output "/tmp/chorus_routed_${{ matrix.variant }}.kicad_pcb" \
+            --seed "${{ github.event.inputs.seed || '42' }}" \
+            ${{ matrix.flags }} \
+            2>&1 | tee "chorus-results/route_${{ matrix.variant }}.log" || true
+
+      - name: Parse strict-count result
+        if: steps.fixture.outputs.present == 'true'
+        run: |
+          uv run python scripts/ci/parse_chorus_result.py \
+            --variant "${{ matrix.variant }}" \
+            --log "chorus-results/route_${{ matrix.variant }}.log" \
+            --output "chorus-results/result_${{ matrix.variant }}.json"
+
+      - name: Leg summary
+        if: always() && steps.fixture.outputs.present == 'true'
+        run: |
+          {
+            echo "## chorus leg: ${{ matrix.variant }}"
+            echo ""
+            echo "Flags: \`${{ matrix.flags }}\` (KCT_JOINT_REGION_RESOLVE=${{ matrix.joint_region_resolve }})"
+            echo ""
+            if [ -f "chorus-results/result_${{ matrix.variant }}.json" ]; then
+              echo '```json'
+              cat "chorus-results/result_${{ matrix.variant }}.json"
+              echo '```'
+            else
+              echo "_No parsed result -- route_chorus.py did not emit a final report (see log artifact)._"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload leg artifacts
+        if: always() && steps.fixture.outputs.present == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: chorus-${{ matrix.variant }}-${{ github.run_id }}
+          path: |
+            chorus-results/route_${{ matrix.variant }}.log
+            chorus-results/result_${{ matrix.variant }}.json
+          retention-days: 30
+
+  summarize:
+    name: chorus comparison table
+    needs: measure
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Download all leg artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: chorus-artifacts
+          pattern: chorus-*-${{ github.run_id }}
+          merge-multiple: true
+
+      - name: Build comparison table
+        run: |
+          uv run python scripts/ci/summarize_chorus_matrix.py \
+            --results-dir chorus-artifacts \
+            >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/ci/parse_chorus_result.py
+++ b/scripts/ci/parse_chorus_result.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Parse the chorus strict/partial/unrouted/DRC counts from a route_chorus.py log.
+
+Issue #3873 (MEASUREMENT-INFRASTRUCTURE): the chorus M2/M3 measurement
+workflow (``.github/workflows/chorus-flag-matrix.yml``) runs
+``scripts/route_chorus.py`` under four flag variants on CI-parity
+hardware and needs to extract the headline connectivity numbers from
+each leg's captured stdout so the summary job can print a comparison
+table.
+
+``route_chorus.py`` ends each run with a "Final chorus report" block::
+
+    ============================================================
+    Final chorus report
+    ============================================================
+      Partially-routed signal nets: 20
+        - SPI_SCK
+        - ...
+      Unrouted signal nets: 0
+      Non-connectivity DRC errors: 7
+
+      Routed board: /tmp/chorus_routed_r2.kicad_pcb
+      Manufacturable bar: unfinished=20, blocking DRC=7 (target 0/0)
+
+The chorus v21 fixture has a fixed total of 51 multi-pad signal nets
+(``CHORUS_V21_NETS_TOTAL`` in ``tests/test_chorus_reach_floor_3237.py``),
+so the **strict** (fully-routed) count is::
+
+    strict = total - partial - unrouted
+
+This helper is deliberately tiny and pure (no I/O beyond an optional CLI
+front-end) so it can be unit-tested locally against a captured sample
+log -- the routing itself is only exercisable on CI-parity hardware with
+the private chorus fixture staged.
+
+Usage (CLI, used by the workflow)::
+
+    python scripts/ci/parse_chorus_result.py \\
+        --variant m2 --log route_m2.log --output result_m2.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+#: Total multi-pad signal nets in the chorus-test-revA_v21_stripped
+#: fixture.  Mirrors ``CHORUS_V21_NETS_TOTAL`` in
+#: ``tests/test_chorus_reach_floor_3237.py``.  Strict reach is the
+#: complement of the partial+unrouted count against this total.
+CHORUS_V21_NETS_TOTAL = 51
+
+_PARTIAL_RE = re.compile(r"^\s*Partially-routed signal nets:\s*(\d+)\s*$", re.MULTILINE)
+_UNROUTED_RE = re.compile(r"^\s*Unrouted signal nets:\s*(\d+)\s*$", re.MULTILINE)
+_DRC_RE = re.compile(r"^\s*Non-connectivity DRC errors:\s*(\d+)\s*$", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class ChorusResult:
+    """Headline connectivity numbers extracted from a route_chorus log."""
+
+    variant: str
+    total: int
+    partial: int
+    unrouted: int
+    strict: int
+    drc_errors: int
+
+    def as_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def _find_last_int(pattern: re.Pattern[str], text: str, label: str) -> int:
+    """Return the integer from the LAST match of ``pattern`` in ``text``.
+
+    route_chorus.py can print the per-class report more than once across
+    its stages; the authoritative "Final chorus report" is the last one,
+    so we always take the final match.
+    """
+    matches = pattern.findall(text)
+    if not matches:
+        raise ValueError(
+            f"could not find {label!r} count in route_chorus.py log (pattern: {pattern.pattern!r})"
+        )
+    return int(matches[-1])
+
+
+def parse_chorus_log(
+    log_text: str,
+    *,
+    variant: str = "",
+    total: int = CHORUS_V21_NETS_TOTAL,
+) -> ChorusResult:
+    """Extract strict/partial/unrouted/DRC counts from a route_chorus log.
+
+    Parameters
+    ----------
+    log_text:
+        The full captured stdout of a ``scripts/route_chorus.py`` run.
+    variant:
+        Free-form label for the flag variant (e.g. ``"baseline"``,
+        ``"m2"``, ``"m3"``, ``"m2m3"``); echoed into the result.
+    total:
+        Total multi-pad signal nets on the board.  Defaults to the
+        chorus v21 fixture's ``CHORUS_V21_NETS_TOTAL``.
+
+    Returns
+    -------
+    ChorusResult
+        ``strict = total - partial - unrouted``.
+
+    Raises
+    ------
+    ValueError
+        If any of the three report lines is absent (a routing run that
+        crashed before printing its final report).
+    """
+    partial = _find_last_int(_PARTIAL_RE, log_text, "Partially-routed signal nets")
+    unrouted = _find_last_int(_UNROUTED_RE, log_text, "Unrouted signal nets")
+    drc_errors = _find_last_int(_DRC_RE, log_text, "Non-connectivity DRC errors")
+    strict = total - partial - unrouted
+    return ChorusResult(
+        variant=variant,
+        total=total,
+        partial=partial,
+        unrouted=unrouted,
+        strict=strict,
+        drc_errors=drc_errors,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--variant",
+        default="",
+        help="Flag-variant label echoed into the JSON (baseline/m2/m3/m2m3).",
+    )
+    parser.add_argument(
+        "--log",
+        type=Path,
+        required=True,
+        help="Path to the captured route_chorus.py stdout log.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Write the parsed result as JSON to this path (also prints to stdout).",
+    )
+    parser.add_argument(
+        "--total",
+        type=int,
+        default=CHORUS_V21_NETS_TOTAL,
+        help=f"Total signal nets (default {CHORUS_V21_NETS_TOTAL}).",
+    )
+    args = parser.parse_args(argv)
+
+    log_text = args.log.read_text(encoding="utf-8", errors="replace")
+    result = parse_chorus_log(log_text, variant=args.variant, total=args.total)
+    payload = json.dumps(result.as_dict(), indent=2)
+    if args.output is not None:
+        args.output.write_text(payload + "\n", encoding="utf-8")
+    print(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/summarize_chorus_matrix.py
+++ b/scripts/ci/summarize_chorus_matrix.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Render the chorus M2/M3 flag-matrix comparison table (issue #3873).
+
+The summary job of ``.github/workflows/chorus-flag-matrix.yml`` collects
+the four per-leg ``result_<variant>.json`` files written by
+``scripts/ci/parse_chorus_result.py`` and renders a single Markdown
+comparison table (baseline vs m2 vs m3 vs m2m3, with strict-count deltas
+relative to baseline) to the workflow Step Summary, so the headline
+result is visible without digging through individual leg logs.
+
+The table is the deliverable of the measurement harness: the whole point
+of #3873 is to read, in one place, "did M2/M3 actually move the chorus
+strict count, and by how much" on hardware that the dev machine could not
+provide.
+
+Usage::
+
+    python scripts/ci/summarize_chorus_matrix.py --results-dir chorus-artifacts
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+#: Canonical leg order for the table (baseline first so deltas read left
+#: to right against it).
+VARIANT_ORDER = ("baseline", "m2", "m3", "m2m3")
+
+#: Human-readable flag description per variant, for the table.
+VARIANT_FLAGS = {
+    "baseline": "(none)",
+    "m2": "--joint-region-resolve",
+    "m3": "--placement-nudge",
+    "m2m3": "--joint-region-resolve --placement-nudge",
+}
+
+
+def load_results(results_dir: Path) -> dict[str, dict[str, object]]:
+    """Load every ``result_*.json`` under ``results_dir`` keyed by variant."""
+    results: dict[str, dict[str, object]] = {}
+    for path in sorted(results_dir.rglob("result_*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        variant = str(data.get("variant") or path.stem.removeprefix("result_"))
+        results[variant] = data
+    return results
+
+
+def _delta_str(value: int | None, baseline: int | None) -> str:
+    """Signed delta of ``value`` vs ``baseline`` strict count, or ``n/a``."""
+    if value is None or baseline is None:
+        return "n/a"
+    delta = value - baseline
+    return f"+{delta}" if delta > 0 else str(delta)
+
+
+def render_table(results: dict[str, dict[str, object]]) -> str:
+    """Render the Markdown comparison table from loaded per-leg results."""
+    lines: list[str] = []
+    lines.append("## Chorus M2/M3 flag-matrix results")
+    lines.append("")
+    lines.append(
+        "Strict = fully-routed signal nets out of the chorus v21 total "
+        "(51).  Delta is vs the baseline leg."
+    )
+    lines.append("")
+
+    if not results:
+        lines.append(
+            "_No leg results found.  Either the chorus fixture was absent "
+            "(no CHORUS_TEST_GIT_URL secret) so every leg skipped, or no "
+            "leg emitted a parseable final report.  See the per-leg logs._"
+        )
+        return "\n".join(lines) + "\n"
+
+    baseline = results.get("baseline")
+    baseline_strict: int | None = None
+    if baseline is not None:
+        baseline_value = baseline.get("strict")
+        if isinstance(baseline_value, int):
+            baseline_strict = baseline_value
+
+    lines.append("| variant | flags | strict | delta | partial | unrouted | DRC errors |")
+    lines.append("|---|---|---:|---:|---:|---:|---:|")
+
+    # Stable, known order first; then any unexpected extra variants.
+    ordered = [v for v in VARIANT_ORDER if v in results]
+    ordered += [v for v in results if v not in VARIANT_ORDER]
+
+    for variant in ordered:
+        data = results[variant]
+        strict = data.get("strict")
+        strict_int = int(strict) if isinstance(strict, int) else None
+        flags = VARIANT_FLAGS.get(variant, "(unknown)")
+        delta = _delta_str(strict_int, baseline_strict) if variant != "baseline" else "-"
+        lines.append(
+            f"| {variant} "
+            f"| `{flags}` "
+            f"| {data.get('strict', '?')} "
+            f"| {delta} "
+            f"| {data.get('partial', '?')} "
+            f"| {data.get('unrouted', '?')} "
+            f"| {data.get('drc_errors', '?')} |"
+        )
+
+    lines.append("")
+    lines.append(
+        "_This is the measurement harness output (issue #3873).  "
+        "Tightening tests/test_chorus_reach_floor_3237.py or changing "
+        "route_chorus.py defaults are follow-ups gated on these numbers._"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--results-dir",
+        type=Path,
+        required=True,
+        help="Directory containing the per-leg result_<variant>.json files.",
+    )
+    args = parser.parse_args(argv)
+    results = load_results(args.results_dir)
+    sys.stdout.write(render_table(results))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_ci_parse_chorus_result.py
+++ b/tests/test_ci_parse_chorus_result.py
@@ -1,0 +1,169 @@
+"""Tests for the chorus strict-count log parser (issue #3873).
+
+``scripts/ci/parse_chorus_result.py`` extracts the headline connectivity
+numbers (strict / partial / unrouted / non-connectivity DRC) from the
+"Final chorus report" block printed by ``scripts/route_chorus.py``.  The
+chorus M2/M3 measurement workflow runs route_chorus under four flag
+variants and feeds each leg's captured stdout to this parser so the
+summary job can print a baseline-vs-m2-vs-m3-vs-m2m3 comparison table.
+
+The routing itself is only exercisable on CI-parity hardware with the
+private chorus fixture staged; this parser is the locally-testable piece,
+validated here against a realistic captured log sample.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HELPER_SCRIPT_PATH = REPO_ROOT / "scripts" / "ci" / "parse_chorus_result.py"
+
+
+def _load_helper_module():
+    """Import ``scripts/ci/parse_chorus_result.py`` as a module."""
+    spec = importlib.util.spec_from_file_location("parse_chorus_result", HELPER_SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["parse_chorus_result"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+parse_chorus_result = _load_helper_module()
+
+
+# A realistic capture of the tail of a route_chorus.py run.  The leading
+# noise (main-pass + completion-pass chatter) is intentionally present so
+# the test proves the parser tolerates arbitrary preceding output and
+# pins on the "Final chorus report" lines.  Numbers chosen so that
+# strict = 51 - 20 - 0 = 31 (the documented chorus baseline).
+SAMPLE_LOG_BASELINE = """\
+Main pass: /usr/bin/python -m kicad_tools.cli route ...
+[route] detailed routing reached 51/51 nets
+Completion pass 1/3: 20 unfinished nets ...
+Completion pass 2/3: 20 unfinished nets ...
+
+Pruned 12 stranded copper block(s) from 20 unfinished net(s) (issue #3470 stub hygiene)
+
+============================================================
+Final chorus report
+============================================================
+  Partially-routed signal nets: 20
+    - SPI_SCK
+    - SPI_MOSI
+    - I2C_SDA
+  Unrouted signal nets: 0
+  Non-connectivity DRC errors: 7
+
+  Routed board: /tmp/chorus_routed_r2.kicad_pcb
+  Manufacturable bar: unfinished=20, blocking DRC=7 (target 0/0)
+"""
+
+# A variant where some nets are fully unrouted as well as partial.
+# strict = 51 - 7 - 4 = 40.
+SAMPLE_LOG_M2M3 = """\
+Joint region re-solve ENABLED (KCT_JOINT_REGION_RESOLVE=1)
+Main pass: ...
+
+Placement nudge ENABLED (issue #3865, M3)
+nudged 3 part(s); accepted (+5 strict)
+
+============================================================
+Final chorus report
+============================================================
+  Partially-routed signal nets: 7
+    - CLK_A
+  Unrouted signal nets: 4
+    - AUX_1
+    - AUX_2
+  Non-connectivity DRC errors: 2
+
+  Routed board: /tmp/chorus_routed_r2.kicad_pcb
+  Manufacturable bar: unfinished=11, blocking DRC=2 (target 0/0)
+"""
+
+
+def test_parses_baseline_counts() -> None:
+    result = parse_chorus_result.parse_chorus_log(SAMPLE_LOG_BASELINE, variant="baseline")
+    assert result.variant == "baseline"
+    assert result.total == 51
+    assert result.partial == 20
+    assert result.unrouted == 0
+    assert result.drc_errors == 7
+    # strict is the complement: 51 - 20 - 0.
+    assert result.strict == 31
+
+
+def test_parses_m2m3_counts_with_unrouted() -> None:
+    result = parse_chorus_result.parse_chorus_log(SAMPLE_LOG_M2M3, variant="m2m3")
+    assert result.variant == "m2m3"
+    assert result.partial == 7
+    assert result.unrouted == 4
+    assert result.drc_errors == 2
+    assert result.strict == 51 - 7 - 4  # 40
+
+
+def test_takes_the_last_report_block() -> None:
+    """When the report is printed more than once, the final block wins."""
+    doubled = SAMPLE_LOG_BASELINE + "\n" + SAMPLE_LOG_M2M3
+    result = parse_chorus_result.parse_chorus_log(doubled)
+    # Should reflect the M2M3 (last) block, not the baseline one.
+    assert result.partial == 7
+    assert result.unrouted == 4
+    assert result.drc_errors == 2
+    assert result.strict == 40
+
+
+def test_custom_total_changes_strict() -> None:
+    result = parse_chorus_result.parse_chorus_log(SAMPLE_LOG_BASELINE, variant="baseline", total=48)
+    assert result.total == 48
+    assert result.strict == 48 - 20 - 0  # 28
+
+
+def test_missing_report_raises() -> None:
+    with pytest.raises(ValueError, match="Partially-routed signal nets"):
+        parse_chorus_result.parse_chorus_log("no report here\njust noise\n")
+
+
+def test_partial_report_missing_drc_raises() -> None:
+    """A run that crashed after the partial line but before DRC must fail loudly."""
+    truncated = (
+        "Final chorus report\n  Partially-routed signal nets: 20\n  Unrouted signal nets: 0\n"
+        # no DRC line
+    )
+    with pytest.raises(ValueError, match="Non-connectivity DRC errors"):
+        parse_chorus_result.parse_chorus_log(truncated)
+
+
+def test_as_dict_is_json_serializable() -> None:
+    result = parse_chorus_result.parse_chorus_log(SAMPLE_LOG_BASELINE, variant="m2")
+    payload = json.dumps(result.as_dict())
+    restored = json.loads(payload)
+    assert restored == {
+        "variant": "m2",
+        "total": 51,
+        "partial": 20,
+        "unrouted": 0,
+        "strict": 31,
+        "drc_errors": 7,
+    }
+
+
+def test_cli_writes_json(tmp_path: Path) -> None:
+    log_path = tmp_path / "route.log"
+    log_path.write_text(SAMPLE_LOG_BASELINE, encoding="utf-8")
+    out_path = tmp_path / "result.json"
+    rc = parse_chorus_result.main(
+        ["--variant", "baseline", "--log", str(log_path), "--output", str(out_path)]
+    )
+    assert rc == 0
+    data = json.loads(out_path.read_text(encoding="utf-8"))
+    assert data["variant"] == "baseline"
+    assert data["strict"] == 31
+    assert data["drc_errors"] == 7

--- a/tests/test_ci_summarize_chorus_matrix.py
+++ b/tests/test_ci_summarize_chorus_matrix.py
@@ -1,0 +1,105 @@
+"""Tests for the chorus flag-matrix comparison-table renderer (issue #3873).
+
+``scripts/ci/summarize_chorus_matrix.py`` is the summary-job side of the
+chorus M2/M3 measurement workflow: it loads the per-leg
+``result_<variant>.json`` files written by
+``scripts/ci/parse_chorus_result.py`` and renders a single Markdown
+comparison table (baseline vs m2 vs m3 vs m2m3, with strict-count deltas)
+to the workflow Step Summary.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HELPER_SCRIPT_PATH = REPO_ROOT / "scripts" / "ci" / "summarize_chorus_matrix.py"
+
+
+def _load_helper_module():
+    spec = importlib.util.spec_from_file_location("summarize_chorus_matrix", HELPER_SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["summarize_chorus_matrix"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+summarize_chorus_matrix = _load_helper_module()
+
+
+def _write_result(
+    results_dir: Path,
+    variant: str,
+    *,
+    strict: int,
+    partial: int,
+    unrouted: int,
+    drc_errors: int,
+) -> None:
+    payload = {
+        "variant": variant,
+        "total": 51,
+        "partial": partial,
+        "unrouted": unrouted,
+        "strict": strict,
+        "drc_errors": drc_errors,
+    }
+    (results_dir / f"result_{variant}.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_renders_full_matrix_with_deltas(tmp_path: Path) -> None:
+    _write_result(tmp_path, "baseline", strict=31, partial=20, unrouted=0, drc_errors=7)
+    _write_result(tmp_path, "m2", strict=36, partial=15, unrouted=0, drc_errors=5)
+    _write_result(tmp_path, "m3", strict=34, partial=14, unrouted=3, drc_errors=4)
+    _write_result(tmp_path, "m2m3", strict=40, partial=11, unrouted=0, drc_errors=2)
+
+    results = summarize_chorus_matrix.load_results(tmp_path)
+    table = summarize_chorus_matrix.render_table(results)
+
+    # All four variants present, in canonical order.
+    assert table.index("| baseline ") < table.index("| m2 ")
+    assert table.index("| m2 ") < table.index("| m3 ")
+    assert table.index("| m3 ") < table.index("| m2m3 ")
+
+    # Deltas computed vs baseline strict (31).
+    assert "| +5 |" in table  # m2: 36 - 31
+    assert "| +3 |" in table  # m3: 34 - 31
+    assert "| +9 |" in table  # m2m3: 40 - 31
+    # Baseline row shows a dash, not a delta.
+    assert "| baseline " in table
+
+
+def test_negative_delta_rendered(tmp_path: Path) -> None:
+    _write_result(tmp_path, "baseline", strict=31, partial=20, unrouted=0, drc_errors=7)
+    _write_result(tmp_path, "m2", strict=28, partial=23, unrouted=0, drc_errors=9)
+    results = summarize_chorus_matrix.load_results(tmp_path)
+    table = summarize_chorus_matrix.render_table(results)
+    assert "| -3 |" in table
+
+
+def test_empty_results_dir_renders_note(tmp_path: Path) -> None:
+    results = summarize_chorus_matrix.load_results(tmp_path)
+    assert results == {}
+    table = summarize_chorus_matrix.render_table(results)
+    assert "No leg results found" in table
+
+
+def test_missing_baseline_yields_na_deltas(tmp_path: Path) -> None:
+    # Only m2 present (baseline leg crashed / produced no JSON).
+    _write_result(tmp_path, "m2", strict=36, partial=15, unrouted=0, drc_errors=5)
+    results = summarize_chorus_matrix.load_results(tmp_path)
+    table = summarize_chorus_matrix.render_table(results)
+    assert "| n/a |" in table
+
+
+def test_main_writes_to_stdout(tmp_path: Path, capsys) -> None:
+    _write_result(tmp_path, "baseline", strict=31, partial=20, unrouted=0, drc_errors=7)
+    rc = summarize_chorus_matrix.main(["--results-dir", str(tmp_path)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Chorus M2/M3 flag-matrix results" in out
+    assert "| baseline " in out


### PR DESCRIPTION
## Summary

Closes #3873 (the MEASUREMENT-INFRASTRUCTURE scope).

The dense-board unblock stack is merged — M2 joint region re-solve (#3871, `--joint-region-resolve` / `KCT_JOINT_REGION_RESOLVE=1`) and M3 placement nudge (#3872, `--placement-nudge`) — but its **end-to-end chorus strict-count gain is unmeasured**. The dev machine that built it was too throttled (load avg ~30; the C++ router fell back to pure-Python A* and starved), so the chorus baseline measured 8–31/51 run-to-run and the M2/M3 re-routes never finished in budget.

This PR delivers the **measurement harness** — not the measured numbers, and not a PR gate.

## What's here

- **`.github/workflows/chorus-flag-matrix.yml`** — a `workflow_dispatch` (+ monthly schedule) workflow with a **parallel matrix** that routes `chorus-test-revA_v21_stripped` under four variants so each leg fits the per-job timeout:
  | variant | flags |
  |---|---|
  | baseline | (none) |
  | m2 | `--joint-region-resolve` |
  | m3 | `--placement-nudge` |
  | m2m3 | `--joint-region-resolve --placement-nudge` |

  Each leg: `uv sync` → **build the C++ backend** (`kct build-native` + `--check`, since the missing native ext was the root cause of the unmeasurable baseline) → fetch the private fixture via the existing `scripts/ci/fetch_chorus_test.py` + `CHORUS_TEST_GIT_URL`/`CHORUS_TEST_GIT_REF` secrets (skips gracefully when absent — no red workflow) → run `route_chorus.py` with `PYTHONHASHSEED=0` and the variant flags (150-min timeout) → parse + upload the log and result JSON. A final **`summarize`** job (`needs: measure`) renders a baseline-vs-m2-vs-m3-vs-m2m3 **comparison table with strict-count deltas** to the Step Summary.

- **`scripts/ci/parse_chorus_result.py`** — pure, tested helper that extracts partial / unrouted / non-connectivity-DRC counts from `route_chorus.py`'s "Final chorus report" block and derives `strict = 51 - partial - unrouted` (chorus v21 total).

- **`scripts/ci/summarize_chorus_matrix.py`** — renders the comparison table from the per-leg result JSON.

- **`tests/test_ci_parse_chorus_result.py`** + **`tests/test_ci_summarize_chorus_matrix.py`** — 13 unit tests against realistic captured-log / result-JSON samples.

## Explicitly out of scope (follow-ups gated on the numbers)

Per the issue, this PR does **not** tighten `tests/test_chorus_reach_floor_3237.py` and does **not** change `route_chorus.py` defaults. Those depend on first *seeing* the measured M2/M3 delta.

## How to get the actual numbers

The chorus measurement is only exercisable via a **manual CI run** (`workflow_dispatch` on `Chorus M2/M3 flag matrix (measurement)`) with the `CHORUS_TEST_GIT_URL` secret configured. The routing itself could not be validated locally (machine load + the private fixture). Once merged, run the workflow once and read the comparison table from the run's Step Summary.

## Local validation

- Workflow YAML parses (`yaml.safe_load`).
- `route_chorus.py --help` confirms `--joint-region-resolve` / `--placement-nudge` / `--pcb` / `--output` / `--seed` exist on `origin/main`.
- Parse + summarize wired end-to-end via CLI smoke (produces the delta table).
- 13 unit tests pass.
- `ruff 0.14.10` check + format clean; `mypy` clean on both new scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)