### PR TITLE
fix(route): suppress failure-flavored diagnostics on fully-routed boards

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 3940
-# Branch: feature/issue-3940
+# Issue: 3942
+# Branch: feature/issue-3942
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -460,6 +460,47 @@ def _per_attempt_budgeted_timeout(args, attempt_index: int, max_attempts: int) -
     return min(float(timeout), remaining, per_attempt_slice)
 
 
+def _routable_multi_pad_nets(router: "Autorouter") -> list[int]:
+    """Return the multi-pad net IDs the router will actually route.
+
+    Issue #3942 (Bug B): the routed/total summary denominator must count
+    only the nets the router was asked to route.  A net that carries 2+
+    pads but is *pour-served* -- ``router._is_pour_net(net_id)`` is True
+    because its net class declares ``is_pour_net`` and it has a copper
+    zone -- is stripped from the routing order by
+    :meth:`Autorouter._filter_pour_nets` and is therefore never counted
+    in ``stats['nets_routed']``.
+
+    Historically these nets were excluded from the denominator only when
+    the CLI's ``skip_nets`` list caught them (their pads get rewritten to
+    net 0 at load time, so ``net_num > 0`` already drops them).  But the
+    router's own pour classification (``net_class_map``) can flag a net as
+    pour even when the CLI's zone-detection regex missed the zone and did
+    not add it to ``skip_nets``.  In that case the net kept ``net_num >
+    0``, landed in the multi-pad denominator, yet the router silently
+    skipped it -- producing a bogus ``PARTIAL: Routed 1/2`` line on a
+    board that routed every net it was asked to.
+
+    Gating on ``_is_pour_net`` (which returns False for pour nets in
+    ``_pour_nets_without_zones`` -- those are routed as signals, so they
+    stay in the count) makes the denominator match precisely the set the
+    router hands to the A* loop.
+
+    Args:
+        router: The Autorouter, already loaded (so ``net_class_map`` and
+            ``_pour_nets_without_zones`` are populated).
+
+    Returns:
+        Sorted list of net IDs with ``net_num > 0``, 2+ pads, that the
+        router will route (i.e. are not pour-served).
+    """
+    result: list[int] = []
+    for net_num, pads in router.nets.items():
+        if net_num > 0 and len(pads) >= 2 and not router._is_pour_net(net_num):
+            result.append(net_num)
+    return sorted(result)
+
+
 def _emit_single_pad_net_warning(
     router: "Autorouter",
     single_pad_nets: list[int],
@@ -1234,7 +1275,18 @@ def _finalize_routes(
     stats = router.get_statistics(nets_to_route_ids=multi_pad_net_ids)
 
     if not quiet:
-        flush_print("\n--- Results ---")
+        # Issue #3942 (Bug C): these statistics are scoped to the
+        # newly-routed multi-pad nets (``get_statistics`` is filtered by
+        # ``multi_pad_net_ids``).  When existing copper is preserved
+        # (``--preserve-existing``), the written PCB carries additional
+        # segments/vias re-emitted above and logged on the "Preserved
+        # existing:" line -- so the file totals are these counts PLUS the
+        # preserved copper.  Label the heading so the numbers are not
+        # mistaken for file-final totals.
+        _results_heading = "\n--- Results ---"
+        if preserve_existing:
+            _results_heading += " (newly-routed nets only; preserved copper counted above)"
+        flush_print(_results_heading)
         flush_print(f"  Routes created:  {stats['routes']}")
         flush_print(f"  Segments:        {stats['segments']}")
         flush_print(f"  Vias:            {stats['vias']}")
@@ -3443,10 +3495,11 @@ def route_with_layer_escalation(
         # Issue #1841: Tell the autorouter which pour nets lack zones
         router._pour_nets_without_zones = set(_no_zone)
 
-        # Count nets to route
-        multi_pad_nets = [
-            net_num for net_num, pads in router.nets.items() if net_num > 0 and len(pads) >= 2
-        ]
+        # Count nets to route.  Issue #3942 (Bug B): exclude pour-served
+        # multi-pad nets (router-stripped via _filter_pour_nets) from the
+        # denominator so routed/total matches what the router was asked to
+        # route.  See _routable_multi_pad_nets for the rationale.
+        multi_pad_nets = _routable_multi_pad_nets(router)
         single_pad_nets = [
             net_num for net_num, pads in router.nets.items() if net_num > 0 and len(pads) == 1
         ]
@@ -4321,10 +4374,11 @@ def route_with_rule_relaxation(
         # Issue #1841: Tell the autorouter which pour nets lack zones
         router._pour_nets_without_zones = set(_no_zone)
 
-        # Count nets to route
-        multi_pad_nets = [
-            net_num for net_num, pads in router.nets.items() if net_num > 0 and len(pads) >= 2
-        ]
+        # Count nets to route.  Issue #3942 (Bug B): exclude pour-served
+        # multi-pad nets (router-stripped via _filter_pour_nets) from the
+        # denominator so routed/total matches what the router was asked to
+        # route.  See _routable_multi_pad_nets for the rationale.
+        multi_pad_nets = _routable_multi_pad_nets(router)
         single_pad_nets = [
             net_num for net_num, pads in router.nets.items() if net_num > 0 and len(pads) == 1
         ]
@@ -6404,10 +6458,9 @@ def route_with_combined_escalation(
             # Issue #1841: Tell the autorouter which pour nets lack zones
             router._pour_nets_without_zones = set(_no_zone)
 
-            # Count nets to route
-            multi_pad_nets = [
-                net_num for net_num, pads in router.nets.items() if net_num > 0 and len(pads) >= 2
-            ]
+            # Count nets to route.  Issue #3942 (Bug B): exclude pour-served
+            # multi-pad nets from the denominator (see _routable_multi_pad_nets).
+            multi_pad_nets = _routable_multi_pad_nets(router)
             nets_to_route = len(multi_pad_nets)
 
             # Route
@@ -8768,15 +8821,19 @@ def main(argv: list[str] | None = None) -> int:
     # - Multi-pad nets: 2+ pads, need actual routing
     # - Single-pad nets: 1 pad, trivially complete (no routing needed)
     # - Power nets: skipped via skip_nets, handled by copper pours
-    multi_pad_nets = []
-    single_pad_nets = []
-    for net_num, pads in router.nets.items():
-        if net_num > 0:  # Skip net 0 (unconnected)
-            if len(pads) >= 2:
-                multi_pad_nets.append(net_num)
-            elif len(pads) == 1:
-                single_pad_nets.append(net_num)
-    nets_to_route = len(multi_pad_nets)  # Only multi-pad nets need routing
+    #
+    # Issue #3942 (Bug B): pour-served multi-pad nets that the router
+    # strips via ``_filter_pour_nets`` are excluded from the denominator
+    # by ``_routable_multi_pad_nets`` so the routed/total summary counts
+    # only the nets the router was actually asked to route.  Without this
+    # a pour net the CLI's zone regex missed (kept ``net_num > 0``) but the
+    # router's net-class flagged as pour was counted-but-never-routed,
+    # yielding a spurious ``PARTIAL: Routed 1/2`` on a fully-routed board.
+    multi_pad_nets = _routable_multi_pad_nets(router)
+    single_pad_nets = [
+        net_num for net_num, pads in router.nets.items() if net_num > 0 and len(pads) == 1
+    ]
+    nets_to_route = len(multi_pad_nets)  # Only routable multi-pad nets need routing
     power_nets_skipped = len(skip_nets)
 
     if not quiet:

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -360,6 +360,39 @@ def _format_pad_ref(pad: Pad) -> str:
 _select_seg_seg_demotion_nets = select_seg_seg_demotion_nets
 
 
+def _should_flush_oscillation_msgs(
+    deferred_msgs: list[str],
+    stranded_net_count: int,
+) -> bool:
+    """Decide whether buffered oscillation/escape diagnostics are surfaced.
+
+    Issue #3942 (Bug A): the negotiated loop buffers its mid-loop
+    ``⚠ Oscillation detected`` / ``All N escape strategies exhausted``
+    messages instead of printing them immediately.  After the loop exits,
+    they are surfaced ONLY when the route genuinely failed -- i.e. at
+    least one routable net remains stranded (its pads are not all in one
+    connected component).
+
+    We deliberately do NOT gate on residual overflow: a board can reach
+    full connectivity while carrying overflow from overlaps that the
+    post-loop demotion/correction passes resolve (e.g. the board 01
+    voltage divider ends 3/3 connected with overflow=2).  Gating on
+    overflow alone would still leak the failure-flavored wording there.
+
+    Args:
+        deferred_msgs: The buffered diagnostic lines (empty => nothing to
+            flush, so this returns False).
+        stranded_net_count: Number of routable nets NOT fully connected at
+            loop exit (``len(_stranded_nets())``).  Zero means the route
+            succeeded; any positive value is a genuine partial.
+
+    Returns:
+        True when the buffered messages should be printed (genuine
+        partial), False when they should be dropped (full success).
+    """
+    return bool(deferred_msgs) and stranded_net_count > 0
+
+
 def _run_monte_carlo_trial(config: dict) -> tuple[list, float, int]:
     """Run a single Monte Carlo trial in a worker process.
 
@@ -6633,6 +6666,26 @@ class Autorouter:
         overflow_history: list[int] = []
         escape_strategy_index = 0
 
+        # Issue #3942 (Bug A): buffer oscillation/escape diagnostics printed
+        # mid-loop and only surface them if the router ends with stranded nets
+        # (a genuine partial route).  These messages describe an intermediate
+        # local-minimum the negotiated loop hit; when a later iteration (or the
+        # post-loop best-state restore) resolves the board to full connectivity
+        # they are misleading noise that reads as a failure on a 100%-routed
+        # board.  See ``_should_flush_oscillation_msgs`` for the gate and the
+        # post-loop flush site.
+        deferred_oscillation_msgs: list[str] = []
+
+        def _emit_oscillation_msg(message: str) -> None:
+            """Buffer an oscillation/escape diagnostic for conditional flush.
+
+            Issue #3942: mid-loop oscillation and escape messages are surfaced
+            only if the route ultimately fails to connect every routable net.
+            When the route converges to full connectivity they are dropped so a
+            100%%-routed board produces no failure-flavored wording.
+            """
+            deferred_oscillation_msgs.append(message)
+
         # Issue #2334: Stochastic perturbation state tracking.
         # perturbation_stagnation_count tracks how many iterations the
         # overflow has not improved, used to scale perturbation magnitude.
@@ -8655,8 +8708,13 @@ class Autorouter:
                                     f"stagnation={perturbation_stagnation_count}) ({elapsed_str()})"
                                 )
 
-                            print(f"  ⚠ Oscillation detected: {overflow_history[-4:]}")
-                            print(
+                            # Issue #3942: buffer these diagnostics; they are
+                            # only surfaced if the route ends with residual
+                            # overflow (see deferred flush after the loop).
+                            _emit_oscillation_msg(
+                                f"  ⚠ Oscillation detected: {overflow_history[-4:]}"
+                            )
+                            _emit_oscillation_msg(
                                 f"    Attempting escape strategies starting from {escape_strategy_index + 1}..."
                             )
 
@@ -8686,14 +8744,14 @@ class Autorouter:
                             escape_strategy_index += tried
 
                             if success:
-                                print(
+                                _emit_oscillation_msg(
                                     f"    Escape successful! Overflow: {overflow} → {new_overflow}"
                                 )
                                 overflow = new_overflow
                                 overflow_history[-1] = new_overflow
                                 overused = self.grid.find_overused_cells()
                             else:
-                                print(
+                                _emit_oscillation_msg(
                                     f"    All {tried} escape strategies exhausted without improvement"
                                 )
 
@@ -9291,8 +9349,11 @@ class Autorouter:
                                 f"stagnation={perturbation_stagnation_count}) ({elapsed_str()})"
                             )
 
-                        print(f"  ⚠ Oscillation detected: {overflow_history[-4:]}")
-                        print(
+                        # Issue #3942: buffer these diagnostics; they are only
+                        # surfaced if the route ends with residual overflow
+                        # (see deferred flush after the loop).
+                        _emit_oscillation_msg(f"  ⚠ Oscillation detected: {overflow_history[-4:]}")
+                        _emit_oscillation_msg(
                             f"    Attempting escape strategies starting from {escape_strategy_index + 1}..."
                         )
 
@@ -9322,12 +9383,14 @@ class Autorouter:
                         escape_strategy_index += tried
 
                         if success:
-                            print(f"    Escape successful! Overflow: {overflow} → {new_overflow}")
+                            _emit_oscillation_msg(
+                                f"    Escape successful! Overflow: {overflow} → {new_overflow}"
+                            )
                             overflow = new_overflow
                             overflow_history[-1] = new_overflow  # Update last entry
                             overused = self.grid.find_overused_cells()
                         else:
-                            print(
+                            _emit_oscillation_msg(
                                 f"    All {tried} escape strategies exhausted without improvement"
                             )
                             # Continue to next iteration with different parameters
@@ -9452,6 +9515,25 @@ class Autorouter:
             # queue every subsequent unmark_route on a long-lived grid
             # (follow-up to #3488).  No-op when no window is open.
             self._flush_corridor_reservation(net_routes)
+
+        # Issue #3942: flush buffered oscillation/escape diagnostics only when
+        # the route did NOT fully succeed.  These intermediate local-minimum
+        # messages describe a state the negotiated loop hit mid-way; when a
+        # later iteration (or the post-loop restore) resolves the board to full
+        # connectivity, they are misleading noise that reads as a failure on a
+        # 100%-routed board.
+        #
+        # "Fully succeeded" here means every routable net's pads are in one
+        # connected component (``_stranded_nets()`` is empty).  We deliberately
+        # do NOT gate on ``overflow == 0``: a board can route to 100%
+        # connectivity while carrying residual overflow from overlaps that the
+        # post-loop demotion/correction passes resolve (board 01 voltage
+        # divider ends 3/3 connected with overflow=2).  Gating on overflow
+        # alone would still surface the failure-flavored wording there.
+        if _should_flush_oscillation_msgs(deferred_oscillation_msgs, len(_stranded_nets())):
+            for _msg in deferred_oscillation_msgs:
+                print(_msg)
+        deferred_oscillation_msgs.clear()
 
         successful_nets = sum(1 for routes in net_routes.values() if routes)
         total_elapsed = time.time() - start_time

--- a/tests/test_adaptive_early_stop.py
+++ b/tests/test_adaptive_early_stop.py
@@ -28,6 +28,10 @@ def _make_fake_router(nets_routed: int, nets_total: int = 20, segments: int = 0,
     router.grid = MagicMock(width=50, height=50)
     router.routes = []
     router._pour_nets_without_zones = set()
+    # Issue #3942 (Bug B): _routable_multi_pad_nets calls _is_pour_net to
+    # drop pour-served nets from the denominator.  A bare MagicMock returns
+    # truthy, zeroing nets_to_route; these mocks model no-pour boards.
+    router._is_pour_net.return_value = False
     router.get_statistics.return_value = {
         "nets_routed": nets_routed,
         "segments": segments,

--- a/tests/test_layer_escalation.py
+++ b/tests/test_layer_escalation.py
@@ -855,6 +855,12 @@ class TestEarlyTermination:
         }
         router.power_stall_abort = False
         router._pour_nets_without_zones = set()
+        # Issue #3942 (Bug B): route_cmd._routable_multi_pad_nets calls
+        # router._is_pour_net(net_id) to exclude pour-served nets from the
+        # denominator.  A bare MagicMock returns a truthy sentinel, which
+        # would misclassify every net as pour-served (nets_to_route -> 0).
+        # These mock routers model boards with no pour nets, so return False.
+        router._is_pour_net.return_value = False
         # Provide real float values for rules attributes used by drc_nudge
         router.rules.via_diameter = 0.6
         router.rules.min_drill_clearance = 0.0
@@ -1374,6 +1380,10 @@ class TestRegressionEarlyExit:
         }
         router.power_stall_abort = False
         router._pour_nets_without_zones = set()
+        # Issue #3942 (Bug B): _routable_multi_pad_nets calls _is_pour_net;
+        # a bare MagicMock returns truthy, misclassifying every net as
+        # pour-served.  These mocks model boards with no pour nets.
+        router._is_pour_net.return_value = False
         router.rules.via_diameter = 0.6
         router.rules.min_drill_clearance = 0.0
         router.rules.trace_width = 0.2
@@ -2040,6 +2050,9 @@ class TestPlacementFeedbackOnPartial:
         router.get_failed_nets.return_value = list(range(1, nets_to_route - nets_routed + 1))
         router.power_stall_abort = False
         router._pour_nets_without_zones = set()
+        # Issue #3942 (Bug B): _routable_multi_pad_nets calls _is_pour_net;
+        # keep every net routable so nets_to_route matches the mock's count.
+        router._is_pour_net.return_value = False
         router.rules.via_diameter = 0.6
         router.rules.min_drill_clearance = 0.0
         router.rules.trace_width = 0.2
@@ -2845,6 +2858,9 @@ class TestStartingLayersEndToEnd:
         }
         router.power_stall_abort = False
         router._pour_nets_without_zones = set()
+        # Issue #3942 (Bug B): _routable_multi_pad_nets calls _is_pour_net;
+        # keep every net routable so nets_to_route matches the mock's count.
+        router._is_pour_net.return_value = False
         router.rules.via_diameter = 0.6
         router.rules.min_drill_clearance = 0.0
         router.rules.trace_width = 0.2

--- a/tests/test_manufacturer_propagation_lint.py
+++ b/tests/test_manufacturer_propagation_lint.py
@@ -57,15 +57,16 @@ _SRC_ROOT = _REPO_ROOT / "src" / "kicad_tools"
 
 # Format: {relative_path: {line_number: reason}}
 _ALLOWLIST: dict[str, dict[int, str]] = {
-    # Router core: default-constructed router (line ~400 is the
-    # ``rules_dict``-spread default in _route_with_seed; line ~817 is
+    # Router core: default-constructed router (line ~433 is the
+    # ``rules_dict``-spread default in _route_with_seed; line ~850 is
     # the constructor default).  Reaching either means the caller did
     # not pass rules.  (Line numbers refreshed for issue #3464, the
-    # #3663 ruff lint burn-down, and again for #3881 which added the
-    # _per_net_iterations field/param shifting both sites.)
+    # #3663 ruff lint burn-down, #3881 which added the
+    # _per_net_iterations field/param, and #3942 which added the
+    # success-output oscillation diagnostics — each shifting both sites.)
     "router/core.py": {
-        400: "worker-process rules_dict-spread default (both calls on this line)",
-        817: "Autorouter.__init__ rules-arg default fallback",
+        433: "worker-process rules_dict-spread default (both calls on this line)",
+        850: "Autorouter.__init__ rules-arg default fallback",
     },
     # AdaptiveRouter default fallback — same pattern as Autorouter.
     "router/adaptive.py": {

--- a/tests/test_route_cmd_success_output.py
+++ b/tests/test_route_cmd_success_output.py
@@ -1,0 +1,265 @@
+"""Issue #3942: the router must not print failure-flavored diagnostics on
+boards that route 100% successfully.
+
+Three distinct diagnostic bugs were reported and are pinned here:
+
+* **Bug A** -- ``⚠ Oscillation detected`` / ``All N escape strategies
+  exhausted`` lines were printed mid-loop and stayed visible even when a
+  later iteration resolved the board to full connectivity.  They are now
+  buffered and only surfaced when the route ends with stranded nets (a
+  genuine partial).  See ``src/kicad_tools/router/core.py`` (deferred
+  ``_emit_oscillation_msg`` buffer + post-loop flush gated on
+  ``_stranded_nets()``).
+
+* **Bug B** -- the routed/total summary counted pour-served multi-pad
+  nets in the denominator even though the router strips them via
+  ``_filter_pour_nets``, yielding a spurious ``PARTIAL: Routed 1/2`` on a
+  fully-routed board.  ``_routable_multi_pad_nets`` now excludes them so
+  the denominator matches what the router was asked to route.
+
+* **Bug C** -- the ``--- Results ---`` segment/via counts are scoped to
+  newly-routed multi-pad nets, but the written file also carries
+  preserved copper.  The heading is now annotated when
+  ``--preserve-existing`` is active so the counts are not mistaken for
+  file totals.
+
+The subprocess-based checks route the real demo boards (board 00, board
+01) and assert the final output contains no failure-flavored wording;
+the unit checks pin the denominator/buffer mechanics directly.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.timeout(900)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BOARD_00 = REPO_ROOT / "boards" / "00-simple-led" / "output" / "simple_led.kicad_pcb"
+BOARD_01 = REPO_ROOT / "boards" / "01-voltage-divider" / "output" / "voltage_divider.kicad_pcb"
+
+# Failure-flavored wording that must NOT appear on a 100%-routed board.
+_OSCILLATION_RE = re.compile(r"Oscillation detected")
+_ESCAPE_EXHAUSTED_RE = re.compile(r"escape strateg(?:y|ies) exhausted", re.IGNORECASE)
+_PARTIAL_RE = re.compile(r"^PARTIAL:", re.MULTILINE)
+
+
+def _route(pcb: Path, out: Path, *extra: str) -> subprocess.CompletedProcess:
+    """Run ``kct route`` as a subprocess and capture combined output."""
+    cmd = [
+        sys.executable,
+        "-m",
+        "kicad_tools.cli",
+        "route",
+        str(pcb),
+        "--output",
+        str(out),
+        *extra,
+    ]
+    return subprocess.run(
+        cmd,
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bug A + Bug B: successful routes must not print failure-flavored wording
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not BOARD_00.exists(), reason="board 00 fixture missing")
+def test_board00_success_output_has_no_failure_wording(tmp_path):
+    """Board 00 (GND/VCC pour-served) routes 100% and must read as SUCCESS.
+
+    Pins Bug A (no oscillation/escape-exhausted lines) and Bug B (the
+    pour-served power nets are excluded from the denominator, so the
+    summary is SUCCESS, never PARTIAL).
+    """
+    out = tmp_path / "board00_routed.kicad_pcb"
+    proc = _route(BOARD_00, out, "--layers", "2")
+    output = proc.stdout + proc.stderr
+
+    assert out.exists(), f"route did not write output:\n{output}"
+    # Bug B: fully-routed board reports SUCCESS, not PARTIAL.
+    assert "SUCCESS:" in output, f"expected SUCCESS headline:\n{output}"
+    assert not _PARTIAL_RE.search(output), f"unexpected PARTIAL on 100% board:\n{output}"
+    # Bug A: no failure-flavored oscillation/escape wording on a success.
+    assert not _OSCILLATION_RE.search(output), f"oscillation wording on success:\n{output}"
+    assert not _ESCAPE_EXHAUSTED_RE.search(output), (
+        f"escape-exhausted wording on success:\n{output}"
+    )
+
+
+@pytest.mark.skipif(not BOARD_01.exists(), reason="board 01 fixture missing")
+def test_board01_success_output_has_no_failure_wording(tmp_path):
+    """Board 01 (voltage divider) exercises the escape loop yet routes 3/3.
+
+    Board 01 historically ends with residual overflow (overlaps demoted
+    post-loop) at full connectivity, so it is the canonical case where
+    gating on ``overflow == 0`` alone would still leak the failure
+    wording.  Gating on ``_stranded_nets()`` suppresses it correctly.
+    """
+    out = tmp_path / "board01_routed.kicad_pcb"
+    proc = _route(BOARD_01, out, "--layers", "2")
+    output = proc.stdout + proc.stderr
+
+    assert out.exists(), f"route did not write output:\n{output}"
+    assert not _PARTIAL_RE.search(output), f"unexpected PARTIAL on 100% board:\n{output}"
+    assert not _OSCILLATION_RE.search(output), f"oscillation wording on success:\n{output}"
+    assert not _ESCAPE_EXHAUSTED_RE.search(output), (
+        f"escape-exhausted wording on success:\n{output}"
+    )
+
+
+@pytest.mark.skipif(not BOARD_00.exists(), reason="board 00 fixture missing")
+def test_verbose_keeps_status_detail(tmp_path):
+    """--verbose still surfaces the normal per-iteration/status detail.
+
+    The Bug A fix suppresses only the failure-flavored oscillation/escape
+    lines on success; it must not swallow the ordinary progress/status
+    output the router prints (e.g. the SUCCESS headline).
+    """
+    out = tmp_path / "board00_verbose.kicad_pcb"
+    proc = _route(BOARD_00, out, "--layers", "2", "--verbose")
+    output = proc.stdout + proc.stderr
+
+    assert out.exists(), f"route did not write output:\n{output}"
+    assert "SUCCESS:" in output, f"verbose run lost its SUCCESS headline:\n{output}"
+    # Even under --verbose, a clean route stays free of the failure wording.
+    assert not _OSCILLATION_RE.search(output), f"oscillation wording under --verbose:\n{output}"
+
+
+# ---------------------------------------------------------------------------
+# Bug B: denominator excludes pour-served multi-pad nets
+# ---------------------------------------------------------------------------
+
+
+class _FakeRouter:
+    """Minimal stand-in exposing what ``_routable_multi_pad_nets`` reads."""
+
+    def __init__(self, nets, pour_net_ids):
+        # nets: {net_id: [pad, pad, ...]}
+        self.nets = nets
+        self._pour_net_ids = set(pour_net_ids)
+
+    def _is_pour_net(self, net_id):  # noqa: D401 - mirror Autorouter API
+        return net_id in self._pour_net_ids
+
+
+def test_routable_multi_pad_nets_excludes_pour_served():
+    """A pour-served multi-pad net (net_num > 0) is dropped from the count."""
+    from kicad_tools.cli.route_cmd import _routable_multi_pad_nets
+
+    router = _FakeRouter(
+        nets={
+            0: ["p"],  # net 0 obstacle -- excluded (net_num > 0 filter)
+            1: ["a", "b"],  # routable signal
+            2: ["c", "d"],  # pour-served (has zone, is_pour_net) -- excluded
+            3: ["e"],  # single-pad -- excluded (needs 2+)
+        },
+        pour_net_ids={2},
+    )
+
+    assert _routable_multi_pad_nets(router) == [1]
+
+
+def test_routable_multi_pad_nets_keeps_no_zone_pour_nets():
+    """A pour net without a zone is routed as a signal, so it stays counted.
+
+    ``Autorouter._is_pour_net`` returns False for nets in
+    ``_pour_nets_without_zones`` -- the router DOES route them, so they
+    belong in the denominator.  Here net 2 is pour-classified-but-no-zone,
+    modeled by ``_is_pour_net`` returning False.
+    """
+    from kicad_tools.cli.route_cmd import _routable_multi_pad_nets
+
+    router = _FakeRouter(
+        nets={1: ["a", "b"], 2: ["c", "d"]},
+        pour_net_ids=set(),  # neither is pour-served -> both routable
+    )
+
+    assert _routable_multi_pad_nets(router) == [1, 2]
+
+
+# ---------------------------------------------------------------------------
+# Bug A: the buffer-flush gate (genuine failures stay loud, successes quiet)
+# ---------------------------------------------------------------------------
+
+
+def test_flush_gate_suppresses_on_full_success():
+    """Zero stranded nets => buffered oscillation messages are dropped."""
+    from kicad_tools.router.core import _should_flush_oscillation_msgs
+
+    msgs = ["  ⚠ Oscillation detected: [4, 2, 4, 2]", "    All 4 escape strategies exhausted"]
+    assert _should_flush_oscillation_msgs(msgs, stranded_net_count=0) is False
+
+
+def test_flush_gate_surfaces_on_genuine_partial():
+    """Any stranded net => buffered messages ARE surfaced (stay loud)."""
+    from kicad_tools.router.core import _should_flush_oscillation_msgs
+
+    msgs = ["  ⚠ Oscillation detected: [4, 2, 4, 2]", "    All 4 escape strategies exhausted"]
+    assert _should_flush_oscillation_msgs(msgs, stranded_net_count=1) is True
+    assert _should_flush_oscillation_msgs(msgs, stranded_net_count=7) is True
+
+
+def test_flush_gate_noop_when_no_messages_buffered():
+    """No buffered messages => nothing to flush regardless of stranded count."""
+    from kicad_tools.router.core import _should_flush_oscillation_msgs
+
+    assert _should_flush_oscillation_msgs([], stranded_net_count=0) is False
+    assert _should_flush_oscillation_msgs([], stranded_net_count=5) is False
+
+
+def test_flush_gate_ignores_residual_overflow_on_success():
+    """Full connectivity with residual overflow still suppresses (board 01).
+
+    The gate keys on stranded-net count, NOT overflow -- a board that
+    reaches full connectivity while carrying overlap-driven overflow must
+    still suppress the failure wording.
+    """
+    from kicad_tools.router.core import _should_flush_oscillation_msgs
+
+    msgs = ["  ⚠ Oscillation detected: [2, 2, 2, 2]"]
+    # stranded=0 models "all nets connected"; overflow is intentionally not
+    # a parameter, proving the decision does not depend on it.
+    assert _should_flush_oscillation_msgs(msgs, stranded_net_count=0) is False
+
+
+# ---------------------------------------------------------------------------
+# Bug C: --- Results --- heading is scope-labeled under --preserve-existing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not BOARD_00.exists(), reason="board 00 fixture missing")
+def test_results_heading_annotated_when_preserving(tmp_path):
+    """With --preserve-existing, the Results heading carries a scope label.
+
+    The counts under ``--- Results ---`` are newly-routed-only; the label
+    tells the user the written file also includes the preserved copper.
+    """
+    routed = REPO_ROOT / "boards" / "00-simple-led" / "output" / "simple_led_routed.kicad_pcb"
+    if not routed.exists():
+        pytest.skip("board 00 routed fixture missing")
+    src = tmp_path / "preserve_in.kicad_pcb"
+    shutil.copy(routed, src)
+    out = tmp_path / "preserve_out.kicad_pcb"
+    proc = _route(src, out, "--layers", "2", "--preserve-existing")
+    output = proc.stdout + proc.stderr
+
+    if "--- Results ---" not in output:
+        pytest.skip(f"route path did not reach Results block:\n{output}")
+    # The heading must carry the newly-routed scope annotation.
+    results_line = next(
+        line for line in output.splitlines() if line.strip().startswith("--- Results ---")
+    )
+    assert "newly-routed" in results_line, f"Results heading not scope-labeled: {results_line!r}"


### PR DESCRIPTION
## Summary

The router printed three failure-flavored diagnostics on boards that route 100% successfully, making clean builds read as failures. This fixes all three by gating each diagnostic on the route's *final* outcome (and scope), never mid-loop state.

## Changes

**Bug A — oscillation/escape warnings on success** (`router/core.py`)
- The negotiated loop's `⚠ Oscillation detected` and `All N escape strategies exhausted` lines were printed mid-loop. A later iteration (or the post-loop best-state restore) can resolve the board to full connectivity, leaving the warnings stranded in the log.
- These messages are now buffered (`_emit_oscillation_msg`) and flushed after the loop **only when the route genuinely fails** — gated on `_stranded_nets()`, not overflow. A 100%-connected board can carry overlap-driven residual overflow (board 01 ends 3/3 connected with `overflow=2`), so gating on `overflow == 0` alone would still leak the wording. The decision lives in the pure helper `_should_flush_oscillation_msgs` for deterministic unit testing.

**Bug B — `PARTIAL` denominator counts pour-served nets** (`cli/route_cmd.py`)
- `nets_to_route` counted multi-pad nets the router strips via `_filter_pour_nets`. When the CLI's zone regex missed a zone that the net-class still flagged as pour, the net kept `net_num > 0`, entered the denominator, yet was never routed → spurious `PARTIAL: Routed 1/2` on a fully-routed board.
- New `_routable_multi_pad_nets(router)` excludes router-pour nets (`router._is_pour_net`) from the denominator at **all four** count sites (`route_pcb` + the three escalation paths). No-zone pour nets (routed as signals) stay counted.

**Bug C — `--- Results ---` scope unlabeled** (`cli/route_cmd.py`)
- The segment/via counts are scoped to newly-routed multi-pad nets, but the written file also carries preserved copper (logged separately). The heading now carries `(newly-routed nets only; preserved copper counted above)` under `--preserve-existing`.

**Tests**
- New `tests/test_route_cmd_success_output.py`: subprocess routes of demo boards 00/01 assert no failure wording and a `SUCCESS` headline; `--verbose` keeps status detail; unit tests for `_routable_multi_pad_nets` and the flush gate (genuine partial stays loud, success stays quiet, residual-overflow-on-success suppressed).
- Updated the `MagicMock` router helpers in `test_layer_escalation.py` and `test_adaptive_early_stop.py` to stub `_is_pour_net -> False` so the new denominator path sees no-pour boards.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| 100%-routed board output contains no failure-flavored wording | ✅ | `kct route boards/00` and `boards/01` produce no `Oscillation`/`exhausted`/`PARTIAL`; asserted by `test_board00/01_success_output_has_no_failure_wording` |
| Genuine failures still loud | ✅ | `_should_flush_oscillation_msgs` returns True for any stranded net; `test_flush_gate_surfaces_on_genuine_partial` |
| `--verbose` keeps detail | ✅ | `test_verbose_keeps_status_detail` (SUCCESS headline + status retained) |
| Bug B: pour-served net excluded from denominator | ✅ | `_routable_multi_pad_nets` at 4 sites; `test_routable_multi_pad_nets_excludes_pour_served`; board 00 reports SUCCESS 1/1 |
| Bug B: no-zone pour nets stay counted | ✅ | `test_routable_multi_pad_nets_keeps_no_zone_pour_nets` |
| Bug C: Results heading scope-labeled | ✅ | `test_results_heading_annotated_when_preserving` |
| Verified on a real demo board route | ✅ | board 00 (fixed 2L) + board 01 routed end-to-end |

## Test Plan

- `pytest tests/test_route_cmd_success_output.py` — 10 passed
- `pytest tests/router/` — 449 passed, 3 skipped, 1 xfailed
- `pytest tests/test_layer_escalation.py tests/test_adaptive_early_stop.py tests/test_auto_pour.py tests/test_route_cmd_power_nets.py tests/test_negotiated_*` and related — all green
- `ruff check` / `ruff format --check` clean on all changed files
- `mypy` on changed files: 77 errors, all pre-existing (identical count on `origin/main` baseline via `git stash`); zero on added/changed lines

Closes #3942