### PR TITLE
fix(validate): report DRC violation locations in sheet-absolute coordinates

### DIFF
--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -7,6 +7,7 @@ Checks on PCB designs without requiring kicad-cli.
 from __future__ import annotations
 
 import sys
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 from kicad_tools.manufacturers import DesignRules, get_profile
@@ -206,6 +207,53 @@ class DRCChecker:
         """
         return rule_id in cls.ADVISORY_RULE_IDS
 
+    def _absolutize(self, results: DRCResults) -> DRCResults:
+        """Rewrite violation locations from board-relative to sheet-absolute.
+
+        Every DRC rule that inspects :class:`~kicad_tools.schema.pcb.PCB`
+        geometry (pad/footprint positions, segment endpoints, via
+        positions, zone-polygon vertices) reads those attributes *after*
+        :meth:`PCB._detect_board_origin` has subtracted ``board_origin``
+        from them in place -- an internal, board-relative frame the
+        connectivity / zone-generation code relies on (see the
+        ``PCB.board_origin`` docstring).  The rules therefore build
+        ``DRCViolation.location`` in that board-relative frame.
+
+        Users, the KiCad GUI, and ``kicad-cli pcb drc`` all speak
+        sheet-absolute coordinates (the literal ``(at ...)`` values in the
+        ``.kicad_pcb`` file).  This helper adds ``board_origin`` back to
+        each violation's ``location`` exactly once so ``kct check`` reports
+        the same coordinates a human would see when clicking the defect in
+        KiCad -- fixing the per-board offset described in issue #4025.
+
+        Applied by every rule-backed ``check_*`` method.  It is deliberately
+        NOT applied to :meth:`check_pad_grid_alignment`, whose locations
+        come from :func:`router.io.load_pads_for_analysis` parsing the raw
+        ``.kicad_pcb`` text directly and are already sheet-absolute (adding
+        ``board_origin`` there would double-shift them).
+
+        Args:
+            results: A rule's board-relative :class:`DRCResults`.
+
+        Returns:
+            The same ``results`` object with each ``location`` shifted to
+            sheet-absolute coordinates.  Violations with ``location=None``
+            are left untouched.
+        """
+        ox, oy = self.pcb.board_origin
+        if ox == 0.0 and oy == 0.0:
+            # No offset to apply -- board is already at the sheet origin.
+            return results
+        shifted: list[DRCViolation] = []
+        for v in results.violations:
+            if v.location is None:
+                shifted.append(v)
+                continue
+            lx, ly = v.location
+            shifted.append(replace(v, location=(round(lx + ox, 3), round(ly + oy, 3))))
+        results.violations = shifted
+        return results
+
     def check_all(
         self,
         filters: list[ViolationFilter] | None = None,
@@ -261,7 +309,7 @@ class DRCChecker:
             DRCResults containing clearance violations
         """
         rule = ClearanceRule()
-        return rule.check(self.pcb, self.design_rules)
+        return self._absolutize(rule.check(self.pcb, self.design_rules))
 
     def check_segment_zone_clearances(self) -> DRCResults:
         """Check track segments against foreign-net zone fill copper.
@@ -281,7 +329,7 @@ class DRCChecker:
             (severity error, blocking).
         """
         rule = SegmentZoneClearanceRule()
-        return rule.check(self.pcb, self.design_rules)
+        return self._absolutize(rule.check(self.pcb, self.design_rules))
 
     def check_via_zone_clearances(self) -> DRCResults:
         """Check vias and pads against foreign-net zone fill copper.
@@ -301,7 +349,7 @@ class DRCChecker:
             ``clearance_pad_zone`` violations (severity error, blocking).
         """
         rule = ViaZoneClearanceRule()
-        return rule.check(self.pcb, self.design_rules)
+        return self._absolutize(rule.check(self.pcb, self.design_rules))
 
     def check_copper_slivers(self) -> DRCResults:
         """Check copper layers for thin slivers via a morphological open.
@@ -327,7 +375,7 @@ class DRCChecker:
             DRCResults containing ``copper_sliver`` warnings.
         """
         rule = CopperSliverRule()
-        return rule.check(self.pcb, self.design_rules)
+        return self._absolutize(rule.check(self.pcb, self.design_rules))
 
     def check_connectivity(self) -> DRCResults:
         """Check that every multi-pad net is fully connected.
@@ -349,7 +397,7 @@ class DRCChecker:
             multi-pad net (severity error).
         """
         rule = ConnectivityRule()
-        return rule.check(self.pcb, self.design_rules)
+        return self._absolutize(rule.check(self.pcb, self.design_rules))
 
     def check_diffpair_clearance_intra(self) -> DRCResults:
         """Check within-pair clearance for differential pairs.
@@ -377,7 +425,7 @@ class DRCChecker:
         """
 
         rule = DiffPairClearanceIntraRule()
-        return rule.check(self.pcb, self.design_rules)
+        return self._absolutize(rule.check(self.pcb, self.design_rules))
 
     def _warn_inactive_skew_rule(self, rule_name: str) -> None:
         """Emit a one-time stderr warning that a skew rule is inactive.
@@ -467,7 +515,7 @@ class DRCChecker:
             threshold_map=skew_threshold_map,
             emit_info=self._emit_skew_info,
         )
-        return rule.check(self.pcb, self.design_rules)
+        return self._absolutize(rule.check(self.pcb, self.design_rules))
 
     def check_diffpair_routing_continuity(self) -> DRCResults:
         """Check routing continuity for engaged differential pairs.
@@ -511,7 +559,7 @@ class DRCChecker:
             threshold_map=threshold_map,
             emit_info=self._emit_skew_info,
         )
-        return rule.check(self.pcb, self.design_rules)
+        return self._absolutize(rule.check(self.pcb, self.design_rules))
 
     def check_dimensions(self) -> DRCResults:
         """Check dimension rules (trace width, via drill, annular ring).
@@ -529,7 +577,7 @@ class DRCChecker:
         from .rules.dimensions import DimensionRules
 
         rule = DimensionRules()
-        return rule.check(self.pcb, self.design_rules)
+        return self._absolutize(rule.check(self.pcb, self.design_rules))
 
     def check_edge_clearances(self) -> DRCResults:
         """Check edge clearance rules (copper-to-board-edge).
@@ -542,7 +590,7 @@ class DRCChecker:
             DRCResults containing edge clearance violations
         """
         rule = EdgeClearanceRule()
-        return rule.check(self.pcb, self.design_rules)
+        return self._absolutize(rule.check(self.pcb, self.design_rules))
 
     def check_impedance(self) -> DRCResults:
         """Check trace widths against target impedance specifications.
@@ -602,7 +650,7 @@ class DRCChecker:
             # single-ended impedance, ``specs`` is empty -> conservative
             # no-op (no single-ended impedance errors).
             rule = ImpedanceRule(specs=specs)
-        return rule.check(self.pcb, self.design_rules)
+        return self._absolutize(rule.check(self.pcb, self.design_rules))
 
     def check_match_group_length_skew(self) -> DRCResults:
         """Check routed-length skew for declared N-trace match groups.
@@ -669,7 +717,7 @@ class DRCChecker:
                 threshold_map=threshold_map,
                 emit_info=self._emit_skew_info,
             )
-        return rule.check(self.pcb, self.design_rules)
+        return self._absolutize(rule.check(self.pcb, self.design_rules))
 
     def check_silkscreen(self) -> DRCResults:
         """Check silkscreen rules.
@@ -687,8 +735,10 @@ class DRCChecker:
         Returns:
             DRCResults containing silkscreen violations
         """
-        return check_all_silkscreen(
-            self.pcb, self.design_rules, suppress_library=self.suppress_library
+        return self._absolutize(
+            check_all_silkscreen(
+                self.pcb, self.design_rules, suppress_library=self.suppress_library
+            )
         )
 
     def check_solder_mask_pads(self) -> DRCResults:
@@ -705,7 +755,7 @@ class DRCChecker:
         from .rules.solder_mask import SolderMaskPadRules
 
         rule = SolderMaskPadRules()
-        return rule.check(self.pcb, self.design_rules)
+        return self._absolutize(rule.check(self.pcb, self.design_rules))
 
     def check_footprint_placement(self) -> DRCResults:
         """Check that footprints are placed inside the board outline.
@@ -717,7 +767,7 @@ class DRCChecker:
             DRCResults containing placement violations
         """
         rule = FootprintOutsideBoardRule()
-        return rule.check(self.pcb, self.design_rules)
+        return self._absolutize(rule.check(self.pcb, self.design_rules))
 
     def check_netlist(self) -> DRCResults:
         """Check for pads referencing undeclared nets.
@@ -732,7 +782,7 @@ class DRCChecker:
         from .rules.netlist import NetlistRule
 
         rule = NetlistRule()
-        return rule.check(self.pcb, self.design_rules)
+        return self._absolutize(rule.check(self.pcb, self.design_rules))
 
     def check_single_pad_nets(self) -> DRCResults:
         """Check for signal nets that are connected to only one pad.
@@ -749,7 +799,7 @@ class DRCChecker:
         from .rules.single_pad_net import SinglePadNetRule
 
         rule = SinglePadNetRule()
-        return rule.check(self.pcb, self.design_rules)
+        return self._absolutize(rule.check(self.pcb, self.design_rules))
 
     def check_via_in_pad(self) -> DRCResults:
         """Check for vias placed inside SMD pads on unsupported profiles.
@@ -767,7 +817,7 @@ class DRCChecker:
             via-in-pad (e.g., jlcpcb-tier1, pcbway).
         """
         rule = ViaInPadRule()
-        return rule.check(self.pcb, self.design_rules)
+        return self._absolutize(rule.check(self.pcb, self.design_rules))
 
     def check_zones(self) -> DRCResults:
         """Check zone fill rules (unfilled zones, disabled fill, unassigned nets).
@@ -780,7 +830,7 @@ class DRCChecker:
             DRCResults containing zone fill violations
         """
         rule = ZoneFillRule()
-        return rule.check(self.pcb, self.design_rules)
+        return self._absolutize(rule.check(self.pcb, self.design_rules))
 
     def check_pad_grid_alignment(
         self,

--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -240,7 +240,7 @@ class DRCChecker:
             sheet-absolute coordinates.  Violations with ``location=None``
             are left untouched.
         """
-        ox, oy = self.pcb.board_origin
+        ox, oy = getattr(self.pcb, "board_origin", (0.0, 0.0))
         if ox == 0.0 and oy == 0.0:
             # No offset to apply -- board is already at the sheet origin.
             return results

--- a/tests/test_drc_location_absolute.py
+++ b/tests/test_drc_location_absolute.py
@@ -1,0 +1,186 @@
+"""DRC violation locations must be reported in sheet-absolute coordinates.
+
+Regression tests for issue #4025.
+
+``PCB.load()`` -> ``PCB._detect_board_origin()`` detects the board outline's
+corner in sheet-absolute coordinates and subtracts it in place from every
+footprint/segment/via/zone coordinate, giving the rest of kicad_tools a
+consistent *board-relative* frame to reason in.  The pure-Python DRC rules
+build ``DRCViolation.location`` from those already-shifted attributes, so
+without a correction ``kct check`` reported violation coordinates offset by
+``-board_origin`` from what a human sees in the KiCad GUI or what
+``kicad-cli pcb drc`` reports (which are both sheet-absolute -- the literal
+``(at ...)`` values in the ``.kicad_pcb`` file).
+
+Because boards are no longer at a uniform origin (#4015 centers each board
+independently), the offset is different per board -- any hardcoded frame
+assumption is guaranteed wrong.  These tests assert that the reported
+locations equal the sheet-absolute coordinates in the file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.schema.pcb import PCB
+from kicad_tools.validate import DRCChecker
+
+# Two parallel F.Cu tracks on different nets, 0.15 mm apart (below the JLCPCB
+# 2-layer 0.2 mm trace-to-trace floor), placed on a board whose Edge.Cuts rect
+# starts at a deliberately non-trivial, non-zero origin (37, 41).  The tracks
+# run from x=100 to x=110 at y=100 and y=100.15 in *sheet-absolute* file
+# coordinates -- so the true clearance-violation midpoint is (105, 100.075).
+#
+# After ``PCB.load()`` the loader shifts these into the board-relative frame
+# (subtracting board_origin = (37, 41)); a naive rule would report the
+# violation at (105-37, 100.075-41) == (68, 59.075).  The fix must report the
+# sheet-absolute (105, 100.075) instead.
+_ORIGIN_X = 37.0
+_ORIGIN_Y = 41.0
+_EXPECTED_ABS_X = 105.0
+_EXPECTED_ABS_Y = 100.075
+
+_PCB_NONZERO_ORIGIN = f"""\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3V3")
+  (gr_rect (start {_ORIGIN_X} {_ORIGIN_Y}) (end 180 160)
+    (stroke (width 0.1) (type default)) (fill none) (layer "Edge.Cuts")
+    (uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
+  (segment (start 100 100) (end 110 100) (width 0.25) (layer "F.Cu") (net 1 "GND") (uuid "seg-gnd1"))
+  (segment (start 100 100.15) (end 110 100.15) (width 0.25) (layer "F.Cu") (net 2 "+3V3") (uuid "seg-3v3"))
+)
+"""
+
+
+def _write(tmp_path: Path, content: str) -> PCB:
+    pcb_path = tmp_path / "board.kicad_pcb"
+    pcb_path.write_text(content)
+    return PCB.load(pcb_path)
+
+
+def test_board_origin_is_nonzero(tmp_path: Path):
+    """Sanity guard: the fixture actually exercises a non-zero origin."""
+    pcb = _write(tmp_path, _PCB_NONZERO_ORIGIN)
+    assert pcb.board_origin == pytest.approx((_ORIGIN_X, _ORIGIN_Y))
+
+
+def test_clearance_violation_location_is_sheet_absolute(tmp_path: Path):
+    """A clearance violation reports the sheet-absolute midpoint (issue #4025).
+
+    Verifies the coordinate a user reads out of ``kct check`` lands on the
+    defect in the KiCad GUI / matches ``kicad-cli pcb drc`` -- i.e. it equals
+    the file's ``(at ...)`` frame, NOT the internal board-relative frame.
+    """
+    pcb = _write(tmp_path, _PCB_NONZERO_ORIGIN)
+
+    checker = DRCChecker(pcb, manufacturer="jlcpcb", layers=2, copper_oz=1.0)
+    results = checker.check_clearances()
+
+    clearance_violations = [v for v in results.violations if v.location is not None]
+    assert clearance_violations, "expected at least one located clearance violation"
+
+    v = clearance_violations[0]
+    assert v.location is not None
+    lx, ly = v.location
+
+    # Sheet-absolute midpoint of the two tracks, matching the raw file coords.
+    assert lx == pytest.approx(_EXPECTED_ABS_X, abs=0.01)
+    assert ly == pytest.approx(_EXPECTED_ABS_Y, abs=0.01)
+
+    # And explicitly NOT the board-relative value the bug used to report.
+    assert lx != pytest.approx(_EXPECTED_ABS_X - _ORIGIN_X, abs=0.01)
+    assert ly != pytest.approx(_EXPECTED_ABS_Y - _ORIGIN_Y, abs=0.01)
+
+
+def test_check_all_clearance_location_is_sheet_absolute(tmp_path: Path):
+    """The full ``check_all()`` aggregation preserves sheet-absolute coords.
+
+    Guards the primary aggregation path (the one behind the Python API and,
+    structurally, the ``kct check`` CLI dispatch loop) -- not just the single
+    ``check_clearances()`` entry point.
+    """
+    pcb = _write(tmp_path, _PCB_NONZERO_ORIGIN)
+
+    checker = DRCChecker(pcb, manufacturer="jlcpcb", layers=2, copper_oz=1.0)
+    results = checker.check_all()
+
+    located = [
+        v
+        for v in results.violations
+        if v.rule_id.startswith("clearance") and v.location is not None
+    ]
+    assert located, "expected a located clearance violation from check_all()"
+
+    lx, ly = located[0].location  # type: ignore[misc]
+    assert lx == pytest.approx(_EXPECTED_ABS_X, abs=0.01)
+    assert ly == pytest.approx(_EXPECTED_ABS_Y, abs=0.01)
+
+
+def test_pad_grid_location_not_double_shifted(tmp_path: Path):
+    """``pad_grid`` locations are already sheet-absolute -- do not shift them.
+
+    ``check_pad_grid_alignment`` sources its coordinates from
+    ``router.io.load_pads_for_analysis``, which parses the raw ``.kicad_pcb``
+    text directly and never passes through ``_detect_board_origin``.  Adding
+    ``board_origin`` to those would double-shift them, so ``_absolutize`` must
+    NOT be applied to that rule.  This regression asserts the pad_grid path is
+    untouched: any reported pad_grid location stays within the board's
+    sheet-absolute footprint bounds (well away from a double-shifted value,
+    which would land at absolute + board_origin).
+    """
+    # A footprint whose single pad sits off the alignment grid, on the same
+    # non-zero-origin board.  The pad is at sheet-absolute (100.037, 100.0).
+    pcb_content = f"""\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (gr_rect (start {_ORIGIN_X} {_ORIGIN_Y}) (end 180 160)
+    (stroke (width 0.1) (type default)) (fill none) (layer "Edge.Cuts")
+    (uuid "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"))
+  (footprint "test:R"
+    (layer "F.Cu")
+    (uuid "cccccccc-cccc-cccc-cccc-cccccccccccc")
+    (at 100.037 100)
+    (pad "1" smd rect (at 0 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "GND"))
+  )
+)
+"""
+    pcb = _write(tmp_path, pcb_content)
+
+    checker = DRCChecker(pcb, manufacturer="jlcpcb", layers=2, copper_oz=1.0)
+    results = checker.check_pad_grid_alignment(auto_derive_threshold=False)
+
+    located = [v for v in results.violations if v.location is not None]
+    for v in located:
+        lx, ly = v.location  # type: ignore[misc]
+        # A double-shifted pad_grid location would be pushed to
+        # ~ (100.037 + 37, 100 + 41); assert it stays in the sheet-absolute
+        # band around the real pad instead.
+        assert lx < _ORIGIN_X + 100.0
+        assert ly < _ORIGIN_Y + 100.0


### PR DESCRIPTION
## Summary

`kct check` reported DRC violation coordinates in the board's internal
board-relative frame, offset from the sheet-absolute frame that the KiCad GUI,
`kicad-cli pcb drc`, and the raw `.kicad_pcb` `(at ...)` values all use. On
board-05 this cost real diagnosis time (#4003): the reporter said (20.75, 54.9)
while the file said (25.75, 59.9).

**Root cause.** `PCB.load()` -> `PCB._detect_board_origin()` detects the
Edge.Cuts corner in sheet-absolute coordinates and subtracts it in place from
every footprint/segment/via/zone coordinate, giving kicad_tools a consistent
board-relative frame to reason in (a deliberate, load-bearing invariant used by
connectivity/zone-generation). The pure-Python DRC rules build
`DRCViolation.location` from those already-shifted attributes and never add
`board_origin` back. The delta is therefore exactly `-board_origin` — not a
hardcoded `5.0`. Since #4015 centers each board independently, the offset is now
different per board, confirming it is systemic rather than a fixed off-by-5mm
literal.

## Changes

- Add `DRCChecker._absolutize(results)` — adds `board_origin` back to each
  violation's `location` exactly once (no-op when origin is `(0,0)`;
  `location=None` violations untouched).
- Route every rule-backed `check_*` method (18 `rule.check(...)` sites +
  `check_silkscreen`) through `_absolutize`. Because the correction lives in
  the per-rule methods, it covers `check_all`, the `kct check` CLI dispatch
  loop (`check_cmd.py`, which does NOT use `check_all`), and direct callers
  (`router/optimizer/pcb.py`) alike.
- Deliberately **exclude** `check_pad_grid_alignment`: its coordinates come from
  `router.io.load_pads_for_analysis` parsing raw `.kicad_pcb` text directly and
  are already sheet-absolute; shifting them would double-count `board_origin`.
- Add `tests/test_drc_location_absolute.py`.

## Blast-radius review

- **fix-drc repair path** (`drc.compat` -> `repair_clearance` /
  `repair_drill_clearance`): searches raw-SExp absolute `(at ...)` geometry via
  `_find_vias_near`/`_find_segments_near`. It already expected absolute
  violation locations, so this fix makes those repairs correct on
  non-zero-origin boards (they were previously misaligned by `board_origin`) —
  a fix, not a regression.
- **`kct drc`** (`drc/report.py`, kicad-cli-backed, uses `.locations` plural)
  is unaffected — it reports sheet-absolute natively.
- No consumer re-subtracts `board_origin` from a DRC violation location, so
  nothing downstream double-un-offsets.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| 1. Synthetic non-zero-origin fixture: reported location == sheet-absolute | ✅ | `test_clearance_violation_location_is_sheet_absolute` (origin (37,41); reports (105, 100.075), the file midpoint) |
| 2. New test asserts kct-vs-file agreement for a PCB-path rule | ✅ | New `tests/test_drc_location_absolute.py` (clearance rule) |
| 3. `pad_grid` unchanged (no double-shift) | ✅ | `test_pad_grid_location_not_double_shifted` + not routed through `_absolutize` |
| 4. Existing board-relative-location assertions updated | ✅ | Full `tests/test_validate*.py` + `-k "location or violation"` (761 passed) — none asserted board-relative DRC locations under non-zero origin |
| 5. Committed `drc_report.json` not regenerated | ✅ | Not touched; see note below |
| 6. No change to counts/rule_id/severity/message | ✅ | Location-field-only change; suites green |

**Verified the fix catches the bug:** temporarily neutering `_absolutize` makes
the clearance test report `68.0` (board-relative `105 - 37`) and fail; the fix
restores `105.0`.

**Note on committed artifacts (AC5):** `boards/*/output/drc_report.json` files
will show a `location` diff on their next regeneration — that is expected and
correct (they were emitting board-relative coordinates). Regen is out of scope
here (expensive; host disk is tight per repo guidance).

## Test Plan

- `tests/test_drc_location_absolute.py` — 4 passed
- `tests/test_validate*.py`, `test_validate_*`, `test_clearance_net_names`,
  `test_drc_nudge`, `test_fix_drc_cmd` — 381 passed
- `pytest -k "location or violation"` — 761 passed
- `test_edge_clearance_epsilon`, `test_incremental_drc`,
  `test_place_route_optimizer`, `test_check_cmd_coverage`,
  `test_auto_pcb_size_drc_proxy` — 221 passed
- `ruff check` + `ruff format` clean on touched files
- Pre-existing `FilterEngine.apply` mypy invariance warning in `checker.py`
  predates this PR (confirmed by stashing the change) — out of scope.

Closes #4025