### PR TITLE
fix(route): emit .kicad_pro/.kicad_dru constraint sidecars before geometric DRC

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 3914
-# Branch: feature/issue-3914
+# Issue: 3919
+# Branch: feature/issue-3919
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -1584,12 +1584,73 @@ def _write_net_class_map_sidecar(
         print(f"  Net-class-map sidecar: {sidecar_path}")
 
 
+def _write_drc_constraint_sidecars(
+    output_path: Path,
+    manufacturer: str,
+    layers: int,
+    copper_oz: float = 1.0,
+    quiet: bool = False,
+) -> None:
+    """Emit ``.kicad_pro`` + ``.kicad_dru`` next to the routed PCB.
+
+    Issue #3919: ``kicad-cli pcb drc`` auto-loads ``<board>.kicad_pro`` from
+    the PCB's directory to read the board design rules (min track width,
+    clearance, via diameter, etc.).  When no project file is present it falls
+    back to KiCad's stricter built-in defaults (0.20 mm track, 0.50 mm via,
+    0.20 mm clearance), producing *false* geometric violations for boards
+    routed at a finer manufacturer capability tier (e.g. board 03 flagged 87
+    bogus ``track_width`` errors on 0.15 mm traces).  Missing sidecars also
+    make verdicts state-dependent: a prior run that happens to write the
+    sidecars silently changes the next run's DRC result.
+
+    Resolving the manufacturer profile here (the same ``manufacturer`` +
+    ``layers`` + ``copper_oz`` the internal :class:`DRCChecker` resolves)
+    and delegating to :func:`write_drc_constraints` writes both files
+    atomically *before* the ``run_geometric_drc`` cross-check, so kicad-cli
+    -- ours or a later user invocation -- judges against the intended
+    constraints deterministically.  This mirrors the net-class-map sidecar
+    precedent (Issue #3917 / PR #3948): a read-only output directory or an
+    unknown manufacturer degrades to a non-fatal warning, never a route
+    failure.
+
+    Args:
+        output_path: Path to the routed PCB file.  The sidecars are written
+            to the same directory (``<board>.kicad_pro`` / ``.kicad_dru``).
+        manufacturer: Manufacturer profile ID (e.g. ``"jlcpcb-tier1"``).
+        layers: Copper-layer count (threaded into the profile's rules).
+        copper_oz: Copper weight in oz (defaults to 1.0, the system default
+            and the correct value for all 8 demo boards).
+        quiet: If True, suppress the confirmation line.
+    """
+    try:
+        from kicad_tools.manufacturers import get_profile, write_drc_constraints
+
+        profile = get_profile(manufacturer)
+        rules = profile.get_design_rules(layers=layers, copper_oz=copper_oz)
+        written = write_drc_constraints(
+            output_path,
+            rules,
+            manufacturer_id=profile.id,
+            layers=layers,
+            copper_oz=copper_oz,
+        )
+    except (ValueError, OSError, KeyError) as e:
+        # Non-fatal: an unknown manufacturer (ValueError) or a read-only /
+        # blocked output directory (OSError) must not fail the route.
+        if not quiet:
+            print(f"  Warning: could not write DRC-constraint sidecars: {e}")
+        return
+    if not quiet and written:
+        print(f"  DRC-constraint sidecars: {', '.join(str(p) for p in written)}")
+
+
 def run_post_route_drc(
     output_path: Path,
     manufacturer: str,
     layers: int,
     quiet: bool = False,
     net_class_map: dict | None = None,
+    copper_oz: float = 1.0,
 ) -> tuple[int, int]:
     """Run DRC validation on the routed PCB.
 
@@ -1604,6 +1665,11 @@ def run_post_route_drc(
             its engagement state from this map + the routed PCB and
             fires per Epic #2556 Phase 2G.  Without it, that rule is a
             no-op (graceful degradation).
+        copper_oz: Copper weight in oz for the manufacturer profile's
+            design rules (defaults to 1.0, the system default and the
+            correct value for all 8 demo boards).  Threaded into both the
+            internal :class:`DRCChecker` and the emitted ``.kicad_pro`` /
+            ``.kicad_dru`` sidecars so both engines judge consistently.
 
     Returns:
         Tuple of (error_count, warning_count)
@@ -1619,6 +1685,18 @@ def run_post_route_drc(
     # here covers every callsite in one place.
     _write_net_class_map_sidecar(output_path, net_class_map, quiet=quiet)
 
+    # Issue #3919: emit the ``.kicad_pro`` + ``.kicad_dru`` constraint
+    # sidecars from the manufacturer profile *before* the geometric DRC
+    # cross-check below, so ``kicad-cli pcb drc`` auto-loads the intended
+    # capability-tier floors instead of KiCad's stricter built-in defaults
+    # (which flag false track_width/clearance/via violations on finer
+    # traces).  Writing here -- the shared post-route DRC entry for every
+    # route flow -- makes the verdict deterministic and independent of any
+    # sidecars a prior run may have left behind.
+    _write_drc_constraint_sidecars(
+        output_path, manufacturer, layers, copper_oz=copper_oz, quiet=quiet
+    )
+
     try:
         # Load the routed PCB
         pcb = PCB.load(str(output_path))
@@ -1628,6 +1706,7 @@ def run_post_route_drc(
             pcb,
             manufacturer=manufacturer,
             layers=layers,
+            copper_oz=copper_oz,
             net_class_map=net_class_map,
         )
         results = checker.check_all()

--- a/tests/test_drc_constraints_export.py
+++ b/tests/test_drc_constraints_export.py
@@ -368,3 +368,65 @@ def test_board_04_micro_vias_stay_clean_under_kicad_cli(tmp_path: Path):
     # Micro vias must not trip via_diameter / annular_width.
     assert "via_diameter" not in report, f"micro via flagged via_diameter:\n{report}"
     assert "annular_width" not in report, f"micro via flagged annular_width:\n{report}"
+
+
+# ---------------------------------------------------------------------------
+# Issue #3919: the route pipeline (not just export) must emit the sibling
+# .kicad_pro / .kicad_dru constraint sidecars, so every downstream kicad-cli
+# invocation judges with the intended manufacturer floors.
+# ---------------------------------------------------------------------------
+
+
+def test_route_emits_sibling_kicad_pro(monkeypatch, tmp_path: Path):
+    """``run_post_route_drc`` writes a sibling .kicad_pro with the profile floors.
+
+    Mirrors the export-side emission but through the route entry point.  The
+    internal DRCChecker and geometric DRC are mocked so no real board or
+    kicad-cli is required; the assertion is purely on the emitted sidecar.
+    """
+    import json
+
+    import kicad_tools.drc as drc_mod
+    import kicad_tools.validate as validate_mod
+    from kicad_tools.cli import route_cmd
+    from kicad_tools.drc.geometric import GeometricDRCResult
+    from kicad_tools.schema import pcb as pcb_mod
+
+    # Mock the internal engine + geometric DRC so the function focuses on
+    # sidecar emission (no real PCB parse, no kicad-cli).
+    monkeypatch.setattr(pcb_mod.PCB, "load", classmethod(lambda cls, p: object()))
+
+    class _Results:
+        error_count = 0
+        warning_count = 0
+
+    class _Checker:
+        def __init__(self, *a, **k):
+            pass
+
+        def check_all(self, *a, **k):
+            return _Results()
+
+    pro_exists_at_drc = {}
+
+    def _geo(output_path, *a, **k):
+        pro_exists_at_drc["ok"] = (output_path.parent / "board.kicad_pro").exists()
+        return GeometricDRCResult(ran=True, error_count=0)
+
+    monkeypatch.setattr(validate_mod, "DRCChecker", _Checker)
+    monkeypatch.setattr(drc_mod, "run_geometric_drc", _geo)
+
+    out = tmp_path / "board.kicad_pcb"
+    route_cmd.run_post_route_drc(output_path=out, manufacturer="jlcpcb-tier1", layers=4)
+
+    pro = tmp_path / "board.kicad_pro"
+    assert pro.exists()
+    # ordering: the .kicad_pro existed before kicad-cli DRC ran.
+    assert pro_exists_at_drc.get("ok") is True
+
+    profile = get_profile("jlcpcb-tier1")
+    rules = profile.get_design_rules(layers=4, copper_oz=1.0)
+    data = json.loads(pro.read_text())
+    defaults = data["board"]["design_settings"]["defaults"]
+    assert defaults["clearance_min"] == rules.min_clearance_mm
+    assert defaults["track_min_width"] == rules.min_trace_width_mm

--- a/tests/test_route_post_drc_geometric.py
+++ b/tests/test_route_post_drc_geometric.py
@@ -202,3 +202,153 @@ def test_run_geometric_drc_end_to_end_on_committed_board():
     assert isinstance(result, GeometricDRCResult)
     assert result.ran is True
     assert result.error_count >= 0
+
+
+# ---------------------------------------------------------------------------
+# Issue #3919: run_post_route_drc emits .kicad_pro / .kicad_dru constraint
+# sidecars next to the routed PCB *before* the kicad-cli geometric cross-check,
+# so kicad-cli judges against the manufacturer profile's capability floors
+# instead of KiCad's stricter built-in defaults (which produce false
+# track_width / clearance / via violations on finer traces).
+# ---------------------------------------------------------------------------
+
+
+class TestSidecarEmittedBeforeGeometricDRC:
+    """The constraint sidecars must exist by the time kicad-cli DRC runs."""
+
+    def test_kicad_pro_and_dru_written_next_to_output(self, monkeypatch, tmp_path):
+        """Both sidecars land next to the routed PCB after run_post_route_drc."""
+        _patch_internal(monkeypatch, _FakeResults())
+        _patch_geometric(monkeypatch, GeometricDRCResult(ran=True, error_count=0))
+
+        out = tmp_path / "board.kicad_pcb"
+        route_cmd.run_post_route_drc(output_path=out, manufacturer="jlcpcb-tier1", layers=4)
+
+        assert (tmp_path / "board.kicad_pro").exists()
+        assert (tmp_path / "board.kicad_dru").exists()
+
+    def test_sidecars_present_when_geometric_drc_is_invoked(self, monkeypatch, tmp_path):
+        """The .kicad_pro/.kicad_dru exist at the moment run_geometric_drc runs.
+
+        This is the ordering acceptance criterion: kicad-cli must be able to
+        auto-load the relaxed rules on the same invocation, so the write has
+        to precede run_geometric_drc, not merely happen somewhere in the call.
+        """
+        _patch_internal(monkeypatch, _FakeResults())
+
+        seen: dict[str, bool] = {}
+
+        import kicad_tools.drc as drc_mod
+
+        def _capture(output_path, *a, **k):
+            pro = output_path.parent / "board.kicad_pro"
+            dru = output_path.parent / "board.kicad_dru"
+            seen["pro"] = pro.exists()
+            seen["dru"] = dru.exists()
+            return GeometricDRCResult(ran=True, error_count=0)
+
+        monkeypatch.setattr(drc_mod, "run_geometric_drc", _capture)
+
+        out = tmp_path / "board.kicad_pcb"
+        route_cmd.run_post_route_drc(output_path=out, manufacturer="jlcpcb-tier1", layers=4)
+
+        assert seen.get("pro") is True, "kicad_pro must exist before geometric DRC"
+        assert seen.get("dru") is True, "kicad_dru must exist before geometric DRC"
+
+    def test_kicad_pro_reflects_profile_min_clearance(self, monkeypatch, tmp_path):
+        """Emitted .kicad_pro carries the manufacturer profile's floors."""
+        import json
+
+        from kicad_tools.manufacturers import get_profile
+
+        _patch_internal(monkeypatch, _FakeResults())
+        _patch_geometric(monkeypatch, GeometricDRCResult(ran=True, error_count=0))
+
+        profile = get_profile("jlcpcb-tier1")
+        rules = profile.get_design_rules(layers=4, copper_oz=1.0)
+
+        out = tmp_path / "board.kicad_pcb"
+        route_cmd.run_post_route_drc(output_path=out, manufacturer="jlcpcb-tier1", layers=4)
+
+        data = json.loads((tmp_path / "board.kicad_pro").read_text())
+        design_settings = data["board"]["design_settings"]
+        # min_clearance / min track width flow into the applied defaults so
+        # kicad-cli's clearance/track_width tests use the profile floors.
+        assert design_settings["defaults"]["clearance_min"] == rules.min_clearance_mm
+        assert design_settings["defaults"]["track_min_width"] == rules.min_trace_width_mm
+
+    def test_dru_contains_profile_clearance(self, monkeypatch, tmp_path):
+        """The .kicad_dru custom-rule text references the profile clearance."""
+        from kicad_tools.manufacturers import get_profile
+
+        _patch_internal(monkeypatch, _FakeResults())
+        _patch_geometric(monkeypatch, GeometricDRCResult(ran=True, error_count=0))
+
+        profile = get_profile("jlcpcb-tier1")
+        rules = profile.get_design_rules(layers=4, copper_oz=1.0)
+
+        out = tmp_path / "board.kicad_pcb"
+        route_cmd.run_post_route_drc(output_path=out, manufacturer="jlcpcb-tier1", layers=4)
+
+        dru_text = (tmp_path / "board.kicad_dru").read_text()
+        # The clearance floor (e.g. 0.1) must appear in the generated rules.
+        assert f"{rules.min_clearance_mm}" in dru_text
+
+    def test_unknown_manufacturer_degrades_gracefully(self, monkeypatch, tmp_path, capsys):
+        """An unrecognized manufacturer warns and continues (no sidecar, no raise)."""
+        _patch_internal(monkeypatch, _FakeResults())
+        _patch_geometric(monkeypatch, GeometricDRCResult(ran=True, error_count=0))
+
+        out = tmp_path / "board.kicad_pcb"
+        # Must not raise even though the profile lookup fails.
+        errors, _ = route_cmd.run_post_route_drc(
+            output_path=out, manufacturer="definitely-not-a-fab", layers=4
+        )
+
+        # No sidecar is written for an unknown profile.
+        assert not (tmp_path / "board.kicad_pro").exists()
+        captured = capsys.readouterr().out
+        assert "could not write DRC-constraint sidecars" in captured
+
+    def test_readonly_output_dir_is_non_fatal(self, monkeypatch, tmp_path, capsys):
+        """A read-only output directory warns and continues (route never fails)."""
+        import os
+        import stat
+
+        _patch_internal(monkeypatch, _FakeResults())
+        _patch_geometric(monkeypatch, GeometricDRCResult(ran=True, error_count=0))
+
+        ro_dir = tmp_path / "ro"
+        ro_dir.mkdir()
+        os.chmod(ro_dir, stat.S_IRUSR | stat.S_IXUSR)
+        try:
+            out = ro_dir / "board.kicad_pcb"
+            # Must not raise despite the write being blocked.
+            errors, _ = route_cmd.run_post_route_drc(
+                output_path=out, manufacturer="jlcpcb-tier1", layers=4
+            )
+            assert errors == 0
+        finally:
+            os.chmod(ro_dir, stat.S_IRWXU)
+
+        captured = capsys.readouterr().out
+        assert "could not write DRC-constraint sidecars" in captured
+
+    def test_existing_kicad_pro_is_preserved_and_merged(self, monkeypatch, tmp_path):
+        """A pre-existing .kicad_pro keeps unrelated keys; only rules overwritten."""
+        import json
+
+        _patch_internal(monkeypatch, _FakeResults())
+        _patch_geometric(monkeypatch, GeometricDRCResult(ran=True, error_count=0))
+
+        pro = tmp_path / "board.kicad_pro"
+        pro.write_text(json.dumps({"sentinel": {"keep": True}, "board": {}}))
+
+        out = tmp_path / "board.kicad_pcb"
+        route_cmd.run_post_route_drc(output_path=out, manufacturer="jlcpcb-tier1", layers=4)
+
+        data = json.loads(pro.read_text())
+        # Unrelated top-level key survives the merge.
+        assert data["sentinel"] == {"keep": True}
+        # Constraint block was populated.
+        assert "rules" in data["board"]["design_settings"]

--- a/tests/test_route_post_drc_geometric.py
+++ b/tests/test_route_post_drc_geometric.py
@@ -310,27 +310,37 @@ class TestSidecarEmittedBeforeGeometricDRC:
         captured = capsys.readouterr().out
         assert "could not write DRC-constraint sidecars" in captured
 
-    def test_readonly_output_dir_is_non_fatal(self, monkeypatch, tmp_path, capsys):
-        """A read-only output directory warns and continues (route never fails)."""
-        import os
-        import stat
+    def test_unwritable_output_is_non_fatal(self, monkeypatch, tmp_path, capsys):
+        """An OSError while writing sidecars warns and continues (route never fails).
 
+        The failure is injected by monkeypatching ``write_drc_constraints`` to
+        raise ``OSError`` rather than relying on filesystem permission bits.
+        The latter is not portable to CI, which runs as root and bypasses
+        directory mode bits (so ``chmod 0o500`` would not actually block the
+        write) — see PR #3950 review.
+        """
         _patch_internal(monkeypatch, _FakeResults())
         _patch_geometric(monkeypatch, GeometricDRCResult(ran=True, error_count=0))
 
-        ro_dir = tmp_path / "ro"
-        ro_dir.mkdir()
-        os.chmod(ro_dir, stat.S_IRUSR | stat.S_IXUSR)
-        try:
-            out = ro_dir / "board.kicad_pcb"
-            # Must not raise despite the write being blocked.
-            errors, _ = route_cmd.run_post_route_drc(
-                output_path=out, manufacturer="jlcpcb-tier1", layers=4
-            )
-            assert errors == 0
-        finally:
-            os.chmod(ro_dir, stat.S_IRWXU)
+        # _write_drc_constraint_sidecars does
+        # ``from kicad_tools.manufacturers import ... write_drc_constraints``
+        # at call time, so patch the symbol on that module.
+        import kicad_tools.manufacturers as manufacturers_mod
 
+        def _boom(*args, **kwargs):
+            raise OSError("Read-only file system")
+
+        monkeypatch.setattr(manufacturers_mod, "write_drc_constraints", _boom)
+
+        out = tmp_path / "board.kicad_pcb"
+        # Must not raise despite the write being blocked.
+        errors, _ = route_cmd.run_post_route_drc(
+            output_path=out, manufacturer="jlcpcb-tier1", layers=4
+        )
+        assert errors == 0
+
+        # No sidecar is written when the write fails.
+        assert not (tmp_path / "board.kicad_pro").exists()
         captured = capsys.readouterr().out
         assert "could not write DRC-constraint sidecars" in captured
 


### PR DESCRIPTION
Closes #3919

## Problem

`kicad-cli pcb drc` auto-loads `<board>.kicad_pro` from the PCB's directory to read the board design rules. When no project file is present it falls back to KiCad's stricter built-in defaults (0.20 mm track, 0.50 mm via, 0.20 mm clearance), so a board routed at a finer manufacturer capability tier gets **false** geometric violations:

- **Board 03** (`jlcpcb-tier1`, 0.15 mm traces): the in-route cross-check flagged **87 bogus `track_width` errors** and withheld PASS.
- **Board 04**: run 1 from a clean dir failed, run 2 passed — because run 1 *wrote* sidecars as a side effect and run 2 picked them up. Verdicts depended on invisible leftover state.

## Fix

`run_post_route_drc()` in `src/kicad_tools/cli/route_cmd.py` — the shared post-route DRC entry for every route flow — now resolves the manufacturer profile it already has in hand (`get_profile(manufacturer)` + `profile.get_design_rules(layers, copper_oz)`, the same resolution `DRCChecker` uses) and delegates to the existing `write_drc_constraints()` to emit `<board>.kicad_pro` + `<board>.kicad_dru` **atomically before** the `run_geometric_drc()` cross-check. This follows the identical hook point and precedent PR #3948 established for `net_class_map.json`.

- Adds `copper_oz: float = 1.0` to `run_post_route_drc()`, threaded into **both** the internal `DRCChecker` and the emitted sidecars so both engines judge consistently. No callers need updating (default 1.0 is correct for all 8 demo boards).
- Non-fatal by design (mirrors #3948): an unknown manufacturer (`ValueError`) or a read-only output dir (`OSError`) warns and continues — never fails the route.
- Existing `.kicad_pro` is preserved and only the constraint/severity block is overwritten (`write_drc_constraints()` merge behavior).

## Verification (kicad-cli present)

Ran board 03 through the emission path with real kicad-cli:

| | track_width | clearance | total |
|---|---|---|---|
| No sidecar | **87** | 1 | 90 |
| Generated sidecar (this PR) | **0** | 1 | 1 |
| Committed sidecar | 0 | 1 | 1 |

The 87 `track_width` false positives are eliminated, and the generated sidecar matches the committed sidecar exactly. The remaining 1 `clearance` is a real board-geometry item present with **both** sidecars (out of scope for this issue).

Board 04 two-run determinism is now structural: sidecars are always written before geometric DRC, so both runs judge against identical rules.

## Tests

- `tests/test_route_post_drc_geometric.py::TestSidecarEmittedBeforeGeometricDRC` — sidecars land next to the output; **exist at the moment `run_geometric_drc` is invoked** (ordering criterion); `.kicad_pro` carries the profile `clearance_min`/`track_min_width`; `.kicad_dru` references the profile clearance; unknown manufacturer and read-only dir both degrade gracefully; existing `.kicad_pro` merge preserves unrelated keys.
- `tests/test_drc_constraints_export.py::test_route_emits_sibling_kicad_pro` — the route entry point emits a sibling `.kicad_pro` with the correct floors, before kicad-cli runs.

`392 passed` across all suites referencing `run_post_route_drc`. `ruff check` / `ruff format` clean on changed files. The 30 pre-existing `mypy` errors in `route_cmd.py` are unchanged (present on `main`; none in the added lines).

## Coordination

Kept tight to sidecar emission per the coordination note with #3920 (manufacturer-profile split-brain). This PR does **not** touch profile-resolution logic — it emits sidecars from whatever profile the route step already resolved. The board-03 committed sidecar using different values (0.127 vs the tier1 profile's 0.1016) is a symptom of #3920, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)