### PR TITLE
test(bom): pin degraded-mode enrichment determinism + document contract

### DIFF
--- a/src/kicad_tools/export/bom_enrich.py
+++ b/src/kicad_tools/export/bom_enrich.py
@@ -123,6 +123,31 @@ def enrich_bom_lcsc(
 
     Items that already have an ``lcsc`` value are left untouched.
 
+    Degraded-mode determinism contract (issue #3935)
+    ------------------------------------------------
+    When the JLCPCB API is unavailable it responds with 403 Forbidden.
+    On the first such response this function trips a circuit breaker
+    (``api_forbidden``) and resolves every remaining group from the
+    enrichment cache via :func:`_try_cache_fallback`.  This degraded path
+    is **deterministic for a fixed input and a fixed cache state**: two
+    successive calls with the same ``items`` and the same enrichment
+    cache produce byte-identical :class:`EnrichmentReport` outputs (same
+    entries, sources, ``lcsc_part`` values, and order).  This holds
+    because the fallback only performs pure SQLite reads
+    (``get_enrichment_match(..., ignore_expiry=True)``) and never mutates
+    the cache in the API-forbidden path.
+
+    The *observed* nondeterminism reported in issue #3935 (match counts
+    drifting 8 -> 9 -> 10 across "identical" runs) is not a property of a
+    single call: it arises because the cache **accumulates** matches
+    across runs when the live API is sporadically reachable.  A run that
+    reaches the API writes new ``enrichment_matches`` rows
+    (``source="auto"``); a later API-forbidden run then serves those rows
+    as ``source="cache"``.  The determinism guaranteed here is therefore
+    conditional on the cache state being held constant -- pin the LCSC
+    mapping in the project spec (or a committed lockfile) if you need
+    reproducibility that is independent of local cache warmth.
+
     Args:
         items: List of BOM items to enrich (modified in place).
         prefer_basic: Prefer JLCPCB Basic parts (no extra assembly fee).

--- a/tests/test_bom_enrich.py
+++ b/tests/test_bom_enrich.py
@@ -553,6 +553,191 @@ class TestEnrichBomLcscCacheFallback:
             assert report.cache_matched == 0
 
 
+class TestEnrichBomLcscDeterminism:
+    """Regression tests for degraded-mode (API-forbidden) determinism.
+
+    Issue #3935: BOM enrichment was observed to drift across "identical"
+    runs (8 -> 9 -> 10 matches) when the JLCPCB API was intermittently
+    available. The drift comes from the enrichment cache *accumulating*
+    matches across runs -- not from any nondeterminism within a single
+    call. These tests pin the contract: for a fixed cache state and fixed
+    input, two API-forbidden runs produce byte-identical reports.
+    """
+
+    def _seed_cache(self, cache: PartsCache) -> None:
+        """Populate the enrichment cache with a known set of matches."""
+        cache.put_enrichment_match(
+            "10k",
+            "Resistor_SMD:R_0402_1005Metric",
+            "C25744",
+            confidence=0.85,
+            part_type="Basic",
+        )
+        cache.put_enrichment_match(
+            "100nF",
+            "Capacitor_SMD:C_0402_1005Metric",
+            "C1525",
+            confidence=0.9,
+            part_type="Basic",
+        )
+
+    @patch("kicad_tools.export.bom_enrich.PartSuggester")
+    def test_two_offline_runs_produce_identical_reports(self, MockSuggester):
+        """AC5: two 403-forbidden runs with the same cache are byte-identical.
+
+        This is the direct regression guard for the sweep-observed drift:
+        with a frozen cache state and frozen inputs, the degraded-mode
+        output must not change between runs.
+        """
+        from kicad_tools.parts.lcsc import LCSCForbiddenError
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cache = PartsCache(db_path=Path(tmp) / "test.db")
+            self._seed_cache(cache)
+
+            def _run() -> EnrichmentReport:
+                mock_instance = MagicMock()
+                _make_suggester_mock(mock_instance)
+                mock_instance._get_client.return_value.cache = cache
+                mock_instance.suggest_for_component.side_effect = LCSCForbiddenError(
+                    "403 Forbidden"
+                )
+                MockSuggester.return_value = mock_instance
+                # One cache hit ("10k"), one cache miss ("47uF" -> unmatched),
+                # exercising both the cache and unmatched degraded branches.
+                items = [
+                    _make_item("R1", "10k", "Resistor_SMD:R_0402_1005Metric"),
+                    _make_item("C1", "100nF", "Capacitor_SMD:C_0402_1005Metric"),
+                    _make_item("C2", "47uF", "Capacitor_SMD:C_0805_2012Metric"),
+                ]
+                return enrich_bom_lcsc(items)
+
+            report1 = _run()
+            report2 = _run()
+
+            # @dataclass generates field-by-field __eq__, so this asserts
+            # same entries, sources, lcsc_part values, confidences, order.
+            assert report1.entries == report2.entries
+            assert report1 == report2
+
+            # Sanity: the cache state was not mutated between runs, so the
+            # bucket counts are stable and reflect the seeded state.
+            assert report1.cache_matched == 2
+            assert report1.unmatched == 1
+            assert report2.cache_matched == 2
+            assert report2.unmatched == 1
+
+    @patch("kicad_tools.export.bom_enrich.PartSuggester")
+    def test_offline_run_does_not_mutate_cache(self, MockSuggester):
+        """The API-forbidden path performs pure reads (no cache writes).
+
+        If a degraded run wrote to the cache, the second run could observe
+        a different state -- the exact mechanism behind the reported drift.
+        """
+        from kicad_tools.parts.lcsc import LCSCForbiddenError
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cache = PartsCache(db_path=Path(tmp) / "test.db")
+            self._seed_cache(cache)
+
+            mock_instance = MagicMock()
+            _make_suggester_mock(mock_instance)
+            mock_instance._get_client.return_value.cache = cache
+            mock_instance.suggest_for_component.side_effect = LCSCForbiddenError("403 Forbidden")
+            MockSuggester.return_value = mock_instance
+
+            items = [
+                _make_item("R1", "10k", "Resistor_SMD:R_0402_1005Metric"),
+                # A brand-new (value, footprint) that is NOT in the cache:
+                # a degraded run must not write it back.
+                _make_item("C2", "47uF", "Capacitor_SMD:C_0805_2012Metric"),
+            ]
+
+            enrich_bom_lcsc(items)
+
+            # The uncached group must remain absent -- no write-back occurred.
+            assert (
+                cache.get_enrichment_match(
+                    "47uF", "Capacitor_SMD:C_0805_2012Metric", ignore_expiry=True
+                )
+                is None
+            )
+            # The seeded entries are untouched.
+            match = cache.get_enrichment_match(
+                "10k", "Resistor_SMD:R_0402_1005Metric", ignore_expiry=True
+            )
+            assert match is not None
+            assert match["lcsc_part"] == "C25744"
+
+    @patch("kicad_tools.export.bom_enrich.PartSuggester")
+    def test_offline_run_emits_warning_not_debug(self, MockSuggester, caplog):
+        """AC2: degraded mode surfaces a WARNING-level message to callers.
+
+        The 403 circuit breaker and each stale cache fallback must log at
+        WARNING (not be silenced to DEBUG), so an operator reviewing logs
+        can tell a connected run from an offline one.
+        """
+        import logging
+
+        from kicad_tools.parts.lcsc import LCSCForbiddenError
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cache = PartsCache(db_path=Path(tmp) / "test.db")
+            self._seed_cache(cache)
+
+            mock_instance = MagicMock()
+            _make_suggester_mock(mock_instance)
+            mock_instance._get_client.return_value.cache = cache
+            mock_instance.suggest_for_component.side_effect = LCSCForbiddenError("403 Forbidden")
+            MockSuggester.return_value = mock_instance
+
+            items = [
+                _make_item("R1", "10k", "Resistor_SMD:R_0402_1005Metric"),
+            ]
+
+            with caplog.at_level(logging.WARNING, logger="kicad_tools.export.bom_enrich"):
+                enrich_bom_lcsc(items)
+
+            warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+            # The 403 circuit-breaker warning must be present.
+            assert any("403 Forbidden" in r.getMessage() for r in warnings)
+            # The stale cache fallback must also warn (degraded, verify-before-fab).
+            assert any("Cache fallback" in r.getMessage() for r in warnings)
+
+    @patch("kicad_tools.export.bom_enrich.PartSuggester")
+    def test_cache_bucket_surfaced_distinct_from_auto(self, MockSuggester):
+        """AC3: the summary distinguishes cache-sourced entries from auto.
+
+        A degraded run's ``cache`` count must be a distinct bucket in the
+        summary so two exports can be compared without reading raw logs.
+        """
+        from kicad_tools.parts.lcsc import LCSCForbiddenError
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cache = PartsCache(db_path=Path(tmp) / "test.db")
+            self._seed_cache(cache)
+
+            mock_instance = MagicMock()
+            _make_suggester_mock(mock_instance)
+            mock_instance._get_client.return_value.cache = cache
+            mock_instance.suggest_for_component.side_effect = LCSCForbiddenError("403 Forbidden")
+            MockSuggester.return_value = mock_instance
+
+            items = [
+                _make_item("R1", "10k", "Resistor_SMD:R_0402_1005Metric"),
+                _make_item("C1", "100nF", "Capacitor_SMD:C_0402_1005Metric"),
+            ]
+
+            report = enrich_bom_lcsc(items)
+            summary = report.summary_lines()[0]
+
+            # "cache" is a distinct bucket, and none were auto-matched.
+            assert "2 from cache" in summary
+            assert "0 auto-matched" in summary
+            assert report.cache_matched == 2
+            assert report.auto_matched == 0
+
+
 class TestEnrichmentReport:
     """Tests for the EnrichmentReport dataclass."""
 


### PR DESCRIPTION
## Summary

BOM LCSC enrichment appeared nondeterministic when the JLCPCB API was
unavailable: successive "identical" runs drifted (8 -> 9 -> 10 matches).
The root cause is **cache warmth**, not per-call nondeterminism — a run
that reaches the live API writes new `enrichment_matches` rows, and a
later API-forbidden run serves those rows as `source="cache"`. A single
`enrich_bom_lcsc` call is already deterministic for a fixed cache state,
because the degraded path only performs pure SQLite reads
(`get_enrichment_match(..., ignore_expiry=True)`).

This PR implements the **minimal fix** (AC1–AC3, AC5): it documents the
degraded-mode determinism contract and adds a regression guard so the
drift cannot silently return. It deliberately does **not** add the
`bom.lock` lockfile (AC4) — that is the larger structural remedy and was
scoped as a follow-on; it did not fall out naturally here.

## Changes

- `src/kicad_tools/export/bom_enrich.py`: document the degraded-mode
  determinism contract in `enrich_bom_lcsc` — identical input + identical
  cache state produces byte-identical `EnrichmentReport`; the reported
  drift is a cache-accumulation effect across sporadically-online runs.
- `tests/test_bom_enrich.py`: add `TestEnrichBomLcscDeterminism` with four
  tests (two 403 runs equal; offline path does not mutate the cache;
  WARNING-level logging; cache bucket surfaced distinct from auto).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| AC1 (deterministic degraded mode) | ✅ | `test_two_offline_runs_produce_identical_reports` asserts `report1 == report2` via `@dataclass` field equality across cache-hit + unmatched groups |
| AC2 (explicit degraded-mode WARNING) | ✅ | `test_offline_run_emits_warning_not_debug` asserts both the 403 circuit-breaker and stale cache-fallback log at `WARNING` |
| AC3 (cache-state surfaced in log) | ✅ | `test_cache_bucket_surfaced_distinct_from_auto` asserts `summary_lines()` shows `"2 from cache"` distinct from `"0 auto-matched"` |
| AC5 (test: two offline runs identical) | ✅ | new regression test pre-seeds cache, calls twice with API mocked as 403, asserts equal reports and stable bucket counts |
| AC6 (no change to live-API path) | ✅ | no production logic changed (docstring only); all pre-existing `TestEnrichBomLcsc*` tests pass unmodified |
| AC4 (lockfile/spec pinning) | ➖ | out of scope for the minimal fix; documented as the structural follow-on |

Supporting guard: `test_offline_run_does_not_mutate_cache` proves the
API-forbidden path performs pure reads (no write-back), which is the
mechanism that keeps successive runs identical.

## Test Plan

- `uv run pytest tests/test_bom_enrich.py` — 24 passed (20 existing + 4 new).
- `uv run ruff check` and `ruff format --check` on both files — clean.
- No real JLCPCB API calls: `PartSuggester` is mocked, cache is a
  `PartsCache` on a `TemporaryDirectory`.
- mypy: the 2 pre-existing errors in `bom_enrich.py` (`find_*_mismatch`
  assignment types, lines 337/345) are unchanged from `origin/main`
  (verified via `git stash`); this PR introduces no new type errors and
  the docstring-only production change touches none of that code.

Closes #3935