### PR TITLE
fix(fleet): auto-detect single-board-dir in status/ship-ready discovery

### DIFF
--- a/src/kicad_tools/cli/fleet_cmd.py
+++ b/src/kicad_tools/cli/fleet_cmd.py
@@ -1156,6 +1156,18 @@ def _survey_board(
     )
 
 
+def _is_single_board_dir(path: Path) -> bool:
+    """Return True if ``path`` appears to be a board directory itself.
+
+    Detects the presence of an ``output/`` child or a ``project.kct`` file,
+    which distinguishes a single board root (e.g. ``boards/04-stm32-devboard``)
+    from a fleet parent directory (e.g. ``boards/``). This lets discovery
+    auto-detect single-board-dir invocations instead of returning an empty
+    list when ``--boards-dir`` already points at a board.
+    """
+    return (path / "output").is_dir() or (path / "project.kct").is_file()
+
+
 def _discover_boards(
     boards_dir: Path,
     pattern: str,
@@ -1166,12 +1178,22 @@ def _discover_boards(
     A board is discovered if it contains a routed PCB matching ``pattern``
     under ``<board>/output/``. Boards without a routed PCB are silently
     skipped (they haven't reached the routing stage yet).
+
+    When ``boards_dir`` itself looks like a board directory (see
+    :func:`_is_single_board_dir`), it is surveyed directly as a single
+    board rather than being scanned for board sub-directories.
     """
     if not boards_dir.is_dir():
         return []
     tolerances = _load_drc_tolerances(
         drc_tolerance_path if drc_tolerance_path is not None else _DRC_TOLERANCE_PATH
     )
+    # Auto-detect single-board-dir invocation: --boards-dir points at a
+    # board rather than a parent of boards.
+    if _is_single_board_dir(boards_dir):
+        if _discover_routed_pcb(boards_dir, pattern) is None:
+            return []
+        return [_survey_board(boards_dir, pattern, tolerances)]
     boards: list[BoardStatus] = []
     for entry in sorted(boards_dir.iterdir()):
         if not entry.is_dir():
@@ -1232,14 +1254,20 @@ def _discover_ship_ready(
 ) -> list[ShipReadyStatus]:
     """Survey every board sub-directory for ship-readiness.
 
-    Mirrors :func:`_discover_boards` (same skip rules) but builds the
-    richer :class:`ShipReadyStatus` per board.
+    Mirrors :func:`_discover_boards` (same skip rules, including the
+    single-board-dir auto-detection) but builds the richer
+    :class:`ShipReadyStatus` per board.
     """
     if not boards_dir.is_dir():
         return []
     tolerances = _load_drc_tolerances(
         drc_tolerance_path if drc_tolerance_path is not None else _DRC_TOLERANCE_PATH
     )
+    # Auto-detect single-board-dir invocation (see _discover_boards).
+    if _is_single_board_dir(boards_dir):
+        if _discover_routed_pcb(boards_dir, pattern) is None:
+            return []
+        return [_survey_board_ship_ready(boards_dir, pattern, tolerances)]
     results: list[ShipReadyStatus] = []
     for entry in sorted(boards_dir.iterdir()):
         if not entry.is_dir():

--- a/tests/test_fleet_status.py
+++ b/tests/test_fleet_status.py
@@ -1897,3 +1897,122 @@ class TestExtractPcbNamedNets:
 
         result = _extract_pcb_named_nets(tmp_path / "nonexistent.kicad_pcb")
         assert result is None
+
+
+class TestSingleBoardDirDiscovery:
+    """Auto-detection of single-board-dir vs parent-dir invocations (#3938)."""
+
+    _PATTERN = "*_routed.kicad_pcb"
+
+    def test_is_single_board_dir_output_child(self, tmp_path: Path):
+        from kicad_tools.cli.fleet_cmd import _is_single_board_dir
+
+        board_dir = tmp_path / "04-stm32-devboard"
+        (board_dir / "output").mkdir(parents=True)
+        assert _is_single_board_dir(board_dir) is True
+
+    def test_is_single_board_dir_project_kct(self, tmp_path: Path):
+        from kicad_tools.cli.fleet_cmd import _is_single_board_dir
+
+        board_dir = tmp_path / "04-stm32-devboard"
+        board_dir.mkdir()
+        (board_dir / "project.kct").write_text("{}")
+        assert _is_single_board_dir(board_dir) is True
+
+    def test_is_single_board_dir_parent_is_false(self, tmp_path: Path):
+        from kicad_tools.cli.fleet_cmd import _is_single_board_dir
+
+        parent = tmp_path / "boards"
+        make_fake_board(parent, "a-board", routed_complete=True)
+        # A parent-of-boards directory has neither output/ nor project.kct.
+        assert _is_single_board_dir(parent) is False
+
+    def test_discover_boards_single_board_dir(self, tmp_path: Path):
+        """--boards-dir pointing at a board itself returns exactly one row."""
+        from kicad_tools.cli.fleet_cmd import _discover_boards
+
+        boards = tmp_path / "boards"
+        make_fake_board(boards, "04-stm32-devboard", routed_complete=True)
+        board_dir = boards / "04-stm32-devboard"
+
+        results = _discover_boards(board_dir, self._PATTERN)
+        assert len(results) == 1
+        assert results[0].name == "04-stm32-devboard"
+
+    def test_discover_boards_parent_dir_unchanged(self, tmp_path: Path):
+        """Parent-dir invocation still enumerates every board subdirectory."""
+        from kicad_tools.cli.fleet_cmd import _discover_boards
+
+        boards = tmp_path / "boards"
+        make_fake_board(boards, "a-board", routed_complete=True)
+        make_fake_board(boards, "b-board", routed_complete=True)
+
+        results = _discover_boards(boards, self._PATTERN)
+        assert {b.name for b in results} == {"a-board", "b-board"}
+
+    def test_discover_boards_single_board_dir_no_routed_pcb(self, tmp_path: Path):
+        """A board dir with output/ but no routed PCB returns an empty list."""
+        from kicad_tools.cli.fleet_cmd import _discover_boards
+
+        board_dir = tmp_path / "04-stm32-devboard"
+        (board_dir / "output").mkdir(parents=True)
+        # project.kct present so it is recognised as a board dir, but no PCB.
+        (board_dir / "project.kct").write_text("{}")
+
+        assert _discover_boards(board_dir, self._PATTERN) == []
+
+    def test_discover_boards_missing_dir(self, tmp_path: Path):
+        """Nonexistent --boards-dir still returns an empty list (no regression)."""
+        from kicad_tools.cli.fleet_cmd import _discover_boards
+
+        assert _discover_boards(tmp_path / "nope", self._PATTERN) == []
+
+    def test_discover_ship_ready_single_board_dir(self, tmp_path: Path):
+        """Ship-ready discovery also auto-detects a single-board-dir path."""
+        from kicad_tools.cli.fleet_cmd import _discover_ship_ready
+
+        boards = tmp_path / "boards"
+        make_fake_board(
+            boards,
+            "04-stm32-devboard",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        board_dir = boards / "04-stm32-devboard"
+
+        results = _discover_ship_ready(board_dir, self._PATTERN)
+        assert len(results) == 1
+        assert results[0].board.name == "04-stm32-devboard"
+
+    def test_discover_ship_ready_parent_dir_unchanged(self, tmp_path: Path):
+        from kicad_tools.cli.fleet_cmd import _discover_ship_ready
+
+        boards = tmp_path / "boards"
+        make_fake_board(boards, "a-board", routed_complete=True)
+        make_fake_board(boards, "b-board", routed_complete=True)
+
+        results = _discover_ship_ready(boards, self._PATTERN)
+        assert {s.board.name for s in results} == {"a-board", "b-board"}
+
+    def test_status_cli_single_board_dir(self, tmp_path: Path, capsys):
+        """End-to-end: `status --boards-dir <board>` prints one board row."""
+        boards = tmp_path / "boards"
+        make_fake_board(
+            boards,
+            "04-stm32-devboard",
+            routed_complete=True,
+            has_gerbers=True,
+            has_bom=True,
+            has_cpl=True,
+            has_manifest=True,
+        )
+        board_dir = boards / "04-stm32-devboard"
+
+        result = main(["status", "--boards-dir", str(board_dir), "--format", "json"])
+        assert result == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["summary"]["total"] == 1
+        assert data["boards"][0]["name"] == "04-stm32-devboard"


### PR DESCRIPTION
## Summary

`kct fleet status --boards-dir <single-board-dir>` returned "No boards found" because `_discover_boards()` (and its sibling `_discover_ship_ready()`) assumed `--boards-dir` was always a *parent* of board directories. They iterated the given directory's children looking for a grandchild `output/` — which never matches when the path is itself a board directory (its `output/` is a direct child, not a grandchild).

This PR adds auto-detection: when `--boards-dir` looks like a board directory itself, it is surveyed directly as a single board. The parent-dir invocation is unchanged.

## Changes

- Add `_is_single_board_dir(path)` sentinel in `src/kicad_tools/cli/fleet_cmd.py` — returns True when `path` has a direct `output/` child or a `project.kct` file.
- `_discover_boards()`: early-return branch that surveys the given dir as one board when the sentinel matches (guards on a routed PCB being present).
- `_discover_ship_ready()`: identical early-return branch building a `ShipReadyStatus`.
- `tests/test_fleet_status.py`: new `TestSingleBoardDirDiscovery` class (10 tests) covering the sentinel, single-board-dir vs parent-dir discovery for both functions, the no-routed-PCB guard, the missing-dir path, and an end-to-end CLI status check.

`src/kicad_tools/cli/commands/fleet.py` needed no change — it only forwards `--boards-dir` to `fleet_cmd.main`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `status --boards-dir boards/04-stm32-devboard` returns the board's row | ✅ | Manual CLI: prints `04-stm32-devboard ... YES` (was "No boards found") |
| `status --boards-dir boards/` still enumerates all boards | ✅ | Manual CLI: 8 boards surveyed, unchanged |
| `ship-ready --boards-dir boards/04-stm32-devboard` works | ✅ | Manual CLI: `04-stm32-devboard ... PASS` |
| `status --boards-dir /nonexistent` still "No boards found" | ✅ | Manual CLI + `test_discover_boards_missing_dir` |
| JSON output works for single-board-dir | ✅ | `test_status_cli_single_board_dir` (`--format json`, total==1) |

## Test Plan

- `uv run pytest tests/test_fleet_status.py` — 58 passed (10 new).
- `uv run ruff check` / `ruff format --check` — clean on both files.
- `uv run mypy src/kicad_tools/cli/fleet_cmd.py` — no new errors (pre-existing yaml-stub warning on line 508 only).
- Manual CLI runs against real `boards/` confirming all five acceptance criteria above.

Closes #3938