### PR TITLE
chore(ci): ratchet board-06 routed-DRC floor 24 → 18 + copper-LVS vacuity guard

### DIFF
--- a/.github/routed-drc-tolerance.yml
+++ b/.github/routed-drc-tolerance.yml
@@ -1114,14 +1114,30 @@ tolerances:
   # #3540-#3544), pinned by EXPECTED_STRICT_GATE_ERRORS = 18.  kicad-cli:
   # 0 errors / 0 unconnected; manufacturing report.md Errors = 0.
   #
-  # This floor deliberately STAYS at 24: the binding count is
-  # max(committed 18, seed-42 re-route as measured ON CI), and the
-  # re-route has not been CI-measured with the new step-13 pass yet (the
-  # measure-on-CI-never-guess rule, #3822 -- local counts are
-  # non-authoritative).  Exit clause: after the next CI run of the
-  # Diff-Pair Routing Regression gate reports its deterministic count,
-  # ratchet this floor to max(18, that count).
-  boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb: 24
+  # !!! FLOOR RATCHETED 24 -> 18 (#4019, July 10 2026) !!!
+  # ----------------------------------------------------------------------
+  # The exit clause above is now closed.  The seed-42 Diff-Pair Routing
+  # Regression gate has been CI-measured with the step-13 legalization
+  # pass in place, and it reports the deterministic count on three
+  # independent green ``main`` runs, all measuring exactly 18 with ZERO
+  # divergence between the committed artifact and the from-scratch
+  # re-route (measure-on-CI-never-guess rule, #3822):
+  #   * run 29075253404 (main 076d5efd) -- seed-42 re-route: 18
+  #   * run 29072031350 (main de0d91ec) -- seed-42 re-route: 18
+  #   * run 29070816533 (main ad2d703f) -- seed-42 re-route: 18
+  # The diff-pair violation breakdown is stable: 9 diffpair_length_skew +
+  # 9 diffpair_routing_continuity = 18 (#3540-#3544), matching the
+  # committed strict-gate count exactly.  Binding count =
+  # max(committed 18, seed-42 re-route 18) = 18, so all three gated paths
+  # (committed-artifact routed-pcb-drc-check, seed-42 Diff-Pair Routing
+  # Regression, and the Board 06 E2E "Independent DRC re-check" fresh
+  # regen) agree at 18 -- unlike board 04, no ``--allow`` split is needed
+  # (#4035 was board-04-specific).  check_routed_drc.py's own slack
+  # warning independently recommended "Tighten to 18".  This is the
+  # tightest honest monotonic floor (floor >= committed deterministic
+  # count, zero slack).  EXPECTED_STRICT_GATE_ERRORS = 18 in
+  # tests/test_board_06_diffpair_test.py already equals this count.
+  boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb: 18
 
   # Match-group regression testbench (Epic #2661 Phase 3L, #2724).
   # Held at 70 by issue #2781's rect-pad fix.  Two CI jobs measure

--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 4008
-# Branch: feature/issue-4008
+# Issue: 4019
+# Branch: feature/issue-4019
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/scripts/ci/check_copper_lvs.py
+++ b/scripts/ci/check_copper_lvs.py
@@ -108,6 +108,19 @@ def assert_clean(payload: dict[str, Any]) -> str | None:
     """
     clean = payload["clean"]
     if clean:
+        if payload.get("bound_pad_count") == 0:
+            # Belt-and-braces (#4019, mirrors check_board_00_e2e.py:184): a
+            # clean=true report claiming zero bound pins is exactly the
+            # zero-evidence vacuity artifact the guard forbids (#4006).  The
+            # copper_lvs.py producer already forces clean=False on vacuity
+            # (copper_lvs.py:196), so this is unreachable via the guarded
+            # core -- defense-in-depth against a hand-built or regressed
+            # payload, never accept it as clean.
+            return (
+                "copper-LVS reports clean=true but is VACUOUS "
+                "(bound_pad_count=0, #4006/#4019) -- zero-evidence clean "
+                "is not clean"
+            )
         return None
     mismatches = payload.get("mismatches", [])
     if not isinstance(mismatches, list):

--- a/tests/test_ci_check_copper_lvs.py
+++ b/tests/test_ci_check_copper_lvs.py
@@ -68,6 +68,42 @@ def test_clean_result_no_mismatches_key_exits_0(tmp_path: Path) -> None:
     assert check_copper_lvs.main([str(p)]) == 0
 
 
+# --- vacuity guard (#4019) -------------------------------------------------
+
+
+def test_assert_clean_rejects_clean_true_with_zero_bound_pads() -> None:
+    # Belt-and-braces vacuity guard (#4019, mirrors check_board_00_e2e.py):
+    # a clean=true payload claiming zero bound pins is the zero-evidence
+    # artifact the vacuity guard forbids (#4006) -- assert_clean must reject
+    # it rather than pass it as clean.
+    msg = check_copper_lvs.assert_clean({"clean": True, "bound_pad_count": 0})
+    assert msg is not None
+    assert "VACUOUS" in msg
+
+
+def test_clean_true_zero_bound_pads_exits_2(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # The full asserter maps the vacuity rejection to a dirty exit (2).
+    p = _write_json(tmp_path, {"clean": True, "bound_pad_count": 0, "mismatches": []})
+    rc = check_copper_lvs.main([str(p)])
+    assert rc == 2
+    out = capsys.readouterr().out
+    assert "::error" in out
+    assert "VACUOUS" in out
+
+
+def test_assert_clean_passes_clean_true_with_positive_bound_pads() -> None:
+    # A clean=true payload with real bound evidence is still clean.
+    assert check_copper_lvs.assert_clean({"clean": True, "bound_pad_count": 42}) is None
+
+
+def test_assert_clean_passes_clean_true_without_bound_pad_count() -> None:
+    # ``bound_pad_count`` is optional/``null`` on pre-guard payloads; its
+    # absence must not spuriously trip the vacuity guard.
+    assert check_copper_lvs.assert_clean({"clean": True}) is None
+
+
 # --- dirty result -> exit 2 ------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Closes #4019.

Ratchets the board-06 routed-DRC tolerance floor from 24 to 18, closing the exit clause in `.github/routed-drc-tolerance.yml`, plus a small belt-and-braces rider on the copper-LVS asserter.

### 1. Floor ratchet 24 → 18 (`.github/routed-drc-tolerance.yml:1124`)

The exit clause was waiting for the seed-42 Diff-Pair Routing Regression gate to be CI-measured with the step-13 legalization pass in place. It now has been, on three independent green `main` runs — all reporting exactly **18** with **zero divergence** between the committed artifact and the from-scratch re-route:

- run 29075253404 (main `076d5efd`)
- run 29072031350 (main `de0d91ec`)
- run 29070816533 (main `ad2d703f`)

`max(committed 18, seed-42 re-route 18) = 18`, so all three gated paths agree. Unlike board 04 (#4035), **no `--allow` split is needed** — there is no committed-vs-fresh-regen divergence to reconcile. `check_routed_drc.py`'s own slack warning independently recommended "Tighten to 18".

`EXPECTED_STRICT_GATE_ERRORS` in `tests/test_board_06_diffpair_test.py` was already pinned to 18 (per the exit clause's two-step design), so **no test change was needed** for the ratchet. The exit-clause comment block is rewritten to record why the floor moved, citing the CI run IDs.

Local manual verification:
```
OK: boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb -- 18 errors (--mfr jlcpcb, allowlist max 18; ...)
```
No slack warning.

### 2. Rider: copper-LVS vacuity guard (`scripts/ci/check_copper_lvs.py`)

Adds a `bound_pad_count == 0` guard to `assert_clean()`, mirroring `check_board_00_e2e.py::assert_lvs_clean`. A `clean=true` payload claiming zero bound pins is exactly the zero-evidence artifact the vacuity guard forbids (#4006). The `copper_lvs.py` producer already forces `clean=False` on vacuity (`copper_lvs.py:196`), so this is **defense-in-depth** against a hand-built or regressed payload — not an active bug.

Adds four unit tests in `tests/test_ci_check_copper_lvs.py`.

## Test results

- `uv run pytest tests/test_ci_check_copper_lvs.py` — 30 passed (4 new)
- `uv run pytest tests/test_board_06_diffpair_test.py -k "strict_gate or allowlist"` — 2 passed against the new floor
- `uv run ruff check` + `ruff format --check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)