### PR TITLE
docs(diffpair): record shadow-ON blockers; add reproducible board-06 toggle

### DIFF
--- a/boards/06-diffpair-test/generate_design.py
+++ b/boards/06-diffpair-test/generate_design.py
@@ -1834,17 +1834,33 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
     # back to the Python pathfinder there) and the budget must cover
     # probe + shadow + swapped-probe + bounded fallback searches.
     # Issue #3508 (decomposition): the geometric shadow constructor is
-    # kept OFF for this recipe.  The 2026-06-11 seed-42 integration
-    # measurement (run-4) showed it converts 6/9 pairs nominally but
-    # the committed geometry is not yet artifact-quality: stranded
-    # shadow tails (USB3_RX1+/RX2+ goal pads), shadow vias physically
-    # intersecting the partner trace at the tightly-coupled gap, and
-    # greedily-claimed pre-phase corridors stranding MIPI_D0-/USB_CC1
-    # (16/21 reach vs the asserted 21/21; strict-gate 49 blocking vs
-    # the committed floor 20).  Flip BOTH this constant and the
-    # optimizer/nudge diff-pair protections below together once the
-    # #3508 follow-up issues land.
-    ENABLE_COUPLED_SHADOW = False
+    # kept OFF for this recipe.  Set ``KCT_BOARD06_SHADOW=1`` to reproduce
+    # the shadow-ON run (the constant defaults False so the committed
+    # artifact and CI stay on the pre-#3508 budget-exit behaviour).
+    #
+    # Issue #3921 (2026-07-08 re-scope + re-measure): two of the three
+    # original artifact-quality defects are now FIXED on main -- stranded
+    # shadow tails (#3665 transactional connectivity rollback) and shadow
+    # vias intersecting the partner (#3667 full-polyline via validation).
+    # The re-scoped corridor-competition defect did NOT reproduce on the
+    # current (#3413-phase-6, tightened-width) geometry: the shadow-ON
+    # seed-42 re-run reached 15/15 single-ended nets at its best
+    # negotiated snapshot (MIPI_D0-/USB_CC1 not stranded).  But shadow-ON
+    # is still not shippable here for two deeper reasons:
+    #   * Convergence collapsed 6-7/9 -> 3/9.  The 0.225-0.275 mm coupled
+    #     widths make the geometric parallel offset infeasible for 6/9
+    #     pairs (self-check overlap -0.165..-0.275 mm; mid-route blockage).
+    #   * The surviving shadow segments are 3.7-11.9 deg off-angle
+    #     (#3975 OffAngleSegmentWarning -> would fail the 45-census if
+    #     committed) and the 6 fallbacks blow the wall-clock (>1200 s vs
+    #     ~150 s / 21-21 shadow-OFF; the negotiated 360 s backstop fires).
+    # Enabling by default needs a shadow-aware by-construction dogleg
+    # (#3907/#3975) plus a parallel-offset feasibility fix at the tight
+    # widths.  When BOTH land, flip the env default and the optimizer/nudge
+    # diff-pair protections below together.  See #3921 for the full data.
+    import os as _os
+
+    ENABLE_COUPLED_SHADOW = _os.environ.get("KCT_BOARD06_SHADOW", "0") == "1"
 
     diffpair_config = DifferentialPairConfig(
         enabled=True,

--- a/src/kicad_tools/router/diffpair.py
+++ b/src/kicad_tools/router/diffpair.py
@@ -622,19 +622,50 @@ class DifferentialPairConfig:
     # (``DiffPairRouter._shadow_route_pair``: single-ended guide route
     # + validated parallel offset, tried before the joint-state
     # coupled A*).  The constructor converges pairs the joint search
-    # cannot (6/9 nominal on board 06's seed-42 recipe vs 0/9), but
-    # the 2026-06-11 board 06 integration measurement shows its
-    # committed geometry is not yet artifact-quality: shadow tails can
-    # leave goal pads stranded while still claiming the net
-    # (USB3_RX1+/RX2+ "1 of 2 pads stranded"), staggered shadow vias
-    # physically intersect the partner trace at tightly-coupled gaps
-    # (0.3 mm via radius > 0.15 mm edge gap + 0.1125 mm half-width),
-    # and the pre-phase's greedily-claimed corridors strand later
-    # single-ended nets that the negotiated loop cannot rip
-    # (MIPI_D0-, USB_CC1 -> 16/21 reach vs board 06's asserted
-    # 21/21).  Default False keeps recipes on their pre-#3508
-    # budget-exit behaviour; flip on per-board once the #3508
-    # decomposition follow-ups land.
+    # cannot -- historically 6-7/9 on board 06's seed-42 recipe vs 0/9
+    # for the joint A* -- but its committed geometry has not been
+    # artifact-quality.  The three original defects (2026-06-11 run-4):
+    #
+    #   1. Stranded shadow tails: a parallel-offset tail claimed the net
+    #      but left a goal pad unreachable (USB3_RX1+/RX2+ "1 of 2 pads
+    #      stranded").  FIXED (#3665): the post-commit
+    #      ``validate_net_connectivity`` check rolls back the whole pair
+    #      on any strand (``diffpair_routing.py`` ~4795-4866).
+    #   2. Shadow via intersecting the partner trace at tightly-coupled
+    #      gaps.  FIXED (#3667): via sites are validated against the full
+    #      guide polyline with the crossing-tail via-clear bound
+    #      (``_shadow_route_pair`` ~3448-3465).
+    #   3. Corridor competition stranding later single-ended nets.  This
+    #      one did NOT reproduce on the current (post-#3413-phase-6)
+    #      board-06 geometry: the 2026-07-08 seed-42 shadow-ON re-run
+    #      reached 15/15 single-ended nets at its best negotiated
+    #      snapshot -- MIPI_D0-/USB_CC1 were not stranded.
+    #
+    # Issue #3921 (2026-07-08) re-measured shadow-ON end-to-end and found
+    # TWO NEW blockers that keep the flag OFF on the current geometry:
+    #
+    #   A. Convergence collapsed to 3/9.  The tightened coupled widths
+    #      (0.225-0.275 mm from #3413 phase 6) make the geometric parallel
+    #      offset infeasible for 6/9 pairs: the offset lands copper on the
+    #      partner (10 "self-check overlap" events, worst -0.165..-0.275 mm)
+    #      or cannot clear an obstacle the guide threaded (12 "mid-route
+    #      blockage" events).  Only MIPI_CLK/MIPI_D0/PCIE_RX construct.
+    #   B. Off-angle geometry + wall-time blowup.  The surviving shadow
+    #      segments serialize at 3.7-11.9 deg off the 0/45/90/135 set
+    #      (``OffAngleSegmentWarning`` from the #3975 emission guard), so a
+    #      committed shadow-ON artifact would fail the fleet 45-census; and
+    #      the 6 failed-shadow pairs fall back to a ~350 s coupled pre-phase
+    #      plus a negotiated phase that hits its 360 s backstop, blowing the
+    #      CI wall-clock (>1200 s vs ~150 s shadow-OFF, which reaches 21/21).
+    #
+    # Enabling this by default is therefore blocked on (i) a shadow-aware
+    # by-construction dogleg at the emission site (migrating
+    # ``_shadow_route_pair`` per #3907/#3975) and (ii) restoring the
+    # parallel-offset feasibility at the tightened widths -- both deeper
+    # than the corridor-competition rip-up this field was re-scoped for.
+    # Set ``KCT_BOARD06_SHADOW=1`` on the board-06 recipe to reproduce the
+    # shadow-ON run.  Default False keeps recipes on their pre-#3508
+    # budget-exit behaviour (0/9 coupled, 21/21 single-ended reach).
     enable_shadow_construction: bool = False
 
     def get_rules(self, pair_type: DifferentialPairType) -> DifferentialPairRules:

--- a/tests/test_diffpair_shadow.py
+++ b/tests/test_diffpair_shadow.py
@@ -335,11 +335,21 @@ def test_proximity_guard_allows_exact_min_spacing():
 def test_shadow_construction_flag_defaults_off():
     """The geometric shadow constructor is opt-in (default False).
 
-    The 2026-06-11 board 06 seed-42 integration run showed the
-    constructor's committed geometry is not yet artifact-quality
-    (stranded shadow tails, shadow-via/partner intersections, corridor
-    competition stranding single-ended nets -> 16/21 reach).  Recipes
-    must explicitly opt in once the follow-up issues land.
+    Two of the three original artifact-quality defects are fixed on main
+    (stranded shadow tails -> #3665 transactional rollback; shadow-via /
+    partner intersections -> #3667 full-polyline via validation), and the
+    corridor-competition defect did not reproduce on the current
+    tightened-width geometry (#3921 seed-42 re-run reached 15/15 singles).
+
+    The flag stays OFF because the #3921 (2026-07-08) end-to-end
+    re-measurement found shadow-ON still un-shippable on board 06:
+    convergence collapsed to 3/9 (the 0.225-0.275 mm coupled widths make
+    the geometric parallel offset infeasible for 6/9 pairs), the surviving
+    shadow segments are off-angle (would fail the #3975 45-census if
+    committed), and the fallbacks blow the CI wall-clock (>1200 s vs
+    ~150 s / 21-21 shadow-OFF).  Flipping this default would regress CI;
+    it stays opt-in until a shadow-aware by-construction dogleg and a
+    parallel-offset feasibility fix land.  See #3921 for the full data.
     """
     from kicad_tools.router.diffpair import DifferentialPairConfig
 


### PR DESCRIPTION
## Summary

Issue #3921 was re-scoped (owner, 2026-07-08) to **shadow-constructor quality work**: fix the artifact-quality defects that keep `enable_shadow_construction` OFF, then enable it by default for coupled routing. I ran the full end-to-end seed-42 measurement on board 06 (both shadow-OFF and shadow-ON) and found that **shadow-ON cannot be enabled by default on the current board geometry without regressing CI**. Per the issue's explicit guidance ("if the corridor-competition fix proves architecturally deep ... STOP, do not force it ... an honest partial beats a regression"), this PR ships only the safe, documented subset and keeps the flag OFF.

This is a **partial** (Refs, not Closes): the acceptance criterion "shadow ON by default for coupled routing" cannot be met safely; the remaining work is deeper than the corridor-competition rip-up the issue was re-scoped for (see Findings).

## Findings (board 06, seed 42, PYTHONHASHSEED=42)

| | shadow OFF (default) | shadow ON |
|---|---|---|
| Coupled convergence | 0/9 | **3/9** (MIPI_CLK, MIPI_D0, PCIE_RX) |
| Single-ended reach | **21/21** (SUCCESS) | 15/15 at best negotiated snapshot |
| Wall-clock | ~150 s, completes | **>1200 s, times out** (never serializes) |
| Off-angle geometry | none | 3.7-11.9 deg off-angle shadow segments |

- **Defect 1** (stranded shadow tails) and **Defect 2** (shadow-via/partner intersection) are confirmed **FIXED** on main (#3665 transactional connectivity rollback, #3667 full-polyline via validation).
- **Defect 3** (corridor competition stranding MIPI_D0-/USB_CC1) **did NOT reproduce** on the current (#3413-phase-6, tightened-width) geometry: the shadow-ON run reached 15/15 single-ended nets at its best negotiated snapshot. The negotiated relief-rescue already rips coupled copper when it strands a single (observed even in the shadow-OFF baseline: "Relief rescue: MIPI_RST ... ripped 4 blocker(s): MIPI_CLK+/-, MIPI_D0+/-").
- **Two deeper blockers remain**, both outside the re-scoped corridor-competition work:
  1. **Convergence collapsed 6-7/9 -> 3/9.** The 0.225-0.275 mm coupled widths make the geometric parallel offset infeasible for 6/9 pairs: 10 "self-check overlap" events (offset lands copper on the partner, worst -0.165..-0.275 mm) and 12 "mid-route blockage" events.
  2. **Off-angle geometry + wall-time blowup.** The surviving shadow segments serialize off-angle (`OffAngleSegmentWarning` from the #3975 emission guard) so a committed shadow-ON artifact would fail `test_fleet_45_census.py`; and the 6 failed-shadow fallbacks drive a ~350 s coupled pre-phase plus a negotiated phase that hits its 360 s backstop, so the run never completes within a CI-affordable budget.

Enabling shadow-ON by default needs (i) a shadow-aware **by-construction dogleg** at the emission site (migrating `_shadow_route_pair` per #3907/#3975) and (ii) a **parallel-offset feasibility fix** at the tightened widths. Both are new, deeper efforts than a corridor-competition rip-up.

## Changes

- `boards/06-diffpair-test/generate_design.py`: read `ENABLE_COUPLED_SHADOW` from the `KCT_BOARD06_SHADOW` env var (default `0`/OFF) so the shadow-ON run is reproducible without editing the recipe; committed artifact and CI behavior unchanged. Comment block updated with the 2026-07-08 findings.
- `src/kicad_tools/router/diffpair.py`: rewrite the `enable_shadow_construction` field docstring — fixed-defect status (#3665/#3667), the corridor-competition non-reproduction, and the two remaining blockers.
- `tests/test_diffpair_shadow.py`: expand `test_shadow_construction_flag_defaults_off`'s rationale to cite the #3921 measurement.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Shadow ON by default for coupled routing | ❌ not delivered | Would regress CI (>1200 s, off-angle census failure, 3/9). STOP condition per issue guidance; kept OFF. |
| Board-06 convergence measurably >0/9 | ◑ measured 3/9 | Shadow-ON reaches 3/9 but is not shippable (wall-time/off-angle). Documented, not enabled. |
| Board-06 single-net reach not regressed | ✅ | shadow-OFF default stays 21/21; committed artifact unchanged. |
| No DRC/census/skew regressions on 03/06/07 | ✅ | `test_fleet_45_census.py` green (committed artifact untouched); default path unchanged. |
| #3855 corridor cases handled/exempted | ✅ exempted | Corridor competition did not reproduce; documented as such. |

## Test Plan

- `uv run pytest tests/test_diffpair_shadow.py tests/test_diffpair_per_pair_timeout.py` — 37 passed.
- `uv run pytest tests/test_diffpair_routing_integration.py tests/test_fleet_45_census.py` — passed (committed board-06 artifact restored; re-route outputs are not part of this PR).
- `uv run ruff check .` — clean. `uv run ruff format --check` — clean. mypy: 2 pre-existing errors in `diffpair.py` unrelated to this change (verified via stash).
- Baseline shadow-OFF re-route: 21/21 signal nets routed, 0/9 coupled. Shadow-ON re-route (`KCT_BOARD06_SHADOW=1`): 3/9 coupled, times out.

Refs #3921