### PR TITLE
fix(3d): offset canonical STEP models onto origin-centered pads by pad-centroid delta

### DIFF
--- a/boards/00-simple-led/output/simple_led.kicad_pcb
+++ b/boards/00-simple-led/output/simple_led.kicad_pcb
@@ -51,7 +51,7 @@
     (pad "2" thru_hole oval (at 0 1.270) (size 1.7 1.7) (drill 1.0) (layers "*.Cu" "*.Mask") (net 3 "GND"))
   	(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x02_P2.54mm_Vertical.step"
   		(offset
-  			(xyz 0 0 0)
+  			(xyz 0 1.27 0)
   		)
   		(scale
   			(xyz 1 1 1)
@@ -99,7 +99,7 @@
     (pad "2" thru_hole circle (at 1.270 0 0) (size 1.8 1.8) (drill 0.9) (layers "*.Cu" "*.Mask") (net 2 "LED_ANODE"))
   	(model "${KICAD10_3DMODEL_DIR}/LED_THT.3dshapes/LED_D5.0mm.step"
   		(offset
-  			(xyz 0 0 0)
+  			(xyz -1.27 0 0)
   		)
   		(scale
   			(xyz 1 1 1)

--- a/boards/00-simple-led/output/simple_led_routed.kicad_pcb
+++ b/boards/00-simple-led/output/simple_led_routed.kicad_pcb
@@ -226,7 +226,7 @@
 		(embedded_fonts no)
 		(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x02_P2.54mm_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz 0 1.27 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -306,7 +306,7 @@
 		(embedded_fonts no)
 		(model "${KICAD10_3DMODEL_DIR}/LED_THT.3dshapes/LED_D5.0mm.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz -1.27 0 0)
 			)
 			(scale
 				(xyz 1 1 1)

--- a/boards/01-voltage-divider/output/voltage_divider.kicad_pcb
+++ b/boards/01-voltage-divider/output/voltage_divider.kicad_pcb
@@ -51,7 +51,7 @@
     (pad "2" thru_hole oval (at 0 1.270) (size 1.7 1.7) (drill 1.0) (layers "*.Cu" "*.Mask") (net 3 "GND"))
   	(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x02_P2.54mm_Vertical.step"
   		(offset
-  			(xyz 0 0 0)
+  			(xyz 0 1.27 0)
   		)
   		(scale
   			(xyz 1 1 1)
@@ -123,7 +123,7 @@
     (pad "2" thru_hole oval (at 0 1.270) (size 1.7 1.7) (drill 1.0) (layers "*.Cu" "*.Mask") (net 3 "GND"))
   	(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x02_P2.54mm_Vertical.step"
   		(offset
-  			(xyz 0 0 0)
+  			(xyz 0 1.27 0)
   		)
   		(scale
   			(xyz 1 1 1)

--- a/boards/01-voltage-divider/output/voltage_divider_routed.kicad_pcb
+++ b/boards/01-voltage-divider/output/voltage_divider_routed.kicad_pcb
@@ -147,7 +147,7 @@
 		(embedded_fonts no)
 		(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x02_P2.54mm_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz 0 1.27 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -305,7 +305,7 @@
 		(embedded_fonts no)
 		(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x02_P2.54mm_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz 0 1.27 0)
 			)
 			(scale
 				(xyz 1 1 1)

--- a/boards/02-charlieplex-led/output/charlieplex_3x3.kicad_pcb
+++ b/boards/02-charlieplex-led/output/charlieplex_3x3.kicad_pcb
@@ -64,7 +64,7 @@
     (pad "8" thru_hole oval (at 3.800 -3.700) (size 1.6 1.6) (drill 0.8) (layers "*.Cu" "*.Mask") (net 10 "GND"))
   	(model "${KICAD10_3DMODEL_DIR}/Package_DIP.3dshapes/DIP-8_W7.62mm.step"
   		(offset
-  			(xyz 0 0 0)
+  			(xyz -3.81 3.76 0)
   		)
   		(scale
   			(xyz 1 1 1)

--- a/boards/02-charlieplex-led/output/charlieplex_3x3_routed.kicad_pcb
+++ b/boards/02-charlieplex-led/output/charlieplex_3x3_routed.kicad_pcb
@@ -598,7 +598,7 @@
 		(embedded_fonts no)
 		(model "${KICAD10_3DMODEL_DIR}/Package_DIP.3dshapes/DIP-8_W7.62mm.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz -3.81 3.76 0)
 			)
 			(scale
 				(xyz 1 1 1)

--- a/boards/03-usb-joystick/output/usb_joystick.kicad_pcb
+++ b/boards/03-usb-joystick/output/usb_joystick.kicad_pcb
@@ -136,7 +136,7 @@
     (pad "SH" thru_hole circle (at 4.3 1.5) (size 1.0 1.0) (drill 0.6) (layers "*.Cu" "*.Mask") (net 3 "GND"))
   	(model "${KICAD10_3DMODEL_DIR}/Connector_USB.3dshapes/USB_C_Receptacle_GCT_USB4105-xx-A_16P_TopMnt_Horizontal.step"
   		(offset
-  			(xyz 0 0 0)
+  			(xyz 0 -3.70884 0)
   		)
   		(scale
   			(xyz 1 1 1)
@@ -178,7 +178,7 @@
     (pad "2" thru_hole circle (at 2.44 0) (size 1.5 1.5) (drill 0.8) (layers "*.Cu" "*.Mask") (net 16 "XTAL2"))
   	(model "${KICAD10_3DMODEL_DIR}/Crystal.3dshapes/Crystal_HC49-U_Vertical.step"
   		(offset
-  			(xyz 0 0 0)
+  			(xyz -2.44 0 0)
   		)
   		(scale
   			(xyz 1 1 1)

--- a/boards/03-usb-joystick/output/usb_joystick_routed.kicad_pcb
+++ b/boards/03-usb-joystick/output/usb_joystick_routed.kicad_pcb
@@ -1405,7 +1405,7 @@
 		(embedded_fonts no)
 		(model "${KICAD10_3DMODEL_DIR}/Crystal.3dshapes/Crystal_HC49-U_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz -2.44 0 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -1607,7 +1607,7 @@
 		(embedded_fonts no)
 		(model "${KICAD10_3DMODEL_DIR}/Connector_USB.3dshapes/USB_C_Receptacle_GCT_USB4105-xx-A_16P_TopMnt_Horizontal.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz 0 -3.70884 0)
 			)
 			(scale
 				(xyz 1 1 1)

--- a/boards/04-stm32-devboard/output/stm32_devboard.kicad_pcb
+++ b/boards/04-stm32-devboard/output/stm32_devboard.kicad_pcb
@@ -228,7 +228,7 @@
     (pad "2" thru_hole circle (at 2.44 0) (size 1.5 1.5) (drill 0.8) (layers "*.Cu" "*.Mask") (net 5 "OSC_OUT"))
   	(model "${KICAD10_3DMODEL_DIR}/Crystal.3dshapes/Crystal_HC49-4H_Vertical.step"
   		(offset
-  			(xyz 0 0 0)
+  			(xyz -2.44 0 0)
   		)
   		(scale
   			(xyz 1 1 1)
@@ -496,7 +496,7 @@
     (pad "6" thru_hole oval (at 0 6.35) (size 1.7 1.7) (drill 1.0) (layers "*.Cu" "*.Mask") (net 3 "GND"))
   	(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x06_P2.54mm_Vertical.step"
   		(offset
-  			(xyz 0 0 0)
+  			(xyz 0 6.35 0)
   		)
   		(scale
   			(xyz 1 1 1)

--- a/boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb
+++ b/boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb
@@ -431,7 +431,7 @@
 		(embedded_fonts no)
 		(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x06_P2.54mm_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz 0 6.35 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -918,7 +918,7 @@
 		(embedded_fonts no)
 		(model "${KICAD10_3DMODEL_DIR}/Crystal.3dshapes/Crystal_HC49-4H_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz -2.44 0 0)
 			)
 			(scale
 				(xyz 1 1 1)

--- a/boards/05-bldc-motor-controller/output/bldc_controller.kicad_pcb
+++ b/boards/05-bldc-motor-controller/output/bldc_controller.kicad_pcb
@@ -269,7 +269,7 @@
 		)
 		(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x02_P2.54mm_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz 0 1.27 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -545,7 +545,7 @@
 		)
 		(model "${KICAD10_3DMODEL_DIR}/Package_TO_SOT_SMD.3dshapes/TO-263-5_TabPin3.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz 1.035 0 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -1127,7 +1127,7 @@
 		)
 		(model "${KICAD10_3DMODEL_DIR}/Crystal.3dshapes/Crystal_HC49-4H_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz -2.44 0 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -2248,7 +2248,7 @@
 		)
 		(model "${KICAD10_3DMODEL_DIR}/Package_TO_SOT_THT.3dshapes/TO-220-3_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz -2.54 0 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -2307,7 +2307,7 @@
 		)
 		(model "${KICAD10_3DMODEL_DIR}/Package_TO_SOT_THT.3dshapes/TO-220-3_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz -2.54 0 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -2366,7 +2366,7 @@
 		)
 		(model "${KICAD10_3DMODEL_DIR}/Package_TO_SOT_THT.3dshapes/TO-220-3_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz -2.54 0 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -2425,7 +2425,7 @@
 		)
 		(model "${KICAD10_3DMODEL_DIR}/Package_TO_SOT_THT.3dshapes/TO-220-3_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz -2.54 0 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -2484,7 +2484,7 @@
 		)
 		(model "${KICAD10_3DMODEL_DIR}/Package_TO_SOT_THT.3dshapes/TO-220-3_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz -2.54 0 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -2543,7 +2543,7 @@
 		)
 		(model "${KICAD10_3DMODEL_DIR}/Package_TO_SOT_THT.3dshapes/TO-220-3_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz -2.54 0 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -2914,7 +2914,7 @@
 		)
 		(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x03_P2.54mm_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz 0 2.54 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -2987,7 +2987,7 @@
 		)
 		(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x05_P2.54mm_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz 0 5.08 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -3067,7 +3067,7 @@
 		)
 		(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x06_P2.54mm_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz 0 6.35 0)
 			)
 			(scale
 				(xyz 1 1 1)

--- a/boards/05-bldc-motor-controller/output/bldc_controller_routed.kicad_pcb
+++ b/boards/05-bldc-motor-controller/output/bldc_controller_routed.kicad_pcb
@@ -234,7 +234,7 @@
 		(embedded_fonts no)
 		(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x06_P2.54mm_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz 0 6.35 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -482,7 +482,7 @@
 		(embedded_fonts no)
 		(model "${KICAD10_3DMODEL_DIR}/Package_TO_SOT_THT.3dshapes/TO-220-3_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz -2.54 0 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -562,7 +562,7 @@
 		(embedded_fonts no)
 		(model "${KICAD10_3DMODEL_DIR}/Crystal.3dshapes/Crystal_HC49-4H_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz -2.44 0 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -790,7 +790,7 @@
 		(embedded_fonts no)
 		(model "${KICAD10_3DMODEL_DIR}/Package_TO_SOT_THT.3dshapes/TO-220-3_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz -2.54 0 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -938,7 +938,7 @@
 		(embedded_fonts no)
 		(model "${KICAD10_3DMODEL_DIR}/Package_TO_SOT_THT.3dshapes/TO-220-3_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz -2.54 0 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -1118,7 +1118,7 @@
 		(embedded_fonts no)
 		(model "${KICAD10_3DMODEL_DIR}/Package_TO_SOT_THT.3dshapes/TO-220-3_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz -2.54 0 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -1198,7 +1198,7 @@
 		(embedded_fonts no)
 		(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x02_P2.54mm_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz 0 1.27 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -2782,7 +2782,7 @@
 		(embedded_fonts no)
 		(model "${KICAD10_3DMODEL_DIR}/Package_TO_SOT_SMD.3dshapes/TO-263-5_TabPin3.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz 1.035 0 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -4446,7 +4446,7 @@
 		(embedded_fonts no)
 		(model "${KICAD10_3DMODEL_DIR}/Package_TO_SOT_THT.3dshapes/TO-220-3_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz -2.54 0 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -4554,7 +4554,7 @@
 		(embedded_fonts no)
 		(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x05_P2.54mm_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz 0 5.08 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -4802,7 +4802,7 @@
 		(embedded_fonts no)
 		(model "${KICAD10_3DMODEL_DIR}/Package_TO_SOT_THT.3dshapes/TO-220-3_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz -2.54 0 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -5263,7 +5263,7 @@
 		(embedded_fonts no)
 		(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x03_P2.54mm_Vertical.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz 0 2.54 0)
 			)
 			(scale
 				(xyz 1 1 1)

--- a/boards/06-diffpair-test/output/diffpair_test.kicad_pcb
+++ b/boards/06-diffpair-test/output/diffpair_test.kicad_pcb
@@ -100,7 +100,7 @@
     (pad "S2" thru_hole circle (at 7.500 1.000) (size 1.000 1.000) (drill 0.600) (layers "*.Cu" "*.Mask") (net 5 "GND"))
   	(model "${KICAD10_3DMODEL_DIR}/Connector_USB.3dshapes/USB_C_Receptacle_GCT_USB4105-xx-A_16P_TopMnt_Horizontal.step"
   		(offset
-  			(xyz 0 0 0)
+  			(xyz 0 -4.09773 0)
   		)
   		(scale
   			(xyz 1 1 1)
@@ -152,7 +152,7 @@
     (pad "RST" smd rect (at 0.000 -1.500) (size 0.500 0.500) (layers "F.Cu" "F.Paste" "F.Mask") (net 26 "MIPI_RST"))
   	(model "${KICAD10_3DMODEL_DIR}/Connector_FFC-FPC.3dshapes/Amphenol_F32Q-1A7x1-11004_1x04-1MP_P0.5mm_Horizontal.step"
   		(offset
-  			(xyz 0 0 0)
+  			(xyz 0 -2.65357 0)
   		)
   		(scale
   			(xyz 1 1 1)

--- a/boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb
+++ b/boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb
@@ -209,7 +209,7 @@
 		(embedded_fonts no)
 		(model "${KICAD10_3DMODEL_DIR}/Connector_FFC-FPC.3dshapes/Amphenol_F32Q-1A7x1-11004_1x04-1MP_P0.5mm_Horizontal.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz 0 -2.65357 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -783,7 +783,7 @@
 		(embedded_fonts no)
 		(model "${KICAD10_3DMODEL_DIR}/Connector_USB.3dshapes/USB_C_Receptacle_GCT_USB4105-xx-A_16P_TopMnt_Horizontal.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz 0 -4.09773 0)
 			)
 			(scale
 				(xyz 1 1 1)

--- a/boards/07-matchgroup-test/output/matchgroup_test.kicad_pcb
+++ b/boards/07-matchgroup-test/output/matchgroup_test.kicad_pcb
@@ -230,7 +230,7 @@
     (pad "M2" thru_hole circle (at 3.500 1.500) (size 1.000 1.000) (drill 0.600) (layers "*.Cu" "*.Mask") (net 3 "GND"))
   	(model "${KICAD10_3DMODEL_DIR}/Connector_FFC-FPC.3dshapes/TE_84952-6_1x06-1MP_P1.0mm_Horizontal.step"
   		(offset
-  			(xyz 0 0 0)
+  			(xyz 0 -1.475 0)
   		)
   		(scale
   			(xyz 1 1 1)
@@ -308,7 +308,7 @@
     (pad "S2" thru_hole circle (at 5.000 1.500) (size 1.200 1.200) (drill 0.700) (layers "*.Cu" "*.Mask") (net 3 "GND"))
   	(model "${KICAD10_3DMODEL_DIR}/Connector_Video.3dshapes/HDMI_A_Amphenol_10029449-x01xLF_Horizontal.step"
   		(offset
-  			(xyz 0 0 0)
+  			(xyz -0.206522 -4.7 0)
   		)
   		(scale
   			(xyz 1 1 1)
@@ -410,7 +410,7 @@
     (pad "9" thru_hole circle (at 10.160 0.000) (size 1.500 1.500) (drill 0.800) (layers "*.Cu" "*.Mask") (net 34 "A7"))
   	(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x09_P2.54mm_Vertical.step"
   		(offset
-  			(xyz 0 0 0)
+  			(xyz 0 10.16 0)
   		)
   		(scale
   			(xyz 1 1 1)

--- a/boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb
+++ b/boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb
@@ -533,10 +533,15 @@
 			(net 3 "GND")
 		)
 		(embedded_fonts no)
-		(model "${KICAD10_3DMODEL_DIR}/Package_DFN_QFN.3dshapes/QFN-48-1EP_7x7mm_P0.5mm_EP3.5x3.5mm.step" (offset (xyz 0 0 0))
-			(scale (xyz 1 1 1)
+		(model "${KICAD10_3DMODEL_DIR}/Package_DFN_QFN.3dshapes/QFN-48-1EP_7x7mm_P0.5mm_EP3.5x3.5mm.step"
+			(offset
+				(xyz 0 0 0)
 			)
-			(rotate (xyz 0 0 0)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
 			)
 		)
 	)
@@ -671,10 +676,15 @@
 			(net 34 "A7")
 		)
 		(embedded_fonts no)
-		(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x09_P2.54mm_Vertical.step" (offset (xyz 0 0 0))
-			(scale (xyz 1 1 1)
+		(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x09_P2.54mm_Vertical.step"
+			(offset
+				(xyz 0 10.16 0)
 			)
-			(rotate (xyz 0 0 0)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
 			)
 		)
 	)
@@ -1104,10 +1114,15 @@
 			(net 3 "GND")
 		)
 		(embedded_fonts no)
-		(model "${KICAD10_3DMODEL_DIR}/Package_QFP.3dshapes/LQFP-48_7x7mm_P0.5mm.step" (offset (xyz 0 0 0))
-			(scale (xyz 1 1 1)
+		(model "${KICAD10_3DMODEL_DIR}/Package_QFP.3dshapes/LQFP-48_7x7mm_P0.5mm.step"
+			(offset
+				(xyz 0 0 0)
 			)
-			(rotate (xyz 0 0 0)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
 			)
 		)
 	)
@@ -1225,7 +1240,7 @@
 		(embedded_fonts no)
 		(model "${KICAD10_3DMODEL_DIR}/Connector_FFC-FPC.3dshapes/TE_84952-6_1x06-1MP_P1.0mm_Horizontal.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz 0 -1.475 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -1471,10 +1486,15 @@
 			(net 3 "GND")
 		)
 		(embedded_fonts no)
-		(model "${KICAD10_3DMODEL_DIR}/Package_DFN_QFN.3dshapes/QFN-24-1EP_4x4mm_P0.5mm_EP2.5x2.5mm.step" (offset (xyz 0 0 0))
-			(scale (xyz 1 1 1)
+		(model "${KICAD10_3DMODEL_DIR}/Package_DFN_QFN.3dshapes/QFN-24-1EP_4x4mm_P0.5mm_EP2.5x2.5mm.step"
+			(offset
+				(xyz 0 0 0)
 			)
-			(rotate (xyz 0 0 0)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
 			)
 		)
 	)
@@ -2054,7 +2074,7 @@
 		(embedded_fonts no)
 		(model "${KICAD10_3DMODEL_DIR}/Connector_Video.3dshapes/HDMI_A_Amphenol_10029449-x01xLF_Horizontal.step"
 			(offset
-				(xyz 0 0 0)
+				(xyz -0.206522 -4.7 0)
 			)
 			(scale
 				(xyz 1 1 1)
@@ -2487,10 +2507,15 @@
 			(net 3 "GND")
 		)
 		(embedded_fonts no)
-		(model "${KICAD10_3DMODEL_DIR}/Package_DFN_QFN.3dshapes/QFN-48-1EP_7x7mm_P0.5mm_EP3.5x3.5mm.step" (offset (xyz 0 0 0))
-			(scale (xyz 1 1 1)
+		(model "${KICAD10_3DMODEL_DIR}/Package_DFN_QFN.3dshapes/QFN-48-1EP_7x7mm_P0.5mm_EP3.5x3.5mm.step"
+			(offset
+				(xyz 0 0 0)
 			)
-			(rotate (xyz 0 0 0)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
 			)
 		)
 	)

--- a/src/kicad_tools/cli/pcb_add_3d_models.py
+++ b/src/kicad_tools/cli/pcb_add_3d_models.py
@@ -3,8 +3,16 @@
 ``kct pcb add-3d-models`` patches missing ``(model ...)`` nodes into a
 ``.kicad_pcb`` so ``kicad-cli pcb render`` (and the KiCad 3D viewer) shows
 component bodies instead of a bare board.  The model references are copied
-verbatim from the installed KiCad footprint libraries (``.kicad_mod``
-sources), so offsets/rotations match what KiCad itself would embed.
+from the installed KiCad footprint libraries (``.kicad_mod`` sources).
+
+kicad-tools boards often reuse a canonical footprint *name* while placing
+pads on a different origin convention (origin-centered rather than KiCad's
+pad-1-at-origin), so a verbatim copy would leave the body shifted by half the
+pad pitch.  The patcher therefore adds the ``target_centroid -
+source_centroid`` pad delta into each inserted model's ``(offset (xyz ...))``
+(model-frame Y negated vs the footprint 2D frame) so the body lands on the
+target's pads.  Footprints already sharing the library convention compute a
+zero delta and are inserted verbatim.
 
 The patch is pure text insertion scoped to ``(model ...)`` metadata — no
 copper, placement, zone, or net bytes change, so DRC results are identical

--- a/src/kicad_tools/pcb/models3d.py
+++ b/src/kicad_tools/pcb/models3d.py
@@ -10,10 +10,27 @@ copies those references into an existing ``.kicad_pcb`` after the fact.
 
 The patch is **pure text insertion**: for each footprint block whose lib id
 resolves to an installed KiCad library footprint that has one or more
-``(model ...)`` nodes, the nodes are inserted verbatim (re-indented) just
-before the footprint's closing paren.  No other bytes of the file change --
-copper, placement, zones and nets are untouched, so DRC results are
-guaranteed identical.
+``(model ...)`` nodes, the nodes are inserted (re-indented) just before the
+footprint's closing paren.  No other bytes of the file change -- copper,
+placement, zones and nets are untouched, so DRC results are guaranteed
+identical.
+
+**Origin-convention offset.**  A STEP model is authored in its *library*
+footprint's local frame (pad 1 at the library footprint's pad-1 position).
+kicad-tools boards often reuse a canonical footprint *name* while placing
+pads on a different origin convention -- e.g. a 2-pad 0.1" header whose pads
+sit at ``(0, -1.27)`` / ``(0, +1.27)`` (centered on the origin) instead of
+KiCad's ``(0, 0)`` / ``(0, 2.54)`` (pad 1 at origin).  Copying the model with
+a zero offset then leaves the body shifted by the pad-1 delta (half the pitch
+for a 2-pad part).  So before inserting a ``(model ...)`` node we add the
+``target_pad1 - source_pad1`` delta into its ``(offset (xyz ...))`` node,
+expressed in the KiCad 3D-model frame (X follows the footprint X, **Y is
+negated** relative to the footprint 2D frame, Z is unchanged).  This keeps
+the change pure render metadata -- only the newly inserted model block's own
+offset numbers differ from the library source; no pre-existing byte moves and
+no copper/pad/zone/net geometry changes.  Footprints that already share the
+library's origin convention (most SMD parts, e.g. ``R_0805_2012Metric``)
+compute a zero delta and are inserted verbatim.
 
 Used by ``kct pcb add-3d-models``.
 """
@@ -34,6 +51,7 @@ from kicad_tools.pcb.model_substitutions import substitute_lib_id
 __all__ = [
     "FootprintBlock",
     "ModelPatchReport",
+    "ResolvedModels",
     "add_model_refs",
     "add_model_refs_to_text",
     "extract_model_blocks",
@@ -208,10 +226,156 @@ def _indent_block(block: str, indent: str) -> str:
 
 
 # --------------------------------------------------------------------------
+# Pad-1 origin-convention offset
+# --------------------------------------------------------------------------
+
+
+def _pad_anchor(block_text: str) -> tuple[float, float] | None:
+    """Return the pad *centroid* of a footprint block, in local coordinates.
+
+    Scans *block_text* (a full ``(footprint ...)`` or ``.kicad_mod`` body,
+    string-aware) for every copper ``(pad ...)`` node and averages the ``(at
+    x y)`` positions.  The centroid -- not pad 1 alone -- is the anchor for
+    the origin-convention offset because a STEP body is centered on the
+    footprint's pad field: two footprints that share a centroid (even with
+    different pad *pitch*, e.g. ``R_0805`` with 1.0mm vs the library's
+    0.9125mm half-pitch) need **zero** offset, while a footprint translated
+    off the library origin (e.g. a header re-centered from pad-1-at-origin to
+    origin-centered) needs the centroid delta.
+
+    A pad rotation angle (the optional third ``at`` field) is ignored: a
+    pad's *position* is already in the footprint-local (unrotated) frame, so
+    the centroid delta is well defined regardless of pad rotation.  Returns
+    ``None`` when the block has no positioned pads (e.g. a footprint whose
+    pads all lack an ``(at ...)``).
+    """
+    xs: list[float] = []
+    ys: list[float] = []
+    i = 0
+    n = len(block_text)
+    needle = "(pad"
+    while i < n:
+        c = block_text[i]
+        if c == '"':
+            i = _skip_string(block_text, i)
+            continue
+        if c == "(" and block_text.startswith(needle, i):
+            after = i + len(needle)
+            if after < n and block_text[after] in " \t\n":
+                pad_end = _find_matching_paren(block_text, i)
+                at = _find_first_at(block_text, i, pad_end)
+                if at is not None:
+                    xs.append(at[0])
+                    ys.append(at[1])
+                i = pad_end + 1
+                continue
+        i += 1
+    if not xs:
+        return None
+    return sum(xs) / len(xs), sum(ys) / len(ys)
+
+
+def _find_first_at(text: str, start: int, end: int) -> tuple[float, float] | None:
+    """Return ``(x, y)`` of the first ``(at x y ...)`` in ``text[start:end]``."""
+    i = start
+    at_needle = "(at"
+    while i < end:
+        c = text[i]
+        if c == '"':
+            i = _skip_string(text, i)
+            continue
+        if c == "(" and text.startswith(at_needle, i):
+            after = i + len(at_needle)
+            if after < end and text[after] in " \t\n":
+                close = _find_matching_paren(text, i)
+                fields = text[after:close].split()
+                if len(fields) >= 2:
+                    try:
+                        return float(fields[0]), float(fields[1])
+                    except ValueError:
+                        return None
+                return None
+        i += 1
+    return None
+
+
+def _apply_offset_delta(model_block: str, dx: float, dy: float) -> str:
+    """Return *model_block* with ``(dx, -dy)`` added into its ``(offset ...)``.
+
+    KiCad's 3D-model ``(offset (xyz ...))`` lives in the model frame whose X
+    matches the footprint X but whose **Y is negated** relative to the
+    footprint 2D frame (Z is unchanged).  A pad-1 delta of ``(dx, dy)`` in
+    footprint-local 2D coordinates therefore maps to a model offset delta of
+    ``(dx, -dy, 0)``.
+
+    Only the ``x`` and ``y`` numbers of the model's own ``(offset (xyz ...))``
+    are rewritten; every other byte of the node is preserved.  When *dx* and
+    *dy* are both (near) zero (target shares the library origin convention)
+    the block is returned unchanged so already-correct footprints get a
+    verbatim insert -- a 1nm tolerance absorbs centroid-averaging FP noise.
+    """
+    if abs(dx) < 1e-6 and abs(dy) < 1e-6:
+        return model_block
+    # Locate (offset ... (xyz X Y Z) ...) inside the model node.
+    off_idx = model_block.find("(offset")
+    if off_idx == -1:
+        return model_block
+    off_end = _find_matching_paren(model_block, off_idx)
+    xyz_idx = model_block.find("(xyz", off_idx, off_end)
+    if xyz_idx == -1:
+        return model_block
+    xyz_end = _find_matching_paren(model_block, xyz_idx)
+    inner = model_block[xyz_idx + len("(xyz") : xyz_end]
+    fields = inner.split()
+    if len(fields) < 3:
+        return model_block
+    try:
+        ox, oy, oz = float(fields[0]), float(fields[1]), float(fields[2])
+    except ValueError:
+        return model_block
+    nx = _fmt_num(ox + dx)
+    ny = _fmt_num(oy - dy)  # model-frame Y is negated vs footprint 2D Y
+    nz = _fmt_num(oz)
+    new_xyz = f"(xyz {nx} {ny} {nz})"
+    return model_block[:xyz_idx] + new_xyz + model_block[xyz_end + 1 :]
+
+
+def _fmt_num(value: float) -> str:
+    """Format a float the way KiCad writes model offsets (no trailing zeros)."""
+    if value == 0.0:
+        value = 0.0  # normalize -0.0 -> 0.0
+    # Round to a hair under KiCad's 6-dp model-offset precision to avoid FP
+    # noise like 1.2699999999 while keeping legitimate sub-micron values.
+    rounded = round(value, 6)
+    if rounded == int(rounded):
+        return str(int(rounded))
+    return f"{rounded:g}"
+
+
+# --------------------------------------------------------------------------
 # Resolvers: lib id -> dedented (model ...) block texts
 # --------------------------------------------------------------------------
 
-Resolver = Callable[[str], list[str] | None]
+
+@dataclass
+class ResolvedModels:
+    """A resolver hit: the model block texts plus the source pad-1 position.
+
+    *models* are the dedented ``(model ...)`` node texts from the resolved
+    library ``.kicad_mod``.  *source_anchor* is that footprint's own pad
+    centroid (``None`` when it has no positioned pads), used to compute the
+    origin-convention offset ``target_anchor - source_anchor`` at insertion
+    time.
+    """
+
+    models: list[str]
+    source_anchor: tuple[float, float] | None = None
+
+
+# A resolver maps a lib id to its resolved models.  For backward
+# compatibility it may return a bare ``list[str]`` (models only, no pad-1
+# information -> zero offset applied) instead of a ``ResolvedModels``.
+Resolver = Callable[[str], "ResolvedModels | list[str] | None"]
 
 
 def _find_variant_mod(paths: LibraryPaths, library: str, name: str) -> Path | None:
@@ -277,7 +441,7 @@ def make_library_resolver(
             substitution, so callers can report them.
     """
     paths = library_paths if library_paths is not None else detect_kicad_library_path()
-    cache: dict[str, list[str] | None] = {}
+    cache: dict[str, ResolvedModels | None] = {}
 
     def _lookup_mod(lib_id: str) -> tuple[Path | None, str | None]:
         """Return (mod path, substitute lib id) for *lib_id*, or (None, None).
@@ -307,18 +471,22 @@ def make_library_resolver(
                         return mod_path, sub_id
         return None, None
 
-    def resolve(lib_id: str) -> list[str] | None:
+    def resolve(lib_id: str) -> ResolvedModels | None:
         if lib_id in cache:
             return cache[lib_id]
-        result: list[str] | None = None
+        result: ResolvedModels | None = None
         if paths.found:
             mod_path, sub_id = _lookup_mod(lib_id)
             if mod_path is not None:
                 try:
-                    result = extract_model_blocks(mod_path.read_text())
+                    mod_text = mod_path.read_text()
                 except OSError:
                     result = None
                 else:
+                    result = ResolvedModels(
+                        models=extract_model_blocks(mod_text),
+                        source_anchor=_pad_anchor(mod_text),
+                    )
                     if sub_id is not None and substitution_log is not None:
                         substitution_log[lib_id] = sub_id
         cache[lib_id] = result
@@ -371,17 +539,35 @@ def add_model_refs_to_text(pcb_text: str, resolver: Resolver) -> tuple[str, Mode
         if _contains_token(body, "model"):
             report.already_present.append(block.lib_id)
             continue
-        models = resolver(block.lib_id)
-        if models is None:
+        resolved = resolver(block.lib_id)
+        if resolved is None:
             report.unresolved.append(block.lib_id)
             continue
+        # Accept a bare list[str] (legacy resolvers) or a ResolvedModels.
+        if isinstance(resolved, ResolvedModels):
+            models = resolved.models
+            source_anchor = resolved.source_anchor
+        else:
+            models = resolved
+            source_anchor = None
         if not models:
             report.no_model_in_library.append(block.lib_id)
             continue
+        # Origin-convention offset: shift the body by target_anchor -
+        # source_anchor (pad centroids) so the model lands on the target
+        # footprint's pads even when it reuses a canonical name on a
+        # different origin convention.
+        target_anchor = _pad_anchor(body)
+        dx = dy = 0.0
+        if source_anchor is not None and target_anchor is not None:
+            dx = target_anchor[0] - source_anchor[0]
+            dy = target_anchor[1] - source_anchor[1]
         # Insert before the line that holds the footprint's closing paren.
         close_line_start = pcb_text.rfind("\n", 0, block.end) + 1
         child_indent = block.indent + "\t"
-        text = "".join(_indent_block(m, child_indent) + "\n" for m in models)
+        text = "".join(
+            _indent_block(_apply_offset_delta(m, dx, dy), child_indent) + "\n" for m in models
+        )
         insertions.append((close_line_start, text))
         report.patched.append(block.lib_id)
 

--- a/tests/test_pcb_add_3d_models.py
+++ b/tests/test_pcb_add_3d_models.py
@@ -13,6 +13,9 @@ from pathlib import Path
 
 from kicad_tools.footprints.library_path import LibraryPaths
 from kicad_tools.pcb.models3d import (
+    ResolvedModels,
+    _apply_offset_delta,
+    _pad_anchor,
     add_model_refs,
     add_model_refs_to_text,
     extract_model_blocks,
@@ -506,3 +509,242 @@ class TestCLI:
         rc = run_add_3d_models(pcb, output_format="text")
         assert rc == 1
         assert "not found" in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------
+# Origin-convention offset (issue #4034)
+# --------------------------------------------------------------------------
+#
+# kct-generated footprints reuse canonical KiCad names but place pads on an
+# *origin-centered* convention, while the library footprint (and its STEP
+# model) uses pad-1-at-origin.  Copying the model with a zero offset leaves
+# the body shifted by the pad-centroid delta (half the pitch for a 2-pad
+# part).  The patcher must add ``target_centroid - source_centroid`` into the
+# model ``(offset (xyz ...))`` -- with the model-frame Y negated relative to
+# the footprint 2D frame -- so the body lands on the target's pads.
+
+# Library footprint: pad 1 at origin, pad 2 one 2.54mm pitch up in +Y
+# (KiCad's convention for a vertical 2-pin header).  Centroid = (0, 1.27).
+HEADER_LIB_MOD = """(footprint "PinHeader_1x02_P2.54mm_Vertical"
+\t(layer "F.Cu")
+\t(pad "1" thru_hole rect
+\t\t(at 0 0)
+\t\t(size 1.7 1.7)
+\t\t(drill 1)
+\t\t(layers "*.Cu" "*.Mask")
+\t)
+\t(pad "2" thru_hole oval
+\t\t(at 0 2.54)
+\t\t(size 1.7 1.7)
+\t\t(drill 1)
+\t\t(layers "*.Cu" "*.Mask")
+\t)
+\t(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x02_P2.54mm_Vertical.step"
+\t\t(offset
+\t\t\t(xyz 0 0 0)
+\t\t)
+\t\t(scale
+\t\t\t(xyz 1 1 1)
+\t\t)
+\t\t(rotate
+\t\t\t(xyz 0 0 0)
+\t\t)
+\t)
+)
+"""
+
+# Board footprint reusing that lib id but origin-centered: pads at (0, -1.27)
+# and (0, +1.27).  Centroid = (0, 0).  Expected delta = (0, 0) - (0, 1.27) =
+# (0, -1.27); model-frame offset = (0 + 0, 0 - (-1.27), 0) = (0, 1.27, 0).
+HEADER_PCB_TEXT = """(kicad_pcb
+\t(version 20240108)
+\t(footprint "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical"
+\t\t(layer "F.Cu")
+\t\t(at 100 100)
+\t\t(pad "1" thru_hole rect
+\t\t\t(at 0 -1.27)
+\t\t\t(size 1.7 1.7)
+\t\t\t(drill 1)
+\t\t\t(layers "*.Cu" "*.Mask")
+\t\t)
+\t\t(pad "2" thru_hole oval
+\t\t\t(at 0 1.27)
+\t\t\t(size 1.7 1.7)
+\t\t\t(drill 1)
+\t\t\t(layers "*.Cu" "*.Mask")
+\t\t)
+\t)
+)
+"""
+
+
+def _make_header_library(tmp_path: Path) -> LibraryPaths:
+    root = tmp_path / "footprints"
+    lib = root / "Connector_PinHeader_2.54mm.pretty"
+    lib.mkdir(parents=True)
+    (lib / "PinHeader_1x02_P2.54mm_Vertical.kicad_mod").write_text(HEADER_LIB_MOD)
+    return LibraryPaths(footprints_path=root, source="config")
+
+
+class TestPadAnchorHelper:
+    def test_centroid_of_two_pads(self):
+        block = (
+            '(footprint "x"\n'
+            '\t(pad "1" thru_hole rect (at 0 -1.27) (size 1 1))\n'
+            '\t(pad "2" thru_hole oval (at 0 1.27) (size 1 1))\n'
+            ")\n"
+        )
+        assert _pad_anchor(block) == (0.0, 0.0)
+
+    def test_centroid_ignores_pad_rotation_angle(self):
+        block = (
+            '(footprint "x"\n'
+            '\t(pad "1" smd rect (at 1 2 90) (size 1 1))\n'
+            '\t(pad "2" smd rect (at 3 4 270) (size 1 1))\n'
+            ")\n"
+        )
+        assert _pad_anchor(block) == (2.0, 3.0)
+
+    def test_no_pads_returns_none(self):
+        assert _pad_anchor('(footprint "x"\n\t(layer "F.Cu")\n)\n') is None
+
+    def test_pad_token_in_string_ignored(self):
+        block = '(footprint "x"\n\t(property "n" "(pad ...)")\n\t(pad "1" smd rect (at 5 0))\n)\n'
+        assert _pad_anchor(block) == (5.0, 0.0)
+
+
+class TestApplyOffsetDelta:
+    MODEL = '(model "a.step"\n\t(offset\n\t\t(xyz 0 0 0)\n\t)\n\t(scale\n\t\t(xyz 1 1 1)\n\t)\n)'
+
+    def test_y_is_negated_relative_to_footprint_frame(self):
+        # footprint-local delta (0, -1.27) -> model offset (0, +1.27, 0)
+        out = _apply_offset_delta(self.MODEL, 0.0, -1.27)
+        assert "(xyz 0 1.27 0)" in out
+        # only the xyz numbers changed; scale untouched
+        assert "(xyz 1 1 1)" in out
+
+    def test_x_follows_footprint_frame(self):
+        out = _apply_offset_delta(self.MODEL, -1.27, 0.0)
+        assert "(xyz -1.27 0 0)" in out
+
+    def test_zero_delta_is_verbatim(self):
+        assert _apply_offset_delta(self.MODEL, 0.0, 0.0) == self.MODEL
+
+    def test_subnanometre_delta_is_verbatim(self):
+        # Centroid-averaging FP noise below 1nm must not perturb the block.
+        assert _apply_offset_delta(self.MODEL, 1e-9, -1e-9) == self.MODEL
+
+    def test_existing_nonzero_offset_is_added_to(self):
+        model = '(model "a.step"\n\t(offset\n\t\t(xyz 1 2 3)\n\t)\n)'
+        out = _apply_offset_delta(model, 0.5, -0.5)
+        # x: 1 + 0.5 = 1.5 ; y: 2 - (-0.5) = 2.5 ; z unchanged
+        assert "(xyz 1.5 2.5 3)" in out
+
+
+class TestOriginConventionOffset:
+    def test_centered_header_gets_half_pitch_offset(self, tmp_path):
+        """A synthetic origin-centered header resolved against a pad-1-at-
+        origin library footprint gets the centroid-delta offset written."""
+        lib = _make_header_library(tmp_path)
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(HEADER_PCB_TEXT)
+        report = add_model_refs(pcb, library_paths=lib)
+        assert report.patched == ["Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical"]
+        text = pcb.read_text()
+        # Model-frame offset: (0, 1.27, 0) (Y negated vs the (0,-1.27) delta).
+        assert "(xyz 0 1.27 0)" in text
+        # The offset node specifically must no longer read the zero default
+        # (scale/rotate legitimately keep their own 0/1 xyz nodes).
+        import re
+
+        offset_xyz = re.search(r"\(offset\s*\(xyz ([^)]+)\)", text)
+        assert offset_xyz is not None
+        assert offset_xyz.group(1).strip() == "0 1.27 0"
+
+    def test_matched_centroid_gets_zero_offset(self, tmp_path):
+        """R_0805-style part: library and board share centroid (0,0) despite
+        different pad pitch -> zero offset, verbatim insertion."""
+        lib = _make_library(tmp_path)
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(PCB_TEXT)  # R1 pads at (-1,0)/(1,0); lib at (-0.9125,0)/(0.9125,0)
+        add_model_refs(pcb, library_paths=lib)
+        text = pcb.read_text()
+        # The inserted R_0805 model keeps its verbatim zero offset.
+        assert "R_0805_2012Metric.step" in text
+        assert "(xyz 0 0 0)" in text
+
+    def test_offset_is_pure_metadata_no_copper_delta(self, tmp_path):
+        """Only the newly-inserted model block bytes differ; every pad/at line
+        of the original text is preserved verbatim."""
+        lib = _make_header_library(tmp_path)
+        new_text, _ = add_model_refs_to_text(HEADER_PCB_TEXT, make_library_resolver(lib))
+        original_lines = HEADER_PCB_TEXT.splitlines()
+        new_lines = new_text.splitlines()
+        # No original line removed or reordered: original is a subsequence.
+        it = iter(new_lines)
+        assert all(line in it for line in original_lines), "an original line moved/was dropped"
+        # Every added line is model metadata.
+        added = set(new_lines) - set(original_lines)
+        for line in added:
+            body = line.strip()
+            assert body.startswith(("(model", "(offset", "(scale", "(rotate", "(xyz", ")"))
+
+    def test_offset_applies_through_substitution_tier(self, tmp_path):
+        """The offset must be computed for cross-library substitution matches
+        too -- keyed off the *target* footprint's own centroid, since the
+        substitute is a different physical part."""
+        root = tmp_path / "footprints"
+        lib = root / "Connector_FFC-FPC.pretty"
+        lib.mkdir(parents=True)
+        # Substitute library part: pads at (0,0) and (0.5,0) -> centroid (0.25, 0).
+        sub_name = "Amphenol_F32Q-1A7x1-11004_1x04-1MP_P0.5mm_Horizontal"
+        sub_mod = (
+            f'(footprint "{sub_name}"\n'
+            '\t(pad "1" smd rect (at 0 0) (size 0.3 1))\n'
+            '\t(pad "2" smd rect (at 0.5 0) (size 0.3 1))\n'
+            f'\t(model "${{KICAD10_3DMODEL_DIR}}/Connector_FFC-FPC.3dshapes/{sub_name}.step"\n'
+            "\t\t(offset\n\t\t\t(xyz 0 0 0)\n\t\t)\n"
+            "\t)\n"
+            ")\n"
+        )
+        (lib / f"{sub_name}.kicad_mod").write_text(sub_mod)
+        paths = LibraryPaths(footprints_path=root, source="config")
+        # Target footprint (no exact/variant match): centroid (2, 3).
+        pcb_text = (
+            "(kicad_pcb\n"
+            '\t(footprint "Connector_FFC:FFC_4P_0.5mm"\n'
+            '\t\t(layer "F.Cu")\n'
+            '\t\t(pad "1" smd rect (at 1 3) (size 0.3 1))\n'
+            '\t\t(pad "2" smd rect (at 3 3) (size 0.3 1))\n'
+            "\t)\n"
+            ")\n"
+        )
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(pcb_text)
+        report = add_model_refs(pcb, library_paths=paths)
+        assert report.substitution_matches  # went through the substitution tier
+        text = pcb.read_text()
+        # delta = target(2,3) - source(0.25,0) = (1.75, 3) -> model (1.75, -3, 0)
+        assert "(xyz 1.75 -3 0)" in text
+
+
+class TestResolvedModels:
+    def test_resolver_returns_source_anchor(self, tmp_path):
+        lib = _make_header_library(tmp_path)
+        resolver = make_library_resolver(lib)
+        resolved = resolver("Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical")
+        assert isinstance(resolved, ResolvedModels)
+        assert resolved.source_anchor == (0.0, 1.27)
+        assert len(resolved.models) == 1
+
+    def test_legacy_list_resolver_still_supported(self):
+        """A resolver returning a bare list[str] (no anchor) inserts verbatim."""
+        model = '(model "x.step"\n\t(offset\n\t\t(xyz 0 0 0)\n\t)\n)'
+
+        def resolver(lib_id: str):
+            return [model] if lib_id.endswith("PinHeader_1x02_P2.54mm_Vertical") else None
+
+        new_text, report = add_model_refs_to_text(HEADER_PCB_TEXT, resolver)
+        assert report.patched
+        # No anchor available -> zero offset applied (verbatim).
+        assert "(xyz 0 0 0)" in new_text


### PR DESCRIPTION
## Summary

`kct pcb add-3d-models` copied library `(model ...)` refs with a zero offset
onto kct-generated footprints that reuse a canonical KiCad name while placing
pads on an **origin-centered** convention (pads symmetric about the origin)
instead of KiCad's **pad-1-at-origin**. Since a STEP body is authored in the
library footprint's local frame, a zero-offset copy left THT bodies shifted
by half the pad pitch relative to their drilled holes — board 00's J1 header
and D1 LED were reported misaligned on the live gallery, and the same bug hit
headers, DIP, TO-92/220/263, and crystals fleet-wide.

Before inserting each `(model ...)` node the patcher now adds the
`target_centroid - source_centroid` pad-centroid delta into its
`(offset (xyz ...))`, expressed in the KiCad 3D-model frame (X follows the
footprint X, **Y negated** vs the footprint 2D frame, Z unchanged).

## Changes

- `src/kicad_tools/pcb/models3d.py`:
  - `_pad_anchor()` — pad-centroid of a footprint block (string-aware scan).
    Centroid (not pad 1) is the anchor so parts sharing a center but not a
    pitch (e.g. `R_0805`, board pads at ±1.0 vs library ±0.9125) compute a
    zero delta and insert verbatim.
  - `_apply_offset_delta()` — rewrites only the model's own `(offset (xyz ...))`
    x/y numbers, applying the Y-flip and a 1nm tolerance so already-correct
    footprints stay byte-identical.
  - `ResolvedModels` — the resolver now returns the source `.kicad_mod`'s
    centroid alongside its model texts. `add_model_refs_to_text` computes the
    delta from the **target** footprint's own pads, so all three resolution
    tiers (exact / same-library variant / #4033 cross-library substitution)
    get the offset uniformly — including substitution matches where the
    substitute is a different physical part. Legacy `list[str]` resolvers are
    still accepted (zero offset).
- `src/kicad_tools/cli/pcb_add_3d_models.py` — docstring documents the offset.
- `tests/test_pcb_add_3d_models.py` — offset regression coverage (see below).
- `boards/*/output/*.kicad_pcb` (16 artifacts) — regenerated with corrected
  offsets (artifact-first convention).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Board 00 J1/D1 bodies centered on holes | ✅ | Top-down `kicad-cli pcb render` before/after: zero-offset shows J1 body shifted up + D1 lens off its pads; fixed shows both centered. Sign confirmed empirically. |
| Fleet audit of all #4012-patched boards | ✅ | Re-ran across all 16 `boards/*/output/*.kicad_pcb`; 242 footprints re-patched; every non-zero offset inspected by real block boundaries and is a sensible half-span shift (headers, DIP-8, TO-220/263, crystals, USB-C, HDMI, FFC). |
| Pure-insertion guard holds | ✅ | All pad/segment/via/zone/net/at/size/drill/layer lines byte-identical to HEAD across all 16 artifacts; board 00 `kicad-cli pcb drc` = 0 violations. |
| Regression test for offset computation | ✅ | `TestOriginConventionOffset` (synthetic origin-centered header vs pad-1-at-origin library), `TestPadAnchorHelper`, `TestApplyOffsetDelta` (Y-flip, zero/subnanometre verbatim), plus a substitution-tier case. |
| Applies to substitution matches (#4033) | ✅ | `test_offset_applies_through_substitution_tier` asserts the delta keyed off the target's own centroid; boards 06/07 render with centered substitute bodies. |

## Test Plan

- `uv run pytest tests/test_pcb_add_3d_models.py tests/test_render_cmd.py` — 73 passed.
- `uv run ruff check` + `ruff format --check` on touched files — clean.
- `uv run mypy src/kicad_tools/pcb/models3d.py` — no issues.
- Manual: rendered boards 00/02/05/07 front + back; verified bodies land on pads.

## Deferred

- Model **rotation** for parts whose kct footprint is rotated relative to the
  library origin is out of scope: this fleet's pad-1 rotations are 0, the delta
  is computed in the unrotated local frame, and rotation would risk copper-free
  but visually different diffs. Filed as a note for a follow-up if a rotated THT
  part appears.
- Surfacing per-footprint offset values in the CLI report JSON was evaluated
  (curator's "check if") but not added: the render is the audit mechanism and
  the report schema stays minimal (scope discipline).

Closes #4034