### PR TITLE
fix(preflight): don't warn on LCSC that spec overlay will populate (#3926)

### DIFF
--- a/src/kicad_tools/export/preflight.py
+++ b/src/kicad_tools/export/preflight.py
@@ -666,6 +666,10 @@ class PreflightChecker:
         ]
 
         issues: list[str] = []
+        # Informational notes that do NOT constitute a problem (e.g. missing
+        # LCSC fields that the spec overlay will populate).  Kept separate so
+        # they never inflate the problem count or force a WARN status.
+        notes: list[str] = []
         status: Literal["OK", "WARN", "FAIL"] = "OK"
 
         if missing_fp:
@@ -680,11 +684,28 @@ class PreflightChecker:
                 status = "WARN"
 
         if missing_lcsc:
-            count = len(missing_lcsc)
             total = len([i for i in bom.items if not i.is_virtual and not i.dnp])
-            issues.append(f"{count}/{total} active item(s) missing LCSC part number")
-            if status != "FAIL":
-                status = "WARN"
+            # Preflight loads a *raw* BOM (Step 0) before the assembly
+            # pipeline applies the spec overlay (Step 1).  Items whose LCSC
+            # will be populated from the project ``.kct`` spec are not
+            # genuinely missing -- warning about them here produces a false
+            # positive (issue #3926).  Resolve which refs the spec covers and
+            # only warn about the genuinely-unresolved remainder.
+            spec_lcsc_refs = self._spec_lcsc_refs()
+            unresolved = [item for item in missing_lcsc if item.reference not in spec_lcsc_refs]
+            resolvable = len(missing_lcsc) - len(unresolved)
+
+            if unresolved:
+                msg = f"{len(unresolved)}/{total} active item(s) missing LCSC part number"
+                if resolvable:
+                    msg += f" ({resolvable} resolvable from spec)"
+                issues.append(msg)
+                if status != "FAIL":
+                    status = "WARN"
+            elif resolvable:
+                # Every missing-LCSC item is covered by the spec overlay:
+                # record an informational note instead of a false WARN.
+                notes.append(f"{resolvable} active item(s) will receive LCSC from spec overlay")
 
         if not issues:
             active_count = len([i for i in bom.items if not i.is_virtual])
@@ -692,13 +713,14 @@ class PreflightChecker:
                 name="bom_fields",
                 status="OK",
                 message=f"All {active_count} BOM items have required fields",
+                details="; ".join(notes),
             )
 
         return PreflightResult(
             name="bom_fields",
             status=status,
             message=f"BOM field issues: {len(issues)} problem(s)",
-            details="; ".join(issues),
+            details="; ".join(issues + notes),
         )
 
     def _check_bom_lcsc_values(self) -> PreflightResult:
@@ -1040,6 +1062,48 @@ class PreflightChecker:
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    def _spec_lcsc_refs(self) -> set[str]:
+        """Return references whose LCSC will be populated by the spec overlay.
+
+        Preflight (Step 0) inspects a *raw* BOM, but the assembly pipeline
+        (Step 1) applies the project ``.kct`` spec overlay before shipping
+        the BOM.  This helper mirrors the overlay's ref resolution so that
+        ``_check_bom_fields`` can tell which "missing LCSC" items will in
+        fact be filled in from the spec, and avoid a false-positive warning
+        (issue #3926).
+
+        Only references that both (a) match a spec ``bom_entries`` entry and
+        (b) carry a non-empty ``lcsc`` value in that entry are returned --
+        an entry with only an MPN does not resolve the LCSC gap.
+
+        The lookup is best-effort: if no spec file is found or it cannot be
+        parsed, an empty set is returned so the check falls back to its
+        original (warn-on-missing) behaviour.
+        """
+        try:
+            from .bom_spec_overlay import expand_ref_range, find_spec_file
+
+            spec_file = find_spec_file(self.pcb_path.parent)
+            if spec_file is None:
+                return set()
+
+            from ..spec.parser import load_spec
+
+            spec = load_spec(spec_file)
+            if not spec.bom_entries:
+                return set()
+
+            refs: set[str] = set()
+            for entry in spec.bom_entries:
+                if not entry.lcsc:
+                    continue
+                for ref in expand_ref_range(entry.ref):
+                    refs.add(ref)
+            return refs
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug("Spec LCSC resolution failed (ignoring): %s", e)
+            return set()
 
     def _load_bom(self):
         """Load and cache BOM data.

--- a/tests/test_manufacturing_package.py
+++ b/tests/test_manufacturing_package.py
@@ -1520,3 +1520,94 @@ class TestDRCSafetyFloor:
 
         assert assembly_called["value"]
         assert result.success, f"Unexpected errors: {result.errors}"
+
+
+class TestManufacturingPreflightSpecOverlay:
+    """Integration: preflight run by ManufacturingPackage must not falsely
+    warn about LCSC fields that the ``.kct`` spec overlay will populate
+    (issue #3926).
+
+    Preflight (Step 0) sees a raw BOM; the spec overlay is applied later in
+    the assembly pipeline (Step 1).  The manufacturing package must wire the
+    checker to the board directory so ``find_spec_file`` locates the spec and
+    the ``bom_fields`` check can distinguish spec-covered from truly-missing
+    LCSC.
+    """
+
+    def _make_bom_all_missing_lcsc(self, refs):
+        """Build a raw BOM (no LCSC set) for the given references."""
+        from kicad_tools.schema.bom import BOM, BOMItem
+
+        return BOM(
+            items=[
+                BOMItem(reference=r, value="100nF", footprint="C_0402", lib_id="Device:C", lcsc="")
+                for r in refs
+            ]
+        )
+
+    def _write_project(self, tmp_path, kct_body=None):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        pcb = project_dir / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+        (project_dir / "board.kicad_sch").write_text("(kicad_sch)")
+        if kct_body is not None:
+            (project_dir / "project.kct").write_text(kct_body)
+        return project_dir, pcb
+
+    def _bom_fields_result(self, pkg, monkeypatch, bom):
+        """Run only ``_check_bom_fields`` on a checker wired like the package.
+
+        The checker is constructed with the same paths the manufacturing
+        package would use (``pkg.pcb_path`` lives in the board directory), so
+        ``find_spec_file`` locates the sibling ``project.kct`` exactly as it
+        does in the real Step-0 preflight.  We mock only ``_load_bom`` to
+        supply a raw (pre-overlay) BOM without needing a parseable PCB.
+        """
+        checker = PreflightChecker(
+            pcb_path=pkg.pcb_path,
+            schematic_path=pkg.schematic_path,
+            manufacturer=pkg.manufacturer,
+            config=PreflightConfig(),
+            bom_source=pkg.config.bom_source,
+        )
+        monkeypatch.setattr(checker, "_load_bom", lambda: bom)
+        return checker._check_bom_fields()
+
+    def test_spec_covered_lcsc_no_false_warn(self, tmp_path, monkeypatch):
+        """Board with a spec covering all items => no bom_fields LCSC WARN."""
+        kct = (
+            'kct_version: "1.0"\n'
+            "project:\n"
+            '  name: "T"\n'
+            '  revision: "A"\n'
+            "bom_entries:\n"
+            "  - ref: C1\n"
+            "    part: MPN1\n"
+            "    lcsc: C111\n"
+            "  - ref: C2\n"
+            "    part: MPN2\n"
+            "    lcsc: C222\n"
+        )
+        _, pcb = self._write_project(tmp_path, kct)
+        config = ManufacturingConfig(include_report=False)
+        pkg = ManufacturingPackage(pcb_path=pcb, manufacturer="jlcpcb", config=config)
+
+        bom = self._make_bom_all_missing_lcsc(["C1", "C2"])
+        result = self._bom_fields_result(pkg, monkeypatch, bom)
+
+        assert result.status == "OK"
+        assert "missing LCSC" not in result.message
+        assert "missing LCSC" not in result.details
+
+    def test_no_spec_still_warns(self, tmp_path, monkeypatch):
+        """Board with no spec file => genuine missing-LCSC WARN still fires."""
+        _, pcb = self._write_project(tmp_path, kct_body=None)
+        config = ManufacturingConfig(include_report=False)
+        pkg = ManufacturingPackage(pcb_path=pcb, manufacturer="jlcpcb", config=config)
+
+        bom = self._make_bom_all_missing_lcsc(["C1", "C2"])
+        result = self._bom_fields_result(pkg, monkeypatch, bom)
+
+        assert result.status == "WARN"
+        assert "2/2 active item(s) missing LCSC part number" in result.details

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -657,6 +657,124 @@ class TestPreflightBomPcbMatchSeverity:
 
 
 # ---------------------------------------------------------------------------
+# PreflightChecker -- bom_fields LCSC spec-overlay awareness (issue #3926)
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightBomFieldsSpecOverlay:
+    """`_check_bom_fields` must not falsely warn about LCSC that the spec fills.
+
+    Preflight loads a *raw* BOM (Step 0) before the assembly pipeline applies
+    the ``.kct`` spec overlay (Step 1).  Items whose LCSC will be populated
+    from the spec are not genuinely missing -- warning about them is the false
+    positive fixed in issue #3926.
+    """
+
+    def _make_checker(self, monkeypatch, bom_items, spec_lcsc_refs):
+        """Build a bare checker with mocked BOM and spec-resolution."""
+        from kicad_tools.schema.bom import BOM
+
+        checker = PreflightChecker.__new__(PreflightChecker)
+        checker.config = PreflightConfig()
+        checker.pcb_path = Path("board.kicad_pcb")
+
+        bom = BOM(items=bom_items)
+        monkeypatch.setattr(checker, "_load_bom", lambda: bom)
+        monkeypatch.setattr(checker, "_spec_lcsc_refs", lambda: set(spec_lcsc_refs))
+        return checker
+
+    def _item(self, reference, **kwargs):
+        from kicad_tools.schema.bom import BOMItem
+
+        defaults = {"value": "100nF", "footprint": "C_0402", "lib_id": "Device:C", "lcsc": ""}
+        defaults.update(kwargs)
+        return BOMItem(reference=reference, **defaults)
+
+    def test_all_missing_lcsc_covered_by_spec_no_warn(self, monkeypatch):
+        """When every missing-LCSC item is spec-covered, no WARN fires."""
+        items = [self._item("C1"), self._item("R1", lib_id="Device:R")]
+        checker = self._make_checker(monkeypatch, items, {"C1", "R1"})
+
+        result = checker._check_bom_fields()
+
+        assert result.status == "OK"
+        assert "missing LCSC" not in result.message
+        assert "missing LCSC" not in result.details
+        assert "spec overlay" in result.details
+
+    def test_partial_spec_coverage_warns_only_uncovered(self, monkeypatch):
+        """Only the items NOT covered by the spec are counted in the WARN."""
+        items = [
+            self._item("C1"),
+            self._item("C2"),
+            self._item("R1", lib_id="Device:R"),
+        ]
+        # Spec covers only C1, C2 -- R1 remains genuinely missing.
+        checker = self._make_checker(monkeypatch, items, {"C1", "C2"})
+
+        result = checker._check_bom_fields()
+
+        assert result.status == "WARN"
+        assert "1/3 active item(s) missing LCSC part number" in result.details
+        assert "2 resolvable from spec" in result.details
+
+    def test_no_spec_all_missing_still_warns(self, monkeypatch):
+        """With no spec coverage, every missing-LCSC item still warns."""
+        items = [self._item("C1"), self._item("R1", lib_id="Device:R")]
+        checker = self._make_checker(monkeypatch, items, set())
+
+        result = checker._check_bom_fields()
+
+        assert result.status == "WARN"
+        assert "2/2 active item(s) missing LCSC part number" in result.details
+        assert "resolvable from spec" not in result.details
+
+    def test_items_with_lcsc_never_warn(self, monkeypatch):
+        """Items that already carry an LCSC are never counted as missing."""
+        items = [self._item("C1", lcsc="C111"), self._item("R1", lcsc="C222")]
+        checker = self._make_checker(monkeypatch, items, set())
+
+        result = checker._check_bom_fields()
+
+        assert result.status == "OK"
+        assert "missing LCSC" not in result.details
+
+    def test_spec_lcsc_refs_reads_kct_file(self, monkeypatch, tmp_path):
+        """`_spec_lcsc_refs` resolves refs (incl. ranges) from a real .kct."""
+        (tmp_path / "project.kct").write_text(
+            'kct_version: "1.0"\n'
+            "project:\n"
+            '  name: "T"\n'
+            '  revision: "A"\n'
+            "bom_entries:\n"
+            "  - ref: C1\n"
+            "    part: MPN1\n"
+            "    lcsc: C111\n"
+            "  - ref: R1-R3\n"
+            "    part: MPN2\n"
+            "    lcsc: C222\n"
+            "  - ref: U1\n"  # MPN only, no lcsc -> must NOT be resolved
+            "    part: MPN3\n"
+        )
+        # No .git boundary in tmp_path, so find_spec_file finds project.kct.
+        checker = PreflightChecker.__new__(PreflightChecker)
+        checker.pcb_path = tmp_path / "board.kicad_pcb"
+
+        refs = checker._spec_lcsc_refs()
+
+        assert refs == {"C1", "R1", "R2", "R3"}
+        assert "U1" not in refs
+
+    def test_spec_lcsc_refs_no_spec_returns_empty(self, monkeypatch, tmp_path):
+        """No .kct file present -> empty set, preserving legacy warn behaviour."""
+        # tmp_path has no .kct and no .git; find_spec_file walks up harmlessly.
+        checker = PreflightChecker.__new__(PreflightChecker)
+        checker.pcb_path = tmp_path / "board.kicad_pcb"
+
+        assert checker._spec_lcsc_refs() == set()
+
+
+# ---------------------------------------------------------------------------
 # PreflightChecker -- skip all
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #3926

## Problem

Export preflight (Step 0) falsely warned `N/N active item(s) missing LCSC part number` on boards 00/01/02. Root cause (per curator): `PreflightChecker._check_bom_fields()` loads a **raw** BOM via `_load_bom()`, which never has LCSC fields populated. The `.kct` spec overlay (`apply_spec_overlay`) runs later — Step 1, inside `AssemblyPackage._generate_bom_items()` — so at preflight time every spec-covered part looks "missing".

## Fix (curator's Option B)

- New `PreflightChecker._spec_lcsc_refs()` helper: locates the project spec via `find_spec_file(self.pcb_path.parent)`, loads it, and returns the set of references whose LCSC the overlay will fill. It mirrors the overlay's `expand_ref_range` handling and only counts `bom_entries` with a non-empty `lcsc` (an MPN-only entry does **not** resolve the LCSC gap). Best-effort: a missing/unparseable spec returns an empty set, preserving legacy behaviour.
- `_check_bom_fields()` now subtracts spec-covered refs from the missing-LCSC set:
  - **All covered** -> `[OK]` with an informational note (`"N active item(s) will receive LCSC from spec overlay"`), no WARN.
  - **Partially covered** -> WARN counts only the unresolved remainder: `"N/M active item(s) missing LCSC part number (K resolvable from spec)"`.
  - **No spec / genuinely missing** -> original WARN unchanged.
- A separate `notes` list keeps the informational message out of the problem count and OK/WARN logic.

`bom_spec_overlay.py` was not modified — `find_spec_file` / `expand_ref_range` import cleanly into preflight with no circular dependency (verified).

## Verification

Ran `_check_bom_fields()` against the real boards from a fresh checker:

| board | before | after |
|-------|--------|-------|
| 00 | `[WARN] 3/3 missing LCSC` | `[OK]` (3 from spec) |
| 01 | `[WARN] 4/4 missing LCSC` | `[OK]` (4 from spec) |
| 02 | `[WARN] 14/14 missing LCSC` | `[OK]` (14 from spec) |

## Tests

`tests/test_preflight.py::TestPreflightBomFieldsSpecOverlay` (6 tests): all-covered no-warn, partial-coverage warns-only-uncovered, no-spec still warns, items-with-LCSC never warn, `_spec_lcsc_refs` reads a real `.kct` (incl. ranges, excludes MPN-only entries), and no-spec-returns-empty.

`tests/test_manufacturing_package.py::TestManufacturingPreflightSpecOverlay` (2 tests): integration — a board with a sibling `project.kct` covering all items produces no false `bom_fields` WARN; a board with no spec still warns.

Checks run: `pytest tests/test_preflight.py tests/test_manufacturing_package.py` (125 passed), `ruff check`/`ruff format --check` clean on touched files, `mypy` adds **zero** new errors (8 pre-existing errors in untouched lazy-load code, identical on `origin/main`).

## Out of scope (should be split to a separate issue)

The **cache-nondeterminism sub-item** (enrichment auto-match counts drifting `8/2→9/1→10/0→11/0` under a persistent cache + 403 API, and C1525 vs C49678 divergence on board 04) is a distinct bug with a different root cause (stale-cache fallback ordering in `bom_enrich.enrich_bom_lcsc()` / `parts/cache.py`). Per the curator's recommendation it is deliberately untouched here and should be filed as a follow-up issue targeting `src/kicad_tools/export/bom_enrich.py` and `src/kicad_tools/parts/cache.py`.

Built on current `origin/main` (includes PR #3929's DRC safety floor / `PreflightConfig.skip_drc_floor`); no interaction with that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)