### PR TITLE
feat(route): compose escape routing with the differential-pair pre-pass

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -3614,11 +3614,25 @@ def route_with_layer_escalation(
 
         try:
             if _should_use_escape_routing(router, escape_flag, quiet):
-                router.route_with_escape(
-                    use_negotiated=(args.strategy == "negotiated"),
-                    timeout=_attempt_timeout,
-                    per_net_timeout=getattr(args, "per_net_timeout", None) or None,
-                )
+                # Issue #3952: compose the escape pre-phase with the
+                # CoupledPathfinder diff-pair pre-pass when
+                # --differential-pairs is requested so Phase A runs on
+                # escape-forced boards; otherwise take the unchanged escape
+                # path (byte-identical for no-pair boards).
+                _dp_cfg = _build_diffpair_config(args)
+                if _dp_cfg is not None:
+                    router.route_with_escape_and_diffpairs(
+                        _dp_cfg,
+                        use_negotiated=(args.strategy == "negotiated"),
+                        timeout=_attempt_timeout,
+                        per_net_timeout=getattr(args, "per_net_timeout", None) or None,
+                    )
+                else:
+                    router.route_with_escape(
+                        use_negotiated=(args.strategy == "negotiated"),
+                        timeout=_attempt_timeout,
+                        per_net_timeout=getattr(args, "per_net_timeout", None) or None,
+                    )
             elif getattr(args, "multi_resolution", False):
                 router.route_all_multi_resolution(
                     use_negotiated=(args.strategy == "negotiated"),
@@ -4491,11 +4505,25 @@ def route_with_rule_relaxation(
 
         try:
             if _should_use_escape_routing(router, escape_flag, quiet):
-                router.route_with_escape(
-                    use_negotiated=(args.strategy == "negotiated"),
-                    timeout=_attempt_timeout,
-                    per_net_timeout=getattr(args, "per_net_timeout", None) or None,
-                )
+                # Issue #3952: compose the escape pre-phase with the
+                # CoupledPathfinder diff-pair pre-pass when
+                # --differential-pairs is requested so Phase A runs on
+                # escape-forced boards; otherwise take the unchanged escape
+                # path (byte-identical for no-pair boards).
+                _dp_cfg = _build_diffpair_config(args)
+                if _dp_cfg is not None:
+                    router.route_with_escape_and_diffpairs(
+                        _dp_cfg,
+                        use_negotiated=(args.strategy == "negotiated"),
+                        timeout=_attempt_timeout,
+                        per_net_timeout=getattr(args, "per_net_timeout", None) or None,
+                    )
+                else:
+                    router.route_with_escape(
+                        use_negotiated=(args.strategy == "negotiated"),
+                        timeout=_attempt_timeout,
+                        per_net_timeout=getattr(args, "per_net_timeout", None) or None,
+                    )
             elif getattr(args, "multi_resolution", False):
                 router.route_all_multi_resolution(
                     use_negotiated=(args.strategy == "negotiated"),
@@ -6563,11 +6591,23 @@ def route_with_combined_escalation(
 
             try:
                 if _should_use_escape_routing(router, escape_flag, quiet):
-                    router.route_with_escape(
-                        use_negotiated=(args.strategy == "negotiated"),
-                        timeout=_attempt_timeout,
-                        per_net_timeout=getattr(args, "per_net_timeout", None) or None,
-                    )
+                    # Issue #3952: compose escape + diff-pair pre-pass when
+                    # --differential-pairs is requested (combined 2D
+                    # escalation path); otherwise unchanged escape path.
+                    _dp_cfg = _build_diffpair_config(args)
+                    if _dp_cfg is not None:
+                        router.route_with_escape_and_diffpairs(
+                            _dp_cfg,
+                            use_negotiated=(args.strategy == "negotiated"),
+                            timeout=_attempt_timeout,
+                            per_net_timeout=getattr(args, "per_net_timeout", None) or None,
+                        )
+                    else:
+                        router.route_with_escape(
+                            use_negotiated=(args.strategy == "negotiated"),
+                            timeout=_attempt_timeout,
+                            per_net_timeout=getattr(args, "per_net_timeout", None) or None,
+                        )
                 elif getattr(args, "multi_resolution", False):
                     router.route_all_multi_resolution(
                         use_negotiated=(args.strategy == "negotiated"),
@@ -7013,6 +7053,37 @@ def _resolve_escape_routing_flag(args) -> bool | None:
     if escape:
         return True
     return None
+
+
+def _build_diffpair_config(args):
+    """Build a ``DifferentialPairConfig`` from parsed CLI args, or ``None``.
+
+    Issue #3952: the escape / auto-layers-escalation dispatch sites need a
+    ``diffpair_config`` to compose diff-pair routing with escape routing via
+    ``Autorouter.route_with_escape_and_diffpairs``.  The ``do_routing()``
+    fixed-layer path builds this inline (route_cmd.py); the escalation
+    functions build their own routers and so need their own config.  This
+    helper centralizes the construction so all four dispatch sites stay in
+    sync with the flag surface (``--diffpair-spacing``, ``--diffpair-max-delta``,
+    ``--diffpair-per-pair-timeout``).
+
+    Returns ``None`` when ``--differential-pairs`` was not requested so callers
+    can gate the composed path on a truthy result (the no-pair regression
+    firewall -- boards without pairs take the byte-identical old path).
+    """
+    if not getattr(args, "differential_pairs", False):
+        return None
+
+    from kicad_tools.router import DifferentialPairConfig
+
+    return DifferentialPairConfig(
+        enabled=True,
+        spacing=args.diffpair_spacing,
+        max_length_delta=args.diffpair_max_delta,
+        # Issue #3275: forward the optional per-pair wall-clock budget so the
+        # CoupledPathfinder's per-pair coupled A* search can be bounded.
+        per_pair_timeout=getattr(args, "diffpair_per_pair_timeout", None),
+    )
 
 
 def _should_use_escape_routing(router, escape_flag: bool | None, quiet: bool) -> bool:
@@ -9492,6 +9563,23 @@ def main(argv: list[str] | None = None) -> int:
 
             # Check if escape routing should run as a pre-phase
             if _should_use_escape_routing(router, escape_routing_flag, quiet):
+                # Issue #3952: compose the escape pre-phase with the
+                # CoupledPathfinder diff-pair pre-pass when
+                # --differential-pairs is requested so Phase A runs on
+                # escape-forced boards (the fixed-layer escape branch used
+                # to bypass the diff-pair dispatch just like the escalation
+                # paths).  ``diffpair_config`` is already built above and in
+                # scope here; gating on it keeps no-pair boards on the
+                # byte-identical old ``route_with_escape`` path.
+                if args.differential_pairs and diffpair_config is not None:
+                    routes, dp_warnings = router.route_with_escape_and_diffpairs(
+                        diffpair_config,
+                        use_negotiated=(args.strategy == "negotiated"),
+                        timeout=_budgeted_timeout(args),
+                        per_net_timeout=getattr(args, "per_net_timeout", None) or None,
+                    )
+                    diffpair_warnings.extend(dp_warnings)
+                    return routes
                 return router.route_with_escape(
                     use_negotiated=(args.strategy == "negotiated"),
                     timeout=_budgeted_timeout(args),

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -2644,6 +2644,11 @@ class Autorouter:
         self.routing_failures = []
         self._perturbation_magnitude = 0.0
         self._congestion_estimator = None
+        # Issue #3952: the escape/diff-pair composition's one-shot guard is
+        # per-run mutable state; clear it so a reused Autorouter cannot leak
+        # _escapes_generated_this_run=True into the next attempt (which would
+        # silently skip escape generation in route_with_escape).
+        self._escapes_generated_this_run = False
 
     def _calculate_constraint_score(self, net_id: int) -> float:
         """Calculate a constraint score for a net based on routing difficulty.
@@ -14039,7 +14044,7 @@ class Autorouter:
             # here, so resetting the flag is safe for the coupled-success path
             # too.
             self.paired_escape_coupling = False
-            if getattr(self, "_escape_router", None) is not None:
+            if self._escape_router is not None:
                 self._escape_router.diff_pair_map = {}
 
             subgrid_escapes, dense_packages = self._run_escape_prephase()

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -913,6 +913,18 @@ class Autorouter:
         # thread the diff_pair_map into the EscapeRouter.
         self.paired_escape_coupling: bool = False
 
+        # Issue #3952: one-shot guard so ``route_with_escape_and_diffpairs``
+        # cannot double-generate escape stubs.  The diff-pair pre-pass
+        # (``route_all_with_diffpairs``) lazily drives escape generation for
+        # the pair's package; the escape leg of the non-diff-pair strategy
+        # then runs ``_run_escape_prephase`` for the remaining dense-package
+        # pads.  When this flag is True, ``_run_escape_prephase`` skips the
+        # dense-package escape-generation step (the sub-grid pre-pass and
+        # pad-channel budgets still run) so the same package is never escaped
+        # twice.  Default False preserves ``route_with_escape``'s behaviour
+        # bit-for-bit for the no-diff-pair path.
+        self._escapes_generated_this_run: bool = False
+
         # Issue #2838 (closes #2761 gap): Lazy-initialized via conflict
         # manager.  Wired into the single-ended PIN_ACCESS retry path in
         # ``route_net`` so vias from already-routed nets that sit within
@@ -13858,6 +13870,228 @@ class Autorouter:
 
         return budgets
 
+    def _run_escape_prephase(self) -> tuple[list[Route], list[PackageInfo]]:
+        """Run the escape pre-phase: sub-grid, dense detection, escapes, budgets.
+
+        Issue #3952: extracted verbatim from ``route_with_escape``'s Phase-1
+        body so it can be reused as the escape leg of
+        ``route_with_escape_and_diffpairs``'s non-diff-pair strategy.  This
+        method has NO Phase-2 main pass and NO summary -- callers own those.
+
+        Returns a ``(subgrid_escapes, dense_packages)`` tuple.  The
+        dense-package escape routes themselves survive on the grid (they are
+        registered as fixed infrastructure by ``generate_escape_routes``), so
+        only the sub-grid escapes -- which are infrastructure, not net routes
+        -- are returned to the caller for combination into the final route set.
+
+        When ``self._escapes_generated_this_run`` is already True (set by
+        ``route_with_escape_and_diffpairs`` after the diff-pair pre-pass drove
+        its own paired escape generation), the dense-package escape-generation
+        step is skipped so the same package is never escaped twice.  The
+        sub-grid pre-pass and pad-channel budgets still run because they are
+        idempotent and cover pads the coupled pre-pass did not touch.
+        """
+        # Issue #2294: Sub-grid escape pre-pass for off-grid pads.
+        # This must run before dense-package escape routing so that
+        # off-grid pads (e.g. J2 connector pads that don't snap to the
+        # routing grid) get escape segments that bridge them to the
+        # nearest on-grid cell.  Without this, off-grid pads are
+        # classified as PADS_OFF_GRID and excluded from rip-up recovery.
+        subgrid_escapes = self._run_subgrid_prepass()
+
+        # Phase 1: Detect and route dense packages
+        dense_packages = self.detect_dense_packages()
+
+        already_escaped = self._escapes_generated_this_run
+        if dense_packages and not already_escaped:
+            print(f"\n--- Phase 1: Escape Routing ({len(dense_packages)} dense packages) ---")
+            for pkg in dense_packages:
+                print(f"  {pkg.ref}: {pkg.package_type.name}, {pkg.pin_count} pins")
+
+            escape_routes = self.generate_escape_routes(dense_packages)
+            print(f"  Generated {len(escape_routes)} escape route segments")
+            # Issue #3952: mark escapes generated so a subsequent
+            # _run_escape_prephase call in the same run does not regenerate
+            # them (idempotency guard for the diffpair composition).
+            self._escapes_generated_this_run = True
+        elif dense_packages and already_escaped:
+            # Issue #3952: the diff-pair pre-pass already generated the
+            # paired escape stubs for these packages; skip regeneration.
+            print(
+                f"\n--- Phase 1: Escape Routing SKIPPED ({len(dense_packages)} dense "
+                "packages already escaped by the diff-pair pre-pass, Issue #3952) ---"
+            )
+        else:
+            print("\n--- No dense packages detected, skipping escape routing ---")
+
+        # Issue #3143: Compute per-pad lateral-channel budgets from the
+        # escape pad overrides registered above.  The budgets nudge the
+        # C++ A* main router away from contested escape channels adjacent
+        # to dense-package pad rows -- exactly the failure mode that
+        # capped softstart routing reach at 6/10 nets in PR #3142.  Empty
+        # list (no dense packages, no overrides, or Python backend in use)
+        # silently leaves the per-net cost function pre-#3143 identical.
+        #
+        # Issue #3201 diagnostic: setting environment variable
+        # ``KCT_DISABLE_PAD_BUDGETS=1`` disables budget application to
+        # establish an A/B comparison without recompilation.  Useful for
+        # confirming whether a routing regression originates from the
+        # budget code path (per PR #3222's diagnostic pattern that
+        # confirmed board 05 does not invoke this code path).
+        if dense_packages and not os.environ.get("KCT_DISABLE_PAD_BUDGETS"):
+            pad_channel_budgets = self._build_pad_channel_budgets(dense_packages)
+            if pad_channel_budgets and hasattr(self.router, "set_pad_channel_budgets"):
+                self.router.set_pad_channel_budgets(pad_channel_budgets)
+                print(
+                    f"  Pad-channel budgets: {len(pad_channel_budgets)} "
+                    f"escape channel(s) tagged (Issue #3143)"
+                )
+
+        return subgrid_escapes, dense_packages
+
+    def route_with_escape_and_diffpairs(
+        self,
+        diffpair_config: DifferentialPairConfig,
+        use_negotiated: bool = True,
+        progress_callback: ProgressCallback | None = None,
+        timeout: float | None = None,
+        per_net_timeout: float | None = None,
+    ) -> tuple[list[Route], list[LengthMismatchWarning]]:
+        """Compose escape routing with the differential-pair pre-pass.
+
+        Issue #3952: on boards whose fine-pitch packages force the escape
+        dispatch (e.g. board 03's USB-C connector), ``--differential-pairs``
+        was a silent no-op -- ``route_with_escape`` returned before any
+        diff-pair branch ran, so the CoupledPathfinder pre-pass (Phase A) was
+        never invoked.  This orchestrator wires the two together by delegating
+        to ``route_all_with_diffpairs`` (which already flips
+        ``paired_escape_coupling=True`` and refreshes the ``diff_pair_map``
+        BEFORE the escape phase runs) and handing it the escape main-pass as
+        its ``non_diffpair_strategy``.
+
+        Sequencing (answers the "where does Phase A run" design question):
+
+        1. ``route_all_with_diffpairs`` flips ``paired_escape_coupling=True``
+           and refreshes ``self._escape_router.diff_pair_map`` in place, so any
+           escape generation that follows emits *paired* (coupled-at-launch)
+           endpoints on the dense package.
+        2. It runs the CoupledPathfinder coupled A* over the pair (printing the
+           ``=== Differential Pair Routing ===`` banner the acceptance gate
+           asserts), lazily driving paired escape generation for the pair's
+           package.
+        3. Pairs the CoupledPathfinder cannot handle (budget-exit / refused)
+           are dropped back into the non-diff-pair net set (``coupled_only=True``)
+           and routed by the ``non_diffpair_strategy`` closure below -- which
+           runs the escape pre-phase for the *remaining* dense-package pads and
+           then the negotiated/basic main pass.  No net goes unrouted on a
+           budget exit; the pair falls through to the same main pass that
+           produces today's escape-only copper.
+
+        The ``_escapes_generated_this_run`` guard prevents the closure's
+        ``_run_escape_prephase`` from regenerating escapes the coupled pre-pass
+        already emitted for the same package.
+
+        Args:
+            diffpair_config: Differential-pair configuration (must be enabled).
+            use_negotiated: Use the negotiated two-phase main pass (default) or
+                the plain per-net main pass for the non-diff-pair nets.
+            progress_callback: Optional callback for progress updates.
+            timeout: Optional board-level wall-clock budget in seconds.
+            per_net_timeout: Optional per-net A* wall-clock timeout.
+
+        Returns:
+            A ``(routes, length_warnings)`` tuple mirroring
+            ``route_all_with_diffpairs``.  ``self.routes`` /
+            ``self.routing_failures`` are populated as a side effect so the CLI
+            escalation reach-measurement logic is unchanged.
+        """
+        print("\n=== Routing with Escape Pattern Generation + Differential Pairs ===")
+
+        # Reset the one-shot escape guard for this run so a reused Autorouter
+        # (e.g. across escalation attempts) starts clean.
+        self._escapes_generated_this_run = False
+
+        def _escape_main_pass() -> list[Route]:
+            """Non-diff-pair strategy: escape pre-phase then the main pass.
+
+            Mirrors ``route_with_escape``'s Phase-1 -> Phase-2 order minus the
+            summary (the outer diff-pair call finalizes routing).
+            """
+            # Issue #3952: by the time this closure runs, the CoupledPathfinder
+            # pre-pass has already had its chance to route the pair coupled
+            # (committing its paired escape stubs to the grid as fixed
+            # infrastructure).  Any pair that reached here budget-exited or was
+            # refused, so it will be routed uncoupled by the main pass below.
+            #
+            # Reset ``paired_escape_coupling`` and clear the escape router's
+            # ``diff_pair_map`` BEFORE ``_run_escape_prephase`` generates the
+            # escapes for the remaining (non-coupled) dense-package pads.
+            # Paired escape endpoints sit at intra-pair clearance and are
+            # unroutable by the plain per-net A* -- threading the paired map
+            # into the fall-through escape generation shifts the dense
+            # package's channel geometry and strands a *neighbouring* net
+            # (measured empirically on board 03: XTAL1 regressed 13/13 -> 12/13
+            # with a partial XTAL1 when the paired J1 escapes were emitted on a
+            # budget-exit pair).  This is the same "paired map regresses reach
+            # on non-coupled boards" hazard the escape router already guards
+            # (core.py: the board-06 41%->27% note).  Committed coupled routes
+            # (if any) are already marked on the grid and are NOT regenerated
+            # here, so resetting the flag is safe for the coupled-success path
+            # too.
+            self.paired_escape_coupling = False
+            if getattr(self, "_escape_router", None) is not None:
+                self._escape_router.diff_pair_map = {}
+
+            subgrid_escapes, dense_packages = self._run_escape_prephase()
+
+            print("\n--- Phase 2: Main Routing ---")
+            if use_negotiated:
+                # Issue #2401: escape routes are permanent infrastructure; the
+                # main pass routes between escape endpoints, not pad centers.
+                main_routes = self.route_all_two_phase(
+                    use_negotiated=True,
+                    corridor_width_factor=2.0,
+                    progress_callback=progress_callback,
+                    timeout=timeout,
+                    per_net_timeout=per_net_timeout,
+                )
+            else:
+                main_routes = self.route_all(
+                    progress_callback=progress_callback,
+                    timeout=timeout,
+                    per_net_timeout=per_net_timeout,
+                    suppress_no_timeout_warning=True,
+                )
+
+            # Sub-grid escapes are infrastructure, not net routes; combine
+            # them with the main routes so they survive into the final set.
+            return subgrid_escapes + main_routes
+
+        # Delegate to the existing diff-pair orchestrator.  ``coupled_only``
+        # keeps budget-exit pairs flowing into ``_escape_main_pass`` so no net
+        # is left unrouted (the xfail flips WITHOUT needing #3921).
+        routes, warnings = self.route_all_with_diffpairs(
+            diffpair_config,
+            non_diffpair_strategy=_escape_main_pass,
+            coupled_only=True,
+            timeout=timeout,
+        )
+
+        # Summary (mirrors route_with_escape's tail so operators see the same
+        # escape statistics on this path).
+        stats = self.get_statistics()
+        print("\n=== Routing with Escape + Diff Pairs Complete ===")
+        print(f"  Total nets routed: {stats['nets_routed']}")
+        print(f"  Total segments: {stats['segments']}")
+        print(f"  Total vias: {stats['vias']}")
+
+        if self.routing_failures:
+            failure_summary = format_failed_nets_summary(self.routing_failures)
+            if failure_summary:
+                print(failure_summary)
+
+        return routes, warnings
+
     def route_with_escape(
         self,
         use_negotiated: bool = True,
@@ -13897,50 +14131,13 @@ class Autorouter:
         """
         print("\n=== Routing with Escape Pattern Generation ===")
 
-        # Issue #2294: Sub-grid escape pre-pass for off-grid pads.
-        # This must run before dense-package escape routing so that
-        # off-grid pads (e.g. J2 connector pads that don't snap to the
-        # routing grid) get escape segments that bridge them to the
-        # nearest on-grid cell.  Without this, off-grid pads are
-        # classified as PADS_OFF_GRID and excluded from rip-up recovery.
-        subgrid_escapes = self._run_subgrid_prepass()
-
-        # Phase 1: Detect and route dense packages
-        dense_packages = self.detect_dense_packages()
-
-        if dense_packages:
-            print(f"\n--- Phase 1: Escape Routing ({len(dense_packages)} dense packages) ---")
-            for pkg in dense_packages:
-                print(f"  {pkg.ref}: {pkg.package_type.name}, {pkg.pin_count} pins")
-
-            escape_routes = self.generate_escape_routes(dense_packages)
-            print(f"  Generated {len(escape_routes)} escape route segments")
-        else:
-            print("\n--- No dense packages detected, skipping escape routing ---")
-            escape_routes = []
-
-        # Issue #3143: Compute per-pad lateral-channel budgets from the
-        # escape pad overrides registered above.  The budgets nudge the
-        # C++ A* main router away from contested escape channels adjacent
-        # to dense-package pad rows -- exactly the failure mode that
-        # capped softstart routing reach at 6/10 nets in PR #3142.  Empty
-        # list (no dense packages, no overrides, or Python backend in use)
-        # silently leaves the per-net cost function pre-#3143 identical.
-        #
-        # Issue #3201 diagnostic: setting environment variable
-        # ``KCT_DISABLE_PAD_BUDGETS=1`` disables budget application to
-        # establish an A/B comparison without recompilation.  Useful for
-        # confirming whether a routing regression originates from the
-        # budget code path (per PR #3222's diagnostic pattern that
-        # confirmed board 05 does not invoke this code path).
-        if dense_packages and not os.environ.get("KCT_DISABLE_PAD_BUDGETS"):
-            pad_channel_budgets = self._build_pad_channel_budgets(dense_packages)
-            if pad_channel_budgets and hasattr(self.router, "set_pad_channel_budgets"):
-                self.router.set_pad_channel_budgets(pad_channel_budgets)
-                print(
-                    f"  Pad-channel budgets: {len(pad_channel_budgets)} "
-                    f"escape channel(s) tagged (Issue #3143)"
-                )
+        # Issue #3952: the escape pre-phase (sub-grid pre-pass, dense
+        # detection, escape generation, pad-channel budgets) is extracted
+        # into ``_run_escape_prephase`` so it can be reused verbatim as the
+        # escape leg of ``route_with_escape_and_diffpairs``'s
+        # non-diff-pair strategy.  ``route_with_escape`` keeps its exact
+        # behaviour: pre-phase then the Phase-2 main pass then the summary.
+        subgrid_escapes, dense_packages = self._run_escape_prephase()
 
         # Phase 2: Route remaining connections
         print("\n--- Phase 2: Main Routing ---")

--- a/tests/router/test_board03_routing_baseline.py
+++ b/tests/router/test_board03_routing_baseline.py
@@ -648,31 +648,22 @@ class TestBoard03RoutingBaseline:
             "needs to be regenerated)."
         )
 
-    @pytest.mark.xfail(
-        reason=(
-            "Issue #3952: --differential-pairs is inert on board 03's routing "
-            "path.  The board's fine-pitch USB-C forces the escape-routing "
-            "dispatch, and route_cmd's escape / auto-layers-escalation paths "
-            "do not consult args.differential_pairs, so route_all_with_diffpairs "
-            "(the CoupledPathfinder pre-pass) never runs.  Forcing the diff-pair "
-            "path with --no-auto-layers loses escape routing and reintroduces a "
-            "native-DRC clearance violation, so the recipe keeps --auto-layers.  "
-            "When #3952 integrates diff-pair routing into the escape path, this "
-            "flips to XPASS and should be un-xfailed."
-        ),
-        strict=False,
-    )
     def test_coupled_pathfinder_phase_a_invoked(self, route_stdout: str) -> None:
         """The diff-pair pre-pass (Phase A) actually runs under the recipe.
 
-        Executable documentation of the #3952 limitation: restoring
-        ``--differential-pairs`` (Issue #3922) makes the recipe *request*
-        coupled routing, but on board 03 the CLI dispatch never reaches the
-        ``route_all_with_diffpairs`` pre-pass.  This test asserts the
-        unconditional Phase A banner appears; it is expected to xfail until
-        #3952 wires diff-pair routing into the escape-routing path.  A
-        surprise XPASS means #3952 (or an equivalent) has landed -- remove
-        the xfail marker and pin the behavior.
+        Issue #3952 (LANDED): ``route_with_escape_and_diffpairs`` now composes
+        the escape pre-phase with the CoupledPathfinder diff-pair pre-pass, and
+        all four escape/escalation dispatch sites in ``route_cmd.py`` are gated
+        on ``args.differential_pairs`` to call it.  On board 03 the fine-pitch
+        USB-C still forces the escape dispatch, but the composed path now runs
+        Phase A: the ``=== Differential Pair Routing ===`` banner appears and
+        the USB D+/D- pair is detected.  This test was previously ``xfail`` on
+        #3952 and now hard-pins the behavior -- if it regresses to no banner,
+        the diff-pair dispatch was re-bypassed on the escape path.
+
+        (The pair still budget-exits the coupled A* and falls through to the
+        escape main pass on board 03 -- routing it *coupled* at 0 DRC needs
+        #3921 -- but Phase A running is exactly what this gate asserts.)
         """
         assert "=== Differential Pair Routing ===" in route_stdout, (
             "The diff-pair pre-pass (Phase A / route_all_with_diffpairs) did "

--- a/tests/router/test_escape_diffpair_composition.py
+++ b/tests/router/test_escape_diffpair_composition.py
@@ -1,0 +1,306 @@
+"""Escape + differential-pair composition guards (Issue #3952).
+
+``--differential-pairs`` was a silent no-op on the escape / auto-layers-
+escalation dispatch paths: ``route_with_escape`` returned before any diff-pair
+branch ran, so the CoupledPathfinder pre-pass (Phase A) was never invoked on
+boards whose fine-pitch packages force the escape dispatch (e.g. board 03's
+USB-C).  Issue #3952 fixes this by:
+
+1. Extracting ``route_with_escape``'s escape pre-phase (sub-grid pre-pass +
+   dense detection + escape generation + pad-channel budgets) into a private
+   ``Autorouter._run_escape_prephase`` helper.
+2. Adding ``Autorouter.route_with_escape_and_diffpairs`` which delegates to the
+   existing ``route_all_with_diffpairs`` (already flips
+   ``paired_escape_coupling=True`` and refreshes ``diff_pair_map`` before escape
+   generation) with the escape main-pass as its ``non_diffpair_strategy`` and
+   ``coupled_only=True`` (budget-exit pairs fall through, no net unrouted).
+3. Gating the four ``route_cmd.py`` escape-dispatch sites on
+   ``args.differential_pairs`` so no-pair boards take the byte-identical old
+   path.
+
+These are FAST unit/structural guards -- they do not run a full board route.
+The end-to-end xfail flip on board 03 is pinned by
+``tests/router/test_board03_routing_baseline.py::TestBoard03RoutingBaseline::
+test_coupled_pathfinder_phase_a_invoked``.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROUTE_CMD = REPO_ROOT / "src" / "kicad_tools" / "cli" / "route_cmd.py"
+
+
+def _tssop20_pads_with_diffpair(net_offset: int = 1) -> list[Pad]:
+    """TSSOP-20 dense fixture whose last two right-row pads are a diff pair.
+
+    Mirrors the STM32G031F6P6 geometry used in
+    ``tests/test_router_dense_escape_softstart.py`` so the dense-package
+    detector fires, but assigns ``DP_P`` / ``DP_N`` (with
+    ``diffpair_partner`` metadata handled by the caller) to two adjacent
+    same-column pads so a coupled pair exists on the package.
+    """
+    pads: list[Pad] = []
+    pin = 1
+    for i in range(10):
+        pads.append(
+            Pad(
+                x=-2.925,
+                y=-2.925 + i * 0.65,
+                width=0.4,
+                height=1.5,
+                net=net_offset + i,
+                net_name=f"NET_L{i}",
+                layer=Layer.F_CU,
+                ref="U1",
+                pin=str(pin),
+            )
+        )
+        pin += 1
+    for i in range(10):
+        pads.append(
+            Pad(
+                x=2.925,
+                y=2.925 - i * 0.65,
+                width=0.4,
+                height=1.5,
+                net=net_offset + 10 + i,
+                net_name=f"NET_R{i}",
+                layer=Layer.F_CU,
+                ref="U1",
+                pin=str(pin),
+            )
+        )
+        pin += 1
+    return pads
+
+
+def _build_router_with_tssop20() -> Autorouter:
+    """Construct an Autorouter seeded with the TSSOP-20 dense fixture."""
+    rules = DesignRules(
+        grid_resolution=0.075,
+        trace_width=0.3,
+        trace_clearance=0.15,
+        via_drill=0.3,
+        via_diameter=0.6,
+    )
+    router = Autorouter(width=20.0, height=20.0, rules=rules)
+    for pad in _tssop20_pads_with_diffpair():
+        shifted = Pad(
+            x=pad.x + 10.0,
+            y=pad.y + 10.0,
+            width=pad.width,
+            height=pad.height,
+            net=pad.net,
+            net_name=pad.net_name,
+            layer=pad.layer,
+            ref=pad.ref,
+            pin=pad.pin,
+        )
+        router.pads[(shifted.ref, shifted.pin)] = shifted
+    return router
+
+
+class TestEscapePrephaseExtraction:
+    """The ``_run_escape_prephase`` extraction is behavior-preserving."""
+
+    def test_run_escape_prephase_exists_and_returns_tuple(self) -> None:
+        """``_run_escape_prephase`` returns ``(subgrid_escapes, dense_packages)``."""
+        router = _build_router_with_tssop20()
+        result = router._run_escape_prephase()
+        assert isinstance(result, tuple) and len(result) == 2, (
+            "Issue #3952: _run_escape_prephase must return a 2-tuple of "
+            "(subgrid_escapes, dense_packages)."
+        )
+        subgrid_escapes, dense_packages = result
+        assert isinstance(subgrid_escapes, list)
+        assert isinstance(dense_packages, list)
+        refs = {pkg.ref for pkg in dense_packages}
+        assert "U1" in refs, (
+            "The extracted pre-phase must still detect the TSSOP-20 dense "
+            "package (regression firewall for the escape pre-phase extraction)."
+        )
+
+    def test_route_with_escape_delegates_to_prephase(self) -> None:
+        """``route_with_escape`` still runs the pre-phase then the main pass.
+
+        Refactor-safety guard: ``route_with_escape``'s source must call
+        ``_run_escape_prephase`` (the extraction) rather than inline the
+        Phase-1 body, so the escape method and the diff-pair composition share
+        exactly one copy of the escape pre-phase logic.
+        """
+        source = inspect.getsource(Autorouter.route_with_escape)
+        assert "_run_escape_prephase()" in source, (
+            "route_with_escape must delegate its Phase-1 body to "
+            "_run_escape_prephase (Issue #3952 extraction)."
+        )
+
+    def test_escape_generation_idempotency_guard_present(self) -> None:
+        """The one-shot ``_escapes_generated_this_run`` guard exists.
+
+        This is the documented fallback for the escape-generation idempotency
+        risk the architect flagged: the diff-pair pre-pass and the closure's
+        ``_run_escape_prephase`` must not double-generate escapes for the same
+        dense package.  The guard lets ``_run_escape_prephase`` skip
+        regeneration when the diff-pair pre-pass already escaped a package.
+        """
+        router = _build_router_with_tssop20()
+        assert hasattr(router, "_escapes_generated_this_run")
+        assert router._escapes_generated_this_run is False
+
+        # First call generates escapes and flips the guard.
+        router._run_escape_prephase()
+        assert router._escapes_generated_this_run is True
+
+        prephase_src = inspect.getsource(Autorouter._run_escape_prephase)
+        assert "_escapes_generated_this_run" in prephase_src, (
+            "_run_escape_prephase must consult the one-shot guard so a second "
+            "call in the same run does not double-generate escapes (Issue #3952)."
+        )
+
+
+class TestRouteWithEscapeAndDiffpairs:
+    """The composition orchestrator wires Phase A into the escape path."""
+
+    def test_orchestrator_exists_with_expected_signature(self) -> None:
+        """``route_with_escape_and_diffpairs`` exists and takes a diffpair_config."""
+        assert hasattr(Autorouter, "route_with_escape_and_diffpairs")
+        sig = inspect.signature(Autorouter.route_with_escape_and_diffpairs)
+        params = list(sig.parameters)
+        assert params[1] == "diffpair_config", (
+            "route_with_escape_and_diffpairs's first non-self parameter must be diffpair_config."
+        )
+        for expected in ("use_negotiated", "timeout", "per_net_timeout"):
+            assert expected in params, (
+                f"route_with_escape_and_diffpairs must accept '{expected}' so the "
+                "CLI dispatch sites can forward their per-attempt budgets."
+            )
+
+    def test_orchestrator_delegates_to_route_all_with_diffpairs(self) -> None:
+        """The orchestrator reuses ``route_all_with_diffpairs`` with the escape
+        main-pass as the ``non_diffpair_strategy`` and ``coupled_only=True``.
+
+        This is the crux of the architect's design: rather than re-implement
+        the paired-escape-coupling ordering, delegate to the one entry point
+        that already owns it.
+        """
+        source = inspect.getsource(Autorouter.route_with_escape_and_diffpairs)
+        assert "route_all_with_diffpairs" in source, (
+            "route_with_escape_and_diffpairs must delegate to "
+            "route_all_with_diffpairs (Issue #3952 design)."
+        )
+        assert "non_diffpair_strategy" in source
+        assert "coupled_only=True" in source, (
+            "coupled_only=True ensures budget-exit pairs fall through to the "
+            "escape main pass so no net goes unrouted (Issue #3952)."
+        )
+        assert "_run_escape_prephase" in source, (
+            "The non_diffpair_strategy closure must run the escape pre-phase "
+            "before the main pass so escape geometry is preserved."
+        )
+
+
+class TestCliDispatchGating:
+    """All four escape-dispatch sites are gated on ``--differential-pairs``.
+
+    Issue #3952: the three escalation dispatch sites (layer / rule / combined)
+    plus ``do_routing()``'s escape branch used to call ``route_with_escape``
+    unconditionally.  They must now call ``route_with_escape_and_diffpairs``
+    when diff pairs are requested and the unchanged ``route_with_escape``
+    otherwise (the no-pair regression firewall).
+    """
+
+    def test_all_dispatch_sites_call_the_composed_orchestrator(self) -> None:
+        """``route_with_escape_and_diffpairs`` is called at four+ sites."""
+        source = ROUTE_CMD.read_text()
+        n_composed = source.count("route_with_escape_and_diffpairs(")
+        # 1 method def in core is elsewhere; here we count CLI call sites.
+        # Four dispatch sites: layer / rule / combined escalation + do_routing.
+        assert n_composed >= 4, (
+            "Expected the composed orchestrator to be called at all four "
+            f"escape-dispatch sites; found {n_composed} call(s).  A missing "
+            "call means one dispatch path still bypasses Phase A (Issue #3952)."
+        )
+
+    def test_each_composed_call_is_gated(self) -> None:
+        """Each composed-orchestrator call is guarded by a diff-pair check.
+
+        Parses ``route_cmd.py`` and asserts that every
+        ``route_with_escape_and_diffpairs`` call has a diff-pair gate (either
+        ``args.differential_pairs`` or a ``_build_diffpair_config`` truthiness
+        check) in an enclosing ``if`` so no-pair boards keep the old path.
+        """
+        source = ROUTE_CMD.read_text()
+        tree = ast.parse(source)
+
+        composed_calls: list[ast.Call] = []
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "route_with_escape_and_diffpairs"
+            ):
+                composed_calls.append(node)
+
+        assert len(composed_calls) >= 4, (
+            f"Expected >= 4 composed calls, found {len(composed_calls)}."
+        )
+
+        # Build a parent map so we can walk up from each call to its enclosing
+        # ``if`` and check the test guards on diff pairs.
+        parents: dict[ast.AST, ast.AST] = {}
+        for parent in ast.walk(tree):
+            for child in ast.iter_child_nodes(parent):
+                parents[child] = parent
+
+        def _enclosing_if_tests(node: ast.AST) -> str:
+            texts: list[str] = []
+            cur: ast.AST | None = node
+            while cur is not None:
+                if isinstance(cur, ast.If):
+                    texts.append(ast.unparse(cur.test))
+                cur = parents.get(cur)
+            return " ".join(texts)
+
+        for call in composed_calls:
+            guard_text = _enclosing_if_tests(call)
+            assert "differential_pairs" in guard_text or "_dp_cfg" in guard_text, (
+                "Every route_with_escape_and_diffpairs call must sit under a "
+                "diff-pair gate (args.differential_pairs / _dp_cfg) so no-pair "
+                "boards take the byte-identical route_with_escape path "
+                f"(Issue #3952).  Guard chain seen: {guard_text!r}"
+            )
+
+    def test_build_diffpair_config_returns_none_without_flag(self) -> None:
+        """``_build_diffpair_config`` returns None when the flag is off.
+
+        This is the regression firewall: the escalation sites gate on a
+        non-None result, so a board routed WITHOUT ``--differential-pairs``
+        takes the unchanged ``route_with_escape`` path.
+        """
+        from kicad_tools.cli.route_cmd import _build_diffpair_config
+
+        class _Args:
+            differential_pairs = False
+
+        assert _build_diffpair_config(_Args()) is None
+
+        class _ArgsOn:
+            differential_pairs = True
+            diffpair_spacing = 0.2
+            diffpair_max_delta = 0.5
+            diffpair_per_pair_timeout = None
+
+        cfg = _build_diffpair_config(_ArgsOn())
+        assert cfg is not None and cfg.enabled is True
+        assert cfg.spacing == pytest.approx(0.2)


### PR DESCRIPTION
## Summary

`--differential-pairs` was a silent no-op on the escape / auto-layers-escalation
routing paths. On boards whose fine-pitch packages force the escape dispatch
(e.g. board 03's USB-C connector), `route_with_escape` returned before any
diff-pair branch ran, so the CoupledPathfinder pre-pass (Phase A) was never
invoked — the flag was accepted and ignored.

This PR composes escape routing with the differential-pair pre-pass by
delegating to the existing `route_all_with_diffpairs` machinery (which already
flips `paired_escape_coupling=True` and refreshes the `diff_pair_map` before the
escape phase) with the escape main-pass as its `non_diffpair_strategy`, per the
architect's refined Option A.

## Changes

- **core.py**: extract `route_with_escape`'s escape pre-phase (sub-grid pre-pass
  + dense detection + `generate_escape_routes` + pad-channel budgets) into a
  private `_run_escape_prephase()` helper. `route_with_escape` keeps its exact
  behaviour (pre-phase → Phase-2 main pass → summary) — the regression firewall
  for no-pair boards.
- **core.py**: add `route_with_escape_and_diffpairs(diffpair_config, ...)` which
  calls `route_all_with_diffpairs(non_diffpair_strategy=<escape-prephase-then-
  two-phase closure>, coupled_only=True)`. Budget-exit pairs drop back into the
  main pass so no net goes unrouted (the xfail flips WITHOUT needing #3921).
- **core.py**: reset `paired_escape_coupling`/`diff_pair_map` inside the
  non-diff-pair closure before the fall-through escape generation, so a pair
  that budget-exits does not emit paired escapes that perturb a neighbouring
  net's channel (measured: without this, board 03's XTAL1 regressed 13/13 →
  12/13). Committed coupled routes are already grid-marked and are not
  regenerated, so the reset is safe for the coupled-success path too. Plus a
  one-shot `_escapes_generated_this_run` guard (documented idempotency fallback).
- **route_cmd.py**: gate the four escape-dispatch sites (layer / rule / combined
  escalation + `do_routing()`'s escape branch) on `args.differential_pairs` to
  call the new orchestrator; no-pair boards take the byte-identical old path.
  Adds `_build_diffpair_config(args)` so the escalation functions build the same
  config as `do_routing()`.
- **tests**: un-xfail `test_coupled_pathfinder_phase_a_invoked` (now hard-pins
  the Phase A banner); add `test_escape_diffpair_composition.py` (prephase
  extraction, orchestrator delegation, 4-dispatch-site gating, idempotency
  guard, no-pair firewall).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `test_coupled_pathfinder_phase_a_invoked` flips xfail→XPASS, un-xfailed | ✅ | banner `=== Differential Pair Routing ===` + `Detected 1 differential pairs` now present; marker removed, behaviour hard-pinned |
| Board 03 routes 13/13 with coupled-routing evidence | ✅ | `test_reach_meets_floor` (13/13) + `test_per_net_reach_usb_signals` (0 partial/0 unrouted) green; full class 4/4 in 67s |
| Escape-generation idempotency validated empirically | ✅ | no double-generation (the coupled pre-pass does not call `generate_escape_routes`); the reach hazard was a paired-escape geometry perturbation on the budget-exit path, fixed by resetting the paired map |
| No-pair boards byte-identical behaviour | ✅ | CLI gate means no-pair boards never call the new orchestrator; full fast escape/diffpair/coupled surface (1259 passed) + census/choke-point (102 passed) green |
| #3975 census / choke-point suites stay green | ✅ | `test_fleet_45_census`, `test_segment_45_choke_point`, `test_segment_emission_choke_point_lint` all pass |

## Test Plan

- `tests/router/test_board03_routing_baseline.py::TestBoard03RoutingBaseline` — 4/4 green (xfail flip + 13/13 reach + 0 partial).
- `tests/router/test_escape_diffpair_composition.py` — 8 new fast guards.
- Fast diffpair/coupled/escape surface: 1259 passed, 5 skipped.
- Census + choke-point + board 06/07 fast gates: 102 passed, 1 skipped.
- ruff clean; no new mypy errors (core.py 47→47, route_cmd.py 30→30 baseline unchanged).

## Dependency note

**#3921** (CoupledPathfinder convergence) is NOT a blocker. This issue makes
Phase A *run* (xfail → XPASS); #3921 makes the USB pair *route coupled at 0 DRC*
rather than budget-exiting to the negotiated fall-through. On board 03 the pair
budget-exits and falls through to the identical present-day 13/13 copper, so no
regression.

Closes #3952