### PR TITLE
fix(build): resolve one manufacturer profile for every pipeline stage (#3920)

### DIFF
--- a/boards/03-usb-joystick/project.kct
+++ b/boards/03-usb-joystick/project.kct
@@ -77,7 +77,7 @@ requirements:
       height: "60mm"
 
   manufacturing:
-    target_fab: jlcpcb
+    target_fab: jlcpcb-tier1
     layers:
       preferred: 2
     min_trace: "0.15mm"

--- a/boards/04-stm32-devboard/project.kct
+++ b/boards/04-stm32-devboard/project.kct
@@ -78,7 +78,7 @@ requirements:
       height: "40mm"
 
   manufacturing:
-    target_fab: jlcpcb
+    target_fab: jlcpcb-tier1
     layers:
       preferred: 2
     min_trace: "0.15mm"

--- a/src/kicad_tools/cli/build_cmd.py
+++ b/src/kicad_tools/cli/build_cmd.py
@@ -102,6 +102,42 @@ class BuildContext:
         return script.resolve() in self._executed_scripts
 
 
+def _resolve_effective_mfr(
+    cli_mfr: str | None,
+    spec: ProjectSpec | None,
+    default: str = "jlcpcb",
+) -> str:
+    """Resolve the single manufacturer profile the whole build judges against.
+
+    Precedence (highest first):
+
+    1. ``cli_mfr`` -- an explicit ``--mfr`` flag. ``None`` means the flag was
+       not supplied (the argparse default is ``None``), so it does not win.
+    2. ``spec.requirements.manufacturing.target_fab`` -- the project's
+       declared fab tier.
+    3. ``default`` -- the historical ``"jlcpcb"`` fallback.
+
+    This is the fix for the issue #3920 "split-brain": previously only the
+    export step consulted ``target_fab`` while route/verify/stitch used the
+    CLI default ``"jlcpcb"``, so a board whose recipe routed at (e.g.)
+    ``jlcpcb-tier1`` was verified at the base tier and reported spurious
+    ``via_in_pad`` errors. Resolving once here and threading the result
+    through ``BuildContext.mfr`` makes every stage agree.
+    """
+    if cli_mfr is not None:
+        return cli_mfr
+
+    if (
+        spec is not None
+        and spec.requirements is not None
+        and spec.requirements.manufacturing is not None
+        and spec.requirements.manufacturing.target_fab
+    ):
+        return spec.requirements.manufacturing.target_fab
+
+    return default
+
+
 def _find_spec_file(directory: Path) -> Path | None:
     """Find a .kct file in the given directory."""
     kct_files = list(directory.glob("*.kct"))
@@ -2390,15 +2426,13 @@ def _run_step_export(ctx: BuildContext, console: Console) -> BuildResult:
             message="No PCB file found to export",
         )
 
-    # Determine manufacturer: prefer target_fab from spec, fall back to ctx.mfr
+    # Use the single resolved profile. ctx.mfr was resolved once in main()
+    # from (in precedence order) an explicit --mfr flag, the spec's
+    # manufacturing.target_fab, or the "jlcpcb" default -- so every pipeline
+    # step judges against the same manufacturer (issue #3920). Re-reading
+    # target_fab here would silently override an explicit --mfr and re-open
+    # the split-brain, so we deliberately do not.
     mfr = ctx.mfr
-    if (
-        ctx.spec
-        and ctx.spec.requirements
-        and ctx.spec.requirements.manufacturing
-        and ctx.spec.requirements.manufacturing.target_fab
-    ):
-        mfr = ctx.spec.requirements.manufacturing.target_fab
 
     # Determine output directory
     if ctx.output_dir:
@@ -2636,8 +2670,13 @@ Examples:
         "--mfr",
         "-m",
         choices=get_all_manufacturer_names(),
-        default="jlcpcb",
-        help="Target manufacturer for verification (default: jlcpcb)",
+        default=None,
+        help=(
+            "Target manufacturer for verification. When omitted, the "
+            "manufacturing.target_fab from the project spec is used "
+            "(default: jlcpcb if neither is set). An explicit --mfr "
+            "always overrides the spec."
+        ),
     )
     parser.add_argument(
         "--dry-run",
@@ -2738,6 +2777,12 @@ def main(argv: list[str] | None = None) -> int:
                 e,
             )
 
+    # Resolve the effective manufacturer profile once, so every pipeline
+    # step (route, stitch, verify, export) judges against a single source
+    # of truth (issue #3920). Precedence: an explicit --mfr flag wins,
+    # otherwise the spec's manufacturing.target_fab, otherwise "jlcpcb".
+    effective_mfr = _resolve_effective_mfr(args.mfr, spec)
+
     # Resolve output directory if provided
     output_dir: Path | None = None
     if args.output:
@@ -2759,7 +2804,7 @@ def main(argv: list[str] | None = None) -> int:
         schematic_file=schematic,
         pcb_file=pcb,
         output_dir=output_dir,
-        mfr=args.mfr,
+        mfr=effective_mfr,
         verbose=args.verbose,
         dry_run=args.dry_run,
         quiet=args.quiet,
@@ -2776,7 +2821,7 @@ def main(argv: list[str] | None = None) -> int:
         header_lines = (
             f"[bold]Building:[/bold] {project_name}\n"
             f"[dim]Directory:[/dim] {project_dir}\n"
-            f"[dim]Manufacturer:[/dim] {args.mfr}"
+            f"[dim]Manufacturer:[/dim] {effective_mfr}"
         )
         if output_dir:
             header_lines += f"\n[dim]Output:[/dim] {output_dir}"

--- a/src/kicad_tools/cli/commands/build.py
+++ b/src/kicad_tools/cli/commands/build.py
@@ -17,9 +17,13 @@ def run_build_command(args) -> int:
     if getattr(args, "build_step", "all") != "all":
         sub_argv.extend(["--step", args.build_step])
 
-    # Manufacturer
-    if getattr(args, "build_mfr", "jlcpcb") != "jlcpcb":
-        sub_argv.extend(["--mfr", args.build_mfr])
+    # Manufacturer. The outer parser default is None so an explicit --mfr
+    # (even "--mfr jlcpcb") is forwarded and treated as an override, while
+    # omitting the flag lets build_cmd resolve the spec's target_fab
+    # (issue #3920). Forwarding only-when-not-None preserves that signal.
+    build_mfr = getattr(args, "build_mfr", None)
+    if build_mfr is not None:
+        sub_argv.extend(["--mfr", build_mfr])
 
     # Flags
     if getattr(args, "build_dry_run", False):

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -6106,8 +6106,12 @@ def _add_build_parser(subparsers) -> None:
         "-m",
         dest="build_mfr",
         choices=get_all_manufacturer_names(),
-        default="jlcpcb",
-        help="Target manufacturer for verification (default: jlcpcb)",
+        default=None,
+        help=(
+            "Target manufacturer for verification. When omitted, the "
+            "project spec's manufacturing.target_fab is used (falling back "
+            "to jlcpcb). An explicit --mfr always overrides the spec."
+        ),
     )
     build_parser.add_argument(
         "--dry-run",

--- a/tests/test_build_export_step.py
+++ b/tests/test_build_export_step.py
@@ -92,12 +92,24 @@ class TestRunStepExport:
         assert result.success
         assert "board_routed" in result.message
 
-    def test_uses_target_fab_from_spec(self, tmp_path: Path) -> None:
-        """When spec has target_fab, it should be used instead of ctx.mfr."""
+    def test_uses_ctx_mfr_not_stale_spec_reread(self, tmp_path: Path) -> None:
+        """The export step uses ctx.mfr, not a fresh re-read of spec.target_fab.
+
+        Issue #3920: previously ``_run_step_export`` re-read
+        ``spec.requirements.manufacturing.target_fab`` and let it override
+        ctx.mfr -- the "split-brain" where export judged against a different
+        profile than route/verify/stitch. The manufacturer is now resolved
+        exactly once (``build_cmd._resolve_effective_mfr``) and threaded
+        through ``ctx.mfr`` at BuildContext creation, so the export step must
+        honour ctx.mfr even when the spec carries a *different* target_fab
+        (e.g. when an explicit ``--mfr`` override was applied upstream).
+        """
         pcb_file = tmp_path / "board.kicad_pcb"
         pcb_file.write_text("(kicad_pcb)")
 
-        # Create a mock spec with target_fab
+        # Spec still declares "pcbway", but ctx.mfr was resolved to "oshpark"
+        # upstream (e.g. an explicit --mfr override). The export step must
+        # follow ctx.mfr, not silently snap back to the spec value.
         mock_spec = MagicMock()
         mock_spec.requirements.manufacturing.target_fab = "pcbway"
         mock_spec.requirements.manufacturing.assembly = None
@@ -107,13 +119,14 @@ class TestRunStepExport:
             spec_file=None,
             pcb_file=pcb_file,
             spec=mock_spec,
-            mfr="jlcpcb",
+            mfr="oshpark",
             dry_run=True,
         )
         console = Console(quiet=True)
         result = _run_step_export(ctx, console)
         assert result.success
-        assert "pcbway" in result.message
+        assert "oshpark" in result.message
+        assert "pcbway" not in result.message
 
     def test_falls_back_to_ctx_mfr(self, tmp_path: Path) -> None:
         """When spec has no target_fab, ctx.mfr should be used."""

--- a/tests/test_mfr_profile_consistency.py
+++ b/tests/test_mfr_profile_consistency.py
@@ -1,0 +1,278 @@
+"""Cross-stage manufacturer-profile consistency regression guard (issue #3920).
+
+Background -- the "split-brain"
+--------------------------------
+Boards 03 (USB joystick) and 04 (STM32 devboard) route with
+``kct route --manufacturer jlcpcb-tier1`` (JLCPCB Tier 1 permits the
+in-pad / micro-vias these boards deliberately place). But their
+``project.kct`` used to declare ``target_fab: jlcpcb`` (the base tier,
+which forbids via-in-pad), and ``kct build`` only consulted
+``target_fab`` in its *export* step -- every other step
+(route/verify/stitch) used ``BuildContext.mfr`` which was initialised
+from the CLI default ``"jlcpcb"``.
+
+The result was that the *same committed PCB* scored differently at each
+surface: the recipe saw 0 violations (tier1), the build verify step saw
+4 ``via_in_pad`` errors (base tier), and the export preflight / board.json
+saw 5. This test pins the two halves of the fix so the disagreement
+cannot silently return:
+
+* **Part 1 (data):** ``project.kct target_fab`` now declares
+  ``jlcpcb-tier1`` for boards 03 and 04, matching the tier the recipes
+  route against.
+* **Part 2 (pipeline):** ``kct build`` resolves the manufacturer once
+  (``build_cmd._resolve_effective_mfr``) and threads it through
+  ``BuildContext.mfr`` so route/verify/stitch/export all agree.
+
+What this test asserts
+----------------------
+1. ``_resolve_effective_mfr`` precedence: explicit ``--mfr`` wins; else
+   the spec's ``target_fab``; else the ``"jlcpcb"`` default.
+2. For each board that declares ``target_fab``, ``kct check`` against the
+   committed routed PCB at that profile reports **0 blocking DRC errors**.
+3. Negative control: board 03's committed PCB *does* report ``via_in_pad``
+   errors at the base ``jlcpcb`` tier -- proving the two tiers genuinely
+   disagree and that the ``target_fab`` declaration is load-bearing, not
+   vacuous. (This is the "reproduce the 0-vs-4 disagreement" half of the
+   issue's test plan.)
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from kicad_tools.cli.build_cmd import _resolve_effective_mfr
+from kicad_tools.spec import load_spec
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_TOLERANCE_YAML = REPO_ROOT / ".github" / "routed-drc-tolerance.yml"
+
+# Boards whose recipe routes at an explicit non-default fab tier and whose
+# committed routed artifact must therefore verify clean at that same tier.
+_BOARDS = {
+    "03-usb-joystick": "output/usb_joystick_routed.kicad_pcb",
+    "04-stm32-devboard": "output/stm32_devboard_routed.kicad_pcb",
+}
+
+
+def _project_kct(board: str) -> Path:
+    return REPO_ROOT / "boards" / board / "project.kct"
+
+
+def _routed_pcb(board: str) -> Path:
+    return REPO_ROOT / "boards" / board / _BOARDS[board]
+
+
+def _pcb_rel(board: str) -> str:
+    return f"boards/{board}/{_BOARDS[board]}"
+
+
+def _tolerance_doc() -> dict:
+    return yaml.safe_load(_TOLERANCE_YAML.read_text())
+
+
+def _tolerance_floor(board: str) -> int:
+    """Max blocking errors the CI gate tolerates for this board (default 0)."""
+    doc = _tolerance_doc()
+    return int(doc.get("tolerances", {}).get(_pcb_rel(board), 0))
+
+
+def _tolerance_mfr(board: str) -> str | None:
+    """Manufacturer profile the CI gate uses for this board (default None)."""
+    doc = _tolerance_doc()
+    return doc.get("manufacturers", {}).get(_pcb_rel(board))
+
+
+def _target_fab(board: str) -> str:
+    spec = load_spec(_project_kct(board))
+    assert spec.requirements is not None
+    assert spec.requirements.manufacturing is not None
+    fab = spec.requirements.manufacturing.target_fab
+    assert fab, f"{board}/project.kct declares no manufacturing.target_fab"
+    return fab
+
+
+def _run_check(pcb: Path, mfr: str) -> dict:
+    """Run ``kct check --format json`` and return the parsed report."""
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "kicad_tools.cli",
+            "check",
+            str(pcb),
+            "--mfr",
+            mfr,
+            "--format",
+            "json",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    assert proc.stdout, (
+        f"kct check produced no stdout for {pcb.name} @ {mfr}.\nstderr:\n{proc.stderr}"
+    )
+    return json.loads(proc.stdout)
+
+
+# --------------------------------------------------------------------------
+# Part 2 unit coverage: the single-source-of-truth resolver.
+# --------------------------------------------------------------------------
+
+
+class _MockManufacturing:
+    def __init__(self, target_fab: str | None) -> None:
+        self.target_fab = target_fab
+
+
+class _MockRequirements:
+    def __init__(self, target_fab: str | None) -> None:
+        self.manufacturing = _MockManufacturing(target_fab)
+
+
+class _MockSpec:
+    def __init__(self, target_fab: str | None) -> None:
+        self.requirements = _MockRequirements(target_fab)
+
+
+def test_resolve_explicit_mfr_wins_over_spec() -> None:
+    """An explicit ``--mfr`` flag overrides the spec's target_fab."""
+    spec = _MockSpec(target_fab="jlcpcb-tier1")
+    assert _resolve_effective_mfr("jlcpcb", spec) == "jlcpcb"  # type: ignore[arg-type]
+
+
+def test_resolve_spec_target_fab_when_no_flag() -> None:
+    """With no ``--mfr`` flag (None), the spec's target_fab is used.
+
+    This is the crux of #3920: before the fix, route/verify/stitch fell
+    back to the CLI default ``"jlcpcb"`` and ignored target_fab entirely.
+    """
+    spec = _MockSpec(target_fab="jlcpcb-tier1")
+    assert _resolve_effective_mfr(None, spec) == "jlcpcb-tier1"  # type: ignore[arg-type]
+
+
+def test_resolve_default_when_no_flag_and_no_target_fab() -> None:
+    """Falls back to the historical ``"jlcpcb"`` default when nothing else set."""
+    assert _resolve_effective_mfr(None, None) == "jlcpcb"
+    assert _resolve_effective_mfr(None, _MockSpec(target_fab=None)) == "jlcpcb"  # type: ignore[arg-type]
+
+
+def test_resolve_real_spec_board_03() -> None:
+    """The real board-03 spec resolves to its declared tier with no flag."""
+    spec = load_spec(_project_kct("03-usb-joystick"))
+    assert _resolve_effective_mfr(None, spec) == "jlcpcb-tier1"
+
+
+# --------------------------------------------------------------------------
+# Part 1 data coverage: the declaration matches the routed tier.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("board", sorted(_BOARDS))
+def test_project_kct_declares_tier1(board: str) -> None:
+    """Boards 03/04 declare jlcpcb-tier1 (the tier their recipes route at)."""
+    assert _target_fab(board) == "jlcpcb-tier1", (
+        f"{board}/project.kct target_fab must match the tier its "
+        f"generate_design.py routes against (jlcpcb-tier1). If the board "
+        f"was retargeted, update the recipe --manufacturer arg and "
+        f".github/routed-drc-tolerance.yml in lockstep."
+    )
+
+
+@pytest.mark.parametrize("board", sorted(_BOARDS))
+def test_declarations_agree_across_files(board: str) -> None:
+    """The two profile declaration files must name the same manufacturer.
+
+    ``project.kct target_fab`` (consumed by ``kct build``) and the
+    ``manufacturers:`` block of ``.github/routed-drc-tolerance.yml``
+    (consumed by the CI gate) are the two surfaces that declare which
+    profile a board is judged against. Issue #3920's whole point is a
+    single source of truth -- if these two disagree, the split-brain is
+    back on a different pair of surfaces.
+    """
+    spec_fab = _target_fab(board)
+    ci_fab = _tolerance_mfr(board)
+    assert ci_fab == spec_fab, (
+        f"{board}: project.kct target_fab={spec_fab!r} disagrees with the "
+        f".github/routed-drc-tolerance.yml manufacturers: entry {ci_fab!r}. "
+        f"These must be kept in lockstep so kct build and the CI DRC gate "
+        f"judge the same copper against the same fab tier (issue #3920)."
+    )
+
+
+# --------------------------------------------------------------------------
+# Cross-stage agreement: committed PCB verifies clean at the declared tier.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("board", sorted(_BOARDS))
+def test_committed_pcb_within_gate_at_declared_tier(board: str) -> None:
+    """``kct check`` at ``project.kct target_fab`` passes the CI DRC gate.
+
+    Core acceptance criterion: the profile the board declares is the
+    profile under which its committed copper meets the CI gate, so every
+    ``kct build`` stage (which now sources ``ctx.mfr`` from ``target_fab``)
+    agrees with the gate.
+
+    The bar is the ``tolerances:`` floor from
+    ``.github/routed-drc-tolerance.yml`` -- 0 for board 03 (strict clean),
+    2 for board 04 (two documented pre-existing sub-0.5mm drill pairs,
+    a layout issue tracked separately in #3847 and *out of scope* for the
+    profile-consistency fix). Anchoring to the same floor the CI gate uses
+    keeps this test honest about what "consistent" means without pretending
+    the drill residual is a profile bug.
+    """
+    pcb = _routed_pcb(board)
+    if not pcb.exists():
+        pytest.skip(f"committed routed PCB not present: {pcb}")
+
+    fab = _target_fab(board)
+    floor = _tolerance_floor(board)
+    report = _run_check(pcb, fab)
+
+    assert report["manufacturer"] == fab
+    errors = report["summary"]["errors"]
+    error_rules = [v["rule_id"] for v in report["violations"] if v["severity"] == "error"]
+    assert errors <= floor, (
+        f"{board} committed PCB reports {errors} blocking DRC error(s) at "
+        f"its declared tier {fab!r}, exceeding the CI gate floor of {floor}. "
+        f"Either the copper regressed or target_fab drifted out of "
+        f"agreement with the routed artifact. Error rules: {error_rules}"
+    )
+
+
+def test_board_03_reproduces_split_brain_at_base_tier() -> None:
+    """Negative control: board-03 PCB is NOT clean at the base jlcpcb tier.
+
+    Reproduces the original 0-vs-4 disagreement (issue #3920): the same
+    committed copper that is clean at jlcpcb-tier1 reports ``via_in_pad``
+    errors at the base ``jlcpcb`` tier, because that tier forbids the
+    in-pad vias on the USB-C F.Cu/GND pads. This proves the target_fab
+    declaration is load-bearing -- if this test ever passes with 0 errors,
+    the two tiers no longer differ on this board and the guard above is
+    vacuous.
+    """
+    pcb = _routed_pcb("03-usb-joystick")
+    if not pcb.exists():
+        pytest.skip(f"committed routed PCB not present: {pcb}")
+
+    report = _run_check(pcb, "jlcpcb")
+    error_rules = {v["rule_id"] for v in report["violations"] if v["severity"] == "error"}
+    assert report["summary"]["errors"] > 0
+    assert "via_in_pad" in error_rules, (
+        "Expected via_in_pad errors at the base jlcpcb tier (the "
+        "split-brain the fix eliminates at tier1). If the board's copper "
+        "changed so it no longer uses in-pad vias, this negative control "
+        "and the issue-3920 rationale need revisiting."
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover -- manual debugging convenience.
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes the issue #3920 "split-brain" where the *same committed PCB* scored differently at each build surface. Boards 03 (USB joystick) and 04 (STM32 devboard) route with `--manufacturer jlcpcb-tier1` (Tier 1 permits their deliberate in-pad vias), but their `project.kct` declared `target_fab: jlcpcb` (base tier, which forbids via-in-pad). Meanwhile `kct build` only consulted `target_fab` in its **export** step; every other step (route/verify/stitch) used `BuildContext.mfr` initialised from the CLI default `"jlcpcb"`. Result: verify saw 4 spurious `via_in_pad` errors on copper the recipe judged clean (0), export/board.json saw 5.

## Root cause & fix (two compounding causes)

**Part 1 - data.** `boards/03-usb-joystick/project.kct` and `boards/04-stm32-devboard/project.kct`: `target_fab: jlcpcb` -> `jlcpcb-tier1`, aligning the declared tier with the tier the recipes already route against. This also matches the `manufacturers:` block in `.github/routed-drc-tolerance.yml` (already `jlcpcb-tier1`).

**Part 2 - pipeline.** `src/kicad_tools/cli/build_cmd.py` now resolves the manufacturer exactly once via a new `_resolve_effective_mfr()` helper (precedence: explicit `--mfr` > spec `target_fab` > `"jlcpcb"`) and threads it through `BuildContext.mfr`, so route/verify/stitch/export all agree. `_run_step_export` now uses `ctx.mfr` directly instead of re-reading `target_fab` (which would silently override an explicit `--mfr` and re-open the split-brain). The outer build parser's `--mfr` default is `None` with forward-when-not-None dispatch in `commands/build.py`, so `--mfr jlcpcb` is a real override rather than being swallowed as the default.

Out of scope (deliberately untouched): routing/via geometry, `board_metrics_cmd.py` structure, and the `.kicad_pro`/`.kicad_dru` sidecar emission of #3919 (parallel work). Board 04's 2 pre-existing sub-0.5mm drill-clearance violations are a layout issue tracked in #3847, not a profile bug; the tolerance floor (2) is unchanged.

## Before / after (Board 03 committed routed PCB)

| Surface | Before | After |
|---|---|---|
| `kct check --mfr jlcpcb-tier1` | 0 errors | 0 errors |
| `kct check --mfr jlcpcb` (base) | 4 via_in_pad | 4 via_in_pad (override still works) |
| `kct build` resolved profile (no flag) | `jlcpcb` (default) -> verify FAIL | `jlcpcb-tier1` (from target_fab) -> agrees |
| `kct build --mfr jlcpcb` (override) | swallowed -> tier1 | `jlcpcb` honoured end-to-end |

## Tests

- New `tests/test_mfr_profile_consistency.py` (11 tests): resolver precedence; both declaration files (`project.kct` + `routed-drc-tolerance.yml`) name the same profile; committed PCBs meet the CI gate floor at their declared tier; negative control reproducing the 0-vs-4 base-tier disagreement (`via_in_pad`).
- Updated `test_build_export_step` to guard the new single-source-of-truth (export follows `ctx.mfr`, not a stale spec re-read).
- Green: `test_mfr_profile_consistency`, `test_build_export_step`, `test_build_parser_parity`, `test_board_03_regression`, `test_board_04_drc_recipe_mfr`, `test_board_04_mfr_gate`, plus build sync/erc/zones/cmd_errors and manufacturer registry sync (300+ tests). No new mypy errors (3 pre-existing, unchanged). Ruff clean.

Closes #3920

🤖 Generated with [Claude Code](https://claude.com/claude-code)