### PR TITLE
fix(optimize-placement): score current layout in --dry-run, not a random seed

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 3937
-# Branch: feature/issue-3937
+# Issue: 3940
+# Branch: feature/issue-3940
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/docs/placement-scoring.md
+++ b/docs/placement-scoring.md
@@ -1,0 +1,85 @@
+# Placement scoring: four surfaces, three metrics
+
+kicad-tools exposes several commands that report a "score" or "overlap/DRC"
+verdict for a component placement. Historically these produced numbers that
+disagreed on the *same* layout, which made it impossible for a user to tell
+whether a placement was actually good. This document explains what each
+surface measures, why they differ, and which one to trust for which purpose.
+
+> Context: [issue #3940](https://github.com/rjwalters/kicad-tools/issues/3940).
+> The most severe defect — `optimize-placement --dry-run` scoring a freshly
+> generated force-directed *seed* instead of the actual on-disk placement —
+> is fixed. The remaining differences below are **intentional** and are
+> documented here rather than force-unified, because the surfaces serve
+> genuinely different audiences.
+
+## The surfaces at a glance
+
+| Surface | Command | Overlap metric | DRC metric | Layout scored |
+|---------|---------|----------------|------------|---------------|
+| Diagnostics | `kct placement check` | courtyard-expanded polygon (margin, default 0.25 mm) — boolean/severity per pair | real KiCad DRC violations | **actual on-disk placement** |
+| Optimizer objective (dry-run) | `kct optimize-placement --dry-run` | AABB overlap *area* (mm²), no margin | bbox clearance *count* | **actual on-disk placement** (fixed in #3940) |
+| Optimizer objective (search) | `kct optimize-placement` initial/seed eval | AABB overlap *area* (mm²), no margin | bbox clearance *count* | seed / candidate populations during the search |
+| Interactive energy | `kct placement refine` session | none (spacing energy proxy) | none explicit | live positions in the session |
+
+## Why the numbers differ
+
+There are **two independent axes** of difference:
+
+### 1. Different geometry (courtyard vs. raw bounding box)
+
+- `kct placement check`
+  ([`PlacementAnalyzer`](../src/kicad_tools/placement/analyzer.py)) expands
+  each footprint's pad bounding box by `courtyard_margin` before testing for
+  overlap, and reports each conflicting pair as a human-readable
+  warning/error. A pair that merely *touches* (0 mm gap) is flagged because
+  the courtyard margins overlap.
+- The optimizer objective
+  ([`evaluate_placement`](../src/kicad_tools/placement/cost.py)) measures the
+  raw axis-aligned bounding-box overlap **area** in mm², with **no** margin.
+  The same touching pair contributes **zero** overlap.
+
+So for touching footprints the two surfaces disagree *by construction* — up to
+the courtyard margin. This is intentional: the analyzer produces actionable
+per-violation diagnostics, while the optimizer needs a smooth, continuous
+objective (area) that a search algorithm can descend.
+
+### 2. Different layout (the `--dry-run` seeding bug — now fixed)
+
+Before #3940, `optimize-placement --dry-run` did **not** evaluate the layout on
+disk. It called `_generate_seed(...)` (force-directed placement) and scored
+*that*, so the reported `ovl`/`drc` reflected a randomized arrangement, not the
+footprints as placed. The optimizer's own "initial eval" line scored yet
+another arrangement (the best of a random CMA-ES initial population). That is
+why the same board could read `ovl=58.26 drc=23` (dry-run seed),
+`ovl=1.87 drc=5` (random initial population), and `1 warning`
+(`placement check`) all at once.
+
+`--dry-run` now encodes the **current** footprint positions
+(`_read_current_vector`) and scores them, so its overlap/DRC numbers reflect
+the layout on disk and agree with a direct `evaluate_placement()` call on the
+decoded current vector (verified by
+[`tests/placement/test_scoring_parity.py`](../tests/placement/test_scoring_parity.py)).
+
+## Which surface should I trust?
+
+- **"Is my hand placement manufacturable?"** → `kct placement check`. It uses
+  courtyard geometry and real KiCad DRC, and reports *what* to fix.
+- **"Is the optimizer making progress / is this candidate feasible in the
+  optimizer's own terms?"** → `optimize-placement --dry-run` and the optimizer
+  progress output. These share one objective, so their scalars are directly
+  comparable to each other.
+- **`kct placement refine` score** is a *physics-simulation energy proxy*
+  (`wire_length + energy * 0.1`), used only to drive the interactive
+  hill-climb. It is **not** comparable to the other surfaces' overlap/DRC
+  numbers and should not be read as a placement-quality verdict.
+
+## Practical guidance
+
+- A clean `kct placement check` (0 warnings/errors) is the manufacturability
+  gate. `--dry-run` feasibility (`Feasible: True`) is the *optimizer's* gate
+  and uses looser, margin-free geometry — it can report feasible while
+  `placement check` still flags a courtyard nibble.
+- When you optimize from a good hand placement, **seed the optimizer from it**
+  rather than a random population; otherwise CMA-ES searches a layout space
+  disconnected from your placement and can regress wirelength substantially.

--- a/src/kicad_tools/cli/optimize_placement_cmd.py
+++ b/src/kicad_tools/cli/optimize_placement_cmd.py
@@ -241,6 +241,64 @@ def _create_strategy(strategy_name: str) -> PlacementStrategy:
         raise ValueError(f"Unknown strategy: {strategy_name!r}. Available: cmaes")
 
 
+def _read_current_vector(
+    pcb_path: str,
+    components: Sequence[ComponentDef],
+) -> PlacementVector:
+    """Encode the current on-disk footprint placement as a PlacementVector.
+
+    Unlike :func:`_generate_seed`, this reads the actual footprint positions
+    from the ``.kicad_pcb`` file so that ``--dry-run`` scores the *layout as
+    placed* rather than a freshly generated seed (issue #3940).
+
+    Positions are read via ``PCB.load``, which converts footprint coordinates
+    to board-relative space (offset by the detected board origin) -- the same
+    coordinate space :func:`evaluate_placement` and the writer operate in.
+    Rotation is snapped to the nearest 90-degree step and ``side`` is derived
+    from the footprint layer (``B.Cu`` -> back).
+
+    Args:
+        pcb_path: Path to the ``.kicad_pcb`` file.
+        components: Component definitions in the order produced by
+            :func:`_read_board_data`. The returned vector uses this same
+            order so ``decode(vector, components)`` round-trips correctly.
+
+    Returns:
+        A :class:`PlacementVector` encoding the current placement, aligned to
+        ``components`` order. Components absent from the PCB (should not happen
+        for vectors derived from the same file) default to the origin.
+    """
+    from kicad_tools.placement.vector import PlacedComponent, encode
+    from kicad_tools.schema.pcb import PCB as SchemaPCB
+
+    pcb = SchemaPCB.load(pcb_path)
+
+    # Map reference -> (x, y, rotation, side) from the current placement.
+    current: dict[str, tuple[float, float, float, int]] = {}
+    for fp in pcb.footprints:
+        ref = fp.reference
+        if not ref:
+            continue
+        x, y = fp.position
+        side = 1 if fp.layer == "B.Cu" else 0
+        current[ref] = (x, y, fp.rotation, side)
+
+    placed: list[PlacedComponent] = []
+    for comp in components:
+        x, y, rot, side = current.get(comp.reference, (0.0, 0.0, 0.0, 0))
+        placed.append(
+            PlacedComponent(
+                reference=comp.reference,
+                x=x,
+                y=y,
+                rotation=rot,
+                side=side,
+            )
+        )
+
+    return encode(placed)
+
+
 def _generate_seed(
     seed_method: str,
     components: Sequence[ComponentDef],
@@ -629,16 +687,18 @@ def run_optimize_placement(
     # Compute bounds
     placement_bounds = bounds(board_outline, components)
 
-    # --dry-run: just evaluate the current placement
+    # --dry-run: evaluate the CURRENT on-disk placement (issue #3940).
+    # Previously this generated a fresh force-directed seed and scored that,
+    # so the reported ovl/drc reflected a randomized layout rather than the
+    # footprints as placed -- making the check meaningless. We now encode the
+    # actual positions read from the .kicad_pcb file.
     if dry_run:
         if not quiet:
             print("\n[dry-run] Evaluating current placement...")
 
-        # Generate a seed to evaluate (since we don't have current positions
-        # encoded as a vector, use force-directed as a proxy)
-        seed_vector = _generate_seed(seed_method, components, nets, board_outline)
+        current_vector = _read_current_vector(pcb_path, components)
         score = _evaluate(
-            seed_vector,
+            current_vector,
             components,
             nets,
             rules,
@@ -650,6 +710,17 @@ def run_optimize_placement(
             _print_score("Current", score)
             print(f"\n  Feasible: {score.is_feasible}")
             print(f"  Total score: {score.total:.4f}")
+            # The optimizer objective (bounding-box overlap area in mm^2 and a
+            # bbox-clearance DRC count) is a distinct metric from
+            # `kct placement check`, which uses courtyard-expanded polygons and
+            # real KiCad DRC. The two surfaces can disagree by the courtyard
+            # margin for touching footprints; this is intentional. See
+            # docs/placement-scoring.md for the full comparison.
+            print(
+                "\n  Note: this is the optimizer objective (bbox overlap area / "
+                "bbox-clearance DRC), NOT the `kct placement check` metric "
+                "(courtyard polygons / KiCad DRC). See docs/placement-scoring.md."
+            )
         return 0
 
     # Create strategy

--- a/src/kicad_tools/optim/session.py
+++ b/src/kicad_tools/optim/session.py
@@ -271,7 +271,24 @@ class PlacementSession:
         return SessionState(positions=positions, violations=violations, score=score)
 
     def _compute_score(self) -> float:
-        """Compute placement score (lower is better)."""
+        """Compute the interactive-session placement score (lower is better).
+
+        .. note::
+            This is a **physics-simulation energy proxy**, *not* a
+            placement-quality score comparable to the other scoring surfaces.
+            It combines the force-directed optimizer's total wire length with
+            a spacing-energy term (``wire_length + energy * 0.1``) purely to
+            drive the interactive ``kct placement refine`` hill-climb toward
+            shorter, less-congested layouts.
+
+            It deliberately does **not** delegate to
+            :func:`kicad_tools.placement.cost.evaluate_placement` (the
+            optimizer objective used by ``optimize-placement``) nor to the
+            courtyard-based ``kct placement check`` metric. The three surfaces
+            measure different things and their scalar outputs are not
+            interchangeable -- see ``docs/placement-scoring.md`` for the full
+            comparison (issue #3940).
+        """
         # Use total wire length as primary metric
         wire_length = self._optimizer.total_wire_length()
         # Add energy as secondary (captures component spacing)

--- a/src/kicad_tools/placement/analyzer.py
+++ b/src/kicad_tools/placement/analyzer.py
@@ -50,6 +50,19 @@ class PlacementAnalyzer:
         # Or with custom rules:
         rules = DesignRules(min_pad_clearance=0.15)
         conflicts = analyzer.find_conflicts("board.kicad_pcb", rules=rules)
+
+    .. note::
+        This analyzer powers ``kct placement check``. Its overlap metric
+        expands each footprint's pad bounding box by ``courtyard_margin``
+        (default 0.25 mm) and yields per-violation, human-readable
+        diagnostics. It is a **different metric** from the optimizer
+        objective in :func:`kicad_tools.placement.cost.evaluate_placement`,
+        which uses raw axis-aligned bounding-box overlap area with no
+        courtyard margin. The courtyard expansion means this check can flag
+        a "touching" pair that the optimizer objective scores as zero
+        overlap. Keeping the two separate is intentional (actionable
+        diagnostics vs. a smooth optimizer search space); see
+        ``docs/placement-scoring.md`` for the full comparison (issue #3940).
     """
 
     def __init__(self, verbose: bool = False):

--- a/src/kicad_tools/placement/cost.py
+++ b/src/kicad_tools/placement/cost.py
@@ -538,6 +538,20 @@ def evaluate_placement(
     This is a pure function with no side effects, safe to call from
     multiple threads for parallel evaluation.
 
+    .. note::
+        This is the **optimizer objective**. Overlap is measured as raw
+        axis-aligned bounding-box overlap *area* (mm^2, see
+        :func:`compute_overlap`) and DRC as a bbox-clearance *count* (see
+        :func:`compute_drc_violations`) -- with **no courtyard margin** and
+        **no KiCad-layer awareness**. This intentionally differs from
+        ``kct placement check``
+        (:class:`kicad_tools.placement.analyzer.PlacementAnalyzer`), which
+        expands each footprint by a ``courtyard_margin`` and reports real
+        KiCad DRC violations. The two metrics serve different audiences
+        (optimizer search vs. user-facing diagnostics) and can disagree by
+        the courtyard margin for touching footprints. See
+        ``docs/placement-scoring.md`` for the full comparison (issue #3940).
+
     Args:
         placements: Current component positions.
         nets: Net connectivity information for wirelength estimation.

--- a/tests/placement/test_scoring_parity.py
+++ b/tests/placement/test_scoring_parity.py
@@ -1,0 +1,167 @@
+"""Regression tests for placement scoring parity across surfaces (issue #3940).
+
+The three optimizer-facing scoring surfaces (`optimize-placement --dry-run`,
+the optimizer's internal `_evaluate`, and a direct `evaluate_placement()` call)
+must agree when scoring the *same* layout. The original defect was that
+`--dry-run` scored a freshly generated force-directed seed instead of the
+actual on-disk placement, so its ovl/drc were meaningless as a check.
+
+These tests load the committed board-04 (STM32 devboard) layout and assert:
+
+* `--dry-run` scores the layout as placed (feasible, ovl=0), NOT a random seed.
+* `--dry-run` output matches a direct `evaluate_placement()` call on the
+  decoded current placement vector within a tight tolerance.
+* A board whose moveable footprints are all cleanly placed reports ovl=0/drc=0
+  under `--dry-run`, matching the intent of `kct placement check`.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.optimize_placement_cmd import (
+    _build_footprint_sizes,
+    _evaluate,
+    _parse_weights,
+    _read_board_data,
+    _read_current_vector,
+    run_optimize_placement,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+# Board-04 committed layout: a clean, feasible hand placement used across the
+# fleet-parity suite. Repo-relative from tests/placement/ -> repo root.
+BOARD_04 = (
+    Path(__file__).resolve().parents[2]
+    / "boards"
+    / "04-stm32-devboard"
+    / "output"
+    / "stm32_devboard.kicad_pcb"
+)
+
+
+@pytest.fixture
+def board_04_path() -> Path:
+    if not BOARD_04.exists():
+        pytest.skip(f"board-04 fixture not found: {BOARD_04}")
+    return BOARD_04
+
+
+def _parse_dry_run_score(output: str) -> tuple[float, float, bool]:
+    """Extract (overlap, drc, feasible) from `--dry-run` stdout.
+
+    The score line looks like::
+
+        Current: 493.8000 (feasible) [wl=351.00 ovl=0.00 bnd=0.00 drc=0 area=1428.00]
+    """
+    m = re.search(r"ovl=([\d.eE+-]+)\s+bnd=[\d.eE+-]+\s+drc=([\d.eE+-]+)", output)
+    assert m is not None, f"could not parse ovl/drc from dry-run output:\n{output}"
+    ovl = float(m.group(1))
+    drc = float(m.group(2))
+    feasible = "(feasible)" in output
+    return ovl, drc, feasible
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_scores_current_layout_not_a_seed(board_04_path, capsys):
+    """--dry-run must evaluate the on-disk placement (feasible), not a seed.
+
+    Board-04's committed layout is a clean hand placement. Under the old
+    (buggy) behaviour, --dry-run scored a force-directed seed and reported
+    a wildly infeasible overlap/DRC. It must now report the actual layout,
+    which is feasible with zero bbox overlap.
+    """
+    result = run_optimize_placement(str(board_04_path), dry_run=True)
+    assert result == 0
+
+    out = capsys.readouterr().out
+    ovl, drc, feasible = _parse_dry_run_score(out)
+
+    assert feasible, f"expected feasible on-disk layout, got:\n{out}"
+    assert ovl == pytest.approx(0.0, abs=0.5)
+    assert drc == pytest.approx(0.0, abs=1)
+
+
+def test_dry_run_matches_direct_evaluate_placement(board_04_path, capsys):
+    """--dry-run scoring agrees with a direct evaluate_placement() call.
+
+    Both paths must score the same decoded current vector, so their overlap
+    and DRC values agree within the documented tolerance (±0.5 overlap,
+    ±1 drc).
+    """
+    # --- Direct path: decode current positions and evaluate ---
+    components, nets, board_outline, rules, _origin = _read_board_data(str(board_04_path))
+    footprint_sizes = _build_footprint_sizes(components)
+    cost_config = _parse_weights(None)
+
+    current_vector = _read_current_vector(str(board_04_path), components)
+    direct_score = _evaluate(
+        current_vector,
+        components,
+        nets,
+        rules,
+        board_outline,
+        cost_config,
+        footprint_sizes,
+    )
+
+    # --- CLI path: run --dry-run and parse its printed score ---
+    result = run_optimize_placement(str(board_04_path), dry_run=True)
+    assert result == 0
+    out = capsys.readouterr().out
+    cli_ovl, cli_drc, cli_feasible = _parse_dry_run_score(out)
+
+    assert cli_ovl == pytest.approx(direct_score.breakdown.overlap, abs=0.5)
+    assert cli_drc == pytest.approx(direct_score.breakdown.drc, abs=1)
+    assert cli_feasible == direct_score.is_feasible
+
+
+def test_read_current_vector_round_trips_positions(board_04_path):
+    """The encoded current vector decodes back to the on-disk positions.
+
+    This guards the core of the fix: _read_current_vector must faithfully
+    capture the footprint positions (board-relative) so that decode() yields
+    the same coordinates the writer/analyzer operate on.
+    """
+    from kicad_tools.placement.vector import decode
+    from kicad_tools.schema.pcb import PCB as SchemaPCB
+
+    components, _nets, _board, _rules, _origin = _read_board_data(str(board_04_path))
+    vector = _read_current_vector(str(board_04_path), components)
+    placed = decode(vector, components)
+
+    # Reference positions straight from the PCB (board-relative).
+    pcb = SchemaPCB.load(str(board_04_path))
+    ref_pos = {fp.reference: fp.position for fp in pcb.footprints if fp.reference}
+
+    assert len(placed) == len(components)
+    for p in placed:
+        assert p.reference in ref_pos
+        ex, ey = ref_pos[p.reference]
+        assert p.x == pytest.approx(ex, abs=1e-6)
+        assert p.y == pytest.approx(ey, abs=1e-6)
+
+
+def test_dry_run_deterministic(board_04_path, capsys):
+    """--dry-run on a fixed layout is deterministic (no random seed leak).
+
+    Because it now scores the on-disk layout rather than a randomly seeded
+    one, repeated runs must produce identical overlap/DRC numbers.
+    """
+    run_optimize_placement(str(board_04_path), dry_run=True)
+    first = _parse_dry_run_score(capsys.readouterr().out)
+
+    run_optimize_placement(str(board_04_path), dry_run=True)
+    second = _parse_dry_run_score(capsys.readouterr().out)
+
+    assert first == second


### PR DESCRIPTION
## Summary

`kct optimize-placement --dry-run` was scoring a freshly generated
force-directed **seed** instead of the actual on-disk placement, so its
`ovl`/`drc` verdict was meaningless as a check (issue #3940 observed
`ovl=58.26 drc=23` from `--dry-run` on the same board-04 layout that
`kct placement check` reported clean-with-1-warning). This PR fixes the
seeding bug and documents the intentional differences between the four
scoring surfaces.

## Changes

- **`--dry-run` now scores the current layout.** New `_read_current_vector()`
  reads the footprint positions from the `.kicad_pcb` file (board-relative,
  side from `B.Cu`/`F.Cu`, rotation snapped to 90°) and encodes them into a
  `PlacementVector`, which is scored instead of a generated seed. Adds an
  output note that this is the optimizer objective, not the `placement check`
  metric.
- **Documented the intentional metric differences** (docstrings +
  `docs/placement-scoring.md`):
  - `evaluate_placement()` (cost.py): raw AABB overlap area, no courtyard margin.
  - `PlacementAnalyzer` (analyzer.py): courtyard-expanded polygons + KiCad DRC.
  - `PlacementSession._compute_score()` (session.py): annotated as a
    physics-simulation energy proxy, NOT a placement-quality score.
- **New regression suite** `tests/placement/test_scoring_parity.py`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `--dry-run` evaluates the actual current layout, not a seed | ✅ | Manual run on board-04 now reports `ovl=0.00 drc=0 (feasible)`; `test_dry_run_scores_current_layout_not_a_seed` |
| `--dry-run` prints a documented note explaining the metric difference | ✅ | Note added to output pointing at `docs/placement-scoring.md` |
| Surfaces produce consistent numbers OR each documents its metric | ✅ | `docs/placement-scoring.md` comparison table + per-module docstrings |
| `PlacementSession._compute_score()` unified or annotated | ✅ | Docstring now marks it a physics-simulation energy proxy |
| Regression test asserts `--dry-run` == `evaluate_placement()` within tolerance | ✅ | `test_dry_run_matches_direct_evaluate_placement` (±0.5 ovl, ±1 drc) |

## Test Plan

- New suite: `uv run pytest tests/placement/test_scoring_parity.py` — 4 passed.
- Affected suites: `tests/placement/`, `tests/test_optimize_placement_cmd.py`,
  `tests/test_placement_cost.py`, `tests/test_mcp_optimize_placement.py` — all pass.
- Broad `-k "session or placement or optimize or analyzer or cost or dry_run"`
  sweep — 2235 passed, 30 skipped.
- `ruff check` / `ruff format --check` clean on all changed files.
- mypy: the 7 errors reported on `optimize_placement_cmd.py` are pre-existing
  on `origin/main` (verified against the base file) and untouched by this change;
  the new `_read_current_vector` adds no new mypy errors.

Manual cross-check on `boards/04-stm32-devboard/output/stm32_devboard.kicad_pcb`:
- `--dry-run`: `Current: ... (feasible) [... ovl=0.00 ... drc=0 ...]`
- `placement check`: 1 warning (U2/C11 courtyard overlap 0.050mm) — the
  documented courtyard-vs-bbox difference, both scoring the same layout.

Closes #3940