### PR TITLE
test(rtree): make R-tree perf benchmarks noise-robust with interleaved min-of-N

### DIFF
--- a/tests/test_router_via_rtree_perf.py
+++ b/tests/test_router_via_rtree_perf.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import math
 import random
-import time
+import timeit
 
 import pytest
 
@@ -298,78 +298,125 @@ class TestViaRtreeCorrectness:
 # ---------------------------------------------------------------------------
 
 
+def _measure_via_rtree_ratio(n_trials: int = 5, n_iters: int = 1) -> tuple[float, float, float]:
+    """Measure the R-tree/linear-scan via-clearance timing ratio robustly.
+
+    Builds a 1000-via grid and 200 ``path_is_clear`` queries once, then
+    runs ``n_trials`` *interleaved* (R-tree, linear) measurement rounds --
+    each round times ``n_iters`` full passes over the 200 queries -- and
+    takes the **minimum** wall-clock for each path.
+
+    Interleaving means a transient CPU-contention spike (xdist sibling
+    workers, shared CI-runner neighbors) tends to hit both paths in the
+    same round rather than biasing one; taking the min discards
+    scheduler-noise-polluted rounds, since the minimum is the best
+    estimator of true cost for a deterministic micro-benchmark.  The
+    original single ``time.perf_counter()`` pair had no such protection
+    and flaked (observed ``ratio=1.855``) when the R-tree block happened
+    to land in a scheduler contention window (issue #3949).
+
+    Returns:
+        (ratio, rtree_min, linear_min) where ``ratio = rtree_min /
+        linear_min``.
+    """
+    grid = _make_grid(width=100.0, height=100.0)
+    # 1000 vias is a strict superset of any real board's via count.
+    _populate_vias(grid, 1000, width=100.0, height=100.0)
+
+    checker = VectorCollisionChecker(grid)
+    rng = random.Random(0xBEEF)
+
+    queries: list[tuple[float, float, float, float]] = []
+    for _ in range(200):
+        x1 = rng.uniform(0.5, 99.5)
+        y1 = rng.uniform(0.5, 99.5)
+        angle = rng.uniform(0, 2 * math.pi)
+        length = rng.uniform(0.5, 5.0)
+        x2 = x1 + math.cos(angle) * length
+        y2 = y1 + math.sin(angle) * length
+        queries.append((x1, y1, x2, y2))
+
+    saved_rtree = grid._via_rtree
+    saved_items = grid._via_rtree_items
+
+    def run_rtree() -> None:
+        for x1, y1, x2, y2 in queries:
+            checker.path_is_clear(x1, y1, x2, y2, Layer.F_CU, 0.2, exclude_net=999)
+
+    def run_linear() -> None:
+        # Null the index so the collision checker's fallback branch
+        # (linear scan over ``grid.routes``) runs, then restore it.
+        grid._via_rtree = None
+        grid._via_rtree_items = {}
+        try:
+            for x1, y1, x2, y2 in queries:
+                checker.path_is_clear(x1, y1, x2, y2, Layer.F_CU, 0.2, exclude_net=999)
+        finally:
+            grid._via_rtree = saved_rtree
+            grid._via_rtree_items = saved_items
+
+    # Warm up both paths so first-call lazy imports / index access don't
+    # taint the comparison.
+    run_rtree()
+    run_linear()
+
+    rtree_min = float("inf")
+    linear_min = float("inf")
+    for _ in range(n_trials):
+        rtree_min = min(rtree_min, timeit.timeit(run_rtree, number=n_iters))
+        linear_min = min(linear_min, timeit.timeit(run_linear, number=n_iters))
+
+    ratio = rtree_min / max(linear_min, 1e-9)
+    return ratio, rtree_min, linear_min
+
+
 class TestViaRtreePerformance:
     """The R-tree query must be significantly faster than the linear scan.
 
     The synthetic workload mirrors the optimizer hot path: thousands of
     short-segment ``path_is_clear`` calls against hundreds of foreign
-    vias.  The R-tree should reduce wall-clock by 5x+ on this size; we
-    assert a conservative 2x to keep the test stable on slow CI.
+    vias.  The R-tree should reduce wall-clock by 5x+ on this size.
 
     Issue #2960 acceptance criterion: "synthetic grid with 1000 vias +
     100 path_is_clear calls; wall-clock <5% of linear-scan baseline".
-    The bound below (<20% of linear, i.e. >5x speedup) over a tighter
-    workload (1000 vias / 200 calls) satisfies that criterion.
+    The nightly ``slow`` variant (<0.2 of linear, i.e. >5x speedup) over
+    a tighter workload (1000 vias / 200 calls) satisfies that criterion;
+    the per-PR guard uses a generous noise-tolerant bound instead.
     """
 
     def test_rtree_query_faster_than_linear_scan(self) -> None:
-        grid = _make_grid(width=100.0, height=100.0)
-        # 1000 vias is a strict superset of any real board's via count.
-        _populate_vias(grid, 1000, width=100.0, height=100.0)
+        """Per-PR guard: R-tree query is faster than the linear scan.
 
-        checker = VectorCollisionChecker(grid)
-        rng = random.Random(0xBEEF)
+        Uses interleaved min-of-N ``timeit`` trials (see
+        ``_measure_via_rtree_ratio``) so a transient scheduler spike
+        cannot bias a single measurement.  The bound is a generous,
+        noise-tolerant ``ratio < 0.75`` (R-tree runs in under 75% of
+        linear time) -- still a meaningful regression signal with ~25%
+        headroom above the real ~10x speedup floor.  The tight design
+        target is asserted in the nightly ``slow`` variant below.
+        """
+        ratio, rtree_min, linear_min = _measure_via_rtree_ratio()
+        assert ratio < 0.75, (
+            f"R-tree query is not faster than linear scan: "
+            f"rtree={rtree_min * 1000:.2f}ms, "
+            f"linear={linear_min * 1000:.2f}ms, "
+            f"ratio={ratio:.3f} (min of 5 interleaved trials; expected "
+            f"<0.75, CI noise budget; see issue #3949)."
+        )
 
-        queries: list[tuple[float, float, float, float]] = []
-        for _ in range(200):
-            x1 = rng.uniform(0.5, 99.5)
-            y1 = rng.uniform(0.5, 99.5)
-            angle = rng.uniform(0, 2 * math.pi)
-            length = rng.uniform(0.5, 5.0)
-            x2 = x1 + math.cos(angle) * length
-            y2 = y1 + math.sin(angle) * length
-            queries.append((x1, y1, x2, y2))
+    @pytest.mark.slow
+    def test_rtree_query_faster_than_linear_scan_tight(self) -> None:
+        """Nightly tight guard: R-tree query is >5x faster than linear scan.
 
-        # R-tree path: time the real collision checker.
-        # Warm-up so the first-call lazy import / index access doesn't
-        # taint the comparison.
-        for x1, y1, x2, y2 in queries[:5]:
-            checker.path_is_clear(x1, y1, x2, y2, Layer.F_CU, 0.2, exclude_net=999)
-        start = time.perf_counter()
-        for x1, y1, x2, y2 in queries:
-            checker.path_is_clear(x1, y1, x2, y2, Layer.F_CU, 0.2, exclude_net=999)
-        rtree_elapsed = time.perf_counter() - start
-
-        # Linear-scan path: re-run with the via R-tree disabled to
-        # simulate the pre-#2960 behaviour.  We point the checker at
-        # the grid AFTER nulling the index so the collision checker's
-        # fallback branch (linear scan over ``grid.routes``) runs.
-        saved_rtree = grid._via_rtree
-        saved_items = grid._via_rtree_items
-        try:
-            grid._via_rtree = None
-            grid._via_rtree_items = {}
-            for x1, y1, x2, y2 in queries[:5]:
-                checker.path_is_clear(x1, y1, x2, y2, Layer.F_CU, 0.2, exclude_net=999)
-            start = time.perf_counter()
-            for x1, y1, x2, y2 in queries:
-                checker.path_is_clear(x1, y1, x2, y2, Layer.F_CU, 0.2, exclude_net=999)
-            linear_elapsed = time.perf_counter() - start
-        finally:
-            grid._via_rtree = saved_rtree
-            grid._via_rtree_items = saved_items
-
-        # The R-tree must run at no more than 50% of the linear scan
-        # time on this workload.  We choose 50% (rather than the 5%
-        # bound from the issue description) to keep the assertion
-        # robust against slow CI and Python interpreter variance; in
-        # practice we observe ~10x speedup locally.  The slope of the
-        # underlying complexity gap is O(V) -> O(log V), so the bound
-        # is conservative.
-        ratio = rtree_elapsed / max(linear_elapsed, 1e-9)
-        assert ratio < 0.5, (
-            f"R-tree query is not significantly faster than linear scan: "
-            f"rtree={rtree_elapsed * 1000:.2f}ms, "
-            f"linear={linear_elapsed * 1000:.2f}ms, "
-            f"ratio={ratio:.3f} (expected <0.5)"
+        Runs only in the nightly ``slow-tests`` lane (and locally via
+        ``pytest -m slow``), where interleaved min-of-N sampling makes a
+        tighter bound reliable.  Asserts the issue #2960 design
+        acceptance criterion (``ratio < 0.2``, i.e. >5x speedup).
+        """
+        ratio, rtree_min, linear_min = _measure_via_rtree_ratio()
+        assert ratio < 0.2, (
+            f"R-tree query is not >5x faster than linear scan: "
+            f"rtree={rtree_min * 1000:.2f}ms, "
+            f"linear={linear_min * 1000:.2f}ms, "
+            f"ratio={ratio:.3f} (expected <0.2)."
         )

--- a/tests/test_rtree_segment_index.py
+++ b/tests/test_rtree_segment_index.py
@@ -7,7 +7,7 @@ works when rtree is unavailable.
 """
 
 import random
-import time
+import timeit
 
 import pytest
 
@@ -512,62 +512,130 @@ class TestRtreeThreshold:
 # ---------------------------------------------------------------------------
 
 
+def _measure_segment_rtree_speedup(
+    rules, n_trials: int = 5, n_iters: int = 1
+) -> tuple[float, float, float]:
+    """Measure the R-tree/brute-force segment-clearance speedup robustly.
+
+    Builds a ~200-segment grid once, then runs ``n_trials`` *interleaved*
+    (R-tree, brute-force) measurement rounds -- each round times
+    ``n_iters`` full passes over the 100 queries -- and takes the
+    **minimum** wall-clock for each path.
+
+    Interleaving means a transient CPU-contention spike (xdist sibling
+    workers, shared CI-runner neighbors) tends to hit both paths in the
+    same round rather than biasing one; taking the min discards
+    scheduler-noise-polluted rounds, since the minimum is the best
+    estimator of true cost for a deterministic micro-benchmark.  The
+    original single ``time.perf_counter()`` pair had no such protection
+    and flaked when the R-tree block happened to land in a scheduler
+    contention window (issue #3949).
+
+    Returns:
+        (speedup, rtree_min, brute_min) where ``speedup = brute_min /
+        rtree_min``.
+    """
+    grid = RoutingGrid(width=100.0, height=100.0, rules=rules)
+
+    # Populate with ~200 segments across 40 nets
+    rng = random.Random(42)
+    for i in range(40):
+        net = i + 1
+        segs = []
+        x = rng.uniform(5.0, 90.0)
+        y = rng.uniform(5.0, 90.0)
+        for _ in range(5):
+            x2 = max(2.0, min(98.0, x + rng.uniform(-8.0, 8.0)))
+            y2 = max(2.0, min(98.0, y + rng.uniform(-8.0, 8.0)))
+            segs.append(_make_segment(x, y, x2, y2, net=net))
+            x, y = x2, y2
+        grid.mark_route(_make_route(segs, net=net))
+
+    assert grid._seg_rtree_count >= 200
+
+    # Prepare queries
+    queries = []
+    for _ in range(100):
+        x1 = rng.uniform(5.0, 95.0)
+        y1 = rng.uniform(5.0, 95.0)
+        x2 = x1 + rng.uniform(-10.0, 10.0)
+        y2 = y1 + rng.uniform(-10.0, 10.0)
+        queries.append(_make_segment(x1, y1, x2, y2, net=999))
+
+    saved = grid._seg_rtree_count
+
+    def run_rtree() -> None:
+        for q in queries:
+            grid.validate_segment_clearance(q, exclude_net=999)
+
+    def run_brute() -> None:
+        # Force the count below threshold so the brute-force path runs.
+        grid._seg_rtree_count = 0
+        try:
+            for q in queries:
+                grid.validate_segment_clearance(q, exclude_net=999)
+        finally:
+            grid._seg_rtree_count = saved
+
+    # Warm up -- prime lazy imports / caches for both paths.
+    run_rtree()
+    run_brute()
+
+    rtree_min = float("inf")
+    brute_min = float("inf")
+    for _ in range(n_trials):
+        rtree_min = min(rtree_min, timeit.timeit(run_rtree, number=n_iters))
+        brute_min = min(brute_min, timeit.timeit(run_brute, number=n_iters))
+
+    speedup = brute_min / rtree_min if rtree_min > 0 else float("inf")
+    return speedup, rtree_min, brute_min
+
+
 class TestRtreePerformance:
     """Benchmark: R-tree should be faster than brute-force at scale."""
 
     @pytest.mark.skipif(not RTREE_AVAILABLE, reason="rtree not installed")
     def test_rtree_faster_at_200_segments(self, rules):
-        """R-tree query at 200+ segments is measurably faster than brute-force."""
-        grid = RoutingGrid(width=100.0, height=100.0, rules=rules)
+        """Per-PR guard: R-tree path does not regress vs brute-force.
 
-        # Populate with ~200 segments across 40 nets
-        rng = random.Random(42)
-        for i in range(40):
-            net = i + 1
-            segs = []
-            x = rng.uniform(5.0, 90.0)
-            y = rng.uniform(5.0, 90.0)
-            for _ in range(5):
-                x2 = max(2.0, min(98.0, x + rng.uniform(-8.0, 8.0)))
-                y2 = max(2.0, min(98.0, y + rng.uniform(-8.0, 8.0)))
-                segs.append(_make_segment(x, y, x2, y2, net=net))
-                x, y = x2, y2
-            grid.mark_route(_make_route(segs, net=net))
+        Uses interleaved min-of-N ``timeit`` trials (see
+        ``_measure_segment_rtree_speedup``) so a transient scheduler
+        spike cannot bias a single measurement.  At only 200 segments the
+        R-tree advantage over O(N) brute-force is shallow, so the per-PR
+        bound is a generous, noise-tolerant ``> 0.5`` (runtime at most 2x
+        brute-force).  The real speedup grows with N and is asserted
+        tightly in the nightly ``slow`` variant below.
+        """
+        speedup, rtree_min, brute_min = _measure_segment_rtree_speedup(rules)
+        # Log for diagnostic visibility even if the assertion passes.
+        print(
+            f"\nR-tree: {rtree_min:.4f}s, Brute: {brute_min:.4f}s, "
+            f"Speedup: {speedup:.2f}x (min of 5 interleaved trials)"
+        )
+        assert speedup > 0.5, (
+            f"R-tree path was unexpectedly slow: {speedup:.2f}x "
+            f"(rtree_min={rtree_min:.4f}s, brute_min={brute_min:.4f}s, "
+            f"min of 5 interleaved trials).  Expected speedup > 0.5 "
+            f"(CI noise budget; see issue #3949)."
+        )
 
-        assert grid._seg_rtree_count >= 200
+    @pytest.mark.slow
+    @pytest.mark.skipif(not RTREE_AVAILABLE, reason="rtree not installed")
+    def test_rtree_faster_at_200_segments_tight(self, rules):
+        """Nightly tight guard: R-tree is meaningfully faster than brute-force.
 
-        # Prepare queries
-        queries = []
-        for _ in range(100):
-            x1 = rng.uniform(5.0, 95.0)
-            y1 = rng.uniform(5.0, 95.0)
-            x2 = x1 + rng.uniform(-10.0, 10.0)
-            y2 = y1 + rng.uniform(-10.0, 10.0)
-            queries.append(_make_segment(x1, y1, x2, y2, net=999))
-
-        # Time R-tree path
-        t0 = time.perf_counter()
-        for q in queries:
-            grid.validate_segment_clearance(q, exclude_net=999)
-        rtree_time = time.perf_counter() - t0
-
-        # Time brute-force path (by forcing count below threshold)
-        saved = grid._seg_rtree_count
-        grid._seg_rtree_count = 0
-        t0 = time.perf_counter()
-        for q in queries:
-            grid.validate_segment_clearance(q, exclude_net=999)
-        brute_time = time.perf_counter() - t0
-        grid._seg_rtree_count = saved
-
-        # R-tree should be at least 1.5x faster (conservative bound).
-        # The issue targets 2x but we use a looser bound for CI stability.
-        speedup = brute_time / rtree_time if rtree_time > 0 else float("inf")
-        # Log for diagnostic visibility even if the assertion passes
-        print(f"\nR-tree: {rtree_time:.4f}s, Brute: {brute_time:.4f}s, Speedup: {speedup:.2f}x")
-        # On small synthetic boards the speedup can vary; ensure at minimum
-        # that the R-tree path does not regress performance.
-        assert speedup > 0.8, (
-            f"R-tree path was unexpectedly slower: {speedup:.2f}x "
-            f"(rtree={rtree_time:.4f}s, brute={brute_time:.4f}s)"
+        Runs only in the nightly ``slow-tests`` lane (and locally via
+        ``pytest -m slow``), where interleaved min-of-N sampling makes a
+        tighter bound reliable.  Asserts the documented target that the
+        R-tree path outpaces brute-force (``speedup > 1.5``).
+        """
+        speedup, rtree_min, brute_min = _measure_segment_rtree_speedup(rules)
+        print(
+            f"\nR-tree: {rtree_min:.4f}s, Brute: {brute_min:.4f}s, "
+            f"Speedup: {speedup:.2f}x (min of 5 interleaved trials)"
+        )
+        assert speedup > 1.5, (
+            f"R-tree path is not meaningfully faster than brute-force: "
+            f"{speedup:.2f}x (rtree_min={rtree_min:.4f}s, "
+            f"brute_min={brute_min:.4f}s).  Expected speedup > 1.5."
         )


### PR DESCRIPTION
## Summary

Two R-tree performance microbenchmarks flaked and turned the required CI `Test` job red under scheduler noise on shared runners. Each measured a single back-to-back `time.perf_counter()` pair (accelerated block then reference block) with no interleaving or min-of-N sampling, so a CPU-contention window landing on the R-tree block flipped the ratio (observed: segment `speedup=0.15x`, via `ratio=1.855`).

This refactors both to the canonical interleaved `timeit` min-of-N two-tier pattern already established in `tests/perf/test_pathfinder_dormant_partner_perf.py` (`_measure_dormant_ratio`).

## Changes

- **`tests/test_rtree_segment_index.py`**: Extract `_measure_segment_rtree_speedup(rules)` — builds the ~200-segment grid + 100 queries once, warms up both paths, then runs 5 interleaved (R-tree, brute-force) `timeit` rounds and takes the min per path. `test_rtree_faster_at_200_segments` now asserts a generous noise-tolerant `speedup > 0.5`; a new `@pytest.mark.slow` `test_rtree_faster_at_200_segments_tight` asserts `speedup > 1.5`. Swapped `import time` → `import timeit`.
- **`tests/test_router_via_rtree_perf.py`**: Extract `_measure_via_rtree_ratio()` (1000 vias / 200 queries, same interleaved min-of-N structure). `test_rtree_query_faster_than_linear_scan` now asserts `ratio < 0.75`; a new `@pytest.mark.slow` `test_rtree_query_faster_than_linear_scan_tight` asserts `ratio < 0.2` (the issue #2960 design criterion). Swapped `import time` → `import timeit`.
- Correctness classes untouched. No production, `pyproject.toml`, or CI-workflow changes; uses the already-registered `slow` marker.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| CI `Test` job (`-m "not slow"`) can't be turned red by scheduler noise | ✅ | 12 back-to-back measurement runs: segment speedup 9.01x–10.58x (bound >0.5), via ratio 0.1573–0.1840 (bound <0.75) — orders of magnitude of headroom |
| Perf regression signal preserved | ✅ | Both tests remain in the default suite with generous bounds; tight variants run nightly in `slow-tests.yml` |
| Correctness classes unmodified & still default-collected | ✅ | `-m "not slow"` collects 27 tests across both files; only timing assertions restructured |
| Slow variants assert tighter bounds | ✅ | segment `>1.5`, via `<0.2`; `-m slow` selects exactly the 2 new variants and both pass |
| No new pytest markers | ✅ | Reuses existing `slow` marker from `pyproject.toml` |

## Test Plan

- `pytest tests/test_rtree_segment_index.py tests/test_router_via_rtree_perf.py tests/perf/` → 29 passed, 1 skipped (default run, green)
- `pytest ... -m slow` → 2 passed, 27 deselected; `-m "not slow"` collects 27
- 12-run stability sweep (see above) — no run approached any per-PR or slow bound
- `ruff check` / `ruff format` clean on both files

Closes #3949