### PR TITLE
feat(lvs): wire boards 06/07 fixture schematics so LVS carries real evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1302,36 +1302,37 @@ jobs:
             /tmp/board03-staging/03-usb-joystick
 
   board-06-end-to-end:
-    # Issue #3779 (reworked for #4006): end-to-end gate for board 06
-    # ("diffpair-test").  Board 06 is a PCB-first routing fixture whose
-    # generated schematic has NO ``(wire ...)`` elements, so LVS is
-    # UNAVAILABLE: the copper comparator binds 0 of the 198 board pads and
-    # can detect neither shorts nor opens.  The former copper-only hard
-    # gate here (``write_lvs_report(..., run_label=False)``, #4004)
-    # therefore passed on ZERO evidence -- the vacuity hole found in PR
-    # #4005's review.  The recipe now SKIPS the LVS step (emits NO
-    # ``lvs.json``), and this job asserts the honest state instead of a
-    # zero-evidence ``clean=true``:
+    # Issue #3779 (LVS re-enabled by #4012): end-to-end LVS gate for board
+    # 06 ("diffpair-test").  The fixture schematic is now FULLY WIRED
+    # (#4012: generate_schematic.py synthesizes PCB-native-pad symbols and
+    # emits a wire stub + global label for all 198 pins), so both LVS
+    # comparators carry real evidence: copper binds 198/198 pads and the
+    # label comparator agrees pin-for-pin.  The recipe hard-gates on both
+    # (``write_lvs_report(..., require_clean=True)``, boards 00-02 style)
+    # and emits ``lvs.json``; this job asserts:
     #
-    # * the vacuity guard fires on the regenerated schematic+PCB pair
-    #   (``check_copper_lvs.py --expect-vacuous``) -- a ``clean=true``
-    #   there would mean the #4006 guard regressed;
-    # * ``lvs.json`` is ABSENT and ``board.json`` omits ``lvs_clean``
-    #   (``check_board_00_e2e.py --lvs-not-run``) -- the gallery renders
-    #   "LVS not run", never a zero-evidence "Ready" LVS chip.
+    # * a fresh out-of-process copper-LVS re-check on the REGENERATED
+    #   schematic+PCB pair is clean (``check_copper_lvs.py``, no flags);
+    # * ``lvs.json`` reports ``clean: true`` and ``board.json`` carries
+    #   ``lvs_clean: true`` (``check_board_00_e2e.py --lvs-only``).
+    #
+    # (History: before #4012 the schematic had ZERO wires, the copper
+    # comparator bound 0 pins, and this job asserted the #4006
+    # vacuity-guard verdict + lvs.json ABSENT.  #4012 wired the schematic,
+    # graduating the job to the true LVS gate #4004 originally intended.)
     #
     # This job does NOT replace the ``diffpair-routing-regression`` job
     # (which keeps its allowlist-based DRC coverage gate on the ``--step
-    # route`` re-route).  Board 06 carries allowlisted DRC residuals
-    # (.github/routed-drc-tolerance.yml) and routes PARTIAL by design, so
-    # its recipe may exit non-zero (tolerated) and no ``status:ok``
-    # assertion applies.  If the fixture schematic ever gains real wired
-    # nets, graduate this job back to a true LVS gate (--lvs-only +
-    # a plain check_copper_lvs.py clean assertion).
+    # route`` re-route).  Board 06 carries allowlisted DRC *quality*
+    # residuals (.github/routed-drc-tolerance.yml: diff-pair length-skew /
+    # continuity measurements), so ``--lvs-only`` skips the ``status:ok``
+    # / ``drc_violations:0`` assertions -- but all 21 nets route to
+    # completion, which is exactly what the copper-LVS clean assertion
+    # proves (no opens, no shorts).
     #
     # Advisory until a repo admin adds it to branch protection (same as the
     # board 00/01 e2e jobs).
-    name: Board 06 End-to-End (LVS vacuity)
+    name: Board 06 End-to-End (LVS)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     container:
@@ -1367,37 +1368,37 @@ jobs:
         run: uv run kct build-native
 
       - name: Regenerate board 06 from recipe (--step all, clean tmp directory)
-        # PARTIAL routing is expected on this board (USB3_TX1 blocked by the
-        # BGA partner-via escape, #2677), so the recipe may exit non-zero --
-        # tolerate it (|| true).  The recipe SKIPS the LVS step (#4006:
-        # unwired fixture schematic, LVS unavailable) so lvs.json must NOT
-        # exist; the asserters below are the gate.
+        # The recipe hard-gates on LVS (#4012: require_clean=True on both
+        # comparators), so a copper open/short or label divergence exits
+        # non-zero -- tolerate the exit code (|| true) and let the explicit
+        # asserters below be the gate (a dirty regen leaves lvs.json with
+        # clean=false, which check_board_00_e2e.py --lvs-only rejects; an
+        # aborted recipe also fails the manifest presence check).
         run: |
           set -uo pipefail
           rm -rf /tmp/board06-ci
           mkdir -p /tmp/board06-ci
           uv run python boards/06-diffpair-test/generate_design.py \
             /tmp/board06-ci --step all --seed 42 || true
-          test ! -f /tmp/board06-ci/lvs.json
+          test -f /tmp/board06-ci/lvs.json
           test -f /tmp/board06-ci/diffpair_test.kicad_sch
           test -f /tmp/board06-ci/diffpair_test_routed.kicad_pcb
 
-      - name: Copper-LVS vacuity-guard re-check (out-of-process, #4006)
+      - name: Copper-LVS clean re-check (out-of-process, #3838/#4012)
         # Re-run compare_copper_netlist in a process the CI job controls (NOT
         # the recipe) on the REGENERATED schematic + routed PCB.  Board 06's
-        # schematic is unwired, so the honest verdict is the vacuity guard's
-        # (clean=false, kind='vacuous'): --expect-vacuous asserts exactly
-        # that.  A clean=true result means the #4006 guard regressed (the
-        # zero-evidence pass this job used to encode); a short/open means the
-        # schematic gained wired nets -- graduate this job to a real clean
-        # assertion.  Entrypoint from #3838.
+        # schematic is fully wired (#4012: 198/198 pads bound), so the honest
+        # verdict is a genuinely-evidenced clean -- the plain assertion also
+        # rejects a vacuous result (the #4006 guard forces clean=false when
+        # zero pins bind, so a schematic wiring regression fails here too).
+        # Entrypoint from #3838.
         run: |
           set -euo pipefail
           uv run python -m kicad_tools.lvs.copper_lvs \
             /tmp/board06-ci/diffpair_test.kicad_sch \
             /tmp/board06-ci/diffpair_test_routed.kicad_pcb \
             > /tmp/board06-copper.json
-          uv run python scripts/ci/check_copper_lvs.py --expect-vacuous /tmp/board06-copper.json
+          uv run python scripts/ci/check_copper_lvs.py /tmp/board06-copper.json
 
       - name: Independent DRC re-check within allowlist (out-of-process, issue #3840)
         # Validate the REGENERATED routed PCB's DRC out-of-process against the
@@ -1424,40 +1425,47 @@ jobs:
           cp -r /tmp/board06-ci/. /tmp/board06-staging/06-diffpair-test/output/
           uv run kct board-metrics /tmp/board06-staging/06-diffpair-test
 
-      - name: Assert artifacts + honest LVS-not-run state (#4006)
-        # --lvs-not-run: assert lvs.json ABSENT + board.json omits lvs_clean
-        # ("LVS not run" on the gallery -- never a zero-evidence badge), but
-        # NOT status:ok / drc_violations:0 (board 06 carries allowlisted DRC
-        # residuals -> status='partial').
+      - name: Assert artifacts + LVS clean (#4012)
+        # --lvs-only: assert lvs.json clean=true + board.json lvs_clean=true,
+        # but NOT status:ok / drc_violations:0 (board 06 carries allowlisted
+        # DRC quality residuals -> status='partial').
         run: |
           set -euo pipefail
           uv run python scripts/ci/check_board_00_e2e.py \
             --stem diffpair_test \
-            --lvs-not-run \
+            --lvs-only \
             /tmp/board06-staging/06-diffpair-test
 
   board-07-end-to-end:
-    # Issue #3779 (reworked for #4006): end-to-end gate for board 07
-    # ("matchgroup-test").  Same unwired-fixture situation as board 06:
-    # the generated schematic has no ``(wire ...)`` elements, so the
-    # copper comparator binds 0 pins and LVS is UNAVAILABLE -- the former
-    # copper-only ``clean=true`` here was zero-evidence (PR #4005 review /
-    # #4006; board 07 in fact had 5 real copper opens the vacuous verdict
-    # masked).  Unlike board 06, board 07's recipe still EMITS
-    # ``output/lvs.json`` in ``--step all`` (this job asserts the file
-    # exists); with the #4006 vacuity guard that file now carries the
-    # honest dirty verdict (clean=false, copper_vacuous=true) and
-    # ``kct board-metrics`` treats it as "LVS not run" (omits lvs_clean).
+    # Issue #3779 (LVS honestly dirty per #4012): end-to-end gate for
+    # board 07 ("matchgroup-test").  The fixture schematic is now FULLY
+    # WIRED (#4012: 244/244 pads bound), so the copper comparator carries
+    # real evidence -- and board 07 routes PARTIAL by design (5
+    # seed-invariant unroutable nets, #3438: DQ3, DQ4, MIPI_DAT0_N,
+    # TMDS_D0_N, TMDS_D1_N), so the HONEST verdict is ``clean: false``
+    # with exactly those 5 opens.  (Before #4012 the schematic bound 0
+    # pins and the #4006 vacuity guard masked these real opens behind a
+    # "LVS not run" verdict; before #4006, a zero-evidence ``clean=true``
+    # masked them entirely.)  The recipe emits ``lvs.json`` with
+    # ``require_clean=False`` (the opens are expected); this job asserts
+    # the exact known-opens contract:
+    #
+    # * ``check_copper_lvs.py --expect-opens DQ3,...`` on a fresh
+    #   out-of-process re-check: ONLY kind='open', on EXACTLY those 5
+    #   nets -- a short, a new open, or a net becoming routable all fail;
+    # * ``check_board_00_e2e.py --lvs-known-opens DQ3,...``: lvs.json
+    #   carries the same 5 opens (label leg clean) and board.json renders
+    #   the honest ``lvs_clean: false`` (gallery: "LVS: 5 mismatches",
+    #   status 'partial').
     #
     # NEW, ADDITIVE gate -- does NOT replace the
     # ``matchgroup-routing-regression`` job.  Board 07 carries allowlisted
-    # DRC residuals (.github/routed-drc-tolerance.yml:
-    # matchgroup_test_routed.kicad_pcb=120) and routes PARTIAL by design,
-    # so no Overall: PASSED / status:ok / drc_violations:0 assertions
-    # apply.  If the fixture schematic ever gains real wired nets,
-    # graduate this job to --lvs-only + a plain copper-clean assertion.
+    # DRC residuals (.github/routed-drc-tolerance.yml) and routes PARTIAL
+    # by design, so no Overall: PASSED / status:ok / drc_violations:0
+    # assertions apply.  If #3438 ever makes the 5 nets routable, graduate
+    # this job to --lvs-only + a plain copper-clean assertion.
     # Advisory until a repo admin adds it to branch protection.
-    name: Board 07 End-to-End (LVS vacuity)
+    name: Board 07 End-to-End (LVS known opens)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     container:
@@ -1493,11 +1501,11 @@ jobs:
         run: uv run kct build-native
 
       - name: Regenerate board 07 from recipe (--step all, clean tmp directory)
-        # PARTIAL routing is expected on this board, so tolerate a non-zero
-        # recipe exit (|| true).  The recipe still emits lvs.json; with the
-        # #4006 vacuity guard it carries clean=false / copper_vacuous=true
-        # (the recipe's LVS gate raising on the vacuous verdict is part of
-        # the tolerated non-zero exit).  The asserters below are the gate.
+        # PARTIAL routing is expected on this board (5 unroutable nets,
+        # #3438), so the recipe exits non-zero -- tolerate it (|| true).
+        # The recipe emits lvs.json with the honest clean=false / 5-opens
+        # verdict (#4012, require_clean=False because the opens are
+        # expected).  The asserters below are the gate.
         run: |
           set -uo pipefail
           rm -rf /tmp/board07-ci
@@ -1508,21 +1516,24 @@ jobs:
           test -f /tmp/board07-ci/matchgroup_test.kicad_sch
           test -f /tmp/board07-ci/matchgroup_test_routed.kicad_pcb
 
-      - name: Copper-LVS vacuity-guard re-check (out-of-process, #4006)
+      - name: Copper-LVS known-opens re-check (out-of-process, #3838/#4012)
         # Re-run compare_copper_netlist in a process the CI job controls (NOT
         # the recipe) on the REGENERATED schematic + routed PCB.  Board 07's
-        # schematic is unwired, so the honest verdict is the vacuity guard's
-        # (clean=false, kind='vacuous'): --expect-vacuous asserts exactly
-        # that.  A clean=true result means the #4006 guard regressed; a
-        # short/open means the schematic gained wired nets -- graduate this
-        # job to a real clean assertion.  Entrypoint from #3838.
+        # schematic is fully wired (#4012: 244/244 pads bound) and the board
+        # routes PARTIAL by design, so the honest verdict is exactly the 5
+        # seed-invariant opens (#3438): --expect-opens asserts that set and
+        # nothing else.  A copper short, a NEW open, a vacuous verdict (the
+        # schematic regressed to unwired), or one of the 5 becoming routable
+        # all fail the gate.  Entrypoint from #3838.
         run: |
           set -euo pipefail
           uv run python -m kicad_tools.lvs.copper_lvs \
             /tmp/board07-ci/matchgroup_test.kicad_sch \
             /tmp/board07-ci/matchgroup_test_routed.kicad_pcb \
             > /tmp/board07-copper.json
-          uv run python scripts/ci/check_copper_lvs.py --expect-vacuous /tmp/board07-copper.json
+          uv run python scripts/ci/check_copper_lvs.py \
+            --expect-opens "DQ3,DQ4,MIPI_DAT0_N,TMDS_D0_N,TMDS_D1_N" \
+            /tmp/board07-copper.json
 
       - name: Independent DRC re-check within allowlist (out-of-process, issue #3840)
         # Validate the REGENERATED routed PCB's DRC out-of-process against the
@@ -1548,17 +1559,19 @@ jobs:
           cp -r /tmp/board07-ci/. /tmp/board07-staging/07-matchgroup-test/output/
           uv run kct board-metrics /tmp/board07-staging/07-matchgroup-test
 
-      - name: Assert artifacts + honest vacuous-LVS state (#4006)
-        # --lvs-vacuous: lvs.json must be present (this recipe still emits
-        # it) and must carry the vacuity-guard verdict (clean=false,
-        # copper_vacuous=true); board.json must OMIT lvs_clean ("LVS not
-        # run" on the gallery).  No status/drc_violations assertions
-        # (allowlisted DRC residuals -> status='partial').
+      - name: Assert artifacts + honest known-opens LVS state (#4012)
+        # --lvs-known-opens: lvs.json must be present, clean=false, NOT
+        # vacuous, with ONLY kind='open' copper mismatches on exactly the
+        # 5 seed-invariant unroutable nets (#3438) and an empty
+        # label-mismatch list; board.json must carry the honest
+        # lvs_clean=false (gallery: "LVS: 5 mismatches").  No
+        # status/drc_violations assertions (allowlisted DRC residuals ->
+        # status='partial').
         run: |
           set -euo pipefail
           uv run python scripts/ci/check_board_00_e2e.py \
             --stem matchgroup_test \
-            --lvs-vacuous \
+            --lvs-known-opens "DQ3,DQ4,MIPI_DAT0_N,TMDS_D0_N,TMDS_D1_N" \
             /tmp/board07-staging/07-matchgroup-test
 
   board-05-routing-regression:

--- a/boards/06-diffpair-test/generate_design.py
+++ b/boards/06-diffpair-test/generate_design.py
@@ -39,6 +39,7 @@ from pathlib import Path
 
 from kicad_tools.core.project_file import create_minimal_project, save_project
 from kicad_tools.dev import warn_if_stale
+from kicad_tools.lvs import write_lvs_report
 from kicad_tools.router.rules import NET_CLASS_HIGH_SPEED, NET_CLASS_POWER, NetClassRouting
 
 # Re-export net definitions and footprint generators from generate_pcb.
@@ -3402,35 +3403,29 @@ def main() -> int:
             route_success = route_pcb(pcb_path, routed_path)
             drc_ok = run_drc(routed_path)
 
-            # LVS: SKIPPED -- schematic not wired, LVS unavailable (#4005
-            # review).  Board 06 is a PCB-first routing fixture whose
-            # schematic has no ``(wire ...)`` elements, so every schematic
-            # pin is floating: the copper comparator binds 0 of the board's
-            # 198 pads and can detect neither shorts nor opens.  The
-            # copper-only hard gate #4004 added here
-            # (``write_lvs_report(..., require_clean=True, run_label=False)``)
-            # therefore passed on ZERO evidence -- and with the vacuity
-            # guard it now (correctly) raises instead.  Rather than weaken
-            # the guard, this recipe skips the LVS step and emits NO
-            # ``lvs.json``: ``kct board-metrics`` omits ``lvs_clean`` and
-            # the gallery honestly shows "LVS not run".  Re-enable
-            # ``write_lvs_report`` here if/when the fixture schematic gets
-            # wired nets.
-            print("\n" + "=" * 60)
-            print("LVS: SKIPPED -- schematic not wired, LVS unavailable")
-            print("=" * 60)
-            print(
-                "   Board 06's fixture schematic binds 0 pins (no wires/"
-                "labels), so copper-LVS would be vacuous (#4005 review).\n"
-                "   No lvs.json is emitted; board-metrics reports 'LVS not "
-                "run'."
+            # LVS (#3779, re-enabled by #4012): the fixture schematic is
+            # now FULLY WIRED (generate_schematic.py emits a wire stub +
+            # global label for all 198 pins, PIN_NETS mirroring
+            # generate_pcb.py pad-for-pad), so both comparators carry real
+            # evidence: the copper comparator binds 198/198 pads and the
+            # label comparator agrees pin-for-pin.  Gate on BOTH
+            # comparators, boards 00-02 style (see the gate-policy matrix
+            # in kicad_tools/lvs/recipe.py): ``require_clean=True`` raises
+            # BoardNetlistMismatch on any short/open/label divergence so
+            # the recipe exit gate trips before the manufacturing export.
+            # (History: the pre-#4012 schematic had ZERO wires, the copper
+            # comparator bound 0 pins, and the #4006 vacuity guard rightly
+            # refused to call that clean -- the LVS step was skipped
+            # entirely.  #4012 wired the schematic, restoring the hard
+            # gate #4004 originally intended.)
+            write_lvs_report(
+                sch_path,
+                routed_path,
+                output_dir,
+                require_clean=True,
+                run_copper=True,
+                run_label=True,
             )
-            # Drop any stale lvs.json from an earlier recipe version so the
-            # gallery cannot keep rendering a zero-evidence LVS badge.
-            stale_lvs = output_dir / "lvs.json"
-            if stale_lvs.exists():
-                stale_lvs.unlink()
-                print(f"   Removed stale {stale_lvs} (vacuous artifact).")
 
             # Export manufacturing bundle (#3147) so ``kct fleet status``
             # reports ``ship_ready=true`` (the bundle's manifest mtime must

--- a/boards/06-diffpair-test/generate_schematic.py
+++ b/boards/06-diffpair-test/generate_schematic.py
@@ -2,14 +2,28 @@
 """
 Generate a KiCad Schematic for the differential-pair test board (board 06).
 
-This emits a flat schematic with global labels for each declared net.
-The schematic is a minimal logical map of the PCB --- it's a routing
-regression testbench, not a working device, so the schematic uses
-placeholder symbols (Conn_01xN connectors) for source / sink endpoints.
+This emits a flat schematic that is a **fully wired** logical map of the
+PCB: every component pin carries a short wire stub terminated by a global
+label naming the pin's net, so the schematic netlist is pad-for-pad
+identical to the PCB's (issue #4012; the pre-#4012 revision emitted only
+floating labels, which bound ZERO pins and made LVS vacuous, #4005/#4006).
 
-Each global label declares one net.  Differential pairs are drawn with
-adjacent labels so the schematic visually communicates the P/N pairing
-without needing the (more complex) ``DiffPair`` annotation.
+Because the PCB's pad numbering is package-native (USB-C ``A1..B12`` +
+``S1/S2`` shield pads, BGA ``A1..G7``, FFC ``M1/M2/RST``), the stock
+``Connector_Generic`` symbols (numeric pins ``1..N``) can never bind those
+pads.  Instead this script synthesizes one testbench symbol per component
+via :mod:`kicad_tools.schematic.symbol_generator`, with pin numbers
+matching the PCB pads exactly, writes them to a project-local
+``diffpair_lvs.kicad_sym`` library next to the schematic, and resolves
+them through ``Schematic(local_symbol_libs=[...])`` (the board-05
+``board05_custom`` pattern).  The emitted ``.kicad_sch`` embeds the
+symbol definitions in ``lib_symbols``, so downstream consumers (LVS,
+KiCad itself) need no library setup.
+
+``PIN_NETS`` below is the schematic-side source of truth and mirrors the
+per-pad net assignment in ``generate_pcb.py`` — the LVS gate in
+``generate_design.py`` (label + copper comparators) is what keeps the two
+in lock-step: any divergence fails the recipe.
 
 Usage:
     python generate_schematic.py [output_file]
@@ -22,6 +36,13 @@ import sys
 from pathlib import Path
 
 from kicad_tools.dev import warn_if_stale
+from kicad_tools.schematic import (
+    PinDef,
+    PinSide,
+    PinType,
+    SymbolDef,
+    generate_symbol_sexp,
+)
 from kicad_tools.schematic.models.schematic import Schematic, SnapMode
 
 # Warn if running source scripts with stale pipx install
@@ -29,9 +50,303 @@ warn_if_stale()
 
 WIRE_STUB = 5.08  # 200 mils
 
+# Name of the generated project-local symbol library (written next to the
+# schematic).  lib_ids take the form ``diffpair_lvs:<SYMBOL>``.
+LIB_NAME = "diffpair_lvs"
+
+# ---------------------------------------------------------------------------
+# Schematic-side netlist: {ref: {pad: net}} for every pad on the board.
+# Mirrors generate_pcb.py's per-pad net assignment pad-for-pad (the LVS gate
+# in generate_design.py fails the recipe if the two ever diverge).
+# ---------------------------------------------------------------------------
+PIN_NETS: dict[str, dict[str, str]] = {
+    # J1 -- USB-C receptacle (source for USB 2.0 + USB 3.0 pairs)
+    "J1": {
+        "A1": "GND",
+        "A2": "USB3_TX1+",
+        "A3": "USB3_TX1-",
+        "A4": "VBUS_USB",
+        "A5": "USB_CC1",
+        "A6": "USB2_D+",
+        "A7": "USB2_D-",
+        "A8": "+3V3",
+        "A9": "VBUS_USB",
+        "A10": "USB3_RX2-",
+        "A11": "USB3_RX2+",
+        "A12": "GND",
+        "B1": "GND",
+        "B2": "USB3_TX2+",
+        "B3": "USB3_TX2-",
+        "B4": "VBUS_USB",
+        "B5": "USB_CC2",
+        "B6": "USB2_D+",
+        "B7": "USB2_D-",
+        "B8": "+3V3",
+        "B9": "VBUS_USB",
+        "B10": "USB3_RX1-",
+        "B11": "USB3_RX1+",
+        "B12": "GND",
+        "S1": "GND",
+        "S2": "GND",
+    },
+    # J3 -- Mini-PCIe edge connector (PCIe pair source)
+    "J3": {
+        "1": "GND",
+        "2": "GND",
+        "3": "+3V3",
+        "4": "GND",
+        "5": "PCIE_TX+",
+        "6": "PCIE_TX-",
+        "7": "GND",
+        "8": "PCIE_RX+",
+        "9": "PCIE_RX-",
+        "10": "+1V2",
+        "11": "GND",
+        "12": "GND",
+    },
+    # J4 -- FFC connector (MIPI source)
+    "J4": {
+        "1": "MIPI_CLK+",
+        "2": "MIPI_CLK-",
+        "3": "MIPI_D0+",
+        "4": "MIPI_D0-",
+        "M1": "GND",
+        "M2": "GND",
+        "RST": "MIPI_RST",
+    },
+    # U1 -- QFN-32 USB 2.0 sink
+    "U1": {
+        "1": "+3V3",
+        "2": "GND",
+        "3": "GND",
+        "4": "GND",
+        "5": "GND",
+        "6": "GND",
+        "7": "GND",
+        "8": "GND",
+        "9": "VBUS_USB",
+        "10": "USB2_D+",
+        "11": "USB2_D-",
+        "12": "USB_CC1",
+        "13": "USB_CC2",
+        "14": "GND",
+        "15": "GND",
+        "16": "+1V8",
+        "17": "+3V3",
+        "18": "GND",
+        "19": "GND",
+        "20": "GND",
+        "21": "GND",
+        "22": "GND",
+        "23": "GND",
+        "24": "GND",
+        "25": "GND",
+        "26": "GND",
+        "27": "GND",
+        "28": "GND",
+        "29": "GND",
+        "30": "GND",
+        "31": "GND",
+        "32": "GND",
+    },
+    # U2 -- BGA-49 USB 3.0 sink
+    "U2": {
+        "A1": "GND",
+        "A2": "GND",
+        "A3": "GND",
+        "A4": "GND",
+        "A5": "GND",
+        "A6": "GND",
+        "A7": "GND",
+        "B1": "GND",
+        "B2": "USB3_TX1+",
+        "B3": "USB3_TX1-",
+        "B4": "GND",
+        "B5": "USB3_RX1+",
+        "B6": "USB3_RX1-",
+        "B7": "GND",
+        "C1": "GND",
+        "C2": "+3V3",
+        "C3": "+1V2",
+        "C4": "+1V2",
+        "C5": "+1V2",
+        "C6": "+3V3",
+        "C7": "GND",
+        "D1": "GND",
+        "D2": "+1V2",
+        "D3": "+1V2",
+        "D4": "+1V2",
+        "D5": "+1V2",
+        "D6": "+1V2",
+        "D7": "GND",
+        "E1": "GND",
+        "E2": "+3V3",
+        "E3": "+1V2",
+        "E4": "+1V2",
+        "E5": "+1V2",
+        "E6": "+3V3",
+        "E7": "GND",
+        "F1": "GND",
+        "F2": "USB3_TX2+",
+        "F3": "USB3_TX2-",
+        "F4": "GND",
+        "F5": "USB3_RX2+",
+        "F6": "USB3_RX2-",
+        "F7": "GND",
+        "G1": "GND",
+        "G2": "GND",
+        "G3": "GND",
+        "G4": "GND",
+        "G5": "GND",
+        "G6": "GND",
+        "G7": "GND",
+    },
+    # U3 -- QFP-48 PCIe sink
+    "U3": {
+        "1": "GND",
+        "2": "GND",
+        "3": "GND",
+        "4": "GND",
+        "5": "GND",
+        "6": "GND",
+        "7": "GND",
+        "8": "GND",
+        "9": "GND",
+        "10": "GND",
+        "11": "GND",
+        "12": "GND",
+        "13": "GND",
+        "14": "GND",
+        "15": "GND",
+        "16": "GND",
+        "17": "GND",
+        "18": "GND",
+        "19": "GND",
+        "20": "GND",
+        "21": "GND",
+        "22": "GND",
+        "23": "GND",
+        "24": "GND",
+        "25": "+3V3",
+        "26": "GND",
+        "27": "GND",
+        "28": "PCIE_TX+",
+        "29": "PCIE_TX-",
+        "30": "GND",
+        "31": "PCIE_RX+",
+        "32": "PCIE_RX-",
+        "33": "GND",
+        "34": "GND",
+        "35": "GND",
+        "36": "+1V2",
+        "37": "GND",
+        "38": "GND",
+        "39": "GND",
+        "40": "GND",
+        "41": "GND",
+        "42": "GND",
+        "43": "GND",
+        "44": "GND",
+        "45": "GND",
+        "46": "GND",
+        "47": "GND",
+        "48": "GND",
+    },
+    # U4 -- QFN-24 MIPI sink
+    "U4": {
+        "1": "MIPI_CLK+",
+        "2": "MIPI_CLK-",
+        "3": "MIPI_D0+",
+        "4": "MIPI_D0-",
+        "5": "MIPI_RST",
+        "6": "+1V8",
+        "7": "GND",
+        "8": "GND",
+        "9": "GND",
+        "10": "GND",
+        "11": "GND",
+        "12": "+3V3",
+        "13": "GND",
+        "14": "GND",
+        "15": "GND",
+        "16": "GND",
+        "17": "GND",
+        "18": "+1V8",
+        "19": "GND",
+        "20": "GND",
+        "21": "GND",
+        "22": "GND",
+        "23": "GND",
+        "24": "GND",
+    },
+}
+
+# Placement + identity per component: (ref, symbol_name, value, footprint,
+# x, y).  Sources in the left column, sinks in the right column; y spacing
+# leaves room for each symbol's body (pin count / 2 * 2.54mm) plus stubs.
+COMPONENTS: list[tuple[str, str, str, str, float, float]] = [
+    ("J1", "USBC_SRC", "USB-C", "Connector_USB:USB_C_Receptacle_USB2.0", 50.8, 50.8),
+    ("J3", "MINIPCIE_SRC", "MiniPCIe", "Connector_PCIE:PCIE_Mini_Edge", 50.8, 106.68),
+    ("J4", "FFC_SRC", "FFC4", "Connector_FFC:FFC_4P_0.5mm", 50.8, 137.16),
+    ("U1", "QFN32_USB2", "QFN32_USB2", "Package_DFN_QFN:QFN-32-1EP_5x5mm_P0.5mm", 177.8, 50.8),
+    (
+        "U2",
+        "BGA49_USB3",
+        "BGA49_USB3",
+        "Package_BGA:BGA-49_5.0x5.0mm_Layout7x7_P0.5mm",
+        177.8,
+        127.0,
+    ),
+    ("U3", "QFP48_PCIE", "QFP48_PCIe", "Package_QFP:LQFP-48_7x7mm_P0.5mm", 177.8, 203.2),
+    ("U4", "QFN24_MIPI", "QFN24_MIPI", "Package_DFN_QFN:QFN-24-1EP_4x4mm_P0.5mm", 177.8, 266.7),
+]
+
+
+def _build_symbol_lib(lib_path: Path) -> None:
+    """Write the project-local testbench symbol library.
+
+    One symbol per component, pin numbers matching the PCB pads exactly
+    (first half of the pad list on the left edge, second half on the
+    right).  All pins are ``passive`` — these are testbench endpoints, not
+    electrical models.
+    """
+    blocks: list[str] = []
+    for _ref, symbol_name, _value, footprint, _x, _y in COMPONENTS:
+        pads = list(PIN_NETS[_ref])
+        half = (len(pads) + 1) // 2
+        pins = [
+            PinDef(
+                number=pad,
+                name=pad,
+                pin_type=PinType.PASSIVE,
+                side=PinSide.LEFT if i < half else PinSide.RIGHT,
+            )
+            for i, pad in enumerate(pads)
+        ]
+        sym = SymbolDef(name=symbol_name, pins=pins, reference="U", footprint=footprint)
+        text = generate_symbol_sexp(sym)
+        lines = text.splitlines()
+        start = next(i for i, ln in enumerate(lines) if ln.startswith("\t(symbol "))
+        if lines[-1] != ")":
+            raise RuntimeError(f"unexpected symbol-lib tail for {symbol_name}")
+        blocks.append("\n".join(lines[start:-1]))
+
+    header = (
+        "(kicad_symbol_lib\n"
+        "\t(version 20231120)\n"
+        '\t(generator "kicad_tools")\n'
+        '\t(generator_version "1.0")\n'
+    )
+    lib_path.write_text(header + "\n".join(blocks) + "\n)\n")
+
 
 def add_pin_label(sch: Schematic, pin_pos: tuple, net_name: str, direction: str = "right") -> None:
-    """Add a wire stub from a pin position to a global label."""
+    """Add a wire stub from a pin position to a global label.
+
+    Pin attach is ENDPOINT-only (KiCad semantics): the wire must start
+    exactly at the pin position.  The label names the net from the stub's
+    far end.
+    """
     if not pin_pos:
         return
     x, y = pin_pos
@@ -45,173 +360,91 @@ def add_pin_label(sch: Schematic, pin_pos: tuple, net_name: str, direction: str 
     sch.add_global_label(net_name, end_x, y, shape="bidirectional", rotation=rotation, snap=False)
 
 
+def _wire_all_pins(sch: Schematic, sym, pin_nets: dict[str, str]) -> int:
+    """Wire every pin of ``sym`` to a global label carrying its net name."""
+    wired = 0
+    for pin in sym.symbol_def.pins:
+        pos = sym.pin_position(pin.number)
+        if pos is None:
+            raise RuntimeError(f"{sym.reference}.{pin.number}: no pin position")
+        net = pin_nets[pin.number]
+        direction = "left" if pos[0] < sym.x else "right"
+        add_pin_label(sch, pos, net, direction)
+        wired += 1
+    return wired
+
+
 def create_diffpair_schematic(output_path: Path) -> bool:
-    """Create the diff-pair testbench schematic."""
+    """Create the diff-pair testbench schematic (fully wired, #4012)."""
     print("Creating Differential Pair Test Schematic...")
     print("=" * 60)
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # ---------------------------------------------------------------------
+    # 1. Synthesize the project-local symbol library (PCB-native pads)
+    # ---------------------------------------------------------------------
+    print("\n1. Writing project-local symbol library...")
+    lib_path = output_path.parent / f"{LIB_NAME}.kicad_sym"
+    _build_symbol_lib(lib_path)
+    print(f"   {lib_path} ({len(COMPONENTS)} symbols)")
 
     sch = Schematic(
         title="Differential Pair Test Board",
         date="2026-05",
-        revision="A",
+        revision="B",
         company="kicad-tools",
         comment1="Multi-protocol HSDI regression testbench",
-        comment2="Epic #2556 Phase 4L (issue #2658)",
+        comment2="Epic #2556 Phase 4L (issue #2658); wired netlist #4012",
         snap_mode=SnapMode.AUTO,
-        grid=2.54,
+        grid=1.27,
+        local_symbol_libs=[lib_path],
     )
 
-    # =========================================================================
-    # Source connectors (left column)
-    # =========================================================================
-    print("\n1. Placing source connectors...")
+    # ---------------------------------------------------------------------
+    # 2. Place components and wire every pin to its net label
+    # ---------------------------------------------------------------------
+    print("\n2. Placing components + wiring all pins...")
+    total_wired = 0
+    for ref, symbol_name, value, footprint, x, y in COMPONENTS:
+        sym = sch.add_symbol(
+            f"{LIB_NAME}:{symbol_name}",
+            x=x,
+            y=y,
+            ref=ref,
+            value=value,
+            footprint=footprint,
+        )
+        wired = _wire_all_pins(sch, sym, PIN_NETS[ref])
+        total_wired += wired
+        print(f"   {ref} ({symbol_name}): {wired} pins wired at ({sym.x}, {sym.y})")
 
-    # USB-C source (J1) - large connector to source USB 2.0 and USB 3.0 pairs
-    j1 = sch.add_symbol(
-        "Connector_Generic:Conn_02x12_Counter_Clockwise",
-        x=50.8,
-        y=50.8,
-        ref="J1",
-        value="USB-C",
-        footprint="Connector_USB:USB_C_Receptacle_USB2.0",
-    )
-    print(f"   J1 (USB-C source): ({j1.x}, {j1.y})")
+    expected = sum(len(v) for v in PIN_NETS.values())
+    print(f"   Total: {total_wired}/{expected} pins wired")
+    if total_wired != expected:
+        raise RuntimeError(f"expected {expected} wired pins, got {total_wired}")
 
-    # Mini-PCIe edge connector (J3)
-    j3 = sch.add_symbol(
-        "Connector_Generic:Conn_01x12",
-        x=50.8,
-        y=139.7,
-        ref="J3",
-        value="MiniPCIe",
-        footprint="Connector_PCIE:PCIE_Mini_Edge",
-    )
-    print(f"   J3 (Mini-PCIe source): ({j3.x}, {j3.y})")
-
-    # FFC connector (J4)
-    j4 = sch.add_symbol(
-        "Connector_Generic:Conn_01x04",
-        x=50.8,
-        y=190.5,
-        ref="J4",
-        value="FFC4",
-        footprint="Connector_FFC:FFC_4P_0.5mm",
-    )
-    print(f"   J4 (FFC source): ({j4.x}, {j4.y})")
-
-    # =========================================================================
-    # Sink ICs (right column)
-    # =========================================================================
-    print("\n2. Placing sink ICs...")
-
-    u1 = sch.add_symbol(
-        "Connector_Generic:Conn_02x16_Counter_Clockwise",
-        x=152.4,
-        y=50.8,
-        ref="U1",
-        value="QFN32_USB2",
-        footprint="Package_DFN_QFN:QFN-32-1EP_5x5mm_P0.5mm",
-    )
-    print(f"   U1 (QFN-32 USB 2.0 sink): ({u1.x}, {u1.y})")
-
-    u2 = sch.add_symbol(
-        "Connector_Generic:Conn_02x16_Counter_Clockwise",
-        x=152.4,
-        y=101.6,
-        ref="U2",
-        value="BGA49_USB3",
-        footprint="Package_BGA:BGA-49_5.0x5.0mm_Layout7x7_P0.5mm",
-    )
-    print(f"   U2 (BGA-49 USB 3.0 sink): ({u2.x}, {u2.y})")
-
-    u3 = sch.add_symbol(
-        "Connector_Generic:Conn_02x16_Counter_Clockwise",
-        x=152.4,
-        y=152.4,
-        ref="U3",
-        value="QFP48_PCIe",
-        footprint="Package_QFP:LQFP-48_7x7mm_P0.5mm",
-    )
-    print(f"   U3 (QFP-48 PCIe sink): ({u3.x}, {u3.y})")
-
-    u4 = sch.add_symbol(
-        "Connector_Generic:Conn_02x12_Counter_Clockwise",
-        x=152.4,
-        y=203.2,
-        ref="U4",
-        value="QFN24_MIPI",
-        footprint="Package_DFN_QFN:QFN-24-1EP_4x4mm_P0.5mm",
-    )
-    print(f"   U4 (QFN-24 MIPI sink): ({u4.x}, {u4.y})")
-
-    # =========================================================================
-    # Power flags
-    # =========================================================================
+    # ---------------------------------------------------------------------
+    # 3. Power flags (ERC: mark rails as externally driven)
+    # ---------------------------------------------------------------------
     print("\n3. Power symbols + PWR_FLAG...")
-
     rails = [
         ("VBUS_USB", 7.62),
         ("+3V3", 17.78),
         ("+1V8", 27.94),
         ("+1V2", 38.1),
-        ("GND", 226.06),
+        ("GND", 297.18),
     ]
     for name, y in rails:
-        pwr_x = 25.4
+        pwr_x = 12.7
         sch.add_global_label(name, pwr_x, y, shape="input", rotation=0, snap=False)
         sch.add_pwr_flag(pwr_x, y)
 
-    # =========================================================================
-    # Pair-by-pair global label emission (the schematic-side "nets")
-    # =========================================================================
-    print("\n4. Differential pair declarations (global labels)...")
-
-    # We don't try to wire each connector pin to its exact partner; the
-    # PCB-side net assignment carries the connectivity.  Instead we emit
-    # one labelled wire stub per net, grouped by protocol, so the
-    # schematic file contains every diff-pair net by name.  This makes
-    # the schematic queryable for "does this design exercise the MIPI
-    # CLK pair?" and similar audits.
-    #
-    # Labels are arranged in a column on the right (x=190.5) for
-    # readability.  ERC will report unconnected pins on U1-U4 / J1-J4
-    # because we don't wire each pin --- that's accepted, since this is
-    # a routing scaffold not a wiring-correct device schematic.
-    label_x = 190.5
-    pairs = [
-        ("USB2_D+", "USB2_D-"),
-        ("USB3_TX1+", "USB3_TX1-"),
-        ("USB3_RX1+", "USB3_RX1-"),
-        ("USB3_TX2+", "USB3_TX2-"),
-        ("USB3_RX2+", "USB3_RX2-"),
-        ("PCIE_TX+", "PCIE_TX-"),
-        ("PCIE_RX+", "PCIE_RX-"),
-        ("MIPI_CLK+", "MIPI_CLK-"),
-        ("MIPI_D0+", "MIPI_D0-"),
-    ]
-    label_y = 50.8
-    for p_name, n_name in pairs:
-        sch.add_global_label(
-            p_name, label_x, label_y, shape="bidirectional", rotation=0, snap=False
-        )
-        sch.add_global_label(
-            n_name, label_x, label_y + 5.08, shape="bidirectional", rotation=0, snap=False
-        )
-        label_y += 12.7
-
-    # Single-ended sideband
-    sideband = ["USB_CC1", "USB_CC2", "MIPI_RST"]
-    for name in sideband:
-        sch.add_global_label(name, label_x, label_y, shape="bidirectional", rotation=0, snap=False)
-        label_y += 5.08
-
-    print(f"   Emitted {len(pairs) * 2 + len(sideband)} signal labels")
-
-    # =========================================================================
-    # Write
-    # =========================================================================
-    print("\n5. Writing schematic...")
-    output_path.parent.mkdir(parents=True, exist_ok=True)
+    # ---------------------------------------------------------------------
+    # 4. Write
+    # ---------------------------------------------------------------------
+    print("\n4. Writing schematic...")
     sch.write(output_path)
     print(f"   Schematic: {output_path}")
 

--- a/boards/06-diffpair-test/output/diffpair_lvs.kicad_sym
+++ b/boards/06-diffpair-test/output/diffpair_lvs.kicad_sym
@@ -1,0 +1,4073 @@
+(kicad_symbol_lib
+	(version 20231120)
+	(generator "kicad_tools")
+	(generator_version "1.0")
+	(symbol "USBC_SRC"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "U"
+			(at 0 19.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "USBC_SRC"
+			(at 0 -19.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Connector_USB:USB_C_Receptacle_USB2.0"
+			(at 0 -21.59 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 -24.13 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 0 -26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "USBC_SRC_0_1"
+			(rectangle
+				(start -7.62 16.51)
+				(end 7.62 -16.51)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+		)
+		(symbol "USBC_SRC_1_1"
+			(pin passive line
+				(at -10.16 15.24 0)
+				(length 2.54)
+				(name "A1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -10.16 12.70 0)
+				(length 2.54)
+				(name "A2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -10.16 10.16 0)
+				(length 2.54)
+				(name "A3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -10.16 7.62 0)
+				(length 2.54)
+				(name "A4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -10.16 5.08 0)
+				(length 2.54)
+				(name "A5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -10.16 2.54 0)
+				(length 2.54)
+				(name "A6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -10.16 0.00 0)
+				(length 2.54)
+				(name "A7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -10.16 -2.54 0)
+				(length 2.54)
+				(name "A8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -10.16 -5.08 0)
+				(length 2.54)
+				(name "A9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -10.16 -7.62 0)
+				(length 2.54)
+				(name "A10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -10.16 -10.16 0)
+				(length 2.54)
+				(name "A11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -10.16 -12.70 0)
+				(length 2.54)
+				(name "A12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -10.16 -15.24 0)
+				(length 2.54)
+				(name "B1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 10.16 15.24 180)
+				(length 2.54)
+				(name "B2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 10.16 12.70 180)
+				(length 2.54)
+				(name "B3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 10.16 10.16 180)
+				(length 2.54)
+				(name "B4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 10.16 7.62 180)
+				(length 2.54)
+				(name "B5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 10.16 5.08 180)
+				(length 2.54)
+				(name "B6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 10.16 2.54 180)
+				(length 2.54)
+				(name "B7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 10.16 0.00 180)
+				(length 2.54)
+				(name "B8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 10.16 -2.54 180)
+				(length 2.54)
+				(name "B9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 10.16 -5.08 180)
+				(length 2.54)
+				(name "B10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 10.16 -7.62 180)
+				(length 2.54)
+				(name "B11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 10.16 -10.16 180)
+				(length 2.54)
+				(name "B12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 10.16 -12.70 180)
+				(length 2.54)
+				(name "S1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "S1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 10.16 -15.24 180)
+				(length 2.54)
+				(name "S2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "S2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+	)
+	(symbol "MINIPCIE_SRC"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "U"
+			(at 0 10.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "MINIPCIE_SRC"
+			(at 0 -10.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Connector_PCIE:PCIE_Mini_Edge"
+			(at 0 -12.70 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 -15.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 0 -17.78 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "MINIPCIE_SRC_0_1"
+			(rectangle
+				(start -6.35 7.62)
+				(end 6.35 -7.62)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+		)
+		(symbol "MINIPCIE_SRC_1_1"
+			(pin passive line
+				(at -8.89 6.35 0)
+				(length 2.54)
+				(name "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 3.81 0)
+				(length 2.54)
+				(name "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 1.27 0)
+				(length 2.54)
+				(name "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -1.27 0)
+				(length 2.54)
+				(name "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -3.81 0)
+				(length 2.54)
+				(name "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -6.35 0)
+				(length 2.54)
+				(name "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 6.35 180)
+				(length 2.54)
+				(name "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 3.81 180)
+				(length 2.54)
+				(name "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 1.27 180)
+				(length 2.54)
+				(name "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -1.27 180)
+				(length 2.54)
+				(name "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -3.81 180)
+				(length 2.54)
+				(name "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -6.35 180)
+				(length 2.54)
+				(name "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+	)
+	(symbol "FFC_SRC"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "U"
+			(at 0 7.62 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "FFC_SRC"
+			(at 0 -7.62 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Connector_FFC:FFC_4P_0.5mm"
+			(at 0 -10.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 -12.70 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 0 -15.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "FFC_SRC_0_1"
+			(rectangle
+				(start -7.62 5.08)
+				(end 7.62 -5.08)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+		)
+		(symbol "FFC_SRC_1_1"
+			(pin passive line
+				(at -10.16 3.81 0)
+				(length 2.54)
+				(name "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -10.16 1.27 0)
+				(length 2.54)
+				(name "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -10.16 -1.27 0)
+				(length 2.54)
+				(name "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -10.16 -3.81 0)
+				(length 2.54)
+				(name "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 10.16 3.81 180)
+				(length 2.54)
+				(name "M1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "M1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 10.16 1.27 180)
+				(length 2.54)
+				(name "M2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "M2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 10.16 -1.27 180)
+				(length 2.54)
+				(name "RST"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "RST"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+	)
+	(symbol "QFN32_USB2"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "U"
+			(at 0 22.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "QFN32_USB2"
+			(at 0 -22.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Package_DFN_QFN:QFN-32-1EP_5x5mm_P0.5mm"
+			(at 0 -25.40 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 -27.94 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 0 -30.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "QFN32_USB2_0_1"
+			(rectangle
+				(start -6.35 20.32)
+				(end 6.35 -20.32)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+		)
+		(symbol "QFN32_USB2_1_1"
+			(pin passive line
+				(at -8.89 19.05 0)
+				(length 2.54)
+				(name "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 16.51 0)
+				(length 2.54)
+				(name "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 13.97 0)
+				(length 2.54)
+				(name "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 11.43 0)
+				(length 2.54)
+				(name "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 8.89 0)
+				(length 2.54)
+				(name "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 6.35 0)
+				(length 2.54)
+				(name "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 3.81 0)
+				(length 2.54)
+				(name "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 1.27 0)
+				(length 2.54)
+				(name "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -1.27 0)
+				(length 2.54)
+				(name "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -3.81 0)
+				(length 2.54)
+				(name "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -6.35 0)
+				(length 2.54)
+				(name "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -8.89 0)
+				(length 2.54)
+				(name "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -11.43 0)
+				(length 2.54)
+				(name "13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -13.97 0)
+				(length 2.54)
+				(name "14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -16.51 0)
+				(length 2.54)
+				(name "15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -19.05 0)
+				(length 2.54)
+				(name "16"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "16"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 19.05 180)
+				(length 2.54)
+				(name "17"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "17"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 16.51 180)
+				(length 2.54)
+				(name "18"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "18"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 13.97 180)
+				(length 2.54)
+				(name "19"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "19"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 11.43 180)
+				(length 2.54)
+				(name "20"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "20"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 8.89 180)
+				(length 2.54)
+				(name "21"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "21"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 6.35 180)
+				(length 2.54)
+				(name "22"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "22"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 3.81 180)
+				(length 2.54)
+				(name "23"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "23"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 1.27 180)
+				(length 2.54)
+				(name "24"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "24"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -1.27 180)
+				(length 2.54)
+				(name "25"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "25"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -3.81 180)
+				(length 2.54)
+				(name "26"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "26"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -6.35 180)
+				(length 2.54)
+				(name "27"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "27"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -8.89 180)
+				(length 2.54)
+				(name "28"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "28"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -11.43 180)
+				(length 2.54)
+				(name "29"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "29"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -13.97 180)
+				(length 2.54)
+				(name "30"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "30"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -16.51 180)
+				(length 2.54)
+				(name "31"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "31"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -19.05 180)
+				(length 2.54)
+				(name "32"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "32"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+	)
+	(symbol "BGA49_USB3"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "U"
+			(at 0 34.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "BGA49_USB3"
+			(at 0 -34.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Package_BGA:BGA-49_5.0x5.0mm_Layout7x7_P0.5mm"
+			(at 0 -36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 -39.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 0 -41.91 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "BGA49_USB3_0_1"
+			(rectangle
+				(start -6.35 31.75)
+				(end 6.35 -31.75)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+		)
+		(symbol "BGA49_USB3_1_1"
+			(pin passive line
+				(at -8.89 30.48 0)
+				(length 2.54)
+				(name "A1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 27.94 0)
+				(length 2.54)
+				(name "A2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 25.40 0)
+				(length 2.54)
+				(name "A3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 22.86 0)
+				(length 2.54)
+				(name "A4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 20.32 0)
+				(length 2.54)
+				(name "A5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 17.78 0)
+				(length 2.54)
+				(name "A6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 15.24 0)
+				(length 2.54)
+				(name "A7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 12.70 0)
+				(length 2.54)
+				(name "B1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 10.16 0)
+				(length 2.54)
+				(name "B2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 7.62 0)
+				(length 2.54)
+				(name "B3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 5.08 0)
+				(length 2.54)
+				(name "B4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 2.54 0)
+				(length 2.54)
+				(name "B5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 0.00 0)
+				(length 2.54)
+				(name "B6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -2.54 0)
+				(length 2.54)
+				(name "B7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -5.08 0)
+				(length 2.54)
+				(name "C1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "C1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -7.62 0)
+				(length 2.54)
+				(name "C2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "C2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -10.16 0)
+				(length 2.54)
+				(name "C3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "C3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -12.70 0)
+				(length 2.54)
+				(name "C4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "C4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -15.24 0)
+				(length 2.54)
+				(name "C5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "C5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -17.78 0)
+				(length 2.54)
+				(name "C6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "C6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -20.32 0)
+				(length 2.54)
+				(name "C7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "C7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -22.86 0)
+				(length 2.54)
+				(name "D1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "D1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -25.40 0)
+				(length 2.54)
+				(name "D2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "D2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -27.94 0)
+				(length 2.54)
+				(name "D3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "D3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -30.48 0)
+				(length 2.54)
+				(name "D4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "D4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 30.48 180)
+				(length 2.54)
+				(name "D5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "D5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 27.94 180)
+				(length 2.54)
+				(name "D6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "D6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 25.40 180)
+				(length 2.54)
+				(name "D7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "D7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 22.86 180)
+				(length 2.54)
+				(name "E1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "E1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 20.32 180)
+				(length 2.54)
+				(name "E2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "E2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 17.78 180)
+				(length 2.54)
+				(name "E3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "E3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 15.24 180)
+				(length 2.54)
+				(name "E4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "E4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 12.70 180)
+				(length 2.54)
+				(name "E5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "E5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 10.16 180)
+				(length 2.54)
+				(name "E6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "E6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 7.62 180)
+				(length 2.54)
+				(name "E7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "E7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 5.08 180)
+				(length 2.54)
+				(name "F1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "F1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 2.54 180)
+				(length 2.54)
+				(name "F2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "F2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 0.00 180)
+				(length 2.54)
+				(name "F3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "F3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -2.54 180)
+				(length 2.54)
+				(name "F4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "F4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -5.08 180)
+				(length 2.54)
+				(name "F5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "F5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -7.62 180)
+				(length 2.54)
+				(name "F6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "F6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -10.16 180)
+				(length 2.54)
+				(name "F7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "F7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -12.70 180)
+				(length 2.54)
+				(name "G1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "G1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -15.24 180)
+				(length 2.54)
+				(name "G2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "G2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -17.78 180)
+				(length 2.54)
+				(name "G3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "G3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -20.32 180)
+				(length 2.54)
+				(name "G4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "G4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -22.86 180)
+				(length 2.54)
+				(name "G5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "G5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -25.40 180)
+				(length 2.54)
+				(name "G6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "G6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -27.94 180)
+				(length 2.54)
+				(name "G7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "G7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+	)
+	(symbol "QFP48_PCIE"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "U"
+			(at 0 33.02 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "QFP48_PCIE"
+			(at 0 -33.02 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Package_QFP:LQFP-48_7x7mm_P0.5mm"
+			(at 0 -35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 -38.10 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 0 -40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "QFP48_PCIE_0_1"
+			(rectangle
+				(start -6.35 30.48)
+				(end 6.35 -30.48)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+		)
+		(symbol "QFP48_PCIE_1_1"
+			(pin passive line
+				(at -8.89 29.21 0)
+				(length 2.54)
+				(name "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 26.67 0)
+				(length 2.54)
+				(name "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 24.13 0)
+				(length 2.54)
+				(name "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 21.59 0)
+				(length 2.54)
+				(name "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 19.05 0)
+				(length 2.54)
+				(name "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 16.51 0)
+				(length 2.54)
+				(name "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 13.97 0)
+				(length 2.54)
+				(name "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 11.43 0)
+				(length 2.54)
+				(name "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 8.89 0)
+				(length 2.54)
+				(name "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 6.35 0)
+				(length 2.54)
+				(name "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 3.81 0)
+				(length 2.54)
+				(name "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 1.27 0)
+				(length 2.54)
+				(name "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -1.27 0)
+				(length 2.54)
+				(name "13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -3.81 0)
+				(length 2.54)
+				(name "14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -6.35 0)
+				(length 2.54)
+				(name "15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -8.89 0)
+				(length 2.54)
+				(name "16"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "16"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -11.43 0)
+				(length 2.54)
+				(name "17"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "17"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -13.97 0)
+				(length 2.54)
+				(name "18"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "18"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -16.51 0)
+				(length 2.54)
+				(name "19"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "19"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -19.05 0)
+				(length 2.54)
+				(name "20"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "20"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -21.59 0)
+				(length 2.54)
+				(name "21"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "21"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -24.13 0)
+				(length 2.54)
+				(name "22"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "22"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -26.67 0)
+				(length 2.54)
+				(name "23"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "23"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -29.21 0)
+				(length 2.54)
+				(name "24"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "24"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 29.21 180)
+				(length 2.54)
+				(name "25"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "25"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 26.67 180)
+				(length 2.54)
+				(name "26"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "26"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 24.13 180)
+				(length 2.54)
+				(name "27"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "27"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 21.59 180)
+				(length 2.54)
+				(name "28"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "28"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 19.05 180)
+				(length 2.54)
+				(name "29"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "29"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 16.51 180)
+				(length 2.54)
+				(name "30"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "30"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 13.97 180)
+				(length 2.54)
+				(name "31"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "31"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 11.43 180)
+				(length 2.54)
+				(name "32"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "32"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 8.89 180)
+				(length 2.54)
+				(name "33"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "33"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 6.35 180)
+				(length 2.54)
+				(name "34"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "34"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 3.81 180)
+				(length 2.54)
+				(name "35"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "35"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 1.27 180)
+				(length 2.54)
+				(name "36"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "36"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -1.27 180)
+				(length 2.54)
+				(name "37"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "37"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -3.81 180)
+				(length 2.54)
+				(name "38"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "38"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -6.35 180)
+				(length 2.54)
+				(name "39"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "39"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -8.89 180)
+				(length 2.54)
+				(name "40"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "40"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -11.43 180)
+				(length 2.54)
+				(name "41"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "41"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -13.97 180)
+				(length 2.54)
+				(name "42"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "42"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -16.51 180)
+				(length 2.54)
+				(name "43"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "43"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -19.05 180)
+				(length 2.54)
+				(name "44"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "44"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -21.59 180)
+				(length 2.54)
+				(name "45"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "45"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -24.13 180)
+				(length 2.54)
+				(name "46"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "46"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -26.67 180)
+				(length 2.54)
+				(name "47"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "47"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -29.21 180)
+				(length 2.54)
+				(name "48"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "48"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+	)
+	(symbol "QFN24_MIPI"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "U"
+			(at 0 17.78 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "QFN24_MIPI"
+			(at 0 -17.78 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Package_DFN_QFN:QFN-24-1EP_4x4mm_P0.5mm"
+			(at 0 -20.32 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 -22.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 0 -25.40 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "QFN24_MIPI_0_1"
+			(rectangle
+				(start -6.35 15.24)
+				(end 6.35 -15.24)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+		)
+		(symbol "QFN24_MIPI_1_1"
+			(pin passive line
+				(at -8.89 13.97 0)
+				(length 2.54)
+				(name "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 11.43 0)
+				(length 2.54)
+				(name "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 8.89 0)
+				(length 2.54)
+				(name "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 6.35 0)
+				(length 2.54)
+				(name "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 3.81 0)
+				(length 2.54)
+				(name "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 1.27 0)
+				(length 2.54)
+				(name "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -1.27 0)
+				(length 2.54)
+				(name "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -3.81 0)
+				(length 2.54)
+				(name "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -6.35 0)
+				(length 2.54)
+				(name "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -8.89 0)
+				(length 2.54)
+				(name "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -11.43 0)
+				(length 2.54)
+				(name "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -13.97 0)
+				(length 2.54)
+				(name "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 13.97 180)
+				(length 2.54)
+				(name "13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 11.43 180)
+				(length 2.54)
+				(name "14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 8.89 180)
+				(length 2.54)
+				(name "15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 6.35 180)
+				(length 2.54)
+				(name "16"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "16"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 3.81 180)
+				(length 2.54)
+				(name "17"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "17"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 1.27 180)
+				(length 2.54)
+				(name "18"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "18"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -1.27 180)
+				(length 2.54)
+				(name "19"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "19"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -3.81 180)
+				(length 2.54)
+				(name "20"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "20"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -6.35 180)
+				(length 2.54)
+				(name "21"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "21"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -8.89 180)
+				(length 2.54)
+				(name "22"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "22"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -11.43 180)
+				(length 2.54)
+				(name "23"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "23"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -13.97 180)
+				(length 2.54)
+				(name "24"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "24"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+	)
+)

--- a/boards/06-diffpair-test/output/diffpair_test.kicad_sch
+++ b/boards/06-diffpair-test/output/diffpair_test.kicad_sch
@@ -2,101 +2,75 @@
 	(version 20231120)
 	(generator "eeschema")
 	(generator_version "9.0")
-	(uuid "c5c992a2-d28d-430b-b400-e92ec2ef4b19")
-	(paper "A3")
+	(uuid "3c6e0a49-39a7-454c-8046-2b8048737b80")
+	(paper "A2")
 	(title_block
 		(title "Differential Pair Test Board")
 		(date "2026-05")
-		(rev "A")
+		(rev "B")
 		(company "kicad-tools")
 		(comment 1 "Multi-protocol HSDI regression testbench")
-		(comment 2 "Epic #2556 Phase 4L (issue #2658)")
+		(comment 2 "Epic #2556 Phase 4L (issue #2658); wired netlist #4012")
 	)
 	(lib_symbols
-		(symbol "Connector_Generic:Conn_02x12_Counter_Clockwise"
-			(pin_names (offset 1.016) (hide yes))
+		(symbol "diffpair_lvs:USBC_SRC"
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
-			(in_pos_files yes)
-			(duplicate_pin_numbers_are_jumpers no)
-			(property "Reference" "J"
-				(at 1.27 15.24 0)
-				(show_name no)
-				(do_not_autoplace no)
+			(property "Reference" "U"
+				(at 0 19.05 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
 				)
 			)
-			(property "Value" "Conn_02x12_Counter_Clockwise"
-				(at 1.27 -17.78 0)
-				(show_name no)
-				(do_not_autoplace no)
+			(property "Value" "USBC_SRC"
+				(at 0 -19.05 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
 				)
 			)
-			(property "Footprint" ""
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
+			(property "Footprint" "Connector_USB:USB_C_Receptacle_USB2.0"
+				(at 0 -21.59 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
 			(property "Datasheet" ""
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
+				(at 0 -24.13 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
-			(property "Description" "Generic connector, double row, 02x12, counter clockwise pin numbering scheme (similar to DIP package numbering), script generated (kicad-library-utils/schlib/autogen/connector/)"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
+			(property "Description" ""
+				(at 0 -26.67 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
-			(property "ki_keywords" "connector"
+			(property "ki_keywords" ""
 				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
-			(property "ki_fp_filters" "Connector*:*_2x??_*"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(symbol "Conn_02x12_Counter_Clockwise_1_1"
-				(rectangle (start -1.27 13.97) (end 3.81 -16.51)
+			(symbol "USBC_SRC_0_1"
+				(rectangle (start -7.62 16.51) (end 7.62 -16.51)
 					(stroke
 						(width 0.254)
 						(type default)
@@ -104,207 +78,17 @@
 					(fill (type background)
 					)
 				)
-				(rectangle (start -1.27 12.827) (end 0 12.573)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 10.287) (end 0 10.033)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 7.747) (end 0 7.493)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 5.207) (end 0 4.953)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 2.667) (end 0 2.413)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 0.127) (end 0 -0.127)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -2.413) (end 0 -2.667)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -4.953) (end 0 -5.207)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -7.493) (end 0 -7.747)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -10.033) (end 0 -10.287)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -12.573) (end 0 -12.827)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -15.113) (end 0 -15.367)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 12.827) (end 2.54 12.573)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 10.287) (end 2.54 10.033)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 7.747) (end 2.54 7.493)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 5.207) (end 2.54 4.953)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 2.667) (end 2.54 2.413)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 0.127) (end 2.54 -0.127)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -2.413) (end 2.54 -2.667)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -4.953) (end 2.54 -5.207)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -7.493) (end 2.54 -7.747)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -10.033) (end 2.54 -10.287)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -12.573) (end 2.54 -12.827)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -15.113) (end 2.54 -15.367)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(pin passive line (at -5.08 12.7 0) (length 3.81)
-					(name "Pin_1"
+			)
+			(symbol "USBC_SRC_1_1"
+				(pin passive line (at -10.16 15.24 0) (length 2.54)
+					(name "A1"
 						(effects
 							(font
 								(size 1.27 1.27)
 							)
 						)
 					)
-					(number "1"
+					(number "A1"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -312,31 +96,15 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 10.16 0) (length 3.81)
-					(name "Pin_2"
+				(pin passive line (at -10.16 12.70 0) (length 2.54)
+					(name "A2"
 						(effects
 							(font
 								(size 1.27 1.27)
 							)
 						)
 					)
-					(number "2"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at -5.08 7.62 0) (length 3.81)
-					(name "Pin_3"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "3"
+					(number "A2"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -344,31 +112,15 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 5.08 0) (length 3.81)
-					(name "Pin_4"
+				(pin passive line (at -10.16 10.16 0) (length 2.54)
+					(name "A3"
 						(effects
 							(font
 								(size 1.27 1.27)
 							)
 						)
 					)
-					(number "4"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at -5.08 2.54 0) (length 3.81)
-					(name "Pin_5"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "5"
+					(number "A3"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -376,31 +128,15 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 0 0) (length 3.81)
-					(name "Pin_6"
+				(pin passive line (at -10.16 7.62 0) (length 2.54)
+					(name "A4"
 						(effects
 							(font
 								(size 1.27 1.27)
 							)
 						)
 					)
-					(number "6"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at -5.08 -2.54 0) (length 3.81)
-					(name "Pin_7"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "7"
+					(number "A4"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -408,31 +144,15 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -5.08 0) (length 3.81)
-					(name "Pin_8"
+				(pin passive line (at -10.16 5.08 0) (length 2.54)
+					(name "A5"
 						(effects
 							(font
 								(size 1.27 1.27)
 							)
 						)
 					)
-					(number "8"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at -5.08 -7.62 0) (length 3.81)
-					(name "Pin_9"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "9"
+					(number "A5"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -440,31 +160,15 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -10.16 0) (length 3.81)
-					(name "Pin_10"
+				(pin passive line (at -10.16 2.54 0) (length 2.54)
+					(name "A6"
 						(effects
 							(font
 								(size 1.27 1.27)
 							)
 						)
 					)
-					(number "10"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at -5.08 -12.7 0) (length 3.81)
-					(name "Pin_11"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "11"
+					(number "A6"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -472,31 +176,15 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -15.24 0) (length 3.81)
-					(name "Pin_12"
+				(pin passive line (at -10.16 0.00 0) (length 2.54)
+					(name "A7"
 						(effects
 							(font
 								(size 1.27 1.27)
 							)
 						)
 					)
-					(number "12"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at 7.62 -15.24 180) (length 3.81)
-					(name "Pin_13"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "13"
+					(number "A7"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -504,31 +192,15 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -12.7 180) (length 3.81)
-					(name "Pin_14"
+				(pin passive line (at -10.16 -2.54 0) (length 2.54)
+					(name "A8"
 						(effects
 							(font
 								(size 1.27 1.27)
 							)
 						)
 					)
-					(number "14"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at 7.62 -10.16 180) (length 3.81)
-					(name "Pin_15"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "15"
+					(number "A8"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -536,31 +208,15 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -7.62 180) (length 3.81)
-					(name "Pin_16"
+				(pin passive line (at -10.16 -5.08 0) (length 2.54)
+					(name "A9"
 						(effects
 							(font
 								(size 1.27 1.27)
 							)
 						)
 					)
-					(number "16"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at 7.62 -5.08 180) (length 3.81)
-					(name "Pin_17"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "17"
+					(number "A9"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -568,31 +224,15 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -2.54 180) (length 3.81)
-					(name "Pin_18"
+				(pin passive line (at -10.16 -7.62 0) (length 2.54)
+					(name "A10"
 						(effects
 							(font
 								(size 1.27 1.27)
 							)
 						)
 					)
-					(number "18"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at 7.62 0 180) (length 3.81)
-					(name "Pin_19"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "19"
+					(number "A10"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -600,31 +240,15 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 2.54 180) (length 3.81)
-					(name "Pin_20"
+				(pin passive line (at -10.16 -10.16 0) (length 2.54)
+					(name "A11"
 						(effects
 							(font
 								(size 1.27 1.27)
 							)
 						)
 					)
-					(number "20"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at 7.62 5.08 180) (length 3.81)
-					(name "Pin_21"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "21"
+					(number "A11"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -632,31 +256,15 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 7.62 180) (length 3.81)
-					(name "Pin_22"
+				(pin passive line (at -10.16 -12.70 0) (length 2.54)
+					(name "A12"
 						(effects
 							(font
 								(size 1.27 1.27)
 							)
 						)
 					)
-					(number "22"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at 7.62 10.16 180) (length 3.81)
-					(name "Pin_23"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "23"
+					(number "A12"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -664,15 +272,223 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 12.7 180) (length 3.81)
-					(name "Pin_24"
+				(pin passive line (at -10.16 -15.24 0) (length 2.54)
+					(name "B1"
 						(effects
 							(font
 								(size 1.27 1.27)
 							)
 						)
 					)
-					(number "24"
+					(number "B1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 10.16 15.24 180) (length 2.54)
+					(name "B2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 10.16 12.70 180) (length 2.54)
+					(name "B3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 10.16 10.16 180) (length 2.54)
+					(name "B4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 10.16 7.62 180) (length 2.54)
+					(name "B5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 10.16 5.08 180) (length 2.54)
+					(name "B6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 10.16 2.54 180) (length 2.54)
+					(name "B7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 10.16 0.00 180) (length 2.54)
+					(name "B8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 10.16 -2.54 180) (length 2.54)
+					(name "B9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 10.16 -5.08 180) (length 2.54)
+					(name "B10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 10.16 -7.62 180) (length 2.54)
+					(name "B11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 10.16 -10.16 180) (length 2.54)
+					(name "B12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 10.16 -12.70 180) (length 2.54)
+					(name "S1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "S1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 10.16 -15.24 180) (length 2.54)
+					(name "S2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "S2"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -681,92 +497,65 @@
 					)
 				)
 			)
-			(embedded_fonts no)
 		)
-		(symbol "Connector_Generic:Conn_01x12"
-			(pin_names (offset 1.016) (hide yes))
+		(symbol "diffpair_lvs:MINIPCIE_SRC"
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
-			(in_pos_files yes)
-			(duplicate_pin_numbers_are_jumpers no)
-			(property "Reference" "J"
-				(at 0 15.24 0)
-				(show_name no)
-				(do_not_autoplace no)
+			(property "Reference" "U"
+				(at 0 10.16 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
 				)
 			)
-			(property "Value" "Conn_01x12"
+			(property "Value" "MINIPCIE_SRC"
+				(at 0 -10.16 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "Connector_PCIE:PCIE_Mini_Edge"
+				(at 0 -12.70 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 -15.24 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" ""
 				(at 0 -17.78 0)
-				(show_name no)
-				(do_not_autoplace no)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
-			(property "Footprint" ""
+			(property "ki_keywords" ""
 				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
-			(property "Datasheet" ""
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "Description" "Generic connector, single row, 01x12, script generated (kicad-library-utils/schlib/autogen/connector/)"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "ki_keywords" "connector"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "ki_fp_filters" "Connector*:*_1x??_*"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(symbol "Conn_01x12_1_1"
-				(rectangle (start -1.27 13.97) (end 1.27 -16.51)
+			(symbol "MINIPCIE_SRC_0_1"
+				(rectangle (start -6.35 7.62) (end 6.35 -7.62)
 					(stroke
 						(width 0.254)
 						(type default)
@@ -774,104 +563,10 @@
 					(fill (type background)
 					)
 				)
-				(rectangle (start -1.27 12.827) (end 0 12.573)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 10.287) (end 0 10.033)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 7.747) (end 0 7.493)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 5.207) (end 0 4.953)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 2.667) (end 0 2.413)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 0.127) (end 0 -0.127)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -2.413) (end 0 -2.667)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -4.953) (end 0 -5.207)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -7.493) (end 0 -7.747)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -10.033) (end 0 -10.287)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -12.573) (end 0 -12.827)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -15.113) (end 0 -15.367)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(pin passive line (at -5.08 12.7 0) (length 3.81)
-					(name "Pin_1"
+			)
+			(symbol "MINIPCIE_SRC_1_1"
+				(pin passive line (at -8.89 6.35 0) (length 2.54)
+					(name "1"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -886,8 +581,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 10.16 0) (length 3.81)
-					(name "Pin_2"
+				(pin passive line (at -8.89 3.81 0) (length 2.54)
+					(name "2"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -902,8 +597,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 7.62 0) (length 3.81)
-					(name "Pin_3"
+				(pin passive line (at -8.89 1.27 0) (length 2.54)
+					(name "3"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -918,8 +613,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 5.08 0) (length 3.81)
-					(name "Pin_4"
+				(pin passive line (at -8.89 -1.27 0) (length 2.54)
+					(name "4"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -934,8 +629,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 2.54 0) (length 3.81)
-					(name "Pin_5"
+				(pin passive line (at -8.89 -3.81 0) (length 2.54)
+					(name "5"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -950,8 +645,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 0 0) (length 3.81)
-					(name "Pin_6"
+				(pin passive line (at -8.89 -6.35 0) (length 2.54)
+					(name "6"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -966,8 +661,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -2.54 0) (length 3.81)
-					(name "Pin_7"
+				(pin passive line (at 8.89 6.35 180) (length 2.54)
+					(name "7"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -982,8 +677,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -5.08 0) (length 3.81)
-					(name "Pin_8"
+				(pin passive line (at 8.89 3.81 180) (length 2.54)
+					(name "8"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -998,8 +693,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -7.62 0) (length 3.81)
-					(name "Pin_9"
+				(pin passive line (at 8.89 1.27 180) (length 2.54)
+					(name "9"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1014,8 +709,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -10.16 0) (length 3.81)
-					(name "Pin_10"
+				(pin passive line (at 8.89 -1.27 180) (length 2.54)
+					(name "10"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1030,8 +725,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -12.7 0) (length 3.81)
-					(name "Pin_11"
+				(pin passive line (at 8.89 -3.81 180) (length 2.54)
+					(name "11"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1046,8 +741,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -15.24 0) (length 3.81)
-					(name "Pin_12"
+				(pin passive line (at 8.89 -6.35 180) (length 2.54)
+					(name "12"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1063,92 +758,65 @@
 					)
 				)
 			)
-			(embedded_fonts no)
 		)
-		(symbol "Connector_Generic:Conn_01x04"
-			(pin_names (offset 1.016) (hide yes))
+		(symbol "diffpair_lvs:FFC_SRC"
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
-			(in_pos_files yes)
-			(duplicate_pin_numbers_are_jumpers no)
-			(property "Reference" "J"
-				(at 0 5.08 0)
-				(show_name no)
-				(do_not_autoplace no)
+			(property "Reference" "U"
+				(at 0 7.62 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
 				)
 			)
-			(property "Value" "Conn_01x04"
+			(property "Value" "FFC_SRC"
 				(at 0 -7.62 0)
-				(show_name no)
-				(do_not_autoplace no)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
 				)
 			)
-			(property "Footprint" ""
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
+			(property "Footprint" "Connector_FFC:FFC_4P_0.5mm"
+				(at 0 -10.16 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
 			(property "Datasheet" ""
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
+				(at 0 -12.70 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
-			(property "Description" "Generic connector, single row, 01x04, script generated (kicad-library-utils/schlib/autogen/connector/)"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
+			(property "Description" ""
+				(at 0 -15.24 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
-			(property "ki_keywords" "connector"
+			(property "ki_keywords" ""
 				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
-			(property "ki_fp_filters" "Connector*:*_1x??_*"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(symbol "Conn_01x04_1_1"
-				(rectangle (start -1.27 3.81) (end 1.27 -6.35)
+			(symbol "FFC_SRC_0_1"
+				(rectangle (start -7.62 5.08) (end 7.62 -5.08)
 					(stroke
 						(width 0.254)
 						(type default)
@@ -1156,40 +824,10 @@
 					(fill (type background)
 					)
 				)
-				(rectangle (start -1.27 2.667) (end 0 2.413)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 0.127) (end 0 -0.127)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -2.413) (end 0 -2.667)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -4.953) (end 0 -5.207)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(pin passive line (at -5.08 2.54 0) (length 3.81)
-					(name "Pin_1"
+			)
+			(symbol "FFC_SRC_1_1"
+				(pin passive line (at -10.16 3.81 0) (length 2.54)
+					(name "1"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1204,8 +842,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 0 0) (length 3.81)
-					(name "Pin_2"
+				(pin passive line (at -10.16 1.27 0) (length 2.54)
+					(name "2"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1220,8 +858,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -2.54 0) (length 3.81)
-					(name "Pin_3"
+				(pin passive line (at -10.16 -1.27 0) (length 2.54)
+					(name "3"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1236,8 +874,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -5.08 0) (length 3.81)
-					(name "Pin_4"
+				(pin passive line (at -10.16 -3.81 0) (length 2.54)
+					(name "4"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1252,93 +890,114 @@
 						)
 					)
 				)
+				(pin passive line (at 10.16 3.81 180) (length 2.54)
+					(name "M1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 10.16 1.27 180) (length 2.54)
+					(name "M2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 10.16 -1.27 180) (length 2.54)
+					(name "RST"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "RST"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
 			)
-			(embedded_fonts no)
 		)
-		(symbol "Connector_Generic:Conn_02x16_Counter_Clockwise"
-			(pin_names (offset 1.016) (hide yes))
+		(symbol "diffpair_lvs:QFN32_USB2"
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
-			(in_pos_files yes)
-			(duplicate_pin_numbers_are_jumpers no)
-			(property "Reference" "J"
-				(at 1.27 20.32 0)
-				(show_name no)
-				(do_not_autoplace no)
+			(property "Reference" "U"
+				(at 0 22.86 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
 				)
 			)
-			(property "Value" "Conn_02x16_Counter_Clockwise"
-				(at 1.27 -22.86 0)
-				(show_name no)
-				(do_not_autoplace no)
+			(property "Value" "QFN32_USB2"
+				(at 0 -22.86 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
 				)
 			)
-			(property "Footprint" ""
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
+			(property "Footprint" "Package_DFN_QFN:QFN-32-1EP_5x5mm_P0.5mm"
+				(at 0 -25.40 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
 			(property "Datasheet" ""
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
+				(at 0 -27.94 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
-			(property "Description" "Generic connector, double row, 02x16, counter clockwise pin numbering scheme (similar to DIP package numbering), script generated (kicad-library-utils/schlib/autogen/connector/)"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
+			(property "Description" ""
+				(at 0 -30.48 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
-			(property "ki_keywords" "connector"
+			(property "ki_keywords" ""
 				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
-			(property "ki_fp_filters" "Connector*:*_2x??_*"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(symbol "Conn_02x16_Counter_Clockwise_1_1"
-				(rectangle (start -1.27 19.05) (end 3.81 -21.59)
+			(symbol "QFN32_USB2_0_1"
+				(rectangle (start -6.35 20.32) (end 6.35 -20.32)
 					(stroke
 						(width 0.254)
 						(type default)
@@ -1346,264 +1005,10 @@
 					(fill (type background)
 					)
 				)
-				(rectangle (start -1.27 17.907) (end 0 17.653)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 15.367) (end 0 15.113)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 12.827) (end 0 12.573)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 10.287) (end 0 10.033)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 7.747) (end 0 7.493)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 5.207) (end 0 4.953)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 2.667) (end 0 2.413)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 0.127) (end 0 -0.127)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -2.413) (end 0 -2.667)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -4.953) (end 0 -5.207)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -7.493) (end 0 -7.747)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -10.033) (end 0 -10.287)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -12.573) (end 0 -12.827)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -15.113) (end 0 -15.367)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -17.653) (end 0 -17.907)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -20.193) (end 0 -20.447)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 17.907) (end 2.54 17.653)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 15.367) (end 2.54 15.113)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 12.827) (end 2.54 12.573)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 10.287) (end 2.54 10.033)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 7.747) (end 2.54 7.493)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 5.207) (end 2.54 4.953)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 2.667) (end 2.54 2.413)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 0.127) (end 2.54 -0.127)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -2.413) (end 2.54 -2.667)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -4.953) (end 2.54 -5.207)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -7.493) (end 2.54 -7.747)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -10.033) (end 2.54 -10.287)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -12.573) (end 2.54 -12.827)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -15.113) (end 2.54 -15.367)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -17.653) (end 2.54 -17.907)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -20.193) (end 2.54 -20.447)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(pin passive line (at -5.08 17.78 0) (length 3.81)
-					(name "Pin_1"
+			)
+			(symbol "QFN32_USB2_1_1"
+				(pin passive line (at -8.89 19.05 0) (length 2.54)
+					(name "1"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1618,8 +1023,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 15.24 0) (length 3.81)
-					(name "Pin_2"
+				(pin passive line (at -8.89 16.51 0) (length 2.54)
+					(name "2"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1634,8 +1039,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 12.7 0) (length 3.81)
-					(name "Pin_3"
+				(pin passive line (at -8.89 13.97 0) (length 2.54)
+					(name "3"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1650,8 +1055,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 10.16 0) (length 3.81)
-					(name "Pin_4"
+				(pin passive line (at -8.89 11.43 0) (length 2.54)
+					(name "4"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1666,8 +1071,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 7.62 0) (length 3.81)
-					(name "Pin_5"
+				(pin passive line (at -8.89 8.89 0) (length 2.54)
+					(name "5"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1682,8 +1087,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 5.08 0) (length 3.81)
-					(name "Pin_6"
+				(pin passive line (at -8.89 6.35 0) (length 2.54)
+					(name "6"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1698,8 +1103,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 2.54 0) (length 3.81)
-					(name "Pin_7"
+				(pin passive line (at -8.89 3.81 0) (length 2.54)
+					(name "7"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1714,8 +1119,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 0 0) (length 3.81)
-					(name "Pin_8"
+				(pin passive line (at -8.89 1.27 0) (length 2.54)
+					(name "8"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1730,8 +1135,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -2.54 0) (length 3.81)
-					(name "Pin_9"
+				(pin passive line (at -8.89 -1.27 0) (length 2.54)
+					(name "9"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1746,8 +1151,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -5.08 0) (length 3.81)
-					(name "Pin_10"
+				(pin passive line (at -8.89 -3.81 0) (length 2.54)
+					(name "10"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1762,8 +1167,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -7.62 0) (length 3.81)
-					(name "Pin_11"
+				(pin passive line (at -8.89 -6.35 0) (length 2.54)
+					(name "11"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1778,8 +1183,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -10.16 0) (length 3.81)
-					(name "Pin_12"
+				(pin passive line (at -8.89 -8.89 0) (length 2.54)
+					(name "12"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1794,8 +1199,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -12.7 0) (length 3.81)
-					(name "Pin_13"
+				(pin passive line (at -8.89 -11.43 0) (length 2.54)
+					(name "13"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1810,8 +1215,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -15.24 0) (length 3.81)
-					(name "Pin_14"
+				(pin passive line (at -8.89 -13.97 0) (length 2.54)
+					(name "14"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1826,8 +1231,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -17.78 0) (length 3.81)
-					(name "Pin_15"
+				(pin passive line (at -8.89 -16.51 0) (length 2.54)
+					(name "15"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1842,8 +1247,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -20.32 0) (length 3.81)
-					(name "Pin_16"
+				(pin passive line (at -8.89 -19.05 0) (length 2.54)
+					(name "16"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1858,8 +1263,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -20.32 180) (length 3.81)
-					(name "Pin_17"
+				(pin passive line (at 8.89 19.05 180) (length 2.54)
+					(name "17"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1874,8 +1279,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -17.78 180) (length 3.81)
-					(name "Pin_18"
+				(pin passive line (at 8.89 16.51 180) (length 2.54)
+					(name "18"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1890,8 +1295,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -15.24 180) (length 3.81)
-					(name "Pin_19"
+				(pin passive line (at 8.89 13.97 180) (length 2.54)
+					(name "19"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1906,8 +1311,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -12.7 180) (length 3.81)
-					(name "Pin_20"
+				(pin passive line (at 8.89 11.43 180) (length 2.54)
+					(name "20"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1922,8 +1327,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -10.16 180) (length 3.81)
-					(name "Pin_21"
+				(pin passive line (at 8.89 8.89 180) (length 2.54)
+					(name "21"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1938,8 +1343,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -7.62 180) (length 3.81)
-					(name "Pin_22"
+				(pin passive line (at 8.89 6.35 180) (length 2.54)
+					(name "22"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1954,8 +1359,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -5.08 180) (length 3.81)
-					(name "Pin_23"
+				(pin passive line (at 8.89 3.81 180) (length 2.54)
+					(name "23"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1970,8 +1375,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -2.54 180) (length 3.81)
-					(name "Pin_24"
+				(pin passive line (at 8.89 1.27 180) (length 2.54)
+					(name "24"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1986,8 +1391,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 0 180) (length 3.81)
-					(name "Pin_25"
+				(pin passive line (at 8.89 -1.27 180) (length 2.54)
+					(name "25"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2002,8 +1407,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 2.54 180) (length 3.81)
-					(name "Pin_26"
+				(pin passive line (at 8.89 -3.81 180) (length 2.54)
+					(name "26"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2018,8 +1423,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 5.08 180) (length 3.81)
-					(name "Pin_27"
+				(pin passive line (at 8.89 -6.35 180) (length 2.54)
+					(name "27"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2034,8 +1439,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 7.62 180) (length 3.81)
-					(name "Pin_28"
+				(pin passive line (at 8.89 -8.89 180) (length 2.54)
+					(name "28"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2050,8 +1455,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 10.16 180) (length 3.81)
-					(name "Pin_29"
+				(pin passive line (at 8.89 -11.43 180) (length 2.54)
+					(name "29"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2066,8 +1471,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 12.7 180) (length 3.81)
-					(name "Pin_30"
+				(pin passive line (at 8.89 -13.97 180) (length 2.54)
+					(name "30"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2082,8 +1487,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 15.24 180) (length 3.81)
-					(name "Pin_31"
+				(pin passive line (at 8.89 -16.51 180) (length 2.54)
+					(name "31"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2098,8 +1503,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 17.78 180) (length 3.81)
-					(name "Pin_32"
+				(pin passive line (at 8.89 -19.05 180) (length 2.54)
+					(name "32"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2115,7 +1520,2149 @@
 					)
 				)
 			)
-			(embedded_fonts no)
+		)
+		(symbol "diffpair_lvs:BGA49_USB3"
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "U"
+				(at 0 34.29 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "BGA49_USB3"
+				(at 0 -34.29 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "Package_BGA:BGA-49_5.0x5.0mm_Layout7x7_P0.5mm"
+				(at 0 -36.83 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 -39.37 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" ""
+				(at 0 -41.91 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "BGA49_USB3_0_1"
+				(rectangle (start -6.35 31.75) (end 6.35 -31.75)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill (type background)
+					)
+				)
+			)
+			(symbol "BGA49_USB3_1_1"
+				(pin passive line (at -8.89 30.48 0) (length 2.54)
+					(name "A1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 27.94 0) (length 2.54)
+					(name "A2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 25.40 0) (length 2.54)
+					(name "A3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 22.86 0) (length 2.54)
+					(name "A4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 20.32 0) (length 2.54)
+					(name "A5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 17.78 0) (length 2.54)
+					(name "A6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 15.24 0) (length 2.54)
+					(name "A7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 12.70 0) (length 2.54)
+					(name "B1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 10.16 0) (length 2.54)
+					(name "B2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 7.62 0) (length 2.54)
+					(name "B3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 5.08 0) (length 2.54)
+					(name "B4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 2.54 0) (length 2.54)
+					(name "B5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 0.00 0) (length 2.54)
+					(name "B6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -2.54 0) (length 2.54)
+					(name "B7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -5.08 0) (length 2.54)
+					(name "C1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -7.62 0) (length 2.54)
+					(name "C2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -10.16 0) (length 2.54)
+					(name "C3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -12.70 0) (length 2.54)
+					(name "C4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -15.24 0) (length 2.54)
+					(name "C5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -17.78 0) (length 2.54)
+					(name "C6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -20.32 0) (length 2.54)
+					(name "C7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -22.86 0) (length 2.54)
+					(name "D1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -25.40 0) (length 2.54)
+					(name "D2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -27.94 0) (length 2.54)
+					(name "D3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -30.48 0) (length 2.54)
+					(name "D4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 30.48 180) (length 2.54)
+					(name "D5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 27.94 180) (length 2.54)
+					(name "D6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 25.40 180) (length 2.54)
+					(name "D7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 22.86 180) (length 2.54)
+					(name "E1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 20.32 180) (length 2.54)
+					(name "E2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 17.78 180) (length 2.54)
+					(name "E3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 15.24 180) (length 2.54)
+					(name "E4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 12.70 180) (length 2.54)
+					(name "E5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 10.16 180) (length 2.54)
+					(name "E6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 7.62 180) (length 2.54)
+					(name "E7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 5.08 180) (length 2.54)
+					(name "F1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 2.54 180) (length 2.54)
+					(name "F2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 0.00 180) (length 2.54)
+					(name "F3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -2.54 180) (length 2.54)
+					(name "F4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -5.08 180) (length 2.54)
+					(name "F5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -7.62 180) (length 2.54)
+					(name "F6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -10.16 180) (length 2.54)
+					(name "F7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -12.70 180) (length 2.54)
+					(name "G1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -15.24 180) (length 2.54)
+					(name "G2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -17.78 180) (length 2.54)
+					(name "G3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -20.32 180) (length 2.54)
+					(name "G4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -22.86 180) (length 2.54)
+					(name "G5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -25.40 180) (length 2.54)
+					(name "G6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -27.94 180) (length 2.54)
+					(name "G7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+		(symbol "diffpair_lvs:QFP48_PCIE"
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "U"
+				(at 0 33.02 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "QFP48_PCIE"
+				(at 0 -33.02 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "Package_QFP:LQFP-48_7x7mm_P0.5mm"
+				(at 0 -35.56 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 -38.10 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" ""
+				(at 0 -40.64 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "QFP48_PCIE_0_1"
+				(rectangle (start -6.35 30.48) (end 6.35 -30.48)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill (type background)
+					)
+				)
+			)
+			(symbol "QFP48_PCIE_1_1"
+				(pin passive line (at -8.89 29.21 0) (length 2.54)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 26.67 0) (length 2.54)
+					(name "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 24.13 0) (length 2.54)
+					(name "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 21.59 0) (length 2.54)
+					(name "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 19.05 0) (length 2.54)
+					(name "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 16.51 0) (length 2.54)
+					(name "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 13.97 0) (length 2.54)
+					(name "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 11.43 0) (length 2.54)
+					(name "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 8.89 0) (length 2.54)
+					(name "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 6.35 0) (length 2.54)
+					(name "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 3.81 0) (length 2.54)
+					(name "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 1.27 0) (length 2.54)
+					(name "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -1.27 0) (length 2.54)
+					(name "13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -3.81 0) (length 2.54)
+					(name "14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -6.35 0) (length 2.54)
+					(name "15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -8.89 0) (length 2.54)
+					(name "16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -11.43 0) (length 2.54)
+					(name "17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -13.97 0) (length 2.54)
+					(name "18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -16.51 0) (length 2.54)
+					(name "19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -19.05 0) (length 2.54)
+					(name "20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -21.59 0) (length 2.54)
+					(name "21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -24.13 0) (length 2.54)
+					(name "22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -26.67 0) (length 2.54)
+					(name "23"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "23"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -29.21 0) (length 2.54)
+					(name "24"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "24"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 29.21 180) (length 2.54)
+					(name "25"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "25"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 26.67 180) (length 2.54)
+					(name "26"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "26"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 24.13 180) (length 2.54)
+					(name "27"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "27"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 21.59 180) (length 2.54)
+					(name "28"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "28"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 19.05 180) (length 2.54)
+					(name "29"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "29"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 16.51 180) (length 2.54)
+					(name "30"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "30"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 13.97 180) (length 2.54)
+					(name "31"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "31"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 11.43 180) (length 2.54)
+					(name "32"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "32"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 8.89 180) (length 2.54)
+					(name "33"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "33"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 6.35 180) (length 2.54)
+					(name "34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 3.81 180) (length 2.54)
+					(name "35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 1.27 180) (length 2.54)
+					(name "36"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "36"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -1.27 180) (length 2.54)
+					(name "37"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "37"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -3.81 180) (length 2.54)
+					(name "38"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "38"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -6.35 180) (length 2.54)
+					(name "39"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "39"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -8.89 180) (length 2.54)
+					(name "40"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "40"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -11.43 180) (length 2.54)
+					(name "41"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "41"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -13.97 180) (length 2.54)
+					(name "42"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "42"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -16.51 180) (length 2.54)
+					(name "43"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "43"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -19.05 180) (length 2.54)
+					(name "44"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "44"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -21.59 180) (length 2.54)
+					(name "45"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "45"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -24.13 180) (length 2.54)
+					(name "46"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "46"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -26.67 180) (length 2.54)
+					(name "47"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "47"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -29.21 180) (length 2.54)
+					(name "48"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "48"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+		(symbol "diffpair_lvs:QFN24_MIPI"
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "U"
+				(at 0 17.78 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "QFN24_MIPI"
+				(at 0 -17.78 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "Package_DFN_QFN:QFN-24-1EP_4x4mm_P0.5mm"
+				(at 0 -20.32 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 -22.86 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" ""
+				(at 0 -25.40 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "QFN24_MIPI_0_1"
+				(rectangle (start -6.35 15.24) (end 6.35 -15.24)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill (type background)
+					)
+				)
+			)
+			(symbol "QFN24_MIPI_1_1"
+				(pin passive line (at -8.89 13.97 0) (length 2.54)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 11.43 0) (length 2.54)
+					(name "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 8.89 0) (length 2.54)
+					(name "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 6.35 0) (length 2.54)
+					(name "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 3.81 0) (length 2.54)
+					(name "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 1.27 0) (length 2.54)
+					(name "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -1.27 0) (length 2.54)
+					(name "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -3.81 0) (length 2.54)
+					(name "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -6.35 0) (length 2.54)
+					(name "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -8.89 0) (length 2.54)
+					(name "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -11.43 0) (length 2.54)
+					(name "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -13.97 0) (length 2.54)
+					(name "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 13.97 180) (length 2.54)
+					(name "13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 11.43 180) (length 2.54)
+					(name "14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 8.89 180) (length 2.54)
+					(name "15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 6.35 180) (length 2.54)
+					(name "16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 3.81 180) (length 2.54)
+					(name "17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 1.27 180) (length 2.54)
+					(name "18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -1.27 180) (length 2.54)
+					(name "19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -3.81 180) (length 2.54)
+					(name "20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -6.35 180) (length 2.54)
+					(name "21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -8.89 180) (length 2.54)
+					(name "22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -11.43 180) (length 2.54)
+					(name "23"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "23"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -13.97 180) (length 2.54)
+					(name "24"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "24"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
 		)
 		(symbol "power:PWR_FLAG"
 			(power global)
@@ -2225,14 +3772,14 @@
 		)
 	)
 	(symbol
-		(lib_id "Connector_Generic:Conn_02x12_Counter_Clockwise")
+		(lib_id "diffpair_lvs:USBC_SRC")
 		(at 50.8 50.8 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "13574026-afd7-4333-a17d-4345f30f3062")
+		(uuid "f049669e-d8e7-494d-83d4-189c8c6d0434")
 		(property "Reference" "J1"
 			(at 50.8 45.72 0)
 			(effects
@@ -2267,72 +3814,76 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "6b2dfeb0-62f3-4b75-a20d-1d57a030bd36")
+		(pin "A1" (uuid "91764f55-8382-4b22-9fcd-54922e1cb548")
 		)
-		(pin "2" (uuid "74361d55-d7b8-4f2d-9643-60ce2fffd037")
+		(pin "A2" (uuid "98a2504b-fe59-45aa-8928-f8e801f577ee")
 		)
-		(pin "3" (uuid "0a0a9ae7-2969-43d8-a730-017bb88d84d4")
+		(pin "A3" (uuid "260252ad-e7b4-48f2-bcfb-2f0dacc374d5")
 		)
-		(pin "4" (uuid "8c20deea-c529-4227-8c48-263d16df792e")
+		(pin "A4" (uuid "100fc7e5-0cc3-4046-8a89-b608f47c955f")
 		)
-		(pin "5" (uuid "e03214b9-219e-45b6-8a7d-48acb9b99b0f")
+		(pin "A5" (uuid "2e02e328-e55d-48a5-9bd6-d603d8013229")
 		)
-		(pin "6" (uuid "529ce1e9-62bb-4289-8cf9-bfc65b1325e4")
+		(pin "A6" (uuid "7ac2a15b-f70a-46d5-8e51-51227e665a34")
 		)
-		(pin "7" (uuid "556cb205-2705-4a89-9211-c73450471db6")
+		(pin "A7" (uuid "f12a851b-463b-4745-a228-e8aac89143f4")
 		)
-		(pin "8" (uuid "302de9e4-ba69-4c05-a7c5-ace13c9b3537")
+		(pin "A8" (uuid "42a33ae9-4258-4f83-b048-cdc62d68b3f4")
 		)
-		(pin "9" (uuid "b55416e2-0294-409c-ae7d-97bd529a754f")
+		(pin "A9" (uuid "2ba030c2-2205-45db-acd4-d13f557e649f")
 		)
-		(pin "10" (uuid "0c6aae74-68d5-4e6d-933f-1fa6d92e2550")
+		(pin "A10" (uuid "f606ccb1-3f75-4148-b625-00b564625508")
 		)
-		(pin "11" (uuid "bb95fe94-926f-4ccc-b231-e499554338e2")
+		(pin "A11" (uuid "e6e2a0f1-0f23-4cad-abab-1dc5de380fd0")
 		)
-		(pin "12" (uuid "0de01c70-4c95-41e4-bd99-78f68bdb5c71")
+		(pin "A12" (uuid "efcf22db-4f77-4ac0-89dd-c97ba1e3ffa3")
 		)
-		(pin "13" (uuid "e3c1edd6-3566-4ae8-b8be-d630dca68406")
+		(pin "B1" (uuid "c07c2933-391b-4eca-9389-d79ba060e4e7")
 		)
-		(pin "14" (uuid "aeb21539-8dbd-4de0-99fa-a01f38a36b8a")
+		(pin "B2" (uuid "1d4102ae-7611-476f-b9b9-778423550fcf")
 		)
-		(pin "15" (uuid "99b9ffa2-01f8-439f-b774-5442a0282bc4")
+		(pin "B3" (uuid "075b6f2f-d839-4c72-9781-807604641932")
 		)
-		(pin "16" (uuid "150f87fe-9236-4090-a62e-b2472ec7eaf6")
+		(pin "B4" (uuid "a6c066b6-4dd3-49a9-bcba-bfe0eeb73044")
 		)
-		(pin "17" (uuid "c4404c30-2a81-40c9-8035-2d09d40735dc")
+		(pin "B5" (uuid "c8a62a3c-adc0-4981-90e5-0217a3da05f7")
 		)
-		(pin "18" (uuid "0e54f4a2-4c94-473d-9401-8537c021aa49")
+		(pin "B6" (uuid "da154147-b560-4eb4-96de-1c023c137b92")
 		)
-		(pin "19" (uuid "4cb239a5-fd59-4403-ab36-6efd1cd3a811")
+		(pin "B7" (uuid "4ce1dad4-ffaa-4cc5-afe9-30da617a3495")
 		)
-		(pin "20" (uuid "0a51ee3c-ffdc-4c32-ba00-959e32c3c0e3")
+		(pin "B8" (uuid "f026d982-9e22-4bf5-bd31-613a06cf4247")
 		)
-		(pin "21" (uuid "bb39e880-9b00-4659-93e0-77a85bc1e179")
+		(pin "B9" (uuid "a6bb215f-719a-4b33-b319-7fb9eb0f75b7")
 		)
-		(pin "22" (uuid "3f20b3ba-4a95-4a0c-afe2-53ea874706cf")
+		(pin "B10" (uuid "5d373475-19a2-426c-9d15-c0e02ff0db85")
 		)
-		(pin "23" (uuid "62691660-cfd8-4dc3-aecd-74f824165115")
+		(pin "B11" (uuid "5f8e19f2-4dda-4a6c-a28d-3ceef397c3c4")
 		)
-		(pin "24" (uuid "0c08e1af-3d83-46dc-8ee2-fb80191e9aa1")
+		(pin "B12" (uuid "1eaf78c1-4514-4855-a5c7-33af0b7df3bc")
+		)
+		(pin "S1" (uuid "5543b2f9-e5e7-45a6-9081-02f0fb3f8e84")
+		)
+		(pin "S2" (uuid "4f23342d-9056-447b-a0a1-ab22a7aee5b6")
 		)
 		(instances
 			(project "project"
-				(path "/c5c992a2-d28d-430b-b400-e92ec2ef4b19" (reference "J1") (unit 1)
+				(path "/3c6e0a49-39a7-454c-8046-2b8048737b80" (reference "J1") (unit 1)
 				)
 			)
 		)
 	)
 	(symbol
-		(lib_id "Connector_Generic:Conn_01x12")
-		(at 50.8 139.7 0)
+		(lib_id "diffpair_lvs:MINIPCIE_SRC")
+		(at 50.8 106.68 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "f8b6fd81-770f-4f2a-97ca-e2dc68c44ce5")
+		(uuid "1caed9e0-855d-4874-97db-56d5d266c18c")
 		(property "Reference" "J3"
-			(at 50.8 134.62 0)
+			(at 50.8 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2340,7 +3891,7 @@
 			)
 		)
 		(property "Value" "MiniPCIe"
-			(at 50.8 137.16 0)
+			(at 50.8 104.14 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2348,7 +3899,7 @@
 			)
 		)
 		(property "Footprint" "Connector_PCIE:PCIE_Mini_Edge"
-			(at 50.8 139.7 0)
+			(at 50.8 106.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2357,7 +3908,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 50.8 139.7 0)
+			(at 50.8 106.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2365,48 +3916,48 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "92380768-31f8-4161-8c19-739fb05f86e5")
+		(pin "1" (uuid "1114ea27-cb29-41eb-9af5-2ac2d7c9ede4")
 		)
-		(pin "2" (uuid "9e66864b-8442-4966-b1c3-c936dab8d017")
+		(pin "2" (uuid "3295f604-22a9-4735-875b-782ce6fece33")
 		)
-		(pin "3" (uuid "e10586e8-ad77-4ce4-bf68-0d8b717c1df4")
+		(pin "3" (uuid "adaf3208-4257-422a-be2f-c6e77c9a7bfa")
 		)
-		(pin "4" (uuid "81f89cd8-7523-4000-9eb9-8b9a79c5400b")
+		(pin "4" (uuid "6f49b3c3-f84c-455c-9a64-f22c22c100e4")
 		)
-		(pin "5" (uuid "cbd20443-74fa-4553-9c7b-51f16d23993d")
+		(pin "5" (uuid "788b797e-4bb7-49fb-95a9-690fed758237")
 		)
-		(pin "6" (uuid "5cf223a9-fded-4ae6-8334-eab60e05c398")
+		(pin "6" (uuid "da0ea4ba-cf2c-49b9-b2f0-3ccbed255fa5")
 		)
-		(pin "7" (uuid "dac8e121-e7d8-4b76-ba13-ec0664335c8c")
+		(pin "7" (uuid "8e8793a2-5d6d-4921-9d59-346417e05e3b")
 		)
-		(pin "8" (uuid "3561da14-adca-444d-8a2d-dda7a3e1d63c")
+		(pin "8" (uuid "170a7b7c-4a8a-4450-9751-450ea0feda3c")
 		)
-		(pin "9" (uuid "77a8e57b-03f1-4de2-80ab-76822dda3c0f")
+		(pin "9" (uuid "34a925d2-e811-4c08-9dfd-8a69c0d0c07e")
 		)
-		(pin "10" (uuid "bd533c31-2923-4748-a505-b1486c4aa3e4")
+		(pin "10" (uuid "1759b51a-75e3-46ab-b98c-6ee244ac0f96")
 		)
-		(pin "11" (uuid "a7ec62a2-a71b-4f97-9b22-1b6ef48e7777")
+		(pin "11" (uuid "cbdf5ae9-f2ed-4028-b2c5-d1f0cb689c88")
 		)
-		(pin "12" (uuid "8a57dc83-244f-4ae5-b679-b0e444ba6835")
+		(pin "12" (uuid "6e6a10a7-2cb6-4eb6-881e-7e3d537b8a11")
 		)
 		(instances
 			(project "project"
-				(path "/c5c992a2-d28d-430b-b400-e92ec2ef4b19" (reference "J3") (unit 1)
+				(path "/3c6e0a49-39a7-454c-8046-2b8048737b80" (reference "J3") (unit 1)
 				)
 			)
 		)
 	)
 	(symbol
-		(lib_id "Connector_Generic:Conn_01x04")
-		(at 50.8 190.5 0)
+		(lib_id "diffpair_lvs:FFC_SRC")
+		(at 50.8 137.16 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "5d5e0582-6148-44b6-abc4-02d9979b86d5")
+		(uuid "4368e2b6-db39-4803-aadf-aa1206103db1")
 		(property "Reference" "J4"
-			(at 50.8 185.42 0)
+			(at 50.8 132.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2414,7 +3965,7 @@
 			)
 		)
 		(property "Value" "FFC4"
-			(at 50.8 187.96 0)
+			(at 50.8 134.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2422,7 +3973,7 @@
 			)
 		)
 		(property "Footprint" "Connector_FFC:FFC_4P_0.5mm"
-			(at 50.8 190.5 0)
+			(at 50.8 137.16 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2431,7 +3982,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 50.8 190.5 0)
+			(at 50.8 137.16 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2439,32 +3990,38 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "e6bd5ac6-754c-4375-aaf6-ec9f7b811e88")
+		(pin "1" (uuid "e374d508-3cba-4c34-aed2-159cde1e33ab")
 		)
-		(pin "2" (uuid "fc0e60d1-8c4b-44c5-857c-dcf90a506966")
+		(pin "2" (uuid "08d4e0b9-206a-4a80-9ab0-6b587a004d38")
 		)
-		(pin "3" (uuid "63b28f46-4c3a-4ea2-8eec-b956009c532c")
+		(pin "3" (uuid "62676aeb-9c2e-4a10-90d2-6a4c0a246884")
 		)
-		(pin "4" (uuid "5c9f9ea0-2c14-4521-8399-5424f263f816")
+		(pin "4" (uuid "44e1b07f-7de8-4f9d-9ea9-aa64fba844be")
+		)
+		(pin "M1" (uuid "b422a7d8-53c3-449b-afe1-88dd60c0de55")
+		)
+		(pin "M2" (uuid "2144c16e-6e87-4620-97e9-f45aa82f545d")
+		)
+		(pin "RST" (uuid "447f8ecf-86c1-4c46-a501-920cb38d5ce9")
 		)
 		(instances
 			(project "project"
-				(path "/c5c992a2-d28d-430b-b400-e92ec2ef4b19" (reference "J4") (unit 1)
+				(path "/3c6e0a49-39a7-454c-8046-2b8048737b80" (reference "J4") (unit 1)
 				)
 			)
 		)
 	)
 	(symbol
-		(lib_id "Connector_Generic:Conn_02x16_Counter_Clockwise")
-		(at 152.4 50.8 0)
+		(lib_id "diffpair_lvs:QFN32_USB2")
+		(at 177.8 50.8 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "b55113a1-48b0-4b94-8528-42e323eba308")
+		(uuid "b0e22851-1b06-4f57-848f-f94b0e4d6087")
 		(property "Reference" "U1"
-			(at 152.4 45.72 0)
+			(at 177.8 45.72 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2472,7 +4029,7 @@
 			)
 		)
 		(property "Value" "QFN32_USB2"
-			(at 152.4 48.26 0)
+			(at 177.8 48.26 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2480,7 +4037,7 @@
 			)
 		)
 		(property "Footprint" "Package_DFN_QFN:QFN-32-1EP_5x5mm_P0.5mm"
-			(at 152.4 50.8 0)
+			(at 177.8 50.8 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2489,7 +4046,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 152.4 50.8 0)
+			(at 177.8 50.8 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2497,88 +4054,88 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "00f01c71-ee23-4b57-8601-7c75cdf01164")
+		(pin "1" (uuid "53a32ddc-d211-4dfd-b2e1-edc77e1dfcee")
 		)
-		(pin "2" (uuid "545594d4-3a15-4000-bbf8-0fc6f16e8471")
+		(pin "2" (uuid "faf86bd6-476d-42c3-a326-e18f3d41960d")
 		)
-		(pin "3" (uuid "6b80e4b5-5e5b-4be2-b844-5c874495354f")
+		(pin "3" (uuid "90a4d1b8-b24b-4af9-82b0-58b3721e5fda")
 		)
-		(pin "4" (uuid "636e8954-af72-467a-b203-befc325d4653")
+		(pin "4" (uuid "5e1cbf38-0b5d-42b9-bfea-4652e0f87737")
 		)
-		(pin "5" (uuid "e54db6ac-23c7-43e5-93e6-765f0c7ec704")
+		(pin "5" (uuid "af7580f2-1873-4a9a-a7d0-41fcfc4736b7")
 		)
-		(pin "6" (uuid "b1b0f45c-dbc3-4435-8a5c-9c559d512af0")
+		(pin "6" (uuid "6399cd5a-c62d-47cd-b25f-bae7e42925fc")
 		)
-		(pin "7" (uuid "7c995924-6c4f-4c27-b2b5-d41035ba3757")
+		(pin "7" (uuid "7de654e0-f9d4-45e1-9f56-8a909b019025")
 		)
-		(pin "8" (uuid "79dd62d1-c601-4ff5-9cfb-58b2911f1cf7")
+		(pin "8" (uuid "c016dbfa-cd8f-4d91-8b88-498000b17cd7")
 		)
-		(pin "9" (uuid "96a9f2fc-6c91-4b63-8101-69a738563226")
+		(pin "9" (uuid "927c5063-a780-498f-a864-a2fde07dfad4")
 		)
-		(pin "10" (uuid "44f03f1d-dfcb-48f1-be99-c567b9e81e2d")
+		(pin "10" (uuid "58b66bf1-5966-4a72-8422-235e61f19545")
 		)
-		(pin "11" (uuid "c7ef05fc-d3e0-4bcc-b8db-7f3353d9857b")
+		(pin "11" (uuid "d0a466aa-8fc9-431e-84a1-380c07c6bdb7")
 		)
-		(pin "12" (uuid "a2c1d586-e671-44c3-a13b-e9854f7ea2a7")
+		(pin "12" (uuid "0de1850c-aab4-4939-9232-b1f4545cf58e")
 		)
-		(pin "13" (uuid "1a778727-74e8-4b47-867c-81e6e9b74fab")
+		(pin "13" (uuid "b0cb2d18-1448-4767-af7b-b4ff7506e776")
 		)
-		(pin "14" (uuid "8027f7af-2f5c-4da5-b96a-8b1da56225dd")
+		(pin "14" (uuid "db061988-8bce-4d36-97bf-691a7fcf12a2")
 		)
-		(pin "15" (uuid "6cb22825-1c9c-4281-9880-953ffd8fdc18")
+		(pin "15" (uuid "c0ccae0b-40d2-4660-8594-1eb9e29552c3")
 		)
-		(pin "16" (uuid "c6496e5a-b17b-4d08-9ee6-c9da93b442f5")
+		(pin "16" (uuid "9debf87f-52da-4a3c-a9c3-091fb8451b7e")
 		)
-		(pin "17" (uuid "1f534f6f-f588-4ae6-aa54-6fdb8b367c99")
+		(pin "17" (uuid "6d3989c2-8ac5-4c7a-9086-221fd5853d6f")
 		)
-		(pin "18" (uuid "b3c178d3-48b4-4405-9a16-9decbd2fd92d")
+		(pin "18" (uuid "30877cfd-5093-4b08-8003-e6544e50b0fa")
 		)
-		(pin "19" (uuid "06be5294-bea6-4e6e-959d-73b08ccbba4f")
+		(pin "19" (uuid "81b0bf1d-bce0-4b44-b67d-4ab5a8f9fb7a")
 		)
-		(pin "20" (uuid "c7fd67ff-faa1-4f2a-a9af-b93f0a579d3f")
+		(pin "20" (uuid "a7d09f60-fe86-4099-a79a-733e8326476a")
 		)
-		(pin "21" (uuid "efcf0811-271c-4fe5-a2b2-ee91b18cf3bd")
+		(pin "21" (uuid "e5b4199d-c246-44cf-8c8b-0a7dddf6d3d5")
 		)
-		(pin "22" (uuid "37b07e55-bdeb-4446-bb36-6a607de2312d")
+		(pin "22" (uuid "063d34a2-108e-4b05-aaa2-68852a1d20b4")
 		)
-		(pin "23" (uuid "78304892-2262-4748-addd-44b1b060e365")
+		(pin "23" (uuid "c1b05d97-d4bd-4413-9467-21d6f2167ed2")
 		)
-		(pin "24" (uuid "85ae68e5-5e31-49b4-9eb7-301ff497c437")
+		(pin "24" (uuid "fe7f8f28-a76e-4154-a925-d53bb648b66b")
 		)
-		(pin "25" (uuid "79fece96-8b53-4f29-b179-7c74973377db")
+		(pin "25" (uuid "77472f36-e635-4472-af88-4692b56d1f73")
 		)
-		(pin "26" (uuid "bf69af6d-9e11-4eeb-bb84-3700675469f7")
+		(pin "26" (uuid "d513d433-4ee1-486d-b8a2-bdc42a122eaf")
 		)
-		(pin "27" (uuid "3fb9ea0a-6009-45d7-8a24-b180662c60d9")
+		(pin "27" (uuid "75ebb17d-21a2-4779-9c22-beff3af39cdd")
 		)
-		(pin "28" (uuid "5e4bb13c-df0b-43e5-a9e5-faf2ab148b25")
+		(pin "28" (uuid "acc00792-1ca2-498a-b372-33fa29db066a")
 		)
-		(pin "29" (uuid "25137f75-9974-4879-8038-6d28e162fa27")
+		(pin "29" (uuid "d1ed49e6-2a1c-43c5-99ff-643f4fa4690e")
 		)
-		(pin "30" (uuid "286910c4-267e-4a61-9cb0-250b8f86aa8f")
+		(pin "30" (uuid "6232417f-855d-4332-a41c-a8c97746e46f")
 		)
-		(pin "31" (uuid "eb3c37c5-5616-4f73-8158-dfe07ff891f7")
+		(pin "31" (uuid "7b240b1d-713e-44f3-a295-3fd9ccc6d622")
 		)
-		(pin "32" (uuid "93058484-6158-4d5f-8ff3-2571ebffa619")
+		(pin "32" (uuid "bf8892cb-c0d2-44eb-b044-b5abcbde9c95")
 		)
 		(instances
 			(project "project"
-				(path "/c5c992a2-d28d-430b-b400-e92ec2ef4b19" (reference "U1") (unit 1)
+				(path "/3c6e0a49-39a7-454c-8046-2b8048737b80" (reference "U1") (unit 1)
 				)
 			)
 		)
 	)
 	(symbol
-		(lib_id "Connector_Generic:Conn_02x16_Counter_Clockwise")
-		(at 152.4 101.6 0)
+		(lib_id "diffpair_lvs:BGA49_USB3")
+		(at 177.8 127 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "3306dc98-b570-4d3a-b348-b69ab1e6c571")
+		(uuid "ddba2c1d-5cfc-430e-9c0b-f777c18e35b3")
 		(property "Reference" "U2"
-			(at 152.4 96.52 0)
+			(at 177.8 121.92 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2586,7 +4143,7 @@
 			)
 		)
 		(property "Value" "BGA49_USB3"
-			(at 152.4 99.06 0)
+			(at 177.8 124.46 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2594,7 +4151,7 @@
 			)
 		)
 		(property "Footprint" "Package_BGA:BGA-49_5.0x5.0mm_Layout7x7_P0.5mm"
-			(at 152.4 101.6 0)
+			(at 177.8 127 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2603,7 +4160,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 152.4 101.6 0)
+			(at 177.8 127 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2611,88 +4168,122 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "26b2b8d9-a07b-42e4-ad68-d1f5135780fa")
+		(pin "A1" (uuid "298c03fd-ad59-4b92-ab89-c4b26dca3fd0")
 		)
-		(pin "2" (uuid "f8c2f6f8-323d-4e4f-b444-39cda4b9d322")
+		(pin "A2" (uuid "036c6c97-b5b8-43e7-ba2e-45be3a898be7")
 		)
-		(pin "3" (uuid "35021469-d017-4aae-824c-aa85e4e448d7")
+		(pin "A3" (uuid "9c9bf9e2-bb87-4cd9-894c-f874df3fc447")
 		)
-		(pin "4" (uuid "7bb9322c-be63-4409-a616-d324bd99616c")
+		(pin "A4" (uuid "13c3aba6-d9c8-4580-b209-81ccedec9355")
 		)
-		(pin "5" (uuid "d2ad30e0-2ddd-44c9-886e-c972c8ff64c8")
+		(pin "A5" (uuid "0f76cf0c-6f65-4d19-9fa6-42aa125da29a")
 		)
-		(pin "6" (uuid "273e110d-9352-4ba9-96e9-1f7c63262863")
+		(pin "A6" (uuid "fce89e98-128e-439b-b35b-f33a710af80a")
 		)
-		(pin "7" (uuid "a543f98d-d76b-4791-8f30-cabbe9953e6a")
+		(pin "A7" (uuid "ef66c262-130c-4558-b157-4efede586258")
 		)
-		(pin "8" (uuid "543711e3-2d31-48df-83a0-67ba03e5c46b")
+		(pin "B1" (uuid "41107961-baaf-4eb9-9a0a-b35bbf316c61")
 		)
-		(pin "9" (uuid "fe41301a-2118-4ef6-8a4f-fd8695f4df5a")
+		(pin "B2" (uuid "4134da66-5084-43df-9176-c6f3966b8f28")
 		)
-		(pin "10" (uuid "c36359be-0135-4630-817c-ca0b18ed1c3c")
+		(pin "B3" (uuid "3f930c21-a6e5-4358-9e37-f9ca3154516d")
 		)
-		(pin "11" (uuid "a460aff9-17f8-4d7f-8d99-6b6cc119b3fc")
+		(pin "B4" (uuid "6e2886ee-1033-4872-b45c-4a53f6df6f7b")
 		)
-		(pin "12" (uuid "e64998c8-8923-42b7-8317-2dc602483a32")
+		(pin "B5" (uuid "6acf3060-1790-404d-b82e-974dac0f6d9e")
 		)
-		(pin "13" (uuid "aa72a2c9-01b4-4f7e-a4ad-b546cb63952f")
+		(pin "B6" (uuid "93cd50a2-751e-4fbb-8b1a-59ce839841ef")
 		)
-		(pin "14" (uuid "39c85a0c-0feb-4426-8c86-35fb29fa1e26")
+		(pin "B7" (uuid "6ea16a74-28ad-4e33-8c81-0cfcedb7f495")
 		)
-		(pin "15" (uuid "57ff8bbd-c7ca-4301-b7d0-48cf10acec10")
+		(pin "C1" (uuid "83f66716-a7bf-44d3-9774-45eed75e62ed")
 		)
-		(pin "16" (uuid "6f8fc61e-3b50-407a-9991-669a0d799a7f")
+		(pin "C2" (uuid "3a1d3a1f-ff56-4dfa-aa70-92e6ffd6053a")
 		)
-		(pin "17" (uuid "c328ede6-44f5-4bff-9d18-8391445be49a")
+		(pin "C3" (uuid "776c93cc-5939-4bc3-b473-d946a4e95d4d")
 		)
-		(pin "18" (uuid "0ebf12a7-5766-49c9-825c-4d524238722d")
+		(pin "C4" (uuid "17f0c2d9-35e8-4a0c-9736-bd73015003ce")
 		)
-		(pin "19" (uuid "ddd80a34-3f4e-46b1-bf4b-e32e1b9ae535")
+		(pin "C5" (uuid "18f2b679-5cca-4272-b5ee-1a7917a66c94")
 		)
-		(pin "20" (uuid "d769ad04-7204-4cc6-a8f0-7c121f9e1ef2")
+		(pin "C6" (uuid "d45b4ed0-5252-49ce-9cb6-eddc4cb38106")
 		)
-		(pin "21" (uuid "8947b6a8-9fb6-40fe-9679-bb33766d47cf")
+		(pin "C7" (uuid "b29673b3-3e40-4287-b9d7-5752905df066")
 		)
-		(pin "22" (uuid "e4233bc5-cf2a-4b8a-8be9-a417beb5a9d2")
+		(pin "D1" (uuid "5f9e9b66-15d9-43f6-98b8-db5f85fec263")
 		)
-		(pin "23" (uuid "dde4b107-6982-45ba-a147-6773cec9538b")
+		(pin "D2" (uuid "b0bee3ca-6702-4b84-9b6e-9b5253f51577")
 		)
-		(pin "24" (uuid "d42bad9f-ec9e-4b4a-976a-1b1d276a9520")
+		(pin "D3" (uuid "39bce64d-9d2e-4bba-acaf-6ee8c302497c")
 		)
-		(pin "25" (uuid "3534da31-e6c3-4572-9286-d3ec1134a3d2")
+		(pin "D4" (uuid "5f2adb87-3c37-4e67-b7d8-302f433dcba8")
 		)
-		(pin "26" (uuid "acf6e2a0-4d57-4c5e-9606-592eccd00575")
+		(pin "D5" (uuid "da35449e-d9da-4e21-a370-7ac16a07ae02")
 		)
-		(pin "27" (uuid "e471286a-5e24-4c50-a5d9-016226217c38")
+		(pin "D6" (uuid "ce7083da-58bd-4ee2-8166-3a44848f9c28")
 		)
-		(pin "28" (uuid "6aac68f7-f513-4fc2-9cf1-8f625618504b")
+		(pin "D7" (uuid "90f3c5dc-7413-48cd-b40f-2fd44ea59ed3")
 		)
-		(pin "29" (uuid "afbc75fc-704e-4121-af18-8d16345bc588")
+		(pin "E1" (uuid "e5c25495-0d59-4503-9414-f351aa983c50")
 		)
-		(pin "30" (uuid "a3908212-0bdf-472d-9c24-721967d95f29")
+		(pin "E2" (uuid "70fec62a-cabb-485a-af20-a61260ee0547")
 		)
-		(pin "31" (uuid "55a117bf-9e8a-4bba-80c4-94adf29909ff")
+		(pin "E3" (uuid "c81797d0-0ddf-49ef-acb7-d25ca0f24c9d")
 		)
-		(pin "32" (uuid "7c77f204-5131-4c76-a8f3-9449ee72596f")
+		(pin "E4" (uuid "41812319-0332-4d1d-8b68-371971aa3383")
+		)
+		(pin "E5" (uuid "0556bf73-d165-4b73-8795-5469de20b380")
+		)
+		(pin "E6" (uuid "286e9c05-c72e-4f3a-a4d9-107a3dca8385")
+		)
+		(pin "E7" (uuid "f06ee210-8914-422e-a952-a559dbfc6362")
+		)
+		(pin "F1" (uuid "938ea38f-ea35-41a4-9f20-13e2f083ae95")
+		)
+		(pin "F2" (uuid "fc6ced05-6c43-40b8-826c-efde4cc5e7fd")
+		)
+		(pin "F3" (uuid "f8e13330-7fea-4013-ad66-d14434ea506b")
+		)
+		(pin "F4" (uuid "91e4a719-9af2-43f0-a4ff-dcfc90864acb")
+		)
+		(pin "F5" (uuid "b05f8fe7-7b99-4a9e-9bc6-311ea47119ee")
+		)
+		(pin "F6" (uuid "04323e2b-e3a4-4d7b-98a3-dbb0db608f9b")
+		)
+		(pin "F7" (uuid "3a4ba857-6510-46ac-88bb-4cba6831a438")
+		)
+		(pin "G1" (uuid "c455356a-a89b-435e-a143-a04b1cc04e1a")
+		)
+		(pin "G2" (uuid "35c8b4b3-6899-4726-8081-efe7769a3003")
+		)
+		(pin "G3" (uuid "e6a56b7e-41a8-4723-9284-b89ead9d55fa")
+		)
+		(pin "G4" (uuid "bb5b5856-4c3f-4eaa-bfcc-dab78fed3b7e")
+		)
+		(pin "G5" (uuid "04eca5a3-2ebf-43ee-b2a7-baac33e3e4a6")
+		)
+		(pin "G6" (uuid "06edf272-4a2b-4bd9-8d80-e7d35dd18146")
+		)
+		(pin "G7" (uuid "3f439a48-ebd7-4478-b435-67acc6aa5e44")
 		)
 		(instances
 			(project "project"
-				(path "/c5c992a2-d28d-430b-b400-e92ec2ef4b19" (reference "U2") (unit 1)
+				(path "/3c6e0a49-39a7-454c-8046-2b8048737b80" (reference "U2") (unit 1)
 				)
 			)
 		)
 	)
 	(symbol
-		(lib_id "Connector_Generic:Conn_02x16_Counter_Clockwise")
-		(at 152.4 152.4 0)
+		(lib_id "diffpair_lvs:QFP48_PCIE")
+		(at 177.8 203.2 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "37a987fb-b00d-45db-8382-c207af25f218")
+		(uuid "21dd1828-005c-422b-b99a-4b768238cdbe")
 		(property "Reference" "U3"
-			(at 152.4 147.32 0)
+			(at 177.8 198.12 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2700,7 +4291,7 @@
 			)
 		)
 		(property "Value" "QFP48_PCIe"
-			(at 152.4 149.86 0)
+			(at 177.8 200.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2708,7 +4299,7 @@
 			)
 		)
 		(property "Footprint" "Package_QFP:LQFP-48_7x7mm_P0.5mm"
-			(at 152.4 152.4 0)
+			(at 177.8 203.2 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2717,7 +4308,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 152.4 152.4 0)
+			(at 177.8 203.2 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2725,88 +4316,120 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "43e01b66-5ef6-42e6-8e68-aefd9e64b266")
+		(pin "1" (uuid "d86603f4-993e-4440-9fc7-55cd45d3c5d4")
 		)
-		(pin "2" (uuid "8a93e22e-082f-4297-807a-88f512758b68")
+		(pin "2" (uuid "2084a3d2-7ce2-47a7-bff9-6b612c98a473")
 		)
-		(pin "3" (uuid "7758f41b-1b09-4cba-97b9-aac490472c42")
+		(pin "3" (uuid "8b5195b6-4689-4732-b004-62663627649f")
 		)
-		(pin "4" (uuid "8f03e172-4fb2-4ab7-9789-ba27a2bab96e")
+		(pin "4" (uuid "f889f408-2ebd-4d82-8dc3-2b89987704f2")
 		)
-		(pin "5" (uuid "4f36da4d-7338-45de-802a-d216172a16d8")
+		(pin "5" (uuid "7bb663fa-55c2-4aff-b38b-d761e291dcda")
 		)
-		(pin "6" (uuid "82b293c8-c76c-4500-975d-402639791091")
+		(pin "6" (uuid "4cad3823-a618-454d-82e7-065dc9e2e461")
 		)
-		(pin "7" (uuid "f875c1cc-fd44-45d7-911a-a102e50fd031")
+		(pin "7" (uuid "9e9c7ff7-401c-476c-a086-ad1f99ad8a1a")
 		)
-		(pin "8" (uuid "66ec130a-912b-4388-9cc5-40ece7cfeed4")
+		(pin "8" (uuid "3edab5d3-70e1-44b4-b5c3-fa4532153945")
 		)
-		(pin "9" (uuid "dcca045e-437f-4cad-8518-07918546bd1e")
+		(pin "9" (uuid "211b0597-62f5-4b37-a281-991a5151ed0b")
 		)
-		(pin "10" (uuid "6b06aca5-46fa-49c6-91f4-f836770464d4")
+		(pin "10" (uuid "70b7ca61-4ed3-41af-b05b-8d4ccfd307c5")
 		)
-		(pin "11" (uuid "31cdda66-570a-40cd-a37b-122fd0920cdd")
+		(pin "11" (uuid "09249428-e41b-43d2-97b6-810cc83094a3")
 		)
-		(pin "12" (uuid "3bff131b-3ed3-4803-900b-34cd42f7ea0d")
+		(pin "12" (uuid "eaef2fd1-b6bc-4305-b175-8e715e3fc397")
 		)
-		(pin "13" (uuid "5dce4d17-9b3c-41be-81c6-181d36dadb7f")
+		(pin "13" (uuid "1b2de8c6-48cb-48c3-ba88-e9e3ce4b8069")
 		)
-		(pin "14" (uuid "9a5cb4f8-70ba-4ff0-8866-befaf9e33e5f")
+		(pin "14" (uuid "73ce364e-29b6-41a3-9fd3-485fce92c0ef")
 		)
-		(pin "15" (uuid "fb23b440-0320-4535-b548-fe948605c10c")
+		(pin "15" (uuid "e3f0d166-f598-4a4f-942e-b41f58a8f4d6")
 		)
-		(pin "16" (uuid "bb03e50c-7a9b-4d2e-9127-a87f4d2ece80")
+		(pin "16" (uuid "d8dcfb2b-8eb3-4bd1-a51d-5dd3d35c55fc")
 		)
-		(pin "17" (uuid "8b1add22-c551-4ee1-8f8f-488a06e9f2bf")
+		(pin "17" (uuid "825f83e4-c172-42c0-8a97-3682a9244dfb")
 		)
-		(pin "18" (uuid "be1eabb1-2cd5-4570-bfd7-3f1ffdf6eecc")
+		(pin "18" (uuid "83cab28d-26ac-467c-acd0-76e309007899")
 		)
-		(pin "19" (uuid "ca83c837-261a-4618-9426-fcd1638fd8d7")
+		(pin "19" (uuid "08f0f66a-fd0b-4451-b365-2e7c549101b3")
 		)
-		(pin "20" (uuid "f1858633-df04-47c6-ae65-bdbda17f1627")
+		(pin "20" (uuid "b500093d-7cdb-41e4-9bcb-8ece619a6e08")
 		)
-		(pin "21" (uuid "034ec737-9b90-49bc-957c-1a6766c7e7d0")
+		(pin "21" (uuid "6dc10dea-0026-4f2f-94cf-827e8150f92d")
 		)
-		(pin "22" (uuid "66d6acf7-5eff-4683-a1a8-70dc18667e39")
+		(pin "22" (uuid "74d70035-8b41-44ff-87de-78225b875846")
 		)
-		(pin "23" (uuid "7d2cba55-b00d-4dde-a957-22111df02607")
+		(pin "23" (uuid "bfee8cac-845f-4e67-87de-b4f02f78d59a")
 		)
-		(pin "24" (uuid "906e7deb-9350-488d-b4b2-d8de90b8bceb")
+		(pin "24" (uuid "d4f9f609-33cb-4e71-9923-f7eb776b97dc")
 		)
-		(pin "25" (uuid "0a60ff7c-bba2-401f-b09e-79e6cb8b9d4c")
+		(pin "25" (uuid "3ed13c19-9db2-424c-86c0-0ef9635db9a1")
 		)
-		(pin "26" (uuid "da309c1a-1d45-4abe-b551-ed30c025ee7e")
+		(pin "26" (uuid "4a1632b1-e9ab-4bb5-91c6-f50f75608a2c")
 		)
-		(pin "27" (uuid "bb0c2fe4-7bc7-473e-b7e4-f32565c43ac8")
+		(pin "27" (uuid "b069bec2-c75a-452d-961f-1d240e8985f1")
 		)
-		(pin "28" (uuid "a0d952bb-196a-4969-8556-9f2ba5e3d8b5")
+		(pin "28" (uuid "df0f6989-6637-4f9b-b82b-b193837951c2")
 		)
-		(pin "29" (uuid "a11c1eef-441b-4e88-983d-3b64d3fea208")
+		(pin "29" (uuid "e1b229b0-f807-4aa3-ac3a-a20b92cb1455")
 		)
-		(pin "30" (uuid "64dda2b9-7044-4ddf-aed1-f8686182b61b")
+		(pin "30" (uuid "df830456-2d9a-4264-8813-258f4c2e96b3")
 		)
-		(pin "31" (uuid "2ee064bc-84c6-47d1-928c-f8544f4bd5a9")
+		(pin "31" (uuid "9d5dacc1-443c-4c5c-b26a-e15b00e6e3ae")
 		)
-		(pin "32" (uuid "d945d992-1274-4496-8ab9-8756a0b7aebc")
+		(pin "32" (uuid "a2e49cc1-b9e1-40d3-9a5b-822784b17b6c")
+		)
+		(pin "33" (uuid "7696f730-a86d-4972-abd3-e087d9e1b42e")
+		)
+		(pin "34" (uuid "8d2000b5-89f6-448d-9f6f-6c55e0125ade")
+		)
+		(pin "35" (uuid "f2b5d486-47e3-46ca-a898-2a232ee853e7")
+		)
+		(pin "36" (uuid "25fdf156-b1c6-4903-9fe0-5a84c38a58e8")
+		)
+		(pin "37" (uuid "ed420f01-3e5e-4e26-a37a-a64250c5fafc")
+		)
+		(pin "38" (uuid "bbd242f5-4533-4098-b921-8125a3718a9b")
+		)
+		(pin "39" (uuid "176bbd68-76ab-4049-98da-f0616d1de0f3")
+		)
+		(pin "40" (uuid "dbcb00db-bcfb-42ad-849a-42dc2b02653a")
+		)
+		(pin "41" (uuid "c393367f-c7b3-4271-b5df-0b8fa945e9bb")
+		)
+		(pin "42" (uuid "ee9af3d2-4e5a-4f79-8d9e-b80fb4c394c5")
+		)
+		(pin "43" (uuid "af6f432f-183d-41bd-894d-d1dba3fa7ae7")
+		)
+		(pin "44" (uuid "defd2f9a-f0fc-4e6d-aa20-0ad34f957db2")
+		)
+		(pin "45" (uuid "48439abe-d974-4ada-841d-d5c3c98f267b")
+		)
+		(pin "46" (uuid "42bbbab5-da39-451a-85bd-034e31bf78ef")
+		)
+		(pin "47" (uuid "861a89e9-fe0f-4108-8a27-378060f0ea40")
+		)
+		(pin "48" (uuid "32035084-e94d-4866-bdc3-ed9bc8fd5a36")
 		)
 		(instances
 			(project "project"
-				(path "/c5c992a2-d28d-430b-b400-e92ec2ef4b19" (reference "U3") (unit 1)
+				(path "/3c6e0a49-39a7-454c-8046-2b8048737b80" (reference "U3") (unit 1)
 				)
 			)
 		)
 	)
 	(symbol
-		(lib_id "Connector_Generic:Conn_02x12_Counter_Clockwise")
-		(at 152.4 203.2 0)
+		(lib_id "diffpair_lvs:QFN24_MIPI")
+		(at 177.8 266.7 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "91a24cc0-c18e-486c-9008-ac8bb4d55f0d")
+		(uuid "b2680525-71ef-431b-8d3e-0fa897e14637")
 		(property "Reference" "U4"
-			(at 152.4 198.12 0)
+			(at 177.8 261.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2814,7 +4437,7 @@
 			)
 		)
 		(property "Value" "QFN24_MIPI"
-			(at 152.4 200.66 0)
+			(at 177.8 264.16 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2822,7 +4445,7 @@
 			)
 		)
 		(property "Footprint" "Package_DFN_QFN:QFN-24-1EP_4x4mm_P0.5mm"
-			(at 152.4 203.2 0)
+			(at 177.8 266.7 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2831,7 +4454,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 152.4 203.2 0)
+			(at 177.8 266.7 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2839,72 +4462,72 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "55a7889f-458f-4a22-a74f-c0a5f1f2b3e5")
+		(pin "1" (uuid "a6b3aa32-1a24-451a-a240-3715017c4448")
 		)
-		(pin "2" (uuid "b5f44d8b-4af5-44ff-92f1-8045bd7bae6f")
+		(pin "2" (uuid "ce1f5a88-f64d-4957-9272-2696597aab16")
 		)
-		(pin "3" (uuid "ea783d2f-f518-4abc-9ffe-1938b5c9eba6")
+		(pin "3" (uuid "723c4e44-187a-4dd9-89cd-baf4d1aef760")
 		)
-		(pin "4" (uuid "1341e19e-47bc-48a4-b90b-952c70f3ec66")
+		(pin "4" (uuid "29d79352-bf32-449a-a517-ea103210ab8b")
 		)
-		(pin "5" (uuid "d0c264af-6129-41e8-8512-5214a79ad74b")
+		(pin "5" (uuid "eab23073-3063-4016-a70a-495fc2f63a22")
 		)
-		(pin "6" (uuid "734a8a47-c0bb-4b65-84a4-cbbbd73f2c6a")
+		(pin "6" (uuid "e7572595-c6bd-4d9e-95aa-f3e2e1718eab")
 		)
-		(pin "7" (uuid "44c72e76-c8c9-4d9b-95ff-9fea9919e93b")
+		(pin "7" (uuid "49787ac7-9351-40ae-9dad-37818b3fb8ba")
 		)
-		(pin "8" (uuid "f87843e1-20a7-4df2-9a8e-8578b150c30b")
+		(pin "8" (uuid "b614c629-8b03-4ffc-8b22-a4fab49a2d94")
 		)
-		(pin "9" (uuid "5dfc6892-73bf-4b0e-9167-6616717ab637")
+		(pin "9" (uuid "1fa468fe-5c3b-4f75-b6fe-6be17668257b")
 		)
-		(pin "10" (uuid "e6c58eb8-44ac-474c-91b6-0c11f9f9c61f")
+		(pin "10" (uuid "3c04a738-0865-4159-a8d8-3ff256988a8b")
 		)
-		(pin "11" (uuid "e263f757-7f54-42fe-8168-77b5faafec05")
+		(pin "11" (uuid "0446f870-da6b-4636-a871-b124e89a6e50")
 		)
-		(pin "12" (uuid "9390875d-a279-4900-b282-99298494112a")
+		(pin "12" (uuid "3a99ea51-1f17-414b-a611-f6ee1de483dd")
 		)
-		(pin "13" (uuid "85dca8d7-47a2-46b0-bf1b-a167547dcff0")
+		(pin "13" (uuid "7b5c1d50-785b-44b4-ba32-8a70ad384163")
 		)
-		(pin "14" (uuid "a06f7def-f1a4-48b4-811c-e8568b92ad6b")
+		(pin "14" (uuid "fc72b721-c248-4ca7-9f83-4d16ca693e2a")
 		)
-		(pin "15" (uuid "b3a09225-add6-4ca6-830d-f10b53dc12aa")
+		(pin "15" (uuid "b2719a00-5b03-4943-b44a-a603a3284c4d")
 		)
-		(pin "16" (uuid "d1866bf6-f8f6-4a32-8829-a3ca4e615a77")
+		(pin "16" (uuid "0f9e0916-ae60-44fb-ab5b-683751b70ea6")
 		)
-		(pin "17" (uuid "33448144-3a30-4e0b-8bb7-65c114e93010")
+		(pin "17" (uuid "35faa381-8794-4e48-a50b-c24dcfc37753")
 		)
-		(pin "18" (uuid "a6aa3970-5866-4c16-8451-1b94a083f557")
+		(pin "18" (uuid "a63b1fb5-4651-42e4-a0d3-9b89a7efff9a")
 		)
-		(pin "19" (uuid "d7f7cda9-770e-4be9-8e96-bca45bba5f63")
+		(pin "19" (uuid "b1a18ae3-e5c8-4a40-a470-d01a30b466d9")
 		)
-		(pin "20" (uuid "30a7e3fa-2437-446d-8aa3-da199943ebd1")
+		(pin "20" (uuid "9add8b10-c735-4ae2-9bc3-1700ca9021d3")
 		)
-		(pin "21" (uuid "f8e9166f-14b1-491e-bbd4-78e74d024cf8")
+		(pin "21" (uuid "7fdab2e4-d86d-4015-9785-3d52992c8c73")
 		)
-		(pin "22" (uuid "9405d858-a14d-44b5-a3c3-ad96ca094a2d")
+		(pin "22" (uuid "aef8cda6-f26f-4035-9e29-e437208c5107")
 		)
-		(pin "23" (uuid "fee9d3a2-d253-4fb2-8aaf-fc72d0b5bf3d")
+		(pin "23" (uuid "aaeab9e0-8c96-469e-9a66-8417d6c8ad84")
 		)
-		(pin "24" (uuid "41f1be90-9065-4fd3-ad95-48a0768d9404")
+		(pin "24" (uuid "908b0325-b239-4f0f-a3e8-507c0b6a84ba")
 		)
 		(instances
 			(project "project"
-				(path "/c5c992a2-d28d-430b-b400-e92ec2ef4b19" (reference "U4") (unit 1)
+				(path "/3c6e0a49-39a7-454c-8046-2b8048737b80" (reference "U4") (unit 1)
 				)
 			)
 		)
 	)
 	(symbol
 		(lib_id "power:PWR_FLAG")
-		(at 25.4 7.62 0)
+		(at 12.7 7.62 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "df9851f9-f254-4156-8e41-aa2b5216ccdc")
+		(uuid "fb2de09c-71b0-449e-9165-50560b3d3927")
 		(property "Reference" "#PWR01"
-			(at 25.4 10.16 0)
+			(at 12.7 10.16 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2913,7 +4536,7 @@
 			)
 		)
 		(property "Value" "PWR_FLAG"
-			(at 25.4 12.7 0)
+			(at 12.7 12.7 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2921,7 +4544,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 25.4 7.62 0)
+			(at 12.7 7.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2930,7 +4553,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 25.4 7.62 0)
+			(at 12.7 7.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2938,26 +4561,26 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "7c389734-91f1-476e-967d-98f1d28abaa4")
+		(pin "1" (uuid "08c770ce-3a48-4fdc-83d8-8d230cb7a826")
 		)
 		(instances
 			(project "project"
-				(path "/c5c992a2-d28d-430b-b400-e92ec2ef4b19" (reference "#PWR01") (unit 1)
+				(path "/3c6e0a49-39a7-454c-8046-2b8048737b80" (reference "#PWR01") (unit 1)
 				)
 			)
 		)
 	)
 	(symbol
 		(lib_id "power:PWR_FLAG")
-		(at 25.4 17.78 0)
+		(at 12.7 17.78 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "3ee691f2-645d-4a3a-899f-51f8b333ae78")
+		(uuid "eeb8e608-a0ac-4dbe-bd43-97c95b2ca48d")
 		(property "Reference" "#PWR02"
-			(at 25.4 20.32 0)
+			(at 12.7 20.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2966,7 +4589,7 @@
 			)
 		)
 		(property "Value" "PWR_FLAG"
-			(at 25.4 22.86 0)
+			(at 12.7 22.86 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2974,7 +4597,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 25.4 17.78 0)
+			(at 12.7 17.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2983,7 +4606,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 25.4 17.78 0)
+			(at 12.7 17.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2991,26 +4614,26 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "00df4b25-bbd1-47ea-bee0-18f42b6b2743")
+		(pin "1" (uuid "63ba62e1-c4e4-40fc-8767-5ba4eb3176fd")
 		)
 		(instances
 			(project "project"
-				(path "/c5c992a2-d28d-430b-b400-e92ec2ef4b19" (reference "#PWR02") (unit 1)
+				(path "/3c6e0a49-39a7-454c-8046-2b8048737b80" (reference "#PWR02") (unit 1)
 				)
 			)
 		)
 	)
 	(symbol
 		(lib_id "power:PWR_FLAG")
-		(at 25.4 27.94 0)
+		(at 12.7 27.94 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "756ef65f-d427-4792-9272-8e838b08ad1a")
+		(uuid "f04ef4b8-cf4a-4720-9101-1551e6cd9f02")
 		(property "Reference" "#PWR03"
-			(at 25.4 30.48 0)
+			(at 12.7 30.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3019,7 +4642,7 @@
 			)
 		)
 		(property "Value" "PWR_FLAG"
-			(at 25.4 33.02 0)
+			(at 12.7 33.02 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3027,7 +4650,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 25.4 27.94 0)
+			(at 12.7 27.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3036,7 +4659,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 25.4 27.94 0)
+			(at 12.7 27.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3044,26 +4667,26 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "468cef37-8df8-460b-897b-ab3ed277d6fe")
+		(pin "1" (uuid "d39f9c3f-e17b-4926-8079-6b7c8526de53")
 		)
 		(instances
 			(project "project"
-				(path "/c5c992a2-d28d-430b-b400-e92ec2ef4b19" (reference "#PWR03") (unit 1)
+				(path "/3c6e0a49-39a7-454c-8046-2b8048737b80" (reference "#PWR03") (unit 1)
 				)
 			)
 		)
 	)
 	(symbol
 		(lib_id "power:PWR_FLAG")
-		(at 25.4 38.1 0)
+		(at 12.7 38.1 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "71521344-842d-49ea-ad71-e39a7b479daf")
+		(uuid "cbb1d7cb-ed8b-40b0-a7b7-6b7aee2f333b")
 		(property "Reference" "#PWR04"
-			(at 25.4 40.64 0)
+			(at 12.7 40.64 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3072,7 +4695,7 @@
 			)
 		)
 		(property "Value" "PWR_FLAG"
-			(at 25.4 43.18 0)
+			(at 12.7 43.18 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3080,7 +4703,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 25.4 38.1 0)
+			(at 12.7 38.1 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3089,7 +4712,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 25.4 38.1 0)
+			(at 12.7 38.1 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3097,26 +4720,26 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "7e8187e1-9d24-4fe0-907f-91c23d2e6554")
+		(pin "1" (uuid "b375850e-7d35-4c11-8702-75a4a9b39157")
 		)
 		(instances
 			(project "project"
-				(path "/c5c992a2-d28d-430b-b400-e92ec2ef4b19" (reference "#PWR04") (unit 1)
+				(path "/3c6e0a49-39a7-454c-8046-2b8048737b80" (reference "#PWR04") (unit 1)
 				)
 			)
 		)
 	)
 	(symbol
 		(lib_id "power:PWR_FLAG")
-		(at 25.4 226.06 0)
+		(at 12.7 297.18 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "8a4a0f5b-16f7-495e-b608-49de83d500a0")
+		(uuid "e468934c-45ce-44d8-be41-ff0cd3de74f6")
 		(property "Reference" "#PWR05"
-			(at 25.4 228.6 0)
+			(at 12.7 299.72 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3125,7 +4748,7 @@
 			)
 		)
 		(property "Value" "PWR_FLAG"
-			(at 25.4 231.14 0)
+			(at 12.7 302.26 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3133,7 +4756,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 25.4 226.06 0)
+			(at 12.7 297.18 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3142,7 +4765,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 25.4 226.06 0)
+			(at 12.7 297.18 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3150,251 +4773,3428 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "af0a8ffc-0473-49af-9d7c-956aa13f4a6f")
+		(pin "1" (uuid "45b321a6-c0e0-4821-b60d-7001fd6e8939")
 		)
 		(instances
 			(project "project"
-				(path "/c5c992a2-d28d-430b-b400-e92ec2ef4b19" (reference "#PWR05") (unit 1)
+				(path "/3c6e0a49-39a7-454c-8046-2b8048737b80" (reference "#PWR05") (unit 1)
 				)
 			)
 		)
 	)
-	(global_label "VBUS_USB" (shape input) (at 25.4 7.62 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 40.64 35.56) (xy 35.56 35.56))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "cb9b3ea7-5ca9-4682-a6d3-e437e55dda4f")
+		(uuid "f316b0f5-6a20-4d89-abf3-43c180df7995")
 	)
-	(global_label "+3V3" (shape input) (at 25.4 17.78 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 40.64 38.1) (xy 35.56 38.1))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "d2c32ad4-48ee-413d-bdc6-de3c435180f4")
+		(uuid "eb385a5f-27d7-4fc2-9088-6224b9ec6014")
 	)
-	(global_label "+1V8" (shape input) (at 25.4 27.94 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 40.64 40.64) (xy 35.56 40.64))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "5d6d0366-1ec3-4bf0-b593-f0c20b101d31")
+		(uuid "3db0246c-da53-47f7-b734-849124662373")
 	)
-	(global_label "+1V2" (shape input) (at 25.4 38.1 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 40.64 43.18) (xy 35.56 43.18))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "21cceec0-d958-4abb-a966-468ffe2952f7")
+		(uuid "f195ac04-487a-4ed4-8dc5-94c1c35f82a0")
 	)
-	(global_label "GND" (shape input) (at 25.4 226.06 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 40.64 45.72) (xy 35.56 45.72))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "9a4e0dbb-3d9c-4d44-8da8-81d6d0fbbcd2")
+		(uuid "033cea7c-b339-4f96-894a-466048c77c4f")
 	)
-	(global_label "USB2_D+" (shape bidirectional) (at 190.5 50.8 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 40.64 48.26) (xy 35.56 48.26))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "d7863bba-4081-4c74-904b-c446594daf07")
+		(uuid "a14d4f24-36b7-49c8-b5a4-2103f3ce22d8")
 	)
-	(global_label "USB2_D-" (shape bidirectional) (at 190.5 55.88 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 40.64 50.8) (xy 35.56 50.8))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "80388497-3af5-4b8d-b069-e13568d2a72b")
+		(uuid "b3563225-7385-4eee-aa08-96d2e0d49df7")
 	)
-	(global_label "USB3_TX1+" (shape bidirectional) (at 190.5 63.5 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 40.64 53.34) (xy 35.56 53.34))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "2d78d87d-7eba-4b57-8864-a62277d4eac2")
+		(uuid "260b31b5-fd73-4ef3-98d8-1edf41943879")
 	)
-	(global_label "USB3_TX1-" (shape bidirectional) (at 190.5 68.58 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 40.64 55.88) (xy 35.56 55.88))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "e95528ac-2922-4986-a652-846494c37d32")
+		(uuid "4c2f1a18-158c-4223-89d9-c26590d0736a")
 	)
-	(global_label "USB3_RX1+" (shape bidirectional) (at 190.5 76.2 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 40.64 58.42) (xy 35.56 58.42))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "19176ff6-2ab2-4eda-b9cc-2e5ad78474dd")
+		(uuid "aed1d8ab-733e-4999-9ee0-ca3d316fe122")
 	)
-	(global_label "USB3_RX1-" (shape bidirectional) (at 190.5 81.28 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 40.64 60.96) (xy 35.56 60.96))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "7718226d-f621-4983-adf4-88c397dcbf95")
+		(uuid "0e7e560c-6a06-4d5b-a095-cbb32473ec98")
 	)
-	(global_label "USB3_TX2+" (shape bidirectional) (at 190.5 88.9 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 40.64 63.5) (xy 35.56 63.5))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "4d5d88da-daac-43f2-a9c8-d620021c72f6")
+		(uuid "ccea84e4-0d29-4223-92b1-b58e72cac95a")
 	)
-	(global_label "USB3_TX2-" (shape bidirectional) (at 190.5 93.98 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 40.64 66.04) (xy 35.56 66.04))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "57765a8a-3da8-4a72-9769-de4aeead1569")
+		(uuid "ca07ef7c-10ac-4fdd-a968-f7314173c1a5")
 	)
-	(global_label "USB3_RX2+" (shape bidirectional) (at 190.5 101.6 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 60.96 35.56) (xy 66.04 35.56))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "a0e948df-0c97-4a34-b052-04504d17b83a")
+		(uuid "7465bd4b-2bfc-4025-8509-837153fe13d3")
 	)
-	(global_label "USB3_RX2-" (shape bidirectional) (at 190.5 106.68 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 60.96 38.1) (xy 66.04 38.1))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "c24e5a9e-4809-4ece-b3de-c8b41e4ed18b")
+		(uuid "ec1647f1-beba-44f9-ae2e-a7447dcad1e1")
 	)
-	(global_label "PCIE_TX+" (shape bidirectional) (at 190.5 114.3 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 60.96 40.64) (xy 66.04 40.64))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "b7003e39-f589-488b-bb77-c4bcd9f6466e")
+		(uuid "26cb6558-18fa-4ba2-9019-c00aae48f7c9")
 	)
-	(global_label "PCIE_TX-" (shape bidirectional) (at 190.5 119.38 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 60.96 43.18) (xy 66.04 43.18))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "1d0882bc-1fbd-4882-a2f3-db726ac38cd8")
+		(uuid "ee398dc0-1ceb-4ca5-865e-5bc249a215df")
 	)
-	(global_label "PCIE_RX+" (shape bidirectional) (at 190.5 127 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 60.96 45.72) (xy 66.04 45.72))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "49f0cb0e-cbb6-461d-9446-d296ec6e2e68")
+		(uuid "93d384a5-772b-4339-9a3f-06a13745b277")
 	)
-	(global_label "PCIE_RX-" (shape bidirectional) (at 190.5 132.08 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 60.96 48.26) (xy 66.04 48.26))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "f8dcb613-17f4-46cb-9f63-fde61303f0f7")
+		(uuid "d3a95ed8-e289-4bae-8939-efc41e64b0ea")
 	)
-	(global_label "MIPI_CLK+" (shape bidirectional) (at 190.5 139.7 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 60.96 50.8) (xy 66.04 50.8))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "a2d5d3f7-af3c-42cc-9a60-906c8cf67a45")
+		(uuid "9ccbe85b-cf27-4ca3-bc74-de3ad64ecd14")
 	)
-	(global_label "MIPI_CLK-" (shape bidirectional) (at 190.5 144.78 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 60.96 53.34) (xy 66.04 53.34))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "af3e4a67-9248-4982-8abb-ff1524b5b78c")
+		(uuid "41941b36-2722-4339-a706-327e4f0f3259")
 	)
-	(global_label "MIPI_D0+" (shape bidirectional) (at 190.5 152.4 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 60.96 55.88) (xy 66.04 55.88))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "e94e2e19-8c05-4a46-a89d-bfeebbdc6e9b")
+		(uuid "de9cb2b7-6abb-4caa-a846-c4dcde38ecf4")
 	)
-	(global_label "MIPI_D0-" (shape bidirectional) (at 190.5 157.48 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 60.96 58.42) (xy 66.04 58.42))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "e9cee9a5-a03b-4c54-909c-e5fcd140f72f")
+		(uuid "b480faf5-954d-4249-ae44-fb201ef3a241")
 	)
-	(global_label "USB_CC1" (shape bidirectional) (at 190.5 165.1 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 60.96 60.96) (xy 66.04 60.96))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "29869766-e2b3-445d-b52a-c1330e4c10a5")
+		(uuid "75d27af1-15ff-4f78-91e4-e0a912e6e841")
 	)
-	(global_label "USB_CC2" (shape bidirectional) (at 190.5 170.18 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 60.96 63.5) (xy 66.04 63.5))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "53c0dba5-202c-4bed-9d56-f91ad1e4af8c")
+		(uuid "101836a6-0d95-4134-b75d-21973d524e73")
 	)
-	(global_label "MIPI_RST" (shape bidirectional) (at 190.5 175.26 0) (fields_autoplaced yes)
+	(wire
+		(pts (xy 60.96 66.04) (xy 66.04 66.04))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a9620c85-4941-48a0-b3b1-c3136ff1cbde")
+	)
+	(wire
+		(pts (xy 41.91 100.33) (xy 36.83 100.33))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e99bea28-312a-4dea-9d55-9ce14f732c2c")
+	)
+	(wire
+		(pts (xy 41.91 102.87) (xy 36.83 102.87))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1a0df916-c722-4f2d-ae7e-d8b91ce4d0d3")
+	)
+	(wire
+		(pts (xy 41.91 105.41) (xy 36.83 105.41))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4e40524e-ebec-44c9-8fd9-6bc308e9bfaf")
+	)
+	(wire
+		(pts (xy 41.91 107.95) (xy 36.83 107.95))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fe7be71c-ae6d-442a-a1b8-c483b9e03d74")
+	)
+	(wire
+		(pts (xy 41.91 110.49) (xy 36.83 110.49))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1e212134-f68f-42e7-97be-38a719a7774b")
+	)
+	(wire
+		(pts (xy 41.91 113.03) (xy 36.83 113.03))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e78681e9-8eb6-42ec-b7b3-a0691f390c69")
+	)
+	(wire
+		(pts (xy 59.69 100.33) (xy 64.77 100.33))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "05128cab-2fec-4507-a9f4-a88e4dc09077")
+	)
+	(wire
+		(pts (xy 59.69 102.87) (xy 64.77 102.87))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2fa618ca-0c8d-4ab1-b763-0a6f3c14468f")
+	)
+	(wire
+		(pts (xy 59.69 105.41) (xy 64.77 105.41))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "345064b4-d7ad-4d02-ba61-384d117ab2ec")
+	)
+	(wire
+		(pts (xy 59.69 107.95) (xy 64.77 107.95))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ad167a5d-3614-4f56-818f-3ee6ef25bea8")
+	)
+	(wire
+		(pts (xy 59.69 110.49) (xy 64.77 110.49))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b924a91c-b3c1-400b-a8c2-265e87d63a22")
+	)
+	(wire
+		(pts (xy 59.69 113.03) (xy 64.77 113.03))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7d3ac9b2-d897-494f-a6ce-758daf34325d")
+	)
+	(wire
+		(pts (xy 40.64 133.35) (xy 35.56 133.35))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "08a0a651-7a40-4a9f-969c-ce190c1cb214")
+	)
+	(wire
+		(pts (xy 40.64 135.89) (xy 35.56 135.89))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "222343aa-b355-48cf-a58f-8edb92e0872c")
+	)
+	(wire
+		(pts (xy 40.64 138.43) (xy 35.56 138.43))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "00b4ae4e-2428-4ea0-8fa2-4d772ddefcae")
+	)
+	(wire
+		(pts (xy 40.64 140.97) (xy 35.56 140.97))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6adc49a9-5a54-427b-9e13-aee784b5c514")
+	)
+	(wire
+		(pts (xy 60.96 133.35) (xy 66.04 133.35))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9aa069ad-06ef-4f8a-8b8e-fc586a1fb31c")
+	)
+	(wire
+		(pts (xy 60.96 135.89) (xy 66.04 135.89))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9c85570f-26ec-46f1-9939-477f00814533")
+	)
+	(wire
+		(pts (xy 60.96 138.43) (xy 66.04 138.43))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "58c2d0d7-e80e-4ca0-b67b-3f937484b458")
+	)
+	(wire
+		(pts (xy 168.91 31.75) (xy 163.83 31.75))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "56c0411b-2ea0-4afa-9add-14bc22a03c58")
+	)
+	(wire
+		(pts (xy 168.91 34.29) (xy 163.83 34.29))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1a2a65c8-81db-4ac0-8e33-d162611c3810")
+	)
+	(wire
+		(pts (xy 168.91 36.83) (xy 163.83 36.83))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1bd302f2-20a5-4df1-9009-14b0c27d867e")
+	)
+	(wire
+		(pts (xy 168.91 39.37) (xy 163.83 39.37))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "79002ce8-ae2e-47b4-992a-3d1a3170ee74")
+	)
+	(wire
+		(pts (xy 168.91 41.91) (xy 163.83 41.91))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cf375b24-b108-47f1-a7b9-8d49a310c045")
+	)
+	(wire
+		(pts (xy 168.91 44.45) (xy 163.83 44.45))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5db1d694-3ee5-4d6f-bb9b-079de25ee3eb")
+	)
+	(wire
+		(pts (xy 168.91 46.99) (xy 163.83 46.99))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9dde5983-b829-404f-8b37-711730e992bd")
+	)
+	(wire
+		(pts (xy 168.91 49.53) (xy 163.83 49.53))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9a7b9cb5-6abe-4773-ad57-221b210ac258")
+	)
+	(wire
+		(pts (xy 168.91 52.07) (xy 163.83 52.07))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5e9711d4-de7f-47a2-b7a9-9aaf8a6ba2a0")
+	)
+	(wire
+		(pts (xy 168.91 54.61) (xy 163.83 54.61))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cda1cecb-4e95-46a4-bfc1-b271b0e9c2e9")
+	)
+	(wire
+		(pts (xy 168.91 57.15) (xy 163.83 57.15))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "81d51c99-932c-45ff-abdc-65caa62ed58f")
+	)
+	(wire
+		(pts (xy 168.91 59.69) (xy 163.83 59.69))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "69053468-2440-418e-a17c-e7def8f7e797")
+	)
+	(wire
+		(pts (xy 168.91 62.23) (xy 163.83 62.23))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "75b121a1-b24e-46ef-b8dd-e198b687bc76")
+	)
+	(wire
+		(pts (xy 168.91 64.77) (xy 163.83 64.77))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "86b07ec8-a7b0-4569-bde2-5159e2f517e0")
+	)
+	(wire
+		(pts (xy 168.91 67.31) (xy 163.83 67.31))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f6012483-f375-49e9-8913-b1a0815d47e5")
+	)
+	(wire
+		(pts (xy 168.91 69.85) (xy 163.83 69.85))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d4d81ec9-1cb7-4832-9ac1-9ac81415cd5e")
+	)
+	(wire
+		(pts (xy 186.69 31.75) (xy 191.77 31.75))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "912d2012-56d8-43f9-80cd-a41e3c339a32")
+	)
+	(wire
+		(pts (xy 186.69 34.29) (xy 191.77 34.29))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "761688af-95c8-471a-8752-a93d110f5ef5")
+	)
+	(wire
+		(pts (xy 186.69 36.83) (xy 191.77 36.83))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "17454ec3-8117-4568-b8ba-017770aa212e")
+	)
+	(wire
+		(pts (xy 186.69 39.37) (xy 191.77 39.37))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a17f4633-ed81-424d-a1b4-31c764d74493")
+	)
+	(wire
+		(pts (xy 186.69 41.91) (xy 191.77 41.91))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b6f3cc28-c9d3-4c85-812d-f47756437c88")
+	)
+	(wire
+		(pts (xy 186.69 44.45) (xy 191.77 44.45))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "54dbcb94-874a-4877-8d59-083991bf5af3")
+	)
+	(wire
+		(pts (xy 186.69 46.99) (xy 191.77 46.99))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "15e01ad0-cb38-4df9-ba6e-ad29568c8fe5")
+	)
+	(wire
+		(pts (xy 186.69 49.53) (xy 191.77 49.53))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8aebcc51-49c9-430d-be04-1fc25a733e19")
+	)
+	(wire
+		(pts (xy 186.69 52.07) (xy 191.77 52.07))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3391732e-7d94-4167-9151-55aae02a3b5b")
+	)
+	(wire
+		(pts (xy 186.69 54.61) (xy 191.77 54.61))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a7570edb-cc39-4419-8f0a-80268a1438ea")
+	)
+	(wire
+		(pts (xy 186.69 57.15) (xy 191.77 57.15))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "072cb08d-3cce-4d68-907c-6b21e235d586")
+	)
+	(wire
+		(pts (xy 186.69 59.69) (xy 191.77 59.69))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "85611c95-e04c-4003-8810-923b909dfa5c")
+	)
+	(wire
+		(pts (xy 186.69 62.23) (xy 191.77 62.23))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a19cbfa0-2a55-46f0-98ad-1fb66a7bcd6c")
+	)
+	(wire
+		(pts (xy 186.69 64.77) (xy 191.77 64.77))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2879de27-f5b8-468a-911b-479e8f666d5d")
+	)
+	(wire
+		(pts (xy 186.69 67.31) (xy 191.77 67.31))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c3426e92-479e-4a08-a486-e51494273a70")
+	)
+	(wire
+		(pts (xy 186.69 69.85) (xy 191.77 69.85))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1cc30dd5-cbcd-427d-9589-29b24828e40c")
+	)
+	(wire
+		(pts (xy 168.91 96.52) (xy 163.83 96.52))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ff9eed40-48bf-43ef-9572-6e5d4f8c3723")
+	)
+	(wire
+		(pts (xy 168.91 99.06) (xy 163.83 99.06))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4cc2a529-13b5-40fa-8fe4-c951700bd0c9")
+	)
+	(wire
+		(pts (xy 168.91 101.6) (xy 163.83 101.6))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "09c9f856-a552-452b-8a5b-1ebf6fe9d680")
+	)
+	(wire
+		(pts (xy 168.91 104.14) (xy 163.83 104.14))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2cde93ef-3c92-4b7e-bcb1-6201451f2d96")
+	)
+	(wire
+		(pts (xy 168.91 106.68) (xy 163.83 106.68))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d8f1d488-01cb-40a8-875e-10931e266d39")
+	)
+	(wire
+		(pts (xy 168.91 109.22) (xy 163.83 109.22))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "eb47cd96-94ad-455e-85fd-552bf106bb1b")
+	)
+	(wire
+		(pts (xy 168.91 111.76) (xy 163.83 111.76))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "31744197-d10d-40b3-881b-cb418c9a0e36")
+	)
+	(wire
+		(pts (xy 168.91 114.3) (xy 163.83 114.3))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "090ec0dd-0412-441f-9cc1-5751a2a8519f")
+	)
+	(wire
+		(pts (xy 168.91 116.84) (xy 163.83 116.84))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7c0fb2ec-2666-43a1-bdce-1d0accb39b55")
+	)
+	(wire
+		(pts (xy 168.91 119.38) (xy 163.83 119.38))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d589dc2d-7eae-4540-92c8-1b73da4207ee")
+	)
+	(wire
+		(pts (xy 168.91 121.92) (xy 163.83 121.92))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fa5e49f7-2a15-497e-8a4a-c6ac34cfbf48")
+	)
+	(wire
+		(pts (xy 168.91 124.46) (xy 163.83 124.46))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "de392172-5a82-4365-9b4c-137a10902fed")
+	)
+	(wire
+		(pts (xy 168.91 127) (xy 163.83 127))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a0ea46bb-8b35-4f11-85bb-6d0928562750")
+	)
+	(wire
+		(pts (xy 168.91 129.54) (xy 163.83 129.54))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "050a588c-d18d-4e8c-a2db-f2e2d9a19565")
+	)
+	(wire
+		(pts (xy 168.91 132.08) (xy 163.83 132.08))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5a079c23-0671-4deb-822b-c4a4dc65c90f")
+	)
+	(wire
+		(pts (xy 168.91 134.62) (xy 163.83 134.62))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1d768e12-ba36-4f38-b864-64c6eaffc29c")
+	)
+	(wire
+		(pts (xy 168.91 137.16) (xy 163.83 137.16))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cbb3a43d-6226-448d-88ad-ad5d7d471f36")
+	)
+	(wire
+		(pts (xy 168.91 139.7) (xy 163.83 139.7))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3e2391a3-3ae1-4ef8-ad2f-d9858a6b86c2")
+	)
+	(wire
+		(pts (xy 168.91 142.24) (xy 163.83 142.24))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c6db14c7-1a7e-4507-a9b7-4ac0a739f443")
+	)
+	(wire
+		(pts (xy 168.91 144.78) (xy 163.83 144.78))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f9ba07c7-4ad1-4ad8-8622-fa96b107e0b2")
+	)
+	(wire
+		(pts (xy 168.91 147.32) (xy 163.83 147.32))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "05718f6d-ddeb-40fe-a250-4726fa46db73")
+	)
+	(wire
+		(pts (xy 168.91 149.86) (xy 163.83 149.86))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fed54162-9ce9-4996-8f52-19927e632a6a")
+	)
+	(wire
+		(pts (xy 168.91 152.4) (xy 163.83 152.4))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1b29aba1-110b-4750-acff-af784e09b8df")
+	)
+	(wire
+		(pts (xy 168.91 154.94) (xy 163.83 154.94))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "393d1183-1a31-4719-8235-a2b5bc9be5f2")
+	)
+	(wire
+		(pts (xy 168.91 157.48) (xy 163.83 157.48))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "984a82c6-97be-4112-ab05-475a8cdec02e")
+	)
+	(wire
+		(pts (xy 186.69 96.52) (xy 191.77 96.52))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "38a16a04-891f-48f1-b3cc-dcfad538353e")
+	)
+	(wire
+		(pts (xy 186.69 99.06) (xy 191.77 99.06))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1136b484-2a46-45ea-a984-0c907ca8deb8")
+	)
+	(wire
+		(pts (xy 186.69 101.6) (xy 191.77 101.6))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "62d54e23-9fad-4354-8e16-bb8f5f95b67c")
+	)
+	(wire
+		(pts (xy 186.69 104.14) (xy 191.77 104.14))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "441b4614-8560-4dad-84f7-ffa7b7e50bd8")
+	)
+	(wire
+		(pts (xy 186.69 106.68) (xy 191.77 106.68))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5039e878-403d-4f0a-b187-c6dafcaf723d")
+	)
+	(wire
+		(pts (xy 186.69 109.22) (xy 191.77 109.22))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bf562dac-290d-4a8e-802b-668ad16caa5c")
+	)
+	(wire
+		(pts (xy 186.69 111.76) (xy 191.77 111.76))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1b45d924-3ac1-4e80-b6b8-72d38f8b99ae")
+	)
+	(wire
+		(pts (xy 186.69 114.3) (xy 191.77 114.3))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4c614d83-5ae1-48cf-b644-9477b024b705")
+	)
+	(wire
+		(pts (xy 186.69 116.84) (xy 191.77 116.84))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6db7cd6d-f3ea-4e93-9170-f34052854c68")
+	)
+	(wire
+		(pts (xy 186.69 119.38) (xy 191.77 119.38))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "87e2f6ef-beb4-46b5-99fc-4c3d1bbc813f")
+	)
+	(wire
+		(pts (xy 186.69 121.92) (xy 191.77 121.92))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3e6a3bb5-20cf-4c52-a794-9791a447d157")
+	)
+	(wire
+		(pts (xy 186.69 124.46) (xy 191.77 124.46))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "69ea1795-dad2-423b-88f5-503d6d21e987")
+	)
+	(wire
+		(pts (xy 186.69 127) (xy 191.77 127))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5d1b9ebd-f784-4f96-8e2f-c940e46a68b5")
+	)
+	(wire
+		(pts (xy 186.69 129.54) (xy 191.77 129.54))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3b8bbbaa-448e-48c3-b49b-ac1596b8ce6b")
+	)
+	(wire
+		(pts (xy 186.69 132.08) (xy 191.77 132.08))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e05fa8e0-2f19-4ff8-b748-10ec1a9709e6")
+	)
+	(wire
+		(pts (xy 186.69 134.62) (xy 191.77 134.62))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c2e5d7ff-68cc-4ef6-9d5b-ee0a67219cdc")
+	)
+	(wire
+		(pts (xy 186.69 137.16) (xy 191.77 137.16))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b3f42cbf-9cd8-4040-9aa7-42f8c2eb6f8f")
+	)
+	(wire
+		(pts (xy 186.69 139.7) (xy 191.77 139.7))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c4ae475e-bf3b-4cf7-825f-1e4c982afdb7")
+	)
+	(wire
+		(pts (xy 186.69 142.24) (xy 191.77 142.24))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5e313895-1a93-42ab-a346-0223d73352ee")
+	)
+	(wire
+		(pts (xy 186.69 144.78) (xy 191.77 144.78))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1083cc80-c890-4c63-881c-abc7248e87ab")
+	)
+	(wire
+		(pts (xy 186.69 147.32) (xy 191.77 147.32))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0372ce91-6e22-44a1-9348-78c876a9c3cb")
+	)
+	(wire
+		(pts (xy 186.69 149.86) (xy 191.77 149.86))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0866b4e3-e300-4549-8188-6efe327dd831")
+	)
+	(wire
+		(pts (xy 186.69 152.4) (xy 191.77 152.4))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5c3a2d69-04a7-4a48-b44d-0155fc28ea2d")
+	)
+	(wire
+		(pts (xy 186.69 154.94) (xy 191.77 154.94))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e0c12999-b227-4eb7-98d0-bd244fd20bfc")
+	)
+	(wire
+		(pts (xy 168.91 173.99) (xy 163.83 173.99))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "13bb839e-5c03-4bb0-87b4-e58f16b5abac")
+	)
+	(wire
+		(pts (xy 168.91 176.53) (xy 163.83 176.53))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8d6ddd0d-d437-4ea2-a0e1-86b6603b6d1f")
+	)
+	(wire
+		(pts (xy 168.91 179.07) (xy 163.83 179.07))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3d5dac55-5af5-44b5-96d6-5e8dd14dd351")
+	)
+	(wire
+		(pts (xy 168.91 181.61) (xy 163.83 181.61))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "699db213-d244-4aff-8975-3579b2ae7e4a")
+	)
+	(wire
+		(pts (xy 168.91 184.15) (xy 163.83 184.15))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "92daf68a-0248-4b03-95b5-952c0d4fb707")
+	)
+	(wire
+		(pts (xy 168.91 186.69) (xy 163.83 186.69))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a46981aa-b423-4c2b-907e-a49f79eab088")
+	)
+	(wire
+		(pts (xy 168.91 189.23) (xy 163.83 189.23))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "07e7e425-5422-473b-94c8-5391e8671c14")
+	)
+	(wire
+		(pts (xy 168.91 191.77) (xy 163.83 191.77))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "659de956-1235-4259-be4c-f8277d98e723")
+	)
+	(wire
+		(pts (xy 168.91 194.31) (xy 163.83 194.31))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9194fde6-9517-4068-b11a-e1e9606581cd")
+	)
+	(wire
+		(pts (xy 168.91 196.85) (xy 163.83 196.85))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "58b838dd-e94e-4b46-9683-598371f5c166")
+	)
+	(wire
+		(pts (xy 168.91 199.39) (xy 163.83 199.39))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "21587d3d-d2c4-48ed-96c9-aed8c397a905")
+	)
+	(wire
+		(pts (xy 168.91 201.93) (xy 163.83 201.93))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "677b6b88-6172-4a86-9df5-7763dd14bd5b")
+	)
+	(wire
+		(pts (xy 168.91 204.47) (xy 163.83 204.47))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9853deaa-020f-4278-95cb-066006b0434f")
+	)
+	(wire
+		(pts (xy 168.91 207.01) (xy 163.83 207.01))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "919eff8f-c152-4002-bc6d-8ed9b38fac56")
+	)
+	(wire
+		(pts (xy 168.91 209.55) (xy 163.83 209.55))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d83f2af8-c702-44e6-aad4-23c35231ee98")
+	)
+	(wire
+		(pts (xy 168.91 212.09) (xy 163.83 212.09))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "03acf14b-53eb-404b-be22-799df2f313cf")
+	)
+	(wire
+		(pts (xy 168.91 214.63) (xy 163.83 214.63))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "474c64bc-4ceb-4ec3-bcdf-2fc9616e15b3")
+	)
+	(wire
+		(pts (xy 168.91 217.17) (xy 163.83 217.17))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ce5e876d-1273-4eec-8368-26318a61df78")
+	)
+	(wire
+		(pts (xy 168.91 219.71) (xy 163.83 219.71))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3e9da921-f87d-4e11-832c-2b0a7e6c4c9c")
+	)
+	(wire
+		(pts (xy 168.91 222.25) (xy 163.83 222.25))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f89be149-8f55-49e0-8fd4-d30dbb183ef4")
+	)
+	(wire
+		(pts (xy 168.91 224.79) (xy 163.83 224.79))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dcd311cd-bc00-4072-985a-bdb676fef180")
+	)
+	(wire
+		(pts (xy 168.91 227.33) (xy 163.83 227.33))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3e606987-fc35-4abb-913d-a441a1ded6e6")
+	)
+	(wire
+		(pts (xy 168.91 229.87) (xy 163.83 229.87))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dcbef042-add7-47bf-99a2-cafaaec10c90")
+	)
+	(wire
+		(pts (xy 168.91 232.41) (xy 163.83 232.41))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "594736a4-725f-4ee2-b6f8-d3a39126cebe")
+	)
+	(wire
+		(pts (xy 186.69 173.99) (xy 191.77 173.99))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "15145328-f284-4780-a907-13b3d1866136")
+	)
+	(wire
+		(pts (xy 186.69 176.53) (xy 191.77 176.53))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2dbc9fa3-48f0-49b2-a49e-f67c98680cab")
+	)
+	(wire
+		(pts (xy 186.69 179.07) (xy 191.77 179.07))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6fa1393a-312f-4ab5-9cc5-d7fd97cc9d67")
+	)
+	(wire
+		(pts (xy 186.69 181.61) (xy 191.77 181.61))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "10d8f60f-f496-4bea-b7fd-2f5cabbaa74f")
+	)
+	(wire
+		(pts (xy 186.69 184.15) (xy 191.77 184.15))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e897391d-3956-4baf-b2fd-6e30f0d5ab01")
+	)
+	(wire
+		(pts (xy 186.69 186.69) (xy 191.77 186.69))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "46bd942d-b4f1-47ab-8577-e7eee05c57e4")
+	)
+	(wire
+		(pts (xy 186.69 189.23) (xy 191.77 189.23))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "724a35a5-8618-4848-8438-654c57d8faf0")
+	)
+	(wire
+		(pts (xy 186.69 191.77) (xy 191.77 191.77))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "31371302-6ca0-4964-84e4-0b6295ae4641")
+	)
+	(wire
+		(pts (xy 186.69 194.31) (xy 191.77 194.31))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5fcd7097-4892-4eea-89dc-33c5c5978d99")
+	)
+	(wire
+		(pts (xy 186.69 196.85) (xy 191.77 196.85))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "437d17d3-0848-4a7c-9eee-e64092ec0c01")
+	)
+	(wire
+		(pts (xy 186.69 199.39) (xy 191.77 199.39))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bf77247e-9968-4646-b528-4105cd22f266")
+	)
+	(wire
+		(pts (xy 186.69 201.93) (xy 191.77 201.93))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3d335286-f9a6-4935-bc3e-cd78ce88c348")
+	)
+	(wire
+		(pts (xy 186.69 204.47) (xy 191.77 204.47))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "055a982c-4a0c-4f7d-b526-26f94c3880df")
+	)
+	(wire
+		(pts (xy 186.69 207.01) (xy 191.77 207.01))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aaf6a79a-087e-4039-8994-16cec8905eda")
+	)
+	(wire
+		(pts (xy 186.69 209.55) (xy 191.77 209.55))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "53749a15-9739-4670-a2ad-bfd7ecf3dda2")
+	)
+	(wire
+		(pts (xy 186.69 212.09) (xy 191.77 212.09))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "83e1de8a-e850-4b01-ae3a-3d4ed622ecee")
+	)
+	(wire
+		(pts (xy 186.69 214.63) (xy 191.77 214.63))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cffe9a79-96a9-4e99-88ee-6a817e3cfb7e")
+	)
+	(wire
+		(pts (xy 186.69 217.17) (xy 191.77 217.17))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8a926ca9-d49f-4f83-b706-d5413375c8c9")
+	)
+	(wire
+		(pts (xy 186.69 219.71) (xy 191.77 219.71))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7b6b87dd-f84d-4a44-9370-525111dc37d8")
+	)
+	(wire
+		(pts (xy 186.69 222.25) (xy 191.77 222.25))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9058040f-2c1d-4087-8134-8ecf31f07b9c")
+	)
+	(wire
+		(pts (xy 186.69 224.79) (xy 191.77 224.79))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "58788f90-a797-4f6a-b866-aa6cf679bf0b")
+	)
+	(wire
+		(pts (xy 186.69 227.33) (xy 191.77 227.33))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b09b7864-eb1e-44b7-83e7-55df2a389f55")
+	)
+	(wire
+		(pts (xy 186.69 229.87) (xy 191.77 229.87))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c6a0b059-489f-4978-a29d-8380c82ade28")
+	)
+	(wire
+		(pts (xy 186.69 232.41) (xy 191.77 232.41))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1cdd9c49-bdf4-49b9-9fae-ab92a379bc19")
+	)
+	(wire
+		(pts (xy 168.91 252.73) (xy 163.83 252.73))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "036205c5-724d-4643-90e3-3a4974c9084f")
+	)
+	(wire
+		(pts (xy 168.91 255.27) (xy 163.83 255.27))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f183256d-3d49-46cb-ac46-9c71e818c82c")
+	)
+	(wire
+		(pts (xy 168.91 257.81) (xy 163.83 257.81))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "799a7af0-38e9-4704-a6a0-f61697a902f0")
+	)
+	(wire
+		(pts (xy 168.91 260.35) (xy 163.83 260.35))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "88c20053-6259-44e3-ab68-52acec87fb49")
+	)
+	(wire
+		(pts (xy 168.91 262.89) (xy 163.83 262.89))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aa11b3d2-795a-4e13-8782-091d20a25bd8")
+	)
+	(wire
+		(pts (xy 168.91 265.43) (xy 163.83 265.43))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2bb4ed6b-d281-45bb-b789-62aac1bcb6b5")
+	)
+	(wire
+		(pts (xy 168.91 267.97) (xy 163.83 267.97))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "00089f14-b556-4941-a475-a2547eea718d")
+	)
+	(wire
+		(pts (xy 168.91 270.51) (xy 163.83 270.51))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "479d7306-6885-48eb-a3b5-a2ed9dd8da23")
+	)
+	(wire
+		(pts (xy 168.91 273.05) (xy 163.83 273.05))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b8d4c65f-9925-4b5b-8830-5e499c736c67")
+	)
+	(wire
+		(pts (xy 168.91 275.59) (xy 163.83 275.59))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4a11f2c8-9002-4b4b-9a10-8df9e96e28cd")
+	)
+	(wire
+		(pts (xy 168.91 278.13) (xy 163.83 278.13))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c2d8e7cf-1314-4891-bdd3-765ddf6145f4")
+	)
+	(wire
+		(pts (xy 168.91 280.67) (xy 163.83 280.67))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2be11b17-1a3d-47fa-b311-195e023a1c29")
+	)
+	(wire
+		(pts (xy 186.69 252.73) (xy 191.77 252.73))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6ded972c-0ba4-415d-8a86-23c609483f44")
+	)
+	(wire
+		(pts (xy 186.69 255.27) (xy 191.77 255.27))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bad43dff-e0be-4422-b1db-91f92a6553dd")
+	)
+	(wire
+		(pts (xy 186.69 257.81) (xy 191.77 257.81))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "024d0bdc-0a89-4f6f-8039-b1092d5b0097")
+	)
+	(wire
+		(pts (xy 186.69 260.35) (xy 191.77 260.35))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3c9e7aab-8adf-48d0-b4e3-3f1806be7d8a")
+	)
+	(wire
+		(pts (xy 186.69 262.89) (xy 191.77 262.89))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0f6a59a3-c8d0-4e7a-968f-c44a956515c6")
+	)
+	(wire
+		(pts (xy 186.69 265.43) (xy 191.77 265.43))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "613dbb8b-00c1-4456-8f28-8f6ebba55a37")
+	)
+	(wire
+		(pts (xy 186.69 267.97) (xy 191.77 267.97))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d10fbb7d-8390-40a7-afee-c900e3d3e394")
+	)
+	(wire
+		(pts (xy 186.69 270.51) (xy 191.77 270.51))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ed7f9ace-1691-48b7-9ee4-16c9e5aef2f4")
+	)
+	(wire
+		(pts (xy 186.69 273.05) (xy 191.77 273.05))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4004449f-88d5-4fa0-81c3-7cc86dfd8625")
+	)
+	(wire
+		(pts (xy 186.69 275.59) (xy 191.77 275.59))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2e842e56-bc2b-410c-ab46-25fcf2e24979")
+	)
+	(wire
+		(pts (xy 186.69 278.13) (xy 191.77 278.13))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c7a35d72-6dac-459a-aec8-d59230ffdece")
+	)
+	(wire
+		(pts (xy 186.69 280.67) (xy 191.77 280.67))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6622962a-063c-4553-9171-6b1793888e4d")
+	)
+	(global_label "GND" (shape bidirectional) (at 35.56 35.56 0) (fields_autoplaced yes)
 		(effects
 			(font
 				(size 1.27 1.27)
 			)
 			(justify left)
 		)
-		(uuid "81d49ae0-32ee-4916-9b40-4ca9effafcb0")
+		(uuid "67d46a6b-9561-48ef-84b2-236f3314a570")
+	)
+	(global_label "USB3_TX1+" (shape bidirectional) (at 35.56 38.1 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "e04a4040-06ea-4cc5-888f-43507e8ef365")
+	)
+	(global_label "USB3_TX1-" (shape bidirectional) (at 35.56 40.64 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "9051e53d-db6a-4514-a6f8-c273ed8c2c65")
+	)
+	(global_label "VBUS_USB" (shape bidirectional) (at 35.56 43.18 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "99e64646-93f7-42c8-b6a4-fd0c138893f3")
+	)
+	(global_label "USB_CC1" (shape bidirectional) (at 35.56 45.72 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "98c67c14-91b9-429f-baf1-14f1444cd3b7")
+	)
+	(global_label "USB2_D+" (shape bidirectional) (at 35.56 48.26 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "d5f4d4c7-447b-4223-8cb1-fd8df33d7b5e")
+	)
+	(global_label "USB2_D-" (shape bidirectional) (at 35.56 50.8 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "13158dcd-110d-47b2-83e8-5264a131e845")
+	)
+	(global_label "+3V3" (shape bidirectional) (at 35.56 53.34 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "55cca000-4822-447a-bbf5-ef03a34ec892")
+	)
+	(global_label "VBUS_USB" (shape bidirectional) (at 35.56 55.88 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "d7d0b86e-5939-466e-a228-a3ce6e7197b6")
+	)
+	(global_label "USB3_RX2-" (shape bidirectional) (at 35.56 58.42 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "fec38088-bdd4-4cba-9713-533565b1ab25")
+	)
+	(global_label "USB3_RX2+" (shape bidirectional) (at 35.56 60.96 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f63a759e-2e25-418a-991c-2702eb2fc3c9")
+	)
+	(global_label "GND" (shape bidirectional) (at 35.56 63.5 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "d51ad833-d25c-4e47-89a6-ebc3118a555f")
+	)
+	(global_label "GND" (shape bidirectional) (at 35.56 66.04 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "6b764b37-9458-4e47-9f02-13f4c1e24b91")
+	)
+	(global_label "USB3_TX2+" (shape bidirectional) (at 66.04 35.56 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "80278c5e-178d-4d9e-a88e-e4325cf3d6fc")
+	)
+	(global_label "USB3_TX2-" (shape bidirectional) (at 66.04 38.1 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "d7c6eee3-af16-48b4-a4b8-b81084f48b02")
+	)
+	(global_label "VBUS_USB" (shape bidirectional) (at 66.04 40.64 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "18fa2c0e-91d5-4360-8279-5a54a65add38")
+	)
+	(global_label "USB_CC2" (shape bidirectional) (at 66.04 43.18 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4d3b93ce-98df-42e5-9e3c-1137d051fae6")
+	)
+	(global_label "USB2_D+" (shape bidirectional) (at 66.04 45.72 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "96179960-1799-4c98-b447-7324b47e854e")
+	)
+	(global_label "USB2_D-" (shape bidirectional) (at 66.04 48.26 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "dfb7121c-1048-4f36-82eb-1312da45343c")
+	)
+	(global_label "+3V3" (shape bidirectional) (at 66.04 50.8 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "424913b4-9227-42d0-9604-38e0600ad026")
+	)
+	(global_label "VBUS_USB" (shape bidirectional) (at 66.04 53.34 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "5cd2b659-f9ce-481f-86b6-ff82111300ba")
+	)
+	(global_label "USB3_RX1-" (shape bidirectional) (at 66.04 55.88 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "a4566147-9776-425b-877a-09d701136170")
+	)
+	(global_label "USB3_RX1+" (shape bidirectional) (at 66.04 58.42 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "bc8eb2c3-e7d4-4a5a-a3ab-29d8999d8b02")
+	)
+	(global_label "GND" (shape bidirectional) (at 66.04 60.96 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "0d851ff8-156d-40ce-b2a4-63cf3ddc39c8")
+	)
+	(global_label "GND" (shape bidirectional) (at 66.04 63.5 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "e00ff9cf-49da-43d7-8fcf-8aef911e10cc")
+	)
+	(global_label "GND" (shape bidirectional) (at 66.04 66.04 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "c72277e3-8abb-478e-b04c-bc90424dffbc")
+	)
+	(global_label "GND" (shape bidirectional) (at 36.83 100.33 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "ad771130-6780-4b90-93f9-200154050ebf")
+	)
+	(global_label "GND" (shape bidirectional) (at 36.83 102.87 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "fb07004a-8c59-4101-a331-4de56cbf6715")
+	)
+	(global_label "+3V3" (shape bidirectional) (at 36.83 105.41 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "25263e30-3f19-4b68-8bca-8d54c0e7d9db")
+	)
+	(global_label "GND" (shape bidirectional) (at 36.83 107.95 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "2affc204-8f3c-4cbc-a626-bc914e1bb4ca")
+	)
+	(global_label "PCIE_TX+" (shape bidirectional) (at 36.83 110.49 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "4dd7286a-1e0d-4691-851a-7ae513564967")
+	)
+	(global_label "PCIE_TX-" (shape bidirectional) (at 36.83 113.03 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "a8d5103d-79f2-44d2-bea9-c9d0a6954205")
+	)
+	(global_label "GND" (shape bidirectional) (at 64.77 100.33 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "114c1b20-0dcb-4326-ad51-71fa3ad13414")
+	)
+	(global_label "PCIE_RX+" (shape bidirectional) (at 64.77 102.87 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "ca3bf883-0efd-4959-af51-52448c4b2daa")
+	)
+	(global_label "PCIE_RX-" (shape bidirectional) (at 64.77 105.41 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4883cede-c8b8-47a9-a50d-7664b715f3a7")
+	)
+	(global_label "+1V2" (shape bidirectional) (at 64.77 107.95 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "f19edc32-5600-4928-907d-837e6012afe6")
+	)
+	(global_label "GND" (shape bidirectional) (at 64.77 110.49 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "797c629a-6d94-4e2d-be91-825d7170a025")
+	)
+	(global_label "GND" (shape bidirectional) (at 64.77 113.03 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "2db355b8-672f-442a-8594-e18486eefc81")
+	)
+	(global_label "MIPI_CLK+" (shape bidirectional) (at 35.56 133.35 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "940c665a-b705-4e9c-b560-6d924f2bc585")
+	)
+	(global_label "MIPI_CLK-" (shape bidirectional) (at 35.56 135.89 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "bf13e831-8d04-448b-a1e3-1001480eaff5")
+	)
+	(global_label "MIPI_D0+" (shape bidirectional) (at 35.56 138.43 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "4194b77c-5ef8-49bf-84d0-f4e57f2219d5")
+	)
+	(global_label "MIPI_D0-" (shape bidirectional) (at 35.56 140.97 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "1e3405d1-995d-4788-a524-c2d0e0edcf42")
+	)
+	(global_label "GND" (shape bidirectional) (at 66.04 133.35 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "e71e618f-e556-48b7-90dd-81a549cb5737")
+	)
+	(global_label "GND" (shape bidirectional) (at 66.04 135.89 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "5c9d5133-86c6-49dc-bf6e-e22ca6366c1a")
+	)
+	(global_label "MIPI_RST" (shape bidirectional) (at 66.04 138.43 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "82a299a9-acbe-4b7b-b42f-f0774ff183d6")
+	)
+	(global_label "+3V3" (shape bidirectional) (at 163.83 31.75 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "bd90404e-4e0f-4b0d-ba45-d0cf0849a509")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 34.29 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "77cf74c3-1d55-466e-acba-128cc6ce74b5")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 36.83 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "7e011d3c-6f93-49c1-93a7-6ad9ed967680")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 39.37 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "11bf6e82-18f5-4145-8613-5d3f95779687")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 41.91 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "585f21f4-b9d9-448e-9469-888d0e0c26be")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 44.45 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "8cf63321-6ebc-40ab-ae76-30058a234bad")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 46.99 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "fa76c578-3f11-4c0b-acff-3d914d0b545b")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 49.53 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "c83cd6fe-86ad-4501-84fa-8884621a9a82")
+	)
+	(global_label "VBUS_USB" (shape bidirectional) (at 163.83 52.07 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "1e359d33-4bf0-48e0-acfa-3e6d6ee1c680")
+	)
+	(global_label "USB2_D+" (shape bidirectional) (at 163.83 54.61 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "92cf2a04-29bf-4abf-b0fb-be24aa8ef443")
+	)
+	(global_label "USB2_D-" (shape bidirectional) (at 163.83 57.15 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "2e1c80b9-3c84-41a5-a80e-884b16fc8460")
+	)
+	(global_label "USB_CC1" (shape bidirectional) (at 163.83 59.69 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "e83b4a30-491c-4501-a6cb-ab305259394a")
+	)
+	(global_label "USB_CC2" (shape bidirectional) (at 163.83 62.23 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "89660950-259e-406e-a0ce-c2b2f6243fa2")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 64.77 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "a987d6d7-8e34-4484-ae5b-488b2e54cf1e")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 67.31 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "18fa3d90-0980-4e64-8794-5812d9c9f304")
+	)
+	(global_label "+1V8" (shape bidirectional) (at 163.83 69.85 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "aa1d88ed-4cc5-46b9-8c5b-e628410dc65f")
+	)
+	(global_label "+3V3" (shape bidirectional) (at 191.77 31.75 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "cb63def1-8ed5-4dc8-9b31-c84a8a91cb46")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 34.29 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "567666b4-4ce2-4ca5-a073-579888588b6a")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 36.83 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "333f7c03-5a98-41bb-9c8f-3fc8b40c175f")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 39.37 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "10a7fffe-a228-4ec6-8c24-c5799296c567")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 41.91 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "0fffdb21-26de-4377-bab3-e72d0d20ebd0")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 44.45 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "194dbb63-7554-4190-8ef7-b7ae14a38ce5")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 46.99 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "01801ac6-2112-40ea-97bc-13a3befddb8b")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 49.53 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "9fd33ff7-1511-4a0a-9146-106dcb5de665")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 52.07 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "560b0952-dc83-4fca-a96e-edc954007d72")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 54.61 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "e9afa57f-9949-44cc-8d0e-9420d88db51a")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 57.15 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "0cf00d0e-8755-4c98-89e7-a70541eb179e")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 59.69 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "3298ce56-78e1-422c-973a-4ff16a4372a9")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 62.23 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "cd1b4015-c616-4efe-9b28-639c7e1e71a0")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 64.77 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "a60fef8e-4c38-4732-aa6a-c20494944f68")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 67.31 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "03104f37-2f74-4970-b249-2cee04d652fa")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 69.85 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "c7ca6ef7-b04e-4ee7-bd8c-19a971d90cc7")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 96.52 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "2467bea5-eac9-474d-83be-ee6882271302")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 99.06 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "6ed6e3b4-0526-471e-839e-77854fcb4065")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 101.6 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "03496be0-a264-48c3-8c1c-e0f4a9505a25")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 104.14 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "1e3d14e3-2cd4-4aa9-b5ac-0d1d28147c5a")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 106.68 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "92bb545b-1199-4de1-9803-8a079aa6aaf6")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 109.22 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f8fbf944-fdf4-40b1-9d51-1542f25da5e4")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 111.76 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "02be8410-4d96-4936-835b-1a487eba33c0")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 114.3 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "9189ae6e-964f-4927-a807-bf550d0eb6bc")
+	)
+	(global_label "USB3_TX1+" (shape bidirectional) (at 163.83 116.84 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "b3cdbfb1-1acf-463f-b1a3-fe69cc6f33dc")
+	)
+	(global_label "USB3_TX1-" (shape bidirectional) (at 163.83 119.38 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "dacd8f3a-ac9f-4a32-8da6-4f9caef3a9d0")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 121.92 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "a07e9028-18cd-428c-b48b-45fde6e95796")
+	)
+	(global_label "USB3_RX1+" (shape bidirectional) (at 163.83 124.46 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "1e2f2596-15c6-4122-b459-87e5225d6863")
+	)
+	(global_label "USB3_RX1-" (shape bidirectional) (at 163.83 127 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "b1e7b66c-5dc7-4518-9f0c-3f5d5ba8fb2b")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 129.54 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "0d4d5d1a-e7c2-4ccf-a879-cac408f9f976")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 132.08 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "4777eded-d998-435a-96e5-6a5271e409a7")
+	)
+	(global_label "+3V3" (shape bidirectional) (at 163.83 134.62 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "cda58ba7-27d9-4ad8-bbcd-da16da590dee")
+	)
+	(global_label "+1V2" (shape bidirectional) (at 163.83 137.16 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "9a512f61-51d0-4e29-8413-425f7e88ae37")
+	)
+	(global_label "+1V2" (shape bidirectional) (at 163.83 139.7 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "22c2f546-b105-4767-828a-6bd3a9dd3ad4")
+	)
+	(global_label "+1V2" (shape bidirectional) (at 163.83 142.24 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "0b30bddf-6347-4738-9eaa-4e3808fc9af7")
+	)
+	(global_label "+3V3" (shape bidirectional) (at 163.83 144.78 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "66023364-bfdf-426f-a0ae-8dd6083a9843")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 147.32 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "77b1100c-7dcf-4309-9fec-9652462d50e2")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 149.86 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "20817d91-408e-426a-ad68-cec04f531b42")
+	)
+	(global_label "+1V2" (shape bidirectional) (at 163.83 152.4 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "431e3f93-ee60-4c62-aeec-1b1e31ad33b6")
+	)
+	(global_label "+1V2" (shape bidirectional) (at 163.83 154.94 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "d3a6037f-0741-4051-95b7-f16f737eb16f")
+	)
+	(global_label "+1V2" (shape bidirectional) (at 163.83 157.48 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "fb3ebf80-e281-41f1-b337-2be7e1e72520")
+	)
+	(global_label "+1V2" (shape bidirectional) (at 191.77 96.52 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "ad3d36a6-beaf-4083-b5eb-daab103bff12")
+	)
+	(global_label "+1V2" (shape bidirectional) (at 191.77 99.06 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "36a2d708-e945-4c31-93a5-5f1d82eadf89")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 101.6 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "2919b11d-268b-4744-b440-05e63ba6c930")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 104.14 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "5c4312a5-e10f-4670-9df6-d8dbc0f013d6")
+	)
+	(global_label "+3V3" (shape bidirectional) (at 191.77 106.68 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "24d5e2b0-8844-49a4-bdbb-77e4e3085c00")
+	)
+	(global_label "+1V2" (shape bidirectional) (at 191.77 109.22 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "8a2eb039-aff0-48c3-978b-c291191b0da2")
+	)
+	(global_label "+1V2" (shape bidirectional) (at 191.77 111.76 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "febb7566-5ab1-49c0-b54b-d283bf2be9aa")
+	)
+	(global_label "+1V2" (shape bidirectional) (at 191.77 114.3 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "e995ac7e-de77-4f7a-85c4-93c8a7e2e876")
+	)
+	(global_label "+3V3" (shape bidirectional) (at 191.77 116.84 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "724394e3-0f69-4fdb-905a-0e5799f70c04")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 119.38 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "15b75ff2-8dff-4139-9094-9bc9458143e7")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 121.92 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "fe6465f0-ec20-4efc-8d17-30b5f1890dc4")
+	)
+	(global_label "USB3_TX2+" (shape bidirectional) (at 191.77 124.46 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "d8149787-9d46-47f8-af8e-ce708a748ef8")
+	)
+	(global_label "USB3_TX2-" (shape bidirectional) (at 191.77 127 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4a4667b9-2fb2-4a99-a125-f62f3584b599")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 129.54 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "42e590c9-be80-4c8d-a7d1-a8c3cddc01a6")
+	)
+	(global_label "USB3_RX2+" (shape bidirectional) (at 191.77 132.08 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "98c6c335-49f6-43a1-b011-b442c69dca41")
+	)
+	(global_label "USB3_RX2-" (shape bidirectional) (at 191.77 134.62 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "7942afa4-5c73-4386-a314-d32c2f76deb0")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 137.16 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "d15b43e8-2046-49a2-bb6d-7bb596af215f")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 139.7 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "c12681db-2b03-4364-93dd-b960d60d9b33")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 142.24 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "ee8317c4-92e2-4617-8332-a5e7489b5257")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 144.78 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "ee7dd1c1-e016-4cc8-9ee2-2240370cb8da")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 147.32 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "3f7eb743-c14a-4643-bb88-5c754f575097")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 149.86 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "ad1aeec1-1afc-483d-bfe3-a17ebd703fb4")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 152.4 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "0a9b34e7-4f26-4110-8f79-62bf0e59329a")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 154.94 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "d52db9d5-8116-44f0-8ebf-bf5d201a0f7b")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 173.99 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "6854783c-6d04-4251-be2a-4efb37fa41f7")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 176.53 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "51029e14-d538-4b03-8425-0769de25ad1c")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 179.07 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "3e9e967c-1e06-4f64-af97-bb17e64b4c35")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 181.61 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "d9a1c5b5-a10a-44d8-b6c8-550d9954e748")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 184.15 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "af4cd168-1249-4c2a-bbc4-32f61111f439")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 186.69 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f2f7dd71-a893-428d-8e3b-98301a415086")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 189.23 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "c5180bf0-e8cd-4782-a5bc-ffd13c339ee7")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 191.77 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "b3d5e98f-1f69-4c17-89c4-f5e3f59d2f01")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 194.31 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "34969668-7705-4b84-9949-be897b516782")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 196.85 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "e0f5f1ce-9709-488f-8f87-8f0baec85406")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 199.39 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "4ca73c60-dc27-40e1-b0aa-043ab65316de")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 201.93 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "c0f8d9f5-9fea-4841-8f23-6a8d0b41e73e")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 204.47 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "41545bae-e947-4489-a732-78629e70e390")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 207.01 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "0666db8d-0ad7-499d-8d99-14b1e010e43f")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 209.55 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "55375774-1c25-4bd1-b5e2-11c26172826a")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 212.09 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "17a97a68-00ad-4f5e-a29f-12f2d83a5202")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 214.63 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "71f8c5ff-01ec-4211-94cc-06824f1eb831")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 217.17 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "10cbb639-a163-4ec1-bd77-4150245ab992")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 219.71 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "8b973988-614d-47ca-85bc-2bc31bfed0ae")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 222.25 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "ee82992b-37ec-4875-a67c-18ec25f674eb")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 224.79 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "4bf7cd3b-2a07-43df-8a0a-2e6152fdce56")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 227.33 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "69bd2c7e-8324-4e4c-9179-fd8a2352ba2f")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 229.87 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "ae968236-25a9-46dd-ab71-7621fc8664a7")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 232.41 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "df5bfa7a-0bc6-4a6f-9e5f-faf2f3ced8fa")
+	)
+	(global_label "+3V3" (shape bidirectional) (at 191.77 173.99 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "0354df9f-71f2-429c-84b3-397e8cae8987")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 176.53 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "860f01ab-07f6-436d-931b-017a4067b3a6")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 179.07 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "ea0d4242-7ffd-4f81-97fa-266d4b40e6ce")
+	)
+	(global_label "PCIE_TX+" (shape bidirectional) (at 191.77 181.61 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "f0537ff8-915f-40d9-85a2-1dc204dd4773")
+	)
+	(global_label "PCIE_TX-" (shape bidirectional) (at 191.77 184.15 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "797861c6-2010-405a-aeec-31f42424922b")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 186.69 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "ee0eca43-be5e-4eae-b5c1-5a0abc0cf86c")
+	)
+	(global_label "PCIE_RX+" (shape bidirectional) (at 191.77 189.23 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "29008d33-7e8f-4d80-add7-2dc72eb4940d")
+	)
+	(global_label "PCIE_RX-" (shape bidirectional) (at 191.77 191.77 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "04734433-62e8-435e-99de-7a9676b81150")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 194.31 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "e9bcabb5-8b3e-4a9c-87c0-73cfd48fd6cd")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 196.85 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "7075b87a-bebb-4a6f-9fd2-69b0426c7c1a")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 199.39 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "45896a8e-b530-4f1b-b35b-a665105d74e5")
+	)
+	(global_label "+1V2" (shape bidirectional) (at 191.77 201.93 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "a0fb8afe-2a8f-43b9-8a30-44e2ba2bbdc1")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 204.47 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "e0bda0ac-172a-42cf-9cda-d81615713dfa")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 207.01 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "f21a0df5-5fdb-463a-8c08-657f5f0c8ff2")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 209.55 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "83cd994a-7bf7-45e9-a9c0-8e54e13264e5")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 212.09 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "f102699b-9195-422e-bcd6-49cb275353de")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 214.63 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "696dfc15-0427-43ac-ae3f-411140c7c5ae")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 217.17 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4a6d44a7-afae-457e-9c0c-f75746ac5191")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 219.71 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "a3779db1-1602-4bb9-9f17-ef14dc0513b3")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 222.25 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "ae743ab6-4c8f-46de-8945-d335ff48eea3")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 224.79 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "1561ee1d-4fc1-40fd-9124-59df5f9ba845")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 227.33 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "c8d831fb-6572-44e7-8897-fce18ccf1ed5")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 229.87 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4a5c3a79-ca9e-4bb9-bb6c-c7fc80c6756d")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 232.41 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "fd28de31-4436-4c28-a824-acca30aa2c7a")
+	)
+	(global_label "MIPI_CLK+" (shape bidirectional) (at 163.83 252.73 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "5e7584ab-5886-4cae-9334-d3c23002653d")
+	)
+	(global_label "MIPI_CLK-" (shape bidirectional) (at 163.83 255.27 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "9fdf231f-7c66-4126-9772-d4b767b838e5")
+	)
+	(global_label "MIPI_D0+" (shape bidirectional) (at 163.83 257.81 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "c0a1ac52-40e3-4f76-a593-23537795ac1e")
+	)
+	(global_label "MIPI_D0-" (shape bidirectional) (at 163.83 260.35 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "d8a74bf7-7028-44cc-b468-4571dc678195")
+	)
+	(global_label "MIPI_RST" (shape bidirectional) (at 163.83 262.89 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "70480326-9ab1-489f-ad69-8dc080b527e1")
+	)
+	(global_label "+1V8" (shape bidirectional) (at 163.83 265.43 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "3300b17f-9061-45e6-9cfa-88d6bff274f0")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 267.97 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "cfc8af1e-55e1-4951-83b5-e0db38352b18")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 270.51 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "d2d16393-de85-4af1-9ad0-70cbfb2fce55")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 273.05 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "ebda6e39-b94c-4d78-9d68-25aaaad63c30")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 275.59 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "6a7e03d7-7f73-4f46-9a27-55698a1e0f83")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 278.13 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "9f771338-3b67-45a2-9516-fef467cdc1f8")
+	)
+	(global_label "+3V3" (shape bidirectional) (at 163.83 280.67 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "a5bdcf47-7199-4126-8b12-4769581d0ae1")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 252.73 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "c096c8dd-6615-4e4d-9c44-839192843dd2")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 255.27 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "9510b201-7cbf-42ec-9e9c-d73ab614ac5e")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 257.81 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "24b17f71-70d9-449b-bbc1-f9278ff9e9e8")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 260.35 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "f6f9c95b-b6da-4f1c-908e-a289f39d77a9")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 262.89 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "b89972db-914e-4f1d-b327-f9410376e48a")
+	)
+	(global_label "+1V8" (shape bidirectional) (at 191.77 265.43 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "57f25dfd-2e57-4065-a0e6-32a98735ab76")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 267.97 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "535e757c-d72e-48f4-92ac-24fcb78e658f")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 270.51 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "93507cfc-2315-4055-a19a-2e99244bd6df")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 273.05 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "2f65e397-eac4-42e9-b684-0101602ac051")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 275.59 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "6fd661ad-ec42-4c64-b1ee-378ea47c5b3f")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 278.13 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "ccb63597-6595-4d3b-b952-b5b4a3183d4e")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 280.67 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "5bd49e0f-dcc5-406c-8e0c-1a56236a7ee9")
+	)
+	(global_label "VBUS_USB" (shape input) (at 12.7 7.62 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "59b899f3-4593-47d2-ab6a-6a2ee94682e6")
+	)
+	(global_label "+3V3" (shape input) (at 12.7 17.78 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "1d111a9b-e036-44ba-ae68-ca285aaed8ab")
+	)
+	(global_label "+1V8" (shape input) (at 12.7 27.94 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "5ef6072b-97f2-4dcc-9b0e-561be2b960fb")
+	)
+	(global_label "+1V2" (shape input) (at 12.7 38.1 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f2102291-2fad-4452-8b00-ec3c159b64ce")
+	)
+	(global_label "GND" (shape input) (at 12.7 297.18 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "897d26ad-c4a3-4d5b-87ac-4fdb0c25b49f")
 	)
 	(sheet_instances
-		(path "/c5c992a2-d28d-430b-b400-e92ec2ef4b19" (page "1")
+		(path "/3c6e0a49-39a7-454c-8046-2b8048737b80" (page "1")
 		)
 	)
 )

--- a/boards/06-diffpair-test/output/lvs.json
+++ b/boards/06-diffpair-test/output/lvs.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://kicad-tools.org/schemas/lvs/v1.json",
+  "clean": true,
+  "mismatches": [],
+  "copper_mismatches": [],
+  "copper_vacuous": false,
+  "copper_bound_pad_count": 198
+}

--- a/boards/07-matchgroup-test/generate_design.py
+++ b/boards/07-matchgroup-test/generate_design.py
@@ -2023,27 +2023,28 @@ def main() -> int:
             route_success = route_pcb(pcb_path, routed_path)
             drc_ok = run_drc(routed_path)
 
-            # LVS (#3779) -- copper-only, and VACUOUS on this board
-            # (issue #4006).  The generated schematic is a PCB-first
-            # fixture with ZERO ``(wire ...)`` elements (floating labels
-            # only), so ``_schematic_pin_to_net`` binds 0 of ~223 pins --
-            # ALL nets, DDR included, not just the MIPI/TMDS connectors.
-            # With an empty pad->net map the copper comparator has no
-            # evidence and can detect neither opens nor shorts, so the
-            # #4006 vacuity guard now reports ``clean=false`` with a
-            # synthetic ``vacuous`` mismatch instead of the old
-            # zero-comparison ``clean: true`` (which masked this board's
-            # real copper opens).  ``require_clean=False`` (advisory)
-            # because the vacuous verdict is EXPECTED here: a hard gate
-            # would abort the recipe before the manufacturing-bundle
-            # export.  The write stays because the board-07-end-to-end CI
-            # job regenerates into a tmp dir, asserts ``lvs.json`` exists
-            # there, and gates on the vacuity-guard verdict
-            # (``check_board_00_e2e.py --lvs-vacuous`` +
-            # ``check_copper_lvs.py --expect-vacuous``); ``output/lvs.json``
-            # must NOT be committed: ``kct board-metrics`` treats a vacuous
-            # report as "LVS not run" (#3749/#4006) and the site renders
-            # the honest chip.  This step only runs in ``--step all`` (the
+            # LVS (#3779, wired schematic #4012) -- HONESTLY DIRTY on this
+            # board.  The fixture schematic is now fully wired
+            # (generate_schematic.py emits a wire stub + global label for
+            # all 244 pins, PIN_NETS mirroring generate_pcb.py
+            # pad-for-pad), so the copper comparator binds 244/244 pads
+            # and carries real evidence.  Board 07 routes PARTIAL by
+            # design -- 5 seed-invariant unroutable nets (#3438: DQ3, DQ4,
+            # MIPI_DAT0_N, TMDS_D0_N, TMDS_D1_N) -- so copper-LVS reports
+            # exactly those 5 opens and ``lvs.json`` carries the honest
+            # ``clean=false`` verdict (label comparator: clean; it is run
+            # so the payload records both legs).  ``require_clean=False``
+            # (advisory) because the 5 opens are EXPECTED here: a hard
+            # gate would abort the recipe before the manufacturing-bundle
+            # export.  ``kct board-metrics`` renders lvs_clean=false /
+            # lvs_mismatches=5 and downgrades status to 'partial' -- that
+            # is the truthful gallery state.  The board-07-end-to-end CI
+            # job regenerates into a tmp dir and asserts exactly these 5
+            # named opens and nothing else (``check_copper_lvs.py
+            # --expect-opens`` + ``check_board_00_e2e.py
+            # --lvs-known-opens``), so a NEW open/short -- or one of the 5
+            # becoming routable -- fails the job and forces this comment
+            # to be updated.  This step only runs in ``--step all`` (the
             # ``--step route`` CI branch has no schematic).
             copper_clean, _label_clean = write_lvs_report(
                 sch_path,
@@ -2051,15 +2052,18 @@ def main() -> int:
                 output_dir,
                 require_clean=False,
                 run_copper=True,
-                run_label=False,
+                run_label=True,
             )
             if not copper_clean:
                 print(
-                    "[lvs] WARNING: copper-LVS is VACUOUS on this fixture "
-                    "(schematic has no wires, so 0 pins bind to nets; issue "
-                    "#4006) -- lvs.json carries clean=false/copper_vacuous. "
-                    "It is written for the CI e2e tmp gate only -- never "
-                    "commit output/lvs.json."
+                    "[lvs] copper-LVS is dirty -- EXPECTED on this "
+                    "partial-by-design board (#3438 known opens: DQ3, DQ4, "
+                    "MIPI_DAT0_N, TMDS_D0_N, TMDS_D1_N).  lvs.json carries "
+                    "the honest clean=false verdict; board-metrics "
+                    "downgrades status to 'partial'.  The CI e2e job "
+                    "asserts the mismatch set is EXACTLY those 5 opens and "
+                    "no shorts (check_copper_lvs.py --expect-opens); see "
+                    "the summary above for what this run actually produced."
                 )
 
             # Export manufacturing bundle (#3147) so ``kct fleet status``

--- a/boards/07-matchgroup-test/generate_schematic.py
+++ b/boards/07-matchgroup-test/generate_schematic.py
@@ -2,14 +2,30 @@
 """
 Generate a KiCad Schematic for the match-group test board (board 07).
 
-This emits a flat schematic with global labels for each declared net.
-The schematic is a minimal logical map of the PCB --- it's a routing
-regression testbench, not a working device, so the schematic uses
-placeholder symbols (Conn_01xN connectors) for source / sink endpoints.
+This emits a flat schematic that is a **fully wired** logical map of the
+PCB: every component pin carries a short wire stub terminated by a global
+label naming the pin's net, so the schematic netlist is pad-for-pad
+identical to the PCB's (issue #4012; the pre-#4012 revision emitted only
+floating labels, which bound ZERO pins and made LVS vacuous, #4005/#4006).
 
-Each global label declares one net.  Match-group members are drawn
-in adjacent groups so the schematic visually communicates the
-length-matching intent without a (more complex) bus annotation.
+Because the PCB's pad numbering is package-native (HDMI ``S1/S2`` shield
+pads, FFC ``M1/M2`` mounting pads, BGA ``A1..G7``), the stock
+``Connector_Generic`` symbols (numeric pins ``1..N``) can never bind those
+pads.  Instead this script synthesizes one testbench symbol per component
+via :mod:`kicad_tools.schematic.symbol_generator`, with pin numbers
+matching the PCB pads exactly, writes them to a project-local
+``matchgroup_lvs.kicad_sym`` library next to the schematic, and resolves
+them through ``Schematic(local_symbol_libs=[...])`` (the board-05
+``board05_custom`` pattern).  The emitted ``.kicad_sch`` embeds the
+symbol definitions in ``lib_symbols``, so downstream consumers (LVS,
+KiCad itself) need no library setup.
+
+``PIN_NETS`` below is the schematic-side source of truth and mirrors the
+per-pad net assignment in ``generate_pcb.py`` — the copper-LVS step in
+``generate_design.py`` is what keeps the two in lock-step.  Note board 07
+routes PARTIAL by design (5 seed-invariant unroutable nets, #3438:
+DQ3 / DQ4 / MIPI_DAT0_N / TMDS_D0_N / TMDS_D1_N), so with a wired
+schematic copper-LVS HONESTLY reports those 5 as opens.
 
 Usage:
     python generate_schematic.py [output_file]
@@ -22,6 +38,13 @@ import sys
 from pathlib import Path
 
 from kicad_tools.dev import warn_if_stale
+from kicad_tools.schematic import (
+    PinDef,
+    PinSide,
+    PinType,
+    SymbolDef,
+    generate_symbol_sexp,
+)
 from kicad_tools.schematic.models.schematic import Schematic, SnapMode
 
 # Warn if running source scripts with stale pipx install
@@ -29,204 +52,463 @@ warn_if_stale()
 
 WIRE_STUB = 5.08  # 200 mils
 
+# Name of the generated project-local symbol library (written next to the
+# schematic).  lib_ids take the form ``matchgroup_lvs:<SYMBOL>``.
+LIB_NAME = "matchgroup_lvs"
+
+# ---------------------------------------------------------------------------
+# Schematic-side netlist: {ref: {pad: net}} for every pad on the board.
+# Mirrors generate_pcb.py's per-pad net assignment pad-for-pad (the
+# copper-LVS step in generate_design.py flags any divergence).
+# ---------------------------------------------------------------------------
+PIN_NETS: dict[str, dict[str, str]] = {
+    # J1 -- FFC-6 MIPI CSI source
+    "J1": {
+        "1": "MIPI_CLK_P",
+        "2": "MIPI_CLK_N",
+        "3": "MIPI_DAT0_P",
+        "4": "MIPI_DAT0_N",
+        "5": "MIPI_DAT1_P",
+        "6": "MIPI_DAT1_N",
+        "M1": "GND",
+        "M2": "GND",
+    },
+    # J2 -- HDMI TMDS source
+    "J2": {
+        "1": "TMDS_D0_P",
+        "2": "TMDS_D0_N",
+        "3": "GND",
+        "4": "TMDS_D1_P",
+        "5": "TMDS_D1_N",
+        "6": "GND",
+        "7": "TMDS_D2_P",
+        "8": "TMDS_D2_N",
+        "S1": "GND",
+        "S2": "GND",
+    },
+    # J3 -- ADDR bus header
+    "J3": {
+        "1": "GND",
+        "2": "A0",
+        "3": "A1",
+        "4": "A2",
+        "5": "A3",
+        "6": "A4",
+        "7": "A5",
+        "8": "A6",
+        "9": "A7",
+    },
+    # U1 -- QFN-48 DDR controller (source for DDR data byte)
+    "U1": {
+        "1": "+1V8",
+        "2": "GND",
+        "3": "GND",
+        "4": "GND",
+        "5": "GND",
+        "6": "GND",
+        "7": "GND",
+        "8": "GND",
+        "9": "GND",
+        "10": "GND",
+        "11": "GND",
+        "12": "+1V2",
+        "13": "GND",
+        "14": "GND",
+        "15": "GND",
+        "16": "GND",
+        "17": "GND",
+        "18": "GND",
+        "19": "GND",
+        "20": "GND",
+        "21": "GND",
+        "22": "GND",
+        "23": "GND",
+        "24": "GND",
+        "25": "DQ0",
+        "26": "DQ1",
+        "27": "DQ2",
+        "28": "DQ3",
+        "29": "DM0",
+        "30": "DQS_P",
+        "31": "DQS_N",
+        "32": "DQ4",
+        "33": "DQ5",
+        "34": "DQ6",
+        "35": "DQ7",
+        "36": "+1V2",
+        "37": "GND",
+        "38": "GND",
+        "39": "GND",
+        "40": "GND",
+        "41": "GND",
+        "42": "GND",
+        "43": "GND",
+        "44": "GND",
+        "45": "GND",
+        "46": "GND",
+        "47": "GND",
+        "48": "GND",
+    },
+    # U2 -- QFN-48 DDR DRAM sink
+    "U2": {
+        "1": "DQ0",
+        "2": "DQ1",
+        "3": "DQ2",
+        "4": "DQ3",
+        "5": "DM0",
+        "6": "DQS_P",
+        "7": "DQS_N",
+        "8": "DQ4",
+        "9": "DQ5",
+        "10": "DQ6",
+        "11": "DQ7",
+        "12": "+1V2",
+        "13": "GND",
+        "14": "GND",
+        "15": "GND",
+        "16": "GND",
+        "17": "GND",
+        "18": "GND",
+        "19": "GND",
+        "20": "GND",
+        "21": "GND",
+        "22": "GND",
+        "23": "GND",
+        "24": "+1V2",
+        "25": "GND",
+        "26": "GND",
+        "27": "GND",
+        "28": "GND",
+        "29": "GND",
+        "30": "GND",
+        "31": "GND",
+        "32": "GND",
+        "33": "GND",
+        "34": "GND",
+        "35": "GND",
+        "36": "+1V8",
+        "37": "GND",
+        "38": "GND",
+        "39": "GND",
+        "40": "GND",
+        "41": "GND",
+        "42": "GND",
+        "43": "GND",
+        "44": "GND",
+        "45": "GND",
+        "46": "GND",
+        "47": "GND",
+        "48": "GND",
+    },
+    # U3 -- QFN-24 MIPI sink
+    "U3": {
+        "1": "MIPI_CLK_P",
+        "2": "MIPI_CLK_N",
+        "3": "MIPI_DAT0_P",
+        "4": "MIPI_DAT0_N",
+        "5": "MIPI_DAT1_P",
+        "6": "MIPI_DAT1_N",
+        "7": "GND",
+        "8": "GND",
+        "9": "GND",
+        "10": "GND",
+        "11": "GND",
+        "12": "+1V8",
+        "13": "GND",
+        "14": "GND",
+        "15": "GND",
+        "16": "GND",
+        "17": "GND",
+        "18": "+1V2",
+        "19": "GND",
+        "20": "GND",
+        "21": "GND",
+        "22": "GND",
+        "23": "GND",
+        "24": "GND",
+    },
+    # U4 -- BGA-49 HDMI sink
+    "U4": {
+        "A1": "GND",
+        "A2": "GND",
+        "A3": "GND",
+        "A4": "GND",
+        "A5": "GND",
+        "A6": "GND",
+        "A7": "GND",
+        "B1": "TMDS_D0_P",
+        "B2": "TMDS_D0_N",
+        "B3": "TMDS_D1_P",
+        "B4": "TMDS_D1_N",
+        "B5": "TMDS_D2_P",
+        "B6": "TMDS_D2_N",
+        "B7": "GND",
+        "C1": "GND",
+        "C2": "+1V2",
+        "C3": "+1V8",
+        "C4": "+1V8",
+        "C5": "+1V8",
+        "C6": "+1V8",
+        "C7": "GND",
+        "D1": "GND",
+        "D2": "+1V8",
+        "D3": "+1V8",
+        "D4": "+1V8",
+        "D5": "+1V8",
+        "D6": "+1V8",
+        "D7": "GND",
+        "E1": "GND",
+        "E2": "+1V8",
+        "E3": "+1V8",
+        "E4": "+1V8",
+        "E5": "+1V8",
+        "E6": "+1V2",
+        "E7": "GND",
+        "F1": "GND",
+        "F2": "GND",
+        "F3": "GND",
+        "F4": "GND",
+        "F5": "GND",
+        "F6": "GND",
+        "F7": "GND",
+        "G1": "GND",
+        "G2": "GND",
+        "G3": "GND",
+        "G4": "GND",
+        "G5": "GND",
+        "G6": "GND",
+        "G7": "GND",
+    },
+    # U5 -- QFP-48 SRAM (ADDR sink)
+    "U5": {
+        "1": "A0",
+        "2": "A1",
+        "3": "A2",
+        "4": "A3",
+        "5": "A4",
+        "6": "A5",
+        "7": "A6",
+        "8": "A7",
+        "9": "GND",
+        "10": "GND",
+        "11": "GND",
+        "12": "+1V8",
+        "13": "GND",
+        "14": "GND",
+        "15": "GND",
+        "16": "GND",
+        "17": "GND",
+        "18": "GND",
+        "19": "GND",
+        "20": "GND",
+        "21": "GND",
+        "22": "GND",
+        "23": "GND",
+        "24": "+1V2",
+        "25": "GND",
+        "26": "GND",
+        "27": "GND",
+        "28": "GND",
+        "29": "GND",
+        "30": "GND",
+        "31": "GND",
+        "32": "GND",
+        "33": "GND",
+        "34": "GND",
+        "35": "GND",
+        "36": "+1V8",
+        "37": "GND",
+        "38": "GND",
+        "39": "GND",
+        "40": "GND",
+        "41": "GND",
+        "42": "GND",
+        "43": "GND",
+        "44": "GND",
+        "45": "GND",
+        "46": "GND",
+        "47": "GND",
+        "48": "GND",
+    },
+}
+
+# Placement + identity per component: (ref, symbol_name, value, footprint,
+# x, y).  Sources in the left column, sinks in the right column; y spacing
+# leaves room for each symbol's body (pin count / 2 * 2.54mm) plus stubs.
+COMPONENTS: list[tuple[str, str, str, str, float, float]] = [
+    (
+        "U1",
+        "QFN48_DDR_CTRL",
+        "QFN48_DDR_CTRL",
+        "Package_DFN_QFN:QFN-48-1EP_7x7mm_P0.5mm",
+        50.8,
+        50.8,
+    ),
+    ("J1", "FFC6_MIPI_SRC", "FFC6_MIPI", "Connector_FFC:FFC_6P_1.0mm", 50.8, 101.6),
+    ("J2", "HDMI_SRC", "HDMI19", "Connector_Video:HDMI_A_Receptacle", 50.8, 127.0),
+    (
+        "J3",
+        "ADDR_HDR_SRC",
+        "ADDR_HDR",
+        "Connector_PinHeader_2.54mm:PinHeader_1x09_P2.54mm_Vertical",
+        50.8,
+        152.4,
+    ),
+    ("U2", "QFN48_DRAM", "QFN48_DRAM", "Package_DFN_QFN:QFN-48-1EP_7x7mm_P0.5mm", 177.8, 50.8),
+    ("U3", "QFN24_MIPI", "QFN24_MIPI", "Package_DFN_QFN:QFN-24-1EP_4x4mm_P0.5mm", 177.8, 127.0),
+    (
+        "U4",
+        "BGA49_HDMI",
+        "BGA49_HDMI",
+        "Package_BGA:BGA-49_5.0x5.0mm_Layout7x7_P0.5mm",
+        177.8,
+        190.5,
+    ),
+    ("U5", "QFP48_SRAM", "QFP48_SRAM", "Package_QFP:LQFP-48_7x7mm_P0.5mm", 177.8, 266.7),
+]
+
+
+def _build_symbol_lib(lib_path: Path) -> None:
+    """Write the project-local testbench symbol library.
+
+    One symbol per component, pin numbers matching the PCB pads exactly
+    (first half of the pad list on the left edge, second half on the
+    right).  All pins are ``passive`` — these are testbench endpoints, not
+    electrical models.
+    """
+    blocks: list[str] = []
+    for _ref, symbol_name, _value, footprint, _x, _y in COMPONENTS:
+        pads = list(PIN_NETS[_ref])
+        half = (len(pads) + 1) // 2
+        pins = [
+            PinDef(
+                number=pad,
+                name=pad,
+                pin_type=PinType.PASSIVE,
+                side=PinSide.LEFT if i < half else PinSide.RIGHT,
+            )
+            for i, pad in enumerate(pads)
+        ]
+        sym = SymbolDef(name=symbol_name, pins=pins, reference="U", footprint=footprint)
+        text = generate_symbol_sexp(sym)
+        lines = text.splitlines()
+        start = next(i for i, ln in enumerate(lines) if ln.startswith("\t(symbol "))
+        if lines[-1] != ")":
+            raise RuntimeError(f"unexpected symbol-lib tail for {symbol_name}")
+        blocks.append("\n".join(lines[start:-1]))
+
+    header = (
+        "(kicad_symbol_lib\n"
+        "\t(version 20231120)\n"
+        '\t(generator "kicad_tools")\n'
+        '\t(generator_version "1.0")\n'
+    )
+    lib_path.write_text(header + "\n".join(blocks) + "\n)\n")
+
+
+def add_pin_label(sch: Schematic, pin_pos: tuple, net_name: str, direction: str = "right") -> None:
+    """Add a wire stub from a pin position to a global label.
+
+    Pin attach is ENDPOINT-only (KiCad semantics): the wire must start
+    exactly at the pin position.  The label names the net from the stub's
+    far end.
+    """
+    if not pin_pos:
+        return
+    x, y = pin_pos
+    if direction == "right":
+        end_x = x + WIRE_STUB
+        rotation = 180
+    else:
+        end_x = x - WIRE_STUB
+        rotation = 0
+    sch.add_wire((x, y), (end_x, y), snap=False)
+    sch.add_global_label(net_name, end_x, y, shape="bidirectional", rotation=rotation, snap=False)
+
+
+def _wire_all_pins(sch: Schematic, sym, pin_nets: dict[str, str]) -> int:
+    """Wire every pin of ``sym`` to a global label carrying its net name."""
+    wired = 0
+    for pin in sym.symbol_def.pins:
+        pos = sym.pin_position(pin.number)
+        if pos is None:
+            raise RuntimeError(f"{sym.reference}.{pin.number}: no pin position")
+        net = pin_nets[pin.number]
+        direction = "left" if pos[0] < sym.x else "right"
+        add_pin_label(sch, pos, net, direction)
+        wired += 1
+    return wired
+
 
 def create_matchgroup_schematic(output_path: Path) -> bool:
-    """Create the match-group testbench schematic."""
+    """Create the match-group testbench schematic (fully wired, #4012)."""
     print("Creating Match-Group Test Schematic...")
     print("=" * 60)
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # ---------------------------------------------------------------------
+    # 1. Synthesize the project-local symbol library (PCB-native pads)
+    # ---------------------------------------------------------------------
+    print("\n1. Writing project-local symbol library...")
+    lib_path = output_path.parent / f"{LIB_NAME}.kicad_sym"
+    _build_symbol_lib(lib_path)
+    print(f"   {lib_path} ({len(COMPONENTS)} symbols)")
 
     sch = Schematic(
         title="Match-Group Test Board",
         date="2026-05",
-        revision="A",
+        revision="B",
         company="kicad-tools",
         comment1="N-trace + group-of-pairs match-group regression testbench",
-        comment2="Epic #2661 Phase 3L (issue #2724)",
+        comment2="Epic #2661 Phase 3L (issue #2724); wired netlist #4012",
         snap_mode=SnapMode.AUTO,
-        grid=2.54,
+        grid=1.27,
+        local_symbol_libs=[lib_path],
     )
 
-    # =========================================================================
-    # Source connectors (left column)
-    # =========================================================================
-    print("\n1. Placing source connectors / ICs...")
+    # ---------------------------------------------------------------------
+    # 2. Place components and wire every pin to its net label
+    # ---------------------------------------------------------------------
+    print("\n2. Placing components + wiring all pins...")
+    total_wired = 0
+    for ref, symbol_name, value, footprint, x, y in COMPONENTS:
+        sym = sch.add_symbol(
+            f"{LIB_NAME}:{symbol_name}",
+            x=x,
+            y=y,
+            ref=ref,
+            value=value,
+            footprint=footprint,
+        )
+        wired = _wire_all_pins(sch, sym, PIN_NETS[ref])
+        total_wired += wired
+        print(f"   {ref} ({symbol_name}): {wired} pins wired at ({sym.x}, {sym.y})")
 
-    # U1 -- DDR controller (source for DDR data byte)
-    u1 = sch.add_symbol(
-        "Connector_Generic:Conn_02x24_Counter_Clockwise",
-        x=50.8,
-        y=50.8,
-        ref="U1",
-        value="QFN48_DDR_CTRL",
-        footprint="Package_DFN_QFN:QFN-48-1EP_7x7mm_P0.5mm",
-    )
-    print(f"   U1 (DDR controller source): ({u1.x}, {u1.y})")
+    expected = sum(len(v) for v in PIN_NETS.values())
+    print(f"   Total: {total_wired}/{expected} pins wired")
+    if total_wired != expected:
+        raise RuntimeError(f"expected {expected} wired pins, got {total_wired}")
 
-    # J1 -- MIPI CSI source (FFC-6)
-    j1 = sch.add_symbol(
-        "Connector_Generic:Conn_01x06",
-        x=50.8,
-        y=125.0,
-        ref="J1",
-        value="FFC6_MIPI",
-        footprint="Connector_FFC:FFC_6P_1.0mm",
-    )
-    print(f"   J1 (MIPI source): ({j1.x}, {j1.y})")
-
-    # J2 -- HDMI source
-    j2 = sch.add_symbol(
-        "Connector_Generic:Conn_01x08",
-        x=50.8,
-        y=170.0,
-        ref="J2",
-        value="HDMI19",
-        footprint="Connector_Video:HDMI_A_Receptacle",
-    )
-    print(f"   J2 (HDMI source): ({j2.x}, {j2.y})")
-
-    # J3 -- ADDR header (source for address bus)
-    j3 = sch.add_symbol(
-        "Connector_Generic:Conn_01x09",
-        x=50.8,
-        y=215.0,
-        ref="J3",
-        value="ADDR_HDR",
-        footprint="Connector_PinHeader_2.54mm:PinHeader_1x09_P2.54mm_Vertical",
-    )
-    print(f"   J3 (ADDR source): ({j3.x}, {j3.y})")
-
-    # =========================================================================
-    # Sink ICs (right column)
-    # =========================================================================
-    print("\n2. Placing sink ICs...")
-
-    u2 = sch.add_symbol(
-        "Connector_Generic:Conn_02x24_Counter_Clockwise",
-        x=152.4,
-        y=50.8,
-        ref="U2",
-        value="QFN48_DRAM",
-        footprint="Package_DFN_QFN:QFN-48-1EP_7x7mm_P0.5mm",
-    )
-    print(f"   U2 (DDR DRAM sink): ({u2.x}, {u2.y})")
-
-    u3 = sch.add_symbol(
-        "Connector_Generic:Conn_02x12_Counter_Clockwise",
-        x=152.4,
-        y=125.0,
-        ref="U3",
-        value="QFN24_MIPI",
-        footprint="Package_DFN_QFN:QFN-24-1EP_4x4mm_P0.5mm",
-    )
-    print(f"   U3 (MIPI sink): ({u3.x}, {u3.y})")
-
-    u4 = sch.add_symbol(
-        "Connector_Generic:Conn_02x16_Counter_Clockwise",
-        x=152.4,
-        y=170.0,
-        ref="U4",
-        value="BGA49_HDMI",
-        footprint="Package_BGA:BGA-49_5.0x5.0mm_Layout7x7_P0.5mm",
-    )
-    print(f"   U4 (HDMI sink): ({u4.x}, {u4.y})")
-
-    u5 = sch.add_symbol(
-        "Connector_Generic:Conn_02x24_Counter_Clockwise",
-        x=152.4,
-        y=215.0,
-        ref="U5",
-        value="QFP48_SRAM",
-        footprint="Package_QFP:LQFP-48_7x7mm_P0.5mm",
-    )
-    print(f"   U5 (ADDR sink): ({u5.x}, {u5.y})")
-
-    # =========================================================================
-    # Power flags
-    # =========================================================================
+    # ---------------------------------------------------------------------
+    # 3. Power flags (ERC: mark rails as externally driven)
+    # ---------------------------------------------------------------------
     print("\n3. Power symbols + PWR_FLAG...")
-
     rails = [
         ("+1V2", 7.62),
         ("+1V8", 17.78),
-        ("GND", 240.0),
+        ("GND", 309.88),
     ]
     for name, y in rails:
-        pwr_x = 25.4
+        pwr_x = 12.7
         sch.add_global_label(name, pwr_x, y, shape="input", rotation=0, snap=False)
         sch.add_pwr_flag(pwr_x, y)
 
-    # =========================================================================
-    # Match-group label emission (the schematic-side "nets")
-    # =========================================================================
-    print("\n4. Match-group declarations (global labels)...")
-
-    # Labels arranged in a column on the right (x=190.5) for readability.
-    # Grouped by match-group so the schematic communicates intent.
-    label_x = 190.5
-    label_y = 30.0
-
-    # DDR data byte: 9 singles + DQS pair = 10 group members
-    print("   DDR_DATA_BYTE_0:")
-    ddr_singles = ["DQ0", "DQ1", "DQ2", "DQ3", "DQ4", "DQ5", "DQ6", "DQ7", "DM0"]
-    for name in ddr_singles:
-        sch.add_global_label(name, label_x, label_y, shape="bidirectional", rotation=0, snap=False)
-        label_y += 5.08
-    # DQS pair
-    sch.add_global_label("DQS_P", label_x, label_y, shape="bidirectional", rotation=0, snap=False)
-    label_y += 5.08
-    sch.add_global_label("DQS_N", label_x, label_y, shape="bidirectional", rotation=0, snap=False)
-    label_y += 7.62  # extra spacing between groups
-
-    # MIPI CSI: 3 pairs
-    print("   MIPI_CSI_LANES:")
-    mipi_pairs = [
-        ("MIPI_CLK_P", "MIPI_CLK_N"),
-        ("MIPI_DAT0_P", "MIPI_DAT0_N"),
-        ("MIPI_DAT1_P", "MIPI_DAT1_N"),
-    ]
-    for p_name, n_name in mipi_pairs:
-        sch.add_global_label(
-            p_name, label_x, label_y, shape="bidirectional", rotation=0, snap=False
-        )
-        sch.add_global_label(
-            n_name, label_x, label_y + 5.08, shape="bidirectional", rotation=0, snap=False
-        )
-        label_y += 12.7
-    label_y += 5.08
-
-    # HDMI TMDS: 3 pairs
-    print("   HDMI_TMDS_LANES:")
-    tmds_pairs = [
-        ("TMDS_D0_P", "TMDS_D0_N"),
-        ("TMDS_D1_P", "TMDS_D1_N"),
-        ("TMDS_D2_P", "TMDS_D2_N"),
-    ]
-    for p_name, n_name in tmds_pairs:
-        sch.add_global_label(
-            p_name, label_x, label_y, shape="bidirectional", rotation=0, snap=False
-        )
-        sch.add_global_label(
-            n_name, label_x, label_y + 5.08, shape="bidirectional", rotation=0, snap=False
-        )
-        label_y += 12.7
-    label_y += 5.08
-
-    # ADDR bus: A0-A7
-    print("   ADDR_BUS:")
-    addr = ["A0", "A1", "A2", "A3", "A4", "A5", "A6", "A7"]
-    for name in addr:
-        sch.add_global_label(name, label_x, label_y, shape="bidirectional", rotation=0, snap=False)
-        label_y += 5.08
-
-    print(
-        f"   Emitted {len(ddr_singles) + 2 + 6 + 6 + len(addr)} signal labels across 4 match groups"
-    )
-
-    # =========================================================================
-    # Write
-    # =========================================================================
-    print("\n5. Writing schematic...")
-    output_path.parent.mkdir(parents=True, exist_ok=True)
+    # ---------------------------------------------------------------------
+    # 4. Write
+    # ---------------------------------------------------------------------
+    print("\n4. Writing schematic...")
     sch.write(output_path)
     print(f"   Schematic: {output_path}")
 

--- a/boards/07-matchgroup-test/output/lvs.json
+++ b/boards/07-matchgroup-test/output/lvs.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://kicad-tools.org/schemas/lvs/v1.json",
+  "clean": false,
+  "mismatches": [],
+  "copper_mismatches": [
+    {
+      "kind": "open",
+      "net_a": "DQ3",
+      "net_b": "DQ3",
+      "pad_a": "U1.28",
+      "pad_b": "U2.4"
+    },
+    {
+      "kind": "open",
+      "net_a": "DQ4",
+      "net_b": "DQ4",
+      "pad_a": "U1.32",
+      "pad_b": "U2.8"
+    },
+    {
+      "kind": "open",
+      "net_a": "MIPI_DAT0_N",
+      "net_b": "MIPI_DAT0_N",
+      "pad_a": "J1.4",
+      "pad_b": "U3.4"
+    },
+    {
+      "kind": "open",
+      "net_a": "TMDS_D0_N",
+      "net_b": "TMDS_D0_N",
+      "pad_a": "J2.2",
+      "pad_b": "U4.B2"
+    },
+    {
+      "kind": "open",
+      "net_a": "TMDS_D1_N",
+      "net_b": "TMDS_D1_N",
+      "pad_a": "J2.5",
+      "pad_b": "U4.B4"
+    }
+  ],
+  "copper_vacuous": false,
+  "copper_bound_pad_count": 244
+}

--- a/boards/07-matchgroup-test/output/matchgroup_lvs.kicad_sym
+++ b/boards/07-matchgroup-test/output/matchgroup_lvs.kicad_sym
@@ -1,0 +1,4973 @@
+(kicad_symbol_lib
+	(version 20231120)
+	(generator "kicad_tools")
+	(generator_version "1.0")
+	(symbol "QFN48_DDR_CTRL"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "U"
+			(at 0 33.02 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "QFN48_DDR_CTRL"
+			(at 0 -33.02 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Package_DFN_QFN:QFN-48-1EP_7x7mm_P0.5mm"
+			(at 0 -35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 -38.10 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 0 -40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "QFN48_DDR_CTRL_0_1"
+			(rectangle
+				(start -6.35 30.48)
+				(end 6.35 -30.48)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+		)
+		(symbol "QFN48_DDR_CTRL_1_1"
+			(pin passive line
+				(at -8.89 29.21 0)
+				(length 2.54)
+				(name "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 26.67 0)
+				(length 2.54)
+				(name "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 24.13 0)
+				(length 2.54)
+				(name "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 21.59 0)
+				(length 2.54)
+				(name "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 19.05 0)
+				(length 2.54)
+				(name "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 16.51 0)
+				(length 2.54)
+				(name "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 13.97 0)
+				(length 2.54)
+				(name "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 11.43 0)
+				(length 2.54)
+				(name "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 8.89 0)
+				(length 2.54)
+				(name "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 6.35 0)
+				(length 2.54)
+				(name "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 3.81 0)
+				(length 2.54)
+				(name "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 1.27 0)
+				(length 2.54)
+				(name "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -1.27 0)
+				(length 2.54)
+				(name "13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -3.81 0)
+				(length 2.54)
+				(name "14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -6.35 0)
+				(length 2.54)
+				(name "15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -8.89 0)
+				(length 2.54)
+				(name "16"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "16"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -11.43 0)
+				(length 2.54)
+				(name "17"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "17"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -13.97 0)
+				(length 2.54)
+				(name "18"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "18"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -16.51 0)
+				(length 2.54)
+				(name "19"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "19"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -19.05 0)
+				(length 2.54)
+				(name "20"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "20"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -21.59 0)
+				(length 2.54)
+				(name "21"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "21"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -24.13 0)
+				(length 2.54)
+				(name "22"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "22"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -26.67 0)
+				(length 2.54)
+				(name "23"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "23"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -29.21 0)
+				(length 2.54)
+				(name "24"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "24"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 29.21 180)
+				(length 2.54)
+				(name "25"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "25"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 26.67 180)
+				(length 2.54)
+				(name "26"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "26"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 24.13 180)
+				(length 2.54)
+				(name "27"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "27"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 21.59 180)
+				(length 2.54)
+				(name "28"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "28"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 19.05 180)
+				(length 2.54)
+				(name "29"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "29"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 16.51 180)
+				(length 2.54)
+				(name "30"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "30"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 13.97 180)
+				(length 2.54)
+				(name "31"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "31"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 11.43 180)
+				(length 2.54)
+				(name "32"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "32"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 8.89 180)
+				(length 2.54)
+				(name "33"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "33"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 6.35 180)
+				(length 2.54)
+				(name "34"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "34"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 3.81 180)
+				(length 2.54)
+				(name "35"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "35"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 1.27 180)
+				(length 2.54)
+				(name "36"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "36"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -1.27 180)
+				(length 2.54)
+				(name "37"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "37"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -3.81 180)
+				(length 2.54)
+				(name "38"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "38"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -6.35 180)
+				(length 2.54)
+				(name "39"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "39"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -8.89 180)
+				(length 2.54)
+				(name "40"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "40"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -11.43 180)
+				(length 2.54)
+				(name "41"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "41"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -13.97 180)
+				(length 2.54)
+				(name "42"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "42"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -16.51 180)
+				(length 2.54)
+				(name "43"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "43"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -19.05 180)
+				(length 2.54)
+				(name "44"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "44"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -21.59 180)
+				(length 2.54)
+				(name "45"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "45"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -24.13 180)
+				(length 2.54)
+				(name "46"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "46"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -26.67 180)
+				(length 2.54)
+				(name "47"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "47"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -29.21 180)
+				(length 2.54)
+				(name "48"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "48"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+	)
+	(symbol "FFC6_MIPI_SRC"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "U"
+			(at 0 7.62 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "FFC6_MIPI_SRC"
+			(at 0 -7.62 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Connector_FFC:FFC_6P_1.0mm"
+			(at 0 -10.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 -12.70 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 0 -15.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "FFC6_MIPI_SRC_0_1"
+			(rectangle
+				(start -6.35 5.08)
+				(end 6.35 -5.08)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+		)
+		(symbol "FFC6_MIPI_SRC_1_1"
+			(pin passive line
+				(at -8.89 3.81 0)
+				(length 2.54)
+				(name "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 1.27 0)
+				(length 2.54)
+				(name "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -1.27 0)
+				(length 2.54)
+				(name "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -3.81 0)
+				(length 2.54)
+				(name "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 3.81 180)
+				(length 2.54)
+				(name "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 1.27 180)
+				(length 2.54)
+				(name "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -1.27 180)
+				(length 2.54)
+				(name "M1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "M1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -3.81 180)
+				(length 2.54)
+				(name "M2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "M2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+	)
+	(symbol "HDMI_SRC"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "U"
+			(at 0 8.89 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "HDMI_SRC"
+			(at 0 -8.89 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Connector_Video:HDMI_A_Receptacle"
+			(at 0 -11.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 -13.97 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 0 -16.51 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "HDMI_SRC_0_1"
+			(rectangle
+				(start -6.35 6.35)
+				(end 6.35 -6.35)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+		)
+		(symbol "HDMI_SRC_1_1"
+			(pin passive line
+				(at -8.89 5.08 0)
+				(length 2.54)
+				(name "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 2.54 0)
+				(length 2.54)
+				(name "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 0.00 0)
+				(length 2.54)
+				(name "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -2.54 0)
+				(length 2.54)
+				(name "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -5.08 0)
+				(length 2.54)
+				(name "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 5.08 180)
+				(length 2.54)
+				(name "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 2.54 180)
+				(length 2.54)
+				(name "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 0.00 180)
+				(length 2.54)
+				(name "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -2.54 180)
+				(length 2.54)
+				(name "S1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "S1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -5.08 180)
+				(length 2.54)
+				(name "S2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "S2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+	)
+	(symbol "ADDR_HDR_SRC"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "U"
+			(at 0 8.89 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "ADDR_HDR_SRC"
+			(at 0 -8.89 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Connector_PinHeader_2.54mm:PinHeader_1x09_P2.54mm_Vertical"
+			(at 0 -11.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 -13.97 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 0 -16.51 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "ADDR_HDR_SRC_0_1"
+			(rectangle
+				(start -5.08 6.35)
+				(end 5.08 -6.35)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+		)
+		(symbol "ADDR_HDR_SRC_1_1"
+			(pin passive line
+				(at -7.62 5.08 0)
+				(length 2.54)
+				(name "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -7.62 2.54 0)
+				(length 2.54)
+				(name "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -7.62 0.00 0)
+				(length 2.54)
+				(name "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -7.62 -2.54 0)
+				(length 2.54)
+				(name "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -7.62 -5.08 0)
+				(length 2.54)
+				(name "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 7.62 5.08 180)
+				(length 2.54)
+				(name "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 7.62 2.54 180)
+				(length 2.54)
+				(name "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 7.62 0.00 180)
+				(length 2.54)
+				(name "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 7.62 -2.54 180)
+				(length 2.54)
+				(name "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+	)
+	(symbol "QFN48_DRAM"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "U"
+			(at 0 33.02 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "QFN48_DRAM"
+			(at 0 -33.02 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Package_DFN_QFN:QFN-48-1EP_7x7mm_P0.5mm"
+			(at 0 -35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 -38.10 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 0 -40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "QFN48_DRAM_0_1"
+			(rectangle
+				(start -6.35 30.48)
+				(end 6.35 -30.48)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+		)
+		(symbol "QFN48_DRAM_1_1"
+			(pin passive line
+				(at -8.89 29.21 0)
+				(length 2.54)
+				(name "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 26.67 0)
+				(length 2.54)
+				(name "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 24.13 0)
+				(length 2.54)
+				(name "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 21.59 0)
+				(length 2.54)
+				(name "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 19.05 0)
+				(length 2.54)
+				(name "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 16.51 0)
+				(length 2.54)
+				(name "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 13.97 0)
+				(length 2.54)
+				(name "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 11.43 0)
+				(length 2.54)
+				(name "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 8.89 0)
+				(length 2.54)
+				(name "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 6.35 0)
+				(length 2.54)
+				(name "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 3.81 0)
+				(length 2.54)
+				(name "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 1.27 0)
+				(length 2.54)
+				(name "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -1.27 0)
+				(length 2.54)
+				(name "13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -3.81 0)
+				(length 2.54)
+				(name "14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -6.35 0)
+				(length 2.54)
+				(name "15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -8.89 0)
+				(length 2.54)
+				(name "16"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "16"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -11.43 0)
+				(length 2.54)
+				(name "17"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "17"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -13.97 0)
+				(length 2.54)
+				(name "18"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "18"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -16.51 0)
+				(length 2.54)
+				(name "19"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "19"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -19.05 0)
+				(length 2.54)
+				(name "20"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "20"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -21.59 0)
+				(length 2.54)
+				(name "21"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "21"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -24.13 0)
+				(length 2.54)
+				(name "22"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "22"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -26.67 0)
+				(length 2.54)
+				(name "23"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "23"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -29.21 0)
+				(length 2.54)
+				(name "24"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "24"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 29.21 180)
+				(length 2.54)
+				(name "25"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "25"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 26.67 180)
+				(length 2.54)
+				(name "26"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "26"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 24.13 180)
+				(length 2.54)
+				(name "27"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "27"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 21.59 180)
+				(length 2.54)
+				(name "28"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "28"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 19.05 180)
+				(length 2.54)
+				(name "29"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "29"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 16.51 180)
+				(length 2.54)
+				(name "30"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "30"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 13.97 180)
+				(length 2.54)
+				(name "31"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "31"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 11.43 180)
+				(length 2.54)
+				(name "32"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "32"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 8.89 180)
+				(length 2.54)
+				(name "33"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "33"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 6.35 180)
+				(length 2.54)
+				(name "34"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "34"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 3.81 180)
+				(length 2.54)
+				(name "35"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "35"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 1.27 180)
+				(length 2.54)
+				(name "36"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "36"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -1.27 180)
+				(length 2.54)
+				(name "37"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "37"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -3.81 180)
+				(length 2.54)
+				(name "38"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "38"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -6.35 180)
+				(length 2.54)
+				(name "39"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "39"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -8.89 180)
+				(length 2.54)
+				(name "40"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "40"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -11.43 180)
+				(length 2.54)
+				(name "41"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "41"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -13.97 180)
+				(length 2.54)
+				(name "42"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "42"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -16.51 180)
+				(length 2.54)
+				(name "43"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "43"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -19.05 180)
+				(length 2.54)
+				(name "44"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "44"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -21.59 180)
+				(length 2.54)
+				(name "45"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "45"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -24.13 180)
+				(length 2.54)
+				(name "46"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "46"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -26.67 180)
+				(length 2.54)
+				(name "47"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "47"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -29.21 180)
+				(length 2.54)
+				(name "48"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "48"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+	)
+	(symbol "QFN24_MIPI"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "U"
+			(at 0 17.78 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "QFN24_MIPI"
+			(at 0 -17.78 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Package_DFN_QFN:QFN-24-1EP_4x4mm_P0.5mm"
+			(at 0 -20.32 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 -22.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 0 -25.40 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "QFN24_MIPI_0_1"
+			(rectangle
+				(start -6.35 15.24)
+				(end 6.35 -15.24)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+		)
+		(symbol "QFN24_MIPI_1_1"
+			(pin passive line
+				(at -8.89 13.97 0)
+				(length 2.54)
+				(name "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 11.43 0)
+				(length 2.54)
+				(name "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 8.89 0)
+				(length 2.54)
+				(name "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 6.35 0)
+				(length 2.54)
+				(name "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 3.81 0)
+				(length 2.54)
+				(name "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 1.27 0)
+				(length 2.54)
+				(name "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -1.27 0)
+				(length 2.54)
+				(name "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -3.81 0)
+				(length 2.54)
+				(name "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -6.35 0)
+				(length 2.54)
+				(name "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -8.89 0)
+				(length 2.54)
+				(name "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -11.43 0)
+				(length 2.54)
+				(name "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -13.97 0)
+				(length 2.54)
+				(name "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 13.97 180)
+				(length 2.54)
+				(name "13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 11.43 180)
+				(length 2.54)
+				(name "14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 8.89 180)
+				(length 2.54)
+				(name "15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 6.35 180)
+				(length 2.54)
+				(name "16"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "16"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 3.81 180)
+				(length 2.54)
+				(name "17"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "17"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 1.27 180)
+				(length 2.54)
+				(name "18"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "18"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -1.27 180)
+				(length 2.54)
+				(name "19"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "19"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -3.81 180)
+				(length 2.54)
+				(name "20"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "20"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -6.35 180)
+				(length 2.54)
+				(name "21"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "21"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -8.89 180)
+				(length 2.54)
+				(name "22"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "22"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -11.43 180)
+				(length 2.54)
+				(name "23"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "23"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -13.97 180)
+				(length 2.54)
+				(name "24"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "24"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+	)
+	(symbol "BGA49_HDMI"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "U"
+			(at 0 34.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "BGA49_HDMI"
+			(at 0 -34.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Package_BGA:BGA-49_5.0x5.0mm_Layout7x7_P0.5mm"
+			(at 0 -36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 -39.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 0 -41.91 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "BGA49_HDMI_0_1"
+			(rectangle
+				(start -6.35 31.75)
+				(end 6.35 -31.75)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+		)
+		(symbol "BGA49_HDMI_1_1"
+			(pin passive line
+				(at -8.89 30.48 0)
+				(length 2.54)
+				(name "A1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 27.94 0)
+				(length 2.54)
+				(name "A2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 25.40 0)
+				(length 2.54)
+				(name "A3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 22.86 0)
+				(length 2.54)
+				(name "A4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 20.32 0)
+				(length 2.54)
+				(name "A5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 17.78 0)
+				(length 2.54)
+				(name "A6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 15.24 0)
+				(length 2.54)
+				(name "A7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 12.70 0)
+				(length 2.54)
+				(name "B1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 10.16 0)
+				(length 2.54)
+				(name "B2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 7.62 0)
+				(length 2.54)
+				(name "B3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 5.08 0)
+				(length 2.54)
+				(name "B4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 2.54 0)
+				(length 2.54)
+				(name "B5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 0.00 0)
+				(length 2.54)
+				(name "B6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -2.54 0)
+				(length 2.54)
+				(name "B7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -5.08 0)
+				(length 2.54)
+				(name "C1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "C1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -7.62 0)
+				(length 2.54)
+				(name "C2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "C2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -10.16 0)
+				(length 2.54)
+				(name "C3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "C3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -12.70 0)
+				(length 2.54)
+				(name "C4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "C4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -15.24 0)
+				(length 2.54)
+				(name "C5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "C5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -17.78 0)
+				(length 2.54)
+				(name "C6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "C6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -20.32 0)
+				(length 2.54)
+				(name "C7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "C7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -22.86 0)
+				(length 2.54)
+				(name "D1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "D1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -25.40 0)
+				(length 2.54)
+				(name "D2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "D2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -27.94 0)
+				(length 2.54)
+				(name "D3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "D3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -30.48 0)
+				(length 2.54)
+				(name "D4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "D4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 30.48 180)
+				(length 2.54)
+				(name "D5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "D5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 27.94 180)
+				(length 2.54)
+				(name "D6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "D6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 25.40 180)
+				(length 2.54)
+				(name "D7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "D7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 22.86 180)
+				(length 2.54)
+				(name "E1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "E1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 20.32 180)
+				(length 2.54)
+				(name "E2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "E2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 17.78 180)
+				(length 2.54)
+				(name "E3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "E3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 15.24 180)
+				(length 2.54)
+				(name "E4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "E4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 12.70 180)
+				(length 2.54)
+				(name "E5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "E5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 10.16 180)
+				(length 2.54)
+				(name "E6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "E6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 7.62 180)
+				(length 2.54)
+				(name "E7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "E7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 5.08 180)
+				(length 2.54)
+				(name "F1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "F1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 2.54 180)
+				(length 2.54)
+				(name "F2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "F2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 0.00 180)
+				(length 2.54)
+				(name "F3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "F3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -2.54 180)
+				(length 2.54)
+				(name "F4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "F4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -5.08 180)
+				(length 2.54)
+				(name "F5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "F5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -7.62 180)
+				(length 2.54)
+				(name "F6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "F6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -10.16 180)
+				(length 2.54)
+				(name "F7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "F7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -12.70 180)
+				(length 2.54)
+				(name "G1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "G1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -15.24 180)
+				(length 2.54)
+				(name "G2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "G2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -17.78 180)
+				(length 2.54)
+				(name "G3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "G3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -20.32 180)
+				(length 2.54)
+				(name "G4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "G4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -22.86 180)
+				(length 2.54)
+				(name "G5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "G5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -25.40 180)
+				(length 2.54)
+				(name "G6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "G6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -27.94 180)
+				(length 2.54)
+				(name "G7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "G7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+	)
+	(symbol "QFP48_SRAM"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "U"
+			(at 0 33.02 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "QFP48_SRAM"
+			(at 0 -33.02 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Package_QFP:LQFP-48_7x7mm_P0.5mm"
+			(at 0 -35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 -38.10 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 0 -40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "QFP48_SRAM_0_1"
+			(rectangle
+				(start -6.35 30.48)
+				(end 6.35 -30.48)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+		)
+		(symbol "QFP48_SRAM_1_1"
+			(pin passive line
+				(at -8.89 29.21 0)
+				(length 2.54)
+				(name "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 26.67 0)
+				(length 2.54)
+				(name "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 24.13 0)
+				(length 2.54)
+				(name "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 21.59 0)
+				(length 2.54)
+				(name "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 19.05 0)
+				(length 2.54)
+				(name "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 16.51 0)
+				(length 2.54)
+				(name "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 13.97 0)
+				(length 2.54)
+				(name "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 11.43 0)
+				(length 2.54)
+				(name "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 8.89 0)
+				(length 2.54)
+				(name "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 6.35 0)
+				(length 2.54)
+				(name "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 3.81 0)
+				(length 2.54)
+				(name "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 1.27 0)
+				(length 2.54)
+				(name "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -1.27 0)
+				(length 2.54)
+				(name "13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -3.81 0)
+				(length 2.54)
+				(name "14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -6.35 0)
+				(length 2.54)
+				(name "15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -8.89 0)
+				(length 2.54)
+				(name "16"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "16"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -11.43 0)
+				(length 2.54)
+				(name "17"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "17"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -13.97 0)
+				(length 2.54)
+				(name "18"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "18"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -16.51 0)
+				(length 2.54)
+				(name "19"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "19"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -19.05 0)
+				(length 2.54)
+				(name "20"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "20"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -21.59 0)
+				(length 2.54)
+				(name "21"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "21"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -24.13 0)
+				(length 2.54)
+				(name "22"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "22"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -26.67 0)
+				(length 2.54)
+				(name "23"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "23"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -8.89 -29.21 0)
+				(length 2.54)
+				(name "24"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "24"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 29.21 180)
+				(length 2.54)
+				(name "25"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "25"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 26.67 180)
+				(length 2.54)
+				(name "26"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "26"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 24.13 180)
+				(length 2.54)
+				(name "27"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "27"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 21.59 180)
+				(length 2.54)
+				(name "28"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "28"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 19.05 180)
+				(length 2.54)
+				(name "29"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "29"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 16.51 180)
+				(length 2.54)
+				(name "30"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "30"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 13.97 180)
+				(length 2.54)
+				(name "31"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "31"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 11.43 180)
+				(length 2.54)
+				(name "32"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "32"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 8.89 180)
+				(length 2.54)
+				(name "33"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "33"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 6.35 180)
+				(length 2.54)
+				(name "34"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "34"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 3.81 180)
+				(length 2.54)
+				(name "35"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "35"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 1.27 180)
+				(length 2.54)
+				(name "36"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "36"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -1.27 180)
+				(length 2.54)
+				(name "37"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "37"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -3.81 180)
+				(length 2.54)
+				(name "38"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "38"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -6.35 180)
+				(length 2.54)
+				(name "39"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "39"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -8.89 180)
+				(length 2.54)
+				(name "40"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "40"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -11.43 180)
+				(length 2.54)
+				(name "41"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "41"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -13.97 180)
+				(length 2.54)
+				(name "42"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "42"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -16.51 180)
+				(length 2.54)
+				(name "43"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "43"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -19.05 180)
+				(length 2.54)
+				(name "44"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "44"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -21.59 180)
+				(length 2.54)
+				(name "45"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "45"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -24.13 180)
+				(length 2.54)
+				(name "46"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "46"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -26.67 180)
+				(length 2.54)
+				(name "47"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "47"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 8.89 -29.21 180)
+				(length 2.54)
+				(name "48"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "48"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+	)
+)

--- a/boards/07-matchgroup-test/output/matchgroup_test.kicad_sch
+++ b/boards/07-matchgroup-test/output/matchgroup_test.kicad_sch
@@ -2,101 +2,75 @@
 	(version 20231120)
 	(generator "eeschema")
 	(generator_version "9.0")
-	(uuid "0d315cf6-faeb-4774-88b8-21b8269a7e13")
-	(paper "A3")
+	(uuid "5b6ec878-611a-4148-afea-b98afc10dc0a")
+	(paper "A2")
 	(title_block
 		(title "Match-Group Test Board")
 		(date "2026-05")
-		(rev "A")
+		(rev "B")
 		(company "kicad-tools")
 		(comment 1 "N-trace + group-of-pairs match-group regression testbench")
-		(comment 2 "Epic #2661 Phase 3L (issue #2724)")
+		(comment 2 "Epic #2661 Phase 3L (issue #2724); wired netlist #4012")
 	)
 	(lib_symbols
-		(symbol "Connector_Generic:Conn_02x24_Counter_Clockwise"
-			(pin_names (offset 1.016) (hide yes))
+		(symbol "matchgroup_lvs:QFN48_DDR_CTRL"
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
-			(in_pos_files yes)
-			(duplicate_pin_numbers_are_jumpers no)
-			(property "Reference" "J"
-				(at 1.27 30.48 0)
-				(show_name no)
-				(do_not_autoplace no)
+			(property "Reference" "U"
+				(at 0 33.02 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
 				)
 			)
-			(property "Value" "Conn_02x24_Counter_Clockwise"
-				(at 1.27 -33.02 0)
-				(show_name no)
-				(do_not_autoplace no)
+			(property "Value" "QFN48_DDR_CTRL"
+				(at 0 -33.02 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
 				)
 			)
-			(property "Footprint" ""
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
+			(property "Footprint" "Package_DFN_QFN:QFN-48-1EP_7x7mm_P0.5mm"
+				(at 0 -35.56 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
 			(property "Datasheet" ""
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
+				(at 0 -38.10 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
-			(property "Description" "Generic connector, double row, 02x24, counter clockwise pin numbering scheme (similar to DIP package numbering), script generated (kicad-library-utils/schlib/autogen/connector/)"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
+			(property "Description" ""
+				(at 0 -40.64 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
-			(property "ki_keywords" "connector"
+			(property "ki_keywords" ""
 				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
-			(property "ki_fp_filters" "Connector*:*_2x??_*"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(symbol "Conn_02x24_Counter_Clockwise_1_1"
-				(rectangle (start -1.27 29.21) (end 3.81 -31.75)
+			(symbol "QFN48_DDR_CTRL_0_1"
+				(rectangle (start -6.35 30.48) (end 6.35 -30.48)
 					(stroke
 						(width 0.254)
 						(type default)
@@ -104,392 +78,10 @@
 					(fill (type background)
 					)
 				)
-				(rectangle (start -1.27 28.067) (end 0 27.813)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 25.527) (end 0 25.273)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 22.987) (end 0 22.733)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 20.447) (end 0 20.193)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 17.907) (end 0 17.653)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 15.367) (end 0 15.113)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 12.827) (end 0 12.573)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 10.287) (end 0 10.033)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 7.747) (end 0 7.493)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 5.207) (end 0 4.953)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 2.667) (end 0 2.413)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 0.127) (end 0 -0.127)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -2.413) (end 0 -2.667)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -4.953) (end 0 -5.207)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -7.493) (end 0 -7.747)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -10.033) (end 0 -10.287)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -12.573) (end 0 -12.827)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -15.113) (end 0 -15.367)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -17.653) (end 0 -17.907)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -20.193) (end 0 -20.447)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -22.733) (end 0 -22.987)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -25.273) (end 0 -25.527)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -27.813) (end 0 -28.067)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -30.353) (end 0 -30.607)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 28.067) (end 2.54 27.813)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 25.527) (end 2.54 25.273)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 22.987) (end 2.54 22.733)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 20.447) (end 2.54 20.193)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 17.907) (end 2.54 17.653)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 15.367) (end 2.54 15.113)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 12.827) (end 2.54 12.573)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 10.287) (end 2.54 10.033)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 7.747) (end 2.54 7.493)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 5.207) (end 2.54 4.953)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 2.667) (end 2.54 2.413)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 0.127) (end 2.54 -0.127)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -2.413) (end 2.54 -2.667)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -4.953) (end 2.54 -5.207)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -7.493) (end 2.54 -7.747)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -10.033) (end 2.54 -10.287)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -12.573) (end 2.54 -12.827)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -15.113) (end 2.54 -15.367)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -17.653) (end 2.54 -17.907)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -20.193) (end 2.54 -20.447)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -22.733) (end 2.54 -22.987)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -25.273) (end 2.54 -25.527)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -27.813) (end 2.54 -28.067)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -30.353) (end 2.54 -30.607)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(pin passive line (at -5.08 27.94 0) (length 3.81)
-					(name "Pin_1"
+			)
+			(symbol "QFN48_DDR_CTRL_1_1"
+				(pin passive line (at -8.89 29.21 0) (length 2.54)
+					(name "1"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -504,8 +96,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 25.4 0) (length 3.81)
-					(name "Pin_2"
+				(pin passive line (at -8.89 26.67 0) (length 2.54)
+					(name "2"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -520,8 +112,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 22.86 0) (length 3.81)
-					(name "Pin_3"
+				(pin passive line (at -8.89 24.13 0) (length 2.54)
+					(name "3"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -536,8 +128,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 20.32 0) (length 3.81)
-					(name "Pin_4"
+				(pin passive line (at -8.89 21.59 0) (length 2.54)
+					(name "4"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -552,8 +144,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 17.78 0) (length 3.81)
-					(name "Pin_5"
+				(pin passive line (at -8.89 19.05 0) (length 2.54)
+					(name "5"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -568,8 +160,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 15.24 0) (length 3.81)
-					(name "Pin_6"
+				(pin passive line (at -8.89 16.51 0) (length 2.54)
+					(name "6"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -584,8 +176,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 12.7 0) (length 3.81)
-					(name "Pin_7"
+				(pin passive line (at -8.89 13.97 0) (length 2.54)
+					(name "7"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -600,8 +192,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 10.16 0) (length 3.81)
-					(name "Pin_8"
+				(pin passive line (at -8.89 11.43 0) (length 2.54)
+					(name "8"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -616,8 +208,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 7.62 0) (length 3.81)
-					(name "Pin_9"
+				(pin passive line (at -8.89 8.89 0) (length 2.54)
+					(name "9"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -632,8 +224,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 5.08 0) (length 3.81)
-					(name "Pin_10"
+				(pin passive line (at -8.89 6.35 0) (length 2.54)
+					(name "10"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -648,8 +240,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 2.54 0) (length 3.81)
-					(name "Pin_11"
+				(pin passive line (at -8.89 3.81 0) (length 2.54)
+					(name "11"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -664,8 +256,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 0 0) (length 3.81)
-					(name "Pin_12"
+				(pin passive line (at -8.89 1.27 0) (length 2.54)
+					(name "12"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -680,8 +272,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -2.54 0) (length 3.81)
-					(name "Pin_13"
+				(pin passive line (at -8.89 -1.27 0) (length 2.54)
+					(name "13"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -696,8 +288,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -5.08 0) (length 3.81)
-					(name "Pin_14"
+				(pin passive line (at -8.89 -3.81 0) (length 2.54)
+					(name "14"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -712,8 +304,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -7.62 0) (length 3.81)
-					(name "Pin_15"
+				(pin passive line (at -8.89 -6.35 0) (length 2.54)
+					(name "15"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -728,8 +320,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -10.16 0) (length 3.81)
-					(name "Pin_16"
+				(pin passive line (at -8.89 -8.89 0) (length 2.54)
+					(name "16"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -744,8 +336,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -12.7 0) (length 3.81)
-					(name "Pin_17"
+				(pin passive line (at -8.89 -11.43 0) (length 2.54)
+					(name "17"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -760,8 +352,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -15.24 0) (length 3.81)
-					(name "Pin_18"
+				(pin passive line (at -8.89 -13.97 0) (length 2.54)
+					(name "18"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -776,8 +368,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -17.78 0) (length 3.81)
-					(name "Pin_19"
+				(pin passive line (at -8.89 -16.51 0) (length 2.54)
+					(name "19"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -792,8 +384,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -20.32 0) (length 3.81)
-					(name "Pin_20"
+				(pin passive line (at -8.89 -19.05 0) (length 2.54)
+					(name "20"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -808,8 +400,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -22.86 0) (length 3.81)
-					(name "Pin_21"
+				(pin passive line (at -8.89 -21.59 0) (length 2.54)
+					(name "21"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -824,8 +416,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -25.4 0) (length 3.81)
-					(name "Pin_22"
+				(pin passive line (at -8.89 -24.13 0) (length 2.54)
+					(name "22"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -840,8 +432,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -27.94 0) (length 3.81)
-					(name "Pin_23"
+				(pin passive line (at -8.89 -26.67 0) (length 2.54)
+					(name "23"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -856,8 +448,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -30.48 0) (length 3.81)
-					(name "Pin_24"
+				(pin passive line (at -8.89 -29.21 0) (length 2.54)
+					(name "24"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -872,8 +464,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -30.48 180) (length 3.81)
-					(name "Pin_25"
+				(pin passive line (at 8.89 29.21 180) (length 2.54)
+					(name "25"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -888,8 +480,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -27.94 180) (length 3.81)
-					(name "Pin_26"
+				(pin passive line (at 8.89 26.67 180) (length 2.54)
+					(name "26"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -904,8 +496,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -25.4 180) (length 3.81)
-					(name "Pin_27"
+				(pin passive line (at 8.89 24.13 180) (length 2.54)
+					(name "27"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -920,8 +512,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -22.86 180) (length 3.81)
-					(name "Pin_28"
+				(pin passive line (at 8.89 21.59 180) (length 2.54)
+					(name "28"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -936,8 +528,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -20.32 180) (length 3.81)
-					(name "Pin_29"
+				(pin passive line (at 8.89 19.05 180) (length 2.54)
+					(name "29"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -952,8 +544,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -17.78 180) (length 3.81)
-					(name "Pin_30"
+				(pin passive line (at 8.89 16.51 180) (length 2.54)
+					(name "30"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -968,8 +560,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -15.24 180) (length 3.81)
-					(name "Pin_31"
+				(pin passive line (at 8.89 13.97 180) (length 2.54)
+					(name "31"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -984,8 +576,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -12.7 180) (length 3.81)
-					(name "Pin_32"
+				(pin passive line (at 8.89 11.43 180) (length 2.54)
+					(name "32"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1000,8 +592,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -10.16 180) (length 3.81)
-					(name "Pin_33"
+				(pin passive line (at 8.89 8.89 180) (length 2.54)
+					(name "33"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1016,8 +608,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -7.62 180) (length 3.81)
-					(name "Pin_34"
+				(pin passive line (at 8.89 6.35 180) (length 2.54)
+					(name "34"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1032,8 +624,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -5.08 180) (length 3.81)
-					(name "Pin_35"
+				(pin passive line (at 8.89 3.81 180) (length 2.54)
+					(name "35"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1048,8 +640,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -2.54 180) (length 3.81)
-					(name "Pin_36"
+				(pin passive line (at 8.89 1.27 180) (length 2.54)
+					(name "36"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1064,8 +656,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 0 180) (length 3.81)
-					(name "Pin_37"
+				(pin passive line (at 8.89 -1.27 180) (length 2.54)
+					(name "37"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1080,8 +672,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 2.54 180) (length 3.81)
-					(name "Pin_38"
+				(pin passive line (at 8.89 -3.81 180) (length 2.54)
+					(name "38"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1096,8 +688,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 5.08 180) (length 3.81)
-					(name "Pin_39"
+				(pin passive line (at 8.89 -6.35 180) (length 2.54)
+					(name "39"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1112,8 +704,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 7.62 180) (length 3.81)
-					(name "Pin_40"
+				(pin passive line (at 8.89 -8.89 180) (length 2.54)
+					(name "40"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1128,8 +720,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 10.16 180) (length 3.81)
-					(name "Pin_41"
+				(pin passive line (at 8.89 -11.43 180) (length 2.54)
+					(name "41"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1144,8 +736,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 12.7 180) (length 3.81)
-					(name "Pin_42"
+				(pin passive line (at 8.89 -13.97 180) (length 2.54)
+					(name "42"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1160,8 +752,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 15.24 180) (length 3.81)
-					(name "Pin_43"
+				(pin passive line (at 8.89 -16.51 180) (length 2.54)
+					(name "43"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1176,8 +768,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 17.78 180) (length 3.81)
-					(name "Pin_44"
+				(pin passive line (at 8.89 -19.05 180) (length 2.54)
+					(name "44"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1192,8 +784,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 20.32 180) (length 3.81)
-					(name "Pin_45"
+				(pin passive line (at 8.89 -21.59 180) (length 2.54)
+					(name "45"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1208,8 +800,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 22.86 180) (length 3.81)
-					(name "Pin_46"
+				(pin passive line (at 8.89 -24.13 180) (length 2.54)
+					(name "46"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1224,8 +816,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 25.4 180) (length 3.81)
-					(name "Pin_47"
+				(pin passive line (at 8.89 -26.67 180) (length 2.54)
+					(name "47"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1240,8 +832,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 27.94 180) (length 3.81)
-					(name "Pin_48"
+				(pin passive line (at 8.89 -29.21 180) (length 2.54)
+					(name "48"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1257,92 +849,65 @@
 					)
 				)
 			)
-			(embedded_fonts no)
 		)
-		(symbol "Connector_Generic:Conn_01x06"
-			(pin_names (offset 1.016) (hide yes))
+		(symbol "matchgroup_lvs:FFC6_MIPI_SRC"
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
-			(in_pos_files yes)
-			(duplicate_pin_numbers_are_jumpers no)
-			(property "Reference" "J"
+			(property "Reference" "U"
 				(at 0 7.62 0)
-				(show_name no)
-				(do_not_autoplace no)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
 				)
 			)
-			(property "Value" "Conn_01x06"
+			(property "Value" "FFC6_MIPI_SRC"
+				(at 0 -7.62 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "Connector_FFC:FFC_6P_1.0mm"
 				(at 0 -10.16 0)
-				(show_name no)
-				(do_not_autoplace no)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
-				)
-			)
-			(property "Footprint" ""
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
+					(hide yes)
 				)
 			)
 			(property "Datasheet" ""
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
+				(at 0 -12.70 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
-			(property "Description" "Generic connector, single row, 01x06, script generated (kicad-library-utils/schlib/autogen/connector/)"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
+			(property "Description" ""
+				(at 0 -15.24 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
-			(property "ki_keywords" "connector"
+			(property "ki_keywords" ""
 				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
-			(property "ki_fp_filters" "Connector*:*_1x??_*"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(symbol "Conn_01x06_1_1"
-				(rectangle (start -1.27 6.35) (end 1.27 -8.89)
+			(symbol "FFC6_MIPI_SRC_0_1"
+				(rectangle (start -6.35 5.08) (end 6.35 -5.08)
 					(stroke
 						(width 0.254)
 						(type default)
@@ -1350,56 +915,10 @@
 					(fill (type background)
 					)
 				)
-				(rectangle (start -1.27 5.207) (end 0 4.953)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 2.667) (end 0 2.413)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 0.127) (end 0 -0.127)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -2.413) (end 0 -2.667)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -4.953) (end 0 -5.207)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -7.493) (end 0 -7.747)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(pin passive line (at -5.08 5.08 0) (length 3.81)
-					(name "Pin_1"
+			)
+			(symbol "FFC6_MIPI_SRC_1_1"
+				(pin passive line (at -8.89 3.81 0) (length 2.54)
+					(name "1"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1414,8 +933,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 2.54 0) (length 3.81)
-					(name "Pin_2"
+				(pin passive line (at -8.89 1.27 0) (length 2.54)
+					(name "2"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1430,8 +949,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 0 0) (length 3.81)
-					(name "Pin_3"
+				(pin passive line (at -8.89 -1.27 0) (length 2.54)
+					(name "3"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1446,8 +965,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -2.54 0) (length 3.81)
-					(name "Pin_4"
+				(pin passive line (at -8.89 -3.81 0) (length 2.54)
+					(name "4"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1462,8 +981,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -5.08 0) (length 3.81)
-					(name "Pin_5"
+				(pin passive line (at 8.89 3.81 180) (length 2.54)
+					(name "5"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1478,8 +997,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -7.62 0) (length 3.81)
-					(name "Pin_6"
+				(pin passive line (at 8.89 1.27 180) (length 2.54)
+					(name "6"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1494,93 +1013,98 @@
 						)
 					)
 				)
+				(pin passive line (at 8.89 -1.27 180) (length 2.54)
+					(name "M1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -3.81 180) (length 2.54)
+					(name "M2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
 			)
-			(embedded_fonts no)
 		)
-		(symbol "Connector_Generic:Conn_01x08"
-			(pin_names (offset 1.016) (hide yes))
+		(symbol "matchgroup_lvs:HDMI_SRC"
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
-			(in_pos_files yes)
-			(duplicate_pin_numbers_are_jumpers no)
-			(property "Reference" "J"
-				(at 0 10.16 0)
-				(show_name no)
-				(do_not_autoplace no)
+			(property "Reference" "U"
+				(at 0 8.89 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
 				)
 			)
-			(property "Value" "Conn_01x08"
-				(at 0 -12.7 0)
-				(show_name no)
-				(do_not_autoplace no)
+			(property "Value" "HDMI_SRC"
+				(at 0 -8.89 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
 				)
 			)
-			(property "Footprint" ""
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
+			(property "Footprint" "Connector_Video:HDMI_A_Receptacle"
+				(at 0 -11.43 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
 			(property "Datasheet" ""
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
+				(at 0 -13.97 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
-			(property "Description" "Generic connector, single row, 01x08, script generated (kicad-library-utils/schlib/autogen/connector/)"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
+			(property "Description" ""
+				(at 0 -16.51 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
-			(property "ki_keywords" "connector"
+			(property "ki_keywords" ""
 				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
-			(property "ki_fp_filters" "Connector*:*_1x??_*"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(symbol "Conn_01x08_1_1"
-				(rectangle (start -1.27 8.89) (end 1.27 -11.43)
+			(symbol "HDMI_SRC_0_1"
+				(rectangle (start -6.35 6.35) (end 6.35 -6.35)
 					(stroke
 						(width 0.254)
 						(type default)
@@ -1588,72 +1112,10 @@
 					(fill (type background)
 					)
 				)
-				(rectangle (start -1.27 7.747) (end 0 7.493)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 5.207) (end 0 4.953)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 2.667) (end 0 2.413)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 0.127) (end 0 -0.127)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -2.413) (end 0 -2.667)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -4.953) (end 0 -5.207)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -7.493) (end 0 -7.747)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -10.033) (end 0 -10.287)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(pin passive line (at -5.08 7.62 0) (length 3.81)
-					(name "Pin_1"
+			)
+			(symbol "HDMI_SRC_1_1"
+				(pin passive line (at -8.89 5.08 0) (length 2.54)
+					(name "1"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1668,8 +1130,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 5.08 0) (length 3.81)
-					(name "Pin_2"
+				(pin passive line (at -8.89 2.54 0) (length 2.54)
+					(name "2"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1684,8 +1146,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 2.54 0) (length 3.81)
-					(name "Pin_3"
+				(pin passive line (at -8.89 0.00 0) (length 2.54)
+					(name "3"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1700,8 +1162,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 0 0) (length 3.81)
-					(name "Pin_4"
+				(pin passive line (at -8.89 -2.54 0) (length 2.54)
+					(name "4"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1716,8 +1178,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -2.54 0) (length 3.81)
-					(name "Pin_5"
+				(pin passive line (at -8.89 -5.08 0) (length 2.54)
+					(name "5"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1732,8 +1194,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -5.08 0) (length 3.81)
-					(name "Pin_6"
+				(pin passive line (at 8.89 5.08 180) (length 2.54)
+					(name "6"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1748,8 +1210,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -7.62 0) (length 3.81)
-					(name "Pin_7"
+				(pin passive line (at 8.89 2.54 180) (length 2.54)
+					(name "7"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1764,8 +1226,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -10.16 0) (length 3.81)
-					(name "Pin_8"
+				(pin passive line (at 8.89 0.00 180) (length 2.54)
+					(name "8"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1780,93 +1242,98 @@
 						)
 					)
 				)
+				(pin passive line (at 8.89 -2.54 180) (length 2.54)
+					(name "S1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "S1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -5.08 180) (length 2.54)
+					(name "S2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "S2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
 			)
-			(embedded_fonts no)
 		)
-		(symbol "Connector_Generic:Conn_01x09"
-			(pin_names (offset 1.016) (hide yes))
+		(symbol "matchgroup_lvs:ADDR_HDR_SRC"
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
-			(in_pos_files yes)
-			(duplicate_pin_numbers_are_jumpers no)
-			(property "Reference" "J"
-				(at 0 12.7 0)
-				(show_name no)
-				(do_not_autoplace no)
+			(property "Reference" "U"
+				(at 0 8.89 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
 				)
 			)
-			(property "Value" "Conn_01x09"
-				(at 0 -12.7 0)
-				(show_name no)
-				(do_not_autoplace no)
+			(property "Value" "ADDR_HDR_SRC"
+				(at 0 -8.89 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
 				)
 			)
-			(property "Footprint" ""
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
+			(property "Footprint" "Connector_PinHeader_2.54mm:PinHeader_1x09_P2.54mm_Vertical"
+				(at 0 -11.43 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
 			(property "Datasheet" ""
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
+				(at 0 -13.97 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
-			(property "Description" "Generic connector, single row, 01x09, script generated (kicad-library-utils/schlib/autogen/connector/)"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
+			(property "Description" ""
+				(at 0 -16.51 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
-			(property "ki_keywords" "connector"
+			(property "ki_keywords" ""
 				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
-			(property "ki_fp_filters" "Connector*:*_1x??_*"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(symbol "Conn_01x09_1_1"
-				(rectangle (start -1.27 11.43) (end 1.27 -11.43)
+			(symbol "ADDR_HDR_SRC_0_1"
+				(rectangle (start -5.08 6.35) (end 5.08 -6.35)
 					(stroke
 						(width 0.254)
 						(type default)
@@ -1874,80 +1341,10 @@
 					(fill (type background)
 					)
 				)
-				(rectangle (start -1.27 10.287) (end 0 10.033)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 7.747) (end 0 7.493)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 5.207) (end 0 4.953)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 2.667) (end 0 2.413)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 0.127) (end 0 -0.127)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -2.413) (end 0 -2.667)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -4.953) (end 0 -5.207)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -7.493) (end 0 -7.747)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -10.033) (end 0 -10.287)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(pin passive line (at -5.08 10.16 0) (length 3.81)
-					(name "Pin_1"
+			)
+			(symbol "ADDR_HDR_SRC_1_1"
+				(pin passive line (at -7.62 5.08 0) (length 2.54)
+					(name "1"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1962,8 +1359,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 7.62 0) (length 3.81)
-					(name "Pin_2"
+				(pin passive line (at -7.62 2.54 0) (length 2.54)
+					(name "2"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1978,8 +1375,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 5.08 0) (length 3.81)
-					(name "Pin_3"
+				(pin passive line (at -7.62 0.00 0) (length 2.54)
+					(name "3"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -1994,8 +1391,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 2.54 0) (length 3.81)
-					(name "Pin_4"
+				(pin passive line (at -7.62 -2.54 0) (length 2.54)
+					(name "4"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2010,8 +1407,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 0 0) (length 3.81)
-					(name "Pin_5"
+				(pin passive line (at -7.62 -5.08 0) (length 2.54)
+					(name "5"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2026,8 +1423,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -2.54 0) (length 3.81)
-					(name "Pin_6"
+				(pin passive line (at 7.62 5.08 180) (length 2.54)
+					(name "6"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2042,8 +1439,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -5.08 0) (length 3.81)
-					(name "Pin_7"
+				(pin passive line (at 7.62 2.54 180) (length 2.54)
+					(name "7"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2058,8 +1455,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -7.62 0) (length 3.81)
-					(name "Pin_8"
+				(pin passive line (at 7.62 0.00 180) (length 2.54)
+					(name "8"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2074,8 +1471,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -10.16 0) (length 3.81)
-					(name "Pin_9"
+				(pin passive line (at 7.62 -2.54 180) (length 2.54)
+					(name "9"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2091,92 +1488,65 @@
 					)
 				)
 			)
-			(embedded_fonts no)
 		)
-		(symbol "Connector_Generic:Conn_02x12_Counter_Clockwise"
-			(pin_names (offset 1.016) (hide yes))
+		(symbol "matchgroup_lvs:QFN48_DRAM"
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
-			(in_pos_files yes)
-			(duplicate_pin_numbers_are_jumpers no)
-			(property "Reference" "J"
-				(at 1.27 15.24 0)
-				(show_name no)
-				(do_not_autoplace no)
+			(property "Reference" "U"
+				(at 0 33.02 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
 				)
 			)
-			(property "Value" "Conn_02x12_Counter_Clockwise"
-				(at 1.27 -17.78 0)
-				(show_name no)
-				(do_not_autoplace no)
+			(property "Value" "QFN48_DRAM"
+				(at 0 -33.02 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
 				)
 			)
-			(property "Footprint" ""
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
+			(property "Footprint" "Package_DFN_QFN:QFN-48-1EP_7x7mm_P0.5mm"
+				(at 0 -35.56 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
 			(property "Datasheet" ""
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
+				(at 0 -38.10 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
-			(property "Description" "Generic connector, double row, 02x12, counter clockwise pin numbering scheme (similar to DIP package numbering), script generated (kicad-library-utils/schlib/autogen/connector/)"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
+			(property "Description" ""
+				(at 0 -40.64 0)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
-			(property "ki_keywords" "connector"
+			(property "ki_keywords" ""
 				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
 				(effects
 					(font
 						(size 1.27 1.27)
 					)
+					(hide yes)
 				)
 			)
-			(property "ki_fp_filters" "Connector*:*_2x??_*"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(symbol "Conn_02x12_Counter_Clockwise_1_1"
-				(rectangle (start -1.27 13.97) (end 3.81 -16.51)
+			(symbol "QFN48_DRAM_0_1"
+				(rectangle (start -6.35 30.48) (end 6.35 -30.48)
 					(stroke
 						(width 0.254)
 						(type default)
@@ -2184,200 +1554,10 @@
 					(fill (type background)
 					)
 				)
-				(rectangle (start -1.27 12.827) (end 0 12.573)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 10.287) (end 0 10.033)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 7.747) (end 0 7.493)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 5.207) (end 0 4.953)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 2.667) (end 0 2.413)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 0.127) (end 0 -0.127)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -2.413) (end 0 -2.667)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -4.953) (end 0 -5.207)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -7.493) (end 0 -7.747)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -10.033) (end 0 -10.287)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -12.573) (end 0 -12.827)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -15.113) (end 0 -15.367)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 12.827) (end 2.54 12.573)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 10.287) (end 2.54 10.033)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 7.747) (end 2.54 7.493)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 5.207) (end 2.54 4.953)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 2.667) (end 2.54 2.413)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 0.127) (end 2.54 -0.127)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -2.413) (end 2.54 -2.667)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -4.953) (end 2.54 -5.207)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -7.493) (end 2.54 -7.747)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -10.033) (end 2.54 -10.287)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -12.573) (end 2.54 -12.827)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -15.113) (end 2.54 -15.367)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(pin passive line (at -5.08 12.7 0) (length 3.81)
-					(name "Pin_1"
+			)
+			(symbol "QFN48_DRAM_1_1"
+				(pin passive line (at -8.89 29.21 0) (length 2.54)
+					(name "1"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2392,8 +1572,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 10.16 0) (length 3.81)
-					(name "Pin_2"
+				(pin passive line (at -8.89 26.67 0) (length 2.54)
+					(name "2"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2408,8 +1588,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 7.62 0) (length 3.81)
-					(name "Pin_3"
+				(pin passive line (at -8.89 24.13 0) (length 2.54)
+					(name "3"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2424,8 +1604,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 5.08 0) (length 3.81)
-					(name "Pin_4"
+				(pin passive line (at -8.89 21.59 0) (length 2.54)
+					(name "4"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2440,8 +1620,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 2.54 0) (length 3.81)
-					(name "Pin_5"
+				(pin passive line (at -8.89 19.05 0) (length 2.54)
+					(name "5"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2456,8 +1636,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 0 0) (length 3.81)
-					(name "Pin_6"
+				(pin passive line (at -8.89 16.51 0) (length 2.54)
+					(name "6"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2472,8 +1652,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -2.54 0) (length 3.81)
-					(name "Pin_7"
+				(pin passive line (at -8.89 13.97 0) (length 2.54)
+					(name "7"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2488,8 +1668,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -5.08 0) (length 3.81)
-					(name "Pin_8"
+				(pin passive line (at -8.89 11.43 0) (length 2.54)
+					(name "8"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2504,8 +1684,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -7.62 0) (length 3.81)
-					(name "Pin_9"
+				(pin passive line (at -8.89 8.89 0) (length 2.54)
+					(name "9"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2520,8 +1700,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -10.16 0) (length 3.81)
-					(name "Pin_10"
+				(pin passive line (at -8.89 6.35 0) (length 2.54)
+					(name "10"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2536,8 +1716,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -12.7 0) (length 3.81)
-					(name "Pin_11"
+				(pin passive line (at -8.89 3.81 0) (length 2.54)
+					(name "11"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2552,8 +1732,8 @@
 						)
 					)
 				)
-				(pin passive line (at -5.08 -15.24 0) (length 3.81)
-					(name "Pin_12"
+				(pin passive line (at -8.89 1.27 0) (length 2.54)
+					(name "12"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2568,8 +1748,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -15.24 180) (length 3.81)
-					(name "Pin_13"
+				(pin passive line (at -8.89 -1.27 0) (length 2.54)
+					(name "13"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2584,8 +1764,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -12.7 180) (length 3.81)
-					(name "Pin_14"
+				(pin passive line (at -8.89 -3.81 0) (length 2.54)
+					(name "14"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2600,8 +1780,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -10.16 180) (length 3.81)
-					(name "Pin_15"
+				(pin passive line (at -8.89 -6.35 0) (length 2.54)
+					(name "15"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2616,8 +1796,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -7.62 180) (length 3.81)
-					(name "Pin_16"
+				(pin passive line (at -8.89 -8.89 0) (length 2.54)
+					(name "16"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2632,8 +1812,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -5.08 180) (length 3.81)
-					(name "Pin_17"
+				(pin passive line (at -8.89 -11.43 0) (length 2.54)
+					(name "17"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2648,8 +1828,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 -2.54 180) (length 3.81)
-					(name "Pin_18"
+				(pin passive line (at -8.89 -13.97 0) (length 2.54)
+					(name "18"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2664,8 +1844,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 0 180) (length 3.81)
-					(name "Pin_19"
+				(pin passive line (at -8.89 -16.51 0) (length 2.54)
+					(name "19"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2680,8 +1860,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 2.54 180) (length 3.81)
-					(name "Pin_20"
+				(pin passive line (at -8.89 -19.05 0) (length 2.54)
+					(name "20"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2696,8 +1876,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 5.08 180) (length 3.81)
-					(name "Pin_21"
+				(pin passive line (at -8.89 -21.59 0) (length 2.54)
+					(name "21"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2712,8 +1892,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 7.62 180) (length 3.81)
-					(name "Pin_22"
+				(pin passive line (at -8.89 -24.13 0) (length 2.54)
+					(name "22"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2728,8 +1908,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 10.16 180) (length 3.81)
-					(name "Pin_23"
+				(pin passive line (at -8.89 -26.67 0) (length 2.54)
+					(name "23"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2744,8 +1924,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 12.7 180) (length 3.81)
-					(name "Pin_24"
+				(pin passive line (at -8.89 -29.21 0) (length 2.54)
+					(name "24"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2760,742 +1940,8 @@
 						)
 					)
 				)
-			)
-			(embedded_fonts no)
-		)
-		(symbol "Connector_Generic:Conn_02x16_Counter_Clockwise"
-			(pin_names (offset 1.016) (hide yes))
-			(exclude_from_sim no)
-			(in_bom yes)
-			(on_board yes)
-			(in_pos_files yes)
-			(duplicate_pin_numbers_are_jumpers no)
-			(property "Reference" "J"
-				(at 1.27 20.32 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "Value" "Conn_02x16_Counter_Clockwise"
-				(at 1.27 -22.86 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "Footprint" ""
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "Datasheet" ""
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "Description" "Generic connector, double row, 02x16, counter clockwise pin numbering scheme (similar to DIP package numbering), script generated (kicad-library-utils/schlib/autogen/connector/)"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "ki_keywords" "connector"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "ki_fp_filters" "Connector*:*_2x??_*"
-				(at 0 0 0)
-				(show_name no)
-				(do_not_autoplace no)
-				(hide yes)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(symbol "Conn_02x16_Counter_Clockwise_1_1"
-				(rectangle (start -1.27 19.05) (end 3.81 -21.59)
-					(stroke
-						(width 0.254)
-						(type default)
-					)
-					(fill (type background)
-					)
-				)
-				(rectangle (start -1.27 17.907) (end 0 17.653)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 15.367) (end 0 15.113)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 12.827) (end 0 12.573)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 10.287) (end 0 10.033)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 7.747) (end 0 7.493)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 5.207) (end 0 4.953)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 2.667) (end 0 2.413)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 0.127) (end 0 -0.127)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -2.413) (end 0 -2.667)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -4.953) (end 0 -5.207)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -7.493) (end 0 -7.747)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -10.033) (end 0 -10.287)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -12.573) (end 0 -12.827)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -15.113) (end 0 -15.367)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -17.653) (end 0 -17.907)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start -1.27 -20.193) (end 0 -20.447)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 17.907) (end 2.54 17.653)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 15.367) (end 2.54 15.113)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 12.827) (end 2.54 12.573)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 10.287) (end 2.54 10.033)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 7.747) (end 2.54 7.493)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 5.207) (end 2.54 4.953)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 2.667) (end 2.54 2.413)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 0.127) (end 2.54 -0.127)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -2.413) (end 2.54 -2.667)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -4.953) (end 2.54 -5.207)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -7.493) (end 2.54 -7.747)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -10.033) (end 2.54 -10.287)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -12.573) (end 2.54 -12.827)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -15.113) (end 2.54 -15.367)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -17.653) (end 2.54 -17.907)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(rectangle (start 3.81 -20.193) (end 2.54 -20.447)
-					(stroke
-						(width 0.1524)
-						(type default)
-					)
-					(fill (type none)
-					)
-				)
-				(pin passive line (at -5.08 17.78 0) (length 3.81)
-					(name "Pin_1"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "1"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at -5.08 15.24 0) (length 3.81)
-					(name "Pin_2"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "2"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at -5.08 12.7 0) (length 3.81)
-					(name "Pin_3"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "3"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at -5.08 10.16 0) (length 3.81)
-					(name "Pin_4"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "4"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at -5.08 7.62 0) (length 3.81)
-					(name "Pin_5"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "5"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at -5.08 5.08 0) (length 3.81)
-					(name "Pin_6"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "6"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at -5.08 2.54 0) (length 3.81)
-					(name "Pin_7"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "7"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at -5.08 0 0) (length 3.81)
-					(name "Pin_8"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "8"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at -5.08 -2.54 0) (length 3.81)
-					(name "Pin_9"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "9"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at -5.08 -5.08 0) (length 3.81)
-					(name "Pin_10"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "10"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at -5.08 -7.62 0) (length 3.81)
-					(name "Pin_11"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "11"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at -5.08 -10.16 0) (length 3.81)
-					(name "Pin_12"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "12"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at -5.08 -12.7 0) (length 3.81)
-					(name "Pin_13"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "13"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at -5.08 -15.24 0) (length 3.81)
-					(name "Pin_14"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "14"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at -5.08 -17.78 0) (length 3.81)
-					(name "Pin_15"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "15"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at -5.08 -20.32 0) (length 3.81)
-					(name "Pin_16"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "16"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at 7.62 -20.32 180) (length 3.81)
-					(name "Pin_17"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "17"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at 7.62 -17.78 180) (length 3.81)
-					(name "Pin_18"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "18"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at 7.62 -15.24 180) (length 3.81)
-					(name "Pin_19"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "19"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at 7.62 -12.7 180) (length 3.81)
-					(name "Pin_20"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "20"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at 7.62 -10.16 180) (length 3.81)
-					(name "Pin_21"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "21"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at 7.62 -7.62 180) (length 3.81)
-					(name "Pin_22"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "22"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at 7.62 -5.08 180) (length 3.81)
-					(name "Pin_23"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "23"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at 7.62 -2.54 180) (length 3.81)
-					(name "Pin_24"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "24"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line (at 7.62 0 180) (length 3.81)
-					(name "Pin_25"
+				(pin passive line (at 8.89 29.21 180) (length 2.54)
+					(name "25"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -3510,8 +1956,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 2.54 180) (length 3.81)
-					(name "Pin_26"
+				(pin passive line (at 8.89 26.67 180) (length 2.54)
+					(name "26"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -3526,8 +1972,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 5.08 180) (length 3.81)
-					(name "Pin_27"
+				(pin passive line (at 8.89 24.13 180) (length 2.54)
+					(name "27"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -3542,8 +1988,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 7.62 180) (length 3.81)
-					(name "Pin_28"
+				(pin passive line (at 8.89 21.59 180) (length 2.54)
+					(name "28"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -3558,8 +2004,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 10.16 180) (length 3.81)
-					(name "Pin_29"
+				(pin passive line (at 8.89 19.05 180) (length 2.54)
+					(name "29"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -3574,8 +2020,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 12.7 180) (length 3.81)
-					(name "Pin_30"
+				(pin passive line (at 8.89 16.51 180) (length 2.54)
+					(name "30"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -3590,8 +2036,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 15.24 180) (length 3.81)
-					(name "Pin_31"
+				(pin passive line (at 8.89 13.97 180) (length 2.54)
+					(name "31"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -3606,8 +2052,8 @@
 						)
 					)
 				)
-				(pin passive line (at 7.62 17.78 180) (length 3.81)
-					(name "Pin_32"
+				(pin passive line (at 8.89 11.43 180) (length 2.54)
+					(name "32"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -3622,8 +2068,2406 @@
 						)
 					)
 				)
+				(pin passive line (at 8.89 8.89 180) (length 2.54)
+					(name "33"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "33"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 6.35 180) (length 2.54)
+					(name "34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 3.81 180) (length 2.54)
+					(name "35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 1.27 180) (length 2.54)
+					(name "36"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "36"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -1.27 180) (length 2.54)
+					(name "37"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "37"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -3.81 180) (length 2.54)
+					(name "38"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "38"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -6.35 180) (length 2.54)
+					(name "39"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "39"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -8.89 180) (length 2.54)
+					(name "40"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "40"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -11.43 180) (length 2.54)
+					(name "41"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "41"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -13.97 180) (length 2.54)
+					(name "42"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "42"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -16.51 180) (length 2.54)
+					(name "43"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "43"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -19.05 180) (length 2.54)
+					(name "44"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "44"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -21.59 180) (length 2.54)
+					(name "45"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "45"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -24.13 180) (length 2.54)
+					(name "46"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "46"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -26.67 180) (length 2.54)
+					(name "47"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "47"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -29.21 180) (length 2.54)
+					(name "48"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "48"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
 			)
-			(embedded_fonts no)
+		)
+		(symbol "matchgroup_lvs:QFN24_MIPI"
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "U"
+				(at 0 17.78 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "QFN24_MIPI"
+				(at 0 -17.78 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "Package_DFN_QFN:QFN-24-1EP_4x4mm_P0.5mm"
+				(at 0 -20.32 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 -22.86 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" ""
+				(at 0 -25.40 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "QFN24_MIPI_0_1"
+				(rectangle (start -6.35 15.24) (end 6.35 -15.24)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill (type background)
+					)
+				)
+			)
+			(symbol "QFN24_MIPI_1_1"
+				(pin passive line (at -8.89 13.97 0) (length 2.54)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 11.43 0) (length 2.54)
+					(name "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 8.89 0) (length 2.54)
+					(name "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 6.35 0) (length 2.54)
+					(name "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 3.81 0) (length 2.54)
+					(name "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 1.27 0) (length 2.54)
+					(name "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -1.27 0) (length 2.54)
+					(name "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -3.81 0) (length 2.54)
+					(name "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -6.35 0) (length 2.54)
+					(name "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -8.89 0) (length 2.54)
+					(name "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -11.43 0) (length 2.54)
+					(name "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -13.97 0) (length 2.54)
+					(name "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 13.97 180) (length 2.54)
+					(name "13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 11.43 180) (length 2.54)
+					(name "14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 8.89 180) (length 2.54)
+					(name "15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 6.35 180) (length 2.54)
+					(name "16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 3.81 180) (length 2.54)
+					(name "17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 1.27 180) (length 2.54)
+					(name "18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -1.27 180) (length 2.54)
+					(name "19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -3.81 180) (length 2.54)
+					(name "20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -6.35 180) (length 2.54)
+					(name "21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -8.89 180) (length 2.54)
+					(name "22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -11.43 180) (length 2.54)
+					(name "23"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "23"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -13.97 180) (length 2.54)
+					(name "24"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "24"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+		(symbol "matchgroup_lvs:BGA49_HDMI"
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "U"
+				(at 0 34.29 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "BGA49_HDMI"
+				(at 0 -34.29 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "Package_BGA:BGA-49_5.0x5.0mm_Layout7x7_P0.5mm"
+				(at 0 -36.83 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 -39.37 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" ""
+				(at 0 -41.91 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "BGA49_HDMI_0_1"
+				(rectangle (start -6.35 31.75) (end 6.35 -31.75)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill (type background)
+					)
+				)
+			)
+			(symbol "BGA49_HDMI_1_1"
+				(pin passive line (at -8.89 30.48 0) (length 2.54)
+					(name "A1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 27.94 0) (length 2.54)
+					(name "A2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 25.40 0) (length 2.54)
+					(name "A3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 22.86 0) (length 2.54)
+					(name "A4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 20.32 0) (length 2.54)
+					(name "A5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 17.78 0) (length 2.54)
+					(name "A6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 15.24 0) (length 2.54)
+					(name "A7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 12.70 0) (length 2.54)
+					(name "B1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 10.16 0) (length 2.54)
+					(name "B2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 7.62 0) (length 2.54)
+					(name "B3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 5.08 0) (length 2.54)
+					(name "B4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 2.54 0) (length 2.54)
+					(name "B5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 0.00 0) (length 2.54)
+					(name "B6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -2.54 0) (length 2.54)
+					(name "B7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -5.08 0) (length 2.54)
+					(name "C1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -7.62 0) (length 2.54)
+					(name "C2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -10.16 0) (length 2.54)
+					(name "C3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -12.70 0) (length 2.54)
+					(name "C4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -15.24 0) (length 2.54)
+					(name "C5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -17.78 0) (length 2.54)
+					(name "C6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -20.32 0) (length 2.54)
+					(name "C7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -22.86 0) (length 2.54)
+					(name "D1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -25.40 0) (length 2.54)
+					(name "D2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -27.94 0) (length 2.54)
+					(name "D3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -30.48 0) (length 2.54)
+					(name "D4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 30.48 180) (length 2.54)
+					(name "D5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 27.94 180) (length 2.54)
+					(name "D6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 25.40 180) (length 2.54)
+					(name "D7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 22.86 180) (length 2.54)
+					(name "E1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 20.32 180) (length 2.54)
+					(name "E2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 17.78 180) (length 2.54)
+					(name "E3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 15.24 180) (length 2.54)
+					(name "E4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 12.70 180) (length 2.54)
+					(name "E5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 10.16 180) (length 2.54)
+					(name "E6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 7.62 180) (length 2.54)
+					(name "E7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 5.08 180) (length 2.54)
+					(name "F1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 2.54 180) (length 2.54)
+					(name "F2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 0.00 180) (length 2.54)
+					(name "F3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -2.54 180) (length 2.54)
+					(name "F4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -5.08 180) (length 2.54)
+					(name "F5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -7.62 180) (length 2.54)
+					(name "F6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -10.16 180) (length 2.54)
+					(name "F7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -12.70 180) (length 2.54)
+					(name "G1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -15.24 180) (length 2.54)
+					(name "G2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -17.78 180) (length 2.54)
+					(name "G3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -20.32 180) (length 2.54)
+					(name "G4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -22.86 180) (length 2.54)
+					(name "G5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -25.40 180) (length 2.54)
+					(name "G6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -27.94 180) (length 2.54)
+					(name "G7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+		(symbol "matchgroup_lvs:QFP48_SRAM"
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "U"
+				(at 0 33.02 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "QFP48_SRAM"
+				(at 0 -33.02 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "Package_QFP:LQFP-48_7x7mm_P0.5mm"
+				(at 0 -35.56 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 -38.10 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" ""
+				(at 0 -40.64 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "QFP48_SRAM_0_1"
+				(rectangle (start -6.35 30.48) (end 6.35 -30.48)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill (type background)
+					)
+				)
+			)
+			(symbol "QFP48_SRAM_1_1"
+				(pin passive line (at -8.89 29.21 0) (length 2.54)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 26.67 0) (length 2.54)
+					(name "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 24.13 0) (length 2.54)
+					(name "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 21.59 0) (length 2.54)
+					(name "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 19.05 0) (length 2.54)
+					(name "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 16.51 0) (length 2.54)
+					(name "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 13.97 0) (length 2.54)
+					(name "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 11.43 0) (length 2.54)
+					(name "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 8.89 0) (length 2.54)
+					(name "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 6.35 0) (length 2.54)
+					(name "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 3.81 0) (length 2.54)
+					(name "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 1.27 0) (length 2.54)
+					(name "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -1.27 0) (length 2.54)
+					(name "13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -3.81 0) (length 2.54)
+					(name "14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -6.35 0) (length 2.54)
+					(name "15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -8.89 0) (length 2.54)
+					(name "16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -11.43 0) (length 2.54)
+					(name "17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -13.97 0) (length 2.54)
+					(name "18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -16.51 0) (length 2.54)
+					(name "19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -19.05 0) (length 2.54)
+					(name "20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -21.59 0) (length 2.54)
+					(name "21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -24.13 0) (length 2.54)
+					(name "22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -26.67 0) (length 2.54)
+					(name "23"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "23"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at -8.89 -29.21 0) (length 2.54)
+					(name "24"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "24"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 29.21 180) (length 2.54)
+					(name "25"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "25"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 26.67 180) (length 2.54)
+					(name "26"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "26"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 24.13 180) (length 2.54)
+					(name "27"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "27"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 21.59 180) (length 2.54)
+					(name "28"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "28"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 19.05 180) (length 2.54)
+					(name "29"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "29"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 16.51 180) (length 2.54)
+					(name "30"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "30"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 13.97 180) (length 2.54)
+					(name "31"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "31"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 11.43 180) (length 2.54)
+					(name "32"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "32"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 8.89 180) (length 2.54)
+					(name "33"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "33"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 6.35 180) (length 2.54)
+					(name "34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 3.81 180) (length 2.54)
+					(name "35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 1.27 180) (length 2.54)
+					(name "36"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "36"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -1.27 180) (length 2.54)
+					(name "37"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "37"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -3.81 180) (length 2.54)
+					(name "38"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "38"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -6.35 180) (length 2.54)
+					(name "39"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "39"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -8.89 180) (length 2.54)
+					(name "40"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "40"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -11.43 180) (length 2.54)
+					(name "41"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "41"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -13.97 180) (length 2.54)
+					(name "42"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "42"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -16.51 180) (length 2.54)
+					(name "43"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "43"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -19.05 180) (length 2.54)
+					(name "44"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "44"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -21.59 180) (length 2.54)
+					(name "45"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "45"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -24.13 180) (length 2.54)
+					(name "46"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "46"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -26.67 180) (length 2.54)
+					(name "47"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "47"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line (at 8.89 -29.21 180) (length 2.54)
+					(name "48"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "48"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
 		)
 		(symbol "power:PWR_FLAG"
 			(power global)
@@ -3733,14 +4577,14 @@
 		)
 	)
 	(symbol
-		(lib_id "Connector_Generic:Conn_02x24_Counter_Clockwise")
+		(lib_id "matchgroup_lvs:QFN48_DDR_CTRL")
 		(at 50.8 50.8 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "5a4b0ef7-d806-4e8b-bcd4-a2a471cebafb")
+		(uuid "fb2f5400-2f28-44d5-9bee-5a22d160232b")
 		(property "Reference" "U1"
 			(at 50.8 45.72 0)
 			(effects
@@ -3775,120 +4619,120 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "f44e96fc-6f68-43d2-ac67-5dd86c68c9f7")
+		(pin "1" (uuid "bfb7ddb7-c776-463d-b7d6-344a155fd79e")
 		)
-		(pin "2" (uuid "ecf7fd8a-8449-4f12-8cbf-539b84b8b24c")
+		(pin "2" (uuid "3589a91d-60f2-464e-9b19-a38c5af88fb0")
 		)
-		(pin "3" (uuid "4363aca6-946a-4b3c-a249-33219d190e19")
+		(pin "3" (uuid "73898e0e-bb07-424a-8cc4-e2a649e2ba4f")
 		)
-		(pin "4" (uuid "f780aa43-652d-41e0-b141-b32c229b6641")
+		(pin "4" (uuid "7d89dbc0-d850-446e-87ca-9ea687311d60")
 		)
-		(pin "5" (uuid "f7218324-edfb-4322-aa91-ef93805e5786")
+		(pin "5" (uuid "f3f9243a-e32f-48b7-96b5-033b7cfbac69")
 		)
-		(pin "6" (uuid "a1a2f2dc-749b-4c9c-9090-d3117c8a0d93")
+		(pin "6" (uuid "6a3695d4-5aaa-457f-8567-691a86b23ab4")
 		)
-		(pin "7" (uuid "56ab1861-9960-4b2e-be4c-ffa6fec54ebe")
+		(pin "7" (uuid "e130ddbd-9b78-46e2-b152-b1442b2760ef")
 		)
-		(pin "8" (uuid "b1eff1a4-53ba-4555-8e26-be00428f86f6")
+		(pin "8" (uuid "65becea8-61ed-4d68-a490-2b7fbd126531")
 		)
-		(pin "9" (uuid "a0cc4156-63b4-4592-a282-ea7ea6fb74ad")
+		(pin "9" (uuid "54c897a0-8ed2-40b5-a469-5b0282061d53")
 		)
-		(pin "10" (uuid "2e194518-0acf-4ce2-9c7b-e4d65f132185")
+		(pin "10" (uuid "3f24b649-b68c-421c-a7e4-bc060b2a72c3")
 		)
-		(pin "11" (uuid "8b31c623-0f94-4454-bf0a-d0d45cecb3a8")
+		(pin "11" (uuid "dababfe2-d13b-40dd-b8be-bf7b5b451c10")
 		)
-		(pin "12" (uuid "4541c5fe-9233-4718-b027-35ea24886d4a")
+		(pin "12" (uuid "09214708-87ae-4f50-80f7-1576128bd9e1")
 		)
-		(pin "13" (uuid "58772443-b335-4408-b15e-ab015ef35f50")
+		(pin "13" (uuid "1ea94c72-3829-464e-9393-e298fbe34c92")
 		)
-		(pin "14" (uuid "3681a28e-aea2-4cd6-a130-eb8cdaa8d3a2")
+		(pin "14" (uuid "fd685ae7-045d-4af0-ad25-b95a674c8742")
 		)
-		(pin "15" (uuid "03cb9dc7-2271-4629-9122-cab76c7d47fc")
+		(pin "15" (uuid "d5707c00-8988-41bb-9553-e68bc796e765")
 		)
-		(pin "16" (uuid "c1988226-6453-4ab6-964a-dfc89214a92d")
+		(pin "16" (uuid "f9371136-5573-405c-8fcb-0cffc0b49d8d")
 		)
-		(pin "17" (uuid "e243f52a-051c-46fb-9974-d2e7cfc489bf")
+		(pin "17" (uuid "347034cc-ad27-4d9d-b675-03753e0116ae")
 		)
-		(pin "18" (uuid "d6cbea37-e535-400b-9728-d7f7e606c257")
+		(pin "18" (uuid "426e0be9-51d4-4baa-ac1e-441a7d3143f7")
 		)
-		(pin "19" (uuid "730c8cff-5323-4d5a-bd05-d0c7786c1717")
+		(pin "19" (uuid "9a111689-9b69-42ca-a701-f80be1e2bc64")
 		)
-		(pin "20" (uuid "afbfe230-7e05-4028-b975-817d0ba59a9e")
+		(pin "20" (uuid "ef61daa4-e47f-42da-aec9-2433a78daa9c")
 		)
-		(pin "21" (uuid "6388d700-7d08-4b0d-8d3a-b678871c547f")
+		(pin "21" (uuid "770b1d97-29d7-4619-9991-07f57aeba3d0")
 		)
-		(pin "22" (uuid "318dbfc1-7f37-4862-a63a-2dfb11703ace")
+		(pin "22" (uuid "a5fdc1f0-42a5-4d88-8bdc-6618b42c5676")
 		)
-		(pin "23" (uuid "c262f922-d8e0-4297-93a0-6aded285cc4b")
+		(pin "23" (uuid "575d4f7f-2ff4-4bc2-b32e-ec86dc1ad958")
 		)
-		(pin "24" (uuid "553cf834-e067-464d-97ca-e2a0de979bd9")
+		(pin "24" (uuid "189ecf39-4468-4cd3-8557-41a0de8a25ab")
 		)
-		(pin "25" (uuid "c0992280-a31a-466d-a8c0-2767b439442a")
+		(pin "25" (uuid "8c4ebedd-c10a-48e8-ae9a-76d8d1649e9b")
 		)
-		(pin "26" (uuid "6f8ad46e-4470-483a-a61b-c8795ca3f915")
+		(pin "26" (uuid "58b5ff56-0eac-4bf0-a419-d344e6c60757")
 		)
-		(pin "27" (uuid "6475a4f0-afdd-456f-a203-ce9e06c88eb8")
+		(pin "27" (uuid "de1d59b7-729f-4d97-b64b-c0f27da8dca2")
 		)
-		(pin "28" (uuid "af1ac81e-8e5c-4c03-8614-54b747b898c9")
+		(pin "28" (uuid "f145d96e-c111-4ae4-b2f5-95b5904ea027")
 		)
-		(pin "29" (uuid "b5b524dd-4f92-4c7c-9dcb-94206efc68c9")
+		(pin "29" (uuid "97f1a26f-35be-4960-ab6d-bf5f5d91135c")
 		)
-		(pin "30" (uuid "10cb1509-1a9a-4030-be89-565b6b3ce361")
+		(pin "30" (uuid "17b7cfce-19a9-4f79-8dd3-f74c70e3f197")
 		)
-		(pin "31" (uuid "39ddb36e-1eda-4fc0-bfcb-1213c8b75795")
+		(pin "31" (uuid "ea8952e9-3f58-40c0-ae50-af75da1934ad")
 		)
-		(pin "32" (uuid "3cb2eca1-0a43-4dea-92f2-43c5ffa87823")
+		(pin "32" (uuid "d0c1e492-6567-44c2-b71d-63a7c086d1b7")
 		)
-		(pin "33" (uuid "9a226993-7dc4-4e17-8cdc-2bfb14a33f8e")
+		(pin "33" (uuid "6733d813-29cd-4b6c-b3f0-be5c4a977748")
 		)
-		(pin "34" (uuid "d0b85a45-0c33-420f-87e6-2100a85be46f")
+		(pin "34" (uuid "f6dae1e1-7cf0-434c-9a28-eed55e423514")
 		)
-		(pin "35" (uuid "e6d2dbcb-aebf-41c3-81ca-dfc8acb611e5")
+		(pin "35" (uuid "f57b8b69-c42d-478f-9273-40f46a13ee3f")
 		)
-		(pin "36" (uuid "525939e0-0e1b-4652-8c13-3a763061e7fe")
+		(pin "36" (uuid "587edba7-b519-44c8-8be2-a163714a9480")
 		)
-		(pin "37" (uuid "b8d6dbe9-363d-4bad-bdbf-90316cc5fffd")
+		(pin "37" (uuid "c53b7003-731a-4df8-8cd5-448c71f9ee59")
 		)
-		(pin "38" (uuid "dfc6e899-4de2-47db-8fbb-5ce7b1b19cba")
+		(pin "38" (uuid "b47ebbea-1df5-4b7d-bdfb-e8a81dd3f778")
 		)
-		(pin "39" (uuid "281023a1-b8f3-4819-b054-d72f5a52e268")
+		(pin "39" (uuid "6d931778-ce73-4c4a-92cf-6323698528f1")
 		)
-		(pin "40" (uuid "cbe0d166-b16d-4404-bb13-042d8d7fe83d")
+		(pin "40" (uuid "6dfc926b-6a3a-4e88-a69d-487fb257b6ca")
 		)
-		(pin "41" (uuid "8596545d-ce43-4695-8a5f-b7737c44795a")
+		(pin "41" (uuid "5fa6a89a-880d-4eb0-a2cc-c285c1cdea66")
 		)
-		(pin "42" (uuid "d99de0e6-4de1-4cf3-b339-3c2ed18938ed")
+		(pin "42" (uuid "0ddb2aef-f2a1-44f9-b9db-3620b714053e")
 		)
-		(pin "43" (uuid "a342b30b-f523-4bec-a3c5-62295a682b6f")
+		(pin "43" (uuid "f09f1fcb-b4b2-4fc9-8ddc-3c217a6f968c")
 		)
-		(pin "44" (uuid "f387e2f4-4941-4774-b013-dc75e9a08722")
+		(pin "44" (uuid "252d3f9b-ebab-43ce-9fa4-dd00d2dea930")
 		)
-		(pin "45" (uuid "e0f5cdd8-116e-4fd4-a318-8fc8a4db1d5a")
+		(pin "45" (uuid "707819f8-17be-4ef1-b9b3-c79ef64619bf")
 		)
-		(pin "46" (uuid "01398c17-f857-4e8d-abb2-41cce3eca0f5")
+		(pin "46" (uuid "4f80c8b4-d5a9-4328-a2e3-76475afaba5f")
 		)
-		(pin "47" (uuid "9853b2d8-4a23-4c4f-9ae2-0894e7e6b625")
+		(pin "47" (uuid "1cd2bbb0-ae35-4636-b437-d20ac3a5eec3")
 		)
-		(pin "48" (uuid "05a7deca-c363-4c33-899d-9af56b1126af")
+		(pin "48" (uuid "3ee0f359-9b6e-4335-a2cc-fba0852fc059")
 		)
 		(instances
 			(project "project"
-				(path "/0d315cf6-faeb-4774-88b8-21b8269a7e13" (reference "U1") (unit 1)
+				(path "/5b6ec878-611a-4148-afea-b98afc10dc0a" (reference "U1") (unit 1)
 				)
 			)
 		)
 	)
 	(symbol
-		(lib_id "Connector_Generic:Conn_01x06")
-		(at 50.8 124.46 0)
+		(lib_id "matchgroup_lvs:FFC6_MIPI_SRC")
+		(at 50.8 101.6 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "05bd4898-9486-4e6c-b561-de9f84be5898")
+		(uuid "0359b8f7-53ae-41a7-a85c-e4326ed19a0d")
 		(property "Reference" "J1"
-			(at 50.8 119.38 0)
+			(at 50.8 96.52 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3896,7 +4740,7 @@
 			)
 		)
 		(property "Value" "FFC6_MIPI"
-			(at 50.8 121.92 0)
+			(at 50.8 99.06 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3904,7 +4748,7 @@
 			)
 		)
 		(property "Footprint" "Connector_FFC:FFC_6P_1.0mm"
-			(at 50.8 124.46 0)
+			(at 50.8 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3913,7 +4757,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 50.8 124.46 0)
+			(at 50.8 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3921,36 +4765,40 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "aad962f0-cc77-4a83-9a9c-fde7592d00c5")
+		(pin "1" (uuid "5b85701f-0a9e-4408-ab86-bc8eddf85625")
 		)
-		(pin "2" (uuid "83f09b52-c1a7-4ccb-99a6-8920cc025404")
+		(pin "2" (uuid "a82a1ff3-8cd9-4e1b-a446-17ff1ee2b506")
 		)
-		(pin "3" (uuid "2aca23aa-5853-461c-b24c-726868f4ddf5")
+		(pin "3" (uuid "690e8ca2-2455-4673-950d-17800faa58d5")
 		)
-		(pin "4" (uuid "881536d8-ba7b-455a-830b-3f68ec70a009")
+		(pin "4" (uuid "73b03db6-bade-4ac8-a430-f60ad8337255")
 		)
-		(pin "5" (uuid "5075d4d6-4e16-4390-8dce-cd0b45b69c1f")
+		(pin "5" (uuid "2033ffc6-8b7b-4abf-ae08-053927bbf33d")
 		)
-		(pin "6" (uuid "ef8b57ce-883b-4db6-b0fa-5b1dccf412c3")
+		(pin "6" (uuid "7c6f1a66-2534-4a85-ad99-0350e2c1cede")
+		)
+		(pin "M1" (uuid "aee71659-8991-4f01-a6a9-c001730d67ac")
+		)
+		(pin "M2" (uuid "40a175ff-8a9a-43f2-89a2-372ae472572b")
 		)
 		(instances
 			(project "project"
-				(path "/0d315cf6-faeb-4774-88b8-21b8269a7e13" (reference "J1") (unit 1)
+				(path "/5b6ec878-611a-4148-afea-b98afc10dc0a" (reference "J1") (unit 1)
 				)
 			)
 		)
 	)
 	(symbol
-		(lib_id "Connector_Generic:Conn_01x08")
-		(at 50.8 170.18 0)
+		(lib_id "matchgroup_lvs:HDMI_SRC")
+		(at 50.8 127 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "9ddc25ab-7dd8-4db1-af6a-9526a1c13060")
+		(uuid "194cdd57-8d54-472d-8a06-7f006234867d")
 		(property "Reference" "J2"
-			(at 50.8 165.1 0)
+			(at 50.8 121.92 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3958,7 +4806,7 @@
 			)
 		)
 		(property "Value" "HDMI19"
-			(at 50.8 167.64 0)
+			(at 50.8 124.46 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3966,7 +4814,7 @@
 			)
 		)
 		(property "Footprint" "Connector_Video:HDMI_A_Receptacle"
-			(at 50.8 170.18 0)
+			(at 50.8 127 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3975,7 +4823,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 50.8 170.18 0)
+			(at 50.8 127 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3983,40 +4831,44 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "956be60a-97bd-4f72-9f1e-4e3aae8da1a5")
+		(pin "1" (uuid "d7569d16-1371-4f7a-a9c7-1aec87809593")
 		)
-		(pin "2" (uuid "62fffdd0-7007-4704-90ee-6e0b339fec13")
+		(pin "2" (uuid "5b288344-e533-48f5-b4d7-bde02afe5826")
 		)
-		(pin "3" (uuid "a401bf21-b380-4202-8405-cc46746794e3")
+		(pin "3" (uuid "73bf498d-e1c1-40a1-9d45-728136f0c7a3")
 		)
-		(pin "4" (uuid "3c3d5914-7826-4466-9570-5c4ccb2381d0")
+		(pin "4" (uuid "8049ecec-a0f0-4d65-838d-9f514461189a")
 		)
-		(pin "5" (uuid "43a5e390-07cb-41ee-9119-64f3701ccef7")
+		(pin "5" (uuid "a509cbdf-a454-46be-a6ab-8d6aa00ba4f7")
 		)
-		(pin "6" (uuid "d59187b8-3112-4054-8285-a0e90ed0fb97")
+		(pin "6" (uuid "05f19595-a32f-4093-ba3b-099255ac98c1")
 		)
-		(pin "7" (uuid "93017343-2f73-44dd-8a7d-c7f5527b7166")
+		(pin "7" (uuid "0bb6b817-f6bd-4c0c-8d3b-587b6cfe6d64")
 		)
-		(pin "8" (uuid "b6c44b0f-2061-4894-ab62-62facb22b120")
+		(pin "8" (uuid "6fd1e3bd-8452-4746-b76d-3c73903e58df")
+		)
+		(pin "S1" (uuid "f0a3a629-c556-4d77-9522-5c44ffca53d6")
+		)
+		(pin "S2" (uuid "86ab2a2d-cb9f-4c71-b9d5-50156f8f2673")
 		)
 		(instances
 			(project "project"
-				(path "/0d315cf6-faeb-4774-88b8-21b8269a7e13" (reference "J2") (unit 1)
+				(path "/5b6ec878-611a-4148-afea-b98afc10dc0a" (reference "J2") (unit 1)
 				)
 			)
 		)
 	)
 	(symbol
-		(lib_id "Connector_Generic:Conn_01x09")
-		(at 50.8 215.9 0)
+		(lib_id "matchgroup_lvs:ADDR_HDR_SRC")
+		(at 50.8 152.4 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "a6de1da9-b252-486e-88e7-03318607a266")
+		(uuid "7d5aeec3-ce07-4315-94cc-8df8da137098")
 		(property "Reference" "J3"
-			(at 50.8 210.82 0)
+			(at 50.8 147.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4024,7 +4876,7 @@
 			)
 		)
 		(property "Value" "ADDR_HDR"
-			(at 50.8 213.36 0)
+			(at 50.8 149.86 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4032,7 +4884,7 @@
 			)
 		)
 		(property "Footprint" "Connector_PinHeader_2.54mm:PinHeader_1x09_P2.54mm_Vertical"
-			(at 50.8 215.9 0)
+			(at 50.8 152.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4041,7 +4893,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 50.8 215.9 0)
+			(at 50.8 152.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4049,42 +4901,42 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "da921e35-3aaf-4aa4-98f8-5b4a4993ee66")
+		(pin "1" (uuid "16dff94e-6ee9-4159-8b9d-bcded396e345")
 		)
-		(pin "2" (uuid "4ccbd706-281d-4453-b720-4891abd6e2d1")
+		(pin "2" (uuid "48accdf6-b652-4e6b-b8de-2ae3822e9a10")
 		)
-		(pin "3" (uuid "36d1ac80-3c38-4887-9fdc-cc9022c1e924")
+		(pin "3" (uuid "accbc281-71b1-4514-b3d6-4aa4a11b63f1")
 		)
-		(pin "4" (uuid "6321ebf0-9571-4a8a-af98-91beb8da365e")
+		(pin "4" (uuid "4029c89f-f64d-4314-88da-70f28bb8ac4f")
 		)
-		(pin "5" (uuid "367e3448-724e-401f-b6b2-b6cd6ceb3219")
+		(pin "5" (uuid "3fdc1b7c-f1cc-48a7-9193-827d260c99c0")
 		)
-		(pin "6" (uuid "210da72e-fe62-4fdc-b159-1c988b8940e6")
+		(pin "6" (uuid "503ab2df-12aa-40ec-878f-abb11a30f6bd")
 		)
-		(pin "7" (uuid "4172d848-e7ba-488f-a6a5-f950428feeb9")
+		(pin "7" (uuid "192fb6cd-a43e-4076-8b35-8757e14aca5c")
 		)
-		(pin "8" (uuid "bf80fe89-c27e-4777-9044-40ef1eb5629a")
+		(pin "8" (uuid "8b8f9d2b-cf0e-42c9-969c-b75c6f760108")
 		)
-		(pin "9" (uuid "cd848969-0d40-41cb-b28f-b00a5a14c2b1")
+		(pin "9" (uuid "53e471ba-b4ac-4cff-b4d4-e3029db73b57")
 		)
 		(instances
 			(project "project"
-				(path "/0d315cf6-faeb-4774-88b8-21b8269a7e13" (reference "J3") (unit 1)
+				(path "/5b6ec878-611a-4148-afea-b98afc10dc0a" (reference "J3") (unit 1)
 				)
 			)
 		)
 	)
 	(symbol
-		(lib_id "Connector_Generic:Conn_02x24_Counter_Clockwise")
-		(at 152.4 50.8 0)
+		(lib_id "matchgroup_lvs:QFN48_DRAM")
+		(at 177.8 50.8 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "c0d8b2bc-5d3f-4155-ab79-45fde805f4dd")
+		(uuid "6cfdf52d-e4a7-4ed8-ad83-2a0f3d4d5e2b")
 		(property "Reference" "U2"
-			(at 152.4 45.72 0)
+			(at 177.8 45.72 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4092,7 +4944,7 @@
 			)
 		)
 		(property "Value" "QFN48_DRAM"
-			(at 152.4 48.26 0)
+			(at 177.8 48.26 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4100,7 +4952,7 @@
 			)
 		)
 		(property "Footprint" "Package_DFN_QFN:QFN-48-1EP_7x7mm_P0.5mm"
-			(at 152.4 50.8 0)
+			(at 177.8 50.8 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4109,7 +4961,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 152.4 50.8 0)
+			(at 177.8 50.8 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4117,120 +4969,120 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "8b3ae4e3-e058-4331-a9d1-a93f27a9f750")
+		(pin "1" (uuid "a4dea39d-0a69-49ab-bbe7-c6e6cf6f6eb3")
 		)
-		(pin "2" (uuid "7b84ba22-992b-4716-b8ea-3ce819f49425")
+		(pin "2" (uuid "28f911d7-8405-402b-939a-9f008ebd24dd")
 		)
-		(pin "3" (uuid "1379a81e-319d-47fa-b96e-23cc6f0b4863")
+		(pin "3" (uuid "94c870f2-8c2a-4f45-9070-7a71eaccbb4f")
 		)
-		(pin "4" (uuid "06f0d4ca-47bb-4729-a1e1-ac0257db9ac9")
+		(pin "4" (uuid "6d847d2f-fa51-4da4-85a5-17b0c820322a")
 		)
-		(pin "5" (uuid "83c4a4b4-62f2-47cc-8d8f-49e6143cb537")
+		(pin "5" (uuid "a912fbbd-83d0-4a2d-920e-cc7d48eace30")
 		)
-		(pin "6" (uuid "7e0f3191-dad2-4e19-98db-36e0af872977")
+		(pin "6" (uuid "c113c793-80dc-4c8f-8e22-d35287dfe540")
 		)
-		(pin "7" (uuid "c4dda0d5-2dbb-4c2e-a9e1-611c37b6064d")
+		(pin "7" (uuid "d08450ed-ec2c-4b67-83d8-563dd02c5dd9")
 		)
-		(pin "8" (uuid "ca78115f-1061-4e6b-a172-82ae617c55b8")
+		(pin "8" (uuid "a2c0d06e-fd83-4655-b21a-946b9816873d")
 		)
-		(pin "9" (uuid "b13120ce-d892-429e-a92d-60017b3660c7")
+		(pin "9" (uuid "77553dc2-b229-45aa-b177-a4303911cf52")
 		)
-		(pin "10" (uuid "3db1612a-1cae-453a-ac3b-1f445ccf5910")
+		(pin "10" (uuid "ab1ea73c-677c-40ac-8069-ebdddb9d3b54")
 		)
-		(pin "11" (uuid "37d8b2d0-fb51-4e20-b513-1d4f7ba02c99")
+		(pin "11" (uuid "de49b8e7-09f4-4d36-b8f3-1a4f8b237b5f")
 		)
-		(pin "12" (uuid "b9638f55-6525-4c0a-a88f-195e5dd7ef95")
+		(pin "12" (uuid "3be4e16a-3b2f-407e-8d5a-173426fa26d8")
 		)
-		(pin "13" (uuid "17d5aedf-7ab0-403f-ae02-e70b098f6b7b")
+		(pin "13" (uuid "cbd61a70-0e28-4376-b270-dc3122cef34a")
 		)
-		(pin "14" (uuid "ddad4f18-48bd-4998-bad5-25ce25653989")
+		(pin "14" (uuid "886cded5-9bba-4efb-9012-15ffa7b04c11")
 		)
-		(pin "15" (uuid "0ea76174-b8f0-45a7-b076-c90e343db923")
+		(pin "15" (uuid "d5896674-11d7-4771-a6e7-a368442a45cc")
 		)
-		(pin "16" (uuid "056f5cf2-7c81-4839-9445-0e36e9b04d0e")
+		(pin "16" (uuid "f86a7db7-70c1-49f1-828b-ccd79c36b803")
 		)
-		(pin "17" (uuid "244aefae-04ef-4710-98b9-be04de25c4ba")
+		(pin "17" (uuid "658ce4d8-7fc0-40ae-9daf-d32762ac9ec4")
 		)
-		(pin "18" (uuid "9b4d0129-5811-48f4-a6b1-33c3eea6bbf5")
+		(pin "18" (uuid "0ddf5364-4baf-4789-a75b-f787bc9e8291")
 		)
-		(pin "19" (uuid "4e7cdd9c-787e-4d7c-a9a2-37d4d7a12d89")
+		(pin "19" (uuid "f2fbf86a-7eaa-4535-9058-ab835462387e")
 		)
-		(pin "20" (uuid "f9965770-239c-4346-8fc0-dcc50a425107")
+		(pin "20" (uuid "3b818a8a-4e64-4cbc-83d7-b409b44106fe")
 		)
-		(pin "21" (uuid "93ca5e83-466f-4727-b75a-97eee2386a4a")
+		(pin "21" (uuid "fdf46f52-b4c5-496f-9b80-b778779ae4a3")
 		)
-		(pin "22" (uuid "96b47dc5-e804-4eaa-854a-7f59ed0be211")
+		(pin "22" (uuid "b9e122f9-cea8-4766-8dcd-7e64ac4bf092")
 		)
-		(pin "23" (uuid "a50d2b8f-2137-4d7c-b5fc-18f4d0081e88")
+		(pin "23" (uuid "9cc7a84b-9290-4007-925b-c7e505251fe1")
 		)
-		(pin "24" (uuid "7490d0c9-45c0-4b8f-915d-3ec0efa8ac79")
+		(pin "24" (uuid "03a421f1-fbeb-4a79-ade8-ccb3dd513a89")
 		)
-		(pin "25" (uuid "45b7466a-e93b-4f15-a919-46df92161bb1")
+		(pin "25" (uuid "5f608fb1-c77d-4a2b-9cf6-9752a577d8d8")
 		)
-		(pin "26" (uuid "27eb4ee2-e737-4c1d-9d95-6855486d05a8")
+		(pin "26" (uuid "055cda42-bd56-4d5c-aa50-786550172375")
 		)
-		(pin "27" (uuid "e4269f74-6562-4a51-83c6-c96d5d595777")
+		(pin "27" (uuid "d61848a5-d9e0-4bcf-826d-a0d2d02aa332")
 		)
-		(pin "28" (uuid "491f5e32-441c-4c8d-8b4d-f12e3ba35f3f")
+		(pin "28" (uuid "af34a1b3-8be6-4a59-b767-13e8e61294e8")
 		)
-		(pin "29" (uuid "b25c556f-92de-45a1-bcc1-b8e5d6ac654e")
+		(pin "29" (uuid "8e0ae724-d8a0-4b81-830d-d5b382c68a6c")
 		)
-		(pin "30" (uuid "436f4f18-01f7-484c-8e03-dc2f488748d3")
+		(pin "30" (uuid "f36a2315-8ca4-4d05-b8ac-7654c6e42f94")
 		)
-		(pin "31" (uuid "7aeb060e-0a52-4381-84e1-f000b792af3a")
+		(pin "31" (uuid "12f3ba10-de95-4c0b-beb6-c134df0ee1bd")
 		)
-		(pin "32" (uuid "2c2b6238-45ce-4076-82cf-959475fc781b")
+		(pin "32" (uuid "e184b186-4970-414a-925a-98f69d4ced3a")
 		)
-		(pin "33" (uuid "eab7d1fd-0325-4cc5-aa28-5c6abfcf2816")
+		(pin "33" (uuid "26d19cf6-2b33-4cbc-b1b8-72574df80c30")
 		)
-		(pin "34" (uuid "b22667b9-f5fd-4298-897a-07327b7d5845")
+		(pin "34" (uuid "50bd0324-52a3-40dc-b334-3593a06af463")
 		)
-		(pin "35" (uuid "307fe55a-3c1d-4cbf-b8a7-afa85a7de15f")
+		(pin "35" (uuid "a8718238-254b-4f38-9063-f305578916b8")
 		)
-		(pin "36" (uuid "36be18f7-e1ce-4add-a082-ce029ef4efce")
+		(pin "36" (uuid "d80237e9-081f-4761-bbde-d19142a4c266")
 		)
-		(pin "37" (uuid "33fab18d-6f2d-41d2-9d99-b553cdcd3622")
+		(pin "37" (uuid "30916e79-ba7e-4275-bc42-d7e29a960669")
 		)
-		(pin "38" (uuid "a6a9e37a-c9fc-4a37-92e6-af2830c8e766")
+		(pin "38" (uuid "6f00add1-eaa0-4142-a137-eb1831ed5481")
 		)
-		(pin "39" (uuid "90e77f8f-5c0e-48bc-9c9e-b93be66330d1")
+		(pin "39" (uuid "484c28d1-c153-4594-bc73-895849fa4fb4")
 		)
-		(pin "40" (uuid "511a9cdd-545c-4b61-b3d3-201c401e1d95")
+		(pin "40" (uuid "a98c6971-fbf3-4963-af7a-0e7282c5ae80")
 		)
-		(pin "41" (uuid "0091931c-ea88-4d12-87cb-ff6ef95365eb")
+		(pin "41" (uuid "8d1489a0-05f6-4e04-badb-7e7494ed09ee")
 		)
-		(pin "42" (uuid "f0e65cff-9ed7-4dea-880e-55e6d49814f1")
+		(pin "42" (uuid "2ef61c48-c1b1-490c-85e4-5ba15dc396b8")
 		)
-		(pin "43" (uuid "4b5e5822-0be9-461f-90c6-89d8020a5e7b")
+		(pin "43" (uuid "2575e97d-969d-41b6-a9cc-3b4ef30155c2")
 		)
-		(pin "44" (uuid "79f8e712-9fb0-47f1-b52b-a23891fe3d1a")
+		(pin "44" (uuid "5c456955-7374-473b-8eeb-e5b006902159")
 		)
-		(pin "45" (uuid "43412a05-6e15-48bd-8017-9324fd6191ec")
+		(pin "45" (uuid "19c1f583-5477-4920-b606-157621d2383f")
 		)
-		(pin "46" (uuid "c147e8cb-029f-4a93-bcb3-e97c6e9be7b2")
+		(pin "46" (uuid "7998be46-ff04-4beb-9039-92d3244d6d45")
 		)
-		(pin "47" (uuid "c23503d7-e39b-4375-bbdf-1f712091ae64")
+		(pin "47" (uuid "49fe65ff-5fa1-46d6-9836-1e8a5b45179e")
 		)
-		(pin "48" (uuid "85049c42-3128-4208-b4bf-6f86c38cc2a2")
+		(pin "48" (uuid "4a22701c-a1d8-4fd8-956a-b37752c2e8b3")
 		)
 		(instances
 			(project "project"
-				(path "/0d315cf6-faeb-4774-88b8-21b8269a7e13" (reference "U2") (unit 1)
+				(path "/5b6ec878-611a-4148-afea-b98afc10dc0a" (reference "U2") (unit 1)
 				)
 			)
 		)
 	)
 	(symbol
-		(lib_id "Connector_Generic:Conn_02x12_Counter_Clockwise")
-		(at 152.4 124.46 0)
+		(lib_id "matchgroup_lvs:QFN24_MIPI")
+		(at 177.8 127 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "f707cad9-bbc2-4ab6-8ce2-174b86982c4b")
+		(uuid "7860a353-7980-41ff-9529-e5ccdf1d2470")
 		(property "Reference" "U3"
-			(at 152.4 119.38 0)
+			(at 177.8 121.92 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4238,7 +5090,7 @@
 			)
 		)
 		(property "Value" "QFN24_MIPI"
-			(at 152.4 121.92 0)
+			(at 177.8 124.46 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4246,7 +5098,7 @@
 			)
 		)
 		(property "Footprint" "Package_DFN_QFN:QFN-24-1EP_4x4mm_P0.5mm"
-			(at 152.4 124.46 0)
+			(at 177.8 127 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4255,7 +5107,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 152.4 124.46 0)
+			(at 177.8 127 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4263,72 +5115,72 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "cbeba629-1558-41b2-b022-b3a0a7bf969c")
+		(pin "1" (uuid "347d4847-3ec9-44e4-afbe-d22ccaf48592")
 		)
-		(pin "2" (uuid "9776ffc2-fb79-4fdf-9ce6-beb1d3a4e605")
+		(pin "2" (uuid "c6a62200-6040-42cf-b623-6dcf0a939b1d")
 		)
-		(pin "3" (uuid "0f5e5b3e-78bf-4e16-a81a-7d7a8bd661ec")
+		(pin "3" (uuid "f77e31d5-7041-4d68-9fd4-3cb120933cb7")
 		)
-		(pin "4" (uuid "2cbc7af1-fa22-4797-9d46-e73454c7b0c7")
+		(pin "4" (uuid "3bbafa64-d7ce-4ddd-a846-250a72b22146")
 		)
-		(pin "5" (uuid "ce9cd947-8a55-457f-8496-9ab4679d7791")
+		(pin "5" (uuid "6fb8f613-e25a-495e-9200-4926951a647c")
 		)
-		(pin "6" (uuid "d98915aa-37a5-4324-989d-24b9203fc0de")
+		(pin "6" (uuid "72ca0bdf-2b2f-4033-9e38-d9150ae2d78b")
 		)
-		(pin "7" (uuid "4e6fcde8-cb2e-4531-acc9-de2fb045bd03")
+		(pin "7" (uuid "4520a0c2-c86e-4ab7-a70e-eea16a24aef0")
 		)
-		(pin "8" (uuid "14201ff7-9d4d-48ec-b634-5780c8b002cd")
+		(pin "8" (uuid "eeca5b14-2cbf-4e8e-a5ef-1854d39efd52")
 		)
-		(pin "9" (uuid "c4c0b1af-0c55-40c1-9738-d430d9848f9f")
+		(pin "9" (uuid "32b50e1f-d9e1-4024-b917-f1b93d70f020")
 		)
-		(pin "10" (uuid "4821f80c-ccba-47cb-b9d0-1565275b7497")
+		(pin "10" (uuid "692073c2-ad21-4238-b28d-eb6f7c365af7")
 		)
-		(pin "11" (uuid "9a406284-e228-4ef4-bb49-b854bfdb1385")
+		(pin "11" (uuid "1e370a0e-e656-4dea-af9c-d97de3df4175")
 		)
-		(pin "12" (uuid "3ca8d495-58f5-4111-acd9-ec372a87c6b2")
+		(pin "12" (uuid "0f469151-7df6-4e83-9e03-988df36af122")
 		)
-		(pin "13" (uuid "d9d52472-9448-42c8-91f8-dba396ab9ee1")
+		(pin "13" (uuid "5d87186c-9a34-43e1-82db-32f535811ef3")
 		)
-		(pin "14" (uuid "d9ee4a87-1a11-4c3f-97de-d6815539bfdf")
+		(pin "14" (uuid "1098d35e-5f75-4b89-ae8c-bebff6dd0486")
 		)
-		(pin "15" (uuid "0860b552-8cd2-4a90-b364-e8b368271c7d")
+		(pin "15" (uuid "1f2d03d5-e3d8-4033-a4f2-dd58227a7c92")
 		)
-		(pin "16" (uuid "bbcedf68-4584-48c9-aeaa-b0a7781af44e")
+		(pin "16" (uuid "411c6f79-48aa-4b7a-b5d4-f049124c6a9d")
 		)
-		(pin "17" (uuid "b9ba1749-6029-4d4a-8b4d-9b1fcbc4d3af")
+		(pin "17" (uuid "9071f3d2-797f-41d7-9cb5-e4f61341e135")
 		)
-		(pin "18" (uuid "c298c0e4-c000-4103-853b-fd84782d0979")
+		(pin "18" (uuid "c4cec24a-de64-4f2a-b7ad-5c8fdac24386")
 		)
-		(pin "19" (uuid "184d29e4-eade-41e0-906d-8598ec87d513")
+		(pin "19" (uuid "00a86d58-a4cf-46a5-964d-27fb7957558d")
 		)
-		(pin "20" (uuid "3ab1b866-17c4-4d72-a9a2-920794bc5bba")
+		(pin "20" (uuid "2d60f6de-b143-44fd-9d5c-0371b16ddf5b")
 		)
-		(pin "21" (uuid "8b450353-c4e1-4d34-b77c-e8f551fe3a84")
+		(pin "21" (uuid "61840486-7795-40d2-8920-fddc6d27a5db")
 		)
-		(pin "22" (uuid "8ebd984b-6d56-4049-b142-40159a883015")
+		(pin "22" (uuid "2a589374-e42a-4b8e-86c9-c6e72b5b96ed")
 		)
-		(pin "23" (uuid "a6f75791-a85e-4d68-a542-7dae305021e1")
+		(pin "23" (uuid "1a1e6233-dd32-4e19-858c-0c685a28e1c9")
 		)
-		(pin "24" (uuid "5f257f13-b9fc-4322-a9a6-a1b87b2683bf")
+		(pin "24" (uuid "9b71d869-9efc-42de-b874-32763b0bd574")
 		)
 		(instances
 			(project "project"
-				(path "/0d315cf6-faeb-4774-88b8-21b8269a7e13" (reference "U3") (unit 1)
+				(path "/5b6ec878-611a-4148-afea-b98afc10dc0a" (reference "U3") (unit 1)
 				)
 			)
 		)
 	)
 	(symbol
-		(lib_id "Connector_Generic:Conn_02x16_Counter_Clockwise")
-		(at 152.4 170.18 0)
+		(lib_id "matchgroup_lvs:BGA49_HDMI")
+		(at 177.8 190.5 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "2ba4b764-6ecd-4266-bd6c-d72a5ec7ea3b")
+		(uuid "53211ec2-0c04-4fb9-a9fd-e0b53df9b26f")
 		(property "Reference" "U4"
-			(at 152.4 165.1 0)
+			(at 177.8 185.42 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4336,7 +5188,7 @@
 			)
 		)
 		(property "Value" "BGA49_HDMI"
-			(at 152.4 167.64 0)
+			(at 177.8 187.96 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4344,7 +5196,7 @@
 			)
 		)
 		(property "Footprint" "Package_BGA:BGA-49_5.0x5.0mm_Layout7x7_P0.5mm"
-			(at 152.4 170.18 0)
+			(at 177.8 190.5 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4353,7 +5205,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 152.4 170.18 0)
+			(at 177.8 190.5 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4361,88 +5213,122 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "60dd139d-3624-43e1-b67b-74278574d218")
+		(pin "A1" (uuid "14cc3270-ca32-44de-9512-f6e865493602")
 		)
-		(pin "2" (uuid "d6467312-31f4-43eb-849a-bbb0eeef627e")
+		(pin "A2" (uuid "4e425c97-23e2-4a85-b7ff-93734bb08df3")
 		)
-		(pin "3" (uuid "ad1962f3-f8e1-4b32-8e86-7c80bd39a35b")
+		(pin "A3" (uuid "0d7e3b48-0298-46d1-8019-761b41a9f46f")
 		)
-		(pin "4" (uuid "85b6ca12-bb96-44bc-9f6b-918330935fbd")
+		(pin "A4" (uuid "051d0e66-5015-481f-a27c-f5dd46cc8ff6")
 		)
-		(pin "5" (uuid "5253bd01-016d-4b28-a3cb-36f5a05e6c41")
+		(pin "A5" (uuid "a8583ad9-27ec-43ea-bc37-48d5d9bd0d39")
 		)
-		(pin "6" (uuid "bfbfd260-101b-427e-88bd-fe5f9f3be58e")
+		(pin "A6" (uuid "c5fce956-b543-42d7-9333-3d3c7fdd07e0")
 		)
-		(pin "7" (uuid "79153c94-e362-41b0-8ba6-54f81fee94b1")
+		(pin "A7" (uuid "0e592112-c224-4db7-b8c4-b7de8283bf08")
 		)
-		(pin "8" (uuid "d052a0b5-5573-4b96-bb57-4fcc17bf2a06")
+		(pin "B1" (uuid "725f6011-36f0-456d-a803-0b467e92b6e4")
 		)
-		(pin "9" (uuid "4e29ed90-b9df-471b-8b0c-1e6fd6b934a7")
+		(pin "B2" (uuid "efcedc65-5aa9-4e97-b677-11c06668052d")
 		)
-		(pin "10" (uuid "80466306-68d3-4714-99ed-54e8843fbc0b")
+		(pin "B3" (uuid "2abfefe1-cbf2-4409-a182-525d65f711df")
 		)
-		(pin "11" (uuid "6112be3f-0ab3-4f4d-a9f2-9fdef4322bbf")
+		(pin "B4" (uuid "55a70d88-ec14-413f-a6c4-b06709076d17")
 		)
-		(pin "12" (uuid "541c8a38-63d4-4acc-9710-664fd065cf3a")
+		(pin "B5" (uuid "aca26199-7c46-45b3-8720-69eaad217fe6")
 		)
-		(pin "13" (uuid "1881db4d-871e-4fba-844c-3ead6e86e9e0")
+		(pin "B6" (uuid "c3b45008-0308-4563-aa28-8d3db724b3cc")
 		)
-		(pin "14" (uuid "81f7db52-8827-47b8-8c5e-f69446008f10")
+		(pin "B7" (uuid "af686e26-c219-4df9-bcbc-3e57f1d5eef1")
 		)
-		(pin "15" (uuid "71d73b2a-e19e-4799-8396-70b2aa629734")
+		(pin "C1" (uuid "56aed028-0c06-4b71-8199-c031056e4491")
 		)
-		(pin "16" (uuid "8b2a8105-5436-4d54-b178-591cf3c9d369")
+		(pin "C2" (uuid "27663103-f6e0-41b9-bb8d-2960391e2a52")
 		)
-		(pin "17" (uuid "702d4e9a-4730-4789-a3dc-8f678ae76028")
+		(pin "C3" (uuid "22dc49a4-8f70-45c1-9555-9d68ef8dddb1")
 		)
-		(pin "18" (uuid "c4bdd8b0-b803-4fa0-9593-e27bc44c1e83")
+		(pin "C4" (uuid "0ca7e66e-ef6a-46b4-a9e1-c826c2df3a9c")
 		)
-		(pin "19" (uuid "5a0dd12c-0954-402b-a83b-f94a70a81b77")
+		(pin "C5" (uuid "07545a7f-ea95-4b52-b49d-afdaad5150ac")
 		)
-		(pin "20" (uuid "38d5adc1-f7cd-47c8-8696-2976f78128b8")
+		(pin "C6" (uuid "f9383fbc-60b3-430e-8beb-2678a7aeef64")
 		)
-		(pin "21" (uuid "7d5ebce0-ba5b-4c1a-b7dd-351496c7f741")
+		(pin "C7" (uuid "3b8fcdc4-52d7-4b75-b7d8-03e156229e67")
 		)
-		(pin "22" (uuid "a9b131fc-a310-4855-9eac-47e32d42c445")
+		(pin "D1" (uuid "2d44b178-bb74-4955-bc1d-e42cb5ee3766")
 		)
-		(pin "23" (uuid "d9d5e506-8cb4-4073-ac7f-82a148571668")
+		(pin "D2" (uuid "04135204-89c7-4281-8aac-991f593e5433")
 		)
-		(pin "24" (uuid "e7bfb822-0353-40fc-8899-90e7b51f53d0")
+		(pin "D3" (uuid "f4fd1906-dd05-4449-b8e6-f2d55932e18c")
 		)
-		(pin "25" (uuid "7bc370c5-965f-463c-a911-c37f53e55183")
+		(pin "D4" (uuid "7fe3366a-31d3-486e-95ee-4271443c4d09")
 		)
-		(pin "26" (uuid "9558ea7f-d95d-49d3-889c-50689db73572")
+		(pin "D5" (uuid "289e7e17-62b5-4c49-8d4d-d2edbf4ba679")
 		)
-		(pin "27" (uuid "82652405-719d-407b-a0a2-77fb6eb5ab1e")
+		(pin "D6" (uuid "5e24d8f6-d92b-4bd0-833c-b63d87c66c51")
 		)
-		(pin "28" (uuid "017af992-9b5c-445d-b1e0-fd098c1a4bcc")
+		(pin "D7" (uuid "bed2c020-188b-47a2-9a47-a836fd1f904a")
 		)
-		(pin "29" (uuid "f7d3d4a1-95b8-47c2-b9ff-d94a48b60789")
+		(pin "E1" (uuid "5ac3d3db-e26f-491a-9c43-c97ad844a438")
 		)
-		(pin "30" (uuid "65899479-231d-49a5-b48c-33cab88cc5ba")
+		(pin "E2" (uuid "9bfbd51e-6bb1-415d-b2ac-765606bfb1c0")
 		)
-		(pin "31" (uuid "3eb485d5-fa64-4be4-94fa-36b8f1e46cbc")
+		(pin "E3" (uuid "973c6b2c-00d6-40f2-a9ed-a0b8bbd161d0")
 		)
-		(pin "32" (uuid "638eaeca-e8f2-4e37-a6ab-7e9396bb60d0")
+		(pin "E4" (uuid "855e4032-0a28-404a-81ef-614e7cd1c954")
+		)
+		(pin "E5" (uuid "b64bf9c0-5325-42c5-b422-f9404d352958")
+		)
+		(pin "E6" (uuid "4f07c00f-8628-45fa-baff-f73c58e140eb")
+		)
+		(pin "E7" (uuid "43727d5a-62e8-4cf3-b0cc-2054c075b770")
+		)
+		(pin "F1" (uuid "5811af58-5916-4afd-84ee-1be84517ae3d")
+		)
+		(pin "F2" (uuid "81d987c4-89a0-4162-969a-d6d0d8c976db")
+		)
+		(pin "F3" (uuid "9ec8c28e-38d7-45e9-9c35-6305c1edd21f")
+		)
+		(pin "F4" (uuid "4a283dcc-ea39-4b6a-aebc-3555a172bfc1")
+		)
+		(pin "F5" (uuid "111a1cea-9692-4471-8de3-4ac6c0c4dcdf")
+		)
+		(pin "F6" (uuid "c575cad3-e7ae-4f68-9937-7a1076a3512c")
+		)
+		(pin "F7" (uuid "201586f4-d2b0-472b-9aa0-78021c3b7447")
+		)
+		(pin "G1" (uuid "0f929529-bd32-46ad-9d6d-0d9404b931d9")
+		)
+		(pin "G2" (uuid "5bc2b6f3-5498-4b43-ab21-3a084796eb58")
+		)
+		(pin "G3" (uuid "04e6fdf1-cabd-4b41-aadf-a99c57d111d7")
+		)
+		(pin "G4" (uuid "0719b94f-787f-49d0-bbb8-104f74d99025")
+		)
+		(pin "G5" (uuid "49f0ad26-c775-4135-928d-2e94b579f62f")
+		)
+		(pin "G6" (uuid "f8d25a39-db0b-474c-b0be-45b8886cbbc8")
+		)
+		(pin "G7" (uuid "253f46aa-c2d0-4419-b90a-392bc1ab3e6e")
 		)
 		(instances
 			(project "project"
-				(path "/0d315cf6-faeb-4774-88b8-21b8269a7e13" (reference "U4") (unit 1)
+				(path "/5b6ec878-611a-4148-afea-b98afc10dc0a" (reference "U4") (unit 1)
 				)
 			)
 		)
 	)
 	(symbol
-		(lib_id "Connector_Generic:Conn_02x24_Counter_Clockwise")
-		(at 152.4 215.9 0)
+		(lib_id "matchgroup_lvs:QFP48_SRAM")
+		(at 177.8 266.7 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "dfe20691-07b6-4abe-a9dc-91ccd60744ad")
+		(uuid "6e37fd8d-9dd7-4bb4-ae61-309ce4910d0d")
 		(property "Reference" "U5"
-			(at 152.4 210.82 0)
+			(at 177.8 261.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4450,7 +5336,7 @@
 			)
 		)
 		(property "Value" "QFP48_SRAM"
-			(at 152.4 213.36 0)
+			(at 177.8 264.16 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4458,7 +5344,7 @@
 			)
 		)
 		(property "Footprint" "Package_QFP:LQFP-48_7x7mm_P0.5mm"
-			(at 152.4 215.9 0)
+			(at 177.8 266.7 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4467,7 +5353,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 152.4 215.9 0)
+			(at 177.8 266.7 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4475,120 +5361,120 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "dfb8e698-95d2-4427-88fe-57d11482c091")
+		(pin "1" (uuid "5da0c701-0e39-4362-a8b8-337fa6d26fe6")
 		)
-		(pin "2" (uuid "1b0416ef-fcf6-4c22-b90b-f56ebf0019dd")
+		(pin "2" (uuid "a63702f1-0f6b-40f3-b692-ea8e274a46e4")
 		)
-		(pin "3" (uuid "f5936c39-e532-41be-bebf-3625175545c2")
+		(pin "3" (uuid "17f147f4-abab-43db-b75d-aa2aac057fd0")
 		)
-		(pin "4" (uuid "448fbfc9-bb62-4f10-8c08-22e48cbb747d")
+		(pin "4" (uuid "c47a43a5-96c8-480d-be8a-12550c0e00c4")
 		)
-		(pin "5" (uuid "ea8757f5-4a00-4dc8-a441-f5e2813c5f15")
+		(pin "5" (uuid "3a55e7e7-ec23-4b90-96b8-30ce272fda46")
 		)
-		(pin "6" (uuid "62076c07-3df4-453c-bdca-73e7ac856bc7")
+		(pin "6" (uuid "8db09978-f2c1-493a-88c4-6db68f787f08")
 		)
-		(pin "7" (uuid "feb2f7b9-d100-415d-bafb-418078805355")
+		(pin "7" (uuid "9b29cab9-7638-42c8-9b1a-1d6c2dae22d5")
 		)
-		(pin "8" (uuid "4f160b40-2b2b-45f9-9575-ccfbf12dfeb8")
+		(pin "8" (uuid "0dc72347-08a0-4869-a05a-6418ad5a7f26")
 		)
-		(pin "9" (uuid "2b7ed76c-756a-4d1f-ab9f-aad973ed05ba")
+		(pin "9" (uuid "d11aae9a-db6f-467d-82d8-c2d614f68835")
 		)
-		(pin "10" (uuid "5c7d237c-d986-48a5-bb97-1a3b4b5ba9d4")
+		(pin "10" (uuid "3ace8868-ac0d-485c-95a2-8bf84c3c7a0c")
 		)
-		(pin "11" (uuid "b56fa30d-2a0b-4d47-8ccf-1ff159c078e5")
+		(pin "11" (uuid "330c9c9e-0b79-4dad-b63f-1535d9a3c8d9")
 		)
-		(pin "12" (uuid "0bae17ed-728b-4875-988c-d8bd17760314")
+		(pin "12" (uuid "5d1e8d30-abf0-4cf4-b8ad-13650e513d9b")
 		)
-		(pin "13" (uuid "097912bf-eaa4-40b5-8b07-2d4340137a5e")
+		(pin "13" (uuid "3399ee35-e93b-45aa-8729-fec35af1b351")
 		)
-		(pin "14" (uuid "58cbbd2b-9afa-4064-8ab2-01ec2577062b")
+		(pin "14" (uuid "57c7c7b4-83f2-48bc-afa1-97e550200817")
 		)
-		(pin "15" (uuid "fba3456b-555b-40ec-861d-b828d96b5859")
+		(pin "15" (uuid "0c4e9591-8dfd-4da2-bc66-fae88ee540ab")
 		)
-		(pin "16" (uuid "5631dafd-e8fe-4701-ad45-4c030f39558f")
+		(pin "16" (uuid "443e7ed9-ac05-44cb-b978-3fb273245ffa")
 		)
-		(pin "17" (uuid "6861fe99-9353-45fd-b1e9-2f916d5ff2fc")
+		(pin "17" (uuid "52a94efb-f33e-4712-bc0c-f9d1b1686d0c")
 		)
-		(pin "18" (uuid "6bb3f97b-827b-4ec4-a70f-caaaadb3a0d0")
+		(pin "18" (uuid "b096a7b7-fc9f-44d3-b0e5-04d679c373f2")
 		)
-		(pin "19" (uuid "7b00eff5-b2ba-4020-9988-c69fba328efe")
+		(pin "19" (uuid "32b18270-94c5-4c58-af10-9f1f1c02ba30")
 		)
-		(pin "20" (uuid "d457c39b-3703-4461-8525-1aa5c123f1fd")
+		(pin "20" (uuid "fa873412-15db-40d8-884b-6123d9ea2d41")
 		)
-		(pin "21" (uuid "8d0f5e18-f534-4a47-ae80-3601076975c3")
+		(pin "21" (uuid "836b19d2-bf52-495e-ba47-b71606e77849")
 		)
-		(pin "22" (uuid "bd89b4f0-d6bb-46c2-82d7-c7bec3372be4")
+		(pin "22" (uuid "6af49257-7708-48fe-93bd-dd32a7e8e1b3")
 		)
-		(pin "23" (uuid "0d20d99e-b332-46cb-b9b0-e87b16ec8eca")
+		(pin "23" (uuid "b366f855-b992-46a5-aedc-54019e1b24c2")
 		)
-		(pin "24" (uuid "a5572f30-bfdf-497b-baf2-5a229e438319")
+		(pin "24" (uuid "4f754021-1e85-42f4-8d0e-cbd600d04153")
 		)
-		(pin "25" (uuid "4b4865bf-3239-4e5d-9fd2-1150440aa4dc")
+		(pin "25" (uuid "6cc5fb76-8d94-4ee4-a72b-e3ad9a208cb5")
 		)
-		(pin "26" (uuid "ae575cba-bd3c-4f26-9b23-ff303317b992")
+		(pin "26" (uuid "b1d2a842-4495-4cd2-8045-f2a9be914f73")
 		)
-		(pin "27" (uuid "c271bb33-7888-4cb2-b5d3-7da6680e720a")
+		(pin "27" (uuid "12f2f45c-c9d6-47e6-ba96-ff78f2abf484")
 		)
-		(pin "28" (uuid "e2568fec-8c9f-4d12-9ed1-680736c34ea1")
+		(pin "28" (uuid "b371bbaa-15ef-4afb-9a64-c22084dda526")
 		)
-		(pin "29" (uuid "ed582b46-22f8-4f4f-b51b-f2ab33b0dd6c")
+		(pin "29" (uuid "4bf8d798-1b1f-465c-aa85-7f287f72ddbe")
 		)
-		(pin "30" (uuid "a7a94cd8-5860-44d4-b449-221ebfb824d8")
+		(pin "30" (uuid "c78af789-f705-462f-9579-88f731ede325")
 		)
-		(pin "31" (uuid "dcfe003b-8595-4515-91f9-71031f1152cf")
+		(pin "31" (uuid "67ab8f1c-452a-4918-afa9-eb512f4bdeb5")
 		)
-		(pin "32" (uuid "4165810b-d602-4ed7-9e03-7083c2f29674")
+		(pin "32" (uuid "3861a552-df8a-45e9-a2af-318a922ae07f")
 		)
-		(pin "33" (uuid "9d4bcf4c-ca86-4775-ad17-9ae282a9a854")
+		(pin "33" (uuid "a4f616b8-3f97-468d-8569-0cc7376f39b1")
 		)
-		(pin "34" (uuid "537eaee1-5014-44a7-a45e-0c71572c1dd5")
+		(pin "34" (uuid "16a1f501-c140-49b9-86c4-64fcdd28c5fe")
 		)
-		(pin "35" (uuid "2b213de9-0fa0-45e0-8150-867fb00d6fba")
+		(pin "35" (uuid "d339ba22-b5e3-40c4-a17d-4d54fd705fdc")
 		)
-		(pin "36" (uuid "5aedb2c9-f09e-4e94-9179-33471e43699f")
+		(pin "36" (uuid "e1d98cd8-f5e7-4778-a8bd-947d3aef2f1a")
 		)
-		(pin "37" (uuid "2d888ede-9b61-4a4f-9462-e874d1515ca0")
+		(pin "37" (uuid "bc7dc5c1-b379-4d6f-8cad-da6fc1e3e067")
 		)
-		(pin "38" (uuid "c5b0db6b-fd3d-422f-b089-d27fc1955e67")
+		(pin "38" (uuid "aaff67c1-8061-4b2c-81ef-dde3100797d0")
 		)
-		(pin "39" (uuid "157f19ec-3e3e-47cf-a729-5b85a9781a8a")
+		(pin "39" (uuid "c41be1cd-846a-4540-9ec1-8fabc63a0145")
 		)
-		(pin "40" (uuid "37987b0f-66c4-4083-b22f-336ec02d8298")
+		(pin "40" (uuid "de3e9802-f79e-429f-98fd-2c71e4f758b5")
 		)
-		(pin "41" (uuid "ff282a78-889f-471a-a735-fed4f4cb47c5")
+		(pin "41" (uuid "c32fe219-1987-47fc-98eb-eed43659b801")
 		)
-		(pin "42" (uuid "ac2bd408-47a0-48d8-ac80-8e223115a88f")
+		(pin "42" (uuid "2ebdc28c-6daa-40ee-b4d5-899467d4d481")
 		)
-		(pin "43" (uuid "ec98f3d5-338c-4e70-b996-4e088e6baace")
+		(pin "43" (uuid "b739e22b-68cc-4bc6-869f-3c5eabad9761")
 		)
-		(pin "44" (uuid "fee8ba91-3613-4879-a4f3-35cfc513fc92")
+		(pin "44" (uuid "cd956f44-397e-4d08-8c70-781091f9e1b9")
 		)
-		(pin "45" (uuid "98c16120-d49e-48cf-ba69-4481dde567ed")
+		(pin "45" (uuid "37d85828-d6ba-413a-be80-ef0c9d3be5be")
 		)
-		(pin "46" (uuid "6aef1a98-151a-4fa6-a1c0-e0bc1e52ed3c")
+		(pin "46" (uuid "4f0a364e-730e-4744-82d7-ceff6e4a67b9")
 		)
-		(pin "47" (uuid "e330b592-9caf-4617-9a0f-68f5aa60919b")
+		(pin "47" (uuid "7388e356-b97e-4d07-bb19-23f712986117")
 		)
-		(pin "48" (uuid "dd88014d-4225-4e51-b29f-18b1dc20bcff")
+		(pin "48" (uuid "3f954e77-3767-48b3-8a77-3a56f635e9a6")
 		)
 		(instances
 			(project "project"
-				(path "/0d315cf6-faeb-4774-88b8-21b8269a7e13" (reference "U5") (unit 1)
+				(path "/5b6ec878-611a-4148-afea-b98afc10dc0a" (reference "U5") (unit 1)
 				)
 			)
 		)
 	)
 	(symbol
 		(lib_id "power:PWR_FLAG")
-		(at 25.4 7.62 0)
+		(at 12.7 7.62 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "8c7699ed-5ce6-40a9-9db3-a98a66649877")
+		(uuid "8cece1f2-3106-474f-a928-292fb5ffde0b")
 		(property "Reference" "#PWR01"
-			(at 25.4 10.16 0)
+			(at 12.7 10.16 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4597,7 +5483,7 @@
 			)
 		)
 		(property "Value" "PWR_FLAG"
-			(at 25.4 12.7 0)
+			(at 12.7 12.7 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4605,7 +5491,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 25.4 7.62 0)
+			(at 12.7 7.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4614,7 +5500,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 25.4 7.62 0)
+			(at 12.7 7.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4622,26 +5508,26 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "9d0fc217-1e4d-4857-ba60-1e3614b3160e")
+		(pin "1" (uuid "7d778bd2-b4b1-41b7-a66f-28c12f72216f")
 		)
 		(instances
 			(project "project"
-				(path "/0d315cf6-faeb-4774-88b8-21b8269a7e13" (reference "#PWR01") (unit 1)
+				(path "/5b6ec878-611a-4148-afea-b98afc10dc0a" (reference "#PWR01") (unit 1)
 				)
 			)
 		)
 	)
 	(symbol
 		(lib_id "power:PWR_FLAG")
-		(at 25.4 17.78 0)
+		(at 12.7 17.78 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "23fbc417-79ee-41c9-96d6-a9482091bfd7")
+		(uuid "21467688-04f4-4f0a-bd8f-0cf9f15f6a01")
 		(property "Reference" "#PWR02"
-			(at 25.4 20.32 0)
+			(at 12.7 20.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4650,7 +5536,7 @@
 			)
 		)
 		(property "Value" "PWR_FLAG"
-			(at 25.4 22.86 0)
+			(at 12.7 22.86 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4658,7 +5544,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 25.4 17.78 0)
+			(at 12.7 17.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4667,7 +5553,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 25.4 17.78 0)
+			(at 12.7 17.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4675,26 +5561,26 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "78c0bde5-b145-4368-b4d3-be43a7962a70")
+		(pin "1" (uuid "a4f96ee2-b2d9-499c-b972-923a5b0d01f7")
 		)
 		(instances
 			(project "project"
-				(path "/0d315cf6-faeb-4774-88b8-21b8269a7e13" (reference "#PWR02") (unit 1)
+				(path "/5b6ec878-611a-4148-afea-b98afc10dc0a" (reference "#PWR02") (unit 1)
 				)
 			)
 		)
 	)
 	(symbol
 		(lib_id "power:PWR_FLAG")
-		(at 25.4 238.76 0)
+		(at 12.7 309.88 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "28213886-51b0-43d6-8de7-e8f5e57d95b9")
+		(uuid "be56675f-153c-4a6b-bed8-15cf715ff3db")
 		(property "Reference" "#PWR03"
-			(at 25.4 241.3 0)
+			(at 12.7 312.42 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4703,7 +5589,7 @@
 			)
 		)
 		(property "Value" "PWR_FLAG"
-			(at 25.4 243.84 0)
+			(at 12.7 314.96 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4711,7 +5597,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 25.4 238.76 0)
+			(at 12.7 309.88 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4720,7 +5606,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 25.4 238.76 0)
+			(at 12.7 309.88 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4728,323 +5614,4192 @@
 				(hide yes)
 			)
 		)
-		(pin "1" (uuid "87839a04-0de8-42a2-bc23-cd673177f4b9")
+		(pin "1" (uuid "3c21357f-e940-4e85-9a29-1194cc23d9d0")
 		)
 		(instances
 			(project "project"
-				(path "/0d315cf6-faeb-4774-88b8-21b8269a7e13" (reference "#PWR03") (unit 1)
+				(path "/5b6ec878-611a-4148-afea-b98afc10dc0a" (reference "#PWR03") (unit 1)
 				)
 			)
 		)
 	)
-	(global_label "+1V2" (shape input) (at 25.4 7.62 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 41.91 21.59) (xy 36.83 21.59))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "251c494d-509b-4c1e-baa8-09175ae4a94d")
+		(uuid "aaf019ce-3f3d-4716-971d-f84af2c6c23e")
 	)
-	(global_label "+1V8" (shape input) (at 25.4 17.78 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 41.91 24.13) (xy 36.83 24.13))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "53bec00d-b778-4104-a7cf-9756d1ecf8eb")
+		(uuid "ba64a4c6-5dc4-4cd8-a927-03130e0feeb5")
 	)
-	(global_label "GND" (shape input) (at 25.4 240 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 41.91 26.67) (xy 36.83 26.67))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "3656d880-9e1a-4ba7-83ae-ff4ae9044bd5")
+		(uuid "0d52646b-1a55-4fd2-b728-8f2b740ddff4")
 	)
-	(global_label "DQ0" (shape bidirectional) (at 190.5 30 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 41.91 29.21) (xy 36.83 29.21))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "a2ac97c4-41d5-4d1b-bb3a-9914ca140582")
+		(uuid "543f08d4-e1ce-4079-9124-a075a8556cd3")
 	)
-	(global_label "DQ1" (shape bidirectional) (at 190.5 35.08 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 41.91 31.75) (xy 36.83 31.75))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "0843c00d-27fc-4fa9-a679-be6d45921346")
+		(uuid "ef5c211c-a987-4fd7-a950-1ae9b3e24c15")
 	)
-	(global_label "DQ2" (shape bidirectional) (at 190.5 40.16 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 41.91 34.29) (xy 36.83 34.29))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "4683208c-10e3-45e3-bd6a-f88baa4477e5")
+		(uuid "96d95ab2-d027-40d4-a082-16efa68f6774")
 	)
-	(global_label "DQ3" (shape bidirectional) (at 190.5 45.24 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 41.91 36.83) (xy 36.83 36.83))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "255c92ea-0939-4d54-a3cb-e96e27bb329c")
+		(uuid "7ce84c3e-9b86-49d9-9d7b-6e4fc669bfc3")
 	)
-	(global_label "DQ4" (shape bidirectional) (at 190.5 50.32 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 41.91 39.37) (xy 36.83 39.37))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "ba7e647f-05eb-4306-8149-3ad5fbd6a9ef")
+		(uuid "a353f856-c496-4fb7-b48f-0836f1a704a1")
 	)
-	(global_label "DQ5" (shape bidirectional) (at 190.5 55.4 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 41.91 41.91) (xy 36.83 41.91))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "a58942e3-ad2d-4a10-a958-f0c839236578")
+		(uuid "70bdc635-1ba3-415c-8caa-a12deefd0412")
 	)
-	(global_label "DQ6" (shape bidirectional) (at 190.5 60.48 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 41.91 44.45) (xy 36.83 44.45))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "5c50816c-cd39-4648-8be6-2d54f156d6e6")
+		(uuid "7243651f-42e8-4cc8-bfcb-6d1008159d04")
 	)
-	(global_label "DQ7" (shape bidirectional) (at 190.5 65.56 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 41.91 46.99) (xy 36.83 46.99))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "acbd111a-0363-4596-8e75-8249e62db941")
+		(uuid "1e5f031a-ffba-4ccd-881d-5fc44443b0dd")
 	)
-	(global_label "DM0" (shape bidirectional) (at 190.5 70.64 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 41.91 49.53) (xy 36.83 49.53))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "cf7ee128-2571-4b94-8e4f-13421a6cdc1b")
+		(uuid "88e657d8-90b5-4703-9f55-db5173eb6ee4")
 	)
-	(global_label "DQS_P" (shape bidirectional) (at 190.5 75.72 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 41.91 52.07) (xy 36.83 52.07))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "01d0036d-9bf0-4df3-b9ed-9f5d9eeeba74")
+		(uuid "5f5bac0e-00a9-4989-a2bb-34f8b5c4775b")
 	)
-	(global_label "DQS_N" (shape bidirectional) (at 190.5 80.8 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 41.91 54.61) (xy 36.83 54.61))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "f579112f-4c4d-4e2c-bb3b-3c32627ba2f6")
+		(uuid "22ff0776-feb4-4915-87db-a133436a45ea")
 	)
-	(global_label "MIPI_CLK_P" (shape bidirectional) (at 190.5 88.42 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 41.91 57.15) (xy 36.83 57.15))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "e026961a-9724-4c60-b8ab-2851a045da4d")
+		(uuid "f47efc11-4f00-4e5e-b81a-44738cb03627")
 	)
-	(global_label "MIPI_CLK_N" (shape bidirectional) (at 190.5 93.5 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 41.91 59.69) (xy 36.83 59.69))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "cda8d6aa-8772-4604-907d-2f9d37390a5f")
+		(uuid "a12c3ba2-aaf9-44dd-8f29-def91b35ce6f")
 	)
-	(global_label "MIPI_DAT0_P" (shape bidirectional) (at 190.5 101.12 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 41.91 62.23) (xy 36.83 62.23))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "56712d65-a699-463b-aab5-b56261d4b88f")
+		(uuid "56105ae8-acfe-49d9-a46a-bc6bc05ec35c")
 	)
-	(global_label "MIPI_DAT0_N" (shape bidirectional) (at 190.5 106.2 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 41.91 64.77) (xy 36.83 64.77))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "7809b3ef-165c-4382-a75f-7ef355f1ff9a")
+		(uuid "7cc133b2-d7ab-43f2-ae67-44fc16b9e447")
 	)
-	(global_label "MIPI_DAT1_P" (shape bidirectional) (at 190.5 113.82 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 41.91 67.31) (xy 36.83 67.31))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "65c6398a-e93c-423c-a10e-82a9602cab3f")
+		(uuid "cd682c6e-7d43-4c93-8da1-875a1c0cf563")
 	)
-	(global_label "MIPI_DAT1_N" (shape bidirectional) (at 190.5 118.9 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 41.91 69.85) (xy 36.83 69.85))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "e9ed708b-3c88-4146-81a3-3a52d79e6414")
+		(uuid "7da6a526-804a-445f-8d0a-e8752b4af9a6")
 	)
-	(global_label "TMDS_D0_P" (shape bidirectional) (at 190.5 131.6 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 41.91 72.39) (xy 36.83 72.39))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "333c3f63-83a1-4e05-9714-2b420edd536c")
+		(uuid "d66b82d6-180d-43d8-bcfd-88e00e4e2f62")
 	)
-	(global_label "TMDS_D0_N" (shape bidirectional) (at 190.5 136.68 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 41.91 74.93) (xy 36.83 74.93))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "fa75d48a-febb-4bdd-9110-34f34be5d363")
+		(uuid "a668e370-8620-4e95-a4ec-827d33ed5221")
 	)
-	(global_label "TMDS_D1_P" (shape bidirectional) (at 190.5 144.3 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 41.91 77.47) (xy 36.83 77.47))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "9cf69b19-44c4-45b4-b1e5-8b6e5f82b8e3")
+		(uuid "bf09760a-e4e4-4e06-bb54-8694015495f2")
 	)
-	(global_label "TMDS_D1_N" (shape bidirectional) (at 190.5 149.38 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 41.91 80.01) (xy 36.83 80.01))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "bd5685cf-59f4-46cf-ba4c-a07adf2bf0f2")
+		(uuid "079cdd90-52c9-4e06-9e68-13b6b2b63376")
 	)
-	(global_label "TMDS_D2_P" (shape bidirectional) (at 190.5 157 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 59.69 21.59) (xy 64.77 21.59))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "54ebdb7e-685a-42c7-b54c-e7dc01a0e078")
+		(uuid "ec712cb1-7021-420a-9cd0-f0d8cbc96525")
 	)
-	(global_label "TMDS_D2_N" (shape bidirectional) (at 190.5 162.08 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 59.69 24.13) (xy 64.77 24.13))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "67b22f02-6f93-4367-82b2-77368d5fc80e")
+		(uuid "a90135fa-888e-407e-b703-14f38d07d603")
 	)
-	(global_label "A0" (shape bidirectional) (at 190.5 174.78 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 59.69 26.67) (xy 64.77 26.67))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "0f0f6735-3c3c-44ef-8f59-f5c11767e62a")
+		(uuid "68da8b7c-df18-4376-bbf0-79bf3b89483c")
 	)
-	(global_label "A1" (shape bidirectional) (at 190.5 179.86 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 59.69 29.21) (xy 64.77 29.21))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "135d4c89-e3c6-4e89-94d7-e996b1d9c11f")
+		(uuid "c282b928-5031-4a29-bef5-9728d9980039")
 	)
-	(global_label "A2" (shape bidirectional) (at 190.5 184.94 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 59.69 31.75) (xy 64.77 31.75))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "4a5170fa-3800-4061-84da-cdda0c8a6f38")
+		(uuid "31a7e2cf-d5fb-42d1-a380-d36ceeca83c3")
 	)
-	(global_label "A3" (shape bidirectional) (at 190.5 190.02 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 59.69 34.29) (xy 64.77 34.29))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "f3b66a4c-c6b2-48c4-9d73-017508e61e7c")
+		(uuid "cf61cba8-628b-407a-8f4c-b993356304e1")
 	)
-	(global_label "A4" (shape bidirectional) (at 190.5 195.1 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 59.69 36.83) (xy 64.77 36.83))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "7be7ce65-e9ca-4037-b96b-ba3619079c7f")
+		(uuid "6face997-3369-4606-83dd-f72360d689fc")
 	)
-	(global_label "A5" (shape bidirectional) (at 190.5 200.18 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 59.69 39.37) (xy 64.77 39.37))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "990ef541-b036-4d62-a0ca-134a269ad2fa")
+		(uuid "6a84b8e1-6b7b-4c5b-a58a-2073391168ad")
 	)
-	(global_label "A6" (shape bidirectional) (at 190.5 205.26 0) (fields_autoplaced yes)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
+	(wire
+		(pts (xy 59.69 41.91) (xy 64.77 41.91))
+		(stroke
+			(width 0)
+			(type default)
 		)
-		(uuid "1d56133b-0aeb-4a35-bd63-f10659fa459f")
+		(uuid "95ceb9c5-0ea1-420c-b388-f6a5ccb6e56b")
 	)
-	(global_label "A7" (shape bidirectional) (at 190.5 210.34 0) (fields_autoplaced yes)
+	(wire
+		(pts (xy 59.69 44.45) (xy 64.77 44.45))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bd0a348d-17ee-428e-91d0-2786295f2040")
+	)
+	(wire
+		(pts (xy 59.69 46.99) (xy 64.77 46.99))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e5276c4a-b479-4ff1-bfec-6c9962ff06eb")
+	)
+	(wire
+		(pts (xy 59.69 49.53) (xy 64.77 49.53))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "03f81fea-e8b1-43c1-905b-aa90d6d393e3")
+	)
+	(wire
+		(pts (xy 59.69 52.07) (xy 64.77 52.07))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d1f6bb8f-63bc-4752-9711-b3ad5828c6ff")
+	)
+	(wire
+		(pts (xy 59.69 54.61) (xy 64.77 54.61))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e503df39-5c78-498b-a5bc-714777bd3da7")
+	)
+	(wire
+		(pts (xy 59.69 57.15) (xy 64.77 57.15))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "12d3d35a-e02d-4a6a-a9f1-abe8eaf02b3b")
+	)
+	(wire
+		(pts (xy 59.69 59.69) (xy 64.77 59.69))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0428d412-1609-4c59-ac79-73c4f25c971b")
+	)
+	(wire
+		(pts (xy 59.69 62.23) (xy 64.77 62.23))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ce8d31c8-be60-434d-9961-9aadc5d80bcb")
+	)
+	(wire
+		(pts (xy 59.69 64.77) (xy 64.77 64.77))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7b4da1c8-82ec-45be-9659-31c06bb6d062")
+	)
+	(wire
+		(pts (xy 59.69 67.31) (xy 64.77 67.31))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bf262304-897f-41e9-8c5a-61c79e25a9e5")
+	)
+	(wire
+		(pts (xy 59.69 69.85) (xy 64.77 69.85))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dd4a0196-75c9-4ea7-881e-a3ee65e91f2b")
+	)
+	(wire
+		(pts (xy 59.69 72.39) (xy 64.77 72.39))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5b6f4475-ce06-4bb2-8655-040641cfacb4")
+	)
+	(wire
+		(pts (xy 59.69 74.93) (xy 64.77 74.93))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3c1bd455-7b59-43d4-bad6-2f4a805221ee")
+	)
+	(wire
+		(pts (xy 59.69 77.47) (xy 64.77 77.47))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "180cb080-4f69-4653-b083-33e1946df02e")
+	)
+	(wire
+		(pts (xy 59.69 80.01) (xy 64.77 80.01))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "45307ce7-d5f3-42a0-a912-ec0ec3563f86")
+	)
+	(wire
+		(pts (xy 41.91 97.79) (xy 36.83 97.79))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d91bcc8a-06ac-4922-942b-25f937064828")
+	)
+	(wire
+		(pts (xy 41.91 100.33) (xy 36.83 100.33))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "948a382b-5700-460c-8bb3-b0a0211cb2dc")
+	)
+	(wire
+		(pts (xy 41.91 102.87) (xy 36.83 102.87))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7e2706dc-d065-474d-beda-5afb91d4ecb5")
+	)
+	(wire
+		(pts (xy 41.91 105.41) (xy 36.83 105.41))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f29113a5-535c-4cd2-95ea-631ec4345c6b")
+	)
+	(wire
+		(pts (xy 59.69 97.79) (xy 64.77 97.79))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "81cf4c6b-af4c-4308-aff2-a58fab6e499c")
+	)
+	(wire
+		(pts (xy 59.69 100.33) (xy 64.77 100.33))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3f4d4bbb-422e-4231-96c7-aa516cd4a854")
+	)
+	(wire
+		(pts (xy 59.69 102.87) (xy 64.77 102.87))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d0e15e02-e17e-4219-9806-34e1725269b3")
+	)
+	(wire
+		(pts (xy 59.69 105.41) (xy 64.77 105.41))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fd02bc44-b004-4f8f-bc37-8347e0ab3d2c")
+	)
+	(wire
+		(pts (xy 41.91 121.92) (xy 36.83 121.92))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c4081ce8-e14b-49e7-bb1e-98e693799936")
+	)
+	(wire
+		(pts (xy 41.91 124.46) (xy 36.83 124.46))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2bfdf2bc-e6c1-4365-a68e-766c1daa5ccd")
+	)
+	(wire
+		(pts (xy 41.91 127) (xy 36.83 127))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1090e471-1d98-47bb-b1dd-3a60103d152a")
+	)
+	(wire
+		(pts (xy 41.91 129.54) (xy 36.83 129.54))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f4b77237-3d4d-47d9-a64f-9cf6854dd541")
+	)
+	(wire
+		(pts (xy 41.91 132.08) (xy 36.83 132.08))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f61f495d-f6ff-47d8-99a7-b3c14285cf86")
+	)
+	(wire
+		(pts (xy 59.69 121.92) (xy 64.77 121.92))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c32b2ecc-8842-4517-9623-3ad49dcbaa69")
+	)
+	(wire
+		(pts (xy 59.69 124.46) (xy 64.77 124.46))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "94193bc1-e8df-480e-8c8c-48b6a1253a8b")
+	)
+	(wire
+		(pts (xy 59.69 127) (xy 64.77 127))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7cde420d-c193-4c81-823b-725d72735ae8")
+	)
+	(wire
+		(pts (xy 59.69 129.54) (xy 64.77 129.54))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a5f13912-857d-4170-9a2f-7375cc79059f")
+	)
+	(wire
+		(pts (xy 59.69 132.08) (xy 64.77 132.08))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c1bb3e9b-0bf5-44cd-aa51-4dc422ef5e60")
+	)
+	(wire
+		(pts (xy 43.18 147.32) (xy 38.1 147.32))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4c7dac17-d259-46f4-bf07-63f0ea5d37f1")
+	)
+	(wire
+		(pts (xy 43.18 149.86) (xy 38.1 149.86))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "22d55ddb-339d-45b3-9ccc-a54894cfbac0")
+	)
+	(wire
+		(pts (xy 43.18 152.4) (xy 38.1 152.4))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5d7f70f9-fde2-4bfd-8b37-e29629bb5e14")
+	)
+	(wire
+		(pts (xy 43.18 154.94) (xy 38.1 154.94))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6ab9dd54-3cf2-40f4-9e4a-1e84938b23ac")
+	)
+	(wire
+		(pts (xy 43.18 157.48) (xy 38.1 157.48))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1d71cb31-8671-47c8-a8ae-9b89ca4b9e43")
+	)
+	(wire
+		(pts (xy 58.42 147.32) (xy 63.5 147.32))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cccf7e59-29a1-4040-b45e-7b9029b2a426")
+	)
+	(wire
+		(pts (xy 58.42 149.86) (xy 63.5 149.86))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7928b9f4-3f01-4f4b-9170-5da253d40e52")
+	)
+	(wire
+		(pts (xy 58.42 152.4) (xy 63.5 152.4))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0269c528-3cd2-4c81-911b-ff3142c992fc")
+	)
+	(wire
+		(pts (xy 58.42 154.94) (xy 63.5 154.94))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7f243de2-83ad-40c0-a82c-f01f79e95ea9")
+	)
+	(wire
+		(pts (xy 168.91 21.59) (xy 163.83 21.59))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "af5ca65e-524c-426d-961c-a41b44f6d405")
+	)
+	(wire
+		(pts (xy 168.91 24.13) (xy 163.83 24.13))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4a4ff99f-bee6-4979-b341-702577e60fd9")
+	)
+	(wire
+		(pts (xy 168.91 26.67) (xy 163.83 26.67))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "938ca04b-f4da-48f8-ab19-638d090a0d40")
+	)
+	(wire
+		(pts (xy 168.91 29.21) (xy 163.83 29.21))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3f9e9eef-5f37-4e28-9dfa-a2fa178fbb7b")
+	)
+	(wire
+		(pts (xy 168.91 31.75) (xy 163.83 31.75))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f5f182d6-74cc-40df-8930-8d9bc6b3325e")
+	)
+	(wire
+		(pts (xy 168.91 34.29) (xy 163.83 34.29))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ce8622bd-e2ba-45a3-afb1-46adbe02869a")
+	)
+	(wire
+		(pts (xy 168.91 36.83) (xy 163.83 36.83))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5a58a9dd-5ad3-491f-9912-5960abfc79fb")
+	)
+	(wire
+		(pts (xy 168.91 39.37) (xy 163.83 39.37))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f9e12e8d-a473-47b3-afd8-216d4d6d8713")
+	)
+	(wire
+		(pts (xy 168.91 41.91) (xy 163.83 41.91))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "91580fcc-66e8-4748-9e35-70d06f0b32e5")
+	)
+	(wire
+		(pts (xy 168.91 44.45) (xy 163.83 44.45))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "62321da5-7d3e-4873-9751-364b9610f8f8")
+	)
+	(wire
+		(pts (xy 168.91 46.99) (xy 163.83 46.99))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c6c5cd21-3d21-4bd2-9609-00cd78482794")
+	)
+	(wire
+		(pts (xy 168.91 49.53) (xy 163.83 49.53))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d4b4ddac-75d5-47a8-889f-6e04f9ec00ab")
+	)
+	(wire
+		(pts (xy 168.91 52.07) (xy 163.83 52.07))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "800072ca-d735-4ee0-b8c6-e3b075250c3c")
+	)
+	(wire
+		(pts (xy 168.91 54.61) (xy 163.83 54.61))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2a793da9-d0db-48f9-8f3b-04f0c11ef6b1")
+	)
+	(wire
+		(pts (xy 168.91 57.15) (xy 163.83 57.15))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f95fe002-7667-4a9d-881c-27acfde43294")
+	)
+	(wire
+		(pts (xy 168.91 59.69) (xy 163.83 59.69))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "12d1e648-cd77-4dd1-bd95-12c93bbc1713")
+	)
+	(wire
+		(pts (xy 168.91 62.23) (xy 163.83 62.23))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "66198980-c3c6-4f1d-acc4-a62729c29e5c")
+	)
+	(wire
+		(pts (xy 168.91 64.77) (xy 163.83 64.77))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ded67b39-0042-4ba7-951e-fc7f8768dc81")
+	)
+	(wire
+		(pts (xy 168.91 67.31) (xy 163.83 67.31))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9e702921-5324-41c9-9df1-16a2fb505889")
+	)
+	(wire
+		(pts (xy 168.91 69.85) (xy 163.83 69.85))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0c1a7ae6-46f9-4749-b0a5-6a3a06930fea")
+	)
+	(wire
+		(pts (xy 168.91 72.39) (xy 163.83 72.39))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "09c045c9-3228-4a3d-8225-cd20d8b80ed7")
+	)
+	(wire
+		(pts (xy 168.91 74.93) (xy 163.83 74.93))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "255627cc-15ee-4a22-b8a3-f8327e5d29b2")
+	)
+	(wire
+		(pts (xy 168.91 77.47) (xy 163.83 77.47))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c11f59f3-9885-4090-92ca-78caf3faa446")
+	)
+	(wire
+		(pts (xy 168.91 80.01) (xy 163.83 80.01))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dc6f18a1-8d87-4d96-af14-274912df82fb")
+	)
+	(wire
+		(pts (xy 186.69 21.59) (xy 191.77 21.59))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "927bc9db-da98-41af-b14e-fe61b3930a49")
+	)
+	(wire
+		(pts (xy 186.69 24.13) (xy 191.77 24.13))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5e5ccc57-a746-456e-9343-ed8477925da9")
+	)
+	(wire
+		(pts (xy 186.69 26.67) (xy 191.77 26.67))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0e0c7d75-372e-475e-a2f7-cd03f1599e6f")
+	)
+	(wire
+		(pts (xy 186.69 29.21) (xy 191.77 29.21))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cb652329-5bd8-4b6c-9932-a12c663cc209")
+	)
+	(wire
+		(pts (xy 186.69 31.75) (xy 191.77 31.75))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7fc09bd5-85cf-44fb-909f-0793d8c78d84")
+	)
+	(wire
+		(pts (xy 186.69 34.29) (xy 191.77 34.29))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "81ea9584-044a-4d5d-a1b7-59221ebb61f9")
+	)
+	(wire
+		(pts (xy 186.69 36.83) (xy 191.77 36.83))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "98853545-3545-4f1d-bc41-ed669853adef")
+	)
+	(wire
+		(pts (xy 186.69 39.37) (xy 191.77 39.37))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dc663a37-3bb8-456a-af9b-e25a32124228")
+	)
+	(wire
+		(pts (xy 186.69 41.91) (xy 191.77 41.91))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8326ee7d-a67c-4c30-86b7-0e2d18b4873b")
+	)
+	(wire
+		(pts (xy 186.69 44.45) (xy 191.77 44.45))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "047a2815-6061-403f-914d-f2c2038790ce")
+	)
+	(wire
+		(pts (xy 186.69 46.99) (xy 191.77 46.99))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9c102d1e-be5c-45a1-b012-3953bc99ff2e")
+	)
+	(wire
+		(pts (xy 186.69 49.53) (xy 191.77 49.53))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "690d15d2-c33a-4bdd-9c27-9e6faff8d672")
+	)
+	(wire
+		(pts (xy 186.69 52.07) (xy 191.77 52.07))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d6e75c8c-32a9-4c3b-9917-4ebc0ce206d7")
+	)
+	(wire
+		(pts (xy 186.69 54.61) (xy 191.77 54.61))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bbae70b4-03f9-48d6-8193-82734e4ca293")
+	)
+	(wire
+		(pts (xy 186.69 57.15) (xy 191.77 57.15))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dddafbe8-1b8b-42d6-848a-409ab5c88a56")
+	)
+	(wire
+		(pts (xy 186.69 59.69) (xy 191.77 59.69))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d2f92db3-4a6c-4233-b5aa-3b4f7802730e")
+	)
+	(wire
+		(pts (xy 186.69 62.23) (xy 191.77 62.23))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0adb354c-e679-4872-9b7e-7c8b09e19236")
+	)
+	(wire
+		(pts (xy 186.69 64.77) (xy 191.77 64.77))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "de729123-e97c-4d11-bd3a-200d9f28dcd9")
+	)
+	(wire
+		(pts (xy 186.69 67.31) (xy 191.77 67.31))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7cbc7a4b-720e-475d-b75e-55684d5f7ac7")
+	)
+	(wire
+		(pts (xy 186.69 69.85) (xy 191.77 69.85))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d9d4bd1c-8d81-49e3-8c11-379bf860a34c")
+	)
+	(wire
+		(pts (xy 186.69 72.39) (xy 191.77 72.39))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aee77e53-1330-4287-bc86-7fb12d3ee4ee")
+	)
+	(wire
+		(pts (xy 186.69 74.93) (xy 191.77 74.93))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fd0f092f-f51c-4d07-ad29-74fc33bc90f2")
+	)
+	(wire
+		(pts (xy 186.69 77.47) (xy 191.77 77.47))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "643e9a2e-0ed1-45db-9b23-6a790b4dfb9c")
+	)
+	(wire
+		(pts (xy 186.69 80.01) (xy 191.77 80.01))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e8444522-1a61-432c-95ba-2c3720559f6d")
+	)
+	(wire
+		(pts (xy 168.91 113.03) (xy 163.83 113.03))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d6f2cb57-2f8a-42fb-8b47-156dc98b2103")
+	)
+	(wire
+		(pts (xy 168.91 115.57) (xy 163.83 115.57))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "35cbcea5-e7bb-4c18-8c38-712ccd523c37")
+	)
+	(wire
+		(pts (xy 168.91 118.11) (xy 163.83 118.11))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bdd29f7f-b703-42b8-9d92-75d095ecabc2")
+	)
+	(wire
+		(pts (xy 168.91 120.65) (xy 163.83 120.65))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "33f2c89e-9204-4778-bb49-a17ea52c32b2")
+	)
+	(wire
+		(pts (xy 168.91 123.19) (xy 163.83 123.19))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "03fd7b99-abc4-4916-bbf5-e58a2c01f860")
+	)
+	(wire
+		(pts (xy 168.91 125.73) (xy 163.83 125.73))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1c64170a-a43e-4b87-bcbf-ab681883d831")
+	)
+	(wire
+		(pts (xy 168.91 128.27) (xy 163.83 128.27))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f6efa50d-4907-4881-a623-17ef5da5b319")
+	)
+	(wire
+		(pts (xy 168.91 130.81) (xy 163.83 130.81))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4eaba313-381b-486e-af09-5cda95c643fa")
+	)
+	(wire
+		(pts (xy 168.91 133.35) (xy 163.83 133.35))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "351eeb91-beb1-4c4d-9f46-49f069605280")
+	)
+	(wire
+		(pts (xy 168.91 135.89) (xy 163.83 135.89))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a0c5ccb1-b952-4c85-8bd7-d4563702032a")
+	)
+	(wire
+		(pts (xy 168.91 138.43) (xy 163.83 138.43))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9908494c-db93-4eba-9ba4-6f03366668cc")
+	)
+	(wire
+		(pts (xy 168.91 140.97) (xy 163.83 140.97))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7020be15-c6ee-4674-bd2a-d7cb5e1f1293")
+	)
+	(wire
+		(pts (xy 186.69 113.03) (xy 191.77 113.03))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "22ccf927-fe08-4587-9d96-b3913c5bb3d3")
+	)
+	(wire
+		(pts (xy 186.69 115.57) (xy 191.77 115.57))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "caeaa8ea-51c2-497d-b494-c92896f99ded")
+	)
+	(wire
+		(pts (xy 186.69 118.11) (xy 191.77 118.11))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e10ec13a-6581-44d0-b96e-e80e2039ab5f")
+	)
+	(wire
+		(pts (xy 186.69 120.65) (xy 191.77 120.65))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fefa3310-dfe3-4113-9055-3b038d3882a1")
+	)
+	(wire
+		(pts (xy 186.69 123.19) (xy 191.77 123.19))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c8b18518-0000-4508-bf99-87a042579f61")
+	)
+	(wire
+		(pts (xy 186.69 125.73) (xy 191.77 125.73))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1039677e-5f75-43ac-afd5-aa967147b434")
+	)
+	(wire
+		(pts (xy 186.69 128.27) (xy 191.77 128.27))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "17b7a9af-483a-4e98-80f2-e790b0e36c24")
+	)
+	(wire
+		(pts (xy 186.69 130.81) (xy 191.77 130.81))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1765eda3-1f8a-4318-a477-63e811863109")
+	)
+	(wire
+		(pts (xy 186.69 133.35) (xy 191.77 133.35))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7dc96030-325d-4fce-af63-5a4c9e24b56e")
+	)
+	(wire
+		(pts (xy 186.69 135.89) (xy 191.77 135.89))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0e68e76f-8aa4-41eb-a8e3-42abbb59e9dc")
+	)
+	(wire
+		(pts (xy 186.69 138.43) (xy 191.77 138.43))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "70824e24-aeb5-4c90-915d-7688d9ef0688")
+	)
+	(wire
+		(pts (xy 186.69 140.97) (xy 191.77 140.97))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6b66d5ea-88c5-4232-a78d-95ea953adb5d")
+	)
+	(wire
+		(pts (xy 168.91 160.02) (xy 163.83 160.02))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "607e1aca-1578-4c07-97b1-e579dad365fa")
+	)
+	(wire
+		(pts (xy 168.91 162.56) (xy 163.83 162.56))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "977dd254-5efe-42c0-a3cf-a282e07a6cb6")
+	)
+	(wire
+		(pts (xy 168.91 165.1) (xy 163.83 165.1))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "640dbb64-bea2-4d6e-a706-3a6bfc15c2e1")
+	)
+	(wire
+		(pts (xy 168.91 167.64) (xy 163.83 167.64))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ad1c54c2-f6c1-4236-a501-d8c7087a1691")
+	)
+	(wire
+		(pts (xy 168.91 170.18) (xy 163.83 170.18))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4894cba4-b32e-43a5-8cb3-e0fce40b8734")
+	)
+	(wire
+		(pts (xy 168.91 172.72) (xy 163.83 172.72))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f5f21f38-9869-4d33-9408-fb9e85e06ac7")
+	)
+	(wire
+		(pts (xy 168.91 175.26) (xy 163.83 175.26))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e6fec390-9097-408c-92a0-17baff692804")
+	)
+	(wire
+		(pts (xy 168.91 177.8) (xy 163.83 177.8))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dd652539-a982-4e09-961d-402d343edb3c")
+	)
+	(wire
+		(pts (xy 168.91 180.34) (xy 163.83 180.34))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "72fc176d-d097-4883-a1e5-7a361af1e997")
+	)
+	(wire
+		(pts (xy 168.91 182.88) (xy 163.83 182.88))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bc0417ec-e01c-488d-92ab-9586519953d5")
+	)
+	(wire
+		(pts (xy 168.91 185.42) (xy 163.83 185.42))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "96fe4cdd-e310-48f4-a684-76597d0cb255")
+	)
+	(wire
+		(pts (xy 168.91 187.96) (xy 163.83 187.96))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "02cfccd4-47f8-4fbd-ba06-775b6c606265")
+	)
+	(wire
+		(pts (xy 168.91 190.5) (xy 163.83 190.5))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4e9e5748-9d91-44dd-89bc-a8b4a3cb371a")
+	)
+	(wire
+		(pts (xy 168.91 193.04) (xy 163.83 193.04))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c6d1a465-a2d2-43d2-8631-af2bff412b2e")
+	)
+	(wire
+		(pts (xy 168.91 195.58) (xy 163.83 195.58))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "835f1800-26c8-45c7-9bb4-100693c7f77c")
+	)
+	(wire
+		(pts (xy 168.91 198.12) (xy 163.83 198.12))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "029de57c-d6c7-4620-9136-b37f7133b52a")
+	)
+	(wire
+		(pts (xy 168.91 200.66) (xy 163.83 200.66))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "79bd900d-1f9a-481e-be3c-3b473118b2eb")
+	)
+	(wire
+		(pts (xy 168.91 203.2) (xy 163.83 203.2))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e10fd7c1-8cf7-43a4-8195-1814b551bdc7")
+	)
+	(wire
+		(pts (xy 168.91 205.74) (xy 163.83 205.74))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "60a9edb7-86bc-42e1-93bf-b0e52e8ac9fa")
+	)
+	(wire
+		(pts (xy 168.91 208.28) (xy 163.83 208.28))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e410c2b3-78fd-4bfa-a78b-159fb0489bb8")
+	)
+	(wire
+		(pts (xy 168.91 210.82) (xy 163.83 210.82))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ff121c8a-94ee-498a-bdf0-6d08573a3cf4")
+	)
+	(wire
+		(pts (xy 168.91 213.36) (xy 163.83 213.36))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4ec0825b-bfa1-4750-a8ad-356e7988562d")
+	)
+	(wire
+		(pts (xy 168.91 215.9) (xy 163.83 215.9))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f97716e9-d123-4b9b-afca-0bcf0ab82a5f")
+	)
+	(wire
+		(pts (xy 168.91 218.44) (xy 163.83 218.44))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3d1b2e05-3550-4067-81bb-7c4b6ccb0933")
+	)
+	(wire
+		(pts (xy 168.91 220.98) (xy 163.83 220.98))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9c172bb7-99af-46b7-a56a-c0906822faf1")
+	)
+	(wire
+		(pts (xy 186.69 160.02) (xy 191.77 160.02))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "09f6f3f9-bf33-40af-aef4-571821d468dc")
+	)
+	(wire
+		(pts (xy 186.69 162.56) (xy 191.77 162.56))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c8cb9794-855c-4078-9a9b-d907eead48e9")
+	)
+	(wire
+		(pts (xy 186.69 165.1) (xy 191.77 165.1))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e6c6444a-57b2-47ab-94fd-99d01e6c168f")
+	)
+	(wire
+		(pts (xy 186.69 167.64) (xy 191.77 167.64))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bbb8d696-8798-4b68-a84f-8af78dc67ca8")
+	)
+	(wire
+		(pts (xy 186.69 170.18) (xy 191.77 170.18))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "62b069a7-3d46-4caa-b835-39bbb6dd4319")
+	)
+	(wire
+		(pts (xy 186.69 172.72) (xy 191.77 172.72))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "370a9c05-e2d9-49e0-858a-d9c2ced9c370")
+	)
+	(wire
+		(pts (xy 186.69 175.26) (xy 191.77 175.26))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7ca952e6-9cd7-4b6e-939c-7b361b00ed09")
+	)
+	(wire
+		(pts (xy 186.69 177.8) (xy 191.77 177.8))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0824ec37-7104-4925-bc77-549d24e241ff")
+	)
+	(wire
+		(pts (xy 186.69 180.34) (xy 191.77 180.34))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "653316d1-3c82-40a4-9082-b37f0bfd3982")
+	)
+	(wire
+		(pts (xy 186.69 182.88) (xy 191.77 182.88))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8f423b91-1233-45fc-9309-e23f5f24979c")
+	)
+	(wire
+		(pts (xy 186.69 185.42) (xy 191.77 185.42))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "28f062af-000b-4d7d-a0a1-4e23d406bf08")
+	)
+	(wire
+		(pts (xy 186.69 187.96) (xy 191.77 187.96))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5192af6b-0b3c-4abe-9430-3557a993c938")
+	)
+	(wire
+		(pts (xy 186.69 190.5) (xy 191.77 190.5))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c69f2552-5324-4fd5-84e6-4981011f9799")
+	)
+	(wire
+		(pts (xy 186.69 193.04) (xy 191.77 193.04))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2f9f9c86-32f7-4f50-bb97-6a279b2fbd18")
+	)
+	(wire
+		(pts (xy 186.69 195.58) (xy 191.77 195.58))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3c9c7cae-a0f2-4704-8cb3-fe0ba468654b")
+	)
+	(wire
+		(pts (xy 186.69 198.12) (xy 191.77 198.12))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "980e4126-40aa-4ac8-8b4c-147fcfd42f58")
+	)
+	(wire
+		(pts (xy 186.69 200.66) (xy 191.77 200.66))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "de94fea3-09e9-41d1-8697-4d8b653563bd")
+	)
+	(wire
+		(pts (xy 186.69 203.2) (xy 191.77 203.2))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6e4c5c3d-9894-4322-a2b8-71e1bbfd865b")
+	)
+	(wire
+		(pts (xy 186.69 205.74) (xy 191.77 205.74))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "caf00540-91d8-4c95-9602-2b86beb60885")
+	)
+	(wire
+		(pts (xy 186.69 208.28) (xy 191.77 208.28))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "35f8a704-a24a-4dbd-be13-3b18f738bf38")
+	)
+	(wire
+		(pts (xy 186.69 210.82) (xy 191.77 210.82))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "eb144d4b-794f-47ea-83c2-d35fd72d76ce")
+	)
+	(wire
+		(pts (xy 186.69 213.36) (xy 191.77 213.36))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5f637157-d17e-4f09-8d0c-27d0efcd719e")
+	)
+	(wire
+		(pts (xy 186.69 215.9) (xy 191.77 215.9))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "913308ff-b57e-4f75-9571-d656722436d6")
+	)
+	(wire
+		(pts (xy 186.69 218.44) (xy 191.77 218.44))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b887f94d-584a-4fa5-aa66-08fa4559e0a2")
+	)
+	(wire
+		(pts (xy 168.91 237.49) (xy 163.83 237.49))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e54841bd-07ad-40e9-a90b-647fc414491f")
+	)
+	(wire
+		(pts (xy 168.91 240.03) (xy 163.83 240.03))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4dbc677f-bc2a-47de-818b-9facd94bd6d0")
+	)
+	(wire
+		(pts (xy 168.91 242.57) (xy 163.83 242.57))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0e636471-317a-4d17-9777-aa2a1fdcc7ea")
+	)
+	(wire
+		(pts (xy 168.91 245.11) (xy 163.83 245.11))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fd8ee3eb-aaf3-43c9-a17e-5c6ebc2ae545")
+	)
+	(wire
+		(pts (xy 168.91 247.65) (xy 163.83 247.65))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a44e9c33-b463-4164-ba1e-ba7928b9258f")
+	)
+	(wire
+		(pts (xy 168.91 250.19) (xy 163.83 250.19))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d26322f1-adc3-4dd8-9564-fe9782a3385c")
+	)
+	(wire
+		(pts (xy 168.91 252.73) (xy 163.83 252.73))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9de56dde-9dbb-4223-a745-161303b19785")
+	)
+	(wire
+		(pts (xy 168.91 255.27) (xy 163.83 255.27))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "011a86f4-be59-465d-bb75-976c1c588487")
+	)
+	(wire
+		(pts (xy 168.91 257.81) (xy 163.83 257.81))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7e169878-7011-4267-a4e4-8294d65bf315")
+	)
+	(wire
+		(pts (xy 168.91 260.35) (xy 163.83 260.35))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "94c0833d-34eb-49c1-a29a-d266f4602d77")
+	)
+	(wire
+		(pts (xy 168.91 262.89) (xy 163.83 262.89))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ec0b2886-f225-40cd-a05d-758506cdca3d")
+	)
+	(wire
+		(pts (xy 168.91 265.43) (xy 163.83 265.43))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ea3b0a4b-94c6-48c9-b0cc-615f2b9bd79d")
+	)
+	(wire
+		(pts (xy 168.91 267.97) (xy 163.83 267.97))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ae057dda-06e8-4df3-9c89-fef417aa5218")
+	)
+	(wire
+		(pts (xy 168.91 270.51) (xy 163.83 270.51))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "33b248d0-b317-4f0b-b90e-b87e8499e9f7")
+	)
+	(wire
+		(pts (xy 168.91 273.05) (xy 163.83 273.05))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d0accde2-ae79-4289-9f4a-596e4458a7f6")
+	)
+	(wire
+		(pts (xy 168.91 275.59) (xy 163.83 275.59))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cfd49ad1-c3f8-47a0-93fe-429f36a2c834")
+	)
+	(wire
+		(pts (xy 168.91 278.13) (xy 163.83 278.13))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fe2b9292-1843-4771-bc72-504c16504d5b")
+	)
+	(wire
+		(pts (xy 168.91 280.67) (xy 163.83 280.67))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0ada3b18-982e-4c6f-8603-e4e3e1225c48")
+	)
+	(wire
+		(pts (xy 168.91 283.21) (xy 163.83 283.21))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "42b964ab-6483-435b-b293-a8bf7a3fa222")
+	)
+	(wire
+		(pts (xy 168.91 285.75) (xy 163.83 285.75))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ea17c865-35da-466a-b7a4-6c1ad51c2feb")
+	)
+	(wire
+		(pts (xy 168.91 288.29) (xy 163.83 288.29))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a5aa2a34-696d-47df-b8e8-440491dcd6ae")
+	)
+	(wire
+		(pts (xy 168.91 290.83) (xy 163.83 290.83))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "92c9d558-5498-4e99-9ef2-e669885a1a49")
+	)
+	(wire
+		(pts (xy 168.91 293.37) (xy 163.83 293.37))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e6ff5dfe-3a75-4cc3-8b12-19fc588c3589")
+	)
+	(wire
+		(pts (xy 168.91 295.91) (xy 163.83 295.91))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e8564c5a-8696-4437-a60c-e8a039a8b7a8")
+	)
+	(wire
+		(pts (xy 186.69 237.49) (xy 191.77 237.49))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4994020e-a62f-48da-9443-787617f46f50")
+	)
+	(wire
+		(pts (xy 186.69 240.03) (xy 191.77 240.03))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bedb015e-d111-47bf-b216-d2f4c187c749")
+	)
+	(wire
+		(pts (xy 186.69 242.57) (xy 191.77 242.57))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6fbed61d-9fed-4452-96f6-a809cd889215")
+	)
+	(wire
+		(pts (xy 186.69 245.11) (xy 191.77 245.11))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2a89bf29-4aef-40ec-aad7-615b7b791865")
+	)
+	(wire
+		(pts (xy 186.69 247.65) (xy 191.77 247.65))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1b27305a-4893-43fb-8e1b-c9216e8537c2")
+	)
+	(wire
+		(pts (xy 186.69 250.19) (xy 191.77 250.19))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3be7349f-ea23-469f-bfc0-dc4409802b99")
+	)
+	(wire
+		(pts (xy 186.69 252.73) (xy 191.77 252.73))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b2275a71-90f5-4c62-a92b-327f5ae9d99c")
+	)
+	(wire
+		(pts (xy 186.69 255.27) (xy 191.77 255.27))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "27941f28-668a-440b-bf3a-fe0a50710aa8")
+	)
+	(wire
+		(pts (xy 186.69 257.81) (xy 191.77 257.81))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "96dfe9e9-d7d3-4ad5-98a2-42687b0472c1")
+	)
+	(wire
+		(pts (xy 186.69 260.35) (xy 191.77 260.35))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c0d85d61-32fe-4bfb-aeaf-af858bfa6c47")
+	)
+	(wire
+		(pts (xy 186.69 262.89) (xy 191.77 262.89))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "69c410b0-4905-4321-bd6d-511828d210f5")
+	)
+	(wire
+		(pts (xy 186.69 265.43) (xy 191.77 265.43))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "efd3164f-6441-4943-b93d-67e780d56a25")
+	)
+	(wire
+		(pts (xy 186.69 267.97) (xy 191.77 267.97))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "22220e8f-9067-483c-80be-8b856114424e")
+	)
+	(wire
+		(pts (xy 186.69 270.51) (xy 191.77 270.51))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5ee30d14-1f49-402d-8c2a-a5306b03ee3f")
+	)
+	(wire
+		(pts (xy 186.69 273.05) (xy 191.77 273.05))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "23dccd40-2fd5-4995-9872-96ca80dd7a2c")
+	)
+	(wire
+		(pts (xy 186.69 275.59) (xy 191.77 275.59))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a48fa92c-b8e2-4460-a465-a90e238f2a6b")
+	)
+	(wire
+		(pts (xy 186.69 278.13) (xy 191.77 278.13))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "80e40071-6bfc-40d2-856e-8f901fc7b6f4")
+	)
+	(wire
+		(pts (xy 186.69 280.67) (xy 191.77 280.67))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "88aef194-beaa-4d2f-99cc-8cafd12ae252")
+	)
+	(wire
+		(pts (xy 186.69 283.21) (xy 191.77 283.21))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "40f7b7fe-7282-4ef3-88d0-f0b75eb09835")
+	)
+	(wire
+		(pts (xy 186.69 285.75) (xy 191.77 285.75))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d813491d-b09e-4f00-b020-8027b455d500")
+	)
+	(wire
+		(pts (xy 186.69 288.29) (xy 191.77 288.29))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b14b892c-ffa2-4d1e-ad13-c056a03accc8")
+	)
+	(wire
+		(pts (xy 186.69 290.83) (xy 191.77 290.83))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2a0a8c40-a72f-46f9-b833-b6c9b8493e2c")
+	)
+	(wire
+		(pts (xy 186.69 293.37) (xy 191.77 293.37))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "eeb18ea4-02f4-4566-9c95-f96e49790418")
+	)
+	(wire
+		(pts (xy 186.69 295.91) (xy 191.77 295.91))
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dc2b54f7-e8a0-4807-957c-a634f343360b")
+	)
+	(global_label "+1V8" (shape bidirectional) (at 36.83 21.59 0) (fields_autoplaced yes)
 		(effects
 			(font
 				(size 1.27 1.27)
 			)
 			(justify left)
 		)
-		(uuid "a6b6bbb8-c2fb-466b-babf-98f67499f2c5")
+		(uuid "e4f4343f-6e48-4b68-8e5f-119ad6065a05")
+	)
+	(global_label "GND" (shape bidirectional) (at 36.83 24.13 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "5abf195d-514b-4d98-aaf7-39f8f361dc46")
+	)
+	(global_label "GND" (shape bidirectional) (at 36.83 26.67 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "e3856f2b-9f91-4482-9c67-fe92435d4dcc")
+	)
+	(global_label "GND" (shape bidirectional) (at 36.83 29.21 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "c604a485-49f8-44de-8028-98a89b4543d5")
+	)
+	(global_label "GND" (shape bidirectional) (at 36.83 31.75 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "84b6765f-639f-4692-a6ae-3d8a902c46bb")
+	)
+	(global_label "GND" (shape bidirectional) (at 36.83 34.29 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "6b261b6a-1e2c-4aa4-8a02-575dbeaca172")
+	)
+	(global_label "GND" (shape bidirectional) (at 36.83 36.83 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "32db6139-9f83-4759-b7e6-9a0d7e0c102c")
+	)
+	(global_label "GND" (shape bidirectional) (at 36.83 39.37 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "daf26e10-d23e-4c87-a040-df3963167676")
+	)
+	(global_label "GND" (shape bidirectional) (at 36.83 41.91 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "4597c1a6-111f-4b20-91c6-62ea8e9bb203")
+	)
+	(global_label "GND" (shape bidirectional) (at 36.83 44.45 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "551b5c20-7916-427e-9eff-8d0f8590c139")
+	)
+	(global_label "GND" (shape bidirectional) (at 36.83 46.99 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "817021b6-ef5b-4cfe-8230-03c4bcceff69")
+	)
+	(global_label "+1V2" (shape bidirectional) (at 36.83 49.53 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "b6222ec9-64a1-4348-804a-0211a37e512f")
+	)
+	(global_label "GND" (shape bidirectional) (at 36.83 52.07 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "37a519f7-bbb4-40ff-8003-524557e4ed0a")
+	)
+	(global_label "GND" (shape bidirectional) (at 36.83 54.61 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "8ca1b303-4a11-4bcd-b0c6-da26ce6e8abb")
+	)
+	(global_label "GND" (shape bidirectional) (at 36.83 57.15 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f97f5214-b7bc-4fbd-9fbb-19f8b79fec28")
+	)
+	(global_label "GND" (shape bidirectional) (at 36.83 59.69 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "9b9ab93a-efd7-4fb7-b54b-a20d0a5f1fc7")
+	)
+	(global_label "GND" (shape bidirectional) (at 36.83 62.23 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "ce252311-d19d-4fbe-8e88-9a059216d95c")
+	)
+	(global_label "GND" (shape bidirectional) (at 36.83 64.77 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "405e125a-f85a-4610-a153-7cb1901f75a6")
+	)
+	(global_label "GND" (shape bidirectional) (at 36.83 67.31 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "fe69b431-ff9b-4d93-a582-e3e4f9366a99")
+	)
+	(global_label "GND" (shape bidirectional) (at 36.83 69.85 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "0c88b8e9-ef86-4e2f-bbbb-a7909ea29aa5")
+	)
+	(global_label "GND" (shape bidirectional) (at 36.83 72.39 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "32f15e2b-beb3-4838-877c-5f9c022a47eb")
+	)
+	(global_label "GND" (shape bidirectional) (at 36.83 74.93 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "b2810eb5-a26c-4cca-aa77-accc8d2d6891")
+	)
+	(global_label "GND" (shape bidirectional) (at 36.83 77.47 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "0837a445-0b15-4ac0-b757-fc0de4b3985b")
+	)
+	(global_label "GND" (shape bidirectional) (at 36.83 80.01 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "17c56ed4-d32e-4338-a2bb-f0689d24218e")
+	)
+	(global_label "DQ0" (shape bidirectional) (at 64.77 21.59 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "a83184bd-b55c-4a0e-9c70-fd963116fcd5")
+	)
+	(global_label "DQ1" (shape bidirectional) (at 64.77 24.13 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "a2999881-636b-4aa7-a698-ae1ad7d52c5c")
+	)
+	(global_label "DQ2" (shape bidirectional) (at 64.77 26.67 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "8dcd3a8a-d96d-4540-8085-f4ae687ad858")
+	)
+	(global_label "DQ3" (shape bidirectional) (at 64.77 29.21 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "65a8ef77-781f-4116-a015-82996a7c1b83")
+	)
+	(global_label "DM0" (shape bidirectional) (at 64.77 31.75 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4bc052c6-aaa3-47ab-a702-d523434994d2")
+	)
+	(global_label "DQS_P" (shape bidirectional) (at 64.77 34.29 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4408057c-f10c-4db7-88ee-214b72bac9b1")
+	)
+	(global_label "DQS_N" (shape bidirectional) (at 64.77 36.83 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "586cd8ac-55cf-4408-b762-1035030e081d")
+	)
+	(global_label "DQ4" (shape bidirectional) (at 64.77 39.37 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "53eee827-4c57-4a36-9291-6e41c70e181b")
+	)
+	(global_label "DQ5" (shape bidirectional) (at 64.77 41.91 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "afb1e6ee-20eb-44b1-bad7-1d79ab920c0c")
+	)
+	(global_label "DQ6" (shape bidirectional) (at 64.77 44.45 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "b5ccb89e-fd69-4902-9b89-fbbc1713ae83")
+	)
+	(global_label "DQ7" (shape bidirectional) (at 64.77 46.99 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "1e266367-6ac1-4f97-861b-199425aae408")
+	)
+	(global_label "+1V2" (shape bidirectional) (at 64.77 49.53 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "d5bb32c0-a4f0-4225-adc8-bf216bfca643")
+	)
+	(global_label "GND" (shape bidirectional) (at 64.77 52.07 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "e4df9b27-d73d-40db-804d-a3f5abb1e42c")
+	)
+	(global_label "GND" (shape bidirectional) (at 64.77 54.61 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "02a69947-dfdb-4785-989d-2c250aba6a87")
+	)
+	(global_label "GND" (shape bidirectional) (at 64.77 57.15 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "b0a4afab-d028-4d99-903e-b72a527779e8")
+	)
+	(global_label "GND" (shape bidirectional) (at 64.77 59.69 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "62155214-f4e2-4426-956e-0779d395cbaa")
+	)
+	(global_label "GND" (shape bidirectional) (at 64.77 62.23 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "ebd82f8c-9a8b-442f-95d1-ef1e2217cd9d")
+	)
+	(global_label "GND" (shape bidirectional) (at 64.77 64.77 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "898160eb-605d-42a9-b922-4d55ac52d84b")
+	)
+	(global_label "GND" (shape bidirectional) (at 64.77 67.31 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "0674302e-1fde-4dff-b51e-dcae1b4e1725")
+	)
+	(global_label "GND" (shape bidirectional) (at 64.77 69.85 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "28a26f00-9acd-4f54-9af8-295cef820e94")
+	)
+	(global_label "GND" (shape bidirectional) (at 64.77 72.39 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "5ca6118f-3ad1-4b0b-b0db-a4159b58a6d6")
+	)
+	(global_label "GND" (shape bidirectional) (at 64.77 74.93 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "ef8447f6-feb8-4d00-afa2-f576e732fe58")
+	)
+	(global_label "GND" (shape bidirectional) (at 64.77 77.47 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "d54fe6b4-5532-4e99-8be3-cb674c0d92f0")
+	)
+	(global_label "GND" (shape bidirectional) (at 64.77 80.01 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "76c2f8f4-84ae-4763-a673-cb57957d60c0")
+	)
+	(global_label "MIPI_CLK_P" (shape bidirectional) (at 36.83 97.79 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "afde86f3-e981-44f8-8c13-f93c90b09a4c")
+	)
+	(global_label "MIPI_CLK_N" (shape bidirectional) (at 36.83 100.33 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "4d869639-1fbc-43e3-8c7e-ee18d058aa37")
+	)
+	(global_label "MIPI_DAT0_P" (shape bidirectional) (at 36.83 102.87 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "06331cea-78cb-4178-a2a5-4f2d4a58b71a")
+	)
+	(global_label "MIPI_DAT0_N" (shape bidirectional) (at 36.83 105.41 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "492df978-cdda-44f5-9950-ff24fb6bf013")
+	)
+	(global_label "MIPI_DAT1_P" (shape bidirectional) (at 64.77 97.79 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4d011ac1-cac5-41f6-b1ee-41d3525f5ed1")
+	)
+	(global_label "MIPI_DAT1_N" (shape bidirectional) (at 64.77 100.33 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "bf02cf7f-d2d6-469f-b834-d448899ff65e")
+	)
+	(global_label "GND" (shape bidirectional) (at 64.77 102.87 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "26be2f49-7857-4673-a10c-bba602df76b7")
+	)
+	(global_label "GND" (shape bidirectional) (at 64.77 105.41 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "63b4b93c-13ce-4229-8b77-9d9a3c7ca15b")
+	)
+	(global_label "TMDS_D0_P" (shape bidirectional) (at 36.83 121.92 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "27e694d2-9837-4885-a739-894fcfbdcb36")
+	)
+	(global_label "TMDS_D0_N" (shape bidirectional) (at 36.83 124.46 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "c6353ebd-09c6-4343-9c36-9349f30659d9")
+	)
+	(global_label "GND" (shape bidirectional) (at 36.83 127 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "e541f8d2-dc1d-4c41-9f29-45755731e05a")
+	)
+	(global_label "TMDS_D1_P" (shape bidirectional) (at 36.83 129.54 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "6543329a-e2be-4404-9024-5aae1aacb925")
+	)
+	(global_label "TMDS_D1_N" (shape bidirectional) (at 36.83 132.08 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "2534edee-4782-44eb-9c84-55309d8b892f")
+	)
+	(global_label "GND" (shape bidirectional) (at 64.77 121.92 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "97a55ff6-7dfe-4ccb-9b4b-f095a2cf4126")
+	)
+	(global_label "TMDS_D2_P" (shape bidirectional) (at 64.77 124.46 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "59f0bfac-34e5-4f85-a4f8-715a5d7f9499")
+	)
+	(global_label "TMDS_D2_N" (shape bidirectional) (at 64.77 127 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "7a65ff47-d67d-4e48-bcc5-b7d1de8bf72e")
+	)
+	(global_label "GND" (shape bidirectional) (at 64.77 129.54 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "09351672-3a11-4c5f-be1c-a70f2169b506")
+	)
+	(global_label "GND" (shape bidirectional) (at 64.77 132.08 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "5c314cb6-e403-4188-9746-33a6300208fb")
+	)
+	(global_label "GND" (shape bidirectional) (at 38.1 147.32 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "4b2f1cdf-80a1-43bf-bad3-8b3db30b75c3")
+	)
+	(global_label "A0" (shape bidirectional) (at 38.1 149.86 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "44596396-c164-4d9a-a98b-9df12e3041a3")
+	)
+	(global_label "A1" (shape bidirectional) (at 38.1 152.4 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "bd083ad4-3c62-4ab6-bbc3-f6c74e9193cf")
+	)
+	(global_label "A2" (shape bidirectional) (at 38.1 154.94 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "da6a421a-8623-416a-b1c7-39d6129706c6")
+	)
+	(global_label "A3" (shape bidirectional) (at 38.1 157.48 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "23b34155-76a3-46e5-ac11-db4b4e84c7e8")
+	)
+	(global_label "A4" (shape bidirectional) (at 63.5 147.32 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "ff3d5051-5e12-492a-8372-1419b52f12e7")
+	)
+	(global_label "A5" (shape bidirectional) (at 63.5 149.86 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "ca225ebe-7e17-4788-a9ae-6c310cec1b38")
+	)
+	(global_label "A6" (shape bidirectional) (at 63.5 152.4 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "fba77c67-c2aa-4679-9673-d7ed65191faa")
+	)
+	(global_label "A7" (shape bidirectional) (at 63.5 154.94 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "abfeaa81-f2fd-4eb9-bce5-f981536f5e4a")
+	)
+	(global_label "DQ0" (shape bidirectional) (at 163.83 21.59 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "76313088-45e7-4e5e-bace-0938485bdf63")
+	)
+	(global_label "DQ1" (shape bidirectional) (at 163.83 24.13 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "5f59828e-4705-49e3-81ed-3af391b947de")
+	)
+	(global_label "DQ2" (shape bidirectional) (at 163.83 26.67 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "8b3059ef-3bfa-42fb-8c20-259e6f588582")
+	)
+	(global_label "DQ3" (shape bidirectional) (at 163.83 29.21 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f33a0208-7f15-437f-876b-4404bbe61154")
+	)
+	(global_label "DM0" (shape bidirectional) (at 163.83 31.75 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "bcb3f675-1333-49a1-a94c-57c3214cc25b")
+	)
+	(global_label "DQS_P" (shape bidirectional) (at 163.83 34.29 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "711b5cd3-e9a3-4e39-8fe5-c0e11487b537")
+	)
+	(global_label "DQS_N" (shape bidirectional) (at 163.83 36.83 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "94dfc4a2-1b0d-4b12-bd98-8592dc706b07")
+	)
+	(global_label "DQ4" (shape bidirectional) (at 163.83 39.37 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "e5cd7d61-0420-4ce0-a7fd-2219488c806b")
+	)
+	(global_label "DQ5" (shape bidirectional) (at 163.83 41.91 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "1b520448-02cd-40a6-9a05-2176b2454021")
+	)
+	(global_label "DQ6" (shape bidirectional) (at 163.83 44.45 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "6db911dc-8833-4acd-8d03-e1d5906c2898")
+	)
+	(global_label "DQ7" (shape bidirectional) (at 163.83 46.99 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "7fef5399-2479-4988-8a3d-59fb7591cfb6")
+	)
+	(global_label "+1V2" (shape bidirectional) (at 163.83 49.53 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "ecce957a-e66a-4f45-a3bb-5a97ad370648")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 52.07 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f73a0620-1f9b-4db4-b141-a1015359dc06")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 54.61 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "3a9042c6-4dcf-4b1f-be42-82d8849525f5")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 57.15 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "eb681909-b70d-4fbb-a42a-b59df66af1d9")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 59.69 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "c360d131-2459-461b-834b-d5a5c019ae0f")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 62.23 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "beb2787c-37e2-4829-abbe-31de0ce8a633")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 64.77 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f4524843-4287-46a8-86e6-4d4fa0d4ef89")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 67.31 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "1be2fea4-1bd3-47d9-b412-c369e522ab22")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 69.85 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "fd3b4504-4b62-4110-8908-6fdf290de586")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 72.39 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "01334f6f-b07e-4a72-967d-d262744250cf")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 74.93 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "a2ea59d9-327e-4e29-a43f-e5af52ac6e2e")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 77.47 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "5bbeba88-2653-499c-9d59-e78fd4ba2fbe")
+	)
+	(global_label "+1V2" (shape bidirectional) (at 163.83 80.01 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "3bbb019d-c6ac-478b-9551-4e4dc26921af")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 21.59 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "04cfb8e0-6ab5-4f00-b6a5-b0421f85656b")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 24.13 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "576c1bb8-7d9f-4dc4-a0c5-ef0d7eb08705")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 26.67 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "07d5e432-af51-4dcd-9667-ad8779f10096")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 29.21 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "3895722d-a4a3-4e38-af64-6e67ef6ec85c")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 31.75 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "52a8f3ab-2bd0-4ecf-b013-58ea1c285aab")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 34.29 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "98c13bd4-effb-432f-b23d-b7b3f98535d4")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 36.83 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "f17f324d-e74a-4c0a-bdc3-edce0330859e")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 39.37 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "c807849c-243f-4d47-8853-e939cb6798e0")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 41.91 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "fc1c16d4-59a5-4380-82e0-070c5f3fcba8")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 44.45 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "6b49dcca-0592-4049-906e-6357a9b45b66")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 46.99 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "eeb5f8df-283d-469a-bad4-b9e854d74915")
+	)
+	(global_label "+1V8" (shape bidirectional) (at 191.77 49.53 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "3f376617-c2bd-4af0-9400-7ac3d0bd2426")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 52.07 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "1d8b1931-36f6-4a73-a0a7-4dd72041e7d7")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 54.61 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "6db42042-0752-4e89-9482-4df35acbb8b9")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 57.15 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "7ccee6f8-3193-42bb-a093-f67b810ab4e1")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 59.69 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "f254338e-5d9b-4006-a8c0-4ba3c7e27c46")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 62.23 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "5bafce01-386e-411a-b982-20e622d6d3a1")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 64.77 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "413f831c-80f6-479e-871f-8fd177eef123")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 67.31 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "85e2f1cf-b95b-4edd-84e3-4d55318de2bc")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 69.85 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4bc7648b-27af-4414-9d16-a107081b5a86")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 72.39 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "0862cb44-c266-403a-8dbe-f8283ae06d55")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 74.93 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "0cef64c0-fc4a-4e31-8286-1c0257f642b1")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 77.47 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "543c80bc-17ec-4f58-83ac-13640d1cc312")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 80.01 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "dae5d5e5-f1c4-47a6-9e36-5b0f153fb832")
+	)
+	(global_label "MIPI_CLK_P" (shape bidirectional) (at 163.83 113.03 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "15d716ba-6d41-42ff-9e1c-204c1509b754")
+	)
+	(global_label "MIPI_CLK_N" (shape bidirectional) (at 163.83 115.57 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f3ff3961-6ee8-4ef5-8772-a25c86279f0a")
+	)
+	(global_label "MIPI_DAT0_P" (shape bidirectional) (at 163.83 118.11 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "e1d80593-6047-4593-86b2-0636f22c1502")
+	)
+	(global_label "MIPI_DAT0_N" (shape bidirectional) (at 163.83 120.65 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "7643c19f-9042-4dd7-8ff5-55f941ea3ac8")
+	)
+	(global_label "MIPI_DAT1_P" (shape bidirectional) (at 163.83 123.19 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "4f3b06ee-a9b9-4131-a204-497d44316520")
+	)
+	(global_label "MIPI_DAT1_N" (shape bidirectional) (at 163.83 125.73 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "1c5f2613-2e3c-45cd-9a53-f0aa4d21295e")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 128.27 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "bb1760e6-17e3-430b-90ac-cdeb28cd5970")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 130.81 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f8f9917f-c9c5-4a35-b19f-c4ef43d5feae")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 133.35 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "7cdad105-91a4-479d-96d6-e12bea3a873c")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 135.89 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "a197319a-3017-4841-b569-22bac220ff26")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 138.43 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "cdbd2cdb-3b72-4c0d-b49b-161c97081b5b")
+	)
+	(global_label "+1V8" (shape bidirectional) (at 163.83 140.97 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "15eabcb3-194f-40b0-b91a-f842be213cad")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 113.03 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "9c89f424-ea90-4e33-90cd-f1e6807c7fcf")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 115.57 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "3b7d7c67-9c8a-4558-b77d-94862d130163")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 118.11 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "2421a8f8-cf9a-43d9-934b-099bcea53411")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 120.65 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "caa936c2-09c6-466e-b652-dd9073df457a")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 123.19 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "c9e57801-8621-48ed-9518-9a9a95a96a84")
+	)
+	(global_label "+1V2" (shape bidirectional) (at 191.77 125.73 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "bf4893b4-9af1-4714-843f-fbc150917916")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 128.27 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "8e0db040-6d39-4073-b56a-551c176792a8")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 130.81 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "b049d778-cb5f-4d5d-98ea-e18cf21917b2")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 133.35 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "c28dbf62-13a3-430c-840f-b7241d518de4")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 135.89 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "25dd56bb-ab7c-4228-9015-b3b567d7ab1d")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 138.43 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "3dedb94b-88b4-46bc-93a3-438420f66075")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 140.97 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "b73fe360-fde4-415f-a2d4-d51afbe80128")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 160.02 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "888cb371-8173-44c2-b595-ff5b729819f2")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 162.56 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "d4b4f610-53dc-498e-8ce2-304b1f59a9c1")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 165.1 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "ff62a6a4-725d-41b2-934f-6b1a8f9b0275")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 167.64 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "89be2b69-ff72-43be-a95f-2846035a9dcd")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 170.18 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "6524fca2-a9c1-4661-98a0-cee077dc43b6")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 172.72 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "54ead929-5ae0-4e2a-8e67-51d660ce932d")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 175.26 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f47e1b99-cee7-490f-9e9e-9d619a05bdef")
+	)
+	(global_label "TMDS_D0_P" (shape bidirectional) (at 163.83 177.8 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "571ff374-8c95-42ef-a26b-6bf3057de383")
+	)
+	(global_label "TMDS_D0_N" (shape bidirectional) (at 163.83 180.34 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "44167197-9a93-4540-9c79-4f4ce6f5b168")
+	)
+	(global_label "TMDS_D1_P" (shape bidirectional) (at 163.83 182.88 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "9cb30e20-2a91-493e-8143-d2630e149d9a")
+	)
+	(global_label "TMDS_D1_N" (shape bidirectional) (at 163.83 185.42 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "453ebac5-ecd0-4844-bbd2-5bd590025456")
+	)
+	(global_label "TMDS_D2_P" (shape bidirectional) (at 163.83 187.96 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "b1e794f5-1546-4a58-97b8-7196fcb6391a")
+	)
+	(global_label "TMDS_D2_N" (shape bidirectional) (at 163.83 190.5 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "d4df0067-ec9d-4176-bcb7-4ae129b99dd5")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 193.04 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "5b2110b5-15d5-4f8c-9d5e-433f8187b063")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 195.58 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "b2cfd679-bcb9-41d7-bfd6-5bf267e064ee")
+	)
+	(global_label "+1V2" (shape bidirectional) (at 163.83 198.12 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "fb699e51-ad39-4676-a7d2-f8b42cc7c5fc")
+	)
+	(global_label "+1V8" (shape bidirectional) (at 163.83 200.66 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "5632e3f2-a1d6-425c-96d5-a1584106b9ba")
+	)
+	(global_label "+1V8" (shape bidirectional) (at 163.83 203.2 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "e3b52717-6912-488c-848b-dfef95ef4e10")
+	)
+	(global_label "+1V8" (shape bidirectional) (at 163.83 205.74 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "2d46aec2-4cea-4a72-b069-27753e0d44df")
+	)
+	(global_label "+1V8" (shape bidirectional) (at 163.83 208.28 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "fd3f73a6-a270-4411-bf31-b7767cab4461")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 210.82 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "3666d534-7726-4466-8d1b-669fa1d208af")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 213.36 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "0add21c4-5262-4343-8349-e1d3d0dd7e9d")
+	)
+	(global_label "+1V8" (shape bidirectional) (at 163.83 215.9 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "72e1b3c1-881c-465b-b264-d7897ebe1422")
+	)
+	(global_label "+1V8" (shape bidirectional) (at 163.83 218.44 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "a465e521-a38c-4d32-8858-5b33c04c97dc")
+	)
+	(global_label "+1V8" (shape bidirectional) (at 163.83 220.98 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "3e526b55-4b44-4ca8-8c3e-8b9bb8664fd5")
+	)
+	(global_label "+1V8" (shape bidirectional) (at 191.77 160.02 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "fb6c3f75-1e5d-497b-8a46-2264528a4517")
+	)
+	(global_label "+1V8" (shape bidirectional) (at 191.77 162.56 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "b1ce9d21-fc3c-4553-8bb2-5c720c90cd6e")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 165.1 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "ea8be730-7201-40b0-b117-96557c4203da")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 167.64 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "93950b8e-3476-419a-b112-7c9b74e0e2a3")
+	)
+	(global_label "+1V8" (shape bidirectional) (at 191.77 170.18 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "05e187dd-56a3-4393-853a-d8ada6c2f9ff")
+	)
+	(global_label "+1V8" (shape bidirectional) (at 191.77 172.72 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "6a8b6962-2d50-4ae0-a095-f7bbbecefbb9")
+	)
+	(global_label "+1V8" (shape bidirectional) (at 191.77 175.26 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4b233deb-3d19-450c-b36a-d266ec974a4e")
+	)
+	(global_label "+1V8" (shape bidirectional) (at 191.77 177.8 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "d87daf67-535d-4835-b41d-72326d28194f")
+	)
+	(global_label "+1V2" (shape bidirectional) (at 191.77 180.34 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "973ab571-35d4-4804-a146-64670bb29b3a")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 182.88 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "fcdf33fe-32f8-4145-a639-65eff42ce35f")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 185.42 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "b7554788-9705-4995-aa1f-4a354189c0fa")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 187.96 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "96499e9f-b507-4f4e-a9e9-06c7a87d0253")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 190.5 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "64197e19-6309-4935-90d0-3a9ee62a9623")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 193.04 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "6ce8145c-1092-4425-93e4-b09c87f23118")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 195.58 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "0e1e4835-85cd-44e2-bab3-e75c1f5f29c7")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 198.12 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "21121066-1337-4682-89cf-cc5bcba446cc")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 200.66 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "a380ef26-f0ff-47dc-9a53-0b87b500e548")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 203.2 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "1f39c7d4-38d6-432c-8686-c6a1f3b0bd7b")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 205.74 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "f3f3757f-431a-4dd8-a637-cf607591e0fc")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 208.28 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "e3331c8c-c9b9-45f0-b581-2dd440ad5df0")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 210.82 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "5e95ac5c-3dc9-4de8-8554-b39708f1eab2")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 213.36 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "bd891a60-4a54-406a-800c-6433c7153808")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 215.9 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "de2ba4c4-d340-49da-9d3a-5ef1fdf8733e")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 218.44 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "8bb98f29-0847-452e-85c2-63c8d8dd0644")
+	)
+	(global_label "A0" (shape bidirectional) (at 163.83 237.49 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "ed9119a7-d8e5-48dc-b43f-7662a05db94a")
+	)
+	(global_label "A1" (shape bidirectional) (at 163.83 240.03 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "0059a7a8-852f-4df6-b04a-83db90582ff4")
+	)
+	(global_label "A2" (shape bidirectional) (at 163.83 242.57 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "8be1ffb2-9e48-4c84-9474-f5cab5b85b09")
+	)
+	(global_label "A3" (shape bidirectional) (at 163.83 245.11 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "59b53be4-bf20-440b-abea-b5dfb5b63efa")
+	)
+	(global_label "A4" (shape bidirectional) (at 163.83 247.65 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "7320b03e-fe40-489f-93b6-6d289d9e8feb")
+	)
+	(global_label "A5" (shape bidirectional) (at 163.83 250.19 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "96eaa9f4-5e54-4913-8534-5d842d493d4a")
+	)
+	(global_label "A6" (shape bidirectional) (at 163.83 252.73 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "44e76c72-010d-4309-b25b-7e8e989295c2")
+	)
+	(global_label "A7" (shape bidirectional) (at 163.83 255.27 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "c44bdab8-36c7-4999-bdf1-ade687d84336")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 257.81 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "af20d06c-2abb-4737-94f6-1aaf128a76eb")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 260.35 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "9ac60b02-7897-4806-8a92-707b59c4c6f6")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 262.89 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "dbc45d1e-f916-456b-8a39-7bc80910c81e")
+	)
+	(global_label "+1V8" (shape bidirectional) (at 163.83 265.43 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "755bae7b-9d9a-408f-b05d-6e63be442047")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 267.97 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "cce89f9d-24a9-4041-80cf-24da4117899f")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 270.51 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "65671ea9-636f-489d-9c92-852ca57ccfea")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 273.05 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "7bd5685c-ad36-4139-b25c-78d8d5a4ee9b")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 275.59 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "0e2b439a-6e6d-4cfb-93db-7c288cf3c4ed")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 278.13 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "290586d5-d788-4d9b-ba34-ff8a6a0a28f7")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 280.67 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "466c702e-b924-4c89-869f-0f8982b8a632")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 283.21 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "ff791eef-5594-487a-87be-610f69171bf0")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 285.75 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "88c76e7e-4c24-4809-bab7-b7277bb31413")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 288.29 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "8b82cfb7-b261-42a1-bf0e-060a6cafcf89")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 290.83 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "9f14da5d-1379-4c73-a76c-04d0d4533892")
+	)
+	(global_label "GND" (shape bidirectional) (at 163.83 293.37 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "2dae6d4c-23c4-43b7-8994-31098f472f01")
+	)
+	(global_label "+1V2" (shape bidirectional) (at 163.83 295.91 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "4306c810-d67f-4d2f-932e-f9e57096da87")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 237.49 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "605cab78-9c7b-45b1-ade0-62bb6e87b42a")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 240.03 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "31f3c7a7-5c42-41d1-9532-ba0c54878303")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 242.57 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4706fbfc-6f5a-4024-871b-e447e87f7b1d")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 245.11 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "ef122533-1001-4886-9025-35f86ff6ca82")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 247.65 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "42ef658f-f42b-4bc0-bdad-628f5f78fd34")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 250.19 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "e1658e14-5358-4193-9c46-ea7796ef8e3b")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 252.73 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "0bb3edd2-8e2c-4bf5-b191-62577350165b")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 255.27 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "3c8af3cc-126d-4391-8faf-1646e06891bf")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 257.81 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "d9cebbc6-492a-4461-b888-9a20feadcf8f")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 260.35 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "7961dfdb-f067-432b-a509-5ecaf8731866")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 262.89 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "6f4e8982-66e4-4f61-825b-0a1b0d244a3d")
+	)
+	(global_label "+1V8" (shape bidirectional) (at 191.77 265.43 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "ee6b7b97-da2c-47ba-837d-5fe01757a021")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 267.97 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "0e60c7f2-9b07-40e7-a23c-02bee9a9489c")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 270.51 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "e78b176e-70a2-41a1-b9ec-d340118f9fe7")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 273.05 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "675b8780-c254-4f81-a056-202062fa6178")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 275.59 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "c3831986-ef44-42f1-90a7-7d1dd8243a66")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 278.13 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "6db063bb-d173-4298-a7bb-b130ea527cff")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 280.67 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "2e9efdf3-14fd-4905-baf4-2d2ecd8e9113")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 283.21 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "9bf8acf1-8e9f-40f8-af81-2d07813999e3")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 285.75 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "52d5f9d6-6723-46c8-99da-7fc095ebcbe9")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 288.29 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "e78b6380-16b4-40e8-9ffc-2ebc4d68245a")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 290.83 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "d1175351-0018-4c65-baa5-ef7ba3c11f3e")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 293.37 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "adf4310a-7fc0-49af-8e23-14aeb970428f")
+	)
+	(global_label "GND" (shape bidirectional) (at 191.77 295.91 180) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "dfd2cfcf-e0f8-439c-b8b4-6245ab8bd367")
+	)
+	(global_label "+1V2" (shape input) (at 12.7 7.62 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "dd09a005-ac14-473d-9ef7-3f58798897f6")
+	)
+	(global_label "+1V8" (shape input) (at 12.7 17.78 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "438a8515-ba1d-4bd6-bd87-ec50accf483f")
+	)
+	(global_label "GND" (shape input) (at 12.7 309.88 0) (fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "db1902b4-a1e0-4eb5-b82f-2e348368d071")
 	)
 	(sheet_instances
-		(path "/0d315cf6-faeb-4774-88b8-21b8269a7e13" (page "1")
+		(path "/5b6ec878-611a-4148-afea-b98afc10dc0a" (page "1")
 		)
 	)
 )

--- a/scripts/ci/check_board_00_e2e.py
+++ b/scripts/ci/check_board_00_e2e.py
@@ -38,14 +38,26 @@ artifacts EXCEPT ``lvs.json`` present, ``lvs.json`` ABSENT, and
 ``board.json`` carrying NO ``lvs_clean`` key (the site then renders
 "LVS not run" instead of a zero-evidence "Ready" badge).
 
-``--lvs-vacuous`` mode (#4006, board 07): same unwired-fixture situation,
+``--lvs-vacuous`` mode (#4006): same unwired-fixture situation,
 but for a recipe that still *emits* ``lvs.json`` (its CI job asserts the
 file exists).  Asserts ``lvs.json`` is present and carries the
 vacuity-guard verdict (``clean: false`` + ``copper_vacuous: true``), and
 that ``board.json`` does NOT claim ``lvs_clean`` (board-metrics treats a
 vacuous report as LVS-not-run).  A ``clean: true`` here means the guard
 regressed; a non-vacuous dirty result means the schematic gained wired
-nets and the job should graduate to ``--lvs-only``.
+nets and the job should graduate to ``--lvs-only``.  (Boards 06/07 used
+the unwired-fixture modes until #4012 wired their schematics; no current
+board uses ``--lvs-not-run``/``--lvs-vacuous``, but the modes stay for
+future PCB-first fixtures.)
+
+``--lvs-known-opens NET[,NET...]`` mode (#4012, board 07): for a *wired*
+fixture schematic on a board that routes PARTIAL by design (5
+seed-invariant unroutable nets, #3438).  Asserts ``lvs.json`` is present
+and honestly dirty: ``clean: false``, NOT vacuous, ONLY ``kind="open"``
+copper mismatches on exactly the named nets, an empty label-mismatch
+list, and ``board.json`` carrying ``lvs_clean: false``.  Any short, any
+open outside the set, or one of the named nets becoming routable fails
+the gate (the expectation must then be updated deliberately).
 
 and exits non-zero with a ``::error::``-annotated message on any mismatch
 so the failure surfaces inline on the GitHub PR Files-changed view.
@@ -209,6 +221,61 @@ def assert_lvs_vacuous(lvs_path: Path) -> str | None:
     return None
 
 
+def assert_lvs_known_opens(lvs_path: Path, expected_nets: set[str]) -> str | None:
+    """Assert ``lvs.json`` carries EXACTLY the expected known opens (#4012).
+
+    For wired-schematic boards that route PARTIAL by design (board 07: 5
+    seed-invariant unroutable nets, #3438).  Expected shape:
+
+    * ``clean: false`` (the opens are real evidence, not vacuity);
+    * NOT vacuous (``copper_vacuous`` false/absent, bound pads > 0);
+    * ``copper_mismatches`` contains ONLY ``kind="open"`` entries whose
+      net names are exactly ``expected_nets`` (a short, a new open, or a
+      no-longer-open net all fail);
+    * label ``mismatches`` empty (the label comparator agrees pin-for-pin).
+
+    Returns ``None`` on pass, or a human-readable error message on fail.
+    """
+    try:
+        data = json.loads(lvs_path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        return f"could not read/parse {lvs_path}: {e}"
+    if data.get("clean"):
+        return (
+            f"expected lvs.json clean=false with opens on {sorted(expected_nets)} "
+            "(#3438) but it reports clean=true -- the previously-unroutable nets "
+            "appear routed now; graduate this job to --lvs-only"
+        )
+    if data.get("copper_vacuous") is True or data.get("copper_bound_pad_count") == 0:
+        return (
+            "expected named copper opens but lvs.json is VACUOUS "
+            "(copper_vacuous/copper_bound_pad_count=0) -- the schematic regressed "
+            "to unwired (binds 0 pins)"
+        )
+    label_mismatches = data.get("mismatches") or []
+    if label_mismatches:
+        return (
+            f"expected an empty label-mismatch list but got {len(label_mismatches)} "
+            f"label mismatch(es); first: {label_mismatches[0]}"
+        )
+    copper = data.get("copper_mismatches") or []
+    kinds = sorted({m.get("kind") for m in copper if isinstance(m, dict)})
+    if kinds != ["open"]:
+        return (
+            f"expected ONLY kind='open' copper mismatches but got kinds {kinds} "
+            f"({len(copper)} total) -- a copper short is a hard regression"
+        )
+    got_nets = {m.get("net_a", "?") for m in copper if isinstance(m, dict)}
+    if got_nets != expected_nets:
+        unexpected = sorted(got_nets - expected_nets)
+        missing = sorted(expected_nets - got_nets)
+        return (
+            f"copper opens {sorted(got_nets)} != expected {sorted(expected_nets)} "
+            f"(unexpected: {unexpected or 'none'}; no-longer-open: {missing or 'none'})"
+        )
+    return None
+
+
 def assert_board_json_fields(
     board_json_path: Path,
     required_fields: dict[str, Any] = REQUIRED_BOARD_JSON_FIELDS,
@@ -287,13 +354,32 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help=(
             "Honest-state gate for an unwired fixture schematic whose recipe "
-            "still EMITS lvs.json (#4006, board 07): assert lvs.json is "
+            "still EMITS lvs.json (#4006): assert lvs.json is "
             "present with the vacuity-guard verdict (clean=false, "
             "copper_vacuous=true) and board.json carries NO lvs_clean key, "
             "and SKIP the status/drc_violations assertions."
         ),
     )
+    mode_group.add_argument(
+        "--lvs-known-opens",
+        metavar="NET[,NET...]",
+        help=(
+            "Honest-state gate for a WIRED fixture schematic on a board that "
+            "routes PARTIAL by design (#4012, board 07): assert lvs.json is "
+            "present, clean=false, NOT vacuous, with ONLY kind='open' copper "
+            "mismatches whose net names are exactly this comma-separated set "
+            "(and an empty label-mismatch list); assert board.json carries "
+            "lvs_clean=false; SKIP the status/drc_violations assertions."
+        ),
+    )
     args = parser.parse_args(argv)
+
+    known_open_nets: set[str] = set()
+    if args.lvs_known_opens:
+        known_open_nets = {n.strip() for n in args.lvs_known_opens.split(",") if n.strip()}
+        if not known_open_nets:
+            _err("--lvs-known-opens was given an empty net list")
+            return 1
 
     board_dir: Path = args.board_dir
     if not board_dir.is_dir():
@@ -344,6 +430,18 @@ def main(argv: list[str] | None = None) -> int:
             else:
                 print("[ok] lvs.json carries the vacuity-guard verdict (#4006)")
         # (missing lvs.json was already reported above)
+    elif known_open_nets:
+        if lvs_path.is_file():
+            lvs_err = assert_lvs_known_opens(lvs_path, known_open_nets)
+            if lvs_err is not None:
+                _err(lvs_err, file=lvs_path)
+                failed = True
+            else:
+                print(
+                    "[ok] lvs.json carries exactly the expected known opens "
+                    f"({', '.join(sorted(known_open_nets))}) and nothing else (#4012)"
+                )
+        # (missing lvs.json was already reported above)
     elif lvs_path.is_file():
         lvs_err = assert_lvs_clean(lvs_path)
         if lvs_err is not None:
@@ -379,9 +477,16 @@ def main(argv: list[str] | None = None) -> int:
                 else:
                     print("[ok] board.json omits lvs_clean ('LVS not run')")
     else:
-        required_fields = (
-            LVS_ONLY_BOARD_JSON_FIELDS if args.lvs_only else REQUIRED_BOARD_JSON_FIELDS
-        )
+        if known_open_nets:
+            # Known-opens boards (#4012) are honestly DIRTY: board-metrics
+            # must render lvs_clean=false (never omit it -- that would be
+            # "LVS not run", and never true).  status/drc are not asserted
+            # (partial-by-design boards carry allowlisted residuals).
+            required_fields: dict[str, Any] = {"lvs_clean": False}
+        elif args.lvs_only:
+            required_fields = LVS_ONLY_BOARD_JSON_FIELDS
+        else:
+            required_fields = REQUIRED_BOARD_JSON_FIELDS
         if board_json_path.is_file():
             field_errors = assert_board_json_fields(board_json_path, required_fields)
             if field_errors:

--- a/scripts/ci/check_copper_lvs.py
+++ b/scripts/ci/check_copper_lvs.py
@@ -155,6 +155,59 @@ def assert_vacuous(payload: dict[str, Any]) -> str | None:
     return None
 
 
+def assert_known_opens(payload: dict[str, Any], expected_nets: set[str]) -> str | None:
+    """Assert a copper-LVS payload reports EXACTLY the expected opens (#4012).
+
+    Used for boards that route PARTIAL by design with a *wired* fixture
+    schematic (board 07: 5 seed-invariant unroutable nets, #3438).  The
+    honest expectation is ``clean: false`` with only ``kind="open"``
+    mismatches whose net names are exactly ``expected_nets`` — nothing
+    more (a NEW open/short is a regression), nothing less (an expected
+    open disappearing means the router improved and the expectation, or
+    the gate, must be updated), and never the vacuity verdict (the
+    schematic regressed to unwired).
+
+    Returns:
+        ``None`` on pass.  A human-readable error message otherwise
+        (caller maps to exit 2).
+
+    Raises:
+        KeyError: If ``clean`` is absent (caller maps to exit 1).
+    """
+    clean = payload["clean"]
+    mismatches = payload.get("mismatches", [])
+    if not isinstance(mismatches, list):
+        mismatches = []
+    kinds = sorted({m.get("kind") for m in mismatches if isinstance(m, dict)})
+    if clean:
+        return (
+            f"expected copper-LVS opens on {sorted(expected_nets)} (#3438) but got "
+            "clean=true -- the previously-unroutable nets appear routed now; "
+            "graduate this CI gate to a plain clean assertion"
+        )
+    if "vacuous" in kinds:
+        return (
+            "expected named copper-LVS opens but got the vacuity-guard verdict "
+            "(kind='vacuous') -- the schematic regressed to unwired (binds 0 pins)"
+        )
+    if kinds != ["open"]:
+        return (
+            f"expected ONLY kind='open' mismatches but got kinds {kinds}: "
+            f"{_summarize_mismatches(mismatches)} -- a copper short is a hard "
+            "regression regardless of the known-opens allowance"
+        )
+    got_nets = sorted({m.get("net_a", "?") for m in mismatches if isinstance(m, dict)})
+    if set(got_nets) != expected_nets:
+        unexpected = sorted(set(got_nets) - expected_nets)
+        missing = sorted(expected_nets - set(got_nets))
+        return (
+            f"copper-LVS opens {got_nets} != expected {sorted(expected_nets)} "
+            f"(unexpected: {unexpected or 'none'}; no-longer-open: {missing or 'none'}) "
+            f"-- {_summarize_mismatches(mismatches)}"
+        )
+    return None
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="check_copper_lvs.py",
@@ -172,15 +225,28 @@ def main(argv: list[str] | None = None) -> int:
             "(use '-' or '/dev/stdin' to read from stdin)."
         ),
     )
-    parser.add_argument(
+    mode_group = parser.add_mutually_exclusive_group()
+    mode_group.add_argument(
         "--expect-vacuous",
         action="store_true",
         help=(
-            "Invert the contract for deliberately-unwired fixture schematics "
-            "(board 06): assert the result is the vacuity-guard verdict "
+            "Invert the contract for deliberately-unwired fixture schematics: "
+            "assert the result is the vacuity-guard verdict "
             "(clean=false with only kind='vacuous' mismatches, #4005 review). "
             "Fails on clean=true (guard regression) AND on real shorts/opens "
             "(schematic gained nets; upgrade the gate)."
+        ),
+    )
+    mode_group.add_argument(
+        "--expect-opens",
+        metavar="NET[,NET...]",
+        help=(
+            "Known-opens contract for wired-schematic boards that route "
+            "PARTIAL by design (board 07, #3438/#4012): assert clean=false "
+            "with ONLY kind='open' mismatches whose net names are exactly "
+            "this comma-separated set.  Fails on clean=true (nets became "
+            "routable; upgrade the gate), on any short, on the vacuous "
+            "verdict, and on any open outside the set."
         ),
     )
     args = parser.parse_args(argv)
@@ -211,9 +277,18 @@ def main(argv: list[str] | None = None) -> int:
         _err(f"copper-LVS JSON from {display} is not a JSON object: {type(payload).__name__}")
         return 1
 
+    expected_open_nets: set[str] = set()
+    if args.expect_opens:
+        expected_open_nets = {n.strip() for n in args.expect_opens.split(",") if n.strip()}
+        if not expected_open_nets:
+            _err("--expect-opens was given an empty net list")
+            return 1
+
     try:
         if args.expect_vacuous:
             dirty_msg = assert_vacuous(payload)
+        elif expected_open_nets:
+            dirty_msg = assert_known_opens(payload, expected_open_nets)
         else:
             dirty_msg = assert_clean(payload)
     except KeyError:
@@ -234,6 +309,11 @@ def main(argv: list[str] | None = None) -> int:
         print(
             "[ok] copper-LVS vacuity guard fired as expected "
             "(clean=false, kind='vacuous'; unwired fixture schematic)"
+        )
+    elif expected_open_nets:
+        print(
+            "[ok] copper-LVS reports exactly the expected known opens "
+            f"({', '.join(sorted(expected_open_nets))}) and nothing else"
         )
     else:
         print("[ok] copper-LVS clean (independent out-of-process re-check)")

--- a/src/kicad_tools/cli/board_metrics_cmd.py
+++ b/src/kicad_tools/cli/board_metrics_cmd.py
@@ -243,7 +243,14 @@ def _parse_lvs(lvs_path: Path, slug: str) -> dict:
         return {}
     return {
         "lvs_clean": bool(data.get("clean", False)),
-        "lvs_mismatches": len(data.get("mismatches") or []),
+        # Count BOTH comparator legs (#4012): ``mismatches`` is the
+        # label-based list (historical board-00 schema) and
+        # ``copper_mismatches`` the copper-extracted shorts/opens (#3762).
+        # A board like 07 -- label-clean but with 5 real copper opens
+        # (#3438) -- must render "5 mismatches", not a dishonest 0.
+        "lvs_mismatches": (
+            len(data.get("mismatches") or []) + len(data.get("copper_mismatches") or [])
+        ),
     }
 
 

--- a/tests/test_board_metrics.py
+++ b/tests/test_board_metrics.py
@@ -418,6 +418,31 @@ def test_lvs_dirty_downgrades_status_to_partial(tmp_path: Path):
     assert m["status"] == "partial"
 
 
+def test_lvs_copper_mismatches_counted(tmp_path: Path):
+    # #4012 (board 07 shape): label leg clean (mismatches=[]) but the copper
+    # comparator reports real opens.  lvs_mismatches must count the copper
+    # leg too -- rendering "0 mismatches" for a clean=false report would be
+    # dishonest -- and the dirty verdict still downgrades status.
+    board = _make_board(
+        tmp_path,
+        lvs={
+            "$schema": "https://kicad-tools.org/schemas/lvs/v1.json",
+            "clean": False,
+            "mismatches": [],
+            "copper_mismatches": [
+                {"kind": "open", "net_a": n, "net_b": n, "pad_a": "U1.1", "pad_b": "U2.1"}
+                for n in ("DQ3", "DQ4", "MIPI_DAT0_N", "TMDS_D0_N", "TMDS_D1_N")
+            ],
+            "copper_vacuous": False,
+            "copper_bound_pad_count": 244,
+        },
+    )
+    m = extract_board_metrics(board)
+    assert m["lvs_clean"] is False
+    assert m["lvs_mismatches"] == 5
+    assert m["status"] == "partial"
+
+
 def test_vacuous_lvs_json_treated_as_lvs_not_run(tmp_path: Path):
     # A vacuous lvs.json (#4006: schematic bound zero pins, copper_vacuous
     # true) carries NO evidence either way -- both LVS fields are OMITTED

--- a/tests/test_check_board_e2e.py
+++ b/tests/test_check_board_e2e.py
@@ -329,3 +329,175 @@ def test_default_mode_rejects_vacuous_clean_true_lvs_json(tmp_path: Path) -> Non
     )
     rc = helper.main([str(board_dir), "--stem", "voltage_divider"])
     assert rc == 2
+
+
+# --- --lvs-known-opens mode (#4012, board 07) --------------------------------
+#
+# Wired fixture schematic on a partial-by-design board (5 seed-invariant
+# unroutable nets, #3438): lvs.json is honestly DIRTY with exactly those
+# opens, and board.json renders lvs_clean=false.
+
+_B07_OPENS = ["DQ3", "DQ4", "MIPI_DAT0_N", "TMDS_D0_N", "TMDS_D1_N"]
+_B07_OPENS_ARG = ",".join(_B07_OPENS)
+
+
+def _stage_known_opens_board(root: Path, stem: str) -> Path:
+    """Staging dir mimicking board 07 post-#4012: honest 5-opens lvs.json."""
+    helper = _load_helper()
+    board_dir = root / "board"
+    output = board_dir / "output"
+    (output / "manufacturing").mkdir(parents=True)
+    for rel in helper.required_artifacts(stem):
+        p = output / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("placeholder")
+    (output / "lvs.json").write_text(
+        json.dumps(
+            {
+                "clean": False,
+                "mismatches": [],
+                "copper_mismatches": [
+                    {"kind": "open", "net_a": n, "net_b": n, "pad_a": "U1.1", "pad_b": "U2.1"}
+                    for n in _B07_OPENS
+                ],
+                "copper_vacuous": False,
+                "copper_bound_pad_count": 244,
+            }
+        )
+    )
+    (output / "board.json").write_text(
+        json.dumps(
+            {
+                "status": "partial",
+                "drc_violations": 0,
+                "lvs_clean": False,
+                "lvs_mismatches": 5,
+            }
+        )
+    )
+    return board_dir
+
+
+def test_lvs_known_opens_passes_honest_state(tmp_path: Path) -> None:
+    helper = _load_helper()
+    board_dir = _stage_known_opens_board(tmp_path, "matchgroup_test")
+    rc = helper.main(
+        [str(board_dir), "--stem", "matchgroup_test", "--lvs-known-opens", _B07_OPENS_ARG]
+    )
+    assert rc == 0
+
+
+def test_lvs_known_opens_rejects_clean_true(tmp_path: Path) -> None:
+    # The nets got routed: the gate forces a deliberate graduation to
+    # --lvs-only instead of silently blessing a stale expectation.
+    helper = _load_helper()
+    board_dir = _stage_known_opens_board(tmp_path, "matchgroup_test")
+    (board_dir / "output" / "lvs.json").write_text(json.dumps({"clean": True, "mismatches": []}))
+    rc = helper.main(
+        [str(board_dir), "--stem", "matchgroup_test", "--lvs-known-opens", _B07_OPENS_ARG]
+    )
+    assert rc == 2
+
+
+def test_lvs_known_opens_rejects_vacuous(tmp_path: Path) -> None:
+    # The schematic regressed to unwired: vacuity is never "known opens".
+    helper = _load_helper()
+    board_dir = _stage_known_opens_board(tmp_path, "matchgroup_test")
+    (board_dir / "output" / "lvs.json").write_text(
+        json.dumps(
+            {
+                "clean": False,
+                "mismatches": [],
+                "copper_mismatches": [
+                    {
+                        "kind": "vacuous",
+                        "net_a": "<no-schematic-evidence>",
+                        "net_b": "<no-schematic-evidence>",
+                        "pad_a": "bound_pads=0",
+                        "pad_b": "board_pads=244",
+                    }
+                ],
+                "copper_vacuous": True,
+                "copper_bound_pad_count": 0,
+            }
+        )
+    )
+    rc = helper.main(
+        [str(board_dir), "--stem", "matchgroup_test", "--lvs-known-opens", _B07_OPENS_ARG]
+    )
+    assert rc == 2
+
+
+def test_lvs_known_opens_rejects_short(tmp_path: Path) -> None:
+    helper = _load_helper()
+    board_dir = _stage_known_opens_board(tmp_path, "matchgroup_test")
+    payload = json.loads((board_dir / "output" / "lvs.json").read_text())
+    payload["copper_mismatches"].append(
+        {"kind": "short", "net_a": "A", "net_b": "B", "pad_a": "U1.1", "pad_b": "U1.2"}
+    )
+    (board_dir / "output" / "lvs.json").write_text(json.dumps(payload))
+    rc = helper.main(
+        [str(board_dir), "--stem", "matchgroup_test", "--lvs-known-opens", _B07_OPENS_ARG]
+    )
+    assert rc == 2
+
+
+def test_lvs_known_opens_rejects_unexpected_open(tmp_path: Path) -> None:
+    helper = _load_helper()
+    board_dir = _stage_known_opens_board(tmp_path, "matchgroup_test")
+    payload = json.loads((board_dir / "output" / "lvs.json").read_text())
+    payload["copper_mismatches"].append(
+        {"kind": "open", "net_a": "SURPRISE", "net_b": "SURPRISE", "pad_a": "X.1", "pad_b": "Y.1"}
+    )
+    (board_dir / "output" / "lvs.json").write_text(json.dumps(payload))
+    rc = helper.main(
+        [str(board_dir), "--stem", "matchgroup_test", "--lvs-known-opens", _B07_OPENS_ARG]
+    )
+    assert rc == 2
+
+
+def test_lvs_known_opens_rejects_label_mismatches(tmp_path: Path) -> None:
+    # The label leg is expected clean on board 07; a label mismatch is a
+    # separate regression the known-opens allowance must not absorb.
+    helper = _load_helper()
+    board_dir = _stage_known_opens_board(tmp_path, "matchgroup_test")
+    payload = json.loads((board_dir / "output" / "lvs.json").read_text())
+    payload["mismatches"] = [{"ref": "U1", "pad": "1", "schematic_net": "A", "pcb_net": "B"}]
+    (board_dir / "output" / "lvs.json").write_text(json.dumps(payload))
+    rc = helper.main(
+        [str(board_dir), "--stem", "matchgroup_test", "--lvs-known-opens", _B07_OPENS_ARG]
+    )
+    assert rc == 2
+
+
+def test_lvs_known_opens_rejects_board_json_omitting_lvs_clean(tmp_path: Path) -> None:
+    # board.json must carry the honest lvs_clean=false -- omission means
+    # "LVS not run", which would misrepresent real evidence.
+    helper = _load_helper()
+    board_dir = _stage_known_opens_board(tmp_path, "matchgroup_test")
+    (board_dir / "output" / "board.json").write_text(
+        json.dumps({"status": "partial", "drc_violations": 0})
+    )
+    rc = helper.main(
+        [str(board_dir), "--stem", "matchgroup_test", "--lvs-known-opens", _B07_OPENS_ARG]
+    )
+    assert rc == 2
+
+
+def test_lvs_known_opens_rejects_board_json_lvs_clean_true(tmp_path: Path) -> None:
+    helper = _load_helper()
+    board_dir = _stage_known_opens_board(tmp_path, "matchgroup_test")
+    (board_dir / "output" / "board.json").write_text(
+        json.dumps({"status": "partial", "drc_violations": 0, "lvs_clean": True})
+    )
+    rc = helper.main(
+        [str(board_dir), "--stem", "matchgroup_test", "--lvs-known-opens", _B07_OPENS_ARG]
+    )
+    assert rc == 2
+
+
+def test_lvs_known_opens_mutually_exclusive_with_other_modes(tmp_path: Path) -> None:
+    helper = _load_helper()
+    board_dir = _stage_known_opens_board(tmp_path, "matchgroup_test")
+    with pytest.raises(SystemExit):
+        helper.main([str(board_dir), "--lvs-vacuous", "--lvs-known-opens", _B07_OPENS_ARG])

--- a/tests/test_ci_check_copper_lvs.py
+++ b/tests/test_ci_check_copper_lvs.py
@@ -272,3 +272,91 @@ def test_default_mode_rejects_vacuous_as_dirty(tmp_path: Path) -> None:
     # the default clean-assertion path must exit 2, never 0.
     p = _write_json(tmp_path, _VACUOUS_PAYLOAD)
     assert check_copper_lvs.main([str(p)]) == 2
+
+
+# --- --expect-opens mode (#4012, board 07) ----------------------------------
+#
+# Known-opens contract for wired-schematic boards that route PARTIAL by
+# design (board 07: 5 seed-invariant unroutable nets, #3438).  The gate
+# passes ONLY when the result carries kind='open' mismatches on exactly the
+# named net set -- clean=true, a short, a vacuous verdict, an unexpected
+# open, or a missing expected open all trip it.
+
+_KNOWN_OPENS_ARG = "DQ3,DQ4,MIPI_DAT0_N"
+
+
+def _opens_payload(nets: list[str], extra: list[dict] | None = None) -> dict:
+    mismatches = [
+        {"kind": "open", "net_a": n, "net_b": n, "pad_a": "U1.1", "pad_b": "U2.1"} for n in nets
+    ]
+    if extra:
+        mismatches.extend(extra)
+    return {"clean": False, "bound_pad_count": 244, "mismatches": mismatches}
+
+
+def test_expect_opens_passes_on_exact_set(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = _write_json(tmp_path, _opens_payload(["DQ3", "DQ4", "MIPI_DAT0_N"]))
+    assert check_copper_lvs.main(["--expect-opens", _KNOWN_OPENS_ARG, str(p)]) == 0
+    assert "expected known opens" in capsys.readouterr().out
+
+
+def test_expect_opens_fails_on_clean_true(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # The previously-unroutable nets got routed: the expectation is stale
+    # and the gate must force a deliberate upgrade to a clean assertion.
+    p = _write_json(tmp_path, {"clean": True, "mismatches": []})
+    assert check_copper_lvs.main(["--expect-opens", _KNOWN_OPENS_ARG, str(p)]) == 2
+    assert "graduate" in capsys.readouterr().out
+
+
+def test_expect_opens_fails_on_short(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    # A short is a hard regression regardless of the known-opens allowance.
+    p = _write_json(
+        tmp_path,
+        _opens_payload(
+            ["DQ3", "DQ4", "MIPI_DAT0_N"],
+            extra=[{"kind": "short", "net_a": "A", "net_b": "B", "pad_a": "U1.1", "pad_b": "U1.2"}],
+        ),
+    )
+    assert check_copper_lvs.main(["--expect-opens", _KNOWN_OPENS_ARG, str(p)]) == 2
+    assert "short" in capsys.readouterr().out
+
+
+def test_expect_opens_fails_on_unexpected_open(tmp_path: Path) -> None:
+    p = _write_json(tmp_path, _opens_payload(["DQ3", "DQ4", "MIPI_DAT0_N", "SURPRISE_NET"]))
+    assert check_copper_lvs.main(["--expect-opens", _KNOWN_OPENS_ARG, str(p)]) == 2
+
+
+def test_expect_opens_fails_on_missing_expected_open(tmp_path: Path) -> None:
+    # One of the named nets is no longer open: the expectation must be
+    # updated deliberately (net became routable), so the gate trips.
+    p = _write_json(tmp_path, _opens_payload(["DQ3", "DQ4"]))
+    assert check_copper_lvs.main(["--expect-opens", _KNOWN_OPENS_ARG, str(p)]) == 2
+
+
+def test_expect_opens_fails_on_vacuous_verdict(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # The schematic regressed to unwired: vacuity is never "known opens".
+    p = _write_json(tmp_path, _VACUOUS_PAYLOAD)
+    assert check_copper_lvs.main(["--expect-opens", _KNOWN_OPENS_ARG, str(p)]) == 2
+    assert "unwired" in capsys.readouterr().out
+
+
+def test_expect_opens_missing_clean_key_exits_1(tmp_path: Path) -> None:
+    p = _write_json(tmp_path, {"mismatches": []})
+    assert check_copper_lvs.main(["--expect-opens", _KNOWN_OPENS_ARG, str(p)]) == 1
+
+
+def test_expect_opens_empty_net_list_exits_1(tmp_path: Path) -> None:
+    p = _write_json(tmp_path, _opens_payload(["DQ3"]))
+    assert check_copper_lvs.main(["--expect-opens", " , ", str(p)]) == 1
+
+
+def test_expect_opens_mutually_exclusive_with_expect_vacuous(tmp_path: Path) -> None:
+    p = _write_json(tmp_path, _opens_payload(["DQ3"]))
+    with pytest.raises(SystemExit):
+        check_copper_lvs.main(["--expect-vacuous", "--expect-opens", "DQ3", str(p)])

--- a/tests/test_copper_lvs.py
+++ b/tests/test_copper_lvs.py
@@ -954,7 +954,7 @@ def test_pour_extraction_unions_pads_across_disjoint_fill_islands_of_one_zone(
 
 @requires_shapely
 def test_compare_copper_netlist_on_pour_heavy_board07_artifacts() -> None:
-    """End-to-end: pour-heavy extraction runs, and the verdict is VACUOUS.
+    """End-to-end: pour-heavy extraction reports board 07's 5 honest opens.
 
     Board 07 (match-group test) carries the GND / +1V2 / +1V8 plane pours
     (one zone per net since #3818 de-duplicated the router/recipe overlap),
@@ -963,12 +963,13 @@ def test_compare_copper_netlist_on_pour_heavy_board07_artifacts() -> None:
     extraction and the pad-box erosion guard on real routed copper without
     crashing.
 
-    The verdict itself, however, is *vacuous* (#4006): board 07's fixture
-    schematic has no ``(wire ...)`` elements, so zero pins bind and the
-    historical ``clean=True`` this test pinned was zero-evidence (it would
-    have masked board 07's 5 real copper opens).  The honest contract is
-    now ``clean=False`` + ``vacuous`` — this is the guard's end-to-end
-    regression pin on a real pour-heavy board.
+    The fixture schematic is fully wired since #4012 (244/244 pads bound),
+    so the comparator carries real evidence — and board 07 routes PARTIAL
+    by design (5 seed-invariant unroutable nets, #3438), so the honest
+    verdict is ``clean=False`` with exactly those 5 opens and no shorts.
+    (History: pre-#4012 the schematic bound 0 pins; this test pinned the
+    #4006 vacuous verdict, and before that a zero-evidence ``clean=True``
+    that masked these same 5 real opens.)
     """
     repo_root = Path(__file__).resolve().parent.parent
     board_out = repo_root / "boards" / "07-matchgroup-test" / "output"
@@ -978,22 +979,31 @@ def test_compare_copper_netlist_on_pour_heavy_board07_artifacts() -> None:
         pytest.skip("board 07 artifacts not present; run generate_design.py")
     result = compare_copper_netlist(sch, pcb)
     assert isinstance(result, CopperLVSResult)
-    assert result.vacuous, (
-        "board 07's fixture schematic was expected to bind 0 pins (vacuous, "
-        f"#4006) but bound {result.bound_pad_count}; if the schematic gained "
-        "wired nets, upgrade this test to a real clean assertion"
+    assert not result.vacuous, (
+        "board 07's fixture schematic is wired since #4012 and must bind "
+        f"pins; got vacuous with bound_pad_count={result.bound_pad_count}"
     )
+    assert result.bound_pad_count == 244
     assert not result.clean
-    assert result.bound_pad_count == 0
+    assert result.shorts == ()
+    assert sorted({m.net_a for m in result.opens}) == [
+        "DQ3",
+        "DQ4",
+        "MIPI_DAT0_N",
+        "TMDS_D0_N",
+        "TMDS_D1_N",
+    ], "expected exactly the 5 seed-invariant unroutable nets (#3438)"
 
 
-def test_compare_copper_netlist_on_board06_wireless_fixture_is_vacuous() -> None:
-    """End-to-end #4006 pin: board 06's unwired schematic yields VACUOUS.
+def test_compare_copper_netlist_on_board06_wired_fixture_is_clean() -> None:
+    """End-to-end #4012 pin: board 06's wired schematic yields a real clean.
 
-    Board 06's committed ``lvs.json`` (merged in #4004) claimed
-    ``clean=true`` off exactly this pair of artifacts while binding zero
-    pins — the vacuity hole from PR #4005's review.  The comparator must
-    now refuse that: dirty, vacuous, zero bound pads.
+    History: board 06's schematic was unwired pre-#4012 (0/198 pins bound)
+    and its #4004 ``lvs.json`` claimed ``clean=true`` on zero evidence —
+    the vacuity hole from PR #4005's review, pinned here as a VACUOUS
+    verdict until #4012 wired the schematic.  Now the comparator binds all
+    198 pads and the clean verdict is genuinely evidenced (21/21 nets
+    routed to copper completion).
     """
     repo_root = Path(__file__).resolve().parent.parent
     board_out = repo_root / "boards" / "06-diffpair-test" / "output"
@@ -1002,10 +1012,10 @@ def test_compare_copper_netlist_on_board06_wireless_fixture_is_vacuous() -> None
     if not (sch.exists() and pcb.exists()):
         pytest.skip("board 06 artifacts not present; run generate_design.py")
     result = compare_copper_netlist(sch, pcb)
-    assert not result.clean
-    assert result.vacuous
-    assert result.bound_pad_count == 0
-    assert [m.kind for m in result.mismatches] == [VACUOUS_KIND]
+    assert not result.vacuous
+    assert result.bound_pad_count == 198
+    assert result.clean
+    assert result.mismatches == ()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Boards 06 (diffpair-test) and 07 (matchgroup-test) showed **"LVS not run"** on the kicad-tools.org gallery: their PCB-first fixture schematics contained **zero `(wire ...)` elements**, every pin floated, `_schematic_pin_to_net` bound 0 pins, and the #4011 vacuity guard correctly refused `clean=true` on zero evidence. This PR wires both schematics so LVS has real evidence — board 06 graduates to a genuinely-verified **Ready**, board 07 to an **honest partial** with its 5 real copper opens on display.

## Wiring approach

The PCBs use package-native pad names (USB-C `A1..B12` + `S1/S2` shields, BGA `A1..G7`, FFC `M1/M2/RST`), which stock `Connector_Generic` symbols (numeric pins `1..N`) can never bind. So each `generate_schematic.py` now:

1. **Synthesizes one testbench symbol per component** via `kicad_tools.schematic.symbol_generator` (`SymbolDef`/`PinDef`), pin numbers matching the PCB pads exactly, written to a project-local library (`diffpair_lvs.kicad_sym` / `matchgroup_lvs.kicad_sym`) and resolved via `Schematic(local_symbol_libs=[...])` — the board-05 `board05_custom` pattern. The emitted `.kicad_sch` embeds the defs in `lib_symbols`, so LVS/KiCad need no library setup.
2. **Wires every pin**: a short wire stub attached at the pin ENDPOINT (per #4003's review note — mid-span crossings don't connect) terminated by a global label carrying the pin's net name. `PIN_NETS` in each generator mirrors `generate_pcb.py` pad-for-pad; the LVS gate is what keeps the two in lock-step.

## Bound pins before → after

| Board | Before | After |
|---|---|---|
| 06-diffpair-test | 0 / 198 | **198 / 198** |
| 07-matchgroup-test | 0 / 244 | **244 / 244** |

## LVS results (committed artifacts)

* **Board 06**: copper 0 shorts / 0 opens (198 bound pads) **and** label 0 mismatches → committed `lvs.json` `clean=true`. Recipe hard-gates on **both** comparators (`require_clean=True`, boards 00-02 style per the `kicad_tools/lvs/recipe.py` matrix). `board.json`: `status=ok`, `lvs_clean=true` → gallery **Ready**.
* **Board 07**: label clean; copper honestly reports **exactly the 5 seed-invariant unroutable nets** (#3438: `DQ3, DQ4, MIPI_DAT0_N, TMDS_D0_N, TMDS_D1_N`) as opens → committed `lvs.json` `clean=false` with 5 copper opens (deliberately committed — it is the truth). Recipe keeps `require_clean=False` (the opens are expected) with an accurate warning. `board.json`: `status=partial`, `lvs_clean=false`, `lvs_mismatches=5`. No routing was attempted on the 5 nets (known-blocked router work, #3438).

`kct board-metrics` change: `_parse_lvs` now counts `copper_mismatches` into `lvs_mismatches` (the label leg alone would render a dishonest "0 mismatches" for board 07's `clean=false` report). All other committed boards carry 0 copper mismatches — no other `board.json` changes (verified with `--all`).

## CI interlock (updated in this PR)

* **board-06-end-to-end** graduates from the vacuity assertions (`lvs.json` ABSENT, `--expect-vacuous`, `--lvs-not-run`) to the true gate: `lvs.json` present, plain `check_copper_lvs.py` clean re-check on the regenerated pair, `check_board_00_e2e.py --lvs-only` (`lvs_clean=true`).
* **board-07-end-to-end** graduates to a **known-opens contract**: new `check_copper_lvs.py --expect-opens "DQ3,DQ4,MIPI_DAT0_N,TMDS_D0_N,TMDS_D1_N"` + new `check_board_00_e2e.py --lvs-known-opens ...` assert `clean=false` with ONLY `kind='open'` on EXACTLY those nets, label leg clean, and `board.json` `lvs_clean=false`. A copper short, a new open, a vacuity regression, or one of the 5 becoming routable all fail the job and force a deliberate expectation update.
* Both new asserter modes are unit-tested (`tests/test_ci_check_copper_lvs.py`, `tests/test_check_board_e2e.py`); the old modes stay for future PCB-first fixtures.

### Fresh-regen validation
* Board 06 `--step all --seed 42` regen (local): 21/21 routed, label+copper LVS PASS, exit 0; all mirrored CI steps pass. Latest main CI run confirms `Routing: SUCCESS`, 18/24 allowlisted quality errors, no connectivity residuals.
* Board 07 on CI (latest main run, py3.12/linux container): 5 connectivity residuals, 9/14 allowlisted errors — consistent with exactly the 5 known opens. **Caveat:** a local py3.14/macOS regen produced one extra `DQ1↔DQ6` short (clearance_segment_via −0.375 mm) that CI does not reproduce; the `--expect-opens` gate will surface it loudly if CI ever does.

## Tests

* `test_copper_lvs.py` end-to-end pins upgraded from the vacuous verdicts to the wired-state contracts (their own docstrings mandated this upgrade path).
* New coverage: `--expect-opens` (9 tests), `--lvs-known-opens` (9 tests), copper-mismatch counting in board-metrics.
* Selection `-k "board06 or board07 or diffpair or matchgroup or lvs"`: **1003 passed, 3 skipped, 0 failed**. `ruff` clean, `mypy` clean on touched src, `ci.yml` parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)