### PR TITLE
fix(connectivity): model pour nets per fill-island, not zone boundary

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 3909
-# Branch: feature/issue-3909
+# Issue: 3914
+# Branch: feature/issue-3914
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/src/kicad_tools/analysis/net_status.py
+++ b/src/kicad_tools/analysis/net_status.py
@@ -21,7 +21,7 @@ import math
 from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from kicad_tools.core.layers import COPPER_LAYER_ORDER, via_spans_layer
 
@@ -74,6 +74,7 @@ class NetStatus:
     plane_layers: list[str] = field(default_factory=list)
     has_routing: bool = False
     has_vias: bool = False
+    has_filled_zone: bool = False  # A zone on this net produced fill copper
 
     @property
     def connected_count(self) -> int:
@@ -183,6 +184,7 @@ class NetStatus:
             "unconnected_count": self.unconnected_count,
             "connection_percentage": round(self.connection_percentage, 1),
             "is_plane_net": self.is_plane_net,
+            "has_filled_zone": self.has_filled_zone,
             "is_advisory_incomplete": self.is_advisory_incomplete,
             "plane_layer": self.plane_layer,
             "plane_layers": list(self.plane_layers),
@@ -473,6 +475,13 @@ class NetStatusAnalyzer:
             status.is_plane_net = True
             status.plane_layers = zone_nets[net_number]
             status.plane_layer = zone_nets[net_number][0]
+            # A zone that produced no filled copper (fill disabled, or fully
+            # carved away) provides no connectivity (Issue #3482) and is NOT a
+            # basis for suppressing a connectivity error (Issue #3914): only a
+            # zone with real fill copper makes an incomplete pour net advisory.
+            status.has_filled_zone = any(
+                zone.net_number == net_number and zone.filled_polygons for zone in self.pcb.zones
+            )
 
         # Check for routing
         segments = list(self.pcb.segments_in_net(net_number))
@@ -696,107 +705,30 @@ class NetStatusAnalyzer:
                             graph[pad].add(other)
                             graph[other].add(pad)
 
-        # Build bounding-box indices for zone polygons to avoid O(n*v) point-in-polygon
-        # checks for zones whose bounding box doesn't contain the query point.
-        boundary_bboxes = [
-            (layer, boundary, self._polygon_bbox(boundary)) for layer, boundary in zone_boundaries
-        ]
-        filled_bboxes = [
-            (layer, polys, [self._polygon_bbox(p) for p in polys]) for layer, polys in net_zones
-        ]
-
-        # Find zone connection points (via positions that touch zones)
-        # Check BOTH filled polygons AND zone boundaries because:
-        # - Filled polygons have thermal clearance cutouts around pads
-        # - Stitching vias are placed at pad positions (inside those cutouts)
-        # - But they ARE still within the zone boundary and thus connected
-        zone_connection_points: set[tuple[float, float]] = set()
-
-        # Check vias against zone boundaries (Issue #479 fix)
-        # This catches vias in thermal clearance cutouts that are still in the zone.
-        # Use _via_spans_layer to handle through-vias whose layer list is
-        # ["F.Cu", "B.Cu"] but which electrically connect all intermediate layers.
-        for zone_layer, boundary, bbox in boundary_bboxes:
-            for via in vias:
-                if not self._via_spans_layer(via.layers, zone_layer):
-                    continue
-                if not self._point_in_bbox(via.position, bbox):
-                    continue
-                if self._point_in_polygon(via.position, boundary):
-                    zone_connection_points.add(via.position)
-
-        # Also check vias against filled polygons (original behavior)
-        for zone_layer, filled_polys, poly_bboxes in filled_bboxes:
-            for via in vias:
-                if not self._via_spans_layer(via.layers, zone_layer):
-                    continue
-                for poly, bbox in zip(filled_polys, poly_bboxes, strict=False):
-                    if not self._point_in_bbox(via.position, bbox):
-                        continue
-                    if self._point_in_polygon(via.position, poly):
-                        zone_connection_points.add(via.position)
-                        break
-
-        # Connect pads through via-to-zone connectivity
-        # A pad is zone-connected if:
-        # 1. It's directly at a zone connection point, OR
-        # 2. It's in a segment chain that touches a zone connection point
-        zone_connected_pads: set[str] = set()
-
-        # Pads directly at zone connection points
-        for zcp in zone_connection_points:
-            zone_connected_pads.update(self._find_pads_at_point(zcp, pad_positions))
-
-        # Pads that directly overlap with zone boundaries or filled polygons (Issue #441, #479)
-        # This handles through-hole pads that connect to inner layer zones
-        # Check boundaries first (catches pads in thermal clearance cutouts)
-        for pad_id, pad_pos in pad_positions.items():
-            layers = pad_layers.get(pad_id, [])
-            # Check zone boundaries (Issue #479 fix)
-            for zone_layer, boundary, bbox in boundary_bboxes:
-                if not self._pad_layer_matches_zone(layers, zone_layer):
-                    continue
-                if not self._point_in_bbox(pad_pos, bbox):
-                    continue
-                if self._point_in_polygon(pad_pos, boundary):
-                    zone_connected_pads.add(pad_id)
-                    break
-            # Also check filled polygons (original behavior)
-            for zone_layer, filled_polys, poly_bboxes in filled_bboxes:
-                if not self._pad_layer_matches_zone(layers, zone_layer):
-                    continue
-                for poly, bbox in zip(filled_polys, poly_bboxes, strict=False):
-                    if not self._point_in_bbox(pad_pos, bbox):
-                        continue
-                    if self._point_in_polygon(pad_pos, poly):
-                        zone_connected_pads.add(pad_id)
-                        break
-
-        # Pads connected via segment chains that touch zone connection points
-        for component in segment_components:
-            touches_zone = False
-            for seg_idx in component:
-                seg = segments[seg_idx]
-                for zcp in zone_connection_points:
-                    if self._points_close(seg.start, zcp) or self._points_close(seg.end, zcp):
-                        touches_zone = True
-                        break
-                if touches_zone:
-                    break
-
-            if touches_zone:
-                # All pads in this segment chain are connected to the zone
-                for seg_idx in component:
-                    seg = segments[seg_idx]
-                    zone_connected_pads.update(self._find_pads_at_point(seg.start, pad_positions))
-                    zone_connected_pads.update(self._find_pads_at_point(seg.end, pad_positions))
-
-        # Connect all zone-connected pads to each other
-        zone_pad_list = list(zone_connected_pads)
-        for i, pad in enumerate(zone_pad_list):
-            for other in zone_pad_list[i + 1 :]:
-                graph[pad].add(other)
-                graph[other].add(pad)
+        # --- Zone / pour connectivity via per-fill-island grouping (#3914) ---
+        # The previous model added every pad inside a zone *boundary* polygon
+        # to one global ``zone_connected_pads`` set and connected them all to
+        # each other, treating the whole zone outline as a single copper
+        # component.  A pour whose fill has a discontinuity (two isolated copper
+        # islands) therefore still reported every boundary-interior pad as
+        # mutually connected -> a false ``complete`` even when kicad-cli
+        # reported unconnected items.  We now group pads by the poured copper
+        # *island* their copper actually overlaps (hole-aware solid region,
+        # matching ``ConnectivityValidator.extract_pad_partition``), so a pad
+        # reachable only through island A is not fused with a pad on a separate
+        # island B, and a pad sitting in the zone outline but not on any real
+        # fill copper is not spuriously connected at all.
+        self._apply_zone_connectivity(
+            net_number,
+            graph,
+            pad_positions,
+            pad_layers,
+            vias,
+            segments,
+            segment_components,
+            net_zones,
+            zone_boundaries,
+        )
 
         # Connect pads at same copper positions (segments and vias only).
         # Zone polygon vertices are NOT sampled here because the pad-to-zone
@@ -817,6 +749,278 @@ class NetStatusAnalyzer:
                             graph[other_id].add(pad_id)
 
         return graph
+
+    def _connectivity_geometry(self) -> Any:
+        """Return a cached :class:`ConnectivityValidator` for geometry reuse.
+
+        ``NetStatusAnalyzer`` reuses the validator's hole-aware pour geometry
+        (``_pad_copper_polygon`` / ``_fill_solid_region`` / ``_via_copper_geom``)
+        so the zone-connectivity model here stays byte-for-byte consistent with
+        the reference partition extractor (Issue #3914).  The validator is
+        constructed from the already-loaded PCB object (no re-parse) and cached
+        for the lifetime of this analyzer.
+        """
+        cv = getattr(self, "_cv_geometry", None)
+        if cv is None:
+            from kicad_tools.validate.connectivity import ConnectivityValidator
+
+            cv = ConnectivityValidator(self.pcb)
+            self._cv_geometry = cv
+        return cv
+
+    def _apply_zone_connectivity(
+        self,
+        net_number: int,
+        graph: dict[str, set[str]],
+        pad_positions: dict[str, tuple[float, float]],
+        pad_layers: dict[str, list[str]],
+        vias: list,
+        segments: list,
+        segment_components: list[set[int]],
+        net_zones: list[tuple[str, list[list[tuple[float, float]]]]],
+        zone_boundaries: list[tuple[str, list[tuple[float, float]]]],
+    ) -> None:
+        """Wire zone/pour copper into the graph, one group per fill island.
+
+        Computes per-fill-island pad groups (Issue #3914) and unions each
+        group into ``graph``.  Pads on separate poured copper islands are NOT
+        connected, so a discontinuous fill reports ``incomplete`` instead of a
+        false ``complete``.  When ``shapely`` is unavailable the hole-aware
+        island geometry cannot be computed, so we fall back to the legacy
+        boundary-polygon bulk-connect (one global zone component) to preserve
+        pre-#3914 behaviour on core-only installs.
+        """
+        groups = self._build_fill_island_groups(
+            net_number, pad_positions, pad_layers, vias, segments, segment_components
+        )
+        if groups is None:
+            legacy = self._legacy_zone_connected_pads(
+                pad_positions,
+                pad_layers,
+                vias,
+                segments,
+                segment_components,
+                net_zones,
+                zone_boundaries,
+            )
+            groups = [legacy] if legacy else []
+
+        for group in groups:
+            members = list(group)
+            for i, pad in enumerate(members):
+                for other in members[i + 1 :]:
+                    graph[pad].add(other)
+                    graph[other].add(pad)
+
+    def _build_fill_island_groups(
+        self,
+        net_number: int,
+        pad_positions: dict[str, tuple[float, float]],
+        pad_layers: dict[str, list[str]],
+        vias: list,
+        segments: list,
+        segment_components: list[set[int]],
+    ) -> list[set[str]] | None:
+        """Group this net's pads by the poured copper island they overlap.
+
+        Each ``filled_polygon`` is a poured copper island.  A pad is bonded to
+        a zone's fill iff its copper box overlaps the island's hole-aware solid
+        region (:meth:`ConnectivityValidator._fill_solid_region`) on a matching
+        copper layer -- clearance moats / thermal antipads carved out of the
+        pour are real holes the pad must not be tied across.  The pad *box*
+        (not its bare centre) is tested so a thermally-relieved pad, whose
+        centre sits in the antipad moat but whose copper edge reaches the
+        thermal spokes, still bonds.
+
+        A zone's fill fragments are unioned into a single group: KiCad
+        fragments one pour into many ``filled_polygon`` entries around thermal
+        reliefs, and all fragments of one ``zone`` object are the same net and
+        DRC-bonded (this avoids a false ``open`` for a pad alone in its own
+        thermal fragment).  Crucially the union is **per zone object**, not
+        global across all zones, so two pads covered by genuinely separate
+        pours (or separate zones) are only connected when a via / trace bridges
+        them.
+
+        Vias whose copper penetrates a fill island bond the pads reached
+        through them (directly, or via a segment chain ending at the via) into
+        that island, closing the ``pad -> trace -> stitch via -> pour`` path.
+
+        Returns ``None`` when ``shapely`` is unavailable (the caller then uses
+        the legacy boundary-based fallback); otherwise a list of pad-id groups,
+        one per bonded fill island.
+        """
+        from kicad_tools._shapely import has_shapely
+
+        if not has_shapely():
+            return None
+
+        cv = self._connectivity_geometry()
+
+        # Board-frame eroded copper box per pad on this net.  Reuse the
+        # reference validator's geometry so the model matches
+        # ``extract_pad_partition`` exactly.
+        pad_polys: dict[str, Any] = {}
+        for fp in self.pcb.footprints:
+            if not fp.reference or fp.reference.startswith("#"):
+                continue
+            for pad in fp.pads:
+                if pad.net_number != net_number:
+                    continue
+                if pad.number is None or pad.number == "":
+                    continue
+                pad_id = f"{fp.reference}.{pad.number}"
+                if pad_id not in pad_positions:
+                    continue
+                poly = cv._pad_copper_polygon(fp, pad)
+                if poly is not None:
+                    pad_polys[pad_id] = poly
+
+        # Copper-circle geometry per via (radius = size / 2, eroded like a pad
+        # box).  A via whose copper penetrates a pour's solid region ties any
+        # pad reachable through it into that island.
+        via_geoms = [
+            (
+                via,
+                cv._via_copper_geom(via.position, max(getattr(via, "size", 0.0) or 0.0, 0.0) / 2.0),
+            )
+            for via in vias
+        ]
+
+        groups: list[set[str]] = []
+        for zone in self.pcb.zones:
+            if zone.net_number != net_number or not zone.filled_polygons:
+                continue
+            bonded: set[str] = set()
+            for i, fill_pts in enumerate(zone.filled_polygons):
+                region = cv._fill_solid_region(fill_pts)
+                if region is None:
+                    continue
+                fill_layer = zone.filled_polygon_layer(i)
+
+                # Direct pad bonds: pad copper box overlaps the solid fill.
+                for pad_id, pad_geom in pad_polys.items():
+                    if not self._pad_layer_matches_zone(pad_layers.get(pad_id, []), fill_layer):
+                        continue
+                    if region.intersects(pad_geom):
+                        bonded.add(pad_id)
+
+                # Via bonds: a via whose copper penetrates this fill island ties
+                # the pads reached through it (directly or via a segment chain
+                # ending at the via) into the same island.
+                for via, via_geom in via_geoms:
+                    if not self._via_spans_layer(via.layers, fill_layer):
+                        continue
+                    if not region.intersects(via_geom):
+                        continue
+                    bonded.update(self._find_pads_at_point(via.position, pad_positions))
+                    for component in segment_components:
+                        touches = any(
+                            self._points_close(segments[s].start, via.position)
+                            or self._points_close(segments[s].end, via.position)
+                            for s in component
+                        )
+                        if not touches:
+                            continue
+                        for s in component:
+                            bonded.update(
+                                self._find_pads_at_point(segments[s].start, pad_positions)
+                            )
+                            bonded.update(self._find_pads_at_point(segments[s].end, pad_positions))
+
+            if bonded:
+                groups.append(bonded)
+        return groups
+
+    def _legacy_zone_connected_pads(
+        self,
+        pad_positions: dict[str, tuple[float, float]],
+        pad_layers: dict[str, list[str]],
+        vias: list,
+        segments: list,
+        segment_components: list[set[int]],
+        net_zones: list[tuple[str, list[list[tuple[float, float]]]]],
+        zone_boundaries: list[tuple[str, list[tuple[float, float]]]],
+    ) -> set[str]:
+        """Legacy boundary-based zone connectivity (shapely-absent fallback).
+
+        Reproduces the pre-#3914 behaviour: every pad inside a zone boundary or
+        filled polygon (plus pads reached through vias / segment chains that
+        touch a zone) is collected into one global set that is then fully
+        interconnected.  This is only used when ``shapely`` is unavailable and
+        the hole-aware per-island model cannot run.
+        """
+        boundary_bboxes = [
+            (layer, boundary, self._polygon_bbox(boundary)) for layer, boundary in zone_boundaries
+        ]
+        filled_bboxes = [
+            (layer, polys, [self._polygon_bbox(p) for p in polys]) for layer, polys in net_zones
+        ]
+
+        zone_connection_points: set[tuple[float, float]] = set()
+
+        for zone_layer, boundary, bbox in boundary_bboxes:
+            for via in vias:
+                if not self._via_spans_layer(via.layers, zone_layer):
+                    continue
+                if not self._point_in_bbox(via.position, bbox):
+                    continue
+                if self._point_in_polygon(via.position, boundary):
+                    zone_connection_points.add(via.position)
+
+        for zone_layer, filled_polys, poly_bboxes in filled_bboxes:
+            for via in vias:
+                if not self._via_spans_layer(via.layers, zone_layer):
+                    continue
+                for poly, bbox in zip(filled_polys, poly_bboxes, strict=False):
+                    if not self._point_in_bbox(via.position, bbox):
+                        continue
+                    if self._point_in_polygon(via.position, poly):
+                        zone_connection_points.add(via.position)
+                        break
+
+        zone_connected_pads: set[str] = set()
+
+        for zcp in zone_connection_points:
+            zone_connected_pads.update(self._find_pads_at_point(zcp, pad_positions))
+
+        for pad_id, pad_pos in pad_positions.items():
+            layers = pad_layers.get(pad_id, [])
+            for zone_layer, boundary, bbox in boundary_bboxes:
+                if not self._pad_layer_matches_zone(layers, zone_layer):
+                    continue
+                if not self._point_in_bbox(pad_pos, bbox):
+                    continue
+                if self._point_in_polygon(pad_pos, boundary):
+                    zone_connected_pads.add(pad_id)
+                    break
+            for zone_layer, filled_polys, poly_bboxes in filled_bboxes:
+                if not self._pad_layer_matches_zone(layers, zone_layer):
+                    continue
+                for poly, bbox in zip(filled_polys, poly_bboxes, strict=False):
+                    if not self._point_in_bbox(pad_pos, bbox):
+                        continue
+                    if self._point_in_polygon(pad_pos, poly):
+                        zone_connected_pads.add(pad_id)
+                        break
+
+        for component in segment_components:
+            touches_zone = False
+            for seg_idx in component:
+                seg = segments[seg_idx]
+                for zcp in zone_connection_points:
+                    if self._points_close(seg.start, zcp) or self._points_close(seg.end, zcp):
+                        touches_zone = True
+                        break
+                if touches_zone:
+                    break
+
+            if touches_zone:
+                for seg_idx in component:
+                    seg = segments[seg_idx]
+                    zone_connected_pads.update(self._find_pads_at_point(seg.start, pad_positions))
+                    zone_connected_pads.update(self._find_pads_at_point(seg.end, pad_positions))
+
+        return zone_connected_pads
 
     def _build_segment_components(self, segments: list) -> list[set[int]]:
         """Build connected components of segments.

--- a/src/kicad_tools/lvs/copper_lvs.py
+++ b/src/kicad_tools/lvs/copper_lvs.py
@@ -77,6 +77,7 @@ class CopperLVSResult:
 def compare_partitions(
     schematic_net_of_pad: dict[tuple[str, str], str | None],
     copper_partition: list[frozenset[str]],
+    advisory_net_names: frozenset[str] = frozenset(),
 ) -> CopperLVSResult:
     """Diff a physical copper partition against a schematic netlist.
 
@@ -89,11 +90,22 @@ def compare_partitions(
             pin is floating in the schematic and is excluded from the diff.
         copper_partition: list of ``frozenset`` pad-id groups (``"REF.PAD"``
             form) from :meth:`ConnectivityValidator.extract_pad_partition`.
+        advisory_net_names: nets whose completeness is satisfied by copper
+            pours rather than traces (Issue #3914).  Pour-routed power/ground
+            nets are stitched incrementally: pads not yet touched by a
+            stitching via or segment each land in their own copper island, so
+            a strict opens diff reports one advisory "open" per stranded pad
+            (88-105 of them on board 05), drowning any real signal opens in
+            noise.  ``open`` reporting is suppressed for these nets; ``short``
+            reporting is NOT (a pour net copper-fused to a foreign net is
+            still a hard defect).  Callers pass the set of nets that own a
+            copper zone (see :func:`compare_copper_netlist`).
 
     Returns:
         :class:`CopperLVSResult`.  A short is reported once per offending
         net pair (the lexicographically smallest pad witnesses are used);
-        an open is reported once per pair of same-net copper islands.
+        an open is reported once per pair of same-net copper islands, except
+        for nets in ``advisory_net_names`` (opens suppressed).
     """
     # Build {pad_id -> schematic_net} restricted to pads that (a) have a
     # real schematic net and (b) actually appear on the board, so the diff
@@ -157,6 +169,12 @@ def compare_partitions(
     for net, pads in sorted(net_to_pads.items()):
         if len(pads) < 2:
             continue
+        # Pour-routed nets (own a copper zone) are stitched incrementally;
+        # pads not yet bonded to the pour form advisory singleton islands that
+        # are not real opens (Issue #3914).  Suppress opens for these nets so
+        # genuine signal-net opens stay visible.  Shorts are still reported.
+        if net in advisory_net_names:
+            continue
         # Group these pads by copper component.
         comps: dict[int, list[str]] = {}
         for pad_id in sorted(pads):
@@ -200,14 +218,30 @@ def compare_copper_netlist(sch_path: str | Path, pcb_path: str | Path) -> Copper
     """
     # Import lazily: ConnectivityValidator pulls in the PCB schema stack and
     # we want ``import kicad_tools.lvs`` to stay cheap.
+    from kicad_tools.analysis.net_status import build_zone_net_map
     from kicad_tools.validate.connectivity import ConnectivityValidator
 
     sch_path = Path(sch_path)
     pcb_path = Path(pcb_path)
 
     schematic_net_of_pad = _schematic_pin_to_net(sch_path)
-    copper_partition = ConnectivityValidator(pcb_path).extract_pad_partition()
-    return compare_partitions(schematic_net_of_pad, copper_partition)
+    validator = ConnectivityValidator(pcb_path)
+    copper_partition = validator.extract_pad_partition()
+
+    # Nets that own a copper zone are pour-routed: their completeness comes
+    # from fill copper, not traces, so stitching residuals must not be
+    # reported as opens (Issue #3914).  ``build_zone_net_map`` returns the
+    # net numbers with zones; resolve them to names for the advisory filter.
+    pcb = validator.pcb
+    zone_net_numbers = build_zone_net_map(pcb)
+    advisory_net_names = frozenset(
+        pcb.nets[net_number].name
+        for net_number in zone_net_numbers
+        if net_number in pcb.nets and pcb.nets[net_number].name
+    )
+    return compare_partitions(
+        schematic_net_of_pad, copper_partition, advisory_net_names=advisory_net_names
+    )
 
 
 def result_to_json(result: CopperLVSResult) -> dict:

--- a/src/kicad_tools/validate/rules/connectivity.py
+++ b/src/kicad_tools/validate/rules/connectivity.py
@@ -108,6 +108,24 @@ class ConnectivityRule(DRCRule):
             if net_status.status == "complete":
                 continue
 
+            # Pour/plane nets whose incomplete status is a stitching residual
+            # (a thermal-relief cutout or a discontinuous fill island) are
+            # advisory, not a missing-trace defect (Issue #3914).  The false
+            # positive this fixes: a GND pour net that owns filled copper
+            # zones, reported "partially routed" here even though kicad-cli
+            # reports 0 unconnected on the same file (boards 03/04/06).
+            #
+            # The suppression is gated on ``has_filled_zone`` (the net owns a
+            # zone that produced REAL fill copper), NOT on the name-based
+            # ``net_type`` heuristic: a pour-NAMED net with no zone -- or a
+            # zone with fill disabled / zero filled polygons -- is genuinely
+            # disconnected and still fires (``test_pour_named_net_without_zone_fires``
+            # and the zero-fill edge case).  ``is_advisory_incomplete`` already
+            # requires ``status == "incomplete"``, so a pour net that is fully
+            # ``unrouted`` (no copper at all) is not suppressed either.
+            if net_status.has_filled_zone and net_status.is_advisory_incomplete:
+                continue
+
             # Choose a representative location: the first unconnected
             # pad (sorted alphabetically by REF.PAD inside
             # NetStatusAnalyzer) gives a stable, reproducible coordinate

--- a/tests/test_analysis_net_status.py
+++ b/tests/test_analysis_net_status.py
@@ -1183,6 +1183,25 @@ def _generate_large_zone_pcb(num_filled_polygons: int = 500) -> str:
     )"""
         )
 
+    # Fill fragments covering the two stitching vias at (50, 52) and (150, 52).
+    # The pads reach the In1.Cu pour through F.Cu->B.Cu through-vias, so the
+    # island-aware connectivity model (#3914) requires each via's copper to
+    # actually land on filled pour copper (not merely inside the zone
+    # boundary).  These fragments belong to the same zone object as every tile,
+    # so the per-zone union still ties both pads into one GND island.
+    for vx in (50, 150):
+        filled_parts.append(
+            f"""    (filled_polygon
+      (layer "In1.Cu")
+      (pts
+        (xy {vx - 1} 51)
+        (xy {vx + 1} 51)
+        (xy {vx + 1} 53)
+        (xy {vx - 1} 53)
+      )
+    )"""
+        )
+
     footer = """  )
 )
 """
@@ -1670,6 +1689,37 @@ PARTIAL_FILL_ZONE_PCB = _ZONE_FILL_PCB_TEMPLATE.format(
 """,
 )
 
+# Zone with a DISCONTINUOUS fill: two separate copper islands, only one of
+# which reaches a pad (#3914).  Island A (10..18) covers C1.2 (15, 15.25);
+# island B (26..30) is a detached fragment that touches no pad.  C2.2
+# (25, 15.25) sits in the boundary gap between the islands with no copper.
+# The pre-#3914 boundary heuristic added every boundary-interior pad to one
+# global zone component and reported the net ``complete`` -- the false
+# negative this fixture pins.  The island-aware model must report it
+# ``incomplete``.
+DISCONTINUOUS_FILL_ZONE_PCB = _ZONE_FILL_PCB_TEMPLATE.format(
+    fill_clause="(fill yes (thermal_gap 0.2) (thermal_bridge_width 0.2))",
+    filled_polygons="""    (filled_polygon
+      (layer "F.Cu")
+      (pts
+        (xy 10 10)
+        (xy 18 10)
+        (xy 18 20)
+        (xy 10 20)
+      )
+    )
+    (filled_polygon
+      (layer "F.Cu")
+      (pts
+        (xy 26 10)
+        (xy 30 10)
+        (xy 30 20)
+        (xy 26 20)
+      )
+    )
+""",
+)
+
 
 class TestZeroFillZoneConnectivity:
     """Regression tests for Issue #3482.
@@ -1698,6 +1748,12 @@ class TestZeroFillZoneConnectivity:
     def partial_fill_pcb(self, tmp_path: Path) -> Path:
         pcb_file = tmp_path / "partial_fill.kicad_pcb"
         pcb_file.write_text(PARTIAL_FILL_ZONE_PCB)
+        return pcb_file
+
+    @pytest.fixture
+    def discontinuous_fill_pcb(self, tmp_path: Path) -> Path:
+        pcb_file = tmp_path / "discontinuous_fill.kicad_pcb"
+        pcb_file.write_text(DISCONTINUOUS_FILL_ZONE_PCB)
         return pcb_file
 
     def test_zero_fill_zone_is_not_connectivity(self, zero_fill_pcb: Path):
@@ -1746,21 +1802,55 @@ class TestZeroFillZoneConnectivity:
         assert gnd.is_plane_net is True
         assert gnd.plane_layer == "F.Cu"
 
-    def test_partial_fill_zone_provides_connectivity(self, partial_fill_pcb: Path):
-        """A zone with at least one filled polygon retains the Issue #479
-        boundary heuristic: pads inside the outline (including thermal-relief
-        cutouts) are zone-connected.
+    def test_partial_fill_zone_only_connects_pads_on_copper(self, partial_fill_pcb: Path):
+        """A pad inside the zone outline but NOT on real fill copper is open.
+
+        Issue #3914 supersedes the over-eager Issue #479 boundary heuristic:
+        connectivity now follows the *filled copper island* a pad's copper
+        actually overlaps, not the zone outline.  In this fixture the fill
+        covers x in [10, 22]: C1.2 (15, 15.25) lands on filled copper and
+        bonds to the pour, but C2.2 (25, 15.25) sits in the boundary-only
+        gap with no copper reaching it.  Reporting this net ``complete`` was
+        the false-negative documented in #3914 (a boundary-interior pad with
+        no fill wrongly counted as connected), so the net must now read
+        ``incomplete`` -- C2.2 is genuinely stranded on the manufactured
+        board.
         """
         analyzer = NetStatusAnalyzer(partial_fill_pcb)
         result = analyzer.analyze()
 
         gnd = result.get_net("GND")
         assert gnd is not None
-        assert gnd.status == "complete", (
-            f"Partially filled zone should connect pads inside its boundary; "
-            f"got status={gnd.status}, "
-            f"unconnected: {[p.full_name for p in gnd.unconnected_pads]}"
+        assert gnd.status != "complete", (
+            f"A pad in the zone boundary but off real fill copper must not be "
+            f"reported connected; got status={gnd.status}"
         )
+        # Only C1.2 sits on filled copper; C2.2 is stranded off the fill.
+        assert gnd.connected_count == 1
+        assert gnd.unconnected_count == 1
+        assert gnd.unconnected_pads[0].full_name == "C2.2"
+
+    def test_discontinuous_fill_not_complete(self, discontinuous_fill_pcb: Path):
+        """A discontinuous fill must not report a pour net ``complete`` (#3914).
+
+        Two GND pads sit inside the zone outline, but the fill is split into
+        two detached copper islands and only the left island reaches C1.2;
+        C2.2 is stranded in the gap.  The old boundary heuristic fused every
+        boundary-interior pad into one component and reported ``complete`` --
+        the false negative.  The island-aware model must report the net
+        ``incomplete`` with C2.2 unconnected.
+        """
+        analyzer = NetStatusAnalyzer(discontinuous_fill_pcb)
+        result = analyzer.analyze()
+
+        gnd = result.get_net("GND")
+        assert gnd is not None
+        assert gnd.status != "complete", (
+            f"Discontinuous fill must not read complete; got status={gnd.status}"
+        )
+        assert gnd.connected_count == 1
+        assert gnd.unconnected_count == 1
+        assert gnd.unconnected_pads[0].full_name == "C2.2"
 
     def test_fully_filled_zone_regression(self, tmp_path: Path):
         """Fully filled zone behavior (Issue #479) must not regress."""

--- a/tests/test_board_06_diffpair_test.py
+++ b/tests/test_board_06_diffpair_test.py
@@ -830,10 +830,16 @@ class TestBoard06StrictGateGuard:
     # Net: 18 diff-pair + 1 drill + 5 clearance/via = 24.  When #3540-#3544
     # drive the diff-pair errors down, tighten this AND the tolerance entry.
     EXPECTED_STRICT_GATE_ERRORS = 24
-    # Advisory ``connectivity`` dropped 2 -> 1 on the fresh re-route (one
-    # fewer NetStatusAnalyzer false positive); the copper-union audit still
-    # PASSES (see ``TestPourCopperUnionAudit``).
-    EXPECTED_ADVISORY_CONNECTIVITY = 1
+    # Advisory ``connectivity`` is now 0 (Issue #3914).  The residual entries
+    # were ``NetStatusAnalyzer`` false positives on GND / +1V2 pour nets: the
+    # pre-#3914 per-net model bulk-connected every pad inside a zone boundary
+    # and then flagged a stitching residual as "partially routed" even though
+    # the net owns filled pour copper and kicad-cli reports it clean.  The
+    # ``ConnectivityRule`` now defers to the pour classification (``has_filled_zone``
+    # + ``is_advisory_incomplete``) and emits nothing for these nets, so the
+    # advisory count drops to 0.  The copper-union audit still PASSES (see
+    # ``TestPourCopperUnionAudit``).
+    EXPECTED_ADVISORY_CONNECTIVITY = 0
 
     @pytest.fixture(scope="class")
     def routed_pcb(self) -> Path:
@@ -995,18 +1001,22 @@ class TestBoard06StrictGateGuard:
         )
 
     def test_advisory_connectivity_pinned(self, strict_gate_result: dict) -> None:
-        """Advisory ``connectivity`` count pinned at 2 (GND + +1V2).
+        """Advisory ``connectivity`` count pinned at 0 (Issue #3914).
 
         Issue #3413 phases 4-6: all 21 signal nets are routed (the
         historical USB3_TX1+/USB3_TX1-/MIPI_RST incompletes are gone)
         and every pour net is GENUINELY one copper component per the
-        copper-union audit (``TestPourCopperUnionAudit``).  The 2
-        remaining advisory entries are ``NetStatusAnalyzer`` false
-        positives: its per-net model cannot follow the
-        pad -> stub -> via -> plane-fill chain the phase-4 stitching
-        uses (the inverse face of the #3482 analyzer gap).  A drift in
-        this count means the stitch/repair pipeline gained or lost
-        coverage -- investigate with the copper-union audit before
+        copper-union audit (``TestPourCopperUnionAudit``).  The formerly
+        pinned advisory entries were ``NetStatusAnalyzer`` false positives
+        on the GND / +1V2 pour nets -- its per-net model bulk-connected
+        every pad inside a zone boundary and then reported a stitching
+        residual as "partially routed", even though the net owns filled
+        pour copper and kicad-cli reports it clean.  Issue #3914 taught
+        ``ConnectivityRule`` to defer to the pour classification
+        (``has_filled_zone`` + ``is_advisory_incomplete``), so no
+        connectivity violation is emitted for these nets and the advisory
+        count is now 0.  A drift ABOVE 0 means a genuinely-unrouted net
+        regressed -- investigate with the copper-union audit before
         updating the pin.
         """
         violations = strict_gate_result.get("violations", [])
@@ -1016,7 +1026,7 @@ class TestBoard06StrictGateGuard:
         assert connectivity == self.EXPECTED_ADVISORY_CONNECTIVITY, (
             f"Advisory connectivity count on the committed routed PCB is "
             f"{connectivity}; expected {self.EXPECTED_ADVISORY_CONNECTIVITY} "
-            f"(GND + +1V2 analyzer false positives; see #3482).  A change "
+            f"(GND + +1V2 pour false positives removed by #3914).  A change "
             f"here indicates the stitch/repair pipeline gained or lost "
             f"coverage -- investigate before updating the pin."
         )

--- a/tests/test_connectivity_rule.py
+++ b/tests/test_connectivity_rule.py
@@ -194,6 +194,51 @@ def _three_pad_pour_with_zone_pcb() -> str:
     )
 
 
+def _discontinuous_pour_pcb() -> str:
+    """A GND pour whose fill reaches only one of its two pads.
+
+    The zone boundary (95..125, 95..105) contains both GND pads, but the
+    single filled polygon covers only the left island (95..105): R1.1 at
+    (99, 100) lands on real fill copper while R2.1 at (119, 100) sits in the
+    boundary-only gap with no copper reaching it.  Under the island-aware
+    connectivity model (#3914) this net is genuinely ``incomplete`` -- R2.1 is
+    stranded on the manufactured board.  Because the net owns real filled pour
+    copper, the residual is advisory (a stitching gap, not a missing signal
+    trace), so ``ConnectivityRule`` must NOT fire a hard error.  This is the
+    boards 03/04/06 "GND N of M pads stranded" false positive.
+    """
+    return (
+        _PCB_HEADER
+        + """
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "Resistor_SMD:R_0805" (layer "F.Cu")
+    (at 100 100)
+    (property "Reference" "R1" (at 0 -2 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000001"))
+    (property "Value" "10k" (at 0 2 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000002"))
+    (pad "1" smd rect (at -1 0) (size 1 1) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "GND") (uuid "00000000-0000-0000-0000-000000000003"))
+  )
+  (footprint "Resistor_SMD:R_0805" (layer "F.Cu")
+    (at 120 100)
+    (property "Reference" "R2" (at 0 -2 0) (layer "F.SilkS") (uuid "00000000-0000-0000-0000-000000000004"))
+    (property "Value" "10k" (at 0 2 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000005"))
+    (pad "1" smd rect (at -1 0) (size 1 1) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "GND") (uuid "00000000-0000-0000-0000-000000000006"))
+  )
+  (zone (net 1) (net_name "GND") (layer "F.Cu") (uuid "00000000-0000-0000-0000-00000000000a") (hatch edge 0.5)
+    (connect_pads (clearance 0.2))
+    (min_thickness 0.25)
+    (filled_areas_thickness no)
+    (polygon (pts (xy 95 95) (xy 125 95) (xy 125 105) (xy 95 105)))
+    (filled_polygon
+      (layer "F.Cu")
+      (pts (xy 95 95) (xy 105 95) (xy 105 105) (xy 95 105))
+    )
+  )
+)
+"""
+    )
+
+
 def _three_pad_pour_no_zone_pcb() -> str:
     """Three GND pads, no copper zone, no traces -- still an error.
 
@@ -319,6 +364,39 @@ class TestConnectivityRuleUnit:
         # All three GND pads are inside the same-net filled polygon, so
         # NetStatusAnalyzer reports status="complete" and the rule
         # produces zero violations.
+        assert results.error_count == 0
+
+    def test_discontinuous_pour_does_not_fire(self, tmp_path: Path) -> None:
+        """A pour net with real fill but a stitching residual is advisory (#3914).
+
+        GND owns a filled F.Cu zone, but the fill reaches only R1.1; R2.1 is
+        stranded in the boundary-only gap.  ``NetStatusAnalyzer`` correctly
+        reports the net ``incomplete`` (R2.1 is genuinely off-copper), but
+        because the net owns real filled pour copper the incompleteness is a
+        stitching residual -- advisory, not a missing-trace defect -- so the
+        rule must produce zero errors.  This is the false positive removed by
+        the ``has_filled_zone`` guard.
+        """
+        from kicad_tools.analysis.net_status import NetStatusAnalyzer
+        from kicad_tools.manufacturers import get_profile
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate.rules.connectivity import ConnectivityRule
+
+        pcb_path = tmp_path / "discontinuous_pour.kicad_pcb"
+        pcb_path.write_text(_discontinuous_pour_pcb())
+        pcb = PCB.load(pcb_path)
+        rules = get_profile("jlcpcb").get_design_rules(2, 1.0)
+
+        # Precondition: the net really is incomplete-but-advisory, so the
+        # zero-error result below exercises the suppression path (not the
+        # "complete" fast path).
+        gnd = NetStatusAnalyzer(pcb).analyze().get_net("GND")
+        assert gnd is not None
+        assert gnd.status == "incomplete"
+        assert gnd.has_filled_zone is True
+        assert gnd.is_advisory_incomplete is True
+
+        results = ConnectivityRule().check(pcb, rules)
         assert results.error_count == 0
 
     def test_pour_named_net_without_zone_fires(self, tmp_path: Path) -> None:

--- a/tests/test_copper_lvs.py
+++ b/tests/test_copper_lvs.py
@@ -89,6 +89,54 @@ def test_open_detected_when_same_net_splits_across_islands() -> None:
     assert {open_rec.pad_a, open_rec.pad_b} == {"R1.1", "R2.1"}
 
 
+def test_pour_opens_suppressed() -> None:
+    """Advisory pour nets suppress opens; signal nets still report them (#3914).
+
+    A pour-routed net (GND) whose fill has not yet been stitched leaves its
+    pads in separate copper islands.  Reporting one advisory "open" per
+    stranded pad drowns real signal opens in noise (88-105 of them on board
+    05), so opens are suppressed for nets in ``advisory_net_names``.  A signal
+    net split across two islands is a genuine open and is still reported, and
+    a pour net copper-fused to a *foreign* net is still a short.
+    """
+    sch = {
+        ("U1", "1"): "GND",
+        ("U2", "1"): "GND",
+        ("R1", "1"): "SIG",
+        ("R2", "1"): "SIG",
+    }
+    # GND split across two islands (unstitched pour); SIG split across two
+    # islands (genuine signal open).
+    partition = [
+        frozenset({"U1.1"}),
+        frozenset({"U2.1"}),
+        frozenset({"R1.1"}),
+        frozenset({"R2.1"}),
+    ]
+
+    # Without the advisory filter both nets report an open.
+    strict = compare_partitions(sch, partition)
+    assert {o.net_a for o in strict.opens} == {"GND", "SIG"}
+
+    # With GND marked advisory, only the SIG open survives.
+    filtered = compare_partitions(sch, partition, advisory_net_names=frozenset({"GND"}))
+    assert [o.net_a for o in filtered.opens] == ["SIG"]
+    assert filtered.shorts == ()
+
+
+def test_pour_advisory_filter_does_not_suppress_shorts() -> None:
+    """Opens are suppressed for advisory nets, but shorts never are (#3914)."""
+    sch = {
+        ("U1", "1"): "GND",
+        ("R1", "1"): "SIG",
+    }
+    # GND and SIG copper-fused into one island -> a real short.
+    partition = [frozenset({"U1.1", "R1.1"})]
+    result = compare_partitions(sch, partition, advisory_net_names=frozenset({"GND"}))
+    assert len(result.shorts) == 1
+    assert {result.shorts[0].net_a, result.shorts[0].net_b} == {"GND", "SIG"}
+
+
 def test_floating_schematic_pin_excluded_from_diff() -> None:
     """A pin with no schematic net (None) is ignored, not flagged."""
     sch = {


### PR DESCRIPTION
## Summary

Three components shared the job of answering "are all pads on this pour net connected?" but used three incompatible copper models, producing false results in **both** directions at once. This PR unifies them on a per-fill-island copper model.

- **False negative** (net-status): a discontinuous pour was reported `Complete`.
- **False positive** (`kct check`): a fully-poured GND net was reported "partially routed" even when kicad-cli reports 0 unconnected.
- **Opens noise** (copper-LVS): 88-105 advisory opens per board drowned real signal opens.

## Changes

- **`analysis/net_status.py`** — `_build_connectivity_graph` no longer bulk-connects every pad inside a zone *boundary* polygon. New `_build_fill_island_groups` groups pads by the poured copper *island* their (hole-aware, thermal-relief-tolerant) copper box actually overlaps, reusing `ConnectivityValidator`'s proven pad-box / fill-region / via-circle geometry. A zone's fill fragments union together (KiCad fragments one pour around thermal reliefs), but separate zones/islands never fuse. A `has_filled_zone` flag is added to `NetStatus`. The legacy boundary bulk-connect is retained only as a shapely-absent fallback.
- **`validate/rules/connectivity.py`** — the rule now skips a net when `has_filled_zone and is_advisory_incomplete` (owns real filled pour copper + incomplete only as a stitching residual). A pour-named net with **no** zone, or a zero-fill zone, still fires.
- **`lvs/copper_lvs.py`** — `compare_partitions` gains `advisory_net_names`; opens are suppressed for those nets (shorts are not). `compare_copper_netlist` derives the set from `build_zone_net_map`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Pour net with real fill not reported "partially routed" | ✅ | `test_discontinuous_pour_does_not_fire`; board-06 advisory-connectivity pin 1→0 |
| Discontinuous fill not reported "Complete" | ✅ | `test_discontinuous_fill_not_complete`; `test_partial_fill_zone_only_connects_pads_on_copper` |
| `test_pour_named_net_without_zone_fires` still passes | ✅ | Gate is `has_filled_zone`, not the name heuristic |
| Zero-fill zone still fires | ✅ | `has_filled_zone` requires real filled polygons (existing zero-fill tests green) |
| Copper-LVS suppresses advisory pour opens, keeps signal opens + shorts | ✅ | `test_pour_opens_suppressed`, `test_pour_advisory_filter_does_not_suppress_shorts` |
| Fully-covered pour zone still `Complete` | ✅ | `test_fully_filled_zone_regression`, `test_multi_zone_complete`, `test_zone_no_boundary` |

## Test Plan

- `uv run pytest tests/test_connectivity_rule.py tests/test_analysis_net_status.py tests/test_net_status.py tests/test_copper_lvs.py` — 153 passed (4 new).
- Regression sweep over every suite referencing the changed modules (board 03/04/05/06 copper-LVS, fleet status, LVS recipe, report collector/generator, pipeline, routing baselines, softstart) — green; the single board-06 pin was the targeted false positive and was updated with rationale.
- `ruff check` / `ruff format --check` / `mypy` clean on the changed source.

Scope note: `validate/connectivity.py` (the reference extractor) is not modified — its geometry is reused by composition. Short-detection paths from #3946 are untouched.

Closes #3914