### PR TITLE
fix(build): skip route step when recipe already produced a routed PCB

### DIFF
--- a/src/kicad_tools/cli/build_cmd.py
+++ b/src/kicad_tools/cli/build_cmd.py
@@ -1281,6 +1281,25 @@ def _resolve_routed_pcb_path(ctx: BuildContext) -> Path:
 
 def _run_step_route(ctx: BuildContext, console: Console) -> BuildResult:
     """Run autorouting step."""
+    # If the PCB step (or a prior run) already left a routed artifact and
+    # recorded it on the context, skip re-routing entirely. This protects
+    # recipe-routed boards (e.g. board 04's generate_design.py, which routes,
+    # stitches, and fills zones during the PCB step) from being clobbered by
+    # the generic autorouter. The post-PCB scan in main() populates
+    # ``ctx.routed_pcb_file`` when it finds a ``*_routed.kicad_pcb`` sibling,
+    # so this guard is robust against filesystem mtime granularity that the
+    # timestamp-based checks below cannot reliably resolve. ``--force`` (which
+    # sets ``ctx.force``) intentionally re-routes and bypasses this guard.
+    if not ctx.force and ctx.routed_pcb_file and ctx.routed_pcb_file.exists():
+        if not ctx.quiet:
+            console.print(f"  Recipe already produced routed PCB: {ctx.routed_pcb_file.name}")
+        return BuildResult(
+            step="route",
+            success=True,
+            message="Skipping route: recipe-produced routed PCB already present",
+            output_file=ctx.routed_pcb_file,
+        )
+
     # Check if a routed PCB already exists (e.g., from generate_design.py)
     # This prevents double-routing when a script already handled routing
     # Skip these checks if force rebuild is requested
@@ -3041,6 +3060,16 @@ def main(argv: list[str] | None = None) -> int:
                 result = _run_step_pcb(ctx, console)
                 if result.output_file:
                     ctx.pcb_file = result.output_file
+                    # If the PCB step's recipe already produced a routed
+                    # artifact (e.g. board 04's generate_design.py routes,
+                    # stitches, and fills zones in-place), record it so the
+                    # ROUTE step's guard skips re-routing instead of clobbering
+                    # it with the generic autorouter. See issue #3971.
+                    expected_routed = result.output_file.with_stem(
+                        result.output_file.stem + "_routed"
+                    )
+                    if expected_routed.exists():
+                        ctx.routed_pcb_file = expected_routed
 
             elif step == BuildStep.SYNC:
                 result = _run_step_sync(ctx, console)

--- a/tests/test_build_cmd_errors.py
+++ b/tests/test_build_cmd_errors.py
@@ -419,3 +419,86 @@ class TestBuildRouteExitCode2:
 
         assert result.success is True
         assert "DRC violations remain" in result.message
+
+
+class TestRouteStepRecipeArtifactGuard:
+    """The ROUTE step must not clobber a recipe-produced routed PCB.
+
+    Board 04's ``generate_design.py`` routes, stitches, and fills zones
+    during the PCB step, writing ``*_routed.kicad_pcb`` in-place. The PCB
+    arm of ``main()`` records that artifact on ``ctx.routed_pcb_file``; the
+    ROUTE step must then skip re-routing instead of overwriting it with the
+    generic autorouter (issue #3971).
+    """
+
+    def test_route_step_skips_when_recipe_artifact_present(self, tmp_path: Path) -> None:
+        """Pre-set ``routed_pcb_file`` short-circuits the route step."""
+        from unittest.mock import patch
+
+        from rich.console import Console
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text("(kicad_pcb)")
+        routed_file = tmp_path / "board_routed.kicad_pcb"
+        routed_file.write_text("(kicad_pcb)")
+
+        ctx = BuildContext(
+            project_dir=tmp_path,
+            spec_file=None,
+        )
+        ctx.pcb_file = pcb_file
+        ctx.routed_pcb_file = routed_file
+        ctx.mfr = "jlcpcb"
+        ctx.quiet = True
+        ctx.verbose = False
+        ctx.dry_run = False
+        ctx.force = False
+        ctx.output_dir = None
+        ctx.spec = None
+
+        console = Console()
+
+        # The router must never be invoked when the recipe already routed.
+        with patch("kicad_tools.cli.build_cmd._run_subprocess_with_heartbeat") as mock_run:
+            result = _run_step_route(ctx, console)
+
+        assert result.success is True
+        assert "recipe" in result.message.lower()
+        assert result.output_file == routed_file
+        mock_run.assert_not_called()
+
+    def test_force_bypasses_recipe_artifact_guard(self, tmp_path: Path) -> None:
+        """``--force`` (ctx.force) re-routes even when a routed artifact exists."""
+        from unittest.mock import MagicMock, patch
+
+        from rich.console import Console
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text("(kicad_pcb)")
+        routed_file = tmp_path / "board_routed.kicad_pcb"
+        routed_file.write_text("(kicad_pcb)")
+
+        ctx = BuildContext(
+            project_dir=tmp_path,
+            spec_file=None,
+        )
+        ctx.pcb_file = pcb_file
+        ctx.routed_pcb_file = routed_file
+        ctx.mfr = "jlcpcb"
+        ctx.quiet = True
+        ctx.verbose = False
+        ctx.dry_run = False
+        ctx.force = True
+        ctx.output_dir = None
+        ctx.spec = None
+
+        console = Console()
+
+        with patch("kicad_tools.cli.build_cmd._run_subprocess_with_heartbeat") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+            result = _run_step_route(ctx, console)
+
+        # With force, the guard is bypassed and the router actually runs.
+        assert result.success is True
+        assert "recipe" not in result.message.lower()
+        mock_run.assert_called()


### PR DESCRIPTION
## Summary

`kct build` runs a fixed pipeline that includes a ROUTE step. Board 04's `generate_design.py` is a mega-recipe that routes, stitches, and fills zones **in-place** during the PCB step, writing `stm32_devboard_routed.kicad_pcb`. The ROUTE step then re-ran the generic autorouter and **overwrote** the recipe's carefully constructed artifact — collapsing connectivity (GND 1/18 pads) because the generic autorouter lacks the board-04-specific escape/stitch/tie/quantize/zone-fill steps.

The existing mtime-based sibling guard in `_run_step_route()` was unreliable: `generate_design.py` writes the unrouted and routed PCBs within the same filesystem mtime quantum, so the `routed.mtime >= unrouted.mtime` check could not reliably fire.

This implements the curator's recommended **Option A**: a post-PCB artifact scan that records the recipe's routed output on `ctx.routed_pcb_file`, plus an early-return guard in `_run_step_route()` that skips re-routing when that field is already set. This is robust against filesystem mtime granularity.

## Changes

- `src/kicad_tools/cli/build_cmd.py`:
  - **Post-PCB scan** (`main()`, `BuildStep.PCB` arm): after the PCB step records `ctx.pcb_file`, look for a co-located `*_routed.kicad_pcb` sibling and, if present, set `ctx.routed_pcb_file`.
  - **Early-return guard** (top of `_run_step_route()`): when `ctx.routed_pcb_file` is already set and exists (and `--force` is not passed), skip the autorouter and return success with a "recipe-produced routed PCB already present" message.
- `tests/test_build_cmd_errors.py`: new `TestRouteStepRecipeArtifactGuard` class with two tests — the skip fires and never invokes the router; `--force` bypasses the guard and re-routes.

## Semantics decisions

- **`--force`** (`ctx.force`) intentionally bypasses the guard and re-routes (acceptance criterion + existing idiom).
- **Standalone `--step route`** (no prior PCB step in the same run) is unaffected: `ctx.routed_pcb_file` starts `None`, so the guard does not fire and the router runs normally. Verified by a standalone `kct build <unrouted.kicad_pcb> --step route` invocation, which routed the board (guard message did NOT print).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Fresh board-04 build does not overwrite recipe's routed PCB | ✅ | Fresh `rm -rf output && kct build boards/04-stm32-devboard`: ROUTE step prints "Recipe already produced routed PCB", recipe artifact preserved (9/9 signal nets, DRC PASS, full mfg bundle) |
| ROUTE step prints recipe-skip message | ✅ | `[OK] route: Skipping route: recipe-produced routed PCB already present` |
| `--force` re-routes | ✅ | Unit test `test_force_bypasses_recipe_artifact_guard` (router invoked, no recipe message) |
| Boards without a routed artifact unaffected | ✅ | Standalone `--step route` on an unrouted PCB routes normally (guard silent) |
| No regression in build_cmd suites | ✅ | 102 passed, 1 skipped across build_cmd/route/preflight/verify suites |
| New unit test present | ✅ | `test_route_step_skips_when_recipe_artifact_present` asserts message contains "recipe" and `output_file` == pre-set path |

## Test Plan

- `uv run pytest tests/test_build_cmd_errors.py tests/test_build_preflight_routing_step.py tests/test_build_verify_step.py` — 55 passed.
- Broader: `pytest -k "build_cmd or build_route or build_preflight or build_verify"` — 102 passed, 1 skipped.
- `ruff check` / `ruff format` clean on changed files; `mypy` introduces no new errors (3 pre-existing errors on `main` unchanged).
- Fresh builds: **board 04** → 11/12 (route step preserves recipe artifact; the sole remaining gate is preflight-routing reporting GND 17/18 — the last pad is connected via zone-fill copper the preflight-routing connectivity check does not credit; recipe's own DRC PASSES. This gate is orthogonal to this fix and matches the known #3901 "pour nets invisible" limitation). **Board 00** → 14/14, **board 01** → 14/14 (both recipes also route in-place; guard fires and builds go green — no skip regression).

Closes #3971