### PR TITLE
fix(validate): rotate THT pad offsets in drill-clearance check (#4044)

### DIFF
--- a/src/kicad_tools/validate/rules/dimensions.py
+++ b/src/kicad_tools/validate/rules/dimensions.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import math
 from typing import TYPE_CHECKING
 
+from kicad_tools.core.geometry import rotate_pad_offset
+
 from ..violations import DRCResults, DRCViolation
 from .base import DRC_TOLERANCE, DRCRule
 
@@ -207,9 +209,18 @@ class DimensionRules(DRCRule):
         for fp in pcb.footprints:
             for pad in fp.pads:
                 if pad.type == "thru_hole" and pad.drill > 0:
-                    # Pad position is relative to footprint
-                    abs_x = fp.position[0] + pad.position[0]
-                    abs_y = fp.position[1] + pad.position[1]
+                    # Pad position is stored footprint-local and must be
+                    # rotated by the footprint orientation before translating
+                    # to board coordinates (KiCad's negated-angle convention;
+                    # see core.geometry.rotate_pad_offset, issue #3739). A
+                    # naive add ignores rotation and produces phantom
+                    # hole-to-hole violations on rotated/flipped footprints
+                    # (issue #4044).
+                    rotated_x, rotated_y = rotate_pad_offset(
+                        pad.position[0], pad.position[1], fp.rotation
+                    )
+                    abs_x = fp.position[0] + rotated_x
+                    abs_y = fp.position[1] + rotated_y
                     net_name = pad.net_name if pad.net_name else f"net:{pad.net_number}"
                     drills.append(
                         (

--- a/tests/test_validate_dimensions.py
+++ b/tests/test_validate_dimensions.py
@@ -117,10 +117,16 @@ class MockFootprint:
         reference: str,
         position: tuple[float, float],
         pads: list[MockPad],
+        rotation: float = 0.0,
     ):
         self.reference = reference
         self.position = position
         self.pads = pads
+        # Footprint orientation in degrees. Pad positions are stored
+        # footprint-local and must be rotated by this angle before
+        # translation to board coordinates (issue #4044). Defaults to 0.0
+        # so existing tests are unaffected.
+        self.rotation = rotation
 
 
 class MockPCB:
@@ -528,6 +534,109 @@ class TestDrillClearanceCheck:
             v for v in results.violations if v.rule_id == "dimension_drill_clearance"
         ]
         assert len(clearance_violations) == 1
+
+    def test_rotated_footprint_no_false_positive(self):
+        """Issue #4044: a rotated THT footprint must not phantom-flag.
+
+        A footprint at (10, 10) rotated 90 deg has pad 1 at local offset
+        (0, 4). KiCad's negated-angle convention (rotate_pad_offset) maps
+        that to board offset (4, 0), so the true hole center is (14, 10).
+
+        - Naive (buggy) add:  fp.position + pad.position = (10, 14)
+        - Rotation-correct:                                 (14, 10)
+
+        A via is placed at (14, 1.0) -- i.e. 9.0mm from the *true* pad
+        position (safe: 9.0 - 0.2 - 0.2 = 8.6mm >> 0.5mm) but only 1.0mm
+        from the *naive* (14 vs 10 in x is 4mm; but y 14 vs 1 is 13mm...).
+
+        Concretely the via is placed 0.7mm from the buggy position and
+        far from the true one, so the naive code flags a hole-to-hole
+        violation that does not exist in the rotated geometry.
+        """
+        # Buggy position: (10, 14). True position: (14, 10).
+        # Via placed at (10, 14.7): 0.7mm from buggy pos (would flag),
+        # but sqrt((14-10)^2 + (10-14.7)^2) = sqrt(16 + 22.09) = 6.17mm
+        # from the true pos (edge = 6.17 - 0.4 = 5.77mm, safe).
+        pcb = MockPCB(
+            vias=[
+                MockVia((10, 14.7), size=0.6, drill=0.4, layers=["F.Cu", "B.Cu"], net_number=1),
+            ],
+            footprints=[
+                MockFootprint(
+                    reference="J1",
+                    position=(10, 10),
+                    rotation=90.0,
+                    pads=[
+                        MockPad(
+                            number="1",
+                            type="thru_hole",
+                            position=(0, 4),  # local; rotates to board (4, 0)
+                            drill=0.4,
+                            net_name="NET2",
+                            net_number=2,
+                        ),
+                    ],
+                ),
+            ],
+            nets={1: MockNet(1, "NET1"), 2: MockNet(2, "NET2")},
+        )
+        rules = MockDesignRules(min_clearance_mm=0.127, min_hole_to_hole_mm=0.5)
+        rule = DimensionRules()
+
+        results = rule.check(pcb, rules)
+
+        clearance_violations = [
+            v for v in results.violations if v.rule_id == "dimension_drill_clearance"
+        ]
+        # Buggy code would find the via 0.7mm from the (10,14) pad -> flag.
+        # Correct code measures against (14,10) -> 5.77mm edge -> no flag.
+        assert len(clearance_violations) == 0
+
+    def test_rotated_footprint_genuine_violation_detected(self):
+        """Issue #4044: a real hole-to-hole conflict at rotation still flags.
+
+        Same 90 deg footprint whose pad 1 true hole center is (14, 10).
+        A via placed at (14.7, 10) is a genuine 0.3mm edge-to-edge conflict
+        (0.7 center - 0.2 - 0.2) with the *true* rotated pad position. The
+        fix must not silently disable the check (guard against a false
+        negative).
+        """
+        # True pad pos (14, 10). Via at (14.7, 10): center dist 0.7mm,
+        # edge = 0.7 - 0.2 - 0.2 = 0.3mm < 0.5mm -> genuine violation.
+        pcb = MockPCB(
+            vias=[
+                MockVia((14.7, 10), size=0.6, drill=0.4, layers=["F.Cu", "B.Cu"], net_number=1),
+            ],
+            footprints=[
+                MockFootprint(
+                    reference="J1",
+                    position=(10, 10),
+                    rotation=90.0,
+                    pads=[
+                        MockPad(
+                            number="1",
+                            type="thru_hole",
+                            position=(0, 4),  # local; rotates to board (4, 0)
+                            drill=0.4,
+                            net_name="NET2",
+                            net_number=2,
+                        ),
+                    ],
+                ),
+            ],
+            nets={1: MockNet(1, "NET1"), 2: MockNet(2, "NET2")},
+        )
+        rules = MockDesignRules(min_clearance_mm=0.127, min_hole_to_hole_mm=0.5)
+        rule = DimensionRules()
+
+        results = rule.check(pcb, rules)
+
+        clearance_violations = [
+            v for v in results.violations if v.rule_id == "dimension_drill_clearance"
+        ]
+        assert len(clearance_violations) == 1
+        assert clearance_violations[0].actual_value == pytest.approx(0.3)
+        assert clearance_violations[0].required_value == pytest.approx(0.5)
 
     def test_smd_pads_not_checked(self):
         """Test that SMD pads are not included in drill clearance check."""


### PR DESCRIPTION
Closes #4044

## Problem

`validate/rules/dimensions.py::_check_drill_clearance` computed a through-hole pad's board position by plain addition, ignoring footprint rotation:

```python
abs_x = fp.position[0] + pad.position[0]
abs_y = fp.position[1] + pad.position[1]
```

`Pad.position` is stored **footprint-local** and must be rotated by `footprint.rotation` before translation (documented in `schema/pcb.py`'s `Pad` docstring). Because these `abs_x`/`abs_y` values feed directly into the center-to-center distance math that drives the violation determination, this is a correctness bug: on any rotated/flipped footprint the THT hole centers were placed at the wrong location (~10mm off in the reported real-board case), producing phantom `dimension_drill_clearance` violations and potentially missing real ones.

## Fix

Mirrors the existing correct pattern already used in `validate/connectivity.py::_transform_pad_position`, `validate/rules/clearance.py::_transform_pad_position`, and `validate/rules/via_in_pad.py`: rotate the pad-local offset via the pcbnew-verified `core.geometry.rotate_pad_offset` (KiCad's negated-angle convention, #3739), then translate by `fp.position`.

```python
rotated_x, rotated_y = rotate_pad_offset(pad.position[0], pad.position[1], fp.rotation)
abs_x = fp.position[0] + rotated_x
abs_y = fp.position[1] + rotated_y
```

The via-collection loop above is untouched (vias carry absolute board-frame positions — no footprint-local offset, no rotation).

## Tests

- Added a `rotation: float = 0.0` parameter to `MockFootprint` (previously it had no rotation param at all — every existing drill-clearance test implicitly used `rotation=0`, exactly the "test trap" the `rotate_pad_offset` docstring warns about, since 0deg/180deg agree under both correct and incorrect sign conventions).
- `test_rotated_footprint_no_false_positive`: a 90deg footprint with a THT pad at non-zero local offset, plus a via 0.7mm from the **naive** (buggy) position but ~5.8mm from the **true** rotated position — asserts **zero** violations (the false-positive case).
- `test_rotated_footprint_genuine_violation_detected`: same 90deg setup, via genuinely 0.3mm edge-to-edge from the **true** rotated pad hole — asserts the violation **is still detected** (guards against a false negative / the fix silently disabling the check).
- All 3 pre-existing 0deg drill-clearance tests continue to pass unmodified.

`uv run pytest tests/test_validate_dimensions.py` → **35 passed**. Related suites (`test_connectivity.py`, `test_component_clearance.py`) → green. `ruff check` + `ruff format --check` clean on both touched files.

## Fleet-impact finding

**No committed manufacturing artifacts change.** I scanned every board for the only footprint class this fix affects — through-hole pads at a non-zero local offset on a footprint with `rotation != 0`:

- The 4 boards with committed `output/drc_report.json` (00-simple-led, 03-usb-joystick, 04-stm32-devboard, 05-bldc-motor-controller): **0** such footprints each; none of those reports currently contain any `dimension_drill_clearance` entry.
- Full fleet scan across all `boards/*/output/*_routed.kicad_pcb`: **0** rotated-THT-pad(non-zero-offset) instances total.

Since the fix only relocates hole centers for that footprint class, its effect on the current fleet is a provable no-op — no `drc_report.json` regeneration was needed or performed.

## Out of scope (recommended follow-up)

`validate/rules/solder_mask.py` has the same unrotated-addition pattern at 3 sites (`_check_solder_mask_clearance` ~L100, `_check_min_pad_size` ~L143, `_check_pth_annular_ring` ~L195), but there `abs_x`/`abs_y` feed **only** the reported violation's display `location` tuple — the pass/fail determination in each is computed from pad-local dimensions and does not depend on absolute position. On a rotated footprint those rules would report a slightly wrong location marker but produce no false positives/negatives. Recommend a separate low-severity follow-up issue; deliberately not folded into this PR per the curated scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)