### PR TITLE
fix(schematic): emit companion sym-lib-table for synthesized power symbols

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 3940
-# Branch: feature/issue-3940
+# Issue: 3943
+# Branch: feature/issue-3943
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/src/kicad_tools/schematic/models/io_mixin.py
+++ b/src/kicad_tools/schematic/models/io_mixin.py
@@ -6,6 +6,7 @@ Provides file loading and saving capabilities for Schematic class.
 
 from __future__ import annotations
 
+import copy
 import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -464,9 +465,147 @@ class SchematicIOMixin:
         path.write_text(content)
         # Store the path for later use (e.g., run_erc)
         self._saved_path = path
+        # Emit the companion sym-lib-table + .kicad_sym so kicad-cli's ERC
+        # nickname-presence check resolves ``kicad_tools_pwr`` (issue #3943).
+        self._write_sym_lib_table(path)
         _log_info(
             f"Wrote schematic to {path} ({len(self.symbols)} symbols, {len(self.wires)} wires)"
         )
+
+    # KiCad's sym-lib-table version tag (KiCad 7+ uses version 7).
+    _SYM_LIB_TABLE_VERSION = 7
+
+    def _write_sym_lib_table(self, sch_path: Path) -> None:
+        """Emit sidecar files that satisfy ERC's library-nickname check.
+
+        The generator embeds synthesized ``kicad_tools_pwr:{net}`` power
+        symbols directly in the schematic's ``lib_symbols`` block, which is
+        authoritative for *loading* the file. However, ``kicad-cli sch erc``
+        (and the KiCad GUI's ERC runner) separately validate that every
+        library *nickname* referenced by a placed symbol resolves through
+        the project's ``sym-lib-table``. Generated schematics never write
+        that table, so ERC logs a spurious "does not include the symbol
+        library 'kicad_tools_pwr'" warning even though the definitions are
+        embedded (issue #3943).
+
+        This writes two sidecars next to the schematic:
+
+        * ``kicad_tools_pwr.kicad_sym`` — a real symbol library holding the
+          synthesized definitions (names stripped of the nickname prefix),
+          so KiCad can locate the nickname's backing file.
+        * ``sym-lib-table`` — registers the ``kicad_tools_pwr`` nickname,
+          pointing at the ``.kicad_sym`` above via ``${KIPRJMOD}``.
+
+        Both are no-ops when the schematic uses no synthesized power symbols
+        (``add_pwr_symbol``), so plain schematics gain no spurious sidecar.
+
+        A pre-existing ``sym-lib-table`` (e.g. a user's own project table)
+        is **merged**, never clobbered: the ``kicad_tools_pwr`` entry is
+        appended only when absent. If the existing table cannot be parsed,
+        it is left untouched and a warning is logged.
+
+        Note: KiCad only consults the local ``sym-lib-table`` when a
+        companion ``.kicad_pro`` project file exists in the same directory
+        (which board generators emit). When no project file is present the
+        sidecars are harmless — they simply aren't read.
+        """
+        if not self._synthesized_pwr_defs:
+            return
+
+        directory = sch_path.parent
+
+        try:
+            self._write_synth_pwr_symbol_lib(directory / "kicad_tools_pwr.kicad_sym")
+            self._merge_sym_lib_table_entry(directory / "sym-lib-table")
+        except OSError as exc:
+            # Read-only directory or similar — degrade to a warning rather
+            # than failing the whole write() after the .kicad_sch landed.
+            _log_warning(
+                f"Could not write sym-lib-table sidecar for synthesized power "
+                f"symbols next to {sch_path.name}: {exc}. ERC may warn about a "
+                f"missing 'kicad_tools_pwr' library until the sidecar exists."
+            )
+
+    def _write_synth_pwr_symbol_lib(self, path: Path) -> None:
+        """Write the ``kicad_tools_pwr.kicad_sym`` backing library.
+
+        Each synthesized def is emitted with its outer symbol name reduced
+        from ``kicad_tools_pwr:{net}`` to just ``{net}`` — inside a
+        ``.kicad_sym`` file the nickname is supplied by the table entry, so
+        the symbol name must be bare (matching how stock KiCad libraries
+        store their symbols).
+        """
+        lib = SExp.list(
+            "kicad_symbol_lib",
+            SExp.list("version", 20231120),
+            SExp.list("generator", "kicad-tools"),
+        )
+        prefix = f"{self._PWR_SYNTH_LIB_PREFIX}:"
+        for net_name, sym_node in self._synthesized_pwr_defs.items():
+            bare = copy.deepcopy(sym_node)
+            # The def's first atom is the prefixed lib_id
+            # (``kicad_tools_pwr:{net}``); strip the nickname prefix.
+            first = bare.get_first_atom()
+            if isinstance(first, str) and first.startswith(prefix):
+                bare.set_atom(0, net_name)
+            lib.append(bare)
+        path.write_text(lib.to_string() + "\n")
+
+    def _merge_sym_lib_table_entry(self, path: Path) -> None:
+        """Ensure ``sym-lib-table`` registers the ``kicad_tools_pwr`` nickname.
+
+        Creates the table if absent; otherwise appends the entry only when
+        the nickname is not already present, preserving any user entries.
+        """
+        from kicad_tools.sexp import parse_string
+
+        nickname = self._PWR_SYNTH_LIB_PREFIX
+        entry = SExp.list(
+            "lib",
+            SExp.list("name", SExp.quoted_atom(nickname)),
+            SExp.list("type", SExp.quoted_atom("KiCad")),
+            SExp.list(
+                "uri",
+                SExp.quoted_atom("${KIPRJMOD}/kicad_tools_pwr.kicad_sym"),
+            ),
+            SExp.list("options", SExp.quoted_atom("")),
+            SExp.list(
+                "descr",
+                SExp.quoted_atom("kicad-tools synthesized power symbols"),
+            ),
+        )
+
+        if path.exists():
+            try:
+                table = parse_string(path.read_text())
+            except Exception as exc:
+                _log_warning(
+                    f"Existing sym-lib-table at {path} could not be parsed "
+                    f"({exc}); leaving it untouched. ERC may warn about the "
+                    f"'kicad_tools_pwr' library until the entry is added."
+                )
+                return
+            if table.name != "sym_lib_table":
+                _log_warning(
+                    f"Existing sym-lib-table at {path} is not a sym_lib_table "
+                    f"node; leaving it untouched."
+                )
+                return
+            # Skip if the nickname is already registered.
+            for lib_node in table.find_all("lib"):
+                name_node = lib_node.get("name")
+                if name_node and str(name_node.get_first_atom() or "") == nickname:
+                    return
+            table.append(entry)
+            path.write_text(table.to_string() + "\n")
+            return
+
+        table = SExp.list(
+            "sym_lib_table",
+            SExp.list("version", self._SYM_LIB_TABLE_VERSION),
+            entry,
+        )
+        path.write_text(table.to_string() + "\n")
 
     def _warn_if_content_overflows(self) -> None:
         """Log a warning when content exceeds the declared sheet bounds."""

--- a/src/kicad_tools/schematic/models/io_mixin.py
+++ b/src/kicad_tools/schematic/models/io_mixin.py
@@ -32,6 +32,13 @@ if TYPE_CHECKING:
 class SchematicIOMixin:
     """Mixin providing I/O operations for Schematic class."""
 
+    if TYPE_CHECKING:
+        # Attributes provided by the concrete ``Schematic`` class (via
+        # ``SchematicElementsMixin`` and ``Schematic.__init__``).  Declared
+        # here so mypy can see them when this mixin references them.
+        _PWR_SYNTH_LIB_PREFIX: str
+        _synthesized_pwr_defs: dict[str, SExp]
+
     @classmethod
     def load(cls, path: str | Path) -> Schematic:
         """Load a schematic from a .kicad_sch file.

--- a/tests/test_pwr_symbol_net_match.py
+++ b/tests/test_pwr_symbol_net_match.py
@@ -252,6 +252,119 @@ class TestSnapping:
 
 
 # ---------------------------------------------------------------------------
+# sym-lib-table sidecar (issue #3943)
+# ---------------------------------------------------------------------------
+
+
+class TestSymLibTableSidecar:
+    """``write()`` emits a companion sym-lib-table for synthesized power syms.
+
+    ERC's library-nickname check validates ``kicad_tools_pwr`` against the
+    project's ``sym-lib-table`` (separate from the embedded ``lib_symbols``
+    block). Generated schematics never wrote that table, producing a
+    spurious "missing library" ERC warning (issue #3943). ``write()`` now
+    emits the table plus a backing ``.kicad_sym`` when synthesized power
+    symbols are present.
+    """
+
+    def test_sidecars_written_when_synth_pwr_present(self, tmp_path: Path):
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sch.add_pwr_symbol("VMOTOR", x=100, y=100)
+        p = tmp_path / "t.kicad_sch"
+        sch.write(p)
+
+        table = tmp_path / "sym-lib-table"
+        lib = tmp_path / "kicad_tools_pwr.kicad_sym"
+        assert table.exists(), "sym-lib-table sidecar should be written"
+        assert lib.exists(), "kicad_tools_pwr.kicad_sym backing library missing"
+
+    def test_no_sidecar_without_synth_pwr(self, tmp_path: Path):
+        """A schematic with no ``add_pwr_symbol`` gains no sidecar."""
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sch.add_symbol("Device:R", 100, 100, "R1", "10k")
+        p = tmp_path / "t.kicad_sch"
+        sch.write(p)
+
+        assert not (tmp_path / "sym-lib-table").exists()
+        assert not (tmp_path / "kicad_tools_pwr.kicad_sym").exists()
+
+    def test_stock_power_symbol_does_not_trigger_sidecar(self, tmp_path: Path):
+        """Only synthesized (``add_pwr_symbol``) symbols trigger the sidecar."""
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sch.add_power("power:+5V", x=100, y=100)
+        p = tmp_path / "t.kicad_sch"
+        sch.write(p)
+
+        assert not (tmp_path / "sym-lib-table").exists()
+
+    def test_table_registers_nickname(self, tmp_path: Path):
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sch.add_pwr_symbol("VMOTOR", x=100, y=100)
+        p = tmp_path / "t.kicad_sch"
+        sch.write(p)
+
+        text = (tmp_path / "sym-lib-table").read_text()
+        assert "sym_lib_table" in text
+        assert "kicad_tools_pwr" in text
+        assert "${KIPRJMOD}/kicad_tools_pwr.kicad_sym" in text
+
+    def test_backing_lib_uses_bare_symbol_name(self, tmp_path: Path):
+        """Inside the .kicad_sym the symbol name drops the nickname prefix."""
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sch.add_pwr_symbol("VMOTOR", x=100, y=100)
+        p = tmp_path / "t.kicad_sch"
+        sch.write(p)
+
+        text = (tmp_path / "kicad_tools_pwr.kicad_sym").read_text()
+        assert '(symbol "VMOTOR"' in text
+        assert "kicad_tools_pwr:VMOTOR" not in text
+        # The published net value is preserved.
+        assert '(property "Value" "VMOTOR"' in text
+
+    def test_embedded_lib_symbols_block_unchanged(self, tmp_path: Path):
+        """The .kicad_sch embedded block keeps the prefixed lib_id (unchanged)."""
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sch.add_pwr_symbol("VMOTOR", x=100, y=100)
+        p = tmp_path / "t.kicad_sch"
+        sch.write(p)
+
+        sch_text = p.read_text()
+        # The schematic still embeds the prefixed symbol definition.
+        assert '(symbol "kicad_tools_pwr:VMOTOR"' in sch_text
+
+    def test_existing_user_table_is_merged_not_clobbered(self, tmp_path: Path):
+        """A pre-existing sym-lib-table entry is preserved; ours is appended."""
+        table = tmp_path / "sym-lib-table"
+        table.write_text(
+            "(sym_lib_table\n"
+            "  (version 7)\n"
+            '  (lib (name "MyLib")(type "KiCad")'
+            '(uri "${KIPRJMOD}/MyLib.kicad_sym")(options "")(descr ""))\n'
+            ")\n"
+        )
+
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sch.add_pwr_symbol("VMOTOR", x=100, y=100)
+        p = tmp_path / "t.kicad_sch"
+        sch.write(p)
+
+        text = table.read_text()
+        assert "MyLib" in text, "user's existing entry must be preserved"
+        assert "kicad_tools_pwr" in text, "our nickname must be appended"
+
+    def test_idempotent_no_duplicate_entry(self, tmp_path: Path):
+        """Writing twice does not duplicate the kicad_tools_pwr entry."""
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sch.add_pwr_symbol("VMOTOR", x=100, y=100)
+        p = tmp_path / "t.kicad_sch"
+        sch.write(p)
+        sch.write(p)
+
+        text = (tmp_path / "sym-lib-table").read_text()
+        assert text.count('(name "kicad_tools_pwr")') == 1
+
+
+# ---------------------------------------------------------------------------
 # Integration: kicad-cli loads the synthesized schematic
 # ---------------------------------------------------------------------------
 
@@ -350,4 +463,65 @@ class TestKicadCliIntegration:
         assert total == 0, (
             f"Expected zero ERC errors with PWR_FLAG driving the synthesized "
             f"VMOTOR symbol; got {total}. Report: {erc}"
+        )
+
+    def _run_erc_all(self, sch_path: Path, out_dir: Path) -> dict:
+        """Run ``kicad-cli sch erc --severity-all`` and return parsed JSON.
+
+        ``--severity-all`` is required because the missing-library nit is a
+        *warning*, not an error, so ``--severity-error`` would hide it.
+        """
+        import json
+        import subprocess
+
+        cli = _find_kicad_cli()
+        report = out_dir / "erc_all.json"
+        subprocess.run(
+            [
+                cli,
+                "sch",
+                "erc",
+                str(sch_path),
+                "-o",
+                str(report),
+                "--format",
+                "json",
+                "--severity-all",
+            ],
+            capture_output=True,
+            check=False,
+        )
+        return json.loads(report.read_text())
+
+    def test_no_missing_library_warning_for_synth_pwr(self, tmp_path: Path):
+        """ERC emits no 'missing kicad_tools_pwr library' warning (issue #3943).
+
+        ``write()`` emits a companion ``sym-lib-table`` + ``.kicad_sym`` so
+        ERC's library-nickname check resolves ``kicad_tools_pwr``. KiCad only
+        consults the local table when a matching ``.kicad_pro`` exists, so we
+        drop a minimal project file next to the schematic (board generators
+        always emit one).
+        """
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sch.add_wire((100, 100), (100, 110), warn_on_collision=False)
+        sch.add_wire((100, 110), (200, 110), warn_on_collision=False)
+        sch.add_pwr_symbol("VMOTOR", x=100, y=100)
+        sch.add_label("VMOTOR", x=150, y=110, validate_connection=False)
+        sch.add_pwr_flag(100, 110)
+
+        p = tmp_path / "t.kicad_sch"
+        sch.write(p)
+        # Minimal companion project so kicad-cli reads the local sym-lib-table.
+        (tmp_path / "t.kicad_pro").write_text('{"meta": {"version": 1}}\n')
+
+        erc = self._run_erc_all(p, tmp_path)
+
+        offending = [
+            v
+            for s in erc.get("sheets", [])
+            for v in s.get("violations", [])
+            if "kicad_tools_pwr" in v.get("description", "")
+        ]
+        assert not offending, (
+            f"Expected no ERC 'missing library' warning naming kicad_tools_pwr; got {offending!r}"
         )


### PR DESCRIPTION
## Summary

Every ERC run (`kicad-cli sch erc`) on a kicad-tools-generated schematic warned:
`The current configuration does not include the symbol library 'kicad_tools_pwr'`.
The generator correctly embeds synthesized `kicad_tools_pwr:{net}` power symbols
in the schematic's `lib_symbols` block (authoritative for *loading*), but ERC
separately validates library **nicknames** against the project's `sym-lib-table`
sidecar — which generated schematics never wrote. The result was chronic false-
positive noise that would mask a real library problem (issue #3943).

`Schematic.write()` now emits the companion sidecars whenever synthesized power
symbols are present.

## Changes

- `src/kicad_tools/schematic/models/io_mixin.py`
  - `write()` calls a new `_write_sym_lib_table()` after writing the `.kicad_sch`.
  - `_write_synth_pwr_symbol_lib()` writes `kicad_tools_pwr.kicad_sym` containing
    the synthesized definitions, with the `kicad_tools_pwr:` nickname prefix
    stripped from each symbol name (bare names, as stock KiCad libs store them).
  - `_merge_sym_lib_table_entry()` writes/merges a `sym-lib-table` registering the
    `kicad_tools_pwr` nickname (`${KIPRJMOD}/kicad_tools_pwr.kicad_sym`). An existing
    table is merged (entry appended only if absent), never clobbered; unparseable
    tables are left untouched with a warning; a read-only directory degrades to a
    warning rather than raising after the `.kicad_sch` already landed.
- `tests/test_pwr_symbol_net_match.py`
  - New `TestSymLibTableSidecar` unit class (9 assertions: sidecars present/absent,
    nickname registration, bare symbol names, embedded block unchanged, user-table
    merge, idempotency).
  - New `TestKicadCliIntegration::test_no_missing_library_warning_for_synth_pwr`
    (kicad-cli, `--severity-all`) asserting zero `kicad_tools_pwr` violations.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Generated schematic passes ERC with zero `kicad_tools_pwr` "missing library" violations | ✅ | Reproduced the warning on board-01 output (1 violation), then confirmed 0 violations with sidecars via `kicad-cli sch erc --severity-all`; new integration test asserts it |
| Embedded `lib_symbols` block unchanged (self-contained, round-trip-stable) | ✅ | `test_embedded_lib_symbols_block_unchanged` + existing `TestSynthesizedLibSymbolRoundTrip` pass unchanged |
| No `sym-lib-table` sidecar when no synthesized power symbols | ✅ | `test_no_sidecar_without_synth_pwr`, `test_stock_power_symbol_does_not_trigger_sidecar` |
| Existing `TestKicadCliIntegration` tests still pass | ✅ | All 19 original tests green |
| New test asserts zero `kicad_tools_pwr` ERC violations | ✅ | `test_no_missing_library_warning_for_synth_pwr` (not skipped locally) |

## Test Plan

- `uv run pytest tests/test_pwr_symbol_net_match.py` — 28 passed (19 original + 9 new).
- `uv run pytest tests/test_schematic_run_erc.py` — passes.
- Manual: reproduced the exact warning on `boards/01-voltage-divider/output/voltage_divider.kicad_sch`,
  then verified sidecars (`sym-lib-table` + `kicad_tools_pwr.kicad_sym` + companion `.kicad_pro`)
  clear it to 0 violations under `kicad-cli sch erc --severity-all`.
- `ruff check` / `ruff format` clean on changed files.

**Note (empirical):** the sym-lib-table alone is insufficient — KiCad only consults
the local table when a matching `.kicad_pro` exists (board generators always emit one)
AND the nickname's backing `.kicad_sym` file exists on disk. This PR writes both sidecars;
the project file is out of scope for `write()` (generators own it).

**Out of scope:** the 11 `UserWarning` T-connection warnings from `wiring_mixin.py`
are a separate concern (per curator guidance) and are untouched here.

Closes #3943