### PR TITLE
feat(router): reactive escape-freedom byte-lane reorder (opt-in, off by default)

### DIFF
--- a/src/kicad_tools/router/algorithms/two_phase.py
+++ b/src/kicad_tools/router/algorithms/two_phase.py
@@ -303,12 +303,12 @@ class TwoPhaseRouter:
         if self._interleave_match_groups is not None:
             net_order = self._interleave_match_groups(net_order)
 
-        # Issue #2962: Mirrored byte-lane detection hook (scaffolding only).
-        # See the ``Autorouter._apply_byte_lane_inner_priority`` docstring
-        # for the rationale and the R1/R2/R3 trace.  Applied after the
-        # starvation-fairness pass so a future implementation that swaps
-        # the helper body for a real reorder keeps the head-class ordering
-        # exact; only within-class neighbour priorities would be adjusted.
+        # Issue #2962 / #2983 / #4051: Mirrored byte-lane escape ordering.
+        # ``_apply_byte_lane_inner_priority`` reserves inner-corner
+        # corridors (#2983) and reorders each qualifying byte-lane group
+        # by reactive escape freedom (#4051).  Applied after the
+        # starvation-fairness pass so the head-class ordering stays exact;
+        # only within-group neighbour priorities are adjusted.
         if self._apply_byte_lane_inner_priority is not None:
             net_order = self._apply_byte_lane_inner_priority(net_order)
 

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -5212,9 +5212,7 @@ class Autorouter:
 
         # Row-axis coordinate for each member; fall back to positional
         # index if a projection is missing (should not happen).
-        coord = {
-            nid: row_positions.get(nid, float(idx)) for idx, nid in enumerate(members)
-        }
+        coord = {nid: row_positions.get(nid, float(idx)) for idx, nid in enumerate(members)}
 
         # Two frontiers walking inward from each end.
         lo = 0

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -865,6 +865,18 @@ class Autorouter:
         # iteration slice and skips the Python fallback for capped nets.
         self._per_net_iterations = int(per_net_iterations) if per_net_iterations else 0
 
+        # Issue #4051 (Phase 1b, epic #4049): reactive escape-freedom
+        # reorder for mirrored byte-lane bundles.  OFF by default:
+        # measured on board 07's DDR bundle it REGRESSED reach
+        # (10/11 -> 9/11, DQ2+DQ3 stranded vs DQ3 alone), matching
+        # #3438's finding that an outside-in-style schedule tops out
+        # below the identity baseline on this bundle.  The scheduler
+        # (``_schedule_by_escape_freedom``) and its wiring are kept
+        # behind this flag so the capability + diagnostics are available
+        # for future geometries without perturbing production routing.
+        # Set to True to opt in (see ``_apply_byte_lane_inner_priority``).
+        self.enable_byte_lane_reorder = False
+
         # Initialize grid and routers using shared helper
         # Issue #972: Helper includes adaptive grid resolution for large boards
         self.grid, self.router, self.zone_manager = self._create_grid_and_routers(
@@ -4698,15 +4710,38 @@ class Autorouter:
         return out
 
     def _apply_byte_lane_inner_priority(self, net_order: list[int]) -> list[int]:
-        """Scaffolding-only detection hook for mirrored byte-lane match groups.
+        """Escape-freedom net ordering for mirrored byte-lane match groups.
 
-        Status: **scaffolding only (identity return)**.  This helper
-        detects mirrored byte-lane match groups (e.g. board 07's DDR
-        data byte on a mirrored QFN-48 pair) but does NOT modify the
-        net order.  It exists as the integration surface for a future
-        layered-escape strategy (see follow-up issue
-        ``router: layered-escape strategy for mirrored byte-lane DDR
-        (decouples via placement from net ordering)``).
+        This helper detects mirrored byte-lane match groups (e.g. board
+        07's DDR data byte on a mirrored QFN-48 pair) and, for each
+        qualifying group, does two things:
+
+        1. **Corridor reservation** (Issue #2983 / PR #2987): reserves an
+           inner-layer lateral corridor for the inner-corner pads (sorted
+           row positions 1 and N-2) before any corner-net through-hole
+           via is placed.  This is a *geometric* side effect and is
+           preserved unchanged.
+        2. **Reactive escape-freedom reorder** (Issue #4051, Phase 1b of
+           epic #4049): permutes the group's slots in ``net_order`` so
+           the least-free (outermost/corner) nets escape onto the shared
+           F.Cu strip before their more-free neighbours fill it.  See
+           ``_reactive_escape_freedom_order`` for the scheduling rule.
+           Only the slots the group already occupies are permuted; every
+           non-group net keeps its exact position.
+
+        Gating (``enable_byte_lane_reorder``, default ``False``): the
+        reorder in step 2 is **off by default** because it was measured
+        to REGRESS board 07's DDR bundle (10/11 -> 9/11 routed; see the
+        Issue #4051 measurement).  When disabled, this method still runs
+        detection and the corridor reservation (step 1) and returns the
+        identity order, exactly as before Issue #4051.  The scheduler is
+        retained behind the flag so the capability and its diagnostics
+        stay available for future non-uniform bundle geometries where an
+        outside-in-style schedule is not equivalent to the reactive one.
+        Detection requires a match group of at least
+        ``MIN_BYTE_LANE_SIZE`` members projecting onto a single
+        co-located row on one component (the mirrored byte-lane
+        topology); boards without such a group are always identity.
 
         Issue #2962: On board 07 a DDR data byte (10 nets routed between
         mirrored QFN-48 packages U1 and U2) repeatedly leaves the
@@ -4742,14 +4777,21 @@ class Autorouter:
           DRC 12 (well under 70 allowlist), but DQ5 still blocked by
           DQ4 with the SAME 0.44mm clearance failure as round 2 --
           the underlying constraint is geometric, not orderable.
-        - **Conclusion** (this PR, terminal outcome): convert the
-          helper to scaffolding-only (identity return).  The
-          detection / projection / sort machinery and all three
-          integration hook sites are kept in place as the surface
-          for a future PR that implements a layered-escape strategy
-          (corridor reservation, deferred via stitching for the
-          inner-corner pads, or explicit lateral-lane assignment --
-          all approaches that decouple via placement from priority).
+        - **PR #2969 outcome**: net-ordering *permutation alone* could
+          not resolve the round-1/2/3 geometric collision, so that PR
+          left the helper as a detection-only scaffold (identity return)
+          and preserved the three integration hook sites.
+        - **Issue #2983 / PR #2987**: landed corridor reservation as the
+          first real side effect (see item 1 above) while keeping the
+          net order identity.
+        - **Issue #4051 (this change)**: adds the reactive
+          escape-freedom reorder (item 2 above) *on top of* the corridor
+          reservation.  It differs from PR #2969's static permutations by
+          re-evaluating each net's escape freedom against the neighbours
+          committed so far, rather than applying a permutation fixed up
+          front (the three static permutations tried in #3438 --
+          monotone, reverse, outside-in -- topped out at 10/11, 10/11,
+          8/11).
 
         Three integration hooks remain wired (``route_all``,
         ``route_all_negotiated``, and ``TwoPhaseRouter`` via the
@@ -4758,8 +4800,7 @@ class Autorouter:
         ``_interleave_match_groups`` BEFORE this helper, preserving
         PR #2914's starvation-fairness guarantee.
 
-        Detection (kept for inspection / future use, geometry-only,
-        no hardcoded net names):
+        Detection (geometry-only, no hardcoded net names):
 
         1. Identify match groups with at least ``MIN_BYTE_LANE_SIZE``
            members.  Smaller groups don't exhibit the mirrored byte-lane
@@ -4771,22 +4812,18 @@ class Autorouter:
            least ``MIN_BYTE_LANE_SIZE`` to confirm a co-located row.
         4. Project pads onto the axis with greater spatial variance
            (the row's long axis).  Sort by that projection.
-        5. The pads at sorted index 1 and N-2 are "inner-corner".
-
-        The detection loop runs eagerly but is otherwise side-effect
-        free; the eventual reorder step is intentionally omitted in
-        this scaffolding cut.  Future work can replace the
-        ``# (scaffolding fallback) ...`` block at the end with a real
-        layered-escape implementation without touching the three
-        callers.
+        5. The pads at sorted index 1 and N-2 are "inner-corner"
+           (corridor-reservation targets); the row-sorted list is then
+           handed to the reactive escape-freedom scheduler for reorder.
 
         Args:
             net_order: Routing order after ``_interleave_match_groups``.
 
         Returns:
-            ``net_order`` unchanged.  Detection telemetry is currently
-            discarded; future revisions may emit a diagnostic via the
-            logger or thread a placement-aware reorder through here.
+            ``net_order`` with each qualifying byte-lane group's occupied
+            slots permuted into the reactive escape-freedom schedule
+            (identity when no qualifying group is present).  Always a
+            permutation of the input.
         """
         # Minimum group size to qualify as a mirrored byte-lane.  A
         # 4-net group can't be congested enough at its row middle to
@@ -4840,11 +4877,23 @@ class Autorouter:
             if nid in net_order_set:
                 groups.setdefault(grp, []).append(nid)
 
-        # Detection-only scan.  We walk each candidate group, identify
-        # its primary component, project pads onto the row axis, and
-        # locate the inner-corner indices -- but DO NOT promote (the
-        # round-3 promote-rank-0 implementation was a no-op against the
-        # underlying geometric constraint; see method docstring).
+        # Reorder plans collected during the scan: for each qualifying
+        # byte-lane group we record the row-sorted net ids so that, after
+        # the corridor-reservation pass, we can permute each group's
+        # occupied slots into an escape-freedom schedule (see
+        # ``_reactive_escape_freedom_order``).  ``escape_row_positions``
+        # maps net_id -> its 1D projection along the row long axis, used
+        # by the reactive scheduler to reason about neighbour proximity.
+        reorder_plans: list[list[int]] = []
+        escape_row_positions: dict[int, float] = {}
+
+        # Detection scan.  We walk each candidate group, identify its
+        # primary component, project pads onto the row axis, and locate
+        # the inner-corner indices.  As of Issue #4051 (Phase 1b of epic
+        # #4049) this scan additionally records a reorder plan per
+        # qualifying group; the corridor reservation for the
+        # inner-corner pads (positions 1 / N-2, Issue #2983 / PR #2987)
+        # still fires as before.
         for grp_name, grp_net_ids in groups.items():
             if len(grp_net_ids) < MIN_BYTE_LANE_SIZE:
                 continue
@@ -4910,6 +4959,17 @@ class Autorouter:
             n = len(sorted_nets)
             if n < MIN_BYTE_LANE_SIZE:
                 continue
+
+            # Issue #4051: record this group's row-sorted order and the
+            # per-net row-axis projection so the reactive escape-freedom
+            # scheduler (applied after the corridor-reservation pass) can
+            # permute the group's slots in ``net_order``.  ``proj`` is the
+            # coordinate along the row long axis (y for a vertical row,
+            # x for a horizontal one).
+            proj_index = 1 if y_span >= x_span else 0
+            for nid_s in sorted_nets:
+                escape_row_positions[nid_s] = net_to_pad[nid_s][proj_index]
+            reorder_plans.append(list(sorted_nets))
 
             # Inner-corner indices in the sorted row.  Position 1 (one in
             # from the top corner) and position n-2 (one in from the
@@ -4996,14 +5056,212 @@ class Autorouter:
                         exc_info=True,
                     )
 
-        # Identity ordering preserved: the corridor reservation is the
-        # mechanism that breaks the geometric collision (PR #2969 proved
-        # net-ordering changes alone could not).  Callers
-        # (``route_all``, ``route_all_negotiated``, ``TwoPhaseRouter``)
-        # consume the unchanged order and the escape pre-pass + main
-        # routing loop honour the per-cell reservation via
-        # ``RoutingGrid._mark_via``.
-        return net_order
+        # Issue #4051 (Phase 1b, epic #4049): apply a reactive
+        # escape-freedom reorder on top of the corridor reservation.
+        # Each qualifying byte-lane group's members are permuted *within
+        # the slots they already occupy* in ``net_order`` so that nets
+        # with the least escape freedom are scheduled first (they claim
+        # lanes on the shared F.Cu escape strip before their more-free
+        # neighbours fill them).  Non-group nets keep their positions
+        # exactly; the corridor reservation above is unchanged.  See
+        # ``_reactive_escape_freedom_order`` for the scheduling rule and
+        # the design history (three *static* permutations -- monotone,
+        # reverse, outside-in -- were already isolation-tested on this
+        # bundle in #3438 and topped out at 10/11, 10/11, 8/11; this is a
+        # *reactive* schedule that re-evaluates neighbour proximity as
+        # each net is placed, the one variant not yet tried).
+        #
+        # Gated OFF by default (``enable_byte_lane_reorder``): the reorder
+        # was measured to REGRESS board 07's DDR bundle (10/11 -> 9/11, DQ2
+        # and DQ3 stranded vs DQ3 alone), matching #3438's finding that an
+        # outside-in-style schedule tops out below the identity baseline on
+        # this bundle.  When disabled the method still runs detection +
+        # corridor reservation and returns the identity order, exactly as
+        # before Issue #4051 -- so production routing is unperturbed.  The
+        # scheduler and its wiring are retained behind the flag so the
+        # capability + diagnostics remain available for future geometries.
+        if not reorder_plans or not getattr(self, "enable_byte_lane_reorder", False):
+            return net_order
+
+        reordered = self._reactive_escape_freedom_order(
+            net_order, reorder_plans, escape_row_positions
+        )
+        # Permutation invariant: never drop or duplicate a net.  A
+        # bug in the reorder must degrade to identity, not corrupt the
+        # routing set (defense-in-depth, mirrors _interleave_match_groups).
+        if sorted(reordered) != sorted(net_order):
+            logger.error(
+                "_apply_byte_lane_inner_priority reorder produced a "
+                "non-permutation (%d in, %d out); falling back to identity",
+                len(net_order),
+                len(reordered),
+            )
+            return net_order
+        return reordered
+
+    def _reactive_escape_freedom_order(
+        self,
+        net_order: list[int],
+        reorder_plans: list[list[int]],
+        row_positions: dict[int, float],
+    ) -> list[int]:
+        """Reactively schedule byte-lane members by escape freedom.
+
+        Issue #4051.  For each detected mirrored byte-lane group
+        (``reorder_plans`` entries are the group members sorted along the
+        row long axis, outer-to-inner-to-outer), compute a routing order
+        that schedules the **least-free** nets first, re-evaluating each
+        net's freedom against the neighbours already committed *this
+        step* rather than from a fixed positional rule.
+
+        Why reactive rather than static:  on the board-07 DDR bundle
+        every net must escape onto one shared F.Cu strip (in-column vias
+        are forbidden at 0.8 mm pitch), and whichever nets are scheduled
+        *last* get sealed out by earlier nets' stubs/vias (#3438).  The
+        outermost/corner nets have the least lateral freedom (only one
+        direction is "outward" and it is the one most likely already
+        claimed), so they must go first.  Three *static* permutations of
+        this intuition (monotone, reverse, outside-in) were already
+        measured on this exact bundle in #3438 and none reached 11/11.
+        The untried signal is a schedule that, at every step, picks the
+        remaining net whose escape corridor is *currently* most
+        threatened by an already-scheduled neighbour -- a greedy that
+        reacts to committed geometry instead of a permutation fixed up
+        front.
+
+        The scheduler:
+
+        1. Seed the schedule with the two row extremes (indices 0 and
+           N-1 of the sorted group).  These are the corner nets: each has
+           an already-open outward side and a single inward neighbour, so
+           they are the least free and must escape first.
+        2. Repeatedly select, from the not-yet-scheduled members, the net
+           adjacent to the *frontier* (the innermost scheduled net on each
+           side) whose remaining escape gap is smallest -- i.e. the net
+           most threatened by the neighbour just committed.  This walks
+           inward from both ends, but the *choice of which side advances*
+           is recomputed each step from the current frontier gaps, so a
+           tighter side is served before a looser one (the reactive part).
+        3. The centre net(s) -- flanked on both sides by committed
+           neighbours and therefore having a corridor argument on each
+           side -- are scheduled last.
+
+        The permutation is applied only to the ``net_order`` slots the
+        group already occupies, so non-group nets and inter-group
+        ordering (starvation fairness from ``_interleave_match_groups``)
+        are preserved exactly.
+
+        Args:
+            net_order: The full routing order after corridor reservation.
+            reorder_plans: One list per qualifying group, each the group's
+                net ids sorted along the row long axis.
+            row_positions: net_id -> row-axis projection (mm).
+
+        Returns:
+            ``net_order`` with each group's occupied slots permuted into
+            the reactive escape-freedom schedule.  Always a permutation
+            of the input.
+        """
+        result = list(net_order)
+        pos_in_order = {nid: i for i, nid in enumerate(net_order)}
+
+        for sorted_nets in reorder_plans:
+            members = [nid for nid in sorted_nets if nid in pos_in_order]
+            if len(members) < 3:
+                continue
+
+            schedule = self._schedule_by_escape_freedom(members, row_positions)
+            if sorted(schedule) != sorted(members):
+                # Defensive: bad schedule -> leave this group untouched.
+                continue
+
+            # The slots this group occupies in net_order, in ascending
+            # index order.  We drop the group's members into those exact
+            # slots following the escape-freedom schedule, so every other
+            # net keeps its position.
+            slots = sorted(pos_in_order[nid] for nid in members)
+            for slot, nid in zip(slots, schedule, strict=True):
+                result[slot] = nid
+
+        return result
+
+    @staticmethod
+    def _schedule_by_escape_freedom(
+        members: list[int],
+        row_positions: dict[int, float],
+    ) -> list[int]:
+        """Order one byte-lane group least-free-first (Issue #4051).
+
+        ``members`` is the group's net ids sorted along the row long
+        axis.  Returns a reordering that schedules the two row extremes
+        first, then reactively advances whichever side's frontier gap is
+        currently smallest, ending on the centre net(s).
+
+        The "gap" for a candidate net is its row-axis distance to the
+        neighbour already scheduled on its outward side -- the smaller
+        the gap, the more threatened its escape corridor by that
+        committed neighbour, so it is scheduled sooner.  Because the gap
+        is read from the *current* frontier each iteration (not a fixed
+        positional rank), a side that has been squeezed tighter by prior
+        commits is served before a looser side -- the reactive property
+        the three static permutations in #3438 lacked.
+        """
+        n = len(members)
+        if n < 3:
+            return list(members)
+
+        # Row-axis coordinate for each member; fall back to positional
+        # index if a projection is missing (should not happen).
+        coord = {
+            nid: row_positions.get(nid, float(idx)) for idx, nid in enumerate(members)
+        }
+
+        # Two frontiers walking inward from each end.
+        lo = 0
+        hi = n - 1
+        schedule: list[int] = []
+
+        # Seed with both corners (least free: one already-open side).
+        schedule.append(members[lo])
+        if hi != lo:
+            schedule.append(members[hi])
+        lo += 1
+        hi -= 1
+
+        # ``last_side`` tracks which frontier advanced most recently so
+        # that on a *tie* (uniform pitch is the common case on a DDR row)
+        # the two frontiers alternate and converge symmetrically on the
+        # centre -- otherwise a strict ``<=`` would drain one side fully
+        # and schedule the true centre net second-to-last instead of last.
+        _EPS = 1e-9
+        last_side = "hi"  # so the first tie advances lo (mirrors seed order)
+
+        while lo <= hi:
+            if lo == hi:
+                # Single centre net remaining.
+                schedule.append(members[lo])
+                break
+            # Gap from each candidate to its just-committed outward
+            # neighbour.  The side with the smaller gap is more
+            # threatened and advances first.
+            lo_gap = abs(coord[members[lo]] - coord[members[lo - 1]])
+            hi_gap = abs(coord[members[hi]] - coord[members[hi + 1]])
+            if abs(lo_gap - hi_gap) <= _EPS:
+                # Tie: alternate to keep both frontiers balanced so the
+                # geometric centre is genuinely scheduled last.
+                advance_lo = last_side == "hi"
+            else:
+                advance_lo = lo_gap < hi_gap
+            if advance_lo:
+                schedule.append(members[lo])
+                lo += 1
+                last_side = "lo"
+            else:
+                schedule.append(members[hi])
+                hi -= 1
+                last_side = "hi"
+
+        return schedule
 
     def _compute_mst_edges(self, net_id: int) -> list[MSTEdgeInfo]:
         """Compute MST edges for a net and return them sorted by distance.
@@ -5339,12 +5597,13 @@ class Autorouter:
         # match suffix-inference patterns) receive an identity ordering.
         net_order = self._interleave_match_groups(net_order)
 
-        # Issue #2962: Mirrored byte-lane detection hook (scaffolding only).
-        # ``_apply_byte_lane_inner_priority`` currently returns ``net_order``
-        # unchanged.  The detection / projection / sort machinery is
-        # preserved as the integration surface for a future layered-escape
-        # PR; see that method's docstring for the R1/R2/R3 trace and the
-        # follow-up issue link.
+        # Issue #2962 / #2983 / #4051: Mirrored byte-lane escape ordering.
+        # ``_apply_byte_lane_inner_priority`` reserves inner-corner
+        # corridors (#2983) and reorders each qualifying byte-lane group's
+        # slots by reactive escape freedom (#4051), least-free-first.
+        # Applied AFTER ``_interleave_match_groups`` so the head-class
+        # starvation-fairness ordering is preserved; only within-group
+        # neighbour priorities are adjusted.
         net_order = self._apply_byte_lane_inner_priority(net_order)
 
         if parallel:
@@ -6851,12 +7110,14 @@ class Autorouter:
         # for the fairness-vs-priority trade-off rationale.
         net_order = self._interleave_match_groups(net_order)
 
-        # Issue #2962: Mirrored byte-lane detection hook (scaffolding only;
-        # see ``_apply_byte_lane_inner_priority`` docstring).  Identical
-        # hook to ``route_all``: applied AFTER ``_interleave_match_groups``
-        # so a future implementation that swaps the helper body for a real
-        # reorder keeps the starvation-fairness ordering and adjusts only
-        # within-class neighbour priorities.
+        # Issue #2962 / #2983 / #4051: Mirrored byte-lane escape ordering.
+        # Reserves inner-corner corridors (#2983) and reorders each
+        # qualifying byte-lane group by reactive escape freedom (#4051).
+        # This is the negotiated production path (``kct route`` defaults
+        # to ``--strategy negotiated``, and board 07's
+        # ``generate_design.py --step route`` routes through here).
+        # Applied AFTER ``_interleave_match_groups`` so starvation
+        # fairness is preserved; only within-group priorities shift.
         net_order = self._apply_byte_lane_inner_priority(net_order)
 
         total_nets = len(net_order)

--- a/tests/router/test_byte_lane_corridor_reservation.py
+++ b/tests/router/test_byte_lane_corridor_reservation.py
@@ -29,8 +29,12 @@ Tests in this module pin the contract:
 3. The reservation runs as part of
    :meth:`_apply_byte_lane_inner_priority` (so it lands BEFORE
    any corner-net via marking in the escape pre-pass).
-4. The ordering output is still identity (PR #2969 contract
-   preserved — corridor reservation does not perturb net order).
+4. The reservation coexists with the reactive escape-freedom
+   reorder added in Issue #4051: for a qualifying byte-lane the
+   ordering output is now a *permutation* of the input (not
+   identity), while the reservation counters are unchanged (the two
+   effects are independent).  Non-qualifying inputs (small / no-group /
+   non-mirrored) keep the identity ordering.
 5. The 2-layer guard is honoured (no reservation on 2-layer
    stack-ups; that case has no via-blocking contention to
    resolve and would actively starve partner-net escapes).
@@ -172,8 +176,11 @@ class TestCorridorReservationOnPlaneStackup:
         # Drive the detection + reservation pass.
         out = router._apply_byte_lane_inner_priority(net_ids)
 
-        # Identity contract preserved.
-        assert out == net_ids
+        # Issue #4051: ordering is no longer identity for a qualifying
+        # byte-lane — it is now a reactive escape-freedom permutation.
+        # The reservation side-effect (this test's subject) is unchanged.
+        assert set(out) == set(net_ids)
+        assert len(out) == len(net_ids)
         # Two inner-corner pads (positions 1 and N-2) on the primary
         # component (U1 or U2 — both host all 10 group members; the
         # tie-break picks one deterministically).
@@ -186,7 +193,8 @@ class TestCorridorReservationOnPlaneStackup:
         router, net_ids, _ = _make_byte_lane_router(group_size=9, layer_stack=stack)
 
         out = router._apply_byte_lane_inner_priority(net_ids)
-        assert out == net_ids
+        # Issue #4051: reorder active; reservation count unchanged.
+        assert set(out) == set(net_ids)
         assert router._escape.byte_lane_corridor_reservations == 2
         assert router._escape.byte_lane_corridor_reserved_cells > 0
 
@@ -208,7 +216,8 @@ class TestCorridorReservationOnSignalStackup:
         router, net_ids, _ = _make_byte_lane_router(group_size=10, layer_stack=stack)
 
         out = router._apply_byte_lane_inner_priority(net_ids)
-        assert out == net_ids
+        # Issue #4051: reorder active; reservation count unchanged.
+        assert set(out) == set(net_ids)
         assert router._escape.byte_lane_corridor_reservations == 2
         assert router._escape.byte_lane_corridor_reserved_cells > 0
 
@@ -283,35 +292,59 @@ class TestTwoLayerStackupGuard:
 
 
 # =============================================================================
-# Tests: Identity preservation (PR #2969 ordering contract)
+# Tests: Reorder coexists with reservation (Issue #4051 ordering contract)
 # =============================================================================
 
 
-class TestOrderingStillIdentity:
-    """Corridor reservation must NOT change net ordering.
+class TestReorderCoexistsWithReservation:
+    """The reactive escape-freedom reorder (Issue #4051) fires alongside
+    the corridor reservation (Issue #2983) — the two are independent.
 
-    PR #2969's R1/R2/R3 trace proved net-ordering changes alone are
-    insufficient AND, in R1, actively regressed DRC.  The Issue #2983
-    fix is corridor-reservation-only: the helper's return value must
-    remain identical to the input order so the downstream priority
-    semantics (PR #2914 starvation fairness, PR #2482 connector
-    sibling promotion, complexity-tier ordering, etc.) are
-    preserved verbatim.
+    Historical note: PR #2969's R1/R2/R3 trace proved a *static*
+    net-ordering permutation alone is insufficient (and, in R1,
+    regressed DRC), so #2983 shipped corridor-reservation-only with an
+    identity order.  Issue #4051 adds a *reactive* schedule on top: the
+    return value is now a permutation of the input (not identity) for
+    qualifying byte-lanes, while the reservation side-effect is
+    unchanged and the group's occupied slots are permuted in place so
+    non-group ordering (PR #2914 starvation fairness, PR #2482 connector
+    sibling promotion) is preserved.
     """
 
-    def test_identity_on_4_layer_signal_stack(self) -> None:
+    def test_reorder_on_4_layer_signal_stack(self) -> None:
         stack = LayerStack.four_layer_all_signal()
         router, net_ids, _ = _make_byte_lane_router(group_size=10, layer_stack=stack)
+        router.enable_byte_lane_reorder = True  # opt in (OFF by default)
         out = router._apply_byte_lane_inner_priority(net_ids)
-        assert out == net_ids
+        # Permutation invariant holds; ordering is no longer identity.
         assert set(out) == set(net_ids)
         assert len(out) == len(net_ids)
+        assert out != net_ids
+        # Reservation still fires (independent of the reorder flag).
+        assert router._escape.byte_lane_corridor_reservations == 2
 
-    def test_identity_on_plane_stack(self) -> None:
+    def test_reorder_on_plane_stack(self) -> None:
         stack = LayerStack.four_layer_sig_gnd_pwr_sig()
         router, net_ids, _ = _make_byte_lane_router(group_size=10, layer_stack=stack)
+        router.enable_byte_lane_reorder = True
         out = router._apply_byte_lane_inner_priority(net_ids)
-        assert out == net_ids
+        assert set(out) == set(net_ids)
+        assert out != net_ids
+        assert router._escape.byte_lane_corridor_reservations == 2
+
+    def test_reservation_without_reorder_is_identity(self) -> None:
+        """Default (flag OFF): reservation fires but order is identity.
+
+        This pins the non-regression contract — production routing (flag
+        OFF) keeps the pre-#4051 identity ordering while still reserving
+        the inner-corner corridors from #2983.
+        """
+        stack = LayerStack.four_layer_all_signal()
+        router, net_ids, _ = _make_byte_lane_router(group_size=10, layer_stack=stack)
+        # enable_byte_lane_reorder defaults to False.
+        out = router._apply_byte_lane_inner_priority(net_ids)
+        assert out == net_ids  # identity preserved when flag is off
+        assert router._escape.byte_lane_corridor_reservations == 2
 
 
 # =============================================================================

--- a/tests/router/test_byte_lane_priority.py
+++ b/tests/router/test_byte_lane_priority.py
@@ -1,12 +1,18 @@
-"""Tests for the mirrored byte-lane scaffolding hook (Issue #2962).
+"""Tests for the mirrored byte-lane escape ordering (Issues #2962 /
+#2983 / #4051).
 
 The :meth:`Autorouter._apply_byte_lane_inner_priority` helper detects
 mirrored byte-lane match groups (e.g. board 07's DDR data byte on a
-mirrored QFN-48 pair) but, in this scaffolding-only cut, **returns the
-input net order unchanged**.  The detection / projection / sort
-machinery and the three integration hook sites (``route_all``,
-``route_all_negotiated``, ``TwoPhaseRouter``) are preserved as the
-surface for a future layered-escape PR.
+mirrored QFN-48 pair) and, for a qualifying group, (a) reserves an
+inner-corner corridor (Issue #2983) and (b) reorders the group's slots
+by *reactive escape freedom* (Issue #4051): the least-free/outermost
+nets are scheduled first so they claim lanes on the shared F.Cu escape
+strip before their more-free neighbours fill them.  The reorder is
+applied only to the slots the group already occupies, so non-group nets
+and the three integration hook sites (``route_all``,
+``route_all_negotiated``, ``TwoPhaseRouter``) preserve their ordering.
+Non-qualifying inputs (tiny / no-group / small-group) keep the identity
+ordering.
 
 PR #2969 design history (preserved as the AC for issue #2962's
 net-ordering exploration):
@@ -49,7 +55,7 @@ issue):
         remaining lateral lane.
     The inner-corner nets are squeezed out.
 
-The helper's current scaffolding contract:
+The helper's current contract:
 
 1.  **Identity on tiny inputs** -- ``net_order`` shorter than 4 is
     returned unchanged.
@@ -58,11 +64,12 @@ The helper's current scaffolding contract:
 3.  **Identity on small groups** -- groups with fewer than 5 members
     don't exhibit the mirrored byte-lane topology; the helper degrades
     to identity for them.
-4.  **Identity on mirrored byte-lane groups** -- detection runs but
-    no reorder is applied.  A future PR will replace this with a
-    placement-aware layered-escape strategy.
-5.  **Multi-group preservation** -- non-byte-lane groups in the same
-    routing pass are not affected.
+4.  **Reactive reorder on mirrored byte-lane groups** (Issue #4051) --
+    detection runs and the group's slots are permuted into a
+    corner-first escape-freedom schedule.
+5.  **Multi-group / non-group preservation** -- nets outside a
+    qualifying byte-lane keep their exact slots (the reorder only
+    permutes within the group's occupied slots).
 6.  **Length and membership invariant** -- output is always a
     permutation of the input.
 """
@@ -223,70 +230,84 @@ class TestIdentityOnSmallGroups:
         assert out == net_ids
 
 
-class TestScaffoldingIdentityOnByteLane:
-    """Mirrored byte-lane groups return identity, with corridor reservation.
+class TestReactiveReorderOnByteLane:
+    """Mirrored byte-lane groups are reordered by escape freedom.
 
-    Issue #2983 updates the contract: the helper still returns the
-    input net order unchanged (PR #2969 R1/R2/R3 proved net-ordering
-    changes alone are insufficient and, in R1, regressed DRC), but
-    the **corridor reservation** side-effect now runs for each
-    detected mirrored byte-lane group.  The reservation lands ONLY
-    when a routable inner layer is available in the stack-up; the
-    fixture here does NOT pass a ``layer_stack`` so the internal
-    2-layer fallback is in effect and the reservation is correctly
-    skipped (the 2-layer guard prevents starving partner-net
-    escapes — see ``test_byte_lane_corridor_reservation.py`` for
-    the multi-layer reservation contract).
+    Issue #4051 (Phase 1b of epic #4049) updates the contract: for a
+    qualifying mirrored byte-lane the helper now returns a *reactive
+    escape-freedom permutation* of the input (least-free/outermost nets
+    scheduled first), not the identity order.  Historical context: PR
+    #2969's R1/R2/R3 proved a *static* permutation alone is insufficient
+    and #2983 shipped corridor-reservation-only with an identity order;
+    #4051 adds the *reactive* schedule on top of that reservation.
 
-    The detection / projection / sort machinery runs eagerly so
-    callers observe consistent intermediate state.  The integration
-    hooks (``route_all``, ``route_all_negotiated``, ``TwoPhaseRouter``)
-    consume the unchanged order and the escape pre-pass + main
-    routing loop honour the per-cell reservation via
-    ``RoutingGrid._mark_via``.
+    The schedule seeds the two row extremes (corners), then advances
+    inward from whichever side's frontier gap is currently smallest,
+    ending on the centre net.  For a uniform-pitch synthetic row the
+    gaps tie, so the schedule is deterministic:
+    ``[0, N-1, N-2, ..., 1]``-style corner-first walk (see
+    :meth:`Autorouter._schedule_by_escape_freedom`).
     """
 
-    def test_nine_net_byte_lane_identity(self) -> None:
-        """9-net byte-lane (DDR-byte minus DQS pair): detection runs,
-        no reorder applied — output equals input.
+    def test_default_flag_off_is_identity(self) -> None:
+        """Default (``enable_byte_lane_reorder`` False): a qualifying
+        byte-lane returns the identity order.
 
-        Issue #2983 contract: ordering is identity, AND on a
-        multi-layer stack-up the corridor reservation runs as a
-        side effect.  This fixture uses the default 2-layer
-        Autorouter (no ``layer_stack``), so the reservation is
-        correctly skipped here by the 2-layer guard.  See
-        ``test_byte_lane_corridor_reservation.py`` for the
-        reservation count assertions on 4-layer stack-ups.
+        This pins the production non-regression contract — the reorder
+        is opt-in because it regressed board 07's DDR bundle.
         """
         router, net_ids, _ = _make_byte_lane_router(group_size=9)
+        # Flag defaults to False; do NOT enable it.
+        out = router._apply_byte_lane_inner_priority(net_ids)
+        assert out == net_ids
+
+    def test_nine_net_byte_lane_reordered(self) -> None:
+        """9-net byte-lane (DDR-byte minus DQS pair): reactive reorder
+        applied — output is a corner-first permutation of the input.
+
+        This fixture uses the default 2-layer Autorouter (no
+        ``layer_stack``), so the corridor reservation is correctly
+        skipped by the 2-layer guard, but the *reorder* still fires
+        (it is independent of the reservation).  See
+        ``test_byte_lane_corridor_reservation.py`` for the
+        reservation-count assertions on 4-layer stack-ups.
+        """
+        router, net_ids, _ = _make_byte_lane_router(group_size=9)
+        # Issue #4051: the reorder is opt-in (OFF by default because it
+        # regressed board 07); enable it to exercise the reorder contract.
+        router.enable_byte_lane_reorder = True
 
         out = router._apply_byte_lane_inner_priority(net_ids)
 
-        # Identity contract: output is the input list, unchanged.
-        assert out == net_ids
-        # Membership + length invariants hold trivially under identity.
+        # Permutation invariant.
         assert len(out) == len(net_ids)
         assert set(out) == set(net_ids)
+        # Non-identity: the reorder is active for this qualifying group.
+        assert out != net_ids
+        # Corner-first: both row extremes are scheduled before the centre.
+        assert out[0] == net_ids[0]  # top corner first
+        assert out[1] == net_ids[-1]  # bottom corner second
+        assert out[-1] == net_ids[len(net_ids) // 2]  # centre last
         # 2-layer fallback => no reservation on this fixture.
         assert router._escape.byte_lane_corridor_reservations == 0
 
-    def test_ten_net_byte_lane_identity(self) -> None:
-        """A 10-net byte-lane (full DDR-byte): detection runs, but
-        no reorder is applied — output equals input.
+    def test_ten_net_byte_lane_reordered(self) -> None:
+        """A 10-net byte-lane (full DDR-byte): reactive reorder applied.
 
-        See the module docstring for the R1/R2/R3 design-history
-        trace explaining why net-ordering alone is insufficient,
-        and ``test_byte_lane_corridor_reservation.py`` for the
-        Issue #2983 reservation-count assertions on multi-layer
-        stack-ups (where the corridor is actually carved out).
+        See the module docstring for the R1/R2/R3 design-history trace
+        explaining why a *static* net-ordering alone is insufficient,
+        and ``test_byte_lane_corridor_reservation.py`` for the Issue
+        #2983 reservation-count assertions on multi-layer stack-ups.
         """
         router, net_ids, _ = _make_byte_lane_router(group_size=10)
+        router.enable_byte_lane_reorder = True
         out = router._apply_byte_lane_inner_priority(net_ids)
 
-        # Identity contract.
-        assert out == net_ids
         assert len(out) == len(net_ids)
         assert set(out) == set(net_ids)
+        assert out != net_ids
+        assert out[0] == net_ids[0]  # top corner first
+        assert out[1] == net_ids[-1]  # bottom corner second
         # 2-layer fallback => no reservation on this fixture.
         assert router._escape.byte_lane_corridor_reservations == 0
 
@@ -297,6 +318,7 @@ class TestMultiGroupPreservation:
     def test_non_group_nets_keep_position(self) -> None:
         """Add 3 ungrouped nets and confirm they keep their slots."""
         router, byte_lane_ids, _ = _make_byte_lane_router(group_size=9)
+        router.enable_byte_lane_reorder = True
 
         # Add 3 standalone nets after the byte-lane group.  These have
         # NO match-group declaration, so the helper must leave them in
@@ -320,12 +342,17 @@ class TestMultiGroupPreservation:
         net_order = byte_lane_ids + extra_ids
         out = router._apply_byte_lane_inner_priority(net_order)
 
-        # Under the scaffolding cut the full input order is preserved,
-        # which trivially keeps the standalone nets in place.
-        assert out == net_order
         # Membership preserved.
         assert set(out) == set(net_order)
         assert len(out) == len(net_order)
+        # Issue #4051: the byte-lane group is reordered *within the
+        # slots it already occupies* (slots 0..8 here), so the 3
+        # standalone nets at slots 9,10,11 keep their exact positions.
+        assert out[9:] == extra_ids
+        # The byte-lane slots now hold a permutation of the group.
+        assert set(out[:9]) == set(byte_lane_ids)
+        # And the reorder is active (non-identity) on the group slots.
+        assert out[:9] != byte_lane_ids
 
 
 class TestPermutationInvariant:
@@ -340,14 +367,12 @@ class TestPermutationInvariant:
 
     def test_horizontal_row_orientation(self) -> None:
         """A horizontal row (pads share y, vary x) exercises the
-        axis-with-greater-variance detection branch but, in the
-        scaffolding cut, still returns identity.
+        axis-with-greater-variance detection branch AND the reactive
+        reorder (Issue #4051).
 
-        Round-4 contract per PR #2969: even when the detection logic
-        successfully classifies the row, no reorder is applied.  The
-        axis-selection branch is exercised here for coverage so a
-        future layered-escape implementation has a regression
-        fingerprint to compare against.
+        The row long axis is x here; the scheduler projects onto x,
+        seeds the two x-extremes, and walks inward — a corner-first
+        permutation, same as the vertical case.
         """
         cls = NetClassRouting(
             name="HORIZ_BUS",
@@ -392,12 +417,17 @@ class TestPermutationInvariant:
             net_class_map[nm] = cls
             net_ids.append(net_id)
         router.net_class_map = net_class_map
+        router.enable_byte_lane_reorder = True
 
         out = router._apply_byte_lane_inner_priority(net_ids)
 
-        # Identity contract: horizontal row detection runs but no
-        # reorder is applied.
-        assert out == net_ids
+        # Issue #4051: reactive reorder is applied to the horizontal row.
+        assert set(out) == set(net_ids)
+        assert out != net_ids
+        # Corner-first: the two x-extremes escape before the centre.
+        assert out[0] == net_ids[0]
+        assert out[1] == net_ids[-1]
+        assert out[-1] == net_ids[len(net_ids) // 2]
 
 
 class TestNonMirroredTopologyGracefulFallback:
@@ -439,3 +469,64 @@ class TestNonMirroredTopologyGracefulFallback:
         # No primary component has 5+ group-member pads -> no promotion
         # plan -> identity.
         assert out == net_ids
+
+
+class TestScheduleByEscapeFreedom:
+    """Unit tests for the reactive escape-freedom scheduler (Issue #4051).
+
+    The scheduler operates on a row-sorted member list and a row-axis
+    projection map.  It seeds the two extremes (corners), then advances
+    inward from whichever side's frontier gap is currently smaller,
+    ending on the centre.  For a uniform-pitch row the gaps tie every
+    step so the walk is deterministic and reproducible.
+    """
+
+    def test_permutation_invariant(self) -> None:
+        members = list(range(11))
+        pos = {i: float(i) * 0.8 for i in members}
+        sched = Autorouter._schedule_by_escape_freedom(members, pos)
+        assert sorted(sched) == sorted(members)
+
+    def test_corners_first_centre_last_uniform(self) -> None:
+        """Uniform pitch: extremes scheduled first, centre last."""
+        members = list(range(11))
+        pos = {i: float(i) * 0.8 for i in members}
+        sched = Autorouter._schedule_by_escape_freedom(members, pos)
+        assert sched[0] == 0  # top corner
+        assert sched[1] == 10  # bottom corner
+        assert sched[-1] == 5  # centre net routes last
+
+    def test_tighter_side_advances_first(self) -> None:
+        """Reactive property: the side with the smaller frontier gap is
+        served before the looser side.
+
+        Squeeze the high end (indices 8,9 close together) and leave the
+        low end evenly spaced.  After the two corners (0 and 10) are
+        seeded, the high frontier's inward gap (10->9) is smaller than
+        the low frontier's (0->1), so index 9 is scheduled before 1.
+        """
+        members = list(range(11))
+        pos = {i: float(i) for i in members}
+        pos[9] = 8.1  # 9 close to 10 (gap 1.9 vs low gap 1.0)... make hi tighter
+        pos[8] = 8.0
+        # Recompute to guarantee the hi frontier gap (|pos[10]-pos[9]|)
+        # is the smaller one after seeding corners.
+        pos[10] = 8.15
+        sched = Autorouter._schedule_by_escape_freedom(members, pos)
+        assert sorted(sched) == sorted(members)
+        # index 9 (tighter hi frontier) is scheduled before index 1.
+        assert sched.index(9) < sched.index(1)
+
+    def test_short_group_returns_input(self) -> None:
+        """Fewer than 3 members: nothing to schedule, return as-is."""
+        assert Autorouter._schedule_by_escape_freedom([7, 8], {7: 0.0, 8: 1.0}) == [
+            7,
+            8,
+        ]
+
+    def test_odd_and_even_sizes_terminate(self) -> None:
+        for n in (5, 6, 9, 10, 11, 12):
+            members = list(range(n))
+            pos = {i: float(i) for i in members}
+            sched = Autorouter._schedule_by_escape_freedom(members, pos)
+            assert sorted(sched) == sorted(members), f"n={n}"


### PR DESCRIPTION
## Summary

Phase 1b of epic #4049. Extends `_apply_byte_lane_inner_priority` from an identity-order return to a **reactive escape-freedom net reorder** for mirrored byte-lane bundles (board 07's DDR data byte on facing QFN-48 columns), the one variant #3438 had not yet isolated. The existing inner-corner corridor reservation (#2983/PR #2987) is preserved.

**Measured result: the reorder does NOT reach 11/11 — it regresses the DDR bundle 10/11 → 9/11.** Per the epic's measurement-first framing and the curator's gating guidance, it therefore ships **off by default** behind `enable_byte_lane_reorder`. With the flag off the method is byte-identical to pre-#4051 behaviour, so no board regresses by construction. The scheduler + diagnostics are retained behind the flag for future non-uniform bundle geometries.

## Changes

- **`_schedule_by_escape_freedom`** (new): seeds the two row extremes (least-free corner nets), then walks inward advancing whichever frontier is currently most threatened by its just-committed neighbour — reacts to committed geometry rather than a static up-front permutation.
- **`_reactive_escape_freedom_order`** (new): permutes only the slots each byte-lane group already occupies, preserving non-group ordering (starvation fairness) and the permutation invariant.
- **`enable_byte_lane_reorder`** flag on `Autorouter` (default `False`) gating the reorder; detection + corridor reservation still run and identity is returned when off.
- Updated stale "scaffolding only (identity return)" / "future follow-up issue" docstring and the three call-site comments (`route_all`, `route_all_negotiated`, `TwoPhaseRouter`) to reflect that #2983 shipped and #4051 adds reordering on top.
- Tests: byte-lane priority + corridor-reservation suites updated for the opt-in contract; added `_schedule_by_escape_freedom` unit tests.

## Measurement (DDR-bundle repro, back-to-back, solo)

| Config | Routed | Stranded | Wall |
|--------|--------|----------|------|
| Baseline (flag off = identity = `main`) | 10/11 | DQ3 | 3m18s |
| Reactive reorder (flag on) | 9/11 | DQ2, DQ3 | 7m12s |

Confirms #3438's N-1 structural-capacity conclusion: escape-sequence reordering (static or reactive) does not clear this bundle; joint corridor allocation (Phase 3 / #4053) remains the fallback.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Reorder heuristic active for collated bundles (flag or auto-detect) | ✅ | Behind `enable_byte_lane_reorder`; auto-detect proven unsafe (regressed board 07) so flag defaults OFF per curator gating guidance |
| Corridor-reservation side effect preserved | ✅ | Reservation loop unchanged; `test_byte_lane_corridor_reservation.py` still asserts count==2; new `test_reservation_without_reorder_is_identity` |
| DDR-bundle repro measured with heuristic on; result posted | ✅ | 9/11 (DQ2+DQ3), posted on #4051 |
| Board-07 production recipe before/after | ✅ (by construction) | Flag off = identity path = byte-identical to `main`; production recipe unchanged, so reach/DRC unchanged |
| No cross-board regression (00–06) | ✅ (by construction) | Flag-off path is byte-identical; full `tests/router/` green except a pre-existing board-02 baseline drift that also fails on clean `main` |
| Stale scaffolding/follow-up language updated | ✅ | Docstring + 3 call-site comments + two_phase.py comment updated |
| Byte-lane tests updated for new contract | ✅ | Identity when flag off; corner-first permutation when on; scheduler unit tests added |
| Report actual result if not 11/11 | ✅ | 9/11 reported; Phase 3 (#4053) remains the decision-gated fallback |

## Test Plan

- `uv run pytest tests/router/test_byte_lane_priority.py tests/router/test_byte_lane_corridor_reservation.py` — 27 passed.
- `uv run pytest tests/router/` — 464 passed, 3 skipped (1 pre-existing board-02 baseline-drift failure, reproduced on clean `main`, unrelated).
- `uv run ruff check` on all touched files — clean.
- DDR-bundle repro measured baseline vs variant back-to-back (table above).

Closes #4051