### PR TITLE
fix(board03): fail fast on a partial route instead of a misleading LVS trace

### DIFF
--- a/boards/03-usb-joystick/generate_design.py
+++ b/boards/03-usb-joystick/generate_design.py
@@ -818,6 +818,35 @@ def main() -> int:
         routed_path = output_dir / "usb_joystick_routed.kicad_pcb"
         route_success = route_pcb(pcb_path, routed_path)
 
+        # Step 5.3: Fast-fail gate on a PARTIAL route (#4027).  ``route_pcb``
+        # returns ``False`` when fewer than all signal nets landed.  Under
+        # concurrent CPU load the ``--timeout 600`` wall-clock SAFETY backstop
+        # (route_cmd._set_wall_clock_deadline / _remaining_budget) can fire
+        # BEFORE the outer escalation loop routes every net -- 600 real seconds
+        # buys fewer CPU cycles on a loaded machine.  (The per-net A* search is
+        # already load-independent via --deterministic-budget, #3538/#3799, so
+        # the flake lives in the OUTER wall-clock loop, not the router
+        # internals.)  If we fall through, the downstream ``add_gnd_stitching_
+        # vias`` -> ``fill_zones_in_routed_pcb`` -> ``write_lvs_report(
+        # require_clean=True)`` sees a genuinely unrouted signal net as a copper
+        # OPEN and raises ``BoardNetlistMismatch``, which the broad ``except``
+        # below reports as exit 1 -- misdirecting the reviewer to the GND
+        # stitching / LVS subsystem when the true cause is upstream route
+        # truncation.  Raise a DISTINCT, clearly-worded error here instead so
+        # the failure names the real cause.  The "PARTIAL: Routed N/M signal
+        # nets" line is already printed above by ``route_pcb``.
+        if not route_success:
+            raise RuntimeError(
+                "partial route -- likely wall-clock budget exhaustion under "
+                "load (the --timeout 600 safety backstop fired before every "
+                "signal net landed; see the 'PARTIAL: Routed N/M signal nets' "
+                "line above for the exact count). This is NOT a copper-LVS / "
+                "GND-stitching failure -- the pipeline stopped before the LVS "
+                "gate. Re-run boards/03-usb-joystick/generate_design.py in "
+                "isolation on a quiet machine, or raise the --timeout in "
+                "route_pcb() if this recurs on an unloaded host."
+            )
+
         # Step 5.4: Add GND F.Cu<->B.Cu stitching vias (#3787).  The board
         # has GND planes on both copper layers but the router emits zero GND
         # vias, so the J1 USB-C F.Cu-only shield pads strand in their own

--- a/tests/test_board_03_copper_lvs.py
+++ b/tests/test_board_03_copper_lvs.py
@@ -114,8 +114,8 @@ class TestBoard03CopperLVSClean:
         )
 
 
-def _load_add_gnd_stitching_vias():
-    """Import ``add_gnd_stitching_vias`` from the board-03 recipe module."""
+def _load_board03_module():
+    """Import the board-03 ``generate_design.py`` recipe module."""
     import importlib.util
 
     gen = BOARD_DIR / "generate_design.py"
@@ -123,7 +123,12 @@ def _load_add_gnd_stitching_vias():
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    return module.add_gnd_stitching_vias
+    return module
+
+
+def _load_add_gnd_stitching_vias():
+    """Import ``add_gnd_stitching_vias`` from the board-03 recipe module."""
+    return _load_board03_module().add_gnd_stitching_vias
 
 
 class TestBoard03UnconditionalUsbcStitch:
@@ -204,6 +209,116 @@ class TestBoard03UnconditionalUsbcStitch:
         out = work_pcb.read_text()
         for coord in ("145.75 65.5", "151.25 65.5", "151.25 66.5", "145.75 66.5"):
             assert f"(at {coord})" in out, f"no GND stitch via placed at J1 pad ({coord})"
+
+
+class TestBoard03PartialRouteFastFail:
+    """A partial route fails fast with a distinct message, not an LVS trace (#4027).
+
+    Root cause of the #4027 flake: ``route_pcb`` routes under a ``--timeout
+    600`` wall-clock SAFETY backstop layered above the load-independent
+    per-net ``--deterministic-budget`` iteration cap.  Under concurrent CPU
+    load that outer deadline can fire before every signal net lands, so
+    ``route_pcb`` returns ``False``.  Before this fix ``main()`` never
+    checked that return value and fell through to ``add_gnd_stitching_vias``
+    -> ``fill_zones_in_routed_pcb`` -> ``write_lvs_report(require_clean=True)``,
+    which raised ``BoardNetlistMismatch`` on the unrouted net's copper OPEN
+    and surfaced as a misleading "copper-LVS DIRTY / GND stitching" failure.
+
+    These tests are fast and hermetic: they monkeypatch the recipe's own
+    module-level functions so ``main()`` runs without invoking the router,
+    ``kicad-cli``, or the LVS comparator.  They pin two guarantees:
+      1. a partial route (``route_pcb`` -> ``False``) exits non-zero with a
+         distinct "partial route" message BEFORE any stitching/fill/LVS step;
+      2. a full route (``route_pcb`` -> ``True``) still reaches the existing
+         LVS gate (no false positive on the happy path).
+    """
+
+    def _stub_pipeline_prefix(self, module, monkeypatch, tmp_path: Path) -> None:
+        """Neutralise the recipe steps that run before the route_success gate."""
+        sch = tmp_path / "usb_joystick.kicad_sch"
+        sch.write_text("(kicad_sch)")
+        pcb = tmp_path / "usb_joystick.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+
+        monkeypatch.setattr(module, "create_project", lambda *a, **k: tmp_path / "p.kicad_pro")
+        monkeypatch.setattr(module, "create_usb_joystick_schematic", lambda *a, **k: sch)
+        monkeypatch.setattr(module, "run_erc", lambda *a, **k: True)
+        monkeypatch.setattr(module, "create_usb_joystick_pcb", lambda *a, **k: pcb)
+        monkeypatch.setattr(module, "create_zones_for_pcb", lambda *a, **k: None)
+
+    def _forbid_downstream(self, module, monkeypatch) -> None:
+        """Make every post-gate step blow up loudly if the gate lets them run."""
+
+        def _boom(name):
+            def _raise(*a, **k):
+                raise AssertionError(
+                    f"{name} ran despite a partial route -- the route_success "
+                    "gate (#4027) did not short-circuit the pipeline"
+                )
+
+            return _raise
+
+        monkeypatch.setattr(module, "add_gnd_stitching_vias", _boom("add_gnd_stitching_vias"))
+        monkeypatch.setattr(module, "fill_zones_in_routed_pcb", _boom("fill_zones_in_routed_pcb"))
+        monkeypatch.setattr(module, "run_drc", _boom("run_drc"))
+        monkeypatch.setattr(module, "write_lvs_report", _boom("write_lvs_report"))
+
+    def test_partial_route_fails_fast_with_distinct_message(
+        self, monkeypatch, capsys, tmp_path: Path
+    ) -> None:
+        module = _load_board03_module()
+        self._stub_pipeline_prefix(module, monkeypatch, tmp_path)
+        self._forbid_downstream(module, monkeypatch)
+        # The proximate cause of the #4027 flake: route_pcb returns False.
+        monkeypatch.setattr(module, "route_pcb", lambda *a, **k: False)
+        monkeypatch.setattr(module.sys, "argv", ["generate_design.py", str(tmp_path / "out")])
+
+        rc = module.main()
+
+        assert rc == 1, "partial route must make main() exit non-zero"
+        err = capsys.readouterr().err
+        # The message must name the real cause (partial route / wall-clock
+        # budget) and must NOT be a copper-LVS / GND-stitching trace.
+        assert "partial route" in err.lower(), (
+            "partial-route failure must be reported with a distinct 'partial "
+            f"route' message, got stderr:\n{err}"
+        )
+        assert "wall-clock budget" in err.lower()
+        assert "BoardNetlistMismatch" not in err, (
+            "a partial route must NOT surface as an LVS BoardNetlistMismatch"
+        )
+
+    def test_full_route_still_reaches_lvs_gate(self, monkeypatch, tmp_path: Path) -> None:
+        """A full route (N==M) must NOT trip the fast-fail gate.
+
+        The gate keys strictly off ``route_pcb`` returning ``False``; a full
+        route still flows into the existing stitching/fill/LVS steps.  We stub
+        those to no-ops and assert the LVS gate is the one that runs (proving
+        the fast-fail path did not swallow the happy path).
+        """
+        module = _load_board03_module()
+        self._stub_pipeline_prefix(module, monkeypatch, tmp_path)
+        monkeypatch.setattr(module, "route_pcb", lambda *a, **k: True)
+        monkeypatch.setattr(module, "add_gnd_stitching_vias", lambda *a, **k: 0)
+        monkeypatch.setattr(module, "fill_zones_in_routed_pcb", lambda *a, **k: None)
+        monkeypatch.setattr(module, "run_drc", lambda *a, **k: True)
+
+        lvs_called: list[bool] = []
+
+        def _fake_lvs(*a, **k):
+            lvs_called.append(True)
+
+        monkeypatch.setattr(module, "write_lvs_report", _fake_lvs)
+        monkeypatch.setattr(module, "export_manufacturing_bundle", lambda *a, **k: True)
+        monkeypatch.setattr(module.sys, "argv", ["generate_design.py", str(tmp_path / "out")])
+
+        rc = module.main()
+
+        assert lvs_called == [True], (
+            "a full (N==M) route must still reach write_lvs_report -- the "
+            "#4027 fast-fail gate must not fire on a complete route"
+        )
+        assert rc == 0
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary

Board 03's `generate_design.py` regen (`test_board_03_copper_lvs.py::TestBoard03FreshRegenCopperLVSClean`) flaked under concurrent load twice on 2026-07-09, passing on quiet re-runs. The failure surfaced as a *copper-LVS / GND-stitching* error, which misdirected reviewers to the wrong subsystem.

Per the curator's verified root-cause analysis: the per-net A* budget is already load-independent (`--deterministic-budget`, #3538/#3799). The flake lives in the **outer `--timeout 600` wall-clock safety backstop** — under concurrent CPU contention 600 real seconds buys fewer CPU cycles, so the escalation loop can bail with fewer nets landed. `main()` captured `route_success` but **never checked it**, so a partial route fell through to `add_gnd_stitching_vias` → `fill_zones_in_routed_pcb` → `write_lvs_report(require_clean=True)`, where the unrouted signal net reads as a GND copper open and raises `BoardNetlistMismatch` — reported by the broad `except` as a misleading exit 1.

This implements the curator's recommended **option (c), narrowly scoped**: fail fast on a partial route with a distinct message before the pipeline reaches the LVS gate. No change to the router internals or the outer `--timeout` safety-valve design.

## Changes

- `boards/03-usb-joystick/generate_design.py`: add a `route_success` gate in `main()` immediately after `route_pcb()` returns. On a partial route it raises a distinct `RuntimeError` ("partial route -- likely wall-clock budget exhaustion under load ...") **before** GND stitching, zone fill, or `write_lvs_report` run. The message explicitly disclaims a copper-LVS/GND-stitching cause and points at the `--timeout` backstop.
- `tests/test_board_03_copper_lvs.py`: add hermetic `TestBoard03PartialRouteFastFail` (monkeypatches the recipe's module-level functions; no router / `kicad-cli` / LVS invocation):
  - `test_partial_route_fails_fast_with_distinct_message` — `route_pcb` → `False` makes `main()` exit non-zero with a "partial route" / "wall-clock budget" message, and forbidden downstream steps (`add_gnd_stitching_vias`, `fill_zones_in_routed_pcb`, `run_drc`, `write_lvs_report`) raise if the gate lets them run; asserts no `BoardNetlistMismatch` in the output.
  - `test_full_route_still_reaches_lvs_gate` — `route_pcb` → `True` still reaches `write_lvs_report` (no false positive on the happy path).
  - Refactored the module loader into `_load_board03_module()` (reused by the existing `_load_add_gnd_stitching_vias`).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `main()` checks routing result after `route_pcb()`; partial route exits distinctly without reaching stitching/fill/LVS | ✅ | New gate at `generate_design.py:838`; `test_partial_route_fails_fast_with_distinct_message` proves forbidden downstream steps never run |
| Failure message distinguishes "partial route (wall-clock budget)" from "copper-LVS dirty (GND stitching)" | ✅ | Message text + test asserts `"partial route"`/`"wall-clock budget"` present and `"BoardNetlistMismatch"` absent |
| Test covers the partial-route path (force `route_success=False`) | ✅ | `TestBoard03PartialRouteFastFail` monkeypatches `route_pcb` → `False` |
| No change to the per-net A* budget mechanism | ✅ | Only board recipe + test touched; router internals unchanged |
| Existing clean-regen behavior unaffected | ✅ | `test_fresh_regen_is_copper_lvs_clean` passes isolated (111.81s); `test_full_route_still_reaches_lvs_gate` proves the gate doesn't fire on N==M |

## Test Plan

- `uv run pytest tests/test_board_03_copper_lvs.py -m "not slow"` → 6 passed (2 new).
- `uv run pytest tests/test_board_03_copper_lvs.py::TestBoard03FreshRegenCopperLVSClean::test_fresh_regen_is_copper_lvs_clean` → 1 passed in 111.81s (isolated, quiet machine — happy path unaffected).
- `uv run ruff check` + `ruff format --check` on both touched files → clean.
- C++ router backend built in the worktree (`kct build-native`, available 1.0.0) so the slow regen ran at native speed.

## Note: siblings share the latent pattern (deferred, out of scope)

Boards 00/01/02/04/06 (`generate_design.py`) also capture `route_success` from `route_pcb()` and then run `write_lvs_report(require_clean=True)` unconditionally, so they carry the same misattribution risk if their route ever truncates under load. This PR is scoped to board 03 (the board that actually flaked) per the issue. If the same flake appears on a sibling, the identical gate applies — worth a follow-up issue rather than expanding this PR's blast radius.

Closes #4027