### PR TITLE
feat(3d): cross-library substitution tier for generic footprint model refs

### DIFF
--- a/boards/06-diffpair-test/output/diffpair_test.kicad_pcb
+++ b/boards/06-diffpair-test/output/diffpair_test.kicad_pcb
@@ -98,6 +98,17 @@
     (pad "B12" smd rect (at -5.500 2.000) (size 0.300 0.600) (layers "F.Cu" "F.Paste" "F.Mask") (net 5 "GND"))
     (pad "S1" thru_hole circle (at -7.500 1.000) (size 1.000 1.000) (drill 0.600) (layers "*.Cu" "*.Mask") (net 5 "GND"))
     (pad "S2" thru_hole circle (at 7.500 1.000) (size 1.000 1.000) (drill 0.600) (layers "*.Cu" "*.Mask") (net 5 "GND"))
+  	(model "${KICAD10_3DMODEL_DIR}/Connector_USB.3dshapes/USB_C_Receptacle_GCT_USB4105-xx-A_16P_TopMnt_Horizontal.step"
+  		(offset
+  			(xyz 0 0 0)
+  		)
+  		(scale
+  			(xyz 1 1 1)
+  		)
+  		(rotate
+  			(xyz 0 0 0)
+  		)
+  	)
   )
   (footprint "Connector_PCIE:PCIE_Mini_Edge"
     (layer "F.Cu")
@@ -139,6 +150,17 @@
     (pad "M1" thru_hole circle (at -1.500 1.200) (size 1.000 1.000) (drill 0.600) (layers "*.Cu" "*.Mask") (net 5 "GND"))
     (pad "M2" thru_hole circle (at 1.500 1.200) (size 1.000 1.000) (drill 0.600) (layers "*.Cu" "*.Mask") (net 5 "GND"))
     (pad "RST" smd rect (at 0.000 -1.500) (size 0.500 0.500) (layers "F.Cu" "F.Paste" "F.Mask") (net 26 "MIPI_RST"))
+  	(model "${KICAD10_3DMODEL_DIR}/Connector_FFC-FPC.3dshapes/Amphenol_F32Q-1A7x1-11004_1x04-1MP_P0.5mm_Horizontal.step"
+  		(offset
+  			(xyz 0 0 0)
+  		)
+  		(scale
+  			(xyz 1 1 1)
+  		)
+  		(rotate
+  			(xyz 0 0 0)
+  		)
+  	)
   )
   (footprint "Package_DFN_QFN:QFN-32-1EP_5x5mm_P0.5mm"
     (layer "F.Cu")
@@ -253,6 +275,17 @@
     (pad "G5" smd rect (at 1.270 3.810) (size 0.450 0.450) (layers "F.Cu" "F.Paste" "F.Mask") (net 5 "GND"))
     (pad "G6" smd rect (at 2.540 3.810) (size 0.450 0.450) (layers "F.Cu" "F.Paste" "F.Mask") (net 5 "GND"))
     (pad "G7" smd rect (at 3.810 3.810) (size 0.450 0.450) (layers "F.Cu" "F.Paste" "F.Mask") (net 5 "GND"))
+  	(model "${KICAD10_3DMODEL_DIR}/Package_BGA.3dshapes/VFBGA-49_5.0x5.0mm_Layout7x7_P0.65mm.step"
+  		(offset
+  			(xyz 0 0 0)
+  		)
+  		(scale
+  			(xyz 1 1 1)
+  		)
+  		(rotate
+  			(xyz 0 0 0)
+  		)
+  	)
   )
   (footprint "Package_QFP:LQFP-48_7x7mm_P0.5mm"
     (layer "F.Cu")

--- a/boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb
+++ b/boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb
@@ -207,6 +207,17 @@
 			(net 26 "MIPI_RST")
 		)
 		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/Connector_FFC-FPC.3dshapes/Amphenol_F32Q-1A7x1-11004_1x04-1MP_P0.5mm_Horizontal.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
 	)
 	(footprint "Package_DFN_QFN:QFN-32-1EP_5x5mm_P0.5mm"
 		(layer "F.Cu")
@@ -770,6 +781,17 @@
 			(net 5 "GND")
 		)
 		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/Connector_USB.3dshapes/USB_C_Receptacle_GCT_USB4105-xx-A_16P_TopMnt_Horizontal.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
 	)
 	(footprint "Package_DFN_QFN:QFN-24-1EP_4x4mm_P0.5mm"
 		(layer "F.Cu")
@@ -2039,6 +2061,17 @@
 			(net 5 "GND")
 		)
 		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/Package_BGA.3dshapes/VFBGA-49_5.0x5.0mm_Layout7x7_P0.65mm.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
 	)
 	(gr_rect
 		(start 98.5 47.5)

--- a/boards/07-matchgroup-test/output/matchgroup_test.kicad_pcb
+++ b/boards/07-matchgroup-test/output/matchgroup_test.kicad_pcb
@@ -228,6 +228,17 @@
     (pad "6" smd rect (at 2.500 0.000) (size 0.400 0.900) (layers "F.Cu" "F.Paste" "F.Mask") (net 20 "MIPI_DAT1_N"))
     (pad "M1" thru_hole circle (at -3.500 1.500) (size 1.000 1.000) (drill 0.600) (layers "*.Cu" "*.Mask") (net 3 "GND"))
     (pad "M2" thru_hole circle (at 3.500 1.500) (size 1.000 1.000) (drill 0.600) (layers "*.Cu" "*.Mask") (net 3 "GND"))
+  	(model "${KICAD10_3DMODEL_DIR}/Connector_FFC-FPC.3dshapes/TE_84952-6_1x06-1MP_P1.0mm_Horizontal.step"
+  		(offset
+  			(xyz 0 0 0)
+  		)
+  		(scale
+  			(xyz 1 1 1)
+  		)
+  		(rotate
+  			(xyz 0 0 0)
+  		)
+  	)
   )
   (footprint "Package_DFN_QFN:QFN-24-1EP_4x4mm_P0.5mm"
     (layer "F.Cu")
@@ -295,6 +306,17 @@
     (pad "8" smd rect (at 3.500 0.000) (size 0.400 1.000) (layers "F.Cu" "F.Paste" "F.Mask") (net 26 "TMDS_D2_N"))
     (pad "S1" thru_hole circle (at -5.000 1.500) (size 1.200 1.200) (drill 0.700) (layers "*.Cu" "*.Mask") (net 3 "GND"))
     (pad "S2" thru_hole circle (at 5.000 1.500) (size 1.200 1.200) (drill 0.700) (layers "*.Cu" "*.Mask") (net 3 "GND"))
+  	(model "${KICAD10_3DMODEL_DIR}/Connector_Video.3dshapes/HDMI_A_Amphenol_10029449-x01xLF_Horizontal.step"
+  		(offset
+  			(xyz 0 0 0)
+  		)
+  		(scale
+  			(xyz 1 1 1)
+  		)
+  		(rotate
+  			(xyz 0 0 0)
+  		)
+  	)
   )
   (footprint "Package_BGA:BGA-49_5.0x5.0mm_Layout7x7_P0.5mm"
     (layer "F.Cu")
@@ -355,6 +377,17 @@
     (pad "G5" smd rect (at 1.270 3.810) (size 0.450 0.450) (layers "F.Cu" "F.Paste" "F.Mask") (net 3 "GND"))
     (pad "G6" smd rect (at 2.540 3.810) (size 0.450 0.450) (layers "F.Cu" "F.Paste" "F.Mask") (net 3 "GND"))
     (pad "G7" smd rect (at 3.810 3.810) (size 0.450 0.450) (layers "F.Cu" "F.Paste" "F.Mask") (net 3 "GND"))
+  	(model "${KICAD10_3DMODEL_DIR}/Package_BGA.3dshapes/VFBGA-49_5.0x5.0mm_Layout7x7_P0.65mm.step"
+  		(offset
+  			(xyz 0 0 0)
+  		)
+  		(scale
+  			(xyz 1 1 1)
+  		)
+  		(rotate
+  			(xyz 0 0 0)
+  		)
+  	)
   )
   (footprint "Connector_PinHeader_2.54mm:PinHeader_1x09_P2.54mm_Vertical"
     (layer "F.Cu")

--- a/boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb
+++ b/boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb
@@ -1223,6 +1223,17 @@
 			(net 3 "GND")
 		)
 		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/Connector_FFC-FPC.3dshapes/TE_84952-6_1x06-1MP_P1.0mm_Horizontal.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
 	)
 	(footprint "Package_DFN_QFN:QFN-24-1EP_4x4mm_P0.5mm"
 		(layer "F.Cu")
@@ -1903,6 +1914,17 @@
 			(net 3 "GND")
 		)
 		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/Package_BGA.3dshapes/VFBGA-49_5.0x5.0mm_Layout7x7_P0.65mm.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
 	)
 	(footprint "Connector_Video:HDMI_A_Receptacle"
 		(layer "F.Cu")
@@ -2030,6 +2052,17 @@
 			(net 3 "GND")
 		)
 		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/Connector_Video.3dshapes/HDMI_A_Amphenol_10029449-x01xLF_Horizontal.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
 	)
 	(footprint "Package_DFN_QFN:QFN-48-1EP_7x7mm_P0.5mm"
 		(layer "F.Cu")

--- a/src/kicad_tools/cli/pcb_add_3d_models.py
+++ b/src/kicad_tools/cli/pcb_add_3d_models.py
@@ -83,6 +83,7 @@ def run_add_3d_models(
         "unresolved": report.unresolved,
         "no_model_in_library": report.no_model_in_library,
         "variant_matches": report.variant_matches,
+        "substitution_matches": report.substitution_matches,
     }
 
     if output_format == "json":
@@ -104,6 +105,10 @@ def run_add_3d_models(
             print("  Same-library variant models used (visual match):")
             for lib_id, stem in sorted(report.variant_matches.items()):
                 print(f"    {lib_id} -> {stem}")
+        if report.substitution_matches:
+            print("  Cross-library substitution models used (curated equivalent):")
+            for lib_id, sub in sorted(report.substitution_matches.items()):
+                print(f"    {lib_id} -> {sub}")
         if report.already_present:
             print(f"  Already had models: {len(report.already_present)}")
         if report.no_model_in_library:

--- a/src/kicad_tools/pcb/model_substitutions.py
+++ b/src/kicad_tools/pcb/model_substitutions.py
@@ -1,0 +1,76 @@
+"""Cross-library 3D-model substitutions for footprints with no direct match.
+
+Some board generators emit synthetic or generic footprint lib ids that do
+**not** correspond to any installed KiCad ``.kicad_mod`` — and, unlike the
+same-library variant fallback in ``models3d._find_variant_mod``, the visual
+equivalent lives in a *different* library under a *different* name.  Two
+naming-convention gaps drive this:
+
+* **Renamed libraries.**  ``Connector_FFC`` was renamed to
+  ``Connector_FFC-FPC`` upstream; the generic ``FFC_4P_0.5mm`` /
+  ``FFC_6P_1.0mm`` names never shipped as real footprints.
+* **Vendor-suffixed names only.**  ``Connector_USB`` and
+  ``Connector_Video`` ship only vendor-specific names
+  (``USB_C_Receptacle_GCT_...``, ``HDMI_A_Amphenol_...``), so a generic
+  ``USB_C_Receptacle_USB2.0`` / ``HDMI_A_Receptacle`` lib id resolves to
+  nothing even though a body-compatible part is installed.
+* **Near-neighbour JEDEC package.**  ``BGA-49_5.0x5.0mm_Layout7x7_P0.5mm``
+  has no exact match, but ``VFBGA-49_5.0x5.0mm_Layout7x7_P0.65mm`` is the
+  same ball count and outline — close enough for a render body.
+
+This is an **explicit, curated** ``lib_id -> lib_id`` table, not a fuzzy
+search: each entry is a hand-verified visual equivalent whose installed
+``.kicad_mod`` carries a ``(model ...)`` node.  The resolver consults it
+only after both exact-match and same-library variant matching have failed,
+so it can never redirect an already-resolvable footprint.
+
+The substituted body is *render metadata only* — no copper, pad, or DRC
+geometry is affected (the patch stays a pure ``(model ...)`` insertion).
+The substitute is deliberately chosen for the right *outline/pin family*,
+not pin-for-pin electrical identity.
+
+Footprints with **no** installed or open substitute at all (e.g.
+``Module:Joystick_Analog``, ``Connector_PCIE:PCIE_Mini_Edge``) are
+intentionally *absent* from this table: they need a vendor-sourced STEP
+file that must be collected by a human/operator, and are tracked in a
+separate follow-up issue.
+"""
+
+from __future__ import annotations
+
+__all__ = ["MODEL_SUBSTITUTIONS", "substitute_lib_id"]
+
+
+# Curated generic/synthetic lib id -> installed body-compatible lib id.
+# Every value is verified to exist in the standard KiCad libraries with a
+# (model ...) node at authoring time (see issue #4014).
+MODEL_SUBSTITUTIONS: dict[str, str] = {
+    # Connector_FFC was renamed Connector_FFC-FPC; pick the pin-count- and
+    # pitch-matched vendor part.
+    "Connector_FFC:FFC_4P_0.5mm": (
+        "Connector_FFC-FPC:Amphenol_F32Q-1A7x1-11004_1x04-1MP_P0.5mm_Horizontal"
+    ),
+    "Connector_FFC:FFC_6P_1.0mm": ("Connector_FFC-FPC:TE_84952-6_1x06-1MP_P1.0mm_Horizontal"),
+    # Connector_USB ships only vendor-suffixed USB-C names; this GCT part is
+    # already the body board 03 resolves against for the same lib id.
+    "Connector_USB:USB_C_Receptacle_USB2.0": (
+        "Connector_USB:USB_C_Receptacle_GCT_USB4105-xx-A_16P_TopMnt_Horizontal"
+    ),
+    # Connector_Video ships only vendor-suffixed HDMI names.
+    "Connector_Video:HDMI_A_Receptacle": (
+        "Connector_Video:HDMI_A_Amphenol_10029449-x01xLF_Horizontal"
+    ),
+    # Same 49-ball 5.0x5.0 7x7 outline; nearest installed pitch (0.65mm).
+    "Package_BGA:BGA-49_5.0x5.0mm_Layout7x7_P0.5mm": (
+        "Package_BGA:VFBGA-49_5.0x5.0mm_Layout7x7_P0.65mm"
+    ),
+}
+
+
+def substitute_lib_id(lib_id: str) -> str | None:
+    """Return the substitute lib id for *lib_id*, or ``None`` if none exists.
+
+    Consulted by the model resolver only after exact-match and same-library
+    variant matching have both failed.
+    """
+    return MODEL_SUBSTITUTIONS.get(lib_id)

--- a/src/kicad_tools/pcb/models3d.py
+++ b/src/kicad_tools/pcb/models3d.py
@@ -29,6 +29,7 @@ from kicad_tools.footprints.library_path import (
     detect_kicad_library_path,
     parse_library_id,
 )
+from kicad_tools.pcb.model_substitutions import substitute_lib_id
 
 __all__ = [
     "FootprintBlock",
@@ -241,7 +242,9 @@ def make_library_resolver(
     library_paths: LibraryPaths | None = None,
     *,
     allow_variants: bool = True,
+    allow_substitutions: bool = True,
     variant_log: dict[str, str] | None = None,
+    substitution_log: dict[str, str] | None = None,
 ) -> Resolver:
     """Build a resolver that reads model refs from installed KiCad libraries.
 
@@ -251,34 +254,73 @@ def make_library_resolver(
     found and ``[]`` when it exists but carries no model reference.
     Results are cached per lib id.
 
+    Resolution tiers (first hit wins):
+
+    1. **Exact** installed footprint for ``library:name``.
+    2. **Same-library variant** (``_find_variant_mod``) — a suffixed name in
+       the same library, when ``allow_variants`` is set.
+    3. **Cross-library substitution** (``model_substitutions``) — an explicit,
+       curated ``lib_id -> lib_id`` mapping for generic/synthetic lib ids that
+       have a body-compatible equivalent in a *different* library, when
+       ``allow_substitutions`` is set.
+
     Args:
         library_paths: Explicit library location (default: auto-detect).
         allow_variants: When the exact footprint name is missing, fall back
             to a same-library name variant (see ``_find_variant_mod``).
+        allow_substitutions: When exact + variant matching both miss, fall
+            back to the curated cross-library substitution table.
         variant_log: Optional dict populated with ``lib_id -> variant stem``
-            for every fallback match, so callers can report them.
+            for every same-library variant match, so callers can report them.
+        substitution_log: Optional dict populated with
+            ``lib_id -> substitute lib_id`` for every cross-library
+            substitution, so callers can report them.
     """
     paths = library_paths if library_paths is not None else detect_kicad_library_path()
     cache: dict[str, list[str] | None] = {}
+
+    def _lookup_mod(lib_id: str) -> tuple[Path | None, str | None]:
+        """Return (mod path, substitute lib id) for *lib_id*, or (None, None).
+
+        The second element is set only when the match came from the
+        cross-library substitution table.
+        """
+        library, name = parse_library_id(lib_id)
+        if not library:
+            return None, None
+        mod_path = paths.get_footprint_file(library, name, fallback_search=False)
+        if mod_path is not None:
+            return mod_path, None
+        if allow_variants:
+            mod_path = _find_variant_mod(paths, library, name)
+            if mod_path is not None:
+                if variant_log is not None:
+                    variant_log[lib_id] = mod_path.stem
+                return mod_path, None
+        if allow_substitutions:
+            sub_id = substitute_lib_id(lib_id)
+            if sub_id is not None:
+                sub_lib, sub_name = parse_library_id(sub_id)
+                if sub_lib:
+                    mod_path = paths.get_footprint_file(sub_lib, sub_name, fallback_search=False)
+                    if mod_path is not None:
+                        return mod_path, sub_id
+        return None, None
 
     def resolve(lib_id: str) -> list[str] | None:
         if lib_id in cache:
             return cache[lib_id]
         result: list[str] | None = None
         if paths.found:
-            library, name = parse_library_id(lib_id)
-            mod_path = None
-            if library:
-                mod_path = paths.get_footprint_file(library, name, fallback_search=False)
-                if mod_path is None and allow_variants:
-                    mod_path = _find_variant_mod(paths, library, name)
-                    if mod_path is not None and variant_log is not None:
-                        variant_log[lib_id] = mod_path.stem
+            mod_path, sub_id = _lookup_mod(lib_id)
             if mod_path is not None:
                 try:
                     result = extract_model_blocks(mod_path.read_text())
                 except OSError:
                     result = None
+                else:
+                    if sub_id is not None and substitution_log is not None:
+                        substitution_log[lib_id] = sub_id
         cache[lib_id] = result
         return result
 
@@ -305,6 +347,9 @@ class ModelPatchReport:
     variant_matches: dict[str, str] = field(default_factory=dict)
     """Lib ids whose model came from a same-library name variant
     (``lib_id -> matched footprint name``)."""
+    substitution_matches: dict[str, str] = field(default_factory=dict)
+    """Lib ids whose model came from a cross-library substitution
+    (``lib_id -> substitute lib_id``)."""
 
     @property
     def changed(self) -> bool:
@@ -360,6 +405,7 @@ def add_model_refs(
     library_paths: LibraryPaths | None = None,
     resolver: Resolver | None = None,
     allow_variants: bool = True,
+    allow_substitutions: bool = True,
     dry_run: bool = False,
 ) -> ModelPatchReport:
     """Patch missing 3D model refs into a ``.kicad_pcb`` file.
@@ -373,6 +419,9 @@ def add_model_refs(
         allow_variants: Accept same-library footprint-name variants when the
             exact name is missing (visual fallback; reported in
             ``variant_matches``). Ignored when *resolver* is supplied.
+        allow_substitutions: Accept curated cross-library substitutions when
+            exact + variant matching both miss (reported in
+            ``substitution_matches``). Ignored when *resolver* is supplied.
         dry_run: When True, nothing is written.
 
     Returns:
@@ -381,14 +430,22 @@ def add_model_refs(
     pcb_path = Path(pcb_path)
     text = pcb_path.read_text()
     variant_log: dict[str, str] = {}
+    substitution_log: dict[str, str] = {}
     if resolver is None:
         resolver = make_library_resolver(
-            library_paths, allow_variants=allow_variants, variant_log=variant_log
+            library_paths,
+            allow_variants=allow_variants,
+            allow_substitutions=allow_substitutions,
+            variant_log=variant_log,
+            substitution_log=substitution_log,
         )
     new_text, report = add_model_refs_to_text(text, resolver)
-    # Only surface variants that actually got patched in.
+    # Only surface variants/substitutions that actually got patched in.
     report.variant_matches = {
         lib_id: stem for lib_id, stem in variant_log.items() if lib_id in report.patched
+    }
+    report.substitution_matches = {
+        lib_id: sub for lib_id, sub in substitution_log.items() if lib_id in report.patched
     }
     if report.changed and not dry_run:
         dest = Path(output_path) if output_path is not None else pcb_path

--- a/tests/test_pcb_add_3d_models.py
+++ b/tests/test_pcb_add_3d_models.py
@@ -274,6 +274,155 @@ class TestVariantFallback:
 
 
 # --------------------------------------------------------------------------
+# Cross-library substitution tier (curated lib_id -> lib_id equivalents)
+# --------------------------------------------------------------------------
+
+# A synthetic lib id with no exact match and no same-library variant, but a
+# curated substitute in a *different* library.
+SUBSTITUTION_PCB_TEXT = """(kicad_pcb
+\t(version 20240108)
+\t(footprint "Connector_FFC:FFC_4P_0.5mm"
+\t\t(layer "F.Cu")
+\t\t(at 100 100)
+\t)
+)
+"""
+
+
+def _make_substitution_library(tmp_path: Path) -> LibraryPaths:
+    """Build a library where only the *substitute* library exists.
+
+    The requested ``Connector_FFC`` library is entirely absent (mirrors the
+    real upstream rename to ``Connector_FFC-FPC``), so only the cross-library
+    substitution tier can resolve it.
+    """
+    root = tmp_path / "footprints"
+    lib = root / "Connector_FFC-FPC.pretty"
+    lib.mkdir(parents=True)
+    name = "Amphenol_F32Q-1A7x1-11004_1x04-1MP_P0.5mm_Horizontal"
+    model = (
+        f'(footprint "{name}"\n'
+        '\t(layer "F.Cu")\n'
+        f'\t(model "${{KICAD10_3DMODEL_DIR}}/Connector_FFC-FPC.3dshapes/{name}.step"\n'
+        "\t\t(offset\n\t\t\t(xyz 0 0 0)\n\t\t)\n"
+        "\t)\n"
+        ")\n"
+    )
+    (lib / f"{name}.kicad_mod").write_text(model)
+    return LibraryPaths(footprints_path=root, source="config")
+
+
+class TestCrossLibrarySubstitution:
+    def test_substitution_match_used_and_reported(self, tmp_path):
+        lib = _make_substitution_library(tmp_path)
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(SUBSTITUTION_PCB_TEXT)
+        report = add_model_refs(pcb, library_paths=lib)
+        assert report.patched == ["Connector_FFC:FFC_4P_0.5mm"]
+        # Reported as a cross-library substitution, NOT a same-library variant.
+        assert report.substitution_matches == {
+            "Connector_FFC:FFC_4P_0.5mm": (
+                "Connector_FFC-FPC:Amphenol_F32Q-1A7x1-11004_1x04-1MP_P0.5mm_Horizontal"
+            )
+        }
+        assert report.variant_matches == {}
+        assert "Connector_FFC-FPC.3dshapes" in pcb.read_text()
+
+    def test_substitution_disabled_leaves_unresolved(self, tmp_path):
+        lib = _make_substitution_library(tmp_path)
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(SUBSTITUTION_PCB_TEXT)
+        report = add_model_refs(pcb, library_paths=lib, allow_substitutions=False)
+        assert report.patched == []
+        assert report.unresolved == ["Connector_FFC:FFC_4P_0.5mm"]
+        assert pcb.read_text() == SUBSTITUTION_PCB_TEXT
+
+    def test_exact_match_never_redirected_to_substitution(self, tmp_path):
+        """A lib id that resolves exactly must NOT hit the substitution tier."""
+        lib = _make_library(tmp_path)
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(PCB_TEXT)
+        report = add_model_refs(pcb, library_paths=lib)
+        assert report.patched == ["Resistor_SMD:R_0805_2012Metric"]
+        assert report.substitution_matches == {}
+
+    def test_variant_beats_substitution(self, tmp_path):
+        """When a same-library variant exists, it wins over substitution.
+
+        Uses a lib id in the substitution table but provides a same-library
+        variant; the resolver must report a variant match, not a substitution.
+        """
+        root = tmp_path / "footprints"
+        lib = root / "Package_BGA.pretty"
+        lib.mkdir(parents=True)
+        name = "BGA-49_5.0x5.0mm_Layout7x7_P0.5mm_ExtraSuffix"
+        model = (
+            f'(footprint "{name}"\n'
+            '\t(layer "F.Cu")\n'
+            f'\t(model "${{KICAD10_3DMODEL_DIR}}/Package_BGA.3dshapes/{name}.step"\n'
+            "\t\t(offset\n\t\t\t(xyz 0 0 0)\n\t\t)\n"
+            "\t)\n"
+            ")\n"
+        )
+        (lib / f"{name}.kicad_mod").write_text(model)
+        paths = LibraryPaths(footprints_path=root, source="config")
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(
+            SUBSTITUTION_PCB_TEXT.replace(
+                "Connector_FFC:FFC_4P_0.5mm",
+                "Package_BGA:BGA-49_5.0x5.0mm_Layout7x7_P0.5mm",
+            )
+        )
+        report = add_model_refs(pcb, library_paths=paths)
+        assert report.patched == ["Package_BGA:BGA-49_5.0x5.0mm_Layout7x7_P0.5mm"]
+        assert report.variant_matches == {"Package_BGA:BGA-49_5.0x5.0mm_Layout7x7_P0.5mm": name}
+        assert report.substitution_matches == {}
+
+    def test_substitution_reported_in_cli_json(self, tmp_path, capsys):
+        from kicad_tools.cli.pcb_add_3d_models import run_add_3d_models
+
+        _make_substitution_library(tmp_path)
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(SUBSTITUTION_PCB_TEXT)
+        rc = run_add_3d_models(pcb, lib_path=tmp_path / "footprints", output_format="json")
+        assert rc == 0
+        import json
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["patched"] == ["Connector_FFC:FFC_4P_0.5mm"]
+        assert payload["substitution_matches"] == {
+            "Connector_FFC:FFC_4P_0.5mm": (
+                "Connector_FFC-FPC:Amphenol_F32Q-1A7x1-11004_1x04-1MP_P0.5mm_Horizontal"
+            )
+        }
+
+
+# --------------------------------------------------------------------------
+# Substitution table integrity
+# --------------------------------------------------------------------------
+
+
+class TestSubstitutionTable:
+    def test_table_covers_required_lib_ids(self):
+        from kicad_tools.pcb.model_substitutions import MODEL_SUBSTITUTIONS
+
+        required = {
+            "Connector_FFC:FFC_4P_0.5mm",
+            "Connector_FFC:FFC_6P_1.0mm",
+            "Connector_USB:USB_C_Receptacle_USB2.0",
+            "Connector_Video:HDMI_A_Receptacle",
+            "Package_BGA:BGA-49_5.0x5.0mm_Layout7x7_P0.5mm",
+        }
+        assert required <= set(MODEL_SUBSTITUTIONS)
+
+    def test_substitute_lib_id_helper(self):
+        from kicad_tools.pcb.model_substitutions import substitute_lib_id
+
+        assert substitute_lib_id("Connector_FFC:FFC_4P_0.5mm") is not None
+        assert substitute_lib_id("Nonexistent:Thing") is None
+
+
+# --------------------------------------------------------------------------
 # File-level API + parseability
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`kct pcb add-3d-models` left several footprints bare after #4012 because their lib ids are generic/synthetic and the existing resolver only searches *within the same library* (exact match, then same-prefix variant). Their visual equivalents exist in the installed KiCad libraries — under a **different** library name (upstream rename) or a vendor-suffixed name. This adds an explicit, curated cross-library substitution tier so those resolve, resurfacing component bodies in the gallery renders for boards 06 and 07.

## Changes

- **New `src/kicad_tools/pcb/model_substitutions.py`**: curated `lib_id -> lib_id` table (`MODEL_SUBSTITUTIONS`) + `substitute_lib_id()` helper. Each value is a hand-verified, installed, body-compatible footprint that carries a `(model ...)` node.
- **`models3d.py` resolver tier**: `make_library_resolver` gains `allow_substitutions` and a `substitution_log`. Resolution order is now exact -> same-library variant -> **cross-library substitution**, so it can never redirect an already-resolvable footprint.
- **`ModelPatchReport.substitution_matches`**: new field parallel to `variant_matches`, distinguishing cross-library substitutions from same-library variants.
- **CLI (`pcb_add_3d_models.py`)**: surfaces the substitution bucket in both text and JSON output.
- **Regenerated artifacts**: boards 06 and 07 `output/*.kicad_pcb` (routed + non-routed) patched with the newly-resolved model refs — pure `(model ...)` insertion, zero removed bytes.
- **Tests**: new `TestCrossLibrarySubstitution` and `TestSubstitutionTable` classes cover exact-miss -> variant-miss -> table-hit, table-miss -> unresolved, `allow_substitutions=False`, variant-beats-substitution precedence, exact-never-redirected, and CLI JSON surfacing.

## Substitution table

| Requested lib_id | Substitute |
|---|---|
| `Connector_FFC:FFC_4P_0.5mm` | `Connector_FFC-FPC:Amphenol_F32Q-1A7x1-11004_1x04-1MP_P0.5mm_Horizontal` |
| `Connector_FFC:FFC_6P_1.0mm` | `Connector_FFC-FPC:TE_84952-6_1x06-1MP_P1.0mm_Horizontal` |
| `Connector_USB:USB_C_Receptacle_USB2.0` | `Connector_USB:USB_C_Receptacle_GCT_USB4105-xx-A_16P_TopMnt_Horizontal` |
| `Connector_Video:HDMI_A_Receptacle` | `Connector_Video:HDMI_A_Amphenol_10029449-x01xLF_Horizontal` |
| `Package_BGA:BGA-49_5.0x5.0mm_Layout7x7_P0.5mm` | `Package_BGA:VFBGA-49_5.0x5.0mm_Layout7x7_P0.65mm` |

## Waiver (out of scope — see follow-up #4032)

Two footprints have **no** installed or open substitute and need a vendor-sourced STEP file that a builder cannot download:

- **`Module:Joystick_Analog`** (board 03) — synthetic lib id; no `Module.pretty` library exists in KiCad at all.
- **`Connector_PCIE:PCIE_Mini_Edge`** (board 06) — no installed KiCad library covers PCIe mini-edge connectors.

These are tracked in **#4032** (`loom:operator-only`) for human vendor-STEP collection with license recording. Board 06's `unresolved` correctly shrinks to just `PCIE_Mini_Edge`; board 03 is unaffected by this change.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Resolver gains cross-library substitution tier after variant matching | ✅ | `make_library_resolver` `_lookup_mod` tier order exact -> variant -> substitution |
| Table covers the 5 named lib ids | ✅ | `TestSubstitutionTable::test_table_covers_required_lib_ids` |
| Report distinguishes substitutions from variants (text + JSON) | ✅ | `substitution_matches` field; CLI prints separate bucket; `test_substitution_reported_in_cli_json` |
| Boards 06/07 resolve all but `PCIE_Mini_Edge` (06) and `Joystick_Analog` (03) | ✅ | Dry-run: 06 unresolved=`[PCIE_Mini_Edge]`, 07 unresolved=`[]`, 03 unchanged |
| Pure-insertion guard preserved | ✅ | `git diff` shows 0 removed lines; all added lines are `(model/offset/scale/rotate/xyz)`; `test_patch_is_pure_insertion` |
| Board 06/07 artifacts regenerated | ✅ | 4 `output/*.kicad_pcb` patched in place (+33 lines each) |
| Two irreducible cases split into a labelled follow-up | ✅ | #4032, `loom:operator-only` |
| No regression: boards 00-05 get no unexpected substitutions | ✅ | Dry-run across 00-05: `substitution_matches` empty for all |

## Test Plan

- `uv run pytest tests/test_pcb_add_3d_models.py` — 24 passed.
- `uv run ruff check` + `uv run ruff format --check` on changed files — clean.
- Patched boards re-parse via `PCB.load()` (7 and 8 footprints respectively).

Closes #4014