### PR TITLE
fix(connectivity): gate step-2e XY-coincident fusion on shared copper layer

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 4019
-# Branch: feature/issue-4019
+# Issue: 4022
+# Branch: feature/issue-4022
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/src/kicad_tools/validate/connectivity.py
+++ b/src/kicad_tools/validate/connectivity.py
@@ -608,13 +608,24 @@ class ConnectivityValidator:
         else:  # pragma: no cover - exercised only on core-only installs
             self._connect_pour_pads_by_declared_net(pad_positions, pad_layers, _connect)
 
-        # 2e. Coincident pads with no intervening copper still share metal
-        #     if they occupy the same point (e.g. stacked pads).
+        # 2e. Coincident pads/via-nodes with no intervening copper still share
+        #     metal if they occupy the same point AND share a copper layer.
+        #     The layer gate mirrors steps 2a/2c/2c2: an XY match alone is not
+        #     enough — a blind/buried via stacked under a foreign pad on a
+        #     disjoint layer span must NOT fuse (HDI false-connect, issue
+        #     #4022). ``pad_layers`` is populated for both real pads and
+        #     synthetic via nodes at this point, so no extra plumbing is needed.
         pad_ids = list(pad_positions)
         for i, p in enumerate(pad_ids):
             for other in pad_ids[i + 1 :]:
-                if self._points_close(pad_positions[p], pad_positions[other]):
-                    _connect(p, other)
+                if not self._points_close(pad_positions[p], pad_positions[other]):
+                    continue
+                if not (
+                    self._copper_layers_of(pad_layers.get(p, []))
+                    & self._copper_layers_of(pad_layers.get(other, []))
+                ):
+                    continue
+                _connect(p, other)
 
         # 3. Flood-fill connected components of the pad graph.  Synthetic via
         #    nodes (1b) participate in the flood so they carry connectivity

--- a/tests/test_connectivity.py
+++ b/tests/test_connectivity.py
@@ -1320,6 +1320,119 @@ def _four_layer_thruvia_pcb() -> str:
 """
 
 
+def _hdi_blind_via_under_foreign_pad_pcb() -> str:
+    """4-layer HDI PCB: a blind via (B.Cu-In2.Cu) sits at the same XY as an
+    F.Cu-only SMD pad on a *different* net.
+
+    The blind via's bridged span is {In2.Cu, B.Cu}; the SMD pad lives only on
+    F.Cu.  They share no copper layer, so an XY coincidence must NOT fuse them
+    (HDI false-connect, issue #4022).  Each footprint has a second pad so the
+    net has a real anchor and never trivially collapses.
+    """
+    return """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (2 "In2.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "SIG_TOP")
+  (net 2 "SIG_BOT")
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000f1")
+    (at 110 110)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "fp-f1-ref"))
+    (property "Value" "1k" (at 0 1.5 0) (layer "F.Fab") (uuid "fp-f1-val"))
+    (pad "1" smd roundrect (at 0 0) (size 0.6 0.6) (layers "F.Cu" "F.Paste" "F.Mask")
+      (roundrect_rratio 0.25) (net 1 "SIG_TOP"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000f2")
+    (at 120 110)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "F.SilkS") (uuid "fp-f2-ref"))
+    (property "Value" "1k" (at 0 1.5 0) (layer "F.Fab") (uuid "fp-f2-val"))
+    (pad "1" smd roundrect (at 0 0) (size 0.6 0.6) (layers "F.Cu" "F.Paste" "F.Mask")
+      (roundrect_rratio 0.25) (net 1 "SIG_TOP"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "B.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000f3")
+    (at 130 110)
+    (property "Reference" "R3" (at 0 -1.5 0) (layer "B.SilkS") (uuid "fp-f3-ref"))
+    (property "Value" "1k" (at 0 1.5 0) (layer "B.Fab") (uuid "fp-f3-val"))
+    (pad "1" smd roundrect (at 0 0) (size 0.6 0.6) (layers "B.Cu" "B.Paste" "B.Mask")
+      (roundrect_rratio 0.25) (net 2 "SIG_BOT"))
+  )
+  (segment (start 110 110) (end 120 110) (width 0.25) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-0000000000f4"))
+  (segment (start 110 110) (end 130 110) (width 0.25) (layer "B.Cu") (net 2)
+    (uuid "00000000-0000-0000-0000-0000000000f5"))
+  (via (at 110 110) (size 0.4) (drill 0.2) (layers "In2.Cu" "B.Cu") (net 2)
+    (uuid "00000000-0000-0000-0000-0000000000f6"))
+)
+"""
+
+
+def _through_via_under_pad_pcb() -> str:
+    """4-layer PCB: a through via (F.Cu-B.Cu) sits at the same XY as an F.Cu
+    SMD pad on a *different* net, with no trace tying them.
+
+    The via's span includes F.Cu (through-hole), so it DOES share a copper
+    layer with the F.Cu pad.  Their XY coincidence therefore SHOULD still
+    fuse (proves the layer gate narrows correctly rather than breaking
+    legitimate stacked pad/via fusion, issue #4022).
+    """
+    return """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (2 "In2.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "SIG_A")
+  (net 2 "SIG_B")
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000g1")
+    (at 110 110)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "fp-g1-ref"))
+    (property "Value" "1k" (at 0 1.5 0) (layer "F.Fab") (uuid "fp-g1-val"))
+    (pad "1" smd roundrect (at 0 0) (size 0.6 0.6) (layers "F.Cu" "F.Paste" "F.Mask")
+      (roundrect_rratio 0.25) (net 1 "SIG_A"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "B.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000g3")
+    (at 130 110)
+    (property "Reference" "R3" (at 0 -1.5 0) (layer "B.SilkS") (uuid "fp-g3-ref"))
+    (property "Value" "1k" (at 0 1.5 0) (layer "B.Fab") (uuid "fp-g3-val"))
+    (pad "1" smd roundrect (at 0 0) (size 0.6 0.6) (layers "B.Cu" "B.Paste" "B.Mask")
+      (roundrect_rratio 0.25) (net 2 "SIG_B"))
+  )
+  (segment (start 130 110) (end 110 110) (width 0.25) (layer "B.Cu") (net 2)
+    (uuid "00000000-0000-0000-0000-0000000000g5"))
+  (via (at 110 110) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 2)
+    (uuid "00000000-0000-0000-0000-0000000000g6"))
+)
+"""
+
+
 class TestLayerAwareSegmentChaining:
     """Issue #3783: cross-layer copper only fuses where a via/pad bridges."""
 
@@ -1375,6 +1488,37 @@ class TestLayerAwareSegmentChaining:
         assert order == ["F.Cu", "In1.Cu", "In2.Cu", "B.Cu"]
         bridged = validator._via_bridged_layers(["F.Cu", "B.Cu"])
         assert bridged == frozenset({"F.Cu", "In1.Cu", "In2.Cu", "B.Cu"})
+
+    def test_blind_via_under_foreign_pad_does_not_fuse(self, tmp_path: Path) -> None:
+        """Issue #4022: step 2e must be layer-aware.
+
+        A blind via spanning In2.Cu-B.Cu that lands at the same XY as an
+        F.Cu-only SMD pad on a different net shares NO copper layer with the
+        pad — the XY coincidence alone must NOT fuse them.
+        """
+        pcb_file = tmp_path / "hdi_blind_via.kicad_pcb"
+        pcb_file.write_text(_hdi_blind_via_under_foreign_pad_pcb())
+        partition = ConnectivityValidator(pcb_file).extract_pad_partition()
+        # SIG_TOP (F.Cu, R1/R2) and SIG_BOT (B.Cu, R3) must stay separate: the
+        # blind via under R1.1 does not reach F.Cu, so it cannot bridge them.
+        assert frozenset({"R1.1", "R2.1"}) in partition
+        assert frozenset({"R3.1"}) in partition
+        assert len(partition) == 2
+
+    def test_through_via_under_pad_still_fuses(self, tmp_path: Path) -> None:
+        """Issue #4022: the layer gate must not break legitimate fusion.
+
+        A through via (F.Cu-B.Cu) coincident with an F.Cu pad DOES share the
+        F.Cu copper layer, so the XY coincidence must STILL fuse — proving the
+        gate narrows correctly rather than suppressing valid stacked ties.
+        """
+        pcb_file = tmp_path / "through_via_under_pad.kicad_pcb"
+        pcb_file.write_text(_through_via_under_pad_pcb())
+        partition = ConnectivityValidator(pcb_file).extract_pad_partition()
+        # The through via (net 2, reached from R3.1 on B.Cu) is F.Cu-B.Cu, so
+        # it fuses to R1.1's F.Cu pad at the shared XY -> one component.
+        assert frozenset({"R1.1", "R3.1"}) in partition
+        assert len(partition) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Step 2e of `extract_pad_partition` (`connectivity.py`) fused any two pad/via nodes that shared an XY position, with **no layer check** — unlike every other cross-copper step in the same function (2a gates on `seg.layer`, 2c on `_copper_layers_of` overlap, 2c2 on `_pad_layer_matches_zone`). On HDI boards this is a latent false-connect: a blind/buried via node (whose span `_via_bridged_layers` correctly narrows to the physical layers it passes through) could fuse to a foreign-net SMD pad on a *disjoint* layer at the same XY.

This PR adds a shared-copper-layer gate to the 2e loop, reusing the existing `_copper_layers_of` helper. The gate is a **strict narrowing** — it removes false fuses only, so it cannot introduce a new short on any board that was DRC/LVS-clean before.

## Changes

- `src/kicad_tools/validate/connectivity.py`: step 2e now requires `_copper_layers_of(pad_layers[p]) & _copper_layers_of(pad_layers[other])` to be non-empty before fusing two XY-coincident nodes. `pad_layers` is already populated for both real pads and synthetic `__via` nodes at this point, so no new plumbing was needed.
- `tests/test_connectivity.py`: two regression tests near `TestLayerAwareSegmentChaining`, plus two 4-layer fixtures:
  - `test_blind_via_under_foreign_pad_does_not_fuse` — a blind via (In2.Cu-B.Cu) XY-coincident with an F.Cu-only foreign-net pad must NOT fuse.
  - `test_through_via_under_pad_still_fuses` — a through via (F.Cu-B.Cu) under an F.Cu pad DOES share F.Cu and must STILL fuse (proves the gate narrows correctly rather than breaking legitimate stacked pad/via fusion).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Step 2e requires shared copper layer via `_copper_layers_of` | ✅ | Layer-overlap guard added mirroring 2a/2c/2c2 |
| HDI blind-via-under-foreign-pad regression (must NOT fuse) | ✅ | `test_blind_via_under_foreign_pad_does_not_fuse` passes; partition = 2 components |
| Positive shared-layer test (must STILL fuse) | ✅ | `test_through_via_under_pad_still_fuses` passes; partition = 1 component |
| Board-05 in-pad microvia still fuses; copper-LVS unchanged | ✅ | `test_copper_lvs.py` 103 passed (101 baseline + 2 new); board-05 stitch/DRV8301 suites pass |
| Fleet-wide zero-diff on existing fixtures | ✅ | `test_connectivity.py` + `test_copper_lvs.py` all green; board-0* 251 passed |
| `ruff check` / `ruff format --check` clean | ✅ | Clean on both changed files |

## Test Plan

- `uv run pytest tests/test_connectivity.py tests/test_copper_lvs.py` — 103 passed (was 101; +2 new tests, zero-diff on the rest).
- `uv run pytest tests/test_board_04_copper_lvs.py tests/test_board_05_stitch_pipeline.py tests/test_board_05_drv8301_pin_nets.py` — 17 passed.
- `uv run pytest tests/test_board_0*.py` — 251 passed, 1 skipped. The 2 errors are in `TestBoard05RoutingThroughput` (a class-scoped fixture that runs `kct route` and fails on an auto-grid memory-budget cap) — pre-existing routing infrastructure, **unrelated to this change** (zero diff to any routing code).
- `uv run ruff check` / `ruff format --check` on both changed files — clean.

Closes #4022