### PR TITLE
fix(export): block shorted-board manufacturing bundles with a DRC safety floor

### DIFF
--- a/boards/05-bldc-motor-controller/design.py
+++ b/boards/05-bldc-motor-controller/design.py
@@ -3274,9 +3274,13 @@ def generate_manufacturing(routed_path: Path, output_dir: Path) -> bool:
         "jlcpcb",
         "--output",
         str(mfr_dir),
-        # The post-route PCB has known clearance violations on this
-        # board (see M-E follow-up); allow the bundle to be produced
-        # so downstream tooling/UI sees the artifacts.
+        # 2026-07-05 (#3912): --skip-preflight skips BOM/ERC/LCSC/cosmetic
+        # checks so the bundle is produced despite this board's known
+        # *clearance* violations (see M-E follow-up).  It does NOT suppress
+        # the connectivity safety floor added in #3912 -- if the committed
+        # drc_report.json ever contains net shorts, export will still abort
+        # non-zero.  That is intentional: skipping cosmetic checks is safe;
+        # shipping a shorted board is not.
         "--skip-preflight",
     ]
     print(f"\n   Command: {' '.join(cmd)}")
@@ -3448,7 +3452,11 @@ def main() -> int:
         print(f"  Zones: {zones_created} zone(s) created, {zones_filled} filled")
         print(f"  Routing: {'SUCCESS' if route_success else 'PARTIAL'}")
         print(f"  DRC: {'PASS' if drc_success else 'FAIL'}")
-        print(f"  Manufacturing bundle: {'PASS' if mfg_success else 'FAIL'}")
+        # #3912: mfg_success reflects whether `kct export` wrote a bundle
+        # (exit 0), NOT whether the board is DRC-clean.  Board DRC status is
+        # reported separately above ("DRC: ...").  Label this line "written"
+        # to avoid implying the board passed DRC.
+        print(f"  Manufacturing bundle: {'WRITTEN' if mfg_success else 'FAILED'}")
         print("\nComponent summary:")
         print("  Power input: J1, F1, D1, C1-C2")
         print("  Buck (24V->5V): U1, L1, D2, C3-C4")

--- a/boards/07-matchgroup-test/generate_design.py
+++ b/boards/07-matchgroup-test/generate_design.py
@@ -1900,6 +1900,12 @@ def export_manufacturing_bundle(routed_path: Path, output_dir: Path) -> bool:
         str(mfg_dir),
         "--mfr",
         "jlcpcb",
+        # 2026-07-05 (#3912): --skip-preflight skips BOM/ERC/LCSC/cosmetic
+        # checks for this synthetic match-group test board.  It does NOT
+        # suppress the connectivity safety floor added in #3912 -- if a
+        # pre-existing drc_report.json next to the routed PCB contains net
+        # shorts, export still aborts non-zero.  Cosmetic-check skipping is
+        # safe here; shipping a shorted board is not.
         "--skip-preflight",
     ]
     print(f"\n   Command: {' '.join(cmd)}")
@@ -2029,7 +2035,11 @@ def main() -> int:
             print("\nResults:")
             print(f"  Routing: {'SUCCESS' if route_success else 'PARTIAL'}")
             print(f"  DRC:     {'PASS' if drc_ok else 'FAIL (see above)'}")
-            print(f"  MFG:     {'PASS' if mfg_ok else 'FAIL (see above)'}")
+            # #3912: mfg_ok means `kct export` wrote a bundle (exit 0), not
+            # that the board is DRC-clean.  Board DRC status is the "DRC:"
+            # line above.  Label "WRITTEN" so PASS is never mistaken for a
+            # DRC pass.
+            print(f"  MFG:     {'WRITTEN' if mfg_ok else 'FAILED (see above)'}")
 
             return 0 if route_success else 1
 

--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -808,6 +808,8 @@ def _run_export_command(args) -> int:
         sub_argv.append("--no-auto-lcsc")
     if getattr(args, "export_skip_preflight", False):
         sub_argv.append("--skip-preflight")
+    if getattr(args, "export_skip_drc_floor", False):
+        sub_argv.append("--skip-drc-floor")
     if getattr(args, "export_strict_preflight", False):
         sub_argv.append("--strict-preflight")
     if getattr(args, "export_skip_drc", False):

--- a/src/kicad_tools/cli/export_cmd.py
+++ b/src/kicad_tools/cli/export_cmd.py
@@ -142,7 +142,21 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--skip-preflight",
         action="store_true",
-        help="Skip all pre-flight validation checks",
+        help=(
+            "Skip BOM/ERC/LCSC/cosmetic pre-flight validation checks. Does NOT "
+            "suppress the hard connectivity safety floor (net shorts / "
+            "connectivity errors in a pre-existing DRC report still block "
+            "export). Use --skip-drc-floor to override that too."
+        ),
+    )
+    parser.add_argument(
+        "--skip-drc-floor",
+        action="store_true",
+        help=(
+            "Disable the connectivity safety floor that blocks export on net "
+            "shorts found in a pre-existing DRC report. Only for known-safe "
+            "workarounds -- shipping a shorted board is never safe."
+        ),
     )
     parser.add_argument(
         "--strict-preflight",
@@ -249,6 +263,7 @@ def run_export(args: argparse.Namespace) -> int:
         skip_all=getattr(args, "skip_preflight", False),
         skip_drc=getattr(args, "skip_drc", False),
         skip_erc=getattr(args, "skip_erc", False),
+        skip_drc_floor=getattr(args, "skip_drc_floor", False),
         drc_report_path=getattr(args, "drc_report", None),
         erc_report_path=getattr(args, "erc_report", None),
     )

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -7031,7 +7031,20 @@ def _add_export_parser(subparsers) -> None:
         "--skip-preflight",
         dest="export_skip_preflight",
         action="store_true",
-        help="Skip all pre-flight validation checks",
+        help=(
+            "Skip BOM/ERC/LCSC/cosmetic pre-flight validation checks. Does NOT "
+            "suppress the hard connectivity safety floor (net shorts). Use "
+            "--skip-drc-floor to override that too."
+        ),
+    )
+    export_parser.add_argument(
+        "--skip-drc-floor",
+        dest="export_skip_drc_floor",
+        action="store_true",
+        help=(
+            "Disable the connectivity safety floor that blocks export on net "
+            "shorts in a pre-existing DRC report. Only for known-safe workarounds."
+        ),
     )
     export_parser.add_argument(
         "--strict-preflight",

--- a/src/kicad_tools/export/manufacturing.py
+++ b/src/kicad_tools/export/manufacturing.py
@@ -481,6 +481,13 @@ class ManufacturingPackage:
         """
         preflight_cfg = self.config.preflight
         if preflight_cfg is not None and preflight_cfg.skip_drc_floor:
+            msg = (
+                "DRC connectivity safety floor DISABLED via --skip-drc-floor; "
+                "export will proceed even if the board has net shorts. "
+                "This is unsafe unless you have independently verified the board."
+            )
+            logger.warning(msg)
+            result.warnings.append(msg)
             return
 
         # Resolve the report path: explicit config path wins, else look for a
@@ -500,6 +507,19 @@ class ManufacturingPackage:
 
         if report_path is None:
             return
+
+        # Surface a stale-report note: if the resolved DRC report predates the
+        # PCB, its verdict may not reflect the current board. The floor still
+        # blocks on a stale FAIL (staleness in the blocking direction is the
+        # safe side); this warning just explains a potentially spurious block.
+        try:
+            if report_path.stat().st_mtime < self.pcb_path.stat().st_mtime:
+                logger.warning(
+                    f"DRC report {report_path.name} is older than the PCB; "
+                    "safety-floor verdict may be stale."
+                )
+        except OSError:
+            pass
 
         try:
             from ..drc.report import DRCReport

--- a/src/kicad_tools/export/manufacturing.py
+++ b/src/kicad_tools/export/manufacturing.py
@@ -340,6 +340,17 @@ class ManufacturingPackage:
         if dry_run:
             return self._dry_run(out_dir, result)
 
+        # Step 0-floor: Connectivity safety floor.  Read any pre-existing DRC
+        # report for hard shorts / connectivity errors *regardless* of
+        # skip_preflight (skip_all).  Shipping a shorted board is never safe,
+        # so this hard gate fires even when the rest of preflight is skipped
+        # -- and it runs before any output files are written.  It performs no
+        # kicad-cli invocation (it only parses a report already on disk), so
+        # it adds no dependency and cannot slow a clean board's export.
+        self._check_drc_safety_floor(result)
+        if not result.success:
+            return result
+
         # Pre-construct the assembly package so we surface fatal input
         # errors (e.g. a schematic-sourced BOM with no discoverable
         # .kicad_sch) *before* preflight runs or we create any output
@@ -447,6 +458,77 @@ class ManufacturingPackage:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    def _check_drc_safety_floor(self, result: ManufacturingResult) -> None:
+        """Hard-abort export on net shorts / connectivity errors.
+
+        Reads any pre-existing DRC report next to the source PCB (or the
+        explicit ``drc_report_path`` from the preflight config) and appends
+        an error to ``result`` when it contains SHORTING_ITEMS or other
+        connectivity-error violations.  Because ``ManufacturingResult.success``
+        is ``len(errors) == 0``, appending an error causes ``export()`` to
+        return a non-success result and skip writing output files.
+
+        This gate runs even when ``preflight.skip_all`` (``--skip-preflight``)
+        is True -- that flag skips BOM/ERC/LCSC/cosmetic checks but must not
+        suppress the hard safety floor.  The only way to bypass it is the
+        explicit ``skip_drc_floor`` escape hatch (``--skip-drc-floor``), for
+        known-safe workarounds.
+
+        No kicad-cli is invoked; if no report exists, or it cannot be parsed,
+        the floor does nothing (prefer a false-negative over breaking boards
+        that never ran kicad-cli DRC).
+        """
+        preflight_cfg = self.config.preflight
+        if preflight_cfg is not None and preflight_cfg.skip_drc_floor:
+            return
+
+        # Resolve the report path: explicit config path wins, else look for a
+        # report sitting next to the source PCB (JSON preferred over text).
+        report_path: Path | None = None
+        explicit = preflight_cfg.drc_report_path if preflight_cfg else None
+        if explicit is not None:
+            candidate = Path(explicit)
+            if candidate.exists():
+                report_path = candidate
+        else:
+            for name in ("drc_report.json", "drc_report.txt"):
+                candidate = self.pcb_path.parent / name
+                if candidate.exists():
+                    report_path = candidate
+                    break
+
+        if report_path is None:
+            return
+
+        try:
+            from ..drc.report import DRCReport
+            from ..drc.violation import ViolationType
+
+            report = DRCReport.load(report_path)
+            connectivity_errors = [
+                v
+                for v in report.errors
+                if v.type in (ViolationType.SHORTING_ITEMS, ViolationType.UNCONNECTED_ITEMS)
+            ]
+        except Exception as e:
+            # If we can't read the report, don't block -- prefer a
+            # false-negative over breaking boards that never ran DRC.
+            logger.warning(f"DRC safety floor could not read {report_path}: {e}")
+            return
+
+        if connectivity_errors:
+            short_count = sum(
+                1 for v in connectivity_errors if v.type == ViolationType.SHORTING_ITEMS
+            )
+            msg = (
+                f"Safety floor: {len(connectivity_errors)} connectivity error(s) "
+                f"({short_count} net short(s)) in DRC report ({report_path.name}); "
+                "export blocked. Fix the shorts, or pass --skip-drc-floor to "
+                "override (only for known-safe workarounds)."
+            )
+            result.errors.append(msg)
+            logger.error(msg)
 
     def _run_preflight(self) -> list[PreflightResult]:
         """Run pre-flight validation checks."""

--- a/src/kicad_tools/export/preflight.py
+++ b/src/kicad_tools/export/preflight.py
@@ -59,6 +59,14 @@ class PreflightConfig:
     skip_drc: bool = False
     skip_erc: bool = False
 
+    # When True, disables the connectivity safety floor -- the hard abort on
+    # net shorts / connectivity errors read from a pre-existing DRC report
+    # that fires even when ``skip_all`` is set.  This is an explicit escape
+    # hatch for extraordinary, known-safe workarounds; it should almost never
+    # be used because shipping a shorted board is not safe.  See
+    # ``ManufacturingPackage._check_drc_safety_floor``.
+    skip_drc_floor: bool = False
+
     # Paths to pre-existing report files (avoids re-running kicad-cli)
     drc_report_path: str | Path | None = None
     erc_report_path: str | Path | None = None

--- a/tests/test_export_cmd.py
+++ b/tests/test_export_cmd.py
@@ -836,3 +836,159 @@ class TestExportCmdSchematicAutoDiscovery:
             ]
         )
         assert rc == 0
+
+
+class TestExportDRCSafetyFloor:
+    """CLI-level tests for the connectivity safety floor (#3912)."""
+
+    @staticmethod
+    def _patch_assembly(monkeypatch):
+        from kicad_tools.export import assembly
+
+        def fake_export(self, output_dir=None):
+            od = Path(output_dir) if output_dir else self.config.output_dir
+            od.mkdir(parents=True, exist_ok=True)
+            bom_path = od / "bom_jlcpcb.csv"
+            bom_path.write_text("Comment,Designator,Footprint,LCSC Part #\n")
+            return assembly.AssemblyPackageResult(output_dir=od, bom_path=bom_path)
+
+        monkeypatch.setattr(assembly.AssemblyPackage, "export", fake_export)
+
+    @staticmethod
+    def _write_shorting_drc_report(path: Path) -> None:
+        import json
+
+        path.write_text(
+            json.dumps(
+                {
+                    "file": "board.kicad_pcb",
+                    "manufacturer": "jlcpcb",
+                    "summary": {"errors": 1, "warnings": 0, "passed": False},
+                    "violations": [
+                        {
+                            "rule_id": "shorting_items",
+                            "severity": "error",
+                            "message": "Two items share a net (GND / PHASE_A)",
+                            "items": ["Track [GND]", "Track [PHASE_A]"],
+                        }
+                    ],
+                }
+            )
+        )
+
+    def test_skip_preflight_blocks_on_drc_shorts(self, tmp_path, monkeypatch):
+        """`kct export --skip-preflight` on a shorted board must return 1."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        pcb = project_dir / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+        (project_dir / "board.kicad_sch").write_text("(kicad_sch)")
+        self._write_shorting_drc_report(project_dir / "drc_report.json")
+
+        self._patch_assembly(monkeypatch)
+
+        out_dir = tmp_path / "manufacturing"
+        rc = export_main(
+            [
+                str(pcb),
+                "--mfr",
+                "jlcpcb",
+                "-o",
+                str(out_dir),
+                "--no-report",
+                "--skip-preflight",
+            ]
+        )
+
+        assert rc == 1, "Export must exit non-zero on net shorts"
+        # No manifest should have been written -- export aborted before assembly.
+        assert not (out_dir / "manifest.json").exists()
+
+    def test_skip_drc_floor_allows_shorted_export(self, tmp_path, monkeypatch):
+        """`--skip-drc-floor` bypasses the floor and exits 0 (escape hatch)."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        pcb = project_dir / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+        (project_dir / "board.kicad_sch").write_text("(kicad_sch)")
+        self._write_shorting_drc_report(project_dir / "drc_report.json")
+
+        self._patch_assembly(monkeypatch)
+
+        out_dir = tmp_path / "manufacturing"
+        rc = export_main(
+            [
+                str(pcb),
+                "--mfr",
+                "jlcpcb",
+                "-o",
+                str(out_dir),
+                "--no-report",
+                "--skip-preflight",
+                "--skip-drc-floor",
+            ]
+        )
+
+        assert rc == 0, "Escape hatch should allow export despite shorts"
+        assert (out_dir / "manifest.json").exists()
+
+    def test_skip_preflight_clean_board_still_exports(self, tmp_path, monkeypatch):
+        """`--skip-preflight` on a board with no DRC report exits 0 (no regression)."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        pcb = project_dir / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+        (project_dir / "board.kicad_sch").write_text("(kicad_sch)")
+        # No drc_report.json -- floor is a no-op.
+
+        self._patch_assembly(monkeypatch)
+
+        out_dir = tmp_path / "manufacturing"
+        rc = export_main(
+            [
+                str(pcb),
+                "--mfr",
+                "jlcpcb",
+                "-o",
+                str(out_dir),
+                "--no-report",
+                "--skip-preflight",
+            ]
+        )
+
+        assert rc == 0
+        assert (out_dir / "manifest.json").exists()
+
+    def test_parser_skip_drc_floor_flag(self):
+        """--skip-drc-floor parses to export_skip_drc_floor=True."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["export", "board.kicad_pcb", "--skip-drc-floor"])
+        assert args.export_skip_drc_floor is True
+
+    def test_parser_skip_drc_floor_default_false(self):
+        """--skip-drc-floor defaults to False."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["export", "board.kicad_pcb"])
+        assert args.export_skip_drc_floor is False
+
+    def test_dispatch_forwards_skip_drc_floor(self, tmp_path, monkeypatch):
+        """--skip-drc-floor should be forwarded through dispatch to export_cmd."""
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+
+        captured = {}
+
+        def spy_main(argv=None):
+            captured["argv"] = argv
+            return 0
+
+        monkeypatch.setattr("kicad_tools.cli.export_cmd.main", spy_main)
+
+        from kicad_tools.cli import main as cli_main
+
+        cli_main(["export", str(pcb), "--skip-drc-floor"])
+        assert "--skip-drc-floor" in captured["argv"]

--- a/tests/test_manufacturing_package.py
+++ b/tests/test_manufacturing_package.py
@@ -1,6 +1,7 @@
 """Tests for the manufacturing package generator."""
 
 import json
+import logging
 import zipfile
 from pathlib import Path
 
@@ -1396,8 +1397,8 @@ class TestDRCSafetyFloor:
         assert not result.success
         assert any("short" in e.lower() for e in result.errors), result.errors
 
-    def test_skip_drc_floor_overrides_safety_floor(self, tmp_path, monkeypatch):
-        """The explicit --skip-drc-floor escape hatch bypasses the floor."""
+    def test_skip_drc_floor_overrides_safety_floor(self, tmp_path, monkeypatch, caplog):
+        """The explicit --skip-drc-floor escape hatch bypasses the floor -- loudly."""
         project_dir = tmp_path / "project"
         project_dir.mkdir()
         pcb = project_dir / "board.kicad_pcb"
@@ -1415,11 +1416,62 @@ class TestDRCSafetyFloor:
             preflight=PreflightConfig(skip_all=True, skip_drc_floor=True),
         )
         pkg = ManufacturingPackage(pcb_path=pcb, manufacturer="jlcpcb", config=config)
-        result = pkg.export(tmp_path / "out")
+        with caplog.at_level(logging.WARNING, logger="kicad_tools.export.manufacturing"):
+            result = pkg.export(tmp_path / "out")
 
         # With the escape hatch, the floor does not fire and assembly runs.
         assert assembly_called["value"], "Assembly should run when floor is skipped"
         assert result.success, f"Unexpected errors: {result.errors}"
+
+        # Bypassing the floor must leave a loud audit trail: both a logged
+        # warning and a result.warnings entry (surfaced in export output).
+        assert any(
+            "--skip-drc-floor" in rec.getMessage() and rec.levelno == logging.WARNING
+            for rec in caplog.records
+        ), "Expected a logger.warning when the floor is bypassed"
+        assert any("--skip-drc-floor" in w for w in result.warnings), (
+            f"Expected a result.warnings entry; got {result.warnings}"
+        )
+
+    def test_stale_drc_report_emits_warning(self, tmp_path, monkeypatch, caplog):
+        """A DRC report older than the PCB emits a one-line stale-mtime warning.
+
+        The floor still blocks on the stale FAIL (staleness in the blocking
+        direction is the safe side); the warning just explains the block.
+        """
+        import os
+
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        pcb = project_dir / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+        (project_dir / "board.kicad_sch").write_text("(kicad_sch)")
+        report = project_dir / "drc_report.json"
+        self._write_shorting_drc_report(report)
+
+        # Make the report older than the PCB.
+        pcb_mtime = pcb.stat().st_mtime
+        os.utime(report, (pcb_mtime - 100, pcb_mtime - 100))
+
+        self._patch_assembly(monkeypatch)
+
+        config = ManufacturingConfig(
+            include_report=False,
+            include_project_zip=False,
+            include_manifest=False,
+            include_readme=False,
+            preflight=PreflightConfig(skip_all=True),
+        )
+        pkg = ManufacturingPackage(pcb_path=pcb, manufacturer="jlcpcb", config=config)
+        with caplog.at_level(logging.WARNING, logger="kicad_tools.export.manufacturing"):
+            result = pkg.export(tmp_path / "out")
+
+        # Still blocks (stale FAIL is the safe side).
+        assert not result.success
+        # And warns that the verdict may be stale.
+        assert any("older than the PCB" in rec.getMessage() for rec in caplog.records), (
+            "Expected a stale-mtime warning when the report predates the PCB"
+        )
 
     def test_clean_drc_report_does_not_block(self, tmp_path, monkeypatch):
         """A clean pre-existing DRC report must not block export (no regression)."""

--- a/tests/test_manufacturing_package.py
+++ b/tests/test_manufacturing_package.py
@@ -1293,3 +1293,178 @@ class TestTHTHandSolderDocumentation:
             assembly_result=AssemblyPackageResult(output_dir=tmp_path),
         )
         assert ManufacturingPackage._tht_component_groups(empty) == []
+
+
+class TestDRCSafetyFloor:
+    """Tests for the connectivity safety floor (#3912).
+
+    Shipping a shorted board is never safe, so a pre-existing DRC report
+    containing SHORTING_ITEMS (or other connectivity errors) must block
+    export even when preflight is fully skipped (``skip_all=True``).
+    """
+
+    @staticmethod
+    def _write_shorting_drc_report(path: Path) -> None:
+        """Write a kct-check-format DRC report with one net short."""
+        report = {
+            "file": "board.kicad_pcb",
+            "manufacturer": "jlcpcb",
+            "summary": {"errors": 1, "warnings": 0, "passed": False},
+            "violations": [
+                {
+                    "rule_id": "shorting_items",
+                    "severity": "error",
+                    "message": "Two items share a net (net GND / net PHASE_A)",
+                    "items": ["Track [GND]", "Track [PHASE_A]"],
+                }
+            ],
+        }
+        path.write_text(json.dumps(report))
+
+    @staticmethod
+    def _write_clean_drc_report(path: Path) -> None:
+        """Write a kct-check-format DRC report with no errors."""
+        report = {
+            "file": "board.kicad_pcb",
+            "manufacturer": "jlcpcb",
+            "summary": {"errors": 0, "warnings": 0, "passed": True},
+            "violations": [],
+        }
+        path.write_text(json.dumps(report))
+
+    def _patch_assembly(self, monkeypatch):
+        from kicad_tools.export import assembly
+
+        called = {"value": False}
+
+        def fake_assembly_export(self, output_dir=None):
+            called["value"] = True
+            od = Path(output_dir) if output_dir else self.config.output_dir
+            od.mkdir(parents=True, exist_ok=True)
+            bom_path = od / "bom_jlcpcb.csv"
+            bom_path.write_text("Comment,Designator,Footprint,LCSC Part #\n")
+            return assembly.AssemblyPackageResult(output_dir=od, bom_path=bom_path)
+
+        monkeypatch.setattr(assembly.AssemblyPackage, "export", fake_assembly_export)
+        return called
+
+    def test_skip_preflight_does_not_suppress_shorts(self, tmp_path, monkeypatch):
+        """skip_all=True must NOT suppress the safety floor on net shorts."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        pcb = project_dir / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+        (project_dir / "board.kicad_sch").write_text("(kicad_sch)")
+        # Pre-existing DRC report next to the PCB, containing a short.
+        self._write_shorting_drc_report(project_dir / "drc_report.json")
+
+        assembly_called = self._patch_assembly(monkeypatch)
+
+        config = ManufacturingConfig(
+            include_report=False,
+            include_project_zip=False,
+            preflight=PreflightConfig(skip_all=True),
+        )
+        pkg = ManufacturingPackage(pcb_path=pcb, manufacturer="jlcpcb", config=config)
+        result = pkg.export(tmp_path / "out")
+
+        # Export must fail and must not have written any assembly artifacts.
+        assert not result.success, "Safety floor should block export on shorts"
+        assert any("short" in e.lower() for e in result.errors), result.errors
+        assert not assembly_called["value"], "Assembly must not run when floor blocks"
+
+    def test_safety_floor_reads_explicit_report_path(self, tmp_path, monkeypatch):
+        """An explicit drc_report_path with shorts also blocks export."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        pcb = project_dir / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+        (project_dir / "board.kicad_sch").write_text("(kicad_sch)")
+        report_path = tmp_path / "custom_drc.json"
+        self._write_shorting_drc_report(report_path)
+
+        self._patch_assembly(monkeypatch)
+
+        config = ManufacturingConfig(
+            include_report=False,
+            include_project_zip=False,
+            preflight=PreflightConfig(skip_all=True, drc_report_path=str(report_path)),
+        )
+        pkg = ManufacturingPackage(pcb_path=pcb, manufacturer="jlcpcb", config=config)
+        result = pkg.export(tmp_path / "out")
+
+        assert not result.success
+        assert any("short" in e.lower() for e in result.errors), result.errors
+
+    def test_skip_drc_floor_overrides_safety_floor(self, tmp_path, monkeypatch):
+        """The explicit --skip-drc-floor escape hatch bypasses the floor."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        pcb = project_dir / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+        (project_dir / "board.kicad_sch").write_text("(kicad_sch)")
+        self._write_shorting_drc_report(project_dir / "drc_report.json")
+
+        assembly_called = self._patch_assembly(monkeypatch)
+
+        config = ManufacturingConfig(
+            include_report=False,
+            include_project_zip=False,
+            include_manifest=False,
+            include_readme=False,
+            preflight=PreflightConfig(skip_all=True, skip_drc_floor=True),
+        )
+        pkg = ManufacturingPackage(pcb_path=pcb, manufacturer="jlcpcb", config=config)
+        result = pkg.export(tmp_path / "out")
+
+        # With the escape hatch, the floor does not fire and assembly runs.
+        assert assembly_called["value"], "Assembly should run when floor is skipped"
+        assert result.success, f"Unexpected errors: {result.errors}"
+
+    def test_clean_drc_report_does_not_block(self, tmp_path, monkeypatch):
+        """A clean pre-existing DRC report must not block export (no regression)."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        pcb = project_dir / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+        (project_dir / "board.kicad_sch").write_text("(kicad_sch)")
+        self._write_clean_drc_report(project_dir / "drc_report.json")
+
+        assembly_called = self._patch_assembly(monkeypatch)
+
+        config = ManufacturingConfig(
+            include_report=False,
+            include_project_zip=False,
+            include_manifest=False,
+            include_readme=False,
+            preflight=PreflightConfig(skip_all=True),
+        )
+        pkg = ManufacturingPackage(pcb_path=pcb, manufacturer="jlcpcb", config=config)
+        result = pkg.export(tmp_path / "out")
+
+        assert assembly_called["value"]
+        assert result.success, f"Unexpected errors: {result.errors}"
+
+    def test_no_drc_report_does_not_block(self, tmp_path, monkeypatch):
+        """With no DRC report on disk, the floor is a no-op (no false-positive)."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        pcb = project_dir / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+        (project_dir / "board.kicad_sch").write_text("(kicad_sch)")
+        # No drc_report.json written.
+
+        assembly_called = self._patch_assembly(monkeypatch)
+
+        config = ManufacturingConfig(
+            include_report=False,
+            include_project_zip=False,
+            include_manifest=False,
+            include_readme=False,
+            preflight=PreflightConfig(skip_all=True),
+        )
+        pkg = ManufacturingPackage(pcb_path=pcb, manufacturer="jlcpcb", config=config)
+        result = pkg.export(tmp_path / "out")
+
+        assert assembly_called["value"]
+        assert result.success, f"Unexpected errors: {result.errors}"


### PR DESCRIPTION
## Summary

`kct export <board> --mfr jlcpcb --skip-preflight` produced a complete "PASS" manufacturing bundle from boards that fail DRC with net shorts. Two failure modes compounded: `PreflightConfig.skip_all=True` bypassed the entire pre-flight gate in `ManufacturingPackage.export()` (including the shorting-items check), and board recipes printed `kct export`'s exit code as "Manufacturing bundle: PASS" instead of the board's DRC status.

This PR implements the curator's recommended Option A: a connectivity **safety floor** that reads a pre-existing DRC report (no kicad-cli invocation) and hard-aborts export on net shorts regardless of `--skip-preflight`.

## Changes

- **`export/manufacturing.py`**: `_check_drc_safety_floor()` runs at the top of `export()`, before any files are written. It resolves the DRC report (explicit `drc_report_path`, else `drc_report.json`/`.txt` next to the PCB), loads it via the existing `DRCReport.load()`, and appends an error (making `result.success` False) when `SHORTING_ITEMS`/`UNCONNECTED_ITEMS` error-level violations are present. Missing/unparseable report -> no-op (prefer false-negative over breaking boards that never ran DRC).
- **`export/preflight.py`**: add `PreflightConfig.skip_drc_floor` escape hatch.
- **`cli/export_cmd.py` + `cli/parser.py` + `cli/__init__.py`**: add `--skip-drc-floor`, wire it through dispatch, and clarify `--skip-preflight` help ("skips BOM/ERC/LCSC/cosmetic checks; does NOT suppress the safety floor").
- **Board 05 & 07 recipes**: dated rationale comment scoping `--skip-preflight` to non-short DRC issues; relabel summary `"Manufacturing bundle: PASS"` -> `"WRITTEN"` so it no longer implies DRC-clean.
- **Tests**: `TestDRCSafetyFloor` (manufacturing) and `TestExportDRCSafetyFloor` (CLI).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `--skip-preflight` on a board with shorts MUST exit non-zero / not write output | ✅ | `test_skip_preflight_blocks_on_drc_shorts` (rc==1, no manifest); `test_skip_preflight_does_not_suppress_shorts` (result.success False, assembly never runs) |
| `--skip-preflight` on a DRC-clean board still exits 0 with full bundle | ✅ | `test_clean_drc_report_does_not_block`, `test_skip_preflight_clean_board_still_exports` |
| Non-`--skip-preflight` behaviour unchanged | ✅ | Existing strict/non-strict preflight tests still pass (162 passed) |
| Board 05 & 07 recipes audited (removed or dated rationale) | ✅ | Both `--skip-preflight` sites carry a 2026-07-05 (#3912) comment scoping them to clearance, not shorts |
| "Manufacturing bundle: PASS" reflects DRC status OR is rephrased | ✅ | Relabeled to "WRITTEN"/"FAILED" with clarifying comment in both recipes |
| New test: `export()` with `skip_all=True` + shorted report -> non-success | ✅ | `TestDRCSafetyFloor::test_skip_preflight_does_not_suppress_shorts` |

## Test Plan

- `pytest tests/test_manufacturing_package.py tests/test_export_cmd.py tests/test_preflight.py` -> 162 passed.
- `ruff check` / `ruff format --check` clean on all changed files.
- `mypy` introduces no new errors (14 pre-existing errors identical to main baseline).
- Board recipes `py_compile` clean.

Scope note: #3926 (LCSC preflight warning ordering) is intentionally left untouched.

Closes #3912