### PR TITLE
feat(3d): LCSC/EasyEDA fetch-on-demand model resolver tier (#4072)

### DIFF
--- a/docs/guides/lcsc-3d-models.md
+++ b/docs/guides/lcsc-3d-models.md
@@ -1,0 +1,82 @@
+# LCSC/EasyEDA fetch-on-demand 3D models
+
+`kct pcb add-3d-models` resolves `(model ...)` 3D bodies for footprints in four
+tiers (first hit wins):
+
+1. **Exact** installed KiCad `library:name` footprint.
+2. **Same-library variant** — a suffixed name in the same library.
+3. **Cross-library substitution** — a curated `lib_id -> lib_id` table for
+   generic/synthetic lib ids with a body-compatible equivalent elsewhere.
+4. **LCSC/EasyEDA fetch-on-demand** — for footprints whose only usable identity
+   is an **LCSC C-number** (the JLCPCB-assembly fleet already carries these in
+   its BOMs). Nearly every LCSC part has a STEP body in the EasyEDA parts
+   database; this tier fetches it on demand into a local cache and emits a
+   portable model ref.
+
+## Using the LCSC tier
+
+Provide a per-board **sidecar** mapping `lib_id -> C-number`:
+
+```json
+{
+  "Module:Joystick_Analog": "C50950",
+  "Connector_PCIE:PCIE_Mini_Edge": "C123456"
+}
+```
+
+Then run:
+
+```bash
+# Cache-only (no network): resolves only C-numbers already cached.
+kct pcb add-3d-models board.kicad_pcb --lcsc-models lcsc_models.json
+
+# Opt in to fetching missing STEP bodies from EasyEDA on a cache miss.
+kct pcb add-3d-models board.kicad_pcb --lcsc-models lcsc_models.json --fetch-lcsc
+```
+
+The sidecar is **lib_id-keyed** (not reference-designator-keyed): each synthetic
+lib id in the fleet is unique per board, so one C-number per lib id suffices.
+
+## Cache and environment variables
+
+- **`KCT_LCSC_3D_DIR`** — the on-disk STEP cache directory. Default:
+  `~/.cache/kicad-tools/lcsc-3d/`, one file per C-number (`C50950.step`). It
+  doubles as the **path variable** in emitted refs
+  (`(model "${KCT_LCSC_3D_DIR}/C50950.step" ...)`), so committed `.kicad_pcb`
+  files stay machine-portable — each machine resolves the ref from its own
+  cache at render time. `kct pcb render` `setdefault`s this variable into the
+  `kicad-cli` subprocess environment (mirroring the `${KICADn_3DMODEL_DIR}`
+  precedent).
+- **`KCT_LCSC_FETCH`** — set to `1`/`true`/`yes`/`on` to enable fetch-on-demand
+  without the `--fetch-lcsc` flag. Default: cache-only.
+
+## Safety and behavior notes
+
+- **Offline / CI safe.** The tier activates only on a cache hit, or when
+  fetching is explicitly enabled. CI never needs network.
+- **Skip-on-miss.** On a cache miss with fetching disabled (or a fetch
+  failure), the footprint is reported *unresolved* and **no** `(model ...)` ref
+  is emitted — the tool never ships a `.kicad_pcb` with a ref to a
+  known-absent file. Fetch failures degrade to a warning; the patch and render
+  never fail for want of a body.
+- **Pure metadata insertion.** As with the other tiers, only `(model ...)`
+  lines are inserted — copper, placement, zones, and nets are untouched, so DRC
+  results are identical before and after.
+- **Origin-authored placement (approximation).** An EasyEDA STEP is a bare
+  `.step` with no `.kicad_mod`, so there is no source pad centroid. The body is
+  treated as origin-centered (`source_anchor=(0, 0)`), and the shared offset
+  machinery lands its origin on the target footprint's pad centroid. Scale and
+  rotation are left at KiCad defaults; a fetched body whose native orientation
+  differs from the footprint silkscreen may sit rotated. These bodies are
+  cosmetic render aids.
+- **Licensing.** EasyEDA/LCSC models are design-use-oriented and **not**
+  explicitly redistributable — they are cached locally and **never committed**
+  to the repo. Only the portable `${KCT_LCSC_3D_DIR}` path-variable ref is
+  committed.
+
+## No new dependency
+
+The EasyEDA client is a ~50-line in-repo, stdlib-only (`urllib` + `json`)
+two-call fetch (`.../api/products/{lcsc_id}/components` → extract the 3D-model
+uuid → `https://modules.easyeda.com/.../{uuid}` → raw STEP bytes). No
+`easyeda2kicad` dependency is added.

--- a/src/kicad_tools/cli/commands/pcb.py
+++ b/src/kicad_tools/cli/commands/pcb.py
@@ -668,11 +668,14 @@ def _run_add_3d_models_command(args, pcb_path: Path) -> int:
 
     output = getattr(args, "output", None)
     lib_path = getattr(args, "lib_path", None)
+    lcsc_models = getattr(args, "lcsc_models", None)
     return run_add_3d_models(
         pcb_path=pcb_path,
         output_path=Path(output) if output else None,
         lib_path=Path(lib_path) if lib_path else None,
         allow_variants=not getattr(args, "exact", False),
+        lcsc_models=Path(lcsc_models) if lcsc_models else None,
+        fetch_lcsc=getattr(args, "fetch_lcsc", False),
         dry_run=getattr(args, "dry_run", False),
         output_format=getattr(args, "format", "text"),
     )

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1672,6 +1672,21 @@ def _add_pcb_parser(subparsers) -> None:
         "name-variant fallback used for visual model lookup)",
     )
     pcb_add_models.add_argument(
+        "--lcsc-models",
+        dest="lcsc_models",
+        help="Path to an lcsc_models.json sidecar mapping lib_id -> LCSC "
+        "C-number, enabling the LCSC/EasyEDA fetch-on-demand tier. Bodies are "
+        "resolved from a cache dir (${KCT_LCSC_3D_DIR}, default "
+        "~/.cache/kicad-tools/lcsc-3d/) and emitted as portable "
+        "${KCT_LCSC_3D_DIR}/C#####.step refs",
+    )
+    pcb_add_models.add_argument(
+        "--fetch-lcsc",
+        action="store_true",
+        help="Fetch missing LCSC STEP bodies from EasyEDA on a cache miss "
+        "(default: cache-only, no network; also enabled by KCT_LCSC_FETCH=1)",
+    )
+    pcb_add_models.add_argument(
         "--format",
         choices=["text", "json"],
         default="text",

--- a/src/kicad_tools/cli/pcb_add_3d_models.py
+++ b/src/kicad_tools/cli/pcb_add_3d_models.py
@@ -31,6 +31,8 @@ def run_add_3d_models(
     output_path: Path | None = None,
     lib_path: Path | None = None,
     allow_variants: bool = True,
+    lcsc_models: Path | None = None,
+    fetch_lcsc: bool = False,
     dry_run: bool = False,
     output_format: str = "text",
 ) -> int:
@@ -44,6 +46,12 @@ def run_add_3d_models(
         allow_variants: Accept same-library footprint-name variants when the
             exact name is missing (e.g. ``QFN-24-1EP_4x4mm_P0.5mm`` matches
             the ``..._EP2.6x2.6mm`` variant — the model body is identical).
+        lcsc_models: Optional path to an ``lcsc_models.json`` sidecar mapping
+            ``lib_id -> C-number``, enabling the LCSC/EasyEDA fetch-on-demand
+            tier.
+        fetch_lcsc: When True, fetch a missing LCSC STEP from EasyEDA on a
+            cache miss (default: cache-only; also enabled by
+            ``KCT_LCSC_FETCH``).
         dry_run: Report what would be inserted without writing.
         output_format: ``"text"`` or ``"json"``.
 
@@ -51,10 +59,23 @@ def run_add_3d_models(
         Exit code (0 success, 1 error).
     """
     from kicad_tools.footprints.library_path import detect_kicad_library_path
+    from kicad_tools.pcb.lcsc_models import fetch_enabled, load_lcsc_mapping
     from kicad_tools.pcb.models3d import add_model_refs
 
+    lcsc_mapping: dict[str, str] | None = None
+    if lcsc_models is not None:
+        try:
+            lcsc_mapping = load_lcsc_mapping(lcsc_models)
+        except ValueError as e:
+            if output_format == "json":
+                print(json.dumps({"error": str(e)}))
+            else:
+                print(f"Error: {e}", file=sys.stderr)
+            return 1
+
     library_paths = detect_kicad_library_path(config_override=lib_path)
-    if not library_paths.found:
+    if not library_paths.found and lcsc_mapping is None:
+        # Only the installed-library tiers can help and they're unavailable.
         msg = (
             "KiCad footprint libraries not found (install KiCad or pass "
             "--lib-path / set KICAD_FOOTPRINT_DIR)"
@@ -65,12 +86,18 @@ def run_add_3d_models(
             print(f"Error: {msg}", file=sys.stderr)
         return 1
 
+    def _warn(message: str) -> None:
+        print(f"Warning: {message}", file=sys.stderr)
+
     try:
         report = add_model_refs(
             pcb_path,
             output_path=output_path,
             library_paths=library_paths,
             allow_variants=allow_variants,
+            lcsc_mapping=lcsc_mapping,
+            lcsc_fetch=fetch_enabled(fetch_lcsc),
+            lcsc_warn=_warn,
             dry_run=dry_run,
         )
     except Exception as e:
@@ -92,6 +119,7 @@ def run_add_3d_models(
         "no_model_in_library": report.no_model_in_library,
         "variant_matches": report.variant_matches,
         "substitution_matches": report.substitution_matches,
+        "lcsc_matches": report.lcsc_matches,
     }
 
     if output_format == "json":
@@ -117,6 +145,10 @@ def run_add_3d_models(
             print("  Cross-library substitution models used (curated equivalent):")
             for lib_id, sub in sorted(report.substitution_matches.items()):
                 print(f"    {lib_id} -> {sub}")
+        if report.lcsc_matches:
+            print("  LCSC/EasyEDA fetched models used (cached STEP):")
+            for lib_id, cnum in sorted(report.lcsc_matches.items()):
+                print(f"    {lib_id} -> {cnum}")
         if report.already_present:
             print(f"  Already had models: {len(report.already_present)}")
         if report.no_model_in_library:

--- a/src/kicad_tools/cli/runner.py
+++ b/src/kicad_tools/cli/runner.py
@@ -1669,15 +1669,24 @@ def find_kicad_3dmodel_dir(kicad_cli: Path | None = None) -> Path | None:
 def _render_env(kicad_cli: Path | None) -> dict[str, str] | None:
     """Build a subprocess environment that resolves 3D model path variables.
 
-    Returns None (inherit as-is) when no model directory can be located.
-    Existing environment variables are never overridden.
+    Sets the ``KICADn_3DMODEL_DIR`` variables (when a KiCad model dir is found)
+    and ``KCT_LCSC_3D_DIR`` (the LCSC fetch-on-demand STEP cache) so committed
+    ``(model "${...}/...")`` refs resolve at render time.  Returns None (inherit
+    as-is) only when neither can be supplied.  Existing environment variables
+    are never overridden.
     """
+    from kicad_tools.pcb.lcsc_models import DEFAULT_CACHE_ENV_VAR, lcsc_cache_dir
+
     model_dir = find_kicad_3dmodel_dir(kicad_cli)
-    if model_dir is None:
+    lcsc_dir = lcsc_cache_dir()
+    if model_dir is None and DEFAULT_CACHE_ENV_VAR in os.environ:
+        # Nothing to inject: KiCad libs absent and the LCSC var is already set.
         return None
     env = os.environ.copy()
-    for var in KICAD_3DMODEL_ENV_VARS:
-        env.setdefault(var, str(model_dir))
+    if model_dir is not None:
+        for var in KICAD_3DMODEL_ENV_VARS:
+            env.setdefault(var, str(model_dir))
+    env.setdefault(DEFAULT_CACHE_ENV_VAR, str(lcsc_dir))
     return env
 
 

--- a/src/kicad_tools/pcb/lcsc_models.py
+++ b/src/kicad_tools/pcb/lcsc_models.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -71,6 +72,30 @@ _USER_AGENT = (
     "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
 )
 _HTTP_TIMEOUT = 30
+
+# --------------------------------------------------------------------------
+# Untrusted-input validation
+# --------------------------------------------------------------------------
+# The C-number originates from a committed sidecar (``lcsc_models.json``) that
+# must be treated as untrusted: it flows into a cache *filename*
+# (``{lcsc_id}.step``), into a request *URL* (``.format(lcsc_id=...)``), and
+# into a committed ``.kicad_pcb`` *model ref*.  An unvalidated value enables
+# path traversal (``../outside/pwned``), URL injection (``C1/../../evil?x=``),
+# and ref injection.  EasyEDA C-numbers are ``C`` followed by digits, so we pin
+# the value to that shape at every trust boundary.
+_LCSC_ID_RE = re.compile(r"^C\d+$")
+
+# Bounds on a fetched STEP body written to the cache.  A compromised/rogue
+# endpoint can return an arbitrarily large or non-STEP payload; cap the size
+# and require the ISO-10303-21 header before ever writing to disk.  Real LCSC
+# bodies are typically a few MB; 50 MB is generous but bounded.
+_MAX_STEP_BYTES = 50 * 1024 * 1024
+_STEP_MAGIC = b"ISO-10303-21"
+
+
+def _is_valid_lcsc_id(lcsc_id: str) -> bool:
+    """True when *lcsc_id* is a well-formed EasyEDA C-number (``C`` + digits)."""
+    return bool(_LCSC_ID_RE.match(lcsc_id))
 
 
 def lcsc_cache_dir() -> Path:
@@ -120,6 +145,15 @@ def load_lcsc_mapping(sidecar_path: Path | str) -> dict[str, str]:
         if not isinstance(key, str) or not isinstance(value, str):
             raise ValueError(
                 f"LCSC sidecar {path}: entries must be string lib_id -> string C-number"
+            )
+        # The C-number is untrusted and flows into a cache filename, a request
+        # URL, and a committed board ref; a malformed value (path traversal,
+        # URL injection, non-C string) is a build error, matching the
+        # malformed-sidecar posture above.
+        if not _is_valid_lcsc_id(value):
+            raise ValueError(
+                f"LCSC sidecar {path}: invalid C-number {value!r} for {key!r} "
+                "(expected 'C' followed by digits, e.g. 'C50950')"
             )
         mapping[key] = value
     return mapping
@@ -209,6 +243,12 @@ def _fetch_lcsc_step(lcsc_id: str) -> bytes | None:
     step = _http_get(_API_STEP_MODEL.format(uuid=uuid))
     if not step:
         return None
+    # Bound the third-party payload before it can reach the disk: reject an
+    # oversize body or anything that is not a real ISO-10303-21 STEP file.
+    if len(step) > _MAX_STEP_BYTES:
+        return None
+    if not step.lstrip().startswith(_STEP_MAGIC):
+        return None
     return step
 
 
@@ -238,6 +278,14 @@ def resolve_lcsc_step(
         fetch: When True, fetch on a cache miss; when False, cache-only.
         warn: Optional ``callable(str)`` invoked on a fetch failure.
     """
+    # Defense in depth: even though ``load_lcsc_mapping`` rejects a malformed
+    # C-number at the sidecar boundary, never let an unvalidated value reach the
+    # filesystem or network here.  The resolver path stays never-raise, so an
+    # invalid id warns and returns None rather than raising.
+    if not _is_valid_lcsc_id(lcsc_id):
+        if callable(warn):
+            warn(f"LCSC 3D model skipped: invalid C-number {lcsc_id!r} (no model inserted)")
+        return None
     cache = cache_dir if cache_dir is not None else lcsc_cache_dir()
     step_path = cache / f"{lcsc_id}.step"
     if step_path.is_file():

--- a/src/kicad_tools/pcb/lcsc_models.py
+++ b/src/kicad_tools/pcb/lcsc_models.py
@@ -1,0 +1,281 @@
+"""LCSC/EasyEDA fetch-on-demand 3D model resolver (fourth ``add-3d-models`` tier).
+
+The JLCPCB-assembly fleet identifies its assembly parts by **LCSC C-numbers**,
+and nearly every LCSC part carries a 3D STEP body in the EasyEDA parts
+database.  This module resolves a footprint whose only usable identity is a
+C-number to a cached ``.step`` file, fetching it on demand from EasyEDA when a
+committed per-board sidecar maps its ``lib_id`` to a C-number.
+
+**License posture.**  EasyEDA/LCSC STEP bodies are design-use-oriented and are
+**not** explicitly redistributable, so the fetched models are cached locally
+and never committed to the repo.  Committed ``.kicad_pcb`` files carry only a
+portable path-variable ``(model "${KCT_LCSC_3D_DIR}/C#####.step" ...)`` ref
+into that cache, resolved at render time (mirroring the
+``${KICADn_3DMODEL_DIR}`` precedent).
+
+**Offset policy.**  An EasyEDA STEP is a bare ``.step`` with no ``.kicad_mod``,
+so there is no *source* footprint pad centroid to register against.  The bodies
+are treated as **origin-authored**: the resolver returns
+``source_anchor=(0.0, 0.0)`` (an explicit origin, *not* ``None``), so the
+shared ``add_model_refs_to_text`` offset math computes ``dx, dy =
+target_anchor`` -- the body's origin lands on the target footprint's pad
+centroid.  This is an approximation (origin-centered placement, not
+pin-1-registered) and scale/rotation are left at KiCad defaults (``1 1 1`` /
+``0 0 0``); a fetched body whose native orientation differs from the
+footprint's silkscreen may sit rotated.  These limitations are acceptable for
+cosmetic render bodies and noted for future per-mapping overrides.
+
+**Offline / CI safety.**  The fetch is opt-in.  A model resolves only when the
+cache already holds the STEP, or when fetching is explicitly enabled (via the
+``fetch`` flag / ``KCT_LCSC_FETCH`` env var).  Fetch and parse failures never
+raise -- they degrade to ``None`` (reported as unresolved) so a patch or render
+never fails for want of a body, and CI never needs network.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+__all__ = [
+    "DEFAULT_CACHE_ENV_VAR",
+    "LCSC_MODEL_PATH_VAR",
+    "fetch_enabled",
+    "load_lcsc_mapping",
+    "lcsc_cache_dir",
+    "resolve_lcsc_step",
+    "synthesize_model_block",
+]
+
+# Env var naming the on-disk LCSC STEP cache directory.  It doubles as the
+# ``(model ...)`` path variable emitted into committed ``.kicad_pcb`` files
+# (KiCad resolves ``${KCT_LCSC_3D_DIR}`` from the process environment at render
+# time), mirroring the ``${KICADn_3DMODEL_DIR}`` mechanism.
+DEFAULT_CACHE_ENV_VAR = "KCT_LCSC_3D_DIR"
+LCSC_MODEL_PATH_VAR = "${KCT_LCSC_3D_DIR}"
+
+# Env var that opts fetch-on-cache-miss in.  Absent/false => cache-only.
+FETCH_ENV_VAR = "KCT_LCSC_FETCH"
+
+# EasyEDA API surface (two plain HTTP GETs).  Endpoint URLs mirror
+# ``easyeda2kicad``'s ``easyeda/easyeda_api.py`` on ``master``.  EasyEDA
+# publishes no public API spec; if a fetch fails, re-check that upstream file
+# for endpoint drift before debugging this client.
+_API_COMPONENT_INFO = "https://easyeda.com/api/products/{lcsc_id}/components"
+_API_STEP_MODEL = "https://modules.easyeda.com/qAxj6KHrDKw4blvCG8QJPs7Y/{uuid}"
+_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+_HTTP_TIMEOUT = 30
+
+
+def lcsc_cache_dir() -> Path:
+    """Return the LCSC STEP cache directory (honoring ``KCT_LCSC_3D_DIR``).
+
+    Default: ``~/.cache/kicad-tools/lcsc-3d/``.  The directory is *not* created
+    here; callers create it lazily on first write.
+    """
+    override = os.environ.get(DEFAULT_CACHE_ENV_VAR)
+    if override:
+        return Path(override)
+    return Path.home() / ".cache" / "kicad-tools" / "lcsc-3d"
+
+
+def fetch_enabled(flag: bool = False) -> bool:
+    """True when fetch-on-cache-miss is permitted.
+
+    Enabled by an explicit *flag* (e.g. ``--fetch-lcsc``) or a truthy
+    ``KCT_LCSC_FETCH`` env var (``1``/``true``/``yes``/``on``).  Default is
+    cache-only (no network).
+    """
+    if flag:
+        return True
+    val = os.environ.get(FETCH_ENV_VAR, "").strip().lower()
+    return val in {"1", "true", "yes", "on"}
+
+
+def load_lcsc_mapping(sidecar_path: Path | str) -> dict[str, str]:
+    """Load a ``lib_id -> C-number`` sidecar (``lcsc_models.json``).
+
+    The sidecar is a flat JSON object, e.g.
+    ``{"Module:Joystick_Analog": "C50950"}``.  Raises ``ValueError`` on a
+    malformed file (not silently ignored -- a broken committed sidecar is a
+    build error, distinct from a runtime network failure).
+    """
+    path = Path(sidecar_path)
+    try:
+        raw = json.loads(path.read_text())
+    except OSError as e:
+        raise ValueError(f"cannot read LCSC sidecar {path}: {e}") from e
+    except json.JSONDecodeError as e:
+        raise ValueError(f"malformed LCSC sidecar {path}: {e}") from e
+    if not isinstance(raw, dict):
+        raise ValueError(f"LCSC sidecar {path} must be a JSON object of lib_id -> C-number")
+    mapping: dict[str, str] = {}
+    for key, value in raw.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            raise ValueError(
+                f"LCSC sidecar {path}: entries must be string lib_id -> string C-number"
+            )
+        mapping[key] = value
+    return mapping
+
+
+# --------------------------------------------------------------------------
+# Minimal in-repo EasyEDA fetch client (stdlib only; no ``easyeda2kicad`` dep)
+# --------------------------------------------------------------------------
+
+
+def _http_get(url: str) -> bytes | None:
+    """GET *url* with a browser User-Agent; return body bytes or ``None``.
+
+    Never raises -- any network/HTTP error degrades to ``None``.
+    """
+    req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})  # noqa: S310
+    try:
+        with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT) as resp:  # noqa: S310
+            body: bytes = resp.read()
+            return body
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, ValueError):
+        return None
+
+
+def _parse_3d_uuid(component_info: bytes) -> str | None:
+    """Extract the 3D-model uuid from an EasyEDA component-info JSON body.
+
+    The uuid lives in ``result.packageDetail.dataStr.shape`` as an
+    ``SVGNODE~{json}`` line whose parsed JSON has ``attrs.uuid`` (falling back
+    to a top-level ``uuid``).  Returns ``None`` when the shape carries no
+    3D-model node.
+    """
+    try:
+        doc = json.loads(component_info)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(doc, dict):
+        return None
+    result = doc.get("result")
+    if not isinstance(result, dict):
+        return None
+    package_detail = result.get("packageDetail")
+    if not isinstance(package_detail, dict):
+        return None
+    data_str = package_detail.get("dataStr")
+    if not isinstance(data_str, dict):
+        return None
+    shape = data_str.get("shape")
+    if not isinstance(shape, list):
+        return None
+    for entry in shape:
+        if not isinstance(entry, str) or not entry.startswith("SVGNODE"):
+            continue
+        # Format: "SVGNODE~{json}" (tilde-delimited).
+        _, _, payload = entry.partition("~")
+        if not payload:
+            continue
+        try:
+            node = json.loads(payload)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if not isinstance(node, dict):
+            continue
+        attrs = node.get("attrs")
+        if isinstance(attrs, dict):
+            uuid = attrs.get("uuid")
+            if isinstance(uuid, str) and uuid:
+                return uuid
+        uuid = node.get("uuid")
+        if isinstance(uuid, str) and uuid:
+            return uuid
+    return None
+
+
+def _fetch_lcsc_step(lcsc_id: str) -> bytes | None:
+    """Fetch raw STEP bytes for *lcsc_id* from EasyEDA, or ``None`` on failure.
+
+    Two GETs: component-info (to extract the 3D-model uuid) then the STEP body.
+    Never raises -- degrades to ``None`` on any network/parse failure.
+    """
+    info = _http_get(_API_COMPONENT_INFO.format(lcsc_id=lcsc_id))
+    if info is None:
+        return None
+    uuid = _parse_3d_uuid(info)
+    if not uuid:
+        return None
+    step = _http_get(_API_STEP_MODEL.format(uuid=uuid))
+    if not step:
+        return None
+    return step
+
+
+# --------------------------------------------------------------------------
+# Cache-aware resolution
+# --------------------------------------------------------------------------
+
+
+def resolve_lcsc_step(
+    lcsc_id: str,
+    *,
+    cache_dir: Path | None = None,
+    fetch: bool = False,
+    warn: object = None,
+) -> Path | None:
+    """Return the cached STEP path for *lcsc_id*, fetching on demand if enabled.
+
+    Cache hit -> returns the path with no network call.  Cache miss with
+    fetching enabled -> fetches, writes ``{lcsc_id}.step`` into *cache_dir*, and
+    returns it; a fetch failure warns (via *warn*, a ``callable(str)`` such as a
+    logger) and returns ``None``.  Cache miss with fetching disabled -> returns
+    ``None`` (no network).
+
+    Args:
+        lcsc_id: LCSC part number (e.g. ``"C50950"``).
+        cache_dir: Cache directory (default: :func:`lcsc_cache_dir`).
+        fetch: When True, fetch on a cache miss; when False, cache-only.
+        warn: Optional ``callable(str)`` invoked on a fetch failure.
+    """
+    cache = cache_dir if cache_dir is not None else lcsc_cache_dir()
+    step_path = cache / f"{lcsc_id}.step"
+    if step_path.is_file():
+        return step_path
+    if not fetch:
+        return None
+    data = _fetch_lcsc_step(lcsc_id)
+    if data is None:
+        if callable(warn):
+            warn(f"LCSC 3D model fetch failed for {lcsc_id} (no model inserted)")
+        return None
+    try:
+        cache.mkdir(parents=True, exist_ok=True)
+        step_path.write_bytes(data)
+    except OSError as e:
+        if callable(warn):
+            warn(f"LCSC 3D model cache write failed for {lcsc_id}: {e}")
+        return None
+    return step_path
+
+
+def synthesize_model_block(lcsc_id: str) -> str:
+    """Build a dedented ``(model ...)`` block referencing the LCSC cache.
+
+    The path uses the portable ``${KCT_LCSC_3D_DIR}`` variable and a baseline
+    ``(offset (xyz 0 0 0))`` so the shared offset machinery injects the full
+    target pad-centroid delta as the model's final offset.
+    """
+    return (
+        f'(model "{LCSC_MODEL_PATH_VAR}/{lcsc_id}.step"\n'
+        "\t(offset\n"
+        "\t\t(xyz 0 0 0)\n"
+        "\t)\n"
+        "\t(scale\n"
+        "\t\t(xyz 1 1 1)\n"
+        "\t)\n"
+        "\t(rotate\n"
+        "\t\t(xyz 0 0 0)\n"
+        "\t)\n"
+        ")"
+    )

--- a/src/kicad_tools/pcb/models3d.py
+++ b/src/kicad_tools/pcb/models3d.py
@@ -409,6 +409,11 @@ def make_library_resolver(
     allow_substitutions: bool = True,
     variant_log: dict[str, str] | None = None,
     substitution_log: dict[str, str] | None = None,
+    lcsc_mapping: dict[str, str] | None = None,
+    lcsc_fetch: bool = False,
+    lcsc_cache_dir: Path | None = None,
+    lcsc_log: dict[str, str] | None = None,
+    lcsc_warn: Callable[[str], None] | None = None,
 ) -> Resolver:
     """Build a resolver that reads model refs from installed KiCad libraries.
 
@@ -427,6 +432,13 @@ def make_library_resolver(
        curated ``lib_id -> lib_id`` mapping for generic/synthetic lib ids that
        have a body-compatible equivalent in a *different* library, when
        ``allow_substitutions`` is set.
+    4. **LCSC/EasyEDA fetch-on-demand** (``lcsc_models``) — an explicit,
+       committed ``lib_id -> C-number`` sidecar mapping whose STEP body is
+       resolved from a local cache (fetched on demand from EasyEDA when
+       ``lcsc_fetch`` is enabled), when *lcsc_mapping* is supplied.  The
+       synthesized ``(model ...)`` ref points at ``${KCT_LCSC_3D_DIR}`` and is
+       authored as **origin-centered** (``source_anchor=(0.0, 0.0)``) so the
+       shared offset machinery lands the body on the target pad centroid.
 
     Args:
         library_paths: Explicit library location (default: auto-detect).
@@ -439,6 +451,15 @@ def make_library_resolver(
         substitution_log: Optional dict populated with
             ``lib_id -> substitute lib_id`` for every cross-library
             substitution, so callers can report them.
+        lcsc_mapping: Optional ``lib_id -> C-number`` sidecar mapping enabling
+            the LCSC tier (tier 4).  Only lib ids present here are eligible.
+        lcsc_fetch: When True, fetch a missing STEP from EasyEDA on a cache
+            miss; default cache-only (no network).
+        lcsc_cache_dir: Optional LCSC STEP cache directory (default:
+            :func:`kicad_tools.pcb.lcsc_models.lcsc_cache_dir`).
+        lcsc_log: Optional dict populated with ``lib_id -> C-number`` for every
+            resolved LCSC match, so callers can report them.
+        lcsc_warn: Optional ``callable(str)`` invoked on a fetch failure.
     """
     paths = library_paths if library_paths is not None else detect_kicad_library_path()
     cache: dict[str, ResolvedModels | None] = {}
@@ -471,6 +492,34 @@ def make_library_resolver(
                         return mod_path, sub_id
         return None, None
 
+    def _resolve_lcsc(lib_id: str) -> ResolvedModels | None:
+        """Tier 4: LCSC/EasyEDA fetch-on-demand.  Returns None when the lib id
+        has no mapping, or the STEP is neither cached nor fetchable."""
+        if not lcsc_mapping:
+            return None
+        lcsc_id = lcsc_mapping.get(lib_id)
+        if not lcsc_id:
+            return None
+        # Imported lazily so the module (and the three installed-library tiers)
+        # never depend on the LCSC client unless the LCSC tier is actually used.
+        from kicad_tools.pcb.lcsc_models import resolve_lcsc_step, synthesize_model_block
+
+        step_path = resolve_lcsc_step(
+            lcsc_id,
+            cache_dir=lcsc_cache_dir,
+            fetch=lcsc_fetch,
+            warn=lcsc_warn,
+        )
+        if step_path is None:
+            # Skip-on-miss: report unresolved rather than emitting a ref to a
+            # file that is known-absent at patch time.
+            return None
+        if lcsc_log is not None:
+            lcsc_log[lib_id] = lcsc_id
+        # Origin-authored body: explicit (0, 0) source anchor so the shared
+        # offset math shifts by the full target pad centroid.
+        return ResolvedModels(models=[synthesize_model_block(lcsc_id)], source_anchor=(0.0, 0.0))
+
     def resolve(lib_id: str) -> ResolvedModels | None:
         if lib_id in cache:
             return cache[lib_id]
@@ -489,6 +538,8 @@ def make_library_resolver(
                     )
                     if sub_id is not None and substitution_log is not None:
                         substitution_log[lib_id] = sub_id
+        if result is None:
+            result = _resolve_lcsc(lib_id)
         cache[lib_id] = result
         return result
 
@@ -518,6 +569,9 @@ class ModelPatchReport:
     substitution_matches: dict[str, str] = field(default_factory=dict)
     """Lib ids whose model came from a cross-library substitution
     (``lib_id -> substitute lib_id``)."""
+    lcsc_matches: dict[str, str] = field(default_factory=dict)
+    """Lib ids whose model came from the LCSC/EasyEDA fetch tier
+    (``lib_id -> C-number``)."""
 
     @property
     def changed(self) -> bool:
@@ -592,6 +646,10 @@ def add_model_refs(
     resolver: Resolver | None = None,
     allow_variants: bool = True,
     allow_substitutions: bool = True,
+    lcsc_mapping: dict[str, str] | None = None,
+    lcsc_fetch: bool = False,
+    lcsc_cache_dir: Path | None = None,
+    lcsc_warn: Callable[[str], None] | None = None,
     dry_run: bool = False,
 ) -> ModelPatchReport:
     """Patch missing 3D model refs into a ``.kicad_pcb`` file.
@@ -608,6 +666,16 @@ def add_model_refs(
         allow_substitutions: Accept curated cross-library substitutions when
             exact + variant matching both miss (reported in
             ``substitution_matches``). Ignored when *resolver* is supplied.
+        lcsc_mapping: Optional ``lib_id -> C-number`` sidecar enabling the LCSC
+            fetch tier (reported in ``lcsc_matches``). Ignored when *resolver*
+            is supplied.
+        lcsc_fetch: When True, fetch a missing LCSC STEP on a cache miss;
+            default cache-only (no network). Ignored when *resolver* is
+            supplied.
+        lcsc_cache_dir: Optional LCSC STEP cache directory. Ignored when
+            *resolver* is supplied.
+        lcsc_warn: Optional ``callable(str)`` invoked on an LCSC fetch failure.
+            Ignored when *resolver* is supplied.
         dry_run: When True, nothing is written.
 
     Returns:
@@ -617,6 +685,7 @@ def add_model_refs(
     text = pcb_path.read_text()
     variant_log: dict[str, str] = {}
     substitution_log: dict[str, str] = {}
+    lcsc_log: dict[str, str] = {}
     if resolver is None:
         resolver = make_library_resolver(
             library_paths,
@@ -624,6 +693,11 @@ def add_model_refs(
             allow_substitutions=allow_substitutions,
             variant_log=variant_log,
             substitution_log=substitution_log,
+            lcsc_mapping=lcsc_mapping,
+            lcsc_fetch=lcsc_fetch,
+            lcsc_cache_dir=lcsc_cache_dir,
+            lcsc_log=lcsc_log,
+            lcsc_warn=lcsc_warn,
         )
     new_text, report = add_model_refs_to_text(text, resolver)
     # Only surface variants/substitutions that actually got patched in.
@@ -632,6 +706,9 @@ def add_model_refs(
     }
     report.substitution_matches = {
         lib_id: sub for lib_id, sub in substitution_log.items() if lib_id in report.patched
+    }
+    report.lcsc_matches = {
+        lib_id: cnum for lib_id, cnum in lcsc_log.items() if lib_id in report.patched
     }
     if report.changed and not dry_run:
         dest = Path(output_path) if output_path is not None else pcb_path

--- a/tests/test_lcsc_models.py
+++ b/tests/test_lcsc_models.py
@@ -169,6 +169,22 @@ class TestFetchClient:
         with mock.patch("urllib.request.urlopen", fake_urlopen):
             assert _fetch_lcsc_step("C50950") is None
 
+    def test_oversize_step_body_rejected(self):
+        # A rogue endpoint returns a body over the size cap: reject, don't cache.
+        huge = b"ISO-10303-21;" + b"\x00" * (50 * 1024 * 1024 + 1)
+        fake = _urlopen_router({"/api/products/C50950/components": COMPONENT_INFO, FAKE_UUID: huge})
+        with mock.patch("urllib.request.urlopen", fake):
+            assert _fetch_lcsc_step("C50950") is None
+
+    def test_non_step_body_rejected(self):
+        # A body without the ISO-10303-21 header is not a STEP file: reject.
+        not_step = b"<html>totally not a step file</html>"
+        fake = _urlopen_router(
+            {"/api/products/C50950/components": COMPONENT_INFO, FAKE_UUID: not_step}
+        )
+        with mock.patch("urllib.request.urlopen", fake):
+            assert _fetch_lcsc_step("C50950") is None
+
 
 # --------------------------------------------------------------------------
 # Cache-aware resolution
@@ -222,6 +238,33 @@ class TestResolveCache:
             path = resolve_lcsc_step("C50950", cache_dir=tmp_path, fetch=True, warn=warnings.append)
         assert path is None
         assert warnings and "C50950" in warnings[0]
+
+    @pytest.mark.parametrize(
+        "bad_id",
+        [
+            "../outside/pwned",  # path traversal into a sibling dir
+            "C1/../../evil?x=",  # URL/path injection
+            "../../../etc/whatever",  # ref-injection style traversal
+            "not-a-c-number",  # non-C value
+            "C",  # 'C' with no digits
+            "",  # empty
+        ],
+    )
+    def test_invalid_id_never_touches_fs_or_network(self, tmp_path, bad_id):
+        # A malicious/malformed id must warn + return None and never write a
+        # file, format a URL, or escape the cache dir.
+        warnings: list[str] = []
+
+        def forbidden(req, timeout=None):  # noqa: ANN001
+            raise AssertionError("invalid id must not reach the network")
+
+        with mock.patch("urllib.request.urlopen", forbidden):
+            path = resolve_lcsc_step(bad_id, cache_dir=tmp_path, fetch=True, warn=warnings.append)
+        assert path is None
+        assert warnings and "invalid C-number" in warnings[0]
+        # Nothing was written anywhere under (or above) the cache dir.
+        assert not any(tmp_path.rglob("*.step"))
+        assert not (tmp_path.parent / "outside" / "pwned.step").exists()
 
 
 # --------------------------------------------------------------------------
@@ -281,6 +324,24 @@ class TestSidecar:
         sidecar = tmp_path / "num.json"
         sidecar.write_text(json.dumps({"Lib:Name": 123}))
         with pytest.raises(ValueError, match="string"):
+            load_lcsc_mapping(sidecar)
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            "../outside/pwned",  # path traversal
+            "C1/../../evil?x=",  # URL injection
+            "not-a-c-number",  # non-C value
+            "C",  # 'C' with no digits
+            "c50950",  # lowercase 'c'
+        ],
+    )
+    def test_invalid_cnumber_is_build_error(self, tmp_path, bad_value):
+        # An untrusted, malformed C-number in a committed sidecar must raise
+        # (build error), never flow silently into the cache/URL/ref sinks.
+        sidecar = tmp_path / "bad_cnumber.json"
+        sidecar.write_text(json.dumps({"Module:Joystick_Analog": bad_value}))
+        with pytest.raises(ValueError, match="invalid C-number"):
             load_lcsc_mapping(sidecar)
 
 

--- a/tests/test_lcsc_models.py
+++ b/tests/test_lcsc_models.py
@@ -1,0 +1,496 @@
+"""Tests for the LCSC/EasyEDA fetch-on-demand 3D model tier.
+
+Covers the minimal in-repo EasyEDA client (mocked, no real network),
+cache hit/miss semantics, offline no-op safety, the fourth resolver tier in
+``make_library_resolver``, ``${KCT_LCSC_3D_DIR}`` path-variable emission,
+skip-on-miss (no dangling ref), and origin-authored offset math parity with
+the #4045 offset machinery.
+
+No test in this file makes a real network call: ``urllib.request.urlopen`` is
+patched everywhere fetching is exercised, and a guard test asserts the
+offline/cache-only path never even constructs a request.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from kicad_tools.footprints.library_path import LibraryPaths
+from kicad_tools.pcb.lcsc_models import (
+    DEFAULT_CACHE_ENV_VAR,
+    LCSC_MODEL_PATH_VAR,
+    _fetch_lcsc_step,
+    _parse_3d_uuid,
+    fetch_enabled,
+    lcsc_cache_dir,
+    load_lcsc_mapping,
+    resolve_lcsc_step,
+    synthesize_model_block,
+)
+from kicad_tools.pcb.models3d import (
+    add_model_refs_to_text,
+    make_library_resolver,
+)
+
+# --------------------------------------------------------------------------
+# Fixtures: a mocked EasyEDA component-info body + fake STEP bytes
+# --------------------------------------------------------------------------
+
+FAKE_UUID = "7b135d4c7d084b658994bacec4f3b635"
+FAKE_STEP = b"ISO-10303-21;\r\nHEADER;\r\n/* fake step body */\r\nEND-ISO-10303-21;\r\n"
+
+COMPONENT_INFO = json.dumps(
+    {
+        "success": True,
+        "result": {
+            "packageDetail": {
+                "dataStr": {
+                    "shape": [
+                        "TRACK~0.5~1~gge1~100 100 200 100",
+                        "SVGNODE~"
+                        + json.dumps(
+                            {
+                                "gId": "gge5",
+                                "attrs": {
+                                    "c_width": "10",
+                                    "uuid": FAKE_UUID,
+                                    "title": "FakePart",
+                                },
+                            }
+                        ),
+                    ]
+                }
+            }
+        },
+    }
+).encode()
+
+
+def _urlopen_router(responses: dict[str, bytes]):
+    """Build a fake ``urlopen`` returning bytes keyed by URL substring.
+
+    Each value is served as an object with ``.read()`` usable as a context
+    manager, matching ``urllib.request.urlopen``'s contract.
+    """
+    calls: list[str] = []
+
+    def fake_urlopen(req, timeout=None):  # noqa: ANN001
+        url = req.full_url if hasattr(req, "full_url") else str(req)
+        calls.append(url)
+        for needle, body in responses.items():
+            if needle in url:
+                return io.BytesIO(body)
+        raise AssertionError(f"unexpected URL fetched: {url}")
+
+    fake_urlopen.calls = calls  # type: ignore[attr-defined]
+    return fake_urlopen
+
+
+# --------------------------------------------------------------------------
+# uuid parsing
+# --------------------------------------------------------------------------
+
+
+class TestParseUuid:
+    def test_extracts_uuid_from_svgnode(self):
+        assert _parse_3d_uuid(COMPONENT_INFO) == FAKE_UUID
+
+    def test_top_level_uuid_fallback(self):
+        body = json.dumps(
+            {
+                "result": {
+                    "packageDetail": {
+                        "dataStr": {"shape": ["SVGNODE~" + json.dumps({"uuid": "abc123"})]}
+                    }
+                }
+            }
+        ).encode()
+        assert _parse_3d_uuid(body) == "abc123"
+
+    def test_no_svgnode_returns_none(self):
+        body = json.dumps(
+            {"result": {"packageDetail": {"dataStr": {"shape": ["TRACK~x"]}}}}
+        ).encode()
+        assert _parse_3d_uuid(body) is None
+
+    def test_malformed_json_returns_none(self):
+        assert _parse_3d_uuid(b"not json") is None
+
+    def test_missing_keys_return_none(self):
+        assert _parse_3d_uuid(json.dumps({"result": {}}).encode()) is None
+        assert _parse_3d_uuid(json.dumps({}).encode()) is None
+
+
+# --------------------------------------------------------------------------
+# Fetch client (mocked network)
+# --------------------------------------------------------------------------
+
+
+class TestFetchClient:
+    def test_two_call_fetch_success(self):
+        fake = _urlopen_router(
+            {"/api/products/C50950/components": COMPONENT_INFO, FAKE_UUID: FAKE_STEP}
+        )
+        with mock.patch("urllib.request.urlopen", fake):
+            step = _fetch_lcsc_step("C50950")
+        assert step == FAKE_STEP
+        # Two GETs: component-info then STEP.
+        assert len(fake.calls) == 2
+        assert "/api/products/C50950/components" in fake.calls[0]
+        assert FAKE_UUID in fake.calls[1]
+
+    def test_component_info_http_failure_returns_none(self):
+        def boom(req, timeout=None):  # noqa: ANN001
+            raise OSError("network down")
+
+        with mock.patch("urllib.request.urlopen", boom):
+            assert _fetch_lcsc_step("C50950") is None
+
+    def test_no_uuid_skips_step_fetch(self):
+        empty = json.dumps({"result": {"packageDetail": {"dataStr": {"shape": []}}}}).encode()
+        fake = _urlopen_router({"/api/products/C1/components": empty})
+        with mock.patch("urllib.request.urlopen", fake):
+            assert _fetch_lcsc_step("C1") is None
+        # Only the component-info call happened; STEP endpoint never hit.
+        assert len(fake.calls) == 1
+
+    def test_step_fetch_failure_returns_none(self):
+        def fake_urlopen(req, timeout=None):  # noqa: ANN001
+            url = req.full_url
+            if "components" in url:
+                return io.BytesIO(COMPONENT_INFO)
+            raise OSError("step endpoint down")
+
+        with mock.patch("urllib.request.urlopen", fake_urlopen):
+            assert _fetch_lcsc_step("C50950") is None
+
+
+# --------------------------------------------------------------------------
+# Cache-aware resolution
+# --------------------------------------------------------------------------
+
+
+class TestResolveCache:
+    def test_cache_hit_makes_no_network_call(self, tmp_path):
+        (tmp_path / "C50950.step").write_bytes(FAKE_STEP)
+
+        def forbidden(req, timeout=None):  # noqa: ANN001
+            raise AssertionError("network called on a cache hit")
+
+        with mock.patch("urllib.request.urlopen", forbidden):
+            path = resolve_lcsc_step("C50950", cache_dir=tmp_path, fetch=True)
+        assert path == tmp_path / "C50950.step"
+
+    def test_cache_miss_fetch_disabled_is_offline_noop(self, tmp_path):
+        def forbidden(req, timeout=None):  # noqa: ANN001
+            raise AssertionError("network called with fetch disabled")
+
+        with mock.patch("urllib.request.urlopen", forbidden):
+            assert resolve_lcsc_step("C50950", cache_dir=tmp_path, fetch=False) is None
+        assert not (tmp_path / "C50950.step").exists()
+
+    def test_cache_miss_fetch_enabled_writes_then_hits(self, tmp_path):
+        fake = _urlopen_router(
+            {"/api/products/C50950/components": COMPONENT_INFO, FAKE_UUID: FAKE_STEP}
+        )
+        with mock.patch("urllib.request.urlopen", fake):
+            path = resolve_lcsc_step("C50950", cache_dir=tmp_path, fetch=True)
+        assert path == tmp_path / "C50950.step"
+        assert path.read_bytes() == FAKE_STEP
+        assert len(fake.calls) == 2
+
+        # Second resolution is a pure cache hit — no further network.
+        def forbidden(req, timeout=None):  # noqa: ANN001
+            raise AssertionError("second resolve should hit cache")
+
+        with mock.patch("urllib.request.urlopen", forbidden):
+            path2 = resolve_lcsc_step("C50950", cache_dir=tmp_path, fetch=True)
+        assert path2 == path
+
+    def test_fetch_failure_warns_and_returns_none(self, tmp_path):
+        warnings: list[str] = []
+
+        def boom(req, timeout=None):  # noqa: ANN001
+            raise OSError("down")
+
+        with mock.patch("urllib.request.urlopen", boom):
+            path = resolve_lcsc_step("C50950", cache_dir=tmp_path, fetch=True, warn=warnings.append)
+        assert path is None
+        assert warnings and "C50950" in warnings[0]
+
+
+# --------------------------------------------------------------------------
+# Cache dir / fetch-flag env resolution
+# --------------------------------------------------------------------------
+
+
+class TestConfig:
+    def test_cache_dir_default(self, monkeypatch):
+        monkeypatch.delenv(DEFAULT_CACHE_ENV_VAR, raising=False)
+        assert lcsc_cache_dir() == Path.home() / ".cache" / "kicad-tools" / "lcsc-3d"
+
+    def test_cache_dir_env_override(self, monkeypatch, tmp_path):
+        monkeypatch.setenv(DEFAULT_CACHE_ENV_VAR, str(tmp_path))
+        assert lcsc_cache_dir() == tmp_path
+
+    def test_fetch_enabled_flag(self, monkeypatch):
+        monkeypatch.delenv("KCT_LCSC_FETCH", raising=False)
+        assert fetch_enabled(True) is True
+        assert fetch_enabled(False) is False
+
+    @pytest.mark.parametrize("val", ["1", "true", "YES", "on"])
+    def test_fetch_enabled_env_truthy(self, monkeypatch, val):
+        monkeypatch.setenv("KCT_LCSC_FETCH", val)
+        assert fetch_enabled(False) is True
+
+    @pytest.mark.parametrize("val", ["0", "false", "", "no"])
+    def test_fetch_enabled_env_falsy(self, monkeypatch, val):
+        monkeypatch.setenv("KCT_LCSC_FETCH", val)
+        assert fetch_enabled(False) is False
+
+
+# --------------------------------------------------------------------------
+# Sidecar loading
+# --------------------------------------------------------------------------
+
+
+class TestSidecar:
+    def test_loads_lib_id_to_cnumber(self, tmp_path):
+        sidecar = tmp_path / "lcsc_models.json"
+        sidecar.write_text(json.dumps({"Module:Joystick_Analog": "C50950"}))
+        assert load_lcsc_mapping(sidecar) == {"Module:Joystick_Analog": "C50950"}
+
+    def test_malformed_json_raises_value_error(self, tmp_path):
+        sidecar = tmp_path / "bad.json"
+        sidecar.write_text("{not json")
+        with pytest.raises(ValueError, match="malformed"):
+            load_lcsc_mapping(sidecar)
+
+    def test_non_object_raises(self, tmp_path):
+        sidecar = tmp_path / "list.json"
+        sidecar.write_text("[1, 2]")
+        with pytest.raises(ValueError, match="must be a JSON object"):
+            load_lcsc_mapping(sidecar)
+
+    def test_non_string_values_raise(self, tmp_path):
+        sidecar = tmp_path / "num.json"
+        sidecar.write_text(json.dumps({"Lib:Name": 123}))
+        with pytest.raises(ValueError, match="string"):
+            load_lcsc_mapping(sidecar)
+
+
+# --------------------------------------------------------------------------
+# Synthesized model block
+# --------------------------------------------------------------------------
+
+
+class TestSynthesize:
+    def test_uses_portable_path_variable(self):
+        block = synthesize_model_block("C50950")
+        assert block.startswith(f'(model "{LCSC_MODEL_PATH_VAR}/C50950.step"')
+        assert "${KCT_LCSC_3D_DIR}" in block
+        assert "(offset" in block and "(xyz 0 0 0)" in block
+        assert block.endswith(")")
+
+
+# --------------------------------------------------------------------------
+# Fourth resolver tier integration (via make_library_resolver)
+# --------------------------------------------------------------------------
+
+# A board footprint with a synthetic lib id no installed library covers, pads
+# centered off origin so the offset math has a non-trivial delta.
+PCB_LCSC = """(kicad_pcb
+\t(version 20240108)
+\t(generator "kicad_tools")
+\t(footprint "Module:Joystick_Analog"
+\t\t(layer "F.Cu")
+\t\t(at 50 50)
+\t\t(pad "1" thru_hole circle
+\t\t\t(at 2.0 -1.27)
+\t\t\t(size 1.7 1.7)
+\t\t\t(drill 1.0)
+\t\t\t(layers "*.Cu" "*.Mask")
+\t\t)
+\t)
+)
+"""
+
+
+# An empty (no-pad) footprints tree: forces the installed-library tiers to
+# miss so the LCSC tier is the only one that can resolve.
+def _empty_library(tmp_path: Path) -> LibraryPaths:
+    root = tmp_path / "footprints"
+    root.mkdir(parents=True)
+    return LibraryPaths(footprints_path=root, source="config")
+
+
+class TestLcscTier:
+    def test_cache_hit_resolves_and_emits_portable_ref(self, tmp_path):
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        (cache / "C50950.step").write_bytes(FAKE_STEP)
+        lib = _empty_library(tmp_path)
+        log: dict[str, str] = {}
+        resolver = make_library_resolver(
+            lib,
+            lcsc_mapping={"Module:Joystick_Analog": "C50950"},
+            lcsc_cache_dir=cache,
+            lcsc_fetch=False,
+            lcsc_log=log,
+        )
+        new_text, report = add_model_refs_to_text(PCB_LCSC, resolver)
+
+        assert report.patched == ["Module:Joystick_Analog"]
+        assert log == {"Module:Joystick_Analog": "C50950"}
+        assert "${KCT_LCSC_3D_DIR}/C50950.step" in new_text
+        # A portable variable, never an absolute cache path.
+        assert str(cache) not in new_text
+
+    def test_skip_on_miss_reports_unresolved_no_dangling_ref(self, tmp_path):
+        # Empty cache, fetch disabled: the tier must skip, not emit a ref.
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        lib = _empty_library(tmp_path)
+        resolver = make_library_resolver(
+            lib,
+            lcsc_mapping={"Module:Joystick_Analog": "C50950"},
+            lcsc_cache_dir=cache,
+            lcsc_fetch=False,
+        )
+
+        def forbidden(req, timeout=None):  # noqa: ANN001
+            raise AssertionError("offline no-op must not touch the network")
+
+        with mock.patch("urllib.request.urlopen", forbidden):
+            new_text, report = add_model_refs_to_text(PCB_LCSC, resolver)
+
+        assert report.patched == []
+        assert report.unresolved == ["Module:Joystick_Analog"]
+        assert "(model " not in new_text
+        assert new_text == PCB_LCSC  # pure no-op
+
+    def test_no_mapping_entry_is_unresolved(self, tmp_path):
+        lib = _empty_library(tmp_path)
+        resolver = make_library_resolver(lib, lcsc_mapping={"Other:Part": "C1"})
+        _, report = add_model_refs_to_text(PCB_LCSC, resolver)
+        assert report.unresolved == ["Module:Joystick_Analog"]
+
+    def test_fetch_enabled_writes_cache_and_patches(self, tmp_path):
+        cache = tmp_path / "cache"
+        lib = _empty_library(tmp_path)
+        fake = _urlopen_router(
+            {"/api/products/C50950/components": COMPONENT_INFO, FAKE_UUID: FAKE_STEP}
+        )
+        resolver = make_library_resolver(
+            lib,
+            lcsc_mapping={"Module:Joystick_Analog": "C50950"},
+            lcsc_cache_dir=cache,
+            lcsc_fetch=True,
+        )
+        with mock.patch("urllib.request.urlopen", fake):
+            new_text, report = add_model_refs_to_text(PCB_LCSC, resolver)
+        assert report.patched == ["Module:Joystick_Analog"]
+        assert (cache / "C50950.step").read_bytes() == FAKE_STEP
+        assert "${KCT_LCSC_3D_DIR}/C50950.step" in new_text
+
+
+# --------------------------------------------------------------------------
+# Offset math: origin-authored source_anchor composes with #4045 machinery
+# --------------------------------------------------------------------------
+
+
+class TestLcscOffset:
+    def test_resolver_returns_origin_source_anchor(self, tmp_path):
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        (cache / "C50950.step").write_bytes(FAKE_STEP)
+        lib = _empty_library(tmp_path)
+        resolver = make_library_resolver(
+            lib,
+            lcsc_mapping={"Module:Joystick_Analog": "C50950"},
+            lcsc_cache_dir=cache,
+        )
+        resolved = resolver("Module:Joystick_Analog")
+        assert resolved is not None
+        # Explicit origin (NOT None) so the delta becomes the full target
+        # pad centroid, not a zero shift.
+        assert resolved.source_anchor == (0.0, 0.0)
+
+    def test_offset_equals_target_pad_centroid_with_y_negated(self, tmp_path):
+        # Single pad at (2.0, -1.27): centroid == (2.0, -1.27); the emitted
+        # model offset must be (2.0, +1.27, 0) — Y negated per the model frame.
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        (cache / "C50950.step").write_bytes(FAKE_STEP)
+        lib = _empty_library(tmp_path)
+        resolver = make_library_resolver(
+            lib,
+            lcsc_mapping={"Module:Joystick_Analog": "C50950"},
+            lcsc_cache_dir=cache,
+        )
+        new_text, report = add_model_refs_to_text(PCB_LCSC, resolver)
+        assert report.patched == ["Module:Joystick_Analog"]
+        # The inserted model's own offset carries the target pad-centroid delta.
+        assert "(xyz 2 1.27 0)" in new_text
+
+
+# --------------------------------------------------------------------------
+# _render_env registers the LCSC path variable
+# --------------------------------------------------------------------------
+
+
+class TestRenderEnv:
+    def test_render_env_sets_lcsc_dir_default(self, tmp_path, monkeypatch):
+        from kicad_tools.cli.runner import _render_env
+
+        monkeypatch.delenv(DEFAULT_CACHE_ENV_VAR, raising=False)
+        # Point KiCad model discovery at a real dir so env isn't None.
+        model_dir = tmp_path / "3dmodels"
+        model_dir.mkdir()
+        monkeypatch.setenv("KICAD10_3DMODEL_DIR", str(model_dir))
+        env = _render_env(None)
+        assert env is not None
+        expected = str(Path.home() / ".cache" / "kicad-tools" / "lcsc-3d")
+        assert env[DEFAULT_CACHE_ENV_VAR] == expected
+
+    def test_render_env_lcsc_dir_env_not_overridden(self, tmp_path, monkeypatch):
+        from kicad_tools.cli.runner import _render_env
+
+        model_dir = tmp_path / "3dmodels"
+        model_dir.mkdir()
+        monkeypatch.setenv("KICAD10_3DMODEL_DIR", str(model_dir))
+        monkeypatch.setenv(DEFAULT_CACHE_ENV_VAR, "/custom/lcsc")
+        env = _render_env(None)
+        assert env is not None
+        assert env[DEFAULT_CACHE_ENV_VAR] == "/custom/lcsc"
+
+    def test_render_env_sets_lcsc_dir_even_without_kicad_libs(self, tmp_path, monkeypatch):
+        """LCSC cache is independent of the KiCad 3dmodels dir."""
+        from kicad_tools.cli import runner
+
+        for var in runner.KICAD_3DMODEL_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv(DEFAULT_CACHE_ENV_VAR, str(tmp_path / "lcsc"))
+        # No KiCad model dir discoverable.
+        monkeypatch.setattr(runner, "find_kicad_3dmodel_dir", lambda cli: None)
+        env = runner._render_env(None)
+        # DEFAULT_CACHE_ENV_VAR was already set -> inherit-as-is (None).
+        assert env is None
+
+    def test_render_env_injects_lcsc_when_only_lcsc_missing(self, tmp_path, monkeypatch):
+        from kicad_tools.cli import runner
+
+        for var in runner.KICAD_3DMODEL_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.delenv(DEFAULT_CACHE_ENV_VAR, raising=False)
+        model_dir = tmp_path / "3dmodels"
+        model_dir.mkdir()
+        monkeypatch.setattr(runner, "find_kicad_3dmodel_dir", lambda cli: model_dir)
+        env = runner._render_env(None)
+        assert env is not None
+        assert env[DEFAULT_CACHE_ENV_VAR] == str(lcsc_cache_dir())

--- a/tests/test_render_cmd.py
+++ b/tests/test_render_cmd.py
@@ -403,8 +403,20 @@ class TestRender3DModelEnv:
         assert env["KICAD10_3DMODEL_DIR"] == str(model_dir)
 
     def test_no_model_dir_inherits_environment(self, tmp_path, monkeypatch):
+        # With no KiCad model dir AND the LCSC cache var already set, there is
+        # nothing to inject, so the env is inherited as-is (None).
+        monkeypatch.setenv("KCT_LCSC_3D_DIR", str(tmp_path / "lcsc"))
         captured = self._run_and_capture_kwargs(tmp_path, monkeypatch, None)
         assert captured["kwargs"]["env"] is None
+
+    def test_no_model_dir_still_injects_lcsc_cache_var(self, tmp_path, monkeypatch):
+        # No KiCad model dir, but the LCSC cache var is unset: inject its
+        # default so committed ${KCT_LCSC_3D_DIR} refs still resolve at render.
+        monkeypatch.delenv("KCT_LCSC_3D_DIR", raising=False)
+        captured = self._run_and_capture_kwargs(tmp_path, monkeypatch, None)
+        env = captured["kwargs"]["env"]
+        assert env is not None
+        assert "KCT_LCSC_3D_DIR" in env
 
     def test_find_kicad_3dmodel_dir_env_wins(self, tmp_path, monkeypatch):
         from kicad_tools.cli.runner import find_kicad_3dmodel_dir


### PR DESCRIPTION
## Summary

Adds a **fourth tier** to `kct pcb add-3d-models` that resolves a 3D STEP body for footprints whose only usable identity is an **LCSC C-number** (the JLCPCB-assembly fleet already carries these in its BOMs), closing the residual gap that no installed KiCad library can reach.

Implements all four curator rulings on issue #4072.

### Client design (ruling a — no new dependency)
`src/kicad_tools/pcb/lcsc_models.py` (new): a ~50-line, **stdlib-only** (`urllib` + `json`) in-repo EasyEDA client. Two HTTP GETs:
1. `GET https://easyeda.com/api/products/{lcsc_id}/components` → parse the 3D-model `uuid` from the `SVGNODE` entry in `result.packageDetail.dataStr.shape`.
2. `GET https://modules.easyeda.com/qAxj6KHrDKw4blvCG8QJPs7Y/{uuid}` → raw STEP bytes.

No `easyeda2kicad` dependency added. Fetch/parse failures never raise — they degrade to `None`.

### Tier integration (ruling b — origin-authored anchor)
`models3d.py`: fourth tier in `make_library_resolver`, gated by a committed `lib_id -> C-number` sidecar. It returns `ResolvedModels(models=[synthesized_block], source_anchor=(0.0, 0.0))` — an **explicit** origin (not `None`) — so the #4045 offset machinery computes `dx, dy = target_pad_centroid` and lands the origin-authored body on the target footprint's pads. **Zero changes** to `_pad_anchor` / `_apply_offset_delta` / `add_model_refs_to_text`. Skip-on-miss (reports `unresolved`) rather than emitting a dangling ref. Added `lcsc_matches` to `ModelPatchReport`.

### Cache / env-var behavior (rulings c + d)
- Sidecar is **lib_id-keyed** only (`{"Module:Joystick_Analog": "C50950"}`) — no reference-designator plumbing.
- Cache dir `KCT_LCSC_3D_DIR` (default `~/.cache/kicad-tools/lcsc-3d/`), one `.step` per C-number.
- Emitted refs use the portable `${KCT_LCSC_3D_DIR}` path variable; `runner.py::_render_env` now `setdefault`s it into the render subprocess env (mirrors the `KICADn_3DMODEL_DIR` pattern from #4012), so committed refs stay machine-portable.
- CLI: `--lcsc-models <sidecar>` + `--fetch-lcsc` opt-in (also `KCT_LCSC_FETCH=1`). **Cache-only by default; CI needs no network.**

### Real-fetch sanity result (C50950, run manually, not in the test suite)
- Component-info GET → 11669 bytes → parsed uuid `7b135d4c7d084b658994bacec4f3b635`.
- STEP GET → 1896563 bytes, header `ISO-10303-21; ... FILE_DESCRIPTION (( 'STEP AP214' )...` — a valid STEP file.
- Full CLI path (`--lcsc-models ... --fetch-lcsc`) emitted `(model "${KCT_LCSC_3D_DIR}/C50950.step" ...)` with offset `(xyz 2 1.27 0)` (Y-negated, matching the `(2.0, -1.27)` pad centroid) and cached the STEP. The offline run (empty cache, fetch disabled) reported `unresolved` and made **zero** network calls.
- **No downloaded STEP is committed** (design/license posture: not redistributable).

### Test results
- New `tests/test_lcsc_models.py`: 39 tests — mocked-API fetch (both endpoints, uuid parse, error paths), cache hit/miss, offline no-op (guarded so any network call fails the test), `${KCT_LCSC_3D_DIR}` emission, origin-anchor offset math, skip-on-miss, `_render_env` LCSC-var injection.
- `tests/test_pcb_add_3d_models.py` + `tests/test_render_cmd.py` + new file: **113 passed** (updated one pre-existing render-env test for the new LCSC-var injection behavior).
- `ruff check` + `ruff format --check`: clean on touched files.
- mypy: touched files clean; the 7 `runner.py` errors are pre-existing on `origin/main` (verified by stash) — no new mypy errors introduced.

### Follow-up
Sibling **#4073** (fleet application, closes #4032) builds on this tier and should run **after** this merges.

Closes #4072

🤖 Generated with [Claude Code](https://claude.com/claude-code)