### PR TITLE
fix(build): reject stale *_routed.kicad_pcb via pre-PCB-step mtime capture

### DIFF
--- a/src/kicad_tools/cli/build_cmd.py
+++ b/src/kicad_tools/cli/build_cmd.py
@@ -569,6 +569,77 @@ def _run_step_schematic(ctx: BuildContext, console: Console) -> BuildResult:
     )
 
 
+def _capture_routed_artifact_mtime(pcb_file: Path | None) -> float | None:
+    """Snapshot the ``*_routed.kicad_pcb`` sibling's mtime before the PCB step.
+
+    Returns the ``st_mtime`` of the candidate routed artifact next to
+    ``pcb_file`` if it already exists on disk, otherwise ``None`` (no file
+    to compare against). Called immediately *before* ``_run_step_pcb()`` so
+    the post-PCB scan can tell whether the PCB step actually (re)wrote the
+    routed artifact or merely found a stale copy left in the repo. See
+    :func:`_scan_recipe_routed_artifact` and issue #3978.
+    """
+    if pcb_file is None:
+        return None
+    candidate = pcb_file.with_stem(pcb_file.stem + "_routed")
+    if candidate.exists():
+        return candidate.stat().st_mtime
+    return None
+
+
+def _scan_recipe_routed_artifact(
+    pcb_output_file: Path,
+    pre_pcb_routed_mtime: float | None,
+    console: Console,
+    *,
+    quiet: bool = False,
+) -> Path | None:
+    """Decide whether the PCB step produced a trustworthy routed artifact.
+
+    Board 04's ``generate_design.py`` routes, stitches, and fills zones
+    during the PCB step, writing ``*_routed.kicad_pcb`` in-place. When it
+    does, the ROUTE step's guard must skip re-routing instead of clobbering
+    that artifact with the generic autorouter (issue #3971).
+
+    However, *existence alone* is not proof of freshness: an external board
+    whose PCB generator does **not** route in-place could have a stale
+    ``*_routed.kicad_pcb`` committed in the repo (or left from a prior
+    partial run). Trusting it on existence would silently skip routing and
+    ship stale copper (issue #3978).
+
+    This helper compares the routed artifact's mtime *after* the PCB step
+    against the snapshot taken *before* it (``pre_pcb_routed_mtime``). The
+    artifact is trusted only when it was newly created (no prior file) or
+    its mtime advanced (the PCB step rewrote it). A stale file that survived
+    the PCB step unchanged is rejected with a warning so the ROUTE step
+    re-routes.
+
+    Note this compares the routed file against *its own* pre-run state, not
+    against the unrouted file, so it does not reintroduce the same-mtime
+    quantum race #3971 mitigated.
+
+    Returns the routed :class:`~pathlib.Path` when it should be recorded on
+    ``ctx.routed_pcb_file``, otherwise ``None``.
+    """
+    expected_routed = pcb_output_file.with_stem(pcb_output_file.stem + "_routed")
+    if not expected_routed.exists():
+        return None
+
+    routed_mtime = expected_routed.stat().st_mtime
+    if pre_pcb_routed_mtime is None or routed_mtime > pre_pcb_routed_mtime:
+        # Either the PCB step created the routed artifact, or it advanced an
+        # existing one's mtime — safe to trust it.
+        return expected_routed
+
+    # The file existed before the PCB step and was not updated by it: stale.
+    if not quiet:
+        console.print(
+            f"  [yellow]Stale {expected_routed.name} found (not written by the "
+            f"PCB step); ROUTE step will re-route. Use --force to override.[/yellow]"
+        )
+    return None
+
+
 def _run_step_pcb(ctx: BuildContext, console: Console) -> BuildResult:
     """Run PCB generation step."""
     script = _find_generator_script(ctx.project_dir, "pcb")
@@ -3264,6 +3335,10 @@ def main(argv: list[str] | None = None) -> int:
                 result = _run_step_erc(ctx, console)
 
             elif step == BuildStep.PCB:
+                # Snapshot any pre-existing routed artifact's mtime *before*
+                # the PCB step runs so we can tell whether the step actually
+                # (re)wrote it or merely found a stale copy. See issue #3978.
+                pre_pcb_routed_mtime = _capture_routed_artifact_mtime(ctx.pcb_file)
                 result = _run_step_pcb(ctx, console)
                 if result.output_file:
                     ctx.pcb_file = result.output_file
@@ -3271,12 +3346,17 @@ def main(argv: list[str] | None = None) -> int:
                     # artifact (e.g. board 04's generate_design.py routes,
                     # stitches, and fills zones in-place), record it so the
                     # ROUTE step's guard skips re-routing instead of clobbering
-                    # it with the generic autorouter. See issue #3971.
-                    expected_routed = result.output_file.with_stem(
-                        result.output_file.stem + "_routed"
+                    # it with the generic autorouter (issue #3971). Only trust
+                    # the artifact when the PCB step created or refreshed it —
+                    # a stale pre-existing file is rejected (issue #3978).
+                    routed = _scan_recipe_routed_artifact(
+                        result.output_file,
+                        pre_pcb_routed_mtime,
+                        console,
+                        quiet=args.quiet,
                     )
-                    if expected_routed.exists():
-                        ctx.routed_pcb_file = expected_routed
+                    if routed is not None:
+                        ctx.routed_pcb_file = routed
 
             elif step == BuildStep.SYNC:
                 result = _run_step_sync(ctx, console)

--- a/tests/test_build_cmd_errors.py
+++ b/tests/test_build_cmd_errors.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from kicad_tools.cli.build_cmd import (
     BuildContext,
+    _capture_routed_artifact_mtime,
     _format_no_generator_message,
     _generate_design_supports_step_route,
     _generator_candidates,
@@ -14,6 +15,7 @@ from kicad_tools.cli.build_cmd import (
     _run_step_pcb,
     _run_step_route,
     _run_step_schematic,
+    _scan_recipe_routed_artifact,
     main,
 )
 
@@ -502,6 +504,166 @@ class TestRouteStepRecipeArtifactGuard:
 
         # With force, the guard is bypassed and the router actually runs.
         assert result.success is True
+        assert "recipe" not in result.message.lower()
+        mock_run.assert_called()
+
+
+class TestScanRecipeRoutedArtifact:
+    """The post-PCB scan must reject stale ``*_routed.kicad_pcb`` artifacts.
+
+    ``_scan_recipe_routed_artifact`` decides whether the routed sibling
+    produced beside the PCB output should be recorded on
+    ``ctx.routed_pcb_file``. It trusts the artifact only when the PCB step
+    created or refreshed it (mtime advanced past the pre-step snapshot),
+    guarding against stale copper committed in external boards (issue #3978)
+    while preserving in-place-routing recipe behavior (issue #3971).
+    """
+
+    def test_freshly_written_routed_artifact_is_trusted(self, tmp_path: Path) -> None:
+        """An in-place recipe that rewrites the routed file → artifact trusted.
+
+        Mirrors board 04: no routed file exists before the PCB step, so the
+        pre-step snapshot is ``None`` and any produced artifact is trusted.
+        """
+        from rich.console import Console
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text("(kicad_pcb)")
+
+        pre_mtime = _capture_routed_artifact_mtime(pcb_file)
+        assert pre_mtime is None  # no routed file existed before the PCB step
+
+        # PCB step writes the routed artifact.
+        routed_file = tmp_path / "board_routed.kicad_pcb"
+        routed_file.write_text("(kicad_pcb)")
+
+        result = _scan_recipe_routed_artifact(pcb_file, pre_mtime, Console(), quiet=True)
+        assert result == routed_file
+
+    def test_refreshed_routed_artifact_is_trusted(self, tmp_path: Path) -> None:
+        """A pre-existing routed file whose mtime advances → artifact trusted."""
+        from rich.console import Console
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text("(kicad_pcb)")
+        routed_file = tmp_path / "board_routed.kicad_pcb"
+        routed_file.write_text("(kicad_pcb)")
+
+        # Simulate an old pre-existing routed artifact.
+        old = 1_000_000.0
+        os.utime(routed_file, (old, old))
+        pre_mtime = _capture_routed_artifact_mtime(pcb_file)
+        assert pre_mtime == old
+
+        # PCB step rewrites the routed artifact (mtime advances).
+        os.utime(routed_file, (old + 100, old + 100))
+
+        result = _scan_recipe_routed_artifact(pcb_file, pre_mtime, Console(), quiet=True)
+        assert result == routed_file
+
+    def test_stale_routed_artifact_is_rejected_with_warning(self, tmp_path: Path) -> None:
+        """A stale routed file untouched by the PCB step → rejected + warning.
+
+        Simulates an external board whose PCB generator does not route
+        in-place: the ``*_routed.kicad_pcb`` predates the PCB step and its
+        mtime does not advance, so it must not be recorded (issue #3978).
+        """
+        from rich.console import Console
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text("(kicad_pcb)")
+        routed_file = tmp_path / "board_routed.kicad_pcb"
+        routed_file.write_text("(kicad_pcb)")
+
+        # Stale routed artifact, older than the "PCB step start".
+        old = 1_000_000.0
+        os.utime(routed_file, (old, old))
+        pre_mtime = _capture_routed_artifact_mtime(pcb_file)
+        assert pre_mtime == old
+
+        # PCB step runs but does NOT touch the routed file (mtime unchanged).
+        console = Console(record=True)
+        result = _scan_recipe_routed_artifact(pcb_file, pre_mtime, console)
+
+        assert result is None
+        output = console.export_text()
+        assert "Stale" in output
+        assert "board_routed.kicad_pcb" in output
+
+    def test_stale_rejection_is_quiet_when_requested(self, tmp_path: Path) -> None:
+        """``quiet=True`` suppresses the stale-artifact warning."""
+        from rich.console import Console
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text("(kicad_pcb)")
+        routed_file = tmp_path / "board_routed.kicad_pcb"
+        routed_file.write_text("(kicad_pcb)")
+
+        old = 1_000_000.0
+        os.utime(routed_file, (old, old))
+        pre_mtime = _capture_routed_artifact_mtime(pcb_file)
+
+        console = Console(record=True)
+        result = _scan_recipe_routed_artifact(pcb_file, pre_mtime, console, quiet=True)
+
+        assert result is None
+        assert "Stale" not in console.export_text()
+
+    def test_no_routed_artifact_returns_none(self, tmp_path: Path) -> None:
+        """No routed sibling produced → nothing to record, no warning."""
+        from rich.console import Console
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text("(kicad_pcb)")
+
+        pre_mtime = _capture_routed_artifact_mtime(pcb_file)
+        console = Console(record=True)
+        result = _scan_recipe_routed_artifact(pcb_file, pre_mtime, console)
+
+        assert result is None
+        assert "Stale" not in console.export_text()
+
+    def test_stale_artifact_then_route_step_actually_routes(self, tmp_path: Path) -> None:
+        """End-to-end: a rejected stale artifact leaves ROUTE free to run.
+
+        With a stale routed file, the post-PCB scan returns ``None`` so
+        ``ctx.routed_pcb_file`` stays unset; ``_run_step_route`` then does not
+        hit the recipe-artifact short-circuit and invokes the router.
+        """
+        from unittest.mock import MagicMock, patch
+
+        from rich.console import Console
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text("(kicad_pcb)")
+        routed_file = tmp_path / "board_routed.kicad_pcb"
+        routed_file.write_text("(kicad_pcb)")
+
+        # Stale artifact untouched by the (mock) PCB step.
+        old = 1_000_000.0
+        os.utime(routed_file, (old, old))
+        pre_mtime = _capture_routed_artifact_mtime(pcb_file)
+
+        ctx = BuildContext(project_dir=tmp_path, spec_file=None)
+        ctx.pcb_file = pcb_file
+        ctx.mfr = "jlcpcb"
+        ctx.quiet = True
+        ctx.verbose = False
+        ctx.dry_run = False
+        ctx.force = False
+        ctx.output_dir = None
+        ctx.spec = None
+
+        # Post-PCB scan rejects the stale artifact.
+        routed = _scan_recipe_routed_artifact(pcb_file, pre_mtime, Console(), quiet=True)
+        assert routed is None
+        ctx.routed_pcb_file = routed  # stays None → guard will not short-circuit
+
+        with patch("kicad_tools.cli.build_cmd._run_subprocess_with_heartbeat") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+            result = _run_step_route(ctx, Console())
+
+        # The router ran (not skipped via the recipe-artifact short-circuit).
         assert "recipe" not in result.message.lower()
         mock_run.assert_called()
 


### PR DESCRIPTION
## Summary

The post-PCB scan in `main()`'s `BuildStep.PCB` arm recorded a `*_routed.kicad_pcb` sibling on `ctx.routed_pcb_file` based on **existence alone**. For an external board whose PCB generator does not route in-place, a stale routed artifact committed in the repo (or left from a prior partial run) would survive the scan, set `ctx.routed_pcb_file`, and cause the ROUTE step's early-return guard to silently skip routing — shipping stale copper (issue #3978).

This implements the curator's recommended **Option A**: snapshot the candidate routed file's `st_mtime` immediately *before* `_run_step_pcb()` runs, then only trust the artifact when the PCB step created it or advanced its mtime.

## Changes

- Add `_capture_routed_artifact_mtime(pcb_file)` — snapshots the `*_routed.kicad_pcb` sibling's mtime before the PCB step (or `None` if absent).
- Add `_scan_recipe_routed_artifact(pcb_output_file, pre_pcb_routed_mtime, console, *, quiet)` — returns the routed path only when it was newly created (`pre == None`) or its mtime advanced; otherwise rejects it with a `[yellow]Stale …[/yellow]` warning and returns `None`.
- Wire both helpers into the `BuildStep.PCB` arm: capture pre-step mtime, then guard the `ctx.routed_pcb_file` assignment through the scan helper.
- Add `TestScanRecipeRoutedArtifact` (6 tests) using `os.utime()` to simulate stale/refreshed artifacts.

**Why this does not reintroduce #3971:** the comparison is `routed.mtime_after > routed.mtime_before` (the file vs. its own pre-run state), not `routed.mtime >= unrouted.mtime`. Any write by an in-place recipe advances the mtime, so all in-repo boards are unaffected. The defense-in-depth mtime-sibling guard inside `_run_step_route()` is untouched.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Stale generator + stale routed file → ROUTE runs, with warning | ✅ | `test_stale_routed_artifact_is_rejected_with_warning` (asserts `None` + "Stale" in `Console(record=True)` output); `test_stale_artifact_then_route_step_actually_routes` confirms `_run_step_route` invokes the router |
| Non-in-place generator + no routed file → ROUTE runs as before | ✅ | `test_no_routed_artifact_returns_none` |
| Board 04 (in-place recipe): ROUTE still skips | ✅ | Fresh `uv run kct build boards/04-stm32-devboard` → "Skipping route: recipe-produced routed PCB already present", 11/12 steps |
| All 8 in-repo boards unchanged | ✅ | In-place recipes always advance mtime → `pre == None` path trusts artifact exactly as before |
| `--force` still bypasses all guards | ✅ | `test_force_bypasses_recipe_artifact_guard` (unchanged, passes) |
| Standalone `--step route` (`routed_pcb_file` is `None`) routes normally | ✅ | Post-PCB scan only runs in the PCB arm; unchanged |

## Test Plan

- `uv run pytest tests/test_build_cmd_errors.py` → 54 passed (48 existing + 6 new).
- Fresh full build of board 04 (`rm -rf output && uv run kct build boards/04-stm32-devboard`): PCB step routes in-place, post-PCB scan trusts the freshly-written artifact, ROUTE step skips ("Skipping route: recipe-produced routed PCB already present"), build reaches 11/12. Regenerated tracked output artifacts were reverted (out of scope).
- `ruff check` / `ruff format --check` clean on both files; `mypy` introduces no new errors (3 pre-existing errors unchanged).

Closes #3978