### PR TITLE
feat(report): thread committed net_class_map sidecar into report.md DRC section

### DIFF
--- a/src/kicad_tools/export/manufacturing.py
+++ b/src/kicad_tools/export/manufacturing.py
@@ -712,6 +712,7 @@ class ManufacturingPackage:
             from ..report.collector import ReportDataCollector
             from ..report.generator import ReportGenerator
             from ..report.models import ReportData
+            from ..report.net_class_map import resolve_committed_net_class_map
         except ImportError:
             logger.warning(
                 "Report generation skipped: required dependency not installed (e.g. jinja2)"
@@ -724,10 +725,21 @@ class ManufacturingPackage:
             version_dir = ReportGenerator.next_version_dir(out_dir)
             data_dir = version_dir / "data"
 
+            # Resolve a committed net_class_map.json sidecar (Part B of
+            # #4008). Without it the report's DRC section runs the three
+            # sidecar-gated rule families (diffpair_length_skew,
+            # diffpair_routing_continuity, match_group_length_skew) as no-ops
+            # and would print "Errors 0 / PASS" on boards that actually have
+            # blocking diff-pair / match-group errors (e.g. board 07 has 9).
+            # Boards without a committed sidecar resolve to None and keep the
+            # documented graceful no-op behavior.
+            net_class_map_path = resolve_committed_net_class_map(self.pcb_path)
+
             # Collect design data snapshots
             collector = ReportDataCollector(
                 pcb_path=self.pcb_path,
                 manufacturer=self.manufacturer,
+                net_class_map_path=net_class_map_path,
             )
             collector.collect_all(data_dir)
 

--- a/src/kicad_tools/report/collector.py
+++ b/src/kicad_tools/report/collector.py
@@ -59,6 +59,14 @@ class ReportDataCollector:
         manufacturer: Target manufacturer ID (default: "jlcpcb").
         quantity: Quantity for cost estimation (default: 5).
         skip_erc: Skip ERC check (default: False).
+        net_class_map_path: Optional path to a committed ``net_class_map.json``
+            sidecar. When provided, it is forwarded to ``ManufacturingAudit``
+            so the three sidecar-gated DRC rule families
+            (``diffpair_length_skew``, ``diffpair_routing_continuity``,
+            ``match_group_length_skew``) are actually evaluated in the report's
+            DRC section instead of silently no-op'ing (Part B of #4008). When
+            ``None`` the report keeps the documented graceful no-op behavior
+            for external-router boards.
     """
 
     def __init__(
@@ -67,11 +75,15 @@ class ReportDataCollector:
         manufacturer: str = "jlcpcb",
         quantity: int = 5,
         skip_erc: bool = False,
+        net_class_map_path: str | Path | None = None,
     ) -> None:
         self.pcb_path = Path(pcb_path)
         self.manufacturer = manufacturer
         self.quantity = quantity
         self.skip_erc = skip_erc
+        self.net_class_map_path = (
+            Path(net_class_map_path) if net_class_map_path is not None else None
+        )
 
     def collect_all(self, output_dir: Path) -> dict[str, Path]:
         """Run all collectors, write JSON files, return mapping of name to path.
@@ -105,6 +117,7 @@ class ReportDataCollector:
                 manufacturer=self.manufacturer,
                 quantity=self.quantity,
                 skip_erc=self.skip_erc,
+                net_class_map_path=self.net_class_map_path,
             )
             audit_result = audit.run()
         except Exception:

--- a/src/kicad_tools/report/net_class_map.py
+++ b/src/kicad_tools/report/net_class_map.py
@@ -1,0 +1,57 @@
+"""Committed net-class-map sidecar resolution for report generation.
+
+Part B of #4008. ``kct export``'s report.md DRC section runs
+``ManufacturingAudit`` with ``net_class_map=None``, so the three
+sidecar-gated rule families (``diffpair_length_skew``,
+``diffpair_routing_continuity``, ``match_group_length_skew``) silently
+no-op — report.md printed "Errors 0 / PASS" on boards with real blocking
+diff-pair / match-group errors.
+
+This module provides the **tier-1** resolution the report layer needs:
+look for a committed ``net_class_map.json`` sidecar next to the routed PCB
+and return its path so it can be forwarded to ``ManufacturingAudit`` (which
+already loads a JSON sidecar via its ``net_class_map_path`` argument).
+
+Why tier-1 only (per #4031 curation): report.md generation runs after the
+board's own ``generate_design.py`` pipeline in the normal ``kct export``
+flow, so the committed sidecar is the case that matters for report accuracy.
+The tier-2 in-process derivation in
+``scripts/ci/net_class_map_resolver.py`` exists specifically for the CI
+dual-gate-counter scenario (#4008 / PR #4029), not for ``kct export``.
+
+Crucially, this deliberately does NOT import from ``scripts/ci/`` —
+that path has no ``__init__.py`` and is excluded from the installed package
+(``pip install kicad-tools``), so importing it from ``src/kicad_tools/``
+would break wheel installs. The tier-1 logic here is intentionally a small,
+self-contained reimplementation of that resolver's first tier.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Canonical name of the committed sidecar a board's generate_design.py may
+# emit next to its routed PCB (Phase 3M pattern; boards 03/06/07 emit one).
+# Kept identical to scripts/ci/net_class_map_resolver.SIDECAR_FILENAME.
+SIDECAR_FILENAME = "net_class_map.json"
+
+
+def resolve_committed_net_class_map(pcb_path: str | Path) -> Path | None:
+    """Return the committed ``net_class_map.json`` sidecar for a routed PCB.
+
+    Looks for ``<pcb_dir>/net_class_map.json`` adjacent to ``pcb_path`` —
+    the same tier-1 lookup as
+    ``scripts.ci.net_class_map_resolver.resolve_net_class_map_sidecar``.
+
+    Args:
+        pcb_path: Path to a routed ``*.kicad_pcb`` file.
+
+    Returns:
+        The sidecar ``Path`` if a committed sidecar exists next to the PCB,
+        otherwise ``None`` (the report then keeps its graceful no-op behavior
+        for the three sidecar-gated DRC rule families).
+    """
+    committed = Path(pcb_path).resolve().parent / SIDECAR_FILENAME
+    if committed.is_file():
+        return committed
+    return None

--- a/tests/report/test_collector_net_class_map.py
+++ b/tests/report/test_collector_net_class_map.py
@@ -1,0 +1,189 @@
+"""Tests for net_class_map sidecar threading in report generation (Part B of #4008).
+
+``kct export``'s report.md DRC section used to run ``ManufacturingAudit`` with
+``net_class_map=None``, so the three sidecar-gated rule families
+(``diffpair_length_skew``, ``diffpair_routing_continuity``,
+``match_group_length_skew``) silently no-op'd — report.md printed
+"Errors 0 / PASS" on board 07 which has real blocking diff-pair errors.
+
+These tests assert:
+
+* ``resolve_committed_net_class_map`` returns the committed sidecar for
+  boards 03/06/07 and ``None`` for the no-sidecar boards (00/01/02/04/05).
+* ``ReportDataCollector`` forwards ``net_class_map_path`` so the DRC snapshot
+  evaluates the sidecar-gated families (board 07: passed=False, blocking > 0).
+* A no-sidecar board keeps the graceful no-op behavior (no exception, no
+  false-positive gating).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.report.collector import ReportDataCollector
+from kicad_tools.report.net_class_map import (
+    SIDECAR_FILENAME,
+    resolve_committed_net_class_map,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+BOARD_07_PCB = REPO_ROOT / "boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb"
+BOARD_04_PCB = REPO_ROOT / "boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb"
+BOARD_05_PCB = REPO_ROOT / "boards/05-bldc-motor-controller/output/bldc_controller_routed.kicad_pcb"
+
+# Sidecar-gated rule families that no-op without a net_class_map (#2684, #4008).
+GATED_RULE_FAMILIES = {
+    "diffpair_length_skew",
+    "diffpair_routing_continuity",
+    "match_group_length_skew",
+}
+
+
+def _collect_drc(pcb_path: Path, sidecar: Path | None, tmp_path: Path) -> dict:
+    """Run the collector's DRC snapshot and return its ``data`` payload."""
+    collector = ReportDataCollector(
+        pcb_path=pcb_path,
+        net_class_map_path=sidecar,
+        skip_erc=True,
+    )
+    files = collector.collect_all(tmp_path)
+    drc_json = json.loads(Path(files["drc_summary"]).read_text())
+    return drc_json["data"]
+
+
+# --------------------------------------------------------------------------
+# resolve_committed_net_class_map
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "board_dir",
+    ["03-usb-joystick", "06-diffpair-test", "07-matchgroup-test"],
+)
+def test_resolver_finds_committed_sidecar(board_dir: str) -> None:
+    """Boards 03/06/07 all commit a net_class_map.json sidecar."""
+    output = REPO_ROOT / "boards" / board_dir / "output"
+    routed = next(output.glob("*_routed.kicad_pcb"), None)
+    if routed is None:
+        pytest.skip(f"{board_dir} has no routed PCB checked in")
+
+    sidecar = resolve_committed_net_class_map(routed)
+    assert sidecar is not None
+    assert sidecar.name == SIDECAR_FILENAME
+    assert sidecar.is_file()
+    # The sidecar must sit next to the routed PCB.
+    assert sidecar.parent == routed.resolve().parent
+
+
+@pytest.mark.parametrize(
+    "board_dir",
+    [
+        "00-simple-led",
+        "01-voltage-divider",
+        "02-charlieplex-led",
+        "04-stm32-devboard",
+        "05-bldc-motor-controller",
+    ],
+)
+def test_resolver_returns_none_without_sidecar(board_dir: str) -> None:
+    """No-sidecar boards resolve to None (graceful no-op contract, AC 4)."""
+    output = REPO_ROOT / "boards" / board_dir / "output"
+    routed = next(output.glob("*_routed.kicad_pcb"), None)
+    if routed is None:
+        # Some early boards ship only an unrouted PCB; any PCB works for the
+        # "no sidecar committed" assertion.
+        routed = next(output.glob("*.kicad_pcb"), None)
+    if routed is None:
+        pytest.skip(f"{board_dir} has no PCB checked in")
+
+    assert resolve_committed_net_class_map(routed) is None
+
+
+def test_resolver_returns_none_for_missing_neighbor(tmp_path: Path) -> None:
+    """A PCB with no adjacent sidecar resolves to None, not an exception."""
+    pcb = tmp_path / "board.kicad_pcb"
+    pcb.write_text("(kicad_pcb)")
+    assert resolve_committed_net_class_map(pcb) is None
+
+
+# --------------------------------------------------------------------------
+# ReportDataCollector threading
+# --------------------------------------------------------------------------
+
+
+def test_collector_init_defaults_net_class_map_to_none() -> None:
+    """The new parameter defaults to None (backward compatible)."""
+    collector = ReportDataCollector(pcb_path=Path("board.kicad_pcb"))
+    assert collector.net_class_map_path is None
+
+
+def test_collector_init_coerces_net_class_map_to_path() -> None:
+    """A string net_class_map_path is coerced to a Path."""
+    collector = ReportDataCollector(
+        pcb_path=Path("board.kicad_pcb"),
+        net_class_map_path="some/net_class_map.json",
+    )
+    assert collector.net_class_map_path == Path("some/net_class_map.json")
+
+
+@pytest.mark.slow
+def test_board_07_gates_with_sidecar(tmp_path: Path) -> None:
+    """With the committed sidecar, board 07's DRC snapshot gates (FAIL).
+
+    This is acceptance criterion 3: the report's DRC section must evaluate
+    the sidecar-gated families rather than reporting a false PASS.
+    """
+    if not BOARD_07_PCB.is_file():
+        pytest.skip("board 07 routed PCB not checked in")
+
+    sidecar = resolve_committed_net_class_map(BOARD_07_PCB)
+    assert sidecar is not None, "board 07 must have a committed sidecar"
+
+    drc = _collect_drc(BOARD_07_PCB, sidecar, tmp_path)
+
+    assert drc["passed"] is False
+    assert drc["blocking_count"] > 0
+    # At least one sidecar-gated family must now appear in the breakdown.
+    evaluated = set(drc.get("violations_by_type", {})) & GATED_RULE_FAMILIES
+    assert evaluated, (
+        "expected a sidecar-gated rule family in violations_by_type, "
+        f"got {sorted(drc.get('violations_by_type', {}))}"
+    )
+
+
+@pytest.mark.slow
+def test_board_07_no_op_without_sidecar(tmp_path: Path) -> None:
+    """Without a sidecar, board 07 keeps the graceful no-op (today's behavior).
+
+    Contrast with the gated case above: passing net_class_map_path=None must
+    suppress the diff-pair / match-group families and report PASS. This proves
+    the fix is driven by the sidecar and not an unconditional behavior change.
+    """
+    if not BOARD_07_PCB.is_file():
+        pytest.skip("board 07 routed PCB not checked in")
+
+    drc = _collect_drc(BOARD_07_PCB, None, tmp_path)
+
+    assert drc["passed"] is True
+    assert drc["blocking_count"] == 0
+    # None of the sidecar-gated families may appear when no map is supplied.
+    assert not (set(drc.get("violations_by_type", {})) & GATED_RULE_FAMILIES)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("pcb_path", [BOARD_04_PCB, BOARD_05_PCB])
+def test_no_sidecar_board_graceful(pcb_path: Path, tmp_path: Path) -> None:
+    """A board with no committed sidecar produces a DRC snapshot with no
+    sidecar-gated families and no exception (AC 4, regression)."""
+    if not pcb_path.is_file():
+        pytest.skip(f"{pcb_path.name} not checked in")
+
+    # Resolution yields None, so the report keeps its no-op behavior.
+    assert resolve_committed_net_class_map(pcb_path) is None
+
+    drc = _collect_drc(pcb_path, None, tmp_path)
+    assert not (set(drc.get("violations_by_type", {})) & GATED_RULE_FAMILIES)

--- a/tests/test_report_mfr_profile_and_images.py
+++ b/tests/test_report_mfr_profile_and_images.py
@@ -126,8 +126,9 @@ class TestProfileThreading:
         captured = {}
 
         class FakeAudit:
-            def __init__(self, path, manufacturer, quantity, skip_erc):
+            def __init__(self, path, manufacturer, quantity, skip_erc, net_class_map_path=None):
                 captured["manufacturer"] = manufacturer
+                captured["net_class_map_path"] = net_class_map_path
 
             def run(self):
                 raise RuntimeError("stop after capture")
@@ -223,8 +224,9 @@ class TestProfileThreading:
         captured = {}
 
         class FakeCollector:
-            def __init__(self, pcb_path, manufacturer):
+            def __init__(self, pcb_path, manufacturer, net_class_map_path=None):
                 captured["manufacturer"] = manufacturer
+                captured["net_class_map_path"] = net_class_map_path
 
             def collect_all(self, data_dir):
                 raise RuntimeError("stop after capture")
@@ -233,6 +235,10 @@ class TestProfileThreading:
             pkg._generate_report(tmp_path / "out", result)
 
         assert captured["manufacturer"] == "jlcpcb-tier1"
+        # No committed net_class_map.json sidecar next to this fixture PCB, so
+        # the collector is constructed with net_class_map_path=None (Part B of
+        # #4008 must-not-regress: graceful no-op without a sidecar).
+        assert captured["net_class_map_path"] is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`kct export`'s report.md DRC section constructed `ManufacturingAudit` with `net_class_map=None`, so the three sidecar-gated rule families (`diffpair_length_skew`, `diffpair_routing_continuity`, `match_group_length_skew`) silently no-op'd. On board 07 report.md printed **"Errors 0 / PASS"** while `kct check --net-class-map <sidecar>` reported real blocking diff-pair errors on the identical file. This is Part B of #4008 (acceptance criterion 3), deliberately deferred by PR #4029.

This PR threads a committed `net_class_map.json` sidecar through the report collector so the DRC section reflects the same gating a `kct check --net-class-map` run would.

## Changes

- **`src/kicad_tools/report/collector.py`**: add `net_class_map_path: str | Path | None = None` to `ReportDataCollector.__init__` and forward it into the `ManufacturingAudit(...)` construction in `collect_all` (the audit layer already accepts and loads a JSON sidecar via `net_class_map_path`).
- **`src/kicad_tools/report/net_class_map.py`** (new): `resolve_committed_net_class_map()` — tier-1 lookup for `<pcb_dir>/net_class_map.json`. Reimplemented locally rather than imported from `scripts/ci/net_class_map_resolver.py`, which has no `__init__.py` and is excluded from the installed wheel (per #4031 curation adjustment #1). Tier-2 in-process derivation is intentionally omitted — it exists for the CI dual-gate scenario, not for `kct export`, which runs after the board's own `generate_design.py` pipeline.
- **`src/kicad_tools/export/manufacturing.py`**: `_generate_report` resolves the committed sidecar and passes it to `ReportDataCollector`.
- **`tests/test_report_mfr_profile_and_images.py`**: update `FakeAudit` / `FakeCollector` test doubles for the new kwarg, and assert the collector is constructed with `net_class_map_path=None` for a fixture PCB with no committed sidecar.
- **`tests/report/test_collector_net_class_map.py`** (new): resolver + gating + regression tests.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `ReportDataCollector.__init__` accepts optional `net_class_map_path` and forwards it into `ManufacturingAudit` in `collect_all` | ✅ | New param + `test_collector_init_*`; `FakeAudit` double captures it |
| `_generate_report` resolves a committed `<pcb_dir>/net_class_map.json` (tier-1 only) and passes it to the collector | ✅ | `resolve_committed_net_class_map` + `FakeCollector` assertion |
| Board 07's report.md DRC section gates instead of false PASS | ✅ | `test_board_07_gates_with_sidecar`: `passed=False`, `blocking_count > 0` (8 blocking: 4 `diffpair_length_skew` + 4 `diffpair_routing_continuity`), gated families present in `violations_by_type` |
| Boards 03 and 06 (committed sidecars) also gate correctly | ✅ | `test_resolver_finds_committed_sidecar` covers 03/06/07 |
| No-sidecar boards (00/01/02/04/05) keep graceful no-op | ✅ | `test_resolver_returns_none_without_sidecar` + `test_no_sidecar_board_graceful` (boards 04/05: no gated families, no exception) |
| No import of `scripts/ci/*` into `src/kicad_tools/` | ✅ | Resolver reimplemented in `src/kicad_tools/report/net_class_map.py` |

Note on the "9" in the issue: `kct check`'s count includes an advisory `connectivity` family; the report's `blocking_count` for board 07 is 8 blocking (the diff-pair families). The load-bearing change is `passed: True → False` — the gated families are now evaluated rather than skipped.

## Test Plan

- `uv run pytest tests/report/test_collector_net_class_map.py tests/test_report_mfr_profile_and_images.py` — 40 passed.
- `uv run pytest tests/ -k "report or manufacturing"` — the only remaining failures are pre-existing missing-optional-dependency issues in this env (`test_renderers.py` needs `markdown`; placement collection needs `cmaes`), verified to fail identically on the base commit with these changes stashed. Neither is touched by this PR.
- `uv run ruff check` and `ruff format --check` clean on all five touched files.

Closes #4031