### PR TITLE
fix(router): skip Python fallback on wall-clock FAILURE_TIMEOUT

### DIFF
--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -1586,6 +1586,7 @@ class CppPathfinder:
                     extra_goal_cells=extra_goal_cells,
                     deadline=route_deadline,
                     reason=self._describe_cpp_failure(result),
+                    cpp_failure_reason=getattr(result, "failure_reason", None),
                 )
 
             for attempt in range(max_resume_attempts + 1):
@@ -1640,6 +1641,7 @@ class CppPathfinder:
                             "post-route clearance validation failed; "
                             f"exhausted {max_resume_attempts} resume attempts"
                         ),
+                        cpp_failure_reason=getattr(result, "failure_reason", None),
                     )
 
                 # Find the goal cell of the failed path and reject it.
@@ -1678,6 +1680,7 @@ class CppPathfinder:
                             "resume after rejected goal cell failed: "
                             + self._describe_cpp_failure(result)
                         ),
+                        cpp_failure_reason=getattr(result, "failure_reason", None),
                     )
 
             return None
@@ -2165,6 +2168,7 @@ class CppPathfinder:
         extra_goal_cells: set[tuple[int, int, int]] | None = None,
         deadline: float | None = None,
         reason: str = "unknown",
+        cpp_failure_reason: int | None = None,
     ) -> Route | None:
         """Attempt to route using the Python pathfinder as a fallback.
 
@@ -2196,13 +2200,56 @@ class CppPathfinder:
                 handed this net to the Python fallback (issue #3456).
                 Surfaced in the once-per-net WARNING and recorded in
                 ``fallback_stats['fallback_reasons']``.
+            cpp_failure_reason: The ``FAILURE_*`` code from the failed C++
+                ``RouteResult`` (issue #3876).  When this is
+                ``FAILURE_TIMEOUT`` -- a WALL-CLOCK artifact, not a
+                geometric dead-end -- the Python fallback is short-circuited
+                (returns ``None`` immediately, before constructing the
+                Python ``Router`` or running the 10-100x-slower A*).  A
+                wall-clock timeout means ~``per_net_timeout`` has already
+                elapsed, so the fallback would start with ~0 budget and
+                immediately time out itself, wasting deadline that
+                subsequent nets need.  Geometric failures
+                (``FAILURE_NO_PATH``, ``FAILURE_VIA_VIA_BLOCKED``,
+                ``FAILURE_ITERATION_LIMIT``) are NOT short-circuited -- the
+                Python A*'s different neighbor expansion is exactly the
+                value-add there (issue #3456).  ``None`` (the default)
+                preserves pre-#3876 behavior.
 
         Returns:
             Route object if fallback succeeds, None if also fails (or the
-            shared per-net deadline is already exhausted).
+            shared per-net deadline is already exhausted, or the C++ failure
+            was a wall-clock timeout per issue #3876).
         """
         py_grid = self._grid._py_grid
         if py_grid is None:
+            return None
+
+        net_name = getattr(start, "net_name", "?")
+
+        # Issue #3876: a wall-clock FAILURE_TIMEOUT is a load artifact, not a
+        # geometric dead-end -- on an idle machine the C++ search would have
+        # found the path at the same (deterministic) iteration count.  The
+        # Python fallback shares the SAME per-net deadline, so on a timeout it
+        # would start with ~0 remaining budget and immediately time out
+        # itself, burning deadline that later nets need.  Short-circuit BEFORE
+        # constructing the Python ``Router`` / running the A* so the deadline
+        # is a hard budget rather than a reason to grind 10-100x longer.  This
+        # is a strict subset of the #3474 ``remaining <= 0.05`` skip below and
+        # cannot reduce routed reach.  ``router_cpp`` may be ``None`` (import
+        # failed); guard the constant lookup as the other failure-path helpers
+        # do.  Geometric failures fall through and keep the fallback.
+        if (
+            cpp_failure_reason is not None
+            and router_cpp is not None
+            and int(cpp_failure_reason) == int(router_cpp.FAILURE_TIMEOUT)
+        ):
+            logger.debug(
+                "Net %s: C++ search hit the per-net wall-clock deadline "
+                "(FAILURE_TIMEOUT); skipping Python fallback so the budget is "
+                "hard (issue #3876)",
+                net_name,
+            )
             return None
 
         # Issue #3456: the silent C++ -> Python downgrade is the bug.
@@ -2214,7 +2261,6 @@ class CppPathfinder:
         # relief-probe mode: probes deliberately stress the search, are
         # never committed, and a probe-time fallback is not a
         # user-facing performance event.
-        net_name = getattr(start, "net_name", "?")
 
         # Issue #3474 R1: clamp the fallback budget to the unspent
         # remainder of the shared per-net deadline.

--- a/tests/test_router_timeout_no_fallback_3876.py
+++ b/tests/test_router_timeout_no_fallback_3876.py
@@ -1,0 +1,268 @@
+"""Regression tests for Issue #3876: wall-clock FAILURE_TIMEOUT must NOT
+trigger the slow Python fallback.
+
+Mechanism (see ``CppPathfinder._try_python_fallback`` in
+``src/kicad_tools/router/cpp_backend.py``):
+
+The per-net budget is a WALL-CLOCK deadline checked inside the C++ A*
+loop every ~1024 iterations.  Under machine load wall-clock advances
+faster relative to node-expansion rate, so the deadline fires at a
+*smaller, non-deterministic* iteration count and the C++ pathfinder
+returns ``FAILURE_TIMEOUT`` where on an idle machine it would have found
+the path.  ``FAILURE_TIMEOUT`` is therefore a LOAD ARTIFACT, not a
+geometric dead-end.
+
+The resume loop shares the SAME (already-expiring) deadline.  Before
+#3876 a ``FAILURE_TIMEOUT`` was treated like a geometric failure and
+handed to the pure-Python A* (10-100x slower), which then ALSO timed out
+on the ~0 remaining budget -- wasting deadline that subsequent nets need.
+
+#3876 short-circuits the fallback on ``FAILURE_TIMEOUT``: it returns
+``None`` BEFORE constructing the Python ``Router`` or running the A*.
+Genuine geometric failures (``FAILURE_NO_PATH``,
+``FAILURE_VIA_VIA_BLOCKED``, ``FAILURE_ITERATION_LIMIT``) STILL fall back
+-- the Python A*'s different neighbor expansion is the value-add there
+(issue #3456).
+
+These tests patch the lazily-imported ``pathfinder.Router`` and assert it
+is (not) constructed depending on the C++ failure reason.  This is purely
+Python-side wiring, so it does not require a routed board.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest import mock
+
+import pytest
+
+from kicad_tools.router.cpp_backend import (
+    CppGrid,
+    CppPathfinder,
+    is_cpp_available,
+    router_cpp,
+)
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules
+
+requires_cpp = pytest.mark.skipif(
+    not is_cpp_available(),
+    reason="C++ router backend not available",
+)
+
+CPP_BACKEND_LOGGER = "kicad_tools.router.cpp_backend"
+
+
+def _make_pathfinder() -> tuple[CppPathfinder, RoutingGrid]:
+    rules = DesignRules(
+        trace_width=0.2,
+        trace_clearance=0.2,
+        via_drill=0.35,
+        via_diameter=0.6,
+        via_clearance=0.2,
+        grid_resolution=0.1,
+    )
+    grid = RoutingGrid(
+        width=10.0,
+        height=10.0,
+        rules=rules,
+        layer_stack=LayerStack.two_layer(),
+    )
+    cpp_grid = CppGrid.from_routing_grid(grid)
+    pathfinder = CppPathfinder(cpp_grid, rules, diagonal_routing=True)
+    pathfinder.set_routable_layers(cpp_grid.get_routable_indices())
+    return pathfinder, grid
+
+
+def _make_pads(net: int = 1, net_name: str = "NET1") -> tuple[Pad, Pad]:
+    start = Pad(
+        x=2.0,
+        y=5.0,
+        width=0.6,
+        height=0.6,
+        net=net,
+        net_name=net_name,
+        layer=Layer.F_CU,
+    )
+    end = Pad(
+        x=8.0,
+        y=5.0,
+        width=0.6,
+        height=0.6,
+        net=net,
+        net_name=net_name,
+        layer=Layer.F_CU,
+    )
+    return start, end
+
+
+@requires_cpp
+class TestTimeoutShortCircuitsFallback:
+    """A wall-clock ``FAILURE_TIMEOUT`` must NOT enter the Python fallback."""
+
+    def test_timeout_does_not_construct_python_router(self, caplog) -> None:
+        pathfinder, _ = _make_pathfinder()
+        start, end = _make_pads(net_name="TIMEOUT_NET")
+
+        with mock.patch("kicad_tools.router.pathfinder.Router") as router_cls:
+            with caplog.at_level(logging.DEBUG, logger=CPP_BACKEND_LOGGER):
+                result = pathfinder._try_python_fallback(
+                    start,
+                    end,
+                    reason="per-net wall-clock deadline exceeded",
+                    cpp_failure_reason=int(router_cpp.FAILURE_TIMEOUT),
+                )
+
+        assert result is None, (
+            "issue #3876: a wall-clock FAILURE_TIMEOUT must fail the net "
+            "fast (return None), not grind in the Python A*."
+        )
+        router_cls.assert_not_called()
+
+    def test_timeout_short_circuit_emits_debug_not_warning(self, caplog) -> None:
+        """The short-circuit happens BEFORE the loud #3456 fallback
+        WARNING, so a load-induced timeout no longer logs the misleading
+        'C++ gave up; falling back' line."""
+        pathfinder, _ = _make_pathfinder()
+        start, end = _make_pads(net_name="TIMEOUT_NET2")
+
+        with mock.patch("kicad_tools.router.pathfinder.Router"):
+            with caplog.at_level(logging.DEBUG, logger=CPP_BACKEND_LOGGER):
+                pathfinder._try_python_fallback(
+                    start,
+                    end,
+                    reason="per-net wall-clock deadline exceeded",
+                    cpp_failure_reason=int(router_cpp.FAILURE_TIMEOUT),
+                )
+
+        fallback_warnings = [
+            rec
+            for rec in caplog.records
+            if rec.levelno == logging.WARNING and "falling back" in rec.getMessage()
+        ]
+        assert fallback_warnings == [], (
+            "issue #3876: a FAILURE_TIMEOUT short-circuit must not emit "
+            "the misleading 'falling back' WARNING."
+        )
+        debug_msgs = [
+            rec.getMessage()
+            for rec in caplog.records
+            if rec.levelno == logging.DEBUG and "#3876" in rec.getMessage()
+        ]
+        assert any("TIMEOUT_NET2" in m for m in debug_msgs), (
+            "the short-circuit should log a debug line naming the net"
+        )
+
+    def test_timeout_not_recorded_in_fallback_stats(self) -> None:
+        """A short-circuited timeout never ran a fallback, so it must not
+        pollute ``fallback_stats`` (no slow grind to attribute)."""
+        pathfinder, _ = _make_pathfinder()
+        start, end = _make_pads(net_name="TIMEOUT_NET3")
+
+        with mock.patch("kicad_tools.router.pathfinder.Router"):
+            pathfinder._try_python_fallback(
+                start,
+                end,
+                reason="per-net wall-clock deadline exceeded",
+                cpp_failure_reason=int(router_cpp.FAILURE_TIMEOUT),
+            )
+
+        stats = pathfinder.fallback_stats
+        assert "TIMEOUT_NET3" not in stats["fallback_reasons"]
+        assert "TIMEOUT_NET3" not in stats["fallback_nets"]
+        assert stats["fallback_count"] == 0
+
+
+@requires_cpp
+class TestGeometricFailuresStillFallBack:
+    """Geometric failures must PRESERVE the existing fallback behavior."""
+
+    @pytest.mark.parametrize(
+        "failure_reason",
+        [
+            "FAILURE_NO_PATH",
+            "FAILURE_VIA_VIA_BLOCKED",
+            "FAILURE_ITERATION_LIMIT",
+        ],
+    )
+    def test_geometric_failure_constructs_python_router(self, failure_reason) -> None:
+        pathfinder, _ = _make_pathfinder()
+        start, end = _make_pads(net_name=f"GEOM_{failure_reason}")
+        code = int(getattr(router_cpp, failure_reason))
+
+        with mock.patch("kicad_tools.router.pathfinder.Router") as router_cls:
+            # Make the constructed router's route() return None so we only
+            # assert on construction, not on a real Python A* run.
+            router_cls.return_value.route.return_value = None
+            pathfinder._try_python_fallback(
+                start,
+                end,
+                reason="geometric failure",
+                cpp_failure_reason=code,
+            )
+
+        router_cls.assert_called_once()
+
+    def test_none_failure_reason_preserves_legacy_fallback(self) -> None:
+        """``cpp_failure_reason=None`` (the default / pre-#3876 callers)
+        must still fall back -- the guard is opt-in."""
+        pathfinder, _ = _make_pathfinder()
+        start, end = _make_pads(net_name="LEGACY_NET")
+
+        with mock.patch("kicad_tools.router.pathfinder.Router") as router_cls:
+            router_cls.return_value.route.return_value = None
+            pathfinder._try_python_fallback(
+                start,
+                end,
+                reason="legacy caller",
+                cpp_failure_reason=None,
+            )
+
+        router_cls.assert_called_once()
+
+
+@requires_cpp
+class TestTimeoutGuardEdgeCases:
+    """Edge cases: the guard must not crash and must not double-count."""
+
+    def test_relief_mode_timeout_still_short_circuits(self) -> None:
+        """Relief-probe mode is unaffected by the #3876 guard at the
+        fallback layer: a relief-mode route returns before validation, but
+        if the fallback IS reached with a timeout it must still skip."""
+        pathfinder, _ = _make_pathfinder()
+        start, end = _make_pads(net_name="RELIEF_TIMEOUT")
+        pathfinder.set_relief_mode(True)
+
+        with mock.patch("kicad_tools.router.pathfinder.Router") as router_cls:
+            result = pathfinder._try_python_fallback(
+                start,
+                end,
+                reason="per-net wall-clock deadline exceeded",
+                cpp_failure_reason=int(router_cpp.FAILURE_TIMEOUT),
+            )
+
+        assert result is None
+        router_cls.assert_not_called()
+
+    def test_timeout_guard_layers_on_3474_skip(self, caplog) -> None:
+        """The #3474 ``remaining <= 0.05`` skip still fires independently.
+        A FAILURE_NO_PATH with an exhausted deadline must STILL be skipped
+        by #3474 (so #3876 does not change #3474's behavior)."""
+        import time
+
+        pathfinder, _ = _make_pathfinder()
+        start, end = _make_pads(net_name="EXHAUSTED_GEOM")
+
+        with mock.patch("kicad_tools.router.pathfinder.Router") as router_cls:
+            result = pathfinder._try_python_fallback(
+                start,
+                end,
+                reason="no path",
+                cpp_failure_reason=int(router_cpp.FAILURE_NO_PATH),
+                deadline=time.monotonic() - 1.0,
+            )
+
+        assert result is None
+        router_cls.assert_not_called()


### PR DESCRIPTION
## Summary

The C++ A* per-net budget is a **wall-clock** deadline checked inside the
search loop every ~1024 iterations. Under machine load wall-clock advances
faster relative to node-expansion rate, so the deadline fires at a smaller,
*non-deterministic* iteration count and the C++ pathfinder returns
`FAILURE_TIMEOUT` where on an idle machine it would have found the path.
`FAILURE_TIMEOUT` is therefore a **load artifact, not a geometric dead-end**.

Before this change the post-route resume loop shared the same already-expiring
deadline and treated `FAILURE_TIMEOUT` like a geometric failure, handing the
net to the pure-Python A* (10-100x slower). That fallback then *also* timed out
on the ~0 remaining budget, wasting deadline that subsequent nets need
(starvation -> the 8/51 vs 31/51 chorus swing in #3876).

This is the bounded **Option D** from the issue (PR 1). The separate
`--deterministic-budget` adoption is tracked as #3877 and is NOT part of this PR.

## Changes

- `src/kicad_tools/router/cpp_backend.py`:
  - Add a `cpp_failure_reason: int | None = None` keyword arg to
    `_try_python_fallback`.
  - When it is `FAILURE_TIMEOUT`, short-circuit **before** constructing the
    Python `Router` / running the A* and return `None`, logging at `debug`
    (mirroring the #3474 skip). The misleading once-per-net "falling back"
    WARNING is no longer emitted for a wall-clock timeout.
  - Thread `cpp_failure_reason=getattr(result, "failure_reason", None)` from the
    three resume-loop call sites (initial `route_resumable` failure, resume
    attempts exhausted, resume-after-rejected-goal failure).
- `tests/test_router_timeout_no_fallback_3876.py` (new): unit tests asserting a
  `FAILURE_TIMEOUT` result does NOT construct the Python `Router`, while
  `FAILURE_NO_PATH` / `FAILURE_VIA_VIA_BLOCKED` / `FAILURE_ITERATION_LIMIT`
  still do; plus the `None`-reason legacy path, relief mode, the no-stats-leak
  case, and that the #3474 `remaining<=0.05` skip still fires independently.

## Why this cannot reduce routed reach

A `FAILURE_TIMEOUT` means ~`per_net_timeout` has already elapsed. The fallback
that this skips would, by construction, start with ~0 remaining budget and
immediately time out itself (and is *already* skipped in the common case by the
#3474 `remaining <= 0.05` guard, since the C++ shares the same deadline). The
skip is a strict subset of #3474 behavior, so no flag gate is needed.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `FAILURE_TIMEOUT` does NOT enter the Python fallback / construct `Router` | done | `test_timeout_does_not_construct_python_router` (patches `pathfinder.Router`, asserts `assert_not_called`) |
| Geometric failures STILL fall back | done | `test_geometric_failure_constructs_python_router` parametrized over `FAILURE_NO_PATH`, `FAILURE_VIA_VIA_BLOCKED`, `FAILURE_ITERATION_LIMIT` (`assert_called_once`) |
| `_capture_failure_info` / relief mode / #3474 skip preserved | done | call sites unchanged before fallback; `test_relief_mode_timeout_still_short_circuits`, `test_timeout_guard_layers_on_3474_skip` |
| `router_cpp is None` guarded | done | guard checks `router_cpp is not None` before the `FAILURE_TIMEOUT` constant lookup |
| No new warning noise on timeout | done | `test_timeout_short_circuit_emits_debug_not_warning` |
| No routed-count regression | done | see Test Plan |

## Test Plan

- `uv run pytest tests/test_router_timeout_no_fallback_3876.py tests/test_router_cpp_fallback_warning_3456.py tests/test_route_deterministic_budget.py -q` -> 36 passed.
- `uv run ruff check` + `ruff format --check` on touched files: clean (ruff 0.14.10).
- `mypy`: no new errors introduced on changed lines (pre-existing C++-binding `Any`-return / `attr-defined` errors only).
- No-regression: board-06 routed with `--backend cpp --seed 42`; routed-net count unchanged vs `origin/main`. (This machine is under heavy load, ~31 load avg; the change only skips a doomed Python fallback and is a strict subset of the #3474 skip, so it cannot lower reach below current state.)

Closes #3876