### PR TITLE
fix(ci): unify blocking-error counter across the two routed-DRC gates

### DIFF
--- a/.github/routed-drc-tolerance.yml
+++ b/.github/routed-drc-tolerance.yml
@@ -1720,13 +1720,21 @@ tolerances:
   # MIPI_DAT0_N, TMDS_D0_N, TMDS_D1_N -- the #3438 negotiated-reach
   # residual; 26/31 is seed-invariant under --deterministic-budget, verified
   # across 7 seeds + --differential-pairs + --order-method congestion).
-  # Ratcheted 35 -> 14.  Counter-semantics note: check_routed_drc.py
-  # compares its ADVISORY-FILTERED blocking count (9) against this value,
-  # while check_matchgroup_coverage.py compares the RAW kct-check
-  # summary.errors (14 = 9 blocking + 5 advisory connectivity).  The single
-  # shared value must satisfy the raw counter, so 14 is zero-slack for the
-  # match-group gate and +5 slack for the blocking gate.
-  boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb: 14
+  # Ratcheted 35 -> 14 -> 9.
+  #
+  # 2026-07-09 (Issue #4008): the dual-counter seam is GONE.  Both gates now
+  # count BLOCKING errors: check_matchgroup_coverage.py's
+  # count_errors_via_kct_check delegates to the shared
+  # net_class_map_resolver.count_blocking_errors, the same advisory-filtered
+  # counter check_routed_drc.py uses.  Previously this floor had to satisfy
+  # the RAW-errors counter (14 = 9 blocking + 5 advisory connectivity),
+  # which forced +5 dead slack onto the blocking gate -- a 9 -> 13 blocking
+  # regression would have silently passed CI (13 <= 14).  Now both gates
+  # compare the identical blocking count (9), so the floor drops to the
+  # zero-slack blocking value.  Exit clause unchanged: re-route so the
+  # remaining 9 sidecar-gated errors clear (skew tuner + #3438
+  # negotiated-reach residual) and ratchet 9 downward.
+  boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb: 9
 
   # Board 05 (BLDC motor controller).  Issue #3470 (2026-06-10) removed
   # this board's tolerances entry -- the committed artifact reached a

--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 3942
-# Branch: feature/issue-3942
+# Issue: 4008
+# Branch: feature/issue-4008
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/scripts/ci/check_matchgroup_coverage.py
+++ b/scripts/ci/check_matchgroup_coverage.py
@@ -74,9 +74,17 @@ Reusing logic from ``check_diffpair_coverage.py`` / ``check_routed_drc.py``:
     * Re-route + PCB-locate helpers (``re_route_board``, ``find_routed_pcb``)
     * net_class_map import from generate_design.py (``build_net_class_map_for_board``)
 
-The helpers are duplicated rather than imported to keep each CI gate's
+Most helpers are duplicated rather than imported to keep each CI gate's
 blast radius minimal and to match the byte-for-byte convention
 established by ``check_diffpair_coverage.py``.
+
+Exception (Issue #4008): the blocking-vs-advisory error counter is
+IMPORTED from :mod:`net_class_map_resolver` rather than duplicated, so
+this gate and ``check_routed_drc.py`` compare the *same* count against the
+*same* ``.github/routed-drc-tolerance.yml`` floor.  This script previously
+read the raw ``summary.errors`` integer (advisory ``connectivity`` errors
+included), which diverged from ``check_routed_drc.py``'s blocking-only
+count and forced the shared floor up to absorb the difference.
 """
 
 from __future__ import annotations
@@ -89,6 +97,12 @@ import sys
 from pathlib import Path
 
 import yaml
+
+# Issue #4008: import the single shared blocking-error counter so this gate
+# and ``check_routed_drc.py`` agree on the count they gate against.
+# ``net_class_map_resolver`` lives next to this script in ``scripts/ci``.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from net_class_map_resolver import count_blocking_errors  # noqa: E402
 
 # --- shared with check_routed_drc.py / check_diffpair_coverage.py ------------
 
@@ -442,12 +456,25 @@ def measure_pour_connectivity(recipe_mod, pcb_path: Path, pour_nets: set[str]) -
 
 
 def count_errors_via_kct_check(pcb_path: Path, sidecar: Path | None) -> int:
-    """Count errors via ``kct check --mfr jlcpcb --errors-only --format json``.
+    """Count BLOCKING errors via ``kct check --mfr jlcpcb --errors-only``.
 
-    Mirrors ``check_diffpair_coverage.count_errors_via_kct_check`` so the
-    allowlist semantic matches the sibling CI gates exactly -- a value of
-    80 on the same routed PCB must mean the same thing across all three
-    gates (committed-diff, diff-pair regression, match-group regression).
+    Issue #4008: this counter now applies the same advisory-rule filter as
+    ``check_routed_drc.py`` -- it delegates to the shared
+    :func:`net_class_map_resolver.count_blocking_errors`, which excludes
+    ``DRCChecker.ADVISORY_RULE_IDS`` (currently just ``connectivity``) from
+    the count.  Previously this function returned the raw ``summary.errors``
+    integer, so on board 07 it reported 14 (9 blocking + 5 advisory
+    connectivity) while ``check_routed_drc.py`` reported 9 for the SAME
+    routed PCB against the SAME ``.github/routed-drc-tolerance.yml`` floor.
+    That divergence forced the shared floor up to the raw count and granted
+    the blocking gate dead slack.  Both gates now compare the identical
+    blocking-only count, so the floor can be tightened to the blocking
+    number.
+
+    The allowlist semantic still matches the sibling CI gates exactly -- a
+    value of N on the same routed PCB means the same thing across all
+    gates (committed-diff, diff-pair regression, match-group regression),
+    now that they all count blocking errors.
 
     The ``--net-class-map`` sidecar (when present) is passed through
     explicitly per the Phase 3L pattern (#2724 / curator comment).
@@ -460,7 +487,8 @@ def count_errors_via_kct_check(pcb_path: Path, sidecar: Path | None) -> int:
             the match-group rule to fire under standalone ``kct check``.
 
     Returns:
-        The ``summary.errors`` integer from the kct check JSON envelope.
+        The blocking (advisory-filtered) error count from the kct check
+        JSON envelope.
     """
     cmd = [
         "uv",
@@ -486,16 +514,25 @@ def count_errors_via_kct_check(pcb_path: Path, sidecar: Path | None) -> int:
             f"kct check returned unexpected exit code {proc.returncode} on "
             f"{pcb_path}. stderr:\n{proc.stderr.strip()}"
         )
+
+    # ``kct check``'s advisory drift banner is routed to stderr, but strip
+    # any leading non-``{`` lines defensively (mirrors check_routed_drc.py)
+    # so an older/regressed ``kct`` that prints ahead of the JSON body
+    # cannot break this parser.  The payload is always a single top-level
+    # object, so the first ``{`` reliably marks its start.
+    raw_stdout = proc.stdout
+    first_brace = raw_stdout.find("{")
+    json_stdout = raw_stdout[first_brace:] if first_brace > 0 else raw_stdout
     try:
-        data = json.loads(proc.stdout)
+        data = json.loads(json_stdout)
     except json.JSONDecodeError as e:
         raise RuntimeError(f"kct check produced invalid JSON on {pcb_path}: {e}") from e
 
-    summary = data.get("summary", {})
-    errors = summary.get("errors")
-    if not isinstance(errors, int):
-        raise RuntimeError(f"kct check JSON missing summary.errors field for {pcb_path}: {data!r}")
-    return errors
+    try:
+        blocking, _advisory_by_rule = count_blocking_errors(data)
+    except RuntimeError as e:
+        raise RuntimeError(f"{e} (source: {pcb_path})") from e
+    return blocking
 
 
 def compute_rule_coverage(

--- a/scripts/ci/check_routed_drc.py
+++ b/scripts/ci/check_routed_drc.py
@@ -48,17 +48,14 @@ from typing import Any
 import yaml
 
 # The CI gate mirrors the audit pipeline's advisory-rule classification
-# (``src/kicad_tools/audit/auditor.py:768``) so any rule classified as
-# advisory by :class:`DRCChecker.ADVISORY_RULE_IDS` does NOT block the gate.
-# Today that is just ``connectivity`` (partial-route reports surface in the
-# diagnostic output but do not gate manufacturability).
+# (``src/kicad_tools/audit/auditor.py``) so any rule classified as advisory
+# by :class:`DRCChecker.ADVISORY_RULE_IDS` does NOT block the gate.  Today
+# that is just ``connectivity`` (partial-route reports surface in the
+# diagnostic output but do not gate manufacturability).  The classifier
+# import now lives inside :func:`net_class_map_resolver.count_blocking_errors`
+# (Issue #4008 hoisted the shared counter), so this gate no longer imports
+# ``DRCChecker`` directly.
 #
-# The import lives here at module scope so a missing/renamed classifier
-# surfaces immediately at script start, not deep inside ``count_errors``.
-# The helper script runs under ``uv run`` (see ``main()`` call to
-# ``uv run kct check``) so ``kicad_tools`` is always importable.
-from kicad_tools.validate.checker import DRCChecker  # noqa: E402
-
 # Issue #3151: the strict error-count gate must count the diff-pair and
 # match-group rule families, which only fire when ``kct check`` is given a
 # ``--net-class-map`` sidecar (the rules no-op without one -- the documented
@@ -67,7 +64,10 @@ from kicad_tools.validate.checker import DRCChecker  # noqa: E402
 # import works whether the gate is launched as ``scripts/ci/check_routed_drc.py``
 # or imported as a module by the test suite.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from net_class_map_resolver import resolve_net_class_map_sidecar  # noqa: E402
+from net_class_map_resolver import (  # noqa: E402
+    count_blocking_errors,
+    resolve_net_class_map_sidecar,
+)
 
 DEFAULT_ALLOWLIST = Path(".github/routed-drc-tolerance.yml")
 DEFAULT_MANUFACTURER = "jlcpcb"
@@ -189,67 +189,16 @@ def load_manufacturers(allowlist_path: Path) -> dict[str, str]:
 def _count_blocking_errors(data: dict[str, Any]) -> tuple[int, dict[str, int]]:
     """Filter advisory rules out of a ``kct check --format json`` payload.
 
-    The gating verdict mirrors the audit pipeline's classifier
-    (``DRCChecker.is_advisory_rule``): rules in
-    :attr:`DRCChecker.ADVISORY_RULE_IDS` (currently just ``connectivity``)
-    surface to consumers but do not block manufacturability.  PR #3060 added
-    the ``connectivity`` rule and PR #3064 introduced the central classifier;
-    this helper makes the CI gate honour the same severity model as
-    ``ManufacturingAudit._check_drc``.
+    Issue #4008: the implementation now lives in
+    :func:`net_class_map_resolver.count_blocking_errors` so this gate and
+    ``check_matchgroup_coverage.py`` share ONE blocking-vs-advisory counter.
+    This thin wrapper is retained for the module's existing callers and unit
+    tests; it delegates verbatim to the shared helper.
 
-    Args:
-        data: Parsed JSON object emitted by ``kct check --format json``.
-            Expected to contain ``violations`` (a list with per-violation
-            ``rule_id`` and ``severity`` fields) and a ``summary.errors``
-            integer (the unfiltered count, used as a fall-back when no
-            ``violations`` array is present).
-
-    Returns:
-        Tuple of ``(blocking_errors, advisory_by_rule)``:
-
-        * ``blocking_errors`` -- number of error-severity violations whose
-          ``rule_id`` is NOT in ``ADVISORY_RULE_IDS``.  This is what the
-          gate compares to the allowlist.
-        * ``advisory_by_rule`` -- mapping of advisory ``rule_id`` to count
-          of error-severity violations of that rule, so callers can still
-          print the connectivity findings for diagnostic visibility per
-          the issue #3074 AC ("connectivity rule still appears in
-          violation reports").
-
-    Raises:
-        RuntimeError: If the JSON lacks both a ``violations`` array and a
-            ``summary.errors`` integer (the payload is malformed).
+    See :func:`net_class_map_resolver.count_blocking_errors` for the full
+    contract.
     """
-    violations = data.get("violations")
-    if isinstance(violations, list):
-        blocking = 0
-        advisory_by_rule: dict[str, int] = {}
-        for v in violations:
-            if not isinstance(v, dict):
-                continue
-            # Only error-severity violations count toward the gate; warnings
-            # are filtered upstream by ``--errors-only`` but we re-check
-            # defensively in case a future flag change loosens that.
-            severity = v.get("severity", "error")
-            if severity != "error":
-                continue
-            rule_id = v.get("rule_id", "")
-            if not isinstance(rule_id, str):
-                continue
-            if DRCChecker.is_advisory_rule(rule_id):
-                advisory_by_rule[rule_id] = advisory_by_rule.get(rule_id, 0) + 1
-            else:
-                blocking += 1
-        return blocking, advisory_by_rule
-
-    # Fall-back: no per-violation array (legacy format).  Trust
-    # ``summary.errors``.  Advisory awareness degrades gracefully -- the
-    # gate behaves exactly as it did before this change in that path.
-    summary = data.get("summary", {})
-    errors = summary.get("errors")
-    if not isinstance(errors, int):
-        raise RuntimeError(f"kct check JSON missing both violations and summary.errors: {data!r}")
-    return errors, {}
+    return count_blocking_errors(data)
 
 
 def count_errors(pcb_path: Path, mfr: str = DEFAULT_MANUFACTURER) -> tuple[int, dict[str, int]]:

--- a/scripts/ci/net_class_map_resolver.py
+++ b/scripts/ci/net_class_map_resolver.py
@@ -54,6 +54,90 @@ from typing import Any
 SIDECAR_FILENAME = "net_class_map.json"
 
 
+def count_blocking_errors(data: dict[str, Any]) -> tuple[int, dict[str, int]]:
+    """Filter advisory rules out of a ``kct check --format json`` payload.
+
+    Issue #4008: this is the single shared implementation of the
+    blocking-vs-advisory error count used by BOTH routed-PCB CI gates
+    (``check_routed_drc.py`` and ``check_matchgroup_coverage.py``).  Before
+    it was hoisted here, ``check_routed_drc.py`` filtered advisory rules but
+    ``check_matchgroup_coverage.py`` read the raw ``summary.errors`` integer,
+    so the two gates compared *different* counts (9 blocking vs 14 raw on
+    board 07) against the *same* ``.github/routed-drc-tolerance.yml`` floor.
+    That forced the shared floor up to the raw count, silently granting the
+    blocking gate dead slack (a 9->13 blocking regression could pass CI).
+    Centralising the counter lets both gates agree and lets the floor drop
+    to the blocking-only count.
+
+    The gating verdict mirrors the audit pipeline's classifier
+    (``DRCChecker.is_advisory_rule``): rules in
+    :attr:`DRCChecker.ADVISORY_RULE_IDS` (currently just ``connectivity``)
+    surface to consumers but do not block manufacturability.  PR #3060 added
+    the ``connectivity`` rule and PR #3064 introduced the central classifier;
+    this helper makes the CI gates honour the same severity model as
+    ``ManufacturingAudit._check_drc``.
+
+    Args:
+        data: Parsed JSON object emitted by ``kct check --format json``.
+            Expected to contain ``violations`` (a list with per-violation
+            ``rule_id`` and ``severity`` fields) and a ``summary.errors``
+            integer (the unfiltered count, used as a fall-back when no
+            ``violations`` array is present).
+
+    Returns:
+        Tuple of ``(blocking_errors, advisory_by_rule)``:
+
+        * ``blocking_errors`` -- number of error-severity violations whose
+          ``rule_id`` is NOT in ``ADVISORY_RULE_IDS``.  This is what the
+          gates compare to the allowlist.
+        * ``advisory_by_rule`` -- mapping of advisory ``rule_id`` to count
+          of error-severity violations of that rule, so callers can still
+          print the connectivity findings for diagnostic visibility per
+          the issue #3074 AC ("connectivity rule still appears in
+          violation reports").
+
+    Raises:
+        RuntimeError: If the JSON lacks both a ``violations`` array and a
+            ``summary.errors`` integer (the payload is malformed).
+    """
+    # Import lazily so the module stays importable in contexts where
+    # ``kicad_tools`` is not yet on the path (the CI scripts run under
+    # ``uv run`` where it always is).  A missing/renamed classifier surfaces
+    # here, at the first count, rather than at module import time.
+    from kicad_tools.validate.checker import DRCChecker
+
+    violations = data.get("violations")
+    if isinstance(violations, list):
+        blocking = 0
+        advisory_by_rule: dict[str, int] = {}
+        for v in violations:
+            if not isinstance(v, dict):
+                continue
+            # Only error-severity violations count toward the gate; warnings
+            # are filtered upstream by ``--errors-only`` but we re-check
+            # defensively in case a future flag change loosens that.
+            severity = v.get("severity", "error")
+            if severity != "error":
+                continue
+            rule_id = v.get("rule_id", "")
+            if not isinstance(rule_id, str):
+                continue
+            if DRCChecker.is_advisory_rule(rule_id):
+                advisory_by_rule[rule_id] = advisory_by_rule.get(rule_id, 0) + 1
+            else:
+                blocking += 1
+        return blocking, advisory_by_rule
+
+    # Fall-back: no per-violation array (legacy format).  Trust
+    # ``summary.errors``.  Advisory awareness degrades gracefully -- the
+    # gates behave exactly as they did before this change in that path.
+    summary = data.get("summary", {})
+    errors = summary.get("errors")
+    if not isinstance(errors, int):
+        raise RuntimeError(f"kct check JSON missing both violations and summary.errors: {data!r}")
+    return errors, {}
+
+
 def _import_module_from_path(module_name: str, path: Path) -> Any:
     """Import a module by file path without permanently polluting sys.path."""
     spec = importlib.util.spec_from_file_location(module_name, path)

--- a/tests/test_check_routed_drc_advisory.py
+++ b/tests/test_check_routed_drc_advisory.py
@@ -34,17 +34,31 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-HELPER_SCRIPT_PATH = REPO_ROOT / "scripts" / "ci" / "check_routed_drc.py"
+CI_DIR = REPO_ROOT / "scripts" / "ci"
+HELPER_SCRIPT_PATH = CI_DIR / "check_routed_drc.py"
+COVERAGE_SCRIPT_PATH = CI_DIR / "check_matchgroup_coverage.py"
+
+
+def _load_script_module(name: str, path: Path):
+    """Import a ``scripts/ci`` helper script as a module.
+
+    ``scripts/ci`` is added to ``sys.path`` first so the scripts'
+    ``from net_class_map_resolver import ...`` statements resolve when the
+    module is loaded outside its own ``sys.path.insert`` (the insert runs at
+    import time, but pytest may import a sibling first)."""
+    if str(CI_DIR) not in sys.path:
+        sys.path.insert(0, str(CI_DIR))
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def _load_helper_module():
     """Import ``scripts/ci/check_routed_drc.py`` as a module."""
-    spec = importlib.util.spec_from_file_location("check_routed_drc", HELPER_SCRIPT_PATH)
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    sys.modules["check_routed_drc"] = module
-    spec.loader.exec_module(module)
-    return module
+    return _load_script_module("check_routed_drc", HELPER_SCRIPT_PATH)
 
 
 def _make_violation(rule_id: str, severity: str = "error", message: str = "synthetic") -> dict:
@@ -86,35 +100,28 @@ def _make_kct_json(violations: list[dict]) -> str:
 
 
 class TestAdvisoryRuleIdsImport:
-    """Pin that the helper imports the classifier from the canonical source.
+    """Pin that the shared counter uses the classifier from the canonical
+    source.
 
     A future refactor that hardcodes a local set instead of using
     ``DRCChecker.is_advisory_rule`` would silently drift -- the audit
-    pipeline and the gate must stay in lockstep.
+    pipeline and the gates must stay in lockstep.  Issue #4008 hoisted the
+    counter into ``net_class_map_resolver.count_blocking_errors``, so the
+    ``DRCChecker`` import now lives there (imported lazily) rather than at
+    ``check_routed_drc.py`` module scope.
     """
-
-    def setup_method(self) -> None:
-        self.helper = _load_helper_module()
-
-    def test_helper_imports_drcchecker(self) -> None:
-        """The helper module must expose the imported ``DRCChecker`` so
-        the gate's filtering uses the same classifier as the audit
-        pipeline (``src/kicad_tools/audit/auditor.py:768``)."""
-        assert hasattr(self.helper, "DRCChecker"), (
-            "scripts/ci/check_routed_drc.py must import DRCChecker so the "
-            "advisory-rule classifier stays in lockstep with the audit "
-            "pipeline (issue #3074)."
-        )
 
     def test_connectivity_is_currently_advisory(self) -> None:
         """Document the current ADVISORY_RULE_IDS membership so a future
         refactor that drops ``connectivity`` (or adds a new rule whose
         severity should NOT block the gate) surfaces a test failure that
         triggers an explicit re-think rather than a silent CI drift."""
-        assert self.helper.DRCChecker.is_advisory_rule("connectivity")
+        from kicad_tools.validate.checker import DRCChecker
+
+        assert DRCChecker.is_advisory_rule("connectivity")
         # Non-advisory blocking rules must NOT be misclassified.
-        assert not self.helper.DRCChecker.is_advisory_rule("clearance_segment_via")
-        assert not self.helper.DRCChecker.is_advisory_rule("clearance_pad_via")
+        assert not DRCChecker.is_advisory_rule("clearance_segment_via")
+        assert not DRCChecker.is_advisory_rule("clearance_pad_via")
 
 
 class TestCountBlockingErrorsDirect:
@@ -373,3 +380,92 @@ class TestStdoutPrefixTolerance:
         with self._stub_kct(polluted):
             with pytest.raises(RuntimeError, match="invalid JSON"):
                 self.helper.count_errors(Path("synthetic.kicad_pcb"))
+
+
+class TestCrossScriptCounterParity:
+    """Issue #4008: the two routed-PCB CI gates must count the SAME blocking
+    errors for the same ``kct check`` payload.
+
+    Before this issue, ``check_routed_drc.py`` filtered advisory rules while
+    ``check_matchgroup_coverage.py`` read the raw ``summary.errors`` integer,
+    so on board 07 they reported 9 vs 14 against the SAME
+    ``.github/routed-drc-tolerance.yml`` floor -- forcing +5 dead slack onto
+    the blocking gate.  These tests pin that both gates now delegate to the
+    single shared ``net_class_map_resolver.count_blocking_errors``.
+    """
+
+    def setup_method(self) -> None:
+        # Drop any stale cached copies so the two scripts import a fresh,
+        # shared ``net_class_map_resolver`` in a deterministic order.
+        for name in ("check_routed_drc", "check_matchgroup_coverage", "net_class_map_resolver"):
+            sys.modules.pop(name, None)
+        self.drc = _load_helper_module()
+        self.coverage = _load_script_module("check_matchgroup_coverage", COVERAGE_SCRIPT_PATH)
+        # Reuse the resolver the scripts already imported (same object) so the
+        # identity assertion below is meaningful; both scripts do
+        # ``from net_class_map_resolver import count_blocking_errors``.
+        self.resolver = sys.modules["net_class_map_resolver"]
+
+    def _stub_kct(self, json_payload: str, returncode: int = 2):
+        mock_proc = MagicMock()
+        mock_proc.returncode = returncode
+        mock_proc.stdout = json_payload
+        mock_proc.stderr = ""
+        return patch.object(subprocess, "run", return_value=mock_proc)
+
+    def test_board07_shaped_payload_agrees_across_scripts(self) -> None:
+        """A payload matching board 07 (9 blocking + 5 advisory
+        connectivity = 14 raw) must yield 9 from BOTH gates, not 9 vs 14."""
+        violations = (
+            [_make_violation("diffpair_length_skew") for _ in range(4)]
+            + [_make_violation("diffpair_routing_continuity") for _ in range(4)]
+            + [_make_violation("match_group_length_skew")]
+            + [_make_violation("connectivity") for _ in range(5)]
+        )
+        payload = _make_kct_json(violations)
+        # Raw summary.errors is 14 (the OLD count) -- assert we do NOT use it.
+        assert json.loads(payload)["summary"]["errors"] == 14
+
+        # check_routed_drc.py path
+        with self._stub_kct(payload):
+            drc_blocking, drc_advisory = self.drc.count_errors(
+                Path("boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb")
+            )
+        # check_matchgroup_coverage.py path
+        with self._stub_kct(payload):
+            coverage_blocking = self.coverage.count_errors_via_kct_check(
+                Path("boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb"),
+                sidecar=None,
+            )
+        # Shared helper path (the source of truth both delegate to)
+        shared_blocking, shared_advisory = self.resolver.count_blocking_errors(json.loads(payload))
+
+        assert drc_blocking == coverage_blocking == shared_blocking == 9, (
+            f"Gates disagree: check_routed_drc={drc_blocking}, "
+            f"check_matchgroup_coverage={coverage_blocking}, "
+            f"shared={shared_blocking} (expected 9 blocking, advisory excluded)."
+        )
+        assert drc_advisory == shared_advisory == {"connectivity": 5}
+
+    def test_both_scripts_share_one_counter_function(self) -> None:
+        """Both scripts must reference the SAME ``count_blocking_errors``
+        object from ``net_class_map_resolver`` -- not private copies that
+        could drift.  This is the structural guard against the seam ever
+        re-opening."""
+        assert self.drc.count_blocking_errors is self.resolver.count_blocking_errors
+        assert self.coverage.count_blocking_errors is self.resolver.count_blocking_errors
+
+    def test_pure_advisory_payload_agrees_at_zero(self) -> None:
+        """A payload with only advisory connectivity must yield 0 blocking
+        from both gates (not the raw connectivity count)."""
+        violations = [_make_violation("connectivity") for _ in range(3)]
+        payload = _make_kct_json(violations)
+        assert json.loads(payload)["summary"]["errors"] == 3
+
+        with self._stub_kct(payload):
+            drc_blocking, _ = self.drc.count_errors(Path("synthetic.kicad_pcb"))
+        with self._stub_kct(payload):
+            coverage_blocking = self.coverage.count_errors_via_kct_check(
+                Path("synthetic.kicad_pcb"), sidecar=None
+            )
+        assert drc_blocking == coverage_blocking == 0


### PR DESCRIPTION
## Summary

`scripts/ci/check_routed_drc.py` and `scripts/ci/check_matchgroup_coverage.py` both gate a routed PCB's DRC error count against the same `.github/routed-drc-tolerance.yml` floor, but they counted **different** things:

- `check_routed_drc.py::_count_blocking_errors` filtered advisory rules (`DRCChecker.ADVISORY_RULE_IDS`, currently just `connectivity`) and reported the **blocking-only** count -- **9** on board 07.
- `check_matchgroup_coverage.py::count_errors_via_kct_check` read the raw `summary.errors` integer with **no advisory filter** -- **14** on board 07 (9 blocking + 5 advisory connectivity).

The single shared floor had to satisfy the raw counter, so it sat at **14**, forcing **+5 dead slack** onto the blocking gate: a real 9->13 blocking regression would have silently passed CI (`13 <= 14`).

This PR hoists the counter into the shared module both gates already sit next to and has both delegate to it, then tightens the board-07 floor to the now-zero-slack blocking value of **9**.

## Changes

- **`scripts/ci/net_class_map_resolver.py`**: new shared `count_blocking_errors(data)` -- the single blocking-vs-advisory counter (imports `DRCChecker` lazily so the classifier stays in lockstep with the audit pipeline).
- **`scripts/ci/check_routed_drc.py`**: `_count_blocking_errors` is now a thin wrapper delegating to the shared helper; the module-scope `DRCChecker` import (now dead) is removed.
- **`scripts/ci/check_matchgroup_coverage.py`**: `count_errors_via_kct_check` now returns the blocking (advisory-filtered) count via the shared helper instead of raw `summary.errors`; also adds the same defensive strip-to-first-`{` stdout handling `check_routed_drc.py` uses.
- **`.github/routed-drc-tolerance.yml`**: board-07 floor `14 -> 9`, comment rewritten to record the seam is closed.
- **`tests/test_check_routed_drc_advisory.py`**: new `TestCrossScriptCounterParity` asserting both scripts reference the *same* `count_blocking_errors` object and produce identical counts (9) on a board-07-shaped mixed fixture; updated the classifier-import pin for the hoist.

## Scope note (Part A only)

Per the curation guidance, this PR is scoped to **Part A**: counter unification + yml tightening + tests. **Part B** -- threading a `net_class_map` sidecar through `kct export`'s `report.md` DRC section (acceptance criterion 3) -- is deliberately **left out** to keep the blast radius inside `scripts/ci/`. It stays tracked by #4008 (or a follow-up). Part A alone removes the more actionable CI-gate blind spot (the dead slack that could hide a blocking-count regression).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| 1. Both gates compare the same blocking count on board 07 | ✅ | Ran both against `boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb`: `check_routed_drc.py` -> `9 errors`, `check_matchgroup_coverage.py --skip-route` -> `DRC error count: 9 (allowed: 9)`. Identical. |
| 2. yml board-07 entry tightened to remove dual-counter slack | ✅ | `14 -> 9` (zero slack). Board 06 left at 24 -- its slack is re-route-bound (`max(committed 18, seed-42 re-route)`), not the dual-counter seam, so out of scope for this fix. |
| 3. report.md sidecar threading | ⏭️ | Deliberately deferred (Part B) -- see Scope note. |
| 4. Bare/no-sidecar boards still degrade gracefully | ✅ | Shared helper's legacy/no-`violations` fall-back path preserved and unit-tested; board 06 (no dual-counter) reports 18 unchanged. |
| 5. Existing tests updated + regression test added | ✅ | `TestCrossScriptCounterParity` added; classifier-import pin updated; full advisory + coverage + board-06/07 suites pass. |

## Test Plan

- `uv run pytest tests/test_check_routed_drc_advisory.py` -- 18 passed (incl. new parity class).
- `uv run pytest tests/test_check_matchgroup_coverage.py tests/test_check_diffpair_coverage.py` -- 64 passed.
- `uv run pytest tests/test_board_07_matchgroup_test.py tests/test_kct_check_parity.py` -- 62 passed.
- `uv run pytest tests/test_ci_routed_drc_workflow.py tests/test_board_06_diffpair_test.py` -- 91 passed.
- `uv run ruff check` + `ruff format --check` on all changed files -- clean.
- End-to-end: both CI scripts run against the committed board-07 artifact report an identical `9` against the tightened floor of `9` (PASS, zero slack).

Closes #4008