### PR TITLE
fix(validate): aggregate off-grid pad warnings by component ref

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -1022,9 +1022,14 @@ def run_selected_checks(
     # Build the pad_grid invocation as a thunk so the map below can
     # remain uniform (every value is a zero-arg callable).
     def _pad_grid_check() -> DRCResults:
+        # Issue #3941: collapse a fixed-pitch footprint's per-pad warnings
+        # into one aggregated warning per component ref by default; under
+        # ``--verbose`` (surfaced as ``checker.verbose``) emit the full
+        # per-pad detail instead.
         return checker.check_pad_grid_alignment(
             threshold=pad_grid_threshold,
             auto_derive_threshold=pad_grid_auto_derive,
+            aggregate=not checker.verbose,
         )
 
     # Map of category to check method.  This dict MUST stay a superset

--- a/src/kicad_tools/router/preflight.py
+++ b/src/kicad_tools/router/preflight.py
@@ -109,6 +109,21 @@ class OffGridReport:
         """True when no off-grid pads were found."""
         return not self.off_grid_pads
 
+    def grouped_by_ref(self) -> dict[str, list[PreflightOffGridPad]]:
+        """Group off-grid pads by component reference.
+
+        Returns an insertion-ordered mapping from component ref (e.g.
+        ``"U2"``) to the list of that component's off-grid pads.  Pads with
+        an empty ``ref`` are collected under the ``""`` key.  This is the
+        aggregation primitive used by the DRC layer to collapse a
+        fixed-pitch footprint's 47+ per-pad warnings into a single
+        per-component warning (issue #3941).
+        """
+        groups: dict[str, list[PreflightOffGridPad]] = {}
+        for pad in self.off_grid_pads:
+            groups.setdefault(pad.ref, []).append(pad)
+        return groups
+
     def summary(self) -> str:
         """Human-readable, multi-line summary suitable for CLI output."""
         if self.passed:

--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -787,6 +787,7 @@ class DRCChecker:
         grid_resolution: float = 0.1,
         threshold: float | None = None,
         auto_derive_threshold: bool = False,
+        aggregate: bool = True,
     ) -> DRCResults:
         """Check that every pad aligns to the router grid.
 
@@ -813,12 +814,25 @@ class DRCChecker:
                 pad-offset histogram (issue #3061).  Defaults to
                 ``False`` so the Python API preserves PR #3057 behaviour;
                 ``kct check`` opts in by default.
+            aggregate: When ``True`` (the default), collapse the per-pad
+                warnings into one aggregated ``pad_grid`` warning per
+                component reference (issue #3941).  A fixed-pitch footprint
+                such as an LQFP-48 whose 0.5 mm pitch places all 48 pads off
+                the 0.1 mm router grid thus emits a single warning instead
+                of 47+.  When ``False`` (the ``--verbose`` path), emit one
+                warning per off-grid pad, preserving the full per-pad detail.
 
         Returns:
-            :class:`DRCResults` with one ``pad_grid`` violation (severity
-            error) per off-grid pad.  Empty when all pads align.
+            :class:`DRCResults` with ``pad_grid`` warnings.  When
+            ``aggregate=True`` there is one warning per component reference
+            (with a pad count and representative example); when
+            ``aggregate=False`` there is one warning per off-grid pad.
+            Empty when all pads align.
         """
-        from kicad_tools.router.preflight import check_pad_grid_alignment
+        from kicad_tools.router.preflight import (
+            PreflightOffGridPad,
+            check_pad_grid_alignment,
+        )
 
         results = DRCResults()
 
@@ -841,18 +855,75 @@ class DRCChecker:
 
         results.rules_checked += 1
 
-        for pad in report.off_grid_pads:
-            message = pad.message(report.grid_resolution, report.suggested_grid)
-            ref_label = pad.label
+        def _emit_per_pad(pads: list[PreflightOffGridPad]) -> None:
+            for pad in pads:
+                message = pad.message(report.grid_resolution, report.suggested_grid)
+                ref_label = pad.label
+                results.add(
+                    DRCViolation(
+                        rule_id="pad_grid",
+                        severity="warning",
+                        message=message,
+                        location=(pad.x, pad.y),
+                        actual_value=pad.offset_mm,
+                        required_value=report.threshold,
+                        items=(ref_label,) if ref_label else (),
+                    )
+                )
+
+        if not aggregate:
+            # ``--verbose`` path: preserve the full per-pad detail.
+            _emit_per_pad(report.off_grid_pads)
+            return results
+
+        # Default path: collapse each component's off-grid pads into a
+        # single aggregated warning (issue #3941).  A single-pad group keeps
+        # the original per-pad message so the common case is unchanged.
+        for ref, pads in report.grouped_by_ref().items():
+            if len(pads) == 1:
+                _emit_per_pad(pads)
+                continue
+
+            example = max(pads, key=lambda p: p.offset_mm)
+            max_offset = example.offset_mm
+            fp_name = example.footprint_name
+            count = len(pads)
+
+            if report.suggested_grid is not None:
+                message = (
+                    f"{ref}: {count} pads off-grid by up to "
+                    f"{max_offset:.3f}mm (grid {report.grid_resolution}mm"
+                    + (f", footprint {fp_name}" if fp_name else "")
+                    + ").\n"
+                    f"  Example: pad {example.label} at "
+                    f"({example.x:.3f}, {example.y:.3f}).\n"
+                    f"  Suggested fix: round pad positions OR set finer router "
+                    f"grid ({report.suggested_grid}mm would align all pads).\n"
+                    f"  Use --verbose for per-pad detail."
+                )
+            else:
+                message = (
+                    f"{ref}: {count} pads off-grid by up to "
+                    f"{max_offset:.3f}mm (grid {report.grid_resolution}mm"
+                    + (f", footprint {fp_name}" if fp_name else "")
+                    + ").\n"
+                    f"  Example: pad {example.label} at "
+                    f"({example.x:.3f}, {example.y:.3f}).\n"
+                    f"  Suggested fix: round pad positions to the router grid "
+                    f"(footprint pitch may not align to "
+                    f"{report.grid_resolution}mm).\n"
+                    f"  Use --verbose for per-pad detail."
+                )
+
             results.add(
                 DRCViolation(
                     rule_id="pad_grid",
                     severity="warning",
                     message=message,
-                    location=(pad.x, pad.y),
-                    actual_value=pad.offset_mm,
+                    location=(example.x, example.y),
+                    actual_value=max_offset,
                     required_value=report.threshold,
-                    items=(ref_label,) if ref_label else (),
+                    items=(ref,) if ref else (),
                 )
             )
         return results

--- a/tests/test_pad_grid_preflight.py
+++ b/tests/test_pad_grid_preflight.py
@@ -362,6 +362,181 @@ class TestDRCCheckerIntegration:
 
 
 # ---------------------------------------------------------------------------
+# Issue #3941: aggregate per-pad warnings into one warning per component ref
+
+
+#: Per-axis offset that yields an L2 distance-to-grid of ~0.057 mm, clearly
+#: above the 0.05 mm default tolerance (issue #3042).  The max per-axis
+#: distance to a 0.1 mm grid is 0.05 mm, so a genuinely off-grid pad must be
+#: off on BOTH axes; 0.04 mm on each gives L2 = sqrt(0.04**2 * 2) ~= 0.0566.
+_OFF_GRID_AXIS = 0.04
+
+
+def _lqfp48_pads(axis_offset: float = _OFF_GRID_AXIS) -> list[tuple[str, float, float]]:
+    """Build 48 off-grid pads on a 0.5 mm pitch, each uniformly off-grid.
+
+    Emulates an LQFP-48 whose 0.5 mm lattice, placed at a non-integer
+    origin, leaves every pad the same L2 distance off the 0.1 mm router
+    grid.  ``axis_offset`` is applied on both axes so the L2 deviation
+    exceeds the 0.05 mm default tolerance.
+    """
+    pads: list[tuple[str, float, float]] = []
+    for i in range(48):
+        # 0.5 mm pitch lands on the 0.1 grid; the constant per-axis offset
+        # pushes every pad the same distance off-grid.
+        pads.append((str(i + 1), i * 0.5 + axis_offset, axis_offset))
+    return pads
+
+
+class TestAggregation:
+    """One aggregated ``pad_grid`` warning per component ref (issue #3941)."""
+
+    def _checker(self, tmp_path: Path, footprints: list) -> object:  # type: ignore[type-arg]
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate import DRCChecker
+
+        text = _pcb_with_pads(footprints)
+        pcb_path = _write_pcb(tmp_path, text)
+        pcb = PCB.load(pcb_path)
+        return DRCChecker(pcb, manufacturer="jlcpcb", layers=2)
+
+    def test_lqfp48_collapses_to_one_warning(self, tmp_path: Path) -> None:
+        """48 uniformly off-grid pads emit exactly 1 aggregated warning."""
+        checker = self._checker(
+            tmp_path,
+            [
+                (
+                    "Package_QFP:LQFP-48_7x7mm_P0.5mm",
+                    "U2",
+                    100.0,
+                    100.0,
+                    0.0,
+                    _lqfp48_pads(),
+                )
+            ],
+        )
+        results = checker.check_pad_grid_alignment(grid_resolution=0.1)  # type: ignore[attr-defined]
+        assert results.warning_count == 1
+        v = results.violations[0]
+        assert v.rule_id == "pad_grid"
+        assert v.severity == "warning"
+        assert v.items == ("U2",)
+        # Message carries the count, the footprint context, and a verbose hint.
+        assert "48 pads off-grid" in v.message
+        assert "U2" in v.message
+        assert "LQFP-48" in v.message
+        assert "--verbose" in v.message
+
+    def test_verbose_preserves_per_pad_detail(self, tmp_path: Path) -> None:
+        """``aggregate=False`` restores one warning per off-grid pad."""
+        checker = self._checker(
+            tmp_path,
+            [
+                (
+                    "Package_QFP:LQFP-48_7x7mm_P0.5mm",
+                    "U2",
+                    100.0,
+                    100.0,
+                    0.0,
+                    _lqfp48_pads(),
+                )
+            ],
+        )
+        results = checker.check_pad_grid_alignment(  # type: ignore[attr-defined]
+            grid_resolution=0.1, aggregate=False
+        )
+        assert results.warning_count == 48
+        # Each per-pad message keeps the original single-pad format.
+        assert all("is off-grid by" in v.message for v in results.violations)
+
+    def test_single_off_grid_pad_unchanged(self, tmp_path: Path) -> None:
+        """A component with one off-grid pad keeps the per-pad message."""
+        checker = self._checker(
+            tmp_path,
+            [
+                (
+                    "Test:FP",
+                    "U1",
+                    100.0,
+                    100.0,
+                    0.0,
+                    [("1", 0.0, 0.0), ("2", 1.25, 0.04)],
+                )
+            ],
+        )
+        results = checker.check_pad_grid_alignment(grid_resolution=0.1)  # type: ignore[attr-defined]
+        assert results.warning_count == 1
+        v = results.violations[0]
+        assert "U1.2" in v.message
+        assert "is off-grid by" in v.message
+        # Single-pad group is NOT rendered as an aggregate.
+        assert "pads off-grid" not in v.message
+
+    def test_multi_component_one_warning_per_ref(self, tmp_path: Path) -> None:
+        """Two off-grid footprints emit exactly two aggregated warnings."""
+        checker = self._checker(
+            tmp_path,
+            [
+                (
+                    "Package_QFP:LQFP-48_7x7mm_P0.5mm",
+                    "U1",
+                    100.0,
+                    100.0,
+                    0.0,
+                    [(str(i + 1), i * 0.5 + 0.04, 0.04) for i in range(10)],
+                ),
+                (
+                    "Package_QFP:LQFP-48_7x7mm_P0.5mm",
+                    "U2",
+                    100.0,
+                    120.0,
+                    0.0,
+                    [(str(i + 1), i * 0.5 + 0.04, 0.04) for i in range(5)],
+                ),
+            ],
+        )
+        results = checker.check_pad_grid_alignment(grid_resolution=0.1)  # type: ignore[attr-defined]
+        assert results.warning_count == 2
+        refs = {v.items[0] for v in results.violations}
+        assert refs == {"U1", "U2"}
+        by_ref = {v.items[0]: v for v in results.violations}
+        assert "10 pads off-grid" in by_ref["U1"].message
+        assert "5 pads off-grid" in by_ref["U2"].message
+
+    def test_grouped_by_ref_helper(self, tmp_path: Path) -> None:
+        """``OffGridReport.grouped_by_ref`` buckets pads by component ref."""
+        text = _pcb_with_pads(
+            [
+                (
+                    "Package_QFP:LQFP-48_7x7mm_P0.5mm",
+                    "U1",
+                    100.0,
+                    100.0,
+                    0.0,
+                    [(str(i + 1), i * 0.5 + 0.04, 0.04) for i in range(4)],
+                ),
+                (
+                    "Package_QFP:LQFP-48_7x7mm_P0.5mm",
+                    "U2",
+                    100.0,
+                    120.0,
+                    0.0,
+                    [(str(i + 1), i * 0.5 + 0.04, 0.04) for i in range(3)],
+                ),
+            ]
+        )
+        pcb = _write_pcb(tmp_path, text)
+        report = check_pad_grid_alignment(pcb, grid_resolution=0.1)
+        groups = report.grouped_by_ref()
+        assert set(groups.keys()) == {"U1", "U2"}
+        assert len(groups["U1"]) == 4
+        assert len(groups["U2"]) == 3
+        # Flattening the groups reproduces the full off_grid_pads list.
+        flat = [p for pads in groups.values() for p in pads]
+        assert len(flat) == len(report.off_grid_pads)
+
+
+# ---------------------------------------------------------------------------
 # Issue #3042: stock-library-friendly default tolerance
 
 


### PR DESCRIPTION
## Summary

`DRCChecker.check_pad_grid_alignment` emitted one `pad_grid` `DRCViolation` per off-grid pad. A fixed-pitch footprint such as an LQFP-48 — whose 0.5 mm pitch places every one of its 48 pads off the 0.1 mm router grid — produced 47+ near-identical warnings with the same root cause and a per-pad suggested fix that is not actionable (the pitch is fixed by the silicon package). This PR collapses those into a single aggregated warning per component ref while preserving full per-pad detail under `--verbose`.

## Changes

- `router/preflight.py`: add `OffGridReport.grouped_by_ref()` — insertion-ordered `dict[ref, list[PreflightOffGridPad]]`. Additive, non-breaking; `OffGridReport.off_grid_pads` stays flat (detection unchanged).
- `validate/checker.py`: add `aggregate: bool = True` to `check_pad_grid_alignment`. When aggregating, emit one warning per ref with pad count, worst offset, footprint context, a representative example pad, and a `--verbose` hint. Single-pad components keep the original per-pad message (no regression for the common case). `aggregate=False` restores the per-pad behavior.
- `cli/check_cmd.py`: the `pad_grid` thunk passes `aggregate=not checker.verbose`, so `kct check --verbose` surfaces the full per-pad detail and default output is bounded.
- `tests/test_pad_grid_preflight.py`: new `TestAggregation` class — LQFP-48 collapse to 1 warning, verbose per-pad preservation (48), single-pad no-regression, multi-component (2 refs -> 2 warnings), and `grouped_by_ref` helper.

Aggregation happens at the `DRCResults` layer, so JSON output and any warning-counting tooling also see the bounded per-ref list (Option A from the curation comment).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| LQFP-48 (48 uniformly off-grid pads) emits exactly 1 aggregated warning | ✅ | `test_lqfp48_collapses_to_one_warning` asserts `warning_count == 1`, `items == ("U2",)` |
| Single off-grid pad still emits 1 warning, unchanged message | ✅ | `test_single_off_grid_pad_unchanged` — keeps `U1.2 ... is off-grid by`, no `pads off-grid` aggregate text |
| Multi-component: 2 off-grid footprints -> 2 warnings, one per ref | ✅ | `test_multi_component_one_warning_per_ref` (U1=10 pads, U2=5 pads) |
| `--verbose` preserves per-pad detail | ✅ | `test_verbose_preserves_per_pad_detail` — `aggregate=False` -> 48 per-pad warnings; CLI threads `aggregate=not checker.verbose` |
| No actionable info lost | ✅ | Aggregated message carries count, max offset, footprint, example pad, and finer-grid suggestion |
| `grouped_by_ref()` helper on `OffGridReport` | ✅ | `test_grouped_by_ref_helper` |
| `aggregate=False` restores per-pad behavior | ✅ | Covered by verbose test |

## Test Plan

- `uv run pytest tests/test_pad_grid_preflight.py tests/test_pad_grid_auto_derive.py tests/test_check_cmd_coverage.py tests/test_report_mfr_profile_and_images.py` — 75 passed
- Broader: `pytest -k "pad_grid or check_cmd or checker"` — 163 passed, 5 skipped
- `ruff check` / `ruff format` clean on changed files; `mypy` clean on changed additions (the one `mypy` error at `checker.py:248` is pre-existing on `main`, in the unrelated `FilterEngine.apply` call)

Closes #3941