### PR TITLE
test: skip cmaes-dependent modules when optional dep is absent

### DIFF
--- a/tests/placement/test_cmaes_strategy.py
+++ b/tests/placement/test_cmaes_strategy.py
@@ -8,7 +8,12 @@ INFEASIBILITY_OFFSET`` under :class:`CostMode.LEXICOGRAPHIC`).
 
 from __future__ import annotations
 
-from kicad_tools.placement.cmaes_strategy import CMAESStrategy
+import pytest
+
+# Skip entire module if cmaes is not installed
+pytest.importorskip("cmaes", reason="cmaes not installed (optional 'placement'/'dev' extra)")
+
+from kicad_tools.placement.cmaes_strategy import CMAESStrategy  # noqa: E402
 from kicad_tools.placement.cost import INFEASIBILITY_OFFSET, BoardOutline
 from kicad_tools.placement.strategy import StrategyConfig
 from kicad_tools.placement.vector import ComponentDef, bounds

--- a/tests/test_optimize_placement_cmd.py
+++ b/tests/test_optimize_placement_cmd.py
@@ -8,7 +8,10 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from kicad_tools.cli.optimize_placement_cmd import (
+# Skip entire module if cmaes is not installed
+pytest.importorskip("cmaes", reason="cmaes not installed (optional 'placement'/'dev' extra)")
+
+from kicad_tools.cli.optimize_placement_cmd import (  # noqa: E402
     _build_footprint_sizes,
     _create_strategy,
     _evaluate,
@@ -19,7 +22,7 @@ from kicad_tools.cli.optimize_placement_cmd import (
     _write_placements_to_pcb_atomic,
     run_optimize_placement,
 )
-from kicad_tools.placement.cmaes_strategy import CMAESStrategy
+from kicad_tools.placement.cmaes_strategy import CMAESStrategy  # noqa: E402
 from kicad_tools.placement.cost import (
     BoardOutline,
     CostBreakdown,

--- a/tests/test_placement_benchmark.py
+++ b/tests/test_placement_benchmark.py
@@ -20,7 +20,10 @@ from typing import Any
 
 import pytest
 
-from kicad_tools.placement.cmaes_strategy import CMAESStrategy
+# Skip entire module if cmaes is not installed
+pytest.importorskip("cmaes", reason="cmaes not installed (optional 'placement'/'dev' extra)")
+
+from kicad_tools.placement.cmaes_strategy import CMAESStrategy  # noqa: E402
 from kicad_tools.placement.cost import (
     BoardOutline,
     ComponentPlacement,

--- a/tests/test_placement_strategy.py
+++ b/tests/test_placement_strategy.py
@@ -19,7 +19,13 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from kicad_tools.placement.cmaes_strategy import CMAESStrategy, _auto_population_size
+# Skip entire module if cmaes is not installed
+pytest.importorskip("cmaes", reason="cmaes not installed (optional 'placement'/'dev' extra)")
+
+from kicad_tools.placement.cmaes_strategy import (  # noqa: E402
+    CMAESStrategy,
+    _auto_population_size,
+)
 from kicad_tools.placement.cost import BoardOutline
 from kicad_tools.placement.strategy import PlacementStrategy, StrategyConfig
 from kicad_tools.placement.vector import (


### PR DESCRIPTION
## Summary

Four placement test modules imported `kicad_tools.placement.cmaes_strategy` at module scope, which raises ImportError at pytest **collection** when the optional `cmaes` package isn't installed (bare `uv sync` in fresh worktrees). Reviewers repeatedly re-diagnosed these collection ERRORs as environmental.

Adds `pytest.importorskip("cmaes", reason="cmaes not installed (optional 'placement'/'dev' extra)")` at module top — before the `cmaes_strategy` import — in:

- `tests/test_placement_benchmark.py`
- `tests/test_optimize_placement_cmd.py` (function-scoped re-imports at ~679/723 untouched — already safe)
- `tests/test_placement_strategy.py`
- `tests/placement/test_cmaes_strategy.py`

Mirrors the existing repo pattern (`tests/test_bo_strategy.py:26` for ax-platform; same for shapely/pydantic/yaml/jinja2/mcp elsewhere). `# noqa: E402` on the now-below-guard imports.

## Verification

- All 4 modules with cmaes present: **125 passed** (zero behavior change).
- `ruff check` + `ruff format` clean.
- With cmaes absent, `importorskip` converts the collection error to skip-with-reason (mechanism verified in curation via a MetaPathFinder ImportError simulation; per-module skip exercised by the guard being placed before the failing import).

## Notes

Built per the curation plan on #4026. The builder agent's edits were verified/shipped by the sweep orchestrator after a host disk-full incident interrupted the builder's finishing steps; verification ran against the main venv (tests-only diff).

Closes #4026

🤖 Generated with [Claude Code](https://claude.com/claude-code)