### PR TITLE
fix(stitch): reject connectivity-fallback vias that graze foreign pour

### DIFF
--- a/src/kicad_tools/cli/build_cmd.py
+++ b/src/kicad_tools/cli/build_cmd.py
@@ -1699,6 +1699,20 @@ def _run_step_stitch(ctx: BuildContext, console: Console) -> BuildResult:
     added = len(result.vias_added)
     already = result.already_connected
     skipped = len(result.pads_skipped)
+    fallback = len(result.connectivity_fallback)
+
+    # Issue #3910: connectivity fallbacks that graze FOREIGN pour copper are
+    # now rejected inside run_stitch (they short across nets once zones
+    # re-fill), so a remaining non-empty connectivity_fallback list is only a
+    # marginal graze against sibling stitch geometry (#3633), not a short.
+    # Surface it as a visible warning so the operator can inspect the board.
+    if fallback and not ctx.quiet:
+        console.print(
+            f"  [yellow]warning:[/yellow] {fallback} pour pad(s) used the "
+            "connectivity fallback (marginal cross-net graze against sibling "
+            "stitch geometry; run `kicad-cli pcb drc --refill-zones` to "
+            "confirm no shorts)"
+        )
 
     if added == 0 and already > 0:
         message = (

--- a/src/kicad_tools/cli/stitch_cmd.py
+++ b/src/kicad_tools/cli/stitch_cmd.py
@@ -2963,6 +2963,69 @@ def _check_point_filled_polygon_clearance(
     return True
 
 
+def _fallback_grazes_foreign_pour(
+    via_pos: tuple[float, float] | None,
+    dogleg_pos: tuple[float, float, float, float] | None,
+    extended_pos: tuple[float, float, list[tuple[float, float]]] | None,
+    via_size: float,
+    clearance: float,
+    other_net_filled_polygons: list[FilledPolygon],
+) -> bool:
+    """Test whether a connectivity-fallback via lands on foreign pour copper.
+
+    The connectivity fallback (issue #3633) intentionally drops just-placed
+    sibling stitch geometry from the obstacle pool so a stranded pour pad can
+    reclaim its load-bearing bridge via.  That is only safe when the sole
+    blocker was self-inflicted stitch geometry.  When the *pre-existing*
+    poured copper of a **different** net already overlaps the candidate
+    position, dropping the sibling obstacles exposes a via that physically
+    grazes the foreign fill polygon -- once KiCad re-fills zones the boundary
+    resolves against the new via and produces a genuine short (issue #3910).
+
+    This gate re-checks the committed via pad circle against
+    ``other_net_filled_polygons`` alone (foreign pour fill).  It deliberately
+    ignores sibling stitch geometry: a graze against a just-placed sibling via
+    remains grandfathered per #3633; only a graze against foreign *pour*
+    copper is rejected here.
+
+    Args:
+        via_pos: Straight-line placement ``(x, y)`` or ``None``.
+        dogleg_pos: Dog-leg placement ``(via_x, via_y, mid_x, mid_y)`` or
+            ``None``.  Only the via center ``(via_x, via_y)`` is checked.
+        extended_pos: Extended-escape placement
+            ``(via_x, via_y, waypoints)`` or ``None``.  Only the via center is
+            checked.
+        via_size: Diameter of the placed via (micro or standard).
+        clearance: Required clearance from foreign pour copper.
+        other_net_filled_polygons: Foreign-net poured zone fill polygons.
+
+    Returns:
+        True if the via pad circle overlaps a foreign pour polygon within
+        ``clearance`` (i.e. the placement must be rejected); False if the via
+        clears all foreign pour copper.
+    """
+    if extended_pos is not None:
+        via_x, via_y = extended_pos[0], extended_pos[1]
+    elif dogleg_pos is not None:
+        via_x, via_y = dogleg_pos[0], dogleg_pos[1]
+    elif via_pos is not None:
+        via_x, via_y = via_pos[0], via_pos[1]
+    else:
+        # No placement to evaluate -- nothing to reject.
+        return False
+
+    via_radius = via_size / 2.0
+    # _check_point_filled_polygon_clearance returns True when clearance is
+    # satisfied.  A graze is its negation.
+    return not _check_point_filled_polygon_clearance(
+        via_x,
+        via_y,
+        via_radius,
+        other_net_filled_polygons,
+        clearance,
+    )
+
+
 def _check_segment_filled_polygon_clearance(
     sx: float,
     sy: float,
@@ -4273,9 +4336,53 @@ def run_stitch(
                     )
                 )
                 continue
-            # Fallback succeeded: place the least-violating via anyway and log
-            # it so the marginal cross-net graze is auditable.
+            # Fallback found a candidate against pre-existing copper.
             via_pos, dogleg_pos, extended_pos, is_micro = fallback_result
+
+            # Issue #3910: the fallback deliberately drops just-placed sibling
+            # stitch geometry so a self-inflicted graze (#3633) can be
+            # rescued.  But if the candidate via lands on FOREIGN pour copper,
+            # the graze is not self-inflicted -- once KiCad re-fills zones the
+            # boundary resolves against the new via and creates a genuine
+            # cross-net short.  A stranded pad is a visible DRC ``unconnected``
+            # the operator can fix; a short silently ships a manufacturing
+            # defect.  So reject the fallback when it grazes foreign pour fill,
+            # degrading to the same skip diagnostic as a genuine obstruction.
+            fallback_via_size = micro_via_size if is_micro else via_size
+            if _fallback_grazes_foreign_pour(
+                via_pos,
+                dogleg_pos,
+                extended_pos,
+                fallback_via_size,
+                clearance,
+                other_net_filled_polys,
+            ):
+                detail = identify_nearest_obstacle(
+                    pad,
+                    fallback_via_size,
+                    clearance,
+                    existing_vias,
+                    other_net_tracks,
+                    other_net_vias,
+                    other_net_pads,
+                    other_net_filled_polys,
+                    net_map=obstacle_net_map,
+                )
+                result.skip_details.append((pad, detail))
+                result.pads_skipped.append(
+                    (
+                        pad,
+                        "connectivity fallback rejected: only reachable via "
+                        "position grazes a foreign pour fill polygon (placing "
+                        "it would short across nets once zones re-fill); pad "
+                        f"left unconnected instead (nearest obstacle: {detail.reason})",
+                    )
+                )
+                continue
+
+            # Fallback via clears foreign pour copper: place the
+            # least-violating via anyway and log it so the marginal cross-net
+            # graze (against sibling stitch geometry only) is auditable.
             result.connectivity_fallback.append(
                 (
                     pad,

--- a/tests/test_build_stitch_step.py
+++ b/tests/test_build_stitch_step.py
@@ -34,7 +34,13 @@ from kicad_tools.cli.build_cmd import (
     BuildStep,
     _run_step_stitch,
 )
-from kicad_tools.cli.stitch_cmd import find_all_plane_nets, run_stitch
+from kicad_tools.cli.stitch_cmd import (
+    PadInfo,
+    StitchResult,
+    ViaPlacement,
+    find_all_plane_nets,
+    run_stitch,
+)
 from kicad_tools.core.sexp_file import load_pcb
 
 # ---------------------------------------------------------------------------
@@ -504,6 +510,52 @@ class TestRunStepStitchBehaviour:
         assert "kct stitch" in result.message
         # File contents unchanged.
         assert four_layer_with_zones_pcb.read_text() == original_content
+
+
+class TestStitchConnectivityFallbackWarning:
+    """Issue #3910: the build step must surface a warning when the stitcher
+    reports a non-empty ``connectivity_fallback`` list.
+
+    Pour pads that grazed FOREIGN pour copper are now rejected inside
+    ``run_stitch`` (they short once zones re-fill), so a remaining
+    ``connectivity_fallback`` entry is only a marginal graze against sibling
+    stitch geometry -- but it is still worth flagging so the operator can
+    cross-check with ``kicad-cli pcb drc --refill-zones``.
+    """
+
+    def test_warns_on_connectivity_fallback(
+        self,
+        four_layer_with_zones_pcb: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys,
+    ) -> None:
+        # Force run_stitch to report one connectivity fallback.
+        pad = PadInfo("C1", "1", 2, "+3.3V", 110.0, 110.0, "F.Cu", 0.54, 0.64)
+
+        def fake_run_stitch(*args, **kwargs) -> StitchResult:  # type: ignore[no-untyped-def]
+            result = StitchResult(pcb_name="four_layer_zones", target_nets=["+3.3V"])
+            result.vias_added.append(
+                ViaPlacement(
+                    pad=pad,
+                    via_x=110.5,
+                    via_y=110.0,
+                    size=0.45,
+                    drill=0.2,
+                    layers=("F.Cu", "In2.Cu"),
+                )
+            )
+            result.connectivity_fallback.append((pad, "marginal graze"))
+            return result
+
+        monkeypatch.setattr("kicad_tools.cli.stitch_cmd.run_stitch", fake_run_stitch)
+
+        ctx = _make_ctx(pcb_file=four_layer_with_zones_pcb)
+        result = _run_step_stitch(ctx, Console())
+        assert result.success is True
+
+        out = capsys.readouterr().out
+        assert "connectivity fallback" in out.lower()
+        assert "warning" in out.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_stitch_cmd.py
+++ b/tests/test_stitch_cmd.py
@@ -15,6 +15,8 @@ from kicad_tools.cli.stitch_cmd import (
     ViaPlacement,
     ZonePolygon,
     _carve_foreign_copper_after_stitch,
+    _check_point_filled_polygon_clearance,
+    _fallback_grazes_foreign_pour,
     _is_ground_net,
     _should_use_stackup_fallback,
     calculate_dogleg_via_position,
@@ -5896,6 +5898,215 @@ class TestPourConnectivityFallback:
         assert len(plus_vias) == 3, "every stranded pour pad must get a via"
         assert len(result.connectivity_fallback) == 3
         assert all(pad.net_name == "+3.3V" for pad, _ in result.connectivity_fallback)
+
+    def test_no_committed_fallback_via_grazes_foreign_pour(self, tmp_path: Path) -> None:
+        """Issue #3910: no via recorded in ``connectivity_fallback`` may graze
+        a foreign pour fill polygon.
+
+        This is acceptance criterion #5: the fallback deliberately drops
+        just-placed sibling stitch geometry from the obstacle pool, which can
+        expose a via that lands on pre-existing FOREIGN pour copper -- once
+        KiCad re-fills zones the boundary resolves against the new via and
+        shorts the two nets.  The fix rejects any such fallback candidate
+        before it is appended, so every committed fallback via must clear all
+        foreign pour polygons.
+
+        Fixture: the board-07 sibling-graze pattern (GND stitches first and
+        boxes in each +3.3V pad's escape) plus a NET1 pour band placed where
+        the +3.3V fallback vias were probed to land (x~111.33/121.33/131.33,
+        y=110).  NET1 is not stitched, so it is pure pre-existing pour copper.
+        """
+        foreign_pour = (
+            '  (zone (net 3) (net_name "NET1") (layer "F.Cu") (uuid "zone-net1-band")\n'
+            '    (name "NET1_band")\n'
+            "    (connect_pads (clearance 0.2))\n"
+            "    (min_thickness 0.2)\n"
+            "    (fill yes)\n"
+            "    (polygon (pts (xy 111 109.5) (xy 132 109.5) (xy 132 110.5) (xy 111 110.5)))\n"
+            '    (filled_polygon (layer "F.Cu") '
+            "(pts (xy 111 109.5) (xy 132 109.5) (xy 132 110.5) (xy 111 110.5)))\n"
+            "  )\n"
+        )
+        pcb_text = STITCH_TEST_PCB.rstrip()
+        assert pcb_text.endswith(")")
+        pcb_text = pcb_text[:-1] + foreign_pour + ")\n"
+
+        pcb_file = tmp_path / "fallback_grazes_pour.kicad_pcb"
+        pcb_file.write_text(pcb_text)
+
+        result = run_stitch(
+            pcb_path=pcb_file,
+            net_names=["GND", "+3.3V"],
+            dry_run=True,
+        )
+
+        # Rebuild the foreign-pour polygon set the fallback gate consults.
+        sexp = load_pcb(pcb_file)
+        net_map = get_net_map(sexp)
+        target_nets = {num for num, name in net_map.items() if name in {"GND", "+3.3V"}}
+        foreign_polys = find_all_filled_polygons(sexp, exclude_nets=target_nets)
+        assert foreign_polys, "fixture must expose the NET1 foreign pour"
+
+        # Every via recorded as a connectivity fallback must clear the foreign
+        # pour (radius = via_size / 2), else it would short once zones re-fill.
+        for pad, _reason in result.connectivity_fallback:
+            placed = next(v for v in result.vias_added if v.pad is pad)
+            assert _check_point_filled_polygon_clearance(
+                placed.via_x,
+                placed.via_y,
+                placed.size / 2.0,
+                foreign_polys,
+                0.2,
+            ), (
+                f"connectivity-fallback via for {pad.net_name}:{pad.reference} at "
+                f"({placed.via_x:.3f}, {placed.via_y:.3f}) grazes a foreign pour"
+            )
+
+    def test_fallback_on_foreign_pour_lands_in_pads_skipped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Issue #3910 (acceptance criterion #6): when the fallback's only
+        candidate overlaps a foreign pour polygon, the pad must land in
+        ``pads_skipped``, NOT ``vias_added``.
+
+        The normal placement path can independently relocate vias, which makes
+        a pure-geometry full-PCB fixture brittle for isolating the fallback
+        branch.  To exercise exactly the fallback rejection wiring, we force
+        the placement helpers: the cross-net-augmented attempt returns ``None``
+        (no clearing placement -> fallback fires), and the un-augmented
+        fallback attempt returns a via position that sits inside the foreign
+        NET1 pour.  The fix must reject it and skip the pad.
+        """
+        import kicad_tools.cli.stitch_cmd as stitch_mod
+
+        # Fixture: one +3.3V pad plus a NET1 pour band the fallback via lands on.
+        pcb_text = (
+            '(kicad_pcb (version 20240108) (generator test) (generator_version "8.0")\n'
+            '  (general (thickness 1.6) (legacy_teardrops no)) (paper "A4")\n'
+            '  (layers (0 "F.Cu" signal) (31 "B.Cu" signal))\n'
+            "  (setup (pad_to_mask_clearance 0))\n"
+            '  (net 0 "") (net 2 "+3.3V") (net 3 "NET1")\n'
+            '  (zone (net 3) (net_name "NET1") (layer "F.Cu") (uuid "z-net1")\n'
+            '    (name "NET1_band") (connect_pads (clearance 0.2)) (min_thickness 0.2) (fill yes)\n'
+            "    (polygon (pts (xy 111 109.5) (xy 113 109.5) (xy 113 110.5) (xy 111 110.5)))\n"
+            '    (filled_polygon (layer "F.Cu") '
+            "(pts (xy 111 109.5) (xy 113 109.5) (xy 113 110.5) (xy 111 110.5)))\n"
+            "  )\n"
+            '  (footprint "Capacitor_SMD:C_0402_1005Metric" (layer "F.Cu")\n'
+            '    (uuid "00000000-0000-0000-0000-0000000000f1") (at 110 110)\n'
+            '    (property "Reference" "C1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "r-c1"))\n'
+            '    (pad "1" smd roundrect (at 0 0) (size 0.54 0.64) '
+            '(layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 2 "+3.3V"))\n'
+            "  )\n"
+            ")\n"
+        )
+        pcb_file = tmp_path / "forced_fallback.kicad_pcb"
+        pcb_file.write_text(pcb_text)
+
+        # Fallback via lands at (112.0, 110.0) -- inside the NET1 band.
+        grazing_via = (112.0, 110.0)
+
+        def fake_calc_via(pad, *, other_net_vias, **kwargs):  # type: ignore[no-untyped-def]
+            # The augmented attempt includes cross-net stitch vias; the
+            # un-augmented fallback attempt does not.  Here there is no sibling
+            # stitch geometry, so distinguish by identity is not possible --
+            # instead, fail the FIRST call (augmented) and succeed on the
+            # SECOND call (fallback).  Track via a mutable counter.
+            fake_calc_via.calls += 1  # type: ignore[attr-defined]
+            if fake_calc_via.calls == 1:  # type: ignore[attr-defined]
+                return None
+            return grazing_via
+
+        fake_calc_via.calls = 0  # type: ignore[attr-defined]
+
+        # Dog-leg / extended must also fail on the augmented attempt so the
+        # augmented _attempt_placement returns None and the fallback fires.
+        monkeypatch.setattr(stitch_mod, "calculate_via_position", fake_calc_via)
+        monkeypatch.setattr(stitch_mod, "calculate_dogleg_via_position", lambda *a, **k: None)
+        monkeypatch.setattr(stitch_mod, "calculate_extended_escape_position", lambda *a, **k: None)
+
+        result = run_stitch(
+            pcb_path=pcb_file,
+            net_names=["+3.3V"],
+            via_size=0.45,
+            drill=0.2,
+            clearance=0.2,
+            dry_run=True,
+        )
+
+        # The fallback via at (112, 110) grazes the NET1 pour -> rejected.
+        assert len(result.connectivity_fallback) == 0
+        assert len(result.vias_added) == 0, "grazing fallback via must not be placed"
+        assert len(result.pads_skipped) == 1
+        skipped_pad, reason = result.pads_skipped[0]
+        assert skipped_pad.net_name == "+3.3V"
+        assert "foreign pour" in reason
+
+    def test_fallback_grazes_foreign_pour_helper(self) -> None:
+        """Unit-level proof of the rejection predicate (issue #3910).
+
+        A via center inside a foreign pour polygon (or within clearance of its
+        edge) grazes; a via center far from the polygon clears.
+        """
+        polygon = FilledPolygon(
+            net_number=3,
+            net_name="NET1",
+            layer="F.Cu",
+            points=[(111.0, 109.5), (132.0, 109.5), (132.0, 110.5), (111.0, 110.5)],
+        )
+
+        # Via center inside the pour band -> graze (reject).
+        assert (
+            _fallback_grazes_foreign_pour(
+                via_pos=(111.33, 110.0),
+                dogleg_pos=None,
+                extended_pos=None,
+                via_size=0.45,
+                clearance=0.2,
+                other_net_filled_polygons=[polygon],
+            )
+            is True
+        )
+
+        # Dog-leg placement (via center is the first two coords) inside the
+        # band -> graze (reject).
+        assert (
+            _fallback_grazes_foreign_pour(
+                via_pos=None,
+                dogleg_pos=(121.33, 110.0, 120.0, 110.0),
+                extended_pos=None,
+                via_size=0.45,
+                clearance=0.2,
+                other_net_filled_polygons=[polygon],
+            )
+            is True
+        )
+
+        # Via center far from the pour band -> clears (accept).
+        assert (
+            _fallback_grazes_foreign_pour(
+                via_pos=(50.0, 50.0),
+                dogleg_pos=None,
+                extended_pos=None,
+                via_size=0.45,
+                clearance=0.2,
+                other_net_filled_polygons=[polygon],
+            )
+            is False
+        )
+
+        # No foreign pour at all -> nothing to reject.
+        assert (
+            _fallback_grazes_foreign_pour(
+                via_pos=(111.33, 110.0),
+                dogleg_pos=None,
+                extended_pos=None,
+                via_size=0.45,
+                clearance=0.2,
+                other_net_filled_polygons=[],
+            )
+            is False
+        )
 
     def test_non_stranded_pad_still_uses_clearing_placement(self, tmp_path: Path) -> None:
         """When a clearing placement DOES exist, the fallback must NOT fire --


### PR DESCRIPTION
## Summary

The pour-connectivity fallback (#3633) intentionally drops just-placed sibling stitch geometry from the obstacle pool so a stranded pour pad can reclaim its load-bearing bridge via. That is only safe when the sole blocker was self-inflicted stitch geometry. When the pre-existing poured copper of a **different** net already overlaps the candidate position, dropping the sibling obstacles exposes a via that lands on the foreign fill polygon — once KiCad re-fills zones the boundary resolves against the new via and produces a genuine cross-net short (#3910).

This implements the curator's **recommended Option A** (reject, don't place) as the structural fix, plus **Option C** as an interim guard (build-step warning). Option B (place-then-verify with kicad-cli) was declined per the curator's own assessment ("over-engineered for this failure mode").

## Changes

- **`stitch_cmd.py`**: New helper `_fallback_grazes_foreign_pour()` re-checks the committed fallback via pad circle (radius = `via_size / 2`) against foreign pour fill polygons only, reusing the existing `_check_point_filled_polygon_clearance`. At the fallback site in `run_stitch()`, a graze now degrades the pad to `pads_skipped` (with a descriptive reason) instead of appending to `connectivity_fallback`. The self-inflicted sibling-graze rescue #3633 was designed for is preserved — only foreign **pour** overlap is rejected.
- **`build_cmd.py`**: `_run_step_stitch` now surfaces a non-empty `result.connectivity_fallback` as a visible warning advising a `kicad-cli pcb drc --refill-zones` cross-check.
- **Tests**: helper predicate (graze/clear; straight and dog-leg), forced-fallback rejection into `pads_skipped`, the invariant that no committed fallback via grazes foreign pour, and a build-step warning test.

The pipeline shell path (`pipeline_cmd.py`) inherits the fix automatically: it invokes the same `run_stitch()` via `kct stitch`, so the rejection is entry-point agnostic. No pipeline flag was added (would be scope creep beyond the geometry fix).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Fallback via grazing a foreign pour polygon is rejected → pad recorded in `pads_skipped`, not `connectivity_fallback` | ✅ | `test_fallback_on_foreign_pour_lands_in_pads_skipped` |
| `build_cmd.py` treats non-empty `connectivity_fallback` as at least a logged warning | ✅ | `test_warns_on_connectivity_fallback` |
| Existing #3633 rescue test still passes (genuine sibling-via graze still rescued) | ✅ | `test_stranded_pour_pad_rescued_by_fallback` unchanged and green |
| No via in `connectivity_fallback` would graze a foreign pour polygon | ✅ | `test_no_committed_fallback_via_grazes_foreign_pour` |
| `StitchResult.connectivity_fallback` field retained (rejection before append) | ✅ | Field untouched; only the append is gated |

Note: acceptance criteria referencing a fresh `boards/07-matchgroup-test` build + `kicad-cli pcb drc --refill-zones` were verified structurally at the unit level (the graze rejection is proven geometrically and via forced-fallback); a full board route is the multi-minute path the curator's unit-level guidance was written to avoid.

## Test Plan

- `uv run pytest tests/test_stitch_cmd.py tests/test_build_stitch_step.py` — 268 passed
- `uv run ruff check` + `ruff format --check` on all four changed files — clean
- `uv run mypy` on both changed source files — 20 errors, identical to the pre-change baseline (zero introduced by this PR)

Closes #3910