### PR TITLE
fix(ci): revert board-05 deterministic budget to restore green re-route gate (#3894)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1573,30 +1573,21 @@ jobs:
     # deterministic.  <= 11 catches GROSS regressions without flaking on the
     # 9-vs-10 nondeterminism.
     #
-    # Issue #3887: board 05's re-route is now DETERMINISTIC -- the main pass and
-    # the rescue loop were migrated from the load-sensitive --per-net-timeout
-    # wall-clock cutoff to a fixed per-net ITERATION budget
-    # (--deterministic-budget --per-net-iterations 200000; see
-    # boards/05-bldc-motor-controller/design.py _BOARD_05_PER_NET_ITERATIONS),
-    # so a fresh re-route here is now reproducible AND terminates with headroom
-    # under the 90-min timeout below.  --max-blocking INTENTIONALLY stays at 11
-    # in the #3887 PR: per #3822 the deterministic blocking count is CI-
-    # authoritative, so the tightened bound (toward 7) is deferred to a measured
-    # follow-up that reads it off a green run of THIS job, rather than guessed.
+    # Issue #3887 (SUPERSEDED by #3894): #3887 migrated board 05's main pass +
+    # rescue loop from the --per-net-timeout wall-clock cutoff to a fixed per-net
+    # ITERATION budget, claiming determinism; that claim did not hold up on CI.
     #
-    # Issue #3894: #3887's determinism was INCOMPLETE.  It left the OUTER
-    # wall-clock caps in place (--timeout 900 main pass, stage_timeout_s 300
-    # rescue), and those FIRED under CI runner load -- truncating the otherwise-
-    # deterministic route so the blocking count varied run-to-run (12 on
-    # 007c4709 vs <=11 on 1256f11b, byte-identical recipe).  #3894 disables both
-    # outer caps (--timeout 0 == unbounded; the per-net iteration budget is the
-    # sole terminator), so the completed-net set -- hence the blocking count --
-    # is machine-independent.  Termination is still guaranteed by the iteration
-    # budget, and THIS job's timeout-minutes:90 is the ultimate backstop (a loud
-    # red job, never a silent count change).  --max-blocking STILL stays at 11:
-    # the un-truncated route is expected to land back at the historical 9-10
-    # floor (<=11); tightening 11 -> the CI-measured deterministic count is a
-    # deliberate follow-up, gated on two consecutive green runs of THIS job.
+    # Issue #3894: REVERTED #3887's deterministic per-net ITERATION budget on
+    # board 05 back to the pre-#3887 wall-clock recipe (--per-net-timeout 60 /
+    # --timeout 900).  #3887's iteration budget did LESS total routing work than
+    # the wall-clock outer rip-up/reroute loop, so it completed FEWER nets and
+    # REGRESSED this job's blocking count to 12-15 (vs the historical wall-clock
+    # 9-10); the byte-determinism it promised was never actually achieved on CI.
+    # The wall-clock recipe is board 05's known-GREEN state (<=11).  It is
+    # admittedly nondeterministic run-to-run (~9-10), so --max-blocking STAYS at
+    # 11 (the loose bound above the observed CI ceiling of 10); genuine board-05
+    # routing determinism -- and any tightening toward 7/0 -- is deferred to
+    # #3775 / #3766 / #3829.
     #
     # The ``Build C++ router backend`` step is REQUIRED: the recipe re-routes
     # during regen, and per CLAUDE.md a missing native extension makes routing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1584,6 +1584,20 @@ jobs:
     # authoritative, so the tightened bound (toward 7) is deferred to a measured
     # follow-up that reads it off a green run of THIS job, rather than guessed.
     #
+    # Issue #3894: #3887's determinism was INCOMPLETE.  It left the OUTER
+    # wall-clock caps in place (--timeout 900 main pass, stage_timeout_s 300
+    # rescue), and those FIRED under CI runner load -- truncating the otherwise-
+    # deterministic route so the blocking count varied run-to-run (12 on
+    # 007c4709 vs <=11 on 1256f11b, byte-identical recipe).  #3894 disables both
+    # outer caps (--timeout 0 == unbounded; the per-net iteration budget is the
+    # sole terminator), so the completed-net set -- hence the blocking count --
+    # is machine-independent.  Termination is still guaranteed by the iteration
+    # budget, and THIS job's timeout-minutes:90 is the ultimate backstop (a loud
+    # red job, never a silent count change).  --max-blocking STILL stays at 11:
+    # the un-truncated route is expected to land back at the historical 9-10
+    # floor (<=11); tightening 11 -> the CI-measured deterministic count is a
+    # deliberate follow-up, gated on two consecutive green runs of THIS job.
+    #
     # The ``Build C++ router backend`` step is REQUIRED: the recipe re-routes
     # during regen, and per CLAUDE.md a missing native extension makes routing
     # multi-minute-per-net.  Board 05's recipe is named design.py (NOT

--- a/boards/05-bldc-motor-controller/design.py
+++ b/boards/05-bldc-motor-controller/design.py
@@ -2707,41 +2707,6 @@ def create_zones_for_pcb(pcb_path: Path) -> int:
     return zones_created
 
 
-# Issue #3887: board-05-specific deterministic per-net iteration cap.
-#
-# #3880 set out to make the board-05 re-route deterministic by swapping the
-# load-sensitive wall-clock per-net cutoff (``--per-net-timeout 60``) for an
-# ITERATION budget (``--deterministic-budget``), so the routed copper -- and its
-# blocking-net count -- is reproducible across machines instead of varying with
-# runner speed/load (#3822 macOS-vs-CI divergence, #3836 flakes).  The generic
-# budget from #3881 (1,000,000 node expansions/net) was REVERTED for board-05 in
-# PR #3886: on the dense BLDC board the per-net cap is effectively unbounded, the
-# heaviest re-route in the matrix routed for many minutes per net, and the
-# ``board-05-routing-regression`` job blew past its 90-min limit (cancelled).
-#
-# 200,000 node expansions/net is the board-05-tuned cap: it bounds each per-net
-# A* search (C++ AND the Python fallback, which shares this cap via
-# ``CppPathfinder._effective_search_iterations`` -- see pathfinder.py
-# ``_max_iterations_override``) to a fixed, machine-independent amount of work so
-# the full route TERMINATES with large headroom under the 90-min CI job limit,
-# while leaving enough budget for the productive nets.  The value was chosen by
-# local A/B measurement (200k main-pass routes in ~8 min on the macOS host vs
-# the wall-clock recipe's comparable time; 500k+ regresses to >30 min because
-# the per-net Python fallback on the structurally-blocked ISENSE/PWM nets grinds
-# to the higher cap).  Per #3822 the EXACT reach/blocking count is CI-authori-
-# tative (the macOS host routes fewer nets than the Linux CI runner), so the
-# ``board-05-routing-regression`` job's measured ``blocking_incomplete_count`` --
-# not a local count -- governs any future tightening of ``--max-blocking``
-# (currently held at the temporary loose bound of 11; see
-# scripts/ci/check_board_05_blocking.py and ci.yml).
-#
-# MUST stay in sync between the main pass (``route_pcb`` argv below) and the
-# rescue loop (``_RESCUE_CONFIG`` further down): both re-route the same dense
-# board and both need the SAME bounded per-net cap to stay deterministic and
-# terminating.
-_BOARD_05_PER_NET_ITERATIONS = 200_000
-
-
 def route_pcb(input_path: Path, output_path: Path) -> bool:
     """
     Route the PCB by invoking the ``kct route`` CLI with the proven flag recipe.
@@ -2850,39 +2815,22 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
       of silently falling back to python and producing a different
       deterministic output -- build it with ``kct build-native``
       (see CLAUDE.md fresh-worktree checklist).
-    - ``--seed 7``: deterministic per-net ordering.  Issue #3887: under
-      ``--deterministic-budget`` (below) the route is now *byte*-identical
-      across re-runs, not merely semantically deterministic -- the per-net
-      abort point is a fixed node-expansion count, not a timing-sensitive
-      wall-clock cutoff, so route-twice produces an identical copper set
-      (proven by the board-05 case in
-      scripts/ci/board_route_determinism_smoke.sh).  Seed selected by
-      measurement (42 -> 27/35, 123 -> 27/35, 7 -> 28/35 at
-      otherwise-identical flags).
-    - ``--deterministic-budget --per-net-iterations
-      _BOARD_05_PER_NET_ITERATIONS`` + ``--timeout 0`` (wall-clock cap
-      DISABLED, Issue #3894): Issue #3887 replaced the old
-      ``--per-net-timeout 60`` wall-clock cap with a fixed per-net iteration
-      budget so the re-route is reproducible across machines (the #3880 goal
-      that PR #3886 deferred for board 05).  The per-net iteration cap is
-      BOTH the reach lever and the termination guarantee here: the generic
-      #3881 default (1,000,000/net) made this dense board non-terminating on
-      CI (PR #3886's 90-min timeout), and the board-05-tuned 200,000 (see
-      ``_BOARD_05_PER_NET_ITERATIONS``) bounds each per-net A* -- C++ and the
-      Python fallback alike -- to a fixed amount of work so the route lands
-      the productive nets and finishes with clear headroom under the 90-min
-      job limit.  Issue #3894: ``--timeout`` is now 0 (unbounded).  #3887
-      KEPT a 900 s outer wall-clock backstop, but that cap was load-sensitive:
-      on a slow/contended CI runner the SAME deterministic work took >900 s
-      and the cap FIRED, truncating the route to a smaller completed-net set
-      and a higher blocking count (the 12-vs-<=11 flake) -- reintroducing the
-      load-sensitivity #3887 removed one layer down.  Disabling it makes the
-      iteration budget the SOLE terminator, so the completed-net set (hence
-      the blocking count) is machine-independent.  Do NOT restore
-      ``--per-net-timeout`` (it reintroduces per-net load-sensitivity) and do
-      NOT set a finite ``--timeout`` that can bind before the iteration budget
-      completes (that firing outer deadline is precisely the #3894 bug); the
-      job's own timeout-minutes:90 is the ultimate, loud-failing backstop.
+    - ``--seed 7``: deterministic per-net ordering.  NOTE: with
+      ``--per-net-timeout`` the route is *semantically* deterministic
+      (same reach, same partial set, same single residual violation at
+      the same location across re-runs) but NOT byte-identical -- the
+      60 s wall-clock cutoffs are timing-sensitive.  All CI gates
+      measure the COMMITTED artifact, not a fresh re-route, so CI is
+      stable.  Seed selected by measurement (42 -> 27/35, 123 ->
+      27/35, 7 -> 28/35 at otherwise-identical flags); the DRC profile
+      is the same single residual across all three seeds.
+    - ``--timeout 900 --per-net-timeout 60``: the per-net budget is
+      the reach lever on this board -- at the default 30 s the
+      BLOCKED_BY_COMPONENT rip-up for ISENSE_A-/B- "did not converge"
+      and left HALL_A/B/C collateral-damaged (23/35); at 60 s the
+      rip-up re-lands the displaced siblings (27-28/35).  Raising the
+      wall budget instead (1500 s) is counter-productive: the extra
+      budget feeds a second destructive rip-up wave (23/35).
     - Dropped vs the old 2L recipe (all by measurement, #3425):
       ``--differential-pairs`` (the ISENSE pair classes refuse
       engagement: ``opt_in_disabled``; flag was a no-op for pairing
@@ -3052,48 +3000,39 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
         "cpp",
         "--seed",
         "7",  # Issue #3425: measured best of {7, 42, 123} -- 28/35 vs 27/35
-        # Issue #3887: board 05's re-route is now DETERMINISTIC -- it is bounded
-        # by a fixed per-net ITERATION budget instead of the old load-sensitive
-        # ``--per-net-timeout 60`` wall-clock cutoff.  ``--deterministic-budget``
-        # (#3538) sets ``per_net_timeout=0`` and pins the C++ A* iteration
-        # backstop; ``--per-net-iterations`` overrides the generic #3881 default
-        # (1,000,000/net, which made this dense board non-terminating on CI --
-        # the PR #3886 timeout) with the board-05-tuned cap above.  Each per-net
-        # search now aborts after the SAME node-expansion count on every machine,
-        # so a route-twice produces byte-identical copper (the re-added board-05
-        # case in scripts/ci/board_route_determinism_smoke.sh is the gate) and
-        # the run terminates with clear headroom under the 90-min
-        # board-05-routing-regression job limit.  This is the #3880 follow-up
-        # that PR #3886 deferred for board 05.  ``--timeout`` is retained ONLY as
-        # an outer safety backstop (a firing outer deadline would re-introduce
-        # wall-clock dependence; the iteration cap, not the wall clock, is the
-        # binding constraint).
-        "--deterministic-budget",
-        "--per-net-iterations",
-        str(_BOARD_05_PER_NET_ITERATIONS),
+        # Issue #3880: board 05 INTENTIONALLY stays on the wall-clock per-net
+        # cutoff below; --deterministic-budget is NOT used here.  Threading the
+        # iteration budget onto this main pass (per #3881: per_net_timeout=0 +
+        # ~1M-per-net / 12M-total iteration cap) removes board 05's terminating
+        # wall-clock cap.  On the slower/contended CI runner the dense BLDC
+        # board (the heaviest re-route in the matrix) then routes effectively
+        # unbounded and blew past the 90-min board-05-routing-regression job
+        # limit (timed out / cancelled -- see PR #3886).  Board 06's
+        # deterministic-budget adoption WAS validated locally and is kept; board
+        # 05 stays on its existing bounded path until a CI-measured terminating
+        # iteration ceiling is available (follow-up to #3880).
+        #
+        # Issue #3894: REVERTED #3887's deterministic per-net ITERATION budget
+        # (--deterministic-budget --per-net-iterations 200000) back to this
+        # wall-clock recipe.  #3887's deterministic budget did LESS total
+        # routing work than the wall-clock recipe's outer rip-up/reroute loop
+        # had time to do, so it completed FEWER nets -- a reach regression
+        # (12-15 blocking vs the historical wall-clock 9-10, gate threshold
+        # <=11), and full determinism was never actually achieved.  This
+        # wall-clock recipe (the pre-#3887 / #3886 state) is the known-GREEN
+        # board-05 gate state (<=11).  It is admittedly nondeterministic
+        # run-to-run (9-10); achieving genuine board-05 routing determinism
+        # without a reach regression is deferred to #3775 / #3766 / #3829.
+        # Do NOT re-add --deterministic-budget here without a CI-measured
+        # iteration ceiling that matches the wall-clock recipe's reach.
         "--timeout",
-        # Issue #3894: the outer wall-clock cap is now DISABLED (0 ==
-        # unbounded; see route_cmd._set_wall_clock_deadline, which treats a
-        # falsy --timeout as "no deadline").  History: #3111 set 360, #3425
-        # raised to 900.  Under --deterministic-budget the per-net ITERATION
-        # cap (_BOARD_05_PER_NET_ITERATIONS) is the binding terminator, so the
-        # 900 s wall-clock was meant to be a never-firing backstop.  It was
-        # NOT never-firing: on a loaded CI runner the SAME deterministic work
-        # took >900 s wall-clock, so the cap fired and TRUNCATED the route,
-        # landing fewer completed nets and a higher blocking count (12 vs the
-        # <=11 the un-truncated route lands) -- run-to-run variance that
-        # reintroduced exactly the load-sensitivity #3887 removed one layer
-        # down (#3894).  Setting it to 0 makes the iteration budget the SOLE
-        # terminator, so the completed-net set -- and therefore the blocking
-        # count -- is machine-independent.  Termination is still guaranteed:
-        # the 200k/net iteration cap bounds each per-net A* to a fixed amount
-        # of work (the #3887 fix for the #3886 90-min hang), and the
-        # board-05-routing-regression job's own timeout-minutes:90 remains the
-        # ultimate backstop -- if the iteration-bounded route ever fails to
-        # terminate it fails LOUD (red job) instead of silently truncating to
-        # a different count.  Do NOT restore a finite --timeout that can bind
-        # before the iteration budget completes (that is the #3894 bug).
-        "0",
+        # Issue #3111: was 360.  #3425: do NOT raise to 1500 (23/35, see docstring).
+        "900",
+        # Issue #3425: 30 -> 60; the reach lever (rip-up convergence, see
+        # docstring).  This wall-clock cap is what keeps the board-05 re-route
+        # CI-terminating (see the --deterministic-budget note above).
+        "--per-net-timeout",
+        "60",
         "--skip-nets",
         ",".join(skip_nets),
     ]
@@ -3147,45 +3086,25 @@ _RESCUE_EXCLUDED_NETS = frozenset(
 #   * seed 7 + ``--micro-via-in-pad-fallback`` (Issue #3425/#3118): the
 #     0.3 mm in-pad rescue vias the router needs to escape the DRV8301
 #     (U3, 0.5 mm-pitch),
-#   * Issue #3887: the rescue loop is now DETERMINISTIC and bounded by the
-#     SAME per-net iteration cap as the main pass (``deterministic_budget=True``
-#     + ``--per-net-iterations _BOARD_05_PER_NET_ITERATIONS`` via ``extra_args``).
-#     This is the #3880 follow-up PR #3886 deferred for board 05: both the main
-#     pass and this rescue loop re-route the same dense board, so both must use
-#     the iteration budget (not the old load-sensitive ``per_net_timeout_s=60``
-#     wall-clock cutoff) to stay reproducible across machines AND terminate
-#     within the 90-min CI job limit.  Issue #3894: ``stage_timeout_s`` is now
-#     0 (== unbounded; ``build_rescue_command`` forwards it as ``--timeout 0``,
-#     which route_cmd treats as "no deadline").  It was 300 s as a "never-
-#     firing" outer per-stage backstop, but -- exactly like the main pass's
-#     900 s cap -- on a loaded CI runner a per-net rescue stage's fixed
-#     deterministic work occasionally took >300 s wall-clock, so the cap fired
-#     and TRUNCATED that stage, dropping a net that would otherwise complete
-#     and bumping the final blocking count (the 12-vs-<=11 flake, #3894).  With
-#     the cap disabled the per-net ITERATION budget is the sole terminator, so
-#     the rescued copper -- and the blocking count -- is machine-independent.
-#     Termination is still bounded by the iteration cap per net and by the
-#     job's timeout-minutes:90 (a loud red job, never a silent count change).
-#     KEEP THE CAP IN SYNC with the main pass: re-tune both together, never one
-#     alone.  ``build_rescue_command`` honours an explicit ``--per-net-iterations``
-#     in ``extra_args`` verbatim (it overrides the generic #3881 default the bare
-#     ``--deterministic-budget`` would otherwise apply).
+#   * 60 s per-net matches the main recipe; 300 s stage wall bounds the
+#     #3485 budget-leak overshoot inside escape/rip-up phases.  Issue #3880:
+#     the rescue loop INTENTIONALLY stays on this wall-clock per-net cutoff
+#     (no ``deterministic_budget``).  It must match the main pass, which also
+#     stays on wall-clock for board 05 (the iteration budget made the dense
+#     BLDC re-route non-terminating on CI -- see the route_pcb() note and
+#     PR #3886).  Re-enable deterministic_budget here only together with the
+#     main pass, once a CI-terminating iteration ceiling is measured.
 #   * 4-layer, cpp backend, jlcpcb-tier1 -- same as the main pass.
 _RESCUE_CONFIG = RescueConfig(
     manufacturer="jlcpcb-tier1",
     backend="cpp",
     seed=7,
-    # Issue #3894: 0 == unbounded outer wall-clock cap (the deterministic
-    # per-net iteration budget below is the binding terminator).  Was 300 s;
-    # a firing per-stage cap truncated rescues under CI load and varied the
-    # blocking count run-to-run.  See the comment block above.
-    stage_timeout_s=0,
-    deterministic_budget=True,
+    stage_timeout_s=300,
+    per_net_timeout_s=60,
     starting_layers=4,
     max_layers=4,
     excluded_nets=_RESCUE_EXCLUDED_NETS,
     micro_via_in_pad_fallback=True,
-    extra_args=("--per-net-iterations", str(_BOARD_05_PER_NET_ITERATIONS)),
 )
 
 

--- a/boards/05-bldc-motor-controller/design.py
+++ b/boards/05-bldc-motor-controller/design.py
@@ -2860,20 +2860,29 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
       measurement (42 -> 27/35, 123 -> 27/35, 7 -> 28/35 at
       otherwise-identical flags).
     - ``--deterministic-budget --per-net-iterations
-      _BOARD_05_PER_NET_ITERATIONS`` + ``--timeout 900`` (safety backstop):
-      Issue #3887 replaced the old ``--per-net-timeout 60`` wall-clock cap
-      with a fixed per-net iteration budget so the re-route is reproducible
-      across machines (the #3880 goal that PR #3886 deferred for board 05).
-      The per-net iteration cap is BOTH the reach lever and the termination
-      guarantee here: the generic #3881 default (1,000,000/net) made this
-      dense board non-terminating on CI (PR #3886's 90-min timeout), and the
-      board-05-tuned 200,000 (see ``_BOARD_05_PER_NET_ITERATIONS``) bounds
-      each per-net A* -- C++ and the Python fallback alike -- to a fixed
-      amount of work so the route lands the productive nets and finishes
-      with clear headroom under the 90-min job limit.  Do NOT restore
-      ``--per-net-timeout`` (it reintroduces the load-sensitivity #3887
-      removed) and do NOT raise ``--timeout`` to bind (a firing outer
-      deadline breaks determinism).
+      _BOARD_05_PER_NET_ITERATIONS`` + ``--timeout 0`` (wall-clock cap
+      DISABLED, Issue #3894): Issue #3887 replaced the old
+      ``--per-net-timeout 60`` wall-clock cap with a fixed per-net iteration
+      budget so the re-route is reproducible across machines (the #3880 goal
+      that PR #3886 deferred for board 05).  The per-net iteration cap is
+      BOTH the reach lever and the termination guarantee here: the generic
+      #3881 default (1,000,000/net) made this dense board non-terminating on
+      CI (PR #3886's 90-min timeout), and the board-05-tuned 200,000 (see
+      ``_BOARD_05_PER_NET_ITERATIONS``) bounds each per-net A* -- C++ and the
+      Python fallback alike -- to a fixed amount of work so the route lands
+      the productive nets and finishes with clear headroom under the 90-min
+      job limit.  Issue #3894: ``--timeout`` is now 0 (unbounded).  #3887
+      KEPT a 900 s outer wall-clock backstop, but that cap was load-sensitive:
+      on a slow/contended CI runner the SAME deterministic work took >900 s
+      and the cap FIRED, truncating the route to a smaller completed-net set
+      and a higher blocking count (the 12-vs-<=11 flake) -- reintroducing the
+      load-sensitivity #3887 removed one layer down.  Disabling it makes the
+      iteration budget the SOLE terminator, so the completed-net set (hence
+      the blocking count) is machine-independent.  Do NOT restore
+      ``--per-net-timeout`` (it reintroduces per-net load-sensitivity) and do
+      NOT set a finite ``--timeout`` that can bind before the iteration budget
+      completes (that firing outer deadline is precisely the #3894 bug); the
+      job's own timeout-minutes:90 is the ultimate, loud-failing backstop.
     - Dropped vs the old 2L recipe (all by measurement, #3425):
       ``--differential-pairs`` (the ISENSE pair classes refuse
       engagement: ``opt_in_disabled``; flag was a no-op for pairing
@@ -3063,9 +3072,28 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
         "--per-net-iterations",
         str(_BOARD_05_PER_NET_ITERATIONS),
         "--timeout",
-        # Issue #3111: was 360.  #3425: do NOT raise to 1500 (23/35).  Under
-        # --deterministic-budget this is only the outer safety backstop.
-        "900",
+        # Issue #3894: the outer wall-clock cap is now DISABLED (0 ==
+        # unbounded; see route_cmd._set_wall_clock_deadline, which treats a
+        # falsy --timeout as "no deadline").  History: #3111 set 360, #3425
+        # raised to 900.  Under --deterministic-budget the per-net ITERATION
+        # cap (_BOARD_05_PER_NET_ITERATIONS) is the binding terminator, so the
+        # 900 s wall-clock was meant to be a never-firing backstop.  It was
+        # NOT never-firing: on a loaded CI runner the SAME deterministic work
+        # took >900 s wall-clock, so the cap fired and TRUNCATED the route,
+        # landing fewer completed nets and a higher blocking count (12 vs the
+        # <=11 the un-truncated route lands) -- run-to-run variance that
+        # reintroduced exactly the load-sensitivity #3887 removed one layer
+        # down (#3894).  Setting it to 0 makes the iteration budget the SOLE
+        # terminator, so the completed-net set -- and therefore the blocking
+        # count -- is machine-independent.  Termination is still guaranteed:
+        # the 200k/net iteration cap bounds each per-net A* to a fixed amount
+        # of work (the #3887 fix for the #3886 90-min hang), and the
+        # board-05-routing-regression job's own timeout-minutes:90 remains the
+        # ultimate backstop -- if the iteration-bounded route ever fails to
+        # terminate it fails LOUD (red job) instead of silently truncating to
+        # a different count.  Do NOT restore a finite --timeout that can bind
+        # before the iteration budget completes (that is the #3894 bug).
+        "0",
         "--skip-nets",
         ",".join(skip_nets),
     ]
@@ -3126,9 +3154,18 @@ _RESCUE_EXCLUDED_NETS = frozenset(
 #     pass and this rescue loop re-route the same dense board, so both must use
 #     the iteration budget (not the old load-sensitive ``per_net_timeout_s=60``
 #     wall-clock cutoff) to stay reproducible across machines AND terminate
-#     within the 90-min CI job limit.  ``stage_timeout_s=300`` is retained ONLY
-#     as the outer per-stage safety backstop (under deterministic_budget the
-#     wall-clock ``per_net_timeout_s`` is ignored; the iteration cap binds).
+#     within the 90-min CI job limit.  Issue #3894: ``stage_timeout_s`` is now
+#     0 (== unbounded; ``build_rescue_command`` forwards it as ``--timeout 0``,
+#     which route_cmd treats as "no deadline").  It was 300 s as a "never-
+#     firing" outer per-stage backstop, but -- exactly like the main pass's
+#     900 s cap -- on a loaded CI runner a per-net rescue stage's fixed
+#     deterministic work occasionally took >300 s wall-clock, so the cap fired
+#     and TRUNCATED that stage, dropping a net that would otherwise complete
+#     and bumping the final blocking count (the 12-vs-<=11 flake, #3894).  With
+#     the cap disabled the per-net ITERATION budget is the sole terminator, so
+#     the rescued copper -- and the blocking count -- is machine-independent.
+#     Termination is still bounded by the iteration cap per net and by the
+#     job's timeout-minutes:90 (a loud red job, never a silent count change).
 #     KEEP THE CAP IN SYNC with the main pass: re-tune both together, never one
 #     alone.  ``build_rescue_command`` honours an explicit ``--per-net-iterations``
 #     in ``extra_args`` verbatim (it overrides the generic #3881 default the bare
@@ -3138,7 +3175,11 @@ _RESCUE_CONFIG = RescueConfig(
     manufacturer="jlcpcb-tier1",
     backend="cpp",
     seed=7,
-    stage_timeout_s=300,
+    # Issue #3894: 0 == unbounded outer wall-clock cap (the deterministic
+    # per-net iteration budget below is the binding terminator).  Was 300 s;
+    # a firing per-stage cap truncated rescues under CI load and varied the
+    # blocking count run-to-run.  See the comment block above.
+    stage_timeout_s=0,
     deterministic_budget=True,
     starting_layers=4,
     max_layers=4,

--- a/scripts/ci/board_route_determinism_smoke.sh
+++ b/scripts/ci/board_route_determinism_smoke.sh
@@ -6,7 +6,9 @@
 # now include ``--deterministic-budget`` + ``--seed 42`` + a pinned
 # ``PYTHONHASHSEED=42`` -- and asserts that the UUID-normalized routed
 # COPPER (the ``(segment ...)`` / ``(via ...)`` / ``(arc ...)`` set) is
-# byte-identical across every run.
+# byte-identical across every run AND that the blocking-incomplete-net
+# COUNT (NetStatusAnalyzer.blocking_incomplete_count -- the metric the
+# board-05 CI gate enforces) is identical across every run (Issue #3894).
 #
 # WHY this exists (Issue #3799 root cause):
 #   ``--seed`` only seeds Python's global ``random``.  It does NOT control
@@ -103,6 +105,11 @@ case "${BOARD}" in
     # cap (_BOARD_05_PER_NET_ITERATIONS) that keeps the dense BLDC re-route both
     # reproducible AND terminating within the 90-min CI job limit; KEEP IT IN
     # SYNC with the recipe.  Seed 7 (not 42) per the recipe's measured best.
+    # Issue #3894: --timeout is 0 (DISABLED) to mirror the recipe.  A finite
+    # outer wall-clock cap (was 900 s) fired under CI load and truncated the
+    # deterministic iteration-bounded route to a machine-DEPENDENT completed-
+    # net set; 0 makes the --per-net-iterations budget the sole terminator so
+    # the routed copper AND its blocking count are reproducible across runs.
     BOARD_DIR="boards/05-bldc-motor-controller"
     STEM="bldc_controller"
     ROUTE_FLAGS=(
@@ -115,7 +122,7 @@ case "${BOARD}" in
       --seed 7
       --deterministic-budget
       --per-net-iterations 200000
-      --timeout 900
+      --timeout 0
       --skip-nets "+24V,+5V,+3V3,GND,PHASE_A,PHASE_B,PHASE_C"
     )
     ;;
@@ -160,7 +167,31 @@ normalize_copper() {
     | sort
 }
 
+# Issue #3894: blocking-incomplete-net count for a routed PCB, via the same
+# NetStatusAnalyzer metric the board-05 CI gate (scripts/ci/check_board_05_
+# blocking.py) and the DRC gate use.  The determinism contract is extended
+# from "byte-identical copper" to "identical blocking COUNT": the board-05
+# flake (#3894) was a run-to-run *count* change (12 vs <=11) caused by a
+# load-sensitive outer wall-clock cap truncating the route, NOT a copper-set
+# bug the copper diff could catch.  Asserting a stable count here makes a
+# future reintroduction of count variance fail loudly.  Prints just the
+# integer on stdout (empty on analysis failure, which the caller treats as
+# a tool error).
+blocking_count() {
+  uv run python - "$1" <<'PY' 2>/dev/null || true
+import sys
+from kicad_tools.analysis.net_status import NetStatusAnalyzer
+
+try:
+    result = NetStatusAnalyzer(sys.argv[1]).analyze()
+except Exception:
+    sys.exit(1)
+print(result.blocking_incomplete_count)
+PY
+}
+
 prev_norm=""
+prev_count=""
 for ((i = 1; i <= N; i++)); do
   pcb="${OUT_DIR}/run-${i}.kicad_pcb"
   log="${OUT_DIR}/run-${i}.log"
@@ -183,8 +214,16 @@ for ((i = 1; i <= N; i++)); do
   fi
 
   normalize_copper "${pcb}" >"${norm}"
-  echo "  Elapsed:     $((end_s - start_s))s"
+  count="$(blocking_count "${pcb}")"
+  echo "  Elapsed:      $((end_s - start_s))s"
   echo "  Copper lines: $(wc -l <"${norm}")"
+  echo "  Blocking nets: ${count:-<analysis failed>}"
+
+  if [[ -z "${count}" ]]; then
+    echo "FAIL: run ${i} blocking-net analysis failed (NetStatusAnalyzer)." >&2
+    echo "      See ${log} for the route log." >&2
+    exit 2
+  fi
 
   if [[ -n "${prev_norm}" ]]; then
     if ! diff -q "${prev_norm}" "${norm}" >/dev/null; then
@@ -198,9 +237,24 @@ for ((i = 1; i <= N; i++)); do
       echo "      PCBs preserved in ${OUT_DIR} for post-mortem."
       exit 3
     fi
+    # Issue #3894: extend the determinism contract from copper to the
+    # blocking COUNT.  (Within one run/machine this is implied by the copper
+    # diff above; the explicit assertion documents the metric and guards
+    # against a future change that varies the count without varying copper.)
+    if [[ "${count}" != "${prev_count}" ]]; then
+      echo
+      echo "FAIL: run ${i} blocking-net COUNT (${count}) differs from the"
+      echo "      prior run (${prev_count}).  Same board + deterministic"
+      echo "      budget produced a DIFFERENT blocking count -- the count-"
+      echo "      determinism guarantee regressed (Issue #3894)."
+      echo "      PCBs preserved in ${OUT_DIR} for post-mortem."
+      exit 3
+    fi
   fi
   prev_norm="${norm}"
+  prev_count="${count}"
 done
 
 echo
-echo "PASS: board ${BOARD} routed byte-identical copper across ${N} runs."
+echo "PASS: board ${BOARD} routed byte-identical copper AND a stable"
+echo "      blocking-net count (${prev_count}) across ${N} runs."

--- a/scripts/ci/board_route_determinism_smoke.sh
+++ b/scripts/ci/board_route_determinism_smoke.sh
@@ -7,8 +7,8 @@
 # ``PYTHONHASHSEED=42`` -- and asserts that the UUID-normalized routed
 # COPPER (the ``(segment ...)`` / ``(via ...)`` / ``(arc ...)`` set) is
 # byte-identical across every run AND that the blocking-incomplete-net
-# COUNT (NetStatusAnalyzer.blocking_incomplete_count -- the metric the
-# board-05 CI gate enforces) is identical across every run (Issue #3894).
+# COUNT (NetStatusAnalyzer.blocking_incomplete_count -- the same metric the
+# board CI gates enforce) is identical across every run (Issue #3894).
 #
 # WHY this exists (Issue #3799 root cause):
 #   ``--seed`` only seeds Python's global ``random``.  It does NOT control
@@ -26,20 +26,23 @@
 # Examples:
 #   ./scripts/ci/board_route_determinism_smoke.sh 02        # 2 runs
 #   ./scripts/ci/board_route_determinism_smoke.sh 04 3      # 3 runs
-#   ./scripts/ci/board_route_determinism_smoke.sh 05        # 2 runs
 #
 # Supported boards: 02 (charlieplex-led), 03 (usb-joystick),
-# 04 (stm32-devboard), 05 (bldc-motor-controller).  Each board's flag set
-# mirrors the ``kct route`` argv in its
-# ``boards/<dir>/{generate_,}design.py:route_pcb()``.  KEEP THE FLAG LISTS
-# BELOW IN SYNC with the recipes.
+# 04 (stm32-devboard).  Each board's flag set mirrors the ``kct route`` argv
+# in its ``boards/<dir>/{generate_,}design.py:route_pcb()``.  KEEP THE FLAG
+# LISTS BELOW IN SYNC with the recipes.
 #
-# NOTE (issue #3887): board 05 IS now covered.  Its main pass was migrated from
-# the load-sensitive wall-clock ``--per-net-timeout 60`` cutoff to a fixed
-# per-net ITERATION budget (``--deterministic-budget --per-net-iterations
-# 200000``), so a route-twice-identical-copper check is now meaningful and the
-# dense BLDC re-route terminates within the CI job limit.  This re-adds the
-# board-05 case that #3880/PR #3886 had deferred.
+# NOTE (issue #3894): board 05 is NOT covered by this strict route-twice
+# determinism gate.  #3887 briefly added a board-05 case on a deterministic
+# per-net ITERATION budget, but #3894 REVERTED board 05 to its pre-#3887
+# wall-clock recipe (``--per-net-timeout 60``): the iteration budget did less
+# total routing work than the wall-clock outer rip-up/reroute loop and
+# REGRESSED reach (12-15 blocking vs the historical 9-10), and was never
+# actually byte-deterministic.  Board 05's wall-clock re-route is inherently
+# nondeterministic run-to-run, so it would FAIL this strict copper/count
+# assertion; genuine board-05 routing determinism is deferred to
+# #3775 / #3766 / #3829.  The count-stability assertion below still guards
+# the boards that ARE deterministic (02/03/04).
 
 set -euo pipefail
 
@@ -47,7 +50,7 @@ BOARD="${1:-}"
 N="${2:-2}"
 
 if [[ -z "${BOARD}" ]]; then
-  echo "ERROR: board number required (02, 03, 04, or 05)" >&2
+  echo "ERROR: board number required (02, 03, or 04)" >&2
   echo "Usage: $0 <board-number> [runs]" >&2
   exit 1
 fi
@@ -98,36 +101,10 @@ case "${BOARD}" in
       --timeout 600
     )
     ;;
-  05)
-    # Issue #3887: mirrors boards/05-bldc-motor-controller/design.py:route_pcb()
-    # (note: board 05's recipe file is design.py, not generate_design.py).  The
-    # board-05-tuned --per-net-iterations 200000 is the deterministic per-net
-    # cap (_BOARD_05_PER_NET_ITERATIONS) that keeps the dense BLDC re-route both
-    # reproducible AND terminating within the 90-min CI job limit; KEEP IT IN
-    # SYNC with the recipe.  Seed 7 (not 42) per the recipe's measured best.
-    # Issue #3894: --timeout is 0 (DISABLED) to mirror the recipe.  A finite
-    # outer wall-clock cap (was 900 s) fired under CI load and truncated the
-    # deterministic iteration-bounded route to a machine-DEPENDENT completed-
-    # net set; 0 makes the --per-net-iterations budget the sole terminator so
-    # the routed copper AND its blocking count are reproducible across runs.
-    BOARD_DIR="boards/05-bldc-motor-controller"
-    STEM="bldc_controller"
-    ROUTE_FLAGS=(
-      --auto-layers
-      --starting-layers 4
-      --max-layers 4
-      --manufacturer jlcpcb-tier1
-      --micro-via-in-pad-fallback
-      --backend cpp
-      --seed 7
-      --deterministic-budget
-      --per-net-iterations 200000
-      --timeout 0
-      --skip-nets "+24V,+5V,+3V3,GND,PHASE_A,PHASE_B,PHASE_C"
-    )
-    ;;
   *)
-    echo "ERROR: unsupported board '${BOARD}' (supported: 02, 03, 04, 05)" >&2
+    echo "ERROR: unsupported board '${BOARD}' (supported: 02, 03, 04)" >&2
+    echo "       Board 05 is intentionally excluded (Issue #3894): its" >&2
+    echo "       wall-clock re-route is nondeterministic run-to-run." >&2
     exit 1
     ;;
 esac
@@ -168,15 +145,15 @@ normalize_copper() {
 }
 
 # Issue #3894: blocking-incomplete-net count for a routed PCB, via the same
-# NetStatusAnalyzer metric the board-05 CI gate (scripts/ci/check_board_05_
-# blocking.py) and the DRC gate use.  The determinism contract is extended
-# from "byte-identical copper" to "identical blocking COUNT": the board-05
-# flake (#3894) was a run-to-run *count* change (12 vs <=11) caused by a
-# load-sensitive outer wall-clock cap truncating the route, NOT a copper-set
-# bug the copper diff could catch.  Asserting a stable count here makes a
-# future reintroduction of count variance fail loudly.  Prints just the
-# integer on stdout (empty on analysis failure, which the caller treats as
-# a tool error).
+# NetStatusAnalyzer.blocking_incomplete_count metric the board CI gates and
+# the DRC gate enforce.  The determinism contract is extended from "byte-
+# identical copper" to "identical blocking COUNT": the count is the metric the
+# gates actually enforce, so asserting it is stable run-to-run guards against a
+# regression that varies the count even when copper looks similar.  This guards
+# the deterministic boards (02/03/04); board 05 is intentionally NOT run here
+# because its wall-clock recipe is nondeterministic (see the case block /
+# header note).  Prints just the integer on stdout (empty on analysis failure,
+# which the caller treats as a tool error).
 blocking_count() {
   uv run python - "$1" <<'PY' 2>/dev/null || true
 import sys

--- a/scripts/ci/check_board_05_blocking.py
+++ b/scripts/ci/check_board_05_blocking.py
@@ -87,28 +87,22 @@ from pathlib import Path
 # which this should be tightened back toward 7 then 0 -- tracked in
 # #3775 / #3766 / #3829.
 #
-# Issue #3887: board-05's re-route IS now deterministic (the main pass +
-# rescue loop moved from the wall-clock --per-net-timeout cutoff to a fixed
-# per-net ITERATION budget; see boards/05-bldc-motor-controller/design.py
-# _BOARD_05_PER_NET_ITERATIONS). The threshold INTENTIONALLY stays at 11 in
-# this PR: per #3822 the deterministic blocking_incomplete_count is CI-
-# authoritative (the macOS host routes fewer nets than the Linux CI runner),
-# so the tightened bound must be read off a green board-05-routing-regression
-# run and is deferred to that measured follow-up rather than guessed here.
+# Issue #3887 (SUPERSEDED by #3894): #3887 moved board-05's main pass + rescue
+# loop from the wall-clock --per-net-timeout cutoff to a fixed per-net
+# ITERATION budget, claiming determinism. That claim did not hold up on CI.
 #
-# Issue #3894: #3887's determinism was INCOMPLETE -- it made the per-net
-# budget deterministic but left the OUTER wall-clock caps (--timeout 900 on
-# the main pass, stage_timeout_s 300 on the rescue loop) in place. Those caps
-# FIRED under CI runner load and truncated the otherwise-deterministic route,
-# so the blocking count varied run-to-run (observed 12 vs <=11 on a byte-
-# identical recipe). #3894 disables both outer caps (--timeout 0 == unbounded;
-# the iteration budget is the sole terminator), so the completed-net set --
-# hence this count -- is now machine-independent. The threshold STILL stays at
-# 11 here: per #3822 the true deterministic floor must be read off two
-# consecutive green board-05-routing-regression runs (the un-truncated route
-# is expected to land back at the historical 9-10 floor, comfortably <=11),
-# and tightening 11 -> that measured value is a deliberate follow-up, NOT a
-# locally-guessed number.
+# Issue #3894: REVERTED #3887's deterministic per-net ITERATION budget on
+# board 05 back to the pre-#3887 wall-clock recipe (--per-net-timeout 60 /
+# --timeout 900). #3887's budget did LESS total routing work than the
+# wall-clock outer rip-up/reroute loop, so it completed FEWER nets and
+# REGRESSED this count to 12-15 (vs the historical wall-clock 9-10); the
+# byte-determinism it promised was also never actually achieved on CI.
+# Restoring the wall-clock recipe returns board 05 to its known-GREEN state
+# (<=11). The threshold STAYS at 11: the wall-clock re-route is nondeterministic
+# run-to-run (~9-10), and per #3822 the CI-measured blocking_incomplete_count is
+# authoritative, so any tightening toward the documented target of 7 is a
+# deliberate follow-up gated on a genuine board-05 determinism fix
+# (#3775 / #3766 / #3829), NOT a locally-guessed number.
 DEFAULT_MAX_BLOCKING = 11
 
 

--- a/scripts/ci/check_board_05_blocking.py
+++ b/scripts/ci/check_board_05_blocking.py
@@ -95,6 +95,20 @@ from pathlib import Path
 # authoritative (the macOS host routes fewer nets than the Linux CI runner),
 # so the tightened bound must be read off a green board-05-routing-regression
 # run and is deferred to that measured follow-up rather than guessed here.
+#
+# Issue #3894: #3887's determinism was INCOMPLETE -- it made the per-net
+# budget deterministic but left the OUTER wall-clock caps (--timeout 900 on
+# the main pass, stage_timeout_s 300 on the rescue loop) in place. Those caps
+# FIRED under CI runner load and truncated the otherwise-deterministic route,
+# so the blocking count varied run-to-run (observed 12 vs <=11 on a byte-
+# identical recipe). #3894 disables both outer caps (--timeout 0 == unbounded;
+# the iteration budget is the sole terminator), so the completed-net set --
+# hence this count -- is now machine-independent. The threshold STILL stays at
+# 11 here: per #3822 the true deterministic floor must be read off two
+# consecutive green board-05-routing-regression runs (the un-truncated route
+# is expected to land back at the historical 9-10 floor, comfortably <=11),
+# and tightening 11 -> that measured value is a deliberate follow-up, NOT a
+# locally-guessed number.
 DEFAULT_MAX_BLOCKING = 11
 
 


### PR DESCRIPTION
## What

Restores the board-05 routing-regression CI gate to **green on main** by reverting #3887's deterministic per-net iteration budget on board-05 back to its pre-#3887 wall-clock recipe.

Closes #3894.

## Why (the investigation)

#3887/#3892 adopted a deterministic per-net iteration budget (`--per-net-iterations 200000`) on board-05 to make the gate reproducible. It didn't work: the gate went red on main (12 blocking > 11), and an initial fix attempt in this PR (disabling the outer `--timeout 900` wall-clock cap) made it **worse** — 15 blocking in 6m51s vs 12 in ~32min. The ~5× speedup was the smoking gun: the wall-clock budget was *feeding* the outer negotiated rip-up/reroute loop the time it needs to complete nets; the 200k-per-net iteration budget alone does far less total routing work. **#3887's deterministic budget is a reach regression on board-05**, previously masked by the residual wall-clock cap.

## What shipped (the honest fallback — #3894 option 2)

- `boards/05-bldc-motor-controller/design.py`: reverted the board-05 main-pass argv and `_RESCUE_CONFIG` to the pre-#3887 wall-clock recipe (`--per-net-timeout 60` + `--timeout 900`; rescue `stage_timeout_s=300`/`per_net_timeout_s=60`) — byte-identical to the green #3886 state. Removed the unused `_BOARD_05_PER_NET_ITERATIONS`.
- `scripts/ci/board_route_determinism_smoke.sh`: removed board-05 from the strict determinism harness (its wall-clock re-route is inherently nondeterministic); **kept** this PR's useful count-stability assertion for the genuinely-deterministic boards (02/03/04).
- `--max-blocking` left at 11 (not loosened, not guess-tightened); comments updated in `check_board_05_blocking.py` and `ci.yml`.

## Result

Board-05 routing-regression gate is **green** (38m37s, ≤11 blocking); all checks pass; merge state CLEAN. This trades #3887's deterministic-but-red board-05 gate for the historically-green flaky-but-passing wall-clock recipe. **Full board-05 routing determinism remains open research** (the dense-board routing problem) — tracked in #3775/#3766/#3829; #3894 documents why it was deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)