### PR TITLE
test: add shared isolate_pcb_from_sidecars helper for bare kct check tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,50 @@
 """Pytest fixtures for kicad-tools tests."""
 
 import hashlib
+import shutil
 import subprocess
 from pathlib import Path
 
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def isolate_pcb_from_sidecars(pcb_path: Path, dest_dir: Path) -> Path:
+    """Copy a routed PCB into ``dest_dir`` WITHOUT any sidecar files.
+
+    Issue #3948 made ``kct check`` auto-discover a committed
+    ``net_class_map.json`` next to the PCB (see
+    ``check_cmd._discover_net_class_map_sidecar``, which probes
+    ``<pcb_dir>/net_class_map.json``, ``<pcb_dir>/output/net_class_map.json``
+    and ``<pcb_dir>/../output/net_class_map.json``).  A "bare" ``kct check``
+    against a committed board artifact is therefore no longer actually
+    bare -- the sidecar auto-loads and the no-op / graceful-degradation
+    contract for external-router boards can no longer be observed.
+
+    This helper copies ONLY the PCB into a fresh, otherwise-empty
+    ``dest_dir`` so none of the auto-probe candidate paths resolve
+    (no sibling ``net_class_map.json``, no ``output/`` subtree, no
+    ``../output/`` sibling).  The returned path can be handed to a
+    subprocess ``kct check`` invocation with the guarantee that no
+    sidecar is discoverable.
+
+    Reuse this instead of re-deriving the tmp-dir-copy pattern whenever a
+    board that commits a ``net_class_map.json`` sidecar needs a genuinely
+    sidecar-less ``kct check`` run (Issue #4009).
+
+    Args:
+        pcb_path: The committed routed PCB to isolate.
+        dest_dir: A directory (typically a pytest tmp dir) to copy into.
+            Must not already contain sidecar files; a freshly created
+            ``tmp_path`` / ``tmp_path_factory.mktemp(...)`` dir is ideal.
+
+    Returns:
+        The path to the isolated PCB copy inside ``dest_dir``.
+    """
+    isolated = dest_dir / pcb_path.name
+    shutil.copy2(pcb_path, isolated)
+    return isolated
 
 
 def _committed_board_output_files() -> list[str]:

--- a/tests/test_kct_check_parity.py
+++ b/tests/test_kct_check_parity.py
@@ -322,9 +322,7 @@ class TestBoard07KctCheckParity:
         """
         if not BOARD_07_PCB.is_file():
             pytest.skip("board 07 routed PCB not present")
-        isolated = isolate_pcb_from_sidecars(
-            BOARD_07_PCB, tmp_path_factory.mktemp("board07-bare")
-        )
+        isolated = isolate_pcb_from_sidecars(BOARD_07_PCB, tmp_path_factory.mktemp("board07-bare"))
         return _run_kct_check(isolated, sidecar=None)
 
     @pytest.fixture(scope="class")

--- a/tests/test_kct_check_parity.py
+++ b/tests/test_kct_check_parity.py
@@ -37,6 +37,14 @@ The real-``kct check`` parity checks are marked ``integration`` + ``slow``
 (they run the full DRC engine on a routed BGA board, ~30s each).  The
 resolver unit tests are fast (temp dirs + a tiny derived map) and always
 run.
+
+Sidecar isolation (Issue #4009): since #3948 ``kct check`` auto-discovers a
+committed ``net_class_map.json`` next to the PCB, so a "bare" run against a
+committed board artifact is no longer actually bare.  The ``bare`` fixture
+below isolates the PCB from its sidecar via the shared
+``isolate_pcb_from_sidecars`` helper in ``tests/conftest.py`` -- reuse that
+helper for any future board's bare-check parity test instead of
+re-deriving the tmp-dir-copy pattern.
 """
 
 from __future__ import annotations
@@ -49,6 +57,8 @@ from collections import Counter
 from pathlib import Path
 
 import pytest
+
+from tests.conftest import isolate_pcb_from_sidecars
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CI_DIR = REPO_ROOT / "scripts" / "ci"
@@ -306,15 +316,15 @@ class TestBoard07KctCheckParity:
         ``net_class_map.json`` next to the PCB, so running against the
         in-repo artifact is no longer "bare" -- the no-op contract this
         class pins is only observable when no sidecar is DISCOVERABLE.
-        Copy the routed PCB into an isolated tmp dir (without the sidecar)
-        so the graceful-degradation path is actually exercised.
+        Use the shared ``isolate_pcb_from_sidecars`` helper (Issue #4009)
+        to copy the routed PCB into an isolated tmp dir without the
+        sidecar so the graceful-degradation path is actually exercised.
         """
         if not BOARD_07_PCB.is_file():
             pytest.skip("board 07 routed PCB not present")
-        import shutil
-
-        isolated = tmp_path_factory.mktemp("board07-bare") / BOARD_07_PCB.name
-        shutil.copy2(BOARD_07_PCB, isolated)
+        isolated = isolate_pcb_from_sidecars(
+            BOARD_07_PCB, tmp_path_factory.mktemp("board07-bare")
+        )
         return _run_kct_check(isolated, sidecar=None)
 
     @pytest.fixture(scope="class")


### PR DESCRIPTION
## Summary

Since #3948, `kct check` auto-discovers a committed `net_class_map.json` next to the PCB (`check_cmd._discover_net_class_map_sidecar`). A "bare" `kct check` against an in-repo board artifact is therefore no longer actually bare — the sidecar auto-loads, and the no-op / graceful-degradation contract for external-router boards can no longer be observed. `tests/test_kct_check_parity.py::TestBoard07KctCheckParity.bare` worked around this with an ad-hoc `shutil.copy2` into a fresh tmp dir.

This PR extracts that workaround into a reusable helper so a future board that commits a `net_class_map.json` sidecar doesn't have to reinvent the isolation pattern (Option A from the curation). Pure test-infra de-duplication — no behavior change.

## Changes

- `tests/conftest.py`: add `isolate_pcb_from_sidecars(pcb_path, dest_dir)` — copies only the PCB into an empty directory so none of `_discover_net_class_map_sidecar`'s three candidate paths (`<pcb_dir>/net_class_map.json`, `<pcb_dir>/output/...`, `<pcb_dir>/../output/...`) resolve. Documents the #3948 rationale and the auto-probe paths.
- `tests/test_kct_check_parity.py`: replace the inline `shutil.copy2` in the `bare` fixture with a call to the shared helper; import it via `from tests.conftest import isolate_pcb_from_sidecars`; add a cross-reference note in the module docstring pointing future bare-check parity tests at the helper.

Scoped to `net_class_map.json` only, per the curator's correction (there is no `.kicad_dru`/`.kicad_pro` auto-discovery inside `kct check`). The optional `--no-sidecar` CLI flag (Option B) was intentionally skipped — not required for this issue.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Reusable test helper for isolating a committed PCB from auto-discoverable sidecars | ✅ | `isolate_pcb_from_sidecars` added to `tests/conftest.py` |
| `bare` fixture uses the shared helper instead of inline `shutil.copy2` | ✅ | Fixture now calls `isolate_pcb_from_sidecars(BOARD_07_PCB, tmp_path_factory.mktemp("board07-bare"))` |
| Helper discoverable from the top of the parity test | ✅ | Module docstring now names the helper + `tests/conftest.py`; import at top of file |
| `pytest tests/test_kct_check_parity.py` passes (both `-m "not slow"` and `-m slow`) | ✅ | 32 passed (`-m "not slow"`) + 5 passed (`-m slow`) = full file green |

## Test Plan

- `uv run pytest tests/test_kct_check_parity.py tests/test_cli_check_net_class_map.py -m "not slow"` → 32 passed, 5 deselected
- `uv run pytest tests/test_kct_check_parity.py -m "slow"` → 5 passed (exercises the refactored `bare` fixture end-to-end through the real DRC engine)
- `uv run ruff check tests/conftest.py tests/test_kct_check_parity.py` → All checks passed

Closes #4009