### PR TITLE
fix(diffpair): distinguish iteration vs wall-clock exit in coupled budget diagnostic (#3921)

### DIFF
--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -618,6 +618,18 @@ class CoupledPathfinder:
         # invocation.
         self.last_timeout_exceeded: bool = False
 
+        # Issue #3921: disambiguates WHICH budget fired when
+        # ``last_timeout_exceeded`` is True.  ``route_coupled`` sets the
+        # shared ``last_timeout_exceeded`` flag for both the iteration
+        # budget (``max_iterations_budget``) and the wall-clock budget
+        # (``timeout_seconds``), so the caller's budget-exit diagnostic
+        # cannot tell a 0.3s iteration bail from a 120s wall-clock bail.
+        # ``True`` means the ITERATION budget was the binding constraint;
+        # ``False`` (with ``last_timeout_exceeded`` True) means the
+        # wall-clock budget fired.  Reset to ``False`` at the start of
+        # every ``route_coupled`` invocation.
+        self.last_iteration_limited: bool = False
+
         # Issue #3473 (review of #3439): number of A* iterations the
         # most recent ``route_coupled`` call consumed.  The two-phase
         # corridor-then-open caller charges the corridor attempt's
@@ -1480,6 +1492,8 @@ class CoupledPathfinder:
         # this immediately after ``route_coupled`` returns ``None`` to
         # decide whether to attempt an independent-routing fallback.
         self.last_timeout_exceeded = False
+        # Issue #3921: reset the iteration-vs-wall-clock discriminator.
+        self.last_iteration_limited = False
         # Issue #3473: reset the iteration counter for this call.
         self.last_iterations = 0
         # Issue #3508: best progress-toward-goal (joint Manhattan
@@ -1659,6 +1673,10 @@ class CoupledPathfinder:
                     n_start.net_name,
                 )
                 self.last_timeout_exceeded = True
+                # Issue #3921: mark the ITERATION budget as the binding
+                # constraint so the caller's diagnostic reports iteration
+                # counts, not a misleading wall-clock-seconds figure.
+                self.last_iteration_limited = True
                 return None
 
             # Issue #3089: periodic wall-clock check.  Exits with ``None``
@@ -4181,6 +4199,22 @@ class DiffPairRouter:
         # re-route gate's per-pair budget), so this default never narrows
         # an opt-in run.  An explicit ``per_pair_max_iterations`` (board
         # configs, the re-route gate) always takes precedence.
+        #
+        # Issue #3921 (investigation): the curation comment proposed
+        # raising this flag-off default to a FLOOR so board 06's explicit
+        # ``per_pair_max_iterations=2000`` would be lifted to 40000.  That
+        # was VERIFIED against the actual seed-42 bench and does NOT
+        # restore convergence: at 20000 iters/phase the joint search's
+        # best-progress plateaus identically to the 1000-iter run
+        # (398->398, 61->64 cells from goal) while wall-time balloons
+        # 562s -> >600s.  The reason is the ``heuristic_weight`` note
+        # above: classic optimal A* (weight=1.0, the flag-off search)
+        # floods cost_turn f-plateaus and "no CI-affordable iteration
+        # budget converges".  The historical 6/9 convergence came from the
+        # geometric SHADOW CONSTRUCTOR (``enable_shadow_construction=
+        # True``), not the joint A* search -- so a budget floor is the
+        # wrong lever and was dropped.  See the #3921 PR body for the
+        # three-way measurement (floor / weighted / shadow).
         if (
             not self.enable_shadow_construction
             and (per_pair_max_iterations is None or per_pair_max_iterations <= 0)
@@ -4519,18 +4553,58 @@ class DiffPairRouter:
                 # budget was actually plumbed; otherwise let the search
                 # DEFER to the independent fallback below.
                 if pathfinder.last_timeout_exceeded and per_pair_timeout is not None:
+                    # Issue #3921: report WHICH budget actually fired.
+                    # ``route_coupled`` raises ``last_timeout_exceeded``
+                    # for both the iteration budget and the wall-clock
+                    # budget, so the old message hard-coded the
+                    # ``per_pair_timeout`` seconds ("budget exceeded
+                    # (120s)") even when the iteration budget bailed the
+                    # search in 0.3s.  ``last_iteration_limited``
+                    # disambiguates; surface the actual iteration count
+                    # and the per-phase split so the exit reason is not
+                    # opaque.
+                    if pathfinder.last_iteration_limited:
+                        # ``per_pair_max_iterations`` is the total budget;
+                        # the two-phase caller splits it ~half corridor /
+                        # half open (see ``corridor_iteration_budget``).
+                        total_budget = per_pair_max_iterations
+                        phase_budget = (
+                            max(1, total_budget // 2)
+                            if total_budget is not None and total_budget > 0
+                            else None
+                        )
+                        budget_desc = (
+                            f"iteration budget exceeded "
+                            f"({pathfinder.last_iterations} iters; "
+                            f"phase cap {phase_budget}, total {total_budget}) "
+                            f"in {spec_elapsed:.1f}s"
+                            if phase_budget is not None
+                            else f"iteration budget exceeded "
+                            f"({pathfinder.last_iterations} iters) "
+                            f"in {spec_elapsed:.1f}s"
+                        )
+                    else:
+                        budget_desc = (
+                            f"wall-clock budget exceeded "
+                            f"({per_pair_timeout:.0f}s; "
+                            f"{pathfinder.last_iterations} iters)"
+                        )
                     print(
-                        "    WARNING: Coupled routing budget exceeded "
-                        f"({per_pair_timeout:.0f}s); skipping diff-pair "
-                        "and leaving nets for the main strategy."
+                        f"    WARNING: Coupled routing {budget_desc}; "
+                        "skipping diff-pair and leaving nets for the "
+                        "main strategy."
                     )
                     logger.warning(
                         "diffpair coupled-routing budget exceeded: pair=%r "
-                        "p_net=%r n_net=%r budget=%.1fs",
+                        "p_net=%r n_net=%r reason=%s iters=%d "
+                        "wall_budget=%.1fs elapsed=%.2fs",
                         pair.name,
                         pair.positive.net_name,
                         pair.negative.net_name,
+                        "iteration" if pathfinder.last_iteration_limited else "wall-clock",
+                        pathfinder.last_iterations,
                         float(per_pair_timeout) if per_pair_timeout else -1.0,
+                        spec_elapsed,
                     )
                     self._last_pair_budget_exit = True
                     return [], None

--- a/tests/test_diffpair_shadow.py
+++ b/tests/test_diffpair_shadow.py
@@ -491,6 +491,9 @@ class _StubPathfinder:
     def __init__(self, result, rescue_eligible: bool = True):
         self._result = result
         self.last_timeout_exceeded = False
+        # Issue #3921: iteration-vs-wall-clock discriminator read by the
+        # caller's budget-exit diagnostic.
+        self.last_iteration_limited = False
         self.last_iterations = 1
         self.last_best_progress = 0.0  # <= NEAR_MISS_RESCUE_CELLS
         self.last_best_state = object()
@@ -569,6 +572,112 @@ def test_flag_on_uses_weighted_astar_search(monkeypatch):
         "flag-on run must use the weighted-A* upgrade "
         f"({COUPLED_HEURISTIC_WEIGHT}), got {captured.get('heuristic_weight')}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #3921: coupled budget-exit DIAGNOSTIC.
+#
+# ``CoupledPathfinder.route_coupled`` raises the shared
+# ``last_timeout_exceeded`` flag for BOTH its iteration budget
+# (``max_iterations_budget``) and its wall-clock budget
+# (``timeout_seconds``).  The old budget-exit WARNING hard-coded the
+# ``per_pair_timeout`` seconds ("budget exceeded (120s)") even when the
+# iteration budget bailed the search in 0.3s.  ``last_iteration_limited``
+# now disambiguates the two, and the message reports the actual iteration
+# count and per-phase split so the exit reason is no longer opaque.
+#
+# (The curation comment also proposed raising the flag-off iteration
+# budget to a FLOOR to restore board-06 coupled convergence.  That was
+# measured against the real seed-42 bench and does NOT converge any pair
+# -- best-progress plateaus identically at 20x the iterations while
+# wall-time balloons -- so the floor was dropped as ineffective and
+# wall-time-harmful.  See the #3921 PR body.)
+# ---------------------------------------------------------------------------
+
+
+def test_flag_off_iteration_exit_diagnostic_reports_iterations(monkeypatch, capsys):
+    """Issue #3921 diagnostic: iteration-budget exit must NOT say "120s".
+
+    When the ITERATION budget fires (``last_iteration_limited=True``) the
+    user-visible budget-exit WARNING must cite the iteration count, not
+    hard-code the wall-clock ``per_pair_timeout`` seconds.  Previously the
+    message read "budget exceeded (120s)" even for a search that bailed in
+    0.3s after exhausting its iteration budget.
+    """
+    router, pair = _two_pad_coupled_router_and_pair()
+    dpr = router._diffpair
+    dpr.enable_shadow_construction = False
+    monkeypatch.setattr(dpr, "_single_ended_guide_route", lambda *a, **k: None)
+
+    # Script an ITERATION-budget exit: search deferred, timeout flag set,
+    # discriminator says the iteration budget was the binding constraint.
+    def _factory(*_a, **kwargs):
+        stub = _StubPathfinder(None, rescue_eligible=False)
+        stub.last_timeout_exceeded = True
+        stub.last_iteration_limited = True
+        stub.last_iterations = 20000
+        return stub
+
+    import kicad_tools.router.diffpair_routing as dpr_mod
+
+    monkeypatch.setattr(dpr_mod, "CoupledPathfinder", _factory)
+
+    routes, _warning = dpr.route_differential_pair_coupled(
+        pair,
+        coupled_only=True,
+        per_pair_timeout=120.0,
+        per_pair_max_iterations=2000,
+    )
+
+    out = capsys.readouterr().out
+    assert "iteration budget exceeded" in out, (
+        f"iteration-budget exit must report an iteration budget; got: {out!r}"
+    )
+    assert "20000 iters" in out, (
+        f"iteration-budget exit must cite the iteration count; got: {out!r}"
+    )
+    # The pair is skipped (deferred to the main strategy) on a budget exit.
+    assert routes == []
+
+
+def test_flag_off_wallclock_exit_diagnostic_reports_seconds(monkeypatch, capsys):
+    """Control: a genuine wall-clock exit still reports seconds.
+
+    When the WALL-CLOCK budget fires (``last_iteration_limited=False``)
+    the message reports the ``per_pair_timeout`` seconds, not an iteration
+    budget -- the two exit reasons are now distinguished.
+    """
+    router, pair = _two_pad_coupled_router_and_pair()
+    dpr = router._diffpair
+    dpr.enable_shadow_construction = False
+    monkeypatch.setattr(dpr, "_single_ended_guide_route", lambda *a, **k: None)
+    holder: dict = {}
+
+    def _factory(*_a, **kwargs):
+        stub = _StubPathfinder(None, rescue_eligible=False)
+        stub.last_timeout_exceeded = True
+        stub.last_iteration_limited = False  # wall-clock, not iterations
+        stub.last_iterations = 137
+        holder["stub"] = stub
+        return stub
+
+    import kicad_tools.router.diffpair_routing as dpr_mod
+
+    monkeypatch.setattr(dpr_mod, "CoupledPathfinder", _factory)
+
+    dpr.route_differential_pair_coupled(
+        pair,
+        coupled_only=True,
+        per_pair_timeout=120.0,
+        per_pair_max_iterations=2000,
+    )
+
+    out = capsys.readouterr().out
+    assert "wall-clock budget exceeded" in out, (
+        f"wall-clock exit must report a wall-clock budget; got: {out!r}"
+    )
+    assert "120s" in out, f"wall-clock exit must cite the seconds budget; got: {out!r}"
+    assert "iteration budget exceeded" not in out
 
 
 def test_flag_off_does_not_invoke_near_miss_rescue(monkeypatch):


### PR DESCRIPTION
Refs #3921.

## Summary

Fixes the **diagnostic bug** explicitly called out in #3921 ("Also fix the diagnostics"): the coupled-routing budget-exit `WARNING` hard-coded the `per_pair_timeout` seconds (`"budget exceeded (120s)"`) even when the **iteration** budget fired in a fraction of a second. `CoupledPathfinder.route_coupled` raised the shared `last_timeout_exceeded` flag for *both* the iteration budget and the wall-clock budget, so the caller had no way to tell which one bound.

- Adds a `last_iteration_limited` discriminator on `CoupledPathfinder`, set only on the iteration-budget exit path (reset per call).
- Rewrites the budget-exit diagnostic to surface the real exit reason, the actual iteration count, and the per-phase split, in both the stdout `WARNING` and the structured `logger.warning`.
- Two regression tests (`tests/test_diffpair_shadow.py`).

Before: `WARNING: Coupled routing budget exceeded (120s); ...`
After (iteration exit): `WARNING: Coupled routing iteration budget exceeded (20000 iters; phase cap 20000, total 40000) in 21.9s; ...`
After (wall-clock exit): `... reason=wall-clock iters=86336 wall_budget=60.0s ...`

## The convergence half needs re-scoping (root-cause in the curation comment is incorrect)

The curation comment proposed restoring board-06 coupled convergence (0/9 -> positive) by raising the flag-off iteration budget to a **40000 FLOOR**. I implemented that first and **verified it against the real seed-42 bench** (`boards/06-diffpair-test`, `--step route`). It does not work, and I dropped it. Three-way measurement:

| Configuration | Coupled convergence | best_progress (cells to goal) | Wall time (route phase) |
|---|---|---|---|
| Baseline (classic A*, budget 2000) | **0/9** | 398, 363, 65, 213, 1041, ... | 562s |
| **Floor 40000** (curator Option A) | **0/9** | 398, 361, **64**, 213, 1041, ... (plateau) | **>600s** (timed out) |
| Weighted A* (weight 1.5) + budget 2000 | **0/9** | 398, 361, 61, 213, 1041, ... (plateau) | 569s |
| `enable_shadow_construction=True` | **3-5/9** (shadow constructor + rescue) | n/a (geometric) | >600s (timed out) |

Findings:
1. **The floor cannot fix convergence.** At 20000 iters/phase (20x the budget) best-progress plateaus identically to the 1000-iter run (398->398, 65->64). This matches the code's own note at `diffpair_routing.py:~4164`: classic optimal A* floods `cost_turn` f-plateaus and *"no CI-affordable iteration budget converges."* The floor also balloons wall-time for zero benefit, violating the issue's "must not blow up bench duration" guardrail. So it was **removed**.
2. **The heuristic is not the lever either.** Forcing weighted A* (weight 1.5) on the flag-off search still yields 0/9 with the same plateau — the current board-06 geometry does not admit a joint-state coupled route at reasonable cost.
3. **The historical "6/9" came from the geometric shadow constructor** (`enable_shadow_construction=True`), *not* the joint A* search. That flag is deliberately OFF for board 06 on documented artifact-quality grounds (stranded shadow tails, shadow vias intersecting the partner trace, greedily-claimed corridors stranding nets — see the recipe comment at `generate_design.py:~1828`). Turning it on is the only lever that produces convergence, and it is a deliberate-design reversal that needs artifact/EE review + wall-time work.

**Recommendation:** keep #3921 open (or split): the convergence portion should be re-scoped as a shadow-constructor geometry-quality effort (the #3508 follow-ups the recipe already references), not a budget/heuristic tweak in the pathfinder. This PR ships the correct, in-scope, non-harmful diagnostic fix.

## Scope

- Did NOT touch `boards/03` recipe (parallel #3922).
- Did NOT modify the board-06 recipe or artifact.
- No new mypy errors (file has 9 pre-existing on both main and this branch).

## Tests

- `tests/test_diffpair_shadow.py`, `test_diffpair_per_pair_timeout.py`, `test_diffpair_coupled_floor.py`, `test_router_core_diffpair_timeout.py`: 58 passed.
- Broader diffpair sweep (shadow/npad/integration/phase_b/swap-via/board_06): 173 passed.
- ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)