### PR TITLE
feat(install): vendor portable CI gates into consumer .kct/ci/

### DIFF
--- a/scripts/install-kct.sh
+++ b/scripts/install-kct.sh
@@ -7,10 +7,17 @@
 #      (git source by default, local path source with --path <dir>).
 #   2. Vendors .claude/commands/kct/*.md skills into the target (NEVER touches
 #      .claude/commands/loom/ — coexists additively with Loom).
-#   3. Appends a guarded, idempotent <!-- BEGIN KICAD-TOOLS --> block to the
+#   3. Vendors the portable CI gate scripts (scripts/ci/check_copper_lvs.py,
+#      check_routed_drc.py, net_class_map_resolver.py) into the target's
+#      .kct/ci/ (Epic #4054 Child 2, #4056). These are stdlib+yaml only, take
+#      the board path as a CLI argument, and gate copper-LVS / routed-DRC in
+#      the consumer's own CI. Copied verbatim as a sibling triple so
+#      check_routed_drc.py's local `from net_class_map_resolver import ...`
+#      (a sys.path insert relative to the script's own dir) still resolves.
+#   4. Appends a guarded, idempotent <!-- BEGIN KICAD-TOOLS --> block to the
 #      target's CLAUDE.md carrying the three hard-won Epic #4054 conventions.
-#   4. Writes .kct/install-metadata.json for a future uninstaller/upgrader.
-#   5. --dry-run prints every planned write and writes nothing.
+#   5. Writes .kct/install-metadata.json for a future uninstaller/upgrader.
+#   6. --dry-run prints every planned write and writes nothing.
 #
 # Usage:
 #   ./scripts/install-kct.sh [OPTIONS] <target-repo>
@@ -127,7 +134,23 @@ KCT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 [[ -f "$KCT_ROOT/pyproject.toml" ]] || error "source root missing pyproject.toml: $KCT_ROOT"
 SKILLS_SRC="$KCT_ROOT/.claude/commands/kct"
 [[ -d "$SKILLS_SRC" ]] || error "source root missing .claude/commands/kct/: $KCT_ROOT"
+CI_GATES_SRC="$KCT_ROOT/scripts/ci"
+[[ -d "$CI_GATES_SRC" ]] || error "source root missing scripts/ci/: $KCT_ROOT"
 ok "KCT_ROOT=$KCT_ROOT"
+
+# The portable CI gate scripts vendored into the consumer's .kct/ci/ (#4056).
+# This list is DELIBERATELY explicit, not a glob: only these three gates are
+# consumer-generic (stdlib+yaml, CLI-arg-driven, no boards/ assumption). The
+# board-specific / repo-internal gates in scripts/ci/ (check_board_00_e2e.py,
+# check_board_05_blocking.py, check_diffpair_coverage.py, etc.) are NOT vendored.
+# They are copied verbatim as a sibling triple: check_routed_drc.py imports
+# net_class_map_resolver via a sys.path insert relative to its OWN directory,
+# so the three must land together in one dir for that import to resolve.
+CI_GATE_FILES=(
+  "check_copper_lvs.py"
+  "check_routed_drc.py"
+  "net_class_map_resolver.py"
+)
 
 # Extract kicad-tools version from the source pyproject.toml (first version =).
 KCT_VERSION="$(grep -m1 -E '^version[[:space:]]*=' "$KCT_ROOT/pyproject.toml" \
@@ -357,6 +380,87 @@ for s in "${SELECTED_SKILLS[@]}"; do
 done
 ok "vendored ${#VENDORED_FILES[@]} skill file(s)"
 
+# ----- Stage 6b: vendor portable CI gate scripts (#4056) --------------------
+# Copy the three consumer-generic gates verbatim into .kct/ci/ as a sibling
+# triple. Executable (chmod 0755) so a consumer can invoke them directly; also
+# recorded in installed_files for the upgrader. Re-running the installer
+# overwrites them from the (possibly newer) source checkout — the documented
+# `uv lock --upgrade` + re-run refresh path (no separate versioning scheme).
+info "Stage 6b: vendor portable CI gate scripts into .kct/ci/"
+DST_CI_DIR="$TARGET/.kct/ci"
+
+vendor_ci_gate() {
+  local src="$1" dst="$2"
+  mkdir -p "$(dirname "$dst")"
+  cp "$src" "$dst"
+  chmod 0755 "$dst"
+}
+
+for gate in "${CI_GATE_FILES[@]}"; do
+  [[ -f "$CI_GATES_SRC/$gate" ]] || error "source CI gate missing: $CI_GATES_SRC/$gate"
+  do_action "vendor .kct/ci/$gate" \
+    vendor_ci_gate "$CI_GATES_SRC/$gate" "$DST_CI_DIR/$gate"
+  VENDORED_FILES+=(".kct/ci/$gate")
+done
+# Ship a short README next to the gates documenting the consumer-side
+# invocation (path-as-CLI-arg, --allow N instead of the repo-internal allowlist).
+CI_README_DST="$DST_CI_DIR/README.md"
+write_ci_readme() {
+  mkdir -p "$DST_CI_DIR"
+  cat > "$CI_README_DST" <<'CI_README_EOF'
+# Portable kicad-tools CI gates (`.kct/ci/`)
+
+These scripts are vendored by `install-kct.sh` (kicad-tools Epic #4054,
+Child #4056). They are copies of `scripts/ci/*.py` from the kicad-tools
+source repo — **installer-managed**: re-running `install-kct.sh` (the
+`uv lock --upgrade` + re-run upgrade path) overwrites them. Edit the
+upstream originals, not these copies.
+
+They are stdlib + `yaml` only (no `kicad_tools` import) and take the board
+path as a CLI argument, so they run against **your** board path — there is
+no `boards/` assumption.
+
+## `check_copper_lvs.py` — copper-LVS gate
+
+Run the checker from the `kicad_tools` package (available via the uv
+dependency) to emit a JSON verdict, then gate on it:
+
+```bash
+uv run python -m kicad_tools.lvs.copper_lvs \
+  hardware/<your-board>/<board>.kicad_sch \
+  hardware/<your-board>/output/<board>_routed.kicad_pcb \
+  > /tmp/copper-lvs.json
+uv run python .kct/ci/check_copper_lvs.py /tmp/copper-lvs.json
+```
+
+Exit `0` = clean, `2` = a short/open was found, `1` = usage/tool error.
+
+## `check_routed_drc.py` — routed-DRC blocking-error gate
+
+Pass your routed `*.kicad_pcb` path(s). Use `--allow N` to set the tolerance
+explicitly. Do **not** rely on the default `--allowlist`
+(`.github/routed-drc-tolerance.yml`) — that is the kicad-tools repo's own
+per-board grandfather list and does not exist in a fresh consumer repo.
+
+```bash
+# Fail on any blocking DRC error (fresh repo, no grandfathered history):
+uv run python .kct/ci/check_routed_drc.py \
+  hardware/<your-board>/output/<board>_routed.kicad_pcb \
+  --allow 0
+```
+
+Exit `0` = within tolerance, `2` = exceeded (job fails), `1` = tool error.
+Passing zero files is a no-op that exits `0` (a first CI run with no changed
+`*_routed.kicad_pcb` files passes).
+
+`net_class_map_resolver.py` is a dependency of `check_routed_drc.py`; keep
+all three files together in this directory so its sibling import resolves.
+CI_README_EOF
+}
+do_action "write .kct/ci/README.md" write_ci_readme
+VENDORED_FILES+=(".kct/ci/README.md")
+ok "vendored ${#CI_GATE_FILES[@]} CI gate script(s) + README into .kct/ci/"
+
 # ----- Stage 7: guarded CLAUDE.md block -------------------------------------
 info "Stage 7: CLAUDE.md guarded block"
 CLAUDE_MD="$TARGET/CLAUDE.md"
@@ -369,8 +473,10 @@ NEW_BLOCK="$KCT_MARK_BEGIN
 
 This repo uses [kicad-tools](https://github.com/rjwalters/kicad-tools) (\`kct\`)
 for PCB design/routing/DRC. Skills live under \`.claude/commands/kct/\` and are
-invoked as \`/kct:<name>\`. This block is managed by \`install-kct.sh\` — edit
-outside the markers only; re-running the installer replaces it in place.
+invoked as \`/kct:<name>\`. Portable CI gates (copper-LVS, routed-DRC) live under
+\`.kct/ci/\` — see \`.kct/ci/README.md\` for consumer-side invocation. This block
+is managed by \`install-kct.sh\` — edit outside the markers only; re-running the
+installer replaces it in place.
 
 ### Conventions (load-bearing — do not drop)
 1. **Build the C++ router backend after every fresh checkout/worktree.** Run

--- a/tests/install/test_install_kct.py
+++ b/tests/install/test_install_kct.py
@@ -25,6 +25,15 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[2]
 INSTALLER = REPO_ROOT / "scripts" / "install-kct.sh"
 SKILLS_SRC = REPO_ROOT / ".claude" / "commands" / "kct"
+CI_GATES_SRC = REPO_ROOT / "scripts" / "ci"
+
+# The three portable CI gates vendored into the consumer's .kct/ci/ (#4056).
+# Must stay in sync with CI_GATE_FILES in scripts/install-kct.sh.
+VENDORED_CI_GATES = (
+    "check_copper_lvs.py",
+    "check_routed_drc.py",
+    "net_class_map_resolver.py",
+)
 
 
 # --- fake uv -----------------------------------------------------------------
@@ -369,3 +378,137 @@ def test_git_mode_writes_git_source(target_repo: Path, fake_uv_env: dict[str, st
     assert "v0.14.0" in src
     meta = json.loads((target_repo / ".kct" / "install-metadata.json").read_text())
     assert meta["source_mode"] == "git"
+
+
+# --- portable CI gates vendored into .kct/ci/ (#4056) ------------------------
+
+
+def test_ci_gates_vendored_byte_identical_and_executable(
+    target_repo: Path, fake_uv_env: dict[str, str]
+) -> None:
+    """The 3 portable gates land in .kct/ci/, byte-identical + executable."""
+    result = run_installer(target_repo, "--path", str(REPO_ROOT), env=fake_uv_env)
+    assert result.returncode == 0, result.stderr
+
+    ci_dir = target_repo / ".kct" / "ci"
+    for name in VENDORED_CI_GATES:
+        dst = ci_dir / name
+        assert dst.exists(), f"{name} not vendored into .kct/ci/"
+        assert dst.read_bytes() == (CI_GATES_SRC / name).read_bytes(), (
+            f"{name} must be a verbatim copy of scripts/ci/{name}"
+        )
+        # Executable so a consumer can invoke the gate directly.
+        assert dst.stat().st_mode & 0o111, f"{name} must be executable"
+
+    # A README documenting consumer-side invocation ships alongside the gates.
+    readme = ci_dir / "README.md"
+    assert readme.exists()
+    readme_text = readme.read_text()
+    assert "--allow" in readme_text, "README must document the --allow N pattern"
+    assert "check_copper_lvs.py" in readme_text
+    assert "check_routed_drc.py" in readme_text
+
+
+def test_ci_gates_not_over_vendored(target_repo: Path, fake_uv_env: dict[str, str]) -> None:
+    """Repo-internal / board-specific gates must NOT be vendored."""
+    result = run_installer(target_repo, "--path", str(REPO_ROOT), env=fake_uv_env)
+    assert result.returncode == 0, result.stderr
+    ci_dir = target_repo / ".kct" / "ci"
+    for excluded in (
+        "check_board_00_e2e.py",
+        "check_board_05_blocking.py",
+        "check_diffpair_coverage.py",
+        "check_matchgroup_coverage.py",
+    ):
+        assert not (ci_dir / excluded).exists(), f"{excluded} must not be vendored"
+
+
+def test_ci_gates_recorded_in_metadata(target_repo: Path, fake_uv_env: dict[str, str]) -> None:
+    """install-metadata.json installed_files lists every vendored gate + README."""
+    result = run_installer(target_repo, "--path", str(REPO_ROOT), env=fake_uv_env)
+    assert result.returncode == 0, result.stderr
+    meta = json.loads((target_repo / ".kct" / "install-metadata.json").read_text())
+    for name in VENDORED_CI_GATES:
+        assert f".kct/ci/{name}" in meta["installed_files"]
+    assert ".kct/ci/README.md" in meta["installed_files"]
+
+
+def test_ci_gates_dry_run_writes_nothing(target_repo: Path, fake_uv_env: dict[str, str]) -> None:
+    """--dry-run must not create .kct/ci/ or any gate file."""
+    result = run_installer(target_repo, "--dry-run", "--path", str(REPO_ROOT), env=fake_uv_env)
+    assert result.returncode == 0, result.stderr
+    assert not (target_repo / ".kct" / "ci").exists()
+    assert "vendor .kct/ci/check_copper_lvs.py" in result.stdout
+
+
+def test_ci_gates_rerun_idempotent(target_repo: Path, fake_uv_env: dict[str, str]) -> None:
+    """A second install re-copies the gates without duplication or drift."""
+    first = run_installer(target_repo, "--path", str(REPO_ROOT), env=fake_uv_env)
+    assert first.returncode == 0, first.stderr
+    second = run_installer(target_repo, "--path", str(REPO_ROOT), env=fake_uv_env)
+    assert second.returncode == 0, second.stderr
+
+    ci_dir = target_repo / ".kct" / "ci"
+    # Still exactly the expected set (3 gates + README), all byte-identical.
+    vendored = sorted(p.name for p in ci_dir.iterdir())
+    assert vendored == sorted([*VENDORED_CI_GATES, "README.md"])
+    for name in VENDORED_CI_GATES:
+        assert (ci_dir / name).read_bytes() == (CI_GATES_SRC / name).read_bytes()
+
+    # Metadata still lists each gate exactly once.
+    meta = json.loads((target_repo / ".kct" / "install-metadata.json").read_text())
+    for name in VENDORED_CI_GATES:
+        assert meta["installed_files"].count(f".kct/ci/{name}") == 1
+
+
+def test_vendored_gates_run_standalone_from_consumer(
+    target_repo: Path, fake_uv_env: dict[str, str]
+) -> None:
+    """Functional smoke: the vendored gates operate standalone from .kct/ci/.
+
+    Proves (a) check_routed_drc.py's sibling `from net_class_map_resolver
+    import ...` still resolves after relocation (its --help importing the
+    module is the tell), (b) the zero-files no-op exits 0, and (c) copper-LVS
+    gates a JSON verdict with no repo-relative path leakage.
+    """
+    result = run_installer(target_repo, "--path", str(REPO_ROOT), env=fake_uv_env)
+    assert result.returncode == 0, result.stderr
+    ci_dir = target_repo / ".kct" / "ci"
+
+    # (a) check_routed_drc.py --help succeeds ONLY if the sibling import of
+    # net_class_map_resolver resolves at module load (it is a top-level import).
+    drc_help = subprocess.run(
+        ["python3", str(ci_dir / "check_routed_drc.py"), "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert drc_help.returncode == 0, drc_help.stderr
+    assert "usage: check_routed_drc" in drc_help.stdout
+
+    # (b) zero files passed is a documented no-op that exits 0.
+    drc_noop = subprocess.run(
+        ["python3", str(ci_dir / "check_routed_drc.py"), "--allow", "0"],
+        capture_output=True,
+        text=True,
+    )
+    assert drc_noop.returncode == 0, drc_noop.stderr
+
+    # (c) copper-LVS gate: clean verdict -> 0, dirty verdict -> 2, from a path
+    # outside this repo (the tmp target), proving no boards/-relative assumption.
+    clean = target_repo / "clean.json"
+    clean.write_text('{"clean": true, "mismatches": []}')
+    clean_run = subprocess.run(
+        ["python3", str(ci_dir / "check_copper_lvs.py"), str(clean)],
+        capture_output=True,
+        text=True,
+    )
+    assert clean_run.returncode == 0, clean_run.stderr
+
+    dirty = target_repo / "dirty.json"
+    dirty.write_text('{"clean": false, "mismatches": [{"net": "N", "kind": "short"}]}')
+    dirty_run = subprocess.run(
+        ["python3", str(ci_dir / "check_copper_lvs.py"), str(dirty)],
+        capture_output=True,
+        text=True,
+    )
+    assert dirty_run.returncode == 2, dirty_run.stdout


### PR DESCRIPTION
## Summary

Extends `scripts/install-kct.sh` (from #4055) to vendor the three portable CI
gate scripts into a consumer repo's `.kct/ci/`, implementing Epic #4054's
Child #2 per the curator's **Option A (vendor, don't relocate)** decision. The
gates are stdlib+yaml only (zero `kicad_tools` imports) and CLI-arg-driven, so
they gate copper-LVS / routed-DRC against the consumer's own board path.

## Changes

- **`scripts/install-kct.sh`**
  - New Stage 6b vendors `check_copper_lvs.py`, `check_routed_drc.py`,
    `net_class_map_resolver.py` verbatim into `.kct/ci/`, `chmod 0755`.
  - An explicit `CI_GATE_FILES` list (NOT a glob) so board-specific /
    repo-internal gates are never over-vendored.
  - Ships `.kct/ci/README.md` documenting consumer-side invocation, including
    the `--allow N` pattern instead of the repo-internal
    `.github/routed-drc-tolerance.yml` default.
  - Records all four vendored paths in `install-metadata.json` `installed_files`
    (existing manifest — feeds the documented `uv lock --upgrade` + re-run
    refresh path; no new versioning scheme).
  - One-line pointer to `.kct/ci/README.md` added to the CLAUDE.md block.
  - `--dry-run` prints the planned writes and writes nothing.
- **`tests/install/test_install_kct.py`** — 5 new tests (see below).

## Cross-script import preservation

`check_routed_drc.py` imports its `net_class_map_resolver` dependency via
`sys.path.insert(0, str(Path(__file__).resolve().parent))` — resolved relative
to the *script's own* directory, not to `scripts/ci`. Vendoring all three as a
sibling triple in one directory keeps that import working unmodified.
`check_copper_lvs.py` is fully standalone (stdlib only). Verified by a
functional test that runs `check_routed_drc.py --help` from the vendored
location (a top-level import, so it only succeeds if the sibling module loads).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Option A recorded; installer vendors exactly the 3 gates into `.kct/ci/` | ✅ | `test_ci_gates_vendored_byte_identical_and_executable` + `test_ci_gates_not_over_vendored` |
| Sibling `net_class_map_resolver` import works after relocation | ✅ | `test_vendored_gates_run_standalone_from_consumer` (drc `--help` from `.kct/ci/`) |
| Consumer runs gates against its own board path (CLI arg, not hardcoded) | ✅ | copper-LVS gate run on a JSON path under the tmp target: clean→0, dirty→2 |
| `--allow N` documented as consumer-side pattern | ✅ | `.kct/ci/README.md`; asserted in `test_ci_gates_vendored...` |
| This repo's `.github/workflows/ci.yml` unchanged | ✅ | `git diff origin/main` does not include ci.yml |
| `install-metadata.json` records provenance + vendored file list | ✅ | `test_ci_gates_recorded_in_metadata` (existing kct_version/kct_commit/source_ref fields carry provenance) |
| Zero-files DRC run is a no-op exit 0 | ✅ | `test_vendored_gates_run_standalone_from_consumer` |
| `src` never imports `scripts/ci` invariant preserved | ✅ | trivially — nothing moved into `src/` |
| Idempotent re-run | ✅ | `test_ci_gates_rerun_idempotent` |

## Test Plan

`uv run pytest tests/install/` → **17 passed** (12 pre-existing + 5 new).
`shellcheck scripts/install-kct.sh` clean; `ruff check` / `ruff format --check`
clean on touched files. Manual end-to-end install into a scratch target
confirmed all four files land executable and the gates run standalone.

Closes #4056