### PR TITLE
feat(diffpair): quantize shadow copper by construction + hard per-pair shadow budget

### DIFF
--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -43,6 +43,11 @@ from .layers import Layer
 from .observability import validate_net_connectivity
 from .path import calculate_route_length
 from .primitives import Pad, Route, Segment, Via
+from .quantize import (
+    OffAngleSegmentError,
+    dogleg_points,
+    verify_segment_45,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -108,6 +113,19 @@ NEAR_MISS_RESCUE_CELLS: int = int(os.environ.get("KCT_COUPLED_RESCUE_CELLS", "60
 # keeps the coupled-length fraction comfortably above the 0.7-0.9
 # continuity thresholds.
 _SHADOW_MAX_TRIM_MM: float = float(os.environ.get("KCT_SHADOW_MAX_TRIM_MM", "5.0"))
+
+# Issue #3987 (unit 2a of #3921): hard per-pair wall-clock budget for the
+# shadow-construction coupled attempt.  When ``enable_shadow_construction``
+# is on, a pair is routed either as a validated parallel shadow (ms) or it
+# is DEFERRED to the uncoupled fallback -- it must NOT fall through to the
+# open joint-state A* search, which floods the cost_turn f-plateaus and
+# drove the >1200s tail the #3986 board-06 measurements documented (6 of 9
+# failed-shadow pairs each burned a ~45s corridor probe plus the negotiated
+# 360s backstop).  This budget bounds the corridor probe + shadow
+# construction per pair; on shadow failure the search fails fast to the
+# uncoupled fallback without re-flooding the open A*.  Env-overridable for
+# experimentation (KCT_SHADOW_PER_PAIR_BUDGET_S).
+_SHADOW_PER_PAIR_BUDGET_S: float = float(os.environ.get("KCT_SHADOW_PER_PAIR_BUDGET_S", "30.0"))
 
 
 # ---------------------------------------------------------------------------
@@ -3388,6 +3406,136 @@ class DiffPairRouter:
             )
         return tail
 
+    def _quantize_shadow_segments(
+        self,
+        route: Route,
+        pathfinder: CoupledPathfinder,
+    ) -> None:
+        """Rewrite off-angle shadow segments as 45-legal doglegs, in place.
+
+        Issue #3987 (unit 2a of #3921).  The shadow guide is the C++
+        on-grid per-net router's output, so every guide segment is already
+        45-aligned; off-angle shadow copper comes only from three
+        non-offset construction sites in :meth:`_shadow_route_pair`:
+
+        1. the raw miter-apex join at guide corners (acute / mixed
+           axis-diagonal turns land the apex off-grid, 3.7-11.9 deg off),
+        2. the shadow-via jog segments (the via site is chosen from a
+           lateral/stagger lattice that is not on the 8-direction set), and
+        3. the pad-approach rescue tails (off-grid pad centres).
+
+        Rather than dogleg each site individually, this pass lifts the
+        battle-tested file-layer transform (:func:`quantize.dogleg_points`,
+        #3532 / #3907) to the route layer: it walks the assembled
+        ``route.segments`` once and replaces any segment whose displacement
+        is off the {0, 45, 90, 135} set with a two-leg dogleg that shares
+        both endpoints exactly.  This makes shadow copper 45-compliant by
+        construction (census-clean, no ``OffAngleSegmentWarning``) with a
+        single transform covering all three sites -- the #3975 pattern
+        lifted from the file layer to the route layer.
+
+        The pass is OBSTACLE-AWARE (mirroring the subgrid escape doglegs of
+        #3975): a dogleg's perpendicular bulge is bounded by
+        ``min(|dx|, |dy|)`` but can still touch copper, so each candidate
+        variant's legs are re-rastered against ``pathfinder._is_cell_blocked``
+        and the first variant whose legs are both clear is kept.  When
+        neither the default nor the ``axis_first`` (outboard-bulge) variant
+        clears, the original segment is left untouched -- the downstream
+        self-check / physical-overlap gates and the emission census still
+        apply, so a residual off-angle segment degrades gracefully rather
+        than shipping a short.
+
+        The alignment decision is made on the SERIALIZED (4-decimal) copper
+        via :func:`quantize.verify_segment_45` -- the same predicate the
+        emission census reads -- not on the raw analytic displacement.  A
+        shadow body offset can be exactly 45-aligned analytically yet round
+        to a 2-quantum-asymmetric diagonal (``dx=0.0501, dy=0.0499``, 0.11
+        deg off), which the census flags; deciding on the raw floats would
+        skip it.  Doglegging on the rounded endpoints yields one exact axis
+        leg + one exact diagonal leg that both pass the census.
+        """
+        grid = self.autorouter.grid
+
+        def _is_census_clean(x1: float, y1: float, x2: float, y2: float) -> bool:
+            # True iff the SERIALIZED segment passes the emission census
+            # (``verify_segment_45`` accepts axis/diagonal within one 0.1 um
+            # quantum).  Forced strict so it raises rather than warns.
+            try:
+                verify_segment_45(x1, y1, x2, y2, strict=True)
+            except OffAngleSegmentError:
+                return False
+            return True
+
+        new_segments: list[Segment] = []
+        for seg in route.segments:
+            # Decide on the serialized (4dp) copper the census governs.
+            rx1, ry1 = round(seg.x1, 4), round(seg.y1, 4)
+            rx2, ry2 = round(seg.x2, 4), round(seg.y2, 4)
+            if _is_census_clean(rx1, ry1, rx2, ry2):
+                new_segments.append(seg)
+                continue
+            li = grid.layer_to_index(seg.layer.value)
+
+            def _legs_clear(mid: tuple[float, float], _li: int = li, _seg: Segment = seg) -> bool:
+                for x1, y1, x2, y2 in (
+                    (_seg.x1, _seg.y1, mid[0], mid[1]),
+                    (mid[0], mid[1], _seg.x2, _seg.y2),
+                ):
+                    seg_len = math.hypot(x2 - x1, y2 - y1)
+                    if seg_len < 1e-9:
+                        continue
+                    n_steps = max(1, int(math.ceil(seg_len / grid.resolution)))
+                    for i in range(n_steps + 1):
+                        t = i / n_steps
+                        gx, gy = grid.world_to_grid(x1 + (x2 - x1) * t, y1 + (y2 - y1) * t)
+                        if pathfinder._is_cell_blocked(gx, gy, _li, _seg.net):
+                            return False
+                return True
+
+            chosen_mid: tuple[float, float] | None = None
+            for axis_first in (False, True):
+                # Dogleg on the ROUNDED endpoints so the two legs the census
+                # reads are exactly axis / diagonal.
+                pts = dogleg_points(rx1, ry1, rx2, ry2, axis_first=axis_first)
+                if len(pts) != 3:
+                    # Already aligned after rounding: keep as-is.
+                    break
+                mid = pts[1]
+                # Only accept a variant whose BOTH legs are census-clean AND
+                # obstacle-clear.
+                if (
+                    _is_census_clean(rx1, ry1, mid[0], mid[1])
+                    and _is_census_clean(mid[0], mid[1], rx2, ry2)
+                    and _legs_clear(mid)
+                ):
+                    chosen_mid = mid
+                    break
+            if chosen_mid is None:
+                # No clean+clear dogleg variant -- keep the original segment;
+                # the self-check / overlap gates and the emission census
+                # still apply.  Graceful degradation, not a silent short.
+                new_segments.append(seg)
+                continue
+            for x1, y1, x2, y2 in (
+                (rx1, ry1, chosen_mid[0], chosen_mid[1]),
+                (chosen_mid[0], chosen_mid[1], rx2, ry2),
+            ):
+                if math.hypot(x2 - x1, y2 - y1) < 1e-9:
+                    continue
+                new_segments.append(
+                    Segment(
+                        x1=x1,
+                        y1=y1,
+                        x2=x2,
+                        y2=y2,
+                        width=seg.width,
+                        layer=seg.layer,
+                        net=seg.net,
+                        net_name=seg.net_name,
+                    )
+                )
+        route.segments[:] = new_segments
+
     def _shadow_route_pair(
         self,
         pair: DifferentialPair,
@@ -3825,6 +3973,19 @@ class DiffPairRouter:
                 )
             shadow_route.segments.extend(end_tail.segments)
             shadow_route.vias.extend(end_tail.vias)
+
+            # Issue #3987 (unit 2a of #3921): make the assembled shadow
+            # copper 45-compliant BY CONSTRUCTION.  The guide (P side, or N
+            # when swapped) is the C++ on-grid router's output and is
+            # already 45-aligned; the geometric shadow (miter apex, via
+            # jogs, pad-approach tails) is the only off-angle source.  Run
+            # the dogleg pass over the assembled shadow segments BEFORE the
+            # self-check / overlap gates below, so the doglegged geometry is
+            # what those gates -- and the downstream emission census
+            # (#3975) -- validate.  A residual off-angle segment (no clear
+            # dogleg variant) degrades gracefully; it is not silently
+            # shipped as a short.
+            self._quantize_shadow_segments(shadow_route, pathfinder)
 
             guide_net_pad = spec.n_start if swap_roles else spec.p_start
             guide_route_obj = Route(net=guide_net_pad.net, net_name=guide_net_pad.net_name)
@@ -4292,7 +4453,15 @@ class DiffPairRouter:
             if per_pair_timeout is None:
                 probe_timeout = None
             elif self.enable_shadow_construction:
-                probe_timeout = min(max(per_pair_timeout * 0.125, 45.0), per_pair_timeout * 0.5)
+                # Issue #3987 (unit 2a of #3921): a hard per-pair shadow
+                # budget.  When shadow is ON the pair is shadow-or-uncoupled
+                # (the joint-state fallback is gated OFF below), so the whole
+                # coupled attempt must fit a small budget: cap the P guide
+                # probe at ``_SHADOW_PER_PAIR_BUDGET_S`` (clamped to
+                # ``per_pair_timeout``).  This bounds the >1200s #3986 tail
+                # -- 6/9 failed-shadow pairs previously each burned a ~45s
+                # probe before falling through to the flooded A*.
+                probe_timeout = min(_SHADOW_PER_PAIR_BUDGET_S, per_pair_timeout)
             else:
                 probe_timeout = per_pair_timeout * 0.125
             probe_t0 = time.monotonic()
@@ -4343,8 +4512,21 @@ class DiffPairRouter:
                 # the N side (same endpoints geometry) will not be
                 # either, and the retry would just burn a second probe
                 # budget per deferred pair.
+                # Issue #3987: bound the N (swapped) probe by the REMAINDER
+                # of the hard per-pair shadow budget so the two probes
+                # together cannot exceed ``_SHADOW_PER_PAIR_BUDGET_S`` --
+                # the fail-fast contract is per PAIR, not per probe.
+                n_probe_timeout = probe_timeout
+                if per_pair_timeout is not None and probe_timeout is not None:
+                    n_probe_timeout = max(
+                        0.5,
+                        min(
+                            probe_timeout,
+                            _SHADOW_PER_PAIR_BUDGET_S - (time.monotonic() - spec_t0),
+                        ),
+                    )
                 n_guide = self._single_ended_guide_route(
-                    spec.n_start, spec.n_end, per_net_timeout=probe_timeout
+                    spec.n_start, spec.n_end, per_net_timeout=n_probe_timeout
                 )
                 if n_guide is not None and n_guide.segments:
                     shadow = self._shadow_route_pair(
@@ -4357,7 +4539,25 @@ class DiffPairRouter:
                             "    [coupled-shadow] pair constructed as N guide + parallel P shadow"
                         )
 
-            if result is None and guide_route is not None and guide_route.segments:
+            # Issue #3987 (unit 2a of #3921): when the shadow constructor is
+            # ON, a pair is EITHER a validated parallel shadow (ms) OR it is
+            # deferred to the uncoupled fallback.  It must NOT fall through
+            # to the corridor / open joint-state A* below: those flood the
+            # cost_turn f-plateaus (the #3954 bench disproved convergence at
+            # 20x iterations) and the 6/9 failed-shadow pairs each burning a
+            # corridor budget + the negotiated backstop is exactly the
+            # >1200s tail the #3986 board-06 measurements documented.  A hard
+            # per-pair shadow budget (``_SHADOW_PER_PAIR_BUDGET_S``) already
+            # bounds the corridor probe + shadow construction above; here we
+            # fail FAST to the uncoupled fallback -- shadow-or-uncoupled,
+            # never shadow-then-flooded-A*.
+            shadow_fail_fast = self.enable_shadow_construction
+            if (
+                result is None
+                and not shadow_fail_fast
+                and guide_route is not None
+                and guide_route.segments
+            ):
                 grid = self.autorouter.grid
                 resolution = grid.resolution
                 start_spacing_cells = (
@@ -4426,7 +4626,7 @@ class DiffPairRouter:
                 if result is not None:
                     coupled_phase = "corridor"
 
-            if result is None:
+            if result is None and not shadow_fail_fast:
                 remaining_budget = per_pair_timeout
                 if per_pair_timeout is not None:
                     remaining_budget = max(1.0, per_pair_timeout - (time.monotonic() - spec_t0))

--- a/tests/test_diffpair_shadow.py
+++ b/tests/test_diffpair_shadow.py
@@ -818,10 +818,17 @@ def test_shadow_claim_rolls_back_when_goal_pad_stranded(monkeypatch):
     router, pair = _two_pad_coupled_router_and_pair()
     dpr = router._diffpair
     dpr.enable_shadow_construction = True
-    monkeypatch.setattr(dpr, "_single_ended_guide_route", lambda *a, **k: None)
     # P strands its J1 goal pad (stops at x=15.0); N reaches its goal.
     stranded = _coupled_routes_for_pair(pair, p_end_x=15.0, n_end_x=25.0)
-    _patch_pathfinder_capture_weight(monkeypatch, stranded, rescue_eligible=False)
+    # Issue #3987 (unit 2a of #3921): with shadow ON the joint-state
+    # ``route_coupled`` fallback is gated OFF, so the transactional rollback
+    # is reached via the SHADOW constructor.  Provide a guide and stub
+    # ``_shadow_route_pair`` to return the stranded result -- the connectivity
+    # gate that rips it is downstream of ``result`` and fires identically.
+    guide = _coupled_routes_for_pair(pair, p_end_x=25.0, n_end_x=25.0)[0]
+    monkeypatch.setattr(dpr, "_single_ended_guide_route", lambda *a, **k: guide)
+    monkeypatch.setattr(dpr, "_shadow_route_pair", lambda *a, **k: stranded)
+    _patch_pathfinder_capture_weight(monkeypatch, None, rescue_eligible=False)
 
     grid = router.grid
 
@@ -861,9 +868,18 @@ def test_shadow_claim_commits_when_all_pads_reached(monkeypatch):
     router, pair = _two_pad_coupled_router_and_pair()
     dpr = router._diffpair
     dpr.enable_shadow_construction = True
-    monkeypatch.setattr(dpr, "_single_ended_guide_route", lambda *a, **k: None)
     good = _coupled_routes_for_pair(pair, p_end_x=25.0, n_end_x=25.0)
-    _patch_pathfinder_capture_weight(monkeypatch, good, rescue_eligible=False)
+    # Issue #3987 (unit 2a of #3921): with shadow ON the pair is
+    # shadow-or-uncoupled -- the joint-state ``route_coupled`` fallback is
+    # gated OFF -- so a claimed pair reaches the transactional connectivity
+    # gate via the SHADOW constructor.  Provide a guide so the shadow path
+    # runs, and stub ``_shadow_route_pair`` to return the fully-connected
+    # result under test (the gate is downstream of ``result`` and is
+    # exercised identically whether the result came from shadow or search).
+    guide = _coupled_routes_for_pair(pair, p_end_x=25.0, n_end_x=25.0)[0]
+    monkeypatch.setattr(dpr, "_single_ended_guide_route", lambda *a, **k: guide)
+    monkeypatch.setattr(dpr, "_shadow_route_pair", lambda *a, **k: good)
+    _patch_pathfinder_capture_weight(monkeypatch, None, rescue_eligible=False)
 
     routes, _warning = dpr.route_differential_pair_coupled(pair, coupled_only=True)
 
@@ -1151,3 +1167,171 @@ def test_shadow_via_guard_is_load_bearing(monkeypatch):
         "the guard must change the committed geometry: clearing via "
         f"({guarded_dist:.4f} mm) vs grazing via ({unguarded_dist:.4f} mm)"
     )
+
+
+# ---------------------------------------------------------------------------
+# 11. Issue #3987 (unit 2a of #3921): shadow copper is 45-compliant by
+# construction.
+#
+# ``_shadow_route_pair`` runs the assembled shadow segments through
+# ``_quantize_shadow_segments`` before its self-check gates, so every
+# shadow-emitted segment is on the {0, 45, 90, 135} angle set (census-clean,
+# no ``OffAngleSegmentWarning`` from the #3975 emission guard).  The guide
+# side is the C++ on-grid router's output and is already aligned; the
+# geometric shadow (miter apex / via jogs / pad-approach tails) was the only
+# off-angle source.  The dogleg pass reuses ``quantize.dogleg_points`` (the
+# #3532/#3907 file-layer transform) lifted to the route layer, and is
+# obstacle-aware: each dogleg variant's legs are re-rastered against
+# ``_is_cell_blocked`` and a variant that collides is rejected.
+# ---------------------------------------------------------------------------
+
+
+def _seg(x1, y1, x2, y2, net=1):
+    return Segment(x1=x1, y1=y1, x2=x2, y2=y2, width=0.2, layer=Layer.F_CU, net=net, net_name="N")
+
+
+def test_quantize_shadow_leaves_aligned_segments_untouched():
+    """Axis/diagonal shadow legs pass through the dogleg pass unchanged."""
+    from kicad_tools.router.quantize import is_45_aligned
+
+    router, _pair = _two_pad_coupled_router_and_pair()
+    dpr = router._diffpair
+    pf = CoupledPathfinder(grid=router.grid, rules=router.rules, target_spacing_cells=4)
+
+    route = Route(net=1, net_name="N")
+    route.segments.append(_seg(1.0, 1.0, 5.0, 1.0))  # horizontal (0 deg)
+    route.segments.append(_seg(5.0, 1.0, 8.0, 4.0))  # exact diagonal (45 deg)
+    before = list(route.segments)
+
+    dpr._quantize_shadow_segments(route, pf)
+
+    assert route.segments == before, "aligned segments must not be rewritten"
+    for s in route.segments:
+        assert is_45_aligned(s.x2 - s.x1, s.y2 - s.y1)
+
+
+def test_quantize_shadow_doglegs_off_angle_segment():
+    """An off-angle shadow segment is split into two 45-legal legs.
+
+    The dogleg preserves both endpoints exactly (so the coupled gap the
+    constructor established is held) and every resulting leg is on the
+    {0,45,90,135} set -- the geometry the #3975 emission census reads.
+    """
+    from kicad_tools.router.quantize import is_45_aligned, off_angle_degrees
+
+    router, _pair = _two_pad_coupled_router_and_pair()
+    dpr = router._diffpair
+    pf = CoupledPathfinder(grid=router.grid, rules=router.rules, target_spacing_cells=4)
+
+    # A miter-apex-like skew: 20 deg off the axis, off every 45-multiple.
+    off = _seg(2.0, 2.0, 8.0, 4.0)
+    assert off_angle_degrees(off.x2 - off.x1, off.y2 - off.y1) > 1.0
+    route = Route(net=1, net_name="N")
+    route.segments.append(off)
+
+    dpr._quantize_shadow_segments(route, pf)
+
+    assert len(route.segments) == 2, "off-angle segment must split into a two-leg dogleg"
+    for s in route.segments:
+        assert is_45_aligned(s.x2 - s.x1, s.y2 - s.y1), (
+            f"dogleg leg ({s.x1},{s.y1})->({s.x2},{s.y2}) is still off-angle"
+        )
+    # Endpoints preserved exactly (contiguous, and the chord's ends unchanged).
+    assert (route.segments[0].x1, route.segments[0].y1) == (2.0, 2.0)
+    assert (route.segments[-1].x2, route.segments[-1].y2) == (8.0, 4.0)
+    assert (route.segments[0].x2, route.segments[0].y2) == (
+        route.segments[1].x1,
+        route.segments[1].y1,
+    )
+
+
+def test_quantize_shadow_keeps_off_angle_when_no_clear_variant():
+    """Obstacle-aware: with BOTH dogleg bulges blocked, keep the original.
+
+    The pass re-rasters each dogleg variant against ``_is_cell_blocked``.
+    If the default and ``axis_first`` variants both collide, the segment is
+    left untouched (graceful degradation -- the downstream self-check /
+    overlap gates and the emission census still apply) rather than shipping a
+    dogleg through copper (the obstacle-blind post-hoc-quantizer short #3906
+    hit).
+    """
+    router, _pair = _two_pad_coupled_router_and_pair()
+    dpr = router._diffpair
+    pf = CoupledPathfinder(grid=router.grid, rules=router.rules, target_spacing_cells=4)
+
+    off = _seg(2.0, 2.0, 8.0, 4.0, net=1)
+    route = Route(net=1, net_name="N")
+    route.segments.append(off)
+
+    # Force every candidate leg to look blocked (foreign net everywhere).
+    monkey = pf._is_cell_blocked
+    try:
+        pf._is_cell_blocked = lambda gx, gy, li, net: True  # type: ignore[method-assign]
+        dpr._quantize_shadow_segments(route, pf)
+    finally:
+        pf._is_cell_blocked = monkey  # type: ignore[method-assign]
+
+    assert len(route.segments) == 1, "no clear dogleg variant -> keep the original segment"
+    assert (
+        route.segments[0].x1,
+        route.segments[0].y1,
+        route.segments[0].x2,
+        route.segments[0].y2,
+    ) == (
+        2.0,
+        2.0,
+        8.0,
+        4.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 12. Issue #3987 (unit 2a of #3921): hard per-pair shadow time budget.
+#
+# When ``enable_shadow_construction`` is on, a pair is shadow-or-uncoupled:
+# on shadow failure it must fail FAST to the uncoupled fallback WITHOUT
+# running the open joint-state ``route_coupled`` search (which floods the
+# cost_turn f-plateaus and drove the >1200s #3986 board-06 tail).  With the
+# flag OFF the joint-state search remains the pre-phase, unchanged.
+# ---------------------------------------------------------------------------
+
+
+def test_shadow_on_shadow_failure_does_not_flood_open_search(monkeypatch):
+    """Flag ON + shadow fails -> the joint-state search is NOT invoked."""
+    router, pair = _two_pad_coupled_router_and_pair()
+    dpr = router._diffpair
+    dpr.enable_shadow_construction = True
+    # A guide exists (so the shadow path is attempted) but the shadow
+    # constructor declines the pair.
+    guide = _coupled_routes_for_pair(pair, p_end_x=25.0, n_end_x=25.0)[0]
+    monkeypatch.setattr(dpr, "_single_ended_guide_route", lambda *a, **k: guide)
+    monkeypatch.setattr(dpr, "_shadow_route_pair", lambda *a, **k: None)
+    captured = _patch_pathfinder_capture_weight(monkeypatch, None, rescue_eligible=False)
+    called = {"route_coupled": 0}
+    orig_factory_pf = _StubPathfinder
+
+    def _counting_pf(*a, **k):
+        pf = orig_factory_pf(None, rescue_eligible=False)
+        real_rc = pf.route_coupled
+
+        def _rc(*aa, **kk):
+            called["route_coupled"] += 1
+            return real_rc(*aa, **kk)
+
+        pf.route_coupled = _rc  # type: ignore[method-assign]
+        return pf
+
+    import kicad_tools.router.diffpair_routing as dpr_mod
+
+    monkeypatch.setattr(dpr_mod, "CoupledPathfinder", _counting_pf)
+
+    routes, _warning = dpr.route_differential_pair_coupled(pair, coupled_only=True)
+
+    assert called["route_coupled"] == 0, (
+        "with shadow ON and the shadow constructor failing, the open "
+        "joint-state route_coupled search must NOT run (fail fast to "
+        "uncoupled -- never shadow-then-flooded-A*)"
+    )
+    # coupled_only defers cleanly (uncoupled fallback returns [], None).
+    assert routes == []
+    assert captured is not None


### PR DESCRIPTION
## Summary

Unit 2a of the #3921 shadow-construction design (architect design comment, 2026-07-08). Makes the geometric diff-pair shadow constructor emit **45-compliant copper by construction** and bounds its **per-pair time budget**, so a `KCT_BOARD06_SHADOW=1` run stops emitting off-angle shadow segments and stops re-flooding the open joint-state A*. Both changes are gated behind `enable_shadow_construction` (default **OFF**); shadow-OFF routing is byte-for-byte unchanged.

Scoped exactly to `src/kicad_tools/router/diffpair_routing.py::_shadow_route_pair` + the shadow-attempt budget, reusing `quantize.dogleg_points`, per the design. Convergence recovery (blocker 1, variable-gap offset) is deferred to unit 2b.

## Changes

- **Dogleg-at-emission pass** (`_quantize_shadow_segments`): an in-memory transform over the assembled shadow `Route.segments`, applied before the self-check/overlap gates. The guide side is the C++ on-grid router's already-45-aligned output; the geometric shadow's **miter-apex joins, via jogs, and pad-approach tails** were the only off-angle sources (the 3.7–11.9° segments #3986 measured). Lifts `quantize.dogleg_points` (the #3532/#3907 file-layer transform) to the route layer.
  - **Serialized-displacement decision**: alignment is judged on the 4dp-rounded copper via `verify_segment_45` — the same predicate the #3975 emission census reads — so an analytically-45 offset that *rounds* to a 2-quantum-asymmetric diagonal (dx=0.0501/dy=0.0499, 0.11° off) is caught too, not just the gross miter skew.
  - **Obstacle-aware** (the #3975 subgrid-escape pattern): each dogleg variant's legs are re-rastered against `_is_cell_blocked`; a colliding variant is rejected, and with no clean+clear variant the segment is left untouched (graceful degradation, not a silent short).
- **Hard per-pair shadow time budget** (`_SHADOW_PER_PAIR_BUDGET_S`, 30s): when shadow is ON a pair is **shadow-or-uncoupled** — on shadow failure the corridor / open joint-state A* searches are skipped and the pair fails fast to the uncoupled fallback. Never shadow-then-flooded-A*.
- Tests: 3 new `_quantize_shadow_segments` unit tests (aligned untouched / off-angle split preserving endpoints / obstacle-blocked keep-original), 1 fail-fast test (shadow-fail does not invoke `route_coupled`), and updates to the two transactional-claim tests to route their fixtures through the shadow constructor (the joint-state fallback is now gated off with shadow ON).

## Measured (board 06, seed 42, `PYTHONHASHSEED=42`, `KCT_BOARD06_SHADOW=1`)

| Metric | Before (#3986 shadow-ON) | After (this PR) |
|---|---|---|
| Coupled convergence | 3/9 | **3/9** (MIPI_CLK, MIPI_D0, PCIE_RX) — no regression |
| Coupled pre-phase wall time | ~350s | **~54s** (failed-shadow pairs run **0** joint-state iterations — no open-A* re-flooding) |
| Off-angle **shadow** segments | 3.7–11.9° (many) | **0** — shadow copper is census-clean by construction |

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| ≥3/9 convergence, no regression | ✅ | 3/9 shadow-constructed (MIPI_CLK, MIPI_D0, PCIE_RX) on the seed-42 bench |
| Every **shadow-emitted** segment quantum-aligned (no `OffAngleSegmentWarning`) | ✅ | The 3.7–11.9° + 0.11° shadow off-angle segments are eliminated by the census-aware dogleg pass; unit tests assert every dogleg leg is 45-legal |
| No open-A* re-flooding / bounded coupled attempt | ✅ | `last_iters=0` for all failed-shadow pairs; coupled phase 350s→54s; new fail-fast unit test asserts `route_coupled` is not invoked when shadow fails |
| Default (shadow OFF) byte-for-byte unchanged; boards 03/06/07 gates green | ✅ | All new code paths gate on `enable_shadow_construction`; `test_board_03/06/07*` + census (118 passed, 1 skipped) green; a fresh shadow-OFF `--step route` exercises none of the new code |
| Flag stays OFF by default | ✅ | No default flipped; `KCT_BOARD06_SHADOW` still defaults to `0` |
| Whole `KCT_BOARD06_SHADOW=1` run completes < ~1200s | ⚠️ | **Coupled tail eliminated (350s→54s).** The residual full-run tail is the **negotiated rip-up loop** overshooting its 360s backstop on board-06 seed-42 — reproduced on a **fresh shadow-OFF `--step route` run too** (≈206s per rip-up iteration, pure-Python A* fallbacks), so it is a **pre-existing `core.py` negotiated-router issue, not introduced by this change and outside `_shadow_route_pair` scope**. Shadow-ON is worse only because committed diff-pair copper starves the remaining singles' corridors — that is blocker 1/3 (corridor competition), the unit 2b work. This PR delivers the in-scope coupled-phase bound; the negotiated-deadline overshoot should be tracked separately. |

## Test Plan

- `uv run pytest tests/test_diffpair_shadow.py tests/test_diffpair_per_pair_timeout.py tests/test_fleet_45_census.py tests/test_diffpair_routing_integration.py tests/test_diffpair_coupled_floor.py tests/test_diffpair_corridor.py tests/test_router_core_diffpair_timeout.py` → 90 passed
- `uv run pytest tests/test_board_03_regression.py tests/test_board_03_copper_lvs.py tests/test_board_06_diffpair_test.py tests/test_board_07_matchgroup_test.py` → 118 passed, 1 skipped
- `uv run ruff check .` / `ruff format --check` clean; `mypy` unchanged (9 pre-existing errors, none in the new code)
- Board-06 seed-42 `KCT_BOARD06_SHADOW=1` bench measured for the before/after table above

Closes #3987
Refs #3921