### PR TITLE
fix(drc): refill zones in geometric cross-check + truthful board-03 DRC message

### DIFF
--- a/boards/03-usb-joystick/route_demo.py
+++ b/boards/03-usb-joystick/route_demo.py
@@ -47,15 +47,33 @@ warn_if_stale()
 
 
 def run_drc(pcb_path: Path) -> tuple[bool, int, int]:
-    """Run DRC on the PCB using kct check for consistent results.
+    """Run DRC on the routed PCB and return a truthful (passed, errors, warnings).
 
     Issue #3150 / #3308: align the local DRC summary with the
     jlcpcb-tier1 profile this board ships and is gated against (see
     ``.github/routed-drc-tolerance.yml`` and
     ``generate_design.py:run_drc()``).
 
+    Issue #3969 (Bug B): this used to call ``kct check`` WITHOUT
+    ``--drc-only``.  That runs the *meta-check rollup* (DRC + ERC + LVS +
+    Manifest).  On a fresh route the PCB lives in a directory with no
+    ERC/LVS/Manifest artifacts, so those sub-checks are ``NOT RUN`` and
+    the rollup exits ``INCOMPLETE`` (exit code 2) even though the DRC
+    engine itself found ``Errors: 0``.  The old code read
+    ``returncode != 0`` as ``drc_passed=False``, parsed 0 errors, and the
+    caller then printed the logically impossible
+    ``"0 DRC violation(s) detected!"`` banner.
+
+    The fix mirrors ``generate_design.py:run_drc()``: add ``--drc-only``
+    so the exit code reflects *geometric DRC only* (non-zero iff
+    ``error_count > 0``).  This guarantees the invariant the caller relies
+    on -- ``passed`` is True iff ``errors == 0`` -- so the "0 violations
+    detected" message can never appear on a failing exit.
+
     Returns:
-        Tuple of (success, error_count, warning_count)
+        Tuple of (passed, error_count, warning_count).  ``passed`` is True
+        exactly when ``error_count == 0``.  On a hard failure to run the
+        checker, returns ``(False, -1, -1)``.
     """
     try:
         result = subprocess.run(
@@ -67,6 +85,11 @@ def run_drc(pcb_path: Path) -> tuple[bool, int, int]:
                 str(pcb_path),
                 "--mfr",
                 "jlcpcb-tier1",
+                # Issue #3969: scope to geometric DRC so a fresh-route temp
+                # dir without ERC/LVS/Manifest artifacts does not exit
+                # INCOMPLETE (2) and get misread as a DRC failure with 0
+                # parsed errors.  Matches generate_design.py:run_drc().
+                "--drc-only",
             ],
             capture_output=True,
             text=True,
@@ -83,7 +106,13 @@ def run_drc(pcb_path: Path) -> tuple[bool, int, int]:
                 with contextlib.suppress(ValueError):
                     warning_count = int(line.split(":")[-1].strip())
 
-        return result.returncode == 0, error_count, warning_count
+        # Issue #3969: derive ``passed`` from the parsed error count, not
+        # solely the exit code, so the (passed, errors) pair is always
+        # self-consistent.  With --drc-only the exit code already tracks
+        # error_count, but keying off the count as well makes the "0
+        # violations on a failing exit" banner structurally impossible.
+        passed = result.returncode == 0 and error_count == 0
+        return passed, error_count, warning_count
 
     except Exception as e:
         print(f"  Warning: DRC check failed: {e}")
@@ -154,8 +183,18 @@ def main():
         print("SUCCESS: All nets routed, DRC passed!")
         exit_code = 0
     elif success and not drc_passed:
-        print(f"WARNING: All nets routed, but {drc_errors} DRC violation(s) detected!")
-        print("  Review DRC errors before manufacturing.")
+        # Issue #3969 (Bug B): never claim "0 DRC violation(s) detected!"
+        # on a failing path.  run_drc() now guarantees drc_passed is False
+        # only when errors are present (drc_errors > 0) or the checker
+        # could not run (drc_errors == -1).  Word the banner to match
+        # whichever case actually occurred instead of blindly printing the
+        # count.
+        if drc_errors > 0:
+            print(f"WARNING: All nets routed, but {drc_errors} DRC violation(s) detected!")
+            print("  Review DRC errors before manufacturing.")
+        else:
+            print("WARNING: All nets routed, but the DRC check could not be completed.")
+            print("  Re-run 'kct check' manually before manufacturing.")
         exit_code = 1
     else:
         # ``route_pcb`` already printed the per-net partial line; here we
@@ -164,7 +203,12 @@ def main():
         # is within the jlcpcb-tier1 ceiling.
         print("PARTIAL: not all nets routed (see route_pcb output above)")
         if not drc_passed:
-            print(f"  Additionally, {drc_errors} DRC violation(s) detected.")
+            # Issue #3969: only report a violation *count* when there
+            # actually is one; otherwise say the DRC could not complete.
+            if drc_errors > 0:
+                print(f"  Additionally, {drc_errors} DRC violation(s) detected.")
+            else:
+                print("  Additionally, the DRC check could not be completed.")
         # Partial routing is acceptable for this board; the USB-C
         # connector pad density exceeds what a 2-layer autorouter can
         # fully handle.  Match the approach used by generate_design.py:

--- a/src/kicad_tools/drc/geometric.py
+++ b/src/kicad_tools/drc/geometric.py
@@ -83,6 +83,19 @@ def run_geometric_drc(
     the manufacturer's fab-accurate rules with ``lib_footprint_mismatch``
     / ``isolated_copper`` already downgraded below error severity.
 
+    Issue #3969: the invocation passes ``--refill-zones`` so kicad-cli
+    re-fills the copper pours from scratch *before* evaluating clearance,
+    exactly as a fab-house DRC (and ``kicad-cli pcb drc --refill-zones``,
+    the acceptance command boards are gated against) does.  Without it,
+    kicad-cli judges the *stale* zone-fill polygons persisted in the
+    ``.kicad_pcb``; those can differ from a fresh fill by sub-micron
+    rounding and manufacture a phantom ``clearance`` violation (board 03
+    reported ``zone clearance 0.3000 mm; actual 0.2996 mm`` -- a 0.4 µm
+    gap that vanishes on refill).  This phantom was latent in the
+    committed board too and only surfaced once PR #3950 wired this
+    cross-check into the post-route gate; refilling makes both engines and
+    the shipped manufacturing bundle judge the same geometry.
+
     This never raises: every failure mode (kicad-cli absent, timeout, no
     report, parse error) returns a :class:`GeometricDRCResult` with
     ``ran=False`` and an explanatory ``note`` so callers can degrade
@@ -114,6 +127,11 @@ def run_geometric_drc(
             str(kicad_cli),
             "pcb",
             "drc",
+            # Issue #3969: refill zones before evaluating so clearance is
+            # judged against a fresh fill (as the fab / the acceptance
+            # command does), not the stale persisted pour polygons that
+            # can carry a sub-micron rounding phantom.
+            "--refill-zones",
             "--format",
             "json",
             "--severity-error",

--- a/tests/test_board_03_regression.py
+++ b/tests/test_board_03_regression.py
@@ -1481,3 +1481,142 @@ def test_joystick_j2_pin1_inside_pcb_edge(regenerated_board: Path) -> None:
         "edge-to-copper clearance, so this will likely DRC-fail.  Pull "
         "J2 back east."
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #3969: two defects on a fresh board-03 build.
+#
+#   Bug A -- ``kicad-cli pcb drc`` was run WITHOUT ``--refill-zones`` in the
+#   shared ``run_geometric_drc`` helper, so it judged the stale persisted
+#   pour polygons.  Those can differ from a fresh fill by sub-micron
+#   rounding, manufacturing a phantom ``clearance`` violation (board 03:
+#   ``zone clearance 0.3000 mm; actual 0.2996 mm`` -- a 0.4 um gap that is
+#   present in the COMMITTED artifact too and vanishes on refill).  The fix
+#   adds ``--refill-zones`` so both engines and the shipped manufacturing
+#   bundle judge the same geometry.
+#
+#   Bug B -- ``route_demo.py:run_drc()`` called ``kct check`` WITHOUT
+#   ``--drc-only``; the meta-check rollup exits INCOMPLETE (2) on a fresh
+#   temp-dir route (no ERC/LVS/Manifest artifacts) even though DRC found 0
+#   errors, and the caller then printed the impossible "0 DRC violation(s)
+#   detected!" banner.  The fix scopes the call to ``--drc-only`` and keys
+#   the ``passed`` verdict off the parsed error count.
+# ---------------------------------------------------------------------------
+
+
+def test_run_geometric_drc_passes_refill_zones() -> None:
+    """Bug A (#3969): the shared helper must invoke kicad-cli with
+    ``--refill-zones`` so clearance is judged against a fresh pour fill,
+    not the stale persisted zone polygons.
+
+    Pure command-construction assertion -- no kicad-cli required.  We
+    capture the ``subprocess.run`` argv the helper builds and assert the
+    refill flag is present.  Without it, the sub-micron stale-fill phantom
+    (``zone clearance 0.3000; actual 0.2996``) re-appears on board 03.
+    """
+    import kicad_tools.drc.geometric as geo_mod
+
+    captured: dict[str, list[str]] = {}
+
+    def _fake_run(cmd, *a, **k):
+        captured["cmd"] = list(cmd)
+
+        class _R:
+            returncode = 0
+
+        return _R()
+
+    # Force the helper past the kicad-cli discovery guard, then intercept
+    # the subprocess call so no real kicad-cli is needed.
+    fake_cli = Path("/usr/bin/kicad-cli")
+    monkey = pytest.MonkeyPatch()
+    try:
+        monkey.setattr(geo_mod.subprocess, "run", _fake_run)
+        # The report file never gets written by our fake, so the helper
+        # returns ran=False -- that is fine; we only assert on the argv.
+        geo_mod.run_geometric_drc(
+            REPO_ROOT / "boards" / "03-usb-joystick" / "output" / "usb_joystick_routed.kicad_pcb",
+            kicad_cli=fake_cli,
+        )
+    finally:
+        monkey.undo()
+
+    cmd = captured.get("cmd")
+    assert cmd is not None, "run_geometric_drc did not invoke subprocess.run"
+    assert "--refill-zones" in cmd, (
+        "run_geometric_drc must pass --refill-zones so kicad-cli judges a "
+        "fresh zone fill (issue #3969); otherwise the stale-fill sub-micron "
+        f"clearance phantom returns.  argv was: {cmd}"
+    )
+    # The refill flag must precede the DRC evaluation flags in the same
+    # invocation (it is a mode flag on `pcb drc`, not a separate step).
+    assert cmd.index("--refill-zones") < cmd.index("--format")
+
+
+def test_committed_routed_board_is_geometrically_clean_with_refill() -> None:
+    """Bug A (#3969) end-to-end: the committed board-03 routed PCB reports
+    0 error-severity geometric violations from the shared helper.
+
+    This is the AC5 guard: the committed artifact must pass
+    ``kicad-cli pcb drc --refill-zones`` at 0 violations.  It exercises the
+    real ``run_geometric_drc`` (now refill-aware) against the committed
+    PCB.  Skipped when kicad-cli is unavailable (CI without KiCad).
+    """
+    from kicad_tools.cli.runner import find_kicad_cli
+    from kicad_tools.drc import run_geometric_drc
+
+    if find_kicad_cli() is None:
+        pytest.skip("kicad-cli not installed")
+    if not ROUTED_PCB_FILE.exists():
+        pytest.skip(f"committed routed board not found at {ROUTED_PCB_FILE!s}")
+
+    result = run_geometric_drc(ROUTED_PCB_FILE)
+
+    assert result.ran is True, f"geometric DRC did not run: {result.note}"
+    assert result.error_count == 0, (
+        "Committed board-03 routed PCB has "
+        f"{result.error_count} error-severity geometric violation(s) after "
+        f"zone refill: {result.by_type}.  Before #3969 this reported a "
+        "phantom 'clearance' violation because zones were not refilled."
+    )
+
+
+def test_route_demo_run_drc_never_reports_zero_errors_on_failure() -> None:
+    """Bug B (#3969): ``route_demo.run_drc()`` must never return the
+    logically impossible ``(passed=False, errors=0)`` pair.
+
+    We drive the function against the (clean) committed board and assert
+    the invariant ``passed == (errors == 0)`` holds.  Because run_drc now
+    uses ``--drc-only``, the meta-check INCOMPLETE (exit 2) path that used
+    to yield ``(False, 0)`` cannot occur.  Skipped without kicad-cli /
+    committed artifact.
+    """
+    import importlib.util
+
+    from kicad_tools.cli.runner import find_kicad_cli
+
+    if find_kicad_cli() is None:
+        pytest.skip("kicad-cli not installed")
+    if not ROUTED_PCB_FILE.exists():
+        pytest.skip(f"committed routed board not found at {ROUTED_PCB_FILE!s}")
+
+    # Import route_demo.py by path (it is a board script, not a package).
+    spec = importlib.util.spec_from_file_location("board03_route_demo", str(ROUTE_DEMO_SCRIPT))
+    assert spec is not None and spec.loader is not None
+    route_demo = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(route_demo)
+
+    passed, errors, _warnings = route_demo.run_drc(ROUTED_PCB_FILE)
+
+    # The core anti-regression: passed is True IFF there are zero errors.
+    # This makes "0 DRC violation(s) detected!" on a failing exit
+    # structurally impossible.
+    assert passed == (errors == 0), (
+        f"run_drc returned inconsistent (passed={passed}, errors={errors}); "
+        "the 'N DRC violation(s) detected' banner would lie.  passed must be "
+        "True exactly when errors == 0 (issue #3969 Bug B)."
+    )
+    # The committed board is clean, so this must be a clean PASS.
+    assert passed is True and errors == 0, (
+        f"committed board-03 expected DRC-clean, got passed={passed}, errors={errors}"
+    )


### PR DESCRIPTION
## Summary

Fixes two defects on a fresh `kct build boards/03-usb-joystick` (issue #3969).

**Bug A — phantom clearance violation.** The shared `run_geometric_drc()` helper ran `kicad-cli pcb drc` **without `--refill-zones`**, so kicad-cli judged the *stale* persisted pour polygons instead of a fresh fill. On board 03 those differ from a fresh fill by a sub-micron rounding artifact and manufacture a phantom `clearance` violation: `zone clearance 0.3000 mm; actual 0.2996 mm` — a **0.4 µm** gap. It vanishes on refill (`--refill-zones` → 0 violations). The fix adds `--refill-zones` so both DRC engines and the shipped manufacturing bundle judge the same geometry.

**Bug B — "0 DRC violation(s) detected!" on a failing exit.** `route_demo.py:run_drc()` called `kct check` **without `--drc-only`**. On a fresh temp-dir route (no ERC/LVS/Manifest artifacts) the meta-check rollup exits INCOMPLETE (2) even though DRC found `Errors: 0`; the caller then printed the logically impossible `"0 DRC violation(s) detected!"` banner. The fix scopes the call to `--drc-only` (matching `generate_design.py:run_drc()`) and derives `passed` from the parsed error count so the `(passed, errors)` pair is always self-consistent.

## The #3956 hypothesis was REFUTED

The curator's prime suspect was PR #3956 (rung dedup) changing board 03's escape copper. Empirical bisection disproves this: the **committed** `usb_joystick_routed.kicad_pcb` (which shipped as "clean") reproduces the *identical* `zone clearance 0.3000; actual 0.2996` phantom when kicad-cli runs without `--refill-zones`. The gap is a pre-existing geometric property, independent of any recent router change — it only surfaced once PR #3950 wired the `run_geometric_drc` cross-check (which omits `--refill-zones`) into the post-route gate. The fix is therefore in the DRC helper, not the router; no router dedup logic was touched.

## Changes

- `src/kicad_tools/drc/geometric.py` — add `--refill-zones` to the `kicad-cli pcb drc` invocation in `run_geometric_drc()` (the shared helper used by both the post-route gate and DesignAuditor).
- `boards/03-usb-joystick/route_demo.py` — `run_drc()` now uses `--drc-only` and keys `passed` off the error count; banners only print a violation *count* when one exists, else say the DRC could not complete.
- `tests/test_board_03_regression.py` — three regression guards (see below).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| AC1: fresh build green + `kicad-cli pcb drc --refill-zones` reports 0 violations | ✅ | Fresh `route_demo.py` → 13/13 nets, `DRC PASSED`; `kicad-cli pcb drc --refill-zones --severity-error` → 0 error-severity violations |
| AC2: failing exit never prints "0 DRC violation(s) detected!" | ✅ | `run_drc()` returns `passed == (errors==0)`; banner branches print a count only when `drc_errors > 0` |
| AC3: regression test cross-checks routed PCB with kicad-cli, asserts 0 | ✅ | `test_committed_routed_board_is_geometrically_clean_with_refill` (skips w/o kicad-cli) |
| AC4: `run_drc()` returns `(True,0,0)` clean / never `(False, 0, _)` | ✅ | `test_route_demo_run_drc_never_reports_zero_errors_on_failure` |
| AC5: committed artifact passes `--refill-zones` at 0 violations | ✅ | Verified via `run_geometric_drc` (now refill-aware) on the committed PCB |

## Test Plan

- Fresh empirical repro at origin/main (0f374e86): reproduced BOTH bugs before the fix.
- Bisection: committed artifact shows the same no-refill phantom → #3956 refuted.
- `uv run pytest tests/test_board_03_regression.py tests/test_route_post_drc_geometric.py tests/test_audit.py tests/test_drc_constraints_export.py` → all pass.
- #3956-adjacent regression suites (`test_cpp_resume_exhaustion_skip_3923.py`, `test_router_integration.py`, `test_layer_escalation.py`, `test_checkpoint_in_escalation.py`) → 123 passed, no regressions.
- `ruff check` / `ruff format` clean on all changed files.

Note: an untrusted zip attachment from a non-collaborator comment on the issue was ignored; no third-party code was used.

Closes #3969

🤖 Generated with [Claude Code](https://claude.com/claude-code)