### PR TITLE
fix(lvs): vacuity guard — zero bound schematic pins can never be clean=true (closes #4006)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1302,36 +1302,36 @@ jobs:
             /tmp/board03-staging/03-usb-joystick
 
   board-06-end-to-end:
-    # Issue #3779: LVS-ONLY end-to-end gate for board 06 ("diffpair-test").
-    # Board 06 is a PCB-first routing fixture (USB3 connectors with no
-    # schematic-side net), so its label-LVS is all ``schematic_net=None``
-    # advisory noise.  Its recipe now runs
-    # ``write_lvs_report(..., require_clean=True, run_copper=True,
-    # run_label=False)`` in the ``--step all`` branch, hard-gating on the
-    # copper-extracted comparator only and emitting ``output/lvs.json``.
+    # Issue #3779 (reworked for #4006): end-to-end gate for board 06
+    # ("diffpair-test").  Board 06 is a PCB-first routing fixture whose
+    # generated schematic has NO ``(wire ...)`` elements, so LVS is
+    # UNAVAILABLE: the copper comparator binds 0 of the 198 board pads and
+    # can detect neither shorts nor opens.  The former copper-only hard
+    # gate here (``write_lvs_report(..., run_label=False)``, #4004)
+    # therefore passed on ZERO evidence -- the vacuity hole found in PR
+    # #4005's review.  The recipe now SKIPS the LVS step (emits NO
+    # ``lvs.json``), and this job asserts the honest state instead of a
+    # zero-evidence ``clean=true``:
     #
-    # This job is a NEW, ADDITIVE gate -- it does NOT replace the
-    # ``diffpair-routing-regression`` job (which keeps its allowlist-based
-    # DRC coverage gate on the ``--step route`` re-route).  Unlike board
-    # 00/01, board 06 carries allowlisted DRC residuals
-    # (.github/routed-drc-tolerance.yml: diffpair_test_routed.kicad_pcb=18)
-    # and routes PARTIAL by design, so its board.json is
-    # ``status:"partial"`` / ``drc_violations>0``.  It therefore CANNOT
-    # assert ``kct check Overall: PASSED`` or ``board.json status:ok`` --
-    # this job uses the asserter's ``--lvs-only`` mode, which checks only
-    # artifact presence + ``lvs.json clean=true`` (+ ``board.json
-    # lvs_clean=true``).
+    # * the vacuity guard fires on the regenerated schematic+PCB pair
+    #   (``check_copper_lvs.py --expect-vacuous``) -- a ``clean=true``
+    #   there would mean the #4006 guard regressed;
+    # * ``lvs.json`` is ABSENT and ``board.json`` omits ``lvs_clean``
+    #   (``check_board_00_e2e.py --lvs-not-run``) -- the gallery renders
+    #   "LVS not run", never a zero-evidence "Ready" LVS chip.
     #
-    # The recipe returns non-zero on PARTIAL routing (expected on this
-    # board), so the regen step tolerates a non-zero recipe exit (``|| true``)
-    # and the LVS-only asserter is the real gate: a copper short/open makes
-    # ``write_lvs_report`` write ``lvs.json clean=false`` (before it raises),
-    # which the asserter catches.  Determinism via ``--seed 42`` +
-    # PYTHONHASHSEED (mirrors the routing-regression jobs).
+    # This job does NOT replace the ``diffpair-routing-regression`` job
+    # (which keeps its allowlist-based DRC coverage gate on the ``--step
+    # route`` re-route).  Board 06 carries allowlisted DRC residuals
+    # (.github/routed-drc-tolerance.yml) and routes PARTIAL by design, so
+    # its recipe may exit non-zero (tolerated) and no ``status:ok``
+    # assertion applies.  If the fixture schematic ever gains real wired
+    # nets, graduate this job back to a true LVS gate (--lvs-only +
+    # a plain check_copper_lvs.py clean assertion).
     #
     # Advisory until a repo admin adds it to branch protection (same as the
     # board 00/01 e2e jobs).
-    name: Board 06 End-to-End (LVS-only)
+    name: Board 06 End-to-End (LVS vacuity)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     container:
@@ -1368,35 +1368,36 @@ jobs:
 
       - name: Regenerate board 06 from recipe (--step all, clean tmp directory)
         # PARTIAL routing is expected on this board (USB3_TX1 blocked by the
-        # BGA partner-via escape, #2677), so the recipe may exit non-zero
-        # even when copper-LVS is clean -- tolerate it (|| true).  The
-        # LVS-only asserter below is the gate: write_lvs_report writes
-        # lvs.json (clean=false before raising) on any copper short/open.
+        # BGA partner-via escape, #2677), so the recipe may exit non-zero --
+        # tolerate it (|| true).  The recipe SKIPS the LVS step (#4006:
+        # unwired fixture schematic, LVS unavailable) so lvs.json must NOT
+        # exist; the asserters below are the gate.
         run: |
           set -uo pipefail
           rm -rf /tmp/board06-ci
           mkdir -p /tmp/board06-ci
           uv run python boards/06-diffpair-test/generate_design.py \
             /tmp/board06-ci --step all --seed 42 || true
-          test -f /tmp/board06-ci/lvs.json
+          test ! -f /tmp/board06-ci/lvs.json
           test -f /tmp/board06-ci/diffpair_test.kicad_sch
           test -f /tmp/board06-ci/diffpair_test_routed.kicad_pcb
 
-      - name: Independent copper-LVS re-check (out-of-process, issue #3840)
+      - name: Copper-LVS vacuity-guard re-check (out-of-process, #4006)
         # Re-run compare_copper_netlist in a process the CI job controls (NOT
-        # the recipe) on the REGENERATED schematic + routed PCB, and assert
-        # clean.  Does NOT read lvs.json, so it catches a copper short/open
-        # even if the recipe mis-wrote lvs.json.  Board 06 routes PARTIAL by
-        # design (recipe exits non-zero, tolerated above), but the persisted
-        # *_routed.kicad_pcb exists regardless, so this re-check still runs and
-        # gates.  Entrypoint from #3838; asserter maps clean->0, dirty->2.
+        # the recipe) on the REGENERATED schematic + routed PCB.  Board 06's
+        # schematic is unwired, so the honest verdict is the vacuity guard's
+        # (clean=false, kind='vacuous'): --expect-vacuous asserts exactly
+        # that.  A clean=true result means the #4006 guard regressed (the
+        # zero-evidence pass this job used to encode); a short/open means the
+        # schematic gained wired nets -- graduate this job to a real clean
+        # assertion.  Entrypoint from #3838.
         run: |
           set -euo pipefail
           uv run python -m kicad_tools.lvs.copper_lvs \
             /tmp/board06-ci/diffpair_test.kicad_sch \
             /tmp/board06-ci/diffpair_test_routed.kicad_pcb \
             > /tmp/board06-copper.json
-          uv run python scripts/ci/check_copper_lvs.py /tmp/board06-copper.json
+          uv run python scripts/ci/check_copper_lvs.py --expect-vacuous /tmp/board06-copper.json
 
       - name: Independent DRC re-check within allowlist (out-of-process, issue #3840)
         # Validate the REGENERATED routed PCB's DRC out-of-process against the
@@ -1423,34 +1424,40 @@ jobs:
           cp -r /tmp/board06-ci/. /tmp/board06-staging/06-diffpair-test/output/
           uv run kct board-metrics /tmp/board06-staging/06-diffpair-test
 
-      - name: Assert artifacts + lvs.json clean (LVS-only)
-        # --lvs-only: assert artifact presence + lvs.json clean=true +
-        # board.json lvs_clean=true, but NOT status:ok / drc_violations:0
-        # (board 06 carries allowlisted DRC residuals -> status='partial').
+      - name: Assert artifacts + honest LVS-not-run state (#4006)
+        # --lvs-not-run: assert lvs.json ABSENT + board.json omits lvs_clean
+        # ("LVS not run" on the gallery -- never a zero-evidence badge), but
+        # NOT status:ok / drc_violations:0 (board 06 carries allowlisted DRC
+        # residuals -> status='partial').
         run: |
           set -euo pipefail
           uv run python scripts/ci/check_board_00_e2e.py \
             --stem diffpair_test \
-            --lvs-only \
+            --lvs-not-run \
             /tmp/board06-staging/06-diffpair-test
 
   board-07-end-to-end:
-    # Issue #3779: LVS-ONLY end-to-end gate for board 07 ("matchgroup-test").
-    # Same shape as the board-06 job: board 07 is a PCB-first routing
-    # fixture (MIPI/TMDS connectors with no schematic-side net) whose
-    # label-LVS is all ``schematic_net=None`` advisory noise.  Its recipe
-    # now runs ``write_lvs_report(..., require_clean=True, run_copper=True,
-    # run_label=False)`` in the ``--step all`` branch, hard-gating on
-    # copper only and emitting ``output/lvs.json``.
+    # Issue #3779 (reworked for #4006): end-to-end gate for board 07
+    # ("matchgroup-test").  Same unwired-fixture situation as board 06:
+    # the generated schematic has no ``(wire ...)`` elements, so the
+    # copper comparator binds 0 pins and LVS is UNAVAILABLE -- the former
+    # copper-only ``clean=true`` here was zero-evidence (PR #4005 review /
+    # #4006; board 07 in fact had 5 real copper opens the vacuous verdict
+    # masked).  Unlike board 06, board 07's recipe still EMITS
+    # ``output/lvs.json`` in ``--step all`` (this job asserts the file
+    # exists); with the #4006 vacuity guard that file now carries the
+    # honest dirty verdict (clean=false, copper_vacuous=true) and
+    # ``kct board-metrics`` treats it as "LVS not run" (omits lvs_clean).
     #
     # NEW, ADDITIVE gate -- does NOT replace the
     # ``matchgroup-routing-regression`` job.  Board 07 carries allowlisted
     # DRC residuals (.github/routed-drc-tolerance.yml:
     # matchgroup_test_routed.kicad_pcb=120) and routes PARTIAL by design,
-    # so it uses the asserter's ``--lvs-only`` mode (no Overall: PASSED /
-    # status:ok / drc_violations:0 assertions).  Advisory until a repo
-    # admin adds it to branch protection.
-    name: Board 07 End-to-End (LVS-only)
+    # so no Overall: PASSED / status:ok / drc_violations:0 assertions
+    # apply.  If the fixture schematic ever gains real wired nets,
+    # graduate this job to --lvs-only + a plain copper-clean assertion.
+    # Advisory until a repo admin adds it to branch protection.
+    name: Board 07 End-to-End (LVS vacuity)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     container:
@@ -1487,7 +1494,10 @@ jobs:
 
       - name: Regenerate board 07 from recipe (--step all, clean tmp directory)
         # PARTIAL routing is expected on this board, so tolerate a non-zero
-        # recipe exit (|| true); the LVS-only asserter is the real gate.
+        # recipe exit (|| true).  The recipe still emits lvs.json; with the
+        # #4006 vacuity guard it carries clean=false / copper_vacuous=true
+        # (the recipe's LVS gate raising on the vacuous verdict is part of
+        # the tolerated non-zero exit).  The asserters below are the gate.
         run: |
           set -uo pipefail
           rm -rf /tmp/board07-ci
@@ -1498,21 +1508,21 @@ jobs:
           test -f /tmp/board07-ci/matchgroup_test.kicad_sch
           test -f /tmp/board07-ci/matchgroup_test_routed.kicad_pcb
 
-      - name: Independent copper-LVS re-check (out-of-process, issue #3840)
+      - name: Copper-LVS vacuity-guard re-check (out-of-process, #4006)
         # Re-run compare_copper_netlist in a process the CI job controls (NOT
-        # the recipe) on the REGENERATED schematic + routed PCB, and assert
-        # clean.  Does NOT read lvs.json, so it catches a copper short/open
-        # even if the recipe mis-wrote lvs.json.  Board 07 routes PARTIAL by
-        # design (recipe exits non-zero, tolerated above), but the persisted
-        # *_routed.kicad_pcb exists regardless, so this re-check still runs and
-        # gates.  Entrypoint from #3838; asserter maps clean->0, dirty->2.
+        # the recipe) on the REGENERATED schematic + routed PCB.  Board 07's
+        # schematic is unwired, so the honest verdict is the vacuity guard's
+        # (clean=false, kind='vacuous'): --expect-vacuous asserts exactly
+        # that.  A clean=true result means the #4006 guard regressed; a
+        # short/open means the schematic gained wired nets -- graduate this
+        # job to a real clean assertion.  Entrypoint from #3838.
         run: |
           set -euo pipefail
           uv run python -m kicad_tools.lvs.copper_lvs \
             /tmp/board07-ci/matchgroup_test.kicad_sch \
             /tmp/board07-ci/matchgroup_test_routed.kicad_pcb \
             > /tmp/board07-copper.json
-          uv run python scripts/ci/check_copper_lvs.py /tmp/board07-copper.json
+          uv run python scripts/ci/check_copper_lvs.py --expect-vacuous /tmp/board07-copper.json
 
       - name: Independent DRC re-check within allowlist (out-of-process, issue #3840)
         # Validate the REGENERATED routed PCB's DRC out-of-process against the
@@ -1538,12 +1548,17 @@ jobs:
           cp -r /tmp/board07-ci/. /tmp/board07-staging/07-matchgroup-test/output/
           uv run kct board-metrics /tmp/board07-staging/07-matchgroup-test
 
-      - name: Assert artifacts + lvs.json clean (LVS-only)
+      - name: Assert artifacts + honest vacuous-LVS state (#4006)
+        # --lvs-vacuous: lvs.json must be present (this recipe still emits
+        # it) and must carry the vacuity-guard verdict (clean=false,
+        # copper_vacuous=true); board.json must OMIT lvs_clean ("LVS not
+        # run" on the gallery).  No status/drc_violations assertions
+        # (allowlisted DRC residuals -> status='partial').
         run: |
           set -euo pipefail
           uv run python scripts/ci/check_board_00_e2e.py \
             --stem matchgroup_test \
-            --lvs-only \
+            --lvs-vacuous \
             /tmp/board07-staging/07-matchgroup-test
 
   board-05-routing-regression:

--- a/boards/06-diffpair-test/generate_design.py
+++ b/boards/06-diffpair-test/generate_design.py
@@ -39,7 +39,6 @@ from pathlib import Path
 
 from kicad_tools.core.project_file import create_minimal_project, save_project
 from kicad_tools.dev import warn_if_stale
-from kicad_tools.lvs import write_lvs_report
 from kicad_tools.router.rules import NET_CLASS_HIGH_SPEED, NET_CLASS_POWER, NetClassRouting
 
 # Re-export net definitions and footprint generators from generate_pcb.
@@ -3403,24 +3402,35 @@ def main() -> int:
             route_success = route_pcb(pcb_path, routed_path)
             drc_ok = run_drc(routed_path)
 
-            # LVS (#3779) -- copper-only hard gate.  Board 06 is a PCB-first
-            # routing fixture (USB3 connectors with no schematic-side net), so
-            # the label comparator reports every pad as ``schematic_net=None``
-            # (advisory noise, not a real defect).  The copper-extracted
-            # comparator correctly ignores ``None``-net pads, so we gate on
-            # copper only (``run_label=False``): a copper short/open raises
-            # ``BoardNetlistMismatch`` and fails the recipe.  Writes
-            # ``output/lvs.json`` so ``kct board-metrics`` surfaces
-            # ``lvs_clean: true``.  This step only runs in ``--step all``
-            # (the ``--step route`` CI branch has no schematic).
-            copper_clean, _label_clean = write_lvs_report(
-                sch_path,
-                routed_path,
-                output_dir,
-                require_clean=True,
-                run_copper=True,
-                run_label=False,
+            # LVS: SKIPPED -- schematic not wired, LVS unavailable (#4005
+            # review).  Board 06 is a PCB-first routing fixture whose
+            # schematic has no ``(wire ...)`` elements, so every schematic
+            # pin is floating: the copper comparator binds 0 of the board's
+            # 198 pads and can detect neither shorts nor opens.  The
+            # copper-only hard gate #4004 added here
+            # (``write_lvs_report(..., require_clean=True, run_label=False)``)
+            # therefore passed on ZERO evidence -- and with the vacuity
+            # guard it now (correctly) raises instead.  Rather than weaken
+            # the guard, this recipe skips the LVS step and emits NO
+            # ``lvs.json``: ``kct board-metrics`` omits ``lvs_clean`` and
+            # the gallery honestly shows "LVS not run".  Re-enable
+            # ``write_lvs_report`` here if/when the fixture schematic gets
+            # wired nets.
+            print("\n" + "=" * 60)
+            print("LVS: SKIPPED -- schematic not wired, LVS unavailable")
+            print("=" * 60)
+            print(
+                "   Board 06's fixture schematic binds 0 pins (no wires/"
+                "labels), so copper-LVS would be vacuous (#4005 review).\n"
+                "   No lvs.json is emitted; board-metrics reports 'LVS not "
+                "run'."
             )
+            # Drop any stale lvs.json from an earlier recipe version so the
+            # gallery cannot keep rendering a zero-evidence LVS badge.
+            stale_lvs = output_dir / "lvs.json"
+            if stale_lvs.exists():
+                stale_lvs.unlink()
+                print(f"   Removed stale {stale_lvs} (vacuous artifact).")
 
             # Export manufacturing bundle (#3147) so ``kct fleet status``
             # reports ``ship_ready=true`` (the bundle's manifest mtime must

--- a/boards/06-diffpair-test/output/lvs.json
+++ b/boards/06-diffpair-test/output/lvs.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://kicad-tools.org/schemas/lvs/v1.json",
-  "clean": true,
-  "mismatches": [],
-  "copper_mismatches": []
-}

--- a/boards/07-matchgroup-test/generate_design.py
+++ b/boards/07-matchgroup-test/generate_design.py
@@ -2023,38 +2023,44 @@ def main() -> int:
             route_success = route_pcb(pcb_path, routed_path)
             drc_ok = run_drc(routed_path)
 
-            # LVS (#3779) -- copper-only, and currently VACUOUS on this
-            # board (issue #4006).  The generated schematic is a PCB-first
+            # LVS (#3779) -- copper-only, and VACUOUS on this board
+            # (issue #4006).  The generated schematic is a PCB-first
             # fixture with ZERO ``(wire ...)`` elements (floating labels
             # only), so ``_schematic_pin_to_net`` binds 0 of ~223 pins --
             # ALL nets, DDR included, not just the MIPI/TMDS connectors.
             # With an empty pad->net map the copper comparator has no
             # evidence and can detect neither opens nor shorts, so the
-            # ``clean: true`` it reports is a zero-comparison result, not a
-            # verification (this board's 5 unrouted nets are real copper
-            # opens it cannot see).  The write stays because the
-            # board-07-end-to-end CI job regenerates into a tmp dir and
-            # asserts ``lvs.json`` exists there, but ``output/lvs.json``
-            # must NOT be committed: ``kct board-metrics`` + the site
-            # gallery key the "Ready" badge off ``lvs_clean`` (#3749), and
-            # a missing file renders the honest "LVS not run" chip.  See
-            # #4006 for the vacuity guard (gate ``clean`` on a nonzero
-            # bound-pin count).  This step only runs in ``--step all`` (the
+            # #4006 vacuity guard now reports ``clean=false`` with a
+            # synthetic ``vacuous`` mismatch instead of the old
+            # zero-comparison ``clean: true`` (which masked this board's
+            # real copper opens).  ``require_clean=False`` (advisory)
+            # because the vacuous verdict is EXPECTED here: a hard gate
+            # would abort the recipe before the manufacturing-bundle
+            # export.  The write stays because the board-07-end-to-end CI
+            # job regenerates into a tmp dir, asserts ``lvs.json`` exists
+            # there, and gates on the vacuity-guard verdict
+            # (``check_board_00_e2e.py --lvs-vacuous`` +
+            # ``check_copper_lvs.py --expect-vacuous``); ``output/lvs.json``
+            # must NOT be committed: ``kct board-metrics`` treats a vacuous
+            # report as "LVS not run" (#3749/#4006) and the site renders
+            # the honest chip.  This step only runs in ``--step all`` (the
             # ``--step route`` CI branch has no schematic).
             copper_clean, _label_clean = write_lvs_report(
                 sch_path,
                 routed_path,
                 output_dir,
-                require_clean=True,
+                require_clean=False,
                 run_copper=True,
                 run_label=False,
             )
-            print(
-                "[lvs] WARNING: copper-LVS is VACUOUS on this fixture "
-                "(schematic has no wires, so 0 pins bind to nets; issue "
-                "#4006).  lvs.json is written for the CI e2e tmp gate "
-                "only -- never commit output/lvs.json."
-            )
+            if not copper_clean:
+                print(
+                    "[lvs] WARNING: copper-LVS is VACUOUS on this fixture "
+                    "(schematic has no wires, so 0 pins bind to nets; issue "
+                    "#4006) -- lvs.json carries clean=false/copper_vacuous. "
+                    "It is written for the CI e2e tmp gate only -- never "
+                    "commit output/lvs.json."
+                )
 
             # Export manufacturing bundle (#3147) so ``kct fleet status``
             # reports ``ship_ready=true`` (the bundle's manifest mtime must

--- a/scripts/ci/check_board_00_e2e.py
+++ b/scripts/ci/check_board_00_e2e.py
@@ -21,14 +21,31 @@ board directory it:
 
 ``--lvs-only`` mode (issue #3779) restricts the gate to artifact presence
 + ``lvs.json clean: true`` and **skips** the ``board.json``
-``status``/``drc_violations`` assertions.  This is for boards 06/07
-(diffpair-test, matchgroup-test): they are copper-LVS clean (so the LVS
-gate applies) but carry **allowlisted DRC residuals** in
-``.github/routed-drc-tolerance.yml`` and route PARTIAL by design, so their
-``board.json`` is ``status: "partial"`` / ``drc_violations > 0`` and the
-full ``status: ok`` / ``drc_violations: 0`` assertion would (incorrectly)
+``status``/``drc_violations`` assertions.  This is for boards with
+**allowlisted DRC residuals** in ``.github/routed-drc-tolerance.yml``
+that route PARTIAL by design, so their ``board.json`` is
+``status: "partial"`` / ``drc_violations > 0`` and the full
+``status: ok`` / ``drc_violations: 0`` assertion would (incorrectly)
 fail.  ``board.json[lvs_clean]`` is still asserted when ``board.json`` is
 present, since copper-LVS clean is the whole point of those jobs.
+
+``--lvs-not-run`` mode (#4006, board 06): for PCB-first fixture boards
+whose schematic is deliberately unwired, LVS is *unavailable* — the
+copper comparator binds zero pins and any verdict would be zero-evidence
+(the vacuity hole found in PR #4005's review).  Board 06's recipe skips
+the LVS step entirely, so this mode asserts the honest state: all
+artifacts EXCEPT ``lvs.json`` present, ``lvs.json`` ABSENT, and
+``board.json`` carrying NO ``lvs_clean`` key (the site then renders
+"LVS not run" instead of a zero-evidence "Ready" badge).
+
+``--lvs-vacuous`` mode (#4006, board 07): same unwired-fixture situation,
+but for a recipe that still *emits* ``lvs.json`` (its CI job asserts the
+file exists).  Asserts ``lvs.json`` is present and carries the
+vacuity-guard verdict (``clean: false`` + ``copper_vacuous: true``), and
+that ``board.json`` does NOT claim ``lvs_clean`` (board-metrics treats a
+vacuous report as LVS-not-run).  A ``clean: true`` here means the guard
+regressed; a non-vacuous dirty result means the schematic gained wired
+nets and the job should graduate to ``--lvs-only``.
 
 and exits non-zero with a ``::error::``-annotated message on any mismatch
 so the failure surfaces inline on the GitHub PR Files-changed view.
@@ -152,6 +169,43 @@ def assert_lvs_clean(lvs_path: Path) -> str | None:
             f"lvs.json reports clean=False with {len(mismatches)} mismatch(es); "
             f"first: {mismatches[0] if mismatches else '<none>'}"
         )
+    if data.get("copper_vacuous") is True or data.get("copper_bound_pad_count") == 0:
+        # Belt-and-braces (#4006): a clean=true report claiming zero bound
+        # pins is exactly the zero-evidence artifact the vacuity guard
+        # forbids; never accept it as clean.
+        return (
+            "lvs.json reports clean=true but is VACUOUS "
+            "(copper_vacuous/copper_bound_pad_count=0, #4006) -- zero-evidence "
+            "clean is not clean"
+        )
+    return None
+
+
+def assert_lvs_vacuous(lvs_path: Path) -> str | None:
+    """Assert ``lvs.json`` carries the vacuity-guard verdict (#4006).
+
+    Expected shape for an unwired fixture schematic:
+    ``clean: false`` AND ``copper_vacuous: true``.
+
+    Returns ``None`` on pass, or a human-readable error message on fail.
+    """
+    try:
+        data = json.loads(lvs_path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        return f"could not read/parse {lvs_path}: {e}"
+    if data.get("clean"):
+        return (
+            "expected a VACUOUS lvs.json (clean=false, copper_vacuous=true, "
+            "#4006) but it reports clean=true -- either the vacuity guard "
+            "regressed or the schematic is now wired (graduate this job to "
+            "--lvs-only)"
+        )
+    if data.get("copper_vacuous") is not True:
+        return (
+            "expected a VACUOUS lvs.json (copper_vacuous=true, #4006) but got "
+            "a non-vacuous dirty report -- the schematic appears to bind pins "
+            "now; graduate this job to --lvs-only and fix the real mismatches"
+        )
     return None
 
 
@@ -206,15 +260,37 @@ def main(argv: list[str] | None = None) -> int:
             "for board 01)."
         ),
     )
-    parser.add_argument(
+    mode_group = parser.add_mutually_exclusive_group()
+    mode_group.add_argument(
         "--lvs-only",
         action="store_true",
         help=(
             "Restrict the gate to artifact presence + lvs.json clean=true "
             "(plus board.json lvs_clean=true when present), and SKIP the "
             "board.json status=ok / drc_violations=0 assertions.  Use for "
-            "boards 06/07 (diffpair-test, matchgroup-test): copper-LVS clean "
-            "but carrying allowlisted DRC residuals (status='partial')."
+            "boards with genuinely wired schematics that carry allowlisted "
+            "DRC residuals (status='partial')."
+        ),
+    )
+    mode_group.add_argument(
+        "--lvs-not-run",
+        action="store_true",
+        help=(
+            "Honest-state gate for an unwired fixture schematic whose recipe "
+            "SKIPS the LVS step (#4006, board 06): assert lvs.json is ABSENT "
+            "and board.json carries NO lvs_clean key ('LVS not run'), and "
+            "SKIP the status/drc_violations assertions."
+        ),
+    )
+    mode_group.add_argument(
+        "--lvs-vacuous",
+        action="store_true",
+        help=(
+            "Honest-state gate for an unwired fixture schematic whose recipe "
+            "still EMITS lvs.json (#4006, board 07): assert lvs.json is "
+            "present with the vacuity-guard verdict (clean=false, "
+            "copper_vacuous=true) and board.json carries NO lvs_clean key, "
+            "and SKIP the status/drc_violations assertions."
         ),
     )
     args = parser.parse_args(argv)
@@ -230,6 +306,10 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     artifacts = required_artifacts(args.stem)
+    if args.lvs_not_run:
+        # The recipe deliberately emits NO lvs.json (#4006); its absence is
+        # asserted below instead of its presence here.
+        artifacts = tuple(a for a in artifacts if a != "lvs.json")
     failed = False
 
     # 1. Artifact presence ----------------------------------------------------
@@ -241,9 +321,30 @@ def main(argv: list[str] | None = None) -> int:
     else:
         print(f"[ok] all {len(artifacts)} required artifacts present")
 
-    # 2. LVS clean ------------------------------------------------------------
+    # 2. LVS verdict -----------------------------------------------------------
     lvs_path = output_dir / "lvs.json"
-    if lvs_path.is_file():
+    if args.lvs_not_run:
+        if lvs_path.is_file():
+            _err(
+                "lvs.json must be ABSENT in --lvs-not-run mode (#4006): this "
+                "board's schematic is unwired, so any emitted LVS verdict is "
+                "zero-evidence.  If the schematic is now wired, graduate this "
+                "job to --lvs-only.",
+                file=lvs_path,
+            )
+            failed = True
+        else:
+            print("[ok] lvs.json absent (LVS not run -- unwired fixture schematic)")
+    elif args.lvs_vacuous:
+        if lvs_path.is_file():
+            lvs_err = assert_lvs_vacuous(lvs_path)
+            if lvs_err is not None:
+                _err(lvs_err, file=lvs_path)
+                failed = True
+            else:
+                print("[ok] lvs.json carries the vacuity-guard verdict (#4006)")
+        # (missing lvs.json was already reported above)
+    elif lvs_path.is_file():
         lvs_err = assert_lvs_clean(lvs_path)
         if lvs_err is not None:
             _err(lvs_err, file=lvs_path)
@@ -253,22 +354,45 @@ def main(argv: list[str] | None = None) -> int:
     # (missing lvs.json was already reported above)
 
     # 3. board.json fields ----------------------------------------------------
-    # In --lvs-only mode assert only lvs_clean (boards 06/07 carry allowlisted
-    # DRC residuals -> status='partial' / drc_violations>0, which the full
-    # field set would incorrectly reject).
-    required_fields = LVS_ONLY_BOARD_JSON_FIELDS if args.lvs_only else REQUIRED_BOARD_JSON_FIELDS
+    # In --lvs-only mode assert only lvs_clean (allowlisted-DRC boards are
+    # status='partial' / drc_violations>0, which the full field set would
+    # incorrectly reject).  In the unwired-fixture modes (#4006) assert
+    # lvs_clean is ABSENT: board-metrics omits it when LVS was not run / the
+    # report is vacuous, and its presence would mean a zero-evidence badge.
     board_json_path = output_dir / "board.json"
-    if board_json_path.is_file():
-        field_errors = assert_board_json_fields(board_json_path, required_fields)
-        if field_errors:
-            for msg in field_errors:
-                _err(msg, file=board_json_path)
-            failed = True
-        else:
-            print(
-                "[ok] board.json fields: "
-                + ", ".join(f"{k}={v!r}" for k, v in required_fields.items())
-            )
+    if args.lvs_not_run or args.lvs_vacuous:
+        if board_json_path.is_file():
+            try:
+                board_data = json.loads(board_json_path.read_text())
+            except (OSError, json.JSONDecodeError) as e:
+                _err(f"could not read/parse {board_json_path}: {e}")
+                failed = True
+            else:
+                if "lvs_clean" in board_data:
+                    _err(
+                        "board.json must NOT carry lvs_clean for an unwired "
+                        f"fixture board (#4006); got lvs_clean="
+                        f"{board_data['lvs_clean']!r}",
+                        file=board_json_path,
+                    )
+                    failed = True
+                else:
+                    print("[ok] board.json omits lvs_clean ('LVS not run')")
+    else:
+        required_fields = (
+            LVS_ONLY_BOARD_JSON_FIELDS if args.lvs_only else REQUIRED_BOARD_JSON_FIELDS
+        )
+        if board_json_path.is_file():
+            field_errors = assert_board_json_fields(board_json_path, required_fields)
+            if field_errors:
+                for msg in field_errors:
+                    _err(msg, file=board_json_path)
+                failed = True
+            else:
+                print(
+                    "[ok] board.json fields: "
+                    + ", ".join(f"{k}={v!r}" for k, v in required_fields.items())
+                )
 
     return 2 if failed else 0
 

--- a/scripts/ci/check_copper_lvs.py
+++ b/scripts/ci/check_copper_lvs.py
@@ -115,6 +115,46 @@ def assert_clean(payload: dict[str, Any]) -> str | None:
     return f"copper-LVS reports clean=false with {_summarize_mismatches(mismatches)}"
 
 
+def assert_vacuous(payload: dict[str, Any]) -> str | None:
+    """Assert a copper-LVS payload is the *vacuity-guard* verdict (#4005).
+
+    Used for boards whose fixture schematic is deliberately unwired (board
+    06): the honest expectation is that the comparator binds zero pins and
+    reports ``clean: false`` with exactly the synthetic ``kind="vacuous"``
+    mismatch — no shorts/opens are detectable, and a ``clean: true`` here
+    would mean the vacuity guard regressed (the zero-evidence pass this
+    gate exists to prevent).  A short/open or a genuinely clean result also
+    fails: either means the schematic gained wired nets and the CI job must
+    be upgraded to a real ``clean`` assertion.
+
+    Returns:
+        ``None`` on pass (vacuous verdict as expected).  A human-readable
+        error message otherwise (caller maps to exit 2).
+
+    Raises:
+        KeyError: If ``clean`` is absent (caller maps to exit 1).
+    """
+    clean = payload["clean"]
+    mismatches = payload.get("mismatches", [])
+    if not isinstance(mismatches, list):
+        mismatches = []
+    kinds = sorted({m.get("kind") for m in mismatches if isinstance(m, dict)})
+    if clean:
+        return (
+            "expected a VACUOUS copper-LVS verdict (clean=false, kind='vacuous') "
+            "but got clean=true -- either the vacuity guard regressed, or the "
+            "schematic is now wired and this CI gate should assert clean instead"
+        )
+    if kinds != ["vacuous"]:
+        return (
+            "expected a VACUOUS copper-LVS verdict (only kind='vacuous') but got "
+            f"mismatch kinds {kinds}: {_summarize_mismatches(mismatches)} -- the "
+            "schematic appears to bind pins now; upgrade this CI gate to a real "
+            "clean assertion"
+        )
+    return None
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="check_copper_lvs.py",
@@ -130,6 +170,17 @@ def main(argv: list[str] | None = None) -> int:
         help=(
             "Path to the JSON file emitted by python -m kicad_tools.lvs.copper_lvs "
             "(use '-' or '/dev/stdin' to read from stdin)."
+        ),
+    )
+    parser.add_argument(
+        "--expect-vacuous",
+        action="store_true",
+        help=(
+            "Invert the contract for deliberately-unwired fixture schematics "
+            "(board 06): assert the result is the vacuity-guard verdict "
+            "(clean=false with only kind='vacuous' mismatches, #4005 review). "
+            "Fails on clean=true (guard regression) AND on real shorts/opens "
+            "(schematic gained nets; upgrade the gate)."
         ),
     )
     args = parser.parse_args(argv)
@@ -161,7 +212,10 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     try:
-        dirty_msg = assert_clean(payload)
+        if args.expect_vacuous:
+            dirty_msg = assert_vacuous(payload)
+        else:
+            dirty_msg = assert_clean(payload)
     except KeyError:
         _err(f"copper-LVS JSON from {display} missing required 'clean' key: {payload!r}")
         return 1
@@ -176,7 +230,13 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 2
 
-    print("[ok] copper-LVS clean (independent out-of-process re-check)")
+    if args.expect_vacuous:
+        print(
+            "[ok] copper-LVS vacuity guard fired as expected "
+            "(clean=false, kind='vacuous'; unwired fixture schematic)"
+        )
+    else:
+        print("[ok] copper-LVS clean (independent out-of-process re-check)")
     return 0
 
 

--- a/src/kicad_tools/cli/board_metrics_cmd.py
+++ b/src/kicad_tools/cli/board_metrics_cmd.py
@@ -220,6 +220,12 @@ def _parse_lvs(lvs_path: Path, slug: str) -> dict:
     present and readable; returns ``{}`` when the file is absent or unparseable
     so the keys are *omitted* from the emitted ``board.json`` rather than set
     to ``null`` (the board.json contract: missing artifact → field omitted).
+
+    A *vacuous* report (#4006: ``copper_vacuous: true`` or
+    ``copper_bound_pad_count: 0`` — the schematic bound zero pins, so the
+    comparator observed nothing) is also treated as "LVS not run" (``{}``):
+    rendering it as either "clean" or "dirty" would claim evidence that does
+    not exist.
     """
     if not lvs_path.is_file():
         return {}
@@ -227,6 +233,13 @@ def _parse_lvs(lvs_path: Path, slug: str) -> dict:
         data = json.loads(lvs_path.read_text())
     except (OSError, json.JSONDecodeError) as exc:
         logger.warning("board %s: could not read lvs.json (%s)", slug, exc)
+        return {}
+    if data.get("copper_vacuous") is True or data.get("copper_bound_pad_count") == 0:
+        logger.info(
+            "board %s: lvs.json is vacuous (0 schematic pins bound, #4006); "
+            "treating as LVS-not-run",
+            slug,
+        )
         return {}
     return {
         "lvs_clean": bool(data.get("clean", False)),

--- a/src/kicad_tools/lvs/__init__.py
+++ b/src/kicad_tools/lvs/__init__.py
@@ -46,6 +46,8 @@ from kicad_tools.lvs.board_lvs import (
     compare_netlists,
 )
 from kicad_tools.lvs.copper_lvs import (
+    VACUOUS_KIND,
+    VACUOUS_NET,
     CopperLVSMismatch,
     CopperLVSResult,
     compare_copper_netlist,
@@ -65,6 +67,8 @@ __all__ = [
     "FreshCopperCheckError",
     "LVSMismatch",
     "LVSResult",
+    "VACUOUS_KIND",
+    "VACUOUS_NET",
     "_ref_of",
     "compare_copper_netlist",
     "compare_netlists",

--- a/src/kicad_tools/lvs/copper_lvs.py
+++ b/src/kicad_tools/lvs/copper_lvs.py
@@ -24,6 +24,22 @@ Pads present on only one side (schematic-only or PCB-only) are ignored
 for the partition diff — that asymmetry is the label-based comparator's
 job (:func:`board_lvs.compare_netlists`), and the two checks are meant
 to run side by side.
+
+Vacuity guard (#4005 review): when the schematic binds **zero** pads —
+every pin floats (a PCB-first fixture schematic with no ``(wire ...)``
+elements) or no schematic pin matches a board pad — the partition diff
+can detect neither shorts nor opens, so an empty mismatch list is *no
+evidence*, not a pass.  The comparator refuses to report ``clean=True``
+in that case: it emits a single synthetic mismatch of
+``kind="vacuous"`` (see :data:`VACUOUS_KIND`), making the result dirty.
+
+The contract is deliberately the simplest defensible one: **vacuous iff
+zero bound pads**.  A percentage floor (e.g. "<50% of pads bindable")
+was considered and rejected: any bound pad contributes real, falsifiable
+evidence for the nets it touches, and legitimate boards mix wired power
+nets with PCB-only connector fixtures — a ratio threshold would need an
+arbitrary constant and misfire on those.  Zero bound pads is the unique
+case where the comparator can observe literally nothing.
 """
 
 from __future__ import annotations
@@ -33,18 +49,34 @@ from pathlib import Path
 
 from kicad_tools.lvs.board_lvs import _schematic_pin_to_net
 
+# Mismatch ``kind`` emitted by the vacuity guard (#4005 review): the
+# schematic bound zero pads, so the comparator has no evidence and must
+# not report clean.  Additive to the v1 lvs.json schema (a new enum value
+# inside the existing ``copper_mismatches[].kind`` field).
+VACUOUS_KIND = "vacuous"
+
+# Sentinel "net name" carried by the synthetic vacuity mismatch.  Angle
+# brackets keep it out of the legal KiCad net-name space.
+VACUOUS_NET = "<no-schematic-evidence>"
+
 
 @dataclass(frozen=True)
 class CopperLVSMismatch:
     """A single copper-vs-schematic partition disagreement.
 
     Attributes:
-        kind: ``"short"`` (different schematic nets fused in copper) or
-            ``"open"`` (same schematic net split across copper islands).
+        kind: ``"short"`` (different schematic nets fused in copper),
+            ``"open"`` (same schematic net split across copper islands),
+            or ``"vacuous"`` (the schematic bound zero pads, so the
+            comparator has no evidence either way — synthetic guard
+            entry, see :data:`VACUOUS_KIND`).
         net_a / net_b: The schematic net names involved.  For a short
-            these differ; for an open they are equal.
+            these differ; for an open they are equal; for a vacuous
+            entry both are :data:`VACUOUS_NET`.
         pad_a / pad_b: The two offending pads (``"REF.PAD"`` form) that
-            witness the mismatch.
+            witness the mismatch.  For a vacuous entry these carry the
+            evidence counters (``"bound_pads=0"`` / ``"board_pads=N"``)
+            instead of pad ids.
     """
 
     kind: str
@@ -60,10 +92,17 @@ class CopperLVSResult:
 
     ``clean`` is ``True`` iff ``mismatches`` is empty.  ``shorts`` and
     ``opens`` partition the mismatches by kind for convenient reporting.
+
+    ``bound_pad_count`` records how many board pads carried a real
+    (non-``None``) schematic net — the amount of evidence the diff was
+    computed from.  ``None`` means the count was not recorded (results
+    hand-built by older callers/tests); results produced by
+    :func:`compare_partitions` always set it.
     """
 
     clean: bool
     mismatches: tuple[CopperLVSMismatch, ...]
+    bound_pad_count: int | None = None
 
     @property
     def shorts(self) -> tuple[CopperLVSMismatch, ...]:
@@ -72,6 +111,17 @@ class CopperLVSResult:
     @property
     def opens(self) -> tuple[CopperLVSMismatch, ...]:
         return tuple(m for m in self.mismatches if m.kind == "open")
+
+    @property
+    def vacuous(self) -> bool:
+        """True when this result is the vacuity-guard verdict (#4005 review).
+
+        A vacuous result means the schematic bound zero pads, so the
+        comparator observed nothing — ``clean`` is forced ``False`` and
+        the sole mismatch has ``kind="vacuous"``.  Derived from the
+        mismatch list (not stored) so JSON round-trips preserve it.
+        """
+        return any(m.kind == VACUOUS_KIND for m in self.mismatches)
 
 
 def compare_partitions(
@@ -106,6 +156,12 @@ def compare_partitions(
         net pair (the lexicographically smallest pad witnesses are used);
         an open is reported once per pair of same-net copper islands, except
         for nets in ``advisory_net_names`` (opens suppressed).
+
+        **Vacuity guard (#4005 review):** if zero pads end up bound (no
+        schematic pin carries a real net AND matches a board pad), the
+        diff has no evidence and the result is NOT clean — it carries a
+        single synthetic ``kind="vacuous"`` mismatch and
+        ``bound_pad_count=0`` instead of a vacuous ``clean=True``.
     """
     # Build {pad_id -> schematic_net} restricted to pads that (a) have a
     # real schematic net and (b) actually appear on the board, so the diff
@@ -122,6 +178,22 @@ def compare_partitions(
         pad_id = f"{ref}.{pad}"
         if pad_id in on_board:
             pad_net[pad_id] = net
+
+    # --- Vacuity guard (#4005 review): zero bound pads means the diff
+    #     below can detect neither shorts nor opens, so an empty mismatch
+    #     list would be zero-evidence, not a pass.  Refuse to report clean:
+    #     emit one synthetic ``vacuous`` mismatch so ``clean`` is False and
+    #     every downstream consumer (recipe gate, lvs.json, CI asserters,
+    #     JSON round-trip) sees a dirty result. ---
+    if not pad_net:
+        vacuity = CopperLVSMismatch(
+            kind=VACUOUS_KIND,
+            net_a=VACUOUS_NET,
+            net_b=VACUOUS_NET,
+            pad_a="bound_pads=0",
+            pad_b=f"board_pads={len(on_board)}",
+        )
+        return CopperLVSResult(clean=False, mismatches=(vacuity,), bound_pad_count=0)
 
     # Map each pad to its copper-component index.
     comp_of_pad: dict[str, int] = {}
@@ -196,7 +268,11 @@ def compare_partitions(
                 )
             )
 
-    return CopperLVSResult(clean=not mismatches, mismatches=tuple(mismatches))
+    return CopperLVSResult(
+        clean=not mismatches,
+        mismatches=tuple(mismatches),
+        bound_pad_count=len(pad_net),
+    )
 
 
 def compare_copper_netlist(sch_path: str | Path, pcb_path: str | Path) -> CopperLVSResult:
@@ -254,6 +330,10 @@ def result_to_json(result: CopperLVSResult) -> dict:
     """
     return {
         "clean": result.clean,
+        # Additive evidence field (#4005 review): how many board pads carried
+        # a real schematic net.  ``null`` when the producing result predates
+        # the vacuity guard / was hand-built without a count.
+        "bound_pad_count": result.bound_pad_count,
         "mismatches": [
             {
                 "kind": m.kind,
@@ -279,7 +359,12 @@ def result_from_json(payload: dict) -> CopperLVSResult:
         )
         for m in payload.get("mismatches", ())
     )
-    return CopperLVSResult(clean=bool(payload["clean"]), mismatches=mismatches)
+    bound = payload.get("bound_pad_count")
+    return CopperLVSResult(
+        clean=bool(payload["clean"]),
+        mismatches=mismatches,
+        bound_pad_count=int(bound) if bound is not None else None,
+    )
 
 
 def _main(argv: list[str] | None = None) -> int:

--- a/src/kicad_tools/lvs/recipe.py
+++ b/src/kicad_tools/lvs/recipe.py
@@ -23,9 +23,19 @@ payload but does not flip ``clean`` or trigger a raise.
 Gate policy is per-board (see the curator matrix on #3762):
 
 * Boards verified clean (00, 01, 02) gate on both comparators.
-* Boards 06/07 are copper-clean but label-dirty (PCB-first test fixtures
-  whose floating schematic pins read ``schematic_net=None``); they gate on
-  copper only (``run_label=False``).
+* Boards 06/07 are label-dirty (PCB-first test fixtures whose floating
+  schematic pins read ``schematic_net=None``); they gate on copper only
+  (``run_label=False``).  **Vacuity caveat (#4005 review):** on a fully
+  *wireless* fixture schematic the copper comparator binds zero pins, so
+  its historical ``clean=True`` was zero-evidence.  The comparator now
+  returns a dirty ``vacuous`` result in that case, which means a
+  copper-only gate (``run_label=False``) on a wireless schematic FAILS
+  instead of passing vacuously — such boards must either wire their
+  schematic or skip the LVS step explicitly (emit no ``lvs.json``; the
+  gallery then honestly shows "LVS not run").  Note the label comparator
+  has no symmetric hole: on a wireless schematic every netted PCB pad
+  mismatches ``schematic_net=None``, so label-LVS reads *dirty*, never
+  vacuously clean.
 * Boards in :data:`ADVISORY_LVS_BOARDS` (04/05) are genuinely dirty on a
   fresh clean-room regen; they still run LVS and emit ``lvs.json`` so the
   gallery chip and ``board-metrics`` surface the true state, but pass
@@ -214,7 +224,10 @@ def write_lvs_report(
         require_clean: When ``True`` (hard gate), raise
             :class:`BoardNetlistMismatch` if any *gated* comparator is dirty.
             When ``False`` (advisory), log the mismatch summary and return
-            the dirty flags without raising.
+            the dirty flags without raising.  A *vacuous* copper result
+            (schematic binds zero pins, #4005 review) counts as dirty:
+            gating copper-only on a wireless schematic raises rather than
+            passing on zero evidence.
         run_copper: When ``True``, run the copper-extracted comparator and
             include it in the gated ``clean`` decision.
         run_label: When ``True``, run the label-based comparator and include
@@ -302,6 +315,9 @@ def _build_payload(
     historical board-00 schema so ``_parse_lvs`` and the e2e asserter keep
     working).  ``copper_mismatches`` is an additive field recording the
     copper-extracted shorts/opens so a copper-dirty board is reflected too.
+    ``copper_vacuous`` / ``copper_bound_pad_count`` (additive, #4005
+    review) record whether the copper verdict carried any schematic
+    evidence; a vacuous copper leg forces ``clean=false``.
     """
     payload: dict = {
         "$schema": _LVS_SCHEMA_URL,
@@ -326,6 +342,9 @@ def _build_payload(
             for cm in (copper_result.mismatches if copper_result is not None else ())
         ],
     }
+    if copper_result is not None:
+        payload["copper_vacuous"] = copper_result.vacuous
+        payload["copper_bound_pad_count"] = copper_result.bound_pad_count
     return payload
 
 
@@ -364,8 +383,17 @@ def _print_summary(
                 )
 
     if run_copper and copper_result is not None:
-        if copper_result.clean:
-            print("   copper-LVS PASS: 0 shorts / 0 opens")
+        if copper_result.vacuous:
+            print(
+                "   copper-LVS VACUOUS (treated as FAIL): schematic binds 0 pins "
+                "-- no shorts/opens are detectable, so 'clean' would be "
+                "zero-evidence (#4005 review).  Wire the schematic or skip the "
+                "LVS step explicitly."
+            )
+        elif copper_result.clean:
+            bound = copper_result.bound_pad_count
+            evidence = f" ({bound} bound pad(s))" if bound is not None else ""
+            print(f"   copper-LVS PASS: 0 shorts / 0 opens{evidence}")
         else:
             print(
                 f"   copper-LVS FAIL: {len(copper_result.shorts)} short(s) / "

--- a/tests/test_board_metrics.py
+++ b/tests/test_board_metrics.py
@@ -418,6 +418,53 @@ def test_lvs_dirty_downgrades_status_to_partial(tmp_path: Path):
     assert m["status"] == "partial"
 
 
+def test_vacuous_lvs_json_treated_as_lvs_not_run(tmp_path: Path):
+    # A vacuous lvs.json (#4006: schematic bound zero pins, copper_vacuous
+    # true) carries NO evidence either way -- both LVS fields are OMITTED
+    # ("LVS not run" on the site) and status is not downgraded.
+    board = _make_board(
+        tmp_path,
+        lvs={
+            "$schema": "https://kicad-tools.org/schemas/lvs/v1.json",
+            "clean": False,
+            "mismatches": [],
+            "copper_mismatches": [
+                {
+                    "kind": "vacuous",
+                    "net_a": "<no-schematic-evidence>",
+                    "net_b": "<no-schematic-evidence>",
+                    "pad_a": "bound_pads=0",
+                    "pad_b": "board_pads=198",
+                }
+            ],
+            "copper_vacuous": True,
+            "copper_bound_pad_count": 0,
+        },
+    )
+    m = extract_board_metrics(board)
+    assert "lvs_clean" not in m
+    assert "lvs_mismatches" not in m
+    assert m["status"] == "ok"
+
+
+def test_legacy_vacuous_clean_true_lvs_json_not_rendered_clean(tmp_path: Path):
+    # Defense-in-depth (#4006): a pre-guard artifact claiming clean=true
+    # while self-identifying zero bound pads must NOT surface lvs_clean=true.
+    board = _make_board(
+        tmp_path,
+        lvs={
+            "$schema": "https://kicad-tools.org/schemas/lvs/v1.json",
+            "clean": True,
+            "mismatches": [],
+            "copper_mismatches": [],
+            "copper_bound_pad_count": 0,
+        },
+    )
+    m = extract_board_metrics(board)
+    assert "lvs_clean" not in m
+    assert "lvs_mismatches" not in m
+
+
 def test_lvs_fields_omitted_when_lvs_json_absent(tmp_path: Path):
     # No lvs.json on disk -> both LVS fields are OMITTED (never null), and
     # status follows the existing DRC-only logic (does NOT downgrade).

--- a/tests/test_check_board_e2e.py
+++ b/tests/test_check_board_e2e.py
@@ -22,6 +22,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 HELPER_SCRIPT_PATH = REPO_ROOT / "scripts" / "ci" / "check_board_00_e2e.py"
 
@@ -171,4 +173,159 @@ def test_lvs_only_rejects_board_json_lvs_clean_false(tmp_path: Path) -> None:
         json.dumps({"status": "partial", "drc_violations": 18, "lvs_clean": False})
     )
     rc = helper.main([str(board_dir), "--stem", "diffpair_test", "--lvs-only"])
+    assert rc == 2
+
+
+# --- --lvs-not-run / --lvs-vacuous modes (#4006) ----------------------------
+#
+# Unwired fixture schematics make LVS unavailable: the copper comparator
+# binds zero pins and any 'clean' verdict is zero-evidence (PR #4005
+# review).  Board 06's recipe now SKIPS the LVS step (no lvs.json at all:
+# --lvs-not-run) while board 07's still emits a vacuity-guard-marked
+# lvs.json (--lvs-vacuous).  Both modes also require board.json to OMIT
+# lvs_clean ("LVS not run" on the gallery).
+
+
+def _stage_lvs_not_run_board(root: Path, stem: str) -> Path:
+    """Staging dir mimicking board 06 post-#4006: no lvs.json at all."""
+    helper = _load_helper()
+    board_dir = root / "board"
+    output = board_dir / "output"
+    (output / "manufacturing").mkdir(parents=True)
+    for rel in helper.required_artifacts(stem):
+        if rel == "lvs.json":
+            continue
+        p = output / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("placeholder")
+    (output / "board.json").write_text(json.dumps({"status": "partial", "drc_violations": 18}))
+    return board_dir
+
+
+def _stage_lvs_vacuous_board(root: Path, stem: str) -> Path:
+    """Staging dir mimicking board 07 post-#4006: vacuous lvs.json emitted."""
+    board_dir = _stage_lvs_not_run_board(root, stem)
+    (board_dir / "output" / "lvs.json").write_text(
+        json.dumps(
+            {
+                "clean": False,
+                "mismatches": [],
+                "copper_mismatches": [
+                    {
+                        "kind": "vacuous",
+                        "net_a": "<no-schematic-evidence>",
+                        "net_b": "<no-schematic-evidence>",
+                        "pad_a": "bound_pads=0",
+                        "pad_b": "board_pads=223",
+                    }
+                ],
+                "copper_vacuous": True,
+                "copper_bound_pad_count": 0,
+            }
+        )
+    )
+    return board_dir
+
+
+def test_lvs_not_run_passes_honest_state(tmp_path: Path) -> None:
+    helper = _load_helper()
+    board_dir = _stage_lvs_not_run_board(tmp_path, "diffpair_test")
+    rc = helper.main([str(board_dir), "--stem", "diffpair_test", "--lvs-not-run"])
+    assert rc == 0
+
+
+def test_lvs_not_run_rejects_present_lvs_json(tmp_path: Path) -> None:
+    # Any emitted lvs.json (even a "clean" one) is zero-evidence on an
+    # unwired fixture board -- its presence must trip the gate.
+    helper = _load_helper()
+    board_dir = _stage_lvs_not_run_board(tmp_path, "diffpair_test")
+    (board_dir / "output" / "lvs.json").write_text(json.dumps({"clean": True, "mismatches": []}))
+    rc = helper.main([str(board_dir), "--stem", "diffpair_test", "--lvs-not-run"])
+    assert rc == 2
+
+
+def test_lvs_not_run_rejects_board_json_claiming_lvs_clean(tmp_path: Path) -> None:
+    helper = _load_helper()
+    board_dir = _stage_lvs_not_run_board(tmp_path, "diffpair_test")
+    (board_dir / "output" / "board.json").write_text(
+        json.dumps({"status": "partial", "drc_violations": 18, "lvs_clean": True})
+    )
+    rc = helper.main([str(board_dir), "--stem", "diffpair_test", "--lvs-not-run"])
+    assert rc == 2
+
+
+def test_lvs_vacuous_passes_honest_state(tmp_path: Path) -> None:
+    helper = _load_helper()
+    board_dir = _stage_lvs_vacuous_board(tmp_path, "matchgroup_test")
+    rc = helper.main([str(board_dir), "--stem", "matchgroup_test", "--lvs-vacuous"])
+    assert rc == 0
+
+
+def test_lvs_vacuous_rejects_clean_true(tmp_path: Path) -> None:
+    # clean=true under --lvs-vacuous means the vacuity guard regressed.
+    helper = _load_helper()
+    board_dir = _stage_lvs_vacuous_board(tmp_path, "matchgroup_test")
+    (board_dir / "output" / "lvs.json").write_text(json.dumps({"clean": True, "mismatches": []}))
+    rc = helper.main([str(board_dir), "--stem", "matchgroup_test", "--lvs-vacuous"])
+    assert rc == 2
+
+
+def test_lvs_vacuous_rejects_non_vacuous_dirty(tmp_path: Path) -> None:
+    # A real (non-vacuous) dirty report means the schematic binds pins now;
+    # the job must graduate to --lvs-only instead of blessing the mismatch.
+    helper = _load_helper()
+    board_dir = _stage_lvs_vacuous_board(tmp_path, "matchgroup_test")
+    (board_dir / "output" / "lvs.json").write_text(
+        json.dumps(
+            {
+                "clean": False,
+                "mismatches": [],
+                "copper_mismatches": [
+                    {"kind": "open", "net_a": "N", "net_b": "N", "pad_a": "R1.1", "pad_b": "R2.1"}
+                ],
+            }
+        )
+    )
+    rc = helper.main([str(board_dir), "--stem", "matchgroup_test", "--lvs-vacuous"])
+    assert rc == 2
+
+
+def test_lvs_vacuous_rejects_missing_lvs_json(tmp_path: Path) -> None:
+    # --lvs-vacuous is for recipes that still EMIT lvs.json; absence is a
+    # regression of that contract (the board-07 CI job asserts the file).
+    helper = _load_helper()
+    board_dir = _stage_lvs_vacuous_board(tmp_path, "matchgroup_test")
+    (board_dir / "output" / "lvs.json").unlink()
+    rc = helper.main([str(board_dir), "--stem", "matchgroup_test", "--lvs-vacuous"])
+    assert rc == 2
+
+
+def test_lvs_vacuous_rejects_board_json_claiming_lvs_clean(tmp_path: Path) -> None:
+    helper = _load_helper()
+    board_dir = _stage_lvs_vacuous_board(tmp_path, "matchgroup_test")
+    (board_dir / "output" / "board.json").write_text(
+        json.dumps({"status": "partial", "drc_violations": 18, "lvs_clean": False})
+    )
+    rc = helper.main([str(board_dir), "--stem", "matchgroup_test", "--lvs-vacuous"])
+    assert rc == 2
+
+
+def test_lvs_modes_are_mutually_exclusive(tmp_path: Path) -> None:
+    helper = _load_helper()
+    board_dir = _stage_lvs_not_run_board(tmp_path, "diffpair_test")
+    with pytest.raises(SystemExit):
+        helper.main([str(board_dir), "--lvs-only", "--lvs-not-run"])
+
+
+def test_default_mode_rejects_vacuous_clean_true_lvs_json(tmp_path: Path) -> None:
+    # Belt-and-braces: even the default clean assertion refuses a clean=true
+    # report that self-identifies as vacuous (#4006).
+    helper = _load_helper()
+    board_dir = _stage_clean_board(tmp_path, "voltage_divider")
+    (board_dir / "output" / "lvs.json").write_text(
+        json.dumps(
+            {"clean": True, "mismatches": [], "copper_vacuous": True, "copper_bound_pad_count": 0}
+        )
+    )
+    rc = helper.main([str(board_dir), "--stem", "voltage_divider"])
     assert rc == 2

--- a/tests/test_ci_check_copper_lvs.py
+++ b/tests/test_ci_check_copper_lvs.py
@@ -186,3 +186,89 @@ def test_reads_dirty_from_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
         ),
     )
     assert check_copper_lvs.main(["/dev/stdin"]) == 2
+
+
+# --- --expect-vacuous mode (#4006) ------------------------------------------
+#
+# For deliberately-unwired fixture schematics (board 06) the honest verdict
+# is the vacuity guard's (clean=false, only kind='vacuous' mismatches).
+# --expect-vacuous asserts exactly that shape and fails BOTH ways: on
+# clean=true (guard regression -- the zero-evidence pass) and on real
+# shorts/opens (schematic gained nets; the CI gate must graduate).
+
+_VACUOUS_PAYLOAD = {
+    "clean": False,
+    "bound_pad_count": 0,
+    "mismatches": [
+        {
+            "kind": "vacuous",
+            "net_a": "<no-schematic-evidence>",
+            "net_b": "<no-schematic-evidence>",
+            "pad_a": "bound_pads=0",
+            "pad_b": "board_pads=198",
+        }
+    ],
+}
+
+
+def test_expect_vacuous_passes_on_vacuous_verdict(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = _write_json(tmp_path, _VACUOUS_PAYLOAD)
+    assert check_copper_lvs.main(["--expect-vacuous", str(p)]) == 0
+    assert "vacuity guard fired as expected" in capsys.readouterr().out
+
+
+def test_expect_vacuous_fails_on_clean_true(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # clean=true under --expect-vacuous means the #4006 guard regressed
+    # (or the schematic got wired): either way the gate must trip.
+    p = _write_json(tmp_path, {"clean": True, "mismatches": []})
+    assert check_copper_lvs.main(["--expect-vacuous", str(p)]) == 2
+    assert "::error" in capsys.readouterr().out
+
+
+def test_expect_vacuous_fails_on_real_short(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = _write_json(
+        tmp_path,
+        {
+            "clean": False,
+            "mismatches": [
+                {"kind": "short", "net_a": "A", "net_b": "B", "pad_a": "U1.1", "pad_b": "U1.2"}
+            ],
+        },
+    )
+    assert check_copper_lvs.main(["--expect-vacuous", str(p)]) == 2
+    out = capsys.readouterr().out
+    assert "::error" in out
+    assert "graduate" in out or "upgrade" in out
+
+
+def test_expect_vacuous_fails_on_mixed_kinds(tmp_path: Path) -> None:
+    # A vacuous mismatch mixed with a real one is malformed evidence; trip.
+    p = _write_json(
+        tmp_path,
+        {
+            "clean": False,
+            "mismatches": [
+                {"kind": "vacuous", "net_a": "x", "net_b": "x", "pad_a": "a", "pad_b": "b"},
+                {"kind": "open", "net_a": "N", "net_b": "N", "pad_a": "R1.1", "pad_b": "R2.1"},
+            ],
+        },
+    )
+    assert check_copper_lvs.main(["--expect-vacuous", str(p)]) == 2
+
+
+def test_expect_vacuous_missing_clean_key_exits_1(tmp_path: Path) -> None:
+    p = _write_json(tmp_path, {"mismatches": []})
+    assert check_copper_lvs.main(["--expect-vacuous", str(p)]) == 1
+
+
+def test_default_mode_rejects_vacuous_as_dirty(tmp_path: Path) -> None:
+    # Without --expect-vacuous, a vacuous verdict is simply a dirty result:
+    # the default clean-assertion path must exit 2, never 0.
+    p = _write_json(tmp_path, _VACUOUS_PAYLOAD)
+    assert check_copper_lvs.main([str(p)]) == 2

--- a/tests/test_copper_lvs.py
+++ b/tests/test_copper_lvs.py
@@ -18,10 +18,13 @@ import pytest
 
 from kicad_tools.core.geometry import rotate_pad_offset
 from kicad_tools.lvs import (
+    VACUOUS_KIND,
+    VACUOUS_NET,
     CopperLVSResult,
     compare_copper_netlist,
     compare_partitions,
 )
+from kicad_tools.lvs.copper_lvs import result_from_json, result_to_json
 from kicad_tools.validate.connectivity import ConnectivityValidator
 
 # ---------------------------------------------------------------------------
@@ -196,6 +199,99 @@ def test_short_reported_once_per_net_pair() -> None:
         frozenset({"N1", "N3"}),
         frozenset({"N2", "N3"}),
     }
+
+
+# ---------------------------------------------------------------------------
+# Vacuity guard (#4006, PR #4005 review): zero bound pins must not be "clean"
+# ---------------------------------------------------------------------------
+
+
+def test_wireless_schematic_is_vacuous_not_clean() -> None:
+    """A schematic that binds zero pins (all floating) must NOT read clean.
+
+    This is the exact PR #4005 review hole: PCB-first fixture schematics
+    with no ``(wire ...)`` elements resolve every pin to ``None``, so the
+    partition diff observes nothing.  The old behavior returned a
+    zero-evidence ``clean=True``; the guard now returns a dirty result
+    carrying a single synthetic ``vacuous`` mismatch.
+    """
+    sch: dict[tuple[str, str], str | None] = {
+        ("J1", "1"): None,
+        ("J1", "2"): None,
+        ("R1", "1"): None,
+    }
+    partition = [frozenset({"J1.1", "J1.2"}), frozenset({"R1.1"})]
+    result = compare_partitions(sch, partition)
+    assert not result.clean
+    assert result.vacuous
+    assert result.bound_pad_count == 0
+    assert len(result.mismatches) == 1
+    m = result.mismatches[0]
+    assert m.kind == VACUOUS_KIND
+    assert m.net_a == m.net_b == VACUOUS_NET
+    assert m.pad_a == "bound_pads=0"
+    assert m.pad_b == "board_pads=3"
+    # The synthetic entry is neither a short nor an open.
+    assert result.shorts == ()
+    assert result.opens == ()
+
+
+def test_no_schematic_board_overlap_is_vacuous() -> None:
+    """Wired schematic pins that match NO board pad also bind nothing."""
+    sch = {("R9", "1"): "VCC", ("R9", "2"): "GND"}  # R9 not on the board
+    partition = [frozenset({"U1.1"}), frozenset({"U1.2"})]
+    result = compare_partitions(sch, partition)
+    assert not result.clean
+    assert result.vacuous
+    assert result.bound_pad_count == 0
+
+
+def test_single_bound_pad_is_evidence_not_vacuous() -> None:
+    """The floor is exactly zero: one bound pad is real (if thin) evidence."""
+    sch = {("R1", "1"): "VCC", ("R1", "2"): None}
+    partition = [frozenset({"R1.1"}), frozenset({"R1.2"})]
+    result = compare_partitions(sch, partition)
+    assert result.clean
+    assert not result.vacuous
+    assert result.bound_pad_count == 1
+
+
+def test_wired_clean_result_records_bound_pad_count() -> None:
+    """Non-vacuous results carry their evidence count (#4006)."""
+    sch = {
+        ("R1", "1"): "VCC",
+        ("R1", "2"): "LED_ANODE",
+        ("D1", "1"): "LED_ANODE",
+        ("D1", "2"): "GND",
+    }
+    partition = [
+        frozenset({"R1.1"}),
+        frozenset({"R1.2", "D1.1"}),
+        frozenset({"D1.2"}),
+    ]
+    result = compare_partitions(sch, partition)
+    assert result.clean
+    assert not result.vacuous
+    assert result.bound_pad_count == 4
+
+
+def test_vacuous_result_survives_json_round_trip() -> None:
+    """The subprocess gate marshals results as JSON; vacuity must survive."""
+    sch: dict[tuple[str, str], str | None] = {("J1", "1"): None}
+    result = compare_partitions(sch, [frozenset({"J1.1"})])
+    round_tripped = result_from_json(result_to_json(result))
+    assert round_tripped == result
+    assert round_tripped.vacuous
+    assert not round_tripped.clean
+    assert round_tripped.bound_pad_count == 0
+
+
+def test_legacy_payload_without_bound_pad_count_round_trips() -> None:
+    """Older JSON payloads (no bound_pad_count key) still parse (additive)."""
+    result = result_from_json({"clean": True, "mismatches": []})
+    assert result.clean
+    assert result.bound_pad_count is None
+    assert not result.vacuous
 
 
 # ---------------------------------------------------------------------------
@@ -511,6 +607,10 @@ def test_compare_copper_netlist_on_board00_artifacts() -> None:
     result = compare_copper_netlist(sch, pcb)
     assert isinstance(result, CopperLVSResult)
     assert result.clean, f"board 00 copper LVS unexpectedly dirty: {result.mismatches}"
+    # Board 00's schematic is genuinely wired: its clean verdict must carry
+    # real evidence, not the vacuous zero-comparison kind (#4006).
+    assert not result.vacuous
+    assert result.bound_pad_count is not None and result.bound_pad_count > 0
 
 
 # ---------------------------------------------------------------------------
@@ -854,15 +954,21 @@ def test_pour_extraction_unions_pads_across_disjoint_fill_islands_of_one_zone(
 
 @requires_shapely
 def test_compare_copper_netlist_on_pour_heavy_board07_artifacts() -> None:
-    """End-to-end: the label-free pour model stays clean on a pour-heavy board.
+    """End-to-end: pour-heavy extraction runs, and the verdict is VACUOUS.
 
     Board 07 (match-group test) carries the GND / +1V2 / +1V8 plane pours
     (one zone per net since #3818 de-duplicated the router/recipe overlap),
     fragmented into multiple ``filled_polygons`` by thermal reliefs and
     foreign-pad clearance moats, so it exercises the hole-aware solid-region
-    extraction and the pad-box erosion guard on real routed copper.  It must
-    NOT introduce false shorts.  Skips when the artifacts (or shapely) are
-    absent, mirroring the board-00 end-to-end policy.
+    extraction and the pad-box erosion guard on real routed copper without
+    crashing.
+
+    The verdict itself, however, is *vacuous* (#4006): board 07's fixture
+    schematic has no ``(wire ...)`` elements, so zero pins bind and the
+    historical ``clean=True`` this test pinned was zero-evidence (it would
+    have masked board 07's 5 real copper opens).  The honest contract is
+    now ``clean=False`` + ``vacuous`` — this is the guard's end-to-end
+    regression pin on a real pour-heavy board.
     """
     repo_root = Path(__file__).resolve().parent.parent
     board_out = repo_root / "boards" / "07-matchgroup-test" / "output"
@@ -872,7 +978,34 @@ def test_compare_copper_netlist_on_pour_heavy_board07_artifacts() -> None:
         pytest.skip("board 07 artifacts not present; run generate_design.py")
     result = compare_copper_netlist(sch, pcb)
     assert isinstance(result, CopperLVSResult)
-    assert result.clean, f"pour-heavy board 07 copper LVS unexpectedly dirty: {result.mismatches}"
+    assert result.vacuous, (
+        "board 07's fixture schematic was expected to bind 0 pins (vacuous, "
+        f"#4006) but bound {result.bound_pad_count}; if the schematic gained "
+        "wired nets, upgrade this test to a real clean assertion"
+    )
+    assert not result.clean
+    assert result.bound_pad_count == 0
+
+
+def test_compare_copper_netlist_on_board06_wireless_fixture_is_vacuous() -> None:
+    """End-to-end #4006 pin: board 06's unwired schematic yields VACUOUS.
+
+    Board 06's committed ``lvs.json`` (merged in #4004) claimed
+    ``clean=true`` off exactly this pair of artifacts while binding zero
+    pins — the vacuity hole from PR #4005's review.  The comparator must
+    now refuse that: dirty, vacuous, zero bound pads.
+    """
+    repo_root = Path(__file__).resolve().parent.parent
+    board_out = repo_root / "boards" / "06-diffpair-test" / "output"
+    sch = board_out / "diffpair_test.kicad_sch"
+    pcb = board_out / "diffpair_test_routed.kicad_pcb"
+    if not (sch.exists() and pcb.exists()):
+        pytest.skip("board 06 artifacts not present; run generate_design.py")
+    result = compare_copper_netlist(sch, pcb)
+    assert not result.clean
+    assert result.vacuous
+    assert result.bound_pad_count == 0
+    assert [m.kind for m in result.mismatches] == [VACUOUS_KIND]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_lvs_recipe.py
+++ b/tests/test_lvs_recipe.py
@@ -69,6 +69,22 @@ _FLOATING_LABEL = LVSResult(
     clean=False,
     mismatches=(LVSMismatch(ref="J1", pad="1", schematic_net=None, pcb_net="USB_DP"),),
 )
+# Vacuity-guard verdict (#4006): a wireless fixture schematic binds zero
+# pins, so the comparator refuses to report clean (single synthetic
+# ``vacuous`` mismatch, bound_pad_count=0).
+_VACUOUS_COPPER = CopperLVSResult(
+    clean=False,
+    mismatches=(
+        CopperLVSMismatch(
+            kind="vacuous",
+            net_a="<no-schematic-evidence>",
+            net_b="<no-schematic-evidence>",
+            pad_a="bound_pads=0",
+            pad_b="board_pads=198",
+        ),
+    ),
+    bound_pad_count=0,
+)
 
 
 def _read(tmp_path: Path) -> dict:
@@ -180,6 +196,75 @@ def test_copper_only_gating_ignores_label_mismatches(
     data = _read(tmp_path)
     assert data["clean"] is True
     assert data["mismatches"] == []  # no label result -> empty
+
+
+def test_vacuous_copper_only_gate_raises_instead_of_passing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The #4006 crux: copper-only gate + wireless schematic must FAIL.
+
+    Before the vacuity guard this exact configuration (board 06/07's
+    ``run_label=False`` hard gate) passed with a zero-evidence
+    ``clean=true`` lvs.json.  Now the vacuous copper verdict is dirty, so
+    ``require_clean=True`` raises — a board gating copper-only on a
+    wireless schematic can no longer pass vacuously.
+    """
+    _patch_comparators(monkeypatch, copper=_VACUOUS_COPPER, label=_FLOATING_LABEL)
+    with pytest.raises(BoardNetlistMismatch):
+        write_lvs_report(
+            Path("sch"),
+            Path("pcb"),
+            tmp_path,
+            require_clean=True,
+            run_copper=True,
+            run_label=False,
+            fresh_copper_check=False,
+        )
+    data = _read(tmp_path)
+    assert data["clean"] is False
+    assert data["copper_vacuous"] is True
+    assert data["copper_bound_pad_count"] == 0
+    assert data["copper_mismatches"][0]["kind"] == "vacuous"
+    # Additive v1 schema: historical fields unchanged in shape.
+    assert data["$schema"] == "https://kicad-tools.org/schemas/lvs/v1.json"
+    assert data["mismatches"] == []  # label comparator not run
+
+
+def test_vacuous_copper_advisory_writes_dirty_report_without_raising(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Advisory mode (require_clean=False) logs the vacuity, never clean=true."""
+    _patch_comparators(monkeypatch, copper=_VACUOUS_COPPER, label=_FLOATING_LABEL)
+    copper_clean, label_clean = write_lvs_report(
+        Path("sch"),
+        Path("pcb"),
+        tmp_path,
+        require_clean=False,
+        run_copper=True,
+        run_label=False,
+        fresh_copper_check=False,
+    )
+    assert copper_clean is False  # vacuous counts as dirty
+    assert label_clean is True  # not run -> vacuously true for the gate AND
+    data = _read(tmp_path)
+    assert data["clean"] is False
+    assert data["copper_vacuous"] is True
+
+
+def test_clean_copper_payload_carries_evidence_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A genuinely clean copper result records its evidence (#4006 additive)."""
+    wired_clean = CopperLVSResult(clean=True, mismatches=(), bound_pad_count=6)
+    _patch_comparators(monkeypatch, copper=wired_clean, label=_CLEAN_LABEL)
+    copper_clean, label_clean = write_lvs_report(
+        Path("sch"), Path("pcb"), tmp_path, require_clean=True, fresh_copper_check=False
+    )
+    assert (copper_clean, label_clean) == (True, True)
+    data = _read(tmp_path)
+    assert data["clean"] is True
+    assert data["copper_vacuous"] is False
+    assert data["copper_bound_pad_count"] == 6
 
 
 def test_no_comparator_selected_raises_value_error(


### PR DESCRIPTION
Closes #4006. Fixes the LVS-vacuity hole found by the PR #4005 judge review (https://github.com/rjwalters/kicad-tools/pull/4005#issuecomment-4921804544) and cleans up board 06's already-merged instance of it (#4004).

## The hole

`compare_copper_netlist` returned `clean: true` with **zero evidence** on wireless fixture schematics: with no `(wire ...)` elements, `_schematic_pin_to_net` binds 0 pins, `compare_partitions` can detect neither shorts nor opens, and "copper-only 0 shorts / 0 opens" was a zero-comparison result. Board 07's 5 real copper opens were masked by exactly this; board 06 shipped a vacuous `clean=true` lvs.json on main via #4004, rendering a zero-evidence "Ready" LVS badge.

## Guard contract (deliberately the simplest defensible one)

**A copper-LVS result is VACUOUS iff zero board pads carry a real schematic net** — and a vacuous result is never `clean=true`. `compare_partitions` returns `clean=false` with a single synthetic mismatch of `kind="vacuous"` (`net=<no-schematic-evidence>`, witnesses `bound_pads=0` / `board_pads=N`) plus `bound_pad_count=0`.

Why zero rather than a `<50%`-style floor: any bound pad ≥ 1 is real, falsifiable evidence for the nets it touches, and legitimate boards mix wired nets with PCB-only fixtures — a ratio threshold needs an arbitrary constant and misfires on those. Zero bound pads is the unique case where the comparator observes literally nothing. (Documented in `copper_lvs.py`'s module docstring.)

Because the guard lives in the pure `compare_partitions` core, it covers `compare_copper_netlist`, the `python -m kicad_tools.lvs.copper_lvs` subprocess entrypoint, `write_lvs_report`'s #3838 fresh-check gate, and `kct check`'s LVS leg identically. Note the label comparator has no symmetric hole: on a wireless schematic every netted pad mismatches `schematic_net=None`, so label-LVS reads *dirty*, never vacuously clean — the vacuity hole was specific to copper-only gating (`run_label=False`).

## Schema: additive to v1 lvs.json (field additions only)

* `copper_vacuous: bool`, `copper_bound_pad_count: int|null` (recipe payload)
* `bound_pad_count` in the subprocess JSON (round-trips through `result_to_json`/`result_from_json`; legacy payloads without it still parse)
* new `"vacuous"` value inside the existing `copper_mismatches[].kind` enum

`kct board-metrics` treats a vacuous lvs.json as **LVS not run** (fields omitted — never "clean", and never a false "dirty"), including legacy `clean=true` artifacts that self-identify `copper_bound_pad_count=0` (belt-and-braces in `check_board_00_e2e.py`'s default mode too).

## Board 06 (the merged instance)

* `boards/06-diffpair-test/output/lvs.json` **removed** (vacuous artifact from #4004: `clean=true` off 0/160 bound pins, 198 board pads).
* Verified via `kct board-metrics`: board 06's `board.json` now omits `lvs_clean` → the site renders the honest **"LVS not run"** chip. The DRC-clean routed artifact and manufacturing bundle are untouched.
* `generate_design.py`: #4004's `write_lvs_report(..., require_clean=True, run_label=False)` hard gate would now fail on the wireless schematic — the recipe instead **skips the LVS step** with an explicit "LVS: SKIPPED — schematic not wired, LVS unavailable" note, emits no lvs.json, and unlinks any stale one. The guard itself is not weakened. (Re-enable the gate if the fixture schematic ever gains wired nets.)

## Board 07 coexistence (merged #4005)

#4005 dropped board 07's committed lvs.json but kept `write_lvs_report(..., require_clean=True)` in the recipe; under the guard that hard gate would raise and abort the recipe *before the manufacturing-bundle export its CI job needs*. Switched to `require_clean=False` (advisory) with the vacuity warning now conditional on the dirty flag: lvs.json is still emitted for the CI tmp-file assert but carries the honest `clean=false` / `copper_vacuous=true` verdict.

## CI adjustments (coverage reshaped, not deleted)

* `scripts/ci/check_copper_lvs.py` gains `--expect-vacuous`: asserts the vacuity-guard verdict (clean=false, only `vacuous` kinds). Fails **both** ways — on `clean=true` (guard regression) and on real shorts/opens (schematic gained nets → graduate the gate).
* `scripts/ci/check_board_00_e2e.py` gains `--lvs-not-run` (board 06: lvs.json ABSENT + board.json omits `lvs_clean`) and `--lvs-vacuous` (board 07: lvs.json present with the guard verdict + board.json omits `lvs_clean`). Mutually exclusive with `--lvs-only`.
* `board-06-end-to-end` job: renamed "LVS vacuity"; regen step asserts `test ! -f lvs.json`; copper re-check uses `--expect-vacuous`; final asserter uses `--lvs-not-run`. DRC re-check and board-metrics steps unchanged.
* `board-07-end-to-end` job: same reshape with `--expect-vacuous` + `--lvs-vacuous` (keeps its `test -f lvs.json` assert).
* Simulated the full board-07 chain locally (write → board-metrics → asserter): all green.

## Fleet sweep (bound-pin counts, committed artifacts on latest main)

| board | sch pins | netted | board pads | bound | verdict | committed lvs.json |
|---|---|---|---|---|---|---|
| 00-simple-led | 6 | 6 | 6 | **6** | clean | genuine |
| 01-voltage-divider | 8 | 8 | 8 | **8** | clean | genuine |
| 02-charlieplex-led | 34 | 34 | 34 | **34** | clean | genuine |
| 03-usb-joystick | 86 | 84 | 86 | **84** | clean | genuine |
| 04-stm32-devboard | 85 | 54 | 85 | **54** | clean | genuine |
| 05-bldc-motor-controller | 205 | 197 | 205 | **197** | clean | genuine (#4003) |
| 06-diffpair-test | 160 | 0 | 198 | **0** | VACUOUS | **removed here** |
| 07-matchgroup-test | 223 | 0 | 244 | **0** | VACUOUS | already dropped (#4005) |

Board 06's was the only remaining vacuous committed artifact. (softstart at rjwalters/softstart was separately verified non-vacuous.)

## Tests

New pins: wireless schematic → not clean/vacuous/bound=0 (pure + end-to-end on boards 06 and 07 committed artifacts); one bound pad = evidence (floor is exactly zero); JSON round-trip incl. legacy payloads; recipe copper-only hard gate raises on vacuous + advisory writes dirty report; board-metrics vacuous→omitted; `--expect-vacuous` / `--lvs-not-run` / `--lvs-vacuous` asserter matrices; board 00's clean integration test now also asserts non-vacuity. The formerly-vacuous board-07 pour-heavy test now pins the vacuous verdict instead of the zero-evidence `clean=true` it used to bless.

Runs: `pytest -k lvs` 166 passed + slow board-03 fresh-regen pass; `test_copper_lvs.py`, `test_lvs_recipe.py`, `test_board_metrics.py`, `test_cli_check.py`, `test_check_board_e2e.py`, `test_ci_check_copper_lvs.py`, board 06/07 suites: 203 passed. ruff + mypy clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
