### PR TITLE
fix(boards/03): restore --differential-pairs to routing recipe (#3922)

### DIFF
--- a/boards/03-usb-joystick/generate_design.py
+++ b/boards/03-usb-joystick/generate_design.py
@@ -581,10 +581,39 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
         # wall-clock cutoff and pins a fixed node-expansion backstop, so
         # the seed-42 re-route is byte-identical (UUID-normalized) across
         # machines.  --timeout 600 below is then a SAFETY backstop only.
-        # KEEP IN SYNC with tests/router/test_board03_routing_baseline.py.
+        # KEEP IN SYNC with tests/router/test_board03_routing_baseline.py --
+        # this includes --differential-pairs and --net-class-map below.
         "--deterministic-budget",
         "--timeout",
         "600",
+        # Issue #3922 REGRESSION FIX: the #3308/#3410 recipe consolidation
+        # silently dropped ``--differential-pairs``, so the recipe no longer
+        # even *requested* diff-pair routing and the boards/README claim went
+        # false.  Restore the flag (and forward the sidecar via
+        # ``--net-class-map`` so the USB D+/D- ``diffpair_partner`` /
+        # ``intra_pair_clearance`` (0.15mm, #3095) metadata engages the
+        # validate-side diff-pair DRC rules).  The sidecar is written above.
+        #
+        # IMPORTANT (scope note for #3922): on THIS board the flag is
+        # currently inert at routing time.  Board 03 has dense fine-pitch
+        # packages (U1 QFP-32, J1 USB-C), so the CLI takes the escape-routing
+        # dispatch, and route_cmd's escape / auto-layers-escalation paths do
+        # not consult ``args.differential_pairs`` -- the CoupledPathfinder
+        # pre-pass is only wired into the (escape-less) adaptive path.  So we
+        # deliberately keep ``--auto-layers`` (the default): it preserves the
+        # escape pre-phase that board 03 needs for 13/13 + 0 native-DRC.
+        # Forcing the diff-pair path via ``--no-auto-layers`` DOES invoke
+        # Phase A, but loses escape routing and reintroduces a native
+        # ``kicad-cli`` clearance violation -- unacceptable for a
+        # manufacturing-clean board.  Making Phase A run WITH escape routing
+        # is a route_cmd dispatch fix tracked in #3952 (adjacent to the
+        # CoupledPathfinder convergence work in #3921); once it lands, the
+        # xfail in tests/router/test_board03_routing_baseline.py
+        # (test_coupled_pathfinder_phase_a_invoked) will flip to XPASS.
+        # KEEP IN SYNC with tests/router/test_board03_routing_baseline.py.
+        "--differential-pairs",
+        "--net-class-map",
+        str(sidecar_path),
         # Issues #3507/#3454: ``--raw`` (skip TraceOptimizer) was
         # LOAD-BEARING for the 0-DRC acceptance until the grid-staleness
         # fix.  The optimize pass used to replace Route objects without

--- a/boards/README.md
+++ b/boards/README.md
@@ -32,7 +32,7 @@ kct build boards/01-voltage-divider --mfr jlcpcb
 |---|-------|--------|------------|------|-------|
 | 01 | [Voltage Divider](01-voltage-divider/) | ✅ Working | 4 | 3 | Simplest possible design, workflow validation |
 | 02 | [Charlieplex LED](02-charlieplex-led/) | ✅ Working | 14 | 8 | Routes 8/8 signal nets; both DRC engines clean (verified 2026-07-05) |
-| 03 | [USB Joystick](03-usb-joystick/) | ✅ Working | ~20 | 13 | Routes 13/13 on 2-layer in ~24s; diff-pair entry regression tracked in [#3922] |
+| 03 | [USB Joystick](03-usb-joystick/) | ✅ Working | ~20 | 13 | Routes 13/13 on 2-layer in ~24s, 0 native DRC; recipe requests `--differential-pairs` (runtime coupling gated on [#3952]) |
 | 04 | [STM32 Dev Board](04-stm32-devboard/) | ✅ Working | ~30 | 12 | Fully routed via `generate_design.py`; kicad-cli DRC clean (verified 2026-07-05) |
 | 06 | [Diff-Pair Test](06-diffpair-test/) | ⚠️ Scaffold | 7 | 26 | Epic [#2556] Phase 4L regression bench --- USB 2.0/3.0, PCIe, MIPI on 4-layer; exercises Phase 1-3 features (intra_pair_clearance, coupled_routing, coupled_continuity_threshold, target_diff_impedance, skew_tolerance_mm) |
 | 07 | [Match-Group Test](07-matchgroup-test/) | ⚠️ Scaffold | 8 | 33 | Epic [#2661] Phase 3L regression bench --- DDR data byte, MIPI CSI, HDMI TMDS, address bus on 4-layer; exercises Phase 1A-2G match-group features (length_match_group, length_match_reference, length_match_tolerance_mm) |
@@ -108,12 +108,32 @@ the `intra_pair_clearance`, `coupled_continuity_threshold`, and
 invoke the Phase A/B pipeline explicitly.  PR #3069 (board 03) and PR #3090
 (board 06) migrated to this entry after the bypass bug was diagnosed.
 
-> **⚠️ Regression ([#3922]):** the #3308/#3410 recipe consolidation silently
-> dropped `--differential-pairs` from board 03's routing recipe
-> (`generate_design.py:route_pcb()`), so board 03 currently routes its USB
-> pair through the plain per-net path again. Its clean skew today is
-> coincidental, not constructed. Do not copy board 03's recipe for a new
-> diff-pair board until [#3922] lands.
+> **✅ Recipe restored ([#3922]):** the #3308/#3410 recipe consolidation had
+> silently dropped `--differential-pairs` from board 03's routing recipe
+> (`generate_design.py:route_pcb()`), so the recipe no longer even *requested*
+> diff-pair routing and this README's claim went false. The flag (plus
+> `--net-class-map`, which forwards the D+/D- `intra_pair_clearance` metadata
+> and engages the validate-side diff-pair DRC rules) is now restored and
+> mirrored in `tests/router/test_board03_routing_baseline.py`, guarded by
+> `test_recipe_includes_differential_pairs_flag()` so a future consolidation
+> cannot drop it silently again.
+>
+> **Known limitation — runtime coupling gated on [#3952]:** on board 03 the
+> flag is currently **inert at routing time**. The board's fine-pitch USB-C
+> (J1) and QFP-32 (U1) force the CLI's escape-routing dispatch, and
+> `route_cmd`'s escape / auto-layers-escalation paths do not consult
+> `args.differential_pairs` — so the `CoupledPathfinder` pre-pass
+> (`route_all_with_diffpairs`) never runs and the D+/D- skew remains
+> coincidental rather than constructed. The recipe deliberately keeps
+> `--auto-layers` (the default) because it preserves the escape pre-phase
+> board 03 needs for **13/13 + 0 native DRC**; forcing the diff-pair path with
+> `--no-auto-layers` *does* invoke Phase A but drops escape routing and
+> reintroduces a `kicad-cli` clearance violation. Integrating diff-pair
+> routing into the escape path (so Phase A runs *with* escape routing at 0
+> DRC) is tracked in [#3952] (adjacent to the `CoupledPathfinder` convergence
+> work in [#3921]). The behavior is pinned by an xfail'd
+> `test_coupled_pathfinder_phase_a_invoked` that will flip to XPASS when
+> [#3952] lands.
 
 ### Subprocess (`kct route`) vs. in-process (`router.route_all_*`)
 
@@ -149,7 +169,11 @@ reasons:
    **Update 2026-07-05: the footgun bit** --- board 03 lost its
    diff-pair-aware entry in a later recipe consolidation without anyone
    noticing ([#3922]), exactly the failure mode auto-detect would have
-   prevented. Weigh this when re-promoting the auto-detect work.
+   prevented. The flag was restored and a recipe-contract test now guards
+   it ([#3922]); note the restored flag is still inert on board 03 until the
+   route_cmd escape/diff-pair dispatch is fixed ([#3952]). The procedural
+   footgun remains for the *next* new board — weigh this when re-promoting
+   the auto-detect work.
 2. An auto-detect change would have to land on both surfaces (in-process
    and CLI) to be complete, and the `CoupledPathfinder` latency issue
    tracked in [#3089] makes a CLI-default flip premature.
@@ -173,7 +197,9 @@ These are known limitations that may affect your experience:
 [#659]: https://github.com/rjwalters/kicad-tools/issues/659
 [#661]: https://github.com/rjwalters/kicad-tools/issues/661
 [#3918]: https://github.com/rjwalters/kicad-tools/issues/3918
+[#3921]: https://github.com/rjwalters/kicad-tools/issues/3921
 [#3922]: https://github.com/rjwalters/kicad-tools/issues/3922
+[#3952]: https://github.com/rjwalters/kicad-tools/issues/3952
 
 ## Project Files (.kct)
 

--- a/tests/router/test_board03_routing_baseline.py
+++ b/tests/router/test_board03_routing_baseline.py
@@ -373,6 +373,43 @@ def _parse_per_net_status(stdout: str) -> dict[str, str]:
     return result
 
 
+def _write_diffpair_sidecar(dest_dir: Path) -> Path:
+    """Write the board 03 net-class sidecar into ``dest_dir``.
+
+    Mirrors ``generate_design.py:route_pcb()`` exactly: annotate the USB
+    D+/D- pair with ``diffpair_partner`` and a 0.15mm
+    ``intra_pair_clearance`` (#3095) so the ``--net-class-map`` flag can
+    hand the CoupledPathfinder the coupled-routing metadata.  Returns the
+    path to the written ``net_class_map.json``.  KEEP IN SYNC with
+    generate_design.py:route_pcb() (Issue #3922).
+    """
+    import json as _json
+    from dataclasses import replace as _dc_replace
+
+    from kicad_tools.router import create_net_class_map
+    from kicad_tools.router.rules import net_class_map_to_dict
+
+    net_class_map = create_net_class_map(
+        power_nets=["VCC", "VBUS", "GND"],
+        high_speed_nets=["USB_D+", "USB_D-"],
+        clock_nets=["XTAL1", "XTAL2"],
+    )
+    if "USB_D+" in net_class_map and "USB_D-" in net_class_map:
+        net_class_map["USB_D+"] = _dc_replace(
+            net_class_map["USB_D+"],
+            diffpair_partner="USB_D-",
+            intra_pair_clearance=0.15,
+        )
+        net_class_map["USB_D-"] = _dc_replace(
+            net_class_map["USB_D-"],
+            diffpair_partner="USB_D+",
+            intra_pair_clearance=0.15,
+        )
+    sidecar_path = dest_dir / "net_class_map.json"
+    sidecar_path.write_text(_json.dumps(net_class_map_to_dict(net_class_map), indent=2))
+    return sidecar_path
+
+
 @pytest.fixture(scope="module")
 def unrouted_pcb_path() -> Path:
     """Verify the committed unrouted board 03 PCB exists.
@@ -399,6 +436,11 @@ def _run_kct_route(unrouted: Path, seed: int) -> str:
         pcb_copy = Path(td) / "usb_joystick.kicad_pcb"
         shutil.copy2(unrouted, pcb_copy)
         output_path = Path(td) / "usb_joystick_routed.kicad_pcb"
+        # Issue #3922: mirror the production net-class sidecar so
+        # ``--net-class-map`` (below) reads the same USB D+/D-
+        # diffpair_partner / intra_pair_clearance metadata the recipe
+        # writes.  KEEP IN SYNC with generate_design.py:route_pcb().
+        sidecar_path = _write_diffpair_sidecar(output_path.parent)
         cmd = [
             sys.executable,
             "-m",
@@ -421,6 +463,22 @@ def _run_kct_route(unrouted: Path, seed: int) -> str:
             "--deterministic-budget",
             "--timeout",
             "600",
+            # Issue #3922: --differential-pairs was silently dropped in the
+            # #3308/#3410 recipe consolidation, so USB_D+/USB_D- routed
+            # through the plain per-net A* loop and the CoupledPathfinder
+            # (Phase A) was never invoked.  Restored here in lock-step with
+            # generate_design.py:route_pcb().  --net-class-map forwards the
+            # sidecar so the router reads the diff-pair metadata.
+            "--differential-pairs",
+            "--net-class-map",
+            str(sidecar_path),
+            # Issue #3922: --auto-layers is kept (the default) so the escape
+            # pre-phase board 03's fine-pitch USB-C needs still runs (13/13 +
+            # 0 native DRC).  On this board --differential-pairs is inert at
+            # routing time because route_cmd's escape / escalation dispatch
+            # does not consult it (tracked in #3952); forcing the diff-pair
+            # path with --no-auto-layers would reintroduce a DRC clearance
+            # violation.  KEEP IN SYNC with generate_design.py:route_pcb().
             # Issues #3507/#3454: ``--raw`` removed in lock-step with the
             # production recipe in ``generate_design.py:route_pcb()`` --
             # the grid-transactional optimize pass retired the
@@ -589,6 +647,76 @@ class TestBoard03RoutingBaseline:
             "the destination MCU U1 (in which case generate_pcb.py "
             "needs to be regenerated)."
         )
+
+    @pytest.mark.xfail(
+        reason=(
+            "Issue #3952: --differential-pairs is inert on board 03's routing "
+            "path.  The board's fine-pitch USB-C forces the escape-routing "
+            "dispatch, and route_cmd's escape / auto-layers-escalation paths "
+            "do not consult args.differential_pairs, so route_all_with_diffpairs "
+            "(the CoupledPathfinder pre-pass) never runs.  Forcing the diff-pair "
+            "path with --no-auto-layers loses escape routing and reintroduces a "
+            "native-DRC clearance violation, so the recipe keeps --auto-layers.  "
+            "When #3952 integrates diff-pair routing into the escape path, this "
+            "flips to XPASS and should be un-xfailed."
+        ),
+        strict=False,
+    )
+    def test_coupled_pathfinder_phase_a_invoked(self, route_stdout: str) -> None:
+        """The diff-pair pre-pass (Phase A) actually runs under the recipe.
+
+        Executable documentation of the #3952 limitation: restoring
+        ``--differential-pairs`` (Issue #3922) makes the recipe *request*
+        coupled routing, but on board 03 the CLI dispatch never reaches the
+        ``route_all_with_diffpairs`` pre-pass.  This test asserts the
+        unconditional Phase A banner appears; it is expected to xfail until
+        #3952 wires diff-pair routing into the escape-routing path.  A
+        surprise XPASS means #3952 (or an equivalent) has landed -- remove
+        the xfail marker and pin the behavior.
+        """
+        assert "=== Differential Pair Routing ===" in route_stdout, (
+            "The diff-pair pre-pass (Phase A / route_all_with_diffpairs) did "
+            "not run -- see #3952.\n"
+            f"stdout (last 4000 chars):\n{route_stdout[-4000:]}"
+        )
+        assert "Detected 1 differential pairs" in route_stdout, (
+            "Phase A ran but did not detect the USB D+/D- pair.  Check that "
+            "--net-class-map still forwards the diffpair_partner metadata "
+            "(Issue #3922).\n"
+            f"stdout (last 4000 chars):\n{route_stdout[-4000:]}"
+        )
+
+
+def test_recipe_includes_differential_pairs_flag() -> None:
+    """Guard against recipe consolidations silently dropping --differential-pairs.
+
+    Issue #3922: the #3308/#3410 consolidation dropped ``--differential-pairs``
+    from ``generate_design.py:route_pcb()`` without any test detecting it, so
+    the recipe stopped even requesting diff-pair routing and the boards/README
+    claim went false.  This fast text-search guard makes the flag a contract:
+    if a future refactor drops it, this test goes red before the regression
+    can ship.  ``--net-class-map`` is checked too because it forwards the
+    diff-pair metadata (and engages the validate-side diff-pair DRC rules).
+
+    NB: on board 03 the flag is currently inert at routing time -- route_cmd's
+    escape / escalation dispatch does not consult it (tracked in #3952).  This
+    guard therefore protects the recipe *contract*, not the runtime behavior;
+    the runtime behavior is documented by the xfail'd
+    ``test_coupled_pathfinder_phase_a_invoked`` above.
+    """
+    source = (BOARD_DIR / "generate_design.py").read_text()
+    assert "--differential-pairs" in source, (
+        "generate_design.py:route_pcb() must include '--differential-pairs' so "
+        "the recipe requests diff-pair-aware routing.  If you changed the "
+        "routing recipe, keep the flag and mirror it in _run_kct_route() "
+        "(Issue #3922)."
+    )
+    assert "--net-class-map" in source, (
+        "generate_design.py:route_pcb() must forward '--net-class-map' so the "
+        "router reads the USB D+/D- diffpair_partner / intra_pair_clearance "
+        "metadata from the sidecar; without it --differential-pairs falls back "
+        "to default spacing (Issue #3922)."
+    )
 
 
 @pytest.mark.slow

--- a/tests/test_board_03_regression.py
+++ b/tests/test_board_03_regression.py
@@ -139,12 +139,18 @@ def unrouted_pcb_path() -> Path:
 
 @pytest.fixture(scope="module")
 def routed_board_03(unrouted_pcb_path: Path):
-    """Load board 03 and route it with the canonical recipe.
+    """Load board 03 and route it with the in-process ``route_all`` path.
 
-    Issue #3308: mirrors ``generate_design.py:route_pcb()`` (the
-    canonical recipe ``route_demo.py`` now delegates to) so a regression
-    here is a regression in both the demo's behavior AND the build
-    recipe.
+    Issue #3308: this fixture WAS introduced as a mirror of
+    ``generate_design.py:route_pcb()``.  It no longer mirrors that recipe
+    -- it intentionally exercises the per-net ``route_all`` path with
+    in-pad escape rescues as a standalone ROUTER-CAPABILITY regression net
+    for the #2760 USB_D+ stub failure mode.  (Issue #3922 restored
+    ``--differential-pairs`` to the CLI recipe, but on board 03 that flag
+    is inert at routing time -- the escape-routing dispatch never reaches
+    the CoupledPathfinder pre-pass, tracked in #3952.)  The end-to-end CLI
+    recipe reach is pinned separately by
+    ``tests/router/test_board03_routing_baseline.py``.
 
     Key differences from the legacy pre-#3308 fixture:
 
@@ -159,11 +165,13 @@ def routed_board_03(unrouted_pcb_path: Path):
       * ``intra_pair_clearance=0.15mm`` on USB_D+/USB_D-.
       * ``random.seed(42)`` for determinism (#3065 plumbing).
       * Uses ``route_all`` with ``enable_in_pad_escape_rescues=True``
-        and explicit rescue pins (U1 12-15, 26-27) -- the canonical
-        recipe DISABLES ``CoupledPathfinder`` because the pre-pass
-        packs USB_D+/D- into adjacent 0.05mm grid cells producing
-        intra-clearance violations (#3095).  The per-net A* route_all
-        handles the diff pair with lateral offset.
+        and explicit rescue pins (U1 12-15, 26-27).  This fixture
+        deliberately exercises the per-net A* path (with 0.15mm
+        intra_pair_clearance widening + lateral offset) as a capability
+        net.  The CLI recipe requests ``--differential-pairs`` (#3922) but
+        the CoupledPathfinder is currently gated behind route_cmd's
+        escape-routing dispatch on this board (#3952); the recipe reach is
+        validated end-to-end by ``test_board03_routing_baseline.py``.
 
     Returns the populated ``Autorouter`` instance plus the net_map dict.
     """
@@ -242,15 +250,15 @@ def test_usb_diff_pair_routes_via_coupled_pathfinder(routed_board_03) -> None:
     a 2-of-3-pads stub (J1.A6 -> J1.B6 only) because the USB_D- via near
     U1.29 blocked the only remaining pad-access corridor.
 
-    Issue #3095 / #3308 (June 2026): the canonical recipe in
-    ``generate_design.py:route_pcb()`` (which ``route_demo.py`` now
-    delegates to) DISABLES ``CoupledPathfinder`` because the pre-pass
-    packs USB_D+/D- into adjacent 0.05mm grid cells producing 19
-    ``diffpair_clearance_intra`` violations.  USB_D+ now routes via
-    per-net A* with explicit ``intra_pair_clearance=0.15mm`` widening
-    and in-pad escape rescues on U1.  USB_D- may currently be partial
-    under the router state pinned by ``test_board03_routing_baseline.py``
-    -- that's tracked under #3308 AC #2/#3 as a separate router regression.
+    Issue #3095 / #3308 (June 2026): this in-process fixture uses the
+    per-net ``route_all`` path (NOT the CLI recipe -- see the fixture
+    docstring).  USB_D+ routes via per-net A* with explicit
+    ``intra_pair_clearance=0.15mm`` widening and in-pad escape rescues on
+    U1.  USB_D- may be partial under this per-net path -- that is a
+    property of this capability fixture, not the CLI recipe.  The CLI
+    recipe requests ``--differential-pairs`` (#3922) though the coupled
+    pre-pass is currently gated on board 03 (#3952); its reach is pinned
+    by ``test_board03_routing_baseline.py``.
 
     This test asserts the minimum viable success criterion (the original
     #2760 floor): USB_D+ has > 0 routed segments AND is not in


### PR DESCRIPTION
Closes #3922

## What & why

The #3308/#3410 recipe consolidation silently dropped `--differential-pairs` from `boards/03-usb-joystick/generate_design.py:route_pcb()`. The recipe stopped even *requesting* diff-pair routing, and the `boards/README` "Routing Entry Point Conventions" claim (board 03 uses `--differential-pairs`) went false.

This PR restores the flag and forwards the existing net-class sidecar via `--net-class-map`, so the USB D+/D- `diffpair_partner` / `intra_pair_clearance` (0.15mm, #3095) metadata engages the validate-side diff-pair DRC rules.

## Important scope finding (follow-up: #3952)

Restoring the flag alone does **not** make the CoupledPathfinder run on board 03 — a deeper `route_cmd` limitation that the curator's scoping did not anticipate:

- The board's fine-pitch USB-C (J1) / QFP-32 (U1) force the CLI's **escape-routing dispatch**.
- `route_cmd`'s escape (`route_with_escape`) and auto-layers-escalation (`route_with_layer_escalation`) paths **never consult `args.differential_pairs`**, so `route_all_with_diffpairs` (Phase A) is never called.
- The only path that *does* run Phase A is the escape-less adaptive path. Forcing it with `--no-auto-layers` **does** invoke Phase A (verified: `=== Differential Pair Routing ===`, `Detected 1 differential pairs`, `CoupledPathfinder.route_coupled` budget-exits per #3921) **but drops escape routing and reintroduces a native `kicad-cli` clearance violation** — unacceptable for a manufacturing-clean board.

So the recipe deliberately **keeps `--auto-layers`** to preserve board 03's **13/13 + 0 native DRC**. Making Phase A run *with* escape routing at 0 DRC is a `route_cmd` dispatch fix, filed as **#3952** (out of scope here per the #3921 boundary; `src/kicad_tools/router/` and `route_cmd.py` untouched).

## Changes

- `boards/03-usb-joystick/generate_design.py` — add `--differential-pairs` + `--net-class-map <sidecar>` to `route_pcb()`; thorough comment explaining why `--auto-layers` is kept (the #3952 limitation).
- `tests/router/test_board03_routing_baseline.py` — mirror the flags in `_run_kct_route()` (KEEP IN SYNC contract); add `test_recipe_includes_differential_pairs_flag()` (static regression guard); add `test_coupled_pathfinder_phase_a_invoked()` as an `xfail(strict=False)` that documents #3952 and will flip to XPASS when it lands.
- `boards/README.md` — regression warning → "recipe restored" with an explicit #3952 known-limitation note; board 03 status row + auto-detect footgun note corrected; add #3921/#3952 link refs.
- `tests/test_board_03_regression.py` — comment-only corrections (stop claiming the CLI recipe routes the pair via CoupledPathfinder).

## Verification

- Fresh `python boards/03-usb-joystick/generate_design.py`: **13/13 signal nets, 0 native kicad-cli DRC**.
- `--no-auto-layers` cross-check (not shipped): Phase A invoked but 1 native DRC clearance violation → confirms the #3952 tradeoff.
- `pytest tests/router/test_board03_routing_baseline.py::TestBoard03RoutingBaseline`: **3 passed, 1 xfailed** (42s).
- Non-slow board-03 suites: 15 passed, 1 skipped.
- `ruff check` / `ruff format --check`: clean on all changed files.

Note: committed `output/` artifacts are intentionally not regenerated — the baseline tests re-route into tmpdirs, and the committed board stays at its origin/main 13/13 + 0 DRC state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)