### PR TITLE
feat(build): add per-step timings and heartbeat for silent subprocess steps

### DIFF
--- a/src/kicad_tools/cli/build_cmd.py
+++ b/src/kicad_tools/cli/build_cmd.py
@@ -18,6 +18,8 @@ import logging
 import re
 import subprocess
 import sys
+import threading
+import time
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -26,6 +28,7 @@ from typing import TYPE_CHECKING
 from rich.console import Console
 
 logger = logging.getLogger(__name__)
+from rich.markup import escape as markup_escape
 from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
@@ -385,6 +388,101 @@ def _run_python_script(
 
     except Exception as e:
         return False, f"Failed to run {script_path.name}: {e}"
+
+
+# Interval (seconds) between "still running" heartbeats emitted while a
+# long subprocess step is alive.  Chosen well under the 60s ceiling in
+# issue #3944's acceptance criteria so users can distinguish "still
+# working" from "hung" without waiting a full minute.
+_HEARTBEAT_INTERVAL_S = 30.0
+
+
+def _format_elapsed(seconds: float) -> str:
+    """Format an elapsed duration for ledger / summary lines.
+
+    Sub-minute durations render as fractional seconds (``24.3s``);
+    longer durations render as ``4m32s`` so multi-minute steps read
+    cleanly.  All timing is fed from ``time.monotonic()`` deltas so it
+    is insensitive to wall-clock adjustments (issue #3944).
+    """
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    minutes = int(seconds // 60)
+    rem = int(round(seconds - minutes * 60))
+    if rem == 60:  # rounding pushed us to the next minute
+        minutes += 1
+        rem = 0
+    return f"{minutes}m{rem:02d}s"
+
+
+def _run_subprocess_with_heartbeat(
+    cmd: list[str],
+    *,
+    cwd: str,
+    console: Console,
+    label: str,
+    quiet: bool,
+    heartbeat_interval: float = _HEARTBEAT_INTERVAL_S,
+) -> subprocess.CompletedProcess[str]:
+    """Run ``cmd`` while emitting periodic "still running" heartbeats.
+
+    Issue #3944: several ``kct build`` sub-steps (placement, route
+    fallback, verify DRC/sync, export) shelled out with
+    ``subprocess.run(capture_output=...)`` and went completely silent for
+    minutes at a time -- indistinguishable from a hang.  This helper
+    captures the child's stdout/stderr (so callers keep the same
+    ``CompletedProcess`` contract they had with ``subprocess.run``) but
+    spawns a daemon thread that prints ``[label]: still running, Xs
+    elapsed`` every ``heartbeat_interval`` seconds until the process
+    exits.
+
+    ``quiet`` suppresses the heartbeat entirely (the existing ``--quiet``
+    contract).  The returned object matches ``subprocess.run(...,
+    capture_output=True, text=True)`` so callers can inspect
+    ``returncode``, ``stdout``, and ``stderr`` unchanged.
+    """
+    start = time.monotonic()
+    process = subprocess.Popen(
+        cmd,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    stop = threading.Event()
+
+    # Escape the label so Rich renders the surrounding brackets as
+    # literal ``[label]`` text instead of interpreting them as console
+    # markup (which would otherwise silently strip the label).
+    safe_label = markup_escape(label)
+
+    def _heartbeat() -> None:
+        # Wait in interval-sized slices; exit promptly when signalled.
+        while not stop.wait(heartbeat_interval):
+            elapsed = time.monotonic() - start
+            console.print(
+                f"  [dim]\\[{safe_label}]: still running, {_format_elapsed(elapsed)} elapsed[/dim]"
+            )
+
+    thread: threading.Thread | None = None
+    if not quiet:
+        thread = threading.Thread(target=_heartbeat, daemon=True)
+        thread.start()
+
+    try:
+        stdout, stderr = process.communicate()
+    finally:
+        stop.set()
+        if thread is not None:
+            thread.join(timeout=1.0)
+
+    return subprocess.CompletedProcess(
+        args=cmd,
+        returncode=process.returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
 
 
 def _run_step_schematic(ctx: BuildContext, console: Console) -> BuildResult:
@@ -852,12 +950,15 @@ def _run_step_placement(ctx: BuildContext, console: Console) -> BuildResult:
         if ctx.verbose:
             cmd.append("--verbose")
 
-        result = subprocess.run(
+        result = _run_subprocess_with_heartbeat(
             cmd,
             cwd=str(ctx.project_dir),
-            capture_output=not ctx.verbose,
-            text=True,
+            console=console,
+            label="placement",
+            quiet=ctx.quiet,
         )
+        if ctx.verbose and result.stdout:
+            console.print(result.stdout)
 
         if result.returncode == 0:
             return BuildResult(
@@ -1336,12 +1437,15 @@ def _run_step_route(ctx: BuildContext, console: Console) -> BuildResult:
         if ctx.quiet:
             cmd.append("--quiet")
 
-        result = subprocess.run(
+        result = _run_subprocess_with_heartbeat(
             cmd,
             cwd=str(ctx.project_dir),
-            capture_output=not ctx.verbose,
-            text=True,
+            console=console,
+            label="route",
+            quiet=ctx.quiet,
         )
+        if ctx.verbose and result.stdout:
+            console.print(result.stdout)
 
         if result.returncode == 0:
             # Defense-in-depth postcondition (issue #2740): the router can
@@ -2336,11 +2440,12 @@ def _run_step_verify(ctx: BuildContext, console: Console) -> BuildResult:
             str(drc_report_path),
         ]
 
-        result = subprocess.run(
+        result = _run_subprocess_with_heartbeat(
             cmd,
             cwd=str(ctx.project_dir),
-            capture_output=True,
-            text=True,
+            console=console,
+            label="verify",
+            quiet=ctx.quiet,
         )
 
         drc_success = result.returncode == 0
@@ -2365,11 +2470,12 @@ def _run_step_verify(ctx: BuildContext, console: Console) -> BuildResult:
                 str(pcb_to_verify),
             ]
 
-            sync_result = subprocess.run(
+            sync_result = _run_subprocess_with_heartbeat(
                 sync_cmd,
                 cwd=str(ctx.project_dir),
-                capture_output=True,
-                text=True,
+                console=console,
+                label="verify (sync)",
+                quiet=ctx.quiet,
             )
 
             if sync_result.returncode != 0:
@@ -2479,12 +2585,15 @@ def _run_step_export(ctx: BuildContext, console: Console) -> BuildResult:
             cmd.append("--no-bom")
             cmd.append("--no-cpl")
 
-        result = subprocess.run(
+        result = _run_subprocess_with_heartbeat(
             cmd,
             cwd=str(ctx.project_dir),
-            capture_output=not ctx.verbose,
-            text=True,
+            console=console,
+            label="export",
+            quiet=ctx.quiet,
         )
+        if ctx.verbose and result.stdout:
+            console.print(result.stdout)
 
         if result.returncode == 0:
             return BuildResult(
@@ -2857,6 +2966,11 @@ def main(argv: list[str] | None = None) -> int:
     # Run build steps
     results: list[BuildResult] = []
 
+    # Wall-clock anchor for the whole pipeline (issue #3944).  Uses
+    # ``time.monotonic()`` so the reported totals are immune to system
+    # clock adjustments mid-build.
+    build_start = time.monotonic()
+
     with Progress(
         SpinnerColumn(),
         TextColumn("[progress.description]{task.description}"),
@@ -2865,6 +2979,7 @@ def main(argv: list[str] | None = None) -> int:
     ) as progress:
         for step in steps:
             task = progress.add_task(f"[cyan]{step.value}[/cyan]...", total=None)
+            step_start = time.monotonic()
 
             if step == BuildStep.SCHEMATIC:
                 result = _run_step_schematic(ctx, console)
@@ -2921,13 +3036,18 @@ def main(argv: list[str] | None = None) -> int:
             else:
                 result = BuildResult(step=step.value, success=False, message="Unknown step")
 
+            step_elapsed = time.monotonic() - step_start
             results.append(result)
             progress.remove_task(task)
 
-            # Print step result
+            # Print step result with per-step elapsed time (issue #3944)
+            # so users can see how long each stage took directly on the
+            # ledger line, e.g. ``[OK] route: ... (24.3s)``.
             if not args.quiet:
                 status = "[green]OK[/green]" if result.success else "[red]FAIL[/red]"
-                console.print(f"  [{status}] {step.value}: {result.message}")
+                console.print(
+                    f"  [{status}] {step.value}: {result.message} ({_format_elapsed(step_elapsed)})"
+                )
 
             # Stop on failure unless verifying or exporting
             if not result.success and step not in (
@@ -2957,13 +3077,15 @@ def main(argv: list[str] | None = None) -> int:
 
     # Print summary
     if not args.quiet:
+        total_elapsed = _format_elapsed(time.monotonic() - build_start)
         console.print()
         success_count = sum(1 for r in results if r.success)
         total_count = len(results)
 
         if success_count == total_count:
             console.print(
-                f"[green]Build completed successfully[/green] ({success_count}/{total_count} steps)"
+                f"[green]Build completed successfully[/green] "
+                f"({success_count}/{total_count} steps) in {total_elapsed}"
             )
 
             # Show output files
@@ -2978,7 +3100,8 @@ def main(argv: list[str] | None = None) -> int:
                 console.print(f"[dim]Manufacturing:[/dim] {export_results[0].output_file}")
         else:
             console.print(
-                f"[red]Build failed[/red] ({success_count}/{total_count} steps succeeded)"
+                f"[red]Build failed[/red] "
+                f"({success_count}/{total_count} steps succeeded) in {total_elapsed}"
             )
             return 1
 

--- a/tests/test_build_cmd_errors.py
+++ b/tests/test_build_cmd_errors.py
@@ -314,7 +314,7 @@ class TestBuildRouteExitCode2:
 
         console = Console()
 
-        with patch("subprocess.run") as mock_run:
+        with patch("kicad_tools.cli.build_cmd._run_subprocess_with_heartbeat") as mock_run:
             mock_run.return_value = MagicMock(returncode=2, stderr="", stdout="")
             result = _run_step_route(ctx, console)
 
@@ -347,7 +347,7 @@ class TestBuildRouteExitCode2:
 
         console = Console()
 
-        with patch("subprocess.run") as mock_run:
+        with patch("kicad_tools.cli.build_cmd._run_subprocess_with_heartbeat") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
             result = _run_step_route(ctx, console)
 
@@ -377,7 +377,7 @@ class TestBuildRouteExitCode2:
 
         console = Console()
 
-        with patch("subprocess.run") as mock_run:
+        with patch("kicad_tools.cli.build_cmd._run_subprocess_with_heartbeat") as mock_run:
             mock_run.return_value = MagicMock(returncode=1, stderr="routing failed", stdout="")
             result = _run_step_route(ctx, console)
 
@@ -413,7 +413,7 @@ class TestBuildRouteExitCode2:
 
         console = Console()
 
-        with patch("subprocess.run") as mock_run:
+        with patch("kicad_tools.cli.build_cmd._run_subprocess_with_heartbeat") as mock_run:
             mock_run.return_value = MagicMock(returncode=3, stderr="DRC violations", stdout="")
             result = _run_step_route(ctx, console)
 

--- a/tests/test_build_cmd_stdout_streaming.py
+++ b/tests/test_build_cmd_stdout_streaming.py
@@ -22,12 +22,14 @@ These tests verify:
 
 from __future__ import annotations
 
+import sys
 import textwrap
 from pathlib import Path
 
 import pytest
 
-from kicad_tools.cli.build_cmd import _run_python_script
+from kicad_tools.cli import build_cmd
+from kicad_tools.cli.build_cmd import _run_python_script, _run_subprocess_with_heartbeat
 
 
 @pytest.fixture
@@ -220,6 +222,51 @@ class TestStdoutStreamingChildEnv:
         captured = capsys.readouterr()
         # Caller's value (``x``) wins over our default (``1``).
         assert "unbuffered=x" in captured.out
+
+
+class TestSubprocessHeartbeatStreaming:
+    """Issue #3944: the silent ``subprocess.run`` sites (placement,
+    route fallback, verify, export) now route through
+    ``_run_subprocess_with_heartbeat``, which surfaces a bounded-interval
+    "still running" heartbeat so long steps are distinguishable from a
+    hang without ``--verbose``."""
+
+    def test_heartbeat_visible_by_default(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A slow child produces at least one heartbeat line in the
+        default (non-quiet) mode."""
+        cmd = [sys.executable, "-c", "import time; time.sleep(0.25)"]
+        result = _run_subprocess_with_heartbeat(
+            cmd,
+            cwd=".",
+            console=build_cmd.Console(),
+            label="route",
+            quiet=False,
+            heartbeat_interval=0.05,
+        )
+        assert result.returncode == 0
+        assert "still running" in capsys.readouterr().out
+
+    def test_heartbeat_suppressed_when_quiet(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``quiet=True`` mirrors the ``--quiet`` contract and prints no
+        heartbeat, matching the streaming-suppression behaviour of
+        ``_run_python_script(quiet=True)``."""
+        cmd = [sys.executable, "-c", "import time; time.sleep(0.25)"]
+        result = _run_subprocess_with_heartbeat(
+            cmd,
+            cwd=".",
+            console=build_cmd.Console(),
+            label="route",
+            quiet=True,
+            heartbeat_interval=0.05,
+        )
+        assert result.returncode == 0
+        assert "still running" not in capsys.readouterr().out
 
 
 class TestRouteAllSmokeBudget:

--- a/tests/test_build_cmd_timings.py
+++ b/tests/test_build_cmd_timings.py
@@ -1,0 +1,283 @@
+"""Tests for ``kct build`` per-step timings and long-step heartbeats (#3944).
+
+Two symptoms motivated this module:
+
+1. The step-runner loop in ``main()`` printed ``[OK]/[FAIL]`` ledger
+   lines with no elapsed time, and the final summary had no wall-clock
+   total -- so users could not tell how long any stage took.
+2. Several sub-steps shelled out with ``subprocess.run(capture_output=
+   ...)`` and went completely silent for minutes, indistinguishable
+   from a hang.
+
+The fixes:
+
+* Wrap each step invocation with ``time.monotonic()`` and print the
+  elapsed time on the ledger line, plus a total on the summary line.
+* Route the silent subprocess sites through
+  ``_run_subprocess_with_heartbeat``, which emits a bounded-interval
+  "still running" heartbeat while the child is alive.
+
+These tests exercise the timing formatter, the heartbeat helper, and
+the ``main()`` ledger/summary output with a mockable clock, and confirm
+``--quiet`` suppresses all of it.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from kicad_tools.cli import build_cmd
+from kicad_tools.cli.build_cmd import (
+    BuildResult,
+    _format_elapsed,
+    _run_subprocess_with_heartbeat,
+)
+
+
+class TestFormatElapsed:
+    """``_format_elapsed`` renders monotonic deltas for the ledger."""
+
+    def test_sub_minute_uses_fractional_seconds(self) -> None:
+        assert _format_elapsed(24.3) == "24.3s"
+        assert _format_elapsed(0.0) == "0.0s"
+        assert _format_elapsed(59.9) == "59.9s"
+
+    def test_multi_minute_uses_mmss(self) -> None:
+        assert _format_elapsed(60.0) == "1m00s"
+        assert _format_elapsed(272.0) == "4m32s"
+        assert _format_elapsed(125.4) == "2m05s"
+
+    def test_rounding_up_to_next_minute_carries(self) -> None:
+        # 119.6s rounds seconds-part to 60 -> should carry to 2m00s,
+        # never emit "1m60s".
+        assert _format_elapsed(119.6) == "2m00s"
+
+
+class TestHeartbeat:
+    """``_run_subprocess_with_heartbeat`` streams "still running" lines."""
+
+    def test_emits_heartbeat_for_slow_process(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A child that outlives the heartbeat interval triggers at
+        least one "still running" line before it exits."""
+        cmd = [sys.executable, "-c", "import time; time.sleep(0.25)"]
+        result = _run_subprocess_with_heartbeat(
+            cmd,
+            cwd=".",
+            console=build_cmd.Console(),
+            label="route",
+            quiet=False,
+            heartbeat_interval=0.05,
+        )
+        assert result.returncode == 0
+        captured = capsys.readouterr()
+        assert "still running" in captured.out
+        assert "[route]" in captured.out
+
+    def test_quiet_suppresses_heartbeat(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """With ``quiet=True`` no heartbeat line is printed even for a
+        slow child."""
+        cmd = [sys.executable, "-c", "import time; time.sleep(0.25)"]
+        result = _run_subprocess_with_heartbeat(
+            cmd,
+            cwd=".",
+            console=build_cmd.Console(),
+            label="route",
+            quiet=True,
+            heartbeat_interval=0.05,
+        )
+        assert result.returncode == 0
+        captured = capsys.readouterr()
+        assert "still running" not in captured.out
+
+    def test_captures_stdout_and_returncode(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """The helper preserves the ``CompletedProcess`` contract:
+        stdout/stderr are captured and returncode is surfaced."""
+        cmd = [
+            sys.executable,
+            "-c",
+            "import sys; print('hello'); print('bad', file=sys.stderr); sys.exit(3)",
+        ]
+        result = _run_subprocess_with_heartbeat(
+            cmd,
+            cwd=".",
+            console=build_cmd.Console(),
+            label="export",
+            quiet=False,
+            heartbeat_interval=5.0,  # long enough that no heartbeat fires
+        )
+        assert result.returncode == 3
+        assert "hello" in result.stdout
+        assert "bad" in result.stderr
+
+
+def _run_single_step_build(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    quiet: bool,
+    monotonic_values: list[float],
+    step_success: bool = True,
+) -> None:
+    """Drive ``main()`` for a single step with a mocked step runner and
+    a mocked ``time.monotonic`` clock; return captured stdout.
+
+    We target the ERC step because ``_run_step_erc`` is easy to stub and
+    the loop treats ERC failures as non-fatal, keeping the harness
+    simple.  The clock is fed a deterministic list so elapsed values are
+    reproducible.
+    """
+    values = iter(monotonic_values)
+
+    def fake_monotonic() -> float:
+        try:
+            return next(values)
+        except StopIteration:  # pragma: no cover - defensive
+            return monotonic_values[-1]
+
+    monkeypatch.setattr(build_cmd.time, "monotonic", fake_monotonic)
+
+    def fake_erc(ctx: Any, console: Any) -> BuildResult:
+        return BuildResult(
+            step="erc",
+            success=step_success,
+            message="ERC passed" if step_success else "ERC found issues",
+        )
+
+    monkeypatch.setattr(build_cmd, "_run_step_erc", fake_erc)
+
+    argv = [str(tmp_path), "--step", "erc"]
+    if quiet:
+        argv.append("--quiet")
+
+    build_cmd.main(argv)
+
+
+class TestMainLedgerTimings:
+    """``main()`` prints per-step elapsed and a total on the summary."""
+
+    def test_step_ledger_includes_elapsed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Clock sequence: build_start=0.0, step_start=0.0, step_end=24.3,
+        # summary=25.0.
+        _run_single_step_build(
+            monkeypatch,
+            tmp_path,
+            quiet=False,
+            monotonic_values=[0.0, 0.0, 24.3, 25.0],
+        )
+        out = capsys.readouterr().out
+        assert "24.3s" in out, out
+        assert "erc" in out
+
+    def test_summary_includes_total_elapsed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _run_single_step_build(
+            monkeypatch,
+            tmp_path,
+            quiet=False,
+            monotonic_values=[0.0, 0.0, 1.0, 272.0],
+        )
+        out = capsys.readouterr().out
+        # Total elapsed = 272.0 - 0.0 -> "4m32s".
+        assert re.search(r"in 4m32s", out), out
+
+    def test_quiet_suppresses_all_timing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _run_single_step_build(
+            monkeypatch,
+            tmp_path,
+            quiet=True,
+            monotonic_values=[0.0, 0.0, 24.3, 25.0],
+        )
+        out = capsys.readouterr().out
+        assert "24.3s" not in out
+        assert "4m32s" not in out
+        # Quiet build prints nothing at all.
+        assert out.strip() == "", repr(out)
+
+    def test_summary_total_matches_duration_regex(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Acceptance: the summary line carries a duration token in
+        either ``\\d+\\.\\d+s`` or ``\\d+m\\d+s`` form."""
+        _run_single_step_build(
+            monkeypatch,
+            tmp_path,
+            quiet=False,
+            monotonic_values=[0.0, 0.0, 1.0, 5.5],
+        )
+        out = capsys.readouterr().out
+        assert re.search(r"in (\d+m\d+s|\d+\.\d+s)", out), out
+
+
+class TestHeartbeatUsesMonotonic:
+    """Regression guard: heartbeat elapsed derives from monotonic."""
+
+    def test_helper_reads_module_monotonic(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """The heartbeat's elapsed value is computed from
+        ``time.monotonic`` (not wall-clock ``time.time``).  We patch the
+        module's ``time.monotonic`` to advance by a fixed amount and
+        assert the emitted elapsed reflects it."""
+        clock = {"t": 100.0}
+
+        real_monotonic = time.monotonic
+
+        def fake_monotonic() -> float:
+            # First call (start) returns 100.0; subsequent calls advance.
+            clock["t"] += 40.0
+            return clock["t"]
+
+        monkeypatch.setattr(build_cmd.time, "monotonic", fake_monotonic)
+
+        cmd = [sys.executable, "-c", "import time; time.sleep(0.2)"]
+        try:
+            result = _run_subprocess_with_heartbeat(
+                cmd,
+                cwd=".",
+                console=build_cmd.Console(),
+                label="verify",
+                quiet=False,
+                heartbeat_interval=0.05,
+            )
+        finally:
+            monkeypatch.setattr(build_cmd.time, "monotonic", real_monotonic)
+        assert result.returncode == 0
+        out = capsys.readouterr().out
+        # The mocked clock jumps 40s per read, so the heartbeat should
+        # report a "40s"-scale elapsed rather than the real ~0.2s.
+        assert "still running" in out
+        assert re.search(r"\d+(\.\d+)?s elapsed", out), out

--- a/tests/test_build_export_step.py
+++ b/tests/test_build_export_step.py
@@ -155,7 +155,7 @@ class TestRunStepExport:
         )
         console = Console(quiet=True)
 
-        with patch("subprocess.run") as mock_run:
+        with patch("kicad_tools.cli.build_cmd._run_subprocess_with_heartbeat") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
             result = _run_step_export(ctx, console)
 
@@ -173,7 +173,7 @@ class TestRunStepExport:
         )
         console = Console(quiet=True)
 
-        with patch("subprocess.run") as mock_run:
+        with patch("kicad_tools.cli.build_cmd._run_subprocess_with_heartbeat") as mock_run:
             mock_run.return_value = MagicMock(returncode=1, stderr="export error", stdout="")
             result = _run_step_export(ctx, console)
 
@@ -211,7 +211,7 @@ class TestRunStepExport:
         )
         console = Console(quiet=True)
 
-        with patch("subprocess.run") as mock_run:
+        with patch("kicad_tools.cli.build_cmd._run_subprocess_with_heartbeat") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
             _run_step_export(ctx, console)
 
@@ -238,7 +238,7 @@ class TestRunStepExport:
         )
         console = Console(quiet=True)
 
-        with patch("subprocess.run") as mock_run:
+        with patch("kicad_tools.cli.build_cmd._run_subprocess_with_heartbeat") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
             _run_step_export(ctx, console)
 
@@ -267,7 +267,7 @@ class TestRunStepExport:
         )
         console = Console(quiet=True)
 
-        with patch("subprocess.run") as mock_run:
+        with patch("kicad_tools.cli.build_cmd._run_subprocess_with_heartbeat") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
             _run_step_export(ctx, console)
 

--- a/tests/test_build_placement_step.py
+++ b/tests/test_build_placement_step.py
@@ -85,7 +85,7 @@ class TestRunStepPlacement:
         ctx = self._make_ctx(tmp_path, optimize_placement=True, pcb_file=pcb, quiet=True)
         console = Console(quiet=True)
 
-        with patch("kicad_tools.cli.build_cmd.subprocess.run") as mock_run:
+        with patch("kicad_tools.cli.build_cmd._run_subprocess_with_heartbeat") as mock_run:
             mock_run.return_value.returncode = 0
             result = _run_step_placement(ctx, console)
 
@@ -104,7 +104,7 @@ class TestRunStepPlacement:
         ctx = self._make_ctx(tmp_path, optimize_placement=True, pcb_file=pcb, quiet=True)
         console = Console(quiet=True)
 
-        with patch("kicad_tools.cli.build_cmd.subprocess.run") as mock_run:
+        with patch("kicad_tools.cli.build_cmd._run_subprocess_with_heartbeat") as mock_run:
             mock_run.return_value.returncode = 1
             mock_run.return_value.stderr = "optimization error"
             result = _run_step_placement(ctx, console)

--- a/tests/test_route_exit_codes.py
+++ b/tests/test_route_exit_codes.py
@@ -738,7 +738,10 @@ class TestBuildCmdExitCodeHandling:
 
         console = MagicMock()
 
-        with patch("kicad_tools.cli.build_cmd.subprocess.run", return_value=mock_result):
+        with patch(
+            "kicad_tools.cli.build_cmd._run_subprocess_with_heartbeat",
+            return_value=mock_result,
+        ):
             # Mock _get_routing_params to avoid needing a real spec
             with patch(
                 "kicad_tools.cli.build_cmd._get_routing_params",


### PR DESCRIPTION
## Summary

`kct build` printed `[OK]/[FAIL]` ledger lines with no elapsed time, and shelled out to several sub-steps via `subprocess.run(capture_output=...)` — so placement, route-fallback, verify (DRC/sync), and export went completely silent for minutes at a time, indistinguishable from a hang. This adds per-step timings, a total build wall-clock, and a bounded-interval heartbeat for the previously-silent subprocess sites.

## Changes

- **Per-step elapsed:** wrap each step invocation in `main()` with `time.monotonic()` and print elapsed on the ledger line, e.g. `[OK] route: ... (24.3s)`.
- **Summary total:** append total wall-clock elapsed to the build summary, e.g. `Build completed successfully (14/14 steps) in 4m32s` (also on the failure line).
- **Heartbeat helper:** new `_run_subprocess_with_heartbeat()` captures stdout/stderr (same `CompletedProcess` contract as `subprocess.run`) but spawns a daemon thread that emits `[label]: still running, Xs elapsed` every 30s while the child is alive. `--quiet` suppresses it. The four silent sites (placement, route fallback, verify DRC + sync, export) now route through it.
- **Formatter:** `_format_elapsed()` renders monotonic deltas — fractional seconds under a minute (`24.3s`), `MmSSs` above (`4m32s`), with carry handling so it never emits `1m60s`.
- Repointed existing `subprocess.run` mocks (export, route exit-code, placement) to the new helper.

All timing derives from `time.monotonic()`. No changes to `BuildResult`, `BuildContext`, `BuildStep`, or the argument parser; `--heartbeat-interval` was intentionally not added.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Every step prints elapsed seconds on its ledger line | ✅ | Real build: `[OK] export: ... (8.9s)`, `[FAIL] verify: ... (1.5s)`; test `test_step_ledger_includes_elapsed` |
| Long subprocess steps stream/heartbeat within ≤60s; `--quiet` suppresses | ✅ | Manual smoke fires `[route]: still running, 0.4s elapsed` at a 0.4s interval; tests `test_emits_heartbeat_for_slow_process`, `test_quiet_suppresses_heartbeat` |
| Summary includes total wall-clock | ✅ | Real build: `Build completed successfully (1/1 steps) in 8.9s`; tests `test_summary_includes_total_elapsed`, `test_summary_total_matches_duration_regex` |
| Timing based on `time.monotonic()` | ✅ | `_format_elapsed`/heartbeat/loop/summary all use `time.monotonic()`; mockable-clock tests patch `build_cmd.time.monotonic` |
| `--quiet` suppresses all timing output | ✅ | Test `test_quiet_suppresses_all_timing` asserts empty output |
| No change to `BuildResult`/`BuildContext`/`BuildStep`/arg parser | ✅ | Diff confined to `main()` loop, summary, and the silent step call sites |

## Test Plan

- New `tests/test_build_cmd_timings.py`: formatter, heartbeat (visible/quiet/captured-output), mockable-clock through `main()`, quiet suppression, summary regex, monotonic-derived heartbeat.
- Extended `tests/test_build_cmd_stdout_streaming.py` with heartbeat streaming/suppression tests.
- `uv run pytest` on all affected suites (timings, streaming, export, errors, placement, route-exit-codes, mfr-profile): **145 passed**.
- `uv run ruff check` / `ruff format` clean on all changed files; `mypy src/kicad_tools/cli/build_cmd.py` reports only the 3 pre-existing errors (verified identical on base).
- Manual: `uv run kct build boards/00-simple-led --step {export,verify}` shows per-step `(Xs)` and summary `in Xs`; heartbeat smoke fires within the interval. Board-00 output artifacts regenerated during verification were reverted (out of scope).

Closes #3944