### PR TITLE
fix(match-group-skew): length-check groups composed only of diff pairs

### DIFF
--- a/scripts/ci/check_matchgroup_coverage.py
+++ b/scripts/ci/check_matchgroup_coverage.py
@@ -120,6 +120,23 @@ MATCHGROUP_RULE_IDS: tuple[str, ...] = ("match_group_length_skew",)
 # error.  Dropping this baseline back to strict 0 requires a via-balanced
 # re-route (or an artifact refresh), which is blocked on the artifact-churn
 # problem tracked in #3925.  See #3931 for the resolution plan.
+#
+# Issue #3916 (pair-only groups now length-checked) -- the producer used to
+# skip any match group whose members were exclusively differential pairs
+# (``net_ids=[]`` after ``_extract_pair_ids``), so board 07's MIPI_CSI_LANES
+# and HDMI_TMDS_LANES were never skew-checked.  ``derive_group_skew_data`` now
+# measures diff-pair members via the pair-average ``(L_P + L_N) / 2``
+# contribution, making both groups checkable.  On the COMMITTED board 07
+# artifact this baseline stays at 1: MIPI/HDMI each still have at least one
+# unrouted diff-pair leg (e.g. MIPI_CLK_N, MIPI_DAT0_N, TMDS_D0_*, TMDS_D1_*
+# carry zero geometry) and DDR_DATA_BYTE_0 has an unrouted DQ3, so all three
+# are correctly gated out by the existing partial-routing rule -- only the
+# fully-routed ADDR_BUS group produces a violation.  Once board 07 routes
+# those lanes end-to-end (blocked on the same artifact-churn work as #3931 /
+# #3925), MIPI (measured ~23mm skew vs 0.05mm) and HDMI (~8.7mm vs 0.075mm)
+# will each add a genuine ``match_group_length_skew`` error and this baseline
+# must be raised to 3 with a reroute of the committed artifact.  Composition
+# today: 1 = ADDR_BUS via-imbalance (#3931).
 MATCHGROUP_VIOLATION_BASELINE: dict[str, int] = {
     "boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb": 1,
 }

--- a/scripts/ci/check_matchgroup_coverage.py
+++ b/scripts/ci/check_matchgroup_coverage.py
@@ -126,19 +126,36 @@ MATCHGROUP_RULE_IDS: tuple[str, ...] = ("match_group_length_skew",)
 # (``net_ids=[]`` after ``_extract_pair_ids``), so board 07's MIPI_CSI_LANES
 # and HDMI_TMDS_LANES were never skew-checked.  ``derive_group_skew_data`` now
 # measures diff-pair members via the pair-average ``(L_P + L_N) / 2``
-# contribution, making both groups checkable.  On the COMMITTED board 07
-# artifact this baseline stays at 1: MIPI/HDMI each still have at least one
-# unrouted diff-pair leg (e.g. MIPI_CLK_N, MIPI_DAT0_N, TMDS_D0_*, TMDS_D1_*
-# carry zero geometry) and DDR_DATA_BYTE_0 has an unrouted DQ3, so all three
-# are correctly gated out by the existing partial-routing rule -- only the
-# fully-routed ADDR_BUS group produces a violation.  Once board 07 routes
-# those lanes end-to-end (blocked on the same artifact-churn work as #3931 /
-# #3925), MIPI (measured ~23mm skew vs 0.05mm) and HDMI (~8.7mm vs 0.075mm)
-# will each add a genuine ``match_group_length_skew`` error and this baseline
-# must be raised to 3 with a reroute of the committed artifact.  Composition
-# today: 1 = ADDR_BUS via-imbalance (#3931).
+# contribution, making both groups checkable.  This baseline is now **2**, but
+# the value the gate observes depends on WHICH artifact it runs against:
+#
+#   * ``--skip-route`` (committed-artifact path, used by the diff-driven
+#     routed-pcb-drc-check and by local verification): counts exactly **1**
+#     match-group violation.  On the COMMITTED board 07 artifact MIPI/HDMI
+#     each still have at least one unrouted diff-pair leg (e.g. MIPI_CLK_N,
+#     MIPI_DAT0_N, TMDS_D0_*, TMDS_D1_* carry zero geometry) and
+#     DDR_DATA_BYTE_0 has an unrouted DQ3, so all three are gated out by the
+#     partial-routing rule -- only the fully-routed ADDR_BUS group fires.
+#
+#   * full reroute (the Match-Group Routing Regression CI job, which runs
+#     ``generate_design.py --step route`` end-to-end before the gate):
+#     counts **2**.  The reroute lands every MIPI leg, so MIPI_CSI_LANES now
+#     produces a genuine ``match_group_length_skew`` error on top of
+#     ADDR_BUS's via-imbalance.  HDMI_TMDS_LANES does NOT fire even after the
+#     reroute: its TMDS_D0_N / TMDS_D1_N legs remain unrouted (the router
+#     reports them "still stranded -- NO relief path"), so the unrouted-leg
+#     gate correctly excludes HDMI.  A single baseline of 2 satisfies BOTH
+#     paths (the ``--skip-route`` count of 1 also passes, since 1 <= 2).
+#
+# Composition of the reroute baseline (2):
+#   1x ADDR_BUS via-imbalance (#3931) + 1x MIPI_CSI_LANES pair-only skew
+#   (#3916, the group newly made checkable by this change).
+# (An earlier prediction of 3 assumed HDMI would also fire once routed; the
+# reroute shows HDMI's TMDS legs do not route, so the observed count is 2.
+# Dropping this baseline toward strict 0 requires a via-balanced,
+# fully-routed board 07 -- blocked on the artifact-churn work in #3925.)
 MATCHGROUP_VIOLATION_BASELINE: dict[str, int] = {
-    "boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb": 1,
+    "boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb": 2,
 }
 
 

--- a/src/kicad_tools/validate/match_group_skew.py
+++ b/src/kicad_tools/validate/match_group_skew.py
@@ -51,13 +51,25 @@ imports from router/match_group_length.py only).  Tests live in
 ``tests/test_validate_match_group_skew.py`` and the drift-prevention
 test mirrors PR #2685's pattern.
 
-Group-of-pairs note (Phase 2F reserve):
+Group-of-pairs composition (Issue #3916):
 
-The :class:`MatchGroup` dataclass has a ``pair_ids`` field reserved for
-Phase 2F group-of-pairs composition.  Phase 1B's measurement layer
-ignores it; this producer follows suit and only sums ``net_ids`` until
-Phase 2F lands.  This matches the Phase 1B forwarder semantics and the
-rule's current member-count documentation.
+The :class:`MatchGroup` dataclass carries a ``pair_ids`` field populated
+by :func:`match_group_detection._extract_pair_ids` for differential-pair
+members.  A group whose members are *exclusively* diff pairs (e.g.,
+MIPI_CSI_LANES, HDMI_TMDS_LANES) exits detection with ``net_ids=[]`` and
+a fully-populated ``pair_ids`` -- the old producer skipped those groups
+entirely (the ``not grp.net_ids`` guard), so the skew rule never fired
+on them regardless of how large their lane-to-lane skew was.
+
+This producer now measures both member kinds.  Single-ended members
+(``net_ids``) contribute their own length; diff-pair members
+(``pair_ids``) contribute the *pair-average* ``(L_P + L_N) / 2`` as a
+single lane-length entry.  Pair-average (not per-leg) is deliberate: the
+group-level skew is a *lane-to-lane* timing budget, so within-pair
+imbalance -- already gated by the separate ``diffpair_length_skew`` rule
+-- must not be double-counted in the group figure.  A group's
+contribution vector therefore has exactly ``len(net_ids) + len(pair_ids)``
+entries.
 """
 
 from __future__ import annotations
@@ -202,14 +214,17 @@ def derive_group_skew_data(
     # Build the {net_id -> net_name} reverse so we can look up the net
     # class for any member via the autorouter's name-keyed map.
     for grp in detected:
-        # Phase 2F reserve: pair_ids are ignored here -- the Phase 1B
-        # measurement layer does the same, and the rule's documented
-        # member-count today is len(net_ids) + 2 * len(pair_ids).  We
-        # match Phase 1B byte-for-byte (only net_ids contribute to the
-        # skew computation in this phase).
-        if not grp.net_ids:
+        # Issue #3916: a group whose members are exclusively differential
+        # pairs (MIPI_CSI_LANES, HDMI_TMDS_LANES on board 07) exits
+        # ``_extract_pair_ids`` with ``net_ids=[]`` and ``pair_ids`` fully
+        # populated.  The old ``if not grp.net_ids: continue`` guard
+        # silently dropped those groups so the skew rule never fired on
+        # them.  We now measure BOTH single-ended members (``net_ids``)
+        # AND diff-pair members (``pair_ids``); the early-exit only
+        # triggers when the group has no members of either kind.
+        if not grp.net_ids and not grp.pair_ids:
             logger.debug(
-                "[match-group-skew] %s skipped (no single-ended members in Phase 1B scope)",
+                "[match-group-skew] %s skipped (no members)",
                 grp.name,
             )
             continue
@@ -219,8 +234,13 @@ def derive_group_skew_data(
         # which only populates the name-keyed cache when ALL declared
         # members are routed (a partially-routed group is excluded from
         # the bulk skew report -- see match_group_length.py:310-316).
+        # For a diff-pair member the gate applies to BOTH legs: if either
+        # leg is unrouted the whole group is omitted (Issue #3916, matches
+        # the single-ended unrouted-member gating).
         any_unrouted = False
         measured: list[float] = []
+
+        # Single-ended members contribute their own length directly.
         for net_id in grp.net_ids:
             if not _net_has_geometry(pcb, net_id):
                 any_unrouted = True
@@ -232,6 +252,33 @@ def derive_group_skew_data(
                 num_copper_layers=num_copper_layers,
             )
             measured.append(length)
+
+        # Diff-pair members (Issue #3916) contribute the *pair-average*
+        # length ``(L_P + L_N) / 2`` as a single lane-length entry -- NOT
+        # both legs separately.  The group-level skew is a lane-to-lane
+        # timing budget ("does MIPI lane 0 arrive with lane 1?"), so
+        # collapsing each pair to one entry keeps the ``max - min``
+        # computation purely between-lane.  Including both legs would
+        # conflate within-pair imbalance (already gated by the separate
+        # ``diffpair_length_skew`` rule) into the group skew figure.
+        if not any_unrouted:
+            for p_id, n_id in grp.pair_ids:
+                if not _net_has_geometry(pcb, p_id) or not _net_has_geometry(pcb, n_id):
+                    any_unrouted = True
+                    break
+                l_p = MatchGroupTracker.measure_net_from_pcb(
+                    pcb,
+                    p_id,
+                    board_thickness_mm=board_thickness_mm,
+                    num_copper_layers=num_copper_layers,
+                )
+                l_n = MatchGroupTracker.measure_net_from_pcb(
+                    pcb,
+                    n_id,
+                    board_thickness_mm=board_thickness_mm,
+                    num_copper_layers=num_copper_layers,
+                )
+                measured.append((l_p + l_n) / 2.0)
 
         if any_unrouted or len(measured) < 2:
             logger.debug(
@@ -247,8 +294,13 @@ def derive_group_skew_data(
         # member (groups should span one class; if they diverge, the
         # first-member-by-net-id wins -- deterministic given
         # :class:`MatchGroup`'s sorted-by-net-id member ordering from
-        # detect_match_groups).
-        first_net_id = grp.net_ids[0]
+        # detect_match_groups).  Issue #3916: pair-only groups have empty
+        # ``net_ids``, so fall back to the P-leg of the first pair for the
+        # net-class anchor (pairs are sorted, so this is deterministic).
+        if grp.net_ids:
+            first_net_id = grp.net_ids[0]
+        else:
+            first_net_id = grp.pair_ids[0][0]
         first_net_name = net_names.get(first_net_id)
         nc = net_class_map.get(first_net_name) if first_net_name else None
         if nc is not None and hasattr(nc, "effective_length_match_tolerance"):

--- a/tests/test_check_matchgroup_coverage.py
+++ b/tests/test_check_matchgroup_coverage.py
@@ -87,15 +87,20 @@ class TestCheckZeroViolations:
         assert mod.check_zero_violations({"match_group_length_skew": 4}, baseline=4) == []
 
     def test_board_07_documented_via_skew_baseline(self):
-        """Board 07's ADDR_BUS carries a via-count mismatch (A4/A6 extra via
-        pair vs A0) that became visible once #3915 threaded the board stackup
-        into via-aware match-group skew measurement.  It is documented as a
-        baseline of 1 pending a via-balanced re-route (Issue #3931, blocked on
-        the artifact-churn problem #3925), not silently absorbed by the large
-        error-count allowlist floor."""
+        """Board 07's documented match-group baseline is 2 on the reroute path
+        that the Match-Group Routing Regression CI job exercises: 1x ADDR_BUS
+        via-count mismatch (A4/A6 extra via pair vs A0, visible since #3915
+        threaded the board stackup into via-aware skew; Issue #3931) plus 1x
+        MIPI_CSI_LANES pair-only skew (the group #3916 newly makes checkable,
+        which fires once the reroute lands every MIPI leg).  HDMI_TMDS_LANES
+        does not fire -- its TMDS_D0_N/TMDS_D1_N legs stay unrouted after the
+        reroute, so the unrouted-leg gate excludes it.  A baseline of 2 also
+        satisfies the ``--skip-route`` committed-artifact path, which counts 1
+        (MIPI/HDMI/DDR each have an unrouted leg there).  Neither count is
+        silently absorbed by the large error-count allowlist floor."""
         mod = _load_helper_module()
         key = "boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb"
-        assert mod.MATCHGROUP_VIOLATION_BASELINE.get(key, 0) == 1
+        assert mod.MATCHGROUP_VIOLATION_BASELINE.get(key, 0) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_validate_match_group_skew.py
+++ b/tests/test_validate_match_group_skew.py
@@ -406,6 +406,237 @@ class TestDeriveGroupSkewDataPartialRouting:
 
 
 # ---------------------------------------------------------------------------
+# Pair-only groups (Issue #3916)
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveGroupSkewDataPairOnly:
+    """Groups composed exclusively of diff pairs must be length-checked.
+
+    Regression coverage for Issue #3916: MIPI_CSI_LANES / HDMI_TMDS_LANES
+    on board 07 exit ``_extract_pair_ids`` with ``net_ids=[]`` and a
+    fully-populated ``pair_ids``.  The old ``if not grp.net_ids: continue``
+    guard silently dropped those groups so the skew rule never fired.  The
+    producer now measures diff-pair members via the pair-average
+    ``(L_P + L_N) / 2`` contribution.
+    """
+
+    def test_pair_only_group_produces_skew(self):
+        """AC6: a group of 2+ diff pairs yields a non-empty skew_data dict.
+
+        Three MIPI lanes (P/N per lane), all legs routed.  With net_ids=[]
+        and pair_ids populated, the group must still be measured and appear
+        in group_skew_data with a correct between-lane skew value.
+        """
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.match_group_skew import derive_group_skew_data
+
+        nc = NetClassRouting(
+            name="MIPI",
+            length_match_group="MIPI_LANES",
+            length_match_tolerance_mm=0.05,
+        )
+        # 3 lanes: DAT0 (P/N), DAT1 (P/N), CLK (P/N).  _P/_N suffixes make
+        # the detector pair them, so the group ends up pair-only.
+        net_class_map = {
+            "MIPI_DAT0_P": nc,
+            "MIPI_DAT0_N": nc,
+            "MIPI_DAT1_P": nc,
+            "MIPI_DAT1_N": nc,
+            "MIPI_CLK_P": nc,
+            "MIPI_CLK_N": nc,
+        }
+        # Lane averages: lane0 = (10.0+10.0)/2 = 10.0, lane1 = 11.0,
+        # lane2 = 12.0  ->  between-lane skew = 12.0 - 10.0 = 2.0
+        pcb = _make_ddr_pcb(
+            net_lengths_mm={
+                40: 10.0,  # DAT0_P
+                41: 10.0,  # DAT0_N
+                42: 11.0,  # DAT1_P
+                43: 11.0,  # DAT1_N
+                44: 12.0,  # CLK_P
+                45: 12.0,  # CLK_N
+            },
+            net_names_map={
+                40: "MIPI_DAT0_P",
+                41: "MIPI_DAT0_N",
+                42: "MIPI_DAT1_P",
+                43: "MIPI_DAT1_N",
+                44: "MIPI_CLK_P",
+                45: "MIPI_CLK_N",
+            },
+        )
+        skew_data, groups, threshold_map = derive_group_skew_data(pcb, net_class_map)
+
+        # The group is pair-only: net_ids empty, three pairs.
+        assert len(groups) == 1
+        assert groups[0].name == "MIPI_LANES"
+        assert groups[0].net_ids == []
+        assert len(groups[0].pair_ids) == 3
+
+        # AC6: pair-only group is measured, not skipped.
+        assert "MIPI_LANES" in skew_data
+        assert abs(skew_data["MIPI_LANES"] - 2.0) < 1e-9
+        # Threshold falls back to the P-leg-of-first-pair net class.
+        assert threshold_map["MIPI_LANES"] == 0.05
+
+    def test_pair_average_not_per_leg_semantics(self):
+        """AC7: each pair contributes ONE averaged entry, not two per-leg entries.
+
+        Lane 0: L_P=10.0, L_N=10.1 -> average 10.05.
+        Lane 1: L_P=10.3, L_N=10.3 -> average 10.30.
+        Pair-average skew = 10.30 - 10.05 = 0.25mm.
+        Per-leg (wrong) skew would be max(10.3) - min(10.0) = 0.30mm.
+        """
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.match_group_skew import derive_group_skew_data
+
+        nc = NetClassRouting(
+            name="HDMI",
+            length_match_group="TMDS_LANES",
+            length_match_tolerance_mm=0.075,
+        )
+        net_class_map = {
+            "TMDS_D0_P": nc,
+            "TMDS_D0_N": nc,
+            "TMDS_D1_P": nc,
+            "TMDS_D1_N": nc,
+        }
+        pcb = _make_ddr_pcb(
+            net_lengths_mm={
+                50: 10.0,  # D0_P
+                51: 10.1,  # D0_N  -> lane0 avg 10.05
+                52: 10.3,  # D1_P
+                53: 10.3,  # D1_N  -> lane1 avg 10.30
+            },
+            net_names_map={
+                50: "TMDS_D0_P",
+                51: "TMDS_D0_N",
+                52: "TMDS_D1_P",
+                53: "TMDS_D1_N",
+            },
+        )
+        skew_data, groups, _ = derive_group_skew_data(pcb, net_class_map)
+
+        assert groups[0].net_ids == []
+        assert len(groups[0].pair_ids) == 2
+        assert "TMDS_LANES" in skew_data
+        # Pair-average, NOT per-leg.
+        assert abs(skew_data["TMDS_LANES"] - 0.25) < 1e-9
+        # Guard the anti-pattern explicitly: must NOT be the per-leg 0.30.
+        assert abs(skew_data["TMDS_LANES"] - 0.30) > 1e-3
+
+    def test_pair_with_one_unrouted_leg_omits_group(self):
+        """AC8: a pair with one unrouted leg omits the whole group.
+
+        Matches the single-ended unrouted-member gating: if either leg of
+        any pair has zero geometry, the group is excluded from skew_data.
+        """
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.match_group_skew import derive_group_skew_data
+
+        nc = NetClassRouting(
+            name="MIPI",
+            length_match_group="MIPI_LANES",
+            length_match_tolerance_mm=0.05,
+        )
+        net_class_map = {
+            "MIPI_DAT0_P": nc,
+            "MIPI_DAT0_N": nc,
+            "MIPI_DAT1_P": nc,
+            "MIPI_DAT1_N": nc,
+        }
+        # DAT1_N (net 43) unrouted -> its pair, hence the group, is dropped.
+        pcb = _make_ddr_pcb(
+            net_lengths_mm={
+                40: 10.0,  # DAT0_P
+                41: 10.0,  # DAT0_N
+                42: 11.0,  # DAT1_P
+                43: None,  # DAT1_N unrouted
+            },
+            net_names_map={
+                40: "MIPI_DAT0_P",
+                41: "MIPI_DAT0_N",
+                42: "MIPI_DAT1_P",
+                43: "MIPI_DAT1_N",
+            },
+        )
+        skew_data, _, threshold_map = derive_group_skew_data(pcb, net_class_map)
+
+        assert skew_data == {}
+        assert threshold_map == {}
+
+    def test_single_pair_group_below_min_members(self):
+        """A group with a single diff pair contributes one entry -> skipped.
+
+        The ``< 2 members`` guard stays: one pair collapses to one averaged
+        value (len(measured) == 1), which is not enough for max-min skew.
+        """
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.match_group_skew import derive_group_skew_data
+
+        nc = NetClassRouting(
+            name="MIPI",
+            length_match_group="MIPI_LANES",
+            length_match_tolerance_mm=0.05,
+        )
+        net_class_map = {"MIPI_DAT0_P": nc, "MIPI_DAT0_N": nc}
+        pcb = _make_ddr_pcb(
+            net_lengths_mm={40: 10.0, 41: 10.2},
+            net_names_map={40: "MIPI_DAT0_P", 41: "MIPI_DAT0_N"},
+        )
+        skew_data, _, _ = derive_group_skew_data(pcb, net_class_map)
+
+        # One pair -> one averaged member -> below the 2-member floor.
+        assert skew_data == {}
+
+    def test_mixed_single_ended_and_pair_members(self):
+        """A group with both net_ids and pair_ids measures both kinds.
+
+        Regression guard for DDR-style groups (single-ended DQ nets +
+        a DQS pair): the pair contributes its average alongside the
+        single-ended lengths.
+        """
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.match_group_skew import derive_group_skew_data
+
+        nc = NetClassRouting(
+            name="DDR",
+            length_match_group="DDR_BYTE",
+            length_match_tolerance_mm=0.5,
+        )
+        net_class_map = {
+            "DQ0": nc,
+            "DQ1": nc,
+            "DQS_P": nc,
+            "DQS_N": nc,
+        }
+        # DQ0=10.0, DQ1=10.0, DQS pair avg = (10.4+10.6)/2 = 10.5
+        # skew = 10.5 - 10.0 = 0.5
+        pcb = _make_ddr_pcb(
+            net_lengths_mm={
+                60: 10.0,  # DQ0
+                61: 10.0,  # DQ1
+                62: 10.4,  # DQS_P
+                63: 10.6,  # DQS_N
+            },
+            net_names_map={
+                60: "DQ0",
+                61: "DQ1",
+                62: "DQS_P",
+                63: "DQS_N",
+            },
+        )
+        skew_data, groups, _ = derive_group_skew_data(pcb, net_class_map)
+
+        assert len(groups) == 1
+        assert sorted(groups[0].net_ids) == [60, 61]
+        assert len(groups[0].pair_ids) == 1
+        assert "DDR_BYTE" in skew_data
+        assert abs(skew_data["DDR_BYTE"] - 0.5) < 1e-9
+
+
+# ---------------------------------------------------------------------------
 # Drift-prevention tests (the core property tested in this issue).
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`derive_group_skew_data` never length-checked a match group whose members
were exclusively differential pairs. After `detect_match_groups` runs
`_extract_pair_ids`, each `_P`/`_N` net is moved out of `net_ids` into
`pair_ids`, so groups like board 07's MIPI_CSI_LANES and HDMI_TMDS_LANES
exit detection with `net_ids=[]`. The `if not grp.net_ids: continue` guard
then silently dropped the whole group and the `match_group_length_skew`
rule never fired on it, regardless of how large the lane-to-lane skew was.

## Changes

- **`src/kicad_tools/validate/match_group_skew.py`** — extend the
  measurement loop to also measure `pair_ids` members. Each diff pair
  contributes the **pair-average** `(L_P + L_N) / 2` as a single
  lane-length entry (not both legs), so group skew is purely between-lane
  and does not double-count within-pair imbalance (already gated by the
  separate `diffpair_length_skew` rule). The early-exit now only fires when
  both `net_ids` and `pair_ids` are empty; the unrouted-member gate applies
  to both legs of a pair; the threshold-map anchor falls back to the P-leg
  of the first pair for pair-only groups. Updated the module docstring.
- **`tests/test_validate_match_group_skew.py`** — new `TestDeriveGroupSkewDataPairOnly`
  class (5 tests) covering pair-only skew, pair-average vs per-leg,
  one-unrouted-leg gating, single-pair below-min, and mixed member groups.
- **`scripts/ci/check_matchgroup_coverage.py`** — raise
  `MATCHGROUP_VIOLATION_BASELINE` for board 07 to **2** to reconcile the
  **reroute** path the Match-Group Routing Regression CI job exercises
  (see verification below), with a comment documenting both gate paths.
- **`tests/test_check_matchgroup_coverage.py`** — update the baseline unit
  test to assert **2** with the corrected composition.

## Baseline verification (both gate paths)

The observed match-group violation count depends on which artifact the
gate runs against:

- **`--skip-route`** (committed-artifact path): **1**. On the committed
  board 07 artifact MIPI/HDMI each still have an unrouted diff-pair leg
  (MIPI_CLK_N, MIPI_DAT0_N, TMDS_D0_*, TMDS_D1_* carry zero geometry) and
  DDR_DATA_BYTE_0 has an unrouted DQ3, so all three are gated out by the
  partial-routing rule — only fully-routed ADDR_BUS fires.
- **full reroute** (the Match-Group Routing Regression CI job, which runs
  `generate_design.py --step route` end-to-end): **2**, verified locally
  with `PYTHONHASHSEED=42 ... --seed 42` (matches CI run 28771297359). The
  reroute lands every MIPI leg, so **MIPI_CSI_LANES** now fires a genuine
  `match_group_length_skew` error on top of ADDR_BUS's via-imbalance.

**Why not 3?** An earlier prediction assumed HDMI_TMDS_LANES would also
fire once routed. It does not: even after the full reroute, HDMI's
`TMDS_D0_N` / `TMDS_D1_N` legs fail to route (the router reports them
"still stranded — NO relief path"), so the unrouted-leg gate correctly
excludes HDMI. The reroute count is therefore **2**, not 3.

A single baseline of **2** satisfies both gate paths: the reroute count of
2 is `<= 2`, and the `--skip-route` count of 1 is also `<= 2`.
Composition of the reroute baseline: 1× ADDR_BUS via-imbalance (#3931) +
1× MIPI_CSI_LANES pair-only skew (#3916). The
`.github/routed-drc-tolerance.yml` allowlist is intentionally NOT touched
(these are `match_group_length_skew` error-severity violations, tracked by
the baseline, not the DRC floor).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| AC1 — coverage for all declared groups | ✅ mechanism landed | Pair-only groups are now measured; the full reroute fires MIPI_CSI_LANES. HDMI stays gated because its TMDS legs do not route even after the reroute. |
| AC2 — MIPI produces findings | ✅ | Full reroute fires MIPI_CSI_LANES; unit test `test_pair_only_group_produces_skew` |
| AC3 — HDMI produces findings | ✅ mechanism landed | Same mechanism; HDMI's TMDS_D0/D1 legs stay unrouted after the reroute so it is correctly gated (not a producer gap) |
| AC4 — DDR/ADDR still checked | ✅ | ADDR_BUS still fires; `test_mixed_single_ended_and_pair_members` guards the mixed path |
| AC5 — CI baseline reconciled | ✅ | Reroute path verified at 2; `MATCHGROUP_VIOLATION_BASELINE` raised to 2 with both-path documentation; `--skip-route` still passes (1 <= 2) |
| AC6 — pair-only group produces skew | ✅ | `test_pair_only_group_produces_skew` |
| AC7 — pair-average semantics | ✅ | `test_pair_average_not_per_leg_semantics` asserts 0.25mm (avg) not 0.30mm (per-leg) |
| AC8 — one unrouted leg skips group | ✅ | `test_pair_with_one_unrouted_leg_omits_group` |

## Test Plan

- `uv run pytest tests/test_validate_match_group_skew.py` — pass (26 prior + 5 new)
- `uv run pytest tests/test_check_matchgroup_coverage.py tests/test_board_07_matchgroup_test.py tests/test_validate_match_group_length_skew.py` — all pass
- Full reroute (`PYTHONHASHSEED=42 uv run python scripts/ci/check_matchgroup_coverage.py boards/07-matchgroup-test --seed 42`) — match-group violations = 2 (== baseline)
- `--skip-route` on committed artifact — match-group violations = 1 (within baseline)
- `ruff check` / `ruff format --check` clean on all changed files

Pre-existing (unrelated, present on `main`): the board 07 committed
artifact's DRC error count drifts above the routed-drc-tolerance allowlist
floor — this artifact-churn drift (#3925) predates and is out of scope for
this change; the reroute path's DRC count (32) is within the allowlist.

Closes #3916
