### PR TITLE
feat(boards): emit lvs.json for boards 01+02 (gallery LVS gate)

### DIFF
--- a/boards/01-voltage-divider/output/lvs.json
+++ b/boards/01-voltage-divider/output/lvs.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://kicad-tools.org/schemas/lvs/v1.json",
+  "clean": true,
+  "mismatches": [],
+  "copper_mismatches": []
+}

--- a/boards/02-charlieplex-led/output/lvs.json
+++ b/boards/02-charlieplex-led/output/lvs.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://kicad-tools.org/schemas/lvs/v1.json",
+  "clean": true,
+  "mismatches": [],
+  "copper_mismatches": []
+}


### PR DESCRIPTION
## Summary
Boards 01-voltage-divider and 02-charlieplex-led are status=ok / DRC 0, but the kicad-tools.org gallery showed **"LVS not run"** because neither had a committed `output/lvs.json` (the site's `lvs_clean === undefined` → unverified gate, see `site/src/data/boardStatus.ts`).

This PR adds the missing LVS artifacts, generated with `kicad_tools.lvs.recipe.write_lvs_report` against the **committed** schematic + routed PCB (artifact-first — no recipe or board changes):

| Board | label-LVS | copper-LVS |
|---|---|---|
| 01-voltage-divider | PASS (0 mismatches) | PASS (0 shorts / 0 opens) |
| 02-charlieplex-led | PASS (0 mismatches) | PASS (0 shorts / 0 opens) |

Both runs used the default fresh-subprocess copper re-check (#3838) with in-process/fresh agreement.

## Effect
`kct board-metrics` now emits `lvs_clean: true` for both boards → gallery badge flips to **Ready** (2 of the 7 non-Ready boards on https://kicad-tools.org).

## Notes
- Board 02's recipe already wires `write_lvs_report` (hard gate); board 01's recipe does not yet — this PR does not change recipes, it only commits the verified artifacts, matching how boards 00/03/04 carry `output/lvs.json` in-tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)