### PR TITLE
test(lint): key manufacturer-propagation allowlist by enclosing scope, not line number

### DIFF
--- a/tests/test_manufacturer_propagation_lint.py
+++ b/tests/test_manufacturer_propagation_lint.py
@@ -26,8 +26,9 @@ This file guards against future regressions by statically scanning every
 asserting that:
 
 1. The call passes ``manufacturer=`` explicitly, OR
-2. The call sits on an allowlisted line in ``_ALLOWLIST`` below with a
-   documented reason.
+2. The call sits in an allowlisted *scope* in ``_ALLOWLIST`` below
+   (keyed by enclosing function/method, line-stable) with a documented
+   reason and expected call count.
 
 The placement-side ``placement.analyzer.DesignRules`` is a different
 dataclass with no manufacturer field and is not at risk; the lint
@@ -47,52 +48,75 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 _SRC_ROOT = _REPO_ROOT / "src" / "kicad_tools"
 
 # ----------------------------------------------------------------------------
-# Allowlist: files known to legitimately omit ``manufacturer=``.
+# Allowlist: sites known to legitimately omit ``manufacturer=``.
 #
-# Each entry maps a file path (relative to ``src/kicad_tools``) to a set of
-# 1-based line numbers where ``DesignRules(...)`` is intentionally
-# constructed without ``manufacturer=``.  Add a brief reason next to the
-# tuple to document why omission is safe.
+# Historically this allowlist was keyed by 1-based line numbers, which
+# broke on *every* unrelated insertion above an audited site (issue #3993
+# tracked three such breakages — PRs #3945, #3966, #3992 — each costing a
+# full Doctor->Judge round-trip).  It is now keyed by the **enclosing
+# scope** (module-level function or ``Class.method`` qualified name), which
+# is stable against line shifts: inserting no-op lines above an allowlisted
+# call no longer invalidates it, while a *new* ``DesignRules()`` fallback in
+# an un-audited scope is still caught.
+#
+# To also catch a new bad call added *inside* an already-allowlisted scope,
+# each entry records the exact number of manufacturer-less ``DesignRules()``
+# calls expected in that scope.  Adding an extra call in an allowlisted
+# scope raises the observed count above the allowed count and fails the
+# lint (the extra call must be threaded through or explicitly re-audited).
+#
+# Format: {relative_path: {scope_qualname: (expected_count, reason)}}
+#   - ``scope_qualname`` is the dotted path of enclosing FunctionDef /
+#     AsyncFunctionDef / ClassDef names (e.g. ``Autorouter.__init__``).
+#   - Module-level calls (no enclosing scope) use the key ``"<module>"``.
 # ----------------------------------------------------------------------------
 
-# Format: {relative_path: {line_number: reason}}
-_ALLOWLIST: dict[str, dict[int, str]] = {
-    # Router core: default-constructed router (line ~434 is the
-    # ``rules_dict``-spread default in _route_with_seed; line ~851 is
-    # the constructor default).  Reaching either means the caller did
-    # not pass rules.  (Line numbers refreshed for issue #3464, the
-    # #3663 ruff lint burn-down, #3881 which added the
-    # _per_net_iterations field/param, #3942 which added the
-    # success-output oscillation diagnostics, and #3989 which added the
-    # derive_iter_per_net_cap import — each shifting both sites.)
+_MODULE_SCOPE = "<module>"
+
+_ALLOWLIST: dict[str, dict[str, tuple[int, str]]] = {
+    # Router core: default-constructed router.  ``_run_monte_carlo_trial``
+    # holds the ``rules_dict``-spread default (a ternary that emits *two*
+    # bare ``DesignRules()`` calls on one line); ``Autorouter.__init__``
+    # holds the constructor ``rules or DesignRules()`` fallback.  Reaching
+    # either means the caller did not pass rules.
     "router/core.py": {
-        434: "worker-process rules_dict-spread default (both calls on this line)",
-        851: "Autorouter.__init__ rules-arg default fallback",
+        "_run_monte_carlo_trial": (
+            2,
+            "worker-process rules_dict-spread default (ternary: two calls)",
+        ),
+        "Autorouter.__init__": (1, "Autorouter.__init__ rules-arg default fallback"),
     },
     # AdaptiveRouter default fallback — same pattern as Autorouter.
     "router/adaptive.py": {
-        108: "AdaptiveAutorouter.__init__ default fallback",
+        "AdaptiveAutorouter.__init__": (1, "AdaptiveAutorouter.__init__ default fallback"),
     },
     # Library API: ``route_pcb()`` synthesises default rules only when
     # the caller explicitly passes ``rules=None`` (no PCB rules either).
     # The CLI always supplies its own rules with manufacturer wired in.
     "router/io.py": {
-        3022: "route_pcb() fallback when caller passes rules=None",
-        3625: "load_pcb_for_routing() inner fallback when neither rules nor pcb_rules supplied",
+        "route_pcb": (1, "route_pcb() fallback when caller passes rules=None"),
+        "load_pcb_for_routing": (
+            1,
+            "load_pcb_for_routing() inner fallback when neither rules nor pcb_rules supplied",
+        ),
     },
     # Benchmark/synthetic fixture generators — no real CLI context.
     "benchmark/runner.py": {
-        112: "Benchmark harness fixture; no manufacturer context",
+        "BenchmarkRunner.run_single": (1, "Benchmark harness fixture; no manufacturer context"),
     },
     "benchmark/generators.py": {
-        52: "Synthetic benchmark generator fixture",
-        147: "Synthetic benchmark generator fixture",
+        "generate_bga_breakout": (1, "Synthetic benchmark generator fixture"),
+        "generate_random_board": (1, "Synthetic benchmark generator fixture"),
     },
     # Evolutionary algorithm: constructs DesignRules from a serialised
     # rules_dict to recreate router state across worker processes.  The
     # ``manufacturer`` field flows through ``rules_dict`` if present.
+    # ``_run_evolutionary_trial`` also uses the two-call ternary form.
     "router/algorithms/evolutionary.py": {
-        224: "Evolutionary worker rules_dict-spread; manufacturer flows via dict",
+        "_run_evolutionary_trial": (
+            2,
+            "Evolutionary worker rules_dict-spread; manufacturer flows via dict (ternary: two calls)",
+        ),
     },
 }
 
@@ -110,12 +134,21 @@ class _DesignRulesCallFinder(ast.NodeVisitor):
     router package, then matching call-site names against that alias
     set.  Bare ``DesignRules`` and attribute access (``mod.DesignRules``)
     are also matched.
+
+    Each recorded site carries its **enclosing scope** — the dotted path
+    of enclosing function/method/class names (e.g. ``Autorouter.__init__``
+    or ``_run_monte_carlo_trial``).  This lets the allowlist be keyed by a
+    line-stable identifier instead of a raw line number (issue #3993).
+    Module-level calls report the scope ``"<module>"``.
     """
 
     def __init__(self, source_tree: ast.AST | None = None) -> None:
-        self.sites: list[tuple[int, list[str]]] = []
+        # Each site: (lineno, keywords, scope_qualname).
+        self.sites: list[tuple[int, list[str], str]] = []
         # Aliases that resolve to router.rules.DesignRules.
         self.router_aliases: set[str] = {"DesignRules"}
+        # Stack of enclosing scope names as we descend the tree.
+        self._scope_stack: list[str] = []
         if source_tree is not None:
             self._collect_router_aliases(source_tree)
 
@@ -135,13 +168,31 @@ class _DesignRulesCallFinder(ast.NodeVisitor):
                 if alias.name == "DesignRules":
                     self.router_aliases.add(alias.asname or "DesignRules")
 
+    @property
+    def _current_scope(self) -> str:
+        return ".".join(self._scope_stack) if self._scope_stack else _MODULE_SCOPE
+
+    def _visit_scope(self, node: ast.AST) -> None:
+        self._scope_stack.append(getattr(node, "name", "?"))
+        self.generic_visit(node)
+        self._scope_stack.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
+        self._visit_scope(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:  # noqa: N802
+        self._visit_scope(node)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:  # noqa: N802
+        self._visit_scope(node)
+
     def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
         # Only match bare-name calls.  Attribute-access calls like
         # ``router_cpp.DesignRules()`` refer to a different class (the
         # C++ binding) and must not be flagged by this lint.
         if isinstance(node.func, ast.Name) and node.func.id in self.router_aliases:
             keywords = [kw.arg for kw in node.keywords if kw.arg is not None]
-            self.sites.append((node.lineno, keywords))
+            self.sites.append((node.lineno, keywords, self._current_scope))
         self.generic_visit(node)
 
 
@@ -208,6 +259,62 @@ def _iter_python_files() -> list[Path]:
 _NOQA_RE = re.compile(r"#\s*noqa\s*:\s*MFR001\b", re.IGNORECASE)
 
 
+def _scan_source_for_violations(
+    rel: str,
+    source: str,
+    allowlist: dict[str, tuple[int, str]],
+) -> list[str]:
+    """Scan one module's source for manufacturer-less ``DesignRules()`` calls.
+
+    Returns a list of human-readable violation strings for every bare
+    ``DesignRules()`` construction whose enclosing scope is not covered by
+    ``allowlist`` (keyed by scope qualname -> (expected_count, reason)) and
+    not suppressed by an inline ``# noqa: MFR001`` pragma.
+
+    Sharing this helper between the canonical lint and the acceptance tests
+    guarantees the tests exercise the *actual* line-stable scope matching,
+    not a re-implementation of it.
+    """
+    tree = ast.parse(source)
+    finder = _DesignRulesCallFinder(tree)
+    finder.visit(tree)
+
+    source_lines = source.splitlines()
+
+    # Count how many manufacturer-less calls each scope is allowed to
+    # host, then decrement as we account for them.  A scope that hosts
+    # *more* bare calls than its allowlisted budget still reports the
+    # surplus as a violation (catches a new bad call added inside an
+    # already-allowlisted scope).
+    scope_budget: dict[str, int] = {scope: count for scope, (count, _) in allowlist.items()}
+
+    violations: list[str] = []
+    for lineno, keywords, scope in finder.sites:
+        if "manufacturer" in keywords:
+            continue
+        if scope_budget.get(scope, 0) > 0:
+            scope_budget[scope] -= 1
+            continue
+
+        # In-line noqa pragma escape hatch — search a small window
+        # around the opening paren, since the call may span lines.
+        window_start = max(0, lineno - 1)
+        window_end = min(len(source_lines), lineno + 1)
+        window = "\n".join(source_lines[window_start:window_end])
+        if _NOQA_RE.search(window):
+            continue
+
+        violations.append(
+            f"{rel}:{lineno} (scope {scope!r}): DesignRules(...) "
+            f"constructed without manufacturer= and not covered by "
+            f"_ALLOWLIST. Either thread manufacturer through, add the "
+            f"enclosing scope to _ALLOWLIST in this test file with a "
+            f'reason, or add `# noqa: MFR001 reason="..."` on the same '
+            f"line."
+        )
+    return violations
+
+
 def test_manufacturer_propagation_in_router_design_rules():
     """Every ``router.rules.DesignRules(...)`` call must pass ``manufacturer=``.
 
@@ -240,33 +347,7 @@ def test_manufacturer_propagation_in_router_design_rules():
         if _imports_placement_design_rules(tree) and not _imports_router_design_rules(tree):
             continue
 
-        finder = _DesignRulesCallFinder(tree)
-        finder.visit(tree)
-
-        source_lines = source.splitlines()
-        allowlist = _ALLOWLIST.get(rel, {})
-
-        for lineno, keywords in finder.sites:
-            if "manufacturer" in keywords:
-                continue
-            if lineno in allowlist:
-                continue
-
-            # In-line noqa pragma escape hatch — search a small window
-            # around the opening paren, since the call may span lines.
-            window_start = max(0, lineno - 1)
-            window_end = min(len(source_lines), lineno + 1)
-            window = "\n".join(source_lines[window_start:window_end])
-            if _NOQA_RE.search(window):
-                continue
-
-            violations.append(
-                f"{rel}:{lineno}: DesignRules(...) constructed without "
-                f"manufacturer= and not in allowlist. Either thread "
-                f"manufacturer through, add the line to _ALLOWLIST in "
-                f"this test file with a reason, or add `# noqa: MFR001 "
-                f'reason="..."` on the same line.'
-            )
+        violations.extend(_scan_source_for_violations(rel, source, _ALLOWLIST.get(rel, {})))
 
     assert not violations, "manufacturer propagation regression (Issue #2708):\n  " + "\n  ".join(
         violations
@@ -279,9 +360,18 @@ def test_manufacturer_propagation_in_router_design_rules():
 
 
 def test_allowlist_entries_resolve_to_actual_call_sites():
-    """Each allowlist entry must point to a real ``DesignRules(`` call."""
+    """Each allowlist entry must resolve to the expected bare-call scope.
+
+    A scope-keyed entry is *stale* when its enclosing scope no longer
+    hosts any manufacturer-less ``DesignRules()`` call, or when the number
+    of such calls differs from the recorded ``expected_count`` (either a
+    site was removed/threaded through, or a new one was added and must be
+    re-audited).
+    """
+    from collections import Counter
+
     stale: list[str] = []
-    for rel, lines in _ALLOWLIST.items():
+    for rel, scopes in _ALLOWLIST.items():
         path = _SRC_ROOT / rel
         if not path.exists():
             stale.append(f"{rel}: file does not exist")
@@ -293,11 +383,24 @@ def test_allowlist_entries_resolve_to_actual_call_sites():
             continue
         finder = _DesignRulesCallFinder(tree)
         finder.visit(tree)
-        site_lines = {site[0] for site in finder.sites}
-        for lineno in lines:
-            if lineno not in site_lines:
+
+        # Count manufacturer-less calls per enclosing scope.
+        observed: Counter[str] = Counter(
+            site[2] for site in finder.sites if "manufacturer" not in site[1]
+        )
+
+        for scope, (expected_count, _reason) in scopes.items():
+            actual = observed.get(scope, 0)
+            if actual == 0:
                 stale.append(
-                    f"{rel}:{lineno}: no DesignRules() call at this line (allowlist out of date)"
+                    f"{rel}: scope {scope!r} hosts no manufacturer-less "
+                    f"DesignRules() call (allowlist out of date)"
+                )
+            elif actual != expected_count:
+                stale.append(
+                    f"{rel}: scope {scope!r} hosts {actual} manufacturer-less "
+                    f"DesignRules() call(s), allowlist expects {expected_count} "
+                    f"(update the expected count if the change is intentional)"
                 )
 
     assert not stale, "Stale entries in _ALLOWLIST:\n  " + "\n  ".join(stale)
@@ -331,4 +434,94 @@ def test_fixed_sites_pass_manufacturer(site_description):
         f"{rel} ({description}): expected at least one DesignRules(...) "
         f"call passing manufacturer=, found none. Issue #2708 audit must "
         f"have regressed."
+    )
+
+
+# ----------------------------------------------------------------------------
+# Line-stability regression tests (Issue #3993)
+#
+# The allowlist was previously keyed by absolute line number, so inserting
+# unrelated code above an audited site broke the lint (observed three times:
+# PRs #3945, #3966, #3992).  These synthetic-source tests pin the two
+# acceptance criteria: (1) no-op insertions above an allowlisted site do not
+# fail; (2) a genuinely new fallback site still fails.  They run through the
+# real ``_scan_source_for_violations`` helper so they track the production
+# matching logic.
+# ----------------------------------------------------------------------------
+
+
+# Synthetic module mirroring the ``Autorouter.__init__`` fallback pattern:
+# a single manufacturer-less ``DesignRules()`` inside an allowlisted scope.
+_SYNTHETIC_SOURCE = """\
+from kicad_tools.router.rules import DesignRules
+
+
+class Autorouter:
+    def __init__(self, rules=None):
+        self.rules = rules or DesignRules()
+"""
+
+# Allowlist covering exactly the audited scope with a budget of one call.
+_SYNTHETIC_ALLOWLIST = {"Autorouter.__init__": (1, "synthetic audited fallback")}
+
+
+def test_noop_insertion_above_allowlisted_site_does_not_fail():
+    """Acceptance: inserting no-op lines above an audited site stays green.
+
+    This is the exact failure mode from issue #3993 — a line-number-keyed
+    allowlist would flag the shifted site.  The scope-keyed allowlist must
+    not.
+    """
+    # Baseline: the audited site is covered, so no violations.
+    baseline = _scan_source_for_violations("synthetic.py", _SYNTHETIC_SOURCE, _SYNTHETIC_ALLOWLIST)
+    assert baseline == [], f"baseline synthetic source unexpectedly flagged: {baseline}"
+
+    # Insert 25 unrelated no-op lines above the class, shifting the audited
+    # call far from its original line number.
+    noop_block = "\n".join(f"_UNUSED_{i} = {i}  # unrelated insertion" for i in range(25))
+    shifted_source = _SYNTHETIC_SOURCE.replace(
+        "class Autorouter:", f"{noop_block}\n\n\nclass Autorouter:"
+    )
+
+    shifted = _scan_source_for_violations("synthetic.py", shifted_source, _SYNTHETIC_ALLOWLIST)
+    assert shifted == [], (
+        "Inserting no-op lines above an allowlisted DesignRules() site must "
+        f"NOT fail the lint (issue #3993), but got violations: {shifted}"
+    )
+
+
+def test_new_fallback_site_still_fails():
+    """Acceptance: a genuinely new manufacturer-less fallback still fails.
+
+    The lint's intent must survive the re-keying: an un-audited scope, and
+    an extra bare call added *inside* an audited scope, both remain
+    violations.
+    """
+    # (a) New fallback in a brand-new, un-allowlisted scope.
+    new_scope_source = _SYNTHETIC_SOURCE + (
+        "\n\n"
+        "def brand_new_factory():\n"
+        "    return DesignRules()  # newly-added, un-audited fallback\n"
+    )
+    new_scope = _scan_source_for_violations("synthetic.py", new_scope_source, _SYNTHETIC_ALLOWLIST)
+    assert new_scope, (
+        "A new DesignRules() fallback in an un-allowlisted scope must fail "
+        "the lint, but no violation was reported."
+    )
+    assert any("brand_new_factory" in v for v in new_scope), new_scope
+
+    # (b) A second bare call added *inside* an already-allowlisted scope
+    #     exceeds the recorded budget of 1 and must still fail.
+    extra_call_source = _SYNTHETIC_SOURCE.replace(
+        "        self.rules = rules or DesignRules()\n",
+        "        self.rules = rules or DesignRules()\n"
+        "        self.backup_rules = DesignRules()  # extra, un-audited\n",
+    )
+    extra_call = _scan_source_for_violations(
+        "synthetic.py", extra_call_source, _SYNTHETIC_ALLOWLIST
+    )
+    assert extra_call, (
+        "A second manufacturer-less DesignRules() added inside an "
+        "allowlisted scope must exceed the recorded budget and fail the "
+        "lint, but no violation was reported."
     )


### PR DESCRIPTION
## Summary
The MFR001 manufacturer-propagation lint (`tests/test_manufacturer_propagation_lint.py`) keyed its `_ALLOWLIST` by absolute 1-based line numbers. Any unrelated insertion above an audited `DesignRules()` fallback shifted the site and broke the lint — observed three times (PRs #3945, #3966, #3992), each costing a full Doctor→Judge round-trip. This re-keys the allowlist by the **enclosing scope** (line-stable), preserving the lint's intent while eliminating the line-shift fragility.

## Changes
- Re-key `_ALLOWLIST` from `{path: {line_number: reason}}` to `{path: {scope_qualname: (expected_count, reason)}}`, where `scope_qualname` is the dotted enclosing-function/method path (e.g. `Autorouter.__init__`, `_run_monte_carlo_trial`).
- Extend `_DesignRulesCallFinder` with a scope stack (`FunctionDef`/`AsyncFunctionDef`/`ClassDef`) so every recorded call site carries its enclosing scope; module-level calls use `"<module>"`.
- Record a per-scope expected call count so a *new* bare `DesignRules()` added **inside** an already-allowlisted scope still fails (budget-exceeded), keeping the guard tight.
- Update `test_allowlist_entries_resolve_to_actual_call_sites` to validate scope + count instead of line numbers.
- Extract the per-file scan into `_scan_source_for_violations()`, shared by the canonical lint and the new acceptance tests (so the tests exercise production logic, not a re-implementation).
- Add two acceptance tests (`test_noop_insertion_above_allowlisted_site_does_not_fail`, `test_new_fallback_site_still_fails`).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Inserting a no-op line above an allowlisted site does not fail the lint | ✅ | New `test_noop_insertion...` (25 synthetic no-op lines) + live check: injected 5 no-op lines above `router/core.py` L434, allowlisted call shifted to L439, `pytest` stayed 9/9 green, then reverted |
| Adding a genuinely new `DesignRules()` call site still fails | ✅ | `test_new_fallback_site_still_fails` covers both a new un-audited scope and an extra call inside an audited scope |
| Existing allowlisted sites carry over | ✅ | All 9 audited scopes (core/adaptive/io/benchmark/evolutionary) resolve; `test_manufacturer_propagation_...` + `test_allowlist_entries_resolve...` pass |
| Test covers both cases | ✅ | Two new acceptance tests, run through the shared `_scan_source_for_violations` helper |
| Lint intent intact (no unaudited manufacturer-default fallbacks) | ✅ | Scope + count enforcement; `test_fixed_sites_pass_manufacturer` unchanged and passing |

## Test Plan
- `uv run pytest tests/test_manufacturer_propagation_lint.py` → 9 passed.
- Live line-shift simulation: 5 no-op lines injected above the `router/core.py` allowlisted site (shifted L434→L439), lint stayed green, reverted (no `src/` changes in this PR).
- `uv run ruff check .` → all checks passed; `uv run ruff format . --check` → all formatted.

Closes #3993