### PR TITLE
fix(check): auto-load net-class-map sidecar and warn on inactive skew rules (#3917)

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -135,6 +135,42 @@ def _find_pcb_file(directory: Path) -> Path | None:
     return None
 
 
+def _discover_net_class_map_sidecar(pcb_path: Path) -> Path | None:
+    """Probe conventional locations for a ``net_class_map.json`` sidecar.
+
+    Issue #3917 Defect 2: ``kct route`` writes a ``net_class_map.json``
+    sidecar next to the routed PCB (in the output directory).  ``kct
+    check`` should auto-load it so the sidecar-gated skew / continuity
+    rules fire without the user having to pass ``--net-class-map`` by
+    hand -- mirroring the existing schematic auto-discovery.
+
+    Candidate locations, in priority order, relative to the resolved
+    PCB path:
+
+    - ``<pcb_dir>/net_class_map.json`` (sidecar written alongside a
+      routed board that lives in its own output directory)
+    - ``<pcb_dir>/output/net_class_map.json`` (board dir with an
+      ``output/`` subtree)
+    - ``<pcb_dir>/../output/net_class_map.json`` (routed PCB inside
+      ``output/`` with the sidecar as a sibling -- redundant with the
+      first candidate but kept for the ``<board>/output/<pcb>`` layout)
+
+    Returns:
+        The first existing candidate path, or ``None`` when no sidecar
+        is found.
+    """
+    pcb_dir = pcb_path.parent
+    candidates = [
+        pcb_dir / "net_class_map.json",
+        pcb_dir / "output" / "net_class_map.json",
+        pcb_dir.parent / "output" / "net_class_map.json",
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
 def _emit_drift_banner(pcb_path: Path, schematic: str | None) -> None:
     """Print the advisory schematic/PCB drift banner (non-blocking).
 
@@ -743,23 +779,55 @@ def main(argv: list[str] | None = None) -> int:
     # engagement / skew state from the routed PCB and fire.  When omitted,
     # the rules degrade to no-ops (AC #3: graceful-degradation contract).
     net_class_map = None
-    if args.net_class_map is not None:
+    # Issue #3917 Defect 2: when the user did not pass --net-class-map,
+    # auto-discover the conventional sidecar written by ``kct route`` next
+    # to the routed PCB.  An explicit flag always wins and short-circuits
+    # the probe (AC3: no double-load).
+    ncm_explicit = args.net_class_map is not None
+    if ncm_explicit:
+        ncm_path: Path | None = Path(args.net_class_map).resolve()
+    else:
+        ncm_path = _discover_net_class_map_sidecar(pcb_path)
+
+    if ncm_path is not None:
         from kicad_tools.router.rules import net_class_map_from_dict
 
-        ncm_path = Path(args.net_class_map).resolve()
         if not ncm_path.exists():
+            # Only reachable via an explicit flag (the auto-probe returns
+            # existing files only).
             print(f"Error: net-class-map file not found: {ncm_path}", file=sys.stderr)
             return 1
+        ncm_load_error: str | None = None
+        net_class_map = None
         try:
             ncm_data = json.loads(ncm_path.read_text())
-        except json.JSONDecodeError as e:
-            print(f"Error parsing net-class-map JSON: {e}", file=sys.stderr)
-            return 1
-        try:
             net_class_map = net_class_map_from_dict(ncm_data)
+        except json.JSONDecodeError as e:
+            ncm_load_error = f"parsing net-class-map JSON: {e}"
         except (TypeError, ValueError) as e:
-            print(f"Error: invalid net-class-map structure: {e}", file=sys.stderr)
-            return 1
+            ncm_load_error = f"invalid net-class-map structure: {e}"
+
+        if ncm_load_error is not None:
+            if ncm_explicit:
+                # An explicit path that fails to load is a hard error --
+                # the user asked for it specifically.
+                print(f"Error: {ncm_load_error}", file=sys.stderr)
+                return 1
+            # An auto-discovered sidecar that fails to load degrades
+            # gracefully: warn and fall back to no-sidecar behaviour
+            # rather than crashing the whole check (Issue #3917 edge case).
+            print(
+                f"WARNING: ignoring malformed net-class-map sidecar {ncm_path}: {ncm_load_error}",
+                file=sys.stderr,
+            )
+            net_class_map = None
+        elif not ncm_explicit:
+            # Auto-loaded successfully: tell the user which file engaged
+            # the sidecar-gated rules (AC2).
+            print(
+                f"[INFO] auto-loaded net-class-map sidecar: {ncm_path}",
+                file=sys.stderr,
+            )
 
     # Issue #3440: the skew rules (match_group_length_skew,
     # diffpair_length_skew, diffpair_routing_continuity) degrade to
@@ -798,6 +866,11 @@ def main(argv: list[str] | None = None) -> int:
             copper_oz=args.copper,
             suppress_library=args.suppress_library,
             net_class_map=net_class_map,
+            # The CLI already prints its own up-front INACTIVE warning
+            # below, so suppress the per-rule checker-level warning here to
+            # avoid duplicating it (Issue #3917 Defect 3).
+            warn_on_inactive_skew_rules=False,
+            verbose=args.verbose,
         )
     except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -1538,6 +1538,52 @@ def show_preview(
         return "n"
 
 
+def _write_net_class_map_sidecar(
+    output_path: Path,
+    net_class_map: dict | None,
+    quiet: bool = False,
+) -> None:
+    """Serialize the router's net-class map to a sidecar next to the PCB.
+
+    Issue #3917 Defect 1: ``net_class_map_to_dict()`` existed and was
+    round-trip tested but was never called from the route step, so the
+    ``output/net_class_map.json`` sidecar that every user-facing hint (and
+    ``kct check`` auto-discovery) points at was never actually written.
+
+    Writes ``<output_dir>/net_class_map.json`` adjacent to the routed PCB
+    so ``kct check`` can auto-load it and fire the sidecar-gated skew /
+    continuity rules.  A blocked write (read-only output dir) is a
+    non-fatal warning, never a route failure.
+
+    Args:
+        output_path: Path to the routed PCB file.  The sidecar is written
+            to the same directory.
+        net_class_map: The autorouter's ``{net_name: NetClassRouting}``
+            map.  Skipped when ``None`` or empty (an empty map would write
+            a misleading sidecar that the check-side probe would treat as
+            present).
+        quiet: If True, suppress the confirmation line.
+    """
+    if not net_class_map:
+        return
+    import json
+
+    from kicad_tools.router.rules import net_class_map_to_dict
+
+    sidecar_path = output_path.parent / "net_class_map.json"
+    try:
+        payload = net_class_map_to_dict(net_class_map)
+        sidecar_path.write_text(json.dumps(payload, indent=2))
+    except (OSError, TypeError, ValueError) as e:
+        # Non-fatal: a blocked / read-only output directory (or an
+        # unexpectedly non-serializable map) must not fail the route.
+        if not quiet:
+            print(f"  Warning: could not write net-class-map sidecar: {e}")
+        return
+    if not quiet:
+        print(f"  Net-class-map sidecar: {sidecar_path}")
+
+
 def run_post_route_drc(
     output_path: Path,
     manufacturer: str,
@@ -1564,6 +1610,14 @@ def run_post_route_drc(
     """
     from kicad_tools.schema.pcb import PCB
     from kicad_tools.validate import DRCChecker
+
+    # Issue #3917 Defect 1: persist the net-class map as a sidecar next to
+    # the routed PCB so ``kct check`` (and re-runs of this DRC) can
+    # auto-load it and fire the sidecar-gated skew / continuity rules.
+    # This is the shared post-route DRC entry for all three route flows
+    # (default multi-layer, rule-relaxation, and single-layer), so writing
+    # here covers every callsite in one place.
+    _write_net_class_map_sidecar(output_path, net_class_map, quiet=quiet)
 
     try:
         # Load the routed PCB

--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -6,6 +6,7 @@ Checks on PCB designs without requiring kicad-cli.
 
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING
 
 from kicad_tools.manufacturers import DesignRules, get_profile
@@ -66,6 +67,8 @@ class DRCChecker:
         copper_oz: float = 1.0,
         suppress_library: bool = False,
         net_class_map: dict[str, NetClassRouting] | None = None,
+        warn_on_inactive_skew_rules: bool = True,
+        verbose: bool = False,
     ) -> None:
         """Initialize the DRC checker.
 
@@ -84,6 +87,22 @@ class DRCChecker:
                 ``engaged_pairs`` set + per-pair threshold map.  When
                 omitted, the rule degrades to a no-op (graceful
                 standalone-``kct check`` behaviour).
+            warn_on_inactive_skew_rules: When True (default), the three
+                sidecar-gated skew rules
+                (``match_group_length_skew``, ``diffpair_length_skew``,
+                ``diffpair_routing_continuity``) emit a one-time stderr
+                warning when they degrade to a no-op because
+                ``net_class_map`` is ``None``.  This makes the "silently
+                passes without a sidecar" failure mode visible on *every*
+                invocation surface -- not just the ``kct check`` CLI
+                entry point, which prints its own up-front warning
+                (Issue #3917 Defect 3).  The CLI passes ``False`` here to
+                avoid duplicating its own warning.
+            verbose: When True, the sidecar-gated skew / continuity rules
+                emit advisory ``info``-severity findings that carry the
+                measured per-pair / per-group values even when the pair /
+                group passes, so ``kct check --verbose`` surfaces the
+                measurements on a clean board (Issue #3917 AC5).
 
         Raises:
             ValueError: If manufacturer ID is not recognized
@@ -94,6 +113,11 @@ class DRCChecker:
         self.copper_oz = copper_oz
         self.suppress_library = suppress_library
         self.net_class_map = net_class_map
+        self.warn_on_inactive_skew_rules = warn_on_inactive_skew_rules
+        self.verbose = verbose
+        # Dedup guard so the per-rule INACTIVE warning fires at most once
+        # per rule per checker instance (Issue #3917).
+        self._inactive_skew_warned: set[str] = set()
 
         # Load manufacturer profile and design rules
         profile = get_profile(manufacturer)
@@ -340,6 +364,33 @@ class DRCChecker:
         rule = DiffPairClearanceIntraRule()
         return rule.check(self.pcb, self.design_rules)
 
+    def _warn_inactive_skew_rule(self, rule_name: str) -> None:
+        """Emit a one-time stderr warning that a skew rule is inactive.
+
+        Issue #3917 Defect 3: the three sidecar-gated rules
+        (``match_group_length_skew``, ``diffpair_length_skew``,
+        ``diffpair_routing_continuity``) degrade to silent no-ops when the
+        checker was built without a ``net_class_map``.  The ``kct check``
+        CLI prints an up-front warning, but *direct* ``DRCChecker``
+        instantiations (the build pipeline, embedded post-route checks)
+        bypass it entirely.  Emitting the warning here makes the
+        degradation visible on every invocation surface.
+
+        Guarded by ``warn_on_inactive_skew_rules`` (the CLI disables it to
+        avoid double-warning) and deduplicated per rule per instance.
+        """
+        if not self.warn_on_inactive_skew_rules:
+            return
+        if rule_name in self._inactive_skew_warned:
+            return
+        self._inactive_skew_warned.add(rule_name)
+        print(
+            f"WARNING: rule {rule_name!r} is INACTIVE without a net-class-map "
+            "sidecar and will silently pass; pass the routed board's sidecar "
+            "(e.g. output/net_class_map.json) to validate length-match skew.",
+            file=sys.stderr,
+        )
+
     def check_diffpair_length_skew(self) -> DRCResults:
         """Check routed-length skew for engaged differential pairs.
 
@@ -385,12 +436,16 @@ class DRCChecker:
         from kicad_tools.validate.diffpair_engagement import derive_engagement_state
         from kicad_tools.validate.diffpair_skew import derive_skew_data
 
+        if self.net_class_map is None:
+            self._warn_inactive_skew_rule("diffpair_length_skew")
+
         skew_data, skew_threshold_map = derive_skew_data(self.pcb, self.net_class_map)
         engaged_pairs, _ = derive_engagement_state(self.pcb, self.net_class_map)
         rule = DiffPairLengthSkewRule(
             skew_data=skew_data,
             engaged_pairs=engaged_pairs,
             threshold_map=skew_threshold_map,
+            emit_info=self.verbose,
         )
         return rule.check(self.pcb, self.design_rules)
 
@@ -427,10 +482,14 @@ class DRCChecker:
         """
         from kicad_tools.validate.diffpair_engagement import derive_engagement_state
 
+        if self.net_class_map is None:
+            self._warn_inactive_skew_rule("diffpair_routing_continuity")
+
         engaged_pairs, threshold_map = derive_engagement_state(self.pcb, self.net_class_map)
         rule = DiffPairRoutingContinuityRule(
             engaged_pairs=engaged_pairs,
             threshold_map=threshold_map,
+            emit_info=self.verbose,
         )
         return rule.check(self.pcb, self.design_rules)
 
@@ -573,6 +632,7 @@ class DRCChecker:
         if self.net_class_map is None:
             # Graceful-no-op: no router context -> no skew data to
             # validate.  Matches the standalone-``kct check`` contract.
+            self._warn_inactive_skew_rule("match_group_length_skew")
             rule = MatchGroupLengthSkewRule()
         else:
             from kicad_tools.validate.match_group_skew import derive_group_skew_data
@@ -587,6 +647,7 @@ class DRCChecker:
                 group_skew_data=group_skew_data,
                 tracker_match_groups=tracker_match_groups,
                 threshold_map=threshold_map,
+                emit_info=self.verbose,
             )
         return rule.check(self.pcb, self.design_rules)
 

--- a/src/kicad_tools/validate/rules/diffpair_length_skew.py
+++ b/src/kicad_tools/validate/rules/diffpair_length_skew.py
@@ -161,6 +161,7 @@ class DiffPairLengthSkewRule(DRCRule):
         engaged_pairs: set[tuple[int, int]] | None = None,
         threshold_map: dict[tuple[int, int], float] | None = None,
         default_tolerance_mm: float = DEFAULT_SKEW_TOLERANCE_MM,
+        emit_info: bool = False,
     ) -> None:
         """Initialize the rule.
 
@@ -184,6 +185,12 @@ class DiffPairLengthSkewRule(DRCRule):
             default_tolerance_mm: Fallback when no per-pair tolerance
                 is set.  Defaults to
                 :data:`DEFAULT_SKEW_TOLERANCE_MM` (0.5).
+            emit_info: When True, emit an advisory ``info``-severity
+                :class:`DRCViolation` for each engaged pair that *passes*
+                its skew tolerance, carrying the measured skew.  Lets
+                ``kct check --verbose`` surface per-pair measurements even
+                on a clean board (Issue #3917 AC5).  Defaults to False
+                (no advisory noise on the default, non-verbose path).
         """
         # Normalize skew_data keys -- name tuples sorted lexicographically
         # so the caller does not have to maintain P/N ordering.
@@ -205,6 +212,7 @@ class DiffPairLengthSkewRule(DRCRule):
                 self._threshold_map[key] = thr
 
         self._default_tolerance_mm = default_tolerance_mm
+        self._emit_info = emit_info
 
     def check(
         self,
@@ -285,8 +293,44 @@ class DiffPairLengthSkewRule(DRCRule):
                         tolerance_mm=tolerance_mm,
                     )
                 )
+            elif self._emit_info:
+                # Passing pair -- surface the measured skew as an advisory
+                # ``info`` finding so ``kct check --verbose`` reports the
+                # per-pair measurement even on a clean board (Issue #3917).
+                results.add(
+                    self._make_info(
+                        name_a=name_a,
+                        name_b=name_b,
+                        skew_mm=skew_mm,
+                        tolerance_mm=tolerance_mm,
+                    )
+                )
 
         return results
+
+    def _make_info(
+        self,
+        name_a: str,
+        name_b: str,
+        skew_mm: float,
+        tolerance_mm: float,
+    ) -> DRCViolation:
+        """Build an ``info`` DRCViolation for a passing engaged pair."""
+        first, second = sorted([name_a, name_b])
+        return DRCViolation(
+            rule_id=self.rule_id,
+            severity="info",
+            message=(
+                f"Engaged differential pair {first}/{second} length-skew "
+                f"{skew_mm:.3f} mm within tolerance {tolerance_mm:.3f} mm"
+            ),
+            location=None,
+            layer=None,
+            actual_value=round(skew_mm, 4),
+            required_value=round(tolerance_mm, 4),
+            items=(),
+            nets=(first, second),
+        )
 
     def _make_violation(
         self,

--- a/src/kicad_tools/validate/rules/diffpair_routing_continuity.py
+++ b/src/kicad_tools/validate/rules/diffpair_routing_continuity.py
@@ -241,6 +241,7 @@ class DiffPairRoutingContinuityRule(DRCRule):
         coupling_window_mm: float = DEFAULT_COUPLING_WINDOW_MM,
         parallel_tolerance_deg: float = DEFAULT_PARALLEL_TOLERANCE_DEG,
         default_threshold: float = DEFAULT_COUPLED_CONTINUITY_THRESHOLD,
+        emit_info: bool = False,
     ) -> None:
         """Initialize the rule.
 
@@ -262,6 +263,12 @@ class DiffPairRoutingContinuityRule(DRCRule):
             default_threshold: Fallback when no per-pair threshold is
                 set.  Defaults to
                 :data:`DEFAULT_COUPLED_CONTINUITY_THRESHOLD` (0.7).
+            emit_info: When True, emit an advisory ``info``-severity
+                :class:`DRCViolation` for each engaged pair that *passes*
+                its continuity threshold, carrying the measured coupled
+                fraction.  Lets ``kct check --verbose`` surface per-pair
+                measurements even on a clean board (Issue #3917 AC5).
+                Defaults to False.
         """
         # Normalize key ordering so callers don't have to.
         self._engaged: set[tuple[int, int]] = set()
@@ -278,6 +285,7 @@ class DiffPairRoutingContinuityRule(DRCRule):
         self._coupling_window_mm = coupling_window_mm
         self._parallel_tolerance_deg = parallel_tolerance_deg
         self._default_threshold = default_threshold
+        self._emit_info = emit_info
 
     def check(
         self,
@@ -360,8 +368,46 @@ class DiffPairRoutingContinuityRule(DRCRule):
                         threshold=threshold,
                     )
                 )
+            elif self._emit_info:
+                # Passing pair -- surface the measured coupled fraction as
+                # an advisory ``info`` finding so ``kct check --verbose``
+                # reports the per-pair measurement even on a clean board
+                # (Issue #3917 AC5).
+                results.add(
+                    self._make_info(
+                        name_a=net_names.get(net_a, ""),
+                        name_b=net_names.get(net_b, ""),
+                        coupled_fraction=coupled_fraction,
+                        threshold=threshold,
+                    )
+                )
 
         return results
+
+    def _make_info(
+        self,
+        name_a: str,
+        name_b: str,
+        coupled_fraction: float,
+        threshold: float,
+    ) -> DRCViolation:
+        """Build an ``info`` DRCViolation for a passing engaged pair."""
+        first, second = sorted([name_a, name_b])
+        return DRCViolation(
+            rule_id=self.rule_id,
+            severity="info",
+            message=(
+                f"Engaged differential pair {first}/{second} coupled "
+                f"{coupled_fraction * 100:.1f}% of its length "
+                f"(>= {threshold * 100:.1f}% required)"
+            ),
+            location=None,
+            layer=None,
+            actual_value=round(coupled_fraction, 4),
+            required_value=round(threshold, 4),
+            items=(),
+            nets=(first, second),
+        )
 
     def _coupled_length(
         self,

--- a/src/kicad_tools/validate/rules/match_group_length_skew.py
+++ b/src/kicad_tools/validate/rules/match_group_length_skew.py
@@ -164,6 +164,7 @@ class MatchGroupLengthSkewRule(DRCRule):
         tracker_match_groups: list[MatchGroup] | None = None,
         threshold_map: dict[str, float] | None = None,
         default_tolerance_mm: float = DEFAULT_MATCH_GROUP_TOLERANCE_MM,
+        emit_info: bool = False,
     ) -> None:
         """Initialize the rule.
 
@@ -184,6 +185,11 @@ class MatchGroupLengthSkewRule(DRCRule):
             default_tolerance_mm: Fallback when no per-group tolerance
                 is set.  Defaults to
                 :data:`DEFAULT_MATCH_GROUP_TOLERANCE_MM` (0.5).
+            emit_info: When True, emit an advisory ``info``-severity
+                :class:`DRCViolation` for each declared group that *passes*
+                its tolerance, carrying the measured skew.  Lets ``kct
+                check --verbose`` surface per-group measurements even on a
+                clean board (Issue #3917 AC5).  Defaults to False.
         """
         self._group_skew_data: dict[str, float] = dict(group_skew_data) if group_skew_data else {}
 
@@ -197,6 +203,7 @@ class MatchGroupLengthSkewRule(DRCRule):
 
         self._threshold_map: dict[str, float] = dict(threshold_map) if threshold_map else {}
         self._default_tolerance_mm = default_tolerance_mm
+        self._emit_info = emit_info
 
     def check(
         self,
@@ -264,8 +271,43 @@ class MatchGroupLengthSkewRule(DRCRule):
                         tolerance_mm=tolerance_mm,
                     )
                 )
+            elif self._emit_info:
+                # Passing group -- surface the measured skew as an advisory
+                # ``info`` finding so ``kct check --verbose`` reports the
+                # per-group measurement even on a clean board (Issue #3917).
+                results.add(
+                    self._make_info(
+                        group=grp,
+                        skew_mm=skew_mm,
+                        tolerance_mm=tolerance_mm,
+                    )
+                )
 
         return results
+
+    def _make_info(
+        self,
+        group: MatchGroup,
+        skew_mm: float,
+        tolerance_mm: float,
+    ) -> DRCViolation:
+        """Build an ``info`` DRCViolation for a passing match group."""
+        member_count = len(group.net_ids) + 2 * len(group.pair_ids)
+        return DRCViolation(
+            rule_id=self.rule_id,
+            severity="info",
+            message=(
+                f"Match group {group.name!r} ({member_count} member"
+                f"{'s' if member_count != 1 else ''}) length-skew "
+                f"{skew_mm:.3f} mm within tolerance {tolerance_mm:.3f} mm"
+            ),
+            location=None,
+            layer=None,
+            actual_value=round(skew_mm, 4),
+            required_value=round(tolerance_mm, 4),
+            items=(group.name,),
+            nets=(),
+        )
 
     def _make_violation(
         self,

--- a/tests/test_cli_check_net_class_map.py
+++ b/tests/test_cli_check_net_class_map.py
@@ -312,3 +312,387 @@ class TestInactiveSkewRuleWarning:
         main([str(diffpair_pcb), "--format", "summary", "--only", "clearance"])
         captured = capsys.readouterr()
         assert "INACTIVE without --net-class-map" not in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Issue #3917: a match-group PCB whose group skew fires ONLY when the
+# net-class-map sidecar is loaded.  Used to exercise sidecar auto-discovery
+# (Defect 2), explicit-flag precedence (AC3), the malformed-sidecar
+# fall-back edge case, and the AC6 "10 errors vanish" regression.
+# ---------------------------------------------------------------------------
+MATCHGROUP_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "DQ0")
+  (net 2 "DQ1")
+  (net 3 "DQ2")
+  (net 4 "DQ3")
+  (gr_rect (start 0 0) (end 200 200)
+    (stroke (width 0.1) (type default)) (fill none) (layer "Edge.Cuts"))
+  (segment (start 10 10) (end 40 10) (width 0.2) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-000000000001"))
+  (segment (start 10 20) (end 40 20) (width 0.2) (layer "F.Cu") (net 2)
+    (uuid "00000000-0000-0000-0000-000000000002"))
+  (segment (start 10 30) (end 40 30) (width 0.2) (layer "F.Cu") (net 3)
+    (uuid "00000000-0000-0000-0000-000000000003"))
+  (segment (start 10 40) (end 100 40) (width 0.2) (layer "F.Cu") (net 4)
+    (uuid "00000000-0000-0000-0000-000000000004"))
+)
+"""
+
+# Equal-length variant: all four DQ nets are 30mm so the group skew is
+# 0mm and the rule PASSES -- used to exercise the AC5 --verbose per-group
+# INFO line on a clean board.
+MATCHGROUP_PCB_EQUAL = MATCHGROUP_PCB.replace(
+    '(segment (start 10 40) (end 100 40) (width 0.2) (layer "F.Cu") (net 4)',
+    '(segment (start 10 40) (end 40 40) (width 0.2) (layer "F.Cu") (net 4)',
+)
+
+_DDR_ENTRY = {"name": "DDR", "length_match_group": "DDR_DATA"}
+MATCHGROUP_SIDECAR = {
+    "DQ0": _DDR_ENTRY,
+    "DQ1": _DDR_ENTRY,
+    "DQ2": _DDR_ENTRY,
+    "DQ3": _DDR_ENTRY,
+}
+
+
+def _write_matchgroup_board(directory: Path, *, equal: bool = False) -> Path:
+    pcb = directory / "ddr.kicad_pcb"
+    pcb.write_text(MATCHGROUP_PCB_EQUAL if equal else MATCHGROUP_PCB)
+    return pcb
+
+
+def _write_matchgroup_sidecar(directory: Path) -> Path:
+    scar = directory / "net_class_map.json"
+    scar.write_text(json.dumps(MATCHGROUP_SIDECAR, indent=2))
+    return scar
+
+
+def _mg_error_count(json_out: str) -> int:
+    data = json.loads(json_out)
+    return sum(
+        1
+        for v in data["violations"]
+        if v["rule_id"] == "match_group_length_skew" and v["severity"] == "error"
+    )
+
+
+class TestSidecarAutoLoad:
+    """Issue #3917 Defect 2 / AC2, AC3: ``kct check`` auto-discovers the
+    ``net_class_map.json`` sidecar written by ``kct route``."""
+
+    def test_auto_load_when_sidecar_present(self, tmp_path: Path, capsys):
+        """No ``--net-class-map`` flag, but a sibling sidecar exists ->
+        auto-loaded with an INFO line, and the sidecar-gated rule fires."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = _write_matchgroup_board(tmp_path)
+        _write_matchgroup_sidecar(tmp_path)
+
+        rc = main(
+            [
+                str(pcb),
+                "--only",
+                "match_group_length_skew",
+                "--format",
+                "json",
+                "--allow-incomplete",
+            ]
+        )
+        captured = capsys.readouterr()
+        assert "auto-loaded net-class-map sidecar" in captured.err
+        # AC2: the auto-loaded sidecar engaged the rule -> it fired.
+        assert _mg_error_count(captured.out) >= 1
+        # A fired blocking rule flips the exit code off 0.
+        assert rc == 2
+
+    def test_no_autoload_message_without_sidecar(self, tmp_path: Path, capsys):
+        """No sibling sidecar -> no auto-load INFO line, rule stays a no-op."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = _write_matchgroup_board(tmp_path)  # no sidecar written
+
+        main(
+            [
+                str(pcb),
+                "--only",
+                "match_group_length_skew",
+                "--format",
+                "json",
+                "--allow-incomplete",
+            ]
+        )
+        captured = capsys.readouterr()
+        assert "auto-loaded net-class-map sidecar" not in captured.err
+        assert _mg_error_count(captured.out) == 0
+
+    def test_explicit_flag_skips_autoprobe(self, tmp_path: Path, capsys):
+        """AC3: an explicit ``--net-class-map`` wins and the auto-probe is
+        skipped (no auto-load INFO line, no double-load)."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = _write_matchgroup_board(tmp_path)
+        scar = _write_matchgroup_sidecar(tmp_path)
+
+        main(
+            [
+                str(pcb),
+                "--only",
+                "match_group_length_skew",
+                "--format",
+                "json",
+                "--allow-incomplete",
+                "--net-class-map",
+                str(scar),
+            ]
+        )
+        captured = capsys.readouterr()
+        # Explicit path -> the auto-discovery INFO line must NOT appear.
+        assert "auto-loaded net-class-map sidecar" not in captured.err
+        # Rule still fires (explicit path loaded fine).
+        assert _mg_error_count(captured.out) >= 1
+
+    def test_malformed_auto_sidecar_falls_back(self, tmp_path: Path, capsys):
+        """A malformed auto-discovered sidecar degrades gracefully: warn and
+        fall back to no-sidecar behaviour, never a hard exit-1 crash."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = _write_matchgroup_board(tmp_path)
+        (tmp_path / "net_class_map.json").write_text("not { valid json")
+
+        rc = main(
+            [
+                str(pcb),
+                "--only",
+                "match_group_length_skew",
+                "--format",
+                "json",
+                "--allow-incomplete",
+            ]
+        )
+        captured = capsys.readouterr()
+        # Not a tool-level failure (exit 1 is reserved for those).
+        assert rc != 1
+        assert "malformed net-class-map sidecar" in captured.err
+        # Fell back to no-sidecar -> rule is a no-op.
+        assert _mg_error_count(captured.out) == 0
+
+
+class TestSidecarWrittenByRoute:
+    """Issue #3917 Defect 1: the route step persists the net-class map as a
+    sidecar next to the routed PCB via ``_write_net_class_map_sidecar``."""
+
+    def test_sidecar_written_and_round_trips(self, tmp_path: Path):
+        from kicad_tools.cli.route_cmd import _write_net_class_map_sidecar
+        from kicad_tools.router.rules import (
+            NetClassRouting,
+            net_class_map_from_dict,
+            net_class_map_to_dict,
+        )
+
+        pcb_out = tmp_path / "board_routed.kicad_pcb"
+        pcb_out.write_text("(kicad_pcb)")
+        ncm = {
+            "DQ0": NetClassRouting(name="DDR", length_match_group="DDR_DATA"),
+            "DQ1": NetClassRouting(name="DDR", length_match_group="DDR_DATA"),
+        }
+
+        _write_net_class_map_sidecar(pcb_out, ncm, quiet=True)
+
+        sidecar = tmp_path / "net_class_map.json"
+        assert sidecar.is_file()
+        # AC1: round-trips with no data loss.
+        loaded = net_class_map_from_dict(json.loads(sidecar.read_text()))
+        assert loaded.keys() == ncm.keys()
+        assert loaded["DQ0"].length_match_group == "DDR_DATA"
+        assert net_class_map_to_dict(loaded) == net_class_map_to_dict(ncm)
+
+    def test_empty_map_writes_nothing(self, tmp_path: Path):
+        """An empty / None map writes no sidecar (a misleading empty sidecar
+        would trip the check-side probe)."""
+        from kicad_tools.cli.route_cmd import _write_net_class_map_sidecar
+
+        pcb_out = tmp_path / "board_routed.kicad_pcb"
+        pcb_out.write_text("(kicad_pcb)")
+
+        _write_net_class_map_sidecar(pcb_out, {}, quiet=True)
+        _write_net_class_map_sidecar(pcb_out, None, quiet=True)
+
+        assert not (tmp_path / "net_class_map.json").exists()
+
+    def test_readonly_output_dir_is_non_fatal(self, tmp_path: Path, capsys):
+        """A blocked write (read-only output dir) warns but does not raise --
+        the route must not fail because the sidecar could not be persisted."""
+        from kicad_tools.cli.route_cmd import _write_net_class_map_sidecar
+        from kicad_tools.router.rules import NetClassRouting
+
+        ro_dir = tmp_path / "ro"
+        ro_dir.mkdir()
+        pcb_out = ro_dir / "board_routed.kicad_pcb"
+        pcb_out.write_text("(kicad_pcb)")
+        ncm = {"DQ0": NetClassRouting(name="DDR", length_match_group="DDR_DATA")}
+
+        import os
+
+        os.chmod(ro_dir, 0o500)
+        try:
+            # Must not raise.
+            _write_net_class_map_sidecar(pcb_out, ncm, quiet=False)
+        finally:
+            os.chmod(ro_dir, 0o700)
+        captured = capsys.readouterr()
+        # Either the write was blocked (warning emitted) or the platform
+        # ignored the mode bits (running as root) and the sidecar exists.
+        assert (
+            "could not write net-class-map sidecar" in captured.out
+            or (ro_dir / "net_class_map.json").exists()
+        )
+
+
+class TestInactiveSkewRuleWarningNonCLI:
+    """Issue #3917 Defect 3 / AC4: the INACTIVE warning fires from a *direct*
+    ``DRCChecker`` instantiation too, not only through the ``kct check`` CLI
+    entry point."""
+
+    def test_direct_checker_warns_on_inactive_rule(self, tmp_path: Path, capsys):
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate import DRCChecker
+
+        pcb = PCB.load(_write_matchgroup_board(tmp_path))
+        checker = DRCChecker(pcb, net_class_map=None)  # default warn=True
+
+        checker.check_match_group_length_skew()
+        captured = capsys.readouterr()
+        assert "INACTIVE" in captured.err
+        assert "match_group_length_skew" in captured.err
+
+    def test_warning_deduplicated_per_rule(self, tmp_path: Path, capsys):
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate import DRCChecker
+
+        pcb = PCB.load(_write_matchgroup_board(tmp_path))
+        checker = DRCChecker(pcb, net_class_map=None)
+
+        checker.check_match_group_length_skew()
+        checker.check_match_group_length_skew()
+        captured = capsys.readouterr()
+        # One warning per rule per instance, even across repeated calls.
+        assert captured.err.count("match_group_length_skew") == 1
+
+    def test_warning_suppressible(self, tmp_path: Path, capsys):
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate import DRCChecker
+
+        pcb = PCB.load(_write_matchgroup_board(tmp_path))
+        checker = DRCChecker(pcb, net_class_map=None, warn_on_inactive_skew_rules=False)
+
+        checker.check_match_group_length_skew()
+        captured = capsys.readouterr()
+        assert "INACTIVE" not in captured.err
+
+
+class TestVerboseMeasuredValues:
+    """Issue #3917 AC5: ``--verbose`` surfaces per-group measured values even
+    when the group passes (no violation)."""
+
+    def test_passing_group_emits_info_under_verbose(self, tmp_path: Path, capsys):
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = _write_matchgroup_board(tmp_path, equal=True)
+        _write_matchgroup_sidecar(tmp_path)
+
+        main(
+            [
+                str(pcb),
+                "--only",
+                "match_group_length_skew",
+                "--verbose",
+                "--allow-incomplete",
+            ]
+        )
+        captured = capsys.readouterr()
+        # The passing group's measured skew appears as an advisory info line.
+        assert "within tolerance" in captured.out
+
+    def test_no_info_without_verbose(self, tmp_path: Path, capsys):
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = _write_matchgroup_board(tmp_path, equal=True)
+        _write_matchgroup_sidecar(tmp_path)
+
+        main(
+            [
+                str(pcb),
+                "--only",
+                "match_group_length_skew",
+                "--allow-incomplete",
+            ]
+        )
+        captured = capsys.readouterr()
+        assert "within tolerance" not in captured.out
+
+
+class TestTenVanishingErrorsRegression:
+    """Issue #3917 AC6: reproduce the board-07 "10 errors vanish" case --
+    without the sidecar the error count is strictly lower, and the delta is
+    attributable to ``match_group_length_skew`` specifically."""
+
+    def test_sidecar_delta_covers_match_group_skew(self, tmp_path: Path, capsys):
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = _write_matchgroup_board(tmp_path)
+
+        # (1) Without the sidecar: the rule degrades to a no-op.
+        rc_without = main(
+            [
+                str(pcb),
+                "--only",
+                "match_group_length_skew",
+                "--format",
+                "json",
+                "--allow-incomplete",
+            ]
+        )
+        without = capsys.readouterr()
+        without_data = json.loads(without.out)
+        without_errors = without_data["summary"]["errors"]
+        assert _mg_error_count(without.out) == 0
+        assert rc_without == 0
+        # The recipe that forgot the sidecar is warned, not sailed through.
+        assert "INACTIVE" in without.err
+
+        # (2) With the sidecar (explicit): the rule fires.
+        scar = _write_matchgroup_sidecar(tmp_path)
+        main(
+            [
+                str(pcb),
+                "--only",
+                "match_group_length_skew",
+                "--format",
+                "json",
+                "--allow-incomplete",
+                "--net-class-map",
+                str(scar),
+            ]
+        )
+        with_ = capsys.readouterr()
+        with_data = json.loads(with_.out)
+        with_errors = with_data["summary"]["errors"]
+        with_mg = _mg_error_count(with_.out)
+
+        # AC6: strictly lower without the sidecar, and the whole delta is
+        # attributable to match_group_length_skew.
+        assert with_errors > without_errors
+        assert with_mg >= 1
+        assert with_errors - without_errors == with_mg


### PR DESCRIPTION
Closes #3917

## Summary

Fixes the three coupled defects behind "kct check silently drops net-class rules (10 errors vanish) when the sidecar is absent":

1. **Defect 1 — route never wrote the sidecar.** `run_post_route_drc()` now serializes the router's `net_class_map` to `<output_dir>/net_class_map.json` via the previously-unused `net_class_map_to_dict()`. Writing in the shared post-route DRC entry covers all three route flows (default multi-layer, rule-relaxation, single-layer) in one place. Empty/`None` maps write nothing; a blocked (read-only) write warns but never fails the route.
2. **Defect 2 — check never auto-loaded it.** `check_cmd.main()` now probes conventional sidecar locations next to the PCB (mirroring the existing schematic auto-discovery) when `--net-class-map` is absent, loads it with an `[INFO] auto-loaded net-class-map sidecar: <path>` line, and short-circuits when an explicit flag is supplied (no double-load). A malformed auto-discovered sidecar warns and falls back to no-sidecar behaviour instead of crashing.
3. **Defect 3 — warning only fired via the CLI.** `DRCChecker` now emits a one-time INACTIVE warning per degraded rule on **every** invocation surface (build pipeline, embedded post-route checks), deduplicated per rule per instance. The CLI keeps its own up-front warning and passes `warn_on_inactive_skew_rules=False` to avoid duplicating it.

Plus the secondary gap (AC5): `--verbose` now surfaces per-pair/per-group measured values (skew mm, coupled fraction) as advisory `info` findings even when the pair/group **passes**, via a new `emit_info` knob on the three rules threaded from `DRCChecker(verbose=...)`.

## Acceptance criteria
- AC1 — sidecar written by route step and round-trips with no data loss
- AC2 — auto-load when present, sidecar-gated rule fires
- AC3 — explicit flag wins, auto-probe skipped
- AC4 — INACTIVE warning on every surface (direct `DRCChecker` too)
- AC5 — measured values visible on a passing check under `--verbose`
- AC6 — regression test reproduces the "errors vanish without sidecar" case: without the sidecar the error count is strictly lower and the delta is attributable to `match_group_length_skew` specifically

## Tests
- Extended `tests/test_cli_check_net_class_map.py`: `TestSidecarAutoLoad`, `TestSidecarWrittenByRoute`, `TestInactiveSkewRuleWarningNonCLI`, `TestVerboseMeasuredValues`, `TestTenVanishingErrorsRegression` — 22 pass (13 new).
- Related suites green: match-group / diff-pair validate + coverage (123 pass), route auto-fix / layer-escalation (137 pass).
- Scope kept to #3917; #3934 (DRC_TOLERANCE) left untouched.

Note: `tests/test_kct_check_parity.py::...test_board_07_gate_counts_diffpair_and_matchgroup` fails on this branch, but it fails **identically with these changes stashed** — a pre-existing board-07 committed-artifact churn issue (#3925), not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)