### PR TITLE
feat(net-status): classify pour-carried nets as POUR_DISCONTINUOUS

### DIFF
--- a/src/kicad_tools/cli/net_status_cmd.py
+++ b/src/kicad_tools/cli/net_status_cmd.py
@@ -304,6 +304,7 @@ def output_why(pcb_path: Path, fmt: str) -> int:
     print(f"  ESCAPE_BLOCKED:       {counts['escape_blocked']}")
     print(f"  CONGESTION_SATURATED: {counts['congestion_saturated']}")
     print(f"  PLACEMENT_BOUND:      {counts['placement_bound']}")
+    print(f"  POUR_DISCONTINUOUS:   {counts['pour_discontinuous']}")
     print()
 
     if not result.diagnoses:
@@ -312,7 +313,12 @@ def output_why(pcb_path: Path, fmt: str) -> int:
         return 0
 
     # Group for readability, escape-blocked first (most upstream).
-    order = {"escape_blocked": 0, "congestion_saturated": 1, "placement_bound": 2}
+    order = {
+        "escape_blocked": 0,
+        "congestion_saturated": 1,
+        "placement_bound": 2,
+        "pour_discontinuous": 3,
+    }
     for diag in sorted(result.diagnoses, key=lambda d: order[d.classification_value]):
         pads = ", ".join(diag.unconnected_pads) or "(none)"
         print(f"[{diag.classification.value.upper()}] {diag.net_name}")

--- a/src/kicad_tools/router/stuck_classifier.py
+++ b/src/kicad_tools/router/stuck_classifier.py
@@ -125,6 +125,7 @@ class StuckClass(Enum):
     ESCAPE_BLOCKED = "escape_blocked"
     CONGESTION_SATURATED = "congestion_saturated"
     PLACEMENT_BOUND = "placement_bound"
+    POUR_DISCONTINUOUS = "pour_discontinuous"
 
     @property
     def description(self) -> str:
@@ -144,6 +145,11 @@ class StuckClass(Enum):
                 "congestion -- no routing order closes it. Fix: placement "
                 "nudge (M3)."
             ),
+            "pour_discontinuous": (
+                "Pour-carried net has stranded pads -- copper zone does not reach "
+                "all pads on this net. Fix: re-pour, add stitching vias, or bridge "
+                "the zone island gap."
+            ),
         }[self.value]
 
     @property
@@ -153,6 +159,7 @@ class StuckClass(Enum):
             "escape_blocked": FailureCause.PIN_ACCESS,
             "congestion_saturated": FailureCause.CONGESTION,
             "placement_bound": FailureCause.ROUTING_ORDER,
+            "pour_discontinuous": FailureCause.BLOCKED_PATH,
         }[self.value]
 
 
@@ -468,6 +475,18 @@ def classify_stuck_nets_from_pcb(
     # Map net name -> net number for richer output.
     number_by_name = {net.name: nid for nid, net in pcb.nets.items() if net.name}
 
+    # Pour-carried incomplete nets: connectivity is expected to be closed by
+    # copper fill (zone/pour), so a signal-geometry analysis would misclassify
+    # them.  Union of (a) the ML-tagged advisory set the analyzer populates and
+    # (b) zone-backed plane/power nets that are still incomplete.  These are
+    # routed to POUR_DISCONTINUOUS in the second pass below rather than dropped.
+    pour_carried_names: set[str] = set(analysis.advisory_incomplete_names)
+    pour_carried_names.update(
+        n.net_name
+        for n in analysis.nets
+        if n.net_type in ("plane", "power") and n.status == "incomplete"
+    )
+
     diagnoses: list[StuckNetDiagnosis] = []
     for net in analysis.nets:
         if net.net_name in excluded_nets:
@@ -478,6 +497,11 @@ def classify_stuck_nets_from_pcb(
             continue
         # Skip advisory (plane/pour) residuals -- not genuine signal gaps.
         if net.is_advisory_incomplete:
+            continue
+        # Signal-named nets the ML pour-net classifier tagged as pour-carried
+        # pass the guards above; route them to POUR_DISCONTINUOUS instead of
+        # letting them receive an incorrect signal-failure classification.
+        if net.net_name in pour_carried_names:
             continue
 
         net_number = number_by_name.get(net.net_name, net.net_number)
@@ -526,6 +550,34 @@ def classify_stuck_nets_from_pcb(
             dense_cluster_threshold=dense_cluster_threshold,
         )
         diagnoses.append(diag)
+
+    # Second pass: pour-carried incomplete nets.  Their connectivity is closed
+    # by copper fill, so the stranded-pad inventory comes straight from
+    # NetStatus.unconnected_pads (no zone-fill geometry analysis for this MVP --
+    # island counting is a possible follow-on).
+    for net in analysis.nets:
+        if net.net_name in excluded_nets:
+            continue
+        if net.net_name not in pour_carried_names:
+            continue
+        if net.status != "incomplete":
+            continue
+        net_number = number_by_name.get(net.net_name, net.net_number)
+        pad_names = [p.full_name for p in net.unconnected_pads]
+        layers_str = ", ".join(net.plane_layers) if net.plane_layers else "no zone definition"
+        evidence = (
+            f"pour-carried net: {net.unconnected_count} pad(s) stranded from main "
+            f"connected island (layers: {layers_str})"
+        )
+        diagnoses.append(
+            StuckNetDiagnosis(
+                net_name=net.net_name,
+                net_number=net_number,
+                classification=StuckClass.POUR_DISCONTINUOUS,
+                unconnected_pads=pad_names,
+                evidence=evidence,
+            )
+        )
 
     return StuckClassifierResult(diagnoses=diagnoses)
 

--- a/tests/router/test_stuck_classifier.py
+++ b/tests/router/test_stuck_classifier.py
@@ -220,6 +220,61 @@ class TestPlacementBound:
         assert "a part must move" in d.evidence
 
 
+def _pour_discontinuous_board() -> str:
+    """VCC (power net) is incomplete: R1.1/R1.2 connected, U1.1 stranded."""
+    return _HEADER + (
+        '  (net 0 "")\n'
+        '  (net 1 "VCC")\n'
+        '  (net 2 "SIG")\n'
+        '  (footprint "R_0402" (layer "F.Cu") (at 10 10)\n'
+        '    (property "Reference" "R1")\n'
+        '    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "VCC"))\n'
+        '    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "VCC"))\n'
+        "  )\n"
+        '  (footprint "U_SOT" (layer "F.Cu") (at 80 80)\n'
+        '    (property "Reference" "U1")\n'
+        '    (pad "1" smd circle (at 0 0) (size 0.2 0.2) (layers "F.Cu") (net 1 "VCC"))\n'
+        "  )\n"
+        # connect R1.1-R1.2 so VCC is "incomplete" (not "unrouted")
+        '  (segment (start 9.5 10) (end 10.5 10) (width 0.25) (layer "F.Cu") (net 1))\n'
+        ")\n"
+    )
+
+
+class TestPourDiscontinuous:
+    def test_power_net_stranded_pad_is_pour_discontinuous(self, tmp_path: Path):
+        p = tmp_path / "pour.kicad_pcb"
+        p.write_text(_pour_discontinuous_board())
+        result = classify_stuck_nets(p)
+        vcc = [d for d in result.diagnoses if d.net_name == "VCC"]
+        assert len(vcc) == 1
+        d = vcc[0]
+        assert d.classification is StuckClass.POUR_DISCONTINUOUS
+        assert "U1.1" in d.unconnected_pads
+        assert "pour-carried" in d.evidence
+
+    def test_pour_discontinuous_not_in_signal_diagnoses(self, tmp_path: Path):
+        """VCC must not appear under any signal failure class."""
+        p = tmp_path / "pour.kicad_pcb"
+        p.write_text(_pour_discontinuous_board())
+        result = classify_stuck_nets(p)
+        signal_classes = {
+            StuckClass.ESCAPE_BLOCKED,
+            StuckClass.CONGESTION_SATURATED,
+            StuckClass.PLACEMENT_BOUND,
+        }
+        for d in result.diagnoses:
+            if d.net_name == "VCC":
+                assert d.classification not in signal_classes
+
+    def test_counts_include_pour_discontinuous(self, tmp_path: Path):
+        p = tmp_path / "pour.kicad_pcb"
+        p.write_text(_pour_discontinuous_board())
+        result = classify_stuck_nets(p)
+        assert "pour_discontinuous" in result.counts
+        assert result.counts["pour_discontinuous"] >= 1
+
+
 class TestClassifierAggregate:
     def test_counts_and_to_dict(self, congestion_pcb: Path):
         result = classify_stuck_nets(congestion_pcb)
@@ -228,6 +283,7 @@ class TestClassifierAggregate:
             "escape_blocked",
             "congestion_saturated",
             "placement_bound",
+            "pour_discontinuous",
         }
         assert counts["congestion_saturated"] == 1
         data = result.to_dict()


### PR DESCRIPTION
## Summary

`kct net-status --why` never classified pour-carried nets — they were silently dropped or misclassified. This adds a dedicated `POUR_DISCONTINUOUS` class so pour-carried nets with stranded pads surface in `--why` output.

## Root cause

In `classify_stuck_nets_from_pcb`:
- The `net_type != "signal"` gate silently discarded zone-backed **plane/power** nets (e.g. NRST, UCC_HO_NEG) before any analysis — no `--why` entry emitted.
- `analysis.advisory_incomplete_names` (ML-tagged pour-carried **signal** nets) was never consulted, so those nets passed both guards and received an incorrect signal-failure classification.

## Change

- **`stuck_classifier.py`**: add `POUR_DISCONTINUOUS` to `StuckClass` (description + `failure_cause` → `FailureCause.BLOCKED_PATH`). Build `pour_carried_names` = `advisory_incomplete_names` ∪ incomplete plane/power nets. Guard the signal loop against that set (prevents misclassification), then a second collection pass emits POUR_DISCONTINUOUS diagnoses with stranded pads from `NetStatus.unconnected_pads` and the zone layer list. No zone-fill geometry analysis (island counting is a possible follow-on).
- **`net_status_cmd.py`**: render the new class in the `--why` text summary and detail ordering. JSON path unchanged (already generic).
- **`tests/router/test_stuck_classifier.py`**: `TestPourDiscontinuous` (3 tests) + `_pour_discontinuous_board()` fixture; updated `test_counts_and_to_dict` key set.

## Advisory interception

The curated third case — signal-named nets the ML classifier tags `is_pour_net=True` — is handled by unioning `analysis.advisory_incomplete_names` into `pour_carried_names` and adding `if net.net_name in pour_carried_names: continue` immediately after the existing `is_advisory_incomplete` guard in the signal loop. Those nets are then re-collected by the second pass under POUR_DISCONTINUOUS instead of receiving a signal-failure class.

## Tests

- `tests/router/test_stuck_classifier.py`: 9 passed (3 new)
- `tests/test_net_status_cmd.py` + `tests/test_analysis_net_status.py`: 82 passed
- `ruff check` / `ruff format`: clean on touched files
- CLI smoke test confirms `[POUR_DISCONTINUOUS] VCC` renders with stranded pad + layer list, exit code 2

Pre-existing mypy error at `net_status_cmd.py:279` (`output_json`, untouched by this PR) is out of scope.

Closes #3901

🤖 Generated with [Claude Code](https://claude.com/claude-code)