### PR TITLE
fix(router): bound negotiated rip-up reroutes by remaining-budget per-net cap

### DIFF
--- a/src/kicad_tools/router/algorithms/__init__.py
+++ b/src/kicad_tools/router/algorithms/__init__.py
@@ -27,6 +27,7 @@ from .negotiated import (
     calculate_congestion_tuned_params,
     calculate_history_increment,
     calculate_present_cost,
+    derive_iter_per_net_cap,
     derive_per_net_cap,
     detect_oscillation,
     detect_ripup_stagnation,
@@ -55,6 +56,8 @@ __all__ = [
     "PER_NET_CAP_FLOOR_S",
     "PER_NET_CAP_STAGE_FRACTION",
     "derive_per_net_cap",
+    # Per-iteration per-net cap from remaining budget (Issue #3989)
+    "derive_iter_per_net_cap",
     # Adaptive parameter functions (Issue #633, #2333)
     "calculate_congestion_tuned_params",
     "calculate_history_increment",

--- a/src/kicad_tools/router/algorithms/negotiated.py
+++ b/src/kicad_tools/router/algorithms/negotiated.py
@@ -116,6 +116,62 @@ def derive_per_net_cap(
     return max(PER_NET_CAP_FLOOR_S, PER_NET_CAP_STAGE_FRACTION * float(stage_timeout))
 
 
+def derive_iter_per_net_cap(
+    per_net_timeout: float | None,
+    remaining_budget: float | None,
+) -> float | None:
+    """Return the per-net A* budget for one rip-up *iteration*.
+
+    Issue #3989 (rip-up-loop backstop integrity): :func:`derive_per_net_cap`
+    bounds the *initial* pass against the WHOLE stage budget, but that cap is
+    static for the life of the run.  The negotiated rip-up loop calls
+    ``_route_net_negotiated`` from several reroute sites (sequential reroute,
+    stagnation recovery, zero-overflow recovery), and the stage
+    ``check_timeout()`` only fires BETWEEN nets.  When a net drops to the
+    pure-Python A* fallback on a first-time geometric failure
+    (``FAILURE_NO_PATH`` / ``FAILURE_CLEARANCE`` -- not covered by #3956's
+    resume-exhaustion fast-path), one unbounded call can run ~200 s and
+    overshoot a 360 s backstop before the between-net check ever runs.
+
+    The fix is to derive a per-net cap from the *remaining* stage budget at
+    each iteration entry.  Early iterations get a generous cap (a fraction of
+    the plentiful remaining budget); late iterations shrink toward
+    ``PER_NET_CAP_FLOOR_S`` as the deadline approaches.  This makes the
+    backstop honest: the loop can overshoot at most by one final net's
+    bounded cap plus per-iteration overhead, never by an unbounded fallback.
+
+    An explicit ``per_net_timeout`` always binds when it is *tighter* than the
+    remaining-budget derivation, so an operator's ``--per-net-timeout`` is
+    never loosened; but as the deadline nears, the remaining-budget cap can
+    tighten below the explicit value so a late net cannot overrun the stage.
+
+    Args:
+        per_net_timeout: The effective per-net cap already in force for this
+            run (e.g. the value :func:`derive_per_net_cap` produced for the
+            initial pass, or an explicit ``--per-net-timeout``).  ``None`` =>
+            no standing cap.
+        remaining_budget: Seconds left in the stage budget at iteration entry
+            (``start_time + timeout - now``).  ``None`` => no stage budget
+            (legacy unbounded behaviour); non-positive => already past the
+            deadline, so clamp to the floor.
+
+    Returns:
+        The per-net budget in seconds for this iteration, or ``None`` when
+        neither a standing cap nor a stage budget is configured.
+    """
+    if remaining_budget is None:
+        # No stage budget: honour only whatever standing cap exists.
+        return per_net_timeout
+    # Derive a cap from the remaining budget: generous early, tight late.
+    remaining_cap = max(PER_NET_CAP_FLOOR_S, PER_NET_CAP_STAGE_FRACTION * float(remaining_budget))
+    if per_net_timeout is None:
+        return remaining_cap
+    # Both exist: take the tighter.  The remaining-budget derivation shrinks as
+    # the deadline nears, so late in the run it can bind below an explicit cap
+    # -- that is the whole point (the stage backstop must stay honest).
+    return min(per_net_timeout, remaining_cap)
+
+
 def run_initial_pass_grace(
     grace_nets: list[int],
     route_fn: Callable[[int, float], list],

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -44,6 +44,7 @@ from .algorithms import (
     calculate_congestion_tuned_params,
     calculate_history_increment,
     calculate_present_cost,
+    derive_iter_per_net_cap,
     derive_per_net_cap,
     detect_oscillation,
     run_initial_pass_grace,
@@ -7618,6 +7619,44 @@ class Autorouter:
                         timed_out = True
                         break
 
+                    # Issue #3989: derive a per-net A* cap from the budget
+                    # REMAINING at this iteration's entry.  ``check_timeout()``
+                    # only fires BETWEEN nets, so a single unbounded Python A*
+                    # fallback (first-time geometric failure, ~200 s -- NOT
+                    # covered by #3956's resume-exhaustion fast-path) can blow
+                    # far past the stage backstop before the next check runs
+                    # (board-06 seed-42: a 360 s backstop overran to ~560 s
+                    # wall, all of it AFTER the best 21/21 state was already
+                    # banked -- the grind produced a strictly worse state that
+                    # the end-of-loop restore then discarded).  Deriving the cap
+                    # from the remaining budget keeps the backstop honest:
+                    # generous early (a fraction of the plentiful remaining
+                    # budget), tight late (shrinks toward PER_NET_CAP_FLOOR_S as
+                    # the deadline nears) so the loop can overshoot at most by
+                    # one final net's bounded cap plus per-iteration overhead.
+                    # The standing ``per_net_timeout`` (explicit
+                    # --per-net-timeout or the #3474 initial-pass derivation)
+                    # still binds when it is tighter; the remaining-budget cap
+                    # only ever tightens it.
+                    #
+                    # Issue #3877 (why this is safe under --deterministic-budget):
+                    # the deterministic iteration backstop bounds the PRIMARY
+                    # search by a fixed node-expansion count for machine-
+                    # independent REACH, and this block runs even in that mode
+                    # (``per_net_timeout`` is ``None`` there).  The derived cap
+                    # is a fraction of the WHOLE remaining stage budget (36 s
+                    # early on a 360 s stage) -- orders of magnitude larger than
+                    # any healthy per-net negotiated search on these boards
+                    # (<1 s/net), so it can never cut a legitimately-routing
+                    # net short and cannot regress reach.  It only bounds the
+                    # pathological Python fallback grind (60-200 s/net) on nets
+                    # that are geometrically failing anyway -- exactly the
+                    # unbounded overshoot this issue targets.
+                    iter_remaining = (
+                        None if timeout is None else (start_time + timeout) - time.time()
+                    )
+                    iter_per_net_cap = derive_iter_per_net_cap(per_net_timeout, iter_remaining)
+
                     # Issue #2540 + #2803: Snapshot state at top of each iteration
                     # BEFORE any destructive ``rip_up_nets`` call.  If a
                     # mid-iteration timeout escapes the per-net reroute loop, the
@@ -8200,7 +8239,7 @@ class Autorouter:
                                 if rn not in pads_by_net:
                                     continue
                                 routes = self._route_net_negotiated(
-                                    rn, recovery_factor, per_net_timeout=per_net_timeout
+                                    rn, recovery_factor, per_net_timeout=iter_per_net_cap
                                 )
                                 if routes:
                                     net_routes[rn] = routes
@@ -8301,7 +8340,7 @@ class Autorouter:
                                 continue
                             attempted += 1
                             routes = self._route_net_negotiated(
-                                fn, recovery_factor, per_net_timeout=per_net_timeout
+                                fn, recovery_factor, per_net_timeout=iter_per_net_cap
                             )
                             if routes:
                                 net_routes[fn] = routes
@@ -8503,7 +8542,7 @@ class Autorouter:
                                     mark_route_callback=mark_route,
                                     ripup_history=ripup_history,
                                     max_ripups_per_net=max_ripups_per_net,
-                                    per_net_timeout=per_net_timeout,
+                                    per_net_timeout=iter_per_net_cap,
                                 )
                                 if success:
                                     targeted_ripup_count += 1
@@ -8531,7 +8570,7 @@ class Autorouter:
                                     routes = self._route_net_negotiated(
                                         failed_net,
                                         present_factor,
-                                        per_net_timeout=per_net_timeout,
+                                        per_net_timeout=iter_per_net_cap,
                                     )
                                     if routes:
                                         net_routes[failed_net] = routes
@@ -8548,7 +8587,7 @@ class Autorouter:
                                         other_routes = self._route_net_negotiated(
                                             other_net,
                                             present_factor,
-                                            per_net_timeout=per_net_timeout,
+                                            per_net_timeout=iter_per_net_cap,
                                         )
                                         if other_routes:
                                             net_routes[other_net] = other_routes
@@ -8564,7 +8603,7 @@ class Autorouter:
                                     routes = self._route_net_negotiated(
                                         failed_net,
                                         present_factor,
-                                        per_net_timeout=per_net_timeout,
+                                        per_net_timeout=iter_per_net_cap,
                                     )
                                     if routes:
                                         net_routes[failed_net] = routes
@@ -8681,7 +8720,7 @@ class Autorouter:
                                     mark_route_callback=_mark_route_neighborhood,
                                     stall_count=neighborhood_stall_count
                                     - neighborhood_stall_threshold,
-                                    per_net_timeout=per_net_timeout,
+                                    per_net_timeout=iter_per_net_cap,
                                     max_attempts=neighborhood_max_attempts,
                                     initial_radius_factor=neighborhood_initial_radius,
                                     escalation_factor=neighborhood_escalation_factor,
@@ -8755,7 +8794,7 @@ class Autorouter:
                                 present_cost_factor=present_factor,
                                 mark_route_callback=mark_route_targeted,
                                 strategy_index=escape_strategy_index,
-                                per_net_timeout=per_net_timeout,
+                                per_net_timeout=iter_per_net_cap,
                                 escape_budget=escape_budget,
                             )
                             escape_strategy_index += tried
@@ -8804,10 +8843,10 @@ class Autorouter:
                         # Use region-based parallelism if enabled (Issue #965)
                         if region_router is not None and len(nets_to_reroute) > 1:
                             # Route using region-based parallelism
-                            def route_fn(net: int, pf: float) -> list[Route]:
-                                return self._route_net_negotiated(
-                                    net, pf, per_net_timeout=per_net_timeout
-                                )
+                            def route_fn(
+                                net: int, pf: float, _cap: float | None = iter_per_net_cap
+                            ) -> list[Route]:
+                                return self._route_net_negotiated(net, pf, per_net_timeout=_cap)
 
                             def mark_fn(route: Route) -> None:
                                 self.grid.mark_route_usage(route)
@@ -8843,7 +8882,7 @@ class Autorouter:
                                 )
 
                                 routes = self._route_net_negotiated(
-                                    net, present_factor, per_net_timeout=per_net_timeout
+                                    net, present_factor, per_net_timeout=iter_per_net_cap
                                 )
                                 if routes:
                                     net_routes[net] = routes
@@ -8924,7 +8963,7 @@ class Autorouter:
                                 mark_route_callback=_mark_route_via_blocked,
                                 ripup_history=ripup_history,
                                 max_ripups_per_net=max_ripups_per_net,
-                                per_net_timeout=per_net_timeout,
+                                per_net_timeout=iter_per_net_cap,
                             )
                             if via_attempted > 0:
                                 flush_print(
@@ -8973,7 +9012,7 @@ class Autorouter:
                                         ripup_history=ripup_history,
                                         present_cost_factor=present_factor,
                                         max_ripups_per_net=max_ripups_per_net,
-                                        per_net_timeout=per_net_timeout,
+                                        per_net_timeout=iter_per_net_cap,
                                     )
                                     if rescued:
                                         component_ripup_count += 1
@@ -9051,7 +9090,7 @@ class Autorouter:
                                         mark_route_callback=_mark_route_fallback,
                                         ripup_history=ripup_history,
                                         max_ripups_per_net=max_ripups_per_net,
-                                        per_net_timeout=per_net_timeout,
+                                        per_net_timeout=iter_per_net_cap,
                                     )
                                     if success:
                                         targeted_fallback_count += 1
@@ -9110,7 +9149,7 @@ class Autorouter:
                                     net_routes,
                                     pads_by_net,
                                     present_factor,
-                                    per_net_timeout,
+                                    iter_per_net_cap,
                                     flush_print,
                                     elapsed_str,
                                     deadline=relief_deadline,
@@ -9189,7 +9228,7 @@ class Autorouter:
                                             mark_route_callback=_mark_route_silent,
                                             ripup_history=ripup_history,
                                             max_ripups_per_net=max_ripups_per_net,
-                                            per_net_timeout=per_net_timeout,
+                                            per_net_timeout=iter_per_net_cap,
                                         ):
                                             silent_resolved += 1
                                             continue
@@ -9210,7 +9249,7 @@ class Autorouter:
                                         net_routes,
                                         pads_by_net,
                                         present_factor,
-                                        per_net_timeout,
+                                        iter_per_net_cap,
                                         flush_print,
                                         elapsed_str,
                                         deadline=relief_deadline,
@@ -9270,7 +9309,7 @@ class Autorouter:
                                     mark_route_callback=_mark_route_neighborhood_std,
                                     stall_count=neighborhood_stall_count
                                     - neighborhood_stall_threshold,
-                                    per_net_timeout=per_net_timeout,
+                                    per_net_timeout=iter_per_net_cap,
                                     max_attempts=neighborhood_max_attempts,
                                     initial_radius_factor=neighborhood_initial_radius,
                                     escalation_factor=neighborhood_escalation_factor,
@@ -9394,7 +9433,7 @@ class Autorouter:
                             present_cost_factor=present_factor,
                             mark_route_callback=mark_route,
                             strategy_index=escape_strategy_index,
-                            per_net_timeout=per_net_timeout,
+                            per_net_timeout=iter_per_net_cap,
                             escape_budget=escape_budget,
                         )
                         escape_strategy_index += tried

--- a/tests/test_manufacturer_propagation_lint.py
+++ b/tests/test_manufacturer_propagation_lint.py
@@ -57,16 +57,17 @@ _SRC_ROOT = _REPO_ROOT / "src" / "kicad_tools"
 
 # Format: {relative_path: {line_number: reason}}
 _ALLOWLIST: dict[str, dict[int, str]] = {
-    # Router core: default-constructed router (line ~433 is the
-    # ``rules_dict``-spread default in _route_with_seed; line ~850 is
+    # Router core: default-constructed router (line ~434 is the
+    # ``rules_dict``-spread default in _route_with_seed; line ~851 is
     # the constructor default).  Reaching either means the caller did
     # not pass rules.  (Line numbers refreshed for issue #3464, the
     # #3663 ruff lint burn-down, #3881 which added the
-    # _per_net_iterations field/param, and #3942 which added the
-    # success-output oscillation diagnostics — each shifting both sites.)
+    # _per_net_iterations field/param, #3942 which added the
+    # success-output oscillation diagnostics, and #3989 which added the
+    # derive_iter_per_net_cap import — each shifting both sites.)
     "router/core.py": {
-        433: "worker-process rules_dict-spread default (both calls on this line)",
-        850: "Autorouter.__init__ rules-arg default fallback",
+        434: "worker-process rules_dict-spread default (both calls on this line)",
+        851: "Autorouter.__init__ rules-arg default fallback",
     },
     # AdaptiveRouter default fallback — same pattern as Autorouter.
     "router/adaptive.py": {

--- a/tests/test_negotiated_timeout_propagation.py
+++ b/tests/test_negotiated_timeout_propagation.py
@@ -483,3 +483,207 @@ class TestHierarchicalTimeoutPropagation:
 
         # All initial-pass calls must have received ``per_net_timeout=42.0``.
         assert captured_per_net == [42.0]
+
+
+# =============================================================================
+# Issue #3989 — rip-up-loop backstop integrity
+# =============================================================================
+#
+# ``route_all_negotiated`` takes a stage ``timeout`` (the backstop) and
+# enforces it via ``check_timeout()``, which fires only BETWEEN nets.  When a
+# net drops to the pure-Python A* fallback on a first-time geometric failure
+# (``FAILURE_NO_PATH`` / ``FAILURE_CLEARANCE`` -- NOT covered by #3956's
+# resume-exhaustion fast-path), one unbounded call can run ~200 s and overshoot
+# a 360 s backstop before the next between-net check runs.
+#
+# The fix (Option A) derives a per-net A* cap from the budget REMAINING at each
+# iteration entry and threads it to every reroute call site.  The cap is
+# generous early (a fraction of the plentiful remaining budget) and tightens
+# toward ``PER_NET_CAP_FLOOR_S`` as the deadline nears, so the loop can overshoot
+# by at most one final net's bounded cap plus per-iteration overhead.
+
+from kicad_tools.router.algorithms import (  # noqa: E402
+    PER_NET_CAP_FLOOR_S,
+    PER_NET_CAP_STAGE_FRACTION,
+    derive_iter_per_net_cap,
+    derive_per_net_cap,
+)
+from kicad_tools.router.core import Autorouter  # noqa: E402
+
+
+class TestDeriveIterPerNetCap:
+    """Unit coverage for the remaining-budget per-net cap derivation."""
+
+    def test_no_stage_budget_returns_standing_cap(self):
+        # ``remaining_budget=None`` => legacy unbounded stage: honour only the
+        # standing cap (explicit --per-net-timeout, or None for unbounded).
+        assert derive_iter_per_net_cap(None, None) is None
+        assert derive_iter_per_net_cap(30.0, None) == 30.0
+
+    def test_generous_early_when_budget_plentiful(self):
+        # Early in a 600 s stage: 10% of remaining = 60 s, well above floor.
+        assert derive_iter_per_net_cap(None, 600.0) == (PER_NET_CAP_STAGE_FRACTION * 600.0)
+
+    def test_curation_worked_example(self):
+        # The acceptance-criteria example: timeout=60 => derive_per_net_cap
+        # gives the standing cap of 6.0; at iteration entry with the full 60 s
+        # still remaining, the iter cap is also 6.0.
+        standing = derive_per_net_cap(None, 60.0)
+        assert standing == 6.0
+        assert derive_iter_per_net_cap(standing, 60.0) == 6.0
+
+    def test_tightens_toward_floor_late_in_stage(self):
+        # As the deadline nears, the remaining-budget cap shrinks; below the
+        # floor it clamps to PER_NET_CAP_FLOOR_S so a late net still gets a
+        # fair (but bounded) share.
+        assert derive_iter_per_net_cap(None, 1.0) == PER_NET_CAP_FLOOR_S
+        assert derive_iter_per_net_cap(None, 0.0) == PER_NET_CAP_FLOOR_S
+        # Already past the deadline (negative remaining) also clamps to floor.
+        assert derive_iter_per_net_cap(None, -50.0) == PER_NET_CAP_FLOOR_S
+
+    def test_explicit_cap_binds_when_tighter(self):
+        # An operator's explicit --per-net-timeout is never LOOSENED: when it is
+        # tighter than the remaining-budget derivation, it binds.
+        # 10% of 600 = 60; explicit 30 < 60 => 30 binds.
+        assert derive_iter_per_net_cap(30.0, 600.0) == 30.0
+
+    def test_remaining_budget_tightens_explicit_cap_late(self):
+        # Late in the stage the remaining-budget cap can drop BELOW an explicit
+        # cap -- that is the whole point: the backstop must stay honest even
+        # when the operator set a generous per-net budget.
+        # 10% of 20 = 2 -> clamps to floor 5.0; explicit 36 > 5 => 5 binds.
+        assert derive_iter_per_net_cap(36.0, 20.0) == PER_NET_CAP_FLOOR_S
+
+
+def _build_slow_net_router() -> Autorouter:
+    """Two nets on a 20x20 board.  Net 1 is trivial; net 2 is the
+    pathological net whose A* fallback we mock as slow.  Geometry keeps the
+    loop iterating via the mocked grid overflow below.
+    """
+    ar = Autorouter(width=20.0, height=20.0)
+    ar.add_component(
+        "R1",
+        [
+            {"number": "1", "x": 2.0, "y": 2.0, "net": 1, "net_name": "NET1"},
+            {"number": "2", "x": 18.0, "y": 2.0, "net": 1, "net_name": "NET1"},
+        ],
+    )
+    ar.add_component(
+        "R2",
+        [
+            {"number": "1", "x": 2.0, "y": 18.0, "net": 2, "net_name": "NET2"},
+            {"number": "2", "x": 18.0, "y": 18.0, "net": 2, "net_name": "NET2"},
+        ],
+    )
+    return ar
+
+
+class _ControllableClock:
+    """``time.time()`` returns ``self.now`` WITHOUT auto-advancing.  The mocked
+    slow net advances ``self.now`` explicitly by however long its (capped) A*
+    'runs'.  This drives ``check_timeout()`` deterministically with no real
+    sleeping, so the test is instant and load-independent."""
+
+    def __init__(self, start: float = 1000.0):
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+
+class TestRipupLoopBackstopHonored:
+    """Issue #3989: a single slow Python-fallback A* call must not let the
+    negotiated rip-up loop overshoot its stage backstop unboundedly."""
+
+    def _run(self, timeout: float, per_net_timeout, unbounded_call_cost: float):
+        """Drive ``route_all_negotiated`` with net 2's ``_route_net_negotiated``
+        mocked to 'run' for ``unbounded_call_cost`` seconds UNLESS a
+        ``per_net_timeout`` bounds it -- exactly how a deadline-respecting A*
+        behaves.  Returns ``(final_now, start, clock)``.
+        """
+        ar = _build_slow_net_router()
+        clock = _ControllableClock(start=1000.0)
+
+        # Force overflow to persist so the rip-up loop keeps iterating and the
+        # slow net is re-attempted each iteration (the #3413/#3448 recovery
+        # paths that this fix threads the cap into).
+        ar.grid.get_total_overflow = lambda: 5  # type: ignore[method-assign]
+        # ``find_overused_cells`` yields (gx, gy, layer, overflow) 4-tuples.
+        ar.grid.find_overused_cells = lambda: [(10, 10, 0, 5)]  # type: ignore[method-assign]
+
+        orig = ar._route_net_negotiated
+
+        def slow_fake(net, present_factor, per_net_timeout=None):
+            if net != 2:
+                return orig(net, present_factor, per_net_timeout=per_net_timeout)
+            # A deadline-respecting A*: it 'runs' for its cost, but never past
+            # the per-net cap it was handed.  A ``None`` cap (the bug) means an
+            # UNBOUNDED run that eats ``unbounded_call_cost`` whole.
+            cost = unbounded_call_cost
+            if per_net_timeout is not None:
+                cost = min(cost, per_net_timeout)
+            clock.now += cost
+            # Return a partial/empty result so the net stays 'unrouted' and the
+            # recovery paths keep re-attempting it (drives repeated slow calls).
+            return []
+
+        ar._route_net_negotiated = slow_fake  # type: ignore[method-assign]
+
+        with patch("kicad_tools.router.core.time.time", clock):
+            ar.route_all_negotiated(
+                max_iterations=8,
+                timeout=timeout,
+                per_net_timeout=per_net_timeout,
+                adaptive=False,
+                perturbation=False,
+            )
+        return clock.now, 1000.0, clock
+
+    def test_single_slow_call_does_not_blow_past_backstop(self):
+        """With ``timeout=60`` and ``per_net_timeout=None`` (board-06's recipe),
+        a net whose fallback would run 200 s must be capped so the loop's total
+        overshoot is bounded to ~one final net's derived cap.
+
+        Acceptance criterion: elapsed <= timeout + derived_cap + epsilon, where
+        derived_cap = derive_per_net_cap(None, 60.0) = 6.0.
+        """
+        final_now, start, _ = self._run(
+            timeout=60.0, per_net_timeout=None, unbounded_call_cost=200.0
+        )
+        elapsed = final_now - start
+        derived_cap = derive_per_net_cap(None, 60.0)
+        assert derived_cap == 6.0
+        # Overshoot bounded to one final net's cap plus a small overhead grace.
+        # WITHOUT the fix, one uncapped 200 s call alone lands elapsed >= 200.
+        assert elapsed <= 60.0 + derived_cap + 1.0, (
+            f"loop overshot backstop: elapsed={elapsed:.1f}s (budget 60 + cap {derived_cap} + eps)"
+        )
+        # Sanity: it must actually have consumed most of the budget (the slow
+        # net really did run), not exit trivially early.
+        assert elapsed >= 60.0 - 12.0
+
+    def test_no_stage_budget_leaves_slow_call_unbounded(self):
+        """Edge case: ``timeout=None, per_net_timeout=None`` (legacy unbounded)
+        derives no cap -- the slow call is NOT bounded.  Confirms the fix does
+        not silently impose a cap when no budget exists."""
+        final_now, start, _ = self._run(
+            timeout=None, per_net_timeout=None, unbounded_call_cost=200.0
+        )
+        elapsed = final_now - start
+        # No backstop => the full 200 s call ran unbounded at least once.
+        assert elapsed >= 200.0
+
+    def test_explicit_per_net_timeout_is_respected(self):
+        """Edge case: an explicit ``per_net_timeout`` that is TIGHTER than the
+        remaining-budget derivation must bind, not be loosened to the derived
+        stage fraction."""
+        # timeout=360 => standing derived cap would be 36; but the caller passes
+        # an explicit 8.0, which is tighter and must bind every call.
+        final_now, start, _ = self._run(
+            timeout=360.0, per_net_timeout=8.0, unbounded_call_cost=200.0
+        )
+        elapsed = final_now - start
+        # Each slow call is capped at 8s (< 36 derived, < 200 unbounded).  With
+        # a 360 s budget the loop runs several iterations but each net call is
+        # bounded at 8 s, so it never overshoots by a whole 200 s call.
+        assert elapsed <= 360.0 + 8.0 + 1.0


### PR DESCRIPTION
## Summary

The negotiated rip-up loop takes a stage `timeout` (the backstop) enforced by `check_timeout()`, which fires only BETWEEN nets. When a net drops to the pure-Python A* fallback on a **first-time geometric failure** (`FAILURE_NO_PATH` / `FAILURE_CLEARANCE` -- NOT covered by #3956's resume-exhaustion fast-path), one call can run ~200 s and overshoot the backstop before the next between-net check runs.

On board-06 (`--step route --seed 42`) a 360 s backstop overran to ~384 s of loop time (563 s total wall) -- all of it AFTER the best 21/21 state was banked at ~18 s. The grind produced a strictly worse state (`connected=2`) that the end-of-loop restore then discarded, so the overshoot was pure wasted wall time.

Option A from the issue: at each iteration entry, derive a per-net A* cap from the budget REMAINING and thread it to every reroute call site inside the iteration body. Generous early (a fraction of the plentiful remaining budget), tightening toward `PER_NET_CAP_FLOOR_S` as the deadline nears, so the loop can overshoot at most by one final net's bounded cap plus overhead.

## Changes

- **`algorithms/negotiated.py`**: add `derive_iter_per_net_cap(per_net_timeout, remaining_budget)` -- extends the #3474 `derive_per_net_cap` pattern to the iteration passes using REMAINING (not total) budget. An explicit `--per-net-timeout` still binds when tighter; the remaining-budget cap only ever tightens it.
- **`algorithms/__init__.py`**: export `derive_iter_per_net_cap`.
- **`router/core.py`**: in `route_all_negotiated`, derive `iter_per_net_cap` at each iteration entry and pass it (instead of the static `per_net_timeout`) to every in-loop reroute site: sequential reroute, stagnation recovery, zero-overflow recovery, targeted / full-reorder / neighborhood / via-blocked / escape rescues, and the two relief-rescue calls.
- **`tests/test_negotiated_timeout_propagation.py`**: unit coverage for the derivation + integration tests driving a real `Autorouter` through `route_all_negotiated` with a mocked deadline-respecting slow net, proving the overshoot bound.

The cap is a fraction of the whole stage budget (36 s early on a 360 s stage) -- orders of magnitude larger than any healthy per-net search (<1 s/net on these boards) -- so it never cuts a legitimately-routing net short and cannot regress reach. It only bounds the pathological fallback grind on nets that are geometrically failing anyway. This is why it is safe even under `--deterministic-budget` (the primary search stays iteration-bounded for machine-independent reach).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Negotiated-loop wall time honestly bounded (overshoot ≤ one net's capped budget + overhead) | ✅ | Board-06 loop overshoot **24.5 s → 2.6 s** past the 360 s backstop |
| Board-06 negotiated runs complete within CI-class budgets | ✅ | Loop now ends at 362.6 s (was 384.5 s); the ~175 s post-loop optimize/quantize/DRC is a separate pipeline stage, unchanged |
| No completion-rate regression on boards 03/06/07 gates | ✅ | Board-06 best state **21/21 identical** before/after; board-06 gate + fleet-census + escalation suites green |
| Cap derives from REMAINING budget (generous early, tight late; explicit cap respected) | ✅ | Unit tests: `(None,600)→60`, `(None,60)→6`, `(None,1)→5.0 floor`, `(36,20)→5.0`, `(30,None)→30`, `(None,None)→None` |
| Mocked-slow-net test proves the bound | ✅ | `TestRipupLoopBackstopHonored`: `timeout=60, per_net_timeout=None`, 200 s/call mock ⇒ elapsed ≤ 60 + derive_per_net_cap(None,60)=6 + eps |
| No existing tests in the named suites broken | ✅ | `test_negotiated_timeout_propagation`, `test_negotiated_congestion_model`, `test_best_metric_patience` all green |

## Test Plan

- `uv run pytest tests/test_negotiated_timeout_propagation.py tests/test_negotiated_congestion_model.py tests/test_best_metric_patience.py tests/test_negotiated_convergence_stranded.py` -- 57 passed
- Escalation + deadline suites (`test_checkpoint_in_escalation`, `test_layer_escalation`, `test_per_net_deadline_audit`) + board-06 gate + fleet-census -- green
- `test_router_core` + `test_negotiated_adaptive` + rollback suites -- 319 passed
- Real board-06 `--step route --seed 42`: before 563.4 s wall / loop-end 384.5 s / 21/21; after 536.5 s wall / loop-end 362.6 s / 21/21
- `ruff check` + `ruff format --check` clean; no new mypy errors on changed files (the 15 pre-existing `negotiated.py` errors are unrelated and present on `origin/main`)

Closes #3989