### PR TITLE
fix(lvs): detect via-to-foreign-pour shorts and name nets on negative-clearance overlaps

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 3880
-# Branch: feature/issue-3880
+# Issue: 3909
+# Branch: feature/issue-3909
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/src/kicad_tools/validate/connectivity.py
+++ b/src/kicad_tools/validate/connectivity.py
@@ -1198,6 +1198,42 @@ class ConnectivityValidator:
             return None
         return poly
 
+    def _synthetic_via_radii(self, synthetic_nodes: set[str]) -> dict[str, float]:
+        """Map each ``__via{index}`` node to its copper radius (``size / 2``).
+
+        The synthetic via node ids created in :meth:`extract_pad_partition`
+        (step 1b) are ``f"__via{index}"`` in board via order, so we recover the
+        copper radius by re-enumerating ``self.pcb.vias``.  Only nodes present
+        in ``synthetic_nodes`` are returned.
+        """
+        radii: dict[str, float] = {}
+        for via_index, via in enumerate(self.pcb.vias):
+            node_id = f"__via{via_index}"
+            if node_id in synthetic_nodes:
+                radii[node_id] = max(getattr(via, "size", 0.0) or 0.0, 0.0) / 2.0
+        return radii
+
+    def _via_copper_geom(self, pos: tuple[float, float], radius: float) -> Any:
+        """Build a shapely geometry approximating a via's copper (issue #3909).
+
+        Returns the via's copper *circle* (a disk of ``radius`` about ``pos``,
+        eroded inward by :data:`POUR_PAD_ERODE` to match the pad-box treatment)
+        so a via whose copper ring overlaps a foreign pour's solid region bonds
+        into that island and surfaces the short.  Falls back to a bare
+        ``Point`` when the via has no positive size (degenerate) so the legacy
+        centre-in-solid bond (issue #3794) still fires.
+        """
+        if radius <= 0:
+            return _ShapelyPoint(pos)
+        circle = _ShapelyPoint(pos).buffer(radius)
+        if self.POUR_PAD_ERODE > 0:
+            eroded = circle.buffer(-self.POUR_PAD_ERODE)
+            # Erosion can empty a very small via; keep the full circle so the
+            # via is still testable rather than silently dropped.
+            if not eroded.is_empty:
+                return eroded
+        return circle
+
     def _connect_via_in_pad(
         self,
         pad_positions: dict[str, tuple[float, float]],
@@ -1270,14 +1306,28 @@ class ConnectivityValidator:
         foreign-net pad whose copper bonds to the pour is fused into it.
 
         Synthetic via nodes (issue #3794, listed in ``synthetic_nodes``) are
-        bonded the same way, but tested as a *point* at the via position
-        rather than a size box — a via that lands inside the pour's solid
-        region on a layer the via spans is unioned into the island, so a pad
-        reaching that via through a trace (on the via's *other* layer) inherits
-        the pour bond.  This is what closes the ``pad -> trace -> stitch via
-        -> opposite-layer pour`` path that pad-box-only testing misses; it adds
-        only real copper (a via tying a trace to a pour) and re-uses the same
-        eroded-solid-region guard, so it cannot fabricate a false short.
+        bonded the same way, but tested as the via's *copper circle* (radius
+        ``size / 2``, eroded by :data:`POUR_PAD_ERODE`) rather than a size box.
+        A via that lands inside the pour's solid region on a layer the via
+        spans is unioned into the island, so a pad reaching that via through a
+        trace (on the via's *other* layer) inherits the pour bond.  This is
+        what closes the ``pad -> trace -> stitch via -> opposite-layer pour``
+        path that pad-box-only testing misses; it adds only real copper (a via
+        tying a trace to a pour) and re-uses the same eroded-solid-region
+        guard, so it cannot fabricate a false short.
+
+        Testing the via *circle* (not a bare centre point) is also what lets
+        this method surface a **via-to-foreign-pour short** (issue #3909).
+        KiCad carves an antipad clearance hole centred on every foreign-net
+        via, so the via *centre* always sits inside that hole and a bare-point
+        test can never see the short.  When the antipad is marginal or absent
+        (the Python-fill-vs-kicad-cli-refill discrepancy), the via's copper
+        annular ring pokes past the too-small hole into the foreign fill's
+        solid region — the circle test catches that overlap and fuses the via
+        into the foreign island, so :func:`compare_partitions` reports the
+        short.  On a DRC-clean board the antipad hole is wider than the via
+        copper, so the eroded circle stays clear of the foreign solid region
+        and no false short is introduced (verified against boards 00-04).
 
         Pads are approximated by their size box (:meth:`_pad_copper_polygon`)
         rather than a bare center point: a thermally-relieved pad's center
@@ -1303,10 +1353,13 @@ class ConnectivityValidator:
         # Board-frame pad copper polygons, keyed by pad id.  Built once here
         # so each fill island can be tested against every candidate pad.
         # Synthetic via nodes (issue #3794) have no footprint pad, so they are
-        # represented by a bare point at the via position: a via that lands in
-        # the solid pour region penetrates the copper there, and a point test
-        # is the conservative analogue of the eroded pad box (the via must be
-        # inside the solid region, past any clearance moat, to bond).
+        # represented by their copper *circle* (radius ``size / 2``, eroded by
+        # ``POUR_PAD_ERODE`` like a pad box): a via whose copper penetrates the
+        # solid pour region there is bonded.  The circle — not a bare centre
+        # point — is what surfaces a via-to-foreign-pour short (issue #3909):
+        # the foreign pour's antipad hole is centred on the via, so the centre
+        # is always moated out, but the copper ring pokes past a marginal hole
+        # into the foreign fill.
         pad_polygons: dict[str, Any] = {}
         for fp in self.pcb.footprints:
             if not fp.reference or fp.reference.startswith("#"):
@@ -1317,10 +1370,12 @@ class ConnectivityValidator:
                 poly = self._pad_copper_polygon(fp, pad)
                 if poly is not None:
                     pad_polygons[f"{fp.reference}.{pad.number}"] = poly
+        via_radius = self._synthetic_via_radii(synthetic_nodes)
         for node_id in synthetic_nodes:
             pos = pad_positions.get(node_id)
-            if pos is not None:
-                pad_polygons[node_id] = _ShapelyPoint(pos)
+            if pos is None:
+                continue
+            pad_polygons[node_id] = self._via_copper_geom(pos, via_radius.get(node_id, 0.0))
 
         for zone in self.pcb.zones:
             if not zone.filled_polygons:

--- a/src/kicad_tools/validate/rules/clearance.py
+++ b/src/kicad_tools/validate/rules/clearance.py
@@ -1089,24 +1089,50 @@ class ClearanceRule(DRCRule):
         loc_x: float,
         loc_y: float,
     ) -> DRCViolation:
-        """Create a DRC violation for a clearance issue."""
+        """Create a DRC violation for a clearance issue.
+
+        A *negative* ``actual`` means the two copper geometries physically
+        overlap — that is an electrical short, not a borderline clearance
+        violation.  In that case the message is promoted to a net-named
+        ``SHORT: ...`` string at default verbosity (issue #3909) so an
+        operator sees the same actionable signal ``kicad-cli`` emits
+        ("Items shorting two nets (A and B)"), instead of a net-anonymous
+        "Segment to via clearance -0.188mm < minimum ..." line that only
+        surfaces the nets under ``--verbose``.
+        """
         # Determine rule ID suffix based on element types
         types = sorted([elem1.element_type, elem2.element_type])
         rule_suffix = f"{types[0]}_{types[1]}"
 
+        net_a = elem1.net_name
+        net_b = elem2.net_name
+        if actual < 0 and net_a and net_b and net_a != net_b:
+            # Physical copper overlap between two distinct named nets: this is
+            # an electrical short, not a borderline clearance miss.  Promote
+            # the message to a net-named ``SHORT: ...`` line so it is visible
+            # at default verbosity (issue #3909).  ``rule_id`` is kept as the
+            # plain ``clearance_<suffix>`` so existing exact-rule_id filters
+            # and the ``ViolationType.from_string`` alias table stay stable.
+            message = (
+                f"SHORT: '{net_a}' and '{net_b}' copper overlaps by "
+                f"{-actual:.3f}mm ({elem1.element_type} to {elem2.element_type})"
+            )
+        else:
+            message = (
+                f"{elem1.element_type.title()} to {elem2.element_type} clearance "
+                f"{actual:.3f}mm < minimum {required:.3f}mm"
+            )
+
         return DRCViolation(
             rule_id=f"clearance_{rule_suffix}",
             severity="error",
-            message=(
-                f"{elem1.element_type.title()} to {elem2.element_type} clearance "
-                f"{actual:.3f}mm < minimum {required:.3f}mm"
-            ),
+            message=message,
             location=(round(loc_x, 3), round(loc_y, 3)),
             layer=layer,
             actual_value=round(actual, 4),
             required_value=required,
             items=(elem1.reference, elem2.reference),
-            nets=(elem1.net_name, elem2.net_name),
+            nets=(net_a, net_b),
         )
 
 

--- a/tests/test_clearance_net_names.py
+++ b/tests/test_clearance_net_names.py
@@ -359,6 +359,108 @@ class TestClearanceRuleNetNames:
 
 
 # ---------------------------------------------------------------------------
+# Negative clearance (physical overlap) is reported as a named SHORT (#3909)
+# ---------------------------------------------------------------------------
+
+
+class TestNegativeClearanceShortMessage:
+    """A negative clearance (copper overlap) yields a net-named SHORT message.
+
+    kicad-cli names both nets in its ``shorting_items`` error; ``kct check``
+    must match that signal at *default* verbosity rather than emitting a
+    net-anonymous ``"Segment to via clearance -0.188mm < minimum ..."`` line
+    that only surfaced the nets under ``--verbose``.
+    """
+
+    def _pcb(self, via_y: float) -> str:
+        return f"""\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3V3")
+  (segment (start 100 100) (end 110 100) (width 0.25) (layer "F.Cu") (net 1 "GND") (uuid "seg-gnd1"))
+  (via (at 100 {via_y}) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 2 "+3V3") (uuid "via-3v3"))
+)
+"""
+
+    def _violations(self, tmp_path: Path, via_y: float):
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate import DRCChecker
+
+        pcb_path = tmp_path / "t.kicad_pcb"
+        pcb_path.write_text(self._pcb(via_y))
+        pcb = PCB.load(pcb_path)
+        checker = DRCChecker(pcb, manufacturer="jlcpcb", layers=2, copper_oz=1.0)
+        return checker.check_clearances().violations
+
+    def test_negative_clearance_message_names_both_nets(self, tmp_path: Path):
+        """A via overlapping a foreign segment (actual < 0) -> named SHORT msg."""
+        # via at y=100.25 vs segment at y=100: copper overlaps by ~0.175mm.
+        violations = self._violations(tmp_path, 100.25)
+        assert violations, "expected an overlap clearance violation"
+        v = violations[0]
+        assert v.actual_value < 0, f"fixture must produce a copper overlap; got {v.actual_value}"
+        # Default-verbosity message must be actionable: SHORT + both net names.
+        assert v.message.startswith("SHORT:"), v.message
+        assert "GND" in v.message and "+3V3" in v.message, v.message
+        assert "overlaps by" in v.message, v.message
+        # nets tuple still carries both names (unchanged behaviour).
+        assert set(v.nets) == {"GND", "+3V3"}
+
+    def test_positive_clearance_keeps_plain_message(self, tmp_path: Path):
+        """A tight-but-legal gap (actual > 0) keeps the plain clearance msg.
+
+        Only a genuine physical overlap is promoted to a SHORT; a via that is
+        merely closer than the minimum must NOT be mislabelled as shorted.
+        """
+        # via at y=100.45: a +0.025mm gap -> a clearance miss, not a short.
+        violations = self._violations(tmp_path, 100.45)
+        assert violations, "expected a tight-clearance violation"
+        v = violations[0]
+        assert v.actual_value > 0, f"fixture must produce a positive gap; got {v.actual_value}"
+        assert not v.message.startswith("SHORT:"), v.message
+        assert "< minimum" in v.message, v.message
+
+    def test_negative_clearance_same_net_not_a_short(self, tmp_path: Path):
+        """A negative clearance between copper on the SAME net is not a SHORT.
+
+        Same-net overlap is normal (a via landing on its own trace); the
+        net-named SHORT promotion requires two *distinct* named nets.
+        """
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate import DRCChecker
+
+        # Both the segment and the via are GND (net 1); they overlap.
+        src = self._pcb(100.25).replace(
+            '(via (at 100 100.25) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 2 "+3V3") (uuid "via-3v3"))',
+            '(via (at 100 100.25) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 1 "GND") (uuid "via-gnd2"))',
+        )
+        pcb_path = tmp_path / "t.kicad_pcb"
+        pcb_path.write_text(src)
+        pcb = PCB.load(pcb_path)
+        violations = (
+            DRCChecker(pcb, manufacturer="jlcpcb", layers=2, copper_oz=1.0)
+            .check_clearances()
+            .violations
+        )
+        # Same-net copper may or may not be flagged by the clearance rule, but
+        # if it is, it must not masquerade as a cross-net SHORT.
+        for v in violations:
+            assert not v.message.startswith("SHORT:"), v.message
+
+
+# ---------------------------------------------------------------------------
 # Reverse net name resolution: (net N) without inline name
 # ---------------------------------------------------------------------------
 

--- a/tests/test_copper_lvs.py
+++ b/tests/test_copper_lvs.py
@@ -828,6 +828,192 @@ def test_compare_copper_netlist_on_pour_heavy_board07_artifacts() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Via-to-foreign-pour short detection (issue #3909)
+# ---------------------------------------------------------------------------
+#
+# A stitch/connectivity via whose *copper ring* overlaps a foreign-net pour is
+# a real electrical short that kicad-cli's ``--refill-zones`` DRC flags but the
+# Python-fill-based copper-LVS historically missed: KiCad carves an antipad
+# clearance hole centred on every foreign via, so the via *centre* always sits
+# in that hole.  The pre-#3909 extractor tested each via as a bare centre POINT
+# against the pour solid region, so a via whose ring poked past a marginal /
+# too-small antipad into the solid pour was never bonded and the short was
+# invisible.  Representing the via as its copper CIRCLE catches the overlap.
+
+# Solid GND pour on F.Cu over x=8..20, y=0..20, with a SMALL antipad hole
+# (0.4 x 0.4, centred on the via at (10, 10)) carved out the way KiCad
+# flattens a hole: one ring whose boundary dips into the cutout through a
+# narrow slit.  ``_fill_solid_region`` (shapely buffer(0)) re-derives the hole.
+# The via centre lands INSIDE this hole (a bare-point test bonds nothing), but
+# the via's copper ring (size 1.0 -> radius 0.5, eroded to 0.4) reaches 0.2 mm
+# past the hole edge (at 0.2 mm) into the solid pour -> a real short.
+_VIA_POUR_FILL_RING = (
+    "(xy 8 0) (xy 9.98 0) (xy 9.98 9.8) "
+    "(xy 9.8 9.8) (xy 9.8 10.2) (xy 10.2 10.2) (xy 10.2 9.8) "
+    "(xy 10.02 9.8) (xy 10.02 0) "
+    "(xy 20 0) (xy 20 20) (xy 8 20) (xy 8 0)"
+)
+
+
+def _pcb_via_grazes_foreign_pour() -> str:
+    """A SIG via whose copper ring pokes into a GND pour past a marginal antipad.
+
+    * ``R2`` pad "1" at board (5, 10): declared **SIG**, sits OUTSIDE the pour
+      (pour starts at x=8) so it is not bonded to GND by its own copper.
+    * A track segment ties R2.1 to a via at (10, 10) (also SIG copper).
+    * The via at (10, 10) sits in the GND pour's antipad hole, but its copper
+      ring pokes past the too-small hole into the solid GND pour.
+    * ``R3`` pad "1" at board (15, 10): declared **GND**, copper in the solid
+      pour -> bonded, the GND anchor the via shorts against.
+
+    Result: R2.1 --seg--> via --(ring overlap)--> GND pour --> R3.1, fusing SIG
+    and GND into one copper island (a short) that a bare-centre-point via test
+    would miss (the via centre is moated out by the antipad hole).
+    """
+    return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "SIG")
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000c1")
+    (at 5 10)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "F.SilkS") (uuid "fp-c1-ref"))
+    (property "Value" "1k" (at 0 1.5 0) (layer "F.Fab") (uuid "fp-c1-val"))
+    (pad "1" smd roundrect (at 0 0) (size 1.5 1.5) (layers "F.Cu" "F.Paste" "F.Mask")
+      (roundrect_rratio 0.25) (net 2 "SIG"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000c3")
+    (at 15 10)
+    (property "Reference" "R3" (at 0 -1.5 0) (layer "F.SilkS") (uuid "fp-c3-ref"))
+    (property "Value" "1k" (at 0 1.5 0) (layer "F.Fab") (uuid "fp-c3-val"))
+    (pad "1" smd roundrect (at 0 0) (size 1.5 1.5) (layers "F.Cu" "F.Paste" "F.Mask")
+      (roundrect_rratio 0.25) (net 1 "GND"))
+  )
+  (segment (start 5 10) (end 10 10) (width 0.25) (layer "F.Cu") (net 2))
+  (via (at 10 10) (size 1.0) (drill 0.4) (layers "F.Cu" "B.Cu") (net 2 "SIG"))
+  (zone
+    (net 1 "GND")
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000z3")
+    (hatch edge 0.5)
+    (connect_pads (clearance 0.2))
+    (min_thickness 0.2)
+    (fill yes (thermal_gap 0.2) (thermal_bridge_width 0.3))
+    (polygon (pts (xy 8 0) (xy 20 0) (xy 20 20) (xy 8 20)))
+    (filled_polygon (layer "F.Cu") (pts {_VIA_POUR_FILL_RING}))
+  )
+)
+"""
+
+
+_VIA_POUR_SCHEMATIC: dict[tuple[str, str], str | None] = {
+    ("R2", "1"): "SIG",
+    ("R3", "1"): "GND",
+}
+
+
+def _point_via_partition(pcb_path: Path) -> list[frozenset[str]]:
+    """Extract the partition under the LEGACY bare-centre-point via model.
+
+    Patches :meth:`ConnectivityValidator._via_copper_geom` to return a bare
+    ``Point`` (the pre-#3909 behaviour) so the very same fixture can be run
+    through the old via-vs-pour test on which the short was invisible.
+    """
+    from unittest import mock
+
+    from shapely.geometry import Point as _P  # type: ignore[import-untyped]
+
+    def _point_only(self: ConnectivityValidator, pos, radius):  # noqa: ANN001, ARG001
+        return _P(pos)
+
+    with mock.patch.object(ConnectivityValidator, "_via_copper_geom", _point_only):
+        return ConnectivityValidator(pcb_path).extract_pad_partition()
+
+
+@requires_shapely
+def test_via_grazing_foreign_pour_is_a_short(tmp_path: Path) -> None:
+    """Crux (#3909): same fixture, POINT via model masks, CIRCLE model catches.
+
+    A SIG via's copper ring overlaps a GND pour (its antipad hole is marginal /
+    too small).  The via centre is moated out, so the old bare-point test never
+    bonds it and copper-LVS reports CLEAN — the exact blind spot that let a
+    board ship ``lvs_clean: true`` while kicad-cli reported ``shorting_items``.
+    The copper-circle test bonds the ring into the pour, surfacing the short.
+    """
+    pcb_path = _write(tmp_path, "via_pour.kicad_pcb", _pcb_via_grazes_foreign_pour())
+
+    # --- OLD bare-point via model: masks the short (clean) ---
+    old_partition = _point_via_partition(pcb_path)
+    old_result = compare_partitions(_VIA_POUR_SCHEMATIC, old_partition)
+    assert old_result.clean, (
+        "the legacy bare-centre-point via test should MASK this via-to-foreign-"
+        f"pour short (the via centre is moated out); got {old_result.mismatches}"
+    )
+
+    # --- NEW copper-circle via model: catches the short (dirty) ---
+    new_partition = ConnectivityValidator(pcb_path).extract_pad_partition()
+    new_result = compare_partitions(_VIA_POUR_SCHEMATIC, new_partition)
+    assert not new_result.clean, (
+        "the via copper-circle test must FLAG the via-to-foreign-pour short; "
+        f"partition={new_partition}"
+    )
+    short_pairs = {frozenset({m.net_a, m.net_b}) for m in new_result.shorts}
+    assert frozenset({"GND", "SIG"}) in short_pairs, (
+        f"expected a GND/SIG short named on both nets; shorts={new_result.shorts}"
+    )
+    # R2.1 (SIG) and R3.1 (GND) are fused into one copper island by the via.
+    fused = next(c for c in new_partition if "R2.1" in c)
+    assert {"R2.1", "R3.1"} <= fused, (
+        f"the via must fuse the SIG pad and the GND pour anchor; got {fused}"
+    )
+
+
+@requires_shapely
+def test_via_on_net0_adjacent_to_pour_is_not_a_false_short(tmp_path: Path) -> None:
+    """Edge case (#3909): a net-0 via with a proper antipad raises no false SHORT.
+
+    Relabel the via to net 0 (unconnected) and widen the antipad hole so the
+    via copper stays clear of the solid pour (a DRC-clean placement).  The
+    copper-circle test must NOT fabricate a short: with a proper clearance moat
+    the eroded ring never reaches the solid pour, and a net-0 via carries no
+    schematic net to short in any case.
+    """
+    # Wider antipad hole (1.2 x 1.2 around the via) so the eroded via ring
+    # (radius 0.4) stays inside the hole -> no bond to the solid pour.
+    wide_hole_ring = (
+        "(xy 8 0) (xy 9.98 0) (xy 9.98 9.4) "
+        "(xy 9.4 9.4) (xy 9.4 10.6) (xy 10.6 10.6) (xy 10.6 9.4) "
+        "(xy 10.02 9.4) (xy 10.02 0) "
+        "(xy 20 0) (xy 20 20) (xy 8 20) (xy 8 0)"
+    )
+    src = (
+        _pcb_via_grazes_foreign_pour()
+        .replace(
+            '(via (at 10 10) (size 1.0) (drill 0.4) (layers "F.Cu" "B.Cu") (net 2 "SIG"))',
+            '(via (at 10 10) (size 1.0) (drill 0.4) (layers "F.Cu" "B.Cu") (net 0 ""))',
+        )
+        .replace(_VIA_POUR_FILL_RING, wide_hole_ring)
+    )
+    pcb_path = _write(tmp_path, "via_pour_clean.kicad_pcb", src)
+    partition = ConnectivityValidator(pcb_path).extract_pad_partition()
+    result = compare_partitions(_VIA_POUR_SCHEMATIC, partition)
+    assert result.clean, (
+        "a net-0 via with a proper antipad clearance moat must not be reported "
+        f"as a short; mismatches={result.mismatches}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Board-04 short diagnosis (issue #3781): the two named shorts, classified.
 # ---------------------------------------------------------------------------
 #


### PR DESCRIPTION
## Summary

Two correctness gaps let a board ship `lvs_clean: true` while `kicad-cli pcb drc --refill-zones` reported real shorts (issue #3909):

1. **Copper-LVS was blind to via-to-foreign-pour shorts.** `_connect_pour_pads_label_free` bonded each synthetic via node to poured copper by testing the via's bare *centre point* against the fill solid region. KiCad carves an antipad clearance hole centred on every foreign-net via, so the via centre always lands in that hole and the point test never bonded it. A via whose *copper ring* pokes past a marginal / too-small antipad into a foreign net's fill — a physical short — was therefore invisible to the Python-fill-based comparator, even though kicad-cli's native refill flags it as `shorting_items`.

2. **`kct check` reported negative clearances net-anonymously.** A negative clearance means the two copper geometries physically overlap (an electrical short), but `_create_violation` emitted `"Segment to via clearance -0.188mm < minimum 0.102mm"` with the net names only visible under `--verbose`.

## Changes

- **`src/kicad_tools/validate/connectivity.py`** — Represent each synthetic via node as its copper *circle* (radius `size/2`, eroded by `POUR_PAD_ERODE` like a pad box) instead of a bare point when bonding to pours. A via whose ring overlaps a foreign pour is now fused into that island, so `compare_partitions` surfaces the short. Added helpers `_synthetic_via_radii()` and `_via_copper_geom()`. The circle strictly contains the old centre point, so every existing via→pour bond (the `pad → trace → via → opposite-layer pour` path, #3794) still fires.
- **`src/kicad_tools/validate/rules/clearance.py`** — When `actual < 0` between two distinct named nets, promote the message to `SHORT: '<a>' and '<b>' copper overlaps by <d>mm (<t1> to <t2>)` at default verbosity. `rule_id` is left as `clearance_<suffix>` so exact-rule_id filters and the `ViolationType.from_string` alias table stay stable.
- **Tests** — new via-to-foreign-pour crux test (old point model masks / new circle model catches), a net-0-via false-positive guard, and negative/positive/same-net clearance-message tests.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| AC1: via overlapping foreign pour → `clean: False` short naming both nets | ✅ | `test_via_grazing_foreign_pour_is_a_short` (old bare-point model masks, new circle model reports GND/SIG short) |
| AC2: board 07 agrees with kicad-cli | ✅ | kicad-cli `shorting_items = 0` and copper-LVS `shorts = 0` on committed board-07 artifact (post-#3930); new code introduces no false short |
| AC3: negative-clearance message names both nets at default verbosity | ✅ | `test_negative_clearance_message_names_both_nets` → `SHORT: 'GND' and '+3V3' copper overlaps by 0.175mm (segment to via)` |
| AC4: `board.json` `lvs_clean` inherits corrected verdict | ✅ | No change needed — `_parse_lvs` reads `lvs.json` `clean`, now driven by the corrected partition |
| AC5: no false positives on boards 00-04 / 07 | ✅ | Board LVS regression tests pass; kicad-cli vs copper-LVS both 0 shorts on 00/03/07 |

## Test Plan

- `tests/test_copper_lvs.py`, `tests/test_clearance_net_names.py`, `tests/test_connectivity*.py`, `tests/test_board_0{0,3,4}*lvs*.py`, `tests/test_drc_violation_type_validate.py`, clearance/segment-via suites — **291 passed**.
- Ground-truth cross-check with `kicad-cli pcb drc` (10.0.4) on committed artifacts: boards 00 / 03 / 07 report 0 `shorting_items`, matching copper-LVS 0 shorts / `clean=True`.
- `ruff check` + `ruff format` clean on changed files; no new mypy errors (pre-existing shapely-stub / `Pad`-type errors in untouched code only).

Closes #3909