### PR TITLE
fix(schema): preserve multi-unit symbol structure on from-scratch save

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 3877
-# Branch: feature/issue-3877
+# Issue: 3874
+# Branch: feature/issue-3874
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/src/kicad_tools/schema/library.py
+++ b/src/kicad_tools/schema/library.py
@@ -359,10 +359,16 @@ class LibraryPin:
         return (0, 0)
 
     @classmethod
-    def from_sexp(cls, sexp: SExp) -> LibraryPin:
-        """Parse from S-expression."""
+    def from_sexp(cls, sexp: SExp, unit: int = 1) -> LibraryPin:
+        """Parse from S-expression.
+
+        Args:
+            sexp: The ``(pin ...)`` S-expression node.
+            unit: The unit number of the enclosing ``_N_1`` sub-symbol
+                (1-indexed). Defaults to ``1`` for top-level pins.
+        """
         pin_type = sexp.get_string(0) or "passive"
-        _pin_shape = sexp.get_string(1) or "line"  # noqa: F841 - reserved for rendering
+        pin_shape = sexp.get_string(1) or "line"
 
         pos = (0.0, 0.0)
         rot = 0.0
@@ -391,6 +397,8 @@ class LibraryPin:
             position=pos,
             rotation=rot,
             length=length,
+            unit=unit,
+            shape=pin_shape,
         )
 
     def to_sexp_node(self) -> SExp:
@@ -442,6 +450,39 @@ def _snap_to_kicad_grid(
     if abs(value - nearest) <= tolerance:
         return nearest
     return value
+
+
+def _parse_unit_index(unit_name: str, parent_name: str) -> int | None:
+    """Parse the unit index from a KiCad unit sub-symbol name.
+
+    Unit sub-symbols are named ``{short_name}_{unit}_{variant}`` (e.g.
+    ``MyPart_2_1``). The ``_0_*`` sub-symbol holds graphical decoration and is
+    reported as unit ``0``. ``_N_*`` (N>=1) sub-symbols hold pins for unit N.
+
+    Symbol names may themselves contain underscores, so the trailing
+    ``_<int>_<int>`` suffix is split from the right.
+
+    Args:
+        unit_name: The name of the sub-symbol (e.g. ``MyPart_2_1``).
+        parent_name: The (short) name of the enclosing symbol, used to
+            sanity-check the prefix.
+
+    Returns:
+        The parsed unit index (0 for the graphics sub-symbol, >=1 for pin
+        units), or ``None`` if *unit_name* does not match the expected
+        ``<prefix>_<int>_<int>`` shape.
+    """
+    parts = unit_name.rsplit("_", 2)
+    if len(parts) != 3:
+        return None
+    prefix, unit_str, variant_str = parts
+    if not (unit_str.isdigit() and variant_str.isdigit()):
+        return None
+    # The prefix should match the enclosing symbol's short name. If it does
+    # not, this is not a recognized unit sub-symbol (be conservative).
+    if prefix != parent_name:
+        return None
+    return int(unit_str)
 
 
 @dataclass
@@ -583,15 +624,35 @@ class LibrarySymbol:
             if prop_name:
                 properties[prop_name] = prop_value or ""
 
-        # Parse pins and graphics from unit symbols
+        # Parse pins and graphics from unit sub-symbols.
+        #
+        # Unit sub-symbols are named "{short_name}_{unit}_{variant}" (e.g.
+        # "TPA3116D2_1_1"). The "_0_1" sub-symbol holds graphical decoration;
+        # "_N_1" (N>=1) sub-symbols hold the pins for unit N. We parse the unit
+        # index from each sub-symbol name so that:
+        #   - every pin records its enclosing unit (LibraryPin.unit), and
+        #   - the symbol records how many pin units exist (LibrarySymbol.units).
+        # Sub-symbols whose names do not match the "<prefix>_<int>_<int>" shape
+        # (e.g. pins placed directly under the parent) default to unit 1.
+        short_name = name.split(":", 1)[1] if ":" in name else name
+
         pins: list[LibraryPin] = []
         graphics: list[SymbolPolyline | SymbolCircle | SymbolArc | SymbolRectangle] = []
-        for unit_sym in sexp.find_all("symbol"):
-            _unit_name = unit_sym.get_string(0) or ""  # noqa: F841
-            # Unit symbols have names like "TPA3116D2_1_1"
-            # Format: {name}_{unit}_{variant}
+        max_unit = 1
+        for unit_sym in sexp.find_children("symbol"):
+            unit_name = unit_sym.get_string(0) or ""
+            parsed_unit = _parse_unit_index(unit_name, short_name)
+            # Pins inherit the enclosing sub-symbol's unit index. The "_0_1"
+            # graphics sub-symbol (parsed_unit == 0) has no pins; treat
+            # unparsable names as unit 1.
+            pin_unit = parsed_unit if (parsed_unit and parsed_unit >= 1) else 1
+
             for pin_sexp in unit_sym.find_all("pin"):
-                pins.append(LibraryPin.from_sexp(pin_sexp))
+                pins.append(LibraryPin.from_sexp(pin_sexp, unit=pin_unit))
+                max_unit = max(max_unit, pin_unit)
+
+            if parsed_unit is not None and parsed_unit >= 1:
+                max_unit = max(max_unit, parsed_unit)
 
             # Parse graphical primitives
             for polyline_sexp in unit_sym.find_all("polyline"):
@@ -608,6 +669,7 @@ class LibrarySymbol:
             properties=properties,
             pins=pins,
             graphics=graphics,
+            units=max_unit,
             extends=extends,
         )
 
@@ -1054,8 +1116,12 @@ class SymbolLibrary:
         if generator_node := sexp.find("generator"):
             generator = generator_node.get_string(0) or ""
 
+        # Only top-level (direct child) symbols are library symbols. Their
+        # nested "_N_1" unit sub-symbols must NOT be parsed as standalone
+        # library entries -- using find_all() here would recurse into them and
+        # corrupt the library with spurious empty top-level symbols.
         symbols = {}
-        for sym_sexp in sexp.find_all("symbol"):
+        for sym_sexp in sexp.find_children("symbol"):
             sym = LibrarySymbol.from_sexp(sym_sexp)
             symbols[sym.name] = sym
 
@@ -1085,8 +1151,10 @@ class SymbolLibrary:
         if generator_node := sexp.find("generator"):
             generator = generator_node.get_string(0) or ""
 
+        # Only top-level (direct child) symbols are library symbols; nested
+        # "_N_1" unit sub-symbols are parsed by LibrarySymbol.from_sexp.
         symbols = {}
-        for sym_sexp in sexp.find_all("symbol"):
+        for sym_sexp in sexp.find_children("symbol"):
             sym = LibrarySymbol.from_sexp(sym_sexp)
             symbols[sym.name] = sym
 

--- a/tests/fixtures/multiunit_test.kicad_sym
+++ b/tests/fixtures/multiunit_test.kicad_sym
@@ -1,0 +1,21 @@
+(kicad_symbol_lib
+	(version 20231120)
+	(generator "kicad_symbol_editor")
+	(generator_version "8.0")
+	(symbol "MultiUnitPart"
+		(property "Reference" "U" (at 0 5.08 0) (effects (font (size 1.27 1.27))))
+		(property "Value" "MultiUnitPart" (at 0 2.54 0) (effects (font (size 1.27 1.27))))
+		(symbol "MultiUnitPart_1_1"
+			(pin input line (at -7.62 2.54 0) (length 2.54) (name "A1" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+			(pin input line (at -7.62 0 0) (length 2.54) (name "A2" (effects (font (size 1.27 1.27)))) (number "2" (effects (font (size 1.27 1.27)))))
+		)
+		(symbol "MultiUnitPart_2_1"
+			(pin input line (at -7.62 2.54 0) (length 2.54) (name "B1" (effects (font (size 1.27 1.27)))) (number "3" (effects (font (size 1.27 1.27)))))
+			(pin output line (at 7.62 0 180) (length 2.54) (name "B2" (effects (font (size 1.27 1.27)))) (number "4" (effects (font (size 1.27 1.27)))))
+		)
+		(symbol "MultiUnitPart_3_1"
+			(pin power_in line (at 0 7.62 270) (length 2.54) (name "VCC" (effects (font (size 1.27 1.27)))) (number "5" (effects (font (size 1.27 1.27)))))
+			(pin power_in line (at 0 -7.62 90) (length 2.54) (name "GND" (effects (font (size 1.27 1.27)))) (number "6" (effects (font (size 1.27 1.27)))))
+		)
+	)
+)

--- a/tests/test_library_multiunit_roundtrip.py
+++ b/tests/test_library_multiunit_roundtrip.py
@@ -1,0 +1,243 @@
+"""Regression tests for multi-unit symbol serialization (issue #3874).
+
+When a ``SymbolLibrary``'s cached ``._sexp`` is present, ``save()``
+round-trips multi-unit symbols by re-emitting the cached tree verbatim.
+The bug exercised here is the *from-scratch* path (``_sexp = None``), where
+the s-expression must be regenerated from the dataclass model.
+
+Previously, the from-scratch path corrupted multi-unit symbols:
+  - pins were flattened onto the parent symbol (all defaulting to unit 1),
+  - the ``units`` count was never parsed (stayed at the default of 1),
+  - nested ``_N_1`` sub-symbols were re-parsed as spurious empty top-level
+    symbols, and
+  - a spurious ``_0_1`` decoration block could appear.
+
+These tests assert the from-scratch regeneration reproduces the original
+multi-unit structure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kicad_tools.schema.library import SymbolLibrary
+
+FIXTURE = Path(__file__).parent / "fixtures" / "multiunit_test.kicad_sym"
+
+
+def _pin_unit_map(symbol) -> dict[str, int]:
+    """Map each pin number to its unit index."""
+    return {pin.number: pin.unit for pin in symbol.pins}
+
+
+class TestMultiUnitRoundtrip:
+    """From-scratch (``_sexp = None``) round-trip of multi-unit symbols."""
+
+    def test_load_parses_units_and_pin_units(self):
+        """Loading a multi-unit symbol records unit count and per-pin unit."""
+        lib = SymbolLibrary.load(str(FIXTURE))
+
+        # Only the top-level symbol is a library entry -- the nested _N_1
+        # sub-symbols must NOT appear as standalone symbols.
+        assert set(lib.symbols.keys()) == {"MultiUnitPart"}
+
+        symbol = lib.get_symbol("MultiUnitPart")
+        assert symbol is not None
+        assert symbol.units == 3
+        assert symbol.pin_count == 6
+
+        # Pins 1-2 -> unit 1, 3-4 -> unit 2, 5-6 -> unit 3.
+        assert _pin_unit_map(symbol) == {
+            "1": 1,
+            "2": 1,
+            "3": 2,
+            "4": 2,
+            "5": 3,
+            "6": 3,
+        }
+
+    def test_from_scratch_save_preserves_units(self, tmp_path):
+        """Clearing _sexp and saving reparses to an equivalent model."""
+        lib = SymbolLibrary.load(str(FIXTURE))
+        original = lib.get_symbol("MultiUnitPart")
+        original_unit_map = _pin_unit_map(original)
+        original_units = original.units
+
+        # Force the from-scratch serialization path.
+        lib._sexp = None
+        out = tmp_path / "multiunit_out.kicad_sym"
+        lib.save(str(out))
+
+        # Reload the regenerated file and compare structure.
+        reloaded = SymbolLibrary.load(str(out))
+
+        # No spurious top-level symbols (e.g. _1_1, _0_1) leaked into the lib.
+        assert set(reloaded.symbols.keys()) == {"MultiUnitPart"}
+
+        reloaded_symbol = reloaded.get_symbol("MultiUnitPart")
+        assert reloaded_symbol is not None
+        assert reloaded_symbol.units == original_units == 3
+        assert _pin_unit_map(reloaded_symbol) == original_unit_map
+
+    def test_from_scratch_no_spurious_0_1_block(self, tmp_path):
+        """A graphics-free multi-unit symbol emits no _0_1 decoration block."""
+        lib = SymbolLibrary.load(str(FIXTURE))
+        lib._sexp = None
+        out = tmp_path / "multiunit_out.kicad_sym"
+        lib.save(str(out))
+
+        text = out.read_text()
+        # No _0_1 graphics sub-symbol should appear for a pin-only symbol.
+        assert "MultiUnitPart_0_1" not in text
+        # All three pin units must be present.
+        assert "MultiUnitPart_1_1" in text
+        assert "MultiUnitPart_2_1" in text
+        assert "MultiUnitPart_3_1" in text
+
+    def test_from_scratch_pins_under_correct_units(self, tmp_path):
+        """Each pin is emitted under its own _N_1 unit sub-symbol."""
+        lib = SymbolLibrary.load(str(FIXTURE))
+        lib._sexp = None
+        out = tmp_path / "multiunit_out.kicad_sym"
+        lib.save(str(out))
+
+        # Reparse the regenerated tree and confirm each unit sub-symbol holds
+        # exactly its original pins.
+        reloaded = SymbolLibrary.load(str(out))
+        symbol = reloaded.get_symbol("MultiUnitPart")
+
+        unit1 = {p.number for p in symbol.get_pins_for_unit(1)}
+        unit2 = {p.number for p in symbol.get_pins_for_unit(2)}
+        unit3 = {p.number for p in symbol.get_pins_for_unit(3)}
+
+        assert unit1 == {"1", "2"}
+        assert unit2 == {"3", "4"}
+        assert unit3 == {"5", "6"}
+
+
+class TestSingleUnitRoundtrip:
+    """Single-unit symbols must not regress."""
+
+    SINGLE_UNIT = """(kicad_symbol_lib
+        (version 20231120)
+        (generator "kicad_symbol_editor")
+        (symbol "SinglePart"
+            (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+            (property "Value" "SinglePart" (at 0 0 0) (effects (font (size 1.27 1.27))))
+            (symbol "SinglePart_1_1"
+                (pin input line (at -5.08 2.54 0) (length 2.54) (name "IN" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+                (pin output line (at 5.08 0 180) (length 2.54) (name "OUT" (effects (font (size 1.27 1.27)))) (number "2" (effects (font (size 1.27 1.27)))))
+            )
+        )
+    )"""
+
+    def test_single_unit_from_scratch(self, tmp_path):
+        """A single-unit symbol stays single-unit through a from-scratch save."""
+        src = tmp_path / "single.kicad_sym"
+        src.write_text(self.SINGLE_UNIT)
+
+        lib = SymbolLibrary.load(str(src))
+        symbol = lib.get_symbol("SinglePart")
+        assert symbol.units == 1
+        assert all(pin.unit == 1 for pin in symbol.pins)
+
+        lib._sexp = None
+        out = tmp_path / "single_out.kicad_sym"
+        lib.save(str(out))
+
+        reloaded = SymbolLibrary.load(str(out))
+        assert set(reloaded.symbols.keys()) == {"SinglePart"}
+        reloaded_symbol = reloaded.get_symbol("SinglePart")
+        assert reloaded_symbol.units == 1
+        assert reloaded_symbol.pin_count == 2
+        # No spurious _0_1 for a graphics-free symbol.
+        assert "SinglePart_0_1" not in out.read_text()
+
+
+class TestGraphicsDecorationRoundtrip:
+    """Symbols with _0_1 graphics decoration round-trip unchanged."""
+
+    WITH_GRAPHICS = """(kicad_symbol_lib
+        (version 20231120)
+        (generator "kicad_symbol_editor")
+        (symbol "GfxPart"
+            (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+            (property "Value" "GfxPart" (at 0 0 0) (effects (font (size 1.27 1.27))))
+            (symbol "GfxPart_0_1"
+                (rectangle (start -5.08 5.08) (end 5.08 -5.08)
+                    (stroke (width 0.254) (type default))
+                    (fill (type background)))
+            )
+            (symbol "GfxPart_1_1"
+                (pin input line (at -7.62 0 0) (length 2.54) (name "IN" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+            )
+        )
+    )"""
+
+    def test_graphics_decoration_from_scratch(self, tmp_path):
+        """A _0_1 decoration block survives a from-scratch save."""
+        src = tmp_path / "gfx.kicad_sym"
+        src.write_text(self.WITH_GRAPHICS)
+
+        lib = SymbolLibrary.load(str(src))
+        symbol = lib.get_symbol("GfxPart")
+        # Graphics in _0_1 are unit 0 and must not be counted as a pin unit.
+        assert symbol.units == 1
+        assert len(symbol.graphics) == 1
+        assert symbol.pin_count == 1
+
+        lib._sexp = None
+        out = tmp_path / "gfx_out.kicad_sym"
+        lib.save(str(out))
+
+        text = out.read_text()
+        # The graphics block is re-emitted under _0_1, pins under _1_1.
+        assert "GfxPart_0_1" in text
+        assert "GfxPart_1_1" in text
+
+        reloaded = SymbolLibrary.load(str(out))
+        assert set(reloaded.symbols.keys()) == {"GfxPart"}
+        reloaded_symbol = reloaded.get_symbol("GfxPart")
+        assert reloaded_symbol.units == 1
+        assert reloaded_symbol.pin_count == 1
+        assert len(reloaded_symbol.graphics) == 1
+
+
+class TestUnderscoreNameRoundtrip:
+    """Symbol names containing underscores parse units correctly (rsplit)."""
+
+    UNDERSCORE_NAME = """(kicad_symbol_lib
+        (version 20231120)
+        (generator "kicad_symbol_editor")
+        (symbol "My_Part_X"
+            (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+            (property "Value" "My_Part_X" (at 0 0 0) (effects (font (size 1.27 1.27))))
+            (symbol "My_Part_X_1_1"
+                (pin input line (at -5.08 2.54 0) (length 2.54) (name "A" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+            )
+            (symbol "My_Part_X_2_1"
+                (pin output line (at 5.08 0 180) (length 2.54) (name "B" (effects (font (size 1.27 1.27)))) (number "2" (effects (font (size 1.27 1.27)))))
+            )
+        )
+    )"""
+
+    def test_underscore_name_units(self, tmp_path):
+        """Units parse correctly when the symbol name contains underscores."""
+        src = tmp_path / "underscore.kicad_sym"
+        src.write_text(self.UNDERSCORE_NAME)
+
+        lib = SymbolLibrary.load(str(src))
+        symbol = lib.get_symbol("My_Part_X")
+        assert symbol is not None
+        assert symbol.units == 2
+        assert {p.number: p.unit for p in symbol.pins} == {"1": 1, "2": 2}
+
+        lib._sexp = None
+        out = tmp_path / "underscore_out.kicad_sym"
+        lib.save(str(out))
+
+        reloaded = SymbolLibrary.load(str(out))
+        assert set(reloaded.symbols.keys()) == {"My_Part_X"}
+        reloaded_symbol = reloaded.get_symbol("My_Part_X")
+        assert reloaded_symbol.units == 2
+        assert {p.number: p.unit for p in reloaded_symbol.pins} == {"1": 1, "2": 2}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1746,11 +1746,17 @@ class TestSymbolLibraryLoad:
         """Test loading a valid symbol library."""
         lib = SymbolLibrary.load(str(minimal_symbol_library))
 
-        # Library contains 4 symbols: Device:R, Device:R_0_1, Device:C, Device:C_0_1
-        # (main symbols plus their unit sub-symbols)
-        assert len(lib.symbols) == 4
+        # Library contains 2 top-level symbols: Device:R and Device:C. Their
+        # nested unit sub-symbols (Device:R_0_1, Device:C_0_1) are NOT loaded
+        # as standalone library entries -- they describe the parent symbol's
+        # pins/graphics (see issue #3874).
+        assert len(lib.symbols) == 2
         assert "Device:R" in lib.symbols
         assert "Device:C" in lib.symbols
+        assert "Device:R_0_1" not in lib.symbols
+        assert "Device:C_0_1" not in lib.symbols
+        # Pins from the _0_1 sub-symbol are attached to the parent symbol.
+        assert lib.symbols["Device:R"].pin_count == 2
 
     def test_load_invalid_file(self, tmp_path: Path):
         """Test loading a non-library file raises an error."""


### PR DESCRIPTION
## Summary

Fixes the multi-unit `.kicad_sym` serialization bug (#3874). When a `SymbolLibrary`'s cached `._sexp` is present, `.save()` round-trips multi-unit symbols by re-emitting the cached tree verbatim. The bug only manifests on the **from-scratch** path (`_sexp = None`), which the reporter's real use case (moving/copying symbols between libraries) always hits. Previously that path collapsed all pins onto one unit, lost the unit count, and leaked nested `_N_1` sub-symbols back in as spurious empty top-level symbols.

## Changes

All in `src/kicad_tools/schema/library.py`:

- **`SymbolLibrary.load` / `load_from_string`**: use `find_children("symbol")` instead of the recursive `find_all("symbol")`. The recursive variant descended into the `_N_1` unit sub-symbols and registered each as a standalone library entry (the "`_1_1`..`_3_1` became empty top-level symbols" corruption).
- **`LibrarySymbol.from_sexp`**: added `_parse_unit_index()` (rsplit-based so symbol names with underscores parse correctly; `_0_1` treated as graphics/unit 0). Each pin now records its enclosing unit (`pin.unit`) and the symbol records the correct `units` count.
- **`LibraryPin.from_sexp`**: now accepts a `unit` argument and retains the parsed pin `shape` (previously discarded), so non-`line` pins also round-trip from scratch.

With `pin.unit` and `units` populated, the existing `to_sexp_node` emitters reconstruct the correct per-unit `_N_1` layout and no longer emit a spurious `_0_1` block for graphics-free symbols (no emitter change needed).

Tests: new `tests/test_library_multiunit_roundtrip.py` + `tests/fixtures/multiunit_test.kicad_sym`. Updated one assertion in `tests/test_schema.py` that had encoded the buggy sub-symbol-leak behavior (expected 4 symbols where 2 is correct).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| From-scratch save of a multi-unit symbol is structurally equivalent (pins under correct `_N_1`, no spurious `_0_1`, no empty top-level units) | ✅ | `test_from_scratch_save_preserves_units`, `test_from_scratch_no_spurious_0_1_block`, `test_from_scratch_pins_under_correct_units` |
| `from_sexp` populates `LibraryPin.unit` per sub-symbol and sets `LibrarySymbol.units` | ✅ | `test_load_parses_units_and_pin_units` |
| Single-unit symbols and `_0_1` graphics decoration round-trip unchanged | ✅ | `test_single_unit_from_scratch`, `test_graphics_decoration_from_scratch` |
| From-scratch save reparses to an equivalent model | ✅ | reload-and-compare in the multi-unit + underscore-name tests |
| Symbol names containing underscores parse units correctly (rsplit) | ✅ | `test_underscore_name_units` |

## Test Plan

- `uv run pytest tests/test_library_multiunit_roundtrip.py` — 7 passed
- `uv run pytest tests/test_schema.py tests/test_schematic_library.py tests/test_library_extends.py tests/test_operations.py tests/test_schematic_registry.py` — all passed
- Broader library-referencing suites (BOM, netlist, zones, PCB, schematic editing, symbol generator, etc.) — all passed
- `ruff check` / `ruff format --check` clean on changed files; `mypy` introduces no new errors (one pre-existing error at the unrelated `get_string` assignment remains).

Closes #3874