### PR TITLE
Installer MVP: scripts/install-kct.sh <target-repo> with --dry-run (#4055)

### DIFF
--- a/scripts/install-kct.sh
+++ b/scripts/install-kct.sh
@@ -1,0 +1,481 @@
+#!/usr/bin/env bash
+# install-kct.sh - Install kicad-tools into a consumer PCB-design repository.
+#
+# Distribution model (Epic #4054, owner-confirmed): uv-dependency + vendored
+# skills (Anvil's model, NOT Loom's full-package vendoring). This installer:
+#   1. Adds kicad-tools as a uv dependency in the target's pyproject.toml
+#      (git source by default, local path source with --path <dir>).
+#   2. Vendors .claude/commands/kct/*.md skills into the target (NEVER touches
+#      .claude/commands/loom/ — coexists additively with Loom).
+#   3. Appends a guarded, idempotent <!-- BEGIN KICAD-TOOLS --> block to the
+#      target's CLAUDE.md carrying the three hard-won Epic #4054 conventions.
+#   4. Writes .kct/install-metadata.json for a future uninstaller/upgrader.
+#   5. --dry-run prints every planned write and writes nothing.
+#
+# Usage:
+#   ./scripts/install-kct.sh [OPTIONS] <target-repo>
+#
+# Options:
+#   --path <dir>       Install kicad-tools as a LOCAL PATH dependency pointing
+#                      at <dir> (a kicad-tools checkout), for sibling-repo
+#                      development (e.g. --path ../kicad-tools). Network-free.
+#                      Without --path, a git source is used (default).
+#   --tag <tag>        Git-source pin: use this tag (git mode only). Default:
+#                      the source checkout's kct version tag (v<version>).
+#   --rev <rev>        Git-source pin: use this rev/sha (git mode only).
+#   --skills=<a,b,c>   Vendor only the listed skills (default: all *.md under
+#                      the source .claude/commands/kct/). README is always
+#                      vendored (it documents the namespace).
+#   --dry-run          Print planned actions, write nothing.
+#   -y, --yes          Non-interactive (skip confirmation; auto-enabled when
+#                      stdin is not a TTY, e.g. CI/agent shells).
+#   -h, --help         Show this help and exit.
+#
+# Examples:
+#   ./scripts/install-kct.sh /path/to/board-repo
+#   ./scripts/install-kct.sh --path ../kicad-tools /path/to/board-repo
+#   ./scripts/install-kct.sh --dry-run /path/to/board-repo
+#   ./scripts/install-kct.sh --skills=ee-review /path/to/board-repo
+#
+# Prerequisites in the target repo:
+#   - A pyproject.toml at the target root. This MVP does NOT `uv init` a
+#     non-uv repo; it fails with a clear error naming the missing file
+#     (Epic #4054 "least-invasive mechanism" — the happy path is a
+#     uv-managed consumer repo).
+#
+# Re-running the installer is the upgrade/idempotency path: a second run with
+# the same args adds no duplicate CLAUDE.md block and no duplicate dependency.
+
+set -euo pipefail
+
+# ----- ANSI colors -----------------------------------------------------------
+if [[ -t 1 ]]; then
+  RED=$'\033[0;31m'
+  GREEN=$'\033[0;32m'
+  BLUE=$'\033[0;34m'
+  YELLOW=$'\033[1;33m'
+  CYAN=$'\033[0;36m'
+  NC=$'\033[0m'
+else
+  RED=""; GREEN=""; BLUE=""; YELLOW=""; CYAN=""; NC=""
+fi
+
+error() { echo "${RED}error: $*${NC}" >&2; exit 1; }
+info()  { echo "${BLUE}> $*${NC}"; }
+ok()    { echo "${GREEN}  ok: $*${NC}"; }
+warn()  { echo "${YELLOW}  warn: $*${NC}"; }
+note()  { echo "${CYAN}  note: $*${NC}"; }
+
+usage() {
+  # The Usage / Options / Examples block lives in the header comment.
+  sed -n '4,45p' "$0" | sed 's/^# \{0,1\}//'
+  exit 0
+}
+
+# ----- CLAUDE.md marker constants -------------------------------------------
+KCT_MARK_BEGIN='<!-- BEGIN KICAD-TOOLS -->'
+KCT_MARK_END='<!-- END KICAD-TOOLS -->'
+
+# ----- Argument parsing ------------------------------------------------------
+SKILLS_FILTER=""
+DRY_RUN=false
+NON_INTERACTIVE=false
+PATH_MODE=false
+PATH_DIR=""
+GIT_TAG=""
+GIT_REV=""
+TARGET=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skills=*) SKILLS_FILTER="${1#--skills=}"; [[ -z "$SKILLS_FILTER" ]] && error "--skills requires a comma-separated list"; shift ;;
+    --skills)   shift; SKILLS_FILTER="${1:-}"; [[ -z "$SKILLS_FILTER" ]] && error "--skills requires a comma-separated list"; shift ;;
+    --path)     shift; PATH_DIR="${1:-}"; [[ -z "$PATH_DIR" ]] && error "--path requires a directory argument"; PATH_MODE=true; shift ;;
+    --path=*)   PATH_DIR="${1#--path=}"; [[ -z "$PATH_DIR" ]] && error "--path requires a directory argument"; PATH_MODE=true; shift ;;
+    --tag)      shift; GIT_TAG="${1:-}"; [[ -z "$GIT_TAG" ]] && error "--tag requires a value"; shift ;;
+    --tag=*)    GIT_TAG="${1#--tag=}"; shift ;;
+    --rev)      shift; GIT_REV="${1:-}"; [[ -z "$GIT_REV" ]] && error "--rev requires a value"; shift ;;
+    --rev=*)    GIT_REV="${1#--rev=}"; shift ;;
+    --dry-run)  DRY_RUN=true; shift ;;
+    -y|--yes)   NON_INTERACTIVE=true; shift ;;
+    -h|--help)  usage ;;
+    --*)        error "unknown option: $1 (run with --help to see usage)" ;;
+    *)
+      if [[ -n "$TARGET" ]]; then
+        error "unexpected extra argument: $1 (target already set to: $TARGET)"
+      fi
+      TARGET="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ "$PATH_MODE" == true ]] && { [[ -n "$GIT_TAG" ]] || [[ -n "$GIT_REV" ]]; }; then
+  error "--path is a local-path source; --tag/--rev only apply to git mode"
+fi
+
+# Auto-detect non-interactive mode when stdin is not a TTY (agent/CI shells).
+if [[ "$NON_INTERACTIVE" != true ]] && [[ ! -t 0 ]]; then
+  NON_INTERACTIVE=true
+fi
+
+[[ -z "$TARGET" ]] && error "target repository path required (run with --help to see usage)"
+
+# ----- Stage 1: resolve KCT_ROOT (this installer's source checkout) ---------
+info "Stage 1: resolve kicad-tools source root"
+KCT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+[[ -f "$KCT_ROOT/pyproject.toml" ]] || error "source root missing pyproject.toml: $KCT_ROOT"
+SKILLS_SRC="$KCT_ROOT/.claude/commands/kct"
+[[ -d "$SKILLS_SRC" ]] || error "source root missing .claude/commands/kct/: $KCT_ROOT"
+ok "KCT_ROOT=$KCT_ROOT"
+
+# Extract kicad-tools version from the source pyproject.toml (first version =).
+KCT_VERSION="$(grep -m1 -E '^version[[:space:]]*=' "$KCT_ROOT/pyproject.toml" \
+  | sed -E 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')"
+[[ -n "$KCT_VERSION" ]] || error "could not extract version from $KCT_ROOT/pyproject.toml"
+ok "KCT_VERSION=$KCT_VERSION"
+
+# Source checkout short SHA (empty if not a git checkout — tolerated).
+KCT_COMMIT="$(git -C "$KCT_ROOT" rev-parse --short HEAD 2>/dev/null || echo "")"
+INSTALL_DATE="$(date +%Y-%m-%d)"
+KCT_GIT_URL="https://github.com/rjwalters/kicad-tools"
+
+# ----- Stage 2: resolve and validate TARGET ---------------------------------
+info "Stage 2: resolve and validate target"
+TARGET="${TARGET/#\~/$HOME}"
+[[ -d "$TARGET" ]] || error "target directory does not exist: $TARGET"
+TARGET="$(cd "$TARGET" && pwd)"
+ok "TARGET=$TARGET"
+
+if [[ "$TARGET" == "$KCT_ROOT" ]]; then
+  error "refusing to install kicad-tools into its own source checkout ($KCT_ROOT)"
+fi
+
+TARGET_PYPROJECT="$TARGET/pyproject.toml"
+if [[ ! -f "$TARGET_PYPROJECT" ]]; then
+  error "target has no pyproject.toml: $TARGET
+       kicad-tools installs as a uv dependency and requires a uv-managed
+       consumer repo. Run 'uv init' in the target first, then re-run."
+fi
+
+# ----- Stage 3: resolve source mode + ref -----------------------------------
+info "Stage 3: resolve source mode"
+if [[ "$PATH_MODE" == true ]]; then
+  PATH_DIR="${PATH_DIR/#\~/$HOME}"
+  [[ -d "$PATH_DIR" ]] || error "--path directory does not exist: $PATH_DIR"
+  RESOLVED_PATH="$(cd "$PATH_DIR" && pwd)"
+  [[ -f "$RESOLVED_PATH/pyproject.toml" ]] || error "--path is not a kicad-tools checkout (no pyproject.toml): $RESOLVED_PATH"
+  SOURCE_MODE="path"
+  SOURCE_REF="$RESOLVED_PATH"
+  # Record the path source's own short SHA when available.
+  PATH_COMMIT="$(git -C "$RESOLVED_PATH" rev-parse --short HEAD 2>/dev/null || echo "")"
+  [[ -n "$PATH_COMMIT" ]] && KCT_COMMIT="$PATH_COMMIT"
+  note "path mode: local source at $RESOLVED_PATH (network-free)"
+else
+  SOURCE_MODE="git"
+  # Default the git pin to the source version tag when neither --tag nor --rev
+  # was given, so a bare `install-kct.sh <target>` pins reproducibly.
+  if [[ -z "$GIT_TAG" && -z "$GIT_REV" ]]; then
+    GIT_TAG="v$KCT_VERSION"
+  fi
+  if [[ -n "$GIT_TAG" ]]; then
+    SOURCE_REF="$KCT_GIT_URL@$GIT_TAG"
+  else
+    SOURCE_REF="$KCT_GIT_URL@$GIT_REV"
+  fi
+  note "git mode: $SOURCE_REF"
+fi
+ok "source_mode=$SOURCE_MODE"
+
+# ----- Stage 4: enumerate + filter skills -----------------------------------
+info "Stage 4: enumerate source skills"
+# Glob *.md under the source skills dir at install time (Curator: never
+# hardcode the file list — Child 3 additions must be picked up automatically).
+# README.md documents the namespace and is always vendored; the remaining *.md
+# files are the selectable skills.
+ALL_SKILLS=()
+while IFS= read -r -d '' md; do
+  base="$(basename "$md" .md)"
+  [[ "$base" == "README" ]] && continue
+  ALL_SKILLS+=("$base")
+done < <(find "$SKILLS_SRC" -maxdepth 1 -name '*.md' -type f -print0 | LC_ALL=C sort -z)
+
+[[ ${#ALL_SKILLS[@]} -gt 0 ]] || error "no skills found under $SKILLS_SRC/*.md"
+note "available skills: ${ALL_SKILLS[*]}"
+
+SELECTED_SKILLS=()
+if [[ -n "$SKILLS_FILTER" ]]; then
+  IFS=',' read -r -a REQUESTED <<< "$SKILLS_FILTER"
+  for s in "${REQUESTED[@]}"; do
+    s="$(echo "$s" | tr -d '[:space:]')"
+    [[ -z "$s" ]] && continue
+    found=false
+    for avail in "${ALL_SKILLS[@]}"; do
+      [[ "$avail" == "$s" ]] && { found=true; break; }
+    done
+    $found || error "unknown skill: $s; available: ${ALL_SKILLS[*]}"
+    SELECTED_SKILLS+=("$s")
+  done
+  [[ ${#SELECTED_SKILLS[@]} -gt 0 ]] || error "--skills= was empty after filtering"
+else
+  SELECTED_SKILLS=("${ALL_SKILLS[@]}")
+fi
+ok "selected: ${SELECTED_SKILLS[*]}"
+
+# ----- Confirmation prompt --------------------------------------------------
+if [[ "$NON_INTERACTIVE" != true ]] && [[ "$DRY_RUN" != true ]]; then
+  echo ""
+  echo "About to install kicad-tools v$KCT_VERSION into: $TARGET"
+  echo "Source: $SOURCE_MODE ($SOURCE_REF)"
+  echo "Skills: ${SELECTED_SKILLS[*]}"
+  echo ""
+  read -r -p "Proceed? [y/N] " -n 1 reply
+  echo ""
+  [[ "$reply" =~ ^[Yy]$ ]] || { info "cancelled"; exit 0; }
+fi
+
+# ----- Helpers --------------------------------------------------------------
+# Run a write action, or print it under --dry-run.
+do_action() {
+  local desc="$1"; shift
+  if [[ "$DRY_RUN" == true ]]; then
+    echo "  [dry-run] $desc"
+  else
+    "$@"
+  fi
+}
+
+# Does the target pyproject.toml already declare a whole-word `kicad-tools`
+# dependency in [project.dependencies]? Matches the bare name at a value
+# boundary so `kicad-tools-extra` does not false-positive.
+target_declares_kct_dep() {
+  # A PEP 621 dependency entry looks like `"kicad-tools"` or
+  # `"kicad-tools @ ..."` or `"kicad-tools>=1.0"`; the name is always
+  # immediately after an opening quote and ends at a quote, space, or a
+  # version/marker operator. Anchor on the opening quote + name + a
+  # terminator that is NOT `-` (which would be part of a longer name).
+  grep -Eq '"kicad-tools([[:space:]]|"|[<>=!~@]|;)' "$TARGET_PYPROJECT"
+}
+
+# Does [tool.uv.sources] already carry a kicad-tools entry, and does it match
+# the requested source mode + ref? Echoes "match", "mismatch", or "absent".
+uv_source_state() {
+  local line
+  line="$(grep -E '^[[:space:]]*kicad-tools[[:space:]]*=' "$TARGET_PYPROJECT" | head -n1 || true)"
+  if [[ -z "$line" ]]; then
+    echo "absent"; return
+  fi
+  if [[ "$SOURCE_MODE" == "path" ]]; then
+    # uv records the path relative to the target's pyproject.toml, so compare
+    # by resolving whatever path uv wrote back to an absolute directory rather
+    # than string-matching the (possibly relative) literal.
+    local recorded
+    recorded="$(printf '%s' "$line" | sed -nE 's/.*path[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p')"
+    if [[ -n "$recorded" ]]; then
+      local abs
+      abs="$(cd "$TARGET" && cd "$recorded" 2>/dev/null && pwd || echo "")"
+      if [[ "$line" == *"path"* && "$abs" == "$RESOLVED_PATH" ]]; then
+        echo "match"; else echo "mismatch"; fi
+    else
+      echo "mismatch"
+    fi
+  else
+    # git mode: match on the URL and the specific tag/rev value.
+    local pin="${GIT_TAG:-$GIT_REV}"
+    if [[ "$line" == *"git"* && "$line" == *"$KCT_GIT_URL"* && "$line" == *"$pin"* ]]; then
+      echo "match"; else echo "mismatch"; fi
+  fi
+}
+
+# Build the uv add invocation for the resolved source mode.
+run_uv_add() {
+  if ! command -v uv >/dev/null 2>&1; then
+    error "uv not found on PATH but required to add the kicad-tools dependency"
+  fi
+  if [[ "$SOURCE_MODE" == "path" ]]; then
+    # Idiomatic uv path-dependency form: pass the directory itself as the
+    # package argument; uv detects the local pyproject.toml and records a
+    # path source under [tool.uv.sources]. --editable makes it an editable
+    # path install (sibling-repo dev workflow).
+    # --frozen writes the pyproject/[tool.uv.sources] entry WITHOUT resolving
+    # or syncing the environment — keeps path mode network-free (Epic #4054
+    # CI-no-network constraint). The operator runs `uv sync` afterwards.
+    ( cd "$TARGET" && uv add "$RESOLVED_PATH" --editable --frozen )
+  elif [[ -n "$GIT_TAG" ]]; then
+    ( cd "$TARGET" && uv add kicad-tools --git "$KCT_GIT_URL" --tag "$GIT_TAG" )
+  else
+    ( cd "$TARGET" && uv add kicad-tools --git "$KCT_GIT_URL" --rev "$GIT_REV" )
+  fi
+}
+
+# ----- Stage 5: add the kicad-tools uv dependency ---------------------------
+# Idempotency (Curator's 4-step algorithm): only call `uv add` when the dep is
+# absent OR present-but-pointing-at-a-different-source. If present and the
+# source entry already matches the requested mode/ref, no-op.
+info "Stage 5: kicad-tools uv dependency"
+if target_declares_kct_dep; then
+  case "$(uv_source_state)" in
+    match)
+      ok "kicad-tools dependency already present and up to date (no-op)"
+      ;;
+    mismatch)
+      warn "kicad-tools present but points at a different source; updating to $SOURCE_MODE"
+      do_action "uv add kicad-tools ($SOURCE_MODE: $SOURCE_REF) [update]" run_uv_add
+      ;;
+    absent)
+      note "kicad-tools listed in dependencies but no [tool.uv.sources] entry; adding source"
+      do_action "uv add kicad-tools ($SOURCE_MODE: $SOURCE_REF)" run_uv_add
+      ;;
+  esac
+else
+  do_action "uv add kicad-tools ($SOURCE_MODE: $SOURCE_REF)" run_uv_add
+fi
+
+# ----- Stage 6: vendor .claude/commands/kct/ skills -------------------------
+# Copy README.md (always) plus each selected skill's <name>.md. NEVER touch
+# .claude/commands/loom/ (coexist additively with Loom).
+info "Stage 6: vendor .claude/commands/kct/ skills"
+DST_SKILLS_DIR="$TARGET/.claude/commands/kct"
+VENDORED_FILES=()  # target-relative paths, for the metadata manifest.
+
+vendor_file() {
+  local src="$1" dst="$2"
+  mkdir -p "$(dirname "$dst")"
+  cp "$src" "$dst"
+  chmod 0644 "$dst"
+}
+
+# README.md is always vendored (documents the namespace convention).
+do_action "vendor .claude/commands/kct/README.md" \
+  vendor_file "$SKILLS_SRC/README.md" "$DST_SKILLS_DIR/README.md"
+VENDORED_FILES+=(".claude/commands/kct/README.md")
+
+for s in "${SELECTED_SKILLS[@]}"; do
+  do_action "vendor .claude/commands/kct/$s.md" \
+    vendor_file "$SKILLS_SRC/$s.md" "$DST_SKILLS_DIR/$s.md"
+  VENDORED_FILES+=(".claude/commands/kct/$s.md")
+done
+ok "vendored ${#VENDORED_FILES[@]} skill file(s)"
+
+# ----- Stage 7: guarded CLAUDE.md block -------------------------------------
+info "Stage 7: CLAUDE.md guarded block"
+CLAUDE_MD="$TARGET/CLAUDE.md"
+
+# The block literally carries the three load-bearing Epic #4054 conventions.
+# It must survive even if the target's CLAUDE.md diverges from ours, so the
+# substance is inlined, not linked.
+NEW_BLOCK="$KCT_MARK_BEGIN
+## kicad-tools ($KCT_VERSION)
+
+This repo uses [kicad-tools](https://github.com/rjwalters/kicad-tools) (\`kct\`)
+for PCB design/routing/DRC. Skills live under \`.claude/commands/kct/\` and are
+invoked as \`/kct:<name>\`. This block is managed by \`install-kct.sh\` — edit
+outside the markers only; re-running the installer replaces it in place.
+
+### Conventions (load-bearing — do not drop)
+1. **Build the C++ router backend after every fresh checkout/worktree.** Run
+   \`uv run kct build-native\` (verify with \`--check\`). \`uv sync\` alone does
+   NOT build the native extension; a missing backend makes routing 10-100x
+   slower (multi-minute-per-net).
+2. **Cross-gate DRC for manufacturing sign-off.** \`kct check\` alone is
+   insufficient — always also run \`kicad-cli pcb drc --refill-zones\`. \`kct check\`
+   can miss marginals (e.g. 0.1000 vs 0.1016 mm) and read stale zone fills.
+3. **Artifact-first.** The committed board artifact is shipping truth. A
+   \`generate_design.py\`/regeneration may diverge by design and is NOT
+   authoritative over a committed board.
+$KCT_MARK_END"
+
+merge_claude_md() {
+  if [[ ! -f "$CLAUDE_MD" ]]; then
+    printf '%s\n' "$NEW_BLOCK" > "$CLAUDE_MD"
+    return
+  fi
+
+  if grep -qF "$KCT_MARK_BEGIN" "$CLAUDE_MD"; then
+    # Replace the marked block in place. Pure-bash line rebuild (BSD-sed-safe;
+    # no GNU `sed -i`). Preserves everything outside the markers, including any
+    # Loom or Anvil block.
+    local tmp in_block=0 replaced=0
+    tmp="$(mktemp)"
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      if [[ "$in_block" -eq 0 ]]; then
+        if [[ "$line" == *"$KCT_MARK_BEGIN"* ]]; then
+          printf '%s\n' "$NEW_BLOCK" >> "$tmp"
+          in_block=1
+          replaced=1
+        else
+          printf '%s\n' "$line" >> "$tmp"
+        fi
+      else
+        if [[ "$line" == *"$KCT_MARK_END"* ]]; then
+          in_block=0
+        fi
+      fi
+    done < "$CLAUDE_MD"
+    if [[ "$replaced" -eq 0 ]]; then
+      rm -f "$tmp"
+      return 1
+    fi
+    mv "$tmp" "$CLAUDE_MD"
+    return
+  fi
+
+  # Existing CLAUDE.md, no kicad-tools markers: append after a blank line,
+  # preserving all existing content untouched.
+  local existing
+  existing="$(cat "$CLAUDE_MD")"
+  printf '%s\n\n%s\n' "${existing%$'\n'}" "$NEW_BLOCK" > "$CLAUDE_MD"
+}
+
+if [[ "$DRY_RUN" == true ]]; then
+  if [[ ! -f "$CLAUDE_MD" ]]; then
+    echo "  [dry-run] create CLAUDE.md with kicad-tools marker block"
+  elif grep -qF "$KCT_MARK_BEGIN" "$CLAUDE_MD"; then
+    echo "  [dry-run] replace existing kicad-tools block in CLAUDE.md (in place)"
+  else
+    echo "  [dry-run] append kicad-tools marker block to CLAUDE.md (preserves existing content)"
+  fi
+else
+  merge_claude_md
+  ok "CLAUDE.md updated"
+fi
+
+# ----- Stage 8: install metadata --------------------------------------------
+info "Stage 8: install metadata"
+METADATA_DIR="$TARGET/.kct"
+METADATA="$METADATA_DIR/install-metadata.json"
+
+write_metadata() {
+  mkdir -p "$METADATA_DIR"
+  # Emit skills_selected and installed_files as JSON arrays.
+  local skills_json files_json
+  skills_json="$(printf '%s\n' "${SELECTED_SKILLS[@]}" \
+    | awk 'BEGIN{printf "["} {printf "%s\"%s\"", (NR>1?", ":""), $0} END{printf "]"}')"
+  files_json="$(printf '%s\n' "${VENDORED_FILES[@]}" \
+    | awk 'BEGIN{printf "["} {printf "%s\"%s\"", (NR>1?", ":""), $0} END{printf "]"}')"
+  cat > "$METADATA" <<META_EOF
+{
+  "kct_version": "$KCT_VERSION",
+  "kct_commit": "$KCT_COMMIT",
+  "install_date": "$INSTALL_DATE",
+  "source_mode": "$SOURCE_MODE",
+  "source_ref": "$SOURCE_REF",
+  "skills_selected": $skills_json,
+  "installed_files": $files_json
+}
+META_EOF
+}
+
+do_action "write .kct/install-metadata.json" write_metadata
+[[ "$DRY_RUN" == true ]] || ok "wrote $METADATA"
+
+# ----- Summary --------------------------------------------------------------
+echo ""
+if [[ "$DRY_RUN" == true ]]; then
+  info "dry-run complete — no files written to $TARGET"
+else
+  info "kicad-tools v$KCT_VERSION installed into $TARGET"
+  note "source: $SOURCE_MODE ($SOURCE_REF)"
+  note "skills: ${SELECTED_SKILLS[*]}"
+  note "next: run 'uv sync' in the target, then 'uv run kct build-native' (see the CLAUDE.md block)"
+fi

--- a/scripts/install-kct.sh
+++ b/scripts/install-kct.sh
@@ -385,6 +385,34 @@ outside the markers only; re-running the installer replaces it in place.
    authoritative over a committed board.
 $KCT_MARK_END"
 
+# Validate the kicad-tools marker structure of a CLAUDE.md. Echoes a
+# human-readable reason and returns non-zero when the markers are malformed
+# (unterminated BEGIN, or an END that appears before its BEGIN). Shared by the
+# real merge and the --dry-run preview so both agree on what will happen.
+#
+# A malformed file MUST NOT be edited: an unterminated BEGIN would cause every
+# line after it to be silently dropped, then clobber the original on `mv`.
+claude_md_marker_error() {
+  local file="$1"
+  local line depth=0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ "$line" == *"$KCT_MARK_BEGIN"* ]]; then
+      depth=$((depth + 1))
+    elif [[ "$line" == *"$KCT_MARK_END"* ]]; then
+      if [[ "$depth" -eq 0 ]]; then
+        echo "CLAUDE.md has an $KCT_MARK_END before any $KCT_MARK_BEGIN; refusing to edit — fix the markers and re-run"
+        return 1
+      fi
+      depth=$((depth - 1))
+    fi
+  done < "$file"
+  if [[ "$depth" -ne 0 ]]; then
+    echo "CLAUDE.md has an unterminated $KCT_MARK_BEGIN block (no $KCT_MARK_END marker); refusing to edit — fix the markers and re-run"
+    return 1
+  fi
+  return 0
+}
+
 merge_claude_md() {
   if [[ ! -f "$CLAUDE_MD" ]]; then
     printf '%s\n' "$NEW_BLOCK" > "$CLAUDE_MD"
@@ -392,6 +420,12 @@ merge_claude_md() {
   fi
 
   if grep -qF "$KCT_MARK_BEGIN" "$CLAUDE_MD"; then
+    # Abort on a malformed target rather than risk silent data loss.
+    local marker_err
+    if ! marker_err="$(claude_md_marker_error "$CLAUDE_MD")"; then
+      error "$marker_err"
+    fi
+
     # Replace the marked block in place. Pure-bash line rebuild (BSD-sed-safe;
     # no GNU `sed -i`). Preserves everything outside the markers, including any
     # Loom or Anvil block.
@@ -431,6 +465,7 @@ if [[ "$DRY_RUN" == true ]]; then
   if [[ ! -f "$CLAUDE_MD" ]]; then
     echo "  [dry-run] create CLAUDE.md with kicad-tools marker block"
   elif grep -qF "$KCT_MARK_BEGIN" "$CLAUDE_MD"; then
+    marker_err="$(claude_md_marker_error "$CLAUDE_MD")" || error "$marker_err"
     echo "  [dry-run] replace existing kicad-tools block in CLAUDE.md (in place)"
   else
     echo "  [dry-run] append kicad-tools marker block to CLAUDE.md (preserves existing content)"

--- a/tests/install/test_install_kct.py
+++ b/tests/install/test_install_kct.py
@@ -244,6 +244,81 @@ def test_loom_dir_untouched(target_repo: Path, fake_uv_env: dict[str, str]) -> N
     assert loom_file.read_bytes() == before, "installer must never touch loom skills"
 
 
+# --- malformed CLAUDE.md markers: error, never silent data loss --------------
+
+
+def test_unterminated_begin_marker_errors_without_data_loss(
+    target_repo: Path, fake_uv_env: dict[str, str]
+) -> None:
+    """A BEGIN with no matching END must abort and leave the file byte-unchanged.
+
+    Regression for the PR #4062 judge finding: the in-place line rebuild dropped
+    every line after a stale BEGIN (in_block never cleared), then clobbered the
+    original — silent data loss on exit 0.
+    """
+    claude = target_repo / "CLAUDE.md"
+    claude.write_text(
+        "# My Repo\n"
+        "IMPORTANT USER CONTENT\n"
+        "<!-- BEGIN KICAD-TOOLS -->\n"
+        "stale half block\n"
+        "MORE IMPORTANT CONTENT AFTER STALE BEGIN\n"
+    )
+    before = claude.read_bytes()
+
+    result = run_installer(target_repo, "--path", str(REPO_ROOT), env=fake_uv_env)
+
+    assert result.returncode != 0, "unterminated BEGIN must fail, not exit 0"
+    assert "unterminated" in result.stderr.lower()
+    assert claude.read_bytes() == before, "malformed target must be byte-unchanged"
+
+
+def test_unterminated_begin_marker_dry_run_errors(
+    target_repo: Path, fake_uv_env: dict[str, str]
+) -> None:
+    """--dry-run must surface the malformed-marker error, not report an in-place replace."""
+    claude = target_repo / "CLAUDE.md"
+    claude.write_text("# My Repo\n<!-- BEGIN KICAD-TOOLS -->\nstale half block\nUSER CONTENT\n")
+    before = claude.read_bytes()
+
+    result = run_installer(target_repo, "--dry-run", "--path", str(REPO_ROOT), env=fake_uv_env)
+
+    assert result.returncode != 0
+    assert "unterminated" in result.stderr.lower()
+    assert "replace existing kicad-tools block" not in result.stdout
+    assert claude.read_bytes() == before
+
+
+def test_end_before_begin_marker_errors_without_data_loss(
+    target_repo: Path, fake_uv_env: dict[str, str]
+) -> None:
+    """Inverse malformation (END before BEGIN): also errors out, file unchanged.
+
+    Documented behavior: an END that precedes its BEGIN is treated as malformed
+    and aborts (the grep gate still fires because a BEGIN exists later). Either
+    an error or a safe no-op is acceptable per the issue; we choose to error so
+    the operator fixes the markers. Never silent corruption.
+    """
+    claude = target_repo / "CLAUDE.md"
+    claude.write_text(
+        "# My Repo\n"
+        "USER CONTENT ABOVE\n"
+        "<!-- END KICAD-TOOLS -->\n"
+        "USER CONTENT BETWEEN\n"
+        "<!-- BEGIN KICAD-TOOLS -->\n"
+        "block body\n"
+        "<!-- END KICAD-TOOLS -->\n"
+    )
+    before = claude.read_bytes()
+
+    result = run_installer(target_repo, "--path", str(REPO_ROOT), env=fake_uv_env)
+
+    assert result.returncode != 0
+    err = result.stderr.lower()
+    assert "before any" in err or "unterminated" in err
+    assert claude.read_bytes() == before
+
+
 # --- skill selection ---------------------------------------------------------
 
 

--- a/tests/install/test_install_kct.py
+++ b/tests/install/test_install_kct.py
@@ -1,0 +1,296 @@
+"""Tests for scripts/install-kct.sh (Installer MVP, issue #4055).
+
+These drive a throwaway ``git init``-ed target repo through the installer's
+dry-run, real path-mode install, idempotent re-run, skill-selection, and
+loom-coexistence paths (see the issue's Acceptance / Test Plan).
+
+Hermeticity: the tests stub ``uv`` with a fake on PATH that emulates
+``uv add``'s pyproject/[tool.uv.sources] write-back. This keeps the suite
+network-free and fast in CI while still exercising the installer's real
+idempotency logic (existing-dependency detection, marker-block replacement,
+metadata emission) against the resulting pyproject content -- exactly the
+"git-mode dep addition asserted on pyproject content rather than resolved"
+approach the issue calls for.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALLER = REPO_ROOT / "scripts" / "install-kct.sh"
+SKILLS_SRC = REPO_ROOT / ".claude" / "commands" / "kct"
+
+
+# --- fake uv -----------------------------------------------------------------
+# Emulates just enough of `uv add <path> --editable --frozen` to write the
+# dependency + [tool.uv.sources] path entry the installer's idempotency logic
+# reads back. No venv, no network, no resolution.
+FAKE_UV = r"""#!/usr/bin/env bash
+set -euo pipefail
+# We only implement: uv add <path-or-name> [--editable] [--frozen] [--git URL]
+#                    [--tag T] [--rev R]
+[[ "${1:-}" == "add" ]] || { echo "fake-uv: only 'add' is stubbed" >&2; exit 2; }
+shift
+PKG=""
+IS_GIT=false
+GIT_URL=""
+PIN=""
+PATH_SRC=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --editable|--frozen) shift ;;
+    --git) IS_GIT=true; GIT_URL="$2"; shift 2 ;;
+    --tag|--rev) PIN="$2"; shift 2 ;;
+    -*) shift ;;
+    *) PKG="$1"; shift ;;
+  esac
+done
+PYPROJECT="pyproject.toml"
+[[ -f "$PYPROJECT" ]] || { echo "fake-uv: no pyproject.toml" >&2; exit 1; }
+
+python3 - "$PYPROJECT" "$PKG" "$IS_GIT" "$GIT_URL" "$PIN" <<'PYEOF'
+import re, sys
+pyproject, pkg, is_git, git_url, pin = sys.argv[1:6]
+text = open(pyproject).read()
+
+# 1. Ensure "kicad-tools" is in [project.dependencies] exactly once.
+if '"kicad-tools"' not in text and '"kicad-tools ' not in text:
+    m = re.search(r'(dependencies\s*=\s*\[)(.*?)(\])', text, re.S)
+    if m:
+        head, body, tail = m.groups()
+        entry = '\n    "kicad-tools",'
+        text = text[:m.start()] + head + body.rstrip() + entry + "\n" + tail + text[m.end():]
+
+# 2. Compute the [tool.uv.sources] entry line.
+if is_git == "true":
+    key = "tag" if pin else "rev"  # test passes tag by convention
+    src = f'kicad-tools = {{ git = "{git_url}", {key} = "{pin}" }}'
+else:
+    # path mode: pkg is an absolute path; record it verbatim (installer
+    # resolves it back to absolute, so verbatim absolute is fine for the test).
+    src = f'kicad-tools = {{ path = "{pkg}", editable = true }}'
+
+if "[tool.uv.sources]" in text:
+    # replace any existing kicad-tools = line, else append under the table.
+    lines = text.splitlines()
+    out, in_sources, replaced = [], False, False
+    for ln in lines:
+        if ln.strip() == "[tool.uv.sources]":
+            in_sources = True
+            out.append(ln)
+            continue
+        if in_sources and ln.strip().startswith("kicad-tools"):
+            out.append(src)
+            replaced = True
+            continue
+        if in_sources and ln.startswith("[") and ln.strip() != "[tool.uv.sources]":
+            if not replaced:
+                out.append(src)
+                replaced = True
+            in_sources = False
+        out.append(ln)
+    if not replaced:
+        out.append(src)
+    text = "\n".join(out) + "\n"
+else:
+    text = text.rstrip() + f"\n\n[tool.uv.sources]\n{src}\n"
+
+open(pyproject, "w").write(text)
+PYEOF
+"""
+
+
+@pytest.fixture
+def fake_uv_env(tmp_path: Path) -> dict[str, str]:
+    """A PATH-front-loaded env whose ``uv`` is the stub above."""
+    bindir = tmp_path / "fakebin"
+    bindir.mkdir()
+    uv = bindir / "uv"
+    uv.write_text(FAKE_UV)
+    uv.chmod(0o755)
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}{os.pathsep}{env['PATH']}"
+    return env
+
+
+@pytest.fixture
+def target_repo(tmp_path: Path) -> Path:
+    """A throwaway git repo with a minimal uv-style pyproject + CLAUDE.md."""
+    target = tmp_path / "board-repo"
+    target.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=target, check=True)
+    (target / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "board-repo"\n'
+        'version = "0.1.0"\n'
+        'requires-python = ">=3.10"\n'
+        "dependencies = []\n"
+    )
+    (target / "CLAUDE.md").write_text("# Board Repo\n\nExisting content stays.\n")
+    # Seed a loom skill to prove the installer never touches it.
+    loom = target / ".claude" / "commands" / "loom"
+    loom.mkdir(parents=True)
+    (loom / "seed.md").write_text("LOOM SEED — DO NOT TOUCH\n")
+    return target
+
+
+def run_installer(
+    target: Path, *args: str, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(INSTALLER), *args, str(target)],
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        env=env,
+    )
+
+
+def _snapshot(target: Path) -> dict[str, str]:
+    return {
+        str(p.relative_to(target)): p.read_text(errors="replace")
+        for p in target.rglob("*")
+        if p.is_file() and ".git" not in p.parts
+    }
+
+
+# --- dry-run: writes nothing -------------------------------------------------
+
+
+def test_dry_run_writes_nothing(target_repo: Path, fake_uv_env: dict[str, str]) -> None:
+    before = _snapshot(target_repo)
+    result = run_installer(target_repo, "--dry-run", "--path", str(REPO_ROOT), env=fake_uv_env)
+    assert result.returncode == 0, result.stderr
+    assert _snapshot(target_repo) == before, "dry-run must not modify any file"
+    assert not (target_repo / ".kct").exists()
+    assert not (target_repo / ".claude" / "commands" / "kct").exists()
+    assert "dry-run" in result.stdout
+
+
+# --- real path-mode install --------------------------------------------------
+
+
+def test_path_install_produces_all_artifacts(
+    target_repo: Path, fake_uv_env: dict[str, str]
+) -> None:
+    result = run_installer(target_repo, "--path", str(REPO_ROOT), env=fake_uv_env)
+    assert result.returncode == 0, result.stderr
+
+    # Dependency + path source in pyproject.
+    pyproject = (target_repo / "pyproject.toml").read_text()
+    assert '"kicad-tools"' in pyproject
+    assert "[tool.uv.sources]" in pyproject
+    assert "path" in pyproject.split("[tool.uv.sources]", 1)[1]
+
+    # Vendored skills byte-identical to source.
+    for name in ("README.md", "ee-review.md"):
+        dst = target_repo / ".claude" / "commands" / "kct" / name
+        assert dst.exists()
+        assert dst.read_bytes() == (SKILLS_SRC / name).read_bytes()
+
+    # Exactly one guarded CLAUDE.md block, all three conventions present.
+    claude = (target_repo / "CLAUDE.md").read_text()
+    assert claude.count("<!-- BEGIN KICAD-TOOLS -->") == 1
+    assert claude.count("<!-- END KICAD-TOOLS -->") == 1
+    assert "build-native" in claude
+    assert "refill-zones" in claude
+    assert "Artifact-first" in claude
+    assert "Existing content stays." in claude  # pre-existing content preserved
+
+    # Metadata is valid JSON with the schema fields.
+    meta = json.loads((target_repo / ".kct" / "install-metadata.json").read_text())
+    assert meta["kct_version"]
+    assert meta["source_mode"] == "path"
+    assert meta["source_ref"] == str(REPO_ROOT)
+    assert "ee-review" in meta["skills_selected"]
+    assert ".claude/commands/kct/ee-review.md" in meta["installed_files"]
+    assert ".claude/commands/kct/README.md" in meta["installed_files"]
+
+
+# --- idempotent re-run -------------------------------------------------------
+
+
+def test_rerun_is_idempotent(target_repo: Path, fake_uv_env: dict[str, str]) -> None:
+    first = run_installer(target_repo, "--path", str(REPO_ROOT), env=fake_uv_env)
+    assert first.returncode == 0, first.stderr
+    second = run_installer(target_repo, "--path", str(REPO_ROOT), env=fake_uv_env)
+    assert second.returncode == 0, second.stderr
+
+    pyproject = (target_repo / "pyproject.toml").read_text()
+    assert pyproject.count('"kicad-tools"') == 1, "dependency must not duplicate"
+
+    claude = (target_repo / "CLAUDE.md").read_text()
+    assert claude.count("<!-- BEGIN KICAD-TOOLS -->") == 1
+    assert claude.count("<!-- END KICAD-TOOLS -->") == 1
+
+    # The second run must recognize the up-to-date dependency and no-op it.
+    assert "already present and up to date" in second.stdout
+
+
+# --- loom coexistence --------------------------------------------------------
+
+
+def test_loom_dir_untouched(target_repo: Path, fake_uv_env: dict[str, str]) -> None:
+    loom_file = target_repo / ".claude" / "commands" / "loom" / "seed.md"
+    before = loom_file.read_bytes()
+    result = run_installer(target_repo, "--path", str(REPO_ROOT), env=fake_uv_env)
+    assert result.returncode == 0, result.stderr
+    assert loom_file.read_bytes() == before, "installer must never touch loom skills"
+
+
+# --- skill selection ---------------------------------------------------------
+
+
+def test_skills_filter_selects_named_skill(target_repo: Path, fake_uv_env: dict[str, str]) -> None:
+    result = run_installer(
+        target_repo, "--skills=ee-review", "--path", str(REPO_ROOT), env=fake_uv_env
+    )
+    assert result.returncode == 0, result.stderr
+    kct_dir = target_repo / ".claude" / "commands" / "kct"
+    assert (kct_dir / "ee-review.md").exists()
+    # README is always vendored (documents the namespace).
+    assert (kct_dir / "README.md").exists()
+    meta = json.loads((target_repo / ".kct" / "install-metadata.json").read_text())
+    assert meta["skills_selected"] == ["ee-review"]
+
+
+def test_unknown_skill_errors(target_repo: Path, fake_uv_env: dict[str, str]) -> None:
+    result = run_installer(
+        target_repo, "--skills=does-not-exist", "--path", str(REPO_ROOT), env=fake_uv_env
+    )
+    assert result.returncode != 0
+    assert "unknown skill" in result.stderr
+
+
+# --- prerequisite failure ----------------------------------------------------
+
+
+def test_missing_pyproject_fails_clearly(tmp_path: Path, fake_uv_env: dict[str, str]) -> None:
+    target = tmp_path / "no-pyproject"
+    target.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=target, check=True)
+    result = run_installer(target, "--path", str(REPO_ROOT), env=fake_uv_env)
+    assert result.returncode != 0
+    assert "no pyproject.toml" in result.stderr
+
+
+# --- git mode (asserted on pyproject content, no network) --------------------
+
+
+def test_git_mode_writes_git_source(target_repo: Path, fake_uv_env: dict[str, str]) -> None:
+    result = run_installer(target_repo, "--tag", "v0.14.0", env=fake_uv_env)
+    assert result.returncode == 0, result.stderr
+    pyproject = (target_repo / "pyproject.toml").read_text()
+    assert '"kicad-tools"' in pyproject
+    src = pyproject.split("[tool.uv.sources]", 1)[1]
+    assert "git" in src
+    assert "rjwalters/kicad-tools" in src
+    assert "v0.14.0" in src
+    meta = json.loads((target_repo / ".kct" / "install-metadata.json").read_text())
+    assert meta["source_mode"] == "git"


### PR DESCRIPTION
Closes #4055 (child of Epic #4054).

## What
Ships `scripts/install-kct.sh`, the kicad-tools consumer-repo installer, per the owner-confirmed **uv-dependency + vendored-skills** model (Anvil's model, not Loom's full-vendoring).

### Installer behavior
- **uv dependency**: git source by default (pins to `v<version>` tag; `--tag`/`--rev` override), or a **network-free editable path source** via the installer's own `--path <dir>` flag. Path mode uses `uv add <dir> --editable --frozen`, so it writes the `pyproject.toml` + `[tool.uv.sources]` entry without resolving/syncing (offline, CI-safe).
- **Vendors `.claude/commands/kct/*.md`** — globbed at install time (Child 3's future skills are picked up automatically; no hardcoded list). README is always vendored. **Never touches `.claude/commands/loom/`** (coexists additively with Loom).
- **Guarded CLAUDE.md block** — idempotent `<!-- BEGIN KICAD-TOOLS -->` / `<!-- END KICAD-TOOLS -->` markers, replaced in place via a BSD-sed-safe pure-bash line rebuild (no GNU `sed -i`). The block literally carries the three load-bearing Epic #4054 conventions: build-native-after-checkout, the `kicad-cli pcb drc --refill-zones` cross-gate rule, and artifact-first.
- **`.kct/install-metadata.json`** — modeled on Loom's schema (`kct_version`, `kct_commit`, `install_date`, `source_mode`, `source_ref`, `skills_selected`, `installed_files`) for a future uninstaller/upgrade-detector.
- **`--dry-run`** prints every planned write, writes nothing.

### Dependency idempotency (curated 4-step algorithm)
Whole-word `kicad-tools` detection (no false-positive on `kicad-tools-extra`), source-mode/ref match check (path entries resolved back to absolute before comparing, since uv records a relative path), and a genuine no-op ("already present and up to date") when nothing changed.

## Tests — `tests/install/test_install_kct.py`
Drives a `tmp_path` git repo through: dry-run (no writes), path-mode install (dep + source + byte-identical skills + single CLAUDE block with all three conventions + valid metadata JSON), idempotent rerun (single block, no dep duplication, dep no-op), loom-coexistence (loom skill byte-unchanged), skill selection + unknown-skill error, missing-pyproject failure, and git-mode source write. **Hermetic**: `uv` is stubbed on PATH, so the suite is network-free.

```
8 passed in 2.05s
```

## Checks
- `uv run pytest tests/install/` — 8 passed
- `uv run ruff check` / `ruff format --check` on touched files — clean
- `shellcheck scripts/install-kct.sh` — clean

## Deferred (per issue non-goals)
- PyPI publishing, full package vendoring (Loom's model, rejected).
- CI gates (Child 2) and skill *content* (Child 3) — this child ships the mechanism.
- Non-uv target repos: `install-kct.sh` fails with a clear "no pyproject.toml" error rather than running `uv init` (documented in `--help`; out of the MVP happy path per the curated uv-mechanics point 4).
- Git-mode network resolution is not exercised live in tests (asserted on pyproject content via the uv stub, per the issue's CI-no-network constraint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)