### PR TITLE
test: pass --allow-unsafe-grid in board-05 throughput fixture to fix ERROR

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 4022
-# Branch: feature/issue-4022
+# Issue: 4024
+# Branch: feature/issue-4024
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/tests/test_board_05_routing_regression.py
+++ b/tests/test_board_05_routing_regression.py
@@ -34,6 +34,20 @@ path entirely.  Do not treat this throughput floor as a manufacturability
 or DRC-cleanliness gate for board 05; that is
 ``tests/test_board_05_drc_hotspot_regression.py`` against the committed
 cpp/tier1/4L snapshot.
+
+The recipe also passes ``--allow-unsafe-grid`` (Issue #4024).  Board 05's
+geometry (210 pads, 0.15mm clearance, 80x100mm) makes ``--grid auto``
+select a grid coarser than clearance/2 once the memory budget cap
+(max_cells=2,000,000) is hit, which trips the #3911 auto-grid safety gate
+(``route_cmd.py`` ~8594) BEFORE any backend selection happens -- so the
+gate does ``return 1`` identically under both ``--backend python`` and
+``--backend cpp``.  A fatal exit 1 raised inside the class-scoped fixture
+turns into pytest ERROR (not FAIL) for every dependent test.  Because this
+throughput guard discards its routed output (written to a
+``TemporaryDirectory`` and never manufactured or DRC-checked), the
+DRC-safety gate is irrelevant here; ``--allow-unsafe-grid`` makes the gate
+a no-op for this fixture without touching production behavior anywhere
+else.
 """
 
 from __future__ import annotations
@@ -181,6 +195,19 @@ class TestBoard05RoutingThroughput:
             # cached route rather than current router throughput.  Both
             # tests in this class pin THROUGHPUT, so the route must
             # actually run.
+            # ``--allow-unsafe-grid`` (issue #4024): board 05's dense
+            # geometry (210 pads, 0.15mm clearance) forces ``--grid auto``
+            # coarser than clearance/2 under the memory budget cap, tripping
+            # the #3911 auto-grid safety gate (route_cmd.py ~8594), which
+            # does ``return 1`` BEFORE backend selection -- identically for
+            # python and cpp.  That fatal exit inside this class-scoped
+            # fixture surfaces as pytest ERROR (not FAIL) on every dependent
+            # test.  This is a throughput-only guard: the routed PCB is
+            # written to the TemporaryDirectory above and discarded (never
+            # manufactured, never DRC-checked), so the DRC-safety intent of
+            # the gate does not apply.  The flag makes the gate a no-op here
+            # WITHOUT altering production gate behavior (see #3911); it does
+            # not change the throughput numbers the assertions below parse.
             cmd = [
                 sys.executable,
                 "-m",
@@ -200,6 +227,7 @@ class TestBoard05RoutingThroughput:
                 "--backend",
                 "python",
                 "--no-cache",
+                "--allow-unsafe-grid",
             ]
             proc = subprocess.run(
                 cmd,


### PR DESCRIPTION
## Summary

`TestBoard05RoutingThroughput` errored (not failed) on `main`. The two
tests reported `ERROR at setup` because the class-scoped `route_stdout`
fixture called `pytest.fail()` after `kct route` returned exit code 1.

The root cause is **not** a python-vs-cpp backend distinction (refuting the
issue's original diagnosis). Board 05's dense geometry (210 pads, 0.15mm
clearance, 80x100mm) forces `--grid auto` coarser than clearance/2 once the
memory budget cap (`max_cells=2,000,000`) is hit, tripping the #3911
auto-grid safety gate (`route_cmd.py` ~8594). That gate does `return 1`
**before** backend selection, so it fires identically under `--backend
python` and `--backend cpp`. A `pytest.fail()` raised inside a class-scoped
fixture is what pytest reports as ERROR for every dependent test.

This class is a **throughput-only** regression guard (the #2681 per-net A*
slowdown dimension). Its routed PCB is written to a `TemporaryDirectory` and
discarded — never manufactured, never DRC-checked — so the DRC-safety intent
of the auto-grid gate does not apply. Adding `--allow-unsafe-grid` to the
fixture's `kct route` invocation makes the gate a no-op **for this test
only**, without touching production gate logic.

## Changes

- `tests/test_board_05_routing_regression.py`: add `--allow-unsafe-grid` to
  the `route_stdout` fixture's `cmd` list.
- Update the class/module docstring and add an inline comment explaining why
  the flag is safe here (throughput-only, output discarded), mirroring the
  existing NON-PRODUCTION RECIPE note style.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| 1. Both tests report PASS/SKIP/FAIL (never ERROR), with and without C++ backend | ✅ | Ran `uv run pytest -m slow` with the C++ backend built → `2 passed in 259.65s`. The gate fires identically under both backends (before backend selection), and the flag bypasses it in both, so the python-only checkout also reports PASS/FAIL, never ERROR. |
| 2. Throughput assertions still exercise real `kct route` output | ✅ | Fixture still runs real `kct route` as a subprocess (`--backend python`, 240s budget, seed 42, `--no-cache`); both tests parse actual "Nets routed:"/"Initial pass:" stdout — no stub/mock. `MIN_2L_COMPLETION_PCT=35` and the iter-0 floor of 15 both executed and passed against live output. |
| 3. No change to `io.py` / `route_cmd.py` production gate logic | ✅ | `git diff --stat` shows only `tests/test_board_05_routing_regression.py` (plus the auto-managed `.loom-managed` worktree marker). #3911's gate is untouched. |
| 4. `.github/workflows/slow-tests.yml` nightly runner unaffected | ✅ | Inspected: workflow runs `-m slow` (unchanged selection), builds the C++ backend, gates on pytest exit code. The change is confined to a CLI flag inside the test subprocess; the test still runs under `-m slow` and now PASSes instead of ERRORing. |
| 5. Docstring updated to note the flag and why it's safe | ✅ | Module docstring + inline comment added, matching the existing NON-PRODUCTION RECIPE style. |

## Test Plan

- `uv run ruff check tests/test_board_05_routing_regression.py` → All checks passed
- `uv run ruff format --check tests/test_board_05_routing_regression.py` → already formatted
- `uv run pytest tests/test_board_05_routing_regression.py -m slow -v` → `2 passed in 259.65s` (C++ backend built via `kct build-native`)

Closes #4024