### PR TITLE
feat(diffpair): variable-gap parallel offset within the impedance band for the shadow constructor

### DIFF
--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -127,6 +127,29 @@ _SHADOW_MAX_TRIM_MM: float = float(os.environ.get("KCT_SHADOW_MAX_TRIM_MM", "5.0
 # experimentation (KCT_SHADOW_PER_PAIR_BUDGET_S).
 _SHADOW_PER_PAIR_BUDGET_S: float = float(os.environ.get("KCT_SHADOW_PER_PAIR_BUDGET_S", "30.0"))
 
+# Issue #3990 (unit 2b of #3921): variable-gap parallel offset.  The
+# geometric shadow constructor historically offset the WHOLE guide by a
+# single constant center-to-center gap ``d = spacing_cells * resolution``.
+# At the tightened 0.225-0.275 mm coupled widths this fixed gap is
+# infeasible for 6/9 board-06 pairs: on inside curves the offset overlaps
+# the partner (the -0.165..-0.275 mm ``self-check overlap`` events) and
+# where the guide threaded a gap only wide enough for a zero-width
+# centerline the offset crosses an obstacle (the ``mid-route blockage``
+# events).  Because the diff-pair coupling constraint is a clearance BAND
+# (a floor set by ``effective_intra_pair_clearance()`` and a ceiling set by
+# the impedance tolerance), the offset gap may be varied PER SECTION within
+# ``[d_min, d_max]`` to dodge both failure modes -- tighten toward
+# ``d_min`` on an inside curve that would self-overlap, widen toward
+# ``d_max`` to step around an obstacle -- while both legs stay inside the
+# impedance band.  ``_SHADOW_GAP_BAND_STEPS`` is the number of candidate
+# gaps probed per section (a small linear ladder from ``d_min`` to
+# ``d_max``); the tightest feasible gap that clears both the partner and
+# the grid is kept.  ``_SHADOW_GAP_MAX_TOL_FRAC`` caps how far above the
+# nominal gap the ceiling may reach when the net class exposes no explicit
+# impedance tolerance.  Env-overridable for bench experimentation.
+_SHADOW_GAP_BAND_STEPS: int = int(os.environ.get("KCT_SHADOW_GAP_BAND_STEPS", "5"))
+_SHADOW_GAP_MAX_TOL_FRAC: float = float(os.environ.get("KCT_SHADOW_GAP_MAX_TOL_FRAC", "0.15"))
+
 
 # ---------------------------------------------------------------------------
 # Issue #3023 Phase A: intra-pair clearance violation detection
@@ -3536,6 +3559,129 @@ class DiffPairRouter:
                 )
         route.segments[:] = new_segments
 
+    @staticmethod
+    def _shadow_gap_ladder(d: float, d_min: float, d_max: float) -> list[float]:
+        """Ordered candidate offset gaps for the variable-gap parallel offset.
+
+        Issue #3990 (unit 2b of #3921).  Returns a list of center-to-center
+        gaps to try for a single guide section, ordered by PREFERENCE:
+
+        1. the nominal ``d`` first -- a section feasible at nominal keeps
+           the exact fixed-gap geometry (so the easy pairs are unchanged),
+        2. then TIGHTER gaps stepping down toward ``d_min`` -- the fix for
+           inside-curve self-overlap (a smaller gap pulls the offset off the
+           partner), tried before widening so the coupled gap stays as
+           close to nominal as feasibility allows,
+        3. then WIDER gaps stepping up toward ``d_max`` -- the fix for
+           obstacle blockage (a larger gap steps the offset around copper
+           the guide only cleared for a zero-width centerline).
+
+        All returned gaps lie in ``[d_min, d_max]`` (the impedance band).
+        ``_SHADOW_GAP_BAND_STEPS`` sets the ladder density.  When the band
+        is degenerate (``d_max <= d_min`` or steps <= 1) only ``d`` is
+        returned, collapsing to the fixed-gap constructor.
+        """
+        steps = max(1, _SHADOW_GAP_BAND_STEPS)
+        if steps <= 1 or d_max - d_min < 1e-6:
+            return [d]
+        tighter: list[float] = []
+        wider: list[float] = []
+        # Uniform ladder resolution across the whole band.
+        span = d_max - d_min
+        inc = span / steps
+        # Tighter rungs: from just below nominal down to d_min.
+        g = d - inc
+        while g >= d_min - 1e-9:
+            tighter.append(max(d_min, g))
+            g -= inc
+        # Wider rungs: from just above nominal up to d_max.
+        g = d + inc
+        while g <= d_max + 1e-9:
+            wider.append(min(d_max, g))
+            g += inc
+        ladder = [d]
+        # Interleave tighter-first (prefer holding the coupling as tight as
+        # feasibility allows), then wider fallbacks for obstacle stepping.
+        ladder.extend(tighter)
+        ladder.extend(wider)
+        # De-dup while preserving order (float rungs can coincide at bounds).
+        seen: list[float] = []
+        for gv in ladder:
+            if all(abs(gv - s) > 1e-9 for s in seen):
+                seen.append(gv)
+        return seen
+
+    def _shadow_select_gap(
+        self,
+        seg: Segment,
+        nx: float,
+        ny: float,
+        gap_ladder: list[float],
+        layer_idx: int,
+        s_net: int,
+        pathfinder: CoupledPathfinder,
+        guide_segs: list[Segment],
+        min_center_dist: float,
+    ) -> float:
+        """Choose the per-section parallel-offset gap from the impedance band.
+
+        Issue #3990 (unit 2b of #3921).  ``gap_ladder`` is the preference-
+        ordered list of candidate center-to-center gaps (nominal first, then
+        tighter, then wider -- all inside the impedance band).  This walks
+        the ladder and returns the FIRST gap whose offset of ``seg`` (by
+        ``gap * (nx, ny)``) is BOTH:
+
+        * obstacle-clear -- every rastered cell of the offset segment is
+          unblocked for ``s_net`` (dodges the ``mid-route blockage`` events
+          where the guide threaded a zero-width-centerline gap the offset
+          cannot fit through), AND
+        * partner-clear -- the offset segment's minimum distance to the
+          guide (partner) copper on this layer stays at or above
+          ``min_center_dist`` (center-to-center), i.e. the coupled EDGE gap
+          holds at or above the intra-pair clearance floor (dodges the
+          inside-curve ``self-check overlap`` events).
+
+        Because the ladder tries the nominal gap first and tighter rungs
+        before wider ones, an easy segment keeps the exact nominal geometry,
+        an inside-curve segment tightens just enough to pull off the
+        partner, and an obstructed segment widens just enough to step
+        around the obstacle -- always within ``[d_min, d_max]``.
+
+        When NO ladder rung is feasible the nominal gap (the ladder head) is
+        returned unchanged: the downstream self-check / physical-overlap
+        gates and the trim logic still apply, so an infeasible section
+        degrades to today's fixed-gap behaviour rather than shipping a
+        violation.
+        """
+        grid = self.autorouter.grid
+        step = grid.resolution
+        for gap in gap_ladder:
+            ax, ay = seg.x1 + gap * nx, seg.y1 + gap * ny
+            bx, by = seg.x2 + gap * nx, seg.y2 + gap * ny
+            # Obstacle raster over the candidate offset segment.
+            seg_len = math.hypot(bx - ax, by - ay)
+            if seg_len < 1e-9:
+                return gap
+            n_steps = max(1, int(math.ceil(seg_len / step)))
+            blocked = False
+            for i in range(n_steps + 1):
+                t = i / n_steps
+                gx, gy = grid.world_to_grid(ax + (bx - ax) * t, ay + (by - ay) * t)
+                if pathfinder._is_cell_blocked(gx, gy, layer_idx, s_net):
+                    blocked = True
+                    break
+            if blocked:
+                continue
+            # Partner-clearance: keep the coupled edge gap >= intra floor.
+            if (
+                self._min_distance_to_partner(ax, ay, bx, by, guide_segs, seg.layer)
+                < min_center_dist
+            ):
+                continue
+            return gap
+        # No feasible rung: keep nominal (ladder head), degrade gracefully.
+        return gap_ladder[0]
+
     def _shadow_route_pair(
         self,
         pair: DifferentialPair,
@@ -3589,6 +3735,51 @@ class DiffPairRouter:
         s_net_name = shadow_start.net_name
         s_width = pathfinder._get_trace_width_for_net(s_net_name)
         d = spacing_cells * grid.resolution
+
+        # Issue #3990 (unit 2b of #3921): the parallel-offset gap is a BAND,
+        # not a single value.  ``d`` above is the nominal center-to-center
+        # spacing; the offset for each guide section may vary within
+        # ``[d_min, d_max]`` to dodge inside-curve self-overlap (tighten
+        # toward ``d_min``) and obstacle blockages (widen toward ``d_max``)
+        # while both legs stay inside the impedance tolerance band.
+        #
+        # Band source (authoritative):
+        #   * ``d_min`` -- the intra-pair clearance FLOOR.  The center-to-
+        #     center spacing must keep at least
+        #     ``trace_width + effective_intra_pair_clearance()`` so the
+        #     within-pair EDGE clearance holds; this is exactly the
+        #     ``required_center_spacing`` the caller derives for
+        #     ``min_spacing_cells`` (``route_differential_pair_coupled``).
+        #     Read from the pair's ``NetClassRouting`` when available.
+        #   * ``d_max`` -- the impedance CEILING.  Widening the gap lowers
+        #     coupling and raises the differential impedance; the net
+        #     class' ``impedance_tolerance_percent`` (the same tolerance the
+        #     ``ImpedanceRule`` DRC fires on) bounds how far.  Differential
+        #     impedance is monotone-increasing and near-linear in the gap
+        #     for small deviations, so bounding the GAP deviation by that
+        #     percentage is a conservative proxy that keeps the pair inside
+        #     the impedance band.  Capped at ``_SHADOW_GAP_MAX_TOL_FRAC``.
+        pair_nc = (getattr(self.autorouter, "net_class_map", None) or {}).get(spec.p_start.net_name)
+        if pair_nc is not None:
+            nc_trace_width = float(pair_nc.trace_width)
+            intra_floor = float(pair_nc.effective_intra_pair_clearance())
+            tol_frac = min(
+                _SHADOW_GAP_MAX_TOL_FRAC,
+                max(0.0, float(pair_nc.impedance_tolerance_percent) / 100.0),
+            )
+        else:
+            nc_trace_width = float(s_width)
+            intra_floor = float(rules.trace_clearance)
+            tol_frac = _SHADOW_GAP_MAX_TOL_FRAC
+        # Never let the floor exceed the nominal (a class whose min-spacing
+        # already equals the nominal collapses the band to the single ``d``).
+        d_min = min(d, nc_trace_width + intra_floor)
+        d_max = d * (1.0 + tol_frac)
+        # Candidate gaps: a linear ladder from ``d_min`` up to ``d_max``,
+        # always including the nominal ``d`` and preferring the nominal so a
+        # section that is feasible at nominal is unchanged (byte-for-byte
+        # stable relative to the fixed-gap constructor for the easy pairs).
+        gap_ladder = self._shadow_gap_ladder(d, d_min, d_max)
         # Shadow via lateral offset: the barrel must clear the guide
         # trace (via_r + clearance + guide_width/2), independent of the
         # tighter coupled gap d.
@@ -3642,8 +3833,30 @@ class DiffPairRouter:
                     uy /= length
                     nx = -uy * side
                     ny = ux * side
-                    a = (seg.x1 + d * nx, seg.y1 + d * ny)
-                    b = (seg.x2 + d * nx, seg.y2 + d * ny)
+                    # Issue #3990 (unit 2b): pick the per-section offset gap
+                    # from the impedance band.  Prefer the nominal ``d``;
+                    # tighten (dodges inside-curve self-overlap) or widen
+                    # (dodges obstacle blockage) only when the nominal offset
+                    # is infeasible for THIS segment.  Feasibility is judged
+                    # on the offset segment's grid raster (obstacle-clear)
+                    # and its distance to the guide/partner copper (>= the
+                    # intra-pair clearance floor, so the coupled edge gap
+                    # holds).  Both bounds keep the pair inside the impedance
+                    # band by construction (``gap_ladder`` rungs are all in
+                    # ``[d_min, d_max]``).
+                    seg_gap = self._shadow_select_gap(
+                        seg,
+                        nx,
+                        ny,
+                        gap_ladder,
+                        sec_layer,
+                        s_net,
+                        pathfinder,
+                        guide_segs,
+                        intra_floor + s_width / 2.0 + guide_width / 2.0,
+                    )
+                    a = (seg.x1 + seg_gap * nx, seg.y1 + seg_gap * ny)
+                    b = (seg.x2 + seg_gap * nx, seg.y2 + seg_gap * ny)
                     if prev_pt is not None and prev_layer is not None:
                         if first_in_section and prev_layer != sec_layer:
                             # Guide layer change: place the shadow via.

--- a/tests/test_diffpair_shadow.py
+++ b/tests/test_diffpair_shadow.py
@@ -1335,3 +1335,111 @@ def test_shadow_on_shadow_failure_does_not_flood_open_search(monkeypatch):
     # coupled_only defers cleanly (uncoupled fallback returns [], None).
     assert routes == []
     assert captured is not None
+
+
+# ---------------------------------------------------------------------------
+# 13. Issue #3990 (unit 2b of #3921): variable-gap parallel offset within the
+# impedance band.
+#
+# The fixed-gap constructor offset the whole guide by a single ``d``; at the
+# tightened 0.225-0.275 mm coupled widths this is infeasible for 6/9 board-06
+# pairs (inside-curve self-overlap + obstacle blockage).  The per-section gap
+# may vary within ``[d_min, d_max]`` -- floor from
+# ``effective_intra_pair_clearance()``, ceiling from
+# ``impedance_tolerance_percent`` -- tightening to dodge self-overlap and
+# widening to step around obstacles, always inside the impedance band.
+# ---------------------------------------------------------------------------
+
+
+def test_shadow_gap_ladder_prefers_nominal_first():
+    """The nominal gap is always the ladder head (easy sections unchanged)."""
+    from kicad_tools.router.diffpair_routing import DiffPairRouter
+
+    ladder = DiffPairRouter._shadow_gap_ladder(0.30, 0.25, 0.345)
+    assert ladder[0] == 0.30, "nominal gap must be tried first"
+    # Every rung stays inside the band.
+    assert all(0.25 - 1e-9 <= g <= 0.345 + 1e-9 for g in ladder)
+    # Tighter rungs come before wider rungs (tighten-first preference).
+    below = [g for g in ladder[1:] if g < 0.30 - 1e-9]
+    above = [g for g in ladder[1:] if g > 0.30 + 1e-9]
+    assert below, "band should include tighter rungs"
+    assert above, "band should include wider rungs"
+    first_above_idx = next(i for i, g in enumerate(ladder) if g > 0.30 + 1e-9)
+    first_below_idx = next(i for i, g in enumerate(ladder) if g < 0.30 - 1e-9)
+    assert first_below_idx < first_above_idx, "tighter rungs must precede wider rungs"
+
+
+def test_shadow_gap_ladder_collapses_to_nominal_when_band_degenerate():
+    """A collapsed band (d_max == d_min) yields only the nominal gap."""
+    from kicad_tools.router.diffpair_routing import DiffPairRouter
+
+    ladder = DiffPairRouter._shadow_gap_ladder(0.30, 0.30, 0.30)
+    assert ladder == [0.30], "degenerate band collapses to the fixed-gap constructor"
+
+
+def test_shadow_select_gap_keeps_nominal_when_feasible():
+    """An unobstructed segment far from the partner keeps the nominal gap."""
+    router, _pair = _two_pad_coupled_router_and_pair()
+    dpr = router._diffpair
+    pf = CoupledPathfinder(grid=router.grid, rules=router.rules, target_spacing_cells=4)
+
+    seg = _seg(2.0, 2.0, 8.0, 2.0)  # horizontal, on F.Cu
+    li = router.grid.layer_to_index(Layer.F_CU.value)
+    # Partner far away (single distant segment) so partner-clearance never binds;
+    # empty grid so no obstacle binds -> nominal (ladder head) is chosen.
+    guide_segs = [_seg(2.0, 20.0, 8.0, 20.0)]
+    ladder = [0.30, 0.25, 0.35]
+    nx, ny = 0.0, 1.0
+    gap = dpr._shadow_select_gap(seg, nx, ny, ladder, li, seg.net, pf, guide_segs, 0.2)
+    assert gap == 0.30, "feasible nominal section must keep the nominal gap"
+
+
+def test_shadow_select_gap_tightens_to_dodge_partner_overlap():
+    """When the nominal offset lands too close to the partner, a tighter gap wins.
+
+    The partner (guide) copper sits at ``y = 2.0 + 0.28`` (just inside the
+    nominal 0.30 offset).  The nominal gap would put the offset segment within
+    ``min_center_dist`` of the partner (self-overlap); the ladder's tighter
+    rung (0.25) pulls the offset back to a legal separation.
+    """
+    router, _pair = _two_pad_coupled_router_and_pair()
+    dpr = router._diffpair
+    pf = CoupledPathfinder(grid=router.grid, rules=router.rules, target_spacing_cells=4)
+
+    seg = _seg(2.0, 2.0, 8.0, 2.0)
+    li = router.grid.layer_to_index(Layer.F_CU.value)
+    nx, ny = 0.0, 1.0  # offset upward (+y)
+    # Partner copper just above the nominal offset: at y=2.30 the nominal
+    # offset (y=2.30) coincides; a tighter 0.24 offset (y=2.24) clears by
+    # 0.06 which exceeds min_center_dist below.
+    guide_segs = [_seg(2.0, 2.30, 8.0, 2.30)]
+    ladder = [0.30, 0.24, 0.36]
+    min_center = 0.05
+    gap = dpr._shadow_select_gap(seg, nx, ny, ladder, li, seg.net, pf, guide_segs, min_center)
+    assert gap == 0.24, (
+        "an inside-curve section whose nominal offset overlaps the partner "
+        "must tighten to a legal gap within the band"
+    )
+
+
+def test_shadow_select_gap_degrades_to_nominal_when_no_rung_feasible():
+    """With every rung obstacle-blocked, the nominal gap is returned (graceful)."""
+    router, _pair = _two_pad_coupled_router_and_pair()
+    dpr = router._diffpair
+    pf = CoupledPathfinder(grid=router.grid, rules=router.rules, target_spacing_cells=4)
+
+    seg = _seg(2.0, 2.0, 8.0, 2.0)
+    li = router.grid.layer_to_index(Layer.F_CU.value)
+    guide_segs = [_seg(2.0, 20.0, 8.0, 20.0)]
+    ladder = [0.30, 0.25, 0.35]
+    # Force every candidate offset to look obstacle-blocked.
+    saved = pf._is_cell_blocked
+    try:
+        pf._is_cell_blocked = lambda gx, gy, layer, net: True  # type: ignore[method-assign]
+        gap = dpr._shadow_select_gap(seg, 0.0, 1.0, ladder, li, seg.net, pf, guide_segs, 0.2)
+    finally:
+        pf._is_cell_blocked = saved  # type: ignore[method-assign]
+    assert gap == 0.30, (
+        "no feasible rung must degrade to the nominal gap (ladder head), not "
+        "silently ship a blocked offset -- the downstream self-check gates apply"
+    )


### PR DESCRIPTION
## Summary

Unit 2b of the #3921 shadow-construction design: makes the geometric diff-pair shadow constructor's parallel-offset gap **adaptive within the impedance tolerance band** instead of a single constant `d`. Gated behind `enable_shadow_construction` (default **OFF**); shadow-OFF routing is byte-for-byte unchanged.

This is an **honest partial** (`Refs`, not `Closes`). Approach A was implemented and measured to the acceptance bench; it is a real, safe, in-band robustness improvement but **does not lift board-06 convergence to the ≥6/9 gate** — because the binding failure there is a **tail-vs-guide crossover near the connector fanout, not body-offset feasibility**. Full evidence + the disposition recommendation are posted on #3990 and #3921. Approach C (joint pathfinding) was explicitly rejected and not attempted.

## Changes

- `_shadow_gap_ladder` — builds a preference-ordered candidate-gap ladder for a guide section: nominal `d` first (easy sections keep the exact fixed-gap geometry), then tighter rungs (dodge inside-curve self-overlap), then wider rungs (step around obstacle blockage) — all inside `[d_min, d_max]`.
- `_shadow_select_gap` — walks the ladder and returns the first gap whose offset segment is BOTH obstacle-clear (`_is_cell_blocked` raster) AND partner-clear (min distance to the guide ≥ the intra-pair clearance floor). Degrades to the nominal gap when no rung is feasible (downstream self-check / overlap gates and the #3975 emission census still apply — no silent short).
- `_shadow_route_pair` — the body offset now uses the per-section `seg_gap` in place of the constant `d`.
- Band source (authoritative, documented in-code): `d_min = trace_width + effective_intra_pair_clearance()` (the same `required_center_spacing` the caller derives for `min_spacing_cells`); `d_max = d · (1 + impedance_tolerance_percent/100)` capped by `_SHADOW_GAP_MAX_TOL_FRAC` (0.15). Both bounds keep the pair inside the net class' impedance band by construction.
- Constants `_SHADOW_GAP_BAND_STEPS`, `_SHADOW_GAP_MAX_TOL_FRAC` (env-overridable for bench experimentation).
- 5 unit tests: ladder ordering (nominal-first, tighten-before-widen, band-bounded), degenerate-band collapse, select-gap keeps-nominal / tightens-to-dodge-partner / degrades-when-blocked.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Board-06 seed-42, `KCT_BOARD06_SHADOW=1`: convergence ≥6/9 | NOT MET | 3/9 (unchanged). Root-cause proven: all 14 `self-check overlap` events are **tail-vs-guide** (instrumented), never the body offset; the nominal gap already equals `d_min` for every failing pair, so the body band is widening-only and cannot fix a tail crossover. A 60% band still yields 3/9. Evidence on #3990. |
| Shadow copper still census-clean (unit 2a preserved) | PASS | 0 `OffAngleSegmentWarning` in the shadow-ON bench; `test_fleet_45_census.py` green. |
| Pre-phase wall time stays fail-fast bounded | PASS | 61.6 s pre-phase; every failed-shadow pair runs 0 joint-state iterations (no open-A* re-flooding). |
| Gap variations stay within the tolerance band; document the band source | PASS | Band = `[trace_width + effective_intra_pair_clearance(), d·(1+impedance_tolerance_percent/100)]`; documented in-code and in the commit body. |
| Default (shadow OFF) byte-for-byte unchanged; boards 03/06/07 gates green | PASS | All new code gates on `enable_shadow_construction`; `test_board_03_*`, `test_board_06_diffpair_test`, `test_board_07_matchgroup_test`, census: **127 passed, 1 skipped**. |
| If BOTH approaches plateau <6/9: post evidence + recommend disposition | PASS | Evidence posted on #3990 and #3921; recommended **close-wontfix for the variable-gap unit** (remaining lever is a crossover-aware tail synthesizer, a separate larger effort). |

## Why approach B was not implemented

- 3 of the 6 failing pairs are **polarity-swap** (PCIE_TX, USB3_RX2, USB3_TX2): the tail crossover is a topological requirement of the pad arrangement, which B's symmetric centerline offset **cannot express**.
- A faithful B for the 3 non-swap pairs needs the centerline routed with an **inflated keep-out width**, which requires plumbing a per-net trace-width override through the per-net router and the **C++ backend** — out of scope for a shadow-constructor issue, and it still cannot fix the swap majority, so it cannot reach 6/9.
- Full reasoning in the #3990 / #3921 evidence comment.

## Test Plan

- `tests/test_diffpair_shadow.py` — 35 passed (30 existing + 5 new).
- `tests/test_diffpair_{corridor,coupled_floor,routing_integration,self_intersection,npad,swap_via_reject,per_pair_timeout,phase_b}.py` — 121 passed.
- `tests/test_board_03_regression.py`, `test_board_03_copper_lvs.py`, `test_board_06_diffpair_test.py`, `test_board_07_matchgroup_test.py`, `test_fleet_45_census.py` — 127 passed, 1 skipped.
- `ruff check` + `ruff format --check` clean on both changed files. No new mypy errors introduced (the 9 in `diffpair_routing.py` are pre-existing, all outside the edited regions).
- Board-06 seed-42 shadow-ON bench (`PYTHONHASHSEED=42 KCT_BOARD06_SHADOW=1`): 3/9 convergence, 0 off-angle shadow segments, fail-fast pre-phase.

Refs #3990
Refs #3921
