### PR TITLE
fix(site): frame interactive viewer on the board, not the drawing sheet

### DIFF
--- a/site/src/pages/[slug].astro
+++ b/site/src/pages/[slug].astro
@@ -298,10 +298,29 @@ if (board.manifest_generated_at !== undefined) {
   var isLoaded = function () {
     return !!(embed && embed.loaded);
   };
+  // Re-frame the camera on the board outline instead of the drawing sheet.
+  // KiCanvas's load path unconditionally calls zoom_to_page(), which fits the
+  // whole worksheet frame — boards sitting in a corner of the sheet render
+  // tiny and offset (user-visible on every board page). The board viewer
+  // exposes zoom_to_board() (fits Edge.Cuts bbox + 10%) but nothing calls it,
+  // so we do, once, when the viewer reports loaded. Best-effort: any failure
+  // leaves the stock page-fit behavior.
+  var zoomToBoard = function () {
+    try {
+      var root = embed && (embed.renderRoot || embed.shadowRoot);
+      var app = root && root.querySelector("kc-board-app");
+      var viewer = app && app.viewer;
+      if (viewer && typeof viewer.zoom_to_board === "function") {
+        viewer.zoom_to_board();
+        if (typeof viewer.draw === "function") viewer.draw();
+      }
+    } catch (e) {}
+  };
   var hideOverlay = function () {
     if (settled) return;
     settled = true;
     stopPolling();
+    zoomToBoard();
     try {
       if (overlay && overlay.parentNode) overlay.remove();
     } catch (e) {}


### PR DESCRIPTION
## Summary
The gallery's Interactive Viewer opened fit-to-page (KiCanvas always calls `zoom_to_page()` on load), so boards rendered small/offset within the worksheet frame. This calls the viewer's own `zoom_to_board()` (fits Edge.Cuts +10%) once the existing `embed.loaded` poll sees the viewer ready, via the open shadow DOM (`kicanvas-embed` → `kc-board-app` → `.viewer`).

- Best-effort: wrapped in try/catch; failure falls back to stock page-fit.
- No vendored-bundle patch — survives KiCanvas upgrades.
- Toolbar zoom-to-page still available for the full-sheet view.
- Already validated in production (deployed alongside #4015's board centering; user-confirmed issue, camera now opens on the board).

## Test
`cd site && npm run build` (10 pages) and `npx vitest run src/data` (28 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)