### PR TITLE
fix(schematic): make net-query connectivity multi-unit-aware

### DIFF
--- a/src/kicad_tools/schematic/models/netlist_mixin.py
+++ b/src/kicad_tools/schematic/models/netlist_mixin.py
@@ -29,6 +29,31 @@ class PinRef:
         return f"{self.symbol_ref}.{self.pin}"
 
 
+def _instance_owns_pin(sym, pin) -> bool:
+    """Return True if a placed ``SymbolInstance`` owns ``pin``.
+
+    Multi-unit KiCad symbols (e.g. the LM393 dual comparator) share a
+    single ``SymbolDef`` — and therefore a single ``symbol_def.pins``
+    list containing *every* unit's pins — across several placed
+    ``SymbolInstance`` rows that share a ``reference`` but differ in
+    their ``unit`` field.  Connectivity must attribute each pin to the
+    instance that actually carries it, otherwise a unit-2-only pin gets
+    positioned against a unit-1 instance's placement anchor and produces
+    "phantom" nets from unit-1 geometry (issue #4020).
+
+    A pin belongs to an instance when its ``pin.unit`` matches the
+    instance's ``unit`` field, or when it is a unit-0 "common to all
+    units" pin (shared package power pins, and single-unit symbols whose
+    pins are all tagged ``unit=0``).  This mirrors ``_pin_matches_unit``
+    in :meth:`SymbolInstance.pin_position` and the per-unit filter in
+    :meth:`Schematic._check_unconnected_pins` (issue #3349), keeping the
+    three code paths from drifting apart.
+    """
+    pin_unit = getattr(pin, "unit", 0)
+    sym_unit = getattr(sym, "unit", 1)
+    return pin_unit == 0 or pin_unit == sym_unit
+
+
 class SchematicNetlistMixin:
     """Mixin providing netlist extraction and query operations for Schematic class."""
 
@@ -114,8 +139,19 @@ class SchematicNetlistMixin:
                     union(junc_pos, seg_end)
 
         # Connect symbol pins to wires and track pin locations
+        #
+        # ``symbol_def.pins`` lists every unit's pins, shared across all
+        # placed instances of a multi-unit symbol.  Only contribute the
+        # pins this instance actually owns (``_instance_owns_pin``) so a
+        # unit-2 pin is never registered at a unit-1 instance's position
+        # — the phantom-net / duplicate-PinRef bug of issue #4020.  Unit-0
+        # "common" pins are still contributed by every placed instance
+        # (each at its own resolved coordinate) because connectivity, not
+        # a one-shot flag, is being computed here.
         for sym in self.symbols:
             for pin in sym.symbol_def.pins:
+                if not _instance_owns_pin(sym, pin):
+                    continue
                 pos = sym.pin_position(pin.number)
                 pos_rounded = (round(pos[0], 2), round(pos[1], 2))
 
@@ -289,6 +325,33 @@ class SchematicNetlistMixin:
 
         return netlist
 
+    def _resolve_pin_instance(self, symbol_ref: str, pin: str):
+        """Return the placed ``SymbolInstance`` that owns ``pin``.
+
+        For multi-unit symbols the same ``reference`` is placed once per
+        unit; a given pin number lives on exactly one unit.  This selects
+        the instance whose ``unit`` owns the requested pin so a pin's net
+        is resolved against that unit's real placement, not the first
+        instance with a matching reference (issue #4020).
+
+        ``pin`` may be a pin number or a pin name.  Matching prefers an
+        instance that both matches the reference and owns the pin under
+        :func:`_instance_owns_pin`; if none does (e.g. the owning unit is
+        not placed, or the pin is a unit-0 common), the first
+        matching-reference instance is returned, preserving single-unit
+        behaviour.  Returns ``None`` if no instance matches the reference.
+        """
+        fallback = None
+        for sym in self.symbols:
+            if sym.reference != symbol_ref:
+                continue
+            if fallback is None:
+                fallback = sym
+            for p in sym.symbol_def.pins:
+                if (p.number == pin or p.name == pin) and _instance_owns_pin(sym, p):
+                    return sym
+        return fallback
+
     def get_net_for_pin(self, symbol_ref: str, pin: str) -> str | None:
         """Get the net name connected to a symbol's pin.
 
@@ -305,12 +368,15 @@ class SchematicNetlistMixin:
             >>> print(net)
             '+3.3V'
         """
-        # Find the symbol
-        symbol = None
-        for sym in self.symbols:
-            if sym.reference == symbol_ref:
-                symbol = sym
-                break
+        # Find the placed instance that owns this pin.  A multi-unit
+        # symbol shares a ``reference`` across several instances (one per
+        # unit); the requested pin lives on exactly one of them.  Pick the
+        # instance whose ``unit`` owns the pin rather than the first
+        # matching reference, otherwise a unit-2 pin resolves against
+        # unit-1's placement and returns a phantom net (issue #4020).
+        # Fall back to the first matching-reference instance when no
+        # unit-owning instance is placed, preserving single-unit behaviour.
+        symbol = self._resolve_pin_instance(symbol_ref, pin)
 
         if symbol is None:
             return None
@@ -389,13 +455,13 @@ class SchematicNetlistMixin:
             >>> if sch.are_connected("U1", "VO", "C1", "1"):
             ...     print("Regulator output connected to capacitor")
         """
-        # Find both symbols and their pin positions
-        sym1 = sym2 = None
-        for sym in self.symbols:
-            if sym.reference == symbol1:
-                sym1 = sym
-            if sym.reference == symbol2:
-                sym2 = sym
+        # Find the placed instance that owns each pin.  For multi-unit
+        # symbols the reference is shared across units, so select the
+        # unit-owning instance rather than the first reference match —
+        # otherwise two pins on different units resolve to the same
+        # unit-1 geometry and report a false connection (issue #4020).
+        sym1 = self._resolve_pin_instance(symbol1, pin1)
+        sym2 = self._resolve_pin_instance(symbol2, pin2)
 
         if sym1 is None or sym2 is None:
             return False

--- a/tests/test_netlist_query.py
+++ b/tests/test_netlist_query.py
@@ -569,3 +569,249 @@ class TestPinEndpointOnlyWireAttach:
         netlist = sch.extract_netlist()
         gnd_pins = {str(p) for p in netlist.get("GND", [])}
         assert "R1.2" not in gnd_pins
+
+
+def _build_dual_unit_symdef() -> SymbolDef:
+    """Build a SymbolDef mimicking a dual-unit LM393 comparator.
+
+    Follows the ``LM393_<unit>_<style>`` parser tagging convention:
+
+    - Unit 1 (channel A): IN- (pin 2), IN+ (pin 3), OUT_A (pin 1).
+    - Unit 2 (channel B): IN- (pin 6), IN+ (pin 5), OUT_B (pin 7).
+    - Common package power (unit 0): V+ (pin 8), V- (pin 4).
+
+    Pins carry non-zero symbol-local ``x`` offsets so a placed instance's
+    ``pin_position`` differs from the instance origin — this lets the
+    regression tests wire unit 2's pins at *different sheet coordinates*
+    than unit 1's, which is exactly the geometry that exposed the
+    phantom-net bug (issue #4020).
+    """
+    return SymbolDef(
+        lib_id="Comparator:LM393",
+        name="LM393",
+        raw_sexp="",
+        pins=[
+            # Unit 1 (channel A)
+            Pin(
+                name="-",
+                number="2",
+                x=-2.54,
+                y=2.54,
+                angle=0,
+                length=2.54,
+                pin_type="input",
+                unit=1,
+            ),
+            Pin(
+                name="+",
+                number="3",
+                x=-2.54,
+                y=-2.54,
+                angle=0,
+                length=2.54,
+                pin_type="input",
+                unit=1,
+            ),
+            Pin(
+                name="OUT_A",
+                number="1",
+                x=2.54,
+                y=0,
+                angle=0,
+                length=2.54,
+                pin_type="open_collector",
+                unit=1,
+            ),
+            # Unit 2 (channel B)
+            Pin(
+                name="-",
+                number="6",
+                x=-2.54,
+                y=2.54,
+                angle=0,
+                length=2.54,
+                pin_type="input",
+                unit=2,
+            ),
+            Pin(
+                name="+",
+                number="5",
+                x=-2.54,
+                y=-2.54,
+                angle=0,
+                length=2.54,
+                pin_type="input",
+                unit=2,
+            ),
+            Pin(
+                name="OUT_B",
+                number="7",
+                x=2.54,
+                y=0,
+                angle=0,
+                length=2.54,
+                pin_type="open_collector",
+                unit=2,
+            ),
+            # Unit 0 (common package power)
+            Pin(
+                name="V+",
+                number="8",
+                x=0,
+                y=2.54,
+                angle=0,
+                length=2.54,
+                pin_type="power_in",
+                unit=0,
+            ),
+            Pin(
+                name="V-",
+                number="4",
+                x=0,
+                y=-2.54,
+                angle=0,
+                length=2.54,
+                pin_type="power_in",
+                unit=0,
+            ),
+        ],
+    )
+
+
+class TestMultiUnitNetResolution:
+    """Multi-unit symbols resolve nets per placed unit (issue #4020).
+
+    A multi-unit symbol (e.g. LM393) shares one ``symbol_def.pins`` list
+    across several placed ``SymbolInstance`` rows that share a
+    ``reference`` but differ in ``unit``.  Connectivity must attribute
+    each pin to the instance that actually owns it; otherwise a
+    unit-2-only pin gets positioned at a unit-1 instance's anchor and
+    produces phantom nets, false ``are_connected`` results, and duplicate
+    ``PinRef`` entries.
+    """
+
+    def _dual_unit_schematic(self) -> Schematic:
+        """Place unit 1 @ (100,100) and unit 2 @ (200,200) — different coords.
+
+        Unit 1's OUT_A (pin 1, +2.54 x offset) lands at (102.54, 100) and
+        is wired to a net labelled ``A_OUT``.  Unit 2's OUT_B (pin 7) is
+        left unwired at (202.54, 200).  Under the old buggy resolution,
+        pin 7 would be registered at unit 1's geometry and appear on
+        ``A_OUT``; the fix keeps it floating.
+        """
+        sch = Schematic("Test")
+        sym_def = _build_dual_unit_symdef()
+        u1 = SymbolInstance(
+            symbol_def=sym_def, x=100, y=100, rotation=0, reference="U1", value="LM393", unit=1
+        )
+        u2 = SymbolInstance(
+            symbol_def=sym_def, x=200, y=200, rotation=0, reference="U1", value="LM393", unit=2
+        )
+        sch.symbols.extend([u1, u2])
+        # Wire unit 1's OUT_A (102.54, 100) east and name it A_OUT.
+        sch.wires.append(Wire(x1=102.54, y1=100, x2=110, y2=100))
+        sch.labels.append(Label(text="A_OUT", x=110, y=100))
+        return sch
+
+    def test_get_net_for_pin_resolves_against_owning_unit(self):
+        """Unit 1's OUT_A resolves to its real net, not a phantom."""
+        sch = self._dual_unit_schematic()
+        assert sch.get_net_for_pin("U1", "1") == "A_OUT"
+
+    def test_get_net_for_pin_unwired_unit2_pin_is_floating(self):
+        """Unit 2's OUT_B is unwired -> None, despite unit 1 being wired.
+
+        The core phantom-net bug: pin 7 lives on unit 2 at (202.54, 200)
+        with no wire, so it must read as floating even though unit 1's
+        similarly-shaped geometry is wired to A_OUT.
+        """
+        sch = self._dual_unit_schematic()
+        assert sch.get_net_for_pin("U1", "7") is None
+
+    def test_get_net_for_pin_wired_unit2_pin_uses_unit2_wiring(self):
+        """A wire at unit 2's real position names unit 2's pin, not unit 1's."""
+        sch = self._dual_unit_schematic()
+        # Wire unit 2's OUT_B at its actual sheet position (202.54, 200).
+        sch.wires.append(Wire(x1=202.54, y1=200, x2=210, y2=200))
+        sch.labels.append(Label(text="B_OUT", x=210, y=200))
+        assert sch.get_net_for_pin("U1", "7") == "B_OUT"
+        # Unit 1's pin 1 is still on its own net, unchanged.
+        assert sch.get_net_for_pin("U1", "1") == "A_OUT"
+
+    def test_are_connected_false_for_unwired_cross_unit_pins(self):
+        """Two pins on different units, not wired together -> False.
+
+        Under the old resolution both pins collapsed onto unit 1's
+        geometry and reported a false connection.
+        """
+        sch = self._dual_unit_schematic()
+        assert sch.are_connected("U1", "1", "U1", "7") is False
+
+    def test_are_connected_true_when_units_actually_wired_together(self):
+        """Cross-unit pins wired to the same net still report connected."""
+        sch = self._dual_unit_schematic()
+        # Wire unit 2's OUT_B (202.54, 200) back to the A_OUT net node so
+        # both units genuinely share a net.
+        sch.wires.append(Wire(x1=202.54, y1=200, x2=110, y2=100))
+        assert sch.are_connected("U1", "1", "U1", "7") is True
+
+    def test_extract_netlist_no_duplicate_unit_specific_pinrefs(self):
+        """Unit-specific pins register once — no per-instance phantom dupes.
+
+        Before the fix, every placed unit re-registered *every* unit's
+        pins at its own anchor, so unit-specific pins like OUT_A (pin 1)
+        and OUT_B (pin 7) appeared twice each.  After the fix each is
+        attributed to its owning unit exactly once.
+
+        Note: unit-0 *common* pins (V+/V-, pins 8/4) legitimately appear
+        once per placed instance — each at its own resolved coordinate —
+        because connectivity is being computed, not a one-shot flag
+        (issue #4020 guidance).  They are excluded from this dedup check.
+        """
+        sch = self._dual_unit_schematic()
+        netlist = sch.extract_netlist()
+
+        common_pins = {"8", "4"}  # unit-0 V+ / V-
+        unit_specific_refs = [
+            str(p) for pins in netlist.values() for p in pins if p.pin not in common_pins
+        ]
+        assert len(unit_specific_refs) == len(set(unit_specific_refs)), (
+            f"duplicate unit-specific PinRefs: {unit_specific_refs}"
+        )
+        # A_OUT carries exactly unit 1's OUT_A once (not twice from both
+        # placed instances).
+        assert [str(p) for p in netlist["A_OUT"]] == ["U1.1"]
+
+    def test_extract_netlist_no_phantom_cross_unit_pin_on_wired_net(self):
+        """The wired net (A_OUT) does not gain unit 2's pin as a phantom.
+
+        This is the direct netlist-level symptom of the bug: unit 2's
+        OUT_B (pin 7), positioned against unit 1's geometry under the old
+        resolution, would union onto A_OUT.  It must not appear there.
+        """
+        sch = self._dual_unit_schematic()
+        netlist = sch.extract_netlist()
+        a_out = {str(p) for p in netlist["A_OUT"]}
+        assert "U1.7" not in a_out
+
+    def test_pins_on_net_no_phantom_cross_unit_pin(self):
+        """pins_on_net for unit 1's net does not include unit 2's pin."""
+        sch = self._dual_unit_schematic()
+        pins = {str(p) for p in sch.pins_on_net("A_OUT")}
+        assert pins == {"U1.1"}
+        assert "U1.7" not in pins
+
+    def test_common_pin_connects_across_all_placed_units(self):
+        """Unit-0 common pins (V+/V-) still connect through any unit.
+
+        Common package-power pins are shared by every unit; wiring them
+        at one placed instance's position must still resolve — the fix
+        must not over-restrict unit-0 commons.
+        """
+        sch = self._dual_unit_schematic()
+        # V+ (pin 8) on unit 1 resolves to (100, 97.46) after the
+        # schematic Y-flip; wire it there and name the net VCC.
+        assert sch.symbols[0].pin_position("8") == (100.0, 97.46)
+        sch.wires.append(Wire(x1=100, y1=97.46, x2=100, y2=90))
+        sch.labels.append(Label(text="VCC", x=100, y=90))
+        assert sch.get_net_for_pin("U1", "8") == "VCC"


### PR DESCRIPTION
## Summary

`get_net_for_pin`, `are_connected`, `extract_netlist`, and `pins_on_net`
all sit on top of `SchematicNetlistMixin._build_connectivity_graph()`,
which was not multi-unit-aware. For a multi-unit symbol (e.g. an LM393
comparator with channel-A / channel-B / power units sharing one
`reference`), the shared `symbol_def.pins` list contains every unit's
pins. `_build_connectivity_graph()` iterated that whole list for **each**
placed `SymbolInstance` without filtering by `pin.unit`, so every placed
unit re-registered every other unit's pins at its *own* placement anchor.

Result: phantom nets synthesized from unit-1 geometry, false
`are_connected()` results, and duplicate `PinRef` entries. This is core
connectivity used by LVS and every board recipe.

`get_net_for_pin()` and `are_connected()` compounded the bug by picking
the **first** `SymbolInstance` whose `.reference` matched, ignoring which
unit actually owns the requested pin.

## Changes

- Add module-level `_instance_owns_pin(sym, pin)` helper — a pin belongs
  to an instance when `pin.unit == 0` (common) or equals the instance's
  `unit`. Mirrors the proven per-unit filter in
  `validation_mixin._check_unconnected_pins` (#3349) and
  `pin_position`'s `_pin_matches_unit` (#3346) so the three paths don't
  drift.
- Filter contributed pins in `_build_connectivity_graph()` so each
  instance only registers pins it owns. Unit-0 "common" pins are still
  contributed by every placed instance (each at its own resolved
  coordinate) — connectivity, not a one-shot flag.
- Add `_resolve_pin_instance()` and use it in `get_net_for_pin()` and
  `are_connected()` to select the unit-owning instance, falling back to
  the first matching-reference instance so single-unit behaviour is
  unchanged.
- Regression tests (`TestMultiUnitNetResolution` in
  `tests/test_netlist_query.py`): synthetic dual-unit LM393-shaped
  fixture with unit 1 and unit 2 placed at **different sheet
  coordinates**.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `get_net_for_pin` uses the specific placed instance (reference + owning unit) | ✅ | `_resolve_pin_instance`; `test_get_net_for_pin_resolves_against_owning_unit`, `test_get_net_for_pin_wired_unit2_pin_uses_unit2_wiring` |
| `_build_connectivity_graph` filters pins to those the instance owns | ✅ | `_instance_owns_pin` guard in the pin loop |
| Dual-unit fixture at different coords: unit-2 pin returns real net / `None` when unwired | ✅ | `test_get_net_for_pin_unwired_unit2_pin_is_floating` (`None`), `..._uses_unit2_wiring` (real net) |
| `are_connected` returns `False` for unwired cross-unit pins | ✅ | `test_are_connected_false_for_unwired_cross_unit_pins`; `..._true_when_units_actually_wired_together` for the positive case |
| No duplicate `PinRef` across unit instances | ✅ | `test_extract_netlist_no_duplicate_unit_specific_pinrefs`, `test_extract_netlist_no_phantom_cross_unit_pin_on_wired_net`, `test_pins_on_net_no_phantom_cross_unit_pin` |
| Existing multi-unit + `test_netlist_query.py` suites pass unchanged | ✅ | `test_schematic_models.py`, `test_blocks_overcurrent_comparator.py`, `test_netlist_query.py` all green |
| No dependency on external softstart repo | ✅ | Fixture fully synthetic in `test_netlist_query.py` |

## Test Plan

- `uv run pytest tests/test_netlist_query.py tests/test_schematic_models.py tests/test_blocks_overcurrent_comparator.py` → 257 passed (+9 new).
- Broad guard: `uv run pytest tests/ -k "schematic or netlist or lvs"` (excluding 4 pre-existing `cmaes`-import-error collection failures unrelated to this change) → 1543 passed, 1 flaky failure in `TestBoard03FreshRegenCopperLVSClean` (a full PCB route+DRC regen — `connectivity: 2 errors` come from the router/kicad-cli DRC, not schematic net queries). That test **passes in isolation** on this branch, confirming the failure is pre-existing routing flakiness, not caused by this change.
- Manual: the issue's reproduction script now prints `None` / `False` / deduplicated PinRefs (was `PHANTOM_NET` / `True` / duplicated).
- Single-unit symbols are zero-diff: pins tagged `unit=0` match any instance, and the first-match fallback preserves prior behaviour.

### Out of scope (note-only)

The softstart repo (external, local-only) worked around this bug by
synthesizing a single-unit `LM393_SINGLE` symbol. That workaround can now
be retired as a **separate, out-of-repo follow-up** — not touched here.
The fix and its regression fixture are fully self-contained in
`kicad-tools`.

Closes #4020