### PR TITLE
feat(router): scoped bundle river planner v1 for facing-column bus reversals (#4053)

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 4024
-# Branch: feature/issue-4024
+# Issue: 4053
+# Branch: feature/issue-4053
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -203,6 +203,11 @@ def run_route_command(args) -> int:
     # explicitly-provided values (matches the early-stop-patience pattern).
     if getattr(args, "targeted_ripup", False):
         sub_argv.append("--targeted-ripup")
+    # Issue #4053: forward --bundle-river-planner.  Both parsers declare it
+    # as store_true defaulting to False, so only forward when the user set
+    # it (byte-identical when absent).
+    if getattr(args, "bundle_river_planner", False):
+        sub_argv.append("--bundle-river-planner")
     max_ripups_val = getattr(args, "max_ripups_per_net", None)
     if max_ripups_val is not None:
         sub_argv.extend(["--max-ripups-per-net", str(max_ripups_val)])

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2746,6 +2746,23 @@ def _add_route_parser(subparsers) -> None:
             "and the two-phase initial-pass stall recovery."
         ),
     )
+    route_parser.add_argument(
+        "--bundle-river-planner",
+        action="store_true",
+        default=False,
+        help=(
+            "Enable the scoped bundle river planner for mirrored byte-lane "
+            "bus reversals (Issue #4053, epic #4049).  Board 07's DDR data "
+            "byte is a FULL bus reversal between two facing QFN-48 pin "
+            "columns (all C(11,2)=55 pairs cross), which planar same-layer "
+            "lane ordering cannot solve (every ordering-only approach "
+            "capped at <=10/11).  Resolves both facing rows, diffs their "
+            "permutation, and reserves one inner-layer via-hop corridor per "
+            "inverted (crossing) pair so the losing net can dip under its "
+            "partner.  Default OFF (byte-identical when absent); DDR-bundle "
+            "scoped in v1."
+        ),
+    )
     # Issue #3054 (Phase 2 of #3045): wire region-based parallelism through to
     # ``route_all_negotiated``.  Opt-in (default off) so existing scripts and
     # CI runs see byte-identical routes; when set, the negotiated loop

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -2785,6 +2785,21 @@ def _apply_ripup_budget_override(router: "Autorouter", args) -> None:
     router.stall_ripup_budget = budget
 
 
+def _apply_bundle_river_planner(router: "Autorouter", args) -> None:
+    """Enable the scoped bundle river planner when requested (Issue #4053).
+
+    Off by default (mirrors ``enable_byte_lane_reorder`` / the #4051
+    precedent).  When ``--bundle-river-planner`` is passed, set the
+    router's ``enable_bundle_river_planner`` flag so
+    ``_apply_byte_lane_inner_priority`` reserves inner-layer via-hop
+    corridors for the inverted (crossing) pairs of a mirrored byte-lane
+    bus reversal (board 07's DDR byte).  A no-op when the flag is absent,
+    so production routing is byte-identical to pre-#4053 main.
+    """
+    if getattr(args, "bundle_river_planner", False):
+        router.enable_bundle_river_planner = True
+
+
 def _targeted_ripup_budget(args) -> int:
     """Resolve ``--max-ripups-per-net`` for the negotiated targeted path.
 
@@ -3558,6 +3573,7 @@ def route_with_layer_escalation(
         # Issue #3470: thread --max-ripups-per-net into the destructive
         # rip-up budgets (route_all + two-phase stall recovery).
         _apply_ripup_budget_override(router, args)
+        _apply_bundle_river_planner(router, args)
 
         # Issue #3171: inject boosted analog routing class for --analog-nets /
         # --auto-analog selected nets (pour/ground nets are left untouched).
@@ -4457,6 +4473,7 @@ def route_with_rule_relaxation(
         # Issue #3470: thread --max-ripups-per-net into the destructive
         # rip-up budgets (route_all + two-phase stall recovery).
         _apply_ripup_budget_override(router, args)
+        _apply_bundle_river_planner(router, args)
 
         # Issue #3171: inject boosted analog routing class for --analog-nets /
         # --auto-analog selected nets (pour/ground nets are left untouched).
@@ -6557,6 +6574,7 @@ def route_with_combined_escalation(
             # Issue #3470: thread --max-ripups-per-net into the destructive
             # rip-up budgets (route_all + two-phase stall recovery).
             _apply_ripup_budget_override(router, args)
+            _apply_bundle_river_planner(router, args)
 
             # Issue #3171: inject boosted analog routing class for --analog-nets
             # / --auto-analog selected nets (pour/ground nets left untouched).
@@ -7271,6 +7289,23 @@ def main(argv: list[str] | None = None) -> int:
             "cannot recover.  The underlying implementation "
             "(route_all_negotiated(use_targeted_ripup=...)) predates this "
             "flag but was previously unreachable from the CLI."
+        ),
+    )
+    parser.add_argument(
+        "--bundle-river-planner",
+        action="store_true",
+        help=(
+            "Enable the scoped bundle river planner for mirrored byte-lane "
+            "bus reversals (Issue #4053, epic #4049).  Board 07's DDR data "
+            "byte is a FULL bus reversal between two facing QFN-48 pin "
+            "columns (all C(11,2)=55 pairs cross), which planar same-layer "
+            "lane ordering cannot solve — every ordering-only approach "
+            "(#3438/#4050/#4051) capped at <=10/11.  This flag resolves both "
+            "facing rows, diffs their permutation, and reserves one "
+            "inner-layer via-hop corridor per inverted (crossing) pair so "
+            "the losing net can dip under its partner.  Default OFF "
+            "(byte-identical to prior behaviour when absent); DDR-bundle "
+            "scoped in v1."
         ),
     )
     parser.add_argument(
@@ -8952,6 +8987,7 @@ def main(argv: list[str] | None = None) -> int:
     # Issue #3470: thread --max-ripups-per-net into the destructive
     # rip-up budgets (route_all + two-phase stall recovery).
     _apply_ripup_budget_override(router, args)
+    _apply_bundle_river_planner(router, args)
 
     # Issue #3171: inject boosted analog routing class for --analog-nets /
     # --auto-analog selected nets (pour/ground nets are left untouched).

--- a/src/kicad_tools/router/bundle_river.py
+++ b/src/kicad_tools/router/bundle_river.py
@@ -1,0 +1,220 @@
+"""Facing-row inversion analysis for the scoped bundle river planner.
+
+Issue #4053 (Phase 3 of epic #4049): a *scoped* river-routing planner for
+straight facing-column bundles.  The board-07 DDR data byte is a **full
+bus reversal** between two mirrored QFN-48 pin columns (U1's right column
+carries ``DQ0`` at the top ``DQ7`` at the bottom; U2's facing left column
+carries the same nets in the *opposite* row order), so every pair of nets
+whose relative row order flips between the two columns must cross.  Planar
+same-layer lane ordering cannot resolve a reversal (the "conflict graph"
+of a full reversal is a complete graph): each crossing pair needs one net
+to hop to an inner layer to pass under its partner.
+
+This module owns the *pure, search-free* geometry step that the epic's
+curation scoped for v1:
+
+    resolve both facing rows -> diff their permutation -> emit the
+    inversion set (the required crossing pairs) directly from the static
+    placement.
+
+Keeping it a free function (rather than a method on ``Autorouter``) makes
+the crossing-set computation unit-testable on a small synthetic two-row
+fixture without constructing a full router or board geometry, which the
+curated Test Plan requires (assert the correct inversion pairs for a known
+reversal AND an *empty* set for a genuinely planar, non-reversed two-row
+fixture — the over-triggering regression guard).
+
+The consumer (``Autorouter._apply_byte_lane_inner_priority``) reserves one
+inner-layer via-hop corridor per inverted pair, gated behind the default-
+OFF ``enable_bundle_river_planner`` flag (the #4051 precedent: even a
+geometry-only auto-detect regressed production, so v1 ships opt-in).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RowMember:
+    """One net's position on a facing row.
+
+    Attributes:
+        net_id: The net's integer id.
+        net_name: The net's name (used to match members across the two
+            facing rows — the bundle is a one-to-one name-matched bus).
+        projection: The member's 1-D coordinate along the row's long axis
+            (y for a vertical column, x for a horizontal one).  Only the
+            *relative order* of projections is used, so the absolute
+            coordinate system does not matter.
+    """
+
+    net_id: int
+    net_name: str
+    projection: float
+
+
+@dataclass(frozen=True)
+class InvertedPair:
+    """A required crossing between two nets of a facing-column bundle.
+
+    ``net_a`` / ``net_b`` are ordered so ``net_a`` is the *outer* net on
+    the primary row (smaller sorted index): its relative row order flips
+    versus ``net_b`` between the two facing columns, so on a single shared
+    escape strip the two lanes must cross.  ``loser_net_id`` names the net
+    v1 gives an inner-layer via-hop corridor to (the crossing net that
+    dips under its partner); see ``choose_via_hop_loser`` for the rule.
+    """
+
+    net_a_id: int
+    net_b_id: int
+    net_a_name: str
+    net_b_name: str
+    loser_net_id: int
+
+
+def _sorted_row(members: list[RowMember]) -> list[RowMember]:
+    """Return members sorted by projection (ascending), name as tiebreak.
+
+    The name tiebreak keeps the ordering deterministic when two pads share
+    a projection (degenerate, but defends against nondeterministic output
+    feeding the reservation pass).
+    """
+    return sorted(members, key=lambda m: (m.projection, m.net_name))
+
+
+def compute_row_permutation(
+    primary_row: list[RowMember],
+    secondary_row: list[RowMember],
+) -> list[tuple[str, int, int]] | None:
+    """Diff the two facing rows into a per-net (primary_rank, secondary_rank).
+
+    Both rows are sorted along their own long axis; each net's rank is its
+    index in that sort.  The returned list is keyed by net name (the bus is
+    matched one-to-one by name), one entry per net present in BOTH rows.
+
+    Returns ``None`` when the rows do not form a clean one-to-one matched
+    bus (different net-name sets between the rows), which is v1's explicit
+    non-goal (partial reversals / non-matched net counts belong to #3673's
+    shelved general planner).  A ``None`` return tells the caller to skip
+    the planner for this group rather than guess.
+    """
+    if not primary_row or not secondary_row:
+        return None
+
+    primary_names = {m.net_name for m in primary_row}
+    secondary_names = {m.net_name for m in secondary_row}
+    # v1 restriction: exactly one-to-one name matching between the rows.
+    if primary_names != secondary_names:
+        return None
+    if len(primary_names) != len(primary_row) or len(secondary_names) != len(secondary_row):
+        # A net appears twice on a row -> not a clean single-column bus.
+        return None
+
+    primary_sorted = _sorted_row(primary_row)
+    secondary_sorted = _sorted_row(secondary_row)
+
+    primary_rank = {m.net_name: i for i, m in enumerate(primary_sorted)}
+    secondary_rank = {m.net_name: i for i, m in enumerate(secondary_sorted)}
+    net_id = {m.net_name: m.net_id for m in primary_sorted}
+
+    perm: list[tuple[str, int, int]] = []
+    for name in sorted(primary_rank, key=lambda n: primary_rank[n]):
+        perm.append((name, net_id[name], secondary_rank[name]))
+    return perm
+
+
+def choose_via_hop_loser(
+    net_a_id: int,
+    net_a_name: str,
+    net_b_id: int,
+    net_b_name: str,
+) -> int:
+    """Pick which net of an inverted pair gets the inner-layer via hop.
+
+    Deterministic rule: the net whose *name* sorts later takes the hop.
+    The choice is arbitrary for correctness (either net can be the one to
+    dip under) but must be stable so the reservation pass is reproducible
+    across runs and the unit tests can pin it.  Name-sort (rather than
+    net-id) keeps it independent of net-numbering churn between board
+    regenerations.
+    """
+    if net_a_name <= net_b_name:
+        return net_b_id
+    return net_a_id
+
+
+def compute_facing_row_inversions(
+    primary_row: list[RowMember],
+    secondary_row: list[RowMember],
+) -> list[InvertedPair]:
+    """Compute the crossing set (inverted pairs) between two facing rows.
+
+    This is the search-free core of the v1 planner.  Two nets form an
+    inverted pair when their relative order flips between the primary row
+    and the secondary row — i.e. net A is above net B on the primary
+    column but below it on the secondary column.  On a single shared
+    F.Cu escape strip such a pair MUST cross, so one of the two needs an
+    inner-layer via hop to pass under the other.
+
+    For a *genuinely planar* (non-reversed) bundle — where both rows sort
+    into the same net order — the inversion set is EMPTY, so the caller
+    reserves no via-hop corridors and behaves exactly as before (the
+    curated over-triggering regression guard).
+
+    For a *full* bus reversal of ``n`` matched nets this returns all
+    ``C(n, 2)`` pairs (every relative order flips).
+
+    Args:
+        primary_row: Members on the primary facing column.
+        secondary_row: Members on the mirrored facing column.
+
+    Returns:
+        The list of inverted pairs (empty when the rows are co-oriented
+        or when the rows are not a clean matched bus).  Ordering is
+        deterministic (by the primary row's sorted rank of ``net_a``,
+        then ``net_b``).
+    """
+    perm = compute_row_permutation(primary_row, secondary_row)
+    if perm is None:
+        return []
+
+    inversions: list[InvertedPair] = []
+    n = len(perm)
+    for i in range(n):
+        name_i, id_i, sec_i = perm[i]
+        for j in range(i + 1, n):
+            name_j, id_j, sec_j = perm[j]
+            # perm is ordered by primary rank, so i < j means net_i is
+            # above net_j on the primary column.  They cross iff net_i is
+            # BELOW net_j on the secondary column (secondary rank flips).
+            if sec_i > sec_j:
+                loser = choose_via_hop_loser(id_i, name_i, id_j, name_j)
+                inversions.append(
+                    InvertedPair(
+                        net_a_id=id_i,
+                        net_b_id=id_j,
+                        net_a_name=name_i,
+                        net_b_name=name_j,
+                        loser_net_id=loser,
+                    )
+                )
+    return inversions
+
+
+def via_hop_loser_nets(inversions: list[InvertedPair]) -> list[int]:
+    """Return the distinct via-hop nets, one per inverted pair, deduped.
+
+    A net can be the "loser" of several inverted pairs (in a full
+    reversal the innermost nets lose many crossings).  For the corridor
+    reservation pass we only need to hop each losing net ONCE — the hop
+    lets it cross under every partner it inverts against — so this dedups
+    the loser set preserving first-seen order (deterministic).
+    """
+    seen: set[int] = set()
+    out: list[int] = []
+    for pair in inversions:
+        if pair.loser_net_id not in seen:
+            seen.add(pair.loser_net_id)
+            out.append(pair.loser_net_id)
+    return out

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -5211,13 +5211,9 @@ class Autorouter:
         for nid in sorted_nets:
             name = self.net_names.get(nid, str(nid))
             if nid in primary_net_to_pad:
-                primary_row.append(
-                    RowMember(nid, name, primary_net_to_pad[nid][proj_index])
-                )
+                primary_row.append(RowMember(nid, name, primary_net_to_pad[nid][proj_index]))
             if nid in secondary_net_to_pad:
-                secondary_row.append(
-                    RowMember(nid, name, secondary_net_to_pad[nid][proj_index])
-                )
+                secondary_row.append(RowMember(nid, name, secondary_net_to_pad[nid][proj_index]))
 
         inversions = compute_facing_row_inversions(primary_row, secondary_row)
         if not inversions:
@@ -5278,8 +5274,7 @@ class Autorouter:
                 )
             except Exception:
                 logger.debug(
-                    "Bundle-river via-hop reservation failed for net %d "
-                    "(group %s); continuing",
+                    "Bundle-river via-hop reservation failed for net %d (group %s); continuing",
                     loser,
                     grp_name,
                     exc_info=True,

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -877,6 +877,24 @@ class Autorouter:
         # Set to True to opt in (see ``_apply_byte_lane_inner_priority``).
         self.enable_byte_lane_reorder = False
 
+        # Issue #4053 (Phase 3, epic #4049): scoped bundle river planner.
+        # OFF by default.  When enabled, ``_apply_byte_lane_inner_priority``
+        # resolves BOTH facing rows of a mirrored byte-lane group, diffs
+        # their permutation, and reserves one inner-layer via-hop corridor
+        # per inverted (crossing) pair so the "losing" net of each crossing
+        # can dip to an inner layer and pass under its partner.  The board-07
+        # DDR byte is a full bus reversal (all C(11,2)=55 pairs cross) that
+        # planar same-layer lane ordering cannot solve, which is why every
+        # ordering-only approach (#3438/#4050/#4051) capped at <=10/11.
+        #
+        # Gated OFF (mirrors ``enable_byte_lane_reorder`` and the #4051
+        # precedent) because even a geometry-only auto-detect regressed
+        # production once; flag-off is byte-identical to pre-#4053 main
+        # (detection + the pre-existing #2983 inner-corner reservation still
+        # run; the new via-hop reservations do NOT).  Set True to opt in
+        # (see ``_apply_byte_lane_inner_priority`` / ``bundle_river.py``).
+        self.enable_bundle_river_planner = False
+
         # Initialize grid and routers using shared helper
         # Issue #972: Helper includes adaptive grid resolution for large boards
         self.grid, self.router, self.zone_manager = self._create_grid_and_routers(
@@ -5056,6 +5074,37 @@ class Autorouter:
                         exc_info=True,
                     )
 
+            # Issue #4053 (Phase 3, epic #4049): scoped bundle river
+            # planner.  When ``enable_bundle_river_planner`` is set, resolve
+            # the SECONDARY facing component's row for this group, diff the
+            # two rows' permutations, and reserve one inner-layer via-hop
+            # corridor per inverted (crossing) pair so the losing net can
+            # dip under its partner.  Gated OFF by default; when off this
+            # entire block is skipped and behaviour is byte-identical to the
+            # pre-#4053 inner-corner-reservation-only path above.
+            if getattr(self, "enable_bundle_river_planner", False):
+                try:
+                    self._reserve_bundle_river_via_hops(
+                        escape=escape,
+                        primary_ref=primary_ref,
+                        comp_pad_count=comp_pad_count,
+                        primary_net_to_pad=net_to_pad,
+                        sorted_nets=sorted_nets,
+                        vertical_row=(y_span >= x_span),
+                        cx=cx,
+                        cy=cy,
+                        grp_name=grp_name,
+                    )
+                except Exception:
+                    # Planner is advisory; any failure degrades to the
+                    # inner-corner-reservation-only behaviour (no via hops).
+                    logger.debug(
+                        "Bundle river planner failed for group %s; "
+                        "continuing without via-hop reservations",
+                        grp_name,
+                        exc_info=True,
+                    )
+
         # Issue #4051 (Phase 1b, epic #4049): apply a reactive
         # escape-freedom reorder on top of the corridor reservation.
         # Each qualifying byte-lane group's members are permuted *within
@@ -5098,6 +5147,156 @@ class Autorouter:
             )
             return net_order
         return reordered
+
+    def _reserve_bundle_river_via_hops(
+        self,
+        *,
+        escape: Any,
+        primary_ref: str,
+        comp_pad_count: dict[str, list[tuple[int, float, float]]],
+        primary_net_to_pad: dict[int, tuple[float, float]],
+        sorted_nets: list[int],
+        vertical_row: bool,
+        cx: float,
+        cy: float,
+        grp_name: str,
+    ) -> int:
+        """Reserve inner-layer via-hop corridors for a bus-reversal bundle.
+
+        Issue #4053 (Phase 3, epic #4049).  Given the primary facing row
+        already resolved by ``_apply_byte_lane_inner_priority``'s detection
+        scan, this resolves the SECONDARY facing component's row, diffs the
+        two rows' permutations via ``bundle_river.compute_facing_row_inversions``,
+        and reserves one inner-layer via-hop corridor per losing net so
+        crossings in a bus reversal actually get an under-pass.
+
+        The crossing set is fully determined by the two pad rows' geometry
+        (no search).  For a genuinely planar (co-oriented) bundle the
+        inversion set is empty and this reserves nothing — the
+        over-triggering guard the curation called for.
+
+        Returns:
+            Number of via-hop corridors reserved (0 when there is no
+            secondary row, no clean matched bus, or no inversions).
+        """
+        from .bundle_river import (
+            RowMember,
+            compute_facing_row_inversions,
+            via_hop_loser_nets,
+        )
+
+        proj_index = 1 if vertical_row else 0
+
+        # Resolve the secondary facing component: the component (other than
+        # the primary) hosting the most group-member pads.  In a mirrored
+        # byte-lane topology this is the opposite QFN (U2 when primary is
+        # U1).  Collapse to one pad per net, same as the primary row.
+        secondary_candidates = {
+            ref: pads for ref, pads in comp_pad_count.items() if ref != primary_ref
+        }
+        if not secondary_candidates:
+            return 0
+        secondary_ref = max(
+            secondary_candidates.keys(),
+            key=lambda r: (len(secondary_candidates[r]), -ord(r[0]) if r else 0),
+        )
+        secondary_net_to_pad: dict[int, tuple[float, float]] = {}
+        for nid, px, py in secondary_candidates[secondary_ref]:
+            if nid not in secondary_net_to_pad:
+                secondary_net_to_pad[nid] = (px, py)
+
+        # Build the two RowMember lists (only nets present on BOTH rows).
+        primary_row: list[RowMember] = []
+        secondary_row: list[RowMember] = []
+        for nid in sorted_nets:
+            name = self.net_names.get(nid, str(nid))
+            if nid in primary_net_to_pad:
+                primary_row.append(
+                    RowMember(nid, name, primary_net_to_pad[nid][proj_index])
+                )
+            if nid in secondary_net_to_pad:
+                secondary_row.append(
+                    RowMember(nid, name, secondary_net_to_pad[nid][proj_index])
+                )
+
+        inversions = compute_facing_row_inversions(primary_row, secondary_row)
+        if not inversions:
+            return 0
+
+        losers = via_hop_loser_nets(inversions)
+
+        # Row-axis unit vector on the primary row (for the lateral
+        # under-pass extent).  Projections increase along +proj_index.
+        if vertical_row:
+            row_axis_dx, row_axis_dy = 0.0, 1.0
+        else:
+            row_axis_dx, row_axis_dy = 1.0, 0.0
+
+        # The crossing span for a losing net is the row-position distance
+        # from its own lane to the FARTHEST partner it inverts against —
+        # that is how far it must travel laterally under the strip.
+        primary_proj = {m.net_id: m.projection for m in primary_row}
+        loser_span: dict[int, float] = {}
+        for pair in inversions:
+            for loser in (pair.loser_net_id,):
+                if loser not in primary_proj:
+                    continue
+                other = pair.net_a_id if pair.net_b_id == loser else pair.net_b_id
+                if other not in primary_proj:
+                    continue
+                dist = abs(primary_proj[loser] - primary_proj[other])
+                loser_span[loser] = max(loser_span.get(loser, 0.0), dist)
+
+        reserved = 0
+        for loser in losers:
+            pad_obj = None
+            for pkey, p in self.pads.items():
+                if p.ref == primary_ref and p.net is not None and int(p.net) == loser:
+                    pad_obj = p
+                    break
+            if pad_obj is None:
+                continue
+
+            px, py = primary_net_to_pad.get(loser, (pad_obj.x, pad_obj.y))
+            # Launch outward from the primary centroid, perpendicular to
+            # the row (same convention as the inner-corner reservation).
+            if vertical_row:
+                launch_dx = 1.0 if px >= cx else -1.0
+                launch_dy = 0.0
+            else:
+                launch_dx = 0.0
+                launch_dy = 1.0 if py >= cy else -1.0
+
+            try:
+                count = escape.reserve_bundle_river_via_hop_corridor(
+                    pad=pad_obj,
+                    launch_dx=launch_dx,
+                    launch_dy=launch_dy,
+                    row_axis_dx=row_axis_dx,
+                    row_axis_dy=row_axis_dy,
+                    crossing_span=loser_span.get(loser, 0.0),
+                )
+            except Exception:
+                logger.debug(
+                    "Bundle-river via-hop reservation failed for net %d "
+                    "(group %s); continuing",
+                    loser,
+                    grp_name,
+                    exc_info=True,
+                )
+                continue
+            if count > 0:
+                reserved += 1
+
+        logger.debug(
+            "Bundle river planner (group %s): %d inversions, %d losing nets, "
+            "%d via-hop corridors reserved",
+            grp_name,
+            len(inversions),
+            len(losers),
+            reserved,
+        )
+        return reserved
 
     def _reactive_escape_freedom_order(
         self,

--- a/src/kicad_tools/router/escape.py
+++ b/src/kicad_tools/router/escape.py
@@ -2623,9 +2623,7 @@ class EscapeRouter:
         # reservation would starve partner escapes.
         if self.grid.layer_stack is not None:
             if self.grid.layer_stack.num_layers < 3:
-                logger.debug(
-                    "Bundle-river via-hop corridor skipped: 2-layer stack-up"
-                )
+                logger.debug("Bundle-river via-hop corridor skipped: 2-layer stack-up")
                 return 0
             target_def = self.grid.layer_stack.get_layer_by_name(target_inner_layer.kicad_name)
             if target_def is None:

--- a/src/kicad_tools/router/escape.py
+++ b/src/kicad_tools/router/escape.py
@@ -2534,6 +2534,195 @@ class EscapeRouter:
             )
         return count
 
+    def reserve_bundle_river_via_hop_corridor(
+        self,
+        pad: Pad,
+        launch_dx: float,
+        launch_dy: float,
+        row_axis_dx: float,
+        row_axis_dy: float,
+        crossing_span: float,
+        target_inner_layer: Layer | None = None,
+    ) -> int:
+        """Reserve an inner-layer via-hop corridor for one crossing net.
+
+        Issue #4053 (Phase 3, epic #4049): the single-strip generalisation
+        of ``reserve_inner_corner_lane_corridor``.  Where that helper
+        protects a single inner-corner pad's *straight* continuation lane,
+        this one reserves an inner-layer corridor for the "losing" net of
+        an inverted (crossing) pair in a full/partial bus reversal — the
+        net that must dip to an inner layer, travel LATERALLY across the
+        escape strip to pass under its partner, then return.
+
+        A bus reversal between two facing pin columns forces every net
+        whose relative row order flips to cross its partner.  On a single
+        shared F.Cu strip those crossings cannot be planarised by lane
+        ordering (the conflict graph of a full reversal is complete), so
+        v1 gives each losing net a reserved inner-layer channel that spans
+        the crossing: forward along the launch vector AND laterally along
+        the row axis by ``crossing_span``, so the reserved cells cover the
+        under-pass the net needs.
+
+        Same soft mechanic as the diff-pair / inner-corner corridors
+        (``RoutingGrid.reserve_corridor_cells`` + the ``_mark_via`` per-cell
+        skip + the A* attractor bonus): the cells are net-OWNED, not
+        universally blocked, so partner-net vias detour while the crossing
+        net is *attracted* onto the reserved inner layer.  This is the
+        SOFT reservation the epic scoped — deliberately NOT a hard
+        pre-routed via (``--preserve-existing`` measured counterproductive
+        in #3414) and NOT the coupled-search primitive (#4052/#4065 proved
+        it basin-floods).
+
+        Args:
+            pad: The losing net's pad (origin of the via hop).  Must have
+                a non-zero ``pad.net``.
+            launch_dx, launch_dy: Outward launch direction (perpendicular
+                to the row, away from the package body) — same convention
+                as ``reserve_inner_corner_lane_corridor``.  Normalised
+                internally.
+            row_axis_dx, row_axis_dy: Unit vector ALONG the row's long
+                axis.  The lateral extent of the corridor is grown along
+                this axis so the reserved channel covers the net's
+                cross-strip travel toward its partner's lane.
+            crossing_span: How far along the row axis (mm) the corridor
+                must reach — sized by the caller to the row-position gap
+                between the losing net and the partner it passes under.
+            target_inner_layer: Inner copper layer.  Defaults to
+                ``_select_inner_escape_layer(pad.layer)`` (In1.Cu on a
+                4-layer signal stack; B.Cu fallback on a plane stack).
+
+        Returns:
+            Number of grid cells reserved (0 on any no-op: zero net id,
+            zero launch vector, 2-layer stack, layer not in stack).
+        """
+        net_id = int(pad.net) if pad.net else 0
+        if net_id == 0:
+            return 0
+
+        length_norm = math.hypot(launch_dx, launch_dy)
+        if length_norm == 0:
+            return 0
+        dx = launch_dx / length_norm
+        dy = launch_dy / length_norm
+
+        # Normalise the row axis vector (defensive; caller passes a unit
+        # vector but a zero vector collapses the lateral extent to the
+        # single-pad case, which is still a valid — if minimal — hop).
+        row_norm = math.hypot(row_axis_dx, row_axis_dy)
+        if row_norm > 0:
+            rax = row_axis_dx / row_norm
+            ray = row_axis_dy / row_norm
+        else:
+            rax = ray = 0.0
+
+        if target_inner_layer is None:
+            target_inner_layer = self._select_inner_escape_layer(pad.layer)
+
+        # Same 2-layer / layer-presence guards as the inner-corner helper:
+        # on a 2-layer board there is no inner layer to hop to, and a B.Cu
+        # reservation would starve partner escapes.
+        if self.grid.layer_stack is not None:
+            if self.grid.layer_stack.num_layers < 3:
+                logger.debug(
+                    "Bundle-river via-hop corridor skipped: 2-layer stack-up"
+                )
+                return 0
+            target_def = self.grid.layer_stack.get_layer_by_name(target_inner_layer.kicad_name)
+            if target_def is None:
+                logger.debug(
+                    "Bundle-river via-hop corridor skipped: layer %s not in stack",
+                    target_inner_layer.name,
+                )
+                return 0
+
+        try:
+            target_idx = self.grid.layer_to_index(target_inner_layer.value)
+        except Exception:
+            logger.debug(
+                "Bundle-river via-hop corridor skipped: layer %s not in grid stack",
+                target_inner_layer.name,
+            )
+            return 0
+
+        trace_w = self._get_trace_width_for_net(pad.net_name or "")
+        launch_step = self.escape_clearance + 2 * trace_w
+
+        # Forward extent: a couple of launch steps to clear the pad's own
+        # escape via before the lateral run begins.
+        corridor_length = launch_step * 2.0
+        # Lateral half-width: one launch step of protection around the
+        # under-pass channel, matching the inner-corner recipe's
+        # starvation-avoidance sizing (narrow, per-net, not a wide halo).
+        corridor_half_width = launch_step
+
+        # Enumerate cells: a rectangle that extends ``corridor_length``
+        # forward along the launch vector AND spans ``crossing_span`` along
+        # the row axis (the cross-strip under-pass), padded laterally by
+        # ``corridor_half_width`` on the launch-perpendicular sides.
+        cx, cy = pad.x, pad.y
+        # Lateral (launch-perpendicular) unit vector.
+        lat_dx, lat_dy = -dy, dx
+
+        span = max(0.0, float(crossing_span))
+        step = self.grid.resolution * 0.5
+        cells: set[tuple[int, int]] = set()
+
+        # Segment 1: forward launch stub (pad -> inner layer).
+        t = 0.0
+        while t <= corridor_length:
+            u = -corridor_half_width
+            while u <= corridor_half_width:
+                wx = cx + dx * t + lat_dx * u
+                wy = cy + dy * t + lat_dy * u
+                gx, gy = self.grid.world_to_grid(wx, wy)
+                cells.add((gx, gy))
+                u += step
+            t += step
+
+        # Segment 2: lateral under-pass run along the row axis, offset
+        # forward by the launch stub so it sits in the escape channel, not
+        # on top of the pad row.  Reserved as a band ``2*corridor_half_width``
+        # wide (perpendicular to the row axis) sliding ``span`` along it.
+        base_x = cx + dx * corridor_length
+        base_y = cy + dy * corridor_length
+        s = 0.0
+        while s <= span:
+            w = -corridor_half_width
+            while w <= corridor_half_width:
+                # Perpendicular to the row axis within the strip plane is
+                # the launch direction (dx, dy).
+                wx = base_x + rax * s + dx * w
+                wy = base_y + ray * s + dy * w
+                gx, gy = self.grid.world_to_grid(wx, wy)
+                cells.add((gx, gy))
+                w += step
+            s += step
+
+        if not cells:
+            return 0
+
+        count = self.grid.reserve_corridor_cells(
+            layer_idx=target_idx,
+            cells=cells,
+            net_ids={net_id},
+        )
+        if count > 0:
+            self.byte_lane_corridor_reservations += 1
+            self.byte_lane_corridor_reserved_cells += count
+            logger.debug(
+                "Bundle-river via-hop corridor reserved: layer=%s cells=%d "
+                "net=%d pad=%s.%s launch=(%.2f,%.2f) span=%.2fmm",
+                target_inner_layer.name,
+                count,
+                net_id,
+                pad.ref,
+                pad.pin,
+                dx,
+                dy,
+                span,
+            )
+        return count
+
     def _escape_bga_rings(self, package: PackageInfo) -> list[EscapeRoute]:
         """Generate ring-based escape routes for BGA packages.
 

--- a/tests/router/test_bundle_river_inversions.py
+++ b/tests/router/test_bundle_river_inversions.py
@@ -1,0 +1,173 @@
+"""Unit tests for the facing-row inversion analysis (Issue #4053).
+
+These tests pin the search-free crossing-set computation on small
+synthetic two-row fixtures — no full router or board geometry required —
+per the curated Test Plan:
+
+  * a known **full bus reversal** yields all C(n, 2) inverted pairs;
+  * a genuinely **planar (co-oriented)** two-row fixture yields an EMPTY
+    inversion set (the over-triggering regression guard — v1 must not
+    reserve via-hop corridors where no crossing exists);
+  * a **partial reversal** yields exactly the flipped pairs;
+  * non-matched net sets between the rows are rejected (``None`` /
+    empty), keeping v1 restricted to clean one-to-one matched buses.
+
+The fixture geometry mirrors the board-07 DDR byte described in
+``_apply_byte_lane_inner_priority``'s Issue #2962 docstring: U1's right
+column carries DQ0 at the top ... DQ7 at the bottom; U2's facing left
+column carries the same nets in the opposite row order.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.router.bundle_river import (
+    RowMember,
+    choose_via_hop_loser,
+    compute_facing_row_inversions,
+    compute_row_permutation,
+    via_hop_loser_nets,
+)
+
+
+def _reversed_rows(
+    names: list[str],
+) -> tuple[list[RowMember], list[RowMember]]:
+    """Build a primary/secondary row pair that is a FULL reversal.
+
+    Primary column: names[i] at projection i (top-to-bottom in order).
+    Secondary column: the SAME nets in reverse row order (mirror), i.e.
+    names[i] at projection (n-1-i).  Net ids are 1..n by primary order.
+    """
+    n = len(names)
+    primary = [RowMember(net_id=i + 1, net_name=names[i], projection=float(i)) for i in range(n)]
+    secondary = [
+        RowMember(net_id=i + 1, net_name=names[i], projection=float(n - 1 - i)) for i in range(n)
+    ]
+    return primary, secondary
+
+
+def _planar_rows(names: list[str]) -> tuple[list[RowMember], list[RowMember]]:
+    """Build a primary/secondary row pair that is co-oriented (planar)."""
+    n = len(names)
+    primary = [RowMember(net_id=i + 1, net_name=names[i], projection=float(i)) for i in range(n)]
+    secondary = [RowMember(net_id=i + 1, net_name=names[i], projection=float(i)) for i in range(n)]
+    return primary, secondary
+
+
+class TestFullReversal:
+    """A full bus reversal crosses every pair: C(n, 2) inversions."""
+
+    def test_full_reversal_yields_all_pairs(self) -> None:
+        names = ["DQ0", "DQ1", "DQ2", "DQ3", "DM0", "DQ4", "DQ5", "DQ6", "DQ7"]
+        primary, secondary = _reversed_rows(names)
+        inversions = compute_facing_row_inversions(primary, secondary)
+        n = len(names)
+        assert len(inversions) == n * (n - 1) // 2
+
+    def test_ddr_eleven_net_reversal(self) -> None:
+        """The board-07 DDR byte (11 nets) => C(11, 2) = 55 crossings."""
+        names = [
+            "DQ0",
+            "DQ1",
+            "DQ2",
+            "DQ3",
+            "DM0",
+            "DQS_P",
+            "DQS_N",
+            "DQ4",
+            "DQ5",
+            "DQ6",
+            "DQ7",
+        ]
+        primary, secondary = _reversed_rows(names)
+        inversions = compute_facing_row_inversions(primary, secondary)
+        assert len(inversions) == 55
+
+    def test_reversal_pairs_are_ordered_and_named(self) -> None:
+        names = ["A", "B", "C"]
+        primary, secondary = _reversed_rows(names)
+        inversions = compute_facing_row_inversions(primary, secondary)
+        # All 3 pairs cross: (A,B), (A,C), (B,C).
+        got = {(p.net_a_name, p.net_b_name) for p in inversions}
+        assert got == {("A", "B"), ("A", "C"), ("B", "C")}
+
+
+class TestPlanarGuard:
+    """A co-oriented (non-reversed) bundle yields ZERO inversions.
+
+    This is the over-triggering regression guard: the byte-lane synthetic
+    fixtures in test_byte_lane_priority.py / _corridor_reservation.py place
+    DQ_i at the SAME projection on both components, so the planner must
+    reserve NO via-hop corridors for them.
+    """
+
+    def test_planar_two_row_yields_no_inversions(self) -> None:
+        names = ["DQ0", "DQ1", "DQ2", "DQ3", "DQ4"]
+        primary, secondary = _planar_rows(names)
+        assert compute_facing_row_inversions(primary, secondary) == []
+
+    def test_via_hop_loser_set_empty_for_planar(self) -> None:
+        names = ["DQ0", "DQ1", "DQ2", "DQ3", "DQ4"]
+        primary, secondary = _planar_rows(names)
+        inversions = compute_facing_row_inversions(primary, secondary)
+        assert via_hop_loser_nets(inversions) == []
+
+
+class TestPartialReversal:
+    """Only the flipped pairs cross; co-oriented pairs do not."""
+
+    def test_single_adjacent_swap(self) -> None:
+        # Primary order: A(0) B(1) C(2) D(3)
+        # Secondary: A(0) C(1) B(2) D(3)  -> only (B, C) flips.
+        primary = [
+            RowMember(1, "A", 0.0),
+            RowMember(2, "B", 1.0),
+            RowMember(3, "C", 2.0),
+            RowMember(4, "D", 3.0),
+        ]
+        secondary = [
+            RowMember(1, "A", 0.0),
+            RowMember(2, "B", 2.0),
+            RowMember(3, "C", 1.0),
+            RowMember(4, "D", 3.0),
+        ]
+        inversions = compute_facing_row_inversions(primary, secondary)
+        assert len(inversions) == 1
+        assert {inversions[0].net_a_name, inversions[0].net_b_name} == {"B", "C"}
+
+
+class TestNonMatchedRowsRejected:
+    """v1 is restricted to clean one-to-one matched buses."""
+
+    def test_different_net_sets_rejected(self) -> None:
+        primary = [RowMember(1, "A", 0.0), RowMember(2, "B", 1.0)]
+        secondary = [RowMember(1, "A", 0.0), RowMember(3, "X", 1.0)]
+        assert compute_row_permutation(primary, secondary) is None
+        assert compute_facing_row_inversions(primary, secondary) == []
+
+    def test_duplicate_net_on_row_rejected(self) -> None:
+        primary = [RowMember(1, "A", 0.0), RowMember(1, "A", 1.0)]
+        secondary = [RowMember(1, "A", 0.0), RowMember(1, "A", 1.0)]
+        assert compute_row_permutation(primary, secondary) is None
+
+    def test_empty_rows_rejected(self) -> None:
+        assert compute_row_permutation([], []) is None
+        assert compute_facing_row_inversions([], []) == []
+
+
+class TestViaHopLoserSelection:
+    """The via-hop loser choice is deterministic and dedups per net."""
+
+    def test_loser_is_later_name(self) -> None:
+        assert choose_via_hop_loser(1, "DQ0", 2, "DQ7") == 2
+        assert choose_via_hop_loser(2, "DQ7", 1, "DQ0") == 2
+
+    def test_loser_dedup_preserves_order(self) -> None:
+        # Full reversal of 4 nets: innermost nets lose repeatedly, but each
+        # losing net should be hopped only once.
+        names = ["A", "B", "C", "D"]
+        primary, secondary = _reversed_rows(names)
+        inversions = compute_facing_row_inversions(primary, secondary)
+        losers = via_hop_loser_nets(inversions)
+        # No duplicates.
+        assert len(losers) == len(set(losers))

--- a/tests/router/test_bundle_river_planner.py
+++ b/tests/router/test_bundle_river_planner.py
@@ -1,0 +1,162 @@
+"""Integration tests for the scoped bundle river planner (Issue #4053).
+
+These drive ``Autorouter._apply_byte_lane_inner_priority`` on synthetic
+mirrored byte-lane fixtures and pin the flag contract:
+
+  * flag OFF (default): NO via-hop corridors reserved beyond the existing
+    #2983 inner-corner reservations — byte-identical to pre-#4053 main
+    (protects the reservation-count assertions in
+    ``test_byte_lane_corridor_reservation.py``);
+  * flag ON, **reversed** fixture: additional via-hop corridors reserved
+    for the crossing nets (reservation count exceeds the #2983 baseline
+    of 2);
+  * flag ON, **planar (co-oriented)** fixture: NO extra via-hop corridors
+    (over-triggering guard) — the reservation count stays at the #2983
+    baseline.
+
+The reversed fixture mirrors board 07's DDR byte: U1's row carries the
+nets top-to-bottom in order, U2's facing row carries them in reverse.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.layers import LayerStack
+from kicad_tools.router.rules import NetClassRouting
+
+
+def _make_bus_router(
+    *,
+    reversed_secondary: bool,
+    group_size: int = 10,
+    pitch: float = 0.8,
+    layer_stack: LayerStack | None = None,
+) -> tuple[Autorouter, list[int]]:
+    """Build a mirrored byte-lane router; secondary row optionally reversed.
+
+    Primary component U1 carries DQ0..DQ(n-1) top-to-bottom.  U2 carries
+    the same nets either co-oriented (``reversed_secondary=False``,
+    planar) or in reverse row order (``reversed_secondary=True``, a full
+    bus reversal like board 07's DDR byte).
+    """
+    group_name = "DDR_DATA_BYTE_0"
+    cls = NetClassRouting(
+        name=group_name,
+        priority=1,
+        trace_width=0.15,
+        clearance=0.10,
+        length_critical=True,
+        length_match_group=group_name,
+        length_match_reference=None,
+        length_match_tolerance_mm=0.1,
+    )
+    net_class_map: dict[str, NetClassRouting] = {}
+    router = Autorouter(
+        width=120.0,
+        height=80.0,
+        net_class_map=net_class_map,
+        layer_stack=layer_stack,
+    )
+
+    centre_y = 40.0
+    base_y = centre_y - (group_size - 1) * pitch / 2.0
+
+    net_ids: list[int] = []
+    for i in range(group_size):
+        net_id = i + 1
+        net_name = f"DQ{i}"
+        net_ids.append(net_id)
+        y_primary = base_y + i * pitch
+        # Secondary row: reversed order places DQ_i at the mirrored y.
+        j = (group_size - 1 - i) if reversed_secondary else i
+        y_secondary = base_y + j * pitch
+
+        router.add_component(
+            "U1",
+            [
+                {
+                    "number": str(25 + i),
+                    "x": 40.0,
+                    "y": y_primary,
+                    "net": net_id,
+                    "net_name": net_name,
+                }
+            ],
+        )
+        router.add_component(
+            "U2",
+            [
+                {
+                    "number": str(1 + i),
+                    "x": 80.0,
+                    "y": y_secondary,
+                    "net": net_id,
+                    "net_name": net_name,
+                }
+            ],
+        )
+        net_class_map[net_name] = cls
+
+    router.net_class_map = net_class_map
+    return router, net_ids
+
+
+class TestFlagOffByteIdentical:
+    """Flag OFF => only the #2983 inner-corner reservations (count 2)."""
+
+    def test_reversed_fixture_flag_off_baseline_reservations(self) -> None:
+        stack = LayerStack.four_layer_all_signal()
+        router, net_ids = _make_bus_router(reversed_secondary=True, layer_stack=stack)
+        # Default: enable_bundle_river_planner is False.
+        assert router.enable_bundle_river_planner is False
+        router._apply_byte_lane_inner_priority(net_ids)
+        # Exactly the two inner-corner reservations from #2983 — no via
+        # hops added when the planner flag is off.
+        assert router._escape.byte_lane_corridor_reservations == 2
+
+    def test_planar_fixture_flag_off_baseline_reservations(self) -> None:
+        stack = LayerStack.four_layer_all_signal()
+        router, net_ids = _make_bus_router(reversed_secondary=False, layer_stack=stack)
+        router._apply_byte_lane_inner_priority(net_ids)
+        assert router._escape.byte_lane_corridor_reservations == 2
+
+
+class TestFlagOnReversedReservesViaHops:
+    """Flag ON on a reversal => extra via-hop corridors beyond the 2 baseline."""
+
+    def test_reversed_fixture_reserves_via_hops(self) -> None:
+        stack = LayerStack.four_layer_all_signal()
+        router, net_ids = _make_bus_router(reversed_secondary=True, layer_stack=stack)
+        router.enable_bundle_river_planner = True
+        router._apply_byte_lane_inner_priority(net_ids)
+        # 2 inner-corner reservations + N via-hop corridors (one per losing
+        # net of the reversal).  A full reversal loses on multiple nets, so
+        # the count must exceed the #2983 baseline of 2.
+        assert router._escape.byte_lane_corridor_reservations > 2
+        assert router._escape.byte_lane_corridor_reserved_cells > 0
+
+
+class TestFlagOnPlanarNoViaHops:
+    """Flag ON on a co-oriented bundle => NO extra via hops (guard)."""
+
+    def test_planar_fixture_no_via_hops(self) -> None:
+        stack = LayerStack.four_layer_all_signal()
+        router, net_ids = _make_bus_router(reversed_secondary=False, layer_stack=stack)
+        router.enable_bundle_river_planner = True
+        router._apply_byte_lane_inner_priority(net_ids)
+        # Planar bundle has an empty inversion set: the planner reserves no
+        # via hops, so the count stays at the #2983 baseline of 2.
+        assert router._escape.byte_lane_corridor_reservations == 2
+
+
+class TestPermutationInvariantHeld:
+    """The planner is a pure side-effect: net_order stays a permutation."""
+
+    def test_order_unchanged_when_reorder_flag_off(self) -> None:
+        stack = LayerStack.four_layer_all_signal()
+        router, net_ids = _make_bus_router(reversed_secondary=True, layer_stack=stack)
+        router.enable_bundle_river_planner = True
+        # enable_byte_lane_reorder stays False, so the ORDER is identity
+        # even though via-hop corridors are reserved.
+        out = router._apply_byte_lane_inner_priority(net_ids)
+        assert out == net_ids


### PR DESCRIPTION
## Summary

Scoped river-routing planner v1 for straight facing-column bundles (Phase 3
of epic #4049). Implements the curator-defined design: resolve both facing
rows of a mirrored byte-lane group, diff their permutation to derive the
required-crossing (inverted-pair) set, and reserve one **soft** inner-layer
via-hop corridor per inverted pair so the losing net of each crossing can
dip to an inner layer and pass under its partner. Everything gates behind a
new default-OFF flag `enable_bundle_river_planner` (CLI: `--bundle-river-planner`).

Closes #4053.

## What v1 actually does

- **`src/kicad_tools/router/bundle_river.py`** (new): pure, search-free
  crossing-set computation. `compute_facing_row_inversions(primary_row,
  secondary_row)` sorts both rows, diffs their permutation, and emits the
  inverted pairs. A **full bus reversal** yields all C(n,2) pairs; a
  **co-oriented (planar)** bundle yields an **empty** set (the
  over-triggering guard). Free functions so the math is unit-testable
  without a router/board.
- **`escape.py`**: `reserve_bundle_river_via_hop_corridor` generalizes
  `reserve_inner_corner_lane_corridor` (#2983) from a single straight lane
  to a via-hop corridor that runs forward + laterally along the row axis
  (the under-pass). Same SOFT mechanic (`reserve_corridor_cells` +
  net-owned keep-out + A* attractor) — **not** hard pre-routed copper,
  **not** the coupled-search primitive, exactly as the curation scoped.
- **`core.py`**: `_apply_byte_lane_inner_priority` gains
  `_reserve_bundle_river_via_hops`, which resolves the SECONDARY facing
  component's row (the existing scan only resolved the primary), calls
  `bundle_river`, and reserves one via-hop per losing net. Gated so
  flag-off is byte-identical to pre-#4053 main.
- CLI flag wired through `parser.py` + `route_cmd.py` inner parser +
  `commands/routing.py` bridge, applied via `_apply_bundle_river_planner`
  at all four `_apply_ripup_budget_override` call sites.

Verified the detection is correct on the real board: the board-07 DDR
bundle resolves to U1/U2 (11 pads each), a **full 11-net reversal → 55
inversions → 10 distinct losing nets**; the planner reserves via-hop
corridors (9 total reservations, 7425 cells) on In1.Cu.

## Measurements (DDR-bundle repro, seed 42, solo, `--targeted-ripup --max-ripups-per-net 3`)

| Backend | `--bundle-river-planner` | Routed | Stranded | Wall |
|---------|--------------------------|--------|----------|------|
| C++ (production) | off | **10/11** | DQ3 | 164s |
| C++ (production) | on | **10/11** | DQ3 | 165s |
| Python | off | 7/11 | DQ1, DQ2, DQ5, DQS_N | 241s |
| Python | on | **8/11** | DQ1, DQ2, DQS_N | 161s |

**The 11/11 acceptance bar is NOT met.** Honest findings:

1. **On the production C++ backend the via-hop reservation is completely
   inert** — the C++ path is **byte-identical** flag-on vs flag-off (same
   6003-line routed file, same 22 vias). Root cause (pre-existing, not
   introduced here): the C++ grid deliberately omits the corridor-reservation
   map — see `cpp/src/grid.cpp:126-143` ("This C++ implementation deliberately
   omits that check because the escape phase is Python-grid-only today").
   `reserve_corridor_cells` (grid.py) has no C++ sync, so the C++ A* never
   sees the keep-out **or** the attractor bonus. The soft-reservation
   surface the curation scoped is structurally unreachable from the
   production routing loop.
2. **On the Python backend (which DOES consult the attractor) the planner
   works as designed and helps: 7/11 → 8/11** (DQ5 rescued), and faster.
   This confirms the via-hop mechanism is sound — but the Python backend's
   absolute reach (8/11) is far below the C++ baseline (10/11), and +1 net
   still doesn't clear the full 55-crossing reversal.

The crossing-set analysis validates the curation's planarity correction
(the bundle IS a full reversal, not a planar bundle), and the mechanism
proves out on the attractor-honoring backend. The gap to 11/11 is that a
single-strip SOFT via-hop is not strong enough to force 10 nets to hop, and
on the shipping backend the reservation has no effect at all.

## Flag-off regression safety

- DDR repro C++ flag-on == flag-off byte-for-byte (diff empty, 6003 lines).
- Board-02 (charlieplex) routes 8/8 flag-off — no regression on a
  representative production board.
- Flag-off skips 100% of the new code path; boards 00-06 are structurally
  unaffected (CI covers the route gates).

## Deferred scope (v2 / follow-up)

- **The blocker: port corridor reservations + the attractor to the C++
  grid** (`cpp/src/grid.cpp` `mark_via` + a pathfinder attractor hook).
  Until this lands, NO soft-reservation planner can affect production
  routing — this is the real prerequisite the epic's evidence now points
  to, and it also gates board-06's USB3 escape fix per the grid.cpp
  comment. Recommend a dedicated child.
- Auto-detect safe engagement (only after the flag has a positive track
  record); N>2 facing columns / partial-nested reversals (#3673 scope);
  jointly planning the DQS_P/DQS_N member via the C++ coupled loop (#4065).

## Tests / lint / mypy

- `tests/router/test_bundle_river_inversions.py` (11) — crossing-set math
  (full reversal C(n,2); planar empty; partial reversal; non-matched rows
  rejected; deterministic loser selection).
- `tests/router/test_bundle_river_planner.py` (5) — flag-off byte-identical
  (2 reservations); flag-on reversal reserves via-hops (>2); flag-on planar
  reserves none (guard); order stays identity.
- Existing `test_byte_lane_priority.py` + `test_byte_lane_corridor_reservation.py`
  (27) unchanged and green.
- ruff check + format clean on all touched files.
- mypy baseline gate PASSES: 1496 errors, all within the 1514 baseline, no
  new type errors (18 baseline errors removed by line shifts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
