### PR TITLE
docs(render): correct --help to say 2D plots are .svg, not .png

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 3925
-# Branch: feature/issue-3925
+# Issue: 3937
+# Branch: feature/issue-3937
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/docs/board-json-schema.md
+++ b/docs/board-json-schema.md
@@ -21,7 +21,7 @@ directory — `kct board-metrics` never recomputes anything from KiCad.
 | `nets_routed_pct`       | `report.md` → `\| Signal Net Completion \|` row | float percent |
 | `drc_violations`        | `report.md` → `## DRC Status` → `\| Errors \|` row | integer |
 | `cost`                  | `report.md` → `## Cost Estimate` block | omitted if section absent |
-| `renders`               | `output/renders/*.png` (from `kct render`, #3675) | only existing files |
+| `renders`               | `output/renders/*.{svg,png}` (2D plots are `.svg`, 3D renders are `.png`; from `kct render`, #3675) | only existing files |
 | `manufacturing_package` | `output/manufacturing/kicad_project.zip` | omitted if absent |
 | `manifest_generated_at` | `manifest.json` → `generated_at`      | ISO-8601 string |
 | `lvs_clean`             | `output/lvs.json` → `clean`           | omitted when `lvs.json` is absent (#3748, #3749) |
@@ -44,8 +44,8 @@ directory — `kct board-metrics` never recomputes anything from KiCad.
   "drc_violations": 14,
   "cost": { "per_board_usd": 9.16, "batch_qty": 5, "batch_total_usd": 45.78 },
   "renders": {
-    "pcb_front": "renders/pcb-front.png",
-    "pcb_back": "renders/pcb-back.png",
+    "pcb_front": "renders/pcb-front.svg",
+    "pcb_back": "renders/pcb-back.svg",
     "3d_front": "renders/3d-front.png",
     "3d_back": "renders/3d-back.png"
   },
@@ -83,8 +83,8 @@ directory — `kct board-metrics` never recomputes anything from KiCad.
 ### Paths are relative to `board.json`
 
 `renders` values and `manufacturing_package` are relative to the `board.json`
-file location (`boards/<id>/output/`). For example `renders/pcb-front.png`
-resolves to `boards/<id>/output/renders/pcb-front.png`.
+file location (`boards/<id>/output/`). For example `renders/pcb-front.svg`
+resolves to `boards/<id>/output/renders/pcb-front.svg`.
 
 ### `status` values
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -5221,18 +5221,19 @@ def _add_fleet_parser(subparsers) -> None:
 def _add_render_parser(subparsers) -> None:
     """Add the ``render`` subcommand parser (Epic #3674, Phase 1).
 
-    Generates per-board 2D layer plots and 3D ray-traced PNGs into
+    Generates per-board 2D layer plots (SVGs) and 3D ray-traced PNGs into
     ``boards/<id>/output/renders/`` for downstream gallery consumption.
     """
     render_parser = subparsers.add_parser(
         "render",
-        help="Render per-board 2D layer plots + 3D PNGs into output/renders/",
+        help="Render per-board 2D SVGs + 3D PNGs into output/renders/",
         description=(
             "Generate visual artifacts for one board or every board under a "
             "root: 2D front/back layer plots (copper + silkscreen + edge cuts) "
-            "via 'kicad-cli pcb export png', and 3D front/back ray-traced PNGs "
+            "via 'kicad-cli pcb export svg', and 3D front/back ray-traced PNGs "
             "via 'kicad-cli pcb render'. Outputs go to a fixed, documented path "
-            "(boards/<id>/output/renders/{pcb-front,pcb-back,3d-front,3d-back}.png). "
+            "(boards/<id>/output/renders/{pcb-front,pcb-back}.svg and "
+            "{3d-front,3d-back}.png). "
             "The routed PCB is preferred with graceful fallback to the unrouted "
             "PCB. 3D render requires KiCad 8.0.4+ and a display (xvfb on CI)."
         ),

--- a/src/kicad_tools/cli/render_cmd.py
+++ b/src/kicad_tools/cli/render_cmd.py
@@ -261,7 +261,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="kct render",
         description=(
-            "Render per-board 2D layer plots and 3D ray-traced PNGs into "
+            "Render per-board 2D layer plots (SVGs) and 3D ray-traced PNGs into "
             "boards/<id>/output/renders/."
         ),
     )

--- a/tests/test_render_cmd.py
+++ b/tests/test_render_cmd.py
@@ -158,6 +158,68 @@ class TestOutputPathContract:
 
 
 # --------------------------------------------------------------------------
+# Help text accuracy (regression guard for #3937)
+# --------------------------------------------------------------------------
+
+
+class TestHelpText:
+    """Pin the `--help` text so it matches the real output contract.
+
+    The 2D layer plots are written as ``.svg`` via ``kicad-cli pcb export svg``
+    and only the 3D renders are ``.png`` (via ``kicad-cli pcb render``). The
+    help text used to promise ``.png`` for the 2D plots and named the stale
+    ``pcb export png`` subcommand; these assertions catch that regression.
+    """
+
+    def _render_subaction(self):
+        """Return the argparse action for the ``render`` subcommand.
+
+        We inspect the parser structure directly rather than the rendered
+        ``--help`` text because argparse line-wraps the description, which would
+        split the filename globs (e.g. ``{pcb-\\nfront,pcb-back}.svg``) and make
+        substring assertions brittle.
+        """
+        from argparse import _SubParsersAction
+
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        for action in parser._actions:
+            if isinstance(action, _SubParsersAction):
+                return action.choices["render"], action._choices_actions
+        raise AssertionError("no subparsers action found")
+
+    def test_standalone_help_mentions_svg_for_2d(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            render_main(["--help"])
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        assert "SVG" in out
+        # The standalone description must not call the 2D plots plain "PNGs".
+        assert "2D layer plots (SVGs)" in out
+
+    def test_subparser_description_names_export_svg_not_png(self):
+        render_parser, _ = self._render_subaction()
+        desc = render_parser.description
+        assert "kicad-cli pcb export svg" in desc
+        assert "kicad-cli pcb export png" not in desc
+
+    def test_subparser_description_2d_outputs_are_svg(self):
+        render_parser, _ = self._render_subaction()
+        desc = render_parser.description
+        assert "{pcb-front,pcb-back}.svg" in desc
+        assert "{3d-front,3d-back}.png" in desc
+        # The old glob promised .png for the 2D plots — must be gone.
+        assert "{pcb-front,pcb-back,3d-front,3d-back}.png" not in desc
+
+    def test_subparser_help_line_mentions_svg_not_png(self):
+        _, choices_actions = self._render_subaction()
+        render_help = next(a.help for a in choices_actions if a.dest == "render")
+        assert "SVG" in render_help
+        assert "3D PNGs" in render_help
+
+
+# --------------------------------------------------------------------------
 # Routed PCB preference / fallback
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
`kct render --help` promised the 2D layer plots would be written as `.png`
(`{pcb-front,pcb-back}.png`) and named the KiCad subcommand `kicad-cli pcb export png`.
Both are stale: the implementation writes 2D plots as `.svg` via `kicad-cli pcb export svg`,
and only the 3D renders are `.png`. This is a text-only fix — no logic changes.

## Changes
- `src/kicad_tools/cli/parser.py` (`_add_render_parser`): `help` now says "2D SVGs + 3D PNGs"; `description` uses `kicad-cli pcb export svg` and the corrected glob `{pcb-front,pcb-back}.svg` + `{3d-front,3d-back}.png`; docstring updated to "2D layer plots (SVGs)".
- `src/kicad_tools/cli/render_cmd.py` (`main`): standalone description now reads "2D layer plots (SVGs) and 3D ray-traced PNGs".
- `docs/board-json-schema.md`: `renders` glob and the JSON example show `pcb_front`/`pcb_back` as `.svg`; the relative-path example uses `pcb-front.svg`.
- `tests/test_render_cmd.py`: new `TestHelpText` class pins the corrected strings (inspects parser structure directly to avoid argparse line-wrap brittleness).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `render --help` no longer mentions `.png` for 2D plots | ✅ | `uv run kct render --help` shows `{pcb-front,pcb-back}.svg` |
| Help states `kicad-cli pcb export svg` (not `png`) | ✅ | grep of help output shows `export svg`, no `export png` |
| Help states 2D are `.svg`, 3D are `.png` | ✅ | glob is `{pcb-front,pcb-back}.svg and {3d-front,3d-back}.png` |
| `board-json-schema.md` example shows `pcb_front`/`pcb_back` as `.svg` | ✅ | doc edited |
| `render_cmd.py` standalone `--help` accurate | ✅ | description now "2D layer plots (SVGs)" |
| New regression test | ✅ | `TestHelpText` added |

## Test Plan
- `uv run pytest tests/test_render_cmd.py` — 28 passed (4 new `TestHelpText` tests).
- `uv run pytest tests/test_cli_parser_drift.py` — 15 passed.
- `uv run ruff check` / `ruff format` — clean on all changed files.
- Manual: `uv run kct render --help` shows `export svg` and `.svg` for 2D outputs.

Closes #3937