### PR TITLE
docs(boards): correct stale statuses/claims found by the 2026-07-05 fresh-build sweep

### DIFF
--- a/boards/02-charlieplex-led/README.md
+++ b/boards/02-charlieplex-led/README.md
@@ -96,9 +96,10 @@ This:
 3. Uses A* pathfinding to route connections
 4. Saves the routed result to `output/charlieplex_3x3_routed.kicad_pcb`
 
-**Note:** Due to the dense charlieplex topology, some nets may not be routable on a
-2-layer board. This is expected behavior and demonstrates real-world routing challenges.
-The autorouter successfully routes approximately 5-6 of the 8 signal nets.
+**Note:** The dense charlieplex topology was historically a routing challenge,
+but as of 2026-07-05 the negotiated router completes **all 8 signal nets**
+(plus pour-carried VCC/GND) on 2 layers in a few seconds, clean under both
+`kct check` and `kicad-cli pcb drc`.
 
 ### Step 3: View in KiCad (Optional)
 

--- a/boards/03-usb-joystick/project.kct
+++ b/boards/03-usb-joystick/project.kct
@@ -73,8 +73,8 @@ requirements:
 
   mechanical:
     dimensions:
-      width: "60mm"
-      height: "40mm"
+      width: "80mm"
+      height: "60mm"
 
   manufacturing:
     target_fab: jlcpcb

--- a/boards/04-stm32-devboard/README.md
+++ b/boards/04-stm32-devboard/README.md
@@ -96,14 +96,15 @@ connected) and has **0 blocking DRC errors** against `--mfr jlcpcb-tier1`
   #2834 / #3033 case). The MCU VSS rail still bonds to plane through the other
   stitched VSS pads.
 
-**Routed-PCB regeneration note (#3773):** a fresh end-to-end regen on current
-`main` cannot reproduce this clean routed PCB — the zone filler emits `+3.3V` /
-`+5V` F.Cu pours that are not cleared around the router's GND tracks/vias,
-producing ~30 `clearance_segment_zone` / `clearance_via_zone` shorts. This is a
-**separate regression** (reproducible from pristine `main` with the PCB net
-table unchanged, i.e. independent of the net reconciliation), tracked in
-**#3773**. Until it lands, board-04 ships the committed-good routed PCB, which
-is net-consistent with the reconciled schematic.
+**Routed-PCB regeneration note (#3773):** the zone-filler regression described
+in #3773 (~30 `clearance_*_zone` shorts on fresh regen) **no longer reproduces**
+as of the 2026-07-05 fresh-build sweep: a from-scratch `generate_design.py` run
+produced a fully routed board with copper-LVS 0 shorts / 0 opens and
+`kicad-cli pcb drc --refill-zones` reporting 0 violations. Caveats that remain:
+the recipe is run-twice non-idempotent (first run from a clean dir exits 1 via
+a constraint-sidecar interaction, second run passes — #3919) and `kct build`
+still cannot reproduce the board (#3918), so regenerate via
+`generate_design.py` directly.
 
 The 2026-05-11 audit table (router 8/9, #2695/#2696/#3075/#3080) was removed
 when those issues closed — see issue #3212 for the rationale.

--- a/boards/04-stm32-devboard/project.kct
+++ b/boards/04-stm32-devboard/project.kct
@@ -175,12 +175,12 @@ progress:
         - "[x] Crystal oscillator block"
         - "[x] Debug header"
         - "[x] User LED"
-        - "[ ] Add MCU symbol (manual step)"
-        - "[ ] Connect MCU to peripherals"
+        - "[x] Add MCU symbol"
+        - "[x] Connect MCU to peripherals"
     layout:
-      status: pending
+      status: completed
       checklist:
-        - "[ ] Component placement"
-        - "[ ] Power routing"
-        - "[ ] Signal routing"
-        - "[ ] DRC clean"
+        - "[x] Component placement"
+        - "[x] Power routing"
+        - "[x] Signal routing"
+        - "[x] DRC clean (kicad-cli 0 violations, 2026-07-05)"

--- a/boards/04-stm32-devboard/project.kct
+++ b/boards/04-stm32-devboard/project.kct
@@ -74,8 +74,8 @@ requirements:
 
   mechanical:
     dimensions:
-      width: "50mm"
-      height: "25mm"
+      width: "60mm"
+      height: "40mm"
 
   manufacturing:
     target_fab: jlcpcb
@@ -158,7 +158,7 @@ decisions:
     alternatives: ["16MHz", "12MHz"]
 
 progress:
-  phase: schematic
+  phase: layout
   phases:
     concept:
       status: completed
@@ -168,7 +168,7 @@ progress:
         - "[x] Determine debug interface (SWD)"
         - "[x] Choose crystal frequency"
     schematic:
-      status: in_progress
+      status: completed
       checklist:
         - "[x] Power input section"
         - "[x] LDO with decoupling"

--- a/boards/06-diffpair-test/project.kct
+++ b/boards/06-diffpair-test/project.kct
@@ -112,8 +112,8 @@ requirements:
 
   mechanical:
     dimensions:
-      width: "80mm"
-      height: "60mm"
+      width: "100mm"
+      height: "80mm"
 
   manufacturing:
     target_fab: jlcpcb

--- a/boards/README.md
+++ b/boards/README.md
@@ -31,9 +31,9 @@ kct build boards/01-voltage-divider --mfr jlcpcb
 | # | Board | Status | Components | Nets | Notes |
 |---|-------|--------|------------|------|-------|
 | 01 | [Voltage Divider](01-voltage-divider/) | ✅ Working | 4 | 3 | Simplest possible design, workflow validation |
-| 02 | [Charlieplex LED](02-charlieplex-led/) | ⚠️ Needs optimization | 14 | 8 | Dense topology, may need trace optimization ([#659]) |
-| 03 | [USB Joystick](03-usb-joystick/) | ⚠️ Complex routing | ~20 | 13 | Mixed signals, may not complete all routes on 2-layer |
-| 04 | [STM32 Dev Board](04-stm32-devboard/) | 🚧 Schematic only | ~30 | - | Layout pending, demonstrates programmatic schematic generation |
+| 02 | [Charlieplex LED](02-charlieplex-led/) | ✅ Working | 14 | 8 | Routes 8/8 signal nets; both DRC engines clean (verified 2026-07-05) |
+| 03 | [USB Joystick](03-usb-joystick/) | ✅ Working | ~20 | 13 | Routes 13/13 on 2-layer in ~24s; diff-pair entry regression tracked in [#3922] |
+| 04 | [STM32 Dev Board](04-stm32-devboard/) | ✅ Working | ~30 | 12 | Fully routed via `generate_design.py`; kicad-cli DRC clean (verified 2026-07-05) |
 | 06 | [Diff-Pair Test](06-diffpair-test/) | ⚠️ Scaffold | 7 | 26 | Epic [#2556] Phase 4L regression bench --- USB 2.0/3.0, PCIe, MIPI on 4-layer; exercises Phase 1-3 features (intra_pair_clearance, coupled_routing, coupled_continuity_threshold, target_diff_impedance, skew_tolerance_mm) |
 | 07 | [Match-Group Test](07-matchgroup-test/) | ⚠️ Scaffold | 8 | 33 | Epic [#2661] Phase 3L regression bench --- DDR data byte, MIPI CSI, HDMI TMDS, address bus on 4-layer; exercises Phase 1A-2G match-group features (length_match_group, length_match_reference, length_match_tolerance_mm) |
 
@@ -108,6 +108,13 @@ the `intra_pair_clearance`, `coupled_continuity_threshold`, and
 invoke the Phase A/B pipeline explicitly.  PR #3069 (board 03) and PR #3090
 (board 06) migrated to this entry after the bypass bug was diagnosed.
 
+> **⚠️ Regression ([#3922]):** the #3308/#3410 recipe consolidation silently
+> dropped `--differential-pairs` from board 03's routing recipe
+> (`generate_design.py:route_pcb()`), so board 03 currently routes its USB
+> pair through the plain per-net path again. Its clean skew today is
+> coincidental, not constructed. Do not copy board 03's recipe for a new
+> diff-pair board until [#3922] lands.
+
 ### Subprocess (`kct route`) vs. in-process (`router.route_all_*`)
 
 Both are supported.  The subprocess path (`subprocess.run(["kct", "route", ...])`)
@@ -123,9 +130,13 @@ The in-process path remains the right choice when a board needs to:
 
 - Inject custom logic between routing and post-processing (e.g. board 06's
   custom diff-pair config plumbing).
-- Exercise router internals that the CLI does not yet expose (e.g. the
-  `diffpair_config` object with non-default `intra_pair_clearance` values
-  that don't survive the JSON-roundtrip the CLI uses).
+- Exercise router internals that the CLI does not yet expose (e.g.
+  `DifferentialPairConfig.per_pair_max_iterations`,
+  `enable_shadow_construction`, or board 06's tightly-coupled width
+  re-solve). Note: per-class values like `intra_pair_clearance` **do**
+  survive the CLI's JSON sidecar round-trip (`kct route --net-class-map`,
+  #2996) — an earlier version of this section claimed otherwise; that claim
+  was verified false in the 2026-07-05 sweep.
 
 ### Architectural decision: auto-detect was rejected
 
@@ -134,9 +145,11 @@ default path) to auto-detect diff pairs and short-circuit to the
 Phase-A/B-aware entry.  The decision was to **not** auto-detect, for two
 reasons:
 
-1. The remaining footgun is procedural (new boards forget the right entry),
-   not active --- every existing diff-pair-bearing board is already wired
-   correctly as of PR #3090 (board 06 migration).
+1. The remaining footgun is procedural (new boards forget the right entry).
+   **Update 2026-07-05: the footgun bit** --- board 03 lost its
+   diff-pair-aware entry in a later recipe consolidation without anyone
+   noticing ([#3922]), exactly the failure mode auto-detect would have
+   prevented. Weigh this when re-promoting the auto-detect work.
 2. An auto-detect change would have to land on both surfaces (in-process
    and CLI) to be complete, and the `CoupledPathfinder` latency issue
    tracked in [#3089] makes a CLI-default flip premature.
@@ -153,11 +166,14 @@ These are known limitations that may affect your experience:
 
 | Issue | Affects | Description |
 |-------|---------|-------------|
-| [#659] | 02, 03 | Trace optimization may be needed for dense designs |
+| [#659] | 02, 03 | Trace optimization may be needed for dense designs (02 now routes 8/8 as of 2026-07-05) |
 | [#661] | All | Router doesn't always warn about DRC violations |
+| [#3918] | All | `kct build` currently cannot complete on any demo board — use each board's `generate_design.py`/`design.py` recipe until the orchestrator fixes land |
 
 [#659]: https://github.com/rjwalters/kicad-tools/issues/659
 [#661]: https://github.com/rjwalters/kicad-tools/issues/661
+[#3918]: https://github.com/rjwalters/kicad-tools/issues/3918
+[#3922]: https://github.com/rjwalters/kicad-tools/issues/3922
 
 ## Project Files (.kct)
 


### PR DESCRIPTION
## Summary

All 8 demo boards were rebuilt from scratch in isolated worktrees (fresh `uv sync` + `kct build-native` + wiped `output/`), dual-gated with `kct check --mfr jlcpcb` **and** `kicad-cli pcb drc --refill-zones`. The sweep filed issues #3909–#3926 for the tool friction; this PR lands only the **documentation corrections** — no code, no artifacts (artifact refresh is blocked on #3925).

### Corrections
- **Status table**: board 02 routes **8/8** (doc said "5-6 of 8"); board 03 routes **13/13 on 2-layer in ~24s** (doc said "may not complete"); board 04 is **fully routed, kicad-cli DRC clean** (doc said "schematic only / layout pending").
- **Diff-pair conventions section**: board 03 silently lost `--differential-pairs` in the #3308/#3410 consolidation (#3922) — the "footgun not active / every board wired correctly" claim is corrected with a warning box; the "intra_pair_clearance doesn't survive the CLI JSON-roundtrip" justification was **verified false** (round-trips losslessly via #2996) and replaced with the real remaining CLI gaps.
- **Board 04 README**: the #3773 zone-filler regression **no longer reproduces** (fresh regen: copper-LVS 0/0, kicad-cli 0 violations); note rewritten with the remaining caveats (#3918, #3919). `project.kct` progress promoted schematic → layout.
- **project.kct dimensions** corrected to the boards actually generated: 03: 60×40→80×60, 04: 50×25→60×40, 06: 80×60→100×80 (the build outline step logs these values; the stale ones were a footgun).
- **Known Issues table**: added #3918 (`kct build` completes on 0/8 demo boards; use per-board recipes meanwhile).

### Verification
- All three edited `project.kct` files parse (yaml.safe_load).
- Grepped tests/src for pinned old dimension strings — only synthetic fixtures match.
- Every factual claim traces to a per-board sweep report (dual-checker outputs captured in the sweep worktrees).

🤖 Generated with [Claude Code](https://claude.com/claude-code)