### PR TITLE
feat(check): surface length-match measurements on default output + via-inclusive diffpair skew

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -1176,9 +1176,22 @@ def output_table(
     # has no measurement findings (e.g. no net-class-map sidecar -- AC5).
     _print_measurement_summary(violations)
 
-    # Group by rule_id summary
+    # Group by rule_id summary.
+    #
+    # Issue #3924: the length-match / continuity measurement findings are
+    # info-severity rows surfaced by the dedicated MEASUREMENT SUMMARY table
+    # above.  On the default (non-``--verbose``) path we exclude them from the
+    # BY RULE breakdown -- mirroring the INFOS-listing suppression below -- so
+    # that default output stays backward-compatible for consumers that grep
+    # ``BY RULE:`` severity-agnostically (e.g. the board03 baseline test).
+    # Under ``--verbose`` they remain visible in BY RULE alongside INFOS.
+    by_rule_source = (
+        violations
+        if verbose
+        else [v for v in violations if not (v.is_info and v.rule_id in _MEASUREMENT_RULE_IDS)]
+    )
     by_rule: dict[str, dict[str, int]] = {}
-    for v in violations:
+    for v in by_rule_source:
         if v.rule_id not in by_rule:
             by_rule[v.rule_id] = {"errors": 0, "warnings": 0, "infos": 0}
         if v.is_error:
@@ -1188,8 +1201,12 @@ def output_table(
         else:
             by_rule[v.rule_id]["warnings"] += 1
 
-    print(f"\n{'-' * 60}")
-    print("BY RULE:")
+    # ``by_rule`` can be empty when the only findings are measurement info
+    # rows suppressed above (already surfaced in MEASUREMENT SUMMARY); skip the
+    # empty BY RULE header in that case.
+    if by_rule:
+        print(f"\n{'-' * 60}")
+        print("BY RULE:")
     for rule_id, counts in sorted(
         by_rule.items(),
         key=lambda x: -(x[1]["errors"] + x[1]["warnings"] + x[1]["infos"]),

--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -38,6 +38,20 @@ from kicad_tools.validate import DRCChecker, DRCResults, DRCViolation
 # so callers can compare against the literal.
 SubCheckStatus = Literal["PASSED", "FAILED", "NOT RUN"]
 
+# Issue #3924 AC1: the sidecar-gated length-skew / continuity rules that
+# carry a measured ``actual_value`` (skew mm or coupled fraction) on every
+# finding -- both passing (``info``) and failing (``error``).  ``output_table``
+# collects these into a dedicated MEASUREMENT SUMMARY table so users see the
+# measured values on the default (non-``--verbose``) path, distinct from the
+# violation listing.
+_MEASUREMENT_RULE_IDS: frozenset[str] = frozenset(
+    {
+        "match_group_length_skew",
+        "diffpair_length_skew",
+        "diffpair_routing_continuity",
+    }
+)
+
 
 @dataclass
 class SubCheckResult:
@@ -871,6 +885,12 @@ def main(argv: list[str] | None = None) -> int:
             # avoid duplicating it (Issue #3917 Defect 3).
             warn_on_inactive_skew_rules=False,
             verbose=args.verbose,
+            # Always collect the per-pair / per-group measured skew info
+            # findings so ``output_table`` can render the measurement
+            # summary at default verbosity (Issue #3924 AC1).  With no
+            # sidecar the skew rules produce no info findings, so this is a
+            # graceful no-op (AC5).
+            emit_measurements=True,
         )
     except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)
@@ -1052,6 +1072,70 @@ def run_selected_checks(
     return results
 
 
+def _print_measurement_summary(violations: list[DRCViolation]) -> None:
+    """Print a per-group / per-pair length-measurement summary table.
+
+    Issue #3924 AC1.  The sidecar-gated length-skew and routing-continuity
+    rules (:data:`_MEASUREMENT_RULE_IDS`) attach the measured value
+    (``actual_value``) and its tolerance (``required_value``) to every
+    finding they emit -- passing findings are ``info`` severity (only
+    produced when the checker was built with ``emit_measurements=True`` or
+    ``verbose=True``) and failing findings are ``error`` severity.  This
+    renders both into one compact table so a user running plain
+    ``kct check`` (no ``--verbose``) can read the achieved skew / continuity
+    values without wading through the info stream.
+
+    The table is only printed when at least one measurement finding is
+    present.  With no net-class-map sidecar the skew rules produce no
+    findings, so this is a graceful no-op (Issue #3924 AC5).
+    """
+    measurements = [v for v in violations if v.rule_id in _MEASUREMENT_RULE_IDS]
+    # Only rows that actually carry a measured value are renderable.
+    measurements = [v for v in measurements if v.actual_value is not None]
+    if not measurements:
+        return
+
+    def _subject(v: DRCViolation) -> str:
+        # Match groups carry the group name in ``items``; diff pairs carry
+        # their two net names in ``nets``.
+        if v.items:
+            return v.items[0]
+        if v.nets:
+            return "/".join(n for n in v.nets if n)
+        return v.rule_id
+
+    def _metric(rule_id: str) -> str:
+        # diffpair_routing_continuity measures a coupled *fraction*, not a
+        # length skew -- label the column accordingly.
+        if rule_id == "diffpair_routing_continuity":
+            return "continuity"
+        return "skew"
+
+    rows: list[tuple[str, str, str, str, str]] = []
+    for v in sorted(measurements, key=lambda x: (x.rule_id, _subject(x))):
+        subject = _subject(v)
+        metric = _metric(v.rule_id)
+        measured = f"{v.actual_value:.3f}" if v.actual_value is not None else "-"
+        tol = f"{v.required_value:.3f}" if v.required_value is not None else "-"
+        status = "FAIL" if v.is_error else "pass"
+        rows.append((subject, metric, measured, tol, status))
+
+    subject_w = max(len("Group/Pair"), *(len(r[0]) for r in rows))
+    metric_w = max(len("Metric"), *(len(r[1]) for r in rows))
+
+    print(f"\n{'-' * 60}")
+    print("MEASUREMENT SUMMARY (length-match / continuity):")
+    header = (
+        f"  {'Group/Pair':<{subject_w}}  {'Metric':<{metric_w}}  "
+        f"{'Measured':>10}  {'Tolerance':>10}  Status"
+    )
+    print(header)
+    for subject, metric, measured, tol, status in rows:
+        print(
+            f"  {subject:<{subject_w}}  {metric:<{metric_w}}  {measured:>10}  {tol:>10}  {status}"
+        )
+
+
 def output_table(
     violations: list[DRCViolation],
     results: DRCResults,
@@ -1085,6 +1169,12 @@ def output_table(
         print(f"\n{'=' * 60}")
         print("DRC PASSED - No violations found")
         return
+
+    # Issue #3924 AC1: render the length-match / continuity measurement
+    # table before the violation listing so the measured values are visible
+    # even on the default (non-``--verbose``) path.  No-op when the board
+    # has no measurement findings (e.g. no net-class-map sidecar -- AC5).
+    _print_measurement_summary(violations)
 
     # Group by rule_id summary
     by_rule: dict[str, dict[str, int]] = {}
@@ -1133,14 +1223,23 @@ def output_table(
         if len(warnings) > 10 and not verbose:
             print(f"\n  ... and {len(warnings) - 10} more warnings (use --verbose)")
 
-    if infos:
+    # Issue #3924 AC1/AC4: the per-pair / per-group measurement info findings
+    # are shown in the dedicated MEASUREMENT SUMMARY table above at every
+    # verbosity.  In the generic INFOS listing we keep them only under
+    # ``--verbose`` (preserving PR #3948's advisory-line behaviour) and
+    # suppress them on the default path to avoid duplicating the summary
+    # and flooding plain output.
+    display_infos_source = (
+        infos if verbose else [v for v in infos if v.rule_id not in _MEASUREMENT_RULE_IDS]
+    )
+    if display_infos_source:
         print(f"\n{'-' * 60}")
         print("INFOS (advisory only):")
-        display_infos = infos if verbose else infos[:10]
+        display_infos = display_infos_source if verbose else display_infos_source[:10]
         for v in display_infos:
             _print_violation(v, verbose)
-        if len(infos) > 10 and not verbose:
-            print(f"\n  ... and {len(infos) - 10} more infos (use --verbose)")
+        if len(display_infos_source) > 10 and not verbose:
+            print(f"\n  ... and {len(display_infos_source) - 10} more infos (use --verbose)")
 
     print(f"\n{'=' * 60}")
     if errors:

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -12437,12 +12437,25 @@ class Autorouter:
                 # silently dropped ``reference`` / ``longer_than_reference``
                 # / ``unrouted`` members, producing an all-zeros summary
                 # while 15.4mm of skew went untouched on board 07.
-                from .match_group_tuning import format_reason_counts
+                from .match_group_tuning import (
+                    format_reason_counts,
+                    group_skew_before_after,
+                )
 
                 print(
                     f"  {group.name}: {len(group_results)} members "
                     f"({format_reason_counts(res.reason for (_r, res) in group_results.values())})"
                 )
+                # Issue #3924 AC2: report the achieved group skew before and
+                # after tuning so the reason buckets are anchored to a
+                # concrete measured improvement (e.g. 15.4mm -> 0.002mm).
+                _skew = group_skew_before_after(
+                    (res.length_before_mm, res.length_after_mm)
+                    for (_r, res) in group_results.values()
+                )
+                if _skew is not None:
+                    _skew_before, _skew_after = _skew
+                    print(f"    skew: {_skew_before:.3f}mm -> {_skew_after:.3f}mm")
                 # Issue #3440 addendum: rollbacks / budget exhaustion /
                 # missing segments must say WHY (which DRC rule the
                 # candidate meander violated, requested-vs-achieved mm)

--- a/src/kicad_tools/router/match_group_tuning.py
+++ b/src/kicad_tools/router/match_group_tuning.py
@@ -356,6 +356,45 @@ def format_reason_counts(reasons: Iterable[str]) -> str:
     return ", ".join(parts)
 
 
+def group_skew_before_after(
+    lengths: Iterable[tuple[float, float]],
+) -> tuple[float, float] | None:
+    """Compute a group's length-skew before and after tuning.
+
+    Issue #3924 AC2.  A match group's skew is the ``max(L) - min(L)`` spread
+    across its members' routed lengths.  Given each member's
+    ``(length_before_mm, length_after_mm)`` (from :attr:`TuneResult`), this
+    returns ``(skew_before_mm, skew_after_mm)`` so the tuner's verbose
+    summary can report the achieved improvement per group.
+
+    Members whose *before* and *after* lengths are both ``0.0`` (unrouted
+    placeholders) are excluded from the spread -- an unrouted member has no
+    measured length and would otherwise drag the min to 0 and inflate the
+    reported skew.
+
+    Args:
+        lengths: Iterable of ``(before_mm, after_mm)`` pairs, one per group
+            member.
+
+    Returns:
+        ``(skew_before_mm, skew_after_mm)`` rounded to 4 decimals, or
+        ``None`` when fewer than two members carry a measured length (skew
+        is undefined for a single trace).
+    """
+    befores: list[float] = []
+    afters: list[float] = []
+    for before, after in lengths:
+        if before == 0.0 and after == 0.0:
+            continue
+        befores.append(before)
+        afters.append(after)
+    if len(befores) < 2:
+        return None
+    skew_before = max(befores) - min(befores)
+    skew_after = max(afters) - min(afters)
+    return round(skew_before, 4), round(skew_after, 4)
+
+
 # ---------------------------------------------------------------------------
 # Result type
 # ---------------------------------------------------------------------------

--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -69,6 +69,7 @@ class DRCChecker:
         net_class_map: dict[str, NetClassRouting] | None = None,
         warn_on_inactive_skew_rules: bool = True,
         verbose: bool = False,
+        emit_measurements: bool = False,
     ) -> None:
         """Initialize the DRC checker.
 
@@ -103,6 +104,15 @@ class DRCChecker:
                 measured per-pair / per-group values even when the pair /
                 group passes, so ``kct check --verbose`` surfaces the
                 measurements on a clean board (Issue #3917 AC5).
+            emit_measurements: When True, the sidecar-gated skew /
+                continuity rules emit the same advisory ``info``-severity
+                measurement findings regardless of ``verbose``.  This lets
+                a caller collect the measured per-pair / per-group values
+                (for a measurement-summary table) at default verbosity
+                without flooding the ``--verbose`` info stream (Issue
+                #3924 AC1).  The ``kct check`` CLI sets this True so it can
+                render a concise measurement summary after the violation
+                table.
 
         Raises:
             ValueError: If manufacturer ID is not recognized
@@ -115,6 +125,11 @@ class DRCChecker:
         self.net_class_map = net_class_map
         self.warn_on_inactive_skew_rules = warn_on_inactive_skew_rules
         self.verbose = verbose
+        self.emit_measurements = emit_measurements
+        # The skew / continuity rules surface their measured info findings
+        # when either the user asked for --verbose OR a caller wants the
+        # measurement summary (Issue #3924 AC1).
+        self._emit_skew_info = verbose or emit_measurements
         # Dedup guard so the per-rule INACTIVE warning fires at most once
         # per rule per checker instance (Issue #3917).
         self._inactive_skew_warned: set[str] = set()
@@ -439,13 +454,18 @@ class DRCChecker:
         if self.net_class_map is None:
             self._warn_inactive_skew_rule("diffpair_length_skew")
 
-        skew_data, skew_threshold_map = derive_skew_data(self.pcb, self.net_class_map)
+        skew_data, skew_threshold_map = derive_skew_data(
+            self.pcb,
+            self.net_class_map,
+            board_thickness_mm=self.design_rules.board_thickness_mm,
+            num_copper_layers=self.layers,
+        )
         engaged_pairs, _ = derive_engagement_state(self.pcb, self.net_class_map)
         rule = DiffPairLengthSkewRule(
             skew_data=skew_data,
             engaged_pairs=engaged_pairs,
             threshold_map=skew_threshold_map,
-            emit_info=self.verbose,
+            emit_info=self._emit_skew_info,
         )
         return rule.check(self.pcb, self.design_rules)
 
@@ -489,7 +509,7 @@ class DRCChecker:
         rule = DiffPairRoutingContinuityRule(
             engaged_pairs=engaged_pairs,
             threshold_map=threshold_map,
-            emit_info=self.verbose,
+            emit_info=self._emit_skew_info,
         )
         return rule.check(self.pcb, self.design_rules)
 
@@ -647,7 +667,7 @@ class DRCChecker:
                 group_skew_data=group_skew_data,
                 tracker_match_groups=tracker_match_groups,
                 threshold_map=threshold_map,
-                emit_info=self.verbose,
+                emit_info=self._emit_skew_info,
             )
         return rule.check(self.pcb, self.design_rules)
 

--- a/tests/test_apply_match_group_tuning.py
+++ b/tests/test_apply_match_group_tuning.py
@@ -124,6 +124,22 @@ class TestTripleGate:
         assert "DDR_DATA_BYTE_0" in results
         assert "DDR_DATA_BYTE_1" in results
 
+    def test_verbose_summary_reports_before_after_skew(self, capsys):
+        """Issue #3924 AC2: the verbose per-group summary prints an achieved
+        ``skew: <before>mm -> <after>mm`` line alongside the reason buckets."""
+        ar, group = _make_autorouter_with_4_net_group()
+        ar.apply_match_group_tuning(
+            detected_groups=[group],
+            verbose=True,
+        )
+        out = capsys.readouterr().out
+        # The reason-bucket line is still present ...
+        assert "DDR_DATA_BYTE_0" in out
+        assert "members" in out
+        # ... and now the achieved-skew line accompanies it.
+        assert "skew:" in out
+        assert "mm ->" in out
+
     def test_returns_per_member_tune_results_keyed_by_net_id(self):
         ar, group = _make_autorouter_with_4_net_group()
         results = ar.apply_match_group_tuning(

--- a/tests/test_cli_check_net_class_map.py
+++ b/tests/test_cli_check_net_class_map.py
@@ -643,6 +643,101 @@ class TestVerboseMeasuredValues:
         assert "within tolerance" not in captured.out
 
 
+class TestMeasurementSummary:
+    """Issue #3924 AC1/AC4/AC5: the default (non-``--verbose``) ``kct check``
+    table surface prints a per-group / per-pair length-measurement summary
+    for boards with a net-class-map sidecar, showing measured skew and
+    tolerance for both passing and failing groups."""
+
+    def test_failing_group_summary_default_verbosity(self, tmp_path: Path, capsys):
+        """AC1: an over-skew group prints a MEASUREMENT SUMMARY row with the
+        measured skew, tolerance, and a FAIL status -- without ``--verbose``."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = _write_matchgroup_board(tmp_path)  # unequal -> over-skew
+        _write_matchgroup_sidecar(tmp_path)
+
+        main(
+            [
+                str(pcb),
+                "--only",
+                "match_group_length_skew",
+                "--allow-incomplete",
+            ]
+        )
+        out = capsys.readouterr().out
+        assert "MEASUREMENT SUMMARY" in out
+        # The DDR group's measured skew and tolerance appear with FAIL.
+        summary = out.split("MEASUREMENT SUMMARY", 1)[1]
+        assert "DDR" in summary
+        assert "0.500" in summary  # default tolerance column
+        assert "FAIL" in summary
+
+    def test_passing_group_summary_default_verbosity(self, tmp_path: Path, capsys):
+        """AC1: a passing (equal-length) group still appears in the summary
+        with a ``pass`` status at default verbosity -- but the raw info line
+        (``within tolerance``) is NOT shown outside ``--verbose`` (AC4)."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = _write_matchgroup_board(tmp_path, equal=True)
+        _write_matchgroup_sidecar(tmp_path)
+
+        main(
+            [
+                str(pcb),
+                "--only",
+                "match_group_length_skew",
+                "--allow-incomplete",
+            ]
+        )
+        out = capsys.readouterr().out
+        assert "MEASUREMENT SUMMARY" in out
+        summary = out.split("MEASUREMENT SUMMARY", 1)[1]
+        assert "DDR" in summary
+        assert "pass" in summary
+        # AC4: the advisory info-finding wording is reserved for --verbose.
+        assert "within tolerance" not in out
+
+    def test_verbose_still_shows_info_line_and_summary(self, tmp_path: Path, capsys):
+        """AC4: ``--verbose`` keeps the per-group advisory info line AND the
+        measurement summary table (no regression to PR #3948's AC5)."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = _write_matchgroup_board(tmp_path, equal=True)
+        _write_matchgroup_sidecar(tmp_path)
+
+        main(
+            [
+                str(pcb),
+                "--only",
+                "match_group_length_skew",
+                "--verbose",
+                "--allow-incomplete",
+            ]
+        )
+        out = capsys.readouterr().out
+        assert "MEASUREMENT SUMMARY" in out
+        assert "within tolerance" in out
+
+    def test_no_summary_without_sidecar(self, tmp_path: Path, capsys):
+        """AC5: no net-class-map sidecar -> no measurement findings -> no
+        MEASUREMENT SUMMARY table (graceful no-op unchanged)."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = _write_matchgroup_board(tmp_path)  # no sidecar written
+
+        main(
+            [
+                str(pcb),
+                "--only",
+                "match_group_length_skew",
+                "--allow-incomplete",
+            ]
+        )
+        out = capsys.readouterr().out
+        assert "MEASUREMENT SUMMARY" not in out
+
+
 class TestTenVanishingErrorsRegression:
     """Issue #3917 AC6: reproduce the board-07 "10 errors vanish" case --
     without the sidecar the error count is strictly lower, and the delta is

--- a/tests/test_match_group_tuning.py
+++ b/tests/test_match_group_tuning.py
@@ -40,6 +40,7 @@ from kicad_tools.router.match_group_tuning import (
     _post_insertion_clearance_detail_group,
     _post_insertion_clearance_ok_group,
     format_reason_counts,
+    group_skew_before_after,
     tune_match_group_v2,
 )
 from kicad_tools.router.optimizer.serpentine import (
@@ -2659,6 +2660,39 @@ class TestFormatReasonCounts:
         out = format_reason_counts(["reference"] + ["longer_than_reference"] * 7)
         assert "1 reference" in out
         assert "7 longer-than-ref" in out
+
+
+class TestGroupSkewBeforeAfter:
+    """Issue #3924 AC2: the tuner's verbose summary reports achieved group
+    skew before and after tuning, derived from per-member
+    ``(length_before_mm, length_after_mm)``."""
+
+    def test_converged_group_reports_shrinking_skew(self):
+        # Reference held at 20mm; two shorter members grown toward it.
+        lengths = [(20.0, 20.0), (4.6, 19.998), (10.0, 20.001)]
+        result = group_skew_before_after(lengths)
+        assert result is not None
+        skew_before, skew_after = result
+        # Before: max 20 - min 4.6 = 15.4mm.  After: ~0.003mm.
+        assert skew_before == pytest.approx(15.4, abs=1e-6)
+        assert skew_after < 0.01
+
+    def test_single_member_returns_none(self):
+        # Skew is undefined for a single trace.
+        assert group_skew_before_after([(10.0, 10.0)]) is None
+
+    def test_empty_returns_none(self):
+        assert group_skew_before_after([]) is None
+
+    def test_unrouted_placeholders_excluded(self):
+        # An unrouted member (0.0, 0.0) must not drag min to zero and
+        # inflate the reported skew.  Only the two real members count.
+        lengths = [(10.0, 10.0), (10.5, 10.5), (0.0, 0.0)]
+        result = group_skew_before_after(lengths)
+        assert result is not None
+        skew_before, skew_after = result
+        assert skew_before == pytest.approx(0.5, abs=1e-6)
+        assert skew_after == pytest.approx(0.5, abs=1e-6)
 
 
 # =============================================================================

--- a/tests/test_validate_diffpair_skew.py
+++ b/tests/test_validate_diffpair_skew.py
@@ -295,6 +295,83 @@ class TestDeriveSkewDataBasic:
         assert threshold_map[(4, 5)] == 3.0
 
 
+class TestDeriveSkewDataViaInclusive:
+    """Issue #3924 AC3: ``derive_skew_data`` must thread ``board_thickness_mm``
+    and ``num_copper_layers`` so per-pair skew is *via-inclusive* on
+    multi-layer boards -- the sibling of PR #3928's
+    ``derive_group_skew_data`` fix (which threaded the same args for match
+    groups).  Without the threading, a via that appears on only one half of
+    the pair contributes 0 mm and the skew reads 0.0.
+    """
+
+    @staticmethod
+    def _pair_pcb_with_via_on_positive() -> _StubPCB:
+        """Symmetric-copper pair (both halves 10 mm on F.Cu) where the
+        positive half additionally carries one via.  Any measured skew is
+        therefore attributable solely to the via's drilled contribution."""
+        p_net, n_net = 4, 5
+        p_name, n_name = "USB_D+", "USB_D-"
+        nets = {
+            0: _StubNet(0, ""),
+            p_net: _StubNet(p_net, p_name),
+            n_net: _StubNet(n_net, n_name),
+        }
+        segs = [
+            _StubSegment(start=(0.0, 0.0), end=(10.0, 0.0), net_number=p_net, net_name=p_name),
+            _StubSegment(start=(0.0, 1.0), end=(10.0, 1.0), net_number=n_net, net_name=n_name),
+        ]
+        # A single F.Cu<->B.Cu via on the positive half only.
+        vias = [
+            _StubVia(
+                position=(10.0, 0.0),
+                layers=["F.Cu", "B.Cu"],
+                net_number=p_net,
+                net_name=p_name,
+            )
+        ]
+        return _StubPCB(_nets=nets, _segments=segs, _vias=vias)
+
+    def test_via_blind_without_board_thickness(self):
+        """Default call (no ``board_thickness_mm``) -> via contributes 0 mm,
+        so the copper-symmetric pair reads 0.0 skew (the old via-blind
+        behaviour the AC3 fix must NOT change for the no-thickness path)."""
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.diffpair_skew import derive_skew_data
+
+        nc = NetClassRouting(name="HIGH_SPEED", coupled_routing=True)
+        net_class_map = {"USB_D+": nc, "USB_D-": nc}
+
+        pcb = self._pair_pcb_with_via_on_positive()
+        skew_data, _ = derive_skew_data(pcb, net_class_map)
+
+        assert skew_data[("USB_D+", "USB_D-")] == 0.0
+
+    def test_via_inclusive_with_board_thickness(self):
+        """4-layer board with ``board_thickness_mm`` supplied -> the lone via
+        on the positive half adds its drilled length, so the pair now reports
+        a non-zero via-inclusive skew (AC3: matches the #3928 group fix)."""
+        from kicad_tools.router.rules import NetClassRouting
+        from kicad_tools.validate.diffpair_skew import derive_skew_data
+
+        nc = NetClassRouting(name="HIGH_SPEED", coupled_routing=True)
+        net_class_map = {"USB_D+": nc, "USB_D-": nc}
+
+        pcb = self._pair_pcb_with_via_on_positive()
+        skew_data, _ = derive_skew_data(
+            pcb,
+            net_class_map,
+            board_thickness_mm=1.6,
+            num_copper_layers=4,
+        )
+
+        skew = skew_data[("USB_D+", "USB_D-")]
+        # The via's drilled contribution is strictly positive and bounded by
+        # the total stackup thickness (a single F.Cu<->B.Cu via spans the
+        # full 1.6 mm on a 4-layer board).
+        assert skew > 0.0
+        assert skew <= 1.6
+
+
 class TestDeriveSkewDataUnroutedHalf:
     """Pairs where one half has no geometry are omitted (graceful degradation)."""
 


### PR DESCRIPTION
## Summary

Closes the remaining observability + correctness gaps the curator scoped on #3924 after PRs #3928/#3933/#3948 (all merged). Three items: (AC1) a per-group/per-pair measurement summary on the default `kct check` output, (AC2) before/after group skew in the tuner's verbose per-group print, and (AC3) via-inclusive per-pair diff-pair skew (the sibling of #3928's match-group fix). The standalone `kct lengths` surface (gap 3) was explicitly deferred and is NOT built here.

## Changes

- **AC1 — default measurement summary** (`check_cmd.py`, `checker.py`): new `DRCChecker(emit_measurements=...)` knob collects the skew rules' per-pair/per-group info findings regardless of `--verbose`. `output_table` renders them (plus failing skew/continuity violations) into a dedicated `MEASUREMENT SUMMARY` table with columns Group/Pair, Metric, Measured, Tolerance, Status. The raw advisory info lines are still gated on `--verbose` in the generic INFOS section (no regression to PR #3948).
- **AC3 — via-inclusive diffpair skew** (`checker.py`): threads `board_thickness_mm` / `num_copper_layers` into `derive_skew_data` at the `check_diffpair_length_skew` callsite, matching what #3928 did for `derive_group_skew_data`.
- **AC2 — tuner before/after skew** (`match_group_tuning.py`, `core.py`): new pure helper `group_skew_before_after`; the `apply_match_group_tuning` verbose loop now prints `skew: <before>mm -> <after>mm` per group alongside the reason buckets. `route_cmd.py` was intentionally left untouched — the tuner's verbose print is owned by `core.py` and already has the data locally, so no threading through `route_cmd.py` was needed (also avoids colliding with the parallel #3923 router work).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| AC1: default `kct check` prints per-group/per-pair measurement table (pass + fail) | ✅ | Manual on board 07 (table shows ADDR_BUS 1.600mm/0.500mm FAIL, per-pair skew + continuity); tests `TestMeasurementSummary` |
| AC2: tuner verbose prints achieved before/after skew per group | ✅ | `TestGroupSkewBeforeAfter` + `test_verbose_summary_reports_before_after_skew` |
| AC3: `check_diffpair_length_skew` threads board thickness → via-inclusive skew | ✅ | `TestDeriveSkewDataViaInclusive` (via-blind without thickness == 0.0; via-inclusive with 4-layer thickness > 0) |
| AC4: `--verbose` still surfaces per-pair/per-group info findings | ✅ | `test_verbose_still_shows_info_line_and_summary`; existing `TestVerboseMeasuredValues` unchanged |
| AC5: no measured values without a sidecar (graceful no-op) | ✅ | `test_no_summary_without_sidecar`; manual (board copied to sidecar-less temp dir prints no table) |

## Test Plan

- `uv run pytest tests/test_cli_check_net_class_map.py tests/test_validate_diffpair_skew.py tests/test_validate_diffpair_length_skew.py tests/test_validate_match_group_skew.py tests/test_validate_match_group_length_skew.py tests/test_match_group_tuning.py tests/test_apply_match_group_tuning.py tests/test_cli_route_match_groups.py tests/test_check_cmd_coverage.py` → 277 passed.
- `tests/test_board_07_matchgroup_test.py tests/test_cli_check_match_group_length_skew.py` → 55 passed.
- `ruff check` / `ruff format --check` clean on all changed files.
- `mypy` on changed source files introduces no new errors (the 2 remaining errors in `diffpair_skew.py:213` and `checker.py` pre-exist on origin/main).

Closes #3924