### PR TITLE
fix(build): delete manufacturing bundle when VERIFY fails after EXPORT

### DIFF
--- a/src/kicad_tools/cli/build_cmd.py
+++ b/src/kicad_tools/cli/build_cmd.py
@@ -17,6 +17,7 @@ import argparse
 import logging
 import re
 import shlex
+import shutil
 import subprocess
 import sys
 import threading
@@ -3312,6 +3313,30 @@ def main(argv: list[str] | None = None) -> int:
 
             elif step == BuildStep.VERIFY:
                 result = _run_step_verify(ctx, console)
+                # Re-arm the #3929 connectivity DRC safety floor on the
+                # reordered EXPORT-before-VERIFY path (#3976). After PR #3974
+                # put EXPORT ahead of VERIFY, a fresh single-pass build writes
+                # the manufacturing bundle before VERIFY has produced a
+                # drc_report.json for the export-time floor to read — so a
+                # shorted board could leave a bundle on disk even though the
+                # build correctly exits FAILED. If VERIFY fails after EXPORT
+                # already ran, delete the bundle it wrote so no artifact
+                # survives a shorted build.
+                if not result.success:
+                    export_result = next(
+                        (r for r in results if r.step == BuildStep.EXPORT.value and r.output_file),
+                        None,
+                    )
+                    if (
+                        export_result is not None
+                        and export_result.output_file is not None
+                        and export_result.output_file.exists()
+                    ):
+                        shutil.rmtree(export_result.output_file)
+                        console.print(
+                            "  [yellow]WARN[/yellow] manufacturing bundle "
+                            "removed — verify step detected DRC failures"
+                        )
 
             elif step == BuildStep.EXPORT:
                 result = _run_step_export(ctx, console)

--- a/tests/test_build_export_step.py
+++ b/tests/test_build_export_step.py
@@ -10,6 +10,7 @@ from rich.console import Console
 from kicad_tools.cli.build_cmd import (
     _ALL_STEPS,
     BuildContext,
+    BuildResult,
     BuildStep,
     _run_step_export,
     main,
@@ -300,3 +301,195 @@ class TestBuildStepExportCLI:
         # With dry-run, all steps should be listed without error
         ret = main([str(kct_file), "--dry-run", "--quiet"])
         assert ret in (0, 1)
+
+
+class TestExportVerifyInteraction:
+    """Re-arm the #3929 connectivity DRC safety floor on EXPORT-before-VERIFY.
+
+    After PR #3974 put EXPORT ahead of VERIFY (#3970), a fresh single-pass
+    build writes the manufacturing bundle before VERIFY produces the
+    ``drc_report.json`` that the export-time floor reads. A shorted board
+    could therefore leave a bundle on disk even though the build correctly
+    exits FAILED. Issue #3976 deletes that bundle when VERIFY fails after a
+    successful EXPORT.
+
+    These tests drive ``main()`` with a trimmed ``_ALL_STEPS`` of just
+    ``[EXPORT, VERIFY]`` so the step loop runs without invoking the whole
+    routing pipeline; the two step functions are mocked to isolate the
+    removal branch.
+    """
+
+    def _make_bundle(self, tmp_path: Path) -> Path:
+        """Create a fake manufacturing bundle directory with a file inside."""
+        mfr_dir = tmp_path / "manufacturing"
+        mfr_dir.mkdir()
+        (mfr_dir / "manifest.json").write_text("{}")
+        return mfr_dir
+
+    def test_bundle_removed_when_verify_fails_after_export(self, tmp_path: Path) -> None:
+        """A VERIFY failure after a successful EXPORT deletes the bundle."""
+        kct_file = tmp_path / "project.kct"
+        kct_file.write_text("[project]\nname = 'test'\n")
+        mfr_dir = self._make_bundle(tmp_path)
+
+        export_result = BuildResult(
+            step=BuildStep.EXPORT.value,
+            success=True,
+            message="exported",
+            output_file=mfr_dir,
+        )
+        verify_result = BuildResult(
+            step=BuildStep.VERIFY.value,
+            success=False,
+            message="DRC found shorts",
+        )
+
+        with (
+            patch(
+                "kicad_tools.cli.build_cmd._ALL_STEPS",
+                [BuildStep.EXPORT, BuildStep.VERIFY],
+            ),
+            patch(
+                "kicad_tools.cli.build_cmd._run_step_export",
+                return_value=export_result,
+            ),
+            patch(
+                "kicad_tools.cli.build_cmd._run_step_verify",
+                return_value=verify_result,
+            ),
+        ):
+            # No --quiet: the non-quiet summary block is where the failing
+            # exit code (return 1) is emitted.
+            ret = main([str(kct_file)])
+
+        # Build fails (VERIFY failed) and the bundle no longer exists.
+        assert ret == 1
+        assert not mfr_dir.exists()
+
+    def test_bundle_removed_prints_warn(self, tmp_path: Path) -> None:
+        """Console prints a WARN line referencing DRC failures on removal."""
+        kct_file = tmp_path / "project.kct"
+        kct_file.write_text("[project]\nname = 'test'\n")
+        mfr_dir = self._make_bundle(tmp_path)
+
+        export_result = BuildResult(
+            step=BuildStep.EXPORT.value,
+            success=True,
+            message="exported",
+            output_file=mfr_dir,
+        )
+        verify_result = BuildResult(
+            step=BuildStep.VERIFY.value,
+            success=False,
+            message="DRC found shorts",
+        )
+
+        console_mock = MagicMock()
+        with (
+            patch(
+                "kicad_tools.cli.build_cmd._ALL_STEPS",
+                [BuildStep.EXPORT, BuildStep.VERIFY],
+            ),
+            patch(
+                "kicad_tools.cli.build_cmd._run_step_export",
+                return_value=export_result,
+            ),
+            patch(
+                "kicad_tools.cli.build_cmd._run_step_verify",
+                return_value=verify_result,
+            ),
+            patch("kicad_tools.cli.build_cmd.Console", return_value=console_mock),
+        ):
+            main([str(kct_file)])
+
+        printed = " ".join(
+            str(call.args[0]) if call.args else "" for call in console_mock.print.call_args_list
+        )
+        assert "manufacturing bundle removed" in printed
+        assert "DRC failures" in printed
+
+    def test_bundle_kept_when_verify_passes(self, tmp_path: Path) -> None:
+        """No removal when VERIFY succeeds after EXPORT (no false positive)."""
+        kct_file = tmp_path / "project.kct"
+        kct_file.write_text("[project]\nname = 'test'\n")
+        mfr_dir = self._make_bundle(tmp_path)
+
+        export_result = BuildResult(
+            step=BuildStep.EXPORT.value,
+            success=True,
+            message="exported",
+            output_file=mfr_dir,
+        )
+        verify_result = BuildResult(
+            step=BuildStep.VERIFY.value,
+            success=True,
+            message="DRC clean",
+        )
+
+        with (
+            patch(
+                "kicad_tools.cli.build_cmd._ALL_STEPS",
+                [BuildStep.EXPORT, BuildStep.VERIFY],
+            ),
+            patch(
+                "kicad_tools.cli.build_cmd._run_step_export",
+                return_value=export_result,
+            ),
+            patch(
+                "kicad_tools.cli.build_cmd._run_step_verify",
+                return_value=verify_result,
+            ),
+        ):
+            ret = main([str(kct_file), "--quiet"])
+
+        assert ret == 0
+        assert mfr_dir.exists()
+
+    def test_verify_only_run_does_not_remove(self, tmp_path: Path) -> None:
+        """--step verify in isolation removes nothing (no EXPORT ran).
+
+        There is no EXPORT result in ``results``, so even a failing VERIFY
+        must not delete a pre-existing bundle from a prior build.
+        """
+        kct_file = tmp_path / "project.kct"
+        kct_file.write_text("[project]\nname = 'test'\n")
+        mfr_dir = self._make_bundle(tmp_path)
+
+        verify_result = BuildResult(
+            step=BuildStep.VERIFY.value,
+            success=False,
+            message="DRC found shorts",
+        )
+
+        with patch(
+            "kicad_tools.cli.build_cmd._run_step_verify",
+            return_value=verify_result,
+        ):
+            ret = main([str(kct_file), "--step", "verify"])
+
+        # VERIFY failed but there was no EXPORT in this run, so the
+        # pre-existing bundle is left untouched.
+        assert ret == 1
+        assert mfr_dir.exists()
+
+    def test_export_only_run_does_not_remove(self, tmp_path: Path) -> None:
+        """--step export in isolation never removes the bundle it wrote."""
+        kct_file = tmp_path / "project.kct"
+        kct_file.write_text("[project]\nname = 'test'\n")
+        mfr_dir = self._make_bundle(tmp_path)
+
+        export_result = BuildResult(
+            step=BuildStep.EXPORT.value,
+            success=True,
+            message="exported",
+            output_file=mfr_dir,
+        )
+
+        with patch(
+            "kicad_tools.cli.build_cmd._run_step_export",
+            return_value=export_result,
+        ):
+            ret = main([str(kct_file), "--step", "export", "--quiet"])
+
+        assert ret == 0
+        assert mfr_dir.exists()


### PR DESCRIPTION
## Summary

Re-arms the #3929 connectivity DRC safety floor on the reordered
EXPORT-before-VERIFY path. After PR #3974 put EXPORT ahead of VERIFY, a
fresh single-pass `kct build` wrote the `manufacturing/` bundle *before*
VERIFY produced the `drc_report.json` that the export-time floor reads —
so a shorted board could leave a bundle on disk even though the build
correctly exited FAILED.

Per the curator's recommended Option A, the fix lives entirely in the
`main()` step loop: when VERIFY fails after a successful EXPORT in the
same run, the bundle EXPORT wrote (located via `BuildResult.output_file`)
is `shutil.rmtree`'d and a WARN line is printed. No changes to
`ManufacturingPackage` or `_check_drc_safety_floor`, and no new
subprocess invocations.

## Changes

- `src/kicad_tools/cli/build_cmd.py`
  - Add top-level `import shutil`.
  - In the VERIFY branch of the build loop, when `result.success` is
    False, find the EXPORT `BuildResult` (by `step == "export"` with an
    `output_file`) and remove its bundle directory if it still exists,
    printing `WARN manufacturing bundle removed — verify step detected
    DRC failures`.
- `tests/test_build_export_step.py`
  - New `TestExportVerifyInteraction` class (5 tests) driving `main()`
    with a trimmed `_ALL_STEPS` of `[EXPORT, VERIFY]` and mocked step
    functions to isolate the removal branch.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Shorted board leaves no `manufacturing/` after fresh `--step all` | ✅ | `test_bundle_removed_when_verify_fails_after_export` asserts bundle deleted + `ret == 1` |
| Stale bundle from a prior build removed when current VERIFY fails | ✅ | Same test seeds an existing bundle dir; it is removed |
| WARN line referencing DRC failures printed on removal | ✅ | `test_bundle_removed_prints_warn` asserts console output |
| `--step export` alone unaffected (no removal) | ✅ | `test_export_only_run_does_not_remove` |
| `--step verify` alone unaffected (no removal) | ✅ | `test_verify_only_run_does_not_remove` |
| Boards 00/01 still produce a bundle on a clean full build | ✅ | Fresh `kct build` of boards 00 and 01: 14/14 green, bundle present, no WARN |
| `TestDRCSafetyFloor` unchanged and passing | ✅ | `tests/test_manufacturing_package.py` untouched; 77 tests pass |

## Test Plan

- `uv run pytest tests/test_build_export_step.py tests/test_manufacturing_package.py` — 77 passed (5 new).
- Core build-loop suites (`test_build_cmd_errors`, `test_build_verify_step`, `test_build_context`, `test_build_smoke_check`, `test_build_parser_parity`) — 91 passed.
- Fresh `kct build` of boards 00 (14/14, 58s) and 01 (14/14, 1m29s): both green with `manufacturing/` present and no false-positive removal.
- `ruff check` / `ruff format` clean; `mypy` introduces no new errors (the 3 pre-existing `build_cmd.py` errors are present on main unchanged).

### Note on board 02

Board 02 (`02-charlieplex-led`) fails a fresh `-o` build with a
pre-existing `IsADirectoryError` in its own `generate_pcb.py`
(`output_path.write_text` on the output *directory*), failing at the PCB
step (2/3) before ever reaching EXPORT/VERIFY. Confirmed identical
failure on pristine `origin/main` — unrelated to this change and out of
scope.

Closes #3976