### PR TITLE
fix(validate): rotate pad offset for solder_mask violation locations

### DIFF
--- a/src/kicad_tools/validate/rules/solder_mask.py
+++ b/src/kicad_tools/validate/rules/solder_mask.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from kicad_tools.core.geometry import rotate_pad_offset
+
 from ..violations import DRCResults, DRCViolation
 from .base import DRCRule
 
@@ -97,8 +99,17 @@ class SolderMaskPadRules(DRCRule):
                 # AND is non-zero (a zero value is KiCad's default meaning
                 # "use global/manufacturer default" and should not be flagged).
                 if effective_clearance != 0.0 and effective_clearance < min_clearance:
-                    abs_x = fp.position[0] + pad.position[0]
-                    abs_y = fp.position[1] + pad.position[1]
+                    # Pad position is stored footprint-local and must be
+                    # rotated by the footprint orientation before translating
+                    # to board coordinates (KiCad's negated-angle convention;
+                    # see core.geometry.rotate_pad_offset, issue #3739). A
+                    # naive add misreports the violation location on
+                    # rotated/flipped footprints (issue #4081).
+                    rotated_x, rotated_y = rotate_pad_offset(
+                        pad.position[0], pad.position[1], fp.rotation
+                    )
+                    abs_x = fp.position[0] + rotated_x
+                    abs_y = fp.position[1] + rotated_y
 
                     results.add(
                         DRCViolation(
@@ -140,8 +151,15 @@ class SolderMaskPadRules(DRCRule):
                 min_dim = min(pad_w, pad_h)
 
                 if min_dim > 0 and min_dim < min_size:
-                    abs_x = fp.position[0] + pad.position[0]
-                    abs_y = fp.position[1] + pad.position[1]
+                    # Rotate footprint-local pad offset into board frame
+                    # before translating (KiCad negated-angle convention;
+                    # see core.geometry.rotate_pad_offset, issue #3739;
+                    # display-only fix, issue #4081).
+                    rotated_x, rotated_y = rotate_pad_offset(
+                        pad.position[0], pad.position[1], fp.rotation
+                    )
+                    abs_x = fp.position[0] + rotated_x
+                    abs_y = fp.position[1] + rotated_y
 
                     results.add(
                         DRCViolation(
@@ -192,8 +210,15 @@ class SolderMaskPadRules(DRCRule):
                 annular_ring = (min_pad_dim - pad.drill) / 2
 
                 if annular_ring < min_annular:
-                    abs_x = fp.position[0] + pad.position[0]
-                    abs_y = fp.position[1] + pad.position[1]
+                    # Rotate footprint-local pad offset into board frame
+                    # before translating (KiCad negated-angle convention;
+                    # see core.geometry.rotate_pad_offset, issue #3739;
+                    # display-only fix, issue #4081).
+                    rotated_x, rotated_y = rotate_pad_offset(
+                        pad.position[0], pad.position[1], fp.rotation
+                    )
+                    abs_x = fp.position[0] + rotated_x
+                    abs_y = fp.position[1] + rotated_y
                     net_name = pad.net_name or f"net:{pad.net_number}"
 
                     results.add(

--- a/tests/test_validate_solder_mask.py
+++ b/tests/test_validate_solder_mask.py
@@ -62,11 +62,13 @@ class MockFootprint:
         reference: str = "U1",
         position: tuple[float, float] = (10.0, 20.0),
         layer: str = "F.Cu",
+        rotation: float = 0.0,
         pads: list[MockPad] | None = None,
     ):
         self.reference = reference
         self.position = position
         self.layer = layer
+        self.rotation = rotation
         self.pads = pads or []
 
 
@@ -325,6 +327,128 @@ class TestMinPadSize:
         pad_violations = [v for v in results.violations if v.rule_id == "min_pad_size"]
         assert len(pad_violations) == 1
         assert pad_violations[0].location == pytest.approx((105.0, 203.0))
+
+
+# -- Rotation-Correct Location Tests ---------------------------------------
+
+
+class TestRotatedViolationLocation:
+    """Issue #4081: reported violation location must account for rotation.
+
+    The pad position is stored footprint-local; before translating to board
+    coordinates it must be rotated by the footprint orientation using KiCad's
+    negated-angle convention (core.geometry.rotate_pad_offset, issue #3739).
+    A non-cardinal angle (37 deg) is used deliberately to avoid the 90/270
+    "test trap" where sign errors can hide.
+    """
+
+    @staticmethod
+    def _expected_location(
+        fp_pos: tuple[float, float],
+        pad_local: tuple[float, float],
+        rotation_deg: float,
+    ) -> tuple[float, float]:
+        # Re-derive independently of the implementation under test to make
+        # this a genuine regression guard (KiCad negated-angle convention).
+        import math
+
+        angle_rad = math.radians(-rotation_deg)
+        rx = pad_local[0] * math.cos(angle_rad) - pad_local[1] * math.sin(angle_rad)
+        ry = pad_local[0] * math.sin(angle_rad) + pad_local[1] * math.cos(angle_rad)
+        return (fp_pos[0] + rx, fp_pos[1] + ry)
+
+    def test_min_pad_size_location_is_rotation_correct(self):
+        """min_pad_size violation location accounts for footprint rotation."""
+        fp_pos = (100.0, 200.0)
+        pad_local = (5.0, 3.0)
+        rotation_deg = 37.0
+
+        pcb = MockPCB(
+            footprints=[
+                MockFootprint(
+                    position=fp_pos,
+                    rotation=rotation_deg,
+                    pads=[
+                        MockPad(position=pad_local, size=(0.1, 0.1)),
+                    ],
+                ),
+            ],
+        )
+        rules = MockDesignRules(min_pad_size_mm=0.25)
+        rule = SolderMaskPadRules()
+
+        results = rule.check(pcb, rules)
+
+        pad_violations = [v for v in results.violations if v.rule_id == "min_pad_size"]
+        assert len(pad_violations) == 1
+        expected = self._expected_location(fp_pos, pad_local, rotation_deg)
+        assert pad_violations[0].location == pytest.approx(expected)
+        # Sanity: rotation actually moved the reported point away from the
+        # naive (unrotated) add, so this test would fail against the old code.
+        naive = (fp_pos[0] + pad_local[0], fp_pos[1] + pad_local[1])
+        assert pad_violations[0].location != pytest.approx(naive)
+
+    def test_solder_mask_clearance_location_is_rotation_correct(self):
+        """solder_mask_clearance violation location accounts for rotation."""
+        fp_pos = (100.0, 200.0)
+        pad_local = (5.0, 3.0)
+        rotation_deg = 37.0
+
+        pcb = MockPCB(
+            footprints=[
+                MockFootprint(
+                    position=fp_pos,
+                    rotation=rotation_deg,
+                    pads=[
+                        MockPad(position=pad_local, solder_mask_margin=0.02),
+                    ],
+                ),
+            ],
+        )
+        rules = MockDesignRules(min_solder_mask_clearance_mm=0.05)
+        rule = SolderMaskPadRules()
+
+        results = rule.check(pcb, rules)
+
+        mask_violations = [v for v in results.violations if v.rule_id == "solder_mask_clearance"]
+        assert len(mask_violations) == 1
+        expected = self._expected_location(fp_pos, pad_local, rotation_deg)
+        assert mask_violations[0].location == pytest.approx(expected)
+
+    def test_pth_annular_ring_location_is_rotation_correct(self):
+        """pth_annular_ring violation location accounts for rotation."""
+        fp_pos = (100.0, 200.0)
+        pad_local = (5.0, 3.0)
+        rotation_deg = 37.0
+
+        pcb = MockPCB(
+            footprints=[
+                MockFootprint(
+                    position=fp_pos,
+                    rotation=rotation_deg,
+                    pads=[
+                        MockPad(
+                            position=pad_local,
+                            type="thru_hole",
+                            size=(1.0, 1.0),
+                            drill=0.9,
+                            layers=["*.Cu", "*.Mask"],
+                            net_name="VCC",
+                        ),
+                    ],
+                ),
+            ],
+        )
+        # annular_ring = (1.0 - 0.9) / 2 = 0.05mm < 0.15mm -> violation
+        rules = MockDesignRules(min_annular_ring_mm=0.15)
+        rule = SolderMaskPadRules()
+
+        results = rule.check(pcb, rules)
+
+        ring_violations = [v for v in results.violations if v.rule_id == "pth_annular_ring"]
+        assert len(ring_violations) == 1
+        expected = self._expected_location(fp_pos, pad_local, rotation_deg)
+        assert ring_violations[0].location == pytest.approx(expected)
 
 
 # -- PTH Annular Ring Tests ------------------------------------------------


### PR DESCRIPTION
## Summary

`src/kicad_tools/validate/rules/solder_mask.py` translated footprint-local pad positions to board coordinates with a naive `fp.position + pad.position` add at three `DRCViolation`-emitting sites, ignoring footprint rotation. On rotated/flipped footprints this misreported the `DRCViolation.location`. This mirrors the already-merged `dimensions.py` fix (PR #4067, #4044) by applying `core.geometry.rotate_pad_offset` (KiCad negated-angle convention, #3739) before translating.

This is a display-coordinate-only fix: all three `abs_x`/`abs_y` blocks live inside the violation-emit branch, after the pass/fail decision, so no verdict, violation count, or rule_id changes.

## Changes

- `solder_mask.py`: add `from kicad_tools.core.geometry import rotate_pad_offset`; replace the naive add with `rotate_pad_offset(pad.position[0], pad.position[1], fp.rotation)` + translation at all 3 sites (`_check_solder_mask_clearance`, `_check_min_pad_size`, `_check_pth_annular_ring`).
- `tests/test_validate_solder_mask.py`: add missing `rotation: float = 0.0` field to `MockFootprint` (identity transform, keeps existing tests unchanged); add `TestRotatedViolationLocation` with a non-cardinal (37 deg) regression test per rule_id, re-deriving the expected board position independently of the implementation.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| All 3 sites use `rotate_pad_offset` before board translation | Done | Diff shows the pattern at lines feeding `location=` for all 3 rule_ids |
| Non-cardinal regression test asserts rotation-correct `location` | Done | `TestRotatedViolationLocation` covers all 3 rule_ids at 37 deg; asserts against independently re-derived KiCad negated-angle position |
| No pass/fail verdict change | Done | All pre-existing verdict/count tests pass unchanged; `rotation=0.0` default is identity |

## Test Plan

`uv run pytest tests/test_validate_solder_mask.py tests/test_validate_dimensions.py` -> 60 passed (solder_mask.py at 100% coverage). `ruff check` and `ruff format --check` clean on both changed files.

Closes #4081