### PR TITLE
feat(router): apply corridor attractor in coupled joint-state cost loop

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 4053
-# Branch: feature/issue-4053
+# Issue: 4080
+# Branch: feature/issue-4080
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/src/kicad_tools/router/cpp/src/coupled_pathfinder.cpp
+++ b/src/kicad_tools/router/cpp/src/coupled_pathfinder.cpp
@@ -456,6 +456,17 @@ CoupledRouteResult CoupledPathfinder::route(
             bool dir_changed = !(current.dir_dx == 0 && current.dir_dy == 0) &&
                                !(current.dir_dx == dx && current.dir_dy == dy);
             if (dir_changed) cost += rules_.cost_turn;
+            // Issue #4080: corridor attractor for the coupled joint-state
+            // loop.  A symmetric move advances BOTH nets, so query each
+            // landing cell against its own net (mirrors the single-ended
+            // attractor in ``pathfinder.cpp``).  Clamped at 0 so the joint
+            // step cost stays non-negative and A* admissibility holds.
+            double attractor_bonus =
+                grid_.corridor_attractor_bonus(np_x, np_y, np_l, p_net,
+                                               rules_.cost_corridor_attractor) +
+                grid_.corridor_attractor_bonus(nn_x, nn_y, nn_l, n_net,
+                                               rules_.cost_corridor_attractor);
+            if (attractor_bonus > 0.0) cost = std::max(0.0, cost - attractor_bonus);
             neighbors.push_back({np_x, np_y, np_l, nn_x, nn_y, nn_l, dx, dy, cost, false});
         }
 
@@ -490,6 +501,18 @@ CoupledRouteResult CoupledPathfinder::route(
                                     !(current.dir_dx == 0 && current.dir_dy == 0) &&
                                     !(current.dir_dx == dx && current.dir_dy == dy);
                                 if (dir_changed) cost += rules_.cost_turn;
+                                // Issue #4080: corridor attractor (per-net)
+                                // for the asymmetric P-advance move.  See the
+                                // symmetric-move comment above.
+                                double attractor_bonus =
+                                    grid_.corridor_attractor_bonus(
+                                        cp_x, cp_y, cp_l, p_net,
+                                        rules_.cost_corridor_attractor) +
+                                    grid_.corridor_attractor_bonus(
+                                        cn_x, cn_y, cn_l, n_net,
+                                        rules_.cost_corridor_attractor);
+                                if (attractor_bonus > 0.0)
+                                    cost = std::max(0.0, cost - attractor_bonus);
                                 neighbors.push_back(
                                     {cp_x, cp_y, cp_l, cn_x, cn_y, cn_l, dx, dy, cost, false});
                             }
@@ -521,6 +544,18 @@ CoupledRouteResult CoupledPathfinder::route(
                                     !(current.dir_dx == 0 && current.dir_dy == 0) &&
                                     !(current.dir_dx == dx && current.dir_dy == dy);
                                 if (dir_changed) cost += rules_.cost_turn;
+                                // Issue #4080: corridor attractor (per-net)
+                                // for the asymmetric N-advance move.  See the
+                                // symmetric-move comment above.
+                                double attractor_bonus =
+                                    grid_.corridor_attractor_bonus(
+                                        cp_x, cp_y, cp_l, p_net,
+                                        rules_.cost_corridor_attractor) +
+                                    grid_.corridor_attractor_bonus(
+                                        cn_x, cn_y, cn_l, n_net,
+                                        rules_.cost_corridor_attractor);
+                                if (attractor_bonus > 0.0)
+                                    cost = std::max(0.0, cost - attractor_bonus);
                                 neighbors.push_back(
                                     {cp_x, cp_y, cp_l, cn_x, cn_y, cn_l, dx, dy, cost, false});
                             }
@@ -543,6 +578,18 @@ CoupledRouteResult CoupledPathfinder::route(
                 if (!p_at_ep && is_trace_blocked(current.p_x, current.p_y, new_layer, p_net)) continue;
                 if (!n_at_ep && is_trace_blocked(current.n_x, current.n_y, new_layer, n_net)) continue;
                 double cost = rules_.cost_via * 2.0;
+                // Issue #4080: corridor attractor on the via-drop
+                // destination cells -- the reservation is what makes the
+                // coupled router prefer to actually via-hop INTO the
+                // reserved channel (mirrors the single-ended via-drop
+                // attractor in ``pathfinder.cpp``).  Per-net query,
+                // clamped at 0.
+                double attractor_bonus =
+                    grid_.corridor_attractor_bonus(current.p_x, current.p_y, new_layer,
+                                                   p_net, rules_.cost_corridor_attractor) +
+                    grid_.corridor_attractor_bonus(current.n_x, current.n_y, new_layer,
+                                                   n_net, rules_.cost_corridor_attractor);
+                if (attractor_bonus > 0.0) cost = std::max(0.0, cost - attractor_bonus);
                 neighbors.push_back({current.p_x, current.p_y, new_layer,
                                      current.n_x, current.n_y, new_layer,
                                      current.dir_dx, current.dir_dy, cost, true});

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -1165,6 +1165,19 @@ class CoupledPathfinder:
             if state.direction != (0, 0) and state.direction != new_direction:
                 cost += self.rules.cost_turn
 
+            # Issue #4080: corridor attractor for the coupled joint-state
+            # loop.  A symmetric move advances BOTH nets, so query each
+            # landing cell against its own net (mirrors the single-ended
+            # attractor in ``pathfinder.py``).  Clamped at 0 so the joint
+            # step cost stays non-negative and A* admissibility holds.
+            attractor_bonus = self.grid.get_corridor_attractor_bonus(
+                new_p.layer, new_p.x, new_p.y, p_net, self.rules.cost_corridor_attractor
+            ) + self.grid.get_corridor_attractor_bonus(
+                new_n.layer, new_n.x, new_n.y, n_net, self.rules.cost_corridor_attractor
+            )
+            if attractor_bonus > 0.0:
+                cost = max(0.0, cost - attractor_bonus)
+
             new_state = CoupledState(new_p, new_n, new_direction)
             neighbors.append((new_state, cost, False))
 
@@ -1263,6 +1276,24 @@ class CoupledPathfinder:
                             cost = self.rules.cost_straight
                             if state.direction != (0, 0) and state.direction != (dx, dy):
                                 cost += self.rules.cost_turn
+                            # Issue #4080: corridor attractor (per-net) for
+                            # the asymmetric P-advance move.  See the
+                            # symmetric-move comment above.
+                            attractor_bonus = self.grid.get_corridor_attractor_bonus(
+                                cand_p.layer,
+                                cand_p.x,
+                                cand_p.y,
+                                p_net,
+                                self.rules.cost_corridor_attractor,
+                            ) + self.grid.get_corridor_attractor_bonus(
+                                cand_n.layer,
+                                cand_n.x,
+                                cand_n.y,
+                                n_net,
+                                self.rules.cost_corridor_attractor,
+                            )
+                            if attractor_bonus > 0.0:
+                                cost = max(0.0, cost - attractor_bonus)
                             new_state = CoupledState(cand_p, cand_n, (dx, dy))
                             neighbors.append((new_state, cost, False))
 
@@ -1317,6 +1348,24 @@ class CoupledPathfinder:
                 cost = self.rules.cost_straight
                 if state.direction != (0, 0) and state.direction != (dx, dy):
                     cost += self.rules.cost_turn
+                # Issue #4080: corridor attractor (per-net) for the
+                # asymmetric N-advance move.  See the symmetric-move
+                # comment above.
+                attractor_bonus = self.grid.get_corridor_attractor_bonus(
+                    cand_p2.layer,
+                    cand_p2.x,
+                    cand_p2.y,
+                    p_net,
+                    self.rules.cost_corridor_attractor,
+                ) + self.grid.get_corridor_attractor_bonus(
+                    cand_n2.layer,
+                    cand_n2.x,
+                    cand_n2.y,
+                    n_net,
+                    self.rules.cost_corridor_attractor,
+                )
+                if attractor_bonus > 0.0:
+                    cost = max(0.0, cost - attractor_bonus)
                 new_state = CoupledState(cand_p2, cand_n2, (dx, dy))
                 neighbors.append((new_state, cost, False))
 
@@ -1361,6 +1410,19 @@ class CoupledPathfinder:
 
             # Via cost for both traces
             cost = self.rules.cost_via * 2
+
+            # Issue #4080: corridor attractor on the via-drop destination
+            # cells -- the reservation is what makes the coupled router
+            # prefer to actually via-hop INTO the reserved channel
+            # (mirrors the single-ended via-drop attractor in
+            # ``pathfinder.py``).  Per-net query, clamped at 0.
+            attractor_bonus = self.grid.get_corridor_attractor_bonus(
+                new_p.layer, new_p.x, new_p.y, p_net, self.rules.cost_corridor_attractor
+            ) + self.grid.get_corridor_attractor_bonus(
+                new_n.layer, new_n.x, new_n.y, n_net, self.rules.cost_corridor_attractor
+            )
+            if attractor_bonus > 0.0:
+                cost = max(0.0, cost - attractor_bonus)
 
             new_state = CoupledState(new_p, new_n, state.direction)
             neighbors.append((new_state, cost, True))

--- a/tests/test_diffpair_coupled_cpp_parity.py
+++ b/tests/test_diffpair_coupled_cpp_parity.py
@@ -355,3 +355,139 @@ def test_cpp_converging_search_is_deterministic():
         p, n = res
         lengths.append((round(_route_length(p), 6), round(_route_length(n), 6)))
     assert lengths[0] == lengths[1] == lengths[2], f"non-deterministic C++ result: {lengths}"
+
+
+# ---------------------------------------------------------------------------
+# Issue #4080: corridor attractor in the coupled joint-state cost loop
+# ---------------------------------------------------------------------------
+#
+# The single-ended attractor (#4071) discounts a reserved cell's step cost for
+# the owning net.  Issue #4080 wires the same discount into the coupled
+# joint-state loop -- both the pure-Python ``_get_coupled_neighbors`` and the
+# C++ ``CoupledPathfinder``.  These tests prove:
+#   (a) the per-net discount fires through the coupled loop for the owning net
+#       set and NOT for a foreign net / unreserved cell (mirrors
+#       ``test_grid_cpp_parity.py::test_cpp_attractor_discounts_owning_net_step_cost``
+#       but exercised through the joint-state neighbor expansion), and
+#   (b) with a corridor reserved for the pair's net set, both backends still
+#       agree on routed cost (parity is preserved with the attractor active).
+
+
+def _reserve_pair_corridor(grid: RoutingGrid, pads, p_net: int, n_net: int) -> int:
+    """Reserve every cell on the F_CU layer along the pair centerline band
+    for the ``{p_net, n_net}`` owner set.
+
+    The band spans the y-range the P and N heads sweep (their pads plus the
+    coupled channel between them) across the full x-span of the run, so any
+    joint-state move the search takes lands on reserved cells and picks up the
+    attractor discount.
+    """
+    p_start, p_end, n_start, n_end = pads
+    layer_idx = grid.layer_to_index(Layer.F_CU.value)
+    gx_lo, gy_lo = grid.world_to_grid(min(p_start.x, p_end.x), min(p_start.y, p_end.y))
+    gx_hi, gy_hi = grid.world_to_grid(max(n_start.x, n_end.x), max(n_start.y, n_end.y))
+    cells = [(gx, gy) for gx in range(gx_lo, gx_hi + 1) for gy in range(gy_lo, gy_hi + 1)]
+    return grid.reserve_corridor_cells(layer_idx, cells, frozenset({p_net, n_net}))
+
+
+def test_coupled_attractor_discount_fires_only_for_owning_pair():
+    """The coupled attractor discounts a reserved-corridor step for the pair's
+    own nets, and returns 0 for a foreign net / unreserved cell.
+
+    Low-level analogue of ``test_cpp_attractor_discounts_owning_net_step_cost``
+    driven through the joint-state cost sites: a symmetric coupled move that
+    lands both heads on reserved cells must cost ``cost_corridor_attractor``
+    (one per net) less than the same move on an unreserved grid.
+    """
+    from kicad_tools.router.cpp_backend import CppGrid
+    from kicad_tools.router.diffpair_routing import CoupledState, GridPos
+
+    rules = DesignRules()
+    bonus = rules.cost_corridor_attractor
+    p_net, n_net = 1, 2
+    # P and N heads exactly ``target_spacing_cells`` (=2) apart so a symmetric
+    # +x step is spacing-legal and produces a straight coupled continuation.
+    p_gx, p_gy = 30, 40
+    n_gx, n_gy = 30, 42  # 2 cells below P
+    layer_idx = _make_grid().layer_to_index(Layer.F_CU.value)
+
+    def _min_straight_cost(grid: RoutingGrid) -> float:
+        pf = _make_pf(grid, use_cpp=False)
+        state = CoupledState(GridPos(p_gx, p_gy, layer_idx), GridPos(n_gx, n_gy, layer_idx), (1, 0))
+        neighbors = pf._get_coupled_neighbors(state, p_net, n_net)
+        # The straight +x continuation (no turn) is the cheapest non-via move.
+        straight = [cost for st, cost, is_via in neighbors if not is_via and st.direction == (1, 0)]
+        assert straight, "expected a straight +x coupled continuation move"
+        return min(straight)
+
+    # Plain grid: no reservation, no discount.
+    plain = _make_grid()
+    plain_cost = _min_straight_cost(plain)
+
+    # Reserved grid: reserve exactly the two +x landing cells for the pair.
+    reserved = _make_grid()
+    n_reserved = reserved.reserve_corridor_cells(
+        layer_idx, [(p_gx + 1, p_gy), (n_gx + 1, n_gy)], frozenset({p_net, n_net})
+    )
+    assert n_reserved == 2, "fixture must reserve both landing cells"
+    reserved_cost = _min_straight_cost(reserved)
+
+    # Both P and N land on reserved cells => two bonuses subtracted.
+    assert reserved_cost == pytest.approx(max(0.0, plain_cost - 2.0 * bonus))
+
+    # A foreign net must NOT pick up the discount: the same reserved grid,
+    # queried with net ids not in the owner set, yields the plain cost.
+    foreign_pf = _make_pf(reserved, use_cpp=False)
+    foreign_state = CoupledState(
+        GridPos(p_gx, p_gy, layer_idx), GridPos(n_gx, n_gy, layer_idx), (1, 0)
+    )
+    foreign_neighbors = foreign_pf._get_coupled_neighbors(foreign_state, 888, 999)
+    foreign_straight = [
+        c for st, c, is_via in foreign_neighbors if not is_via and st.direction == (1, 0)
+    ]
+    assert foreign_straight, "expected a straight +x move for the foreign query too"
+    assert min(foreign_straight) == pytest.approx(plain_cost)
+
+    # C++ primitive parity: the reserved cells discount for the owning nets
+    # and NOT for a foreign net, matching the Python query the loop makes.
+    cpp = CppGrid.from_routing_grid(reserved)
+    gx, gy = p_gx + 1, p_gy
+    assert cpp._impl.corridor_attractor_bonus(gx, gy, layer_idx, p_net, bonus) == pytest.approx(
+        reserved.get_corridor_attractor_bonus(layer_idx, gx, gy, p_net, bonus)
+    )
+    assert cpp._impl.corridor_attractor_bonus(gx, gy, layer_idx, 999, bonus) == pytest.approx(0.0)
+
+
+def test_cpp_and_python_agree_with_reserved_corridor():
+    """Reservation-fixture parity: with a corridor reserved for the pair's net
+    set, both backends route the pair AND agree on routed cost.
+
+    Guards the Issue #4080 acceptance criterion that the coupled path honors
+    the attractor with Python/C++ parity -- the per-net discount is applied
+    identically on both sides, so the two backends do not diverge when a
+    corridor is active.
+    """
+    pads = _make_simple_pair_pads()
+    p_net, n_net = 1, 2
+
+    py_grid = _make_grid()
+    cpp_grid = _make_grid()
+    py_n = _reserve_pair_corridor(py_grid, pads, p_net, n_net)
+    cpp_n = _reserve_pair_corridor(cpp_grid, pads, p_net, n_net)
+    assert py_n == cpp_n and py_n > 0
+
+    py_pf = _make_pf(py_grid, use_cpp=False)
+    cpp_pf = _make_pf(cpp_grid, use_cpp=True)
+
+    py_res = py_pf.route_coupled(*pads)
+    cpp_res = cpp_pf.route_coupled(*pads)
+
+    assert py_res is not None, "python fallback must route the reserved pair"
+    assert cpp_res is not None, "C++ coupled must route the reserved pair"
+
+    py_p, py_n_route = py_res
+    cpp_p, cpp_n_route = cpp_res
+
+    # Cost-equality with the attractor active on both backends.
+    assert _route_length(cpp_p) == pytest.approx(_route_length(py_p), abs=0.2)
+    assert _route_length(cpp_n_route) == pytest.approx(_route_length(py_n_route), abs=0.2)


### PR DESCRIPTION
## Summary

Wires the diff-pair / match-group corridor attractor into the **coupled** joint-state A* cost loop on both backends (pure-Python `_get_coupled_neighbors` and C++ `CoupledPathfinder`), mirroring the single-ended attractor added by #4071 / PR #4078. Before this change, neither coupled implementation consumed `cost_corridor_attractor` — they were at parity only in *ignoring* the attractor. This is an enhancement (nothing to "port"), so the subtraction is added to both sides in the same change.

Parent epic: #4049.

## Changes

- **Python** `src/kicad_tools/router/diffpair_routing.py::_get_coupled_neighbors`: subtract the attractor bonus (clamped at 0) at the 4 in-scope cost sites — symmetric both-advance, asymmetric P-advance, asymmetric N-advance, via-drop. Each candidate cell is queried against its own net (`p_net` for P's landing cell, `n_net` for N's), and the two per-net bonuses are summed before clamping.
- **C++** `src/kicad_tools/router/cpp/src/coupled_pathfinder.cpp`: mirror the identical subtraction at the corresponding 4 sites, reading `grid_.corridor_attractor_bonus(...)` / `rules_.cost_corridor_attractor`, matching the single-ended `pathfinder.cpp` pattern.
- **Tests** `tests/test_diffpair_coupled_cpp_parity.py`: add a reservation-fixture parity test (cost-equal routes across Python/C++ with a corridor reserved for the pair's net set) and a low-level test proving the per-net discount fires through the coupled loop for the owning pair and is 0 for a foreign net / unreserved cell.

The Python-only swap-via site (`diffpair_routing.py`, `allow_swap_via`) is **left untouched** per the issue's scope note — it has no C++ counterpart, so adding the attractor there would create new divergence.

**Soft reservations (#4079):** the attractor primitive keys on owner-set membership only, not the hard/soft flag, so SOFT (attractor-only, non-blocking) reservations pick up the coupled bonus identically to the single-ended path — no special handling needed.

**No `ROUTER_CPP_BUILD_VERSION` bump:** logic is added inside the existing cost loop; no symbol / struct-field / signature change crosses the bindings boundary. Rebuilt via `uv run kct build-native` (mtime staleness auto-rebuild); `kct build-native --check` reports the backend available.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Python subtracts attractor at 4 in-scope sites, per-net query | ✅ | Edits at both-advance / P-advance / N-advance / via-drop, each summing `p_net` + `n_net` queries, clamped at 0 |
| C++ mirrors the same 4 sites | ✅ | Mirrored in `coupled_pathfinder.cpp` using `grid_.corridor_attractor_bonus` / `rules_.cost_corridor_attractor` |
| Applied only for own-net reserved cells (no net-widening) | ✅ | Uses existing primitive that returns 0 for foreign/unreserved cells; `test_coupled_attractor_discount_fires_only_for_owning_pair` asserts foreign-net query yields plain cost |
| Python/C++ parity on a reservation fixture | ✅ | `test_cpp_and_python_agree_with_reserved_corridor` (cost-equal routes with corridor active) |
| No board regression | ✅ | Board-06 diffpair suite (`test_board_06_diffpair_test.py`, `test_diffpair_routing_integration.py`) 50 passed; coupled + corridor + floor modules green; CI runs boards 00-07 |
| Swap-via site left untouched | ✅ | `diffpair_routing.py:1400` unchanged; `test_swap_via_and_manhattan_defer_to_python` still passes |
| Attractor never drives cost negative | ✅ | `max(0.0, cost - bonus)` on both sides, matching single-ended clamp |

## Test Plan

- `tests/test_diffpair_coupled_cpp_parity.py` — 12 passed (incl. 2 new #4080 tests)
- `tests/test_diffpair_coupled_floor.py`, `tests/test_coupled_lines.py`, `tests/test_diffpair_corridor.py` — 61 passed (byte-identical costs when no reservation is active)
- `tests/test_grid_cpp_parity.py -k "attractor or reserv"` — 13 passed (single-ended attractor unaffected)
- `tests/test_board_06_diffpair_test.py`, `tests/test_diffpair_routing_integration.py`, `tests/test_diffpair_swap_via_reject.py` — 50 passed
- `uv run kct build-native` rebuilt the `.so`; `--check` reports `C++ backend: available (version 1.0.0)`
- `ruff check` + `ruff format --check` clean on changed files

Closes #4080