### PR TITLE
feat(kct): consumer-generic .claude/commands/kct/ skills (#4057)

### DIFF
--- a/.claude/commands/kct/README.md
+++ b/.claude/commands/kct/README.md
@@ -20,3 +20,6 @@ invoked as `/kct:<name>`. Do not place them under `.claude/commands/loom/` or `.
 | Command | Purpose | Model |
 |---------|---------|-------|
 | `/kct:ee-review <issue-or-board>` | Produce an EE decision document (escalating intervention ladder + binding constraints, cited and confidence-graded) for an analog/placement-blocked board. Advisory only — decisions, not copper. | opus |
+| `/kct:manufacturing-readiness <board-path>` | Sign off a routed board for fabrication: `kct check` + the mandatory `kicad-cli pcb drc --refill-zones` cross-gate + a `kct export` bundle at the board's fab tier. Refuses sign-off if any gate is skipped. | sonnet |
+| `/kct:board-recipe-scaffold <board-path>` | Scaffold a new consumer board recipe (`generate_design.py`) following the artifact-first convention: project → schematic+ERC → PCB → route+pour → check → LVS hard gate → export, with circuit-specific parts left as fill-in points. | sonnet |
+| `/kct:layout-journal <board-path>` | Keep a `LAYOUT_NOTES.md` journal for a hand-routing session so the reasoning behind manual copper (decisions, rip-ups, referee results, blockers) survives reboots and hand-offs. | sonnet |

--- a/.claude/commands/kct/board-recipe-scaffold.md
+++ b/.claude/commands/kct/board-recipe-scaffold.md
@@ -1,0 +1,93 @@
+---
+name: board-recipe-scaffold
+invocation: /kct:board-recipe-scaffold
+suggestedModel: sonnet
+description: Scaffold a new consumer board recipe (generate_design.py) following the artifact-first convention — a project → schematic+ERC → PCB → route+pour → check → LVS-hard-gate → export pipeline with circuit-specific parts left as fill-in points.
+---
+
+# Board recipe scaffold
+
+Scaffold a new `generate_design.py`-style board recipe for a consumer PCB, following the **artifact-first convention**: the committed board artifact is shipping truth, and regeneration may diverge by design. This skill emits the proven sequential pipeline (steps 1-9) as a template with the circuit-specific parts left as clearly marked fill-in points — it does **not** reproduce any specific board's circuit.
+
+> **The `kct` namespace.** This skill lives in `.claude/commands/kct/` — the kicad-tools-native, harness-agnostic agent-tool namespace, invoked as `/kct:board-recipe-scaffold`. It runs from inside a **consumer repo** that depends on kicad-tools as a `uv` dependency. It hardcodes no board path and assumes nothing about the current directory being the kicad-tools repo.
+
+> **Artifact-first (why this shape).** The recipe's job is to *generate* a board artifact; once committed, that artifact is the shipping truth. A later `python generate_design.py` run may diverge from the committed artifact (placement heuristics, router seed) — that is intentional, not a bug. The committed `*.kicad_pcb` and its `manufacturing/` bundle are what ships; the recipe documents *how* it was produced. This is Epic #4054 convention #3 expressed as code structure.
+
+## Prerequisite
+
+The native router/DRC backend must be built in the active checkout before the routing step (step 5) will run at full speed (Epic #4054 convention #1):
+
+```bash
+uv run kct build-native --check   # expect: "C++ backend: available"
+uv run kct build-native           # if "not installed" (uv sync does NOT build it)
+```
+
+## Model selection
+
+`suggestedModel: sonnet`. Emitting a well-understood pipeline template with marked fill-in points is a structured code-generation task, not a frontier-judgment one. Model resolves through the harness's normal precedence chain.
+
+## Arguments
+
+**Arguments**: `$ARGUMENTS`
+
+`$ARGUMENTS` is `<board-path> [--name <slug>] [--mfr <tier>]`.
+
+| Token | Meaning |
+|-------|---------|
+| `<board-path>` | **Required.** The directory for the new board recipe (e.g. the path where `generate_design.py` and its `output/` will live). The user supplies it; the scaffold writes into it. Never a hardcoded board directory. |
+| `--name <slug>` | Project slug used for the `.kicad_pro` / output filenames. Optional; default derived from `<board-path>`'s basename. |
+| `--mfr <tier>` | Fab tier for the export step. Optional; if omitted, leave a marked fill-in point and resolve it the same way `/kct:manufacturing-readiness` does (read the recipe/manifest or ask the user; validate against `kicad_tools.manufacturers.get_manufacturer_ids()` / `kct export --help`). **Do not hardcode a tier list.** |
+
+## The recipe skeleton (steps 1-9)
+
+Emit a `<board-path>/generate_design.py` with these nine steps as functions, and a `main()` that runs them in order, prints a summary, and gates the exit code. Everything in **‹angle brackets›** is a circuit-specific fill-in point the author must complete — do not invent a specific circuit.
+
+1. **`create_project(output_dir, name)`** — minimal `.kicad_pro` via `kicad_tools.core.project_file.create_minimal_project`.
+
+2. **`create_‹circuit›_schematic(output_dir)`** — build the schematic with `kicad_tools.schematic.models.schematic.Schematic`, add the ‹components, nets, wiring›, then `sch.validate()` (ERC-adjacent structural checks), then `sch.write(...)`. Return the `.kicad_sch` path.
+
+3. **`run_erc(sch_path)`** — `kicad_tools.cli.runner.run_erc` + `kicad_tools.erc.ERCReport`. **Treat "kicad-cli not found" as skip-not-fail** (dev-machine tolerant) but **hard-fail on any ERC error violation**.
+
+4. **`create_‹circuit›_pcb(output_dir)`** — build the `.kicad_pcb` with an explicit `NETS` dict and footprints placed at **0° / 45° / 90° / 135° only**. Non-multiple-of-45° rotations hit a footprint rotation-transform ambiguity (see issue #3737 for *why* — cited as rationale, not a required read). Return the unrouted PCB path.
+
+5. **`route_pcb(input_path, output_path)`** — `kicad_tools.router.DesignRules` + `load_pcb_for_routing` + `router.route_all()` + `TraceOptimizer`; then pour: `kicad_tools.router.auto_pour.auto_pour_if_missing()` + `kicad_tools.cli.route_cmd._fill_zones_after_route()` for the power/ground pour nets. Return success (partial routing is tolerated — see `main()`).
+
+6. **`run_drc(pcb_path)`** — subprocess the CLI: `kct check <pcb> --allow-incomplete`. The `--allow-incomplete` opt-in matters: it runs **before** the manufacturing bundle exists, so the Manifest sub-check would otherwise report NOT RUN and fail the whole gate. Hard-fail on real DRC errors.
+
+7. **`run_lvs(sch_path, routed_pcb_path, output_dir)`** — `kicad_tools.lvs.write_lvs_report(..., require_clean=True, run_copper=True, run_label=True)`. **This is a HARD GATE, not optional.** LVS is what catches schematic/PCB divergence (a real polarity flip, issue #3747, slipped through everything else and was caught here). A dirty LVS raises; the recipe must exit non-zero rather than ship a diverging board.
+
+8. **`export_manufacturing_bundle(routed_path, output_dir)`** — subprocess `kct export <routed.kicad_pcb> --output <output_dir>/manufacturing --mfr ‹tier› --skip-preflight`; then verify `manifest.json` was written. Resolve ‹tier› per the `--mfr` argument rules above (never hardcode a tier list). Run this **unconditionally** so the manifest mtime stays newer than the routed PCB even when routing is incomplete.
+
+9. **`main()`** — run steps 1-8 in order, print a summary table (ERC / Routing / DRC / LVS / MFG), and **exit 0 only if ERC + DRC + LVS all pass**. **Routing partial-completion is tolerated and tracked separately** — surface this as a documented, explicit option in the summary (e.g. print `Routing: PARTIAL`), not a silent swallow. Wrap the body in try/except that prints the traceback and returns 1.
+
+## The gating contract (make it explicit in `main()`)
+
+```
+return 0 if erc_success and drc_success and lvs_success else 1
+```
+
+- ERC, DRC, LVS are **hard gates** — any failure ⇒ non-zero exit.
+- Routing may be **PARTIAL** and still exit 0, but the summary must say so plainly (documented option, not hidden).
+- LVS specifically is never downgraded to advisory — it is the divergence catcher.
+
+## What to leave as fill-in points (do NOT invent a circuit)
+
+The scaffold ships the pipeline shape and the gating contract. The author fills in, per their actual board:
+
+- schematic topology (components, values, net names, wiring) — step 2;
+- footprint selection + placement coordinates (multiples of 45° only) — step 4;
+- the `NETS` dict and pour-net names (power/ground) — steps 4-5;
+- the fab `‹tier›` — step 8, resolved via the registry, never a hardcoded list.
+
+Mark each of these `# TODO(author): ...` in the emitted template so they cannot be mistaken for done.
+
+## What this skill does NOT do
+
+- It does not choose or invent a specific circuit — only the pipeline scaffold + gating contract.
+- It does not depend on any CI workflow, GitHub Actions context, or repo-internal `scripts/ci/*` gate. The recipe it emits runs as a plain `python generate_design.py <output_dir>` inside any consumer repo.
+- It does not hardcode fab tiers; the tier set is owned by `kicad_tools.manufacturers`.
+
+## References
+
+- The nine-step skeleton is the validated artifact-first pipeline shape used across kicad-tools' own board fleet (validated end-to-end on the repo's own smallest fixture recipe). Issue #3737 (rotation-transform ambiguity → 45°-multiple placements) and #3747 (LVS caught a polarity divergence) are the *why* behind two of the constraints.
+- `/kct:manufacturing-readiness` — the sibling sign-off skill for the committed artifact (adds the `kicad-cli pcb drc --refill-zones` cross-gate on top of `kct check` + `kct export`).

--- a/.claude/commands/kct/board-recipe-scaffold.md
+++ b/.claude/commands/kct/board-recipe-scaffold.md
@@ -50,7 +50,23 @@ Emit a `<board-path>/generate_design.py` with these nine steps as functions, and
 
 4. **`create_‹circuit›_pcb(output_dir)`** — build the `.kicad_pcb` with an explicit `NETS` dict and footprints placed at **0° / 45° / 90° / 135° only**. Non-multiple-of-45° rotations hit a footprint rotation-transform ambiguity (see issue #3737 for *why* — cited as rationale, not a required read). Return the unrouted PCB path.
 
-5. **`route_pcb(input_path, output_path)`** — `kicad_tools.router.DesignRules` + `load_pcb_for_routing` + `router.route_all()` + `TraceOptimizer`; then pour: `kicad_tools.router.auto_pour.auto_pour_if_missing()` + `kicad_tools.cli.route_cmd._fill_zones_after_route()` for the power/ground pour nets. Return success (partial routing is tolerated — see `main()`).
+5. **`route_pcb(input_path, output_path)`** — `kicad_tools.router.DesignRules` + `load_pcb_for_routing` + `router.route_all()` + `TraceOptimizer`; then pour: `kicad_tools.router.auto_pour.auto_pour_if_missing()` + `kicad_tools.cli.route_cmd._fill_zones_after_route()` for the power/ground pour nets. Return a `route_success` boolean (`True` only when **all** signal nets landed) — do **not** swallow a partial route here; the gate in step 5.5 owns the decision.
+
+5.5. **`route_success` fast-fail gate (do this in `main()`, immediately after `route_pcb(...)`, BEFORE pour-stitching / LVS / export).** If `not route_success`, `raise` a **distinct, clearly-worded** error and stop — do not fall through to the LVS/pour/export steps:
+
+   ```python
+   if not route_success:
+       raise RuntimeError(
+           "partial route — likely wall-clock budget exhaustion under load "
+           "(the routing wall-clock safety backstop fired before every signal "
+           "net landed; see the 'PARTIAL: Routed N/M signal nets' line above "
+           "for the exact count). This is NOT a copper-LVS / GND-stitching "
+           "failure — the pipeline stopped before the LVS gate. Re-run on a "
+           "quiet machine, or raise the routing timeout if it recurs."
+       )
+   ```
+
+   **Why (issue #4047).** Without this gate, a partial route falls through to step 7's `write_lvs_report(..., require_clean=True)`, where an unrouted signal net reaches the copper comparator as a GND OPEN and raises `BoardNetlistMismatch`. The broad `try/except` in `main()` then reports exit 1 with a **misleading LVS traceback**, misdirecting the reviewer to the LVS / GND-stitching subsystem when the true cause is upstream route truncation (a loaded machine buys fewer CPU cycles inside the fixed wall-clock budget). Raising a distinct error here names the real cause. The reference recipe only dodged this by routing fully; a generic scaffold must teach the guard, because any board large enough to route partially will hit it. This is a hard fail-fast: it **supersedes** the "partial route → exit 0" tolerance below whenever LVS is a `require_clean=True` gate (which it always is in step 7).
 
 6. **`run_drc(pcb_path)`** — subprocess the CLI: `kct check <pcb> --allow-incomplete`. The `--allow-incomplete` opt-in matters: it runs **before** the manufacturing bundle exists, so the Manifest sub-check would otherwise report NOT RUN and fail the whole gate. Hard-fail on real DRC errors.
 
@@ -58,7 +74,7 @@ Emit a `<board-path>/generate_design.py` with these nine steps as functions, and
 
 8. **`export_manufacturing_bundle(routed_path, output_dir)`** — subprocess `kct export <routed.kicad_pcb> --output <output_dir>/manufacturing --mfr ‹tier› --skip-preflight`; then verify `manifest.json` was written. Resolve ‹tier› per the `--mfr` argument rules above (never hardcode a tier list). Run this **unconditionally** so the manifest mtime stays newer than the routed PCB even when routing is incomplete.
 
-9. **`main()`** — run steps 1-8 in order, print a summary table (ERC / Routing / DRC / LVS / MFG), and **exit 0 only if ERC + DRC + LVS all pass**. **Routing partial-completion is tolerated and tracked separately** — surface this as a documented, explicit option in the summary (e.g. print `Routing: PARTIAL`), not a silent swallow. Wrap the body in try/except that prints the traceback and returns 1.
+9. **`main()`** — run steps 1-8 in order (with the step 5.5 `route_success` gate right after routing), print a summary table (ERC / Routing / DRC / LVS / MFG), and **exit 0 only if ERC + DRC + LVS all pass**. Wrap the body in try/except that prints the traceback and returns 1. **A partial route never reaches this exit gate** — step 5.5 fast-fails it with a distinct "partial route" error *before* LVS, precisely so the reviewer is not handed a misleading `BoardNetlistMismatch`/LVS trace for what is really route truncation (issue #4047). If you ever downgrade LVS out of the `require_clean=True` hard gate, then and only then may a partial route be surfaced as a tolerated `Routing: PARTIAL` summary line instead of a hard fail-fast.
 
 ## The gating contract (make it explicit in `main()`)
 
@@ -67,7 +83,7 @@ return 0 if erc_success and drc_success and lvs_success else 1
 ```
 
 - ERC, DRC, LVS are **hard gates** — any failure ⇒ non-zero exit.
-- Routing may be **PARTIAL** and still exit 0, but the summary must say so plainly (documented option, not hidden).
+- A **partial route is a fast-fail** (step 5.5): while LVS is a `require_clean=True` hard gate, `not route_success` `raise`s a distinct "partial route" error *before* LVS runs, so the recipe never emits a misleading `BoardNetlistMismatch`/LVS traceback for what is really route truncation (issue #4047). Only a recipe that intentionally downgrades LVS below `require_clean=True` may instead tolerate a partial route as an explicit `Routing: PARTIAL` summary line (documented option, never a silent swallow).
 - LVS specifically is never downgraded to advisory — it is the divergence catcher.
 
 ## What to leave as fill-in points (do NOT invent a circuit)
@@ -89,5 +105,5 @@ Mark each of these `# TODO(author): ...` in the emitted template so they cannot 
 
 ## References
 
-- The nine-step skeleton is the validated artifact-first pipeline shape used across kicad-tools' own board fleet (validated end-to-end on the repo's own smallest fixture recipe). Issue #3737 (rotation-transform ambiguity → 45°-multiple placements) and #3747 (LVS caught a polarity divergence) are the *why* behind two of the constraints.
+- The nine-step skeleton is the validated artifact-first pipeline shape used across kicad-tools' own board fleet (validated end-to-end on the repo's own smallest fixture recipe). Issue #3737 (rotation-transform ambiguity → 45°-multiple placements), #3747 (LVS caught a polarity divergence), and #4047 (the `route_success` fast-fail so a partial route surfaces as a distinct "partial route" error, not a misleading LVS `BoardNetlistMismatch`) are the *why* behind three of the constraints.
 - `/kct:manufacturing-readiness` — the sibling sign-off skill for the committed artifact (adds the `kicad-cli pcb drc --refill-zones` cross-gate on top of `kct check` + `kct export`).

--- a/.claude/commands/kct/layout-journal.md
+++ b/.claude/commands/kct/layout-journal.md
@@ -1,0 +1,100 @@
+---
+name: layout-journal
+invocation: /kct:layout-journal
+suggestedModel: sonnet
+description: Keep a LAYOUT_NOTES.md journal for a hand-routing session so the reasoning behind manual copper survives across reboots and hand-offs — decisions, rip-ups, referee results, and open blockers, all tied to the committed artifact.
+---
+
+# Layout journal
+
+Keep a `LAYOUT_NOTES.md` journal alongside a board while hand-routing it, so the *reasoning* behind manual copper is not lost when the scratch workspace is (a reboot, a new worktree, a hand-off to another agent or the owner). The committed board artifact is shipping truth; this journal is the *why* behind it. This skill generalizes the hand-router-session convention proven during kicad-tools' own manufacturing hand-routing work — it hardcodes no board and no fixture.
+
+> **The `kct` namespace.** This skill lives in `.claude/commands/kct/` — the kicad-tools-native, harness-agnostic agent-tool namespace, invoked as `/kct:layout-journal`. It runs from inside a **consumer repo** and assumes nothing about the current directory being the kicad-tools repo.
+
+## Why this skill exists
+
+Hand-routing is iterative and the intermediate reasoning is fragile: which nets you ripped and why, which corridor you chose, what the referee said after each pass, what is still blocked and on whom. Scratch state (`/tmp`, un-committed working notes) is routinely lost on reboot. A `LAYOUT_NOTES.md` committed next to the board preserves that journal as durable, reviewable truth — the same reason artifact-first treats the committed board as canonical (Epic #4054 convention #3). Without it, a resumed session re-derives decisions that were already made and paid for.
+
+## Prerequisite
+
+The native router/DRC backend must be built in the active checkout so the referee gate (below) runs at full speed:
+
+```bash
+uv run kct build-native --check   # expect: "C++ backend: available"
+uv run kct build-native           # if "not installed"
+```
+
+## Model selection
+
+`suggestedModel: sonnet`. Maintaining a structured journal and running a referee gate is disciplined record-keeping, not frontier judgment. Model resolves through the harness's normal precedence chain.
+
+## Arguments
+
+**Arguments**: `$ARGUMENTS`
+
+`$ARGUMENTS` is `<board-path> [--entry "<free text>"]`.
+
+| Token | Meaning |
+|-------|---------|
+| `<board-path>` | **Required.** Path to the board being hand-routed (a `*.kicad_pcb`, or a board directory containing one). The journal is written to `<board-dir>/LAYOUT_NOTES.md`, derived from this token — never a hardcoded board directory. |
+| `--entry "<free text>"` | Append a single dated session entry describing what you just did (the nets touched, the decision, the referee result). Optional; if omitted, the skill creates/updates the journal skeleton and prompts for the first entry. |
+
+## The `LAYOUT_NOTES.md` convention
+
+Maintain `<board-dir>/LAYOUT_NOTES.md` with these sections. Keep it terse and factual — it is a journal, not prose.
+
+```markdown
+# LAYOUT_NOTES — <board name>
+
+Artifact-first: the committed <board>.kicad_pcb is shipping truth; this file is the WHY.
+Referee for every entry: `kicad-cli pcb drc --refill-zones <board.kicad_pcb>` → 0 new errors.
+
+## Standing constraints
+- <constraint the hand-route must not violate — e.g. net class widths, keep-outs, Kelvin taps>
+- <owner/EE decisions already ratified that bind this board>
+
+## Net status (living)
+| Net | Status | Notes |
+|-----|--------|-------|
+| <NET_NAME> | routed / partial / blocked | <one line> |
+
+## Session journal (newest first)
+### YYYY-MM-DD — <one-line summary>
+- Touched: <nets ripped / re-dressed / newly routed>
+- Decision: <what you chose and WHY — corridor, layer, order>
+- Referee: `kicad-cli pcb drc --refill-zones` → <N new errors>; `kct check --mfr <tier>` → <result>
+- Open: <what's still blocked, and on whom (owner call / EE review / another net)>
+```
+
+### Rules for each session entry
+
+1. **One dated entry per session, newest first.** Never overwrite prior entries — the history is the value.
+2. **Every entry names the referee result.** After a hand-route pass, run the cross-gate and record it:
+   ```bash
+   kicad-cli pcb drc --refill-zones <board.kicad_pcb>
+   ```
+   `--refill-zones` is load-bearing (it refills pours before checking, so DRC sees actual copper, not a stale fill). Record **new-error count**, not a bare "looks fine". A pass entry is one with **0 new errors**.
+3. **Record decisions, not just actions.** "Ripped 5 sense nets and re-dressed as one Kelvin-ordered bundle through the south band *because* the nearest blockers were 0.05-0.35mm" — the *because* is what a resumed session needs.
+4. **Surface blockers explicitly.** If a net is stuck on an owner/EE decision, say so in "Open" and in the net-status table — do not bury it. (For an analog/placement-blocked net, `/kct:ee-review <board-path>` produces the decision document the hand-route then executes.)
+5. **Tie every claim to the committed artifact.** Measured facts ("nearest blocker 0.05mm") come from `kct net-status <pcb> --why` on the committed board, not memory.
+
+## Referee gate (mandatory before you call a session done)
+
+```bash
+kicad-cli pcb drc --refill-zones <board.kicad_pcb>   # 0 new errors
+kct check <board.kicad_pcb> --mfr <tier>             # tier resolved per /kct:manufacturing-readiness
+```
+
+A hand-route session is not "done" until the referee is clean and the journal entry records it. For full fab sign-off, hand off to `/kct:manufacturing-readiness <board-path>` (adds the export bundle on top of the cross-gate).
+
+## What this skill does NOT do
+
+- It does not route copper for you — it records the reasoning behind copper you route by hand.
+- It does not depend on any CI workflow, GitHub Actions context, or repo-internal gate script. It runs identically inside any consumer repo's working tree.
+- It hardcodes no board, no fixture, and no fab-tier list (tiers come from `kicad_tools.manufacturers`).
+
+## References
+
+- The `LAYOUT_NOTES.md` journal pattern was proven during kicad-tools' own manufacturing hand-routing work, where a preserved journal survived scratch-state loss across reboots and carried the routing rationale forward.
+- `/kct:ee-review` — produces the EE decision document a hand-route executes when a net is analog/placement-blocked.
+- `/kct:manufacturing-readiness` — the fab sign-off ritual the finished hand-route hands off to.

--- a/.claude/commands/kct/manufacturing-readiness.md
+++ b/.claude/commands/kct/manufacturing-readiness.md
@@ -1,0 +1,120 @@
+---
+name: manufacturing-readiness
+invocation: /kct:manufacturing-readiness
+suggestedModel: sonnet
+description: Sign off a routed board for fabrication — run kct check, the mandatory kicad-cli pcb drc --refill-zones cross-gate, and a kct export bundle at the board's fab tier — and refuse sign-off if any gate is skipped.
+---
+
+# Manufacturing readiness
+
+Sign off a routed `.kicad_pcb` for fabrication. This skill codifies the **sign-off ritual**: `kct check` at the board's fab tier, the **mandatory** independent cross-gate `kicad-cli pcb drc --refill-zones`, and a `kct export` manufacturing bundle — then confirms a `manifest.json` was produced. A clean `kct check` **alone is not sign-off**.
+
+> **The `kct` namespace.** This skill lives in `.claude/commands/kct/` — the kicad-tools-native, harness-agnostic agent-tool namespace, invoked as `/kct:manufacturing-readiness`. It runs from inside a **consumer repo** that depends on kicad-tools as a `uv` dependency (`kct ...` is on `PATH` via the venv). It does **not** assume the current directory is the kicad-tools repo, and it hardcodes no board path, no fab-tier list, and no CI-workflow context.
+
+## Prerequisite
+
+The native router/DRC backend must be built in the active checkout before this skill is meaningful (Epic #4054 convention #1). Run once per checkout / worktree:
+
+```bash
+uv run kct build-native --check   # expect: "C++ backend: available"
+# if "not installed":
+uv run kct build-native
+```
+
+`uv sync` does **not** build the native extension. A fresh checkout or git worktree needs this step explicitly.
+
+## Model selection
+
+`suggestedModel: sonnet`. This is a deterministic checklist-execution task — run three gates in order, read their exit codes and reports, and refuse sign-off on any failure. It does not require frontier judgment. Model resolves through the harness's normal precedence chain (explicit dispatch param → harness role config → this doc's frontmatter `suggestedModel` → session default).
+
+## Arguments
+
+**Arguments**: `$ARGUMENTS`
+
+`$ARGUMENTS` is `<board-path> [--mfr <tier>] [--output <dir>]`.
+
+| Token | Meaning |
+|-------|---------|
+| `<board-path>` | **Required.** Path to the routed `*.kicad_pcb` to sign off (or a board directory containing one). Everything the skill operates on is derived from this token — never from a hardcoded board directory. The user supplies it. |
+| `--mfr <tier>` | The fabrication tier to check and export against. **Optional**; if omitted, discover it (see "Resolving the fab tier" below) rather than assuming a default. |
+| `--output <dir>` | Where the export bundle is written. Optional; defaults to `<pcb-dir>/manufacturing/` (the `kct export` default). |
+
+## Resolving the fab tier (never hardcode a tier list)
+
+Do **not** embed a fixed list of tier names in your reasoning — the set of tiers lives in `kicad_tools.manufacturers` and grows without any edit to this skill. Resolve `<tier>` in this order:
+
+1. If the user passed `--mfr <tier>`, use it.
+2. Otherwise read the tier from the **board's own recipe / manifest** — a `generate_design.py`, `README.md`, or existing `manufacturing/manifest.json` next to the board usually names its target fab. Use that.
+3. Otherwise ask the user which tier to target.
+
+Then **validate** the resolved tier against `kct`'s own registry rather than a memorized list:
+
+```bash
+# The authoritative choices — sourced from kicad_tools.manufacturers.get_manufacturer_ids():
+kct check --help      # see the --mfr {choices} set
+kct export --help     # same registry, plus the "generic" export-only pseudo-tier
+# or, programmatically:
+uv run python -c "from kicad_tools.manufacturers import get_manufacturer_ids; print(get_manufacturer_ids())"
+```
+
+If the resolved tier is not in that set, stop and ask — do not silently fall back to a default, because the fab tier is load-bearing (in-pad-via rescue rules, min trace/space floors, etc. differ by tier).
+
+## The sign-off ritual (run all three, in order)
+
+### Gate 1 — `kct check` at the fab tier
+
+```bash
+kct check <board.kicad_pcb> --mfr <tier>
+```
+
+- This is the DRC / manufacturing-rules check (clearances, dimensions, edge, silkscreen, plus the ERC / LVS / Manifest meta sub-checks).
+- **`--net-class-map` is auto-discovered** — `kct check` probes `<pcb_dir>/net_class_map.json`, `<pcb_dir>/output/net_class_map.json`, and `<pcb_dir>/../output/net_class_map.json` (the sidecar `kct route` itself writes). Do **not** over-specify `--net-class-map` unless the sidecar lives somewhere non-conventional; if it does, pass it explicitly:
+  ```bash
+  kct check <board.kicad_pcb> --mfr <tier> --net-class-map <path/to/net_class_map.json>
+  ```
+- A clean exit here is necessary but **not sufficient**. Proceed to Gate 2 regardless — do not treat a green Gate 1 as sign-off.
+
+### Gate 2 — the mandatory independent cross-gate (NOT optional)
+
+```bash
+kicad-cli pcb drc --refill-zones <board.kicad_pcb>
+```
+
+This is **not decorative and not skippable.** It is a *second, independent* DRC engine (KiCad's own), and it is the gate that catches what `kct check` misses:
+
+- On 2026-07-04 a live copper short shipped past a clean `kct check` because `kct` read **stale zone fills**. The `--refill-zones` flag is load-bearing: it forces KiCad to refill the pours before checking, so the DRC reasons over the *actual* copper, not a stale cache.
+- A clean `kct check` **does not by itself constitute manufacturing sign-off.** Both engines must agree.
+
+Read the KiCad DRC report. **Zero new errors** is required. If `kicad-cli` is not installed on the machine, this is a **hard blocker for sign-off** — say so explicitly; do not silently sign off on Gate 1 alone.
+
+### Gate 3 — export the manufacturing bundle at the fab tier
+
+```bash
+kct export <board.kicad_pcb> --output <dir> --mfr <tier>
+```
+
+- Produces gerbers, drill, BOM, CPL, a report, and `manifest.json`.
+- **Confirm `<dir>/manifest.json` exists and was freshly written** (its mtime should be newer than the routed PCB). No manifest ⇒ no sign-off.
+- Useful variants: `--dry-run` (show what would be generated without writing) and `--no-report`.
+
+## Sign-off verdict
+
+Sign off **only if all three** hold:
+
+1. Gate 1 `kct check --mfr <tier>` exits clean at the resolved tier.
+2. Gate 2 `kicad-cli pcb drc --refill-zones` reports **0 new errors** (and actually ran — a missing `kicad-cli` is a blocker, not a pass).
+3. Gate 3 `kct export --mfr <tier>` wrote a fresh `manifest.json`.
+
+If any gate fails or could not run, report **NOT signed off**, name the failing gate, and quote the specific violation(s). Never mark a board fab-ready on a partial run.
+
+## What this skill does NOT do
+
+- It does not route copper, place parts, or edit the `.kicad_pcb`.
+- It does not depend on any CI workflow, GitHub Actions context, or repo-internal `scripts/ci/*` gate. It runs identically as an interactive agent invocation inside any consumer repo's working tree. (Consumer repos that installed kicad-tools get portable gates under their own `.kct/ci/` — reference those if you need a scripted gate — but this skill needs only the `kct` / `kicad-cli` commands above.)
+- It does not enumerate fab tiers; the tier set is owned by `kicad_tools.manufacturers`.
+
+## References
+
+- `kct check --help` / `kct export --help` — authoritative `--mfr` tier choices (sourced from `kicad_tools.manufacturers.get_manufacturer_ids()`).
+- The `--refill-zones` cross-gate convention (Epic #4054 convention #2) was established after a 2026-07-04 defect where `kct check` alone missed a live short and read stale zone fills.
+- `/kct:ee-review` — sibling `kct` skill for analog/placement-blocked boards (advisory decisions, not copper).

--- a/tests/test_kct_skills_consumer_generic.py
+++ b/tests/test_kct_skills_consumer_generic.py
@@ -1,0 +1,170 @@
+"""Consumer-generic acceptance gates for `.claude/commands/kct/` skills (issue #4057).
+
+The `kct` skill namespace is vendored into arbitrary consumer PCB-design repos by
+`scripts/install-kct.sh` (Epic #4054). Skills authored under #4057 must therefore be
+*consumer-generic*: no repo-internal path literals, a user-supplied board path (not a
+hardcoded board), no hardcoded fab-tier enum (defer to
+``kicad_tools.manufacturers.get_manufacturer_ids()``), and no CI-workflow assumptions.
+
+These tests encode the curated grep-based acceptance gates so they are enforced in CI,
+not just checked once at authoring time. ``ee-review.md`` is intentionally excluded from
+the path-literal gate: it is board-05-cited as its own worked example (#3995), predates
+#4057, and is out of scope for this issue.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+KCT_DIR = REPO_ROOT / ".claude" / "commands" / "kct"
+
+# Skills shipped by #4057 (ee-review.md predates this issue and is exempt from the
+# path-literal gate; README.md is the index, not a skill body).
+NEW_SKILLS = (
+    "manufacturing-readiness",
+    "board-recipe-scaffold",
+    "layout-journal",
+)
+
+# The manufacturing-readiness skill is the one that must not enumerate fab tiers.
+MFR_SKILL = "manufacturing-readiness"
+
+# Gate 1: repo-internal path literals that would break a consumer install.
+REPO_INTERNAL_RE = re.compile(
+    r"(boards/0[0-9]-|hardware/board-0[0-9]|scripts/ci/board0[0-9]|chorus|softstart)"
+)
+
+# Gate 3: concrete fab-tier ids from get_manufacturer_ids() must not appear as a
+# hardcoded enum in the manufacturing-readiness skill's instructions.
+TIER_ID_RE = re.compile(r"\b(jlcpcb-tier1|jlcpcb|pcbway|oshpark|seeed|flashpcb)\b")
+
+# Gate 4: a directive reference to CI workflow / repo-internal ci scripts. A prose
+# disclaimer ("does not depend on scripts/ci/*") is explicitly compliant, so lines
+# that negate are not violations.
+CI_REF_RE = re.compile(r"(\.github/workflows|scripts/ci/)")
+NEGATION_RE = re.compile(r"\b(not|never|no)\b|does not|doesn't", re.IGNORECASE)
+
+
+def _skill_path(name: str) -> Path:
+    p = KCT_DIR / f"{name}.md"
+    assert p.exists(), f"expected skill file missing: {p}"
+    return p
+
+
+def _lines(name: str) -> list[str]:
+    return _skill_path(name).read_text(encoding="utf-8").splitlines()
+
+
+@pytest.mark.parametrize("skill", NEW_SKILLS)
+def test_no_repo_internal_path_literals(skill: str) -> None:
+    """Gate 1: no boards/0N-, hardware/board-0N, scripts/ci/board0N, chorus, softstart."""
+    hits = [
+        f"{skill}.md:{i}: {line}"
+        for i, line in enumerate(_lines(skill), 1)
+        if REPO_INTERNAL_RE.search(line)
+    ]
+    assert not hits, "repo-internal path literals found:\n" + "\n".join(hits)
+
+
+@pytest.mark.parametrize("skill", NEW_SKILLS)
+def test_board_path_is_a_parameter(skill: str) -> None:
+    """Gate 2: each skill defines and uses a user-supplied <board-path> token."""
+    text = _skill_path(skill).read_text(encoding="utf-8")
+    assert "## Arguments" in text, f"{skill}.md missing an ## Arguments section"
+    assert "`<board-path>`" in text, f"{skill}.md does not define a <board-path> token"
+    # The token must appear outside the Arguments table too (used in the body).
+    assert text.count("<board-path>") >= 2, (
+        f"{skill}.md defines <board-path> but never references it in the body"
+    )
+
+
+def test_no_hardcoded_fab_tier_enum() -> None:
+    """Gate 3: the mfr-readiness skill must not enumerate concrete fab-tier ids.
+
+    Tier discovery must defer to kct's own registry
+    (kicad_tools.manufacturers.get_manufacturer_ids() / kct check --help).
+    """
+    hits = [
+        f"{MFR_SKILL}.md:{i}: {line}"
+        for i, line in enumerate(_lines(MFR_SKILL), 1)
+        if TIER_ID_RE.search(line)
+    ]
+    assert not hits, (
+        "hardcoded fab-tier ids found (defer to get_manufacturer_ids() instead):\n"
+        + "\n".join(hits)
+    )
+
+
+def test_mfr_skill_defers_to_registry() -> None:
+    """Gate 3 (positive): the skill points at the authoritative tier source."""
+    text = _skill_path(MFR_SKILL).read_text(encoding="utf-8")
+    assert "get_manufacturer_ids" in text, (
+        f"{MFR_SKILL}.md should reference kicad_tools.manufacturers.get_manufacturer_ids()"
+    )
+    assert "--help" in text, (
+        f"{MFR_SKILL}.md should point at `kct check --help`/`kct export --help` for tiers"
+    )
+
+
+@pytest.mark.parametrize("skill", NEW_SKILLS)
+def test_no_ci_workflow_assumptions(skill: str) -> None:
+    """Gate 4: no directive reference to .github/workflows/* or scripts/ci/*.
+
+    A disclaimer line that negates ("does not depend on scripts/ci/*") is compliant.
+    """
+    hits = [
+        f"{skill}.md:{i}: {line}"
+        for i, line in enumerate(_lines(skill), 1)
+        if CI_REF_RE.search(line) and not NEGATION_RE.search(line)
+    ]
+    assert not hits, "CI-workflow assumption found:\n" + "\n".join(hits)
+
+
+@pytest.mark.parametrize("skill", NEW_SKILLS)
+def test_frontmatter_matches_house_style(skill: str) -> None:
+    """Every skill carries the ee-review.md frontmatter block."""
+    text = _skill_path(skill).read_text(encoding="utf-8")
+    assert text.startswith("---\n"), f"{skill}.md missing YAML frontmatter"
+    head = text.split("---", 2)[1]
+    for key in ("name:", "invocation:", "suggestedModel:", "description:"):
+        assert key in head, f"{skill}.md frontmatter missing `{key}`"
+    assert f"invocation: /kct:{skill}" in head, f"{skill}.md invocation must be /kct:{skill}"
+
+
+def test_mfr_skill_states_cross_gate_is_mandatory() -> None:
+    """The load-bearing rule: kicad-cli pcb drc --refill-zones is NOT optional."""
+    text = _skill_path(MFR_SKILL).read_text(encoding="utf-8")
+    assert "kicad-cli pcb drc --refill-zones" in text, (
+        "manufacturing-readiness must codify the --refill-zones cross-gate"
+    )
+    # The doc must assert the cross-gate's non-optionality somewhere.
+    assert re.search(r"not\s+optional|NOT optional|not skippable", text), (
+        "manufacturing-readiness must state the cross-gate is not optional"
+    )
+
+
+@pytest.mark.parametrize("skill", NEW_SKILLS)
+def test_readme_indexes_every_new_skill(skill: str) -> None:
+    """Gate: README table lists every new skill in the same table as ee-review."""
+    readme = (KCT_DIR / "README.md").read_text(encoding="utf-8")
+    assert f"/kct:{skill}" in readme, f"README.md does not index /kct:{skill}"
+
+
+def test_manufacturer_registry_is_the_authoritative_source() -> None:
+    """Sanity: the registry the skill defers to actually exists and is non-empty.
+
+    This locks the skill's contract to the real API rather than a memorized enum.
+    """
+    from kicad_tools.manufacturers import get_manufacturer_ids
+
+    ids = get_manufacturer_ids()
+    assert ids, "get_manufacturer_ids() returned no tiers"
+    # Whatever the tiers are, the mfr skill must NOT hardcode them — cross-check
+    # that none of the current ids appear verbatim in the skill body.
+    text = _skill_path(MFR_SKILL).read_text(encoding="utf-8")
+    leaked = [tid for tid in ids if re.search(rf"\b{re.escape(tid)}\b", text)]
+    assert not leaked, f"skill body leaked live tier ids: {leaked}"


### PR DESCRIPTION
Closes #4057. Last automated child of epic #4054 — the #4055 installer and #4056 vendored CI gates are both merged; the installer auto-vendors every `.md` under `.claude/commands/kct/`, so these skills ship to consumers automatically (verified: a real install into a fake consumer repo lands all four skills + README).

## Skills shipped (a, b, and optional c)

| Skill | File | Role |
|-------|------|------|
| (a) Manufacturing readiness | `manufacturing-readiness.md` | Sign-off ritual: `kct check --mfr <tier>` + the **mandatory** `kicad-cli pcb drc --refill-zones` cross-gate + `kct export` bundle; verifies `manifest.json`. Codifies that a clean `kct check` alone is **not** sign-off (a live short slipped past it 2026-07-04, caught only by the second DRC engine with `--refill-zones`). Sidecar `net_class_map.json` auto-discovery documented. |
| (b) Board-recipe scaffold | `board-recipe-scaffold.md` | Artifact-first `generate_design.py` skeleton (project → schematic+ERC → PCB → route+pour → `check --allow-incomplete` → LVS **hard gate** → export), with circuit-specific parts left as `# TODO(author)` fill-in points. Committed artifact = shipping truth; regen may diverge by design. |
| (c) Layout journal (optional) | `layout-journal.md` | Included because the `LAYOUT_NOTES.md` hand-route journal convention generalizes cleanly (no fixture dependency). Dated newest-first entries, each recording the `--refill-zones` referee result. |

`README.md` skills index updated with the same `Command / Purpose / Model` columns as the existing `ee-review` row.

## Consumer-generic gates — enforced in CI (not just checked once)

`tests/test_kct_skills_consumer_generic.py` implements the curated grep-based acceptance criteria as pytest so they hold on every future edit:

1. **No repo-internal path literals** — `boards/0N-`, `hardware/board-0N`, `scripts/ci/board0N`, `chorus`, `softstart` → zero matches in each new skill.
2. **`<board-path>` is a parameter, not an assumption** — each skill's `## Arguments` defines `<board-path>` and references it in the body (≥2 occurrences).
3. **No hardcoded fab-tier enum** — the mfr skill must not enumerate tier ids; it defers to `kicad_tools.manufacturers.get_manufacturer_ids()` / `kct check --help`. The test cross-checks that **no live tier id from the registry leaks** into the skill body, so it stays correct as tiers are added.
4. **No CI-workflow assumptions** — no directive `.github/workflows/*` or `scripts/ci/*` reference (negating disclaimers like "does not depend on `scripts/ci/*`" are compliant).
   Plus frontmatter house-style and README-index gates.

## Verification

- All referenced commands/flags verified via `--help`: `kct check --mfr/--net-class-map/--allow-incomplete`, `kct export --mfr/--output/--dry-run/--no-report/--skip-preflight`, `kct build-native --check/--force`, `kicad-cli pcb drc --refill-zones`.
- `uv run pytest tests/test_kct_skills_consumer_generic.py tests/install/` → **36 passed** (26 new + 10 install; install vendoring picks up the new skills unchanged).
- `ruff check` + `ruff format --check` clean on touched files.
- Real install into a throwaway consumer repo vendored all four skills automatically.

## Deferred / notes

- Manual end-to-end walk of skill (a) against a live board (Test Plan item 1) is left to the reviewer/auditor; the automated gates cover the doc-structure invariants.
- The curated "re-curation after #4055/#4056 merge" flag is resolved: both merged; skill (a) references consumers' own `.kct/ci/` (post-#4056) rather than `scripts/ci/*`, and the installer surface is confirmed by the passing `tests/install/`.
- `.loom-managed` bookkeeping churn intentionally left out of the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)