### PR TITLE
feat(3d): apply LCSC tier to fleet waived parts (Joystick_Analog C50950, PCIE_Mini_Edge C444929)

### DIFF
--- a/boards/03-usb-joystick/lcsc_models.json
+++ b/boards/03-usb-joystick/lcsc_models.json
@@ -1,0 +1,3 @@
+{
+  "Module:Joystick_Analog": "C50950"
+}

--- a/boards/03-usb-joystick/output/usb_joystick.kicad_pcb
+++ b/boards/03-usb-joystick/output/usb_joystick.kicad_pcb
@@ -163,6 +163,17 @@
     (pad "3" thru_hole circle (at 0 0) (size 1.6 1.6) (drill 1.0) (layers "*.Cu" "*.Mask") (net 8 "JOY_X"))
     (pad "4" thru_hole circle (at 2 0) (size 1.6 1.6) (drill 1.0) (layers "*.Cu" "*.Mask") (net 9 "JOY_Y"))
     (pad "5" thru_hole circle (at 4 0) (size 1.6 1.6) (drill 1.0) (layers "*.Cu" "*.Mask") (net 10 "JOY_BTN"))
+  	(model "${KCT_LCSC_3D_DIR}/C50950.step"
+  		(offset
+  			(xyz 0 0 0)
+  		)
+  		(scale
+  			(xyz 1 1 1)
+  		)
+  		(rotate
+  			(xyz 0 0 0)
+  		)
+  	)
   )
   (footprint "Crystal:Crystal_HC49-U_Vertical"
     (layer "F.Cu")

--- a/boards/03-usb-joystick/output/usb_joystick_routed.kicad_pcb
+++ b/boards/03-usb-joystick/output/usb_joystick_routed.kicad_pcb
@@ -1714,6 +1714,17 @@
 			(net 10 "JOY_BTN")
 		)
 		(embedded_fonts no)
+		(model "${KCT_LCSC_3D_DIR}/C50950.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
 	)
 	(footprint "Button_Switch_SMD:SW_SPST_TL3342"
 		(layer "F.Cu")

--- a/boards/06-diffpair-test/lcsc_models.json
+++ b/boards/06-diffpair-test/lcsc_models.json
@@ -1,0 +1,3 @@
+{
+  "Connector_PCIE:PCIE_Mini_Edge": "C444929"
+}

--- a/boards/06-diffpair-test/output/diffpair_test.kicad_pcb
+++ b/boards/06-diffpair-test/output/diffpair_test.kicad_pcb
@@ -132,6 +132,17 @@
     (pad "10" smd rect (at 0.000 2.800) (size 0.500 0.600) (layers "F.Cu" "F.Paste" "F.Mask") (net 4 "+1V2"))
     (pad "11" smd rect (at 0.000 3.600) (size 0.500 0.600) (layers "F.Cu" "F.Paste" "F.Mask") (net 5 "GND"))
     (pad "12" smd rect (at 0.000 4.400) (size 0.500 0.600) (layers "F.Cu" "F.Paste" "F.Mask") (net 5 "GND"))
+  	(model "${KCT_LCSC_3D_DIR}/C444929.step"
+  		(offset
+  			(xyz 0 0 0)
+  		)
+  		(scale
+  			(xyz 1 1 1)
+  		)
+  		(rotate
+  			(xyz 0 0 0)
+  		)
+  	)
   )
   (footprint "Connector_FFC:FFC_4P_0.5mm"
     (layer "F.Cu")

--- a/boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb
+++ b/boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb
@@ -1626,6 +1626,17 @@
 			(net 5 "GND")
 		)
 		(embedded_fonts no)
+		(model "${KCT_LCSC_3D_DIR}/C444929.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
 	)
 	(footprint "Package_BGA:BGA-49_5.0x5.0mm_Layout7x7_P0.5mm"
 		(layer "F.Cu")


### PR DESCRIPTION
## Summary

Applies the merged LCSC/EasyEDA fetch-on-demand 3D resolver tier (#4072 / PR #4075) to the fleet's two remaining bare synthetic footprints — the parts #4032 waived from the #4014/#4033 substitution work because no cleanly-redistributable vendor STEP or installed KiCad library covers them.

**Both C-numbers resolved and fetch-verified in-session** (this environment has network access), so #4032 is closed in full — no follow-up needed.

## C-number picks (both fetch-verified against EasyEDA)

| Board | ref | lib_id | C-number | Body | STEP |
|---|---|---|---|---|---|
| 03-usb-joystick | J2 | `Module:Joystick_Analog` | **C50950** | BOOMELE "2.54-1*5P" — KY-023-class 5-pin thumbstick header | ~1.9MB, `ISO-10303-21` valid |
| 06-diffpair-test | J3 | `Connector_PCIE:PCIE_Mini_Edge` | **C444929** | SOFNG `PCIE-SMD_52P-P0.80` — 52-position 0.8mm-pitch mini-PCIe card-edge socket | ~4.8MB, `ISO-10303-21` valid |

**PCIE resolution method (the piece the curator deferred):** the curator could not reach LCSC's bot-protected search SPA. I resolved it via the **JLCPCB parts-search API** (`selectSmtComponentList`), which returned real mini-PCIe card-edge sockets under the "PCI / PCIe Connector" category (XUNPU/SOFNG PCIE-52PxxH family). Candidates C266899 / C920235 / C444929 all fetched valid mini-PCIe connector bodies from EasyEDA; **C444929** was chosen because its STEP filename declares `P0.80` pitch — a direct match to the generator's documented 0.8mm-pitch 52-pin card-edge abstraction. Render confirms an unmistakable card-edge socket body.

**Accepted approximation (joystick):** the repo footprint is 2.0mm-pitch; C50950 (like every commercial KY-023 module) is 2.54mm. Both footprints are synthetic testbench geometries — the render goal is a representative body, centroid-placed (#4045 offset machinery), not pin-for-pin registration.

## What changed

- **New:** `boards/03-usb-joystick/lcsc_models.json`, `boards/06-diffpair-test/lcsc_models.json` — flat `lib_id -> C-number` sidecars (schema per #4072).
- **Regenerated (metadata-only):** the four committed `.kicad_pcb` artifacts — unrouted + routed for both boards — each gains exactly one `(model "${KCT_LCSC_3D_DIR}/C#####.step" ...)` block for J2/J3.

## Verification

- **Pure-insertion:** each `.kicad_pcb` diffed byte-for-byte against its pre-patch copy — the only change is the added `(model ...)` block. No copper/pad/via/zone/net S-expression changed, so `drc_report.json` / `lvs.json` are unmodified (not in this diff).
- **Render (local):** `kct render` on both boards with `KCT_LCSC_3D_DIR` set — the joystick module body and the mini-PCIe card-edge socket both appear on-board, centered on their pad centroids (both J2 and J3 pad centroids are exactly (0,0) local, so the offset-0 model origin lands dead-on).
- **Portable refs:** committed refs use the `${KCT_LCSC_3D_DIR}` path variable; no absolute cache paths leaked.
- **No STEP binaries committed** — fetch-on-demand cache only (`~/.cache/kicad-tools/lcsc-3d/`), per the tier's license posture. CI stays cache-free; the ref is benign-unresolved without a local cache, matching the `${KICADn_3DMODEL_DIR}` precedent.
- **Renders are gitignored** (`boards/*/output/renders/`) — deploy-time artifacts, regenerated by `deploy-site.sh` (which now `setdefault`s `KCT_LCSC_3D_DIR` via runner.py). Local render is verification only.
- **Tests:** `tests/test_lcsc_models.py tests/test_pcb_add_3d_models.py` — 91 passed. `ruff check` / `ruff format --check` clean.

## Note on the connector body extent

The C444929 body is a full 52-position connector and physically larger than board 06's synthetic 12-pad row, so it overhangs J3's board-edge placement. It is correctly centroid-placed; the overhang is the accepted representative-body approximation the issue calls for (real part vs synthetic testbench footprint), not a placement bug.

Closes #4073
Closes #4032

🤖 Generated with [Claude Code](https://claude.com/claude-code)